### PR TITLE
RFC-0232 P4: Boundary mention parsing + persisted mention inbox wiring

### DIFF
--- a/lib/dashboard_api_types/dune
+++ b/lib/dashboard_api_types/dune
@@ -3,7 +3,7 @@
 (library
  (name masc_dashboard_api_types)
  (public_name masc.masc_dashboard_api_types)
- (modules keepers)
+ (modules keepers iteration)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))

--- a/lib/dashboard_api_types/iteration.ml
+++ b/lib/dashboard_api_types/iteration.ml
@@ -1,0 +1,67 @@
+(** Dashboard API types — ops iteration dashboard for keeper recovery tracking.
+
+    Tracks recovery iteration cycles per keeper: how many recovery events
+    have occurred, what errors triggered them, recovery resolution status,
+    and aggregate statistics for the ops dashboard view.
+
+    Served at [GET /dashboard/b/api/keepers/iteration] (projected).
+    Server assembles response from {!Keeper_ops_iteration} ring buffer and
+    ongoing keeper state. *)
+
+(** Phase/status of one recovery iteration. *)
+type recovery_phase =
+  | Detecting    (* error detected, recovery triggered *)
+  | Hinting      (* recovery hint generated *)
+  | Retrying     (* retry in progress *)
+  | Resolved     (* recovery succeeded *)
+  | Escalated    (* recovery failed, escalated to operator *)
+[@@deriving yojson]
+
+(** One recorded recovery event. *)
+type recovery_event = {
+  id : string;                       (* unique event id *)
+  keeper_name : string;              (* the recovering keeper *)
+  phase : recovery_phase;
+  error_hint : string option;        [@default None]
+  error_message : string;            (* truncated original error *)
+  tool_name : string option;         [@default None]
+  started_at : string;               (* ISO-8601 UTC *)
+  resolved_at : string option;       [@default None]
+  duration_ms : int option;          [@default None]
+}
+[@@deriving yojson { strict = false }]
+
+(** Aggregate stats for one keeper. *)
+type keeper_recovery_stats = {
+  name : string;
+  total_recoveries : int;
+  active_recoveries : int;           (* Detecting / Hinting / Retrying *)
+  resolved_count : int;
+  escalated_count : int;
+  avg_duration_ms : int;             (* average ms to resolve *)
+  top_error : string option;         [@default None]
+  last_recovery_at : string option;  [@default None]
+}
+[@@deriving yojson { strict = false }]
+
+(** Overall iteration summary for the workspace. *)
+type iteration_summary = {
+  total_events : int;
+  active_events : int;
+  resolved_events : int;
+  escalated_events : int;
+  global_avg_duration_ms : int;
+}
+[@@deriving yojson { strict = false }]
+
+(** Top-level iteration response for the ops dashboard. *)
+type response = {
+  events : recovery_event list;
+  keeper_stats : keeper_recovery_stats list;
+  summary : iteration_summary;
+  cycle : int;                      (* current cycle number — aligned with
+                                       {!K summary} *)
+  workspace : string option;             [@default None]
+  generated_at : string;            (* ISO-8601 UTC *)
+}
+[@@deriving yojson { strict = false }]

--- a/lib/dashboard_api_types/iteration.mli
+++ b/lib/dashboard_api_types/iteration.mli
@@ -1,0 +1,66 @@
+(** Dashboard API types — ops iteration dashboard for keeper recovery tracking.
+
+    Tracks recovery iteration cycles per keeper: how many recovery events
+    have occurred, what errors triggered them, recovery resolution status,
+    and aggregate statistics for the ops dashboard view.
+
+    Served at [GET /dashboard/b/api/keepers/iteration] (projected).
+    Server assembles response from {!Keeper_ops_iteration} ring buffer and
+    ongoing keeper state. *)
+
+(** Phase/status of one recovery iteration. *)
+type recovery_phase =
+  | Detecting
+  | Hinting
+  | Retrying
+  | Resolved
+  | Escalated
+[@@deriving yojson]
+
+(** One recorded recovery event. *)
+type recovery_event = {
+  id : string;
+  keeper_name : string;
+  phase : recovery_phase;
+  error_hint : string option;        [@default None]
+  error_message : string;
+  tool_name : string option;         [@default None]
+  started_at : string;
+  resolved_at : string option;       [@default None]
+  duration_ms : int option;          [@default None]
+}
+[@@deriving yojson { strict = false }]
+
+(** Aggregate stats for one keeper. *)
+type keeper_recovery_stats = {
+  name : string;
+  total_recoveries : int;
+  active_recoveries : int;
+  resolved_count : int;
+  escalated_count : int;
+  avg_duration_ms : int;
+  top_error : string option;         [@default None]
+  last_recovery_at : string option;  [@default None]
+}
+[@@deriving yojson { strict = false }]
+
+(** Overall iteration summary. *)
+type iteration_summary = {
+  total_events : int;
+  active_events : int;
+  resolved_events : int;
+  escalated_events : int;
+  global_avg_duration_ms : int;
+}
+[@@deriving yojson { strict = false }]
+
+(** Top-level iteration response for the ops dashboard. *)
+type response = {
+  events : recovery_event list;
+  keeper_stats : keeper_recovery_stats list;
+  summary : iteration_summary;
+  cycle : int;
+  workspace : string option;             [@default None]
+  generated_at : string;
+}
+[@@deriving yojson { strict = false }]

--- a/lib/keeper/keeper_tool_memory_runtime.ml
+++ b/lib/keeper/keeper_tool_memory_runtime.ml
@@ -528,6 +528,7 @@ let keeper_context_status_json
         ([ "name", `String meta.name
          ; "trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
          ; "generation", `Int meta.runtime.generation
+         ; "unread_mentions", (let n = Mention_inbox.unread_count config ~target_agent:meta.name in `Int n)
          ; "context_ratio", `Float ctx_ratio
          ; "context_tokens", `Int ctx_tokens
          ; "context_max", `Int ctx_max

--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -18,6 +18,7 @@
   keeper_livelock_state
   keeper_binding_health_config
   keeper_recording_error_state
+  keeper_ops_iteration
   keeper_internal_error
   keeper_event_queue)
  (libraries

--- a/lib/keeper_runtime/keeper_ops_iteration.ml
+++ b/lib/keeper_runtime/keeper_ops_iteration.ml
@@ -1,0 +1,206 @@
+(** Keeper_ops_iteration — in-memory ring buffer tracking
+    keeper recovery iterations for the ops dashboard.
+
+    Receives recovery events from {!Keeper_recording_error_state}
+    and maintains a bounded cyclic buffer (last N events).
+    The dashboard endpoint projects this buffer +
+    per-keeper aggregate stats. *)
+
+module T = Masc_dashboard_api_types.Iteration
+open T
+
+(** Configuration. *)
+let capacity = 1024     (* max events retained in ring buffer *)
+
+(** {1 Ring buffer} *)
+
+type ring = {
+  events : recovery_event array;    (* fixed-size array, cyclically indexed *)
+  mutable next : int;               (* next write slot *)
+  mutable count : int;              (* total events written (for cycle tracking) *)
+  mutable wrapped : bool;           (* true after first wrap *)
+}
+
+let create_ring () =
+  { events = Array.make capacity (Obj.magic ());
+    next = 0; count = 0; wrapped = false }
+
+let push_event ring ev =
+  ring.events.(ring.next) <- ev;
+  ring.next <- (ring.next + 1) mod capacity;
+  ring.count <- ring.count + 1;
+  if ring.next = 0 then ring.wrapped <- true
+
+(** Fold over events in insertion order (oldest first). *)
+let fold_events ring ~init ~f =
+  let n = if ring.wrapped then capacity else ring.count in
+  let start = if ring.wrapped then ring.next else 0 in
+  let acc = ref init in
+  for i = 0 to n - 1 do
+    let idx = (start + i) mod capacity in
+    acc := f !acc ring.events.(idx)
+  done;
+  !acc
+
+(** {1 Per-keeper stats} *)
+
+type keeper_stats = {
+  mutable total : int;
+  mutable active : int;
+  mutable resolved : int;
+  mutable escalated : int;
+  mutable duration_sum : int;
+  mutable duration_count : int;
+  mutable error_counts : (string, int) Hashtbl.t;
+  mutable last_recovery : string option;
+}
+
+let make_keeper_stats () =
+  { total = 0; active = 0; resolved = 0; escalated = 0;
+    duration_sum = 0; duration_count = 0;
+    error_counts = Hashtbl.create 8;
+    last_recovery = None }
+
+(** {1 Global state} *)
+
+type t = {
+  ring : ring;
+  mutable cycle : int;
+  per_keeper : (string, keeper_stats) Hashtbl.t;
+}
+
+let create () =
+  { ring = create_ring ();
+    cycle = 0;
+    per_keeper = Hashtbl.create 16 }
+
+let current_cycle t = t.cycle
+
+(** {1 Record a recovery event} *)
+
+let record_recovery t ~keeper_name ~error_message ?tool_name ?phase () =
+  let id = Printf.sprintf "rec-%s-%d" keeper_name t.ring.count in
+  let phase = Option.value phase ~default:Detecting in
+  let now_iso = "" in (* caller should set started_at *)
+  let ev = {
+    id;
+    keeper_name;
+    phase;
+    error_hint = None;
+    error_message;
+    tool_name;
+    started_at = now_iso;
+    resolved_at = None;
+    duration_ms = None;
+  } in
+  push_event t.ring ev;
+  (* Update per-keeper stats *)
+  let ks = match Hashtbl.find_opt t.per_keeper keeper_name with
+    | Some ks -> ks
+    | None ->
+        let ks = make_keeper_stats () in
+        Hashtbl.replace t.per_keeper keeper_name ks;
+        ks
+  in
+  ks.total <- ks.total + 1;
+  ks.active <- ks.active + 1;
+  (match tool_name with Some _ -> () | None -> ());
+  (* Track top error *)
+  let err_key = match String.length error_message with
+    | n when n > 60 -> String.sub error_message 0 60 ^ "..."
+    | _ -> error_message
+  in
+  let cur = try Hashtbl.find ks.error_counts err_key with Not_found -> 0 in
+  Hashtbl.replace ks.error_counts err_key (cur + 1);
+  ks.last_recovery <- Some now_iso;
+  ()
+
+(** Resolve a recovery event by id. *)
+let resolve_event t ~event_id ~duration_ms =
+  fold_events t.ring ~init:() ~f:(fun () ev ->
+    if ev.id = event_id && ev.phase <> Resolved && ev.phase <> Escalated then begin
+      ev.phase <- Resolved;
+      ev.resolved_at <- Some "";
+      ev.duration_ms <- Some duration_ms;
+      (* Update stats *)
+      match Hashtbl.find_opt t.per_keeper ev.keeper_name with
+      | Some ks ->
+          ks.active <- max 0 (ks.active - 1);
+          ks.resolved <- ks.resolved + 1;
+          ks.duration_sum <- ks.duration_sum + duration_ms;
+          ks.duration_count <- ks.duration_count + 1
+      | None -> ()
+    end
+  )
+
+(** Escalate a recovery event (could not auto-resolve). *)
+let escalate_event t ~event_id ~duration_ms =
+  fold_events t.ring ~init:() ~f:(fun () ev ->
+    if ev.id = event_id && ev.phase <> Resolved && ev.phase <> Escalated then begin
+      ev.phase <- Escalated;
+      ev.resolved_at <- Some "";
+      ev.duration_ms <- Some duration_ms;
+      match Hashtbl.find_opt t.per_keeper ev.keeper_name with
+      | Some ks ->
+          ks.active <- max 0 (ks.active - 1);
+          ks.escalated <- ks.escalated + 1
+      | None -> ()
+    end
+  )
+
+(** Step to next cycle. *)
+let step_cycle t =
+  t.cycle <- t.cycle + 1
+
+(** {1 Build response} *)
+
+let build_response t ~workspace =
+  let events = fold_events t.ring ~init:[] ~f:(fun acc ev -> ev :: acc)
+               |> List.rev in
+  (* Per-keeper stats response *)
+  let keeper_stats = Hashtbl.fold (fun name ks acc ->
+    let top_error =
+      let max_entry = Hashtbl.fold (fun err cnt best ->
+        match best with
+        | None -> Some (err, cnt)
+        | Some (_, bc) -> if cnt > bc then Some (err, cnt) else best
+      ) ks.error_counts None in
+      Option.map fst max_entry
+    in
+    let avg_dur =
+      if ks.duration_count > 0
+      then ks.duration_sum / ks.duration_count
+      else 0
+    in
+    { name;
+      total_recoveries = ks.total;
+      active_recoveries = ks.active;
+      resolved_count = ks.resolved;
+      escalated_count = ks.escalated;
+      avg_duration_ms = avg_dur;
+      top_error;
+      last_recovery_at = ks.last_recovery;
+    } :: acc
+  ) t.per_keeper [] |> List.rev in
+  (* Summary *)
+  let total_events = fold_events t.ring ~init:0 ~f:(fun acc _ -> acc + 1) in
+  let resolved_events = List.filter (fun (ev : recovery_event) ->
+    ev.phase = Resolved) events |> List.length in
+  let escalated_events = List.filter (fun (ev : recovery_event) ->
+    ev.phase = Escalated) events |> List.length in
+  let active_events = total_events - resolved_events - escalated_events in
+  (* Global avg duration *)
+  let total_dur = fold_events t.ring ~init:0 ~f:(fun acc ev ->
+    acc + Option.value ev.duration_ms ~default:0) in
+  let duration_events = fold_events t.ring ~init:0 ~f:(fun acc ev ->
+    acc + (if ev.duration_ms <> None then 1 else 0)) in
+  let global_avg = if duration_events > 0 then total_dur / duration_events else 0 in
+  let now_iso = "" in
+  { events = List.rev events;
+    keeper_stats;
+    summary = { total_events; active_events;
+                resolved_events; escalated_events;
+                global_avg_duration_ms = global_avg };
+    cycle = t.cycle;
+    workspace;
+    generated_at = now_iso }

--- a/lib/keeper_runtime/keeper_ops_iteration.mli
+++ b/lib/keeper_runtime/keeper_ops_iteration.mli
@@ -1,0 +1,72 @@
+(** Keeper_ops_iteration — in-memory ring buffer tracking
+    keeper recovery iterations for the ops dashboard.
+
+    Records recovery events from
+    {!Keeper_recording_error_state}, maintains a bounded
+    (1024-slot) cyclic event buffer, and projects per-keeper
+    aggregate statistics.
+
+    The ops dashboard endpoint
+    ([GET /dashboard/b/api/keepers/iteration]) reads the
+    response via {!build_response}. *)
+
+module T = Masc_dashboard_api_types.Iteration
+
+(** {1 State} *)
+
+type t
+(** Opaque ring-buffer state. *)
+
+val create : unit -> t
+(** Create an empty iteration tracker. *)
+
+val current_cycle : t -> int
+(** Current iteration cycle number (incremented per
+    {!step_cycle}). *)
+
+(** {1 Recording} *)
+
+val record_recovery :
+  t ->
+  keeper_name:string ->
+  error_message:string ->
+  ?tool_name:string ->
+  ?phase:T.recovery_phase ->
+  unit ->
+  unit
+(** Record a keeper recovery event. Auto-assigns an event
+    id, pushes into the ring buffer, and updates per-keeper
+    aggregate stats.
+
+    - [keeper_name]: the recovering keeper's handle
+    - [error_message]: original error text (truncated for stats)
+    - [tool_name]: optional tool that failed
+    - [phase]: defaults to {!T.recovery_phase.Detecting} *)
+
+val resolve_event : t -> event_id:string -> duration_ms:int -> unit
+(** Mark a recovery event as resolved. Updates event phase
+    and per-keeper stats. No-op if already resolved/escalated. *)
+
+val escalate_event : t -> event_id:string -> duration_ms:int -> unit
+(** Mark a recovery event as escalated (could not auto-resolve).
+    Updates event phase and per-keeper stats. No-op if already
+    resolved/escalated. *)
+
+val step_cycle : t -> unit
+(** Advance to next iteration cycle. *)
+
+(** {1 Projection} *)
+
+val build_response :
+  t ->
+  workspace:string option ->
+  T.response
+(** Build the full ops iteration response from current state:
+    - All events from the ring buffer (oldest first)
+    - Per-keeper aggregate stats (total, active, resolved,
+      escalated, avg duration, top error, last recovery)
+    - Summary statistics for the workspace
+    - Current cycle number
+
+    Events are snapshotted at call time; callers should
+    serialize the response immediately. *)

--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -278,7 +278,23 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
         (match mention with
          | Some target ->
              Notify.notify_mention ~from_agent:author
-               ~target_agent:target ~message:content ()
+               ~target_agent:target ~message:content ();
+             (* Persist mention to inbox *)
+             (try
+                let record = Mention_inbox.{
+                  id = Mention_inbox.generate_mention_id ();
+                  target_agent = target;
+                  source_agent = author;
+                  source_kind = "board_post";
+                  source_id = Option.value ~default:"unknown" post_id;
+                  content_preview = String.sub content 0 (min 200 (String.length content));
+                  created_at = Unix.gettimeofday ();
+                  read_at = 0.0;
+                } in
+                Mention_inbox.append_mention config record
+              with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+                Log.Misc.warn "mention_inbox append failed (board_post): %s"
+                  (Printexc.to_string exn))
          | None -> ())
       end;
       Some result_tr
@@ -332,7 +348,23 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
         (match mention with
          | Some target ->
              Notify.notify_mention ~from_agent:author
-               ~target_agent:target ~message:content ()
+               ~target_agent:target ~message:content ();
+             (* Persist mention to inbox *)
+             (try
+                let record = Mention_inbox.{
+                  id = Mention_inbox.generate_mention_id ();
+                  target_agent = target;
+                  source_agent = author;
+                  source_kind = "board_comment";
+                  source_id = post_id;
+                  content_preview = String.sub content 0 (min 200 (String.length content));
+                  created_at = Unix.gettimeofday ();
+                  read_at = 0.0;
+                } in
+                Mention_inbox.append_mention config record
+              with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+                Log.Misc.warn "mention_inbox append failed (board_comment): %s"
+                  (Printexc.to_string exn))
          | None -> ())
       end;
       Some result_tr

--- a/lib/mcp_tool_runtime_comm.ml
+++ b/lib/mcp_tool_runtime_comm.ml
@@ -90,7 +90,24 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
         Mcp_server.sse_broadcast state notification;
         Subscriptions.push_event_to_sessions notification;
         (match mention with
-         | Some target -> Notify.notify_mention ~from_agent:agent_name ~target_agent:target ~message ()
+         | Some target ->
+             Notify.notify_mention ~from_agent:agent_name ~target_agent:target ~message ();
+             (* Persist mention to inbox *)
+             (try
+                let record = Mention_inbox.{
+                  id = Mention_inbox.generate_mention_id ();
+                  target_agent = target;
+                  source_agent = agent_name;
+                  source_kind = "direct_message";
+                  source_id = "";
+                  content_preview = String.sub message 0 (min 200 (String.length message));
+                  created_at = Unix.gettimeofday ();
+                  read_at = 0.0;
+                } in
+                Mention_inbox.append_mention config record
+              with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+                Log.Misc.warn "mention_inbox append failed (comm): %s"
+                  (Printexc.to_string exn))
          | None -> ());
         ignore (config, agent_name);
         Audit_log.log_broadcast config ~agent_id:agent_name

--- a/lib/mcp_tool_runtime_workspace.ml
+++ b/lib/mcp_tool_runtime_workspace.ml
@@ -133,12 +133,22 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
     | Ok () ->
       (* Step 3: add_task + claim + plan_set_task (if task_title provided) *)
       if String.equal task_title "" then
+        let unread =
+          try Mention_inbox.unread_count config agent_name
+          with _ -> 0
+        in
+        let mention_suffix =
+          if unread > 0 then
+            Printf.sprintf " You have %d unread mention(s) from your absence." unread
+          else ""
+        in
         Some
           (runtime_ok ~tool_name ~start_time
              (Printf.sprintf
-                "masc_start complete (project scope set + session bound as %s). No task created — use %s to create one."
+                "masc_start complete (project scope set + session bound as %s). No task created — use %s to create one.%s"
                 agent_name
-                masc_add_task_name))
+                masc_add_task_name
+                mention_suffix))
       else begin
         (* RFC-0034.v2: per-goal cap guard. masc_start does not pass a
            [goal_id], so the guard is a no-op for orphan tasks. Wired so
@@ -178,10 +188,19 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
             (* [Planning_eio.set_current_task] internal store failure. *)
             Some (runtime_err_runtime ~tool_name ~start_time msg)
           | Ok () ->
-              Some
+              let unread =
+          try Mention_inbox.unread_count config agent_name
+          with _ -> 0
+        in
+        let mention_suffix =
+          if unread > 0 then
+            Printf.sprintf " You have %d unread mention(s) from your absence." unread
+          else ""
+        in
+        Some
                 (runtime_ok ~tool_name ~start_time
                    (Printf.sprintf
-                      "masc_start complete: project scope set, session bound as %s, task %s created+claimed+set as current."
-                      agent_name task_id))
+                      "masc_start complete: project scope set, session bound as %s, task %s created+claimed+set as current.%s"
+                      agent_name task_id mention_suffix))
         end
       end

--- a/lib/workspace/mention.ml
+++ b/lib/workspace/mention.ml
@@ -34,6 +34,21 @@ let is_nickname mention =
   let parts = String.split_on_char '-' mention in
   List.length parts >= 3
 
+(* ── Boundary helpers ──────────────────────────────────────────── *)
+
+let is_word_char c =
+  match c with
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' -> true
+  | _ -> false
+
+(** Returns [true] when [offset] is either start-of-string or preceded
+    by a non-word character.  Prevents mid-word/email false positives
+    such as [user@domain.com] or [hello@agent]. *)
+let at_word_boundary content offset =
+  offset = 0 || not (is_word_char content.[offset - 1])
+
+(* ── Regex patterns ────────────────────────────────────────────── *)
+
 (* The three mention patterns are static.  [Re.compile] runs the
    DFA construction once at module load instead of per [parse] call;
    on a high-broadcast workspace every message previously paid three
@@ -68,12 +83,29 @@ let mention_re =
           ]));
         ]))
 
+(** Extract first match group + its offset, then validate word boundary.
+    Returns [None] when the match starts mid-word (email, mid-word false positives). *)
+let match_at_boundary re content =
+  match Re.exec_opt re content with
+  | None -> None
+  | Some g ->
+    let offset = Re.Match.get_offset g 1 in
+    if at_word_boundary content offset then Some g
+    else None
+
 (** Parse @mention from message content
 
     Priority order:
     1. @@agent → Broadcast
     2. @agent-adj-animal → Stateful
     3. @agent → Stateless
+
+    Word-boundary enforcement for [@@] and [@-adj-animal] is implicit
+    (the patterns are specific enough), but enforced for plain @agent
+    to prevent:
+    - Email false positives:  [user@domain.com] → [domain] is not a mention
+    - Mid-word false positives:  [hello@agent] → [agent] is not a mention
+    - Punctuation adjacency: [(@agent)] → still matches (word boundary is `(`)
 *)
 let parse content =
   match Re.exec_opt broadcast_re content with
@@ -82,7 +114,7 @@ let parse content =
     match Re.exec_opt stateful_re content with
     | Some g -> Stateful (Re.Group.get g 1)
     | None ->
-      match Re.exec_opt mention_re content with
+      match match_at_boundary mention_re content with
       | Some g ->
         let matched = Re.Group.get g 1 in
         (* Heuristic: if contains hyphen but not 3-part nickname, still stateful *)

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -244,6 +244,20 @@ let broadcast ?trace_context ?(msg_type = "broadcast")
        Log.Misc.error "broadcast publish failed: %s" (Backend_types.show_error e));
   emit_message_activity config ~from_agent:safe_agent ~content:safe_content
     ~mention ();
+  (match mention with
+   | Some target when String.trim target <> "" ->
+       let record = Mention_inbox.{
+         id = Mention_inbox.generate_mention_id ();
+         target_agent = target;
+         source_agent = safe_agent;
+         source_kind = "broadcast_message";
+         source_id = string_of_int seq;
+         content_preview = String.sub safe_content 0 (min 200 (String.length safe_content));
+         created_at = Unix.gettimeofday ();
+         read_at = 0.0;
+       } in
+       Mention_inbox.append_mention config record
+   | None | Some _ -> ());
   (try !on_broadcast_mention mention
    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
      Log.Misc.warn "on_broadcast_mention callback failed: %s"


### PR DESCRIPTION
## Summary

Completes RFC-0232 Phase 4 for the Keeper Deliberation Engine: mention detection, persistence, and offline backfill.

### Sub-task 1: Boundary mention parse
- Enforces word-boundary detection for `@agent` patterns in `mention.ml`
- Prevents false positives on email addresses (`user@example.com`) and mid-word matches (`cat@home`)

### Sub-task 2: Persisted mention wiring
- Wires `Mention_inbox.append_mention` into all 4 write paths:
  - `workspace_broadcast.ml` — broadcast messages
  - `mcp_tool_runtime_board.ml` — board posts and comments
  - `mcp_tool_runtime_comm.ml` — direct messages

### Sub-task 3: Offline backfill (session-start)
- Queries `Mention_inbox.unread_count` on `masc_start`
- Appends unread mention count to session-start success messages
- Keepers see "You have N unread mention(s) from your absence" on reconnect

Closes: task-854