### PR TITLE
fix(keeper_msg_async): reject '.'/'..' literal in is_safe_request_id (path traversal)

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -47,6 +47,8 @@ let is_safe_request_id request_id =
   let len = String.length request_id in
   if len = 0
   then false
+  else if request_id = "." || request_id = ".."
+  then false
   else if len > max_request_id_len
   then false
   else (
@@ -494,6 +496,7 @@ let cancel ?base_path request_id : bool =
 ;;
 
 module For_testing = struct
+  let is_safe_request_id = is_safe_request_id
   let forget request_id = with_lock (fun () -> Hashtbl.remove pending request_id)
   let clear () = with_lock (fun () -> Hashtbl.clear pending)
   let record_path = record_path

--- a/test/dune
+++ b/test/dune
@@ -1415,6 +1415,7 @@
 
 (include stanzas/test_keeper_long_turn_9943.inc)
 
+(include stanzas/test_keeper_msg_async_path_traversal.inc)
 (include stanzas/test_keeper_msg_cancel.inc)
 
 (include stanzas/test_keeper_memory_bank_consensus_re_10399.inc)

--- a/test/stanzas/test_keeper_msg_async_path_traversal.inc
+++ b/test/stanzas/test_keeper_msg_async_path_traversal.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_msg_async_path_traversal)
+ (modules test_keeper_msg_async_path_traversal)
+ (libraries masc_test_deps))

--- a/test/test_keeper_msg_async_path_traversal.ml
+++ b/test/test_keeper_msg_async_path_traversal.ml
@@ -1,0 +1,44 @@
+(** Test is_safe_request_id path traversal guards. *)
+
+let is_safe = Keeper_msg_async.For_testing.is_safe_request_id
+
+(** Valid request IDs — should be safe *)
+let%test "normal alphanumeric" = is_safe "abc123"
+let%test "with hyphens" = is_safe "my-request-42"
+let%test "with underscores" = is_safe "my_request_42"
+let%test "single char alpha" = is_safe "a"
+let%test "max length valid" =
+  let s = String.init 128 (fun _ -> 'x') in
+  is_safe s
+
+(** Edge cases — request_id containing dots in valid patterns *)
+let%test "dot in middle" = is_safe "req.123"
+let%test "trailing dot" = is_safe "request."
+
+(** Path traversal attempts — must be rejected *)
+let%test _ "single dot rejected" = not (is_safe ".")
+let%test _ "double dot rejected" = not (is_safe "..")
+let%test _ "empty string rejected" = not (is_safe "")
+let%test _ "over max length" =
+  let s = String.init 129 (fun _ -> 'x') in
+  not (is_safe s)
+let%test _ "slash rejected" = not (is_safe "../etc/passwd")
+let%test _ "dots with slash" = not (is_safe "../../config")
+let%test _ "only dots multiple" = not (is_safe "...")
+let%test _ "dots and slash combo" = not (is_safe "a/../b")
+
+(** record_path integration — uses is_safe_request_id *)
+let%test "record_path returns Some for safe id" =
+  match Keeper_msg_async.For_testing.record_path ~base_path:"/tmp" ~request_id:"safe-42" with
+  | Some _ -> true
+  | None -> false
+
+let%test "record_path returns None for path traversal" =
+  match Keeper_msg_async.For_testing.record_path ~base_path:"/tmp" ~request_id:".." with
+  | Some _ -> false
+  | None -> true
+
+let%test "record_path returns None for single dot" =
+  match Keeper_msg_async.For_testing.record_path ~base_path:"/tmp" ~request_id:"." with
+  | Some _ -> false
+  | None -> true


### PR DESCRIPTION
## Summary

Cherry-pick from closed PR #20933 — focused path traversal fix only.

### Changes
- `lib/keeper/keeper_msg_async.ml` (+3 lines): reject `request_id = ".."` and `request_id = "."` in `is_safe_request_id`
- `test/test_keeper_msg_async_path_traversal.ml` (+44 lines): 14 test cases covering valid IDs, dot edge cases, path traversal patterns
- `test/stanzas/test_keeper_msg_async_path_traversal.inc` (+4 lines): test stanza
- `test/dune` (+1 line): stanza include

### Scope
This is the **path traversal fix only** — split from PR #20933 per owner's scope comment (jeong-sik, 2026-06-12). The role_filter feature will be a separate PR.

### Verification (from verifier analysis)
- `is_safe_request_id` guard covers `poll()`, `load_record()`, `record_path()`, `gc_stale_disk()` — all path traversal entry points blocked
- CVSS 5.3 (Medium) — read-side path traversal via request_id

Closes task-853