### PR TITLE
[codex] Add DeepSeek platform runtime seed

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -25,10 +25,41 @@ supports-runtime-mcp-tools = true
 supports-runtime-tool-events = true
 supports-runtime-mcp-http-headers = true
 
+[providers.deepseek]
+display-name = "DeepSeek API"
+protocol = "provider_d-http"
+endpoint = "https://api.deepseek.com"
+
+[providers.deepseek.credentials]
+type = "env"
+key = "DEEPSEEK_API_KEY"
+
+[providers.deepseek.capabilities]
+supports-runtime-mcp-tools = true
+supports-runtime-tool-events = true
+supports-runtime-mcp-http-headers = true
+
 [providers.ollama]
 display-name = "Local Ollama"
 protocol = "ollama-http"
 endpoint = "http://localhost:11434"
+
+[models.deepseek-v4-pro]
+api-name = "deepseek-v4-pro"
+max-context = 1000000
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.deepseek-v4-pro.capabilities]
+max-output-tokens = 384000
+supports-tool-choice = true
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-response-format-json = true
+supports-structured-output = true
 
 [models.deepseek-v4-flash]
 api-name = "deepseek-v4-flash"
@@ -58,6 +89,12 @@ supports-image-input = true
 supports-multimodal-inputs = true
 
 [ollama_cloud.deepseek-v4-flash]
+max-concurrent = 4
+
+[deepseek.deepseek-v4-pro]
+max-concurrent = 2
+
+[deepseek.deepseek-v4-flash]
 max-concurrent = 4
 
 [ollama.gemma4-26b-a4b-qat]


### PR DESCRIPTION
## Summary
- Add the official DeepSeek Platform API provider to the runtime seed.
- Add `deepseek-v4-pro` model metadata, reasoning/tool capabilities, max output metadata, and platform runtime bindings for `deepseek-v4-pro` and `deepseek-v4-flash`.
- Keep the existing default on `ollama_cloud.deepseek-v4-flash` and the local Gemma QAT canary assignment unchanged.

## Validation
- `scripts/check-toml-syntax.sh config/runtime.toml`
- `env DUNE_BUILD_DIR=/private/tmp/masc-deepseek-provider-build dune build --root . test/test_runtime_config_validity.exe test/test_runtime_provider_auth_headers.exe`
- `/private/tmp/masc-deepseek-provider-build/default/test/test_runtime_config_validity.exe`
- `/private/tmp/masc-deepseek-provider-build/default/test/test_runtime_provider_auth_headers.exe`
- `git diff --check`