### PR TITLE
fix(prompts): sync runtime prompt markdown from binary-embedded assets at boot (#20929)

### DIFF
--- a/lib/prompt_defaults.ml
+++ b/lib/prompt_defaults.ml
@@ -27,6 +27,61 @@ let resolve_prompt_markdown_dir ~workspace_path ~base_path =
 
 let bootstrapped_signature : (string * string) option ref = ref None
 
+(* ── Binary-embedded prompt asset sync (#20929) ─────────────────────────
+   The binary embeds the repo's config/ tree (lib/embedded_config); the
+   runtime markdown dir under <base>/.masc/config/prompts is derived
+   distribution state.  Operator customization has its own layer
+   (prompt_overrides.json, replayed after directory load), so prompt
+   markdown that differs from the embedded asset is stale, not customized
+   — overwriting is the correct convergence.  Only the prompts/ subtree
+   syncs: the rest of .masc/config (tool_policy.toml, runtime.toml, …) is
+   operator-edited in place and must never be auto-overwritten. *)
+
+let prompts_asset_prefix = "prompts/"
+
+type sync_result = {
+  copied : string list;
+  overwritten : string list;
+  failed : (string * string) list;
+}
+
+let read_file_opt path =
+  if Sys.file_exists path then
+    try Some (In_channel.with_open_text path In_channel.input_all)
+    with Sys_error _ -> None
+  else None
+
+let sync_prompt_assets ~read ~files ~prompts_dir () =
+  let prefix_len = String.length prompts_asset_prefix in
+  List.fold_left
+    (fun acc rel ->
+      if not (String.starts_with ~prefix:prompts_asset_prefix rel) then acc
+      else
+        match read rel with
+        | None ->
+            { acc with failed = (rel, "embedded asset unreadable") :: acc.failed }
+        | Some content ->
+            let dest =
+              Filename.concat prompts_dir
+                (String.sub rel prefix_len (String.length rel - prefix_len))
+            in
+            let existing = read_file_opt dest in
+            (match existing with
+             | Some current when String.equal current content -> acc
+             | _ -> (
+                 try
+                   Fs_compat.mkdir_p (Filename.dirname dest);
+                   Fs_compat.save_file dest content;
+                   if Option.is_some existing then
+                     { acc with overwritten = rel :: acc.overwritten }
+                   else { acc with copied = rel :: acc.copied }
+                 with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | Sys_error msg ->
+                     { acc with failed = (rel, msg) :: acc.failed })))
+    { copied = []; overwritten = []; failed = [] }
+    files
+
 (** Scan the current markdown dir and register all prompts with frontmatter.
     Called by [bootstrap_runtime]; also usable in tests after [set_markdown_dir]. *)
 let init () =

--- a/lib/prompt_defaults.mli
+++ b/lib/prompt_defaults.mli
@@ -22,6 +22,39 @@ val resolve_prompt_markdown_dir :
     candidate list, falling back to {!Config_dir_resolver.prompts_dir}
     when none exist yet. *)
 
+type sync_result = {
+  copied : string list;
+  overwritten : string list;
+  failed : (string * string) list;
+}
+(** Outcome of one prompt asset sync pass. Entries are embedded asset
+    paths (e.g. [prompts/keeper.world.md]); [failed] pairs the path with
+    the error message. *)
+
+val sync_prompt_assets :
+  read:(string -> string option) ->
+  files:string list ->
+  prompts_dir:string ->
+  unit ->
+  sync_result
+(** Converge the runtime prompt markdown dir onto the binary-embedded
+    assets (#20929). Only entries under [prompts/] in [files] are
+    considered; each is written into [prompts_dir] when missing or when
+    its content differs from the embedded copy. Identical files are left
+    untouched; files present only in [prompts_dir] are never deleted.
+
+    Overwrite-on-differ is safe by design: operator prompt customization
+    lives in prompt_overrides.json (replayed after directory load), so a
+    divergent markdown file is a stale distribution copy, not an edit.
+    The rest of .masc/config is operator-edited in place and is out of
+    scope here.
+
+    [read]/[files] are typically [Embedded_config.read] /
+    [Embedded_config.file_list], passed in by the server bootstrap so
+    this module stays asset-source agnostic (and unit-testable).
+    [Eio.Cancel.Cancelled] propagates; per-file [Sys_error] is recorded
+    in [failed] without aborting the pass. *)
+
 val init : unit -> unit
 (** Initialise prompt defaults from the environment.
     Idempotent — safe to call multiple times. *)

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -16,6 +16,9 @@
   ;; directly (specs_json / tlc_results_json) and dune does not re-export through
   ;; the masc dep, so masc_server lists it explicitly.
   masc.dashboard_tla_specs
+  ;; #20929: server bootstrap converges <base>/.masc/config/prompts onto the
+  ;; binary-embedded config/ tree so merged prompt edits ship on restart.
+  masc.embedded_config
   masc.masc_tool_surface
   masc.operator
   yojson

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -267,9 +267,42 @@ let lazy_startup_task_names () =
   lazy_startup_plan ()
   |> List.concat_map (fun group -> group.task_names)
 
+(* Cap the per-boot file list in the sync log line; full counts are always
+   logged, names are illustrative. *)
+let max_logged_prompt_sync_entries = 10
+
+let sync_prompt_assets_from_binary () =
+  let sync =
+    Prompt_defaults.sync_prompt_assets
+      ~read:Embedded_config.read
+      ~files:Embedded_config.file_list
+      ~prompts_dir:(Config_dir_resolver.prompts_dir ())
+      ()
+  in
+  (match sync.Prompt_defaults.copied, sync.Prompt_defaults.overwritten with
+   | [], [] -> ()
+   | copied, overwritten ->
+       let names = copied @ overwritten in
+       let shown =
+         List.filteri (fun i _ -> i < max_logged_prompt_sync_entries) names
+       in
+       Log.Misc.info
+         "prompt assets synced from binary: %d copied, %d overwritten [%s%s]"
+         (List.length copied) (List.length overwritten)
+         (String.concat ", " shown)
+         (if List.length names > max_logged_prompt_sync_entries then ", …"
+          else ""));
+  List.iter
+    (fun (rel, msg) -> Log.Misc.warn "prompt asset sync failed: %s: %s" rel msg)
+    sync.Prompt_defaults.failed
+
 let bootstrap_prompt_state (state : Mcp_server.server_state) =
   Config_dir_resolver.log_warnings ~context:"ServerBootstrap" ();
   Config_dir_resolver.log_resolution ~context:"ServerBootstrap" ();
+  (* Converge runtime prompt markdown onto the binary-embedded assets
+     before the registry scans the directory (#20929: merged prompt edits
+     never reached the runtime dir otherwise). *)
+  sync_prompt_assets_from_binary ();
   (* Initialize prompt registry with defaults and restore saved overrides *)
   let prompt_markdown_dir =
     Prompt_defaults.bootstrap_runtime

--- a/test/dune
+++ b/test/dune
@@ -814,6 +814,7 @@
   test_goal_store
   test_goal_verification
   test_string_util
+  test_prompt_asset_sync
   test_system_error_class
   test_set_util
   test_board_core_payload
@@ -993,6 +994,7 @@
   test_goal_store
   test_goal_verification
   test_string_util
+  test_prompt_asset_sync
   test_system_error_class
   test_set_util
   test_board_core_payload

--- a/test/test_prompt_asset_sync.ml
+++ b/test/test_prompt_asset_sync.ml
@@ -1,0 +1,110 @@
+(** Tests for [Prompt_defaults.sync_prompt_assets] (#20929) — converging the
+    runtime prompt markdown dir onto binary-embedded assets. *)
+
+open Alcotest
+module Prompt_defaults = Masc.Prompt_defaults
+
+let embedded =
+  [
+    ("prompts/keeper.example.md", "---\ndescription: example\n---\nbody v2\n");
+    ("prompts/behavior/contract.md", "---\ndescription: contract\n---\nrules\n");
+    ("tool_policy.toml", "[policy]\n");
+  ]
+
+let read_embedded rel = List.assoc_opt rel embedded
+let embedded_files = List.map fst embedded
+
+let with_temp_prompts_dir f =
+  let dir = Filename.temp_dir "prompt-asset-sync" "test" in
+  Fun.protect
+    ~finally:(fun () ->
+      (* best-effort cleanup; leftover temp dirs are harmless *)
+      try
+        let rec rm path =
+          if Sys.is_directory path then begin
+            Array.iter (fun e -> rm (Filename.concat path e)) (Sys.readdir path);
+            Unix.rmdir path
+          end
+          else Sys.remove path
+        in
+        rm dir
+      with Sys_error _ | Unix.Unix_error _ -> ())
+    (fun () -> f dir)
+
+let read_file path = In_channel.with_open_text path In_channel.input_all
+
+let sync ~prompts_dir =
+  Prompt_defaults.sync_prompt_assets ~read:read_embedded ~files:embedded_files
+    ~prompts_dir ()
+
+let test_copies_missing_and_scopes_to_prompts () =
+  with_temp_prompts_dir (fun dir ->
+      let result = sync ~prompts_dir:dir in
+      check (list string) "copied"
+        [ "prompts/behavior/contract.md"; "prompts/keeper.example.md" ]
+        (List.sort compare result.Prompt_defaults.copied);
+      check (list string) "overwritten" [] result.Prompt_defaults.overwritten;
+      check int "failed" 0 (List.length result.Prompt_defaults.failed);
+      check string "subdir content" "---\ndescription: contract\n---\nrules\n"
+        (read_file (Filename.concat dir "behavior/contract.md"));
+      check bool "non-prompts asset not written" false
+        (Sys.file_exists (Filename.concat dir "tool_policy.toml")))
+
+let test_second_run_is_noop () =
+  with_temp_prompts_dir (fun dir ->
+      let (_ : Prompt_defaults.sync_result) = sync ~prompts_dir:dir in
+      let again = sync ~prompts_dir:dir in
+      check (list string) "copied" [] again.Prompt_defaults.copied;
+      check (list string) "overwritten" [] again.Prompt_defaults.overwritten)
+
+let test_overwrites_stale_copy () =
+  with_temp_prompts_dir (fun dir ->
+      let (_ : Prompt_defaults.sync_result) = sync ~prompts_dir:dir in
+      let stale = Filename.concat dir "keeper.example.md" in
+      Out_channel.with_open_text stale (fun oc ->
+          Out_channel.output_string oc "body v1 (stale)\n");
+      let result = sync ~prompts_dir:dir in
+      check (list string) "overwritten" [ "prompts/keeper.example.md" ]
+        result.Prompt_defaults.overwritten;
+      check (list string) "copied" [] result.Prompt_defaults.copied;
+      check string "converged content"
+        "---\ndescription: example\n---\nbody v2\n" (read_file stale))
+
+let test_runtime_only_files_survive () =
+  with_temp_prompts_dir (fun dir ->
+      let extra = Filename.concat dir "operator.custom.md" in
+      Out_channel.with_open_text extra (fun oc ->
+          Out_channel.output_string oc "local-only\n");
+      let (_ : Prompt_defaults.sync_result) = sync ~prompts_dir:dir in
+      check bool "runtime-only file kept" true (Sys.file_exists extra);
+      check string "runtime-only content kept" "local-only\n" (read_file extra))
+
+let test_unreadable_embedded_entry_is_failed () =
+  with_temp_prompts_dir (fun dir ->
+      let result =
+        Prompt_defaults.sync_prompt_assets
+          ~read:(fun _ -> None)
+          ~files:[ "prompts/ghost.md" ]
+          ~prompts_dir:dir ()
+      in
+      check int "failed count" 1 (List.length result.Prompt_defaults.failed);
+      match result.Prompt_defaults.failed with
+      | [ (rel, _) ] -> check string "failed entry" "prompts/ghost.md" rel
+      | _ -> fail "expected exactly one failure")
+
+let () =
+  run "prompt_asset_sync"
+    [
+      ( "sync",
+        [
+          test_case "copies missing, scopes to prompts/" `Quick
+            test_copies_missing_and_scopes_to_prompts;
+          test_case "second run is a no-op" `Quick test_second_run_is_noop;
+          test_case "overwrites stale runtime copy" `Quick
+            test_overwrites_stale_copy;
+          test_case "runtime-only files are never deleted" `Quick
+            test_runtime_only_files_survive;
+          test_case "unreadable embedded entry recorded as failure" `Quick
+            test_unreadable_embedded_entry_is_failed;
+        ] );
+    ]


### PR DESCRIPTION
Closes #20929.

## 문제

repo `config/prompts/`가 런타임 `<base>/.masc/config/prompts/`로 배포되는 단계가 없었습니다. 시딩은 수동 `masc init`(skip-if-exists) 뿐이라:

- **신규 파일**: librarian/recall/tool_contract 프롬프트 7개가 런타임에 없어서 fleet 전체 `Prompt 'keeper.librarian.system' is missing` (2026-06-12, 수동 cp로 임시 해소)
- **수정 파일 (더 큰 갭)**: 런타임 7개 파일이 6/4 화석. #20409(6/7)의 **keeper identity anchor**(컴팩션 시 정체성 보호)가 머지 후 5일간 미배포 — 페르소나 드리프트(Q10)의 직접 기여 요인

## 수정

서버 부트스트랩(`bootstrap_prompt_state`)이 registry 스캔 *전에* 바이너리 임베디드 자산(`lib/embedded_config`, repo `config/` 트리를 빌드 타임에 crunch)에서 `prompts/` 서브트리를 sync:

- missing → copy, content-differs → **overwrite**, identical → untouched, runtime-only → 보존(삭제 안 함)
- overwrite가 안전한 근거: 운영자 프롬프트 커스터마이징은 별도 레이어(`prompt_overrides.json`, 디렉토리 로드 후 replay)가 공인 경로 — 런타임 .md는 파생 배포물
- `tool_policy.toml` 등 나머지 `.masc/config`는 운영자 직접 수정 파일이라 **sync 범위 제외**

설계: `Prompt_defaults.sync_prompt_assets ~read ~files ~prompts_dir` — 자산 소스를 인자로 받아 모듈은 asset-agnostic + unit-testable. `Embedded_config` 결합은 lib/server 조립 레이어에만 (bin/main_eio.ml의 init_cmd와 동일 패턴).

배포 형태 무관(repo checkout 불필요): 바이너리와 프롬프트가 같은 커밋으로 버전됩니다. "머지됨 ≠ 동작함" 클래스 하나 제거.

## 검증

- `test_prompt_asset_sync.ml` 5/5 green: missing copy(서브디렉토리 포함)/idempotent/stale overwrite/runtime-only 보존/unreadable failure
- `dune build @check` + default target 모두 exit 0
- 임베디드 생성물에 `prompts/` 경로 109 entries + 현재 repo 내용(#20409 Identity continuity 문단) 포함 확인
- 미검증(재배포 필요): 실제 서버 부팅 시 INFO 로그 `prompt assets synced from binary: N copied, M overwritten` 및 stale 7파일 수렴

후속(범위 외): repo에서 *삭제*된 프롬프트의 런타임 잔존(ghost) 정리 — 보수적으로 비삭제 선택, 별도 판단 필요 시 이슈로.

MASC task-856. refs #20921

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
