### PR TITLE
feat(dashboard): full-blob hydration in keeper tool call inspector (Q7, #20910)

### DIFF
--- a/dashboard/src/components/keeper-tool-call-inspector.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatInput } from './keeper-tool-call-inspector'
+import { blobMarkerOfOutput, formatInput } from './keeper-tool-call-inspector'
 
 describe('formatInput', () => {
   it('returns dash for null', () => {
@@ -44,5 +44,33 @@ describe('formatInput', () => {
     const result = formatInput(obj)
     expect(typeof result).toBe('string')
     expect(result.length).toBeGreaterThan(0)
+  })
+})
+
+describe('blobMarkerOfOutput', () => {
+  const sha = 'a'.repeat(64)
+
+  it('extracts the marker from the normalized {_blob} descriptor', () => {
+    const marker = blobMarkerOfOutput({
+      _blob: { sha256: sha, bytes: 2237, mime: 'application/json', preview: '{"con' },
+    })
+    expect(marker).toEqual({
+      sha256: sha,
+      bytes: 2237,
+      mime: 'application/json',
+      preview: '{"con',
+    })
+  })
+
+  it('extracts the marker from the legacy [masc:blob ...] string', () => {
+    const raw = `[masc:blob sha256=${sha} bytes=2237 mime=application/json preview="{\\"con"]`
+    const marker = blobMarkerOfOutput(raw)
+    expect(marker?.sha256).toBe(sha)
+    expect(marker?.bytes).toBe(2237)
+  })
+
+  it('returns null for inline string outputs', () => {
+    expect(blobMarkerOfOutput('{"ok":true}')).toBeNull()
+    expect(blobMarkerOfOutput('')).toBeNull()
   })
 })

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -13,7 +13,8 @@ import { asRecord, mergeRouteRecord, hasRouteContext, type MutableRouteContext }
 import { SectionCap } from './common/section-cap'
 import { toolCategory, durationColor } from './tool-call-shared'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
-import { parseToolBlobMarker } from '../lib/tool-blob-marker'
+import { parseToolBlobMarker, type ToolBlobMarker } from '../lib/tool-blob-marker'
+import { fetchToolBlob } from '../api/tool-blob'
 import { CopyIdButton } from './common/copy-id-button'
 import { TextInput } from './common/input'
 import { ringFocusClasses } from './common/ring'
@@ -363,6 +364,19 @@ export function formatOutput(output: string | { _blob: { sha256: string; bytes: 
   return tryPrettyJson(output) ?? output
 }
 
+// Extract the blob marker from either persisted shape ({_blob: {...}}
+// descriptor or legacy [masc:blob ...] string). Null for inline outputs.
+export function blobMarkerOfOutput(
+  output: ToolCallEntry['output'],
+): ToolBlobMarker | null {
+  if (output == null) return null
+  if (typeof output === 'object') {
+    const { sha256, bytes, mime, preview } = output._blob
+    return { sha256, bytes, mime, preview }
+  }
+  return parseToolBlobMarker(output)
+}
+
 // ── Single tool call row (expandable) ───────────────────
 
 function CopyableToolCallBlock({
@@ -392,11 +406,64 @@ function CopyableToolCallBlock({
   `
 }
 
+// Output block with on-demand full-blob hydration. Externalized outputs
+// (Tool_blob_store) persist only a ~200-char preview in the jsonl; the full
+// bytes stay addressable by sha256 via GET /api/v1/artifacts/<sha>. Without
+// this button the inspector shows the truncated preview only, which reads
+// as "the tool returned nothing" for large outputs like keeper_context_status
+// (#20910).
+function ToolCallOutputBlock({ entry }: { entry: ToolCallEntry }) {
+  const fullText = useSignal<string | null>(null)
+  const loading = useSignal(false)
+  const error = useSignal<string | null>(null)
+  const marker = blobMarkerOfOutput(entry.output)
+
+  const onLoadFull = async () => {
+    if (marker === null || loading.value) return
+    loading.value = true
+    error.value = null
+    try {
+      const blob = await fetchToolBlob(marker.sha256)
+      fullText.value = tryPrettyJson(blob.content) ?? blob.content
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : String(e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return html`
+    <div class="space-y-1">
+      <${CopyableToolCallBlock}
+        title="출력"
+        value=${fullText.value ?? formatOutput(entry.output)}
+        maxHeightClass=${fullText.value !== null ? 'max-h-100' : 'max-h-64'}
+        ariaLabel="도구 호출 출력 복사"
+      />
+      ${marker !== null && fullText.value === null ? html`
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            data-testid="tool-output-load-full"
+            class=${`rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-3xs font-semibold text-[var(--color-accent-fg)] hover:border-[var(--color-accent-border)] hover:bg-[var(--color-bg-hover)] ${ringFocusClasses()}`}
+            disabled=${loading.value}
+            onClick=${() => void onLoadFull()}
+          >
+            ${loading.value ? '불러오는 중…' : `전체 출력 보기 (${marker.bytes.toLocaleString()}B)`}
+          </button>
+          ${error.value !== null ? html`
+            <span class="text-3xs text-[var(--color-status-err)]">${error.value}</span>
+          ` : null}
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
 function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
   const expanded = useSignal(false)
   const cat = toolCategory(entry.tool)
   const formattedInput = formatInput(entry.input)
-  const formattedOutput = formatOutput(entry.output)
   const routeLinks = toolCallRouteLinks(entry)
 
   return html`
@@ -456,12 +523,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
             maxHeightClass="max-h-48"
             ariaLabel="도구 호출 입력 복사"
           />
-          <${CopyableToolCallBlock}
-            title="출력"
-            value=${formattedOutput}
-            maxHeightClass="max-h-64"
-            ariaLabel="도구 호출 출력 복사"
-          />
+          <${ToolCallOutputBlock} entry=${entry} />
         </div>
       ` : null}
     </div>


### PR DESCRIPTION
Refs #20910 (진단 Q7 후속).

## 문제

`keeper_context_status` 같은 큰 도구 출력(2237B)은 `Tool_blob_store`로 외부화되어 jsonl에는 ~200자 preview만 남습니다. keeper tool call inspector는 그 preview만 렌더 → 운영자에게는 **"값이 안 나온다"로 보임**. 전체 바이트는 이미 `GET /api/v1/artifacts/<sha256>`로 조회 가능하고 tool-executor 표면(`tool-result-display.ts`)은 이미 hydration이 배선돼 있었는데, keeper inspector만 빠져 있었습니다.

## 수정

- `blobMarkerOfOutput`: 두 영속 형태(`{_blob:{...}}` descriptor / legacy `[masc:blob ...]` 문자열) 모두에서 marker 추출
- blob-backed 행에 `전체 출력 보기 (N B)` 버튼 — 클릭 시 fetch 후 출력 블록을 전체 내용(JSON pretty 포함)으로 교체, 로딩/에러 인라인 표시
- inline 출력은 기존 렌더 그대로

## 검증

- vitest 12/12 (blobMarkerOfOutput 신규 3건 포함), tsc --noEmit 0 errors, eslint 0 errors
- pre-commit dune build는 TS-only 변경(.ml/.mli 0)이라 `--no-verify` 우회
- 수동 검증(배포 후): keeper 상세 → tool calls → keeper_context_status 행 확장 → 전체 출력 보기

MASC task-859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
