### PR TITLE
feat(keeper): RFC-0232 P4 — boundary mention parse, persisted mentions, offline backfill

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -139,6 +139,17 @@
  (package masc)
  (libraries masc masc_core unix eio eio_main))
 
+;; RFC-0232 P4: offline mention backfill for keeper chat lanes.
+;; Stamps the [mentions] field onto pre-P4 user rows; run with the
+;; server stopped.
+
+(executable
+ (name keeper_chat_backfill_mentions)
+ (modules keeper_chat_backfill_mentions)
+ (public_name masc-keeper-chat-backfill-mentions)
+ (package masc)
+ (libraries masc))
+
 ;; Read-only keeper feature proof CLI: renders the same JSON as
 ;; /api/v1/dashboard/keeper-feature-proof without starting a server.
 

--- a/bin/keeper_chat_backfill_mentions.ml
+++ b/bin/keeper_chat_backfill_mentions.ml
@@ -1,0 +1,37 @@
+(* Offline mention backfill for keeper chat lanes (RFC-0232 P4).
+
+   Usage: keeper_chat_backfill_mentions [--base-path DIR] [--dry-run]
+
+   Stamps the [mentions] field onto pre-P4 user rows whose content
+   parses to mention ids.  Run while the masc server is stopped: a
+   concurrent appender can lose lines to the read-rewrite-rename
+   window. *)
+
+let () =
+  let base_path = ref "." in
+  let dry_run = ref false in
+  let spec =
+    [
+      ( "--base-path",
+        Arg.Set_string base_path,
+        "DIR workspace base path (default: current directory)" );
+      ("--dry-run", Arg.Set dry_run, " report without rewriting");
+    ]
+  in
+  Arg.parse spec
+    (fun anon -> raise (Arg.Bad (Printf.sprintf "unexpected argument %S" anon)))
+    "keeper_chat_backfill_mentions [--base-path DIR] [--dry-run]";
+  let reports =
+    Masc.Keeper_chat_backfill.backfill_base_path ~dry_run:!dry_run !base_path
+  in
+  if reports = [] then print_endline "no keeper chat lanes found"
+  else (
+    List.iter
+      (fun (r : Masc.Keeper_chat_backfill.file_report) ->
+        Printf.printf "%s: %d/%d line(s) %s\n" r.path r.rewritten
+          r.total_lines
+          (if !dry_run then "would be stamped" else "stamped"))
+      reports;
+    let total = List.fold_left (fun acc r -> acc + r.Masc.Keeper_chat_backfill.rewritten) 0 reports in
+    Printf.printf "total: %d line(s) %s\n" total
+      (if !dry_run then "would be stamped" else "stamped"))

--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -25,6 +25,7 @@ type gateway_event = Discord_gateway_state.dispatched_event =
       ; author_id : string
       ; author_name : string option
       ; content : string
+      ; mention_user_ids : string list
       ; mentions_bot : bool
       ; explicit_mentions_bot : bool
       ; message_reference_channel_id : string option

--- a/lib/gate/discord_gateway_client.mli
+++ b/lib/gate/discord_gateway_client.mli
@@ -35,6 +35,7 @@ type gateway_event = Discord_gateway_state.dispatched_event =
       ; author_id : string
       ; author_name : string option
       ; content : string
+      ; mention_user_ids : string list
       ; mentions_bot : bool
       ; explicit_mentions_bot : bool
       ; message_reference_channel_id : string option

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -81,6 +81,10 @@ type dispatched_event =
       ; author_id : string
       ; author_name : string option
       ; content : string
+      ; mention_user_ids : string list
+            (* RFC-0232 §3.3: the structured [mentions] member ids are
+               kept at decode instead of being reduced to a bot bool;
+               the gate maps what its bindings can resolve. *)
       ; mentions_bot : bool
       ; explicit_mentions_bot : bool
       ; message_reference_channel_id : string option
@@ -313,17 +317,16 @@ let decode_message_create ~bot_user_id ~payload =
         | Some _ as name -> name
         | None -> field_string_opt "username" a)
   in
+  let mention_user_ids =
+    match assoc_opt "mentions" payload with
+    | Some (`List items) ->
+        List.filter_map (fun item -> field_string_opt "id" item) items
+    | Some _ | None -> []
+  in
   let mentions_bot =
-    match bot_user_id, assoc_opt "mentions" payload with
-    | None, _ | _, None -> false
-    | Some bot_id, Some (`List items) ->
-        List.exists
-          (fun item ->
-            match field_string_opt "id" item with
-            | Some id -> String.equal id bot_id
-            | None -> false)
-          items
-    | Some _, Some _ -> false
+    match bot_user_id with
+    | None -> false
+    | Some bot_id -> List.exists (String.equal bot_id) mention_user_ids
   in
   let explicit_mentions_bot =
     match bot_user_id with
@@ -359,6 +362,7 @@ let decode_message_create ~bot_user_id ~payload =
            ; author_id
            ; author_name
            ; content
+           ; mention_user_ids
            ; mentions_bot
            ; explicit_mentions_bot
            ; message_reference_channel_id

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -85,6 +85,10 @@ type dispatched_event =
             [author.username]; [None] only when the payload carries
             neither (RFC-0223 P1). *)
       ; content : string
+      ; mention_user_ids : string list
+            (* RFC-0232 §3.3: the structured [mentions] member ids are
+               kept at decode instead of being reduced to a bot bool;
+               the gate maps what its bindings can resolve. *)
       ; mentions_bot : bool
       ; explicit_mentions_bot : bool
         (** [true] only when message [content] contains a literal

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -159,6 +159,16 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
   let opt value = match String.trim value with "" -> None | v -> Some v in
   let conversation_id = metadata_value "conversation_id" metadata in
   let external_message_id = metadata_value "external_message_id" metadata in
+  (* RFC-0232 §3.3: the connector decoded a structured mention of this
+     channel's bound keeper (e.g. Discord <@snowflake>, invisible to
+     the content token parser), so the recorder persists it as an
+     explicit mention of the lane owner. *)
+  let extra_mentions =
+    match metadata_value "mentions_bound_keeper" metadata with
+    | Some "true" ->
+        Option.to_list (Keeper_identity.Keeper_id.of_string keeper_name)
+    | Some _ | None -> []
+  in
   Keeper_chat_store.append_user_message
     ~base_dir:config.Workspace.base_path
     ~keeper_name
@@ -171,6 +181,7 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
       ; speaker_name = opt channel_user_name
       ; speaker_authority = Keeper_chat_store.External
       }
+    ~extra_mentions
     ();
   Keeper_chat_broadcast.chat_appended
     ~keeper_name ~source:lane;

--- a/lib/keeper/keeper_chat_backfill.ml
+++ b/lib/keeper/keeper_chat_backfill.ml
@@ -1,0 +1,91 @@
+(** Offline mention backfill — see the interface for the contract. *)
+
+type file_report = {
+  path : string;
+  total_lines : int;
+  rewritten : int;
+}
+
+let backfill_line (line : string) : string option =
+  match Yojson.Safe.from_string line with
+  | exception Yojson.Json_error _ -> None
+  | `Assoc fields ->
+      let is_user_row =
+        match List.assoc_opt "role" fields with
+        | Some (`String "user") -> true
+        | _ -> false
+      in
+      if (not is_user_row) || List.mem_assoc "mentions" fields then None
+      else (
+        let content =
+          match List.assoc_opt "content" fields with
+          | Some (`String value) -> value
+          | _ -> ""
+        in
+        match Keeper_lane_mentions.mention_ids_of_content content with
+        | [] -> None
+        | ids ->
+            let mentions_field =
+              ( "mentions",
+                `List
+                  (List.map
+                     (fun id ->
+                       `String (Keeper_identity.Keeper_id.to_string id))
+                     ids) )
+            in
+            Some (Yojson.Safe.to_string (`Assoc (fields @ [ mentions_field ]))))
+  | _ -> None
+
+let read_lines path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> try close_in ic with _ -> ())
+    (fun () ->
+      let rec loop acc =
+        match input_line ic with
+        | line -> loop (line :: acc)
+        | exception End_of_file -> List.rev acc
+      in
+      loop [])
+
+let backfill_file ~dry_run path =
+  let lines = read_lines path in
+  let rewritten = ref 0 in
+  let out_lines =
+    List.map
+      (fun line ->
+        match backfill_line line with
+        | Some replacement ->
+            incr rewritten;
+            replacement
+        | None -> line)
+      lines
+  in
+  if (not dry_run) && !rewritten > 0 then (
+    let tmp = path ^ ".backfill-tmp" in
+    let oc = open_out_bin tmp in
+    Fun.protect
+      ~finally:(fun () -> try close_out oc with _ -> ())
+      (fun () ->
+        List.iter
+          (fun line ->
+            output_string oc line;
+            output_char oc '\n')
+          out_lines);
+    Sys.rename tmp path);
+  { path; total_lines = List.length lines; rewritten = !rewritten }
+
+let backfill_base_path ~dry_run base_path =
+  let dir =
+    Filename.concat
+      (Common.masc_dir_from_base_path ~base_path)
+      "keeper_chat"
+  in
+  if not (Sys.file_exists dir && Sys.is_directory dir) then []
+  else
+    Sys.readdir dir
+    |> Array.to_list
+    |> List.filter (fun name -> Filename.check_suffix name ".jsonl")
+    |> List.sort String.compare
+    |> List.map (fun name ->
+           backfill_file ~dry_run (Filename.concat dir name))

--- a/lib/keeper/keeper_chat_backfill.mli
+++ b/lib/keeper/keeper_chat_backfill.mli
@@ -1,0 +1,35 @@
+(** Keeper_chat_backfill — offline mention backfill for keeper chat
+    lanes (RFC-0232 §3.3 / P4).
+
+    Rows written before P4 carry no [mentions] field; at read time they
+    decode as "no mentions", so an unanswered pre-P4 "@name" line would
+    stop registering as pending once observation switches to persisted
+    ids.  This tool stamps those rows offline: for every user row
+    without a [mentions] field whose content yields mention ids under
+    the boundary parser ({!Keeper_lane_mentions.mention_ids_of_content}),
+    it rewrites the row with the parsed ids.  All other lines are
+    preserved byte-for-byte; rewrites are atomic per file (temp file +
+    rename).
+
+    Offline contract: run while the server is stopped — a concurrent
+    appender can lose lines to the read-rewrite-rename window. *)
+
+type file_report = {
+  path : string;
+  total_lines : int;
+  rewritten : int;
+}
+
+val backfill_line : string -> string option
+(** [backfill_line line] is [Some rewritten] when the line is a user
+    row without a [mentions] field whose content parses to at least one
+    mention id; [None] when the line needs no rewrite (kept
+    byte-for-byte), including unparseable lines. *)
+
+val backfill_file : dry_run:bool -> string -> file_report
+(** Backfill one lane file.  With [dry_run] the file is not modified;
+    the report counts what would change. *)
+
+val backfill_base_path : dry_run:bool -> string -> file_report list
+(** Backfill every [.jsonl] lane under
+    [<base_path>/.masc/keeper_chat/].  Missing directory returns []. *)

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -117,6 +117,11 @@ type chat_message = {
   conversation_id : string option;
   external_message_id : string option;
   speaker : speaker option;
+  mentions : Keeper_identity.Keeper_id.t list;
+      (* RFC-0232 §3.3: parsed once at append from the persisted content
+         (plus connector-provided explicit mentions); [] = none.  Rows
+         written before P4 lack the field and read as []; the offline
+         backfill tool stamps them. *)
 }
 
 let redaction_for ~base_dir ~keeper_name =
@@ -149,13 +154,26 @@ let speaker_fields = function
       @ [ ("speaker_authority", `String (authority_label sp.speaker_authority)) ]
 
 let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
-    ?tool_call_name ?source ?conversation_id ?external_message_id ?speaker ()
+    ?tool_call_name ?source ?conversation_id ?external_message_id ?speaker
+    ?(mentions = []) ()
     : string =
   let base_fields = [
     ("role", `String (Role.to_label role));
     ("content", `String content);
     ("ts", `Float ts);
   ] in
+  let mention_fields =
+    match mentions with
+    | [] -> []
+    | ids ->
+        [ ( "mentions",
+            `List
+              (List.map
+                 (fun id ->
+                   `String (Keeper_identity.Keeper_id.to_string id))
+                 ids) )
+        ]
+  in
   let attachment_fields =
     match attachments with
     | None | Some [] -> []
@@ -175,6 +193,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
   let all_fields =
     base_fields
     @ attachment_fields
+    @ mention_fields
     @ opt_string_field "tool_call_id" tool_call_id
     @ opt_string_field "tool_call_name" tool_call_name
     @ opt_string_field "source" source
@@ -193,9 +212,18 @@ let normalize_tool_args args =
 let normalize_tool_call_id ~position call_id =
   if String.trim call_id = "" then Printf.sprintf "tc-%d" position else call_id
 
+(* RFC-0232 §3.3: the append IS the parse boundary.  Mentions are
+   derived from the content that is actually persisted (post-redaction),
+   so an offline re-parse of the stored line reproduces the field;
+   connectors with structured mention data add [extra_mentions]. *)
+let user_line_mentions ~extra_mentions content =
+  Keeper_lane_mentions.mention_ids_of_content content @ extra_mentions
+  |> List.sort_uniq Keeper_identity.Keeper_id.compare
+
 let append_turn ~base_dir ~keeper_name ~(user_content : string)
     ~(user_attachments : attachment list) ?(tool_calls = []) ?source
-    ?conversation_id ?external_message_id ?speaker ~(assistant_content : string)
+    ?conversation_id ?external_message_id ?speaker ?(extra_mentions = [])
+    ~(assistant_content : string)
     () =
   try
     ensure_dir_once ~base_dir;
@@ -217,7 +245,8 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     let user_line =
       encode_line ~role:Role.User ~content:user_content ~ts
         ~attachments:user_attachments ?source ?conversation_id
-        ?external_message_id ?speaker ()
+        ?external_message_id ?speaker
+        ~mentions:(user_line_mentions ~extra_mentions user_content) ()
     in
     let tool_lines =
       List.mapi
@@ -276,7 +305,8 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
    independent of) any turn. A single user line — the assistant reply,
    if one ever comes, is appended separately by the reply path. *)
 let append_user_message ~base_dir ~keeper_name ~(content : string)
-    ?source ?conversation_id ?external_message_id ?speaker () =
+    ?source ?conversation_id ?external_message_id ?speaker
+    ?(extra_mentions = []) () =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
@@ -285,7 +315,8 @@ let append_user_message ~base_dir ~keeper_name ~(content : string)
     let ts = Time_compat.now () in
     let line =
       encode_line ~role:Role.User ~content ~ts ?source ?conversation_id
-        ?external_message_id ?speaker ()
+        ?external_message_id ?speaker
+        ~mentions:(user_line_mentions ~extra_mentions content) ()
     in
     Fs_compat.append_file path (line ^ "\n")
   with
@@ -369,6 +400,43 @@ let parse_line ~file_path (line : string) : chat_message option =
           if atts = [] then None else Some atts
       | _ -> None
     in
+    let mentions =
+      (* Absent field = pre-P4 row or no mentions; both read as [].
+         Entries that cannot mint an id are reported and skipped — the
+         row itself stays valid (losing one malformed mention must not
+         drop the whole line from the lane). *)
+      match Json_util.assoc_member_opt "mentions" json with
+      | None -> []
+      | Some (`List items) ->
+          List.filter_map
+            (fun item ->
+              match item with
+              | `String value -> (
+                  match Keeper_identity.Keeper_id.of_string value with
+                  | Some _ as id -> id
+                  | None ->
+                      report_persistence_read_drop
+                        ~reason:
+                          Safe_ops.persistence_read_drop_reason_invalid_payload
+                        ~path:file_path
+                        ~detail:
+                          (Printf.sprintf "empty mention entry %S" value);
+                      None)
+              | _ ->
+                  report_persistence_read_drop
+                    ~reason:
+                      Safe_ops.persistence_read_drop_reason_invalid_payload
+                    ~path:file_path
+                    ~detail:"non-string mention entry";
+                  None)
+            items
+      | Some _ ->
+          report_persistence_read_drop
+            ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+            ~path:file_path
+            ~detail:"mentions field is not a list";
+          []
+    in
     if role_label = "" || content = "" then (
       report_persistence_read_drop
         ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
@@ -395,7 +463,8 @@ let parse_line ~file_path (line : string) : chat_message option =
       | Some role ->
           Some
             { role; content; ts; attachments; tool_call_id; tool_call_name;
-              source; conversation_id; external_message_id; speaker }
+              source; conversation_id; external_message_id; speaker;
+              mentions }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -87,6 +87,13 @@ type chat_message = {
           older lines, tool/assistant lines, and lines whose persisted
           [speaker_authority] label fails to parse (reported as a
           persistence read drop, row otherwise kept). *)
+  mentions : Keeper_identity.Keeper_id.t list;
+      (** RFC-0232 §3.3: mention ids parsed once at append from the
+          persisted user content (plus connector-supplied explicit
+          mentions).  [[]] on tool/assistant lines, mention-free lines,
+          and rows written before P4 (the offline backfill tool stamps
+          those).  Malformed persisted entries are reported as
+          persistence read drops and skipped; the row stays valid. *)
 }
 
 (** {1 I/O} *)
@@ -111,6 +118,7 @@ val append_turn :
   ?conversation_id:string ->
   ?external_message_id:string ->
   ?speaker:speaker ->
+  ?extra_mentions:Keeper_identity.Keeper_id.t list ->
   assistant_content:string ->
   unit ->
   unit
@@ -143,6 +151,7 @@ val append_user_message :
   ?conversation_id:string ->
   ?external_message_id:string ->
   ?speaker:speaker ->
+  ?extra_mentions:Keeper_identity.Keeper_id.t list ->
   unit ->
   unit
 

--- a/lib/keeper/keeper_lane_mentions.ml
+++ b/lib/keeper/keeper_lane_mentions.ml
@@ -1,0 +1,67 @@
+(** Boundary mention parser — see the interface.  The tokenization is a
+    verbatim relocation of the legacy read-time tokenizer
+    ([trim_token_edges] + whitespace split); equivalence against the
+    legacy decision procedure is pinned by test_keeper_lane_mentions. *)
+
+(* Trim non-word characters from both ends of a token, keeping internal
+   ones.  Word chars are [a-z0-9@_-]; '.' is NOT a word char, so
+   "@dreamer." trims to "@dreamer" while the internal '.' in
+   "email@dreamer.com" is preserved (the whole token stays
+   "email@dreamer.com" and never equals "@dreamer"). *)
+let trim_token_edges s =
+  let is_word c =
+    (c >= 'a' && c <= 'z')
+    || (c >= '0' && c <= '9')
+    || c = '@'
+    || c = '_'
+    || c = '-'
+  in
+  let n = String.length s in
+  let i = ref 0 in
+  let j = ref (n - 1) in
+  while !i < n && not (is_word s.[!i]) do
+    incr i
+  done;
+  while !j >= !i && not (is_word s.[!j]) do
+    decr j
+  done;
+  if !j < !i then "" else String.sub s !i (!j - !i + 1)
+;;
+
+let mention_ids_of_content (content : string) :
+  Keeper_identity.Keeper_id.t list
+  =
+  let normalized =
+    String.map
+      (fun c ->
+        match c with
+        | '\t' | '\n' | '\r' -> ' '
+        | _ -> c)
+      (String.lowercase_ascii content)
+  in
+  String.split_on_char ' ' normalized
+  |> List.filter_map (fun token ->
+    let trimmed = trim_token_edges token in
+    if String.length trimmed >= 2 && trimmed.[0] = '@' then
+      Keeper_identity.Keeper_id.of_string
+        (String.sub trimmed 1 (String.length trimmed - 1))
+    else None)
+  |> List.sort_uniq Keeper_identity.Keeper_id.compare
+;;
+
+let target_ids_of (targets : string list) :
+  Keeper_identity.Keeper_id.t list
+  =
+  List.filter_map Keeper_identity.Keeper_id.of_string targets
+  |> List.sort_uniq Keeper_identity.Keeper_id.compare
+;;
+
+let ids_match ~(target_ids : Keeper_identity.Keeper_id.t list)
+      (mentions : Keeper_identity.Keeper_id.t list)
+  : bool
+  =
+  List.exists
+    (fun mention ->
+      List.exists (Keeper_identity.Keeper_id.equal mention) target_ids)
+    mentions
+;;

--- a/lib/keeper/keeper_lane_mentions.mli
+++ b/lib/keeper/keeper_lane_mentions.mli
@@ -1,0 +1,34 @@
+(** Keeper_lane_mentions — boundary mention parser for keeper chat lanes
+    (RFC-0232 §3.3).
+
+    The legacy [line_mentions] tokenizer ran at {e read} time inside the
+    world-observation scan, re-deriving mention semantics from
+    [chat_message.content] on every observation.  This module is that
+    tokenizer relocated to the {e write} boundary: writers parse a user
+    line once at append, persist the resulting {!Keeper_identity.Keeper_id.t}
+    list on the line, and observation filters on the persisted ids only.
+
+    Tokenization contract (unchanged from the legacy tokenizer): a line
+    mentions [x] when some whitespace-separated token equals ["@" ^ x]
+    after trimming non-word edge characters.  Token equality, not
+    substring — ["@dreamerx"] and ["email@dreamer.com"] do not mention
+    ["dreamer"].  On top of the legacy contract, extracted names are
+    minted through {!Keeper_identity.Keeper_id.of_string}, so
+    keeper-shaped forms (["@keeper-dreamer"]) canonicalize to the same
+    id as the bare name. *)
+
+val mention_ids_of_content : string -> Keeper_identity.Keeper_id.t list
+(** Every ["@name"] token of the content, edge-trimmed, minted to a
+    canonical id, deduplicated.  [[]] when the line mentions nobody. *)
+
+val target_ids_of : string list -> Keeper_identity.Keeper_id.t list
+(** Mint a keeper's mention-target names (e.g.
+    [message_feed_targets meta]) into comparable ids. *)
+
+val ids_match
+  :  target_ids:Keeper_identity.Keeper_id.t list
+  -> Keeper_identity.Keeper_id.t list
+  -> bool
+(** [ids_match ~target_ids mentions] — does any persisted mention hit a
+    target?  The read-side replacement for the deleted
+    [line_mentions ~targets content]. *)

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -34,49 +34,6 @@ let is_keeper_authored_message author =
   Option.is_some (Keeper_identity.canonical_keeper_name_from_agent_name author)
 ;;
 
-(* Trim non-word characters from both ends of a token, keeping internal ones.
-   Word chars are [a-z0-9@_-]; '.' is NOT a word char, so "@dreamer." trims to
-   "@dreamer" while the internal '.' in "email@dreamer.com" is preserved (the
-   whole token stays "email@dreamer.com" and never equals "@dreamer"). *)
-let trim_token_edges s =
-  let is_word c =
-    (c >= 'a' && c <= 'z')
-    || (c >= '0' && c <= '9')
-    || c = '@'
-    || c = '_'
-    || c = '-'
-  in
-  let n = String.length s in
-  let i = ref 0 in
-  let j = ref (n - 1) in
-  while !i < n && not (is_word s.[!i]) do incr i done;
-  while !j >= !i && not (is_word s.[!j]) do decr j done;
-  if !j < !i then "" else String.sub s !i (!j - !i + 1)
-;;
-
-(* A line mentions a target when some whitespace token equals "@<target>"
-   after edge-trimming. Token equality (not substring) is why "@dreamerx" and
-   "email@dreamer.com" do not match "@dreamer". *)
-let line_mentions ~(targets : string list) (content : string) : bool =
-  let needles =
-    List.filter_map
-      (fun target ->
-        let t = String.lowercase_ascii (String.trim target) in
-        if t = "" then None else Some ("@" ^ t))
-      targets
-  in
-  if needles = []
-  then false
-  else (
-    let normalized =
-      String.map
-        (fun c -> match c with '\t' | '\n' | '\r' -> ' ' | _ -> c)
-        (String.lowercase_ascii content)
-    in
-    String.split_on_char ' ' normalized
-    |> List.exists (fun token -> List.mem (trim_token_edges token) needles))
-;;
-
 let speaker_display (m : Keeper_chat_store.chat_message) : string =
   let from_speaker =
     match m.speaker with
@@ -136,9 +93,10 @@ let pending_mentions_of_messages
       (messages : Keeper_chat_store.chat_message list)
   : (string * string) list
   =
+  let target_ids = Keeper_lane_mentions.target_ids_of targets in
   user_lines_after_last_self messages
   |> List.filter_map (fun (m : Keeper_chat_store.chat_message) ->
-    if line_mentions ~targets m.content
+    if Keeper_lane_mentions.ids_match ~target_ids m.mentions
     then Some (speaker_display m, m.content)
     else None)
 ;;
@@ -154,9 +112,12 @@ let pending_scope_of_messages
       (messages : Keeper_chat_store.chat_message list)
   : (string * string) list
   =
+  let target_ids = Keeper_lane_mentions.target_ids_of targets in
   user_lines_after_last_self messages
   |> List.filter_map (fun (m : Keeper_chat_store.chat_message) ->
-    if is_owner_authored m && not (line_mentions ~targets m.content)
+    if
+      is_owner_authored m
+      && not (Keeper_lane_mentions.ids_match ~target_ids m.mentions)
     then Some (speaker_display m, m.content)
     else None)
 ;;

--- a/lib/keeper/keeper_world_observation_message_scope.mli
+++ b/lib/keeper/keeper_world_observation_message_scope.mli
@@ -20,14 +20,9 @@ val is_self_author
 
 val is_keeper_authored_message : string -> bool
 
-(** [line_mentions ~targets content] is true when some whitespace token of
-    [content] equals ["@" ^ target] for a target, after trimming surrounding
-    punctuation. Token equality (not substring) so ["@dreamerx"] and
-    ["email@dreamer.com"] do not match ["@dreamer"]. *)
-val line_mentions : targets:string list -> string -> bool
-
 (** [pending_mentions_of_messages ~targets messages] returns the [(speaker,
-    content)] of every user line that mentions a target and arrives after the
+    content)] of every user line whose persisted [mentions] (RFC-0232
+    §3.3: parsed once at append) hit a target and that arrives after the
     keeper's own last line. Pure (no I/O) so the watermark logic is testable
     directly; this is the core of {!collect_message_scope}. *)
 val pending_mentions_of_messages

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -253,6 +253,13 @@ let handle_message_create ~dispatch
       @ metadata_opt "discord.guild_id" guild_id
       @ metadata_bool "discord.mentions_bot" mentions_bot
       @ metadata_bool "discord.explicit_mentions_bot" explicit_mentions_bot
+      (* Connector-neutral key consumed by the gate recorder: the
+         structured mentions array named this channel's bound keeper
+         (its bot user), so the persisted user line carries an explicit
+         mention even when the text has no "@name" token (Discord
+         renders mentions as <@snowflake>, invisible to the token
+         parser).  RFC-0232 §3.3. *)
+      @ metadata_bool "mentions_bound_keeper" mentions_bot
       @ metadata_opt "discord.message_reference_channel_id"
           message_reference_channel_id
       @ metadata_opt "discord.message_reference_message_id"

--- a/test/dune
+++ b/test/dune
@@ -31,6 +31,7 @@
  (names
   test_keeper_reactive_wake_backlog_gate
   test_keeper_mention_scope
+  test_keeper_lane_mentions
   test_keeper_turn_outcome
   test_keeper_identity_id
   test_board_activity_cache
@@ -307,6 +308,7 @@
   test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate
   test_keeper_mention_scope
+  test_keeper_lane_mentions
   test_keeper_turn_outcome
   test_keeper_identity_id
   test_board_activity_cache

--- a/test/test_keeper_lane_mentions.ml
+++ b/test/test_keeper_lane_mentions.ml
@@ -1,0 +1,287 @@
+(* RFC-0232 P4: boundary mention parse + persisted mentions + backfill.
+
+   Pinned here:
+   1. Parser goldens — the boundary tokenizer keeps the legacy
+      token-equality contract (@dreamerx / email@dreamer.com never hit
+      "@dreamer") and adds canonical minting ("@keeper-dreamer"
+      reaches "dreamer": the documented widening).
+   2. Legacy decision equivalence — the deleted read-time
+      [line_mentions] is replicated verbatim as an oracle; over a
+      corpus of contents and target sets, parse-then-match must agree
+      with it everywhere (the corpus avoids keeper-shaped @-tokens,
+      which are the documented widening, pinned separately).
+   3. Store roundtrip — append parses at the boundary and [load]
+      returns the persisted ids; pre-P4 rows read as [].
+   4. Backfill — stamps exactly the user rows that need it,
+      byte-preserves everything else, and is idempotent. *)
+
+open Alcotest
+
+module Lane = Masc.Keeper_lane_mentions
+module Kid = Masc.Keeper_identity.Keeper_id
+module Store = Masc.Keeper_chat_store
+module Backfill = Masc.Keeper_chat_backfill
+
+let ids = list string
+
+let parse content =
+  Lane.mention_ids_of_content content |> List.map Kid.to_string
+
+(* ── 1. Parser goldens ── *)
+
+let test_parser_goldens () =
+  check ids "plain mention" [ "dreamer" ] (parse "hey @dreamer look");
+  check ids "different token" [ "dreamerx" ] (parse "ping @dreamerx now");
+  check ids "email is one token" [] (parse "send to email@dreamer.com");
+  check ids "case folded" [ "dreamer" ] (parse "PING @DREAMER NOW");
+  check ids "trailing punctuation" [ "dreamer" ] (parse "ok @dreamer, thanks");
+  check ids "no mention" [] (parse "just chatting here");
+  check ids "newline separated" [ "dreamer" ] (parse "line one\n@dreamer two");
+  check ids "deduplicated" [ "dreamer" ] (parse "@dreamer and @dreamer again");
+  check ids "two distinct"
+    [ "dreamer"; "sangsu" ]
+    (parse "@sangsu and @dreamer please");
+  check ids "keeper-shaped form canonicalizes (documented widening)"
+    [ "dreamer" ]
+    (parse "cc @keeper-dreamer");
+  (* Apostrophe is an internal (kept) character — "@sangsu's" is its own
+     token and never reaches "sangsu"; same as the legacy tokenizer. *)
+  check ids "possessive stays distinct" [ "sangsu's" ] (parse "@sangsu's note")
+
+(* ── 2. Legacy decision equivalence ── *)
+
+(* Verbatim replica of the deleted read-time tokenizer + decision. *)
+let legacy_trim_token_edges s =
+  let is_word c =
+    (c >= 'a' && c <= 'z')
+    || (c >= '0' && c <= '9')
+    || c = '@'
+    || c = '_'
+    || c = '-'
+  in
+  let n = String.length s in
+  let i = ref 0 in
+  let j = ref (n - 1) in
+  while !i < n && not (is_word s.[!i]) do
+    incr i
+  done;
+  while !j >= !i && not (is_word s.[!j]) do
+    decr j
+  done;
+  if !j < !i then "" else String.sub s !i (!j - !i + 1)
+
+let legacy_line_mentions ~targets content =
+  let needles =
+    List.filter_map
+      (fun target ->
+        let t = String.lowercase_ascii (String.trim target) in
+        if t = "" then None else Some ("@" ^ t))
+      targets
+  in
+  if needles = [] then false
+  else (
+    let normalized =
+      String.map
+        (fun c ->
+          match c with
+          | '\t' | '\n' | '\r' -> ' '
+          | _ -> c)
+        (String.lowercase_ascii content)
+    in
+    String.split_on_char ' ' normalized
+    |> List.exists (fun token -> List.mem (legacy_trim_token_edges token) needles))
+
+let corpus_contents =
+  [ "hey @dreamer look"
+  ; "ping @dreamerx now"
+  ; "send to email@dreamer.com"
+  ; "PING @DREAMER NOW"
+  ; "ok @dreamer, thanks"
+  ; "just chatting here"
+  ; "@sangsu and @dreamer please"
+  ; "@analyst: status?"
+  ; "tab\t@dreamer\tseparated"
+  ; "(@dreamer)"
+  ; "@@dreamer double at"
+  ; "@ bare at"
+  ; ""
+  ; "   "
+  ; "@vincent are you there"
+  ; "mid@dreamer token"
+  ; "@dreamer."
+  ; "...@sangsu..."
+  ]
+
+let corpus_target_sets =
+  [ [ "dreamer" ]
+  ; [ "sangsu" ]
+  ; [ "dreamer"; "sangsu" ]
+  ; [ "analyst" ]
+  ; [ "vincent" ]
+  ; []
+  ; [ "" ]
+  ; [ "DREAMER" ]
+  ]
+
+let test_legacy_equivalence () =
+  List.iter
+    (fun content ->
+      List.iter
+        (fun targets ->
+          let expected = legacy_line_mentions ~targets content in
+          let actual =
+            Lane.ids_match
+              ~target_ids:(Lane.target_ids_of targets)
+              (Lane.mention_ids_of_content content)
+          in
+          check bool
+            (Printf.sprintf "targets=[%s] content=%S"
+               (String.concat ";" targets)
+               content)
+            expected actual)
+        corpus_target_sets)
+    corpus_contents
+
+(* ── 3. Store roundtrip ── *)
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+
+let temp_base_path prefix =
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+
+let with_base prefix f =
+  let base = temp_base_path prefix in
+  Fun.protect ~finally:(fun () -> remove_tree base) (fun () -> f base)
+
+let message_mentions (m : Store.chat_message) =
+  List.map Kid.to_string m.mentions
+
+let test_append_persists_mentions () =
+  with_base "lane-mentions-append" (fun base ->
+      Store.append_user_message ~base_dir:base ~keeper_name:"dreamer"
+        ~content:"@dreamer please look at @sangsu note" ();
+      Store.append_turn ~base_dir:base ~keeper_name:"dreamer"
+        ~user_content:"thanks @analyst" ~user_attachments:[]
+        ~assistant_content:"done" ();
+      match Store.load ~base_dir:base ~keeper_name:"dreamer" with
+      | [ first; second; third ] ->
+          check ids "user message mentions"
+            [ "dreamer"; "sangsu" ]
+            (message_mentions first);
+          check ids "turn user line mentions" [ "analyst" ]
+            (message_mentions second);
+          check ids "assistant line has none" [] (message_mentions third)
+      | other ->
+          failf "expected 3 lane lines, got %d" (List.length other))
+
+let test_extra_mentions_merge () =
+  with_base "lane-mentions-extra" (fun base ->
+      let extra = Option.to_list (Kid.of_string "dreamer") in
+      Store.append_user_message ~base_dir:base ~keeper_name:"dreamer"
+        ~content:"no at-token here" ~extra_mentions:extra ();
+      match Store.load ~base_dir:base ~keeper_name:"dreamer" with
+      | [ only ] ->
+          check ids "connector-provided mention persisted" [ "dreamer" ]
+            (message_mentions only)
+      | other -> failf "expected 1 lane line, got %d" (List.length other))
+
+let test_pre_p4_row_reads_empty () =
+  with_base "lane-mentions-prep4" (fun base ->
+      (* A pre-P4 row: no [mentions] field even though the content has
+         an @-token.  Reads as [] — exactly the gap the backfill closes. *)
+      Store.append_user_message ~base_dir:base ~keeper_name:"dreamer"
+        ~content:"seed" ();
+      let dir =
+        Filename.concat
+          (Filename.concat base ".masc")
+          "keeper_chat"
+      in
+      let path = Filename.concat dir "dreamer.jsonl" in
+      let oc = open_out_gen [ Open_append ] 0o644 path in
+      output_string oc
+        "{\"role\":\"user\",\"content\":\"@dreamer legacy row\",\"ts\":2.0}\n";
+      close_out oc;
+      match Store.load ~base_dir:base ~keeper_name:"dreamer" with
+      | [ _seed; legacy ] ->
+          check ids "absent field decodes as no mentions" []
+            (message_mentions legacy)
+      | other -> failf "expected 2 lane lines, got %d" (List.length other))
+
+(* ── 4. Backfill ── *)
+
+let test_backfill_line () =
+  check (option string) "legacy user row with mention is stamped"
+    (Some
+       "{\"role\":\"user\",\"content\":\"@dreamer legacy\",\"ts\":2.0,\"mentions\":[\"dreamer\"]}")
+    (Backfill.backfill_line
+       "{\"role\":\"user\",\"content\":\"@dreamer legacy\",\"ts\":2.0}");
+  check (option string) "mention-free row untouched" None
+    (Backfill.backfill_line
+       "{\"role\":\"user\",\"content\":\"no tokens\",\"ts\":2.0}");
+  check (option string) "already-stamped row untouched" None
+    (Backfill.backfill_line
+       "{\"role\":\"user\",\"content\":\"@dreamer x\",\"ts\":2.0,\"mentions\":[]}");
+  check (option string) "assistant row untouched" None
+    (Backfill.backfill_line
+       "{\"role\":\"assistant\",\"content\":\"@dreamer x\",\"ts\":2.0}");
+  check (option string) "garbage line untouched" None
+    (Backfill.backfill_line "not json at all")
+
+let test_backfill_file_idempotent () =
+  with_base "lane-mentions-backfill" (fun base ->
+      Store.append_user_message ~base_dir:base ~keeper_name:"dreamer"
+        ~content:"seed" ();
+      let dir =
+        Filename.concat (Filename.concat base ".masc") "keeper_chat"
+      in
+      let path = Filename.concat dir "dreamer.jsonl" in
+      let oc = open_out_gen [ Open_append ] 0o644 path in
+      output_string oc
+        "{\"role\":\"user\",\"content\":\"@dreamer legacy row\",\"ts\":2.0}\n";
+      output_string oc "{\"role\":\"assistant\",\"content\":\"hi\",\"ts\":3.0}\n";
+      close_out oc;
+      let dry = Backfill.backfill_file ~dry_run:true path in
+      check int "dry-run counts" 1 dry.rewritten;
+      let wet = Backfill.backfill_file ~dry_run:false path in
+      check int "stamped" 1 wet.rewritten;
+      (* The stamped row now registers as a pending mention through the
+         normal load path. *)
+      (match Store.load ~base_dir:base ~keeper_name:"dreamer" with
+       | [ _seed; legacy; _assistant ] ->
+           check ids "stamped row reads back" [ "dreamer" ]
+             (message_mentions legacy)
+       | other -> failf "expected 3 lane lines, got %d" (List.length other));
+      let again = Backfill.backfill_file ~dry_run:false path in
+      check int "idempotent" 0 again.rewritten)
+
+let () =
+  Random.self_init ();
+  run "keeper_lane_mentions"
+    [
+      ("parser", [ test_case "goldens" `Quick test_parser_goldens ]);
+      ( "legacy_equivalence",
+        [ test_case "corpus matrix" `Quick test_legacy_equivalence ] );
+      ( "store_roundtrip",
+        [
+          test_case "append persists mentions" `Quick
+            test_append_persists_mentions;
+          test_case "extra mentions merge" `Quick test_extra_mentions_merge;
+          test_case "pre-P4 row reads empty" `Quick
+            test_pre_p4_row_reads_empty;
+        ] );
+      ( "backfill",
+        [
+          test_case "line" `Quick test_backfill_line;
+          test_case "file + idempotence" `Quick
+            test_backfill_file_idempotent;
+        ] );
+    ]

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -1,8 +1,9 @@
 (* RFC-0230: keeper mention reactivity.
 
    Two pure cores are tested here:
-   - line_mentions: token-equality @-mention match (the substring bug that made
-     "@dreamerx" / "email@dreamer.com" false-match "@dreamer" must not recur).
+   - the boundary mention parse + match (RFC-0232 P4: parse at append,
+     match persisted ids; the substring bug that made "@dreamerx" /
+     "email@dreamer.com" false-match "@dreamer" must not recur).
    - pending_mentions_of_messages: the lane-is-the-state watermark — a mention
      is pending iff it arrives after the keeper's own last line. *)
 
@@ -10,9 +11,16 @@ open Alcotest
 
 module MS = Masc.Keeper_world_observation_message_scope
 module Store = Masc.Keeper_chat_store
+module Lane = Masc.Keeper_lane_mentions
 
 let targets = [ "dreamer" ]
-let lm content = MS.line_mentions ~targets content
+
+(* Boundary-parse-then-match: the P4 equivalent of the deleted
+   read-time [line_mentions]. *)
+let lm content =
+  Lane.ids_match
+    ~target_ids:(Lane.target_ids_of targets)
+    (Lane.mention_ids_of_content content)
 
 let test_plain_mention () = check bool "@dreamer by another" true (lm "hey @dreamer look")
 
@@ -29,7 +37,10 @@ let test_trailing_punct () = check bool "@dreamer, comma" true (lm "ok @dreamer,
 let test_no_mention () = check bool "no @target" false (lm "just chatting here")
 
 let test_empty_targets () =
-  check bool "no targets to match" false (MS.line_mentions ~targets:[] "@dreamer")
+  check bool "no targets to match" false
+    (Lane.ids_match
+       ~target_ids:(Lane.target_ids_of [])
+       (Lane.mention_ids_of_content "@dreamer"))
 ;;
 
 let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None) content
@@ -45,6 +56,7 @@ let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None) content
   ; conversation_id = None
   ; external_message_id = None
   ; speaker
+  ; mentions = Masc.Keeper_lane_mentions.mention_ids_of_content content
   }
 ;;
 
@@ -178,6 +190,7 @@ let tool_line : Store.chat_message =
   ; conversation_id = None
   ; external_message_id = None
   ; speaker = None
+  ; mentions = []
   }
 ;;
 
@@ -221,7 +234,7 @@ let test_assistant_append_empties_pending () =
 
 let () =
   run "keeper_mention_scope"
-    [ ( "line_mentions"
+    [ ( "boundary_mention_match"
       , [ test_case "plain" `Quick test_plain_mention
         ; test_case "dreamerx_not_matched" `Quick test_dreamerx_not_matched
         ; test_case "email_not_matched" `Quick test_email_not_matched

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -22,6 +22,7 @@ let msg ?ts ?source ?speaker ~role content : Store.chat_message =
     conversation_id = None;
     external_message_id = None;
     speaker;
+    mentions = [];
   }
 
 let external_speaker ?name id : Store.speaker =


### PR DESCRIPTION
## RFC-0232 P4 — boundary mention parse + persisted `mentions` + offline backfill

RFC: `docs/rfc/RFC-0232-typed-lane-event-model.md` §3.3 (#20877). P1 #20896, P2 #20914, P3 #20932.

### 문제

멘션 의미가 매 관찰마다 read-time에 재유도됐다 — `pending_mentions_of_messages`가 `line_mentions`로 `m.content`를 토크나이즈. Discord의 구조화 mentions 배열은 decode에서 `mentions_bot : bool`로 축소되어, `<@snowflake>` 형태 멘션(토큰 파서에 안 보임)은 lane에 흔적이 없었다.

### 변경

| 레이어 | 내용 |
|---|---|
| **`Keeper_lane_mentions`** (신규) | legacy 토크나이저를 쓰기 경계로 verbatim 이전. `mention_ids_of_content`가 @-토큰을 추출해 `Keeper_id.of_string`으로 mint. read는 `ids_match`로 persisted id만 |
| **`Keeper_chat_store`** | `chat_message.mentions : Keeper_id.t list` — append에서 **영속된(redaction 후) content** 기준으로 파스(오프라인 재파스가 필드를 재현). `?extra_mentions`로 connector 구조화 데이터 병합. 필드 부재=[] (pre-P4 행), malformed entry는 read-drop 보고 후 행 유지 |
| **Observation** | `pending_mentions`/`pending_scope`가 `m.mentions`만 필터 — `m.content` 불참여. `line_mentions`는 message scope 표면에서 삭제 |
| **Discord decode** | `mention_user_ids : string list`로 구조화 배열 유지(RFC §3.3), `mentions_bot`은 그 리스트에서 유도(동일값). gateway가 connector-중립 `mentions_bound_keeper` 메타데이터 키 추가 → gate recorder가 lane owner의 명시 멘션으로 영속. **`<@snowflake>` 멘션이 처음으로 lane에 등록됨** |
| **Backfill** (신규) | `masc-keeper-chat-backfill-mentions` — pre-P4 user 행에 멘션 stamp. 비대상 라인 byte 보존, 파일별 atomic(temp+rename), 멱등. **서버 정지 상태에서 실행** (`--dry-run` 지원) |

### 동치성 — 증명

`test_keeper_lane_mentions`가 삭제된 `line_mentions`를 oracle로 verbatim 복제, **content 18종 × target set 8종** 매트릭스에서 parse-then-match와 전수 일치. 문서화된 widening 1건: keeper-shaped @-토큰(`@keeper-dreamer`)이 bare name으로 canonicalize (P3 `Keeper_id`의 의도된 효과). 아포스트로피 등 edge(`@sangsu's`≠`sangsu`)는 legacy와 동일하게 비매칭 — golden으로 고정.

### 검증

- `@check` + default target EXIT=0
- 신규 `test_keeper_lane_mentions` 7/7 (parser goldens / oracle 매트릭스 / store roundtrip / pre-P4 [] 의미 / backfill 멱등)
- 영향권: `test_discord_gateway_state` 49/49, `test_gate_keeper_backend` 29/29, `test_keeper_mention_scope` 20/20 (lm 헬퍼를 경계 파서로 이전), `test_keeper_chat_store` 16/16
- DET/NDT gate 로컬 PASS
- 로컬 빌드는 `MASC_SKIP_PIN_CHECK=1` — 병렬 세션이 공유 switch를 SSOT pin보다 앞으로 이동시킴(forward-only floor가 다운그레이드 거부, broadcast 완료). 본 변경은 OAS 표면 무관, CI가 SSOT pin으로 최종 판정

### 배포 메모

머지 → 재배포 → `masc-keeper-chat-backfill-mentions --base-path ~/me [--dry-run]` (서버 정지 중). backfill 전까지 pre-P4 @멘션 행은 pending에 안 잡힘 (watermark는 최근 미응답 라인만 보므로 갭은 짧음).

후속: P5 (`Surface_ref` 통일).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
