### PR TITLE
feat(dashboard): improve keeper prompt editor UX

### DIFF
--- a/dashboard/src/components/common/expandable-textarea.ts
+++ b/dashboard/src/components/common/expandable-textarea.ts
@@ -1,0 +1,120 @@
+// Expandable textarea — full-screen editing for long-form keeper prompts.
+//
+// Uses local state while typing so large texts do not re-render the parent
+// panel on every keystroke. Changes are committed to the parent on blur and
+// when the full-screen modal is confirmed.
+
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+
+export const EXPANDABLE_TEXTAREA_STYLE =
+  'w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded-[var(--r-1)] py-2 px-3 font-mono focus:outline-none focus:border-accent-fg/50 focus:ring-1 focus:ring-accent-fg/50 transition-[border-color,box-shadow] duration-[var(--t-med)] shadow-inset resize-y custom-scrollbar'
+
+export function ExpandableTextarea({
+  value,
+  onChange,
+  label,
+  rows = 6,
+  placeholder = '',
+  dirty = false,
+}: {
+  value: string
+  onChange: (value: string) => void
+  label: string
+  rows?: number
+  placeholder?: string
+  dirty?: boolean
+}) {
+  const [local, setLocal] = useState(value)
+  const [expanded, setExpanded] = useState(false)
+
+  // Sync when the parent resets the draft (e.g. entering/exiting edit mode).
+  useEffect(() => {
+    setLocal(value)
+  }, [value])
+
+  function commit(next: string) {
+    setLocal(next)
+    onChange(next)
+  }
+
+  const borderClass = dirty
+    ? 'border-l-4 border-l-[var(--color-accent-fg)]'
+    : ''
+
+  return html`
+    <div class="relative">
+      <textarea
+        aria-label=${label}
+        class="${EXPANDABLE_TEXTAREA_STYLE} ${borderClass} pr-10"
+        rows=${rows}
+        value=${local}
+        placeholder=${placeholder}
+        onInput=${(e: Event) =>
+          setLocal((e.target as HTMLTextAreaElement).value)}
+        onBlur=${(e: Event) =>
+          commit((e.target as HTMLTextAreaElement).value)}
+      />
+      <button
+        type="button"
+        class="absolute top-2 right-2 rounded-[var(--r-0)] bg-[var(--color-bg-surface)] border border-card-border px-1.5 py-0.5 text-3xs text-[var(--color-fg-muted)] hover:text-text-strong hover:bg-[var(--color-bg-hover)] transition-colors"
+        title="전체 화면으로 편집"
+        onClick=${() => setExpanded(true)}
+      >
+        ⛶
+      </button>
+      ${expanded
+        ? html`
+            <div
+              class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+              onClick=${() => setExpanded(false)}
+            >
+              <div
+                class="flex flex-col w-full max-w-5xl h-[85vh] rounded-[var(--r-3)] border border-card-border bg-[var(--color-bg-elevated)] shadow-[var(--shadow-3)] p-4"
+                onClick=${(e: Event) => e.stopPropagation()}
+              >
+                <div class="flex items-center justify-between mb-3">
+                  <span class="text-sm font-semibold text-text-strong">
+                    ${label}
+                  </span>
+                  <button
+                    type="button"
+                    class="text-2xs text-[var(--color-fg-muted)] hover:text-text-strong"
+                    onClick=${() => setExpanded(false)}
+                  >
+                    닫기
+                  </button>
+                </div>
+                <textarea
+                  class="${EXPANDABLE_TEXTAREA_STYLE} flex-1"
+                  value=${local}
+                  placeholder=${placeholder}
+                  onInput=${(e: Event) =>
+                    setLocal((e.target as HTMLTextAreaElement).value)}
+                />
+                <div class="flex justify-end gap-2 mt-3">
+                  <button
+                    type="button"
+                    class="px-3 py-1.5 rounded-[var(--r-1)] text-2xs bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]"
+                    onClick=${() => setExpanded(false)}
+                  >
+                    취소
+                  </button>
+                  <button
+                    type="button"
+                    class="px-3 py-1.5 rounded-[var(--r-1)] text-2xs bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)]"
+                    onClick=${() => {
+                      commit(local)
+                      setExpanded(false)
+                    }}
+                  >
+                    확인
+                  </button>
+                </div>
+              </div>
+            </div>
+          `
+        : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -19,7 +19,7 @@ import { MISSING_DATA_DASH } from '../lib/format-string'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { BTN_FILLED_BASE } from './common/button-filled-base'
-import { FIELD_STYLE_BASE } from './common/field-style-base'
+import { ExpandableTextarea } from './common/expandable-textarea'
 import { KeeperToolAccessSummary } from './keeper-tool-access'
 import { createAsyncResource, loaded } from '../lib/async-state'
 import { SetupGuideCard } from './setup-guide-card'
@@ -58,6 +58,8 @@ type EditDraft = {
 
 const editDraft = signal<EditDraft | null>(null)
 const hookFilterQuery = signal<string>('')
+const lastSavedAt = signal<string | null>(null)
+const promptPreviewTab = signal<'blocks' | 'effective'>('blocks')
 
 // ── Hook slot filter ─────────────────────────────────────
 
@@ -107,15 +109,33 @@ function initDraftFromConfig(c: KeeperConfig): EditDraft {
 
 function buildPayload(draft: EditDraft, orig: KeeperConfig): KeeperConfigUpdatePayload {
   const payload: KeeperConfigUpdatePayload = {}
-  if (draft.goal !== orig.prompt.goal) payload.goal = draft.goal
-  if (draft.short_goal !== orig.prompt.short_goal) payload.short_goal = draft.short_goal
-  if (draft.mid_goal !== orig.prompt.mid_goal) payload.mid_goal = draft.mid_goal
-  if (draft.long_goal !== orig.prompt.long_goal) payload.long_goal = draft.long_goal
-  if (draft.will !== orig.prompt.will) payload.will = draft.will
-  if (draft.needs !== orig.prompt.needs) payload.needs = draft.needs
-  if (draft.desires !== orig.prompt.desires) payload.desires = draft.desires
-  if (draft.instructions !== orig.prompt.instructions) payload.instructions = draft.instructions
+  const setIfChanged = (key: keyof EditDraft) => {
+    const next = draft[key].trim()
+    const prev = orig.prompt[key].trim()
+    if (next !== prev) {
+      // Preserve the user's exact whitespace when persisting; trim only for comparison.
+      payload[key] = draft[key]
+    }
+  }
+  setIfChanged('goal')
+  setIfChanged('short_goal')
+  setIfChanged('mid_goal')
+  setIfChanged('long_goal')
+  setIfChanged('will')
+  setIfChanged('needs')
+  setIfChanged('desires')
+  setIfChanged('instructions')
   return payload
+}
+
+function formatRelativeTime(date: Date): string {
+  const sec = Math.round((Date.now() - date.getTime()) / 1000)
+  if (sec < 60) return `${sec}초 전`
+  const min = Math.round(sec / 60)
+  if (min < 60) return `${min}분 전`
+  const hour = Math.round(min / 60)
+  if (hour < 24) return `${hour}시간 전`
+  return date.toLocaleString('ko-KR')
 }
 
 // Runtime config draft for sandbox/proactive/compaction/handoff inline editing
@@ -286,6 +306,8 @@ export function resetKeeperConfig(): void {
   editMode.value = false
   editDraft.value = null
   saveError.value = null
+  lastSavedAt.value = null
+  promptPreviewTab.value = 'blocks'
   runtimeDraft.value = null
   runtimeSaving.value = false
   hookFilterQuery.value = ''
@@ -558,19 +580,24 @@ function updateDraft(field: keyof EditDraft, value: string | boolean | number) {
   editDraft.value = { ...d, [field]: value }
 }
 
-function EditTextarea({ field, label, rows = 3 }: { field: keyof EditDraft; label: string; rows?: number }) {
+function EditTextarea({ field, label, rows = 6 }: { field: keyof EditDraft; label: string; rows?: number }) {
   const d = editDraft.value
   if (!d) return null
   const val = d[field] as string
+  const orig = configState.value.status === 'loaded' ? configState.value.data.prompt[field] : val
+  const dirty = val.trim() !== (orig as string).trim()
   return html`
     <div class="mt-3">
-      <div class="text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">${label}</div>
-      <textarea
-        aria-label=${label}
-        class="${FIELD_STYLE_BASE} resize-y custom-scrollbar"
-        rows=${rows}
+      <div class="flex items-center gap-2 mb-1.5">
+        <span class="text-2xs font-semibold uppercase tracking-wider text-text-muted">${label}</span>
+        ${dirty ? html`<span class="text-2xs text-[var(--color-accent-fg)] font-semibold">● 수정됨</span>` : null}
+      </div>
+      <${ExpandableTextarea}
+        label=${label}
         value=${val}
-        onInput=${(e: Event) => updateDraft(field, (e.target as HTMLTextAreaElement).value)}
+        rows=${rows}
+        dirty=${dirty}
+        onChange=${(value: string) => updateDraft(field, value)}
       />
     </div>
   `
@@ -671,6 +698,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     if (!draft) return
     const payload = buildPayload(draft, c)
     if (Object.keys(payload).length === 0) {
+      showToast('변경사항이 없습니다', 'warning')
       cancelEdit()
       return
     }
@@ -681,6 +709,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       configState.value = loaded(updated)
       editMode.value = false
       editDraft.value = null
+      lastSavedAt.value = new Date().toISOString()
       showToast('프롬프트 저장 완료', 'success')
     } catch (err) {
       saveError.value = err instanceof Error ? err.message : '저장 실패'
@@ -690,8 +719,11 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   }
 
   // --- Toolbar ---
+  const lastSavedText = lastSavedAt.value
+    ? `마지막 저장: ${formatRelativeTime(new Date(lastSavedAt.value))}`
+    : null
   const toolbar = html`
-    <div class="flex gap-2 items-center mb-3">
+    <div class="flex flex-wrap gap-2 items-center mb-3">
       ${isEditing ? html`
         <button type="button"
           class="${BTN_FILLED_BASE} bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)]"
@@ -710,6 +742,9 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           onClick=${enterEditMode}
         >편집하기</button>
       `}
+      ${lastSavedText && !isEditing
+        ? html`<span class="text-2xs text-[var(--color-fg-muted)]">${lastSavedText}</span>`
+        : null}
       ${saveError.value ? html`<span class="text-xs text-[var(--color-status-err)]" role="alert">${saveError.value}</span>` : null}
     </div>
   `
@@ -717,14 +752,14 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   // --- Prompt section (editable) ---
   const promptSection = isEditing ? html`
     <${MajorSectionHeader} title="프롬프트 (편집)" />
-    <${EditTextarea} field="goal" label="목표" rows=${3} />
-    <${EditTextarea} field="short_goal" label="단기 목표" rows=${2} />
-    <${EditTextarea} field="mid_goal" label="중기 목표" rows=${2} />
-    <${EditTextarea} field="long_goal" label="장기 목표" rows=${2} />
-    <${EditTextarea} field="will" label="의지" rows=${2} />
-    <${EditTextarea} field="needs" label="필요" rows=${2} />
-    <${EditTextarea} field="desires" label="욕구" rows=${2} />
-    <${EditTextarea} field="instructions" label="지시사항" rows=${4} />
+    <${EditTextarea} field="goal" label="목표" rows=${8} />
+    <${EditTextarea} field="short_goal" label="단기 목표" rows=${5} />
+    <${EditTextarea} field="mid_goal" label="중기 목표" rows=${5} />
+    <${EditTextarea} field="long_goal" label="장기 목표" rows=${5} />
+    <${EditTextarea} field="will" label="의지" rows=${4} />
+    <${EditTextarea} field="needs" label="필요" rows=${4} />
+    <${EditTextarea} field="desires" label="욕구" rows=${4} />
+    <${EditTextarea} field="instructions" label="지시사항" rows=${10} />
   ` : html`
     <${MajorSectionHeader} title="프롬프트" />
     <${SectionHeader} size="xs" class="mb-0.5">목표</${SectionHeader}>
@@ -745,14 +780,26 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${SectionHeader} size="xs" class="mt-2 mb-0.5">지시사항</${SectionHeader}>
       <${LongText} text=${c.prompt.instructions} />
     ` : null}
-    <${SectionHeader} size="xs" class="mt-3 mb-0.5">시스템 프롬프트 블록</${SectionHeader}>
-    <${PromptBlock} title="헌법" block=${c.prompt.system_prompt_blocks.constitution} />
-    <${PromptBlock} title="세계관" block=${c.prompt.system_prompt_blocks.world} />
-    <${PromptBlock} title="능력" block=${c.prompt.system_prompt_blocks.capabilities} />
-    <details class="mt-3">
-      <summary class="cursor-pointer py-2 px-3 text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] list-none select-none rounded-[var(--r-1)] hover:bg-[var(--color-bg-surface)] transition-colors">컴파일된 시스템 프롬프트 보기</summary>
+    <${SectionHeader} size="xs" class="mt-3 mb-0.5">시스템 프롬프트</${SectionHeader}>
+    <div class="flex gap-2 mb-2">
+      <button
+        type="button"
+        class="text-2xs px-2 py-1 rounded-[var(--r-1)] border transition-colors ${promptPreviewTab.value === 'blocks' ? 'bg-[var(--accent-10)] border-[var(--accent-20)] text-accent-fg' : 'border-card-border text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-surface)]'}"
+        onClick=${() => { promptPreviewTab.value = 'blocks' }}
+      >블록</button>
+      <button
+        type="button"
+        class="text-2xs px-2 py-1 rounded-[var(--r-1)] border transition-colors ${promptPreviewTab.value === 'effective' ? 'bg-[var(--accent-10)] border-[var(--accent-20)] text-accent-fg' : 'border-card-border text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-surface)]'}"
+        onClick=${() => { promptPreviewTab.value = 'effective' }}
+      >최종 프롬프트</button>
+    </div>
+    ${promptPreviewTab.value === 'blocks' ? html`
+      <${PromptBlock} title="헌법" block=${c.prompt.system_prompt_blocks.constitution} />
+      <${PromptBlock} title="세계관" block=${c.prompt.system_prompt_blocks.world} />
+      <${PromptBlock} title="능력" block=${c.prompt.system_prompt_blocks.capabilities} />
+    ` : html`
       <${LongText} text=${c.prompt.effective_system_prompt} truncateAt=${null} />
-    </details>
+    `}
   `
 
   const goalState = goalOptionsState.value


### PR DESCRIPTION
## Problem
- Keeper prompt/memory/instructions were edited in tiny textareas (2-4 rows), so operators could not see the full context.
- The compiled system prompt and append blocks were hidden behind a small details element.
- Saving gave weak feedback: empty changes silently closed edit mode, and there was no confirmation that the server had persisted the change.

## Changes
- **New component**: `ExpandableTextarea` with a full-screen modal, local edit state (no parent re-render on every keystroke), and a dirty indicator.
- **Bigger default fields**:
  - goal: 8 rows
  - short/mid/long goals: 5 rows
  - will/needs/desires: 4 rows
  - instructions: 10 rows
- **Dirty indicator**: each edited field shows "● 수정됨" and an accent border.
- **Last-saved timestamp**: shown in the toolbar after a successful save.
- **No-change warning**: saving without changes now shows a toast instead of silently closing.
- **Comparison trimming**: whitespace is trimmed only for comparison, avoiding false dirty states from trailing newlines.
- **System prompt tabs**: switch between "블록" (constitution/world/capabilities) and "최종 프롬프트" (effective_system_prompt).

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅

## Notes
- System prompt blocks remain read-only because the backend API does not yet expose editable fields for them.
- No runtime/config behavior is changed; this is purely a dashboard UX improvement.