### PR TITLE
[codex] Fix keeper surface-context tool routing

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -198,12 +198,14 @@ let tool_search_alias_entries =
   ; "keeper_memory_search", "기억 검색 대화 이전 메시지"
   ; "keeper_library_search", "라이브러리 지식 문서 검색"
   ; "keeper_library_read", "라이브러리 문서 읽기 지식"
-  ; "keeper_surface_read", "커넥터 대화 읽기 디스코드 채널 화자 명부 서피스"
+  ; ( "keeper_surface_read"
+    , "커넥터 대화 읽기 연결된 채널 현재 채널 화자 명부 로스터 서피스 \
+       connected surface lane bound channel current lane participant roster" )
   ; "keeper_surface_post", "커넥터 발화 보내기 디스코드 채널 메시지 전송 서피스"
   ; "keeper_person_note_set", "사람 기억 노트 저장 화자 메모 명부 로스터"
   ; "keeper_time_now", "시간 현재 타임스탬프"
   ; "keeper_context_status", "컨텍스트 상태 토큰 사용량"
-  ; "keeper_tools_list", "도구 목록 기능 할수있는것 능력"
+  ; "keeper_tools_list", "도구 목록 기능 할수있는것 능력 capability introspection"
   ; "keeper_broadcast", "브로드캐스트 알림 공지 전달"
   ; "keeper_tasks_list", "태스크 목록 할일 백로그"
   ; "keeper_tasks_audit", "태스크 감사 고아 방치"

--- a/lib/keeper/keeper_hooks_oas_idle.ml
+++ b/lib/keeper/keeper_hooks_oas_idle.ml
@@ -24,10 +24,22 @@ let suggest_alternatives ~(allowed_tools : string list)
 
 let includes_tool name tools = List.exists (String.equal name) tools
 
-let board_get_recovery_hint ~allowed_tools ~tool_names =
-  if not (includes_tool "keeper_board_post_get" tool_names) then
-    None
-  else
+let recovery_hint ~allowed_tools ~tool_names =
+  if includes_tool "keeper_tools_list" tool_names then
+    Some
+      (if includes_tool "keeper_surface_read" allowed_tools then
+         "keeper_tools_list lists capabilities, not connected-surface or lane \
+          contents; for current lane context use keeper_surface_read with a \
+          surface label from Connected Surfaces or chat history. If the user asks \
+          for a connector-wide channel registry outside those connected lanes, \
+          state that it is unavailable."
+       else
+         "keeper_tools_list lists capabilities, not connected-surface or lane \
+          contents; do not repeat it to answer user content questions.")
+  else if
+    includes_tool "keeper_board_get" tool_names
+    || includes_tool "keeper_board_post_get" tool_names
+  then
     let discovery_tools =
       [ "keeper_board_list"; "keeper_board_search" ]
       |> List.filter (fun name -> includes_tool name allowed_tools)
@@ -40,9 +52,11 @@ let board_get_recovery_hint ~allowed_tools ~tool_names =
     in
     Some
       (Printf.sprintf
-         "keeper_board_post_get requires post_id; if no post_id is visible, use %s first. \
-          Do not call keeper_board_post_get with {}."
+         "keeper_board_get requires post_id; if no post_id is visible, use %s first. \
+          Do not call keeper_board_get with {}."
          discovery)
+  else
+    None
 
 (** Pure decision logic for the on_idle hook.  Testable without Workspace.config.
 
@@ -70,18 +84,26 @@ let on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
     | names -> String.concat ", " names
   in
   let alternatives =
-    suggest_alternatives ~allowed_tools ~repeated_tools:tool_names
-      ~max_suggestions:5
+    let base =
+      suggest_alternatives ~allowed_tools ~repeated_tools:tool_names
+        ~max_suggestions:5
+    in
+    if includes_tool "keeper_tools_list" tool_names
+       && includes_tool "keeper_surface_read" allowed_tools
+    then
+      Keeper_types_profile_toml_normalizers.dedupe_keep_order
+        ("keeper_surface_read" :: base)
+      |> List.filteri (fun i _ -> i < 5)
+    else
+      base
   in
   let alt_str = match alternatives with
     | [] -> "keeper_tool_search or keeper_stay_silent"
     | alts -> String.concat ", " alts
   in
-  let recovery_hint =
-    board_get_recovery_hint ~allowed_tools ~tool_names
-  in
+  let hint = recovery_hint ~allowed_tools ~tool_names in
   let append_hint msg =
-    match recovery_hint with
+    match hint with
     | None -> msg
     | Some hint -> msg ^ " " ^ hint
   in

--- a/lib/keeper/keeper_surface_read.ml
+++ b/lib/keeper/keeper_surface_read.ml
@@ -167,8 +167,9 @@ let respond ~surface ~limit ~has_more ~notes
         [
           ( "error",
             `String
-              "surface is required. Good: surface='discord'. The lane label \
-               equals the source shown in Connected Surfaces or chat history."
+              "surface is required. Use a lane label shown in Connected \
+               Surfaces or chat history; this tool reads that connected lane, \
+               not a connector-wide channel registry."
           );
         ])
   else

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -991,6 +991,8 @@ let internal_descriptors : t list =
       ~name:"keeper_tools_list"
       ~description:
         "List the active keeper tool surface from descriptors and registered schemas. \
+         This is capability introspection, not connector content lookup. Use \
+         keeper_surface_read only for current connected-surface lane context. \
          No arguments."
       ~input_schema:empty_object_schema
       ~policy:(read_only_in_process_policy ())
@@ -1051,8 +1053,11 @@ let internal_descriptors : t list =
       ~description:
         "Read recent conversation from one connected surface lane (dashboard, \
          discord, slack, or another connector label) with speaker identity \
-         and a derived participant roster. Use after Connected Surfaces \
-         shows a lane you want context from."
+         and a derived participant roster. Use when the user asks about a \
+         current connector lane, recent lane messages, or participants. This \
+         does not enumerate connector-wide channel registries; if asked for \
+         channels outside Connected Surfaces, read only visible lane evidence \
+         and state that the wider registry is unavailable."
       ~input_schema:surface_read_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_surface_read

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -761,6 +761,7 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
     if has_prefix "keeper_board_" n || has_prefix "masc_board_" n then "board"
     else if has_prefix "keeper_voice_" n then "voice"
     else if has_prefix "keeper_task_" n || has_prefix "keeper_tasks_" n then "workspace"
+    else if has_prefix "keeper_surface_" n || has_prefix "keeper_person_note_" n then "surface"
     else if String.equal n "tool_execute" then "execute"
     else if String.equal n "tool_search_files" then "search_files"
     else if has_prefix "tool_" n then "fs"

--- a/lib/tool_surface/tool_shard_types_schemas_base.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_base.ml
@@ -145,11 +145,14 @@ let base_tools : Masc_domain.tool_schema list =
     }
   ; (* Tool self-introspection — lets the keeper enumerate its own capabilities *)
     { name = "keeper_tools_list"
-    ; description =
-        "List all tools currently available to you, grouped by category. Use when asked \
-         'what can you do?' or when you need to discover your capabilities. Returns tool \
-         names organized by category. Includes the active runtime schema/descriptor \
-         surface after denylist filtering."
+     ; description =
+         "List all tools currently available to you, grouped by category. Use when asked \
+         'what can you do?' or when you need to discover your capabilities. Do not use \
+         this to answer connector content questions or channel registry questions; use \
+         keeper_surface_read only for current connected-surface lane context and state \
+         the limitation if a connector-wide registry is unavailable. Returns tool names \
+         organized by category. Includes the active runtime schema/descriptor surface \
+         after denylist filtering."
     ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
     }
   ]

--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -6,8 +6,11 @@ let surface_tools : Masc_domain.tool_schema list =
     ; description =
         "Read recent conversation from one connected surface lane (dashboard, \
          discord, slack, or another connector label) with speaker identity \
-         and a derived participant roster. Use after Connected Surfaces \
-         shows a lane you want context from."
+         and a derived participant roster. Use when the user asks about a \
+         current connector lane, recent lane messages, or participants. This \
+         does not enumerate connector-wide channel registries; if asked for \
+         channels outside Connected Surfaces, read only visible lane evidence \
+         and state that the wider registry is unavailable."
     ; input_schema =
         `Assoc
           [ "type", `String "object"

--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -61,6 +61,28 @@ let assert_retrieves ~label index query expected_tool =
       label expected_tool query (String.concat ", " top5));
   rank
 
+let assert_ranks_before ~label index query ~preferred ~discouraged =
+  let retrieved = Agent_sdk.Tool_index.retrieve index query in
+  let names = List.map fst retrieved in
+  let rank name =
+    List.find_index (String.equal name) names |> Option.map (( + ) 1)
+  in
+  match rank preferred, rank discouraged with
+  | Some p, Some d ->
+    Alcotest.(check bool)
+      (Printf.sprintf "%s: %s rank %d before %s rank %d" label preferred p discouraged d)
+      true
+      (p < d)
+  | Some _, None ->
+    Alcotest.(check bool)
+      (Printf.sprintf "%s: %s present and %s absent" label preferred discouraged)
+      true
+      true
+  | None, _ ->
+    let top5 = List.filteri (fun i _ -> i < 5) names in
+    Alcotest.failf "%s: %s NOT in top-20 for query '%s'. Top 5: [%s]"
+      label preferred query (String.concat ", " top5)
+
 (* ================================================================ *)
 (* Scenarios: file operations                                       *)
 (* ================================================================ *)
@@ -228,6 +250,28 @@ let test_tool_execute_worktree_kr () =
     "워크트리 생성 브랜치" "tool_execute")
 
 (* ================================================================ *)
+(* Scenarios: connected surface lanes                               *)
+(* ================================================================ *)
+
+let test_connected_lane_question_kr_prefers_surface_read () =
+  let idx = build_keeper_index () in
+  assert_ranks_before
+    ~label:"connected_lane_question_kr"
+    idx
+    "다른 디스코드 채널 목록 뭐 있음"
+    ~preferred:"keeper_surface_read"
+    ~discouraged:"keeper_tools_list"
+
+let test_connected_lane_question_en_prefers_surface_read () =
+  let idx = build_keeper_index () in
+  assert_ranks_before
+    ~label:"connected_lane_question_en"
+    idx
+    "what other discord channels or connected surface lanes are available"
+    ~preferred:"keeper_surface_read"
+    ~discouraged:"keeper_tools_list"
+
+(* ================================================================ *)
 (* Discrimination: fs_edit vs bash for file writes                  *)
 (* ================================================================ *)
 
@@ -347,6 +391,13 @@ let () =
           Alcotest.test_case "tool search files (kr)" `Quick test_tool_search_files_kr;
           Alcotest.test_case "tool search files (en)" `Quick test_tool_search_files_en;
           Alcotest.test_case "tool execute worktree (kr)" `Quick test_tool_execute_worktree_kr;
+        ] );
+      ( "surfaces",
+        [
+          Alcotest.test_case "connected lane question prefers surface read (kr)" `Quick
+            test_connected_lane_question_kr_prefers_surface_read;
+          Alcotest.test_case "connected lane question prefers surface read (en)" `Quick
+            test_connected_lane_question_en_prefers_surface_read;
         ] );
       ( "discrimination",
         [

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -349,9 +349,11 @@ let test_keeper_tools_list_json_uses_typed_groups () =
              "keeper_board_fake";
              "keeper_voice_speak";
              "keeper_task_claim";
+             "keeper_surface_read";
              "tool_search_files";
              "tool_read_file";
              "keeper_memory_search";
+             "keeper_tools_list";
            ])
       ()
   in
@@ -367,6 +369,12 @@ let test_keeper_tools_list_json_uses_typed_groups () =
     (member "voice" "keeper_voice_speak");
   check bool "task tool grouped as workspace" true
     (member "workspace" "keeper_task_claim");
+  check bool "surface read grouped as surface" true
+    (member "surface" "keeper_surface_read");
+  check bool "surface read not hidden under meta" false
+    (member "meta" "keeper_surface_read");
+  check bool "tools_list remains a meta introspection tool" true
+    (member "meta" "keeper_tools_list");
   check bool "Grep tool grouped" true
     (member "search_files" "tool_search_files");
   check bool "fs tool grouped" true

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -436,6 +436,47 @@ let test_deterministic_prefilter_surfaces_execute_for_shell_request () =
   Alcotest.(check bool) "retired repo helper surface stays out of visible surface"
     false (List.exists (String.starts_with ~prefix:retired_repo_prefix) visible)
 
+let test_deterministic_prefilter_surfaces_connected_lane_context () =
+  let surface_tools =
+    [ make_tool "keeper_surface_read"
+        "Read recent conversation from one connected surface lane: connector lane, channel conversation, participants roster"
+    ; make_tool "keeper_tools_list"
+        "List available tools and keeper capabilities"
+    ; make_tool "keeper_tool_search"
+        "Search for tools by keyword"
+    ; make_tool "keeper_context_status"
+        "Check context window usage"
+    ]
+  in
+  let selected =
+    deterministic_prefilter_for_tools
+      ~tools:surface_tools
+      ~query_text:"내가 빈센이고 다른 디스코드 채널 뭐있음"
+      ~selection_limit:10
+  in
+  let visible =
+    Keeper_tool_selection.merge_tool_selection_boundary
+      ~core:(Keeper_tool_dispatch_runtime.effective_core_tools ())
+      ~deterministic_prefilter:selected
+      ~llm_selected:[]
+      ~discovered:[]
+  in
+  let index_of name =
+    let rec loop i = function
+      | [] -> None
+      | x :: xs -> if String.equal x name then Some i else loop (i + 1) xs
+    in
+    loop 0 visible
+  in
+  Alcotest.(check bool) "surface_read appears in visible surface"
+    true (List.mem "keeper_surface_read" visible);
+  Alcotest.(check bool) "surface_read appears before generic tools_list"
+    true
+    (match index_of "keeper_surface_read", index_of "keeper_tools_list" with
+     | Some s, Some t -> s < t
+     | Some _, None -> true
+     | _ -> false)
+
 let test_tool_search_partition_returns_allowed_core_hits () =
   let partition =
     Keeper_run_tools.partition_tool_search_hits
@@ -558,6 +599,8 @@ let () =
         test_public_aliases_reuse_internal_search_aliases;
       Alcotest.test_case "visible Execute covers shell request" `Quick
         test_deterministic_prefilter_surfaces_execute_for_shell_request;
+      Alcotest.test_case "visible surface_read covers connected lane request" `Quick
+        test_deterministic_prefilter_surfaces_connected_lane_context;
       Alcotest.test_case "tool_search returns allowed core hits" `Quick
         test_tool_search_partition_returns_allowed_core_hits;
       Alcotest.test_case "tool_search projects allowed internals to public aliases" `Quick

--- a/test/test_keeper_unified_metacognition.ml
+++ b/test/test_keeper_unified_metacognition.ml
@@ -81,6 +81,52 @@ let test_on_idle_board_get_nudge_names_post_id_discovery () =
             (Agent_sdk.Hooks.classify_decision other)))
 ;;
 
+let test_on_idle_tools_list_loop_suggests_surface_read () =
+  let decision =
+    HK.on_idle_decision_with_threshold
+      ~skip_at:3
+      ~consecutive_idle_turns:1
+      ~allowed_tools:
+        [ "keeper_context_status"
+        ; "keeper_tool_search"
+        ; "extend_turns"
+        ; "keeper_broadcast"
+        ; "keeper_tasks_list"
+        ; "keeper_surface_read"
+        ; "keeper_stay_silent"
+        ]
+      ~tool_names:[ "keeper_tools_list" ]
+  in
+  match decision with
+  | Agent_sdk.Hooks.Nudge msg ->
+    check
+      bool
+      "tools_list loop nudge names surface_read"
+      true
+      (contains_substring msg "keeper_surface_read");
+    check
+      bool
+      "tools_list loop nudge explains capability-list trap"
+      true
+      (contains_substring msg "keeper_tools_list lists capabilities");
+    check
+      bool
+      "tools_list loop nudge points at connected-surface labels"
+      true
+      (contains_substring msg "Connected Surfaces");
+    check
+      bool
+      "tools_list loop nudge does not hardcode a discord surface argument"
+      false
+      (contains_substring msg "surface=\"discord\"")
+  | other ->
+    fail
+      (Printf.sprintf
+         "expected Nudge, got %s"
+         (Agent_sdk.Hooks.decision_kind_to_string
+            (Agent_sdk.Hooks.classify_decision other)))
+;;
+
 let test_on_idle_final_warning_before_skip () =
   let decision =
     HK.on_idle_decision_with_threshold
@@ -178,6 +224,10 @@ let () =
             "on_idle board_get nudge names post_id discovery"
             `Quick
             test_on_idle_board_get_nudge_names_post_id_discovery
+        ; test_case
+            "on_idle tools_list loop suggests surface_read"
+            `Quick
+            test_on_idle_tools_list_loop_suggests_surface_read
         ; test_case
             "on_idle final warning before skip"
             `Quick


### PR DESCRIPTION
## Summary

- Clarify `keeper_tools_list` as capability introspection only, not connector content or channel registry lookup.
- Clarify `keeper_surface_read` as a bounded connected-lane log/roster projection, not a connector-wide channel registry tool.
- Keep surface routing vocabulary in the keeper production `Tool_index` alias layer instead of duplicating incident-specific terms in the older `Tool_prefilter` synonym table.
- Group keeper surface/person-note tools under `surface` in `keeper_tools_list_json` instead of falling through to `meta`.
- Add idle recovery guidance for repeated `keeper_tools_list` loops that points to `keeper_surface_read` only when current lane context is the right question.
- Add focused regressions for Korean/English connected-lane prompts and visible top-k selection.

## Why

A keeper handling a user asking what other Discord channels exist repeatedly called `keeper_tools_list`, which only lists available capabilities. The root issue is not Discord-specific routing; it is a contract ambiguity between three surfaces:

- `keeper_tools_list`: catalog of callable capabilities.
- `keeper_surface_read`: current connected-surface lane history plus roster, backed by keeper chat log rows.
- Connector-wide channel registry: not currently available through this tool surface.

This PR makes that boundary explicit so the keeper can either read visible lane evidence or state the registry limitation instead of looping on the catalog tool.

## Validation

- `git diff --check $(git merge-base HEAD origin/main)..HEAD`
- `ocamlformat --check` on touched OCaml files
- `env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build_keeper_tool_selection scripts/dune-local.sh exec test/test_keeper_retrieval_quality.exe -- test surfaces`
- `env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build_keeper_tool_selection scripts/dune-local.sh exec test/test_keeper_unified_metacognition.exe`
- `env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build_keeper_tool_selection scripts/dune-local.sh exec test/test_keeper_tool_dispatch_runtime.exe`
- `env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build_keeper_tool_selection scripts/dune-local.sh exec test/test_keeper_topk_llm.exe`

## Notes

The full retrieval quality suite still has existing unrelated drift failures outside the new `surfaces` cases, so this PR relies on the focused `surfaces` subset plus the dispatch/top-k/idle regression coverage above.