### PR TITLE
[codex] Reclaim stale keeper registry entries

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -453,14 +453,32 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
       "start_keepalive skipped %s: identity drift could not be repaired"
       m.name
   | Some m ->
-    let existing_entry = Keeper_registry.get ~base_path:ctx.config.base_path m.name in
-    let reclaim_stale_stopped_entry (entry : Keeper_registry.registry_entry) =
-      entry.phase = Keeper_state_machine.Stopped
-      && Eio.Promise.peek entry.done_p = Some `Stopped
+    let existing_entry =
+      Keeper_registry.get ~base_path:ctx.config.base_path m.name
+    in
+    let reclaimable_stale_entry (entry : Keeper_registry.registry_entry) =
+      let finished = Option.is_some (Eio.Promise.peek entry.done_p) in
+      match entry.phase with
+      | Keeper_state_machine.Stopped -> finished
+      | Keeper_state_machine.Failing
+      | Keeper_state_machine.Overflowed
+      | Keeper_state_machine.Compacting
+      | Keeper_state_machine.HandingOff
+      | Keeper_state_machine.Draining
+      | Keeper_state_machine.Crashed
+      | Keeper_state_machine.Dead
+      | Keeper_state_machine.Zombie -> finished
+      | Keeper_state_machine.Running
+      | Keeper_state_machine.Paused
+      | Keeper_state_machine.Restarting
+      | Keeper_state_machine.Offline -> false
     in
     (match existing_entry with
-     | Some entry when reclaim_stale_stopped_entry entry ->
-       Log.Keeper.info "start_keepalive: reclaiming stale stopped entry %s" m.name;
+     | Some entry when reclaimable_stale_entry entry ->
+       Log.Keeper.info
+         "start_keepalive: reclaiming stale registered entry %s phase=%s"
+         m.name
+         (Keeper_state_machine.phase_to_string entry.phase);
        Keeper_registry.unregister ~base_path:ctx.config.base_path m.name
      | _ -> ());
     if Keeper_registry.is_registered ~base_path:ctx.config.base_path m.name

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -208,4 +208,5 @@ let run_named
 module For_testing = struct
   let checkpoint_after_attempt = checkpoint_after_attempt
   let success_selected_model_raw = success_selected_model_raw
+  let apply_accept = Keeper_turn_driver_try_provider.For_testing.apply_accept
 end

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -153,4 +153,10 @@ module For_testing : sig
     Agent_sdk.Checkpoint.t option
 
   val success_selected_model_raw : Runtime_candidate.t -> string option
+
+  val apply_accept :
+    runtime_id:string ->
+    accept:(Agent_sdk_response.api_response -> bool) ->
+    Runtime_agent.run_result ->
+    (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
 end

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -532,6 +532,92 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
            fail ("expected stopped promise, got crashed: " ^ reason)
          | None -> fail "expected done_p to resolve on stop"))
 
+let test_start_keepalive_preserves_unresolved_failing_entry () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  R.clear ();
+  let base_dir = temp_dir "direct-keepalive-live-failing" in
+  let keeper_name = "live-failing-entry" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_keepalive.stop_keepalive keeper_name;
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "tester"));
+      let meta = make_meta keeper_name in
+      let original = R.register ~base_path:config.base_path keeper_name meta in
+      ignore
+        (R.dispatch_event
+           ~base_path:config.base_path
+           keeper_name
+           (KSM.Turn_failed { consecutive = 1; max_allowed = 3 }));
+      Eio.Switch.run @@ fun sw ->
+      let ctx : _ Keeper_types_profile.context =
+        {
+          config;
+          agent_name = "tester";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      Masc.Keeper_keepalive.start_keepalive ctx meta;
+      match R.get ~base_path:config.base_path keeper_name with
+      | None -> fail "expected live-failing-entry registry entry"
+      | Some entry ->
+        check string "phase remains failing" "failing" (KSM.phase_to_string entry.phase);
+        check bool "unresolved failing entry is preserved" true
+          (entry.done_p == original.done_p);
+        check bool "done promise remains unresolved" true
+          (Option.is_none (Eio.Promise.peek entry.done_p)))
+
+let test_start_keepalive_reclaims_finished_failing_entry () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  R.clear ();
+  let base_dir = temp_dir "direct-keepalive-stale-failing" in
+  let keeper_name = "stale-failing-entry" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_keepalive.stop_keepalive keeper_name;
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "tester"));
+      let meta = make_meta keeper_name in
+      let original = R.register ~base_path:config.base_path keeper_name meta in
+      ignore
+        (R.dispatch_event
+           ~base_path:config.base_path
+           keeper_name
+           (KSM.Turn_failed { consecutive = 1; max_allowed = 3 }));
+      resolve_done_for_test original (`Crashed "provider runtime error");
+      Eio.Switch.run @@ fun sw ->
+      let ctx : _ Keeper_types_profile.context =
+        {
+          config;
+          agent_name = "tester";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      Masc.Keeper_keepalive.start_keepalive ctx meta;
+      match R.get ~base_path:config.base_path keeper_name with
+      | None -> fail "expected stale-failing-entry registry entry"
+      | Some entry ->
+        check string "phase is running after reclaim" "running"
+          (KSM.phase_to_string entry.phase);
+        check bool "stale entry was replaced" true (entry.done_p != original.done_p);
+        check bool "new done promise is unresolved" true
+          (Option.is_none (Eio.Promise.peek entry.done_p));
+        Masc.Keeper_keepalive.stop_keepalive keeper_name)
+
 let test_stop_keepalive_resolves_running_entry_immediately () =
   R.clear ();
   let keeper_name = "manual-stop-entry" in
@@ -747,6 +833,10 @@ let () =
     "direct_keepalive", [
       test_case "stop resolves done promise" `Quick
         test_direct_start_keepalive_resolves_done_on_stop;
+      test_case "unresolved failing entry is preserved" `Quick
+        test_start_keepalive_preserves_unresolved_failing_entry;
+      test_case "finished failing entry is reclaimed" `Quick
+        test_start_keepalive_reclaims_finished_failing_entry;
       test_case "manual stop resolves running entry immediately" `Quick
         test_stop_keepalive_resolves_running_entry_immediately;
       test_case "manual stop preserves crashed outcome" `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -31,7 +31,7 @@ let run_result () : Runtime_agent.run_result =
 
 let test_accept_keeps_result () =
   let result =
-    Keeper_turn_driver_try_provider.For_testing.apply_accept
+    Masc.Keeper_turn_driver.For_testing.apply_accept
       ~runtime_id:"ollama.test"
       ~accept:(fun _ -> true)
       (run_result ())
@@ -45,7 +45,7 @@ let test_accept_keeps_result () =
 
 let test_rejects_as_typed_accept_error () =
   let result =
-    Keeper_turn_driver_try_provider.For_testing.apply_accept
+    Masc.Keeper_turn_driver.For_testing.apply_accept
       ~runtime_id:"ollama.gemma4-26b-a4b-qat"
       ~accept:(fun _ -> false)
       (run_result ())


### PR DESCRIPTION
## Summary
- allow `start_keepalive` to reclaim registered keeper entries whose fiber has already finished in `Failing`/terminal phases
- keep unresolved `Failing` entries registered so active recovery fibers are not replaced
- add heartbeat integration coverage for both preserved-live and reclaimed-stale cases

## Why
A keeper can fail on a provider/runtime error, leave `keepalive_running=false`, and still block dashboard boot because `start_keepalive` only reclaimed resolved `Stopped` entries before checking `is_registered`. This made manual recovery look successful while the new keepalive was skipped as already registered.

## Validation
- `env DUNE_BUILD_DIR=/private/tmp/masc-keeper-stale-reclaim-build dune build --root . test/test_heartbeat_integration.exe`
- `/private/tmp/masc-keeper-stale-reclaim-build/default/test/test_heartbeat_integration.exe`
- `git diff --check HEAD~1..HEAD`