### PR TITLE
[codex] Bump OAS pin and retry provider timeout records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `release`: disabled OTLP export in release binary smoke so GitHub release jobs
   validate boot/listening without blocking on a collector that is intentionally
   absent in CI.
+
 ## [Unreleased]
 
 ### Added
@@ -17,8 +18,14 @@
 ### Changed
 - Bumped the OAS agent SDK pin to `v0.206.1` at
   `a5006c5444c04e4a8af9c650015a91a098cd1d9f` and raised the
-  `agent_sdk` dependency floor to `0.206.1`, picking up the Z.AI
+  `agent_sdk` dependency floor to `0.206.1`, picking up duplicate
+  streaming request-field deduplication from OAS #2022 and the Z.AI
   preserved-thinking request mapping from OAS #2023.
+
+### Fixed
+- `keeper`: classified provider timeout catch-all records such as
+  `provider_error_timeout:http_operation` as retryable provider timeouts
+  instead of terminal `provider_runtime_error` blockers.
 
 ## [0.19.41] - 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC (Multi-Agent workspace Collaboration)
 
 [![OCaml](https://img.shields.io/badge/OCaml-5.4+-orange.svg)](https://ocaml.org/)
-[![OAS](https://img.shields.io/badge/agent__sdk-%E2%89%A50.205.11-blue.svg)](https://github.com/jeong-sik/oas)
+[![OAS](https://img.shields.io/badge/agent__sdk-%E2%89%A50.206.1-blue.svg)](https://github.com/jeong-sik/oas)
 
 > **Personal Infrastructure Invariant**  
 > 본 프로젝트는 개발자 1인의 워크플로우를 위해 설계된 개인용 에이전트 오케스트레이션 및 모니터링 시스템입니다. 프로덕션 SLA, 외부 하드웨어 호환성, 혹은 SemVer 기반의 API 호환성을 제공하지 않습니다.

--- a/lib/keeper/keeper_provider_runtime_boundary.ml
+++ b/lib/keeper/keeper_provider_runtime_boundary.ml
@@ -29,6 +29,103 @@ let timeout_phase_of_masc_internal_phase phase =
   if String.equal phase "" then None else timeout_phase_of_label phase
 ;;
 
+let substring_index haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0
+    then Some idx
+    else if idx + needle_len > haystack_len
+    then None
+    else if String.sub haystack idx needle_len = needle
+    then Some idx
+    else loop (idx + 1)
+  in
+  loop 0
+;;
+
+let suffix_after_prefix text prefix =
+  if String.starts_with ~prefix text
+  then
+    let prefix_len = String.length prefix in
+    Some (String.sub text prefix_len (String.length text - prefix_len) |> String.trim)
+  else None
+;;
+
+let trim_phase_token token =
+  let rec trim_right s =
+    let len = String.length s in
+    if len = 0
+    then s
+    else (
+      match s.[len - 1] with
+      | ':' | ',' | ';' | '.' | ')' -> trim_right (String.sub s 0 (len - 1))
+      | _ -> s)
+  in
+  token |> String.trim |> trim_right
+;;
+
+let phase_label_after_marker detail marker =
+  let detail = String.lowercase_ascii detail in
+  let marker = String.lowercase_ascii marker in
+  match substring_index detail marker with
+  | None -> None
+  | Some marker_start ->
+    let token_start = marker_start + String.length marker in
+    let rec token_end idx =
+      if idx >= String.length detail
+      then idx
+      else (
+        match detail.[idx] with
+        | ' ' | '\t' | '\n' | '\r' -> idx
+        | _ -> token_end (idx + 1))
+    in
+    let token_end = token_end token_start in
+    if token_end <= token_start
+    then None
+    else
+      Some
+        (String.sub detail token_start (token_end - token_start)
+         |> trim_phase_token)
+;;
+
+let provider_runtime_error_timeout_phase_label ~code ~detail =
+  let code = String.lowercase_ascii (String.trim code) in
+  let code_phase =
+    match suffix_after_prefix code "provider_error_timeout:" with
+    | Some label -> Some label
+    | None -> suffix_after_prefix code "provider_error_network:timeout:"
+  in
+  match Option.map trim_phase_token code_phase with
+  | Some phase when not (String.equal phase "") -> Some phase
+  | Some _ | None -> phase_label_after_marker detail "timeout phase="
+;;
+
+let provider_runtime_error_looks_like_timeout ~code ~detail =
+  let code = String.lowercase_ascii (String.trim code) in
+  String.equal code "provider_error_timeout"
+  || String.starts_with ~prefix:"provider_error_timeout:" code
+  || String.equal code "provider_error_network:timeout"
+  || String.starts_with ~prefix:"provider_error_network:timeout:" code
+  || String_util.contains_substring_ci detail "timeout phase="
+  || String_util.contains_substring_ci
+       detail
+       "http operation exceeded wall-clock timeout"
+;;
+
+let classify_provider_runtime_error_record ~code ~detail =
+  if provider_runtime_error_looks_like_timeout ~code ~detail
+  then
+    Provider_timeout
+      { source = Oas_provider
+      ; phase =
+        (Option.bind
+           (provider_runtime_error_timeout_phase_label ~code ~detail)
+           timeout_phase_of_label)
+      }
+  else Not_provider_runtime_failure
+;;
+
 let provider_timeout ~source ~phase =
   Provider_timeout { source; phase }
 ;;

--- a/lib/keeper/keeper_provider_runtime_boundary.mli
+++ b/lib/keeper/keeper_provider_runtime_boundary.mli
@@ -20,6 +20,17 @@ type t =
   | Not_provider_runtime_failure
 
 val classify_sdk_error : Agent_sdk.Error.sdk_error -> t
+
+val classify_provider_runtime_error_record
+  :  code:string
+  -> detail:string
+  -> t
+(** Classify a persisted [Provider_runtime_error] catch-all record.  This is
+    narrower than parsing arbitrary messages: it only recognizes the OAS
+    provider timeout wire markers such as
+    ["provider_error_timeout:http_operation"] and their preserved detail
+    strings. *)
+
 val is_provider_timeout : t -> bool
 val is_provider_timeout_error : Agent_sdk.Error.sdk_error -> bool
 

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -267,15 +267,30 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
               distinct_count)
          Stale_fleet_batch)
   | Keeper_registry.Provider_runtime_error { code; detail; _ } ->
-    Some
-      { blocker_class = "provider_runtime_error"
-      ; summary =
-          Printf.sprintf
-            "Provider runtime catch-all (%s): %s; inspect typed provider/auth/DNS/timeout/capacity cause."
-            code
-            detail
-      ; continue_gate = false
-      }
+    (match
+       Keeper_provider_runtime_boundary.classify_provider_runtime_error_record
+         ~code
+         ~detail
+     with
+     | Keeper_provider_runtime_boundary.Provider_timeout _ ->
+       Some
+         (runtime_blocker_surface_of_typed_class
+            ~summary:
+              (Printf.sprintf
+                 "Provider timeout (%s): %s; keeper can soft-fail and retry with provider cooldown."
+                 code
+                 detail)
+            Turn_timeout)
+     | Keeper_provider_runtime_boundary.Not_provider_runtime_failure ->
+       Some
+         { blocker_class = "provider_runtime_error"
+         ; summary =
+             Printf.sprintf
+               "Provider runtime catch-all (%s): %s; inspect typed provider/auth/DNS/timeout/capacity cause."
+               code
+               detail
+         ; continue_gate = false
+         })
   | Keeper_registry.Ambiguous_partial_commit { kind; detail } ->
     let blocker_class =
       match kind with

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -226,6 +226,20 @@ let failure_reason_policy_decision
     Some
       (Keeper_failure_policy.decide
          (Keeper_failure_policy.Runtime_exhausted { retryable }))
+  | Some (Keeper_registry.Provider_runtime_error { code; detail; reason = None; _ }) ->
+    (match
+       Keeper_provider_runtime_boundary.classify_provider_runtime_error_record
+         ~code
+         ~detail
+     with
+     | Keeper_provider_runtime_boundary.Provider_timeout timeout ->
+       Some
+         (Keeper_failure_policy.decide
+            (Keeper_provider_runtime_boundary.provider_timeout_failure
+               ~strikes:None
+               ~liveness:Keeper_failure_policy.Unknown_liveness
+               timeout))
+     | Keeper_provider_runtime_boundary.Not_provider_runtime_failure -> None)
   | Some _ | None ->
     None
 ;;

--- a/lib/keeper_runtime/keeper_terminal_reason.ml
+++ b/lib/keeper_runtime/keeper_terminal_reason.ml
@@ -79,6 +79,10 @@ let of_wire wire =
   else if
     String.starts_with ~prefix:"api_error_" lowered
     || String.equal lowered "provider_error"
+    || String.equal lowered "provider_error_timeout"
+    || String.starts_with ~prefix:"provider_error_timeout:" lowered
+    || String.equal lowered "provider_error_network:timeout"
+    || String.starts_with ~prefix:"provider_error_network:timeout:" lowered
   then Provider_runtime_failure wire
   else if String.starts_with ~prefix:"completion_contract_violation:" lowered
   then Completion_contract_violation wire
@@ -128,6 +132,10 @@ let is_transient_provider_runtime_failure = function
     let lowered = String.lowercase_ascii wire in
     String.equal lowered wire_api_error_timeout
     || String.equal lowered wire_api_error_network
+    || String.equal lowered "provider_error_timeout"
+    || String.starts_with ~prefix:"provider_error_timeout:" lowered
+    || String.equal lowered "provider_error_network:timeout"
+    || String.starts_with ~prefix:"provider_error_network:timeout:" lowered
   | Runtime_exhausted _
   | Config_or_auth _
   | Completion_contract_violation _

--- a/lib/keeper_runtime/keeper_terminal_reason.mli
+++ b/lib/keeper_runtime/keeper_terminal_reason.mli
@@ -62,12 +62,13 @@ type t =
           branch which was checked before the provider prefixes. Payload is
           the original string. *)
   | Provider_runtime_failure of string
-  (** Wire [String.starts_with ~prefix:"api_error_"] OR exact
-          ["provider_error"]. The parametrised [provider_error_*] codes
-          (server/hard_quota/capacity/missing_api_key/…) do NOT match the
-          exact test and, absent a config/auth substring, fall to [Other] —
-          preserving the pre-typing behaviour. Payload is the original
-          string. *)
+  (** Wire [String.starts_with ~prefix:"api_error_"], exact
+          ["provider_error"], or the provider timeout markers
+          ["provider_error_timeout:*"] / ["provider_error_network:timeout:*"].
+          Other parametrised [provider_error_*] codes
+          (server/hard_quota/capacity/missing_api_key/…) do NOT match and,
+          absent a config/auth substring, fall to [Other]. Payload is the
+          original string. *)
   | Completion_contract_violation of string
   (** Wire [String.starts_with ~prefix:"completion_contract_violation:"],
           including the extended [:called[..]:satisfying[..]] form. Payload
@@ -124,10 +125,11 @@ val terminal_prefix_idle_timeout : string
 
 (** {1 Transient provider-runtime wire codes (SSOT)}
 
-    The two retry-recoverable transient wire codes inside the
-    [Provider_runtime_failure] / [api_error_*] family: a plain
-    (non-structural) [Api.Timeout] and an [Api.NetworkError]. These mirror
-    exactly the [Agent_sdk.Error] variants
+    Retry-recoverable transient wire codes inside the
+    [Provider_runtime_failure] family: a plain (non-structural)
+    [Api.Timeout], [Api.NetworkError], and provider-level timeout markers
+    such as ["provider_error_timeout:http_operation"]. These mirror the
+    [Agent_sdk.Error] variants
     [Keeper_error_classify.is_transient_network_error] reports as transient.
     The encoder [Keeper_agent_error.api_error_terminal_reason_code]
     references these so producer and consumer cannot drift.
@@ -141,12 +143,11 @@ val wire_api_error_network : string
 
 (** [true] when [t] is a [Provider_runtime_failure] carrying one of the
     transient wire codes ([wire_api_error_timeout] / [wire_api_error_network])
-    — a retry-recoverable transient the in-turn retry self-heals. EXACT (not
-    prefix) match on the wire payload, so [api_error_oas_agent_execution_timeout]
-    and every other [api_error_*] code return [false]. Every non-
-    [Provider_runtime_failure] variant is [false]. The disposition classifier
-    routes a [true] result to a runtime-advance disposition instead of
-    [Disp_pause_human]. *)
+    or a provider timeout marker. The API timeout matches remain exact, so
+    [api_error_oas_agent_execution_timeout] and every other [api_error_*] code
+    return [false]. Every non-[Provider_runtime_failure] variant is [false].
+    The disposition classifier routes a [true] result to a runtime-advance
+    disposition instead of [Disp_pause_human]. *)
 val is_transient_provider_runtime_failure : t -> bool
 
 (** [true] when [terminal_reason] (assumed already lowercased by the

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "masc"
-version: "0.19.40"
+version: "0.19.42"
 synopsis: "Multi-Agent Shared Context MCP Server in OCaml"
 description:
   "MASC Protocol: File-based workspace collaboration for Claude, Gemini, and Codex agents"
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.205.11"}
+  "agent_sdk" {= "0.206.1"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -217,8 +217,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.205.11"
-  "git+https://github.com/jeong-sik/oas.git#eac863529d997d2d4bea3ec234e76f84764fd0b2"
+  "agent_sdk.0.206.1"
+  "git+https://github.com/jeong-sik/oas.git#a5006c5444c04e4a8af9c650015a91a098cd1d9f"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -295,6 +295,22 @@ let test_reason_none_provider_error_falls_through () =
     surface.KSB.blocker_class
 ;;
 
+let test_provider_timeout_catch_all_maps_to_turn_timeout () =
+  let surface =
+    provider_runtime_surface_exn
+      ~reason:None
+      ~code:"provider_error_timeout:http_operation"
+      ~detail:
+        "Provider 'unknown' timeout phase=http_operation: HTTP operation exceeded wall-clock timeout"
+      ()
+  in
+  check string
+    "provider timeout catch-all -> turn_timeout"
+    "turn_timeout"
+    surface.KSB.blocker_class;
+  check bool "no continue gate" false surface.KSB.continue_gate
+;;
+
 (* ── Runner ────────────────────────────────────────────────────── *)
 
 let () =
@@ -320,6 +336,8 @@ let () =
             test_typed_provider_reason_falls_through
         ; test_case "reason=None provider error falls through" `Quick
             test_reason_none_provider_error_falls_through
+        ; test_case "provider timeout catch-all maps to timeout" `Quick
+            test_provider_timeout_catch_all_maps_to_turn_timeout
         ] )
     ]
 ;;

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -241,6 +241,27 @@ let test_supervisor_policy_runtime_error_no_reason_falls_through () =
   check bool "reason=None yields no runtime-exhausted decision" true
     (Sup.failure_reason_policy_decision_for_test (Some r) = None)
 
+let test_supervisor_policy_provider_timeout_catch_all_retries () =
+  let r =
+    Reg.Provider_runtime_error
+      { code = "provider_error_timeout:http_operation"
+      ; detail =
+          "Provider 'unknown' timeout phase=http_operation: HTTP operation exceeded wall-clock timeout"
+      ; provider_id = None
+      ; http_status = None
+      ; runtime_id = None
+      ; reason = None
+      }
+  in
+  let decision = policy_decision_exn (Some r) in
+  check string "scope" "provider"
+    (KFP.failure_scope_to_label decision.failure_scope);
+  check string "lifecycle" "soft_fail_turn"
+    (KFP.lifecycle_effect_to_label decision.lifecycle_effect);
+  check string "operator action" "inspect_provider_stream"
+    (KFP.operator_action_to_label decision.operator_action);
+  check string "reason" "provider_timeout:http_operation" decision.reason
+
 (* ── Pure tests: keep_last_n ────────────────────────────── *)
 
 let test_keep_last_n_under_limit () =
@@ -2116,6 +2137,8 @@ let () =
         test_supervisor_policy_runtime_exhausted_retryable_reasons;
       test_case "runtime-exhausted capability/unknown reasons are terminal" `Quick
         test_supervisor_policy_runtime_exhausted_terminal_reasons;
+      test_case "provider timeout catch-all is retryable" `Quick
+        test_supervisor_policy_provider_timeout_catch_all_retries;
       test_case "provider error with reason=None falls through to no decision" `Quick
         test_supervisor_policy_runtime_error_no_reason_falls_through;
     ];

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -430,6 +430,29 @@ let () =
 ;;
 
 let () =
+  let code = "provider_error_timeout:http_operation" in
+  check
+    "provider timeout marker is transient"
+    (Tr.is_transient_provider_runtime_failure (Tr.of_wire code));
+  let receipt =
+    { base_receipt with
+      terminal_reason_code = code
+    ; error_kind = Some (R.error_kind_of_string "provider")
+    ; outcome = `Error
+    ; runtime_outcome = R.Runtime_failed
+    }
+  in
+  let got = R.operator_disposition receipt in
+  let want = R.Disp_fail_open_next_runtime, R.Reason_transient_runtime_retry in
+  check
+    (Printf.sprintf
+       "provider timeout marker disposition want=%s got=%s"
+       (disp_pair_to_string want)
+       (disp_pair_to_string got))
+    (got = want)
+;;
+
+let () =
   match !failures with
   | [] -> print_endline "test_keeper_terminal_reason_typed: OK"
   | xs ->


### PR DESCRIPTION
## Summary

- bump MASC to 0.19.42 and pin agent_sdk/OAS to 0.206.1 at `a5006c5444c04e4a8af9c650015a91a098cd1d9f`
- classify persisted provider timeout catch-all records as provider timeouts instead of terminal `provider_runtime_error`
- treat `provider_error_timeout:http_operation` terminal records as transient retryable runtime failures, with blocker/status coverage

## Validation

After final rebase onto current `origin/main`:

- `scripts/check-version-truth.sh`
- `scripts/check-oas-pin.sh --local-only`
- `scripts/oas-drift-check.sh`
- `git diff --check HEAD~1..HEAD`

Focused tests run earlier on this branch:

- `scripts/dune-local.sh exec test/test_keeper_terminal_reason_typed.exe`
- `scripts/dune-local.sh exec test/test_blocker_class_exhaustiveness.exe`
- `scripts/dune-local.sh exec test/test_keeper_supervisor.exe`
- `scripts/dune-local.sh exec test/test_runtime_attempt_fsm.exe`

## Notes

- OAS PR #2020, #2022, #2023, and release PR #2024 are merged; this PR pins the tagged OAS `v0.206.1` commit containing model catalog aliases, duplicate streaming request-field deduplication, and ZAI preserve-thinking fixes.
- Full local MASC build was intentionally left for the operator to run later.
