### PR TITLE
[codex] Validate keeper public tool inputs

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -17,6 +17,8 @@ Call only the exact tool names in your active schema. Prefer public aliases when
 NEVER encode chaining (&&, ||, ;), file redirects (>, >>), command substitution, or background operators in Execute. Use typed `executable`/`argv` or explicit `pipeline: [{ executable, argv }, ...]`.
 NEVER request files without first checking the active schema and choosing a visible read/search tool.
 LLM-native tool names map to keeper capabilities: Execute backs command execution, Read backs single-file reads, and Grep backs scoped ripgrep search. Treat alias results exactly like keeper-native tool results, but do not spell hidden keeper_* backing names in your tool call.
+`keeper_tool_search` discovers available tool schemas only. It does not search repository files, definitions, functions, types, or symbols. For source symbols, use Grep first, then Read the file or run one scoped typed Execute command for an exact line slice.
+`Read` accepts only `file_path`, optional `cwd`, and optional byte `limit`. Do not pass `start_line`, `end_line`, `offset`, or line-count fields; `limit` is bytes, not lines.
 NEVER type MASC tool names as shell commands. `keeper_board_list`, `keeper_task_claim`, and other keeper_* / masc_* names are JSON tools, not programs in Execute.
 After pushing a prepared branch for assigned code work, create or update the remote PR through Execute as an ordinary typed-argv CLI call from scoped repo cwd. PR creation is not a keeper-native tool concept.
 Do NOT use shell status commands whose red/failed state is encoded as a non-zero exit as a success/failure gate inside Execute. Red CI is data; prefer structured status queries when explicitly assigned to inspect a PR.
@@ -59,6 +61,8 @@ Public tool examples:
   GOOD: Grep pattern="add_comment" path=repos/REPO_NAME/.worktrees/TASK_NAME/lib glob="*.ml"
   BAD:  raw shell text: "cat file 2>/dev/null || echo missing"
   GOOD: Read file_path=file                                 (let the tool error explain missing files)
+  BAD:  Read file_path=file start_line=20 end_line=40
+  GOOD: Grep pattern="target_symbol" path=repos/REPO_NAME/.worktrees/TASK_NAME/lib glob="*.ml"
   BAD:  raw shell text: "ls path 2>/dev/null && echo EXISTS || echo NOT_FOUND"
   GOOD: Execute executable="ls" argv=["path"]              (let the tool error explain missing paths)
   BAD:  raw shell text: "python3 -c 'open(path).write(text)'"
@@ -71,8 +75,8 @@ Public tool examples:
 ## What you can do with your tools
 
 File operations:
-- Read a specific file: Read (preferred for single files) when visible.
-- Search file contents: Grep with pattern=regex, path=dir/path (optional: type=ml, glob="*.ts") when visible.
+- Read a specific file: Read (preferred for single files) when visible. `limit` is approximate bytes. No line offsets or line ranges are supported.
+- Search file contents: Grep with pattern=regex, path=dir/path (optional: type=ml, glob="*.ts") when visible. Use this for functions, types, and symbols.
 - Find files by name: prefer Grep for content, or one scoped Execute `find` typed argv call with cwd set to the repo when Execute is visible.
 - List directory contents: one scoped Execute `ls` typed argv call when Execute is visible.
 - Git history: Execute `executable="git" argv=["log","--oneline","-10"]` with cwd inside the target repo.

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -21,11 +21,11 @@ Your lifecycle:
 
 What you can do:
 - **Board**: post opinions, findings, suggestions (`keeper_board_post`). Comment on others' posts (`keeper_board_comment`). Vote (`keeper_board_vote`). The board is where keepers talk, argue, and share ideas.
-- **Tools**: use the visible tool-search/list tool (`keeper_tool_search` when it is in the active schema, otherwise `keeper_tools_list`) to discover the active runtime schema/descriptor surface. Do not call a tool name that is not in your active schema.
+- **Tools**: use the visible tool-search/list tool (`keeper_tool_search` when it is in the active schema, otherwise `keeper_tools_list`) to discover the active runtime schema/descriptor surface. Tool search is not source-code or symbol search; use `Grep` for functions, types, and file contents. Do not call a tool name that is not in your active schema.
 - **Tasks**: claim tasks from the backlog (`keeper_task_claim`), work on them, and close them with `keeper_task_done` (see "Closing claimed tasks" below).
 - **Forge/PR work**: this is not a separate keeper tool family. When an assigned task explicitly requires a forge operation and Execute is visible, run the ordinary CLI as typed argv from a scoped repo cwd. Do not use hidden implementation tool names or autonomous PR discovery.
 - **Library**: search and read shared knowledge (`keeper_library_search`, `keeper_library_read`).
-- **Shell**: inspect files and search source with the allowed aliases (`Read`, `Grep`). Use `Execute` for command execution when the active schema exposes it. Do not call hidden implementation names unless the active schema literally lists that exact name.
+- **Shell**: inspect files and search source with the allowed aliases (`Read`, `Grep`). `Read` reads one file with a byte limit and has no line-range or offset fields. Use `Execute` for command execution when the active schema exposes it. Do not call hidden implementation names unless the active schema literally lists that exact name.
 - **Memory**: your checkpoint and decision records persist. Use `keeper_memory_search` to recall past context.
 
 Task state is tool state, not repo file state. Do not use shell commands to read
@@ -54,7 +54,8 @@ Your shell starts at the sandbox root, which is **not** a git repository.
 - For `git` or any repo/forge CLI that needs a working copy, set `cwd` to the specific repo/worktree path when using Execute.
   - Example for task work: `Execute { executable: "git", argv: ["log", "--oneline", "-5"], cwd: "repos/REPO_NAME/.worktrees/TASK_NAME" }`.
   - Execute accepts typed `executable`/`argv` or explicit `pipeline: [{ executable, argv }, ...]`; do not prepend `cd repos/REPO_NAME && ...`; use `cwd` instead.
-- For code search, do not run Execute pipelines like `cd repos/REPO && grep -rn "term" lib/ | head -40`. Use `Grep { pattern: "term", path: "lib", glob: "*.ml" }` when Grep is visible, or one scoped typed Execute argv call.
+- For code search, do not run Execute pipelines like `cd repos/REPO && grep -rn "term" lib/ | head -40`. Use `Grep { pattern: "term", path: "lib", glob: "*.ml" }` when Grep is visible, or one scoped typed Execute argv call. To find a function/type definition, search the exact symbol with `Grep`; do not ask `keeper_tool_search` for source symbols.
+- `Read` does not support `start_line`, `end_line`, `offset`, or line-count limits. Its `limit` field is an approximate maximum byte count. After `Grep` finds the relevant file/line, use one scoped typed `Execute` command for a line slice if you need exact surrounding lines.
 - Do not scan all clones from Execute. Replace `rg term repos/` with `Grep { pattern: "term", path: "repos/REPO_NAME/.worktrees/TASK_NAME/lib" }`, and replace `git log --all --grep=term | head` with a scoped `Execute { executable: "git", argv: ["log", "--oneline", "-5", "--grep=term"], cwd: "repos/REPO_NAME/.worktrees/TASK_NAME" }`.
 - Read-only Execute can run local main-branch recovery. For branch checks, use `git status --short --branch`, `git branch --show-current`, or `git worktree list`; use `git checkout main` or `git switch main` only to restore the repo checkout to main.
 - Do not use shell existence tests or shell control flow such as `ls path 2>/dev/null && echo EXISTS || echo NOT_FOUND`. Use `Read`, `Grep`, or one typed `Execute` argv call and let the tool error explain missing paths.

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -180,10 +180,16 @@ let object_schema ?(required = []) properties =
     ]
 ;;
 
+let closed_object_schema ?(required = []) properties =
+  match object_schema ~required properties with
+  | `Assoc fields -> `Assoc (fields @ [ "additionalProperties", `Bool false ])
+  | schema -> schema
+;;
+
 let execute_schema = Tool_shard_types.tool_execute_schema.input_schema
 
 let read_file_schema =
-  object_schema
+  closed_object_schema
     ~required:[ "file_path" ]
     [ property
         "file_path"

--- a/lib/keeper/keeper_tool_descriptor_resolution.ml
+++ b/lib/keeper/keeper_tool_descriptor_resolution.ml
@@ -102,6 +102,47 @@ let descriptor_and_input_for_tool_call ~tool_name ~input =
         | [] -> None))
 ;;
 
+let public_descriptor_and_name_for_tool_call tool_name =
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
+  match Keeper_tool_descriptor.find_public stripped with
+  | Some descriptor -> Some (stripped, descriptor)
+  | None -> None
+;;
+
+let validate_public_input_for_tool_call ~tool_name ~input =
+  match public_descriptor_and_name_for_tool_call tool_name with
+  | Some (public_name, descriptor) ->
+    Some
+      (Tool_input_validation.validate_args
+         ~schema:descriptor.Keeper_tool_descriptor.input_schema
+         ~name:public_name
+         ~args:input
+         ())
+  | None -> None
+;;
+
+let validated_descriptor_and_input_for_tool_call ~tool_name ~input =
+  match public_descriptor_and_name_for_tool_call tool_name with
+  | Some (public_name, descriptor) ->
+    (match
+       Tool_input_validation.validate_args
+         ~schema:descriptor.Keeper_tool_descriptor.input_schema
+         ~name:public_name
+         ~args:input
+         ()
+     with
+     | Ok validated_input ->
+       Some
+         (Ok
+            ( descriptor
+            , descriptor.Keeper_tool_descriptor.translate validated_input ))
+     | Error validation_result -> Some (Error validation_result))
+  | None ->
+    Option.map
+      (fun descriptor_and_input -> Ok descriptor_and_input)
+      (descriptor_and_input_for_tool_call ~tool_name ~input)
+;;
+
 let readonly_for_tool_name tool_name =
   match descriptor_for_tool_name tool_name with
   | Some descriptor -> Keeper_tool_descriptor.readonly_static_hint descriptor

--- a/lib/keeper/keeper_tool_descriptor_resolution.mli
+++ b/lib/keeper/keeper_tool_descriptor_resolution.mli
@@ -28,6 +28,14 @@ val capability_has : Tool_capability.kind -> string -> bool
 val descriptor_and_input_for_tool_call :
   tool_name:string -> input:Yojson.Safe.t -> (Keeper_tool_descriptor.t * Yojson.Safe.t) option
 
+val validate_public_input_for_tool_call :
+  tool_name:string -> input:Yojson.Safe.t -> (Yojson.Safe.t, Tool_result.result) result option
+
+val validated_descriptor_and_input_for_tool_call :
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  ((Keeper_tool_descriptor.t * Yojson.Safe.t), Tool_result.result) result option
+
 val readonly_for_tool_name : string -> bool option
 
 val readonly_for_tool_call : tool_name:string -> input:Yojson.Safe.t -> bool option

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -415,15 +415,17 @@ let execute_keeper_tool_call_with_outcome
        in
        let descriptor_output =
          match
-           Keeper_tool_descriptor_resolution.descriptor_and_input_for_tool_call
+           Keeper_tool_descriptor_resolution.validated_descriptor_and_input_for_tool_call
              ~tool_name:name
              ~input:args
          with
-         | Some (descriptor, translated_args) ->
+         | Some (Ok (descriptor, translated_args)) ->
            Keeper_tool_runtime.handle
              keeper_tool_runtime_context
              ~descriptor
              ~args:translated_args
+         | Some (Error validation_result) ->
+           Some (Yojson.Safe.to_string (Tool_result.data validation_result))
          | None -> Keeper_tool_runtime.handle_internal keeper_tool_runtime_context ~name ~args
        in
        match descriptor_output with

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -332,8 +332,8 @@ let transient_mutex_contention_tool_error
     public name (Execute/Read/...) only appears as the [Tool.schema.name]
     set by [Tool_bridge.oas_tool_of_masc] above this helper.
 
-    [?translate_input] reshapes the incoming JSON from the public schema
-    to the internal tool's expected payload. Identity by default. *)
+    Public aliases validate the LLM-facing payload before translation to the
+    internal tool's expected payload. Identity by default. *)
 
 (* Handlers moved to [Keeper_tools_oas_handler] — see
    keeper_tools_oas_handler.mli for [make_keeper_tool_handler],

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -116,9 +116,9 @@ val transient_mutex_contention_tool_error
     alias tool entries. The closure dispatches via
     [execute_keeper_tool_call_with_outcome] using [~name] as the
     INTERNAL tool name (telemetry SSOT). [~input_schema] is the
-    internal tool schema used for pre-execution validation after
-    [?translate_input] reshapes incoming JSON from a public alias
-    schema to the internal payload (identity by default). *)
+    internal tool schema used for pre-execution validation. Public aliases
+    validate their LLM-facing payload before translation to the internal
+    payload. *)
 
 (** Build the keeper's full [tool_bundle]: internal tools +
     alias-registered (public name) tools that translate input to

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -155,24 +155,32 @@ let make_tool_bundle
              | Some internal_def -> internal_def.input_schema
              | None -> descriptor.input_schema
            in
-           let h =
-             Keeper_tools_oas_handler.make_keeper_tool_handler
-               ~name:internal
-               ~input_schema:handler_input_schema
-               ~config
-                 ~meta
-                 ~ctx_snapshot
-                 ?turn_sandbox_factory
-                 ~exec_cache
-               ?search_fn
-               ?on_tool_called
-               ?clock
-               ~translate_input:descriptor.translate
-               ~failure_counts
-               ()
-           in
            Keeper_tool_descriptor.public_names_of_descriptor descriptor
            |> List.map (fun public_name ->
+             let h =
+               Keeper_tools_oas_handler.make_keeper_tool_handler
+                 ~name:internal
+                 ~input_schema:handler_input_schema
+                 ~config
+                   ~meta
+                   ~ctx_snapshot
+                   ?turn_sandbox_factory
+                   ~exec_cache
+                 ?search_fn
+                 ?on_tool_called
+                 ?clock
+                 ~pre_validate_input:(fun input ->
+                   match
+                     Keeper_tool_descriptor_resolution.validate_public_input_for_tool_call
+                       ~tool_name:public_name
+                       ~input
+                   with
+                   | Some result -> result
+                   | None -> Ok input)
+                 ~translate_input:descriptor.translate
+                 ~failure_counts
+                 ()
+             in
              Tool_bridge.oas_tool_of_masc
                ~name:public_name
                ~description:descriptor.description

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -22,6 +22,7 @@ let make_keeper_tool_handler
       ?search_fn
       ?on_tool_called
       ?clock
+      ?(pre_validate_input = fun input -> Ok input)
       ?(translate_input = fun j -> j)
       ~(failure_counts : failure_counts)
       ()
@@ -33,11 +34,7 @@ let make_keeper_tool_handler
   in
   fun raw_input ->
     let t0 = Time_compat.now () in
-    let input = translate_input raw_input in
-    match
-      Tool_input_validation.validate_args ~schema:input_schema ~name ~args:input ()
-    with
-    | Error validation_result ->
+    let handle_validation_error ~input validation_result =
       let raw_result = Yojson.Safe.to_string (Tool_result.data validation_result) in
       let output_text = normalize_tool_result ~success:false raw_result in
       let duration_ms = 0 in
@@ -93,32 +90,42 @@ let make_keeper_tool_handler
         ~tool_name:name
         ~start_time:t0
         output_text
-    | Ok input ->
-      let key = args_key input in
-      let prior_fails = failure_count_get failure_counts key in
-      if prior_fails >= max_consecutive_failures
-      then (
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string ToolsOasFailures)
-          ~labels:[ "tool", name; "site", "blocked" ]
-          ();
-        Log.Keeper.warn
-          "tool %s blocked after %d consecutive failures (same args)"
-          name
-          prior_fails;
-        let msg =
-          Printf.sprintf
-            "This tool has failed %d times in a row with the same arguments. Try a \
-             different approach or different arguments."
-            prior_fails
-        in
-        let output_text = normalize_tool_result ~success:false msg in
-        Tool_result.error
-          ~failure_class:(Some Tool_result.Runtime_failure)
-          ~tool_name:name
-          ~start_time:t0
-          output_text)
-      else (
+    in
+    match pre_validate_input raw_input with
+    | Error validation_result ->
+      handle_validation_error ~input:raw_input validation_result
+    | Ok pre_validated_input ->
+      let input = translate_input pre_validated_input in
+      (match
+         Tool_input_validation.validate_args ~schema:input_schema ~name ~args:input ()
+       with
+       | Error validation_result -> handle_validation_error ~input validation_result
+       | Ok input ->
+         let key = args_key input in
+         let prior_fails = failure_count_get failure_counts key in
+         if prior_fails >= max_consecutive_failures
+         then (
+           Otel_metric_store.inc_counter
+             Keeper_metrics.(to_string ToolsOasFailures)
+             ~labels:[ "tool", name; "site", "blocked" ]
+             ();
+           Log.Keeper.warn
+             "tool %s blocked after %d consecutive failures (same args)"
+             name
+             prior_fails;
+           let msg =
+             Printf.sprintf
+               "This tool has failed %d times in a row with the same arguments. Try a \
+                different approach or different arguments."
+               prior_fails
+           in
+           let output_text = normalize_tool_result ~success:false msg in
+           Tool_result.error
+             ~failure_class:(Some Tool_result.Runtime_failure)
+             ~tool_name:name
+             ~start_time:t0
+             output_text)
+         else (
           let gate_clock =
             match clock with
             | Some clock -> Some clock
@@ -182,5 +189,5 @@ let make_keeper_tool_handler
                   ~failure_counts
                   ~key
                   ~input
-                  ()))
+                  ())))
 ;;

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -12,9 +12,10 @@
     alias tool entries. The closure dispatches via
     [execute_keeper_tool_call_with_outcome] using [~name] as the
     INTERNAL tool name (telemetry SSOT). [~input_schema] is the
-    internal tool schema used for pre-execution validation after
-    [?translate_input] reshapes incoming JSON from a public alias
-    schema to the internal payload (identity by default). *)
+    internal tool schema used for pre-execution validation. Alias callers may
+    pass [?pre_validate_input] to validate the raw public payload before
+    [?translate_input] reshapes it to the internal payload (identity by
+    default). *)
 val make_keeper_tool_handler
   :  name:string
   -> input_schema:Yojson.Safe.t
@@ -26,6 +27,8 @@ val make_keeper_tool_handler
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?pre_validate_input:
+       (Yojson.Safe.t -> (Yojson.Safe.t, Tool_result.result) result)
   -> ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t)
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> unit

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -205,6 +205,15 @@ let schema_required_fields schema =
   | other -> Alcotest.failf "input_schema is not an object: %s" (Yojson.Safe.to_string other)
 ;;
 
+let schema_forbids_additional_properties schema =
+  match schema with
+  | `Assoc fields ->
+    (match List.assoc_opt "additionalProperties" fields with
+     | Some (`Bool false) -> true
+     | _ -> false)
+  | other -> Alcotest.failf "input_schema is not an object: %s" (Yojson.Safe.to_string other)
+;;
+
 let required_board_schema name =
   match List.find_opt (fun (s : Masc_domain.tool_schema) -> s.name = name) Board.board_tools with
   | Some schema -> schema
@@ -223,6 +232,86 @@ let required_masc_board_schema name =
 
 let check_contains label ~sub text =
   Alcotest.(check bool) label true (string_contains ~sub text)
+;;
+
+let test_read_public_descriptor_schema_is_closed () =
+  let descriptor = required_public_descriptor "Read" in
+  Alcotest.(check bool)
+    "Read schema forbids additional properties"
+    true
+    (schema_forbids_additional_properties descriptor.input_schema)
+;;
+
+let test_read_public_validation_rejects_line_fields () =
+  let input =
+    `Assoc
+      [ "file_path", `String "lib/keeper/keeper_transition_audit.ml"
+      ; "start_line", `Int 255
+      ; "end_line", `Int 280
+      ]
+  in
+  match Resolution.validate_public_input_for_tool_call ~tool_name:"Read" ~input with
+  | Some (Error validation_result) ->
+    let data = Tool_result.data validation_result |> Yojson.Safe.to_string in
+    check_contains
+      "Read validation reports unsupported start_line"
+      ~sub:"start_line"
+      data;
+    check_contains
+      "Read validation reports unsupported end_line"
+      ~sub:"end_line"
+      data;
+    check_contains
+      "Read validation is policy rejection"
+      ~sub:"policy_rejection"
+      data
+  | Some (Ok _) -> Alcotest.fail "Read public validation unexpectedly accepted line fields"
+  | None -> Alcotest.fail "Read public descriptor did not resolve"
+;;
+
+let test_read_public_validation_translates_supported_fields () =
+  let input =
+    `Assoc
+      [ "file_path", `String "lib/keeper/keeper_transition_audit.ml"
+      ; "cwd", `String "repos/masc"
+      ; "limit", `Int 4096
+      ]
+  in
+  match
+    Resolution.validated_descriptor_and_input_for_tool_call
+      ~tool_name:"Read"
+      ~input
+  with
+  | Some (Ok (descriptor, `Assoc fields)) ->
+    Alcotest.(check string)
+      "Read resolves to tool_read_file"
+      "tool_read_file"
+      descriptor.internal_name;
+    Alcotest.(check (option string))
+      "file_path translates to path"
+      (Some "lib/keeper/keeper_transition_audit.ml")
+      (match List.assoc_opt "path" fields with
+       | Some (`String path) -> Some path
+       | _ -> None);
+    Alcotest.(check (option string))
+      "cwd passes through"
+      (Some "repos/masc")
+      (match List.assoc_opt "cwd" fields with
+       | Some (`String cwd) -> Some cwd
+       | _ -> None);
+    Alcotest.(check (option int))
+      "limit translates to max_bytes"
+      (Some 4096)
+      (match List.assoc_opt "max_bytes" fields with
+       | Some (`Int max_bytes) -> Some max_bytes
+       | _ -> None)
+  | Some (Ok (_, other)) ->
+    Alcotest.failf "Read translated input is not an object: %s" (Yojson.Safe.to_string other)
+  | Some (Error validation_result) ->
+    Alcotest.failf
+      "Read public validation unexpectedly failed: %s"
+      (Tool_result.data validation_result |> Yojson.Safe.to_string)
+  | None -> Alcotest.fail "Read public descriptor did not resolve"
 ;;
 
 let test_read_descriptor_spells_out_path_basis () =
@@ -747,6 +836,18 @@ let () =
         ] )
     ; ( "agent-contract"
       , [ test_case
+            "Read public descriptor schema is closed"
+            `Quick
+            test_read_public_descriptor_schema_is_closed
+        ; test_case
+            "Read rejects unsupported line fields before translation"
+            `Quick
+            test_read_public_validation_rejects_line_fields
+        ; test_case
+            "Read validates then translates supported public fields"
+            `Quick
+            test_read_public_validation_translates_supported_fields
+        ; test_case
             "Read path basis is explicit"
             `Quick
             test_read_descriptor_spells_out_path_basis

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -236,6 +236,46 @@ let test_registered_descriptor_bypasses_tool_access_allowlist () =
          | `Assoc _ -> true
          | _ -> false))
 
+let test_public_read_rejects_unsupported_range_fields () =
+  with_exec_fixture
+    "keeper_tool_dispatch_runtime_read_rejects_range_fields"
+    (fun ~config ~meta ~ctx_work ->
+      let result =
+        KET.execute_keeper_tool_call_with_outcome
+          ~config
+          ~meta
+          ~ctx_work
+          ~exec_cache:None
+          ~name:"Read"
+          ~input:
+            (`Assoc
+               [ "file_path", `String "lib/keeper/keeper_transition_audit.ml"
+               ; "start_line", `Int 255
+               ])
+          ()
+      in
+      check string "runtime outcome" "failure"
+        (match result.outcome with `Success -> "success" | `Failure -> "failure");
+      check string "runtime payload shape" "structured_error"
+        (payload_kind result.payload_shape);
+      let json = Yojson.Safe.from_string result.raw_output in
+      let error =
+        Yojson.Safe.Util.(member "error" json |> to_string_option)
+        |> Option.value ~default:""
+      in
+      check bool "error mentions unsupported field" true
+        (contains_substring error "unsupported field");
+      check bool "error mentions start_line" true
+        (contains_substring error "start_line");
+      check string "validation source" "oas_tool_middleware"
+        Yojson.Safe.Util.(member "validation" json |> to_string);
+      check string "failure class" "policy_rejection"
+        Yojson.Safe.Util.(member "failure_class" json |> to_string);
+      check bool "did not reach file runtime" false
+        (match Yojson.Safe.Util.member "path_resolution" json with
+         | `Assoc _ -> true
+         | _ -> false))
+
 let counter_for_tool_not_allowed ~keeper ~tool ~reason =
   Masc.Otel_metric_store.metric_value_or_zero
     Keeper_metrics.(to_string ToolNotAllowed)
@@ -898,6 +938,8 @@ let () =
     ("execute_keeper_tool_call_with_outcome", [
       test_case "registered descriptor bypasses tool_access allowlist" `Quick
         test_registered_descriptor_bypasses_tool_access_allowlist;
+      test_case "public Read rejects unsupported range fields" `Quick
+        test_public_read_rejects_unsupported_range_fields;
       test_case "missing file is failure" `Quick
         test_execute_with_outcome_missing_file_is_failure;
       test_case "bad query is failure" `Quick


### PR DESCRIPTION
## Summary

- Close only the public `Read` schema with `additionalProperties: false` so unsupported line-range fields fail before translation.
- Validate public alias payloads before translating them into internal tool payloads in both OAS handler dispatch and direct keeper runtime dispatch.
- Update keeper prompts to clarify that `keeper_tool_search` is schema search, not code/symbol search, and that `Read` supports byte limits but no line ranges.
- Add regression coverage for unsupported `Read` line fields and validated public-field translation.

## Why

The failure mode was at the MASC public `Read` boundary: unsupported public fields like `start_line`/`end_line` could be ignored during translation before the internal runtime saw them. The fix keeps OAS untouched and makes the MASC descriptor surface validate the public `Read` contract before runtime file access.

This intentionally does not close every descriptor-backed public schema. Broad `additionalProperties: false` has compatibility risk for tool surfaces that legitimately evolve or accept passthrough inputs.

## Validation

- `git diff --check`
- `bash scripts/validate-prompt-paths.sh`
- `ocamlc -stop-after parsing` for touched OCaml implementation/interface/test files
- Built `./test/test_keeper_tool_descriptor_registry_integrity.exe` earlier with isolated `DUNE_BUILD_DIR`; newly added descriptor tests passed. Full suite was not rerun locally because local build validation is being deferred.

## Notes

The CI `Health` failure observed on the first PR run is tracked separately in #20964. The failing file is outside this PR's changed files.
