### PR TITLE
fix(test): rewrite never-compiling path traversal test as Alcotest (broken main)

### DIFF
--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -71,6 +71,7 @@ val status_to_string : request_status -> string
 val entry_to_json : entry -> Yojson.Safe.t
 
 module For_testing : sig
+  val is_safe_request_id : string -> bool
   val forget : string -> unit
   val clear : unit -> unit
   val record_path : base_path:string -> request_id:string -> string option

--- a/test/test_keeper_msg_async_path_traversal.ml
+++ b/test/test_keeper_msg_async_path_traversal.ml
@@ -1,44 +1,55 @@
-(** Test is_safe_request_id path traversal guards. *)
+(** Tests for [Keeper_msg_async.For_testing.is_safe_request_id] path
+    traversal guards and the [record_path] integration (#20942).
+
+    Rewritten from the ppx_inline_test style the original commit used:
+    the test stanza has no inline-test preprocessor, so [let%test] never
+    compiled — this file follows the repo-wide Alcotest convention. *)
+
+open Alcotest
+module Keeper_msg_async = Masc.Keeper_msg_async
 
 let is_safe = Keeper_msg_async.For_testing.is_safe_request_id
+let record_path = Keeper_msg_async.For_testing.record_path
 
-(** Valid request IDs — should be safe *)
-let%test "normal alphanumeric" = is_safe "abc123"
-let%test "with hyphens" = is_safe "my-request-42"
-let%test "with underscores" = is_safe "my_request_42"
-let%test "single char alpha" = is_safe "a"
-let%test "max length valid" =
-  let s = String.init 128 (fun _ -> 'x') in
-  is_safe s
+let test_valid_ids () =
+  check bool "normal alphanumeric" true (is_safe "abc123");
+  check bool "with hyphens" true (is_safe "my-request-42");
+  check bool "with underscores" true (is_safe "my_request_42");
+  check bool "single char alpha" true (is_safe "a");
+  check bool "max length valid" true (is_safe (String.init 128 (fun _ -> 'x')));
+  check bool "dot in middle" true (is_safe "req.123");
+  check bool "trailing dot" true (is_safe "request.");
+  (* "..." has no traversal semantics — only "." and ".." are directory
+     references. The never-compiled #20942 test asserted rejection here,
+     contradicting the implementation it shipped with. *)
+  check bool "triple dot accepted" true (is_safe "...")
 
-(** Edge cases — request_id containing dots in valid patterns *)
-let%test "dot in middle" = is_safe "req.123"
-let%test "trailing dot" = is_safe "request."
+let test_traversal_rejected () =
+  check bool "single dot rejected" false (is_safe ".");
+  check bool "double dot rejected" false (is_safe "..");
+  check bool "empty string rejected" false (is_safe "");
+  check bool "over max length rejected" false
+    (is_safe (String.init 129 (fun _ -> 'x')));
+  check bool "slash rejected" false (is_safe "../etc/passwd");
+  check bool "dots with slash rejected" false (is_safe "../../config");
+  check bool "dots and slash combo rejected" false (is_safe "a/../b")
 
-(** Path traversal attempts — must be rejected *)
-let%test _ "single dot rejected" = not (is_safe ".")
-let%test _ "double dot rejected" = not (is_safe "..")
-let%test _ "empty string rejected" = not (is_safe "")
-let%test _ "over max length" =
-  let s = String.init 129 (fun _ -> 'x') in
-  not (is_safe s)
-let%test _ "slash rejected" = not (is_safe "../etc/passwd")
-let%test _ "dots with slash" = not (is_safe "../../config")
-let%test _ "only dots multiple" = not (is_safe "...")
-let%test _ "dots and slash combo" = not (is_safe "a/../b")
+let test_record_path_integration () =
+  check bool "Some for safe id" true
+    (Option.is_some (record_path ~base_path:"/tmp" ~request_id:"safe-42"));
+  check bool "None for double dot" true
+    (Option.is_none (record_path ~base_path:"/tmp" ~request_id:".."));
+  check bool "None for single dot" true
+    (Option.is_none (record_path ~base_path:"/tmp" ~request_id:"."))
 
-(** record_path integration — uses is_safe_request_id *)
-let%test "record_path returns Some for safe id" =
-  match Keeper_msg_async.For_testing.record_path ~base_path:"/tmp" ~request_id:"safe-42" with
-  | Some _ -> true
-  | None -> false
-
-let%test "record_path returns None for path traversal" =
-  match Keeper_msg_async.For_testing.record_path ~base_path:"/tmp" ~request_id:".." with
-  | Some _ -> false
-  | None -> true
-
-let%test "record_path returns None for single dot" =
-  match Keeper_msg_async.For_testing.record_path ~base_path:"/tmp" ~request_id:"." with
-  | Some _ -> false
-  | None -> true
+let () =
+  run "keeper_msg_async_path_traversal"
+    [
+      ( "is_safe_request_id",
+        [
+          test_case "valid ids accepted" `Quick test_valid_ids;
+          test_case "traversal ids rejected" `Quick test_traversal_rejected;
+          test_case "record_path integration" `Quick
+            test_record_path_integration;
+        ] );
+    ]


### PR DESCRIPTION
## Broken main 복구

#20942가 추가한 `test/test_keeper_msg_async_path_traversal.ml`이 **컴파일된 적 없는 테스트**입니다:

1. `let%test _ "name"` — ppx_inline_test에도 없는 불법 형태인 데다, 해당 stanza(`test/stanzas/...inc`)에 inline-test preprocessor 자체가 없음 → main에서 `dune build @check`/테스트 빌드가 syntax error로 사망 (모든 체크아웃 영향)
2. 테스트가 참조하는 `For_testing.is_safe_request_id`가 .ml struct에는 있으나 **.mli 시그니처에서 누락** — 첫 에러 뒤에 숨은 두 번째 컴파일 에러

## 수정

- repo 관례(Alcotest)로 동일 단언 전부 재작성, `.mli`에 `is_safe_request_id` 노출 1줄 추가
- **재작성이 잡아낸 모순 1건**: 원 테스트는 `"..."` 거부를 단언했지만 함께 머지된 구현은 허용(정확히 `.`/`..`만 디렉토리 참조). traversal 의미상 `...`은 무해한 파일명이므로 구현이 옳다고 판단, 단언을 구현에 맞춤 (주석 명기)

## 검증

- `test_keeper_msg_async_path_traversal.exe` 3/3 green
- `dune build @check` 전체 에러 0 (이 PR 전: syntax error로 red)

⚠️ main의 @check가 깨져 있는 상태라 우선 머지 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
