### PR TITLE
perf(sse): throttle sync_transport_snapshot (~97% allocation cut)

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -116,8 +116,28 @@ let session_kind_to_string = function
 
 let take = List.take
 
+(** Minimum interval between full transport snapshot computations (seconds).
+    The snapshot iterates all SSE clients and builds per-session records;
+    at ~9 broadcasts/sec this path accounts for most allocation on the
+    broadcast hot path.  Throttling to ~0.2/sec cuts allocation by ~97%
+    while keeping dashboard metrics within 5 seconds of reality.
+    Configurable via [MASC_SNAPSHOT_INTERVAL_SEC] env var (default 5.0). *)
+let snapshot_min_interval_sec =
+  try float_of_string (Sys.getenv "MASC_SNAPSHOT_INTERVAL_SEC")
+  with Not_found -> 5.0
+
+(** Timestamp of the last completed snapshot.  CAS-guarded so that
+    concurrent [broadcast_impl] fibers racing to snapshot after the
+    interval expires do not duplicate work — only one fiber wins the
+    compare-and-set and runs the full iteration. *)
+let last_snapshot_time : float Atomic.t = Atomic.make 0.0
+
 let sync_transport_snapshot () =
   let now = Time_compat.now () in
+  let last = Atomic.get last_snapshot_time in
+  if now -. last < snapshot_min_interval_sec then ()
+  else if not (Atomic.compare_and_set last_snapshot_time last now) then ()
+  else begin
   (* Single-pass aggregation: previously [SMap.fold] built a
      [(sid, client)] tuple list, then [List.map] re-walked it to
      produce [session_snapshot] records.  [SMap.iter] over the
@@ -182,6 +202,7 @@ let sync_transport_snapshot () =
   Transport_metrics.set_sse_sessions ~kind:"presence" !presence;
   Transport_metrics.set_sse_queue_snapshot ~avg_depth
     ~max_depth:!max_queue_depth ~hot_sessions
+  end
 
 let mark_seen (client : client) =
   Atomic.set client.last_seen_at (Time_compat.now ())

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -343,6 +343,31 @@ let format_event ?id ?event_type data =
   Buffer.add_string buf "\n\n";
   Buffer.contents buf
 
+(** Format SSE event from a [Yojson.Safe.t] value without the intermediate
+    [to_string] allocation.  Writes JSON bytes directly into the SSE event
+    buffer via [Yojson.Safe.to_buffer], cutting one string allocation per
+    broadcast (~9/sec → ~9 fewer short-lived strings/sec for GC to collect). *)
+let format_event_yojson ?id ?event_type json =
+  let effective_id =
+    match id with
+    | Some i -> i
+    | None -> Atomic.fetch_and_add event_counter 1 + 1
+  in
+  let buf = Buffer.create 128 in
+  Buffer.add_string buf "id: ";
+  Buffer.add_string buf (string_of_int effective_id);
+  Buffer.add_char buf '\n';
+  (match event_type with
+   | Some e ->
+       Buffer.add_string buf "event: ";
+       Buffer.add_string buf e;
+       Buffer.add_char buf '\n'
+   | None -> ());
+  Buffer.add_string buf "data: ";
+  Yojson.Safe.to_buffer buf json;
+  Buffer.add_string buf "\n\n";
+  Buffer.contents buf
+
 (** Get current event ID *)
 let current_id () = Atomic.get event_counter
 
@@ -782,14 +807,16 @@ let reap_dead_external_subscribers () =
 let broadcast_impl ?(buffer = true) ?(notify_external = true)
     ?(event_type = "message") target json =
   let t0 = Time_compat.now () in
-  let data = Yojson.Safe.to_string json in
   let jsonrpc_payload =
     Sse_jsonrpc_filter.jsonrpc_message_for_agent_stream json
   in
   (* Atomically allocate the event id so two concurrent broadcasts
      cannot observe the same peeked counter value and emit duplicates. *)
   let current_event_id = next_id () in
-  let event = format_event ~id:current_event_id ~event_type data in
+  (* Write JSON directly into the SSE event buffer, avoiding the
+     intermediate [Yojson.Safe.to_string] allocation.  The output
+     is byte-for-byte identical to the previous two-step approach. *)
+  let event = format_event_yojson ~id:current_event_id ~event_type json in
   if buffer then
     buffer_event current_event_id event;
   (* The [SMap.t] returned by [Atomic.get] is immutable

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -434,6 +434,41 @@ let test_send_to_nonexistent () =
    Test Runners
    ============================================================ *)
 
+(* ============================================================
+   Snapshot Throttle Tests
+   ============================================================ *)
+
+let test_sync_transport_snapshot_throttle_idempotent () =
+  (* Calling sync_transport_snapshot multiple times rapidly must not
+     crash or corrupt state.  The CAS throttle ensures only the first
+     call in each [snapshot_min_interval_sec] window computes; the
+     rest return () immediately. *)
+  let session_id = "test_throttle_" ^ string_of_int (Random.bits ()) in
+  Fun.protect
+    ~finally:(fun () -> Sse.unregister session_id)
+    (fun () ->
+      let (_id, _, _) = Sse.register session_id ~last_event_id:0 in
+      for _ = 1 to 20 do
+        Sse.sync_transport_snapshot ()
+      done;
+      check int "client count preserved after rapid snapshots"
+        1 (Sse.client_count ()))
+
+let test_broadcast_throttled_snapshot_stability () =
+  (* broadcast_impl calls sync_transport_snapshot internally.
+     Verify rapid broadcasts do not corrupt client state. *)
+  let session_id = "test_bcast_throttle_" ^ string_of_int (Random.bits ()) in
+  Fun.protect
+    ~finally:(fun () -> Sse.unregister session_id)
+    (fun () ->
+      let (_id, _, _) = Sse.register session_id ~last_event_id:0 in
+      let payload = `Assoc [ "test", `String "throttle" ] in
+      for _ = 1 to 20 do
+        Sse.broadcast payload
+      done;
+      check int "client count preserved after rapid broadcasts"
+        1 (Sse.client_count ()))
+
 let () =
   run "Sse Coverage" [
     "format_event", [
@@ -493,6 +528,12 @@ let () =
     "broadcast", [
       test_case "sends to clients" `Quick test_broadcast_sends_to_clients;
       test_case "empty clients" `Quick test_broadcast_empty_clients;
+    ];
+    "snapshot_throttle", [
+      test_case "rapid sync_transport_snapshot idempotent" `Quick
+        test_sync_transport_snapshot_throttle_idempotent;
+      test_case "rapid broadcast snapshot stable" `Quick
+        test_broadcast_throttled_snapshot_stability;
     ];
     "send_to", [
       test_case "existing" `Quick test_send_to_existing;


### PR DESCRIPTION
## Summary

Throttle `sync_transport_snapshot` to reduce allocation on the SSE broadcast hot path by ~97%.

## Problem

`sync_transport_snapshot` iterates all SSE clients and builds per-session records on **every** call. Called at ~9/sec from `broadcast_impl`, this is the largest allocation hotspot on the broadcast hot path, contributing to heap growth from ~500MB to 2.4GB in ~2 hours and triggering OCaml major GC stop-the-world pauses.

## Fix

Add a CAS-guarded time-based throttle:
- `snapshot_min_interval_sec` (default 5.0, configurable via `MASC_SNAPSHOT_INTERVAL_SEC` env)
- Only one fiber wins `Atomic.compare_and_set` per interval window
- Reduces snapshot frequency from ~9/sec to ~0.2/sec (~97% allocation cut)
- Dashboard metrics lag of <5s is acceptable for observability

Transparent to all 6 call sites (register, unregister, subscribe, broadcast_impl, external subscriber, idle eviction).

## Testing

- `dune build @check` passes (no new errors)
- 2 new unit tests in `test_sse_coverage.ml`:
  - `rapid sync_transport_snapshot idempotent` — 20 rapid calls don't corrupt state
  - `rapid broadcast snapshot stable` — 20 rapid broadcasts don't corrupt state

## Metrics Impact

| Before | After |
|--------|-------|
| ~9 snapshot iterations/sec | ~0.2/sec |
| ~90% of broadcast hot path allocation | ~3% |
| Dashboard metrics: real-time | Dashboard metrics: <5s lag |

## References

- Task: task-897 (P0)
- Goal: masc-transport-gc-storm
- Diagnosis: `.tmp/masc-transport-gc-storm-diagnosis-20260612.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
