### PR TITLE
fix(keeper): raise configurable caps for self-model and goal-horizon text

### DIFF
--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -48,9 +48,28 @@ let default_proactive_enabled = true
 let default_proactive_idle_sec = 120
 let default_proactive_cooldown_sec = 300
 let approval_queue_stale_max_wait_sec = 600.0
-let default_goal_horizon_max_chars = 480
+
+(* Environment-configurable caps. Defaults were raised from 480/320 to 4096
+   because silent truncation in the dashboard made operators think edits were
+   not persisting. Operators can lower them via env vars if a deployment needs
+   tighter prompt budgets. *)
+let default_goal_horizon_max_chars =
+  match Env_config_core.raw_value_opt "MASC_KEEPER_GOAL_HORIZON_MAX_CHARS" with
+  | Some v ->
+    (match int_of_string_opt (String.trim v) with
+     | Some n when n > 0 -> n
+     | _ -> 4096)
+  | None -> 4096
+
 let default_drift_max_clauses = 6
-let prompt_render_max_bytes = 320
+
+let prompt_render_max_bytes =
+  match Env_config_core.raw_value_opt "MASC_KEEPER_SELF_MODEL_MAX_BYTES" with
+  | Some v ->
+    (match int_of_string_opt (String.trim v) with
+     | Some n when n > 0 -> n
+     | _ -> 4096)
+  | None -> 4096
 
 (* ── Removed / rejected keeper input keys ───────────────────── *)
 

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -41,7 +41,9 @@ let paused_state_requires_approval (old : keeper_meta) =
   Keeper_approval_queue.has_pending_for_keeper ~keeper_name:old.name
   || blocker_requires_continue_gate old
 
-let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool_result =
+let update_keeper ?(force = false) ?(preserve_prompt_defaults = false)
+    (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool_result
+    =
   match resolve_active_goal_ids ctx.config p old.active_goal_ids with
   | Error msg -> tool_result_error msg
   | Ok active_goal_ids ->
@@ -55,14 +57,17 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     match p.goal_opt with
     | Some g -> normalize_goal_horizon_text g
     | None ->
-        profile_default_text p.profile_defaults.goal
-          (if String.trim old.goal <> "" then old.goal else "")
+        if preserve_prompt_defaults then old.goal
+        else
+          profile_default_text p.profile_defaults.goal
+            (if String.trim old.goal <> "" then old.goal else "")
   in
   let short_goal_default = if goal_provided then goal else old.short_goal in
   let mid_goal_default = if goal_provided then goal else old.mid_goal in
   let long_goal_default = if goal_provided then goal else old.long_goal in
   let horizon_default profile_opt old_default =
     if goal_provided then old_default
+    else if preserve_prompt_defaults then old_default
     else profile_default_text profile_opt old_default
   in
   let short_goal =
@@ -156,25 +161,28 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
       ~fallback:profile_or_old
   in
   let new_will =
-    Option.value
-      ~default:
-        (if String.trim old.will <> "" then old.will
-         else Option.value ~default:(Env_config_core.keeper_will ()) p.profile_defaults.will)
-      p.will_opt
+    match p.will_opt with
+    | Some w -> w
+    | None ->
+        if preserve_prompt_defaults then old.will
+        else if String.trim old.will <> "" then old.will
+        else Option.value ~default:(Env_config_core.keeper_will ()) p.profile_defaults.will
   in
   let new_needs =
-    Option.value
-      ~default:
-        (if String.trim old.needs <> "" then old.needs
-         else Option.value ~default:(Env_config_core.keeper_needs ()) p.profile_defaults.needs)
-      p.needs_opt
+    match p.needs_opt with
+    | Some n -> n
+    | None ->
+        if preserve_prompt_defaults then old.needs
+        else if String.trim old.needs <> "" then old.needs
+        else Option.value ~default:(Env_config_core.keeper_needs ()) p.profile_defaults.needs
   in
   let new_desires =
-    Option.value
-      ~default:
-        (if String.trim old.desires <> "" then old.desires
-         else Option.value ~default:(Env_config_core.keeper_desires ()) p.profile_defaults.desires)
-      p.desires_opt
+    match p.desires_opt with
+    | Some d -> d
+    | None ->
+        if preserve_prompt_defaults then old.desires
+        else if String.trim old.desires <> "" then old.desires
+        else Option.value ~default:(Env_config_core.keeper_desires ()) p.profile_defaults.desires
   in
   (* Layer 1 boundary check: warn (not truncate) when an update brings a
      persona field above the prompt-render cap.  Skip when the value
@@ -238,11 +246,16 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     needs = new_needs;
     desires = new_desires;
     instructions =
-      Option.value
-        ~default:
-          (if String.trim old.instructions <> "" then old.instructions
-           else Option.value ~default:"" p.profile_defaults.instructions)
-        p.instructions_opt;
+      (match p.instructions_arg with
+       | Some v -> v
+       | None ->
+           if preserve_prompt_defaults then old.instructions
+           else
+             Option.value
+               ~default:
+                 (if String.trim old.instructions <> "" then old.instructions
+                  else Option.value ~default:"" p.profile_defaults.instructions)
+               p.instructions_opt);
     allowed_paths;
     sandbox_profile;
     network_mode;
@@ -365,7 +378,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
               err;
             tool_result_error err
           | Ok () ->
-            (match write_meta ctx.config updated with
+            (match write_meta ~force ctx.config updated with
              | Error e ->
                  Otel_metric_store.inc_counter
                    Keeper_metrics.(to_string WriteMetaFailures)

--- a/lib/keeper/keeper_turn_up_update.mli
+++ b/lib/keeper/keeper_turn_up_update.mli
@@ -20,6 +20,8 @@ val resolve_active_goal_ids :
     Returns structured {!Keeper_types_profile.tool_result}; failures carry their
     message on the typed error payload. *)
 val update_keeper :
+  ?force:bool ->
+  ?preserve_prompt_defaults:bool ->
   _ Keeper_types_profile.context ->
   Keeper_turn_up_args.parsed_args ->
   Keeper_meta_contract.keeper_meta ->

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -396,8 +396,14 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                  | Error result ->
                      respond_error reqd (Keeper_types_profile.tool_result_body result)
                  | Ok parsed ->
+                     (* Dashboard edits are user-initiated and should
+                        override concurrent heartbeat/version writes.
+                        Also preserve existing prompt fields when the
+                        request omits them, so profile defaults do not
+                        clobber prior dashboard edits. *)
                      let result =
-                       Keeper_turn_up_update.update_keeper keeper_ctx parsed meta0
+                       Keeper_turn_up_update.update_keeper ~force:true
+                         ~preserve_prompt_defaults:true keeper_ctx parsed meta0
                      in
                      if not (Keeper_types_profile.tool_result_success result) then
                        respond_error reqd (Keeper_types_profile.tool_result_body result)


### PR DESCRIPTION
## Problem
The dashboard now allows editing larger prompt fields (#20955), but several server-side persistence issues caused edits to be lost or reverted:

1. **Silent truncation** at parse time:
   - "will/needs/desires" capped to 320 bytes
   - goal horizon fields capped to 480 characters
   Users would save a longer prompt, reload the panel, and see the text cut off.

2. **CAS version conflicts** on concurrent writes:
   - Dashboard config POST used `write_meta` without `~force:true`, so a heartbeat updating `meta.version` could make the dashboard save fail silently (or, depending on error handling, appear to succeed while not persisting).

3. **TOML profile default overlay**:
   - Because `update_keeper` fell back to profile defaults for omitted prompt fields, a dashboard edit that sent only `will` could clobber `goal`, `instructions`, etc. with TOML defaults on the next save.

## Change
- Introduce two environment variables with much higher defaults:
  - `MASC_KEEPER_SELF_MODEL_MAX_BYTES` (default 4096)
  - `MASC_KEEPER_GOAL_HORIZON_MAX_CHARS` (default 4096)
- Parse-time normalization still caps values, but the new limits are large enough for normal dashboard edits.
- Add `?force:bool` to `Keeper_turn_up_update.update_keeper` and pass `~force:true` from the dashboard config POST to override concurrent heartbeat/version writes.
- Add `?preserve_prompt_defaults:bool` to `update_keeper`. When enabled, omitted goal/self-model/instruction fields keep their persisted values instead of falling back to profile defaults. The dashboard handler enables it.

## Scope
- `lib/keeper/keeper_config_text.ml` — configurable caps.
- `lib/keeper/keeper_turn_up_update.ml{,i}` — optional force + preserve flags.
- `lib/server/server_dashboard_http_keeper_api_post.ml` — dashboard POST uses both flags.
- Dashboard counter UI lives in #20972.

## Verification
- `dune build lib` passes.
