### PR TITLE
[codex] Restore keeper named runtime accept handling

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -112,11 +112,10 @@ let run_named
   in
   let preserve_thinking = runtime_seed.preserve_thinking in
   (* Parameters that only fed the deleted multi-candidate machinery
-     (provider selection, admission queue gating, per-candidate accept). *)
+     (provider selection and admission queue gating). *)
   ignore provider_filter;
   ignore base_path;
   ignore wait_timeout_sec;
-  ignore (accept : Agent_sdk_response.api_response -> bool);
   (* RFC-0207: dispatch to the *requested* runtime (a keeper's persona [model]
      selection or the global default, both produced by [runtime_id_of_meta])
      instead of unconditionally the default.  A requested id that does not
@@ -162,6 +161,7 @@ let run_named
     max_tokens;
     max_input_tokens;
     max_cost_usd;
+    accept;
     guardrails;
     hooks;
     context_reducer;

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -35,6 +35,7 @@ type try_provider_ctx =
   ; max_tokens : int
   ; max_input_tokens : int option
   ; max_cost_usd : float option
+  ; accept : Agent_sdk_response.api_response -> bool
   ; guardrails : Agent_sdk.Guardrails.t option
   ; hooks : Agent_sdk.Hooks.hooks option
   ; context_reducer : Agent_sdk.Context_reducer.t option
@@ -184,6 +185,23 @@ let body_timeout_for_attempt ?per_provider_timeout_s () =
   match Keeper_runtime_resolved.body_timeout_override_sec () with
   | Some _ as s -> s
   | None -> max_execution_time_for_attempt ?per_provider_timeout_s ()
+
+let accept_rejected_error ~runtime_id =
+  Keeper_internal_error.sdk_error_of_masc_internal_error
+    (Keeper_internal_error.Accept_rejected
+       {
+         scope = runtime_id;
+         model =
+           Some
+             (Boundary_redaction.to_string
+                Boundary_redaction.runtime_model_label);
+         reason =
+           Printf.sprintf "response rejected by accept (runtime=%s)" runtime_id;
+       })
+
+let apply_accept ~runtime_id ~accept (run_result : Runtime_agent.run_result) =
+  if accept run_result.response then Ok run_result
+  else Error (accept_rejected_error ~runtime_id)
 
 (** Run a single provider attempt within the runtime.
 
@@ -361,6 +379,13 @@ let run_try_provider
            ~provider_cfg:(Runtime_candidate.provider_cfg candidate))
         result
     in
+    let result =
+      match result with
+      | Ok run_result ->
+        apply_accept ~runtime_id:ctx.error_runtime_id ~accept:ctx.accept
+          run_result
+      | Error _ as err -> err
+    in
     (match ctx.on_runtime_observation, result with
      | Some emit, Ok run_result ->
        Option.iter emit run_result.Runtime_agent.runtime_observation
@@ -390,4 +415,5 @@ module For_testing = struct
   let stream_idle_timeout_for_attempt = stream_idle_timeout_for_attempt
   let sanitize_runtime_mcp_external_tool_choice =
     sanitize_runtime_mcp_external_tool_choice
+  let apply_accept = apply_accept
 end

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -18,6 +18,7 @@ type try_provider_ctx =
   ; max_tokens : int
   ; max_input_tokens : int option
   ; max_cost_usd : float option
+  ; accept : Agent_sdk_response.api_response -> bool
   ; guardrails : Agent_sdk.Guardrails.t option
   ; hooks : Agent_sdk.Hooks.hooks option
   ; context_reducer : Agent_sdk.Context_reducer.t option
@@ -76,4 +77,10 @@ module For_testing : sig
     runtime_mcp_external_tools:bool ->
     Agent_sdk.Hooks.turn_params ->
     Agent_sdk.Hooks.turn_params
+
+  val apply_accept :
+    runtime_id:string ->
+    accept:(Agent_sdk_response.api_response -> bool) ->
+    Runtime_agent.run_result ->
+    (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
 end

--- a/test/dune
+++ b/test/dune
@@ -79,6 +79,7 @@
   test_keeper_reconcile_state
   test_attempt_state
   test_runtime_attempt_fsm
+  test_keeper_turn_driver_accept
   test_actor_mailbox
   test_domain_pool
   test_sse
@@ -356,6 +357,7 @@
   test_keeper_reconcile_state
   test_attempt_state
   test_runtime_attempt_fsm
+  test_keeper_turn_driver_accept
   test_actor_mailbox
   test_domain_pool
   test_sse

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -1,0 +1,83 @@
+let contains ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop i =
+    i + needle_len <= haystack_len
+    && (String.sub haystack i needle_len = needle || loop (i + 1))
+  in
+  needle_len = 0 || loop 0
+
+let empty_response () =
+  {
+    Agent_sdk.Types.id = "resp-test";
+    model = "model-test";
+    stop_reason = Agent_sdk.Types.EndTurn;
+    content = [];
+    usage = None;
+    telemetry = None;
+  }
+
+let run_result () : Runtime_agent.run_result =
+  {
+    response = empty_response ();
+    checkpoint = None;
+    session_id = "session-test";
+    turns = 1;
+    trace_ref = None;
+    run_validation = None;
+    runtime_observation = None;
+    stop_reason = Runtime_agent.Completed;
+  }
+
+let test_accept_keeps_result () =
+  let result =
+    Keeper_turn_driver_try_provider.For_testing.apply_accept
+      ~runtime_id:"ollama.test"
+      ~accept:(fun _ -> true)
+      (run_result ())
+  in
+  match result with
+  | Ok kept ->
+    Alcotest.(check string) "session preserved" "session-test" kept.session_id
+  | Error err ->
+    Alcotest.failf "accepted response should pass through: %s"
+      (Agent_sdk.Error.to_string err)
+
+let test_rejects_as_typed_accept_error () =
+  let result =
+    Keeper_turn_driver_try_provider.For_testing.apply_accept
+      ~runtime_id:"ollama.gemma4-26b-a4b-qat"
+      ~accept:(fun _ -> false)
+      (run_result ())
+  in
+  match result with
+  | Ok _ -> Alcotest.fail "rejected response should fail"
+  | Error err ->
+    (match Keeper_internal_error.classify_masc_internal_error err with
+     | Some (Keeper_internal_error.Accept_rejected { scope; reason; _ }) ->
+       Alcotest.(check string)
+         "scope"
+         "ollama.gemma4-26b-a4b-qat"
+         scope;
+       Alcotest.(check bool)
+         "reason mentions accept rejection"
+         true
+         (contains ~needle:"response rejected by accept" reason)
+     | Some other ->
+       Alcotest.failf "expected Accept_rejected, got %s"
+         (Keeper_internal_error.kind_of_masc_internal_error other)
+     | None ->
+       Alcotest.failf "expected typed keeper error, got %s"
+         (Agent_sdk.Error.to_string err))
+
+let () =
+  Alcotest.run "keeper_turn_driver_accept"
+    [
+      ( "accept"
+      , [
+          Alcotest.test_case "accepted response passes through" `Quick
+            test_accept_keeps_result;
+          Alcotest.test_case "rejected response is typed" `Quick
+            test_rejects_as_typed_accept_error;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- threads the run_named accept predicate into the single-runtime provider attempt path
- maps rejected completed responses to typed Accept_rejected instead of letting empty keeper replies fall through as post-run internal errors
- adds a focused regression for accepted vs rejected run results

## Context
After nick0cave was routed to gemma4, completed turns with no textual reply/tool progress surfaced as Internal error: keeper turn completed with no textual reply. run_named was still accepting an accept predicate from keeper_agent_run, but the RFC-0206 single-runtime path ignored it.

## Validation
- ocamlformat --check lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_driver_try_provider.ml lib/keeper/keeper_turn_driver_try_provider.mli test/test_keeper_turn_driver_accept.ml
- git diff --check
- Not run: focused dune build/test. scripts/dune-local.sh was blocked first by agent_sdk pin drift (current aedda6656..., expected a5038de0...), then by repo-local Dune lock contention; user said they will run the build later.