### PR TITLE
feat(observability): RFC-0233 PR-1 — canonical execution_id at dispatch boundaries

### DIFF
--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -478,6 +478,9 @@ let guarded_execute
           duration_ms;
           error;
           cost_usd = Trajectory.tool_cost_estimate tool_name;
+          (* RFC-0233: this gate path has no paired tool_calls row to join
+             against; id adoption for worker-gate executions is deferred. *)
+          execution_id = None;
         } in
         Trajectory.record_entry acc entry
   in

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -608,6 +608,10 @@ let make_hooks
           Keeper_tool_call_log_context.get_turn_context_record
             ~cell:turn_ctx_cell ()
         in
+        (* RFC-0233 PR-1: one mint per execution at this dispatch boundary;
+           the log_call row and the trajectory entry below share the value
+           so downstream views can join the two stores on a single key. *)
+        let execution_id = Ids.Execution_id.generate () in
         (try
            Keeper_tool_call_log.log_call
              ~keeper_name:(!meta_ref).name
@@ -619,6 +623,7 @@ let make_hooks
              ?thinking_enabled:tctx.thinking_enabled
              ?thinking_budget:tctx.thinking_budget
              ?prompt_fingerprint:tctx.prompt_fingerprint
+             ~execution_id
              ?trace_id:tctx.trace_id ?session_id:tctx.session_id
              ?generation:tctx.generation
              ?turn:tctx.turn ?keeper_turn_id:tctx.keeper_turn_id
@@ -688,6 +693,8 @@ let make_hooks
                duration_ms = trajectory_duration_ms duration_ms;
                error = (if outcome = Tool_result.Ok then None else Some safe_output);
                cost_usd = Trajectory.tool_cost_estimate tool_name;
+               execution_id =
+                 Some (Ids.Execution_id.to_string execution_id);
              }
            in
            Trajectory.record_entry

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -416,6 +416,7 @@ let log_call
       ?thinking_enabled
       ?thinking_budget
       ?prompt_fingerprint
+      ?execution_id
       ?trace_id
       ?session_id
       ?generation
@@ -490,6 +491,14 @@ let log_call
       let trace_id_field =
         match trace_id with
         | Some value -> [ "trace_id", `String value ]
+        | None -> []
+      in
+      (* RFC-0233 PR-1: canonical per-execution join key, minted once at
+         the dispatch boundary and shared with the trajectory row. *)
+      let execution_id_field =
+        match execution_id with
+        | Some value ->
+          [ "execution_id", `String (Ids.Execution_id.to_string value) ]
         | None -> []
       in
       let session_id_field =
@@ -604,6 +613,7 @@ let log_call
            @ thinking_enabled_field
            @ thinking_budget_field
            @ prompt_fingerprint_field
+           @ execution_id_field
            @ trace_id_field
            @ session_id_field
            @ generation_field

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -143,6 +143,7 @@ val log_call :
   ?thinking_enabled:bool ->
   ?thinking_budget:int ->
   ?prompt_fingerprint:string ->
+  ?execution_id:Ids.Execution_id.t ->
   ?trace_id:string ->
   ?session_id:string ->
   ?generation:int ->
@@ -161,6 +162,9 @@ val log_call :
   unit ->
   unit
 (** [log_call ...] persists a single tool call record with full I/O.
+    [execution_id] is the RFC-0233 canonical join key minted once at the
+    dispatch boundary; the trajectory row for the same execution carries
+    the identical value.
     Output is truncated to 4000 bytes. [model] is a compatibility input only;
     non-empty values are redacted to the neutral runtime lane. [runtime_profile]
     is persisted separately as the operator-facing runtime selector. Turn-policy fields ([lane], [tool_choice],

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -342,7 +342,8 @@ let record_runtime_mcp_keeper_trajectory
     ~(arguments : Yojson.Safe.t)
     ~(message : string)
     ~(success : bool)
-    ~(duration_ms : int) : unit =
+    ~(duration_ms : int)
+    ~(execution_id : Ids.Execution_id.t) : unit =
   let trace_id = Option.value ~default:"runtime-mcp" ctx.trace_id in
   let masc_root = runtime_mcp_masc_root ~base_path in
   let safe_input = Observability_redact.redact_json_value arguments in
@@ -400,6 +401,7 @@ let record_runtime_mcp_keeper_trajectory
       duration_ms;
       error;
       cost_usd = Trajectory.tool_cost_estimate tool_name;
+      execution_id = Some (Ids.Execution_id.to_string execution_id);
     }
   in
   try
@@ -434,6 +436,9 @@ let record_runtime_mcp_keeper_tool_trace
       entry
       ~arguments
   in
+  (* RFC-0233 PR-1: one mint per execution at this dispatch boundary;
+     the tool_calls row and the trajectory row below share the value. *)
+  let execution_id = Ids.Execution_id.generate () in
   Keeper_tool_call_log.log_call
     ~keeper_name:ctx.keeper_name
     ~tool_name
@@ -444,6 +449,7 @@ let record_runtime_mcp_keeper_tool_trace
     ~model:ctx.model
     ~lane:"runtime_mcp"
     ?agent_name:ctx.agent_name
+    ~execution_id
     ?trace_id:ctx.trace_id
     ?session_id:ctx.session_id
     ?generation:ctx.generation
@@ -466,7 +472,8 @@ let record_runtime_mcp_keeper_tool_trace
     ~arguments
     ~message
     ~success
-    ~duration_ms;
+    ~duration_ms
+    ~execution_id;
   Sse.broadcast
     (runtime_mcp_keeper_tool_call_sse_payload
        ~keeper_name:ctx.keeper_name

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -31,6 +31,12 @@ type tool_call_entry = {
   duration_ms : int;                (** Wall-clock execution time *)
   error : string option;            (** Exception message if failed *)
   cost_usd : float;                 (** Estimated cost of this call *)
+  execution_id : string option;
+      (** RFC-0233 canonical join key minted at the dispatch boundary; the
+          tool_calls JSONL row for the same execution carries the identical
+          value. Plain string here: Trajectory is a dependency-leaf
+          persistence record, the typed [Ids.Execution_id.t] lives at the
+          mint site. *)
 }
 
 type gate_decode_summary = {
@@ -170,6 +176,9 @@ let entry_to_json ?(result_max_len = default_result_truncation)
        ("error", Json_util.string_opt_to_json e.error);
        ("cost_usd", `Float e.cost_usd);
      ]
+    @ (match e.execution_id with
+       | Some id -> [ ("execution_id", `String id) ]
+       | None -> [])
     @ runtime_contract_field @ action_radius_field)
 
 let default_thinking_truncation = 2000
@@ -657,6 +666,10 @@ let tool_call_entry_of_json (json : Yojson.Safe.t) :
                  | Some (`String s) -> Some s
                  | Some _ -> None);
               cost_usd = (match Json_util.assoc_member_opt "cost_usd" json with Some (`Float f) -> f | Some (`Int n) -> Float.of_int n | _ -> 0.0);
+              execution_id =
+                (match Json_util.assoc_member_opt "execution_id" json with
+                 | Some (`String s) -> Some s
+                 | _ -> None);
             },
             parsed_gate )
   with

--- a/lib/trajectory/trajectory.mli
+++ b/lib/trajectory/trajectory.mli
@@ -21,6 +21,10 @@ type tool_call_entry = {
   duration_ms : int;
   error : string option;
   cost_usd : float;
+  execution_id : string option;
+      (** RFC-0233 canonical join key shared with the tool_calls JSONL row
+          for the same execution. [None] only for rows written by paths
+          that have not adopted the id yet (and historical rows). *)
 }
 
 type gate_decode_summary = {
@@ -92,6 +96,14 @@ val entry_to_json :
   ?action_radius:Yojson.Safe.t ->
   tool_call_entry ->
   Yojson.Safe.t
+
+val tool_call_entry_of_json :
+  Yojson.Safe.t -> (tool_call_entry * bool) option
+(** Decode one persisted JSONL row back into a [tool_call_entry].
+    Returns [None] for non-entry rows (summary/thinking) and malformed
+    JSON. The [bool] is true when the gate field parsed from a
+    persisted value rather than the legacy default. Exposed for
+    RFC-0233 consumers that join rows on [execution_id]. *)
 val thinking_entry_to_json : ?content_max_len:int -> thinking_entry -> Yojson.Safe.t
 val trajectory_line_to_json : ?result_max_len:int -> ?content_max_len:int -> trajectory_line -> Yojson.Safe.t
 val trajectory_to_json : trajectory -> Yojson.Safe.t

--- a/lib/types/ids.ml
+++ b/lib/types/ids.ml
@@ -61,6 +61,40 @@ end = struct
              (Json_util.kind_name other))
 end
 
+(** Tool execution identifier — RFC-0233 canonical join key. One mint
+    per tool execution at the dispatch boundary; every store that
+    records the execution carries the same value. *)
+module Execution_id : sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val generate : unit -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+end = struct
+  type t = string
+  let of_string s = s
+  let to_string t = t
+  let equal = String.equal
+  let pp fmt t = Format.fprintf fmt "%s" t
+  let _id_counter = Atomic.make 0
+  let generate () =
+    let timestamp = int_of_float (Time_compat.now () *. 1000.0) in
+    (* Same fetch_and_add discipline as [Task_id.generate]: two fibers in
+       the same millisecond still get distinct sequence numbers. *)
+    let seq = (Atomic.fetch_and_add _id_counter 1 + 1) land 0xFFFF in
+    Printf.sprintf "exec-%d-%04x" timestamp seq
+  let to_yojson t = `String t
+  let of_yojson = function
+    | `String s -> Ok s
+    | other ->
+        Error
+          (Printf.sprintf "Expected string for Execution_id (received %s)"
+             (Json_util.kind_name other))
+end
+
 (** Thread identifier - conversation thread ID *)
 module Thread_id : sig
   type t

--- a/lib/types/ids.mli
+++ b/lib/types/ids.mli
@@ -30,6 +30,24 @@ module Task_id : sig
   val of_yojson : Yojson.Safe.t -> (t, string) result
 end
 
+(** Tool execution identifier — RFC-0233. Minted exactly once at the
+    dispatch boundary for each tool execution and stamped into every
+    store that records that execution (tool_calls JSONL, trajectory;
+    oas-event join lands in RFC-0233 PR-2), so one physical execution
+    renders as one logical row regardless of how many stores observed
+    it. Timestamp-prefixed ([exec-<ms>-<seq>]) — lexicographic order
+    within a process tracks mint order. *)
+module Execution_id : sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val generate : unit -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+end
+
 (** Conversation thread identifier — timestamp-prefixed sequence. *)
 module Thread_id : sig
   type t

--- a/test/test_eval_gate.ml
+++ b/test/test_eval_gate.ml
@@ -161,6 +161,7 @@ let test_pre_entropy () =
       gate_decision = Trajectory.Pass;
       result = Some "ok"; duration_ms = 10;
       error = None; cost_usd = 0.0001;
+      execution_id = None;
     } in
     (* Add 3 consecutive same-tool calls with same args *)
     Trajectory.record_entry acc (mk "tool_execute" repeated_args);
@@ -193,6 +194,7 @@ let test_pre_entropy_different_args () =
       gate_decision = Trajectory.Pass;
       result = Some "ok"; duration_ms = 10;
       error = None; cost_usd = 0.0001;
+      execution_id = None;
     } in
     (* Add 3 consecutive same-tool calls but with different args *)
     Trajectory.record_entry acc (mk "tool_execute" "{\"command\": \"echo a\"}");
@@ -223,6 +225,7 @@ let test_pre_turn_limit () =
       gate_decision = Trajectory.Pass;
       result = Some "ok"; duration_ms = 10;
       error = None; cost_usd = 0.0001;
+      execution_id = None;
     } in
     Trajectory.record_entry acc (mk "tool_execute");
     Trajectory.record_entry acc (mk "tool_read_file");

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -80,6 +80,7 @@ let test_record_entry () =
       duration_ms = 50;
       error = None;
       cost_usd = 0.0001;
+      execution_id = Some "exec-1000-0001";
     } in
     Trajectory.record_entry acc entry;
     Alcotest.(check int) "entries count" 1 (List.length acc.Trajectory.entries);
@@ -101,6 +102,7 @@ let test_entropy_not_triggered () =
       gate_decision = Trajectory.Pass;
       result = Some "ok"; duration_ms = 10;
       error = None; cost_usd = 0.0001;
+      execution_id = None;
     } in
     Trajectory.record_entry acc (mk_entry "tool_execute");
     let entropy = Trajectory.detect_entropy ~threshold:3 acc "tool_execute" in
@@ -117,6 +119,7 @@ let test_entropy_triggered () =
       gate_decision = Trajectory.Pass;
       result = Some "ok"; duration_ms = 10;
       error = None; cost_usd = 0.0001;
+      execution_id = None;
     } in
     Trajectory.record_entry acc (mk_entry "tool_execute");
     Trajectory.record_entry acc (mk_entry "tool_execute");
@@ -159,6 +162,7 @@ let test_finalize () =
       gate_decision = Trajectory.Pass;
       result = Some "ok"; duration_ms = 100;
       error = None; cost_usd = 0.0001;
+      execution_id = None;
     } in
     Trajectory.record_entry acc entry;
     let traj = Trajectory.finalize acc Trajectory.Completed in
@@ -197,6 +201,7 @@ let test_calls_in_current_turn () =
       gate_decision = Trajectory.Pass;
       result = Some "ok"; duration_ms = 10;
       error = None; cost_usd = 0.001;
+      execution_id = None;
     } in
     Trajectory.record_entry acc (mk "tool_execute");
     Trajectory.record_entry acc (mk "tool_read_file");
@@ -285,6 +290,7 @@ let mk_entry ?(ts = 1000.0) ?(error = None) ?(gate = Trajectory.Pass) name dur c
     gate_decision = gate;
     result = Some "ok"; duration_ms = dur;
     error; cost_usd = cost;
+    execution_id = None;
   }
 
 let test_aggregate_basic () =
@@ -410,6 +416,7 @@ let test_entry_to_json_includes_contract_and_radius () =
     duration_ms = 25;
     error = None;
     cost_usd = 0.0001;
+    execution_id = Some "exec-1000-0001";
   } in
   let runtime_contract =
     Keeper_runtime_contract.runtime_observability_contract_json_from_fields
@@ -438,7 +445,31 @@ let test_entry_to_json_includes_contract_and_radius () =
     (json |> member "action_radius" |> member "tool_name" |> to_string);
   Alcotest.(check string) "observed path" "/tmp/work"
     (json |> member "action_radius" |> member "observed_paths" |> to_list
-     |> List.hd |> to_string)
+     |> List.hd |> to_string);
+  Alcotest.(check string) "execution_id persisted" "exec-1000-0001"
+    (json |> member "execution_id" |> to_string)
+
+(* RFC-0233 PR-1: the canonical join key survives the JSONL round-trip,
+   and rows written before the field existed decode as [None]. *)
+let test_execution_id_roundtrip () =
+  let entry : Trajectory.tool_call_entry = {
+    ts = 1000.0; ts_iso = "2026-06-12T00:00:00Z"; turn = 3; round = 1;
+    tool_name = "tool_execute"; args_json = "{}";
+    gate_decision = Trajectory.Pass;
+    result = Some "ok"; duration_ms = 10; error = None; cost_usd = 0.0;
+    execution_id = Some "exec-1718150400000-0001";
+  } in
+  (match Trajectory.tool_call_entry_of_json (Trajectory.entry_to_json entry) with
+   | Some (decoded, _) ->
+       Alcotest.(check (option string)) "round-trip"
+         (Some "exec-1718150400000-0001") decoded.Trajectory.execution_id
+   | None -> Alcotest.fail "entry did not decode");
+  let legacy = Trajectory.entry_to_json { entry with execution_id = None } in
+  match Trajectory.tool_call_entry_of_json legacy with
+  | Some (decoded, _) ->
+      Alcotest.(check (option string)) "legacy row decodes as None" None
+        decoded.Trajectory.execution_id
+  | None -> Alcotest.fail "legacy entry did not decode"
 
 let has_assoc_key key = function
   | `Assoc fields -> List.mem_assoc key fields
@@ -662,6 +693,8 @@ let () =
       Alcotest.test_case "hourly_bucket to json" `Quick test_hourly_bucket_json;
       Alcotest.test_case "entry carries runtime/action telemetry" `Quick
         test_entry_to_json_includes_contract_and_radius;
+      Alcotest.test_case "execution_id JSONL round-trip + legacy None" `Quick
+        test_execution_id_roundtrip;
       Alcotest.test_case "runtime contract redacts backend details" `Quick
         test_runtime_contract_projection_redacts_backend_details;
     ]);

--- a/test/test_trajectory_atomicity.ml
+++ b/test/test_trajectory_atomicity.ml
@@ -61,6 +61,7 @@ let make_entry ~tid ~seq : Trajectory.tool_call_entry =
     duration_ms = 0;
     error = None;
     cost_usd = 0.0;
+    execution_id = None;
   }
 
 let test_concurrent_threads () =

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -93,6 +93,41 @@ let test_task_id_to_yojson () =
   | `String s -> check string "to json" "task-123" s
   | _ -> fail "expected String"
 
+(* ============================================================
+   Execution_id Tests (RFC-0233)
+   ============================================================ *)
+
+let test_execution_id_generate_prefix () =
+  let s = Masc_domain.Execution_id.(to_string (generate ())) in
+  check bool "starts with exec-" true (String.sub s 0 5 = "exec-")
+
+let test_execution_id_generate_unique () =
+  let id1 = Masc_domain.Execution_id.generate () in
+  let id2 = Masc_domain.Execution_id.generate () in
+  check bool "unique" false (Masc_domain.Execution_id.equal id1 id2)
+
+let test_execution_id_mint_order_sorts () =
+  (* Same-millisecond mints differ by sequence; the lexicographic order
+     of the suffix tracks mint order within a process. *)
+  let ids =
+    List.init 50 (fun _ -> Masc_domain.Execution_id.(to_string (generate ())))
+  in
+  check (list string) "lexicographic order = mint order"
+    ids (List.sort compare ids)
+
+let test_execution_id_yojson_roundtrip () =
+  let id = Masc_domain.Execution_id.of_string "exec-1718150400000-0001" in
+  match Masc_domain.Execution_id.(of_yojson (to_yojson id)) with
+  | Ok back ->
+      check string "roundtrip" "exec-1718150400000-0001"
+        (Masc_domain.Execution_id.to_string back)
+  | Error _ -> fail "expected Ok"
+
+let test_execution_id_of_yojson_rejects_non_string () =
+  match Masc_domain.Execution_id.of_yojson (`Int 42) with
+  | Ok _ -> fail "expected Error for non-string"
+  | Error _ -> check bool "rejected" true true
+
 let test_task_id_of_yojson_ok () =
   let json = `String "my-task" in
   match Masc_domain.Task_id.of_yojson json with
@@ -1282,6 +1317,14 @@ let () =
       test_case "to_yojson" `Quick test_task_id_to_yojson;
       test_case "of_yojson ok" `Quick test_task_id_of_yojson_ok;
       test_case "of_yojson err" `Quick test_task_id_of_yojson_err;
+    ];
+    "execution_id", [
+      test_case "generate prefix" `Quick test_execution_id_generate_prefix;
+      test_case "generate unique" `Quick test_execution_id_generate_unique;
+      test_case "mint order sorts" `Quick test_execution_id_mint_order_sorts;
+      test_case "yojson roundtrip" `Quick test_execution_id_yojson_roundtrip;
+      test_case "of_yojson rejects non-string" `Quick
+        test_execution_id_of_yojson_rejects_non_string;
     ];
     "timestamp", [
       test_case "now_iso format" `Quick test_now_iso_format;


### PR DESCRIPTION
RFC-0233 §4 **PR-1**. refs #20910, RFC-0233.

## 무엇

1 물리 실행 → 3 스토어가 각자 ID 어휘(trajectory turn/round, tool_calls keeper_turn_id, system_log correlation_id)로 기록 → 대시보드 2행 (#20910 진단 Q8). 조인 키가 없어서 view-side dedup도 불가능(워크어라운드 거부 대상)이었습니다.

- **`Ids.Execution_id`** 신규 (`exec-<ms>-<seq:04x>`): Task_id와 동일한 mint 규율(atomic fetch_and_add — 같은 ms의 fiber도 충돌 없음), 프로세스 내 사전순=mint순
- **dispatch 경계 2곳에서 정확히 1회 mint**, 그 경계가 쓰는 두 스토어에 동일 값 스탬프:
  - `keeper_hooks_oas` post-tool-use → `log_call` row + `Trajectory` entry
  - `mcp_server_eio_call_tool` keeper tool trace → `log_call` row + `Trajectory` entry
- additive: tool_calls row의 `execution_id` 필드는 optional, trajectory `tool_call_entry.execution_id : string option` — 레거시 행은 `None`으로 디코드, 구 reader 무영향
- `tool_call_entry_of_json`을 .mli로 노출 (PR-2 join 소비자용)
- worker `eval_gate` 경로는 짝지을 tool_calls row가 없어 `None` 유지 (주석 명기)

## 검증 (RFC §5 하네스)

- mint 유일성/prefix/정렬성/yojson round-trip: `test_types_coverage` execution_id 그룹 5건 green (155 중 실패 3건은 backlog/agent_credential/auth_config — 메모리 기록상 main pre-existing)
- codec round-trip + 레거시 None 디코드: `test_trajectory` 36/36 green
- `test_trajectory_atomicity` 1/1, `test_eval_gate` 24/24 green
- `dune build @check` + default: 잔여 에러는 `test_keeper_msg_async_path_traversal.ml` syntax error **단 1건 — main pre-existing** (#20942가 도입, 핫픽스 #20962 별도 진행 중)

## 다음 (RFC §4)

- PR-2: oas-event consumer join + 대시보드 single-row render
- PR-3: TurnRecord writer — receipt의 `extra_system_context_*` None-하드코딩(#20936)도 이 경계에서 채움
- PR-4: turn inspector block-diff + OTel span attributes

MASC task-858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
