### PR TITLE
[codex] Expose Keeper prompt assembly drift

### DIFF
--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -50,6 +50,7 @@ import { KeeperToolCallInspector } from './keeper-tool-call-inspector'
 import { SupervisorDiagnosticsPanel } from './keeper-supervisor-diagnostics'
 import { KeeperBDIPanel } from './keeper-bdi-panel'
 import { KeeperConfigPanel } from './keeper-config-panel'
+import { KeeperPromptAssemblyPanel } from './keeper-prompt-assembly-panel'
 import { KeeperRuntimeModelEditor } from './keeper-runtime-model-editor'
 import { KeeperConditionsDivergent } from './keeper-conditions-divergent'
 import { KeeperActivitySummary } from './keeper-detail-activity-summary'
@@ -164,6 +165,9 @@ export function KeeperDetailBody({
 
       ${'' /* ── CTX composition by category ── */}
       <${CtxCompositionPanel} keeper=${keeper} />
+
+      ${'' /* ── Keeper prompt assembly provenance and stale guidance audit ── */}
+      <${KeeperPromptAssemblyPanel} compact=${true} />
 
       ${'' /* ── Prompt fingerprint / segment telemetry ── */}
       <${PromptTelemetryPanel} keeper=${keeper} />

--- a/dashboard/src/components/keeper-prompt-assembly-panel.test.ts
+++ b/dashboard/src/components/keeper-prompt-assembly-panel.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import type { DashboardPromptItem } from '../api'
+import { buildKeeperPromptAssemblyReport } from './keeper-prompt-assembly-panel'
+
+function prompt(overrides: Partial<DashboardPromptItem>): DashboardPromptItem {
+  return {
+    key: 'keeper.world',
+    category: 'keeper',
+    description: 'Keeper prompt',
+    current: '',
+    default: null,
+    effective: '',
+    file_value: null,
+    override_value: null,
+    file_path: null,
+    file_exists: true,
+    source: 'file',
+    has_override: false,
+    char_count: 0,
+    required_file: true,
+    template_variables: [],
+    ...overrides,
+  }
+}
+
+describe('buildKeeperPromptAssemblyReport', () => {
+  it('maps keeper prompt sources into assembly rows', () => {
+    const report = buildKeeperPromptAssemblyReport([
+      prompt({
+        key: 'keeper.world',
+        effective: 'world override',
+        override_value: 'world override',
+        source: 'override',
+        has_override: true,
+        file_path: '/tmp/.masc/config/prompts/keeper.world.md',
+      }),
+      prompt({
+        key: 'keeper.capabilities',
+        effective: 'tool policy',
+        file_path: '/tmp/.masc/config/prompts/keeper.capabilities.md',
+      }),
+      prompt({
+        key: 'keeper.unified.system',
+        effective: 'unified prompt',
+        file_path: '/tmp/.masc/config/prompts/keeper.unified.system.md',
+      }),
+    ])
+
+    expect(report.stats.totalRows).toBeGreaterThan(10)
+    expect(report.stats.overrideRows).toBeGreaterThanOrEqual(2)
+    expect(report.activePromptRoots).toEqual(['/tmp/.masc/config/prompts'])
+    expect(report.rows.find(row => row.promptKey === 'keeper.world')?.source).toBe('override')
+    expect(report.rows.find(row => row.promptKey === 'keeper.recovery_block')?.missing).toBe(true)
+  })
+
+  it('detects stale tool aliases and argument shapes in effective prompt text', () => {
+    const report = buildKeeperPromptAssemblyReport([
+      prompt({
+        key: 'keeper.tool_hints',
+        effective: 'Call keeper_board_get then keeper_task_done { notes: "evidence" }',
+      }),
+      prompt({
+        key: 'keeper.capabilities',
+        effective: 'Use keeper_pr_create and repos/masc/lib/foo.ml for PR work',
+      }),
+    ])
+
+    expect(report.warnings.map(warning => warning.id)).toEqual(
+      expect.arrayContaining([
+        'retired-board-get',
+        'task-done-notes',
+        'keeper-pr-create',
+        'hardcoded-masc-path',
+      ]),
+    )
+    expect(report.stats.criticalCount).toBe(2)
+  })
+})

--- a/dashboard/src/components/keeper-prompt-assembly-panel.ts
+++ b/dashboard/src/components/keeper-prompt-assembly-panel.ts
@@ -1,0 +1,573 @@
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+import { AlertTriangle, GitCompareArrows, RefreshCw, Route, ShieldAlert } from 'lucide-preact'
+import { fetchDashboardPrompts, type DashboardPromptItem, type PromptSource } from '../api'
+import { ActionButton } from './common/button'
+import { ErrorState } from './common/feedback-state'
+import { StatusChip, type StatusChipTone } from './common/status-chip'
+import { errorToString } from '../lib/format-string'
+
+type AssemblyLane =
+  | 'registry'
+  | 'system_prompt'
+  | 'user_message'
+  | 'extra_system_context'
+  | 'oas_hook'
+  | 'manifest'
+
+type WarningSeverity = 'critical' | 'warn' | 'info'
+
+interface AssemblyStageSpec {
+  id: string
+  order: number
+  title: string
+  lane: AssemblyLane
+  timing: string
+  injection: string
+  codeSite: string
+  promptKeys: string[]
+}
+
+export interface KeeperPromptAssemblyRow {
+  id: string
+  order: number
+  title: string
+  lane: AssemblyLane
+  timing: string
+  injection: string
+  codeSite: string
+  promptKey: string
+  source: PromptSource | 'computed'
+  hasOverride: boolean
+  filePath: string | null
+  bytes: number
+  estimatedTokens: number
+  fingerprint: string
+  missing: boolean
+}
+
+export interface KeeperPromptAssemblyWarning {
+  id: string
+  severity: WarningSeverity
+  title: string
+  detail: string
+  promptKeys: string[]
+  expected: string
+}
+
+export interface KeeperPromptAssemblyReport {
+  rows: KeeperPromptAssemblyRow[]
+  warnings: KeeperPromptAssemblyWarning[]
+  activePromptRoots: string[]
+  stats: {
+    totalRows: number
+    overrideRows: number
+    missingRows: number
+    warningCount: number
+    criticalCount: number
+    promptBytes: number
+    estimatedTokens: number
+  }
+}
+
+const STAGES: AssemblyStageSpec[] = [
+  {
+    id: 'registry-bootstrap',
+    order: 1,
+    title: 'Registry bootstrap',
+    lane: 'registry',
+    timing: 'server startup / prompt reload',
+    injection: 'Prompt markdown, default, and runtime override are resolved before Keeper run context is built.',
+    codeSite: 'Prompt_defaults.bootstrap_runtime -> Prompt_registry',
+    promptKeys: ['keeper.world', 'keeper.capabilities', 'keeper.unified.system'],
+  },
+  {
+    id: 'base-system',
+    order: 2,
+    title: 'Base system prompt',
+    lane: 'system_prompt',
+    timing: 'Keeper_run_context.prepare_run_context',
+    injection: 'Hard identity, raw behavior files, continuity, world, capabilities, and persona profile become the base system prompt.',
+    codeSite: 'Keeper_prompt.build_keeper_system_prompt',
+    promptKeys: [
+      'keeper.constitution',
+      'keeper.world',
+      'keeper.capabilities',
+      'keeper.recovery_block',
+    ],
+  },
+  {
+    id: 'unified-world',
+    order: 3,
+    title: 'Unified world state',
+    lane: 'user_message',
+    timing: 'Keeper_unified_prompt.build_prompt',
+    injection: 'Turn intent and current world state are rendered as the user-facing world/context prompt.',
+    codeSite: 'Keeper_unified_prompt.build_prompt',
+    promptKeys: [
+      'keeper.unified.system',
+      'keeper.turn_intent',
+      'keeper.turn_intent.claim_guidance_a',
+      'keeper.turn_intent.claim_guidance_b',
+      'keeper.turn_intent.board_activity_guidance',
+      'keeper.turn_intent.board_post_guidance',
+      'keeper.turn_intent.board_curation_guidance',
+      'keeper.turn_intent.broadcast_guidance',
+      'keeper.immediate_task_move',
+    ],
+  },
+  {
+    id: 'turn-soft-context',
+    order: 4,
+    title: 'Turn soft context',
+    lane: 'extra_system_context',
+    timing: 'Keeper_turn.build_turn_prompt callback',
+    injection: 'Continuity snapshot, durable memory, skill route, worktree, telemetry feedback, and turn instructions are appended as soft context.',
+    codeSite: 'Keeper_turn.build_turn_prompt',
+    promptKeys: ['keeper.reply_guidelines'],
+  },
+  {
+    id: 'oas-hook',
+    order: 5,
+    title: 'OAS pre-turn hook',
+    lane: 'oas_hook',
+    timing: 'Keeper_run_tools_hooks.before_turn_params',
+    injection: 'Temporal summary, claimed-task nudge, retry hint, Memory OS recall, tool filter, and tool choice are finalized before provider dispatch.',
+    codeSite: 'Keeper_run_tools_hooks.before_turn_params',
+    promptKeys: [
+      'keeper.memory_os_recall.context',
+      'keeper.memory_os_recall.facts_section',
+      'keeper.memory_os_recall.episodes_section',
+      'keeper.tool_preferred_header',
+      'keeper.tool_preferred_empty',
+      'keeper.tool_unknown_guard',
+    ],
+  },
+  {
+    id: 'manifest-edge',
+    order: 6,
+    title: 'Manifest edge',
+    lane: 'manifest',
+    timing: 'Keeper_agent_run.run_turn dispatch',
+    injection: 'Prompt metrics, fingerprints, and context_injected edges are recorded after final context assembly.',
+    codeSite: 'Keeper_agent_run.append_manifest(context_injected)',
+    promptKeys: [],
+  },
+]
+
+const STALE_RULES: Array<{
+  id: string
+  severity: WarningSeverity
+  title: string
+  pattern: RegExp
+  expected: string
+}> = [
+  {
+    id: 'retired-board-get',
+    severity: 'critical',
+    title: 'Retired board read alias',
+    pattern: /\bkeeper_board_get\b/,
+    expected: 'Use keeper_board_post_get with an exact post_id.',
+  },
+  {
+    id: 'task-done-notes',
+    severity: 'critical',
+    title: 'Stale keeper_task_done argument',
+    pattern: /keeper_task_done[\s\S]{0,120}\bnotes\b/,
+    expected: 'Use keeper_task_done with task_id and result evidence.',
+  },
+  {
+    id: 'keeper-pr-create',
+    severity: 'warn',
+    title: 'Conflicting keeper-native PR creation guidance',
+    pattern: /\bkeeper_pr_create\b/,
+    expected: 'Use the current repo-hosting workflow exposed by active tool policy.',
+  },
+  {
+    id: 'hardcoded-masc-path',
+    severity: 'warn',
+    title: 'Hardcoded repo path example',
+    pattern: /repos\/masc\//,
+    expected: 'Use repos/REPO_NAME/.worktrees/TASK_NAME for task work examples.',
+  },
+  {
+    id: 'playground-path',
+    severity: 'warn',
+    title: 'Legacy playground path example',
+    pattern: /\.masc\/playground\//,
+    expected: 'Use runtime-provided repo/worktree paths, not playground-era paths.',
+  },
+]
+
+const DUPLICATED_TOOL_TERMS = [
+  'keeper_task_done',
+  'keeper_board_post_get',
+  'Execute',
+  'repos/REPO_NAME/.worktrees/TASK_NAME',
+]
+
+function textByteLength(value: string): number {
+  return new TextEncoder().encode(value).length
+}
+
+function estimateTokens(value: string): number {
+  return Math.ceil(textByteLength(value) / 4)
+}
+
+function shortFingerprint(value: string): string {
+  let hash = 2166136261
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+function promptText(prompt: DashboardPromptItem | undefined): string {
+  if (!prompt) return ''
+  return prompt.effective ?? prompt.file_value ?? prompt.default ?? ''
+}
+
+function promptRoot(filePath: string | null): string | null {
+  if (!filePath) return null
+  const marker = '/prompts/'
+  const idx = filePath.indexOf(marker)
+  if (idx < 0) return null
+  return filePath.slice(0, idx + marker.length - 1)
+}
+
+function laneTone(lane: AssemblyLane): StatusChipTone {
+  switch (lane) {
+    case 'extra_system_context':
+    case 'oas_hook':
+      return 'warn'
+    case 'system_prompt':
+      return 'bad'
+    case 'manifest':
+      return 'info'
+    case 'registry':
+      return 'ok'
+    default:
+      return 'neutral'
+  }
+}
+
+function severityTone(severity: WarningSeverity): StatusChipTone {
+  if (severity === 'critical') return 'bad'
+  if (severity === 'warn') return 'warn'
+  return 'info'
+}
+
+export function buildKeeperPromptAssemblyReport(
+  prompts: DashboardPromptItem[],
+): KeeperPromptAssemblyReport {
+  const promptByKey = new Map(prompts.map(prompt => [prompt.key, prompt]))
+  const rows: KeeperPromptAssemblyRow[] = []
+
+  for (const stage of STAGES) {
+    if (stage.promptKeys.length === 0) {
+      rows.push({
+        id: `${stage.id}:computed`,
+        order: stage.order,
+        title: stage.title,
+        lane: stage.lane,
+        timing: stage.timing,
+        injection: stage.injection,
+        codeSite: stage.codeSite,
+        promptKey: '(computed)',
+        source: 'computed',
+        hasOverride: false,
+        filePath: null,
+        bytes: 0,
+        estimatedTokens: 0,
+        fingerprint: '-',
+        missing: false,
+      })
+      continue
+    }
+
+    for (const promptKey of stage.promptKeys) {
+      const prompt = promptByKey.get(promptKey)
+      const text = promptText(prompt)
+      rows.push({
+        id: `${stage.id}:${promptKey}`,
+        order: stage.order,
+        title: stage.title,
+        lane: stage.lane,
+        timing: stage.timing,
+        injection: stage.injection,
+        codeSite: stage.codeSite,
+        promptKey,
+        source: prompt?.source ?? 'missing',
+        hasOverride: prompt?.has_override ?? false,
+        filePath: prompt?.file_path ?? null,
+        bytes: textByteLength(text),
+        estimatedTokens: estimateTokens(text),
+        fingerprint: text ? shortFingerprint(text) : '-',
+        missing: !prompt || prompt.source === 'missing',
+      })
+    }
+  }
+
+  const keeperPrompts = prompts.filter(prompt =>
+    prompt.key.startsWith('keeper.') || prompt.key.startsWith('behavior.'),
+  )
+  const warnings: KeeperPromptAssemblyWarning[] = []
+
+  for (const rule of STALE_RULES) {
+    const hits = keeperPrompts
+      .filter(prompt => rule.pattern.test(promptText(prompt)))
+      .map(prompt => prompt.key)
+      .sort()
+    if (hits.length === 0) continue
+    warnings.push({
+      id: rule.id,
+      severity: rule.severity,
+      title: rule.title,
+      detail: `${hits.length} prompt(s) still contain ${rule.id}.`,
+      promptKeys: hits,
+      expected: rule.expected,
+    })
+  }
+
+  for (const term of DUPLICATED_TOOL_TERMS) {
+    const hits = keeperPrompts
+      .filter(prompt => promptText(prompt).includes(term))
+      .map(prompt => prompt.key)
+      .sort()
+    if (hits.length <= 2) continue
+    warnings.push({
+      id: `duplicate:${term}`,
+      severity: 'info',
+      title: `Duplicated tool guidance: ${term}`,
+      detail: `${term} appears across ${hits.length} Keeper/behavior prompts.`,
+      promptKeys: hits,
+      expected: 'Keep generic tool grammar in one canonical prompt and leave persona/runtime files to add only local policy.',
+    })
+  }
+
+  const activePromptRoots = Array.from(
+    new Set(
+      prompts
+        .map(prompt => promptRoot(prompt.file_path))
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ).sort()
+
+  const promptBytes = rows.reduce((sum, row) => sum + row.bytes, 0)
+  const estimatedTokens = rows.reduce((sum, row) => sum + row.estimatedTokens, 0)
+  const criticalCount = warnings.filter(warning => warning.severity === 'critical').length
+
+  return {
+    rows,
+    warnings,
+    activePromptRoots,
+    stats: {
+      totalRows: rows.length,
+      overrideRows: rows.filter(row => row.hasOverride).length,
+      missingRows: rows.filter(row => row.missing).length,
+      warningCount: warnings.length,
+      criticalCount,
+      promptBytes,
+      estimatedTokens,
+    },
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return '-'
+  if (bytes < 1024) return `${bytes} B`
+  return `${(bytes / 1024).toFixed(1)} KiB`
+}
+
+function PromptAssemblyContent({ report, compact = false }: { report: KeeperPromptAssemblyReport; compact?: boolean }) {
+  const hotspotRows = report.rows.filter(row =>
+    row.lane === 'extra_system_context' || row.lane === 'oas_hook' || row.hasOverride || row.missing,
+  )
+  const visibleRows = compact ? hotspotRows.slice(0, 12) : report.rows
+
+  return html`
+    <div
+      class="rounded-[var(--r-1)] border border-[var(--warn-30)] p-4"
+      style="background:linear-gradient(135deg,var(--bad-10),var(--warn-8) 48%,var(--accent-8));"
+    >
+      <div class="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div class="mb-1 flex items-center gap-2">
+            <${Route} size=${16} class="text-[var(--color-status-warn)]" />
+            <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">Keeper 최종 프롬프트 조립표</h3>
+            <${StatusChip} tone=${report.stats.criticalCount > 0 ? 'bad' : report.stats.warningCount > 0 ? 'warn' : 'ok'}>
+              ${report.stats.criticalCount > 0 ? 'critical drift' : report.stats.warningCount > 0 ? 'watch drift' : 'clean'}
+            <//>
+          </div>
+          <p class="m-0 max-w-3xl text-xs leading-relaxed text-[var(--color-fg-muted)]">
+            system prompt, user/world message, OAS extra_system_context, tool hook가 어느 순서로 합쳐지는지 보여줍니다.
+            byte/fingerprint는 현재 effective prompt 기준입니다.
+          </p>
+        </div>
+        <div class="grid grid-cols-2 gap-2 text-right sm:grid-cols-4">
+          <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+            <div class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">rows</div>
+            <div class="font-mono text-sm text-[var(--color-fg-secondary)]">${report.stats.totalRows}</div>
+          </div>
+          <div class="rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2">
+            <div class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-status-warn)]">warnings</div>
+            <div class="font-mono text-sm text-[var(--color-status-warn)]">${report.stats.warningCount}</div>
+          </div>
+          <div class="rounded-[var(--r-1)] border border-[var(--bad-20)] bg-[var(--bad-10)] px-3 py-2">
+            <div class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--bad-light)]">critical</div>
+            <div class="font-mono text-sm text-[var(--bad-light)]">${report.stats.criticalCount}</div>
+          </div>
+          <div class="rounded-[var(--r-1)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-3 py-2">
+            <div class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">est tokens</div>
+            <div class="font-mono text-sm text-[var(--color-accent-fg)]">${report.stats.estimatedTokens.toLocaleString()}</div>
+          </div>
+        </div>
+      </div>
+
+      ${report.activePromptRoots.length > 0 ? html`
+        <div class="mb-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+          <div class="mb-1 flex items-center gap-2 text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+            <${GitCompareArrows} size=${13} />
+            active prompt root
+          </div>
+          <div class="flex flex-col gap-1">
+            ${report.activePromptRoots.map(root => html`
+              <code class="break-all text-2xs text-[var(--color-fg-secondary)]">${root}</code>
+            `)}
+          </div>
+        </div>
+      ` : null}
+
+      ${report.warnings.length > 0 ? html`
+        <div class="mb-4 grid gap-2">
+          ${report.warnings.map(warning => html`
+            <div class="rounded-[var(--r-1)] border ${warning.severity === 'critical'
+              ? 'border-[var(--bad-30)] bg-[var(--bad-10)]'
+              : warning.severity === 'warn'
+                ? 'border-[var(--warn-30)] bg-[var(--warn-10)]'
+                : 'border-[var(--accent-20)] bg-[var(--accent-10)]'} px-3 py-2">
+              <div class="mb-1 flex flex-wrap items-center gap-2">
+                <${warning.severity === 'critical' ? ShieldAlert : AlertTriangle} size=${14} />
+                <span class="text-xs font-semibold text-[var(--color-fg-primary)]">${warning.title}</span>
+                <${StatusChip} tone=${severityTone(warning.severity)}>${warning.severity}<//>
+              </div>
+              <div class="text-2xs leading-relaxed text-[var(--color-fg-muted)]">${warning.detail} ${warning.expected}</div>
+              <div class="mt-1 flex flex-wrap gap-1">
+                ${warning.promptKeys.map(key => html`
+                  <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 font-mono text-3xs text-[var(--color-fg-secondary)]">${key}</span>
+                `)}
+              </div>
+            </div>
+          `)}
+        </div>
+      ` : null}
+
+      <div class="overflow-x-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
+        <table class="min-w-[980px] w-full border-collapse text-left text-2xs">
+          <thead class="bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)]">
+            <tr>
+              <th class="px-3 py-2 font-semibold uppercase tracking-[var(--track-caps)]">stage</th>
+              <th class="px-3 py-2 font-semibold uppercase tracking-[var(--track-caps)]">lane</th>
+              <th class="px-3 py-2 font-semibold uppercase tracking-[var(--track-caps)]">prompt/source</th>
+              <th class="px-3 py-2 font-semibold uppercase tracking-[var(--track-caps)]">injection</th>
+              <th class="px-3 py-2 font-semibold uppercase tracking-[var(--track-caps)]">size</th>
+              <th class="px-3 py-2 font-semibold uppercase tracking-[var(--track-caps)]">fingerprint</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${visibleRows.map(row => html`
+              <tr class="border-t border-[var(--color-border-default)] ${row.hasOverride
+                ? 'bg-[var(--warn-8)]'
+                : row.missing
+                  ? 'bg-[var(--bad-8)]'
+                  : ''}">
+                <td class="px-3 py-2 align-top">
+                  <div class="font-mono text-[var(--color-fg-disabled)]">#${row.order}</div>
+                  <div class="text-xs font-medium text-[var(--color-fg-primary)]">${row.title}</div>
+                  <div class="mt-1 text-3xs text-[var(--color-fg-muted)]">${row.timing}</div>
+                </td>
+                <td class="px-3 py-2 align-top">
+                  <${StatusChip} tone=${laneTone(row.lane)} uppercase=${false}>${row.lane}<//>
+                  <div class="mt-1 font-mono text-3xs text-[var(--color-fg-disabled)]">${row.codeSite}</div>
+                </td>
+                <td class="px-3 py-2 align-top">
+                  <div class="font-mono text-xs text-[var(--color-fg-secondary)]">${row.promptKey}</div>
+                  <div class="mt-1 flex flex-wrap gap-1">
+                    <${StatusChip} tone=${row.missing ? 'bad' : row.hasOverride ? 'warn' : row.source === 'file' ? 'ok' : 'neutral'}>${row.source}<//>
+                    ${row.hasOverride ? html`<${StatusChip} tone="warn">override<//>` : null}
+                  </div>
+                  ${row.filePath ? html`<div class="mt-1 max-w-[260px] truncate font-mono text-3xs text-[var(--color-fg-disabled)]" title=${row.filePath}>${row.filePath}</div>` : null}
+                </td>
+                <td class="px-3 py-2 align-top text-xs leading-relaxed text-[var(--color-fg-muted)]">${row.injection}</td>
+                <td class="px-3 py-2 align-top font-mono text-xs text-[var(--color-fg-secondary)]">
+                  <div>${formatBytes(row.bytes)}</div>
+                  <div class="text-3xs text-[var(--color-fg-disabled)]">${row.estimatedTokens ? `${row.estimatedTokens.toLocaleString()} tok est` : '-'}</div>
+                </td>
+                <td class="px-3 py-2 align-top font-mono text-xs text-[var(--color-fg-secondary)]">${row.fingerprint}</td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
+
+      ${compact && hotspotRows.length > visibleRows.length ? html`
+        <div class="mt-2 text-2xs text-[var(--color-fg-muted)]">
+          Showing ${visibleRows.length} hotspot rows out of ${hotspotRows.length}. Open Prompt Registry for the full assembly table.
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
+export function KeeperPromptAssemblyPanel({
+  compact = false,
+  prompts: providedPrompts,
+}: {
+  compact?: boolean
+  prompts?: DashboardPromptItem[]
+}) {
+  const [loadedPrompts, setLoadedPrompts] = useState<DashboardPromptItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const ownsFetch = providedPrompts == null
+
+  async function load() {
+    if (!ownsFetch) return
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetchDashboardPrompts()
+      setLoadedPrompts(response.prompts ?? [])
+    } catch (err) {
+      setError(errorToString(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (ownsFetch) void load()
+  }, [ownsFetch])
+
+  const report = buildKeeperPromptAssemblyReport(providedPrompts ?? loadedPrompts)
+
+  return html`
+    <div class="mb-5" data-keeper-prompt-assembly-panel>
+      <div class="mb-2 flex items-center justify-between gap-3">
+        <div class="flex items-center gap-2">
+          <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">Prompt Assembly</span>
+          ${loading ? html`<${StatusChip} tone="info">loading<//>` : null}
+        </div>
+        ${ownsFetch ? html`
+          <${ActionButton} variant="ghost" size="sm" disabled=${loading} onClick=${() => { void load() }}>
+            <${RefreshCw} size=${12} />
+            ${loading ? '새로고침 중' : '새로고침'}
+          <//>
+        ` : null}
+      </div>
+      ${error ? html`<${ErrorState} message=${error} class="mb-3" />` : null}
+      <${PromptAssemblyContent} report=${report} compact=${compact} />
+    </div>
+  `
+}

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -16,6 +16,7 @@ import { TextArea, TextInput } from '../common/input'
 import { FilterChips } from '../common/filter-chips'
 import { StatusChip } from '../common/status-chip'
 import { errorToString } from '../../lib/format-string'
+import { KeeperPromptAssemblyPanel } from '../keeper-prompt-assembly-panel'
 
 type PromptSourceFilter = 'all' | PromptSource
 
@@ -171,6 +172,8 @@ export function PromptRegistryPanel() {
         <div>기준 원문은 resolved config root의 <code>prompts/*.md</code>입니다. 경로는 설정 경로 상세 패널에서 확인할 수 있습니다.</div>
         <div>이 화면에서는 현재 effective 값 확인과 runtime override 적용/해제만 합니다.</div>
       </div>
+
+      <${KeeperPromptAssemblyPanel} prompts=${prompts} />
 
       ${error ? html`<${ErrorState} message=${error} class="mb-4" />` : null}
       ${status ? html`<div class="mb-4 rounded-[var(--r-1)] border border-[var(--sky-28)] bg-[var(--sky-8)] px-3 py-2 text-xs text-[var(--sky-light)]">${status}</div>` : null}

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -57,6 +57,8 @@ export function Tools() {
         runtimeResolution=${data?.runtime_resolution}
       />
 
+      <${PromptRegistryPanel} />
+
       <${SectionCard} label="시스템 도구 목록" class="section mb-4">
         <${FullInventoryView}
           inventory=${inventory}
@@ -97,7 +99,6 @@ export function Tools() {
           </div>`
         : null}
 
-      <${PromptRegistryPanel} />
     </div>`}
     </div>
   `

--- a/docs/audit/keeper-prompt-assembly-visibility-2026-06-12.html
+++ b/docs/audit/keeper-prompt-assembly-visibility-2026-06-12.html
@@ -1,0 +1,254 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Keeper Prompt Assembly Visibility Audit</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #080b10;
+      --panel: #101620;
+      --panel-2: #151e2b;
+      --text: #e7edf7;
+      --muted: #94a3b8;
+      --line: #273449;
+      --hot: #f97316;
+      --warn: #fbbf24;
+      --bad: #fb7185;
+      --ok: #34d399;
+      --info: #38bdf8;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.55 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main { max-width: 1160px; margin: 0 auto; padding: 28px 20px 48px; }
+    header {
+      border: 1px solid rgba(249, 115, 22, .42);
+      background: linear-gradient(135deg, rgba(249, 115, 22, .18), rgba(56, 189, 248, .08));
+      padding: 22px;
+      border-radius: 8px;
+    }
+    h1, h2, h3 { margin: 0; line-height: 1.15; }
+    h1 { font-size: clamp(28px, 4vw, 48px); letter-spacing: 0; }
+    h2 { margin-top: 30px; font-size: 22px; }
+    h3 { margin-top: 18px; font-size: 16px; color: var(--info); }
+    p { color: var(--muted); }
+    .lede { max-width: 860px; margin: 12px 0 0; color: #d7e2ef; font-size: 15px; }
+    .grid { display: grid; gap: 12px; }
+    .grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .card {
+      border: 1px solid var(--line);
+      background: var(--panel);
+      border-radius: 8px;
+      padding: 14px;
+    }
+    .metric { font: 700 26px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .metric.warn { color: var(--warn); }
+    .metric.bad { color: var(--bad); }
+    .metric.ok { color: var(--ok); }
+    .label { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+    table { width: 100%; border-collapse: collapse; margin-top: 12px; overflow: hidden; border-radius: 8px; }
+    th, td { border: 1px solid var(--line); padding: 9px 10px; text-align: left; vertical-align: top; }
+    th { background: var(--panel-2); color: #cbd5e1; font-size: 12px; text-transform: uppercase; letter-spacing: .06em; }
+    td { background: rgba(16, 22, 32, .72); }
+    code {
+      color: #f8fafc;
+      background: rgba(148, 163, 184, .14);
+      border: 1px solid rgba(148, 163, 184, .2);
+      padding: 1px 5px;
+      border-radius: 4px;
+      font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 2px 7px;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: .04em;
+      margin: 0 4px 4px 0;
+      color: #cbd5e1;
+      background: rgba(148, 163, 184, .08);
+    }
+    .tag.bad { border-color: rgba(251, 113, 133, .35); color: var(--bad); background: rgba(251, 113, 133, .12); }
+    .tag.warn { border-color: rgba(251, 191, 36, .35); color: var(--warn); background: rgba(251, 191, 36, .12); }
+    .tag.ok { border-color: rgba(52, 211, 153, .35); color: var(--ok); background: rgba(52, 211, 153, .10); }
+    .callout {
+      border-left: 4px solid var(--hot);
+      background: rgba(249, 115, 22, .10);
+      padding: 12px 14px;
+      margin-top: 14px;
+      border-radius: 6px;
+    }
+    ol, ul { padding-left: 20px; }
+    li { margin: 6px 0; color: var(--d7e2ef, #d7e2ef); }
+    @media (max-width: 860px) {
+      .grid-4, .grid-2 { grid-template-columns: 1fr; }
+      main { padding: 18px 12px 32px; }
+      table { font-size: 12px; }
+      th, td { padding: 7px; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <div class="label">MASC Keeper Prompt Assembly Audit · 2026-06-12</div>
+    <h1>Keeper 최종 삽입 프롬프트가 보이지 않는 문제</h1>
+    <p class="lede">
+      현재 dashboard는 프롬프트 파일과 override 편집은 보여주지만, 실제 Keeper turn에서 어떤 조각이
+      system prompt, user/world message, OAS extra_system_context, tool policy로 흘러 들어가는지 한 화면에
+      보여주지 않는다. 이 문서는 첫 PR의 목표 UI와 stale tool guidance 정리 기준을 고정한다.
+    </p>
+  </header>
+
+  <h2>확인된 현재 상태</h2>
+  <div class="grid grid-4">
+    <section class="card">
+      <div class="label">Runtime</div>
+      <div class="metric ok">0.19.40</div>
+      <p>Live server는 <code>/health?full=1</code> 기준 정상 응답.</p>
+    </section>
+    <section class="card">
+      <div class="label">Runtime commit</div>
+      <div class="metric">3f337cf12</div>
+      <p>실행 중 binary/repo head 확인값.</p>
+    </section>
+    <section class="card">
+      <div class="label">Active prompt root</div>
+      <div class="metric warn">.masc</div>
+      <p><code>/Users/dancer/me/.masc/config/prompts</code>가 live source.</p>
+    </section>
+    <section class="card">
+      <div class="label">Repo/live drift</div>
+      <div class="metric bad">8</div>
+      <p>주요 Keeper prompt 파일 8개가 repo seed와 live runtime 사이에서 다름.</p>
+    </section>
+  </div>
+
+  <h2>최종 조립 경로</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>순서</th>
+        <th>주입 lane</th>
+        <th>무엇이 들어가나</th>
+        <th>대표 소스</th>
+        <th>현재 가시성</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td><span class="tag ok">registry</span></td>
+        <td>Config root, prompt markdown, runtime override를 로딩한다.</td>
+        <td><code>Prompt_defaults.bootstrap_runtime</code>, <code>/api/v1/prompts</code></td>
+        <td>Prompt Registry에서 일부 확인 가능.</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td><span class="tag">system</span></td>
+        <td>core behavior, profile policy, continuity, constitution, world, capabilities, identity/persona/goals.</td>
+        <td><code>Keeper_prompt.build_keeper_system_prompt</code></td>
+        <td>최종 조립표 없음. 파일별로 흩어짐.</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td><span class="tag">user/world</span></td>
+        <td>unified system framing, turn intent, current world state, claimable work, board activity.</td>
+        <td><code>Keeper_unified_prompt.build_prompt</code></td>
+        <td>Prompt telemetry는 있으나 provenance 없음.</td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td><span class="tag warn">extra_system_context</span></td>
+        <td>continuity snapshot, durable memory, skill route, worktree, telemetry feedback, turn instruction.</td>
+        <td><code>Keeper_turn.build_turn_prompt</code></td>
+        <td>가장 중요한데 operator UI에서 거의 안 보임.</td>
+      </tr>
+      <tr>
+        <td>5</td>
+        <td><span class="tag warn">OAS hook</span></td>
+        <td>temporal summary, claimed-task nudge, retry hint, Memory OS recall, tool filter/choice.</td>
+        <td><code>Keeper_run_tools_hooks.before_turn_params</code></td>
+        <td>digest/size 중심. 사람이 읽는 조립표 없음.</td>
+      </tr>
+      <tr>
+        <td>6</td>
+        <td><span class="tag">manifest</span></td>
+        <td>context_injected edge와 prompt metrics가 기록된다.</td>
+        <td><code>Keeper_agent_run.append_manifest</code></td>
+        <td>edge는 있으나 segment provenance가 부족.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Stale tool guidance 위험</h2>
+  <div class="callout">
+    <strong>핵심 문제:</strong> tool 사용법이 prompt, live .masc config, keeper TOML, tool hints에 중복되어 있고
+    일부는 실제 public alias나 argument shape와 어긋난다. 모델 성격 변화처럼 보이는 현상 중 일부는 이 지침 drift로 설명된다.
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th>패턴</th>
+        <th>관찰된 예</th>
+        <th>위험</th>
+        <th>정리 방향</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Retired alias</td>
+        <td><code>keeper_board_get</code> vs <code>keeper_board_post_get</code></td>
+        <td>없는 도구 호출, 같은 실패 반복.</td>
+        <td>active schema/public alias 기준 linter.</td>
+      </tr>
+      <tr>
+        <td>Stale args</td>
+        <td><code>keeper_task_done { notes }</code> vs <code>{ task_id, result }</code></td>
+        <td>완료 보고 실패, task oscillation.</td>
+        <td><code>keeper.tool_hints.toml</code>을 schema example SSOT로 제한.</td>
+      </tr>
+      <tr>
+        <td>Conflicting PR flow</td>
+        <td><code>keeper_pr_create</code> 지침과 Execute typed argv 지침 공존</td>
+        <td>모델이 금지/허용 경계를 혼동.</td>
+        <td>Keeper TOML에는 persona만, 공통 tool grammar 제거.</td>
+      </tr>
+      <tr>
+        <td>Hardcoded path</td>
+        <td><code>repos/masc/lib/foo.ml</code></td>
+        <td>worktree-first 정책 위반, stale path probe.</td>
+        <td><code>repos/REPO_NAME/.worktrees/TASK_NAME</code> 예시로 통일.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>첫 PR 개선 목표</h2>
+  <ol>
+    <li>Keeper detail 화면에 aggressive prompt assembly 패널을 추가한다.</li>
+    <li>Prompt Registry 상단에도 Keeper assembly/stale guidance 요약을 노출한다.</li>
+    <li>각 row는 stage, lane, source prompt, source type, override 상태, byte size, risk를 보여준다.</li>
+    <li>stale alias/args/path/PR-flow warning을 prompt effective text에서 즉시 스캔한다.</li>
+    <li>다음 PR에서 runtime manifest에 segment provenance를 추가할 수 있도록 UI 용어를 고정한다.</li>
+  </ol>
+
+  <h2>Done 기준</h2>
+  <ul>
+    <li>Operator가 Keeper detail에서 최종 삽입 경로를 표로 본다.</li>
+    <li>Override가 최종 prompt에 영향을 주는지 source badge로 바로 보인다.</li>
+    <li>Live .masc prompt가 stale tool guidance를 품으면 dashboard가 경고한다.</li>
+    <li>HTML audit artifact가 PR에 포함되어 review context를 제공한다.</li>
+  </ul>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a Keeper prompt assembly panel that shows how Keeper prompt material flows through registry bootstrap, system prompt, user/world prompt, OAS extra_system_context, pre-turn hooks, and manifest recording.
- Surfaces stale tool guidance warnings from the active prompt registry, including retired aliases, stale argument shapes, conflicting PR-flow guidance, hardcoded repo paths, and duplicated tool grammar.
- Promotes Prompt Registry higher in the Tools page and also places a compact assembly audit in Keeper detail near context/prompt telemetry.
- Adds a standalone HTML audit artifact at `docs/audit/keeper-prompt-assembly-visibility-2026-06-12.html`.

## Why

Operators could edit prompt files and overrides, but could not see where the final Keeper prompt was assembled or which prompt fragments were actually contributing to the final injected context. This made prompt drift and stale tool usage look like model/personality drift.

## Notes

- This first slice uses the existing `/api/v1/prompts` endpoint for effective/file/override prompt data.
- Runtime manifest segment provenance is intentionally left for a follow-up backend slice.
- MASC records created: goal `goal-keeper-prompt-assembly-visibility`, task `task-905`.

## Validation

- `pnpm run typecheck`
- `pnpm exec vitest run --config vitest.config.ts src/components/keeper-prompt-assembly-panel.test.ts src/components/tools/prompt-registry-panel.test.ts src/components/tools/tools-main.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/keeper-prompt-assembly-panel.ts src/components/keeper-prompt-assembly-panel.test.ts src/components/keeper-detail-body.ts src/components/tools/prompt-registry-panel.ts src/components/tools/tools-main.ts`
  - test file is ignored by the repo ESLint config; changed source files had no lint errors.
- `pnpm run build`
- Playwright desktop/mobile smoke against `http://127.0.0.1:5187/dashboard/#lab?section=tools`
  - Verified the prompt assembly panel rendered and contained `Keeper 최종 프롬프트 조립표`, `Registry bootstrap`, `OAS pre-turn hook`, and `ACTIVE PROMPT ROOT`.
  - Existing runtime console warnings were observed for SSE schema drift / dashboard runtime health, unrelated to this panel.
