### PR TITLE
perf(gc): lower space_overhead 200→100 for shorter major GC pauses

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -59,7 +59,11 @@ let () =
     let ctrl = get () in
     set { ctrl with
       minor_heap_size = 2 * 1024 * 1024;  (* 2M words = 16MB on 64-bit; reduces minor->major promotion rate *)
-      space_overhead = 200;               (* default 120; less frequent major GC slices *)
+      space_overhead = 100;               (* default 120; triggers major GC when free > live (was 200/3x).
+                                             Lower value = shorter individual pauses at the cost of more
+                                             frequent GC slices.  P0 allocation fixes (PR #20965) reduced
+                                             broadcast hot-path allocation by ~97%, so the increased GC
+                                             frequency has negligible throughput impact. *)
       max_overhead = 500;                 (* compaction triggers when free memory exceeds 500% of live data *)
     }
   end


### PR DESCRIPTION
Lower OCaml major GC space_overhead from 200 to 100 (below default 120).

Triggers major GC when heap reaches 2x live data instead of 3x. Individual pauses are shorter because there is less to collect. P0 allocation fixes (PR #20965) reduced broadcast hot-path allocation by ~97%, so increased GC frequency has negligible throughput impact.

| Setting | Before | After |
|---------|--------|-------|
| space_overhead | 200 (heap 3x live) | 100 (heap 2x live) |
| Expected GC pause | seconds on 2-3GB heap | sub-second |

Refs: task-902, goal masc-transport-gc-storm

🤖 Generated with [Claude Code](https://claude.com/claude-code)