### PR TITLE
feat(dashboard): show character/byte counters on keeper prompt fields

### DIFF
--- a/dashboard/src/components/common/expandable-textarea.ts
+++ b/dashboard/src/components/common/expandable-textarea.ts
@@ -10,6 +10,10 @@ import { useEffect, useState } from 'preact/hooks'
 export const EXPANDABLE_TEXTAREA_STYLE =
   'w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded-[var(--r-1)] py-2 px-3 font-mono focus:outline-none focus:border-accent-fg/50 focus:ring-1 focus:ring-accent-fg/50 transition-[border-color,box-shadow] duration-[var(--t-med)] shadow-inset resize-y custom-scrollbar'
 
+function byteLength(s: string): number {
+  return new TextEncoder().encode(s).length
+}
+
 export function ExpandableTextarea({
   value,
   onChange,
@@ -17,6 +21,8 @@ export function ExpandableTextarea({
   rows = 6,
   placeholder = '',
   dirty = false,
+  maxBytes,
+  maxChars,
 }: {
   value: string
   onChange: (value: string) => void
@@ -24,6 +30,8 @@ export function ExpandableTextarea({
   rows?: number
   placeholder?: string
   dirty?: boolean
+  maxBytes?: number
+  maxChars?: number
 }) {
   const [local, setLocal] = useState(value)
   const [expanded, setExpanded] = useState(false)
@@ -42,6 +50,33 @@ export function ExpandableTextarea({
     ? 'border-l-4 border-l-[var(--color-accent-fg)]'
     : ''
 
+  const charCount = local.length
+  const byteCount = byteLength(local)
+  const overLimit = (maxBytes !== undefined && byteCount > maxBytes)
+    || (maxChars !== undefined && charCount > maxChars)
+  const nearLimit = !overLimit
+    && ((maxBytes !== undefined && byteCount > maxBytes * 0.9)
+      || (maxChars !== undefined && charCount > maxChars * 0.9))
+
+  let countLabel = ''
+  if (maxBytes !== undefined) {
+    countLabel = `${byteCount.toLocaleString()} / ${maxBytes.toLocaleString()} bytes`
+  } else if (maxChars !== undefined) {
+    countLabel = `${charCount.toLocaleString()} / ${maxChars.toLocaleString()} 글자`
+  } else {
+    countLabel = `${charCount.toLocaleString()} 글자`
+  }
+
+  const countColor = overLimit
+    ? 'text-[var(--color-status-error)]'
+    : nearLimit
+      ? 'text-[var(--color-status-warn)]'
+      : 'text-[var(--color-fg-muted)]'
+
+  const CountHint = () => html`
+    <span class="text-3xs ${countColor} font-medium">${countLabel}</span>
+  `
+
   return html`
     <div class="relative">
       <textarea
@@ -55,6 +90,9 @@ export function ExpandableTextarea({
         onBlur=${(e: Event) =>
           commit((e.target as HTMLTextAreaElement).value)}
       />
+      <div class="flex justify-end mt-1">
+        <${CountHint} />
+      </div>
       <button
         type="button"
         class="absolute top-2 right-2 rounded-[var(--r-0)] bg-[var(--color-bg-surface)] border border-card-border px-1.5 py-0.5 text-3xs text-[var(--color-fg-muted)] hover:text-text-strong hover:bg-[var(--color-bg-hover)] transition-colors"
@@ -92,14 +130,16 @@ export function ExpandableTextarea({
                   onInput=${(e: Event) =>
                     setLocal((e.target as HTMLTextAreaElement).value)}
                 />
-                <div class="flex justify-end gap-2 mt-3">
-                  <button
-                    type="button"
-                    class="px-3 py-1.5 rounded-[var(--r-1)] text-2xs bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]"
-                    onClick=${() => setExpanded(false)}
-                  >
-                    취소
-                  </button>
+                <div class="flex items-center justify-between gap-2 mt-3">
+                  <${CountHint} />
+                  <div class="flex gap-2">
+                    <button
+                      type="button"
+                      class="px-3 py-1.5 rounded-[var(--r-1)] text-2xs bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]"
+                      onClick=${() => setExpanded(false)}
+                    >
+                      취소
+                    </button>
                   <button
                     type="button"
                     class="px-3 py-1.5 rounded-[var(--r-1)] text-2xs bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)]"
@@ -110,6 +150,7 @@ export function ExpandableTextarea({
                   >
                     확인
                   </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -580,7 +580,19 @@ function updateDraft(field: keyof EditDraft, value: string | boolean | number) {
   editDraft.value = { ...d, [field]: value }
 }
 
-function EditTextarea({ field, label, rows = 6 }: { field: keyof EditDraft; label: string; rows?: number }) {
+function EditTextarea({
+  field,
+  label,
+  rows = 6,
+  maxBytes,
+  maxChars,
+}: {
+  field: keyof EditDraft
+  label: string
+  rows?: number
+  maxBytes?: number
+  maxChars?: number
+}) {
   const d = editDraft.value
   if (!d) return null
   const val = d[field] as string
@@ -597,6 +609,8 @@ function EditTextarea({ field, label, rows = 6 }: { field: keyof EditDraft; labe
         value=${val}
         rows=${rows}
         dirty=${dirty}
+        maxBytes=${maxBytes}
+        maxChars=${maxChars}
         onChange=${(value: string) => updateDraft(field, value)}
       />
     </div>
@@ -752,13 +766,13 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   // --- Prompt section (editable) ---
   const promptSection = isEditing ? html`
     <${MajorSectionHeader} title="프롬프트 (편집)" />
-    <${EditTextarea} field="goal" label="목표" rows=${8} />
-    <${EditTextarea} field="short_goal" label="단기 목표" rows=${5} />
-    <${EditTextarea} field="mid_goal" label="중기 목표" rows=${5} />
-    <${EditTextarea} field="long_goal" label="장기 목표" rows=${5} />
-    <${EditTextarea} field="will" label="의지" rows=${4} />
-    <${EditTextarea} field="needs" label="필요" rows=${4} />
-    <${EditTextarea} field="desires" label="욕구" rows=${4} />
+    <${EditTextarea} field="goal" label="목표" rows=${8} maxChars=${4096} />
+    <${EditTextarea} field="short_goal" label="단기 목표" rows=${5} maxChars=${4096} />
+    <${EditTextarea} field="mid_goal" label="중기 목표" rows=${5} maxChars=${4096} />
+    <${EditTextarea} field="long_goal" label="장기 목표" rows=${5} maxChars=${4096} />
+    <${EditTextarea} field="will" label="의지" rows=${4} maxBytes=${4096} />
+    <${EditTextarea} field="needs" label="필요" rows=${4} maxBytes=${4096} />
+    <${EditTextarea} field="desires" label="욕구" rows=${4} maxBytes=${4096} />
     <${EditTextarea} field="instructions" label="지시사항" rows=${10} />
   ` : html`
     <${MajorSectionHeader} title="프롬프트" />


### PR DESCRIPTION
## What
Adds live length indicators to the keeper prompt editor so operators can see when a field is approaching the server's parse-time cap.

## Change
- `ExpandableTextarea` accepts optional `maxBytes` / `maxChars` props and renders a live count hint (e.g. `1,234 / 4,096 bytes`).
- Goal horizon fields use `maxChars=4096`.
- `will/needs/desires` use `maxBytes=4096`, matching the new server-side caps in #20966.
- Counters turn warning color when >90% of the limit and error color when over.

## Verification
- `pnpm typecheck` passes.
- `pnpm lint` passes.

## Related
- #20955 — editor UX (merged)
- #20966 — server-side cap increase
