### PR TITLE
fix(bootstrap): use parent switch directly, remove nested Eio.Switch.run

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -450,16 +450,15 @@ let make_extended_handler routes =
       | None -> try_internal_error_response reqd msg)
 
 (** Main server loop *)
-let run_server ~sw:_ ~env ~host ~port ~base_path =
-  (* Use a dedicated sub-switch so that ALL fibers spawned by
+let run_server ~sw ~env ~host ~port ~base_path =
+  (* Use the parent switch directly so that ALL fibers spawned by
      Server_runtime_bootstrap (background maintenance, keeper loops,
      dashboard refresh, etc.) are children of this switch.  When
      Eio.Fiber.first cancels the run_server fiber on SIGTERM, the
-     sub-switch is cancelled too, which propagates Cancel to every
+     switch is cancelled too, which propagates Cancel to every
      child fiber — preventing the 10s force-exit timeout. *)
-  Eio.Switch.run @@ fun server_sw ->
   try
-    Server_runtime_bootstrap.run ~sw:server_sw ~env ~host ~port ~base_path ~make_routes
+    Server_runtime_bootstrap.run ~sw ~env ~host ~port ~base_path ~make_routes
       ~make_request_handler:make_extended_handler
       ~make_h2_request_handler:Server_h2_gateway.make_request_handler
       ~make_h2_error_handler:Server_h2_gateway.make_error_handler


### PR DESCRIPTION
## Problem

The `run_server` function was ignoring the parent switch (`~sw:_`) and creating its own sub-switch via `Eio.Switch.run`. This meant that when the parent switch was cancelled (e.g. on SIGTERM), the server's background fibers were not properly cleaned up, causing the 10s force-exit timeout.

## Fix

- Changed `~sw:_` to `~sw` — use the parent switch directly
- Removed the intermediate `Eio.Switch.run @@ fun server_sw ->` layer
- Pass `~sw` directly to `Server_runtime_bootstrap.run`

All fibers are now children of the parent switch and will be properly cancelled on shutdown.

## Verification

- `Server_runtime_bootstrap.run` itself uses zero `Switch.run` calls (confirmed by code search)
- Caller at L807 already passes `~sw` — no compatibility issues
- `git diff` shows only the intended 4 insertions / 5 deletions

Closes: task-863