### PR TITLE
feat(dashboard): RFC-0233 PR-2a — session-trace single row per execution_id

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2244,6 +2244,8 @@ export type TrajectoryEntry = {
   ts: number
   ts_iso: string
   turn: number
+  // RFC-0233: canonical execution identity minted at dispatch (absent on pre-PR-1 rows)
+  execution_id?: string
   // Tool-call fields (absent on thinking entries)
   round?: number
   tool_name?: string
@@ -2543,6 +2545,8 @@ export type ToolCallEntry = {
   keeper_turn_id?: number
   task_id?: string
   lane?: string
+  // RFC-0233: canonical execution identity minted at dispatch (absent on pre-PR-1 rows)
+  execution_id?: string
 }
 
 export type ToolCallsResponse = TelemetryFreshnessMetadata & {
@@ -2593,6 +2597,7 @@ function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
     keeper_turn_id: asNumber(raw.keeper_turn_id),
     task_id: asString(raw.task_id),
     lane: asString(raw.lane),
+    execution_id: asString(raw.execution_id),
   }
 }
 

--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -334,6 +334,209 @@ describe('buildTraceEvents', () => {
     expect(events[0]!.detail.lane).toBe('runtime_mcp')
   })
 
+  it('joins trajectory and tool-call log rows on execution_id despite divergent turn vocabularies (#20910)', () => {
+    // Reproduces the double-row symptom: trajectory turn is trace-relative
+    // (0) while the log turn is session-absolute (4064). The heuristic join
+    // fails on that mismatch; the canonical execution_id must win.
+    const events = buildTraceEvents(
+      {
+        agent: 'test',
+        period: { from: '', to: '' },
+        events: [],
+        summary: { tasks_completed: 0, tasks_claimed: 0, messages_sent: 0, active_duration_minutes: 0, total_events: 0 },
+      },
+      {
+        keeper: 'test',
+        trace_id: 'trace-1',
+        generation: 1,
+        total_entries: 1,
+        showing: 1,
+        entries: [{
+          ts: 1712397700,
+          ts_iso: '2024-04-06T10:01:40Z',
+          turn: 0,
+          round: 5,
+          tool_name: 'keeper_fs_read',
+          args: { file_path: '/tmp/trajectory.txt' },
+          result: 'trajectory result',
+          duration_ms: 50,
+          gate: { status: 'pass' },
+          cost_usd: 0.001,
+          error: null,
+          execution_id: 'exec-1712397700000-002a',
+        }],
+      },
+      {
+        keeper: 'test',
+        count: 1,
+        entries: [{
+          ts: 1712397700,
+          keeper: 'test',
+          tool: 'keeper_fs_read',
+          input: { file_path: '/tmp/full.txt' },
+          output: 'full file contents',
+          success: true,
+          duration_ms: 50,
+          trace_id: 'trace-1',
+          session_id: 'trace-1',
+          turn: 4064,
+          keeper_turn_id: 9,
+          task_id: 'task-1',
+          lane: 'runtime_mcp',
+          execution_id: 'exec-1712397700000-002a',
+        }],
+      },
+    )
+    const toolEvents = events.filter(e => e.kind === 'tool_call')
+    expect(toolEvents).toHaveLength(1)
+    expect(toolEvents[0]!.executionId).toBe('exec-1712397700000-002a')
+    expect(toolEvents[0]!.detail.trace_origin).toBe('trajectory+tool_call_log')
+    // Trace-relative T/R pair stays on the badge; absolute turn remains a detail attribute.
+    expect(toolEvents[0]!.turn).toBe(0)
+    expect(toolEvents[0]!.round).toBe(5)
+    expect(toolEvents[0]!.detail.turn).toBe(4064)
+    expect(toolEvents[0]!.toolResult).toBe('full file contents')
+  })
+
+  it('does not join rows with different execution_ids even when heuristics agree', () => {
+    const events = buildTraceEvents(
+      {
+        agent: 'test',
+        period: { from: '', to: '' },
+        events: [],
+        summary: { tasks_completed: 0, tasks_claimed: 0, messages_sent: 0, active_duration_minutes: 0, total_events: 0 },
+      },
+      {
+        keeper: 'test',
+        trace_id: 'trace-1',
+        generation: 1,
+        total_entries: 1,
+        showing: 1,
+        entries: [{
+          ts: 1712397700,
+          ts_iso: '2024-04-06T10:01:40Z',
+          turn: 1,
+          round: 1,
+          tool_name: 'keeper_fs_read',
+          args: { file_path: '/tmp/a.txt' },
+          result: 'a',
+          duration_ms: 50,
+          gate: { status: 'pass' },
+          cost_usd: 0.001,
+          error: null,
+          execution_id: 'exec-1712397700000-0001',
+        }],
+      },
+      {
+        keeper: 'test',
+        count: 1,
+        entries: [{
+          ts: 1712397700,
+          keeper: 'test',
+          tool: 'keeper_fs_read',
+          input: { file_path: '/tmp/a.txt' },
+          output: 'a',
+          success: true,
+          duration_ms: 50,
+          trace_id: 'trace-1',
+          session_id: 'trace-1',
+          turn: 1,
+          keeper_turn_id: 1,
+          lane: 'runtime_mcp',
+          execution_id: 'exec-1712397700001-0002',
+        }],
+      },
+    )
+    const toolEvents = events.filter(e => e.kind === 'tool_call')
+    expect(toolEvents).toHaveLength(2)
+  })
+
+  it('falls back to the heuristic join for pre-PR-1 rows without execution_id', () => {
+    const events = buildTraceEvents(
+      {
+        agent: 'test',
+        period: { from: '', to: '' },
+        events: [],
+        summary: { tasks_completed: 0, tasks_claimed: 0, messages_sent: 0, active_duration_minutes: 0, total_events: 0 },
+      },
+      {
+        keeper: 'test',
+        trace_id: 'trace-1',
+        generation: 1,
+        total_entries: 1,
+        showing: 1,
+        entries: [{
+          ts: 1712397700,
+          ts_iso: '2024-04-06T10:01:40Z',
+          turn: 1,
+          round: 1,
+          tool_name: 'keeper_fs_read',
+          args: { file_path: '/tmp/legacy.txt' },
+          result: 'legacy',
+          duration_ms: 50,
+          gate: { status: 'pass' },
+          cost_usd: 0.001,
+          error: null,
+        }],
+      },
+      {
+        keeper: 'test',
+        count: 1,
+        entries: [{
+          ts: 1712397700,
+          keeper: 'test',
+          tool: 'keeper_fs_read',
+          input: { file_path: '/tmp/legacy.txt' },
+          output: 'legacy full',
+          success: true,
+          duration_ms: 50,
+          trace_id: 'trace-1',
+          session_id: 'trace-1',
+          turn: 1,
+          keeper_turn_id: 1,
+          lane: 'runtime_mcp',
+        }],
+      },
+    )
+    const toolEvents = events.filter(e => e.kind === 'tool_call')
+    expect(toolEvents).toHaveLength(1)
+    expect(toolEvents[0]!.detail.trace_origin).toBe('trajectory+tool_call_log')
+  })
+
+  it('uses execution_id as the stable synthetic row id when present', () => {
+    const events = buildTraceEvents(
+      {
+        agent: 'test',
+        period: { from: '', to: '' },
+        events: [],
+        summary: { tasks_completed: 0, tasks_claimed: 0, messages_sent: 0, active_duration_minutes: 0, total_events: 0 },
+      },
+      null,
+      {
+        keeper: 'test',
+        count: 1,
+        entries: [{
+          ts: 1712397700,
+          keeper: 'test',
+          tool: 'Execute',
+          input: { cmd: 'true' },
+          output: 'ok',
+          success: true,
+          duration_ms: 10,
+          trace_id: 'trace-2',
+          session_id: 'trace-2',
+          turn: 3,
+          keeper_turn_id: 3,
+          lane: 'runtime_mcp',
+          execution_id: 'exec-1712397700000-00ff',
+        }],
+      },
+    )
+    expect(events).toHaveLength(1)
+    expect(events[0]!.id).toBe('tc-exec-1712397700000-00ff')
+    expect(events[0]!.executionId).toBe('exec-1712397700000-00ff')
+  })
+
   it('maps keeper contract verdict activity into lifecycle trace events', () => {
     const events = buildTraceEvents(
       {

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -66,6 +66,10 @@ export interface UnifiedTraceEvent {
   round?: number
   cost_usd?: number
   error?: string | null
+  // RFC-0233: canonical execution identity — same id across trajectory,
+  // tool_call log, and oas-event rows for one physical execution.
+  // Absent on rows written before PR-1 and on timeline rows.
+  executionId?: string
   // thinking fields
   thinkingContent?: string
   thinkingRedacted?: boolean
@@ -392,6 +396,7 @@ function toolCallMetadataDetail(entry: ToolCallEntry, traceOrigin: string): Reco
   if (entry.task_id) detail.task_id = entry.task_id
   if (entry.lane) detail.lane = entry.lane
   if (entry.model) detail.model = entry.model
+  if (entry.execution_id) detail.execution_id = entry.execution_id
   return detail
 }
 
@@ -419,6 +424,14 @@ function toolCallEntryMatchesTraceEvent(
 ): boolean {
   if (event.kind !== 'tool_call' || !event.toolName) return false
   if (event.gate?.status === 'reject') return false
+
+  // RFC-0233: when both sides carry the canonical execution_id, identity
+  // equality is the whole answer — the heuristic below only exists for
+  // rows written before the id was minted (no backfill by design).
+  if (entry.execution_id && event.executionId) {
+    return entry.execution_id === event.executionId
+  }
+
   if (entry.tool !== event.toolName) return false
 
   const eventTraceId = toolEventTraceId(event)
@@ -446,6 +459,7 @@ function toolCallEntryMatchesTraceEvent(
 
 function toolCallEntryMatchScore(entry: ToolCallEntry, event: UnifiedTraceEvent): number {
   let score = Math.abs(event.ts - (entry.ts * 1000))
+  if (entry.execution_id && event.executionId && entry.execution_id === event.executionId) score -= 1_000_000
   if (toolEventTraceId(event) && entry.trace_id && toolEventTraceId(event) === entry.trace_id) score -= 500
   if (toolEventSessionId(event) && entry.session_id && toolEventSessionId(event) === entry.session_id) score -= 200
   if (toolEventTurn(event) != null && (entry.turn ?? entry.keeper_turn_id) === toolEventTurn(event)) score -= 100
@@ -488,7 +502,11 @@ function enrichToolCallTrace(
     toolArgs: normalizeToolCallInput(entry.input) ?? event.toolArgs,
     toolResult: entry.success ? outputText : null,
     duration_ms: entry.duration_ms,
-    turn: entry.turn ?? entry.keeper_turn_id ?? event.turn,
+    // Trajectory turn is trace-relative and pairs with `round`; the log's
+    // session-absolute turn stays readable as detail.turn. Mixing the two
+    // vocabularies in one T#R# badge would mislabel the row.
+    turn: event.turn ?? entry.turn ?? entry.keeper_turn_id,
+    executionId: entry.execution_id ?? event.executionId,
     error,
   }
 }
@@ -497,7 +515,11 @@ function toolCallEntryToSyntheticTrace(entry: ToolCallEntry, index: number): Uni
   const ts = entry.ts * 1000
   const outputText = formatToolCallOutput(entry)
   return {
-    id: `tc-${entry.trace_id ?? 'no-trace'}-${entry.session_id ?? 'no-session'}-${entry.tool}-${Math.round(ts)}-${entry.turn ?? entry.keeper_turn_id ?? index}`,
+    // execution_id is unique per physical execution — a stable row id that
+    // survives refetch; the composite form remains for pre-PR-1 rows.
+    id: entry.execution_id
+      ? `tc-${entry.execution_id}`
+      : `tc-${entry.trace_id ?? 'no-trace'}-${entry.session_id ?? 'no-session'}-${entry.tool}-${Math.round(ts)}-${entry.turn ?? entry.keeper_turn_id ?? index}`,
     ts,
     ts_iso: new Date(ts).toISOString(),
     kind: 'tool_call',
@@ -511,6 +533,7 @@ function toolCallEntryToSyntheticTrace(entry: ToolCallEntry, index: number): Uni
     toolResult: entry.success ? outputText : null,
     duration_ms: entry.duration_ms,
     turn: entry.turn ?? entry.keeper_turn_id,
+    executionId: entry.execution_id,
     error: entry.success ? null : outputText || 'tool call failed',
   }
 }
@@ -520,6 +543,12 @@ function richerToolCallMatchesFallback(
   fallback: UnifiedTraceEvent,
 ): boolean {
   if (richer.kind !== 'tool_call' || fallback.kind !== 'tool_call') return false
+
+  // RFC-0233: canonical identity decides when both rows carry it.
+  if (richer.executionId && fallback.executionId) {
+    return richer.executionId === fallback.executionId
+  }
+
   if (!richer.toolName || !fallback.toolName) return false
   if (richer.toolName !== fallback.toolName) return false
 
@@ -677,7 +706,8 @@ function trajectoryEntryToTrace(
 ): UnifiedTraceEvent {
   // Backend sends `ts` in seconds (Unix float); normalize to milliseconds for sorting.
   const ts = typeof entry.ts === 'number' ? entry.ts * 1000 : safeTimestamp(entry.ts_iso)
-  const detail = traceId ? { trace_id: traceId, trace_origin: 'trajectory' } : { trace_origin: 'trajectory' }
+  const detail: Record<string, unknown> = traceId ? { trace_id: traceId, trace_origin: 'trajectory' } : { trace_origin: 'trajectory' }
+  if (entry.execution_id) detail.execution_id = entry.execution_id
 
   // Handle thinking entries (type === 'thinking')
   if (entry.type === 'thinking') {
@@ -711,6 +741,7 @@ function trajectoryEntryToTrace(
     turn: entry.turn,
     round: entry.round,
     cost_usd: entry.cost_usd,
+    executionId: entry.execution_id,
     error: entry.error,
   }
 }


### PR DESCRIPTION
## 무엇

RFC-0233 §4 PR-2의 대시보드 절반: session-trace가 한 물리적 실행을 두 행으로 렌더하던 #20910 증상을 **정본 키 조인**으로 해소했습니다.

## 왜 두 행이었나 (근본 원인)

- trajectory 행의 `turn` = trace-상대 카운터 (`trajectory.ml:374` 0부터 증가)
- tool_call log 행의 `turn` = 세션-절대 turn (`keeper_run_tools_hooks.ml` `set_turn_context`)
- 휴리스틱 조인 `session-trace-state.ts:439`가 `eventTurn !== entryTurn → false` — 두 값이 모두 있으면 **결정론적으로 실패** → trajectory 행 + synthetic 행 동시 렌더
- 기존 테스트는 양쪽 fixture에 `turn: 1`을 줘서 이 분열을 가리고 있었음

## 어떻게

- PR-1(#20968)이 양 스토어에 이미 심은 `execution_id`를 `/trajectory`·`/tool-calls` 응답에서 디코드 (서버는 이미 방출 중, 대시보드 디코더가 버리고 있었음)
- `toolCallEntryMatchesTraceEvent`: 양측에 id가 있으면 **등호 하나로 판정** — 7-필드 근사 비교는 PR-1 이전 행(backfill 없음, RFC §3) 전용 fallback으로 강등
- 병합된 행: 배지는 trace-상대 T/R 쌍 유지, 세션-절대 turn은 `detail.turn` 속성으로 — 어휘 혼합 방지
- synthetic 행 id를 `tc-<execution_id>`로 안정화 (refetch에도 동일)
- `richerToolCallMatchesFallback`(timeline 억제)에도 동일 정본 키 우선 적용

## 검증

- `vitest run session-trace/` 39/39 (신규 4: 분열-turn 조인 재현, 다른 id 비병합, legacy fallback, 안정 id)
- buildTraceEvents 소비처(task-detail, journey-waterfall) 테스트 25/25
- `tsc --noEmit` exit 0, eslint 0

## 범위 밖 (후속)

- **oas:tool_called/completed 행의 execution_id 스탬프** — OAS 이벤트 페이로드에 `tool_use_id`가 없어 결정론적 조인 불가 (라이브 측정: correlation_id 교집합 0/8526). oas PR(이벤트에 OAS 자신의 tool_use_id 추가) + masc PR-2b(브리지 조인 + `caused_by` 직렬화 복원)로 진행
- live SSE lane의 execution_id (PR-2b)

Refs RFC-0233, #20910, PR-1 #20968

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
