### PR TITLE
feat(keeper): RFC-0232 P5 — shared immutable Surface_ref, lane writers stop inventing source strings

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -118,8 +118,11 @@ let persist_connector_assistant_reply ~base_dir ~keeper_name ~source
     ?conversation_id ~reply () =
   let content = String.trim reply in
   if content <> "" then begin
+    (* RFC-0232 P5: the gate recorder knows the connector label only;
+       coordinates ride [conversation_id] as before. *)
+    let surface = Surface_ref.Gate { label = source; address = [] } in
     Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name
-      ~content ~source ?conversation_id ();
+      ~content ~surface ?conversation_id ();
     Keeper_chat_broadcast.chat_appended ~keeper_name ~source
   end
 
@@ -173,7 +176,7 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
     ~base_dir:config.Workspace.base_path
     ~keeper_name
     ~content:(String.trim content)
-    ~source:lane
+    ~surface:(Surface_ref.Gate { label = lane; address = [] })
     ?conversation_id
     ?external_message_id
     ~speaker:

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -114,6 +114,12 @@ type chat_message = {
   tool_call_id : string option;
   tool_call_name : string option;
   source : string option;
+      (* Legacy lane label.  Derived from [surface] at write since
+         RFC-0232 P5 (writers no longer pass label strings); read
+         verbatim from the wire so pre-P5 rows keep their label. *)
+  surface : Surface_ref.t option;
+      (* RFC-0232 P5: the typed surface, persisted as a structured
+         [surface] field.  [None] on rows written before P5. *)
   conversation_id : string option;
   external_message_id : string option;
   speaker : speaker option;
@@ -154,9 +160,18 @@ let speaker_fields = function
       @ [ ("speaker_authority", `String (authority_label sp.speaker_authority)) ]
 
 let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
-    ?tool_call_name ?source ?conversation_id ?external_message_id ?speaker
+    ?tool_call_name ?surface ?conversation_id ?external_message_id ?speaker
     ?(mentions = []) ()
     : string =
+  (* RFC-0232 P5: the label is a derivation of the typed surface — the
+     single site that turns a [Surface_ref.t] into the legacy [source]
+     string. *)
+  let source = Option.map Surface_ref.lane_label surface in
+  let surface_field =
+    match surface with
+    | None -> []
+    | Some s -> [ ("surface", Surface_ref.to_json s) ]
+  in
   let base_fields = [
     ("role", `String (Role.to_label role));
     ("content", `String content);
@@ -197,6 +212,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     @ opt_string_field "tool_call_id" tool_call_id
     @ opt_string_field "tool_call_name" tool_call_name
     @ opt_string_field "source" source
+    @ surface_field
     @ opt_string_field "conversation_id" conversation_id
     @ opt_string_field "external_message_id" external_message_id
     @ speaker_fields speaker
@@ -221,7 +237,7 @@ let user_line_mentions ~extra_mentions content =
   |> List.sort_uniq Keeper_identity.Keeper_id.compare
 
 let append_turn ~base_dir ~keeper_name ~(user_content : string)
-    ~(user_attachments : attachment list) ?(tool_calls = []) ?source
+    ~(user_attachments : attachment list) ?(tool_calls = []) ?surface
     ?conversation_id ?external_message_id ?speaker ?(extra_mentions = [])
     ~(assistant_content : string)
     () =
@@ -244,7 +260,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
        assistant lines are the keeper's own output. *)
     let user_line =
       encode_line ~role:Role.User ~content:user_content ~ts
-        ~attachments:user_attachments ?source ?conversation_id
+        ~attachments:user_attachments ?surface ?conversation_id
         ?external_message_id ?speaker
         ~mentions:(user_line_mentions ~extra_mentions user_content) ()
     in
@@ -256,11 +272,11 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
             ~ts
             ~tool_call_id:(normalize_tool_call_id ~position tc.call_id)
             ~tool_call_name:tc.call_name
-            ?source ?conversation_id ())
+            ?surface ?conversation_id ())
         tool_calls
     in
     let asst_line =
-      encode_line ~role:Role.Assistant ~content:assistant_content ~ts ?source
+      encode_line ~role:Role.Assistant ~content:assistant_content ~ts ?surface
         ?conversation_id ()
     in
     let payload =
@@ -280,7 +296,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
 (* RFC-0223 P4: keeper-initiated message on one lane. A single
    assistant line — there is no user turn to pair it with. *)
 let append_assistant_message ~base_dir ~keeper_name ~(content : string)
-    ?source ?conversation_id () =
+    ?surface ?conversation_id () =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
@@ -288,7 +304,7 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line =
-      encode_line ~role:Role.Assistant ~content ~ts ?source ?conversation_id ()
+      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id ()
     in
     Fs_compat.append_file path (line ^ "\n")
   with
@@ -305,7 +321,7 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
    independent of) any turn. A single user line — the assistant reply,
    if one ever comes, is appended separately by the reply path. *)
 let append_user_message ~base_dir ~keeper_name ~(content : string)
-    ?source ?conversation_id ?external_message_id ?speaker
+    ?surface ?conversation_id ?external_message_id ?speaker
     ?(extra_mentions = []) () =
   try
     ensure_dir_once ~base_dir;
@@ -314,7 +330,7 @@ let append_user_message ~base_dir ~keeper_name ~(content : string)
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line =
-      encode_line ~role:Role.User ~content ~ts ?source ?conversation_id
+      encode_line ~role:Role.User ~content ~ts ?surface ?conversation_id
         ?external_message_id ?speaker
         ~mentions:(user_line_mentions ~extra_mentions content) ()
     in
@@ -347,6 +363,21 @@ let parse_line ~file_path (line : string) : chat_message option =
     let tool_call_id = opt_string "tool_call_id" in
     let tool_call_name = opt_string "tool_call_name" in
     let source = opt_string "source" in
+    let surface =
+      match Json_util.assoc_member_opt "surface" json with
+      | None -> None
+      | Some surface_json -> (
+          match Surface_ref.of_json surface_json with
+          | Ok s -> Some s
+          | Error detail ->
+              (* Unknown/invalid surface payload: surface it, keep the
+                 row (the label in [source] still renders). *)
+              report_persistence_read_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                ~path:file_path
+                ~detail:(Printf.sprintf "invalid surface field: %s" detail);
+              None)
+    in
     let conversation_id = opt_string "conversation_id" in
     let external_message_id = opt_string "external_message_id" in
     let speaker =
@@ -463,7 +494,7 @@ let parse_line ~file_path (line : string) : chat_message option =
       | Some role ->
           Some
             { role; content; ts; attachments; tool_call_id; tool_call_name;
-              source; conversation_id; external_message_id; speaker;
+              source; surface; conversation_id; external_message_id; speaker;
               mentions }
   with Yojson.Json_error detail ->
     report_persistence_read_drop

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -80,6 +80,13 @@ type chat_message = {
   tool_call_id : string option;
   tool_call_name : string option;
   source : string option;
+      (** Legacy lane label.  Since RFC-0232 P5 it is derived from
+          [surface] at write ({!Surface_ref.lane_label}); pre-P5 rows
+          carry their original label verbatim. *)
+  surface : Surface_ref.t option;
+      (** The typed surface (RFC-0232 §3.6).  [None] on rows written
+          before P5 and on rows whose persisted surface payload fails
+          to decode (reported as a persistence read drop, row kept). *)
   conversation_id : string option;
   external_message_id : string option;
   speaker : speaker option;
@@ -114,7 +121,7 @@ val append_turn :
   user_content:string ->
   user_attachments:attachment list ->
   ?tool_calls:tool_call list ->
-  ?source:string ->
+  ?surface:Surface_ref.t ->
   ?conversation_id:string ->
   ?external_message_id:string ->
   ?speaker:speaker ->
@@ -132,7 +139,7 @@ val append_assistant_message :
   base_dir:string ->
   keeper_name:string ->
   content:string ->
-  ?source:string ->
+  ?surface:Surface_ref.t ->
   ?conversation_id:string ->
   unit ->
   unit
@@ -147,7 +154,7 @@ val append_user_message :
   base_dir:string ->
   keeper_name:string ->
   content:string ->
-  ?source:string ->
+  ?surface:Surface_ref.t ->
   ?conversation_id:string ->
   ?external_message_id:string ->
   ?speaker:speaker ->

--- a/lib/keeper/keeper_external_attention.ml
+++ b/lib/keeper/keeper_external_attention.ml
@@ -19,7 +19,10 @@ let persistence_surface = "keeper_external_attention"
 
 let default_claim_stale_after_s = 900.0
 
-type surface_ref =
+(* RFC-0232 P5: the surface vocabulary moved to the shared [Surface_ref]
+   module; this equation re-exports it so existing consumers keep
+   constructing/matching [Keeper_external_attention.Dashboard] etc. *)
+type surface_ref = Surface_ref.t =
   | Dashboard of { session_id : string option }
   | Discord of {
       guild_id : string option;
@@ -34,6 +37,7 @@ type surface_ref =
     }
   | Github of { repo : string; notification_id : string option }
   | Webhook of { source : string; event_id : string }
+  | Agent
   | Gate of { label : string; address : (string * string) list }
 
 type conversation_ref = {
@@ -185,80 +189,9 @@ let optional_object key = function
 
 let ( let* ) = Result.bind
 
-let surface_ref_to_json = function
-  | Dashboard { session_id } ->
-      `Assoc
-        ([ ("kind", `String "dashboard") ] @ opt_string_field "session_id" session_id)
-  | Discord { guild_id; channel_id; parent_channel_id; thread_id } ->
-      `Assoc
-        ([ ("kind", `String "discord"); ("channel_id", `String channel_id) ]
-        @ opt_string_field "guild_id" guild_id
-        @ opt_string_field "parent_channel_id" parent_channel_id
-        @ opt_string_field "thread_id" thread_id)
-  | Slack { team_id; channel_id; thread_ts } ->
-      `Assoc
-        ([ ("kind", `String "slack"); ("channel_id", `String channel_id) ]
-        @ opt_string_field "team_id" team_id
-        @ opt_string_field "thread_ts" thread_ts)
-  | Github { repo; notification_id } ->
-      `Assoc
-        ([ ("kind", `String "github"); ("repo", `String repo) ]
-        @ opt_string_field "notification_id" notification_id)
-  | Webhook { source; event_id } ->
-      `Assoc
-        [
-          ("kind", `String "webhook");
-          ("source", `String source);
-          ("event_id", `String event_id);
-        ]
-  | Gate { label; address } ->
-      `Assoc
-        [
-          ("kind", `String "gate");
-          ("label", `String label);
-          ("address", string_assoc_json address);
-        ]
+let surface_ref_to_json = Surface_ref.to_json
 
-let surface_ref_of_json json =
-  let* kind = required_string "kind" json in
-  match kind with
-  | "dashboard" -> Ok (Dashboard { session_id = optional_string "session_id" json })
-  | "discord" ->
-      let* channel_id = required_string "channel_id" json in
-      Ok
-        (Discord
-           {
-             guild_id = optional_string "guild_id" json;
-             channel_id;
-             parent_channel_id = optional_string "parent_channel_id" json;
-             thread_id = optional_string "thread_id" json;
-           })
-  | "slack" ->
-      let* channel_id = required_string "channel_id" json in
-      Ok
-        (Slack
-           {
-             team_id = optional_string "team_id" json;
-             channel_id;
-             thread_ts = optional_string "thread_ts" json;
-           })
-  | "github" ->
-      let* repo = required_string "repo" json in
-      Ok (Github { repo; notification_id = optional_string "notification_id" json })
-  | "webhook" ->
-      let* source = required_string "source" json in
-      let* event_id = required_string "event_id" json in
-      Ok (Webhook { source; event_id })
-  | "gate" ->
-      let* label = required_string "label" json in
-      let address =
-        match optional_object "address" json with
-        | None -> Ok []
-        | Some obj -> string_assoc_of_json obj
-      in
-      let* address = address in
-      Ok (Gate { label; address })
-  | other -> Error (Printf.sprintf "unknown surface kind %S" other)
+let surface_ref_of_json = Surface_ref.of_json
 
 let conversation_ref_to_json c =
   `Assoc

--- a/lib/keeper/keeper_external_attention.mli
+++ b/lib/keeper/keeper_external_attention.mli
@@ -10,7 +10,9 @@
 
 (** {1 Coordinates} *)
 
-type surface_ref =
+(** Re-export of the shared surface vocabulary (RFC-0232 P5); see
+    {!Surface_ref}. *)
+type surface_ref = Surface_ref.t =
   | Dashboard of { session_id : string option }
   | Discord of {
       guild_id : string option;
@@ -25,6 +27,7 @@ type surface_ref =
     }
   | Github of { repo : string; notification_id : string option }
   | Webhook of { source : string; event_id : string }
+  | Agent
   | Gate of { label : string; address : (string * string) list }
 
 type conversation_ref = {

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -173,7 +173,7 @@ let handle_surface_post ~config ~(meta : keeper_meta) ~args =
           ~base_dir:config.Workspace.base_path
           ~keeper_name:meta.name
           ~content:safe_content
-          ~source:"dashboard"
+          ~surface:(Surface_ref.Dashboard { session_id = None })
           ();
         Keeper_chat_broadcast.chat_appended ~keeper_name:meta.name
           ~source:"dashboard";
@@ -189,7 +189,14 @@ let handle_surface_post ~config ~(meta : keeper_meta) ~args =
               ~base_dir:config.Workspace.base_path
               ~keeper_name:meta.name
               ~content:safe_content
-              ~source:"discord"
+              ~surface:
+                (Surface_ref.Discord
+                   {
+                     guild_id = None;
+                     channel_id;
+                     parent_channel_id = None;
+                     thread_id = None;
+                   })
               ();
             Keeper_chat_broadcast.chat_appended ~keeper_name:meta.name
               ~source:"discord";

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -549,7 +549,7 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
             ~keeper_name:name
             ~user_content
             ~user_attachments:[]
-            ~source:"agent"
+            ~surface:Surface_ref.Agent
             ~assistant_content
             ();
           Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source:"agent"
@@ -559,7 +559,7 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
             ~base_dir:config.base_path
             ~keeper_name:name
             ~content:assistant_content
-            ~source:channel
+            ~surface:(Surface_ref.Gate { label = channel; address = [] })
             ();
           Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source:channel
         end)

--- a/lib/keeper/surface_ref.ml
+++ b/lib/keeper/surface_ref.ml
@@ -1,0 +1,159 @@
+(* See the interface.  The type and JSON codec are moved verbatim from
+   Keeper_external_attention (RFC-0232 §3.6); [Agent] and [lane_label]
+   are the additions that let the chat lane drop its open [source]
+   strings. *)
+
+type t =
+  | Dashboard of { session_id : string option }
+  | Discord of {
+      guild_id : string option;
+      channel_id : string;
+      parent_channel_id : string option;
+      thread_id : string option;
+    }
+  | Slack of {
+      team_id : string option;
+      channel_id : string;
+      thread_ts : string option;
+    }
+  | Github of { repo : string; notification_id : string option }
+  | Webhook of { source : string; event_id : string }
+  | Agent
+  | Gate of { label : string; address : (string * string) list }
+
+let equal (a : t) (b : t) = a = b
+let compare (a : t) (b : t) = Stdlib.compare a b
+
+let lane_label = function
+  | Dashboard _ -> "dashboard"
+  | Discord _ -> "discord"
+  | Slack _ -> "slack"
+  | Github _ -> "github"
+  | Webhook _ -> "webhook"
+  | Agent -> "agent"
+  | Gate { label; _ } -> label
+
+(* ── JSON codec ── *)
+
+let opt_string_field key = function
+  | None -> []
+  | Some value -> [ (key, `String value) ]
+
+let string_assoc_json fields =
+  `Assoc (List.map (fun (key, value) -> (key, `String value)) fields)
+
+let string_assoc_of_json = function
+  | `Assoc fields ->
+      Ok
+        (List.filter_map
+           (fun (key, value) ->
+             match value with
+             | `String s -> Some (key, s)
+             | _ -> None)
+           fields)
+  | _ -> Error "expected string object"
+
+let required_string key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) -> Ok value
+      | _ -> Error (Printf.sprintf "missing string field %s" key))
+  | _ -> Error "expected object"
+
+let optional_string key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) when String.trim value <> "" -> Some value
+      | Some (`String _) | Some `Null | None -> None
+      | Some _ -> None)
+  | _ -> None
+
+let optional_object key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`Assoc _ as obj) -> Some obj
+      | Some `Null | None -> None
+      | Some _ -> None)
+  | _ -> None
+
+let ( let* ) = Result.bind
+
+let to_json = function
+  | Dashboard { session_id } ->
+      `Assoc
+        ([ ("kind", `String "dashboard") ]
+        @ opt_string_field "session_id" session_id)
+  | Discord { guild_id; channel_id; parent_channel_id; thread_id } ->
+      `Assoc
+        ([ ("kind", `String "discord"); ("channel_id", `String channel_id) ]
+        @ opt_string_field "guild_id" guild_id
+        @ opt_string_field "parent_channel_id" parent_channel_id
+        @ opt_string_field "thread_id" thread_id)
+  | Slack { team_id; channel_id; thread_ts } ->
+      `Assoc
+        ([ ("kind", `String "slack"); ("channel_id", `String channel_id) ]
+        @ opt_string_field "team_id" team_id
+        @ opt_string_field "thread_ts" thread_ts)
+  | Github { repo; notification_id } ->
+      `Assoc
+        ([ ("kind", `String "github"); ("repo", `String repo) ]
+        @ opt_string_field "notification_id" notification_id)
+  | Webhook { source; event_id } ->
+      `Assoc
+        [
+          ("kind", `String "webhook");
+          ("source", `String source);
+          ("event_id", `String event_id);
+        ]
+  | Agent -> `Assoc [ ("kind", `String "agent") ]
+  | Gate { label; address } ->
+      `Assoc
+        [
+          ("kind", `String "gate");
+          ("label", `String label);
+          ("address", string_assoc_json address);
+        ]
+
+let of_json json =
+  let* kind = required_string "kind" json in
+  match kind with
+  | "dashboard" ->
+      Ok (Dashboard { session_id = optional_string "session_id" json })
+  | "discord" ->
+      let* channel_id = required_string "channel_id" json in
+      Ok
+        (Discord
+           {
+             guild_id = optional_string "guild_id" json;
+             channel_id;
+             parent_channel_id = optional_string "parent_channel_id" json;
+             thread_id = optional_string "thread_id" json;
+           })
+  | "slack" ->
+      let* channel_id = required_string "channel_id" json in
+      Ok
+        (Slack
+           {
+             team_id = optional_string "team_id" json;
+             channel_id;
+             thread_ts = optional_string "thread_ts" json;
+           })
+  | "github" ->
+      let* repo = required_string "repo" json in
+      Ok
+        (Github { repo; notification_id = optional_string "notification_id" json })
+  | "webhook" ->
+      let* source = required_string "source" json in
+      let* event_id = required_string "event_id" json in
+      Ok (Webhook { source; event_id })
+  | "agent" -> Ok Agent
+  | "gate" ->
+      let* label = required_string "label" json in
+      let address =
+        match optional_object "address" json with
+        | None -> Ok []
+        | Some obj -> string_assoc_of_json obj
+      in
+      let* address = address in
+      Ok (Gate { label; address })
+  | other -> Error (Printf.sprintf "unknown surface kind %s" other)

--- a/lib/keeper/surface_ref.mli
+++ b/lib/keeper/surface_ref.mli
@@ -1,0 +1,51 @@
+(** Surface_ref — the shared typed surface vocabulary (RFC-0232 §3.6).
+
+    One immutable value names the surface a lane event came from or
+    goes to: the dashboard, a Discord/Slack coordinate, a GitHub
+    notification, a webhook, the keeper's own agent-initiated path, or
+    any other connector speaking the generic gate protocol.  Extracted
+    from [Keeper_external_attention.surface_ref] (which re-exports it
+    unchanged) so the lane ({!Keeper_chat_store}), the attention store,
+    and the gate recorder speak the same closed type instead of open
+    [source] strings.
+
+    Values are pure immutable data — no mutable fields, no hidden
+    state; [equal]/[compare] are structural.  Construction is direct
+    (the variants are the API); the only derivations live here:
+    {!lane_label} (the legacy on-disk label) and the total JSON codec. *)
+
+type t =
+  | Dashboard of { session_id : string option }
+  | Discord of {
+      guild_id : string option;
+      channel_id : string;
+      parent_channel_id : string option;
+      thread_id : string option;
+    }
+  | Slack of {
+      team_id : string option;
+      channel_id : string;
+      thread_ts : string option;
+    }
+  | Github of { repo : string; notification_id : string option }
+  | Webhook of { source : string; event_id : string }
+  | Agent
+      (** Keeper/agent-initiated lane traffic with no external surface
+          (the [masc_keeper_msg] direct path) — previously the open
+          string label ["agent"]. *)
+  | Gate of { label : string; address : (string * string) list }
+
+val equal : t -> t -> bool
+val compare : t -> t -> int
+
+val lane_label : t -> string
+(** The legacy [source] label this surface writes on a lane row:
+    ["dashboard"] / ["discord"] / ["slack"] / ["github"] / ["webhook"]
+    / ["agent"] / the gate channel label verbatim.  The single
+    derivation site — writers no longer invent label strings. *)
+
+val to_json : t -> Yojson.Safe.t
+
+val of_json : Yojson.Safe.t -> (t, string) result
+(** Total decode: unknown [kind] labels are an [Error], never a
+    default. *)

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -400,7 +400,14 @@ let handle_ambient ~base_dir
       in
       Keeper_chat_store.append_user_message
         ~base_dir ~keeper_name ~content:trimmed
-        ~source:State.channel
+        ~surface:
+          (Surface_ref.Discord
+             {
+               guild_id;
+               channel_id;
+               parent_channel_id = None;
+               thread_id = None;
+             })
         ~conversation_id:(discord_conversation_id ~guild_id ~channel_id)
         ~external_message_id:message_id
         ~speaker:

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -600,9 +600,14 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
         { Keeper_chat_store.call_id; call_name; args = Buffer.contents buf })
       !tool_calls_rev
   in
-  let chat_source =
-    if has_connector_context then payload.channel else "dashboard"
+  (* RFC-0232 P5: the typed surface is the write-side truth; the label
+     [chat_source] is its derivation, used for broadcast metadata. *)
+  let chat_surface =
+    if has_connector_context then
+      Surface_ref.Gate { label = payload.channel; address = [] }
+    else Surface_ref.Dashboard { session_id = None }
   in
+  let chat_source = Surface_ref.lane_label chat_surface in
   (* RFC-0223 P1: authority derives from the arrival route. Connector
      context means an arbitrary external person on that channel; its
      absence means the authenticated dashboard operator (the route is
@@ -630,7 +635,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
       ~user_content:payload.message
       ~user_attachments:payload.attachments
       ~tool_calls:(collected_tool_calls ())
-      ~source:chat_source
+      ~surface:chat_surface
       ~speaker:chat_speaker
       ~assistant_content:(persisted_error_reply err)
       ();
@@ -677,7 +682,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
                 ~user_content:payload.message
                 ~user_attachments:payload.attachments
                 ~tool_calls:(collected_tool_calls ())
-                ~source:chat_source
+                ~surface:chat_surface
                 ~speaker:chat_speaker
                 ~assistant_content:visible_reply
                 ();

--- a/test/dune
+++ b/test/dune
@@ -32,6 +32,7 @@
   test_keeper_reactive_wake_backlog_gate
   test_keeper_mention_scope
   test_keeper_lane_mentions
+  test_surface_ref
   test_keeper_turn_outcome
   test_keeper_identity_id
   test_board_activity_cache
@@ -309,6 +310,7 @@
   test_keeper_reactive_wake_backlog_gate
   test_keeper_mention_scope
   test_keeper_lane_mentions
+  test_surface_ref
   test_keeper_turn_outcome
   test_keeper_identity_id
   test_board_activity_cache

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -86,7 +86,8 @@ let test_persist_connector_assistant_reply_records_lane_reply () =
     (fun () ->
       let keeper_name = "discord-reply-keeper" in
       K.append_user_message ~base_dir ~keeper_name
-        ~content:"<@bot> factorio?" ~source:"discord"
+        ~content:"<@bot> factorio?"
+        ~surface:(Masc.Surface_ref.Gate { label = "discord"; address = [] })
         ~conversation_id:"discord:guild-1:channel:chan-9" ();
       Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
         ~keeper_name ~source:"discord"

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -129,7 +129,7 @@ let test_append_turn_roundtrip () =
             (* Empty args normalise to "{}", empty id to a positional one. *)
             { K.call_id = ""; call_name = "masc_status"; args = "  " };
           ]
-        ~source:"dashboard"
+        ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
         ~assistant_content:"all green"
         ();
       let messages = K.load ~base_dir ~keeper_name in
@@ -255,7 +255,7 @@ let test_speaker_external_roundtrip () =
       K.append_turn ~base_dir ~keeper_name
         ~user_content:"hello from discord"
         ~user_attachments:[]
-        ~source:"discord"
+        ~surface:(Masc.Surface_ref.Gate { label = "discord"; address = [] })
         ~speaker:
           { K.speaker_id = Some "98791450001";
             speaker_name = Some "minsu";
@@ -289,7 +289,7 @@ let test_append_user_message_roundtrip () =
       let keeper_name = "keeper-chat-ambient" in
       K.append_user_message ~base_dir ~keeper_name
         ~content:"two humans chatting, no mention"
-        ~source:"discord"
+        ~surface:(Masc.Surface_ref.Gate { label = "discord"; address = [] })
         ~conversation_id:"discord:guild-1:channel:chan-7"
         ~external_message_id:"msg-7"
         ~speaker:
@@ -298,7 +298,8 @@ let test_append_user_message_roundtrip () =
             speaker_authority = K.External }
         ();
       K.append_assistant_message ~base_dir ~keeper_name
-        ~content:"reply recorded separately" ~source:"discord"
+        ~content:"reply recorded separately"
+        ~surface:(Masc.Surface_ref.Gate { label = "discord"; address = [] })
         ~conversation_id:"discord:guild-1:channel:chan-7" ();
       match K.load ~base_dir ~keeper_name with
       | [ user; assistant ] ->
@@ -360,7 +361,7 @@ let test_speaker_owner_roundtrip () =
       K.append_turn ~base_dir ~keeper_name
         ~user_content:"deploy it"
         ~user_attachments:[]
-        ~source:"dashboard"
+        ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
         ~speaker:
           { K.speaker_id = None;
             speaker_name = None;

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -53,6 +53,7 @@ let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None) content
   ; tool_call_id = None
   ; tool_call_name = None
   ; source
+  ; surface = None
   ; conversation_id = None
   ; external_message_id = None
   ; speaker
@@ -187,6 +188,7 @@ let tool_line : Store.chat_message =
   ; tool_call_id = Some "tc-0"
   ; tool_call_name = Some "Read"
   ; source = None
+  ; surface = None
   ; conversation_id = None
   ; external_message_id = None
   ; speaker = None

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -95,7 +95,16 @@ let with_temp_base_dir f =
 let test_assistant_message_persists_with_source () =
   with_temp_base_dir (fun base_dir ->
       Store.append_assistant_message ~base_dir ~keeper_name:"post-keeper"
-        ~content:"keeper-initiated hello" ~source:"discord" ();
+        ~content:"keeper-initiated hello"
+        ~surface:
+          (Masc.Surface_ref.Discord
+             {
+               guild_id = None;
+               channel_id = "chan-1";
+               parent_channel_id = None;
+               thread_id = None;
+             })
+        ();
       let messages = Store.load ~base_dir ~keeper_name:"post-keeper" in
       check int "one line" 1 (List.length messages);
       let m = List.hd messages in

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -19,6 +19,7 @@ let msg ?ts ?source ?speaker ~role content : Store.chat_message =
     tool_call_id = None;
     tool_call_name = None;
     source;
+    surface = None;
     conversation_id = None;
     external_message_id = None;
     speaker;

--- a/test/test_surface_ref.ml
+++ b/test/test_surface_ref.ml
@@ -1,0 +1,156 @@
+(* RFC-0232 P5: shared immutable Surface_ref.
+
+   Pinned here:
+   1. Codec totality — every variant round-trips through JSON; unknown
+      kinds are an Error, never a default.
+   2. lane_label goldens — the single derivation that replaced
+      writer-invented [source] strings, byte-identical to the legacy
+      labels ("dashboard" / "discord" / "agent" / gate channel).
+   3. Lane roundtrip — a typed write persists both the structured
+      [surface] field and the derived [source] label; legacy label-only
+      rows read back as [surface = None] with their label intact;
+      an invalid persisted surface payload is reported and dropped
+      without losing the row. *)
+
+open Alcotest
+
+module S = Masc.Surface_ref
+module Store = Masc.Keeper_chat_store
+
+let surface : S.t testable =
+  testable (fun fmt t -> Format.pp_print_string fmt (S.lane_label t)) S.equal
+
+let all_variants =
+  [ S.Dashboard { session_id = None }
+  ; S.Dashboard { session_id = Some "sess-1" }
+  ; S.Discord
+      {
+        guild_id = Some "g1";
+        channel_id = "c1";
+        parent_channel_id = Some "p1";
+        thread_id = Some "t1";
+      }
+  ; S.Discord
+      { guild_id = None; channel_id = "c2"; parent_channel_id = None; thread_id = None }
+  ; S.Slack { team_id = Some "T1"; channel_id = "C9"; thread_ts = None }
+  ; S.Github { repo = "jeong-sik/masc"; notification_id = Some "n1" }
+  ; S.Webhook { source = "ci"; event_id = "evt-7" }
+  ; S.Agent
+  ; S.Gate { label = "discord"; address = [ ("workspace_id", "w1") ] }
+  ; S.Gate { label = "custom-connector"; address = [] }
+  ]
+
+let test_codec_round_trip () =
+  List.iter
+    (fun v ->
+      match S.of_json (S.to_json v) with
+      | Ok decoded -> check surface (S.lane_label v) v decoded
+      | Error e -> failf "round trip failed for %s: %s" (S.lane_label v) e)
+    all_variants
+
+let test_unknown_kind_is_error () =
+  match S.of_json (`Assoc [ ("kind", `String "telepathy") ]) with
+  | Error _ -> ()
+  | Ok _ -> fail "unknown kind decoded"
+
+let test_lane_label_goldens () =
+  check string "dashboard" "dashboard"
+    (S.lane_label (S.Dashboard { session_id = None }));
+  check string "discord" "discord"
+    (S.lane_label
+       (S.Discord
+          { guild_id = None; channel_id = "c"; parent_channel_id = None; thread_id = None }));
+  check string "agent" "agent" (S.lane_label S.Agent);
+  check string "gate label verbatim" "my-connector"
+    (S.lane_label (S.Gate { label = "my-connector"; address = [] }))
+
+(* ── Lane roundtrip ── *)
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+
+let with_base prefix f =
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+  in
+  Fun.protect ~finally:(fun () -> remove_tree base) (fun () -> f base)
+
+let lane_path base =
+  Filename.concat
+    (Filename.concat (Filename.concat base ".masc") "keeper_chat")
+    "dreamer.jsonl"
+
+let test_typed_write_round_trips () =
+  with_base "surface-ref-write" (fun base ->
+      let ref_ =
+        S.Discord
+          { guild_id = Some "g1"; channel_id = "c1"; parent_channel_id = None; thread_id = None }
+      in
+      Store.append_user_message ~base_dir:base ~keeper_name:"dreamer"
+        ~content:"hello" ~surface:ref_ ();
+      match Store.load ~base_dir:base ~keeper_name:"dreamer" with
+      | [ m ] ->
+          check (option surface) "typed surface read back" (Some ref_)
+            m.surface;
+          check (option string) "label derived from the typed surface"
+            (Some "discord") m.source
+      | other -> failf "expected 1 line, got %d" (List.length other))
+
+let test_legacy_label_row_reads_back () =
+  with_base "surface-ref-legacy" (fun base ->
+      Store.append_user_message ~base_dir:base ~keeper_name:"dreamer"
+        ~content:"seed" ();
+      let oc = open_out_gen [ Open_append ] 0o644 (lane_path base) in
+      output_string oc
+        "{\"role\":\"user\",\"content\":\"old row\",\"ts\":2.0,\"source\":\"discord\"}\n";
+      close_out oc;
+      match Store.load ~base_dir:base ~keeper_name:"dreamer" with
+      | [ _seed; legacy ] ->
+          check (option surface) "no typed surface on pre-P5 row" None
+            legacy.surface;
+          check (option string) "legacy label kept verbatim"
+            (Some "discord") legacy.source
+      | other -> failf "expected 2 lines, got %d" (List.length other))
+
+let test_invalid_surface_payload_keeps_row () =
+  with_base "surface-ref-invalid" (fun base ->
+      Store.append_user_message ~base_dir:base ~keeper_name:"dreamer"
+        ~content:"seed" ();
+      let oc = open_out_gen [ Open_append ] 0o644 (lane_path base) in
+      output_string oc
+        "{\"role\":\"user\",\"content\":\"bad surface\",\"ts\":2.0,\"surface\":{\"kind\":\"telepathy\"}}\n";
+      close_out oc;
+      match Store.load ~base_dir:base ~keeper_name:"dreamer" with
+      | [ _seed; bad ] ->
+          check (option surface) "invalid payload reported, decoded as None"
+            None bad.surface;
+          check string "row content survives" "bad surface" bad.content
+      | other -> failf "expected 2 lines, got %d" (List.length other))
+
+let () =
+  Random.self_init ();
+  run "surface_ref"
+    [
+      ( "codec",
+        [
+          test_case "round trip" `Quick test_codec_round_trip;
+          test_case "unknown kind is error" `Quick test_unknown_kind_is_error;
+        ] );
+      ("labels", [ test_case "lane_label goldens" `Quick test_lane_label_goldens ]);
+      ( "lane",
+        [
+          test_case "typed write round trips" `Quick
+            test_typed_write_round_trips;
+          test_case "legacy label row" `Quick test_legacy_label_row_reads_back;
+          test_case "invalid payload keeps row" `Quick
+            test_invalid_surface_payload_keeps_row;
+        ] );
+    ]


### PR DESCRIPTION
## RFC-0232 P5 — 공유 immutable `Surface_ref`, lane writer의 source 문자열 발명 종료

RFC: `docs/rfc/RFC-0232-typed-lane-event-model.md` §3.6 (#20877). P1 #20896, P2 #20914, P3 #20932, P4 #20951 — **이 PR로 RFC-0232 전 phase 완료**.

### 문제

표면(surface) 어휘가 3벌 공존했다: rich한 `Keeper_external_attention.surface_ref`, label-유래 `Gate_surface`, 그리고 lane row의 **open `source` 문자열** — writer마다 "dashboard"/"agent"/채널 라벨을 독립적으로 발명.

### 변경

| 항목 | 내용 |
|---|---|
| **`Surface_ref`** (신규) | attention 타입 + total codec verbatim 이동. 추가: `Agent` variant(기존 bare `"agent"` 라벨), `lane_label`(legacy 라벨의 **단일 유도 지점**). **Immutable pure data** — mutable 필드 0, 구조적 equal/compare, 미지 kind → `Error`(default 없음) |
| **attention 재수출** | `type surface_ref = Surface_ref.t = ...` 등식 — 소비자 무변경 컴파일 |
| **chat_store write API** | `?source:string` 삭제 → `?surface:Surface_ref.t`. **호출자가 라벨 문자열을 더 이상 발명 불가**. wire는 구조화 `surface` + 유도된 `source` 라벨 동시 기록(진실 1, 유도 1 — 라벨은 기존과 byte-identical) |
| **record** | `surface : Surface_ref.t option` 추가 — pre-P5 행/디코드 실패 행은 `None`(read-drop 보고, 행 유지, 라벨은 계속 렌더) |
| **Writer 전환 5계열** | dashboard chat→`Dashboard`, connector dispatch→`Gate{label}`, Discord ambient→**rich `Discord{guild,channel}`**(좌표 보유), agent-initiated→`Agent`, surface post→`Dashboard`/`Discord{channel_id}` |

### Immutability (요청 반영)

`Surface_ref.t`는 순수 불변 데이터입니다 — 모든 payload가 immutable record/list, 숨은 상태 없음, 생성 후 변경 불가. codec은 total(미지 입력 → `Error`), `lane_label`은 순수 함수. mli 문서에 명시.

### 명시적 Out of scope

- `Gate_surface`(presence 렌더링)는 optional-좌표 모델 유지 — rich 타입의 `channel_id` 필수와의 임피던스 조정은 별도 결정 필요.
- record의 legacy `source` 필드 은퇴는 라벨 backfill 마련 후 후속.

### 검증

- `@check` + default target EXIT=0, DET/NDT gate PASS
- 신규 `test_surface_ref` 6/6: codec totality(Agent 포함 10 variant 왕복), unknown-kind Error, `lane_label` golden, lane 왕복 3종(typed write / legacy 라벨 행 / invalid payload 행 보존)
- 영향권 6스위트: chat_store 16, mention_scope 20, surface_read 9, surface_post 7, gate_keeper_backend 29, lane_mentions 7 — 전부 green
- 로컬 빌드 `MASC_SKIP_PIN_CHECK=1` (공유 switch가 SSOT pin보다 전진, forward-only floor — broadcast 완료, OAS 표면 무관, CI가 최종 판정)

### 참고

Open PR **#20935**("RFC-0232 P3 — uid/name/path record")가 머지된 P3(#20932)와 다른 설계로 열려 있습니다 — 중복/충돌 검토 필요.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
