### PR TITLE
perf(sse): eliminate intermediate Yojson string in send_to

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -913,10 +913,8 @@ let send_to session_id json =
       "Dropping non-JSON-RPC payload sent via Sse.send_to for session %s"
       session_id
   else
-  let data = Yojson.Safe.to_string json in
-  (* Atomic allocation — see [broadcast_impl] for rationale. *)
   let current_event_id = next_id () in
-  let event = format_event ~id:current_event_id ~event_type:"message" data in
+  let event = format_event_yojson ~id:current_event_id ~event_type:"message" json in
   buffer_event current_event_id event;
   let client_opt = SMap.find_opt session_id (Atomic.get clients).entries in
   match client_opt with


### PR DESCRIPTION
Eliminate intermediate `Yojson.Safe.to_string` allocation in `send_to` (the per-session send path).

`send_to` used the same two-step `to_string → format_event` pattern that `broadcast_impl` had before PR #20965. This switches it to `format_event_yojson` which writes JSON bytes directly into the SSE event buffer, cutting one short-lived string allocation per `send_to` call.

| Path | Before | After |
|------|--------|-------|
| `send_to` | `to_string` → `format_event` | `format_event_yojson` (direct buffer) |
| `broadcast_impl` | already optimized (PR #20965) | — |

Refs: goal masc-transport-gc-storm

🤖 Generated with [Claude Code](https://claude.com/claude-code)