### PR TITLE
fix(runtime): remove provider-letter protocol labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   thinking, and strict runtime/provider materialization coverage (#20971).
 
 ### Changed
+- `runtime`: renamed checked-in OpenAI-compatible runtime protocol labels from
+  `provider_d-http`/`provider-d-cli` to `openai-compatible-http` and
+  `openai-compatible-cli`; the TOML parser still accepts legacy provider-letter
+  aliases but canonicalizes parsed provider records before exposing runtime
+  metadata.
 - Bumped the OAS agent SDK pin to `v0.206.1` at
   `a5006c5444c04e4a8af9c650015a91a098cd1d9f` and raised the
   `agent_sdk` dependency floor to `0.206.1`, picking up duplicate

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -14,7 +14,7 @@ default = "ollama_cloud.deepseek-v4-flash"
 
 [providers.ollama_cloud]
 display-name = "Ollama Cloud"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "https://ollama.com/v1"
 
 [providers.ollama_cloud.credentials]
@@ -28,7 +28,7 @@ supports-runtime-mcp-http-headers = true
 
 [providers.deepseek]
 display-name = "DeepSeek API"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "https://api.deepseek.com"
 
 [providers.deepseek.credentials]
@@ -42,7 +42,7 @@ supports-runtime-mcp-http-headers = true
 
 [providers.glm-coding]
 display-name = "GLM Coding Plan"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "https://api.z.ai/api/coding/paas/v4"
 
 [providers.glm-coding.credentials]

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -91,7 +91,7 @@ resolved config root는 별도 탐색 규칙을 가진다: `MASC_CONFIG_DIR` -> 
 | `MASC_SPAWN_TIMEOUT_SEC` | float | 600.0 | 스폰 기본 타임아웃 (10분) |
 | `MASC_SPAWN_CODING_TIMEOUT_SEC` | float | 7200.0 | 코딩 모드 타임아웃 (2시간) |
 | `MASC_SPAWN_GRACE_PERIOD_SEC` | float | 60.0 | SIGTERM 유예 기간 |
-| `LLAMA_SERVER_URL` | string | `Agent_sdk.Defaults.local_llm_url` | 로컬 Provider-D-compatible runtime URL |
+| `LLAMA_SERVER_URL` | string | `Agent_sdk.Defaults.local_llm_url` | 로컬 OpenAI-compatible runtime URL |
 | `LLAMA_DEFAULT_MODEL` | string | `explicit-model-required` | 로컬 기본 모델 |
 | `MASC_LOCAL_MAX_TOKENS` | int | 32768 | 로컬 LLM max_tokens 상한 (fallback: `MASC_LLAMA_MAX_TOKENS`) |
 | `MASC_CANCELLATION_TOKEN_MAX_AGE_SEC` | float | 3600.0 | 취소 토큰 최대 수명 |
@@ -119,7 +119,7 @@ contains four sections: `tts`, `stt`, `session`, `local_playback`.
 |----------|------|--------|------|
 | `MASC_TIMEOUT_GCLOUD_AUTH_SEC` | float | 15.0 | GCP 인증 타임아웃 |
 | `MASC_TIMEOUT_PROVIDER-A_SEC` | int | 120 | Provider-A API 타임아웃 |
-| `MASC_TIMEOUT_OPENAI_COMPAT_SEC` | int | 60 | Provider-D 호환 API 타임아웃 |
+| `MASC_TIMEOUT_OPENAI_COMPAT_SEC` | int | 60 | OpenAI-compatible API 타임아웃 |
 | `MASC_TIMEOUT_MODEL_GRACE_SEC` | float | 5.0 | 모델 호출 네트워크 유예 |
 | `MASC_TIMEOUT_GRAPHQL_SEC` | float | 5.0 | GraphQL 쿼리 타임아웃 |
 | `MASC_TIMEOUT_KEEPER_STATUS_SEC` | float | 5.0 | Keeper 상태 확인 타임아웃 |
@@ -157,7 +157,7 @@ contains four sections: `tts`, `stt`, `session`, `local_playback`.
 | `MASC_CLI_TOOL_A_AUTO_MODELS` | csv string | `"auto"` | 설정 시 `cli-tool-d:auto`를 operator 지정 후보 목록으로 확장. 미설정이면 CLI-Tool-A 기본 모델에 위임한다. |
 | `PROVIDER-C_DEFAULT_MODEL` | string | OAS runtime binding/catalog default | 설정 시 `provider-c` provider `auto` 기본 모델로 사용. |
 | `PROVIDER-A_DEFAULT_MODEL` | string | OAS runtime binding/catalog default | 설정 시 `agent-llm-a` provider `auto` 기본 모델로 사용. |
-| `OPENAI_DEFAULT_MODEL` | string | OAS runtime binding/catalog default | 설정 시 `provider-d` provider `auto` 기본 모델로 사용. |
+| `OPENAI_DEFAULT_MODEL` | string | OAS runtime binding/catalog default | 설정 시 OpenAI-compatible provider `auto` 기본 모델로 사용. |
 | `OLLAMA_DEFAULT_MODEL` | string | `""` | `ollama` provider `auto` 기본 모델 (lib/config/env_config_runtime.ml:181) |
 | `LLAMA_DEFAULT_MODEL` | string | `"explicit-model-required"` | `llama` provider legacy local runtime 기본 모델 (lib/config/env_config_runtime.ml:150) |
 | `OPENROUTER_DEFAULT_MODEL` | string | (없음) | `openrouter` provider `auto` 기본 모델 (lib/runtime/runtime_model_resolve.ml:76) |
@@ -325,7 +325,7 @@ Tier는 mode/category와 독립적으로 적용되는 추가 필터 레이어다
 
 ```toml
 [providers.cli-tool-a]
-protocol = "provider-d-cli"
+protocol = "openai-compatible-cli"
 command = "agent-code"
 is-non-interactive = true
 
@@ -365,7 +365,7 @@ Tier member는 `<provider_id>.<model_id>` 또는
 | Provider | Env Config 모듈 | 기본 모델 |
 |----------|----------------|----------|
 | `ollama` | `Local_runtime` | `OLLAMA_DEFAULT_MODEL` (port 11434, 262k context) |
-| `llama` | `Local_runtime` | `LLAMA_DEFAULT_MODEL` (legacy local Provider-D-compatible runtime) |
+| `llama` | `Local_runtime` | `LLAMA_DEFAULT_MODEL` (legacy local OpenAI-compatible runtime) |
 | `provider-k` | `Glm` | `ZAI_DEFAULT_MODEL` |
 | `provider-k-coding` | `Glm` | `ZAI_CODING_DEFAULT_MODEL` |
 | `provider-f` | `Provider-F` | `PROVIDER-F_DEFAULT_MODEL` |
@@ -373,7 +373,7 @@ Tier member는 `<provider_id>.<model_id>` 또는
 | `cli-tool-a` | CLI transport | `MASC_AGENT-CODE_CLI_AUTO_MODELS` when model is `auto` |
 | `cli-tool-d` | CLI transport | `MASC_CLI_TOOL_A_AUTO_MODELS` when model is `auto` |
 | `agent-llm-a` | `Agent-LLM-A` | `PROVIDER-A_DEFAULT_MODEL` |
-| `provider-d` | `Provider-D` | `OPENAI_DEFAULT_MODEL` |
+| `openai-compatible` | OpenAI-compatible runtime | `OPENAI_DEFAULT_MODEL` |
 | `openrouter` | `OpenRouter` | `OPENROUTER_DEFAULT_MODEL` |
 
 ### 7.3 Per-runtime 추론 파라미터

--- a/lib/core/eval_tool_selector.ml
+++ b/lib/core/eval_tool_selector.ml
@@ -36,7 +36,7 @@ let to_yojson selector =
         ; ("key", `String key)
         ; ("value", `String value)
         ]
-  | _ ->
+  | Tool_name _ | Descriptor_id _ | Runtime_handler _ | Eval_tag _ ->
       let kind, value = kind_value selector in
       `Assoc [ ("type", `String kind); ("value", `String value) ]
 

--- a/lib/keeper/keeper_event_bridge_inference.ml
+++ b/lib/keeper/keeper_event_bridge_inference.ml
@@ -1,6 +1,5 @@
 (* RFC-0166: the previous body of [inference_model_bucket] was a
-   substring classifier over upstream LLM provider names
-   ("provider_c"/"agent_llm_a"/"provider_d"/"provider_f"/"provider_k"/"provider_h"/"llama"). The
+   substring classifier over upstream LLM provider names. The
    server-side enumeration is removed: histogram label cardinality
    becomes 1 ("upstream") rather than a closed enum of providers.
    Per-provider partitioning, if needed, is now the dashboard's

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -76,9 +76,9 @@ let classify_usage_trust ~(usage_reported : bool)
    - [zero]  : context_max = 0 (uninitialised / pre-resolve)
    - [64k]   : (0, 64_000]
    - [128k]  : (64_000, 128_000]
-   - [200k]  : (128_000, 200_000]   — provider_a model-a-sonnet
-   - [256k]  : (200_000, 262_144]   — provider_c / agent_llm_a haiku 4.5
-   - [1m]    : (262_144, 1_048_576] — agent_llm_a opus 4.7 / 1M
+   - [200k]  : (128_000, 200_000]
+   - [256k]  : (200_000, 262_144]
+   - [1m]    : (262_144, 1_048_576]
    - [other] : everything else (sanity check / future caps) *)
 let context_max_bucket (n : int) : string =
   if n <= 0 then "zero"

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -61,21 +61,36 @@ let partition_results
 
 (* --- Protocol string -> Runtime_schema.api_format --- *)
 
+let canonical_protocol_of_protocol = function
+  | "provider_a-cli" -> Some "messages-cli"
+  | "provider_a-http" -> Some "messages-http"
+  | "provider_d-cli" | "provider_f-cli" | "provider_c-cli" ->
+    Some "openai-compatible-cli"
+  | "provider_d-http" -> Some "openai-compatible-http"
+  | "messages-cli" | "messages-http" | "openai-compatible-cli"
+  | "openai-compatible-http" | "ollama-http" as protocol -> Some protocol
+  | _ -> None
+;;
+
+let unknown_protocol_error s =
+  Printf.sprintf
+    "unknown protocol %S: expected one of messages-cli, messages-http, \
+     openai-compatible-cli, openai-compatible-http, ollama-http"
+    s
+;;
+
 let api_format_of_protocol (s : string)
   : (Runtime_schema.api_format, string) result
   =
   match s with
+  | "messages-cli" | "messages-http" -> Ok Runtime_schema.Messages_api
+  | "openai-compatible-cli" | "openai-compatible-http" ->
+    Ok Runtime_schema.Chat_completions_api
   | "provider_a-cli" | "provider_a-http" -> Ok Runtime_schema.Messages_api
   | "provider_d-cli" | "provider_d-http" | "provider_f-cli" | "provider_c-cli" ->
     Ok Runtime_schema.Chat_completions_api
   | "ollama-http" -> Ok Runtime_schema.Ollama_api
-  | _ ->
-    Error
-      (Printf.sprintf
-         "unknown protocol %S: expected one of provider_a-cli, provider_a-http, \
-          provider_d-cli, provider_d-http, provider_f-cli, provider_c-cli, \
-          ollama-http"
-         s)
+  | _ -> Error (unknown_protocol_error s)
 ;;
 
 (* --- Transport extraction --- *)
@@ -231,7 +246,10 @@ let parse_provider (id : string) (tbl : Otoml.t)
     match Otoml.find_opt tbl Otoml.get_string [ "protocol" ] with
     | Some p ->
       (match api_format_of_protocol p with
-       | Ok fmt -> Ok (p, fmt)
+       | Ok fmt ->
+         (match canonical_protocol_of_protocol p with
+          | Some protocol -> Ok (protocol, fmt)
+          | None -> Error (unknown_protocol_error p))
        | Error e -> Error e)
     | None -> Error "missing required field 'protocol'"
   in

--- a/lib/runtime/runtime_toml.mli
+++ b/lib/runtime/runtime_toml.mli
@@ -32,7 +32,10 @@ val parse_file : string -> (Runtime_schema.config, parse_error list) result
 (** {1 Internal: protocol resolution} *)
 
 val api_format_of_protocol : string -> (Runtime_schema.api_format, string) result
-(** Map a TOML protocol string to a {!Runtime_schema.api_format} variant. *)
+(** Map a TOML protocol string to a {!Runtime_schema.api_format} variant.
+    Deprecated provider-letter aliases are accepted only for existing live
+    config compatibility; parsed provider records use canonical protocol
+    labels. *)
 
 val transport_of_provider :
   Otoml.t -> string -> (Runtime_schema.transport, string) result

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -139,7 +139,7 @@ default = "transport_harness.smoke"
 
 [providers.transport_harness]
 display-name = "Transport Harness Smoke"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:9/v1"
 
 [models.smoke]

--- a/scripts/release-evidence.sh
+++ b/scripts/release-evidence.sh
@@ -230,7 +230,7 @@ default = "release_evidence.smoke"
 
 [providers.release_evidence]
 display-name = "Release Evidence Smoke"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:9/v1"
 
 [models.smoke]

--- a/test/keeper_tool_matrix_case_runner.ml
+++ b/test/keeper_tool_matrix_case_runner.ml
@@ -11,7 +11,7 @@ default = "test_provider.test_model"
 
 [providers.test_provider]
 display-name = "Test Provider"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:1"
 
 [models.test_model]

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -34,7 +34,7 @@ default = "test_provider.test_model"
 
 [providers.test_provider]
 display-name = "Test Provider"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:1"
 
 [models.test_model]

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -49,7 +49,7 @@ default = "test_provider.test_model"
 
 [providers.test_provider]
 display-name = "Test Provider"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:1"
 
 [models.test_model]

--- a/test/test_keeper_reactive_wake_backlog_gate.ml
+++ b/test/test_keeper_reactive_wake_backlog_gate.ml
@@ -35,7 +35,7 @@ default = "test_provider.test_model"
 
 [providers.test_provider]
 display-name = "Test Provider"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:1"
 
 [models.test_model]

--- a/test/test_keeper_runtime_denylist.ml
+++ b/test/test_keeper_runtime_denylist.ml
@@ -27,7 +27,7 @@ default = "test.local"
 
 [providers.test]
 display-name = "Test"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:1"
 
 [models.local]

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -34,7 +34,7 @@ default = "test_provider.test_model"
 
 [providers.test_provider]
 display-name = "Test Provider"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:1"
 
 [models.test_model]

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -440,7 +440,7 @@ default = "test_provider.test_model"
 
 [providers.test_provider]
 display-name = "Test Provider"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:1"
 
 [models.test_model]

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -51,7 +51,7 @@ default = "test_provider.test_model"
 
 [providers.test_provider]
 display-name = "Test Provider"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:1"
 
 [models.test_model]

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -74,7 +74,7 @@ default = "test_provider.test_model"
 
 [providers.test_provider]
 display-name = "Test Provider"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:1"
 
 [models.test_model]

--- a/test/test_keeper_transition_audit.ml
+++ b/test/test_keeper_transition_audit.ml
@@ -44,7 +44,7 @@ default = "test_provider.test_model"
 
 [providers.test_provider]
 display-name = "Test Provider"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:1"
 
 [models.test_model]

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -105,12 +105,12 @@ budgettest = "openai.gpt"
 
 [providers.runpod_mtp]
 display-name = "RunPod"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "https://runpod.example/v1"
 
 [providers.openai]
 display-name = "OpenAI"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "https://api.openai.example/v1"
 
 [models.qwen]
@@ -142,12 +142,12 @@ default = "openai.gpt"
 
 [providers.runpod_mtp]
 display-name = "RunPod"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "https://runpod.example/v1"
 
 [providers.openai]
 display-name = "OpenAI"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "https://api.openai.example/v1"
 
 [models.qwen]
@@ -409,7 +409,7 @@ default = "ollama_cloud.think"
 
 [providers.ollama_cloud]
 display-name = "Ollama Cloud"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "https://ollama.example/v1"
 
 [models.think]

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -31,7 +31,7 @@ let with_env key value f =
 let runpod_provider =
   { Runtime_schema.id = "runpod_mtp"
   ; display_name = "RunPod"
-  ; protocol = "provider_d-http"
+  ; protocol = "openai-compatible-http"
   ; api_format = Chat_completions_api
   ; transport = Http "https://example-runpod.proxy.runpod.net/v1"
   ; is_non_interactive = true
@@ -72,7 +72,7 @@ default = "runpod_mtp.qwen"
 
 [providers.runpod_mtp]
 display-name = "RunPod"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "https://example-runpod.proxy.runpod.net/v1"
 
 %s
@@ -152,6 +152,45 @@ key = " OLLAMA_CLOUD_API_KEY "
         | None -> fail "expected credential")
      | _ -> fail "expected one provider")
 
+let test_runtime_toml_canonicalizes_legacy_protocol_alias () =
+  let content =
+    {|
+[runtime]
+default = "legacy_openai_compat.test_model"
+
+[providers.legacy_openai_compat]
+display-name = "Legacy OpenAI-Compatible"
+protocol = "provider_d-http"
+endpoint = "https://legacy-openai-compatible.example/v1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[legacy_openai_compat.test_model]
+max-concurrent = 1
+|}
+  in
+  match Runtime_toml.parse_string content with
+  | Error errors ->
+    fail
+      (errors
+       |> List.map (fun (err : Runtime_toml.parse_error) ->
+         err.path ^ ": " ^ err.message)
+       |> String.concat "; ")
+  | Ok config ->
+    (match config.providers with
+     | [ provider ] ->
+       check string "canonical protocol" "openai-compatible-http"
+         provider.Runtime_schema.protocol;
+       check bool "chat-completions api format" true
+         (match provider.Runtime_schema.api_format with
+          | Chat_completions_api -> true
+          | Messages_api | Ollama_api -> false)
+     | _ -> fail "expected one provider")
+
 let deepseek_runtime_toml =
   {|
 [runtime]
@@ -159,7 +198,7 @@ default = "deepseek.deepseek-v4-pro"
 
 [providers.deepseek]
 display-name = "DeepSeek API"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "https://api.deepseek.com"
 
 [providers.deepseek.credentials]
@@ -218,7 +257,7 @@ default = "glm-coding.glm-4-7-coding"
 
 [providers.glm-coding]
 display-name = "GLM Coding Plan"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "https://api.z.ai/api/coding/paas/v4"
 
 [providers.glm-coding.credentials]
@@ -720,6 +759,10 @@ let () =
             "runtime TOML trims env credential key"
             `Quick
             test_runtime_toml_trims_env_credential_key
+        ; test_case
+            "runtime TOML canonicalizes legacy protocol alias"
+            `Quick
+            test_runtime_toml_canonicalizes_legacy_protocol_alias
         ; test_case
             "runtime TOML accepts DeepSeek reasoning effort"
             `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -497,7 +497,7 @@ let write_partially_invalid_runtime ~base_path ~valid_model =
     (Filename.concat config_root "runtime.toml")
     (Printf.sprintf
        {|[providers.custom]
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = %S
 
 [models.stable]
@@ -532,7 +532,7 @@ let write_partially_invalid_default_runtime ~base_path ~valid_model =
     (Filename.concat config_root "runtime.toml")
     (Printf.sprintf
        {|[providers.custom]
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = %S
 
 [models.stable]

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -302,7 +302,7 @@ default = "sse_storm.smoke"
 
 [providers.sse_storm]
 display-name = "SSE Storm Smoke"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:9/v1"
 
 [models.smoke]

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -172,7 +172,7 @@ let test_forbidden_selector_matches_descriptor_evidence () =
       ()
   in
   let run = selector_run [ selector_tool_call ~route_evidence "masc_agent_card" ] in
-  match Tool_call_quality_benchmark_scoring.score_run ~cases:[ case ] run with
+  match Tool_call_quality_benchmark.score_run ~cases:[ case ] run with
   | Some score ->
       check bool "selector degrades pass" false score.passed;
       check (float 0.0001) "tool selection failed" 0.0 score.tool_selection;
@@ -194,7 +194,7 @@ let test_forbidden_selector_matches_eval_tag_evidence () =
       ()
   in
   let run = selector_run [ selector_tool_call ~route_evidence "renamed_agent_card" ] in
-  match Tool_call_quality_benchmark_scoring.score_run ~cases:[ case ] run with
+  match Tool_call_quality_benchmark.score_run ~cases:[ case ] run with
   | Some score ->
       check bool "eval tag degrades pass" false score.passed;
       check (float 0.0001) "tool selection failed" 0.0 score.tool_selection

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -16,7 +16,7 @@ default = "test_provider.test_model"
 
 [providers.test_provider]
 display-name = "Test Provider"
-protocol = "provider_d-http"
+protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:1"
 
 [models.test_model]


### PR DESCRIPTION
## Summary
- Replace checked-in runtime TOML `provider_d-http` and `provider-d-cli` protocol labels with `openai-compatible-http` / `openai-compatible-cli`.
- Keep legacy aliases accepted in the TOML parser but canonicalize parsed provider metadata before exposing it.
- Update config docs, runtime fixtures, scripts, and keeper metric comments to avoid provider-letter labels in current surfaces.
- Repair latest-main CI drift exposed after rebase:
  - enumerate `Eval_tool_selector.to_yojson` constructors instead of wildcard matching under `-warn-error +a`
  - route benchmark selector tests through the public `Tool_call_quality_benchmark.score_run` facade so types stay on the public boundary

## Verification
- `git diff --check`
- `bash scripts/ci/check-determinism-contract.sh`
- `rg -n 'protocol = "provider_d-http"|protocol = "provider-d-cli"' config scripts test lib/runtime docs/spec/14-configuration.md` only reports the legacy alias compatibility test fixture
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_THROTTLE=0 MASC_SKIP_PIN_CHECK=1 DUNE_BUILD_DIR=/tmp/masc-provider-labels-build scripts/dune-local.sh build test/test_tool_call_quality_benchmark.exe test/test_eval_tool_selector_boundary.exe test/test_keeper_unified_turn_attempt_watchdog.exe test/test_runtime_provider_auth_headers.exe test/test_runtime_per_keeper_routing.exe test/test_runtime_config_validity.exe`
- `env OCAMLPARAM=_,warn-error=+a MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_THROTTLE=0 MASC_SKIP_PIN_CHECK=1 DUNE_BUILD_DIR=/tmp/masc-provider-labels-build scripts/dune-local.sh build test/test_tool_call_quality_benchmark.exe test/test_eval_tool_selector_boundary.exe test/test_keeper_unified_turn_attempt_watchdog.exe`
- `/tmp/masc-provider-labels-build/default/test/test_tool_call_quality_benchmark.exe`
- `/tmp/masc-provider-labels-build/default/test/test_eval_tool_selector_boundary.exe`
- `/tmp/masc-provider-labels-build/default/test/test_keeper_unified_turn_attempt_watchdog.exe`
- `/tmp/masc-provider-labels-build/default/test/test_runtime_provider_auth_headers.exe`
- `/tmp/masc-provider-labels-build/default/test/test_runtime_per_keeper_routing.exe`
- `/tmp/masc-provider-labels-build/default/test/test_runtime_config_validity.exe`

## Notes
- Legacy `provider_d-http` remains accepted only for already-materialized live config compatibility and is covered by a parser test.
