### PR TITLE
[codex] Fix keeper turn driver accept test namespace

### DIFF
--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -1,3 +1,5 @@
+open Masc
+
 let contains ~needle haystack =
   let needle_len = String.length needle in
   let haystack_len = String.length haystack in


### PR DESCRIPTION
## Summary

- open the wrapped Masc library in test_keeper_turn_driver_accept
- fixes the CI "Unbound module Keeper_turn_driver_try_provider" error after #20959 merged

## Validation

- git diff --check origin/main..HEAD

## Notes

- Focused local Dune build was not run because existing bare dune build processes were already active on this machine; CI should validate the one-line test compile fix.
