### PR TITLE
[codex] Classify keeper accept rejection reasons

### DIFF
--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -186,7 +186,14 @@ let body_timeout_for_attempt ?per_provider_timeout_s () =
   | Some _ as s -> s
   | None -> max_execution_time_for_attempt ?per_provider_timeout_s ()
 
-let accept_rejected_error ~runtime_id =
+let accept_rejection_reason response =
+  match Keeper_tool_response.response_accept_rejection_reason response with
+  | Some reason -> reason
+  | None -> "accept_predicate_false"
+;;
+
+let accept_rejected_error ~runtime_id response =
+  let reason_code = accept_rejection_reason response in
   Keeper_internal_error.sdk_error_of_masc_internal_error
     (Keeper_internal_error.Accept_rejected
        {
@@ -196,12 +203,15 @@ let accept_rejected_error ~runtime_id =
              (Boundary_redaction.to_string
                 Boundary_redaction.runtime_model_label);
          reason =
-           Printf.sprintf "response rejected by accept (runtime=%s)" runtime_id;
+           Printf.sprintf
+             "response rejected by accept (runtime=%s reason=%s)"
+             runtime_id
+             reason_code;
        })
 
 let apply_accept ~runtime_id ~accept (run_result : Runtime_agent.run_result) =
   if accept run_result.response then Ok run_result
-  else Error (accept_rejected_error ~runtime_id)
+  else Error (accept_rejected_error ~runtime_id run_result.response)
 
 (** Run a single provider attempt within the runtime.
 

--- a/lib/keeper_tooling/keeper_tool_response.ml
+++ b/lib/keeper_tooling/keeper_tool_response.ml
@@ -33,3 +33,37 @@ let response_has_text_or_tool_progress (response : Agent_sdk.Types.api_response)
        response.content
   || response.stop_reason <> Agent_sdk.Types.EndTurn
 ;;
+
+let response_accept_rejection_reason (response : Agent_sdk.Types.api_response) =
+  if response_has_text_or_tool_progress response
+  then None
+  else (
+    let has_thinking =
+      List.exists
+        (function
+          | Agent_sdk.Types.Thinking _ | Agent_sdk.Types.RedactedThinking _ -> true
+          | _ -> false)
+        response.content
+    in
+    let has_blank_text =
+      List.exists
+        (function
+          | Agent_sdk.Types.Text text -> String.trim text = ""
+          | _ -> false)
+        response.content
+    in
+    let has_tool_result =
+      List.exists
+        (function
+          | Agent_sdk.Types.ToolResult _ -> true
+          | _ -> false)
+        response.content
+    in
+    Some
+      (match response.content with
+       | [] -> "empty_end_turn"
+       | _ when has_thinking -> "thinking_only"
+       | _ when has_blank_text -> "blank_text"
+       | _ when has_tool_result -> "tool_result_only"
+       | _ -> "no_visible_progress"))
+;;

--- a/lib/keeper_tooling/keeper_tool_response.mli
+++ b/lib/keeper_tooling/keeper_tool_response.mli
@@ -15,3 +15,8 @@ val normalize_response_text
     Empty [end_turn] responses are rejected so runtime can try the next
     candidate instead of failing later as "no textual reply". *)
 val response_has_text_or_tool_progress : Agent_sdk.Types.api_response -> bool
+
+(** Stable reason code for responses rejected by
+    {!response_has_text_or_tool_progress}. Returns [None] for acceptable
+    responses. *)
+val response_accept_rejection_reason : Agent_sdk.Types.api_response -> string option

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -7,19 +7,19 @@ let contains ~needle haystack =
   in
   needle_len = 0 || loop 0
 
-let empty_response () =
+let response ?(content = []) ?(stop_reason = Agent_sdk.Types.EndTurn) () =
   {
     Agent_sdk.Types.id = "resp-test";
     model = "model-test";
-    stop_reason = Agent_sdk.Types.EndTurn;
-    content = [];
+    stop_reason;
+    content;
     usage = None;
     telemetry = None;
   }
 
-let run_result () : Runtime_agent.run_result =
+let run_result ?content ?stop_reason () : Runtime_agent.run_result =
   {
-    response = empty_response ();
+    response = response ?content ?stop_reason ();
     checkpoint = None;
     session_id = "session-test";
     turns = 1;
@@ -31,7 +31,7 @@ let run_result () : Runtime_agent.run_result =
 
 let test_accept_keeps_result () =
   let result =
-    Keeper_turn_driver_try_provider.For_testing.apply_accept
+    Masc.Keeper_turn_driver_try_provider.For_testing.apply_accept
       ~runtime_id:"ollama.test"
       ~accept:(fun _ -> true)
       (run_result ())
@@ -43,13 +43,7 @@ let test_accept_keeps_result () =
     Alcotest.failf "accepted response should pass through: %s"
       (Agent_sdk.Error.to_string err)
 
-let test_rejects_as_typed_accept_error () =
-  let result =
-    Keeper_turn_driver_try_provider.For_testing.apply_accept
-      ~runtime_id:"ollama.gemma4-26b-a4b-qat"
-      ~accept:(fun _ -> false)
-      (run_result ())
-  in
+let check_accept_rejected_reason ~expected_reason result =
   match result with
   | Ok _ -> Alcotest.fail "rejected response should fail"
   | Error err ->
@@ -62,13 +56,53 @@ let test_rejects_as_typed_accept_error () =
        Alcotest.(check bool)
          "reason mentions accept rejection"
          true
-         (contains ~needle:"response rejected by accept" reason)
+         (contains ~needle:"response rejected by accept" reason);
+       Alcotest.(check bool)
+         "reason includes response shape"
+         true
+         (contains ~needle:expected_reason reason)
      | Some other ->
        Alcotest.failf "expected Accept_rejected, got %s"
          (Keeper_internal_error.kind_of_masc_internal_error other)
      | None ->
        Alcotest.failf "expected typed keeper error, got %s"
          (Agent_sdk.Error.to_string err))
+
+let reject_result run_result =
+  Masc.Keeper_turn_driver_try_provider.For_testing.apply_accept
+    ~runtime_id:"ollama.gemma4-26b-a4b-qat"
+    ~accept:(fun _ -> false)
+    run_result
+
+let test_rejects_empty_end_turn_with_reason () =
+  let result =
+    reject_result
+      (run_result ~content:[] ~stop_reason:Agent_sdk.Types.EndTurn ())
+  in
+  check_accept_rejected_reason ~expected_reason:"reason=empty_end_turn" result
+
+let test_rejects_thinking_only_with_reason () =
+  let result =
+    reject_result
+      (run_result
+         ~content:
+           [ Agent_sdk.Types.Thinking
+               { thinking_type = "thinking"; content = "reasoning only" }
+           ]
+         ~stop_reason:Agent_sdk.Types.EndTurn
+         ())
+  in
+  check_accept_rejected_reason ~expected_reason:"reason=thinking_only" result
+
+let test_rejects_visible_response_as_predicate_false () =
+  let result =
+    reject_result
+      (run_result
+         ~content:[ Agent_sdk.Types.Text "visible but custom-rejected" ]
+         ~stop_reason:Agent_sdk.Types.EndTurn
+         ())
+  in
+  check_accept_rejected_reason ~expected_reason:"reason=accept_predicate_false" result
 
 let () =
   Alcotest.run "keeper_turn_driver_accept"
@@ -77,7 +111,11 @@ let () =
       , [
           Alcotest.test_case "accepted response passes through" `Quick
             test_accept_keeps_result;
-          Alcotest.test_case "rejected response is typed" `Quick
-            test_rejects_as_typed_accept_error;
+          Alcotest.test_case "empty end_turn rejection is typed" `Quick
+            test_rejects_empty_end_turn_with_reason;
+          Alcotest.test_case "thinking-only rejection is typed" `Quick
+            test_rejects_thinking_only_with_reason;
+          Alcotest.test_case "custom predicate rejection is typed" `Quick
+            test_rejects_visible_response_as_predicate_false;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add stable keeper response rejection reason codes for empty/thinking-only/no-progress responses
- thread the reason code into typed Accept_rejected errors
- extend the run_named accept regression to cover empty, thinking-only, and custom predicate rejection paths

## Validation
- PASS: ocamlformat --check lib/keeper_tooling/keeper_tool_response.ml lib/keeper_tooling/keeper_tool_response.mli lib/keeper/keeper_turn_driver_try_provider.ml test/test_keeper_turn_driver_accept.ml
- PASS: git diff --check
- PASS: CI workflow_dispatch on head 9804dc4ab47263dcfa3484da92a61d7858e393e2: https://github.com/jeong-sik/masc/actions/runs/27399977994
  - Build and Test: success
  - Health: success
  - Lint: success
  - Dashboard: success
  - Meta Guards / OCaml Structure Ratchet / Shell IR Consumption Ratchet / CI Gate: success
- NOTE: the first pull_request CI run on old head 47a2c2ed failed because the grouped test stanza compiled test/test_keeper_turn_driver_accept.ml without the private module in scope. The fix namespaces the test reference through Masc.Keeper_turn_driver_try_provider and the new-head CI above is green.
- NOTE: PR statusCheckRollup is currently empty after the force-push on this draft PR, so the green evidence is the explicit workflow_dispatch run linked above.