### PR TITLE
[codex] add harness tool selectors

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -97,6 +97,16 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/no-keeper-behavior-hardcoding.sh
 
+  no-eval-tool-selector-runtime-import:
+    name: Eval tool selector runtime boundary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Run lint
+        run: bash scripts/lint/no-eval-tool-selector-runtime-import.sh
+
   no-legacy-tool-surface-name:
     name: Legacy tool surface name ratchet (RFC-0064)
     runs-on: ubuntu-latest

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -1,7 +1,7 @@
 # Keeper Tool Boundary Matrix
 
 Status: P0 ratchet source for keeper agent tool boundaries.
-Last updated: 2026-06-05.
+Last updated: 2026-06-12.
 
 This matrix freezes the owner map for keeper modules that participate in the
 agent tool path. A new file in scope must be added here with exactly one owner
@@ -70,6 +70,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_execution_receipt.mli` - execution-dispatch
 - `lib/keeper/keeper_execution.ml` - execution-dispatch
 - `lib/keeper/keeper_execution.mli` - execution-dispatch
+- `lib/keeper/keeper_execution_join.ml` - execution-dispatch
+- `lib/keeper/keeper_execution_join.mli` - execution-dispatch
 - `lib/keeper/keeper_hooks_oas_cost_events.ml` - hook-observation
 - `lib/keeper/keeper_hooks_oas_cost_events.mli` - hook-observation
 - `lib/keeper/keeper_hooks_oas_idle.ml` - hook-observation

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -30,7 +30,8 @@
   read_drop_reason
   actor_types
   actor_mailbox
-  tool_name_alias_axis)
+  tool_name_alias_axis
+  eval_tool_selector)
  (libraries
   yojson
   unix

--- a/lib/core/eval_tool_selector.ml
+++ b/lib/core/eval_tool_selector.ml
@@ -1,0 +1,132 @@
+type t =
+  | Tool_name of string
+  | Descriptor_id of string
+  | Runtime_handler of string
+  | Receipt_label of string * string
+  | Eval_tag of string
+
+type call =
+  { tool_name : string
+  ; route_evidence : Yojson.Safe.t option
+  }
+
+let trim_nonempty value =
+  let trimmed = String.trim value in
+  if String.equal trimmed "" then None else Some trimmed
+
+let label = function
+  | Tool_name value -> "tool_name:" ^ value
+  | Descriptor_id value -> "descriptor_id:" ^ value
+  | Runtime_handler value -> "runtime_handler:" ^ value
+  | Receipt_label (key, value) -> "receipt_label:" ^ key ^ "=" ^ value
+  | Eval_tag value -> "eval_tag:" ^ value
+
+let kind_value = function
+  | Tool_name value -> ("tool_name", value)
+  | Descriptor_id value -> ("descriptor_id", value)
+  | Runtime_handler value -> ("runtime_handler", value)
+  | Eval_tag value -> ("eval_tag", value)
+  | Receipt_label _ -> ("receipt_label", "")
+
+let to_yojson selector =
+  match selector with
+  | Receipt_label (key, value) ->
+      `Assoc
+        [ ("type", `String "receipt_label")
+        ; ("key", `String key)
+        ; ("value", `String value)
+        ]
+  | _ ->
+      let kind, value = kind_value selector in
+      `Assoc [ ("type", `String kind); ("value", `String value) ]
+
+let string_field json key =
+  match Json_util.assoc_member_opt key json with
+  | Some (`String value) -> trim_nonempty value
+  | _ -> None
+
+let errorf fmt = Printf.ksprintf (fun msg -> Error msg) fmt
+
+let of_kind_value ~kind ~value =
+  match String.lowercase_ascii (String.trim kind), trim_nonempty value with
+  | _, None -> errorf "tool selector %S has empty value" kind
+  | ("tool_name" | "tool" | "name"), Some value -> Ok (Tool_name value)
+  | ("descriptor_id" | "descriptor"), Some value -> Ok (Descriptor_id value)
+  | ("runtime_handler" | "handler"), Some value -> Ok (Runtime_handler value)
+  | ("eval_tag" | "tag"), Some value -> Ok (Eval_tag value)
+  | other, Some _ -> errorf "unknown tool selector type: %s" other
+
+let of_yojson = function
+  | `String value -> (
+      match trim_nonempty value with
+      | Some value -> Ok (Tool_name value)
+      | None -> Error "tool selector string must be non-empty")
+  | `Assoc _ as json -> (
+      match string_field json "type", string_field json "kind" with
+      | Some "receipt_label", _ | _, Some "receipt_label" -> (
+          match string_field json "key", string_field json "value" with
+          | Some key, Some value -> Ok (Receipt_label (key, value))
+          | _ -> Error "receipt_label selector requires non-empty key and value")
+      | Some kind, _ -> (
+          match string_field json "value" with
+          | Some value -> of_kind_value ~kind ~value
+          | None -> errorf "tool selector %S requires non-empty value" kind)
+      | None, Some kind -> (
+          match string_field json "value" with
+          | Some value -> of_kind_value ~kind ~value
+          | None -> errorf "tool selector %S requires non-empty value" kind)
+      | None, None -> (
+          match
+            string_field json "tool_name",
+            string_field json "descriptor_id",
+            string_field json "runtime_handler",
+            string_field json "eval_tag"
+          with
+          | Some value, _, _, _ -> Ok (Tool_name value)
+          | _, Some value, _, _ -> Ok (Descriptor_id value)
+          | _, _, Some value, _ -> Ok (Runtime_handler value)
+          | _, _, _, Some value -> Ok (Eval_tag value)
+          | None, None, None, None ->
+              Error
+                "tool selector object requires type/value or one selector field"))
+  | other ->
+      errorf "tool selector must be string or object, got %s"
+        (Json_util.kind_name other)
+
+let route_string_field field route_evidence =
+  match route_evidence with
+  | Some json -> Json_util.assoc_string_opt field json
+  | None -> None
+
+let receipt_label_value key route_evidence =
+  match route_evidence with
+  | Some json -> (
+      match Json_util.assoc_member_opt "receipt_labels" json with
+      | Some (`Assoc fields) -> (
+          match List.assoc_opt key fields with
+          | Some (`String value) -> Some value
+          | _ -> None)
+      | _ -> None)
+  | None -> None
+
+let eval_tags route_evidence =
+  match route_evidence with
+  | Some json -> Json_util.json_string_list_member "eval_tags" json
+  | None -> []
+
+let matches selector call =
+  match selector with
+  | Tool_name expected -> String.equal call.tool_name expected
+  | Descriptor_id expected ->
+      Option.equal String.equal
+        (Some expected)
+        (route_string_field "descriptor_id" call.route_evidence)
+  | Runtime_handler expected ->
+      Option.equal String.equal
+        (Some expected)
+        (route_string_field "runtime_handler" call.route_evidence)
+  | Receipt_label (key, expected) ->
+      Option.equal String.equal
+        (Some expected)
+        (receipt_label_value key call.route_evidence)
+  | Eval_tag expected -> List.exists (String.equal expected) (eval_tags call.route_evidence)

--- a/lib/core/eval_tool_selector.mli
+++ b/lib/core/eval_tool_selector.mli
@@ -1,0 +1,37 @@
+(** Descriptor-aware eval tool-call selector for harness and benchmark checks.
+
+    Selectors are observational: they match recorded tool-call evidence
+    and must not be used as live keeper control-flow gates or live
+    tool-availability policy. *)
+
+type t =
+  | Tool_name of string
+  | Descriptor_id of string
+  | Runtime_handler of string
+  | Receipt_label of string * string
+  | Eval_tag of string
+
+type call =
+  { tool_name : string
+  ; route_evidence : Yojson.Safe.t option
+  }
+
+val label : t -> string
+(** Stable human-readable label used in diagnostics. *)
+
+val to_yojson : t -> Yojson.Safe.t
+val of_yojson : Yojson.Safe.t -> (t, string) result
+(** Parse selector JSON.
+
+    Supported shapes:
+
+    - ["tool_execute"] as legacy shorthand for [Tool_name].
+    - [{"type":"tool_name","value":"tool_execute"}].
+    - [{"type":"descriptor_id","value":"masc.agent.card"}].
+    - [{"type":"runtime_handler","value":"Tool_masc_agent_dispatch"}].
+    - [{"type":"eval_tag","value":"agent_profile_lookup"}].
+    - [{"type":"receipt_label","key":"family","value":"agent_profile_lookup"}]. *)
+
+val matches : t -> call -> bool
+(** [matches selector call] returns [true] when the selector matches the
+    call's tool name or descriptor route evidence. *)

--- a/lib/eval_harness.ml
+++ b/lib/eval_harness.ml
@@ -46,7 +46,8 @@ type grader =
 (* ================================================================ *)
 
 type tool_expectation = {
-  tool_name : string;            (** Expected tool to be called *)
+  tool_name : string;            (** Legacy diagnostic label / exact tool fallback *)
+  selector : Eval_tool_selector.t;    (** Descriptor-aware selector to match *)
   required : bool;               (** Must this tool be called? *)
   max_calls : int option;        (** Max times this tool should be called *)
   args_contain : string option;  (** Args should contain this substring *)
@@ -162,12 +163,17 @@ let apply_deterministic_grader (g : deterministic_grader) (value : string) : gra
   }
 
 (** Check tool expectations against actual tool calls made. *)
-let check_tool_expectations
+let check_tool_expectations_with_evidence
     (expectations : tool_expectation list)
-    (actual_calls : string list)
+    (actual_calls : Eval_tool_selector.call list)
     : grader_result list =
   List.map (fun (exp : tool_expectation) ->
-    let call_count = List_util.count_if (fun c -> c = exp.tool_name) actual_calls in
+    let selector_label = Eval_tool_selector.label exp.selector in
+    let call_count =
+      List_util.count_if
+        (fun call -> Eval_tool_selector.matches exp.selector call)
+        actual_calls
+    in
     let required_ok = if exp.required then call_count > 0 else true in
     let max_ok = match exp.max_calls with
       | None -> true
@@ -176,20 +182,29 @@ let check_tool_expectations
     let passed = required_ok && max_ok in
     let detail =
       if not required_ok then
-        Printf.sprintf "required tool '%s' was not called" exp.tool_name
+        Printf.sprintf "required tool selector '%s' was not called" selector_label
       else if not max_ok then
-        Printf.sprintf "tool '%s' called %d times (max: %d)"
-          exp.tool_name call_count (Option.value ~default:0 exp.max_calls)
+        Printf.sprintf "tool selector '%s' called %d times (max: %d)"
+          selector_label call_count (Option.value ~default:0 exp.max_calls)
       else
-        Printf.sprintf "tool '%s' called %d times — OK" exp.tool_name call_count
+        Printf.sprintf "tool selector '%s' called %d times — OK"
+          selector_label call_count
     in
-    { grader_desc = Printf.sprintf "tool_expectation: %s" exp.tool_name;
+    { grader_desc = Printf.sprintf "tool_expectation: %s" selector_label;
       score = if passed then 1.0 else 0.0;
       weight = 0.5;  (* tool expectations are secondary to content graders *)
       passed;
       detail;
     }
   ) expectations
+
+let check_tool_expectations expectations actual_calls =
+  let calls =
+    actual_calls
+    |> List.map (fun tool_name ->
+           ({ tool_name; route_evidence = None } : Eval_tool_selector.call))
+  in
+  check_tool_expectations_with_evidence expectations calls
 
 (* ================================================================ *)
 (* Score computation                                                 *)
@@ -467,15 +482,36 @@ let scenario_of_json (json : Yojson.Safe.t) : (scenario, string) result =
       match Json_util.assoc_member_opt "tool_expectations" json with
       | Some (`List items) ->
           List.filter_map (fun te ->
-            try Some {
-              tool_name = Json_util.get_string te "tool" |> Option.value ~default:"";
-              required = (match Json_util.assoc_member_opt "required" te with
-                | Some (`Bool b) -> b | _ -> false);
-              max_calls = (match Json_util.assoc_member_opt "max_calls" te with
-                | Some (`Int i) -> Some i | _ -> None);
-              args_contain = (match Json_util.assoc_member_opt "args_contain" te with
-                | Some (`String s) -> Some s | _ -> None);
-            }
+            try
+              let legacy_tool =
+                Json_util.get_string te "tool"
+                |> Option.value ~default:
+                     (Json_util.get_string te "tool_name"
+                      |> Option.value ~default:"")
+              in
+              let selector =
+                match Json_util.assoc_member_opt "selector" te with
+                | Some selector_json -> (
+                    match Eval_tool_selector.of_yojson selector_json with
+                    | Ok selector -> selector
+                    | Error _ -> Eval_tool_selector.Tool_name legacy_tool)
+                | None -> Eval_tool_selector.Tool_name legacy_tool
+              in
+              let tool_name =
+                if String.trim legacy_tool = ""
+                then Eval_tool_selector.label selector
+                else legacy_tool
+              in
+              Some {
+                tool_name;
+                selector;
+                required = (match Json_util.assoc_member_opt "required" te with
+                  | Some (`Bool b) -> b | _ -> false);
+                max_calls = (match Json_util.assoc_member_opt "max_calls" te with
+                  | Some (`Int i) -> Some i | _ -> None);
+                args_contain = (match Json_util.assoc_member_opt "args_contain" te with
+                  | Some (`String s) -> Some s | _ -> None);
+              }
             with Yojson.Safe.Util.Type_error _ -> None
           ) items
       | _ -> []

--- a/lib/eval_harness.mli
+++ b/lib/eval_harness.mli
@@ -48,6 +48,7 @@ type grader =
 
 type tool_expectation = {
   tool_name : string;
+  selector : Eval_tool_selector.t;
   required : bool;
   max_calls : int option;
   args_contain : string option;
@@ -128,6 +129,14 @@ val check_tool_expectations :
   grader_result list
 (** Run every tool expectation against the actual tool-call name
     list and return one [grader_result] per expectation. *)
+
+val check_tool_expectations_with_evidence :
+  tool_expectation list ->
+  Eval_tool_selector.call list ->
+  grader_result list
+(** Run every tool expectation against descriptor-aware tool-call
+    evidence. Use this for replay/shadow harnesses that carry
+    [route_evidence]. *)
 
 (** {1 Pass@k + summary} *)
 

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
@@ -81,6 +81,14 @@ let string_list_field json key =
       |> List.filter_map (function `String s -> Some s | _ -> None)
       |> normalize_string_list)
 
+let selector_list_field json key =
+  let* items = list_field json key in
+  items
+  |> map_m (fun item ->
+         match Eval_tool_selector.of_yojson item with
+         | Ok selector -> Ok selector
+         | Error msg -> errorf "invalid %s entry: %s" key msg)
+
 let parse_json_check json =
   let* path = required_string_field json "path" in
   Ok {
@@ -138,6 +146,7 @@ let benchmark_case_of_yojson json =
   in
   let* prompt = required_string_field json "prompt" in
   let* forbidden_tools = string_list_field json "forbidden_tools" in
+  let* forbidden_selectors = selector_list_field json "forbidden_selectors" in
   let* category =
     Json_util.get_string json "category"
     |> Option.value ~default:"tool_use"
@@ -156,6 +165,7 @@ let benchmark_case_of_yojson json =
     category;
     keeper_profiles;
     forbidden_tools;
+    forbidden_selectors;
     max_tool_calls;
     success_checks;
     arg_checks;
@@ -171,6 +181,7 @@ let tool_call_of_yojson json =
     success = Json_util.get_bool json "success" |> Option.value ~default:false;
     input = (match member_opt "input" json with Some value -> value | None -> `Assoc []);
     output = member_opt "output" json;
+    route_evidence = member_opt "route_evidence" json;
     duration_ms = Json_util.get_float json "duration_ms";
   }
 

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.mli
@@ -48,7 +48,7 @@ val load_cases_from_file :
     - [category] defaults to [["tool_use"]] when absent;
       unknown categories return [Error "unknown tool-call-quality
       category: <other>"]
-    - [forbidden_tools] / [arg_checks]
+    - [forbidden_tools] / [forbidden_selectors] / [arg_checks]
       default to empty lists
     - [recovery_policy] defaults to [None] (case has no recovery
       requirement)
@@ -88,6 +88,7 @@ val load_runs_from_file :
     | [success] | [false] |
     | [input] | [`Assoc []] |
     | [output] | [None] |
+    | [route_evidence] | [None] |
     | [duration_ms] | [None] |
 
     The [tool_name] vs [tool] alias is intentional — older

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.ml
@@ -94,19 +94,6 @@ let evaluate_json_check ~(target : Yojson.Safe.t option) (check : json_check) =
   in
   present_ok && equals_ok && contains_ok && min_int_ok
 
-(* Build a name-keyed set over [run.tool_calls] in one pass.  Used by
-   [forbidden_tool_used] to replace repeated linear scans with one
-   O(C) build plus O(1) lookups. *)
-let tool_call_name_set (run : evidence_run) =
-  let tbl = Hashtbl.create (List.length run.tool_calls) in
-  List.iter (fun call -> Hashtbl.replace tbl call.tool_name ()) run.tool_calls;
-  tbl
-
-let name_set_of_list names =
-  let tbl = Hashtbl.create (List.length names) in
-  List.iter (fun name -> Hashtbl.replace tbl name ()) names;
-  tbl
-
 let arg_check_passes (run : evidence_run) (check : arg_check) =
   let predicate call =
     String.equal call.tool_name check.tool_name
@@ -123,14 +110,19 @@ let arg_check_passes (run : evidence_run) (check : arg_check) =
 let tool_sequence (run : evidence_run) =
   run.tool_calls |> List.map (fun call -> call.tool_name)
 
+let selector_call_view (call : tool_call) : Eval_tool_selector.call =
+  { tool_name = call.tool_name; route_evidence = call.route_evidence }
+
+let forbidden_call_used_by_case (benchmark_case : benchmark_case) (call : tool_call) =
+  List.exists (String.equal call.tool_name) benchmark_case.forbidden_tools
+  || List.exists
+       (fun selector -> Eval_tool_selector.matches selector (selector_call_view call))
+       benchmark_case.forbidden_selectors
+
 let forbidden_tool_used (benchmark_case : benchmark_case) (run : evidence_run) =
   match benchmark_case.category with
   | Tool_forbidden -> Stdlib.List.length run.tool_calls > 0
-  | _ ->
-      let used = tool_call_name_set run in
-      List.exists
-        (fun tool_name -> Hashtbl.mem used tool_name)
-        benchmark_case.forbidden_tools
+  | _ -> List.exists (forbidden_call_used_by_case benchmark_case) run.tool_calls
 
 let task_pass_score (benchmark_case : benchmark_case) (run : evidence_run) =
   let reported = Option.value ~default:false run.task_success in
@@ -182,14 +174,9 @@ let unnecessary_tool_rate (benchmark_case : benchmark_case) (run : evidence_run)
     match benchmark_case.category with
     | Tool_forbidden -> 1.0
     | _ ->
-        (* Iteration is reversed here vs [forbidden_tool_used]: we scan
-           run.tool_calls and check each name against forbidden_tools,
-           so build the set from forbidden_tools (F entries) and let
-           the scan be C × O(1). *)
-        let forbidden_set = name_set_of_list benchmark_case.forbidden_tools in
         let forbidden_count =
           run.tool_calls
-          |> List.filter (fun call -> Hashtbl.mem forbidden_set call.tool_name)
+          |> List.filter (forbidden_call_used_by_case benchmark_case)
           |> List.length
         in
         let over_limit = max 0 (call_count - benchmark_case.max_tool_calls) in

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.mli
@@ -52,7 +52,7 @@ val score_run :
     | Axis | Definition |
     |---|---|
     | `task_pass` | reported [task_success = true] AND every [success_check] passes against [final_result] |
-    | `tool_selection` | [0.0] if any forbidden tool is used; otherwise [1.0]. [Tool_forbidden] cases require zero calls. |
+    | `tool_selection` | [0.0] if any forbidden tool name or forbidden selector is used; otherwise [1.0]. [Tool_forbidden] cases require zero calls. |
     | `arg_validity` | [1.0] if no `arg_checks`; otherwise mean of per-check pass rate (each check passes iff at least one matching tool call satisfies it) |
     | `recovery` | [1.0] for cases without [recovery_policy.required = true]; otherwise [1.0] iff [task_pass = 1.0] AND a successful call exists after at least one failure AND the failure count is within [max_failures_before_success] |
     | `efficiency` | [Tool_forbidden]: [1.0] if zero calls else [0.0]. Otherwise: [1.0 - (over_limit / max_tool_calls)], floored at [0.0]; [max_tool_calls <= 0] forces zero-call requirement |
@@ -62,7 +62,9 @@ val score_run :
     Not part of the composite (separate dashboard column).
     [(forbidden_count + over_limit) / call_count], capped at
     [1.0].  Zero calls -> [0.0].  [Tool_forbidden] case -> [1.0]
-    when any call exists. *)
+    when any call exists.  [forbidden_count] counts calls matching either
+    [forbidden_tools] or [forbidden_selectors], with each call counted at
+    most once. *)
 
 val to_reward_advice :
   agent_name:string ->

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.ml
@@ -50,6 +50,7 @@ type benchmark_case = {
   category : case_category;
   keeper_profiles : string list;
   forbidden_tools : string list;
+  forbidden_selectors : Eval_tool_selector.t list;
   max_tool_calls : int;
   success_checks : json_check list;
   arg_checks : arg_check list;
@@ -61,6 +62,7 @@ type tool_call = {
   success : bool;
   input : Yojson.Safe.t;
   output : Yojson.Safe.t option;
+  route_evidence : Yojson.Safe.t option;
   duration_ms : float option;
 }
 

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.mli
@@ -34,6 +34,7 @@ type benchmark_case = {
   category : case_category;
   keeper_profiles : string list;
   forbidden_tools : string list;
+  forbidden_selectors : Eval_tool_selector.t list;
   max_tool_calls : int;
   success_checks : json_check list;
   arg_checks : arg_check list;
@@ -45,6 +46,7 @@ type tool_call = {
   success : bool;
   input : Yojson.Safe.t;
   output : Yojson.Safe.t option;
+  route_evidence : Yojson.Safe.t option;
   duration_ms : float option;
 }
 

--- a/scripts/lint/no-eval-tool-selector-runtime-import.sh
+++ b/scripts/lint/no-eval-tool-selector-runtime-import.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Keep eval-only tool-call selectors out of live keeper/runtime control paths.
+#
+# Eval_tool_selector is an observational harness primitive. It may match
+# recorded route evidence in eval/replay/benchmark code, but live keeper and
+# runtime code must not import it as a policy gate.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "[no-eval-tool-selector-runtime-import] required tool missing: rg" >&2
+  exit 2
+fi
+
+tmp="$(mktemp -t eval-tool-selector-runtime-import.XXXXXX)"
+trap 'rm -f "$tmp"' EXIT
+
+(
+  cd "$ROOT"
+  rg -n --glob '*.ml' --glob '*.mli' '\bEval_tool_selector\b' \
+    lib/keeper lib/runtime
+) >"$tmp" || true
+
+if [[ -s "$tmp" ]]; then
+  echo "[no-eval-tool-selector-runtime-import] Eval_tool_selector used in live keeper/runtime paths" >&2
+  cat "$tmp" >&2
+  echo "[no-eval-tool-selector-runtime-import] keep it in eval, replay, benchmark, or dashboard read-model code" >&2
+  exit 1
+fi
+
+echo "[no-eval-tool-selector-runtime-import] OK"

--- a/test/dune
+++ b/test/dune
@@ -1906,6 +1906,17 @@
  (modules test_rfc_0086_keeper_namespace_invariant)
  (libraries alcotest))
 
+; Eval_tool_selector is an observational harness/benchmark matcher.  It
+; must not become a live keeper/runtime routing gate or tool policy surface.
+
+(test
+ (name test_eval_tool_selector_boundary)
+ (modules test_eval_tool_selector_boundary)
+ (libraries alcotest)
+ (deps
+  (source_tree ../lib/keeper)
+  (source_tree ../lib/runtime)))
+
 ; RFC-0085 PR-18 — Retroactive AST test for execution_surfaces +
 ; namespace_truth rename (#15486 shipped without a regression test;
 ; restored by #15495).

--- a/test/test_eval_harness.ml
+++ b/test/test_eval_harness.ml
@@ -98,9 +98,17 @@ let test_regex_no_match () =
 (* Test: check_tool_expectations                                     *)
 (* ================================================================ *)
 
+let tool_expect ?max_calls ?(required = true) tool_name =
+  { Eval_harness.tool_name
+  ; selector = Eval_tool_selector.Tool_name tool_name
+  ; required
+  ; max_calls
+  ; args_contain = None
+  }
+
 let test_tool_expect_required_met () =
   let expectations : Eval_harness.tool_expectation list = [
-    { tool_name = "tool_execute"; required = true; max_calls = None; args_contain = None };
+    tool_expect "tool_execute";
   ] in
   let actual = ["tool_execute"; "tool_execute"] in
   let results = Eval_harness.check_tool_expectations expectations actual in
@@ -109,7 +117,7 @@ let test_tool_expect_required_met () =
 
 let test_tool_expect_required_missing () =
   let expectations : Eval_harness.tool_expectation list = [
-    { tool_name = "tool_execute"; required = true; max_calls = None; args_contain = None };
+    tool_expect "tool_execute";
   ] in
   let actual = ["tool_read_file"] in
   let results = Eval_harness.check_tool_expectations expectations actual in
@@ -119,7 +127,7 @@ let test_tool_expect_required_missing () =
 
 let test_tool_expect_max_calls_ok () =
   let expectations : Eval_harness.tool_expectation list = [
-    { tool_name = "tool_execute"; required = true; max_calls = Some 3; args_contain = None };
+    tool_expect ~max_calls:3 "tool_execute";
   ] in
   let actual = ["tool_execute"; "tool_execute"] in
   let results = Eval_harness.check_tool_expectations expectations actual in
@@ -128,13 +136,45 @@ let test_tool_expect_max_calls_ok () =
 
 let test_tool_expect_max_calls_exceeded () =
   let expectations : Eval_harness.tool_expectation list = [
-    { tool_name = "tool_execute"; required = true; max_calls = Some 2; args_contain = None };
+    tool_expect ~max_calls:2 "tool_execute";
   ] in
   let actual = ["tool_execute"; "tool_execute"; "tool_execute"; "tool_execute"; "tool_execute"] in
   let results = Eval_harness.check_tool_expectations expectations actual in
   let r = List.hd results in
   Alcotest.(check bool) "exceeded penalty" true (r.Eval_harness.score < 1.0);
   Alcotest.(check bool) "has warning" true (String.length r.Eval_harness.detail > 0)
+
+let test_tool_expect_descriptor_selector () =
+  let expectations : Eval_harness.tool_expectation list = [
+    { tool_name = "agent profile lookup"
+    ; selector = Eval_tool_selector.Descriptor_id "masc.agent.card"
+    ; required = false
+    ; max_calls = Some 0
+    ; args_contain = None
+    };
+  ] in
+  let actual =
+    [
+      ({ tool_name = "masc_agent_card"
+       ; route_evidence =
+           Some
+             (`Assoc
+                [
+                  ("descriptor_id", `String "masc.agent.card");
+                  ("runtime_handler", `String "Tool_masc_agent_dispatch");
+                ])
+       } : Eval_tool_selector.call);
+    ]
+  in
+  let results =
+    Eval_harness.check_tool_expectations_with_evidence expectations actual
+  in
+  let r = List.hd results in
+  Alcotest.(check (float 0.01)) "descriptor selector exceeded max" 0.0
+    r.Eval_harness.score;
+  Alcotest.(check bool) "detail names selector" true
+    (String_util.contains_substring r.Eval_harness.detail
+       "descriptor_id:masc.agent.card")
 
 (* ================================================================ *)
 (* Test: compute_pass_at_k                                           *)
@@ -315,6 +355,8 @@ let () =
       Alcotest.test_case "required missing" `Quick test_tool_expect_required_missing;
       Alcotest.test_case "max_calls ok" `Quick test_tool_expect_max_calls_ok;
       Alcotest.test_case "max_calls exceeded" `Quick test_tool_expect_max_calls_exceeded;
+      Alcotest.test_case "descriptor selector" `Quick
+        test_tool_expect_descriptor_selector;
     ]);
     ("pass_at_k", [
       Alcotest.test_case "all pass" `Quick test_pass_at_k_all_pass;

--- a/test/test_eval_tool_selector_boundary.ml
+++ b/test/test_eval_tool_selector_boundary.ml
@@ -1,0 +1,69 @@
+open Alcotest
+
+(** [Eval_tool_selector] is an eval/shadow/replay matcher over recorded
+    tool-call evidence. It must not become live keeper/runtime routing policy. *)
+
+let guarded_roots = [ "lib/keeper"; "lib/runtime" ]
+
+let rec collect_sources dir acc =
+  let entries = try Sys.readdir dir with Sys_error _ -> [||] in
+  Array.fold_left
+    (fun acc name ->
+      let path = Filename.concat dir name in
+      if (try Sys.is_directory path with Sys_error _ -> false)
+      then collect_sources path acc
+      else if Filename.check_suffix path ".ml" || Filename.check_suffix path ".mli"
+      then path :: acc
+      else acc)
+    acc
+    entries
+;;
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+;;
+
+let contains_substring ~needle text =
+  let nlen = String.length needle in
+  let tlen = String.length text in
+  let rec loop i =
+    if i + nlen > tlen
+    then false
+    else if String.sub text i nlen = needle
+    then true
+    else loop (i + 1)
+  in
+  loop 0
+;;
+
+let test_not_used_by_live_keeper_or_runtime () =
+  let files = List.fold_left (fun acc root -> collect_sources root acc) [] guarded_roots in
+  let offenders =
+    files
+    |> List.filter (fun path ->
+      contains_substring ~needle:"Eval_tool_selector" (read_file path))
+    |> List.sort String.compare
+  in
+  match offenders with
+  | [] -> ()
+  | _ ->
+    failf
+      "Eval_tool_selector is eval-only and must not be imported by live \
+       keeper/runtime code: %s"
+      (String.concat ", " offenders)
+;;
+
+let () =
+  run
+    "eval-tool-selector-boundary"
+    [ ( "runtime boundary"
+      , [ test_case
+            "lib/keeper and lib/runtime do not import Eval_tool_selector"
+            `Quick
+            test_not_used_by_live_keeper_or_runtime
+        ] )
+    ]
+;;

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -30,6 +30,61 @@ let find_row ~provider ~model ~keeper rows =
       && row.keeper_profile = keeper)
     rows
 
+let json_check_status_completed : Tool_call_quality_benchmark.json_check =
+  {
+    path = "$.status";
+    equals = Some (`String "completed");
+    contains = None;
+    min_int = None;
+    present = None;
+  }
+
+let selector_case ?(forbidden_tools = []) ?(forbidden_selectors = []) () :
+    Tool_call_quality_benchmark.benchmark_case =
+  {
+    id = "selector_case";
+    prompt = "synthetic selector scoring case";
+    category = Tool_call_quality_benchmark.Tool_use;
+    keeper_profiles = [ "bench-selector" ];
+    forbidden_tools;
+    forbidden_selectors;
+    max_tool_calls = 3;
+    success_checks = [ json_check_status_completed ];
+    arg_checks = [];
+    recovery_policy = None;
+  }
+
+let selector_tool_call ?route_evidence tool_name :
+    Tool_call_quality_benchmark.tool_call =
+  {
+    tool_name;
+    success = true;
+    input = `Assoc [];
+    output = None;
+    route_evidence;
+    duration_ms = None;
+  }
+
+let selector_run tool_calls : Tool_call_quality_benchmark.evidence_run =
+  {
+    case_id = "selector_case";
+    provider = "provider-d";
+    model = "model-d-5.4";
+    keeper_profile = "bench-selector";
+    run_id = None;
+    repeat_index = None;
+    prompt_fingerprint = None;
+    task_success = Some true;
+    final_output = Some "completed";
+    final_result = Some (`Assoc [ ("status", `String "completed") ]);
+    latency_ms = None;
+    input_tokens = None;
+    output_tokens = None;
+    cost_usd = None;
+    status = Tool_call_quality_benchmark.Run_ok;
+    tool_calls;
+  }
+
 let test_load_cases_and_runs () =
   let cases, runs = load_fixture () in
   check int "case count" 4 (List.length cases);
@@ -103,6 +158,84 @@ let test_csv_render_has_headers () =
   check bool "csv contains analyst keeper row" true
     (String_util.contains_substring csv "bench-analyst")
 
+let test_forbidden_selector_matches_descriptor_evidence () =
+  let route_evidence =
+    `Assoc
+      [
+        ("descriptor_id", `String "masc.agent.card");
+        ("runtime_handler", `String "Tool_masc_agent_dispatch");
+      ]
+  in
+  let case =
+    selector_case
+      ~forbidden_selectors:[ Eval_tool_selector.Descriptor_id "masc.agent.card" ]
+      ()
+  in
+  let run = selector_run [ selector_tool_call ~route_evidence "masc_agent_card" ] in
+  match Tool_call_quality_benchmark_scoring.score_run ~cases:[ case ] run with
+  | Some score ->
+      check bool "selector degrades pass" false score.passed;
+      check (float 0.0001) "tool selection failed" 0.0 score.tool_selection;
+      check (float 0.0001) "unnecessary tool counted" 1.0
+        score.unnecessary_tool_rate
+  | None -> fail "score_run unexpectedly returned None"
+
+let test_forbidden_selector_matches_eval_tag_evidence () =
+  let route_evidence =
+    `Assoc
+      [
+        ("descriptor_id", `String "masc.agent.card");
+        ("eval_tags", `List [ `String "agent_profile_lookup" ]);
+      ]
+  in
+  let case =
+    selector_case
+      ~forbidden_selectors:[ Eval_tool_selector.Eval_tag "agent_profile_lookup" ]
+      ()
+  in
+  let run = selector_run [ selector_tool_call ~route_evidence "renamed_agent_card" ] in
+  match Tool_call_quality_benchmark_scoring.score_run ~cases:[ case ] run with
+  | Some score ->
+      check bool "eval tag degrades pass" false score.passed;
+      check (float 0.0001) "tool selection failed" 0.0 score.tool_selection
+  | None -> fail "score_run unexpectedly returned None"
+
+let test_loader_parses_forbidden_selectors () =
+  let path = Filename.temp_file "tool-call-quality-selectors" ".json" in
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+      Fs_compat.save_file path
+        {|{
+  "cases": [
+    {
+      "id": "selector_case",
+      "prompt": "synthetic selector case",
+      "category": "tool_use",
+      "keeper_profiles": ["bench-selector"],
+      "forbidden_tools": [],
+      "forbidden_selectors": [
+        {"type": "descriptor_id", "value": "masc.agent.card"},
+        {"type": "receipt_label", "key": "family", "value": "profile_lookup"}
+      ],
+      "max_tool_calls": 3,
+      "success_checks": [
+        {"path": "$.status", "equals": "completed"}
+      ],
+      "arg_checks": []
+    }
+  ]
+}|};
+      match Tool_call_quality_benchmark.load_cases_from_file path with
+      | Ok [ case ] ->
+          check int "selector count" 2
+            (List.length case.Tool_call_quality_benchmark.forbidden_selectors)
+      | Ok cases ->
+          fail
+            (Printf.sprintf "expected one parsed case, got %d"
+               (List.length cases))
+      | Error msg -> fail ("load_cases_from_file failed: " ^ msg))
+
 let () =
   run "tool_call_quality_benchmark"
     [
@@ -111,5 +244,11 @@ let () =
            test_case "summarizes rollups and stability" `Quick
              test_summary_rollups_and_stability;
            test_case "renders csv" `Quick test_csv_render_has_headers;
+           test_case "forbidden selector matches descriptor evidence" `Quick
+             test_forbidden_selector_matches_descriptor_evidence;
+           test_case "forbidden selector matches eval tag evidence" `Quick
+             test_forbidden_selector_matches_eval_tag_evidence;
+           test_case "loader parses forbidden selectors" `Quick
+             test_loader_parses_forbidden_selectors;
          ]);
     ]


### PR DESCRIPTION
## Summary

- add shared `Eval_tool_selector` core module for observational, descriptor-aware tool-call matching
- extend `Eval_harness` so existing `tool_name` expectations keep working while route-evidence-aware callers can match eval selectors
- extend the tool-call quality benchmark with `forbidden_selectors` and per-call `route_evidence`
- add shell/CI and Dune boundary ratchets that prevent `Eval_tool_selector` from being imported by live `lib/keeper` or `lib/runtime` paths
- add focused tests for descriptor-id and eval-tag selector matches

## Why

This is the first harness-level step for catching keeper behavior issues like identity self-check regressions and tool-surface confusion without adding live runtime hardcoding. Selectors match recorded evidence such as `descriptor_id`, `runtime_handler`, receipt labels, or future eval tags, so policy can be evaluated in replay/shadow flows rather than by stopping a keeper turn.

The selector name is intentionally `Eval_tool_selector` to avoid confusion with the live OAS `Agent_sdk.Tool_selector` runtime strategy.

## Validation

- `ocamlformat --check lib/core/eval_tool_selector.ml lib/core/eval_tool_selector.mli lib/eval_harness.ml lib/eval_harness.mli lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.ml lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.mli lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.mli lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.ml lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.mli test/test_eval_harness.ml test/test_tool_call_quality_benchmark.ml`
- `ocamlformat --check test/test_eval_tool_selector_boundary.ml`
- `git diff --check`
- `bash scripts/lint/no-eval-tool-selector-runtime-import.sh`
- `bash scripts/lint/yaml-syntax.sh`

Not run: focused Dune build/tests. The local Dune lock was occupied earlier, and Sangsu asked to run build later.