### PR TITLE
[codex] Pin Keeper streaming watchdog cancellation

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1498,6 +1498,8 @@
 
 (include stanzas/test_keeper_turn_livelock_10121.inc)
 
+(include stanzas/test_keeper_unified_turn_attempt_watchdog.inc)
+
 (include stanzas/test_keeper_turn_helpers_side_effect_metric.inc)
 
 (include stanzas/test_keeper_transition_audit_types.inc)

--- a/test/stanzas/test_keeper_unified_turn_attempt_watchdog.inc
+++ b/test/stanzas/test_keeper_unified_turn_attempt_watchdog.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_unified_turn_attempt_watchdog)
+ (modules test_keeper_unified_turn_attempt_watchdog)
+ (libraries masc_test_deps))

--- a/test/test_keeper_unified_turn_attempt_watchdog.ml
+++ b/test/test_keeper_unified_turn_attempt_watchdog.ml
@@ -1,0 +1,114 @@
+open Alcotest
+
+module W = Keeper_unified_turn_attempt_watchdog
+module Metrics = Otel_metric_store
+
+let watchdog_metric = Keeper_metrics.(to_string AttemptWatchdogFired)
+
+let watchdog_labels keeper = [ "keeper", keeper ]
+
+let test_safety_deadline_records_terminal_reason_and_metric () =
+  let keeper = "test-attempt-watchdog-state-loss" in
+  let cancel_reasons = ref [] in
+  let labels = watchdog_labels keeper in
+  let before = Metrics.metric_value_or_zero watchdog_metric ~labels () in
+  let raised =
+    try
+      ignore
+        (Eio_main.run (fun env ->
+           let clock = Eio.Stdenv.clock env in
+           W.dispatch
+             ~clock
+             ~keeper_name:keeper
+             ~attempt_watchdog_s:(Some 0.01)
+             ~on_cancelled:(fun reason ->
+               cancel_reasons := reason :: !cancel_reasons)
+             ~run:(fun () ->
+               Eio.Time.sleep clock 60.0;
+               Ok ()))
+         : (unit, Agent_sdk.Error.sdk_error) result);
+      false
+    with
+    | Eio.Cancel.Cancelled (Failure "attempt_watchdog_safety_deadline") -> true
+    | Eio.Cancel.Cancelled exn ->
+      Alcotest.failf "unexpected cancellation: %s" (Printexc.to_string exn)
+  in
+  check bool "watchdog raises cancelled deadline" true raised;
+  check (list string)
+    "deadline reason recorded once"
+    [ "attempt_watchdog_safety_deadline" ]
+    (List.rev !cancel_reasons);
+  check (float 0.0001)
+    "attempt watchdog metric increments"
+    (before +. 1.0)
+    (Metrics.metric_value_or_zero watchdog_metric ~labels ())
+;;
+
+let test_external_cancel_records_external_reason_without_metric () =
+  let keeper = "test-attempt-watchdog-external-cancel" in
+  let cancel_reasons = ref [] in
+  let labels = watchdog_labels keeper in
+  let before = Metrics.metric_value_or_zero watchdog_metric ~labels () in
+  let raised =
+    try
+      ignore
+        (Eio_main.run (fun env ->
+           W.dispatch
+             ~clock:(Eio.Stdenv.clock env)
+             ~keeper_name:keeper
+             ~attempt_watchdog_s:(Some 60.0)
+             ~on_cancelled:(fun reason ->
+               cancel_reasons := reason :: !cancel_reasons)
+             ~run:(fun () ->
+               raise (Eio.Cancel.Cancelled (Failure "external-cancel-test"))))
+         : (unit, Agent_sdk.Error.sdk_error) result);
+      false
+    with
+    | Eio.Cancel.Cancelled (Failure "external-cancel-test") -> true
+    | Eio.Cancel.Cancelled exn ->
+      Alcotest.failf "unexpected cancellation: %s" (Printexc.to_string exn)
+  in
+  check bool "external cancel is re-raised" true raised;
+  check (list string)
+    "external cancel reason recorded once"
+    [ "external_cancel" ]
+    (List.rev !cancel_reasons);
+  check (float 0.0001)
+    "external cancel does not increment watchdog metric"
+    before
+    (Metrics.metric_value_or_zero watchdog_metric ~labels ())
+;;
+
+let test_normal_completion_does_not_record_cancel () =
+  let cancel_reasons = ref [] in
+  let outcome =
+    Eio_main.run (fun env ->
+      W.dispatch
+        ~clock:(Eio.Stdenv.clock env)
+        ~keeper_name:"test-attempt-watchdog-normal"
+        ~attempt_watchdog_s:(Some 60.0)
+        ~on_cancelled:(fun reason -> cancel_reasons := reason :: !cancel_reasons)
+        ~run:(fun () -> Ok "done"))
+  in
+  check (result string) "normal result passes through" (Ok "done") outcome;
+  check (list string) "no cancel reason" [] !cancel_reasons
+;;
+
+let () =
+  run "keeper_unified_turn_attempt_watchdog"
+    [ ( "state_loss_regression"
+      , [ test_case
+            "safety deadline records terminal reason and metric"
+            `Quick
+            test_safety_deadline_records_terminal_reason_and_metric
+        ; test_case
+            "external cancel records external reason without metric"
+            `Quick
+            test_external_cancel_records_external_reason_without_metric
+        ; test_case
+            "normal completion does not record cancel"
+            `Quick
+            test_normal_completion_does_not_record_cancel
+        ] )
+    ]
+;;


### PR DESCRIPTION
## What changed

Adds a focused Alcotest regression suite for `Keeper_unified_turn_attempt_watchdog`.

The tests pin three behaviors:

- safety-deadline timeout calls `on_cancelled` with `attempt_watchdog_safety_deadline`
- safety-deadline timeout increments `masc_keeper_attempt_watchdog_fired_total{keeper}`
- external cancellation reports `external_cancel` without incrementing the watchdog metric
- normal completion passes through without recording a cancel reason

## Why

The current Keeper streaming path intentionally records cancellation after a turn has entered `Streaming`. A cleanup that removes the watchdog module or collapses the cancel reason would reopen the prior state-loss failure mode where the FSM emits `Streaming` and then the operator timeline has no terminal observation.

This PR is a guardrail before salvaging the `remove-inter-chunk-idle` work.

## Validation

- `ocamlformat --check test/test_keeper_unified_turn_attempt_watchdog.ml`
- `scripts/check-oas-pin.sh --local-only`

Build/test execution was intentionally deferred per operator request. A focused Dune build was attempted first, but the local worktree hit existing stale `_build` CRC errors around `Agent_sdk__Event_bus`; `check-oas-pin.sh --local-only` passed, classifying that as stale artifact/build-cache state rather than this test diff.
