### PR TITLE
[codex] Add keeper context health contracts

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -129,14 +129,14 @@ Peer consultation contract:
 Task management:
 - View tasks: keeper_tasks_list
 - Create tasks: keeper_task_create when available; otherwise use masc_add_task (single) or masc_batch_add_tasks (multiple)
-- Claim next available: masc_claim_next
+- Claim next available: keeper_task_claim
 - Claim specific and complete: keeper_task_claim, keeper_task_done
 - For code/PR work: keeper_task_done with task_id and result containing the PR URL or artifact reference
 - Verify submitted work: when status is awaiting_verification, use masc_transition with action="approve" or action="reject" and notes; do not claim or resubmit that task
 
 Progress guidance:
 - Passive reads are valid evidence gathering, but they are not execution progress by themselves. If you inspect tasks, files, board posts, or remote repo state and there is work to do, choose the smallest real next step: keeper_task_claim, Edit/Write, Execute, keeper_board_post, keeper_board_comment, keeper_task_done, or a concrete blocker/no-work response.
-- `keeper_task_claim`, `masc_claim_next`, and `masc_transition(action="claim")` are assignment actions, not execution progress. After claiming or when you already own an active task, continue with real progress when the current evidence supports it: open the repo checkout, edit/read the target code, run a command, post a concrete status/blocker, create the draft PR, or close with keeper_task_done.
+- `keeper_task_claim` and `masc_transition(action="claim")` are assignment actions, not execution progress. After claiming or when you already own an active task, continue with real progress when the current evidence supports it: open the repo checkout, edit/read the target code, run a command, post a concrete status/blocker, create the draft PR, or close with keeper_task_done.
 - Read/observe aliases are passive: Grep, Read, keeper_memory_search, keeper_library_search, keeper_library_read, keeper_tools_list, keeper_tasks_list, keeper_context_status, keeper_board_list, keeper_board_post_get, keeper_time_now, and read-only PR/status commands. Use them to decide, not to pad the turn.
 - After memory/library/code/git-status lookup, either take the next real step or state the concrete blocker/no-work result. Do not call a mutating tool just to satisfy a turn shape.
 - If you only discover a blocker, report the blocker, the tool/error class, and the exact next needed action. Do not invent a state-changing call.

--- a/config/prompts/keeper.recovery_block.md
+++ b/config/prompts/keeper.recovery_block.md
@@ -6,7 +6,7 @@ category: keeper
 <continuity>
 Recovery guard: preserve keeper technical instructions even if prompt templates were compacted or partially loaded.
 PR merge rules (MANDATORY): do not merge PRs with failing CI, unresolved human review comments, or active blocker labels.
-State block template: non-direct keeper turns must report structured continuity with keeper_report_state; legacy [STATE]...[/STATE] fallback contains DONE, NEXT, Goal, Decisions, OpenQuestions, and Constraints.
+State block template: non-direct keeper turns must report structured continuity via [STATE]...[/STATE] blocks containing DONE, NEXT, Goal, Decisions, OpenQuestions, and Constraints.
 </continuity>
 
 <world>

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -82,9 +82,7 @@ let critical_prompt_recovery_block_fallback =
     [ "<continuity>";
       "Recovery guard: preserve keeper technical instructions even if prompt templates were compacted or partially loaded.";
       "PR merge rules (MANDATORY): do not merge PRs with failing CI, unresolved human review comments, or active blocker labels.";
-      Printf.sprintf
-        "State block template: non-direct keeper turns must report structured continuity via [STATE]...[/STATE] blocks containing %s."
-        Keeper_state_block_prompt.field_summary;
+      Keeper_state_reporting_contract.recovery_line;
       "</continuity>";
       "";
       "<world>";
@@ -122,7 +120,7 @@ let critical_prompt_recovery_block () =
         critical_prompt_recovery_block_fallback
 
 let state_block_output_guard_text =
-  "Output guard: this turn uses runtime-managed continuity. Report state via [STATE]...[/STATE] blocks. The runtime will synthesize and persist state metadata when needed."
+  Keeper_state_reporting_contract.output_guard_text
 
 let ensure_critical_prompt_anchors prompt =
   match missing_critical_prompt_anchors prompt with

--- a/lib/keeper/keeper_prompt_tool_token_audit.ml
+++ b/lib/keeper/keeper_prompt_tool_token_audit.ml
@@ -1,0 +1,64 @@
+type violation =
+  { token : string
+  ; reason : string
+  }
+
+let is_tool_token_char = function
+  | 'a' .. 'z'
+  | 'A' .. 'Z'
+  | '0' .. '9'
+  | '_' ->
+      true
+  | _ -> false
+
+let starts_with_prefixes token =
+  (String.starts_with ~prefix:"keeper_" token
+   && String.length token > String.length "keeper_")
+  || (String.starts_with ~prefix:"masc_" token
+      && String.length token > String.length "masc_")
+
+let dedupe_preserve_order tokens =
+  let seen = Hashtbl.create 16 in
+  List.filter
+    (fun token ->
+      if Hashtbl.mem seen token then false
+      else (
+        Hashtbl.add seen token ();
+        true))
+    tokens
+
+let tool_like_tokens text =
+  let len = String.length text in
+  let rec scan pos acc =
+    if pos >= len then List.rev acc |> dedupe_preserve_order
+    else if is_tool_token_char text.[pos] then
+      let start = pos in
+      let rec stop i =
+        if i >= len || not (is_tool_token_char text.[i]) then i else stop (i + 1)
+      in
+      let finish = stop pos in
+      let token = String.sub text start (finish - start) in
+      let acc = if starts_with_prefixes token then token :: acc else acc in
+      scan finish acc
+    else scan (pos + 1) acc
+  in
+  scan 0 []
+
+let is_forbidden token =
+  List.exists (String.equal token)
+    Keeper_state_reporting_contract.forbidden_tool_tokens
+
+let violations text =
+  tool_like_tokens text
+  |> List.filter_map (fun token ->
+    if is_forbidden token then Some { token; reason = "forbidden_retired_tool" }
+    else
+      match Keeper_tool_resolution.resolve token with
+      | Keeper_tool_resolution.Unknown _ ->
+          Some { token; reason = "unknown_tool_token" }
+      | Keeper_tool_resolution.Resolved _
+      | Keeper_tool_resolution.Alias_to _ ->
+          None)
+
+let violation_to_json v =
+  `Assoc [ ("token", `String v.token); ("reason", `String v.reason) ]

--- a/lib/keeper/keeper_prompt_tool_token_audit.mli
+++ b/lib/keeper/keeper_prompt_tool_token_audit.mli
@@ -1,0 +1,15 @@
+(** Prompt tool-token audit for rendered keeper instructions.
+
+    The audit checks model-facing instruction text for tool-looking names that
+    either resolve to no current tool surface or are explicitly retired by a
+    domain contract. Runtime use should audit system prompts, not user messages,
+    to avoid treating operator prose as prompt drift. *)
+
+type violation =
+  { token : string
+  ; reason : string
+  }
+
+val tool_like_tokens : string -> string list
+val violations : string -> violation list
+val violation_to_json : violation -> Yojson.Safe.t

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -234,6 +234,19 @@ let sanitize_retired_tool_names text =
 
 let state_block_instruction_text = Keeper_state_block_prompt.instruction_text
 
+let observe_prompt_tool_token_violations ~keeper text =
+  Keeper_prompt_tool_token_audit.violations text
+  |> List.iter (fun (violation : Keeper_prompt_tool_token_audit.violation) ->
+    Otel_metric_store.inc_counter
+      (Keeper_metrics.to_string PromptUnknownToolTokens)
+      ~labels:
+        [
+          ("keeper", keeper);
+          ("token", violation.token);
+          ("reason", violation.reason);
+        ]
+      ())
+
 (* In-binary mirror of config/prompts/keeper.turn_intent.md (minus the
    {{...}} substitution slots that cannot be filled during a fallback).
    Used only when [resolve_turn_intent_block] fails or the registry
@@ -786,6 +799,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
   in
   let sanitized_system = sanitize_retired_tool_names system_prompt in
   let sanitized_user = sanitize_retired_tool_names user_message in
+  observe_prompt_tool_token_violations ~keeper:meta.name sanitized_system;
   (* set_gauge only: a stray inc_counter here used to create this
      (name, labels) cell as Counter first, so the system_prompt series
      kept Counter kind, carried a non-monotonic byte length, and exported

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -212,6 +212,8 @@ type t =
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
   | RuntimeHttpProbeJsonParseFailures
+  | FleetCapacity              (* gauge: fleet capacity split by desired/suppressed/actionable/effective *)
+  | PromptUnknownToolTokens    (* counter: rendered system prompt mentions retired/unknown tool tokens *)
   (* Instruction monitoring metrics *)
   | PromptSegmentBytes          (* histogram: bytes per prompt segment *)
   | PromptTemplateRenderOutcome (* counter: template render ok/fallback/empty *)
@@ -447,6 +449,8 @@ let to_string = function
       "masc_keeper_memory_recall_read_errors_total"
   | RuntimeHttpProbeJsonParseFailures ->
       "masc_runtime_http_probe_json_parse_failures_total"
+  | FleetCapacity -> "masc_keeper_fleet_capacity"
+  | PromptUnknownToolTokens -> "masc_keeper_prompt_unknown_tool_tokens_total"
   | PromptSegmentBytes -> "masc_keeper_prompt_segment_bytes"
   | PromptTemplateRenderOutcome -> "masc_keeper_prompt_template_render_outcome_total"
   | ToolCallParamCompleteness -> "masc_keeper_tool_call_param_completeness_total"
@@ -512,6 +516,7 @@ let all : t list =
     DockerRuntimeDiscarded; ProactiveSkip; StaySilentLoopDetected; UsageTrust;
     UsageAnomalyReason; ConfigEnvParseFailures; PostTurnWireinFailures; RecurringFailures;
     TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; RuntimeHttpProbeJsonParseFailures;
+    FleetCapacity; PromptUnknownToolTokens;
     PromptSegmentBytes; PromptTemplateRenderOutcome; ToolCallParamCompleteness; KeeperTurnInstructionHash;
     KeeperToolCallRetryLoop; AttemptWatchdogFired; ShellIrEffectTotal
   ]

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -203,6 +203,8 @@ type t =
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
   | RuntimeHttpProbeJsonParseFailures
+  | FleetCapacity
+  | PromptUnknownToolTokens
   | PromptSegmentBytes
   | PromptTemplateRenderOutcome
   | ToolCallParamCompleteness

--- a/lib/keeper_registry/dune
+++ b/lib/keeper_registry/dune
@@ -12,6 +12,7 @@
   keeper_id
   keeper_runtime_manifest_types
   keeper_lifecycle_events
+  keeper_state_reporting_contract
   keeper_state_block_prompt
   keeper_state_machine
   keeper_state_machine_json

--- a/lib/keeper_registry/keeper_state_block_prompt.ml
+++ b/lib/keeper_registry/keeper_state_block_prompt.ml
@@ -1,28 +1,3 @@
-let field_summary = "DONE, NEXT, Goal, Decisions, OpenQuestions, and Constraints"
-
-let template_text =
-  String.concat "\n"
-    [
-      "[STATE]";
-      "DONE: what you accomplished this turn";
-      "NEXT: what the next turn should do";
-      (* The post-turn sanitizer validates this field against
-         meta.active_goal_ids (keeper_post_turn); prose here is cleared every
-         turn, so the template must demand the id, not a description (#20937). *)
-      "Goal: active goal id from <available_goals> verbatim (e.g. goal-123-04af), never prose; omit this line when no goal id applies";
-      "Decisions: key decisions (semicolon-separated)";
-      "OpenQuestions: unresolved items (semicolon-separated)";
-      "Constraints: active constraints (semicolon-separated)";
-      "[/STATE]";
-    ]
-
-let instruction_text =
-  String.concat "\n"
-    [
-      Printf.sprintf
-        "State block template: for non-direct keeper turns, report continuity \
-         using the [STATE] block at the end of your response. Fields: %s. All \
-         fields are optional but provide as many as you can."
-        field_summary;
-      template_text;
-    ]
+let field_summary = Keeper_state_reporting_contract.field_summary
+let template_text = Keeper_state_reporting_contract.template_text
+let instruction_text = Keeper_state_reporting_contract.instruction_text

--- a/lib/keeper_registry/keeper_state_block_prompt.mli
+++ b/lib/keeper_registry/keeper_state_block_prompt.mli
@@ -3,5 +3,8 @@
 val instruction_text : string
 (** Scoped instruction that embeds the canonical [STATE] block schema. *)
 
+val template_text : string
+(** Canonical [STATE] block schema template. *)
+
 val field_summary : string
 (** Short field-name summary for recovery/error text. *)

--- a/lib/keeper_registry/keeper_state_reporting_contract.ml
+++ b/lib/keeper_registry/keeper_state_reporting_contract.ml
@@ -1,0 +1,106 @@
+type surface =
+  | State_block
+
+type field =
+  | Done
+  | Next
+  | Goal
+  | Decisions
+  | OpenQuestions
+  | Constraints
+
+let version = "state-reporting.v1"
+let surface = State_block
+
+let surface_to_string = function
+  | State_block -> "state_block"
+
+let all_fields = [ Done; Next; Goal; Decisions; OpenQuestions; Constraints ]
+
+let field_name = function
+  | Done -> "DONE"
+  | Next -> "NEXT"
+  | Goal -> "Goal"
+  | Decisions -> "Decisions"
+  | OpenQuestions -> "OpenQuestions"
+  | Constraints -> "Constraints"
+
+let field_summary =
+  all_fields
+  |> List.map field_name
+  |> function
+  | [] -> ""
+  | [ only ] -> only
+  | fields ->
+      let rec split_last acc = function
+        | [] -> ("", List.rev acc)
+        | [ last ] -> (last, List.rev acc)
+        | x :: xs -> split_last (x :: acc) xs
+      in
+      let last, prefix = split_last [] fields in
+      Printf.sprintf "%s, and %s" (String.concat ", " prefix) last
+
+let template_line = function
+  | Done -> "DONE: what you accomplished this turn"
+  | Next -> "NEXT: what the next turn should do"
+  | Goal ->
+      "Goal: active goal id from <available_goals> verbatim (e.g. goal-123-04af), never prose; omit this line when no goal id applies"
+  | Decisions -> "Decisions: key decisions (semicolon-separated)"
+  | OpenQuestions -> "OpenQuestions: unresolved items (semicolon-separated)"
+  | Constraints -> "Constraints: active constraints (semicolon-separated)"
+
+let template_text =
+  String.concat "\n"
+    (("[STATE]" :: List.map template_line all_fields) @ [ "[/STATE]" ])
+
+let instruction_text =
+  String.concat "\n"
+    [
+      Printf.sprintf
+        "State block template: for non-direct keeper turns, report continuity \
+         using the [STATE] block at the end of your response. Fields: %s. All \
+         fields are optional but provide as many as you can. Contract: %s."
+        field_summary version;
+      template_text;
+    ]
+
+let recovery_line =
+  Printf.sprintf
+    "State block template: non-direct keeper turns must report structured \
+     continuity via [STATE]...[/STATE] blocks containing %s. Contract: %s."
+    field_summary version
+
+let output_guard_text =
+  "Output guard: this turn uses runtime-managed continuity. Report state via [STATE]...[/STATE] blocks. The runtime will synthesize and persist state metadata when needed."
+
+let forbidden_tool_tokens =
+  [
+    "keeper_report_state";
+  ]
+
+let is_tool_token_char = function
+  | 'a' .. 'z'
+  | 'A' .. 'Z'
+  | '0' .. '9'
+  | '_' ->
+      true
+  | _ -> false
+
+let contains_standalone_token text token =
+  let text_len = String.length text in
+  let token_len = String.length token in
+  let rec loop pos =
+    if token_len = 0 || pos + token_len > text_len then false
+    else if
+      String.sub text pos token_len = token
+      && (pos = 0 || not (is_tool_token_char text.[pos - 1]))
+      &&
+      let after = pos + token_len in
+      after >= text_len || not (is_tool_token_char text.[after])
+    then true
+    else loop (pos + 1)
+  in
+  loop 0
+
+let forbidden_tool_tokens_in_text text =
+  List.filter (contains_standalone_token text) forbidden_tool_tokens

--- a/lib/keeper_registry/keeper_state_reporting_contract.mli
+++ b/lib/keeper_registry/keeper_state_reporting_contract.mli
@@ -1,0 +1,32 @@
+(** Canonical keeper state-reporting contract.
+
+    This module owns the model-facing [STATE] instruction, recovery wording,
+    and retired state-reporting tool tokens. Prompt files may render prose
+    around this contract, but they must not re-declare retired tool surfaces. *)
+
+type surface =
+  | State_block
+
+type field =
+  | Done
+  | Next
+  | Goal
+  | Decisions
+  | OpenQuestions
+  | Constraints
+
+val version : string
+val surface : surface
+val surface_to_string : surface -> string
+val all_fields : field list
+val field_name : field -> string
+val field_summary : string
+val template_text : string
+val instruction_text : string
+val recovery_line : string
+val output_guard_text : string
+val forbidden_tool_tokens : string list
+
+val forbidden_tool_tokens_in_text : string -> string list
+(** Return canonical retired/forbidden state-reporting tool tokens that appear
+    as standalone tool-like tokens in [text], de-duplicated in contract order. *)

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -169,10 +169,16 @@ val make_health_json :
     the FSM intentionally allows [Failing] keepers to finish or attempt turns.
     It reports [blocked] when autoboot-enabled keepers exist but no executable
     fiber remains, and [degraded] when executable fibers remain but healthy
-    running capacity is zero, below the safety margin, or below
-    [target_reaction_capacity_count].
-    [paused_autoboot_enabled_keeper_count] makes the intended fleet size
-    visible even when durable pauses suppress every bootable keeper.
+    running capacity is zero, below the safety margin, or below the
+    actionable target.  [target_reaction_capacity_count] /
+    [desired_reaction_capacity_count] keep the configured fleet size visible,
+    while [suppressed_capacity_count] and
+    [actionable_target_reaction_capacity_count] separate durable
+    operator-paused keepers from actual capacity that requires intervention.
+    The raw total shortfall remains available as
+    [raw_reaction_capacity_shortfall_count]; status and
+    [operator_action_required] are driven by
+    [reaction_capacity_shortfall_count], the actionable shortfall.
 
     [keeper_reaction_ledger] summarizes recent durable stimulus -> reaction
     rows per keeper.  It reports [degraded] when a persisted stimulus has no

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -456,26 +456,6 @@ let keeper_fleet_safety_health_json
   in
   let bootable_count = List.length bootable_names in
   let target_count = List.length autoboot_scan.autoboot_names in
-  let minimum_running_fibers =
-    if target_count <= 1 then target_count else 2
-  in
-  let no_running_fibers = target_count > 0 && phase_counts.running = 0 in
-  let no_executable_keeper_fibers = target_count > 0 && phase_counts.executable = 0 in
-  let low_running_fiber_margin =
-    target_count > 1 && phase_counts.running < minimum_running_fibers
-  in
-  let reaction_capacity_shortfall_count =
-    max 0 (target_count - phase_counts.running - phase_counts.recovering)
-  in
-  let reaction_capacity_below_target =
-    target_count > 0 && reaction_capacity_shortfall_count > 0
-  in
-  let executable_reaction_capacity_shortfall_count =
-    max 0 (target_count - phase_counts.executable)
-  in
-  let executable_reaction_capacity_below_target =
-    target_count > 0 && executable_reaction_capacity_shortfall_count > 0
-  in
   let paused_total_count =
     match paused_keepers_json with
     | `Assoc fields ->
@@ -491,6 +471,74 @@ let keeper_fleet_safety_health_json
        | Some (`Int count) -> count
        | _ -> 0)
     | _ -> 0
+  in
+  let suppressed_capacity_count = min target_count paused_autoboot_count in
+  let desired_reaction_capacity_count = target_count in
+  let actionable_target_reaction_capacity_count =
+    max 0 (desired_reaction_capacity_count - suppressed_capacity_count)
+  in
+  let minimum_running_fibers =
+    if actionable_target_reaction_capacity_count <= 1 then
+      actionable_target_reaction_capacity_count
+    else 2
+  in
+  let no_running_fibers =
+    actionable_target_reaction_capacity_count > 0 && phase_counts.running = 0
+  in
+  let no_executable_keeper_fibers =
+    actionable_target_reaction_capacity_count > 0 && phase_counts.executable = 0
+  in
+  let low_running_fiber_margin =
+    actionable_target_reaction_capacity_count > 1
+    && phase_counts.running < minimum_running_fibers
+  in
+  let raw_reaction_capacity_shortfall_count =
+    max 0 (target_count - phase_counts.running - phase_counts.recovering)
+  in
+  let reaction_capacity_shortfall_count =
+    max 0
+      (actionable_target_reaction_capacity_count
+       - phase_counts.running
+       - phase_counts.recovering)
+  in
+  let reaction_capacity_below_target =
+    actionable_target_reaction_capacity_count > 0
+    && reaction_capacity_shortfall_count > 0
+  in
+  let raw_executable_reaction_capacity_shortfall_count =
+    max 0 (target_count - phase_counts.executable)
+  in
+  let executable_reaction_capacity_shortfall_count =
+    max 0 (actionable_target_reaction_capacity_count - phase_counts.executable)
+  in
+  let executable_reaction_capacity_below_target =
+    actionable_target_reaction_capacity_count > 0
+    && executable_reaction_capacity_shortfall_count > 0
+  in
+  let set_capacity_metric kind value =
+    Otel_metric_store.set_gauge
+      Keeper_metrics.(to_string FleetCapacity)
+      ~labels:[("kind", kind)]
+      (Float.of_int value)
+  in
+  let () =
+    List.iter
+      (fun (kind, value) -> set_capacity_metric kind value)
+      [
+        ("desired", desired_reaction_capacity_count);
+        ("suppressed", suppressed_capacity_count);
+        ("actionable_target", actionable_target_reaction_capacity_count);
+        ("running", phase_counts.running);
+        ("recovering", phase_counts.recovering);
+        ("effective", phase_counts.running);
+        ("executable", phase_counts.executable);
+        ("raw_shortfall", raw_reaction_capacity_shortfall_count);
+        ("actionable_shortfall", reaction_capacity_shortfall_count);
+        ( "raw_executable_shortfall",
+          raw_executable_reaction_capacity_shortfall_count );
+        ( "actionable_executable_shortfall",
+          executable_reaction_capacity_shortfall_count );
+      ]
   in
   let status =
     if no_executable_keeper_fibers then "blocked"
@@ -537,6 +585,13 @@ let keeper_fleet_safety_health_json
     ; "effective_reaction_capacity_count", `Int phase_counts.running
     ; "executable_reaction_capacity_count", `Int phase_counts.executable
     ; "target_reaction_capacity_count", `Int target_count
+    ; "desired_reaction_capacity_count", `Int desired_reaction_capacity_count
+    ; "suppressed_capacity_count", `Int suppressed_capacity_count
+    ; ( "actionable_target_reaction_capacity_count"
+      , `Int actionable_target_reaction_capacity_count )
+    ; "raw_reaction_capacity_shortfall_count", `Int raw_reaction_capacity_shortfall_count
+    ; ( "raw_executable_reaction_capacity_shortfall_count"
+      , `Int raw_executable_reaction_capacity_shortfall_count )
     ; "minimum_running_fibers", `Int minimum_running_fibers
     ; "no_running_fibers", `Bool no_running_fibers
     ; "no_executable_keeper_fibers", `Bool no_executable_keeper_fibers

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -14,6 +14,7 @@ module KP = Masc.Keeper_prompt
 module KRP = Masc.Keeper_run_prompt
 module KCB = Masc.Keeper_failure_circuit_breaker
 module KUP = Masc.Keeper_unified_prompt
+module KPT = Masc.Keeper_prompt_tool_token_audit
 
 (* CJK-aware token estimator from OAS *)
 let estimate_tokens s =
@@ -23,6 +24,11 @@ let estimate_tokens s =
 let has_in s needle =
   try ignore (Str.search_forward (Str.regexp_string needle) s 0); true
   with Not_found -> false
+
+let retired_state_tool () =
+  match Keeper_state_reporting_contract.forbidden_tool_tokens with
+  | token :: _ -> token
+  | [] -> fail "state-reporting contract must name retired tool tokens"
 
 let has_prompt_root path =
   Sys.file_exists (Filename.concat path "config/prompts/keeper.world.md")
@@ -268,31 +274,59 @@ let test_state_block_guard_is_runtime_managed_not_absolute_never () =
   let guard = KP.state_block_output_guard_text in
   check bool "guard mentions runtime-managed continuity" true
     (has_in guard "runtime-managed continuity");
-  check bool "guard prefers structured output" true
-    (has_in guard "structured output");
-  check bool "guard names keeper_report_state" true
-    (has_in guard "keeper_report_state");
+  check bool "guard names STATE block" true
+    (has_in guard "[STATE]...[/STATE]");
+  check bool "guard does not name retired state tool" false
+    (has_in guard (retired_state_tool ()));
   check bool "guard avoids absolute NEVER state wording" false
     (has_in guard ("NEVER output " ^ "[STATE]"));
-  check bool "guard names raw state markers" true
-    (has_in guard "raw [STATE]");
   check bool "guard mentions runtime persistence" true
     (has_in guard "persist state metadata")
 
 let test_unified_state_instruction_respects_turn_level_guard () =
   let text = KUP.state_block_instruction_text in
   check bool "instruction is scoped to non-direct turns" true
-    (has_in text "For non-direct keeper turns");
-  check bool "instruction prefers structured output" true
-    (has_in text "structured output");
-  check bool "instruction names keeper_report_state" true
-    (has_in text "keeper_report_state");
-  check bool "instruction keeps raw state fallback scoped" true
-    (has_in text "Only if keeper_report_state is unavailable");
+    (has_in text "for non-direct keeper turns");
+  check bool "instruction names STATE block" true
+    (has_in text "[STATE] block");
+  check bool "instruction carries contract version" true
+    (has_in text "state-reporting.v1");
+  check bool "instruction does not name retired state tool" false
+    (has_in text (retired_state_tool ()));
   check bool "instruction avoids old unconditional wording" false
     (has_in text
        ("End every response with a "
         ^ "[STATE]...[/STATE] block:"))
+
+let test_prompt_tool_token_audit_rejects_retired_state_tool () =
+  let token = retired_state_tool () in
+  let violations =
+    KPT.violations
+      ("State block template: call " ^ token ^ " after every turn.")
+  in
+  check int "one violation" 1 (List.length violations);
+  let violation = List.hd violations in
+  check string "retired token" token violation.KPT.token;
+  check string "retired token reason" "forbidden_retired_tool" violation.KPT.reason
+
+let test_rendered_keeper_prompt_has_no_unknown_tool_tokens () =
+  let prompt =
+    KP.build_keeper_system_prompt
+      ~goal:"Keep keeper guidance aligned with runtime behavior"
+      ~short_goal:"verify tool-token integrity"
+      ~mid_goal:"ship coherent keeper guidance"
+      ~long_goal:"avoid retired tool prompt drift"
+      ~will:"maintain coherent identity"
+      ~needs:"runtime truth and durable continuity"
+      ~desires:"observable progress"
+      ~instructions:""
+      ()
+  in
+  check (list string) "no retired/unknown tool-like tokens" []
+    (List.map
+       (fun (violation : KPT.violation) ->
+          violation.token ^ ":" ^ violation.reason)
+       (KPT.violations prompt))
 
 let test_state_block_schema_is_canonical_six_field_shape () =
   let text = KUP.state_block_instruction_text in
@@ -343,7 +377,7 @@ let test_prompt_mentions_runtime_operator_approval_for_risky_actions () =
 let test_keeper_oas_guardrails_are_visibility_neutral () =
   let source_guardrails =
     { Agent_sdk.Guardrails.tool_filter =
-        Agent_sdk.Guardrails.AllowList [ "keeper_report_state" ]
+        Agent_sdk.Guardrails.AllowList [ "keeper_task_done" ]
     ; max_tool_calls_per_turn = Some 7
     }
   in
@@ -539,6 +573,10 @@ let () =
             test_state_block_guard_is_runtime_managed_not_absolute_never;
           test_case "unified state instruction respects turn-level guard" `Quick
             test_unified_state_instruction_respects_turn_level_guard;
+          test_case "prompt token audit rejects retired state tool" `Quick
+            test_prompt_tool_token_audit_rejects_retired_state_tool;
+          test_case "rendered keeper prompt has no unknown tool tokens" `Quick
+            test_rendered_keeper_prompt_has_no_unknown_tool_tokens;
           test_case "state block schema is canonical six-field shape" `Quick
             test_state_block_schema_is_canonical_six_field_shape;
           test_case "constitution uses canonical state instruction" `Quick

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -217,7 +217,7 @@ let test_finalizer_prefers_reported_state_snapshot () =
   let reported_state_snapshot =
     make_snapshot
       ~goal:(Some "Tool state goal")
-      ~progress:(Some "Reported through keeper_report_state")
+      ~progress:(Some "Reported through STATE block")
       ~done_summary:None
       ~next_summary:None
       ~next_items:[]
@@ -231,7 +231,7 @@ let test_finalizer_prefers_reported_state_snapshot () =
       ~reported_state_snapshot:(Some reported_state_snapshot)
       ~keeper_name:"test"
       ~goal:"Fallback goal"
-      ~actual_keeper_tool_names:[ "keeper_report_state" ]
+      ~actual_keeper_tool_names:[]
       ~stop_reason:Runtime_agent.Completed
       ~raw_response_text:"Visible reply"
       ()
@@ -250,7 +250,7 @@ let test_finalizer_prefers_reported_state_snapshot () =
     state_snapshot_source;
   Alcotest.(check (option string))
     "progress"
-    (Some "Reported through keeper_report_state")
+    (Some "Reported through STATE block")
     state_snapshot.progress;
   Alcotest.(check string)
     "visible response"

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -71,23 +71,24 @@ let test_extend_turns_resolved () =
       fail (Printf.sprintf "extend_turns should resolve, got Unknown (tried: %s)"
               (TR.string_of_tried tried))
 
-let test_keeper_report_state_core_always () =
+let retired_state_tool () =
+  match Keeper_state_reporting_contract.forbidden_tool_tokens with
+  | token :: _ -> token
+  | [] -> fail "state-reporting contract must name retired tool tokens"
+
+let test_retired_state_tool_does_not_resolve () =
+  let token = retired_state_tool () in
   check bool
-    "keeper_report_state is core always"
-    true
-    (Masc.Keeper_tool_registry.is_core_always_tool "keeper_report_state");
-  match TR.resolve "keeper_report_state" with
-  | TR.Resolved { via = TR.Registry_core_tools; _ } -> ()
+    "retired state tool is not core always"
+    false
+    (Masc.Keeper_tool_registry.is_core_always_tool token);
+  match TR.resolve token with
+  | TR.Unknown _ -> ()
   | TR.Resolved { via; _ } | TR.Alias_to { via; _ } ->
       fail
         (Printf.sprintf
-           "keeper_report_state should resolve via Registry_core_tools, got via %s"
+           "retired state tool should not resolve, got via %s"
            (TR.string_of_tried_source via))
-  | TR.Unknown { tried; _ } ->
-      fail
-        (Printf.sprintf
-           "keeper_report_state should resolve, got Unknown (tried: %s)"
-           (TR.string_of_tried tried))
 
 let test_tool_execute_resolves () =
   (* Was "resolves via surface"; the per-actor Surface source was removed in
@@ -319,7 +320,7 @@ let () =
         test_case "mcp prefix stripped and resolved" `Quick test_mcp_prefix_stripped;
         test_case "unknown returns tried list" `Quick test_unknown_returns_tried_list;
         test_case "extend_turns resolves" `Quick test_extend_turns_resolved;
-        test_case "keeper_report_state is core-always structured state tool" `Quick test_keeper_report_state_core_always;
+        test_case "retired state-reporting tool does not resolve" `Quick test_retired_state_tool_does_not_resolve;
         test_case "tool_execute resolves" `Quick test_tool_execute_resolves;
         test_case "masc_keeper_* cluster resolves via descriptor registry (boot guard)" `Quick test_descriptor_registry_admits_masc_keeper_cluster;
         test_case "masc_board_post resolves" `Quick test_masc_board_post_resolves;

--- a/test/test_keeper_validation_breaker_exempt.ml
+++ b/test/test_keeper_validation_breaker_exempt.ml
@@ -48,6 +48,11 @@ let meta_with_active_goals goal_ids =
   | Ok meta -> meta
   | Error err -> fail ("meta_of_json_fixture failed: " ^ err)
 
+let retired_state_tool () =
+  match Keeper_state_reporting_contract.forbidden_tool_tokens with
+  | token :: _ -> token
+  | [] -> fail "state-reporting contract must name retired tool tokens"
+
 (* The error a keeper sees when it sends a non-object contract — the residual
    validation case after D1 makes an OMITTED contract [Ok None]. *)
 let payload =
@@ -113,7 +118,7 @@ let test_task_create_multi_active_goals_without_goal_id_is_unscoped () =
        | tasks ->
            failf "expected exactly one persisted task, got %d" (List.length tasks))
 
-let test_keeper_report_state_returns_state_block () =
+let test_retired_state_tool_is_not_task_tool () =
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
@@ -125,26 +130,23 @@ let test_keeper_report_state_returns_state_block () =
          Task.handle_keeper_task_tool
            ~config
            ~meta
-           ~name:"keeper_report_state"
-           ~args:
-             (`Assoc
-               [ "goal", `String "Keep runtime visible"
-               ; "next_items", `List [ `String "Check main CI" ]
-               ; "constraints", `List [ `String "Use worktrees" ]
-               ])
+           ~name:(retired_state_tool ())
+           ~args:(`Assoc [])
        in
        let json = Yojson.Safe.from_string payload in
-       check bool "state report succeeds" true (json |> U.member "ok" |> U.to_bool);
-       check string "state report keeps goal" "Keep runtime visible"
-         (json
-          |> U.member "state_snapshot"
-          |> U.member "goal"
-          |> U.to_string);
-       check string "state report renders state block"
-         "[STATE]\nGoal: Keep runtime visible\nNext: Check main CI\nConstraints: Use worktrees\n[/STATE]"
-         (json |> U.member "state_block" |> U.to_string);
-       check bool "state report returns typed outcome" true
-         (json |> U.member "typed_outcome" <> `Null))
+       check bool "retired state report is not ok=true" true
+         (match json |> U.member "ok" with
+          | `Bool true -> false
+          | `Bool false
+          | `Null ->
+            true
+          | _ -> false);
+       check string "retired state report is unknown task tool"
+         "unknown_task_tool"
+         (json |> U.member "error" |> U.to_string);
+       check string "retired tool echoed for diagnosis"
+         (retired_state_tool ())
+         (json |> U.member "tool" |> U.to_string))
 
 let () =
   run "keeper validation breaker exemption"
@@ -159,7 +161,7 @@ let () =
             "keeper_task_create treats ambiguous active_goal_ids as advisory"
             `Quick
             test_task_create_multi_active_goals_without_goal_id_is_unscoped
-        ; test_case "keeper_report_state returns state block" `Quick
-            test_keeper_report_state_returns_state_block
+        ; test_case "retired state-reporting tool is not a task tool" `Quick
+            test_retired_state_tool_is_not_task_tool
         ] )
     ]

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1136,6 +1136,14 @@ let test_health_json_surfaces_durable_paused_keepers () =
             (fleet_safety |> member "paused_autoboot_enabled_keeper_count" |> to_int);
           Alcotest.(check int) "health exposes target reaction capacity" 3
             (fleet_safety |> member "target_reaction_capacity_count" |> to_int);
+          Alcotest.(check int) "health exposes desired reaction capacity" 3
+            (fleet_safety |> member "desired_reaction_capacity_count" |> to_int);
+          Alcotest.(check int) "health exposes suppressed capacity" 1
+            (fleet_safety |> member "suppressed_capacity_count" |> to_int);
+          Alcotest.(check int) "health exposes actionable target capacity" 2
+            (fleet_safety
+             |> member "actionable_target_reaction_capacity_count"
+             |> to_int);
           Alcotest.(check int) "health exposes minimum running fibers" 2
             (fleet_safety |> member "minimum_running_fibers" |> to_int);
           Alcotest.(check string) "health marks fleet blocked" "blocked"
@@ -1147,7 +1155,9 @@ let test_health_json_surfaces_durable_paused_keepers () =
             (fleet_safety |> member "no_executable_keeper_fibers" |> to_bool);
           Alcotest.(check bool) "health marks capacity below target" true
             (fleet_safety |> member "reaction_capacity_below_target" |> to_bool);
-          Alcotest.(check int) "health exposes capacity shortfall" 3
+          Alcotest.(check int) "health exposes raw capacity shortfall" 3
+            (fleet_safety |> member "raw_reaction_capacity_shortfall_count" |> to_int);
+          Alcotest.(check int) "health exposes actionable capacity shortfall" 2
             (fleet_safety |> member "reaction_capacity_shortfall_count" |> to_int);
           Alcotest.(check bool) "health fleet asks for operator action" true
             (fleet_safety |> member "operator_action_required" |> to_bool);
@@ -1257,19 +1267,33 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
             (fleet_safety |> member "failing_keeper_fiber_count" |> to_int);
           Alcotest.(check int) "health exposes target reaction capacity" 4
             (fleet_safety |> member "target_reaction_capacity_count" |> to_int);
+          Alcotest.(check int) "health exposes desired reaction capacity" 4
+            (fleet_safety |> member "desired_reaction_capacity_count" |> to_int);
+          Alcotest.(check int) "health exposes suppressed capacity" 1
+            (fleet_safety |> member "suppressed_capacity_count" |> to_int);
+          Alcotest.(check int) "health exposes actionable target capacity" 3
+            (fleet_safety
+             |> member "actionable_target_reaction_capacity_count"
+             |> to_int);
           Alcotest.(check int) "health exposes minimum running fibers" 2
             (fleet_safety |> member "minimum_running_fibers" |> to_int);
           Alcotest.(check bool) "health is not below minimum margin" false
             (fleet_safety |> member "low_running_fiber_margin" |> to_bool);
           Alcotest.(check bool) "health marks capacity below target" true
             (fleet_safety |> member "reaction_capacity_below_target" |> to_bool);
-          Alcotest.(check int) "health exposes capacity shortfall" 2
+          Alcotest.(check int) "health exposes raw capacity shortfall" 2
+            (fleet_safety |> member "raw_reaction_capacity_shortfall_count" |> to_int);
+          Alcotest.(check int) "health exposes actionable capacity shortfall" 1
             (fleet_safety |> member "reaction_capacity_shortfall_count" |> to_int);
-          Alcotest.(check int) "health exposes executable capacity shortfall" 2
+          Alcotest.(check int) "health exposes raw executable capacity shortfall" 2
+            (fleet_safety
+             |> member "raw_executable_reaction_capacity_shortfall_count"
+             |> to_int);
+          Alcotest.(check int) "health exposes actionable executable capacity shortfall" 1
             (fleet_safety
              |> member "executable_reaction_capacity_shortfall_count"
              |> to_int);
-          Alcotest.(check int) "health exposes blocked shortfall" 2
+          Alcotest.(check int) "health exposes blocked shortfall" 1
             (fleet_safety |> member "blocked_count" |> to_int);
           Alcotest.(check string) "health marks fleet degraded" "degraded"
             (fleet_safety |> member "status" |> to_string);
@@ -1279,6 +1303,60 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
 	          Alcotest.(check bool) "health fleet asks for operator action" true
 	            (fleet_safety |> member "operator_action_required" |> to_bool);
 	          ())))
+
+let test_health_json_suppresses_operator_paused_capacity () =
+  let keeper_names = List.init 17 (fun i -> Printf.sprintf "keeper-%02d" i) in
+  let phase_counts : Server_routes_http_runtime_fleet_scan.keeper_phase_counts =
+    { running = 11; failing = 0; recovering = 0; executable = 11 }
+  in
+  let paused_keepers_json =
+    `Assoc
+      [
+        ("count", `Int 6);
+        ("autoboot_enabled_count", `Int 6);
+      ]
+  in
+  let autoboot_scan : Server_routes_http_runtime_fleet_scan.autoboot_keeper_scan =
+    { autoboot_names = keeper_names; read_errors = [] }
+  in
+  let json =
+    Server_routes_http_runtime_fleet_scan.keeper_fleet_safety_health_json
+      ~bootable_names:keeper_names
+      ~autoboot_scan
+      ~phase_counts
+      ~paused_keepers_json
+      ()
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "paused-only capacity is ok" "ok"
+    (json |> member "status" |> to_string);
+  Alcotest.(check string) "paused blocker is informational"
+    "durable_paused_autoboot_enabled"
+    (json |> member "blocker" |> to_string);
+  Alcotest.(check int) "desired capacity" 17
+    (json |> member "desired_reaction_capacity_count" |> to_int);
+  Alcotest.(check int) "suppressed capacity" 6
+    (json |> member "suppressed_capacity_count" |> to_int);
+  Alcotest.(check int) "actionable target" 11
+    (json |> member "actionable_target_reaction_capacity_count" |> to_int);
+  Alcotest.(check int) "raw shortfall remains visible" 6
+    (json |> member "raw_reaction_capacity_shortfall_count" |> to_int);
+  Alcotest.(check int) "actionable shortfall is zero" 0
+    (json |> member "reaction_capacity_shortfall_count" |> to_int);
+  Alcotest.(check bool) "not below actionable target" false
+    (json |> member "reaction_capacity_below_target" |> to_bool);
+  Alcotest.(check bool) "no operator action for operator-paused capacity" false
+    (json |> member "operator_action_required" |> to_bool);
+  Alcotest.(check (float 0.001)) "Grafana suppressed gauge" 6.0
+    (Otel_metric_store.metric_value_or_zero
+       Keeper_metrics.(to_string FleetCapacity)
+       ~labels:[("kind", "suppressed")]
+       ());
+  Alcotest.(check (float 0.001)) "Grafana actionable shortfall gauge" 0.0
+    (Otel_metric_store.metric_value_or_zero
+       Keeper_metrics.(to_string FleetCapacity)
+       ~labels:[("kind", "actionable_shortfall")]
+       ())
 
 let test_health_json_distinguishes_failing_executable_keepers () =
   with_temp_dir "health-failing-executable-keepers" (fun dir ->
@@ -2864,6 +2942,9 @@ let () =
           Alcotest.test_case
             "health json degrades when reaction capacity is below target"
             `Quick test_health_json_degrades_when_reaction_capacity_below_target;
+          Alcotest.test_case
+            "health json suppresses operator-paused capacity"
+            `Quick test_health_json_suppresses_operator_paused_capacity;
           Alcotest.test_case
             "health json distinguishes failing executable keepers"
             `Quick test_health_json_distinguishes_failing_executable_keepers;


### PR DESCRIPTION
## Summary

This PR tightens the Keeper context/prompt/health contract around state reporting and fleet actionability.

- Adds `Keeper_state_reporting_contract` as the SSOT for `[STATE]` reporting instructions, fields, recovery text, output guard, and retired state-tool tokens.
- Converts `Keeper_state_block_prompt` into a compatibility wrapper over that contract.
- Removes stale prompt guidance for removed state-reporting/tool names and adds rendered prompt token auditing for unknown or retired `keeper_*` / `masc_*` tool-looking tokens.
- Adds `masc_keeper_prompt_unknown_tool_tokens_total` and `masc_keeper_fleet_capacity{kind=...}` metrics.
- Splits fleet health capacity into desired, suppressed, actionable target, raw shortfall, and actionable shortfall so operator-paused keepers do not hide the actual actionable deficit.

## Why

The previous surface let prompt files, tests, finalizer comments, and memory-policy paths each encode their own version of state reporting. That made it easy for retired tool names such as `keeper_report_state` or stale task-control names to survive in recovery/context prompts after the runtime tool surface had changed.

Fleet health had a related observability issue: target-vs-running shortfall mixed intentional operator pauses with real capacity deficits. The new fields preserve the old raw picture while exposing the smaller actionable deficit directly for `/health?full=1` and Grafana.

## Validation

Passed before the final rebase:

- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build ./test/test_keeper_prompt_metrics.exe ./test/test_keeper_validation_breaker_exempt.exe ./test/test_keeper_state_snapshot_json.exe ./test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_keeper_prompt_metrics.exe` — 22 tests passed
- `./_build/default/test/test_keeper_validation_breaker_exempt.exe` — 5 tests passed
- `./_build/default/test/test_keeper_state_snapshot_json.exe` — 18 tests passed
- `./_build/default/test/test_server_runtime_bootstrap.exe -q` — new fleet health tests passed; existing unrelated `bootstrap 2` failure remains (`tool policy not copied (deleted module)`)
- `./_build/default/test/test_keeper_tool_resolution.exe -q` — new retired state-tool negative test passed; existing matrix failures remain for `keeper_board_get`, `masc_agents`

After rebasing onto current `origin/main`, a focused rebuild was attempted but blocked by another worktree holding `/tmp/me-dune-local.lock` / `/tmp/me-opam-switch.lock`, so the waiting process was stopped without touching the lock holder.

Local wrapper note: the normal wrapper pin check reports local `agent_sdk` pin drift, so focused code validation used `MASC_SKIP_PIN_CHECK=1`.