### PR TITLE
fix(test): repair never-compiled attempt-watchdog test (#20983) — broken main

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -116,7 +116,6 @@
   keeper_unified_turn_pre_dispatch
   keeper_unified_turn_retry_setup
   keeper_unified_turn_terminal_error
-  keeper_unified_turn_attempt_watchdog
   keeper_unified_turn_cascade_resolution
   keeper_unified_turn_execution
   keeper_unified_turn_livelock_block

--- a/test/test_keeper_unified_turn_attempt_watchdog.ml
+++ b/test/test_keeper_unified_turn_attempt_watchdog.ml
@@ -1,7 +1,7 @@
 open Alcotest
 
-module W = Keeper_unified_turn_attempt_watchdog
-module Metrics = Otel_metric_store
+module W = Masc.Keeper_unified_turn_attempt_watchdog
+module Metrics = Masc.Otel_metric_store
 
 let watchdog_metric = Keeper_metrics.(to_string AttemptWatchdogFired)
 
@@ -29,7 +29,7 @@ let test_safety_deadline_records_terminal_reason_and_metric () =
          : (unit, Agent_sdk.Error.sdk_error) result);
       false
     with
-    | Eio.Cancel.Cancelled (Failure "attempt_watchdog_safety_deadline") -> true
+    | Eio.Cancel.Cancelled (Failure msg) when String.equal msg "attempt_watchdog_safety_deadline" -> true
     | Eio.Cancel.Cancelled exn ->
       Alcotest.failf "unexpected cancellation: %s" (Printexc.to_string exn)
   in
@@ -64,7 +64,7 @@ let test_external_cancel_records_external_reason_without_metric () =
          : (unit, Agent_sdk.Error.sdk_error) result);
       false
     with
-    | Eio.Cancel.Cancelled (Failure "external-cancel-test") -> true
+    | Eio.Cancel.Cancelled (Failure msg) when String.equal msg "external-cancel-test" -> true
     | Eio.Cancel.Cancelled exn ->
       Alcotest.failf "unexpected cancellation: %s" (Printexc.to_string exn)
   in
@@ -90,7 +90,10 @@ let test_normal_completion_does_not_record_cancel () =
         ~on_cancelled:(fun reason -> cancel_reasons := reason :: !cancel_reasons)
         ~run:(fun () -> Ok "done"))
   in
-  check (result string) "normal result passes through" (Ok "done") outcome;
+  (match outcome with
+   | Ok value -> check string "normal result passes through" "done" value
+   | Error err ->
+     Alcotest.failf "unexpected error: %s" (Agent_sdk.Error.to_string err));
   check (list string) "no cancel reason" [] !cancel_reasons
 ;;
 


### PR DESCRIPTION
## 무엇

**main @check가 현재 깨져 있습니다** — #20983이 추가한 `test_keeper_unified_turn_attempt_watchdog.ml`이 한 번도 컴파일된 적 없는 상태로 머지됐습니다 (pristine e8c96210b에서 재현). 24시간 내 3번째 동일 클래스(#20942 ppx 미배선, #20967 open Masc 누락) — 게이트 구조 이슈는 #20987.

## 독립 결함 4건 (전부 수리, 단언은 하나도 버리지 않음)

1. **bare 모듈 참조 + private_modules**: `Keeper_unified_turn_attempt_watchdog`가 wrapped `masc`의 `private_modules`에 있어 "module W is an alias ... which is missing". → `Masc.` 한정 + private 목록에서 제거 (#20958이 Keeper_turn_driver에 적용한 것과 같은 승격 — 테스트가 행사하는 모듈은 private이 아님)
2. **warning 52 × 2**: `Failure "literal"` 패턴 → `Failure msg when String.equal msg ...`
3. **Alcotest `result string`**: error testable 누락 → sdk_error 메시지로 failf하는 match
4. **metric 단언이 영원히 0**: `module Metrics = Otel_metric_store`가 **테스트 더블**(`test/deps/otel_metric_store.ml`, 자체 빈 store)로 해석 — watchdog는 프로덕션 facade에 increment. → `Masc.Otel_metric_store`로 같은 인스턴스를 읽게 수정. 단언 가치 보존(증분 1.0 실측 green)

## 검증

- `dune exec test/test_keeper_unified_turn_attempt_watchdog.exe` → **3/3 PASS, 1.005s**
- 전체 `@check` 빌드 결과는 코멘트로 추가 예정 (백그라운드 진행 중)

## 함의 (리뷰어 참고)

결함 4는 일반화됩니다: **메가-lib(`masc`) 내부 코드의 metric을 테스트 더블로 관측하는 것은 구조적으로 불가능**합니다 (더블과 프로덕션 store는 다른 인스턴스). 같은 패턴의 다른 테스트가 있다면 같은 함정입니다.

Refs #20983, #20987.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
