### PR TITLE
[codex] fix eval selector determinism ratchet

### DIFF
--- a/lib/core/eval_tool_selector.ml
+++ b/lib/core/eval_tool_selector.ml
@@ -21,24 +21,21 @@ let label = function
   | Receipt_label (key, value) -> "receipt_label:" ^ key ^ "=" ^ value
   | Eval_tag value -> "eval_tag:" ^ value
 
-let kind_value = function
-  | Tool_name value -> ("tool_name", value)
-  | Descriptor_id value -> ("descriptor_id", value)
-  | Runtime_handler value -> ("runtime_handler", value)
-  | Eval_tag value -> ("eval_tag", value)
-  | Receipt_label _ -> ("receipt_label", "")
-
 let to_yojson selector =
+  let kind_value kind value =
+    `Assoc [ ("type", `String kind); ("value", `String value) ]
+  in
   match selector with
+  | Tool_name value -> kind_value "tool_name" value
+  | Descriptor_id value -> kind_value "descriptor_id" value
+  | Runtime_handler value -> kind_value "runtime_handler" value
+  | Eval_tag value -> kind_value "eval_tag" value
   | Receipt_label (key, value) ->
       `Assoc
         [ ("type", `String "receipt_label")
         ; ("key", `String key)
         ; ("value", `String value)
         ]
-  | Tool_name _ | Descriptor_id _ | Runtime_handler _ | Eval_tag _ ->
-      let kind, value = kind_value selector in
-      `Assoc [ ("type", `String kind); ("value", `String value) ]
 
 let string_field json key =
   match Json_util.assoc_member_opt key json with

--- a/lib/eval_harness.ml
+++ b/lib/eval_harness.ml
@@ -183,12 +183,17 @@ let check_tool_expectations_with_evidence
     let detail =
       if not required_ok then
         Printf.sprintf "required tool selector '%s' was not called" selector_label
-      else if not max_ok then
-        Printf.sprintf "tool selector '%s' called %d times (max: %d)"
-          selector_label call_count (Option.value ~default:0 exp.max_calls)
-      else
+      else (
+        match exp.max_calls with
+        | Some max when call_count > max ->
+          Printf.sprintf
+            "tool selector '%s' called %d times (max: %d)"
+            selector_label
+            call_count
+            max
+        | _ ->
         Printf.sprintf "tool selector '%s' called %d times — OK"
-          selector_label call_count
+          selector_label call_count)
     in
     { grader_desc = Printf.sprintf "tool_expectation: %s" selector_label;
       score = if passed then 1.0 else 0.0;
@@ -484,10 +489,12 @@ let scenario_of_json (json : Yojson.Safe.t) : (scenario, string) result =
           List.filter_map (fun te ->
             try
               let legacy_tool =
-                Json_util.get_string te "tool"
-                |> Option.value ~default:
-                     (Json_util.get_string te "tool_name"
-                      |> Option.value ~default:"")
+                match Json_util.get_string te "tool" with
+                | Some tool -> tool
+                | None -> (
+                  match Json_util.get_string te "tool_name" with
+                  | Some tool_name -> tool_name
+                  | None -> "")
               in
               let selector =
                 match Json_util.assoc_member_opt "selector" te with

--- a/test/test_eval_harness.ml
+++ b/test/test_eval_harness.ml
@@ -142,7 +142,8 @@ let test_tool_expect_max_calls_exceeded () =
   let results = Eval_harness.check_tool_expectations expectations actual in
   let r = List.hd results in
   Alcotest.(check bool) "exceeded penalty" true (r.Eval_harness.score < 1.0);
-  Alcotest.(check bool) "has warning" true (String.length r.Eval_harness.detail > 0)
+  Alcotest.(check bool) "has max detail" true
+    (String_util.contains_substring r.Eval_harness.detail "max: 2")
 
 let test_tool_expect_descriptor_selector () =
   let expectations : Eval_harness.tool_expectation list = [
@@ -264,6 +265,28 @@ let test_parse_regex_grader () =
        | _ -> Alcotest.fail "Expected Deterministic grader")
   | Error e -> Alcotest.fail (Printf.sprintf "Parse failed: %s" e)
 
+let test_parse_tool_expectation_tool_name_fallback () =
+  let json = Yojson.Safe.from_string {|{
+    "id": "tool-name-fallback",
+    "goal": "Test legacy tool_name fallback",
+    "tool_expectations": [
+      {"tool_name": "keeper_task_claim", "required": true}
+    ]
+  }|} in
+  match Eval_harness.scenario_of_json json with
+  | Ok s ->
+      (match s.Eval_harness.tool_expectations with
+       | [ expectation ] ->
+           Alcotest.(check string) "legacy label" "keeper_task_claim"
+             expectation.Eval_harness.tool_name;
+           (match expectation.Eval_harness.selector with
+            | Eval_tool_selector.Tool_name tool_name ->
+                Alcotest.(check string) "selector fallback" "keeper_task_claim"
+                  tool_name
+            | _ -> Alcotest.fail "Expected Tool_name selector")
+       | _ -> Alcotest.fail "Expected exactly one tool expectation")
+  | Error e -> Alcotest.fail (Printf.sprintf "Parse failed: %s" e)
+
 let test_parse_model_grader () =
   let json = Yojson.Safe.from_string {|{
     "id": "model-test",
@@ -368,6 +391,8 @@ let () =
       Alcotest.test_case "minimal" `Quick test_parse_minimal_scenario;
       Alcotest.test_case "full scenario" `Quick test_parse_full_scenario;
       Alcotest.test_case "regex grader" `Quick test_parse_regex_grader;
+      Alcotest.test_case "tool_name fallback" `Quick
+        test_parse_tool_expectation_tool_name_fallback;
       Alcotest.test_case "model grader" `Quick test_parse_model_grader;
     ]);
     ("file_loading", [


### PR DESCRIPTION
## Summary
- Replace new eval harness Option.value fallbacks with explicit pattern matches.
- Pin the max_calls diagnostic and legacy tool_name fallback behavior in Eval_harness tests.
- Remove Eval_tool_selector.to_yojson wildcard matching so CI lint does not trip fragile-match under warn-error.
- Clear stale CI compile blockers uncovered by the rebase: expose the watchdog unit under masc for its direct test and use the public Tool_call_quality_benchmark.score_run wrapper in selector tests.
- Keep #20982 behavior unchanged while satisfying the DET/NDT and selector boundary ratchets.

## Validation
- ocamlformat --check lib/core/eval_tool_selector.ml lib/eval_harness.ml test/test_eval_harness.ml test/test_tool_call_quality_benchmark.ml
- bash scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD
- bash scripts/lint/no-eval-tool-selector-runtime-import.sh
- bash scripts/audit-keeper-tool-boundary-matrix.sh

Build not run locally per instruction.