### PR TITLE
[codex] emit descriptor eval tags

### DIFF
--- a/lib/core/eval_tool_selector.ml
+++ b/lib/core/eval_tool_selector.ml
@@ -36,7 +36,7 @@ let to_yojson selector =
         ; ("key", `String key)
         ; ("value", `String value)
         ]
-  | _ ->
+  | Tool_name _ | Descriptor_id _ | Runtime_handler _ | Eval_tag _ ->
       let kind, value = kind_value selector in
       `Assoc [ ("type", `String kind); ("value", `String value) ]
 

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -84,6 +84,7 @@ type t =
   ; runtime_handler : runtime_handler
   ; translate : Yojson.Safe.t -> Yojson.Safe.t
   ; receipt_labels : (string * string) list
+  ; eval_tags : string list
   }
 
 let executor_to_string = function
@@ -427,6 +428,7 @@ let descriptor_with_public_aliases
   ; runtime_handler
   ; translate
   ; receipt_labels
+  ; eval_tags = []
   }
 ;;
 
@@ -455,7 +457,11 @@ let descriptor
     ~backend
     ~sandbox
     ~runtime_handler
-    ~translate
+      ~translate
+;;
+
+let with_eval_tags eval_tags descriptor =
+  { descriptor with eval_tags }
 ;;
 
 let public_descriptors =
@@ -992,26 +998,28 @@ let internal_descriptors : t list =
       ~input_schema:empty_object_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_stay_silent
-  ; in_process_descriptor
-      ~id:"keeper.tools_list"
-      ~name:"keeper_tools_list"
-      ~description:
-        "List the active keeper tool surface from descriptors and registered schemas. \
-         This is capability introspection, not connector content lookup. Use \
-         keeper_surface_read only for current connected-surface lane context. \
-         No arguments."
-      ~input_schema:empty_object_schema
-      ~policy:(read_only_in_process_policy ())
-      ~handler:Tool_tools_list
-  ; in_process_descriptor
-      ~id:"keeper.tool_search"
-      ~name:"keeper_tool_search"
-      ~description:
-        "Search keeper tool schemas by free-text query. Returns ranked tool \
-         descriptions and input schemas."
-      ~input_schema:tool_search_schema
-      ~policy:(read_only_in_process_policy ())
-      ~handler:Tool_tool_search
+  ; (in_process_descriptor
+       ~id:"keeper.tools_list"
+       ~name:"keeper_tools_list"
+       ~description:
+         "List the active keeper tool surface from descriptors and registered schemas. \
+          This is capability introspection, not connector content lookup. Use \
+          keeper_surface_read only for current connected-surface lane context. \
+          No arguments."
+       ~input_schema:empty_object_schema
+       ~policy:(read_only_in_process_policy ())
+       ~handler:Tool_tools_list
+     |> with_eval_tags [ "capability_introspection" ])
+  ; (in_process_descriptor
+       ~id:"keeper.tool_search"
+       ~name:"keeper_tool_search"
+       ~description:
+         "Search keeper tool schemas by free-text query. Returns ranked tool \
+          descriptions and input schemas."
+       ~input_schema:tool_search_schema
+       ~policy:(read_only_in_process_policy ())
+       ~handler:Tool_tool_search
+     |> with_eval_tags [ "capability_introspection" ])
     (* ── memory / context (RFC-0179 PR-3) ─────────────────────── *)
   ; in_process_descriptor
       ~id:"keeper.context.status"
@@ -1053,20 +1061,21 @@ let internal_descriptors : t list =
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_library_read
     (* ── connector surfaces (RFC-0223 P3) ─────────────────────── *)
-  ; in_process_descriptor
-      ~id:"keeper.surface.read"
-      ~name:"keeper_surface_read"
-      ~description:
-        "Read recent conversation from one connected surface lane (dashboard, \
-         discord, slack, or another connector label) with speaker identity \
-         and a derived participant roster. Use when the user asks about a \
-         current connector lane, recent lane messages, or participants. This \
-         does not enumerate connector-wide channel registries; if asked for \
-         channels outside Connected Surfaces, read only visible lane evidence \
-         and state that the wider registry is unavailable."
-      ~input_schema:surface_read_schema
-      ~policy:(read_only_in_process_policy ())
-      ~handler:Tool_surface_read
+  ; (in_process_descriptor
+       ~id:"keeper.surface.read"
+       ~name:"keeper_surface_read"
+       ~description:
+         "Read recent conversation from one connected surface lane (dashboard, \
+          discord, slack, or another connector label) with speaker identity \
+          and a derived participant roster. Use when the user asks about a \
+          current connector lane, recent lane messages, or participants. This \
+          does not enumerate connector-wide channel registries; if asked for \
+          channels outside Connected Surfaces, read only visible lane evidence \
+          and state that the wider registry is unavailable."
+       ~input_schema:surface_read_schema
+       ~policy:(read_only_in_process_policy ())
+       ~handler:Tool_surface_read
+     |> with_eval_tags [ "surface_context_read" ])
   ; in_process_descriptor
       ~id:"keeper.surface.post"
       ~name:"keeper_surface_post"
@@ -1267,8 +1276,9 @@ let internal_descriptors : t list =
   (* ── RFC-0182 §3.1 — masc_agent_* cluster (3 entries; masc_agents +
        masc_agent_update removed 2026-06-09 with the dead agent-status
        surface) ────────── *)
-  ; masc_agent_descriptor "card" "masc_agent_card"
-      "Read an agent card." ~readonly:true
+  ; (masc_agent_descriptor "card" "masc_agent_card"
+       "Read an agent card." ~readonly:true
+     |> with_eval_tags [ "agent_profile_lookup" ])
   ; masc_agent_descriptor "fitness" "masc_agent_fitness"
       "Read agent fitness metrics." ~readonly:true
   ; masc_agent_descriptor "get_metrics" "masc_get_metrics"
@@ -1439,6 +1449,10 @@ let receipt_labels_json d =
   `Assoc (List.map (fun (key, value) -> key, `String value) d.receipt_labels)
 ;;
 
+let eval_tags_json d =
+  `List (List.map (fun tag -> `String tag) d.eval_tags)
+;;
+
 let route_evidence_json d =
   let policy = d.policy in
   let policy_fields =
@@ -1459,6 +1473,7 @@ let route_evidence_json d =
      ; "sandbox", `String (sandbox_to_string d.sandbox)
      ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
      ; "receipt_labels", receipt_labels_json d
+     ; "eval_tags", eval_tags_json d
      ; "approval", `String (approval_to_string policy.approval)
      ; "retryable", `Bool policy.retryable
      ; "cwd_scope", Json_util.string_opt_to_json policy.cwd_scope

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -89,6 +89,9 @@ type t =
   ; runtime_handler : runtime_handler
   ; translate : Yojson.Safe.t -> Yojson.Safe.t
   ; receipt_labels : (string * string) list
+  (** Evaluation-only semantic tags emitted in route evidence. These tags
+      support replay/harness scoring and are not runtime selection policy. *)
+  ; eval_tags : string list
   }
 
 val executor_to_string : executor -> string

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -97,9 +97,10 @@ val route_evidence_json_of_tool_io :
 (** [route_evidence_json_of_tool_io] extracts first-class route proof from a
     keeper tool call. Descriptor-backed calls always include descriptor route
     fields such as [descriptor_id], [public_name], [canonical_name], [executor],
-    [backend], [sandbox], and policy labels. Runtime route/status fields such
-    as [via], [sandbox_profile], [network_mode], [status], and redacted
-    command/cwd/path are added when present. *)
+    [backend], [sandbox], evaluation-only [eval_tags], and policy labels.
+    Runtime route/status fields such as [via], [sandbox_profile],
+    [network_mode], [status], and redacted command/cwd/path are added when
+    present. *)
 
 val init : ?cluster_name:string -> base_path:string -> unit -> unit
 (** [init ?cluster_name ~base_path ()] creates the cluster-aware Dated_jsonl

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -662,6 +662,33 @@ let test_route_evidence_records_masc_board_descriptor () =
         (Safe_ops.json_string_opt "runtime_handler" evidence)
     | _ -> Alcotest.fail "expected exactly one entry")
 
+let route_evidence_for_tool tool_name =
+  match
+    Keeper_tool_call_log.route_evidence_json_of_tool_io
+      ~tool_name
+      ~input:(`Assoc [])
+      ~output_text:"{}"
+  with
+  | Some evidence -> evidence
+  | None -> Alcotest.failf "missing route evidence for %s" tool_name
+;;
+
+let check_eval_tags tool_name expected =
+  let evidence = route_evidence_for_tool tool_name in
+  Alcotest.(check (list string))
+    (tool_name ^ " eval tags")
+    expected
+    (Safe_ops.json_string_list "eval_tags" evidence)
+;;
+
+let test_route_evidence_records_descriptor_eval_tags () =
+  check_eval_tags "keeper_tools_list" [ "capability_introspection" ];
+  check_eval_tags "keeper_tool_search" [ "capability_introspection" ];
+  check_eval_tags "keeper_surface_read" [ "surface_context_read" ];
+  check_eval_tags "masc_agent_card" [ "agent_profile_lookup" ];
+  check_eval_tags "keeper_time_now" []
+;;
+
 let test_non_object_input_still_logs_action_radius () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
@@ -1147,6 +1174,10 @@ let () =
             test_route_evidence_records_internal_descriptor
         ; eio_test "route evidence records masc board descriptor"
             test_route_evidence_records_masc_board_descriptor
+        ; Alcotest.test_case
+            "route evidence records descriptor eval tags"
+            `Quick
+            test_route_evidence_records_descriptor_eval_tags
         ; eio_test "non-object input still logs action radius"
             test_non_object_input_still_logs_action_radius
         ; eio_test "dashboard aggregate groups runtime fields"

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -145,6 +145,73 @@ let test_no_blank_names () =
           d.Descriptor.public_name)
     (all_descriptors ())
 
+let eval_tag_charset_ok c =
+  (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c = '_'
+
+let assert_eval_tags_unique descriptor =
+  let seen = Hashtbl.create 8 in
+  List.iter
+    (fun tag ->
+      if Hashtbl.mem seen tag
+      then
+        Alcotest.failf
+          "descriptor %S has duplicate eval_tag %S"
+          descriptor.Descriptor.internal_name
+          tag;
+      Hashtbl.replace seen tag ())
+    descriptor.Descriptor.eval_tags
+;;
+
+let test_eval_tags_are_normalized () =
+  List.iter
+    (fun d ->
+      assert_eval_tags_unique d;
+      List.iter
+        (fun tag ->
+          if is_blank tag
+          then
+            Alcotest.failf
+              "descriptor %S has blank eval_tag"
+              d.Descriptor.internal_name;
+          if not (String.equal tag (String.trim tag))
+          then
+            Alcotest.failf
+              "descriptor %S has untrimmed eval_tag %S"
+              d.Descriptor.internal_name
+              tag;
+          String.iter
+            (fun c ->
+              if not (eval_tag_charset_ok c)
+              then
+                Alcotest.failf
+                  "descriptor %S eval_tag %S contains invalid character %C \
+                   (allowed: a-z, 0-9, _)"
+                  d.Descriptor.internal_name
+                  tag
+                  c)
+            tag)
+        d.Descriptor.eval_tags)
+    (all_descriptors ())
+
+let test_seed_eval_tags_are_registered () =
+  let check tool_name expected =
+    let descriptor =
+      match Descriptor.descriptors_for_internal tool_name with
+      | descriptor :: _ -> descriptor
+      | [] -> Alcotest.failf "missing internal descriptor: %s" tool_name
+    in
+    Alcotest.(check (list string))
+      (tool_name ^ " eval_tags")
+      expected
+      descriptor.Descriptor.eval_tags
+  in
+  check "keeper_tools_list" [ "capability_introspection" ];
+  check "keeper_tool_search" [ "capability_introspection" ];
+  check "keeper_surface_read" [ "surface_context_read" ];
+  check "masc_agent_card" [ "agent_profile_lookup" ];
+  check "keeper_time_now" []
+;;
+
 let internal_name_charset_ok c =
   (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c = '_'
 
@@ -833,6 +900,11 @@ let () =
     ; ( "format"
       , [ test_case "no blank name fields" `Quick test_no_blank_names
         ; test_case "internal_name is snake_case" `Quick test_internal_name_snake_case
+        ; test_case "eval_tags are normalized" `Quick test_eval_tags_are_normalized
+        ; test_case
+            "seed eval_tags are registered"
+            `Quick
+            test_seed_eval_tags_are_registered
         ] )
     ; ( "agent-contract"
       , [ test_case

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -30,7 +30,7 @@ let find_row ~provider ~model ~keeper rows =
       && row.keeper_profile = keeper)
     rows
 
-let json_check_status_completed : Tool_call_quality_benchmark.json_check =
+let json_check_status_completed : Tool_call_quality_benchmark_types.json_check =
   {
     path = "$.status";
     equals = Some (`String "completed");
@@ -40,11 +40,11 @@ let json_check_status_completed : Tool_call_quality_benchmark.json_check =
   }
 
 let selector_case ?(forbidden_tools = []) ?(forbidden_selectors = []) () :
-    Tool_call_quality_benchmark.benchmark_case =
+    Tool_call_quality_benchmark_types.benchmark_case =
   {
     id = "selector_case";
     prompt = "synthetic selector scoring case";
-    category = Tool_call_quality_benchmark.Tool_use;
+    category = Tool_call_quality_benchmark_types.Tool_use;
     keeper_profiles = [ "bench-selector" ];
     forbidden_tools;
     forbidden_selectors;
@@ -55,7 +55,7 @@ let selector_case ?(forbidden_tools = []) ?(forbidden_selectors = []) () :
   }
 
 let selector_tool_call ?route_evidence tool_name :
-    Tool_call_quality_benchmark.tool_call =
+    Tool_call_quality_benchmark_types.tool_call =
   {
     tool_name;
     success = true;
@@ -65,7 +65,7 @@ let selector_tool_call ?route_evidence tool_name :
     duration_ms = None;
   }
 
-let selector_run tool_calls : Tool_call_quality_benchmark.evidence_run =
+let selector_run tool_calls : Tool_call_quality_benchmark_types.evidence_run =
   {
     case_id = "selector_case";
     provider = "provider-d";
@@ -81,7 +81,7 @@ let selector_run tool_calls : Tool_call_quality_benchmark.evidence_run =
     input_tokens = None;
     output_tokens = None;
     cost_usd = None;
-    status = Tool_call_quality_benchmark.Run_ok;
+    status = Tool_call_quality_benchmark_types.Run_ok;
     tool_calls;
   }
 


### PR DESCRIPTION
## Summary
- add evaluation-only `eval_tags` to keeper tool descriptors
- emit `eval_tags` through descriptor route evidence for replay/harness scoring
- seed initial tags for capability introspection, surface context reads, and agent profile lookup
- add route-evidence and registry integrity ratchets for seeded tags and tag normalization
- fix the selector benchmark regression helper annotations to use the leaf benchmark types expected by scoring

## Why
#20982 added selector support for evidence-based tool-call matching, including `Eval_tag`, but live descriptor route evidence did not yet emit those tags. This keeps the improvement harness-side: tags are recorded as observational evidence and are not wired into runtime tool selection or policy.

## Validation
- `ocamlformat --check lib/core/eval_tool_selector.ml lib/keeper/keeper_tool_descriptor.mli lib/keeper_tool_call_log.mli lib/keeper/keeper_tool_descriptor.ml test/test_keeper_tool_call_log.ml test/test_keeper_tool_descriptor_registry_integrity.ml test/test_tool_call_quality_benchmark.ml`
- `git diff --check`
- `bash scripts/lint/no-eval-tool-selector-runtime-import.sh`
- `bash scripts/health_snapshot.sh --skip-build --baseline-ref origin/main --fail-on-lib-regression --json-out /tmp/masc-health-20993-skip-build.json`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-20993-dune scripts/dune-local.sh build test/test_tool_call_quality_benchmark.exe`
- GitHub checks on `7e06ce30a57c40885b08b83ff66ad8b6a2717a42`: `CI Gate`, `Build and Test`, `Health`, `Lint`, `TLA+ Model Checking`, `ocamlformat-check`, `Fundamental Check`, `PR Axis Cross-Check`, and `Test Coverage Check` all pass.
