### PR TITLE
fix(core): enumerate selector constructors in to_yojson catch-all (broken local dev build)

### DIFF
--- a/lib/core/eval_tool_selector.ml
+++ b/lib/core/eval_tool_selector.ml
@@ -36,7 +36,7 @@ let to_yojson selector =
         ; ("key", `String key)
         ; ("value", `String value)
         ]
-  | _ ->
+  | Tool_name _ | Descriptor_id _ | Runtime_handler _ | Eval_tag _ ->
       let kind, value = kind_value selector in
       `Assoc [ ("type", `String kind); ("value", `String value) ]
 


### PR DESCRIPTION
## 문제

`Eval_tool_selector.to_yojson`의 wildcard arm(`| _ ->`)이 dev 프로필 `-warn-error +a`에서 warning 4(fragile-match)로 컴파일 에러를 냅니다. #20982 머지 이후 로컬 `dune build lib/core`(및 masc lib 전체)가 깨진 상태이고, CI는 green이라 로컬 dev 빌드에서만 드러납니다.

## 변경

catch-all을 4개 단일값 constructor 열거로 교체 — variant 추가 시 이 match가 컴파일 타임에 누락을 잡습니다 (CLAUDE.md AI 안티패턴 §4 'FSM Sparse Match / catch-all' 동일 계열).

## 검증

`scripts/dune-local.sh build lib/core` EXIT=0 (수정 전: warning 4 에러)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
