### PR TITLE
feat(keeper): RFC-0233 PR-3 — typed Prompt_block_id + TurnRecord writer

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -634,28 +634,74 @@ let run_turn
                           ~raw_response_text:response_text
                           ())))
                in
-       Keeper_agent_run_receipt.finalize
-         ~config
-         ~meta
-         ~generation
-         ~manifest_keeper_turn_id
-         ~runtime_id
-         ~keeper_visible_sandbox_root
-         ~receipt_started_at
-         ~runtime_manifest_context
-         ~acc
-         ~pre_dispatch_compacted
-         ~pre_dispatch_compaction_trigger:ctx.pre_dispatch_compaction_trigger
-         ~pre_dispatch_compaction_before_tokens:ctx.pre_dispatch_compaction_before_tokens
-         ~pre_dispatch_compaction_after_tokens:ctx.pre_dispatch_compaction_after_tokens
-         ~degraded_retry_applied
-         ~degraded_retry_runtime
-         ~fallback_reason
-         ~runtime_rotation_attempts
-         ~turn_result
-         ~receipt_turn_count_ref
-         ~receipt_model_used_ref
-         ~receipt_stop_reason_ref
-         ~receipt_runtime_observation_ref
-         ~receipt_response_text_present_ref
-         ())
+       let receipt_result =
+         Keeper_agent_run_receipt.finalize
+           ~config
+           ~meta
+           ~generation
+           ~manifest_keeper_turn_id
+           ~runtime_id
+           ~keeper_visible_sandbox_root
+           ~receipt_started_at
+           ~runtime_manifest_context
+           ~acc
+           ~pre_dispatch_compacted
+           ~pre_dispatch_compaction_trigger:ctx.pre_dispatch_compaction_trigger
+           ~pre_dispatch_compaction_before_tokens:ctx.pre_dispatch_compaction_before_tokens
+           ~pre_dispatch_compaction_after_tokens:ctx.pre_dispatch_compaction_after_tokens
+           ~degraded_retry_applied
+           ~degraded_retry_runtime
+           ~fallback_reason
+           ~runtime_rotation_attempts
+           ~turn_result
+           ~receipt_turn_count_ref
+           ~receipt_model_used_ref
+           ~receipt_stop_reason_ref
+           ~receipt_runtime_observation_ref
+           ~receipt_response_text_present_ref
+           ()
+       in
+       (* RFC-0233 PR-3: TurnRecord — same per-keeper-turn cadence as the
+          receipt above. execution_ids come from the trajectory
+          accumulator (every entry of this run carries the id minted at
+          the dispatch boundary); sampling reads the last SDK turn's
+          effective values from the turn context cell. *)
+       (let tctx =
+          Keeper_tool_call_log_context.get_turn_context_record
+            ~cell:turn_ctx_cell ()
+        in
+        let execution_ids =
+          match trajectory_acc with
+          | None -> []
+          | Some tacc ->
+            (* entries are prepended on record; rev restores call order *)
+            List.rev
+              (List.filter_map
+                 (fun (e : Trajectory.tool_call_entry) ->
+                    Option.map Ids.Execution_id.of_string e.execution_id)
+                 tacc.Trajectory.entries)
+        in
+        let usage : Turn_record.usage =
+          match turn_result with
+          | Ok result when result.usage_reported ->
+            { input_tokens = Some result.usage.input_tokens
+            ; output_tokens = Some result.usage.output_tokens
+            }
+          | Ok _ | Error _ -> { input_tokens = None; output_tokens = None }
+        in
+        Keeper_turn_record_writer.write
+          ~config
+          ~keeper_name:meta.name
+          ~trace_id
+          ~absolute_turn:manifest_keeper_turn_id
+          ~runtime_profile:runtime_id_string
+          ~sampling:
+            { temperature = Some temperature
+            ; thinking_budget = tctx.thinking_budget
+            ; enable_thinking = tctx.thinking_enabled
+            }
+          ~usage
+          ~execution_ids
+          ~blocks:acc.prompt_blocks
+          ());
+       receipt_result)

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -118,10 +118,20 @@ let finalize
   let runtime_observation : Runtime_observation.runtime_observation option =
     !receipt_runtime_observation_ref
   in
-  let ( extra_system_context_digest
-      , extra_system_context_computed_size
-      , extra_system_context_injected_size ) =
-    None, None, None
+  (* #20936: the before_turn_params hook snapshots the final injected
+     extra_system_context (digest + byte size) into the accumulator each
+     SDK turn; the receipt reports the last SDK turn's values. The SDK
+     injects the assembled string verbatim, so computed and injected
+     sizes coincide — they diverge only if an injection-side truncation
+     layer ever appears. *)
+  let extra_system_context_digest =
+    acc.Keeper_run_tools.extra_system_context_digest
+  in
+  let extra_system_context_computed_size =
+    acc.Keeper_run_tools.extra_system_context_size
+  in
+  let extra_system_context_injected_size =
+    acc.Keeper_run_tools.extra_system_context_size
   in
   let receipt =
     { Keeper_execution_receipt.keeper_name = meta.name

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -28,6 +28,9 @@ type hook_accumulator = Keeper_run_tools_hook_accumulator.hook_accumulator =
   ; mutable requested_tool_names : string list
   ; mutable receipt_completion_contract_result :
       Keeper_execution_receipt.completion_contract_result
+  ; mutable prompt_blocks : Turn_record.prompt_block list
+  ; mutable extra_system_context_digest : string option
+  ; mutable extra_system_context_size : int option
   }
 
 type hook_outputs = Keeper_run_tools_hook_accumulator.hook_outputs =

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -26,6 +26,9 @@ type hook_accumulator =
   ; mutable requested_tool_names : string list
   ; mutable receipt_completion_contract_result :
       Keeper_execution_receipt.completion_contract_result
+  ; mutable prompt_blocks : Turn_record.prompt_block list
+  ; mutable extra_system_context_digest : string option
+  ; mutable extra_system_context_size : int option
   }
 
 (** Immutable snapshot of hook outputs after OAS execution completes. *)

--- a/lib/keeper/keeper_run_tools_hook_accumulator.ml
+++ b/lib/keeper/keeper_run_tools_hook_accumulator.ml
@@ -22,6 +22,13 @@ type hook_accumulator =
   ; mutable requested_tool_names : string list
   ; mutable receipt_completion_contract_result :
       Keeper_execution_receipt.completion_contract_result
+    (* RFC-0233 PR-3: last SDK turn's context assembly, written by the
+       before_turn_params hook, read at the receipt/TurnRecord write site
+       in run_turn. Last-write-wins matches the turn-context cell
+       semantics the receipt already uses. *)
+  ; mutable prompt_blocks : Turn_record.prompt_block list
+  ; mutable extra_system_context_digest : string option
+  ; mutable extra_system_context_size : int option
   }
 
 type hook_outputs =

--- a/lib/keeper/keeper_run_tools_hook_accumulator.mli
+++ b/lib/keeper/keeper_run_tools_hook_accumulator.mli
@@ -10,6 +10,9 @@ type hook_accumulator =
   ; mutable requested_tool_names : string list
   ; mutable receipt_completion_contract_result :
       Keeper_execution_receipt.completion_contract_result
+  ; mutable prompt_blocks : Turn_record.prompt_block list
+  ; mutable extra_system_context_digest : string option
+  ; mutable extra_system_context_size : int option
   }
 
 type hook_outputs =

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -241,10 +241,22 @@ let assemble_hooks
                        | None -> current_params.preserve_thinking)
                   }
                 in
+                (* RFC-0233 PR-3: every append below also records its
+                   (block id, raw text) pair; the snapshot lands in the
+                   hook accumulator just before AdjustParams so the
+                   receipt/TurnRecord writer can persist typed
+                   provenance. The closed Prompt_block_id sum makes a
+                   new injection site without a recording a compile
+                   error at the snapshot below. *)
+                let recorded_blocks = ref [] in
+                let record_block block text =
+                  recorded_blocks := (block, text) :: !recorded_blocks
+                in
                 let ctx =
                   if String.trim dynamic_context = ""
                   then current_params.extra_system_context
                   else (
+                    record_block Prompt_block_id.Dynamic_context dynamic_context;
                     match current_params.extra_system_context with
                     | None -> Some dynamic_context
                     | Some existing -> Some (existing ^ "\n\n" ^ dynamic_context))
@@ -253,6 +265,7 @@ let assemble_hooks
                   match Masc_context_injector.render_temporal_summary shared_context with
                   | None -> ctx
                   | Some temporal ->
+                    record_block Prompt_block_id.Temporal_summary temporal;
                     (match ctx with
                      | None -> Some temporal
                      | Some existing -> Some (existing ^ "\n\n" ^ temporal))
@@ -290,6 +303,7 @@ let assemble_hooks
                            [STATE] with the blocker instead of inventing a tool name."
                           (Keeper_id.Task_id.to_string task_id)
                       in
+                      record_block Prompt_block_id.Claimed_task_nudge nudge;
                       match ctx with
                       | None -> Some nudge
                       | Some existing -> Some (existing ^ "\n\n" ^ nudge))
@@ -312,14 +326,15 @@ let assemble_hooks
                 in
                 let ctx =
                   if is_retry
-                  then
-                    append_ctx
-                      ctx
-                      (Printf.sprintf
-                         "[RETRY] The previous attempt overflowed the model context. \
-                          Stay concise, prefer already-loaded context, and only use the \
-                          smallest essential tool set if a tool call is strictly \
-                          necessary.")
+                  then (
+                    let retry_nudge =
+                      "[RETRY] The previous attempt overflowed the model context. \
+                       Stay concise, prefer already-loaded context, and only use the \
+                       smallest essential tool set if a tool call is strictly \
+                       necessary."
+                    in
+                    record_block Prompt_block_id.Retry_nudge retry_nudge;
+                    append_ctx ctx retry_nudge)
                   else ctx
                 in
                 let ctx =
@@ -334,7 +349,9 @@ let assemble_hooks
                       ()
                   with
                   | None -> ctx
-                  | Some block -> append_ctx ctx block
+                  | Some block ->
+                    record_block Prompt_block_id.Memory_os_recall block;
+                    append_ctx ctx block
                 in
                 let tool_filter =
                   Agent_sdk.Guardrails.AllowList schema_filter
@@ -422,6 +439,36 @@ let assemble_hooks
                  Keeper_registry.mark_turn_provider_attempt_started
                    ~base_path:config.base_path
                    meta.name);
+                (* RFC-0233 PR-3 + #20936: snapshot this SDK turn's
+                   assembly into the accumulator the receipt/TurnRecord
+                   writer reads. Appended blocks hash their raw appended
+                   text; Persona reuses the prompt-metrics fingerprint
+                   (sha256 of the sanitized rendered system prompt) —
+                   the digest the prompt store already records. *)
+                let sha256_hex text =
+                  Digestif.SHA256.(digest_string text |> to_hex)
+                in
+                let persona_blocks =
+                  match prompt_metrics.system_prompt_segment.fingerprint with
+                  | Some digest ->
+                    [ { Turn_record.block = Prompt_block_id.Persona
+                      ; bytes = prompt_metrics.system_prompt_segment.bytes
+                      ; digest
+                      }
+                    ]
+                  | None -> []
+                in
+                acc.prompt_blocks
+                <- persona_blocks
+                   @ List.rev_map
+                       (fun (block, text) ->
+                          { Turn_record.block
+                          ; bytes = String.length text
+                          ; digest = sha256_hex text
+                          })
+                       !recorded_blocks;
+                acc.extra_system_context_digest <- Option.map sha256_hex ctx;
+                acc.extra_system_context_size <- Option.map String.length ctx;
                 Eio.Fiber.yield ();
                 Agent_sdk.Hooks.AdjustParams
                   { current_params with

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -87,6 +87,9 @@ let prepare_agent_setup
     ; requested_tool_names = []
     ; receipt_completion_contract_result =
         Keeper_execution_receipt.Contract_unknown
+    ; prompt_blocks = []
+    ; extra_system_context_digest = None
+    ; extra_system_context_size = None
     }
   in
   let agent_ref : Agent_sdk.Agent.t option ref = ref None in

--- a/lib/keeper/keeper_turn_record_writer.ml
+++ b/lib/keeper/keeper_turn_record_writer.ml
@@ -1,0 +1,37 @@
+let write
+      ~config
+      ~keeper_name
+      ~trace_id
+      ~absolute_turn
+      ~runtime_profile
+      ~sampling
+      ~usage
+      ~execution_ids
+      ~blocks
+      ()
+  =
+  let record : Turn_record.t =
+    { execution_ids
+    ; keeper = keeper_name
+    ; trace_id
+    ; absolute_turn
+    ; blocks
+    ; runtime_profile
+    ; sampling
+    ; usage
+    ; ts = Time_compat.now ()
+    }
+  in
+  try
+    let store = Keeper_types_support.keeper_turn_record_store config keeper_name in
+    Dated_jsonl.append store (Turn_record.to_json record)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn
+      "turn record append failed: keeper=%s trace=%s turn=%d err=%s"
+      keeper_name
+      trace_id
+      absolute_turn
+      (Printexc.to_string exn)
+;;

--- a/lib/keeper/keeper_turn_record_writer.mli
+++ b/lib/keeper/keeper_turn_record_writer.mli
@@ -1,0 +1,19 @@
+(** RFC-0233 §2.2 — append one TurnRecord per keeper turn, at the same
+    cadence as the execution receipt.
+
+    Append failures never fail the turn: they log a WARN with the
+    keeper/trace coordinates (the receipt path already guards turn
+    integrity; this store is an observability surface). *)
+
+val write :
+  config:Workspace.config ->
+  keeper_name:string ->
+  trace_id:string ->
+  absolute_turn:int ->
+  runtime_profile:string ->
+  sampling:Turn_record.sampling ->
+  usage:Turn_record.usage ->
+  execution_ids:Ids.Execution_id.t list ->
+  blocks:Turn_record.prompt_block list ->
+  unit ->
+  unit

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -64,6 +64,22 @@ let keeper_execution_receipt_store config name : Dated_jsonl.t =
   in
   Eio_guard.with_mutex execution_receipt_store_mu lookup
 
+(* RFC-0233 PR-3: TurnRecord JSONL store next to the receipt store. *)
+let turn_record_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 8
+let turn_record_store_mu = Eio.Mutex.create ()
+
+let keeper_turn_record_store config name : Dated_jsonl.t =
+  let dir = Filename.concat (keeper_dir_ config) (name ^ "/turn-records") in
+  let lookup () =
+    match Hashtbl.find_opt turn_record_store_cache dir with
+    | Some store -> store
+    | None ->
+      let store = Dated_jsonl.create ~base_dir:dir () in
+      Hashtbl.replace turn_record_store_cache dir store;
+      store
+  in
+  Eio_guard.with_mutex turn_record_store_mu lookup
+
 let keeper_memory_bank_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".memory.jsonl")
 

--- a/lib/keeper/keeper_types_support.mli
+++ b/lib/keeper/keeper_types_support.mli
@@ -29,6 +29,10 @@ val keeper_metrics_store : Workspace.config -> string -> Dated_jsonl.t
     [.masc/keepers/<name>/execution-receipts/YYYY-MM/DD.jsonl]. *)
 val keeper_execution_receipt_store : Workspace.config -> string -> Dated_jsonl.t
 
+(** Date-split TurnRecord store (RFC-0233 §2.2):
+    [.masc/keepers/<name>/turn-records/YYYY-MM/DD.jsonl]. *)
+val keeper_turn_record_store : Workspace.config -> string -> Dated_jsonl.t
+
 val keeper_memory_bank_path : Workspace.config -> string -> string
 val keeper_progress_path : Workspace.config -> string -> string
 val keeper_generation_index_path : Workspace.config -> string -> string

--- a/lib/types/dune
+++ b/lib/types/dune
@@ -8,6 +8,8 @@
   rate_limit_types
   masc_error
   ids
+  prompt_block_id
+  turn_record
   evidence_claim
   deterministic_evidence_evaluator
   types_core

--- a/lib/types/prompt_block_id.ml
+++ b/lib/types/prompt_block_id.ml
@@ -1,0 +1,59 @@
+type t =
+  | Persona
+  | Continuity
+  | Dynamic_context
+  | Temporal_summary
+  | Claimed_task_nudge
+  | Retry_nudge
+  | Memory_os_recall
+  | Connected_surface
+  | Other of string
+
+let equal a b =
+  match a, b with
+  | Persona, Persona
+  | Continuity, Continuity
+  | Dynamic_context, Dynamic_context
+  | Temporal_summary, Temporal_summary
+  | Claimed_task_nudge, Claimed_task_nudge
+  | Retry_nudge, Retry_nudge
+  | Memory_os_recall, Memory_os_recall
+  | Connected_surface, Connected_surface -> true
+  | Other a, Other b -> String.equal a b
+  | ( ( Persona | Continuity | Dynamic_context | Temporal_summary
+      | Claimed_task_nudge | Retry_nudge | Memory_os_recall
+      | Connected_surface | Other _ )
+    , _ ) -> false
+
+let to_string = function
+  | Persona -> "persona"
+  | Continuity -> "continuity"
+  | Dynamic_context -> "dynamic_context"
+  | Temporal_summary -> "temporal_summary"
+  | Claimed_task_nudge -> "claimed_task_nudge"
+  | Retry_nudge -> "retry_nudge"
+  | Memory_os_recall -> "memory_os_recall"
+  | Connected_surface -> "connected_surface"
+  | Other name -> name
+
+let of_string = function
+  | "persona" -> Persona
+  | "continuity" -> Continuity
+  | "dynamic_context" -> Dynamic_context
+  | "temporal_summary" -> Temporal_summary
+  | "claimed_task_nudge" -> Claimed_task_nudge
+  | "retry_nudge" -> Retry_nudge
+  | "memory_os_recall" -> Memory_os_recall
+  | "connected_surface" -> Connected_surface
+  | name -> Other name
+
+let all_known =
+  [ Persona
+  ; Continuity
+  ; Dynamic_context
+  ; Temporal_summary
+  ; Claimed_task_nudge
+  ; Retry_nudge
+  ; Memory_os_recall
+  ; Connected_surface
+  ]

--- a/lib/types/prompt_block_id.mli
+++ b/lib/types/prompt_block_id.mli
@@ -1,0 +1,37 @@
+(** RFC-0233 §2.2 — closed identity for keeper prompt-assembly blocks.
+
+    Each constructor names one injection site of the per-turn context
+    assembly. Adding a new injection site without extending this variant
+    is a compile-time error at the TurnRecord write site — that is the
+    leverage that keeps the record honest.
+
+    [Persona] is the rendered system prompt (keeper_prompt.ml).
+    [Dynamic_context] is the composite soft-context string built by
+    keeper_turn.ml/keeper_run_prompt.ml (continuity snapshot, skill
+    route, worktree, telemetry feedback, turn instructions, recent
+    failure memory) — recorded as one block until the producer threads
+    a typed decomposition. [Continuity] and [Connected_surface] exist
+    for that decomposition and for the unified-path user-message block;
+    they have no producer yet. [Other] carries forward-compatible rows
+    read back from disk. *)
+
+type t =
+  | Persona
+  | Continuity
+  | Dynamic_context
+  | Temporal_summary
+  | Claimed_task_nudge
+  | Retry_nudge
+  | Memory_os_recall
+  | Connected_surface
+  | Other of string
+
+val equal : t -> t -> bool
+val to_string : t -> string
+
+val of_string : string -> t
+(** Total: unknown names map to [Other name], so old readers survive new
+    writers and disk rows never fail to decode on this field. *)
+
+val all_known : t list
+(** Every constructor except [Other] — for exhaustive codec tests. *)

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -1,0 +1,200 @@
+type prompt_block =
+  { block : Prompt_block_id.t
+  ; bytes : int
+  ; digest : string
+  }
+
+type sampling =
+  { temperature : float option
+  ; thinking_budget : int option
+  ; enable_thinking : bool option
+  }
+
+type usage =
+  { input_tokens : int option
+  ; output_tokens : int option
+  }
+
+type t =
+  { execution_ids : Ids.Execution_id.t list
+  ; keeper : string
+  ; trace_id : string
+  ; absolute_turn : int
+  ; blocks : prompt_block list
+  ; runtime_profile : string
+  ; sampling : sampling
+  ; usage : usage
+  ; ts : float
+  }
+
+(* ── Codec ─────────────────────────────────────────────── *)
+
+let opt_field name to_json = function
+  | Some value -> [ (name, to_json value) ]
+  | None -> []
+
+let prompt_block_to_json (b : prompt_block) : Yojson.Safe.t =
+  `Assoc
+    [ ("block", `String (Prompt_block_id.to_string b.block))
+    ; ("bytes", `Int b.bytes)
+    ; ("digest", `String b.digest)
+    ]
+
+let to_json (r : t) : Yojson.Safe.t =
+  `Assoc
+    ([ ( "execution_ids"
+       , `List (List.map Ids.Execution_id.to_yojson r.execution_ids) )
+     ; ("keeper", `String r.keeper)
+     ; ("trace_id", `String r.trace_id)
+     ; ("absolute_turn", `Int r.absolute_turn)
+     ; ("blocks", `List (List.map prompt_block_to_json r.blocks))
+     ; ("runtime_profile", `String r.runtime_profile)
+     ]
+    @ opt_field "temperature" (fun v -> `Float v) r.sampling.temperature
+    @ opt_field "thinking_budget" (fun v -> `Int v) r.sampling.thinking_budget
+    @ opt_field "enable_thinking" (fun v -> `Bool v) r.sampling.enable_thinking
+    @ opt_field "input_tokens" (fun v -> `Int v) r.usage.input_tokens
+    @ opt_field "output_tokens" (fun v -> `Int v) r.usage.output_tokens
+    @ [ ("ts", `Float r.ts) ])
+
+let ( let* ) = Result.bind
+
+let member name fields = List.assoc_opt name fields
+
+let require name fields =
+  match member name fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "turn_record: missing field %S" name)
+
+let as_string name = function
+  | `String s -> Ok s
+  | _ -> Error (Printf.sprintf "turn_record: field %S is not a string" name)
+
+let as_int name = function
+  | `Int i -> Ok i
+  | _ -> Error (Printf.sprintf "turn_record: field %S is not an int" name)
+
+let as_float name = function
+  | `Float f -> Ok f
+  | `Int i -> Ok (float_of_int i)
+  | _ -> Error (Printf.sprintf "turn_record: field %S is not a number" name)
+
+let opt_member name fields decode =
+  match member name fields with
+  | None -> Ok None
+  | Some value ->
+      let* decoded = decode name value in
+      Ok (Some decoded)
+
+let as_bool name = function
+  | `Bool b -> Ok b
+  | _ -> Error (Printf.sprintf "turn_record: field %S is not a bool" name)
+
+let prompt_block_of_json (json : Yojson.Safe.t) : (prompt_block, string) result =
+  match json with
+  | `Assoc fields ->
+      let* block_json = require "block" fields in
+      let* block_name = as_string "block" block_json in
+      let* bytes_json = require "bytes" fields in
+      let* bytes = as_int "bytes" bytes_json in
+      let* digest_json = require "digest" fields in
+      let* digest = as_string "digest" digest_json in
+      Ok { block = Prompt_block_id.of_string block_name; bytes; digest }
+  | _ -> Error "turn_record: block entry is not an object"
+
+let rec collect_results acc = function
+  | [] -> Ok (List.rev acc)
+  | item :: rest -> (
+      match item with
+      | Ok value -> collect_results (value :: acc) rest
+      | Error _ as e -> e)
+
+let of_json (json : Yojson.Safe.t) : (t, string) result =
+  match json with
+  | `Assoc fields ->
+      let* ids_json = require "execution_ids" fields in
+      let* execution_ids =
+        match ids_json with
+        | `List items ->
+            collect_results [] (List.map Ids.Execution_id.of_yojson items)
+        | _ -> Error "turn_record: execution_ids is not a list"
+      in
+      let* keeper_json = require "keeper" fields in
+      let* keeper = as_string "keeper" keeper_json in
+      let* trace_json = require "trace_id" fields in
+      let* trace_id = as_string "trace_id" trace_json in
+      let* turn_json = require "absolute_turn" fields in
+      let* absolute_turn = as_int "absolute_turn" turn_json in
+      let* blocks_json = require "blocks" fields in
+      let* blocks =
+        match blocks_json with
+        | `List items -> collect_results [] (List.map prompt_block_of_json items)
+        | _ -> Error "turn_record: blocks is not a list"
+      in
+      let* profile_json = require "runtime_profile" fields in
+      let* runtime_profile = as_string "runtime_profile" profile_json in
+      let* temperature = opt_member "temperature" fields as_float in
+      let* thinking_budget = opt_member "thinking_budget" fields as_int in
+      let* enable_thinking = opt_member "enable_thinking" fields as_bool in
+      let* input_tokens = opt_member "input_tokens" fields as_int in
+      let* output_tokens = opt_member "output_tokens" fields as_int in
+      let* ts_json = require "ts" fields in
+      let* ts = as_float "ts" ts_json in
+      Ok
+        { execution_ids
+        ; keeper
+        ; trace_id
+        ; absolute_turn
+        ; blocks
+        ; runtime_profile
+        ; sampling = { temperature; thinking_budget; enable_thinking }
+        ; usage = { input_tokens; output_tokens }
+        ; ts
+        }
+  | _ -> Error "turn_record: row is not an object"
+
+(* ── Block diff ────────────────────────────────────────── *)
+
+type block_diff =
+  { added : prompt_block list
+  ; removed : prompt_block list
+  ; changed : (prompt_block * prompt_block) list
+  }
+
+let find_block blocks id =
+  List.find_opt (fun (b : prompt_block) -> Prompt_block_id.equal b.block id) blocks
+
+let dedupe_by_id blocks =
+  List.fold_left
+    (fun acc (b : prompt_block) ->
+      if List.exists (fun (seen : prompt_block) ->
+             Prompt_block_id.equal seen.block b.block)
+           acc
+      then acc
+      else b :: acc)
+    [] blocks
+  |> List.rev
+
+let diff_blocks ~(prev : t) ~(next : t) : block_diff =
+  let prev_blocks = dedupe_by_id prev.blocks in
+  let next_blocks = dedupe_by_id next.blocks in
+  let added =
+    List.filter
+      (fun (b : prompt_block) -> find_block prev_blocks b.block = None)
+      next_blocks
+  in
+  let removed =
+    List.filter
+      (fun (b : prompt_block) -> find_block next_blocks b.block = None)
+      prev_blocks
+  in
+  let changed =
+    List.filter_map
+      (fun (next_b : prompt_block) ->
+        match find_block prev_blocks next_b.block with
+        | Some prev_b when not (String.equal prev_b.digest next_b.digest) ->
+            Some (prev_b, next_b)
+        | Some _ | None -> None)
+      next_blocks
+  in
+  { added; removed; changed }

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -1,0 +1,60 @@
+(** RFC-0233 §2.2 — one record per keeper turn, written at the same
+    point that writes the execution receipt.
+
+    Block *text* is never duplicated into the record; [digest] (sha256
+    of the raw block text) joins against the existing prompt/receipt
+    stores. Diffing two consecutive records by [(block, digest)] answers
+    "which instruction blocks entered, left, or changed between turns".
+
+    The assembly chain re-runs once per SDK turn inside one keeper turn;
+    [blocks] records the LAST SDK turn's assembly, matching the
+    last-write-wins semantics of the turn context the receipt already
+    uses. *)
+
+type prompt_block =
+  { block : Prompt_block_id.t
+  ; bytes : int
+  ; digest : string (* sha256 hex of the raw block text *)
+  }
+
+type sampling =
+  { temperature : float option
+  ; thinking_budget : int option
+  ; enable_thinking : bool option
+  }
+
+type usage =
+  { input_tokens : int option
+  ; output_tokens : int option
+  }
+
+type t =
+  { execution_ids : Ids.Execution_id.t list (* tool calls in this turn *)
+  ; keeper : string
+  ; trace_id : string
+  ; absolute_turn : int
+  ; blocks : prompt_block list (* assembly order *)
+  ; runtime_profile : string
+  ; sampling : sampling
+  ; usage : usage
+  ; ts : float
+  }
+
+val to_json : t -> Yojson.Safe.t
+
+val of_json : Yojson.Safe.t -> (t, string) result
+(** Fails loudly on malformed rows (missing fields, unparseable
+    execution ids) instead of repairing them — RFC-0233 §4. Unknown
+    block names decode as [Prompt_block_id.Other] (that field alone is
+    forward-open by design). *)
+
+(** Result of diffing two consecutive records by [(block, digest)]. *)
+type block_diff =
+  { added : prompt_block list (* in [next] only *)
+  ; removed : prompt_block list (* in [prev] only *)
+  ; changed : (prompt_block * prompt_block) list (* (prev, next), digest differs *)
+  }
+
+val diff_blocks : prev:t -> next:t -> block_diff
+(** Blocks are keyed by [block] id; assembly produces at most one block
+    per id, so first occurrence wins if a malformed row repeats one. *)

--- a/test/dune
+++ b/test/dune
@@ -1442,6 +1442,8 @@
 (include stanzas/test_keeper_msg_async_path_traversal.inc)
 (include stanzas/test_keeper_msg_cancel.inc)
 
+(include stanzas/test_turn_record.inc)
+
 (include stanzas/test_keeper_chat_coalescing.inc)
 
 (include stanzas/test_keeper_turn_admission.inc)

--- a/test/stanzas/test_turn_record.inc
+++ b/test/stanzas/test_turn_record.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_turn_record)
+ (modules test_turn_record)
+ (libraries masc_test_deps))

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -1,0 +1,182 @@
+(** RFC-0233 §5 harness for PR-3: Prompt_block_id round-trip, TurnRecord
+    codec round-trip, and block-diff exactness (the "what entered/left
+    context" question as a test). *)
+
+open Alcotest
+
+let block_id = testable (Fmt.of_to_string Prompt_block_id.to_string) Prompt_block_id.equal
+
+(* ── Prompt_block_id ──────────────────────────────────── *)
+
+let test_block_id_roundtrip () =
+  List.iter
+    (fun block ->
+      check block_id
+        (Printf.sprintf "roundtrip %s" (Prompt_block_id.to_string block))
+        block
+        (Prompt_block_id.of_string (Prompt_block_id.to_string block)))
+    Prompt_block_id.all_known
+
+let test_block_id_unknown_maps_to_other () =
+  check block_id "unknown name survives as Other"
+    (Prompt_block_id.Other "future_block")
+    (Prompt_block_id.of_string "future_block");
+  check string "Other renders its name" "future_block"
+    (Prompt_block_id.to_string (Prompt_block_id.Other "future_block"))
+
+(* ── TurnRecord codec ─────────────────────────────────── *)
+
+let sample_block block digest =
+  { Turn_record.block; bytes = String.length digest; digest }
+
+let sample_record () : Turn_record.t =
+  { execution_ids =
+      [ Ids.Execution_id.of_string "exec-1781200000000-0001"
+      ; Ids.Execution_id.of_string "exec-1781200000001-0002"
+      ]
+  ; keeper = "sangsu"
+  ; trace_id = "trace-1780648779957-00000"
+  ; absolute_turn = 4071
+  ; blocks =
+      [ sample_block Prompt_block_id.Persona "aaaa"
+      ; sample_block Prompt_block_id.Dynamic_context "bbbb"
+      ; sample_block Prompt_block_id.Memory_os_recall "cccc"
+      ]
+  ; runtime_profile = "ollama_cloud.deepseek-v4-flash"
+  ; sampling =
+      { temperature = Some 0.3; thinking_budget = Some 1500; enable_thinking = Some true }
+  ; usage = { input_tokens = Some 18000; output_tokens = Some 412 }
+  ; ts = 1781200000.5
+  }
+
+let test_codec_roundtrip () =
+  let record = sample_record () in
+  match Turn_record.of_json (Turn_record.to_json record) with
+  | Error e -> failf "decode failed: %s" e
+  | Ok decoded ->
+    check int "execution_ids count" 2 (List.length decoded.execution_ids);
+    check bool "execution_ids preserved" true
+      (List.for_all2 Ids.Execution_id.equal record.execution_ids
+         decoded.execution_ids);
+    check string "keeper" record.keeper decoded.keeper;
+    check string "trace_id" record.trace_id decoded.trace_id;
+    check int "absolute_turn" record.absolute_turn decoded.absolute_turn;
+    check int "blocks count" 3 (List.length decoded.blocks);
+    check bool "blocks preserved in order" true
+      (List.for_all2
+         (fun (a : Turn_record.prompt_block) (b : Turn_record.prompt_block) ->
+           Prompt_block_id.equal a.block b.block
+           && a.bytes = b.bytes
+           && String.equal a.digest b.digest)
+         record.blocks decoded.blocks);
+    check string "runtime_profile" record.runtime_profile decoded.runtime_profile;
+    check (option (float 0.0001)) "temperature" record.sampling.temperature
+      decoded.sampling.temperature;
+    check (option int) "thinking_budget" record.sampling.thinking_budget
+      decoded.sampling.thinking_budget;
+    check (option bool) "enable_thinking" record.sampling.enable_thinking
+      decoded.sampling.enable_thinking;
+    check (option int) "input_tokens" record.usage.input_tokens
+      decoded.usage.input_tokens;
+    check (option int) "output_tokens" record.usage.output_tokens
+      decoded.usage.output_tokens;
+    check (float 0.0001) "ts" record.ts decoded.ts
+
+let test_codec_optional_fields_absent () =
+  let record =
+    { (sample_record ()) with
+      sampling = { temperature = None; thinking_budget = None; enable_thinking = None }
+    ; usage = { input_tokens = None; output_tokens = None }
+    }
+  in
+  match Turn_record.of_json (Turn_record.to_json record) with
+  | Error e -> failf "decode failed: %s" e
+  | Ok decoded ->
+    check (option (float 0.0001)) "temperature absent" None
+      decoded.sampling.temperature;
+    check (option int) "input_tokens absent" None decoded.usage.input_tokens
+
+let test_codec_rejects_malformed () =
+  (match Turn_record.of_json (`String "not a record") with
+   | Ok _ -> fail "decoded a non-object"
+   | Error _ -> ());
+  match Turn_record.of_json (`Assoc [ ("keeper", `String "x") ]) with
+  | Ok _ -> fail "decoded a row with missing fields"
+  | Error msg ->
+    check bool "error names the missing field" true
+      (Astring.String.is_infix ~affix:"execution_ids" msg)
+
+let test_codec_unknown_block_decodes_as_other () =
+  let json =
+    Turn_record.to_json
+      { (sample_record ()) with
+        blocks = [ sample_block (Prompt_block_id.Other "future_block") "dddd" ]
+      }
+  in
+  match Turn_record.of_json json with
+  | Error e -> failf "decode failed: %s" e
+  | Ok decoded ->
+    (match decoded.blocks with
+     | [ { block; _ } ] ->
+       check block_id "forward-open block id" (Prompt_block_id.Other "future_block") block
+     | _ -> fail "expected exactly one block")
+
+(* ── Block diff (RFC §5: exact added/removed set) ─────── *)
+
+let record_with_blocks blocks = { (sample_record ()) with blocks }
+
+let test_diff_added_removed_changed () =
+  let prev =
+    record_with_blocks
+      [ sample_block Prompt_block_id.Persona "aaaa"
+      ; sample_block Prompt_block_id.Dynamic_context "bbbb"
+      ; sample_block Prompt_block_id.Retry_nudge "rrrr"
+      ]
+  in
+  let next =
+    record_with_blocks
+      [ sample_block Prompt_block_id.Persona "aaaa" (* unchanged *)
+      ; sample_block Prompt_block_id.Dynamic_context "BBBB" (* changed *)
+      ; sample_block Prompt_block_id.Memory_os_recall "mmmm" (* added *)
+      ]
+  in
+  let diff = Turn_record.diff_blocks ~prev ~next in
+  check (list block_id) "added = exactly memory_os_recall"
+    [ Prompt_block_id.Memory_os_recall ]
+    (List.map (fun (b : Turn_record.prompt_block) -> b.block) diff.added);
+  check (list block_id) "removed = exactly retry_nudge"
+    [ Prompt_block_id.Retry_nudge ]
+    (List.map (fun (b : Turn_record.prompt_block) -> b.block) diff.removed);
+  check (list block_id) "changed = exactly dynamic_context"
+    [ Prompt_block_id.Dynamic_context ]
+    (List.map
+       (fun ((_, b) : Turn_record.prompt_block * Turn_record.prompt_block) -> b.block)
+       diff.changed)
+
+let test_diff_identical_records_is_empty () =
+  let record = sample_record () in
+  let diff = Turn_record.diff_blocks ~prev:record ~next:record in
+  check int "no added" 0 (List.length diff.added);
+  check int "no removed" 0 (List.length diff.removed);
+  check int "no changed" 0 (List.length diff.changed)
+
+let () =
+  run "turn_record"
+    [ ( "prompt_block_id"
+      , [ test_case "all known constructors roundtrip" `Quick test_block_id_roundtrip
+        ; test_case "unknown maps to Other" `Quick test_block_id_unknown_maps_to_other
+        ] )
+    ; ( "codec"
+      , [ test_case "roundtrip" `Quick test_codec_roundtrip
+        ; test_case "optional fields absent" `Quick test_codec_optional_fields_absent
+        ; test_case "rejects malformed rows" `Quick test_codec_rejects_malformed
+        ; test_case "unknown block decodes as Other" `Quick
+            test_codec_unknown_block_decodes_as_other
+        ] )
+    ; ( "block_diff"
+      , [ test_case "exact added/removed/changed sets" `Quick
+            test_diff_added_removed_changed
+        ; test_case "identical records diff empty" `Quick
+            test_diff_identical_records_is_empty
+        ] )
+    ]


### PR DESCRIPTION
## 무엇

RFC-0233 §2.2 구현: keeper 턴마다 **무엇이 컨텍스트에 들어갔는지**를 타입으로 기록합니다. receipt와 같은 cadence로 `keepers/<name>/turn-records/YYYY-MM/DD.jsonl`에 1행. #20936(receipt digest 필드 None 하드코딩)도 여기서 해소.

## 왜

- 페르소나 톤 드리프트·post-idle 기억상실의 메커니즘이 **소스 코드를 읽어야만** 재구성 가능했음 (진단 세션 실측)
- receipt의 `extra_system_context_{digest,computed_size,injected_size}`를 생산자가 `None, None, None` 하드코딩 — 주입 관측 경로 전무 (#20936)
- sampling(온도/thinking)은 어디에도 턴 단위로 기록 안 됨

## 설계 (탐색 3-agent 결과 기반)

- **`Prompt_block_id`** (masc_types, 닫힌 합): 새 주입 지점이 variant 확장 없이는 기록 코드에서 컴파일 에러 — RFC가 의도한 레버리지. `of_string`은 `Other`로 total(읽기 forward-open), 쓰기는 닫힌 생성자만
- **`Turn_record`**: execution_ids(PR-1 조인키) + blocks(id, bytes, sha256; 조립 순서) + sampling + usage + absolute_turn. codec은 malformed 행에서 **fail loudly** (RFC §4); `diff_blocks`가 추가/제거/변경 정확 집합 반환
- **훅 수집**: `extra_system_context` 조립 체인의 각 append가 (block, raw text)를 기록 → AdjustParams 직전 스냅샷이 `hook_accumulator`에 (SDK 턴당 last-write-wins = 기존 turn context cell과 동일 의미론). **신규 플럼빙 0** — `~acc`는 이미 receipt finalize까지 흐름
- **writer**: receipt finalize 직후, trajectory accumulator(턴 수명과 일치)에서 execution_ids 도출, `usage_reported=false`면 토큰 None(미보고를 0으로 위장 안 함)

## 정직성 노트 (RFC 블록 목록 vs 실제 체인의 차이)

탐색 결과 RFC의 블록 목록과 실제 조립이 3곳에서 어긋나며, 이번 PR은 **현실을 기록**합니다:
- `Dynamic_context`는 상류(keeper_turn.ml/keeper_run_prompt.ml)에서 이미 합성된 복합 문자열 → 당장은 단일 블록으로 기록 (digest로 변화 감지는 가능). 하위 분해는 생산자에 typed list를 스레딩하는 후속 작업
- `Continuity`는 두 집 (system prompt `<continuity>` 섹션 vs dynamic_context 스냅샷), `Connected_surface`는 unified 경로의 user-message 블록 — 생성자는 예약돼 있고 생산자는 후속
- `Persona` digest는 prompt-metrics fingerprint(살균된 시스템 프롬프트의 sha256) 재사용 — 기존 스토어와 같은 정본

## 검증

- `test_turn_record` **8/8**: 전 생성자 round-trip, codec round-trip(옵션 부재 포함), malformed 거부, forward-open Other, **block-diff 정확 집합**(RFC §5의 "what entered/left context" 질문 그대로)
- lib 빌드 clean. `@check` 실패는 **pre-existing #20983 watchdog 테스트 1건뿐** (픽스 #20990 in-flight; 머지 후 update-branch 필요)

## 후속 (PR-4)

대시보드 turn inspector block-diff 렌더 + OTel per-turn span attributes (`masc.turn.blocks`/`masc.turn.profile`/`masc.execution_id`) — 이 스토어를 읽기만 합니다.

Refs RFC-0233 §2.2 §4. Closes #20936. PR-1 #20968, PR-2a #20975, PR-2b #20985.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
