### PR TITLE
fix(keeper): require max_idle_turns on run_turn; kmsg uses reactive budget

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -91,7 +91,12 @@ let run_turn
       ~(generation : int)
       ?(max_turns : int = Keeper_runtime_resolved.reactive_max_turns_per_call ())
       (* Per-call turn budget. Keeper resumes via checkpoint if exhausted. *)
-      ?(max_idle_turns : int = 3)
+      ~(max_idle_turns : int)
+      (* Required, no default: the OAS loop guard kills the run at this
+         count, so the caller must pick the channel-appropriate threshold
+         (reactive/autonomous). A silent default of 3 sat below the
+         graduated idle hook's skip threshold (4), making graceful Skip
+         unreachable — user chat turns died as IdleDetected errors. *)
       ?(history_user_source = "direct_user")
       ?(history_assistant_source = "direct_assistant")
       ?guardrails

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -90,7 +90,13 @@ val run_turn
   -> ?provider_filter:string list
   -> generation:int
   -> ?max_turns:int
-  -> ?max_idle_turns:int
+  -> max_idle_turns:int
+       (* Required, no default: the OAS loop guard kills the run at this
+          count, so every caller must pick the channel-appropriate threshold
+          ([Keeper_runtime_resolved.reactive_max_idle_turns] /
+          [autonomous_max_idle_turns]). A silent default of 3 sat below the
+          graduated idle hook's skip threshold (4), making graceful Skip
+          unreachable — user chat turns died as IdleDetected errors. *)
   -> ?history_user_source:string
   -> ?history_assistant_source:string
   -> ?guardrails:Agent_sdk.Guardrails.t

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -66,11 +66,24 @@ let autonomous_max_turns_per_call_live () =
           (get_int ~default
              "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS")))
 
+(* The idle loop guard must sit strictly above the graduated idle hook's
+   skip threshold ([Env_config_keeper.KeeperKeepalive.idle_skip_threshold],
+   default 4): the hook ends an idle run gracefully (Skip) at skip_at,
+   while the OAS guard aborts the run with IdleDetected at the guard
+   value. A guard <= skip_at makes Skip unreachable and turns die as
+   errors instead (the 2026-06-12 sangsu kmsg kills). The floor enforces
+   that contract at resolution time, so an env override cannot silently
+   reintroduce the dead zone. *)
+let idle_guard_floor () =
+  Env_config_keeper.KeeperKeepalive.idle_skip_threshold + 1
+
 let reactive_max_idle_turns_live () =
-  max 2 (min 50 (get_int ~default:15 "MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE"))
+  max (idle_guard_floor ())
+    (min 50 (get_int ~default:15 "MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE"))
 
 let autonomous_max_idle_turns_live () =
-  max 2 (min 50 (get_int ~default:10 "MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS"))
+  max (idle_guard_floor ())
+    (min 50 (get_int ~default:10 "MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS"))
 
 let turn_timeout_sec_live () =
   (* SSOT: must match Env_config_keeper.KeeperKeepalive.turn_timeout_sec

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -480,6 +480,12 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
                       (                         (turn_runtime_id))
                     ~world_observation
                     ~turn_affordances
+                    (* A kmsg turn is user-triggered, i.e. reactive: it must
+                       use the reactive idle budget so the graduated idle hook
+                       (nudge -> final warning -> graceful Skip) can run its
+                       course before the OAS loop guard aborts the run. *)
+                    ~max_idle_turns:
+                      (Keeper_runtime_resolved.reactive_max_idle_turns ())
                     ?oas_timeout_s:keeper_msg_oas_timeout_s
                     ?provider_filter:(Env_config_keeper.KeeperRuntimeProviderFilter.provider_allowlist ())
                     ~generation:meta.runtime.generation

--- a/test/dune
+++ b/test/dune
@@ -35,6 +35,7 @@
   test_surface_ref
   test_keeper_turn_outcome
   test_keeper_identity_id
+  test_keeper_idle_threshold_contract
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection
@@ -314,6 +315,7 @@
   test_surface_ref
   test_keeper_turn_outcome
   test_keeper_identity_id
+  test_keeper_idle_threshold_contract
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection

--- a/test/test_keeper_idle_threshold_contract.ml
+++ b/test/test_keeper_idle_threshold_contract.ml
@@ -61,6 +61,33 @@ let test_final_warning_has_a_reaction_turn () =
     true
     (autonomous > final_warning_at + 1)
 
+(* An env override below the hook's skip threshold must not be able to
+   reintroduce the dead zone: resolution clamps the guard to
+   skip_at + 1. This is the exact reproduction that used to fail —
+   MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE=3 with skip_at=4. *)
+let with_env key value f =
+  let prev = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      (match prev with
+       | Some v -> Unix.putenv key v
+       | None -> Unix.putenv key "");
+      Masc.Keeper_runtime_resolved.reset_for_tests ())
+    f
+
+let test_env_override_cannot_lower_guard_below_skip () =
+  with_env "MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE" "3" (fun () ->
+    Masc.Keeper_runtime_resolved.reset_for_tests ();
+    let guard = Masc.Keeper_runtime_resolved.reactive_max_idle_turns () in
+    check bool
+      (Printf.sprintf
+         "override 3 resolves to %d, still above skip threshold (%d)"
+         guard
+         skip_at)
+      true
+      (guard > skip_at))
+
 let () =
   Alcotest.run
     "Keeper_idle_threshold_contract"
@@ -71,5 +98,9 @@ let () =
             "final warning leaves a reaction turn"
             `Quick
             test_final_warning_has_a_reaction_turn
+        ; test_case
+            "env override cannot lower guard below skip"
+            `Quick
+            test_env_override_cannot_lower_guard_below_skip
         ] )
     ]

--- a/test/test_keeper_idle_threshold_contract.ml
+++ b/test/test_keeper_idle_threshold_contract.ml
@@ -1,0 +1,75 @@
+(** Idle threshold contract between the OAS loop guard and the masc
+    graduated idle hook.
+
+    The hook ({!Keeper_hooks_oas_idle}) escalates over consecutive idle
+    turns: nudge -> final warning (skip_at - 1) -> graceful Skip (skip_at).
+    The OAS loop guard aborts the run with [IdleDetected] once the idle
+    counter reaches [max_idle_turns]. The contract: for every turn channel,
+    the guard must sit strictly above the hook's skip threshold — otherwise
+    Skip is unreachable, the final warning is injected on a turn the model
+    never gets, and the run dies as an error instead of ending gracefully.
+
+    Regression context: the kmsg (user chat) path used to fall back to the
+    OAS default guard of 3 while skip_at defaults to 4, so user chat turns
+    were killed as [IdleDetected] errors while autonomous turns (guard
+    10-15) ended via Skip. *)
+
+open Alcotest
+
+let skip_at = Env_config_keeper.KeeperKeepalive.idle_skip_threshold
+
+let test_reactive_guard_above_skip () =
+  let guard = Masc.Keeper_runtime_resolved.reactive_max_idle_turns () in
+  check bool
+    (Printf.sprintf
+       "reactive guard (%d) must exceed idle skip threshold (%d)"
+       guard
+       skip_at)
+    true
+    (guard > skip_at)
+
+let test_autonomous_guard_above_skip () =
+  let guard = Masc.Keeper_runtime_resolved.autonomous_max_idle_turns () in
+  check bool
+    (Printf.sprintf
+       "autonomous guard (%d) must exceed idle skip threshold (%d)"
+       guard
+       skip_at)
+    true
+    (guard > skip_at)
+
+(* The hook injects its final warning at [skip_at - 1]; the model needs at
+   least one further turn to react before the guard aborts. Equivalent to
+   the strict inequality above, stated separately so a future threshold
+   reshuffle that breaks only the warning headroom still fails loudly. *)
+let test_final_warning_has_a_reaction_turn () =
+  let reactive = Masc.Keeper_runtime_resolved.reactive_max_idle_turns () in
+  let autonomous = Masc.Keeper_runtime_resolved.autonomous_max_idle_turns () in
+  let final_warning_at = skip_at - 1 in
+  check bool
+    (Printf.sprintf
+       "reactive guard (%d) leaves a turn after final warning (%d)"
+       reactive
+       final_warning_at)
+    true
+    (reactive > final_warning_at + 1);
+  check bool
+    (Printf.sprintf
+       "autonomous guard (%d) leaves a turn after final warning (%d)"
+       autonomous
+       final_warning_at)
+    true
+    (autonomous > final_warning_at + 1)
+
+let () =
+  Alcotest.run
+    "Keeper_idle_threshold_contract"
+    [ ( "guard vs skip threshold"
+      , [ test_case "reactive channel" `Quick test_reactive_guard_above_skip
+        ; test_case "autonomous channel" `Quick test_autonomous_guard_above_skip
+        ; test_case
+            "final warning leaves a reaction turn"
+            `Quick
+            test_final_warning_has_a_reaction_turn
+        ] )
+    ]


### PR DESCRIPTION
## 문제 (sangsu kmsg idle-kill RCA fix 2/3)

kmsg(사용자 채팅) 경로가 `Keeper_agent_run.run_turn`에 `max_idle_turns`를 전달하지 않아 silent default **3**이 적용됐습니다. masc의 단계적 idle hook은 `skip_at=4`(nudge@1,2 → FINAL WARNING@3 → graceful **Skip@4**) 설계인데, OAS loop guard가 카운터 3 도달 직후 run을 죽이므로:

- FINAL WARNING은 모델이 볼 턴이 없는 dead text
- graceful Skip은 도달 불가
- autonomous/unified 턴(명시 전달 10–15)은 Skip으로 조용히 끝나는데 **사용자 채팅 턴만 `IdleDetected` 에러로 즉사**

실측: 2026-06-12 keeper `sangsu`, `kmsg_sangsu_15_1781234603497`(03:24Z) / `kmsg_sangsu_0_1781246262626`(06:39Z) 두 건 — 같은 keeper의 직전 autonomous 턴은 idle 4에서 Skip으로 정상 종료(06:38:28Z), 직후 chat 턴은 idle 3에서 kill(06:39:32Z).

## 변경

| 항목 | 내용 |
|---|---|
| `run_turn` 시그니처 | `?(max_idle_turns = 3)` → **필수 인자** — 모든 호출자가 채널에 맞는 임계를 명시해야 컴파일 (magic default 제거) |
| kmsg 호출부 (`keeper_turn.ml`) | `Keeper_runtime_resolved.reactive_max_idle_turns ()` 전달 — kmsg 턴은 사용자 트리거=reactive |
| 기존 호출자 | unified 턴은 이미 명시 전달 — 변경 없음 (컴파일러로 전수 확인) |
| 신규 테스트 | `test_keeper_idle_threshold_contract` 3종: 양 채널 guard > skip_at + FINAL WARNING 반응 턴 헤드룸 |

## 검증

- `scripts/dune-local.sh build lib/keeper lib/server test/test_keeper_idle_threshold_contract.exe` EXIT=0
- `test_keeper_idle_threshold_contract` 3/3 green
- 로컬 빌드 시 main pre-existing 깨짐(`lib/core/eval_tool_selector.ml` fragile-match, dev 프로필 한정)은 #20994에서 별도 수정 — 본 브랜치 diff에는 미포함

## 관련

- RCA fix 1/3: jeong-sik/oas#2028 (nudge가 tool 결과를 드랍시키는 직렬화 순서 결함)
- RCA fix 3/3: 후속 PR (transport 에러의 assistant lane 영속 = self-echo 오염)
- RFC-0232 (typed lane event model) 계열 운영 결함 후속

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
