### PR TITLE
fix(test): benchmark selector tests never compiled — facade/type mismatch (broken main, pairs with #20994)

### DIFF
--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -172,7 +172,7 @@ let test_forbidden_selector_matches_descriptor_evidence () =
       ()
   in
   let run = selector_run [ selector_tool_call ~route_evidence "masc_agent_card" ] in
-  match Tool_call_quality_benchmark_scoring.score_run ~cases:[ case ] run with
+  match Tool_call_quality_benchmark.score_run ~cases:[ case ] run with
   | Some score ->
       check bool "selector degrades pass" false score.passed;
       check (float 0.0001) "tool selection failed" 0.0 score.tool_selection;
@@ -194,7 +194,7 @@ let test_forbidden_selector_matches_eval_tag_evidence () =
       ()
   in
   let run = selector_run [ selector_tool_call ~route_evidence "renamed_agent_card" ] in
-  match Tool_call_quality_benchmark_scoring.score_run ~cases:[ case ] run with
+  match Tool_call_quality_benchmark.score_run ~cases:[ case ] run with
   | Some score ->
       check bool "eval tag degrades pass" false score.passed;
       check (float 0.0001) "tool selection failed" 0.0 score.tool_selection


### PR DESCRIPTION
## 무엇

**main @check가 또 깨져 있습니다** (4번째, ~30시간 내) — #20982가 들여온 결함 2건 중 테스트 절반의 픽스입니다. lib 절반(`eval_tool_selector.ml` fragile-match)은 **#20994**가 이미 커버합니다. **둘 다 머지돼야 main이 green입니다.**

## 원인

`selector_case` 헬퍼는 facade 타입(`Tool_call_quality_benchmark.benchmark_case`)으로 주석돼 있는데 `Tool_call_quality_benchmark_scoring.score_run`(서브모듈)을 직접 호출 — facade mli가 `include module type of X`(타입 equality 없는 시그니처 복사)라 두 `benchmark_case`는 nominal하게 다른 타입이고, 이 테스트는 **컴파일된 적이 없습니다**.

## 수정

facade 자신의 `score_run`(mli에 이미 존재) 호출로 교체 — 케이스와 함수가 같은 타입을 보게 됩니다 (2곳).

## 검증

#20994 diff를 로컬 적용한 상태에서: 빌드 clean + `test_tool_call_quality_benchmark` **6/6 PASS**. (이 PR 단독으로는 #20994 절반에 막혀 검증 불가 — 의존성 명시)

## 패턴

#20942 → #20967 → #20983 → #20982: 전부 '컴파일된 적 없는 테스트 머지'. 게이트 이슈 #20987 참조.

Refs #20982, #20994, #20987.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)