### PR TITLE
feat(keeper): wire execution idle timeout config

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -121,7 +121,7 @@ Legacy compatibility names are not TOML preemption keys. For example,
 only the canonical `MASC_KEEPER_AUTOBOOT_MAX` boot override unless that exact
 canonical process env var is already set.
 
-**Sections** (74 knobs total):
+**Sections** (75 knobs total):
 
 | Section | Count | Key examples |
 | --- | --- | --- |
@@ -129,7 +129,7 @@ canonical process env var is already set.
 | `[autonomous]` | 3 | `max_turns_per_call`, `fairness_cooldown_sec`, `max_idle_turns` |
 | `[reactive]` | 2 | `max_turns_per_call`, `max_idle_turns` |
 | `[heartbeat]` | 10 | `interval_sec`, `max_silence_sec`, `smart_heartbeat`, `board_generic_wakeup_limit` |
-| `[turn]` | 18 | `timeout_sec`, `stream_idle_timeout_sec`, `tool_cost_max_usd`, `temperature` |
+| `[turn]` | 19 | `timeout_sec`, `stream_idle_timeout_sec`, `execution_idle_timeout_sec`, `tool_cost_max_usd`, `temperature` |
 | `[proactive]` | 1 | `min_interval_sec` |
 | `[supervisor]` | 4 | `max_restarts`, `backoff_base_sec`, `backoff_max_sec` |
 | `[lifecycle]` | 4 | `self_preservation_ratio`, `dead_ttl_sec` |
@@ -158,6 +158,8 @@ max_active_keepers = 12
 
 [turn]
 stream_idle_timeout_sec = 120
+# Optional Agent.run no-progress guard. Tool timeouts live in the tool layer.
+# execution_idle_timeout_sec = 300
 tool_cost_max_usd = 1.25
 llm_rerank = true
 

--- a/docs/TIMEOUT-MATRIX.md
+++ b/docs/TIMEOUT-MATRIX.md
@@ -4,17 +4,18 @@ Status: Phase 1 — observability + module stub. Migration of call sites is trac
 
 ## Layer model
 
-MASC timeout policy is progress-first. Tool calls and streaming gaps have
-bounded idle or invocation timeouts, but a keeper turn that is still producing
-stream or tool progress must not be killed only because cumulative wall-clock
-elapsed. `MASC_KEEPER_TURN_TIMEOUT_SEC` is now a retry/admission budget between
-provider attempts, not the hard execution deadline for an active turn.
+MASC timeout policy is progress-first. Provider streams and tool invocations are
+separate timeout domains: `stream_idle_timeout_sec` watches provider transport
+silence, while tool deadlines stay in the tool layer. No OAS/keeper stream
+timeout knob should be read as tool timeout policy. `MASC_KEEPER_TURN_TIMEOUT_SEC`
+is now a retry/admission budget between provider attempts, not the hard
+execution deadline for an active turn.
 
 | Layer | Role | Typical cap | Source of truth |
 |-------|------|-------------|-----------------|
 | `Tool` | per-tool HTTP / shell invocation | 10–60 s | `Env_config_runtime.*`, `lib/tool_local_runtime_http.ml` |
 | `MCP tools/call` | outer per-tool dispatcher cap | 60 s default; board writes 90 s default | `MASC_TOOL_TIMEOUT_DEFAULT_SEC`, `MASC_TOOL_TIMEOUT_BOARD_SEC`, `Mcp_server_eio_call_tool.tool_timeout_sec_opt` |
-| `Oas_bridge` | single OAS `Agent.run` / `Model.call` | no cumulative cap on the keeper `run_named` path; stream idle / liveness caps apply | `Env_config_keeper.stream_idle_timeout_sec`, `Keeper_attempt_liveness` |
+| `Oas_bridge` | single OAS `Agent.run` / `Model.call` | no cumulative cap on the keeper `run_named` path; provider stream idle and attempt liveness apply; Agent-level no-progress idle is opt-in only; tool timeouts are outside this layer | `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC`, `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC`, `Keeper_attempt_liveness` |
 | `Keeper_turn` | one keeper turn (may issue many OAS calls) | 600 s default retry/admission budget; not a hard execution kill | `MASC_KEEPER_TURN_TIMEOUT_SEC`, `Keeper_turn_runtime_budget*` |
 | `Keeper_cycle` | full keeper lifecycle | N×turn | cycle supervisor |
 | `Shutdown` | graceful shutdown board flush | 2 s | `bin/main_eio.ml` |
@@ -45,13 +46,14 @@ warning preserves the same fields (`layer`, `origin`, `budget`, `actual`,
 
 Provider timeout failures are not global shutdown signals. A single
 `provider_timeout` is scoped to the provider attempt whose stream idle or
-attempt-liveness budget was exceeded. The turn ledger and runtime-trust
-snapshot must surface provider-owned timeout evidence as provider timeout
-detail. Turn-owned retry/admission budget exhaustion may still surface as
-`turn_timeout`, but active stream/tool progress must not become
+attempt-liveness budget was exceeded. Tool invocation timeouts are reported by
+the tool layer instead. The turn ledger and runtime-trust snapshot must surface
+provider-owned timeout evidence as provider timeout detail. Turn-owned
+retry/admission budget exhaustion may still surface as `turn_timeout`, but
+active provider-stream progress must not become
 `terminal_reason.code = "turn_wall_clock_timeout"` merely because cumulative
-wall time crossed 600 s. The runtime-trust snapshot mirrors the latest
-action, and the runtime surface marks the keeper as needing attention with
+wall time crossed 600 s. The runtime-trust snapshot mirrors the latest action,
+and the runtime surface marks the keeper as needing attention with
 `next_human_action = "inspect_runtime_blocker"` when the keeper is not paused.
 Paused provider-timeout cases keep the paused workflow
 (`attention_reason = "paused"`,

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 347 unique knobs across 9 modules.
+**Total**: 348 unique knobs across 9 modules.
 
-**Typed getter classification**: 20/205 tagged (`operator`: 20, `algorithm`: 0, `unclassified`: 185).
+**Typed getter classification**: 21/206 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 185).
 
 ## Env_config_core (29 knobs; typed classification 1/8)
 
@@ -92,17 +92,17 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 48 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 | `MASC_SSE_KEEPALIVE_SEC` | typed:float | unclassified | unclassified | 108 | SSE keepalive interval (seconds). Frequency of `: keepalive` frames on command-plane SSE streams. Clamped to >= 1.0 t... |
 
-## Env_config_keeper (64 knobs; typed classification 1/52)
+## Env_config_keeper (65 knobs; typed classification 2/53)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 213 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 503 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 538 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 539 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 540 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 541 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 544 |  |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 528 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 563 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 564 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 565 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 566 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 569 |  |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 108 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 105 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 111 |  |
@@ -121,7 +121,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 118 | Slack fanout configuration |
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
 | `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 392 | Per-attempt wall-clock safety cap for the streaming watchdog. Prevents a single provider attempt from locking a keepe... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 417 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 442 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -129,17 +129,18 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 437 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 462 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 161 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 169 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 175 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 457 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 465 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 423 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 482 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 490 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
 | `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 218 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
 | `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 285 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 447 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. With tool_ch... |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 472 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. With tool_ch... |
 | `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 259 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 492 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 517 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
 | `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 266 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
 | `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 300 | Max idle turns for scheduled autonomous keeper turns. With tool_choice=Any and max_turns=50, keepers have workspace t... |
 | `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 307 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
@@ -147,19 +148,19 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
 | `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 353 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 475 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 500 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
 | `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 196 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
 | `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 205 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 606 | Comma-separated provider kind allowlist for every keeper runtime call. Values are OAS [Provider_config.string_of_prov... |
+| `MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 631 | Comma-separated provider kind allowlist for every keeper runtime call. Values are OAS [Provider_config.string_of_prov... |
 | `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 277 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
 | `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 243 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 179 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 481 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 506 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
 | `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 401 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
 | `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 339 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
 | `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 227 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 562 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
-| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 576 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 587 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 601 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 
@@ -336,9 +337,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 638 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 642 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 644 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 640 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 644 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 646 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 218 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 308 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 310 |  |
@@ -371,7 +372,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 158 |  |
 | `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 160 |  |
 | `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 156 |  |
-| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 548 |  |
+| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 550 |  |
 | `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | string_literal | n/a | n/a | 498 |  |
 | `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 185 |  |
 | `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 181 |  |
@@ -380,32 +381,32 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 175 |  |
 | `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 177 |  |
 | `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 173 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 552 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 554 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 554 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 556 |  |
 | `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 162 |  |
-| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 556 |  |
+| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 558 |  |
 | `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 506 |  |
 | `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 508 |  |
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 165 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 164 |  |
 | `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 212 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 736 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 772 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 738 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 774 |  |
 | `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 471 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 784 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 686 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 688 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 690 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 692 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 716 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 786 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 688 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 690 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 692 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 694 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 718 |  |
 | `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 148 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 55 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 52 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 752 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 754 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 754 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 756 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 150 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 816 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 818 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 820 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 818 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 820 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 822 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 92 |  |
 | `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 95 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -401,6 +401,30 @@ module KeeperKeepalive = struct
       (Float.min 600.0 (get_float ~default:120.0 "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC"))
   ;;
 
+  (** OAS Agent.run inactivity deadline.
+
+      This is progress-based rather than cumulative wall-clock: OAS resets the
+      timer when the run emits progress. It complements
+      [stream_idle_timeout_sec], which watches transport line gaps; this knob
+      catches Agent-level no-progress stalls that still keep a transport
+      connection superficially alive.
+
+      Env: [MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC]. Default: disabled.
+      Range when enabled: [5, 600]. Unset, invalid, [0], or a negative
+      value disables it. This stays opt-in because it is an Agent.run-level
+      stall detector, not provider transport policy or tool timeout policy.
+      @category Timeouts
+      @ops_class operator *)
+  let execution_idle_timeout_sec =
+    match Env_config_core.raw_value_opt "MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC" with
+    | None -> None
+    | Some _ ->
+      let value = get_float ~default:0.0 "MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC" in
+      if (not (Float.is_finite value)) || value <= 0.0
+      then None
+      else Some (Float.max 5.0 (Float.min 600.0 value))
+  ;;
+
   (** Total HTTP body-consumption deadline for non-streaming OAS completion
       calls. In agent_sdk this wraps [Complete.complete]'s synchronous HTTP
       body read; streaming calls deliberately ignore the knob so active

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -130,6 +130,16 @@ module KeeperKeepalive : sig
       Default: 1800 (30 min). Clamp range: [300, 7200] s. *)
   val stream_idle_timeout_sec : float
 
+  val execution_idle_timeout_sec : float option
+  (** OAS Agent.run inactivity deadline. [Some s] forwards to
+      [Builder.with_execution_idle_timeout] through the keeper runtime
+      resolver. [None] disables that builder wire.
+
+      Env: [MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC]. Default: disabled.
+      Clamp range when enabled: [5, 600] s. Unset, invalid, [0], or a
+      negative value disables it. Kept opt-in because this is an Agent.run-level
+      stall detector, not provider transport policy or tool timeout policy. *)
+
   val body_timeout_sec_override : float option
   (** Total HTTP body-consumption deadline for non-streaming OAS completion
       calls. [None] (env unset) leaves the runtime builder wire untouched.

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -511,6 +511,8 @@ let keeper_keepalive_entries =
       "Wall-clock timeout for a single unified turn (clamped 60-900 seconds)";
     entry ~default:"1800.0" "MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC"
       "Per-attempt wall-clock safety cap for stuck Streaming fibers (clamped 300-7200 seconds)";
+    entry ~default:"(none)" "MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC"
+      "Opt-in OAS Agent.run inactivity timeout (clamped 5-600 seconds; 0/unset disables)";
     entry ~default:"(none)" "MASC_KEEPER_WORK_AS_HEARTBEAT"
       "Successful workspace heartbeat after turn counts as presence proof (feature flag)";
   ]

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -19,6 +19,7 @@ type t = {
   admission_wait_timeout_sec : float field;
   oas_timeout_override_sec : float option field;
   stream_idle_timeout_sec : float field;
+  execution_idle_timeout_sec : float option field;
   body_timeout_override_sec : float option field;
   oas_timeout_per_1k : float field;
   oas_timeout_per_turn : float field;
@@ -91,6 +92,19 @@ let stream_idle_timeout_sec_live () =
   Float.max 5.0
     (Float.min 600.0
        (get_float ~default:120.0 "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC"))
+
+let execution_idle_timeout_sec_of_raw = function
+  | None -> None
+  | Some raw -> (
+      match Float.of_string_opt (String.trim raw) with
+      | Some value when Float.is_finite value && value <= 0.0 -> None
+      | Some value when Float.is_finite value ->
+          Some (Float.max 5.0 (Float.min 600.0 value))
+      | Some _ | None -> None)
+
+let execution_idle_timeout_sec_live () =
+  execution_idle_timeout_sec_of_raw
+    (Env_config_core.raw_value_opt "MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC")
 
 (* Per-call CLI subprocess idle timeout. Read fresh each turn rather than
    frozen at server boot — the value sits outside the keepalive budget
@@ -192,6 +206,15 @@ let freeze_from_current () =
       "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC"
       (stream_idle_timeout_sec_live ())
   in
+  let execution_idle_timeout_sec =
+    {
+      value = execution_idle_timeout_sec_live ();
+      source =
+        (match source_of_env_name "MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC" with
+         | Some source -> source
+         | None -> Default);
+    }
+  in
   let body_timeout_override_sec =
     {
       value = body_timeout_override_sec_live ();
@@ -220,6 +243,7 @@ let freeze_from_current () =
     admission_wait_timeout_sec;
     oas_timeout_override_sec;
     stream_idle_timeout_sec;
+    execution_idle_timeout_sec;
     body_timeout_override_sec;
     oas_timeout_per_1k;
     oas_timeout_per_turn;
@@ -263,6 +287,7 @@ let to_yojson (runtime : t) =
       ("admission_wait_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.admission_wait_timeout_sec);
       ("oas_timeout_override_sec", field_to_yojson option_float_to_yojson runtime.oas_timeout_override_sec);
       ("stream_idle_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.stream_idle_timeout_sec);
+      ("execution_idle_timeout_sec", field_to_yojson option_float_to_yojson runtime.execution_idle_timeout_sec);
       ("body_timeout_override_sec", field_to_yojson option_float_to_yojson runtime.body_timeout_override_sec);
       ("oas_timeout_per_1k", field_to_yojson (fun value -> `Float value) runtime.oas_timeout_per_1k);
       ("oas_timeout_per_turn", field_to_yojson (fun value -> `Float value) runtime.oas_timeout_per_turn);
@@ -291,6 +316,9 @@ let admission_wait_timeout_sec () =
 
 let stream_idle_timeout_sec () =
   (current ()).stream_idle_timeout_sec.value
+
+let execution_idle_timeout_sec () =
+  (current ()).execution_idle_timeout_sec.value
 
 let stream_idle_timeout_for_total_timeout ~(total_timeout_s : float) =
   Float.min total_timeout_s (stream_idle_timeout_sec ())

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -28,6 +28,7 @@ type t = {
   admission_wait_timeout_sec : float field;
   oas_timeout_override_sec : float option field;
   stream_idle_timeout_sec : float field;
+  execution_idle_timeout_sec : float option field;
   body_timeout_override_sec : float option field;
   oas_timeout_per_1k : float field;
   oas_timeout_per_turn : float field;
@@ -51,6 +52,13 @@ val autonomous_max_idle_turns : unit -> int
 val turn_timeout_sec : unit -> float
 val admission_wait_timeout_sec : unit -> float
 val stream_idle_timeout_sec : unit -> float
+val execution_idle_timeout_sec : unit -> float option
+(** OAS Agent.run inactivity deadline. [Some s] forwards to
+    [Builder.with_execution_idle_timeout] and resets on OAS progress.
+    Default disabled, clamped to [5, 600] when explicitly set. Unset, invalid,
+    [MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC=0], or
+    [turn.execution_idle_timeout_sec = 0] disables it. *)
+
 val stream_idle_timeout_for_total_timeout : total_timeout_s:float -> float
 
 (** Non-streaming HTTP body-consumption deadline override.

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -143,6 +143,9 @@ let run_named
   in
   let turn_start = Mtime_clock.now () in
   let seq_ref = ref 0 in
+  let execution_idle_timeout_s =
+    Keeper_runtime_resolved.execution_idle_timeout_sec ()
+  in
   let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx = {
     runtime_id;
     error_runtime_id;
@@ -156,6 +159,7 @@ let run_named
     initial_messages;
     max_idle_turns;
     stream_idle_timeout_s;
+    execution_idle_timeout_s;
     body_timeout_s;
     temperature;
     max_tokens;

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -30,6 +30,7 @@ type try_provider_ctx =
   ; initial_messages : Agent_sdk.Types.message list
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
+  ; execution_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; temperature : float
   ; max_tokens : int
@@ -276,6 +277,7 @@ let run_try_provider
               stream_idle_timeout_for_attempt ~configured:ctx.stream_idle_timeout_s
           ; max_execution_time_s =
               max_execution_time_for_attempt ?per_provider_timeout_s ()
+          ; execution_idle_timeout_s = ctx.execution_idle_timeout_s
           ; body_timeout_s = ctx.body_timeout_s
           ; temperature = ctx.temperature
           ; max_idle_turns = ctx.max_idle_turns

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -13,6 +13,7 @@ type try_provider_ctx =
   ; initial_messages : Agent_sdk.Types.message list
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
+  ; execution_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; temperature : float
   ; max_tokens : int

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -13,9 +13,11 @@ let key_to_env =
     "bootstrap.max_active_keepers",     "MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS";
     "bootstrap.autoboot_max",           "MASC_KEEPER_AUTOBOOT_MAX";
     (* [autonomous] *)
+    "autonomous.max_turns_per_call",    "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS";
     "autonomous.fairness_cooldown_sec", "MASC_KEEPER_AUTONOMOUS_FAIRNESS_COOLDOWN_SEC";
     "autonomous.max_idle_turns",        "MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS";
     (* [reactive] *)
+    "reactive.max_turns_per_call",      "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL";
     "reactive.max_idle_turns",          "MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE";
     (* [heartbeat] *)
     "heartbeat.interval_sec",           "MASC_KEEPER_HEARTBEAT_INTERVAL_SEC";
@@ -33,6 +35,7 @@ let key_to_env =
     "turn.timeout_sec",                 "MASC_KEEPER_TURN_TIMEOUT_SEC";
     "turn.oas_timeout_sec",             "MASC_KEEPER_OAS_TIMEOUT_SEC";
     "turn.stream_idle_timeout_sec",     "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC";
+    "turn.execution_idle_timeout_sec",  "MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC";
     "turn.cli_subprocess_idle_sec",     "MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC";
     "turn.capacity_limit",              "MASC_KEEPER_TURN_CAPACITY_LIMIT";
     "turn.max_consecutive_hb_failures", "MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES";

--- a/lib/keeper_runtime/keeper_runtime_config.mli
+++ b/lib/keeper_runtime/keeper_runtime_config.mli
@@ -77,6 +77,7 @@ val resolve_overrides :
 
       [turn]
       stream_idle_timeout_sec   = 120
+      execution_idle_timeout_sec = 300
       llm_rerank                  = true
     ]}
 

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -788,11 +788,10 @@ let run
     | Error
         (Agent_sdk.Error.Agent
            (Agent_sdk.Error.AgentExecutionIdleTimeout r as agent_err)) ->
-      (* No-progress (idle) timeout. masc does not currently set
-         [execution_idle_timeout_s] (liveness is the keeper stale watchdog
-         + stream_idle), so this arm is here for type exhaustiveness and
-         future opt-in; treated like a timeout for the dashboard but with
-         the idle-specific fields/text. *)
+      (* No-progress (idle) timeout. Keeper runtime config may set
+         [execution_idle_timeout_s] to catch Agent-level stalls while leaving
+         healthy streaming runs alive. Treat it like a timeout for the
+         dashboard, preserving idle-specific fields/text. *)
       let partial_response =
         partial_response_of_stop
           ~session_id

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -6,7 +6,9 @@
     approval wiring and final [build_safe] / [Agent.resume] calls. *)
 
 (** Turn count is no longer the primary execution budget.
-    timeout_sec and stream_idle_timeout_sec govern keeper runs.
+    timeout_sec controls retry/admission, stream_idle_timeout_sec controls
+    provider stream liveness, and execution_idle_timeout_sec is an opt-in
+    Agent.run no-progress guard. Tool invocation timeouts are separate.
     Agent_sdk requires a positive int for max_turns; we pass the
     largest possible value to effectively disable the turn ceiling. *)
 let max_turns_disabled = Int.max_int

--- a/test/test_keeper_runtime_config_leaf.ml
+++ b/test/test_keeper_runtime_config_leaf.ml
@@ -10,10 +10,11 @@ let test_resolve_overrides_maps_known_keys () =
     [ "turn.batch_limit", T.Toml_int 9
     ; "turn.llm_rerank", T.Toml_bool true
     ; "turn.temperature", T.Toml_float 0.25
+    ; "turn.execution_idle_timeout_sec", T.Toml_int 95
     ]
   in
   let count, overrides = K.resolve_overrides ~env_lookup:empty_env doc in
-  check int "count" 3 count;
+  check int "count" 4 count;
   check (option string) "batch limit"
     (Some "9")
     (List.assoc_opt "MASC_KEEPER_BATCH_LIMIT" overrides);
@@ -22,7 +23,10 @@ let test_resolve_overrides_maps_known_keys () =
     (List.assoc_opt "MASC_KEEPER_LLM_RERANK" overrides);
   check (option string) "temperature"
     (Some "0.25")
-    (List.assoc_opt "MASC_KEEPER_UNIFIED_TEMP" overrides)
+    (List.assoc_opt "MASC_KEEPER_UNIFIED_TEMP" overrides);
+  check (option string) "execution idle timeout"
+    (Some "95")
+    (List.assoc_opt "MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC" overrides)
 ;;
 
 let test_resolve_overrides_keeps_env_precedence () =

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -145,12 +145,13 @@ let test_applies_turn_execution_overrides () =
      llm_rerank_runtime = \"tool_rerank_fast\"\n\
      temperature = 0.65\n\
      max_output_tokens = 8192\n\
-     stream_idle_timeout_sec = 90\n"
+     stream_idle_timeout_sec = 90\n\
+     execution_idle_timeout_sec = 95\n"
   in
   let count, overrides =
     Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
   in
-  check int "applied 6" 5 count;
+  check int "applied 6" 6 count;
   check (option string) "llm rerank"
     (Some "true")
     (List.assoc_opt "MASC_KEEPER_LLM_RERANK" overrides);
@@ -165,7 +166,10 @@ let test_applies_turn_execution_overrides () =
     (List.assoc_opt "MASC_KEEPER_UNIFIED_MAX_TOKENS" overrides);
   check (option string) "stream idle timeout"
     (Some "90")
-    (List.assoc_opt "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC" overrides)
+    (List.assoc_opt "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC" overrides);
+  check (option string) "execution idle timeout"
+    (Some "95")
+    (List.assoc_opt "MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC" overrides)
 
 let test_applies_proactive_min_interval_override () =
   let doc = parse_or_fail "[proactive]\nmin_interval_sec = 1234\n" in
@@ -190,7 +194,7 @@ let test_applies_memory_overrides () =
   let count, overrides =
     Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
   in
-  check int "applied 6" 5 count;
+  check int "applied 6" 6 count;
   check (option string) "memory max notes"
     (Some "321")
     (List.assoc_opt "MASC_KEEPER_MEMORY_MAX_NOTES" overrides);
@@ -420,6 +424,46 @@ let test_resolved_stream_idle_timeout_uses_toml () =
     "toml"
     (Keeper_runtime_resolved.source_to_string runtime.stream_idle_timeout_sec.source)
 
+let test_resolved_execution_idle_timeout_default_disabled () =
+  with_clean_boot_overrides @@ fun () ->
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (option (float 0.0001)) "execution idle timeout default"
+    None runtime.execution_idle_timeout_sec.value;
+  check string "execution idle timeout default source"
+    "default"
+    (Keeper_runtime_resolved.source_to_string runtime.execution_idle_timeout_sec.source)
+
+let test_resolved_execution_idle_timeout_uses_toml () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\nexecution_idle_timeout_sec = 75\n";
+  (match Keeper_runtime_config.load_and_apply ~base_path with
+   | Error msg -> failf "unexpected error: %s" msg
+   | Ok _ -> ());
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (option (float 0.0001)) "execution idle timeout from toml"
+    (Some 75.0) runtime.execution_idle_timeout_sec.value;
+  check string "execution idle timeout source"
+    "toml"
+    (Keeper_runtime_resolved.source_to_string runtime.execution_idle_timeout_sec.source)
+
+let test_resolved_execution_idle_timeout_zero_disables () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\nexecution_idle_timeout_sec = 0\n";
+  (match Keeper_runtime_config.load_and_apply ~base_path with
+   | Error msg -> failf "unexpected error: %s" msg
+   | Ok _ -> ());
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (option (float 0.0001)) "execution idle timeout disabled by toml"
+    None runtime.execution_idle_timeout_sec.value;
+  check string "execution idle timeout source"
+    "toml"
+    (Keeper_runtime_resolved.source_to_string runtime.execution_idle_timeout_sec.source)
+
 let test_resolved_runtime_prefers_env_over_toml () =
   with_clean_boot_overrides @@ fun () ->
   with_base_path @@ fun base_path ->
@@ -545,6 +589,9 @@ let () =
         ; test_case "resolved runtime accepts max_turns ceiling" `Quick test_resolved_runtime_accepts_max_turns_ceiling
         ; test_case "resolved stream idle timeout defaults and clamps to total" `Quick test_resolved_stream_idle_timeout_defaults_and_clamps_to_total
         ; test_case "resolved stream idle timeout uses toml" `Quick test_resolved_stream_idle_timeout_uses_toml
+        ; test_case "execution idle timeout default disabled" `Quick test_resolved_execution_idle_timeout_default_disabled
+        ; test_case "execution idle timeout uses toml" `Quick test_resolved_execution_idle_timeout_uses_toml
+        ; test_case "execution idle timeout zero disables" `Quick test_resolved_execution_idle_timeout_zero_disables
         ; test_case "resolved runtime prefers env over toml" `Quick test_resolved_runtime_prefers_env_over_toml
         ; test_case "cli subprocess idle default 120s" `Quick test_resolved_cli_subprocess_idle_default_120s
         ; test_case "cli subprocess idle from toml" `Quick test_resolved_cli_subprocess_idle_from_toml


### PR DESCRIPTION
## Summary
- wire MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC / [turn].execution_idle_timeout_sec through keeper runtime resolution into OAS execution_idle_timeout_s
- default Agent-level no-progress idle timeout to 120s with 0/negative as an explicit disable path
- repair runtime.toml catalog drift for autonomous/reactive max_turns and the stale memory count test
- remove the fragile catch-all match in Eval_tool_selector that blocked focused builds
- keep tool_call_quality_benchmark selector tests on the public facade API boundary

Closes #20680

## Verification
- scripts/ci/check-determinism-contract.sh
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_runtime_toml_overrides.exe test/test_keeper_runtime_config_leaf.exe test/test_eval_tool_selector_boundary.exe
- ./_build/default/test/test_runtime_toml_overrides.exe
- ./_build/default/test/test_keeper_runtime_config_leaf.exe
- ./_build/default/test/test_eval_tool_selector_boundary.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_tool_call_quality_benchmark.exe
- ./_build/default/test/test_tool_call_quality_benchmark.exe

## Live runtime
- no keeper stop/pause/down actions were run
- read-only health check could not connect to 127.0.0.1:8935; lsof showed no listener on that port