### PR TITLE
Improve WebSearch content enrichment

### DIFF
--- a/config/prompts/keeper.tool_hints.toml
+++ b/config/prompts/keeper.tool_hints.toml
@@ -65,13 +65,13 @@ description = "run one typed argv command; set cwd for git, never type keeper_* 
 
 [[hints]]
 name = "WebSearch"
-call = "`WebSearch` { query: \"current-info query\", limit: 5 }"
-description = "look up current public context before time-sensitive claims"
+call = "`WebSearch` { query: \"current-info query\", limit: 5, includeContent: true, contentMaxChars: 4000 }"
+description = "MASC-owned tool-list alias for current public context; includeContent returns readable page_content for top results"
 
 [[hints]]
 name = "WebFetch"
 call = "`WebFetch` { url: \"https://example.com/page\", timeout: {{web_fetch_timeout}}, extractMode: \"markdown\" }"
-description = "fetch and read an agent-readable web page before citing it"
+description = "fetch one known URL for deeper reading or citation after search"
 
 [[hints]]
 name = "masc_transition"

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -89,7 +89,7 @@ Decide what to do based on the current world state below.
 ### Research evidence
 - Ground novel technical, policy, library, model, pricing, API, or industry-pattern claims with evidence before presenting them as fact.
 - Use code evidence for repo-local claims: search/read the relevant files and cite stable `path:line` references in the post or reply.
-- Use web evidence for external or current claims: call `WebSearch` to find sources, then call `WebFetch` to read the selected source before citing it.
+- Use web evidence for external or current claims: call `WebSearch` with `includeContent: true` to get current sources plus readable `page_content`; call `WebFetch` for a selected URL when you need deeper reading or a citation-ready page. These MASC-owned names are intentionally distinct from generic snake_case web tool names and from MASC backend ids.
 - If no source is found or the available tools cannot verify the claim, mark the claim with `[uncited]` instead of presenting it as verified.
 - When posting research-backed findings to the board, include a `sources` array on `keeper_board_post`/`masc_board_post` with `{url, quote}` entries. The board will persist those sources in metadata and append a Sources footer.
 
@@ -110,7 +110,7 @@ When you claim a task (`keeper_task_claim`), you MUST close it before ending the
 - Respond to board activity (`keeper_board_comment`, if available)
 - Search knowledge library (`keeper_library_search` / `keeper_library_read`, if available)
 - Run shell commands to investigate (`Execute { executable: "git", argv: ["log", "--oneline", "-10"], cwd: "repos/REPO" }`, if available)
-- Search the web (`WebSearch`) for tech context or documentation, then fetch (`WebFetch`) selected pages before citing
+- Search the web (`WebSearch` with `includeContent: true`) for tech context or documentation, then fetch (`WebFetch`) selected pages when a deeper read or citation is needed
 - Recall past context (`keeper_memory_search`, if available) before repeating past work
 - Search code patterns (`Grep { pattern: "regex", path: "lib", type: "ml" }`, if available)
 - Audit failed tasks (`keeper_tasks_audit`, if available) before deciding there is nothing to do

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -86,7 +86,7 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | Workflow | Primary tools |
 |----------|---------------|
 | 의견 내기 / 토론 참여 | `keeper_board_post`, `keeper_board_comment` |
-| 최신 정보 / 외부 자료 확인 | `WebSearch` -> `WebFetch` |
+| 최신 정보 / 외부 자료 확인 | `WebSearch` with `includeContent: true` for current results plus readable `page_content`; `WebFetch` for one selected URL when deeper reading is needed |
 | 찬성 / 반대 신호 | `keeper_board_vote` |
 | 거버넌스 의견 제출 | retired as keeper tools; use board discussion/vote paths and governance dashboard read models |
 | 목표 / 계획 lifecycle | `masc_goal_list`, `masc_goal_upsert`, `masc_goal_transition`, `masc_goal_verify` |

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -225,6 +225,8 @@ Allowlist SSOT: `lib/tool/tool_catalog.ml` > `public_mcp_tools`
 Keeper WebSearch/WebFetch backend 메모:
 
 - `masc_web_search` / `masc_web_fetch`는 Keeper-internal backend 이름이며 MCP `tools/list` public surface에는 노출되지 않는다.
+- `web_search` / `web_fetch` are not OAS-owned capabilities; Keeper agents should call the MASC-owned public aliases shown in their tool list (`WebSearch` / `WebFetch`).
+- `WebSearch { includeContent: true }`는 검색 결과마다 best-effort `page_content`를 붙인다. `WebFetch`는 선택한 단일 URL을 더 깊게 읽을 때 쓴다.
 - `MASC_SEARXNG_URL` 설정 시 self-hosted SearXNG가 최우선 provider로 작동한다.
 - 기본 auto 모드는 공식 provider key가 있으면 `searxng`, `brave`, `tavily`, `exa`, `bing_api` 순으로 먼저 시도한다.
 - 공식 provider가 없거나 실패하면 `duckduckgo`, `bing_rss` 순으로 fallback 한다.

--- a/docs/design/tool-execution-substrate-plan.md
+++ b/docs/design/tool-execution-substrate-plan.md
@@ -47,7 +47,7 @@ Current main already points in the right direction.
 - `Execute` and `Grep` are descriptor-routed through `Shell_ir`.
 - `Read`, `Edit`, and `Write` are descriptor-routed through
   `Filesystem`.
-- `WebSearch` and `WebFetch` are keeper-internal web backend names routed
+- `WebSearch` and `WebFetch` are keeper-facing web aliases routed
   through `In_process` and `Tool_masc_misc_dispatch`; they are not MCP
   `tools/list` entries.
 - RFC-0160 is implemented: typed Execute lowers once to Shell IR, classifies

--- a/lib/dune
+++ b/lib/dune
@@ -183,6 +183,7 @@
   keeper_tool_persona_audit
   tool_misc_web_search
   tool_misc_web_fetch
+  tool_misc_web_enrichment
   meta_cognition_types
   meta_cognition_rules
   meta_cognition_snapshot

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -6,7 +6,8 @@
     input translator, and an optional public schema.
 
     Two descriptor-backed surfaces:
-    - LLM native tools: Execute, Grep/Search, Read, Edit, Write, WebSearch, WebFetch
+    - LLM native-style tools: Execute, Grep/Search, Read, Edit, Write,
+      WebSearch, WebFetch
     - MCP tools: names with the masc_ prefix
 
     Internal [keeper_*] names are implementation details of the routing layer,

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -6,7 +6,8 @@
     public schema.
 
     Two descriptor-backed surfaces:
-    - LLM native tools (Execute, Grep/Search, Read, Edit, Write, WebSearch, WebFetch)
+    - LLM native-style tools (Execute, Grep/Search, Read, Edit, Write,
+      WebSearch, WebFetch)
     - MCP tools (names with the masc_ prefix)
 
     Internal [keeper_*] names are implementation details of the routing

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -264,6 +264,27 @@ let search_web_schema =
     ~required:[ "query" ]
     [ property "query" "string" "Search query text for current public web information."
     ; property "limit" "integer" "Maximum number of results to return."
+    ; property
+        "includeContent"
+        "boolean"
+        "When true, best-effort fetch readable page_content for each returned result."
+    ; ( "contentMaxChars",
+        `Assoc
+          [ "type", `String "integer"
+          ; "description",
+            `String "Maximum readable page_content characters per result."
+          ; "minimum", `Int 100
+          ; "maximum", `Int 20000
+          ; "default", `Int 4000
+          ] )
+    ; ( "contentTimeout",
+        `Assoc
+          [ "type", `String "integer"
+          ; "description", `String "Per-result content fetch timeout in seconds."
+          ; "minimum", `Int 1
+          ; "maximum", `Int 60
+          ; "default", `Int 15
+          ] )
     ]
 ;;
 
@@ -571,7 +592,9 @@ let public_descriptors =
       ~id:"agent.search_web"
       ~public_name:"WebSearch"
       ~internal_name:"masc_web_search"
-      ~description:"Search the public web for current information."
+      ~description:
+        "Search the public web for current information using the MASC-owned \
+         tool-list alias, not a generic snake_case web tool id."
       ~input_schema:search_web_schema
       ~policy:
         (policy
@@ -589,7 +612,9 @@ let public_descriptors =
       ~id:"agent.fetch_web"
       ~public_name:"WebFetch"
       ~internal_name:"masc_web_fetch"
-      ~description:"Fetch a selected web page for source-backed reading."
+      ~description:
+        "Fetch a selected web page for source-backed reading using the \
+         MASC-owned tool-list alias, not a generic snake_case web tool id."
       ~input_schema:fetch_web_schema
       ~policy:
         (policy
@@ -1312,7 +1337,7 @@ let internal_descriptors : t list =
   ; masc_misc_descriptor "tool_help" "masc_tool_help"
       "Read help text for a tool name." ~readonly:true
   (* [masc_web_search] / [masc_web_fetch] are already owned by the
-     LLM-native WebSearch / WebFetch descriptors above. Do not add
+     MASC-owned web descriptors above. Do not add
      duplicate internal descriptors here; that would make runtime receipt
      projection depend on list order. *)
   (* ── RFC-0182 §3.1 — masc_control_* cluster (2 entries) ──────── *)

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -158,7 +158,12 @@ let handle_tool_help ~tool_name ~start_time _ctx args : Tool_result.result =
    With dispatch lifting internally now, these wrappers can pass
    the typed result straight through. *)
 let handle_web_search ~tool_name ~start_time _ctx args : Tool_result.result =
-  Tool_misc_web_search.handle ~tool_name ~start_time args
+  let result = Tool_misc_web_search.handle ~tool_name ~start_time args in
+  Tool_misc_web_enrichment.enrich_result_if_requested
+    ~tool_name
+    ~start_time
+    args
+    result
 
 let handle_web_fetch ~tool_name ~start_time _ctx args : Tool_result.result =
   Tool_misc_web_fetch.handle ~tool_name ~start_time args

--- a/lib/tool_misc_web_enrichment.ml
+++ b/lib/tool_misc_web_enrichment.ml
@@ -1,0 +1,202 @@
+open Tool_args
+
+let web_search_content_default_max_chars = 4_000
+let web_search_content_max_chars_cap = 20_000
+
+let clamp_int ~min ~max value = Stdlib.max min (Stdlib.min max value)
+
+let assoc_replace key value fields =
+  let rec loop acc = function
+    | [] -> List.rev ((key, value) :: acc)
+    | (k, _) :: rest when String.equal k key ->
+        List.rev_append acc ((key, value) :: rest)
+    | field :: rest -> loop (field :: acc) rest
+  in
+  loop [] fields
+
+let json_field_string key = function
+  | `Assoc fields ->
+      (match List.assoc_opt key fields with
+       | Some (`String value) -> Some value
+       | _ -> None)
+  | _ -> None
+
+let json_field_int key = function
+  | `Assoc fields ->
+      (match List.assoc_opt key fields with
+       | Some (`Int value) -> Some value
+       | _ -> None)
+  | _ -> None
+
+let json_field_bool key = function
+  | `Assoc fields ->
+      (match List.assoc_opt key fields with
+       | Some (`Bool value) -> Some value
+       | _ -> None)
+  | _ -> None
+
+let append_assoc_fields fields additions =
+  List.fold_left
+    (fun acc (key, value) -> assoc_replace key value acc)
+    fields
+    additions
+
+let failed_page_content_note ~url message =
+  let message = String.trim message in
+  let message = if String.equal message "" then "unknown error" else message in
+  Printf.sprintf "_Failed to retrieve page content: %s_\n\nSource: %s\n" message url
+
+let fetch_page_content_for_search_hit ~content_max_chars ~content_timeout url =
+  let fetch_args =
+    `Assoc
+      [ "url", `String url
+      ; "extractMode", `String "markdown"
+      ; "maxChars", `Int content_max_chars
+      ; "timeout", `Int content_timeout
+      ]
+  in
+  let start_time = Time_compat.now () in
+  let fetch_result =
+    Tool_misc_web_fetch.handle
+      ~tool_name:"masc_web_fetch"
+      ~start_time
+      fetch_args
+  in
+  if Tool_result.is_success fetch_result then (
+    let data = Tool_result.data fetch_result in
+    match json_field_string "text" data with
+    | None ->
+        let message = "WebFetch success payload missing text field" in
+        ( [ "page_content_status", `String "error"
+          ; "page_content", `String (failed_page_content_note ~url message)
+          ; "page_content_error", `String message
+          ]
+        , false )
+    | Some text ->
+        let fields =
+          [ "page_content_status", `String "ok"
+          ; "page_content", `String text
+          ]
+        in
+        let fields =
+          match json_field_string "final_url" data with
+          | Some value -> ("page_content_final_url", `String value) :: fields
+          | None -> fields
+        in
+        let fields =
+          match json_field_int "http_status" data with
+          | Some value -> ("page_content_http_status", `Int value) :: fields
+          | None -> fields
+        in
+        let fields =
+          match json_field_int "content_chars" data with
+          | Some value -> ("page_content_chars", `Int value) :: fields
+          | None -> fields
+        in
+        let fields =
+          match json_field_bool "truncated" data with
+          | Some value -> ("page_content_truncated", `Bool value) :: fields
+          | None -> fields
+        in
+        let fields =
+          match json_field_string "title" data with
+          | Some value -> ("page_content_title", `String value) :: fields
+          | None -> fields
+        in
+        List.rev fields, true)
+  else
+    ( [ "page_content_status", `String "error"
+      ; "page_content", `String (failed_page_content_note ~url (Tool_result.message fetch_result))
+      ; "page_content_error", `String (Tool_result.message fetch_result)
+      ]
+    , false )
+
+let enrich_web_search_hit ~content_max_chars ~content_timeout hit =
+  match hit with
+  | `Assoc fields ->
+      (match List.assoc_opt "url" fields with
+       | Some (`String url) when not (String.equal (String.trim url) "") ->
+           let additions, ok =
+             fetch_page_content_for_search_hit
+               ~content_max_chars
+               ~content_timeout
+               url
+           in
+           `Assoc (append_assoc_fields fields additions), ok
+       | _ ->
+           ( `Assoc
+               (append_assoc_fields fields
+                  [ "page_content_status", `String "skipped"
+                  ; "page_content",
+                    `String "_Skipped page content fetch: result has no URL._\n"
+                  ])
+           , false ))
+  | other -> other, false
+
+let enrich_web_search_results ~content_max_chars ~content_timeout hits =
+  let ok_count = ref 0 in
+  let enriched =
+    List.map
+      (fun hit ->
+         let hit, ok =
+           enrich_web_search_hit ~content_max_chars ~content_timeout hit
+         in
+         if ok then incr ok_count;
+         hit)
+      hits
+  in
+  let result_count = List.length hits in
+  enriched, !ok_count, result_count - !ok_count
+
+let enrich_web_search_payload ~tool_name ~start_time ~content_max_chars
+  ~content_timeout data =
+  match data with
+  | `Assoc fields ->
+      (match List.assoc_opt "result" fields with
+       | Some (`Assoc result_fields) ->
+           (match List.assoc_opt "results" result_fields with
+            | Some (`List hits) ->
+                let enriched_hits, content_ok_count, content_error_count =
+                  enrich_web_search_results
+                    ~content_max_chars
+                    ~content_timeout
+                    hits
+                in
+                let result_fields =
+                  append_assoc_fields result_fields
+                    [ "results", `List enriched_hits
+                    ; "content_enriched", `Bool true
+                    ; "content_fetch_mode", `String "best_effort"
+                    ; "content_max_chars", `Int content_max_chars
+                    ; "content_timeout", `Int content_timeout
+                    ; "content_result_count", `Int content_ok_count
+                    ; "content_error_count", `Int content_error_count
+                    ]
+                in
+                Tool_result.make_ok
+                  ~tool_name
+                  ~start_time
+                  ~data:(`Assoc (assoc_replace "result" (`Assoc result_fields) fields))
+                  ()
+            | _ -> Tool_result.make_ok ~tool_name ~start_time ~data ())
+       | _ -> Tool_result.make_ok ~tool_name ~start_time ~data ())
+  | _ -> Tool_result.make_ok ~tool_name ~start_time ~data ()
+
+let enrich_result_if_requested ~tool_name ~start_time args result =
+  if not (Tool_result.is_success result) then result
+  else if not (get_bool args "includeContent" false) then result
+  else
+    let content_max_chars =
+      get_int args "contentMaxChars" web_search_content_default_max_chars
+      |> clamp_int ~min:100 ~max:web_search_content_max_chars_cap
+    in
+    let content_timeout =
+      get_int args "contentTimeout" Tool_misc_web_fetch.default_timeout_sec
+      |> clamp_int ~min:1 ~max:60
+    in
+    enrich_web_search_payload
+      ~tool_name
+      ~start_time
+      ~content_max_chars
+      ~content_timeout
+      (Tool_result.data result)

--- a/lib/tool_misc_web_search.mli
+++ b/lib/tool_misc_web_search.mli
@@ -143,6 +143,10 @@ val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_resul
 (** [handle ~tool_name ~start_time args] handles [masc_web_search] tool dispatch.
     Required: [query] (string).  Optional: [limit] (int,
     clamped to [\[1, 10\]], default 5).
+    The misc facade also accepts [includeContent=true] to best-effort enrich
+    each result with readable [page_content] via [WebFetch], plus optional
+    [contentMaxChars] and [contentTimeout] controls. This module remains the
+    search-provider boundary to avoid depending on fetch.
 
     On success the payload [data] is wrapped as
     [`Assoc [ "text", `String json ]] where [json] is the

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -34,6 +34,7 @@ BOARD_TOOLS = {
 }
 WEB_SEARCH_TOOLS = {
     "masc_web_search",
+    "WebSearch",
     "SearchWeb",
 }
 PRODUCT_DOMAIN_MARKERS = {
@@ -1360,7 +1361,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--require-web-search-evidence",
         action="store_true",
         help=(
-            "Fail unless each keeper has successful masc_web_search/SearchWeb "
+            "Fail unless each keeper has successful masc_web_search/WebSearch/SearchWeb "
             "evidence from decision or global tool-call logs."
         ),
     )

--- a/scripts/lint/no-legacy-tool-surface-name.sh
+++ b/scripts/lint/no-legacy-tool-surface-name.sh
@@ -2,7 +2,7 @@
 # Guard against re-emergence of pre-RFC-0064 public tool names in the
 # descriptor-backed tool surface and keeper-facing prompt/persona/config files.
 #
-# After RFC-0202 tool name alignment, the active LLM-native public names are:
+# After the MASC web-alias split, the active keeper-facing public names are:
 #   Execute, Read, Edit, Write, Grep, Search, WebSearch, WebFetch
 #
 # The retired names — Bash, ReadFile, WriteFile, EditFile, SearchFiles,

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -838,7 +838,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         row = {
             "ts": 110.0,
             "keeper": "alpha",
-            "tool": "SearchWeb",
+            "tool": "WebSearch",
             "input": {"query": "latest MASC MCP keeper proof"},
             "output": json.dumps({"ok": True}),
             "success": True,
@@ -849,7 +849,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         self.assertEqual(
             evidence,
             {
-                "web_search:SearchWeb:"
+                "web_search:WebSearch:"
                 "query=latest MASC MCP keeper proof:"
                 "ts=110:"
                 "source=06.jsonl"

--- a/test/test_failing_minimum_essential.ml
+++ b/test/test_failing_minimum_essential.ml
@@ -8,7 +8,7 @@
 
     Properties pinned:
     1. Shard floor preserved (5 base read-only tools present).
-    2. Essential MASC subset present (masc_status / web_search / web_fetch)
+    2. Essential MASC subset present (masc_status / WebSearch / WebFetch)
        — hardcoded in [Masc.Keeper_tool_policy.essential_masc_minimum_names].
     3. No duplicates (sort_uniq).
     4. Non-empty (TLA+ ToolSetNeverEmpty). *)

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -567,7 +567,7 @@ let test_public_local_aliases_dispatch_to_runtime_handlers () =
       check bool "Execute ran in requested cwd" true
         (contains_substring execute_result.raw_output playground))
 
-let test_public_web_search_alias_dispatches_to_misc_runtime () =
+let test_public_masc_web_search_alias_dispatches_to_misc_runtime () =
   with_exec_fixture "keeper_tool_dispatch_web_search_alias"
     (fun ~config ~meta ~ctx_work ->
       Masc.Tool_misc.with_web_search_simulation_for_test
@@ -622,7 +622,7 @@ let test_public_web_search_alias_dispatches_to_misc_runtime () =
               Yojson.Safe.Util.(member "snippet" hit |> to_string)
           | _ -> fail "expected one web search hit"))
 
-let test_public_web_fetch_alias_dispatches_to_misc_runtime () =
+let test_public_masc_web_fetch_alias_dispatches_to_misc_runtime () =
   with_exec_fixture "keeper_tool_dispatch_web_fetch_alias"
     (fun ~config ~meta ~ctx_work ->
       let requested_url = "https://example.com/alias-web-fetch" in
@@ -698,7 +698,7 @@ let test_public_web_fetch_alias_dispatches_to_misc_runtime () =
                Yojson.Safe.Util.(member "text" json |> to_string)
                "Body content & proof.")))
 
-let test_public_web_fetch_blocks_localhost_before_runtime () =
+let test_public_masc_web_fetch_blocks_localhost_before_runtime () =
   with_exec_fixture "keeper_tool_dispatch_web_fetch_blocks_localhost"
     (fun ~config ~meta ~ctx_work ->
       Masc.Tool_misc.with_web_fetch_http_get_for_test
@@ -955,11 +955,11 @@ let () =
       test_case "public local aliases dispatch to runtime handlers" `Quick
         test_public_local_aliases_dispatch_to_runtime_handlers;
       test_case "public WebSearch alias reaches misc runtime" `Quick
-        test_public_web_search_alias_dispatches_to_misc_runtime;
+        test_public_masc_web_search_alias_dispatches_to_misc_runtime;
       test_case "public WebFetch alias reaches misc runtime" `Quick
-        test_public_web_fetch_alias_dispatches_to_misc_runtime;
+        test_public_masc_web_fetch_alias_dispatches_to_misc_runtime;
       test_case "public WebFetch blocks localhost before runtime" `Quick
-        test_public_web_fetch_blocks_localhost_before_runtime;
+        test_public_masc_web_fetch_blocks_localhost_before_runtime;
       test_case "task FSM errors require explicit failure_class" `Quick
         test_tool_result_does_not_infer_task_fsm_rejections_from_message;
       test_case "tool_result_or_error preserves failure_class" `Quick

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -139,13 +139,28 @@ let test_policy_validation_unknown_tool_misses () =
 let test_public_descriptor_names_resolve () =
   List.iter
     (fun name -> check bool (name ^ " resolves") true (resolves name))
-    [ "Execute"; "Grep"; "Search"; "Read"; "Edit"; "Write"; "WebSearch"; "WebFetch" ]
+    [
+      "Execute";
+      "Grep";
+      "Search";
+      "Read";
+      "Edit";
+      "Write";
+      "WebSearch";
+      "WebFetch";
+    ]
 
 let test_retired_public_names_miss () =
   List.iter
     (fun name -> check bool (name ^ " misses") false (resolves name))
-    [ "Bash"; "SearchFiles"; "ReadFile"; "EditFile"; "WriteFile";
-      "keeper_task_submit_for_verification" ]
+    [
+      "Bash";
+      "SearchFiles";
+      "ReadFile";
+      "EditFile";
+      "WriteFile";
+      "keeper_task_submit_for_verification";
+    ]
 
 (* ── Core tool names that must resolve ── *)
 

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -162,8 +162,8 @@ let descriptor_internal_schema name : tool_schema =
   | None -> Alcotest.failf "descriptor for internal tool %S not found" name
 ;;
 
-(* Regression guard for PR #19864 -> keeper "AllowList pruned ... WebSearch,
-   WebFetch" spam. Web tools are descriptor-backed keeper tools: they MUST be
+(* Regression guard for PR #19864 -> keeper web alias pruning spam.
+   Web tools are descriptor-backed keeper tools: they MUST be
    present in the raw substrate inventory, but their schema owner is
    [Keeper_tool_descriptor.public_descriptors], not [Tool_descriptors_gen]. *)
 let test_web_tools_owned_by_keeper_descriptors () =

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -391,6 +391,112 @@ let () = test "web_search_simulate_for_test_reports_all_failures" (fun () ->
     (str_contains (Tool_result.message result) "bing_rss: rss unavailable")
 )
 
+let () = test "dispatch_web_search_include_content_enriches_results" (fun () ->
+  let ctx = make_test_ctx () in
+  let query = "include content enrichment regression" in
+  let url = "https://example.com/masc-web-search-content" in
+  let html =
+    {|<!doctype html>
+<html>
+  <head><title>Result Page &amp; Proof</title></head>
+  <body>
+    <article>
+      <h1>Result Page</h1>
+      <p>Readable <b>page</b> content &amp; proof.</p>
+    </article>
+  </body>
+</html>|}
+  in
+  Tool_misc.with_web_search_simulation_for_test
+    ~outcomes:[ ("duckduckgo", `Hits [ ("Result", url, "Snippet") ]) ]
+    (fun () ->
+      Tool_misc.with_web_fetch_http_get_for_test
+        (fun ~timeout_sec ~headers:_ ~max_response_bytes url_arg ->
+           assert (timeout_sec = 9);
+           assert (max_response_bytes = 2_000_000);
+           assert (url_arg = url);
+           Ok (Some 200, html))
+        (fun () ->
+          let args =
+            `Assoc
+              [ ("query", `String query)
+              ; ("limit", `Int 1)
+              ; ("includeContent", `Bool true)
+              ; ("contentMaxChars", `Int 300)
+              ; ("contentTimeout", `Int 9)
+              ]
+          in
+          match Tool_misc.dispatch ctx ~name:"masc_web_search" ~args with
+          | Some result ->
+              assert (Tool_result.is_success result);
+              let json = parse_json (Tool_result.message result) in
+              let open Yojson.Safe.Util in
+              let result_json = json |> member "result" in
+              assert (result_json |> member "content_enriched" |> to_bool);
+              assert (result_json |> member "content_result_count" |> to_int = 1);
+              assert (result_json |> member "content_error_count" |> to_int = 0);
+              assert (result_json |> member "content_max_chars" |> to_int = 300);
+              assert (result_json |> member "content_timeout" |> to_int = 9);
+              let hits = result_json |> member "results" |> to_list in
+              assert (List.length hits = 1);
+              let hit = List.hd hits in
+              assert (hit |> member "page_content_status" |> to_string = "ok");
+              assert (hit |> member "page_content_http_status" |> to_int = 200);
+              assert (hit |> member "page_content_truncated" |> to_bool = false);
+              assert
+                (str_contains
+                   (hit |> member "page_content" |> to_string)
+                   "# Result Page");
+              assert
+                (str_contains
+                   (hit |> member "page_content" |> to_string)
+                   "Readable page content & proof.")
+          | None -> failwith "dispatch returned None"))
+)
+
+let () = test "dispatch_web_search_include_content_keeps_result_on_fetch_error" (fun () ->
+  let ctx = make_test_ctx () in
+  let query = "include content fetch failure regression" in
+  let url = "https://example.com/masc-web-search-fetch-failure" in
+  Tool_misc.with_web_search_simulation_for_test
+    ~outcomes:[ ("duckduckgo", `Hits [ ("Result", url, "Snippet") ]) ]
+    (fun () ->
+      Tool_misc.with_web_fetch_http_get_for_test
+        (fun ~timeout_sec:_ ~headers:_ ~max_response_bytes:_ url_arg ->
+           assert (url_arg = url);
+           Error "network unavailable")
+        (fun () ->
+          let args =
+            `Assoc
+              [ ("query", `String query)
+              ; ("limit", `Int 1)
+              ; ("includeContent", `Bool true)
+              ]
+          in
+          match Tool_misc.dispatch ctx ~name:"masc_web_search" ~args with
+          | Some result ->
+              assert (Tool_result.is_success result);
+              let json = parse_json (Tool_result.message result) in
+              let open Yojson.Safe.Util in
+              let result_json = json |> member "result" in
+              assert (result_json |> member "content_enriched" |> to_bool);
+              assert (result_json |> member "content_result_count" |> to_int = 0);
+              assert (result_json |> member "content_error_count" |> to_int = 1);
+              let hit =
+                result_json |> member "results" |> to_list |> List.hd
+              in
+              assert (hit |> member "page_content_status" |> to_string = "error");
+              assert
+                (str_contains
+                   (hit |> member "page_content" |> to_string)
+                   "_Failed to retrieve page content:");
+              assert
+                (str_contains
+                   (hit |> member "page_content" |> to_string)
+                   ("Source: " ^ url))
+          | None -> failwith "dispatch returned None"))
+)
+
 let () = test "parse_official_provider_json_payloads" (fun () ->
   let brave =
     Tool_misc.parse_brave_json


### PR DESCRIPTION
## Summary
- add optional `WebSearch` `includeContent` enrichment that fetches readable `page_content` for each result through the existing `WebFetch` path
- expose `includeContent`/`contentMaxChars`/`contentTimeout` in the web-search descriptor, keeper prompts, and docs
- keep `WebSearch` provider lookup and `WebFetch` single-URL reading separate, with best-effort per-result failure notes
- keep keeper-facing web aliases as MASC-owned `WebSearch` / `WebFetch`; backend names remain `masc_web_search` / `masc_web_fetch`
- update keeper readiness and legacy-name ratchets so OAS-owned web/team tool ids do not leak back into MASC prompts/tests

## Related
- OAS boundary cleanup: https://github.com/jeong-sik/oas/pull/2031 removed web-search/fetch from OAS builtin `Tool_id` ownership.
- OAS follow-up cleanup: https://github.com/jeong-sik/oas/pull/2032 removed remaining active OAS web-tool-id mentions.
- OAS team cleanup: https://github.com/jeong-sik/oas/pull/2034 removed `Team_create` / `Team_delete` from OAS builtin `Tool_id` ownership.

## Evidence
- OpenClaw `web_search` exposes provider-backed normalized/cached search controls; `web_fetch` separately handles bounded extraction and SSRF-guarded fetches. Checked 2026-06-12 KST: https://raw.githubusercontent.com/openclaw/openclaw/main/src/agents/tools/web-search.ts and https://raw.githubusercontent.com/openclaw/openclaw/main/src/agents/tools/web-fetch.ts
- Kindly `web_search` returns title/link/snippet/page_content in one call and `get_content` handles a selected URL. Checked 2026-06-12 KST: https://raw.githubusercontent.com/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server/main/README.md and https://raw.githubusercontent.com/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server/main/src/kindly_web_search_mcp_server/server.py

## Local checks
- `git diff --check`
- `python3 -m pytest test/test_audit_keeper_fleet_readiness.py`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md`
- `env DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build @test/runtest-test_runtime_config_validity`
- Earlier focused checks before the final base rebase: `scripts/dune-local.sh build test/test_tool_misc_coverage.exe test/test_tool_call_quality_benchmark.exe`, `./_build/default/test/test_tool_misc_coverage.exe`, `./_build/default/test/test_tool_call_quality_benchmark.exe`, `bash scripts/ci/check-determinism-contract.sh`, `bash scripts/ci/check-enum-string-safety.sh`, `bash scripts/ci/check-silent-failure-patterns.sh`, `bash scripts/ci/check-masc-oas-boundary.sh`

## CI status
- Latest MASC CI run `27413791829` succeeded for head `6d9bfcd7b`.
- `gh pr checks 20999` reports no non-success/non-skipped checks.

## Known local environment note
- Plain local Dune wrapper invocations can still stop at local opam pin drift; focused Dune checks above used `MASC_SKIP_PIN_CHECK=1`, and CI validated the PR on a clean runner.
