### PR TITLE
feat(keeper): RFC-0233 PR-4 — turn inspector block-diff + OTel span attrs

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2634,6 +2634,150 @@ export function fetchKeeperToolCalls(
   })
 }
 
+// ── Keeper turn records (RFC-0233 PR-4) ─────────────────
+
+export type TurnBlock = {
+  block: string
+  bytes: number
+  digest: string
+}
+
+export type TurnRecordEntry = {
+  execution_ids: string[]
+  keeper: string
+  trace_id: string
+  absolute_turn: number
+  blocks: TurnBlock[]
+  runtime_profile: string
+  temperature?: number
+  thinking_budget?: number
+  enable_thinking?: boolean
+  input_tokens?: number
+  output_tokens?: number
+  ts: number
+}
+
+export type TurnBlockDiff = {
+  added: TurnBlock[]
+  removed: TurnBlock[]
+  changed: { prev: TurnBlock; next: TurnBlock }[]
+}
+
+export type TurnRecordRow = {
+  record: TurnRecordEntry
+  // null on the first record of a trace (no same-trace predecessor)
+  diff_vs_prev: TurnBlockDiff | null
+}
+
+export type TurnRecordsResponse = TelemetryFreshnessMetadata & {
+  keeper: string
+  count: number
+  // malformed JSONL rows the server refused to decode (never repaired)
+  skipped_rows: number
+  entries: TurnRecordRow[]
+}
+
+function decodeTurnBlock(raw: unknown): TurnBlock | null {
+  if (!isRecord(raw)) return null
+  const block = asString(raw.block)
+  const digest = asString(raw.digest)
+  const bytes = asNumber(raw.bytes)
+  if (!block || !digest || bytes == null) return null
+  return { block, bytes, digest }
+}
+
+function decodeTurnBlockList(raw: unknown): TurnBlock[] {
+  return asRecordArray(raw)
+    .map(decodeTurnBlock)
+    .filter((block): block is TurnBlock => block !== null)
+}
+
+function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
+  if (!isRecord(raw)) return null
+  const keeper = asString(raw.keeper)
+  const trace_id = asString(raw.trace_id)
+  const absolute_turn = asNumber(raw.absolute_turn)
+  const runtime_profile = asString(raw.runtime_profile)
+  const ts = asNumber(raw.ts)
+  if (!keeper || !trace_id || absolute_turn == null || !runtime_profile || ts == null) {
+    return null
+  }
+  const execution_ids = Array.isArray(raw.execution_ids)
+    ? raw.execution_ids.filter((id): id is string => typeof id === 'string')
+    : []
+  return {
+    execution_ids,
+    keeper,
+    trace_id,
+    absolute_turn,
+    blocks: decodeTurnBlockList(raw.blocks),
+    runtime_profile,
+    temperature: asNumber(raw.temperature),
+    thinking_budget: asNumber(raw.thinking_budget),
+    enable_thinking: typeof raw.enable_thinking === 'boolean' ? raw.enable_thinking : undefined,
+    input_tokens: asNumber(raw.input_tokens),
+    output_tokens: asNumber(raw.output_tokens),
+    ts,
+  }
+}
+
+function decodeTurnBlockDiff(raw: unknown): TurnBlockDiff | null {
+  if (!isRecord(raw)) return null
+  const changed = asRecordArray(raw.changed)
+    .map((pair) => {
+      const prev = decodeTurnBlock(pair.prev)
+      const next = decodeTurnBlock(pair.next)
+      return prev && next ? { prev, next } : null
+    })
+    .filter((pair): pair is { prev: TurnBlock; next: TurnBlock } => pair !== null)
+  return {
+    added: decodeTurnBlockList(raw.added),
+    removed: decodeTurnBlockList(raw.removed),
+    changed,
+  }
+}
+
+function decodeTurnRecordRow(raw: unknown): TurnRecordRow | null {
+  if (!isRecord(raw)) return null
+  const record = decodeTurnRecordEntry(raw.record)
+  if (!record) return null
+  return {
+    record,
+    diff_vs_prev: decodeTurnBlockDiff(raw.diff_vs_prev),
+  }
+}
+
+function decodeTurnRecordsResponse(raw: unknown): TurnRecordsResponse | null {
+  if (!isRecord(raw)) return null
+  const keeper = asString(raw.keeper)
+  if (!keeper) return null
+  return {
+    ...decodeTelemetryFreshnessMetadata(raw),
+    keeper,
+    count: asNumber(raw.count, 0),
+    skipped_rows: asNumber(raw.skipped_rows, 0),
+    entries: asRecordArray(raw.entries)
+      .map(decodeTurnRecordRow)
+      .filter((row): row is TurnRecordRow => row !== null),
+  }
+}
+
+export function fetchKeeperTurnRecords(
+  name: string,
+  limit?: number,
+  opts?: AbortableRequestOptions,
+): Promise<TurnRecordsResponse> {
+  const params = limit != null ? `?limit=${limit}` : ''
+  return get<Record<string, unknown>>(
+    `/api/v1/keepers/${encodeURIComponent(name)}/turn-records${params}`,
+    { signal: opts?.signal },
+  ).then((raw) => {
+    const decoded = decodeTurnRecordsResponse(raw)
+    if (!decoded) throw new Error('유효하지 않은 keeper turn record payload')
+    return decoded
+  })
+}
+
 // ── Unified telemetry ──────────────────────────────────
 
 export type TelemetrySource =

--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -47,6 +47,7 @@ import { SessionTraceView } from './session-trace/session-trace-view'
 import { KeeperToolTelemetry } from './keeper-tool-telemetry'
 import { KeeperEvalQualityPanel } from './keeper-eval-quality'
 import { KeeperToolCallInspector } from './keeper-tool-call-inspector'
+import { KeeperTurnInspector } from './keeper-turn-inspector'
 import { SupervisorDiagnosticsPanel } from './keeper-supervisor-diagnostics'
 import { KeeperBDIPanel } from './keeper-bdi-panel'
 import { KeeperConfigPanel } from './keeper-config-panel'
@@ -215,6 +216,10 @@ export function KeeperDetailBody({
               <div class="pt-3 border-t border-[var(--color-border-divider)]">
                 <${SectionHeader} size="xs" class="mb-3">호출 검사기</${SectionHeader}>
                 ${diagOpen ? html`<${KeeperToolCallInspector} keeperName=${keeper.name} />` : null}
+              </div>
+              <div class="pt-3 border-t border-[var(--color-border-divider)]">
+                <${SectionHeader} size="xs" class="mb-3">턴 검사기 (컨텍스트 블록 diff)</${SectionHeader}>
+                ${diagOpen ? html`<${KeeperTurnInspector} keeperName=${keeper.name} />` : null}
               </div>
             </div>
           <//>

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -1,0 +1,203 @@
+// Keeper Turn Inspector (RFC-0233 PR-4) — one row per keeper turn from
+// GET /api/v1/keepers/:name/turn-records, with the server-computed
+// block diff between consecutive turns of the same trace. Answers the
+// operator question "which instruction blocks entered, left, or changed
+// between turns" without reading source.
+
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import { fetchKeeperTurnRecords } from '../api/dashboard'
+import type {
+  TurnBlock,
+  TurnBlockDiff,
+  TurnRecordRow,
+  TurnRecordsResponse,
+  TelemetryFreshnessMetadata,
+} from '../api/dashboard'
+import { formatTimeHms } from '../lib/format-time'
+import { LoadingState } from './common/feedback-state'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
+import { coverageGapDisplay, sourceHealthClass, freshnessText } from './common/source-health'
+
+function FreshnessLine({ data }: { data: TelemetryFreshnessMetadata }) {
+  const gap = coverageGapDisplay(data)
+  return html`
+    <div class="text-3xs text-[var(--color-fg-disabled)]">
+      <span class="font-mono">${data.source ?? '(unknown source)'}</span>
+      <span class="mx-1" aria-hidden="true">·</span>
+      <span class="font-mono ${sourceHealthClass(data.health)}">${data.health ?? 'unknown'}</span>
+      <span class="mx-1" aria-hidden="true">·</span>
+      <span>${freshnessText(data)}</span>
+      ${gap ? html`<span class="mx-1" aria-hidden="true">·</span><span>${gap}</span>` : null}
+    </div>
+  `
+}
+
+function BlockRow({ block }: { block: TurnBlock }) {
+  return html`
+    <div class="flex items-center gap-2 text-2xs font-mono">
+      <span class="text-[var(--color-fg-default)]">${block.block}</span>
+      <span class="text-[var(--color-fg-muted)]">${block.bytes}B</span>
+      <span class="text-[var(--color-fg-disabled)]" title=${block.digest}>
+        ${block.digest.slice(0, 12)}
+      </span>
+    </div>
+  `
+}
+
+function DiffSection({ diff }: { diff: TurnBlockDiff }) {
+  const empty =
+    diff.added.length === 0 && diff.removed.length === 0 && diff.changed.length === 0
+  if (empty) {
+    return html`<div class="text-2xs text-[var(--color-fg-disabled)]">이전 턴과 블록 변화 없음</div>`
+  }
+  return html`
+    <div class="space-y-1">
+      ${diff.added.map(block => html`
+        <div class="flex items-center gap-2 text-2xs font-mono text-[var(--color-status-ok)]">
+          <span>+</span>
+          <span>${block.block}</span>
+          <span class="opacity-70">${block.bytes}B</span>
+        </div>
+      `)}
+      ${diff.removed.map(block => html`
+        <div class="flex items-center gap-2 text-2xs font-mono text-[var(--color-status-err)]">
+          <span>−</span>
+          <span>${block.block}</span>
+          <span class="opacity-70">${block.bytes}B</span>
+        </div>
+      `)}
+      ${diff.changed.map(({ prev, next }) => html`
+        <div class="flex items-center gap-2 text-2xs font-mono text-[var(--color-status-warn)]">
+          <span>Δ</span>
+          <span>${next.block}</span>
+          <span class="opacity-70">${prev.bytes}B → ${next.bytes}B</span>
+          <span class="opacity-50" title="${prev.digest} → ${next.digest}">
+            ${prev.digest.slice(0, 8)} → ${next.digest.slice(0, 8)}
+          </span>
+        </div>
+      `)}
+    </div>
+  `
+}
+
+function TurnRow({ row }: { row: TurnRecordRow }) {
+  const record = row.record
+  const tokens =
+    record.input_tokens != null || record.output_tokens != null
+      ? `${record.input_tokens ?? '?'}→${record.output_tokens ?? '?'} tok`
+      : null
+  const sampling = [
+    record.temperature != null ? `t=${record.temperature}` : null,
+    record.thinking_budget != null ? `think=${record.thinking_budget}` : null,
+    record.enable_thinking === false ? 'no-think' : null,
+  ].filter(Boolean)
+
+  return html`
+    <details class="rounded-[var(--r-1)] hover:bg-[var(--color-bg-surface)] transition-colors">
+      <summary class="list-none cursor-pointer flex items-center gap-2 py-1.5 px-2 flex-wrap">
+        <span class="text-xs font-mono font-medium text-[var(--color-fg-default)]">
+          T${record.absolute_turn}
+        </span>
+        <span class="text-3xs text-[var(--color-fg-disabled)]">${formatTimeHms(record.ts)}</span>
+        <span class="text-3xs font-mono text-[var(--color-fg-muted)]">${record.runtime_profile}</span>
+        ${tokens ? html`<span class="text-3xs font-mono text-[var(--color-fg-muted)]">${tokens}</span>` : null}
+        ${sampling.length > 0
+          ? html`<span class="text-3xs font-mono text-[var(--color-fg-disabled)]">${sampling.join(' ')}</span>`
+          : null}
+        <span class="text-3xs text-[var(--color-fg-disabled)]">
+          블록 ${record.blocks.length} · 도구 ${record.execution_ids.length}
+        </span>
+        ${row.diff_vs_prev
+          && (row.diff_vs_prev.added.length > 0
+            || row.diff_vs_prev.removed.length > 0
+            || row.diff_vs_prev.changed.length > 0)
+          ? html`<span class="text-3xs font-mono text-[var(--color-status-warn)]">
+              +${row.diff_vs_prev.added.length} −${row.diff_vs_prev.removed.length} Δ${row.diff_vs_prev.changed.length}
+            </span>`
+          : null}
+      </summary>
+      <div class="px-3 pb-2 space-y-2">
+        <div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)] mb-1">
+            컨텍스트 블록 (조립 순서)
+          </div>
+          ${record.blocks.length === 0
+            ? html`<div class="text-2xs text-[var(--color-fg-disabled)]">기록된 블록 없음</div>`
+            : record.blocks.map(block => html`<${BlockRow} block=${block} />`)}
+        </div>
+        <div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)] mb-1">
+            이전 턴 대비
+          </div>
+          ${row.diff_vs_prev
+            ? html`<${DiffSection} diff=${row.diff_vs_prev} />`
+            : html`<div class="text-2xs text-[var(--color-fg-disabled)]">같은 trace의 이전 턴 없음</div>`}
+        </div>
+        ${record.execution_ids.length > 0
+          ? html`
+            <div>
+              <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)] mb-1">
+                execution_ids
+              </div>
+              <div class="text-2xs font-mono text-[var(--color-fg-muted)] break-all">
+                ${record.execution_ids.join(', ')}
+              </div>
+            </div>
+          `
+          : null}
+      </div>
+    </details>
+  `
+}
+
+export function KeeperTurnInspector({ keeperName }: { keeperName: string }) {
+  const resource = useManagedAsyncResource<TurnRecordsResponse | null>(null)
+
+  useEffect(() => {
+    void resource.load(async (signal) => {
+      return await fetchKeeperTurnRecords(keeperName, 50, { signal })
+    })
+    return () => {
+      resource.cancel()
+    }
+  }, [keeperName, resource])
+
+  const response = resource.state.value.data
+
+  if (resource.state.value.loading) {
+    return html`<${LoadingState}>턴 레코드 불러오는 중...<//>`
+  }
+
+  if (resource.state.value.error) {
+    return html`<div class="text-xs text-[var(--color-status-err)] p-4" role="alert">${resource.state.value.error}</div>`
+  }
+
+  const rows = response?.entries ?? []
+
+  if (rows.length === 0) {
+    return html`
+      <div class="p-4 space-y-1">
+        <div class="text-xs text-[var(--color-fg-muted)]">턴 레코드 없음 (서버 재시작 이후 keeper 턴부터 기록됩니다)</div>
+        <${FreshnessLine} data=${response ?? { source: 'turn_record' }} />
+      </div>
+    `
+  }
+
+  // Server returns oldest-first; show newest first.
+  const sorted = [...rows].reverse()
+
+  return html`
+    <div class="p-2 space-y-1">
+      <div class="flex items-center justify-between px-1">
+        <${FreshnessLine} data=${response} />
+        ${response && response.skipped_rows > 0
+          ? html`<span class="text-3xs text-[var(--color-status-warn)]">
+              malformed ${response.skipped_rows}행 제외됨
+            </span>`
+          : null}
+      </div>
+      ${sorted.map(row => html`<${TurnRow} key=${`${row.record.trace_id}-${row.record.absolute_turn}`} row=${row} />`)}
+    </div>
+  `
+}

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -703,5 +703,28 @@ let run_turn
           ~usage
           ~execution_ids
           ~blocks:acc.prompt_blocks
+          ();
+        (* RFC-0233 §2.3 PR-4: project the same record onto the ambient
+           turn span. Both turn drivers (unified "invoke_agent <keeper>"
+           and direct "keeper_turn") keep their span open across this
+           tail on the same fiber, so one add_attrs covers both. The
+           OTel value type has no array — blocks serialize through the
+           Turn_record codec (single encoding SSOT), execution ids join
+           with commas. *)
+        Otel_spans.add_attrs
+          ~attrs:
+            [ ( Otel_genai.Attr_key.masc_turn_blocks
+              , `String
+                  (Yojson.Safe.to_string
+                     (`List
+                        (List.map Turn_record.prompt_block_to_json
+                           acc.prompt_blocks))) )
+            ; ( Otel_genai.Attr_key.masc_turn_profile
+              , `String runtime_id_string )
+            ; ( Otel_genai.Attr_key.masc_turn_execution_ids
+              , `String
+                  (String.concat ","
+                     (List.map Ids.Execution_id.to_string execution_ids)) )
+            ]
           ());
        receipt_result)

--- a/lib/otel_genai/otel_genai.ml
+++ b/lib/otel_genai/otel_genai.ml
@@ -71,6 +71,14 @@ module Attr_key = struct
     register Masc_extension "masc.gen_ai.response.finish_reason"
   ;;
 
+  (* RFC-0233 §2.3 - per-turn TurnRecord projection onto the turn span. *)
+  let masc_turn_blocks = register Masc_extension "masc.turn.blocks"
+  let masc_turn_profile = register Masc_extension "masc.turn.profile"
+
+  let masc_turn_execution_ids =
+    register Masc_extension "masc.turn.execution_ids"
+  ;;
+
   let keeper_name = register Legacy "keeper.name"
   let keeper_agent_name = register Legacy "keeper.agent_name"
   let keeper_trace_id = register Legacy "keeper.trace_id"

--- a/lib/otel_genai/otel_genai.mli
+++ b/lib/otel_genai/otel_genai.mli
@@ -22,6 +22,9 @@ module Attr_key : sig
   val masc_gen_ai_keeper_name : string
   val masc_gen_ai_runtime_id : string
   val masc_gen_ai_response_finish_reason : string
+  val masc_turn_blocks : string
+  val masc_turn_profile : string
+  val masc_turn_execution_ids : string
   val keeper_name : string
   val keeper_agent_name : string
   val keeper_trace_id : string

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -311,6 +311,109 @@ let handle_keeper_get_subroutes state req request reqd =
         ("entries", `List entries);
       ] in
       Http.Response.json_value ~compress:true ~request:req json reqd
+  else if ends_with "/turn-records" then
+    (* RFC-0233 §2.3 PR-4: serve TurnRecords with server-side
+       consecutive-pair block diffs so the dashboard stays a renderer
+       of the tested OCaml diff (views derive; no view-side repair). *)
+    let name = extract_name "/turn-records" in
+    if String.length name = 0 then
+      respond_error reqd "keeper name is required"
+    else if not (Keeper_config.validate_name name) then
+      Http.Response.json_value ~status:`Bad_request
+        (`Assoc
+           [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])
+        reqd
+    else
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:50
+        |> max 1 |> min trajectory_max_limit
+      in
+      let config = state.Mcp_server.workspace_config in
+      let store = Keeper_types_support.keeper_turn_record_store config name in
+      let raw_rows = Dated_jsonl.read_recent store limit in
+      (* Strict decode: malformed rows are counted and reported, never
+         repaired or silently dropped (RFC-0233 §4). *)
+      let records_rev, skipped_rows =
+        List.fold_left
+          (fun (acc, skipped) json ->
+            match Turn_record.of_json json with
+            | Ok record -> (record :: acc, skipped)
+            | Error _ -> (acc, skipped + 1))
+          ([], 0) raw_rows
+      in
+      let records = List.rev records_rev in
+      let block_json = Turn_record.prompt_block_to_json in
+      let entries =
+        Turn_record.entries_with_diffs records
+        |> List.map (fun ((record : Turn_record.t), diff) ->
+             let diff_vs_prev =
+               match diff with
+               | Some (d : Turn_record.block_diff) ->
+                 `Assoc
+                   [ ("added", `List (List.map block_json d.added))
+                   ; ("removed", `List (List.map block_json d.removed))
+                   ; ( "changed"
+                     , `List
+                         (List.map
+                            (fun (prev_b, next_b) ->
+                              `Assoc
+                                [ ("prev", block_json prev_b)
+                                ; ("next", block_json next_b)
+                                ])
+                            d.changed) )
+                   ]
+               | None -> `Null
+             in
+             `Assoc
+               [ ("record", Turn_record.to_json record)
+               ; ("diff_vs_prev", diff_vs_prev)
+               ])
+      in
+      let latest_ts =
+        List.fold_left
+          (fun acc (r : Turn_record.t) ->
+            match acc with
+            | Some existing when existing >= r.ts -> acc
+            | _ -> Some r.ts)
+          None records
+      in
+      let latest_age_s =
+        match latest_ts with
+        | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
+        | None -> None
+      in
+      let health, stale_reason =
+        match latest_age_s with
+        | None -> ("empty", "no_entries")
+        | Some age when age > freshness_slo_s ->
+            ("stale", "freshness_slo_exceeded")
+        | Some _ -> ("ok", "")
+      in
+      let json = `Assoc [
+        ("keeper", `String name);
+        ("count", `Int (List.length records));
+        ("skipped_rows", `Int skipped_rows);
+        ("source", `String "turn_record");
+        ("producer", `String "keeper_agent_run.run_turn|keeper_turn_record_writer");
+        ( "durable_store",
+          `String
+            (Filename.concat
+               (Workspace.masc_root_dir config)
+               (Printf.sprintf "keepers/%s/turn-records" name)) );
+        ("dashboard_surface", `String "/api/v1/keepers/:name/turn-records");
+        ("freshness_slo_s", `Float freshness_slo_s);
+        ("latest_ts_unix", Json_util.float_opt_to_json latest_ts);
+        ( "latest_ts_iso",
+          match latest_ts with
+          | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
+          | None -> `Null );
+        ("latest_age_s", Json_util.float_opt_to_json latest_age_s);
+        ("health", `String health);
+        ( "stale_reason",
+          if stale_reason = "" then `Null else `String stale_reason );
+        ("entries", `List entries);
+      ] in
+      Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/trajectory" then
     let name = extract_name "/trajectory" in
     if String.length name = 0 then

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -198,3 +198,20 @@ let diff_blocks ~(prev : t) ~(next : t) : block_diff =
       next_blocks
   in
   { added; removed; changed }
+
+let entries_with_diffs (records : t list) : (t * block_diff option) list =
+  (* A diff is only meaningful against the previous record of the SAME
+     trace: a generation boundary legitimately replaces the whole
+     assembly, and that diff would be noise rather than signal. *)
+  let rec walk prev = function
+    | [] -> []
+    | record :: rest ->
+        let diff =
+          match prev with
+          | Some p when String.equal p.trace_id record.trace_id ->
+              Some (diff_blocks ~prev:p ~next:record)
+          | Some _ | None -> None
+        in
+        (record, diff) :: walk (Some record) rest
+  in
+  walk None records

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -40,6 +40,8 @@ type t =
   ; ts : float
   }
 
+val prompt_block_to_json : prompt_block -> Yojson.Safe.t
+
 val to_json : t -> Yojson.Safe.t
 
 val of_json : Yojson.Safe.t -> (t, string) result
@@ -58,3 +60,8 @@ type block_diff =
 val diff_blocks : prev:t -> next:t -> block_diff
 (** Blocks are keyed by [block] id; assembly produces at most one block
     per id, so first occurrence wins if a malformed row repeats one. *)
+
+val entries_with_diffs : t list -> (t * block_diff option) list
+(** Pair each record (oldest-first) with its diff against the previous
+    record of the same trace; [None] at trace boundaries, where the
+    whole assembly legitimately changes and a diff would be noise. *)

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -160,6 +160,41 @@ let test_diff_identical_records_is_empty () =
   check int "no removed" 0 (List.length diff.removed);
   check int "no changed" 0 (List.length diff.changed)
 
+let test_entries_with_diffs_same_trace_only () =
+  let r1 =
+    { (record_with_blocks [ sample_block Prompt_block_id.Persona "aaaa" ]) with
+      trace_id = "trace-A"
+    ; absolute_turn = 1
+    }
+  in
+  let r2 =
+    { (record_with_blocks
+         [ sample_block Prompt_block_id.Persona "aaaa"
+         ; sample_block Prompt_block_id.Retry_nudge "rrrr"
+         ])
+      with
+      trace_id = "trace-A"
+    ; absolute_turn = 2
+    }
+  in
+  let r3 =
+    { (record_with_blocks [ sample_block Prompt_block_id.Persona "zzzz" ]) with
+      trace_id = "trace-B" (* new generation: diff must be None *)
+    ; absolute_turn = 3
+    }
+  in
+  match Turn_record.entries_with_diffs [ r1; r2; r3 ] with
+  | [ (_, first); (_, second); (_, third) ] ->
+    check bool "first record has no predecessor" true (first = None);
+    (match second with
+     | Some diff ->
+       check (list block_id) "same-trace diff sees the added nudge"
+         [ Prompt_block_id.Retry_nudge ]
+         (List.map (fun (b : Turn_record.prompt_block) -> b.block) diff.added)
+     | None -> fail "expected a diff for the same-trace successor");
+    check bool "trace boundary yields no diff" true (third = None)
+  | _ -> fail "expected three paired entries"
+
 let () =
   run "turn_record"
     [ ( "prompt_block_id"
@@ -178,5 +213,7 @@ let () =
             test_diff_added_removed_changed
         ; test_case "identical records diff empty" `Quick
             test_diff_identical_records_is_empty
+        ; test_case "entries_with_diffs pairs same-trace only" `Quick
+            test_entries_with_diffs_same_trace_only
         ] )
     ]


### PR DESCRIPTION
## 무엇

RFC-0233 §4 마이그레이션의 **마지막 조각** — PR-3가 만든 TurnRecord 스토어의 소비자 2종. §2.3 원칙 그대로: **views derive, 읽기 쪽에서 새로 계산하지 않음**.

## OTel (§2.3)

- TurnRecord write 지점에서 같은 레코드를 ambient turn span에 투영: `masc.turn.blocks`(Turn_record codec 경유 JSON — OTel 값 타입에 배열이 없어 직렬화 SSOT 재사용), `masc.turn.profile`, `masc.turn.execution_ids`(comma-join)
- 탐색으로 검증: 양 턴 드라이버(unified `invoke_agent <keeper>` / direct `keeper_turn`) 모두 run_turn tail까지 같은 fiber에서 span을 열어두므로 **add_attrs 한 번으로 양쪽 커버**
- 키는 `Attr_key` registry에 `Masc_extension`으로 등록 (partition 테스트 자동 충족)
- RFC 스케치의 단수 `masc.execution_id`는 멀티-콜 턴에 맞지 않아 `masc.turn.execution_ids`로 — 본문에 명시한 의도적 조정

## 서버

- `GET /api/v1/keepers/:name/turn-records` — /tool-calls 미러 (limit 50/cap 500, freshness envelope)
- 행은 **strict decode**: malformed는 `skipped_rows`로 보고, 수리·무시 안 함 (RFC §4)
- 연속 쌍 block diff를 서버에서 `Turn_record.entries_with_diffs`로 계산 — **같은 trace끼리만** 페어링 (세대 경계는 조립 전체가 바뀌는 게 정상이라 diff가 노이즈)

## 대시보드

- `KeeperTurnInspector` — 런타임 진단 섹션, 도구 호출 검사기 옆
- 행: `T<absolute_turn>` · 시각 · profile · 토큰 · 샘플링 칩 · `+N −N ΔN` diff 요약 / 펼침: 조립 순서 블록 표, 이전 턴 대비 diff, execution_ids
- 빈 상태에 "서버 재시작 이후 턴부터 기록" 명시 (스토어는 PR-3 배포 후 생성)

## 검증

- `test_turn_record` **9/9** (신규: same-trace만 페어링 + trace 경계 None)
- lib 빌드 clean — 단, **pre-existing #20982 결함(#20994 in-flight)** 적용 후 기준; 그것 없이는 @check가 그 한 건으로만 실패
- 대시보드: tsc 0, eslint 0, keeper 컴포넌트 vitest **501/501**

## 머지 전 필요

1. #20994 + #20997 (broken main 4번째의 두 절반) — 이후 이 PR rerun
2. 효력은 masc 서버 재시작 + 대시보드 빌드 후. 재시작 후 keeper 턴 2개부터 diff가 보입니다 — 제가 라이브 검증하겠습니다

Refs RFC-0233 §2.3 §4 — **PR-1(#20968)→2a(#20975)→2b(#20985)→3(#20995)→4 마이그레이션 완결.** #20910/#20936 계보 종료.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
