### PR TITLE
fix(keeper): type transport failures in the chat lane (Row_kind)

### DIFF
--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -87,6 +87,35 @@ module Role = struct
     | (User | Assistant | Tool), _ -> false
 end
 
+(* What an assistant line *is*, declared by the writer at append time.
+   [Utterance] is something the keeper actually said; [Transport_failure]
+   is the server persisting a failed request terminal ("Keeper request
+   failed: ...") so the operator still sees the failure after a reload.
+   Readers branch on the type: a transport failure is not a self reply
+   (it must not advance the lane watermark — the user line it answered
+   stays pending and the keeper revisits it) and is never quoted back
+   as the keeper's own words. On disk the field is ["kind"], absent for
+   utterances so pre-existing rows read unchanged. *)
+module Row_kind = struct
+  type t =
+    | Utterance
+    | Transport_failure
+
+  let to_label = function
+    | Utterance -> "utterance"
+    | Transport_failure -> "transport_failure"
+
+  let of_label = function
+    | "utterance" -> Some Utterance
+    | "transport_failure" -> Some Transport_failure
+    | _ -> None
+
+  let equal a b =
+    match a, b with
+    | Utterance, Utterance | Transport_failure, Transport_failure -> true
+    | (Utterance | Transport_failure), _ -> false
+end
+
 type speaker_authority =
   | Owner
   | External
@@ -128,6 +157,12 @@ type chat_message = {
          (plus connector-provided explicit mentions); [] = none.  Rows
          written before P4 lack the field and read as []; the offline
          backfill tool stamps them. *)
+  kind : Row_kind.t;
+      (* Declared by the writer at append.  Absent field (every row
+         written before this field existed) reads as [Utterance]; an
+         unknown label is reported as a persistence read drop and the
+         row reads as [Utterance] (the conservative arm: it renders and
+         advances the watermark like any reply). *)
 }
 
 let redaction_for ~base_dir ~keeper_name =
@@ -161,7 +196,7 @@ let speaker_fields = function
 
 let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     ?tool_call_name ?surface ?conversation_id ?external_message_id ?speaker
-    ?(mentions = []) ()
+    ?(mentions = []) ?(kind = Row_kind.Utterance) ()
     : string =
   (* RFC-0232 P5: the label is a derivation of the typed surface — the
      single site that turns a [Surface_ref.t] into the legacy [source]
@@ -205,10 +240,19 @@ let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
         ) atts in
         [("attachments", `List att_json)]
   in
+  (* Utterance is the absent-field default so rows written before the
+     [kind] field existed and ordinary rows stay byte-identical. *)
+  let kind_field =
+    match kind with
+    | Row_kind.Utterance -> []
+    | Row_kind.Transport_failure ->
+        [ ("kind", `String (Row_kind.to_label kind)) ]
+  in
   let all_fields =
     base_fields
     @ attachment_fields
     @ mention_fields
+    @ kind_field
     @ opt_string_field "tool_call_id" tool_call_id
     @ opt_string_field "tool_call_name" tool_call_name
     @ opt_string_field "source" source
@@ -239,6 +283,7 @@ let user_line_mentions ~extra_mentions content =
 let append_turn ~base_dir ~keeper_name ~(user_content : string)
     ~(user_attachments : attachment list) ?(tool_calls = []) ?surface
     ?conversation_id ?external_message_id ?speaker ?(extra_mentions = [])
+    ?(assistant_kind = Row_kind.Utterance)
     ~(assistant_content : string)
     () =
   try
@@ -277,7 +322,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     in
     let asst_line =
       encode_line ~role:Role.Assistant ~content:assistant_content ~ts ?surface
-        ?conversation_id ()
+        ?conversation_id ~kind:assistant_kind ()
     in
     let payload =
       String.concat "\n" ((user_line :: tool_lines) @ [ asst_line ]) ^ "\n"
@@ -468,6 +513,24 @@ let parse_line ~file_path (line : string) : chat_message option =
             ~detail:"mentions field is not a list";
           []
     in
+    let kind =
+      (* Absent field = every row written before [kind] existed; all of
+         those are utterances. Unknown labels are surfaced and read as
+         [Utterance] — the conservative arm (renders and advances the
+         watermark like any reply) rather than silently resurrecting a
+         pending user line. *)
+      match opt_string "kind" with
+      | None -> Row_kind.Utterance
+      | Some label -> (
+          match Row_kind.of_label label with
+          | Some kind -> kind
+          | None ->
+              report_persistence_read_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                ~path:file_path
+                ~detail:(Printf.sprintf "unknown chat row kind %S" label);
+              Row_kind.Utterance)
+    in
     if role_label = "" || content = "" then (
       report_persistence_read_drop
         ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
@@ -495,7 +558,7 @@ let parse_line ~file_path (line : string) : chat_message option =
           Some
             { role; content; ts; attachments; tool_call_id; tool_call_name;
               source; surface; conversation_id; external_message_id; speaker;
-              mentions }
+              mentions; kind }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -91,11 +91,11 @@ end
    [Utterance] is something the keeper actually said; [Transport_failure]
    is the server persisting a failed request terminal ("Keeper request
    failed: ...") so the operator still sees the failure after a reload.
-   Readers branch on the type: a transport failure is not a self reply
-   (it must not advance the lane watermark — the user line it answered
-   stays pending and the keeper revisits it) and is never quoted back
-   as the keeper's own words. On disk the field is ["kind"], absent for
-   utterances so pre-existing rows read unchanged. *)
+   Readers branch on the type: a transport failure is not a self reply —
+   it does not advance the lane watermark, so the user line it failed to
+   answer stays pending until the keeper's next real utterance — and it
+   is never quoted back as the keeper's own words. On disk the field is
+   ["kind"], absent for utterances so pre-existing rows read unchanged. *)
 module Row_kind = struct
   type t =
     | Utterance
@@ -733,6 +733,13 @@ let to_json_array (messages : chat_message list) : Yojson.Safe.t =
             ] @ (match m.ts with
                  | Some t -> [("ts", `Float t)]
                  | None -> [])
+              (* Dashboard history: surface the writer-declared kind for
+                 non-utterance rows so a reload can tell a transport
+                 failure apart from keeper speech. *)
+              @ (match m.kind with
+                 | Row_kind.Utterance -> []
+                 | Row_kind.Transport_failure ->
+                     [ ("kind", `String (Row_kind.to_label m.kind)) ])
               @ opt_string_field "tool_call_id" m.tool_call_id
               @ opt_string_field "tool_call_name" m.tool_call_name
               @ opt_string_field "source" m.source

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -56,11 +56,11 @@ end
     [Transport_failure] is the server persisting a failed request
     terminal (["Keeper request failed: ..."]) so the operator still sees
     the failure after a reload — it is {e not} a self reply: it does not
-    advance the lane watermark (the user line it answered stays pending
-    and the keeper revisits it on its next turn) and observation never
-    quotes it back as the keeper's own words. Persisted as ["kind"];
-    the field is absent for utterances, so rows written before it
-    existed read unchanged. *)
+    advance the lane watermark, so the user line it failed to answer
+    stays pending until the keeper's next real utterance, and
+    observation never quotes it back as the keeper's own words.
+    Persisted as ["kind"]; the field is absent for utterances, so rows
+    written before it existed read unchanged. *)
 module Row_kind : sig
   type t =
     | Utterance

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -51,6 +51,26 @@ module Role : sig
   val equal : t -> t -> bool
 end
 
+(** What an assistant line {e is}, declared by the writer at append.
+    [Utterance] is something the keeper actually said.
+    [Transport_failure] is the server persisting a failed request
+    terminal (["Keeper request failed: ..."]) so the operator still sees
+    the failure after a reload — it is {e not} a self reply: it does not
+    advance the lane watermark (the user line it answered stays pending
+    and the keeper revisits it on its next turn) and observation never
+    quotes it back as the keeper's own words. Persisted as ["kind"];
+    the field is absent for utterances, so rows written before it
+    existed read unchanged. *)
+module Row_kind : sig
+  type t =
+    | Utterance
+    | Transport_failure
+
+  val to_label : t -> string
+  val of_label : string -> t option
+  val equal : t -> t -> bool
+end
+
 (** Authority class of the human (or agent) whose message opened a
     turn. Derived structurally from the arrival route, never from
     message content: the authenticated dashboard route is [Owner];
@@ -101,6 +121,12 @@ type chat_message = {
           and rows written before P4 (the offline backfill tool stamps
           those).  Malformed persisted entries are reported as
           persistence read drops and skipped; the row stays valid. *)
+  kind : Row_kind.t;
+      (** Declared by the writer at append.  Absent persisted field
+          (every row written before it existed) reads as [Utterance];
+          an unknown label is reported as a persistence read drop and
+          reads as [Utterance] — the conservative arm: the row renders
+          and advances the watermark like any reply. *)
 }
 
 (** {1 I/O} *)
@@ -113,8 +139,10 @@ type chat_message = {
     identifies the user-line author and is written on the user line
     only. [conversation_id] identifies the external conversation/thread
     coordinate and is written on all lines of the turn; [external_message_id]
-    belongs to the inbound user line only. Failures are logged but never raised except for
-    {!Eio.Cancel.Cancelled}. *)
+    belongs to the inbound user line only. [assistant_kind] declares what
+    the assistant line is (default [Utterance]); the failed-request
+    persistence path passes [Transport_failure]. Failures are logged but
+    never raised except for {!Eio.Cancel.Cancelled}. *)
 val append_turn :
   base_dir:string ->
   keeper_name:string ->
@@ -126,6 +154,7 @@ val append_turn :
   ?external_message_id:string ->
   ?speaker:speaker ->
   ?extra_mentions:Keeper_identity.Keeper_id.t list ->
+  ?assistant_kind:Row_kind.t ->
   assistant_content:string ->
   unit ->
   unit

--- a/lib/keeper/keeper_surface_read.ml
+++ b/lib/keeper/keeper_surface_read.ml
@@ -33,9 +33,19 @@ let message_json (m : Store.chat_message) : Yojson.Safe.t =
               `String (Store.authority_label sp.speaker_authority) );
           ]
   in
+  (* Surface the writer-declared kind for non-utterance rows so the
+     keeper reading its own lane sees a transport-failure marker as the
+     server's record of a failed request, not as something it said. *)
+  let kind_fields =
+    match m.kind with
+    | Store.Row_kind.Utterance -> []
+    | Store.Row_kind.Transport_failure ->
+        [ ("kind", `String (Store.Row_kind.to_label m.kind)) ]
+  in
   `Assoc
     ([ ("role", `String (Store.Role.to_label m.role));
        ("content", `String m.content) ]
+    @ kind_fields
     @ opt_float_field "ts" m.ts
     @ opt_string_field "source" m.source
     @ opt_string_field "conversation_id" m.conversation_id

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -70,8 +70,8 @@ let speaker_display (m : Keeper_chat_store.chat_message) : string =
    shared positional watermark for mentions and scope. Only an assistant
    *utterance* is a self reply; a [Transport_failure] row is the server
    persisting a failed request terminal — the keeper never answered, so
-   the user line stays pending and the keeper revisits it on its next
-   turn. *)
+   the user line stays pending until the keeper's next real utterance
+   (which, per positional semantics, clears every pending line). *)
 let user_lines_after_last_self (messages : Keeper_chat_store.chat_message list)
   : Keeper_chat_store.chat_message list
   =

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -67,14 +67,21 @@ let speaker_display (m : Keeper_chat_store.chat_message) : string =
    only adds the [Keeper_chat_store.load]. *)
 
 (* User lines after the keeper's last assistant line, in lane order. The
-   shared positional watermark for mentions and scope. *)
+   shared positional watermark for mentions and scope. Only an assistant
+   *utterance* is a self reply; a [Transport_failure] row is the server
+   persisting a failed request terminal — the keeper never answered, so
+   the user line stays pending and the keeper revisits it on its next
+   turn. *)
 let user_lines_after_last_self (messages : Keeper_chat_store.chat_message list)
   : Keeper_chat_store.chat_message list
   =
   List.fold_left
     (fun acc (m : Keeper_chat_store.chat_message) ->
       match m.role with
-      | Keeper_chat_store.Role.Assistant -> []
+      | Keeper_chat_store.Role.Assistant -> (
+        match m.kind with
+        | Keeper_chat_store.Row_kind.Utterance -> []
+        | Keeper_chat_store.Row_kind.Transport_failure -> acc)
       | Keeper_chat_store.Role.User -> m :: acc
       | Keeper_chat_store.Role.Tool -> acc)
     []

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -629,6 +629,10 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
     push_worker_event (Stream_event evt)
   in
   let persist_failure_reply err =
+    (* The failure marker is typed, not an utterance: it renders for the
+       operator but does not advance the lane watermark, so the user
+       message it failed to answer stays pending for the keeper's next
+       turn — and the keeper never reads the error as its own words. *)
     Keeper_chat_store.append_turn
       ~base_dir:base_path
       ~keeper_name:payload.name
@@ -637,6 +641,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
       ~tool_calls:(collected_tool_calls ())
       ~surface:chat_surface
       ~speaker:chat_speaker
+      ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
       ~assistant_content:(persisted_error_reply err)
       ();
     Keeper_chat_broadcast.chat_appended

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -610,6 +610,78 @@ let test_load_page_binary_search_large_file () =
         (content_no (List.hd (List.rev tail.K.messages)));
       Alcotest.(check bool) "tail has_more" true tail.K.has_more)
 
+(* ── Row_kind (typed transport-failure marker) ───────────── *)
+
+let test_failure_turn_kind_roundtrip () =
+  let base_dir = temp_base_path "keeper-chat-store-kind" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-kind" in
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:"ping"
+        ~user_attachments:[]
+        ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
+        ~assistant_kind:K.Row_kind.Transport_failure
+        ~assistant_content:"Keeper request failed: boom"
+        ();
+      match K.load ~base_dir ~keeper_name with
+      | [ user; asst ] ->
+          Alcotest.(check bool) "user row is an utterance" true
+            (K.Row_kind.equal user.kind K.Row_kind.Utterance);
+          Alcotest.(check bool) "assistant row is a transport failure" true
+            (K.Row_kind.equal asst.kind K.Row_kind.Transport_failure);
+          let raw = read_file (chat_path ~base_dir ~keeper_name) in
+          Alcotest.(check bool) "failure row persists the kind field" true
+            (contains_substring raw {|"kind":"transport_failure"|})
+      | messages ->
+          Alcotest.failf "expected 2 rows, got %d" (List.length messages))
+
+let test_kind_absent_reads_utterance () =
+  (* Every row written before the [kind] field existed is an utterance;
+     the writer also omits the field for utterances, so ordinary rows
+     stay byte-identical to the pre-[kind] format. *)
+  let base_dir = temp_base_path "keeper-chat-store-kind-absent" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-kind-absent" in
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:"hello" ~user_attachments:[]
+        ~assistant_content:"world" ();
+      let raw = read_file (chat_path ~base_dir ~keeper_name) in
+      Alcotest.(check bool) "utterance rows carry no kind field" false
+        (contains_substring raw {|"kind"|});
+      match K.load ~base_dir ~keeper_name with
+      | [ user; asst ] ->
+          Alcotest.(check bool) "user reads as utterance" true
+            (K.Row_kind.equal user.kind K.Row_kind.Utterance);
+          Alcotest.(check bool) "assistant reads as utterance" true
+            (K.Row_kind.equal asst.kind K.Row_kind.Utterance)
+      | messages ->
+          Alcotest.failf "expected 2 rows, got %d" (List.length messages))
+
+let test_unknown_kind_reported_reads_utterance () =
+  let base_dir = temp_base_path "keeper-chat-store-kind-unknown" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-kind-unknown" in
+      let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+      let before = drop_value invalid_payload in
+      let path = chat_path ~base_dir ~keeper_name in
+      write_file path
+        ({|{"role":"assistant","content":"hi","ts":1.0,"kind":"weird"}|} ^ "\n");
+      match K.load ~base_dir ~keeper_name with
+      | [ asst ] ->
+          Alcotest.(check bool)
+            "unknown kind reads as utterance (conservative arm)" true
+            (K.Row_kind.equal asst.kind K.Row_kind.Utterance);
+          Alcotest.(check (float 0.001)) "unknown kind reported" 1.0
+            (drop_value invalid_payload -. before)
+      | messages ->
+          Alcotest.failf "expected 1 row, got %d" (List.length messages))
+
 let () =
   Alcotest.run "keeper_chat_store"
     [
@@ -628,6 +700,15 @@ let () =
             test_tool_row_missing_name_dropped;
           Alcotest.test_case "unknown role row dropped (RFC-0232)" `Quick
             test_unknown_role_row_dropped;
+        ] );
+      ( "row_kind",
+        [
+          Alcotest.test_case "failure turn kind roundtrip" `Quick
+            test_failure_turn_kind_roundtrip;
+          Alcotest.test_case "absent kind reads utterance" `Quick
+            test_kind_absent_reads_utterance;
+          Alcotest.test_case "unknown kind reported, reads utterance" `Quick
+            test_unknown_kind_reported_reads_utterance;
         ] );
       ( "speaker_identity",
         [

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -43,7 +43,8 @@ let test_empty_targets () =
        (Lane.mention_ids_of_content "@dreamer"))
 ;;
 
-let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None) content
+let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None)
+    ?(kind = Store.Row_kind.Utterance) content
   : Store.chat_message
   =
   { role
@@ -58,6 +59,7 @@ let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None) content
   ; external_message_id = None
   ; speaker
   ; mentions = Masc.Keeper_lane_mentions.mention_ids_of_content content
+  ; kind
   }
 ;;
 
@@ -193,6 +195,7 @@ let tool_line : Store.chat_message =
   ; external_message_id = None
   ; speaker = None
   ; mentions = []
+  ; kind = Store.Row_kind.Utterance
   }
 ;;
 
@@ -204,6 +207,28 @@ let test_tool_lines_do_not_clear () =
   in
   check (list string) "tool line is not an answer" [ "@dreamer please look" ]
     (contents (MS.pending_mentions_of_messages ~targets messages))
+;;
+
+let test_transport_failure_does_not_clear () =
+  (* A transport-failure marker is the server recording a failed request
+     terminal ("Keeper request failed: ..."), not the keeper answering;
+     the user line stays pending so the keeper revisits it on its next
+     turn. A real utterance afterwards still clears. *)
+  let failure =
+    msg ~role:Store.Role.Assistant ~ts:(Some 10.5)
+      ~kind:Store.Row_kind.Transport_failure
+      "Keeper request failed: Idle detected"
+  in
+  let messages =
+    [ msg ~role:Store.Role.User ~ts:(Some 10.0) "@dreamer please look"; failure ]
+  in
+  check (list string) "failure marker is not an answer" [ "@dreamer please look" ]
+    (contents (MS.pending_mentions_of_messages ~targets messages));
+  let answered =
+    messages @ [ msg ~role:Store.Role.Assistant ~ts:(Some 11.0) "done" ]
+  in
+  check (list string) "a real utterance still clears" []
+    (contents (MS.pending_mentions_of_messages ~targets answered))
 ;;
 
 let test_assistant_append_empties_pending () =
@@ -262,6 +287,8 @@ let () =
         ; test_case "ts_fuzz_invariant" `Quick test_ts_fuzz_does_not_change_pending
         ; test_case "none_ts_assistant_clears" `Quick test_none_ts_assistant_still_clears
         ; test_case "tool_lines_do_not_clear" `Quick test_tool_lines_do_not_clear
+        ; test_case "transport_failure_does_not_clear" `Quick
+            test_transport_failure_does_not_clear
         ; test_case "assistant_append_empties_pending" `Quick
             test_assistant_append_empties_pending
         ] )

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -24,6 +24,7 @@ let msg ?ts ?source ?speaker ~role content : Store.chat_message =
     external_message_id = None;
     speaker;
     mentions = [];
+    kind = Store.Row_kind.Utterance;
   }
 
 let external_speaker ?name id : Store.speaker =


### PR DESCRIPTION
## 문제 (sangsu kmsg idle-kill RCA fix 3/3)

kmsg 실패 시 `"Keeper request failed: <detail>"`가 **일반 assistant 행**으로 lane에 영속됐습니다. 두 가지 결과:

1. **Self-echo 오염** — keeper가 다음 턴에 이 에러를 "자기가 한 말"로 읽음 (RFC-0232가 닫은 바로 그 계열). 2026-06-12 sangsu lane에 동일 에러 행 3건 적재 실측.
2. **Watermark 오전진** — 에러 행이 positional watermark를 전진시켜, **답변받지 못한 사용자 메시지가 "응답됨"으로 처리**되고 영영 재방문되지 않음 (`kmsg_sangsu_19` silent drop 실측).

## 변경 (RFC-0232 쓰기 경계 타이핑)

| 항목 | 내용 |
|---|---|
| `Row_kind` (신규) | `Utterance \| Transport_failure` — writer가 append 시점에 선언. wire `"kind"` 필드는 utterance에서 생략 → **기존 행·일반 쓰기 byte-identical** |
| `append_turn` | `?assistant_kind` (default `Utterance`); 실패 영속 경로만 `Transport_failure` 전달 |
| watermark (`user_lines_after_last_self`) | failure 행은 tool 행처럼 취급 — **사용자 행이 pending 유지 → keeper가 다음 턴에 재방문** (drop된 요청의 self-heal) |
| `keeper_surface_read` | failure 행에 `"kind"` 라벨 노출 — keeper가 자기 발화로 인용 불가 |
| 디코드 | absent → `Utterance`(pre-kind 행 전부 utterance, total 해석); unknown label → read-drop 보고 + `Utterance` (보수 arm, P2 선례) |
| 대시보드 | 실패 텍스트 렌더 유지 (행 자체는 계속 존재) |

## 검증

- `test_keeper_chat_store` 19/19 (신규 3: kind round-trip+on-disk 형태 / absent→Utterance / unknown→report+Utterance)
- `test_keeper_mention_scope` 21/21 (신규 1: failure 행은 pending 미해제, utterance는 해제)
- `test_keeper_surface_read` 9/9
- `scripts/dune-local.sh build lib lib/server` EXIT=0
- 로컬 빌드 시 main pre-existing dev-profile 깨짐은 #20994에서 별도 수정

## 관련

- RCA fix 1/3: jeong-sik/oas#2028 (nudge 직렬화 순서 → tool 결과 드랍)
- RCA fix 2/3: #20996 (kmsg max_idle_turns 미전달 → 사용자 채팅만 즉사)
- RFC-0232 (typed lane event model) 후속 — lane row의 의미를 writer가 닫힌 타입으로 선언

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
