### PR TITLE
chore(oas): pin agent_sdk 0.206.3 (idle-nudge ordering fix)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.206.2"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.206.3"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="2891ecc5771c991d57d87b68454cd8653f5740c1"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.206.2"
+readonly OAS_AGENT_SDK_SHA="5dccecb97576b4a58d0ea86a3ba335f49eabc5b0"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.206.3"


### PR DESCRIPTION
oas 0.206.3 pin bump — jeong-sik/oas#2028 (nudge가 tool 결과를 드랍시키는 직렬화 순서 결함 수정) 포함. sangsu kmsg idle-kill RCA 3종 중 fix 1/3의 런타임 전달분.

| 항목 | 값 |
|---|---|
| BASE_VERSION | v0.206.2 → v0.206.3 |
| SHA | `2891ecc5…` → `5dccecb97576b4a58d0ea86a3ba335f49eabc5b0` (oas main `chore(main): release 0.206.3 (#2029)`) |
| 0.206.2→0.206.3 변경 | #2022(중복 stream injection fix), #2023(GLM preserve thinking), #2028(idle nudge ordering) — 공개 API 시그니처 변경 없음 |

동반 masc-side 수정: #20996 (kmsg reactive idle budget), #21002 (typed transport-failure lane rows).

CI가 새 pin으로 전체 빌드를 판정합니다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
