### PR TITLE
fix(attempt_fsm): respect accept_on_exhaustion on Call_err path

### DIFF
--- a/lib/runtime/runtime_attempt_fsm.ml
+++ b/lib/runtime/runtime_attempt_fsm.ml
@@ -38,8 +38,6 @@ let decide ~accept_on_exhaustion ~is_last = function
   | Call_err err ->
     if (not is_last) && should_try_next err
     then Try_next { last_err = Some err }
-    else if is_last && accept_on_exhaustion
-    then Exhausted { last_err = None }
     else Exhausted { last_err = Some err }
 
 let decide_and_record ~runtime_id:_ ~accept_on_exhaustion ~is_last outcome =

--- a/lib/runtime/runtime_attempt_fsm.ml
+++ b/lib/runtime/runtime_attempt_fsm.ml
@@ -38,6 +38,8 @@ let decide ~accept_on_exhaustion ~is_last = function
   | Call_err err ->
     if (not is_last) && should_try_next err
     then Try_next { last_err = Some err }
+    else if is_last && accept_on_exhaustion
+    then Exhausted { last_err = None }
     else Exhausted { last_err = Some err }
 
 let decide_and_record ~runtime_id:_ ~accept_on_exhaustion ~is_last outcome =

--- a/test/test_runtime_attempt_fsm.ml
+++ b/test/test_runtime_attempt_fsm.ml
@@ -64,6 +64,16 @@ let test_decide_call_err_retryable_last () =
   | Exhausted { last_err = Some _ } -> ()
   | _ -> Alcotest.fail "retryable + last should yield Exhausted with last_err"
 
+let test_decide_call_err_accept_on_exhaustion_preserves_last_err () =
+  match
+    decide ~accept_on_exhaustion:true ~is_last:true
+      (Call_err (mk_http_err ~code:429 ()))
+  with
+  | Exhausted { last_err = Some _ } -> ()
+  | _ ->
+    Alcotest.fail
+      "accept_on_exhaustion should not discard the final Call_err"
+
 let test_decide_call_err_terminal_not_last () =
   match
     decide ~accept_on_exhaustion:false ~is_last:false
@@ -145,6 +155,8 @@ let () =
             test_decide_call_err_retryable_not_last
         ; Alcotest.test_case "retryable last" `Quick
             test_decide_call_err_retryable_last
+        ; Alcotest.test_case "accept_on_exhaustion preserves Call_err" `Quick
+            test_decide_call_err_accept_on_exhaustion_preserves_last_err
         ; Alcotest.test_case "terminal not-last" `Quick
             test_decide_call_err_terminal_not_last
         ; Alcotest.test_case "accept-rejected via Call_err" `Quick


### PR DESCRIPTION
## Summary

When `is_last && accept_on_exhaustion` and the last provider returns a `Call_err`, the `decide` function now returns `Exhausted { last_err = None }` instead of propagating the raw HTTP error.

## Context

The `Accept_rejected` branch (line 33-36) already handles this case correctly by returning `Exhausted { last_err = Some (AcceptRejected ...) }` when `is_last && accept_on_exhaustion`. The `Call_err` branch was missing this check.

## Change

`runtime_attempt_fsm.ml` lines 39-42: Added a guard so that when `is_last && accept_on_exhaustion`, the function returns `Exhausted { last_err = None }` instead of the raw error. The caller chain (`keeper_runtime_attempt` → `keeper_turn_driver_try_runtime`) already handles `last_err = None` gracefully via `to_user_message None` → "No providers available".

Ref: task-907 / RFC-0232 P5