### PR TITLE
feat(discord): reply when bound keeper is unavailable

### DIFF
--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -302,9 +302,7 @@ let handle_message_create ~dispatch
        (match gate_err with
         | Channel_gate.Dispatch_unavailable ->
           let notice =
-            Printf.sprintf
-              "⚠️ `%s`가 현재 오프라인입니다. 잠시 후 다시 시도해주세요."
-              keeper_name
+            Printf.sprintf "⚠️ `%s` 오프라인" keeper_name
           in
           (match State.send_message ~channel_id ~content:notice
                   ~reply_to_message_id:message_id () with

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -303,7 +303,7 @@ let handle_message_create ~dispatch
         | Channel_gate.Dispatch_unavailable ->
           let notice =
             Printf.sprintf
-              "⚠️ `%s` keeper가 현재 오프라인입니다. 잠시 후 다시 시도해주세요."
+              "⚠️ `%s`가 현재 오프라인입니다. 잠시 후 다시 시도해주세요."
               keeper_name
           in
           (match State.send_message ~channel_id ~content:notice

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -299,11 +299,41 @@ let handle_message_create ~dispatch
          Channel_gate.handle_inbound ~dispatch msg)
      with
      | Error gate_err ->
-       Discord_observability.record_inbound_dispatch
-         Discord_observability.Gate_error;
-       Log.Server.warn "discord inbound -> keeper failed (channel=%s keeper=%s): %s"
-         channel_id keeper_name
-         (Channel_gate.gate_error_to_string gate_err)
+       (match gate_err with
+        | Channel_gate.Dispatch_unavailable ->
+          let notice =
+            Printf.sprintf
+              "⚠️ `%s` keeper가 현재 오프라인입니다. 잠시 후 다시 시도해주세요."
+              keeper_name
+          in
+          (match State.send_message ~channel_id ~content:notice
+                  ~reply_to_message_id:message_id () with
+           | Ok _ ->
+             Discord_observability.record_inbound_dispatch
+               Discord_observability.Reply_sent;
+             Discord_observability.record_reply
+               Discord_observability.Reply_send_ok
+           | Error e ->
+             Discord_observability.record_inbound_dispatch
+               Discord_observability.Gate_error;
+             Discord_observability.record_reply
+               Discord_observability.Reply_send_failed;
+             Log.Server.error
+               "discord send unavailable notice failed (channel=%s): %s"
+               channel_id
+               (Format.asprintf "%a" State.pp_send_error e));
+         Log.Server.info
+           "discord inbound -> keeper unavailable, notice sent (channel=%s keeper=%s)"
+           channel_id keeper_name
+        | Channel_gate.Validation _
+        | Channel_gate.Keeper_error _
+        | Channel_gate.Internal _ ->
+          Discord_observability.record_inbound_dispatch
+            Discord_observability.Gate_error;
+          Log.Server.warn
+            "discord inbound -> keeper failed (channel=%s keeper=%s): %s"
+            channel_id keeper_name
+            (Channel_gate.gate_error_to_string gate_err))
      | Ok out ->
        if String.equal out.content "" then begin
          (match attention_event_id with


### PR DESCRIPTION
Discord 메시지가 바인딩된 keeper에 도달했는데 keeper가 offline/failing이면, 기존엔 로그만 남기고 사용자에게 아무 응답이 없었습니다. 이제 `Dispatch_unavailable` 에러를 잡아 Discord 채널에 상태 메시지를 보냅니다. Co-Authored-By: Claude <noreply@anthropic.com>