### PR TITLE
feat(discord): thread auto-respond (mention_or_thread)

### DIFF
--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -144,6 +144,32 @@ let rec drop_left n xs =
     | [] -> []
     | _ :: tl -> drop_left (n - 1) tl
 
+(* ── Thread registry ──────────────────────────────────────────────
+   Thread→parent mapping populated from THREAD_CREATE gateway events.
+   Used by [resolve_keeper_for_channel] to resolve bindings for thread
+   messages whose channel_id is the thread's snowflake, not the parent
+   channel's. Module-level mutable state (same pattern as [last_ready]). *)
+
+let thread_parent_table : (string, string) Hashtbl.t =
+  Hashtbl.create 16
+
+let register_thread ~thread_id ~parent_channel_id =
+  let tid = String.trim thread_id in
+  let pid = String.trim parent_channel_id in
+  if tid <> "" && pid <> "" then
+    Hashtbl.replace thread_parent_table tid pid
+
+let parent_channel_of_thread ~channel_id : string option =
+  let cid = String.trim channel_id in
+  if cid = "" then None
+  else Hashtbl.find_opt thread_parent_table cid
+
+let is_known_thread ~channel_id =
+  let cid = String.trim channel_id in
+  cid <> "" && Hashtbl.mem thread_parent_table cid
+
+let registered_thread_count () = Hashtbl.length thread_parent_table
+
 let read_recent_audit ~limit =
   let path = binding_audit_read_path () in
   if limit <= 0 || not (Sys.file_exists path) then
@@ -560,26 +586,63 @@ let resolve_keeper_for_channel ~channel_id =
             via_parent = false;
           }
     | None -> (
-        let parent_channel_id =
-          try Names.resolve_parent_channel_id_for_channel ~channel_id:normalized
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | _ -> None
-        in
-        match parent_channel_id with
-        | None -> None
-        | Some parent_channel_id -> (
-            let parent_channel_id = String.trim parent_channel_id in
-            match binding_for_channel candidates ~channel_id:parent_channel_id with
+        (* Thread fallback: if this channel_id is a known Discord thread,
+           try resolving via its parent channel's binding. *)
+        match parent_channel_of_thread ~channel_id:normalized with
+        | Some parent_id when parent_id <> normalized ->
+            (match binding_for_channel candidates ~channel_id:parent_id with
+             | Some b ->
+                 Some
+                   {
+                     keeper_name = b.keeper_name;
+                     incoming_channel_id = normalized;
+                     bound_channel_id = b.channel_id;
+                     via_parent = true;
+                   }
+             | None -> (
+                 (* Final fallback: names file (legacy sidecar data). *)
+                 let names_parent =
+                   try Names.resolve_parent_channel_id_for_channel ~channel_id:normalized
+                   with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | _ -> None
+                 in
+                 match names_parent with
+                 | None -> None
+                 | Some names_parent ->
+                     let names_parent = String.trim names_parent in
+                     match binding_for_channel candidates ~channel_id:names_parent with
+                     | None -> None
+                     | Some b ->
+                         Some
+                           {
+                             keeper_name = b.keeper_name;
+                             incoming_channel_id = normalized;
+                             bound_channel_id = b.channel_id;
+                             via_parent = true;
+                           } ))
+        | _ -> (
+            (* No thread match — try names file (legacy sidecar data). *)
+            let parent_channel_id =
+              try Names.resolve_parent_channel_id_for_channel ~channel_id:normalized
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | _ -> None
+            in
+            match parent_channel_id with
             | None -> None
-            | Some b ->
-                Some
-                  {
-                    keeper_name = b.keeper_name;
-                    incoming_channel_id = normalized;
-                    bound_channel_id = b.channel_id;
-                    via_parent = true;
-                  } ))
+            | Some parent_channel_id -> (
+                let parent_channel_id = String.trim parent_channel_id in
+                match binding_for_channel candidates ~channel_id:parent_channel_id with
+                | None -> None
+                | Some b ->
+                    Some
+                      {
+                        keeper_name = b.keeper_name;
+                        incoming_channel_id = normalized;
+                        bound_channel_id = b.channel_id;
+                        via_parent = true;
+                      } )) )
 
 let keeper_for_channel ~channel_id =
   match resolve_keeper_for_channel ~channel_id with

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -102,6 +102,26 @@ val record_ready : bot_user_id:string -> unit
     [bot_user_id] / [last_ready_at]. Atomic write — safe to call from
     the gateway fiber while HTTP handlers read. *)
 
+(** {2 Thread registry}
+
+    Thread→parent channel mapping populated from THREAD_CREATE gateway
+    events. Used by {!resolve_keeper_for_channel} to resolve bindings
+    for messages in Discord threads (whose [channel_id] is the thread's
+    snowflake, distinct from the parent channel). *)
+
+val register_thread : thread_id:string -> parent_channel_id:string -> unit
+(** Register a Discord thread's parent channel. Called from the gateway's
+    [Thread_tracked] event handler. Overwrites on duplicate. *)
+
+val parent_channel_of_thread : channel_id:string -> string option
+(** If [channel_id] is a known thread, return its parent channel ID. *)
+
+val is_known_thread : channel_id:string -> bool
+(** [true] when [channel_id] has been registered as a Discord thread. *)
+
+val registered_thread_count : unit -> int
+(** Number of threads currently in the registry. For diagnostics. *)
+
 (** Typed failure modes for Discord REST actions. Closed sum — adding
     a new variant forces every consumer to handle it. *)
 type send_error =

--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -38,10 +38,15 @@ type gateway_event = Discord_gateway_state.dispatched_event =
       ; user_id : string
       ; emoji : string
       }
+  | Thread_tracked of
+      { thread_id : string
+      ; parent_channel_id : string
+      }
   | Ignored of string
 
 type trigger_policy = Discord_gateway_state.trigger_policy =
   | Mention_only
+  | Mention_or_thread
   | User_only of string
   | All
 
@@ -238,6 +243,8 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
           Discord_observability.Message_create, Discord_observability.Triggered
         | Reaction_add _ ->
           Discord_observability.Reaction_add, Discord_observability.Triggered
+        | Thread_tracked _ ->
+          Discord_observability.Ignored, Discord_observability.Control
         | Ignored _ -> Discord_observability.Ignored, Discord_observability.Control
       in
       Discord_observability.record_gateway_event ~route event;
@@ -248,6 +255,7 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
         | Ready _ -> Discord_observability.Ready
         | Message_create _ -> Discord_observability.Message_create
         | Reaction_add _ -> Discord_observability.Reaction_add
+        | Thread_tracked _ -> Discord_observability.Ignored
         | Ignored _ -> Discord_observability.Ignored
       in
       Discord_observability.record_gateway_event

--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -42,6 +42,9 @@ type gateway_event = Discord_gateway_state.dispatched_event =
       { thread_id : string
       ; parent_channel_id : string
       }
+  | Threads_bulk_tracked of
+      { threads : (string * string) list
+      }
   | Ignored of string
 
 type trigger_policy = Discord_gateway_state.trigger_policy =
@@ -243,7 +246,7 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
           Discord_observability.Message_create, Discord_observability.Triggered
         | Reaction_add _ ->
           Discord_observability.Reaction_add, Discord_observability.Triggered
-        | Thread_tracked _ ->
+        | Thread_tracked _ | Threads_bulk_tracked _ ->
           Discord_observability.Ignored, Discord_observability.Control
         | Ignored _ -> Discord_observability.Ignored, Discord_observability.Control
       in
@@ -255,7 +258,7 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
         | Ready _ -> Discord_observability.Ready
         | Message_create _ -> Discord_observability.Message_create
         | Reaction_add _ -> Discord_observability.Reaction_add
-        | Thread_tracked _ -> Discord_observability.Ignored
+        | Thread_tracked _ | Threads_bulk_tracked _ -> Discord_observability.Ignored
         | Ignored _ -> Discord_observability.Ignored
       in
       Discord_observability.record_gateway_event

--- a/lib/gate/discord_gateway_client.mli
+++ b/lib/gate/discord_gateway_client.mli
@@ -52,6 +52,9 @@ type gateway_event = Discord_gateway_state.dispatched_event =
       { thread_id : string
       ; parent_channel_id : string
       }
+  | Threads_bulk_tracked of
+      { threads : (string * string) list
+      }
   | Ignored of string
 
 type trigger_policy = Discord_gateway_state.trigger_policy =

--- a/lib/gate/discord_gateway_client.mli
+++ b/lib/gate/discord_gateway_client.mli
@@ -48,10 +48,15 @@ type gateway_event = Discord_gateway_state.dispatched_event =
       ; user_id : string
       ; emoji : string
       }
+  | Thread_tracked of
+      { thread_id : string
+      ; parent_channel_id : string
+      }
   | Ignored of string
 
 type trigger_policy = Discord_gateway_state.trigger_policy =
   | Mention_only
+  | Mention_or_thread
   | User_only of string
   | All
 

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -105,6 +105,13 @@ type dispatched_event =
           layer uses this to populate binding-resolution registries;
           the state machine stores it in [thread_parents] for
           [Mention_or_thread] trigger policy evaluation. *)
+  | Threads_bulk_tracked of
+      { threads : (string * string) list
+            (** (thread_id * parent_channel_id) pairs, typically from
+                GUILD_CREATE's [threads] array. *)
+      }
+      (** Bulk thread discovery from GUILD_CREATE. Carries all active
+          threads in a guild that existed before the bot connected. *)
   | Ignored of string
 
 (* ── Frame ─────────────────────────────────────────────────────── *)
@@ -425,12 +432,32 @@ let decode_thread_create ~payload =
       else Ok (Thread_tracked { thread_id; parent_channel_id })
   | _ -> Ok (Ignored "THREAD_CREATE: missing id or parent_id")
 
+let decode_guild_create_threads ~payload =
+  let threads_json = assoc_opt "threads" payload in
+  match threads_json with
+  | Some (`List items) ->
+      let entries =
+        List.filter_map (fun item ->
+          let thread_id = field_string_opt "id" item in
+          let parent_id = field_string_opt "parent_id" item in
+          match thread_id, parent_id with
+          | Some tid, Some pid
+            when String.trim tid <> "" && String.trim pid <> "" ->
+              Some (tid, pid)
+          | _ -> None)
+          items
+      in
+      if entries = [] then Ok (Ignored "GUILD_CREATE: no valid threads")
+      else Ok (Threads_bulk_tracked { threads = entries })
+  | Some _ | None -> Ok (Ignored "GUILD_CREATE: no threads field")
+
 let decode_dispatch ~bot_user_id ~event_name ~payload =
   match event_name with
   | "READY" -> decode_ready ~payload
   | "MESSAGE_CREATE" -> decode_message_create ~bot_user_id ~payload
   | "MESSAGE_REACTION_ADD" -> decode_reaction_add ~payload
   | "THREAD_CREATE" | "THREAD_UPDATE" -> decode_thread_create ~payload
+  | "GUILD_CREATE" -> decode_guild_create_threads ~payload
   | other -> Ok (Ignored other)
 
 (* ── Trigger policy filters ────────────────────────────────────────
@@ -655,6 +682,21 @@ let handle_dispatch t (frame : frame) =
                      Printf.sprintf
                        "thread tracked: %s -> parent %s"
                        thread_id parent_channel_id
+                 }
+             ] )
+       | Ok (Threads_bulk_tracked { threads } as ev) ->
+           let thread_parents' =
+             List.fold_left (fun acc (tid, pid) -> StringMap.add tid pid acc)
+               t'.thread_parents threads
+           in
+           ( { t' with thread_parents = thread_parents' }
+           , [ Emit_event ev
+             ; Log
+                 { level = `Info
+                 ; message =
+                     Printf.sprintf
+                       "guild threads bulk tracked: %d threads"
+                       (List.length threads)
                  }
              ] )
        | Ok (Ignored "RESUMED") ->

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -97,6 +97,14 @@ type dispatched_event =
       ; user_id : string
       ; emoji : string
       }
+  | Thread_tracked of
+      { thread_id : string
+      ; parent_channel_id : string
+      }
+      (** Discord thread discovered via THREAD_CREATE dispatch. The I/O
+          layer uses this to populate binding-resolution registries;
+          the state machine stores it in [thread_parents] for
+          [Mention_or_thread] trigger policy evaluation. *)
   | Ignored of string
 
 (* ── Frame ─────────────────────────────────────────────────────── *)
@@ -144,6 +152,9 @@ type gateway_effect =
 
 type trigger_policy =
   | Mention_only
+  | Mention_or_thread
+      (** Mention in regular channels, auto-respond in Discord threads.
+          Threads are identified by the [thread_parents] registry in [t]. *)
   | User_only of string
   | All
 
@@ -157,6 +168,7 @@ type config =
 let parse_trigger_policy s =
   match s with
   | "mention_only" -> Ok Mention_only
+  | "mention_or_thread" -> Ok Mention_or_thread
   | "all" -> Ok All
   | _ when String.length s > 10 && String.sub s 0 10 = "user_only:" ->
       let id = String.sub s 10 (String.length s - 10) in
@@ -165,12 +177,14 @@ let parse_trigger_policy s =
   | _ ->
       Error
         (Printf.sprintf
-           "unknown trigger policy %S — expected mention_only | user_only:<id> | all"
+           "unknown trigger policy %S — expected mention_only | mention_or_thread | user_only:<id> | all"
            s)
 
 (* ── Opaque state ──────────────────────────────────────────────── *)
 
 let gateway_url = "wss://gateway.discord.gg/?v=10&encoding=json"
+
+module StringMap = Map.Make (String)
 
 type t =
   { state : connection_state
@@ -183,6 +197,10 @@ type t =
     (* (session_id, last_seq_at_disconnect). Set when leaving Connected
        via a resumable disconnect; cleared on fresh identify path. Lets
        handle_hello choose Identify vs Resume after Awaiting_hello. *)
+  ; thread_parents : string StringMap.t
+    (* thread_id -> parent_channel_id. Populated by THREAD_CREATE
+       dispatches. Used by [Mention_or_thread] trigger policy to
+       auto-accept messages in known threads without @mention. *)
   }
 
 let create ~config =
@@ -193,6 +211,7 @@ let create ~config =
   ; heartbeat_interval_ms = None
   ; resume_gateway_url = None
   ; resume_context = None
+  ; thread_parents = StringMap.empty
   }
 
 let state t = t.state
@@ -395,11 +414,23 @@ let decode_reaction_add ~payload =
         "MESSAGE_REACTION_ADD payload: missing channel_id / message_id / \
          user_id / emoji.name"
 
+let decode_thread_create ~payload =
+  let thread_id = field_string_opt "id" payload in
+  let parent_channel_id = field_string_opt "parent_id" payload in
+  match thread_id, parent_channel_id with
+  | Some thread_id, Some parent_channel_id ->
+      if String.equal (String.trim thread_id) ""
+         || String.equal (String.trim parent_channel_id) ""
+      then Ok (Ignored "THREAD_CREATE: empty id or parent_id")
+      else Ok (Thread_tracked { thread_id; parent_channel_id })
+  | _ -> Ok (Ignored "THREAD_CREATE: missing id or parent_id")
+
 let decode_dispatch ~bot_user_id ~event_name ~payload =
   match event_name with
   | "READY" -> decode_ready ~payload
   | "MESSAGE_CREATE" -> decode_message_create ~bot_user_id ~payload
   | "MESSAGE_REACTION_ADD" -> decode_reaction_add ~payload
+  | "THREAD_CREATE" | "THREAD_UPDATE" -> decode_thread_create ~payload
   | other -> Ok (Ignored other)
 
 (* ── Trigger policy filters ────────────────────────────────────────
@@ -421,12 +452,14 @@ let is_self ~bot_user_id actor_id =
   | Some self -> String.equal self actor_id
   | None -> false
 
-let message_passes_policy policy ~bot_user_id ~author_id ~explicit_mentions_bot =
+let message_passes_policy policy ~bot_user_id ~author_id ~explicit_mentions_bot
+      ~is_thread =
   if is_self ~bot_user_id author_id then false
   else
     match policy with
     | All -> true
     | Mention_only -> explicit_mentions_bot
+    | Mention_or_thread -> explicit_mentions_bot || is_thread
     | User_only id -> String.equal author_id id
 
 let reaction_passes_policy policy ~bot_user_id ~user_id =
@@ -435,6 +468,7 @@ let reaction_passes_policy policy ~bot_user_id ~user_id =
     match policy with
     | All -> true
     | Mention_only -> false
+    | Mention_or_thread -> false
     | User_only id -> String.equal user_id id
 
 (* ── Outbound frame builders (internal) ────────────────────────── *)
@@ -584,11 +618,12 @@ let handle_dispatch t (frame : frame) =
                  ; message = Printf.sprintf "READY (bot_user_id=%s)" bot_user_id
                  }
              ] )
-       | Ok (Message_create { author_id; explicit_mentions_bot; _ } as ev) ->
+       | Ok (Message_create { channel_id; author_id; explicit_mentions_bot; _ } as ev) ->
+           let is_thread = StringMap.mem channel_id t'.thread_parents in
            if
              message_passes_policy t'.config.trigger_policy
                ~bot_user_id:t'.config.bot_user_id ~author_id
-               ~explicit_mentions_bot
+               ~explicit_mentions_bot ~is_thread
            then (t', [ Emit_event ev ])
            else if is_self ~bot_user_id:t'.config.bot_user_id author_id
            then
@@ -608,6 +643,20 @@ let handle_dispatch t (frame : frame) =
                ~bot_user_id:t'.config.bot_user_id ~user_id
            then (t', [ Emit_event ev ])
            else no_op t'
+       | Ok (Thread_tracked { thread_id; parent_channel_id } as ev) ->
+           let thread_parents' =
+             StringMap.add thread_id parent_channel_id t'.thread_parents
+           in
+           ( { t' with thread_parents = thread_parents' }
+           , [ Emit_event ev
+             ; Log
+                 { level = `Info
+                 ; message =
+                     Printf.sprintf
+                       "thread tracked: %s -> parent %s"
+                       thread_id parent_channel_id
+                 }
+             ] )
        | Ok (Ignored "RESUMED") ->
            (* Successful resume — server has replayed missed events
               and signalled completion. Recover session_id from

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -106,6 +106,10 @@ type dispatched_event =
       ; user_id : string
       ; emoji : string
       }
+  | Thread_tracked of
+      { thread_id : string
+      ; parent_channel_id : string
+      }
   | Ignored of string  (** Known dispatch type we deliberately don't surface. *)
 
 (** {1 Inbound frame — what comes off the wire} *)
@@ -187,6 +191,8 @@ type config =
 
 and trigger_policy =
   | Mention_only
+  | Mention_or_thread
+      (** Mention in regular channels, auto-respond in Discord threads. *)
   | User_only of string  (** Discord user snowflake. *)
   | All
 

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -110,6 +110,9 @@ type dispatched_event =
       { thread_id : string
       ; parent_channel_id : string
       }
+  | Threads_bulk_tracked of
+      { threads : (string * string) list
+      }
   | Ignored of string  (** Known dispatch type we deliberately don't surface. *)
 
 (** {1 Inbound frame — what comes off the wire} *)

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -400,6 +400,12 @@ let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
       "Discord thread registered: %s -> parent %s (total=%d)"
       thread_id parent_channel_id
       (State.registered_thread_count ())
+  | Gw.Threads_bulk_tracked { threads } ->
+    List.iter (fun (tid, pid) -> State.register_thread ~thread_id:tid ~parent_channel_id:pid) threads;
+    Log.Server.info
+      "Discord guild threads bulk registered: %d threads (total=%d)"
+      (List.length threads)
+      (State.registered_thread_count ())
   | Gw.Ignored _ ->
     ()
 
@@ -463,7 +469,7 @@ let on_ambient ~base_dir (ev : Gw.gateway_event) =
     ->
     handle_ambient ~base_dir ~channel_id ~guild_id ~message_id ~author_id
       ~author_name ~content
-  | Gw.Ready _ | Gw.Reaction_add _ | Gw.Thread_tracked _ | Gw.Ignored _ -> ()
+  | Gw.Ready _ | Gw.Reaction_add _ | Gw.Thread_tracked _ | Gw.Threads_bulk_tracked _ | Gw.Ignored _ -> ()
 
 (* ---------------------------------------------------------------- *)
 (* Start                                                            *)

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -35,6 +35,7 @@ let parse_trigger_policy raw : Gw.trigger_policy =
   else
     match s with
     | "mention_only" -> Gw.Mention_only
+    | "mention_or_thread" -> Gw.Mention_or_thread
     | "all" -> Gw.All
     | other ->
       let prefix = "user_only:" in
@@ -393,6 +394,12 @@ let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
        trigger to drain pending messages. That feature is dropped in
        the in-process gateway; re-add as a follow-up if needed. *)
     ()
+  | Gw.Thread_tracked { thread_id; parent_channel_id } ->
+    State.register_thread ~thread_id ~parent_channel_id;
+    Log.Server.info
+      "Discord thread registered: %s -> parent %s (total=%d)"
+      thread_id parent_channel_id
+      (State.registered_thread_count ())
   | Gw.Ignored _ ->
     ()
 
@@ -456,7 +463,7 @@ let on_ambient ~base_dir (ev : Gw.gateway_event) =
     ->
     handle_ambient ~base_dir ~channel_id ~guild_id ~message_id ~author_id
       ~author_name ~content
-  | Gw.Ready _ | Gw.Reaction_add _ | Gw.Ignored _ -> ()
+  | Gw.Ready _ | Gw.Reaction_add _ | Gw.Thread_tracked _ | Gw.Ignored _ -> ()
 
 (* ---------------------------------------------------------------- *)
 (* Start                                                            *)
@@ -479,6 +486,7 @@ let start ~sw ~env ~clock ~state =
     let policy_label =
       match policy with
       | Gw.Mention_only -> "mention_only"
+      | Gw.Mention_or_thread -> "mention_or_thread"
       | Gw.All -> "all"
       | Gw.User_only _ -> "user_only:<id>"
     in

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -59,6 +59,7 @@ let test_intents_bitmask () =
 let policy_equal a b =
   match a, b with
   | S.Mention_only, S.Mention_only -> true
+  | S.Mention_or_thread, S.Mention_or_thread -> true
   | S.All, S.All -> true
   | S.User_only x, S.User_only y -> String.equal x y
   | _ -> false
@@ -66,6 +67,7 @@ let policy_equal a b =
 let test_parse_trigger_policy_accepts () =
   let cases =
     [ "mention_only", S.Mention_only
+    ; "mention_or_thread", S.Mention_or_thread
     ; "all", S.All
     ; "user_only:1234567890", S.User_only "1234567890"
     ]
@@ -1124,6 +1126,285 @@ let test_resume_round_trip_to_connected () =
   | _ -> fail "expected Connected sess-1 last_seq=99 after RESUMED"
 
 (* ---------------------------------------------------------------- *)
+(* Thread tracking + Mention_or_thread policy                      *)
+(* ---------------------------------------------------------------- *)
+
+let thread_create_frame ~thread_id ~parent_id ~seq : S.frame =
+  { op = S.Op_dispatch
+  ; s = Some seq
+  ; t = Some "THREAD_CREATE"
+  ; d =
+      `Assoc
+        [ ("id", `String thread_id)
+        ; ("parent_id", `String parent_id)
+        ; ("type", `Int 11)
+        ]
+  }
+
+let guild_create_frame_with_threads ~threads ~seq : S.frame =
+  let thread_items =
+    List.map
+      (fun (tid, pid) ->
+         `Assoc [ ("id", `String tid); ("parent_id", `String pid); ("type", `Int 11) ])
+      threads
+  in
+  { op = S.Op_dispatch
+  ; s = Some seq
+  ; t = Some "GUILD_CREATE"
+  ; d =
+      `Assoc
+        [ ("id", `String "G1")
+        ; ("name", `String "Test Guild")
+        ; ("threads", `List thread_items)
+        ]
+  }
+
+let has_emit_thread_tracked ~thread_id ~parent_channel_id effects =
+  List.exists
+    (function
+      | S.Emit_event
+          (S.Thread_tracked
+            { thread_id = tid; parent_channel_id = pid }) ->
+        String.equal tid thread_id && String.equal pid parent_channel_id
+      | _ -> false)
+    effects
+
+let has_emit_threads_bulk_tracked effects =
+  List.exists
+    (function S.Emit_event (S.Threads_bulk_tracked _) -> true | _ -> false)
+    effects
+
+let test_decode_thread_create () =
+  let payload =
+    `Assoc [ ("id", `String "THR1"); ("parent_id", `String "PARENT1"); ("type", `Int 11) ]
+  in
+  match S.decode_dispatch ~bot_user_id:None ~event_name:"THREAD_CREATE" ~payload with
+  | Ok (S.Thread_tracked { thread_id = "THR1"; parent_channel_id = "PARENT1" }) ->
+      ()
+  | Ok _ -> fail "decoded wrong THREAD_CREATE fields"
+  | Error msg -> fail msg
+
+let test_decode_thread_create_missing_fields () =
+  let payload = `Assoc [ ("id", `String "THR1") ] in
+  match S.decode_dispatch ~bot_user_id:None ~event_name:"THREAD_CREATE" ~payload with
+  | Ok (S.Ignored _) -> ()
+  | Ok _ -> fail "expected Ignored for THREAD_CREATE without parent_id"
+  | Error msg -> fail msg
+
+let test_decode_guild_create_with_threads () =
+  let payload =
+    `Assoc
+      [ ("id", `String "G1")
+      ; ("name", `String "Guild")
+      ; ( "threads",
+          `List
+            [ `Assoc [ ("id", `String "T1"); ("parent_id", `String "C1"); ("type", `Int 11) ]
+            ; `Assoc [ ("id", `String "T2"); ("parent_id", `String "C2"); ("type", `Int 12) ]
+            ] )
+      ]
+  in
+  match S.decode_dispatch ~bot_user_id:None ~event_name:"GUILD_CREATE" ~payload with
+  | Ok (S.Threads_bulk_tracked { threads }) ->
+      check int "2 threads parsed" 2 (List.length threads);
+      let has tid pid = List.exists (fun (t, p) -> t = tid && p = pid) threads in
+      check bool "T1 -> C1 present" true (has "T1" "C1");
+      check bool "T2 -> C2 present" true (has "T2" "C2")
+  | Ok _ -> fail "expected Threads_bulk_tracked"
+  | Error msg -> fail msg
+
+let test_decode_guild_create_without_threads () =
+  let payload =
+    `Assoc [ ("id", `String "G1"); ("name", `String "Guild") ]
+  in
+  match S.decode_dispatch ~bot_user_id:None ~event_name:"GUILD_CREATE" ~payload with
+  | Ok (S.Ignored _) -> ()
+  | Ok _ -> fail "expected Ignored for GUILD_CREATE without threads"
+  | Error msg -> fail msg
+
+let test_decode_thread_update_same_as_create () =
+  let payload =
+    `Assoc [ ("id", `String "THR1"); ("parent_id", `String "P1"); ("type", `Int 11) ]
+  in
+  match S.decode_dispatch ~bot_user_id:None ~event_name:"THREAD_UPDATE" ~payload with
+  | Ok (S.Thread_tracked { thread_id = "THR1"; parent_channel_id = "P1" }) -> ()
+  | Ok _ -> fail "THREAD_UPDATE should decode same as THREAD_CREATE"
+  | Error msg -> fail msg
+
+(* Step-level: THREAD_CREATE populates thread_parents and emits event *)
+let test_step_thread_create_updates_registry () =
+  let m = connected_with_policy ~policy:S.Mention_or_thread ~bot_user_id:"BOT" in
+  let m', effects =
+    S.step m ~now_mono:5.0
+      (S.Frame_received (thread_create_frame ~thread_id:"THR1" ~parent_id:"CH1" ~seq:10))
+  in
+  check bool "Emit_event Thread_tracked emitted" true
+    (has_emit_thread_tracked ~thread_id:"THR1" ~parent_channel_id:"CH1" effects);
+  (* Verify thread_parents was updated: a message in THR1 should now
+     pass Mention_or_thread policy without mention. *)
+  let payload =
+    message_create_payload
+      ~id:"M_T1" ~channel_id:"THR1" ~author_id:"U1" ~content:"thread msg"
+      ~mention_ids:[] ()
+  in
+  let _, effects2 =
+    S.step m' ~now_mono:6.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload ~seq:11))
+  in
+  check bool "Mention_or_thread: message in known thread passes" true
+    (has_emit_event effects2)
+
+let test_step_guild_create_bulk_tracks_threads () =
+  let m = connected_with_policy ~policy:S.Mention_or_thread ~bot_user_id:"BOT" in
+  let m', effects =
+    S.step m ~now_mono:5.0
+      (S.Frame_received
+         (guild_create_frame_with_threads
+            ~threads:[ ("T1", "C1"); ("T2", "C2"); ("T3", "C1") ]
+            ~seq:10))
+  in
+  check bool "Emit_event Threads_bulk_tracked emitted" true
+    (has_emit_threads_bulk_tracked effects);
+  (* Messages in all three threads should now pass policy *)
+  let test_thread m channel_id =
+    let payload =
+      message_create_payload
+        ~id:"M" ~channel_id ~author_id:"U1" ~content:"hi"
+        ~mention_ids:[] ()
+    in
+    let _, eff =
+      S.step m ~now_mono:6.0
+        (S.Frame_received
+           (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload ~seq:11))
+    in
+    has_emit_event eff
+  in
+  check bool "T1 (parent C1) passes" true (test_thread m' "T1");
+  check bool "T2 (parent C2) passes" true (test_thread m' "T2");
+  check bool "T3 (parent C1) passes" true (test_thread m' "T3")
+
+(* Mention_or_thread: regular channel still requires mention *)
+let test_policy_mention_or_thread_regular_channel_requires_mention () =
+  let m = connected_with_policy ~policy:S.Mention_or_thread ~bot_user_id:"BOT" in
+  let payload =
+    message_create_payload
+      ~id:"M1" ~channel_id:"REGULAR" ~author_id:"U1" ~content:"no mention"
+      ~mention_ids:[] ()
+  in
+  let _, effects =
+    S.step m ~now_mono:3.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload ~seq:5))
+  in
+  check bool "Mention_or_thread: regular channel without mention => suppressed"
+    false (has_emit_event effects);
+  check bool "Mention_or_thread: regular channel without mention => ambient"
+    true (has_emit_ambient effects)
+
+let test_policy_mention_or_thread_regular_channel_with_mention_passes () =
+  let m = connected_with_policy ~policy:S.Mention_or_thread ~bot_user_id:"BOT" in
+  let payload =
+    message_create_payload
+      ~id:"M2" ~channel_id:"REGULAR" ~author_id:"U1" ~content:"<@BOT> hi"
+      ~mention_ids:[ "BOT" ] ()
+  in
+  let _, effects =
+    S.step m ~now_mono:3.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload ~seq:5))
+  in
+  check bool "Mention_or_thread: regular channel with mention => passes"
+    true (has_emit_event effects)
+
+let test_policy_mention_or_thread_unknown_thread_still_requires_mention () =
+  let m = connected_with_policy ~policy:S.Mention_or_thread ~bot_user_id:"BOT" in
+  (* No THREAD_CREATE dispatched — "UNKNOWN_THR" is not in thread_parents *)
+  let payload =
+    message_create_payload
+      ~id:"M3" ~channel_id:"UNKNOWN_THR" ~author_id:"U1" ~content:"hi"
+      ~mention_ids:[] ()
+  in
+  let _, effects =
+    S.step m ~now_mono:3.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload ~seq:5))
+  in
+  check bool "Mention_or_thread: unknown thread => suppressed (no mention)"
+    false (has_emit_event effects)
+
+let test_policy_mention_or_thread_reaction_suppressed () =
+  let m = connected_with_policy ~policy:S.Mention_or_thread ~bot_user_id:"BOT" in
+  let payload =
+    reaction_add_payload
+      ~channel_id:"C1" ~message_id:"M1" ~user_id:"U1" ~emoji_name:"👍" ()
+  in
+  let _, effects =
+    S.step m ~now_mono:3.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_REACTION_ADD" ~payload ~seq:5))
+  in
+  check bool "Mention_or_thread: reaction suppressed (same as mention_only)"
+    false (has_emit_event effects)
+
+(* Regression: Mention_only ignores is_thread entirely *)
+let test_policy_mention_only_ignores_thread () =
+  let m = connected_with_policy ~policy:S.Mention_only ~bot_user_id:"BOT" in
+  (* Register thread *)
+  let m', _ =
+    S.step m ~now_mono:5.0
+      (S.Frame_received (thread_create_frame ~thread_id:"THR1" ~parent_id:"CH1" ~seq:10))
+  in
+  (* Thread_parents has THR1, but Mention_only ignores is_thread *)
+  let payload =
+    message_create_payload
+      ~id:"M4" ~channel_id:"THR1" ~author_id:"U1" ~content:"thread msg"
+      ~mention_ids:[] ()
+  in
+  let _, effects =
+    S.step m' ~now_mono:6.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload ~seq:11))
+  in
+  check bool "Mention_only: thread message without mention => suppressed"
+    false (has_emit_event effects)
+
+(* Thread tracking survives reconnect *)
+let test_thread_registry_survives_reconnect () =
+  let m = connected_with_policy ~policy:S.Mention_or_thread ~bot_user_id:"BOT" in
+  (* Register thread *)
+  let m, _ =
+    S.step m ~now_mono:5.0
+      (S.Frame_received (thread_create_frame ~thread_id:"THR1" ~parent_id:"CH1" ~seq:10))
+  in
+  (* Reconnect cycle *)
+  let m, _ =
+    S.step m ~now_mono:10.0
+      (S.Wss_closed { code = 1006; reason = "blip" })
+  in
+  let m, _ = S.step m ~now_mono:12.0 S.Backoff_elapsed in
+  let m, _ =
+    S.step m ~now_mono:13.0
+      (S.Frame_received (hello_frame ~heartbeat_interval:41250))
+  in
+  let resumed : S.frame =
+    { op = S.Op_dispatch; s = Some 99; t = Some "RESUMED"; d = `Assoc [] }
+  in
+  let m, _ = S.step m ~now_mono:14.0 (S.Frame_received resumed) in
+  (* Thread should still be tracked after reconnect *)
+  let payload =
+    message_create_payload
+      ~id:"M5" ~channel_id:"THR1" ~author_id:"U1" ~content:"after reconnect"
+      ~mention_ids:[] ()
+  in
+  let _, effects =
+    S.step m ~now_mono:15.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload ~seq:100))
+  in
+  check bool "thread_parents survives reconnect cycle" true
+    (has_emit_event effects)
+
+(* ---------------------------------------------------------------- *)
 (* Entry                                                            *)
 (* ---------------------------------------------------------------- *)
 
@@ -1253,5 +1534,43 @@ let () =
             "Resume round trip: Connected → blip → Backoff → Hello → \
              Op_resume → RESUMED → Connected"
             `Quick test_resume_round_trip_to_connected
+        ] )
+    ; ( "thread decode"
+      , [ test_case "THREAD_CREATE with id + parent_id => Thread_tracked" `Quick
+            test_decode_thread_create
+        ; test_case "THREAD_CREATE missing parent_id => Ignored" `Quick
+            test_decode_thread_create_missing_fields
+        ; test_case "GUILD_CREATE with threads => Threads_bulk_tracked" `Quick
+            test_decode_guild_create_with_threads
+        ; test_case "GUILD_CREATE without threads => Ignored" `Quick
+            test_decode_guild_create_without_threads
+        ; test_case "THREAD_UPDATE decodes same as THREAD_CREATE" `Quick
+            test_decode_thread_update_same_as_create
+        ] )
+    ; ( "thread tracking + Mention_or_thread policy"
+      , [ test_case
+            "THREAD_CREATE dispatch updates thread_parents + emits event"
+            `Quick test_step_thread_create_updates_registry
+        ; test_case
+            "GUILD_CREATE bulk tracks all threads"
+            `Quick test_step_guild_create_bulk_tracks_threads
+        ; test_case
+            "Mention_or_thread: regular channel without mention => suppressed"
+            `Quick test_policy_mention_or_thread_regular_channel_requires_mention
+        ; test_case
+            "Mention_or_thread: regular channel with mention => passes"
+            `Quick test_policy_mention_or_thread_regular_channel_with_mention_passes
+        ; test_case
+            "Mention_or_thread: unknown thread => suppressed"
+            `Quick test_policy_mention_or_thread_unknown_thread_still_requires_mention
+        ; test_case
+            "Mention_or_thread: reaction suppressed"
+            `Quick test_policy_mention_or_thread_reaction_suppressed
+        ; test_case
+            "Mention_only: ignores is_thread (no auto-respond in threads)"
+            `Quick test_policy_mention_only_ignores_thread
+        ; test_case
+            "thread_parents survives reconnect cycle"
+            `Quick test_thread_registry_survives_reconnect
         ] )
     ]


### PR DESCRIPTION
Discord threads have separate channel_ids. mention_only policy requires @mention even in threads. This PR adds Mention_or_thread policy: auto-respond in threads, require @mention in regular channels. Env: MASC_DISCORD_TRIGGER_POLICY=mention_or_thread