### PR TITLE
feat(schedule): persist scheduled automation requests

### DIFF
--- a/docs/rfc/RFC-0234-scheduled-internal-automation.md
+++ b/docs/rfc/RFC-0234-scheduled-internal-automation.md
@@ -76,9 +76,14 @@ boundary, "schedule something now" becomes a delayed self-approved action.
 5. Scheduled execution reuses the existing descriptor, policy, sandbox, and
    approval surfaces. It does not create a bypass.
 6. Every state change is append-only and replayable; projections are derived.
-7. The schedule core stores opaque payloads only. It has no constructors or
-   dependencies for keepers, tasks, boards, goals, tools, or any other consumer
-   domain. Consumers observe due rows and decide what, if anything, to do.
+7. The schedule core stores opaque payload envelopes only. It has no
+   constructors or dependencies for keepers, tasks, boards, goals, tools, or
+   any other consumer domain. Consumers observe due rows and decide what, if
+   anything, to do.
+8. A schedule entry must not guess missing intent. If the producer cannot
+   produce a valid payload envelope, it asks the operator for clarification or
+   records a consumer-owned clarification payload; the schedule core does not
+   infer domain fields.
 
 ## §3 Scope
 
@@ -136,6 +141,12 @@ type schedule_status =
   | Cancelled
   | Expired
 
+type payload =
+  { kind : string
+  ; schema_version : int
+  ; body : Yojson.Safe.t
+  }
+
 type schedule_request =
   { schedule_id : string
   ; requested_by : actor
@@ -143,7 +154,7 @@ type schedule_request =
   ; requested_at : float
   ; due_at : float
   ; expires_at : float option
-  ; payload : Yojson.Safe.t
+  ; payload : payload
   ; risk_class : risk_class
   ; approval_required : bool
   ; status : schedule_status
@@ -160,12 +171,31 @@ type execution_grant =
 }
 ```
 
-`payload` is intentionally opaque to the schedule core. It may be a text note,
-a JSON envelope, or a consumer-defined command description, but this RFC does
-not define a route enum. Keepers, tasks, boards, goals, tool names, and future
-execution adapters belong outside the schedule domain. A consumer may observe a
-due row and translate the payload later; the schedule ledger only preserves
-time, approval, risk, and audit evidence.
+`payload` is intentionally opaque to the schedule core, but not unstructured.
+The persisted shape is a JSON object envelope:
+
+```json
+{
+  "kind": "consumer.contract.name",
+  "schema_version": 1,
+  "body": {}
+}
+```
+
+The schedule domain validates only the envelope: `kind` must be a non-empty
+string, `schema_version` must be positive, and `body` must be an object. It
+does not define a route enum and does not interpret body fields. Keepers, tasks,
+boards, goals, tool names, and future execution adapters belong outside the
+schedule domain. A consumer may observe a due row and translate the payload
+later; the schedule ledger only preserves time, approval, risk, and audit
+evidence.
+
+If a producer cannot fill the consumer-owned `body` confidently, it must not
+create an executable schedule by guessing. It should either ask the operator a
+clarifying question before schedule creation or create a consumer-owned
+clarification payload such as `kind = "operator.clarification_request"`. The
+schedule core treats that as opaque data too; the consumer decides how to ask
+and what later schedule, if any, to create from the answer.
 
 ## §5 Separation-of-duties invariant
 

--- a/lib/schedule/dune
+++ b/lib/schedule/dune
@@ -1,11 +1,11 @@
 (include_subdirs no)
 
-;; Scheduled internal automation domain. This stays pure: no runner, shell,
-;; transport, or storage dependency in the first slice.
+;; Scheduled internal automation domain + file store. No runner, shell, or
+;; transport dependency at this layer.
 
 (library
  (name masc_schedule)
  (public_name masc.masc_schedule)
  (wrapped false)
- (modules schedule_domain)
- (libraries digestif yojson))
+ (modules schedule_domain schedule_store)
+ (libraries digestif masc_workspace unix yojson))

--- a/lib/schedule/schedule_domain.ml
+++ b/lib/schedule/schedule_domain.ml
@@ -33,6 +33,12 @@ type schedule_source =
   | Automated_request
   | System_request
 
+type payload =
+  { kind : string
+  ; schema_version : int
+  ; body : Yojson.Safe.t
+  }
+
 type schedule_request =
   { schedule_id : string
   ; requested_by : actor
@@ -40,7 +46,7 @@ type schedule_request =
   ; requested_at : float
   ; due_at : float
   ; expires_at : float option
-  ; payload : Yojson.Safe.t
+  ; payload : payload
   ; risk_class : risk_class
   ; approval_required : bool
   ; status : schedule_status
@@ -216,6 +222,11 @@ let float_of_yojson = function
   | _ -> Error "expected float"
 ;;
 
+let int_of_yojson = function
+  | `Int value -> Ok value
+  | _ -> Error "expected int"
+;;
+
 let bool_of_yojson = function
   | `Bool value -> Ok value
   | _ -> Error "expected bool"
@@ -237,6 +248,13 @@ let string_field name fields =
 let float_field name fields =
   let* value = assoc_field name fields in
   match float_of_yojson value with
+  | Ok value -> Ok value
+  | Error err -> Error (name ^ ": " ^ err)
+;;
+
+let int_field name fields =
+  let* value = assoc_field name fields in
+  match int_of_yojson value with
   | Ok value -> Ok value
   | Error err -> Error (name ^ ": " ^ err)
 ;;
@@ -270,7 +288,29 @@ let actor_of_yojson = function
   | _ -> Error "expected actor object"
 ;;
 
-let payload_digest payload = sha256_json payload
+let payload_to_yojson payload =
+  `Assoc
+    [ "kind", `String payload.kind
+    ; "schema_version", `Int payload.schema_version
+    ; "body", payload.body
+    ]
+;;
+
+let payload_of_yojson = function
+  | `Assoc fields ->
+    let* kind = string_field "kind" fields in
+    let* kind = nonempty "payload.kind" kind in
+    let* schema_version = int_field "schema_version" fields in
+    if schema_version <= 0 then Error "payload.schema_version must be positive"
+    else (
+      let* body = assoc_field "body" fields in
+      match body with
+      | `Assoc _ -> Ok { kind; schema_version; body }
+      | _ -> Error "payload.body must be a JSON object")
+  | _ -> Error "payload must be a JSON object"
+;;
+
+let payload_digest payload = payload |> payload_to_yojson |> sha256_json
 
 let evidence_of_request (request : schedule_request) =
   { schedule_id = request.schedule_id
@@ -351,7 +391,7 @@ let schedule_request_to_yojson (request : schedule_request) =
     ; "requested_at", float_to_yojson request.requested_at
     ; "due_at", float_to_yojson request.due_at
     ; "expires_at", option_to_yojson float_to_yojson request.expires_at
-    ; "payload", request.payload
+    ; "payload", payload_to_yojson request.payload
     ; "risk_class", `String (risk_class_to_string request.risk_class)
     ; "approval_required", `Bool request.approval_required
     ; "status", `String (schedule_status_to_string request.status)
@@ -375,7 +415,8 @@ let schedule_request_of_yojson = function
         let* value = float_of_yojson value in
         Ok (Some value)
     in
-    let* payload = assoc_field "payload" fields in
+    let* payload_json = assoc_field "payload" fields in
+    let* payload = payload_of_yojson payload_json in
     let* risk_name = string_field "risk_class" fields in
     let* risk_class = risk_class_of_string risk_name in
     let* approval_required = bool_field "approval_required" fields in
@@ -415,6 +456,7 @@ let create_request
   let* schedule_id = nonempty "schedule_id" schedule_id in
   let* _ = nonempty "requested_by.id" requested_by.id in
   let* _ = nonempty "scheduled_by.id" scheduled_by.id in
+  let* payload = payload_of_yojson payload in
   let approval_required = approval_required || is_side_effecting risk_class in
   let status = if approval_required then Pending_approval else Scheduled in
   Ok

--- a/lib/schedule/schedule_domain.mli
+++ b/lib/schedule/schedule_domain.mli
@@ -38,6 +38,14 @@ type schedule_source =
   | Automated_request
   | System_request
 
+(** Opaque consumer payload.
+
+    The schedule domain does not interpret payload kind or body fields, but it
+    does require a typed envelope so producers cannot persist an ambiguous raw
+    string/null/list as future intent. Serialized shape:
+    [{ kind: string; schema_version: int; body: object }]. *)
+type payload
+
 type schedule_request =
   { schedule_id : string
   ; requested_by : actor
@@ -45,7 +53,7 @@ type schedule_request =
   ; requested_at : float
   ; due_at : float
   ; expires_at : float option
-  ; payload : Yojson.Safe.t
+  ; payload : payload
   ; risk_class : risk_class
   ; approval_required : bool
   ; status : schedule_status
@@ -102,7 +110,9 @@ val is_terminal : schedule_status -> bool
 val is_side_effecting : risk_class -> bool
 val requires_separate_human_grant : schedule_request -> bool
 
-val payload_digest : Yojson.Safe.t -> string
+val payload_of_yojson : Yojson.Safe.t -> (payload, string) result
+val payload_to_yojson : payload -> Yojson.Safe.t
+val payload_digest : payload -> string
 val evidence_of_request : schedule_request -> execution_evidence
 
 val create_execution_grant :

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -1,0 +1,269 @@
+open Schedule_domain
+
+type state =
+  { version : int
+  ; updated_at : float
+  ; schedules : Schedule_domain.schedule_request list
+  ; grants : Schedule_domain.execution_grant list
+  }
+
+type store_error =
+  | Schedule_already_exists
+  | Schedule_not_found
+  | Grant_already_recorded
+  | Invalid_initial_status of string
+  | Grant_validation_failed of Schedule_domain.grant_error
+
+let ( let* ) = Result.bind
+
+let store_error_to_string = function
+  | Schedule_already_exists -> "schedule already exists"
+  | Schedule_not_found -> "schedule not found"
+  | Grant_already_recorded -> "grant already recorded"
+  | Invalid_initial_status reason -> "invalid initial schedule status: " ^ reason
+  | Grant_validation_failed err ->
+    "grant validation failed: " ^ Schedule_domain.grant_error_to_string err
+;;
+
+(* NDT-OK: store boundary timestamp for projection metadata; replay uses the
+   persisted [updated_at] value instead of recomputing it. *)
+let now () = Unix.gettimeofday ()
+
+let schedules_path config =
+  Filename.concat (Workspace_utils.masc_dir config) "schedules.json"
+;;
+
+let recovery_path config = schedules_path config ^ ".last-good"
+
+let ensure_dirs config = Workspace_utils.mkdir_p (Workspace_utils.masc_dir config)
+
+let default_state () =
+  { version = 1; updated_at = now (); schedules = []; grants = [] }
+;;
+
+let state_to_yojson (state : state) =
+  `Assoc
+    [ "version", `Int state.version
+    ; "updated_at", `Float state.updated_at
+    ; ( "schedules"
+      , `List (List.map Schedule_domain.schedule_request_to_yojson state.schedules)
+      )
+    ; "grants", `List (List.map Schedule_domain.execution_grant_to_yojson state.grants)
+    ]
+;;
+
+let int_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Int value) -> Ok value
+  | Some _ -> Error ("expected int field: " ^ name)
+  | None -> Error ("missing field: " ^ name)
+;;
+
+let float_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Float value) -> Ok value
+  | Some (`Int value) -> Ok (float_of_int value)
+  | Some _ -> Error ("expected float field: " ^ name)
+  | None -> Error ("missing field: " ^ name)
+;;
+
+let list_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`List value) -> Ok value
+  | Some _ -> Error ("expected list field: " ^ name)
+  | None -> Error ("missing field: " ^ name)
+;;
+
+let collect_results parse rows =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | row :: rest ->
+      let* value = parse row in
+      loop (value :: acc) rest
+  in
+  loop [] rows
+;;
+
+let state_of_yojson = function
+  | `Assoc fields ->
+    let* version = int_field "version" fields in
+    let* updated_at = float_field "updated_at" fields in
+    let* schedules_json = list_field "schedules" fields in
+    let* grants_json = list_field "grants" fields in
+    let* schedules =
+      collect_results Schedule_domain.schedule_request_of_yojson schedules_json
+    in
+    let* grants =
+      collect_results Schedule_domain.execution_grant_of_yojson grants_json
+    in
+    Ok { version; updated_at; schedules; grants }
+  | json -> Error ("state_of_yojson: " ^ Yojson.Safe.to_string json)
+;;
+
+let read_state config =
+  ensure_dirs config;
+  let path = schedules_path config in
+  if Workspace_utils.path_exists config path then
+    match Workspace_utils.read_json_result config path with
+    | Ok json ->
+      (match state_of_yojson json with
+       | Ok state -> state
+       | Error _ ->
+         let recovery = recovery_path config in
+         if Workspace_utils.path_exists config recovery then
+           match Workspace_utils.read_json_result config recovery with
+           | Ok recovery_json ->
+             (match state_of_yojson recovery_json with
+              | Ok state -> state
+              | Error _ -> default_state ())
+           | Error _ -> default_state ()
+         else
+           default_state ())
+    | Error _ ->
+      let recovery = recovery_path config in
+      if Workspace_utils.path_exists config recovery then
+        match Workspace_utils.read_json_result config recovery with
+        | Ok recovery_json ->
+          (match state_of_yojson recovery_json with
+           | Ok state -> state
+           | Error _ -> default_state ())
+        | Error _ -> default_state ()
+      else
+        default_state ()
+  else
+    default_state ()
+;;
+
+let write_state config state =
+  ensure_dirs config;
+  let json = state_to_yojson state in
+  Workspace_utils.write_json config (schedules_path config) json;
+  Workspace_utils.write_json config (recovery_path config) json
+;;
+
+let bump_state state ~schedules ~grants =
+  { version = state.version + 1; updated_at = now (); schedules; grants }
+;;
+
+let find_schedule state schedule_id =
+  List.find_opt
+    (fun (request : Schedule_domain.schedule_request) ->
+      String.equal request.schedule_id schedule_id)
+    state.schedules
+;;
+
+let replace_schedule schedules (updated : schedule_request) =
+  List.map
+    (fun (request : schedule_request) ->
+      if String.equal request.schedule_id updated.schedule_id then
+        updated
+      else
+        request)
+    schedules
+;;
+
+let grant_exists state grant_id =
+  List.exists
+    (fun (grant : Schedule_domain.execution_grant) ->
+      String.equal grant.grant_id grant_id)
+    state.grants
+;;
+
+let has_approved_grant state schedule_id =
+  List.exists
+    (fun (grant : execution_grant) ->
+      String.equal grant.schedule_id schedule_id
+      &&
+      match grant.decision with
+      | Approve -> true
+      | Reject _ -> false)
+    state.grants
+;;
+
+let list_schedules config = (read_state config).schedules
+
+let get_schedule config ~schedule_id = find_schedule (read_state config) schedule_id
+
+let validate_initial_request (request : Schedule_domain.schedule_request) =
+  if Schedule_domain.is_terminal request.status then
+    Error (Invalid_initial_status "terminal requests cannot be inserted")
+  else if Schedule_domain.requires_separate_human_grant request then
+    match request.status with
+    | Pending_approval -> Ok ()
+    | _ ->
+      Error
+        (Invalid_initial_status
+           "side-effecting requests must start pending approval")
+  else
+    match request.status with
+    | Scheduled -> Ok ()
+    | _ ->
+      Error
+        (Invalid_initial_status
+           "requests without approval requirements must start scheduled")
+;;
+
+let insert_request config (request : Schedule_domain.schedule_request) =
+  Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
+    let state = read_state config in
+    match find_schedule state request.schedule_id with
+    | Some _ -> Error Schedule_already_exists
+    | None ->
+      let* () = validate_initial_request request in
+      let schedules = request :: state.schedules in
+      let next_state = bump_state state ~schedules ~grants:state.grants in
+      write_state config next_state;
+      Ok request)
+;;
+
+let record_grant config (grant : Schedule_domain.execution_grant) =
+  Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
+    let state = read_state config in
+    if grant_exists state grant.grant_id then
+      Error Grant_already_recorded
+    else (
+      match find_schedule state grant.schedule_id with
+      | None -> Error Schedule_not_found
+      | Some request ->
+        match Schedule_domain.apply_execution_grant request grant with
+        | Error err -> Error (Grant_validation_failed err)
+        | Ok updated_request ->
+          let schedules = replace_schedule state.schedules updated_request in
+          let grants = grant :: state.grants in
+          let next_state = bump_state state ~schedules ~grants in
+          write_state config next_state;
+          Ok updated_request))
+;;
+
+let refresh_due config ~now =
+  Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
+    let state = read_state config in
+    let changed = ref 0 in
+    let schedules =
+      List.map
+        (fun request ->
+          let updated = Schedule_domain.mark_due ~now request in
+          if updated.Schedule_domain.status <> request.Schedule_domain.status then
+            incr changed;
+          updated)
+        state.schedules
+    in
+    if !changed = 0 then
+      Ok (state, 0)
+    else (
+      let next_state = bump_state state ~schedules ~grants:state.grants in
+      write_state config next_state;
+      Ok (next_state, !changed)))
+;;
+
+let due_execution_candidates state =
+  state.schedules
+  |> List.filter (fun (request : schedule_request) ->
+    match request.status with
+    | Due ->
+      (not (requires_separate_human_grant request))
+      || has_approved_grant state request.schedule_id
+    | Pending_approval | Scheduled | Running | Succeeded | Failed | Rejected | Cancelled
+    | Expired ->
+      false)
+;;

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -1,0 +1,52 @@
+(** Durable store for scheduled internal automation requests.
+
+    This layer records intent and execution grants. It deliberately does not
+    execute work. Runner/tool wiring must consume due candidates later. *)
+
+type state =
+  { version : int
+  ; updated_at : float
+  ; schedules : Schedule_domain.schedule_request list
+  ; grants : Schedule_domain.execution_grant list
+  }
+
+type store_error =
+  | Schedule_already_exists
+  | Schedule_not_found
+  | Grant_already_recorded
+  | Invalid_initial_status of string
+  | Grant_validation_failed of Schedule_domain.grant_error
+
+val store_error_to_string : store_error -> string
+
+val schedules_path : Workspace_utils.config -> string
+val read_state : Workspace_utils.config -> state
+
+val default_state : unit -> state
+val state_to_yojson : state -> Yojson.Safe.t
+val state_of_yojson : Yojson.Safe.t -> (state, string) result
+
+val list_schedules : Workspace_utils.config -> Schedule_domain.schedule_request list
+val get_schedule :
+  Workspace_utils.config -> schedule_id:string -> Schedule_domain.schedule_request option
+
+val insert_request :
+  Workspace_utils.config ->
+  Schedule_domain.schedule_request ->
+  (Schedule_domain.schedule_request, store_error) result
+
+val record_grant :
+  Workspace_utils.config ->
+  Schedule_domain.execution_grant ->
+  (Schedule_domain.schedule_request, store_error) result
+
+val refresh_due :
+  Workspace_utils.config ->
+  now:float ->
+  (state * int, store_error) result
+(** Marks stored [Scheduled] requests as [Due] when [due_at <= now]. The
+    integer is the number of requests changed. *)
+
+val due_execution_candidates :
+  state -> Schedule_domain.schedule_request list
+(** Returns only due requests that are no longer pending approval. *)

--- a/test/dune
+++ b/test/dune
@@ -1047,6 +1047,11 @@
  (modules test_schedule_domain)
  (libraries alcotest yojson masc_schedule))
 
+(test
+ (name test_schedule_store)
+ (modules test_schedule_store)
+ (libraries masc_test_deps masc_schedule))
+
 ; Typed TOML field resolution helper (RFC-0141 Phase 1).
 
 (test

--- a/test/test_schedule_domain.ml
+++ b/test/test_schedule_domain.ml
@@ -4,6 +4,18 @@ open Schedule_domain
 let human ?display_name id = { id; kind = Human_operator; display_name }
 let automated ?display_name id = { id; kind = Automated_actor; display_name }
 
+let payload_json ?(kind = "consumer.note") ?(schema_version = 1) ?body () =
+  let body =
+    Option.value body
+      ~default:(`Assoc [ "text", `String "ship the thing" ])
+  in
+  `Assoc
+    [ "kind", `String kind
+    ; "schema_version", `Int schema_version
+    ; "body", body
+    ]
+;;
+
 let request
   ?(risk_class = Workspace_write)
   ?(approval_required = false)
@@ -14,8 +26,8 @@ let request
   match
     create_request ~schedule_id:"sched-1" ~requested_by ~scheduled_by
       ~requested_at:100.0 ~due_at:200.0
-      ~payload:(`Assoc [ "body", `String "ship the thing" ])
-      ~risk_class ~approval_required ~source:Operator_request ()
+      ~payload:(payload_json ()) ~risk_class ~approval_required
+      ~source:Operator_request ()
   with
   | Ok request -> request
   | Error msg -> fail msg
@@ -49,6 +61,28 @@ let test_read_only_can_start_scheduled () =
   let req = request ~risk_class:Read_only () in
   check bool "approval not required" false req.approval_required;
   check_status "status" Scheduled req.status
+;;
+
+let test_payload_requires_object_envelope () =
+  match
+    create_request ~schedule_id:"sched-1" ~requested_by:(human "requester")
+      ~scheduled_by:(human "scheduler") ~requested_at:100.0 ~due_at:200.0
+      ~payload:(`String "do later") ~risk_class:Read_only
+      ~approval_required:false ~source:Operator_request ()
+  with
+  | Ok _ -> fail "expected invalid payload"
+  | Error msg -> check string "payload error" "payload must be a JSON object" msg
+;;
+
+let test_payload_requires_known_envelope_fields () =
+  match
+    create_request ~schedule_id:"sched-1" ~requested_by:(human "requester")
+      ~scheduled_by:(human "scheduler") ~requested_at:100.0 ~due_at:200.0
+      ~payload:(`Assoc [ "body", `Assoc [] ]) ~risk_class:Read_only
+      ~approval_required:false ~source:Operator_request ()
+  with
+  | Ok _ -> fail "expected invalid payload"
+  | Error msg -> check string "payload error" "missing field: kind" msg
 ;;
 
 let test_separate_human_approval_accepts () =
@@ -147,6 +181,10 @@ let () =
             test_side_effecting_starts_pending;
           test_case "read-only can start scheduled" `Quick
             test_read_only_can_start_scheduled;
+          test_case "payload requires object envelope" `Quick
+            test_payload_requires_object_envelope;
+          test_case "payload requires envelope fields" `Quick
+            test_payload_requires_known_envelope_fields;
           test_case "mark due only affects scheduled" `Quick
             test_mark_due_only_scheduled;
         ] );

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -1,0 +1,218 @@
+open Alcotest
+open Masc
+open Schedule_domain
+open Schedule_store
+
+let temp_dir () =
+  let path = Filename.temp_file "schedule_store_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let with_workspace f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  let config = Workspace.default_config dir in
+  ignore (Workspace.init config ~agent_name:(Some "test"));
+  f config
+;;
+
+let human ?display_name id = { id; kind = Human_operator; display_name }
+
+let payload_json () =
+  `Assoc
+    [ "kind", `String "consumer.note"
+    ; "schema_version", `Int 1
+    ; "body", `Assoc [ "text", `String "ship later" ]
+    ]
+;;
+
+let make_request ?(schedule_id = "sched-1") ?(risk_class = Workspace_write) () =
+  match
+    create_request ~schedule_id ~requested_by:(human "requester")
+      ~scheduled_by:(human "scheduler") ~requested_at:100.0 ~due_at:200.0
+      ~payload:(payload_json ()) ~risk_class ~approval_required:false
+      ~source:Operator_request ()
+  with
+  | Ok request -> request
+  | Error msg -> fail msg
+;;
+
+let grant ?(approved_by = human "approver") request =
+  create_execution_grant ~grant_id:"grant-1" ~approved_by ~approved_at:150.0
+    ~decision:Approve request
+;;
+
+let insert_ok config request =
+  match insert_request config request with
+  | Ok stored -> stored
+  | Error err -> fail (store_error_to_string err)
+;;
+
+let check_error label expected = function
+  | Ok _ -> fail (label ^ ": expected error")
+  | Error actual ->
+    check string label (store_error_to_string expected) (store_error_to_string actual)
+;;
+
+let check_status label expected actual =
+  check string label (schedule_status_to_string expected) (schedule_status_to_string actual)
+;;
+
+let test_insert_persists_and_bumps_version () =
+  with_workspace
+  @@ fun config ->
+  let before = read_state config in
+  let req = make_request () in
+  (match insert_request config req with
+   | Ok _ -> ()
+   | Error err -> fail (store_error_to_string err));
+  let after = read_state config in
+  check int "version bumped" (before.version + 1) after.version;
+  check int "one schedule" 1 (List.length after.schedules);
+  check_status "stored pending" Pending_approval (List.hd after.schedules).status
+;;
+
+let test_duplicate_insert_rejected_without_bump () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request () in
+  ignore (insert_ok config req);
+  let before = read_state config in
+  check_error "duplicate" Schedule_already_exists (insert_request config req);
+  let after = read_state config in
+  check int "version unchanged" before.version after.version
+;;
+
+let test_store_rejects_side_effecting_scheduled_insert () =
+  with_workspace
+  @@ fun config ->
+  let req = { (make_request ()) with status = Scheduled } in
+  match insert_request config req with
+  | Ok _ -> fail "expected invalid initial status"
+  | Error (Invalid_initial_status _) -> ()
+  | Error err -> fail (store_error_to_string err)
+;;
+
+let test_grant_records_and_schedules_request () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request () in
+  ignore (insert_ok config req);
+  let grant = grant req in
+  (match record_grant config grant with
+   | Ok updated -> check_status "approved status" Scheduled updated.status
+   | Error err -> fail (store_error_to_string err));
+  let after = read_state config in
+  check int "grant recorded" 1 (List.length after.grants);
+  match get_schedule config ~schedule_id:req.schedule_id with
+  | Some stored -> check_status "stored scheduled" Scheduled stored.status
+  | None -> fail "schedule missing"
+;;
+
+let test_requester_grant_rejected_without_bump () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request () in
+  ignore (insert_ok config req);
+  let before = read_state config in
+  let grant = grant ~approved_by:req.requested_by req in
+  check_error "requester grant"
+    (Grant_validation_failed Approver_is_requester)
+    (record_grant config grant);
+  let after = read_state config in
+  check int "version unchanged" before.version after.version;
+  check int "no grant recorded" 0 (List.length after.grants)
+;;
+
+let test_due_candidates_require_approval_grant () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request () in
+  ignore (insert_ok config req);
+  (match refresh_due config ~now:201.0 with
+   | Ok (_, changed) -> check int "pending not due" 0 changed
+   | Error err -> fail (store_error_to_string err));
+  check int "no candidate before grant" 0
+    (List.length (due_execution_candidates (read_state config)));
+  (match record_grant config (grant req) with
+   | Ok _ -> ()
+   | Error err -> fail (store_error_to_string err));
+  (match refresh_due config ~now:201.0 with
+   | Ok (_, changed) -> check int "scheduled became due" 1 changed
+   | Error err -> fail (store_error_to_string err));
+  let candidates = due_execution_candidates (read_state config) in
+  check int "one candidate after grant" 1 (List.length candidates)
+;;
+
+let test_read_only_due_candidate_does_not_need_grant () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request ~schedule_id:"read-1" ~risk_class:Read_only () in
+  ignore (insert_ok config req);
+  (match refresh_due config ~now:201.0 with
+   | Ok (_, changed) -> check int "read only due" 1 changed
+   | Error err -> fail (store_error_to_string err));
+  check int "read-only candidate" 1
+    (List.length (due_execution_candidates (read_state config)))
+;;
+
+let test_recovers_from_last_good () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request ~risk_class:Read_only () in
+  ignore (insert_ok config req);
+  Workspace.write_text config (schedules_path config) "{not json";
+  let recovered = read_state config in
+  check int "recovered schedule" 1 (List.length recovered.schedules)
+;;
+
+let () =
+  run "Schedule_store"
+    [
+      ( "state",
+        [
+          test_case "insert persists and bumps version" `Quick
+            test_insert_persists_and_bumps_version;
+          test_case "duplicate insert rejected without bump" `Quick
+            test_duplicate_insert_rejected_without_bump;
+          test_case "corrupt primary recovers from last-good" `Quick
+            test_recovers_from_last_good;
+        ] );
+      ( "approval",
+        [
+          test_case "side-effecting scheduled insert rejected" `Quick
+            test_store_rejects_side_effecting_scheduled_insert;
+          test_case "grant records and schedules request" `Quick
+            test_grant_records_and_schedules_request;
+          test_case "requester grant rejected without bump" `Quick
+            test_requester_grant_rejected_without_bump;
+        ] );
+      ( "due",
+        [
+          test_case "due candidates require approval grant" `Quick
+            test_due_candidates_require_approval_grant;
+          test_case "read-only due candidate does not need grant" `Quick
+            test_read_only_due_candidate_does_not_need_grant;
+        ] );
+    ]
+;;


### PR DESCRIPTION
## Summary

- add the durable schedule store/projection layer for scheduled internal automation
- persist schedule requests and execution grants under the workspace runtime root
- keep the store consumer-agnostic: it only serializes the domain `payload` envelope and never interprets Keeper/task/board/goal/tool semantics
- stack this on #21022, which tightens payloads to `{ kind; schema_version; body }`

## Verification

- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_schedule_store.exe test/test_schedule_domain.exe`
- `_build/default/test/test_schedule_store.exe`
- `_build/default/test/test_schedule_domain.exe`
- `git diff --check`
- forbidden schedule dependency grep for Keeper/board/task/goal/tool target terms
