### PR TITLE
[codex] surface Discord chat failure observability

### DIFF
--- a/infrastructure/monitoring/grafana/provisioning/alerting/masc-fleet-alerts.yml
+++ b/infrastructure/monitoring/grafana/provisioning/alerting/masc-fleet-alerts.yml
@@ -182,3 +182,71 @@ groups:
               refId: C
               conditions:
                 - evaluator: { type: gt, params: [0] }
+
+      - uid: masc-discord-heartbeat-ack-timeout
+        title: Discord heartbeat ACK timeouts
+        condition: C
+        for: 0m
+        noDataState: NoData
+        execErrState: Error
+        labels: { severity: warning }
+        annotations:
+          summary: >-
+            Discord gateway missed heartbeat ACKs in the last 10 minutes.
+            This is the direct reconnect root cause added after the Discord
+            disconnect fixes; inspect gateway logs before treating reconnects
+            as generic network noise.
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: P4169E866C3094E38
+            model:
+              expr: sum(increase(masc_discord_gateway_ack_timeouts_total[10m]))
+              refId: A
+              intervalMs: 60000
+              maxDataPoints: 300
+          - refId: B
+            datasourceUid: __expr__
+            model: { type: reduce, expression: A, reducer: last, refId: B }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              refId: C
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
+      - uid: masc-chat-transport-failure
+        title: Keeper chat transport failures
+        condition: C
+        for: 0m
+        noDataState: NoData
+        execErrState: Error
+        labels: { severity: warning }
+        annotations:
+          summary: >-
+            Keeper chat transport failures were persisted in the last
+            10 minutes. These rows render to the operator but do not clear
+            the pending user message, so non-zero values explain
+            dropped-looking conversations that should retry on the next turn.
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: P4169E866C3094E38
+            model:
+              expr: sum(increase(masc_keeper_chat_transport_failures_total[10m]))
+              refId: A
+              intervalMs: 60000
+              maxDataPoints: 300
+          - refId: B
+            datasourceUid: __expr__
+            model: { type: reduce, expression: A, reducer: last, refId: B }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              refId: C
+              conditions:
+                - evaluator: { type: gt, params: [0] }

--- a/infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json
+++ b/infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json
@@ -2443,12 +2443,11 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Receipts with unmapped disposition values by keeper.",
+      "description": "Keeper chat request failures written as transport_failure rows, grouped by source. Non-zero values explain conversations that looked dropped but remain pending for retry.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "dark-yellow",
-            "mode": "fixed"
+            "mode": "thresholds"
           },
           "custom": {
             "drawStyle": "line",
@@ -2457,7 +2456,24 @@
             "pointSize": 0,
             "showPoints": "never"
           },
-          "unit": "cpm"
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
         }
       },
       "gridPos": {
@@ -2468,9 +2484,13 @@
       },
       "options": {
         "legend": {
-          "displayMode": "list",
+          "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
         },
         "tooltip": {
           "mode": "multi",
@@ -2479,12 +2499,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (keeper) (rate(masc_keeper_receipt_unmapped_disposition_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
-          "legendFormat": "{{keeper}}",
+          "expr": "sum by (keeper, source) (rate(masc_keeper_chat_transport_failures_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}} {{source}}",
           "refId": "A"
         }
       ],
-      "title": "Receipt Unmapped Disposition",
+      "title": "Chat Transport Failures",
       "transparent": true,
       "type": "timeseries"
     },
@@ -2604,5 +2624,5 @@
   "timezone": "browser",
   "title": "MASC Keeper Full Observability",
   "uid": "masc-keeper-full",
-  "version": 1
+  "version": 2
 }

--- a/infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json
+++ b/infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json
@@ -249,8 +249,8 @@
       }
     },
     {
-      "type": "barchart",
-      "title": "Surface Opens \u2014 7d",
+      "type": "timeseries",
+      "title": "Chat Transport Failures / min",
       "gridPos": {
         "x": 12,
         "y": 8,
@@ -261,19 +261,36 @@
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
       },
-      "description": "Top-level dashboard surface openings in the last 7 days.",
+      "description": "User-visible keeper chat request failures persisted as transport_failure rows. This is the signal for dropped-looking conversations that stay pending for retry.",
       "targets": [
         {
-          "expr": "sum by (surface) (increase(dashboard_surface_open_total[7d]))",
-          "legendFormat": "{{surface}}",
+          "expr": "sum by (source) (rate(masc_keeper_chat_transport_failures_total[5m])) * 60",
+          "legendFormat": "{{source}}",
           "refId": "A"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "ops",
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
           }
         }
       },
@@ -1507,9 +1524,14 @@
           "expr": "sum by (event, route) (rate(masc_discord_gateway_events_total[5m])) * 60",
           "legendFormat": "{{event}} / {{route}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(rate(masc_discord_gateway_ack_timeouts_total[5m])) * 60",
+          "legendFormat": "heartbeat_ack_timeout/min",
+          "refId": "B"
         }
       ],
-      "description": "Gateway readiness, message, reaction, ignored, and WSS open events by low-cardinality route."
+      "description": "Gateway event flow plus explicit heartbeat ACK timeout source signal."
     },
     {
       "id": 18,
@@ -1542,7 +1564,7 @@
           "refId": "A"
         }
       ],
-      "description": "Mention/control dispatch outcomes: dropped unbound, gate error, empty reply, sent, and send error."
+      "description": "Triggered Discord messages by delivery outcome. dispatch_unavailable means the bound keeper was reached but unavailable; reply status is tracked separately."
     },
     {
       "id": 19,
@@ -1580,7 +1602,7 @@
     {
       "id": 20,
       "type": "timeseries",
-      "title": "Discord Reconnects and Closes",
+      "title": "Discord Reconnects, Closes, ACK Timeouts",
       "gridPos": {
         "x": 0,
         "y": 178,
@@ -1611,9 +1633,14 @@
           "expr": "sum by (code) (rate(masc_discord_gateway_closes_total[5m])) * 60",
           "legendFormat": "close {{code}}/min",
           "refId": "B"
+        },
+        {
+          "expr": "sum(rate(masc_discord_gateway_ack_timeouts_total[5m])) * 60",
+          "legendFormat": "heartbeat_ack_timeout/min",
+          "refId": "C"
         }
       ],
-      "description": "Connector stability signal: reconnect scheduling plus gateway close codes."
+      "description": "Connector stability signal: ACK timeout root cause, reconnect scheduling, and gateway close codes."
     },
     {
       "id": 21,
@@ -1646,7 +1673,7 @@
           "refId": "A"
         }
       ],
-      "description": "Reply send outcomes from Discord-bound keeper responses."
+      "description": "Discord REST send outcomes. Pair with inbound dispatch_unavailable to distinguish unavailable notices from real keeper replies."
     }
   ],
   "refresh": "30s",
@@ -1665,5 +1692,5 @@
   "timezone": "browser",
   "title": "MASC Overview",
   "uid": "masc-overview",
-  "version": 3
+  "version": 4
 }

--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -136,13 +136,16 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
               send the next heartbeat and start waiting for its ACK. *)
            Atomic.set heartbeat_ack_ok false;
            Eio.Stream.add input_mailbox Discord_gateway_state.Heartbeat_tick
-         end else
-           (* Discord docs: "If a client does not receive a heartbeat
-              ack between its attempts at sending heartbeats, it should
-              immediately terminate the connection with a non-1000
-              close code and reconnect." *)
-           Eio.Stream.add input_mailbox
-             Discord_gateway_state.Heartbeat_ack_timeout);
+        end else
+          (* Discord docs: "If a client does not receive a heartbeat
+             ack between its attempts at sending heartbeats, it should
+             immediately terminate the connection with a non-1000
+             close code and reconnect." *)
+          begin
+            Discord_observability.record_gateway_ack_timeout ();
+            Eio.Stream.add input_mailbox
+              Discord_gateway_state.Heartbeat_ack_timeout
+          end);
       loop ()
     in
     loop ());

--- a/lib/gate/discord_observability.ml
+++ b/lib/gate/discord_observability.ml
@@ -14,6 +14,7 @@ type gateway_event =
 
 type inbound_outcome =
   | Dropped_unbound
+  | Dispatch_unavailable
   | Gate_error
   | Empty_reply
   | Reply_sent
@@ -44,6 +45,7 @@ let gateway_event_label = function
 
 let inbound_outcome_label = function
   | Dropped_unbound -> "dropped_unbound"
+  | Dispatch_unavailable -> "dispatch_unavailable"
   | Gate_error -> "gate_error"
   | Empty_reply -> "empty_reply"
   | Reply_sent -> "reply_sent"
@@ -80,6 +82,9 @@ let record_gateway_reconnect_scheduled () =
   inc
     Otel_transport_metric_names.metric_discord_gateway_reconnect_scheduled
     ~labels:[]
+
+let record_gateway_ack_timeout () =
+  inc Otel_transport_metric_names.metric_discord_gateway_ack_timeouts ~labels:[]
 
 let record_inbound_dispatch outcome =
   inc

--- a/lib/gate/discord_observability.mli
+++ b/lib/gate/discord_observability.mli
@@ -18,6 +18,7 @@ type gateway_event =
 
 type inbound_outcome =
   | Dropped_unbound
+  | Dispatch_unavailable
   | Gate_error
   | Empty_reply
   | Reply_sent
@@ -43,6 +44,7 @@ val reply_outcome_label : reply_outcome -> string
 val record_gateway_event : route:gateway_route -> gateway_event -> unit
 val record_gateway_close : code:int -> unit
 val record_gateway_reconnect_scheduled : unit -> unit
+val record_gateway_ack_timeout : unit -> unit
 val record_inbound_dispatch : inbound_outcome -> unit
 val record_ambient : ambient_outcome -> unit
 val record_reply : reply_outcome -> unit

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -157,6 +157,7 @@ type t =
   | AlertPersistFailures
   | MetricsSseFailures
   | ChatStoreFailures
+  | ChatTransportFailures
   | PersonNoteStoreFailures
   | ObservationQueryFailures
   | OasOnStop
@@ -385,6 +386,7 @@ let to_string = function
   | AlertPersistFailures -> "masc_keeper_alert_persist_failures_total"
   | MetricsSseFailures -> "masc_keeper_metrics_sse_failures_total"
   | ChatStoreFailures -> "masc_keeper_chat_store_failures_total"
+  | ChatTransportFailures -> "masc_keeper_chat_transport_failures_total"
   | PersonNoteStoreFailures -> "masc_keeper_person_note_store_failures_total"
   | ObservationQueryFailures -> "masc_keeper_observation_query_failures_total"
   | OasOnStop -> "masc_keeper_oas_on_stop_total"
@@ -498,7 +500,7 @@ let all : t list =
     MemoryLlmSummaryOutcomes; MemoryLlmSummaryChainExhausted; UserVisibleReplySource; ContinuitySummarySource;
     SummarizerStateScrubs; SummarizerStateBlocksRemoved; OasEnvKeyRejections; ContinuityTsRecovered;
     MemoryWriteFailures; MemoryConsolidations; WriteMetaCycleFailures; AlertPersistFailures;
-    MetricsSseFailures; ChatStoreFailures; PersonNoteStoreFailures; ObservationQueryFailures; OasOnStop;
+    MetricsSseFailures; ChatStoreFailures; ChatTransportFailures; PersonNoteStoreFailures; ObservationQueryFailures; OasOnStop;
     OasOnIdleEscalated; InvariantViolations; FsmEdgeTransitions; TurnFsmTransitions;
     TurnPhaseDuration; LifecycleTransitions; LifecycleCallbackFailures; CompactionCallbackRecoveries;
     EventBusDrain; SupervisorCleanupFailures; SpawnSlotDenied; RegistryUpdateDropped;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -148,6 +148,7 @@ type t =
   | AlertPersistFailures
   | MetricsSseFailures
   | ChatStoreFailures
+  | ChatTransportFailures
   | PersonNoteStoreFailures
   | ObservationQueryFailures
   | OasOnStop

--- a/lib/otel_metric_store/otel_transport_metric_names.ml
+++ b/lib/otel_metric_store/otel_transport_metric_names.ml
@@ -59,6 +59,11 @@ let metric_discord_gateway_reconnect_scheduled =
     "masc_discord_gateway_reconnect_scheduled_total"
 ;;
 
+let metric_discord_gateway_ack_timeouts =
+  Otel_metric_store_core.declare_counter
+    "masc_discord_gateway_ack_timeouts_total"
+;;
+
 let metric_discord_inbound_dispatch =
   Otel_metric_store_core.declare_counter "masc_discord_inbound_dispatch_total"
 ;;

--- a/lib/otel_metric_store/otel_transport_metric_names.mli
+++ b/lib/otel_metric_store/otel_transport_metric_names.mli
@@ -60,10 +60,14 @@ val metric_discord_gateway_closes : string
 (** Discord gateway reconnect backoffs scheduled by the state machine. *)
 val metric_discord_gateway_reconnect_scheduled : string
 
+(** Discord gateway heartbeat ACK liveness failures detected by the WSS I/O
+    loop before forcing a reconnect. *)
+val metric_discord_gateway_ack_timeouts : string
+
 (** Triggered Discord inbound messages after keeper binding lookup.
     Labels: [outcome] =
-    [dropped_unbound | gate_error | empty_reply | reply_sent |
-     reply_send_error]. *)
+    [dropped_unbound | dispatch_unavailable | gate_error | empty_reply |
+     reply_sent | reply_send_error]. *)
 val metric_discord_inbound_dispatch : string
 
 (** Ambient Discord messages that did not trigger a turn.

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -309,12 +309,12 @@ let handle_message_create ~dispatch
                   ~reply_to_message_id:message_id () with
            | Ok _ ->
              Discord_observability.record_inbound_dispatch
-               Discord_observability.Reply_sent;
+               Discord_observability.Dispatch_unavailable;
              Discord_observability.record_reply
                Discord_observability.Reply_send_ok
            | Error e ->
              Discord_observability.record_inbound_dispatch
-               Discord_observability.Gate_error;
+               Discord_observability.Dispatch_unavailable;
              Discord_observability.record_reply
                Discord_observability.Reply_send_failed;
              Log.Server.error

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -633,6 +633,10 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
        operator but does not advance the lane watermark, so the user
        message it failed to answer stays pending for the keeper's next
        turn — and the keeper never reads the error as its own words. *)
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ChatTransportFailures)
+      ~labels:[ ("keeper", payload.name); ("source", chat_source) ]
+      ();
     Keeper_chat_store.append_turn
       ~base_dir:base_path
       ~keeper_name:payload.name

--- a/test/test_discord_observability.ml
+++ b/test/test_discord_observability.ml
@@ -18,6 +18,8 @@ let test_label_contract () =
     (Obs.gateway_event_label Obs.Message_create);
   check string "dispatch dropped_unbound" "dropped_unbound"
     (Obs.inbound_outcome_label Obs.Dropped_unbound);
+  check string "dispatch unavailable" "dispatch_unavailable"
+    (Obs.inbound_outcome_label Obs.Dispatch_unavailable);
   check string "ambient too_long" "dropped_too_long"
     (Obs.ambient_outcome_label Obs.Ambient_dropped_too_long);
   check string "reply failed" "send_error"
@@ -37,10 +39,14 @@ let test_gateway_reconnect_counter () =
   check_delta Names.metric_discord_gateway_reconnect_scheduled (fun () ->
     Obs.record_gateway_reconnect_scheduled ())
 
+let test_gateway_ack_timeout_counter () =
+  check_delta Names.metric_discord_gateway_ack_timeouts (fun () ->
+    Obs.record_gateway_ack_timeout ())
+
 let test_inbound_dispatch_counter () =
-  let labels = [ "outcome", "gate_error" ] in
+  let labels = [ "outcome", "dispatch_unavailable" ] in
   check_delta Names.metric_discord_inbound_dispatch ~labels (fun () ->
-    Obs.record_inbound_dispatch Obs.Gate_error)
+    Obs.record_inbound_dispatch Obs.Dispatch_unavailable)
 
 let test_ambient_counter () =
   let labels = [ "outcome", "recorded" ] in
@@ -63,6 +69,8 @@ let () =
         ; test_case "gateway close counter" `Quick test_gateway_close_counter
         ; test_case "gateway reconnect counter" `Quick
             test_gateway_reconnect_counter
+        ; test_case "gateway ack timeout counter" `Quick
+            test_gateway_ack_timeout_counter
         ; test_case "inbound dispatch counter" `Quick
             test_inbound_dispatch_counter
         ; test_case "ambient counter" `Quick test_ambient_counter

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -46,11 +46,18 @@ let test_keeper_metrics_zero_filled () =
   | Some m ->
     check (float 0.0) "keeper failure counter starts at 0" 0.0 m.value
 
+let test_chat_transport_metric_zero_filled () =
+  match find_unlabeled Keeper_metrics.(to_string ChatTransportFailures) with
+  | None ->
+    fail "masc_keeper_chat_transport_failures_total must be registered at module init"
+  | Some m ->
+    check (float 0.0) "chat transport failure counter starts at 0" 0.0 m.value
+
 let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
      constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 207
+  check int "Keeper_metrics.all covers every constructor" 210
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"
@@ -66,6 +73,8 @@ let () =
     ; ( "module-init"
       , [ test_case "name module constant" `Quick test_name_module_constant_zero_filled
         ; test_case "keeper metrics" `Quick test_keeper_metrics_zero_filled
+        ; test_case "chat transport metric" `Quick
+            test_chat_transport_metric_zero_filled
         ; test_case "keeper all complete" `Quick test_keeper_metrics_all_complete
         ] )
     ]


### PR DESCRIPTION
## Summary

- add an OTel counter for Discord gateway heartbeat ACK timeouts at the WSS I/O loop
- split Discord inbound `dispatch_unavailable` from normal `reply_sent`, while keeping REST send status in outbound reply metrics
- add `masc_keeper_chat_transport_failures_total` when keeper chat writes a typed `transport_failure` row
- update Grafana overview / keeper dashboard panels plus Grafana alert rules for ACK timeouts and chat transport failures

## Why

Recent PR scan over the latest 500 PRs pointed at a few merged slices whose runtime behavior was not visible enough in OTel/Grafana:

- #20861 added Discord gateway metrics, but #21001 later added heartbeat ACK timeout detection without a direct ACK-timeout metric.
- #21002 added typed `transport_failure` chat rows so failed messages stay pending, but Grafana had no counter for dropped-looking conversations.
- #21006 sends an unavailable notice when the bound keeper is offline, but the inbound metric still looked like a normal `reply_sent` path.
- #21011 broadened Discord thread triggering, which makes connector liveness and delivery-loss panels more important than broad dashboard-surface vanity charts.

## Verification

- `ocamlformat --check lib/gate/discord_observability.ml lib/gate/discord_observability.mli lib/gate/discord_gateway_client.ml lib/server/server_discord_in_process_gateway.ml lib/server/server_routes_http_keeper_stream.ml lib/keeper_metrics/keeper_metrics.ml lib/keeper_metrics/keeper_metrics.mli lib/otel_metric_store/otel_transport_metric_names.ml lib/otel_metric_store/otel_transport_metric_names.mli test/test_discord_observability.ml test/test_otel_zero_fill.ml`
- `git diff --check`
- JSON parse: `masc-overview.json`, `masc-keeper-full.json`
- YAML parse: `masc-fleet-alerts.yml`
- `scripts/dune-local.sh build test/test_discord_observability.exe test/test_otel_zero_fill.exe` (blocked by local `agent_sdk` pin guard: installed `0.206.2`, expected `>= 0.206.3`)
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_discord_observability.exe test/test_otel_zero_fill.exe`
- `_build/default/test/test_discord_observability.exe`
- `_build/default/test/test_otel_zero_fill.exe`
