### PR TITLE
feat(discord): default mention_or_thread + TOML config + dashboard badge

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -163,3 +163,13 @@ max-concurrent = 1
 # [runtime.assignments]
 # sangsu = "glm-coding.glm-5-turbo"
 # nick0cave = "ollama.gemma4-26b-a4b-qat"
+
+# ── Discord ──────────────────────────────────────────────────────────
+# Trigger policy controls which inbound Discord events the bot responds to.
+#   mention_or_thread  — 스레드에서 자동 응답, 일반 채널은 멘션 필요 (기본값)
+#   mention_only       — @멘션된 메시지만 응답
+#   all                — 모든 메시지에 응답
+#   user_only:<snowflake> — 특정 사용자만
+# Env var MASC_DISCORD_TRIGGER_POLICY overrides this value.
+[discord]
+trigger_policy = "mention_or_thread"

--- a/dashboard/src/api/schemas/gate-connectors.ts
+++ b/dashboard/src/api/schemas/gate-connectors.ts
@@ -389,6 +389,7 @@ const GateConnectorsOuterSchema = object({
   connectors: optional(unknown()),
   total: fallback(number(), 0),
   active_count: fallback(number(), 0),
+  discord_trigger_policy: fallback(string(), 'unknown'),
   // Empty string is treated as drift — matches prior decoder's
   // `if (!generatedAt) return null` guard. A connectors payload
   // without a timestamp is not a useful one; the null-returning
@@ -400,6 +401,7 @@ export interface GateConnectorsData {
   connectors: GateConnectorInfo[]
   total: number
   active_count: number
+  discord_trigger_policy: string
   generated_at: string
 }
 
@@ -425,6 +427,7 @@ export function parseGateConnectorsData(data: unknown): GateConnectorsData {
     connectors,
     total: outer.total,
     active_count: outer.active_count,
+    discord_trigger_policy: outer.discord_trigger_policy,
     generated_at: outer.generated_at,
   }
 }

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -155,6 +155,7 @@ async function runBulk(
 interface OverviewProps {
   connectors: GateConnectorInfo[]
   keeperCount: number
+  discordTriggerPolicy?: string
   selectedConnectorId?: KnownConnectorId | null
   onSelectConnector?: (connectorId: KnownConnectorId) => void
   detailTargetId?: string
@@ -719,6 +720,7 @@ function IncidentBanner({ droppedIds }: { droppedIds: string[] }) {
 export function ConnectorOverviewStrip({
   connectors,
   keeperCount,
+  discordTriggerPolicy,
   selectedConnectorId = null,
   onSelectConnector,
   detailTargetId = 'connector-detail-panel',
@@ -749,7 +751,13 @@ export function ConnectorOverviewStrip({
     <${SurfaceCard} class="mb-4 !p-3" data-overview-strip-root>
       <${IncidentBanner} droppedIds=${droppedIds} />
       <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <${StatusSummaryLine} summary=${summary} connectors=${connectors} />
+        <div class="flex flex-wrap items-center gap-2">
+          <${StatusSummaryLine} summary=${summary} connectors=${connectors} />
+          ${discordTriggerPolicy && discordTriggerPolicy !== 'unknown'
+            ? html`<span class="rounded-[var(--r-0)] border border-[var(--border-subtle)] bg-[var(--surface-inset)] px-2 py-0.5 text-3-xs font-medium text-[var(--color-fg-secondary)]">trigger: ${discordTriggerPolicy}</span>`
+            : null
+          }
+        </div>
         <${BulkActions} connectors=${connectors} />
       </div>
       <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1697,6 +1697,7 @@ export function ConnectorStatusPanel() {
             <${ConnectorOverviewStrip}
               connectors=${allConnectors}
               keeperCount=${snapshot.keepers.length}
+              discordTriggerPolicy=${snapshot.connectors?.discord_trigger_policy}
               selectedConnectorId=${focusedConnectorId}
               onSelectConnector=${(connectorId: KnownConnectorId) => { selectedConnectorId.value = connectorId }}
               detailTargetId="connector-detail-panel"

--- a/lib/gate/channel_gate_connector.ml
+++ b/lib/gate/channel_gate_connector.ml
@@ -52,11 +52,17 @@ let connectors_json ?gate_status_json ?(audit_limit = 10) () =
         else acc)
       0 connector_jsons
   in
+  let policy_str =
+    match Channel_gate_discord_state.get_trigger_policy () with
+    | None -> "unknown"
+    | Some p -> Discord_gateway_state.trigger_policy_to_string p
+  in
   `Assoc
     [
       ("connectors", `List connector_jsons);
       ("total", `Int (List.length connectors));
       ("active_count", `Int active_count);
+      ("discord_trigger_policy", `String policy_str);
       ("generated_at",
        `String (Gate_time_util.iso8601_of_unix (Unix.gettimeofday ())));
     ]

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -170,6 +170,19 @@ let is_known_thread ~channel_id =
 
 let registered_thread_count () = Hashtbl.length thread_parent_table
 
+(* ── Trigger policy registry ──────────────────────────────────────
+   Set once at gateway startup by [set_trigger_policy]. Read by
+   [connectors_json] for dashboard display. Same mutable-ref pattern
+   as [record_ready]. *)
+
+let trigger_policy_ref : Discord_gateway_state.trigger_policy option ref =
+  ref None
+
+let set_trigger_policy (policy : Discord_gateway_state.trigger_policy) =
+  trigger_policy_ref := Some policy
+
+let get_trigger_policy () = !trigger_policy_ref
+
 let read_recent_audit ~limit =
   let path = binding_audit_read_path () in
   if limit <= 0 || not (Sys.file_exists path) then

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -122,6 +122,17 @@ val is_known_thread : channel_id:string -> bool
 val registered_thread_count : unit -> int
 (** Number of threads currently in the registry. For diagnostics. *)
 
+(** {2 Trigger policy}
+
+    Set once at gateway startup, read by [connectors_json] for dashboard
+    display. Same mutable-ref pattern as [record_ready]. *)
+
+val set_trigger_policy : Discord_gateway_state.trigger_policy -> unit
+(** Store the resolved trigger policy. Called once at gateway startup. *)
+
+val get_trigger_policy : unit -> Discord_gateway_state.trigger_policy option
+(** Current trigger policy. [None] before gateway startup. *)
+
 (** Typed failure modes for Discord REST actions. Closed sum — adding
     a new variant forces every consumer to handle it. *)
 type send_error =

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -184,8 +184,14 @@ let parse_trigger_policy s =
   | _ ->
       Error
         (Printf.sprintf
-           "unknown trigger policy %S — expected mention_only | mention_or_thread | user_only:<id> | all"
+           "unknown trigger policy %S — expected mention_or_thread | mention_only | user_only:<id> | all"
            s)
+
+let trigger_policy_to_string = function
+  | Mention_only -> "mention_only"
+  | Mention_or_thread -> "mention_or_thread"
+  | User_only id -> Printf.sprintf "user_only:%s" id
+  | All -> "all"
 
 (* ── Opaque state ──────────────────────────────────────────────── *)
 

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -201,9 +201,12 @@ and trigger_policy =
 
 val parse_trigger_policy : string -> (trigger_policy, string) result
 (** Decodes [DISCORD_TRIGGER_POLICY] env value. Accepts exactly
-    ["mention_only"], ["user_only:<snowflake>"], ["all"]. Anything
+    ["mention_only"], ["mention_or_thread"], ["user_only:<snowflake>"], ["all"]. Anything
     else returns [Error] — no string-classifier inference
     (RFC-0203 §Non-goals). *)
+
+val trigger_policy_to_string : trigger_policy -> string
+(** Inverse of {!parse_trigger_policy}. Used for diagnostics and API exposure. *)
 
 (** {1 The state machine itself} *)
 

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -31,7 +31,7 @@ let bot_token_opt () = trimmed_env "DISCORD_BOT_TOKEN"
    compile at every call site rather than silently falling through. *)
 let parse_trigger_policy raw : Gw.trigger_policy =
   let s = String.trim raw in
-  if String.equal s "" then Gw.Mention_only
+  if String.equal s "" then Gw.Mention_or_thread
   else
     match s with
     | "mention_only" -> Gw.Mention_only
@@ -44,13 +44,29 @@ let parse_trigger_policy raw : Gw.trigger_policy =
          && String.equal (String.sub other 0 plen) prefix
       then
         let id = String.trim (String.sub other plen (String.length other - plen)) in
-        if String.equal id "" then Gw.Mention_only else Gw.User_only id
-      else Gw.Mention_only
+        if String.equal id "" then Gw.Mention_or_thread else Gw.User_only id
+      else Gw.Mention_or_thread
 
 let resolved_trigger_policy () =
-  match trimmed_env "MASC_DISCORD_TRIGGER_POLICY" with
-  | None -> Gw.Mention_only
+  let from_toml () =
+    try
+      let resolution = Config_dir_resolver.resolve () in
+      let toml_path =
+        Filename.concat resolution.Config_dir_resolver.config_root.path
+          Config_dir_resolver.runtime_toml_filename
+      in
+      if Sys.file_exists toml_path then
+        let tbl = Otoml.Parser.from_file toml_path in
+        Otoml.find_opt tbl Otoml.get_string [ "discord"; "trigger_policy" ]
+      else None
+    with _ -> None
+  in
+  match from_toml () with
   | Some raw -> parse_trigger_policy raw
+  | None ->
+    (match trimmed_env "MASC_DISCORD_TRIGGER_POLICY" with
+    | None -> Gw.Mention_or_thread
+    | Some raw -> parse_trigger_policy raw)
 
 (* ---------------------------------------------------------------- *)
 (* Inbound delivery                                                 *)
@@ -482,6 +498,7 @@ let start ~sw ~env ~clock ~state =
       "RFC-0203: DISCORD_BOT_TOKEN is unset; in-process Discord gateway not started"
   | Some token ->
     let policy = resolved_trigger_policy () in
+    State.set_trigger_policy policy;
     let dispatch =
       Gate_keeper_backend.dispatch
         ~sw ~clock
@@ -489,13 +506,7 @@ let start ~sw ~env ~clock ~state =
         ~net:state.Mcp_server.net
         ~config:state.Mcp_server.workspace_config
     in
-    let policy_label =
-      match policy with
-      | Gw.Mention_only -> "mention_only"
-      | Gw.Mention_or_thread -> "mention_or_thread"
-      | Gw.All -> "all"
-      | Gw.User_only _ -> "user_only:<id>"
-    in
+    let policy_label = Discord_gateway_state.trigger_policy_to_string policy in
     Log.Server.info
       "RFC-0203: starting in-process Discord gateway (policy=%s, intents=%d)"
       policy_label


### PR DESCRIPTION
## Changes

- **Default trigger_policy**: `mention_only` → `mention_or_thread`
- **TOML config**: New `[discord]` section in `runtime.toml` with `trigger_policy` field
- **Config priority**: TOML → env `MASC_DISCORD_TRIGGER_POLICY` → default
- **Dashboard**: trigger_policy badge in connector overview strip
- **API**: `discord_trigger_policy` field in `/api/v1/gate/connectors` response

## Verification

- `dune build --root . @check` pass
- `dune exec test/test_discord_gateway_state.exe` — 62/62 pass
- Dashboard `tsc --noEmit` pass
- Dashboard vitest — 66/66 + 18/18 pass

Co-Authored-By: Claude <noreply@anthropic.com>
