### PR TITLE
feat(schedule): add service API boundary

### DIFF
--- a/lib/schedule/dune
+++ b/lib/schedule/dune
@@ -1,11 +1,11 @@
 (include_subdirs no)
 
-;; Scheduled internal automation domain + file store. No runner, shell, or
+;; Scheduled internal automation domain + service/store. No runner, shell, or
 ;; transport dependency at this layer.
 
 (library
  (name masc_schedule)
  (public_name masc.masc_schedule)
  (wrapped false)
- (modules schedule_domain schedule_store)
+ (modules schedule_domain schedule_store schedule_service)
  (libraries digestif masc_workspace unix yojson))

--- a/lib/schedule/schedule_service.ml
+++ b/lib/schedule/schedule_service.ml
@@ -1,0 +1,116 @@
+type service_error =
+  | Invalid_request of string
+  | Store_error of Schedule_store.store_error
+
+let ( let* ) = Result.bind
+
+let service_error_to_string = function
+  | Invalid_request msg -> "invalid request: " ^ msg
+  | Store_error err -> Schedule_store.store_error_to_string err
+;;
+
+let map_store = function
+  | Ok value -> Ok value
+  | Error err -> Error (Store_error err)
+;;
+
+(* NDT-OK: service boundary clock; callers can pass explicit timestamps for replay/tests. *)
+let now () = Unix.gettimeofday ()
+
+let id_counter = Atomic.make 0
+
+let mint_id prefix =
+  let micros = int_of_float (now () *. 1_000_000.0) in
+  let serial = Atomic.fetch_and_add id_counter 1 in
+  (* NDT-OK: ID entropy only; schedule ordering and eligibility never branch on it. *)
+  let entropy = Hashtbl.hash (Unix.getpid (), micros, serial) land 0xFFFFFF in
+  Printf.sprintf "%s-%d-%06x-%d" prefix micros entropy serial
+;;
+
+let schedule_id = function
+  | Some id -> id
+  | None -> mint_id "sched"
+;;
+
+let grant_id = function
+  | Some id -> id
+  | None -> mint_id "grant"
+;;
+
+let create
+  config
+  ?schedule_id:provided_schedule_id
+  ?requested_at
+  ?expires_at
+  ?(approval_required = false)
+  ~requested_by
+  ~scheduled_by
+  ~due_at
+  ~payload
+  ~risk_class
+  ~source
+  ()
+  =
+  (* NDT-OK: API boundary default; callers may provide requested_at explicitly. *)
+  let requested_at = Option.value requested_at ~default:(now ()) in
+  let schedule_id = schedule_id provided_schedule_id in
+  let* request =
+    Schedule_domain.create_request ~schedule_id ~requested_by ~scheduled_by
+      ~requested_at ~due_at ?expires_at ~payload ~risk_class
+      ~approval_required ~source ()
+    |> function
+    | Ok request -> Ok request
+    | Error msg -> Error (Invalid_request msg)
+  in
+  Schedule_store.insert_request config request |> map_store
+;;
+
+let list config ?status () =
+  let schedules = Schedule_store.list_schedules config in
+  match status with
+  | None -> schedules
+  | Some expected ->
+    List.filter
+      (fun (request : Schedule_domain.schedule_request) ->
+        request.status = expected)
+      schedules
+;;
+
+let get config ~schedule_id = Schedule_store.get_schedule config ~schedule_id
+
+let decision_grant
+  config
+  ?grant_id:provided_grant_id
+  ?approved_at
+  ~schedule_id
+  ~approved_by
+  ~decision
+  ()
+  =
+  match Schedule_store.get_schedule config ~schedule_id with
+  | None -> Error (Store_error Schedule_store.Schedule_not_found)
+  | Some request -> (* NDT-OK: API boundary default; explicit approved_at is supported. *)
+    let approved_at = Option.value approved_at ~default:(now ()) in
+    let grant_id = grant_id provided_grant_id in
+    let grant =
+      Schedule_domain.create_execution_grant ~grant_id ~approved_by
+        ~approved_at ~decision request
+    in
+    Schedule_store.record_grant config grant |> map_store
+;;
+
+let approve config ?grant_id ?approved_at ~schedule_id ~approved_by () =
+  decision_grant config ?grant_id ?approved_at ~schedule_id ~approved_by
+    ~decision:Schedule_domain.Approve ()
+;;
+
+let reject config ?grant_id ?approved_at ~schedule_id ~approved_by ~reason () =
+  decision_grant config ?grant_id ?approved_at ~schedule_id ~approved_by
+    ~decision:(Schedule_domain.Reject reason) ()
+;;
+
+let due_candidates config ~now =
+  match Schedule_store.refresh_due config ~now with
+  | Error err -> Error (Store_error err)
+  | Ok (state, _) -> Ok (Schedule_store.due_execution_candidates state)
+;;

--- a/lib/schedule/schedule_service.mli
+++ b/lib/schedule/schedule_service.mli
@@ -1,0 +1,62 @@
+(** User-facing service boundary for scheduled internal automation.
+
+    This module creates and approves durable schedule records. It does not run
+    due work and does not interact with consumer lifecycle state. *)
+
+type service_error =
+  | Invalid_request of string
+  | Store_error of Schedule_store.store_error
+
+val service_error_to_string : service_error -> string
+
+val create :
+  Workspace_utils.config ->
+  ?schedule_id:string ->
+  ?requested_at:float ->
+  ?expires_at:float ->
+  ?approval_required:bool ->
+  requested_by:Schedule_domain.actor ->
+  scheduled_by:Schedule_domain.actor ->
+  due_at:float ->
+  payload:Yojson.Safe.t ->
+  risk_class:Schedule_domain.risk_class ->
+  source:Schedule_domain.schedule_source ->
+  unit ->
+  (Schedule_domain.schedule_request, service_error) result
+
+val list :
+  Workspace_utils.config ->
+  ?status:Schedule_domain.schedule_status ->
+  unit ->
+  Schedule_domain.schedule_request list
+
+val get :
+  Workspace_utils.config ->
+  schedule_id:string ->
+  Schedule_domain.schedule_request option
+
+val approve :
+  Workspace_utils.config ->
+  ?grant_id:string ->
+  ?approved_at:float ->
+  schedule_id:string ->
+  approved_by:Schedule_domain.actor ->
+  unit ->
+  (Schedule_domain.schedule_request, service_error) result
+
+val reject :
+  Workspace_utils.config ->
+  ?grant_id:string ->
+  ?approved_at:float ->
+  schedule_id:string ->
+  approved_by:Schedule_domain.actor ->
+  reason:string ->
+  unit ->
+  (Schedule_domain.schedule_request, service_error) result
+
+val due_candidates :
+  Workspace_utils.config ->
+  now:float ->
+  (Schedule_domain.schedule_request list, service_error) result
+(** Refreshes due state and returns visible execution candidates. No execution
+    is performed here. *)

--- a/test/dune
+++ b/test/dune
@@ -1054,6 +1054,11 @@
  (modules test_schedule_store)
  (libraries masc_test_deps masc_schedule))
 
+(test
+ (name test_schedule_service)
+ (modules test_schedule_service)
+ (libraries masc_test_deps masc_schedule))
+
 ; Typed TOML field resolution helper (RFC-0141 Phase 1).
 
 (test

--- a/test/test_schedule_service.ml
+++ b/test/test_schedule_service.ml
@@ -1,0 +1,196 @@
+open Alcotest
+open Masc
+open Schedule_domain
+open Schedule_service
+
+let temp_dir () =
+  let path = Filename.temp_file "schedule_service_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let with_workspace f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  let config = Workspace.default_config dir in
+  ignore (Workspace.init config ~agent_name:(Some "test"));
+  f config
+;;
+
+let human ?display_name id = { id; kind = Human_operator; display_name }
+
+let payload_json () =
+  `Assoc
+    [ "kind", `String "consumer.note"
+    ; "schema_version", `Int 1
+    ; "body", `Assoc [ "text", `String "do later" ]
+    ]
+;;
+
+let has_prefix prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len
+  && String.sub value 0 prefix_len = prefix
+;;
+
+let create_ok
+  ?schedule_id
+  ?(risk_class = Workspace_write)
+  ?approval_required
+  config
+  =
+  match
+    create config ?schedule_id ?approval_required ~requested_at:100.0
+      ~requested_by:(human "requester") ~scheduled_by:(human "scheduler")
+      ~due_at:200.0 ~payload:(payload_json ()) ~risk_class
+      ~source:Operator_request ()
+  with
+  | Ok request -> request
+  | Error err -> fail (service_error_to_string err)
+;;
+
+let check_status label expected actual =
+  check string label (schedule_status_to_string expected) (schedule_status_to_string actual)
+;;
+
+let check_service_error label expected = function
+  | Ok _ -> fail (label ^ ": expected error")
+  | Error actual ->
+    check string label (service_error_to_string expected) (service_error_to_string actual)
+;;
+
+let test_create_mints_schedule_id () =
+  with_workspace
+  @@ fun config ->
+  let request = create_ok config in
+  check bool "schedule id prefix" true (has_prefix "sched-" request.schedule_id);
+  check_status "side-effecting starts pending" Pending_approval request.status
+;;
+
+let test_list_and_get_by_status () =
+  with_workspace
+  @@ fun config ->
+  let pending = create_ok ~schedule_id:"pending-1" config in
+  let scheduled =
+    create_ok ~schedule_id:"scheduled-1" ~risk_class:Read_only config
+  in
+  check int "all schedules" 2 (List.length (list config ()));
+  check int "pending only" 1 (List.length (list config ~status:Pending_approval ()));
+  check int "scheduled only" 1 (List.length (list config ~status:Scheduled ()));
+  (match get config ~schedule_id:pending.schedule_id with
+   | Some stored -> check string "pending id" pending.schedule_id stored.schedule_id
+   | None -> fail "pending missing");
+  (match get config ~schedule_id:scheduled.schedule_id with
+   | Some stored -> check string "scheduled id" scheduled.schedule_id stored.schedule_id
+   | None -> fail "scheduled missing")
+;;
+
+let test_approve_separate_human () =
+  with_workspace
+  @@ fun config ->
+  let request = create_ok ~schedule_id:"approve-1" config in
+  match
+    approve config ~grant_id:"grant-approve-1" ~approved_at:150.0
+      ~schedule_id:request.schedule_id ~approved_by:(human "approver") ()
+  with
+  | Ok updated -> check_status "approved" Scheduled updated.status
+  | Error err -> fail (service_error_to_string err)
+;;
+
+let test_requester_cannot_approve () =
+  with_workspace
+  @@ fun config ->
+  let request = create_ok ~schedule_id:"self-approve-1" config in
+  check_service_error "requester self approve"
+    (Store_error
+       (Schedule_store.Grant_validation_failed Approver_is_requester))
+    (approve config ~grant_id:"grant-self-1" ~approved_at:150.0
+       ~schedule_id:request.schedule_id ~approved_by:request.requested_by ())
+;;
+
+let test_reject_marks_rejected () =
+  with_workspace
+  @@ fun config ->
+  let request = create_ok ~schedule_id:"reject-1" config in
+  match
+    reject config ~grant_id:"grant-reject-1" ~approved_at:150.0
+      ~schedule_id:request.schedule_id ~approved_by:(human "approver")
+      ~reason:"not today" ()
+  with
+  | Ok updated -> check_status "rejected" Rejected updated.status
+  | Error err -> fail (service_error_to_string err)
+;;
+
+let test_due_candidates_do_not_execute_and_require_approval () =
+  with_workspace
+  @@ fun config ->
+  let request = create_ok ~schedule_id:"due-1" config in
+  (match due_candidates config ~now:201.0 with
+   | Ok candidates -> check int "no candidate before approval" 0 (List.length candidates)
+   | Error err -> fail (service_error_to_string err));
+  (match
+     approve config ~grant_id:"grant-due-1" ~approved_at:150.0
+       ~schedule_id:request.schedule_id ~approved_by:(human "approver") ()
+   with
+   | Ok _ -> ()
+   | Error err -> fail (service_error_to_string err));
+  match due_candidates config ~now:201.0 with
+  | Ok [ candidate ] ->
+    check string "candidate id" request.schedule_id candidate.schedule_id;
+    check_status "candidate due" Due candidate.status
+  | Ok candidates ->
+    fail (Printf.sprintf "expected one candidate, got %d" (List.length candidates))
+  | Error err -> fail (service_error_to_string err)
+;;
+
+let test_missing_schedule_approval_reports_store_error () =
+  with_workspace
+  @@ fun config ->
+  check_service_error "missing schedule"
+    (Store_error Schedule_store.Schedule_not_found)
+    (approve config ~grant_id:"grant-missing" ~approved_at:150.0
+       ~schedule_id:"missing" ~approved_by:(human "approver") ())
+;;
+
+let () =
+  run "Schedule_service"
+    [
+      ( "create",
+        [
+          test_case "create mints schedule id" `Quick test_create_mints_schedule_id;
+          test_case "list and get by status" `Quick test_list_and_get_by_status;
+        ] );
+      ( "approval",
+        [
+          test_case "approve by separate human" `Quick test_approve_separate_human;
+          test_case "requester cannot approve" `Quick test_requester_cannot_approve;
+          test_case "reject marks rejected" `Quick test_reject_marks_rejected;
+          test_case "missing schedule reports store error" `Quick
+            test_missing_schedule_approval_reports_store_error;
+        ] );
+      ( "due",
+        [
+          test_case "due candidates require approval and do not execute" `Quick
+            test_due_candidates_do_not_execute_and_require_approval;
+        ] );
+    ]
+;;


### PR DESCRIPTION
## Summary

- add a user-facing schedule service boundary over the durable store
- expose create/list/get/approve/reject/due-candidates operations without running due work
- keep service create payload validation delegated to the domain envelope contract from #21022
- keep the service consumer-agnostic: no Keeper/task/board/goal/tool target enum or execution dispatch

## Verification

- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_schedule_service.exe test/test_schedule_store.exe test/test_schedule_domain.exe`
- `_build/default/test/test_schedule_service.exe`
- `_build/default/test/test_schedule_store.exe`
- `_build/default/test/test_schedule_domain.exe`
- `git diff --check`
- forbidden schedule dependency grep for Keeper/board/task/goal/tool target terms
