### PR TITLE
fix(test): update stale keeper_report_state assertions in test_keeper_prompt_metrics (issue #20948)

### DIFF
--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -268,27 +268,23 @@ let test_state_block_guard_is_runtime_managed_not_absolute_never () =
   let guard = KP.state_block_output_guard_text in
   check bool "guard mentions runtime-managed continuity" true
     (has_in guard "runtime-managed continuity");
-  check bool "guard prefers structured output" true
-    (has_in guard "structured output");
-  check bool "guard names keeper_report_state" true
-    (has_in guard "keeper_report_state");
+  check bool "guard directs bracketed state block output" true
+    (has_in guard "[STATE]...[/STATE]");
   check bool "guard avoids absolute NEVER state wording" false
     (has_in guard ("NEVER output " ^ "[STATE]"));
-  check bool "guard names raw state markers" true
-    (has_in guard "raw [STATE]");
-  check bool "guard mentions runtime persistence" true
-    (has_in guard "persist state metadata")
+  check bool "guard mentions runtime synthesis and persistence" true
+    (has_in guard "synthesize and persist state metadata")
 
 let test_unified_state_instruction_respects_turn_level_guard () =
   let text = KUP.state_block_instruction_text in
+  check bool "instruction names state block template" true
+    (has_in text "State block template");
   check bool "instruction is scoped to non-direct turns" true
-    (has_in text "For non-direct keeper turns");
-  check bool "instruction prefers structured output" true
-    (has_in text "structured output");
-  check bool "instruction names keeper_report_state" true
+    (has_in text "for non-direct keeper turns");
+  check bool "instruction lists canonical fields" true
+    (has_in text "DONE, NEXT, Goal, Decisions, OpenQuestions, and Constraints");
+  check bool "instruction does not depend on keeper_report_state" false
     (has_in text "keeper_report_state");
-  check bool "instruction keeps raw state fallback scoped" true
-    (has_in text "Only if keeper_report_state is unavailable");
   check bool "instruction avoids old unconditional wording" false
     (has_in text
        ("End every response with a "


### PR DESCRIPTION
## Summary
- repair stale keeper prompt metric assertions after keeper_report_state structured-output wording was removed
- assert the current runtime-managed [STATE] continuity contract instead of reintroducing the old tool-centric contract
- keep the tests anchored on non-direct keeper turns, canonical state fields, and the absence of the old unconditional NEVER output [STATE] wording

## Why this is not just test drift masking
The deleted keeper_report_state wording is not the desired runtime contract anymore. The test now checks the active behavior boundary: state metadata is synthesized/persisted by runtime-managed continuity, while non-direct keeper turns may carry the text-only [STATE] block template.

## Validation
- ocamlformat --check test/test_keeper_prompt_metrics.ml
- git diff --check
- local build/test intentionally not run after operator request; rely on PR CI for build coverage

Closes #20948