### PR TITLE
fix(keeper): make stale checkpoints nonfatal watermark hits

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -231,7 +231,6 @@ let run_turn
   in
   let context_injector = ctx.context_injector in
   let shared_context = ctx.shared_context in
-  let session_dir = ctx.session_dir in
   let session = ctx.session in
   let base_system_prompt = ctx.base_system_prompt in
   let resume_oas_checkpoint = ctx.resume_oas_checkpoint in
@@ -537,7 +536,6 @@ let run_turn
                     ~allowed_paths:oas_allowed_paths
                     ~cache_system_prompt:true
                     ~yield_on_tool
-                    ~checkpoint_dir:session_dir
                     ~context_injector
                     ~context:shared_context
                     ~approval:

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -121,11 +121,11 @@ let finalize
           ~snapshot:state_snapshot
       in
       (match
-         Keeper_checkpoint_store.save_oas
+         Keeper_checkpoint_store.save_oas_classified
            ~session_dir:session.session_dir
            patched
        with
-       | Ok () ->
+       | Ok (Keeper_checkpoint_store.Saved _) ->
          append_manifest ~site:"checkpoint_saved"
            ~keeper_turn_id:manifest_keeper_turn_id
            ~oas_turn_count:result.turns
@@ -142,6 +142,17 @@ let finalize
                ])
            Keeper_runtime_manifest.Checkpoint_saved;
          Ok (Some patched)
+       | Ok (Keeper_checkpoint_store.Stale_noop
+                { incoming_turn_count; known_turn_count }) ->
+         Log.Keeper.warn ~keeper_name:meta.name
+           "runtime=%s OAS checkpoint stale no-op: incoming turn_count=%d, last saved=%d"
+           (Keeper_meta_contract.runtime_id_of_meta meta)
+           incoming_turn_count known_turn_count;
+         Otel_metric_store.inc_counter
+           "masc_keeper_checkpoint_stale_noop_total"
+           ~labels:[ "keeper", meta.name; "site", "finalize" ]
+           ();
+         Ok None
        | Error e ->
          Log.Keeper.error ~keeper_name:meta.name
            "runtime=%s OAS checkpoint save failed: %s"

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -319,28 +319,51 @@ let record_saved_oas_turn_count ~session_dir ~session_id turn_count =
     | Some known when known >= turn_count -> ()
     | Some _ | None -> Hashtbl.replace last_saved_oas_turn_count key turn_count)
 
-let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
-  : (unit, string) result =
-  match known_oas_turn_count ~session_dir ~session_id:ckpt.session_id with
+type save_oas_relation = [ `Cold | `Forward | `Equal ]
+
+type save_oas_outcome =
+  | Saved of { relation : save_oas_relation; turn_count : int }
+  | Stale_noop of { incoming_turn_count : int; known_turn_count : int }
+
+let save_relation ~known ~incoming =
+  match known with
+  | None -> `Cold
+  | Some previous when incoming > previous -> `Forward
+  | Some _ -> `Equal
+
+let save_oas_classified ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
+  : (save_oas_outcome, string) result =
+  let known = known_oas_turn_count ~session_dir ~session_id:ckpt.session_id in
+  match known with
   | Some known when ckpt.turn_count < known ->
-    Log.Keeper.error
-      "stale OAS checkpoint write rejected for %s: incoming turn_count=%d, last saved=%d"
+    Log.Keeper.warn
+      "stale OAS checkpoint write skipped for %s: incoming turn_count=%d, last saved=%d"
       ckpt.session_id ckpt.turn_count known;
     Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string CheckpointFailures)
-      ~labels:[("site", Keeper_checkpoint_store_failure_site.(to_label Oas_stale_write_rejected))]
+      "masc_keeper_checkpoint_stale_noop_total"
+      ~labels:[("site", "store_watermark")]
       ();
-    Error
-      (Printf.sprintf
-         "stale checkpoint write rejected for %s: incoming turn_count=%d < last saved %d"
-         ckpt.session_id ckpt.turn_count known)
+    Ok (Stale_noop
+          { incoming_turn_count = ckpt.turn_count
+          ; known_turn_count = known
+          })
   | Some _ | None ->
     (match save_oas_unguarded ~session_dir ckpt with
      | Ok () ->
        record_saved_oas_turn_count
          ~session_dir ~session_id:ckpt.session_id ckpt.turn_count;
-       Ok ()
+       Ok
+         (Saved
+            { relation = save_relation ~known ~incoming:ckpt.turn_count
+            ; turn_count = ckpt.turn_count
+            })
      | Error _ as e -> e)
+
+let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
+  : (unit, string) result =
+  match save_oas_classified ~session_dir ckpt with
+  | Ok (Saved _) | Ok (Stale_noop _) -> Ok ()
+  | Error _ as e -> e
 
 module For_testing = struct
   let reset_stale_write_guard () =

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -45,15 +45,37 @@ val delete_oas_history_files :
   snapshot_ids:string list ->
   string list * string list
 
+(** Relation between an incoming checkpoint and the current known high
+    watermark for the same canonical OAS checkpoint path. *)
+type save_oas_relation = [ `Cold | `Forward | `Equal ]
+
+(** Classified checkpoint save result.
+
+    [Stale_noop] is a successful no-op: the canonical checkpoint was left
+    untouched because accepting [incoming_turn_count] would move memory
+    behind the known high watermark. It must not be treated as keeper
+    turn failure, pause, or stop. *)
+type save_oas_outcome =
+  | Saved of { relation : save_oas_relation; turn_count : int }
+  | Stale_noop of { incoming_turn_count : int; known_turn_count : int }
+
 (** Save [ckpt] via the OAS Checkpoint_store when an Eio FS is
     available; falls back to atomic file write otherwise. Always
     appends to the OAS history archive on success.
 
-    RFC-0225 §3.2 stale-write guard: returns [Error] (and logs at
-    Error with the [oas_stale_write_rejected] failure site) when
+    RFC-0225 §3.2 checkpoint watermark: returns [Ok Stale_noop] when
     [ckpt.turn_count] is older than the last checkpoint saved for the
-    same session — a stale writer must not clobber a conversation the
-    newer writer already persisted. Equal turn_count re-saves pass. *)
+    same session. A stale writer must not clobber a conversation the
+    newer writer already persisted, but this is not a keeper lifecycle
+    failure. Equal turn_count re-saves pass. *)
+val save_oas_classified :
+  session_dir:string ->
+  Agent_sdk.Checkpoint.t ->
+  (save_oas_outcome, string) result
+
+(** Compatibility wrapper around {!save_oas_classified}. [Saved] and
+    [Stale_noop] both return [Ok ()]; only real store/IO failures return
+    [Error]. *)
 val save_oas :
   session_dir:string ->
   Agent_sdk.Checkpoint.t ->

--- a/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.ml
+++ b/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.ml
@@ -4,7 +4,6 @@ type t =
   | Oas_delete
   | Oas_archive_fallback
   | Oas_archive_primary
-  | Oas_stale_write_rejected
 
 let to_label = function
   | Oas_cleanup -> "oas_cleanup"
@@ -12,5 +11,4 @@ let to_label = function
   | Oas_delete -> "oas_delete"
   | Oas_archive_fallback -> "oas_archive_fallback"
   | Oas_archive_primary -> "oas_archive_primary"
-  | Oas_stale_write_rejected -> "oas_stale_write_rejected"
 ;;

--- a/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.mli
+++ b/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.mli
@@ -15,8 +15,5 @@ type t =
   | Oas_delete (** OAS checkpoint delete failed. *)
   | Oas_archive_fallback (** Archive-tier fallback save failed. *)
   | Oas_archive_primary (** Archive-tier primary save failed. *)
-  | Oas_stale_write_rejected
-      (** Save refused: incoming turn_count older than the last saved
-          checkpoint for the session (RFC-0225 §3.2). *)
 
 val to_label : t -> string

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -1,10 +1,11 @@
-(** RFC-0225 §3.2: stale OAS checkpoint writes are rejected.
+(** RFC-0225 §3.2: stale OAS checkpoint writes are no-op.
 
     Two writers for the same session are last-writer-wins on disk; the
     2026-06-10 voice incident had a stale lane (turn_count=1324) clobber
     the conversation the newer lane had just saved (turn_count=1355).
-    [Keeper_checkpoint_store.save_oas] now refuses a save whose
-    [turn_count] is older than the last one saved for the session. *)
+    [Keeper_checkpoint_store.save_oas] now skips a save whose [turn_count]
+    is older than the last one saved for the session without turning that
+    watermark hit into keeper lifecycle failure. *)
 
 open Alcotest
 open Masc
@@ -68,11 +69,6 @@ let make_checkpoint ~session_id ~turn_count ~marker =
     working_context = None;
   }
 
-let contains_substring ~needle haystack =
-  let nl = String.length needle and hl = String.length haystack in
-  let rec go i = i + nl <= hl && (String.sub haystack i nl = needle || go (i + 1)) in
-  go 0
-
 let save_ok ~session_dir ckpt label =
   match Keeper_checkpoint_store.save_oas ~session_dir ckpt with
   | Ok () -> ()
@@ -90,15 +86,18 @@ let test_forward_equal_and_stale () =
     save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:6 ~marker:"v6") "forward save";
     (* Equal turn_count: idempotent re-save (e.g. sanitized retry). *)
     save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:6 ~marker:"v6b") "equal save";
-    (* Stale write must be refused and must not touch disk. *)
+    (* Stale write must be a nonfatal no-op and must not touch disk. *)
     (match
-       Keeper_checkpoint_store.save_oas ~session_dir
+       Keeper_checkpoint_store.save_oas_classified ~session_dir
          (make_checkpoint ~session_id:sid ~turn_count:4 ~marker:"v4-stale")
      with
-     | Ok () -> fail "stale save was accepted"
-     | Error msg ->
-       check bool "error names the stale rejection" true
-         (contains_substring ~needle:"stale checkpoint write rejected" msg));
+     | Ok (Keeper_checkpoint_store.Stale_noop
+              { incoming_turn_count; known_turn_count }) ->
+       check int "stale incoming turn_count" 4 incoming_turn_count;
+       check int "known turn_count is preserved" 6 known_turn_count
+     | Ok (Keeper_checkpoint_store.Saved _) ->
+       fail "stale save advanced the checkpoint"
+     | Error e -> fail ("stale save returned lifecycle failure: " ^ e));
     match Keeper_checkpoint_store.load_oas ~session_dir ~session_id:sid with
     | Ok on_disk ->
       check int "disk keeps the newest turn_count" 6
@@ -119,20 +118,25 @@ let test_cold_start_backfills_from_disk () =
     (* Simulate a process restart: in-memory knowledge is gone. *)
     Keeper_checkpoint_store.For_testing.reset_stale_write_guard ();
     (match
-       Keeper_checkpoint_store.save_oas ~session_dir
+       Keeper_checkpoint_store.save_oas_classified ~session_dir
          (make_checkpoint ~session_id:sid ~turn_count:3 ~marker:"v3-stale")
      with
-     | Ok () -> fail "stale save accepted after cold start"
-     | Error _ -> ());
+     | Ok (Keeper_checkpoint_store.Stale_noop
+              { incoming_turn_count; known_turn_count }) ->
+       check int "cold stale incoming turn_count" 3 incoming_turn_count;
+       check int "cold known turn_count backfilled from disk" 8 known_turn_count
+     | Ok (Keeper_checkpoint_store.Saved _) ->
+       fail "stale save advanced after cold start"
+     | Error e -> fail ("cold stale save returned lifecycle failure: " ^ e));
     save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:9 ~marker:"v9")
       "forward save after cold start")
 
 let () =
-  run "Keeper_checkpoint_store stale-write guard (RFC-0225 §3.2)"
+  run "Keeper_checkpoint_store checkpoint watermark (RFC-0225 §3.2)"
     [
       ( "save_oas guard",
         [
-          test_case "forward and equal saves pass, stale save is refused" `Quick
+          test_case "forward and equal saves pass, stale save is no-op" `Quick
             test_forward_equal_and_stale;
           test_case "cold start backfills last turn_count from disk" `Quick
             test_cold_start_backfills_from_disk;


### PR DESCRIPTION
## Summary
- classify keeper OAS checkpoint saves as `Saved` or `Stale_noop`
- treat stale checkpoint writes as nonfatal no-ops instead of `CheckpointFailures`
- stop passing keeper `session_dir` as runtime `checkpoint_dir`, so the runtime worker no longer direct-writes the keeper canonical checkpoint
- update the stale guard regression to assert no-op semantics and remove the stale-write failure taxonomy value

## Verification
- `ocamlformat --check lib/keeper/keeper_checkpoint_store.ml lib/keeper/keeper_checkpoint_store.mli lib/keeper/keeper_agent_run_finalize_response.ml lib/keeper/keeper_agent_run.ml lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.ml lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.mli test/test_keeper_checkpoint_stale_guard.ml`
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only` failed as expected for local environment drift: installed `agent_sdk` is `0.206.2`, expected `>= 0.206.3`

## Not run
- `scripts/dune-local.sh build test/test_keeper_checkpoint_stale_guard.exe` aborted before build because the local `agent_sdk` pin is drifted (`0.206.2`, expected `>= 0.206.3`).
