### PR TITLE
feat(discord): thread lifecycle (THREAD_DELETE + archived cleanup)

### DIFF
--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -170,6 +170,10 @@ let is_known_thread ~channel_id =
 
 let registered_thread_count () = Hashtbl.length thread_parent_table
 
+let unregister_thread ~thread_id =
+  let tid = String.trim thread_id in
+  if tid <> "" then Hashtbl.remove thread_parent_table tid
+
 (* ── Trigger policy registry ──────────────────────────────────────
    Set once at gateway startup by [set_trigger_policy]. Read by
    [connectors_json] for dashboard display. Same mutable-ref pattern

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -122,6 +122,11 @@ val is_known_thread : channel_id:string -> bool
 val registered_thread_count : unit -> int
 (** Number of threads currently in the registry. For diagnostics. *)
 
+val unregister_thread : thread_id:string -> unit
+(** Remove a Discord thread from the registry. Called when the gateway
+    receives a THREAD_DELETE dispatch or a THREAD_UPDATE with
+    [thread_metadata.archived = true]. No-op for blank or unknown ids. *)
+
 (** {2 Trigger policy}
 
     Set once at gateway startup, read by [connectors_json] for dashboard

--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -45,6 +45,9 @@ type gateway_event = Discord_gateway_state.dispatched_event =
   | Threads_bulk_tracked of
       { threads : (string * string) list
       }
+  | Thread_removed of
+      { thread_id : string
+      }
   | Ignored of string
 
 type trigger_policy = Discord_gateway_state.trigger_policy =
@@ -249,7 +252,7 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
           Discord_observability.Message_create, Discord_observability.Triggered
         | Reaction_add _ ->
           Discord_observability.Reaction_add, Discord_observability.Triggered
-        | Thread_tracked _ | Threads_bulk_tracked _ ->
+        | Thread_tracked _ | Threads_bulk_tracked _ | Thread_removed _ ->
           Discord_observability.Ignored, Discord_observability.Control
         | Ignored _ -> Discord_observability.Ignored, Discord_observability.Control
       in
@@ -261,7 +264,7 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
         | Ready _ -> Discord_observability.Ready
         | Message_create _ -> Discord_observability.Message_create
         | Reaction_add _ -> Discord_observability.Reaction_add
-        | Thread_tracked _ | Threads_bulk_tracked _ -> Discord_observability.Ignored
+        | Thread_tracked _ | Threads_bulk_tracked _ | Thread_removed _ -> Discord_observability.Ignored
         | Ignored _ -> Discord_observability.Ignored
       in
       Discord_observability.record_gateway_event

--- a/lib/gate/discord_gateway_client.mli
+++ b/lib/gate/discord_gateway_client.mli
@@ -55,6 +55,9 @@ type gateway_event = Discord_gateway_state.dispatched_event =
   | Threads_bulk_tracked of
       { threads : (string * string) list
       }
+  | Thread_removed of
+      { thread_id : string
+      }
   | Ignored of string
 
 type trigger_policy = Discord_gateway_state.trigger_policy =

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -112,6 +112,13 @@ type dispatched_event =
       }
       (** Bulk thread discovery from GUILD_CREATE. Carries all active
           threads in a guild that existed before the bot connected. *)
+  | Thread_removed of
+      { thread_id : string
+      }
+      (** A Discord thread was deleted or archived. Removes the entry
+          from [thread_parents] and notifies the I/O layer to clean its
+          mutable registries. Carries only [thread_id] — parent_channel_id
+          is no longer needed after removal. *)
   | Ignored of string
 
 (* ── Frame ─────────────────────────────────────────────────────── *)
@@ -438,6 +445,33 @@ let decode_thread_create ~payload =
       else Ok (Thread_tracked { thread_id; parent_channel_id })
   | _ -> Ok (Ignored "THREAD_CREATE: missing id or parent_id")
 
+let decode_thread_update ~payload =
+  (* THREAD_UPDATE carries thread_metadata.archived — when true the
+     thread is no longer active and should be removed from tracking.
+     Discord docs: "Sent when a thread is updated, including when
+     the thread is archived or unarchived." *)
+  let thread_metadata = assoc_opt "thread_metadata" payload in
+  let is_archived =
+    match thread_metadata with
+    | Some meta -> (match field_bool_opt "archived" meta with
+      | Some true -> true | _ -> false)
+    | None -> false
+  in
+  if is_archived then
+    match field_string_opt "id" payload with
+    | Some thread_id when String.trim thread_id <> "" ->
+        Ok (Thread_removed { thread_id })
+    | _ -> Ok (Ignored "THREAD_UPDATE: archived but missing id")
+  else
+    (* Active thread update — treat same as THREAD_CREATE *)
+    decode_thread_create ~payload
+
+let decode_thread_delete ~payload =
+  match field_string_opt "id" payload with
+  | Some thread_id when String.trim thread_id <> "" ->
+      Ok (Thread_removed { thread_id })
+  | _ -> Ok (Ignored "THREAD_DELETE: missing id")
+
 let decode_guild_create_threads ~payload =
   let threads_json = assoc_opt "threads" payload in
   match threads_json with
@@ -462,7 +496,9 @@ let decode_dispatch ~bot_user_id ~event_name ~payload =
   | "READY" -> decode_ready ~payload
   | "MESSAGE_CREATE" -> decode_message_create ~bot_user_id ~payload
   | "MESSAGE_REACTION_ADD" -> decode_reaction_add ~payload
-  | "THREAD_CREATE" | "THREAD_UPDATE" -> decode_thread_create ~payload
+  | "THREAD_CREATE" -> decode_thread_create ~payload
+  | "THREAD_UPDATE" -> decode_thread_update ~payload
+  | "THREAD_DELETE" -> decode_thread_delete ~payload
   | "GUILD_CREATE" -> decode_guild_create_threads ~payload
   | other -> Ok (Ignored other)
 
@@ -703,6 +739,16 @@ let handle_dispatch t (frame : frame) =
                      Printf.sprintf
                        "guild threads bulk tracked: %d threads"
                        (List.length threads)
+                 }
+             ] )
+       | Ok (Thread_removed { thread_id } as ev) ->
+           let thread_parents' = StringMap.remove thread_id t'.thread_parents in
+           ( { t' with thread_parents = thread_parents' }
+           , [ Emit_event ev
+             ; Log
+                 { level = `Info
+                 ; message =
+                     Printf.sprintf "thread removed: %s" thread_id
                  }
              ] )
        | Ok (Ignored "RESUMED") ->

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -113,6 +113,12 @@ type dispatched_event =
   | Threads_bulk_tracked of
       { threads : (string * string) list
       }
+  | Thread_removed of
+      { thread_id : string
+      }
+      (** A Discord thread was deleted or archived. The state machine
+          removes it from [thread_parents]; the I/O layer should clean
+          its mutable registries accordingly. *)
   | Ignored of string  (** Known dispatch type we deliberately don't surface. *)
 
 (** {1 Inbound frame — what comes off the wire} *)

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -422,6 +422,12 @@ let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
       "Discord guild threads bulk registered: %d threads (total=%d)"
       (List.length threads)
       (State.registered_thread_count ())
+  | Gw.Thread_removed { thread_id } ->
+    State.unregister_thread ~thread_id;
+    Log.Server.info
+      "Discord thread removed: %s (total=%d)"
+      thread_id
+      (State.registered_thread_count ())
   | Gw.Ignored _ ->
     ()
 
@@ -485,7 +491,7 @@ let on_ambient ~base_dir (ev : Gw.gateway_event) =
     ->
     handle_ambient ~base_dir ~channel_id ~guild_id ~message_id ~author_id
       ~author_name ~content
-  | Gw.Ready _ | Gw.Reaction_add _ | Gw.Thread_tracked _ | Gw.Threads_bulk_tracked _ | Gw.Ignored _ -> ()
+  | Gw.Ready _ | Gw.Reaction_add _ | Gw.Thread_tracked _ | Gw.Threads_bulk_tracked _ | Gw.Thread_removed _ | Gw.Ignored _ -> ()
 
 (* ---------------------------------------------------------------- *)
 (* Start                                                            *)

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -1404,6 +1404,170 @@ let test_thread_registry_survives_reconnect () =
   check bool "thread_parents survives reconnect cycle" true
     (has_emit_event effects)
 
+(* ── Thread removal lifecycle ─────────────────────────────────────── *)
+
+let thread_delete_frame ~thread_id ~seq : S.frame =
+  { op = S.Op_dispatch
+  ; s = Some seq
+  ; t = Some "THREAD_DELETE"
+  ; d =
+      `Assoc
+        [ ("id", `String thread_id)
+        ; ("guild_id", `String "G1")
+        ; ("parent_id", `String "CH1")
+        ; ("type", `Int 11)
+        ]
+  }
+
+let thread_update_archived_frame ~thread_id ~parent_id ~seq : S.frame =
+  { op = S.Op_dispatch
+  ; s = Some seq
+  ; t = Some "THREAD_UPDATE"
+  ; d =
+      `Assoc
+        [ ("id", `String thread_id)
+        ; ("parent_id", `String parent_id)
+        ; ("type", `Int 11)
+        ; ("thread_metadata", `Assoc [ ("archived", `Bool true) ])
+        ]
+  }
+
+let has_emit_thread_removed ~thread_id effects =
+  List.exists
+    (function
+      | S.Emit_event (S.Thread_removed { thread_id = tid }) ->
+          String.equal tid thread_id
+      | _ -> false)
+    effects
+
+(* Decode: THREAD_DELETE => Thread_removed *)
+let test_decode_thread_delete () =
+  let payload =
+    `Assoc [ ("id", `String "THR1"); ("parent_id", `String "CH1") ]
+  in
+  match S.decode_dispatch ~bot_user_id:None ~event_name:"THREAD_DELETE" ~payload with
+  | Ok (S.Thread_removed { thread_id = "THR1" }) -> ()
+  | Ok _ -> fail "decoded THREAD_DELETE to wrong variant"
+  | Error e -> fail (Printf.sprintf "THREAD_DELETE decode error: %s" e)
+
+(* Decode: THREAD_DELETE missing id => Ignored *)
+let test_decode_thread_delete_missing_id () =
+  let payload = `Assoc [ ("parent_id", `String "CH1") ] in
+  match S.decode_dispatch ~bot_user_id:None ~event_name:"THREAD_DELETE" ~payload with
+  | Ok (S.Ignored _) -> ()
+  | Ok _ -> fail "expected Ignored for THREAD_DELETE without id"
+  | Error e -> fail (Printf.sprintf "THREAD_DELETE decode error: %s" e)
+
+(* Decode: THREAD_UPDATE with archived=true => Thread_removed *)
+let test_decode_thread_update_archived () =
+  let payload =
+    `Assoc
+      [ ("id", `String "THR1")
+      ; ("parent_id", `String "P1")
+      ; ("thread_metadata", `Assoc [ ("archived", `Bool true) ])
+      ]
+  in
+  match S.decode_dispatch ~bot_user_id:None ~event_name:"THREAD_UPDATE" ~payload with
+  | Ok (S.Thread_removed { thread_id = "THR1" }) -> ()
+  | Ok _ -> fail "THREAD_UPDATE archived=true should decode to Thread_removed"
+  | Error e -> fail (Printf.sprintf "THREAD_UPDATE decode error: %s" e)
+
+(* Decode: THREAD_UPDATE with archived=false => Thread_tracked (unchanged) *)
+let test_decode_thread_update_active_still_tracked () =
+  let payload =
+    `Assoc
+      [ ("id", `String "THR1")
+      ; ("parent_id", `String "P1")
+      ; ("thread_metadata", `Assoc [ ("archived", `Bool false) ])
+      ]
+  in
+  match S.decode_dispatch ~bot_user_id:None ~event_name:"THREAD_UPDATE" ~payload with
+  | Ok (S.Thread_tracked { thread_id = "THR1"; parent_channel_id = "P1" }) -> ()
+  | Ok _ -> fail "THREAD_UPDATE archived=false should still be Thread_tracked"
+  | Error e -> fail (Printf.sprintf "THREAD_UPDATE decode error: %s" e)
+
+(* Step: THREAD_DELETE removes from thread_parents *)
+let test_step_thread_delete_removes_from_registry () =
+  let m = connected_with_policy ~policy:S.Mention_or_thread ~bot_user_id:"BOT" in
+  (* Register thread *)
+  let m, _ =
+    S.step m ~now_mono:5.0
+      (S.Frame_received (thread_create_frame ~thread_id:"THR1" ~parent_id:"CH1" ~seq:10))
+  in
+  (* Verify thread is tracked *)
+  let payload1 =
+    message_create_payload
+      ~id:"M1" ~channel_id:"THR1" ~author_id:"U1" ~content:"in thread"
+      ~mention_ids:[] ()
+  in
+  let _, effects1 =
+    S.step m ~now_mono:6.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload:payload1 ~seq:11))
+  in
+  check bool "before delete: thread message passes policy" true
+    (has_emit_event effects1);
+  (* Delete thread *)
+  let m, effects2 =
+    S.step m ~now_mono:7.0
+      (S.Frame_received (thread_delete_frame ~thread_id:"THR1" ~seq:12))
+  in
+  check bool "Thread_removed emitted" true
+    (has_emit_thread_removed ~thread_id:"THR1" effects2);
+  (* Verify thread is no longer tracked *)
+  let payload3 =
+    message_create_payload
+      ~id:"M3" ~channel_id:"THR1" ~author_id:"U1" ~content:"after delete"
+      ~mention_ids:[] ()
+  in
+  let _, effects3 =
+    S.step m ~now_mono:8.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload:payload3 ~seq:13))
+  in
+  check bool "after delete: thread message suppressed (no longer tracked)" true
+    (not (has_emit_event effects3))
+
+(* Step: THREAD_UPDATE archived=true removes from thread_parents *)
+let test_step_thread_update_archived_removes_from_registry () =
+  let m = connected_with_policy ~policy:S.Mention_or_thread ~bot_user_id:"BOT" in
+  (* Register thread *)
+  let m, _ =
+    S.step m ~now_mono:5.0
+      (S.Frame_received (thread_create_frame ~thread_id:"THR1" ~parent_id:"CH1" ~seq:10))
+  in
+  (* Archive the thread *)
+  let m, effects =
+    S.step m ~now_mono:6.0
+      (S.Frame_received
+         (thread_update_archived_frame ~thread_id:"THR1" ~parent_id:"CH1" ~seq:11))
+  in
+  check bool "Thread_removed emitted on archive" true
+    (has_emit_thread_removed ~thread_id:"THR1" effects);
+  (* Verify thread is no longer tracked *)
+  let payload =
+    message_create_payload
+      ~id:"M2" ~channel_id:"THR1" ~author_id:"U1" ~content:"in archived"
+      ~mention_ids:[] ()
+  in
+  let _, effects2 =
+    S.step m ~now_mono:7.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload ~seq:12))
+  in
+  check bool "after archive: thread message suppressed" true
+    (not (has_emit_event effects2))
+
+(* Step: deleting a non-existent thread is a no-op *)
+let test_step_thread_delete_unknown_is_noop () =
+  let m = connected_with_policy ~policy:S.Mention_or_thread ~bot_user_id:"BOT" in
+  let _, effects =
+    S.step m ~now_mono:5.0
+      (S.Frame_received (thread_delete_frame ~thread_id:"NEVER_EXISTED" ~seq:10))
+  in
+  check bool "Thread_removed emitted for unknown thread" true
+    (has_emit_thread_removed ~thread_id:"NEVER_EXISTED" effects)
+
 (* ---------------------------------------------------------------- *)
 (* Entry                                                            *)
 (* ---------------------------------------------------------------- *)
@@ -1546,6 +1710,14 @@ let () =
             test_decode_guild_create_without_threads
         ; test_case "THREAD_UPDATE decodes same as THREAD_CREATE" `Quick
             test_decode_thread_update_same_as_create
+        ; test_case "THREAD_DELETE => Thread_removed" `Quick
+            test_decode_thread_delete
+        ; test_case "THREAD_DELETE missing id => Ignored" `Quick
+            test_decode_thread_delete_missing_id
+        ; test_case "THREAD_UPDATE archived=true => Thread_removed" `Quick
+            test_decode_thread_update_archived
+        ; test_case "THREAD_UPDATE archived=false => Thread_tracked" `Quick
+            test_decode_thread_update_active_still_tracked
         ] )
     ; ( "thread tracking + Mention_or_thread policy"
       , [ test_case
@@ -1572,5 +1744,14 @@ let () =
         ; test_case
             "thread_parents survives reconnect cycle"
             `Quick test_thread_registry_survives_reconnect
+        ; test_case
+            "THREAD_DELETE removes from thread_parents"
+            `Quick test_step_thread_delete_removes_from_registry
+        ; test_case
+            "THREAD_UPDATE archived=true removes from thread_parents"
+            `Quick test_step_thread_update_archived_removes_from_registry
+        ; test_case
+            "THREAD_DELETE for unknown thread is a no-op"
+            `Quick test_step_thread_delete_unknown_is_noop
         ] )
     ]


### PR DESCRIPTION
스레드 삭제/보관 시 thread_parents StringMap과 thread_parent_table Hashtbl에서 제거. 메모리 누수 방지 + stale 바인딩 해석 방지. 69 tests (기존 62 + 신규 7) 전부 통과.