### PR TITLE
feat(schedule): require typed payload envelope

### DIFF
--- a/docs/rfc/RFC-0234-scheduled-internal-automation.md
+++ b/docs/rfc/RFC-0234-scheduled-internal-automation.md
@@ -76,9 +76,14 @@ boundary, "schedule something now" becomes a delayed self-approved action.
 5. Scheduled execution reuses the existing descriptor, policy, sandbox, and
    approval surfaces. It does not create a bypass.
 6. Every state change is append-only and replayable; projections are derived.
-7. The schedule core stores opaque payloads only. It has no constructors or
-   dependencies for keepers, tasks, boards, goals, tools, or any other consumer
-   domain. Consumers observe due rows and decide what, if anything, to do.
+7. The schedule core stores opaque payload envelopes only. It has no
+   constructors or dependencies for keepers, tasks, boards, goals, tools, or
+   any other consumer domain. Consumers observe due rows and decide what, if
+   anything, to do.
+8. A schedule entry must not guess missing intent. If the producer cannot
+   produce a valid payload envelope, it asks the operator for clarification or
+   records a consumer-owned clarification payload; the schedule core does not
+   infer domain fields.
 
 ## §3 Scope
 
@@ -136,6 +141,12 @@ type schedule_status =
   | Cancelled
   | Expired
 
+type payload =
+  { kind : string
+  ; schema_version : int
+  ; body : Yojson.Safe.t
+  }
+
 type schedule_request =
   { schedule_id : string
   ; requested_by : actor
@@ -143,7 +154,7 @@ type schedule_request =
   ; requested_at : float
   ; due_at : float
   ; expires_at : float option
-  ; payload : Yojson.Safe.t
+  ; payload : payload
   ; risk_class : risk_class
   ; approval_required : bool
   ; status : schedule_status
@@ -160,12 +171,31 @@ type execution_grant =
 }
 ```
 
-`payload` is intentionally opaque to the schedule core. It may be a text note,
-a JSON envelope, or a consumer-defined command description, but this RFC does
-not define a route enum. Keepers, tasks, boards, goals, tool names, and future
-execution adapters belong outside the schedule domain. A consumer may observe a
-due row and translate the payload later; the schedule ledger only preserves
-time, approval, risk, and audit evidence.
+`payload` is intentionally opaque to the schedule core, but not unstructured.
+The persisted shape is a JSON object envelope:
+
+```json
+{
+  "kind": "consumer.contract.name",
+  "schema_version": 1,
+  "body": {}
+}
+```
+
+The schedule domain validates only the envelope: `kind` must be a non-empty
+string, `schema_version` must be positive, and `body` must be an object. It
+does not define a route enum and does not interpret body fields. Keepers, tasks,
+boards, goals, tool names, and future execution adapters belong outside the
+schedule domain. A consumer may observe a due row and translate the payload
+later; the schedule ledger only preserves time, approval, risk, and audit
+evidence.
+
+If a producer cannot fill the consumer-owned `body` confidently, it must not
+create an executable schedule by guessing. It should either ask the operator a
+clarifying question before schedule creation or create a consumer-owned
+clarification payload such as `kind = "operator.clarification_request"`. The
+schedule core treats that as opaque data too; the consumer decides how to ask
+and what later schedule, if any, to create from the answer.
 
 ## §5 Separation-of-duties invariant
 

--- a/lib/schedule/schedule_domain.ml
+++ b/lib/schedule/schedule_domain.ml
@@ -33,6 +33,12 @@ type schedule_source =
   | Automated_request
   | System_request
 
+type payload =
+  { kind : string
+  ; schema_version : int
+  ; body : Yojson.Safe.t
+  }
+
 type schedule_request =
   { schedule_id : string
   ; requested_by : actor
@@ -40,7 +46,7 @@ type schedule_request =
   ; requested_at : float
   ; due_at : float
   ; expires_at : float option
-  ; payload : Yojson.Safe.t
+  ; payload : payload
   ; risk_class : risk_class
   ; approval_required : bool
   ; status : schedule_status
@@ -216,6 +222,11 @@ let float_of_yojson = function
   | _ -> Error "expected float"
 ;;
 
+let int_of_yojson = function
+  | `Int value -> Ok value
+  | _ -> Error "expected int"
+;;
+
 let bool_of_yojson = function
   | `Bool value -> Ok value
   | _ -> Error "expected bool"
@@ -237,6 +248,13 @@ let string_field name fields =
 let float_field name fields =
   let* value = assoc_field name fields in
   match float_of_yojson value with
+  | Ok value -> Ok value
+  | Error err -> Error (name ^ ": " ^ err)
+;;
+
+let int_field name fields =
+  let* value = assoc_field name fields in
+  match int_of_yojson value with
   | Ok value -> Ok value
   | Error err -> Error (name ^ ": " ^ err)
 ;;
@@ -270,7 +288,29 @@ let actor_of_yojson = function
   | _ -> Error "expected actor object"
 ;;
 
-let payload_digest payload = sha256_json payload
+let payload_to_yojson payload =
+  `Assoc
+    [ "kind", `String payload.kind
+    ; "schema_version", `Int payload.schema_version
+    ; "body", payload.body
+    ]
+;;
+
+let payload_of_yojson = function
+  | `Assoc fields ->
+    let* kind = string_field "kind" fields in
+    let* kind = nonempty "payload.kind" kind in
+    let* schema_version = int_field "schema_version" fields in
+    if schema_version <= 0 then Error "payload.schema_version must be positive"
+    else (
+      let* body = assoc_field "body" fields in
+      match body with
+      | `Assoc _ -> Ok { kind; schema_version; body }
+      | _ -> Error "payload.body must be a JSON object")
+  | _ -> Error "payload must be a JSON object"
+;;
+
+let payload_digest payload = payload |> payload_to_yojson |> sha256_json
 
 let evidence_of_request (request : schedule_request) =
   { schedule_id = request.schedule_id
@@ -351,7 +391,7 @@ let schedule_request_to_yojson (request : schedule_request) =
     ; "requested_at", float_to_yojson request.requested_at
     ; "due_at", float_to_yojson request.due_at
     ; "expires_at", option_to_yojson float_to_yojson request.expires_at
-    ; "payload", request.payload
+    ; "payload", payload_to_yojson request.payload
     ; "risk_class", `String (risk_class_to_string request.risk_class)
     ; "approval_required", `Bool request.approval_required
     ; "status", `String (schedule_status_to_string request.status)
@@ -375,7 +415,8 @@ let schedule_request_of_yojson = function
         let* value = float_of_yojson value in
         Ok (Some value)
     in
-    let* payload = assoc_field "payload" fields in
+    let* payload_json = assoc_field "payload" fields in
+    let* payload = payload_of_yojson payload_json in
     let* risk_name = string_field "risk_class" fields in
     let* risk_class = risk_class_of_string risk_name in
     let* approval_required = bool_field "approval_required" fields in
@@ -415,6 +456,7 @@ let create_request
   let* schedule_id = nonempty "schedule_id" schedule_id in
   let* _ = nonempty "requested_by.id" requested_by.id in
   let* _ = nonempty "scheduled_by.id" scheduled_by.id in
+  let* payload = payload_of_yojson payload in
   let approval_required = approval_required || is_side_effecting risk_class in
   let status = if approval_required then Pending_approval else Scheduled in
   Ok

--- a/lib/schedule/schedule_domain.mli
+++ b/lib/schedule/schedule_domain.mli
@@ -38,6 +38,14 @@ type schedule_source =
   | Automated_request
   | System_request
 
+(** Opaque consumer payload.
+
+    The schedule domain does not interpret payload kind or body fields, but it
+    does require a typed envelope so producers cannot persist an ambiguous raw
+    string/null/list as future intent. Serialized shape:
+    [{ kind: string; schema_version: int; body: object }]. *)
+type payload
+
 type schedule_request =
   { schedule_id : string
   ; requested_by : actor
@@ -45,7 +53,7 @@ type schedule_request =
   ; requested_at : float
   ; due_at : float
   ; expires_at : float option
-  ; payload : Yojson.Safe.t
+  ; payload : payload
   ; risk_class : risk_class
   ; approval_required : bool
   ; status : schedule_status
@@ -102,7 +110,9 @@ val is_terminal : schedule_status -> bool
 val is_side_effecting : risk_class -> bool
 val requires_separate_human_grant : schedule_request -> bool
 
-val payload_digest : Yojson.Safe.t -> string
+val payload_of_yojson : Yojson.Safe.t -> (payload, string) result
+val payload_to_yojson : payload -> Yojson.Safe.t
+val payload_digest : payload -> string
 val evidence_of_request : schedule_request -> execution_evidence
 
 val create_execution_grant :

--- a/test/test_schedule_domain.ml
+++ b/test/test_schedule_domain.ml
@@ -4,6 +4,18 @@ open Schedule_domain
 let human ?display_name id = { id; kind = Human_operator; display_name }
 let automated ?display_name id = { id; kind = Automated_actor; display_name }
 
+let payload_json ?(kind = "consumer.note") ?(schema_version = 1) ?body () =
+  let body =
+    Option.value body
+      ~default:(`Assoc [ "text", `String "ship the thing" ])
+  in
+  `Assoc
+    [ "kind", `String kind
+    ; "schema_version", `Int schema_version
+    ; "body", body
+    ]
+;;
+
 let request
   ?(risk_class = Workspace_write)
   ?(approval_required = false)
@@ -14,8 +26,8 @@ let request
   match
     create_request ~schedule_id:"sched-1" ~requested_by ~scheduled_by
       ~requested_at:100.0 ~due_at:200.0
-      ~payload:(`Assoc [ "body", `String "ship the thing" ])
-      ~risk_class ~approval_required ~source:Operator_request ()
+      ~payload:(payload_json ()) ~risk_class ~approval_required
+      ~source:Operator_request ()
   with
   | Ok request -> request
   | Error msg -> fail msg
@@ -49,6 +61,28 @@ let test_read_only_can_start_scheduled () =
   let req = request ~risk_class:Read_only () in
   check bool "approval not required" false req.approval_required;
   check_status "status" Scheduled req.status
+;;
+
+let test_payload_requires_object_envelope () =
+  match
+    create_request ~schedule_id:"sched-1" ~requested_by:(human "requester")
+      ~scheduled_by:(human "scheduler") ~requested_at:100.0 ~due_at:200.0
+      ~payload:(`String "do later") ~risk_class:Read_only
+      ~approval_required:false ~source:Operator_request ()
+  with
+  | Ok _ -> fail "expected invalid payload"
+  | Error msg -> check string "payload error" "payload must be a JSON object" msg
+;;
+
+let test_payload_requires_known_envelope_fields () =
+  match
+    create_request ~schedule_id:"sched-1" ~requested_by:(human "requester")
+      ~scheduled_by:(human "scheduler") ~requested_at:100.0 ~due_at:200.0
+      ~payload:(`Assoc [ "body", `Assoc [] ]) ~risk_class:Read_only
+      ~approval_required:false ~source:Operator_request ()
+  with
+  | Ok _ -> fail "expected invalid payload"
+  | Error msg -> check string "payload error" "missing field: kind" msg
 ;;
 
 let test_separate_human_approval_accepts () =
@@ -147,6 +181,10 @@ let () =
             test_side_effecting_starts_pending;
           test_case "read-only can start scheduled" `Quick
             test_read_only_can_start_scheduled;
+          test_case "payload requires object envelope" `Quick
+            test_payload_requires_object_envelope;
+          test_case "payload requires envelope fields" `Quick
+            test_payload_requires_known_envelope_fields;
           test_case "mark due only affects scheduled" `Quick
             test_mark_due_only_scheduled;
         ] );


### PR DESCRIPTION
## Summary

- tighten scheduled automation payloads from arbitrary JSON to a typed opaque envelope
- require `{ kind; schema_version; body }` at domain create/decode time
- keep `kind` and `body` consumer-owned so schedule still does not know Keeper/task/board/goal/tool semantics
- document that missing intent must be clarified by the producer/consumer instead of guessed by schedule

## Verification

- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_schedule_domain.exe`
- `_build/default/test/test_schedule_domain.exe`
- `python3 scripts/rfc_enforcer.py --check docs/rfc/ --files RFC-0234-scheduled-internal-automation.md --ignore-missing-section1`
- `python3 scripts/rfc_enforcer.py --check-numbering --base-ref origin/main --head-ref HEAD`
- `git diff --check`
