### PR TITLE
[codex] Degrade failed keeper dashboard rows

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -43,6 +43,80 @@ let keeper_names (config : Workspace.config) =
 let keeper_count (config : Workspace.config) : int =
   List.length (keeper_names config)
 
+let non_empty_trimmed_string_opt value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
+let degraded_keeper_dashboard_row
+      ?error
+      ~(site : string)
+      (m : Keeper_meta_contract.keeper_meta)
+  =
+  let attention_reason = Option.value ~default:site error in
+  let runtime_trust =
+    `Assoc
+      [ ("disposition", `String "Degraded")
+      ; ("disposition_reason", `String site)
+      ; ("operator_disposition", `String "blocked_runtime")
+      ; ("operator_disposition_reason", `String site)
+      ; ("needs_attention", `Bool true)
+      ; ("attention_reason", `String attention_reason)
+      ; ("next_human_action", `String "inspect_keeper_dashboard_worker")
+      ]
+  in
+  let fd_pressure = Keeper_fd_pressure.degraded_projection_json () in
+  let runtime_id =
+    Keeper_meta_contract.runtime_id_of_meta m |> non_empty_trimmed_string_opt
+  in
+  let runtime_id_json = Json_util.string_opt_to_json runtime_id in
+  let diagnostic =
+    `Assoc
+      ([ ("status", `String "degraded")
+       ; ("reason", `String site)
+       ; ("error", Json_util.string_opt_to_json error)
+       ; ("fd_pressure", fd_pressure)
+       ])
+  in
+  `Assoc
+    ([ ("name", `String m.name)
+     ; ("agent_name", `String m.agent_name)
+     ; ( "keeper_id"
+       , match m.keeper_id with
+         | Some keeper_id -> `String (Keeper_id.Uid.to_string keeper_id)
+         | None -> `Null )
+     ; ("trace_id", `String (Keeper_id.Trace_id.to_string m.runtime.trace_id))
+     ; ("generation", `Int m.runtime.generation)
+     ; ("current_task_id",
+        Json_util.string_opt_to_json
+          (Option.map Keeper_id.Task_id.to_string m.current_task_id))
+     ; ("active_goal_ids", `List (List.map (fun goal_id -> `String goal_id) m.active_goal_ids))
+     ; ("created_at", `String m.created_at)
+     ; ("updated_at", `String m.updated_at)
+     ; ("goal", `String m.goal)
+     ; ("short_goal", `String m.short_goal)
+     ; ("mid_goal", `String m.mid_goal)
+     ; ("long_goal", `String m.long_goal)
+     ; ("phase", `String "degraded")
+     ; ("pipeline_stage", `String "degraded")
+     ; ("status", `String "degraded")
+     ; ("degraded", `Bool true)
+     ; ("degraded_reason", `String site)
+     ; ("agent", `Null)
+     ; ("diagnostic", diagnostic)
+     ; ("trust", runtime_trust)
+     ; ("runtime_trust", runtime_trust)
+     ; ("paused", `Bool m.paused)
+     ; ("keepalive_running", `Bool false)
+     ; ("total_turns", `Int m.runtime.usage.total_turns)
+     ; ("runtime_id", runtime_id_json)
+     ; ("runtime_canonical", runtime_id_json)
+     ; ("selected_runtime_canonical", runtime_id_json)
+     ; ("primary_model", `Null)
+     ; ("active_model", `Null)
+     ; ("active_model_label", `Null)
+     ; ("last_model_used_label", `Null)
+     ])
+
 type keeper_activity_source =
   | Keeper_meta
   | Tool_call of Yojson.Safe.t
@@ -282,7 +356,8 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
   let results = Array.make (List.length names) None in
   Eio.Fiber.all
     (List.mapi (fun idx name -> fun () ->
-      results.(idx) <- (
+      let row =
+      try
       match Keeper_meta_store.read_meta config name with
       | Error _ | Ok None -> None
       | Ok (Some (m : Keeper_meta_contract.keeper_meta)) ->
@@ -1013,8 +1088,36 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
                 | [] -> `Null);
             ] @ detail_fields)
           in
-          Some summary)
-    ) names);
+          Some summary
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+          let error = Printexc.to_string exn in
+          Keeper_fd_pressure.note_exception ~site:"keeper_dashboard.worker" exn;
+          Log.Dashboard.error
+            "keeper dashboard worker error (%s): %s"
+            name
+            error;
+          (try
+             match Keeper_meta_store.read_meta config name with
+             | Ok (Some meta) ->
+                 Some
+                   (degraded_keeper_dashboard_row
+                      ~site:"keeper_dashboard_worker_exception"
+                      ~error
+                      meta)
+             | Error _ | Ok None -> None
+           with
+           | Eio.Cancel.Cancelled _ as exn -> raise exn
+           | fallback_exn ->
+               Log.Dashboard.error
+                 "keeper dashboard degraded fallback failed (%s): %s"
+                 name
+                 (Printexc.to_string fallback_exn);
+               None)
+      in
+      results.(idx) <- row)
+     names);
   let summaries = Array.to_list results |> List.filter_map Fun.id in
   (* H-9 fix: include recent alerts so BAD alerts are visible on dashboard *)
   let recent_alerts =

--- a/test/dune
+++ b/test/dune
@@ -654,6 +654,7 @@
   ; test_command_plane_help removed (CP purge)
   test_dashboard_cache
   test_dashboard_http_core
+  test_dashboard_keeper_worker_degrade_source
   test_eval_feed
   test_dashboard_verification
   test_tool_quality_classify
@@ -835,6 +836,7 @@
   ; test_command_plane_help removed (CP purge)
   test_dashboard_cache
   test_dashboard_http_core
+  test_dashboard_keeper_worker_degrade_source
   test_eval_feed
   test_dashboard_verification
   test_tool_quality_classify

--- a/test/test_dashboard_keeper_worker_degrade_source.ml
+++ b/test/test_dashboard_keeper_worker_degrade_source.ml
@@ -1,0 +1,99 @@
+(** Structural guard for keeper dashboard per-row failure isolation.
+
+    [keepers_dashboard_json] builds rows in [Eio.Fiber.all]. A row-level
+    exception must not cancel the whole dashboard response; it should log the
+    worker failure and emit a degraded row when keeper meta can still be read.
+
+    This is source-structural because the failure can come from many dashboard
+    sub-readers, and mocking each reader would require widening private helper
+    APIs. *)
+
+open Alcotest
+
+let target_file = "lib/dashboard/dashboard_http_keeper.ml"
+
+let load_source rel =
+  let source_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> root
+    | None -> Sys.getcwd ()
+  in
+  let path = Filename.concat source_root rel in
+  if not (Sys.file_exists path)
+  then failwith (Printf.sprintf "source file not found: %s" path)
+  else (
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> In_channel.input_all ic))
+
+let contains ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if needle_len = 0
+    then true
+    else if idx + needle_len > haystack_len
+    then false
+    else if String.sub haystack idx needle_len = needle
+    then true
+    else loop (idx + 1)
+  in
+  loop 0
+
+let check_contains label src needle =
+  check bool label true (contains ~needle src)
+
+let test_worker_exception_falls_back_to_degraded_row () =
+  let src = load_source target_file in
+  check_contains
+    "degraded row helper exists"
+    src
+    "let degraded_keeper_dashboard_row";
+  check_contains
+    "per-worker row variable protects Fiber.all"
+    src
+    "let row =\n      try";
+  check_contains
+    "cancellation still propagates"
+    src
+    "| Eio.Cancel.Cancelled _ as exn -> raise exn";
+  check_contains
+    "worker exception logs"
+    src
+    "keeper dashboard worker error (%s): %s";
+  check_contains
+    "fallback reason is surfaced"
+    src
+    "keeper_dashboard_worker_exception";
+  check_contains
+    "FD-shaped exception reaches pressure guard"
+    src
+    "Keeper_fd_pressure.note_exception ~site:\"keeper_dashboard.worker\" exn";
+  check_contains
+    "row result is assigned after guarded build"
+    src
+    "results.(idx) <- row"
+
+let test_degraded_row_shape_keeps_dashboard_contract () =
+  let src = load_source target_file in
+  check_contains "degraded status field" src "(\"status\", `String \"degraded\")";
+  check_contains "degraded diagnostic field" src "(\"diagnostic\", diagnostic)";
+  check_contains "runtime trust fallback field" src "(\"runtime_trust\", runtime_trust)";
+  check_contains "agent field remains present" src "(\"agent\", `Null)";
+  check_contains "runtime identity field remains present" src "(\"runtime_id\", runtime_id_json)"
+
+let () =
+  run
+    "dashboard_keeper_worker_degrade_source"
+    [ ( "worker_failure"
+      , [ test_case
+            "worker exception falls back to degraded row"
+            `Quick
+            test_worker_exception_falls_back_to_degraded_row
+        ; test_case
+            "degraded row keeps dashboard contract"
+            `Quick
+            test_degraded_row_shape_keeps_dashboard_contract
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- add a degraded keeper dashboard row fallback for per-keeper worker failures
- keep Eio cancellation fatal while logging ordinary worker exceptions
- record FD-exhaustion-shaped exceptions through the existing Keeper_fd_pressure guard
- add a source-contract regression test for the worker failure fallback

## Why
`keepers_dashboard_json` builds each keeper row inside `Eio.Fiber.all`. A single row-level exception could cancel the whole dashboard payload. This keeps the endpoint available and surfaces the affected keeper as `status=degraded` with diagnostic context when meta can still be read.

## Validation
- `scripts/opam-pin-external-deps.sh --install`
- `ocamlformat --check lib/dashboard/dashboard_http_keeper.ml test/test_dashboard_keeper_worker_degrade_source.ml`
- `scripts/dune-local.sh build test/test_dashboard_keeper_worker_degrade_source.exe lib/dashboard/masc_dashboard.cmxa`
- `scripts/dune-local.sh exec ./test/test_dashboard_keeper_worker_degrade_source.exe`
- earlier before pin update: `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/masc.cmxa`
- earlier before pin update: `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_dashboard_http_core.exe`

## Notes
- Local pin drift initially blocked builds (`agent_sdk 0.206.2`, required `>= 0.206.3`), then `scripts/opam-pin-external-deps.sh --install` updated `agent_sdk` to `0.206.3`.
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh exec ./test/test_dashboard_http_core.exe` was attempted before the pin update; the binary ran but reported 7 unrelated executor_pool failures, first at `test/test_dashboard_http_core.ml:247` (`config_resolution.path` was null). The focused build target and new regression test passed.