### PR TITLE
feat(discord): streaming messages via PATCH edit

### DIFF
--- a/lib/gate/discord_rest_client.ml
+++ b/lib/gate/discord_rest_client.ml
@@ -107,6 +107,35 @@ let send_message ~token ~channel_id ~content ?reply_to_message_id () =
   | Error msg -> Error (Network msg)
   | Ok (status, body) -> parse_response ~status ~body
 
+(* Truncate content to Discord's message_content_limit for PATCH edits.
+   Discord rejects messages exceeding 2000 Unicode scalar units. *)
+let truncate_to_limit content =
+  if String.length content <= message_content_limit then content
+  else String.sub content 0 message_content_limit
+
+let build_edit_request ~token ~channel_id ~message_id ~content () =
+  let url =
+    Printf.sprintf
+      "https://discord.com/api/v10/channels/%s/messages/%s"
+      channel_id message_id
+  in
+  let headers =
+    ("Content-Type", "application/json") :: auth_headers ~token
+  in
+  let truncated = truncate_to_limit content in
+  let body =
+    Yojson.Safe.to_string (`Assoc [ "content", `String truncated ])
+  in
+  (url, headers, body)
+
+let edit_message ~token ~channel_id ~message_id ~content () =
+  let (url, headers, body) =
+    build_edit_request ~token ~channel_id ~message_id ~content ()
+  in
+  match Masc_http_client.patch_sync ~url ~headers ~body () with
+  | Error msg -> Error (Network msg)
+  | Ok (status, body) -> parse_empty_response ~status ~body
+
 let trigger_typing ~token ~channel_id () =
   let url, headers, body = build_typing_request ~token ~channel_id () in
   match Masc_http_client.post_sync ~url ~headers ~body () with

--- a/lib/gate/discord_rest_client.mli
+++ b/lib/gate/discord_rest_client.mli
@@ -52,6 +52,21 @@ val send_message :
 
     @raise nothing — failures are surfaced as typed {!error}. *)
 
+val edit_message :
+  token:string ->
+  channel_id:string ->
+  message_id:string ->
+  content:string ->
+  unit ->
+  (unit, error) result
+(** [edit_message ~token ~channel_id ~message_id ~content ()] patches
+    [PATCH /api/v10/channels/{channel_id}/messages/{message_id}].
+    Used for streaming message display — the message content is updated
+    in-place on Discord. Content exceeding {!message_content_limit} is
+    silently truncated to the first 2000 characters.
+
+    @raise nothing — failures are surfaced as typed {!error}. *)
+
 val trigger_typing :
   token:string ->
   channel_id:string ->
@@ -91,6 +106,17 @@ val build_typing_request :
   string * (string * string) list * string
 (** [(url, headers, body) = build_typing_request ~token ~channel_id ()].
     The body is empty; headers include Authorization and User-Agent. *)
+
+val build_edit_request :
+  token:string ->
+  channel_id:string ->
+  message_id:string ->
+  content:string ->
+  unit ->
+  string * (string * string) list * string
+(** [(url, headers, body) = build_edit_request ~token ~channel_id
+    ~message_id ~content ()].  Content exceeding {!message_content_limit}
+    is silently truncated. *)
 
 val parse_response :
   status:int ->

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -1,10 +1,10 @@
 (** Keeper_chat_discord — Discord delivery adapter for keeper chat events.
 
-    Streaming mode: on the first [Text_delta], POST creates the Discord
-    message.  Subsequent deltas PATCH the message content at most once
-    per [min_edit_interval_s] (rate limit: 5 edits / 5 s per channel).
-    [Text_message_end] and [Run_finished] force a final PATCH so the
-    user always sees the complete text. *)
+    Streaming mode: the first stable text segment POST creates the Discord
+    message. Subsequent deltas PATCH the message content at most once per
+    [min_edit_interval_s] (rate limit: 5 edits / 5 s per channel).
+    [Text_message_end] and [Run_finished] force a final PATCH so the user
+    always sees the complete text. *)
 
 (* Minimum seconds between PATCH edits. Discord allows 5 edits per 5 s;
    1.0 s is 80 % of that budget, leaving headroom for the final edit. *)
@@ -54,6 +54,38 @@ let truncate content =
   if String.length content <= limit then content
   else String.sub content 0 limit
 
+let is_ascii_space = function
+  | ' ' | '\n' | '\r' | '\t' -> true
+  | _ -> false
+
+let stable_stream_prefix content =
+  let len = String.length content in
+  let rec find i =
+    if i < 0 then 0
+    else if is_ascii_space content.[i] then i + 1
+    else find (i - 1)
+  in
+  let stable_len = find (len - 1) in
+  if stable_len = 0 then ""
+  else String.sub content 0 stable_len
+
+let streaming_patch_content content =
+  content |> stable_stream_prefix |> truncate
+
+let final_head_and_overflow content =
+  let redacted = Observability_redact.redact_text content in
+  let limit = Discord_rest_client.message_content_limit in
+  let rlen = String.length redacted in
+  let head =
+    if rlen <= limit then redacted
+    else String.sub redacted 0 limit
+  in
+  let overflow =
+    if rlen <= limit then None
+    else Some (String.sub redacted limit (rlen - limit))
+  in
+  (head, overflow)
+
 let edit_message_silent ~token ~channel_id ~message_id ~content =
   match Discord_rest_client.edit_message
           ~token ~channel_id ~message_id ~content ()
@@ -65,6 +97,11 @@ let edit_message_silent ~token ~channel_id ~message_id ~content =
         "keeper_chat_discord: edit_message failed (msg=%s): %s"
         message_id err_str
 
+module For_testing = struct
+  let streaming_patch_content = streaming_patch_content
+  let final_head_and_overflow = final_head_and_overflow
+end
+
 (* NDT-OK: wall-clock used for Discord rate-limit backoff only,
    not for deterministic policy or state transitions. *)
 let now () = Unix.gettimeofday ()
@@ -73,51 +110,58 @@ let adapter_loop ~token ~channel_id ~events =
   (* Streaming state:
      - msg_id: Some once the initial POST succeeds
      - last_edit_time: wall-clock of last PATCH (rate limiting)
-     - last_edited_text: snapshot of acc_text at last PATCH (skip no-op edits) *)
+     - last_edited_text: content sent by last POST/PATCH (skip no-op edits) *)
   let rec loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text =
     match Keeper_chat_events.subscribe events with
     | Text_delta text ->
         let acc_text = acc_text ^ text in
+        let patch_content = streaming_patch_content acc_text in
         (match msg_id with
          | None ->
-             (* First delta — POST to create the message. *)
-             (match Discord_rest_client.send_message
-                     ~token ~channel_id ~content:(truncate acc_text) ()
-             with
-              | Ok created_id ->
-                  loop ~acc_text
-                    ~msg_id:(Some created_id)
-                    ~last_edit_time:(now ())
-                    ~last_edited_text:acc_text
-              | Error err ->
-                  let err_str =
-                    Format.asprintf "%a" Discord_rest_client.pp_error err
-                  in
-                  Log.Keeper.warn
-                    "keeper_chat_discord: streaming POST failed: %s" err_str;
-                  (* Keep accumulating; will try again on next delta. *)
-                  loop ~acc_text ~msg_id:None
-                    ~last_edit_time ~last_edited_text)
+             (* First stable segment — POST to create the message. *)
+             if String.length patch_content = 0 then
+               loop ~acc_text ~msg_id:None ~last_edit_time ~last_edited_text
+             else
+               (match Discord_rest_client.send_message
+                       ~token ~channel_id ~content:patch_content ()
+               with
+                | Ok created_id ->
+                    loop ~acc_text
+                      ~msg_id:(Some created_id)
+                      ~last_edit_time:(now ())
+                      ~last_edited_text:patch_content
+                | Error err ->
+                    let err_str =
+                      Format.asprintf "%a" Discord_rest_client.pp_error err
+                    in
+                    Log.Keeper.warn
+                      "keeper_chat_discord: streaming POST failed: %s" err_str;
+                    (* Keep accumulating; will try again on next delta. *)
+                    loop ~acc_text ~msg_id:None
+                      ~last_edit_time ~last_edited_text)
          | Some mid ->
              let elapsed = now () -. last_edit_time in
-             if elapsed >= min_edit_interval_s then begin
+             if patch_content = last_edited_text then
+               loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text
+             else if elapsed >= min_edit_interval_s then begin
                edit_message_silent ~token ~channel_id
-                 ~message_id:mid ~content:(truncate acc_text);
+                 ~message_id:mid ~content:patch_content;
                loop ~acc_text ~msg_id
                  ~last_edit_time:(now ())
-                 ~last_edited_text:acc_text
+                 ~last_edited_text:patch_content
              end else
                (* Rate limited — skip this PATCH. *)
                loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text)
     | Text_message_end ->
         (* Force a final PATCH for this text message if content changed. *)
+        let final_content = truncate acc_text in
         (match msg_id with
-         | Some mid when acc_text <> last_edited_text ->
+         | Some mid when final_content <> last_edited_text ->
              edit_message_silent ~token ~channel_id
-               ~message_id:mid ~content:(truncate acc_text);
+               ~message_id:mid ~content:final_content;
              loop ~acc_text ~msg_id
                ~last_edit_time:(now ())
-               ~last_edited_text:acc_text
+               ~last_edited_text:final_content
          | _ ->
              loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text)
     | Run_finished { run_id = _ } ->
@@ -127,25 +171,17 @@ let adapter_loop ~token ~channel_id ~events =
              if String.length acc_text > 0 then
                send_message ~token ~channel_id ~content:acc_text
          | Some mid ->
-             (* Redact once, then split head/tail at the 2000-char limit. *)
-             let redacted = Observability_redact.redact_text acc_text in
-             let limit = Discord_rest_client.message_content_limit in
-             let rlen = String.length redacted in
-             let head =
-               if rlen <= limit then redacted
-               else String.sub redacted 0 limit
-             in
+             let head, overflow = final_head_and_overflow acc_text in
              (* Final PATCH with the head (first 2000 chars). *)
              edit_message_silent ~token ~channel_id
                ~message_id:mid ~content:head;
              (* Send overflow as follow-up messages, matching the original
                 chunking behavior. send_message handles further splitting. *)
-             if rlen > limit then begin
-               let overflow =
-                 String.sub redacted limit (rlen - limit)
-               in
+             (match overflow with
+              | None -> ()
+              | Some overflow ->
                send_message ~token ~channel_id ~content:overflow
-             end);
+             ));
         (* Loop exits after one turn. *)
         ()
     | Event_error { message } ->

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -1,4 +1,14 @@
-(** Keeper_chat_discord — Discord delivery adapter for keeper chat events. *)
+(** Keeper_chat_discord — Discord delivery adapter for keeper chat events.
+
+    Streaming mode: on the first [Text_delta], POST creates the Discord
+    message.  Subsequent deltas PATCH the message content at most once
+    per [min_edit_interval_s] (rate limit: 5 edits / 5 s per channel).
+    [Text_message_end] and [Run_finished] force a final PATCH so the
+    user always sees the complete text. *)
+
+(* Minimum seconds between PATCH edits. Discord allows 5 edits per 5 s;
+   1.0 s is 80 % of that budget, leaving headroom for the final edit. *)
+let min_edit_interval_s = 1.0
 
 let send_message ~token ~channel_id ~content =
   let content = Observability_redact.redact_text content in
@@ -37,16 +47,89 @@ let send_message ~token ~channel_id ~content =
     in
     send_chunks content
 
+(* Truncate to Discord message limit for PATCH edits. *)
+let truncate content =
+  let limit = Discord_rest_client.message_content_limit in
+  if String.length content <= limit then content
+  else String.sub content 0 limit
+
+let edit_message_silent ~token ~channel_id ~message_id ~content =
+  let content = Observability_redact.redact_text content in
+  match Discord_rest_client.edit_message
+          ~token ~channel_id ~message_id ~content ()
+  with
+  | Ok () -> ()
+  | Error err ->
+      let err_str = Format.asprintf "%a" Discord_rest_client.pp_error err in
+      Log.Keeper.warn
+        "keeper_chat_discord: edit_message failed (msg=%s): %s"
+        message_id err_str
+
+(* NDT-OK: wall-clock used for Discord rate-limit backoff only,
+   not for deterministic policy or state transitions. *)
+let now () = Unix.gettimeofday ()
+
 let adapter_loop ~token ~channel_id ~events =
-  let rec loop ~acc_text ~run_id_opt =
+  (* Streaming state:
+     - msg_id: Some once the initial POST succeeds
+     - last_edit_time: wall-clock of last PATCH (rate limiting)
+     - last_edited_text: snapshot of acc_text at last PATCH (skip no-op edits) *)
+  let rec loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text =
     match Keeper_chat_events.subscribe events with
     | Text_delta text ->
-        loop ~acc_text:(acc_text ^ text) ~run_id_opt
+        let acc_text = acc_text ^ text in
+        (match msg_id with
+         | None ->
+             (* First delta — POST to create the message. *)
+             (match Discord_rest_client.send_message
+                     ~token ~channel_id ~content:(truncate acc_text) ()
+             with
+              | Ok created_id ->
+                  loop ~acc_text
+                    ~msg_id:(Some created_id)
+                    ~last_edit_time:(now ())
+                    ~last_edited_text:acc_text
+              | Error err ->
+                  let err_str =
+                    Format.asprintf "%a" Discord_rest_client.pp_error err
+                  in
+                  Log.Keeper.warn
+                    "keeper_chat_discord: streaming POST failed: %s" err_str;
+                  (* Keep accumulating; will try again on next delta. *)
+                  loop ~acc_text ~msg_id:None
+                    ~last_edit_time ~last_edited_text)
+         | Some mid ->
+             let elapsed = now () -. last_edit_time in
+             if elapsed >= min_edit_interval_s then begin
+               edit_message_silent ~token ~channel_id
+                 ~message_id:mid ~content:(truncate acc_text);
+               loop ~acc_text ~msg_id
+                 ~last_edit_time:(now ())
+                 ~last_edited_text:acc_text
+             end else
+               (* Rate limited — skip this PATCH. *)
+               loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text)
     | Text_message_end ->
-        loop ~acc_text ~run_id_opt
+        (* Force a final PATCH for this text message if content changed. *)
+        (match msg_id with
+         | Some mid when acc_text <> last_edited_text ->
+             edit_message_silent ~token ~channel_id
+               ~message_id:mid ~content:(truncate acc_text);
+             loop ~acc_text ~msg_id
+               ~last_edit_time:(now ())
+               ~last_edited_text:acc_text
+         | _ ->
+             loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text)
     | Run_finished { run_id = _ } ->
-        if String.length acc_text > 0 then
-          send_message ~token ~channel_id ~content:acc_text;
+        (match msg_id with
+         | None ->
+             (* No deltas received — fall back to single send. *)
+             if String.length acc_text > 0 then
+               send_message ~token ~channel_id ~content:acc_text
+         | Some mid ->
+             (* Final PATCH with complete text (may be a no-op). *)
+             edit_message_silent ~token ~channel_id
+               ~message_id:mid ~content:(truncate acc_text));
         (* Loop exits after one turn. *)
         ()
     | Event_error { message } ->
@@ -54,15 +137,15 @@ let adapter_loop ~token ~channel_id ~events =
           ~content:("Keeper error: " ^ message);
         (* Loop exits after error. *)
         ()
-    | Run_started { run_id; thread_id = _ } ->
-        loop ~acc_text:"" ~run_id_opt:(Some run_id)
+    | Run_started { run_id = _; thread_id = _ } ->
+        loop ~acc_text:"" ~msg_id:None ~last_edit_time:0.0 ~last_edited_text:""
     | Text_message_start { message_id = _; role = _ } ->
-        loop ~acc_text ~run_id_opt
+        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text
     | Custom { name; value = _ } ->
         Log.Keeper.debug
           "keeper_chat_discord: custom event %s" name;
-        loop ~acc_text ~run_id_opt
+        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text
     | Tool_call_start _ | Tool_call_args _ | Tool_call_end _ ->
-        loop ~acc_text ~run_id_opt
+        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text
   in
-  loop ~acc_text:"" ~run_id_opt:None
+  loop ~acc_text:"" ~msg_id:None ~last_edit_time:0.0 ~last_edited_text:""

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -47,14 +47,14 @@ let send_message ~token ~channel_id ~content =
     in
     send_chunks content
 
-(* Truncate to Discord message limit for PATCH edits. *)
+(* Truncate to Discord message limit for PATCH edits, with redaction. *)
 let truncate content =
+  let content = Observability_redact.redact_text content in
   let limit = Discord_rest_client.message_content_limit in
   if String.length content <= limit then content
   else String.sub content 0 limit
 
 let edit_message_silent ~token ~channel_id ~message_id ~content =
-  let content = Observability_redact.redact_text content in
   match Discord_rest_client.edit_message
           ~token ~channel_id ~message_id ~content ()
   with
@@ -123,13 +123,29 @@ let adapter_loop ~token ~channel_id ~events =
     | Run_finished { run_id = _ } ->
         (match msg_id with
          | None ->
-             (* No deltas received — fall back to single send. *)
+             (* No deltas received — fall back to single send (chunks). *)
              if String.length acc_text > 0 then
                send_message ~token ~channel_id ~content:acc_text
          | Some mid ->
-             (* Final PATCH with complete text (may be a no-op). *)
+             (* Redact once, then split head/tail at the 2000-char limit. *)
+             let redacted = Observability_redact.redact_text acc_text in
+             let limit = Discord_rest_client.message_content_limit in
+             let rlen = String.length redacted in
+             let head =
+               if rlen <= limit then redacted
+               else String.sub redacted 0 limit
+             in
+             (* Final PATCH with the head (first 2000 chars). *)
              edit_message_silent ~token ~channel_id
-               ~message_id:mid ~content:(truncate acc_text));
+               ~message_id:mid ~content:head;
+             (* Send overflow as follow-up messages, matching the original
+                chunking behavior. send_message handles further splitting. *)
+             if rlen > limit then begin
+               let overflow =
+                 String.sub redacted limit (rlen - limit)
+               in
+               send_message ~token ~channel_id ~content:overflow
+             end);
         (* Loop exits after one turn. *)
         ()
     | Event_error { message } ->

--- a/lib/keeper/keeper_chat_discord.mli
+++ b/lib/keeper/keeper_chat_discord.mli
@@ -1,10 +1,13 @@
 (** Keeper_chat_discord — Discord delivery adapter for keeper chat events.
 
-    Streaming mode: on the first [Text_delta], POST creates the Discord
-    message.  Subsequent deltas PATCH the message at most once per
+    Streaming mode: the first stable text segment POST creates the Discord
+    message. Subsequent deltas PATCH the message at most once per
     {!min_edit_interval_s} (Discord rate limit: 5 edits / 5 s).
     [Text_message_end] and [Run_finished] force a final PATCH so the
-    user always sees the complete text.
+    user always sees the complete text. Streaming PATCH/POST content
+    holds back the current trailing non-whitespace segment until a
+    delimiter arrives, so partial secret-like tokens are not published
+    before the redactor can see the complete token.
 
     @since 2.145.0 *)
 
@@ -25,7 +28,8 @@ val adapter_loop :
   unit
 (** [adapter_loop ~token ~channel_id ~events] subscribes to the event
     stream and delivers text to Discord in real time:
-    - [Text_delta] (first): POST creates the message, stores its id.
+    - [Text_delta] (first stable segment): POST creates the message,
+      stores its id.
     - [Text_delta] (subsequent): PATCH edits the message content, at most
       once per {!min_edit_interval_s}.
     - [Text_message_end]: force PATCH if content changed since last edit.
@@ -36,3 +40,13 @@ val adapter_loop :
 
     The loop exits after one turn; the caller must restart it for
     subsequent turns. *)
+
+module For_testing : sig
+  val streaming_patch_content : string -> string
+  (** Redacted, Discord-sized content suitable for streaming POST/PATCH.
+      The current trailing non-whitespace segment is withheld. *)
+
+  val final_head_and_overflow : string -> string * string option
+  (** Redacted final content split into the first Discord message body and
+      optional overflow for follow-up chunked delivery. *)
+end

--- a/lib/keeper/keeper_chat_discord.mli
+++ b/lib/keeper/keeper_chat_discord.mli
@@ -1,25 +1,38 @@
 (** Keeper_chat_discord — Discord delivery adapter for keeper chat events.
 
-    Subscribes to a [Keeper_chat_events] stream, accumulates assistant
-    text deltas, and sends the final reply to a Discord channel via the
-    REST API when the run finishes.
+    Streaming mode: on the first [Text_delta], POST creates the Discord
+    message.  Subsequent deltas PATCH the message at most once per
+    {!min_edit_interval_s} (Discord rate limit: 5 edits / 5 s).
+    [Text_message_end] and [Run_finished] force a final PATCH so the
+    user always sees the complete text.
 
     @since 2.145.0 *)
+
+val min_edit_interval_s : float
+(** Minimum seconds between PATCH edits (default 1.0). *)
 
 val send_message :
   token:string -> channel_id:string -> content:string -> unit
 (** [send_message ~token ~channel_id ~content] posts to Discord.
     Errors are logged as warnings but never raised.
-    The content is truncated to Discord's 2000-character limit. *)
+    Content exceeding Discord's 2000-character limit is split into
+    multiple messages. *)
 
 val adapter_loop :
   token:string ->
   channel_id:string ->
   events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
   unit
-(** [adapter_loop ~token ~channel_id ~events] blocks on the event
-    stream until [Run_finished] or [Error], then sends the accumulated
-    text (or error message) to the given Discord channel.
+(** [adapter_loop ~token ~channel_id ~events] subscribes to the event
+    stream and delivers text to Discord in real time:
+    - [Text_delta] (first): POST creates the message, stores its id.
+    - [Text_delta] (subsequent): PATCH edits the message content, at most
+      once per {!min_edit_interval_s}.
+    - [Text_message_end]: force PATCH if content changed since last edit.
+    - [Run_finished]: force final PATCH with complete text.
+    - [Event_error]: sends error text as a new message.
+
+    Falls back to a single POST if no deltas arrive before [Run_finished].
 
     The loop exits after one turn; the caller must restart it for
     subsequent turns. *)

--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -113,6 +113,15 @@ let post_sync ?clock ?timeout_sec ~url ~headers ~body () =
   | Ok { Pool.status; body; _ } -> Ok (status, body)
   | Error e -> Error e
 
+(** PATCH with structured error handling. *)
+let patch_sync ?clock ?timeout_sec ~url ~headers ~body () =
+  with_optional_timeout ?clock ?timeout_sec @@ fun () ->
+  with_pool @@ fun pool ->
+  match Pool.request pool ?clock ?timeout_seconds:timeout_sec
+          ~method_:`PATCH ~url ~headers ~body () with
+  | Ok { Pool.status; body; _ } -> Ok (status, body)
+  | Error e -> Error e
+
 (** GET with structured error handling. *)
 let get_response_sync ?clock ?timeout_sec ~url ~headers () =
   with_optional_timeout ?clock ?timeout_sec @@ fun () ->

--- a/lib/masc_http_client/masc_http_client.mli
+++ b/lib/masc_http_client/masc_http_client.mli
@@ -51,6 +51,17 @@ val post_sync :
     Connection-level errors (DNS, TLS, I/O) are caught and surfaced
     as [Error _] rather than propagating as exceptions. *)
 
+val patch_sync :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
+  url:string ->
+  headers:(string * string) list ->
+  body:string ->
+  unit ->
+  ((int * string), string) result
+(** [patch_sync ?clock ?timeout_sec ~url ~headers ~body ()] performs
+    a [PATCH url].  Same error handling as {!post_sync}. *)
+
 val get_response_sync :
   ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   ?timeout_sec:float ->

--- a/test/dune
+++ b/test/dune
@@ -1297,6 +1297,8 @@
 
 (include stanzas/test_discord_rest_client.inc)
 
+(include stanzas/test_keeper_chat_discord.inc)
+
 (include stanzas/test_ci_run_tests_script.inc)
 
 (include stanzas/test_context_max_observed_9953.inc)

--- a/test/stanzas/test_keeper_chat_discord.inc
+++ b/test/stanzas/test_keeper_chat_discord.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_chat_discord)
+ (modules test_keeper_chat_discord)
+ (libraries alcotest masc_test_deps))

--- a/test/test_discord_rest_client.ml
+++ b/test/test_discord_rest_client.ml
@@ -76,6 +76,67 @@ let test_build_typing_request_authorization_uses_bot_scheme () =
      && String.sub ua 0 10 = "DiscordBot")
 
 (* ---------------------------------------------------------------- *)
+(* build_edit_request                                               *)
+(* ---------------------------------------------------------------- *)
+
+let test_build_edit_request_url_targets_message () =
+  let url, _, _ =
+    R.build_edit_request ~token:"abc" ~channel_id:"CH123"
+      ~message_id:"MSG456" ~content:"hi" ()
+  in
+  check string "v10 edit URL"
+    "https://discord.com/api/v10/channels/CH123/messages/MSG456"
+    url
+
+let test_build_edit_request_authorization_uses_bot_scheme () =
+  let _, headers, _ =
+    R.build_edit_request ~token:"sekret" ~channel_id:"c"
+      ~message_id:"m" ~content:"." ()
+  in
+  check string "Authorization header" "Bot sekret"
+    (header_value headers "Authorization");
+  check string "Content-Type header" "application/json"
+    (header_value headers "Content-Type")
+
+let test_build_edit_request_body_is_content_object () =
+  let _, _, body =
+    R.build_edit_request ~token:"t" ~channel_id:"c"
+      ~message_id:"m" ~content:"updated text" ()
+  in
+  let json = Yojson.Safe.from_string body in
+  match json with
+  | `Assoc [ ("content", `String "updated text") ] -> ()
+  | _ ->
+      failf
+        "body shape wrong: %s"
+        (Yojson.Safe.to_string json)
+
+let test_build_edit_request_content_truncated_at_limit () =
+  let long_content = String.make 2500 'x' in
+  let _, _, body =
+    R.build_edit_request ~token:"t" ~channel_id:"c"
+      ~message_id:"m" ~content:long_content ()
+  in
+  let json = Yojson.Safe.from_string body in
+  match json with
+  | `Assoc [ ("content", `String truncated) ] ->
+      check int "truncated length" 2000 (String.length truncated)
+  | _ ->
+      failf "body shape wrong: %s" (Yojson.Safe.to_string json)
+
+let test_build_edit_request_short_content_not_truncated () =
+  let short_content = "hello" in
+  let _, _, body =
+    R.build_edit_request ~token:"t" ~channel_id:"c"
+      ~message_id:"m" ~content:short_content ()
+  in
+  let json = Yojson.Safe.from_string body in
+  match json with
+  | `Assoc [ ("content", `String "hello") ] -> ()
+  | _ ->
+      failf "body shape wrong: %s" (Yojson.Safe.to_string json)
+
+(* ---------------------------------------------------------------- *)
 (* parse_response                                                   *)
 (* ---------------------------------------------------------------- *)
 
@@ -171,6 +232,18 @@ let () =
             test_build_typing_request_url_targets_channel
         ; test_case "typing Authorization uses Bot scheme" `Quick
             test_build_typing_request_authorization_uses_bot_scheme
+        ] )
+    ; ( "build_edit_request"
+      , [ test_case "URL targets channel/message" `Quick
+            test_build_edit_request_url_targets_message
+        ; test_case "Authorization uses Bot scheme" `Quick
+            test_build_edit_request_authorization_uses_bot_scheme
+        ; test_case "body is { content: <content> } JSON" `Quick
+            test_build_edit_request_body_is_content_object
+        ; test_case "content truncated at 2000 chars" `Quick
+            test_build_edit_request_content_truncated_at_limit
+        ; test_case "short content not truncated" `Quick
+            test_build_edit_request_short_content_not_truncated
         ] )
     ; ( "parse_response"
       , [ test_case "2xx with id => Ok id" `Quick

--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -1,0 +1,70 @@
+open Alcotest
+
+module D = Masc.Keeper_chat_discord.For_testing
+
+let contains haystack needle =
+  String_util.contains_substring haystack needle
+
+let test_streaming_holds_back_trailing_token () =
+  let content =
+    D.streaming_patch_content "prefix sk-proj-abcdefghijklmnop"
+  in
+  check string "only stable prefix is published" "prefix " content;
+  check bool "raw token prefix withheld" false (contains content "sk-proj")
+
+let test_streaming_redacts_delimited_secret () =
+  let secret = "sk-proj-abcdefghijklmnopqrstuvwxyz" in
+  let content =
+    D.streaming_patch_content ("prefix " ^ secret ^ " done ")
+  in
+  check bool "redaction marker present" true
+    (contains content "[REDACTED]");
+  check bool "raw secret removed" false (contains content secret)
+
+let test_streaming_single_word_waits_for_final_send () =
+  let content = D.streaming_patch_content "hello" in
+  check string "no stable segment yet" "" content
+
+let test_final_split_preserves_overflow () =
+  let input = String.concat "" (List.init 420 (fun _ -> "word ")) in
+  let head, overflow = D.final_head_and_overflow input in
+  check int "head capped at Discord limit" 2000 (String.length head);
+  match overflow with
+  | None -> fail "expected overflow"
+  | Some overflow ->
+      check int "overflow preserves tail"
+        (String.length input - 2000)
+        (String.length overflow);
+      check string "reconstructed final text" input (head ^ overflow)
+
+let test_final_split_redacts_before_chunking () =
+  let secret = "sk-proj-abcdefghijklmnopqrstuvwxyz" in
+  let head, overflow =
+    D.final_head_and_overflow ("prefix " ^ secret ^ " suffix")
+  in
+  let full =
+    match overflow with
+    | None -> head
+    | Some overflow -> head ^ overflow
+  in
+  check bool "redaction marker present" true
+    (contains full "[REDACTED]");
+  check bool "raw secret removed" false (contains full secret)
+
+let () =
+  run "keeper_chat_discord"
+    [ ( "streaming-redaction"
+      , [ test_case "holds back trailing token" `Quick
+            test_streaming_holds_back_trailing_token
+        ; test_case "redacts delimited secret" `Quick
+            test_streaming_redacts_delimited_secret
+        ; test_case "single word waits for final send" `Quick
+            test_streaming_single_word_waits_for_final_send
+        ] )
+    ; ( "final-delivery"
+      , [ test_case "preserves overflow" `Quick
+            test_final_split_preserves_overflow
+        ; test_case "redacts before chunking" `Quick
+            test_final_split_redacts_before_chunking
+        ] )
+    ]


### PR DESCRIPTION
## Summary

Discord는 네이티브 스트리밍 API가 없으므로, POST로 메시지를 만들고 PATCH로 내용을 반복 수정하는 패턴으로 실시간 응답 효과를 구현한다.

## Changes

- Masc_http_client.patch_sync — Pool.request PATCH 위임 편의 함수
- Discord_rest_client.edit_message — PATCH /api/v10/channels/{ch}/messages/{msg} 래퍼
- Keeper_chat_discord.adapter_loop 스트리밍화:
  - 첫 Text_delta: POST로 메시지 생성
  - 이후 Text_delta: 1초 간격 PATCH (Discord 5 edits/5s 안전 마진)
  - Text_message_end/Run_finished: 최종 PATCH
  - delta 없이 완료 시 단일 POST fallback

## Test plan

- [x] dune build --root . @check — 컴파일 통과
- [x] dune build — full build 통과
- [x] test_discord_rest_client — 19 tests (기존 14 + 신규 5)
- [x] test_discord_gateway_state — 69 tests (변경 없음)

Co-Authored-By: Claude <noreply@anthropic.com>