### PR TITLE
feat(schedule): emit due wake signals

### DIFF
--- a/lib/schedule/dune
+++ b/lib/schedule/dune
@@ -1,11 +1,11 @@
 (include_subdirs no)
 
-;; Scheduled internal automation domain + service/store. No runner, shell, or
-;; transport dependency at this layer.
+;; Scheduled internal automation domain + service/store/runner. The runner only
+;; emits generic schedule signals; consumer dispatch stays outside this layer.
 
 (library
  (name masc_schedule)
  (public_name masc.masc_schedule)
  (wrapped false)
- (modules schedule_domain schedule_store schedule_service)
- (libraries digestif masc_workspace unix yojson))
+ (modules schedule_domain schedule_store schedule_service schedule_runner)
+ (libraries digestif masc_workspace dated_jsonl unix yojson))

--- a/lib/schedule/schedule_runner.ml
+++ b/lib/schedule/schedule_runner.ml
@@ -1,0 +1,231 @@
+type signal_kind =
+  | Due_candidate
+  | Due_blocked_approval
+
+type wake_signal =
+  { signal_id : string
+  ; kind : signal_kind
+  ; schedule_id : string
+  ; emitted_at : float
+  ; due_at : float
+  ; risk_class : Schedule_domain.risk_class
+  ; payload_digest : string
+  ; payload : Yojson.Safe.t
+  }
+
+type tick_result =
+  { due_changed : int
+  ; emitted : wake_signal list
+  }
+
+type runner_error =
+  | Service_error of Schedule_service.service_error
+  | Signal_store_error of string
+
+let ( let* ) = Result.bind
+
+let runner_error_to_string = function
+  | Service_error err -> Schedule_service.service_error_to_string err
+  | Signal_store_error msg -> "signal store error: " ^ msg
+;;
+
+let signal_kind_to_string = function
+  | Due_candidate -> "schedule.due_candidate"
+  | Due_blocked_approval -> "schedule.due_blocked_approval"
+;;
+
+let signal_kind_of_string = function
+  | "schedule.due_candidate" -> Ok Due_candidate
+  | "schedule.due_blocked_approval" -> Ok Due_blocked_approval
+  | other -> Error ("unknown schedule signal kind: " ^ other)
+;;
+
+let schedules_dir config =
+  Filename.concat (Workspace_utils.masc_dir config) "schedules"
+;;
+
+let signals_dir config = Filename.concat (schedules_dir config) "signals"
+
+let signal_seen_path config =
+  Filename.concat (schedules_dir config) "signal_keys.json"
+;;
+
+let signal_store config = Dated_jsonl.create ~base_dir:(signals_dir config) ()
+
+let string_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> Error ("expected string field: " ^ name)
+  | None -> Error ("missing field: " ^ name)
+;;
+
+let float_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Float value) -> Ok value
+  | Some (`Int value) -> Ok (float_of_int value)
+  | Some _ -> Error ("expected float field: " ^ name)
+  | None -> Error ("missing field: " ^ name)
+;;
+
+let assoc_field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error ("missing field: " ^ name)
+;;
+
+let wake_signal_to_yojson signal =
+  `Assoc
+    [ "event_type", `String (signal_kind_to_string signal.kind)
+    ; "signal_id", `String signal.signal_id
+    ; "schedule_id", `String signal.schedule_id
+    ; "emitted_at", `Float signal.emitted_at
+    ; "due_at", `Float signal.due_at
+    ; "risk_class", `String (Schedule_domain.risk_class_to_string signal.risk_class)
+    ; "payload_digest", `String signal.payload_digest
+    ; "payload", signal.payload
+    ]
+;;
+
+let wake_signal_of_yojson = function
+  | `Assoc fields ->
+    let* kind_name = string_field "event_type" fields in
+    let* kind = signal_kind_of_string kind_name in
+    let* signal_id = string_field "signal_id" fields in
+    let* schedule_id = string_field "schedule_id" fields in
+    let* emitted_at = float_field "emitted_at" fields in
+    let* due_at = float_field "due_at" fields in
+    let* risk_name = string_field "risk_class" fields in
+    let* risk_class = Schedule_domain.risk_class_of_string risk_name in
+    let* payload_digest = string_field "payload_digest" fields in
+    let* payload = assoc_field "payload" fields in
+    Ok { signal_id; kind; schedule_id; emitted_at; due_at; risk_class; payload_digest; payload }
+  | _ -> Error "expected schedule wake_signal object"
+;;
+
+let sha256_string value =
+  Digestif.SHA256.(digest_string value |> to_hex)
+;;
+
+let stable_float value = Printf.sprintf "%.17g" value
+
+let signal_id kind (request : Schedule_domain.schedule_request) =
+  let payload_digest = Schedule_domain.payload_digest request.payload in
+  String.concat
+    "|"
+    [ signal_kind_to_string kind
+    ; request.schedule_id
+    ; stable_float request.due_at
+    ; payload_digest
+    ]
+  |> sha256_string
+;;
+
+let make_signal ~now kind (request : Schedule_domain.schedule_request) =
+  let payload_digest = Schedule_domain.payload_digest request.payload in
+  { signal_id = signal_id kind request
+  ; kind
+  ; schedule_id = request.schedule_id
+  ; emitted_at = now
+  ; due_at = request.due_at
+  ; risk_class = request.risk_class
+  ; payload_digest
+  ; payload = Schedule_domain.payload_to_yojson request.payload
+  }
+;;
+
+let read_seen config =
+  let path = signal_seen_path config in
+  if not (Workspace_utils.path_exists config path) then Ok []
+  else
+    match Workspace_utils.read_json_result config path with
+    | Error msg -> Error msg
+    | Ok (`List rows) ->
+      let rec loop acc = function
+        | [] -> Ok (List.rev acc)
+        | `String key :: rest -> loop (key :: acc) rest
+        | _ :: _ -> Error "signal_keys.json must be a string list"
+      in
+      loop [] rows
+    | Ok _ -> Error "signal_keys.json must be a JSON list"
+;;
+
+let write_seen config keys =
+  Workspace_utils.mkdir_p (schedules_dir config);
+  Workspace_utils.write_json config (signal_seen_path config)
+    (`List (List.map (fun key -> `String key) keys))
+;;
+
+let append_signal config signal =
+  try
+    Dated_jsonl.append (signal_store config) (wake_signal_to_yojson signal);
+    Ok ()
+  with
+  | Sys_error msg -> Error msg
+  | Unix.Unix_error (err, fn, arg) ->
+    Error
+      (Printf.sprintf
+         "%s failed for %s: %s"
+         fn
+         arg
+         (Unix.error_message err))
+;;
+
+let append_new_signals config candidates =
+  Workspace_utils.mkdir_p (schedules_dir config);
+  Workspace_utils.with_file_lock config (signal_seen_path config) (fun () ->
+    let* seen = read_seen config in
+    let seen_tbl = Hashtbl.create (List.length seen + List.length candidates) in
+    List.iter (fun key -> Hashtbl.replace seen_tbl key ()) seen;
+    let emitted_rev = ref [] in
+    let seen_rev = ref (List.rev seen) in
+    let rec loop = function
+      | [] ->
+        write_seen config (List.rev !seen_rev);
+        Ok (List.rev !emitted_rev)
+      | signal :: rest ->
+        if Hashtbl.mem seen_tbl signal.signal_id then loop rest
+        else (
+          let* () = append_signal config signal in
+          Hashtbl.replace seen_tbl signal.signal_id ();
+          seen_rev := signal.signal_id :: !seen_rev;
+          emitted_rev := signal :: !emitted_rev;
+          loop rest)
+    in
+    loop candidates)
+  |> function
+  | Ok emitted -> Ok emitted
+  | Error msg -> Error (Signal_store_error msg)
+;;
+
+let candidate_signals ~now state =
+  Schedule_store.due_execution_candidates state
+  |> List.map (make_signal ~now Due_candidate)
+;;
+
+let blocked_approval_signals ~now (state : Schedule_store.state) =
+  state.schedules
+  |> List.filter (fun (request : Schedule_domain.schedule_request) ->
+    request.status = Pending_approval
+    && request.due_at <= now
+    && Schedule_domain.requires_separate_human_grant request)
+  |> List.map (make_signal ~now Due_blocked_approval)
+;;
+
+let read_recent_signals config n =
+  Dated_jsonl.read_recent (signal_store config) n
+  |> List.filter_map (fun json ->
+    match wake_signal_of_yojson json with
+    | Ok signal -> Some signal
+    | Error _ -> None)
+;;
+
+let tick config ~now =
+  match Schedule_store.refresh_due config ~now with
+  | Error err -> Error (Service_error (Schedule_service.Store_error err))
+  | Ok (state, due_changed) ->
+    let signals =
+      candidate_signals ~now state @ blocked_approval_signals ~now state
+    in
+    let* emitted = append_new_signals config signals in
+    Ok { due_changed; emitted }
+;;

--- a/lib/schedule/schedule_runner.mli
+++ b/lib/schedule/schedule_runner.mli
@@ -1,0 +1,49 @@
+(** Due scanner and generic wake-signal feed for scheduled automation.
+
+    This module does not dispatch work and does not know consumer domains. It
+    refreshes due schedule state, emits durable generic schedule signals, and
+    leaves interpretation to consumers. *)
+
+type signal_kind =
+  | Due_candidate
+  | Due_blocked_approval
+
+type wake_signal =
+  { signal_id : string
+  ; kind : signal_kind
+  ; schedule_id : string
+  ; emitted_at : float
+  ; due_at : float
+  ; risk_class : Schedule_domain.risk_class
+  ; payload_digest : string
+  ; payload : Yojson.Safe.t
+  }
+
+type tick_result =
+  { due_changed : int
+  ; emitted : wake_signal list
+  }
+
+type runner_error =
+  | Service_error of Schedule_service.service_error
+  | Signal_store_error of string
+
+val runner_error_to_string : runner_error -> string
+
+val signal_kind_to_string : signal_kind -> string
+val signal_kind_of_string : string -> (signal_kind, string) result
+
+val signals_dir : Workspace_utils.config -> string
+val signal_seen_path : Workspace_utils.config -> string
+
+val wake_signal_to_yojson : wake_signal -> Yojson.Safe.t
+val wake_signal_of_yojson : Yojson.Safe.t -> (wake_signal, string) result
+
+val read_recent_signals :
+  Workspace_utils.config -> int -> wake_signal list
+(** Read at most [n] recent durable wake signals in chronological order. *)
+
+val tick :
+  Workspace_utils.config -> now:float -> (tick_result, runner_error) result
+(** Refresh due state and append at-most-once generic wake signals for newly
+    observable due work or due approval blockers. No consumer is invoked. *)

--- a/test/dune
+++ b/test/dune
@@ -1059,6 +1059,11 @@
  (modules test_schedule_service)
  (libraries masc_test_deps masc_schedule))
 
+(test
+ (name test_schedule_runner)
+ (modules test_schedule_runner)
+ (libraries masc_test_deps masc_schedule))
+
 ; Typed TOML field resolution helper (RFC-0141 Phase 1).
 
 (test

--- a/test/test_schedule_runner.ml
+++ b/test/test_schedule_runner.ml
@@ -1,0 +1,127 @@
+open Alcotest
+open Masc
+open Schedule_domain
+open Schedule_runner
+open Schedule_service
+
+let temp_dir () =
+  let path = Filename.temp_file "schedule_runner_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path
+      end
+      else Sys.remove path
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let with_workspace f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  let config = Workspace.default_config dir in
+  ignore (Workspace.init config ~agent_name:(Some "test"));
+  f config
+;;
+
+let human ?display_name id = { id; kind = Human_operator; display_name }
+
+let payload_json text =
+  `Assoc
+    [ "kind", `String "consumer.note"
+    ; "schema_version", `Int 1
+    ; "body", `Assoc [ "text", `String text ]
+    ]
+;;
+
+let create_ok
+  ?(schedule_id = "sched-1")
+  ?(risk_class = Read_only)
+  ?approval_required
+  config
+  =
+  match
+    create config ~schedule_id ?approval_required ~requested_at:100.0
+      ~requested_by:(human "requester") ~scheduled_by:(human "scheduler")
+      ~due_at:200.0 ~payload:(payload_json "wake me") ~risk_class
+      ~source:Operator_request ()
+  with
+  | Ok request -> request
+  | Error err -> fail (service_error_to_string err)
+;;
+
+let tick_ok config ~now =
+  match tick config ~now with
+  | Ok result -> result
+  | Error err -> fail (runner_error_to_string err)
+;;
+
+let check_kind label expected actual =
+  check string label (signal_kind_to_string expected) (signal_kind_to_string actual)
+;;
+
+let test_tick_emits_due_candidate_once () =
+  with_workspace
+  @@ fun config ->
+  let request = create_ok ~schedule_id:"read-1" config in
+  let before_due = tick_ok config ~now:199.0 in
+  check int "no early signal" 0 (List.length before_due.emitted);
+  let due = tick_ok config ~now:201.0 in
+  check int "one signal" 1 (List.length due.emitted);
+  check int "one status transition" 1 due.due_changed;
+  let signal = List.hd due.emitted in
+  check_kind "kind" Due_candidate signal.kind;
+  check string "schedule id" request.schedule_id signal.schedule_id;
+  check string "payload digest"
+    (Schedule_domain.payload_digest request.payload)
+    signal.payload_digest;
+  let repeated = tick_ok config ~now:202.0 in
+  check int "dedupe repeated tick" 0 (List.length repeated.emitted);
+  check int "durable signal count" 1 (List.length (read_recent_signals config 10))
+;;
+
+let test_tick_emits_approval_blocker_then_candidate_after_grant () =
+  with_workspace
+  @@ fun config ->
+  let request =
+    create_ok ~schedule_id:"write-1" ~risk_class:Workspace_write config
+  in
+  let blocked = tick_ok config ~now:201.0 in
+  check int "blocked signal" 1 (List.length blocked.emitted);
+  let blocked_signal = List.hd blocked.emitted in
+  check_kind "blocked kind" Due_blocked_approval blocked_signal.kind;
+  check string "blocked id" request.schedule_id blocked_signal.schedule_id;
+  let blocked_again = tick_ok config ~now:202.0 in
+  check int "blocked dedupe" 0 (List.length blocked_again.emitted);
+  (match approve config ~schedule_id:request.schedule_id ~approved_by:(human "approver") () with
+   | Ok _ -> ()
+   | Error err -> fail (service_error_to_string err));
+  let due = tick_ok config ~now:203.0 in
+  check int "candidate after approval" 1 (List.length due.emitted);
+  check_kind "candidate kind" Due_candidate (List.hd due.emitted).kind;
+  check int "two durable signals" 2 (List.length (read_recent_signals config 10))
+;;
+
+let () =
+  run "Schedule_runner"
+    [ ( "tick",
+        [ test_case "emits due candidate once" `Quick
+            test_tick_emits_due_candidate_once
+        ; test_case "emits approval blocker then candidate after grant" `Quick
+            test_tick_emits_approval_blocker_then_candidate_after_grant
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- add Schedule_runner.tick to refresh due schedule state and emit durable generic wake signals
- persist signals under .masc/schedules/signals/ and dedupe with .masc/schedules/signal_keys.json
- emit schedule.due_candidate and schedule.due_blocked_approval without invoking or depending on any consumer domain
- add focused runner tests for at-most-once due signals and approval blocker to candidate flow

## Verification
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_schedule_runner.exe test/test_schedule_service.exe test/test_schedule_store.exe test/test_schedule_domain.exe
- _build/default/test/test_schedule_runner.exe
- _build/default/test/test_schedule_service.exe
- _build/default/test/test_schedule_store.exe
- _build/default/test/test_schedule_domain.exe
- ocamlformat --check lib/schedule/schedule_runner.ml lib/schedule/schedule_runner.mli test/test_schedule_runner.ml
- git diff --check
- bash scripts/ci/check-determinism-contract.sh
- bash scripts/ci/check-enum-string-safety.sh
- bash scripts/ci/check-masc-oas-boundary.sh

## Notes
- This slice emits the wake signal feed only. Periodic supervisor/server ticking and consumer interpretation stay outside the schedule layer.