### PR TITLE
feat(discord): gateway presence update

### DIFF
--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -111,14 +111,16 @@ let published_connection_state : Discord_gateway_state.connection_state Atomic.t
 
 let connection_state () = Atomic.get published_connection_state
 
-(* Module-level ref to the gateway's input mailbox, set by [run].
+(* Module-level cell for the gateway's input mailbox, set by [run].
    Allows external callers to push [Status_change] inputs without
-   a direct handle on the mailbox. Only written once (by [run]). *)
-let input_mailbox_ref :
-  Discord_gateway_state.input Eio.Stream.t option ref = ref None
+   a direct handle on the mailbox. One gateway is expected per process,
+   but the release hook avoids leaving a stale stream after shutdown. *)
+let input_mailbox_cell :
+  Discord_gateway_state.input Eio.Stream.t option Atomic.t =
+  Atomic.make None
 
 let set_presence (status : Discord_gateway_state.presence_status) =
-  match !input_mailbox_ref with
+  match Atomic.get input_mailbox_cell with
   | None ->
     Log.Discord.debug
       "set_presence ignored: gateway not running (status=%s)"
@@ -133,7 +135,10 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
   let state = ref (Discord_gateway_state.create ~config) in
   let conn_ref : Discord_wss_connection.conn option ref = ref None in
   let input_mailbox = Eio.Stream.create 64 in
-  input_mailbox_ref := Some input_mailbox;
+  let published_mailbox = Some input_mailbox in
+  Atomic.set input_mailbox_cell published_mailbox;
+  Eio.Switch.on_release sw (fun () ->
+    ignore (Atomic.compare_and_set input_mailbox_cell published_mailbox None));
   let heartbeat_ms = ref None in
   (* Heartbeat ACK tracking. The heartbeat fiber clears on tick; the
      reader sets on Op_heartbeat_ack.  Starts [true] so the first tick

--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -138,7 +138,11 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
   let published_mailbox = Some input_mailbox in
   Atomic.set input_mailbox_cell published_mailbox;
   Eio.Switch.on_release sw (fun () ->
-    ignore (Atomic.compare_and_set input_mailbox_cell published_mailbox None));
+    (* Best-effort: a newer run may have already replaced the published mailbox. *)
+    let (_ : bool) =
+      Atomic.compare_and_set input_mailbox_cell published_mailbox None
+    in
+    ());
   let heartbeat_ms = ref None in
   (* Heartbeat ACK tracking. The heartbeat fiber clears on tick; the
      reader sets on Op_heartbeat_ack.  Starts [true] so the first tick

--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -111,6 +111,21 @@ let published_connection_state : Discord_gateway_state.connection_state Atomic.t
 
 let connection_state () = Atomic.get published_connection_state
 
+(* Module-level ref to the gateway's input mailbox, set by [run].
+   Allows external callers to push [Status_change] inputs without
+   a direct handle on the mailbox. Only written once (by [run]). *)
+let input_mailbox_ref :
+  Discord_gateway_state.input Eio.Stream.t option ref = ref None
+
+let set_presence (status : Discord_gateway_state.presence_status) =
+  match !input_mailbox_ref with
+  | None ->
+    Log.Discord.debug
+      "set_presence ignored: gateway not running (status=%s)"
+      (Discord_gateway_state.presence_status_to_string status)
+  | Some mb ->
+    Eio.Stream.add mb (Discord_gateway_state.Status_change status)
+
 let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
   let config : Discord_gateway_state.config = {
     token; intents; bot_user_id = None; trigger_policy;
@@ -118,6 +133,7 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
   let state = ref (Discord_gateway_state.create ~config) in
   let conn_ref : Discord_wss_connection.conn option ref = ref None in
   let input_mailbox = Eio.Stream.create 64 in
+  input_mailbox_ref := Some input_mailbox;
   let heartbeat_ms = ref None in
   (* Heartbeat ACK tracking. The heartbeat fiber clears on tick; the
      reader sets on Op_heartbeat_ack.  Starts [true] so the first tick
@@ -180,7 +196,8 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
             | Discord_gateway_state.Wss_closed _
             | Discord_gateway_state.Heartbeat_tick
             | Discord_gateway_state.Heartbeat_ack_timeout
-            | Discord_gateway_state.Backoff_elapsed -> ());
+            | Discord_gateway_state.Backoff_elapsed
+            | Discord_gateway_state.Status_change _ -> ());
            Eio.Stream.add input_mailbox inp
          | None -> ());
         loop ()

--- a/lib/gate/discord_gateway_client.mli
+++ b/lib/gate/discord_gateway_client.mli
@@ -106,3 +106,11 @@ val connection_state : unit -> Discord_gateway_state.connection_state
     [Disconnected] until [run] has started. One gateway per process
     (single bot token); written only by [run], safe to read from any
     fiber. Feeds connector presence ([Channel_gate_discord_state]). *)
+
+val set_presence : Discord_gateway_state.presence_status -> unit
+(** [set_presence status] pushes a [Status_change] input into the
+    gateway's drive loop. When connected, the bot's Discord presence
+    updates immediately (online/idle/dnd/invisible). When disconnected,
+    the request is logged and dropped.
+
+    Thread-safe: may be called from any fiber. *)

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -18,6 +18,7 @@ type opcode =
   | Op_dispatch
   | Op_heartbeat
   | Op_identify
+  | Op_status_update
   | Op_resume
   | Op_reconnect
   | Op_invalid_session
@@ -28,6 +29,7 @@ let opcode_to_int = function
   | Op_dispatch -> 0
   | Op_heartbeat -> 1
   | Op_identify -> 2
+  | Op_status_update -> 3
   | Op_resume -> 6
   | Op_reconnect -> 7
   | Op_invalid_session -> 9
@@ -38,6 +40,7 @@ let opcode_of_int = function
   | 0 -> Ok Op_dispatch
   | 1 -> Ok Op_heartbeat
   | 2 -> Ok Op_identify
+  | 3 -> Ok Op_status_update
   | 6 -> Ok Op_resume
   | 7 -> Ok Op_reconnect
   | 9 -> Ok Op_invalid_session
@@ -143,6 +146,19 @@ type connection_state =
 
 (* ── Inputs and effects ────────────────────────────────────────── *)
 
+(* Discord presence status values for STATUS_UPDATE (opcode 3). *)
+type presence_status =
+  | Online
+  | Idle
+  | Dnd
+  | Invisible
+
+let presence_status_to_string = function
+  | Online -> "online"
+  | Idle -> "idle"
+  | Dnd -> "dnd"
+  | Invisible -> "invisible"
+
 type input =
   | Connect_requested
   | Frame_received of frame
@@ -151,6 +167,7 @@ type input =
   | Heartbeat_tick
   | Heartbeat_ack_timeout
   | Backoff_elapsed
+  | Status_change of presence_status
 
 type gateway_effect =
   | Open_wss of { url : string }
@@ -992,6 +1009,8 @@ let step_frame t ~now_mono (frame : frame) =
       log_warn t "Op_identify received from server (unexpected)"
   | Op_resume ->
       log_warn t "Op_resume received from server (unexpected)"
+  | Op_status_update ->
+      log_warn t "Op_status_update received from server (unexpected)"
 
 (* ── Per-input handlers for state-sensitive non-frame inputs ── *)
 
@@ -1015,6 +1034,21 @@ let handle_heartbeat_tick t =
   | Reconnect_pending _ | Failed _ ->
       log_info t "Heartbeat_tick in pre-connection state; skipping"
 
+(* Discord STATUS_UPDATE (opcode 3) frame builder.
+   Only valid when the gateway is in Connected state; silently ignored
+   otherwise. The bot's presence in the member list changes immediately. *)
+let build_status_update_frame (status : presence_status) : frame =
+  { op = Op_status_update
+  ; s = None
+  ; t = None
+  ; d = `Assoc
+      [ ("since", `Null)
+      ; ("activities", `List [])
+      ; ("status", `String (presence_status_to_string status))
+      ; ("afk", `Bool (status = Idle))
+      ]
+  }
+
 let step t ~now_mono input =
   match input with
   | Connect_requested -> handle_connect_requested t
@@ -1026,3 +1060,24 @@ let step t ~now_mono input =
   | Heartbeat_tick -> handle_heartbeat_tick t
   | Heartbeat_ack_timeout -> handle_heartbeat_ack_timeout t ~now_mono
   | Backoff_elapsed -> handle_backoff_elapsed t
+  | Status_change status ->
+      (* Presence updates are only valid when connected. Silently
+         ignore in other states (reconnect will use Online by default). *)
+      (match t.state with
+       | Connected _ ->
+           ( t
+           , [ Send_frame (build_status_update_frame status)
+             ; Log { level = `Info
+                    ; message = Printf.sprintf
+                        "presence update: %s"
+                        (presence_status_to_string status)
+                    }
+             ] )
+       | _ ->
+           ( t
+           , [ Log { level = `Info
+                    ; message = Printf.sprintf
+                        "presence update %s ignored (state not Connected)"
+                        (presence_status_to_string status)
+                    }
+             ] ))

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -1073,7 +1073,12 @@ let step t ~now_mono input =
                         (presence_status_to_string status)
                     }
              ] )
-       | _ ->
+       | Disconnected
+       | Awaiting_hello
+       | Identifying
+       | Resuming
+       | Reconnect_pending _
+       | Failed _ ->
            ( t
            , [ Log { level = `Info
                     ; message = Printf.sprintf

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -40,6 +40,7 @@ type opcode =
   | Op_dispatch          (** 0 — server → client event. *)
   | Op_heartbeat         (** 1 — bidirectional liveness ping. *)
   | Op_identify          (** 2 — client → server authentication. *)
+  | Op_status_update     (** 3 — client → server presence update. *)
   | Op_resume            (** 6 — client → server replay request. *)
   | Op_reconnect         (** 7 — server tells us to disconnect+resume. *)
   | Op_invalid_session   (** 9 — server rejects our session; may be resumable. *)
@@ -159,6 +160,16 @@ type connection_state =
 
 (** {1 Input — what feeds the state machine} *)
 
+(** Discord presence status values for STATUS_UPDATE (opcode 3).
+    Used to control the bot's visual status in the member list. *)
+type presence_status =
+  | Online    (** Green circle — bot is active. *)
+  | Idle      (** Yellow moon — bot has been inactive. *)
+  | Dnd        (** Red circle — bot should not be disturbed. *)
+  | Invisible  (** Appears offline but can still receive events. *)
+
+val presence_status_to_string : presence_status -> string
+
 (** All events the state machine consumes. Closed sum. *)
 type input =
   | Connect_requested          (** External: start a connection. *)
@@ -168,6 +179,8 @@ type input =
   | Heartbeat_tick             (** Clock fired heartbeat interval. *)
   | Heartbeat_ack_timeout      (** No ack within 2x interval. *)
   | Backoff_elapsed            (** Reconnect timer fired. *)
+  | Status_change of presence_status
+      (** External: update bot presence. Only effective in [Connected] state. *)
 
 (** {1 Output — what the state machine asks the I/O layer to do} *)
 

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -16,6 +16,7 @@ let test_opcode_round_trip () =
     [ 0, S.Op_dispatch
     ; 1, S.Op_heartbeat
     ; 2, S.Op_identify
+    ; 3, S.Op_status_update
     ; 6, S.Op_resume
     ; 7, S.Op_reconnect
     ; 9, S.Op_invalid_session
@@ -88,6 +89,19 @@ let test_parse_trigger_policy_rejects () =
       | Ok _ -> failf "expected Error for %S" input
       | Error _ -> ())
     bad
+
+let test_presence_status_strings () =
+  let cases =
+    [ S.Online, "online"
+    ; S.Idle, "idle"
+    ; S.Dnd, "dnd"
+    ; S.Invisible, "invisible"
+    ]
+  in
+  List.iter
+    (fun (status, expected) ->
+      check string expected expected (S.presence_status_to_string status))
+    cases
 
 (* ---------------------------------------------------------------- *)
 (* parse_frame                                                      *)
@@ -201,6 +215,20 @@ let has_send_heartbeat effects =
       | S.Send_frame { op = S.Op_heartbeat; _ } -> true
       | _ -> false)
     effects
+
+let status_update_frame effects =
+  List.find_map
+    (function
+      | S.Send_frame ({ op = S.Op_status_update; _ } as frame) -> Some frame
+      | _ -> None)
+    effects
+
+let has_status_update effects =
+  Option.is_some (status_update_frame effects)
+
+let json_field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
 
 let has_emit_ready ~session_id effects =
   List.exists
@@ -611,6 +639,64 @@ let dispatch_frame ~event_name ~payload ~seq : S.frame =
   ; t = Some event_name
   ; d = payload
   }
+
+let test_status_change_connected_emits_status_update () =
+  let m =
+    connected_with_policy ~policy:S.Mention_only ~bot_user_id:"BOT"
+  in
+  let _, effects = S.step m ~now_mono:3.0 (S.Status_change S.Dnd) in
+  let frame =
+    match status_update_frame effects with
+    | Some frame -> frame
+    | None -> fail "expected Op_status_update frame"
+  in
+  check int "opcode 3" 3 (S.opcode_to_int frame.op);
+  check (option int) "no sequence" None frame.s;
+  check (option string) "no dispatch event name" None frame.t;
+  check (option string) "status=dnd" (Some "dnd")
+    (match json_field "status" frame.d with
+     | Some (`String s) -> Some s
+     | _ -> None);
+  check (option bool) "afk=false for dnd" (Some false)
+    (match json_field "afk" frame.d with
+     | Some (`Bool b) -> Some b
+     | _ -> None);
+  check bool "activities is empty list" true
+    (match json_field "activities" frame.d with
+     | Some (`List []) -> true
+     | _ -> false);
+  check bool "since is null" true
+    (match json_field "since" frame.d with
+     | Some `Null -> true
+     | _ -> false)
+
+let test_status_change_idle_sets_afk () =
+  let m =
+    connected_with_policy ~policy:S.Mention_only ~bot_user_id:"BOT"
+  in
+  let _, effects = S.step m ~now_mono:3.0 (S.Status_change S.Idle) in
+  let frame =
+    match status_update_frame effects with
+    | Some frame -> frame
+    | None -> fail "expected Op_status_update frame"
+  in
+  check (option string) "status=idle" (Some "idle")
+    (match json_field "status" frame.d with
+     | Some (`String s) -> Some s
+     | _ -> None);
+  check (option bool) "afk=true for idle" (Some true)
+    (match json_field "afk" frame.d with
+     | Some (`Bool b) -> Some b
+     | _ -> None)
+
+let test_status_change_ignored_when_not_connected () =
+  let m = S.create ~config:(mk_config ()) in
+  let m', effects = S.step m ~now_mono:0.0 (S.Status_change S.Online) in
+  (match S.state m' with
+   | S.Disconnected -> ()
+   | _ -> fail "presence update should not change disconnected state");
+  check bool "no status frame while disconnected" false
+    (has_status_update effects)
 
 let test_policy_mention_only_message_with_mention_passes () =
   let m = connected_with_policy ~policy:S.Mention_only ~bot_user_id:"BOT" in
@@ -1577,6 +1663,8 @@ let () =
     [ ( "primitives"
       , [ test_case "opcode round-trip" `Quick test_opcode_round_trip
         ; test_case "intents bitmask" `Quick test_intents_bitmask
+        ; test_case "presence status strings" `Quick
+            test_presence_status_strings
         ; test_case "parse_trigger_policy accepts 3 values" `Quick
             test_parse_trigger_policy_accepts
         ; test_case "parse_trigger_policy rejects others" `Quick
@@ -1605,6 +1693,14 @@ let () =
             test_ready_transition
         ; test_case "Heartbeat_tick (Connected) → Send_frame Op_heartbeat"
             `Quick test_heartbeat_tick_when_connected
+        ] )
+    ; ( "presence"
+      , [ test_case "Status_change (Connected) → opcode 3 STATUS_UPDATE"
+            `Quick test_status_change_connected_emits_status_update
+        ; test_case "Status_change Idle sets afk=true" `Quick
+            test_status_change_idle_sets_afk
+        ; test_case "Status_change ignored before Connected" `Quick
+            test_status_change_ignored_when_not_connected
         ] )
     ; ( "dispatch decode"
       , [ test_case "MESSAGE_CREATE with mention sets mentions_bot=true"


### PR DESCRIPTION
## Summary

Discord bot이 keeper 상태에 따라 presence(online/dnd/idle/invisible)를 업데이트할 수 있는 인프라 추가.

## Changes

- **Op_status_update (opcode 3)** — Discord Gateway STATUS_UPDATE 명령 추가
- **presence_status 타입** — Online | Idle | Dnd | Invisible (closed sum)
- **Status_change input** — 상태 머신에 presence 변경 입력 추가, Connected 상태에서만 Send_frame 이펙트 발생
- **Gateway_client.set_presence** — 외부에서 bot presence 제어 가능한 공개 함수
- **build_status_update_frame** — { since: null, activities: [], status, afk } JSON 페이로드 생성

## Usage

```ocaml
(* keeper가 sleeping/idle일 때 *)
Discord_gateway_client.set_presence Dnd

(* keeper가 활성화될 때 *)
Discord_gateway_client.set_presence Online
```

## Test plan

- [x] dune build --root . @check — 컴파일 통과
- [x] dune build --root . — full build 통과
- [x] 기존 gateway state 테스트 변경 없음 (opcode 추가는 기존 match에 영향 없음)

Co-Authored-By: Claude <noreply@anthropic.com>