### PR TITLE
fix(keeper): reject empty provider replies before finalization

### DIFF
--- a/lib/keeper_tooling/keeper_tool_response.ml
+++ b/lib/keeper_tooling/keeper_tool_response.ml
@@ -32,8 +32,8 @@ let accept_rejection_kind_to_string = function
 ;;
 
 let response_accept_rejection (response : Agent_sdk.Types.api_response) =
-  if Agent_sdk.Response_shape.ended_without_deliverable_content response
-  then
+  let shape = Agent_sdk.Response_shape.summarize response in
+  if not (Agent_sdk.Response_shape.has_deliverable_content shape) then
     Some
       { kind = No_usable_progress
       ; reason = Agent_sdk.Response_shape.diagnostic_summary response

--- a/lib/keeper_tooling/keeper_tool_response.mli
+++ b/lib/keeper_tooling/keeper_tool_response.mli
@@ -34,7 +34,7 @@ val accept_rejection_of_response :
   runtime_id:string -> Agent_sdk.Types.api_response -> accept_rejection
 
 (** [true] when a provider response carries usable keeper progress for runtime
-    accept/reject: non-blank text, ToolUse, or a non-terminal stop reason.
-    Empty [end_turn] responses are rejected so runtime can try the next
-    candidate instead of failing later as "no textual reply". *)
+    accept/reject: non-blank text or ToolUse. Responses with no deliverable
+    content are rejected before keeper response finalization, instead of
+    failing later as "no textual reply". *)
 val response_has_text_or_tool_progress : Agent_sdk.Types.api_response -> bool

--- a/lib/keeper_tooling/keeper_tool_response.mli
+++ b/lib/keeper_tooling/keeper_tool_response.mli
@@ -33,8 +33,10 @@ val response_accept_rejection : Agent_sdk.Types.api_response -> accept_rejection
 val accept_rejection_of_response :
   runtime_id:string -> Agent_sdk.Types.api_response -> accept_rejection
 
-(** [true] when a provider response carries usable keeper progress for runtime
-    accept/reject: non-blank text or ToolUse. Responses with no deliverable
-    content are rejected before keeper response finalization, instead of
-    failing later as "no textual reply". *)
+(** [true] when a provider response carries OAS-defined downstream-visible
+    progress for runtime accept/reject. This delegates the content-shape
+    boundary to [Agent_sdk.Response_shape.has_deliverable_content]; MASC should
+    not add provider/model-specific accept rules here. Responses with no
+    deliverable content are rejected before keeper response finalization,
+    instead of failing later as "no textual reply". *)
 val response_has_text_or_tool_progress : Agent_sdk.Types.api_response -> bool

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -174,6 +174,53 @@ let test_thinking_with_tool_use_is_accepted () =
     Alcotest.failf "thinking plus tool use should pass accept: %s"
       (Agent_sdk.Error.to_string err)
 
+let check_accept_matches_oas_shape label content =
+  let response = response ~content () in
+  let expected =
+    response
+    |> Agent_sdk.Response_shape.summarize
+    |> Agent_sdk.Response_shape.has_deliverable_content
+  in
+  Alcotest.(check bool)
+    label
+    expected
+    (Keeper_tool_response.response_has_text_or_tool_progress response)
+
+let test_accept_contract_delegates_to_oas_response_shape () =
+  check_accept_matches_oas_shape "empty" [];
+  check_accept_matches_oas_shape
+    "thinking only"
+    [
+      Agent_sdk.Types.Thinking
+        { thinking_type = "reasoning"; content = "internal chain" };
+    ];
+  check_accept_matches_oas_shape "blank text" [ Agent_sdk.Types.Text " \n\t " ];
+  check_accept_matches_oas_shape "text" [ Agent_sdk.Types.Text "visible answer" ];
+  check_accept_matches_oas_shape
+    "tool use"
+    [
+      Agent_sdk.Types.ToolUse
+        { id = "tool-1"; name = "keeper_board_search"; input = `Assoc [] };
+    ];
+  check_accept_matches_oas_shape
+    "tool result"
+    [
+      Agent_sdk.Types.ToolResult
+        {
+          tool_use_id = "tool-1";
+          content = "ok";
+          is_error = false;
+          json = None;
+          content_blocks = None;
+        };
+    ];
+  check_accept_matches_oas_shape
+    "media"
+    [
+      Agent_sdk.Types.Image
+        { media_type = "image/png"; data = "redacted"; source_type = "base64" };
+    ]
+
 let test_thinking_only_non_end_turn_response_is_rejected () =
   let result =
     Masc.Keeper_turn_driver.For_testing.apply_accept
@@ -334,6 +381,8 @@ let () =
             test_thinking_with_text_is_accepted;
           Alcotest.test_case "thinking plus tool use is accepted" `Quick
             test_thinking_with_tool_use_is_accepted;
+          Alcotest.test_case "accept delegates to OAS response shape" `Quick
+            test_accept_contract_delegates_to_oas_response_shape;
           Alcotest.test_case "thinking-only non-end-turn response is rejected" `Quick
             test_thinking_only_non_end_turn_response_is_rejected;
           Alcotest.test_case "empty non-end-turn response is rejected" `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -174,6 +174,59 @@ let test_thinking_with_tool_use_is_accepted () =
     Alcotest.failf "thinking plus tool use should pass accept: %s"
       (Agent_sdk.Error.to_string err)
 
+let test_empty_non_end_turn_response_is_rejected () =
+  let result =
+    Masc.Keeper_turn_driver.For_testing.apply_accept
+      ~runtime_id:"runtime.empty-stop-sequence"
+      ~accept:Keeper_tool_response.response_has_text_or_tool_progress
+      (run_result ~stop_reason:Agent_sdk.Types.StopSequence ())
+  in
+  let err, reason_kind, reason = expect_accept_rejected result in
+  Alcotest.(check bool)
+    "reason kind is no usable progress"
+    true
+    (reason_kind = Some Keeper_internal_error.Accept_no_usable_progress);
+  Alcotest.(check bool)
+    "reason identifies empty shape"
+    true
+    (contains ~needle:"shape=empty" reason);
+  Alcotest.(check bool)
+    "reason keeps non-end stop reason"
+    true
+    (contains ~needle:"stop_reason=stop_sequence" reason);
+  Alcotest.(check bool)
+    "no-progress accept rejection is typed"
+    true
+    (Masc.Keeper_error_classify.is_accept_no_usable_progress_error err)
+
+let test_blank_text_non_end_turn_response_is_rejected () =
+  let result =
+    Masc.Keeper_turn_driver.For_testing.apply_accept
+      ~runtime_id:"runtime.blank-max-tokens"
+      ~accept:Keeper_tool_response.response_has_text_or_tool_progress
+      (run_result
+         ~content:[ Agent_sdk.Types.Text " \n\t " ]
+         ~stop_reason:Agent_sdk.Types.MaxTokens
+         ())
+  in
+  let _err, reason_kind, reason = expect_accept_rejected result in
+  Alcotest.(check bool)
+    "reason kind is no usable progress"
+    true
+    (reason_kind = Some Keeper_internal_error.Accept_no_usable_progress);
+  Alcotest.(check bool)
+    "reason identifies blank text"
+    true
+    (contains ~needle:"shape=blank_text_only" reason);
+  Alcotest.(check bool)
+    "reason reports zero trimmed text chars"
+    true
+    (contains ~needle:"text_chars=0" reason);
+  Alcotest.(check bool)
+    "reason keeps max-token stop reason"
+    true
+    (contains ~needle:"stop_reason=max_tokens" reason)
+
 let test_custom_accept_reject_preserves_predicate_reason () =
   let result =
     Masc.Keeper_turn_driver.For_testing.apply_accept
@@ -253,6 +306,10 @@ let () =
             test_thinking_with_text_is_accepted;
           Alcotest.test_case "thinking plus tool use is accepted" `Quick
             test_thinking_with_tool_use_is_accepted;
+          Alcotest.test_case "empty non-end-turn response is rejected" `Quick
+            test_empty_non_end_turn_response_is_rejected;
+          Alcotest.test_case "blank text non-end-turn response is rejected" `Quick
+            test_blank_text_non_end_turn_response_is_rejected;
           Alcotest.test_case "custom predicate rejection stays distinct" `Quick
             test_custom_accept_reject_preserves_predicate_reason;
           Alcotest.test_case "mixed non-progress rejection is diagnosed" `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -174,6 +174,34 @@ let test_thinking_with_tool_use_is_accepted () =
     Alcotest.failf "thinking plus tool use should pass accept: %s"
       (Agent_sdk.Error.to_string err)
 
+let test_thinking_only_non_end_turn_response_is_rejected () =
+  let result =
+    Masc.Keeper_turn_driver.For_testing.apply_accept
+      ~runtime_id:"runtime.thinking-stop-sequence"
+      ~accept:Keeper_tool_response.response_has_text_or_tool_progress
+      (run_result
+         ~content:
+           [
+             Agent_sdk.Types.Thinking
+               { thinking_type = "reasoning"; content = "internal chain" };
+           ]
+         ~stop_reason:Agent_sdk.Types.StopSequence
+         ())
+  in
+  let _err, reason_kind, reason = expect_accept_rejected result in
+  Alcotest.(check bool)
+    "reason kind is no usable progress"
+    true
+    (reason_kind = Some Keeper_internal_error.Accept_no_usable_progress);
+  Alcotest.(check bool)
+    "reason identifies thinking-only shape"
+    true
+    (contains ~needle:"shape=thinking_only" reason);
+  Alcotest.(check bool)
+    "reason keeps non-end stop reason"
+    true
+    (contains ~needle:"stop_reason=stop_sequence" reason)
+
 let test_empty_non_end_turn_response_is_rejected () =
   let result =
     Masc.Keeper_turn_driver.For_testing.apply_accept
@@ -306,6 +334,8 @@ let () =
             test_thinking_with_text_is_accepted;
           Alcotest.test_case "thinking plus tool use is accepted" `Quick
             test_thinking_with_tool_use_is_accepted;
+          Alcotest.test_case "thinking-only non-end-turn response is rejected" `Quick
+            test_thinking_only_non_end_turn_response_is_rejected;
           Alcotest.test_case "empty non-end-turn response is rejected" `Quick
             test_empty_non_end_turn_response_is_rejected;
           Alcotest.test_case "blank text non-end-turn response is rejected" `Quick


### PR DESCRIPTION
Summary:
- Reject provider responses with no deliverable content before keeper response finalization.
- Align the accept contract with the finalizer contract: non-blank text or ToolUse only.
- Add regression coverage for empty/blank non-EndTurn responses, which previously reached `keeper turn completed with no textual reply`.

Verification:
- `scripts/dune-local.sh build test/test_keeper_turn_driver_accept.exe`
- `./_build/default/test/test_keeper_turn_driver_accept.exe`