### PR TITLE
[codex] Remove keeper run-level tool timeouts

### DIFF
--- a/docs/rfc/RFC-0197-runtime-attempt-watchdog-per-candidate-wrap.md
+++ b/docs/rfc/RFC-0197-runtime-attempt-watchdog-per-candidate-wrap.md
@@ -1,12 +1,23 @@
 # RFC-0197: Runtime Attempt Watchdog — Per-Candidate Wrap + Shared Deadline
 
-**Status**: Draft
+**Status**: Superseded
 **Date**: 2026-05-27
+**Superseded**: 2026-06-12 — do not implement a MASC wall-clock watchdog around
+`Runtime_agent.run`, even per-candidate. Runtime candidates may execute tools,
+so any cumulative wrapper at this layer can kill active tool execution. Keeper
+liveness must be handled by narrower boundaries: admission/queue wait,
+provider connect/body/stream progress in OAS, and tool-local subprocess or MCP
+budgets owned by the tool substrate.
 **Related**: RFC-0192 (runtime deadline propagation, MERGED), RFC-0022 (runtime attempt liveness)
 **Meta-RFC**: RFC-0194 (Tool Surface Semantic SSOT) — §1 + §4 instantiation
 **Memory anchors**: `feedback-runtime-budget-no-hard-gates`, `feedback-runtime-dual-ssot-diagnosis-must-compare-both-toml`
 
 ## Context
+
+> 2026-06-12 update: this RFC is retained as historical diagnosis only. Its
+> proposed per-candidate wrapper is rejected because it still wraps an execution
+> region that may contain tools. The safe replacement is not "move the timeout";
+> it is "make liveness tool-aware before any cancellation".
 
 2026-05-27 server restart (17:08 KST, RFC-0192 PR-1/2/3 deployed) 직후 fleet observation:
 
@@ -104,11 +115,14 @@ Layer 1 (570s, whole turn) > Layer 2 (disabled in Enforce) > Layer 3 (observer, 
 - 4 tier failover chain (`strict_tool_candidates / ollama_cloud_stable / local_llama / glm-coding-with-spark`) 가 코드는 있는데 *실행 불가*.
 - 사용자 직관: "심하게 잘못된 느낌, 이런 에러를 왜 자꾸 내뿜는거지" — 정확한 진단.
 
-## Proposed (Meta-RFC §1 + §4 정합)
+## Historical Proposal (Rejected)
 
-### Design
+### Rejected Design
 
-**Layer 1 watchdog 의 wrap target 을 per-candidate (try_provider 호출) 로 이동**. budget 은 *remaining turn deadline* 으로 shared.
+The old proposal was to move **Layer 1 watchdog 의 wrap target** to
+per-candidate (`try_provider`). This is rejected: `try_provider` still calls
+`Runtime_agent.run`, and `Runtime_agent.run` may include active tool execution.
+That means the wrapper is still a tool timeout in disguise.
 
 ```
 Before (현재):
@@ -119,7 +133,7 @@ Before (현재):
                 ├── try_provider candidate_2   (unreachable if candidate_1 hangs)
                 └── ...
 
-After (RFC-0197):
+Rejected after (do not implement):
   Outer wrap (turn-level): hard ceiling (예: 30min) — 60min hard ceiling 방지
     └── run_turn
           └── runtime run loop
@@ -141,11 +155,13 @@ where remaining_turn_deadline_at_candidate_start = turn_deadline - clock.now()
 
 이는 정확히 RFC-0192 §2 의 `composed_attempt_budget = min(amplifier, deadline-now())` — *attempt* 가 candidate 별 wrap. RFC-0192 의 *semantic 회복*.
 
-### 호환성
+### Rejected Compatibility Assumptions
 
 - **Layer 2 (`outer_wall_for_attempt` Enforce → None)**: 그대로 유지. Layer 3 observer 의 책임 분리 보존 (RFC-0022 design 무변).
-- **Layer 1 (whole-turn watchdog)**: 제거하지 않고 *turn-level absolute upper bound* (예: 30min hard ceiling) 로 retain. RFC-0192 PR-4 의 후속에서 *60min hard ceiling 자체를 줄임* 가능.
-- **Runtime run loop**: 기존 `keeper_turn_driver_try_runtime.ml` 의 `run` 함수가 candidate 시도 — *그 안* 에 per-candidate watchdog wrap 추가.
+- **Layer 1 (whole-turn watchdog)**: do not retain a turn-level absolute bound
+  around active provider/tool execution.
+- **Runtime run loop**: do not add a per-candidate wrapper unless the wrapped
+  region is proven to exclude active tools.
 
 ### Non-goals (Meta-RFC §4 anti-pattern 회피)
 
@@ -154,13 +170,13 @@ where remaining_turn_deadline_at_candidate_start = turn_deadline - clock.now()
 - **새 counter 0**: 기존 `runtime-fallback` log message 활용 (이미 line 532-533 존재).
 - **N-of-M 회피**: 단일 wrap location 추가 (per-candidate), abstraction 변경 없음.
 
-## Implementation outline
+## Rejected Implementation Outline
 
 ### Phase A — RFC doc + Issue (본 PR)
 
 Doc only, code = 0.
 
-### Phase B — Per-candidate watchdog wrap (single PR)
+### Phase B — Per-candidate watchdog wrap (rejected)
 
 변경 위치:
 1. `lib/keeper/keeper_turn_driver_try_runtime.ml` — `run` 함수 의 `candidate :: rest` 분기에 `Eio.Time.with_timeout_exn` wrap 추가.
@@ -168,8 +184,23 @@ Doc only, code = 0.
 3. 새 helper `Runtime_deadline.budget_for_candidate_at` (RFC-0192 PR-1 의 `composed_attempt_budget_at` 와 동일 시그니처 — 또는 alias).
 
 변경 회피:
-- `Keeper_unified_turn_attempt_watchdog.dispatch` 시그니처 무변 (caller 만 변경, 또는 caller 그대로 두고 *내부* 추가 wrap)
-- `keeper_unified_turn_execution.ml:158-170` 의 outer wrap *유지* (turn-level absolute bound) — 추가 layer 만 도입
+- `Keeper_unified_turn_attempt_watchdog.dispatch` should remain a cancellation
+  observer only; it must not add an internal timeout wrap.
+- `keeper_unified_turn_execution.ml` must not keep a turn-level absolute bound
+  around active tool execution.
+
+## Replacement Direction
+
+1. Provider stalls: use OAS provider connect/body/stream-idle progress
+   boundaries, not a MASC wrapper around `Runtime_agent.run`.
+2. Tool execution: use tool-local subprocess/MCP budgets owned by the tool
+   substrate; MASC should observe `ToolCalled` / `ToolCompleted` and avoid
+   classifying active tool work as provider idle.
+3. Keeper liveness: keep the turn visible through FSM state, EventBus drain,
+   execution receipts, and fleet safety. If a turn appears stuck while a tool is
+   active, report it as active tool execution, not provider timeout.
+4. Future cancellation: only introduce cancellation after the execution region
+   is tool-aware and can prove no active tool call is in flight.
 
 ### Phase C — 신규 test
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -120,7 +120,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 127 |  |
 | `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 118 | Slack fanout configuration |
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
-| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 392 | Per-attempt wall-clock safety cap for the streaming watchdog. Prevents a single provider attempt from locking a keepe... |
+| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 392 | Deprecated compatibility knob. Not applied as a MASC wall-clock timeout around active provider/tool execution. |
 | `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 441 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
@@ -133,7 +133,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 161 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 169 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 175 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 422 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
+| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 422 | Parsed compatibility knob. Keeper path does not forward it until active tool execution is excluded from idle accounting. |
 | `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 481 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
 | `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 489 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
 | `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 218 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -374,12 +374,12 @@ module KeeperKeepalive = struct
     | None -> turn_timeout_sec
   ;;
 
-  (** Per-attempt wall-clock safety cap for the streaming watchdog.
+  (** Deprecated compatibility knob for the removed whole-run attempt watchdog.
 
-      Prevents a single provider attempt from locking a keeper in
-      [Streaming] state forever (network hang, silent provider crash).
-      The cap is intentionally generous — any attempt making zero
-      progress for this duration is definitively stuck.
+      The keeper runtime must not apply this as a wall-clock timeout around
+      active provider/tool execution. Real liveness policy must live at a
+      narrower boundary: admission/queue wait, provider connect/stream progress,
+      or tool-local policy owned by the tool substrate.
 
       Env: [MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC].
       Default: 1800 (30 min). Range: [300, 7200]. *)
@@ -408,6 +408,9 @@ module KeeperKeepalive = struct
       [stream_idle_timeout_sec], which watches transport line gaps; this knob
       catches Agent-level no-progress stalls that still keep a transport
       connection superficially alive.
+
+      The keeper path parses this knob but does not forward it until OAS proves
+      active tool execution is excluded from idle accounting.
 
       Env: [MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC]. Default: disabled.
       Range when enabled: [5, 600]. Unset, invalid, [0], or a negative

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -124,16 +124,17 @@ module KeeperKeepalive : sig
   (** Resolved OAS-call timeout: [oas_timeout_sec_override] when set, otherwise
       [turn_timeout_sec]. RFC-0156: no token- or turn-budget dependence. *)
   val attempt_watchdog_safety_cap_sec : float
-  (** Per-attempt wall-clock safety cap for stuck Streaming fibers.
-      Prevents a provider attempt from locking a keeper in [Streaming] state
-      forever. Env: [MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC].
-      Default: 1800 (30 min). Clamp range: [300, 7200] s. *)
+  (** Deprecated compatibility knob for the removed whole-run attempt watchdog.
+      The keeper runtime must not apply this as a wall-clock timeout around
+      active provider/tool execution. Env:
+      [MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC]. *)
   val stream_idle_timeout_sec : float
 
   val execution_idle_timeout_sec : float option
   (** OAS Agent.run inactivity deadline. [Some s] forwards to
       [Builder.with_execution_idle_timeout] through the keeper runtime
-      resolver. [None] disables that builder wire.
+      resolver only for paths that can prove active tool execution is excluded.
+      The keeper path currently parses this knob but does not forward it.
 
       Env: [MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC]. Default: disabled.
       Clamp range when enabled: [5, 600] s. Unset, invalid, [0], or a

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -510,9 +510,9 @@ let keeper_keepalive_entries =
     entry ~default:"600.0" "MASC_KEEPER_TURN_TIMEOUT_SEC"
       "Wall-clock timeout for a single unified turn (clamped 60-900 seconds)";
     entry ~default:"1800.0" "MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC"
-      "Per-attempt wall-clock safety cap for stuck Streaming fibers (clamped 300-7200 seconds)";
+      "Deprecated compatibility knob; not applied as a MASC timeout around active provider/tool execution";
     entry ~default:"(none)" "MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC"
-      "Opt-in OAS Agent.run inactivity timeout (clamped 5-600 seconds; 0/unset disables)";
+      "Parsed compatibility knob; keeper path does not forward until tool execution is excluded";
     entry ~default:"(none)" "MASC_KEEPER_WORK_AS_HEARTBEAT"
       "Successful workspace heartbeat after turn counts as presence proof (feature flag)";
   ]

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -53,8 +53,12 @@ val turn_timeout_sec : unit -> float
 val admission_wait_timeout_sec : unit -> float
 val stream_idle_timeout_sec : unit -> float
 val execution_idle_timeout_sec : unit -> float option
-(** OAS Agent.run inactivity deadline. [Some s] forwards to
-    [Builder.with_execution_idle_timeout] and resets on OAS progress.
+(** Resolved [turn.execution_idle_timeout_sec].
+
+    The keeper runtime currently parses this value but does not forward it to
+    OAS until active tool execution is proven to be excluded from idle
+    accounting.
+
     Default disabled, clamped to [5, 600] when explicitly set. Unset, invalid,
     [MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC=0], or
     [turn.execution_idle_timeout_sec = 0] disables it. *)

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -149,7 +149,7 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Oas_agent_execution_timeout ->
       if summary = ""
       then
-        "OAS Agent.run or the enclosing runtime-attempt watchdog hit its execution timeout; this is not a provider HTTP timeout."
+        "OAS Agent.run reported an execution timeout; inspect whether progress accounting excluded active tool execution."
       else summary
     | Completion_contract_violation ->
       (* TEL-OK: string literal in blocker classification summary, not an action handler *)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -144,7 +144,14 @@ let run_named
   let turn_start = Mtime_clock.now () in
   let seq_ref = ref 0 in
   let execution_idle_timeout_s =
-    Keeper_runtime_resolved.execution_idle_timeout_sec ()
+    (* Keep parsing [turn.execution_idle_timeout_sec] for compatibility, but do
+       not forward it on the keeper path until OAS proves active tool execution
+       is excluded from idle accounting. Otherwise this becomes another MASC
+       knob that can kill a healthy long-running tool call. *)
+    let (_resolved_but_not_forwarded : float option) =
+      Keeper_runtime_resolved.execution_idle_timeout_sec ()
+    in
+    None
   in
   let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx = {
     runtime_id;

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -222,8 +222,9 @@ let apply_accept ~runtime_id ~accept (run_result : Runtime_agent.run_result) =
 
     @param ctx Explicit closure context (captures from [run_named]).
     @param resume_checkpoint Checkpoint from a previous failed provider.
-    @param per_provider_timeout_s Legacy per-provider budget; not forwarded as
-    a cumulative OAS execution timeout on the keeper path.
+    @param per_provider_timeout_s Legacy per-provider budget used for manifest
+    diagnostics only. It is not applied as a cumulative timeout around
+    [Runtime_agent.run] because that run may include active tool execution.
     @param candidate The opaque runtime candidate to attempt.
     @return [(result, checkpoint_after, liveness_success_sample)] tuple. The
     sample is not recorded here; the caller records it only after the runtime
@@ -287,7 +288,12 @@ let run_try_provider
               stream_idle_timeout_for_attempt ~configured:ctx.stream_idle_timeout_s
           ; max_execution_time_s =
               max_execution_time_for_attempt ?per_provider_timeout_s ()
-          ; execution_idle_timeout_s = ctx.execution_idle_timeout_s
+          ; execution_idle_timeout_s =
+              (* Keeper/provider attempts must not forward Agent.run idle
+                 timeout until active tool execution is excluded from OAS idle
+                 accounting. *)
+              (let _ = ctx.execution_idle_timeout_s in
+               None)
           ; body_timeout_s = ctx.body_timeout_s
           ; temperature = ctx.temperature
           ; max_idle_turns = ctx.max_idle_turns
@@ -353,32 +359,14 @@ let run_try_provider
             ~agent_ref:local_agent_ref
             ctx.goal
         in
-        match per_provider_timeout_s with
-        | None -> run_fn ()
-        | Some t ->
-          let clock_opt =
-            match Masc_eio_env.get_opt () with
-            | Some env ->
-              (match env.clock with
-               | Some _ as clock_opt -> clock_opt
-               | None -> Eio_context.get_clock_opt ())
-            | None -> Eio_context.get_clock_opt ()
-          in
-          (match clock_opt with
-           | Some clock ->
-             (try Eio.Time.with_timeout_exn clock t run_fn with
-              | Eio.Time.Timeout ->
-                Log.Misc.info
-                  "[runtime-fallback] runtime %s: per-provider timeout after %.1fs"
-                  ctx.runtime_id
-                  t;
-                Error
-                  (Agent_sdk.Error.Api
-                     (Timeout
-                        { message =
-                            Printf.sprintf "Per-provider timeout after %.1fs" t
-                        })))
-           | None -> run_fn ()))
+        (* Do not wrap [Runtime_agent.run] in a MASC wall-clock timeout here.
+           OAS provider stream/body timeouts and tool-local subprocess budgets
+           are the safe liveness boundaries. A cumulative wrapper at this layer
+           cannot distinguish provider silence from active tool execution. *)
+        (match per_provider_timeout_s with
+         | Some (_ : float) -> ()
+         | None -> ());
+        run_fn ())
     in
     let result =
       (* Restore typed provider-context enrichment (auth-env / not-found hints).

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
@@ -1,26 +1,10 @@
-(* Per-attempt cancel handler for a single keeper turn runtime attempt.
+(* Per-attempt cancellation observer for a single keeper turn runtime attempt.
 
-   A wall-clock safety deadline wraps every attempt:
-     - When [attempt_watchdog_s] is [Some deadline], that deadline is used.
-     - When [attempt_watchdog_s] is [None], the env-configurable safety cap
-       [MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC] (default 1800s / 30 min)
-       prevents a stuck fiber from locking a keeper in [Streaming] state
-       forever. Any provider attempt that makes zero progress for that
-       duration is definitively stuck (network hang, silent provider failure).
-
-   The previous wall-clock watchdog was removed because it killed healthy
-   streams at 540-600s. The safety cap is 3x that, targeting only truly
-   stuck fibers while never affecting legitimate slow-but-progressing streams.
-
-   Two outcomes:
-     - normal completion: pass-through of [run]'s [result]
-     - timeout or [Eio.Cancel.Cancelled]: invoke [on_cancelled] with a
-       reason string for the terminal receipt + FSM transition, then re-raise
-       so the outer cleanup handler observes the cancellation
-
-   [on_cancelled] receives the cancellation reason:
-     - ["attempt_watchdog_safety_deadline"] — wall-clock timeout fired
-     - ["external_cancel"] — fiber was cancelled externally
+   MASC must not create a wall-clock timeout around the whole provider/tool run.
+   The only timeout-like boundaries that belong in MASC are admission, queue,
+   subprocess/tool-local policies, or provider-stream progress once that can be
+   isolated from active tool execution. This wrapper only records cancellation
+   that came from outside this boundary.
 
    The Cancelled re-raise path is the outer catch for cancellations
    that escape the in-band receipt builder in
@@ -30,26 +14,15 @@
    timeline. *)
 
 let dispatch
-    ~clock
-    ~keeper_name
-    ~attempt_watchdog_s
+    ~clock:_
+    ~keeper_name:_
+    ~attempt_watchdog_s:_
     ~on_cancelled
     ~run
   =
-  let deadline_s = match attempt_watchdog_s with
-    | Some s -> Float.max s 1.0
-    | None -> Env_config_keeper.KeeperKeepalive.attempt_watchdog_safety_cap_sec
-  in
   try
-    Eio.Time.with_timeout_exn clock deadline_s run
+    run ()
   with
-  | Eio.Time.Timeout ->
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string AttemptWatchdogFired)
-      ~labels:[ ("keeper", keeper_name) ]
-      ();
-    on_cancelled "attempt_watchdog_safety_deadline";
-    raise (Eio.Cancel.Cancelled (Failure "attempt_watchdog_safety_deadline"))
   | Eio.Cancel.Cancelled _ as e ->
     on_cancelled "external_cancel";
     raise e

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
@@ -1,35 +1,27 @@
-(** Per-attempt cancel handler for a single keeper turn runtime attempt.
+(** Per-attempt cancellation observer for a single keeper turn runtime attempt.
 
-    A wall-clock safety deadline wraps every attempt:
-      - When [attempt_watchdog_s] is [Some deadline], that deadline is used.
-      - When [attempt_watchdog_s] is [None], the env-configurable safety cap
-        {!Env_config_keeper.KeeperKeepalive.attempt_watchdog_safety_cap_sec}
-        (default 1800s / 30 min) prevents a stuck fiber from locking a
-        keeper in [Streaming] state forever. The previous watchdog was
-        removed because it killed healthy streams at 540-600s; the 1800s
-        cap is 3x that, targeting only truly stuck fibers.
+    MASC must not impose a wall-clock timeout around the whole provider/tool
+    run. Active tool execution belongs to the tool substrate / OAS boundary and
+    may legitimately outlive provider stream progress budgets.
 
     Two outcomes:
 
     - normal completion: pass-through of [run]'s [result]
-    - [Eio.Time.Timeout] (safety deadline) or [Eio.Cancel.Cancelled]:
-      invoke [on_cancelled] with a reason string for the terminal receipt
-      + FSM transition, then re-raise so the outer cleanup handler
-      observes the cancellation
+    - [Eio.Cancel.Cancelled]: invoke [on_cancelled] with a reason string for
+      the terminal receipt + FSM transition, then re-raise so the outer cleanup
+      handler observes the cancellation
 
     [on_cancelled] receives the cancellation reason:
-      - ["attempt_watchdog_safety_deadline"] — wall-clock timeout fired
       - ["external_cancel"] — fiber was cancelled externally
-
-    A safety-deadline fire also increments
-    [masc_keeper_attempt_watchdog_fired_total{keeper}] — the alertable
-    "definitively stuck attempt" signal.
 
     The Cancelled re-raise path is the outer catch for cancellations
     that escape the in-band receipt builder in
     [Keeper_agent_run.run_turn]: without [on_cancelled] the FSM emits
     Streaming and then nothing — the turn silently disappears from the
-    operator's timeline. *)
+    operator's timeline.
+
+    [clock], [keeper_name], and [attempt_watchdog_s] are retained for call-site
+    compatibility with the old watchdog API. They are intentionally ignored. *)
 val dispatch
   :  clock:_ Eio.Time.clock
   -> keeper_name:string

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -161,11 +161,10 @@ let run (ctx : ctx)
                ~keeper_turn_id
                ())
            ~run:(fun () ->
-             (* Emit INSIDE the watchdog window: the 2026-06-10 freeze showed
-                this transition's forensics append can park, and any park
-                before [dispatch] arms its [Eio.Time.with_timeout_exn] is
-                unrescuable by design — the safety cap must cover everything
-                that happens once the keeper claims to be Streaming. *)
+             (* Emit before the provider/tool run so operator forensics can see
+                that the keeper entered Streaming. [dispatch] observes external
+                cancellation only; it must not impose a MASC wall-clock timeout
+                around active tool execution. *)
              Keeper_turn_fsm.emit_transition
                ~keeper_name:meta.name
                ~turn_id:keeper_turn_id

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -304,7 +304,7 @@ let record_turn_tool_events
 
 (** Record the observation for a streaming turn that was cancelled.
     [cancel_reason] distinguishes the source:
-      - ["attempt_watchdog_safety_deadline"] — wall-clock watchdog timeout
+      - ["attempt_watchdog_safety_deadline"] — legacy watchdog timeout receipt
       - ["supervisor_stop"] — supervisor requested stop
       - ["external_cancel"] — external fiber cancellation *)
 let record_streaming_cancelled_observation
@@ -351,8 +351,9 @@ let record_streaming_cancelled_observation
   let cancelled_variant =
     match terminal_reason_code with
     | "attempt_watchdog_safety_deadline" ->
-      (* The attempt watchdog firing is an environmental terminal (the
-         provider stalled mid-stream), not a same-turn re-dispatch storm.
+      (* Legacy receipts from the removed whole-run attempt watchdog were
+         environmental terminals (provider stalled mid-stream), not same-turn
+         re-dispatch storms.
          [Keeper_turn_livelock.classify_and_decide] keys [Stuck_age_exceeded]
          off [first_started_at], i.e. the FIRST dispatch of this turn_id; a
          retry after the watchdog cancel inherits that ~watchdog-budget-old
@@ -361,11 +362,9 @@ let record_streaming_cancelled_observation
          pause on a transport stall contradicts the invariant that a keeper
          keeps acting autonomously. Reset the livelock entry so the retry is
          classified Fresh. Rapid re-dispatch storm detection is unaffected:
-         only the watchdog/provider_timeout terminal clears the counter, and
-         only for the keeper whose turn just timed out. The underlying
-         mid-stream stall (dropped OAS stream-idle deadline) is addressed
-         separately; this prevents the symptom from escalating to a
-         fleet-wide pause. *)
+         only legacy watchdog/provider_timeout receipts clear the counter, and
+         only for the affected keeper. Current runtime code must not emit this
+         reason from a MASC-created wall-clock timeout around tool execution. *)
       Keeper_turn_livelock.reset_keeper_livelock ~keeper:run_meta.name;
       Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_provider_timeout
     | _ ->

--- a/lib/keeper/keeper_unified_turn_types.mli
+++ b/lib/keeper/keeper_unified_turn_types.mli
@@ -66,7 +66,7 @@ val record_turn_tool_events :
     [Keeper_turn_helpers.record_pre_dispatch_terminal_observation].
 
     [cancel_reason] overrides the inferred reason when provided:
-      - ["attempt_watchdog_safety_deadline"] — wall-clock watchdog timeout
+      - ["attempt_watchdog_safety_deadline"] — legacy watchdog timeout receipt
       - ["supervisor_stop"] — supervisor requested stop
       - ["external_cancel"] — external fiber cancellation (default) *)
 val record_streaming_cancelled_observation :

--- a/test/test_keeper_turn_livelock_10121.ml
+++ b/test/test_keeper_turn_livelock_10121.ml
@@ -270,10 +270,10 @@ let test_guard_forward_advance_resets () =
    | L.Started L.Fresh -> ()
    | _ -> Alcotest.fail "turn 8 should reset guard state")
 
-(* F2: a provider_timeout terminal (the attempt watchdog firing mid-stream)
-   resets the livelock entry via [reset_keeper_livelock] before the same
+(* F2: a legacy provider_timeout terminal resets the livelock entry via
+   [reset_keeper_livelock] before the same
    turn_id is re-dispatched (see keeper_unified_turn_types.ml,
-   "attempt_watchdog_safety_deadline" arm). Pin the invariant that wiring
+   legacy "attempt_watchdog_safety_deadline" arm). Pin the invariant that wiring
    relies on: a re-dispatch whose age would otherwise cross
    [stuck_after_sec] is reclassified [Fresh] once the entry is reset, so a
    transport stall routes to autonomous retry instead of

--- a/test/test_keeper_unified_turn_attempt_watchdog.ml
+++ b/test/test_keeper_unified_turn_attempt_watchdog.ml
@@ -1,54 +1,37 @@
 open Alcotest
 
 module W = Masc.Keeper_unified_turn_attempt_watchdog
-module Metrics = Masc.Otel_metric_store
 
-let watchdog_metric = Keeper_metrics.(to_string AttemptWatchdogFired)
-
-let watchdog_labels keeper = [ "keeper", keeper ]
-
-let test_safety_deadline_records_terminal_reason_and_metric () =
-  let keeper = "test-attempt-watchdog-state-loss" in
+let test_no_masc_wall_clock_timeout_for_tool_like_work () =
+  let keeper = "test-attempt-watchdog-no-tool-timeout" in
   let cancel_reasons = ref [] in
-  let labels = watchdog_labels keeper in
-  let before = Metrics.metric_value_or_zero watchdog_metric ~labels () in
-  let raised =
+  let outcome =
     try
-      ignore
-        (Eio_main.run (fun env ->
-           let clock = Eio.Stdenv.clock env in
-           W.dispatch
-             ~clock
-             ~keeper_name:keeper
-             ~attempt_watchdog_s:(Some 0.01)
-             ~on_cancelled:(fun reason ->
-               cancel_reasons := reason :: !cancel_reasons)
-             ~run:(fun () ->
-               Eio.Time.sleep clock 60.0;
-               Ok ()))
-         : (unit, Agent_sdk.Error.sdk_error) result);
-      false
+      Eio_main.run (fun env ->
+        let clock = Eio.Stdenv.clock env in
+        W.dispatch
+          ~clock
+          ~keeper_name:keeper
+          ~attempt_watchdog_s:(Some 0.01)
+          ~on_cancelled:(fun reason ->
+            cancel_reasons := reason :: !cancel_reasons)
+          ~run:(fun () ->
+            Eio.Time.sleep clock 0.05;
+            Ok "tool-finished"))
     with
-    | Eio.Cancel.Cancelled (Failure msg) when String.equal msg "attempt_watchdog_safety_deadline" -> true
     | Eio.Cancel.Cancelled exn ->
       Alcotest.failf "unexpected cancellation: %s" (Printexc.to_string exn)
   in
-  check bool "watchdog raises cancelled deadline" true raised;
-  check (list string)
-    "deadline reason recorded once"
-    [ "attempt_watchdog_safety_deadline" ]
-    (List.rev !cancel_reasons);
-  check (float 0.0001)
-    "attempt watchdog metric increments"
-    (before +. 1.0)
-    (Metrics.metric_value_or_zero watchdog_metric ~labels ())
+  (match outcome with
+   | Ok value -> check string "tool-like work is allowed to finish" "tool-finished" value
+   | Error err ->
+     Alcotest.failf "unexpected error: %s" (Agent_sdk.Error.to_string err));
+  check (list string) "no cancel reason" [] !cancel_reasons
 ;;
 
-let test_external_cancel_records_external_reason_without_metric () =
+let test_external_cancel_records_external_reason () =
   let keeper = "test-attempt-watchdog-external-cancel" in
   let cancel_reasons = ref [] in
-  let labels = watchdog_labels keeper in
-  let before = Metrics.metric_value_or_zero watchdog_metric ~labels () in
   let raised =
     try
       ignore
@@ -72,11 +55,7 @@ let test_external_cancel_records_external_reason_without_metric () =
   check (list string)
     "external cancel reason recorded once"
     [ "external_cancel" ]
-    (List.rev !cancel_reasons);
-  check (float 0.0001)
-    "external cancel does not increment watchdog metric"
-    before
-    (Metrics.metric_value_or_zero watchdog_metric ~labels ())
+    (List.rev !cancel_reasons)
 ;;
 
 let test_normal_completion_does_not_record_cancel () =
@@ -101,13 +80,13 @@ let () =
   run "keeper_unified_turn_attempt_watchdog"
     [ ( "state_loss_regression"
       , [ test_case
-            "safety deadline records terminal reason and metric"
+            "does not create MASC wall-clock timeout"
             `Quick
-            test_safety_deadline_records_terminal_reason_and_metric
+            test_no_masc_wall_clock_timeout_for_tool_like_work
         ; test_case
-            "external cancel records external reason without metric"
+            "external cancel records external reason"
             `Quick
-            test_external_cancel_records_external_reason_without_metric
+            test_external_cancel_records_external_reason
         ; test_case
             "normal completion does not record cancel"
             `Quick

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -342,6 +342,20 @@ let test_keeper_oas_path_has_no_bridge_total_timeout () =
     false
     (contains_substring source "Keeper_llm_bridge.run_with_timeout_and_fallback")
 
+let test_runtime_provider_path_has_no_cumulative_run_timeout () =
+  let source = read_file "lib/keeper/keeper_turn_driver_try_provider.ml" in
+  Alcotest.(check bool)
+    "runtime provider path does not timeout Runtime_agent.run"
+    false
+    (contains_substring source "Eio.Time.with_timeout_exn clock t run_fn")
+
+let test_runtime_provider_path_does_not_forward_execution_idle_timeout () =
+  let source = read_file "lib/keeper/keeper_turn_driver_try_provider.ml" in
+  Alcotest.(check bool)
+    "runtime provider path does not forward execution idle timeout"
+    false
+    (contains_substring source "execution_idle_timeout_s = ctx.execution_idle_timeout_s")
+
 let () =
   Alcotest.run "provider_timeout_strike"
   [
@@ -394,5 +408,9 @@ let () =
           test_keeper_turn_has_no_total_wall_clock_kill;
         Alcotest.test_case "keeper OAS path has no bridge total timeout" `Quick
           test_keeper_oas_path_has_no_bridge_total_timeout;
+        Alcotest.test_case "runtime provider path has no cumulative timeout" `Quick
+          test_runtime_provider_path_has_no_cumulative_run_timeout;
+        Alcotest.test_case "runtime provider path does not forward idle timeout" `Quick
+          test_runtime_provider_path_does_not_forward_execution_idle_timeout;
       ] );
   ]


### PR DESCRIPTION
## Summary

This removes MASC-created cumulative timeout wrappers from the keeper provider/tool execution path.

- Make `Keeper_unified_turn_attempt_watchdog` a cancellation observer instead of a wall-clock watchdog around `run_turn`.
- Stop wrapping `Runtime_agent.run` with `per_provider_timeout_s` in `keeper_turn_driver_try_provider`.
- Keep parsing `turn.execution_idle_timeout_sec`, but do not forward it on the keeper path until OAS proves active tool execution is excluded from idle accounting.
- Mark RFC-0197 as superseded because per-candidate watchdog wrapping still covers a region that can execute tools.
- Add ratchets preventing cumulative run timeouts and direct execution idle timeout forwarding from returning.

## Why

The previous boundary could cancel active tool execution because it wrapped the whole provider/tool run. That is not a provider stall detector; it is a tool timeout in disguise. Keeper liveness should be handled by narrower boundaries: OAS provider connect/body/stream progress, tool-local subprocess or MCP budgets, and FSM/EventBus/receipt visibility.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_unified_turn_attempt_watchdog.exe test/test_oas_timeout_budget_strike.exe`
- `./_build/default/test/test_keeper_unified_turn_attempt_watchdog.exe`
- `./_build/default/test/test_oas_timeout_budget_strike.exe`
