### PR TITLE
Improve WebSearch readable content output

### DIFF
--- a/config/prompts/keeper.tool_hints.toml
+++ b/config/prompts/keeper.tool_hints.toml
@@ -66,7 +66,7 @@ description = "run one typed argv command; set cwd for git, never type keeper_* 
 [[hints]]
 name = "WebSearch"
 call = "`WebSearch` { query: \"current-info query\", limit: 5, includeContent: true, contentMaxChars: 4000 }"
-description = "MASC-owned tool-list alias for current public context; includeContent returns readable page_content for top results"
+description = "MASC-owned tool-list alias for current public context; includeContent returns keeper-readable content_text plus raw page_content for top results"
 
 [[hints]]
 name = "WebFetch"

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -89,7 +89,7 @@ Decide what to do based on the current world state below.
 ### Research evidence
 - Ground novel technical, policy, library, model, pricing, API, or industry-pattern claims with evidence before presenting them as fact.
 - Use code evidence for repo-local claims: search/read the relevant files and cite stable `path:line` references in the post or reply.
-- Use web evidence for external or current claims: call `WebSearch` with `includeContent: true` to get current sources plus readable `page_content`; call `WebFetch` for a selected URL when you need deeper reading or a citation-ready page. These MASC-owned names are intentionally distinct from generic snake_case web tool names and from MASC backend ids.
+- Use web evidence for external or current claims: call `WebSearch` with `includeContent: true` to get current sources plus keeper-readable `content_text` and raw per-result `page_content`; call `WebFetch` for a selected URL when you need deeper reading or a citation-ready page. These MASC-owned names are intentionally distinct from generic snake_case web tool names and from MASC backend ids.
 - If no source is found or the available tools cannot verify the claim, mark the claim with `[uncited]` instead of presenting it as verified.
 - When posting research-backed findings to the board, include a `sources` array on `keeper_board_post`/`masc_board_post` with `{url, quote}` entries. The board will persist those sources in metadata and append a Sources footer.
 
@@ -110,7 +110,7 @@ When you claim a task (`keeper_task_claim`), you MUST close it before ending the
 - Respond to board activity (`keeper_board_comment`, if available)
 - Search knowledge library (`keeper_library_search` / `keeper_library_read`, if available)
 - Run shell commands to investigate (`Execute { executable: "git", argv: ["log", "--oneline", "-10"], cwd: "repos/REPO" }`, if available)
-- Search the web (`WebSearch` with `includeContent: true`) for tech context or documentation, then fetch (`WebFetch`) selected pages when a deeper read or citation is needed
+- Search the web (`WebSearch` with `includeContent: true`) for tech context or documentation, read `content_text` first, then fetch (`WebFetch`) selected pages when a deeper read or citation is needed
 - Recall past context (`keeper_memory_search`, if available) before repeating past work
 - Search code patterns (`Grep { pattern: "regex", path: "lib", type: "ml" }`, if available)
 - Audit failed tasks (`keeper_tasks_audit`, if available) before deciding there is nothing to do

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -86,7 +86,7 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | Workflow | Primary tools |
 |----------|---------------|
 | 의견 내기 / 토론 참여 | `keeper_board_post`, `keeper_board_comment` |
-| 최신 정보 / 외부 자료 확인 | `WebSearch` with `includeContent: true` for current results plus readable `page_content`; `WebFetch` for one selected URL when deeper reading is needed |
+| 최신 정보 / 외부 자료 확인 | `WebSearch` with `includeContent: true` for current results plus keeper-readable `content_text` and raw `page_content`; `WebFetch` for one selected URL when deeper reading is needed |
 | 찬성 / 반대 신호 | `keeper_board_vote` |
 | 거버넌스 의견 제출 | retired as keeper tools; use board discussion/vote paths and governance dashboard read models |
 | 목표 / 계획 lifecycle | `masc_goal_list`, `masc_goal_upsert`, `masc_goal_transition`, `masc_goal_verify` |

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -226,7 +226,7 @@ Keeper WebSearch/WebFetch backend 메모:
 
 - `masc_web_search` / `masc_web_fetch`는 Keeper-internal backend 이름이며 MCP `tools/list` public surface에는 노출되지 않는다.
 - `web_search` / `web_fetch` are not OAS-owned capabilities; Keeper agents should call the MASC-owned public aliases shown in their tool list (`WebSearch` / `WebFetch`).
-- `WebSearch { includeContent: true }`는 검색 결과마다 best-effort `page_content`를 붙인다. `WebFetch`는 선택한 단일 URL을 더 깊게 읽을 때 쓴다.
+- `WebSearch { includeContent: true }`는 keeper가 바로 읽는 `content_text`와 결과별 raw `page_content`를 best-effort로 붙인다. `WebFetch`는 선택한 단일 URL을 더 깊게 읽을 때 쓴다.
 - `MASC_SEARXNG_URL` 설정 시 self-hosted SearXNG가 최우선 provider로 작동한다.
 - 기본 auto 모드는 공식 provider key가 있으면 `searxng`, `brave`, `tavily`, `exa`, `bing_api` 순으로 먼저 시도한다.
 - 공식 provider가 없거나 실패하면 `duckduckgo`, `bing_rss` 순으로 fallback 한다.

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -267,12 +267,12 @@ let search_web_schema =
     ; property
         "includeContent"
         "boolean"
-        "When true, best-effort fetch readable page_content for each returned result."
+        "When true, best-effort fetch raw page_content for each result and add a keeper-readable content_text summary."
     ; ( "contentMaxChars",
         `Assoc
           [ "type", `String "integer"
           ; "description",
-            `String "Maximum readable page_content characters per result."
+            `String "Maximum raw page_content characters per result."
           ; "minimum", `Int 100
           ; "maximum", `Int 20000
           ; "default", `Int 4000

--- a/lib/tool_misc_web_enrichment.ml
+++ b/lib/tool_misc_web_enrichment.ml
@@ -41,6 +41,129 @@ let append_assoc_fields fields additions =
     fields
     additions
 
+let assoc_field_string key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) ->
+      let value = String.trim value in
+      if String.equal value "" then None else Some value
+  | _ -> None
+
+let assoc_field_int key fields =
+  match List.assoc_opt key fields with
+  | Some (`Int value) -> Some value
+  | _ -> None
+
+let assoc_field_bool key fields =
+  match List.assoc_opt key fields with
+  | Some (`Bool value) -> Some value
+  | _ -> None
+
+let add_optional_line label value acc =
+  match value with
+  | Some value -> Printf.sprintf "%s: %s" label value :: acc
+  | None -> acc
+
+let add_optional_int_line label value acc =
+  match value with
+  | Some value -> Printf.sprintf "%s: %d" label value :: acc
+  | None -> acc
+
+let string_of_bool value = if value then "true" else "false"
+
+let render_content_status fields =
+  let status =
+    match assoc_field_string "page_content_status" fields with
+    | Some value -> value
+    | None -> "unknown"
+  in
+  let details =
+    []
+    |> (fun acc ->
+      match assoc_field_int "page_content_http_status" fields with
+      | Some value -> Printf.sprintf "http=%d" value :: acc
+      | None -> acc)
+    |> (fun acc ->
+      match assoc_field_int "page_content_chars" fields with
+      | Some value -> Printf.sprintf "chars=%d" value :: acc
+      | None -> acc)
+    |> (fun acc ->
+      match assoc_field_bool "page_content_truncated" fields with
+      | Some value -> Printf.sprintf "truncated=%s" (string_of_bool value) :: acc
+      | None -> acc)
+    |> List.rev
+  in
+  let detail_text =
+    match details with
+    | [] -> ""
+    | _ -> " (" ^ String.concat ", " details ^ ")"
+  in
+  let error_text =
+    match assoc_field_string "page_content_error" fields with
+    | Some value -> " - " ^ value
+    | None -> ""
+  in
+  Printf.sprintf "Content status: %s%s%s" status detail_text error_text
+
+let render_hit_content_text hit =
+  match hit with
+  | `Assoc fields ->
+      let title =
+        match assoc_field_string "title" fields with
+        | Some value -> value
+        | None -> "Untitled result"
+      in
+      let heading =
+        match assoc_field_int "rank" fields with
+        | Some rank -> Printf.sprintf "%d. %s" rank title
+        | None -> title
+      in
+      let content =
+        match assoc_field_string "page_content" fields with
+        | Some value -> value
+        | None -> "(no page content available)"
+      in
+      let metadata =
+        []
+        |> add_optional_line "URL" (assoc_field_string "url" fields)
+        |> add_optional_line "Snippet" (assoc_field_string "snippet" fields)
+        |> add_optional_line "Provider" (assoc_field_string "source" fields)
+        |> add_optional_line "Fetched URL" (assoc_field_string "page_content_final_url" fields)
+        |> add_optional_line "Fetched title" (assoc_field_string "page_content_title" fields)
+        |> List.rev
+      in
+      let lines =
+        heading :: (metadata @ [ render_content_status fields; "Content:"; content ])
+      in
+      String.concat "\n" lines
+  | _ -> "Unreadable search result payload."
+
+let render_content_text ~content_max_chars ~content_timeout ~content_ok_count
+  ~content_error_count result_fields hits =
+  let metadata =
+    []
+    |> add_optional_line "Query" (assoc_field_string "query" result_fields)
+    |> add_optional_line "Engine" (assoc_field_string "engine" result_fields)
+    |> add_optional_line "Search URL" (assoc_field_string "search_url" result_fields)
+    |> add_optional_int_line "Results" (assoc_field_int "result_count" result_fields)
+    |> List.rev
+  in
+  let header =
+    ("WebSearch readable results" :: metadata)
+    @ [ Printf.sprintf
+          "Content fetch: best_effort, ok=%d, unavailable=%d, max_chars=%d, timeout=%ds"
+          content_ok_count
+          content_error_count
+          content_max_chars
+          content_timeout
+      ]
+  in
+  let body =
+    match hits with
+    | [] -> "No results."
+    | _ -> hits |> List.map render_hit_content_text |> String.concat "\n\n---\n\n"
+  in
+  String.concat "\n" header ^ "\n\n" ^ body
+
 let failed_page_content_note ~url message =
   let message = String.trim message in
   let message = if String.equal message "" then "unknown error" else message in
@@ -171,6 +294,15 @@ let enrich_web_search_payload ~tool_name ~start_time ~content_max_chars
                     ; "content_timeout", `Int content_timeout
                     ; "content_result_count", `Int content_ok_count
                     ; "content_error_count", `Int content_error_count
+                    ; ( "content_text",
+                        `String
+                          (render_content_text
+                             ~content_max_chars
+                             ~content_timeout
+                             ~content_ok_count
+                             ~content_error_count
+                             result_fields
+                             enriched_hits) )
                     ]
                 in
                 Tool_result.make_ok

--- a/lib/tool_misc_web_search.mli
+++ b/lib/tool_misc_web_search.mli
@@ -144,9 +144,10 @@ val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_resul
     Required: [query] (string).  Optional: [limit] (int,
     clamped to [\[1, 10\]], default 5).
     The misc facade also accepts [includeContent=true] to best-effort enrich
-    each result with readable [page_content] via [WebFetch], plus optional
-    [contentMaxChars] and [contentTimeout] controls. This module remains the
-    search-provider boundary to avoid depending on fetch.
+    each result with raw [page_content] via [WebFetch] and add a top-level
+    keeper-readable [content_text] rendering, plus optional [contentMaxChars]
+    and [contentTimeout] controls. This module remains the search-provider
+    boundary to avoid depending on fetch.
 
     On success the payload [data] is wrapped as
     [`Assoc [ "text", `String json ]] where [json] is the

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -440,6 +440,14 @@ let () = test "dispatch_web_search_include_content_enriches_results" (fun () ->
               let hits = result_json |> member "results" |> to_list in
               assert (List.length hits = 1);
               let hit = List.hd hits in
+              let content_text = result_json |> member "content_text" |> to_string in
+              assert (str_contains content_text "WebSearch readable results");
+              assert (str_contains content_text ("Query: " ^ query));
+              assert (str_contains content_text "1. Result");
+              assert (str_contains content_text ("URL: " ^ url));
+              assert (str_contains content_text "Snippet: Snippet");
+              assert (str_contains content_text "Content status: ok (http=200");
+              assert (str_contains content_text "Readable page content & proof.");
               assert (hit |> member "page_content_status" |> to_string = "ok");
               assert (hit |> member "page_content_http_status" |> to_int = 200);
               assert (hit |> member "page_content_truncated" |> to_bool = false);
@@ -485,6 +493,13 @@ let () = test "dispatch_web_search_include_content_keeps_result_on_fetch_error" 
               let hit =
                 result_json |> member "results" |> to_list |> List.hd
               in
+              let content_text = result_json |> member "content_text" |> to_string in
+              assert (str_contains content_text "WebSearch readable results");
+              assert (str_contains content_text ("Query: " ^ query));
+              assert (str_contains content_text ("URL: " ^ url));
+              assert (str_contains content_text "Content status: error");
+              assert (str_contains content_text "_Failed to retrieve page content:");
+              assert (str_contains content_text ("Source: " ^ url));
               assert (hit |> member "page_content_status" |> to_string = "error");
               assert
                 (str_contains


### PR DESCRIPTION
## Summary
- add top-level `result.content_text` for `WebSearch { includeContent: true }`
- render query, engine, result count, source URL, snippet, fetch status, and fetched content as keeper-readable text
- keep existing machine-readable fields and raw per-result `page_content` intact
- update keeper prompts, descriptors, and docs to tell agents to read `content_text` first

## Local checks
- `git diff --check`
- `env DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_tool_misc_coverage.exe`
- `./_build/default/test/test_tool_misc_coverage.exe`

## Related
- Follow-up to #20999 after WebSearch/WebFetch ownership and enrichment landed.
