### PR TITLE
fix(keeper): count live keeper fibers in world observation

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -324,7 +324,7 @@ let observation_summary = function
   | None -> "obs=none"
   | Some obs ->
       Printf.sprintf
-        "obs=ratio=%.2f agents=%d unclaimed=%d single_task=%b ctx=%dk local=%b"
+        "obs=ratio=%.2f keepers=%d unclaimed=%d single_task=%b ctx=%dk local=%b"
         obs.context_ratio obs.active_agent_count obs.unclaimed_task_count
         obs.is_single_focused_task (obs.context_window / 1000) obs.is_local_model
 

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -316,7 +316,7 @@ let world_observation_to_prompt_section (obs : world_observation) : string =
     "World state:\n\
     \  - Unclaimed tasks: %d\n\
     \  - Failed tasks: %d\n\
-    \  - Active agents: %d\n\
+    \  - Running keeper fibers: %d\n\
     \  - Agent count changed: %b\n\
     \  - Active goals: %d\n\
     \  - Idle seconds: %d (gate: %d)\n\

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -701,7 +701,9 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
       Buffer.add_string ubuf
         (Printf.sprintf "- Failed tasks: %d\n" observation.failed_task_count);
     Buffer.add_string ubuf
-      (Printf.sprintf "- Active agents: %d\n" observation.active_agent_count);
+      (Printf.sprintf
+         "- Running keeper fibers: %d\n"
+         observation.active_agent_count);
     Buffer.add_char ubuf '\n');
   (* 4. Context health — stable resource framing *)
   Buffer.add_string ubuf

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -75,7 +75,7 @@ type world_observation = {
       so newly added work is not delayed behind the previous turn's timer. *)
 
   active_agent_count : int;
-  (** Number of agents currently active in the workspace. *)
+  (** Number of live keeper fibers for this workspace base path. *)
 
   connected_surfaces : Gate_surface.surface_presence list;
   (** Connector surfaces attached to this keeper (RFC-0223 P2).

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -100,9 +100,13 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
     0, 0, 0, 0, false
 ;;
 
-(** Count active agents in workspace. *)
+(** Count live keeper fibers for keeper world state.
+
+    Keepers do not write the legacy [.masc/agents/] registry.  That registry may
+    be empty while keepers are running normally, so keeper observations must use
+    the live keeper registry instead. *)
 let count_active_agents ~(config : Workspace.config) : int =
-  try List.length (Workspace.get_agents_raw config) with
+  try Keeper_registry.count_running ~base_path:config.base_path () with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | ex ->
     Otel_metric_store.inc_counter

--- a/lib/keeper/keeper_world_observation_inputs.mli
+++ b/lib/keeper/keeper_world_observation_inputs.mli
@@ -15,5 +15,9 @@ val read_backlog_counts
   -> int * int * int * int * bool
 
 val count_active_agents : config:Workspace.config -> int
+(** Count live keeper fibers for [config.base_path].
+
+    This intentionally does not read the legacy [.masc/agents/] registry; that
+    registry may be empty while keeper fibers are healthy and running. *)
 val compute_idle_seconds : meta:keeper_meta -> int
 val read_context_ratio : config:Workspace.config -> meta:keeper_meta -> float

--- a/test/test_keeper_reactive_wake_backlog_gate.ml
+++ b/test/test_keeper_reactive_wake_backlog_gate.ml
@@ -149,6 +149,29 @@ let test_gate_keeps_scheduled_channel () =
      | WO.Scheduled_autonomous -> true
      | WO.Reactive -> false)
 
+let test_live_keeper_count_ignores_empty_agent_registry () =
+  let base_path = Filename.temp_file "keeper-live-count-" "" in
+  Sys.remove base_path;
+  Unix.mkdir base_path 0o755;
+  let masc_dir = Filename.concat base_path ".masc" in
+  let agents_dir = Filename.concat masc_dir "agents" in
+  Unix.mkdir masc_dir 0o755;
+  Unix.mkdir agents_dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      Unix.rmdir agents_dir;
+      Unix.rmdir masc_dir;
+      Unix.rmdir base_path)
+    (fun () ->
+      Masc.Keeper_registry.clear ();
+      let config = Masc.Workspace.default_config base_path in
+      let meta = make_meta "live-count" in
+      ignore
+        (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+      check int "counts running keepers, not .masc/agents" 1
+        (Masc.Keeper_world_observation_inputs.count_active_agents ~config))
+
 let () = init_runtime_default_for_tests ()
 
 let () =
@@ -167,6 +190,10 @@ let () =
             "gate keeps scheduled-autonomous channel"
             `Quick
             test_gate_keeps_scheduled_channel
+        ; test_case
+            "live keeper count ignores empty agent registry"
+            `Quick
+            test_live_keeper_count_ignores_empty_agent_registry
         ] )
     ]
 ;;

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -172,6 +172,17 @@ let test_empty_presence_has_no_section () =
   check bool "no section when empty" false
     (contains ~needle:"### Connected Surfaces" user)
 
+let test_namespace_state_names_running_keeper_fibers () =
+  let user =
+    user_message { base_observation with active_agent_count = 2 }
+  in
+  check bool "namespace state present" true
+    (contains ~needle:"### Namespace State" user);
+  check bool "running keeper label present" true
+    (contains ~needle:"- Running keeper fibers: 2" user);
+  check bool "legacy active agents label absent" false
+    (contains ~needle:"- Active agents:" user)
+
 let () =
   init_runtime_default_for_tests ();
   run "keeper_surface_presence_prompt"
@@ -188,5 +199,7 @@ let () =
             test_dashboard_only_keeper_has_no_section;
           test_case "empty presence has no section" `Quick
             test_empty_presence_has_no_section;
+          test_case "namespace state names running keeper fibers" `Quick
+            test_namespace_state_names_running_keeper_fibers;
         ] );
     ]


### PR DESCRIPTION
## Summary
- stop deriving keeper world-observation active count from the legacy `.masc/agents/` registry
- count live keeper fibers via `Keeper_registry.count_running ~base_path` instead
- rename model-visible labels from `Active agents` / `agents=` to `Running keeper fibers` / `keepers=` so the prompt no longer implies the dead registry is authoritative
- add regression coverage for an empty `.masc/agents` directory while a keeper is registered live

## Evidence
- live `/health?full=1` showed `keeper_fibers=7` and `healthy_running_keeper_fiber_count=7`
- live `/Users/dancer/me/.masc/agents` was empty, matching the false `agents=0` symptom
- code comments already note keepers do not publish `.masc/agents/` records, so world observation should use the live keeper registry

## Validation
- ocamlformat --check lib/context_compact_oas.ml lib/keeper/keeper_world_observation_inputs.ml lib/keeper/keeper_world_observation_inputs.mli lib/keeper/keeper_world_observation.mli lib/keeper/keeper_unified_prompt.ml lib/keeper/keeper_deliberation.ml test/test_keeper_reactive_wake_backlog_gate.ml test/test_keeper_surface_presence_prompt.ml
- git diff --check origin/main
- local build/test intentionally not run per operator request