### PR TITLE
feat(dashboard): add thinking state indicator to keeper chat streaming

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -102,6 +102,33 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('[data-chat-delivery="live"]')).not.toBeNull()
   })
 
+  it('renders a thinking placeholder when the model is reasoning', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({ id: 'u1', text: 'ping' }),
+          entry({
+            id: 'a1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: '',
+            delivery: 'streaming',
+            streamState: 'thinking',
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const placeholder = container.querySelector('[data-chat-stream-placeholder]')
+    expect(placeholder).not.toBeNull()
+    expect(placeholder?.textContent).toContain('생각 중...')
+    expect(container.querySelector('[data-chat-delivery="thinking"]')).not.toBeNull()
+  })
+
   it('uses a parent-bounded flexible transcript in primary mode', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -26,6 +26,7 @@ function deliveryLabel(entry: KeeperConversationEntry): string {
     case 'sending':
       return 'sending'
     case 'streaming':
+      if (entry.streamState === 'thinking') return 'thinking'
       return entry.streamState === 'finalizing' ? 'finalizing' : 'live'
     case 'timeout':
       return 'timeout'
@@ -43,6 +44,7 @@ function deliveryLabel(entry: KeeperConversationEntry): string {
 function liveMessageLabel(entry: KeeperConversationEntry): string | null {
   if (entry.text.trim()) return null
   if (entry.delivery === 'streaming') {
+    if (entry.streamState === 'thinking') return '생각 중...'
     return entry.streamState === 'finalizing' ? '응답 마무리 중...' : '응답 작성 중...'
   }
   if (entry.delivery === 'sending') return '응답 연결 중...'

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -151,6 +151,19 @@ describe('applyKeeperStreamEvent', () => {
       value: { message: 'boom' },
     })).toBe('boom')
   })
+
+  it('sets thinking state on KEEPER_THINKING_DELTA', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { delta: 'reasoning about the problem...' },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.streamState).toBe('thinking')
+    expect(entry?.delivery).toBe('streaming')
+  })
 })
 
 describe('applyKeeperStreamEvent tool calls', () => {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -112,6 +112,10 @@ export function applyKeeperStreamEvent(
       return null
     }
     case 'CUSTOM':
+      if (event.name === 'KEEPER_THINKING_DELTA') {
+        setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
+        return null
+      }
       if (event.name === 'KEEPER_QUEUE_REQUEST') {
         setAssistantStreamState(keeperName, assistantEntryId, 'opening', 'queued')
         return null

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -738,6 +738,7 @@ export interface KeeperConversationAttachment {
 
 export type KeeperConversationStreamState =
   | 'opening'
+  | 'thinking'
   | 'streaming'
   | 'finalizing'
   | null


### PR DESCRIPTION
## Problem

Keeper chat SSE 스트리밍에서 모델이 thinking 토큰을 생성할 때 백엔드는 `KEEPER_THINKING_DELTA` Custom 이벤트를 정상적으로 발행하지만, 프론트엔드가 이 이벤트를 무시합니다.

Z.AI GLM 모델 사용 시 ~2초의 TTFB 동안 thinking 토큰이 스트림되는데, UI는 "응답 작성 중..." 정지 상태로 보여 사용자가 keeper가 실제 작동 중인지 혼란스러운 상태였습니다.

## Streaming Path

```
Z.AI GLM → OAS Agent SDK (ThinkingDelta)
  → backend (KEEPER_THINKING_DELTA Custom SSE)
    → frontend: WAS SILENTLY DROPPED ❌ → NOW HANDLED ✅
```

## Changes (5 files, +47 lines)

| File | Change |
|------|--------|
| `types/core.ts` | `'thinking'`을 `KeeperConversationStreamState` 유니온에 추가 |
| `keeper-stream.ts` | `KEEPER_THINKING_DELTA` Custom 이벤트 핸들러 추가 |
| `primitives.ts` | thinking 상태에서 "생각 중..." 플레이스홀더 + `thinking` 배지 렌더링 |
| `keeper-stream.test.ts` | KEEPER_THINKING_DELTA 이벤트 핸들링 테스트 |
| `primitives.test.ts` | thinking 플레이스홀더 렌더링 테스트 |

## Testing

- `keeper-stream.test.ts`: 12/12 passed ✅
- `tsc --noEmit`: 0 errors ✅
- `primitives.test.ts`: pre-existing jsdom env 실패 (main과 동일)

## UI Effect

Before: thinking 단계에서 "응답 작성 중..." 정지 상태 (pulse dots만)
After: thinking 단계에서 "생각 중..." 표시 + thinking 배지 + pulse dots

Co-Authored-By: Claude <noreply@anthropic.com>
