### PR TITLE
fix(keeper): purge legacy agent count naming

### DIFF
--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -14,7 +14,7 @@ type deliberation_trigger =
   | DirectMention
   | NewUnclaimedTask
   | FailedTask
-  | AgentSessionBoundOrLeft
+  | KeeperFiberStartedOrStopped
   | GoalDeadline
   | BoardActivity of string
   | IdleTimeout
@@ -26,7 +26,7 @@ let deliberation_trigger_to_string = function
   | DirectMention -> "direct_mention"
   | NewUnclaimedTask -> "new_unclaimed_task"
   | FailedTask -> "failed_task"
-  | AgentSessionBoundOrLeft -> "agent_session_bound_or_left"
+  | KeeperFiberStartedOrStopped -> "keeper_fiber_started_or_stopped"
   | GoalDeadline -> "goal_deadline"
   | BoardActivity detail -> "board_activity:" ^ detail
   | IdleTimeout -> "idle_timeout"
@@ -129,8 +129,8 @@ type world_observation = {
   message_content: string;
   unclaimed_task_count: int;
   failed_task_count: int;
-  active_agent_count: int;
-  agent_count_changed: bool;
+  running_keeper_fiber_count: int;
+  keeper_fiber_count_changed: bool;
   active_goal_count: int;
   idle_seconds: int;
   idle_gate: int;
@@ -146,8 +146,8 @@ let empty_world_observation ~keeper_name =
     message_content = "";
     unclaimed_task_count = 0;
     failed_task_count = 0;
-    active_agent_count = 0;
-    agent_count_changed = false;
+    running_keeper_fiber_count = 0;
+    keeper_fiber_count_changed = false;
     active_goal_count = 0;
     idle_seconds = 0;
     idle_gate = 300;
@@ -164,8 +164,8 @@ let world_observation_to_json (obs : world_observation) : Yojson.Safe.t =
       ("message_content_len", `Int (String.length obs.message_content));
       ("unclaimed_task_count", `Int obs.unclaimed_task_count);
       ("failed_task_count", `Int obs.failed_task_count);
-      ("active_agent_count", `Int obs.active_agent_count);
-      ("agent_count_changed", `Bool obs.agent_count_changed);
+      ("running_keeper_fiber_count", `Int obs.running_keeper_fiber_count);
+      ("keeper_fiber_count_changed", `Bool obs.keeper_fiber_count_changed);
       ("active_goal_count", `Int obs.active_goal_count);
       ("idle_seconds", `Int obs.idle_seconds);
       ("idle_gate", `Int obs.idle_gate);
@@ -203,7 +203,7 @@ let triage (obs : world_observation) : triage_result =
   if obs.direct_mention then add DirectMention;
   if obs.unclaimed_task_count > 0 then add NewUnclaimedTask;
   if obs.failed_task_count > 0 then add FailedTask;
-  if obs.agent_count_changed then add AgentSessionBoundOrLeft;
+  if obs.keeper_fiber_count_changed then add KeeperFiberStartedOrStopped;
 
   (* L2 Proactive triggers — goal-directed *)
   if obs.board_mention_count > 0 then
@@ -317,7 +317,7 @@ let world_observation_to_prompt_section (obs : world_observation) : string =
     \  - Unclaimed tasks: %d\n\
     \  - Failed tasks: %d\n\
     \  - Running keeper fibers: %d\n\
-    \  - Agent count changed: %b\n\
+    \  - Keeper fiber count changed: %b\n\
     \  - Active goals: %d\n\
     \  - Idle seconds: %d (gate: %d)\n\
     \  - Board new posts: %d\n\
@@ -326,8 +326,8 @@ let world_observation_to_prompt_section (obs : world_observation) : string =
     \  - Has question: %b"
     obs.unclaimed_task_count
     obs.failed_task_count
-    obs.active_agent_count
-    obs.agent_count_changed
+    obs.running_keeper_fiber_count
+    obs.keeper_fiber_count_changed
     obs.active_goal_count
     obs.idle_seconds obs.idle_gate
     obs.board_new_post_count
@@ -414,7 +414,7 @@ let has_operational_signal (obs : world_observation) =
   has_workspace_signal obs
   || obs.failed_task_count > 0
   || obs.unclaimed_task_count > 0
-  || obs.agent_count_changed
+  || obs.keeper_fiber_count_changed
   || has_board_signal obs
 
 (** Self-directed context: keeper is idle with no goals.

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -9,7 +9,7 @@ type deliberation_trigger =
   | DirectMention
   | NewUnclaimedTask
   | FailedTask
-  | AgentSessionBoundOrLeft
+  | KeeperFiberStartedOrStopped
   | GoalDeadline
   | BoardActivity of string
   | IdleTimeout
@@ -57,8 +57,8 @@ type world_observation = {
   message_content: string;
   unclaimed_task_count: int;
   failed_task_count: int;
-  active_agent_count: int;
-  agent_count_changed: bool;
+  running_keeper_fiber_count: int;
+  keeper_fiber_count_changed: bool;
   active_goal_count: int;
   idle_seconds: int;
   idle_gate: int;

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -186,7 +186,7 @@ let append_decision_record
                       - observation.claimable_task_count)) );
               ("failed_task_count", `Int observation.failed_task_count);
               ("pending_verification_count", `Int observation.pending_verification_count);
-              ("active_agent_count", `Int observation.active_agent_count);
+              ("running_keeper_fiber_count", `Int observation.running_keeper_fiber_count);
             ] );
         ("claim_absolute_available", `Bool (observation.unclaimed_task_count > 0));
         ("claim_matched_available", `Bool (observation.claimable_task_count > 0));

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -666,7 +666,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     || observation.claimable_task_count > 0
     || observation.provider_capacity_blocked_task_count > 0
     || observation.failed_task_count > 0
-    || observation.active_agent_count > 0
+    || observation.running_keeper_fiber_count > 0
   then (
     Buffer.add_string ubuf "### Namespace State\n";
     if observation.unclaimed_task_count > 0 then
@@ -703,7 +703,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     Buffer.add_string ubuf
       (Printf.sprintf
          "- Running keeper fibers: %d\n"
-         observation.active_agent_count);
+         observation.running_keeper_fiber_count);
     Buffer.add_char ubuf '\n');
   (* 4. Context health — stable resource framing *)
   Buffer.add_string ubuf

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -40,7 +40,7 @@ type world_observation =
   ; failed_task_count : int
   ; pending_verification_count : int
   ; backlog_updated_since_last_scheduled_autonomous : bool
-  ; active_agent_count : int
+  ; running_keeper_fiber_count : int
   ; connected_surfaces : Gate_surface.surface_presence list
   }
 
@@ -120,7 +120,7 @@ let self_ids = Message_scope.self_ids
 let is_self_author = Message_scope.is_self_author
 let collect_message_scope = Message_scope.collect_message_scope
 let read_backlog_counts = Inputs.read_backlog_counts
-let count_active_agents = Inputs.count_active_agents
+let count_running_keeper_fibers = Inputs.count_running_keeper_fibers
 let compute_idle_seconds = Inputs.compute_idle_seconds
 let read_context_ratio = Inputs.read_context_ratio
 let board_signal_match = Board_signal.match_signal
@@ -438,7 +438,7 @@ let observe
   let provider_capacity_blocked_task_count =
     provider_capacity_blocked_task_count ~meta ~claimable_task_count ()
   in
-  let active_agent_count = count_active_agents ~config in
+  let running_keeper_fiber_count = count_running_keeper_fibers ~config in
   let idle_seconds = compute_idle_seconds ~meta in
   let context_ratio = read_context_ratio ~config ~meta in
   let continuity_summary = read_continuity_summary ~config ~meta in
@@ -464,7 +464,7 @@ let observe
   ; failed_task_count
   ; pending_verification_count
   ; backlog_updated_since_last_scheduled_autonomous
-  ; active_agent_count
+  ; running_keeper_fiber_count
   ; connected_surfaces =
       Gate_surface.connected_surfaces_for_keeper ~keeper_name:meta.name
   }
@@ -497,7 +497,7 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   ; failed_task_count
   ; pending_verification_count
   ; backlog_updated_since_last_scheduled_autonomous
-  ; active_agent_count = count_active_agents ~config
+  ; running_keeper_fiber_count = count_running_keeper_fibers ~config
   ; connected_surfaces =
       Gate_surface.connected_surfaces_for_keeper ~keeper_name:meta.name
   }

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -74,7 +74,7 @@ type world_observation = {
       autonomous attempt. Lets task-triggered wakeups bypass cooldown once
       so newly added work is not delayed behind the previous turn's timer. *)
 
-  active_agent_count : int;
+  running_keeper_fiber_count : int;
   (** Number of live keeper fibers for this workspace base path. *)
 
   connected_surfaces : Gate_surface.surface_presence list;

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -105,16 +105,20 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
     Keepers do not write the legacy [.masc/agents/] registry.  That registry may
     be empty while keepers are running normally, so keeper observations must use
     the live keeper registry instead. *)
-let count_active_agents ~(config : Workspace.config) : int =
+let count_running_keeper_fibers ~(config : Workspace.config) : int =
   try Keeper_registry.count_running ~base_path:config.base_path () with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | ex ->
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string ObservationQueryFailures)
       ~labels:
-        [ ("operation", Runtime_observation_query_operation.(to_label Count_active_agents)) ]
+        [
+          ( "operation",
+            Runtime_observation_query_operation.(
+              to_label Count_running_keeper_fibers) );
+        ]
       ();
-    Log.Keeper.warn "count_active_agents failed: %s" (Printexc.to_string ex);
+    Log.Keeper.warn "count_running_keeper_fibers failed: %s" (Printexc.to_string ex);
     0
 ;;
 

--- a/lib/keeper/keeper_world_observation_inputs.mli
+++ b/lib/keeper/keeper_world_observation_inputs.mli
@@ -14,7 +14,7 @@ val read_backlog_counts
   -> meta:keeper_meta
   -> int * int * int * int * bool
 
-val count_active_agents : config:Workspace.config -> int
+val count_running_keeper_fibers : config:Workspace.config -> int
 (** Count live keeper fibers for [config.base_path].
 
     This intentionally does not read the legacy [.masc/agents/] registry; that

--- a/lib/runtime_observation_query_operation.ml
+++ b/lib/runtime_observation_query_operation.ml
@@ -1,6 +1,6 @@
 type t =
   | Read_backlog_counts
-  | Count_active_agents
+  | Count_running_keeper_fibers
   | Cursor_stale
   | Board_events
   | Empty_run_reasons
@@ -8,7 +8,7 @@ type t =
 
 let to_label = function
   | Read_backlog_counts -> "read_backlog_counts"
-  | Count_active_agents -> "count_active_agents"
+  | Count_running_keeper_fibers -> "count_running_keeper_fibers"
   | Cursor_stale -> "cursor_stale"
   | Board_events -> "board_events"
   | Empty_run_reasons -> "empty_run_reasons"

--- a/lib/runtime_observation_query_operation.mli
+++ b/lib/runtime_observation_query_operation.mli
@@ -7,7 +7,7 @@
 
 type t =
   | Read_backlog_counts
-  | Count_active_agents
+  | Count_running_keeper_fibers
   | Cursor_stale
   | Board_events
   | Empty_run_reasons

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -82,7 +82,7 @@ let base_observation : WO.world_observation =
   ; failed_task_count = 0
   ; pending_verification_count = 0
   ; backlog_updated_since_last_scheduled_autonomous = false
-  ; active_agent_count = 0
+  ; running_keeper_fiber_count = 0
   ; connected_surfaces = []
   }
 

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -65,13 +65,13 @@ let test_triage_failed_task () =
       check bool "contains FailedTask" true
         (List.mem D.FailedTask triggers)
 
-let test_triage_agent_change () =
-  let obs = { base_obs with agent_count_changed = true } in
+let test_triage_keeper_fiber_count_change () =
+  let obs = { base_obs with keeper_fiber_count_changed = true } in
   match D.triage obs with
-  | D.Skip _ -> fail "expected Triggered for agent change"
+  | D.Skip _ -> fail "expected Triggered for keeper fiber count change"
   | D.Triggered triggers ->
-      check bool "contains AgentSessionBoundOrLeft" true
-        (List.mem D.AgentSessionBoundOrLeft triggers)
+      check bool "contains KeeperFiberStartedOrStopped" true
+        (List.mem D.KeeperFiberStartedOrStopped triggers)
 
 let test_triage_board_mention () =
   let obs = { base_obs with board_mention_count = 2 } in
@@ -994,8 +994,8 @@ let () =
             test_triage_unclaimed_task;
           test_case "failed task triggers" `Quick
             test_triage_failed_task;
-          test_case "agent change triggers" `Quick
-            test_triage_agent_change;
+          test_case "keeper fiber count change triggers" `Quick
+            test_triage_keeper_fiber_count_change;
           test_case "board mention triggers" `Quick
             test_triage_board_mention;
           test_case "idle with goals triggers" `Quick

--- a/test/test_keeper_reactive_wake_backlog_gate.ml
+++ b/test/test_keeper_reactive_wake_backlog_gate.ml
@@ -110,7 +110,7 @@ let global_backlog_obs : WO.world_observation =
   ; failed_task_count = 0
   ; pending_verification_count = 0
   ; backlog_updated_since_last_scheduled_autonomous = true
-  ; active_agent_count = 1
+  ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   }
 
@@ -170,7 +170,7 @@ let test_live_keeper_count_ignores_empty_agent_registry () =
       ignore
         (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
       check int "counts running keepers, not .masc/agents" 1
-        (Masc.Keeper_world_observation_inputs.count_active_agents ~config))
+        (Masc.Keeper_world_observation_inputs.count_running_keeper_fibers ~config))
 
 let () = init_runtime_default_for_tests ()
 

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -24,7 +24,7 @@ let base_observation : WO.world_observation =
     failed_task_count = 0;
     pending_verification_count = 0;
     backlog_updated_since_last_scheduled_autonomous = false;
-    active_agent_count = 0;
+    running_keeper_fiber_count = 0;
     connected_surfaces = [];
   }
 
@@ -174,7 +174,7 @@ let test_empty_presence_has_no_section () =
 
 let test_namespace_state_names_running_keeper_fibers () =
   let user =
-    user_message { base_observation with active_agent_count = 2 }
+    user_message { base_observation with running_keeper_fiber_count = 2 }
   in
   check bool "namespace state present" true
     (contains ~needle:"### Namespace State" user);

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -18,7 +18,7 @@ let base_observation : WO.world_observation =
     failed_task_count = 0;
     pending_verification_count = 0;
     backlog_updated_since_last_scheduled_autonomous = false;
-    active_agent_count = 0;
+    running_keeper_fiber_count = 0;
     connected_surfaces = [];
   }
 


### PR DESCRIPTION
## Summary
- Rename keeper world-observation count fields from legacy active-agent wording to running keeper fiber wording.
- Rename the related reactive trigger and runtime observation operation away from `AgentSessionBoundOrLeft` / `count_active_agents`.
- Keep the #21031 live `Keeper_registry.count_running` path, so empty `.masc/agents` no longer produces a false `agents=0` observation.

## Validation
- `ocamlformat --check` on touched OCaml files
- `git diff --check origin/main`
- `rg` for removed legacy keeper-observation symbols returned no matches
- Not run: local build/tests, per operator request