### PR TITLE
[codex] Guard ElevenLabs voice IDs

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -97,12 +97,12 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 213 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 527 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 562 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 563 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 564 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 565 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 568 |  |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 530 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 565 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 566 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 567 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 568 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 571 |  |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 108 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 105 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 111 |  |
@@ -120,8 +120,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 127 |  |
 | `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 118 | Slack fanout configuration |
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
-| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 392 | Deprecated compatibility knob. Not applied as a MASC wall-clock timeout around active provider/tool execution. |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 441 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 392 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 444 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -129,18 +129,18 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 461 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 464 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 161 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 169 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 175 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 422 | Parsed compatibility knob. Keeper path does not forward it until active tool execution is excluded from idle accounting. |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 481 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 489 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 425 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 484 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 492 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
 | `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 218 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
 | `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 285 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 471 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. With tool_ch... |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 474 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. With tool_ch... |
 | `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 259 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 516 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 519 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
 | `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 266 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
 | `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 300 | Max idle turns for scheduled autonomous keeper turns. With tool_choice=Any and max_turns=50, keepers have workspace t... |
 | `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 307 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
@@ -148,19 +148,19 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
 | `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 353 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 499 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 502 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
 | `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 196 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
 | `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 205 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 630 | Comma-separated provider kind allowlist for every keeper runtime call. Values are OAS [Provider_config.string_of_prov... |
+| `MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 633 | Comma-separated provider kind allowlist for every keeper runtime call. Values are OAS [Provider_config.string_of_prov... |
 | `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 277 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
 | `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 243 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 179 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 505 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 508 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
 | `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 401 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
 | `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 339 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
 | `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 227 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 586 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
-| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 600 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 589 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 603 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 

--- a/lib/voice_bridge_core/voice_bridge_core.ml
+++ b/lib/voice_bridge_core/voice_bridge_core.ml
@@ -443,10 +443,10 @@ let get_voice_for_agent agent_id =
     TTS Adapters
     ============================================ *)
 
-(* elevenlabs_voice_ids removed: dead code. Voice name → ID resolution
-   is config-driven via Voice_config.load () → agent_voices. The
-   ElevenLabs API accepts voice names directly, making a hardcoded
-   lookup table unnecessary. *)
+(* ElevenLabs direct TTS URLs require voice IDs. Voice_config.load ()
+   supplies configured per-agent values; Voice_runtime_overlay keeps a small
+   premade-name compatibility map and rejects arbitrary names before the
+   network call. *)
 
 let trim_opt = Env_config_core.trim_opt
 

--- a/lib/voice_runtime_overlay/voice_runtime_overlay.ml
+++ b/lib/voice_runtime_overlay/voice_runtime_overlay.ml
@@ -274,14 +274,6 @@ let endpoint_base_url (endpoint : Voice_config.endpoint) =
   | _ -> Option.map normalize_base_url endpoint.base_url
 ;;
 
-let elevenlabs_premade_voice_ids =
-  [ "Sarah", "EXAVITQu4vr4xnSDxMaL"
-  ; "Roger", "CwhRBWXzGAHq8TQ4Fs17"
-  ; "George", "JBFqnCBsd6RMkjVDRZzb"
-  ; "Laura", "FGY2WhTYpPnrIDTdsKH5"
-  ]
-;;
-
 let is_elevenlabs_voice_id value =
   let len = String.length value in
   len >= 20
@@ -295,18 +287,20 @@ let is_elevenlabs_voice_id value =
 
 let elevenlabs_voice_id_result voice =
   match String.trim voice with
-  | "" -> Ok "21m00Tcm4TlvDq8ikWAM"
+  | "" ->
+    Error
+      "ElevenLabs direct TTS requires a configured voice_id; set tts.default_voice \
+       or an agent-specific voice in voice config."
   | value ->
-    (match List.assoc_opt value elevenlabs_premade_voice_ids with
-     | Some voice_id -> Ok voice_id
-     | None when is_elevenlabs_voice_id value -> Ok value
-     | None ->
-       Error
-         (Printf.sprintf
-            "ElevenLabs direct TTS requires a voice_id or known premade alias \
-             (got %S). Add shared/library voices to the account first, then \
-             store the resulting voice_id in voice config."
-            value))
+    if is_elevenlabs_voice_id value
+    then Ok value
+    else
+      Error
+        (Printf.sprintf
+           "ElevenLabs direct TTS requires a configured voice_id (got %S). Add \
+            shared/library voices to the account first, then store the resulting \
+            voice_id in voice config."
+           value)
 ;;
 
 let http_request_for_tts

--- a/lib/voice_runtime_overlay/voice_runtime_overlay.ml
+++ b/lib/voice_runtime_overlay/voice_runtime_overlay.ml
@@ -274,14 +274,39 @@ let endpoint_base_url (endpoint : Voice_config.endpoint) =
   | _ -> Option.map normalize_base_url endpoint.base_url
 ;;
 
-let elevenlabs_voice_id voice =
+let elevenlabs_premade_voice_ids =
+  [ "Sarah", "EXAVITQu4vr4xnSDxMaL"
+  ; "Roger", "CwhRBWXzGAHq8TQ4Fs17"
+  ; "George", "JBFqnCBsd6RMkjVDRZzb"
+  ; "Laura", "FGY2WhTYpPnrIDTdsKH5"
+  ]
+;;
+
+let is_elevenlabs_voice_id value =
+  let len = String.length value in
+  len >= 20
+  && len <= 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'A' .. 'Z' | 'a' .. 'z' -> true
+         | _ -> false)
+       value
+;;
+
+let elevenlabs_voice_id_result voice =
   match String.trim voice with
-  | "Sarah" -> "EXAVITQu4vr4xnSDxMaL"
-  | "Roger" -> "CwhRBWXzGAHq8TQ4Fs17"
-  | "George" -> "JBFqnCBsd6RMkjVDRZzb"
-  | "Laura" -> "FGY2WhTYpPnrIDTdsKH5"
-  | "" -> "21m00Tcm4TlvDq8ikWAM"
-  | value -> value
+  | "" -> Ok "21m00Tcm4TlvDq8ikWAM"
+  | value ->
+    (match List.assoc_opt value elevenlabs_premade_voice_ids with
+     | Some voice_id -> Ok voice_id
+     | None when is_elevenlabs_voice_id value -> Ok value
+     | None ->
+       Error
+         (Printf.sprintf
+            "ElevenLabs direct TTS requires a voice_id or known premade alias \
+             (got %S). Add shared/library voices to the account first, then \
+             store the resulting voice_id in voice config."
+            value))
 ;;
 
 let http_request_for_tts
@@ -340,11 +365,14 @@ let http_request_for_tts
               ] )
         ]
     in
-    Ok
-      { url = Printf.sprintf "%s/text-to-speech/%s" base_url (elevenlabs_voice_id voice)
-      ; headers
-      ; body_json
-      }
+    (match elevenlabs_voice_id_result voice with
+     | Error err -> Error err
+     | Ok voice_id ->
+       Ok
+         { url = Printf.sprintf "%s/text-to-speech/%s" base_url voice_id
+         ; headers
+         ; body_json
+         })
 ;;
 
 let stt_request_for_endpoint (endpoint : Voice_config.endpoint) ~api_key ~audio_file ~model =

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -110,6 +110,81 @@ let test_voice_mcp_env_no_longer_overrides_default_session_url () =
               (Voice.default_session_url ~path:"/mcp"))))))
 ;;
 
+let elevenlabs_tts_endpoint : Voice_config.endpoint =
+  { id = "test-tts"
+  ; kind = Voice_config.Elevenlabs_direct
+  ; base_url = Some "https://api.elevenlabs.io/v1"
+  ; mcp_url = None
+  ; health_url = None
+  ; api_key_env = Some "ELEVENLABS_API_KEY"
+  ; enabled = true
+  ; timeout_seconds = Some 30.0
+  ; max_retries = Some 2
+  }
+;;
+
+let default_voice_tuning : Voice_config.voice_tuning =
+  { stability = 0.55; similarity_boost = 0.75; style = 0.0 }
+;;
+
+let test_tts_request_elevenlabs_accepts_voice_id () =
+  match
+    Voice.http_request_for_tts
+      elevenlabs_tts_endpoint
+      ~api_key:"test-key-123"
+      ~message:"hello"
+      ~voice:"CwhRBWXzGAHq8TQ4Fs17"
+      ~model:"eleven_multilingual_v2"
+      ~tuning:default_voice_tuning
+  with
+  | Ok req ->
+    check
+      string
+      "url uses configured voice_id"
+      "https://api.elevenlabs.io/v1/text-to-speech/CwhRBWXzGAHq8TQ4Fs17"
+      req.url
+  | Error err -> fail (Printf.sprintf "expected Ok, got Error: %s" err)
+;;
+
+let test_tts_request_elevenlabs_maps_premade_alias () =
+  match
+    Voice.http_request_for_tts
+      elevenlabs_tts_endpoint
+      ~api_key:"test-key-123"
+      ~message:"hello"
+      ~voice:"Roger"
+      ~model:"eleven_multilingual_v2"
+      ~tuning:default_voice_tuning
+  with
+  | Ok req ->
+    check
+      string
+      "url maps Roger alias"
+      "https://api.elevenlabs.io/v1/text-to-speech/CwhRBWXzGAHq8TQ4Fs17"
+      req.url
+  | Error err -> fail (Printf.sprintf "expected Ok, got Error: %s" err)
+;;
+
+let test_tts_request_elevenlabs_rejects_unknown_name () =
+  match
+    Voice.http_request_for_tts
+      elevenlabs_tts_endpoint
+      ~api_key:"test-key-123"
+      ~message:"hello"
+      ~voice:"Charlotte"
+      ~model:"eleven_multilingual_v2"
+      ~tuning:default_voice_tuning
+  with
+  | Ok _ -> fail "expected Error for unknown ElevenLabs voice name"
+  | Error err ->
+    check
+      bool
+      "error explains voice_id requirement"
+      true
+      (String_util.contains_substring err "voice_id"
+       && String_util.contains_substring err "Charlotte")
+;;
+
 let test_stt_request_elevenlabs_direct () =
   let endpoint : Voice_config.endpoint =
     { id = "test-stt"
@@ -513,6 +588,20 @@ let () =
             test_stt_request_elevenlabs_direct
         ; test_case "stt request provider_d compat" `Quick test_stt_request_openai_compat
         ; test_case "stt request mcp rejected" `Quick test_stt_request_mcp_rejected
+        ] )
+    ; ( "tts"
+      , [ test_case
+            "tts request elevenlabs accepts voice_id"
+            `Quick
+            test_tts_request_elevenlabs_accepts_voice_id
+        ; test_case
+            "tts request elevenlabs maps premade alias"
+            `Quick
+            test_tts_request_elevenlabs_maps_premade_alias
+        ; test_case
+            "tts request elevenlabs rejects unknown name"
+            `Quick
+            test_tts_request_elevenlabs_rejects_unknown_name
         ] )
     ; ( "keeper_voice_speak"
       , [ test_case

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -127,13 +127,15 @@ let default_voice_tuning : Voice_config.voice_tuning =
   { stability = 0.55; similarity_boost = 0.75; style = 0.0 }
 ;;
 
+let test_elevenlabs_voice_id = "testvoiceid0123456789"
+
 let test_tts_request_elevenlabs_accepts_voice_id () =
   match
     Voice.http_request_for_tts
       elevenlabs_tts_endpoint
       ~api_key:"test-key-123"
       ~message:"hello"
-      ~voice:"CwhRBWXzGAHq8TQ4Fs17"
+      ~voice:test_elevenlabs_voice_id
       ~model:"eleven_multilingual_v2"
       ~tuning:default_voice_tuning
   with
@@ -141,28 +143,28 @@ let test_tts_request_elevenlabs_accepts_voice_id () =
     check
       string
       "url uses configured voice_id"
-      "https://api.elevenlabs.io/v1/text-to-speech/CwhRBWXzGAHq8TQ4Fs17"
+      ("https://api.elevenlabs.io/v1/text-to-speech/" ^ test_elevenlabs_voice_id)
       req.url
   | Error err -> fail (Printf.sprintf "expected Ok, got Error: %s" err)
 ;;
 
-let test_tts_request_elevenlabs_maps_premade_alias () =
+let test_tts_request_elevenlabs_rejects_blank_voice () =
   match
     Voice.http_request_for_tts
       elevenlabs_tts_endpoint
       ~api_key:"test-key-123"
       ~message:"hello"
-      ~voice:"Roger"
+      ~voice:""
       ~model:"eleven_multilingual_v2"
       ~tuning:default_voice_tuning
   with
-  | Ok req ->
+  | Ok _ -> fail "expected Error for blank ElevenLabs voice"
+  | Error err ->
     check
-      string
-      "url maps Roger alias"
-      "https://api.elevenlabs.io/v1/text-to-speech/CwhRBWXzGAHq8TQ4Fs17"
-      req.url
-  | Error err -> fail (Printf.sprintf "expected Ok, got Error: %s" err)
+      bool
+      "error explains configured voice_id requirement"
+      true
+      (String_util.contains_substring err "configured voice_id")
 ;;
 
 let test_tts_request_elevenlabs_rejects_unknown_name () =
@@ -595,9 +597,9 @@ let () =
             `Quick
             test_tts_request_elevenlabs_accepts_voice_id
         ; test_case
-            "tts request elevenlabs maps premade alias"
+            "tts request elevenlabs rejects blank voice"
             `Quick
-            test_tts_request_elevenlabs_maps_premade_alias
+            test_tts_request_elevenlabs_rejects_blank_voice
         ; test_case
             "tts request elevenlabs rejects unknown name"
             `Quick


### PR DESCRIPTION
## What changed

- Reject arbitrary voice names for ElevenLabs direct TTS before building the HTTP request URL.
- Remove the code-level ElevenLabs premade voice fallback table; production code no longer carries specific voice IDs.
- Require ElevenLabs direct TTS voices to come from runtime voice config as stable `voice_id` values.
- Correct the stale comment that claimed ElevenLabs direct accepts voice names.
- Add TTS request tests covering configured voice IDs, blank voice rejection, and unknown-name rejection.
- Refresh the generated runtime tunables catalog required by CI.

## Why

The live voice incident showed `Charlotte` had been removed from the ElevenLabs account. Because the direct TTS path put unknown voice strings directly in `/text-to-speech/{voice}`, a deleted or non-ID voice name failed only after the network call with `voice_not_found`.

This makes the config failure explicit locally and keeps the runtime config as the SSOT for voice selection, instead of preserving account-specific voice IDs in source code.

## Validation

- `scripts/dune-local.sh build test/test_voice_runtime_overlay.exe`
- `./_build/default/test/test_voice_runtime_overlay.exe`
- `opam exec -- ocamlformat --check lib/voice_runtime_overlay/voice_runtime_overlay.ml test/test_voice_runtime_overlay.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md`
- `git diff --check`
