### PR TITLE
feat(dashboard): add streaming cursor to keeper chat

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -129,6 +129,54 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('[data-chat-delivery="thinking"]')).not.toBeNull()
   })
 
+  it('shows a streaming cursor while content is streaming', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({ id: 'u1', text: 'ping' }),
+          entry({
+            id: 'a1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: '안녕하세요',
+            delivery: 'streaming',
+            streamState: 'streaming',
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    expect(container.textContent).toContain('안녕하세요')
+    const cursor = container.querySelector('.animate-pulse')
+    expect(cursor).not.toBeNull()
+  })
+
+  it('hides the streaming cursor when delivery is not streaming', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'a1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: '완료된 응답',
+            delivery: 'delivered',
+          }),
+        ]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+
+    const cursor = container.querySelector('.animate-pulse')
+    expect(cursor).toBeNull()
+  })
+
   it('uses a parent-bounded flexible transcript in primary mode', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -350,6 +350,9 @@ function ChatMessageBubble({
                 )
               }}
             />
+            ${entry.delivery === 'streaming'
+              ? html`<span class="inline-block ml-0.5 animate-pulse text-[var(--color-status-info)]" aria-hidden="true">▍</span>`
+              : null}
           `}
       ${isCollapsible
         ? html`


### PR DESCRIPTION
## Problem

텍스트가 스트리밍 중일 때 시각적 피드백이 없습니다. 

`LiveMessagePlaceholder`("생각 중...", "응답 작성 중...")는 `entry.text.trim()`이 비어있을 때만 표시됩니다. 텍스트가 한 번이라도 나타나면 placeholder가 사라지고, 이후 스트림이 잠시 멈추거나 다음 청크를 기다리는 동안 아무 인디케이터가 없어 사용자가 "멈춘 것인가?"라고 혼란합니다.

## Fix

스트리밍 중인 assistant 메시지의 텍스트 끝에 **pulsing block cursor** (`▍`) 추가.

- `delivery === 'streaming'`일 때만 표시
- 스트림 종료(`delivered`/`history`/`error`) 시 자동 사라짐
- 기존 `animate-pulse` Tailwind 클래스 재사용
- `text-[var(--color-status-info)]`로 accent 색상 사용

## Files

| File | Change |
|------|--------|
| `primitives.ts` | streaming 중 markdown 뒤에 pulse cursor 추가 |
| `primitives.test.ts` | cursor 표시/숨김 테스트 2건 추가 |

## Testing

- `tsc --noEmit`: 0 errors ✅

Co-Authored-By: Claude <noreply@anthropic.com>
