### PR TITLE
feat(discord): keeper presence bridge

### DIFF
--- a/lib/server/discord_presence_bridge.ml
+++ b/lib/server/discord_presence_bridge.ml
@@ -1,7 +1,7 @@
-(** Discord_presence_bridge — syncs keeper liveness to Discord bot presence.
+(** Discord_presence_bridge — syncs live keeper liveness to Discord bot presence.
 
-    Periodically checks whether keepers with Discord channel bindings
-    are running and updates the Discord gateway bot presence:
+    Periodically checks whether keepers with Discord channel bindings are
+    running and updates the Discord gateway bot presence:
 
     - At least one active bound keeper → Online (green circle)
     - No active bound keepers → Idle (yellow moon)
@@ -17,37 +17,64 @@ let poll_interval_s = 30.0
 
 (* ── Presence logic ──────────────────────────────────────────────── *)
 
-let keeper_has_active_binding ~base_path keeper_name =
-  Channel_gate_discord_state.bound_channels ~keeper_name <> []
-  && Keeper_registry.is_running ~base_path keeper_name
+type keeper_presence =
+  { keeper_name : string
+  ; running : bool
+  ; bound_channels : string list
+  }
+
+let keeper_has_active_binding keeper =
+  keeper.running && keeper.bound_channels <> []
+;;
+
+let presence_status_for_keepers ~gateway_connected keepers =
+  if not gateway_connected
+  then None
+  else if List.exists keeper_has_active_binding keepers
+  then Some Discord_gateway_state.Online
+  else Some Discord_gateway_state.Idle
+;;
+
+let keeper_presence_of_registry_entry ~base_path (entry : Keeper_registry.registry_entry)
+  =
+  { keeper_name = entry.name
+  ; running = Keeper_registry.is_running ~base_path entry.name
+  ; bound_channels =
+      Channel_gate_discord_state.bound_channels ~keeper_name:entry.name
+  }
+;;
+
+let live_keeper_presence ~base_path =
+  Keeper_registry.all ~base_path ()
+  |> List.map (keeper_presence_of_registry_entry ~base_path)
+;;
 
 let update_presence ~workspace_config =
-  if not (Channel_gate_discord_state.connected ()) then ()
-  else
-    let base_path = workspace_config.Workspace.base_path in
-    let all_keepers = Keeper_meta_store.keeper_names workspace_config in
-    let any_active_bound =
-      List.exists (keeper_has_active_binding ~base_path) all_keepers
-    in
-    let status =
-      if any_active_bound then Discord_gateway_state.Online
-      else Discord_gateway_state.Idle
-    in
-    Discord_gateway_client.set_presence status
+  let base_path = workspace_config.Workspace.base_path in
+  match
+    presence_status_for_keepers
+      ~gateway_connected:(Channel_gate_discord_state.connected ())
+      (live_keeper_presence ~base_path)
+  with
+  | None -> ()
+  | Some status -> Discord_gateway_client.set_presence status
+;;
 
 (* ── Fiber entry ────────────────────────────────────────────────── *)
 
-let start ~sw ~clock ~workspace_config () =
+let start ~sw:_ ~clock ~workspace_config () =
   let rec loop () =
-    (try update_presence ~workspace_config with exn ->
+    (try update_presence ~workspace_config with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
        Log.Discord.warn
          "discord_presence_bridge: update failed: %s"
          (Printexc.to_string exn));
     Eio.Time.sleep clock poll_interval_s;
     loop ()
   in
-  Eio.Fiber.fork ~sw (fun () ->
-    Log.Discord.info
-      "discord_presence_bridge: starting (poll interval %.0fs)"
-      poll_interval_s;
-    loop ())
+  Log.Discord.info
+    "discord_presence_bridge: starting (poll interval %.0fs)"
+    poll_interval_s;
+  loop ()
+;;

--- a/lib/server/discord_presence_bridge.ml
+++ b/lib/server/discord_presence_bridge.ml
@@ -1,0 +1,53 @@
+(** Discord_presence_bridge — syncs keeper liveness to Discord bot presence.
+
+    Periodically checks whether keepers with Discord channel bindings
+    are running and updates the Discord gateway bot presence:
+
+    - At least one active bound keeper → Online (green circle)
+    - No active bound keepers → Idle (yellow moon)
+    - Gateway disconnected → no-op
+
+    Polled every 30 s via a long-lived fiber forked at server startup
+    alongside the other subsystems in {!Server_bootstrap_loops}. *)
+
+(* Minimum seconds between presence checks. Keeper liveness is
+   in-memory state (Keeper_registry), so disk churn is not a concern.
+   30 s balances responsiveness with overhead. *)
+let poll_interval_s = 30.0
+
+(* ── Presence logic ──────────────────────────────────────────────── *)
+
+let keeper_has_active_binding ~base_path keeper_name =
+  Channel_gate_discord_state.bound_channels ~keeper_name <> []
+  && Keeper_registry.is_running ~base_path keeper_name
+
+let update_presence ~workspace_config =
+  if not (Channel_gate_discord_state.connected ()) then ()
+  else
+    let base_path = workspace_config.Workspace.base_path in
+    let all_keepers = Keeper_meta_store.keeper_names workspace_config in
+    let any_active_bound =
+      List.exists (keeper_has_active_binding ~base_path) all_keepers
+    in
+    let status =
+      if any_active_bound then Discord_gateway_state.Online
+      else Discord_gateway_state.Idle
+    in
+    Discord_gateway_client.set_presence status
+
+(* ── Fiber entry ────────────────────────────────────────────────── *)
+
+let start ~sw ~clock ~workspace_config () =
+  let rec loop () =
+    (try update_presence ~workspace_config with exn ->
+       Log.Discord.warn
+         "discord_presence_bridge: update failed: %s"
+         (Printexc.to_string exn));
+    Eio.Time.sleep clock poll_interval_s;
+    loop ()
+  in
+  Eio.Fiber.fork ~sw (fun () ->
+    Log.Discord.info
+      "discord_presence_bridge: starting (poll interval %.0fs)"
+      poll_interval_s;
+    loop ())

--- a/lib/server/discord_presence_bridge.mli
+++ b/lib/server/discord_presence_bridge.mli
@@ -1,0 +1,16 @@
+(** Discord_presence_bridge — syncs keeper liveness to Discord bot presence.
+
+    A long-lived fiber that polls keeper activation status every 30 s
+    and calls {!Discord_gateway_client.set_presence} so Discord users
+    see whether a bound keeper is available (Online) or paused (Idle). *)
+
+val start :
+  sw:Eio.Switch.t ->
+  clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  workspace_config:Workspace.config ->
+  unit ->
+  unit
+(** [start ~sw ~clock ~workspace_config ()] forks a fiber that
+    periodically updates the Discord bot presence.  Safe to call
+    regardless of whether the Discord gateway is running — checks
+    {!Channel_gate_discord_state.connected} before each update. *)

--- a/lib/server/discord_presence_bridge.mli
+++ b/lib/server/discord_presence_bridge.mli
@@ -1,8 +1,26 @@
-(** Discord_presence_bridge — syncs keeper liveness to Discord bot presence.
+(** Discord_presence_bridge — syncs live keeper liveness to Discord bot presence.
 
-    A long-lived fiber that polls keeper activation status every 30 s
-    and calls {!Discord_gateway_client.set_presence} so Discord users
-    see whether a bound keeper is available (Online) or paused (Idle). *)
+    Polls keeper activation status every 30 s and calls
+    {!Discord_gateway_client.set_presence} so Discord users see whether a
+    bound keeper is available (Online) or paused (Idle). *)
+
+type keeper_presence =
+  { keeper_name : string
+  ; running : bool
+  ; bound_channels : string list
+  }
+(** Runtime liveness and Discord binding snapshot for one keeper. *)
+
+val presence_status_for_keepers :
+  gateway_connected:bool ->
+  keeper_presence list ->
+  Discord_gateway_state.presence_status option
+(** [presence_status_for_keepers ~gateway_connected keepers] returns the
+    Discord presence to publish.
+
+    Returns [None] when the gateway is disconnected, [Some Online] when at
+    least one running keeper has a Discord channel binding, and [Some Idle]
+    otherwise. *)
 
 val start :
   sw:Eio.Switch.t ->
@@ -10,7 +28,8 @@ val start :
   workspace_config:Workspace.config ->
   unit ->
   unit
-(** [start ~sw ~clock ~workspace_config ()] forks a fiber that
-    periodically updates the Discord bot presence.  Safe to call
-    regardless of whether the Discord gateway is running — checks
-    {!Channel_gate_discord_state.connected} before each update. *)
+(** [start ~sw ~clock ~workspace_config ()] runs the polling loop until
+    cancelled. It is intended to be called from a managed subsystem fiber.
+
+    Safe to call regardless of whether the Discord gateway is running; the
+    loop checks {!Channel_gate_discord_state.connected} before each update. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -999,6 +999,10 @@ let start_keeper_loops
            Log.Keeper.warn
              "keeper_chat_consumer: failed to start: %s"
              (Printexc.to_string exn)));
+  (* Discord presence bridge — syncs keeper liveness to bot status. *)
+  fork_subsystem "discord_presence" (fun () ->
+    Discord_presence_bridge.start
+      ~sw ~clock ~workspace_config:state.workspace_config ());
   (* Phase 5: unified startup subsystem summary *)
   Log.Startup.info "subsystems: keeper loops started"
 ;;

--- a/test/dune
+++ b/test/dune
@@ -1303,6 +1303,8 @@
 
 (include stanzas/test_discord_gateway_state.inc)
 
+(include stanzas/test_discord_presence_bridge.inc)
+
 (include stanzas/test_discord_observability.inc)
 
 (include stanzas/test_discord_rest_client.inc)

--- a/test/stanzas/test_discord_presence_bridge.inc
+++ b/test/stanzas/test_discord_presence_bridge.inc
@@ -1,0 +1,5 @@
+; Discord presence bridge pure decision contract.
+(test
+ (name test_discord_presence_bridge)
+ (modules test_discord_presence_bridge)
+ (libraries alcotest masc.server masc.gate))

--- a/test/test_discord_presence_bridge.ml
+++ b/test/test_discord_presence_bridge.ml
@@ -1,0 +1,69 @@
+open Alcotest
+
+module Bridge = Discord_presence_bridge
+module Gateway = Discord_gateway_state
+
+let keeper ?(running = false) ?(bound_channels = []) keeper_name =
+  Bridge.{ keeper_name; running; bound_channels }
+;;
+
+let status_name = function
+  | None -> "none"
+  | Some status -> Gateway.presence_status_to_string status
+;;
+
+let check_status label expected actual =
+  check string label (status_name expected) (status_name actual)
+;;
+
+let test_disconnected_gateway_is_noop () =
+  let keepers = [ keeper ~running:true ~bound_channels:[ "C123" ] "verifier" ] in
+  check_status
+    "disconnected gateway"
+    None
+    (Bridge.presence_status_for_keepers ~gateway_connected:false keepers)
+;;
+
+let test_running_bound_keeper_sets_online () =
+  let keepers =
+    [ keeper ~running:false ~bound_channels:[ "C-paused" ] "paused"
+    ; keeper ~running:true ~bound_channels:[ "C-active" ] "active"
+    ]
+  in
+  check_status
+    "active bound keeper"
+    (Some Gateway.Online)
+    (Bridge.presence_status_for_keepers ~gateway_connected:true keepers)
+;;
+
+let test_no_running_bound_keeper_sets_idle () =
+  let keepers =
+    [ keeper ~running:true "unbound"
+    ; keeper ~running:false ~bound_channels:[ "C-paused" ] "paused"
+    ]
+  in
+  check_status
+    "no active bound keeper"
+    (Some Gateway.Idle)
+    (Bridge.presence_status_for_keepers ~gateway_connected:true keepers)
+;;
+
+let () =
+  run
+    "discord_presence_bridge"
+    [ ( "presence decision"
+      , [ test_case
+            "does nothing while gateway is disconnected"
+            `Quick
+            test_disconnected_gateway_is_noop
+        ; test_case
+            "sets online when any running keeper has a Discord binding"
+            `Quick
+            test_running_bound_keeper_sets_online
+        ; test_case
+            "sets idle when no running keeper has a Discord binding"
+            `Quick
+            test_no_running_bound_keeper_sets_idle
+        ] )
+    ]
+;;


### PR DESCRIPTION
Keeper 활성 상태를 Discord bot presence에 동기화. 30초 폴링으로 바인딩된 keeper의 활성 여부 확인. 활성 → Online, paused → Idle. 서버 재시작 후 바로 동작.