### PR TITLE
[codex] Surface stale dashboard bearer token state

### DIFF
--- a/dashboard/src/components/auth-status-banner.test.ts
+++ b/dashboard/src/components/auth-status-banner.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { waitFor } from '@testing-library/preact'
+import type { DashboardShellAuthSummary } from '../types'
+
+const mockState = vi.hoisted(() => ({
+  shellAuthSummary: { value: null as DashboardShellAuthSummary | null },
+  refreshShell: vi.fn().mockResolvedValue(undefined),
+  clearStoredToken: vi.fn(),
+  currentDashboardActor: vi.fn().mockReturnValue('dashboard'),
+  dashboardBearerToken: vi.fn().mockReturnValue('stale-token'),
+  isRemoteAccess: vi.fn().mockReturnValue(false),
+  setStoredToken: vi.fn(),
+  resetMcpClientState: vi.fn(),
+  showToast: vi.fn(),
+}))
+
+vi.mock('../store', () => ({
+  shellAuthSummary: mockState.shellAuthSummary,
+  refreshShell: mockState.refreshShell,
+}))
+
+vi.mock('../api/core', () => ({
+  clearStoredToken: mockState.clearStoredToken,
+  currentDashboardActor: mockState.currentDashboardActor,
+  dashboardBearerToken: mockState.dashboardBearerToken,
+  isRemoteAccess: mockState.isRemoteAccess,
+  setStoredToken: mockState.setStoredToken,
+}))
+
+vi.mock('../api/dev-token', () => ({
+  devTokenBootstrapStatus: { value: 'idle' },
+}))
+
+vi.mock('../api/mcp', () => ({
+  resetMcpClientState: mockState.resetMcpClientState,
+}))
+
+vi.mock('../lib/dashboard-auth-access', () => ({
+  dashboardAuthAccess: vi.fn().mockReturnValue({ allowed: false, reason: 'invalid token' }),
+  cleanErrorMessage: (value: string | null | undefined): string | null =>
+    value ? value.replace(/^[^\w가-힣@]+/u, '').trim() || null : null,
+}))
+
+vi.mock('../lib/dashboard-actor', () => ({
+  hasDashboardActorQueryParam: vi.fn().mockReturnValue(false),
+  readStoredDashboardActorName: vi.fn().mockReturnValue('dashboard'),
+  resolveDashboardActorName: vi.fn().mockReturnValue('dashboard'),
+  syncDashboardActorName: vi.fn((s: string) => s),
+}))
+
+vi.mock('./common/toast', () => ({
+  showToast: mockState.showToast,
+}))
+
+import {
+  RemoteWarningBanner,
+  __resetForTests,
+  authWarningBannerModel,
+} from './auth-status'
+
+const staleTokenSummary = (): DashboardShellAuthSummary => ({
+  enabled: true,
+  require_token: true,
+  token_present: true,
+  token_valid: false,
+  token_agent: null,
+  requested_agent: 'dashboard',
+  effective_agent: null,
+  effective_role: null,
+  default_role: 'reader',
+  auth_error_code: 'invalid_token',
+  auth_error_detail: 'Invalid token: Token mismatch',
+  can_keeper_msg: false,
+  keeper_msg_error: 'Invalid token: Token mismatch',
+})
+
+describe('RemoteWarningBanner auth-error visibility', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    mockState.shellAuthSummary.value = null
+    mockState.refreshShell.mockClear()
+    mockState.clearStoredToken.mockClear()
+    mockState.resetMcpClientState.mockClear()
+    mockState.showToast.mockClear()
+    mockState.isRemoteAccess.mockReturnValue(false)
+    __resetForTests()
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+    __resetForTests()
+  })
+
+  it('models stale bearer token warnings independently of remote access', () => {
+    expect(authWarningBannerModel(staleTokenSummary(), false)).toMatchObject({
+      action: 'auth_error',
+      canClearToken: true,
+    })
+  })
+
+  it('renders stale bearer token remediation on loopback dashboards', () => {
+    mockState.shellAuthSummary.value = staleTokenSummary()
+    mockState.isRemoteAccess.mockReturnValue(false)
+
+    render(html`<${RemoteWarningBanner} />`, container)
+
+    const alert = container.querySelector('[role="alert"]')
+    expect(alert?.textContent).toContain('Stored Bearer token is not verified')
+    expect(alert?.textContent).toContain('Clear token')
+  })
+
+  it('clears the stored token from the warning banner', async () => {
+    mockState.shellAuthSummary.value = staleTokenSummary()
+    render(html`<${RemoteWarningBanner} />`, container)
+
+    const clearButton = container.querySelector(
+      'button[aria-label="Clear stored bearer token"]',
+    ) as HTMLButtonElement
+    expect(clearButton).not.toBeNull()
+    clearButton.click()
+
+    await waitFor(() => {
+      expect(mockState.clearStoredToken).toHaveBeenCalledTimes(1)
+      expect(mockState.resetMcpClientState).toHaveBeenCalledTimes(1)
+      expect(mockState.refreshShell).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('does not render after token verification succeeds', () => {
+    mockState.shellAuthSummary.value = {
+      ...staleTokenSummary(),
+      token_valid: true,
+      auth_error_code: null,
+      auth_error_detail: null,
+    }
+
+    render(html`<${RemoteWarningBanner} />`, container)
+
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -30,6 +30,14 @@ const tokenInput = signal('')
 const actorInput = signal('')
 const bannerDismissed = signal(false)
 
+type AuthBannerAction = 'auth_error' | 'remote_unverified'
+
+export interface AuthWarningBannerModel {
+  action: AuthBannerAction
+  message: string
+  canClearToken: boolean
+}
+
 // Test-only helper. Resets module-level signals so *.test.ts files can
 // guarantee isolation in `beforeEach`. Mirrors use-id.ts:50 pattern.
 export function __resetForTests(): void {
@@ -123,6 +131,40 @@ async function handleClearToken(): Promise<void> {
     ? cleanErrorMessage(summary?.auth_error_detail) ?? 'Token cleared; the session is now unverified.'
     : 'Token cleared; the session is now local.'
   showToast(message, 'warning')
+}
+
+export function authWarningBannerModel(
+  summary: typeof shellAuthSummary.value,
+  remote: boolean,
+): AuthWarningBannerModel | null {
+  if (summary?.token_valid) return null
+
+  const authErrorCode = summary?.auth_error_code
+  const hasStaleToken =
+    authErrorCode === 'invalid_token' || authErrorCode === 'token_expired'
+  if (hasStaleToken) {
+    return {
+      action: 'auth_error',
+      message: 'Stored Bearer token is not verified. Replace it with a fresh token or clear it.',
+      canClearToken: summary?.token_present === true,
+    }
+  }
+
+  if (!remote) return null
+
+  if (authErrorCode === 'actor_mismatch') {
+    return {
+      action: 'remote_unverified',
+      message: 'Token owner and dashboard actor differ, so mutations are blocked. Align the actor or token.',
+      canClearToken: summary?.token_present === true,
+    }
+  }
+
+  return {
+    action: 'remote_unverified',
+    message: 'Remote access detected. Set a verified Bearer token before running mutations.',
+    canClearToken: summary?.token_present === true,
+  }
 }
 
 async function handleApplyActor(): Promise<void> {
@@ -302,19 +344,20 @@ function AuthPopover({ popoverId, labelId }: AuthPopoverProps) {
 
 export function RemoteWarningBanner() {
   const summary = shellAuthSummary.value
-  if (bannerDismissed.value || !isRemoteAccess() || summary?.token_valid) return null
-
-  const message =
-    summary?.auth_error_code === 'invalid_token' || summary?.auth_error_code === 'token_expired'
-      ? 'Stored Bearer token is not verified. Replace it with a fresh token.'
-      : summary?.auth_error_code === 'actor_mismatch'
-        ? 'Token owner and dashboard actor differ, so mutations are blocked. Align the actor or token.'
-        : 'Remote access detected. Set a verified Bearer token before running mutations.'
+  const model = authWarningBannerModel(summary, isRemoteAccess())
+  if (bannerDismissed.value || !model) return null
 
   return html`
     <div role="alert" class="shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-[var(--warn-10)] border-b border-[var(--warn-20)] text-xs text-[var(--color-status-warn)]">
-      <span>${message}</span>
+      <span>${model.message}</span>
       <div class="flex items-center gap-2 shrink-0">
+        ${model.canClearToken ? html`
+          <button type="button"
+            class="px-2 py-0.5 rounded-[var(--r-1)] text-2xs border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] cursor-pointer transition-colors"
+            aria-label="Clear stored bearer token"
+            onClick=${() => { void handleClearToken() }}
+          >Clear token</button>
+        ` : null}
         <button type="button"
           class="px-2 py-0.5 rounded-[var(--r-1)] text-2xs border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-accent-fg)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors"
           aria-label="Open auth panel"

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -634,7 +634,12 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Workspace.
     | _ -> None
   in
   let resolved_agent_name_result =
-    match dashboard_actor_for_request ~base_path:config.base_path request with
+    match token_credential_result with
+    (* Keep stale bearer tokens visible as auth failures in shell summaries instead of
+       recovering a request actor hint as the effective actor. *)
+    | Some (Error err) -> Error err
+    | _ ->
+    (match dashboard_actor_for_request ~base_path:config.base_path request with
     | Some agent_name -> Ok agent_name
     | None ->
       if auth_cfg.enabled && auth_cfg.require_token && token_present
@@ -646,12 +651,12 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Workspace.
                 ; message = "Agent name required (X-Gate-Agent / X-MASC-Agent or token-bound \
                              credential)"
                 }))
-      else Ok "dashboard"
+      else Ok "dashboard")
   in
   let effective_agent =
     match resolved_agent_name_result with
     | Ok agent_name -> Some agent_name
-    | Error _ -> requested_agent
+    | Error _ -> None
   in
   let effective_role_result =
     match resolved_agent_name_result with

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -744,6 +744,36 @@ let test_dashboard_shell_auth_json_reports_missing_token () =
   check string "missing token code surfaced" "missing_token"
     (auth |> member "auth_error_code" |> to_string)
 
+let test_dashboard_shell_auth_json_rejects_stale_token_actor_hint () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let cfg =
+    { Masc_domain.default_auth_config with enabled = true; require_token = true }
+  in
+  Auth.save_auth_config config.base_path cfg;
+  let json =
+    Server_dashboard_http_core.dashboard_shell_http_json
+      ~request:
+        (request_with_headers "/api/v1/dashboard/shell"
+           [
+             ("authorization", "Bearer stale-dashboard-token");
+             ("x-masc-agent", "dashboard");
+           ])
+      config
+  in
+  let open Yojson.Safe.Util in
+  let auth = json |> member "auth" in
+  check bool "token_valid false" false (auth |> member "token_valid" |> to_bool);
+  check string "requested actor surfaced for diagnosis" "dashboard"
+    (auth |> member "requested_agent" |> to_string);
+  check bool "effective actor not recovered from request hint" true
+    (match auth |> member "effective_agent" with `Null -> true | _ -> false);
+  check bool "effective role unavailable" true
+    (match auth |> member "effective_role" with `Null -> true | _ -> false);
+  check string "invalid token code surfaced" "invalid_token"
+    (auth |> member "auth_error_code" |> to_string);
+  check bool "keeper message blocked" false
+    (auth |> member "can_keeper_msg" |> to_bool)
+
 let test_dashboard_shell_snapshot_selector_injects_auth () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   Dashboard_snapshot.reset_for_test ();
@@ -1215,6 +1245,8 @@ let () =
             test_dashboard_shell_auth_json_canonicalizes_token_owner;
           test_case "shell auth reports missing token" `Quick
             test_dashboard_shell_auth_json_reports_missing_token;
+          test_case "shell auth rejects stale token actor hint" `Quick
+            test_dashboard_shell_auth_json_rejects_stale_token_actor_hint;
           test_case "shell snapshot selector injects auth" `Quick
             test_dashboard_shell_snapshot_selector_injects_auth;
           test_case "execution actor canonicalizes token owner" `Quick


### PR DESCRIPTION
## Summary

- Treat invalid/expired dashboard bearer tokens as shell auth failures instead of recovering `effective_agent` from the request actor hint.
- Show the stale-token warning banner even on loopback dashboards, not only remote dashboards.
- Add a banner-level `Clear token` action and regression coverage for the shell auth JSON plus UI banner behavior.

## Why

Stale or mismatched dashboard tokens were too quiet: local dashboards could hide the warning, and the shell auth summary could still show an effective actor derived from request hints. That made token drift look like a valid actor state.

Refs #18332.

## Checks

- `git diff --cached --check`
- `ocamlformat --check lib/server/server_dashboard_http_core.ml test/test_dashboard_http_core.ml`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/auth-status-banner.test.ts src/components/auth-status.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec eslint src/components/auth-status.ts src/components/auth-status-banner.test.ts`
- `scripts/dune-local.sh build --cache=disabled test/test_dashboard_http_core.exe`
- `./_build/default/test/test_dashboard_http_core.exe test executor_pool 20`

## Notes

- Frontend checks used the main checkout's existing `dashboard/node_modules` via a temporary worktree symlink because this worktree does not have its own install.
- The normal Dune cache build path hit a shared-cache cleanup race (`Directory not empty`); the focused target passed with `--cache=disabled`.
- The full `test_dashboard_http_core.exe` binary still has unrelated environment-sensitive failures in this sandbox; the new stale-token test passes directly as case 20.
