### PR TITLE
[codex] Restore keeper persona self-model defaults

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -87,6 +87,10 @@ These are the identity fields that should live in persona by default.
 | `short_goal` | Optional | Short-horizon goal | Defaults to `goal` in create paths. |
 | `mid_goal` | Optional | Mid-horizon goal | Defaults to `goal` in create paths. |
 | `long_goal` | Optional | Long-horizon goal | Defaults to `goal` in create paths. |
+| `will` | Optional | Keeper drive / self-model | Used as prompt default unless a keeper TOML overlay overrides it. |
+| `needs` | Optional | Resources or context the keeper believes it needs | Used as prompt default unless a keeper TOML overlay overrides it. |
+| `desires` | Optional | Desired end state / motivational bias | Used as prompt default unless a keeper TOML overlay overrides it. |
+| `instructions` | Optional | Persona-specific behavior and voice instructions | Used as prompt default unless a keeper TOML overlay overrides it. |
 | `mention_targets` | Optional | Default mention aliases | If omitted, create-from-persona falls back to `[persona_name]`. |
 | `tool_access` | Optional | Default tool candidate profile list | String array of tool names used as profile input; omitted means `[]`. It is not the complete execution gate. |
 | `tool_denylist` | Optional | Tools to remove after candidate profile resolution | Optional policy refinement. |
@@ -100,7 +104,6 @@ These may still be parsed today, but they are **not** the preferred place to enc
 | Field | Status | Preferred owner |
 | --- | --- | --- |
 | `allowed_paths` | Ignored by design | nowhere in persona |
-| `will`, `needs`, `desires`, `instructions` | Ignored by design | existing keeper meta / `keeper.toml` overlay |
 | `runtime_id`, `model`, `runtime_ref` | Removed | `runtime.toml [[runtime.assignments]]` |
 | `persona_ref` | Removed | `keeper.persona_name` |
 | `telemetry_feedback_*` | Compatibility-only | `keeper.toml` or runtime policy |

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -394,10 +394,11 @@ live observer는 shell gate counter와 semantic marker 계열만 남는다.
 | 필드 | 타입 | `-`일 때 의미 | 채우는 방법 |
 |------|------|--------------|------------|
 | `goal`, `short_goal`, `mid_goal`, `long_goal` | string | keeper TOML 또는 기존 meta 사용 | profile.json의 `keeper.*_goal` |
+| `will`, `needs`, `desires`, `instructions` | string | keeper TOML overlay 또는 기존 meta 사용 | profile.json의 `keeper.*` self-model |
 | `mention_targets` | string array | persona 이름 fallback | profile.json의 `keeper.mention_targets` |
 | `proactive_*` | bool/int | keeper TOML 또는 runtime default 사용 | profile.json의 proactive defaults |
 
-`profile.json`의 `keeper.will`, `keeper.needs`, `keeper.desires`, `keeper.instructions`는 더 이상 로드하지 않는다. 기존 keeper meta 또는 `keeper.toml` overlay가 self-model/prompt의 소유자다.
+`profile.json`의 `keeper.will`, `keeper.needs`, `keeper.desires`, `keeper.instructions`는 persona identity 기본값이다. 같은 keeper의 `keeper.toml`에 값이 있으면 TOML overlay가 persona 기본값을 덮어쓴다.
 
 **페르소나 프로필 필드** (Neo4j Agent 노드에서 로드):
 

--- a/lib/keeper/keeper_types_profile_persona_defaults.ml
+++ b/lib/keeper/keeper_types_profile_persona_defaults.ml
@@ -50,10 +50,10 @@ let load ~name : keeper_profile_defaults =
                   long_goal =
                     Normalizers.normalize_goal_horizon_opt
                       (Safe_ops.json_string_opt "long_goal" keeper_json);
-                  will = None;
-                  needs = None;
-                  desires = None;
-                  instructions = None;
+                  will = Safe_ops.json_string_opt "will" keeper_json;
+                  needs = Safe_ops.json_string_opt "needs" keeper_json;
+                  desires = Safe_ops.json_string_opt "desires" keeper_json;
+                  instructions = Safe_ops.json_string_opt "instructions" keeper_json;
                   autoboot_enabled = None;
                   mention_targets = Safe_ops.json_string_list "mention_targets" keeper_json;
                   proactive_enabled = Safe_ops.json_bool_opt "proactive_enabled" keeper_json;

--- a/lib/keeper/keeper_types_profile_persona_defaults.mli
+++ b/lib/keeper/keeper_types_profile_persona_defaults.mli
@@ -1,7 +1,7 @@
 (** Persona JSON -> keeper profile defaults.
 
     This module owns the profile.json conversion boundary. Runtime assignment
-    remains outside persona profiles, and legacy inline self-model fields are
-    ignored here. *)
+    remains outside persona profiles. Persona self-model fields are loaded as
+    defaults and may be overridden by keeper TOML overlays. *)
 
 val load : name:string -> Keeper_types_profile_defaults.keeper_profile_defaults

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -8,6 +8,45 @@ open Alcotest
 
 module WO = Masc.Keeper_world_observation
 module Prompt = Masc.Keeper_unified_prompt
+module KTP = Masc.Keeper_types_profile
+
+let has_repo_prompts root =
+  Sys.file_exists (Filename.concat root "config/prompts/keeper.unified.system.md")
+
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_repo_prompts root -> root
+  | _ ->
+    let rec ascend path =
+      if has_repo_prompts path then path
+      else
+        let parent = Filename.dirname path in
+        if String.equal parent path then Sys.getcwd () else ascend parent
+    in
+    ascend (Sys.getcwd ())
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+
+let with_repo_prompt_config f =
+  let root = repo_root () in
+  let config_dir = Filename.concat root "config" in
+  let prompts_dir = Filename.concat config_dir "prompts" in
+  let original_config = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "MASC_CONFIG_DIR" original_config;
+      Config_dir_resolver.reset ();
+      Prompt_registry.clear ())
+    (fun () ->
+      Unix.putenv "MASC_CONFIG_DIR" config_dir;
+      Config_dir_resolver.reset ();
+      Prompt_registry.clear ();
+      Prompt_registry.set_markdown_dir prompts_dir;
+      Masc.Prompt_defaults.init ();
+      Masc.Keeper_prompt_external.reset_cache ();
+      f ())
 
 let base_observation : WO.world_observation =
   {
@@ -80,6 +119,13 @@ let user_message observation =
     Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~observation ()
   in
   user
+
+let system_prompt ?profile_defaults observation =
+  let system, _user =
+    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ?profile_defaults
+      ~observation ()
+  in
+  system
 
 let contains ~needle haystack =
   let n = String.length needle and h = String.length haystack in
@@ -183,6 +229,29 @@ let test_namespace_state_names_running_keeper_fibers () =
   check bool "legacy active agents label absent" false
     (contains ~needle:"- Active agents:" user)
 
+let test_profile_defaults_feed_identity_prompt () =
+  with_repo_prompt_config @@ fun () ->
+  let profile_defaults =
+    {
+      KTP.empty_keeper_profile_defaults with
+      will = Some "soul will";
+      needs = Some "soul needs";
+      desires = Some "soul desires";
+      instructions = Some "soul instructions";
+    }
+  in
+  let system =
+    system_prompt ~profile_defaults base_observation
+  in
+  check bool "profile will in system prompt" true
+    (contains ~needle:"Will: soul will" system);
+  check bool "profile needs in system prompt" true
+    (contains ~needle:"Needs: soul needs" system);
+  check bool "profile desires in system prompt" true
+    (contains ~needle:"Desires: soul desires" system);
+  check bool "profile instructions in system prompt" true
+    (contains ~needle:"Instructions:\nsoul instructions" system)
+
 let () =
   init_runtime_default_for_tests ();
   run "keeper_surface_presence_prompt"
@@ -201,5 +270,7 @@ let () =
             test_empty_presence_has_no_section;
           test_case "namespace state names running keeper fibers" `Quick
             test_namespace_state_names_running_keeper_fibers;
+          test_case "profile defaults feed identity prompt" `Quick
+            test_profile_defaults_feed_identity_prompt;
         ] );
     ]

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -755,26 +755,44 @@ let require_nonempty_option path field value =
   | _ ->
     fail
       (Printf.sprintf
-         "%s must declare non-empty keeper.%s; persona profile self-model \
-          fields are legacy and ignored by the prompt defaults loader"
+         "%s must resolve non-empty keeper.%s from persona defaults or TOML \
+          overlay"
          path
          field)
 
-let test_bundled_keeper_tomls_declare_prompt_self_model () =
-  let keepers_dir = Filename.concat (repo_root ()) "config/keepers" in
-  Sys.readdir keepers_dir
-  |> Array.to_list
-  |> List.filter (fun file ->
-       Filename.check_suffix file ".toml"
-       && not (String.equal file "base.toml"))
-  |> List.iter (fun file ->
-       let path = Filename.concat keepers_dir file in
-       match KTP.load_keeper_toml path with
-       | Error e -> fail (Printf.sprintf "%s failed to load: %s" path e)
-       | Ok (_, defaults) ->
-         require_nonempty_option path "will" defaults.will;
-         require_nonempty_option path "needs" defaults.needs;
-         require_nonempty_option path "desires" defaults.desires)
+let test_bundled_keeper_profiles_resolve_prompt_self_model () =
+  let repo = repo_root () in
+  let original_config = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  let original_personas = Sys.getenv_opt "MASC_PERSONAS_DIR" in
+  let restore key = function
+    | Some value -> Unix.putenv key value
+    | None -> Unix.putenv key ""
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      restore "MASC_CONFIG_DIR" original_config;
+      restore "MASC_PERSONAS_DIR" original_personas;
+      Config_dir_resolver.reset ())
+    (fun () ->
+      Unix.putenv "MASC_CONFIG_DIR" (Filename.concat repo "config");
+      Unix.putenv "MASC_PERSONAS_DIR"
+        (Filename.concat (Filename.concat repo "config") "personas");
+      Config_dir_resolver.reset ();
+      let keepers_dir = Filename.concat repo "config/keepers" in
+      Sys.readdir keepers_dir
+      |> Array.to_list
+      |> List.filter (fun file ->
+           Filename.check_suffix file ".toml"
+           && not (String.equal file "base.toml"))
+      |> List.iter (fun file ->
+           let path = Filename.concat keepers_dir file in
+           let name = Filename.chop_extension file in
+           match KTP.load_keeper_profile_defaults_result name with
+           | Error e -> fail (Printf.sprintf "%s failed to resolve: %s" path e)
+           | Ok defaults ->
+             require_nonempty_option path "will" defaults.will;
+             require_nonempty_option path "needs" defaults.needs;
+             require_nonempty_option path "desires" defaults.desires))
 
 let with_temp_dir prefix f =
   let dir = Filename.temp_file prefix "" in
@@ -969,7 +987,7 @@ let test_persona_resolver_omits_unspecified_tool_access () =
        | `Null -> ()
        | _ -> fail "unspecified tool_access should be omitted")
 
-let test_persona_defaults_ignore_legacy_self_model_fields () =
+let test_persona_defaults_load_self_model_fields () =
   with_personas_dir @@ fun personas_dir ->
   let persona_dir = Filename.concat personas_dir "probe" in
   mkdir_p persona_dir;
@@ -990,10 +1008,12 @@ let test_persona_defaults_ignore_legacy_self_model_fields () =
   let defaults = KTP.load_keeper_profile_defaults_from_persona "probe" in
   check (option string) "goal still loads" (Some "test persona keeper")
     defaults.goal;
-  check (option string) "legacy will ignored" None defaults.will;
-  check (option string) "legacy needs ignored" None defaults.needs;
-  check (option string) "legacy desires ignored" None defaults.desires;
-  check (option string) "legacy instructions ignored" None defaults.instructions
+  check (option string) "will loads" (Some "legacy will") defaults.will;
+  check (option string) "needs loads" (Some "legacy needs") defaults.needs;
+  check (option string) "desires loads" (Some "legacy desires")
+    defaults.desires;
+  check (option string) "instructions load" (Some "legacy instructions")
+    defaults.instructions
 
 let test_persona_resolver_rejects_operator_todo_profile () =
   with_personas_dir @@ fun personas_dir ->
@@ -1843,12 +1863,12 @@ let () =
           test_case "with files" `Quick test_discover_with_files;
           test_case "nonexistent dir" `Quick test_discover_nonexistent_dir;
           test_case "skips bad files" `Quick test_discover_skips_bad_files;
-          test_case "bundled keeper TOMLs declare prompt self-model" `Quick
-            test_bundled_keeper_tomls_declare_prompt_self_model;
+          test_case "bundled keeper profiles resolve prompt self-model" `Quick
+            test_bundled_keeper_profiles_resolve_prompt_self_model;
           test_case "persona resolver omits unspecified tool_access" `Quick
             test_persona_resolver_omits_unspecified_tool_access;
-          test_case "persona defaults ignore legacy self-model fields" `Quick
-            test_persona_defaults_ignore_legacy_self_model_fields;
+          test_case "persona defaults load self-model fields" `Quick
+            test_persona_defaults_load_self_model_fields;
           test_case "persona resolver rejects OPERATOR_TODO profile" `Quick
             test_persona_resolver_rejects_operator_todo_profile;
           test_case "persona resolver reports placeholder defaults source" `Quick


### PR DESCRIPTION
## Summary

- Restore `profile.json` persona self-model fields as keeper prompt defaults:
  - `keeper.will`
  - `keeper.needs`
  - `keeper.desires`
  - `keeper.instructions`
- Keep `keeper.toml` as the override layer on top of persona identity defaults.
- Update docs that still said persona self-model fields were ignored.
- Add regression coverage for both the loader and final unified system prompt composition.

## Why

Keeper personas still carried their identity text in `config/personas/*/profile.json`, but the persona defaults loader explicitly dropped the self-model fields. That made keepers depend on duplicated `keeper.toml` overlays for their voice and identity, and erased persona instructions whenever the TOML was thin.

This PR restores the intended boundary:

`persona profile identity` -> default prompt self-model
`keeper.toml` -> concrete deployment override
`runtime.toml` -> runtime/model assignment

## Checks

- `git diff --check`
- `ocamlformat --check lib/keeper/keeper_types_profile_persona_defaults.ml lib/keeper/keeper_types_profile_persona_defaults.mli test/test_keeper_toml.ml test/test_keeper_surface_presence_prompt.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_toml.exe test/test_keeper_surface_presence_prompt.exe`
- `./_build/default/test/test_keeper_toml.exe`
- `./_build/default/test/test_keeper_surface_presence_prompt.exe`

## Notes

- Used `MASC_DUNE_ALLOW_BARE_DUNE=1` because another local bare Dune process was present earlier; the focused wrapper build passed.
- Full build/test suite intentionally not run here.
