### PR TITLE
fix(keeper): make tool pair repair span-aware

### DIFF
--- a/docs/rfc/RFC-0110-tool-pair-atomicity-write-boundary.md
+++ b/docs/rfc/RFC-0110-tool-pair-atomicity-write-boundary.md
@@ -17,6 +17,8 @@ implementation_prs: [15924]
 
 `lib/keeper/keeper_context_core.ml` 의 `repair_dangling_tool_use_messages_with_stats` 와 `repair_orphan_tool_result_messages_with_stats` 는 메시지 히스토리에서 짝-잃은 `ToolUse` 와 `ToolResult` block 을 처리한다. 과거 구현은 이 block 을 provider/dashboard-visible transcript 에 남겼고, 그 결과물에 repair 메타데이터를 붙였다. 2026-06-12 이후 구현은 깨진 structural block 을 visible content 에서 drop 하고, bounded id/name sample 을 `masc.tool_pair_repair` metadata 및 telemetry stats 로 남긴다.
 
+Legacy adapter 는 provider/model 명으로 분기하지 않는다. 구조적으로 같은 message 안의 `ToolUse`/`ToolResult` pair 와, assistant `ToolUse` 뒤에 연속으로 붙는 `ToolResult` span 을 하나의 group 으로 취급한다. 따라서 "immediately previous/next message" 만 보는 수리는 유효한 OpenAI-compatible multi-result span 과 Gemma-style same-message pair 를 깨뜨리는 경계 위반이다.
+
 호출 사이트 4개 (`keeper_post_turn.ml:576,919` + `keeper_rollover.ml:266` + 명시적 opt-out `:783,838,867,196`):
 
 ```

--- a/lib/keeper/keeper_context_core_accessors.ml
+++ b/lib/keeper/keeper_context_core_accessors.ml
@@ -252,72 +252,230 @@ let pair_repair_metadata_keys =
 let with_pair_repair_metadata =
   Keeper_context_core_pair_repair_stats.with_pair_repair_metadata
 
-let repair_dangling_tool_use_messages_with_stats
+type tool_pair_repair_mode =
+  { drop_dangling_uses : bool
+  ; drop_orphan_results : bool
+  }
+
+let record_dropped_tool_use stats id name =
+  let id = bound_pair_repair_diagnostic_string id in
+  let name = bound_pair_repair_diagnostic_string name in
+  stats :=
+    add_tool_pair_repair_stats
+      !stats
+      { empty_tool_pair_repair_stats with
+        dropped_tool_uses = 1
+      ; dropped_tool_use_samples = [ id, name ]
+      }
+
+let record_dropped_tool_result stats tool_use_id =
+  let tool_use_id = bound_pair_repair_diagnostic_string tool_use_id in
+  stats :=
+    add_tool_pair_repair_stats
+      !stats
+      { empty_tool_pair_repair_stats with
+        dropped_tool_results = 1
+      ; dropped_tool_result_ids = [ tool_use_id ]
+      }
+
+let pair_repair_metadata_kind stats =
+  match stats.dropped_tool_uses > 0, stats.dropped_tool_results > 0 with
+  | true, true -> "dropped_tool_pair_blocks"
+  | true, false -> "dropped_tool_use"
+  | false, true -> "dropped_tool_result"
+  | false, false -> "none"
+
+let annotate_pair_repair_metadata stats (msg : Agent_sdk.Types.message) =
+  if not (tool_pair_repair_stats_changed stats)
+  then msg
+  else
+    msg
+    |> with_pair_repair_metadata
+         ~tool_use_samples:stats.dropped_tool_use_samples
+         ~tool_result_ids:stats.dropped_tool_result_ids
+         ~kind:(pair_repair_metadata_kind stats)
+         ~count:(stats.dropped_tool_uses + stats.dropped_tool_results)
+
+let repaired_message_opt msg stats content =
+  match content with
+  | [] -> None
+  | content -> Some ({ msg with content } |> annotate_pair_repair_metadata stats)
+
+let is_tool_result_span_message msg =
+  has_tool_result_block msg && tool_use_ids_of_message msg = []
+
+let split_tool_result_group messages =
+  let rec loop original result remainder = function
+    | msg :: rest when tool_use_ids_of_message msg <> [] ->
+        List.rev original, List.rev result, List.rev remainder, msg :: rest
+    | msg :: rest when is_tool_result_span_message msg ->
+        loop (msg :: original) (msg :: result) remainder rest
+    | msg :: rest -> loop (msg :: original) result (msg :: remainder) rest
+    | [] -> List.rev original, List.rev result, List.rev remainder, []
+  in
+  loop [] [] [] messages
+
+let filter_group_message_content
+    mode
+    ~(allowed_tool_use_ids : string list)
+    ~(matched_tool_result_ids : string list)
+    ~(seen_tool_result_ids : string list ref)
+    (msg : Agent_sdk.Types.message)
+    : Agent_sdk.Types.content_block list * tool_pair_repair_stats =
+  let stats = ref empty_tool_pair_repair_stats in
+  let content =
+    List.filter_map
+      (function
+        | Agent_sdk.Types.ToolUse { id; name; _ }
+          when mode.drop_dangling_uses
+               && not (List.mem id matched_tool_result_ids) ->
+            record_dropped_tool_use stats id name;
+            None
+        | Agent_sdk.Types.ToolResult { tool_use_id; _ } as block
+          when mode.drop_orphan_results ->
+            let allowed = List.mem tool_use_id allowed_tool_use_ids in
+            let duplicate = List.mem tool_use_id !seen_tool_result_ids in
+            if allowed && not duplicate
+            then (
+              seen_tool_result_ids := tool_use_id :: !seen_tool_result_ids;
+              Some block)
+            else (
+              record_dropped_tool_result stats tool_use_id;
+              None)
+        | other -> Some other)
+      msg.content
+  in
+  content, !stats
+
+let filter_orphan_result_message_content
+    mode
+    (msg : Agent_sdk.Types.message)
+    : Agent_sdk.Types.content_block list * tool_pair_repair_stats =
+  if not mode.drop_orphan_results
+  then msg.content, empty_tool_pair_repair_stats
+  else
+    let stats = ref empty_tool_pair_repair_stats in
+    let content =
+      List.filter_map
+        (function
+          | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
+              record_dropped_tool_result stats tool_use_id;
+              None
+          | other -> Some other)
+        msg.content
+    in
+    content, !stats
+
+let order_tool_result_group_by_tool_use_ids tool_use_ids messages =
+  let rec index_of needle index = function
+    | [] -> None
+    | id :: rest ->
+        if String.equal needle id
+        then Some index
+        else index_of needle (index + 1) rest
+  in
+  let message_rank msg =
+    msg
+    |> tool_result_ids_of_message
+    |> List.filter_map (fun id -> index_of id 0 tool_use_ids)
+    |> function
+    | [] -> max_int
+    | ranks -> List.fold_left min max_int ranks
+  in
+  messages
+  |> List.mapi (fun original_index msg -> message_rank msg, original_index, msg)
+  |> List.sort (fun (left_rank, left_index, _) (right_rank, right_index, _) ->
+    match Int.compare left_rank right_rank with
+    | 0 -> Int.compare left_index right_index
+    | comparison -> comparison)
+  |> List.map (fun (_, _, msg) -> msg)
+
+let repair_tool_call_pairs_with_stats
+    mode
     (messages : Agent_sdk.Types.message list)
     : Agent_sdk.Types.message list * tool_pair_repair_stats =
-  let repair_with_next
-      (current : Agent_sdk.Types.message)
-      (next_opt : Agent_sdk.Types.message option) =
-    let next_tool_result_ids =
-      match next_opt with
-      | Some next -> tool_result_ids_of_message next
-      | None -> []
+  let reorder_for_pairing = mode.drop_dangling_uses && mode.drop_orphan_results in
+  let append_repaired acc stats msg content =
+    match repaired_message_opt msg stats content with
+    | None -> acc
+    | Some repaired -> repaired :: acc
+  in
+  let append_filtered_group_message
+      allowed_tool_use_ids
+      matched_tool_result_ids
+      seen_tool_result_ids
+      (acc, acc_stats)
+      msg =
+    let content, stats =
+      filter_group_message_content
+        mode
+        ~allowed_tool_use_ids
+        ~matched_tool_result_ids
+        ~seen_tool_result_ids
+        msg
     in
-    let has_dangling =
-      List.exists
-        (function
-          | Agent_sdk.Types.ToolUse { id; _ } ->
-              not (List.mem id next_tool_result_ids)
-          (* Only [ToolUse] blocks can be dangling without a paired ToolResult. *)
-          | Agent_sdk.Types.Text _
-          | Agent_sdk.Types.Thinking _
-          | Agent_sdk.Types.RedactedThinking _
-          | Agent_sdk.Types.ToolResult _
-          | Agent_sdk.Types.Image _
-          | Agent_sdk.Types.Document _
-          | Agent_sdk.Types.Audio _ -> false)
-        current.content
-    in
-    if not has_dangling then (current, empty_tool_pair_repair_stats)
-    else
-      let dropped_tool_uses = ref 0 in
-      let dropped_tool_use_samples = ref [] in
-      let content =
-        List.filter_map
-          (function
-            | Agent_sdk.Types.ToolUse { id; name; _ }
-              when not (List.mem id next_tool_result_ids) ->
-                incr dropped_tool_uses;
-                let id = bound_pair_repair_diagnostic_string id in
-                let name = bound_pair_repair_diagnostic_string name in
-                dropped_tool_use_samples := (id, name) :: !dropped_tool_use_samples;
-                None
-            | other -> Some other)
-          current.content
-      in
-      let dropped_tool_use_samples = List.rev !dropped_tool_use_samples in
-      ( { current with content }
-        |> with_pair_repair_metadata
-             ~tool_use_samples:dropped_tool_use_samples
-             ~kind:"dropped_tool_use"
-             ~count:!dropped_tool_uses
-      , { empty_tool_pair_repair_stats with
-          dropped_tool_uses = !dropped_tool_uses
-        ; dropped_tool_use_samples
-        } )
+    ( append_repaired acc stats msg content
+    , add_tool_pair_repair_stats acc_stats stats )
   in
   let rec loop acc_stats acc = function
     | [] -> List.rev acc, acc_stats
-    | [ current ] ->
-        let repaired, repair_stats = repair_with_next current None in
-        let acc = if repaired.content = [] then acc else repaired :: acc in
-        List.rev acc, add_tool_pair_repair_stats acc_stats repair_stats
-    | current :: ((next :: _) as rest) ->
-        let repaired, repair_stats = repair_with_next current (Some next) in
-        let acc = if repaired.content = [] then acc else repaired :: acc in
-        loop (add_tool_pair_repair_stats acc_stats repair_stats) acc rest
+    | msg :: rest ->
+        let tool_use_ids = tool_use_ids_of_message msg in
+        if tool_use_ids <> []
+        then
+          let original_group, result_group, remainder_group, rest =
+            split_tool_result_group rest
+          in
+          let matched_tool_result_ids =
+            tool_result_ids_of_message msg
+            @ List.concat_map tool_result_ids_of_message result_group
+          in
+          let seen_tool_result_ids = ref [] in
+          let current_content, current_stats =
+            filter_group_message_content
+              mode
+              ~allowed_tool_use_ids:tool_use_ids
+              ~matched_tool_result_ids
+              ~seen_tool_result_ids
+              msg
+          in
+          let acc = append_repaired acc current_stats msg current_content in
+          let acc_stats =
+            add_tool_pair_repair_stats acc_stats current_stats
+          in
+          let group =
+            if reorder_for_pairing
+            then
+              order_tool_result_group_by_tool_use_ids tool_use_ids result_group
+              @ remainder_group
+            else original_group
+          in
+          let acc, acc_stats =
+            List.fold_left
+              (append_filtered_group_message
+                 tool_use_ids
+                 matched_tool_result_ids
+                 seen_tool_result_ids)
+              (acc, acc_stats)
+              group
+          in
+          loop acc_stats acc rest
+        else if has_tool_result_block msg
+        then
+          let content, stats = filter_orphan_result_message_content mode msg in
+          let acc = append_repaired acc stats msg content in
+          loop (add_tool_pair_repair_stats acc_stats stats) acc rest
+        else
+          loop acc_stats (msg :: acc) rest
   in
   loop empty_tool_pair_repair_stats [] messages
+
+let repair_dangling_tool_use_messages_with_stats
+    (messages : Agent_sdk.Types.message list)
+    : Agent_sdk.Types.message list * tool_pair_repair_stats =
+  repair_tool_call_pairs_with_stats
+    { drop_dangling_uses = true; drop_orphan_results = false }
+    messages
 
 let repair_dangling_tool_use_messages messages =
   fst (repair_dangling_tool_use_messages_with_stats messages)
@@ -325,74 +483,9 @@ let repair_dangling_tool_use_messages messages =
 let repair_orphan_tool_result_messages_with_stats
     (messages : Agent_sdk.Types.message list)
     : Agent_sdk.Types.message list * tool_pair_repair_stats =
-  let rec loop acc_stats prev acc = function
-    | [] -> List.rev acc, acc_stats
-    | msg :: rest ->
-        let repaired, stats =
-          if not (has_tool_result_block msg) then
-            (msg, empty_tool_pair_repair_stats)
-          else
-            let prev_tool_use_ids =
-              match prev with
-              | Some previous -> tool_use_ids_of_message previous
-              | None -> []
-            in
-            (* Anthropic validates ToolResult blocks against ToolUse blocks
-               in the immediately previous message. If checkpoint capping
-               drops that predecessor, the resumed history becomes invalid.
-               Drop only the orphaned structured result blocks from visible
-               content and retain bounded diagnostics in pair-repair stats
-               and metadata. *)
-            let has_orphan =
-              List.exists
-                (function
-                  | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
-                      not (List.mem tool_use_id prev_tool_use_ids)
-                  (* Only [ToolResult] can be orphaned w.r.t. prior ToolUse ids. *)
-                  | Agent_sdk.Types.Text _
-                  | Agent_sdk.Types.Thinking _
-                  | Agent_sdk.Types.RedactedThinking _
-                  | Agent_sdk.Types.ToolUse _
-                  | Agent_sdk.Types.Image _
-                  | Agent_sdk.Types.Document _
-                  | Agent_sdk.Types.Audio _ -> false)
-                msg.content
-            in
-            if not has_orphan then (msg, empty_tool_pair_repair_stats)
-            else
-              let dropped_tool_results = ref 0 in
-              let dropped_tool_result_ids = ref [] in
-              let content =
-                List.filter_map
-                  (function
-                    | Agent_sdk.Types.ToolResult { tool_use_id; _ }
-                      when not (List.mem tool_use_id prev_tool_use_ids) ->
-                        incr dropped_tool_results;
-                        let tool_use_id =
-                          bound_pair_repair_diagnostic_string tool_use_id
-                        in
-                        dropped_tool_result_ids := tool_use_id :: !dropped_tool_result_ids;
-                        None
-                    | other -> Some other)
-                  msg.content
-              in
-              let dropped_tool_result_ids = List.rev !dropped_tool_result_ids in
-              ( { msg with content }
-                |> with_pair_repair_metadata
-                     ~tool_result_ids:dropped_tool_result_ids
-                     ~kind:"dropped_tool_result"
-                     ~count:!dropped_tool_results
-              , { empty_tool_pair_repair_stats with
-                  dropped_tool_results = !dropped_tool_results
-                ; dropped_tool_result_ids
-                } )
-        in
-        let prev, acc =
-          if repaired.content = [] then prev, acc else Some repaired, repaired :: acc
-        in
-        loop (add_tool_pair_repair_stats acc_stats stats) prev acc rest
-  in
-  loop empty_tool_pair_repair_stats None [] messages
+  repair_tool_call_pairs_with_stats
+    { drop_dangling_uses = false; drop_orphan_results = true }
+    messages
 
 let repair_orphan_tool_result_messages messages =
   fst (repair_orphan_tool_result_messages_with_stats messages)
@@ -400,9 +493,9 @@ let repair_orphan_tool_result_messages messages =
 let repair_broken_tool_call_pairs_with_stats
     (messages : Agent_sdk.Types.message list)
     : Agent_sdk.Types.message list * tool_pair_repair_stats =
-  let messages, dangling_stats = repair_dangling_tool_use_messages_with_stats messages in
-  let messages, orphan_stats = repair_orphan_tool_result_messages_with_stats messages in
-  messages, add_tool_pair_repair_stats dangling_stats orphan_stats
+  repair_tool_call_pairs_with_stats
+    { drop_dangling_uses = true; drop_orphan_results = true }
+    messages
 
 let repair_broken_tool_call_pairs
     (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =

--- a/lib/keeper/keeper_context_core_pair_repair_stats.ml
+++ b/lib/keeper/keeper_context_core_pair_repair_stats.ml
@@ -22,6 +22,13 @@ let empty_tool_pair_repair_stats =
   }
 
 let sample_cap = 8
+let pair_repair_diagnostic_max_bytes = 256
+
+let bound_pair_repair_diagnostic_string value =
+  value
+  |> String.trim
+  |> Inference_utils.sanitize_text_utf8
+  |> String_util.utf8_prefix ~max_bytes:pair_repair_diagnostic_max_bytes
 
 let take_bounded n items =
   let rec loop remaining acc = function
@@ -31,29 +38,31 @@ let take_bounded n items =
   in
   loop n [] items
 
+let bounded_tool_use_samples samples =
+  samples
+  |> List.map (fun (tool_use_id, tool_name) ->
+    ( bound_pair_repair_diagnostic_string tool_use_id
+    , bound_pair_repair_diagnostic_string tool_name ))
+  |> take_bounded sample_cap
+
+let bounded_tool_result_ids ids =
+  ids |> List.map bound_pair_repair_diagnostic_string |> take_bounded sample_cap
+
 let add_tool_pair_repair_stats left right =
   { dropped_tool_uses =
       left.dropped_tool_uses + right.dropped_tool_uses
   ; dropped_tool_results =
       left.dropped_tool_results + right.dropped_tool_results
   ; dropped_tool_use_samples =
-      take_bounded sample_cap
+      bounded_tool_use_samples
         (left.dropped_tool_use_samples @ right.dropped_tool_use_samples)
   ; dropped_tool_result_ids =
-      take_bounded sample_cap
+      bounded_tool_result_ids
         (left.dropped_tool_result_ids @ right.dropped_tool_result_ids)
   }
 
 let tool_pair_repair_stats_changed stats =
   stats.dropped_tool_uses > 0 || stats.dropped_tool_results > 0
-
-let pair_repair_diagnostic_max_bytes = 256
-
-let bound_pair_repair_diagnostic_string value =
-  value
-  |> String.trim
-  |> Inference_utils.sanitize_text_utf8
-  |> String_util.utf8_prefix ~max_bytes:pair_repair_diagnostic_max_bytes
 
 let pair_repair_metadata_key = "masc.tool_pair_repair"
 
@@ -75,6 +84,8 @@ let with_pair_repair_metadata
     ~kind
     ~count
     (msg : Agent_sdk.Types.message) =
+  let tool_use_samples = bounded_tool_use_samples tool_use_samples in
+  let tool_result_ids = bounded_tool_result_ids tool_result_ids in
   let metadata =
     List.filter
       (fun (key, _) -> not (List.mem key pair_repair_metadata_keys))

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -278,6 +278,64 @@ let assistant_text_and_tool_use ?(input = `Null) text id name : Agent_sdk.Types.
   ; metadata = []
   }
 
+let assistant_tool_uses uses : Agent_sdk.Types.message =
+  { role = Agent_sdk.Types.Assistant
+  ; content =
+      List.map
+        (fun (id, name) -> Agent_sdk.Types.ToolUse { id; name; input = `Null })
+        uses
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+
+let assistant_text_and_tool_uses text uses : Agent_sdk.Types.message =
+  { role = Agent_sdk.Types.Assistant
+  ; content =
+      Agent_sdk.Types.Text text
+      :: List.map
+           (fun (id, name) ->
+             Agent_sdk.Types.ToolUse { id; name; input = `Null })
+           uses
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+
+let assistant_same_message_tool_pair id name content : Agent_sdk.Types.message =
+  { role = Agent_sdk.Types.Assistant
+  ; content =
+      [ Agent_sdk.Types.ToolUse { id; name; input = `Null }
+      ; Agent_sdk.Types.ToolResult
+          { tool_use_id = id
+          ; content
+          ; is_error = false
+          ; json = None
+          ; content_blocks = None
+          }
+      ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+
+let tool_result_message ?(role = Agent_sdk.Types.User) id content
+    : Agent_sdk.Types.message =
+  { role
+  ; content =
+      [ Agent_sdk.Types.ToolResult
+          { tool_use_id = id
+          ; content
+          ; is_error = false
+          ; json = None
+          ; content_blocks = None
+          }
+      ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+
 let user_tool_result id content : Agent_sdk.Types.message =
   { role = Agent_sdk.Types.User
   ; content =
@@ -329,6 +387,24 @@ let text_blocks (messages : Agent_sdk.Types.message list) =
 
 let text_contains needle texts =
   List.exists (fun text -> Astring.String.is_infix ~affix:needle text) texts
+
+let count_tool_blocks messages =
+  List.fold_left
+    (fun counts (msg : Agent_sdk.Types.message) ->
+       List.fold_left
+         (fun (tool_uses, tool_results) -> function
+           | Agent_sdk.Types.ToolUse _ -> tool_uses + 1, tool_results
+           | Agent_sdk.Types.ToolResult _ -> tool_uses, tool_results + 1
+           | Agent_sdk.Types.Text _
+           | Agent_sdk.Types.Thinking _
+           | Agent_sdk.Types.RedactedThinking _
+           | Agent_sdk.Types.Image _
+           | Agent_sdk.Types.Document _
+           | Agent_sdk.Types.Audio _ -> tool_uses, tool_results)
+         counts
+         msg.content)
+    (0, 0)
+    messages
 
 let test_pair_repair_stats_count_drops () =
   let messages =
@@ -398,7 +474,7 @@ let test_pair_repair_drops_dangling_tool_use_details () =
     ; user_text
         "keeper_tools_list lists capabilities; use keeper_surface_read for lane \
          context."
-    ; user_tool_result "toolu_1" {|{"meta":["keeper_tools_list"]}|}
+    ; user_tool_result "toolu_orphan" {|{"meta":["keeper_tools_list"]}|}
     ]
   in
   let repaired, stats = KC.repair_broken_tool_call_pairs_with_stats messages in
@@ -410,7 +486,7 @@ let test_pair_repair_drops_dangling_tool_use_details () =
     stats.dropped_tool_use_samples;
   Alcotest.(check (list string))
     "dropped tool result diagnostic id preserved"
-    [ "toolu_1" ]
+    [ "toolu_orphan" ]
     stats.dropped_tool_result_ids;
   let texts = text_blocks repaired in
   Alcotest.(check bool)
@@ -425,6 +501,133 @@ let test_pair_repair_drops_dangling_tool_use_details () =
     "dangling tool-use input is not serialized into text"
     false
     (text_contains "input={}" texts)
+
+let test_pair_repair_preserves_same_message_tool_pair () =
+  let messages =
+    [ assistant_same_message_tool_pair "toolu_same" "lookup" {|{"ok":true}|} ]
+  in
+  let repaired, stats = KC.repair_broken_tool_call_pairs_with_stats messages in
+  Alcotest.(check bool)
+    "same-message pair does not need repair"
+    false
+    (KC.tool_pair_repair_stats_changed stats);
+  Alcotest.(check int) "same-message pair message preserved" 1 (List.length repaired);
+  Alcotest.(check (pair int int))
+    "same-message ToolUse and ToolResult preserved"
+    (1, 1)
+    (count_tool_blocks repaired)
+
+let test_pair_repair_preserves_contiguous_result_span () =
+  let messages =
+    [ assistant_tool_uses [ "toolu_a", "one"; "toolu_b", "two" ]
+    ; tool_result_message "toolu_a" "a"
+    ; tool_result_message "toolu_b" "b"
+    ; user_text "after"
+    ]
+  in
+  let repaired, stats = KC.repair_broken_tool_call_pairs_with_stats messages in
+  Alcotest.(check bool)
+    "contiguous result span does not need repair"
+    false
+    (KC.tool_pair_repair_stats_changed stats);
+  Alcotest.(check int) "contiguous span messages preserved" 4 (List.length repaired);
+  Alcotest.(check (pair int int))
+    "contiguous span ToolUse and ToolResult blocks preserved"
+    (2, 2)
+    (count_tool_blocks repaired)
+
+let test_pair_repair_moves_late_results_before_interstitial_turns () =
+  let messages =
+    [ assistant_tool_uses [ "toolu_a", "one"; "toolu_b", "two" ]
+    ; user_text "display turn before results"
+    ; tool_result_message "toolu_b" "b"
+    ; tool_result_message "toolu_a" "a"
+    ; user_text "after"
+    ]
+  in
+  let repaired, stats = KC.repair_broken_tool_call_pairs_with_stats messages in
+  Alcotest.(check bool)
+    "late real results are moved, not dropped"
+    false
+    (KC.tool_pair_repair_stats_changed stats);
+  Alcotest.(check (list string))
+    "matching results become adjacent before interstitial turns"
+    [ "assistant"; "result:toolu_a"; "result:toolu_b"; "text:display turn before results"; "text:after" ]
+    (List.map
+       (fun (msg : Agent_sdk.Types.message) ->
+         match msg.content with
+         | [ Agent_sdk.Types.ToolResult { tool_use_id; _ } ] ->
+             "result:" ^ tool_use_id
+         | [ Agent_sdk.Types.Text text ] -> "text:" ^ text
+         | _ -> "assistant")
+       repaired);
+  Alcotest.(check (list string))
+    "tool results follow tool-use order"
+    [ "toolu_a"; "toolu_b" ]
+    (List.filter_map
+       (fun (msg : Agent_sdk.Types.message) ->
+         match msg.content with
+         | [ Agent_sdk.Types.ToolResult { tool_use_id; _ } ] ->
+             Some tool_use_id
+         | _ -> None)
+       repaired);
+  Alcotest.(check (pair int int))
+    "late ToolUse and ToolResult blocks preserved"
+    (2, 2)
+    (count_tool_blocks repaired)
+
+let test_pair_repair_drops_only_invalid_blocks_in_span () =
+  let messages =
+    [ assistant_tool_uses [ "toolu_a", "one"; "toolu_b", "two" ]
+    ; tool_result_message "toolu_a" "a"
+    ; tool_result_message "toolu_c" "c"
+    ; user_text "after"
+    ]
+  in
+  let repaired, stats = KC.repair_broken_tool_call_pairs_with_stats messages in
+  Alcotest.(check int) "unmatched ToolUse dropped" 1 stats.dropped_tool_uses;
+  Alcotest.(check int) "orphan ToolResult dropped" 1 stats.dropped_tool_results;
+  Alcotest.(check (list (pair string string)))
+    "unmatched ToolUse sample preserved"
+    [ "toolu_b", "two" ]
+    stats.dropped_tool_use_samples;
+  Alcotest.(check (list string))
+    "orphan ToolResult id preserved"
+    [ "toolu_c" ]
+    stats.dropped_tool_result_ids;
+  Alcotest.(check int)
+    "empty orphan-only result message dropped"
+    3
+    (List.length repaired);
+  Alcotest.(check (pair int int))
+    "only valid pair remains structured"
+    (1, 1)
+    (count_tool_blocks repaired)
+
+let test_pair_repair_metadata_samples_bounded () =
+  let uses =
+    List.init 10 (fun index ->
+      Printf.sprintf "toolu_%02d" index, Printf.sprintf "tool_%02d" index)
+  in
+  let messages = [ assistant_text_and_tool_uses "kept" uses ] in
+  let repaired, stats = KC.repair_broken_tool_call_pairs_with_stats messages in
+  Alcotest.(check int) "all dangling ToolUses counted" 10 stats.dropped_tool_uses;
+  Alcotest.(check int)
+    "stats ToolUse samples bounded"
+    8
+    (List.length stats.dropped_tool_use_samples);
+  let metadata_sample_count =
+    match repaired with
+    | [ msg ] ->
+        (match List.assoc_opt KC.pair_repair_metadata_key msg.metadata with
+         | Some (`Assoc fields) ->
+             (match List.assoc_opt "tool_use_samples" fields with
+              | Some (`List samples) -> List.length samples
+              | _ -> 0)
+         | _ -> 0)
+    | _ -> 0
+  in
+  Alcotest.(check int) "metadata ToolUse samples bounded" 8 metadata_sample_count
 
 let test_checkpoint_sanitize_preserves_pair_repair_stats () =
   let messages =
@@ -514,11 +717,14 @@ let test_pair_repair_caps_diagnostic_sample_strings () =
     [ user_text "q"
     ; assistant_text_and_tool_use "assistant kept text" long_id long_name
     ; user_text "interrupt"
-    ; user_text_and_tool_result "result wrapper kept text" long_id "late"
+    ; user_text_and_tool_result "result wrapper kept text" (long_id ^ "_orphan") "late"
     ]
   in
   let _repaired, stats = KC.repair_broken_tool_call_pairs_with_stats messages in
   let expected_id = KC.bound_pair_repair_diagnostic_string long_id in
+  let expected_result_id =
+    KC.bound_pair_repair_diagnostic_string (long_id ^ "_orphan")
+  in
   let expected_name = KC.bound_pair_repair_diagnostic_string long_name in
   Alcotest.(check int)
     "diagnostic tool-use id capped"
@@ -534,7 +740,7 @@ let test_pair_repair_caps_diagnostic_sample_strings () =
     stats.dropped_tool_use_samples;
   Alcotest.(check (list string))
     "tool-result diagnostic id strings are capped"
-    [ expected_id ]
+    [ expected_result_id ]
     stats.dropped_tool_result_ids
 
 (* ── Gospel-style specification (documentation) ────────── *)
@@ -576,6 +782,16 @@ let () =
         test_pair_repair_stats_count_drops;
       Alcotest.test_case "pair repair drops dangling tool-use details" `Quick
         test_pair_repair_drops_dangling_tool_use_details;
+      Alcotest.test_case "pair repair preserves same-message tool pair" `Quick
+        test_pair_repair_preserves_same_message_tool_pair;
+      Alcotest.test_case "pair repair preserves contiguous result span" `Quick
+        test_pair_repair_preserves_contiguous_result_span;
+      Alcotest.test_case "pair repair moves late results before interstitial turns" `Quick
+        test_pair_repair_moves_late_results_before_interstitial_turns;
+      Alcotest.test_case "pair repair drops only invalid span blocks" `Quick
+        test_pair_repair_drops_only_invalid_blocks_in_span;
+      Alcotest.test_case "pair repair metadata samples bounded" `Quick
+        test_pair_repair_metadata_samples_bounded;
       Alcotest.test_case "checkpoint sanitize preserves pair repair stats" `Quick
         test_checkpoint_sanitize_preserves_pair_repair_stats;
       Alcotest.test_case "pair repair drops empty structural messages with stats" `Quick


### PR DESCRIPTION
## Summary

- Replace immediate-neighbor tool-pair repair with one-pass structural repair over same-message pairs, contiguous `ToolResult` spans, and late real results before the next assistant `ToolUse`.
- Preserve valid multi-result spans while dropping only unmatched `ToolUse`, orphan `ToolResult`, and duplicate `ToolResult` blocks; composite repair moves late real results adjacent instead of fabricating synthetic outputs.
- Bound pair-repair metadata sample lists using the existing diagnostic string cap.

Follow-up to merged #21039.

## Validation

- `ocamlformat --check lib/keeper/keeper_context_core_accessors.ml test/test_pbt_context_overflow.ml`
- `git diff --check`
- `env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_pbt_context_overflow.exe`
- `./_build/default/test/test_pbt_context_overflow.exe` (16 tests)

Note: local build used the installed newer shared `agent_sdk` pin because the repo-local pin script refused to downgrade the shared switch.
