### PR TITLE
test(keeper): pin self-model meta keys as canonical

### DIFF
--- a/test/test_keeper_meta_unknown_keys_warn.ml
+++ b/test/test_keeper_meta_unknown_keys_warn.ml
@@ -42,6 +42,26 @@ let test_no_counter_tick_when_all_keys_canonical () =
     before
     after
 
+let test_self_model_keys_are_canonical () =
+  let before = counter_total () in
+  Keeper_meta_json.warn_unknown_keeper_meta_keys
+    ~path:"/test/self-model.json"
+    (`Assoc
+      [ ("name", `String "self-model")
+      ; ("agent_name", `String "self-model")
+      ; ("trace_id", `String "trace-self-model")
+      ; ("tool_access", `List [])
+      ; ("will", `String "persist intent")
+      ; ("needs", `String "runtime truth")
+      ; ("desires", `String "quiet logs")
+      ; ("instructions", `String "preserve operator guidance")
+      ]);
+  let after = counter_total () in
+  Alcotest.(check (float 0.0001))
+    "self-model keys are canonical persisted keeper meta keys"
+    before
+    after
+
 let test_counter_ticks_on_genuine_unknown_key () =
   (* Sanity: the warn path still fires when a real unknown key is present. *)
   let before = counter_total () in
@@ -97,6 +117,10 @@ let () =
             "no counter tick when all keys canonical"
             `Quick
             test_no_counter_tick_when_all_keys_canonical
+        ; Alcotest.test_case
+            "self-model keys are canonical"
+            `Quick
+            test_self_model_keys_are_canonical
         ; Alcotest.test_case
             "counter still ticks on genuine unknown"
             `Quick


### PR DESCRIPTION
## Summary
- add a warning-path regression test proving persisted self-model keys are canonical keeper meta keys
- keep the existing genuine-unknown-key counter assertion intact

## Context
- Latest main already persists and recognizes will/needs/desires/instructions via #21043/#21044.
- This PR keeps that behavior pinned at the unknown-key warning gate so live keeper meta does not spam false warnings for those fields again.

## Verification
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh exec ./test/test_keeper_meta_unknown_keys_warn.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh exec ./test/test_keeper_meta_canonical_seed.exe
- git diff --check HEAD~1..HEAD

Note: local shared opam switch has newer agent_sdk 0.206.5 than this worktree pin expects, so the focused local runs skipped the pin guard rather than downgrading the shared switch.