### PR TITLE
fix(keeper): trust keepalive in diagnostics

### DIFF
--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -281,8 +281,6 @@ let live_signal_supersedes_persisted_error ~keepalive_running ~agent_status ~met
 
 let classify_keeper_quiet_reason ~meta ~keepalive_running ~agent_status ~now_ts =
   let quiet_active = quiet_hours_active () in
-  let agent_exists = json_bool "exists" agent_status false in
-  let agent_status_text = agent_status_text agent_status in
   let error_hint =
     if live_signal_supersedes_persisted_error ~keepalive_running ~agent_status ~meta
     then None
@@ -292,11 +290,6 @@ let classify_keeper_quiet_reason ~meta ~keepalive_running ~agent_status ~now_ts 
     Some "disabled"
   else if not keepalive_running then
     Some "not_running"
-  else if
-    not agent_exists
-    || agent_status_text = "offline"
-    || agent_status_text = "inactive"
-  then Some "agent_missing"
   else if meta.runtime.usage.total_turns = 0 && meta.runtime.proactive_rt.count_total = 0 then
     let keeper_age_s =
       match Workspace_resilience.Time.parse_iso8601_opt meta.created_at with
@@ -371,12 +364,14 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
     else
       last_turn_ago_s
   in
-  if not agent_exists || agent_status_text = "offline" || agent_status_text = "inactive"
+  if
+    (not keepalive_running)
+    && (not agent_exists || agent_status_text = "offline" || agent_status_text = "inactive")
   then KH_offline
   (* H-4 fix: true zombies are stale regardless of keepalive state *)
   else if is_zombie then KH_stale
   else if keepalive_running then
-    if last_seen_ago_s > 2.0 *. keepalive_interval_s then KH_stale
+    if agent_exists && last_seen_ago_s > 2.0 *. keepalive_interval_s then KH_stale
     else
       (match quiet_reason with
     | Some "graphql_error" | Some "model_error" -> KH_degraded

--- a/test/test_keeper_diagnostic_stale_last_error.ml
+++ b/test/test_keeper_diagnostic_stale_last_error.ml
@@ -39,6 +39,16 @@ let string_member key json =
   | _ -> None
 ;;
 
+let nullable_string_member key json =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String s) -> Some s
+      | Some `Null | None -> None
+      | _ -> None)
+  | _ -> None
+;;
+
 let meta_with_persisted_error ~proactive_ts ~last_turn_ts =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -80,6 +90,15 @@ let last_error_of_diagnostic ~meta ~agent_status ~keepalive_running =
     ~history_items:[]
     ~now_ts
   |> string_member "last_error"
+;;
+
+let diagnostic_of ~meta ~agent_status ~keepalive_running =
+  Keeper_status_runtime.keeper_diagnostic_json
+    ~meta
+    ~agent_status
+    ~keepalive_running
+    ~history_items:[]
+    ~now_ts
 ;;
 
 (* Production case: keeper (exists=false agent_status) that turned after its
@@ -133,6 +152,29 @@ let test_external_live_signal_hides_stale_error () =
     (last_error_of_diagnostic ~meta ~agent_status ~keepalive_running:true)
 ;;
 
+(* Keepers run as supervised fibers and do not normally publish a separate
+   [.masc/agents/<agent>.json] record. A live keepalive loop is therefore the
+   stronger liveness signal; missing agent-registry state must not make the
+   dashboard report the keeper as offline/recovering. *)
+let test_keepalive_without_agent_record_is_healthy () =
+  let meta =
+    meta_with_persisted_error
+      ~proactive_ts:(now_ts -. 300.0)
+      ~last_turn_ts:(now_ts -. 120.0)
+  in
+  let diagnostic =
+    diagnostic_of ~meta ~agent_status:keeper_agent_status ~keepalive_running:true
+  in
+  Alcotest.(check (option string))
+    "keepalive-running keeper without agent record is healthy"
+    (Some "healthy")
+    (string_member "health_state" diagnostic);
+  Alcotest.(check (option string))
+    "missing agent record is not a quiet reason for live keeper fibers"
+    None
+    (nullable_string_member "quiet_reason" diagnostic)
+;;
+
 let () =
   Alcotest.run
     "keeper_diagnostic_stale_last_error"
@@ -153,6 +195,10 @@ let () =
             "external live signal hides stale error"
             `Quick
             test_external_live_signal_hides_stale_error
+        ; Alcotest.test_case
+            "keepalive without agent record is healthy"
+            `Quick
+            test_keepalive_without_agent_record_is_healthy
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Treat a running keeper keepalive loop as the authoritative liveness signal for keeper diagnostics.
- Stop classifying keepalive-running keepers as offline/recovering solely because they do not publish a separate agent registry row.
- Add regression coverage for the production shape: agent_status={exists=false}, keepalive_running=true.

## Live evidence
- /health?full=1 showed 9 healthy running keeper fibers, but /api/v1/dashboard/execution marked those rows as diagnostic health_state=offline, quiet_reason=agent_missing.
- The same health snapshot showed real capacity shortfall is separate: 4 durable operator_paused keepers plus qa-king offline after attempt_watchdog_safety_deadline.

## Validation
- ocamlformat --check lib/keeper/keeper_status_runtime.ml test/test_keeper_diagnostic_stale_last_error.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_diagnostic_stale_last_error.exe
- _build/default/test/test_keeper_diagnostic_stale_last_error.exe