### PR TITLE
fix(dashboard): refresh session activity trace

### DIFF
--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, it, beforeEach } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+
+const dashboardApiMocks = vi.hoisted(() => ({
+  fetchAgentTimeline: vi.fn(),
+  fetchKeeperToolCalls: vi.fn(),
+  fetchKeeperTrajectory: vi.fn(),
+}))
+
+vi.mock('../../api/dashboard', () => dashboardApiMocks)
+
 import {
   closeSessionTrace,
   getTraceEvents,
@@ -14,6 +23,7 @@ import {
   getTraceLoading,
   getTraceError,
   buildTraceEvents,
+  scheduleSessionTraceReload,
   traceSlots,
 } from './session-trace-state'
 import { appendLiveToolCall, liveTraceFeeds } from './session-trace-live-store'
@@ -23,6 +33,26 @@ beforeEach(() => {
   traceSlots.value = {}
   liveTraceFeeds.value = {}
 })
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+function emptyTimeline(agent = 'keeper-a') {
+  return {
+    agent,
+    period: { from: '', to: '' },
+    events: [],
+    summary: {
+      tasks_completed: 0,
+      tasks_claimed: 0,
+      messages_sent: 0,
+      active_duration_minutes: 0,
+      total_events: 0,
+    },
+  }
+}
 
 describe('appendLiveToolCall', () => {
   it('does nothing when trace slot is not open', () => {
@@ -169,6 +199,64 @@ describe('appendLiveToolCall', () => {
     // Newest-first: tool_call (tsUnix=1712400000) > broadcast (ts=1712399000000)
     expect(events[0]!.kind).toBe('tool_call')
     expect(events[1]!.kind).toBe('broadcast')
+  })
+})
+
+describe('scheduleSessionTraceReload', () => {
+  it('debounces a reload for an open keeper trace slot', async () => {
+    vi.useFakeTimers()
+    traceSlots.value = {
+      'keeper-a': {
+        events: [],
+        loading: false,
+        error: null,
+        filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
+        fetchToken: 0,
+      },
+    }
+    dashboardApiMocks.fetchAgentTimeline.mockResolvedValue(emptyTimeline())
+    dashboardApiMocks.fetchKeeperTrajectory.mockResolvedValue({
+      keeper: 'keeper-a',
+      trace_id: 'trace-1',
+      generation: 1,
+      total_entries: 1,
+      showing: 1,
+      entries: [{
+        type: 'thinking',
+        ts: 1712400000,
+        ts_iso: '2024-04-06T10:40:00Z',
+        turn: 12,
+        content: 'new keeper thought',
+        content_length: 18,
+        redacted: false,
+      }],
+    })
+    dashboardApiMocks.fetchKeeperToolCalls.mockResolvedValue({
+      keeper: 'keeper-a',
+      count: 0,
+      entries: [],
+    })
+
+    scheduleSessionTraceReload('keeper-a', true, 10)
+    scheduleSessionTraceReload('keeper-a', true, 10)
+
+    expect(dashboardApiMocks.fetchAgentTimeline).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(dashboardApiMocks.fetchAgentTimeline).toHaveBeenCalledTimes(1)
+    expect(dashboardApiMocks.fetchKeeperTrajectory).toHaveBeenCalledTimes(1)
+    expect(getTraceEvents('keeper-a')[0]?.summary).toBe('new keeper thought')
+  })
+
+  it('ignores reload requests for closed trace slots', async () => {
+    vi.useFakeTimers()
+
+    scheduleSessionTraceReload('keeper-a', true, 10)
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(dashboardApiMocks.fetchAgentTimeline).not.toHaveBeenCalled()
   })
 })
 

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -803,6 +803,9 @@ const TIMELINE_HOURS = 24
 const TIMELINE_LIMIT = 200
 const TRAJECTORY_LIMIT = 100
 const TOOL_CALL_LIMIT = 100
+const SESSION_TRACE_RELOAD_DEBOUNCE_MS = 1_000
+
+const sessionTraceReloadTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
 export async function loadSessionTrace(agentName: string, isKeeper: boolean): Promise<void> {
   // Bump fetch token for this agent — any prior in-flight fetch becomes stale.
@@ -846,7 +849,30 @@ export async function loadSessionTrace(agentName: string, isKeeper: boolean): Pr
   }
 }
 
+export function scheduleSessionTraceReload(
+  agentName: string,
+  isKeeper: boolean,
+  delayMs = SESSION_TRACE_RELOAD_DEBOUNCE_MS,
+): void {
+  if (traceSlots.value[agentName] == null) return
+
+  const existing = sessionTraceReloadTimers.get(agentName)
+  if (existing != null) clearTimeout(existing)
+
+  const timer = setTimeout(() => {
+    sessionTraceReloadTimers.delete(agentName)
+    if (traceSlots.value[agentName] == null) return
+    void loadSessionTrace(agentName, isKeeper)
+  }, delayMs)
+  sessionTraceReloadTimers.set(agentName, timer)
+}
+
 export function closeSessionTrace(agentName: string): void {
+  const timer = sessionTraceReloadTimers.get(agentName)
+  if (timer != null) {
+    clearTimeout(timer)
+    sessionTraceReloadTimers.delete(agentName)
+  }
   const next = { ...traceSlots.value }
   delete next[agentName]
   traceSlots.value = next

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -15,6 +15,7 @@ import {
   normalizeJournalSource,
 } from './journal-entry'
 import { appendLiveToolCall } from './components/session-trace/session-trace-live-store'
+import { scheduleSessionTraceReload } from './components/session-trace/session-trace-state'
 import { appendAuditEntry } from './live-store'
 import { isCrashedPhase } from './lib/keeper-predicates'
 import { dashboardBearerToken } from './api/core'
@@ -55,6 +56,21 @@ function traceToolArgs(value: unknown): string | Record<string, unknown> | null 
     return value
   }
   return traceValueString(value)
+}
+
+function normalizeKeeperTraceName(raw: string | undefined): string {
+  const name = (raw ?? '').trim()
+  const match = /^keeper-(.+)-agent$/.exec(name)
+  return match?.[1] ?? name
+}
+
+function keeperTraceNameFromEvent(event: SSEEvent, fallback: string): string {
+  return normalizeKeeperTraceName(
+    event.name
+      ?? event.keeper_name
+      ?? event.agent_name
+      ?? fallback,
+  )
 }
 
 // --- Signals ---
@@ -486,6 +502,10 @@ function handleEvent(event: SSEEvent): void {
         break
       }
     case 'keeper_turn_complete':
+      {
+        const keeperName = keeperTraceNameFromEvent(event, agent)
+        if (keeperName) scheduleSessionTraceReload(keeperName, true)
+      }
       addTypedJournalEntry(
         event.name ?? agent,
         `Turn ${event.turn ?? '?'} tok=${((event.input_tokens ?? 0) + (event.output_tokens ?? 0))} tools=${event.tool_calls_made ?? 0}`,
@@ -587,10 +607,12 @@ function handleEvent(event: SSEEvent): void {
         },
       )
       // Push to live trace if session trace is open for this keeper
-      if (event.name) {
+      {
+        const keeperName = keeperTraceNameFromEvent(event, agent)
+        if (!keeperName) break
         const toolArgs = traceToolArgs(event.tool_args) ?? event.tool_args_preview ?? null
         const toolResult = traceValueString(event.tool_result) ?? event.tool_output_preview ?? null
-        appendLiveToolCall(event.name, {
+        appendLiveToolCall(keeperName, {
           toolName,
           durationMs,
           success: event.success !== false,
@@ -617,8 +639,10 @@ function handleEvent(event: SSEEvent): void {
           narrativeText: `${actorLabel(event.name ?? agent)}의 ${toolName} 도구가 차단되었습니다 (${reasonCode})`,
         },
       )
-      if (event.name) {
-        appendLiveToolCall(event.name, {
+      {
+        const keeperName = keeperTraceNameFromEvent(event, agent)
+        if (!keeperName) break
+        appendLiveToolCall(keeperName, {
           toolName,
           durationMs: 0,
           success: false,

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -106,6 +106,22 @@ let event_to_json (e : timeline_event) : Yojson.Safe.t =
       ("detail", e.detail);
     ]
 
+let keeper_actor_id agent_name = "keeper-" ^ agent_name ^ "-agent"
+
+let activity_event_matches_agent ~(agent_name : string) (e : Activity_graph.event) =
+  let actor_matches =
+    match e.actor with
+    | Some a ->
+        String.equal a.id agent_name
+        || String.equal a.id (keeper_actor_id agent_name)
+        || String.equal a.id ("keeper:" ^ agent_name)
+    | None -> false
+  in
+  actor_matches
+  || Safe_ops.json_string_opt "keeper_name" e.payload = Some agent_name
+  || Safe_ops.json_string_opt "agent_name" e.payload = Some agent_name
+  || Safe_ops.json_string_opt "name" e.payload = Some agent_name
+
 (* Collect agent session/status events *)
 let agent_events (config : Workspace.config) ~agent_name :
     timeline_event list =
@@ -261,10 +277,7 @@ let tool_call_events (config : Workspace.config) ~agent_name ~limit :
       ~kinds:["tool.called"] ~after_seq:0 ~limit:scan_limit ()
   in
   all_events
-  |> List.filter (fun (e : Activity_graph.event) ->
-       match e.actor with
-       | Some a -> String.equal a.id agent_name
-       | None -> false)
+  |> List.filter (activity_event_matches_agent ~agent_name)
   |> List.filter_map (fun (e : Activity_graph.event) ->
        let ts = Float.of_int e.ts_ms /. 1000.0 in
        let tool_name =
@@ -311,10 +324,7 @@ let keeper_cdal_events (config : Workspace.config) ~agent_name ~limit :
       ~after_seq:0 ~limit:scan_limit ()
   in
   all_events
-  |> List.filter (fun (e : Activity_graph.event) ->
-       match e.actor with
-       | Some a -> String.equal a.id agent_name
-       | None -> false)
+  |> List.filter (activity_event_matches_agent ~agent_name)
   |> List.map (fun (e : Activity_graph.event) ->
        {
          ts = Float.of_int e.ts_ms /. 1000.0;
@@ -342,10 +352,7 @@ let turn_completed_events (config : Workspace.config) ~agent_name ~limit :
       ~kinds:["keeper.turn_completed"] ~after_seq:0 ~limit:scan_limit ()
   in
   all_events
-  |> List.filter (fun (e : Activity_graph.event) ->
-       match e.actor with
-       | Some a -> String.equal a.id agent_name
-       | None -> false)
+  |> List.filter (activity_event_matches_agent ~agent_name)
   |> List.filter_map (fun (e : Activity_graph.event) ->
        let ts = Float.of_int e.ts_ms /. 1000.0 in
        (* Pure-shape JSON access via Safe_ops: no exception swallow, no


### PR DESCRIPTION
## Summary
- refresh an open session activity trace when keeper turn-complete SSE arrives, so new trajectory/thinking rows are fetched without reopening the panel
- normalize keeper actor ids like `keeper-nick0cave-agent` for live trace attribution
- make agent timeline activity matching accept keeper actor wrappers and keeper_name/agent_name payloads

## Why
The activity durable sink and /api/v1/activity/events were fresh, but the keeper detail "세션 활동 로그" only loaded trajectory/tool-call history on mount/manual refresh. The SSE live path appended tool/OAS events only, so keeper turn/thinking rows could remain stale. Separately, /api/v1/agent-timeline?agent_name=nick0cave missed activity rows whose actor id was `keeper-nick0cave-agent`.

## Verification
- `pnpm exec vitest run --config vitest.config.ts src/components/session-trace/session-trace-state.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/session-trace/session-trace-state.ts src/components/session-trace/session-trace-state.test.ts src/sse.ts`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_activity_graph.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 _build/default/test/test_activity_graph.exe`