### PR TITLE
fix(dashboard): restore SSE wiring for live panels

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -24,6 +24,7 @@ const TARGET_FILES = [
   'src/components/harness-health.ts',
   'src/components/journey-panel.ts',
   'src/components/journey-waterfall-state.ts',
+  'src/components/keeper-sse-match.ts',
   'src/components/keeper-tool-call-inspector.ts',
   'src/components/keeper-tool-telemetry.ts',
   'src/components/logs.ts',
@@ -39,6 +40,7 @@ const TARGET_FILES = [
   'src/runtime-counts.ts',
   'src/schemas/sse.ts',
   'src/sse.ts',
+  'src/sse-store.ts',
   'src/tab-refresh.ts',
   'src/types/sse.ts',
 ]
@@ -61,6 +63,7 @@ const TEST_FILES = [
   'src/components/ide/ide-activity-panel.test.ts',
   'src/components/journey-panel.test.ts',
   'src/components/journey-waterfall-state.test.ts',
+  'src/components/keeper-sse-match.test.ts',
   'src/components/keeper-tool-call-inspector.test.ts',
   'src/components/logs.test.ts',
   'src/components/session-trace/session-trace-state.test.ts',

--- a/dashboard/src/components/keeper-sse-match.test.ts
+++ b/dashboard/src/components/keeper-sse-match.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import type { SSEEvent } from '../types'
+import {
+  isKeeperToolActivityEvent,
+  sseEventMatchesKeeper,
+  sseKeeperName,
+} from './keeper-sse-match'
+
+describe('keeper SSE matching', () => {
+  it('canonicalizes keeper runtime aliases for event matching', () => {
+    const event = {
+      type: 'keeper_tool_call',
+      agent_name: 'keeper-sangsu-agent',
+      tool_name: 'keeper_context_status',
+    } as SSEEvent
+
+    expect(sseKeeperName(event)).toBe('sangsu')
+    expect(sseEventMatchesKeeper(event, 'sangsu')).toBe(true)
+    expect(sseEventMatchesKeeper(event, 'keeper-sangsu-agent')).toBe(true)
+    expect(sseEventMatchesKeeper(event, 'other')).toBe(false)
+  })
+
+  it('recognizes tool-call events across canonical and MASC alias wire types', () => {
+    expect(isKeeperToolActivityEvent({ type: 'keeper_tool_call' } as SSEEvent)).toBe(true)
+    expect(isKeeperToolActivityEvent({ type: 'masc/keeper_tool_call' } as SSEEvent)).toBe(true)
+    expect(isKeeperToolActivityEvent({ type: 'keeper_tool_skipped' } as SSEEvent)).toBe(true)
+    expect(isKeeperToolActivityEvent({ type: 'keeper_turn_complete' } as SSEEvent)).toBe(false)
+  })
+})

--- a/dashboard/src/components/keeper-sse-match.ts
+++ b/dashboard/src/components/keeper-sse-match.ts
@@ -1,0 +1,27 @@
+import type { SSEEvent } from '../types'
+import { normalizeSSEDispatchType } from '../sse'
+import { canonicalKeeperName } from './common/keeper-identity'
+
+function normalizeMatchKey(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase()
+}
+
+export function sseKeeperName(event: SSEEvent): string {
+  return canonicalKeeperName(
+    event.name
+      ?? event.keeper_name
+      ?? event.agent_name
+      ?? event.agent,
+  ) ?? ''
+}
+
+export function sseEventMatchesKeeper(event: SSEEvent, keeperName: string): boolean {
+  const eventKeeper = normalizeMatchKey(sseKeeperName(event))
+  const targetKeeper = normalizeMatchKey(canonicalKeeperName(keeperName) ?? keeperName)
+  return eventKeeper !== '' && eventKeeper === targetKeeper
+}
+
+export function isKeeperToolActivityEvent(event: SSEEvent): boolean {
+  const type = normalizeSSEDispatchType(event.type)
+  return type === 'keeper_tool_call' || type === 'keeper_tool_skipped'
+}

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -2,10 +2,11 @@
 // Fetches from GET /api/v1/keepers/:name/tool-calls
 
 import { html } from 'htm/preact'
-import { useEffect } from 'preact/hooks'
+import { useCallback, useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { fetchKeeperToolCalls } from '../api/dashboard'
 import type { ToolCallEntry, ToolCallsResponse, TelemetryFreshnessMetadata } from '../api/dashboard'
+import { lastEvent } from '../sse'
 import { formatTimeHms } from '../lib/format-time'
 import { formatMsCompact } from '../lib/format-number'
 import { LoadingState } from './common/feedback-state'
@@ -25,6 +26,7 @@ import {
   routeLinksForContext,
   type IdeContextRouteLink,
 } from './ide/ide-context-lens'
+import { isKeeperToolActivityEvent, sseEventMatchesKeeper } from './keeper-sse-match'
 
 // Delegated to lib/format-time (SSOT)
 const formatTimestamp = formatTimeHms
@@ -594,14 +596,27 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
   const resource = useManagedAsyncResource<ToolCallsResponse | null>(null)
   const filterTool = useSignal('')
 
+  const loadToolCalls = useCallback((signal: AbortSignal) =>
+    fetchKeeperToolCalls(keeperName, 100, { signal }), [keeperName])
+
   useEffect(() => {
-    void resource.load(async (signal) => {
-      return await fetchKeeperToolCalls(keeperName, 100, { signal })
-    })
+    void resource.load(loadToolCalls)
     return () => {
       resource.cancel()
     }
-  }, [keeperName, resource])
+  }, [loadToolCalls, resource])
+
+  useEffect(() => {
+    const unsubscribe = lastEvent.subscribe((event) => {
+      if (!event) return
+      if (!isKeeperToolActivityEvent(event)) return
+      if (!sseEventMatchesKeeper(event, keeperName)) return
+      void resource.load(loadToolCalls)
+    })
+    return () => {
+      unsubscribe()
+    }
+  }, [keeperName, loadToolCalls, resource])
 
   const response = resource.state.value.data
   const allEntries = response?.entries ?? []

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -3,9 +3,10 @@
 // cross-trace aggregation, and hourly timeline sparklines.
 
 import { html } from 'htm/preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useCallback, useEffect, useState } from 'preact/hooks'
 import { fetchKeeperToolStats } from '../api/dashboard'
 import type { ToolStat, HourlyBucket, ToolStatsResponse, TelemetryFreshnessMetadata } from '../api/dashboard'
+import { lastEvent } from '../sse'
 import { toolCategory, durationColor, normalizeToolName } from './tool-call-shared'
 import { formatCost, formatMsCompact } from '../lib/format-number'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
@@ -15,6 +16,7 @@ import { PanelCard } from './common/panel-card'
 import { ProgressBar } from './common/progress-bar'
 import { coverageGapDisplay, sourceHealthClass, freshnessText } from './common/source-health'
 import { StatusChip } from './common/status-chip'
+import { isKeeperToolActivityEvent, sseEventMatchesKeeper } from './keeper-sse-match'
 
 // ── Types ─────────────────────────────────────────────
 
@@ -162,34 +164,48 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
   })
   const [query, setQuery] = useState('')
 
+  const loadToolStats = useCallback(async (signal: AbortSignal): Promise<TelemetryState> => {
+    const data: ToolStatsResponse = await fetchKeeperToolStats(keeperName, 24, { signal })
+    return {
+      source: data.source,
+      producer: data.producer,
+      durable_store: data.durable_store,
+      dashboard_surface: data.dashboard_surface,
+      freshness_slo_s: data.freshness_slo_s,
+      latest_ts_unix: data.latest_ts_unix,
+      latest_ts_iso: data.latest_ts_iso,
+      latest_age_s: data.latest_age_s,
+      health: data.health,
+      stale_reason: data.stale_reason,
+      entry_count: data.entry_count,
+      exists: data.exists,
+      coverage_gaps: data.coverage_gaps,
+      coverage_gap_count: data.coverage_gap_count,
+      tools: data.tools,
+      timeline: data.timeline,
+      totalEntries: data.total_entries,
+      windowHours: data.window_hours,
+    }
+  }, [keeperName])
+
   useEffect(() => {
-    void resource.load(async (signal) => {
-      const data: ToolStatsResponse = await fetchKeeperToolStats(keeperName, 24, { signal })
-      return {
-        source: data.source,
-        producer: data.producer,
-        durable_store: data.durable_store,
-        dashboard_surface: data.dashboard_surface,
-        freshness_slo_s: data.freshness_slo_s,
-        latest_ts_unix: data.latest_ts_unix,
-        latest_ts_iso: data.latest_ts_iso,
-        latest_age_s: data.latest_age_s,
-        health: data.health,
-        stale_reason: data.stale_reason,
-        entry_count: data.entry_count,
-        exists: data.exists,
-        coverage_gaps: data.coverage_gaps,
-        coverage_gap_count: data.coverage_gap_count,
-        tools: data.tools,
-        timeline: data.timeline,
-        totalEntries: data.total_entries,
-        windowHours: data.window_hours,
-      }
-    })
+    void resource.load(loadToolStats)
     return () => {
       resource.cancel()
     }
-  }, [keeperName, resource])
+  }, [loadToolStats, resource])
+
+  useEffect(() => {
+    const unsubscribe = lastEvent.subscribe((event) => {
+      if (!event) return
+      if (!isKeeperToolActivityEvent(event)) return
+      if (!sseEventMatchesKeeper(event, keeperName)) return
+      void resource.load(loadToolStats)
+    })
+    return () => {
+      unsubscribe()
+    }
+  }, [keeperName, loadToolStats, resource])
 
   const asyncState = resource.state.value
   const s = asyncState.data ?? {

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -11,6 +11,12 @@ describe('SSEEventTypeSchema', () => {
     expect(SSEEventTypeSchema.parse('keeper_heartbeat')).toBe('keeper_heartbeat')
   })
 
+  it('accepts MASC wire aliases emitted by server-side SSE publishers', () => {
+    expect(SSEEventTypeSchema.parse('masc/broadcast')).toBe('masc/broadcast')
+    expect(SSEEventTypeSchema.parse('masc/agent_bound')).toBe('masc/agent_bound')
+    expect(SSEEventTypeSchema.parse('masc/agent_unbound')).toBe('masc/agent_unbound')
+  })
+
   it('accepts current and future oas-prefixed event types', () => {
     expect(SSEEventTypeSchema.parse('oas:agent_failed')).toBe('oas:agent_failed')
     expect(SSEEventTypeSchema.parse('oas:context_overflow_imminent')).toBe('oas:context_overflow_imminent')
@@ -172,6 +178,15 @@ describe('parseSSEMessage', () => {
     const msg = parseSSEMessage({ type: 'broadcast', message: 'hi' })
     expect(msg).not.toBeNull()
     expect(msg?.type).toBe('broadcast')
+  })
+
+  it('keeps MASC broadcast wire events instead of dropping them as schema drift', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const msg = parseSSEMessage({ type: 'masc/broadcast', from: 'operator', content: 'hi' })
+    expect(msg).not.toBeNull()
+    expect(msg?.type).toBe('masc/broadcast')
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
   })
 
   it('keeps unknown oas-prefixed events instead of dropping them', () => {

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -24,8 +24,11 @@ type SchemaLike<T> = {
 
 const FIXED_SSE_EVENT_TYPES = new Set([
   'agent_bound',
+  'masc/agent_bound',
   'agent_unbound',
+  'masc/agent_unbound',
   'broadcast',
+  'masc/broadcast',
   'task_update',
   'board_post',
   'masc/board_post',

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -240,6 +240,38 @@ describe('setupSSEReaction reconnect hydration', () => {
     cleanup()
   })
 
+  it('normalizes MASC lifecycle aliases before route-scoped execution refresh', async () => {
+    const { sseStore, sse } = await loadSseStore()
+    route.value = { tab: 'monitoring', params: { section: 'agents' }, postId: null }
+    const cleanup = sseStore.setupSSEReaction()
+
+    sse.lastEvent.value = {
+      type: 'masc/keeper_guardrail',
+      name: 'qa-king',
+      reason: 'tool boundary',
+    }
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshExecution).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('normalizes MASC broadcast aliases before route-scoped execution refresh', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'monitoring', params: { section: 'agents' }, postId: null }
+
+    sseStore.routeServerPushEvent({
+      type: 'masc/broadcast',
+      from: 'operator',
+      content: 'heads up',
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshExecution).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps operator lifecycle refreshes scoped to the command route', async () => {
     const { sseStore, sse } = await loadSseStore()
     const refreshOperator = vi.fn()
@@ -259,6 +291,22 @@ describe('setupSSEReaction reconnect hydration', () => {
     expect(refreshExecution).not.toHaveBeenCalled()
 
     cleanup()
+  })
+
+  it('routes all board SSE wire variants through the board refresh budget', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+
+    for (const type of ['board_post', 'masc/board_comment', 'board_delete'] as const) {
+      refreshBoard.mockClear()
+      sseStore.routeServerPushEvent({
+        type,
+        post_id: 'post-1',
+      })
+      vi.advanceTimersByTime(1_000)
+      await flushAsyncWork()
+      expect(refreshBoard).toHaveBeenCalledTimes(1)
+    }
   })
 
   it('routes websocket raw push events through the same route-scoped refresh budget', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -12,6 +12,7 @@ import {
   lastDisconnectedAt,
   pauseQueuedOasRuntimeIngress,
   resumeQueuedOasRuntimeIngress,
+  normalizeSSEDispatchType,
 } from './sse'
 import type {
   BoardPost,
@@ -21,6 +22,7 @@ import type {
   DashboardShellResponse,
   SSEEvent,
 } from './types'
+import type * as TransportHealth from './components/transport-health'
 import {
   keeperHeartbeats,
   invalidateDashboardCache,
@@ -133,17 +135,21 @@ interface SimpleRoute {
 // removed after cross-referencing the OCaml sources under lib/.
 const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   // Agent lifecycle — emitted by lib/mcp_tool_runtime_workspace.ml
-  'masc/agent_bound':  { target: 'execution' },
-  'masc/agent_unbound':    { target: 'execution' },
+  agent_bound:         { target: 'execution' },
+  agent_unbound:       { target: 'execution' },
   // Broadcasts — emitted by lib/mcp_tool_runtime_comm.ml
-  'masc/broadcast':     { target: 'execution' },
+  broadcast:           { target: 'execution' },
   // Keeper lifecycle (also triggers operator refresh via handler)
   keeper_handoff:       { target: 'execution' },
   keeper_compaction:    { target: 'execution' },
+  keeper_guardrail:     { target: 'execution' },
   keeper_phase_changed: { target: 'execution' },
   // Board content — emitted by lib/mcp_tool_runtime_board.ml
+  board_post:          { target: 'board' },
   'masc/board_post':    { target: 'board' },
   board_comment:        { target: 'board' },
+  'masc/board_comment': { target: 'board' },
+  board_delete:         { target: 'board' },
   'masc/board_delete':  { target: 'board' },
   // Board notifications — emitted by lib/server/server_bootstrap_loops.ml
   // via JSON-RPC method="notifications/board" (unwrapped to params.type)
@@ -157,7 +163,9 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
 }
 
 const BOARD_HEARTH_REFRESH_EVENTS = new Set([
+  'board_post',
   'masc/board_post',
+  'board_delete',
   'masc/board_delete',
   'post_created',
 ])
@@ -198,7 +206,8 @@ function scheduleBoardHearthsRefresh(delayMs = SSE_DEFAULT_DEBOUNCE_MS): void {
 // --- Named handlers for complex events ---
 
 const KEEPER_LIFECYCLE_EVENTS = new Set([
-  'keeper_handoff', 'keeper_compaction', 'keeper_turn_complete', 'keeper_phase_changed',
+  'keeper_handoff', 'keeper_compaction', 'keeper_turn_complete', 'keeper_guardrail',
+  'keeper_phase_changed',
 ])
 
 function normalizeMascEventType(type: string): string {
@@ -254,7 +263,7 @@ function handleOperatorDigest(payload: unknown): void {
 //      per session, not on every SSE tick.
 //   2. Promote the failure log to console.warn so operators see it
 //      when investigating "transport health widget is missing/stale."
-let transportHealthModule: Promise<typeof import('./components/transport-health')> | null = null
+let transportHealthModule: Promise<typeof TransportHealth> | null = null
 let transportHealthImportFailed = false
 
 function handleTransportHealth(payload: unknown): void {
@@ -437,26 +446,27 @@ export function routeServerPushEvent(event: SSEEvent): void {
     return
   }
 
-  const simpleRoute = SIMPLE_ROUTES[event.type]
+  const routedType = normalizeSSEDispatchType(event.type)
+  const simpleRoute = SIMPLE_ROUTES[routedType]
   if (simpleRoute) {
     scheduleTargetRefresh(
       simpleRoute.target,
       REFRESH_FNS[simpleRoute.target],
       simpleRoute.debounceMs,
     )
-    if (BOARD_HEARTH_REFRESH_EVENTS.has(event.type)) {
+    if (BOARD_HEARTH_REFRESH_EVENTS.has(routedType)) {
       scheduleBoardHearthsRefresh(simpleRoute.debounceMs)
     }
   }
 
   for (const { prefix, target } of PREFIX_ROUTES) {
-    if (event.type.startsWith(prefix)) {
+    if (routedType.startsWith(prefix)) {
       scheduleTargetRefresh(target, REFRESH_FNS[target])
       break
     }
   }
 
-  if (KEEPER_LIFECYCLE_EVENTS.has(normalizeMascEventType(event.type))) {
+  if (KEEPER_LIFECYCLE_EVENTS.has(normalizeMascEventType(routedType))) {
     handleKeeperLifecycle(event)
   }
 

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -4,8 +4,11 @@ import type { BoardActorIdentity, BoardPost } from './core'
 
 export type SSEEventType =
   | 'agent_bound'
+  | 'masc/agent_bound'
   | 'agent_unbound'
+  | 'masc/agent_unbound'
   | 'broadcast'
+  | 'masc/broadcast'
   | 'task_update'
   | 'board_post'
   | 'masc/board_post'


### PR DESCRIPTION
## Summary
- accept MASC SSE wire aliases for broadcast/session lifecycle events instead of dropping them at the dashboard schema boundary
- normalize SSE route keys before route-scoped refresh so board, execution, and keeper lifecycle aliases hit the same refresh paths
- refresh keeper tool-call inspector and telemetry panels from live keeper tool-call/skipped events, including keeper runtime alias matching

## Verification
- pnpm exec vitest run --config vitest.config.ts src/schemas/sse.test.ts src/sse-store.test.ts src/components/keeper-sse-match.test.ts
- pnpm exec eslint src/schemas/sse.ts src/schemas/sse.test.ts src/types/sse.ts src/sse-store.ts src/sse-store.test.ts src/components/keeper-sse-match.ts src/components/keeper-sse-match.test.ts src/components/keeper-tool-call-inspector.ts src/components/keeper-tool-telemetry.ts
- pnpm exec tsc --noEmit --pretty false