### PR TITLE
fix(tool-schema): list valid phases in masc_goal_list description

### DIFF
--- a/lib/tool_schemas/tool_schemas_workspace_extra.ml
+++ b/lib/tool_schemas/tool_schemas_workspace_extra.ml
@@ -75,6 +75,7 @@ let schemas : tool_schema list =
       name = "masc_goal_list";
       description =
         "List shared planning goals from the Goal Store, optionally filtered by horizon or explicit phase. \
+Valid phases: executing, awaiting_verification, awaiting_approval, blocked, paused, completed, dropped. \
 Use when a PM/planner agent needs current long/mid/short goals before creating tasks or reviews. \
 The dashboard Goal Tree reads the same store. Goal-task links are managed externally. \
 The response includes each goal's explicit lifecycle phase and verification policy.";


### PR DESCRIPTION
Keeper albini sent phase=stuck to masc_goal_list — stuck is a board status, not a goal phase. The tool description did not list valid phases so the LLM guessed. Add valid phases inline: executing, awaiting_verification, awaiting_approval, blocked, paused, completed, dropped. 1-line change, no logic change.