### PR TITLE
feat(dashboard): support and render structured SurfaceRef for chat message sources

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -79,6 +79,26 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out?.external_message_id).toBe('1498985300729172039')
   })
 
+  it('passes surface ref fields through when present', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        source: 'discord',
+        surface: {
+          kind: 'discord',
+          guild_id: 'guild-1',
+          channel_id: 'channel-1',
+          thread_id: 'thread-1',
+        },
+      }),
+    )
+    expect(out?.surface).toEqual({
+      kind: 'discord',
+      guild_id: 'guild-1',
+      channel_id: 'channel-1',
+      thread_id: 'thread-1',
+    })
+  })
+
   it('accepts rows without speaker fields (legacy and non-user lines)', () => {
     const out = safeParseKeeperChatHistoryMessage(validMessage())
     expect(out).not.toBeNull()

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -20,10 +20,28 @@ import {
   number,
   object,
   optional,
+  record,
   safeParse,
   string,
   type InferOutput,
 } from 'valibot'
+
+export const SurfaceRefSchema = object({
+  kind: string(),
+  session_id: optional(string()),
+  guild_id: optional(string()),
+  channel_id: optional(string()),
+  parent_channel_id: optional(string()),
+  thread_id: optional(string()),
+  team_id: optional(string()),
+  thread_ts: optional(string()),
+  repo: optional(string()),
+  notification_id: optional(string()),
+  source: optional(string()),
+  event_id: optional(string()),
+  label: optional(string()),
+  address: optional(record(string(), string())),
+})
 
 export const KeeperChatHistoryMessageSchema = object({
   role: string(),
@@ -39,6 +57,7 @@ export const KeeperChatHistoryMessageSchema = object({
   tool_call_id: optional(string()),
   tool_call_name: optional(string()),
   source: optional(string()),
+  surface: optional(SurfaceRefSchema),
   conversation_id: optional(string()),
   external_message_id: optional(string()),
   // RFC-0223 P1 speaker identity, present on user rows written since

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -7,7 +7,63 @@ import { ActionButton } from '../common/button'
 import { formatTimeHms } from '../../lib/format-time'
 import { formatCost } from '../../lib/format-number'
 import { isSubmitEnter } from '../../lib/keyboard'
-import type { KeeperConversationAttachment, KeeperConversationDetails, KeeperConversationEntry } from '../../types'
+import type { KeeperConversationAttachment, KeeperConversationDetails, KeeperConversationEntry, SurfaceRef } from '../../types'
+
+function surfaceLink(surface?: SurfaceRef | null): { url: string; label: string; icon: string } | null {
+  if (!surface || !surface.kind) return null
+  switch (surface.kind) {
+    case 'discord':
+      if (surface.channel_id) {
+        const targetId = surface.thread_id || surface.channel_id
+        const guild = surface.guild_id || '@me'
+        return {
+          url: `https://discord.com/channels/${guild}/${targetId}`,
+          label: surface.thread_id ? 'Discord Thread' : 'Discord Channel',
+          icon: '🎮',
+        }
+      }
+      break
+    case 'slack':
+      if (surface.channel_id) {
+        const team = surface.team_id ? `&team=${surface.team_id}` : ''
+        return {
+          url: `https://slack.com/app_redirect?channel=${surface.channel_id}${team}`,
+          label: 'Slack Channel',
+          icon: '💬',
+        }
+      }
+      break
+    case 'github':
+      if (surface.repo) {
+        const path = surface.notification_id ? `/notifications/${surface.notification_id}` : ''
+        return {
+          url: `https://github.com/${surface.repo}${path}`,
+          label: `GitHub: ${surface.repo}`,
+          icon: '🐙',
+        }
+      }
+      break
+    case 'dashboard':
+      return {
+        url: '#',
+        label: 'Dashboard',
+        icon: '💻',
+      }
+    case 'agent':
+      return {
+        url: '#',
+        label: 'Agent (Self)',
+        icon: '🤖',
+      }
+    case 'gate':
+      return {
+        url: '#',
+        label: `Gate: ${surface.label || 'connector'}`,
+        icon: '⚡',
+      }
+  }
+  return null
+}
 
 type ChatTranscriptVariant = 'default' | 'messenger'
 type ChatTranscriptSize = 'default' | 'primary'
@@ -240,6 +296,7 @@ function ChatMessageBubble({
   const delivery = deliveryLabel(entry)
   const timestamp = timeLabel(entry.timestamp)
   const attachments = entry.attachments ?? []
+  const surfaceInfo = surfaceLink(entry.surface)
 
   return html`
     <article
@@ -279,6 +336,30 @@ function ChatMessageBubble({
                           </span>
                         `
                       : null}
+                    ${surfaceInfo && surfaceInfo.url !== '#'
+                      ? html`
+                          <a
+                            href=${surfaceInfo.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 text-3xs font-medium text-[var(--color-accent-fg)] hover:bg-[var(--accent-20)]"
+                            title=${surfaceInfo.label}
+                          >
+                            <span>${surfaceInfo.icon}</span>
+                            <span>${surfaceInfo.label}</span>
+                          </a>
+                        `
+                      : surfaceInfo
+                      ? html`
+                          <span
+                            class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs font-medium text-[var(--color-fg-muted)]"
+                            title=${surfaceInfo.label}
+                          >
+                            <span>${surfaceInfo.icon}</span>
+                            <span>${surfaceInfo.label}</span>
+                          </span>
+                        `
+                      : null}
                   </div>
                 `
               : html`
@@ -302,6 +383,30 @@ function ChatMessageBubble({
                       ? html`
                           <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-2.5 py-1 text-3xs font-medium tabular-nums text-[var(--color-fg-muted)]">
                             ${timestamp}
+                          </span>
+                        `
+                      : null}
+                    ${surfaceInfo && surfaceInfo.url !== '#'
+                      ? html`
+                          <a
+                            href=${surfaceInfo.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2.5 py-1 text-3xs font-medium text-[var(--color-accent-fg)] hover:bg-[var(--accent-20)]"
+                            title=${surfaceInfo.label}
+                          >
+                            <span>${surfaceInfo.icon}</span>
+                            <span>${surfaceInfo.label}</span>
+                          </a>
+                        `
+                      : surfaceInfo
+                      ? html`
+                          <span
+                            class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-2.5 py-1 text-3xs font-medium text-[var(--color-fg-muted)]"
+                            title=${surfaceInfo.label}
+                          >
+                            <span>${surfaceInfo.icon}</span>
+                            <span>${surfaceInfo.label}</span>
                           </span>
                         `
                       : null}

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -11,6 +11,7 @@ import type {
   KeeperProbeResult,
   KeeperRecoverResult,
   KeeperStatusDetail,
+  SurfaceRef,
 } from './types'
 
 // --- Signals ---
@@ -230,6 +231,7 @@ function normalizeHistoryEntry(
   if (!text) return null
   const timestamp = toIsoTimestamp(raw.ts_unix) ?? toIsoTimestamp(raw.timestamp)
   const label = role === 'assistant' && keeperName ? keeperName : roleLabel(role)
+  const surface = isRecord(raw.surface) ? (raw.surface as unknown as SurfaceRef) : null
   return {
     id: `${role}-${timestamp ?? 'entry'}-${index}`,
     role,
@@ -241,6 +243,7 @@ function normalizeHistoryEntry(
     delivery: 'history',
     streamState: null,
     details: null,
+    surface,
   }
 }
 
@@ -394,6 +397,7 @@ interface RestChatHistoryMessage {
   tool_call_id?: string
   tool_call_name?: string
   source?: string
+  surface?: SurfaceRef
 }
 
 /** Convert a persisted tool-call row into the same entry shape the live
@@ -416,6 +420,7 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
     delivery: 'history',
     streamState: null,
     details: null,
+    surface: message.surface ?? null,
   }
 }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -743,6 +743,23 @@ export type KeeperConversationStreamState =
   | 'finalizing'
   | null
 
+export interface SurfaceRef {
+  kind: 'dashboard' | 'discord' | 'slack' | 'github' | 'webhook' | 'agent' | 'gate' | string
+  session_id?: string
+  guild_id?: string
+  channel_id?: string
+  parent_channel_id?: string
+  thread_id?: string
+  team_id?: string
+  thread_ts?: string
+  repo?: string
+  notification_id?: string
+  source?: string
+  event_id?: string
+  label?: string
+  address?: Record<string, string>
+}
+
 export interface KeeperConversationEntry {
   id: string
   role: KeeperConversationRole
@@ -756,6 +773,7 @@ export interface KeeperConversationEntry {
   attachments?: KeeperConversationAttachment[]
   details?: KeeperConversationDetails | null
   error?: string | null
+  surface?: SurfaceRef | null
 }
 
 export interface KeeperStatusDetail {


### PR DESCRIPTION
This PR introduces support for structured SurfaceRef in the dashboard chat message schema and renders direct links for external integration platforms like Discord, Slack, and GitHub in the ChatMessageBubble header. Fixes part of RFC-0232 P5.