### PR TITLE
fix(goal): persist task links

### DIFF
--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -70,7 +70,7 @@ let build_forest ~(config : Workspace.config) ~goals ~tasks =
     |> List.map (fun (meta : Keeper_meta_contract.keeper_meta) -> meta.name)
     |> Keeper_execution_receipt.latest_json_by_keeper config
   in
-  let goal_task_index = Workspace_goal_index.build_task_goal_index () in
+  let goal_task_index = Workspace_goal_index.build_task_goal_index_for_config config in
   let context =
     {
       now_ts = Time_compat.now ();

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -101,7 +101,7 @@ let resolve_claim_goal_scope ~(config : Workspace.config) ~(meta : keeper_meta) 
   | [] -> meta_only_claim_goal_scope meta
   | goal_ids ->
     let tasks = Workspace.get_tasks_safe config in
-    let task_goal_index = Workspace_goal_index.build_task_goal_index () in
+    let task_goal_index = Workspace_goal_index.build_task_goal_index_for_config config in
     let scoped_claimable_exists =
       List.exists (fun task ->
              task_is_unclaimed_todo task
@@ -156,9 +156,15 @@ let goal_progress_json ?config (meta : keeper_meta) =
           ("convergence", `Null);
         ]
   | Some config ->
+      let task_goal_index =
+        Workspace_goal_index.build_task_goal_index_for_config config
+      in
       let tasks =
         Workspace.get_tasks_safe config
-        |> List.filter (task_is_linked_to_keeper_goals meta.active_goal_ids)
+        |> List.filter
+             (task_is_linked_to_keeper_goals
+                ~task_goal_index
+                meta.active_goal_ids)
       in
       let linked_task_count = List.length tasks in
       let done_task_count =

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -272,7 +272,7 @@ let wip_admission_result_fields rejections =
 ;;
 
 let find_task_goal_id config task_id =
-  let index = Workspace_goal_index.build_task_goal_index () in
+  let index = Workspace_goal_index.build_task_goal_index_for_config config in
   try Some (List.hd (Hashtbl.find index task_id)) with Not_found -> None
 ;;
 
@@ -501,7 +501,7 @@ let handle_keeper_task_tool
            | Ok contract ->
               let capacity_error =
                 let backlog = Workspace.read_backlog config in
-                Workspace_task_capacity.check ?goal_id backlog
+                Workspace_task_capacity.check_for_config config ?goal_id backlog
               in
               (match capacity_error with
                | Some error -> Workspace_task_capacity.error_to_json_string error
@@ -510,7 +510,10 @@ let handle_keeper_task_tool
                 Workspace_task.add_task
                   ?contract
                   ?goal_id
-                  ~reject_if:(Workspace_task_capacity.rejection_for_add_task ?goal_id)
+                  ~reject_if:
+                    (Workspace_task_capacity.rejection_for_add_task_for_config
+                       config
+                       ?goal_id)
                   config
                   ~title
                   ~priority
@@ -531,12 +534,12 @@ let handle_keeper_task_tool
     in
     let wip_default_repo = wip_admission_default_repo config in
     let wip_rejections = ref [] in
+    let task_goal_index = Workspace_goal_index.build_task_goal_index_for_config config in
     let remember_wip_rejection task_id rejection =
       if not (List.exists (fun (existing_id, _) -> String.equal existing_id task_id) !wip_rejections)
       then wip_rejections := (task_id, rejection) :: !wip_rejections
     in
     let wip_admission_filter ~active_tasks task =
-      let task_goal_index = Workspace_goal_index.build_task_goal_index () in
       let active_items =
         Keeper_wip_admission.active_items_of_tasks
           ~task_goal_index

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -311,7 +311,11 @@ let handle_add_task ~tool_name ~start_time ctx args =
     | Ok contract ->
         Tool_result.ok ~tool_name ~start_time
           (Workspace.add_task ?contract
-            ~reject_if:(Workspace_task_capacity.rejection_for_add_task ?goal_id)
+            ?goal_id
+            ~reject_if:
+              (Workspace_task_capacity.rejection_for_add_task_for_config
+                 ctx.config
+                 ?goal_id)
             ~created_by:ctx.agent_name ctx.config ~title:trimmed_title
             ~priority ~description)
 

--- a/lib/workspace/workspace_goal_index.ml
+++ b/lib/workspace/workspace_goal_index.ml
@@ -5,10 +5,162 @@
     (workspace_task_capacity.ml) by building a Hashtbl-based reverse
     index on demand from explicit goal-task link mappings.
 
-    The index is ephemeral (not persisted): rebuild from the current
-    task list and external link registry each time it is needed. *)
+    The index is rebuilt from the current task list and a small persistent
+    goal-task link registry. *)
 
 open Masc_domain
+open Workspace_utils
+
+let goal_task_links_path config =
+  Filename.concat (tasks_dir config) "goal_task_links.json"
+;;
+
+let goal_task_links_recovery_path config =
+  goal_task_links_path config ^ ".last-good"
+;;
+
+let normalize_link_set links =
+  let tbl = Hashtbl.create 16 in
+  List.iter
+    (fun (goal_id, task_ids) ->
+       let goal_id = String.trim goal_id in
+       if not (String.equal goal_id "") then (
+         let existing = try Hashtbl.find tbl goal_id with Not_found -> [] in
+         let merged =
+           List.fold_left
+             (fun acc task_id ->
+                let task_id = String.trim task_id in
+                if String.equal task_id "" || List.mem task_id acc then acc
+                else task_id :: acc)
+             existing
+             task_ids
+         in
+         Hashtbl.replace tbl goal_id merged))
+    links;
+  Hashtbl.fold
+    (fun goal_id task_ids acc -> (goal_id, List.rev task_ids) :: acc)
+    tbl
+    []
+  |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+;;
+
+let link_to_yojson (goal_id, task_ids) =
+  `Assoc
+    [ "goal_id", `String goal_id
+    ; "task_ids", `List (List.map (fun task_id -> `String task_id) task_ids)
+    ]
+;;
+
+let links_to_yojson links =
+  `Assoc
+    [ "version", `Int 1
+    ; "last_updated", `String (now_iso ())
+    ; "links", `List (List.map link_to_yojson (normalize_link_set links))
+    ]
+;;
+
+let link_of_yojson = function
+  | `Assoc fields ->
+    let goal_id =
+      match List.assoc_opt "goal_id" fields with
+      | Some (`String value) -> String.trim value
+      | _ -> ""
+    in
+    let task_ids =
+      match List.assoc_opt "task_ids" fields with
+      | Some (`List values) ->
+        List.filter_map
+          (function
+            | `String value ->
+              let value = String.trim value in
+              if String.equal value "" then None else Some value
+            | _ -> None)
+          values
+      | _ -> []
+    in
+    if String.equal goal_id "" then None else Some (goal_id, task_ids)
+  | _ -> None
+;;
+
+let links_of_yojson = function
+  | `Assoc fields ->
+    (match List.assoc_opt "links" fields with
+     | Some (`List values) -> normalize_link_set (List.filter_map link_of_yojson values)
+     | _ -> [])
+  | _ -> []
+;;
+
+let read_goal_task_links_r config =
+  let primary_path = goal_task_links_path config in
+  match read_json_result config primary_path with
+  | Ok json -> Ok (links_of_yojson json)
+  | Error primary_msg ->
+    let recovery_path = goal_task_links_recovery_path config in
+    (match read_json_result config recovery_path with
+     | Ok json ->
+       Log.Misc.warn
+         "read_goal_task_links: primary unreadable, recovered from %s (%s)"
+         recovery_path
+         primary_msg;
+       Ok (links_of_yojson json)
+     | Error recovery_msg ->
+       if not (path_exists config primary_path) then Ok []
+       else
+         Error
+           (Printf.sprintf
+              "%s; recovery read failed for %s: %s"
+              primary_msg
+              recovery_path
+              recovery_msg))
+;;
+
+let read_goal_task_links config =
+  match read_goal_task_links_r config with
+  | Ok links -> links
+  | Error msg ->
+    Log.Misc.warn "read_goal_task_links failed: %s" msg;
+    []
+;;
+
+let write_goal_task_links config links =
+  let json = links_to_yojson links in
+  write_json config (goal_task_links_path config) json;
+  write_json config (goal_task_links_recovery_path config) json
+;;
+
+let link_task_to_goal config ~goal_id ~task_id =
+  let goal_id = String.trim goal_id in
+  let task_id = String.trim task_id in
+  if String.equal goal_id "" || String.equal task_id "" then ()
+  else
+    let lock_path = Filename.concat (tasks_dir config) ".goal-task-links" in
+    with_file_lock config lock_path (fun () ->
+      let links = read_goal_task_links config in
+      let links =
+        let updated = ref false in
+        let links =
+          List.map
+            (fun (candidate_goal_id, task_ids) ->
+               if String.equal candidate_goal_id goal_id then (
+                 updated := true;
+                 if List.mem task_id task_ids then candidate_goal_id, task_ids
+                 else candidate_goal_id, task_ids @ [ task_id ])
+               else candidate_goal_id, task_ids)
+            links
+        in
+        if !updated then links else links @ [ goal_id, [ task_id ] ]
+      in
+      write_goal_task_links config links)
+;;
+
+let link_tasks_to_goals config links =
+  List.iter
+    (fun (task_id, goal_id_opt) ->
+       match goal_id_opt with
+       | None -> ()
+       | Some goal_id -> link_task_to_goal config ~goal_id ~task_id)
+    links
+;;
 
 (** Build a reverse index from goal_id to its linked tasks.
 
@@ -82,4 +234,12 @@ let build_task_goal_index
          task_ids)
     goal_task_links;
   tbl
+;;
+
+let build_goal_task_index_for_config config tasks =
+  build_goal_task_index tasks ~goal_task_links:(read_goal_task_links config)
+;;
+
+let build_task_goal_index_for_config config =
+  build_task_goal_index ~goal_task_links:(read_goal_task_links config) ()
 ;;

--- a/lib/workspace/workspace_goal_index.mli
+++ b/lib/workspace/workspace_goal_index.mli
@@ -39,3 +39,36 @@ val build_task_goal_index
   :  ?goal_task_links:(string * string list) list
   -> unit
   -> (string, string list) Hashtbl.t
+
+(** Path to the persistent goal-task link registry. *)
+val goal_task_links_path : Workspace_utils_backend_setup.config -> string
+
+(** Read the persistent goal-task link registry. Missing registry files are
+    treated as an empty link set. *)
+val read_goal_task_links :
+  Workspace_utils_backend_setup.config -> (string * string list) list
+
+val read_goal_task_links_r :
+  Workspace_utils_backend_setup.config ->
+  ((string * string list) list, string) result
+
+(** Persist the goal-task link registry. *)
+val write_goal_task_links :
+  Workspace_utils_backend_setup.config -> (string * string list) list -> unit
+
+(** Add one task-to-goal link to the persistent registry. *)
+val link_task_to_goal :
+  Workspace_utils_backend_setup.config -> goal_id:string -> task_id:string -> unit
+
+(** Add multiple task-to-goal links to the persistent registry. *)
+val link_tasks_to_goals :
+  Workspace_utils_backend_setup.config -> (string * string option) list -> unit
+
+(** Build indexes using the persistent link registry for [config]. *)
+val build_goal_task_index_for_config :
+  Workspace_utils_backend_setup.config ->
+  Masc_domain.task list ->
+  (string, Masc_domain.task list) Hashtbl.t
+
+val build_task_goal_index_for_config :
+  Workspace_utils_backend_setup.config -> (string, string list) Hashtbl.t

--- a/lib/workspace/workspace_task_capacity.ml
+++ b/lib/workspace/workspace_task_capacity.ml
@@ -60,6 +60,10 @@ let check ?goal_id ?(goal_task_links = []) (backlog : Masc_domain.backlog) =
       Some { goal_id; open_task_count; limit; message }
 ;;
 
+let check_for_config config ?goal_id backlog =
+  check ?goal_id ~goal_task_links:(Workspace_goal_index.read_goal_task_links config) backlog
+;;
+
 (* Field order matches the pre-RFC-0034.v2 shape produced by
    [Keeper_tool_shared_runtime.error_json ~fields message], which prepends
    ("error", message) before the supplied [fields]. Preserved verbatim
@@ -82,4 +86,8 @@ let error_to_json_string error =
 
 let rejection_for_add_task ?goal_id backlog =
   check ?goal_id backlog |> Option.map (fun err -> err.message)
+;;
+
+let rejection_for_add_task_for_config config ?goal_id backlog =
+  check_for_config config ?goal_id backlog |> Option.map (fun err -> err.message)
 ;;

--- a/lib/workspace/workspace_task_capacity.mli
+++ b/lib/workspace/workspace_task_capacity.mli
@@ -30,6 +30,14 @@ val default_goal_open_limit : int
     tasks bypass the per-goal cap. *)
 val check : ?goal_id:string -> ?goal_task_links:(string * string list) list -> Masc_domain.backlog -> capacity_error option
 
+(** Same as [check], reading the persistent goal-task link registry from
+    [config]. *)
+val check_for_config :
+  Workspace_utils_backend_setup.config ->
+  ?goal_id:string ->
+  Masc_domain.backlog ->
+  capacity_error option
+
 (** [error_to_json_string err] serializes to the same JSON-string shape
     that the pre-RFC-0034.v2 keeper task runtime helper produced
     (key order: ok, error_kind, goal_id,
@@ -41,3 +49,11 @@ val error_to_json_string : capacity_error -> string
     callback passed to [Workspace_task.add_task]: returns [None] on success
     or [Some message] when the cap would be exceeded. *)
 val rejection_for_add_task : ?goal_id:string -> Masc_domain.backlog -> string option
+
+(** Same as [rejection_for_add_task], reading the persistent goal-task link
+    registry from [config]. *)
+val rejection_for_add_task_for_config :
+  Workspace_utils_backend_setup.config ->
+  ?goal_id:string ->
+  Masc_domain.backlog ->
+  string option

--- a/lib/workspace/workspace_task_create.ml
+++ b/lib/workspace/workspace_task_create.ml
@@ -113,6 +113,10 @@ let add_task
              }
            in
            write_backlog config new_backlog;
+           Option.iter
+             (fun goal_id ->
+                Workspace_goal_index.link_task_to_goal config ~goal_id ~task_id)
+             goal_id;
            let created_by_json = Json_util.string_opt_to_json created_by in
            Workspace_task_classify.emit_task_activity
              config
@@ -196,6 +200,11 @@ let batch_add_tasks_internal ?created_by config tasks =
            }
          in
          write_backlog config new_backlog;
+         Workspace_goal_index.link_tasks_to_goals
+           config
+           (List.map
+              (fun ((task : Masc_domain.task), goal_id) -> task.id, goal_id)
+              added_tasks_with_goal_ids);
          List.iter
            (fun ((task : Masc_domain.task), goal_id) ->
               let created_by_json = Json_util.string_opt_to_json task.created_by in

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -314,9 +314,9 @@ let validate_goal_completion_ready config ~goal_id ~override_note =
   | Some note when not (String.equal (String.trim note) "") -> Ok ()
   | _ ->
     let index =
-      Workspace_goal_index.build_goal_task_index
+      Workspace_goal_index.build_goal_task_index_for_config
+        config
         (Workspace_query.get_tasks_safe config)
-        ~goal_task_links:[]
     in
     let linked_tasks =
       Workspace_goal_index.tasks_for_goal index ~goal_id

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -2248,8 +2248,8 @@ let () = test "rfc_0034_v2_operator_task_inject_orphan_bypasses_cap" (fun () ->
          result))
 
 (* RFC-0034.v2 unit-level: capacity check helper on a goal-bound
-   backlog. Pins the [check] / [rejection_for_add_task] semantics that
-   all 4 entrypoints inherit. *)
+   backlog. Pins the config-aware registry path used by task creation
+   entrypoints. *)
 let () = test "rfc_0034_v2_capacity_check_returns_some_at_limit" (fun () ->
   let ctx = make_test_ctx () in
   let goal, _ =
@@ -2271,7 +2271,7 @@ let () = test "rfc_0034_v2_capacity_check_returns_some_at_limit" (fun () ->
    | None -> ()
    | Some _ ->
        failwith "orphan check (goal_id=None) should be a no-op");
-  (match Workspace_task_capacity.check ~goal_id:goal.id backlog with
+  (match Workspace_task_capacity.check_for_config ctx.config ~goal_id:goal.id backlog with
    | Some err ->
        assert (err.open_task_count = 3);
        assert (err.limit = Workspace_task_capacity.default_goal_open_limit);

--- a/test/test_workspace_goal_index.ml
+++ b/test/test_workspace_goal_index.ml
@@ -8,6 +8,33 @@
     [goal_task_links] mappings. *)
 
 open Masc_domain
+open Masc
+
+let with_test_env f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let tmp_dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc_goal_index_%d_%d"
+         (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1000.)))
+  in
+  Unix.mkdir tmp_dir 0o755;
+  let config = Workspace.default_config tmp_dir in
+  let _ = Workspace.init config ~agent_name:(Some "agent_llm_a") in
+  try
+    f config;
+    let _ = Workspace.reset config in
+    Unix.rmdir tmp_dir
+  with
+  | e ->
+    let _ = Workspace.reset config in
+    Unix.rmdir tmp_dir;
+    raise e
+;;
 
 let make_task ~id ~status =
   { id
@@ -142,6 +169,43 @@ let test_open_count_all_terminal () =
   check_int "all terminal -> 0 open tasks" 0 count
 ;;
 
+(* ── persistent goal-task registry ──────────────────────────────────── *)
+
+let test_add_task_persists_goal_link () =
+  with_test_env (fun config ->
+    let result =
+      Workspace.add_task
+        ~goal_id:"goal-a"
+        config
+        ~title:"linked task"
+        ~priority:1
+        ~description:""
+    in
+    check_bool "add_task succeeds" true (String.starts_with ~prefix:"Added task-001" result);
+    let links = Workspace_goal_index.read_goal_task_links config in
+    check_bool
+      "registry records goal link"
+      true
+      (List.exists
+         (fun (goal_id, task_ids) ->
+            String.equal goal_id "goal-a" && List.mem "task-001" task_ids)
+         links);
+    let tasks = Workspace.get_tasks_safe config in
+    let index = Workspace_goal_index.build_goal_task_index_for_config config tasks in
+    check_list_len
+      "config-aware index sees linked task"
+      1
+      (Workspace_goal_index.tasks_for_goal index ~goal_id:"goal-a");
+    let task_goal_index =
+      Workspace_goal_index.build_task_goal_index_for_config config
+    in
+    check_bool
+      "reverse index sees linked goal"
+      true
+      (try List.mem "goal-a" (Hashtbl.find task_goal_index "task-001") with
+       | Not_found -> false))
+;;
+
 (* ── test suite ─────────────────────────────────────────────────────── *)
 
 let () =
@@ -158,5 +222,12 @@ let () =
                  ; test_case "empty index has 0" `Quick test_open_count_empty
                  ; test_case "all terminal has 0" `Quick test_open_count_all_terminal
                  ] )
+    ; ( "persistent registry"
+      , Alcotest.
+          [ test_case
+              "add_task persists explicit goal link"
+              `Quick
+              test_add_task_persists_goal_link
+          ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- persist explicit goal_id links from task creation into a goal_task_links registry
- make dashboard, keeper claim scope, WIP admission, capacity checks, and goal completion gates read the persistent registry
- pass goal_id through public masc_add_task into Workspace.add_task instead of only using it for validation/capacity

Fixes #21052.

## Evidence
- scripts/dune-local.sh build test/test_workspace_goal_index.exe test/test_tool_task_coverage.exe test/test_goal_tools.exe: passed before rebase
- ./_build/default/test/test_workspace_goal_index.exe: passed, 9 tests
- ./_build/default/test/test_goal_tools.exe: passed, 17 tests
- ./_build/default/test/test_tool_task_coverage.exe: relevant goal/capacity tests passed after fix; full suite still has two unrelated claim-dispatch failures (coverage 7, 35)
- post-rebase git diff --check: passed

## Notes
Post-rebase focused rebuild was blocked by another long-running Dune lock holder from a different worktree, so this is draft and should rely on CI for final full validation.