### PR TITLE
[codex] Improve keeper context compaction summaries

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -101,7 +101,7 @@ let summarize_chunk (msgs : Agent_sdk.Types.message list) : Agent_sdk.Types.mess
       Agent_sdk.Types.role = Agent_sdk.Types.Assistant;
       content = [
         Agent_sdk.Types.Text
-          (Printf.sprintf "[Compacted %d messages into summary]\n%s"
+          (Printf.sprintf "[MEMORY_SUMMARY] Compacted %d older messages\n%s"
              (List.length msgs) (String.concat "\n" lines))
       ];
       name = None;

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -189,6 +189,11 @@ let compaction_policy_of_keeper (meta : keeper_meta) : float * int * int =
   meta.compaction.ratio_gate, meta.compaction.message_gate, meta.compaction.token_gate
 ;;
 
+let checkpoint_compaction_strategies () =
+  Context_compact_oas.
+    [ PruneToolOutputs; MergeContiguous; SummarizeOld; DropLowImportance ]
+;;
+
 let compact_if_needed_typed
       ~(meta : keeper_meta)
       ~(now_ts : float)
@@ -220,10 +225,7 @@ let compact_if_needed_typed
     ctx, None, decision
   | Applied trigger ->
     (* PreCompact observability: log strategy and context state (#3165) *)
-    let strategies =
-      Context_compact_oas.
-        [ PruneToolOutputs; MergeContiguous; SummarizeOld; DropLowImportance ]
-    in
+    let strategies = checkpoint_compaction_strategies () in
     (* Use OAS stub_tool_results instead of MASC's FoldCompleted —
          OAS owns context reduction, MASC is a consumer. *)
     (* V12: per-keeper config replaces the prior hardcoded

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -221,7 +221,8 @@ let compact_if_needed_typed
   | Applied trigger ->
     (* PreCompact observability: log strategy and context state (#3165) *)
     let strategies =
-      Context_compact_oas.[ PruneToolOutputs; MergeContiguous; DropLowImportance ]
+      Context_compact_oas.
+        [ PruneToolOutputs; MergeContiguous; SummarizeOld; DropLowImportance ]
     in
     (* Use OAS stub_tool_results instead of MASC's FoldCompleted —
          OAS owns context reduction, MASC is a consumer. *)

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -49,6 +49,10 @@ val decide_compaction
     tuple. *)
 val compaction_policy_of_keeper : Keeper_meta_contract.keeper_meta -> float * int * int
 
+(** OAS strategy chain used by checkpoint compaction before the
+    keeper-private tool-result fold reducer. *)
+val checkpoint_compaction_strategies : unit -> Context_compact_oas.strategy list
+
 (** [compact_if_needed_typed ~meta ~now_ts ctx] evaluates the compaction
     gates and either returns [ctx] unchanged or applies the OAS
     strategy chain plus the keeper-private fold reducer.

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -13,6 +13,10 @@ module Scoring = Masc.Context_compact_oas
 let msg role text : Agent_sdk.Types.message =
   { role; content = [Types.Text text]; name = None; tool_call_id = None; metadata = [] }
 
+let starts_with ~prefix s =
+  let prefix_len = String.length prefix in
+  String.length s >= prefix_len && String.sub s 0 prefix_len = prefix
+
 let tool_msg ?(id = "tool-1") text : Agent_sdk.Types.message =
   { role = Types.Tool;
     content =
@@ -104,7 +108,17 @@ let test_compact_summarize_old () =
     ~messages:msgs
     ~strategies:[Compact.SummarizeOld] () in
   check bool "message count reduced" true
-    (List.length result < List.length msgs)
+    (List.length result < List.length msgs);
+  let summary_text = Agent_sdk.Types.text_of_message (List.hd result) in
+  check bool "summary uses sticky memory anchor" true
+    (starts_with ~prefix:"[MEMORY_SUMMARY]" summary_text);
+  let summary_score =
+    result
+    |> Scoring.score_messages
+    |> List.assoc 0
+  in
+  check bool "summary survives importance scoring" true
+    (summary_score >= 0.95)
 
 (* ================================================================ *)
 (* Shared Scoring Consistency Tests (C3)                            *)

--- a/test/test_keeper_compact_policy_pure.ml
+++ b/test/test_keeper_compact_policy_pure.ml
@@ -12,39 +12,15 @@ let check_string label expected actual =
 let check_bool label expected actual =
   Alcotest.(check bool) label expected actual
 
-let read_file path =
-  let ic = open_in path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () -> really_input_string ic (in_channel_length ic))
-
-let repo_root () =
-  let marker path = Filename.concat path "lib/keeper/keeper_compact_policy.ml" in
-  let has_marker path = Sys.file_exists (marker path) in
-  match Sys.getenv_opt "DUNE_SOURCEROOT" with
-  | Some root when has_marker root -> root
-  | _ ->
-    let rec ascend path =
-      if has_marker path
-      then path
-      else (
-        let parent = Filename.dirname path in
-        if String.equal parent path then path else ascend parent)
-    in
-    ascend (Sys.getcwd ())
-
 let test_checkpoint_compaction_uses_summarize_old () =
-  let root = repo_root () in
-  let source =
-    read_file (Filename.concat root "lib/keeper/keeper_compact_policy.ml")
+  let strategies =
+    KCP.checkpoint_compaction_strategies ()
+    |> List.map Context_compact_oas.strategy_name
   in
-  let required =
-    "[ PruneToolOutputs; MergeContiguous; SummarizeOld; DropLowImportance ]"
-  in
-  Alcotest.(check bool)
+  Alcotest.(check (list string))
     "checkpoint compaction summarizes old context before importance pruning"
-    true
-    (Astring.String.is_infix ~affix:required source)
+    [ "PruneToolOutputs"; "MergeContiguous"; "SummarizeOld"; "DropLowImportance" ]
+    strategies
 
 (* ── compaction_decision_to_string ───────────────────────────────────── *)
 

--- a/test/test_keeper_compact_policy_pure.ml
+++ b/test/test_keeper_compact_policy_pure.ml
@@ -12,6 +12,40 @@ let check_string label expected actual =
 let check_bool label expected actual =
   Alcotest.(check bool) label expected actual
 
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let repo_root () =
+  let marker path = Filename.concat path "lib/keeper/keeper_compact_policy.ml" in
+  let has_marker path = Sys.file_exists (marker path) in
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_marker root -> root
+  | _ ->
+    let rec ascend path =
+      if has_marker path
+      then path
+      else (
+        let parent = Filename.dirname path in
+        if String.equal parent path then path else ascend parent)
+    in
+    ascend (Sys.getcwd ())
+
+let test_checkpoint_compaction_uses_summarize_old () =
+  let root = repo_root () in
+  let source =
+    read_file (Filename.concat root "lib/keeper/keeper_compact_policy.ml")
+  in
+  let required =
+    "[ PruneToolOutputs; MergeContiguous; SummarizeOld; DropLowImportance ]"
+  in
+  Alcotest.(check bool)
+    "checkpoint compaction summarizes old context before importance pruning"
+    true
+    (Astring.String.is_infix ~affix:required source)
+
 (* ── compaction_decision_to_string ───────────────────────────────────── *)
 
 let test_to_string_applied () =
@@ -210,6 +244,11 @@ let () =
         [
           Alcotest.test_case "emergency threshold in (0,1]" `Quick
             test_emergency_threshold_in_range;
+        ] );
+      ( "strategies",
+        [
+          Alcotest.test_case "checkpoint compaction summarizes old context"
+            `Quick test_checkpoint_compaction_uses_summarize_old;
         ] );
       ( "decide_compaction",
         [


### PR DESCRIPTION
## Summary

- Add `SummarizeOld` to the MASC keeper checkpoint compaction strategy chain.
- Emit `SummarizeOld` summaries with the sticky `[MEMORY_SUMMARY]` anchor so later importance pruning preserves them.
- Add focused coverage for the summary anchor and keeper policy strategy chain.

## Why

Keeper checkpoint compaction was pruning and dropping context without first preserving older turn meaning as a summary. OAS already exposes the reducer support; the MASC policy simply was not using it in the checkpoint compaction path.

## Validation

- `scripts/dune-local.sh build test/test_context_compact_oas_coverage.exe test/test_keeper_compact_policy_pure.exe`
- `scripts/dune-local.sh exec test/test_context_compact_oas_coverage.exe`
- `scripts/dune-local.sh exec test/test_keeper_compact_policy_pure.exe`
- `ocamlformat --check lib/context_compact_oas.ml lib/keeper/keeper_compact_policy.ml test/test_context_compact_oas_coverage.ml test/test_keeper_compact_policy_pure.ml`
- `git diff --check`
