### PR TITLE
[codex] fix keeper runtime tool dispatch context

### DIFF
--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -84,6 +84,18 @@ let status_cache_key ~base_path ~name = base_path ^ ":" ^ name
 
 let normalize_status_name = String.trim
 
+let status_name_lookup_candidates raw_name =
+  let trimmed = normalize_status_name raw_name in
+  if String.equal trimmed "" then
+    []
+  else
+    let aliases =
+      match Keeper_identity.canonical_keeper_name trimmed with
+      | Some candidate when not (String.equal candidate trimmed) -> [ candidate ]
+      | Some _ | None -> []
+    in
+    trimmed :: aliases
+
 let docker_preflight_status_cache_key ~timeout_sec =
   String.concat "|"
     [
@@ -155,18 +167,26 @@ let apply_tail_order order items =
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let resolve_status_target_config ~(config : Workspace.config) ~(agent_name : string) args =
   let requested_name = effective_status_name_config ~agent_name args in
-  if not (validate_name requested_name) then
+  let candidates =
+    status_name_lookup_candidates requested_name
+    |> List.filter validate_name
+  in
+  if candidates = [] then
     Error
       (Printf.sprintf
          "invalid keeper name %S (must be non-empty and match \
           [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
          requested_name)
   else
-    match read_effective_meta_resolved config requested_name with
-    | Error e -> Error e
-    | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)
-    | Ok None ->
-        Error (Printf.sprintf "keeper not found: %s" requested_name)
+    let rec loop = function
+      | [] -> Error (Printf.sprintf "keeper not found: %s" requested_name)
+      | candidate :: rest -> (
+          match read_effective_meta_resolved config candidate with
+          | Error e -> Error e
+          | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)
+          | Ok None -> loop rest)
+    in
+    loop candidates
 
 let resolve_status_target (ctx : _ context) args =
   resolve_status_target_config ~config:ctx.config ~agent_name:ctx.agent_name args

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -495,12 +495,29 @@ let keeper_status_body ~(config : Workspace.config) ~(agent_name : string) args 
 let handle_keeper_status ctx args : tool_result =
   keeper_status_body ~config:ctx.config ~agent_name:ctx.agent_name args
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let keeper_name_lookup_candidates raw_name =
+  let trimmed = String.trim raw_name in
+  if String.equal trimmed "" then
+    []
+  else
+    let aliases =
+      match Keeper_identity.canonical_keeper_name trimmed with
+      | Some candidate when not (String.equal candidate trimmed) -> [ candidate ]
+      | Some _ | None -> []
+    in
+    trimmed :: aliases
+
 let resolve_keeper_name_config ~(config : Workspace.config) args =
   let name = String.trim (get_string args "name" "") in
-  match read_meta_resolved config name with
-  | Ok (Some (resolved_name, _meta)) -> Ok resolved_name
-  | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
-  | Error err -> Error (Printf.sprintf "%s" err)
+  let rec loop = function
+    | [] -> Error (Printf.sprintf "keeper not found: %s" name)
+    | candidate :: rest -> (
+        match read_meta_resolved config candidate with
+        | Ok (Some (resolved_name, _meta)) -> Ok resolved_name
+        | Ok None -> loop rest
+        | Error err -> Error (Printf.sprintf "%s" err))
+  in
+  loop (keeper_name_lookup_candidates name)
 
 let resolve_keeper_name ctx args =
   resolve_keeper_name_config ~config:ctx.config args

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -131,21 +131,34 @@ let make_keeper_tool_handler
             | Some clock -> Some clock
             | None -> Eio_context.get_clock_opt ()
           in
-          match gate_clock with
-          | None ->
+          let run_with_current_eio_context ?clock () =
+            let sw = Eio_context.get_switch_opt () in
+            let net = Eio_context.get_net_opt () in
+            let proc_mgr =
+              match Process_eio.get_proc_mgr () with
+              | Ok proc_mgr -> Some proc_mgr
+              | Error _ -> None
+            in
             Keeper_tools_oas_handler_exec.execute_with_observers
               ~name
               ~config
-                ~meta
-                ~ctx_snapshot
-                ?turn_sandbox_factory
-                ~exec_cache
+              ~meta
+              ~ctx_snapshot
+              ?turn_sandbox_factory
+              ~exec_cache
               ?search_fn
               ?on_tool_called
+              ?sw
+              ?clock
+              ?proc_mgr
+              ?net
               ~failure_counts
               ~key
               ~input
               ()
+          in
+          match gate_clock with
+          | None -> run_with_current_eio_context ()
           | Some clock ->
             let start_time = Time_compat.now () in
             let is_read_only =
@@ -176,18 +189,5 @@ let make_keeper_tool_handler
                   ~tool_name:name
                   ~start_time
                   payload)
-              (fun () ->
-                Keeper_tools_oas_handler_exec.execute_with_observers
-                  ~name
-                  ~config
-                    ~meta
-                    ~ctx_snapshot
-                    ?turn_sandbox_factory
-                    ~exec_cache
-                  ?search_fn
-                  ?on_tool_called
-                  ~failure_counts
-                  ~key
-                  ~input
-                  ())))
+              (fun () -> run_with_current_eio_context ~clock ())))
 ;;

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -93,6 +93,11 @@ let execute_with_observers
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
       ?on_tool_called
+      ?sw
+      ?clock
+      ?proc_mgr
+      ?net
+      ?mcp_session_id
       ~(failure_counts : failure_counts)
       ~(key : string)
       ~(input : Yojson.Safe.t)
@@ -110,6 +115,11 @@ let execute_with_observers
             ?turn_sandbox_factory
             ~exec_cache
           ?search_fn
+          ?sw
+          ?clock
+          ?proc_mgr
+          ?net
+          ?mcp_session_id
           ~name
           ~input
           ())

--- a/lib/keeper/keeper_tools_oas_handler_exec.mli
+++ b/lib/keeper/keeper_tools_oas_handler_exec.mli
@@ -16,6 +16,11 @@ val execute_with_observers
   -> exec_cache:Masc_exec.Exec_cache.t option
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
+  -> ?sw:Eio.Switch.t
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
+  -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?mcp_session_id:string
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> key:string
   -> input:Yojson.Safe.t

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -150,12 +150,16 @@ goal = "%s"
        sandbox_profile
        goal)
 
-let status_goal config name =
-  let args = `Assoc [ ("name", `String name); ("fast", `Bool true) ] in
+let status_goal_with ?(agent_name = "test-agent") ?name config =
+  let args =
+    match name with
+    | Some name -> `Assoc [ ("name", `String name); ("fast", `Bool true) ]
+    | None -> `Assoc [ ("fast", `Bool true) ]
+  in
   let result =
     Status_detail.handle_keeper_status_config
       ~config
-      ~agent_name:"test-agent"
+      ~agent_name
       args
   in
   if not (Profile.tool_result_success result) then
@@ -164,6 +168,51 @@ let status_goal config name =
   match json_string_field "goal" json with
   | Some goal -> goal
   | None -> Alcotest.fail "status response missing goal"
+
+let status_goal config name = status_goal_with ~name config
+
+let resolved_keeper_name config name =
+  match
+    Keeper_tool_surface_ops.resolve_keeper_name_config
+      ~config
+      (`Assoc [ ("name", `String name) ])
+  with
+  | Ok resolved -> resolved
+  | Error err -> Alcotest.failf "resolve_keeper_name_config failed: %s" err
+
+let test_status_resolves_keeper_alias_names () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "aliasprobe" in
+  write_keeper_toml ~keepers_dir ~name ~sandbox_profile:"local"
+    ~goal:"alias status goal";
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  Alcotest.(check string)
+    "explicit agent alias reaches canonical keeper"
+    "alias status goal"
+    (status_goal_with ~name:"keeper-aliasprobe-agent" config);
+  Alcotest.(check string)
+    "prefixed alias reaches canonical keeper"
+    "alias status goal"
+    (status_goal_with ~name:"keeper-aliasprobe" config);
+  Alcotest.(check string)
+    "self fallback agent alias reaches canonical keeper"
+    "alias status goal"
+    (status_goal_with ~agent_name:"keeper-aliasprobe-agent" config)
+
+let test_keeper_surface_resolves_alias_names () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir:_ ->
+  let name = "aliasmsg" in
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  Alcotest.(check string)
+    "agent alias resolves for keeper surface tools"
+    name
+    (resolved_keeper_name config "keeper-aliasmsg-agent");
+  Alcotest.(check string)
+    "prefixed alias resolves for keeper surface tools"
+    name
+    (resolved_keeper_name config "keeper-aliasmsg")
 
 let test_toml_overlay_reaches_effective_meta () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
@@ -567,6 +616,10 @@ let () =
           Alcotest.test_case
             "profile identity snapshot reaches meta JSON"
             `Quick test_profile_identity_snapshot_reaches_meta_json;
+          Alcotest.test_case "status resolves keeper alias names" `Quick
+            test_status_resolves_keeper_alias_names;
+          Alcotest.test_case "keeper surface resolves alias names" `Quick
+            test_keeper_surface_resolves_alias_names;
           Alcotest.test_case "turn setup uses effective meta" `Quick
             test_turn_setup_uses_effective_meta;
           Alcotest.test_case

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -818,6 +818,74 @@ let test_tool_execute_raw_cmd_requires_typed_shell_ir () =
       check bool "single hard-cut rejection does not enrich circuit breaker" true
         Yojson.Safe.Util.(member "circuit_breaker" json = `Null))
 
+let keeper_msg_input_schema () =
+  match
+    List.find_opt
+      (fun (schema : Masc_domain.tool_schema) ->
+        String.equal schema.name "masc_keeper_msg")
+      Masc.Keeper_schema.schemas
+  with
+  | Some schema -> schema.input_schema
+  | None -> fail "masc_keeper_msg schema missing"
+
+let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
+  let dir = temp_dir "oas-handler-eio-context" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let net = Eio.Stdenv.net env in
+      let clock = Eio.Stdenv.clock env in
+      let mono_clock = Eio.Stdenv.mono_clock env in
+      Eio.Switch.run @@ fun root_sw ->
+      Eio_context.with_test_env ~net ~clock ~mono_clock ~sw:root_sw @@ fun () ->
+      Eio.Switch.run @@ fun turn_sw ->
+      Eio_context.with_turn_switch turn_sw @@ fun () ->
+      let config = Workspace.default_config dir in
+      let meta = make_meta ~tool_access:[ "masc_keeper_msg" ] () in
+      ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+      let previous_dispatch = !(Masc.Keeper_dispatch_ref.dispatch) in
+      let saw_turn_sw = Atomic.make false in
+      let saw_clock = Atomic.make false in
+      Fun.protect
+        ~finally:(fun () ->
+          Masc.Keeper_dispatch_ref.dispatch := previous_dispatch;
+          Masc.Keeper_registry.unregister ~base_path:config.base_path meta.name)
+        (fun () ->
+          Masc.Keeper_dispatch_ref.dispatch :=
+            (fun ~config:_ ~agent_name:_ ?sw ?clock ?proc_mgr:_ ?net:_ ?mcp_session_id:_
+                 ~name ~args:_ () ->
+              check string "keeper dispatch tool" "masc_keeper_msg" name;
+              Atomic.set saw_turn_sw
+                (match sw with Some sw -> sw == turn_sw | None -> false);
+              Atomic.set saw_clock (Option.is_some clock);
+              Some
+                (Tool_result.ok ~tool_name:name ~start_time:0.0
+                   "{\"ok\":true,\"request_id\":\"test-request\"}"));
+          let handler =
+            Masc.Keeper_tools_oas_handler.make_keeper_tool_handler
+              ~name:"masc_keeper_msg"
+              ~input_schema:(keeper_msg_input_schema ())
+              ~config
+              ~meta
+              ~ctx_snapshot:(make_ctx ())
+              ~exec_cache:None
+              ~failure_counts:(Masc.Keeper_tools_oas.create_failure_counts ())
+              ()
+          in
+          let result =
+            handler
+              (`Assoc
+                [
+                  ("name", `String "keeper-target");
+                  ("message", `String "hello");
+                ])
+          in
+          check bool "handler succeeds" true (Tool_result.is_success result);
+          check bool "turn switch reaches keeper dispatch" true (Atomic.get saw_turn_sw);
+          check bool "clock reaches keeper dispatch" true (Atomic.get saw_clock)))
+
 let registered_dispatch_probe_tool = "test_keeper_registered_dispatch_probe"
 
 let probe_input_schema =
@@ -968,6 +1036,8 @@ let () =
         test_workflow_rejection_payload_skips_circuit_breaker;
       test_case "tool_execute raw cmd requires typed Shell IR" `Quick
         test_tool_execute_raw_cmd_requires_typed_shell_ir;
+      test_case "OAS handler threads Eio context to keeper dispatch" `Quick
+        test_oas_handler_threads_eio_context_to_keeper_dispatch;
       test_case "registered dispatch does not require masc_ prefix" `Quick
         test_registered_tool_dispatch_without_masc_prefix;
       test_case "registered dispatch preserves workflow failure class" `Quick


### PR DESCRIPTION
## Summary

- Resolve keeper alias names such as `keeper-foo-agent` and `keeper-foo` through existing canonical keeper identity helpers when handling `masc_keeper_status` and keeper surface target lookup.
- Thread current Eio context (`sw`, `clock`, `proc_mgr`, `net`) from OAS tool handlers into keeper tool dispatch so Eio-bound keeper tools can run from the OAS tool path.
- Add focused regression coverage for alias resolution and OAS handler Eio context propagation.

## Why

Runtime tool-call failures showed recoverable keeper lookup misses and an Eio context propagation gap for keeper tool dispatch. These failures are MASC boundary/runtime issues, not OAS provider behavior.

## Validation

- `scripts/dune-local.sh build test/test_keeper_tool_dispatch_runtime.exe test/test_keeper_effective_meta_overlay.exe`
- `_build/default/test/test_keeper_tool_dispatch_runtime.exe`
- `_build/default/test/test_keeper_effective_meta_overlay.exe`