### PR TITLE
[codex] fix keeper OAS turn budget leak

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -510,6 +510,7 @@ let run_turn
               to re-emit. Runaway is bounded by max_idle_turns + token budget,
               not a retry count that halts the turn. *)
                     ~max_idle_turns
+                    ~max_turns
                     ?stream_idle_timeout_s
                     ~body_timeout_s:timeout_s
                     ~temperature

--- a/lib/keeper/keeper_tool_diversity.ml
+++ b/lib/keeper/keeper_tool_diversity.ml
@@ -108,25 +108,14 @@ let compute_diversity ~(available_tools : string list)
     entropy = raw_h; normalized_entropy = norm_h;
     underused_tools = underused; overused_tools = overused }
 
-let record_underused_tool_metrics ~keeper_name ~available_tools summary =
-  let available_tools = List.sort_uniq String.compare available_tools in
+let record_underused_tool_metrics ~keeper_name ~available_tools:_ summary =
   let underused_tools =
     List.sort_uniq String.compare summary.underused_tools
   in
   Otel_metric_store.set_gauge
     Keeper_metrics.(to_string ToolUnderusedAllowedCount)
     ~labels:[ ("keeper", keeper_name) ]
-    (float_of_int (List.length underused_tools));
-  List.iter
-    (fun tool ->
-       let value =
-         if List.mem tool underused_tools then 1.0 else 0.0
-       in
-       Otel_metric_store.set_gauge
-         Keeper_metrics.(to_string ToolUnderusedAllowed)
-         ~labels:[ ("keeper", keeper_name); ("tool", tool) ]
-         value)
-    available_tools
+    (float_of_int (List.length underused_tools))
 
 (** Default normalized entropy threshold.  Below this, the keeper is
     considered to be in an exploitation-only pattern.

--- a/lib/keeper/keeper_tool_diversity.mli
+++ b/lib/keeper/keeper_tool_diversity.mli
@@ -32,5 +32,7 @@ val record_underused_tool_metrics :
   available_tools:string list ->
   diversity_summary ->
   unit
+(** Emit the aggregate underused-tool count. Per-tool heartbeat gauges are
+    intentionally avoided to keep OTel series cardinality bounded by keeper. *)
 val default_entropy_threshold : float
 val stats_of_registry_entries : (string * Keeper_types.tool_call_entry) list -> tool_stat list

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -47,6 +47,7 @@ let run_named
     ?(system_prompt = "")
     ?(tools = [])
     ?(initial_messages = [])
+    ?(max_turns = Agent_sdk.Types.default_config.max_turns)
     ~max_idle_turns
     ?stream_idle_timeout_s
     ?body_timeout_s
@@ -155,6 +156,7 @@ let run_named
     system_prompt;
     tools;
     initial_messages;
+    max_turns;
     max_idle_turns;
     stream_idle_timeout_s;
     execution_idle_timeout_s;

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -98,6 +98,7 @@ val run_named :
   ?system_prompt:string ->
   ?tools:Agent_sdk.Tool.t list ->
   ?initial_messages:Agent_sdk.Types.message list ->
+  ?max_turns:int ->
   max_idle_turns:int ->
   ?stream_idle_timeout_s:float ->
   ?body_timeout_s:float ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -28,6 +28,7 @@ type try_provider_ctx =
   ; system_prompt : string
   ; tools : Agent_sdk.Tool.t list
   ; initial_messages : Agent_sdk.Types.message list
+  ; max_turns : int
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
   ; execution_idle_timeout_s : float option
@@ -360,6 +361,7 @@ let run_try_provider
                None)
           ; body_timeout_s = ctx.body_timeout_s
           ; temperature = ctx.temperature
+          ; max_turns = ctx.max_turns
           ; max_idle_turns = ctx.max_idle_turns
           ; guardrails = ctx.guardrails
           ; hooks

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -11,6 +11,7 @@ type try_provider_ctx =
   ; system_prompt : string
   ; tools : Agent_sdk.Tool.t list
   ; initial_messages : Agent_sdk.Types.message list
+  ; max_turns : int
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
   ; execution_idle_timeout_s : float option

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -30,6 +30,7 @@ type config =
   tools : Agent_sdk.Tool.t list;
   runtime_mcp_policy :
     Llm_provider.Llm_transport.runtime_mcp_policy option;
+  max_turns : int;
   max_idle_turns : int;
   stream_idle_timeout_s : float option;
   max_execution_time_s : float option;

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -52,6 +52,7 @@ type config = Runtime_agent_context.config = {
   tools : Agent_sdk.Tool.t list;
   runtime_mcp_policy :
     Llm_provider.Llm_transport.runtime_mcp_policy option;
+  max_turns : int;
   max_idle_turns : int;
   stream_idle_timeout_s : float option;
   max_execution_time_s : float option;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -5,13 +5,7 @@
     [Runtime_agent] remains the public facade and still performs the
     approval wiring and final [build_safe] / [Agent.resume] calls. *)
 
-(** Turn count is no longer the primary execution budget.
-    timeout_sec controls retry/admission, stream_idle_timeout_sec controls
-    provider stream liveness, and execution_idle_timeout_sec is an opt-in
-    Agent.run no-progress guard. Tool invocation timeouts are separate.
-    Agent_sdk requires a positive int for max_turns; we pass the
-    largest possible value to effectively disable the turn ceiling. *)
-let max_turns_disabled = Int.max_int
+let default_max_turns = Agent_sdk.Types.default_config.max_turns
 
 type stop_reason =
   | Completed
@@ -33,6 +27,7 @@ type config =
   ; system_prompt : string
   ; tools : Agent_sdk.Tool.t list
   ; runtime_mcp_policy : Llm_provider.Llm_transport.runtime_mcp_policy option
+  ; max_turns : int
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
   ; max_execution_time_s : float option
@@ -145,6 +140,7 @@ let default_config
   ; system_prompt
   ; tools
   ; runtime_mcp_policy = None
+  ; max_turns = default_max_turns
   ; max_idle_turns = 3
   ; stream_idle_timeout_s = None
   ; max_execution_time_s = None
@@ -218,7 +214,7 @@ let builder_without_approval
     |> Agent_sdk.Builder.with_name config.name
     |> Agent_sdk.Builder.with_system_prompt config.system_prompt
     |> Agent_sdk.Builder.with_max_tokens config.max_tokens
-    |> Agent_sdk.Builder.with_max_turns max_turns_disabled
+    |> Agent_sdk.Builder.with_max_turns config.max_turns
     |> Agent_sdk.Builder.with_max_idle_turns config.max_idle_turns
     |> Agent_sdk.Builder.with_temperature config.temperature
     |> Agent_sdk.Builder.with_provider config.provider
@@ -415,6 +411,7 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     | Some budget -> Some (checkpoint.usage.estimated_cost_usd +. budget)
     | None -> None
   in
+  let max_turns_for_resume = checkpoint.turn_count + config.max_turns in
   let patched_checkpoint =
     { checkpoint with
       Agent_sdk.Checkpoint.model = config.model_id
@@ -434,7 +431,7 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; model = config.model_id
     ; system_prompt = Some config.system_prompt
     ; max_tokens = Some config.max_tokens
-    ; max_turns = max_turns_disabled
+    ; max_turns = max_turns_for_resume
     ; temperature = Some config.temperature
     ; enable_thinking = config.enable_thinking
     ; preserve_thinking = config.preserve_thinking

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -36,6 +36,7 @@ type config = {
   tools : Agent_sdk.Tool.t list;
   runtime_mcp_policy :
     Llm_provider.Llm_transport.runtime_mcp_policy option;
+  max_turns : int;
   max_idle_turns : int;
   stream_idle_timeout_s : float option;
   max_execution_time_s : float option;
@@ -103,7 +104,7 @@ type config = {
   tool_selector : Agent_sdk.Tool_selector.strategy option;
   checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option;
 }
-(** Per-worker configuration.  55 fields — concrete record because
+(** Per-worker configuration.  56 fields — concrete record because
     callers ({!Runtime_agent}, keeper workers) construct + tweak
     fields field-by-field at the dispatch site. *)
 
@@ -143,7 +144,8 @@ type prepared_resume = {
   options : Agent_sdk.Agent.options;
 }
 (** Output of {!prepare_resume}.  [patched_checkpoint] has
-    [turn_count] and budget fields adjusted so that resume picks
+    runtime identity fields adjusted, and [agent_config.max_turns]
+    is extended past the checkpoint [turn_count] so resume picks
     up where the previous run left off without re-counting
     consumed turns. *)
 
@@ -157,6 +159,6 @@ val prepare_resume :
 (** [prepare_resume ~config ~checkpoint] computes the patched
     checkpoint + agent_config + options for an
     [Agent.resume] call.  Pure — no side effects.  The patched
-    checkpoint extends [config.max_turns] beyond the consumed
+    agent config extends [config.max_turns] beyond the consumed
     [checkpoint.turn_count] so the resumed run gets a fresh
     turn budget instead of inheriting the exhausted one. *)

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -803,6 +803,63 @@ let test_runtime_agent_max_turns_is_continuation_checkpoint () =
   check string "status" "continuation_checkpoint" lifecycle.status;
   check (option string) "no error" None lifecycle.error
 
+let test_runtime_agent_context_uses_configured_turn_budget () =
+  let config =
+    Runtime_agent.default_config
+      ~name:"oas-runpod_mtp.qwen"
+      ~provider_cfg:(provider_cfg ())
+      ~system_prompt:""
+      ~tools:[]
+  in
+  let config = { config with max_turns = 7 } in
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let builder =
+        Runtime_agent_context.builder_without_approval
+          ~net:(Eio.Stdenv.net env)
+          ~config
+          ()
+      in
+      match Agent_sdk.Builder.build_safe builder with
+      | Error err -> fail (Agent_sdk.Error.to_string err)
+      | Ok agent ->
+        check int "builder max_turns" 7
+          (Agent_sdk.Agent.state agent).config.max_turns;
+        Eio.Switch.on_release sw (fun () ->
+          Agent_sdk.Agent.close agent)));
+  let checkpoint =
+    { Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version
+    ; session_id = "session"
+    ; agent_name = "oas-runpod_mtp.qwen"
+    ; model = "qwen"
+    ; system_prompt = Some ""
+    ; messages = []
+    ; usage = Agent_sdk.Types.empty_usage
+    ; turn_count = 24
+    ; created_at = 0.0
+    ; tools = []
+    ; tool_choice = None
+    ; disable_parallel_tool_use = false
+    ; temperature = Some 0.3
+    ; top_p = None
+    ; top_k = None
+    ; min_p = None
+    ; enable_thinking = None
+    ; preserve_thinking = None
+    ; response_format = Agent_sdk.Types.default_config.response_format
+    ; thinking_budget = None
+    ; cache_system_prompt = false
+    ; max_input_tokens = None
+    ; max_total_tokens = None
+    ; context = Agent_sdk.Context.create ()
+    ; mcp_sessions = []
+    ; working_context = None
+    }
+  in
+  let prepared = Runtime_agent_context.prepare_resume ~config ~checkpoint in
+  check int "resume adds fresh per-call turn budget" 31
+    prepared.agent_config.max_turns
+
 (* RFC-OAS-026 §4.6: a configured stream-idle deadline with no resolvable clock
    must fail loudly rather than silently disarm the only I2-legitimate
    streaming timeout. *)
@@ -910,6 +967,10 @@ let () =
             "max turns is continuation checkpoint"
             `Quick
             test_runtime_agent_max_turns_is_continuation_checkpoint
+        ; test_case
+            "runtime agent context uses configured turn budget"
+            `Quick
+            test_runtime_agent_context_uses_configured_turn_budget
         ; test_case
             "dashboard runtime provider reachability contracts"
             `Quick

--- a/test/test_tool_diversity.ml
+++ b/test/test_tool_diversity.ml
@@ -39,7 +39,7 @@ let test_stats_of_registry () =
   check string "first name" "tool_a" first.name;
   check int "first count" 50 first.count
 
-let test_underused_tool_metrics_flag_unused_web_search () =
+let test_underused_tool_metrics_record_aggregate_count () =
   let keeper_name = "test-underused-tool-metrics" in
   let available_tools = [ "keeper_board_post"; "masc_web_search" ] in
   let stats =
@@ -56,21 +56,14 @@ let test_underused_tool_metrics_flag_unused_web_search () =
     Masc.Keeper_tool_diversity.compute_diversity
       ~available_tools stats
   in
+  check int "summary underused count" 1
+    (List.length summary.underused_tools);
   Masc.Keeper_tool_diversity.record_underused_tool_metrics
     ~keeper_name ~available_tools summary;
   check (float 0.001) "one underused allowed tool" 1.0
     (Masc.Otel_metric_store.metric_value_or_zero
        Keeper_metrics.(to_string ToolUnderusedAllowedCount)
-       ~labels:[ ("keeper", keeper_name) ] ());
-  check (float 0.001) "web search flagged underused" 1.0
-    (Masc.Otel_metric_store.metric_value_or_zero
-       Keeper_metrics.(to_string ToolUnderusedAllowed)
-       ~labels:[ ("keeper", keeper_name); ("tool", "masc_web_search") ]
-       ());
-  check (float 0.001) "used board post cleared" 0.0
-    (Masc.Otel_metric_store.metric_value_or_zero
-       Keeper_metrics.(to_string ToolUnderusedAllowed)
-       ~labels:[ ("keeper", keeper_name); ("tool", "keeper_board_post") ]
+       ~labels:[ ("keeper", keeper_name) ]
        ())
 
 (* ── QCheck properties ───────────────────────────────────── *)
@@ -118,8 +111,8 @@ let () =
           test_case "shannon_entropy empty" `Quick test_shannon_entropy_empty;
           test_case "normalized uniform" `Quick test_normalized_uniform;
           test_case "stats_of_registry" `Quick test_stats_of_registry;
-          test_case "underused tool metrics flag unused web search" `Quick
-            test_underused_tool_metrics_flag_unused_web_search;
+          test_case "underused tool metrics record aggregate count" `Quick
+            test_underused_tool_metrics_record_aggregate_count;
         ] );
       ( "qcheck",
         List.map QCheck_alcotest.to_alcotest


### PR DESCRIPTION
## Summary

- Thread keeper `max_turns` through the runtime driver into `Runtime_agent.config`.
- Stop disabling the OAS loop guard with `Int.max_int`; builder runs now use the configured per-call turn budget.
- Preserve resume semantics by extending resumed `max_turns` to `checkpoint.turn_count + config.max_turns`.
- Reduce OTel heartbeat cardinality by emitting only aggregate underused-tool count instead of per-tool `keeper * tool` gauges.

## Root Cause

Keeper runtime computed reactive/autonomous turn budgets, but the runtime agent layer replaced the OAS loop guard with `Int.max_int`. Live turns could therefore continue emitting `stop=tools_executed` telemetry and trajectory data far beyond the configured budget.

## Validation

- `scripts/dune-local.sh build test/test_runtime_provider_auth_headers.exe`
- `./_build/default/test/test_runtime_provider_auth_headers.exe`
- `scripts/dune-local.sh build test/test_oas_timeout_budget_strike.exe`
- `./_build/default/test/test_oas_timeout_budget_strike.exe`
- `scripts/dune-local.sh build test/test_tool_diversity.exe`
- `./_build/default/test/test_tool_diversity.exe`
- `scripts/dune-local.sh build bin/main_eio.exe`
- `git diff --check`
