### PR TITLE
Wire scheduled automation tools

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1660,12 +1660,49 @@ export interface ToolMetricsResponse extends TelemetryFreshnessMetadata {
   registered_count: number
 }
 
+export interface DashboardScheduledAutomationFsm {
+  state: string
+  active_count: number
+  terminal_count: number
+  next_due_at?: string | null
+}
+
+export interface DashboardScheduledAutomationRequest {
+  schedule_id: string
+  status: string
+  risk_class: string
+  approval_required: boolean
+  source: string
+  requested_at?: number
+  requested_at_iso?: string
+  due_at?: number
+  due_at_iso?: string
+  expires_at?: number | null
+  expires_at_iso?: string | null
+  payload_digest?: string
+  payload_kind?: string | null
+}
+
+export interface DashboardScheduledAutomation {
+  schema?: string
+  source?: string
+  generated_at?: string
+  request_count: number
+  request_limit: number
+  truncated: boolean
+  counts: Record<string, number>
+  derived_counts?: Record<string, number>
+  fsm: DashboardScheduledAutomationFsm
+  requests: DashboardScheduledAutomationRequest[]
+}
+
 export interface DashboardToolsResponse {
   generated_at?: string
   config_resolution?: DashboardConfigResolution
   runtime_resolution?: DashboardRuntimeResolution
   tool_inventory: DashboardToolInventoryResponse
   tool_usage: ToolMetricsResponse
+  scheduled_automation?: DashboardScheduledAutomation
 }
 
 export type {

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -1,0 +1,133 @@
+import { html } from 'htm/preact'
+import type {
+  DashboardScheduledAutomation,
+  DashboardScheduledAutomationRequest,
+} from '../../api'
+import { formatDateTimeKo } from '../../lib/format-time'
+import { StatusChip, type StatusChipTone } from '../common/status-chip'
+
+function enumLabel(value: string | null | undefined): string {
+  if (!value) return '-'
+  return value.replace(/_/g, ' ')
+}
+
+function automationTone(status: string | null | undefined): StatusChipTone {
+  switch (status) {
+    case 'running':
+    case 'scheduled':
+      return 'ok'
+    case 'pending_approval':
+    case 'due':
+      return 'warn'
+    case 'failed':
+    case 'rejected':
+    case 'expired':
+      return 'bad'
+    case 'succeeded':
+      return 'info'
+    case 'idle':
+    case 'cancelled':
+    default:
+      return 'neutral'
+  }
+}
+
+function CountChip({ name, count }: { name: string; count: number }) {
+  return html`
+    <span class="inline-flex items-center gap-1 rounded-[var(--r-0)] bg-[var(--color-bg-hover)] px-2 py-1 text-2xs text-[var(--color-fg-secondary)]">
+      <span class="font-mono">${count.toLocaleString()}</span>
+      <span>${enumLabel(name)}</span>
+    </span>
+  `
+}
+
+function ScheduleRow({ request }: { request: DashboardScheduledAutomationRequest }) {
+  return html`
+    <tr class="border-t border-[var(--color-border-default)]">
+      <td class="py-2 pr-3 font-mono text-xs text-[var(--color-fg-secondary)]">${request.schedule_id}</td>
+      <td class="py-2 pr-3">
+        <${StatusChip} tone=${automationTone(request.status)} uppercase=${false}>${enumLabel(request.status)}<//>
+      </td>
+      <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${enumLabel(request.risk_class)}</td>
+      <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${request.payload_kind ?? '-'}</td>
+      <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${formatDateTimeKo(request.due_at_iso ?? null)}</td>
+      <td class="py-2 text-xs text-[var(--color-fg-muted)]">${request.approval_required ? 'required' : 'not required'}</td>
+    </tr>
+  `
+}
+
+export function ScheduledAutomationPanel({
+  automation,
+}: {
+  automation?: DashboardScheduledAutomation | null
+}) {
+  if (!automation) {
+    return html`
+      <div class="text-xs text-[var(--color-fg-muted)]">
+        예약 자동화 projection 없음
+      </div>
+    `
+  }
+
+  const nonzeroCounts = Object.entries(automation.counts ?? {})
+    .filter(([, count]) => count > 0)
+  const rows = automation.requests ?? []
+  const dueEffective = automation.derived_counts?.due_effective ?? 0
+
+  return html`
+    <div class="grid gap-4">
+      <div class="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+        <div class="flex items-center gap-2">
+          <span class="text-[var(--color-fg-muted)]">FSM</span>
+          <${StatusChip} tone=${automationTone(automation.fsm.state)} uppercase=${false}>
+            ${enumLabel(automation.fsm.state)}
+          <//>
+        </div>
+        <span class="text-[var(--color-fg-muted)]">
+          active <span class="font-mono text-[var(--color-fg-secondary)]">${automation.fsm.active_count.toLocaleString()}</span>
+        </span>
+        <span class="text-[var(--color-fg-muted)]">
+          terminal <span class="font-mono text-[var(--color-fg-secondary)]">${automation.fsm.terminal_count.toLocaleString()}</span>
+        </span>
+        <span class="text-[var(--color-fg-muted)]">
+          due effective <span class="font-mono text-[var(--color-fg-secondary)]">${dueEffective.toLocaleString()}</span>
+        </span>
+        <span class="text-[var(--color-fg-muted)]">
+          next due <span class="font-mono text-[var(--color-fg-secondary)]">${formatDateTimeKo(automation.fsm.next_due_at ?? null)}</span>
+        </span>
+        <span class="font-mono text-3xs text-[var(--color-fg-disabled)]">${automation.source ?? 'schedule_store'}</span>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+        ${nonzeroCounts.length > 0
+          ? nonzeroCounts.map(([name, count]) => html`<${CountChip} name=${name} count=${count} />`)
+          : html`<span class="text-xs text-[var(--color-fg-muted)]">active schedule 없음</span>`}
+      </div>
+
+      ${rows.length > 0
+        ? html`
+            <div class="overflow-x-auto">
+              <table class="min-w-full border-collapse text-left">
+                <thead class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">
+                  <tr>
+                    <th class="pb-2 pr-3 font-medium">schedule</th>
+                    <th class="pb-2 pr-3 font-medium">status</th>
+                    <th class="pb-2 pr-3 font-medium">risk</th>
+                    <th class="pb-2 pr-3 font-medium">payload</th>
+                    <th class="pb-2 pr-3 font-medium">due</th>
+                    <th class="pb-2 font-medium">approval</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${rows.map(request => html`<${ScheduleRow} request=${request} />`)}
+                </tbody>
+              </table>
+            </div>
+            ${automation.truncated
+              ? html`<div class="text-3xs text-[var(--color-fg-muted)]">표시 ${rows.length.toLocaleString()} / 전체 ${automation.request_count.toLocaleString()}건</div>`
+              : null}
+          `
+        : html`<div class="text-xs text-[var(--color-fg-muted)]">예약 요청 없음</div>`}
+    </div>
+  `
+}

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -1,10 +1,22 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DashboardScheduledAutomation } from '../../api'
+
+type MockToolsResponse = {
+  generated_at?: string
+  tool_inventory: { tools: unknown[] }
+  tool_usage: Record<string, unknown> & {
+    registered_count: number
+    distinct_tools_called: number
+    never_called_count: number
+  }
+  scheduled_automation?: DashboardScheduledAutomation
+}
 
 const mocks = vi.hoisted(() => ({
   loadTools: vi.fn(),
-  toolsData: { value: null as null | { generated_at?: string; tool_inventory: { tools: unknown[] }; tool_usage: Record<string, unknown> & { registered_count: number; distinct_tools_called: number; never_called_count: number } } },
+  toolsData: { value: null as null | MockToolsResponse },
   toolsLoading: { value: false },
   toolsError: { value: null as string | null },
 }))
@@ -77,11 +89,58 @@ describe('Tools', () => {
 
     expect(mocks.loadTools).toHaveBeenCalledTimes(1)
     expect(container.textContent).toContain('ConfigResolutionPanel')
+    expect(container.textContent).toContain('예약 자동화 FSM')
     expect(container.textContent).toContain('시스템 도구 목록')
     expect(container.textContent).toContain('FullInventoryView')
     expect(container.textContent).toContain('도구 사용 현황')
     expect(container.textContent).toContain('ToolMetrics')
     expect(container.textContent).toContain('PromptRegistryPanel')
+  })
+
+  it('renders scheduled automation FSM projection', async () => {
+    mocks.toolsData.value = {
+      tool_inventory: { tools: [] },
+      tool_usage: {
+        registered_count: 0,
+        distinct_tools_called: 0,
+        never_called_count: 0,
+      },
+      scheduled_automation: {
+        schema: 'masc.dashboard.scheduled_automation.v1',
+        source: 'schedule_store',
+        generated_at: '2026-06-13T00:00:00Z',
+        request_count: 1,
+        request_limit: 20,
+        truncated: false,
+        counts: { pending_approval: 1 },
+        derived_counts: { due_effective: 0 },
+        fsm: {
+          state: 'pending_approval',
+          active_count: 1,
+          terminal_count: 0,
+          next_due_at: '2026-06-13T01:00:00Z',
+        },
+        requests: [
+          {
+            schedule_id: 'sched-1',
+            status: 'pending_approval',
+            risk_class: 'workspace_write',
+            approval_required: true,
+            source: 'operator_request',
+            payload_kind: 'test.reminder',
+            due_at_iso: '2026-06-13T01:00:00Z',
+          },
+        ],
+      },
+    }
+
+    render(html`<${Tools} />`, container)
+    await flush()
+
+    expect(container.textContent).toContain('pending approval')
+    expect(container.textContent).toContain('sched-1')
+    expect(container.textContent).toContain('workspace write')
+    expect(container.textContent).toContain('test.reminder')
   })
 
   it('renders tool usage coverage gap provenance', async () => {

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -18,6 +18,7 @@ import { ActionButton } from '../common/button'
 import { ToolExecutor } from '../tool-executor/tool-executor'
 import { formatElapsedCompact } from '../../lib/format-time'
 import { sourceHealthClass, coverageGapDisplay } from '../common/source-health'
+import { ScheduledAutomationPanel } from './scheduled-automation-panel'
 
 type ToolsView = 'inventory' | 'executor'
 const activeView = signal<ToolsView>('inventory')
@@ -58,6 +59,10 @@ export function Tools() {
       />
 
       <${PromptRegistryPanel} />
+
+      <${SectionCard} label="예약 자동화 FSM" class="section mb-4">
+        <${ScheduledAutomationPanel} automation=${data?.scheduled_automation ?? null} />
+      <//>
 
       <${SectionCard} label="시스템 도구 목록" class="section mb-4">
         <${FullInventoryView}

--- a/lib/dune
+++ b/lib/dune
@@ -249,6 +249,7 @@
   ;; leaf sub-library. The parent library still references those modules
   ;; unqualified, so it must depend on the leaf explicitly.
   masc.tool_types
+  masc_schedule
   masc.tool_contract_prompts
   ;; Shared leaf helpers extracted out of include_subdirs-unqualified ownership.
   masc.lockfree_atomic

--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -55,6 +55,7 @@ let string_of_tag (tag : Tool_dispatch.module_tag) : string =
   | Mod_state -> "state"
   | Mod_control -> "control"
   | Mod_agent_timeline -> "agent_timeline"
+  | Mod_schedule -> "schedule"
   | Mod_misc -> "misc"
   | Mod_inline -> "inline"
   | Mod_operator -> "operator"
@@ -126,6 +127,8 @@ let dispatch
                 name))
     | Mod_agent_timeline ->
       Tool_agent_timeline.dispatch { Tool_agent_timeline.config; agent_name } ~name ~args
+    | Mod_schedule ->
+      Tool_schedule.dispatch { Tool_schedule.config; agent_name } ~name ~args
     | Mod_misc -> Tool_misc.dispatch { Tool_misc.config; agent_name } ~name ~args
     | Mod_library -> Tool_library.dispatch { Tool_library.agent_name } ~name ~args
     (* ── Tier A special: Tool_shard returns Yojson.Safe.t ──────── *)

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -60,6 +60,7 @@ let is_masc_mcp_descriptor (d : Keeper_tool_descriptor.t) =
   | Tool_masc_misc_dispatch
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
+  | Tool_masc_schedule_dispatch
   | Tool_masc_keeper_dispatch
   | Tool_masc_surface_audit -> true
   | Tool_execute

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -55,6 +55,7 @@ type runtime_handler =
   | Tool_masc_misc_dispatch
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
+  | Tool_masc_schedule_dispatch
   | Tool_masc_keeper_dispatch
   | Tool_masc_surface_audit
 
@@ -144,6 +145,7 @@ let runtime_handler_to_string = function
   | Tool_masc_misc_dispatch -> "tool_masc_misc_dispatch"
   | Tool_masc_control_dispatch -> "tool_masc_control_dispatch"
   | Tool_masc_agent_timeline_dispatch -> "tool_masc_agent_timeline_dispatch"
+  | Tool_masc_schedule_dispatch -> "tool_masc_schedule_dispatch"
   | Tool_masc_keeper_dispatch -> "tool_masc_keeper_dispatch"
   | Tool_masc_surface_audit -> "tool_masc_surface_audit"
 ;;
@@ -992,6 +994,21 @@ let masc_agent_timeline_descriptor name description ~readonly =
     ~maintenance_only:false
 ;;
 
+let masc_schedule_descriptor (definition : Tool_schemas_schedule.definition) =
+  let schema : Masc_domain.tool_schema = definition.schema in
+  { (cluster_descriptor
+       ~id:("masc.schedule." ^ definition.id)
+       ~name:schema.name
+       ~description:schema.description
+       ~handler:Tool_masc_schedule_dispatch
+       ~readonly:definition.read_only
+       ~inline_safe:false
+       ~maintenance_only:false)
+    with
+    input_schema = schema.input_schema
+  }
+;;
+
 let masc_keeper_descriptor id name description ~readonly =
   cluster_descriptor
     ~id:("masc.keeper." ^ id)
@@ -1348,11 +1365,15 @@ let internal_descriptors : t list =
   (* ── RFC-0182 §3.1 — masc_agent_timeline singleton (1 entry) ── *)
   ; masc_agent_timeline_descriptor "masc_agent_timeline"
       "Read agent timeline events." ~readonly:true
+  (* ── RFC-0234 — scheduled internal automation (6 entries) ─────── *)
+  ]
+  @ List.map masc_schedule_descriptor Tool_schemas_schedule.definitions
+  @ [
   (* ── RFC-0182 §3.1 — masc_keeper cluster (1 entry today) ──── *)
   (* Other masc_keeper_ tools (status, msg, clear, compact, repair,
      sandbox lifecycle) use the keeper Eio context and are gated on
      Phase 5 Eio plumbing scope. *)
-  ; masc_keeper_descriptor "list" "masc_keeper_list"
+    masc_keeper_descriptor "list" "masc_keeper_list"
       "List configured keepers with optional detailed metadata." ~readonly:true
   ; masc_keeper_descriptor "msg_result" "masc_keeper_msg_result"
       "Poll an async keeper_msg dispatch by request_id." ~readonly:true

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -60,6 +60,7 @@ type runtime_handler =
   | Tool_masc_misc_dispatch
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
+  | Tool_masc_schedule_dispatch
   | Tool_masc_keeper_dispatch
   | Tool_masc_surface_audit
 

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -317,6 +317,11 @@ let handle_masc_agent_timeline ~(config : Workspace.config) ~(meta : keeper_meta
   Tool_agent_timeline.dispatch ctx ~name ~args |> dispatch_option_to_string ~name
 ;;
 
+let handle_masc_schedule ~(config : Workspace.config) ~(meta : keeper_meta) ~name ~args =
+  let ctx : Tool_schedule.context = { config; agent_name = meta.name } in
+  Tool_schedule.dispatch ctx ~name ~args |> dispatch_option_to_string ~name
+;;
+
 (* RFC-0182 §3.1 — masc_tool_shard cluster.  [Tool_shard.execute]
    returns the older [(bool * Yojson.Safe.t)] tuple (predates RFC-0189
    typed-result migration), same shape as Tool_local_runtime.  Tool_shard

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -196,6 +196,15 @@ val handle_masc_agent_timeline
   -> args:Yojson.Safe.t
   -> string
 
+(** RFC-0234 — [handle_masc_schedule] is the descriptor-projection
+    cluster handler for [masc_schedule_*] tools. *)
+val handle_masc_schedule
+  :  config:Workspace.config
+  -> meta:keeper_meta
+  -> name:string
+  -> args:Yojson.Safe.t
+  -> string
+
 (** RFC-0182 §3.1 — [handle_masc_keeper] is the descriptor-projection
     cluster handler for the [masc_keeper_*] ctx-free tool surface.
     Dispatches via [Keeper_dispatch_ref] registered by [Keeper_tool_surface] at

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -73,6 +73,7 @@ let handle_filesystem ctx descriptor args =
   | Tool_masc_misc_dispatch
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
+  | Tool_masc_schedule_dispatch
   | Tool_masc_keeper_dispatch
   | Tool_masc_surface_audit -> None
 ;;
@@ -127,6 +128,7 @@ let handle_shell_ir ctx descriptor args =
   | Tool_masc_misc_dispatch
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
+  | Tool_masc_schedule_dispatch
   | Tool_masc_keeper_dispatch
   | Tool_masc_surface_audit -> None
 ;;
@@ -266,6 +268,13 @@ let handle_in_process ctx descriptor args =
   | Tool_masc_agent_timeline_dispatch ->
     Some
       (Keeper_tool_in_process_runtime.handle_masc_agent_timeline
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~name
+         ~args)
+  | Tool_masc_schedule_dispatch ->
+    Some
+      (Keeper_tool_in_process_runtime.handle_masc_schedule
          ~config:ctx.config
          ~meta:ctx.meta
          ~name

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -315,6 +315,11 @@ let execute_tool_eio
                      { Tool_agent_timeline.config; agent_name }
                      ~name
                      ~args:coerced_args
+                 | Mod_schedule ->
+                   Tool_schedule.dispatch
+                     { Tool_schedule.config; agent_name }
+                     ~name
+                     ~args:coerced_args
                  | Mod_misc ->
                    Tool_misc.dispatch
                      { Tool_misc.config; agent_name }

--- a/lib/schedule/schedule_domain.ml
+++ b/lib/schedule/schedule_domain.ml
@@ -28,6 +28,19 @@ type schedule_status =
   | Cancelled
   | Expired
 
+let all_schedule_statuses =
+  [ Pending_approval
+  ; Scheduled
+  ; Due
+  ; Running
+  ; Succeeded
+  ; Failed
+  ; Rejected
+  ; Cancelled
+  ; Expired
+  ]
+;;
+
 type schedule_source =
   | Operator_request
   | Automated_request

--- a/lib/schedule/schedule_domain.mli
+++ b/lib/schedule/schedule_domain.mli
@@ -33,6 +33,8 @@ type schedule_status =
   | Cancelled
   | Expired
 
+val all_schedule_statuses : schedule_status list
+
 type schedule_source =
   | Operator_request
   | Automated_request

--- a/lib/schedule/schedule_service.ml
+++ b/lib/schedule/schedule_service.ml
@@ -109,6 +109,10 @@ let reject config ?grant_id ?approved_at ~schedule_id ~approved_by ~reason () =
     ~decision:(Schedule_domain.Reject reason) ()
 ;;
 
+let cancel config ~schedule_id =
+  Schedule_store.cancel_request config ~schedule_id |> map_store
+;;
+
 let due_candidates config ~now =
   match Schedule_store.refresh_due config ~now with
   | Error err -> Error (Store_error err)

--- a/lib/schedule/schedule_service.mli
+++ b/lib/schedule/schedule_service.mli
@@ -54,6 +54,11 @@ val reject :
   unit ->
   (Schedule_domain.schedule_request, service_error) result
 
+val cancel :
+  Workspace_utils.config ->
+  schedule_id:string ->
+  (Schedule_domain.schedule_request, service_error) result
+
 val due_candidates :
   Workspace_utils.config ->
   now:float ->

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -12,6 +12,7 @@ type store_error =
   | Schedule_not_found
   | Grant_already_recorded
   | Invalid_initial_status of string
+  | Invalid_status_transition of string
   | Grant_validation_failed of Schedule_domain.grant_error
 
 let ( let* ) = Result.bind
@@ -21,6 +22,7 @@ let store_error_to_string = function
   | Schedule_not_found -> "schedule not found"
   | Grant_already_recorded -> "grant already recorded"
   | Invalid_initial_status reason -> "invalid initial schedule status: " ^ reason
+  | Invalid_status_transition reason -> "invalid schedule status transition: " ^ reason
   | Grant_validation_failed err ->
     "grant validation failed: " ^ Schedule_domain.grant_error_to_string err
 ;;
@@ -233,6 +235,27 @@ let record_grant config (grant : Schedule_domain.execution_grant) =
           let next_state = bump_state state ~schedules ~grants in
           write_state config next_state;
           Ok updated_request))
+;;
+
+let cancel_request config ~schedule_id =
+  Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
+    let state = read_state config in
+    match find_schedule state schedule_id with
+    | None -> Error Schedule_not_found
+    | Some request ->
+      if Schedule_domain.is_terminal request.status || request.status = Running
+      then
+        Error
+          (Invalid_status_transition
+             "only pending, scheduled, or due requests can be cancelled")
+      else
+        let updated_request =
+          { request with Schedule_domain.status = Schedule_domain.Cancelled }
+        in
+        let schedules = replace_schedule state.schedules updated_request in
+        let next_state = bump_state state ~schedules ~grants:state.grants in
+        write_state config next_state;
+        Ok updated_request)
 ;;
 
 let refresh_due config ~now =

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -15,6 +15,7 @@ type store_error =
   | Schedule_not_found
   | Grant_already_recorded
   | Invalid_initial_status of string
+  | Invalid_status_transition of string
   | Grant_validation_failed of Schedule_domain.grant_error
 
 val store_error_to_string : store_error -> string
@@ -38,6 +39,11 @@ val insert_request :
 val record_grant :
   Workspace_utils.config ->
   Schedule_domain.execution_grant ->
+  (Schedule_domain.schedule_request, store_error) result
+
+val cancel_request :
+  Workspace_utils.config ->
+  schedule_id:string ->
   (Schedule_domain.schedule_request, store_error) result
 
 val refresh_due :

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -65,6 +65,7 @@
   agent_sdk
   agent_sdk.base
   agent_sdk.llm_provider
+  masc_schedule
   masc.tool_types
   masc.attribution
   masc.exec_policy

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -39,6 +39,39 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       Tool_metrics_persist.enqueue r
     | _ -> ());
   Tool_metrics_persist.start_flush_fiber ~sw ~clock ~base_path:state.workspace_config.base_path;
+  (* RFC-0234 scheduled automation runner.  Tool-facing create/approve/list
+     paths only mutate the durable ledger; this loop is the production caller
+     that observes due rows and emits at-most-once generic wake signals.  It
+     catches per-tick failures so a corrupt schedule row or transient write
+     error cannot cancel unrelated keeper/server fibers. *)
+  fork_logged_fiber
+    ~sw
+    ~on_error:(log_server_fiber_crash "schedule_runner")
+    (fun () ->
+      let interval = 15.0 in
+      let rec loop () =
+        (try
+           match Schedule_runner.tick state.workspace_config ~now:(Time_compat.now ()) with
+           | Ok result ->
+             if result.Schedule_runner.emitted <> [] then
+               Log.Server.info
+                 "schedule_runner: due_changed=%d emitted=%d"
+                 result.due_changed
+                 (List.length result.emitted)
+           | Error err ->
+             Log.Server.warn
+               "schedule_runner: tick failed: %s"
+               (Schedule_runner.runner_error_to_string err)
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Server.warn
+             "schedule_runner: tick crashed: %s"
+             (Printexc.to_string exn));
+        Eio.Time.sleep clock interval;
+        loop ()
+      in
+      loop ());
   (* Bare-alias audit fiber (PR #15112 surface refresh): re-run the
      classifier every minute so the [masc_auth_bare_alias] gauges
      reflect mid-run regressions, not only the boot snapshot. The

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1659,7 +1659,8 @@ let light_runtime_resolution_json (config : Workspace.config) =
    cadence (~3s polling × 10 = a fresh value at least every minute under
    sustained load).  Tool inventory + usage stats rarely change inside a
    30s window — the per-actor cache key isolates permission changes from
-   leaking across actors. *)
+   leaking across actors.  Schedule FSM projection is attached outside this
+   cache because due/pending state is operationally time-sensitive. *)
 let dashboard_tools_cache_ttl_sec = 30.0
 
 let dashboard_tools_cache_key ~base_path ~actor =
@@ -1668,6 +1669,173 @@ let dashboard_tools_cache_key ~base_path ~actor =
 let dashboard_actor_name = function
   | Some actor when String.trim actor <> "" -> actor
   | Some _ | None -> "dashboard"
+;;
+
+let schedule_projection_request_limit = 20
+
+let unix_iso_json ts = `String (Masc_domain.iso8601_of_unix_seconds ts)
+
+let unix_iso_option_json = function
+  | None -> `Null
+  | Some ts -> unix_iso_json ts
+;;
+
+let schedule_status_count schedules status =
+  List.fold_left
+    (fun count (request : Schedule_domain.schedule_request) ->
+      if request.status = status then count + 1 else count)
+    0 schedules
+;;
+
+let schedule_counts_json schedules =
+  `Assoc
+    (List.map
+       (fun status ->
+         ( Schedule_domain.schedule_status_to_string status
+         , `Int (schedule_status_count schedules status) ))
+       Schedule_domain.all_schedule_statuses)
+;;
+
+let schedule_request_active (request : Schedule_domain.schedule_request) =
+  not (Schedule_domain.is_terminal request.status)
+;;
+
+let schedule_effectively_due ~now (request : Schedule_domain.schedule_request) =
+  match request.status with
+  | Schedule_domain.Due -> true
+  | Schedule_domain.Scheduled -> request.due_at <= now
+  | Schedule_domain.Pending_approval
+  | Schedule_domain.Running
+  | Schedule_domain.Succeeded
+  | Schedule_domain.Failed
+  | Schedule_domain.Rejected
+  | Schedule_domain.Cancelled
+  | Schedule_domain.Expired ->
+    false
+;;
+
+let schedule_due_candidate (request : Schedule_domain.schedule_request) =
+  match request.status with
+  | Schedule_domain.Pending_approval | Schedule_domain.Scheduled | Schedule_domain.Due ->
+    true
+  | Schedule_domain.Running
+  | Schedule_domain.Succeeded
+  | Schedule_domain.Failed
+  | Schedule_domain.Rejected
+  | Schedule_domain.Cancelled
+  | Schedule_domain.Expired ->
+    false
+;;
+
+let schedule_next_due_at schedules =
+  schedules
+  |> List.filter schedule_due_candidate
+  |> List.fold_left
+       (fun acc (request : Schedule_domain.schedule_request) ->
+         match acc with
+         | None -> Some request.due_at
+         | Some ts -> Some (min ts request.due_at))
+       None
+;;
+
+let schedule_fsm_state ~now schedules =
+  let count status = schedule_status_count schedules status in
+  let due_effective_count =
+    List.fold_left
+      (fun count request -> if schedule_effectively_due ~now request then count + 1 else count)
+      0 schedules
+  in
+  if count Schedule_domain.Running > 0
+  then "running"
+  else if count Schedule_domain.Pending_approval > 0
+  then "pending_approval"
+  else if due_effective_count > 0
+  then "due"
+  else if count Schedule_domain.Scheduled > 0
+  then "scheduled"
+  else "idle"
+;;
+
+let schedule_payload_kind request =
+  match Schedule_domain.payload_to_yojson request.Schedule_domain.payload with
+  | `Assoc fields ->
+    (match List.assoc_opt "kind" fields with
+     | Some (`String kind) -> Some kind
+     | _ -> None)
+  | _ -> None
+;;
+
+let schedule_request_dashboard_json (request : Schedule_domain.schedule_request) =
+  `Assoc
+    [ "schedule_id", `String request.schedule_id
+    ; "status", `String (Schedule_domain.schedule_status_to_string request.status)
+    ; "risk_class", `String (Schedule_domain.risk_class_to_string request.risk_class)
+    ; "approval_required", `Bool request.approval_required
+    ; "source", `String (Schedule_domain.schedule_source_to_string request.source)
+    ; "requested_by", Schedule_domain.actor_to_yojson request.requested_by
+    ; "scheduled_by", Schedule_domain.actor_to_yojson request.scheduled_by
+    ; "requested_at", `Float request.requested_at
+    ; "requested_at_iso", unix_iso_json request.requested_at
+    ; "due_at", `Float request.due_at
+    ; "due_at_iso", unix_iso_json request.due_at
+    ; "expires_at", (match request.expires_at with None -> `Null | Some ts -> `Float ts)
+    ; "expires_at_iso", unix_iso_option_json request.expires_at
+    ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
+    ; ( "payload_kind"
+      , match schedule_payload_kind request with
+        | None -> `Null
+        | Some kind -> `String kind )
+    ]
+;;
+
+let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Safe.t =
+  (* NDT-OK: dashboard read-model freshness clock; it derives display-only
+     effective-due state and never mutates the schedule store or runs work. *)
+  let now = Unix.gettimeofday () in
+  let schedules = Schedule_service.list config () in
+  let active_count =
+    List.fold_left
+      (fun count request -> if schedule_request_active request then count + 1 else count)
+      0 schedules
+  in
+  let terminal_count = List.length schedules - active_count in
+  let due_effective_count =
+    List.fold_left
+      (fun count request -> if schedule_effectively_due ~now request then count + 1 else count)
+      0 schedules
+  in
+  let sorted =
+    schedules
+    |> List.sort (fun left right ->
+      match
+        ( schedule_request_active left
+        , schedule_request_active right
+        , compare left.due_at right.due_at )
+      with
+      | true, false, _ -> -1
+      | false, true, _ -> 1
+      | _, _, due_cmp when due_cmp <> 0 -> due_cmp
+      | _ -> String.compare left.schedule_id right.schedule_id)
+  in
+  let request_rows = take schedule_projection_request_limit sorted in
+  `Assoc
+    [ "schema", `String "masc.dashboard.scheduled_automation.v1"
+    ; "source", `String "schedule_store"
+    ; "generated_at", `String (Masc_domain.now_iso ())
+    ; "request_count", `Int (List.length schedules)
+    ; "request_limit", `Int schedule_projection_request_limit
+    ; "truncated", `Bool (List.length schedules > schedule_projection_request_limit)
+    ; "counts", schedule_counts_json schedules
+    ; "derived_counts", `Assoc [ "due_effective", `Int due_effective_count ]
+    ; ( "fsm"
+      , `Assoc
+          [ "state", `String (schedule_fsm_state ~now schedules)
+          ; "active_count", `Int active_count
+          ; "terminal_count", `Int terminal_count
+          ; "next_due_at", unix_iso_option_json (schedule_next_due_at schedules)
+          ] )
+    ; "requests", `List (List.map schedule_request_dashboard_json request_rows)
+    ]
 ;;
 
 let dashboard_tools_http_json ?actor ?timing (config : Workspace.config) : Yojson.Safe.t =
@@ -1711,14 +1879,25 @@ let dashboard_tools_http_json ?actor ?timing (config : Workspace.config) : Yojso
       ; "tool_usage", usage
       ]
   in
-  match timing with
-  | None ->
-    Dashboard_cache.get_or_compute cache_key ~ttl:dashboard_tools_cache_ttl_sec
-      compute
-  | Some t ->
-    Server_timing.measure t Cache_lookup (fun () ->
-      Dashboard_cache.get_or_compute cache_key
-        ~ttl:dashboard_tools_cache_ttl_sec compute)
+  let attach_scheduled_automation json =
+    let scheduled_automation =
+      run Tools_compute (fun () -> scheduled_automation_dashboard_json config)
+    in
+    match json with
+    | `Assoc fields -> `Assoc (fields @ [ "scheduled_automation", scheduled_automation ])
+    | other -> other
+  in
+  let cached =
+    match timing with
+    | None ->
+      Dashboard_cache.get_or_compute cache_key ~ttl:dashboard_tools_cache_ttl_sec
+        compute
+    | Some t ->
+      Server_timing.measure t Cache_lookup (fun () ->
+        Dashboard_cache.get_or_compute cache_key
+          ~ttl:dashboard_tools_cache_ttl_sec compute)
+  in
+  attach_scheduled_automation cached
 ;;
 
 let dashboard_perf_http_json = Server_dashboard_http_perf.dashboard_perf_http_json

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -20,6 +20,7 @@
       {!dashboard_runtime_probe_http_json},
       {!runtime_inventory_json},
       {!dashboard_perf_http_json},
+      {!scheduled_automation_dashboard_json},
       {!dashboard_tools_http_json}).
     - {b runtime probe test seams}
       ({!set_dashboard_runtime_probe_runner_for_tests},
@@ -103,6 +104,11 @@ val dashboard_tools_http_json :
     provided, internal phases (config_resolution, runtime_resolution,
     tools_compute) are accumulated into the [Server_timing.t] for surfacing
     via the [Server-Timing] response header. *)
+
+val scheduled_automation_dashboard_json : Workspace.config -> Yojson.Safe.t
+(** Renders the read-only dashboard projection for scheduled internal
+    automation. This summarizes the schedule store as a small FSM envelope
+    plus recent request rows; it does not refresh due state or run work. *)
 
 (** {1 Runtime-probe test seams} *)
 

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -269,7 +269,7 @@ type module_tag = Tool_tag_types.module_tag =
   | Mod_run
   | Mod_compact
   | Mod_agent | Mod_task | Mod_state
-  | Mod_control | Mod_agent_timeline | Mod_misc
+  | Mod_control | Mod_agent_timeline | Mod_schedule | Mod_misc
   | Mod_library | Mod_external
   | Mod_inline
   | Mod_shard

--- a/lib/tool/tool_dispatch.mli
+++ b/lib/tool/tool_dispatch.mli
@@ -162,7 +162,7 @@ type module_tag =
   | Mod_run
   | Mod_compact
   | Mod_agent | Mod_task | Mod_state
-  | Mod_control | Mod_agent_timeline | Mod_misc
+  | Mod_control | Mod_agent_timeline | Mod_schedule | Mod_misc
   | Mod_library
   (* [Mod_external]: dispatched by a server-boundary handler in the
      composition root, not by a peer [Tool_*] module. The tool layer

--- a/lib/tool/tool_tag_types.ml
+++ b/lib/tool/tool_tag_types.ml
@@ -22,6 +22,7 @@ type module_tag =
   | Mod_state
   | Mod_control
   | Mod_agent_timeline
+  | Mod_schedule
   | Mod_misc
   | Mod_library
   | Mod_external

--- a/lib/tool/tool_tag_types.mli
+++ b/lib/tool/tool_tag_types.mli
@@ -20,6 +20,7 @@ type module_tag =
   | Mod_state
   | Mod_control
   | Mod_agent_timeline
+  | Mod_schedule
   | Mod_misc
   | Mod_library
   | Mod_external

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -1,0 +1,341 @@
+type context =
+  { config : Workspace.config
+  ; agent_name : string
+  }
+
+let ( let* ) = Result.bind
+
+let trim_nonempty value =
+  let trimmed = String.trim value in
+  if String.equal trimmed "" then None else Some trimmed
+;;
+
+let string_opt args key =
+  match Json_util.get_string args key with
+  | None -> None
+  | Some value -> trim_nonempty value
+;;
+
+let required_string args key =
+  match string_opt args key with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "%s is required" key)
+;;
+
+let optional_float args key = Json_util.get_float args key
+let optional_int args key = Json_util.get_int args key
+let optional_bool args key = Json_util.get_bool args key
+
+let parse_due_at args =
+  match optional_float args "due_at_unix", string_opt args "due_at_iso" with
+  | Some due_at, _ -> Ok due_at
+  | None, Some iso ->
+    (match Masc_domain.parse_iso8601_opt iso with
+     | Some due_at -> Ok due_at
+     | None -> Error "due_at_iso must be a parseable ISO-8601 timestamp")
+  | None, None -> Error "one of due_at_unix or due_at_iso is required"
+;;
+
+let actor_kind_of_arg args key default =
+  match string_opt args key with
+  | None -> Ok default
+  | Some raw ->
+    (match Schedule_domain.actor_kind_of_string raw with
+     | Ok kind -> Ok kind
+     | Error msg -> Error msg)
+;;
+
+let source_of_arg args =
+  match string_opt args "source" with
+  | None -> Ok Schedule_domain.Operator_request
+  | Some raw ->
+    (match Schedule_domain.schedule_source_of_string raw with
+     | Ok source -> Ok source
+     | Error msg -> Error msg)
+;;
+
+let risk_class_of_arg args =
+  let* raw = required_string args "risk_class" in
+  match Schedule_domain.risk_class_of_string raw with
+  | Ok risk_class -> Ok risk_class
+  | Error msg -> Error msg
+;;
+
+let status_of_arg args =
+  match string_opt args "status" with
+  | None -> Ok None
+  | Some raw ->
+    (match Schedule_domain.schedule_status_of_string raw with
+     | Ok status -> Ok (Some status)
+     | Error msg -> Error msg)
+;;
+
+let actor_from_args args ~prefix ~default_id ~default_kind =
+  let id =
+    match string_opt args (prefix ^ "_id") with
+    | Some id -> id
+    | None -> default_id
+  in
+  let* kind = actor_kind_of_arg args (prefix ^ "_kind") default_kind in
+  let display_name = string_opt args (prefix ^ "_display_name") in
+  if String.equal (String.trim id) ""
+  then Error (prefix ^ "_id must not be empty")
+  else Ok Schedule_domain.{ id; kind; display_name }
+;;
+
+let approved_by_from_args args =
+  let* id = required_string args "approved_by_id" in
+  Ok
+    Schedule_domain.
+      { id
+      ; kind = Human_operator
+      ; display_name = string_opt args "approved_by_display_name"
+      }
+;;
+
+let payload_from_args args =
+  match Json_util.assoc_member_opt "payload" args with
+  | Some (`Assoc _ as payload) -> Ok payload
+  | Some _ -> Error "payload must be an object envelope"
+  | None ->
+    let* kind = required_string args "payload_kind" in
+    let schema_version =
+      (* DET-OK: absent schema_version means the stable schedule payload v1
+         contract, not provider-derived guessing. *)
+      optional_int args "payload_schema_version" |> Option.value ~default:1
+    in
+    let* body =
+      match Json_util.assoc_member_opt "payload_body" args with
+      | None -> Ok (`Assoc [])
+      | Some (`Assoc _ as body) -> Ok body
+      | Some _ -> Error "payload_body must be an object"
+    in
+    Ok
+      (`Assoc
+        [ "kind", `String kind
+        ; "schema_version", `Int schema_version
+        ; "body", body
+        ])
+;;
+
+let schedule_request_json (request : Schedule_domain.schedule_request) =
+  match Schedule_domain.schedule_request_to_yojson request with
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       @ [ ( "due_at_iso"
+           , `String (Masc_domain.iso8601_of_unix_seconds request.due_at) )
+         ; ( "requested_at_iso"
+           , `String (Masc_domain.iso8601_of_unix_seconds request.requested_at) )
+         ; ( "requires_separate_human_grant"
+           , `Bool (Schedule_domain.requires_separate_human_grant request) )
+         ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
+         ])
+  | other -> other
+;;
+
+let ok ~tool_name ~start_time data =
+  Tool_result.make_ok ~tool_name ~start_time ~data ()
+;;
+
+let workflow_error ~tool_name ~start_time message =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Workflow_rejection
+    ~start_time
+    ~data:(Tool_args.error_assoc [ "message", `String message ])
+    message
+;;
+
+let runtime_error ~tool_name ~start_time message =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Runtime_failure
+    ~start_time
+    ~data:(Tool_args.error_assoc [ "message", `String message ])
+    message
+;;
+
+let request_result ~tool_name ~start_time = function
+  | Ok request -> ok ~tool_name ~start_time (schedule_request_json request)
+  | Error msg -> workflow_error ~tool_name ~start_time msg
+;;
+
+(* TEL-OK: schedule tools return [Tool_result.t] through the shared
+   [Tool_dispatch] paths; [Server_bootstrap_maintenance] installs the canonical
+   dispatch observer that records tool telemetry and metrics once for keeper and
+   MCP calls. *)
+let handle_create ~tool_name ~start_time ctx args =
+  let result =
+    let* due_at = parse_due_at args in
+    let* payload = payload_from_args args in
+    let* risk_class = risk_class_of_arg args in
+    let* source = source_of_arg args in
+    let* requested_by =
+      actor_from_args args ~prefix:"requested_by" ~default_id:"operator"
+        ~default_kind:Schedule_domain.Human_operator
+    in
+    let* scheduled_by =
+      actor_from_args args ~prefix:"scheduled_by" ~default_id:ctx.agent_name
+        ~default_kind:Schedule_domain.Automated_actor
+    in
+    let schedule_id = string_opt args "schedule_id" in
+    let requested_at = optional_float args "requested_at_unix" in
+    let expires_at = optional_float args "expires_at_unix" in
+    let approval_required =
+      (* DET-OK: omitted approval_required uses the domain risk policy; callers
+         must opt in only to stricter approval. *)
+      optional_bool args "approval_required" |> Option.value ~default:false
+    in
+    Schedule_service.create ctx.config ?schedule_id ?requested_at ?expires_at
+      ~approval_required ~requested_by ~scheduled_by ~due_at ~payload ~risk_class
+      ~source ()
+    |> Result.map_error Schedule_service.service_error_to_string
+  in
+  match result with
+  | Error msg -> workflow_error ~tool_name ~start_time msg
+  | Ok request -> request_result ~tool_name ~start_time (Ok request)
+;;
+
+let take limit items =
+  let rec loop acc remaining = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | item :: rest -> loop (item :: acc) (remaining - 1) rest
+  in
+  loop [] limit items
+;;
+
+let handle_list ~tool_name ~start_time ctx args =
+  match status_of_arg args with
+  | Error msg -> workflow_error ~tool_name ~start_time msg
+  | Ok status ->
+    let raw_limit =
+      (* DET-OK: list limit is a bounded projection default for read ergonomics;
+         it does not change schedule eligibility or ordering. *)
+      optional_int args "limit" |> Option.value ~default:50
+    in
+    let limit = min 200 (max 1 raw_limit) in
+    let schedules =
+      Schedule_service.list ctx.config ?status ()
+      |> take limit
+      |> List.map schedule_request_json
+    in
+    ok ~tool_name ~start_time
+      (`Assoc
+        [ "status", `String "ok"
+        ; "limit", `Int limit
+        ; "schedules", `List schedules
+        ])
+;;
+
+let handle_get ~tool_name ~start_time ctx args =
+  match required_string args "schedule_id" with
+  | Error msg -> workflow_error ~tool_name ~start_time msg
+  | Ok schedule_id ->
+    (match Schedule_service.get ctx.config ~schedule_id with
+     | None -> workflow_error ~tool_name ~start_time "schedule not found"
+     | Some request -> ok ~tool_name ~start_time (schedule_request_json request))
+;;
+
+let handle_cancel ~tool_name ~start_time ctx args =
+  let result =
+    let* schedule_id = required_string args "schedule_id" in
+    let* cancelled_by_id = required_string args "cancelled_by_id" in
+    let* cancelled_by_kind =
+      actor_kind_of_arg args "cancelled_by_kind" Schedule_domain.Human_operator
+    in
+    let* reason = required_string args "reason" in
+    let* request =
+      Schedule_service.cancel ctx.config ~schedule_id
+      |> Result.map_error Schedule_service.service_error_to_string
+    in
+    Ok (request, cancelled_by_id, cancelled_by_kind, reason)
+  in
+  match result with
+  | Error msg -> workflow_error ~tool_name ~start_time msg
+  | Ok (request, cancelled_by_id, cancelled_by_kind, reason) ->
+    ok ~tool_name ~start_time
+      (`Assoc
+        [ "status", `String "ok"
+        ; "schedule", schedule_request_json request
+        ; ( "cancelled_by"
+          , `Assoc
+              [ "id", `String cancelled_by_id
+              ; "kind", `String (Schedule_domain.actor_kind_to_string cancelled_by_kind)
+              ] )
+        ; "reason", `String reason
+        ])
+;;
+
+let handle_approve ~tool_name ~start_time ctx args =
+  let result =
+    let* schedule_id = required_string args "schedule_id" in
+    let* approved_by = approved_by_from_args args in
+    let grant_id = string_opt args "grant_id" in
+    let approved_at = optional_float args "approved_at_unix" in
+    Schedule_service.approve ctx.config ?grant_id ?approved_at ~schedule_id
+      ~approved_by ()
+    |> Result.map_error Schedule_service.service_error_to_string
+  in
+  request_result ~tool_name ~start_time result
+;;
+
+let handle_reject ~tool_name ~start_time ctx args =
+  let result =
+    let* schedule_id = required_string args "schedule_id" in
+    let* approved_by = approved_by_from_args args in
+    let* reason = required_string args "reason" in
+    let grant_id = string_opt args "grant_id" in
+    let approved_at = optional_float args "approved_at_unix" in
+    Schedule_service.reject ctx.config ?grant_id ?approved_at ~schedule_id
+      ~approved_by ~reason ()
+    |> Result.map_error Schedule_service.service_error_to_string
+  in
+  request_result ~tool_name ~start_time result
+;;
+
+let dispatch ctx ~name ~args : Tool_result.result option =
+  let start_time = Time_compat.now () in
+  let handle f =
+    try Some (f ~tool_name:name ~start_time ctx args) with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Some
+        (runtime_error ~tool_name:name ~start_time
+           (Printf.sprintf "schedule tool failed: %s" (Printexc.to_string exn)))
+  in
+  let open Tool_schemas_schedule in
+  match find_definition name with
+  | Some { action = Create_request; _ } -> handle handle_create
+  | Some { action = List_requests; _ } -> handle handle_list
+  | Some { action = Get_request; _ } -> handle handle_get
+  | Some { action = Cancel_request; _ } -> handle handle_cancel
+  | Some { action = Approve_request; _ } -> handle handle_approve
+  | Some { action = Reject_request; _ } -> handle handle_reject
+  | _ -> None
+;;
+
+let schemas = Tool_schemas_schedule.schemas
+
+let () =
+  List.iter
+    (fun (definition : Tool_schemas_schedule.definition) ->
+      let schema : Masc_domain.tool_schema = definition.schema in
+      let is_read_only = definition.read_only in
+      Tool_spec.register
+        (Tool_spec.create
+           ~name:schema.name
+           ~description:schema.description
+           ~module_tag:Tool_dispatch.Mod_schedule
+           ~input_schema:schema.input_schema
+           ~handler_binding:Tag_dispatch
+           ~is_read_only
+           ~is_idempotent:is_read_only
+           ~effect_domain:
+             (if is_read_only
+              then Tool_catalog.Read_only
+              else Tool_catalog.Masc_workspace)
+           ()))
+    Tool_schemas_schedule.definitions
+;;

--- a/lib/tool_schemas/dune
+++ b/lib/tool_schemas/dune
@@ -13,6 +13,7 @@
   tool_schemas_inline_episodes
   tool_schemas_inline
   tool_schemas_run
+  tool_schemas_schedule
   tool_schemas_library
   tool_schemas_local_runtime
   tools

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -1,0 +1,222 @@
+open Masc_domain
+
+let string_prop ?description ?enum name =
+  let fields =
+    [ "type", `String "string" ]
+    @ (match description with
+       | None -> []
+       | Some value -> [ "description", `String value ])
+    @ (match enum with
+       | None -> []
+       | Some values -> [ "enum", `List (List.map (fun value -> `String value) values) ])
+  in
+  name, `Assoc fields
+;;
+
+let number_prop ?description name =
+  let fields =
+    [ "type", `String "number" ]
+    @
+    match description with
+    | None -> []
+    | Some value -> [ "description", `String value ]
+  in
+  name, `Assoc fields
+;;
+
+let integer_prop ?description name =
+  let fields =
+    [ "type", `String "integer" ]
+    @
+    match description with
+    | None -> []
+    | Some value -> [ "description", `String value ]
+  in
+  name, `Assoc fields
+;;
+
+let bool_prop ?description name =
+  let fields =
+    [ "type", `String "boolean" ]
+    @
+    match description with
+    | None -> []
+    | Some value -> [ "description", `String value ]
+  in
+  name, `Assoc fields
+;;
+
+let object_prop ?description ?(additional_properties = true) name =
+  let fields =
+    [ "type", `String "object"; "additionalProperties", `Bool additional_properties ]
+    @
+    match description with
+    | None -> []
+    | Some value -> [ "description", `String value ]
+  in
+  name, `Assoc fields
+;;
+
+let object_schema ?(required = []) properties =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc properties
+    ; "required", `List (List.map (fun name -> `String name) required)
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let risk_classes =
+  [ "reminder_only"
+  ; "read_only"
+  ; "workspace_write"
+  ; "external_write"
+  ; "destructive"
+  ; "cost_bearing"
+  ]
+;;
+
+let statuses =
+  [ "pending_approval"
+  ; "scheduled"
+  ; "due"
+  ; "running"
+  ; "succeeded"
+  ; "failed"
+  ; "rejected"
+  ; "cancelled"
+  ; "expired"
+  ]
+;;
+
+let actor_kinds = [ "human_operator"; "automated_actor"; "system" ]
+
+let sources = [ "operator_request"; "automated_request"; "system_request" ]
+
+let create_schema =
+  object_schema
+    ~required:[ "risk_class" ]
+    [ number_prop ~description:"Unix timestamp in seconds. Provide this or due_at_iso." "due_at_unix"
+    ; string_prop ~description:"ISO-8601 timestamp. Provide this or due_at_unix." "due_at_iso"
+    ; object_prop
+        ~description:
+          "Typed schedule payload envelope: {kind:string, schema_version:int, body:object}."
+        "payload"
+    ; string_prop ~description:"Payload kind used when payload is omitted." "payload_kind"
+    ; integer_prop ~description:"Payload schema version used when payload is omitted." "payload_schema_version"
+    ; object_prop ~description:"Payload body used when payload is omitted." "payload_body"
+    ; string_prop ~enum:risk_classes "risk_class"
+    ; bool_prop
+        ~description:
+          "Force a separate human grant even for reminder_only or read_only requests."
+        "approval_required"
+    ; string_prop ~description:"Optional stable schedule id." "schedule_id"
+    ; number_prop ~description:"Optional request timestamp for replay/tests." "requested_at_unix"
+    ; number_prop ~description:"Optional expiry timestamp." "expires_at_unix"
+    ; string_prop ~description:"Requester actor id. Defaults to operator." "requested_by_id"
+    ; string_prop ~enum:actor_kinds "requested_by_kind"
+    ; string_prop ~description:"Requester display name." "requested_by_display_name"
+    ; string_prop ~description:"Scheduler actor id. Defaults to caller agent name." "scheduled_by_id"
+    ; string_prop ~enum:actor_kinds "scheduled_by_kind"
+    ; string_prop ~description:"Scheduler display name." "scheduled_by_display_name"
+    ; string_prop ~enum:sources "source"
+    ]
+;;
+
+let list_schema =
+  object_schema
+    [ string_prop ~enum:statuses "status"
+    ; integer_prop ~description:"Maximum rows to return. Defaults to 50, capped at 200." "limit"
+    ]
+;;
+
+let get_schema =
+  object_schema ~required:[ "schedule_id" ]
+    [ string_prop ~description:"Schedule id to read." "schedule_id" ]
+;;
+
+let cancel_schema =
+  object_schema ~required:[ "schedule_id"; "cancelled_by_id"; "reason" ]
+    [ string_prop ~description:"Schedule id to cancel." "schedule_id"
+    ; string_prop ~description:"Human or system actor id cancelling the schedule." "cancelled_by_id"
+    ; string_prop ~enum:actor_kinds "cancelled_by_kind"
+    ; string_prop ~description:"Reason for operator-visible cancellation." "reason"
+    ]
+;;
+
+let approve_schema =
+  object_schema ~required:[ "schedule_id"; "approved_by_id" ]
+    [ string_prop ~description:"Pending schedule id to approve." "schedule_id"
+    ; string_prop ~description:"Human approver id; cannot equal requester or scheduler." "approved_by_id"
+    ; string_prop ~description:"Approver display name." "approved_by_display_name"
+    ; string_prop ~description:"Optional stable grant id." "grant_id"
+    ; number_prop ~description:"Optional approval timestamp for replay/tests." "approved_at_unix"
+    ]
+;;
+
+let reject_schema =
+  object_schema ~required:[ "schedule_id"; "approved_by_id"; "reason" ]
+    [ string_prop ~description:"Pending schedule id to reject." "schedule_id"
+    ; string_prop ~description:"Human approver id; cannot equal requester or scheduler." "approved_by_id"
+    ; string_prop ~description:"Approver display name." "approved_by_display_name"
+    ; string_prop ~description:"Optional stable grant id." "grant_id"
+    ; number_prop ~description:"Optional decision timestamp for replay/tests." "approved_at_unix"
+    ; string_prop ~description:"Human-readable rejection reason." "reason"
+    ]
+;;
+
+type action =
+  | Create_request
+  | List_requests
+  | Get_request
+  | Cancel_request
+  | Approve_request
+  | Reject_request
+
+type definition =
+  { action : action
+  ; id : string
+  ; schema : Masc_domain.tool_schema
+  ; read_only : bool
+  }
+
+let definition ~action ~id ~name ~description ~input_schema ~read_only =
+  { action; id; schema = { name; description; input_schema }; read_only }
+;;
+
+let definitions : definition list =
+  [ definition ~action:Create_request ~id:"create" ~name:"masc_schedule_create"
+      ~description:
+        "Create a durable scheduled internal automation request. Side-effecting requests start pending approval and require a later separate human grant."
+      ~input_schema:create_schema ~read_only:false
+  ; definition ~action:List_requests ~id:"list" ~name:"masc_schedule_list"
+      ~description:"List durable scheduled internal automation requests."
+      ~input_schema:list_schema ~read_only:true
+  ; definition ~action:Get_request ~id:"get" ~name:"masc_schedule_get"
+      ~description:"Read one durable scheduled internal automation request."
+      ~input_schema:get_schema ~read_only:true
+  ; definition ~action:Cancel_request ~id:"cancel" ~name:"masc_schedule_cancel"
+      ~description:
+        "Cancel a pending, scheduled, or due scheduled request before execution."
+      ~input_schema:cancel_schema ~read_only:false
+  ; definition ~action:Approve_request ~id:"approve" ~name:"masc_schedule_approve"
+      ~description:
+        "Record a separate human execution grant for a pending scheduled request."
+      ~input_schema:approve_schema ~read_only:false
+  ; definition ~action:Reject_request ~id:"reject" ~name:"masc_schedule_reject"
+      ~description:"Reject a pending scheduled request with a human decision."
+      ~input_schema:reject_schema ~read_only:false
+  ]
+;;
+
+let schemas : Masc_domain.tool_schema list =
+  List.map (fun definition -> definition.schema) definitions
+;;
+
+let find_definition name =
+  List.find_opt
+    (fun definition ->
+      let schema : Masc_domain.tool_schema = definition.schema in
+      String.equal schema.name name)
+    definitions
+;;

--- a/lib/tool_schemas/tool_schemas_schedule.mli
+++ b/lib/tool_schemas/tool_schemas_schedule.mli
@@ -1,0 +1,18 @@
+type action =
+  | Create_request
+  | List_requests
+  | Get_request
+  | Cancel_request
+  | Approve_request
+  | Reject_request
+
+type definition =
+  { action : action
+  ; id : string
+  ; schema : Masc_domain.tool_schema
+  ; read_only : bool
+  }
+
+val definitions : definition list
+val schemas : Masc_domain.tool_schema list
+val find_definition : string -> definition option

--- a/lib/tool_schemas/tools.ml
+++ b/lib/tool_schemas/tools.ml
@@ -26,6 +26,7 @@ let raw_schemas : tool_schema list =
   @ Tool_schemas_inline.schemas
   @ Tool_schemas_agent.schemas
   @ Tool_schemas_run.schemas
+  @ Tool_schemas_schedule.schemas
   @ Masc_task_handlers.Tool_task_schemas.schemas
   @ Tool_schemas_library.schemas
 

--- a/test/dune
+++ b/test/dune
@@ -1064,6 +1064,11 @@
  (modules test_schedule_runner)
  (libraries masc_test_deps masc_schedule))
 
+(test
+ (name test_schedule_tool_wiring)
+ (modules test_schedule_tool_wiring)
+ (libraries masc_test_deps masc_schedule))
+
 ; Typed TOML field resolution helper (RFC-0141 Phase 1).
 
 (test

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -129,6 +129,19 @@ let test_grant_records_and_schedules_request () =
   | None -> fail "schedule missing"
 ;;
 
+let test_cancel_request_marks_cancelled () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request ~schedule_id:"cancel-1" ~risk_class:Read_only () in
+  ignore (insert_ok config req);
+  (match cancel_request config ~schedule_id:req.schedule_id with
+   | Ok updated -> check_status "cancelled status" Cancelled updated.status
+   | Error err -> fail (store_error_to_string err));
+  match get_schedule config ~schedule_id:req.schedule_id with
+  | Some stored -> check_status "stored cancelled" Cancelled stored.status
+  | None -> fail "schedule missing"
+;;
+
 let test_requester_grant_rejected_without_bump () =
   with_workspace
   @@ fun config ->
@@ -204,6 +217,8 @@ let () =
             test_store_rejects_side_effecting_scheduled_insert;
           test_case "grant records and schedules request" `Quick
             test_grant_records_and_schedules_request;
+          test_case "cancel request marks cancelled" `Quick
+            test_cancel_request_marks_cancelled;
           test_case "requester grant rejected without bump" `Quick
             test_requester_grant_rejected_without_bump;
         ] );

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -1,0 +1,141 @@
+open Alcotest
+open Masc
+
+let with_config f =
+  let path = Filename.temp_file "schedule_tool_wiring_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then begin
+            Sys.readdir path
+            |> Array.iter (fun entry -> rm (Filename.concat path entry));
+            Unix.rmdir path
+          end else
+            Sys.remove path
+      in
+      rm path)
+    (fun () -> f (Workspace.default_config path))
+;;
+
+let payload =
+  `Assoc
+    [ "kind", `String "test.reminder"
+    ; "schema_version", `Int 1
+    ; "body", `Assoc [ "message", `String "wake me" ]
+    ]
+;;
+
+let create_fields =
+  [ "due_at_unix", `Float 200.0
+  ; "risk_class", `String "read_only"
+  ; "payload", payload
+  ; "requested_by_id", `String "operator"
+  ; "scheduled_by_id", `String "scheduler-agent"
+  ]
+;;
+
+let create_args = `Assoc create_fields
+
+let schedule_definition action =
+  match
+    List.find_opt
+      (fun (definition : Tool_schemas_schedule.definition) ->
+        definition.action = action)
+      Tool_schemas_schedule.definitions
+  with
+  | Some definition -> definition
+  | None -> fail "schedule definition missing"
+;;
+
+let schedule_tool_name action =
+  let schema : Masc_domain.tool_schema = (schedule_definition action).schema in
+  schema.name
+;;
+
+let test_schema_and_descriptor_exposed () =
+  let create_name = schedule_tool_name Tool_schemas_schedule.Create_request in
+  let schema_names =
+    Config.raw_all_tool_schemas
+    |> List.map (fun (s : Masc_domain.tool_schema) -> s.name)
+  in
+  check bool "raw schema has create" true (List.mem create_name schema_names);
+  check bool "tag registered" true
+    (Tool_dispatch.lookup_tag create_name = Some Tool_dispatch.Mod_schedule);
+  let descriptor_names =
+    Keeper_tool_descriptor.all_descriptors ()
+    |> List.map (fun (d : Keeper_tool_descriptor.t) -> d.internal_name)
+  in
+  check bool "descriptor has create" true (List.mem create_name descriptor_names)
+;;
+
+let schedule_ctx config : Tool_schedule.context =
+  { config; agent_name = "scheduler-agent" }
+;;
+
+let test_dispatch_create_persists_schedule () =
+  with_config
+  @@ fun config ->
+  match
+    Tool_schedule.dispatch (schedule_ctx config)
+      ~name:(schedule_tool_name Tool_schemas_schedule.Create_request)
+      ~args:create_args
+  with
+  | None -> fail "dispatch returned None"
+  | Some result ->
+    check bool "create succeeds" true (Tool_result.is_success result);
+    let state = Schedule_store.read_state config in
+    check int "one schedule persisted" 1 (List.length state.schedules);
+    let request = List.hd state.schedules in
+    check string "status" "scheduled"
+      (Schedule_domain.schedule_status_to_string request.status)
+;;
+
+let test_dispatch_cancel_persists_status () =
+  with_config
+  @@ fun config ->
+  let create_result =
+    Tool_schedule.dispatch (schedule_ctx config)
+      ~name:(schedule_tool_name Tool_schemas_schedule.Create_request)
+      ~args:(`Assoc (("schedule_id", `String "sched-cancel") :: create_fields))
+  in
+  (match create_result with
+   | Some result when Tool_result.is_success result -> ()
+   | Some result -> fail ("create failed: " ^ Tool_result.message result)
+   | None -> fail "create dispatch returned None");
+  let cancel_args =
+    `Assoc
+      [ "schedule_id", `String "sched-cancel"
+      ; "cancelled_by_id", `String "operator"
+      ; "reason", `String "test cleanup"
+      ]
+  in
+  match
+    Tool_schedule.dispatch (schedule_ctx config)
+      ~name:(schedule_tool_name Tool_schemas_schedule.Cancel_request)
+      ~args:cancel_args
+  with
+  | None -> fail "cancel dispatch returned None"
+  | Some result ->
+    check bool "cancel succeeds" true (Tool_result.is_success result);
+    match Schedule_store.get_schedule config ~schedule_id:"sched-cancel" with
+    | None -> fail "schedule missing"
+    | Some request ->
+      check string "status" "cancelled"
+        (Schedule_domain.schedule_status_to_string request.status)
+;;
+
+let () =
+  run "Schedule_tool_wiring"
+    [ ( "wiring"
+      , [ test_case "schema and descriptor exposed" `Quick
+            test_schema_and_descriptor_exposed
+        ; test_case "dispatch create persists schedule" `Quick
+            test_dispatch_create_persists_schedule
+        ; test_case "dispatch cancel persists status" `Quick
+            test_dispatch_cancel_persists_status
+        ] )
+    ]
+;;

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -37,6 +37,14 @@ let create_fields =
   ]
 ;;
 
+let human id : Schedule_domain.actor =
+  { id; kind = Schedule_domain.Human_operator; display_name = None }
+;;
+
+let automated id : Schedule_domain.actor =
+  { id; kind = Schedule_domain.Automated_actor; display_name = None }
+;;
+
 let create_args = `Assoc create_fields
 
 let schedule_definition action =
@@ -127,6 +135,54 @@ let test_dispatch_cancel_persists_status () =
         (Schedule_domain.schedule_status_to_string request.status)
 ;;
 
+let create_schedule_exn
+  config
+  ~schedule_id
+  ~due_at
+  ~risk_class
+  ~requested_by
+  ~scheduled_by
+  =
+  match
+    Schedule_service.create config ~schedule_id ~requested_at:100.0
+      ~requested_by ~scheduled_by ~due_at ~payload ~risk_class
+      ~source:Schedule_domain.Operator_request ()
+  with
+  | Ok request -> request
+  | Error err ->
+    fail ("schedule create failed: " ^ Schedule_service.service_error_to_string err)
+;;
+
+let test_dashboard_projection_surfaces_schedule_fsm () =
+  with_config
+  @@ fun config ->
+  ignore
+    (create_schedule_exn config ~schedule_id:"sched-due" ~due_at:1.0
+       ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
+       ~scheduled_by:(automated "scheduler-agent")
+      : Schedule_domain.schedule_request);
+  ignore
+    (create_schedule_exn config ~schedule_id:"sched-approval" ~due_at:300.0
+       ~risk_class:Schedule_domain.Workspace_write ~requested_by:(human "operator")
+       ~scheduled_by:(automated "scheduler-agent")
+      : Schedule_domain.schedule_request);
+  let json =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  check string "schema" "masc.dashboard.scheduled_automation.v1"
+    (json |> member "schema" |> to_string);
+  check int "request count" 2 (json |> member "request_count" |> to_int);
+  check string "fsm state" "pending_approval"
+    (json |> member "fsm" |> member "state" |> to_string);
+  check int "pending count" 1
+    (json |> member "counts" |> member "pending_approval" |> to_int);
+  check int "scheduled count" 1
+    (json |> member "counts" |> member "scheduled" |> to_int);
+  check int "due effective count" 1
+    (json |> member "derived_counts" |> member "due_effective" |> to_int)
+;;
+
 let () =
   run "Schedule_tool_wiring"
     [ ( "wiring"
@@ -136,6 +192,8 @@ let () =
             test_dispatch_create_persists_schedule
         ; test_case "dispatch cancel persists status" `Quick
             test_dispatch_cancel_persists_status
+        ; test_case "dashboard projection surfaces schedule FSM" `Quick
+            test_dashboard_projection_surfaces_schedule_fsm
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- expose RFC-0234 `masc_schedule_*` tools through the shared schema catalog, tag dispatch, keeper descriptors, and MCP execution path
- make schedule tool metadata a single source of truth via `Tool_schemas_schedule.definitions`; schemas, runtime dispatch, `Tool_spec` registration, keeper descriptors, and tests now derive from it
- add schedule `create/list/get/cancel/approve/reject` in-process runtime wiring
- start the schedule runner from server maintenance with per-tick failure isolation
- add a read-only dashboard `scheduled_automation` projection with a small FSM envelope, status counts, effective-due count, next due timestamp, and recent request rows
- render the schedule FSM projection in the Tools dashboard surface
- add cancel support plus wiring/dashboard projection coverage tests

## Product impact

Keepers and MCP clients can now see and call scheduled automation tools. Dashboard users can also see whether scheduled automation is idle, pending approval, scheduled, due, or running without inferring that from raw tool inventory.

## Boundary notes

- MASC owns scheduled automation exposure, execution wiring, and dashboard projection.
- OAS remains untouched; no provider/model transport boundary was moved.
- The schedule dashboard FSM is read-only and derived from the schedule store. It does not refresh due state, run work, pause keepers, or mutate runtime state.
- Schedule projection is attached outside the existing 30s tools cache so due/pending state is not hidden behind inventory caching.
- Runtime failure isolation is per schedule-runner tick, so a bad tick is logged and does not stop keeper/server sibling fibers.

## Evidence

- `opam exec -- ocamlformat --check lib/schedule/schedule_domain.ml lib/schedule/schedule_domain.mli lib/server/server_dashboard_http_runtime_info.ml lib/server/server_dashboard_http_runtime_info.mli test/test_schedule_tool_wiring.ml`
- `scripts/dune-local.sh build lib/schedule/schedule_domain.ml lib/schedule/schedule_domain.mli lib/server/server_dashboard_http_runtime_info.ml lib/server/server_dashboard_http_runtime_info.mli test/test_schedule_tool_wiring.exe`
- `./_build/default/test/test_schedule_tool_wiring.exe`
- `git diff --check`

## Validation notes

- `scripts/dune-local.sh exec ./test/test_schedule_tool_wiring.exe` was not used after the latest build because a separate bare Dune process appeared and the wrapper refused to start another build; the already-built test binary was run directly instead.
- `pnpm --dir dashboard run typecheck` is blocked locally because `dashboard/node_modules` is missing and `tsc` is not installed in this worktree.
- GitHub checks are pending after the latest push.

## Direct evidence

```yaml
schema_version: 1
provenance: operator_proxy
stages:
  - name: schedule_tool_wiring_and_dashboard_projection
    command: ./_build/default/test/test_schedule_tool_wiring.exe
    result: pass
    proves:
      - raw schema catalog exposure
      - Tool_dispatch tag lookup
      - keeper descriptor exposure
      - dispatch create persistence
      - dispatch cancel persistence
      - dashboard scheduled_automation FSM projection
  - name: dashboard_projection_focused_build
    command: scripts/dune-local.sh build lib/schedule/schedule_domain.ml lib/schedule/schedule_domain.mli lib/server/server_dashboard_http_runtime_info.ml lib/server/server_dashboard_http_runtime_info.mli test/test_schedule_tool_wiring.exe
    result: pass
  - name: dashboard_ts_typecheck
    command: pnpm --dir dashboard run typecheck
    result: blocked
    reason: dashboard/node_modules missing; tsc not found
  - name: github_required_checks
    command: gh pr checks 21061 --repo jeong-sik/masc
    result: pending
```

## GOAL LOOP ACT checklist

- [x] Observe — RFC-0234 schedule core existed without complete tool catalog/keeper descriptor/server tick wiring, and dashboard only exposed tools inventory/usage.
- [x] Orient — mapped to schedule tool exposure plus read-only dashboard state projection without crossing into OAS or keeper turn FSM ownership.
- [x] Decide — bounded to MASC tool/keeper/server wiring, schedule service cancel support, and a dashboard schedule-store FSM projection.
- [x] Act — added schema/dispatch/runtime/tick wiring, cancel service path, centralized schedule tool metadata, dashboard projection, and Tools panel rendering.
- [x] Verify — focused OCaml build, projection/wiring test, ocamlformat, and diff whitespace checks pass; dashboard TS typecheck is locally blocked by missing dependencies.
- [x] Loop — hardcoded schedule metadata was removed from runtime/keeper/test surfaces after review; schedule status counts now derive from `Schedule_domain.all_schedule_statuses`.

## Linked issue

- None.

## Variant addition checklist

- [x] **OCaml** — `Mod_schedule`, `Tool_masc_schedule_dispatch`, schedule dashboard projection, and exhaustive dispatch/runtime matches updated.
- [x] **TypeScript** — `DashboardToolsResponse` now includes `scheduled_automation`; Tools dashboard renders the FSM projection.
- [ ] **TLA+ spec** — N/A; no TLA+ domain literal touched.
- [x] **Event / JSON schema** — schedule tool JSON schemas added to the tool schema catalog; dashboard projection schema is `masc.dashboard.scheduled_automation.v1`.
- [ ] **CI** — pending after the latest push.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/schedule-tool-wiring-20260613` → `main` · 2 commit(s) · synced 2026-06-13T01:53:21Z

| sha | subject | date |
|---|---|---|
| `bcf030045` | wire schedule automation tools | 2026-06-12 |
| `d762b075e` | Expose schedule FSM on dashboard | 2026-06-13 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->