### PR TITLE
[codex] fix keeper tool pair repair

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -93,7 +93,7 @@ type overflow_retry_recovery = {
   turn_generation : int;
 } [@@warning "-69"]
 
-let log_orphan_tool_result_repair
+let log_tool_pair_repair
     ~keeper_name
     ~site
     (stats : Keeper_context_core.tool_pair_repair_stats) =
@@ -104,7 +104,17 @@ let log_orphan_tool_result_repair
         (`Assoc
             [ "keeper_name", `String keeper_name
             ; "site", `String site
+            ; "dropped_tool_uses", `Int stats.dropped_tool_uses
             ; "dropped_tool_results", `Int stats.dropped_tool_results
+            ; ( "dropped_tool_use_samples"
+              , `List
+                  (List.map
+                     (fun (tool_use_id, tool_name) ->
+                        `Assoc
+                          [ "tool_use_id", `String tool_use_id
+                          ; "tool_name", `String tool_name
+                          ])
+                     stats.dropped_tool_use_samples) )
             ; ( "dropped_tool_result_ids"
               , `List
                   (List.map
@@ -112,9 +122,11 @@ let log_orphan_tool_result_repair
                      stats.dropped_tool_result_ids) )
             ])
       (Printf.sprintf
-         "orphan_tool_result_repair keeper=%s site=%s dropped_tool_results=%d"
+         "tool_pair_repair keeper=%s site=%s dropped_tool_uses=%d \
+          dropped_tool_results=%d"
          keeper_name
          site
+         stats.dropped_tool_uses
          stats.dropped_tool_results)
 
 (* ── Tier A5: autonomous post-turn wire-in (Cycle 22) ──────────────
@@ -618,10 +630,10 @@ let apply_post_turn_lifecycle_with_resilience_handles
           in
           let compacted_ctx =
             let messages, pair_repair_stats =
-              repair_orphan_tool_result_messages_with_stats
+              repair_broken_tool_call_pairs_with_stats
                 (messages_of_context compacted_ctx)
             in
-            log_orphan_tool_result_repair
+            log_tool_pair_repair
               ~keeper_name:base_meta.agent_name
               ~site:"post_turn_compaction"
               pair_repair_stats;
@@ -895,10 +907,10 @@ let recover_latest_checkpoint_for_overflow_retry
         in
         let compacted_ctx =
           let messages, pair_repair_stats =
-            repair_orphan_tool_result_messages_with_stats
+            repair_broken_tool_call_pairs_with_stats
               (messages_of_context compacted_ctx)
           in
-          log_orphan_tool_result_repair
+          log_tool_pair_repair
             ~keeper_name:meta.agent_name
             ~site:"post_turn_compaction_recovery"
             pair_repair_stats;

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -47,7 +47,7 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_context_core
 
-let log_orphan_tool_result_repair
+let log_tool_pair_repair
     ~keeper_name
     ~site
     (stats : Keeper_context_core.tool_pair_repair_stats) =
@@ -58,7 +58,17 @@ let log_orphan_tool_result_repair
         (`Assoc
             [ "keeper_name", `String keeper_name
             ; "site", `String site
+            ; "dropped_tool_uses", `Int stats.dropped_tool_uses
             ; "dropped_tool_results", `Int stats.dropped_tool_results
+            ; ( "dropped_tool_use_samples"
+              , `List
+                  (List.map
+                     (fun (tool_use_id, tool_name) ->
+                        `Assoc
+                          [ "tool_use_id", `String tool_use_id
+                          ; "tool_name", `String tool_name
+                          ])
+                     stats.dropped_tool_use_samples) )
             ; ( "dropped_tool_result_ids"
               , `List
                   (List.map
@@ -66,9 +76,11 @@ let log_orphan_tool_result_repair
                      stats.dropped_tool_result_ids) )
             ])
       (Printf.sprintf
-         "orphan_tool_result_repair keeper=%s site=%s dropped_tool_results=%d"
+         "tool_pair_repair keeper=%s site=%s dropped_tool_uses=%d \
+          dropped_tool_results=%d"
          keeper_name
          site
+         stats.dropped_tool_uses
          stats.dropped_tool_results)
 
 type handoff_rollover = {
@@ -286,10 +298,10 @@ let maybe_rollover_oas_handoff
           in
           let save_ctx =
             let messages, pair_repair_stats =
-              repair_orphan_tool_result_messages_with_stats
+              repair_broken_tool_call_pairs_with_stats
                 (messages_of_context ctx)
             in
-            log_orphan_tool_result_repair
+            log_tool_pair_repair
               ~keeper_name:base_meta.agent_name
               ~site:"handoff_rollover"
               pair_repair_stats;

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -251,65 +251,6 @@ let test_pair_repair_integration () =
       (Option.is_some local_pos)
   end
 
-let test_lifecycle_checkpoint_saves_use_full_pair_repair () =
-  let find_substring ?(start = 0) haystack needle =
-    let hlen = String.length haystack in
-    let nlen = String.length needle in
-    let rec loop i =
-      if i + nlen > hlen then None
-      else if String.sub haystack i nlen = needle then Some i
-      else loop (i + 1)
-    in
-    if nlen = 0 then Some start else loop start
-  in
-  let has_prompt_root path =
-    Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")
-  in
-  let repo_root =
-    match Sys.getenv_opt "DUNE_SOURCEROOT" with
-    | Some root when has_prompt_root root -> root
-    | _ ->
-        let rec ascend path =
-          if has_prompt_root path then path
-          else
-            let parent = Filename.dirname path in
-            if String.equal parent path then Sys.getcwd () else ascend parent
-        in
-        ascend (Sys.getcwd ())
-  in
-  let read_source rel =
-    let target = Filename.concat repo_root rel in
-    if not (Sys.file_exists target)
-    then None
-    else
-      let ic = open_in target in
-      Some
-        (Fun.protect
-           ~finally:(fun () -> close_in ic)
-           (fun () ->
-              let len = in_channel_length ic in
-              let buf = Bytes.create len in
-              really_input ic buf 0 len;
-              Bytes.to_string buf))
-  in
-  let assert_full_repair rel =
-    match read_source rel with
-    | None -> ()
-    | Some content ->
-        Alcotest.(check bool)
-          (rel ^ " must use full non-fabricating tool pair repair")
-          true
-          (Option.is_some
-             (find_substring content "repair_broken_tool_call_pairs_with_stats"));
-        Alcotest.(check bool)
-          (rel ^ " must not use orphan-only repair before checkpoint save")
-          true
-          (Option.is_none
-             (find_substring content "repair_orphan_tool_result_messages_with_stats"))
-  in
-  assert_full_repair "lib/keeper/keeper_post_turn.ml";
-  assert_full_repair "lib/keeper/keeper_rollover.ml"
-
 let user_text text : Agent_sdk.Types.message =
   { role = Agent_sdk.Types.User
   ; content = [ Agent_sdk.Types.Text text ]
@@ -837,10 +778,6 @@ let () =
         test_cap_message_tokens_integration;
       Alcotest.test_case "local pair repair integrated in reducer chain" `Quick
         test_pair_repair_integration;
-      Alcotest.test_case
-        "lifecycle checkpoint saves use full pair repair"
-        `Quick
-        test_lifecycle_checkpoint_saves_use_full_pair_repair;
       Alcotest.test_case "pair repair stats count drops" `Quick
         test_pair_repair_stats_count_drops;
       Alcotest.test_case "pair repair drops dangling tool-use details" `Quick

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -667,6 +667,48 @@ let test_checkpoint_sanitize_preserves_pair_repair_stats () =
     false
     (text_contains "unpaired tool use elided" texts)
 
+let test_checkpoint_save_repair_drops_unpaired_tool_blocks () =
+  let raw_messages =
+    [ user_text "q"
+    ; assistant_text_and_tool_use "assistant kept text" "dangling" "calc"
+    ; user_text "interrupt"
+    ; user_text_and_tool_result "result wrapper kept text" "orphan" "late"
+    ]
+  in
+  let repaired_messages, stats =
+    KC.repair_broken_tool_call_pairs_with_stats raw_messages
+  in
+  Alcotest.(check int)
+    "save repair drops dangling tool-use"
+    1
+    stats.dropped_tool_uses;
+  Alcotest.(check int)
+    "save repair drops orphan tool-result"
+    1
+    stats.dropped_tool_results;
+  let save_ctx =
+    KC.create ~system_prompt:"system" ~max_tokens:4096
+    |> fun ctx -> KC.append_many ctx repaired_messages
+  in
+  let checkpoint = KC.checkpoint_of_context save_ctx in
+  Alcotest.(check (pair int int))
+    "checkpoint save payload has no unpaired tool blocks"
+    (0, 0)
+    (count_tool_blocks checkpoint.Agent_sdk.Checkpoint.messages);
+  let texts = text_blocks checkpoint.Agent_sdk.Checkpoint.messages in
+  Alcotest.(check bool)
+    "checkpoint save keeps assistant text"
+    true
+    (text_contains "assistant kept text" texts);
+  Alcotest.(check bool)
+    "checkpoint save keeps wrapper text"
+    true
+    (text_contains "result wrapper kept text" texts);
+  Alcotest.(check bool)
+    "checkpoint save does not create visible repair marker"
+    false
+    (text_contains "unpaired tool use elided" texts)
+
 let test_pair_repair_drops_empty_structural_messages_with_stats () =
   let messages =
     [ user_text "q"
@@ -794,6 +836,8 @@ let () =
         test_pair_repair_metadata_samples_bounded;
       Alcotest.test_case "checkpoint sanitize preserves pair repair stats" `Quick
         test_checkpoint_sanitize_preserves_pair_repair_stats;
+      Alcotest.test_case "checkpoint save repair drops unpaired tool blocks" `Quick
+        test_checkpoint_save_repair_drops_unpaired_tool_blocks;
       Alcotest.test_case "pair repair drops empty structural messages with stats" `Quick
         test_pair_repair_drops_empty_structural_messages_with_stats;
       Alcotest.test_case "pair repair caps diagnostic sample strings" `Quick

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -251,6 +251,65 @@ let test_pair_repair_integration () =
       (Option.is_some local_pos)
   end
 
+let test_lifecycle_checkpoint_saves_use_full_pair_repair () =
+  let find_substring ?(start = 0) haystack needle =
+    let hlen = String.length haystack in
+    let nlen = String.length needle in
+    let rec loop i =
+      if i + nlen > hlen then None
+      else if String.sub haystack i nlen = needle then Some i
+      else loop (i + 1)
+    in
+    if nlen = 0 then Some start else loop start
+  in
+  let has_prompt_root path =
+    Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")
+  in
+  let repo_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root when has_prompt_root root -> root
+    | _ ->
+        let rec ascend path =
+          if has_prompt_root path then path
+          else
+            let parent = Filename.dirname path in
+            if String.equal parent path then Sys.getcwd () else ascend parent
+        in
+        ascend (Sys.getcwd ())
+  in
+  let read_source rel =
+    let target = Filename.concat repo_root rel in
+    if not (Sys.file_exists target)
+    then None
+    else
+      let ic = open_in target in
+      Some
+        (Fun.protect
+           ~finally:(fun () -> close_in ic)
+           (fun () ->
+              let len = in_channel_length ic in
+              let buf = Bytes.create len in
+              really_input ic buf 0 len;
+              Bytes.to_string buf))
+  in
+  let assert_full_repair rel =
+    match read_source rel with
+    | None -> ()
+    | Some content ->
+        Alcotest.(check bool)
+          (rel ^ " must use full non-fabricating tool pair repair")
+          true
+          (Option.is_some
+             (find_substring content "repair_broken_tool_call_pairs_with_stats"));
+        Alcotest.(check bool)
+          (rel ^ " must not use orphan-only repair before checkpoint save")
+          true
+          (Option.is_none
+             (find_substring content "repair_orphan_tool_result_messages_with_stats"))
+  in
+  assert_full_repair "lib/keeper/keeper_post_turn.ml";
+  assert_full_repair "lib/keeper/keeper_rollover.ml"
+
 let user_text text : Agent_sdk.Types.message =
   { role = Agent_sdk.Types.User
   ; content = [ Agent_sdk.Types.Text text ]
@@ -778,6 +837,10 @@ let () =
         test_cap_message_tokens_integration;
       Alcotest.test_case "local pair repair integrated in reducer chain" `Quick
         test_pair_repair_integration;
+      Alcotest.test_case
+        "lifecycle checkpoint saves use full pair repair"
+        `Quick
+        test_lifecycle_checkpoint_saves_use_full_pair_repair;
       Alcotest.test_case "pair repair stats count drops" `Quick
         test_pair_repair_stats_count_drops;
       Alcotest.test_case "pair repair drops dangling tool-use details" `Quick


### PR DESCRIPTION
## Summary

Fixes the keeper lifecycle checkpoint save paths so they use the same non-fabricating full tool pair repair as the reducer/checkpoint sanitizer.

## Root Cause

The provider/tool protocols can legitimately produce tool-call-only intermediate turns, but MASC lifecycle checkpoint paths were only dropping orphan `tool_result` blocks before saving compacted or rollover checkpoints. Dangling `tool_use` blocks could survive those saves and later surface as `unpaired tool use elided` during context reduction/UI rendering.

## Changes

- Use `repair_broken_tool_call_pairs_with_stats` before post-turn compaction checkpoint saves.
- Use the same full pair repair before handoff rollover checkpoint saves.
- Expand lifecycle repair logging to include dropped tool-use samples as well as dropped tool-result ids.
- Add a regression guard in `test_pbt_context_overflow.ml` so lifecycle checkpoint saves do not regress to orphan-only repair.

## Validation

- `scripts/dune-local.sh build test/test_pbt_context_overflow.exe`
- `./_build/default/test/test_pbt_context_overflow.exe`