### PR TITLE
fix(discord): prevent permanent reconnect stall from stale conn_ref

### DIFF
--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -222,14 +222,23 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
         ~route:Discord_observability.Control
         Discord_observability.Open_wss;
       (match !conn_ref with
-       | Some _ ->
+       | Some old_conn ->
+         (* Defensive cleanup: the state machine may not have emitted
+            Close_wss before this Open_wss (e.g. Wss_closed from a server
+            Close frame that didn't go through our explicit Close_wss path).
+            Discord_wss_connection.close is idempotent (peek-resolve
+            pattern), so calling it on an already-closed connection is
+            safe. Without this, the stale conn_ref blocks reconnection
+            permanently — the FSM transitions to Awaiting_hello but no
+            socket is opened, and no timeout escapes that state. *)
          log_effect `Warn
-           "Open_wss while conn_ref still Some; expected Close_wss \
-            first — dropping new connect"
-       | None ->
-         let conn = Discord_wss_connection.connect ~sw ~env ~url in
-         conn_ref := Some conn;
-         Eio.Fiber.fork ~sw (fun () -> reader_loop conn))
+           "Open_wss while conn_ref still Some; force-closing stale connection";
+         Discord_wss_connection.close old_conn;
+         conn_ref := None
+       | None -> ());
+      let conn = Discord_wss_connection.connect ~sw ~env ~url in
+      conn_ref := Some conn;
+      Eio.Fiber.fork ~sw (fun () -> reader_loop conn)
     | Close_wss { code; reason = _ } ->
       (* Phase 1.4b: explicit close. Discord_wss_connection.close
          resolves the inner session switch's close-signal promise,

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -234,6 +234,10 @@ type t =
     (* (session_id, last_seq_at_disconnect). Set when leaving Connected
        via a resumable disconnect; cleared on fresh identify path. Lets
        handle_hello choose Identify vs Resume after Awaiting_hello. *)
+  ; awaiting_hello_since_mono : float option
+    (* Timestamp (mono) when Awaiting_hello was entered. Used by
+       Heartbeat_tick to detect a stuck hello-wait (no server response)
+       and escape via Reconnect_pending. None when not in Awaiting_hello. *)
   ; thread_parents : string StringMap.t
     (* thread_id -> parent_channel_id. Populated by THREAD_CREATE
        dispatches. Used by [Mention_or_thread] trigger policy to
@@ -248,6 +252,7 @@ let create ~config =
   ; heartbeat_interval_ms = None
   ; resume_gateway_url = None
   ; resume_context = None
+  ; awaiting_hello_since_mono = None
   ; thread_parents = StringMap.empty
   }
 
@@ -617,6 +622,12 @@ let backoff_ms ~attempts =
   let shift = min attempts 6 in
   min cap (base * Int.shift_left 1 shift)
 
+(* Safety-net timeout: if the gateway stays in Awaiting_hello longer than
+   this, the next Heartbeat_tick will escape to Reconnect_pending.  This
+   prevents a permanent stall when Open_wss was dropped by the I/O layer
+   (stale conn_ref) or the server never sends Hello. *)
+let awaiting_hello_timeout_seconds = 30.0
+
 (* ── Transition function ────────────────────────────────────────
 
    Every [input] variant is matched explicitly. No catch-all arm.
@@ -663,6 +674,7 @@ let handle_hello t (frame : frame) =
            ( { t with
                state = next_state
              ; heartbeat_interval_ms = Some interval_ms
+             ; awaiting_hello_since_mono = None
              }
            , [ Schedule_heartbeat { interval_ms }
              ; Send_frame outbound_frame
@@ -855,7 +867,13 @@ let handle_wss_closed t ~now_mono ~code ~reason =
             ~resume_context
         in
         ( t'
-        , [ Schedule_backoff { delay_ms }
+        , [ Close_wss { code; reason }
+            (* Emit Close_wss so the I/O layer clears conn_ref even when
+               the close originated from a server Close frame (where the
+               socket is already shutting down). Without this, conn_ref
+               stays Some and blocks the next Open_wss, permanently
+               stalling in Awaiting_hello. *)
+          ; Schedule_backoff { delay_ms }
           ; Log
               { level = `Warn
               ; message =
@@ -890,14 +908,17 @@ let handle_heartbeat_ack_timeout t ~now_mono =
       log_warn t
         "Heartbeat_ack_timeout outside Connected state; ignoring"
 
-let handle_backoff_elapsed t =
+let handle_backoff_elapsed t ~now_mono =
   match t.state with
   | Reconnect_pending { resumable = true; _ } ->
       (* Resumable path. Need a resume URL; if missing, defensively
          fall through to fresh identify. *)
       (match t.resume_gateway_url, t.resume_context with
        | Some url, Some _ ->
-           ( { t with state = Awaiting_hello }
+           ( { t with
+               state = Awaiting_hello
+             ; awaiting_hello_since_mono = Some now_mono
+             }
            , [ Open_wss { url }
              ; Log
                  { level = `Info
@@ -906,7 +927,11 @@ let handle_backoff_elapsed t =
                  }
              ] )
        | _ ->
-           ( { t with state = Awaiting_hello; resume_context = None }
+           ( { t with
+               state = Awaiting_hello
+             ; resume_context = None
+             ; awaiting_hello_since_mono = Some now_mono
+             }
            , [ Open_wss { url = gateway_url }
              ; Log
                  { level = `Warn
@@ -916,7 +941,11 @@ let handle_backoff_elapsed t =
                  }
              ] ))
   | Reconnect_pending { resumable = false; _ } ->
-      ( { t with state = Awaiting_hello; resume_context = None }
+      ( { t with
+          state = Awaiting_hello
+        ; resume_context = None
+        ; awaiting_hello_since_mono = Some now_mono
+        }
       , [ Open_wss { url = gateway_url }
         ; Log
             { level = `Info
@@ -1014,10 +1043,13 @@ let step_frame t ~now_mono (frame : frame) =
 
 (* ── Per-input handlers for state-sensitive non-frame inputs ── *)
 
-let handle_connect_requested t =
+let handle_connect_requested t ~now_mono =
   match t.state with
   | Disconnected ->
-      ( { t with state = Awaiting_hello }
+      ( { t with
+          state = Awaiting_hello
+        ; awaiting_hello_since_mono = Some now_mono
+        }
       , [ Open_wss { url = gateway_url }
         ; Log
             { level = `Info; message = "connecting to Discord Gateway" }
@@ -1026,11 +1058,40 @@ let handle_connect_requested t =
   | Connected _ | Reconnect_pending _ | Failed _ ->
       log_warn t "Connect_requested in non-Disconnected state; ignoring"
 
-let handle_heartbeat_tick t =
+let handle_heartbeat_tick t ~now_mono =
   match t.state with
   | Connected _ | Identifying | Resuming ->
       (t, [ Send_frame (heartbeat_frame ~last_seq:t.last_seq) ])
-  | Disconnected | Awaiting_hello
+  | Awaiting_hello ->
+      (match t.awaiting_hello_since_mono with
+       | Some entered when
+           now_mono -. entered > awaiting_hello_timeout_seconds ->
+           (* Safety-net: been in Awaiting_hello too long. The server never
+              sent Hello, or Open_wss was dropped by the I/O layer. Escape
+              to Reconnect_pending so the backoff+retry cycle resumes. *)
+           let resume_context = t.resume_context in
+           let resumable = Option.is_some resume_context in
+           let delay_ms = backoff_ms ~attempts:t.reconnect_attempts in
+           let t' =
+             make_reconnect_pending t ~now_mono ~delay_ms ~resumable
+               ~resume_context
+           in
+           ( t'
+           , [ Schedule_backoff { delay_ms }
+             ; Log
+                 { level = `Warn
+                 ; message =
+                     Printf.sprintf
+                       "Awaiting_hello timeout (%.0fs elapsed); reconnect \
+                        in %dms (resumable=%b)"
+                       (now_mono -. entered) delay_ms resumable
+                 }
+             ] )
+       | _ ->
+           (* Just entered Awaiting_hello or mono clock unavailable;
+              keep waiting. *)
+           log_info t "Heartbeat_tick in pre-connection state; skipping")
+  | Disconnected
   | Reconnect_pending _ | Failed _ ->
       log_info t "Heartbeat_tick in pre-connection state; skipping"
 
@@ -1051,15 +1112,15 @@ let build_status_update_frame (status : presence_status) : frame =
 
 let step t ~now_mono input =
   match input with
-  | Connect_requested -> handle_connect_requested t
+  | Connect_requested -> handle_connect_requested t ~now_mono
   | Frame_received frame -> step_frame t ~now_mono frame
   | Frame_parse_error reason ->
       log_warn t (Printf.sprintf "frame parse error: %s" reason)
   | Wss_closed { code; reason } ->
       handle_wss_closed t ~now_mono ~code ~reason
-  | Heartbeat_tick -> handle_heartbeat_tick t
+  | Heartbeat_tick -> handle_heartbeat_tick t ~now_mono
   | Heartbeat_ack_timeout -> handle_heartbeat_ack_timeout t ~now_mono
-  | Backoff_elapsed -> handle_backoff_elapsed t
+  | Backoff_elapsed -> handle_backoff_elapsed t ~now_mono
   | Status_change status ->
       (* Presence updates are only valid when connected. Silently
          ignore in other states (reconnect will use Online by default). *)

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -1212,6 +1212,97 @@ let test_resume_round_trip_to_connected () =
   | _ -> fail "expected Connected sess-1 last_seq=99 after RESUMED"
 
 (* ---------------------------------------------------------------- *)
+(* Phase 1.4c — reconnect safety-net tests                         *)
+(* ---------------------------------------------------------------- *)
+
+let test_wss_closed_emits_close_wss () =
+  (* Regression: Wss_closed from a connection state must emit Close_wss
+     so the I/O layer can clear conn_ref. Without this, a stale conn_ref
+     blocks the next Open_wss and the gateway stalls permanently in
+     Awaiting_hello. *)
+  let m =
+    connected_at
+      ~session_id:"sess-1"
+      ~resume_url:"wss://resume.discord.gg/"
+      ~user_id:"42"
+  in
+  let _m', effects =
+    S.step m ~now_mono:10.0
+      (S.Wss_closed { code = 1001; reason = "server requested reconnect" })
+  in
+  check bool "Close_wss emitted on Wss_closed from Connected" true
+    (has_close_wss effects);
+  check bool "Schedule_backoff also emitted" true
+    (has_schedule_backoff effects)
+
+let test_wss_closed_emits_close_wss_from_awaiting_hello () =
+  (* Same regression check for Awaiting_hello (WSS opened but no Hello
+     received before a remote close). *)
+  let config =
+    { S.token = "test-token"
+    ; intents = [ S.Guilds; S.Message_content ]
+    ; bot_user_id = None
+    ; trigger_policy = S.Mention_only
+    }
+  in
+  let m, _ = S.step (S.create ~config) ~now_mono:0.0 S.Connect_requested in
+  (match S.state m with
+   | S.Awaiting_hello -> ()
+   | _ -> fail "expected Awaiting_hello");
+  let _m', effects =
+    S.step m ~now_mono:5.0
+      (S.Wss_closed { code = 1000; reason = "remote close" })
+  in
+  check bool "Close_wss emitted on Wss_closed from Awaiting_hello" true
+    (has_close_wss effects)
+
+let test_awaiting_hello_timeout_escapes_to_reconnect () =
+  (* Safety-net: Heartbeat_tick after the timeout threshold in
+     Awaiting_hello should escape to Reconnect_pending instead of
+     staying stuck forever. *)
+  let config =
+    { S.token = "test-token"
+    ; intents = [ S.Guilds; S.Message_content ]
+    ; bot_user_id = None
+    ; trigger_policy = S.Mention_only
+    }
+  in
+  let m, _ = S.step (S.create ~config) ~now_mono:0.0 S.Connect_requested in
+  (match S.state m with
+   | S.Awaiting_hello -> ()
+   | _ -> fail "expected Awaiting_hello");
+  (* Advance time past the 30s timeout *)
+  let m', effects =
+    S.step m ~now_mono:45.0 S.Heartbeat_tick
+  in
+  (match S.state m' with
+   | S.Reconnect_pending _ -> ()
+   | _ -> fail "expected Reconnect_pending after Awaiting_hello timeout");
+  check bool "Schedule_backoff emitted" true
+    (has_schedule_backoff effects)
+
+let test_awaiting_hello_before_timeout_stays () =
+  (* Heartbeat_tick arriving before the timeout should NOT trigger
+     escape — still legitimately waiting for Hello. *)
+  let config =
+    { S.token = "test-token"
+    ; intents = [ S.Guilds; S.Message_content ]
+    ; bot_user_id = None
+    ; trigger_policy = S.Mention_only
+    }
+  in
+  let m, _ = S.step (S.create ~config) ~now_mono:0.0 S.Connect_requested in
+  (* 10s < 30s timeout, should stay in Awaiting_hello *)
+  let m', effects =
+    S.step m ~now_mono:10.0 S.Heartbeat_tick
+  in
+  (match S.state m' with
+   | S.Awaiting_hello -> ()
+   | _ -> fail "expected Awaiting_hello (not timed out yet)");
+  check bool "no Schedule_backoff before timeout" false
+    (has_schedule_backoff effects)
+
+(* ---------------------------------------------------------------- *)
 (* Thread tracking + Mention_or_thread policy                      *)
 (* ---------------------------------------------------------------- *)
 
@@ -1794,6 +1885,18 @@ let () =
             "Resume round trip: Connected → blip → Backoff → Hello → \
              Op_resume → RESUMED → Connected"
             `Quick test_resume_round_trip_to_connected
+        ; test_case
+            "Wss_closed from Connected emits Close_wss (conn_ref cleanup)"
+            `Quick test_wss_closed_emits_close_wss
+        ; test_case
+            "Wss_closed from Awaiting_hello emits Close_wss"
+            `Quick test_wss_closed_emits_close_wss_from_awaiting_hello
+        ; test_case
+            "Awaiting_hello timeout escapes to Reconnect_pending"
+            `Quick test_awaiting_hello_timeout_escapes_to_reconnect
+        ; test_case
+            "Awaiting_hello before timeout stays in Awaiting_hello"
+            `Quick test_awaiting_hello_before_timeout_stays
         ] )
     ; ( "thread decode"
       , [ test_case "THREAD_CREATE with id + parent_id => Thread_tracked" `Quick


### PR DESCRIPTION
## Root Cause

Discord Gateway FSM과 I/O layer 사이에 `conn_ref` 정리 불일치 버그.

`handle_wss_closed`가 `Schedule_backoff`만 emit하고 `Close_wss`를 emit하지 않아, I/O layer의 `conn_ref`가 여전히 `Some`인 상태로 남음. 이후 `Backoff_elapsed` → `Open_wss`가 `conn_ref = Some` 때문에 drop됨. FSM은 `Awaiting_hello`로 전이하지만 실제 소켓이 없고, 탈출 타임아웃도 없어 영구 정지.

### 로그 증거 (2026-06-12)
- 01:23:16Z WSS closed 1001 → Close_wss 미발행
- 01:23:17Z Open_wss dropped (conn_ref still Some)
- 01:23:17~01:39:58Z Heartbeat_tick 450회 연속 skipping (영구 정지)
- 6월 12일 "dropping new connect" 7회, 6월 11일 3회

## Three-layer Fix

1. **I/O layer (`discord_gateway_client.ml`)**: `Open_wss`에서 stale connection을 drop 대신 force-close 후 재연결. `Discord_wss_connection.close`는 idempotent.
2. **State machine (`discord_gateway_state.ml`)**: `handle_wss_closed`에서 `Close_wss` effect 추가. I/O layer conn_ref 정리 보장.
3. **Safety net**: `Awaiting_hello` 30초 타임아웃. `Heartbeat_tick`에서 경과 시간 확인 후 `Reconnect_pending`으로 escape.

## Files Changed

- `lib/gate/discord_gateway_client.ml`: Open_wss stale connection force-close
- `lib/gate/discord_gateway_state.ml`: Close_wss emission + Awaiting_hello timeout + awaiting_hello_since_mono field
- `test/test_discord_gateway_state.ml`: 4 new tests (77 total, all pass)

## Test Results

```
Test Successful in 0.005s. 77 tests run.
```

새 테스트 케이스:
- Wss_closed from Connected emits Close_wss
- Wss_closed from Awaiting_hello emits Close_wss
- Awaiting_hello timeout escapes to Reconnect_pending
- Awaiting_hello before timeout stays in Awaiting_hello

Co-Authored-By: Claude <noreply@anthropic.com>
