### PR TITLE
fix(keeper): break task claim think loop

### DIFF
--- a/config/prompts/keeper.immediate_task_move.md
+++ b/config/prompts/keeper.immediate_task_move.md
@@ -2,7 +2,7 @@
 description: keeper user-prompt Claimable Work section (emitted when claimable backlog is visible and keeper holds no task)
 category: keeper
 ---
-- Claimable backlog exists. `keeper_task_claim {}` may claim the next eligible unclaimed task, but this is an intake option rather than a required move.
+- Claimable backlog exists. `keeper_task_claim {}` may claim the next eligible unclaimed task; when a user, mention, board item, or `keeper_tasks_list` row names a specific task, use `keeper_task_claim { "task_id": "task-123" }` instead. Claiming is an intake option rather than a required move.
 - Use keeper_tasks_list to inspect backlog state, diagnose missing work, or verify task lifecycle before deciding. Never substitute Execute probes (ls/cat/find against .masc/, backlog.json, or repo-local task files) for keeper_tasks_list; the runtime blocks those with `task_state_file_probe_blocked`.
 - Prefer the strongest live signal: pending mention, board activity, active goal, or submitted verification evidence may be better than claiming unrelated work.
 - If you choose to take code-changing task work, claim first and then work through the visible file, edit, and Execute tools from the repo checkout. Create or update a remote PR only after the branch is prepared and the task requires it.

--- a/config/prompts/keeper.tool_hints.toml
+++ b/config/prompts/keeper.tool_hints.toml
@@ -5,8 +5,8 @@
 
 [[hints]]
 name = "keeper_task_claim"
-call = "`keeper_task_claim` {}"
-description = "reserve the next eligible task"
+call = "`keeper_task_claim` {} or { task_id: \"task-123\" }"
+description = "reserve the next eligible task or an explicitly requested task"
 
 [[hints]]
 name = "keeper_tasks_list"

--- a/config/prompts/keeper.turn_intent.claim_guidance_a.md
+++ b/config/prompts/keeper.turn_intent.claim_guidance_a.md
@@ -2,4 +2,4 @@
 description: keeper turn-intent claim guidance bullet A (emitted when claimable backlog is visible)
 category: keeper
 ---
-- Claimable backlog is visible and you do not already hold a task. `keeper_task_claim {}` is available, not mandatory: claim only when the work fits your current goal, persona, and capacity. Use `keeper_tasks_list` when you need to inspect backlog state before deciding.
+- Claimable backlog is visible and you do not already hold a task. `keeper_task_claim {}` is available, not mandatory; use `keeper_task_claim { "task_id": "task-123" }` when a user, mention, board item, or task list row points to a specific task. Claim only when the work fits your current goal, persona, and capacity. Use `keeper_tasks_list` when you need to inspect backlog state before deciding.

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -421,19 +421,40 @@ let handle_keeper_task_tool
          force-released. Example: reason='assignee offline >10 min, no heartbeat'."
     else (
       let agent = keeper_agent_sender ~meta in
-      let _ =
-        Workspace.broadcast
-          config
-          ~from_agent:agent
-          ~content:
-            (Printf.sprintf
-               "Force-releasing task %s (reason: %s)"
-               task_id
-               reason)
+      let result = Workspace.force_release_task_r config ~agent_name:agent ~task_id () in
+      let is_noop =
+        match result with
+        | Ok msg -> String_util.contains_substring_ci msg "no-op"
+        | Error _ -> false
+      in
+      let () =
+        if not is_noop then
+          let _ =
+            Workspace.broadcast
+              config
+              ~from_agent:agent
+              ~content:
+                (Printf.sprintf
+                   "Force-releasing task %s (reason: %s)"
+                   task_id
+                   reason)
+          in
+          ()
+        else ()
+      in
+      let typed_outcome =
+        match result with
+        | Ok _ when is_noop ->
+          Keeper_tool_outcome.No_progress
+            { reason = Keeper_tool_outcome.No_work_available }
+        | Ok _ -> Keeper_tool_outcome.Progress
+        | Error e ->
+          Keeper_tool_outcome.Error
+            { reason = Masc_domain.masc_error_to_string e }
       in
       keeper_task_result_json
-        ~typed_outcome:(Some Keeper_tool_outcome.Progress)
-        (Workspace.force_release_task_r config ~agent_name:agent ~task_id ()))
+        ~typed_outcome:(Some typed_outcome)
+        result)
     | Task_force_done ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let notes = Safe_ops.json_string ~default:"" "notes" args |> String.trim in
@@ -555,12 +576,66 @@ let handle_keeper_task_tool
         remember_wip_rejection task.id rejection;
         false
     in
+    let requested_task_id =
+      Safe_ops.json_string ~default:"" "task_id" args |> String.trim
+    in
+    let explicit_claim_result () =
+      let tasks = Workspace.get_tasks_raw config in
+      let claim_specific task =
+        let active_tasks =
+          List.filter
+            (fun (active : Masc_domain.task) ->
+               not (String.equal active.id requested_task_id))
+            tasks
+        in
+        if not (wip_admission_filter ~active_tasks task)
+        then
+          Workspace.Claim_next_no_eligible
+            { excluded_count = 1
+            ; blocked_count = 0
+            ; verification_blocked_count = 0
+            ; scope_excluded_count = 0
+            ; explicit_excluded_count = 1
+            ; claim_pool_candidate_count = 1
+            }
+        else (
+          match
+            Workspace.claim_task_r
+              config
+              ~agent_name:meta.agent_name
+              ~task_id:requested_task_id
+              ()
+          with
+          | Ok outcome ->
+            Workspace.Claim_next_claimed
+              { task_id = requested_task_id
+              ; title = task.title
+              ; priority = task.priority
+              ; released_task_id = None
+              ; message = outcome.message
+              ; scope_widened = false
+              }
+          | Error e -> Workspace.Claim_next_error (Masc_domain.masc_error_to_string e))
+      in
+      match
+        List.find_opt
+          (fun (task : Masc_domain.task) -> String.equal task.id requested_task_id)
+          tasks
+      with
+      | None ->
+        Workspace.Claim_next_error
+          (Printf.sprintf "unknown task_id: %s" requested_task_id)
+      | Some task -> claim_specific task
+    in
     let result =
-      Workspace.claim_next_r config ~agent_name:meta.agent_name
-        ~task_filter:claim_goal_scope.task_filter
-        ~admission_filter:wip_admission_filter
-        ~allow_scope_fallback:true
-        ()
+      if requested_task_id <> "" then
+        explicit_claim_result ()
+      else
+        Workspace.claim_next_r config ~agent_name:meta.agent_name
+          ~task_filter:claim_goal_scope.task_filter
+          ~admission_filter:wip_admission_filter
+          ~allow_scope_fallback:true
+          ()
     in
     let wip_rejections = List.rev !wip_rejections in
     let auto_started_ok = ref false in

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -373,10 +373,11 @@ let fallback_externalized_bullet key =
   if String.equal key Keeper_prompt_names.turn_intent_claim_guidance_a then
     Some
       "- Claimable backlog is visible and you do not already hold a task. \
-       `keeper_task_claim {}` is available, not mandatory: claim only when \
+       `keeper_task_claim {}` is available, not mandatory; use \
+       `keeper_task_claim { \"task_id\": \"task-123\" }` when a user, mention, \
+       board item, or task list row points to a specific task. Claim only when \
        the work fits your current goal, persona, and capacity. Use \
-       `keeper_tasks_list` when you need to inspect backlog state before \
-       deciding."
+       `keeper_tasks_list` when you need to inspect backlog state before deciding."
   else if String.equal key Keeper_prompt_names.turn_intent_claim_guidance_b then
     Some
       "- Repo and remote PR/issue inspection is observation, not progress by itself. \
@@ -412,8 +413,10 @@ let fallback_externalized_bullet key =
   else if String.equal key Keeper_prompt_names.immediate_task_move then
     Some
       "- Claimable backlog exists. `keeper_task_claim {}` may claim the next \
-       eligible unclaimed task, but this is an intake option rather than a \
-       required move.\n\
+       eligible unclaimed task; when a user, mention, board item, or \
+       `keeper_tasks_list` row names a specific task, use `keeper_task_claim { \
+       \"task_id\": \"task-123\" }` instead. Claiming is an intake option \
+       rather than a required move.\n\
        - Use keeper_tasks_list to inspect backlog state, diagnose missing \
        work, or verify task lifecycle before deciding. Never substitute \
        Execute probes (ls/cat/find against .masc/, backlog.json, or \

--- a/lib/keeper_metrics/keeper_memory_policy_summary_filter.ml
+++ b/lib/keeper_metrics/keeper_memory_policy_summary_filter.ml
@@ -84,12 +84,29 @@ let filter_forward_looking_summary (summary : string) : string =
                 || String_util.contains_substring_ci payload "tool surface"
                 || String_util.contains_substring_ci payload "tool-surface")))
   in
+  let is_stale_goal_capacity_line line =
+    let payload = String.trim line in
+    let markers =
+      [
+        "goal cap";
+        "goal_cap";
+        "goal capacity";
+        "active_goal_ids";
+        "새 작업 못";
+        "작업 못 받";
+      ]
+    in
+    List.exists
+      (fun marker -> String_util.contains_substring_ci payload marker)
+      markers
+  in
   let kept =
     summary
     |> String.split_on_char '\n'
     |> List.filter (fun line -> not (is_backward_line line))
     |> List.filter (fun line -> not (is_inert_next_line line))
     |> List.filter (fun line -> not (is_stale_tool_surface_line line))
+    |> List.filter (fun line -> not (is_stale_goal_capacity_line line))
     |> List.filter (fun line -> String.trim line <> "")
   in
   match kept with

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
@@ -145,16 +145,29 @@ let taskboard_tools : Masc_domain.tool_schema list =
     }
   ; { name = "keeper_task_claim"
     ; description =
-        "Claim the next unclaimed todo task that matches your capabilities. Returns \
-         claimed task details (task_id, title, description) or empty if none available. \
-         If you already own a task in Claimed state (not yet started), it is \
-         auto-released to Todo so the claim can proceed. Tasks in InProgress or \
-         AwaitingVerification block the claim -- use keeper_task_done or \
-         keeper_task_force_release on them first. If active_goal_ids are configured, \
-         only tasks linked to those goals are eligible; when that scoped pool has no \
-         claimable task for your current capabilities, the claim stops instead of \
-         crossing into unrelated goals."
-    ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
+        "Claim MASC backlog work. With no task_id, claims the next eligible \
+         unclaimed todo task that matches your capabilities. With task_id, claims \
+         that exact task when a user, mention, board item, or keeper_tasks_list row \
+         identifies it. If you already own another Claimed/InProgress task, finish \
+         it with keeper_task_done or explicitly release it first; keeper_task_claim \
+         does not auto-release active work. If active_goal_ids are configured, the \
+         no-arg claim prefers goal-linked work and only widens when the scoped pool \
+         has no eligible task."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "task_id"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Optional exact task id from keeper_tasks_list, board, mention, or user request" )
+                      ; "minLength", `Int 1
+                      ] )
+                ] )
+          ]
     }
   ; { name = "keeper_task_done"
     ; description =

--- a/test/test_continuity_forward_filter.ml
+++ b/test/test_continuity_forward_filter.ml
@@ -30,6 +30,13 @@ Next plan: use keeper_task_claim after checking live policy
 Constraints: tool surface: masc_* only; no keeper_* tools visible
 OpenQuestions: why did the previous turn see stale tools?|}
 
+let stale_goal_cap_summary =
+  {|Goal: maintain keeper context
+Next plan: claim task-952 directly after checking tasks
+Next: use keeper_task_claim with task-952
+Constraints: current goal cap 4/3 means 새 작업 못 받음; active_goal_ids stale
+OpenQuestions: is goal capacity really full?|}
+
 let test_strips_backward () =
   let filtered =
     Masc.Keeper_memory_policy.filter_forward_looking_summary full_summary
@@ -113,6 +120,18 @@ let test_drops_stale_tool_surface_claims () =
   Alcotest.(check bool) "live-policy action still kept"
     true (Astring.String.is_infix ~affix:"keeper_task_claim" filtered)
 
+let test_drops_stale_goal_capacity_claims () =
+  let filtered =
+    Masc.Keeper_memory_policy.filter_forward_looking_summary
+      stale_goal_cap_summary
+  in
+  Alcotest.(check bool) "stale goal cap removed"
+    false (Astring.String.is_infix ~affix:"goal cap" filtered);
+  Alcotest.(check bool) "stale active_goal_ids removed"
+    false (Astring.String.is_infix ~affix:"active_goal_ids" filtered);
+  Alcotest.(check bool) "live task-specific action kept"
+    true (Astring.String.is_infix ~affix:"task-952" filtered)
+
 let () =
   Alcotest.run "continuity forward filter"
     [ ( "filter_forward_looking_summary",
@@ -128,5 +147,7 @@ let () =
             test_drops_inert_idle_directives;
           Alcotest.test_case "drops stale tool surface claims" `Quick
             test_drops_stale_tool_surface_claims;
+          Alcotest.test_case "drops stale goal-cap claims" `Quick
+            test_drops_stale_goal_capacity_claims;
         ] );
     ]

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -567,6 +567,84 @@ let test_public_local_aliases_dispatch_to_runtime_handlers () =
       check bool "Execute ran in requested cwd" true
         (contains_substring execute_result.raw_output playground))
 
+let test_keeper_task_claim_accepts_specific_task_id () =
+  with_exec_fixture "keeper_tool_dispatch_specific_task_claim"
+    (fun ~config ~meta ~ctx_work ->
+      ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
+      ignore
+        (Workspace.add_task config ~title:"higher priority task" ~priority:1
+           ~description:"should not be claimed by explicit task_id");
+      ignore
+        (Workspace.add_task config ~title:"requested task" ~priority:3
+           ~description:"must be claimed by explicit task_id");
+      let result =
+        KET.execute_keeper_tool_call_with_outcome
+          ~config
+          ~meta
+          ~ctx_work
+          ~exec_cache:None
+          ~name:"keeper_task_claim"
+          ~input:(`Assoc [ "task_id", `String "task-002" ])
+          ()
+      in
+      check string "specific claim outcome" "success" (outcome_label result.outcome);
+      check string "specific claim payload shape" "structured_success"
+        (payload_kind result.payload_shape);
+      let json = Yojson.Safe.from_string result.raw_output in
+      let claimed_task = Yojson.Safe.Util.member "claimed_task" json in
+      check string "claimed requested task" "task-002"
+        Yojson.Safe.Util.(member "task_id" claimed_task |> to_string);
+      let tasks = Workspace.get_tasks_raw config in
+      let task_status task_id =
+        match
+          List.find_opt
+            (fun (task : Masc_domain.task) -> String.equal task.id task_id)
+            tasks
+        with
+        | None -> fail (Printf.sprintf "missing %s" task_id)
+        | Some task -> task.Masc_domain.task_status
+      in
+      (match task_status "task-001" with
+       | Masc_domain.Todo -> ()
+       | _ -> fail "higher priority task should remain todo");
+      match task_status "task-002" with
+      | Masc_domain.Claimed { assignee; _ }
+      | Masc_domain.InProgress { assignee; _ } ->
+        check string "assignee" meta.agent_name assignee
+      | _ -> fail "requested task should be claimed or auto-started")
+
+let test_keeper_task_force_release_noop_is_no_progress () =
+  with_exec_fixture "keeper_tool_dispatch_force_release_noop"
+    (fun ~config ~meta ~ctx_work ->
+      ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
+      ignore
+        (Workspace.add_task config ~title:"todo task" ~priority:1
+           ~description:"release is a no-op while todo");
+      let result =
+        KET.execute_keeper_tool_call_with_outcome
+          ~config
+          ~meta
+          ~ctx_work
+          ~exec_cache:None
+          ~name:"keeper_task_force_release"
+          ~input:
+            (`Assoc
+               [ "task_id", `String "task-001"
+               ; "reason", `String "already todo smoke"
+               ])
+          ()
+      in
+      check string "force release noop outcome" "success"
+        (outcome_label result.outcome);
+      let json = Yojson.Safe.from_string result.raw_output in
+      check bool "force release noop ok" true
+        (json_bool_field ~default:false "ok" json);
+      let typed = Yojson.Safe.Util.member "typed_outcome" json in
+      check string "typed outcome" "No_progress"
+        Yojson.Safe.Util.(member "kind" typed |> to_string);
+      check string "no-progress reason" "No_work_available"
+        Yojson.Safe.Util.(member "reason" typed |> member "kind" |> to_string))
+
 let test_public_masc_web_search_alias_dispatches_to_misc_runtime () =
   with_exec_fixture "keeper_tool_dispatch_web_search_alias"
     (fun ~config ~meta ~ctx_work ->
@@ -1022,6 +1100,10 @@ let () =
         test_execute_with_outcome_bad_query_is_failure;
       test_case "public local aliases dispatch to runtime handlers" `Quick
         test_public_local_aliases_dispatch_to_runtime_handlers;
+      test_case "keeper_task_claim accepts explicit task_id" `Quick
+        test_keeper_task_claim_accepts_specific_task_id;
+      test_case "keeper_task_force_release todo no-op is no progress" `Quick
+        test_keeper_task_force_release_noop_is_no_progress;
       test_case "public WebSearch alias reaches misc runtime" `Quick
         test_public_masc_web_search_alias_dispatches_to_misc_runtime;
       test_case "public WebFetch alias reaches misc runtime" `Quick

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -495,6 +495,9 @@ let keeper_board_post_get_schema =
 let keeper_task_done_schema =
   find_schema_exn "keeper_task_done" Config.raw_all_tool_schemas
 
+let keeper_task_claim_schema =
+  find_schema_exn "keeper_task_claim" Config.raw_all_tool_schemas
+
 let tool_execute_schema =
   find_schema_exn "tool_execute" Config.raw_all_tool_schemas
 
@@ -1357,6 +1360,11 @@ let assert_schema_requires label schema field =
     true
     (List.mem field (schema_required_fields schema))
 
+let schema_property_names schema =
+  match Yojson.Safe.Util.member "properties" schema with
+  | `Assoc props -> List.map fst props
+  | _ -> []
+
 let assert_validation_rejects ~label ~schema ~tool_name ~args ~snippets =
   match Tool_input_validation.validate_args ~schema ~name:tool_name ~args () with
   | Error result ->
@@ -1409,6 +1417,26 @@ let test_high_risk_tool_contract_rejection_corpus () =
     ]
 
 let test_keeper_tool_hint_contracts_match_required_fields () =
+  Alcotest.(check bool)
+    "keeper_task_claim schema accepts optional task_id"
+    true
+    (List.mem "task_id" (schema_property_names keeper_task_claim_schema));
+  Alcotest.(check bool)
+    "keeper_task_claim schema does not require task_id"
+    false
+    (List.mem "task_id" (schema_required_fields keeper_task_claim_schema));
+  (match
+     Tool_input_validation.validate_args
+       ~schema:keeper_task_claim_schema
+       ~name:"keeper_task_claim"
+       ~args:(`Assoc [ "task_id", `String "task-123" ])
+       ()
+   with
+   | Ok _ -> ()
+   | Error result ->
+     Alcotest.failf
+       "keeper_task_claim task_id should validate: %s"
+       (Yojson.Safe.to_string (Tool_result.data result)));
   assert_schema_requires "keeper_task_done schema" keeper_task_done_schema "task_id";
   assert_schema_requires "keeper_task_done schema" keeper_task_done_schema "result";
   assert_schema_requires
@@ -1421,6 +1449,10 @@ let test_keeper_tool_hint_contracts_match_required_fields () =
     false
     (List.mem "hearth" (schema_required_fields keeper_board_post_schema));
   let hints = read_source_file "config/prompts/keeper.tool_hints.toml" in
+  assert_contains
+    "keeper_task_claim hint names optional task_id"
+    hints
+    "task_id:";
   assert_contains
     "keeper_task_done hint names task_id"
     hints


### PR DESCRIPTION
## Summary
- add optional task_id support to keeper_task_claim so explicit user/task requests do not fall back to priority-only claim_next
- classify force-release no-ops as typed No_progress and avoid broadcasting no-op releases
- filter stale goal-cap/active_goal_ids continuity claims and update keeper claim prompts/schema/hints

## Evidence
- Live sangsu trace showed task-952 requested, but keeper_task_claim {} repeatedly auto-claimed higher-priority tasks and force-released them.
- Live sangsu meta had active_goal_ids=[]/current_task_id=null while continuity claimed goal cap 4/3 or 3/3.

## Tests
- scripts/dune-local.sh build test/test_continuity_forward_filter.exe test/test_keeper_tool_dispatch_runtime.exe test/test_tool_input_validation.exe
- ./_build/default/test/test_continuity_forward_filter.exe
- ./_build/default/test/test_keeper_tool_dispatch_runtime.exe
- ./_build/default/test/test_tool_input_validation.exe