### PR TITLE
[codex] surface keeper tok/sec details

### DIFF
--- a/dashboard/src/components/goals/task-activity-list.test.ts
+++ b/dashboard/src/components/goals/task-activity-list.test.ts
@@ -152,6 +152,40 @@ describe('TaskActivityList', () => {
     expect(text).toContain('turn_completed')
   })
 
+  it('shows tok/sec for LLM response activity rows', async () => {
+    const { container } = render(h(TaskActivityList, {
+      events: [sampleToolCallEvent({
+        kind: 'lifecycle',
+        summary: 'LLM response',
+        toolArgs: undefined,
+        toolResult: null,
+        duration_ms: 2000,
+        detail: {
+          durable_kind: 'llm_response',
+          output_tokens: 80,
+          duration_ms: 2000,
+          stop_reason: 'stop',
+        },
+      })],
+      loading: false,
+      error: null,
+      showToolCalls: true,
+    }))
+
+    expect(screen.getByText('40.0 tok/s')).toBeInTheDocument()
+
+    const details = container.querySelector('details')
+    expect(details).not.toBeNull()
+    if (!details) return
+
+    details.open = true
+    fireEvent(details, new Event('toggle', { bubbles: true }))
+
+    await waitFor(() => {
+      expect(screen.getByText('tok/sec: 40.0 tok/s')).toBeInTheDocument()
+    })
+  })
+
   it('marks decorative icons as hidden from assistive tech', () => {
     const { container } = render(h(TaskActivityList, {
       events: [sampleToolCallEvent({ toolArgs: undefined, toolResult: null })],
@@ -184,4 +218,3 @@ describe('TaskActivityList', () => {
     expect(screen.getByText('broadcast message')).toBeInTheDocument()
   })
 })
-

--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -8,7 +8,7 @@ import { ErrorState, LoadingState } from '../common/feedback-state'
 import { TimeAgo } from '../common/time-ago'
 import { TextInput } from '../common/input'
 import { JsonViewerCard, parseJsonLikeData } from '../common/json-viewer'
-import { formatCost } from '../../lib/format-number'
+import { deriveTokPerSec, formatCost, formatTokPerSec } from '../../lib/format-number'
 import { Settings, MessageSquare, CheckSquare, Heart, RefreshCcw, Dot, ChevronRight } from 'lucide-preact'
 import type { UnifiedTraceEvent, TraceEventKind } from '../session-trace/session-trace-state'
 import { activeFilter, activityListSearchQuery, type ActivityFilter } from './task-detail-state'
@@ -65,9 +65,21 @@ function durationColor(ms: number | undefined): string {
   return 'text-bad'
 }
 
+function asDetailNumber(detail: unknown, key: string): number | null {
+  if (!detail || typeof detail !== 'object') return null
+  const value = (detail as Record<string, unknown>)[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function eventTokPerSec(event: UnifiedTraceEvent): number | null {
+  const outputTokens = asDetailNumber(event.detail, 'output_tokens')
+  const durationMs = event.duration_ms ?? asDetailNumber(event.detail, 'duration_ms')
+  return deriveTokPerSec(outputTokens, durationMs)
+}
 
 function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
   const hasDetail = event.toolArgs != null || event.toolResult != null || (event.detail && Object.keys(event.detail).length > 0)
+  const tokPerSec = eventTokPerSec(event)
   const [isOpen, setIsOpen] = useState(false)
 
   if (!hasDetail) {
@@ -76,6 +88,7 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
         <span class="text-sm ${kindColor(event.kind)}">${kindIcon(event.kind)}</span>
         <span class="flex-1 text-xs text-text-body truncate">${event.summary}</span>
         ${event.duration_ms != null ? html`<span class="text-3xs tabular-nums ${durationColor(event.duration_ms)}">${event.duration_ms}ms</span>` : null}
+        ${tokPerSec != null ? html`<span class="text-3xs tabular-nums text-[var(--color-status-ok)]">${formatTokPerSec(tokPerSec)}</span>` : null}
         ${event.ts_iso ? html`<${TimeAgo} timestamp=${event.ts_iso} class="text-3xs text-text-dim shrink-0" />` : null}
       </div>
     `
@@ -92,6 +105,7 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
         <span class="text-sm ${kindColor(event.kind)}">${kindIcon(event.kind)}</span>
         <span class="flex-1 text-xs text-text-body truncate">${event.summary}</span>
         ${event.duration_ms != null ? html`<span class="text-3xs tabular-nums ${durationColor(event.duration_ms)}">${event.duration_ms}ms</span>` : null}
+        ${tokPerSec != null ? html`<span class="text-3xs tabular-nums text-[var(--color-status-ok)]">${formatTokPerSec(tokPerSec)}</span>` : null}
         ${event.ts_iso ? html`<${TimeAgo} timestamp=${event.ts_iso} class="text-3xs text-text-dim shrink-0" />` : null}
         <span class="text-3xs text-text-dim flex items-center justify-center"><${ChevronRight} size=${14} aria-hidden="true" focusable="false" /></span>
       </summary>
@@ -114,6 +128,7 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
           ` : null}
           ${event.error ? html`<div class="text-2xs text-[var(--bad-light)] mt-1">${event.error}</div>` : null}
           ${event.cost_usd != null ? html`<div class="text-3xs text-text-dim mt-1">cost: ${formatCost(event.cost_usd)}</div>` : null}
+          ${tokPerSec != null ? html`<div class="text-3xs text-text-dim mt-1">tok/sec: ${formatTokPerSec(tokPerSec)}</div>` : null}
         </div>
       ` : null}
     </details>

--- a/dashboard/src/components/keeper-detail-kpi.test.ts
+++ b/dashboard/src/components/keeper-detail-kpi.test.ts
@@ -1,0 +1,110 @@
+import { h } from 'preact'
+import { cleanup, render, screen } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import '@testing-library/jest-dom'
+import type { Keeper, KeeperMetricPoint } from '../types'
+import { KpiGrid } from './keeper-detail-kpi'
+
+afterEach(() => {
+  cleanup()
+})
+
+function metricPoint(overrides: Partial<KeeperMetricPoint>): KeeperMetricPoint {
+  return {
+    ts: 1,
+    context_ratio: 0.2,
+    context_tokens: 200,
+    context_max: 1000,
+    latency_ms: 2000,
+    generation: 1,
+    channel: 'turn',
+    is_handoff: false,
+    is_compaction: false,
+    compaction_saved_tokens: 0,
+    compaction_trigger: null,
+    model_used: 'runtime',
+    cost_usd: 0.01,
+    handoff_to_model: null,
+    handoff_new_generation: null,
+    prompt_fingerprint: null,
+    prompt_metrics: null,
+    provider_timeout_plan: null,
+    ctx_composition: null,
+    input_tokens: 120,
+    output_tokens: 80,
+    total_tokens: 200,
+    wall_tokens_per_second: null,
+    inference_telemetry: null,
+    fallback_applied: false,
+    fallback_hops: 0,
+    fallback_from: null,
+    fallback_to: null,
+    fallback_reason: null,
+    ...overrides,
+  }
+}
+
+describe('KpiGrid', () => {
+  it('surfaces latest keeper tok/sec in the detail KPI grid', () => {
+    const keeper = {
+      name: 'sangsu',
+      status: 'active',
+      context_ratio: 0.2,
+      context_tokens: 200,
+      generation: 3,
+      turn_count: 9,
+      handoff_count_total: 1,
+      compaction_count: 2,
+      metrics_series: [
+        metricPoint({
+          wall_tokens_per_second: 40,
+          inference_telemetry: {
+            system_fingerprint: null,
+            timings: {
+              prompt_n: null,
+              prompt_ms: null,
+              prompt_per_second: null,
+              predicted_n: null,
+              predicted_ms: null,
+              predicted_per_second: 140,
+              cache_n: null,
+            },
+            reasoning_tokens: null,
+            peak_memory_gb: null,
+            request_latency_ms: null,
+            ttfrc_ms: null,
+            prefill_ms: null,
+          },
+        }),
+        metricPoint({
+          ts: 2,
+          wall_tokens_per_second: 60,
+          inference_telemetry: {
+            system_fingerprint: null,
+            timings: {
+              prompt_n: null,
+              prompt_ms: null,
+              prompt_per_second: null,
+              predicted_n: null,
+              predicted_ms: null,
+              predicted_per_second: 150,
+              cache_n: null,
+            },
+            reasoning_tokens: null,
+            peak_memory_gb: null,
+            request_latency_ms: null,
+            ttfrc_ms: null,
+            prefill_ms: null,
+          },
+        }),
+      ],
+    } as Keeper
+
+    render(h(KpiGrid, { keeper }))
+
+    expect(screen.getByText('wall tok/s')).toBeInTheDocument()
+    expect(screen.getByText('60.0 tok/s')).toBeInTheDocument()
+    expect(screen.getByText('hw tok/s')).toBeInTheDocument()
+    expect(screen.getByText('150.0 tok/s')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/keeper-detail-kpi.ts
+++ b/dashboard/src/components/keeper-detail-kpi.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { formatPct1, formatTokens } from '../lib/format-number'
+import { formatPct1, formatTokens, formatTokPerSec, isFiniteMetricValue } from '../lib/format-number'
 import { formatDurationCompound } from '../lib/format-time'
 import { Eyebrow } from './common/eyebrow'
 import { StatTile } from './common/stat-tile'
@@ -129,6 +129,11 @@ export function KpiSection({ title, children }: {
 export function KpiGrid({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
   const lastPt = series[series.length - 1] as KeeperMetricPoint | undefined
+  const latestWallTokPerSec = latestFiniteMetric(series, point => point.wall_tokens_per_second)
+  const latestHwTokPerSec = latestFiniteMetric(
+    series,
+    point => point.inference_telemetry?.timings?.predicted_per_second,
+  )
   const latestCost =
     lastPt && Number.isFinite(lastPt.cost_usd)
       ? `$${lastPt.cost_usd.toFixed(4)}`
@@ -179,6 +184,20 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
             ${latestCost
               ? html`<${StatTile} label="비용 (USD)" value=${latestCost} />`
               : null}
+            ${latestWallTokPerSec != null
+              ? html`<${StatTile}
+                  label="wall tok/s"
+                  value=${formatTokPerSec(latestWallTokPerSec)}
+                  delta=${{ direction: 'flat' as const, text: 'output/latency' }}
+                />`
+              : null}
+            ${latestHwTokPerSec != null
+              ? html`<${StatTile}
+                  label="hw tok/s"
+                  value=${formatTokPerSec(latestHwTokPerSec)}
+                  delta=${{ direction: 'flat' as const, text: 'decode' }}
+                />`
+              : null}
           </div>
           <${OperationalHealth} keeper=${keeper} />
         </div>
@@ -214,4 +233,15 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
       <//>
     </div>
   `
+}
+
+function latestFiniteMetric(
+  series: KeeperMetricPoint[],
+  select: (point: KeeperMetricPoint) => number | null | undefined,
+): number | null {
+  for (let i = series.length - 1; i >= 0; i -= 1) {
+    const value = select(series[i]!)
+    if (isFiniteMetricValue(value)) return value
+  }
+  return null
 }

--- a/dashboard/src/components/session-trace/session-trace-entry.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.test.ts
@@ -179,6 +179,29 @@ describe('SessionTraceEntry', () => {
     expect(links.map(link => link.label)).toEqual(['Goal', 'Board', 'Comment', 'Keeper'])
   })
 
+  it('shows tok/sec for durable LLM response lifecycle details', () => {
+    const { container } = render(h(SessionTraceEntry, {
+      event: {
+        id: 'llm-response-1',
+        ts: 4,
+        ts_iso: '2026-04-03T00:03:00Z',
+        kind: 'lifecycle',
+        sourceLane: 'oas',
+        summary: 'LLM response',
+        detail: {
+          durable_kind: 'llm_response',
+          output_tokens: 80,
+          duration_ms: 2000,
+          stop_reason: 'stop',
+        },
+      },
+    }))
+
+    fireEvent.click(container.querySelector('summary') as HTMLElement)
+
+    expect(container.textContent ?? '').toContain('40.0 tok/s')
+  })
+
   it('does not render Code links for unsafe absolute tool-call file args', () => {
     const { container } = render(h(SessionTraceEntry, {
       event: sampleToolCallEvent({

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -9,7 +9,7 @@ import { Markdown } from '../common/markdown'
 import { ProgressBar } from '../common/progress-bar'
 import { truncate } from '../../lib/truncate'
 import { asNullableString, asRecord, extractCodeLocation, type CodeLocation } from '../common/normalize'
-import { formatCost, formatMsCompact } from '../../lib/format-number'
+import { deriveTokPerSec, formatCost, formatMsCompact, formatTokPerSec } from '../../lib/format-number'
 import { toolCategory, durationColor, formatArgs as sharedFormatArgs } from '../tool-call-shared'
 import { SectionHeader } from '../common/section-header'
 import {
@@ -669,18 +669,20 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
   }
 
   if (durableKind === 'llm_response') {
-    const outputTokens = typeof d.output_tokens === 'number' ? d.output_tokens : 0
+    const outputTokens = typeof d.output_tokens === 'number' ? d.output_tokens : null
     const stopReason = typeof d.stop_reason === 'string' ? d.stop_reason : ''
     const durationMs = typeof d.duration_ms === 'number' ? d.duration_ms : null
+    const tokPerSec = deriveTokPerSec(outputTokens, durationMs)
     const turn = d.turn
     const responseText = typeof d.response_text === 'string' ? d.response_text : ''
     const stopColor = stopReason === 'end_turn' || stopReason === 'stop' ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-warn)]'
     return html`
       <div class="mt-2 px-3 py-2 rounded-[var(--r-1)] ${TRACE_TONE.infoPanel} space-y-1">
         <div class="flex items-center gap-3 text-xs flex-wrap">
-          <span><span class="text-[var(--color-fg-disabled)]">출력:</span> <span class="font-mono">${outputTokens.toLocaleString()}tok</span></span>
+          <span><span class="text-[var(--color-fg-disabled)]">출력:</span> <span class="font-mono">${(outputTokens ?? 0).toLocaleString()}tok</span></span>
           <span><span class="text-[var(--color-fg-disabled)]">종료:</span> <span class="font-mono ${stopColor}">${stopReason}</span></span>
           ${durationMs != null ? html`<span><span class="text-[var(--color-fg-disabled)]">소요:</span> <span class="font-mono ${durationColor(durationMs)}">${formatMsCompact(durationMs)}</span></span>` : null}
+          ${tokPerSec != null ? html`<span><span class="text-[var(--color-fg-disabled)]">속도:</span> <span class="font-mono text-[var(--color-status-ok)]">${formatTokPerSec(tokPerSec)}</span></span>` : null}
           ${turn != null ? html`<span><span class="text-[var(--color-fg-disabled)]">턴:</span> <span class="font-mono">${String(turn)}</span></span>` : null}
         </div>
         ${responseText ? html`

--- a/dashboard/src/lib/format-number.ts
+++ b/dashboard/src/lib/format-number.ts
@@ -32,6 +32,19 @@ export function formatNumber(value: number | null | undefined, digits = 0, fallb
   })
 }
 
+export function formatTokPerSec(value: number | null | undefined, digits = 1, fallback = '-'): string {
+  if (!isFiniteMetricValue(value)) return fallback
+  return `${formatNumber(value, digits, fallback)} tok/s`
+}
+
+export function deriveTokPerSec(
+  tokens: number | null | undefined,
+  durationMs: number | null | undefined,
+): number | null {
+  if (!isFiniteMetricValue(tokens) || !isFiniteMetricValue(durationMs) || durationMs <= 0) return null
+  return tokens / (durationMs / 1000)
+}
+
 /** Format a USD cost value. Sub-cent values get 4 decimals; otherwise 2.
  *  Returns fallback for null/NaN/undefined. */
 export function formatCost(value: number | null | undefined, fallback = '--'): string {


### PR DESCRIPTION
## Summary

- Show latest keeper wall/hardware tok/sec directly in the keeper detail KPI grid when telemetry exists.
- Add derived tok/sec display to LLM response rows in session trace and task activity detail views.
- Centralize tok/sec formatting and derivation helpers for the dashboard UI.

## Root Cause

The backend and metrics series already carried enough throughput data, but the prominent keeper detail KPI surface did not expose it. Task/activity detail rows showed output tokens and duration separately, but never derived the visible `tok/s` value.

## Validation

- `pnpm exec vitest run src/components/keeper-detail-kpi.test.ts src/components/session-trace/session-trace-entry.test.ts src/components/goals/task-activity-list.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`
- Playwright screenshots against `http://127.0.0.1:5179/dashboard/#monitoring?section=agents` and `http://127.0.0.1:5179/dashboard/#monitoring?section=agents&keeper=albini` verified nonblank dashboard/detail rendering without a framework overlay.

Browser plugin was not available in this session, so rendered QA used regular Playwright CLI.