### PR TITLE
feat(discord): add backoff jitter and reconnect OTel metrics

### DIFF
--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -150,6 +150,11 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
      Schedule_heartbeat (new session after reconnect) so a fresh
      heartbeat cycle starts with a clean slate. *)
   let heartbeat_ack_ok = Atomic.make true in
+  (* Reconnect observability: tracks whether this is the first connection
+     or a reconnection, and which method (resume vs fresh identify) was
+     used for the last reconnect attempt. *)
+  let has_connected_before = ref false in
+  let last_reconnect_was_resume = ref false in
 
   let clock = Eio.Stdenv.clock env in
   Eio.Fiber.fork ~sw (fun () ->
@@ -277,12 +282,37 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
     | Schedule_backoff { delay_ms } ->
       Discord_observability.record_gateway_reconnect_scheduled ();
       Eio.Fiber.fork ~sw (fun () ->
-        Eio.Time.sleep clock (float_of_int delay_ms /. 1000.0);
+        (* Add ±25% jitter to the backoff delay. The state machine's
+           backoff_ms remains deterministic for testability; jitter
+           belongs in the I/O layer per RFC-0203. Prevents thundering
+           herd when multiple instances restart simultaneously. *)
+        let jitter_factor =
+          let raw = Mirage_crypto_rng.generate 1 in
+          let byte = Char.code raw.[0] in
+          0.75 +. 0.5 *. (float_of_int byte /. 255.0)
+        in
+        let jittered_ms =
+          int_of_float (float_of_int delay_ms *. jitter_factor)
+        in
+        Eio.Time.sleep clock (float_of_int jittered_ms /. 1000.0);
         Eio.Stream.add input_mailbox Discord_gateway_state.Backoff_elapsed)
     | Emit_event ev ->
       let event, route =
         match ev with
-        | Ready _ -> Discord_observability.Ready, Discord_observability.Control
+        | Ready _ ->
+          (* Track reconnect outcomes: first Ready is initial connect,
+             subsequent ones are reconnect successes. *)
+          if !has_connected_before then begin
+            let method_ =
+              if !last_reconnect_was_resume
+              then Discord_observability.Resume
+              else Discord_observability.Fresh_identify
+            in
+            Discord_observability.record_gateway_reconnect_outcome
+              ~method_ ~outcome:Discord_observability.Reconnect_succeeded
+          end;
+          has_connected_before := true;
+          Discord_observability.Ready, Discord_observability.Control
         | Message_create _ ->
           Discord_observability.Message_create, Discord_observability.Triggered
         | Reaction_add _ ->
@@ -310,6 +340,20 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
 
   let step_now input =
     let now = now_mono env in
+    (* Track reconnect method for observability: check resume_context
+       before stepping so we know whether this Backoff_elapsed leads
+       to a resume or fresh identify path. *)
+    (match input with
+     | Discord_gateway_state.Backoff_elapsed ->
+         last_reconnect_was_resume :=
+           Option.is_some (Discord_gateway_state.resume_context !state)
+     | Discord_gateway_state.Connect_requested
+     | Discord_gateway_state.Frame_received _
+     | Discord_gateway_state.Frame_parse_error _
+     | Discord_gateway_state.Wss_closed _
+     | Discord_gateway_state.Heartbeat_tick
+     | Discord_gateway_state.Heartbeat_ack_timeout
+     | Discord_gateway_state.Status_change _ -> ());
     let (s', effects) = Discord_gateway_state.step !state ~now_mono:now input in
     state := s';
     Atomic.set published_connection_state (Discord_gateway_state.state s');

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -258,6 +258,7 @@ let create ~config =
 
 let state t = t.state
 let config t = t.config
+let resume_context t = t.resume_context
 
 (* ── JSON helpers (internal) ───────────────────────────────────── *)
 

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -237,6 +237,7 @@ val create : config:config -> t
 
 val state : t -> connection_state
 val config : t -> config
+val resume_context : t -> (string * int option) option
 
 (** {2 Transition function} *)
 

--- a/lib/gate/discord_observability.ml
+++ b/lib/gate/discord_observability.ml
@@ -12,6 +12,14 @@ type gateway_event =
   | Ignored
   | Open_wss
 
+type reconnect_method =
+  | Resume
+  | Fresh_identify
+
+type reconnect_outcome =
+  | Reconnect_succeeded
+  | Reconnect_failed
+
 type inbound_outcome =
   | Dropped_unbound
   | Dispatch_unavailable
@@ -62,6 +70,14 @@ let reply_outcome_label = function
   | Reply_send_ok -> "sent"
   | Reply_send_failed -> "send_error"
 
+let reconnect_method_label = function
+  | Resume -> "resume"
+  | Fresh_identify -> "fresh_identify"
+
+let reconnect_outcome_label = function
+  | Reconnect_succeeded -> "succeeded"
+  | Reconnect_failed -> "failed"
+
 let inc name ~labels =
   Otel_metric_store_core.inc_counter name ~labels ()
 
@@ -100,3 +116,11 @@ let record_reply outcome =
   inc
     Otel_transport_metric_names.metric_discord_outbound_replies
     ~labels:[ "outcome", reply_outcome_label outcome ]
+
+let record_gateway_reconnect_outcome ~method_ ~outcome =
+  inc
+    Otel_transport_metric_names.metric_discord_gateway_reconnect_outcomes
+    ~labels:
+      [ "method", reconnect_method_label method_
+      ; "outcome", reconnect_outcome_label outcome
+      ]

--- a/lib/gate/discord_observability.mli
+++ b/lib/gate/discord_observability.mli
@@ -16,6 +16,14 @@ type gateway_event =
   | Ignored
   | Open_wss
 
+type reconnect_method =
+  | Resume
+  | Fresh_identify
+
+type reconnect_outcome =
+  | Reconnect_succeeded
+  | Reconnect_failed
+
 type inbound_outcome =
   | Dropped_unbound
   | Dispatch_unavailable
@@ -40,11 +48,15 @@ val gateway_event_label : gateway_event -> string
 val inbound_outcome_label : inbound_outcome -> string
 val ambient_outcome_label : ambient_outcome -> string
 val reply_outcome_label : reply_outcome -> string
+val reconnect_method_label : reconnect_method -> string
+val reconnect_outcome_label : reconnect_outcome -> string
 
 val record_gateway_event : route:gateway_route -> gateway_event -> unit
 val record_gateway_close : code:int -> unit
 val record_gateway_reconnect_scheduled : unit -> unit
 val record_gateway_ack_timeout : unit -> unit
+val record_gateway_reconnect_outcome :
+  method_:reconnect_method -> outcome:reconnect_outcome -> unit
 val record_inbound_dispatch : inbound_outcome -> unit
 val record_ambient : ambient_outcome -> unit
 val record_reply : reply_outcome -> unit

--- a/lib/otel_metric_store/otel_transport_metric_names.ml
+++ b/lib/otel_metric_store/otel_transport_metric_names.ml
@@ -64,6 +64,11 @@ let metric_discord_gateway_ack_timeouts =
     "masc_discord_gateway_ack_timeouts_total"
 ;;
 
+let metric_discord_gateway_reconnect_outcomes =
+  Otel_metric_store_core.declare_counter
+    "masc_discord_gateway_reconnect_outcomes_total"
+;;
+
 let metric_discord_inbound_dispatch =
   Otel_metric_store_core.declare_counter "masc_discord_inbound_dispatch_total"
 ;;

--- a/lib/otel_metric_store/otel_transport_metric_names.mli
+++ b/lib/otel_metric_store/otel_transport_metric_names.mli
@@ -64,6 +64,11 @@ val metric_discord_gateway_reconnect_scheduled : string
     loop before forcing a reconnect. *)
 val metric_discord_gateway_ack_timeouts : string
 
+(** Discord gateway reconnect attempt outcomes.
+    Labels: [method] = [resume | fresh_identify],
+    [outcome] = [succeeded | failed]. *)
+val metric_discord_gateway_reconnect_outcomes : string
+
 (** Triggered Discord inbound messages after keeper binding lookup.
     Labels: [outcome] =
     [dropped_unbound | dispatch_unavailable | gate_error | empty_reply |


### PR DESCRIPTION
## Summary

PR #21064 (재연결 영구 정지 수정)에 이은 Discord Gateway 추가 개선.

## Changes

### 1. Backoff Jitter (±25%)
- `discord_gateway_client.ml`: `Schedule_backoff` effect 실행 시 ±25% 무작위 지터 추가
- 상태머신의 `backoff_ms`는 테스트 가능성을 위해 결정론적 유지 (RFC-0203 설계 의도)
- I/O layer에서 `Mirage_crypto_rng`로 지터 생성 — 여러 인스턴스가 동시에 재시작해도 thundering herd 방지

### 2. Reconnect OTel Metrics
- `discord_observability.ml`: `reconnect_method` (Resume | Fresh_identify) + `reconnect_outcome` (Succeeded | Failed) 타입 추가
- `otel_transport_metric_names`: `masc_discord_gateway_reconnect_outcomes_total` 카운터 등록
- `discord_gateway_client.ml`: READY 이벤트 시 재연결 성공 메트릭 기록, Backoff_elapsed 시 resume vs fresh identify 추적
- `discord_gateway_state.mli`: `resume_context` 접근자 추가 (추상 타입 캡슐화 유지)

## Test Results

```
dune build @check: pass (no errors)
dune exec test/test_discord_gateway_state.exe: 77 tests, all pass
```

Co-Authored-By: Claude <noreply@anthropic.com>
