### PR TITLE
fix(core): add search_files alias for tool_search_files

### DIFF
--- a/lib/core/tool_name_alias_axis.ml
+++ b/lib/core/tool_name_alias_axis.ml
@@ -12,6 +12,8 @@ let public_aliases =
   ; { public_name = "Read"; internal_name = "tool_read_file" }
   ; { public_name = "Grep"; internal_name = "tool_search_files" }
   ; { public_name = "Search"; internal_name = "tool_search_files" }
+  ; { public_name = "search_files"; internal_name = "tool_search_files" }
+  ; { public_name = "Glob"; internal_name = "tool_search_files" }
   ; { public_name = "WebSearch"; internal_name = "masc_web_search" }
   ; { public_name = "Write"; internal_name = "tool_write_file" }
   ]

--- a/lib/core/tool_name_alias_axis.ml
+++ b/lib/core/tool_name_alias_axis.ml
@@ -13,7 +13,6 @@ let public_aliases =
   ; { public_name = "Grep"; internal_name = "tool_search_files" }
   ; { public_name = "Search"; internal_name = "tool_search_files" }
   ; { public_name = "search_files"; internal_name = "tool_search_files" }
-  ; { public_name = "Glob"; internal_name = "tool_search_files" }
   ; { public_name = "WebSearch"; internal_name = "masc_web_search" }
   ; { public_name = "Write"; internal_name = "tool_write_file" }
   ]


### PR DESCRIPTION
## Problem
Models occasionally emit `search_files` (the internal tool name) instead of the public `Search`/`Grep` names, causing `Tool not found` rejections in the logs.

## Change
Add one public alias in `lib/core/tool_name_alias_axis.ml`:
- `search_files` → `tool_search_files`

`Glob` was considered but intentionally omitted: it implies glob-pattern matching semantics that `tool_search_files` does not provide, so mapping it would be misleading.

## Verification
`dune build --root . @check` passes.

## Related
Closes task-966.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
