### PR TITLE
fix(discord,telemetry): re-land three merges silently reverted by 6f5bfdeb2 (#20869)

### DIFF
--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -444,6 +444,8 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("stale", `Bool (bool_member status "stale"));
       ("stale_after_sec", `Int (int_member status "stale_after_sec"));
       ("error", `String (string_member status "error"));
+      ("status_source", `String (string_member status "status_source"));
+      ("gateway_state", `String (string_member status "gateway_state"));
       ("status_path", `String (string_member status "status_path"));
       ("binding_store_path", `String (string_member status "binding_store_path"));
       ("audit_path", `String (string_member status "audit_path"));

--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -1,8 +1,9 @@
 (* RFC-0203 Phase 1.2b.3 — I/O loop bridging Discord_wss_connection and
    Discord_gateway_state.
 
-   Single session, no reconnect. Phase 1.4 will wrap this in a backoff
-   loop that re-creates the WSS connection on Reconnect_requested. *)
+   The state machine owns reconnect/backoff decisions. This I/O loop
+   applies those effects by closing the current WSS session before
+   opening the next one. *)
 
 type intent = Discord_gateway_state.intent =
   | Guilds

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -838,7 +838,8 @@ let handle_wss_closed t ~now_mono ~code ~reason =
                 (Printf.sprintf "Discord fatal close %d: %s" code reason)
           ; resume_context = None
           }
-        , [ Log
+        , [ Close_wss { code; reason }
+          ; Log
               { level = `Error
               ; message =
                   Printf.sprintf
@@ -855,7 +856,8 @@ let handle_wss_closed t ~now_mono ~code ~reason =
             ~resume_context
         in
         ( t'
-        , [ Schedule_backoff { delay_ms }
+        , [ Close_wss { code; reason }
+          ; Schedule_backoff { delay_ms }
           ; Log
               { level = `Warn
               ; message =

--- a/lib/keeper/keeper_telemetry_consumer.ml
+++ b/lib/keeper/keeper_telemetry_consumer.ml
@@ -1,21 +1,29 @@
 (** Keeper_telemetry_consumer — MASC-side observer for OAS telemetry events.
 
     Subscribes to the OAS event bus via [Agent_sdk_metrics_bridge],
-    filters [Custom("telemetry_event", json)] payloads, and records that a
-    telemetry item was observed. MASC deliberately does not deserialize
-    provider/model-bearing OAS telemetry; concrete runtime identity belongs to
-    OAS.
+    filters [Custom("telemetry_event", json)] payloads, persists each
+    event to [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl] via
+    {!Dated_jsonl}, and increments an OTel counter for dashboard
+    visibility.
 
-    State is purely internal: the subscription handle and the fiber are both
-    bound to the caller's [Eio.Switch.t]. *)
+    MASC deliberately does not deserialize provider/model-bearing OAS
+    telemetry; concrete runtime identity belongs to OAS.
+
+    State is purely internal: the subscription handle, the fiber, and the
+    {!Dated_jsonl.t} store are all bound to the caller's [Eio.Switch.t]. *)
 
 let telemetry_event_counter = "masc_keeper_telemetry_events_consumed_total"
 
-(* drain is non-blocking; loop must yield or it pins the Eio domain and
+(* Drain is non-blocking; the loop must yield or it pins the Eio domain and
    starves co-located fibers (HTTP handlers, lazy startup tasks). *)
 let drain_interval_s = 0.1
 
-let spawn_subscriber ~sw ~clock ~bus =
+let spawn_subscriber ~sw ~clock ~base_path ~bus =
+  let store =
+    Dated_jsonl.create
+      ~base_dir:(Filename.concat base_path "data/harness-telemetry")
+      ()
+  in
   let sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"telemetry_consumer"
@@ -34,11 +42,12 @@ let spawn_subscriber ~sw ~clock ~bus =
          List.iter
            (fun (evt : Agent_sdk.Event_bus.event) ->
               match evt.payload with
-              | Agent_sdk.Event_bus.Custom ("telemetry_event", _) ->
+              | Agent_sdk.Event_bus.Custom ("telemetry_event", json) ->
                   Otel_metric_store.inc_counter
                     telemetry_event_counter
                     ~labels:[ "result", "observed" ]
-                    ()
+                    ();
+                  Dated_jsonl.append store json
               | _ -> ())
            events
        with

--- a/lib/keeper/keeper_telemetry_consumer.mli
+++ b/lib/keeper/keeper_telemetry_consumer.mli
@@ -2,10 +2,18 @@
 
     Spawns a fiber that drains [Custom("telemetry_event", json)]
     payloads from the OAS event bus without deserializing provider/model
-    identity. *)
+    identity.  Each event is persisted to
+    [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl] via
+    {!Dated_jsonl}. *)
 
 val spawn_subscriber
   :  sw:Eio.Switch.t
   -> clock:[> float Eio.Time.clock_ty ] Eio.Std.r
+  -> base_path:string
   -> bus:Agent_sdk.Event_bus.t
   -> unit
+(** [spawn_subscriber ~sw ~clock ~base_path ~bus] forks a fiber that
+    drains [Custom("telemetry_event", json)] payloads from [bus],
+    persists each one to [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl],
+    and increments an OTel counter.  The fiber yields every 100 ms so
+    co-located fibers are not starved. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -357,7 +357,8 @@ let start_keeper_loops
     event_bus;
   (* Telemetry feedback loop: observe OAS per-turn signals without
      deserializing provider/model-bearing payloads. *)
-  Keeper_telemetry_consumer.spawn_subscriber ~sw ~clock ~bus:event_bus;
+  Keeper_telemetry_consumer.spawn_subscriber
+    ~sw ~clock ~base_path:(Env_config.base_path ()) ~bus:event_bus;
   let keeper_lifecycle_sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"lifecycle_listener"

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -196,6 +196,13 @@ let test_connectors_json_advertises_gate_connector_descriptor () =
       (connector |> U.member "connector_id" |> U.to_string);
     check string "display name" "Discord"
       (connector |> U.member "display_name" |> U.to_string);
+    (* status_json carries these (#20813), but connector_json re-projects a
+       fixed field list, so passthrough must be asserted on the connectors
+       surface — the dashboard reads this endpoint, not status_json. *)
+    check string "status_source passthrough" "in_process_gateway"
+      (connector |> U.member "status_source" |> U.to_string);
+    check string "gateway_state passthrough" "disconnected"
+      (connector |> U.member "gateway_state" |> U.to_string);
     check bool "bindings capability exposed" true
       (connector |> U.member "capabilities" |> U.to_list
        |> List.exists (function

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -1046,6 +1046,7 @@ let test_wss_closed_from_connected_is_resumable () =
   (match S.state m' with
    | S.Reconnect_pending { resumable = true; _ } -> ()
    | _ -> fail "expected Reconnect_pending resumable=true");
+  check bool "Close_wss emitted" true (has_close_wss effects);
   check bool "Schedule_backoff emitted" true
     (has_schedule_backoff effects)
 
@@ -1063,6 +1064,7 @@ let test_wss_closed_fatal_goes_to_failed () =
   (match S.state m' with
    | S.Failed _ -> ()
    | _ -> fail "expected Failed for fatal close code 4014");
+  check bool "Close_wss emitted" true (has_close_wss effects);
   check bool "no Schedule_backoff on fatal close" false
     (has_schedule_backoff effects)
 

--- a/test/test_keeper_telemetry_consumer.ml
+++ b/test/test_keeper_telemetry_consumer.ml
@@ -23,6 +23,18 @@ module KTC = Masc.Keeper_telemetry_consumer
 let target_iters = 5
 let inter_sleep_s = 0.02
 let total_expected_wall_clock_s = float_of_int target_iters *. inter_sleep_s
+let temp_counter = ref 0
+
+let temp_base_path prefix =
+  incr temp_counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s_%d_%d_%.0f" prefix !temp_counter (Unix.getpid ())
+         (Unix.gettimeofday ()))
+  in
+  Fs_compat.mkdir_p dir;
+  dir
 
 (* Marker used to break out of [Switch.run] once the assertion data is
    collected. Using [Switch.fail] would propagate as the switch's
@@ -35,9 +47,10 @@ let test_drain_loop_yields_to_co_located_fiber () =
   Eio_main.run @@ fun env ->
     let clock = Eio.Stdenv.clock env in
     let bus = Agent_sdk.Event_bus.create () in
+    let base_path = temp_base_path "keeper_telemetry_consumer" in
     (try
       Eio.Switch.run (fun sw ->
-        KTC.spawn_subscriber ~sw ~clock ~bus;
+        KTC.spawn_subscriber ~sw ~clock ~base_path ~bus;
         for _ = 1 to target_iters do
           Eio.Time.sleep clock inter_sleep_s;
           incr counter


### PR DESCRIPTION
## Summary

`6f5bfdeb2` (#20869, titled `test(otel): fix rfc-0085 tests and tool event order assertions`) was merged from a stale base and textually reverted three sibling PRs that had merged ~3.5h earlier, without mentioning any of them. This PR re-lands all three, including the regression-test assertions that #20869 deleted.

### Re-land 1 — #20859 (`7d9ac3384`): release gateway socket before reconnect
- `handle_wss_closed` emits `Close_wss { code; reason }` ahead of `Schedule_backoff` (resumable branch) and ahead of the fatal `Log` (fatal branch).
- Without it, `conn_ref` is only cleared in the `Close_wss` effect handler (`discord_gateway_client.ml`), so after any remote-initiated WSS close the post-backoff `Open_wss` hits `"Open_wss while conn_ref still Some; expected Close_wss first — dropping new connect"` and the Discord gateway never reconnects.
- Restores both deleted `"Close_wss emitted"` assertions in `test_discord_gateway_state.ml` and the truthful I/O-loop header comment in `discord_gateway_client.ml`.

### Re-land 2 — #20848 (`825766d98`): connector_json gateway_state/status_source passthrough
- `status_json` emits both fields since #20813, but `connector_json` re-projects a fixed field whitelist that omitted them. `/api/v1/gate/connectors` — the surface the dashboard Connectors page reads — never carried the machine state, and the dashboard valibot `fallback(string(), '')` masked the drop (machine-state chip silently blank).
- Restores both passthrough fields and the two deleted descriptor-test assertions.

### Re-land 3 — #20853 (`7e051c947`): persist telemetry_event bus messages via Dated_jsonl
- `keeper_telemetry_consumer` regressed to counter-only (telemetry-as-counter, no record). PR #20850 was closed citing "main contains Keeper_telemetry_consumer with Dated_jsonl writing logic" — that premise had been silently removed.
- Restores `~base_path` plumbing, `Dated_jsonl.append` per `Custom("telemetry_event", json)` payload, the `server_bootstrap_loops.ml` call site, and the test temp-dir spawn args (#20860).

## Context

Found by the 2026-06-13 merge audit (`~/me/reports/masc-merge-audit-2026-06-13.md`): same-day there were four silent stale-base reverts (this commit ×3, `c24a62206` ×1). A separate task (task-947) tracks a merge-gate that detects reverts of recently-merged hunks.

MASC: task-935, goal-merge-audit-20260613.

## Validation

- `dune build @check` exit 0
- `dune build` exit 0
- `test_discord_gateway_state`, `test_channel_gate_discord_state`, `test_keeper_telemetry_consumer` green (restored assertions exercise the re-landed behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
