### PR TITLE
fix(dashboard): stop config preview from advancing the live board cursor

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -251,11 +251,27 @@ let keeper_config_json (config : Workspace.config) (name : string)
       (* Preview the actual unified prompt the keeper turn uses.
          We build the observation from the current workspace state so the
          system message and the "Current World State" user message both
-         match what a turn would see right now. *)
+         match what a turn would see right now.
+
+         Board events are collected WITHOUT advancing the keeper's board
+         cursor: passing [~pending_board_events:None] would route through
+         [collect_board_events ~advance_cursor:true], so merely opening a
+         keeper's detail page would consume the live cursor and the next
+         real turn would miss those events. Only a turn owns cursor
+         advancement. *)
       let unified_system_prompt_preview, unified_user_message_preview =
         let observation =
-          Keeper_world_observation.observe ~pending_board_events:None ~config
-            ~meta:m
+          let pending_board_events, _new_count, _mention_count =
+            Keeper_world_observation
+            .collect_board_events_without_advancing_cursor
+              ~base_path:config.base_path
+              ~continuity_summary:
+                (Keeper_world_observation.read_continuity_summary ~config
+                   ~meta:m)
+              ~meta:m
+          in
+          Keeper_world_observation.observe
+            ~pending_board_events:(Some pending_board_events) ~config ~meta:m
         in
         Keeper_unified_prompt.build_prompt ~meta:m ~base_path:config.base_path
           ~profile_defaults:defaults ~observation ()


### PR DESCRIPTION
## Summary

`GET /api/v1/keepers/:name/config` (the dashboard keeper detail page auto-loads this) builds its unified-prompt preview via `Keeper_world_observation.observe ~pending_board_events:None`, which routes through `collect_board_events ~advance_cursor:true` and executes `Keeper_registry.set_board_cursor` + `Keeper_reaction_ledger.record_board_cursor_ack` on the **live in-process registry entry**.

Merely opening a keeper's detail page therefore consumes that keeper's board cursor — the next real turn no longer sees the events the preview consumed. Introduced by `c24a62206` (#20991), which replaced an intentionally static preview observation (its removed comment explained the preview avoided runtime coupling for exactly this reason).

## Change

Pre-collect board events with the existing non-advancing variant and feed them to `observe`:

- `collect_board_events_without_advancing_cursor` + `read_continuity_summary` (both already exported in the `.mli`), then `observe ~pending_board_events:(Some events)`.
- The only other `~pending_board_events:None` call site is `keeper_heartbeat_loop.ml` — the real turn path, where cursor advancement is the intended owner semantics. Unchanged.

The preview still renders the same world state a turn would see right now; it just no longer mutates it.

## Context

Found by the 2026-06-13 merge audit (`~/me/reports/masc-merge-audit-2026-06-13.md`, P1). MASC: task-936, goal-merge-audit-20260613.

## Validation

- `dune build --root . @check` exit 0
- `dune build --root .` exit 0
- Read-path only change; behavior difference is the absence of cursor writes (`set_board_cursor` / `record_board_cursor_ack` are inside the `if advance_cursor` guard, verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
