### PR TITLE
fix(server): make memory-subsystems cache thread-safe

### DIFF
--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -13,9 +13,15 @@ let memory_subsystems_entry_cache
      * (string * Keeper_memory_policy.keeper_memory_line) list
      * (string * string) list)
       option
-      ref
+      Atomic.t
   =
-  ref None
+  Atomic.make None
+;;
+
+(** Single-flight mutex for refreshing the memory-subsystems cache. The cache
+    itself is an [Atomic.t] so readers can check the TTL without contending for
+    the lock; only a miss contends and one fiber performs the expensive IO. *)
+let memory_subsystems_entry_cache_mu = Eio.Mutex.create ()
 ;;
 
 let dashboard_memory_subsystems_include_entries request =
@@ -29,48 +35,58 @@ let dashboard_memory_subsystems_include_entries request =
 let load_memory_subsystems_entries ~(config : Workspace_utils.config) =
   (* NDT-OK: wall-clock read only gates a dashboard cache TTL. *)
   let now = Unix.gettimeofday () in
-  match !memory_subsystems_entry_cache with
-  | Some (base_path, cached_at, rows, errors)
-    when String.equal base_path config.base_path
-         && now -. cached_at < memory_subsystems_entry_cache_ttl_sec ->
+  let is_fresh = function
+    | Some (base_path, cached_at, _rows, _errors) ->
+      String.equal base_path config.base_path
+      && now -. cached_at < memory_subsystems_entry_cache_ttl_sec
+    | None -> false
+  in
+  match Atomic.get memory_subsystems_entry_cache with
+  | Some (base_path, cached_at, rows, errors) as cached when is_fresh cached ->
     (rows, errors)
   | _ ->
-    let rows, errors =
-      try
-        Keeper_meta_store.keeper_names config
-        |> List.fold_left
-             (fun (rows_acc, errs_acc) keeper ->
-               match
-                 Keeper_memory_recall.read_keeper_memory_summary_result
-                   config
-                   ~name:keeper
-                   ~max_bytes:120000
-                   ~max_lines:180
-                   ~recent_limit:30
-               with
-               | Ok summary ->
-                 let rows =
-                   List.map
-                     (fun (row : Keeper_memory_policy.keeper_memory_line) ->
-                       keeper, row)
-                     summary.recent_notes
-                 in
-                 List.rev_append rows rows_acc, errs_acc
-               | Error exn_class ->
-                 let label =
-                   Keeper_memory_recall_exn_class.to_label exn_class
-                 in
-                 rows_acc, (keeper, label) :: errs_acc)
-             ([], [])
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | _ -> [], []
-    in
-    let rows = List.rev rows in
-    let errors = List.rev errors in
-    memory_subsystems_entry_cache
-    := Some (config.base_path, now, rows, errors);
-    rows, errors
+    Eio.Mutex.use_rw ~protect:true memory_subsystems_entry_cache_mu
+    @@ fun () ->
+    (match Atomic.get memory_subsystems_entry_cache with
+     | Some (base_path, cached_at, rows, errors) as cached when is_fresh cached ->
+       (rows, errors)
+     | _ ->
+       let rows, errors =
+         try
+           Keeper_meta_store.keeper_names config
+           |> List.fold_left
+                (fun (rows_acc, errs_acc) keeper ->
+                  match
+                    Keeper_memory_recall.read_keeper_memory_summary_result
+                      config
+                      ~name:keeper
+                      ~max_bytes:120000
+                      ~max_lines:180
+                      ~recent_limit:30
+                  with
+                  | Ok summary ->
+                    let rows =
+                      List.map
+                        (fun (row : Keeper_memory_policy.keeper_memory_line) ->
+                          keeper, row)
+                        summary.recent_notes
+                    in
+                    List.rev_append rows rows_acc, errs_acc
+                  | Error exn_class ->
+                    let label =
+                      Keeper_memory_recall_exn_class.to_label exn_class
+                    in
+                    rows_acc, (keeper, label) :: errs_acc)
+                ([], [])
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | _ -> [], []
+       in
+       let rows = List.rev rows in
+       let errors = List.rev errors in
+       Atomic.set memory_subsystems_entry_cache
+         (Some (config.base_path, now, rows, errors));
+       rows, errors)
 ;;
 
 let dashboard_memory_subsystems_http_json

--- a/test/dune
+++ b/test/dune
@@ -100,6 +100,7 @@
   test_dashboard_perf
   test_dashboard_tool_host_events
   test_dashboard_nav_event
+  test_server_dashboard_http_memory_subsystems
   test_dashboard_execute_output
   test_tool_assignment_telemetry
   test_dashboard_link_preview
@@ -378,6 +379,7 @@
   test_dashboard_perf
   test_dashboard_tool_host_events
   test_dashboard_nav_event
+  test_server_dashboard_http_memory_subsystems
   test_dashboard_execute_output
   test_tool_assignment_telemetry
   test_dashboard_link_preview

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -1,0 +1,105 @@
+open Alcotest
+
+module Json = Yojson.Safe.Util
+module Memory_subsystems = Server_dashboard_http_memory_subsystems
+
+let request target =
+  Httpun.Request.create ~headers:(Httpun.Headers.of_list []) `GET target
+;;
+
+let check_include target expected =
+  check
+    bool
+    target
+    expected
+    (Memory_subsystems.dashboard_memory_subsystems_include_entries (request target))
+;;
+
+let temp_dir () =
+  let path = Filename.temp_file "memory_subsystems_dashboard_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path
+    then
+      if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path)
+      else Sys.remove path
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let test_include_entries_query_param () =
+  check_include "/dashboard/memory-subsystems" false;
+  check_include "/dashboard/memory-subsystems?include_memory_entries=1" true;
+  check_include "/dashboard/memory-subsystems?include_memory_entries=true" true;
+  check_include "/dashboard/memory-subsystems?include_memory_entries=yes" true;
+  check_include "/dashboard/memory-subsystems?include_memory_entries=y" true;
+  check_include "/dashboard/memory-subsystems?include_memory_entries=0" false;
+  check_include "/dashboard/memory-subsystems?include_memory_entries=false" false;
+  check_include "/dashboard/memory-subsystems?include_memory_entries=no" false;
+  check_include "/dashboard/memory-subsystems?include_memory_entries=n" false
+;;
+
+let test_focus_entries_enables_memory_entries () =
+  check_include "/dashboard/memory-subsystems?focus=entries" true;
+  check_include "/dashboard/memory-subsystems?focus=%20entries%20" true;
+  check_include "/dashboard/memory-subsystems?focus=episodes" false
+;;
+
+let test_http_json_explicitly_disabled_entries_surface () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let config = Workspace_utils.default_config dir in
+      let json =
+        Memory_subsystems.dashboard_memory_subsystems_http_json
+          ~config
+          ~include_memory_entries:false
+          (request "/dashboard/memory-subsystems?limit=9999&focus=entries")
+      in
+      let memory_entries = Json.(json |> member "memory_entries") in
+      check int "memory total" 0 Json.(memory_entries |> member "total" |> to_int);
+      check
+        int
+        "memory filtered"
+        0
+        Json.(memory_entries |> member "filtered" |> to_int);
+      check int "memory shown" 0 Json.(memory_entries |> member "shown" |> to_int);
+      check int "limit clamped" 500 Json.(memory_entries |> member "limit" |> to_int);
+      check
+        int
+        "items empty"
+        0
+        Json.(memory_entries |> member "items" |> to_list |> List.length))
+;;
+
+let () =
+  Alcotest.run
+    "server_dashboard_http_memory_subsystems"
+    [ ( "request"
+      , [ test_case
+            "include_memory_entries accepts explicit bool forms"
+            `Quick
+            test_include_entries_query_param
+        ; test_case
+            "focus entries enables memory entries"
+            `Quick
+            test_focus_entries_enables_memory_entries
+        ] )
+    ; ( "json"
+      , [ test_case
+            "explicit disabled entries keeps empty surface"
+            `Quick
+            test_http_json_explicitly_disabled_entries_surface
+        ] )
+    ]
+;;

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -83,6 +83,7 @@ let test_http_json_explicitly_disabled_entries_surface () =
 ;;
 
 let () =
+  Eio_main.run @@ fun _env ->
   Alcotest.run
     "server_dashboard_http_memory_subsystems"
     [ ( "request"


### PR DESCRIPTION
# ci:skip-test-coverage

## Problem

The module-level memory-subsystems cache was a plain [ref] option updated with a read-check-write sequence. Dashboard HTTP handlers run on Eio fibers, so concurrent requests could observe torn cache tuples, duplicate expensive Keeper_memory_recall IO, and overwrite each other's writes.

## Change

- Replace the [ref] with an [Atomic.t].
- Guard the refresh path with [Eio.Mutex] so only one fiber performs the expensive load.
- Keep the fast cache-hit path lock-free via the Atomic read.

## Verification

- [x] `scripts/dune-local.sh build lib/server/masc_server.a` passes.

Refs: audit finding MASC-mutable-ref-001

# ci:skip-test-coverage
These changes only make an existing internal dashboard cache thread-safe; no new externally-observable behavior is introduced that can be meaningfully unit-tested without a multi-fiber HTTP handler harness.