### PR TITLE
fix(exec,keeper): dangling-else stream duplication + non-routable tool hint (merge-audit quick fixes)

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -422,14 +422,20 @@ let rec dispatch_pipeline ?base_host_env ?stdin_content ?on_output_chunk stages 
                        let stderr = stderr ^ stage_result.stderr in
                        if status_is_timeout stage_result.status
                        then (
+                         (* OCaml binds [else] to the nearest [if]: without
+                            the parentheses the [else] below attached to
+                            [if not is_final], so a streamed final-stage
+                            timeout re-emitted output that had already been
+                            streamed live, and a non-streamed (redirected)
+                            stage timeout emitted nothing. *)
                          let () =
                            if stage_streamed
-                           then
+                           then (
                              if not is_final
                              then
                                emit_stdout_if_captured
                                  on_output_chunk
-                                 stage_result.stdout
+                                 stage_result.stdout)
                            else
                              emit_pipeline_stage_result
                                ~emit_stdout:true

--- a/lib/keeper/keeper_hooks_oas_idle.ml
+++ b/lib/keeper/keeper_hooks_oas_idle.ml
@@ -50,10 +50,13 @@ let recovery_hint ~allowed_tools ~tool_names =
       | [ one ] -> one
       | many -> String.concat " or " many
     in
+    (* The routable tool is keeper_board_post_get; "keeper_board_get" has no
+       dispatch route (models hallucinate it, which is why both names trigger
+       this hint above) — the nudge must name the tool that actually exists. *)
     Some
       (Printf.sprintf
-         "keeper_board_get requires post_id; if no post_id is visible, use %s first. \
-          Do not call keeper_board_get with {}."
+         "keeper_board_post_get requires post_id; if no post_id is visible, use %s first. \
+          Do not call keeper_board_post_get with {}."
          discovery)
   else
     None

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -228,6 +228,65 @@ let () =
   assert (List.mem (`Stdout "out") !chunks);
   assert (List.mem (`Stderr "err") !chunks)
 
+(* --- decomposed pipeline: streamed final-stage timeout must not re-emit ---
+
+   Regression for the dangling-else in the decomposed-chain timeout branch:
+   the [else] bound to [if not is_final] instead of [if stage_streamed], so a
+   streamed final stage that timed out (exit 124) re-emitted its already
+   streamed stdout through [emit_pipeline_stage_result ~emit_stdout:true].
+   Stage 1 carries a redirect to force the decomposed path. *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let sh_bin = Masc_exec.Exec_program.of_string "sh" |> Result.get_ok in
+  let host_sandbox = Masc_exec.Sandbox_target.host () in
+  let upstream_stage =
+    Simple
+      {
+        bin = sh_bin;
+        args =
+          [ Lit ("-c", default_meta); Lit ("printf upstream", default_meta) ];
+        env = [];
+        cwd = None;
+        redirects = [ Masc_exec.Redirect_scope.Fd_to_fd { src = 2; dst = 1 } ];
+        sandbox = host_sandbox;
+      }
+  in
+  let timeout_stage =
+    Simple
+      {
+        bin = sh_bin;
+        args =
+          [
+            Lit ("-c", default_meta);
+            Lit ("cat >/dev/null; printf visible; exit 124", default_meta);
+          ];
+        env = [];
+        cwd = None;
+        redirects = [];
+        sandbox = host_sandbox;
+      }
+  in
+  let chunks = ref [] in
+  let result =
+    Masc_exec.Exec_dispatch.dispatch_pipeline
+      ~on_output_chunk:(fun chunk -> chunks := chunk :: !chunks)
+      [ upstream_stage; timeout_stage ]
+  in
+  assert (result.status = Unix.WEXITED 124);
+  assert (result.stdout = "visible");
+  let streamed_stdout =
+    List.rev !chunks
+    |> List.filter_map (function
+         | `Stdout c -> Some c
+         | `Stderr _ -> None)
+    |> String.concat ""
+  in
+  (* Old parse re-emitted the captured stdout after the live stream:
+     "visiblevisible". *)
+  assert (streamed_stdout = "visible")
+
 (* --- dispatch pipeline exit code: last nonzero wins --- *)
 
 let () =

--- a/test/test_keeper_unified_metacognition.ml
+++ b/test/test_keeper_unified_metacognition.ml
@@ -60,9 +60,9 @@ let test_on_idle_board_get_nudge_names_post_id_discovery () =
   | Agent_sdk.Hooks.Nudge msg ->
     check
       bool
-      "board_get nudge says post_id is required"
+      "board_get nudge names the routable tool, not the hallucinated alias"
       true
-      (contains_substring msg "keeper_board_get requires post_id");
+      (contains_substring msg "keeper_board_post_get requires post_id");
     check
       bool
       "board_get nudge points to board discovery tools"
@@ -72,7 +72,7 @@ let test_on_idle_board_get_nudge_names_post_id_discovery () =
       bool
       "board_get nudge forbids empty args"
       true
-      (contains_substring msg "Do not call keeper_board_get with {}")
+      (contains_substring msg "Do not call keeper_board_post_get with {}")
   | other ->
     fail
       (Printf.sprintf


### PR DESCRIPTION
## Summary

Two small remediations from the 2026-06-13 merge audit (`~/me/reports/masc-merge-audit-2026-06-13.md`).

### 1. exec_dispatch decomposed-pipeline timeout: dangling-else (task-938, P2)

OCaml binds `else` to the nearest `if`. In the decomposed-chain timeout branch the `else` attached to `if not is_final` instead of `if stage_streamed` (the indentation's intent), so:

- a **streamed final stage** that timed out (exit 124) re-emitted its already-streamed stdout via `emit_pipeline_stage_result ~emit_stdout:true` (duplicate output), and
- a **non-streamed (redirected) stage** timeout emitted nothing where `~emit_stdout:true` was intended.

Introduced in `48b675be4` (merge #20841). Repo-wide ocamlformat is disabled (RFC-0010), so no formatter normalized the misleading layout. Fix parenthesizes the inner conditional; regression test drives a real decomposed pipeline (stage 1 carries a `2>&1` redirect to force the decomposed path, final stage streams then exits 124) and asserts the concatenated streamed stdout is `"visible"`, not `"visiblevisible"`.

### 2. Idle nudge names a non-routable tool (task-945, P2)

#20957 changed the idle recovery hint to say `keeper_board_get requires post_id` — but `keeper_board_get` has no dispatch route (no descriptor, no alias; the resolution matrix reports it unresolved). A model following the nudge calls an unknown tool and burns the turn. The trigger still matches both names (models hallucinate `keeper_board_get`); the message now names the routable `keeper_board_post_get`. Test assertions updated to pin the routable name.

## Context

MASC: task-938 + task-945, goal-merge-audit-20260613.

## Validation

- `dune build --root . @check` / `dune build --root .` exit 0
- `test_exec_dispatch` (incl. new regression) and `test_keeper_unified_metacognition` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
