### PR TITLE
fix(auth): serialize stale-token warn dedup hashtbl

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -288,19 +288,29 @@ let sanitize_dashboard_actor_name raw =
 let warn_cooldown_sec = 300.0
 
 let stale_token_warn_log : (string, float) Hashtbl.t = Hashtbl.create 16
+let stale_token_warn_mu = Eio.Mutex.create ()
 
 let record_dashboard_actor_fallback
     (fb : Auth_error_kind.dashboard_actor_fallback) =
   let now = Time_compat.now () in
   let should_log =
+    Eio.Mutex.use_ro stale_token_warn_mu @@ fun () ->
     match Hashtbl.find_opt stale_token_warn_log fb.token_hash_prefix with
     | Some last_ts -> now -. last_ts >= warn_cooldown_sec
     | None -> true
   in
   if should_log then begin
-    Hashtbl.replace stale_token_warn_log fb.token_hash_prefix now;
-    Log.Auth.warn "%s"
-      (Auth_error_kind.dashboard_actor_fallback_log_message fb)
+    Eio.Mutex.use_rw ~protect:true stale_token_warn_mu @@ fun () ->
+    (* Re-check under the write lock; another fiber may have just logged. *)
+    let really_should_log =
+      match Hashtbl.find_opt stale_token_warn_log fb.token_hash_prefix with
+      | Some last_ts -> now -. last_ts >= warn_cooldown_sec
+      | None -> true
+    in
+    if really_should_log then (
+      Hashtbl.replace stale_token_warn_log fb.token_hash_prefix now;
+      Log.Auth.warn "%s"
+        (Auth_error_kind.dashboard_actor_fallback_log_message fb));
   end;
   Otel_metric_store.inc_counter
     Otel_metric_store.metric_silent_dashboard_actor_fallback


### PR DESCRIPTION
# ci:skip-test-coverage

## Problem

The module-level stale-token warn log was a plain Hashtbl.t accessed with a read-check-write sequence from concurrent dashboard HTTP fibers. This could corrupt the table and emit duplicate warnings.

## Change

- Add an [Eio.Mutex] for the warn-log table.
- Guard the read probe and the conditional update with the mutex.
- Leave the metric counter unprotected so metrics remain accurate.

## Verification

- [x] Target module compiles; full build passes aside from unrelated missing-alias artifacts in other worktrees.

Refs: audit finding MASC-mutable-ref-002

# ci:skip-test-coverage
These changes only serialize access to an existing internal dedup table; no new externally-observable behavior is introduced that can be meaningfully unit-tested without fiber-race harnesses.