### PR TITLE
fix(keeper): serialize accountability snapshot cache refresh

### DIFF
--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -725,6 +725,8 @@ let accountability_snapshot_cache :
     (string, float * accountability_snapshot) Hashtbl.t =
   Hashtbl.create 4
 
+let accountability_snapshot_cache_mu = Eio.Mutex.create ()
+
 (* compute_reputation calls accountability_summary_json once per unique post
    author in a board render; rebuilding the windowed claim aggregation
    (read_window_entries + materialize_claims + bucketing) per author was
@@ -761,13 +763,21 @@ let cached_accountability_snapshot (config : Workspace_query.config) :
     accountability_snapshot =
   let key = config.base_path in
   let now = Time_compat.now () in
+  let is_fresh = function
+    | Some (built_at, _snap) -> now -. built_at < accountability_snapshot_ttl_s
+    | None -> false
+  in
   match Hashtbl.find_opt accountability_snapshot_cache key with
-  | Some (built_at, snap) when now -. built_at < accountability_snapshot_ttl_s ->
-      snap
+  | Some (built_at, snap) as cached when is_fresh cached -> snap
   | _ ->
-      let snap = build_accountability_snapshot config in
-      Hashtbl.replace accountability_snapshot_cache key (now, snap);
-      snap
+      Eio.Mutex.use_rw ~protect:true accountability_snapshot_cache_mu
+      @@ fun () ->
+      (match Hashtbl.find_opt accountability_snapshot_cache key with
+       | Some (built_at, snap) as cached when is_fresh cached -> snap
+       | _ ->
+           let snap = build_accountability_snapshot config in
+           Hashtbl.replace accountability_snapshot_cache key (now, snap);
+           snap)
 
 let accountability_summary_lookup (config : Workspace_query.config) =
   let { snap_now = now; by_agent; by_keeper } =

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -624,6 +624,46 @@ let test_summary_lookup_reads_window_once_for_multiple_agents () =
       in
       check int "window read count" 1 read_count)
 
+let test_summary_lookup_reuses_fresh_snapshot_across_lookup_construction () =
+  with_workspace (fun config ->
+      let created_at =
+        iso_of_unix (Unix.gettimeofday () -. (25.0 *. 3600.0))
+      in
+      append_accountability_event config.base_path ~created_at
+        (`Assoc
+           [
+             ("event_type", `String "claim_created");
+             ("claim_id", `String "acct-cache-reuse");
+             ("agent_name", `String "keeper-cache-agent");
+             ("keeper_name", `String "keeper-cache");
+             ("kind", `String "completion_claim");
+             ("subject", `String "Ship cache reuse");
+             ("surface", `String "keeper_turn");
+             ("created_at", `String created_at);
+             ("evidence_refs", `List []);
+             ("synthetic", `Bool false);
+           ]);
+      Keeper_accountability.enable_window_read_count_for_testing ();
+      let read_count =
+        Fun.protect
+          ~finally:Keeper_accountability.disable_window_read_count_for_testing
+          (fun () ->
+            let first =
+              Keeper_accountability.accountability_summary_lookup config
+            in
+            ignore
+              (first ~keeper_name:"keeper-cache"
+                 ~agent_name:"keeper-cache-agent");
+            let second =
+              Keeper_accountability.accountability_summary_lookup config
+            in
+            ignore
+              (second ~keeper_name:"keeper-cache"
+                 ~agent_name:"keeper-cache-agent");
+            Keeper_accountability.window_read_count_for_testing ())
+      in
+      check int "window read count" 1 read_count)
+
 (* compute_reputation calls accountability_summary_json once per post author in
    a board render. After the per-render memoization fix the windowed claim
    aggregation is built once per base path (short TTL) and reused, so two
@@ -782,6 +822,8 @@ let () =
             test_synthetic_claims_do_not_dilute_unsupported_rate;
           test_case "summary lookup reads window once" `Quick
             test_summary_lookup_reads_window_once_for_multiple_agents;
+          test_case "summary lookup reuses fresh snapshot" `Quick
+            test_summary_lookup_reuses_fresh_snapshot_across_lookup_construction;
           test_case "summary json memoizes window across agents" `Quick
             test_summary_json_memoizes_window_across_agents;
         ] );


### PR DESCRIPTION
# ci:skip-test-coverage

## Problem

The module-level accountability snapshot cache was a plain Hashtbl.t updated with a read-check-write sequence. Board renders call this helper once per unique post author from concurrent HTTP fibers, so parallel calls could corrupt the cache or duplicate the expensive windowed claim aggregation.

## Change

- Add an [Eio.Mutex] for the snapshot cache.
- Use double-checked locking so the fast path remains lock-free and only a TTL miss serializes.
- One fiber rebuilds the snapshot while others wait and reuse the result.

## Verification

- [x] `scripts/dune-local.sh build lib/masc.a` passes.

Refs: audit finding MASC-mutable-ref-003

# ci:skip-test-coverage
These changes only serialize access to an existing internal cache; no new externally-observable behavior is introduced that can be meaningfully unit-tested without a multi-fiber board-render harness.