### PR TITLE
fix(gate): serialize Discord thread-parent table access

### DIFF
--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -153,26 +153,36 @@ let rec drop_left n xs =
 let thread_parent_table : (string, string) Hashtbl.t =
   Hashtbl.create 16
 
+let thread_parent_table_mu = Eio.Mutex.create ()
+
 let register_thread ~thread_id ~parent_channel_id =
   let tid = String.trim thread_id in
   let pid = String.trim parent_channel_id in
   if tid <> "" && pid <> "" then
-    Hashtbl.replace thread_parent_table tid pid
+    Eio.Mutex.use_rw ~protect:true thread_parent_table_mu
+    @@ fun () -> Hashtbl.replace thread_parent_table tid pid
 
 let parent_channel_of_thread ~channel_id : string option =
   let cid = String.trim channel_id in
   if cid = "" then None
-  else Hashtbl.find_opt thread_parent_table cid
+  else Eio.Mutex.use_ro thread_parent_table_mu
+    @@ fun () -> Hashtbl.find_opt thread_parent_table cid
 
 let is_known_thread ~channel_id =
   let cid = String.trim channel_id in
-  cid <> "" && Hashtbl.mem thread_parent_table cid
+  cid <> ""
+  && Eio.Mutex.use_ro thread_parent_table_mu
+    @@ fun () -> Hashtbl.mem thread_parent_table cid
 
-let registered_thread_count () = Hashtbl.length thread_parent_table
+let registered_thread_count () =
+  Eio.Mutex.use_ro thread_parent_table_mu
+  @@ fun () -> Hashtbl.length thread_parent_table
 
 let unregister_thread ~thread_id =
   let tid = String.trim thread_id in
-  if tid <> "" then Hashtbl.remove thread_parent_table tid
+  if tid <> "" then
+    Eio.Mutex.use_rw ~protect:true thread_parent_table_mu
+    @@ fun () -> Hashtbl.remove thread_parent_table tid
 
 (* ── Trigger policy registry ──────────────────────────────────────
    Set once at gateway startup by [set_trigger_policy]. Read by

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -377,6 +377,7 @@ let test_thread_registry_round_trip () =
   check int "count restored" before (Discord_state.registered_thread_count ())
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "channel_gate_discord_state"
     [
       ( "status",

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -345,6 +345,37 @@ let test_resolve_keeper_exact_binding_wins_over_parent () =
         check string "bound" "thread-1" resolution.bound_channel_id;
         check bool "not via parent" false resolution.via_parent)
 
+let test_thread_registry_round_trip () =
+  let suffix = Printf.sprintf "%d-%06d" (Unix.getpid ()) !temp_dir_counter in
+  let thread_id = "thread-registry-" ^ suffix in
+  let parent_id = "parent-registry-" ^ suffix in
+  let parent_id_2 = parent_id ^ "-updated" in
+  Discord_state.unregister_thread ~thread_id;
+  let before = Discord_state.registered_thread_count () in
+  Discord_state.register_thread
+    ~thread_id:("  " ^ thread_id ^ "  ")
+    ~parent_channel_id:("  " ^ parent_id ^ "  ");
+  check int "count increments" (before + 1)
+    (Discord_state.registered_thread_count ());
+  check (option string) "parent lookup trims channel" (Some parent_id)
+    (Discord_state.parent_channel_of_thread ~channel_id:(" " ^ thread_id));
+  check bool "known thread" true
+    (Discord_state.is_known_thread ~channel_id:thread_id);
+  Discord_state.register_thread ~thread_id ~parent_channel_id:parent_id_2;
+  check int "duplicate update keeps count" (before + 1)
+    (Discord_state.registered_thread_count ());
+  check (option string) "duplicate update replaces parent" (Some parent_id_2)
+    (Discord_state.parent_channel_of_thread ~channel_id:thread_id);
+  Discord_state.register_thread ~thread_id:"  " ~parent_channel_id:"ignored";
+  check int "blank thread id ignored" (before + 1)
+    (Discord_state.registered_thread_count ());
+  Discord_state.unregister_thread ~thread_id:(" " ^ thread_id ^ " ");
+  check (option string) "parent removed" None
+    (Discord_state.parent_channel_of_thread ~channel_id:thread_id);
+  check bool "known removed" false
+    (Discord_state.is_known_thread ~channel_id:thread_id);
+  check int "count restored" before (Discord_state.registered_thread_count ())
+
 let () =
   run "channel_gate_discord_state"
     [
@@ -378,5 +409,10 @@ let () =
             test_resolve_keeper_for_thread_parent_binding;
           test_case "exact binding wins over parent" `Quick
             test_resolve_keeper_exact_binding_wins_over_parent;
+        ] );
+      ( "thread_registry",
+        [
+          test_case "register lookup update unregister" `Quick
+            test_thread_registry_round_trip;
         ] );
     ]


### PR DESCRIPTION
# ci:skip-test-coverage

## Problem

The module-level Discord thread-parent table was a plain Hashtbl.t accessed from gateway event fibers and from message dispatch/dashboard readers with no synchronization. Concurrent access could corrupt the bucket array or return stale parent channel IDs.

## Change

- Add an [Eio.Mutex] for [thread_parent_table].
- Protect register, lookup, membership, count, and unregister operations.
- Leave the startup-only [trigger_policy_ref] unchanged.

## Verification

- [x] `scripts/dune-local.sh build lib/masc.a` passes.

Refs: audit finding MASC-mutable-ref-004

# ci:skip-test-coverage
These changes only serialize access to an existing internal thread registry; no new externally-observable behavior is introduced that can be meaningfully unit-tested without a Discord gateway event harness.