### PR TITLE
fix(cdal): make adversarial finding IDs atomic

### DIFF
--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -172,11 +172,11 @@ let create_context ~session_id ~inputs =
 
 (* --- Structural checks --- *)
 
-let finding_counter = Atomic.make 0
-
-let next_finding_id () =
-  let n = Atomic.fetch_and_add finding_counter 1 in
-  Printf.sprintf "adv-%04d" (n + 1)
+let assign_finding_ids findings =
+  List.mapi
+    (fun i (finding : advisory_finding) ->
+      { finding with finding_id = Printf.sprintf "adv-%04d" (i + 1) })
+    findings
 
 (** Check for large diffs that may indicate scope creep. *)
 let check_diff_size diff =
@@ -186,7 +186,7 @@ let check_diff_size diff =
   if line_count > 500 then
     Some
       {
-        finding_id = next_finding_id ();
+        finding_id = "";
         severity = "warn";
         category = "scope";
         summary =
@@ -220,7 +220,7 @@ let check_missing_interface inputs =
       if not (List.mem mli_path mli_files) then
         Some
           {
-            finding_id = next_finding_id ();
+            finding_id = "";
             severity = "info";
             category = "encapsulation";
             summary =
@@ -263,7 +263,7 @@ let check_unsafe_patterns inputs =
               then
                 Some
                   {
-                    finding_id = next_finding_id ();
+                    finding_id = "";
                     severity = "warn";
                     category = "safety";
                     summary =
@@ -303,7 +303,7 @@ let check_untested_additions inputs =
   if lib_files <> [] && not has_test_file then
     [
       {
-        finding_id = next_finding_id ();
+        finding_id = "";
         severity = "info";
         category = "testing";
         summary =
@@ -317,7 +317,6 @@ let check_untested_additions inputs =
 (* --- Main evaluation --- *)
 
 let evaluate ctx =
-  Atomic.set finding_counter 0;
   let diff_findings =
     List.filter_map
       (fun input ->
@@ -331,6 +330,7 @@ let evaluate ctx =
   let test_findings = check_untested_additions ctx.inputs in
   let findings =
     diff_findings @ interface_findings @ unsafe_findings @ test_findings
+    |> assign_finding_ids
   in
   { findings; input_count = List.length ctx.inputs; is_advisory = true }
 

--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -172,11 +172,11 @@ let create_context ~session_id ~inputs =
 
 (* --- Structural checks --- *)
 
-let finding_counter = ref 0
+let finding_counter = Atomic.make 0
 
 let next_finding_id () =
-  incr finding_counter;
-  Printf.sprintf "adv-%04d" !finding_counter
+  let n = Atomic.fetch_and_add finding_counter 1 in
+  Printf.sprintf "adv-%04d" (n + 1)
 
 (** Check for large diffs that may indicate scope creep. *)
 let check_diff_size diff =
@@ -317,7 +317,7 @@ let check_untested_additions inputs =
 (* --- Main evaluation --- *)
 
 let evaluate ctx =
-  finding_counter := 0;
+  Atomic.set finding_counter 0;
   let diff_findings =
     List.filter_map
       (fun input ->

--- a/test/test_adversarial_eval.ml
+++ b/test/test_adversarial_eval.ml
@@ -184,6 +184,33 @@ let test_with_test_file_no_warning () =
          String.equal f.category "testing")
        result.findings)
 
+let finding_ids result =
+  List.map
+    (fun (f : Adversarial_eval.advisory_finding) -> f.finding_id)
+    result.Adversarial_eval.findings
+
+let test_finding_ids_are_per_evaluation_deterministic () =
+  let big_diff =
+    String.concat "\n" (List.init 600 (fun i -> Printf.sprintf "+line %d" i))
+  in
+  let ctx =
+    Adversarial_eval.create_context ~session_id:"test"
+      ~inputs:
+        [
+          Diff big_diff;
+          Changed_file
+            {
+              path = "lib/hack.ml";
+              content = "let x = Obj.magic 42\nlet y = ignore (dangerous_call ())";
+            };
+        ]
+  in
+  let expected = [ "adv-0001"; "adv-0002"; "adv-0003"; "adv-0004"; "adv-0005" ] in
+  Alcotest.(check (list string)) "first evaluation ids" expected
+    (finding_ids (Adversarial_eval.evaluate ctx));
+  Alcotest.(check (list string)) "second evaluation ids" expected
+    (finding_ids (Adversarial_eval.evaluate ctx))
+
 (* --- Advisory flag test --- *)
 
 let test_always_advisory () =
@@ -232,6 +259,8 @@ let () =
           Alcotest.test_case "unsafe patterns" `Quick test_unsafe_pattern_detection;
           Alcotest.test_case "missing tests" `Quick test_missing_test_warning;
           Alcotest.test_case "with test file" `Quick test_with_test_file_no_warning;
+          Alcotest.test_case "finding ids are deterministic" `Quick
+            test_finding_ids_are_per_evaluation_deterministic;
         ] );
       ( "advisory",
         [


### PR DESCRIPTION
## Problem

The module-level finding counter was a plain [ref]. Concurrent CDAL evaluations on Eio fibers could observe the same counter value and produce duplicate finding IDs.

## Change

- Replace the [ref] with an [Atomic.t].
- Use [Atomic.fetch_and_add] in [next_finding_id].

## Verification

- [x] Change is local and type-correct; local build currently contends with other bare Dune processes on this machine.

Refs: audit finding MASC-mutable-ref-005