### PR TITLE
fix(keeper): tutor bad tool calls

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -511,7 +511,7 @@ let public_descriptors =
   ; descriptor_with_public_aliases
       ~id:"agent.search_files"
       ~public_name:"Grep"
-      ~public_aliases:[ "Search" ]
+      ~public_aliases:[ "Search"; "search_files" ]
       ~internal_name:"tool_search_files"
       ~description:
         "Search file contents with ripgrep: provide a regex `pattern` (and \

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -276,6 +276,131 @@ let make_executed_tool_result ?outcome raw_output =
   { raw_output; outcome; payload_shape }
 ;;
 
+let args_has_any_field fields args =
+  match args with
+  | `Assoc args_fields ->
+    List.exists
+      (fun wanted -> List.exists (fun (key, _) -> String.equal key wanted) args_fields)
+      fields
+  | _ -> false
+;;
+
+let tool_tutor_json ~kind ~requested_tool ~message ~alternatives =
+  `Assoc
+    [ "kind", `String kind
+    ; "requested_tool", `String requested_tool
+    ; "message", `String message
+    ; "alternatives", `List alternatives
+    ]
+;;
+
+let grep_alternative =
+  `Assoc
+    [ "tool", `String "Grep"
+    ; "when", `String "search file contents with a ripgrep regex"
+    ; "required", `List [ `String "pattern" ]
+    ; "optional", `List [ `String "path"; `String "glob"; `String "type" ]
+    ]
+;;
+
+let execute_find_alternative =
+  `Assoc
+    [ "tool", `String "Execute"
+    ; "when", `String "list files or expand globs"
+    ; ( "example"
+      , `Assoc
+          [ "executable", `String "find"
+          ; "argv", `List [ `String "."; `String "-name"; `String "*.ml" ]
+          ] )
+    ]
+;;
+
+let read_alternative =
+  `Assoc
+    [ "tool", `String "Read"
+    ; "when", `String "read one whole file or a byte-limited prefix"
+    ; "required", `List [ `String "file_path" ]
+    ; "optional", `List [ `String "cwd"; `String "limit" ]
+    ]
+;;
+
+let tool_tutor_for_unknown_name requested_tool =
+  match String.lowercase_ascii (String.trim requested_tool) with
+  | "glob" ->
+    Some
+      (tool_tutor_json
+         ~kind:"unknown_tool"
+         ~requested_tool
+         ~message:
+           "Glob is not an active MASC keeper tool. Use Grep only for content \
+            search; use Execute with find/ls for file listing."
+         ~alternatives:[ grep_alternative; execute_find_alternative ])
+  | "searchfiles" | "search_files" ->
+    Some
+      (tool_tutor_json
+         ~kind:"tool_name_alias"
+         ~requested_tool
+         ~message:
+           "Use Grep or search_files with the public search-files schema: \
+            provide pattern, not query."
+         ~alternatives:[ grep_alternative ])
+  | "readfile" | "read_file" ->
+    Some
+      (tool_tutor_json
+         ~kind:"tool_name_alias"
+         ~requested_tool
+         ~message:"Use Read with file_path; Read has no start_line or offset."
+         ~alternatives:[ read_alternative ])
+  | _ -> None
+;;
+
+let tool_tutor_for_validation ~tool_name ~input =
+  match
+    Keeper_tool_descriptor_resolution.canonical_internal_name_for_tool_name tool_name
+  with
+  | Some "tool_read_file"
+    when args_has_any_field
+           [ "offset"; "start_line"; "end_line"; "line"; "line_start"; "line_end" ]
+           input ->
+    Some
+      (tool_tutor_json
+         ~kind:"invalid_arguments"
+         ~requested_tool:tool_name
+         ~message:
+           "Read does not support line offsets. Use file_path plus optional cwd/limit; \
+            use Grep or Execute for locating a smaller target first."
+         ~alternatives:[ read_alternative; grep_alternative; execute_find_alternative ])
+  | Some "tool_search_files" when args_has_any_field [ "query" ] input ->
+    Some
+      (tool_tutor_json
+         ~kind:"invalid_arguments"
+         ~requested_tool:tool_name
+         ~message:
+           "Grep/search_files requires pattern. Rename query to pattern for \
+            content search."
+         ~alternatives:[ grep_alternative ])
+  | Some _ | None -> None
+;;
+
+let append_assoc_fields json extra_fields =
+  match json with
+  | `Assoc fields -> `Assoc (fields @ extra_fields)
+  | other -> `Assoc (("payload", other) :: extra_fields)
+;;
+
+let add_tool_tutor_to_payload raw_payload tutor =
+  let json =
+    match
+      Safe_ops.parse_json_safe
+        ~context:"Keeper_tool_dispatch_runtime.add_tool_tutor_to_payload"
+        raw_payload
+    with
+    | Ok json -> json
+    | Error _ -> `String raw_payload
+  in
+  Yojson.Safe.to_string (append_assoc_fields json [ "tool_tutor", tutor ])
+;;
+
 (* Workspace tools dispatch through [Keeper_tool_runtime.handle_internal].
    Outcome is inferred from raw JSON via [classify_tool_result_payload]. *)
 
@@ -382,13 +507,18 @@ let execute_keeper_tool_call_with_outcome
          ();
        make_executed_tool_result
          (Yojson.Safe.to_string
-            (`Assoc
-                [ "ok", `Bool false
-                ; "error", `String "tool_not_allowed"
-                ; "tool", `String name
-                ; "reason", `String reason
-                ; "hint", `String hint
-                ])))
+            (let fields =
+               [ "ok", `Bool false
+               ; "error", `String "tool_not_allowed"
+               ; "failure_class", `String "policy_rejection"
+               ; "tool", `String name
+               ; "reason", `String reason
+               ; "hint", `String hint
+               ]
+             in
+             match tool_tutor_for_unknown_name name with
+             | Some tutor -> `Assoc (fields @ [ "tool_tutor", tutor ])
+             | None -> `Assoc fields)))
      else (
        let effective_search_fn =
          match search_fn with
@@ -425,7 +555,13 @@ let execute_keeper_tool_call_with_outcome
              ~descriptor
              ~args:translated_args
          | Some (Error validation_result) ->
-           Some (Yojson.Safe.to_string (Tool_result.data validation_result))
+           let raw_payload = Yojson.Safe.to_string (Tool_result.data validation_result) in
+           let raw_payload =
+             match tool_tutor_for_validation ~tool_name:name ~input:args with
+             | Some tutor -> add_tool_tutor_to_payload raw_payload tutor
+             | None -> raw_payload
+           in
+           Some raw_payload
          | None -> Keeper_tool_runtime.handle_internal keeper_tool_runtime_context ~name ~args
        in
        match descriptor_output with
@@ -494,9 +630,7 @@ let execute_keeper_tool_call_with_outcome
                   ]
               | None -> `String name
             in
-            let fields =
-              [ "error", `String "unknown_tool"; "tool", `String unknown_name ]
-              @
+            let suggestion_fields =
               match suggestion with
               | [] ->
                 [ "hint", `String "Use keeper_tool_search to find available tools." ]
@@ -504,6 +638,20 @@ let execute_keeper_tool_call_with_outcome
                 [ "did_you_mean", `List (List.map enrich_suggestion names)
                 ; "hint", `String "Call one of these tools with the correct parameters."
                 ]
+            in
+            let tutor_fields =
+              match tool_tutor_for_unknown_name unknown_name with
+              | Some tutor -> [ "tool_tutor", tutor ]
+              | None -> []
+            in
+            let fields =
+              [ "ok", `Bool false
+              ; "error", `String "unknown_tool"
+              ; "failure_class", `String "policy_rejection"
+              ; "tool", `String unknown_name
+              ]
+              @ suggestion_fields
+              @ tutor_fields
             in
             make_executed_tool_result (Yojson.Safe.to_string (`Assoc fields))))
       )

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -81,6 +81,104 @@ let result_to_response ~tool_name ~start_time = function
       workflow_err_plain ~tool_name ~start_time
         (Masc_domain.masc_error_to_string e)
 
+let dedupe_keep_order values =
+  let seen = Hashtbl.create (List.length values) in
+  List.filter
+    (fun value ->
+      if String.equal value "" || Hashtbl.mem seen value
+      then false
+      else (
+        Hashtbl.replace seen value ();
+        true))
+    values
+
+let find_first_some f values =
+  let rec loop = function
+    | [] -> None
+    | value :: rest -> (
+        match f value with
+        | Some _ as result -> result
+        | None -> loop rest)
+  in
+  loop values
+
+let parse_wrapped_agent_name ~prefix ~suffix raw =
+  let plen = String.length prefix in
+  let slen = String.length suffix in
+  let len = String.length raw in
+  if len > plen + slen
+     && String.equal (String.sub raw 0 plen) prefix
+     && String.equal (String.sub raw (len - slen) slen) suffix
+  then Some (String.sub raw plen (len - plen - slen))
+  else None
+
+let wrapped_agent_name_candidate raw =
+  [ parse_wrapped_agent_name ~prefix:"keeper-" ~suffix:"-agent" raw
+  ; parse_wrapped_agent_name ~prefix:"keeper_" ~suffix:"_agent" raw
+  ; parse_wrapped_agent_name ~prefix:"keeper-" ~suffix:"_agent" raw
+  ; parse_wrapped_agent_name ~prefix:"keeper_" ~suffix:"-agent" raw
+  ]
+  |> find_first_some (fun candidate -> candidate)
+
+let strip_keeper_prefix raw =
+  let prefix = "keeper-" in
+  let plen = String.length prefix in
+  let len = String.length raw in
+  if len > plen && String.equal (String.sub raw 0 plen) prefix
+  then Some (String.sub raw plen (len - plen))
+  else None
+
+let canonical_keeper_agent_name name = Printf.sprintf "keeper-%s-agent" name
+
+let agent_name_lookup_candidates raw =
+  let trimmed = String.trim raw in
+  let canonical =
+    match wrapped_agent_name_candidate trimmed with
+    | Some value -> Some value
+    | None -> strip_keeper_prefix trimmed
+  in
+  let agent_alias =
+    match canonical with
+    | Some value -> Some (canonical_keeper_agent_name value)
+    | None ->
+      if String.equal trimmed "" then None else Some (canonical_keeper_agent_name trimmed)
+  in
+  dedupe_keep_order ([ trimmed ] @ Option.to_list canonical @ Option.to_list agent_alias)
+
+let metrics_json_with_resolution ~requested ~resolved json =
+  match json with
+  | `Assoc fields when not (String.equal requested resolved) ->
+      `Assoc
+        (fields
+         @ [ "requested_agent_name", `String requested
+           ; "resolved_agent_name", `String resolved
+           ])
+  | _ -> json
+
+let resolve_metrics_for_agent ctx ~requested ~days =
+  requested
+  |> agent_name_lookup_candidates
+  |> find_first_some (fun candidate ->
+    match Metrics_store_eio.calculate_agent_metrics ctx.config ~agent_id:candidate ~days with
+    | Some metrics -> Some (candidate, metrics)
+    | None -> None)
+
+let resolve_existing_metric_agent_id ctx ~requested ~days =
+  match resolve_metrics_for_agent ctx ~requested ~days with
+  | Some (resolved, _) -> resolved
+  | None -> (
+      match agent_name_lookup_candidates requested with
+      | first :: _ -> first
+      | [] -> String.trim requested)
+
+let find_agent_by_identity agents raw =
+  raw
+  |> agent_name_lookup_candidates
+  |> find_first_some (fun candidate ->
+    List.find_opt
+      (fun (agent : Masc_domain.agent) -> String.equal agent.name candidate)
+      agents)
+
 (* Issue #8501: Variant SSOT for masc_agent_card.action.  Adding a
    new constructor forces compilation in [agent_card_action_to_string]
    AND extends [valid_agent_card_action_strings]; the schema in
@@ -128,10 +226,11 @@ let handle_get_metrics ?(tool_name = "masc_get_metrics") ?(start_time = 0.0) ctx
       "agent_name is required"
   else
     let days = get_int args "days" 7 in
-    match Metrics_store_eio.calculate_agent_metrics ctx.config ~agent_id:target ~days with
-    | Some metrics ->
+    match resolve_metrics_for_agent ctx ~requested:target ~days with
+    | Some (resolved, metrics) ->
         json_ok ~tool_name ~start_time
-          (Metrics_store_eio.agent_metrics_to_yojson metrics)
+          (Metrics_store_eio.agent_metrics_to_yojson metrics
+           |> metrics_json_with_resolution ~requested:target ~resolved)
     | None ->
         workflow_err_envelope ~tool_name ~start_time ~code:Not_found
           (Printf.sprintf "no metrics found for agent: %s" target)
@@ -255,7 +354,7 @@ let handle_agent_fitness ?(tool_name = "masc_agent_fitness") ?(start_time = 0.0)
   let days = get_int args "days" 7 in
   let agents =
     match agent_opt with
-    | Some a -> [a]
+    | Some a -> [ resolve_existing_metric_agent_id ctx ~requested:a ~days ]
     | None ->
       (* Merge agents from metrics store AND workspace state.
          Without this, agents active on the board but without task metrics
@@ -326,12 +425,7 @@ let handle_agent_card ?(tool_name = "masc_agent_card") ?(start_time = 0.0) ctx a
   | Some action ->
       let agents = Workspace.get_agents_raw ctx.config in
       let target = get_string_opt args "agent_name" in
-      let target_agent =
-        Option.bind target (fun name ->
-          List.find_opt
-            (fun (agent : Masc_domain.agent) -> String.equal agent.name name)
-            agents)
-      in
+      let target_agent = Option.bind target (find_agent_by_identity agents) in
       let json =
         `Assoc [
           ("schema", `String "masc.agent_card.v1");

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -271,10 +271,43 @@ let test_public_read_rejects_unsupported_range_fields () =
         Yojson.Safe.Util.(member "validation" json |> to_string);
       check string "failure class" "policy_rejection"
         Yojson.Safe.Util.(member "failure_class" json |> to_string);
+      let tutor = Yojson.Safe.Util.member "tool_tutor" json in
+      check string "tutor kind" "invalid_arguments"
+        Yojson.Safe.Util.(member "kind" tutor |> to_string);
+      check bool "tutor explains line offsets" true
+        (contains_substring
+           Yojson.Safe.Util.(member "message" tutor |> to_string)
+           "line offsets");
       check bool "did not reach file runtime" false
         (match Yojson.Safe.Util.member "path_resolution" json with
          | `Assoc _ -> true
          | _ -> false))
+
+let test_public_read_rejects_offset_with_tutor () =
+  with_exec_fixture
+    "keeper_tool_dispatch_runtime_read_rejects_offset"
+    (fun ~config ~meta ~ctx_work ->
+      let result =
+        KET.execute_keeper_tool_call_with_outcome
+          ~config
+          ~meta
+          ~ctx_work
+          ~exec_cache:None
+          ~name:"Read"
+          ~input:
+            (`Assoc
+               [ "file_path", `String "lib/keeper/keeper_transition_audit.ml"
+               ; "offset", `Int 100
+               ])
+          ()
+      in
+      check string "runtime outcome" "failure" (outcome_label result.outcome);
+      let json = Yojson.Safe.from_string result.raw_output in
+      let tutor = Yojson.Safe.Util.member "tool_tutor" json in
+      check string "tutor requested tool" "Read"
+        Yojson.Safe.Util.(member "requested_tool" tutor |> to_string);
+      check bool "tutor names Grep alternative" true
+        (contains_substring result.raw_output {|"tool":"Grep"|}))
 
 let counter_for_tool_not_allowed ~keeper ~tool ~reason =
   Masc.Otel_metric_store.metric_value_or_zero
@@ -552,6 +585,19 @@ let test_public_local_aliases_dispatch_to_runtime_handlers () =
         (contains_substring search_result.raw_output "public-alias.txt");
       check bool "Search match includes content" true
         (contains_substring search_result.raw_output "gamma");
+      let search_files_result =
+        run
+          "search_files"
+          (`Assoc
+             [ "pattern", `String "gamma"; "path", `String visible_file_path ])
+      in
+      let search_files_json =
+        check_success_result "search_files" search_files_result
+      in
+      check string "search_files translates to rg op" "rg"
+        (json_string_field ~default:"" "op" search_files_json);
+      check bool "search_files returns real match" true
+        (contains_substring search_files_result.raw_output "public-alias.txt");
       let execute_result =
         run
           "Execute"
@@ -644,6 +690,35 @@ let test_keeper_task_force_release_noop_is_no_progress () =
         Yojson.Safe.Util.(member "kind" typed |> to_string);
       check string "no-progress reason" "No_work_available"
         Yojson.Safe.Util.(member "reason" typed |> member "kind" |> to_string))
+
+let test_glob_unknown_tool_returns_tutor_guidance () =
+  with_exec_fixture "keeper_tool_dispatch_runtime_glob_tutor"
+    (fun ~config ~meta ~ctx_work ->
+      let result =
+        KET.execute_keeper_tool_call_with_outcome
+          ~config
+          ~meta
+          ~ctx_work
+          ~exec_cache:None
+          ~name:"Glob"
+          ~input:(`Assoc [ "pattern", `String "*.ml" ])
+          ()
+      in
+      check string "runtime outcome" "failure" (outcome_label result.outcome);
+      check string "payload shape" "structured_error"
+        (payload_kind result.payload_shape);
+      let json = Yojson.Safe.from_string result.raw_output in
+      check string "policy rejection" "policy_rejection"
+        Yojson.Safe.Util.(member "failure_class" json |> to_string);
+      let tutor = Yojson.Safe.Util.member "tool_tutor" json in
+      check string "tutor kind" "unknown_tool"
+        Yojson.Safe.Util.(member "kind" tutor |> to_string);
+      check bool "tutor says Glob is not active" true
+        (contains_substring
+           Yojson.Safe.Util.(member "message" tutor |> to_string)
+           "Glob is not an active MASC keeper tool");
+      check bool "tutor names Execute alternative" true
+        (contains_substring result.raw_output {|"tool":"Execute"|}))
 
 let test_public_masc_web_search_alias_dispatches_to_misc_runtime () =
   with_exec_fixture "keeper_tool_dispatch_web_search_alias"
@@ -1094,6 +1169,8 @@ let () =
         test_registered_descriptor_bypasses_tool_access_allowlist;
       test_case "public Read rejects unsupported range fields" `Quick
         test_public_read_rejects_unsupported_range_fields;
+      test_case "public Read rejects offset with tutor guidance" `Quick
+        test_public_read_rejects_offset_with_tutor;
       test_case "missing file is failure" `Quick
         test_execute_with_outcome_missing_file_is_failure;
       test_case "bad query is failure" `Quick
@@ -1104,6 +1181,8 @@ let () =
         test_keeper_task_claim_accepts_specific_task_id;
       test_case "keeper_task_force_release todo no-op is no progress" `Quick
         test_keeper_task_force_release_noop_is_no_progress;
+      test_case "Glob returns tutor guidance instead of aliasing to rg" `Quick
+        test_glob_unknown_tool_returns_tutor_guidance;
       test_case "public WebSearch alias reaches misc runtime" `Quick
         test_public_masc_web_search_alias_dispatches_to_misc_runtime;
       test_case "public WebFetch alias reaches misc runtime" `Quick

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -9,6 +9,7 @@ module Tool_result = Tool_result
 module Meta_cognition = Masc.Meta_cognition
 
 module Tool_agent = Masc.Tool_agent
+module Metrics_store_eio = Masc.Metrics_store_eio
 module Workspace = Masc.Workspace
 
 let test_counter = ref 0
@@ -209,6 +210,38 @@ let test_get_metrics_missing_agent_name () =
     (json |> member "status" |> to_string);
   Alcotest.(check string) "message" "agent_name is required"
     (json |> member "message" |> to_string);
+  )
+
+let record_completed_metric config ~agent_id ~task_id =
+  let metric = Metrics_store_eio.create_metric ~agent_id ~task_id () in
+  let completed = Metrics_store_eio.complete_metric metric ~success:true () in
+  Metrics_store_eio.record config completed;
+  Metrics_store_eio.flush_pending ()
+
+let test_get_metrics_resolves_keeper_agent_alias () =
+  with_ctx (fun ctx ->
+  record_completed_metric ctx.config
+    ~agent_id:"nick0cave"
+    ~task_id:"task-alias-metric";
+  let args =
+    `Assoc
+      [ ("agent_name", `String "keeper-nick0cave-agent")
+      ; ("days", `Int 7)
+      ]
+  in
+  let result = dispatch_exn ctx ~name:"masc_get_metrics" ~args in
+  Alcotest.(check bool) "alias metrics succeeds" true
+    (Tool_result.is_success result);
+  let open Yojson.Safe.Util in
+  let json = Yojson.Safe.from_string (Tool_result.message result) in
+  Alcotest.(check string) "resolved agent id" "nick0cave"
+    (json |> member "agent_id" |> to_string);
+  Alcotest.(check string) "requested agent name" "keeper-nick0cave-agent"
+    (json |> member "requested_agent_name" |> to_string);
+  Alcotest.(check string) "resolved agent name" "nick0cave"
+    (json |> member "resolved_agent_name" |> to_string);
+  Alcotest.(check int) "total tasks" 1
+    (json |> member "total_tasks" |> to_int);
   )
 
 (* ============================================================
@@ -422,6 +455,8 @@ let () =
     ("get_metrics", [
       Alcotest.test_case "no data returns not_found" `Quick test_get_metrics_no_data;
       Alcotest.test_case "missing agent_name fails" `Quick test_get_metrics_missing_agent_name;
+      Alcotest.test_case "keeper agent alias resolves metric key" `Quick
+        test_get_metrics_resolves_keeper_agent_alias;
     ]);
     ("meta_cognition_snapshot", [
       Alcotest.test_case "detects beliefs tensions desires and edges" `Quick


### PR DESCRIPTION
## Summary
- add descriptor-owned `search_files` public alias so it uses the Grep schema/translation path
- return structured `tool_tutor` guidance for bad Keeper tool calls such as `Glob`, Read line offsets, and `query` vs `pattern` search mistakes
- resolve keeper agent aliases like `keeper-nick0cave-agent` when reading metrics, fitness, and agent cards without adding Tool -> Keeper module dependencies

## Verification
- `git diff --check`
- `ocamlformat --check lib/tool_agent.ml lib/keeper/keeper_tool_dispatch_runtime.ml test/test_keeper_tool_dispatch_runtime.ml test/test_tool_agent_coverage.ml`
- `bash scripts/lint/tool-keeper-boundary-ratchet.sh --fail`
- Passed before clean-branch recreation on the same patch: `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_tool_dispatch_runtime.exe test/test_tool_agent_coverage.exe test/test_keeper_tool_resolution.exe`
- Passed before clean-branch recreation on the same patch: `./_build/default/test/test_keeper_tool_dispatch_runtime.exe`
- Passed before clean-branch recreation on the same patch: `./_build/default/test/test_tool_agent_coverage.exe`
- Final clean-branch focused rebuilds were blocked by multiple unrelated concurrent local Dune builds; CI is authoritative for the pushed branch.
