### PR TITLE
fix(keeper): surface crashed heartbeat cycle as turn failure

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -120,6 +120,55 @@ let provider_timeout_metric_outcome =
 (** Run keeper cycle with holder diagnostics. *)
 let run_keeper_cycle = Keeper_heartbeat_loop_cycle.run_keeper_cycle
 
+(* T6 audit: outcome of one keepalive cycle evaluation.
+
+   [cycle_crashed = true] means the catch-all in
+   [run_keepalive_unified_turn] swallowed an exception to keep the
+   keeper fiber alive. The failure has already been recorded via
+   [Keeper_registry.increment_turn_failures] (the same counter the
+   unified-turn failure path in [Keeper_unified_turn_failure] uses),
+   so the caller reads a non-zero [turn_fail_count] and dispatches
+   [Turn_failed] instead of [Turn_succeeded]. A crashed cycle must
+   also NOT refresh the work-as-heartbeat lease. *)
+type keepalive_turn_outcome = {
+  meta : keeper_meta;
+  cycle_crashed : bool;
+}
+
+(* T6 audit: record a swallowed cycle exception as a turn failure.
+
+   Catch-and-survive is intentional (the fiber must outlive the
+   crash); the bug being fixed is that the crash was invisible to the
+   scheduling/escalation layer. Incrementing the registry counter
+   routes the crash through the same channel other turn failures use:
+   the caller loop dispatches [Turn_failed] and raises
+   [Keeper_fiber_crash] at the same threshold, and
+   [Keeper_unified_turn_failure.record_failure_and_maybe_escalate]
+   reads the same counter for its escalation decision. *)
+let record_crashed_cycle_failure ~base_path ~keeper_name exn =
+  (* Capture the backtrace before any other call can clobber it. *)
+  let backtrace = Printexc.get_backtrace () in
+  Keeper_registry.increment_turn_failures ~base_path keeper_name;
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string CycleExceptions)
+    ~labels:[ "keeper", keeper_name ]
+    ();
+  Log.Keeper.error
+    "%s: keeper cycle exception (recorded as turn failure): %s%s"
+    keeper_name
+    (Printexc.to_string exn)
+    (if String.equal backtrace "" then "" else "\n" ^ backtrace)
+;;
+
+(* Pure: post-turn status event derived from the registry turn-failure
+   counter. Extracted from the loop body so the crashed-cycle ->
+   [Turn_failed] mapping is unit-testable. *)
+let turn_status_event ~turn_fail_count ~max_allowed : Keeper_state_machine.event =
+  if turn_fail_count > 0
+  then Keeper_state_machine.Turn_failed { consecutive = turn_fail_count; max_allowed }
+  else Keeper_state_machine.Turn_succeeded
+;;
+
 let run_keepalive_unified_turn
       ~(ctx : _ context)
       ~(meta_after_triage : keeper_meta)
@@ -128,10 +177,10 @@ let run_keepalive_unified_turn
       ~(proactive_warmup_elapsed : bool)
       ~(reactive_wake : bool)
       ~(shared_context : Agent_sdk.Context.t)
-  : keeper_meta
+  : keepalive_turn_outcome
   =
   if not proactive_warmup_elapsed
-  then meta_after_triage
+  then { meta = meta_after_triage; cycle_crashed = false }
   else (
     try
       let event_intake =
@@ -294,71 +343,71 @@ let run_keepalive_unified_turn
         Keeper_decision_audit.flush_if_needed
           ~base_path:ctx.config.base_path
           ~keeper_name:meta_after_triage.name);
-      if Atomic.get stop
-      then meta_after_triage
-      else if should_run_turn && Keeper_fd_pressure.active ()
-      then (
-        Log.Keeper.debug
-          "%s: skipping turn while fd-pressure circuit breaker is active (remaining=%.0fs)"
-          meta_after_triage.name
-          (Keeper_fd_pressure.remaining_sec ());
-        meta_after_triage)
-      else if should_run_turn && Keeper_disk_pressure.active ()
-      then (
-        Log.Keeper.debug
-          "%s: skipping turn while disk-pressure circuit breaker is active \
-           (remaining=%.0fs)"
-          meta_after_triage.name
-          (Keeper_disk_pressure.remaining_sec ());
-        meta_after_triage)
-      else if
-        should_run_turn
-        && not
-             (Keeper_fd_pressure.admit_turn
-                ~active_keepers:(Keeper_registry.count_running ())
-                ())
-      then (
-        Log.Keeper.debug
-          "%s: skipping turn because projected FD budget is exhausted before pressure"
-          meta_after_triage.name;
-        meta_after_triage)
-      else if
-        should_run_turn
-        && not
-             (Keeper_disk_pressure.admit_turn
-                ~masc_root:(Workspace.masc_root_dir ctx.config)
-                ())
-      then (
-        Log.Keeper.debug
-          "%s: skipping turn because disk free-space budget is below fleet floor"
-          meta_after_triage.name;
-        meta_after_triage)
-      else if should_run_turn
-      then (
-        run_keeper_cycle
-          ~ctx
-          ~meta_after_triage
-          ~stop
-          ~obs
-          ~turn_decision
-          ~shared_context
-          ())
-      else meta_after_triage
+      let meta_after_cycle =
+        if Atomic.get stop
+        then meta_after_triage
+        else if should_run_turn && Keeper_fd_pressure.active ()
+        then (
+          Log.Keeper.debug
+            "%s: skipping turn while fd-pressure circuit breaker is active (remaining=%.0fs)"
+            meta_after_triage.name
+            (Keeper_fd_pressure.remaining_sec ());
+          meta_after_triage)
+        else if should_run_turn && Keeper_disk_pressure.active ()
+        then (
+          Log.Keeper.debug
+            "%s: skipping turn while disk-pressure circuit breaker is active \
+             (remaining=%.0fs)"
+            meta_after_triage.name
+            (Keeper_disk_pressure.remaining_sec ());
+          meta_after_triage)
+        else if
+          should_run_turn
+          && not
+               (Keeper_fd_pressure.admit_turn
+                  ~active_keepers:(Keeper_registry.count_running ())
+                  ())
+        then (
+          Log.Keeper.debug
+            "%s: skipping turn because projected FD budget is exhausted before pressure"
+            meta_after_triage.name;
+          meta_after_triage)
+        else if
+          should_run_turn
+          && not
+               (Keeper_disk_pressure.admit_turn
+                  ~masc_root:(Workspace.masc_root_dir ctx.config)
+                  ())
+        then (
+          Log.Keeper.debug
+            "%s: skipping turn because disk free-space budget is below fleet floor"
+            meta_after_triage.name;
+          meta_after_triage)
+        else if should_run_turn
+        then (
+          run_keeper_cycle
+            ~ctx
+            ~meta_after_triage
+            ~stop
+            ~obs
+            ~turn_decision
+            ~shared_context
+            ())
+        else meta_after_triage
+      in
+      { meta = meta_after_cycle; cycle_crashed = false }
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | Keeper_registry.Keeper_fiber_crash as e -> raise e
     | exn ->
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string CycleExceptions)
-        ~labels:[ "keeper", meta_after_triage.name ]
-        ();
-      let backtrace = Printexc.get_backtrace () in
-      Log.Keeper.error
-        "%s: keeper cycle exception: %s%s"
-        meta_after_triage.name
-        (Printexc.to_string exn)
-        (if String.equal backtrace "" then "" else "\n" ^ backtrace);
-      meta_after_triage)
+      (* T6 audit: keep the fiber alive, but surface the crash as a
+         turn failure so the caller does not dispatch
+         [Turn_succeeded] for a cycle that never completed. *)
+      record_crashed_cycle_failure
+        ~base_path:ctx.config.base_path
+        ~keeper_name:meta_after_triage.name
+        exn;
+      { meta = meta_after_triage; cycle_crashed = true })
 ;;
 
 let refresh_work_as_heartbeat = Keeper_heartbeat_loop_refresh_work.refresh_work_as_heartbeat
@@ -758,7 +807,7 @@ let run_heartbeat_loop
         in
         let t_board_end = Time_compat.now () in
         let t_turn_start = t_board_end in
-        let meta_after_proactive =
+        let turn_outcome =
           (* Cycle 43: KeeperHeartbeat.tla TurnComplete bracket — the
              [turn_running] flag toggles around the dispatch and the
              pre/post guards mirror the spec's [turn_state] transition
@@ -788,26 +837,21 @@ let run_heartbeat_loop
           Keeper_keepalive_signal.post_turn_complete_heartbeat ~turn_running;
           r
         in
-        (* Turn failure threshold: registry tracks count (via unified_turn),
-                 keepalive raises to terminate the fiber for supervisor restart. *)
+        let meta_after_proactive = turn_outcome.meta in
+        (* Turn failure threshold: registry tracks count (via unified_turn,
+                 and via [record_crashed_cycle_failure] for swallowed cycle
+                 exceptions), keepalive raises to terminate the fiber for
+                 supervisor restart. *)
         let turn_fail_count =
           Keeper_registry.get_turn_failures ~base_path:ctx.config.base_path m.name
         in
         (* RFC-0002: dispatch turn status event *)
-        if turn_fail_count > 0
-        then
-          Keeper_keepalive_signal.dispatch_keepalive_event
-            ~ctx
-            ~keeper_name:m.name
-            (Keeper_state_machine.Turn_failed
-               { consecutive = turn_fail_count
-               ; max_allowed = Keeper_heartbeat_snapshot.max_consecutive_turn_failures ()
-               })
-        else
-          Keeper_keepalive_signal.dispatch_keepalive_event
-            ~ctx
-            ~keeper_name:m.name
-            Keeper_state_machine.Turn_succeeded;
+        Keeper_keepalive_signal.dispatch_keepalive_event
+          ~ctx
+          ~keeper_name:m.name
+          (turn_status_event
+             ~turn_fail_count
+             ~max_allowed:(Keeper_heartbeat_snapshot.max_consecutive_turn_failures ()));
         if turn_fail_count >= Keeper_heartbeat_snapshot.max_consecutive_turn_failures ()
         then (
           Keeper_registry.set_failure_reason
@@ -818,14 +862,22 @@ let run_heartbeat_loop
         (* Phase 1: work-as-heartbeat — renew point (b).
                  After turn, call Workspace.heartbeat to prove workspace I/O health.
                  On success: refresh freshness lease + reset consecutive_failures.
-                 On failure: leave timestamp unchanged → presence sync resumes next cycle. *)
-        refresh_work_as_heartbeat
-          ~ctx
-          ~meta_after_proactive
-          ~proactive_warmup_elapsed
-          ~work_as_hb
-          ~last_successful_heartbeat_ts
-          ~consecutive_failures;
+                 On failure: leave timestamp unchanged → presence sync resumes next cycle.
+                 T6 audit: a crashed cycle proves nothing about health — do not
+                 refresh the lease or reset consecutive_failures for it. *)
+        if turn_outcome.cycle_crashed
+        then
+          Log.Keeper.info
+            "%s: skipping work-as-heartbeat refresh after crashed keepalive cycle"
+            m.name
+        else
+          refresh_work_as_heartbeat
+            ~ctx
+            ~meta_after_proactive
+            ~proactive_warmup_elapsed
+            ~work_as_hb
+            ~last_successful_heartbeat_ts
+            ~consecutive_failures;
         let t_turn_end = Time_compat.now () in
         let t_recurring_start = t_turn_end in
         (* Recurring task dispatch (#3190) *)

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -88,6 +88,33 @@ val provider_timeout_policy_decision :
     This heartbeat-loop path is reached after the keeper turn returned, so
     timeout evidence is not liveness loss by itself. *)
 
+(** Outcome of one keepalive cycle evaluation.
+
+    [cycle_crashed = true] means the cycle's catch-all swallowed an
+    exception to keep the keeper fiber alive (T6 audit). The failure
+    has already been recorded via
+    [Keeper_registry.increment_turn_failures] — the same counter the
+    unified-turn failure path uses — so the caller dispatches
+    [Turn_failed]. A crashed cycle must not refresh the
+    work-as-heartbeat lease. *)
+type keepalive_turn_outcome = {
+  meta : keeper_meta;
+  cycle_crashed : bool;
+}
+
+(** Record a swallowed keepalive-cycle exception as a turn failure:
+    increments the registry turn-failure counter (shared with
+    [Keeper_unified_turn_failure]), bumps the CycleExceptions counter
+    and logs at ERROR. Does not raise. *)
+val record_crashed_cycle_failure :
+  base_path:string -> keeper_name:string -> exn -> unit
+
+(** Pure: post-turn status event derived from the registry
+    turn-failure counter. [turn_fail_count > 0] maps to [Turn_failed];
+    [0] maps to [Turn_succeeded]. *)
+val turn_status_event :
+  turn_fail_count:int -> max_allowed:int -> Keeper_state_machine.event
+
 val run_keepalive_unified_turn :
   ctx:'a context ->
   meta_after_triage:keeper_meta ->
@@ -96,7 +123,7 @@ val run_keepalive_unified_turn :
   proactive_warmup_elapsed:bool ->
   reactive_wake:bool ->
   shared_context:Agent_sdk.Context.t ->
-  keeper_meta
+  keepalive_turn_outcome
 
 val refresh_work_as_heartbeat :
   ctx:'a context ->

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -483,6 +483,53 @@ let test_fresh_presence_preserves_turn_failures () =
       | Some phase -> check string "heartbeat alone stays failing" "failing" (KSM.phase_to_string phase)
       | None -> fail "expected registered keeper phase")
 
+(** T6 audit: a swallowed keepalive-cycle exception must surface as a
+    turn failure. [record_crashed_cycle_failure] (called by the
+    [run_keepalive_unified_turn] catch-all) increments the same
+    registry counter the unified-turn failure path uses, and the
+    caller's post-turn event mapping ([turn_status_event]) then yields
+    [Turn_failed] — not [Turn_succeeded] — moving the state machine to
+    failing. *)
+let test_crashed_cycle_records_turn_failure () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  R.clear ();
+  let base_path = temp_dir "crashed-cycle-turn-failure" in
+  Fun.protect
+    ~finally:(fun () ->
+      R.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_path in
+      let meta = make_meta "crashed-cycle" in
+      ignore (R.register ~base_path:config.base_path meta.name meta);
+      check int "no failures before crash" 0
+        (R.get_turn_failures ~base_path:config.base_path meta.name);
+      KHL.record_crashed_cycle_failure
+        ~base_path:config.base_path
+        ~keeper_name:meta.name
+        (Failure "boom");
+      let count = R.get_turn_failures ~base_path:config.base_path meta.name in
+      check int "crash recorded as turn failure" 1 count;
+      (* Same registry read + event mapping the caller loop performs
+         after [run_keepalive_unified_turn] returns. *)
+      let event = KHL.turn_status_event ~turn_fail_count:count ~max_allowed:10 in
+      (match event with
+       | KSM.Turn_failed { consecutive; max_allowed } ->
+         check int "consecutive" 1 consecutive;
+         check int "max_allowed" 10 max_allowed
+       | _ -> fail "expected Turn_failed for crashed cycle");
+      ignore (R.dispatch_event ~base_path:config.base_path meta.name event);
+      (match R.get_phase ~base_path:config.base_path meta.name with
+       | Some phase ->
+         check string "crashed cycle moves state machine to failing" "failing"
+           (KSM.phase_to_string phase)
+       | None -> fail "expected registered keeper phase");
+      (* Clean cycle (count = 0) still maps to Turn_succeeded. *)
+      match KHL.turn_status_event ~turn_fail_count:0 ~max_allowed:10 with
+      | KSM.Turn_succeeded -> ()
+      | _ -> fail "expected Turn_succeeded when no failures recorded")
+
 (* ══════════════════════════════════════════════════════════
    8. Direct keepalive path resolves lifecycle promises
    ══════════════════════════════════════════════════════════ *)
@@ -829,6 +876,8 @@ let () =
       test_case "cohort key" `Quick test_cohort_key_turn_failures;
       test_case "fresh presence preserves turn failures" `Quick
         test_fresh_presence_preserves_turn_failures;
+      test_case "crashed cycle surfaces as turn failure" `Quick
+        test_crashed_cycle_records_turn_failure;
     ];
     "direct_keepalive", [
       test_case "stop resolves done promise" `Quick


### PR DESCRIPTION
## 문제 (audit T6)

`lib/keeper/keeper_heartbeat_loop.ml`의 `run_keepalive_unified_turn` catch-all은 `Eio.Cancel.Cancelled`와 `Keeper_registry.Keeper_fiber_crash`만 re-raise하고, 그 외 예외는 CycleExceptions OTel 카운터 증가 + ERROR 로그만 남긴 채 pre-cycle meta를 반환했습니다.

catch-and-survive 자체는 의도된 설계입니다(keeper fiber는 cycle 예외에서 살아남아야 함). 버그는 그 crash가 스케줄링/에스컬레이션 레이어에 보이지 않는다는 점입니다:

- caller loop은 `Keeper_registry.get_turn_failures`를 읽어 turn 상태 이벤트를 결정하는데, catch-all이 이 카운터를 갱신하지 않으므로 crash한 cycle에 대해 `Turn_succeeded`를 dispatch — crash를 성공으로 위장.
- `work_as_hb` 활성 시 `refresh_work_as_heartbeat`가 liveness lease를 갱신하고 `consecutive_failures`를 0으로 리셋 — crash한 cycle이 건강 증거로 카운트됨.
- 에스컬레이션 채널(`keeper_unified_turn_failure.ml:118` threshold escalation, caller loop의 `max_consecutive_turn_failures` fiber-crash 경로)이 같은 registry 카운터를 읽으므로, 반복 crash가 임계값에 도달하지 못함.

## 수정

1. **crash를 turn failure로 기록** (`record_crashed_cycle_failure`): catch-all에서 `Keeper_registry.increment_turn_failures`를 호출합니다. unified-turn failure 경로(`Keeper_unified_turn_failure.record_failure_and_maybe_escalate`)가 쓰는 것과 동일한 카운터이며, 병렬 카운터를 도입하지 않습니다. 기존 OTel CycleExceptions 카운터와 ERROR 로그는 유지. re-raise는 추가하지 않음(fiber 생존 유지). 이후 caller가 같은 카운터를 읽어 `Turn_failed`를 dispatch하고, 임계값 도달 시 기존 `Keeper_fiber_crash` 경로로 supervisor escalation이 동작합니다.
2. **crash한 cycle은 work-as-heartbeat lease를 갱신하지 않음**: `run_keepalive_unified_turn` 반환 타입을 `keepalive_turn_outcome` 레코드(`meta` + `cycle_crashed`)로 변경하고, caller는 `cycle_crashed = true`일 때 `refresh_work_as_heartbeat` 호출을 건너뜁니다(lease 갱신 없음, `consecutive_failures` 리셋 없음).
3. **post-turn 이벤트 매핑을 순수 함수로 추출** (`turn_status_event`): `turn_fail_count > 0 → Turn_failed / 0 → Turn_succeeded` 매핑을 caller loop 인라인에서 추출해 단위 테스트 가능하게 했습니다. caller는 동일 로직을 이 함수로 호출합니다.

`Eio.Cancel.Cancelled` / `Keeper_fiber_crash` re-raise 분기는 변경하지 않았습니다.

## 검증 (실행한 명령과 실제 출력 요약)

worktree에서 `DUNE_CACHE=disabled`로 실행:

- `dune build --root . @check` — 에러 0건 통과
- `dune build --root . @fmt --auto-promote` — 변경 파일 포맷 적용 (무관한 dune 파일 4건의 기존 drift promote는 revert하여 diff 범위 밖 변경 없음)
- `dune build --root .` (default target) — 에러 0건 통과
- `dune build --root . test/test_heartbeat_integration.exe && ./_build/default/test/test_heartbeat_integration.exe` — 전체 suite 통과 (신규 테스트 `crashed cycle surfaces as turn failure` 포함)

신규 테스트 (`test/test_heartbeat_integration.ml`, `turn_failure` 그룹):
- `record_crashed_cycle_failure` 호출 후 `get_turn_failures` 0 → 1 증가 확인
- caller와 동일한 registry read + `turn_status_event` 매핑이 `Turn_failed { consecutive = 1 }` 산출 확인
- 해당 이벤트를 `dispatch_event`로 state machine에 적용 시 phase가 `failing`으로 전이 확인
- `turn_fail_count = 0`이면 `Turn_succeeded` 유지 확인

한계: `run_keepalive_unified_turn` 내부에서 실제 예외를 주입하는 end-to-end 단위 경로는 없습니다(cycle 내부 호출들이 주입 지점 없이 직접 모듈 호출). catch-all → `record_crashed_cycle_failure` 연결과 caller의 `cycle_crashed` 게이트는 타입 변경(`keepalive_turn_outcome`)으로 컴파일러가 모든 반환 지점을 강제하며, 기록/매핑/전이 각 단계는 위 단위 테스트로 커버합니다.

## 근거 (file:line, 변경 전 기준)

- catch-all이 pre-cycle meta 반환: `lib/keeper/keeper_heartbeat_loop.ml:347-361`
- caller가 registry 카운터 기반으로 `Turn_succeeded` dispatch: `lib/keeper/keeper_heartbeat_loop.ml:793-810`
- crash threshold fiber-crash 경로: `lib/keeper/keeper_heartbeat_loop.ml:811-817`
- lease 갱신 + `consecutive_failures` 리셋: `lib/keeper/keeper_heartbeat_loop.ml:822-828`, `lib/keeper/keeper_heartbeat_loop_refresh_work.ml:51-54`
- 동일 카운터를 쓰는 unified-turn failure 경로: `lib/keeper/keeper_unified_turn_failure.ml:18,24,118`
- 관련 RFC: `docs/rfc/RFC-0002-keeper-state-machine.md` — caller loop의 turn 상태 이벤트 dispatch(`Turn_failed`/`Turn_succeeded`)는 RFC-0002의 state machine 이벤트 채널이며, 본 수정은 crash를 그 기존 채널에 연결합니다.

RFC-WAIVED: audit T6 verified-confirmed 단일 버그 수정 — keeper heartbeat loop의 기존 failure-accounting 경로(`Keeper_registry.increment_turn_failures`)에 crash를 연결하는 변경으로, credential/identity/repo_manager/operator control/sandbox/hooks/workflow 문서 등 RFC 발견 게이트 대상 subsystem에 해당하지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
