### PR TITLE
fix(runtime): thread binding keep-alive and num-ctx into Provider_config

### DIFF
--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -248,9 +248,9 @@ let effective_max_tokens_for_model spec requested =
    v1 drops the [Provider_tool_support.runtime_capabilities_override] that the
    deleted adapter carried alongside the config (it was paired with the
    now-removed alias layer); [binding_to_provider_config] never consumed it. *)
-let provider_config_from_declared_provider (provider : Runtime_schema.provider)
-    (spec : Runtime_schema.model_spec) ~(max_tokens : int option)
-    : Llm_provider.Provider_config.t option =
+let provider_config_from_declared_provider ?keep_alive ?num_ctx
+    (provider : Runtime_schema.provider) (spec : Runtime_schema.model_spec)
+    ~(max_tokens : int option) : Llm_provider.Provider_config.t option =
   let registry_entry = find_registry_entry provider.id in
   let supports_tool_choice_override = supports_tool_choice_override_of_model_spec spec in
   let max_tokens = effective_max_tokens_for_model spec max_tokens in
@@ -291,6 +291,8 @@ let provider_config_from_declared_provider (provider : Runtime_schema.provider)
             ~max_context:spec.max_context
             ?supports_tool_choice_override
             ?max_tokens
+            ?keep_alive
+            ?num_ctx
             ())
      | None -> None)
   | Cli _ ->
@@ -306,6 +308,8 @@ let provider_config_from_declared_provider (provider : Runtime_schema.provider)
             ~max_context:spec.max_context
             ?supports_tool_choice_override
             ?max_tokens
+            ?keep_alive
+            ?num_ctx
             ())
      | None -> None)
 ;;
@@ -328,7 +332,14 @@ let binding_to_provider_config (cfg : Runtime_schema.config) (binding : Runtime_
     (match Runtime_schema.provider_of_id cfg binding.provider_id with
      | None -> Error (Printf.sprintf "provider not found: %s" binding.provider_id)
      | Some provider ->
-       (match provider_config_from_declared_provider provider spec ~max_tokens with
+       (match
+          provider_config_from_declared_provider
+            ?keep_alive:binding.keep_alive
+            ?num_ctx:binding.num_ctx
+            provider
+            spec
+            ~max_tokens
+        with
         | None ->
           Error
             (Printf.sprintf

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -484,6 +484,68 @@ let provider_cfg () =
   | Ok provider_cfg -> provider_cfg
   | Error msg -> failf "unexpected adapter error: %s" msg
 
+(* Audit F2: TOML keep-alive / num-ctx must reach the wire-level
+   Provider_config. Before the fix the adapter dropped both binding
+   fields, so keep_alive fell back to OAS_OLLAMA_KEEP_ALIVE / "-1" and
+   num_ctx to the Ollama Modelfile default. *)
+let ollama_keep_alive_runtime_toml =
+  {|
+[runtime]
+default = "ollama.qwen-local"
+
+[providers.ollama]
+display-name = "Local Ollama"
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.qwen-local]
+api-name = "qwen3:32b"
+max-context = 32768
+tools-support = true
+streaming = true
+
+[ollama.qwen-local]
+max-concurrent = 1
+keep-alive = "30m"
+num-ctx = 16384
+|}
+
+let test_runtime_adapter_threads_binding_keep_alive_and_num_ctx () =
+  match Runtime_toml.parse_string ollama_keep_alive_runtime_toml with
+  | Error errors ->
+    failf
+      "expected Ollama keep-alive runtime TOML to parse: %s"
+      (String.concat
+         "; "
+         (List.map
+            (fun (err : Runtime_toml.parse_error) ->
+               Printf.sprintf "%s: %s" err.path err.message)
+            errors))
+  | Ok cfg ->
+    (match cfg.bindings with
+     | [ binding ] ->
+       check (option string) "binding keep_alive parsed" (Some "30m")
+         binding.Runtime_schema.keep_alive;
+       check (option int) "binding num_ctx parsed" (Some 16384)
+         binding.Runtime_schema.num_ctx;
+       (match Runtime_adapter.binding_to_provider_config cfg binding with
+        | Error msg -> failf "unexpected adapter error: %s" msg
+        | Ok provider_cfg ->
+          check bool "kind" true
+            (provider_cfg.kind = Llm_provider.Provider_config.Ollama);
+          check (option string) "provider config keep_alive" (Some "30m")
+            provider_cfg.keep_alive;
+          check (option int) "provider config num_ctx" (Some 16384)
+            provider_cfg.num_ctx)
+     | bindings -> failf "expected one binding, got %d" (List.length bindings))
+
+let test_runtime_adapter_leaves_keep_alive_and_num_ctx_unset_by_default () =
+  let provider_cfg = provider_cfg () in
+  check (option string) "keep_alive unset without TOML value" None
+    provider_cfg.keep_alive;
+  check (option int) "num_ctx unset without TOML value" None
+    provider_cfg.num_ctx
+
 let runtime_or_fail ?(provider = runpod_provider) () =
   let cfg =
     { Runtime_schema.providers = [ provider ]
@@ -783,6 +845,14 @@ let () =
             "runtime adapter materializes GLM Coding Plan provider"
             `Quick
             test_runtime_adapter_materializes_glm_coding_provider
+        ; test_case
+            "runtime adapter threads binding keep-alive and num-ctx"
+            `Quick
+            test_runtime_adapter_threads_binding_keep_alive_and_num_ctx
+        ; test_case
+            "runtime adapter leaves keep-alive and num-ctx unset by default"
+            `Quick
+            test_runtime_adapter_leaves_keep_alive_and_num_ctx_unset_by_default
         ; test_case
             "runtime agent terminal observation carries model identity"
             `Quick


### PR DESCRIPTION
## 문제

Audit F2 (verified-confirmed): 운영자가 MASC runtime TOML에 설정했다고 믿는 `keep-alive` / `num-ctx` 값이 wire에 실리지 않았다.

- `lib/runtime/runtime_toml.ml:492-493`이 binding 테이블의 `keep-alive`(string) / `num-ctx`(int)를 `Runtime_schema.binding`으로 파싱하고, 스키마 필드도 존재한다 (`runtime_schema.mli:122-123`).
- 그러나 `lib/runtime/runtime_adapter.ml`의 `provider_config_from_declared_provider`는 binding 레코드를 받지 않아 두 필드가 구조적으로 도달 불가였다. 비테스트 소비자 0.
- 결과: `keep_alive`는 TOML 값이 무시된 채 `OAS_OLLAMA_KEEP_ALIVE` env → `"-1"`로 silent fallback (oas `backend_ollama.ml:115-128`), `num_ctx`는 Ollama Modelfile 기본값으로 fallback (`backend_ollama.ml:183`은 `num_ctx > 0`일 때만 직렬화).

## 수정

- `provider_config_from_declared_provider`에 `?keep_alive` / `?num_ctx` optional 파라미터를 추가하고, HTTP 경로와 CLI 경로의 `Llm_provider.Provider_config.make` 호출 양쪽에 전달.
- `binding_to_provider_config`가 `?keep_alive:binding.keep_alive ?num_ctx:binding.num_ctx`로 binding 값을 주입.
- OAS `Provider_config.make`는 이미 `?keep_alive`(`provider_config.mli:173`) / `?num_ctx`(`:175`)를 받으므로 OAS 변경 없음. plumbing 스타일은 기존 `Runtime_model_string.make_custom_config`(`lib/runtime_model/runtime_model_string.ml:27-50`) 선례를 따름.
- CLI 경로 참고: `provider_kind_of_cli_provider`는 현재 항상 `None`을 반환하므로 (agent_sdk pin bump에서 CLI provider kind 제거됨) CLI 분기는 현재 도달 불가지만, `make` 시그니처가 동일 필드를 받아 대칭 유지 비용이 없어 같이 전달한다.

## 검증

worktree에서 `DUNE_CACHE=disabled`로 실행:

```
dune build --root . @check                       # 에러 없음
dune build --root . @fmt --auto-promote          # 본 변경 파일 재포맷 없음 (무관한 dune drift는 revert)
dune build --root .                              # default target, 에러 없음
dune build --root . test/test_runtime_provider_auth_headers.exe \
  && ./_build/default/test/test_runtime_provider_auth_headers.exe
# Test Successful in 0.009s. 20 tests run. (신규 2 케이스 포함, 전부 OK)
```

신규 테스트 (`test/test_runtime_provider_auth_headers.ml`):
- `runtime adapter threads binding keep-alive and num-ctx`: `ollama-http` provider + `keep-alive = "30m"` / `num-ctx = 16384` binding TOML fixture → `Runtime_toml.parse_string` → `Runtime_adapter.binding_to_provider_config` 산출 config의 `keep_alive = Some "30m"`, `num_ctx = Some 16384` 확인.
- `runtime adapter leaves keep-alive and num-ctx unset by default`: TOML에 값이 없으면 둘 다 `None` 유지 (env fallback 경로 보존) 확인.

## 근거

- 파싱: `lib/runtime/runtime_toml.ml:492-493`, 스키마: `lib/runtime/runtime_schema.mli:122-123`
- 누락 지점: `lib/runtime/runtime_adapter.ml` `provider_config_from_declared_provider` (HTTP `Provider_config.make` 호출부, CLI 호출부) — binding 미수신
- OAS 수신부: oas `provider_config.mli:173,175` (`?keep_alive` / `?num_ctx`), 직렬화 `backend_ollama.ml:115-128` (keep_alive env/-1 fallback), `:183` (num_ctx > 0 직렬화)
- 선례: `lib/runtime_model/runtime_model_string.ml:27-50` (`parse_model_string` 경로의 동일 plumbing)

RFC-WAIVED: runtime TOML 파서가 이미 선언한 스키마 필드를 adapter가 누락한 wiring 버그 수정으로, credential/identity/repo/operator/sandbox subsystem에 해당하지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
