### PR TITLE
refactor(workspace): typed no-op outcome for task transitions

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -421,10 +421,17 @@ let handle_keeper_task_tool
          force-released. Example: reason='assignee offline >10 min, no heartbeat'."
     else (
       let agent = keeper_agent_sender ~meta in
-      let result = Workspace.force_release_task_r config ~agent_name:agent ~task_id () in
+      let outcome_result =
+        Workspace.force_release_task_outcome_r config ~agent_name:agent ~task_id ()
+      in
+      let result =
+        Result.map
+          (fun (o : Workspace.transition_outcome) -> o.message)
+          outcome_result
+      in
       let is_noop =
-        match result with
-        | Ok msg -> String_util.contains_substring_ci msg "no-op"
+        match outcome_result with
+        | Ok outcome -> outcome.noop
         | Error _ -> false
       in
       let () =

--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -36,6 +36,22 @@ let force_release_task_r config ~agent_name ~task_id ?handoff_context ()
     ()
 ;;
 
+(** Force-release with the typed no-op flag (release on an already-Todo task).
+    Callers needing to distinguish a real release from the idempotent no-op
+    must use this instead of sniffing the message string. *)
+let force_release_task_outcome_r config ~agent_name ~task_id ?handoff_context ()
+  : transition_outcome Masc_domain.masc_result
+  =
+  transition_task_outcome_r
+    config
+    ~agent_name
+    ~task_id
+    ~action:Masc_domain.Release
+    ?handoff_context
+    ~force:true
+    ()
+;;
+
 (** Force-done a task regardless of assignee. Keeper privilege. *)
 let force_done_task_r config ~agent_name ~task_id ~notes ()
   : string Masc_domain.masc_result

--- a/lib/workspace/workspace_task.mli
+++ b/lib/workspace/workspace_task.mli
@@ -23,6 +23,34 @@ include module type of Workspace_task_claim
 
 (** {1 Task transitions} *)
 
+(** Typed transition result. [noop = true] marks the idempotent case
+    (e.g. release on an already-Todo task): status unchanged, no
+    write/events. RFC-0088 §1 follow-up — callers must branch on this
+    field, not on the message string. *)
+type transition_outcome =
+  { message : string
+  ; noop : bool
+  }
+
+val transition_task_outcome_r :
+  config -> agent_name:string -> task_id:string -> action:Masc_domain.task_action ->
+  ?prepare_verification_request:
+    (task:Masc_domain.task ->
+     assignee:string ->
+     verification_id:string ->
+     evidence_refs:string list ->
+     (unit, string) result) ->
+  ?compensate_verification_request:(verification_id:string -> unit) ->
+  ?prepare_verification_verdict:
+    (task:Masc_domain.task ->
+     verifier:string ->
+     verification_id:string ->
+     decision:[ `Approve of string | `Reject of string ] ->
+     (unit, string) result) ->
+  ?expected_version:int -> ?notes:string -> ?reason:string ->
+  ?handoff_context:Masc_domain.task_handoff_context ->
+  ?force:bool -> unit -> transition_outcome Masc_domain.masc_result
+
 val transition_task_r :
   config -> agent_name:string -> task_id:string -> action:Masc_domain.task_action ->
   ?prepare_verification_request:
@@ -50,6 +78,12 @@ val release_task_r :
 val force_release_task_r :
   config -> agent_name:string -> task_id:string ->
   ?handoff_context:Masc_domain.task_handoff_context -> unit -> string Masc_domain.masc_result
+
+(** [force_release_task_r] with the typed no-op flag; see {!transition_outcome}. *)
+val force_release_task_outcome_r :
+  config -> agent_name:string -> task_id:string ->
+  ?handoff_context:Masc_domain.task_handoff_context ->
+  unit -> transition_outcome Masc_domain.masc_result
 
 val force_done_task_r :
   config -> agent_name:string -> task_id:string ->

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -8,7 +8,15 @@ open Workspace_backlog
 include Workspace_task_classify
 include Workspace_task_create
 include Workspace_task_claim
-let transition_task_r
+(* RFC-0088 §1 follow-up (#21065 review): typed surface for the idempotent
+   no-op transition. Previously the only signal was the "(no-op)" substring in
+   the [Ok msg] string, which callers had to sniff with substring matching. *)
+type transition_outcome =
+  { message : string
+  ; noop : bool
+  }
+
+let transition_task_outcome_r
       config
       ~agent_name
       ~task_id
@@ -22,7 +30,7 @@ let transition_task_r
       ?handoff_context
       ?(force = false)
       ()
-  : string Masc_domain.masc_result
+  : transition_outcome Masc_domain.masc_result
   =
   let open Result.Syntax in
   let* () =
@@ -360,10 +368,13 @@ let transition_task_r
         then
 (* Idempotent no-op: status unchanged, skip write/events. Match None explicitly so set_current=Some is never silently dropped. *)
           Ok
-            (Printf.sprintf
-               "%s already %s (no-op)"
-               task_id
-               (task_status_to_string task.task_status))
+            { message =
+                Printf.sprintf
+                  "%s already %s (no-op)"
+                  task_id
+                  (task_status_to_string task.task_status)
+            ; noop = true
+            }
         else (
           let backlog_update =
             Workspace_task_transition_executor.build_backlog_update
@@ -606,14 +617,50 @@ let transition_task_r
            | Masc_domain.Approve_verification
            | Masc_domain.Reject_verification -> ());
           Ok
-            (Printf.sprintf
-               "%s %s → %s"
-               task_id
-               (task_status_to_string task.task_status)
-               (task_status_to_string new_status)))
+            { message =
+                Printf.sprintf
+                  "%s %s → %s"
+                  task_id
+                  (task_status_to_string task.task_status)
+                  (task_status_to_string new_status)
+            ; noop = false
+            })
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
       Error (Masc_domain.System (Masc_domain.System_error.IoError (Printexc.to_string e))))
   |> Workspace_task_verification.flatten_lock_result
+;;
+
+let transition_task_r
+      config
+      ~agent_name
+      ~task_id
+      ~action
+      ?prepare_verification_request
+      ?compensate_verification_request
+      ?prepare_verification_verdict
+      ?expected_version
+      ?notes
+      ?reason
+      ?handoff_context
+      ?force
+      ()
+  : string Masc_domain.masc_result
+  =
+  transition_task_outcome_r
+    config
+    ~agent_name
+    ~task_id
+    ~action
+    ?prepare_verification_request
+    ?compensate_verification_request
+    ?prepare_verification_verdict
+    ?expected_version
+    ?notes
+    ?reason
+    ?handoff_context
+    ?force
+    ()
+  |> Result.map (fun outcome -> outcome.message)
 ;;

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -1089,6 +1089,45 @@ let test_transition_release_todo_noop () =
     | Error _ -> Alcotest.fail "Expected Ok no-op")
 ;;
 
+let test_transition_release_todo_typed_noop () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Test" ~priority:1 ~description:"" in
+    match
+      Workspace.force_release_task_outcome_r
+        config
+        ~agent_name:"agent_llm_a"
+        ~task_id:"task-001"
+        ()
+    with
+    | Ok outcome ->
+      Alcotest.(check bool) "typed release todo no-op" true outcome.noop;
+      Alcotest.(check bool)
+        "message remains human-readable"
+        true
+        (str_contains outcome.message "already todo")
+    | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e))
+;;
+
+let test_transition_force_release_claimed_typed_not_noop () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Test" ~priority:1 ~description:"" in
+    let _ = Workspace.claim_task config ~agent_name:"agent_llm_a" ~task_id:"task-001" in
+    match
+      Workspace.force_release_task_outcome_r
+        config
+        ~agent_name:"system"
+        ~task_id:"task-001"
+        ()
+    with
+    | Ok outcome ->
+      Alcotest.(check bool) "claimed force release mutates" false outcome.noop;
+      Alcotest.(check bool)
+        "release message"
+        true
+        (str_contains outcome.message "todo")
+    | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e))
+;;
+
 let test_transition_invalid () =
   with_test_env (fun config ->
     let _ = Workspace.add_task config ~title:"Test" ~priority:1 ~description:"" in
@@ -1943,6 +1982,14 @@ let () =
             `Quick
             test_transition_release_generated_nickname_alias
         ; Alcotest.test_case "release todo no-op" `Quick test_transition_release_todo_noop
+        ; Alcotest.test_case
+            "release todo typed no-op"
+            `Quick
+            test_transition_release_todo_typed_noop
+        ; Alcotest.test_case
+            "force release claimed typed not no-op"
+            `Quick
+            test_transition_force_release_claimed_typed_not_noop
         ; Alcotest.test_case "invalid" `Quick test_transition_invalid
         ; Alcotest.test_case "version mismatch" `Quick test_transition_version_mismatch
         ; Alcotest.test_case "done idempotent" `Quick test_transition_done_idempotent


### PR DESCRIPTION
## 문제
#21065가 force-release no-op을 `String_util.contains_substring_ci msg "no-op"`로 분류했습니다. 이 신호의 원천은 `workspace_task_transitions.ml`의 `"%s already %s (no-op)"` 메시지 문구뿐이라, 문구가 바뀌면 `No_progress` 분류가 조용히 깨집니다. 같은 repo의 `workspace_task_claim.ml:60` RFC-0088 §1 (#18839) 주석이 정확히 이 패턴(substring 신호 → typed field)을 금지하는 선례입니다. #21065 리뷰 코멘트에서 약속한 후속입니다.

## 수정
- `transition_outcome = { message; noop }` 타입 신설, 코어를 `transition_task_outcome_r`로 — no-op 분기(:noop=true)와 정상 전이(:noop=false)가 타입으로 구분됩니다
- `transition_task_r`은 `Result.map (fun o -> o.message)` 래퍼로 유지 (기존 호출자 무변경)
- `force_release_task_outcome_r` facade 추가
- `keeper_task_force_release`가 substring 대신 `outcome.noop`으로 분기

## 검증
- `dune build --root . @check` / default target — 성공
- `./_build/default/test/test_keeper_tool_dispatch_runtime.exe` — 28 tests 통과 (#21065가 추가한 "force_release todo no-op is no progress" 테스트가 typed 경로를 그대로 통과 = 행동 동일 증명)
- `rg '"no-op"' lib/ bin/ tools/` — 메시지 생산처(transitions) 외 소비처 0건 확인

## 근거
- workspace_task_transitions.ml:361-368 (no-op 분기), :608-616 (정상 전이)
- workspace_task_claim.ml:60-72 (RFC-0088 §1 typed claim_outcome 선례)
- #21065 리뷰 코멘트 (https://github.com/jeong-sik/masc/pull/21065#issuecomment-4696866365)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
