### PR TITLE
fix(runtime): honor rerank runtime_id and delete silently-ignored routing args

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,7 +14,7 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 348 unique knobs across 9 modules.
+**Total**: 347 unique knobs across 9 modules.
 
 **Typed getter classification**: 21/206 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 185).
 
@@ -92,7 +92,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 48 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 | `MASC_SSE_KEEPALIVE_SEC` | typed:float | unclassified | unclassified | 108 | SSE keepalive interval (seconds). Frequency of `: keepalive` frames on command-plane SSE streams. Clamped to >= 1.0 t... |
 
-## Env_config_keeper (65 knobs; typed classification 2/53)
+## Env_config_keeper (64 knobs; typed classification 2/53)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -151,7 +151,6 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 502 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
 | `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 196 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
 | `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 205 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 633 | Comma-separated provider kind allowlist for every keeper runtime call. Values are OAS [Provider_config.string_of_prov... |
 | `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 277 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
 | `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 243 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 179 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
@@ -337,9 +336,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 640 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 644 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 646 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 638 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 642 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 644 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 218 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 308 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 310 |  |
@@ -372,8 +371,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 158 |  |
 | `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 160 |  |
 | `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 156 |  |
-| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 550 |  |
-| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | string_literal | n/a | n/a | 498 |  |
+| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 548 |  |
+| `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | string_literal | n/a | n/a | 496 |  |
 | `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 185 |  |
 | `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 181 |  |
 | `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 179 |  |
@@ -381,32 +380,32 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 175 |  |
 | `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 177 |  |
 | `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 173 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 554 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 556 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 552 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 554 |  |
 | `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 162 |  |
-| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 558 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 506 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 508 |  |
+| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 556 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 504 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 506 |  |
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 165 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 164 |  |
 | `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 212 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 738 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 774 |  |
-| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 471 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 786 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 688 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 690 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 692 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 694 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 718 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 736 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 772 |  |
+| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 469 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 784 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 686 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 688 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 690 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 692 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 716 |  |
 | `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 148 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 55 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 52 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 754 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 756 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 752 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 754 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 150 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 818 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 820 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 822 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 816 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 818 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 820 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 92 |  |
 | `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 95 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -603,47 +603,12 @@ module RuntimeSaturationSignal = struct
     get_bool ~default:false "MASC_RUNTIME_SATURATION_SIGNAL_ENABLED"
 end
 
-(** {1 Runtime Runtime Overrides}
-
-    Runtime-only narrowing of the MASC runtime provider set. The underlying
-    runtime profile (loaded from [runtime.toml]) is unchanged; this filter is
-    applied by the named-runtime execution path via [~provider_filter] on every
-    keeper turn, so switching between full runtime and a single-provider
-    fallback is a pure env-var change with no file or code edit.
-
-    Use case: GLM endpoint outage (e.g. z.ai quota exhausted), Ollama-only
-    hard mode, or A/B testing a single provider. *)
-module KeeperRuntimeProviderFilter = struct
-  (** Comma-separated provider kind allowlist for every keeper runtime call.
-      Values are OAS [Provider_config.string_of_provider_kind]:
-      [ollama], [glm], [provider_a], [provider_f], [openai_compat], [cli_tool_d],
-      [provider_c], [cli_tool_c], [cli_tool_b], [cli_tool_a].
-      Matching is case-insensitive; empty entries are dropped.
-
-      Semantics: when set, keeper turns pass this list as [provider_filter]
-      into [Keeper_turn_driver.run_named], which applies it during MASC runtime
-      provider resolution. The runtime keeps only matching providers from
-      the resolved profile; if the filter leaves zero providers, OAS falls back
-      to the unfiltered profile (see [apply_provider_filter] safety net).
-
-      [None] (env var unset or blank) = full runtime, unfiltered.
-
-      Env: [MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST]. Default: unset. *)
-  let provider_allowlist () : string list option =
-    match Env_config_core.raw_value_opt "MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST" with
-    | None -> None
-    | Some raw ->
-      let parts =
-        raw
-        |> String.split_on_char ','
-        |> List.map String.trim
-        |> List.filter (fun s -> s <> "")
-      in
-      (match parts with
-       | [] -> None
-       | _ -> Some parts)
-  ;;
-end
+(* MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST (KeeperRuntimeProviderFilter) was
+   deleted (audit F8): its value was threaded as [?provider_filter] into
+   [Keeper_turn_driver.run_named] and [Keeper_memory_llm_summary.make], both of
+   which silently ignored it after the RFC-0206 single-runtime purge. The knob
+   was dead while its docs were live; deletion documents reality. Provider
+   selection is runtime.toml SSOT ([runtime].default / [[runtime.assignments]]). *)
 
 (** {1 Transient Retry Backoff}
 

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -235,12 +235,6 @@ module RuntimeSaturationSignal : sig
 end
 
 
-(** {1 Runtime runtime overrides} *)
-
-module KeeperRuntimeProviderFilter : sig
-  val provider_allowlist : unit -> string list option
-end
-
 (** {1 Transient retry backoff} *)
 
 module KeeperRetryBackoff : sig

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -466,8 +466,6 @@ let keeper_bootstrap_entries =
 
 let keeper_runtime_entries =
   [
-    entry ~default:"(none)" "MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST"
-      "Comma-separated provider allowlist for runtime (None=unfiltered)";
     entry ~default:"enforce" "MASC_RUNTIME_ATTEMPT_LIVENESS"
       "Runtime attempt-liveness gate mode (off|observe|enforce). RFC-0022 \
        Explicit values must be canonical; invalid values raise a config error.";

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -87,7 +87,6 @@ let run_turn
       ~(runtime_id : string)
       ?world_observation
       ?(turn_affordances = [])
-      ?provider_filter
       ~(generation : int)
       ?(max_turns : int = Keeper_runtime_resolved.reactive_max_turns_per_call ())
       (* Per-call turn budget. Keeper resumes via checkpoint if exhausted. *)
@@ -426,13 +425,6 @@ let run_turn
     let priority =
       Option.value priority ~default:Llm_provider.Request_priority.Proactive
     in
-    let admission_wait_timeout_sec =
-      if
-        Llm_provider.Request_priority.resolve priority
-        = Llm_provider.Request_priority.Proactive
-      then Some 180.0
-      else None
-    in
     ignore (Keeper_alerting_path.ensure_sandbox_bundle ~config ~meta);
     let _keeper_sandbox_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
     let keeper_visible_sandbox_root =
@@ -492,9 +484,7 @@ let run_turn
                    turn-budget admission. *)
                 Keeper_turn_driver.run_named
                   ~runtime_id:runtime_id_string
-                    ~base_path:config.base_path
                     ~keeper_name:meta.name
-                    ?provider_filter
                     ~goal:user_message
                     ~priority
                     ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
@@ -525,7 +515,6 @@ let run_turn
                     ~temperature
                     ~max_tokens
                     ?max_cost_usd
-                    ?wait_timeout_sec:admission_wait_timeout_sec
                     ~accept:
                       Keeper_tool_response.response_has_text_or_tool_progress
                     ~guardrails:keeper_oas_guardrails
@@ -627,7 +616,7 @@ let run_turn
                           ~acc
                           ~actual_keeper_tool_names
                           ~result ~checkpoint_persistence_error
-                          ~post_turn_t0 ?provider_filter ~runtime_id_string
+                          ~post_turn_t0 ~runtime_id_string
                           ~prompt_metrics ~ctx_composition ~usage
                           ~receipt_response_text_present_ref ~history_assistant_source
                           ~pre_dispatch_compacted:ctx.pre_dispatch_compacted

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -58,7 +58,6 @@ val per_provider_timeout_for_turn
      @param world_observation Structured keeper world snapshot used by
             advisory execution-progress checks. When omitted, the progress check
             does not infer world state from prompt text.
-    @param provider_filter Optional provider restriction
     @param generation Current generation counter
     @param max_turns Maximum agent turns (default from env config)
     @param max_idle_turns Maximum consecutive idle turns before stop
@@ -87,7 +86,6 @@ val run_turn
   -> runtime_id:string
   -> ?world_observation:Keeper_world_observation.world_observation
   -> ?turn_affordances:string list
-  -> ?provider_filter:string list
   -> generation:int
   -> ?max_turns:int
   -> max_idle_turns:int

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -31,7 +31,6 @@ let finalize
     ~(result : Runtime_agent.run_result)
     ~checkpoint_persistence_error
     ~post_turn_t0
-    ?provider_filter
     ~runtime_id_string
     ~prompt_metrics
     ~ctx_composition
@@ -202,7 +201,6 @@ let finalize
       ~state_snapshot_source
       ~librarian_messages
       ~post_turn_t0
-      ?provider_filter
       ~runtime_id:runtime_id_string
       ~inference_telemetry:result.response.telemetry
       ();

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -14,7 +14,6 @@ let run
   ~state_snapshot_source
   ~librarian_messages
   ~post_turn_t0
-  ?provider_filter
   ~runtime_id
   ~inference_telemetry
   ()
@@ -87,7 +86,6 @@ let run
   (try
      let memory_summarizer =
        Keeper_memory_llm_summary.make
-         ?provider_filter
          ~runtime_id
          ~keeper_name:meta.name
          ()

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -20,7 +20,6 @@ val run :
   state_snapshot_source:string ->
   librarian_messages:Agent_sdk.Types.message list ->
   post_turn_t0:float ->
-  ?provider_filter:string list ->
   runtime_id:string ->
   inference_telemetry:Agent_sdk.Types.inference_telemetry option ->
   unit ->

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -359,7 +359,8 @@ let keeper_action_kind_of_tool_names tool_names =
   |> Option.value ~default:"none"
 
 let effective_model_labels_for_turn (m : keeper_meta) : string list =
-  (* provider filtering now handled by OAS runtime via ~provider_filter *)
+  (* Provider selection is runtime.toml SSOT; the former ~provider_filter
+     plumbing was dead and deleted (audit F8). *)
   let configured = Keeper_model_labels.configured_model_labels_of_meta m in
   match String.trim (Keeper_status_runtime.active_model_of_meta m) with
   | "" -> configured

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -220,7 +220,6 @@ let summarize_with_providers
 
 let make
     ?complete
-    ?provider_filter
     ?timeout_sec
     ~(runtime_id : string)
     ~(keeper_name : string)
@@ -230,7 +229,6 @@ let make
     match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
     | Some sw, Some net ->
         let clock = Eio_context.get_clock_opt () in
-        ignore provider_filter;
         (* RFC-0206: named-runtime provider resolution is gone; the memory
            summary uses the single default runtime's provider config. *)
         (match

--- a/lib/keeper/keeper_memory_llm_summary.mli
+++ b/lib/keeper/keeper_memory_llm_summary.mli
@@ -22,7 +22,6 @@ val messages_for_summary :
 
 val make :
   ?complete:complete_fn ->
-  ?provider_filter:string list ->
   ?timeout_sec:float ->
   runtime_id:string ->
   keeper_name:string ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -513,7 +513,6 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
                     ~max_idle_turns:
                       (Keeper_runtime_resolved.reactive_max_idle_turns ())
                     ?oas_timeout_s:keeper_msg_oas_timeout_s
-                    ?provider_filter:(Env_config_keeper.KeeperRuntimeProviderFilter.provider_allowlist ())
                     ~generation:meta.runtime.generation
                     ?on_event
                     ~trajectory_acc

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -40,10 +40,8 @@ let runtime_candidates_of_providers =
   Keeper_turn_driver_admission.runtime_candidates_of_providers
 let run_named
     ~runtime_id
-    ?base_path
     ?(keeper_name = "")
     ~goal
-    ?provider_filter
     ?priority
     ?session_id
     ?(system_prompt = "")
@@ -56,7 +54,6 @@ let run_named
     ?(max_tokens = Runtime_provider_defaults.agent_default_max_tokens)
     ?max_input_tokens
     ?max_cost_usd
-    ?wait_timeout_sec
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?guardrails
     ?hooks
@@ -111,11 +108,10 @@ let run_named
     | None -> enable_thinking
   in
   let preserve_thinking = runtime_seed.preserve_thinking in
-  (* Parameters that only fed the deleted multi-candidate machinery
-     (provider selection and admission queue gating). *)
-  ignore provider_filter;
-  ignore base_path;
-  ignore wait_timeout_sec;
+  (* Audit F8: the former [?provider_filter] / [?base_path] /
+     [?wait_timeout_sec] parameters only fed the deleted multi-candidate
+     machinery and were silently ignored here; they are removed from the
+     signature so callers cannot pass dead routing knobs. *)
   (* RFC-0207: dispatch to the *requested* runtime (a keeper's persona [model]
      selection or the global default, both produced by [runtime_id_of_meta])
      instead of unconditionally the default.  A requested id that does not

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -91,10 +91,8 @@ val provider_attempt_finished_decision :
 
 val run_named :
   runtime_id:string ->
-  ?base_path:string ->
   ?keeper_name:string ->
   goal:string ->
-  ?provider_filter:string list ->
   ?priority:Llm_provider.Request_priority.t ->
   ?session_id:string ->
   ?system_prompt:string ->
@@ -107,7 +105,6 @@ val run_named :
   ?max_tokens:int ->
   ?max_input_tokens:int ->
   ?max_cost_usd:float ->
-  ?wait_timeout_sec:float ->
   ?accept:(Agent_sdk_response.api_response -> bool) ->
   ?guardrails:Agent_sdk.Guardrails.t ->
   ?hooks:Agent_sdk.Hooks.hooks ->

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -172,7 +172,6 @@ let run_named_with_masc_tools
     ?(max_tokens = Runtime_provider_defaults.agent_default_max_tokens)
     ?max_input_tokens
     ?max_cost_usd
-    ?wait_timeout_sec
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?guardrails
     ?hooks
@@ -196,7 +195,7 @@ let run_named_with_masc_tools
   ) masc_tools in
   Keeper_turn_driver.run_named ~runtime_id ~goal ?priority ~system_prompt ~tools:oas_tools
     ~temperature ~max_tokens ?max_input_tokens ?max_cost_usd
-    ?stream_idle_timeout_s ?wait_timeout_sec ?guardrails ?hooks
+    ?stream_idle_timeout_s ?guardrails ?hooks
     ~accept
     ?compact_ratio
     ?approval

--- a/lib/keeper/keeper_turn_driver_wrappers.mli
+++ b/lib/keeper/keeper_turn_driver_wrappers.mli
@@ -50,7 +50,6 @@ val run_named_with_masc_tools :
   ?max_tokens:int ->
   ?max_input_tokens:int ->
   ?max_cost_usd:float ->
-  ?wait_timeout_sec:float ->
   ?accept:(Agent_sdk_response.api_response -> bool) ->
   ?guardrails:Agent_sdk.Guardrails.t ->
   ?hooks:Agent_sdk.Hooks.hooks ->

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -181,8 +181,6 @@ let run (ctx : ctx)
                ~runtime_id:execution.runtime_id
                ~world_observation:observation
                ~turn_affordances
-               ?provider_filter:
-                 (Env_config_keeper.KeeperRuntimeProviderFilter.provider_allowlist ())
                ~generation:run_generation
                ~max_turns
                ~max_idle_turns

--- a/lib/runtime/runtime_candidate.ml
+++ b/lib/runtime/runtime_candidate.ml
@@ -6,8 +6,9 @@
     exactly one Runtime, so the candidate collapses to its provider config and
     the health/capacity/strategy/selection machinery is dropped.
 
-    [type t = Provider_config.t] — no wrapper. The surviving members delegate
-    to {!Runtime_agent} / {!Runtime_provider_binding}; error decoration is
+    [type t] is a record pairing the runtime's [Provider_config.t] with its
+    [max_concurrent] binding limit. The surviving members delegate to
+    {!Runtime_agent} / {!Runtime_provider_binding}; error decoration is
     collapsed to identity. *)
 
 type t =

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -41,20 +41,30 @@ let runtime_catalog_error_to_sdk_error detail =
 (** Resolve runtime provider configs via MASC Runtime_config.
     Returns Provider_config.t list for the downstream OAS runtime,
     bypassing the old Model_spec facade. *)
-let resolve_runtime_providers
-      ?provider_filter:_
-      ?runtime_mcp_policy:_
-      ~runtime_id:_
-      ()
-  =
-  (* RFC-0206 single-binding: runtime catalog resolution removed. The providers
-     are the default runtime's single provider_config. [provider_filter] is
-     moot with one provider; runtime tool surface compatibility is handled by
-     runtime MCP policy resolution. *)
-  match Runtime.get_default_runtime () with
-  | None -> Error "no default runtime configured"
-  | Some rt ->
-    Ok [ rt.Runtime.provider_config ]
+let resolve_runtime_providers ~runtime_id () =
+  (* Audit F8: honor the *requested* runtime id (RFC-0207 catalog lookup).
+     The previous RFC-0206 single-binding stub discarded [runtime_id] and
+     always returned the default runtime, silently substituting an
+     operator-overridable id (e.g. MASC_KEEPER_LLM_RERANK_RUNTIME) — an
+     Unknown→Permissive fallback. An empty id means the default runtime; a
+     non-empty id that is not a configured runtime is an [Error] (no silent
+     substitution — RFC-0206 §2.1). The former [?provider_filter] /
+     [?runtime_mcp_policy] parameters were ignored here and are deleted;
+     each resolved runtime carries exactly one provider_config. *)
+  let runtime_id = String.trim runtime_id in
+  if String.equal runtime_id "" then
+    match Runtime.get_default_runtime () with
+    | None -> Error "no default runtime configured"
+    | Some rt -> Ok [ rt.Runtime.provider_config ]
+  else
+    match Runtime.get_runtime_by_id runtime_id with
+    | Some rt -> Ok [ rt.Runtime.provider_config ]
+    | None ->
+      Error
+        (Printf.sprintf
+           "requested runtime %S not found among configured runtimes \
+            (no silent fallback to default — RFC-0206 §2.1)"
+           runtime_id)
 
 (* Injected keeper name translators (dependency inversion of the
    runtime -> keeper-domain Keeper_identity edge). The runtime no longer

--- a/lib/runtime/runtime_oas_runner.mli
+++ b/lib/runtime/runtime_oas_runner.mli
@@ -35,11 +35,12 @@ val runtime_catalog_error_to_sdk_error : string -> Agent_sdk.Error.sdk_error
 (** {1 Provider resolution} *)
 
 val resolve_runtime_providers :
-  ?provider_filter:string list ->
-  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
   runtime_id:string -> unit ->
   (Llm_provider.Provider_config.t list, string) result
-(** Resolve runtime provider configs via MASC Runtime_config. *)
+(** Resolve the requested runtime's provider config via the RFC-0207 runtime
+    catalog. An empty [runtime_id] resolves the default runtime; a non-empty
+    id that is not a configured runtime returns [Error] — never the default
+    runtime (no Unknown→Permissive substitution, RFC-0206 §2.1; audit F8). *)
 
 (** {1 Keeper name translation (injected)} *)
 

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -341,6 +341,63 @@ let test_get_runtime_by_id_resolves_and_fails_fast () =
          (Runtime.get_runtime_by_id "bogus.binding")))
 ;;
 
+(* ---- rerank resolver: resolve the requested runtime, or fail fast ----
+
+   Audit F8: [Runtime_oas_runner.resolve_runtime_providers] used to discard
+   [runtime_id] and always return the default runtime, silently substituting
+   an operator-overridable id (MASC_KEEPER_LLM_RERANK_RUNTIME on the LLM
+   rerank path).  It must resolve the requested id via the RFC-0207 catalog
+   and return [Error] on an unknown id — never the default runtime. *)
+
+let provider_base_url_of_runtime_id runtime_id =
+  match Runtime.get_runtime_by_id runtime_id with
+  | Some rt -> rt.Runtime.provider_config.Llm_provider.Provider_config.base_url
+  | None -> Alcotest.failf "fixture runtime %s missing from catalog" runtime_id
+;;
+
+let test_rerank_resolver_resolves_requested_runtime () =
+  with_runtime_initialized (fun () ->
+    (* Known non-default id resolves to that runtime's provider, not the
+       default's. *)
+    (match
+       Runtime_oas_runner.resolve_runtime_providers ~runtime_id:"openai.gpt" ()
+     with
+     | Error msg -> Alcotest.failf "expected openai.gpt to resolve: %s" msg
+     | Ok [ provider ] ->
+       Alcotest.(check string)
+         "resolved provider belongs to the requested runtime"
+         (provider_base_url_of_runtime_id "openai.gpt")
+         provider.Llm_provider.Provider_config.base_url
+     | Ok providers ->
+       Alcotest.failf "expected exactly one provider, got %d" (List.length providers));
+    (* Empty id resolves the default runtime. *)
+    match Runtime_oas_runner.resolve_runtime_providers ~runtime_id:"" () with
+    | Error msg -> Alcotest.failf "expected empty id to resolve default: %s" msg
+    | Ok [ provider ] ->
+      Alcotest.(check string)
+        "empty id resolves the default runtime's provider"
+        (provider_base_url_of_runtime_id (Runtime.get_default_runtime_id ()))
+        provider.Llm_provider.Provider_config.base_url
+    | Ok providers ->
+      Alcotest.failf "expected exactly one provider, got %d" (List.length providers))
+;;
+
+let test_rerank_resolver_errors_on_unknown_runtime_id () =
+  with_runtime_initialized (fun () ->
+    match
+      Runtime_oas_runner.resolve_runtime_providers ~runtime_id:"bogus.binding" ()
+    with
+    | Ok _ ->
+      Alcotest.fail
+        "unknown runtime id must return Error, not the default runtime \
+         (silent substitution)"
+    | Error msg ->
+      Alcotest.(check bool)
+        "error names the unknown runtime id"
+        true
+        (string_contains msg "bogus.binding"))
+;;
+
 let test_context_budget_uses_selected_runtime () =
   with_runtime_initialized (fun () ->
     let default_budget =
@@ -534,6 +591,14 @@ let () =
             "get_runtime_by_id resolves known / fails fast on unknown"
             `Quick
             test_get_runtime_by_id_resolves_and_fails_fast
+        ; Alcotest.test_case
+            "rerank resolver resolves the requested runtime (audit F8)"
+            `Quick
+            test_rerank_resolver_resolves_requested_runtime
+        ; Alcotest.test_case
+            "rerank resolver errors on unknown runtime id, no default substitution"
+            `Quick
+            test_rerank_resolver_errors_on_unknown_runtime_id
         ; Alcotest.test_case
             "context budget uses selected runtime max-context"
             `Quick


### PR DESCRIPTION
## 문제

감사(audit) F8 — 런타임 라우팅 인자가 시그니처에는 존재하지만 내부에서 조용히 무시되고 있었다.

- `lib/runtime/runtime_oas_runner.ml:44` `resolve_runtime_providers`가 `runtime_id`/`provider_filter`를 `_` 패턴으로 버리고 항상 default runtime을 반환. 실해(實害): `lib/keeper/keeper_run_tools_setup.ml:511` LLM rerank 경로가 operator가 env `MASC_KEEPER_LLM_RERANK_RUNTIME`로 지정한 runtime id를 넘기는데, 어떤 값을 넣어도 default runtime으로 조용히 치환됨 — Unknown→Permissive fallback.
- `lib/keeper/keeper_turn_driver.ml:116-118` `run_named`가 `?provider_filter` / `?base_path` / `?wait_timeout_sec` 3개를 `ignore`로 버림 (RFC-0206 single-runtime purge 잔재).
- `lib/config/env_config_keeper.ml:609-631` 문서는 `MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST`가 "매 keeper 턴에 `~provider_filter`로 적용된다"고 기술하지만, 그 값이 도달하는 두 종단(`run_named`, `Keeper_memory_llm_summary.make:233`) 모두 ignore — knob은 죽었는데 문서는 살아있는 상태.
- `lib/runtime/runtime_candidate.ml` 헤더 doc이 "type t = Provider_config.t — no wrapper"라고 기술하지만 실제 `t`는 `{ config; max_concurrent }` 레코드.

## 수정

원칙: 조용히 무시되는 파라미터 0개 — 실제로 동작하거나, 컴파일러에 보이게 삭제.

1. `resolve_runtime_providers`: 요청된 `runtime_id`를 RFC-0207 카탈로그(`Runtime.get_runtime_by_id`)로 해석. 빈 id = default runtime, 미등록 non-empty id = `Error` 반환 (default 치환 없음, RFC-0206 §2.1). ignore되던 `?provider_filter`/`?runtime_mcp_policy` 파라미터는 시그니처에서 삭제 (유일 호출처는 둘 다 전달하지 않았음 — 추측성 배선 대신 삭제).
2. `run_named`: ignore되던 3개 파라미터(`?provider_filter`/`?base_path`/`?wait_timeout_sec`) 삭제 + 호출자 배관 제거 (`keeper_agent_run.ml`의 `admission_wait_timeout_sec` dead 바인딩 포함, `run_named_with_masc_tools`의 `?wait_timeout_sec` pass-through 포함). `run_model_by_label`/`run_model_with_masc_tools`의 `?wait_timeout_sec`은 `Admission_queue.with_permit`에 실제 사용되므로 유지.
3. **operator 가시 변경**: env knob `MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST` (`KeeperRuntimeProviderFilter`) 삭제. 이 knob은 이미 비기능 상태였음 — 값이 도달하는 모든 종단이 ignore. 삭제는 현실을 문서화하는 것이며 동작 변화는 없다. snapshot 엔트리, mli, `docs/runtime-tunables.md`(재생성, 348→347 knobs), 그리고 dead `?provider_filter` 체인 전체(`run_turn` → `finalize_response` → `post_turn_memory` → `memory_llm_summary`) 삭제. provider 선택은 runtime.toml SSOT(`[runtime].default` / `[[runtime.assignments]]`).
4. `runtime_candidate.ml`: stale 헤더 doc만 교정 (래퍼 리팩토링 없음).

rerank 경로의 실패 동작: 미등록 runtime id는 이제 기존 `Error` 분기(ToolSelectionFailures counter + WARN log + core+prefilter fallback)로 표면화된다. 이전에는 잘못된 id가 default runtime으로 무증상 치환되었다.

## 검증

```
export DUNE_CACHE=disabled
dune build --root . @check                      # 통과 (경고 없음)
dune build --root . @fmt --auto-promote         # 적용 (무관한 dune 파일 재포맷 4건은 원복)
dune build --root .                             # exit 0 (default target)
dune exec --root . ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md
                                                # wrote docs/runtime-tunables.md (entries=347 files=10)
./_build/default/test/test_runtime_per_keeper_routing.exe   # 18 tests run, Successful (신규 2건 포함)
./_build/default/test/test_keeper_turn_driver_accept.exe    # 11 tests run, Successful
./_build/default/test/test_runtime_toml_overrides.exe       # 30 tests run, Successful
./_build/default/test/test_keeper_summarizer.exe            # 5 tests run, Successful
./_build/default/test/test_oas_timeout_budget_strike.exe    # 21 tests run, Successful
./_build/default/test/test_keeper_memory_os.exe             # 17 tests run, Successful
```

신규 테스트 (`test/test_runtime_per_keeper_routing.ml` "driver lookup" 그룹):
- `rerank resolver resolves the requested runtime (audit F8)` — 요청한 non-default id(`openai.gpt`)가 해당 runtime의 provider로 해석되고, 빈 id는 default로 해석됨을 검증.
- `rerank resolver errors on unknown runtime id, no default substitution` — 미등록 id가 default runtime이 아닌 `Error`를 반환함을 검증.

## 근거

- 감사 F8 (verified-confirmed): rerank silent-substitution이 이 PR이 닫는 구체적 Unknown→Permissive fallback.
- `lib/runtime/runtime_oas_runner.ml:44-57` (변경 전) — `~runtime_id:_` discard, 항상 default 반환.
- `lib/keeper/keeper_run_tools_setup.ml:511-516` — rerank 경로의 `resolve_runtime_providers ~runtime_id:rerank_runtime` 호출 (env `MASC_KEEPER_LLM_RERANK_RUNTIME`, `lib/keeper/keeper_config.ml:353`).
- `lib/keeper/keeper_turn_driver.ml:116-118` (변경 전) — `ignore provider_filter; ignore base_path; ignore wait_timeout_sec`.
- `lib/config/env_config_keeper.ml:609-612` (변경 전) — dead knob의 live 문서.
- `lib/keeper/keeper_memory_llm_summary.ml:233` (변경 전) — `ignore provider_filter` (allowlist 체인의 두 번째 종단).
- RFC-0206 §2.1 (Unknown→Permissive 금지), RFC-0207 (요청된 runtime으로 dispatch, fail-fast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
