### PR TITLE
fix(dashboard): make harness health JSONL stores thread-safe

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -91,11 +91,13 @@ let runtime_warning_ctx_ratio =
   Env_config_keeper.DashboardHealth.runtime_warning_ctx_ratio
 ;;
 
-let pre_compact_store_ref : Dated_jsonl.t option ref = ref None
+let pre_compact_store_ref : Dated_jsonl.t option Atomic.t = Atomic.make None
+let pre_compact_store_mu = Eio.Mutex.create ()
 
 (** Store for wake-time payload observations. Populated lazily on first
     [record_wake_payload] call when [MASC_PAYLOAD_TELEMETRY] is enabled. *)
-let wake_payload_store_ref : Dated_jsonl.t option ref = ref None
+let wake_payload_store_ref : Dated_jsonl.t option Atomic.t = Atomic.make None
+let wake_payload_store_mu = Eio.Mutex.create ()
 
 let status_to_string = function
   | Healthy -> "healthy"
@@ -118,13 +120,17 @@ let wake_payload_store_base_dir () =
   Filename.concat (Env_config.base_path ()) "data/keeper-wake-payload"
 ;;
 
-let get_or_create_store store_ref base_dir_fn =
-  match !store_ref with
+let get_or_create_store ~store_ref ~store_mu base_dir_fn =
+  match Atomic.get store_ref with
   | Some store -> store
   | None ->
-    let store = Dated_jsonl.create ~base_dir:(base_dir_fn ()) () in
-    store_ref := Some store;
-    store
+    Eio.Mutex.use_rw ~protect:true store_mu @@ fun () ->
+    (match Atomic.get store_ref with
+     | Some store -> store
+     | None ->
+       let store = Dated_jsonl.create ~base_dir:(base_dir_fn ()) () in
+       Atomic.set store_ref (Some store);
+       store)
 ;;
 
 let append_store_json_fail_open ~store_ref ~store_name get_store json =
@@ -134,29 +140,35 @@ let append_store_json_fail_open ~store_ref ~store_name get_store json =
     (* Health/event persistence is observability only. If the backing JSONL
          append fails, drop the poisoned store so the next call can recreate
          it instead of leaking Eio_mutex.Poisoned into keeper control flow. *)
-    store_ref := None;
+    Atomic.set store_ref None;
     Log.Harness.warn "[%s] append failed: %s" store_name (Printexc.to_string exn)
 ;;
 
 let get_pre_compact_store () =
-  get_or_create_store pre_compact_store_ref pre_compact_store_base_dir
+  get_or_create_store
+    ~store_ref:pre_compact_store_ref
+    ~store_mu:pre_compact_store_mu
+    pre_compact_store_base_dir
 ;;
 
 let get_wake_payload_store () =
-  get_or_create_store wake_payload_store_ref wake_payload_store_base_dir
+  get_or_create_store
+    ~store_ref:wake_payload_store_ref
+    ~store_mu:wake_payload_store_mu
+    wake_payload_store_base_dir
 ;;
 
 let reset_runtime_stores_for_testing () =
-  pre_compact_store_ref := None;
-  wake_payload_store_ref := None
+  Atomic.set pre_compact_store_ref None;
+  Atomic.set wake_payload_store_ref None
 ;;
 
 let set_pre_compact_store_for_testing ~base_dir =
-  pre_compact_store_ref := Some (Dated_jsonl.create ~base_dir ())
+  Atomic.set pre_compact_store_ref (Some (Dated_jsonl.create ~base_dir ()))
 ;;
 
 let set_wake_payload_store_for_testing ~base_dir =
-  wake_payload_store_ref := Some (Dated_jsonl.create ~base_dir ())
+  Atomic.set wake_payload_store_ref (Some (Dated_jsonl.create ~base_dir ()))
 ;;
 
 let string_field json key = Safe_ops.json_string ~default:"" key json

--- a/test/dune
+++ b/test/dune
@@ -138,6 +138,7 @@
   test_auth_ambiguous_lookup_9786
   test_auth_load_credential_of
   test_keeper_wake_telemetry
+  test_dashboard_harness_health
   test_keeper_timing
   test_keeper_token_count
   test_keeper_chat_store

--- a/test/dune
+++ b/test/dune
@@ -417,6 +417,7 @@
   test_auth_ambiguous_lookup_9786
   test_auth_load_credential_of
   test_keeper_wake_telemetry
+  test_dashboard_harness_health
   test_keeper_timing
   test_keeper_token_count
   test_keeper_chat_store

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -1,0 +1,117 @@
+open Alcotest
+
+module H = Dashboard_harness_health
+
+let temp_dir_counter = ref 0
+
+let with_temp_dir prefix f =
+  incr temp_dir_counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "%s-%d-%06d"
+         prefix
+         (Unix.getpid ())
+         !temp_dir_counter)
+  in
+  Unix.mkdir dir 0o755;
+  let rec rm_rf path =
+    if Sys.file_exists path then
+      if Sys.is_directory path
+      then (
+        Sys.readdir path
+        |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path)
+      else Sys.remove path
+  in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let reset_after f =
+  H.reset_runtime_stores_for_testing ();
+  Fun.protect ~finally:H.reset_runtime_stores_for_testing f
+
+let record_wake_payload ~trace_id =
+  H.record_wake_payload
+    ~keeper_name:"keeper-harness"
+    ~trace_id
+    ~turn_index:7
+    ~model_id:"provider/private-model"
+    ~context_window:4096
+    ~approx_body_bytes:100
+    ~system_prompt_bytes:10
+    ~tool_defs_bytes:20
+    ~messages_bytes:70
+    ~message_count:3
+    ~role_counts:[ "user", 1; "assistant", 2 ]
+    ~tool_count:4
+    ~has_compact_happened:false
+
+let test_wake_payload_store_round_trip () =
+  reset_after @@ fun () ->
+  with_temp_dir "wake-payload-store" @@ fun dir ->
+  H.set_wake_payload_store_for_testing ~base_dir:dir;
+  ignore (H.get_wake_payload_store ());
+  ignore (record_wake_payload ~trace_id:"trace-round-trip");
+  match H.read_wake_payload_events () with
+  | [ event ] ->
+    check string "keeper" "keeper-harness" event.keeper_name;
+    check string "trace" "trace-round-trip" event.trace_id;
+    check int "turn index" 7 event.turn_index;
+    check int "context window" 4096 event.context_window;
+    check int "approx bytes" 100 event.approx_body_bytes;
+    check int "tool count" 4 event.tool_count;
+    check bool "compact flag" false event.has_compact_happened
+  | events ->
+    failf "expected one wake payload event, got %d" (List.length events)
+
+let test_reset_rebinds_wake_payload_store () =
+  reset_after @@ fun () ->
+  with_temp_dir "wake-payload-store-a" @@ fun first_dir ->
+  with_temp_dir "wake-payload-store-b" @@ fun second_dir ->
+  H.set_wake_payload_store_for_testing ~base_dir:first_dir;
+  ignore (record_wake_payload ~trace_id:"trace-first");
+  H.reset_runtime_stores_for_testing ();
+  H.set_wake_payload_store_for_testing ~base_dir:second_dir;
+  ignore (record_wake_payload ~trace_id:"trace-second");
+  match H.read_wake_payload_events () with
+  | [ event ] -> check string "trace after reset" "trace-second" event.trace_id
+  | events -> failf "expected rebound store to contain one event, got %d" (List.length events)
+
+let test_pre_compact_store_setter_records_event () =
+  reset_after @@ fun () ->
+  with_temp_dir "pre-compact-store" @@ fun dir ->
+  H.set_pre_compact_store_for_testing ~base_dir:dir;
+  let event =
+    H.record_pre_compact
+      ~keeper_name:"keeper-harness"
+      ~context_ratio:0.92
+      ~message_count:12
+      ~token_count:3456
+      ~strategies:[ "drop-old"; "summarize" ]
+      ~context_window:8192
+      ~is_local_model:true
+      ~trigger:Compaction_trigger.Manual
+  in
+  check string "keeper" "keeper-harness" event.keeper_name;
+  check (float 0.0001) "ratio" 0.92 event.context_ratio;
+  check int "message count" 12 event.message_count;
+  check int "token count" 3456 event.token_count;
+  check (list string) "strategies" [ "drop-old"; "summarize" ] event.strategies;
+  check int "context window" 8192 event.context_window;
+  check bool "local model" true event.is_local_model;
+  check string "trigger" "manual" (Compaction_trigger.to_label event.trigger)
+
+let () =
+  run
+    "dashboard_harness_health"
+    [
+      ( "runtime_stores",
+        [
+          test_case "wake payload round trip" `Quick test_wake_payload_store_round_trip;
+          test_case "wake payload reset rebinds store" `Quick
+            test_reset_rebinds_wake_payload_store;
+          test_case "pre-compact setter records event" `Quick
+            test_pre_compact_store_setter_records_event;
+        ] );
+    ]

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -103,6 +103,7 @@ let test_pre_compact_store_setter_records_event () =
   check string "trigger" "manual" (Compaction_trigger.to_label event.trigger)
 
 let () =
+  Eio_main.run @@ fun _env ->
   run
     "dashboard_harness_health"
     [


### PR DESCRIPTION
# ci:skip-test-coverage

## Problem

The lazy singleton JSONL stores were plain [ref] options created with a read-check-write sequence. Concurrent keeper event fibers could create duplicate stores and split append streams.

## Change

- Replace both store refs with [Atomic.t] options.
- Add a per-store [Eio.Mutex] and use double-checked locking in [get_or_create_store].
- Update fail-open resets and test-only setters to use [Atomic.set].

## Verification

- [x] `scripts/dune-local.sh build lib/masc.a` passes.

Refs: audit finding MASC-mutable-ref-007

# ci:skip-test-coverage
These changes only make existing lazy JSONL store creation thread-safe; no new externally-observable behavior is introduced that can be meaningfully unit-tested without a multi-fiber keeper event harness.