### PR TITLE
fix(config): declare Gemma4 QAT supports-tool-choice as false

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -112,7 +112,12 @@ preserve-thinking = false
 streaming = true
 
 [models.gemma4-26b-a4b-qat.capabilities]
-supports-tool-choice = true
+# This runtime rides OAS native Ollama /api/chat, which does not serialize
+# tool_choice (oas backend_ollama.ml:24). Declaring true here would override
+# oas models.toml's supports_tool_choice=false (provider_runtime_binding.ml
+# applies this override last) while the transport silently drops forced tool
+# choice. Do not re-enable without a serializer path + model-side proof.
+supports-tool-choice = false
 thinking-control-format = "chat_template_token"
 supports-native-streaming = true
 supports-top-k = true

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -52,7 +52,13 @@ let test_repo_runtime_toml_loads () =
           check bool "Gemma4 chat-template-token thinking control" true
             (Runtime_schema.equal_thinking_control_format
                caps.thinking_control_format
-               Runtime_schema.Chat_template_token)
+               Runtime_schema.Chat_template_token);
+          (* Native Ollama /api/chat never serializes tool_choice
+             (oas backend_ollama.ml:24); declaring true here would override
+             oas models.toml false while the transport drops forced tool
+             choice. *)
+          check bool "Gemma4 forced tool_choice disabled" false
+            caps.supports_tool_choice
         | None -> fail "expected Gemma4 capabilities"));
     (match
        List.find_opt


### PR DESCRIPTION
감사 F4 (verified-confirmed) 대응 PR입니다.

## 문제

`config/runtime.toml`이 Gemma4 QAT 모델에 `supports-tool-choice = true`를 선언하고 있었습니다 (#20927에서 도입).

- 이 선언은 `runtime_toml.ml:351` → `runtime_adapter.ml:226-228/:292` → `Provider_config.supports_tool_choice_override = Some true`로 흐르고, OAS `provider_runtime_binding.ml:355-364`가 이 override를 **마지막에** 적용하므로 oas `models.toml`의 `supports_tool_choice = false`(:907/:925)를 이깁니다. 즉 masc의 `true`가 실제로 승리하며 무시되지 않습니다.
- 그런데 이 모델의 실제 wire는 OAS native Ollama `/api/chat`(`backend_ollama.ml`)이고, 이 backend는 `tool_choice`를 직렬화하지 않습니다 (`backend_ollama.ml:24` 주석). 결과적으로 capability surface는 `true`를 주장하지만 transport는 강제 tool choice를 조용히 버립니다.
- OAS `capabilities.ml:240-256`은 이 override를 소비자가 **검증한** 선언으로 문서화하고 있습니다. 결함은 masc가 검증되지 않은 지원을 선언한 것이며, 수정 방향은 OAS의 문서화된 override 계약을 따릅니다.

## 수정

- `config/runtime.toml`: Gemma4 QAT capability를 `supports-tool-choice = false`로 변경하고, transport 제약(`backend_ollama.ml:24`)과 재활성화 조건(serializer 경로 + 모델 측 증명)을 TOML 주석으로 명시했습니다.
  - 키 제거 대신 명시적 `false`를 선택했습니다. parser 기본값(`runtime_toml.ml:332`, `Otoml.find_or ~default:false`)이 `false`라 제거해도 파싱 결과는 동일하지만, `[models.gemma4-26b-a4b-qat.capabilities]` 테이블이 존재하는 한 `runtime_adapter.ml:226-228`이 어느 쪽이든 `Some false` override를 만들기 때문에, 선언 지점에 의도를 명시하는 쪽을 택했습니다.
- `test/test_runtime_config_validity.ml`: 실제 repo `config/runtime.toml`을 로드하는 기존 하네스에 `Gemma4 forced tool_choice disabled` assertion을 추가해 회귀를 고정했습니다.
- repo 내 다른 사본 확인: `rg "gemma4-26b-a4b-qat" / "gemma-4-26B-A4B"` 결과 stanza 사본은 `config/runtime.toml` 1곳뿐입니다. `test_runtime_provider_auth_headers.ml:336`의 inline TOML fixture는 capabilities에 `thinking-control-format`만 선언하고 있어 수정 불필요, `test_keeper_turn_driver_accept.ml:49`는 runtime id 문자열만 사용합니다. `~/.masc` 런타임 상태는 건드리지 않았습니다.

## 검증

worktree에서 `DUNE_CACHE=disabled`로 실행:

- `dune build --root . @check` — 통과 (deprecation 경고만 출력)
- `dune build --root .` (default target, 최종 게이트) — 통과, 출력 없음
- `dune build --root . test/test_runtime_config_validity.exe && ./_build/default/test/test_runtime_config_validity.exe` — `Test Successful in 0.004s. 3 tests run.` (신규 assertion 포함)
- `dune build --root . test/test_runtime_provider_auth_headers.exe && ./_build/default/test/test_runtime_provider_auth_headers.exe` — `Test Successful in 0.008s. 18 tests run.`
- `dune build --root . @fmt --auto-promote` — 본 diff 파일의 추가 promotion 없음 (무관한 dune 파일 4건의 pre-existing 포맷 drift는 revert하고 커밋에서 제외)

## 근거

- `config/runtime.toml:114-115` (변경 전 `supports-tool-choice = true`, #20927 도입 — `git log` 확인: `45ca6aa4d Add Gemma4 Ollama runtime seed (#20927)`)
- `lib/runtime/runtime_toml.ml:351` (capability 파싱, 기본값 `false`는 :332)
- `lib/runtime/runtime_adapter.ml:226-228, :292` (override 전파)
- oas `provider_runtime_binding.ml:355-364` (override를 마지막에 적용 → masc 선언이 승리)
- oas `backend_ollama.ml:24` (native Ollama `/api/chat`은 `tool_choice` 미직렬화)
- oas `capabilities.ml:240-256` (override는 소비자 검증 선언이라는 계약)
- `test/test_runtime_config_validity.ml:50-62` (신규 회귀 assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
