### PR TITLE
feat(task-schedule): implement release_stale_claims (was stub)

### DIFF
--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -658,5 +658,26 @@ let claim_next config ~agent_name =
     Returns list of (task_id, assignee) pairs that were released. *)
 let release_stale_claims config ~ttl_seconds =
   ensure_initialized config;
-  []
+  match Workspace_backlog.read_backlog_r config with
+  | Error _ -> []
+  | Ok backlog ->
+    let now = Unix.time () in
+    let stale_tasks =
+      List.filter_map
+        (fun (task : Masc_domain.task) ->
+           match task.task_status with
+           | Claimed { assignee; claimed_at }
+           | InProgress { assignee; started_at=claimed_at } ->
+             (match parse_iso_time_opt claimed_at with
+              | Some t when now -. t > ttl_seconds -> Some (task.id, assignee)
+              | _ -> None)
+           | _ -> None)
+        backlog.tasks
+    in
+    List.iter
+      (fun (task_id, assignee) ->
+         let _ = Workspace_task.force_release_task_r config ~agent_name:assignee ~task_id () in
+         ())
+      stale_tasks;
+    stale_tasks
 ;;


### PR DESCRIPTION
Replace the stub `[]` in `release_stale_claims` with real logic:

- Read backlog via `Workspace_backlog.read_backlog_r`
- Filter `Claimed`/`InProgress` tasks where `claimed_at`/`started_at` exceeds `ttl_seconds`
- Force-release each stale claim via `Workspace_task.force_release_task_r`

Fixes: task-1007 — orphaned task accumulation when assigned agents are offline.

**Testing**: logic mirrors existing `is_zombie_agent` pattern but uses time-based TTL on the task timestamp itself.