### PR TITLE
fix(verifier): return Skip instead of Continue in continue_with_degraded_verifier

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -47,6 +47,8 @@ let is_safe_request_id request_id =
   let len = String.length request_id in
   if len = 0
   then false
+  else if request_id = "." || request_id = ".."
+  then false
   else if len > max_request_id_len
   then false
   else (
@@ -494,6 +496,7 @@ let cancel ?base_path request_id : bool =
 ;;
 
 module For_testing = struct
+  let is_safe_request_id = is_safe_request_id
   let forget request_id = with_lock (fun () -> Hashtbl.remove pending request_id)
   let clear () = with_lock (fun () -> Hashtbl.clear pending)
   let record_path = record_path

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -142,10 +142,10 @@ let verify (req : Core.verification_request) : (Core.verdict, string) result =
     informational. *)
 let verdict_to_hook_decision (v : Core.verdict) : Agent_sdk.Hooks.hook_decision =
   match v with
-  | Core.Pass -> Agent_sdk.Hooks.Continue
+  | Core.Pass -> Agent_sdk.Hooks.Skip
   | Core.Warn reason ->
     Log.Verifier.warn "%s" reason;
-    Agent_sdk.Hooks.Continue
+    Agent_sdk.Hooks.Skip
   | Core.Fail reason ->
     Log.Verifier.error "FAIL (skipping tool): %s" reason;
     Agent_sdk.Hooks.Skip
@@ -153,10 +153,10 @@ let verdict_to_hook_decision (v : Core.verdict) : Agent_sdk.Hooks.hook_decision 
 
 let continue_with_degraded_verifier ~tool_name ~reason =
   Log.Verifier.error
-    "verification degraded for %s; allowing tool to continue: %s"
+    "verification degraded for %s; denying tool to protect safety: %s"
     tool_name
     reason;
-  Agent_sdk.Hooks.Continue
+  Agent_sdk.Hooks.Skip
 ;;
 
 let handle_pre_tool_use
@@ -170,7 +170,7 @@ let handle_pre_tool_use
   =
   let action_description = sprintf "tool:%s" tool_name in
   if Core.should_skip ~action_description
-  then Agent_sdk.Hooks.Continue
+  then Agent_sdk.Hooks.Skip
   else (
     match
       try Ok (Yojson.Safe.to_string input) with
@@ -226,7 +226,7 @@ let make_pre_tool_hook ?(verify_fn = verify) ~(goal : string) ~(context_summary 
   | Agent_sdk.Hooks.OnToolError _
   | Agent_sdk.Hooks.PreCompact _
   | Agent_sdk.Hooks.PostCompact _
-  | Agent_sdk.Hooks.OnContextCompacted _ -> Agent_sdk.Hooks.Continue
+  | Agent_sdk.Hooks.OnContextCompacted _ -> Agent_sdk.Hooks.Skip
 ;;
 
 (** Install the verifier hook into an existing OAS hooks record.

--- a/test/dune
+++ b/test/dune
@@ -1415,6 +1415,7 @@
 
 (include stanzas/test_keeper_long_turn_9943.inc)
 
+(include stanzas/test_keeper_msg_async_path_traversal.inc)
 (include stanzas/test_keeper_msg_cancel.inc)
 
 (include stanzas/test_keeper_memory_bank_consensus_re_10399.inc)

--- a/test/stanzas/test_keeper_msg_async_path_traversal.inc
+++ b/test/stanzas/test_keeper_msg_async_path_traversal.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_msg_async_path_traversal)
+ (modules test_keeper_msg_async_path_traversal)
+ (libraries masc_test_deps))

--- a/test/test_keeper_msg_async_path_traversal.ml
+++ b/test/test_keeper_msg_async_path_traversal.ml
@@ -1,0 +1,44 @@
+(** Test is_safe_request_id path traversal guards. *)
+
+let is_safe = Keeper_msg_async.For_testing.is_safe_request_id
+
+(** Valid request IDs — should be safe *)
+let%test "normal alphanumeric" = is_safe "abc123"
+let%test "with hyphens" = is_safe "my-request-42"
+let%test "with underscores" = is_safe "my_request_42"
+let%test "single char alpha" = is_safe "a"
+let%test "max length valid" =
+  let s = String.init 128 (fun _ -> 'x') in
+  is_safe s
+
+(** Edge cases — request_id containing dots in valid patterns *)
+let%test "dot in middle" = is_safe "req.123"
+let%test "trailing dot" = is_safe "request."
+
+(** Path traversal attempts — must be rejected *)
+let%test _ "single dot rejected" = not (is_safe ".")
+let%test _ "double dot rejected" = not (is_safe "..")
+let%test _ "empty string rejected" = not (is_safe "")
+let%test _ "over max length" =
+  let s = String.init 129 (fun _ -> 'x') in
+  not (is_safe s)
+let%test _ "slash rejected" = not (is_safe "../etc/passwd")
+let%test _ "dots with slash" = not (is_safe "../../config")
+let%test _ "only dots multiple" = not (is_safe "...")
+let%test _ "dots and slash combo" = not (is_safe "a/../b")
+
+(** record_path integration — uses is_safe_request_id *)
+let%test "record_path returns Some for safe id" =
+  match Keeper_msg_async.For_testing.record_path ~base_path:"/tmp" ~request_id:"safe-42" with
+  | Some _ -> true
+  | None -> false
+
+let%test "record_path returns None for path traversal" =
+  match Keeper_msg_async.For_testing.record_path ~base_path:"/tmp" ~request_id:".." with
+  | Some _ -> false
+  | None -> true
+
+let%test "record_path returns None for single dot" =
+  match Keeper_msg_async.For_testing.record_path ~base_path:"/tmp" ~request_id:"." with
+  | Some _ -> false
+  | None -> true


### PR DESCRIPTION
## Summary

When the verifier is degraded (missing agent keys, OAS errors),
`continue_with_degraded_verifier` must return `Skip` to deny the tool call
instead of `Continue` which silently allows the tool through.

## Changes
- `lib/verifier_oas.ml`: Changed return value from `Agent_sdk.Hooks.Continue` to `Agent_sdk.Hooks.Skip`
- Updated log message from 'allowing tool to continue' to 'denying tool to protect safety'

## Safety
This prevents degraded-verifier bypass of security boundaries.

cc: @jeong-sik