### PR TITLE
fix(verifier_oas): rebased onto latest main (Fail→Reject, Continue→Skip)

### DIFF
--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -148,7 +148,7 @@ let verdict_to_hook_decision (v : Core.verdict) : Agent_sdk.Hooks.hook_decision 
     Agent_sdk.Hooks.Continue
   | Core.Fail reason ->
     Log.Verifier.error "FAIL (rejecting tool): %s" reason;
-    Agent_sdk.Hooks.Reject { msg = reason }
+    Agent_sdk.Hooks.Reject reason
 ;;
 
 let continue_with_degraded_verifier ~tool_name ~reason =

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -147,16 +147,16 @@ let verdict_to_hook_decision (v : Core.verdict) : Agent_sdk.Hooks.hook_decision 
     Log.Verifier.warn "%s" reason;
     Agent_sdk.Hooks.Continue
   | Core.Fail reason ->
-    Log.Verifier.error "FAIL (skipping tool): %s" reason;
-    Agent_sdk.Hooks.Skip
+    Log.Verifier.error "FAIL (rejecting tool): %s" reason;
+    Agent_sdk.Hooks.Reject { msg = reason }
 ;;
 
 let continue_with_degraded_verifier ~tool_name ~reason =
   Log.Verifier.error
-    "verification degraded for %s; allowing tool to continue: %s"
+    "verification degraded for %s; blocking tool: %s"
     tool_name
     reason;
-  Agent_sdk.Hooks.Continue
+  Agent_sdk.Hooks.Skip
 ;;
 
 let handle_pre_tool_use

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -133,9 +133,9 @@ let test_warn_to_continue () =
 
 let test_fail_to_skip () =
   let decision = Verifier_oas.verdict_to_hook_decision (Core.Fail "critical error") in
-  Alcotest.(check bool) "Fail -> Skip"
+  Alcotest.(check bool) "Fail -> Reject"
     true
-    (decision = Agent_sdk.Hooks.Skip)
+    (decision = Agent_sdk.Hooks.Reject "critical error")
 
 (* ================================================================ *)
 (* read_only_predicate                                               *)


### PR DESCRIPTION
This is a rebased version of PR #21106's fix onto latest main (929d8ab97).

Changes (same as original #21106):
- Line 151: `Core.Fail` → `Hooks.Reject { msg = reason }` (was `Hooks.Skip`)
- Line 159: `continue_with_degraded_verifier` → `Hooks.Skip` (was `Hooks.Continue`)

Rebased and pushed by sangsu using repos/masc-mcp (gh auth anyang-keepers).
Original PR #21106 remains open with CI Gate blockade.

Closes #21106 (rebase version, pending CI).