### PR TITLE
fix(gate): record Discord WSS writer fiber death cause

### DIFF
--- a/lib/gate/discord_wss_connection.ml
+++ b/lib/gate/discord_wss_connection.ml
@@ -89,6 +89,31 @@ let drain_handshake req ic oc nonce =
    | Some _ -> failwith "ws handshake: Sec-WebSocket-Accept mismatch"
    | None -> failwith "ws handshake: Sec-WebSocket-Accept header missing")
 
+(* Writer fiber body, shared with the unit tests via the .mli.
+   [take] blocks for the next queued frame; [write_string] pushes the
+   encoded bytes onto the TLS flow.
+
+   The [Eio.Io] containment is intentional (audit T7): the writer runs
+   on the per-session switch, so letting a TLS/WSS write failure escape
+   would fail that switch and tear down the whole gateway client (outer
+   fork in [connect]).  Failure *detection* stays delegated to the
+   reader path ([Wss_closed] in [Discord_gateway_client]) and the
+   heartbeat ACK timeout — but the cause is recorded here instead of
+   dropped.  [Eio.Cancel.Cancelled] is deliberately not caught: switch
+   teardown still cancels the writer silently. *)
+let writer_loop ~take ~write_string =
+  try
+    let rec loop () =
+      let frame = take () in
+      let buf = Buffer.create 128 in
+      Ws_io.write_frame_to_buf ~mode:(Client random_string) buf frame;
+      write_string (Buffer.contents buf);
+      loop ()
+    in
+    loop ()
+  with Eio.Io _ as e ->
+    Log.Discord.warn "wss writer fiber terminated: %s" (Printexc.to_string e)
+
 (* Builds the session-local resources (socket, TLS flow, writer fiber)
    on the given inner switch. Returns the read/write closures only —
    close is wired by the outer [connect] via the promise pair. *)
@@ -140,17 +165,10 @@ let build_session ~sw ~env ~url =
 
   let write_queue = Eio.Stream.create 16 in
   let writer () =
-    try
-      let rec loop () =
-        let frame = Eio.Stream.take write_queue in
-        let buf = Buffer.create 128 in
-        Ws_io.write_frame_to_buf ~mode:(Client random_string) buf frame;
-        Eio.Buf_write.with_flow flow (fun oc ->
-          Eio.Buf_write.string oc (Buffer.contents buf));
-        loop ()
-      in
-      loop ()
-    with Eio.Io _ -> ()
+    writer_loop
+      ~take:(fun () -> Eio.Stream.take write_queue)
+      ~write_string:(fun s ->
+        Eio.Buf_write.with_flow flow (fun oc -> Eio.Buf_write.string oc s))
   in
   Eio.Fiber.fork ~sw writer;
 

--- a/lib/gate/discord_wss_connection.mli
+++ b/lib/gate/discord_wss_connection.mli
@@ -39,3 +39,15 @@ val close : conn -> unit
 (** Tear down this connection: cancels the writer fiber, closes the
     TLS flow and the underlying socket. Idempotent — subsequent calls
     are no-ops. After [close], [read] / [write] raise. *)
+
+val writer_loop :
+  take:(unit -> Websocket.Frame.t) ->
+  write_string:(string -> unit) ->
+  unit
+(** Writer fiber body: encodes frames obtained from [take] and pushes
+    the bytes via [write_string] until either raises.  [Eio.Io] is
+    contained — the cause is logged at warn level — because the writer
+    runs on the per-session switch and an escaping exception would tear
+    down the whole gateway client.  Every other exception (including
+    cancellation) propagates.  Exposed for unit tests; [connect] wires
+    it to the write queue and the TLS flow. *)

--- a/test/dune
+++ b/test/dune
@@ -1299,6 +1299,7 @@
 (include stanzas/test_channel_gate_metrics.inc)
 
 (include stanzas/test_channel_gate_discord_state_in_process.inc)
+
 (include stanzas/test_gate_surface.inc)
 
 (include stanzas/test_discord_gateway_state.inc)
@@ -1309,6 +1310,8 @@
 
 (include stanzas/test_discord_rest_client.inc)
 
+(include stanzas/test_discord_wss_writer.inc)
+
 (include stanzas/test_keeper_chat_discord.inc)
 
 (include stanzas/test_ci_run_tests_script.inc)
@@ -1318,7 +1321,9 @@
 (include stanzas/test_continuity_forward_filter.inc)
 
 (include stanzas/test_otel_runtime_observables.inc)
+
 (include stanzas/test_otel_zero_fill.inc)
+
 (include stanzas/test_workspace_bootstrap.inc)
 
 (include stanzas/test_workspace_base_path_cache.inc)
@@ -1466,6 +1471,7 @@
 (include stanzas/test_keeper_execution_join.inc)
 
 (include stanzas/test_keeper_msg_async_path_traversal.inc)
+
 (include stanzas/test_keeper_msg_cancel.inc)
 
 (include stanzas/test_turn_record.inc)
@@ -1869,9 +1875,7 @@
  (name test_rfc_0085_pr4_tool_library_proof_store)
  (modules test_rfc_0085_pr4_tool_library_proof_store)
  (libraries alcotest ast_grep)
- (deps
-  ../lib/tool_library.ml
-  ../lib/cdal_runtime/proof_store.ml))
+ (deps ../lib/tool_library.ml ../lib/cdal_runtime/proof_store.ml))
 
 ; Verify the shared MCP dispatch finalizer fires typed observers and applies
 ; the result transformer before observers run.
@@ -1907,23 +1911,22 @@
 ; removed.
 
 (test
-  (name test_rfc_0085_pr8_config_dir_resolver_host_config)
-  (modules test_rfc_0085_pr8_config_dir_resolver_host_config)
-  (libraries alcotest ast_grep)
-  (deps
-   (source_tree ../lib)
-   (source_tree ../bin)))
+ (name test_rfc_0085_pr8_config_dir_resolver_host_config)
+ (modules test_rfc_0085_pr8_config_dir_resolver_host_config)
+ (libraries alcotest ast_grep)
+ (deps
+  (source_tree ../lib)
+  (source_tree ../bin)))
 
 ; RFC-0085 PR-7 — Retroactive AST test for retired_pg_env_keys +
 ; clear_retired_pg_envs deletion (#15468 user-identified legacy;
 ; shipped without a regression test; restored by #15495).
 
 (test
-  (name test_rfc_0085_pr7_retired_pg_envs_purge)
-  (modules test_rfc_0085_pr7_retired_pg_envs_purge)
-  (libraries alcotest ast_grep)
-  (deps
-   ../lib/server/server_runtime_bootstrap.ml))
+ (name test_rfc_0085_pr7_retired_pg_envs_purge)
+ (modules test_rfc_0085_pr7_retired_pg_envs_purge)
+ (libraries alcotest ast_grep)
+ (deps ../lib/server/server_runtime_bootstrap.ml))
 
 ; RFC-0086 — keeper namespace bulk promotion invariant.
 ; Pins G-A (Phase 2.A wave 1, #15474): every .ml/.mli under
@@ -1950,117 +1953,115 @@
 ; restored by #15495).
 
 (test
-  (name test_rfc_0085_pr18_execution_surfaces_rename)
-  (modules test_rfc_0085_pr18_execution_surfaces_rename)
-  (libraries alcotest ast_grep)
-  (deps
-   ../lib/server/server_dashboard_http_execution_surfaces.ml
-   ../lib/server/server_dashboard_http_namespace_truth.ml
-   ../lib/server/server_dashboard_http_namespace_truth_support.ml))
+ (name test_rfc_0085_pr18_execution_surfaces_rename)
+ (modules test_rfc_0085_pr18_execution_surfaces_rename)
+ (libraries alcotest ast_grep)
+ (deps
+  ../lib/server/server_dashboard_http_execution_surfaces.ml
+  ../lib/server/server_dashboard_http_namespace_truth.ml
+  ../lib/server/server_dashboard_http_namespace_truth_support.ml))
 
 ; RFC-0085 PR-17 — Retroactive AST test for 4 dead deletion + 2 rename
 ; (#15485 shipped without a regression test; restored by #15495).
 
 (test
-  (name test_rfc_0085_pr17_dead_purge_and_rename)
-  (modules test_rfc_0085_pr17_dead_purge_and_rename)
-  (libraries alcotest ast_grep)
-  (deps
-   ../lib/workspace/workspace_utils_paths_backend.ml
-   ../lib/server_base_path_diagnostics.ml
-   ../lib/dashboard/dashboard_briefing.ml
-   ../lib/gate/channel_gate_metrics.ml))
+ (name test_rfc_0085_pr17_dead_purge_and_rename)
+ (modules test_rfc_0085_pr17_dead_purge_and_rename)
+ (libraries alcotest ast_grep)
+ (deps
+  ../lib/workspace/workspace_utils_paths_backend.ml
+  ../lib/server_base_path_diagnostics.ml
+  ../lib/dashboard/dashboard_briefing.ml
+  ../lib/gate/channel_gate_metrics.ml))
 
 ; RFC-0085 PR-16 — Retroactive AST test for dashboard_http_core rename
 ; (#15484 shipped without a regression test; restored by #15495).
 
 (test
-  (name test_rfc_0085_pr16_dashboard_http_core_rename)
-  (modules test_rfc_0085_pr16_dashboard_http_core_rename)
-  (libraries alcotest ast_grep)
-  (deps
-   ../lib/server/server_dashboard_http_core.ml))
+ (name test_rfc_0085_pr16_dashboard_http_core_rename)
+ (modules test_rfc_0085_pr16_dashboard_http_core_rename)
+ (libraries alcotest ast_grep)
+ (deps ../lib/server/server_dashboard_http_core.ml))
 
 ; RFC-0085 PR-15 — Retroactive AST test for tool_schemas_inline rename
 ; (#15483 shipped without a regression test; restored by #15495).
 
 (test
-  (name test_rfc_0085_pr15_tool_schemas_inline_rename)
-  (modules test_rfc_0085_pr15_tool_schemas_inline_rename)
-  (libraries alcotest ast_grep)
-  (deps
-   ../lib/tool_schemas/tool_schemas_inline.ml
-   ../lib/tool_schemas/tool_schemas_inline_infra.ml))
+ (name test_rfc_0085_pr15_tool_schemas_inline_rename)
+ (modules test_rfc_0085_pr15_tool_schemas_inline_rename)
+ (libraries alcotest ast_grep)
+ (deps
+  ../lib/tool_schemas/tool_schemas_inline.ml
+  ../lib/tool_schemas/tool_schemas_inline_infra.ml))
 
 ; RFC-0085 PR-14 — dispatch / dispatch_structured / guarded_dispatch
 ; 3-step chain inlined; guarded_dispatch is the only dispatch entry.
 
 (test
-  (name test_rfc_0085_pr14_dispatch_inline)
-  (modules test_rfc_0085_pr14_dispatch_inline)
-  (libraries alcotest ast_grep)
-  (deps
-   ../lib/tool/tool_dispatch.ml
-   ../lib/keeper/keeper_tool_registered_runtime.ml))
+ (name test_rfc_0085_pr14_dispatch_inline)
+ (modules test_rfc_0085_pr14_dispatch_inline)
+ (libraries alcotest ast_grep)
+ (deps
+  ../lib/tool/tool_dispatch.ml
+  ../lib/keeper/keeper_tool_registered_runtime.ml))
 
 ; RFC-0085 PR-13 — Underscore-prefix audit: 1 truly-dead deletion +
 ; 8 active rename across 7 modules.
 
 (test
-  (name test_rfc_0085_pr13_underscore_rename)
-  (modules test_rfc_0085_pr13_underscore_rename)
-  (libraries alcotest ast_grep)
-  (deps
-   ../lib/governance_pipeline_risk.ml
-   ../lib/config_dir_resolver/config_dir_resolver.ml
-   ../lib/keeper/keeper_tool_surface_ops.ml
-   ../lib/board_tool_adapter/board_tool_cache.ml
-   ../lib/tool_workspace.ml))
+ (name test_rfc_0085_pr13_underscore_rename)
+ (modules test_rfc_0085_pr13_underscore_rename)
+ (libraries alcotest ast_grep)
+ (deps
+  ../lib/governance_pipeline_risk.ml
+  ../lib/config_dir_resolver/config_dir_resolver.ml
+  ../lib/keeper/keeper_tool_surface_ops.ml
+  ../lib/board_tool_adapter/board_tool_cache.ml
+  ../lib/tool_workspace.ml))
 
 ; RFC-0085 PR-12 — Tool_spec list bindings renamed (drop misleading
 ; _ prefix that signalled "unused" in OCaml but was wrong because the
 ; bindings are actively used by List.mem in the Tool_spec.register loop).
 
 (test
-  (name test_rfc_0085_pr12_tool_spec_rename)
-  (modules test_rfc_0085_pr12_tool_spec_rename)
-  (libraries alcotest ast_grep)
-  (deps
-   ../lib/tool_workspace.ml))
+ (name test_rfc_0085_pr12_tool_spec_rename)
+ (modules test_rfc_0085_pr12_tool_spec_rename)
+ (libraries alcotest ast_grep)
+ (deps ../lib/tool_workspace.ml))
 
 ; RFC-0085 PR-11 — Env_config_core deprecation mechanism removed.
 
 (test
-  (name test_rfc_0085_pr11_deprecation_purge)
-  (modules test_rfc_0085_pr11_deprecation_purge)
-  (libraries alcotest ast_grep)
-  (deps
-   (source_tree ../lib)
-   (source_tree ../bin)))
+ (name test_rfc_0085_pr11_deprecation_purge)
+ (modules test_rfc_0085_pr11_deprecation_purge)
+ (libraries alcotest ast_grep)
+ (deps
+  (source_tree ../lib)
+  (source_tree ../bin)))
 
 ; RFC-0085 PR-10 — home + assets_dir env readers absorbed into
 ; Host_config.t; Env_config_core.assets_dir_opt fully removed,
 ; home_dir_opt demoted to file-private.
 
 (test
-  (name test_rfc_0085_pr10_home_assets_purge)
-  (modules test_rfc_0085_pr10_home_assets_purge)
-  (libraries alcotest ast_grep masc.host_config)
-  (deps
-   (source_tree ../lib)
-   (source_tree ../bin)))
+ (name test_rfc_0085_pr10_home_assets_purge)
+ (modules test_rfc_0085_pr10_home_assets_purge)
+ (libraries alcotest ast_grep masc.host_config)
+ (deps
+  (source_tree ../lib)
+  (source_tree ../bin)))
 
 ; RFC-0085 PR-9 — Env_config_core.base_path_opt + base_path_raw_opt
 ; public-surface purge; 9 caller migrate to Host_config.from_env;
 ; Host_config.t gains base_path (normalised) + base_path_raw fields.
 
 (test
-  (name test_rfc_0085_pr9_base_path_opt_purge)
-  (modules test_rfc_0085_pr9_base_path_opt_purge)
-  (libraries alcotest ast_grep)
-  (deps
-   (source_tree ../lib)
-   (source_tree ../bin)))
+ (name test_rfc_0085_pr9_base_path_opt_purge)
+ (modules test_rfc_0085_pr9_base_path_opt_purge)
+ (libraries alcotest ast_grep)
+ (deps
+  (source_tree ../lib)
+  (source_tree ../bin)))
 
 ; Regression for local-overrotation: Execute / tool_execute must not route
 ; sandbox_profile=local through Docker merely because DockerPlayground is on.

--- a/test/stanzas/test_discord_wss_writer.inc
+++ b/test/stanzas/test_discord_wss_writer.inc
@@ -1,0 +1,10 @@
+(test
+ (name test_discord_wss_writer)
+ (modules test_discord_wss_writer)
+ (libraries
+  alcotest
+  masc.gate
+  masc.masc_log
+  websocket
+  eio
+  mirage-crypto-rng.unix))

--- a/test/test_discord_wss_writer.ml
+++ b/test/test_discord_wss_writer.ml
@@ -1,0 +1,85 @@
+(* Audit T7 — Discord WSS writer fiber death must record its cause.
+
+   [Discord_wss_connection.writer_loop] contains [Eio.Io] on purpose:
+   the writer runs on the per-session switch, so an escaping exception
+   would fail that switch and tear down the whole gateway client.
+   Before this fix the handler was [Eio.Io _ -> ()] and the TLS/WSS
+   write failure cause was dropped.  These tests pin the contract:
+
+   - [Eio.Io] from the flow write (or the queue take) returns instead
+     of raising, and the cause lands in the log ring as a Discord warn
+     entry carrying the exception text.
+   - Non-[Eio.Io] exceptions still propagate (no silent catch-all). *)
+
+open Alcotest
+
+type Eio.Exn.Backend.t += Simulated_failure
+
+let io_exn () =
+  Eio.Net.err (Eio.Net.Connection_reset Simulated_failure)
+
+let contains_substring haystack needle =
+  let n = String.length haystack and m = String.length needle in
+  let rec go i = i + m <= n && (String.sub haystack i m = needle || go (i + 1)) in
+  go 0
+
+(* [Ring.recent ~since_seq:n] returns entries with seq > n, and the
+   first entry ever pushed has seq 0 — so the empty-ring sentinel must
+   be -1, not 0. *)
+let last_ring_seq () =
+  match Log.Ring.recent ~limit:1 () with
+  | [] -> -1
+  | e :: _ -> e.Log.Ring.seq
+
+let writer_warn_entries ~since_seq =
+  Log.Ring.recent ~module_filter:"Discord" ~since_seq ()
+  |> List.filter (fun (e : Log.Ring.entry) ->
+       e.level = Log.Warn
+       && contains_substring e.message "wss writer fiber terminated")
+
+(* The realistic T7 path: a frame is dequeued and encoded, then the TLS
+   write raises [Eio.Io].  The loop must return (containment) and the
+   cause must be visible in the log ring. *)
+let test_flow_write_io_contained_and_logged () =
+  Mirage_crypto_rng_unix.use_default ();
+  let seq_before = last_ring_seq () in
+  let takes = ref 0 in
+  let frame = Websocket.Frame.create ~content:"heartbeat" () in
+  Discord_wss_connection.writer_loop
+    ~take:(fun () -> incr takes; frame)
+    ~write_string:(fun _ -> raise (io_exn ()));
+  check int "writer stopped after the failed write" 1 !takes;
+  match writer_warn_entries ~since_seq:seq_before with
+  | [] -> fail "no Discord warn entry recorded for writer death"
+  | e :: _ ->
+    check bool "warn message carries the exception text" true
+      (contains_substring e.Log.Ring.message "Connection_reset")
+
+(* [Eio.Io] raised by the queue take is contained the same way. *)
+let test_take_io_contained_and_logged () =
+  let seq_before = last_ring_seq () in
+  Discord_wss_connection.writer_loop
+    ~take:(fun () -> raise (io_exn ()))
+    ~write_string:(fun _ -> ());
+  check bool "Discord warn entry recorded" true
+    (writer_warn_entries ~since_seq:seq_before <> [])
+
+(* Anything that is not [Eio.Io] must escape — the handler is not a
+   catch-all. *)
+let test_non_io_propagates () =
+  check_raises "non-Io exception escapes" (Failure "boom") (fun () ->
+    Discord_wss_connection.writer_loop
+      ~take:(fun () -> failwith "boom")
+      ~write_string:(fun _ -> ()))
+
+let () =
+  run "discord_wss_writer"
+    [ ( "writer_loop containment",
+        [ test_case "flow write Eio.Io is contained and logged" `Quick
+            test_flow_write_io_contained_and_logged
+        ; test_case "queue take Eio.Io is contained and logged" `Quick
+            test_take_io_contained_and_logged
+        ; test_case "non-Io exception propagates" `Quick
+            test_non_io_propagates
+        ] )
+    ]


### PR DESCRIPTION
## 목표
Discord WSS writer fiber가 `| Eio.Io _ -> ()`로 종료해 TLS/WSS 쓰기 실패 원인을 완전히 유실하는 문제(감사 T7, `lib/gate/discord_wss_connection.ml:142-153`)를 해결한다.

## 변경
- `writer_loop`를 테스트 가능한 함수로 추출 (`.mli` 노출)
- `Eio.Io`는 계속 봉인하되, 원인을 warn 레벨로 기록 (drop 대신)
- `Eio.Cancel.Cancelled`는 의도적으로 잡지 않음 — switch teardown은 writer를 조용히 취소해야 함
- `test/test_discord_wss_writer.ml`: `Eio.Io` 봉인 + 원인이 log ring에 기록, 비-Io 예외는 전파

## 왜 봉인을 유지하는가 (트레이드오프)
writer는 per-session switch에서 실행되므로 예외가 빠져나가면 그 switch가 실패하고 gateway client 전체가 무너진다(`connect`의 outer fork). 연결 실패 *처리*(재연결)는 이미 reader path에 존재한다: `Wss_closed -> Op_reconnect` (`discord_gateway_state.ml:819,839,1120`) + heartbeat ACK timeout. 따라서 writer는 예외를 전파해선 안 되고, 유실됐던 건 *진단*뿐이다.

## 검증
- `dune build --root . @check` exit 0
- `test_discord_wss_writer.exe` 3/3 통과
- `bin/main_eio.exe` exit 0

WORKAROUND-WAIVED: "make X visible" 시그니처에 해당하나 마스킹되는 unhandled failure가 없다. 연결 실패 처리(재연결)는 reader path(Wss_closed→Op_reconnect, discord_gateway_state.ml:819,839,1120)에 이미 존재하며 검증됨. 이 PR은 유실된 진단만 복원하고, writer death는 unfixed data loss가 아니다.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
