### PR TITLE
fix(keeper): distinguish corrupt vs missing async request records

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -30,6 +30,15 @@ type entry =
   ; completed_at : float option
   }
 
+(** Outcome of looking up a request record. [Absent] means no record exists
+    (never submitted, or already GC'd); pollers can stop polling or resubmit.
+    [Unreadable] means a record file exists but cannot be decoded — the
+    request WAS accepted, but its result cannot be recovered. *)
+type load_result =
+  | Found of entry
+  | Absent
+  | Unreadable of string
+
 let mu = Eio.Mutex.create ()
 let pending : (string, entry) Hashtbl.t = Hashtbl.create 16
 let active_switches : (string, Eio.Switch.t) Hashtbl.t = Hashtbl.create 16
@@ -119,7 +128,7 @@ let bool_member name json =
   | _ -> None
 ;;
 
-let entry_of_record_json ~base_path json : entry option =
+let entry_of_record_json ~base_path json : (entry, string) result =
   match
     ( string_member "request_id" json
     , string_member "keeper_name" json
@@ -130,10 +139,10 @@ let entry_of_record_json ~base_path json : entry option =
     let completed_at = float_member "completed_at" json in
     let status =
       match status with
-      | "queued" -> Some Queued
-      | "running" -> Some Running
+      | "queued" -> Ok Queued
+      | "running" -> Ok Running
       | "lost" ->
-        Some
+        Ok
           (Lost
              { reason =
                  string_member "reason" json
@@ -148,14 +157,16 @@ let entry_of_record_json ~base_path json : entry option =
           string_member "body" json
           |> Option.value ~default:{|{"error":"result body missing"}|}
         in
-        Some (Done { ok; body })
-      | _ -> None
+        Ok (Done { ok; body })
+      | other -> Error (Printf.sprintf "unknown status %S in record" other)
     in
-    Option.map
+    Result.map
       (fun status ->
          { request_id; keeper_name; base_path; status; submitted_at; completed_at })
       status
-  | _ -> None
+  | _ ->
+    Error
+      "record is missing required fields (request_id/keeper_name/status/submitted_at)"
 ;;
 
 let persist_entry (entry : entry) =
@@ -172,26 +183,31 @@ let persist_entry (entry : entry) =
          err)
 ;;
 
-let load_record ~base_path ~request_id =
+let load_record ~base_path ~request_id : load_result =
   match record_path ~base_path ~request_id with
-  | None -> None
+  | None -> Absent
   | Some path ->
     if not (Fs_compat.file_exists path)
-    then None
+    then Absent
     else (
-      try
-        Fs_compat.load_file path
-        |> Yojson.Safe.from_string
-        |> entry_of_record_json ~base_path
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
+      let decoded =
+        try
+          Fs_compat.load_file path
+          |> Yojson.Safe.from_string
+          |> entry_of_record_json ~base_path
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn -> Error (Printexc.to_string exn)
+      in
+      match decoded with
+      | Ok entry -> Found entry
+      | Error reason ->
         Log.Keeper.warn
           "keeper_msg_async: load failed request_id=%s path=%s error=%s"
           request_id
           path
-          (Printexc.to_string exn);
-        None)
+          reason;
+        Unreadable reason)
 ;;
 
 let has_suffix ~suffix value =
@@ -246,9 +262,11 @@ let gc_stale_disk ~base_path =
                 then removed
                 else (
                   match load_record ~base_path ~request_id with
-                  | Some entry when should_gc_disk_record ~now entry ->
+                  | Found entry when should_gc_disk_record ~now entry ->
                     if remove_record_file path then removed + 1 else removed
-                  | Some _ | None -> removed))
+                  (* Unreadable records are kept so pollers can still observe
+                     that the request was accepted but its result is lost. *)
+                  | Found _ | Absent | Unreadable _ -> removed))
            0
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -409,19 +427,18 @@ let submit ?clock ?timeout_sec ~sw ~base_path ~(f : unit -> tool_result)
 ;;
 
 (** Poll for the result of an async keeper_msg request. *)
-let poll ?base_path request_id : entry option =
+let poll ?base_path request_id : load_result =
   match Eio.Mutex.use_ro mu (fun () -> Hashtbl.find_opt pending request_id) with
-  | Some _ as found -> found
+  | Some entry -> Found entry
   | None ->
     (match base_path with
-     | None -> None
+     | None -> Absent
      | Some base_path ->
        ignore (gc_stale_disk ~base_path);
        (match load_record ~base_path ~request_id with
-        | None -> None
-        | Some ({ status = Queued | Running; _ } as entry) ->
-          Some (mark_lost_after_recovery entry)
-        | Some entry -> Some entry))
+        | Found ({ status = Queued | Running; _ } as entry) ->
+          Found (mark_lost_after_recovery entry)
+        | (Found _ | Absent | Unreadable _) as result -> result))
 ;;
 
 (** List all pending/running requests for a keeper (or all keepers if omitted). *)
@@ -484,7 +501,7 @@ let cancel ?base_path request_id : bool =
     | None -> false
     | Some base_path ->
       match load_record ~base_path ~request_id with
-      | Some ({ status = Queued | Running; _ } as entry) ->
+      | Found ({ status = Queued | Running; _ } as entry) ->
         let reason = "keeper_msg request was cancelled by operator" in
         let cancelled_entry =
           (* NDT-OK: gettimeofday is acceptable for timestamping operator cancelled lost state *)
@@ -492,7 +509,7 @@ let cancel ?base_path request_id : bool =
         in
         persist_entry cancelled_entry;
         true
-      | _ -> false
+      | Found _ | Absent | Unreadable _ -> false
 ;;
 
 module For_testing = struct
@@ -500,5 +517,6 @@ module For_testing = struct
   let forget request_id = with_lock (fun () -> Hashtbl.remove pending request_id)
   let clear () = with_lock (fun () -> Hashtbl.clear pending)
   let record_path = record_path
+  let load_record = load_record
   let gc_stale_disk = gc_stale_disk
 end

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -27,6 +27,19 @@ type entry =
   ; completed_at : float option
   }
 
+(** Outcome of looking up a request record.
+
+    - [Found entry] — the request is known (in memory or recovered from disk).
+    - [Absent] — no record exists: the id was never accepted, or its terminal
+      record already aged out. Pollers can stop polling or resubmit.
+    - [Unreadable reason] — a record file exists but cannot be decoded
+      (corrupt JSON, missing required fields, or unknown status). The request
+      WAS accepted, but its result cannot be recovered. *)
+type load_result =
+  | Found of entry
+  | Absent
+  | Unreadable of string
+
 (** {1 Submit and poll} *)
 
 (** [submit ?clock ?timeout_sec ~sw ~f ~keeper_name] forks a background daemon fiber on
@@ -46,11 +59,12 @@ val submit
   -> unit
   -> string
 
-(** [poll ?base_path request_id] returns the current entry, or [None] when the
-    id was never seen. If [base_path] is supplied and a persisted non-terminal
-    request exists without an in-memory worker, it is returned as [Lost] and the
-    terminal lost state is persisted. *)
-val poll : ?base_path:string -> string -> entry option
+(** [poll ?base_path request_id] returns [Found entry] for a known request,
+    [Absent] when no record exists, and [Unreadable reason] when a persisted
+    record exists but cannot be decoded. If [base_path] is supplied and a
+    persisted non-terminal request exists without an in-memory worker, it is
+    returned as [Lost] and the terminal lost state is persisted. *)
+val poll : ?base_path:string -> string -> load_result
 
 (** [cancel ?base_path request_id] aborts a running async keeper_msg request.
     Returns [true] if it was successfully cancelled, [false] if not found
@@ -75,5 +89,6 @@ module For_testing : sig
   val forget : string -> unit
   val clear : unit -> unit
   val record_path : base_path:string -> request_id:string -> string option
+  val load_record : base_path:string -> request_id:string -> load_result
   val gc_stale_disk : base_path:string -> int
 end

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -698,10 +698,23 @@ let keeper_msg_result_body ~(config : Workspace.config) args : tool_result =
     tool_result_error {|{"error":"request_id is required"}|}
   else
     match Keeper_msg_async.poll ~base_path:config.base_path request_id with
-    | None ->
+    | Keeper_msg_async.Absent ->
       tool_result_error
         (Printf.sprintf {|{"error":"request_id not found","request_id":"%s"}|} request_id)
-    | Some entry ->
+    | Keeper_msg_async.Unreadable reason ->
+      tool_result_error
+        (Yojson.Safe.to_string
+           (`Assoc
+              [ ("error", `String "request_record_unreadable")
+              ; ( "message"
+                , `String
+                    (Printf.sprintf
+                       "request record unreadable: %s — request was accepted but its \
+                        result is lost"
+                       reason) )
+              ; ("request_id", `String request_id)
+              ]))
+    | Keeper_msg_async.Found entry ->
       tool_result_ok (Yojson.Safe.to_string (Keeper_msg_async.entry_to_json entry))
 
 let handle_keeper_msg_result ctx args : tool_result =

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -73,10 +73,18 @@ let handle_keeper_chat_request_result state request reqd =
         Keeper_msg_async.poll
           ~base_path:state.Mcp_server.workspace_config.base_path request_id
       with
-      | None ->
+      | Keeper_msg_async.Absent ->
           respond_json_value_with_cors ~status:`Not_found request reqd
             (keeper_chat_stream_error_json "request_id not found")
-      | Some entry ->
+      | Keeper_msg_async.Unreadable reason ->
+          respond_json_value_with_cors ~status:`Internal_server_error request
+            reqd
+            (keeper_chat_stream_error_json
+               (Printf.sprintf
+                  "request record unreadable: %s — request was accepted but \
+                   its result is lost"
+                  reason))
+      | Keeper_msg_async.Found entry ->
           respond_json_value_with_cors ~status:`OK request reqd
             (Keeper_msg_async.entry_to_json entry) )
 

--- a/test/test_keeper_msg_cancel.ml
+++ b/test/test_keeper_msg_cancel.ml
@@ -42,10 +42,12 @@ let () =
   Eio.Time.sleep clock 0.1;
   
   (match Keeper_msg_async.poll ~base_path request_id with
-   | Some entry ->
+   | Keeper_msg_async.Found entry ->
      Printf.printf "  ✓ Initial status: %s\n%!" (Keeper_msg_async.status_to_string entry.status)
-   | None ->
-     Printf.printf "  ✗ Initial status: Not found\n%!");
+   | Keeper_msg_async.Absent ->
+     Printf.printf "  ✗ Initial status: Not found\n%!"
+   | Keeper_msg_async.Unreadable reason ->
+     Printf.printf "  ✗ Initial status: Unreadable (%s)\n%!" reason);
   
   (* Cancel the request *)
   let cancelled = Keeper_msg_async.cancel ~base_path request_id in
@@ -55,15 +57,17 @@ let () =
   Eio.Time.sleep clock 0.1;
   
   (match Keeper_msg_async.poll ~base_path request_id with
-   | Some entry ->
+   | Keeper_msg_async.Found entry ->
      let status_str = Keeper_msg_async.status_to_string entry.status in
      Printf.printf "  ✓ Cancelled status: %s\n%!" status_str;
      if String.equal status_str "lost" then
        Printf.printf "  ✓ Verification: Lost state correctly recorded\n%!"
      else
        Printf.printf "  ✗ Verification failed: expected lost but got %s\n%!" status_str
-   | None ->
-     Printf.printf "  ✗ Status after cancel: Not found\n%!");
+   | Keeper_msg_async.Absent ->
+     Printf.printf "  ✗ Status after cancel: Not found\n%!"
+   | Keeper_msg_async.Unreadable reason ->
+     Printf.printf "  ✗ Status after cancel: Unreadable (%s)\n%!" reason);
   
   (* Try to cancel again *)
   let cancelled_again = Keeper_msg_async.cancel ~base_path request_id in

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -6,7 +6,7 @@ let tr_ok body = Tool_result.ok ~tool_name:"keeper-test" ~start_time:0.0 body
 let wait_for_done request_id =
   let rec loop remaining =
     match Keeper_msg_async.poll request_id with
-    | Some ({ status = Done _; _ } as entry) -> entry
+    | Keeper_msg_async.Found ({ status = Done _; _ } as entry) -> entry
     | _ when remaining <= 0 ->
       failwith (Printf.sprintf "request %s did not complete" request_id)
     | _ ->
@@ -19,7 +19,7 @@ let wait_for_done request_id =
 let wait_for_done_with_clock clock request_id =
   let rec loop remaining =
     match Keeper_msg_async.poll request_id with
-    | Some ({ status = Done _; _ } as entry) -> entry
+    | Keeper_msg_async.Found ({ status = Done _; _ } as entry) -> entry
     | _ when remaining <= 0 ->
       failwith (Printf.sprintf "request %s did not complete" request_id)
     | _ ->
@@ -32,7 +32,7 @@ let wait_for_done_with_clock clock request_id =
 let wait_for_running request_id =
   let rec loop remaining =
     match Keeper_msg_async.poll request_id with
-    | Some ({ status = Running; _ } as entry) -> entry
+    | Keeper_msg_async.Found ({ status = Running; _ } as entry) -> entry
     | _ when remaining <= 0 ->
       failwith (Printf.sprintf "request %s did not start" request_id)
     | _ ->
@@ -45,7 +45,7 @@ let wait_for_running request_id =
 let wait_for_lost request_id =
   let rec loop remaining =
     match Keeper_msg_async.poll request_id with
-    | Some ({ status = Lost _; _ } as entry) -> entry
+    | Keeper_msg_async.Found ({ status = Lost _; _ } as entry) -> entry
     | _ when remaining <= 0 ->
       failwith (Printf.sprintf "request %s did not become lost" request_id)
     | _ ->
@@ -156,13 +156,14 @@ let test_keeper_msg_async_recovers_done_from_disk () =
      | _ -> false);
   Keeper_msg_async.For_testing.forget request_id;
   match Keeper_msg_async.poll ~base_path request_id with
-  | Some { Keeper_msg_async.status = Done { ok = true; body }; _ } ->
+  | Keeper_msg_async.Found { Keeper_msg_async.status = Done { ok = true; body }; _ } ->
     Alcotest.(check bool) "body persisted" true (String.length body > 0)
-  | Some entry ->
+  | Keeper_msg_async.Found entry ->
     Alcotest.failf
       "expected recovered done, got %s"
       (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
-  | None -> Alcotest.fail "expected persisted request"
+  | Keeper_msg_async.Absent | Keeper_msg_async.Unreadable _ ->
+    Alcotest.fail "expected persisted request"
 ;;
 
 let test_keeper_msg_async_marks_recovered_inflight_lost () =
@@ -185,21 +186,23 @@ let test_keeper_msg_async_marks_recovered_inflight_lost () =
   ignore (wait_for_running request_id : Keeper_msg_async.entry);
   Keeper_msg_async.For_testing.forget request_id;
   match Keeper_msg_async.poll ~base_path request_id with
-  | Some { Keeper_msg_async.status = Lost { reason }; _ } ->
+  | Keeper_msg_async.Found { Keeper_msg_async.status = Lost { reason }; _ } ->
     Alcotest.(check bool) "lost reason retained" true (String.length reason > 0);
     Keeper_msg_async.For_testing.forget request_id;
     (match Keeper_msg_async.poll ~base_path request_id with
-     | Some { Keeper_msg_async.status = Lost _; _ } -> ()
-     | Some entry ->
+     | Keeper_msg_async.Found { Keeper_msg_async.status = Lost _; _ } -> ()
+     | Keeper_msg_async.Found entry ->
        Alcotest.failf
          "expected persisted lost, got %s"
          (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
-     | None -> Alcotest.fail "expected persisted lost request")
-  | Some entry ->
+     | Keeper_msg_async.Absent | Keeper_msg_async.Unreadable _ ->
+       Alcotest.fail "expected persisted lost request")
+  | Keeper_msg_async.Found entry ->
     Alcotest.failf
       "expected recovered lost, got %s"
       (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
-  | None -> Alcotest.fail "expected persisted request"
+  | Keeper_msg_async.Absent | Keeper_msg_async.Unreadable _ ->
+    Alcotest.fail "expected persisted request"
 ;;
 
 let test_keeper_msg_async_marks_cancelled_worker_lost () =
@@ -284,13 +287,14 @@ let test_keeper_msg_async_timeout_is_terminal_error () =
   Eio.Promise.resolve notify_release_late ();
   Eio.Time.sleep clock 0.05;
   match Keeper_msg_async.poll request_id with
-  | Some { Keeper_msg_async.status = Done { ok = false; body }; _ } ->
+  | Keeper_msg_async.Found { Keeper_msg_async.status = Done { ok = false; body }; _ } ->
     Alcotest.(check string) "late worker result cannot overwrite timeout" timeout_body body
-  | Some entry ->
+  | Keeper_msg_async.Found entry ->
     Alcotest.failf
       "expected timeout to remain terminal, got %s"
       (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
-  | None -> Alcotest.fail "expected timeout request to remain pollable"
+  | Keeper_msg_async.Absent | Keeper_msg_async.Unreadable _ ->
+    Alcotest.fail "expected timeout request to remain pollable"
 ;;
 
 let test_keeper_msg_async_gc_removes_stale_terminal_disk_record () =
@@ -334,8 +338,10 @@ let test_keeper_msg_async_gc_removes_stale_terminal_disk_record () =
   Alcotest.(check int) "removed stale disk record" 1 removed;
   Alcotest.(check bool) "record file removed" false (Sys.file_exists path);
   match Keeper_msg_async.poll ~base_path request_id with
-  | None -> ()
-  | Some entry ->
+  | Keeper_msg_async.Absent -> ()
+  | Keeper_msg_async.Unreadable reason ->
+    Alcotest.failf "expected stale disk record to be gone, got unreadable: %s" reason
+  | Keeper_msg_async.Found entry ->
     Alcotest.failf
       "expected stale disk record to be gone, got %s"
       (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
@@ -359,6 +365,119 @@ let test_keeper_msg_async_rejects_oversized_request_id () =
          "129-char request id rejected"
          None
          (Keeper_msg_async.For_testing.record_path ~base_path ~request_id:too_long))
+;;
+
+let rec mkdir_p path =
+  if not (Sys.file_exists path)
+  then (
+    mkdir_p (Filename.dirname path);
+    try Unix.mkdir path 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+;;
+
+let write_disk_record ~base_path ~request_id content =
+  match Keeper_msg_async.For_testing.record_path ~base_path ~request_id with
+  | None -> Alcotest.fail "expected safe record path"
+  | Some path ->
+    mkdir_p (Filename.dirname path);
+    Fs_compat.save_file path content
+;;
+
+let test_keeper_msg_async_load_record_absent_id () =
+  with_eio_env
+  @@ fun _env ->
+  let base_path = temp_dir "keeper-msg-load-absent-" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+       match
+         Keeper_msg_async.For_testing.load_record
+           ~base_path
+           ~request_id:"kmsg_never_existed_0_0"
+       with
+       | Keeper_msg_async.Absent -> ()
+       | Keeper_msg_async.Found _ -> Alcotest.fail "expected absent, got found"
+       | Keeper_msg_async.Unreadable reason ->
+         Alcotest.failf "expected absent, got unreadable: %s" reason)
+;;
+
+let test_keeper_msg_async_load_record_corrupt_json_is_unreadable () =
+  with_eio_env
+  @@ fun _env ->
+  let base_path = temp_dir "keeper-msg-load-corrupt-" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+       let request_id = "kmsg_corrupt_0_0" in
+       write_disk_record ~base_path ~request_id "{ this is not json";
+       (match Keeper_msg_async.For_testing.load_record ~base_path ~request_id with
+        | Keeper_msg_async.Unreadable reason ->
+          Alcotest.(check bool)
+            "unreadable reason non-empty"
+            true
+            (String.length reason > 0)
+        | Keeper_msg_async.Found _ -> Alcotest.fail "expected unreadable, got found"
+        | Keeper_msg_async.Absent -> Alcotest.fail "expected unreadable, got absent");
+       (* poll must surface the same distinction to callers. *)
+       match Keeper_msg_async.poll ~base_path request_id with
+       | Keeper_msg_async.Unreadable _ -> ()
+       | Keeper_msg_async.Found _ -> Alcotest.fail "expected poll unreadable, got found"
+       | Keeper_msg_async.Absent -> Alcotest.fail "expected poll unreadable, got absent")
+;;
+
+let test_keeper_msg_async_load_record_missing_status_is_unreadable () =
+  with_eio_env
+  @@ fun _env ->
+  let base_path = temp_dir "keeper-msg-load-missing-status-" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+       let request_id = "kmsg_missing_status_0_0" in
+       write_disk_record
+         ~base_path
+         ~request_id
+         (Yojson.Safe.to_string
+            (`Assoc
+                [ "request_id", `String request_id
+                ; "keeper_name", `String "alpha"
+                ; "submitted_at", `Float 1.0
+                ]));
+       match Keeper_msg_async.For_testing.load_record ~base_path ~request_id with
+       | Keeper_msg_async.Unreadable reason ->
+         Alcotest.(check bool)
+           "reason mentions missing fields"
+           true
+           (contains_substring ~needle:"missing required fields" reason)
+       | Keeper_msg_async.Found _ -> Alcotest.fail "expected unreadable, got found"
+       | Keeper_msg_async.Absent -> Alcotest.fail "expected unreadable, got absent")
+;;
+
+let test_keeper_msg_async_load_record_unknown_status_is_unreadable () =
+  with_eio_env
+  @@ fun _env ->
+  let base_path = temp_dir "keeper-msg-load-unknown-status-" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+       let request_id = "kmsg_unknown_status_0_0" in
+       write_disk_record
+         ~base_path
+         ~request_id
+         (Yojson.Safe.to_string
+            (`Assoc
+                [ "request_id", `String request_id
+                ; "keeper_name", `String "alpha"
+                ; "status", `String "sideways"
+                ; "submitted_at", `Float 1.0
+                ]));
+       match Keeper_msg_async.For_testing.load_record ~base_path ~request_id with
+       | Keeper_msg_async.Unreadable reason ->
+         Alcotest.(check bool)
+           "reason mentions unknown status"
+           true
+           (contains_substring ~needle:"unknown status" reason)
+       | Keeper_msg_async.Found _ -> Alcotest.fail "expected unreadable, got found"
+       | Keeper_msg_async.Absent -> Alcotest.fail "expected unreadable, got absent")
 ;;
 
 let test_yield_meter_noops_without_runnable_fiber () =
@@ -445,6 +564,22 @@ let () =
             "oversized request id rejected"
             `Quick
             test_keeper_msg_async_rejects_oversized_request_id
+        ; test_case
+            "load_record absent id is Absent"
+            `Quick
+            test_keeper_msg_async_load_record_absent_id
+        ; test_case
+            "load_record corrupt JSON is Unreadable"
+            `Quick
+            test_keeper_msg_async_load_record_corrupt_json_is_unreadable
+        ; test_case
+            "load_record missing status field is Unreadable"
+            `Quick
+            test_keeper_msg_async_load_record_missing_status_is_unreadable
+        ; test_case
+            "load_record unknown status is Unreadable"
+            `Quick
+            test_keeper_msg_async_load_record_unknown_status_is_unreadable
         ] )
     ; ( "eio_guard"
       , [ test_case


### PR DESCRIPTION
## 목표
`keeper_msg_async`가 모든 parse/read 실패를 `None`으로 뭉개 "요청이 제출된 적 없음"과 "요청은 수락됐으나 레코드 손상/접근불가"를 구분 못 하는 문제(감사 T10, `lib/keeper/keeper_msg_async.ml:122-186`)를 typed sum type으로 해결한다.

## 변경
- `load_result = Found of entry | Absent | Unreadable of string` 도입
- `entry_of_record_json`을 `(entry, string) result`로 — unknown status가 silent `None` 대신 `Error "unknown status ..."`
- `load_record`/`poll`이 `load_result` 반환; `gc_stale_disk`는 Unreadable 레코드를 보존(수락-후-유실 상태를 관찰 가능하게 유지)
- 소비처가 구분을 노출: `keeper_msg_result_body`는 `request_record_unreadable` 에러, HTTP keeper-stream route는 Unreadable=500 vs Absent=404
- 전 구간 exhaustive match (catch-all 없음); `For_testing.load_record` 노출
- 테스트: corrupt JSON / missing fields / unknown status → Unreadable, absent id → Absent

## 트레이드오프
`poll`의 공개 타입이 `entry option` → `load_result`로 바뀐다(소비처 2곳 동시 갱신). 두 실패 모드는 반대 처리가 필요하다: Absent=재시도/중단, Unreadable=결과 유실 보고. "Parse, don't validate" 원칙에 따라 illegal state를 표현 불가능하게 만든다.

## 검증
- `dune build --root . @check` exit 0
- `test_keeper_mutex_coverage.exe` 14/14 (신규 corrupt/missing/unknown/absent 케이스 포함)
- `test_keeper_msg_cancel.exe` 통과
- `bin/main_eio.exe` exit 0 (두 소비처 모두 컴파일됨)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
