### PR TITLE
fix(keeper): surface fleet blockers and materialize declarative goals

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -40,12 +40,36 @@ type boot_meta_resolution = {
   materialized : bool;
 }
 
+type boot_meta_failure_reason =
+  | Goal_required
+  | Sandbox_profile_required
+  | Config_parse_failed
+  | Invalid_profile
+  | Missing_meta
+  | Meta_read_error
+  | Bootstrap_failed
+
+let boot_meta_failure_reason_to_string = function
+  | Goal_required -> "goal_required"
+  | Sandbox_profile_required -> "sandbox_profile_required"
+  | Config_parse_failed -> "config_parse_failed"
+  | Invalid_profile -> "invalid_profile"
+  | Missing_meta -> "missing_meta"
+  | Meta_read_error -> "meta_read_error"
+  | Bootstrap_failed -> "bootstrap_failed"
+
 type boot_meta_failure = {
   keeper_name : string;
   base_path : string;
+  reason : boot_meta_failure_reason;
   error : string;
   recorded_at : string;
   recorded_at_unix : float;
+}
+
+type boot_meta_error = {
+  reason : boot_meta_failure_reason;
+  message : string;
 }
 
 let boot_meta_failures : (string, boot_meta_failure) Hashtbl.t =
@@ -58,11 +82,12 @@ let with_boot_meta_failures_lock f =
   Stdlib.Mutex.lock boot_meta_failures_mu;
   Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock boot_meta_failures_mu) f
 
-let record_boot_meta_failure ~base_path ~name ~error =
+let record_boot_meta_failure ~base_path ~name ~reason ~error =
   let failure =
     {
       keeper_name = name;
       base_path;
+      reason;
       error;
       recorded_at = now_iso ();
       recorded_at_unix = Time_compat.now ();
@@ -94,15 +119,17 @@ let boot_meta_failure_for ~base_path ~name =
       Hashtbl.find_opt boot_meta_failures
         (boot_meta_failure_key ~base_path ~name))
 
+let boot_meta_error reason message = { reason; message }
+
 let remember_boot_meta_result ctx name result =
   let base_path = ctx.config.base_path in
   match result with
   | Ok value ->
       clear_boot_meta_failure ~base_path ~name;
       Ok value
-  | Error error ->
-      record_boot_meta_failure ~base_path ~name ~error;
-      Error error
+  | Error { reason; message } ->
+      record_boot_meta_failure ~base_path ~name ~reason ~error:message;
+      Error message
 
 type autoboot_exclusion = {
   keeper_name : string;
@@ -211,6 +238,32 @@ let declarative_materialization_goal
       defaults.will;
       defaults.instructions;
     ]
+
+let profile_defaults_failure_reason name =
+  match keeper_toml_config_error_for_name name with
+  | Some _ -> Config_parse_failed
+  | None -> Invalid_profile
+
+let ensure_keeper_meta_failure_reason config name =
+  match read_meta config name with
+  | Ok None -> Missing_meta
+  | Error _ -> Meta_read_error
+  | Ok (Some _) -> (
+      match load_keeper_profile_defaults_result name with
+      | Error _ -> profile_defaults_failure_reason name
+      | Ok defaults ->
+          if Option.is_none defaults.sandbox_profile then Sandbox_profile_required
+          else Bootstrap_failed)
+
+let materialization_failure_reason name =
+  match load_keeper_profile_defaults_result name with
+  | Error _ -> profile_defaults_failure_reason name
+  | Ok defaults ->
+      if Option.is_none defaults.sandbox_profile then Sandbox_profile_required
+      else
+        match declarative_materialization_goal defaults with
+        | None -> Goal_required
+        | Some _ -> Bootstrap_failed
 
 let invalid_profile_defaults_error ~keeper_name detail =
   if String_util.contains_substring detail "runtime_id" then
@@ -451,8 +504,11 @@ let load_or_materialize_boot_meta (ctx : _ context) name
     match ensure_keeper_meta ctx.config name with
     | Ok meta -> Ok { meta; materialized = false }
     | Error original_error -> (
+        let ensure_failure_reason =
+          ensure_keeper_meta_failure_reason ctx.config name
+        in
         match Config_dir_resolver.keeper_toml_path_opt name with
-        | None -> Error original_error
+        | None -> Error (boot_meta_error ensure_failure_reason original_error)
         | Some toml_path ->
             Log.Keeper.info
               "bootstrapping declarative keeper %s from %s"
@@ -463,29 +519,37 @@ let load_or_materialize_boot_meta (ctx : _ context) name
             in
             if not (tool_result_success result) then
               Error
-                (Printf.sprintf
-                   "failed to materialize declarative keeper %s from %s: %s"
-                   name toml_path (tool_result_body result))
+                (boot_meta_error
+                   (materialization_failure_reason name)
+                   (Printf.sprintf
+                      "failed to materialize declarative keeper %s from %s: %s"
+                      name toml_path (tool_result_body result)))
             else
               match read_meta ctx.config name with
               | Ok None ->
                   Error
-                    (Printf.sprintf
-                       "materialized declarative keeper %s from %s but no meta was written"
-                       name toml_path)
+                    (boot_meta_error
+                       Missing_meta
+                       (Printf.sprintf
+                          "materialized declarative keeper %s from %s but no meta was written"
+                          name toml_path))
               | Error msg ->
                   Error
-                    (Printf.sprintf
-                       "materialized declarative keeper %s from %s but failed to reload meta: %s"
-                       name toml_path msg)
+                    (boot_meta_error
+                       Meta_read_error
+                       (Printf.sprintf
+                          "materialized declarative keeper %s from %s but failed to reload meta: %s"
+                          name toml_path msg))
               | Ok (Some _) -> (
                   match ensure_keeper_meta ctx.config name with
                   | Ok meta -> Ok { meta; materialized = true }
                   | Error msg ->
                       Error
-                        (Printf.sprintf
-                           "materialized declarative keeper %s from %s but failed to reload meta: %s"
-                           name toml_path msg)))
+                        (boot_meta_error
+                           (ensure_keeper_meta_failure_reason ctx.config name)
+                           (Printf.sprintf
+                              "materialized declarative keeper %s from %s but failed to reload meta: %s"
+                              name toml_path msg))))
   in
   remember_boot_meta_result ctx name result
 

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -40,6 +40,87 @@ type boot_meta_resolution = {
   materialized : bool;
 }
 
+type boot_meta_failure = {
+  keeper_name : string;
+  base_path : string;
+  reason : string;
+  error : string;
+  recorded_at : string;
+  recorded_at_unix : float;
+}
+
+let boot_meta_failures : (string, boot_meta_failure) Hashtbl.t =
+  Hashtbl.create 32
+let boot_meta_failures_mu = Stdlib.Mutex.create ()
+
+let boot_meta_failure_key ~base_path ~name = base_path ^ "\000" ^ name
+
+let with_boot_meta_failures_lock f =
+  Stdlib.Mutex.lock boot_meta_failures_mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock boot_meta_failures_mu) f
+
+let boot_meta_failure_reason (error : string) : string =
+  let error_lc = String.lowercase_ascii error in
+  let contains needle = String_util.contains_substring error_lc needle in
+  if contains "goal is required" then "goal_required"
+  else if contains "sandbox_profile is required" then "sandbox_profile_required"
+  else if contains "allowed_paths" then "sandbox_settings_invalid"
+  else if contains "preflight" then "sandbox_preflight_failed"
+  else if contains "max active keepers" || contains "max active reached" then
+    "keeper_capacity_limit"
+  else if contains "invalid keeper profile" || contains "invalid profile.runtime_id" then
+    "invalid_profile"
+  else if contains "parse" || contains "syntax" then "config_parse_failed"
+  else if contains "no persistent meta" then "missing_meta"
+  else "bootstrap_failed"
+
+let record_boot_meta_failure ~base_path ~name ~error =
+  let failure =
+    {
+      keeper_name = name;
+      base_path;
+      reason = boot_meta_failure_reason error;
+      error;
+      recorded_at = now_iso ();
+      recorded_at_unix = Time_compat.now ();
+    }
+  in
+  with_boot_meta_failures_lock (fun () ->
+      Hashtbl.replace boot_meta_failures
+        (boot_meta_failure_key ~base_path ~name)
+        failure)
+
+let clear_boot_meta_failure ~base_path ~name =
+  with_boot_meta_failures_lock (fun () ->
+      Hashtbl.remove boot_meta_failures
+        (boot_meta_failure_key ~base_path ~name))
+
+let clear_boot_meta_failures_for_base_path base_path =
+  with_boot_meta_failures_lock (fun () ->
+      let keys =
+        Hashtbl.fold
+          (fun key (failure : boot_meta_failure) acc ->
+            if String.equal failure.base_path base_path then key :: acc else acc)
+          boot_meta_failures
+          []
+      in
+      List.iter (Hashtbl.remove boot_meta_failures) keys)
+
+let boot_meta_failure_for ~base_path ~name =
+  with_boot_meta_failures_lock (fun () ->
+      Hashtbl.find_opt boot_meta_failures
+        (boot_meta_failure_key ~base_path ~name))
+
+let remember_boot_meta_result ctx name result =
+  let base_path = ctx.config.base_path in
+  match result with
+  | Ok _ ->
+      clear_boot_meta_failure ~base_path ~name;
+      result
+  | Error error ->
+      record_boot_meta_failure ~base_path ~name ~error;
+      result
+
 type autoboot_exclusion = {
   keeper_name : string;
   reason : string;
@@ -128,6 +209,25 @@ let apply_default opt current = match opt with Some v -> v | None -> current
 (** Same as [apply_default] but both TOML and meta are option-typed. *)
 let apply_default_opt opt current = match opt with Some _ -> opt | None -> current
 
+let first_non_empty_goal_candidate candidates =
+  candidates
+  |> List.find_map (function
+       | None -> None
+       | Some raw ->
+         let value = normalize_goal_horizon_text raw in
+         if value = "" then None else Some value)
+
+let declarative_materialization_goal
+    (defaults : Keeper_types_profile.keeper_profile_defaults) =
+  first_non_empty_goal_candidate
+    [
+      defaults.goal;
+      defaults.short_goal;
+      defaults.mid_goal;
+      defaults.long_goal;
+      defaults.will;
+      defaults.instructions;
+    ]
 
 let invalid_profile_defaults_error ~keeper_name detail =
   if String_util.contains_substring detail "runtime_id" then
@@ -185,7 +285,17 @@ let ensure_keeper_meta config name =
       apply_default defaults.social_model meta.social_model
       |> Keeper_social_model.normalize_social_model in
     (* --- Personality --- *)
-    let target_goal = apply_default defaults.goal meta.goal in
+    let target_goal =
+      match defaults.goal with
+      | Some goal -> goal
+      | None -> (
+          match normalize_goal_horizon_text meta.goal with
+          | "" -> (
+              match declarative_materialization_goal defaults with
+              | Some derived -> derived
+              | None -> meta.goal)
+          | normalized -> normalized)
+    in
     let target_short_goal = apply_default defaults.short_goal meta.short_goal in
     let target_mid_goal = apply_default defaults.mid_goal meta.mid_goal in
     let target_long_goal = apply_default defaults.long_goal meta.long_goal in
@@ -336,39 +446,58 @@ let ensure_keeper_meta config name =
     Error (Printf.sprintf "no persistent meta for %s — run keeper_up to initialize" name)
   | Error msg -> Error msg
 
+let declarative_materialization_args name =
+  let fields = [ ("name", `String name) ] in
+  let fields =
+    match load_keeper_profile_defaults_result name with
+    | Error _ -> fields
+    | Ok defaults -> (
+        match declarative_materialization_goal defaults with
+        | None -> fields
+        | Some goal ->
+            Log.Keeper.info
+              "bootstrapping declarative keeper %s with derived goal from TOML defaults"
+              name;
+            ("goal", `String goal) :: fields)
+  in
+  `Assoc (List.rev fields)
+
 let load_or_materialize_boot_meta (ctx : _ context) name
     : (boot_meta_resolution, string) result =
-  match ensure_keeper_meta ctx.config name with
-  | Ok meta -> Ok { meta; materialized = false }
-  | Error original_error -> (
-      match Config_dir_resolver.keeper_toml_path_opt name with
-      | None -> Error original_error
-      | Some toml_path ->
-          Log.Keeper.info
-            "bootstrapping declarative keeper %s from %s"
-            name toml_path;
-          let result =
-            Keeper_turn.handle_keeper_up ctx
-              (`Assoc [ ("name", `String name) ])
-          in
-          if not (tool_result_success result) then
-            Error
-              (Printf.sprintf
-                 "failed to materialize declarative keeper %s from %s: %s"
-                 name toml_path (tool_result_body result))
-          else
-            match read_meta ctx.config name with
-            | Ok (Some meta) -> Ok { meta; materialized = true }
-            | Ok None ->
-                Error
-                  (Printf.sprintf
-                     "materialized declarative keeper %s from %s but no meta was written"
-                     name toml_path)
-            | Error msg ->
-                Error
-                  (Printf.sprintf
-                     "materialized declarative keeper %s from %s but failed to reload meta: %s"
-                     name toml_path msg))
+  let result =
+    match ensure_keeper_meta ctx.config name with
+    | Ok meta -> Ok { meta; materialized = false }
+    | Error original_error -> (
+        match Config_dir_resolver.keeper_toml_path_opt name with
+        | None -> Error original_error
+        | Some toml_path ->
+            Log.Keeper.info
+              "bootstrapping declarative keeper %s from %s"
+              name toml_path;
+            let result =
+              Keeper_turn.handle_keeper_up ctx
+                (declarative_materialization_args name)
+            in
+            if not (tool_result_success result) then
+              Error
+                (Printf.sprintf
+                   "failed to materialize declarative keeper %s from %s: %s"
+                   name toml_path (tool_result_body result))
+            else
+              match ensure_keeper_meta ctx.config name with
+              | Ok meta -> Ok { meta; materialized = true }
+              | Error msg when String_util.contains_substring msg "no persistent meta" ->
+                  Error
+                    (Printf.sprintf
+                       "materialized declarative keeper %s from %s but no meta was written"
+                       name toml_path)
+              | Error msg ->
+                  Error
+                    (Printf.sprintf
+                       "materialized declarative keeper %s from %s but failed to reload meta: %s"
+                       name toml_path msg))
+  in
+  remember_boot_meta_result ctx name result
 
 type keeper_bootstrap_stats = {
   scanned: int;
@@ -747,4 +876,5 @@ let stop_keepalive ?base_path name =
 
 let reset_test_state base_path =
   stop_supervisor_sweep base_path;
+  clear_boot_meta_failures_for_base_path base_path;
   Hashtbl.remove existing_keepalive_bootstrap_done base_path

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -40,13 +40,36 @@ type boot_meta_resolution = {
   materialized : bool;
 }
 
+type boot_meta_failure_reason =
+  | Goal_required
+  | Sandbox_profile_required
+  | Config_parse_failed
+  | Invalid_profile
+  | Missing_meta
+  | Meta_read_error
+  | Bootstrap_failed
+
+let boot_meta_failure_reason_to_string = function
+  | Goal_required -> "goal_required"
+  | Sandbox_profile_required -> "sandbox_profile_required"
+  | Config_parse_failed -> "config_parse_failed"
+  | Invalid_profile -> "invalid_profile"
+  | Missing_meta -> "missing_meta"
+  | Meta_read_error -> "meta_read_error"
+  | Bootstrap_failed -> "bootstrap_failed"
+
 type boot_meta_failure = {
   keeper_name : string;
   base_path : string;
-  reason : string;
+  reason : boot_meta_failure_reason;
   error : string;
   recorded_at : string;
   recorded_at_unix : float;
+}
+
+type boot_meta_error = {
+  reason : boot_meta_failure_reason;
+  message : string;
 }
 
 let boot_meta_failures : (string, boot_meta_failure) Hashtbl.t =
@@ -59,27 +82,12 @@ let with_boot_meta_failures_lock f =
   Stdlib.Mutex.lock boot_meta_failures_mu;
   Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock boot_meta_failures_mu) f
 
-let boot_meta_failure_reason (error : string) : string =
-  let error_lc = String.lowercase_ascii error in
-  let contains needle = String_util.contains_substring error_lc needle in
-  if contains "goal is required" then "goal_required"
-  else if contains "sandbox_profile is required" then "sandbox_profile_required"
-  else if contains "allowed_paths" then "sandbox_settings_invalid"
-  else if contains "preflight" then "sandbox_preflight_failed"
-  else if contains "max active keepers" || contains "max active reached" then
-    "keeper_capacity_limit"
-  else if contains "invalid keeper profile" || contains "invalid profile.runtime_id" then
-    "invalid_profile"
-  else if contains "parse" || contains "syntax" then "config_parse_failed"
-  else if contains "no persistent meta" then "missing_meta"
-  else "bootstrap_failed"
-
-let record_boot_meta_failure ~base_path ~name ~error =
+let record_boot_meta_failure ~base_path ~name ~reason ~error =
   let failure =
     {
       keeper_name = name;
       base_path;
-      reason = boot_meta_failure_reason error;
+      reason;
       error;
       recorded_at = now_iso ();
       recorded_at_unix = Time_compat.now ();
@@ -111,15 +119,17 @@ let boot_meta_failure_for ~base_path ~name =
       Hashtbl.find_opt boot_meta_failures
         (boot_meta_failure_key ~base_path ~name))
 
+let boot_meta_error reason message = { reason; message }
+
 let remember_boot_meta_result ctx name result =
   let base_path = ctx.config.base_path in
   match result with
-  | Ok _ ->
+  | Ok value ->
       clear_boot_meta_failure ~base_path ~name;
-      result
-  | Error error ->
-      record_boot_meta_failure ~base_path ~name ~error;
-      result
+      Ok value
+  | Error { reason; message } ->
+      record_boot_meta_failure ~base_path ~name ~reason ~error:message;
+      Error message
 
 type autoboot_exclusion = {
   keeper_name : string;
@@ -228,6 +238,32 @@ let declarative_materialization_goal
       defaults.will;
       defaults.instructions;
     ]
+
+let profile_defaults_failure_reason name =
+  match keeper_toml_config_error_for_name name with
+  | Some _ -> Config_parse_failed
+  | None -> Invalid_profile
+
+let ensure_keeper_meta_failure_reason config name =
+  match read_meta config name with
+  | Ok None -> Missing_meta
+  | Error _ -> Meta_read_error
+  | Ok (Some _) -> (
+      match load_keeper_profile_defaults_result name with
+      | Error _ -> profile_defaults_failure_reason name
+      | Ok defaults ->
+          if Option.is_none defaults.sandbox_profile then Sandbox_profile_required
+          else Bootstrap_failed)
+
+let materialization_failure_reason name =
+  match load_keeper_profile_defaults_result name with
+  | Error _ -> profile_defaults_failure_reason name
+  | Ok defaults ->
+      if Option.is_none defaults.sandbox_profile then Sandbox_profile_required
+      else
+        match declarative_materialization_goal defaults with
+        | None -> Goal_required
+        | Some _ -> Bootstrap_failed
 
 let invalid_profile_defaults_error ~keeper_name detail =
   if String_util.contains_substring detail "runtime_id" then
@@ -468,8 +504,11 @@ let load_or_materialize_boot_meta (ctx : _ context) name
     match ensure_keeper_meta ctx.config name with
     | Ok meta -> Ok { meta; materialized = false }
     | Error original_error -> (
+        let ensure_failure_reason =
+          ensure_keeper_meta_failure_reason ctx.config name
+        in
         match Config_dir_resolver.keeper_toml_path_opt name with
-        | None -> Error original_error
+        | None -> Error (boot_meta_error ensure_failure_reason original_error)
         | Some toml_path ->
             Log.Keeper.info
               "bootstrapping declarative keeper %s from %s"
@@ -480,22 +519,37 @@ let load_or_materialize_boot_meta (ctx : _ context) name
             in
             if not (tool_result_success result) then
               Error
-                (Printf.sprintf
-                   "failed to materialize declarative keeper %s from %s: %s"
-                   name toml_path (tool_result_body result))
+                (boot_meta_error
+                   (materialization_failure_reason name)
+                   (Printf.sprintf
+                      "failed to materialize declarative keeper %s from %s: %s"
+                      name toml_path (tool_result_body result)))
             else
-              match ensure_keeper_meta ctx.config name with
-              | Ok meta -> Ok { meta; materialized = true }
-              | Error msg when String_util.contains_substring msg "no persistent meta" ->
+              match read_meta ctx.config name with
+              | Ok None ->
                   Error
-                    (Printf.sprintf
-                       "materialized declarative keeper %s from %s but no meta was written"
-                       name toml_path)
+                    (boot_meta_error
+                       Missing_meta
+                       (Printf.sprintf
+                          "materialized declarative keeper %s from %s but no meta was written"
+                          name toml_path))
               | Error msg ->
                   Error
-                    (Printf.sprintf
-                       "materialized declarative keeper %s from %s but failed to reload meta: %s"
-                       name toml_path msg))
+                    (boot_meta_error
+                       Meta_read_error
+                       (Printf.sprintf
+                          "materialized declarative keeper %s from %s but failed to reload meta: %s"
+                          name toml_path msg))
+              | Ok (Some _) -> (
+                  match ensure_keeper_meta ctx.config name with
+                  | Ok meta -> Ok { meta; materialized = true }
+                  | Error msg ->
+                      Error
+                        (boot_meta_error
+                           (ensure_keeper_meta_failure_reason ctx.config name)
+                           (Printf.sprintf
+                              "materialized declarative keeper %s from %s but failed to reload meta: %s"
+                              name toml_path msg))))
   in
   remember_boot_meta_result ctx name result
 

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -40,36 +40,12 @@ type boot_meta_resolution = {
   materialized : bool;
 }
 
-type boot_meta_failure_reason =
-  | Goal_required
-  | Sandbox_profile_required
-  | Config_parse_failed
-  | Invalid_profile
-  | Missing_meta
-  | Meta_read_error
-  | Bootstrap_failed
-
-let boot_meta_failure_reason_to_string = function
-  | Goal_required -> "goal_required"
-  | Sandbox_profile_required -> "sandbox_profile_required"
-  | Config_parse_failed -> "config_parse_failed"
-  | Invalid_profile -> "invalid_profile"
-  | Missing_meta -> "missing_meta"
-  | Meta_read_error -> "meta_read_error"
-  | Bootstrap_failed -> "bootstrap_failed"
-
 type boot_meta_failure = {
   keeper_name : string;
   base_path : string;
-  reason : boot_meta_failure_reason;
   error : string;
   recorded_at : string;
   recorded_at_unix : float;
-}
-
-type boot_meta_error = {
-  reason : boot_meta_failure_reason;
-  message : string;
 }
 
 let boot_meta_failures : (string, boot_meta_failure) Hashtbl.t =
@@ -82,12 +58,11 @@ let with_boot_meta_failures_lock f =
   Stdlib.Mutex.lock boot_meta_failures_mu;
   Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock boot_meta_failures_mu) f
 
-let record_boot_meta_failure ~base_path ~name ~reason ~error =
+let record_boot_meta_failure ~base_path ~name ~error =
   let failure =
     {
       keeper_name = name;
       base_path;
-      reason;
       error;
       recorded_at = now_iso ();
       recorded_at_unix = Time_compat.now ();
@@ -119,17 +94,15 @@ let boot_meta_failure_for ~base_path ~name =
       Hashtbl.find_opt boot_meta_failures
         (boot_meta_failure_key ~base_path ~name))
 
-let boot_meta_error reason message = { reason; message }
-
 let remember_boot_meta_result ctx name result =
   let base_path = ctx.config.base_path in
   match result with
   | Ok value ->
       clear_boot_meta_failure ~base_path ~name;
       Ok value
-  | Error { reason; message } ->
-      record_boot_meta_failure ~base_path ~name ~reason ~error:message;
-      Error message
+  | Error error ->
+      record_boot_meta_failure ~base_path ~name ~error;
+      Error error
 
 type autoboot_exclusion = {
   keeper_name : string;
@@ -238,32 +211,6 @@ let declarative_materialization_goal
       defaults.will;
       defaults.instructions;
     ]
-
-let profile_defaults_failure_reason name =
-  match keeper_toml_config_error_for_name name with
-  | Some _ -> Config_parse_failed
-  | None -> Invalid_profile
-
-let ensure_keeper_meta_failure_reason config name =
-  match read_meta config name with
-  | Ok None -> Missing_meta
-  | Error _ -> Meta_read_error
-  | Ok (Some _) -> (
-      match load_keeper_profile_defaults_result name with
-      | Error _ -> profile_defaults_failure_reason name
-      | Ok defaults ->
-          if Option.is_none defaults.sandbox_profile then Sandbox_profile_required
-          else Bootstrap_failed)
-
-let materialization_failure_reason name =
-  match load_keeper_profile_defaults_result name with
-  | Error _ -> profile_defaults_failure_reason name
-  | Ok defaults ->
-      if Option.is_none defaults.sandbox_profile then Sandbox_profile_required
-      else
-        match declarative_materialization_goal defaults with
-        | None -> Goal_required
-        | Some _ -> Bootstrap_failed
 
 let invalid_profile_defaults_error ~keeper_name detail =
   if String_util.contains_substring detail "runtime_id" then
@@ -504,11 +451,8 @@ let load_or_materialize_boot_meta (ctx : _ context) name
     match ensure_keeper_meta ctx.config name with
     | Ok meta -> Ok { meta; materialized = false }
     | Error original_error -> (
-        let ensure_failure_reason =
-          ensure_keeper_meta_failure_reason ctx.config name
-        in
         match Config_dir_resolver.keeper_toml_path_opt name with
-        | None -> Error (boot_meta_error ensure_failure_reason original_error)
+        | None -> Error original_error
         | Some toml_path ->
             Log.Keeper.info
               "bootstrapping declarative keeper %s from %s"
@@ -519,37 +463,29 @@ let load_or_materialize_boot_meta (ctx : _ context) name
             in
             if not (tool_result_success result) then
               Error
-                (boot_meta_error
-                   (materialization_failure_reason name)
-                   (Printf.sprintf
-                      "failed to materialize declarative keeper %s from %s: %s"
-                      name toml_path (tool_result_body result)))
+                (Printf.sprintf
+                   "failed to materialize declarative keeper %s from %s: %s"
+                   name toml_path (tool_result_body result))
             else
               match read_meta ctx.config name with
               | Ok None ->
                   Error
-                    (boot_meta_error
-                       Missing_meta
-                       (Printf.sprintf
-                          "materialized declarative keeper %s from %s but no meta was written"
-                          name toml_path))
+                    (Printf.sprintf
+                       "materialized declarative keeper %s from %s but no meta was written"
+                       name toml_path)
               | Error msg ->
                   Error
-                    (boot_meta_error
-                       Meta_read_error
-                       (Printf.sprintf
-                          "materialized declarative keeper %s from %s but failed to reload meta: %s"
-                          name toml_path msg))
+                    (Printf.sprintf
+                       "materialized declarative keeper %s from %s but failed to reload meta: %s"
+                       name toml_path msg)
               | Ok (Some _) -> (
                   match ensure_keeper_meta ctx.config name with
                   | Ok meta -> Ok { meta; materialized = true }
                   | Error msg ->
                       Error
-                        (boot_meta_error
-                           (ensure_keeper_meta_failure_reason ctx.config name)
-                           (Printf.sprintf
-                              "materialized declarative keeper %s from %s but failed to reload meta: %s"
-                              name toml_path msg))))
+                        (Printf.sprintf
+                           "materialized declarative keeper %s from %s but failed to reload meta: %s"
+                           name toml_path msg)))
   in
   remember_boot_meta_result ctx name result
 

--- a/lib/keeper/keeper_runtime.mli
+++ b/lib/keeper/keeper_runtime.mli
@@ -41,9 +41,23 @@ type boot_meta_resolution = {
 }
 (** Result of [load_or_materialize_boot_meta]. *)
 
+type boot_meta_failure_reason =
+  | Goal_required
+  | Sandbox_profile_required
+  | Config_parse_failed
+  | Invalid_profile
+  | Missing_meta
+  | Meta_read_error
+  | Bootstrap_failed
+(** Stable, structured reason for a keeper boot/materialization failure. *)
+
+val boot_meta_failure_reason_to_string : boot_meta_failure_reason -> string
+(** Operator/API label for {!boot_meta_failure_reason}. *)
+
 type boot_meta_failure = {
   keeper_name : string;
   base_path : string;
+  reason : boot_meta_failure_reason;
   error : string;
   recorded_at : string;
   recorded_at_unix : float;

--- a/lib/keeper/keeper_runtime.mli
+++ b/lib/keeper/keeper_runtime.mli
@@ -41,10 +41,23 @@ type boot_meta_resolution = {
 }
 (** Result of [load_or_materialize_boot_meta]. *)
 
+type boot_meta_failure_reason =
+  | Goal_required
+  | Sandbox_profile_required
+  | Config_parse_failed
+  | Invalid_profile
+  | Missing_meta
+  | Meta_read_error
+  | Bootstrap_failed
+(** Stable, structured reason for a keeper boot/materialization failure. *)
+
+val boot_meta_failure_reason_to_string : boot_meta_failure_reason -> string
+(** Operator/API label for {!boot_meta_failure_reason}. *)
+
 type boot_meta_failure = {
   keeper_name : string;
   base_path : string;
-  reason : string;
+  reason : boot_meta_failure_reason;
   error : string;
   recorded_at : string;
   recorded_at_unix : float;
@@ -52,9 +65,6 @@ type boot_meta_failure = {
 (** Last boot/materialization failure observed for one keeper in one
     workspace.  Kept in memory so health surfaces the current supervisor
     blocker without scraping logs. *)
-
-val boot_meta_failure_reason : string -> string
-(** Classify a raw boot/materialization error into a stable reason label. *)
 
 val boot_meta_failure_for :
   base_path:string -> name:string -> boot_meta_failure option

--- a/lib/keeper/keeper_runtime.mli
+++ b/lib/keeper/keeper_runtime.mli
@@ -41,6 +41,27 @@ type boot_meta_resolution = {
 }
 (** Result of [load_or_materialize_boot_meta]. *)
 
+type boot_meta_failure = {
+  keeper_name : string;
+  base_path : string;
+  reason : string;
+  error : string;
+  recorded_at : string;
+  recorded_at_unix : float;
+}
+(** Last boot/materialization failure observed for one keeper in one
+    workspace.  Kept in memory so health surfaces the current supervisor
+    blocker without scraping logs. *)
+
+val boot_meta_failure_reason : string -> string
+(** Classify a raw boot/materialization error into a stable reason label. *)
+
+val boot_meta_failure_for :
+  base_path:string -> name:string -> boot_meta_failure option
+(** Lookup the last boot/materialization failure for [name] in [base_path], if
+    the current process has observed one.  Cleared when the keeper loads or
+    materializes successfully. *)
+
 type autoboot_exclusion = {
   keeper_name : string;
   reason : string;

--- a/lib/keeper/keeper_runtime.mli
+++ b/lib/keeper/keeper_runtime.mli
@@ -41,23 +41,9 @@ type boot_meta_resolution = {
 }
 (** Result of [load_or_materialize_boot_meta]. *)
 
-type boot_meta_failure_reason =
-  | Goal_required
-  | Sandbox_profile_required
-  | Config_parse_failed
-  | Invalid_profile
-  | Missing_meta
-  | Meta_read_error
-  | Bootstrap_failed
-(** Stable, structured reason for a keeper boot/materialization failure. *)
-
-val boot_meta_failure_reason_to_string : boot_meta_failure_reason -> string
-(** Operator/API label for {!boot_meta_failure_reason}. *)
-
 type boot_meta_failure = {
   keeper_name : string;
   base_path : string;
-  reason : boot_meta_failure_reason;
   error : string;
   recorded_at : string;
   recorded_at_unix : float;

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -363,6 +363,9 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
   let base_path = runtime_base_path_opt () in
   let phase_snapshot = keeper_phase_snapshot ?base_path () in
   let phase_counts = phase_snapshot.counts in
+  let reaction_capacity_names =
+    phase_snapshot.running_names @ phase_snapshot.recovering_names
+  in
   let keeper_fibers = phase_counts.running in
   (* Single-pass fleet meta scan: reads each keeper meta file once,
      shared by paused-keepers and fleet-safety sections. *)
@@ -397,11 +400,15 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
           keeper_fleet_safety_health_json
             ~bootable_names:scan.bootable_names
             ~autoboot_scan:scan.autoboot_scan
+            ?base_path
+            ~reaction_capacity_names
             ~phase_counts
             ~paused_keepers_json
             ()
         | None ->
           keeper_fleet_safety_health_json
+            ?base_path
+            ~reaction_capacity_names
             ~phase_counts
             ~paused_keepers_json
             ())

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -377,6 +377,8 @@ let empty_keeper_phase_counts =
 type keeper_phase_snapshot =
   { counts : keeper_phase_counts
   ; running_names : string list
+  ; recovering_names : string list
+  ; executable_names : string list
   }
 
 let keeper_phase_snapshot ?base_path () =
@@ -384,33 +386,44 @@ let keeper_phase_snapshot ?base_path () =
   |> List.fold_left
        (fun acc (entry : Keeper_registry.registry_entry) ->
           let counts = acc.counts in
-          let executable =
-            if Keeper_state_machine.can_execute_turn entry.phase then
-              counts.executable + 1
-            else counts.executable
+          let can_execute = Keeper_state_machine.can_execute_turn entry.phase in
+          let executable = if can_execute then counts.executable + 1 else counts.executable in
+          let executable_names =
+            if can_execute then entry.name :: acc.executable_names
+            else acc.executable_names
           in
           (* Keepers in Failing phase with restart budget remaining are
              expected to recover on the next heartbeat cycle — count them
              separately so fleet safety does not report a spurious shortfall
              during transient failures (issue #17218). *)
-          let recovering =
+          let is_recovering =
             match entry.phase with
             | Keeper_state_machine.Failing
-              when entry.conditions.restart_budget_remaining ->
-              counts.recovering + 1
-            | _ -> counts.recovering
+              when entry.conditions.restart_budget_remaining -> true
+            | _ -> false
+          in
+          let recovering =
+            if is_recovering then counts.recovering + 1 else counts.recovering
+          in
+          let recovering_names =
+            if is_recovering then entry.name :: acc.recovering_names
+            else acc.recovering_names
           in
           match entry.phase with
           | Keeper_state_machine.Running ->
             {
               counts = { counts with running = counts.running + 1; executable };
               running_names = entry.name :: acc.running_names;
+              recovering_names;
+              executable_names;
             }
           | Keeper_state_machine.Failing ->
             {
               acc with
               counts =
                 { counts with failing = counts.failing + 1; recovering; executable };
+              recovering_names;
+              executable_names;
             }
           | Keeper_state_machine.Offline
           | Keeper_state_machine.Overflowed
@@ -423,16 +436,112 @@ let keeper_phase_snapshot ?base_path () =
           | Keeper_state_machine.Restarting
           | Keeper_state_machine.Dead
           | Keeper_state_machine.Zombie ->
-            { acc with counts = { counts with executable } })
-       { counts = empty_keeper_phase_counts; running_names = [] }
+            { acc with counts = { counts with executable }; executable_names })
+       {
+         counts = empty_keeper_phase_counts;
+         running_names = [];
+         recovering_names = [];
+         executable_names = [];
+       }
   |> fun snapshot ->
-  { snapshot with running_names = sorted_unique_strings snapshot.running_names }
+  {
+    snapshot with
+    running_names = sorted_unique_strings snapshot.running_names;
+    recovering_names = sorted_unique_strings snapshot.recovering_names;
+    executable_names = sorted_unique_strings snapshot.executable_names;
+  }
 
 let keeper_phase_counts ?base_path () = (keeper_phase_snapshot ?base_path ()).counts
+
+let string_set_of_list values =
+  List.fold_left (fun acc value -> String_set.add value acc) String_set.empty values
+
+let json_string_list_field field = function
+  | `Assoc fields -> (
+      match List.assoc_opt field fields with
+      | Some (`List values) ->
+          values
+          |> List.filter_map (function
+               | `String value -> Some value
+               | _ -> None)
+          |> sorted_unique_strings
+      | _ -> [])
+  | _ -> []
+
+let blocked_keeper_action = function
+  | "paused" -> "resume_or_leave_paused"
+  | "meta_read_error" -> "repair_keeper_meta_file"
+  | "not_bootable" -> "add_keeper_toml_or_disable_stale_autoboot_meta"
+  | "goal_required" -> "add_goal_or_goal_horizon_to_keeper_toml"
+  | "sandbox_profile_required" -> "add_sandbox_profile_to_keeper_toml"
+  | "sandbox_settings_invalid" -> "repair_keeper_sandbox_settings"
+  | "sandbox_preflight_failed" -> "inspect_keeper_sandbox_preflight"
+  | "keeper_capacity_limit" -> "raise_capacity_or_stop_other_keepers"
+  | "invalid_profile" | "config_parse_failed" -> "repair_keeper_toml_config"
+  | "missing_meta" -> "run_keeper_up_or_recreate_meta"
+  | "bootstrap_failed" -> "inspect_keeper_autoboot_logs"
+  | "not_running" -> "start_or_recover_keeper"
+  | _ -> "inspect_keeper_autoboot_logs"
+
+let blocked_keeper_detail_json
+    ?base_path
+    ~bootable_set
+    ~capacity_set
+    ~paused_set
+    ~read_error_set
+    name =
+  let is_paused = String_set.mem name paused_set in
+  let is_bootable = String_set.mem name bootable_set in
+  let is_capacity = String_set.mem name capacity_set in
+  let has_read_error = String_set.mem name read_error_set in
+  let last_failure =
+    match base_path with
+    | None -> None
+    | Some base_path -> Keeper_runtime.boot_meta_failure_for ~base_path ~name
+  in
+  let reason =
+    if is_paused then "paused"
+    else if has_read_error then "meta_read_error"
+    else
+      match last_failure with
+      | Some failure -> failure.Keeper_runtime.reason
+      | None ->
+          if not is_bootable then "not_bootable"
+          else if not is_capacity then "not_running"
+          else "unknown"
+  in
+  let last_failure_fields =
+    match last_failure with
+    | None ->
+        [
+          ("last_bootstrap_reason", `Null);
+          ("last_bootstrap_error", `Null);
+          ("last_bootstrap_recorded_at", `Null);
+        ]
+    | Some failure ->
+        [
+          ("last_bootstrap_reason", `String failure.Keeper_runtime.reason);
+          ("last_bootstrap_error", `String failure.Keeper_runtime.error);
+          ("last_bootstrap_recorded_at", `String failure.Keeper_runtime.recorded_at);
+        ]
+  in
+  `Assoc
+    ([
+       ("name", `String name);
+       ("reason", `String reason);
+       ("action", `String (blocked_keeper_action reason));
+       ("bootable", `Bool is_bootable);
+       ("reaction_capacity", `Bool is_capacity);
+       ("paused", `Bool is_paused);
+       ("meta_read_error", `Bool has_read_error);
+     ]
+     @ last_failure_fields)
 
 let keeper_fleet_safety_health_json
     ?bootable_names:bootable_names_override
     ?autoboot_scan:autoboot_scan_override
+    ?base_path
+    ?reaction_capacity_names
     ~phase_counts
     ~paused_keepers_json
     () =
@@ -456,6 +565,38 @@ let keeper_fleet_safety_health_json
   in
   let bootable_count = List.length bootable_names in
   let target_count = List.length autoboot_scan.autoboot_names in
+  let reaction_capacity_names =
+    match reaction_capacity_names with
+    | Some names -> sorted_unique_strings names
+    | None -> running_keeper_names ?base_path ()
+  in
+  let bootable_set = string_set_of_list bootable_names in
+  let capacity_set = string_set_of_list reaction_capacity_names in
+  let paused_set =
+    paused_keepers_json
+    |> json_string_list_field "autoboot_enabled_names"
+    |> string_set_of_list
+  in
+  let read_error_set =
+    autoboot_scan.read_errors
+    |> List.map fst
+    |> string_set_of_list
+  in
+  let blocked_keeper_names =
+    autoboot_scan.autoboot_names
+    |> List.filter (fun name -> not (String_set.mem name capacity_set))
+    |> sorted_unique_strings
+  in
+  let blocked_keeper_reasons =
+    blocked_keeper_names
+    |> List.map
+         (blocked_keeper_detail_json
+            ?base_path
+            ~bootable_set
+            ~capacity_set
+            ~paused_set
+            ~read_error_set)
+  in
   let minimum_running_fibers =
     if target_count <= 1 then target_count else 2
   in
@@ -551,6 +692,9 @@ let keeper_fleet_safety_health_json
     ; "paused_autoboot_enabled_keeper_count", `Int paused_autoboot_count
     ; "blocked_count", `Int blocked_count
     ; "blocked_keepers", `Int blocked_count
+    ; ( "blocked_keeper_names"
+      , `List (List.map (fun name -> `String name) blocked_keeper_names) )
+    ; "blocked_keeper_reasons", `List blocked_keeper_reasons
     ; ( "operator_action_required"
       , `Bool
           (no_executable_keeper_fibers

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -504,7 +504,9 @@ let blocked_keeper_detail_json
     else if has_read_error then "meta_read_error"
     else
       match last_failure with
-      | Some failure -> failure.Keeper_runtime.reason
+      | Some failure ->
+          Keeper_runtime.boot_meta_failure_reason_to_string
+            failure.Keeper_runtime.reason
       | None ->
           if not is_bootable then "not_bootable"
           else if not is_capacity then "not_running"
@@ -520,7 +522,10 @@ let blocked_keeper_detail_json
         ]
     | Some failure ->
         [
-          ("last_bootstrap_reason", `String failure.Keeper_runtime.reason);
+          ( "last_bootstrap_reason"
+          , `String
+              (Keeper_runtime.boot_meta_failure_reason_to_string
+                 failure.Keeper_runtime.reason) );
           ("last_bootstrap_error", `String failure.Keeper_runtime.error);
           ("last_bootstrap_recorded_at", `String failure.Keeper_runtime.recorded_at);
         ]

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -468,20 +468,29 @@ let json_string_list_field field = function
       | _ -> [])
   | _ -> []
 
+type blocked_keeper_reason =
+  | Paused
+  | Meta_read_error
+  | Not_bootable
+  | Bootstrap_failed
+  | Not_running
+  | Unknown
+
+let blocked_keeper_reason_label = function
+  | Paused -> "paused"
+  | Meta_read_error -> "meta_read_error"
+  | Not_bootable -> "not_bootable"
+  | Bootstrap_failed -> "bootstrap_failed"
+  | Not_running -> "not_running"
+  | Unknown -> "unknown"
+
 let blocked_keeper_action = function
-  | "paused" -> "resume_or_leave_paused"
-  | "meta_read_error" -> "repair_keeper_meta_file"
-  | "not_bootable" -> "add_keeper_toml_or_disable_stale_autoboot_meta"
-  | "goal_required" -> "add_goal_or_goal_horizon_to_keeper_toml"
-  | "sandbox_profile_required" -> "add_sandbox_profile_to_keeper_toml"
-  | "sandbox_settings_invalid" -> "repair_keeper_sandbox_settings"
-  | "sandbox_preflight_failed" -> "inspect_keeper_sandbox_preflight"
-  | "keeper_capacity_limit" -> "raise_capacity_or_stop_other_keepers"
-  | "invalid_profile" | "config_parse_failed" -> "repair_keeper_toml_config"
-  | "missing_meta" -> "run_keeper_up_or_recreate_meta"
-  | "bootstrap_failed" -> "inspect_keeper_autoboot_logs"
-  | "not_running" -> "start_or_recover_keeper"
-  | _ -> "inspect_keeper_autoboot_logs"
+  | Paused -> "resume_or_leave_paused"
+  | Meta_read_error -> "repair_keeper_meta_file"
+  | Not_bootable -> "add_keeper_toml_or_disable_stale_autoboot_meta"
+  | Bootstrap_failed -> "inspect_keeper_autoboot_logs"
+  | Not_running -> "start_or_recover_keeper"
+  | Unknown -> "inspect_keeper_autoboot_logs"
 
 let blocked_keeper_detail_json
     ?base_path
@@ -500,17 +509,15 @@ let blocked_keeper_detail_json
     | Some base_path -> Keeper_runtime.boot_meta_failure_for ~base_path ~name
   in
   let reason =
-    if is_paused then "paused"
-    else if has_read_error then "meta_read_error"
+    if is_paused then Paused
+    else if has_read_error then Meta_read_error
     else
       match last_failure with
-      | Some failure ->
-          Keeper_runtime.boot_meta_failure_reason_to_string
-            failure.Keeper_runtime.reason
+      | Some _ -> Bootstrap_failed
       | None ->
-          if not is_bootable then "not_bootable"
-          else if not is_capacity then "not_running"
-          else "unknown"
+          if not is_bootable then Not_bootable
+          else if not is_capacity then Not_running
+          else Unknown
   in
   let last_failure_fields =
     match last_failure with
@@ -523,9 +530,7 @@ let blocked_keeper_detail_json
     | Some failure ->
         [
           ( "last_bootstrap_reason"
-          , `String
-              (Keeper_runtime.boot_meta_failure_reason_to_string
-                 failure.Keeper_runtime.reason) );
+          , `String (blocked_keeper_reason_label Bootstrap_failed) );
           ("last_bootstrap_error", `String failure.Keeper_runtime.error);
           ("last_bootstrap_recorded_at", `String failure.Keeper_runtime.recorded_at);
         ]
@@ -533,7 +538,7 @@ let blocked_keeper_detail_json
   `Assoc
     ([
        ("name", `String name);
-       ("reason", `String reason);
+       ("reason", `String (blocked_keeper_reason_label reason));
        ("action", `String (blocked_keeper_action reason));
        ("bootable", `Bool is_bootable);
        ("reaction_capacity", `Bool is_capacity);

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -472,7 +472,7 @@ type blocked_keeper_reason =
   | Paused
   | Meta_read_error
   | Not_bootable
-  | Boot_failure of Keeper_runtime.boot_meta_failure_reason
+  | Bootstrap_failed
   | Not_running
   | Unknown
 
@@ -480,7 +480,7 @@ let blocked_keeper_reason_label = function
   | Paused -> "paused"
   | Meta_read_error -> "meta_read_error"
   | Not_bootable -> "not_bootable"
-  | Boot_failure reason -> Keeper_runtime.boot_meta_failure_reason_to_string reason
+  | Bootstrap_failed -> "bootstrap_failed"
   | Not_running -> "not_running"
   | Unknown -> "unknown"
 
@@ -488,13 +488,7 @@ let blocked_keeper_action = function
   | Paused -> "resume_or_leave_paused"
   | Meta_read_error -> "repair_keeper_meta_file"
   | Not_bootable -> "add_keeper_toml_or_disable_stale_autoboot_meta"
-  | Boot_failure Goal_required -> "add_goal_or_goal_horizon_to_keeper_toml"
-  | Boot_failure Sandbox_profile_required -> "add_sandbox_profile_to_keeper_toml"
-  | Boot_failure Config_parse_failed
-  | Boot_failure Invalid_profile -> "repair_keeper_toml_config"
-  | Boot_failure Missing_meta -> "run_keeper_up_or_recreate_meta"
-  | Boot_failure Meta_read_error -> "repair_keeper_meta_file"
-  | Boot_failure Bootstrap_failed -> "inspect_keeper_autoboot_logs"
+  | Bootstrap_failed -> "inspect_keeper_autoboot_logs"
   | Not_running -> "start_or_recover_keeper"
   | Unknown -> "inspect_keeper_autoboot_logs"
 
@@ -519,7 +513,7 @@ let blocked_keeper_detail_json
     else if has_read_error then Meta_read_error
     else
       match last_failure with
-      | Some failure -> Boot_failure failure.Keeper_runtime.reason
+      | Some _ -> Bootstrap_failed
       | None ->
           if not is_bootable then Not_bootable
           else if not is_capacity then Not_running
@@ -536,7 +530,7 @@ let blocked_keeper_detail_json
     | Some failure ->
         [
           ( "last_bootstrap_reason"
-          , `String (blocked_keeper_reason_label (Boot_failure failure.Keeper_runtime.reason)) );
+          , `String (blocked_keeper_reason_label Bootstrap_failed) );
           ("last_bootstrap_error", `String failure.Keeper_runtime.error);
           ("last_bootstrap_recorded_at", `String failure.Keeper_runtime.recorded_at);
         ]

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -472,7 +472,7 @@ type blocked_keeper_reason =
   | Paused
   | Meta_read_error
   | Not_bootable
-  | Bootstrap_failed
+  | Boot_failure of Keeper_runtime.boot_meta_failure_reason
   | Not_running
   | Unknown
 
@@ -480,7 +480,7 @@ let blocked_keeper_reason_label = function
   | Paused -> "paused"
   | Meta_read_error -> "meta_read_error"
   | Not_bootable -> "not_bootable"
-  | Bootstrap_failed -> "bootstrap_failed"
+  | Boot_failure reason -> Keeper_runtime.boot_meta_failure_reason_to_string reason
   | Not_running -> "not_running"
   | Unknown -> "unknown"
 
@@ -488,7 +488,13 @@ let blocked_keeper_action = function
   | Paused -> "resume_or_leave_paused"
   | Meta_read_error -> "repair_keeper_meta_file"
   | Not_bootable -> "add_keeper_toml_or_disable_stale_autoboot_meta"
-  | Bootstrap_failed -> "inspect_keeper_autoboot_logs"
+  | Boot_failure Goal_required -> "add_goal_or_goal_horizon_to_keeper_toml"
+  | Boot_failure Sandbox_profile_required -> "add_sandbox_profile_to_keeper_toml"
+  | Boot_failure Config_parse_failed
+  | Boot_failure Invalid_profile -> "repair_keeper_toml_config"
+  | Boot_failure Missing_meta -> "run_keeper_up_or_recreate_meta"
+  | Boot_failure Meta_read_error -> "repair_keeper_meta_file"
+  | Boot_failure Bootstrap_failed -> "inspect_keeper_autoboot_logs"
   | Not_running -> "start_or_recover_keeper"
   | Unknown -> "inspect_keeper_autoboot_logs"
 
@@ -513,7 +519,7 @@ let blocked_keeper_detail_json
     else if has_read_error then Meta_read_error
     else
       match last_failure with
-      | Some _ -> Bootstrap_failed
+      | Some failure -> Boot_failure failure.Keeper_runtime.reason
       | None ->
           if not is_bootable then Not_bootable
           else if not is_capacity then Not_running
@@ -530,7 +536,7 @@ let blocked_keeper_detail_json
     | Some failure ->
         [
           ( "last_bootstrap_reason"
-          , `String (blocked_keeper_reason_label Bootstrap_failed) );
+          , `String (blocked_keeper_reason_label (Boot_failure failure.Keeper_runtime.reason)) );
           ("last_bootstrap_error", `String failure.Keeper_runtime.error);
           ("last_bootstrap_recorded_at", `String failure.Keeper_runtime.recorded_at);
         ]

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -68,12 +68,16 @@ type keeper_phase_counts = {
 type keeper_phase_snapshot = {
   counts : keeper_phase_counts;
   running_names : string list;
+  recovering_names : string list;
+  executable_names : string list;
 }
 val keeper_phase_snapshot : ?base_path:string -> unit -> keeper_phase_snapshot
 val keeper_phase_counts : ?base_path:string -> unit -> keeper_phase_counts
 val keeper_fleet_safety_health_json :
   ?bootable_names:string list ->
   ?autoboot_scan:autoboot_keeper_scan ->
+  ?base_path:string ->
+  ?reaction_capacity_names:string list ->
   phase_counts:keeper_phase_counts ->
   paused_keepers_json:Yojson.Safe.t ->
   unit ->

--- a/lib/server/server_routes_http_runtime_health_fleet.ml
+++ b/lib/server/server_routes_http_runtime_health_fleet.ml
@@ -78,6 +78,9 @@ let keeper_fleet_runtime_resolution_base_fields
   let base_path = runtime_base_path_opt () in
   let phase_snapshot = keeper_phase_snapshot ?base_path () in
   let phase_counts = phase_snapshot.counts in
+  let reaction_capacity_names =
+    phase_snapshot.running_names @ phase_snapshot.recovering_names
+  in
   let keeper_fibers = phase_counts.running in
   let paused_keepers_json =
     match meta_scan with
@@ -93,11 +96,15 @@ let keeper_fleet_runtime_resolution_base_fields
       keeper_fleet_safety_health_json
         ~bootable_names:scan.bootable_names
         ~autoboot_scan:scan.autoboot_scan
+        ?base_path
+        ~reaction_capacity_names
         ~phase_counts
         ~paused_keepers_json
         ()
     | None ->
       keeper_fleet_safety_health_json
+        ?base_path
+        ~reaction_capacity_names
         ~phase_counts
         ~paused_keepers_json
         ()

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -606,7 +606,8 @@ let test_declarative_boot_materializes_goal_from_will () =
       check string "goal derived from will" will resolution.meta.goal;
       check (option string) "boot failure cleared" None
         (Option.map
-           (fun (failure : KR.boot_meta_failure) -> failure.reason)
+           (fun (failure : KR.boot_meta_failure) ->
+             KR.boot_meta_failure_reason_to_string failure.reason)
            (KR.boot_meta_failure_for ~base_path:config.base_path ~name)))
 
 let test_declarative_boot_records_goal_required_failure () =
@@ -633,7 +634,8 @@ let test_declarative_boot_records_goal_required_failure () =
   | None -> fail "expected boot meta failure to be recorded"
   | Some failure ->
       check string "failure keeper name" name failure.keeper_name;
-      check string "failure reason" "goal_required" failure.reason
+      check string "failure reason" "goal_required"
+        (KR.boot_meta_failure_reason_to_string failure.reason)
 
 let registered_entries names =
   Reg.clear ();

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -604,8 +604,10 @@ let test_declarative_boot_materializes_goal_from_will () =
       | Ok resolution ->
       check bool "materialized from declarative TOML" true resolution.materialized;
       check string "goal derived from will" will resolution.meta.goal;
-      check bool "boot failure cleared" true
-        (Option.is_none
+      check (option string) "boot failure cleared" None
+        (Option.map
+           (fun (failure : KR.boot_meta_failure) ->
+             KR.boot_meta_failure_reason_to_string failure.reason)
            (KR.boot_meta_failure_for ~base_path:config.base_path ~name)))
 
 let test_declarative_boot_records_goal_required_failure () =
@@ -632,8 +634,8 @@ let test_declarative_boot_records_goal_required_failure () =
   | None -> fail "expected boot meta failure to be recorded"
   | Some failure ->
       check string "failure keeper name" name failure.keeper_name;
-      check bool "recorded failure keeps raw error" true
-        (String_util.contains_substring failure.error "goal is required")
+      check string "failure reason" "goal_required"
+        (KR.boot_meta_failure_reason_to_string failure.reason)
 
 let registered_entries names =
   Reg.clear ();

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -604,10 +604,8 @@ let test_declarative_boot_materializes_goal_from_will () =
       | Ok resolution ->
       check bool "materialized from declarative TOML" true resolution.materialized;
       check string "goal derived from will" will resolution.meta.goal;
-      check (option string) "boot failure cleared" None
-        (Option.map
-           (fun (failure : KR.boot_meta_failure) ->
-             KR.boot_meta_failure_reason_to_string failure.reason)
+      check bool "boot failure cleared" true
+        (Option.is_none
            (KR.boot_meta_failure_for ~base_path:config.base_path ~name)))
 
 let test_declarative_boot_records_goal_required_failure () =
@@ -634,8 +632,8 @@ let test_declarative_boot_records_goal_required_failure () =
   | None -> fail "expected boot meta failure to be recorded"
   | Some failure ->
       check string "failure keeper name" name failure.keeper_name;
-      check string "failure reason" "goal_required"
-        (KR.boot_meta_failure_reason_to_string failure.reason)
+      check bool "recorded failure keeps raw error" true
+        (String_util.contains_substring failure.error "goal is required")
 
 let registered_entries names =
   Reg.clear ();

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -86,6 +86,35 @@ sandbox_profile = "local"
 |}
        name)
 
+let write_keeper_toml_without_goal config_dir ~name ~will =
+  write_file
+    (Filename.concat (Filename.concat config_dir "keepers") (name ^ ".toml"))
+    (Printf.sprintf
+       {|
+[keeper]
+name = "%s"
+sandbox_profile = "local"
+proactive_enabled = false
+will = "%s"
+needs = "keep fleet safety diagnosable"
+desires = "avoid silent declarative boot failures"
+|}
+       name will);
+  Keeper_types_profile.invalidate_keeper_profile_defaults_cache name
+
+let write_empty_keeper_toml_without_goal config_dir ~name =
+  write_file
+    (Filename.concat (Filename.concat config_dir "keepers") (name ^ ".toml"))
+    (Printf.sprintf
+       {|
+[keeper]
+name = "%s"
+sandbox_profile = "local"
+proactive_enabled = false
+|}
+       name);
+  Keeper_types_profile.invalidate_keeper_profile_defaults_cache name
+
 let with_restart_launch_noop f =
   Sup.with_restart_launch_noop_for_test f
 
@@ -540,6 +569,71 @@ let test_missing_persona_without_profile_or_toml_is_error () =
      with
      | Sup.Persona_drift_error -> true
      | Sup.Persona_drift_warn -> false)
+
+let keeper_runtime_context env sw config : _ Keeper_types_profile.context =
+  {
+    config;
+    agent_name = "supervisor";
+    sw;
+    clock = Eio.Stdenv.clock env;
+    proc_mgr = Some (Eio.Stdenv.process_mgr env);
+    net = Some (Eio.Stdenv.net env);
+  }
+
+let test_declarative_boot_materializes_goal_from_will () =
+  with_config_dir @@ fun config_dir ->
+  Eio_main.run @@ fun env ->
+  ensure_test_runtime ();
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = Filename.dirname config_dir in
+  let name = "intent-only" in
+  let will = "watch fleet safety and repair keeper bootstrap" in
+  write_keeper_toml_without_goal config_dir ~name ~will;
+  Eio.Switch.on_release sw (fun () ->
+      Reg.clear ();
+      KR.reset_test_state base_dir);
+  let config = Masc.Workspace.default_config base_dir in
+  ignore (Masc.Workspace.init config ~agent_name:(Some "supervisor"));
+  let ctx = keeper_runtime_context env sw config in
+  Fun.protect
+    ~finally:(fun () -> KR.stop_keepalive ~base_path:config.base_path name)
+    (fun () ->
+      match KR.load_or_materialize_boot_meta ctx name with
+      | Error err -> fail err
+      | Ok resolution ->
+      check bool "materialized from declarative TOML" true resolution.materialized;
+      check string "goal derived from will" will resolution.meta.goal;
+      check (option string) "boot failure cleared" None
+        (Option.map
+           (fun (failure : KR.boot_meta_failure) -> failure.reason)
+           (KR.boot_meta_failure_for ~base_path:config.base_path ~name)))
+
+let test_declarative_boot_records_goal_required_failure () =
+  with_config_dir @@ fun config_dir ->
+  Eio_main.run @@ fun env ->
+  ensure_test_runtime ();
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = Filename.dirname config_dir in
+  let name = "empty-intent" in
+  write_empty_keeper_toml_without_goal config_dir ~name;
+  Eio.Switch.on_release sw (fun () ->
+      Reg.clear ();
+      KR.reset_test_state base_dir);
+  let config = Masc.Workspace.default_config base_dir in
+  ignore (Masc.Workspace.init config ~agent_name:(Some "supervisor"));
+  let ctx = keeper_runtime_context env sw config in
+  (match KR.load_or_materialize_boot_meta ctx name with
+   | Ok _ -> fail "expected declarative keeper without any intent to fail"
+   | Error err ->
+       check bool "failure mentions goal" true
+         (String_util.contains_substring err "goal is required"));
+  match KR.boot_meta_failure_for ~base_path:config.base_path ~name with
+  | None -> fail "expected boot meta failure to be recorded"
+  | Some failure ->
+      check string "failure keeper name" name failure.keeper_name;
+      check string "failure reason" "goal_required" failure.reason
 
 let registered_entries names =
   Reg.clear ();
@@ -2114,6 +2208,12 @@ let () =
         test_missing_persona_with_inline_toml_is_warn;
       test_case "missing persona without TOML is ERROR" `Quick
         test_missing_persona_without_profile_or_toml_is_error;
+    ];
+    "boot_meta_materialization", [
+      test_case "declarative boot derives missing goal from will" `Quick
+        test_declarative_boot_materializes_goal_from_will;
+      test_case "declarative boot records goal-required failure" `Quick
+        test_declarative_boot_records_goal_required_failure;
     ];
     "fiber_health", [
       test_case "unknown for unregistered" `Quick test_fiber_health_unknown;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1271,6 +1271,23 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
              |> to_int);
           Alcotest.(check int) "health exposes blocked shortfall" 2
             (fleet_safety |> member "blocked_count" |> to_int);
+          Alcotest.(check (list string)) "health names blocked keepers"
+            [ "capacity-paused"; "example" ]
+            (fleet_safety |> member "blocked_keeper_names" |> to_list
+             |> List.map to_string);
+          let blocked_detail name =
+            fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            |> List.find (fun row -> row |> member "name" |> to_string = name)
+          in
+          Alcotest.(check string) "health explains paused blocked keeper"
+            "paused"
+            (blocked_detail "capacity-paused" |> member "reason" |> to_string);
+          Alcotest.(check string) "health explains config-only blocked keeper"
+            "not_running"
+            (blocked_detail "example" |> member "reason" |> to_string);
+          Alcotest.(check string) "health suggests paused action"
+            "resume_or_leave_paused"
+            (blocked_detail "capacity-paused" |> member "action" |> to_string);
           Alcotest.(check string) "health marks fleet degraded" "degraded"
             (fleet_safety |> member "status" |> to_string);
           Alcotest.(check string) "health marks target-capacity blocker"


### PR DESCRIPTION
## Summary
- derive a declarative keeper goal from TOML goal horizons, will, or instructions when materializing config-only keepers
- remember per-keeper boot/materialization failures in Keeper_runtime so health can surface the current blocker without log scraping
- add keeper_fleet_safety blocked_keeper_names and blocked_keeper_reasons with reason/action details

## Validation
- git diff --check
- ocamlformat --check lib/keeper/keeper_runtime.ml lib/keeper/keeper_runtime.mli lib/server/server_routes_http_runtime.ml lib/server/server_routes_http_runtime_fleet_scan.ml lib/server/server_routes_http_runtime_fleet_scan.mli lib/server/server_routes_http_runtime_health_fleet.ml test/test_keeper_supervisor.ml test/test_server_runtime_bootstrap.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_supervisor.exe
- _build/default/test/test_keeper_supervisor.exe test --quick-tests --show-errors boot_meta_materialization
- _build/default/test/test_server_runtime_bootstrap.exe test --quick-tests --show-errors bootstrap 24

Note: standard scripts/dune-local.sh pin guard currently refuses this worktree because the shared opam switch/floor is agent_sdk 0.206.7 while this branch pin is 0.206.6. I did not downgrade the shared switch; focused builds above used the installed 0.206.7 switch with only the pin-source guard skipped.