### PR TITLE
fix(keeper): persist OAS telemetry events to dated JSONL (re-land #20853, supersedes #21070)

### DIFF
--- a/lib/keeper/keeper_telemetry_consumer.ml
+++ b/lib/keeper/keeper_telemetry_consumer.ml
@@ -1,21 +1,29 @@
 (** Keeper_telemetry_consumer — MASC-side observer for OAS telemetry events.
 
     Subscribes to the OAS event bus via [Agent_sdk_metrics_bridge],
-    filters [Custom("telemetry_event", json)] payloads, and records that a
-    telemetry item was observed. MASC deliberately does not deserialize
-    provider/model-bearing OAS telemetry; concrete runtime identity belongs to
-    OAS.
+    filters [Custom("telemetry_event", json)] payloads, persists each
+    event to [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl] via
+    {!Dated_jsonl}, and increments an OTel counter for dashboard
+    visibility.
 
-    State is purely internal: the subscription handle and the fiber are both
-    bound to the caller's [Eio.Switch.t]. *)
+    MASC deliberately does not deserialize provider/model-bearing OAS
+    telemetry; concrete runtime identity belongs to OAS.
+
+    State is purely internal: the subscription handle, the fiber, and the
+    {!Dated_jsonl.t} store are all bound to the caller's [Eio.Switch.t]. *)
 
 let telemetry_event_counter = "masc_keeper_telemetry_events_consumed_total"
 
-(* drain is non-blocking; loop must yield or it pins the Eio domain and
+(* Drain is non-blocking; the loop must yield or it pins the Eio domain and
    starves co-located fibers (HTTP handlers, lazy startup tasks). *)
 let drain_interval_s = 0.1
 
-let spawn_subscriber ~sw ~clock ~bus =
+let spawn_subscriber ~sw ~clock ~base_path ~bus =
+  let store =
+    Dated_jsonl.create
+      ~base_dir:(Filename.concat base_path "data/harness-telemetry")
+      ()
+  in
   let sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"telemetry_consumer"
@@ -34,11 +42,12 @@ let spawn_subscriber ~sw ~clock ~bus =
          List.iter
            (fun (evt : Agent_sdk.Event_bus.event) ->
               match evt.payload with
-              | Agent_sdk.Event_bus.Custom ("telemetry_event", _) ->
+              | Agent_sdk.Event_bus.Custom ("telemetry_event", json) ->
                   Otel_metric_store.inc_counter
                     telemetry_event_counter
                     ~labels:[ "result", "observed" ]
-                    ()
+                    ();
+                  Dated_jsonl.append store json
               | _ -> ())
            events
        with

--- a/lib/keeper/keeper_telemetry_consumer.mli
+++ b/lib/keeper/keeper_telemetry_consumer.mli
@@ -2,10 +2,18 @@
 
     Spawns a fiber that drains [Custom("telemetry_event", json)]
     payloads from the OAS event bus without deserializing provider/model
-    identity. *)
+    identity.  Each event is persisted to
+    [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl] via
+    {!Dated_jsonl}. *)
 
 val spawn_subscriber
   :  sw:Eio.Switch.t
   -> clock:[> float Eio.Time.clock_ty ] Eio.Std.r
+  -> base_path:string
   -> bus:Agent_sdk.Event_bus.t
   -> unit
+(** [spawn_subscriber ~sw ~clock ~base_path ~bus] forks a fiber that
+    drains [Custom("telemetry_event", json)] payloads from [bus],
+    persists each one to [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl],
+    and increments an OTel counter.  The fiber yields every 100 ms so
+    co-located fibers are not starved. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -357,7 +357,8 @@ let start_keeper_loops
     event_bus;
   (* Telemetry feedback loop: observe OAS per-turn signals without
      deserializing provider/model-bearing payloads. *)
-  Keeper_telemetry_consumer.spawn_subscriber ~sw ~clock ~bus:event_bus;
+  Keeper_telemetry_consumer.spawn_subscriber
+    ~sw ~clock ~base_path:(Env_config.base_path ()) ~bus:event_bus;
   let keeper_lifecycle_sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"lifecycle_listener"

--- a/test/test_keeper_telemetry_consumer.ml
+++ b/test/test_keeper_telemetry_consumer.ml
@@ -23,6 +23,18 @@ module KTC = Masc.Keeper_telemetry_consumer
 let target_iters = 5
 let inter_sleep_s = 0.02
 let total_expected_wall_clock_s = float_of_int target_iters *. inter_sleep_s
+let temp_counter = ref 0
+
+let temp_base_path prefix =
+  incr temp_counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s_%d_%d_%.0f" prefix !temp_counter (Unix.getpid ())
+         (Unix.gettimeofday ()))
+  in
+  Fs_compat.mkdir_p dir;
+  dir
 
 (* Marker used to break out of [Switch.run] once the assertion data is
    collected. Using [Switch.fail] would propagate as the switch's
@@ -35,9 +47,10 @@ let test_drain_loop_yields_to_co_located_fiber () =
   Eio_main.run @@ fun env ->
     let clock = Eio.Stdenv.clock env in
     let bus = Agent_sdk.Event_bus.create () in
+    let base_path = temp_base_path "keeper_telemetry_consumer" in
     (try
       Eio.Switch.run (fun sw ->
-        KTC.spawn_subscriber ~sw ~clock ~bus;
+        KTC.spawn_subscriber ~sw ~clock ~base_path ~bus;
         for _ = 1 to target_iters do
           Eio.Time.sleep clock inter_sleep_s;
           incr counter
@@ -51,6 +64,61 @@ let test_drain_loop_yields_to_co_located_fiber () =
        target_iters total_expected_wall_clock_s)
     target_iters !counter
 
+(* Walk [dir] recursively and return every regular file ending in
+   ".jsonl". Stdlib-only so the test does not need a [dated_jsonl] dune
+   dependency just to read the store back. *)
+let rec find_jsonl dir =
+  if not (Sys.file_exists dir) then []
+  else if Sys.is_directory dir then
+    Sys.readdir dir |> Array.to_list
+    |> List.concat_map (fun name -> find_jsonl (Filename.concat dir name))
+  else if Filename.check_suffix dir ".jsonl" then [ dir ]
+  else []
+
+let contains_substring haystack needle =
+  let hl = String.length haystack and nl = String.length needle in
+  let rec loop i =
+    if i + nl > hl then false
+    else if String.sub haystack i nl = needle then true
+    else loop (i + 1)
+  in
+  nl = 0 || loop 0
+
+(* Regression for the silent telemetry drop: the consumer must persist
+   each [Custom ("telemetry_event", json)] payload to
+   [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl], not merely
+   increment a counter. A counter-only consumer (the state #20853 fixed
+   and 6f5bfdeb2 reverted) drops the payload — this test fails on it. *)
+let test_persists_telemetry_event_to_jsonl () =
+  let base_path = temp_base_path "keeper_telemetry_persist" in
+  let marker = "persist_probe_3f9c1" in
+  let payload =
+    `Assoc [ ("kind", `String "turn_budget"); ("marker", `String marker) ]
+  in
+  Eio_main.run @@ fun env ->
+    let clock = Eio.Stdenv.clock env in
+    let bus = Agent_sdk.Event_bus.create () in
+    (try
+      Eio.Switch.run (fun sw ->
+        KTC.spawn_subscriber ~sw ~clock ~base_path ~bus;
+        Agent_sdk.Event_bus.publish bus
+          (Agent_sdk.Event_bus.mk_event
+             (Agent_sdk.Event_bus.Custom ("telemetry_event", payload)));
+        (* Let several drain intervals (0.1s each) flush to disk. *)
+        Eio.Time.sleep clock 0.35;
+        raise Test_done)
+    with Test_done -> ());
+  let store_dir = Filename.concat base_path "data/harness-telemetry" in
+  let files = find_jsonl store_dir in
+  let persisted =
+    List.exists
+      (fun path -> contains_substring (Fs_compat.load_file path) marker)
+      files
+  in
+  Alcotest.(check bool)
+    "telemetry_event payload persisted to harness-telemetry JSONL"
+    true persisted
+
 let () =
   Alcotest.run "keeper_telemetry_consumer"
     [
@@ -60,5 +128,12 @@ let () =
             "drain loop yields to co-located fiber"
             `Quick
             test_drain_loop_yields_to_co_located_fiber;
+        ] );
+      ( "persistence",
+        [
+          Alcotest.test_case
+            "telemetry_event persisted to dated JSONL"
+            `Quick
+            test_persists_telemetry_event_to_jsonl;
         ] );
     ]


### PR DESCRIPTION
## Summary

Re-lands the OAS telemetry persistence that #20853 added and `6f5bfdeb2` (#20869, titled "test(otel)") silently reverted as plain text. From the 2026-06-13 merge audit (`~/me/reports/masc-merge-audit-2026-06-13.md`, P1).

On current `origin/main`, `keeper_telemetry_consumer.ml` only does:

```
Otel_metric_store.inc_counter telemetry_event_counter ~labels:[ "result", "observed" ] ()
```

and discards the `Custom ("telemetry_event", json)` payload. The counter is an alarm, not a fix — the data is gone.

This is **telemetry-only**, not the full #21070 re-land: the two Discord pieces `6f5bfdeb2` also reverted were already re-landed on `origin/main` by other merges — the `Close_wss` effect by #21064 (`ea7d44009`, "prevent permanent reconnect stall from stale conn_ref", `discord_gateway_state.ml:871`) and `connector_json` `status_source`/`gateway_state` (`channel_gate_discord_state.ml:315-316`). Re-landing them here would conflict and duplicate, so #21070 is superseded by this focused PR.

## Change

- `keeper_telemetry_consumer.spawn_subscriber` gains `~base_path` and appends each event verbatim to `{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl` via `Dated_jsonl` — an append-only WAL, the root fix prescribed for silent-drop counters. The raw `json` blob is persisted **without** deserializing, so the MASC↔OAS boundary holds (runtime/provider identity stays in OAS).
- `server_bootstrap_loops.ml` threads `Env_config.base_path ()`.
- Regression test publishes a `telemetry_event` and asserts the payload lands in the harness-telemetry JSONL (mutation-checked: removing the append makes the suite fail).

## Validation

- `dune build --root . @check` and `dune build --root .` exit 0
- `test_keeper_telemetry_consumer` green (2 tests: cooperative-scheduling + new persistence)

WORKAROUND-WAIVED: this PR removes the counter-only telemetry-as-fix and replaces it with append-only persistence (the root fix per CLAUDE.md §workaround telemetry-as-fix). It does not add a counter/alarm — it restores the dropped data path.

Supersedes #21070 (telemetry slice only; discord slices already on main via #21064).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
