### PR TITLE
fix(keeper): route dashboard meta writes through CAS merge, not force (counter rewind)

### DIFF
--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -41,7 +41,7 @@ let paused_state_requires_approval (old : keeper_meta) =
   Keeper_approval_queue.has_pending_for_keeper ~keeper_name:old.name
   || blocker_requires_continue_gate old
 
-let update_keeper ?(force = false) ?(preserve_prompt_defaults = false)
+let update_keeper ?(preserve_prompt_defaults = false)
     (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool_result
     =
   match resolve_active_goal_ids ctx.config p old.active_goal_ids with
@@ -378,7 +378,19 @@ let update_keeper ?(force = false) ?(preserve_prompt_defaults = false)
               err;
             tool_result_error err
           | Ok () ->
-            (match write_meta ~force ctx.config updated with
+            (* CAS-merge instead of a force write: a dashboard/turn-up edit
+               builds [updated] from a meta snapshot ([old]), so a concurrent
+               keeper turn that bumped cumulative usage counters between the
+               read and this write would otherwise be silently rewound
+               (total_turns 385->370, 2026-06-10). [heartbeat_fields_from_disk]
+               keeps the caller's edited fields but takes the monotonic
+               counters as [max latest caller]. *)
+            (match
+               write_meta_with_merge
+                 ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+                 ctx.config
+                 updated
+             with
              | Error e ->
                  Otel_metric_store.inc_counter
                    Keeper_metrics.(to_string WriteMetaFailures)

--- a/lib/keeper/keeper_turn_up_update.mli
+++ b/lib/keeper/keeper_turn_up_update.mli
@@ -20,7 +20,6 @@ val resolve_active_goal_ids :
     Returns structured {!Keeper_types_profile.tool_result}; failures carry their
     message on the typed error payload. *)
 val update_keeper :
-  ?force:bool ->
   ?preserve_prompt_defaults:bool ->
   _ Keeper_types_profile.context ->
   Keeper_turn_up_args.parsed_args ->

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -99,10 +99,15 @@ let handle_keeper_tools_post state req reqd =
              | Error msg ->
                  respond_error reqd msg
              | Ok meta' ->
-                 (* force: user-initiated tool config is authoritative.
-                    Skips version CAS since user intent overrides
-                    concurrent keeper turn updates. *)
-                 (match Keeper_meta_store.write_meta ~force:true config meta' with
+                 (* User-initiated tool config wins for its edited fields, but
+                    persist via CAS merge so a concurrent keeper turn's
+                    cumulative usage counters are not rewound by this
+                    snapshot-derived write. *)
+                 (match
+                    Keeper_meta_store.write_meta_with_merge
+                      ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+                      config meta'
+                  with
                   | Ok () ->
                       Http.Response.json_value ~compress:true ~request:req
                         (keeper_tools_response_json meta') reqd
@@ -396,13 +401,15 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                  | Error result ->
                      respond_error reqd (Keeper_types_profile.tool_result_body result)
                  | Ok parsed ->
-                     (* Dashboard edits are user-initiated and should
-                        override concurrent heartbeat/version writes.
-                        Also preserve existing prompt fields when the
-                        request omits them, so profile defaults do not
-                        clobber prior dashboard edits. *)
+                     (* Dashboard edits are user-initiated and win for the
+                        fields they touch; update_keeper now persists via a
+                        CAS merge ([heartbeat_fields_from_disk]) so a
+                        concurrent keeper turn's cumulative usage counters are
+                        not rewound by this snapshot-derived write.
+                        [preserve_prompt_defaults] keeps existing prompt fields
+                        when the request omits them. *)
                      let result =
-                       Keeper_turn_up_update.update_keeper ~force:true
+                       Keeper_turn_up_update.update_keeper
                          ~preserve_prompt_defaults:true keeper_ctx parsed meta0
                      in
                      if not (Keeper_types_profile.tool_result_success result) then
@@ -475,7 +482,13 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
                   updated_at = Keeper_meta_contract.now_iso ();
                 }
               in
-              (match Keeper_meta_store.write_meta ~force:true config updated_meta with
+              (* Pause toggle via CAS merge: do not rewind a concurrent
+                 turn's cumulative usage counters. *)
+              (match
+                 Keeper_meta_store.write_meta_with_merge
+                   ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+                   config updated_meta
+               with
                | Ok () -> ()
                | Error err ->
                    Log.Keeper.warn
@@ -667,8 +680,12 @@ let handle_keeper_bulk_directive_post state _agent_name req reqd body_str =
                      updated_at = Keeper_meta_contract.now_iso ();
                    }
                  in
+                 (* Pause toggle via CAS merge: do not rewind a concurrent
+                    turn's cumulative usage counters. *)
                  (match
-                    Keeper_meta_store.write_meta ~force:true config updated_meta
+                    Keeper_meta_store.write_meta_with_merge
+                      ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+                      config updated_meta
                   with
                   | Ok () -> ()
                   | Error err ->

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -199,6 +199,58 @@ let test_monotonic_usage_counters_on_cas_retry () =
     check int "last_* observation stays with the caller" 777
       final.runtime.usage.last_latency_ms)
 
+(* Characterization of the hazard the dashboard write sites carried:
+   [write_meta ~force:true] from a stale snapshot bypasses CAS and
+   rewinds cumulative usage counters that a concurrent turn advanced.
+   This is why the dashboard PATCH/pause/tool-config paths
+   (server_dashboard_http_keeper_api_post.ml, keeper_turn_up_update.ml)
+   must route through [write_meta_with_merge]
+   ~merge:heartbeat_fields_from_disk instead of [~force:true]. If a
+   future change reverts a dashboard write back to [~force:true], the
+   counter regression this test pins becomes reachable again. *)
+let test_force_write_rewinds_usage_counters () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Workspace.default_config base_dir in
+    ignore (Workspace.init config ~agent_name:(Some "operator"));
+    let m0 = make_meta ~name:"delta" in
+    (match Keeper_meta_store.write_meta ~force:true config m0 with
+     | Ok () -> ()
+     | Error e -> fail ("seed write failed: " ^ e));
+    let caller_view = match Keeper_meta_store.read_meta config "delta" with
+      | Ok (Some m) -> m
+      | _ -> fail "seed read failed"
+    in
+    let with_usage (m : Keeper_meta_contract.keeper_meta) usage =
+      { m with runtime = { m.runtime with usage } }
+    in
+    (* Concurrent turn advances counters on disk. *)
+    let racing =
+      with_usage caller_view
+        { caller_view.runtime.usage with total_turns = 42 }
+    in
+    (match Keeper_meta_store.write_meta config racing with
+     | Ok () -> ()
+     | Error e -> fail ("racing write failed: " ^ e));
+    (* A stale snapshot force-write (the old dashboard behavior) ignores
+       the disk version and clobbers the advanced counter. *)
+    let stale =
+      with_usage caller_view
+        { caller_view.runtime.usage with total_turns = 5 }
+    in
+    (match Keeper_meta_store.write_meta ~force:true config stale with
+     | Ok () -> ()
+     | Error e -> fail ("stale force write failed: " ^ e));
+    let final = match Keeper_meta_store.read_meta config "delta" with
+      | Ok (Some m) -> m
+      | _ -> fail "final read failed"
+    in
+    check int "force:true rewinds total_turns from the concurrent disk value"
+      5 final.runtime.usage.total_turns)
+
 let test_is_version_conflict_error_classifies () =
   let conflict_msg = "meta version conflict for foo: expected 3, disk has 4" in
   let other_msg = "failed to write meta /tmp/x: Permission denied" in
@@ -218,6 +270,8 @@ let () =
             test_retry_succeeds_after_concurrent_bump;
           test_case "usage counters stay monotonic on stale retry (RFC-0225 §3.2)"
             `Quick test_monotonic_usage_counters_on_cas_retry;
+          test_case "force:true rewinds counters (dashboard hazard characterization)"
+            `Quick test_force_write_rewinds_usage_counters;
         ] );
       ( "is_version_conflict_error",
         [


### PR DESCRIPTION
## Summary

Dashboard keeper-config HTTP writes bypassed the `meta_version` CAS via `write_meta ~force:true`, so a concurrent keeper turn that advanced cumulative usage counters between the snapshot read and the write was silently rewound. This is the shape of the documented `total_turns` 385→370 regression (2026-06-10) that `Keeper_meta_merge.monotonic_usage_counters` was written to prevent. From the 2026-06-13 merge audit (`~/me/reports/masc-merge-audit-2026-06-13.md`, P2).

## Change

Route the four dashboard-HTTP snapshot-write sites through `write_meta_with_merge ~merge:Keeper_meta_merge.heartbeat_fields_from_disk` (caller wins its edited fields; cumulative counters take `max latest caller`):

- `keeper_turn_up_update.update_keeper` — drop `?force`, always CAS-merge. Its other caller (`keeper_turn_up`, the keeper's own turn-up tool) used `force=false` (plain CAS, fails on conflict) and is strictly improved by gaining merge-on-conflict retry.
- `server_dashboard_http_keeper_api_post.ml` — the PATCH path (via `update_keeper`), the tool-config write, and the two pause-toggle writes.

## Scope (not N-of-M)

This covers **every dashboard-HTTP snapshot-force-write site** — the confirmed bug surface — not a subset. The remaining `write_meta ~force:true` sites are a **different surface** and need per-site judgment, so they are deliberately left untouched and escalated rather than silently patched:

| site | why deferred |
|------|--------------|
| `keeper_tool_surface.ml:645`, `keeper_tool_surface_ops.ml:136` | edit runtime fields (continuity reset / trace rotation); need a merge that keeps those edits while protecting counters |
| `keeper_keepalive.ml:311`, `keeper_heartbeat_loop_presence.ml:82` | keeper-internal bootstrap / single-writer; force may be intentional and these are hot paths |

Follow-up: an RFC on eliminating the `write_meta ~force` escape hatch (route all snapshot-derived writes through CAS+merge, classify each remaining site). Tracked separately so the hot-path/runtime-edit sites get proper analysis instead of a blanket swap.

## Validation

- `dune build --root . @check` and `dune build --root .` exit 0
- `test_keeper_meta_cas_retry` green (5 tests). Added a characterization test pinning that `write_meta ~force:true` from a stale snapshot rewinds `total_turns` (the hazard this PR removes from the dashboard); the existing `test_monotonic_usage_counters_on_cas_retry` already proves the merge preserves the larger disk value.

RFC-WAIVED: keeper meta-store write path + dashboard keeper-config API; not a credential/identity/sandbox/hooks subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
