### PR TITLE
fix(discord): chunk/truncate Discord text on codepoint boundaries (F939)

### DIFF
--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -711,12 +711,14 @@ let send_message ~channel_id ~content ?reply_to_message_id () =
        | Error e -> Error (Rest_error e))
     else
       let rec send_chunks first rest =
-        let rlen = String.length rest in
-        let chunk, remaining =
-          if rlen <= limit then rest, None
-          else
-            ( String.sub rest 0 limit
-            , Some (String.sub rest limit (rlen - limit)) )
+        (* Split on a codepoint boundary: the Discord limit is in Unicode
+           scalar values, and a mid-codepoint byte cut yields invalid
+           UTF-8 that Discord rejects with a 400. *)
+        let chunk, remaining_str =
+          Discord_rest_client.split_at_codepoint rest ~limit
+        in
+        let remaining =
+          if remaining_str = "" then None else Some remaining_str
         in
         let ref_id = if first then reply_to_message_id else None in
         match Discord_rest_client.send_message ~token ~channel_id ~content:chunk ?reply_to_message_id:ref_id () with

--- a/lib/gate/discord_rest_client.ml
+++ b/lib/gate/discord_rest_client.ml
@@ -107,11 +107,54 @@ let send_message ~token ~channel_id ~content ?reply_to_message_id () =
   | Error msg -> Error (Network msg)
   | Ok (status, body) -> parse_response ~status ~body
 
-(* Truncate content to Discord's message_content_limit for PATCH edits.
+(* Byte length of the UTF-8 sequence whose lead byte is [c]. An invalid
+   lead byte counts as 1 so iteration always makes progress. *)
+let utf8_lead_len c =
+  if c land 0x80 = 0 then 1
+  else if c land 0xE0 = 0xC0 then 2
+  else if c land 0xF0 = 0xE0 then 3
+  else if c land 0xF8 = 0xF0 then 4
+  else 1
+
+(* Split [s] at the byte offset following its first [limit] Unicode
+   scalar values. Returns [(head, tail)] where [head] is a valid-UTF-8
+   prefix of at most [limit] codepoints and [tail] is the remainder ([""]
+   when [s] already fits). Discord measures message length in Unicode
+   scalar units, so cutting on codepoint (not byte) boundaries avoids both
+   the 400 rejection a mid-codepoint byte cut produces and the needless
+   over-chunking of multi-byte text (e.g. Korean, 3 bytes/char). *)
+let split_at_codepoint s ~limit =
+  let n = String.length s in
+  if limit <= 0 || n = 0 then (s, "")
+  else begin
+    let rec walk pos cps =
+      if pos >= n then (s, "")
+      else if cps >= limit then
+        (String.sub s 0 pos, String.sub s pos (n - pos))
+      else
+        let step = min (utf8_lead_len (Char.code s.[pos])) (n - pos) in
+        walk (pos + step) (cps + 1)
+    in
+    walk 0 0
+  end
+
+(* Split [s] into a list of chunks each at most [limit] Unicode scalar
+   values, every chunk valid UTF-8. Empty input yields [[]]. *)
+let chunk_by_codepoint s ~limit =
+  let rec loop acc rest =
+    if String.length rest = 0 then List.rev acc
+    else
+      let head, tail = split_at_codepoint rest ~limit in
+      if String.length head = 0 then List.rev (rest :: acc)
+      else loop (head :: acc) tail
+  in
+  loop [] s
+
+(* Truncate content to Discord's message_content_limit for PATCH edits,
+   on a codepoint boundary so the result is valid UTF-8.
    Discord rejects messages exceeding 2000 Unicode scalar units. *)
 let truncate_to_limit content =
-  if String.length content <= message_content_limit then content
-  else String.sub content 0 message_content_limit
+  fst (split_at_codepoint content ~limit:message_content_limit)
 
 let build_edit_request ~token ~channel_id ~message_id ~content () =
   let url =

--- a/lib/gate/discord_rest_client.mli
+++ b/lib/gate/discord_rest_client.mli
@@ -16,6 +16,22 @@ val message_content_limit : int
 (** Discord text-message content limit, in Unicode scalar units.
     Messages longer than this must be split into multiple payloads. *)
 
+val split_at_codepoint : string -> limit:int -> string * string
+(** [split_at_codepoint s ~limit] returns [(head, tail)] where [head] is
+    a valid-UTF-8 prefix of [s] of at most [limit] Unicode scalar values
+    and [tail] is the remainder ([""] when [s] fits). Splitting on
+    codepoint boundaries (not bytes) keeps each piece valid UTF-8 so
+    Discord does not reject it with a 400. *)
+
+val chunk_by_codepoint : string -> limit:int -> string list
+(** [chunk_by_codepoint s ~limit] splits [s] into chunks of at most
+    [limit] Unicode scalar values each, every chunk valid UTF-8.
+    [chunk_by_codepoint "" ~limit] is [[]]. *)
+
+val truncate_to_limit : string -> string
+(** Truncate to {!message_content_limit} Unicode scalar values on a
+    codepoint boundary (valid UTF-8). Used for PATCH edits. *)
+
 (** Typed error from Discord REST. Closed sum — anything Discord
     returns that does not map to one of these becomes [Other]
     (preserving the JSON for inspection) so we never silently consume
@@ -63,7 +79,8 @@ val edit_message :
     [PATCH /api/v10/channels/{channel_id}/messages/{message_id}].
     Used for streaming message display — the message content is updated
     in-place on Discord. Content exceeding {!message_content_limit} is
-    silently truncated to the first 2000 characters.
+    silently truncated to the first 2000 Unicode scalar values on a
+    codepoint boundary (see {!truncate_to_limit}).
 
     @raise nothing — failures are surfaced as typed {!error}. *)
 

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -29,16 +29,13 @@ let send_message ~token ~channel_id ~content =
           "keeper_chat_discord: send_message failed: %s" err_str
   else
     let rec send_chunks rest =
-      let rlen = String.length rest in
-      if rlen = 0 then ()
+      if String.length rest = 0 then ()
       else
-        let chunk =
-          if rlen <= limit then rest
-          else String.sub rest 0 limit
-        in
-        let remaining =
-          if rlen <= limit then ""
-          else String.sub rest limit (rlen - limit)
+        (* Split on a codepoint boundary: Discord measures the limit in
+           Unicode scalar values, and a mid-codepoint byte cut produces
+           invalid UTF-8 that Discord rejects with a 400. *)
+        let chunk, remaining =
+          Discord_rest_client.split_at_codepoint rest ~limit
         in
         (match Discord_rest_client.send_message ~token ~channel_id ~content:chunk () with
          | Ok _msg_id -> send_chunks remaining
@@ -52,12 +49,10 @@ let send_message ~token ~channel_id ~content =
     in
     send_chunks content
 
-(* Truncate to Discord message limit for PATCH edits, with redaction. *)
+(* Truncate to Discord message limit for PATCH edits, with redaction.
+   Cuts on a codepoint boundary so the PATCH body stays valid UTF-8. *)
 let truncate content =
-  let content = Observability_redact.redact_text content in
-  let limit = Discord_rest_client.message_content_limit in
-  if String.length content <= limit then content
-  else String.sub content 0 limit
+  Discord_rest_client.truncate_to_limit (Observability_redact.redact_text content)
 
 let is_ascii_space = function
   | ' ' | '\n' | '\r' | '\t' -> true
@@ -79,16 +74,14 @@ let streaming_patch_content content =
 
 let final_head_and_overflow content =
   let redacted = Observability_redact.redact_text content in
-  let limit = Discord_rest_client.message_content_limit in
-  let rlen = String.length redacted in
-  let head =
-    if rlen <= limit then redacted
-    else String.sub redacted 0 limit
+  (* Split head/overflow on a codepoint boundary so the head PATCH and
+     the overflow follow-up are each valid UTF-8 (a byte cut would split
+     a multi-byte char across the two). *)
+  let head, overflow_str =
+    Discord_rest_client.split_at_codepoint redacted
+      ~limit:Discord_rest_client.message_content_limit
   in
-  let overflow =
-    if rlen <= limit then None
-    else Some (String.sub redacted limit (rlen - limit))
-  in
+  let overflow = if overflow_str = "" then None else Some overflow_str in
   (head, overflow)
 
 let edit_message_silent ~token ~channel_id ~message_id ~content =

--- a/test/test_discord_rest_client.ml
+++ b/test/test_discord_rest_client.ml
@@ -320,6 +320,71 @@ let test_build_edit_embed_request_embeds_and_content () =
   | _ -> fail "expected Assoc"
 
 (* ---------------------------------------------------------------- *)
+(* split_at_codepoint / chunk_by_codepoint / truncate_to_limit       *)
+(* ---------------------------------------------------------------- *)
+
+(* Count Unicode scalar values in a UTF-8 string by stepping the
+   stdlib decoder. Invalid sequences advance one byte (utf_decode_length
+   is >= 1), so this terminates on any input. *)
+let count_codepoints s =
+  let n = String.length s in
+  let rec go i acc =
+    if i >= n then acc
+    else
+      let d = String.get_utf_8_uchar s i in
+      go (i + Uchar.utf_decode_length d) (acc + 1)
+  in
+  go 0 0
+
+(* "가" U+AC00 — a 3-byte UTF-8 char. byte 2000 lands mid-codepoint
+   (2000 / 3 = 666.7), so a byte cut would split it. *)
+let hangul = "\xea\xb0\x80"
+
+let repeat_hangul n =
+  let b = Buffer.create (n * 3) in
+  for _ = 1 to n do Buffer.add_string b hangul done;
+  Buffer.contents b
+
+let test_split_at_codepoint_korean_head_valid_utf8 () =
+  let s = repeat_hangul 2500 in
+  let head, tail = R.split_at_codepoint s ~limit:2000 in
+  check bool "head is valid UTF-8" true (String.is_valid_utf_8 head);
+  check bool "tail is valid UTF-8" true (String.is_valid_utf_8 tail);
+  check int "head is exactly 2000 codepoints" 2000 (count_codepoints head);
+  check int "tail is the remaining 500 codepoints" 500 (count_codepoints tail);
+  check string "head ^ tail reconstructs the original" s (head ^ tail)
+
+let test_split_at_codepoint_short_fits () =
+  let s = "hello" in
+  let head, tail = R.split_at_codepoint s ~limit:2000 in
+  check string "short head is the whole string" "hello" head;
+  check string "short tail is empty" "" tail
+
+let test_chunk_by_codepoint_korean () =
+  let s = repeat_hangul 2500 in
+  let chunks = R.chunk_by_codepoint s ~limit:2000 in
+  check int "2500 codepoints split into 2 chunks" 2 (List.length chunks);
+  List.iter
+    (fun c ->
+      check bool "each chunk valid UTF-8" true (String.is_valid_utf_8 c);
+      check bool "each chunk <= 2000 codepoints" true
+        (count_codepoints c <= 2000))
+    chunks;
+  check string "concat of chunks reconstructs the original" s
+    (String.concat "" chunks)
+
+let test_chunk_by_codepoint_empty () =
+  check int "empty input yields no chunks" 0
+    (List.length (R.chunk_by_codepoint "" ~limit:2000))
+
+let test_truncate_to_limit_korean_valid_utf8 () =
+  let s = repeat_hangul 2500 in
+  let t = R.truncate_to_limit s in
+  check bool "truncated is valid UTF-8" true (String.is_valid_utf_8 t);
+  check int "truncated to message_content_limit codepoints"
+    R.message_content_limit (count_codepoints t)
+
+(* ---------------------------------------------------------------- *)
 (* Entry                                                            *)
 (* ---------------------------------------------------------------- *)
 
@@ -370,6 +435,18 @@ let () =
             test_build_edit_embed_request_url_targets_message
         ; test_case "embeds and content both present" `Quick
             test_build_edit_embed_request_embeds_and_content
+        ] )
+    ; ( "codepoint_chunking"
+      , [ test_case "Korean split head/tail valid UTF-8 on boundary" `Quick
+            test_split_at_codepoint_korean_head_valid_utf8
+        ; test_case "short string fits without splitting" `Quick
+            test_split_at_codepoint_short_fits
+        ; test_case "Korean chunk_by_codepoint: 2 valid chunks" `Quick
+            test_chunk_by_codepoint_korean
+        ; test_case "empty input => no chunks" `Quick
+            test_chunk_by_codepoint_empty
+        ; test_case "truncate_to_limit keeps valid UTF-8" `Quick
+            test_truncate_to_limit_korean_valid_utf8
         ] )
     ; ( "parse_response"
       , [ test_case "2xx with id => Ok id" `Quick


### PR DESCRIPTION
## Summary

Discord's `message_content_limit = 2000` is measured in **Unicode scalar values** (codepoints), but every chunker/truncator in the Discord path cut on **byte** offsets (`String.sub _ 0 2000`). For multi-byte text this produced two distinct bugs:

1. **Invalid UTF-8 → 400.** A byte cut at offset 2000 lands mid-codepoint for Korean (3 bytes/char, 2000/3 = 666.7), so the chunk ended with a truncated multi-byte sequence. Discord rejects that with a 400 and the message is dropped.
2. **Over-chunking.** 2000 bytes is ~666 Korean chars, so a 700-char reply (well under the 2000-codepoint limit) was needlessly split into two messages.

From the 2026-06-13 merge audit (`~/me/reports/masc-merge-audit-2026-06-13.md`, F939).

## Change

Add a shared codepoint-aware primitive to `discord_rest_client` and route **all four** cut sites through it (full surface, not N-of-M):

- `discord_rest_client`:
  - `split_at_codepoint s ~limit` → `(head, tail)`, head ≤ `limit` codepoints, both valid UTF-8.
  - `chunk_by_codepoint`, and a codepoint-based `truncate_to_limit`.
  - `utf8_lead_len` decodes the lead byte; an invalid lead byte counts as 1 so iteration always advances (no infinite loop on malformed input).
- `keeper_chat_discord`: `send_message` chunking, the streaming PATCH `truncate`, **and** `final_head_and_overflow` (head PATCH + overflow follow-up — a byte cut there split a char across the two payloads).
- `channel_gate_discord_state`: `send_message` reply-aware chunking (preserves `reply_to_message_id` on the first chunk only).

The primitive lives in `discord_rest_client` (lower layer); `keeper_chat_discord` (keeper layer) already depended on it, so the dependency direction is unchanged.

## Validation

- `dune build --root . @check` and `dune build --root .` exit 0
- `test_discord_rest_client` 31 tests (5 new `codepoint_chunking`), `test_keeper_chat_discord` 5 tests — all green
- New regression: Korean string >2000 codepoints asserts each chunk is valid UTF-8, ≤ 2000 codepoints, and `concat == original`. **Mutation-checked**: reverting the boundary step to a 1-byte cut fails the "head is valid UTF-8" assertions (3 of 5 new tests turn red).

RFC-WAIVED: Discord REST/gate text-chunking path; not a credential/identity/sandbox/hooks subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
