### PR TITLE
ci(coverage): wire the coverage-checker self-test into CI (F946)

### DIFF
--- a/.github/workflows/test-coverage-check.yml
+++ b/.github/workflows/test-coverage-check.yml
@@ -5,6 +5,11 @@ on:
       - 'lib/**'
       - 'dashboard/**'
       - 'config/**'
+      # Editing the checker (or its self-test) must trigger this
+      # workflow so the self-test runs against the change. Without
+      # these the checker could regress with nothing to catch it.
+      - 'scripts/check_test_coverage.py'
+      - 'scripts/test_check_test_coverage.py'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,6 +28,12 @@ jobs:
           # shallow clone has neither the base ref nor the merge history,
           # so the diff fails and the check silently no-ops.
           fetch-depth: 0
+      - name: Self-test the coverage checker
+        # Runs unconditionally (independent of the per-PR coverage
+        # opt-out): this validates the checker tool itself, not whether
+        # this PR adds tests. A broken checker is caught here before it
+        # can mis-gate any PR.
+        run: python3 scripts/test_check_test_coverage.py
       - name: Check PR body for opt-out
         id: skip_check
         env:


### PR DESCRIPTION
## Summary

`scripts/test_check_test_coverage.py` — 5 unit tests for the coverage checker — existed in the repo but was **never run by any workflow**, while the checker it tests (`scripts/check_test_coverage.py`) gates every PR via `test-coverage-check.yml`. A regression in the checker (e.g. the commit-range / opt-out logic) had nothing to catch it. From the 2026-06-13 merge audit (F946).

## Change

`.github/workflows/test-coverage-check.yml`:

- Add a **"Self-test the coverage checker"** step running `python3 scripts/test_check_test_coverage.py`. It runs **unconditionally** — independent of the per-PR `# ci:skip-test-coverage` opt-out, which exempts a PR's own coverage, not the checker tool's correctness. A broken checker is caught here before it can mis-gate any PR.
- Add `scripts/check_test_coverage.py` and `scripts/test_check_test_coverage.py` to the trigger `paths`. Without this, the workflow triggers only on `lib/`/`dashboard/`/`config/` changes, so a checker-only edit would run **neither** the checker nor its self-test.

## Validation

- `python3 scripts/test_check_test_coverage.py` → 5 tests OK
- Workflow YAML parses (`yaml.safe_load`)

RFC-WAIVED: CI workflow wiring for an existing self-test; not a credential/identity/sandbox/hooks subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
