### PR TITLE
fix(keeper): preserve typed fleet blocker causes

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -40,6 +40,97 @@ type boot_meta_resolution = {
   materialized : bool;
 }
 
+type boot_meta_failure_cause =
+  | Missing_meta
+  | Meta_read_error
+  | Config_parse_failed
+  | Invalid_profile
+  | Sandbox_profile_required
+  | Goal_required
+  | Materialization_failed
+
+let boot_meta_failure_cause_label = function
+  | Missing_meta -> "missing_meta"
+  | Meta_read_error -> "meta_read_error"
+  | Config_parse_failed -> "config_parse_failed"
+  | Invalid_profile -> "invalid_profile"
+  | Sandbox_profile_required -> "sandbox_profile_required"
+  | Goal_required -> "goal_required"
+  | Materialization_failed -> "materialization_failed"
+
+type boot_meta_error = {
+  cause : boot_meta_failure_cause;
+  message : string;
+}
+
+let boot_meta_error cause message = { cause; message }
+
+type boot_meta_failure = {
+  keeper_name : string;
+  base_path : string;
+  cause : boot_meta_failure_cause;
+  error : string;
+  recorded_at : string;
+  recorded_at_unix : float;
+}
+
+let boot_meta_failures : (string, boot_meta_failure) Hashtbl.t =
+  Hashtbl.create 32
+let boot_meta_failures_mu = Stdlib.Mutex.create ()
+
+let boot_meta_failure_key ~base_path ~name = base_path ^ "\000" ^ name
+
+let with_boot_meta_failures_lock f =
+  Stdlib.Mutex.lock boot_meta_failures_mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock boot_meta_failures_mu) f
+
+let record_boot_meta_failure ~base_path ~name ~cause ~error =
+  let failure =
+    {
+      keeper_name = name;
+      base_path;
+      cause;
+      error;
+      recorded_at = now_iso ();
+      recorded_at_unix = Time_compat.now ();
+    }
+  in
+  with_boot_meta_failures_lock (fun () ->
+      Hashtbl.replace boot_meta_failures
+        (boot_meta_failure_key ~base_path ~name)
+        failure)
+
+let clear_boot_meta_failure ~base_path ~name =
+  with_boot_meta_failures_lock (fun () ->
+      Hashtbl.remove boot_meta_failures
+        (boot_meta_failure_key ~base_path ~name))
+
+let clear_boot_meta_failures_for_base_path base_path =
+  with_boot_meta_failures_lock (fun () ->
+      let keys =
+        Hashtbl.fold
+          (fun key (failure : boot_meta_failure) acc ->
+            if String.equal failure.base_path base_path then key :: acc else acc)
+          boot_meta_failures
+          []
+      in
+      List.iter (Hashtbl.remove boot_meta_failures) keys)
+
+let boot_meta_failure_for ~base_path ~name =
+  with_boot_meta_failures_lock (fun () ->
+      Hashtbl.find_opt boot_meta_failures
+        (boot_meta_failure_key ~base_path ~name))
+
+let remember_boot_meta_result ctx name result =
+  let base_path = ctx.config.base_path in
+  match result with
+  | Ok value ->
+      clear_boot_meta_failure ~base_path ~name;
+      Ok value
+  | Error { cause; message } ->
+      record_boot_meta_failure ~base_path ~name ~cause ~error:message;
+      Error message
+
 type autoboot_exclusion = {
   keeper_name : string;
   reason : string;
@@ -128,6 +219,25 @@ let apply_default opt current = match opt with Some v -> v | None -> current
 (** Same as [apply_default] but both TOML and meta are option-typed. *)
 let apply_default_opt opt current = match opt with Some _ -> opt | None -> current
 
+let first_non_empty_goal_candidate candidates =
+  candidates
+  |> List.find_map (function
+       | None -> None
+       | Some raw ->
+         let value = normalize_goal_horizon_text raw in
+         if value = "" then None else Some value)
+
+let declarative_materialization_goal
+    (defaults : Keeper_types_profile.keeper_profile_defaults) =
+  first_non_empty_goal_candidate
+    [
+      defaults.goal;
+      defaults.short_goal;
+      defaults.mid_goal;
+      defaults.long_goal;
+      defaults.will;
+      defaults.instructions;
+    ]
 
 let invalid_profile_defaults_error ~keeper_name detail =
   if String_util.contains_substring detail "runtime_id" then
@@ -136,6 +246,31 @@ let invalid_profile_defaults_error ~keeper_name detail =
       keeper_name detail
   else
     Printf.sprintf "invalid keeper profile for keeper %s: %s" keeper_name detail
+
+let profile_defaults_boot_error ~keeper_name detail =
+  let cause =
+    match Keeper_types_profile.keeper_toml_config_error_for_name keeper_name with
+    | Some _ -> Config_parse_failed
+    | None -> Invalid_profile
+  in
+  boot_meta_error cause (invalid_profile_defaults_error ~keeper_name detail)
+
+let sandbox_profile_required_boot_error ~keeper_name ~manifest_path =
+  let manifest_hint =
+    match manifest_path with
+    | Some path -> Printf.sprintf " (loaded from %s)" path
+    | None -> ""
+  in
+  let msg =
+    Printf.sprintf
+      "keeper %s rejected: sandbox_profile is required (allowed: %s)%s. \
+       Add e.g. `sandbox_profile = \"docker\"` to the keeper TOML."
+      keeper_name
+      (String.concat ", " Keeper_types_profile.valid_sandbox_profile_strings)
+      manifest_hint
+  in
+  Log.Keeper.warn "%s" msg;
+  boot_meta_error Sandbox_profile_required msg
 
 let effective_declarative_runtime_id
     (_defaults : Keeper_types_profile.keeper_profile_defaults)
@@ -156,7 +291,7 @@ let resynced_tool_access
   | Some tools -> normalize_tool_names tools
   | None -> meta.tool_access
 
-let ensure_keeper_meta config name =
+let ensure_keeper_meta_with_cause config name =
   match read_meta config name with
   | Ok (Some meta) ->
     (
@@ -169,7 +304,7 @@ let ensure_keeper_meta config name =
     in
     match defaults_result with
     | Error detail ->
-        Error (invalid_profile_defaults_error ~keeper_name:meta.name detail)
+        Error (profile_defaults_boot_error ~keeper_name:meta.name detail)
     | Ok defaults ->
 
     (* --- Proactive --- *)
@@ -185,7 +320,17 @@ let ensure_keeper_meta config name =
       apply_default defaults.social_model meta.social_model
       |> Keeper_social_model.normalize_social_model in
     (* --- Personality --- *)
-    let target_goal = apply_default defaults.goal meta.goal in
+    let target_goal =
+      match defaults.goal with
+      | Some goal -> goal
+      | None -> (
+          match normalize_goal_horizon_text meta.goal with
+          | "" -> (
+              match declarative_materialization_goal defaults with
+              | Some derived -> derived
+              | None -> meta.goal)
+          | normalized -> normalized)
+    in
     let target_short_goal = apply_default defaults.short_goal meta.short_goal in
     let target_mid_goal = apply_default defaults.mid_goal meta.mid_goal in
     let target_long_goal = apply_default defaults.long_goal meta.long_goal in
@@ -220,22 +365,10 @@ let ensure_keeper_meta config name =
       match defaults.sandbox_profile with
       | Some sp -> Ok sp
       | None ->
-        let manifest_hint =
-          match defaults.manifest_path with
-          | Some path -> Printf.sprintf " (loaded from %s)" path
-          | None -> ""
-        in
-        let msg =
-          Printf.sprintf
-            "keeper %s rejected: sandbox_profile is required (allowed: %s)%s. \
-             Add e.g. `sandbox_profile = \"docker\"` to the keeper TOML."
-            meta.name
-            (String.concat ", "
-               Keeper_types_profile.valid_sandbox_profile_strings)
-            manifest_hint
-        in
-        Log.Keeper.warn "%s" msg;
-        Error msg
+        Error
+          (sandbox_profile_required_boot_error
+             ~keeper_name:meta.name
+             ~manifest_path:defaults.manifest_path)
     in
     (match target_sandbox_profile_result with
      | Error e -> Error e
@@ -333,42 +466,110 @@ let ensure_keeper_meta config name =
   | Ok None ->
     Log.Keeper.warn
       "ensure_keeper_meta: no persistent meta for %s — run keeper_up to initialize" name;
-    Error (Printf.sprintf "no persistent meta for %s — run keeper_up to initialize" name)
-  | Error msg -> Error msg
+    Error
+      (boot_meta_error Missing_meta
+         (Printf.sprintf
+            "no persistent meta for %s — run keeper_up to initialize"
+            name))
+  | Error msg -> Error (boot_meta_error Meta_read_error msg)
+
+let ensure_keeper_meta config name =
+  match ensure_keeper_meta_with_cause config name with
+  | Ok meta -> Ok meta
+  | Error err -> Error err.message
+
+let declarative_materialization_args name defaults =
+  let fields = [ ("name", `String name) ] in
+  let fields =
+    match declarative_materialization_goal defaults with
+    | None -> fields
+    | Some goal ->
+        Log.Keeper.info
+          "bootstrapping declarative keeper %s with derived goal from TOML defaults"
+          name;
+        ("goal", `String goal) :: fields
+  in
+  `Assoc (List.rev fields)
+
+let declarative_materialization_defaults name =
+  match load_keeper_profile_defaults_result name with
+  | Error detail -> Error (profile_defaults_boot_error ~keeper_name:name detail)
+  | Ok defaults -> (
+      match defaults.sandbox_profile with
+      | Some _ -> Ok defaults
+      | None ->
+          Error
+            (sandbox_profile_required_boot_error
+               ~keeper_name:name
+               ~manifest_path:defaults.manifest_path))
+
+let goal_required_boot_error ~name ~toml_path =
+  boot_meta_error Goal_required
+    (Printf.sprintf
+       "failed to materialize declarative keeper %s from %s: goal is required when creating a keeper"
+       name toml_path)
+
+let materialization_failed_boot_error ~name ~toml_path ~body =
+  boot_meta_error Materialization_failed
+    (Printf.sprintf
+       "failed to materialize declarative keeper %s from %s: %s"
+       name toml_path body)
+
+let materialized_reload_boot_error ~name ~toml_path (err : boot_meta_error) =
+  boot_meta_error err.cause
+    (Printf.sprintf
+       "materialized declarative keeper %s from %s but failed to reload meta: %s"
+       name toml_path err.message)
 
 let load_or_materialize_boot_meta (ctx : _ context) name
     : (boot_meta_resolution, string) result =
-  match ensure_keeper_meta ctx.config name with
-  | Ok meta -> Ok { meta; materialized = false }
-  | Error original_error -> (
-      match Config_dir_resolver.keeper_toml_path_opt name with
-      | None -> Error original_error
-      | Some toml_path ->
-          Log.Keeper.info
-            "bootstrapping declarative keeper %s from %s"
-            name toml_path;
-          let result =
-            Keeper_turn.handle_keeper_up ctx
-              (`Assoc [ ("name", `String name) ])
-          in
-          if not (tool_result_success result) then
-            Error
-              (Printf.sprintf
-                 "failed to materialize declarative keeper %s from %s: %s"
-                 name toml_path (tool_result_body result))
-          else
-            match read_meta ctx.config name with
-            | Ok (Some meta) -> Ok { meta; materialized = true }
-            | Ok None ->
-                Error
-                  (Printf.sprintf
-                     "materialized declarative keeper %s from %s but no meta was written"
-                     name toml_path)
-            | Error msg ->
-                Error
-                  (Printf.sprintf
-                     "materialized declarative keeper %s from %s but failed to reload meta: %s"
-                     name toml_path msg))
+  let result =
+    match ensure_keeper_meta_with_cause ctx.config name with
+    | Ok meta -> Ok { meta; materialized = false }
+    | Error original_error -> (
+        match Config_dir_resolver.keeper_toml_path_opt name with
+        | None -> Error original_error
+        | Some toml_path -> (
+            Log.Keeper.info
+              "bootstrapping declarative keeper %s from %s"
+              name toml_path;
+            match declarative_materialization_defaults name with
+            | Error err -> Error err
+            | Ok defaults -> (
+                match declarative_materialization_goal defaults with
+                | None -> Error (goal_required_boot_error ~name ~toml_path)
+                | Some _ ->
+            let result =
+              Keeper_turn.handle_keeper_up ctx
+                (declarative_materialization_args name defaults)
+            in
+            if not (tool_result_success result) then
+              Error
+                (materialization_failed_boot_error
+                   ~name
+                   ~toml_path
+                   ~body:(tool_result_body result))
+            else
+              match read_meta ctx.config name with
+              | Ok None ->
+                  Error
+                    (boot_meta_error Missing_meta
+                       (Printf.sprintf
+                          "materialized declarative keeper %s from %s but no meta was written"
+                          name toml_path))
+              | Error msg ->
+                  Error
+                    (boot_meta_error Meta_read_error
+                       (Printf.sprintf
+                          "materialized declarative keeper %s from %s but failed to reload meta: %s"
+                          name toml_path msg))
+              | Ok (Some _) -> (
+                  match ensure_keeper_meta_with_cause ctx.config name with
+                  | Ok meta -> Ok { meta; materialized = true }
+                  | Error msg ->
+                      Error (materialized_reload_boot_error ~name ~toml_path msg)))))
+  in
+  remember_boot_meta_result ctx name result
 
 type keeper_bootstrap_stats = {
   scanned: int;
@@ -747,4 +948,5 @@ let stop_keepalive ?base_path name =
 
 let reset_test_state base_path =
   stop_supervisor_sweep base_path;
+  clear_boot_meta_failures_for_base_path base_path;
   Hashtbl.remove existing_keepalive_bootstrap_done base_path

--- a/lib/keeper/keeper_runtime.mli
+++ b/lib/keeper/keeper_runtime.mli
@@ -41,6 +41,39 @@ type boot_meta_resolution = {
 }
 (** Result of [load_or_materialize_boot_meta]. *)
 
+type boot_meta_failure_cause =
+  | Missing_meta
+  | Meta_read_error
+  | Config_parse_failed
+  | Invalid_profile
+  | Sandbox_profile_required
+  | Goal_required
+  | Materialization_failed
+(** Structured cause for the last boot/materialization failure.  Labels are
+    rendered only at JSON/log boundaries; fleet recovery policy should pattern
+    match this type, not parse the human-facing [error] text. *)
+
+val boot_meta_failure_cause_label : boot_meta_failure_cause -> string
+(** Stable JSON label for {!boot_meta_failure_cause}. *)
+
+type boot_meta_failure = {
+  keeper_name : string;
+  base_path : string;
+  cause : boot_meta_failure_cause;
+  error : string;
+  recorded_at : string;
+  recorded_at_unix : float;
+}
+(** Last boot/materialization failure observed for one keeper in one
+    workspace.  Kept in memory so health surfaces the current supervisor
+    blocker without scraping logs. *)
+
+val boot_meta_failure_for :
+  base_path:string -> name:string -> boot_meta_failure option
+(** Lookup the last boot/materialization failure for [name] in [base_path], if
+    the current process has observed one.  Cleared when the keeper loads or
+    materializes successfully. *)
+
 type autoboot_exclusion = {
   keeper_name : string;
   reason : string;

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -398,12 +398,14 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
             ~bootable_names:scan.bootable_names
             ~autoboot_scan:scan.autoboot_scan
             ~phase_snapshot
+            ?base_path
             ~phase_counts
             ~paused_keepers_json
             ()
         | None ->
           keeper_fleet_safety_health_json
             ~phase_snapshot
+            ?base_path
             ~phase_counts
             ~paused_keepers_json
             ())

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -413,33 +413,28 @@ let keeper_phase_snapshot ?base_path () =
             }
           in
           let counts = acc.counts in
+          let can_execute = Keeper_state_machine.can_execute_turn entry.phase in
+          let executable = if can_execute then counts.executable + 1 else counts.executable in
           let executable_names =
-            if Keeper_state_machine.can_execute_turn entry.phase then
-              entry.name :: acc.executable_names
+            if can_execute then entry.name :: acc.executable_names
             else acc.executable_names
-          in
-          let executable =
-            if Keeper_state_machine.can_execute_turn entry.phase then
-              counts.executable + 1
-            else counts.executable
           in
           (* Keepers in Failing phase with restart budget remaining are
              expected to recover on the next heartbeat cycle — count them
              separately so fleet safety does not report a spurious shortfall
              during transient failures (issue #17218). *)
-          let recovering =
+          let is_recovering =
             match entry.phase with
             | Keeper_state_machine.Failing
-              when entry.conditions.restart_budget_remaining ->
-              counts.recovering + 1
-            | _ -> counts.recovering
+              when entry.conditions.restart_budget_remaining -> true
+            | _ -> false
+          in
+          let recovering =
+            if is_recovering then counts.recovering + 1 else counts.recovering
           in
           let recovering_names =
-            match entry.phase with
-            | Keeper_state_machine.Failing
-              when entry.conditions.restart_budget_remaining ->
-              entry.name :: acc.recovering_names
-            | _ -> acc.recovering_names
+            if is_recovering then entry.name :: acc.recovering_names
+            else acc.recovering_names
           in
           match entry.phase with
           | Keeper_state_machine.Running ->
@@ -489,10 +484,131 @@ let keeper_phase_snapshot ?base_path () =
 
 let keeper_phase_counts ?base_path () = (keeper_phase_snapshot ?base_path ()).counts
 
+let string_set_of_list values =
+  List.fold_left (fun acc value -> String_set.add value acc) String_set.empty values
+
+let json_string_list_field field = function
+  | `Assoc fields -> (
+      match List.assoc_opt field fields with
+      | Some (`List values) ->
+          values
+          |> List.filter_map (function
+               | `String value -> Some value
+               | _ -> None)
+          |> sorted_unique_strings
+      | _ -> [])
+  | _ -> []
+
+type blocked_keeper_reason =
+  | Durable_paused_autoboot_enabled
+  | Meta_read_error
+  | Not_bootable
+  | Boot_failure of Keeper_runtime.boot_meta_failure_cause
+  | Phase of string
+  | Not_registered
+  | Not_running
+  | Unknown
+
+let blocked_keeper_reason_label = function
+  | Durable_paused_autoboot_enabled -> "durable_paused_autoboot_enabled"
+  | Meta_read_error -> "meta_read_error"
+  | Not_bootable -> "not_bootable"
+  | Boot_failure cause -> Keeper_runtime.boot_meta_failure_cause_label cause
+  | Phase phase -> "phase_" ^ phase
+  | Not_registered -> "not_registered"
+  | Not_running -> "not_running"
+  | Unknown -> "unknown"
+
+let blocked_keeper_action = function
+  | Durable_paused_autoboot_enabled -> "resume_or_leave_paused"
+  | Meta_read_error -> "repair_keeper_meta_file"
+  | Not_bootable -> "add_keeper_toml_or_disable_stale_autoboot_meta"
+  | Boot_failure Keeper_runtime.Missing_meta -> "run_keeper_up_or_recreate_meta"
+  | Boot_failure Keeper_runtime.Meta_read_error -> "repair_keeper_meta_file"
+  | Boot_failure Keeper_runtime.Config_parse_failed
+  | Boot_failure Keeper_runtime.Invalid_profile ->
+      "repair_keeper_toml_config"
+  | Boot_failure Keeper_runtime.Sandbox_profile_required ->
+      "add_sandbox_profile_to_keeper_toml"
+  | Boot_failure Keeper_runtime.Goal_required ->
+      "add_goal_or_goal_horizon_to_keeper_toml"
+  | Boot_failure Keeper_runtime.Materialization_failed ->
+      "inspect_keeper_autoboot_logs"
+  | Phase _
+  | Not_registered ->
+      "start_or_recover_keeper"
+  | Not_running -> "start_or_recover_keeper"
+  | Unknown -> "inspect_keeper_autoboot_logs"
+
+let blocked_keeper_detail_json
+    ?base_path
+    ?phase
+    ~bootable_set
+    ~capacity_set
+    ~paused_set
+    ~read_error_set
+    name =
+  let is_paused = String_set.mem name paused_set in
+  let is_bootable = String_set.mem name bootable_set in
+  let is_capacity = String_set.mem name capacity_set in
+  let has_read_error = String_set.mem name read_error_set in
+  let last_failure =
+    match base_path with
+    | None -> None
+    | Some base_path -> Keeper_runtime.boot_meta_failure_for ~base_path ~name
+  in
+  let reason =
+    if is_paused then Durable_paused_autoboot_enabled
+    else if has_read_error then Meta_read_error
+    else
+      match last_failure with
+      | Some failure -> Boot_failure failure.Keeper_runtime.cause
+      | None ->
+          if not is_bootable then Not_bootable
+          else if not is_capacity then
+            (match phase with
+             | Some phase -> Phase phase
+             | None -> Not_registered)
+          else Unknown
+  in
+  let last_failure_fields =
+    match last_failure with
+    | None ->
+        [
+          ("last_bootstrap_reason", `Null);
+          ("last_bootstrap_error", `Null);
+          ("last_bootstrap_recorded_at", `Null);
+        ]
+    | Some failure ->
+        [
+          ( "last_bootstrap_reason"
+          , `String
+              (Keeper_runtime.boot_meta_failure_cause_label
+                 failure.Keeper_runtime.cause) );
+          ("last_bootstrap_error", `String failure.Keeper_runtime.error);
+          ("last_bootstrap_recorded_at", `String failure.Keeper_runtime.recorded_at);
+        ]
+  in
+  `Assoc
+    ([
+       ("keeper", `String name);
+       ("name", `String name);
+       ("reason", `String (blocked_keeper_reason_label reason));
+       ("action", `String (blocked_keeper_action reason));
+       ("phase", Json_util.string_opt_to_json phase);
+       ("bootable", `Bool is_bootable);
+       ("reaction_capacity", `Bool is_capacity);
+       ("paused", `Bool is_paused);
+       ("meta_read_error", `Bool has_read_error);
+     ]
+     @ last_failure_fields)
+
 let keeper_fleet_safety_health_json
     ?bootable_names:bootable_names_override
     ?autoboot_scan:autoboot_scan_override
     ?phase_snapshot
+    ?base_path
+    ?reaction_capacity_names
     ~phase_counts
     ~paused_keepers_json
     () =
@@ -516,6 +632,39 @@ let keeper_fleet_safety_health_json
   in
   let bootable_count = List.length bootable_names in
   let target_count = List.length autoboot_scan.autoboot_names in
+  let runtime_base_path =
+    match base_path with
+    | Some _ as value -> value
+    | None ->
+      current_server_state_opt ()
+      |> Option.map (fun state -> state.Mcp_server.workspace_config.base_path)
+  in
+  let fallback_running_names =
+    match reaction_capacity_names with
+    | Some names -> sorted_unique_strings names
+    | None -> running_keeper_names ?base_path:runtime_base_path ()
+  in
+  let running_names =
+    match phase_snapshot with
+    | Some snapshot -> snapshot.running_names
+    | None -> fallback_running_names
+  in
+  let recovering_names =
+    match phase_snapshot with
+    | Some snapshot -> snapshot.recovering_names
+    | None -> []
+  in
+  let executable_names =
+    match phase_snapshot with
+    | Some snapshot -> snapshot.executable_names
+    | None -> fallback_running_names
+  in
+  let phase_names =
+    match phase_snapshot with
+    | Some snapshot -> snapshot.phase_names
+    | None -> []
+  in
+  let phase_name name = List.assoc_opt name phase_names in
   let minimum_running_fibers =
     if target_count <= 1 then target_count else 2
   in
@@ -552,47 +701,12 @@ let keeper_fleet_safety_health_json
        | _ -> 0)
     | _ -> 0
   in
-  let json_string_list_field name =
-    match paused_keepers_json with
-    | `Assoc fields -> (
-      match List.assoc_opt name fields with
-      | Some (`List values) ->
-        values
-        |> List.filter_map (function
-             | `String value -> Some value
-             | _ -> None)
-        |> sorted_unique_strings
-      | _ -> [] )
-    | _ -> []
-  in
-  let paused_autoboot_names = json_string_list_field "autoboot_enabled_names" in
   let names_not_in active_names =
     let active_names = sorted_unique_strings active_names in
     autoboot_scan.autoboot_names
     |> List.filter (fun name -> not (List.mem name active_names))
     |> sorted_unique_strings
   in
-  let running_names =
-    match phase_snapshot with
-    | Some snapshot -> snapshot.running_names
-    | None -> []
-  in
-  let recovering_names =
-    match phase_snapshot with
-    | Some snapshot -> snapshot.recovering_names
-    | None -> []
-  in
-  let executable_names =
-    match phase_snapshot with
-    | Some snapshot -> snapshot.executable_names
-    | None -> []
-  in
-  let phase_names =
-    match phase_snapshot with
-    | Some snapshot -> snapshot.phase_names
-    | None -> []
-  in
-  let phase_name name = List.assoc_opt name phase_names in
   let status =
     if no_executable_keeper_fibers then "blocked"
     else if no_running_fibers then "degraded"
@@ -612,23 +726,34 @@ let keeper_fleet_safety_health_json
     then names_not_in (running_names @ recovering_names)
     else []
   in
-  let blocked_keeper_reason name =
-    if List.mem name paused_autoboot_names then "durable_paused_autoboot_enabled"
-    else
-      match phase_name name with
-      | Some "paused" -> "phase_paused"
-      | Some phase -> "phase_" ^ phase
-      | None -> "not_registered"
+  let active_capacity_names =
+    if no_executable_keeper_fibers then executable_names
+    else if no_running_fibers || low_running_fiber_margin || reaction_capacity_below_target
+    then running_names @ recovering_names
+    else running_names
+  in
+  let bootable_set = string_set_of_list bootable_names in
+  let capacity_set = string_set_of_list active_capacity_names in
+  let paused_set =
+    paused_keepers_json
+    |> json_string_list_field "autoboot_enabled_names"
+    |> string_set_of_list
+  in
+  let read_error_set =
+    autoboot_scan.read_errors |> List.map fst |> string_set_of_list
   in
   let blocked_keeper_reasons =
     blocked_keeper_names
-    |> List.map (fun name ->
-         `Assoc
-           [
-             ("keeper", `String name);
-             ("reason", `String (blocked_keeper_reason name));
-             ("phase", Json_util.string_opt_to_json (phase_name name));
-           ])
+    |> List.map
+         (fun name ->
+           blocked_keeper_detail_json
+             ?base_path:runtime_base_path
+             ?phase:(phase_name name)
+             ~bootable_set
+             ~capacity_set
+             ~paused_set
+             ~read_error_set
+             name)
   in
   let blocker =
     if no_executable_keeper_fibers then Some "no_executable_keeper_fibers"

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -78,6 +78,8 @@ val keeper_fleet_safety_health_json :
   ?bootable_names:string list ->
   ?autoboot_scan:autoboot_keeper_scan ->
   ?phase_snapshot:keeper_phase_snapshot ->
+  ?base_path:string ->
+  ?reaction_capacity_names:string list ->
   phase_counts:keeper_phase_counts ->
   paused_keepers_json:Yojson.Safe.t ->
   unit ->

--- a/lib/server/server_routes_http_runtime_health_fleet.ml
+++ b/lib/server/server_routes_http_runtime_health_fleet.ml
@@ -94,12 +94,14 @@ let keeper_fleet_runtime_resolution_base_fields
         ~bootable_names:scan.bootable_names
         ~autoboot_scan:scan.autoboot_scan
         ~phase_snapshot
+        ?base_path
         ~phase_counts
         ~paused_keepers_json
         ()
   | None ->
     keeper_fleet_safety_health_json
       ~phase_snapshot
+      ?base_path
       ~phase_counts
       ~paused_keepers_json
       ()

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -86,6 +86,35 @@ sandbox_profile = "local"
 |}
        name)
 
+let write_keeper_toml_without_goal config_dir ~name ~will =
+  write_file
+    (Filename.concat (Filename.concat config_dir "keepers") (name ^ ".toml"))
+    (Printf.sprintf
+       {|
+[keeper]
+name = "%s"
+sandbox_profile = "local"
+proactive_enabled = false
+will = "%s"
+needs = "keep fleet safety diagnosable"
+desires = "avoid silent declarative boot failures"
+|}
+       name will);
+  Keeper_types_profile.invalidate_keeper_profile_defaults_cache name
+
+let write_empty_keeper_toml_without_goal config_dir ~name =
+  write_file
+    (Filename.concat (Filename.concat config_dir "keepers") (name ^ ".toml"))
+    (Printf.sprintf
+       {|
+[keeper]
+name = "%s"
+sandbox_profile = "local"
+proactive_enabled = false
+|}
+       name);
+  Keeper_types_profile.invalidate_keeper_profile_defaults_cache name
+
 let with_restart_launch_noop f =
   Sup.with_restart_launch_noop_for_test f
 
@@ -540,6 +569,73 @@ let test_missing_persona_without_profile_or_toml_is_error () =
      with
      | Sup.Persona_drift_error -> true
      | Sup.Persona_drift_warn -> false)
+
+let keeper_runtime_context env sw config : _ Keeper_types_profile.context =
+  {
+    config;
+    agent_name = "supervisor";
+    sw;
+    clock = Eio.Stdenv.clock env;
+    proc_mgr = Some (Eio.Stdenv.process_mgr env);
+    net = Some (Eio.Stdenv.net env);
+  }
+
+let test_declarative_boot_materializes_goal_from_will () =
+  with_config_dir @@ fun config_dir ->
+  Eio_main.run @@ fun env ->
+  ensure_test_runtime ();
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = Filename.dirname config_dir in
+  let name = "intent-only" in
+  let will = "watch fleet safety and repair keeper bootstrap" in
+  write_keeper_toml_without_goal config_dir ~name ~will;
+  Eio.Switch.on_release sw (fun () ->
+      Reg.clear ();
+      KR.reset_test_state base_dir);
+  let config = Masc.Workspace.default_config base_dir in
+  ignore (Masc.Workspace.init config ~agent_name:(Some "supervisor"));
+  let ctx = keeper_runtime_context env sw config in
+  Fun.protect
+    ~finally:(fun () -> KR.stop_keepalive ~base_path:config.base_path name)
+    (fun () ->
+      match KR.load_or_materialize_boot_meta ctx name with
+      | Error err -> fail err
+      | Ok resolution ->
+      check bool "materialized from declarative TOML" true resolution.materialized;
+      check string "goal derived from will" will resolution.meta.goal;
+      check bool "boot failure cleared" true
+        (Option.is_none
+           (KR.boot_meta_failure_for ~base_path:config.base_path ~name)))
+
+let test_declarative_boot_records_goal_required_failure () =
+  with_config_dir @@ fun config_dir ->
+  Eio_main.run @@ fun env ->
+  ensure_test_runtime ();
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = Filename.dirname config_dir in
+  let name = "empty-intent" in
+  write_empty_keeper_toml_without_goal config_dir ~name;
+  Eio.Switch.on_release sw (fun () ->
+      Reg.clear ();
+      KR.reset_test_state base_dir);
+  let config = Masc.Workspace.default_config base_dir in
+  ignore (Masc.Workspace.init config ~agent_name:(Some "supervisor"));
+  let ctx = keeper_runtime_context env sw config in
+  (match KR.load_or_materialize_boot_meta ctx name with
+   | Ok _ -> fail "expected declarative keeper without any intent to fail"
+   | Error err ->
+       check bool "failure mentions goal" true
+         (String_util.contains_substring err "goal is required"));
+  match KR.boot_meta_failure_for ~base_path:config.base_path ~name with
+  | None -> fail "expected boot meta failure to be recorded"
+  | Some failure ->
+      check string "failure keeper name" name failure.keeper_name;
+      check string "recorded failure cause" "goal_required"
+        (KR.boot_meta_failure_cause_label failure.cause);
+      check bool "recorded failure keeps raw error" true
+        (String_util.contains_substring failure.error "goal is required")
 
 let registered_entries names =
   Reg.clear ();
@@ -2114,6 +2210,12 @@ let () =
         test_missing_persona_with_inline_toml_is_warn;
       test_case "missing persona without TOML is ERROR" `Quick
         test_missing_persona_without_profile_or_toml_is_error;
+    ];
+    "boot_meta_materialization", [
+      test_case "declarative boot derives missing goal from will" `Quick
+        test_declarative_boot_materializes_goal_from_will;
+      test_case "declarative boot records goal-required failure" `Quick
+        test_declarative_boot_records_goal_required_failure;
     ];
     "fiber_health", [
       test_case "unknown for unregistered" `Quick test_fiber_health_unknown;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1308,6 +1308,19 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
              |> List.map (fun row ->
                   ( row |> member "keeper" |> to_string
                   , row |> member "reason" |> to_string )));
+          let blocked_detail name =
+            fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            |> List.find (fun row -> row |> member "keeper" |> to_string = name)
+          in
+          Alcotest.(check string) "health keeps typed row name alias"
+            "capacity-paused"
+            (blocked_detail "capacity-paused" |> member "name" |> to_string);
+          Alcotest.(check string) "health suggests paused action"
+            "resume_or_leave_paused"
+            (blocked_detail "capacity-paused" |> member "action" |> to_string);
+          Alcotest.(check string) "health suggests unregistered action"
+            "start_or_recover_keeper"
+            (blocked_detail "example" |> member "action" |> to_string);
           Alcotest.(check string) "health marks fleet degraded" "degraded"
             (fleet_safety |> member "status" |> to_string);
           Alcotest.(check string) "health marks target-capacity blocker"


### PR DESCRIPTION
Supersedes #21114.

This relands the keeper fleet diagnostics work from a clean branch, but fixes the blocker/action diagnosis at the source instead of mapping raw strings.

Changes:
- record boot/materialization failures with a typed boot_meta_failure_cause
- derive goal-required, sandbox-profile-required, config-parse, meta-read, and missing-meta causes structurally before JSON rendering
- make fleet health choose blocked keeper actions by pattern matching typed causes
- keep JSON labels only at the boundary: reason, last_bootstrap_reason, action
- preserve current phase-snapshot diagnostics while adding typed reason/action rows
- thread the active runtime base_path into fleet-safety health so last bootstrap failures are read from the correct live root
- remove the generic bootstrap_failed fallback cause from the new path

Validation:
- ocamlformat --check lib/keeper/keeper_runtime.ml lib/keeper/keeper_runtime.mli lib/server/server_routes_http_runtime.ml lib/server/server_routes_http_runtime_health_fleet.ml lib/server/server_routes_http_runtime_fleet_scan.ml lib/server/server_routes_http_runtime_fleet_scan.mli test/test_keeper_supervisor.ml test/test_server_runtime_bootstrap.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_keeper_supervisor.exe test/test_server_runtime_bootstrap.exe
- ./_build/default/test/test_keeper_supervisor.exe test boot_meta_materialization --show-errors
- ./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 22-25 --show-errors
- ./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 26-28 --show-errors
- targeted grep found no string-based blocked keeper action table or generic bootstrap_failed mapping in the touched path