### PR TITLE
fix(streamable_http): make session.last_seen an explicit Atomic.t

### DIFF
--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -13,7 +13,7 @@ type transport = Streamable_HTTP
 type session = {
   id: string;
   created_at: float;
-  mutable last_seen: float [@atomic];
+  last_seen: float Atomic.t;
   transport: transport;
   subscriptions: string list;
 }
@@ -51,7 +51,7 @@ module Session = struct
       let session = {
         id = generate_id ();
         created_at = Time_compat.now ();
-        last_seen = Time_compat.now ();
+        last_seen = Atomic.make (Time_compat.now ());
         transport;
         subscriptions = [];
       } in
@@ -62,7 +62,7 @@ module Session = struct
     with_lock (fun () -> StringMap.find_opt id !sessions)
 
   let touch session =
-    session.last_seen <- Time_compat.now ()
+    Atomic.set session.last_seen (Time_compat.now ())
 
   let remove id =
     with_lock (fun () -> sessions := StringMap.remove id !sessions)
@@ -79,7 +79,7 @@ module Session = struct
     let cutoff = now -. ttl_seconds in
     with_lock (fun () ->
       let to_remove = StringMap.fold (fun id session acc ->
-        if session.last_seen < cutoff then id :: acc else acc
+        if Atomic.get session.last_seen < cutoff then id :: acc else acc
       ) !sessions [] in
       List.iter (fun id -> sessions := StringMap.remove id !sessions) to_remove;
       List.length to_remove)

--- a/lib/streamable_http.mli
+++ b/lib/streamable_http.mli
@@ -16,7 +16,7 @@ type transport = Streamable_HTTP
 type session = {
   id: string;                 (** Unique session ID (UUID) *)
   created_at: float;          (** Unix timestamp *)
-  mutable last_seen: float [@atomic];   (** Last activity timestamp; atomic read/write for unlocked concurrent update via [Session.touch]. *)
+  last_seen: float Atomic.t;   (** Last activity timestamp; atomic read/write for unlocked concurrent update via [Session.touch]. *)
   transport: transport;       (** Transport type for this session *)
   subscriptions: string list; (** Event types subscribed *)
 }

--- a/test/test_streamable_http.ml
+++ b/test/test_streamable_http.ml
@@ -17,10 +17,10 @@ let test_session_find () =
 
 let test_session_touch () =
   let session = SH.Session.create ~transport:SH.Streamable_HTTP in
-  let old_time = session.last_seen in
+  let old_time = Atomic.get session.last_seen in
   Time_compat.sleep 0.01;
   SH.Session.touch session;
-  Alcotest.(check bool) "last_seen updated" true (session.last_seen > old_time)
+  Alcotest.(check bool) "last_seen updated" true (Atomic.get session.last_seen > old_time)
 
 let test_session_cleanup () =
   (* Create a session that will expire immediately *)


### PR DESCRIPTION
The session record used [mutable last_seen: float [@atomic]], mixing locked reads in cleanup with unlocked writes in touch. Replace it with an explicit [float Atomic.t] so concurrent touches are a proper atomic store and cleanup can read safely without the global lock.\n\nRefs: audit finding MASC-mutable-ref-streamable-http-touch