### PR TITLE
perf(keeper): bound external-attention dedup scan to a recent tail (F943)

### DIFF
--- a/lib/keeper/keeper_external_attention.ml
+++ b/lib/keeper/keeper_external_attention.ml
@@ -19,6 +19,17 @@ let persistence_surface = "keeper_external_attention"
 
 let default_claim_stale_after_s = 900.0
 
+(* Dedup scan window for [record]. The store is append-only and
+   unbounded, so parsing the whole file on every record is O(file) per
+   call — O(N^2) across N inbound messages on the Discord hot path. The
+   dedup check only needs to catch gateway *redelivery* (Discord replays
+   missed events after a RESUME), which is bounded to recent events, so
+   scanning the last [dedup_window_bytes] is both sufficient and O(1) in
+   file size (one [Fs_compat.read_slice]). A record older than the
+   window can in principle be re-appended on a very late redelivery —
+   that is a rare, harmless duplicate, never data loss. *)
+let dedup_window_bytes = 64 * 1024
+
 (* RFC-0232 P5: the surface vocabulary moved to the shared [Surface_ref]
    module; this equation re-exports it so existing consumers keep
    constructing/matching [Keeper_external_attention.Dashboard] etc. *)
@@ -436,8 +447,39 @@ let recorded_item_by_event_id events event_id =
       | Recorded _ | Claimed_for_turn _ | Resolved _ | Ignored _ -> None)
     events
 
+(* Events from the last [dedup_window_bytes] of the store, for the
+   redelivery dedup check in [record]. Reads a bounded tail via
+   [read_slice] instead of folding the whole file, so it stays O(window)
+   regardless of how large the append-only store has grown. The slice
+   starts mid-line (and the writer may be mid-append), so only the bytes
+   strictly between the first and last newline are complete lines —
+   parsing just those avoids feeding a partial line to [parse_line]
+   (which would otherwise log a spurious read-drop on every call). *)
+let load_recent_events ~base_path ~keeper_name =
+  let path = attention_path ~base_path ~keeper_name in
+  match Fs_compat.file_size path with
+  | None -> []
+  | Some size when size <= dedup_window_bytes ->
+      (* Small store: the full scan is already within the window. *)
+      load_events ~base_path ~keeper_name
+  | Some size ->
+      let from = size - dedup_window_bytes in
+      let slice = Fs_compat.read_slice ~path ~from ~len:dedup_window_bytes in
+      (match String.index_opt slice '\n', String.rindex_opt slice '\n' with
+       | Some i, Some j when j > i ->
+           String.sub slice (i + 1) (j - i - 1)
+           |> String.split_on_char '\n'
+           |> List.filter_map (fun line ->
+                  let line = String.trim line in
+                  if line = "" then None else parse_line ~file_path:path line)
+       | _ ->
+           (* Fewer than two newlines in the window: no complete line to
+              dedup against. Accept the (rare) duplicate over a partial
+              parse. *)
+           [])
+
 let record ~base_path (item : item) =
-  let events = load_events ~base_path ~keeper_name:item.keeper_name in
+  let events = load_recent_events ~base_path ~keeper_name:item.keeper_name in
   match recorded_item_by_event_id events item.event_id with
   | Some existing -> `Duplicate existing
   | None -> (

--- a/lib/keeper/keeper_external_attention.mli
+++ b/lib/keeper/keeper_external_attention.mli
@@ -127,8 +127,18 @@ type record_result =
   | `Error of string
   ]
 
+val dedup_window_bytes : int
+(** Size of the recent-tail window [record] scans for duplicate
+    [event_id]s. The store is append-only and unbounded; scanning only
+    this tail keeps [record] O(1) in file size. Exposed for tests that
+    need to size input past the window. *)
+
 val record : base_path:string -> item -> record_result
-(** Appends [Recorded item] unless [event_id] already exists in the log. *)
+(** Appends [Recorded item] unless [event_id] already appears within the
+    last {!dedup_window_bytes} of the log. The dedup scan is bounded to
+    that recent tail (gateway redelivery is always recent), so a
+    duplicate older than the window is re-appended rather than
+    suppressed — a rare, harmless duplicate, never data loss. *)
 
 val claim_for_turn :
   base_path:string ->

--- a/test/test_keeper_external_attention.ml
+++ b/test/test_keeper_external_attention.ml
@@ -96,6 +96,57 @@ let with_temp_base name f =
     ~finally:(fun () -> try remove_tree base_path with _ -> ())
     (fun () -> f base_path)
 
+(* F943: [record] dedups against a bounded recent tail, not the whole
+   (unbounded) store. A duplicate inside the window is still suppressed;
+   one pushed past the window is re-appended (rare, harmless). This pins
+   both halves of that contract and, by recording past the window
+   without parsing the whole file each time, exercises the O(window)
+   path. *)
+let test_record_dedup_window_bounded () =
+  with_temp_base "keeper-external-attention-window" @@ fun base_path ->
+  let keeper_name = "windowkeeper" in
+  let mk i =
+    item ~keeper_name
+      ~dedupe_key:(Printf.sprintf "discord:chan-1:msg-%d" i)
+      ()
+  in
+  let record_exn it =
+    match A.record ~base_path it with
+    | `Recorded -> ()
+    | `Duplicate _ -> Alcotest.fail "unexpected duplicate while filling"
+    | `Error d -> Alcotest.failf "record failed: %s" d
+  in
+  (* The oldest event, then enough distinct fillers to push it out of the
+     dedup window. Size the count from the measured per-event byte cost
+     so the test self-adjusts if the window or item shape changes. *)
+  let first = mk 0 in
+  record_exn first;
+  let line_bytes =
+    String.length (Yojson.Safe.to_string (A.event_to_json (A.Recorded first)))
+    + 1 (* newline *)
+  in
+  let fillers = (A.dedup_window_bytes / line_bytes) + 64 in
+  let last_filler = ref first in
+  for i = 1 to fillers do
+    let it = mk i in
+    record_exn it;
+    last_filler := it
+  done;
+  (* The oldest event has scrolled past the window: re-recording it is a
+     fresh append, not a duplicate. *)
+  (match A.record ~base_path first with
+   | `Recorded -> ()
+   | `Duplicate _ ->
+       Alcotest.fail "event older than the dedup window was treated as duplicate"
+   | `Error d -> Alcotest.failf "record failed: %s" d);
+  (* A recent event is still inside the window and is deduped. *)
+  match A.record ~base_path !last_filler with
+  | `Duplicate dup ->
+      Alcotest.(check string) "recent duplicate still caught"
+        !last_filler.A.event_id dup.A.event_id
+  | `Recorded -> Alcotest.fail "recent duplicate inside window was re-recorded"
+  | `Error d -> Alcotest.failf "record failed: %s" d
+
 let test_record_dedupes_and_reads_pending () =
   with_temp_base "keeper-external-attention-record" @@ fun base_path ->
   let att = item () in
@@ -192,6 +243,8 @@ let () =
         [
           Alcotest.test_case "record dedupes and reads pending" `Quick
             test_record_dedupes_and_reads_pending;
+          Alcotest.test_case "record dedup window is bounded (F943)" `Quick
+            test_record_dedup_window_bounded;
           Alcotest.test_case "claim, resolve, ignore projection" `Quick
             test_claim_resolution_and_ignore_projection;
           Alcotest.test_case "stale claim projects back to pending" `Quick


### PR DESCRIPTION
## Summary

`keeper_external_attention.record` is called on **every inbound Discord message** (`server_discord_in_process_gateway.ml:194`). It called `load_events`, which folds over the **entire** append-only JSONL store to dedup-check the `event_id`. The store is never pruned, so each `record` is O(file) and the hot path is O(N²) across N messages. From the 2026-06-13 merge audit (F943).

## Change

The dedup check only needs to catch gateway **redelivery** (Discord replays missed events after a RESUME), which is always recent. Scan the last `dedup_window_bytes` (64 KiB) of the store via `Fs_compat.read_slice` (O(1) in file size, per RFC-0228 P1) instead of the whole file.

`load_recent_events` parses only the bytes strictly between the first and last newline of the slice, so the mid-line start (and any in-flight partial append) never reaches `parse_line` — avoiding a spurious `persistence read-drop` counter on every call.

**This is a correctness-aligned bound, not a cap on a symptom:** redelivery is inherently recent, so scanning the unbounded tail was wasted work. A duplicate older than the window is re-appended (rare, harmless), never data loss.

## Scope

This fixes the **O(N²) read** only. The store still grows unbounded (no prune/retention) — that is a separate retention-policy decision, deliberately out of scope here (it is the F942-class "append-only store retention" question, tracked separately).

## Validation

- `dune build --root . @check` and `dune build --root .` exit 0; `ocamlformat --check` clean.
- `test_keeper_external_attention` 6 tests (1 new). The new test records an event, pushes it past the window with distinct fillers (count derived from the measured per-event byte cost so it self-adjusts to the window/item shape), then asserts the old event is re-recorded while a recent one is still deduped.
- **Mutation-checked**: reverting `record` to the full `load_events` scan fails the "older than the window" assertion.

WORKAROUND-WAIVED: the bounded window is correctness-aligned (matches Discord's redelivery semantics), not a cap suppressing a symptom — scanning the unbounded log was wasted work, and the fix removes O(N²) at the protocol boundary. Unbounded file growth is explicitly left to a separate retention decision rather than masked here.

RFC-WAIVED: keeper external-attention dedup read path; not a credential/identity/sandbox/hooks subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
