### PR TITLE
refactor(keeper): drop dead Memory OS retention-verdict cluster (F942)

### DIFF
--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -1,22 +1,14 @@
-(** Keeper_memory_os_policy — deterministic importance scoring and
-    retention decisions for the Memory OS.
+(** Keeper_memory_os_policy — deterministic importance scoring for the
+    Memory OS.
 
-    The LLM librarian decides *what facts exist*; this module decides
-    *how to retain them* using a deterministic composite score and
-    explicit retention verdicts. *)
+    The LLM librarian decides *what facts exist*; this module assigns
+    each fact a deterministic composite importance score (used by recall
+    ranking). *)
 
 open Keeper_memory_os_types
 
-type retention_verdict =
-  | KeepVerbatim
-  | Summarize
-  | ReferenceOnly
-  | Discard
-
 let default_lambda = 1.0 /. (86400.0 *. 7.0) (* half-life ~7 days *)
 let default_alpha = 0.5
-let keep_verbatim_score_threshold = 0.75
-let summarize_score_threshold = 0.35
 
 (** Forgetting curve: recency decays exponentially with a half-life
     controlled by [lambda]. *)
@@ -46,21 +38,6 @@ let score_tool_result
   =
   let base_confidence = if was_successful then 0.9 else 0.5 in
   base_confidence *. recency_factor ~lambda ~now created_at *. access_factor ~alpha access_count
-;;
-
-let decide_retention score =
-  if score >= keep_verbatim_score_threshold
-  then KeepVerbatim
-  else if score >= summarize_score_threshold
-  then Summarize
-  else Discard
-;;
-
-let verdict_to_string = function
-  | KeepVerbatim -> "keep_verbatim"
-  | Summarize -> "summarize"
-  | ReferenceOnly -> "reference_only"
-  | Discard -> "discard"
 ;;
 
 let string_contains substring str =

--- a/lib/keeper/keeper_memory_os_policy.mli
+++ b/lib/keeper/keeper_memory_os_policy.mli
@@ -1,21 +1,10 @@
-(** Keeper_memory_os_policy — deterministic importance scoring and
-    retention decisions for the Memory OS. *)
+(** Keeper_memory_os_policy — deterministic importance scoring for the
+    Memory OS. *)
 
 open Keeper_memory_os_types
 
-(** Explicit retention verdict. The librarian extracts facts; this
-    policy decides how each fact should be materialised in working
-    memory. *)
-type retention_verdict =
-  | KeepVerbatim
-  | Summarize
-  | ReferenceOnly
-  | Discard
-
 val default_lambda : float
 val default_alpha : float
-val keep_verbatim_score_threshold : float
-val summarize_score_threshold : float
 
 (** Composite importance score for a fact.
 
@@ -34,11 +23,6 @@ val score_tool_result
   -> access_count:int
   -> unit
   -> float
-
-(** Map a score to a retention verdict using fixed thresholds. *)
-val decide_retention : float -> retention_verdict
-
-val verdict_to_string : retention_verdict -> string
 
 (** Lightweight keyword access bump.
 

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -639,13 +639,13 @@ let test_librarian_runtime_appends_episode_bundle () =
         | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
 ;;
 
-let test_policy_score_and_retention () =
+let test_policy_score () =
   let now = 1_000_000.0 in
   let f = fact_fixture ~now () in
   let score = Policy.score_fact ~now f in
   Alcotest.(check bool) "score positive" true (score > 0.0);
-  let verdict = Policy.decide_retention score in
-  Alcotest.(check bool) "high score -> KeepVerbatim" true (verdict = Policy.KeepVerbatim);
+  (* A stale, low-confidence, never-recalled fact scores strictly lower
+     than a fresh confident one — the ordering recall ranking relies on. *)
   let low =
     { f with
       Types.confidence = 0.1
@@ -653,8 +653,8 @@ let test_policy_score_and_retention () =
     ; Types.last_accessed = now -. 864_000.0
     }
   in
-  let verdict_low = Policy.decide_retention (Policy.score_fact ~now low) in
-  Alcotest.(check bool) "low score -> Discard" true (verdict_low = Policy.Discard)
+  Alcotest.(check bool) "stale low-confidence fact scores lower" true
+    (Policy.score_fact ~now low < score)
 ;;
 
 let test_bump_access () =
@@ -1020,7 +1020,7 @@ let () =
             test_librarian_runtime_appends_episode_bundle
         ] )
     ; ( "policy"
-      , [ Alcotest.test_case "score and retention" `Quick test_policy_score_and_retention
+      , [ Alcotest.test_case "score ordering" `Quick test_policy_score
         ; Alcotest.test_case "bump access" `Quick test_bump_access
         ] )
     ; ( "io"


### PR DESCRIPTION
## Summary

`keeper_memory_os_policy` exposed a `retention_verdict` type, `decide_retention`, and `verdict_to_string`, but **`decide_retention` has zero runtime callers** — only `test_keeper_memory_os` referenced it. It is a remnant of the RFC-0231 tiered Memory OS integration, whose PR (#20829) was **closed without merging**. The `ReferenceOnly` variant was never even produced by `decide_retention`. From the 2026-06-13 merge audit (F942).

## Change

Per the project guideline to **delete dead concepts** rather than relocate or RFC-hedge them, remove the whole unused cluster:

- `type retention_verdict` (incl. the dead `ReferenceOnly` variant)
- `keep_verbatim_score_threshold` / `summarize_score_threshold` (used only by `decide_retention`)
- `decide_retention`, `verdict_to_string`

**Kept live:** the deterministic scoring recall actually uses — `score_fact` (called by `keeper_memory_os_recall`), `score_tool_result`, `bump_access_for_turn`, and the recency/access helpers — is unchanged.

The test keeps its scoring coverage, re-pointed from "score → retention verdict" to a **score-ordering** assertion (a stale low-confidence fact scores below a fresh one — the property recall ranking relies on).

## Scope

This does **not** address the unbounded growth of the append-only Memory OS store; that is a separate retention-policy decision, left for when the Memory OS product direction (revive vs retire RFC-0231) is settled.

## Verification (dead-code claim)

- `decide_retention`: callers in `lib/` = 0; only `test_keeper_memory_os`.
- `verdict_to_string` / `retention_verdict`: no `lib/` consumer of this module (the `Policy.verdict_to_string` in `cdal_runtime/audit.ml` is a different `Policy` module — it also calls `decision_point_to_string`, which this module does not define).
- `dune build --root . @check` and `dune build --root .` exit 0 (no other consumer broke), `ocamlformat --check` clean, `test_keeper_memory_os` 20 tests green.

RFC-WAIVED: removing abandoned RFC-0231 dead code from the keeper Memory OS scoring module; not a credential/identity/sandbox/hooks subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
