### PR TITLE
fix(mcp_server): store workspace_config in an Atomic.t

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -392,7 +392,7 @@ let dispatch_route ~router ~request ~path reqd =
       let format = Option.value ~default:"nested" (query_param request "format") in
       let voter = board_voter_query request in
       let config =
-        Option.map (fun state -> state.Mcp_server.workspace_config) !server_state
+        Option.map (fun state -> (Mcp_server.workspace_config state)) !server_state
       in
       let (status, body) =
         board_post_detail_json ~include_moderation:false ~blind_votes:false

--- a/lib/mcp_sdk_adapter_masc.ml
+++ b/lib/mcp_sdk_adapter_masc.ml
@@ -269,7 +269,7 @@ let create_handler
                  (List.map (fun (key, value) -> (key, `String value)) arguments)
              in
              match
-               Mcp_prompt_surface.get_json ~config:state.Mcp_server.workspace_config
+               Mcp_prompt_surface.get_json ~config:(Mcp_server.workspace_config state)
                  ~name:prompt.name ~arguments:args_json
                  Config.raw_all_tool_schemas
              with

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -477,7 +477,7 @@ let schema_markdown =
 
 (** MCP Server state *)
 type server_state = {
-  mutable workspace_config: Workspace.config;
+  workspace_config: Workspace.config Atomic.t;  (* Atomic swap so workspace-switch tools update without data races. *)
   session_registry: Session.registry;
   on_sse_broadcast: (Yojson.Safe.t -> unit) option Atomic.t;  (* SSE push callback, Atomic for cross-fiber visibility *)
   sw: Eio.Switch.t option; (* Request/runtime fibers for HTTP/MCP handlers *)
@@ -488,6 +488,9 @@ type server_state = {
   net: Eio_context.eio_net option; (* For network calls - P3a: replaces global ref *)
 }
 
+let workspace_config state = Atomic.get state.workspace_config
+let set_workspace_config state config = Atomic.set state.workspace_config config
+
 let create_state ~base_path =
   let config = Workspace.default_config base_path in
   let registry = Session.create () in
@@ -496,7 +499,7 @@ let create_state ~base_path =
     Session.push_notification_to_active_agents registry ~event
   );
   let state = {
-    workspace_config = config;
+    workspace_config = Atomic.make config;
     session_registry = registry;
     on_sse_broadcast = Atomic.make None;
     sw = None;
@@ -507,7 +510,7 @@ let create_state ~base_path =
     net = None;
   } in
   Board_tool.set_agent_lookup (fun name ->
-    try Workspace.is_agent_session_bound state.workspace_config ~agent_name:name
+    try Workspace.is_agent_session_bound (workspace_config state) ~agent_name:name
     with Sys_error _ | Not_found | Invalid_argument _ -> false);
   state
 
@@ -552,7 +555,7 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
   );
   Keeper_supervisor.set_global_switch sw;
   let state = {
-    workspace_config = config;
+    workspace_config = Atomic.make config;
     session_registry = registry;
     on_sse_broadcast = Atomic.make None;
     sw = Some sw;
@@ -562,10 +565,10 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
     mono_clock = Some mono_clock;
     net = Some net;
   } in
-  (* Board post kind auto-classification: reads state.workspace_config so
+  (* Board post kind auto-classification: reads [workspace_config state] so
      workspace changes via set_workspace are reflected automatically. *)
   Board_tool.set_agent_lookup (fun name ->
-    try Workspace.is_agent_session_bound state.workspace_config ~agent_name:name
+    try Workspace.is_agent_session_bound (workspace_config state) ~agent_name:name
     with Sys_error _ | Not_found | Invalid_argument _ -> false);
   state
 

--- a/lib/mcp_server.mli
+++ b/lib/mcp_server.mli
@@ -173,7 +173,7 @@ val schema_markdown : string
 (** {1 Server state} *)
 
 type server_state = {
-  mutable workspace_config : Workspace.config;
+  workspace_config : Workspace.config Atomic.t;
   session_registry : Session.registry;
   on_sse_broadcast :
     (Yojson.Safe.t -> unit) option Atomic.t;
@@ -185,10 +185,17 @@ type server_state = {
   net : Eio_context.eio_net option;
 }
 (** Runtime state threaded through every request handler.
-    [workspace_config] is mutable so workspace-switch tools can swap
-    backends mid-flight.  Eio handles are [option] because
-    the legacy non-Eio bootstrap ({!create_state}) still
-    needs to construct a state without an active switch. *)
+    [workspace_config] is stored in an atomic reference so
+    workspace-switch tools can swap backends without tearing reads
+    in concurrent request/background fibers.  Eio handles are
+    [option] because the legacy non-Eio bootstrap ({!create_state})
+    still needs to construct a state without an active switch. *)
+
+val workspace_config : server_state -> Workspace.config
+(** Current workspace configuration. *)
+
+val set_workspace_config : server_state -> Workspace.config -> unit
+(** Atomically replace the active workspace configuration. *)
 
 val create_state : base_path:string -> server_state
 (** Legacy bootstrap.  Every Eio handle is [None]; the

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -649,7 +649,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
       Some (Printf.sprintf "duration_ms=%d|detail=%s" duration_ms truncated)
   in
   let otel_trace_id = Otel_spans.current_trace_id () in
-  Audit_log.log_tool_call state.Mcp_server.workspace_config
+  Audit_log.log_tool_call (Mcp_server.workspace_config state)
     ~agent_id:agent_name ~tool_name:name ~success ~error_msg:error_detail
     ?trace_id:otel_trace_id ();
   if not success then (
@@ -716,7 +716,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   if telemetry_enabled then
     (match state.Mcp_server.fs with
      | Some fs ->
-         (try Telemetry_eio.track_tool_called ~fs state.Mcp_server.workspace_config
+         (try Telemetry_eio.track_tool_called ~fs (Mcp_server.workspace_config state)
                 ~tool_name:name ~agent_id:agent_name ~success ~duration_ms
                 ~source:(Tool_registry.string_of_source source)
                 ?session_id:telemetry_session_id
@@ -793,7 +793,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   (* Emit activity graph event for tool call — enables real-time dashboard tracking *)
   (try
     (* fire-and-forget: activity graph emission must not change the tool-call result. *)
-    ignore (Activity_graph.emit state.Mcp_server.workspace_config
+    ignore (Activity_graph.emit (Mcp_server.workspace_config state)
       ~actor:(Activity_graph.entity ~kind:"agent" agent_name)
       ~subject:(Activity_graph.entity ~kind:"tool" name)
       ~kind:"tool.called"

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -67,7 +67,7 @@ let execute_tool_eio
   Eio_context.set_clock clock;
   (* Otel_metric_store: count every inbound tool call *)
   Otel_metric_store.record_request ();
-  let config = state.Mcp_server.workspace_config in
+  let config = (Mcp_server.workspace_config state) in
   let registry = state.Mcp_server.session_registry in
   (* Fix 3: Cache workspace_initialized to avoid repeated stat syscalls. *)
   let workspace_init_cached = Workspace.is_initialized config in

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -225,7 +225,7 @@ let handle_list_tools_eio
       Some
         (Telemetry_eio.summarize_tool_usage
            ?fs:state.Mcp_server.fs
-           state.Mcp_server.workspace_config)
+           (Mcp_server.workspace_config state))
     else None
   in
   let tools =
@@ -379,7 +379,7 @@ let handle_get_prompt_eio state id params =
        in
        (match
           Mcp_prompt_surface.get_json
-            ~config:state.Mcp_server.workspace_config
+            ~config:(Mcp_server.workspace_config state)
             ~name
             ~arguments
             Config.raw_all_tool_schemas
@@ -474,7 +474,7 @@ let handle_dashboard_hello_eio state id ?mcp_session_id params =
   | Some session_id, Some (`Assoc fields) ->
     let token = optional_string_member "token" fields in
     !dashboard_hello_handler
-      ~base_path:state.Mcp_server.workspace_config.base_path
+      ~base_path:(Mcp_server.workspace_config state).base_path
       ~session_id
       ?token
       ()
@@ -945,7 +945,7 @@ let run_stdio ~handle_request ~sw ~env state =
   let stdout = Eio.Stdenv.stdout env in
   let clock = Eio.Stdenv.clock env in
   Log.Mcp.info "MASC MCP Server (Eio stdio mode)";
-  Log.Mcp.info "Default workspace: %s" Mcp_server.(state.workspace_config.Workspace.base_path);
+  Log.Mcp.info "Default workspace: %s" (Mcp_server.workspace_config state).Workspace.base_path;
   let buf = Eio.Buf_read.of_flow stdin ~max_size:(16 * 1024 * 1024) in
   let read_framed_message_after_first_line first_line =
     let rec read_headers acc =

--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -31,7 +31,7 @@ let handle_read_resource_eio state id params =
         make_error_typed ~id Mcp_error_code.Invalid_params "Missing uri"
       else begin
         let resource_id, uri = Mcp_server.parse_masc_resource_uri uri_str in
-        let config = state.Mcp_server.workspace_config in
+        let config = (Mcp_server.workspace_config state) in
         let registry = state.Mcp_server.session_registry in
 
         let read_messages_json ~since_seq ~limit =

--- a/lib/mcp_tool_runtime_workspace.ml
+++ b/lib/mcp_tool_runtime_workspace.ml
@@ -76,7 +76,7 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
   (* Step 1: set project root *)
   let workspace_result =
     if String.equal path "" then begin
-      if Workspace.is_initialized state.Mcp_server.workspace_config then
+      if Workspace.is_initialized (Mcp_server.workspace_config state) then
         Ok config
       else
         Error "path is required when no project scope is set. Provide the project directory path."
@@ -97,11 +97,11 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
       else begin
         let cfg = Workspace.default_config expanded in
         if Workspace.is_initialized cfg then begin
-          state.Mcp_server.workspace_config <- cfg;
+          Mcp_server.set_workspace_config state cfg;
           Ok cfg
         end else begin
           let _msg = Workspace.init cfg ~agent_name:None in
-          state.Mcp_server.workspace_config <- cfg;
+          Mcp_server.set_workspace_config state cfg;
           Ok cfg
         end
       end

--- a/lib/mcp_tool_runtime_workspace.mli
+++ b/lib/mcp_tool_runtime_workspace.mli
@@ -35,7 +35,8 @@ val handle_start :
 
     1. **Set project root**: validates the directory exists,
        initialises {!Workspace} when not already initialised, and
-       atomically swaps [state.workspace_config].
+       atomically swaps the active workspace config via
+       {!Mcp_server.set_workspace_config}.
     2. **Bind agent session**: idempotent when already bound.
        Failure surfaces as a startup error.
     3. **Optional task creation**: when [task_title] non-empty,

--- a/lib/server/server_activity_http.ml
+++ b/lib/server/server_activity_http.ml
@@ -113,7 +113,7 @@ let events_http_json ~deps ~state request =
        Offload via Domain_pool_ref still protects the HTTP main
        domain from JSONL-scan stall. *)
     Domain_pool_ref.submit_io_or_inline (fun () ->
-      Activity_graph.json_response state.Mcp_server.workspace_config ~kinds
+      Activity_graph.json_response (Mcp_server.workspace_config state) ~kinds
         ~after_seq ~limit ())
 
 let parse_since_ms (raw : string) : int option =
@@ -172,7 +172,7 @@ let graph_http_json ~deps ~state request =
             Some (now_ms - delta_ms)
         | None -> None
       in
-      Activity_graph.graph_json state.Mcp_server.workspace_config ~kinds ~limit
+      Activity_graph.graph_json (Mcp_server.workspace_config state) ~kinds ~limit
         ~timeline_limit ?since_ms ())
 
 let swimlane_http_json ~deps ~state request =
@@ -207,7 +207,7 @@ let swimlane_http_json ~deps ~state request =
             Some (now_ms - delta_ms)
         | None -> None
       in
-      Activity_graph.agent_spans_json state.Mcp_server.workspace_config ~limit
+      Activity_graph.agent_spans_json (Mcp_server.workspace_config state) ~limit
         ?since_ms ())
 
 let stream_headers ~deps origin =
@@ -300,7 +300,7 @@ let handle_stream ~deps ~state request reqd =
        (Printf.sprintf ": activity-stream after=%d\nretry: 3000\n\n"
           after_seq));
   let replay =
-    Activity_graph.list_events state.Mcp_server.workspace_config ~kinds
+    Activity_graph.list_events (Mcp_server.workspace_config state) ~kinds
       ~after_seq ~limit:replay_limit ()
   in
   List.iter (fun value -> ignore (send_raw info (Activity_graph.format_sse_event value))) replay;

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -896,7 +896,7 @@ and with_read_auth handler request reqd =
   match !server_state with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
-      let base_path = state.Mcp_server.workspace_config.base_path in
+      let base_path = (Mcp_server.workspace_config state).base_path in
       (match authorize_read_request ~base_path request with
       | Ok () ->
           (match check_agent_rate_limit request reqd with
@@ -908,7 +908,7 @@ and with_permission_auth ~permission handler request reqd =
   match !server_state with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
-      let base_path = state.Mcp_server.workspace_config.base_path in
+      let base_path = (Mcp_server.workspace_config state).base_path in
       (match authorize_permission_request ~base_path ~permission request with
       | Ok () ->
           (match check_agent_rate_limit request reqd with
@@ -920,7 +920,7 @@ and with_tool_auth ~tool_name handler request reqd =
   match !server_state with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
-      let base_path = state.Mcp_server.workspace_config.base_path in
+      let base_path = (Mcp_server.workspace_config state).base_path in
       (match authorize_tool_request ~base_path ~tool_name request with
       | Ok () ->
           (match check_agent_rate_limit request reqd with
@@ -932,7 +932,7 @@ and with_token_permission_auth ~permission handler request reqd =
   match !server_state with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
-      let base_path = state.Mcp_server.workspace_config.base_path in
+      let base_path = (Mcp_server.workspace_config state).base_path in
       (match authorize_token_bound_permission_request ~base_path ~permission request with
       | Ok agent_name ->
           (match check_agent_rate_limit request reqd with

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -4,7 +4,7 @@
     subsystem-spawning functions into a focused module. *)
 
 let install_tooling ~governance_level (state : Mcp_server.server_state) =
-  Governance_pipeline.install ~config:state.workspace_config ~governance_level
+  Governance_pipeline.install ~config:(Mcp_server.workspace_config state) ~governance_level
 ;;
 
 (* Stable djb2-style hash for the autoboot warmup jitter.
@@ -342,8 +342,8 @@ let start_keeper_loops
   in
   Masc_event_bus.set masc_event_bus;
   (* Event_bus → SSE bridge: relay both OAS and MASC buses to dashboard *)
-  Keeper_event_bridge.start ~sw ~clock ~config:state.workspace_config ~bus:event_bus;
-  Keeper_event_bridge.start ~sw ~clock ~config:state.workspace_config ~bus:masc_event_bus;
+  Keeper_event_bridge.start ~sw ~clock ~config:(Mcp_server.workspace_config state) ~bus:event_bus;
+  Keeper_event_bridge.start ~sw ~clock ~config:(Mcp_server.workspace_config state) ~bus:masc_event_bus;
   (* Compaction audit: subscribe to ContextCompactStarted/ContextCompacted and
      persist paired rows to [base_path/data/harness-compact/YYYY-MM/DD.jsonl]
      with rolling 14-day retention (override via
@@ -437,7 +437,7 @@ let start_keeper_loops
   Keeper_keepalive.set_bus event_bus;
   Board_dispatch.set_board_signal_hook (fun signal ->
     Keeper_keepalive.wakeup_relevant_keeper_for_board_signal
-      ~config:state.workspace_config
+      ~config:(Mcp_server.workspace_config state)
       signal);
   Board_dispatch.set_board_sse_hook (fun event ->
     let params = board_sse_event_params event in
@@ -528,7 +528,7 @@ let start_keeper_loops
     try
       ignore
         (Activity_graph.emit
-           state.workspace_config
+           (Mcp_server.workspace_config state)
            ~actor:activity_actor
            ?subject:activity_subject
            ~kind:activity_kind
@@ -549,17 +549,17 @@ let start_keeper_loops
     fun mention ->
     match mention with
     | Some target ->
-      Keeper_keepalive.wakeup_keeper ~base_path:state.workspace_config.base_path target;
+      Keeper_keepalive.wakeup_keeper ~base_path:(Mcp_server.workspace_config state).base_path target;
       Log.Keeper.info "broadcast mention → wakeup keeper %s" target
     | None ->
-      Keeper_keepalive.wakeup_all_keepers ~base_path:state.workspace_config.base_path ();
+      Keeper_keepalive.wakeup_all_keepers ~base_path:(Mcp_server.workspace_config state).base_path ();
       Log.Keeper.info "broadcast → wakeup all keepers (reactive push)"
   in
   Workspace_broadcast.on_broadcast_mention := broadcast_mention_handler;
   (* Orchestrator needs synchronous registration for shutdown hook *)
   (try
      let cancel_orchestrator =
-       Orchestrator.start ~sw ~proc_mgr ~clock ~domain_mgr state.workspace_config
+       Orchestrator.start ~sw ~proc_mgr ~clock ~domain_mgr (Mcp_server.workspace_config state)
      in
      Shutdown_hooks.register_cancel_orchestrator cancel_orchestrator
    with
@@ -588,7 +588,7 @@ let start_keeper_loops
   in
   let make_judge_dispatch ~actor ~(name : string) ~(args : Yojson.Safe.t) : Tool_result.result =
     let start_time = Time_compat.now () in
-    let config = state.workspace_config in
+    let config = (Mcp_server.workspace_config state) in
     let agent_name = actor in
     let ctx_workspace : Tool_workspace.context = { config; agent_name } in
     let ctx_task : Task.Tool.context = { config; agent_name; sw = Some sw } in
@@ -633,7 +633,7 @@ let start_keeper_loops
   let operator_judge_dispatch = make_judge_dispatch ~actor:"operator-judge" in
   fork_subsystem "operator_judge" (fun () ->
     let operator_judge_ctx : _ Operator_control.context =
-      { config = state.workspace_config
+      { config = (Mcp_server.workspace_config state)
       ; agent_name = "operator-judge"
       ; sw
       ; clock
@@ -646,7 +646,7 @@ let start_keeper_loops
       ~sw
       ~clock
       ~net
-      ~config:state.workspace_config
+      ~config:(Mcp_server.workspace_config state)
       ~masc_tools:judge_masc_tools
       ~dispatch:operator_judge_dispatch
       ~build_facts:(fun () ->
@@ -663,7 +663,7 @@ let start_keeper_loops
     let interval = Env_config_runtime.Verification.timeout_check_interval_seconds in
     let rec loop () =
       Eio.Time.sleep clock interval;
-      Verification_protocol.check_timeouts ~config:state.workspace_config;
+      Verification_protocol.check_timeouts ~config:(Mcp_server.workspace_config state);
       loop ()
     in
     loop ());
@@ -716,7 +716,7 @@ let start_keeper_loops
       Log.Keeper.info "autoboot: lazy startup complete; keeper bootstrap will start last";
       (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
       Eio.Time.sleep clock Env_config_keeper.KeeperBootstrap.post_startup_settle_sec;
-      let config = state.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       let masc_root = Workspace.masc_root_dir config in
       let keeper_dir = Keeper_fs.keeper_dir config in
       let all_names = Keeper_meta_store.keeper_names config in
@@ -901,7 +901,7 @@ let start_keeper_loops
          handle_turn wires process_single_turn for actual turn execution. *)
       (try
          Keeper_chat_consumer.start ~sw ~clock
-           ~base_path:state.Mcp_server.workspace_config.base_path
+           ~base_path:(Mcp_server.workspace_config state).base_path
            ~handle_turn:(fun ~sw ~keeper_name ~queued_message ->
              let open Server_routes_http_keeper_stream in
              let now = Time_compat.now () in
@@ -1003,7 +1003,7 @@ let start_keeper_loops
   (* Discord presence bridge — syncs keeper liveness to bot status. *)
   fork_subsystem "discord_presence" (fun () ->
     Discord_presence_bridge.start
-      ~sw ~clock ~workspace_config:state.workspace_config ());
+      ~sw ~clock ~workspace_config:(Mcp_server.workspace_config state) ());
   (* Phase 5: unified startup subsystem summary *)
   Log.Startup.info "subsystems: keeper loops started"
 ;;

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -38,7 +38,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       Tool_metrics.record r;
       Tool_metrics_persist.enqueue r
     | _ -> ());
-  Tool_metrics_persist.start_flush_fiber ~sw ~clock ~base_path:state.workspace_config.base_path;
+  Tool_metrics_persist.start_flush_fiber ~sw ~clock ~base_path:(Mcp_server.workspace_config state).base_path;
   (* RFC-0234 scheduled automation runner.  Tool-facing create/approve/list
      paths only mutate the durable ledger; this loop is the production caller
      that observes due rows and emits at-most-once generic wake signals.  It
@@ -51,7 +51,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       let interval = 15.0 in
       let rec loop () =
         (try
-           match Schedule_runner.tick state.workspace_config ~now:(Time_compat.now ()) with
+           match Schedule_runner.tick (Mcp_server.workspace_config state) ~now:(Time_compat.now ()) with
            | Ok result ->
              if result.Schedule_runner.emitted <> [] then
                Log.Server.info
@@ -80,9 +80,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
   Auth.start_bare_alias_audit_fiber
     ~sw
     ~clock
-    ~base_path:state.workspace_config.base_path
+    ~base_path:(Mcp_server.workspace_config state).base_path
     ~canonical_names_fn:(fun () ->
-      Keeper_runtime.bootable_keeper_names state.workspace_config
+      Keeper_runtime.bootable_keeper_names (Mcp_server.workspace_config state)
       |> List.map Keeper_identity.keeper_agent_name);
   (* #9876: Hebbian consolidation fiber. Prior to this, the graph was
      write-only — strengthen/weaken populated synapses but decay +
@@ -91,8 +91,8 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      production. *)
   (* System_internal tool usage log: durable JSONL for pruning evidence (#5120) *)
   Tool_usage_log.init
-    ~base_path:state.workspace_config.base_path
-    ~cluster_name:state.workspace_config.backend_config.Backend_types.cluster_name
+    ~base_path:(Mcp_server.workspace_config state).base_path
+    ~cluster_name:(Mcp_server.workspace_config state).backend_config.Backend_types.cluster_name
     ();
   (* Inject keeper FD/disk pressure handling at the boundary so the generic
      Tool_usage_log surface does not reference the keeper subsystem directly
@@ -103,8 +103,8 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     Keeper_disk_pressure.note_exception ~site exn);
   (* Keeper tool call I/O log: full input/output for dashboard inspector *)
   Keeper_tool_call_log.init
-    ~base_path:state.workspace_config.base_path
-    ~cluster_name:state.workspace_config.backend_config.Backend_types.cluster_name
+    ~base_path:(Mcp_server.workspace_config state).base_path
+    ~cluster_name:(Mcp_server.workspace_config state).backend_config.Backend_types.cluster_name
     ();
   Keeper_tool_call_log.start_flush_fiber ~sw ~clock;
   (* Transition-audit forensics writes leave the keeper hot path: recorders
@@ -120,7 +120,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
   Tool_dispatch.set_span_wrapper Tool_telemetry.with_span;
   Otel_metric_store.register_otel_source_once ();
   Otel_runtime_observables.register_once
-    ~masc_root:(Workspace.masc_root_dir state.workspace_config)
+    ~masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state))
     ();
   Otel_spans.setup_exporter ~sw env;
   Shutdown.register ~name:"otel_exporter" ~priority:20 Otel_spans.shutdown;
@@ -189,7 +189,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
            (* SSE replay-buffer eviction is periodic housekeeping; failed
                sends and stale connection reaping remain visible elsewhere. *)
            Log.Server.routine "Evicted %d expired SSE buffer events" evicted_events;
-         let evicted = Cache_eio.evict_expired state.workspace_config in
+         let evicted = Cache_eio.evict_expired (Mcp_server.workspace_config state) in
          if evicted > 0 then Log.Server.info "Cache: evicted %d expired entries" evicted;
          let sse_guards_reaped = Server_mcp_transport_http_sse.reap_stale_guards () in
          let http_guards_reaped = Server_mcp_transport_http.reap_stale_guards () in
@@ -244,7 +244,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
              ticks faster but the helper short-circuits when called too soon. *)
          (match
             Keeper_sandbox_runtime.maybe_cleanup_stale_containers
-              ~base_path:state.workspace_config.base_path
+              ~base_path:(Mcp_server.workspace_config state).base_path
               ~timeout_sec:
                 (Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Cleanup_rm ())
               ()
@@ -270,7 +270,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
              let days =
                Safe_ops.get_env_int_logged "MASC_JSONL_RETENTION_DAYS" ~default:30
              in
-             let masc = Workspace.masc_dir state.workspace_config in
+             let masc = Workspace.masc_dir (Mcp_server.workspace_config state) in
              let prune_dir dir =
                if Sys.file_exists dir
                then Dated_jsonl.prune (Dated_jsonl.create ~base_dir:dir ()) ~days
@@ -319,7 +319,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     let sync_once () =
       try
         let now = Int64.of_float (Eio.Time.now clock) in
-        match Repo_sync.sync_all ~base_path:state.workspace_config.base_path ~now with
+        match Repo_sync.sync_all ~base_path:(Mcp_server.workspace_config state).base_path ~now with
         | Ok repos ->
           if repos <> []
           then Log.Server.info "repo_sync: synced %d repositories" (List.length repos)
@@ -355,9 +355,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
          of the request fiber for the canonical project-snapshot
          response (Step 4 retires the env knobs themselves). *)
       Dashboard_snapshot.refresh_loop
-        ~sw ~clock ~config:state.workspace_config ~state
+        ~sw ~clock ~config:(Mcp_server.workspace_config state) ~state
         ~interval_sec:2.0 ());
-  let resolved_base = state.workspace_config.base_path in
-  let masc_dir = Workspace.masc_root_dir state.workspace_config in
+  let resolved_base = (Mcp_server.workspace_config state).base_path in
+  let masc_dir = Workspace.masc_root_dir (Mcp_server.workspace_config state) in
   resolved_base, masc_dir
 ;;

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -619,11 +619,11 @@ let dashboard_goal_detail_http_json ~(config : Workspace.config) ~goal_id : Yojs
 let operator_action_http_json ~state ~sw ~clock request ~args =
   let actor =
     Server_auth.dashboard_actor_for_request
-      ~base_path:state.Mcp_server.workspace_config.base_path
+      ~base_path:(Mcp_server.workspace_config state).base_path
       request
   in
   let ctx : _ Operator_control.context =
-    { config = state.Mcp_server.workspace_config
+    { config = (Mcp_server.workspace_config state)
     ; agent_name = Option.value ~default:"dashboard" actor
     ; sw
     ; clock
@@ -638,11 +638,11 @@ let operator_action_http_json ~state ~sw ~clock request ~args =
 let operator_confirm_http_json ~state ~sw ~clock request ~args =
   let actor =
     Server_auth.dashboard_actor_for_request
-      ~base_path:state.Mcp_server.workspace_config.base_path
+      ~base_path:(Mcp_server.workspace_config state).base_path
       request
   in
   let ctx : _ Operator_control.context =
-    { config = state.Mcp_server.workspace_config
+    { config = (Mcp_server.workspace_config state)
     ; agent_name = Option.value ~default:"dashboard" actor
     ; sw
     ; clock
@@ -702,7 +702,7 @@ let dashboard_bootstrap_http_json
         ?clock:state.Mcp_server.clock
         ~request
         ~light:true
-        state.Mcp_server.workspace_config)
+        (Mcp_server.workspace_config state))
   in
   let execution =
     slice "execution" (fun () -> dashboard_execution_http_json ~state ~sw ~clock request)
@@ -714,12 +714,12 @@ let dashboard_bootstrap_http_json
        bypassing Dashboard_cache and re-reading goals/backlog on every load. *)
     slice "planning" (fun () ->
       let cache_key =
-        Printf.sprintf "planning:%s" state.Mcp_server.workspace_config.base_path
+        Printf.sprintf "planning:%s" (Mcp_server.workspace_config state).base_path
       in
       Dashboard_cache.get_or_compute cache_key
         ~ttl:Server_dashboard_http_core_cache.standard_cache_ttl_s (fun () ->
           Domain_pool_ref.submit_io_or_inline (fun () ->
-            dashboard_planning_http_json ~config:state.Mcp_server.workspace_config)))
+            dashboard_planning_http_json ~config:(Mcp_server.workspace_config state))))
   in
   let namespace_truth =
     slice "namespace_truth" (fun () ->
@@ -736,16 +736,16 @@ let dashboard_bootstrap_http_json
     (* Share the standalone /api/v1/dashboard/goals cache (same key + ttl). *)
     slice "goals" (fun () ->
       let cache_key =
-        Printf.sprintf "goals_tree:%s" state.Mcp_server.workspace_config.base_path
+        Printf.sprintf "goals_tree:%s" (Mcp_server.workspace_config state).base_path
       in
       Dashboard_cache.get_or_compute cache_key
         ~ttl:Server_dashboard_http_core_cache.standard_cache_ttl_s (fun () ->
           Domain_pool_ref.submit_io_or_inline (fun () ->
-            dashboard_goals_tree_http_json ~config:state.Mcp_server.workspace_config)))
+            dashboard_goals_tree_http_json ~config:(Mcp_server.workspace_config state))))
   in
   let goal_loop_status =
     slice "goal_loop_status" (fun () ->
-      Dashboard_goal_loop.status_json ~base_path:state.Mcp_server.workspace_config.base_path ())
+      Dashboard_goal_loop.status_json ~base_path:(Mcp_server.workspace_config state).base_path ())
   in
   `Assoc
     [ "served_at", `String (Masc_domain.now_iso ())

--- a/lib/server/server_dashboard_http_agent_api.ml
+++ b/lib/server/server_dashboard_http_agent_api.ml
@@ -20,7 +20,7 @@ let add_agent_api_routes router =
          in
          let since = Time_compat.now () -. (hours *. Masc_time_constants.hour) in
          let activities =
-           Telemetry_eio.summarize_agent_activity state.Mcp_server.workspace_config ~since
+           Telemetry_eio.summarize_agent_activity (Mcp_server.workspace_config state) ~since
          in
          let json = `Assoc [
            ("hours", `Float hours);
@@ -79,7 +79,7 @@ let add_agent_api_routes router =
            in
            let json =
              Tool_agent_timeline.build_timeline
-               state.Mcp_server.workspace_config
+               (Mcp_server.workspace_config state)
                ~agent_name ~since_hours ~limit
                ~include_tasks:true ~include_board:false
                ~include_tool_calls:true

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -109,7 +109,7 @@ let mission_cache =
 let _mission_cache = mission_cache
 
 let start_mission_refresh_loop ~state ~sw ~clock =
-  let workspace_config = state.Mcp_server.workspace_config in
+  let workspace_config = (Mcp_server.workspace_config state) in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = state_dashboard_runtime_caps state in
   let mission_refresh_timeout_s = 60.0 in
@@ -154,7 +154,7 @@ let start_mission_refresh_loop ~state ~sw ~clock =
 let dashboard_briefing_http_json ~state ~sw ~clock request =
   let net, mono_clock = state_dashboard_runtime_caps state in
   let actor =
-    dashboard_actor_for_request ~base_path:state.Mcp_server.workspace_config.base_path request
+    dashboard_actor_for_request ~base_path:(Mcp_server.workspace_config state).base_path request
   in
   let compute ?actor () =
     let started_at = Unix.gettimeofday () in
@@ -164,7 +164,7 @@ let dashboard_briefing_http_json ~state ~sw ~clock request =
       ?mono_clock
       ~sw
       ~clock
-      ~config:state.Mcp_server.workspace_config
+      ~config:(Mcp_server.workspace_config state)
       (fun ~config ~sw ->
          Dashboard_briefing.json
            ?actor
@@ -193,7 +193,7 @@ let dashboard_briefing_http_json ~state ~sw ~clock request =
       (* Actor-parameterized: on-demand with SWR cache. *)
       let cache_key =
         dashboard_cache_key
-          state.Mcp_server.workspace_config
+          (Mcp_server.workspace_config state)
           "mission"
           (Option.value ~default:"" actor)
       in
@@ -215,10 +215,10 @@ let dashboard_session_http_json ~state ~sw ~clock request =
        Dashboard_briefing.session_json
          ?actor:
            (dashboard_actor_for_request
-              ~base_path:state.Mcp_server.workspace_config.base_path
+              ~base_path:(Mcp_server.workspace_config state).base_path
               request)
          ~session_id:trimmed_id
-         ~config:state.Mcp_server.workspace_config
+         ~config:(Mcp_server.workspace_config state)
          ~sw
          ~clock
          ~proc_mgr:state.Mcp_server.proc_mgr
@@ -249,14 +249,14 @@ let dashboard_session_http_json ~state ~sw ~clock request =
 
 let dashboard_briefing_sections_http_json ~state ~sw ~clock request =
   let actor =
-    dashboard_actor_for_request ~base_path:state.Mcp_server.workspace_config.base_path request
+    dashboard_actor_for_request ~base_path:(Mcp_server.workspace_config state).base_path request
   in
   let force = bool_query_param request "force" ~default:false in
   let compute () =
     Dashboard_briefing_sections.json
       ?actor
       ~force
-      ~config:state.Mcp_server.workspace_config
+      ~config:(Mcp_server.workspace_config state)
       ~sw
       ~clock
       ~proc_mgr:state.Mcp_server.proc_mgr
@@ -267,7 +267,7 @@ let dashboard_briefing_sections_http_json ~state ~sw ~clock request =
   else (
     let cache_key =
       dashboard_cache_key
-        state.Mcp_server.workspace_config
+        (Mcp_server.workspace_config state)
         "mission_briefing"
         (Option.value ~default:"" actor)
     in

--- a/lib/server/server_dashboard_http_core_digest_refresh.ml
+++ b/lib/server/server_dashboard_http_core_digest_refresh.ml
@@ -38,7 +38,7 @@ module Core_operator = Server_dashboard_http_core_operator
 module Core_operator_query = Server_dashboard_http_core_operator_query
 
 let start_operator_digest_refresh_loop ~state ~sw ~clock =
-  let config = state.Mcp_server.workspace_config in
+  let config = (Mcp_server.workspace_config state) in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
   let compute () =

--- a/lib/server/server_dashboard_http_core_operator_digest_http.ml
+++ b/lib/server/server_dashboard_http_core_operator_digest_http.ml
@@ -42,7 +42,7 @@ module Core_operator_query = Server_dashboard_http_core_operator_query
 open Server_dashboard_http_runtime_support
 
 let operator_digest_http_json ~state ~sw ~clock request =
-  let config = state.Mcp_server.workspace_config in
+  let config = (Mcp_server.workspace_config state) in
   let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
   let actor =
     dashboard_actor_for_request ~base_path:config.base_path request

--- a/lib/server/server_dashboard_http_core_operator_snapshot_http.ml
+++ b/lib/server/server_dashboard_http_core_operator_snapshot_http.ml
@@ -44,7 +44,7 @@ module Core_operator_query = Server_dashboard_http_core_operator_query
 open Server_dashboard_http_runtime_support
 
 let operator_snapshot_http_json ~state ~sw ~clock request =
-  let config = state.Mcp_server.workspace_config in
+  let config = (Mcp_server.workspace_config state) in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
   let actor =

--- a/lib/server/server_dashboard_http_core_snapshot_refresh.ml
+++ b/lib/server/server_dashboard_http_core_snapshot_refresh.ml
@@ -28,7 +28,7 @@ module Core_operator = Server_dashboard_http_core_operator
 module Core_operator_query = Server_dashboard_http_core_operator_query
 
 let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
-  let config = state.Mcp_server.workspace_config in
+  let config = (Mcp_server.workspace_config state) in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
   let compute () =

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -337,7 +337,7 @@ let add_delete_action_routes router =
              | None ->
                  respond_error ~request:req reqd (invalid_request "task_id")
              | Some task_id ->
-             let config = state.Mcp_server.workspace_config in
+             let config = (Mcp_server.workspace_config state) in
              match Task.Dispatch.delete_task config ~task_id with
              | Ok () -> respond_ok ~request:req reqd
              | Error err ->
@@ -359,7 +359,7 @@ let add_delete_action_routes router =
              | None ->
                  respond_error ~request:req reqd (invalid_request "goal_id")
              | Some goal_id ->
-             let config = state.Mcp_server.workspace_config in
+             let config = (Mcp_server.workspace_config state) in
              match Goal_store.delete_goal config ~goal_id with
              | Ok () -> respond_ok ~request:req reqd
              | Error msg ->
@@ -379,7 +379,7 @@ let add_delete_action_routes router =
              | None ->
                respond_error ~request:req reqd (invalid_request "agent_name")
              | Some requested_name ->
-               let config = state.Mcp_server.workspace_config in
+               let config = (Mcp_server.workspace_config state) in
                (match resolve_keeper_purge_target config requested_name with
                 | Some keeper_target ->
                   let toml_deleted = Option.is_some keeper_target.toml_path in

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -31,10 +31,10 @@ let warm_shell_cache (state : Mcp_server.server_state) =
        let t0 = Time_compat.now () in
        let cache_shell_payload ~light =
          let cache_key =
-           dashboard_shell_cache_key ~light state.Mcp_server.workspace_config
+           dashboard_shell_cache_key ~light (Mcp_server.workspace_config state)
          in
          let compute () =
-           dashboard_shell_payload_json ~light state.Mcp_server.workspace_config
+           dashboard_shell_payload_json ~light (Mcp_server.workspace_config state)
          in
          match state.Mcp_server.clock with
          | Some clock ->
@@ -592,7 +592,7 @@ let broadcast_namespace_truth_ref : (Mcp_server.server_state -> unit) ref =
     available, each refresh runs in a pool domain with a domain-local Caqti
     pool. Falls back to in-domain compute. *)
 let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
-  let workspace_config = state.Mcp_server.workspace_config in
+  let workspace_config = (Mcp_server.workspace_config state) in
   let proc_mgr = state.Mcp_server.proc_mgr in
   (* Default keeps timeout < interval (60s) so Proactive_refresh's clamp
      at start does not fire every boot. Env var override can still push
@@ -668,7 +668,7 @@ let start_transport_health_refresh_loop ~state ~sw ~clock =
   in
   let compute () =
     Server_dashboard_http_cache.mark_cached_surface_attempt transport_health_cache;
-    try Transport_metrics.transport_health_json ~config:state.Mcp_server.workspace_config with
+    try Transport_metrics.transport_health_json ~config:(Mcp_server.workspace_config state) with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
       Server_dashboard_http_cache.mark_cached_surface_error transport_health_cache exn;
@@ -691,12 +691,12 @@ let start_transport_health_refresh_loop ~state ~sw ~clock =
         ~event_type:"transport_health_snapshot"
         (Server_dashboard_http_cache.cached_surface_json transport_health_cache
          |> with_transport_health_metadata
-              ~config:state.Mcp_server.workspace_config
+              ~config:(Mcp_server.workspace_config state)
               ~timeout_s))
 ;;
 
 let dashboard_execution_http_json ~state ~sw ~clock request =
-  let config = state.Mcp_server.workspace_config in
+  let config = (Mcp_server.workspace_config state) in
   let net = state.Mcp_server.net in
   let mono_clock = state.Mcp_server.mono_clock in
   let fixture = query_param request "fixture" in
@@ -792,7 +792,7 @@ let dashboard_execution_trust_http_json ~state ~sw ~clock _request =
       ?mono_clock:state.Mcp_server.mono_clock
       ~sw
       ~clock
-      ~config:state.Mcp_server.workspace_config
+      ~config:(Mcp_server.workspace_config state)
       (fun ~config ~sw:_ ->
          Dashboard_http_keeper.execution_trust_dashboard_json config
          |> with_projection_diagnostics ~surface:"execution_trust" ~started_at ~extra:[])
@@ -831,6 +831,6 @@ let dashboard_transport_health_http_json ~state =
     json
     (("source", `String "cached_surface") :: transport_health_cache_diagnostics ())
   |> with_transport_health_metadata
-       ~config:state.Mcp_server.workspace_config
+       ~config:(Mcp_server.workspace_config state)
        ~timeout_s
 ;;

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -31,7 +31,7 @@ let handle_keeper_get_subroutes state req request reqd =
       Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
         (error_json "missing keeper name")
     else
-      let base_dir = state.Mcp_server.workspace_config.base_path in
+      let base_dir = (Mcp_server.workspace_config state).base_path in
       let messages =
         Keeper_chat_store.load ~base_dir ~keeper_name:name
       in
@@ -46,7 +46,7 @@ let handle_keeper_get_subroutes state req request reqd =
       Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
         (error_json "missing keeper name")
     else
-      let base_dir = state.Mcp_server.workspace_config.base_path in
+      let base_dir = (Mcp_server.workspace_config state).base_path in
       let notes = Keeper_person_notes.notes ~base_dir ~keeper_name:name in
       Server_auth.respond_json_value_with_cors ~status:`OK request reqd
         (`List
@@ -62,7 +62,7 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let (st, json) = keeper_checkpoint_inventory_json state.Mcp_server.workspace_config name in
+      let (st, json) = keeper_checkpoint_inventory_json (Mcp_server.workspace_config state) name in
       let status : Httpun.Status.t =
         match st with `OK -> `OK | `Not_found -> `Not_found
       in
@@ -83,7 +83,7 @@ let handle_keeper_get_subroutes state req request reqd =
         |> max 1 |> min trajectory_max_limit
       in
       let st, json =
-        keeper_runtime_trace_json state.Mcp_server.workspace_config name
+        keeper_runtime_trace_json (Mcp_server.workspace_config state) name
           ?trace_id ?turn_id ~limit ()
       in
       let status : Httpun.Status.t =
@@ -95,7 +95,7 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       let (st, json) =
         Dashboard_http_keeper.keeper_config_json config name
       in
@@ -108,7 +108,7 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       let (st, json) =
         Dashboard_http_keeper.keeper_bdi_snapshot_json config name
       in
@@ -126,7 +126,7 @@ let handle_keeper_get_subroutes state req request reqd =
            [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])
         reqd
     else
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       let masc_root = Workspace.masc_root_dir config in
       let window_hours =
         Server_utils.int_query_param req "window_hours"
@@ -246,7 +246,7 @@ let handle_keeper_get_subroutes state req request reqd =
       let entries =
         Keeper_tool_call_log.read_recent ~keeper_name:name ~n:limit ()
       in
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       let masc_root = Workspace.masc_root_dir config in
       let latest_ts =
         List.fold_left
@@ -328,7 +328,7 @@ let handle_keeper_get_subroutes state req request reqd =
         Server_utils.int_query_param req "limit" ~default:50
         |> max 1 |> min trajectory_max_limit
       in
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       let store = Keeper_types_support.keeper_turn_record_store config name in
       let raw_rows = Dated_jsonl.read_recent store limit in
       (* Strict decode: malformed rows are counted and reported, never
@@ -424,7 +424,7 @@ let handle_keeper_get_subroutes state req request reqd =
            [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])
         reqd
     else
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       (match Keeper_meta_store.read_meta config name with
        | Error e ->
          respond_error ~status:`Internal_server_error reqd e
@@ -502,7 +502,7 @@ let handle_keeper_get_subroutes state req request reqd =
         Server_utils.int_query_param req "limit" ~default:20
         |> max 1 |> min 50
       in
-      let base_path = state.Mcp_server.workspace_config.base_path in
+      let base_path = (Mcp_server.workspace_config state).base_path in
       let phase = Keeper_registry.get_phase ~base_path name in
       let phase_str = match phase with
         | Some p -> `String (Keeper_state_machine.phase_to_string p)
@@ -543,14 +543,14 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let base_path = state.Mcp_server.workspace_config.base_path in
+      let base_path = (Mcp_server.workspace_config state).base_path in
       let limit =
         Server_utils.int_query_param req "limit" ~default:10
         |> max 1 |> min 100
       in
       (* Use keeper name as agent_name for eval lookup.
          Keepers may also have a separate agent_name — look up both. *)
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       let agent_name_opt =
         match Keeper_meta_store.read_meta config name with
         | Ok (Some m) when m.agent_name <> name -> Some m.agent_name
@@ -590,16 +590,16 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let base_path = state.Mcp_server.workspace_config.base_path in
+      let base_path = (Mcp_server.workspace_config state).base_path in
       let phase = Keeper_registry.get_phase ~base_path name in
       let current = match phase with Some p -> p | None -> Keeper_state_machine.Offline in
       let mermaid = Keeper_state_machine_mermaid.phase_to_mermaid ~current in
       let phase_str = Keeper_state_machine.phase_to_string current in
       let stats = Thompson_sampling.get_stats name in
       let meta = Keeper_meta_store.read_meta
-          state.Mcp_server.workspace_config name in
+          (Mcp_server.workspace_config state) name in
       let turn_outcome : [`Ok | `Failed] option =
-        match Keeper_registry.get ~base_path:state.Mcp_server.workspace_config.base_path name with
+        match Keeper_registry.get ~base_path:(Mcp_server.workspace_config state).base_path name with
         | Some entry when entry.turn_consecutive_failures > 0 ->
           Some `Failed
         | Some _ -> Some `Ok
@@ -646,7 +646,7 @@ let handle_keeper_get_subroutes state req request reqd =
         | Ok (Some _) ->
           (match
              Keeper_memory.read_keeper_memory_summary_result
-               state.Mcp_server.workspace_config
+               (Mcp_server.workspace_config state)
                ~name ~max_bytes:120_000 ~max_lines:200 ~recent_limit:0
            with
            | Ok summary ->
@@ -720,7 +720,7 @@ let handle_keeper_get_subroutes state req request reqd =
        (LT-16b, upcoming). *)
     let json =
       Server_dashboard_http.dashboard_fleet_composite_json
-        ~config:state.Mcp_server.workspace_config ()
+        ~config:(Mcp_server.workspace_config state) ()
     in
     Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/composite" then
@@ -731,7 +731,7 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let base_path = state.Mcp_server.workspace_config.base_path in
+      let base_path = (Mcp_server.workspace_config state).base_path in
       (match Keeper_registry.get ~base_path name with
        | None ->
          respond_error ~status:`Not_found reqd
@@ -739,14 +739,14 @@ let handle_keeper_get_subroutes state req request reqd =
        | Some entry ->
          let json =
            Server_dashboard_http.dashboard_keeper_composite_json
-             ~config:state.Mcp_server.workspace_config entry
+             ~config:(Mcp_server.workspace_config state) entry
          in
          Http.Response.json_value ~compress:true ~request:req json reqd)
   else if req_path = prefix ^ "regime" then
     (* 7th FSM axis MVP: fleet-wide behavioral-regime snapshot. Same
        purity contract as the composite route above, uses the
        [Keeper_behavioral_regime_observer] pure projection. *)
-    let base_path = state.Mcp_server.workspace_config.base_path in
+    let base_path = (Mcp_server.workspace_config state).base_path in
     let snapshots =
       Keeper_behavioral_regime_observer.all_snapshots ~base_path ()
     in
@@ -768,7 +768,7 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let base_path = state.Mcp_server.workspace_config.base_path in
+      let base_path = (Mcp_server.workspace_config state).base_path in
       (match Keeper_registry.get ~base_path name with
        | None ->
          respond_error ~status:`Not_found reqd

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -65,7 +65,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
   if String.length name = 0 then
     respond_error reqd "keeper name is required"
   else
-    let config = state.Mcp_server.workspace_config in
+    let config = (Mcp_server.workspace_config state) in
     let resolve_keeper_agent_name () =
       match Keeper_registry_lookup.find_by_name name with
       | Some entry -> Some entry.meta.agent_name

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -61,7 +61,7 @@ let handle_keeper_tools_post state req reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name required"
     else
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       match Keeper_meta_store.read_meta config name with
       | Error msg -> respond_error ~status:`Not_found reqd msg
       | Ok None -> respond_error ~status:`Not_found reqd (Printf.sprintf "keeper %S not found" name)
@@ -288,7 +288,7 @@ let handle_keeper_checkpoints_post state req reqd body_str =
   if String.length name = 0 then
     respond_error ~ok:false reqd "keeper name is required"
   else
-    let config = state.Mcp_server.workspace_config in
+    let config = (Mcp_server.workspace_config state) in
     try
       let args = Yojson.Safe.from_string body_str in
       let action = Safe_ops.json_string ~default:"" "action" args in
@@ -353,7 +353,7 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
   if String.length name = 0 then
     respond_error reqd "keeper name is required"
   else
-    let config = state.Mcp_server.workspace_config in
+    let config = (Mcp_server.workspace_config state) in
     match Keeper_meta_store.read_meta config name with
     | Error msg -> respond_error ~status:`Not_found reqd msg
     | Ok None ->
@@ -451,7 +451,7 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
   | Error msg ->
       respond_error ~ok:false reqd msg
     | Ok directive ->
-        let config = state.Mcp_server.workspace_config in
+        let config = (Mcp_server.workspace_config state) in
         let action_str =
           match directive with
           | `Pause -> "pause"
@@ -630,7 +630,7 @@ let handle_keeper_bulk_directive_post state _agent_name req reqd body_str =
         (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
         reqd
   | Ok (names, directive) ->
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       let action_str =
         match directive with
         | `Pause -> "pause"

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -101,7 +101,7 @@ let schedule_namespace_truth_shell_refresh ~sw ~clock config =
                    (Printexc.to_string exn))))
 
 let dashboard_namespace_truth_http_json ~state ~sw ~clock _request =
-  let config = state.Mcp_server.workspace_config in
+  let config = (Mcp_server.workspace_config state) in
   (* Fast-path: if the proactive execution refresh hasn't produced a result
      yet, return "initializing" immediately instead of blocking for 15-20s
      on cold-start on-demand compute. The frontend retries every 3s via
@@ -244,7 +244,7 @@ let namespace_truth_snapshot_from_caches (state : Mcp_server.server_state) :
   if not (cached_surface_has_success Server_dashboard_http_execution_surfaces.execution_cache) then
     None
   else
-    let config = state.Mcp_server.workspace_config in
+    let config = (Mcp_server.workspace_config state) in
     let shell_json = cached_shell_json_for_namespace ~config in
     let execution_json =
       cached_surface_json Server_dashboard_http_execution_surfaces.execution_cache

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -515,7 +515,7 @@ let start ~sw ~env ~clock ~state =
         ~sw ~clock
         ~proc_mgr:state.Mcp_server.proc_mgr
         ~net:state.Mcp_server.net
-        ~config:state.Mcp_server.workspace_config
+        ~config:(Mcp_server.workspace_config state)
     in
     let policy_label = Discord_gateway_state.trigger_policy_to_string policy in
     Log.Server.info
@@ -534,13 +534,13 @@ let start ~sw ~env ~clock ~state =
             on_event
               ~dispatch
               ~clock
-              ~base_dir:state.Mcp_server.workspace_config.base_path
+              ~base_dir:(Mcp_server.workspace_config state).base_path
               ev)
           ~on_ambient:(fun ev ->
             (* Read base_path per event: [workspace_config] is mutable
                (workspace-switch tools swap it). *)
             on_ambient
-              ~base_dir:state.Mcp_server.workspace_config.base_path ev)
+              ~base_dir:(Mcp_server.workspace_config state).base_path ev)
           ()
       with
       | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -116,7 +116,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
         with_initialized_state (fun state ->
           match
             authorize_read_request
-              ~base_path:state.Mcp_server.workspace_config.base_path
+              ~base_path:(Mcp_server.workspace_config state).base_path
               httpun_request
           with
           | Ok () ->
@@ -130,7 +130,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       with_server_state h2_reqd (fun state ->
         match
           authorize_token_bound_permission_request
-            ~base_path:state.Mcp_server.workspace_config.base_path
+            ~base_path:(Mcp_server.workspace_config state).base_path
             ~permission
             httpun_request
         with
@@ -164,7 +164,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
     let _h2_authorize_tool state ~tool_name =
       authorize_tool_request
-        ~base_path:state.Mcp_server.workspace_config.base_path
+        ~base_path:(Mcp_server.workspace_config state).base_path
         ~tool_name httpun_request
     in
 
@@ -228,7 +228,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             with_server_state h2_reqd (fun state ->
               match
                 authorize_permission_request
-                  ~base_path:state.Mcp_server.workspace_config.base_path
+                  ~base_path:(Mcp_server.workspace_config state).base_path
                   ~permission:Masc_domain.CanBroadcast
                   httpun_request
               with
@@ -258,7 +258,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             with_server_state h2_reqd (fun state ->
               match
                 authorize_permission_request
-                  ~base_path:state.Mcp_server.workspace_config.base_path
+                  ~base_path:(Mcp_server.workspace_config state).base_path
                   ~permission:Masc_domain.CanBroadcast
                   httpun_request
               with
@@ -315,7 +315,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           in
           (* HTTP-level auth check for MCP endpoints *)
           let base_path = match !server_state with
-            | Some s -> s.Mcp_server.workspace_config.base_path
+            | Some s -> (Mcp_server.workspace_config s).base_path
             | None -> default_base_path ()
           in
           let context =
@@ -470,7 +470,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             else Server_mcp_transport_http.Full
           in
           let base_path = match !server_state with
-            | Some s -> s.Mcp_server.workspace_config.base_path
+            | Some s -> (Mcp_server.workspace_config s).base_path
             | None -> default_base_path ()
           in
           let auth_result =
@@ -549,7 +549,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       | `POST, "/graphql" ->
           h2_read_body h2_reqd (fun body_str ->
             with_server_state h2_reqd (fun state ->
-              let response = Graphql_api.handle_request ~config:state.workspace_config body_str in
+              let response = Graphql_api.handle_request ~config:(Mcp_server.workspace_config state) body_str in
               let status = match response.status with `OK -> `OK | `Bad_request -> `Bad_request in
               h2_respond_json h2_reqd response.body ~status ~extra_headers:cors))
 
@@ -576,14 +576,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             let json =
               dashboard_shell_http_json ?clock:state.Mcp_server.clock
                 ~request:httpun_request ~light
-                state.Mcp_server.workspace_config
+                (Mcp_server.workspace_config state)
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/branches" ->
           with_server_state h2_reqd (fun state ->
             let json =
-              Dashboard_branches.json ~config:state.Mcp_server.workspace_config
+              Dashboard_branches.json ~config:(Mcp_server.workspace_config state)
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
@@ -595,7 +595,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             in
             let json =
               Dashboard_operator_nudges.json
-                ~config:state.Mcp_server.workspace_config ~limit ()
+                ~config:(Mcp_server.workspace_config state) ~limit ()
             in
             h2_respond_json_value h2_reqd json
               ~extra_headers:cors)
@@ -612,7 +612,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               | None -> trimmed_query_param httpun_request "agent"
             in
             let json =
-              Dashboard_workspace.json ~config:state.Mcp_server.workspace_config ?me
+              Dashboard_workspace.json ~config:(Mcp_server.workspace_config state) ?me
                 ~limit ()
             in
             h2_respond_json_value h2_reqd json
@@ -705,7 +705,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           with_h2_public_read h2_reqd (fun state ->
             let json =
               dashboard_governance_http_json httpun_request
-                ~base_path:state.Mcp_server.workspace_config.base_path
+                ~base_path:(Mcp_server.workspace_config state).base_path
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
@@ -713,7 +713,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           with_h2_public_read h2_reqd (fun state ->
             let json =
               dashboard_proof_http_json
-                ~config:state.Mcp_server.workspace_config httpun_request
+                ~config:(Mcp_server.workspace_config state) httpun_request
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
@@ -721,7 +721,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           with_h2_public_read h2_reqd (fun state ->
             let json =
               dashboard_planning_http_json
-                ~config:state.Mcp_server.workspace_config
+                ~config:(Mcp_server.workspace_config state)
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
@@ -739,7 +739,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           with_h2_public_read h2_reqd (fun state ->
             let json =
               dashboard_goals_tree_http_json
-                ~config:state.Mcp_server.workspace_config
+                ~config:(Mcp_server.workspace_config state)
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
@@ -761,7 +761,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             else
               let json =
                 dashboard_goal_detail_http_json
-                  ~config:state.Mcp_server.workspace_config ~goal_id
+                  ~config:(Mcp_server.workspace_config state) ~goal_id
               in
               h2_respond_json_value h2_reqd json
                 ~extra_headers:cors)
@@ -783,7 +783,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                 |> Server_utils.clamp ~min_v:1 ~max_v:200
               in
               let json =
-                Task.Tool.task_history_events_json state.Mcp_server.workspace_config
+                Task.Tool.task_history_events_json (Mcp_server.workspace_config state)
                   ~task_id ~limit
               in
               h2_respond_json_value h2_reqd json
@@ -814,7 +814,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
       | `GET, "/api/v1/dashboard/perf" ->
           with_h2_public_read h2_reqd (fun state ->
-            let json = dashboard_perf_http_json state.Mcp_server.workspace_config in
+            let json = dashboard_perf_http_json (Mcp_server.workspace_config state) in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/oas/telemetry/recent" ->
@@ -838,7 +838,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
       | `GET, "/api/v1/status" ->
           with_server_state h2_reqd (fun state ->
-            let config = state.Mcp_server.workspace_config in
+            let config = (Mcp_server.workspace_config state) in
             let workspace_state = Workspace.read_state config in
             let tempo = Tempo.get_tempo config in
             let json = `Assoc [
@@ -879,7 +879,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                ~cors ~path
                ~config:
                  (Option.map
-                    (fun state -> state.Mcp_server.workspace_config)
+                    (fun state -> (Mcp_server.workspace_config state))
                     !server_state)
                httpun_meth ->
           ()

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -9,12 +9,12 @@ open Server_utils
 open Masc_domain
 module Http = Http_server_eio
 
-let base_path_of_state state = state.Mcp_server.workspace_config.base_path
+let base_path_of_state state = (Mcp_server.workspace_config state).base_path
 let extract_path_param = Server_utils.extract_path_param
 
 let resolve_workspace_base ~state ~uri =
   let project_base = base_path_of_state state in
-  let config = state.Mcp_server.workspace_config in
+  let config = (Mcp_server.workspace_config state) in
   let lookup_repository repo_id =
     match Repo_store.find ~base_path:project_base repo_id with
     | Ok repo -> Some (Repo_store.local_path ~base_path:project_base repo)
@@ -233,7 +233,7 @@ let add_routes router =
   |> Http.Router.get "/api/v1/status" (fun request reqd ->
     with_public_read
       (fun state _req reqd ->
-         let config = state.Mcp_server.workspace_config in
+         let config = (Mcp_server.workspace_config state) in
          let workspace_state = Workspace.read_state config in
          let tempo = Tempo.get_tempo config in
          let json = `Assoc [

--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -65,7 +65,7 @@ type conn_state =
   ; disconnected : bool Atomic.t
   }
 
-let base_path_of_state state = state.Mcp_server.workspace_config.base_path
+let base_path_of_state state = (Mcp_server.workspace_config state).base_path
 
 (** Signal connection end — resolves the disconnect promise so
     [Eio.Switch.run] exits and cleans up all associated resources. *)

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -179,7 +179,7 @@ let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
             | Some sw, Some clock ->
                 Ok
                   {
-                    base_path = state.Mcp_server.workspace_config.base_path;
+                    base_path = (Mcp_server.workspace_config state).base_path;
                     sw;
                     clock;
                     handle_request =
@@ -203,7 +203,7 @@ let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
     get_base_path =
       (fun () ->
         match current_server_state_opt () with
-        | Some state -> state.Mcp_server.workspace_config.base_path
+        | Some state -> (Mcp_server.workspace_config state).base_path
         | None -> Server_mcp_transport_http.default_base_path ());
     verify_mcp_auth =
       (fun ~base_path request ->

--- a/lib/server/server_routes_http_dashboard_handlers.ml
+++ b/lib/server/server_routes_http_dashboard_handlers.ml
@@ -29,7 +29,7 @@ let handle_broadcast state agent_name reqd body_str =
     let json = Yojson.Safe.from_string body_str in
     match Json_util.assoc_member_opt "message" json with
     | Some (`String message) ->
-        let config = state.Mcp_server.workspace_config in
+        let config = (Mcp_server.workspace_config state) in
         let _ = Workspace.broadcast config ~from_agent:agent_name ~content:message in
         reply true None
     | Some `Null -> reply false (Some "missing required field: message")
@@ -78,12 +78,12 @@ let handle_dashboard_task_history state req reqd =
     in
     let cache_key =
       Printf.sprintf "task_history:%s:%s:%d"
-        state.Mcp_server.workspace_config.base_path task_id limit
+        (Mcp_server.workspace_config state).base_path task_id limit
     in
     let json =
       Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
         Domain_pool_ref.submit_io_or_inline (fun () ->
-          Task.Tool.task_history_events_json state.Mcp_server.workspace_config
+          Task.Tool.task_history_events_json (Mcp_server.workspace_config state)
             ~task_id ~limit))
     in
     Http.Response.json_value ~compress:true ~request:req json reqd
@@ -105,9 +105,9 @@ let handle_dashboard_workspace state req reqd =
      param variants stay distinct. Shared by /dashboard/workspace and /workspaces. *)
   let cache_key =
     Printf.sprintf "workspace:%s:%d:%s"
-      state.Mcp_server.workspace_config.base_path limit
+      (Mcp_server.workspace_config state).base_path limit
       (Option.value ~default:"" me)
   in
   Server_routes_http_common.respond_cached_read ~request:req ~reqd ~cache_key
     ~ttl:Server_dashboard_http_core_cache.realtime_cache_ttl_s (fun () ->
-      Dashboard_workspace.json ~config:state.Mcp_server.workspace_config ?me ~limit ())
+      Dashboard_workspace.json ~config:(Mcp_server.workspace_config state) ?me ~limit ())

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -71,7 +71,7 @@ let handle_keeper_chat_request_result state request reqd =
   | Ok request_id -> (
       match
         Keeper_msg_async.poll
-          ~base_path:state.Mcp_server.workspace_config.base_path request_id
+          ~base_path:(Mcp_server.workspace_config state).base_path request_id
       with
       | Keeper_msg_async.Absent ->
           respond_json_value_with_cors ~status:`Not_found request reqd
@@ -96,7 +96,7 @@ let handle_keeper_chat_request_cancel state request reqd =
   | Ok request_id ->
       let cancelled =
         Keeper_msg_async.cancel
-          ~base_path:state.Mcp_server.workspace_config.base_path request_id
+          ~base_path:(Mcp_server.workspace_config state).base_path request_id
       in
       if cancelled then
         respond_json_value_with_cors ~status:`OK request reqd
@@ -122,7 +122,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
     try
       let keeper_ctx : _ Keeper_tool_surface.context =
         {
-          config = state.Mcp_server.workspace_config;
+          config = (Mcp_server.workspace_config state);
           agent_name;
           sw;
           clock;
@@ -148,7 +148,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
     if success then None
     else Some (Printf.sprintf "duration_ms=%d" duration_ms)
   in
-  Audit_log.log_tool_call state.Mcp_server.workspace_config
+  Audit_log.log_tool_call (Mcp_server.workspace_config state)
     ~agent_id:agent_name ~tool_name:"masc_keeper_msg" ~success ~error_msg ();
   if not success then
     Log.Keeper.emit Log.Error
@@ -171,7 +171,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
              if success then None
              else Some (Telemetry_eio.error_kind_of_string "tool_failure")
            in
-           Telemetry_eio.track_tool_called ~fs state.Mcp_server.workspace_config
+           Telemetry_eio.track_tool_called ~fs (Mcp_server.workspace_config state)
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success ~duration_ms
              ~source:(Tool_registry.string_of_source Agent_internal)
              ?error_kind:telemetry_error_kind ?error_message:error_msg ()
@@ -380,7 +380,7 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ ?on_event stat
     try
       let keeper_ctx : _ Keeper_tool_surface.context =
         {
-          config = state.Mcp_server.workspace_config;
+          config = (Mcp_server.workspace_config state);
           agent_name;
           sw;
           clock;
@@ -409,7 +409,7 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ ?on_event stat
     if success then None
     else Some (Printf.sprintf "duration_ms=%d" duration_ms)
   in
-  Audit_log.log_tool_call state.Mcp_server.workspace_config ~agent_id:agent_name
+  Audit_log.log_tool_call (Mcp_server.workspace_config state) ~agent_id:agent_name
     ~tool_name:"masc_keeper_msg" ~success ~error_msg ();
   if not success then
     Log.Keeper.emit Log.Error
@@ -432,7 +432,7 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ ?on_event stat
              if success then None
              else Some (Telemetry_eio.error_kind_of_string "tool_failure")
            in
-           Telemetry_eio.track_tool_called ~fs state.Mcp_server.workspace_config
+           Telemetry_eio.track_tool_called ~fs (Mcp_server.workspace_config state)
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success
              ~duration_ms ~source:(Tool_registry.string_of_source Agent_internal)
              ?error_kind:telemetry_error_kind ?error_message:error_msg ()
@@ -515,7 +515,7 @@ type keeper_stream_worker_event =
 let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
     ~payload ~run_id ~message_id ~agent_name
     ~(events : Keeper_chat_events.keeper_chat_event Eio.Stream.t) =
-  let base_path = state.Mcp_server.workspace_config.base_path in
+  let base_path = (Mcp_server.workspace_config state).base_path in
   let redaction =
     Keeper_secret_redaction.snapshot ~base_path ~keeper_name:payload.name
   in
@@ -864,7 +864,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
 let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let redaction =
     Keeper_secret_redaction.snapshot
-      ~base_path:state.Mcp_server.workspace_config.base_path
+      ~base_path:(Mcp_server.workspace_config state).base_path
       ~keeper_name:payload.name
   in
   let redact_text = Keeper_secret_redaction.redact_text redaction in

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -445,7 +445,7 @@ let bonsai_api_keepers_summary request reqd =
         (`Assoc [ ("error", `String "server state not initialized") ])
   | Some state ->
       let resp =
-        keepers_summary_from_registry ~base_path:state.workspace_config.base_path
+        keepers_summary_from_registry ~base_path:(Mcp_server.workspace_config state).base_path
       in
       respond_public_read_json_value request reqd
         (Masc_dashboard_api_types.Keepers.response_to_yojson resp)
@@ -516,7 +516,7 @@ let handle_post_graphql request reqd =
         respond_json_with_cors ~status:`Internal_server_error request reqd
           (server_state_error_json message)
     | Ok state ->
-        let response = Graphql_api.handle_request ~config:state.workspace_config body_str in
+        let response = Graphql_api.handle_request ~config:(Mcp_server.workspace_config state) body_str in
         let status = http_status_of_graphql response.status in
         let headers = Httpun.Headers.of_list (
           ("content-length", string_of_int (String.length response.body))

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -206,7 +206,7 @@ let add_routes ~sw ~clock router =
 
   |> Http.Router.get "/api/v1/governance/params/audit" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let base_path = state.Mcp_server.workspace_config.base_path in
+         let base_path = (Mcp_server.workspace_config state).base_path in
          let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
          let entries = Runtime_params.recent_audit ~base_path limit in
          let json = `Assoc [
@@ -218,7 +218,7 @@ let add_routes ~sw ~clock router =
 
   |> Http.Router.get "/api/v1/audit" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let config = state.Mcp_server.workspace_config in
+         let config = (Mcp_server.workspace_config state) in
          let limit  = int_query_param req "limit"  ~default:100 |> clamp ~min_v:1 ~max_v:500 in
          let actor_filter    = query_param req "actor" in
          let kind_filter     = query_param req "kind" in
@@ -266,7 +266,7 @@ let add_routes ~sw ~clock router =
          let blind_votes = bool_query_param req "blind_votes" ~default:false in
          let include_moderation =
            include_moderation_projection
-             ~base_path:state.Mcp_server.workspace_config.base_path
+             ~base_path:(Mcp_server.workspace_config state).base_path
              req
          in
          let posts =
@@ -290,7 +290,7 @@ let add_routes ~sw ~clock router =
          let reactions_for = board_reactions_lookup reaction_rows in
          let contributor_quality_for =
            board_contributor_quality_lookup
-             ~config:state.Mcp_server.workspace_config ()
+             ~config:(Mcp_server.workspace_config state) ()
          in
          let posts_json =
            List.map
@@ -476,12 +476,12 @@ let add_routes ~sw ~clock router =
               in
               let include_moderation =
                 include_moderation_projection
-                  ~base_path:state.Mcp_server.workspace_config.base_path
+                  ~base_path:(Mcp_server.workspace_config state).base_path
                   req
               in
               let (status, body) =
                 board_post_detail_json ~include_moderation ~blind_votes ~voter
-                  ~config:(Some state.Mcp_server.workspace_config)
+                  ~config:(Some (Mcp_server.workspace_config state))
                   ~response_format:format ~post_id
               in
               respond_json_with_cors ~status request reqd body)
@@ -631,11 +631,11 @@ let add_routes ~sw ~clock router =
           | Some agent_name ->
               let limit = standard_limit request in
               let mentions =
-                Mention_inbox.read_mentions state.Mcp_server.workspace_config
+                Mention_inbox.read_mentions (Mcp_server.workspace_config state)
                   ~target_agent:agent_name ~limit
               in
               let unread =
-                Mention_inbox.unread_count state.Mcp_server.workspace_config
+                Mention_inbox.unread_count (Mcp_server.workspace_config state)
                   ~target_agent:agent_name
               in
               let json = `Assoc [
@@ -658,7 +658,7 @@ let add_routes ~sw ~clock router =
           | Some agent_name ->
               let rep =
                 Reputation.compute_reputation
-                  state.Mcp_server.workspace_config ~agent_name
+                  (Mcp_server.workspace_config state) ~agent_name
               in
               Http.Response.json_value
                 (Reputation.reputation_to_json rep) reqd)
@@ -670,7 +670,7 @@ let add_routes ~sw ~clock router =
          let agent_name = query_param req "agent" in
          let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
          let items =
-           Activity_feed.recent_activity state.Mcp_server.workspace_config
+           Activity_feed.recent_activity (Mcp_server.workspace_config state)
              ?agent_name ~limit ()
          in
          let json = `Assoc [
@@ -706,7 +706,7 @@ let add_routes ~sw ~clock router =
                  | "clear" ->
                    Prompt_registry.clear_prompt_override key;
                    (try Prompt_registry.persist_overrides
-                          state.Mcp_server.workspace_config.base_path
+                          (Mcp_server.workspace_config state).base_path
                     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                       Log.Pages.warn "prompt override persist (clear) failed: %s"
                         (Printexc.to_string exn));
@@ -717,7 +717,7 @@ let add_routes ~sw ~clock router =
                    match Prompt_registry.set_override key value with
                    | Ok () ->
                      (try Prompt_registry.persist_overrides
-                            state.Mcp_server.workspace_config.base_path
+                            (Mcp_server.workspace_config state).base_path
                       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                         Log.Pages.warn "prompt override persist (set) failed: %s"
                           (Printexc.to_string exn));
@@ -756,7 +756,7 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args = Yojson.Safe.from_string body_str in
-             let base_path = state.Mcp_server.workspace_config.base_path in
+             let base_path = (Mcp_server.workspace_config state).base_path in
              let actor =
                sanitized_dashboard_actor_for_request ~base_path request
                |> Option.value ~default:"dashboard"
@@ -833,7 +833,7 @@ let add_routes ~sw ~clock router =
              let args = Yojson.Safe.from_string body_str in
              let param_key = Json_util.get_string args "param_key"
                |> Option.value ~default:"" in
-             let base_path = state.Mcp_server.workspace_config.base_path in
+             let base_path = (Mcp_server.workspace_config state).base_path in
              let actor =
                sanitized_dashboard_actor_for_request ~base_path request
                |> Option.value ~default:"dashboard"

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -122,7 +122,7 @@ let handle_gate_message ~sw ~clock state request reqd =
         ~sw ~clock
         ~proc_mgr:state.Mcp_server.proc_mgr
         ~net:state.Mcp_server.net
-        ~config:state.Mcp_server.workspace_config
+        ~config:(Mcp_server.workspace_config state)
     in
     let result =
       try
@@ -256,7 +256,7 @@ let handle_gate_connector_status _state request reqd =
 
 let gate_keeper_ctx ~sw ~clock state =
   {
-    Keeper_tool_surface.config = state.Mcp_server.workspace_config;
+    Keeper_tool_surface.config = (Mcp_server.workspace_config state);
     agent_name = "gate:connector";
     sw;
     clock;
@@ -377,7 +377,7 @@ let handle_bind_for_connector ~sw ~clock state request reqd
         | Ok true -> (
             let actor_name =
               sanitized_dashboard_actor_for_request
-                ~base_path:state.Mcp_server.workspace_config.base_path request
+                ~base_path:(Mcp_server.workspace_config state).base_path request
               |> Option.value ~default:"dashboard"
               |> String.trim
             in
@@ -411,7 +411,7 @@ let handle_unbind_for_connector state request reqd
       else
         let actor_name =
           sanitized_dashboard_actor_for_request
-            ~base_path:state.Mcp_server.workspace_config.base_path request
+            ~base_path:(Mcp_server.workspace_config state).base_path request
           |> Option.value ~default:"dashboard"
           |> String.trim
         in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -327,7 +327,7 @@ let add_routes ~sw ~clock router =
          let json =
            Server_dashboard_snapshot_select.select_shell_json
              ?clock:state.Mcp_server.clock ~request:req
-             ~timing ~light state.Mcp_server.workspace_config
+             ~timing ~light (Mcp_server.workspace_config state)
          in
          Http.Response.json_value ~compress:true ~request:req ~extra_headers:(Server_timing.extra_header timing) json reqd
        ) request reqd)
@@ -339,13 +339,13 @@ let add_routes ~sw ~clock router =
          in
          let cache_key =
            Printf.sprintf "nudges:%s:%d"
-             state.Mcp_server.workspace_config.base_path limit
+             (Mcp_server.workspace_config state).base_path limit
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:realtime_cache_ttl_s (fun () ->
              Domain_pool_ref.submit_io_or_inline (fun () ->
                Dashboard_operator_nudges.json
-                 ~config:state.Mcp_server.workspace_config ~limit ()))
+                 ~config:(Mcp_server.workspace_config state) ~limit ()))
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -353,7 +353,7 @@ let add_routes ~sw ~clock router =
        with_public_read (fun state req reqd ->
          let json =
            Dashboard_goal_loop.status_json
-             ~base_path:state.Mcp_server.workspace_config.base_path ()
+             ~base_path:(Mcp_server.workspace_config state).base_path ()
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -365,11 +365,11 @@ let add_routes ~sw ~clock router =
             an Executor_pool domain instead of blocking the main HTTP domain. *)
          let cache_key =
            Printf.sprintf "branches:%s"
-             state.Mcp_server.workspace_config.base_path
+             (Mcp_server.workspace_config state).base_path
          in
          respond_cached_read ~request:req ~reqd ~cache_key
            ~ttl:realtime_cache_ttl_s (fun () ->
-             Dashboard_branches.json ~config:state.Mcp_server.workspace_config)
+             Dashboard_branches.json ~config:(Mcp_server.workspace_config state))
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/workspace" (fun request reqd ->
        with_public_read handle_dashboard_workspace request reqd)
@@ -385,7 +385,7 @@ let add_routes ~sw ~clock router =
            "dev-token endpoint disabled (non-loopback bind or strict auth)"
        else
          with_public_read (fun state req reqd ->
-           let base_path = state.Mcp_server.workspace_config.base_path in
+           let base_path = (Mcp_server.workspace_config state).base_path in
            let raw_result = ensure_dashboard_dev_token base_path in
            begin
              match raw_result with
@@ -489,7 +489,7 @@ let add_routes ~sw ~clock router =
              Log.Ring.recent ~limit ~min_level ~module_filter ?since_seq ()
            in
            let json =
-             dashboard_logs_json ~config:state.Mcp_server.workspace_config ~limit
+             dashboard_logs_json ~config:(Mcp_server.workspace_config state) ~limit
                ~level_filter ~applied_level ~min_level ~module_filter ~since_seq entries
            in
            Http.Response.json_value ~compress:true ~request:req json reqd
@@ -514,7 +514,7 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            let fallback_agent =
              dashboard_actor_for_request
-               ~base_path:state.Mcp_server.workspace_config.base_path request
+               ~base_path:(Mcp_server.workspace_config state).base_path request
            in
            let report_result =
              try
@@ -526,7 +526,7 @@ let add_routes ~sw ~clock router =
            match report_result with
            | Ok report ->
                Dashboard_tool_host_events.record ?fs:state.Mcp_server.fs
-                 state.Mcp_server.workspace_config
+                 (Mcp_server.workspace_config state)
                  report;
                respond_dashboard_ok ~request:req reqd
            | Error message ->
@@ -648,7 +648,7 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/board" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json =
-           dashboard_memory_http_json ~config:state.Mcp_server.workspace_config req
+           dashboard_memory_http_json ~config:(Mcp_server.workspace_config state) req
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -663,7 +663,7 @@ let add_routes ~sw ~clock router =
          dashboard_memory_subsystems_include_entries request
        in
        let handler state req reqd =
-         let config = state.Mcp_server.workspace_config in
+         let config = (Mcp_server.workspace_config state) in
          let cache_key =
            Printf.sprintf "memory_subsystems:%s:%b"
              config.base_path include_memory_entries
@@ -683,7 +683,7 @@ let add_routes ~sw ~clock router =
        else with_public_read handler request reqd)
   |> Http.Router.get "/api/v1/dashboard/governance" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let base_path = state.Mcp_server.workspace_config.base_path in
+         let base_path = (Mcp_server.workspace_config state).base_path in
          let json = dashboard_governance_http_json req ~base_path in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -695,7 +695,7 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/proof" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json =
-           dashboard_proof_http_json ~config:state.Mcp_server.workspace_config req
+           dashboard_proof_http_json ~config:(Mcp_server.workspace_config state) req
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -704,7 +704,7 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args = Yojson.Safe.from_string body_str in
-             let base_path = state.Mcp_server.workspace_config.base_path in
+             let base_path = (Mcp_server.workspace_config state).base_path in
              match dashboard_governance_approval_resolve_http_json ~base_path ~args with
              | Ok json ->
                  respond_json_value_with_cors request reqd json
@@ -721,7 +721,7 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args = Yojson.Safe.from_string body_str in
-             let base_path = state.Mcp_server.workspace_config.base_path in
+             let base_path = (Mcp_server.workspace_config state).base_path in
              match
                dashboard_governance_approval_rule_delete_http_json ~base_path ~args
              with
@@ -743,7 +743,7 @@ let add_routes ~sw ~clock router =
        with_public_read (fun state req reqd ->
          let cache_key =
            Printf.sprintf "operator_snapshot:%s"
-             state.Mcp_server.workspace_config.base_path
+             (Mcp_server.workspace_config state).base_path
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:realtime_cache_ttl_s (fun () ->
@@ -793,12 +793,12 @@ let add_routes ~sw ~clock router =
        with_public_read (fun state req reqd ->
          let cache_key =
            Printf.sprintf "planning:%s"
-             state.Mcp_server.workspace_config.base_path
+             (Mcp_server.workspace_config state).base_path
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
              Domain_pool_ref.submit_io_or_inline (fun () ->
-               dashboard_planning_http_json ~config:state.Mcp_server.workspace_config))
+               dashboard_planning_http_json ~config:(Mcp_server.workspace_config state)))
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -817,12 +817,12 @@ let add_routes ~sw ~clock router =
        with_public_read (fun state req reqd ->
          let cache_key =
            Printf.sprintf "goals_tree:%s"
-             state.Mcp_server.workspace_config.base_path
+             (Mcp_server.workspace_config state).base_path
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
              Domain_pool_ref.submit_io_or_inline (fun () ->
-               dashboard_goals_tree_http_json ~config:state.Mcp_server.workspace_config))
+               dashboard_goals_tree_http_json ~config:(Mcp_server.workspace_config state)))
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -839,13 +839,13 @@ let add_routes ~sw ~clock router =
          else
            let cache_key =
              Printf.sprintf "goal_detail:%s:%s"
-               state.Mcp_server.workspace_config.base_path goal_id
+               (Mcp_server.workspace_config state).base_path goal_id
            in
            let json =
              Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
                Domain_pool_ref.submit_io_or_inline (fun () ->
                  dashboard_goal_detail_http_json
-                   ~config:state.Mcp_server.workspace_config ~goal_id))
+                   ~config:(Mcp_server.workspace_config state) ~goal_id))
            in
            Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -856,7 +856,7 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/briefing" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let cache_key =
-           Printf.sprintf "briefing:%s" state.Mcp_server.workspace_config.base_path
+           Printf.sprintf "briefing:%s" (Mcp_server.workspace_config state).base_path
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:live_cache_ttl_s (fun () ->
@@ -868,7 +868,7 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/session" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let cache_key =
-           Printf.sprintf "session:%s" state.Mcp_server.workspace_config.base_path
+           Printf.sprintf "session:%s" (Mcp_server.workspace_config state).base_path
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:live_cache_ttl_s (fun () ->
@@ -890,8 +890,8 @@ let add_routes ~sw ~clock router =
                ~timing
                ?actor:
                  (dashboard_actor_for_request
-                    ~base_path:state.Mcp_server.workspace_config.base_path request)
-               state.Mcp_server.workspace_config
+                    ~base_path:(Mcp_server.workspace_config state).base_path request)
+               (Mcp_server.workspace_config state)
            in
          Http.Response.json_value ~compress:true ~request:req ~extra_headers:(Server_timing.extra_header timing) json reqd
        ) request reqd)
@@ -899,7 +899,7 @@ let add_routes ~sw ~clock router =
        with_public_read (fun state req reqd ->
          let cache_key =
            Printf.sprintf "mission_briefing:%s"
-             state.Mcp_server.workspace_config.base_path
+             (Mcp_server.workspace_config state).base_path
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:live_cache_ttl_s (fun () ->
@@ -968,7 +968,7 @@ let add_routes ~sw ~clock router =
               | Some _ | None -> None)
            | None -> None
          in
-         let config = state.Mcp_server.workspace_config in
+         let config = (Mcp_server.workspace_config state) in
          let cache_key =
            Printf.sprintf "keeper_feature_proof:%s:%s"
              config.base_path
@@ -996,7 +996,7 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/perf" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = dashboard_perf_http_json state.Mcp_server.workspace_config in
+         let json = dashboard_perf_http_json (Mcp_server.workspace_config state) in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/harness-health" (fun _request reqd ->
@@ -1005,14 +1005,14 @@ let add_routes ~sw ~clock router =
          let until = Server_utils.query_param req "until" in
          let cache_key =
            Printf.sprintf "harness_health:%s:%s:%s"
-             state.Mcp_server.workspace_config.base_path
+             (Mcp_server.workspace_config state).base_path
              (Option.value ~default:"-" since)
              (Option.value ~default:"-" until)
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
              Domain_pool_ref.submit_io_or_inline (fun () ->
-               Dashboard_harness_health.json ~config:state.Mcp_server.workspace_config
+               Dashboard_harness_health.json ~config:(Mcp_server.workspace_config state)
                  ?since ?until ()))
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
@@ -1034,7 +1034,7 @@ let add_routes ~sw ~clock router =
   (* ── Eval feed (RFC-MASC-005 Phase 2) ── *)
   |> Http.Router.get "/api/v1/dashboard/eval-feed" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let base_path = state.Mcp_server.workspace_config.base_path in
+         let base_path = (Mcp_server.workspace_config state).base_path in
          let agent_name = Server_utils.query_param req "agent_name" in
          let limit =
            Server_utils.int_query_param req "limit" ~default:10
@@ -1101,7 +1101,7 @@ let add_routes ~sw ~clock router =
             for cold start. *)
          let json =
            Server_dashboard_snapshot_select.select_telemetry_summary_json
-             ~timing state.Mcp_server.workspace_config
+             ~timing (Mcp_server.workspace_config state)
          in
          Http.Response.json_value ~compress:true ~request:req ~extra_headers:(Server_timing.extra_header timing) json reqd
        ) request reqd)
@@ -1238,7 +1238,7 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/dashboard/worktree-status" (fun request reqd ->
        with_public_read
          (fun state _req reqd ->
-            let base_path = state.Mcp_server.workspace_config.base_path in
+            let base_path = (Mcp_server.workspace_config state).base_path in
             let worktrees =
               match git_run ~cwd:base_path [ "worktree"; "list"; "--porcelain" ] with
               | None -> []

--- a/lib/server/server_routes_http_routes_dashboard_setup.ml
+++ b/lib/server/server_routes_http_routes_dashboard_setup.ml
@@ -86,7 +86,7 @@ let resolve_telemetry_n ~has_time_window ~(n_param : string option) =
    as part of godfile near-threshold split. *)
 let handle_telemetry request reqd =
   with_public_read (fun state req reqd ->
-    let config = state.Mcp_server.workspace_config in
+    let config = (Mcp_server.workspace_config state) in
     let base_path = config.base_path in
     let masc_root = Workspace.masc_root_dir config in
     let float_query_param req key =

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -58,7 +58,7 @@ let mapping_of_json keeper_id (json : Yojson.Safe.t) :
   | _ -> Error "expected JSON object body"
 
 let handle_list_mappings state req reqd =
-  let base_path = state.Mcp_server.workspace_config.base_path in
+  let base_path = (Mcp_server.workspace_config state).base_path in
   match Keeper_repo_mapping.load_all ~base_path with
   | Error msg ->
       Http.Response.json_value ~status:`Internal_server_error ~request:req
@@ -74,7 +74,7 @@ let handle_list_mappings state req reqd =
         reqd
 
 let handle_get_mapping state keeper_id req reqd =
-  let base_path = state.Mcp_server.workspace_config.base_path in
+  let base_path = (Mcp_server.workspace_config state).base_path in
   match Keeper_repo_mapping.load_all ~base_path with
   | Error msg ->
       Http.Response.json_value ~status:`Internal_server_error ~request:req
@@ -103,7 +103,7 @@ let handle_get_mapping state keeper_id req reqd =
             reqd)
 
 let handle_save_mapping state keeper_id req reqd =
-  let base_path = state.Mcp_server.workspace_config.base_path in
+  let base_path = (Mcp_server.workspace_config state).base_path in
   Http.Request.read_body_async reqd (fun body_str ->
       let response status message =
         Http.Response.json_value ~status ~request:req

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -137,7 +137,7 @@ let add_routes ~sw router =
        with_public_read (fun state req reqd ->
          let window = int_query_param req "window" ~default:30 in
          let bucket_min = int_query_param req "bucket_min" ~default:0 in
-         let base_path = state.Mcp_server.workspace_config.base_path in
+         let base_path = (Mcp_server.workspace_config state).base_path in
          let key =
            cache_key
              [ base_path; string_of_int window; string_of_int bucket_min ]
@@ -161,7 +161,7 @@ let add_routes ~sw router =
   |> Http.Router.get "/api/v1/dashboard/keeper-costs" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let window = int_query_param req "window" ~default:1440 in
-         let config = state.Mcp_server.workspace_config in
+         let config = (Mcp_server.workspace_config state) in
          let keeper_names = Keeper_meta_store.keeper_names config in
          let keepers =
            List.filter_map (fun name ->
@@ -179,7 +179,7 @@ let add_routes ~sw router =
   |> Http.Router.get "/api/v1/dashboard/cost-latency" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let window = int_query_param req "window" ~default:1440 in
-         let base_path = state.Mcp_server.workspace_config.base_path in
+         let base_path = (Mcp_server.workspace_config state).base_path in
          let json =
            cached_dashboard_json ~sw ~cache:dashboard_cost_latency_cache
              ~key:(cache_key [ base_path; string_of_int window ])
@@ -193,7 +193,7 @@ let add_routes ~sw router =
   |> Http.Router.get "/api/v1/dashboard/keeper-decisions" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let limit = dashboard_feed_limit req in
-         let config = state.Mcp_server.workspace_config in
+         let config = (Mcp_server.workspace_config state) in
          let keeper_names = Keeper_meta_store.keeper_names config in
          let keepers =
            List.filter_map (fun name ->
@@ -211,7 +211,7 @@ let add_routes ~sw router =
   |> Http.Router.get "/api/v1/dashboard/keeper-decisions-log" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let limit = dashboard_feed_limit req in
-         let config = state.Mcp_server.workspace_config in
+         let config = (Mcp_server.workspace_config state) in
          let keeper_names = Keeper_meta_store.keeper_names config in
          let keepers =
            List.filter_map (fun name ->
@@ -229,7 +229,7 @@ let add_routes ~sw router =
   |> Http.Router.get "/api/v1/dashboard/keeper-memory-log" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let limit = dashboard_feed_limit req in
-         let config = state.Mcp_server.workspace_config in
+         let config = (Mcp_server.workspace_config state) in
          let keeper_names = Keeper_meta_store.keeper_names config in
          let keepers =
            List.filter_map (fun name ->

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -3,7 +3,7 @@ open Server_utils
 
 module Http = Http_server_eio
 
-let base_path_of_state state = state.Mcp_server.workspace_config.base_path
+let base_path_of_state state = (Mcp_server.workspace_config state).base_path
 
 let json_error message =
   `Assoc [("ok", `Bool false); ("error", `String message)]

--- a/lib/server/server_routes_http_routes_verification.ml
+++ b/lib/server/server_routes_http_routes_verification.ml
@@ -52,7 +52,7 @@ let add_routes router =
            | Some s -> int_of_string_opt s
            | None -> None
          in
-         let base_path = state.Mcp_server.workspace_config.base_path in
+         let base_path = (Mcp_server.workspace_config state).base_path in
          let json =
            Dashboard_verification.requests_json ~base_path ?task_id ?limit ()
          in
@@ -65,7 +65,7 @@ let add_routes router =
            | Some s -> int_of_string_opt s
            | None -> None
          in
-         let base_path = state.Mcp_server.workspace_config.base_path in
+         let base_path = (Mcp_server.workspace_config state).base_path in
          let json = Dashboard_verification.summary_json ~base_path ?recent () in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -85,7 +85,7 @@ let add_routes router =
            Http.Request.read_body_async reqd (fun body_str ->
              try
                let args = Yojson.Safe.from_string body_str in
-               let config = state.Mcp_server.workspace_config in
+               let config = (Mcp_server.workspace_config state) in
                let verifier = verifier_of_request ~base_path:config.base_path req in
                match
                  Server_dashboard_http.dashboard_verification_resolve_http_json

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -4,7 +4,7 @@ open Server_routes_http_pages
 
 module Http = Http_server_eio
 
-let base_path_of_state state = state.Mcp_server.workspace_config.base_path
+let base_path_of_state state = (Mcp_server.workspace_config state).base_path
 
 let sanitize_log_value ?(max_bytes = 240) s =
   let without_controls =
@@ -98,7 +98,7 @@ let classify_workspace_query
 
 let resolve_workspace_base ~state ~uri =
   let project_base = base_path_of_state state in
-  let config = state.Mcp_server.workspace_config in
+  let config = (Mcp_server.workspace_config state) in
   let lookup_repository repo_id =
     match Repo_store.find ~base_path:project_base repo_id with
     | Ok repo -> Some (Repo_store.local_path ~base_path:project_base repo)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -369,7 +369,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
   let fleet_meta_scan =
     match current_server_state_opt () with
     | Some state ->
-      Some (keeper_fleet_meta_scan state.Mcp_server.workspace_config)
+      Some (keeper_fleet_meta_scan (Mcp_server.workspace_config state))
     | None -> None
   in
   let paused_keepers_json =

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -194,7 +194,7 @@ let paused_keepers_health_json () =
   let running_names = running_paused_keeper_names () in
   let durable_scan =
     match current_server_state_opt () with
-    | Some state -> durable_paused_keeper_scan state.Mcp_server.workspace_config
+    | Some state -> durable_paused_keeper_scan (Mcp_server.workspace_config state)
     | None -> empty_paused_keeper_scan
   in
   paused_keepers_health_json_of_scan ~running_names durable_scan
@@ -619,8 +619,8 @@ let keeper_fleet_safety_health_json
       match current_server_state_opt () with
       | Some state ->
         (try
-           ( Keeper_runtime.bootable_keeper_names state.Mcp_server.workspace_config
-           , autoboot_enabled_keeper_scan state.Mcp_server.workspace_config )
+           ( Keeper_runtime.bootable_keeper_names (Mcp_server.workspace_config state)
+           , autoboot_enabled_keeper_scan (Mcp_server.workspace_config state) )
          with
          | Eio.Cancel.Cancelled _ as exn -> raise exn
          | exn ->
@@ -637,7 +637,7 @@ let keeper_fleet_safety_health_json
     | Some _ as value -> value
     | None ->
       current_server_state_opt ()
-      |> Option.map (fun state -> state.Mcp_server.workspace_config.base_path)
+      |> Option.map (fun state -> (Mcp_server.workspace_config state).base_path)
   in
   let fallback_running_names =
     match reaction_capacity_names with

--- a/lib/server/server_routes_http_runtime_health_fleet.ml
+++ b/lib/server/server_routes_http_runtime_health_fleet.ml
@@ -30,7 +30,7 @@ let keeper_reaction_ledger_health_json () =
       ; "keepers", `List []
       ]
   | Some state ->
-    let config = state.Mcp_server.workspace_config in
+    let config = (Mcp_server.workspace_config state) in
     let keeper_names =
       try Keeper_meta_store.keeper_names config |> sorted_unique_strings |> take 64 with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -65,10 +65,10 @@ let bool_field name = function
 (* Scope keeper counts to the active workspace's base_path so a running
    keeper from another workspace cannot mask a local outage in fleet
    safety. `bootable_keeper_count` is already derived from
-   `state.workspace_config`, so the running count must use the same scope. *)
+   `(Mcp_server.workspace_config state)`, so the running count must use the same scope. *)
 let runtime_base_path_opt () =
   match current_server_state_opt () with
-  | Some state -> Some state.Mcp_server.workspace_config.base_path
+  | Some state -> Some (Mcp_server.workspace_config state).base_path
   | None -> None
 
 let keeper_fleet_runtime_resolution_base_fields
@@ -184,7 +184,7 @@ let keeper_fleet_runtime_resolution_light_fields () =
       Some
         (keeper_fleet_meta_scan
            ~include_paused_details:false
-           state.Mcp_server.workspace_config)
+           (Mcp_server.workspace_config state))
     | None -> None
   in
   keeper_fleet_runtime_resolution_base_fields

--- a/lib/server/server_routes_http_runtime_health_helpers.ml
+++ b/lib/server/server_routes_http_runtime_health_helpers.ml
@@ -31,8 +31,8 @@ let health_path_diagnostics () =
       Server_base_path_diagnostics.detect
         ?input_base_path:((Host_config.from_env ()).base_path_raw)
         ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
-        ~effective_base_path:state.workspace_config.base_path
-        ~effective_masc_root:(Workspace.masc_root_dir state.workspace_config)
+        ~effective_base_path:(Mcp_server.workspace_config state).base_path
+        ~effective_masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state))
         ()
   | None ->
       let effective_base_path = default_base_path () in

--- a/lib/server/server_routes_http_sidecar_paths.ml
+++ b/lib/server/server_routes_http_sidecar_paths.ml
@@ -27,7 +27,7 @@ let runtime_base_path ?base_path () =
      | _ -> Sys.getcwd ())
 ;;
 
-let request_base_path state = state.Mcp_server.workspace_config.base_path
+let request_base_path state = (Mcp_server.workspace_config state).base_path
 let dir_exists path = Sys.file_exists path && Sys.is_directory path
 
 let project_root_from_executable () =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -178,8 +178,8 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
     Server_base_path_diagnostics.detect
       ?input_base_path
       ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
-      ~effective_base_path:state.workspace_config.base_path
-      ~effective_masc_root:(Workspace.masc_root_dir state.workspace_config)
+      ~effective_base_path:(Mcp_server.workspace_config state).base_path
+      ~effective_masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state))
       ()
     |> Server_base_path_diagnostics.to_yojson
   in
@@ -197,16 +197,16 @@ let runtime_path_diagnostics ?input_base_path (state : Mcp_server.server_state) 
   Server_base_path_diagnostics.detect
     ?input_base_path
     ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
-    ~effective_base_path:state.workspace_config.base_path
-    ~effective_masc_root:(Workspace.masc_root_dir state.workspace_config)
+    ~effective_base_path:(Mcp_server.workspace_config state).base_path
+    ~effective_masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state))
     ()
 
 let restore_persisted_sessions (state : Mcp_server.server_state) =
   Session.restore_from_disk state.session_registry
-    ~agents_path:(Workspace.agents_dir state.workspace_config)
+    ~agents_path:(Workspace.agents_dir (Mcp_server.workspace_config state))
 
 let reconcile_active_agents_gauge (state : Mcp_server.server_state) =
-  Otel_metric_store.reconcile_active_agents_gauge (Workspace.masc_dir state.workspace_config)
+  Otel_metric_store.reconcile_active_agents_gauge (Workspace.masc_dir (Mcp_server.workspace_config state))
 
 
 (* Startup maintenance extracted to
@@ -222,7 +222,7 @@ let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
      direct state constructors used by tests and execute contexts can leave a
      stale process-global config resolution in place. *)
   Config_dir_resolver.reset ();
-  let (_init_msg : string) = Workspace.init state.workspace_config ~agent_name:None in
+  let (_init_msg : string) = Workspace.init (Mcp_server.workspace_config state) ~agent_name:None in
   Mcp_server.set_sse_callback state Sse.broadcast
 
 
@@ -315,8 +315,8 @@ let bootstrap_prompt_state (state : Mcp_server.server_state) =
   (* Initialize prompt registry with defaults and restore saved overrides *)
   let prompt_markdown_dir =
     Prompt_defaults.bootstrap_runtime
-      ~workspace_path:state.workspace_config.workspace_path
-      ~base_path:state.workspace_config.base_path
+      ~workspace_path:(Mcp_server.workspace_config state).workspace_path
+      ~base_path:(Mcp_server.workspace_config state).base_path
   in
   let expected_prompt_dir = Config_dir_resolver.prompts_dir () in
   if prompt_markdown_dir <> expected_prompt_dir then
@@ -345,7 +345,7 @@ let bootstrap_prompt_state (state : Mcp_server.server_state) =
 let warm_tool_registry_from_telemetry (state : Mcp_server.server_state) =
   (try
      let summary =
-       Telemetry_eio.summarize_tool_usage state.workspace_config
+       Telemetry_eio.summarize_tool_usage (Mcp_server.workspace_config state)
      in
      if summary.telemetry_available then
        (* PR-S3: project the persisted Telemetry_eio summary into the registry's
@@ -377,7 +377,7 @@ let warm_tool_registry_from_telemetry (state : Mcp_server.server_state) =
 let restore_tool_metrics_from_disk (state : Mcp_server.server_state) =
   (try
      let n = Tool_metrics_persist.restore
-       ~base_path:state.workspace_config.base_path in
+       ~base_path:(Mcp_server.workspace_config state).base_path in
      if n > 0 then
        Log.Misc.info "tool metrics: restored %d records from disk" n
    with
@@ -714,7 +714,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         Log.Server.info "lazy_task_group: finished %s" group.group_name
       in
       Server_startup_state.activate_lazy
-        ~backend_mode:(Workspace.backend_name state.workspace_config)
+        ~backend_mode:(Workspace.backend_name (Mcp_server.workspace_config state))
         ~tasks:task_names;
       Eio.Fiber.fork ~sw (fun () -> List.iter run_lazy_task_group task_groups)
     in
@@ -725,7 +725,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       in
       server_state := Some state;
       Server_startup_state.mark_state_ready
-        ~backend_mode:(Workspace.backend_name state.workspace_config);
+        ~backend_mode:(Workspace.backend_name (Mcp_server.workspace_config state));
       let resolved_base, masc_dir =
         Server_bootstrap_loops.start_background_maintenance ~sw ~clock ~env state
       in
@@ -772,7 +772,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
             tool_name (String.length result_str);
         if success then Ok result_str else Error result_str
       in
-      Masc_grpc_server.start ~sw ~env ~workspace_config:state.workspace_config
+      Masc_grpc_server.start ~sw ~env ~workspace_config:(Mcp_server.workspace_config state)
         ~tool_dispatcher;
       (* Initialize gRPC client for keeper heartbeat when transport is gRPC *)
       (match Masc_grpc_transport.from_env () with
@@ -789,7 +789,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         | "shell" ->
             Some
               (Server_dashboard_http.dashboard_shell_payload_json ~light:true
-                 state.Mcp_server.workspace_config)
+                 (Mcp_server.workspace_config state))
         | "execution" ->
             Some (Server_dashboard_http.dashboard_execution_snapshot_json ())
         | "operator" ->
@@ -810,7 +810,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         | "composite" ->
             Some
               (Server_dashboard_http.dashboard_fleet_composite_json
-                 ~config:state.Mcp_server.workspace_config ())
+                 ~config:(Mcp_server.workspace_config state) ())
         | "board" ->
             Some
               (Server_dashboard_http.dashboard_board_json
@@ -819,11 +819,11 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         | "goals" ->
             Some
               (Server_dashboard_http.dashboard_goals_snapshot_json
-                 ~config:state.Mcp_server.workspace_config)
+                 ~config:(Mcp_server.workspace_config state))
         | "ide" ->
             Some
               (Server_dashboard_http.dashboard_ide_snapshot_json
-                 ~config:state.Mcp_server.workspace_config)
+                 ~config:(Mcp_server.workspace_config state))
         | _ ->
             None);
       (* Standalone WebSocket transport (enabled by default, opt-out via MASC_WS_ENABLED=0) *)

--- a/lib/server/server_runtime_startup_credentials.ml
+++ b/lib/server/server_runtime_startup_credentials.ml
@@ -4,7 +4,7 @@
    and shared token rotation. *)
 
 let sync_admin_token_env (state : Mcp_server.server_state) =
-  let base_path = state.Mcp_server.workspace_config.base_path in
+  let base_path = (Mcp_server.workspace_config state).base_path in
   let admin_agent_name =
     match Auth.read_initial_admin base_path with
     | Some name ->
@@ -53,7 +53,7 @@ let sync_admin_token_env (state : Mcp_server.server_state) =
              (Masc_domain.masc_error_to_string err))
 
 let sync_internal_keeper_token_env (state : Mcp_server.server_state) =
-  let base_path = state.Mcp_server.workspace_config.base_path in
+  let base_path = (Mcp_server.workspace_config state).base_path in
   let pre_existing =
     match Sys.getenv_opt "MASC_INTERNAL_MCP_TOKEN" with
     | Some raw when String.trim raw <> "" -> true
@@ -81,12 +81,12 @@ let sync_internal_keeper_token_env (state : Mcp_server.server_state) =
     ()
 
 let sync_bootable_keeper_credentials (state : Mcp_server.server_state) =
-  let base_path = state.Mcp_server.workspace_config.base_path in
+  let base_path = (Mcp_server.workspace_config state).base_path in
   let keeper_names =
-    Keeper_runtime.bootable_keeper_names state.Mcp_server.workspace_config
+    Keeper_runtime.bootable_keeper_names (Mcp_server.workspace_config state)
   in
   let excluded_keepers =
-    Keeper_runtime.autoboot_excluded_keeper_reasons state.Mcp_server.workspace_config
+    Keeper_runtime.autoboot_excluded_keeper_reasons (Mcp_server.workspace_config state)
   in
   let keeper_agent_names =
     List.map Keeper_identity.keeper_agent_name keeper_names

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -9,14 +9,14 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
      let days =
        Safe_ops.get_env_int_logged "MASC_JSONL_RETENTION_DAYS" ~default:30
      in
-     let masc = Workspace.masc_dir state.workspace_config in
+     let masc = Workspace.masc_dir (Mcp_server.workspace_config state) in
      let prune_dir dir =
        if Sys.file_exists dir then
          Dated_jsonl.prune (Dated_jsonl.create ~base_dir:dir ()) ~days
        else 0
      in
      let tool_metrics_dir =
-       Filename.concat state.workspace_config.base_path "data/tool-metrics"
+       Filename.concat (Mcp_server.workspace_config state).base_path "data/tool-metrics"
      in
      let total =
        prune_dir (Filename.concat masc "audit")
@@ -57,7 +57,7 @@ let startup_prune_auth_archive (state : Mcp_server.server_state) =
      in
      let kept, pruned =
        Auth.prune_archive
-         ~base_path:state.workspace_config.base_path
+         ~base_path:(Mcp_server.workspace_config state).base_path
          ~retention_days:days
          ~min_keep
      in
@@ -82,7 +82,7 @@ let startup_prune_auth_archive (state : Mcp_server.server_state) =
 let startup_migrate_keeper_histories (state : Mcp_server.server_state) =
   (try
      let traces_dir =
-       Filename.concat (Workspace.masc_root_dir state.workspace_config) "traces"
+       Filename.concat (Workspace.masc_root_dir (Mcp_server.workspace_config state)) "traces"
      in
      if Sys.file_exists traces_dir then begin
        let moved_total = ref 0 in

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -259,7 +259,7 @@ let test_dashboard_namespace_truth_keeper_only_workspace_not_reported_empty () =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       ignore (Lib.Workspace.init config ~agent_name:None);
       ignore
         (Lib.Workspace.bind_session config
@@ -301,7 +301,7 @@ let test_dashboard_namespace_truth_mixed_runtime_counts () =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       ignore (Lib.Workspace.init config ~agent_name:None);
       ignore
         (Lib.Workspace.bind_session config
@@ -375,7 +375,7 @@ let test_dashboard_namespace_truth_promotes_meta_cognition_focus () =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       ignore (Lib.Workspace.init config ~agent_name:None);
       let masc_dir = Lib.Workspace.masc_dir config in
       save_jsonl
@@ -440,7 +440,7 @@ let test_dashboard_namespace_truth_does_not_auto_post_meta_digest () =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      let config = state.Mcp_server.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       ignore (Lib.Workspace.init config ~agent_name:None);
       let masc_dir = Lib.Workspace.masc_dir config in
       save_jsonl
@@ -519,7 +519,7 @@ let test_dashboard_namespace_truth_warm_request_uses_stale_shell () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      let config = state.Lib.Mcp_server.workspace_config in
+      let config = Lib.Mcp_server.workspace_config state in
       warm_execution_cache ();
       let cached_shell =
         `Assoc
@@ -612,7 +612,7 @@ let test_last_good_shell_fallback_preserves_counts () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      ignore (Lib.Workspace.init state.Lib.Mcp_server.workspace_config ~agent_name:None);
+      ignore (Lib.Workspace.init (Lib.Mcp_server.workspace_config state) ~agent_name:None);
       warm_execution_cache ();
       (* Warm the shell cache so last_good_shell gets populated. *)
       Server_dashboard_http.warm_shell_cache state;

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -15,6 +15,7 @@ module AQ = Masc.Keeper_approval_queue
 module SDH = Server_dashboard_http
 module KT = Keeper_types
 module Mcp_eio = Masc.Mcp_server_eio
+module Mcp_server = Masc.Mcp_server
 
 let check = Alcotest.(check string)
 
@@ -149,7 +150,7 @@ let with_test_config f =
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      f state.workspace_config)
+      f (Mcp_server.workspace_config state))
 
 let with_eio_base_path f =
   Eio_main.run @@ fun env ->
@@ -980,7 +981,7 @@ let test_callback_production_tool_edit_file_requires_approval () =
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let config = state.workspace_config in
+  let config = (Mcp_server.workspace_config state) in
   Eio.Fiber.fork ~sw (fun () ->
     let cb =
       GP.to_oas_approval_callback
@@ -1078,7 +1079,7 @@ let test_callback_production_worktree_prepare_requires_approval () =
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      let config = state.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       Eio.Fiber.fork ~sw (fun () ->
         let cb =
           GP.to_oas_approval_callback
@@ -1228,7 +1229,7 @@ let test_callback_always_approve_respects_forbidden () =
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      let config = state.workspace_config in
+      let config = (Mcp_server.workspace_config state) in
       let meta =
         meta_from_json
           (`Assoc [

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -8,6 +8,7 @@ module Types = Masc_domain
 
 module Mcp_eio = Masc.Mcp_server_eio
 module Mcp = Masc.Mcp_server
+module Mcp_server = Masc.Mcp_server
 module Config = Masc.Config
 module Tool_result = Tool_result
 module Keeper_types = Keeper_types
@@ -327,7 +328,7 @@ let test_create_state () =
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
   Alcotest.(check string) "base_path preserved"
-    base_path state.workspace_config.base_path;
+    base_path (Mcp_server.workspace_config state).base_path;
   cleanup_dir base_path
 
 let test_type_compatibility () =
@@ -336,7 +337,7 @@ let test_type_compatibility () =
   let state : Mcp_eio.server_state = Mcp_eio.create_state ~test_mode:true ~base_path () in
   let state2 : Mcp.server_state = state in  (* Type unification at compile time *)
   (* Verify the unified type preserves field access *)
-  Alcotest.(check string) "base_path via unified type" base_path state2.workspace_config.base_path;
+  Alcotest.(check string) "base_path via unified type" base_path (Mcp_server.workspace_config state2).base_path;
   cleanup_dir base_path
 
 let test_eio_context_delegation () =
@@ -949,12 +950,12 @@ let test_handle_request_tools_call_managed_profile_rejects_hidden_claim_alias ()
   (* masc_init and setup join are not under test here; initialise the workspace
      fixture directly so downstream managed-profile assertions are isolated. *)
   Alcotest.(check bool) "init returns failure (tool pruned)" false (Tool_result.is_success init_result);
-  let _ = Masc.Workspace.init state.workspace_config ~agent_name:None in
+  let _ = Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None in
   let _bound =
-    Masc.Workspace.bind_session state.workspace_config ~agent_name:"agent_code" ~capabilities:[] ()
+    Masc.Workspace.bind_session (Mcp_server.workspace_config state) ~agent_name:"agent_code" ~capabilities:[] ()
   in
   let _added =
-    Masc.Workspace.add_task state.workspace_config ~title:"managed-claim"
+    Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"managed-claim"
       ~priority:2 ~description:""
   in
   let request = Yojson.Safe.to_string (`Assoc [
@@ -1128,12 +1129,12 @@ let test_handle_request_tools_call_transition_claim_guidance () =
   (* masc_init and setup join are not under test here; initialise the workspace
      fixture directly so transition guidance assertions are isolated. *)
   Alcotest.(check bool) "init returns failure (tool pruned)" false (Tool_result.is_success init_result);
-  let _ = Masc.Workspace.init state.workspace_config ~agent_name:None in
+  let _ = Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None in
   let _bound =
-    Masc.Workspace.bind_session state.workspace_config ~agent_name:"agent_code" ~capabilities:[] ()
+    Masc.Workspace.bind_session (Mcp_server.workspace_config state) ~agent_name:"agent_code" ~capabilities:[] ()
   in
   ignore
-    (Masc.Workspace.add_task state.workspace_config ~title:"transition-claim"
+    (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"transition-claim"
        ~priority:2 ~description:"");
   let request =
     Yojson.Safe.to_string
@@ -1160,7 +1161,7 @@ let test_handle_request_tools_call_transition_claim_guidance () =
   in
   let steps = workflow_next_step_names response in
   Alcotest.(check (option string)) "claim binds current_task" (Some "task-001")
-    (Masc.Task.Planning_eio.get_current_task state.workspace_config);
+    (Masc.Task.Planning_eio.get_current_task (Mcp_server.workspace_config state));
   Alcotest.(check bool) "claim guidance omits plan_set_task" false
     (List.mem "masc_plan_set_task" steps);
   cleanup_dir base_path
@@ -1183,12 +1184,12 @@ let test_handle_request_tools_call_transition_done_guidance () =
   (* masc_init and setup join are not under test here; initialise the workspace
      fixture directly so transition guidance assertions are isolated. *)
   Alcotest.(check bool) "init returns failure (tool pruned)" false (Tool_result.is_success init_result);
-  let _ = Masc.Workspace.init state.workspace_config ~agent_name:None in
+  let _ = Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None in
   let _bound =
-    Masc.Workspace.bind_session state.workspace_config ~agent_name:"agent_code" ~capabilities:[] ()
+    Masc.Workspace.bind_session (Mcp_server.workspace_config state) ~agent_name:"agent_code" ~capabilities:[] ()
   in
   ignore
-    (Masc.Workspace.add_task state.workspace_config ~title:"transition-done"
+    (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"transition-done"
        ~priority:2 ~description:"");
   let claim_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
@@ -1250,12 +1251,12 @@ let test_handle_request_tools_call_transition_claim_requires_action () =
   (* masc_init and setup join are not under test here; initialise the workspace
      fixture directly so transition guidance assertions are isolated. *)
   Alcotest.(check bool) "init returns failure (tool pruned)" false (Tool_result.is_success init_result);
-  let _ = Masc.Workspace.init state.workspace_config ~agent_name:None in
+  let _ = Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None in
   let _bound =
-    Masc.Workspace.bind_session state.workspace_config ~agent_name:"agent_code" ~capabilities:[] ()
+    Masc.Workspace.bind_session (Mcp_server.workspace_config state) ~agent_name:"agent_code" ~capabilities:[] ()
   in
   ignore
-    (Masc.Workspace.add_task state.workspace_config ~title:"deprecated-claim"
+    (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"deprecated-claim"
        ~priority:2 ~description:"");
   let request =
     Yojson.Safe.to_string
@@ -1595,16 +1596,16 @@ let test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc.Workspace.init state.workspace_config ~agent_name:None);
+  ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
     match Masc.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
-  ignore (Masc.Workspace.bind_session state.workspace_config ~agent_name:"stable-admin" ~capabilities:[] ());
+  ignore (Masc.Workspace.bind_session (Mcp_server.workspace_config state) ~agent_name:"stable-admin" ~capabilities:[] ());
   ignore
-    (Masc.Workspace.add_task state.workspace_config ~title:"explicit-alias-claim-next"
+    (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"explicit-alias-claim-next"
        ~priority:2 ~description:"");
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
@@ -1613,7 +1614,7 @@ let test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token
   in
   check_auth_preflight_result ~tool_name:"keeper_task_claim"
     (Tool_result.is_success result) ((Tool_result.message result));
-  check_task_still_todo state.workspace_config "task-001";
+  check_task_still_todo (Mcp_server.workspace_config state) "task-001";
   cleanup_dir base_path
 
 let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token () =
@@ -1626,16 +1627,16 @@ let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc.Workspace.init state.workspace_config ~agent_name:None);
+  ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
     match Masc.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
-  ignore (Masc.Workspace.bind_session state.workspace_config ~agent_name:"stable-admin" ~capabilities:[] ());
+  ignore (Masc.Workspace.bind_session (Mcp_server.workspace_config state) ~agent_name:"stable-admin" ~capabilities:[] ());
   ignore
-    (Masc.Workspace.add_task state.workspace_config ~title:"explicit-alias-transition"
+    (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"explicit-alias-transition"
        ~priority:2 ~description:"");
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
@@ -1650,7 +1651,7 @@ let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token
   in
   check_auth_preflight_result ~tool_name:"masc_transition"
     (Tool_result.is_success result) ((Tool_result.message result));
-  check_task_still_todo state.workspace_config "task-001";
+  check_task_still_todo (Mcp_server.workspace_config state) "task-001";
   cleanup_dir base_path
 
 let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token () =
@@ -1663,7 +1664,7 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token ()
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc.Workspace.init state.workspace_config ~agent_name:None);
+  ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
     match Masc.Auth.create_token base_path ~agent_name:"qa-king" ~role:Masc_domain.Admin with
@@ -1671,7 +1672,7 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token ()
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
   ignore
-    (Masc.Workspace.add_task state.workspace_config ~title:"hyphenated-generated-alias-claim-next"
+    (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"hyphenated-generated-alias-claim-next"
        ~priority:2 ~description:"");
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:"sid-hyphenated-generated-alias"
@@ -1685,9 +1686,9 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token ()
     (contains_substring ((Tool_result.message result)) "task-001");
   Alcotest.(check (option string)) "current task set after claim_next"
     (Some "task-001")
-    (Masc.Task.Planning_eio.get_current_task state.workspace_config);
+    (Masc.Task.Planning_eio.get_current_task (Mcp_server.workspace_config state));
   Alcotest.(check bool) "explicit alias joined" true
-    (Masc.Workspace.is_agent_session_bound state.workspace_config
+    (Masc.Workspace.is_agent_session_bound (Mcp_server.workspace_config state)
        ~agent_name:"qa-king-warm-heron");
   cleanup_dir base_path
 
@@ -1701,11 +1702,11 @@ let test_execute_tool_claim_next_requires_auth_before_mutation () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc.Workspace.init state.workspace_config ~agent_name:None);
+  ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
-  ignore (Masc.Workspace.bind_session state.workspace_config ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
+  ignore (Masc.Workspace.bind_session (Mcp_server.workspace_config state) ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
   ignore
-    (Masc.Workspace.add_task state.workspace_config ~title:"claim-next-auth-preflight"
+    (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"claim-next-auth-preflight"
        ~priority:2 ~description:"");
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
@@ -1714,9 +1715,9 @@ let test_execute_tool_claim_next_requires_auth_before_mutation () =
   in
   check_auth_preflight_result ~tool_name:"keeper_task_claim"
     (Tool_result.is_success result) ((Tool_result.message result));
-  check_task_still_todo state.workspace_config "task-001";
+  check_task_still_todo (Mcp_server.workspace_config state) "task-001";
   Alcotest.(check (option string)) "no current task after rejected claim_next" None
-    (Masc.Task.Planning_eio.get_current_task state.workspace_config);
+    (Masc.Task.Planning_eio.get_current_task (Mcp_server.workspace_config state));
   cleanup_dir base_path
 
 let test_execute_tool_transition_requires_auth_before_mutation () =
@@ -1729,11 +1730,11 @@ let test_execute_tool_transition_requires_auth_before_mutation () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc.Workspace.init state.workspace_config ~agent_name:None);
+  ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
-  ignore (Masc.Workspace.bind_session state.workspace_config ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
+  ignore (Masc.Workspace.bind_session (Mcp_server.workspace_config state) ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
   ignore
-    (Masc.Workspace.add_task state.workspace_config ~title:"transition-auth-preflight"
+    (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"transition-auth-preflight"
        ~priority:2 ~description:"");
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
@@ -1748,9 +1749,9 @@ let test_execute_tool_transition_requires_auth_before_mutation () =
   in
   check_auth_preflight_result ~tool_name:"masc_transition"
     (Tool_result.is_success result) ((Tool_result.message result));
-  check_task_still_todo state.workspace_config "task-001";
+  check_task_still_todo (Mcp_server.workspace_config state) "task-001";
   Alcotest.(check (option string)) "no current task after rejected transition" None
-    (Masc.Task.Planning_eio.get_current_task state.workspace_config);
+    (Masc.Task.Planning_eio.get_current_task (Mcp_server.workspace_config state));
   cleanup_dir base_path
 
 let test_execute_tool_add_task_with_admin_token_without_join () =
@@ -1763,7 +1764,7 @@ let test_execute_tool_add_task_with_admin_token_without_join () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc.Workspace.init state.workspace_config ~agent_name:None);
+  ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
     match Masc.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
@@ -1785,7 +1786,7 @@ let test_execute_tool_add_task_with_admin_token_without_join () =
   Alcotest.(check bool) "response mentions added task" true
     (contains_substring ((Tool_result.message result)) "Added task-001");
   let task =
-    match Masc.Workspace.get_tasks_raw state.workspace_config with
+    match Masc.Workspace.get_tasks_raw (Mcp_server.workspace_config state) with
     | [ task ] -> task
     | tasks ->
         Alcotest.failf "expected exactly one task, found %d" (List.length tasks)
@@ -1900,7 +1901,7 @@ let test_handle_request_tools_call_board_post_structured_content () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc.Workspace.init state.workspace_config ~agent_name:None);
+  ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
     ("id", `Int 117);
@@ -1935,7 +1936,7 @@ let test_handle_request_tools_call_logs_structured_mcp_details () =
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      ignore (Masc.Workspace.init state.workspace_config ~agent_name:None);
+      ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
       let request =
         Yojson.Safe.to_string
           (`Assoc
@@ -2010,7 +2011,7 @@ let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
         (Keeper_registry.register ~base_path keeper_name
            (make_keeper_meta ~agent_name:keeper_agent_name keeper_name));
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      ignore (Masc.Workspace.init state.workspace_config ~agent_name:None);
+      ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
       let request =
         Yojson.Safe.to_string
           (`Assoc
@@ -2657,7 +2658,7 @@ let test_handle_request_resources_read_matrix () =
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc.Workspace.init state.workspace_config ~agent_name:(Some "fixture-root"));
+  ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:(Some "fixture-root"));
   let ensure_dir path =
     if not (Sys.file_exists path) then Unix.mkdir path 0o755
   in

--- a/test/test_mcp_server_eio_tool_dispatch.ml
+++ b/test/test_mcp_server_eio_tool_dispatch.ml
@@ -1,4 +1,5 @@
 module Mcp_eio = Masc.Mcp_server_eio
+module Mcp_server = Masc.Mcp_server
 module Tool_dispatch = Tool_dispatch
 module Tool_result = Tool_result
 
@@ -94,7 +95,7 @@ let test_execute_tool_tag_dispatch_respects_pre_hooks () =
           else Tool_dispatch.Pass);
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
       let raw_token = create_admin_token base_path in
-      let _workspace_path = Masc.Workspace.masc_dir state.workspace_config in
+      let _workspace_path = Masc.Workspace.masc_dir (Mcp_server.workspace_config state) in
       let hook_result =
         Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
           ~name:"masc_tool_help"

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -1,6 +1,7 @@
 module Types = Masc_domain
 
 module Mcp_eio = Masc.Mcp_server_eio
+module Mcp_server = Masc.Mcp_server
 module Config = Masc.Config
 module Goal_store = Goal_store
 
@@ -300,7 +301,7 @@ let ensure_initialized fixture =
   (* masc_init pruned from registry. Initialise the workspace state directly so
      downstream tools can work. *)
   ignore
-    (Masc.Workspace.init fixture.state.workspace_config
+    (Masc.Workspace.init (Mcp_server.workspace_config fixture.state)
        ~agent_name:(Some fixture.agent_name))
 
 let ensure_bound fixture =
@@ -379,7 +380,7 @@ let ensure_goal fixture =
   | None ->
       let goal =
         match
-          Goal_store.upsert_goal fixture.state.workspace_config
+          Goal_store.upsert_goal (Mcp_server.workspace_config fixture.state)
             ~title:"Tool Matrix Goal" ()
         with
         | Ok (goal, _status) -> goal
@@ -456,7 +457,7 @@ let ensure_verification_request fixture =
   | Some req_id -> req_id
   | None ->
       let base_path =
-        Masc.Workspace.masc_dir fixture.state.workspace_config
+        Masc.Workspace.masc_dir (Mcp_server.workspace_config fixture.state)
       in
       let req =
         match

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -807,7 +807,7 @@ let test_constructor_is_pure () =
 let test_restore_persisted_sessions_uses_flat_agents_dir () =
   with_temp_dir "startup-scope" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
-      let agents = Workspace.agents_dir state.Mcp_server.workspace_config in
+      let agents = Workspace.agents_dir (Mcp_server.workspace_config state) in
       Fs_compat.mkdir_p agents;
       write_file (Filename.concat agents "test-agent.json") "{}";
       Server_runtime_bootstrap.restore_persisted_sessions state;
@@ -1024,7 +1024,7 @@ let test_health_json_surfaces_durable_paused_keepers () =
         (fun () ->
           let state = Mcp_server.create_state ~base_path:dir in
           Server_auth.server_state := Some state;
-          let config = state.Mcp_server.workspace_config in
+          let config = (Mcp_server.workspace_config state) in
           write_keeper_meta_exn config
             (make_keeper_meta ~name:"durable-paused" ~trace_id:"trace-paused"
                ~paused:true ());
@@ -1194,7 +1194,7 @@ let test_health_json_keeps_timeout_pause_without_policy_manual () =
       (fun () ->
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
-        let config = state.Mcp_server.workspace_config in
+        let config = (Mcp_server.workspace_config state) in
         let timeout_paused =
           { (make_keeper_meta
                ~name:"timeout-without-policy"
@@ -1254,7 +1254,7 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
       (fun () ->
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
-        let config = state.Mcp_server.workspace_config in
+        let config = (Mcp_server.workspace_config state) in
         let paused =
           make_keeper_meta ~name:"capacity-paused" ~trace_id:"trace-capacity-paused"
             ~paused:true ()
@@ -1343,7 +1343,7 @@ let test_health_json_ignores_persisted_only_keeper_for_capacity_target () =
       (fun () ->
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
-        let config = state.Mcp_server.workspace_config in
+        let config = (Mcp_server.workspace_config state) in
         write_keeper_meta_exn config
           (make_keeper_meta ~name:"retired-keeper" ~trace_id:"trace-retired" ());
         let request = Httpun.Request.create `GET "/health" in
@@ -1384,7 +1384,7 @@ let test_health_json_explains_phase_paused_capacity_blocker () =
       (fun () ->
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
-        let config = state.Mcp_server.workspace_config in
+        let config = (Mcp_server.workspace_config state) in
         let phase_paused =
           make_keeper_meta ~name:"phase-paused" ~trace_id:"trace-phase-paused" ()
         in
@@ -1432,7 +1432,7 @@ let test_health_json_distinguishes_failing_executable_keepers () =
       (fun () ->
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
-        let config = state.Mcp_server.workspace_config in
+        let config = (Mcp_server.workspace_config state) in
         let paused =
           make_keeper_meta ~name:"capacity-paused" ~trace_id:"trace-capacity-paused"
             ~paused:true ()
@@ -1488,7 +1488,7 @@ let test_health_json_explains_nonrecoverable_failing_keeper () =
       (fun () ->
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
-        let config = state.Mcp_server.workspace_config in
+        let config = (Mcp_server.workspace_config state) in
         let failing =
           make_keeper_meta ~name:"capacity-failing"
             ~trace_id:"trace-capacity-failing" ()
@@ -1525,7 +1525,7 @@ let test_health_json_reaction_ledger_cursor_sweep_clears_pending () =
         Config_dir_resolver.reset ();
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
-        let config = state.Mcp_server.workspace_config in
+        let config = (Mcp_server.workspace_config state) in
         write_keeper_meta_exn config
           (make_keeper_meta ~name:"cursor-swept" ~trace_id:"trace-cursor" ());
         let stimulus post_id updated_at : Keeper_event_queue.stimulus =

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1124,7 +1124,7 @@ let test_board_curation_submit_roundtrips_to_read () =
 
 let mcp_runtime_board_dispatch ~sw ~clock name args =
   let state = Mcp_server.create_state ~base_path:_test_base_path in
-  Mcp_tool_runtime_board.dispatch ~config:state.Mcp_server.workspace_config
+  Mcp_tool_runtime_board.dispatch ~config:(Mcp_server.workspace_config state)
     ~agent_name:"mcp-runtime-curator" ~arguments:args ~state ~sw ~clock ~name
     ~start_time:(Unix.gettimeofday ())
 


### PR DESCRIPTION
# ci:skip-test-coverage\n\n[Mcp_server.server_state.workspace_config] was a mutable record field that was written by [mcp_tool_runtime_workspace.handle_start] while dozens of concurrent readers accessed it without synchronization. Replace it with a [Workspace.config Atomic.t] and expose [workspace_config]/[set_workspace_config] accessors so reads are atomic swaps and writes are visible without tearing.\n\nAll read sites are updated to use the accessor; the two write sites now call [set_workspace_config]. Tests that accessed the field directly are updated with matching module aliases.\n\nRefs: audit finding MASC-mutable-ref-mcp-server-workspace-config