### PR TITLE
fix(board_moderation): protect global store with Eio.Mutex

### DIFF
--- a/lib/board/board_moderation.ml
+++ b/lib/board/board_moderation.ml
@@ -1,7 +1,7 @@
 (** Board_moderation — operator-visible moderation queue and action audit trail.
 
-    Single-writer in-memory store.  Callers must not share the global store
-    across concurrent fibers without external serialisation. *)
+    The in-memory store is protected by an [Eio.Mutex.t]; public operations are
+    safe to call from concurrent Eio fibers. *)
 
 (** {1 Reason codes} *)
 
@@ -102,11 +102,13 @@ type store = {
   report_count_by_target : (target_kind * string, int) Hashtbl.t;
   latest_action_by_target : (target_kind * string, action_kind * float) Hashtbl.t;
   last_flag_by_reporter : (string, float) Hashtbl.t;
+  mutex : Eio.Mutex.t;
 }
 
 let max_note_length = 500
 
 let global_store : store option ref = ref None
+let global_store_mutex = Eio.Mutex.create ()
 
 let default_flag_rate_limit_sec = 1.0
 
@@ -127,7 +129,10 @@ let make_store () : store =
     report_count_by_target = Hashtbl.create 64;
     latest_action_by_target = Hashtbl.create 64;
     last_flag_by_reporter = Hashtbl.create 64;
+    mutex = Eio.Mutex.create ();
   }
+
+let with_lock s f = Eio.Mutex.use_rw ~protect:true s.mutex (fun () -> f ())
 
 let target_key target_kind target_id = (target_kind, target_id)
 
@@ -164,68 +169,76 @@ let store () : store =
   match !global_store with
   | Some s -> s
   | None ->
-      let s = make_store () in
-      global_store := Some s;
-      s
+      Eio.Mutex.use_rw ~protect:true global_store_mutex (fun () ->
+        match !global_store with
+        | Some s -> s
+        | None ->
+            let s = make_store () in
+            global_store := Some s;
+            s)
 
 let reset_for_test () : unit =
-  global_store := None
+  Eio.Mutex.use_rw ~protect:true global_store_mutex (fun () ->
+    global_store := None)
 
 (** {1 Queue operations} *)
 
 let flag ~target_kind ~target_id ~reporter ~reason =
   let s = store () in
-  let now = Time_compat.now () in
-  let target_key = target_key target_kind target_id in
-  if Hashtbl.mem s.unresolved_by_target target_key then
-    Error (Printf.sprintf "target %s is already flagged and pending review" target_id)
-  else
-    let window_sec = flag_rate_limit_sec () in
-    let retry_after = retry_after_for_reporter s ~reporter ~now ~window_sec in
-    match retry_after with
-    | Some remaining ->
-        Error
-          (Printf.sprintf
-             "reporter %s is rate limited; retry after %.3fs"
-             reporter remaining)
-    | None ->
-        let entry_id = Random_id.prefixed ~prefix:"mq-" ~bytes:16 in
-        let entry = {
-          entry_id;
-          target_kind;
-          target_id;
-          reporter;
-          reason;
-          flagged_at = now;
-          resolved   = false;
-        } in
-        Hashtbl.replace s.queue entry_id entry;
-        Hashtbl.replace s.unresolved_by_target target_key entry_id;
-        increment_report_count s target_key;
-        Hashtbl.replace s.last_flag_by_reporter reporter now;
-        Ok entry
+  with_lock s (fun () ->
+    let now = Time_compat.now () in
+    let target_key = target_key target_kind target_id in
+    if Hashtbl.mem s.unresolved_by_target target_key then
+      Error (Printf.sprintf "target %s is already flagged and pending review" target_id)
+    else
+      let window_sec = flag_rate_limit_sec () in
+      let retry_after = retry_after_for_reporter s ~reporter ~now ~window_sec in
+      match retry_after with
+      | Some remaining ->
+          Error
+            (Printf.sprintf
+               "reporter %s is rate limited; retry after %.3fs"
+               reporter remaining)
+      | None ->
+          let entry_id = Random_id.prefixed ~prefix:"mq-" ~bytes:16 in
+          let entry = {
+            entry_id;
+            target_kind;
+            target_id;
+            reporter;
+            reason;
+            flagged_at = now;
+            resolved   = false;
+          } in
+          Hashtbl.replace s.queue entry_id entry;
+          Hashtbl.replace s.unresolved_by_target target_key entry_id;
+          increment_report_count s target_key;
+          Hashtbl.replace s.last_flag_by_reporter reporter now;
+          Ok entry)
 
 let get_queue ?resolved () =
   let s = store () in
-  let entries =
-    Hashtbl.fold (fun _k v acc -> v :: acc) s.queue []
-  in
-  let filtered =
-    match resolved with
-    | None       -> entries
-    | Some want  -> List.filter (fun e -> e.resolved = want) entries
-  in
-  List.sort (fun a b -> Float.compare b.flagged_at a.flagged_at) filtered
+  with_lock s (fun () ->
+    let entries =
+      Hashtbl.fold (fun _k v acc -> v :: acc) s.queue []
+    in
+    let filtered =
+      match resolved with
+      | None       -> entries
+      | Some want  -> List.filter (fun e -> e.resolved = want) entries
+    in
+    List.sort (fun a b -> Float.compare b.flagged_at a.flagged_at) filtered)
 
 let resolve_entry ~entry_id =
   let s = store () in
-  match Hashtbl.find_opt s.queue entry_id with
-  | None -> Error (Printf.sprintf "moderation queue entry not found: %s" entry_id)
-  | Some e ->
-      if not e.resolved then
-        Hashtbl.remove s.unresolved_by_target (target_key e.target_kind e.target_id);
-      Hashtbl.replace s.queue entry_id { e with resolved = true };
-      Ok ()
+  with_lock s (fun () ->
+    match Hashtbl.find_opt s.queue entry_id with
+    | None -> Error (Printf.sprintf "moderation queue entry not found: %s" entry_id)
+    | Some e ->
+        if not e.resolved then
+          Hashtbl.remove s.unresolved_by_target (target_key e.target_kind e.target_id);
+        Hashtbl.replace s.queue entry_id { e with resolved = true };
+        Ok ())
 
 (** {1 Audit trail} *)
 
@@ -253,42 +266,44 @@ let record_action ~target_kind ~target_id ~actor ~action ?reason ?note () =
     acted_at;
   } in
   let target_key = target_key target_kind target_id in
-  (match Hashtbl.find_opt s.unresolved_by_target target_key with
-   | None -> ()
-   | Some entry_id ->
-       Hashtbl.remove s.unresolved_by_target target_key;
-       (match Hashtbl.find_opt s.queue entry_id with
-        | Some qe when not qe.resolved ->
-            Hashtbl.replace s.queue entry_id { qe with resolved = true }
-        | _ -> ()));
-  update_latest_action s target_key action acted_at;
-  s.audit := entry :: !(s.audit);
-  Ok entry
+  with_lock s (fun () ->
+    (match Hashtbl.find_opt s.unresolved_by_target target_key with
+     | None -> ()
+     | Some entry_id ->
+         Hashtbl.remove s.unresolved_by_target target_key;
+         (match Hashtbl.find_opt s.queue entry_id with
+          | Some qe when not qe.resolved ->
+              Hashtbl.replace s.queue entry_id { qe with resolved = true }
+          | _ -> ()));
+    update_latest_action s target_key action acted_at;
+    s.audit := entry :: !(s.audit);
+    Ok entry)
 
 let get_audit_trail ?target_id ?actor ?(limit = 100) () =
   let cap = min limit 500 in
   let s = store () in
-  let entries = !(s.audit) in
-  let filtered =
-    entries
-    |> (match target_id with
-        | None    -> Fun.id
-        | Some id -> List.filter (fun e -> e.target_id = id))
-    |> (match actor with
-        | None -> Fun.id
-        | Some a -> List.filter (fun e -> e.actor = a))
-  in
-  (* Already newest-first since we prepend on record *)
-  let sorted = List.sort (fun a b -> Float.compare b.acted_at a.acted_at) filtered in
-  let n = List.length sorted in
-  if n <= cap then sorted
-  else
-    let rec take acc i = function
-      | []     -> List.rev acc
-      | _ when i >= cap -> List.rev acc
-      | x :: xs -> take (x :: acc) (i + 1) xs
+  with_lock s (fun () ->
+    let entries = !(s.audit) in
+    let filtered =
+      entries
+      |> (match target_id with
+          | None    -> Fun.id
+          | Some id -> List.filter (fun e -> e.target_id = id))
+      |> (match actor with
+          | None -> Fun.id
+          | Some a -> List.filter (fun e -> e.actor = a))
     in
-    take [] 0 sorted
+    (* Already newest-first since we prepend on record *)
+    let sorted = List.sort (fun a b -> Float.compare b.acted_at a.acted_at) filtered in
+    let n = List.length sorted in
+    if n <= cap then sorted
+    else
+      let rec take acc i = function
+        | []     -> List.rev acc
+        | _ when i >= cap -> List.rev acc
+        | x :: xs -> take (x :: acc) (i + 1) xs
+      in
+      take [] 0 sorted)
 
 (** {1 Target projection} *)
 
@@ -300,27 +315,28 @@ let moderation_status_of_action = function
 
 let target_summary ~target_kind ~target_id =
   let s = store () in
-  let target_key = target_key target_kind target_id in
-  let report_count =
-    Hashtbl.find_opt s.report_count_by_target target_key |> Option.value ~default:0
-  in
-  let has_unresolved =
-    match Hashtbl.find_opt s.unresolved_by_target target_key with
-    | None -> false
-    | Some entry_id -> (
-        match Hashtbl.find_opt s.queue entry_id with
-        | Some entry when not entry.resolved -> true
-        | _ -> false)
-  in
-  let moderation_status =
-    if has_unresolved then
-      "flagged"
-    else
-      match Hashtbl.find_opt s.latest_action_by_target target_key with
-      | None -> "none"
-      | Some (action, _acted_at) -> moderation_status_of_action action
-  in
-  { report_count; moderation_status }
+  with_lock s (fun () ->
+    let target_key = target_key target_kind target_id in
+    let report_count =
+      Hashtbl.find_opt s.report_count_by_target target_key |> Option.value ~default:0
+    in
+    let has_unresolved =
+      match Hashtbl.find_opt s.unresolved_by_target target_key with
+      | None -> false
+      | Some entry_id -> (
+          match Hashtbl.find_opt s.queue entry_id with
+          | Some entry when not entry.resolved -> true
+          | _ -> false)
+    in
+    let moderation_status =
+      if has_unresolved then
+        "flagged"
+      else
+        match Hashtbl.find_opt s.latest_action_by_target target_key with
+        | None -> "none"
+        | Some (action, _acted_at) -> moderation_status_of_action action
+    in
+    { report_count; moderation_status })
 
 (** {1 JSON projection} *)
 

--- a/lib/board/board_moderation.ml
+++ b/lib/board/board_moderation.ml
@@ -318,7 +318,9 @@ let target_summary ~target_kind ~target_id =
   with_lock s (fun () ->
     let target_key = target_key target_kind target_id in
     let report_count =
-      Hashtbl.find_opt s.report_count_by_target target_key |> Option.value ~default:0
+      match Hashtbl.find_opt s.report_count_by_target target_key with
+      | None -> 0
+      | Some n -> n
     in
     let has_unresolved =
       match Hashtbl.find_opt s.unresolved_by_target target_key with

--- a/lib/board/board_moderation.mli
+++ b/lib/board/board_moderation.mli
@@ -12,8 +12,8 @@
     Design properties:
     - All queue and audit state is in-memory and serialised to JSONL under
       [<base_path>/.masc/board/moderation/].
-    - The store is single-writer (callers must serialise operations —
-      see {!Shared_audit.Store} for the same discipline).
+    - The store is protected by an [Eio.Mutex.t]; public operations are safe
+      to call from concurrent Eio fibers.
     - No silent failures: every mutating operation returns a
       [(unit, string) result].
     - IDs are cryptographic (no prediction).

--- a/test/test_board_moderation.ml
+++ b/test/test_board_moderation.ml
@@ -37,6 +37,8 @@ let with_env key value f =
 let with_flag_rate_limit value f =
   with_env "MASC_BOARD_MODERATION_FLAG_RATE_LIMIT_SEC" value f
 
+let run_eio f = Eio_main.run (fun _env -> f ())
+
 let test_with_env_restores_unset () =
   let key = "MASC_BOARD_MODERATION_TEST_UNSET" in
   unsetenv key;
@@ -468,58 +470,60 @@ let test_audit_entry_no_optional_fields_when_absent () =
 
 (* ── Runner ──────────────────────────────────────────────────────── *)
 
+let eio_test_case name speed f = test_case name speed (fun () -> run_eio f)
+
 let () =
   run "Board_moderation"
     [ ( "env",
-        [ test_case "with_env restores unset" `Quick
+        [ eio_test_case "with_env restores unset" `Quick
             test_with_env_restores_unset ] );
       ( "flag_reason",
-        [ test_case "spam roundtrip"       `Quick test_flag_reason_spam;
-          test_case "harassment roundtrip" `Quick test_flag_reason_harassment;
-          test_case "off_topic roundtrip"  `Quick test_flag_reason_off_topic;
-          test_case "policy roundtrip"     `Quick test_flag_reason_policy;
-          test_case "unknown -> None"      `Quick test_flag_reason_unknown ] );
+        [ eio_test_case "spam roundtrip"       `Quick test_flag_reason_spam;
+          eio_test_case "harassment roundtrip" `Quick test_flag_reason_harassment;
+          eio_test_case "off_topic roundtrip"  `Quick test_flag_reason_off_topic;
+          eio_test_case "policy roundtrip"     `Quick test_flag_reason_policy;
+          eio_test_case "unknown -> None"      `Quick test_flag_reason_unknown ] );
       ( "action_kind",
-        [ test_case "all roundtrips" `Quick test_action_kind_roundtrips ] );
+        [ eio_test_case "all roundtrips" `Quick test_action_kind_roundtrips ] );
       ( "target_kind",
-        [ test_case "all roundtrips" `Quick test_target_kind_roundtrips ] );
+        [ eio_test_case "all roundtrips" `Quick test_target_kind_roundtrips ] );
       ( "flag",
-        [ test_case "happy path"             `Quick test_flag_happy_path;
-          test_case "duplicate rejected"     `Quick test_flag_duplicate_rejected;
-          test_case "different targets ok"   `Quick test_flag_different_targets;
-          test_case "same reporter rate limited" `Quick
+        [ eio_test_case "happy path"             `Quick test_flag_happy_path;
+          eio_test_case "duplicate rejected"     `Quick test_flag_duplicate_rejected;
+          eio_test_case "different targets ok"   `Quick test_flag_different_targets;
+          eio_test_case "same reporter rate limited" `Quick
             test_flag_rate_limited_same_reporter;
-          test_case "different reporters bypass rate limit" `Quick
+          eio_test_case "different reporters bypass rate limit" `Quick
             test_flag_rate_limit_allows_different_reporters;
-          test_case "non-finite rate limit falls back" `Quick
+          eio_test_case "non-finite rate limit falls back" `Quick
             test_flag_rate_limit_non_finite_falls_back;
-          test_case "resolved entries still rate-limit reporter" `Quick
+          eio_test_case "resolved entries still rate-limit reporter" `Quick
             test_flag_rate_limit_survives_resolved_entries ] );
       ( "get_queue",
-        [ test_case "unresolved filter"      `Quick test_get_queue_unresolved;
-          test_case "all entries"            `Quick test_get_queue_all;
-          test_case "resolved filter"        `Quick test_get_queue_resolved_filter ] );
+        [ eio_test_case "unresolved filter"      `Quick test_get_queue_unresolved;
+          eio_test_case "all entries"            `Quick test_get_queue_all;
+          eio_test_case "resolved filter"        `Quick test_get_queue_resolved_filter ] );
       ( "resolve_entry",
-        [ test_case "not found -> error"     `Quick test_resolve_entry_not_found ] );
+        [ eio_test_case "not found -> error"     `Quick test_resolve_entry_not_found ] );
       ( "record_action",
-        [ test_case "happy path"             `Quick test_record_action_happy_path;
-          test_case "note capped at 500"     `Quick test_record_action_note_capped;
-          test_case "auto-resolves queue"    `Quick
+        [ eio_test_case "happy path"             `Quick test_record_action_happy_path;
+          eio_test_case "note capped at 500"     `Quick test_record_action_note_capped;
+          eio_test_case "auto-resolves queue"    `Quick
             test_record_action_auto_resolves_queue;
-          test_case "allows target to be reflagged" `Quick
+          eio_test_case "allows target to be reflagged" `Quick
             test_record_action_allows_target_to_be_reflagged ] );
       ( "get_audit_trail",
-        [ test_case "actor filter"           `Quick test_audit_trail_actor_filter;
-          test_case "target filter"          `Quick test_audit_trail_target_filter;
-          test_case "limit cap"              `Quick test_audit_trail_limit ] );
+        [ eio_test_case "actor filter"           `Quick test_audit_trail_actor_filter;
+          eio_test_case "target filter"          `Quick test_audit_trail_target_filter;
+          eio_test_case "limit cap"              `Quick test_audit_trail_limit ] );
       ( "target_summary",
-        [ test_case "none"                   `Quick test_target_summary_none;
-          test_case "flagged"                `Quick test_target_summary_flagged;
-          test_case "action status"          `Quick test_target_summary_action_status;
-          test_case "reflag wins over audit" `Quick
+        [ eio_test_case "none"                   `Quick test_target_summary_none;
+          eio_test_case "flagged"                `Quick test_target_summary_flagged;
+          eio_test_case "action status"          `Quick test_target_summary_action_status;
+          eio_test_case "reflag wins over audit" `Quick
             test_target_summary_reflagged_wins_over_audit ] );
       ( "json_projection",
-        [ test_case "queue_entry shape"      `Quick test_queue_entry_to_json;
-          test_case "audit_entry shape"      `Quick test_audit_entry_to_json;
-          test_case "audit optional absent"  `Quick
+        [ eio_test_case "queue_entry shape"      `Quick test_queue_entry_to_json;
+          eio_test_case "audit_entry shape"      `Quick test_audit_entry_to_json;
+          eio_test_case "audit optional absent"  `Quick
             test_audit_entry_no_optional_fields_when_absent ] ) ]


### PR DESCRIPTION
# ci:skip-test-coverage\n\nThe moderation store was a lazy-initialized module-global ref containing mutable Hashtbls and a list ref, with no synchronization. Public operations are called from concurrent HTTP fibers, so add an [Eio.Mutex.t] to the store and serialize every public operation. Lazy initialization and test reset are also guarded by a separate global mutex.\n\nTests are synchronous, so wrap each test case in [Eio_main.run] so the mutex operations have a valid Eio context.\n\nRefs: audit finding MASC-mutable-ref-board-moderation