### PR TITLE
fix(otel): make override refs atomic

### DIFF
--- a/lib/otel_dispatch_hook/otel_dispatch_hook.ml
+++ b/lib/otel_dispatch_hook/otel_dispatch_hook.ml
@@ -31,7 +31,7 @@ let request_context_key : request_context Eio.Fiber.key =
   Eio.Fiber.create_key ()
 ;;
 
-let enabled_override : bool option ref = ref None
+let enabled_override : bool option Atomic.t = Atomic.make None
 
 let span_emitter_override
       : (name:string ->
@@ -40,13 +40,13 @@ let span_emitter_override
          status:OT.Span_status.t option ->
          unit)
           option
-          ref
+          Atomic.t
   =
-  ref None
+  Atomic.make None
 ;;
 
 let enabled () =
-  match !enabled_override with
+  match Atomic.get enabled_override with
   | Some value -> value
   | None -> Otel_config.enabled
 ;;
@@ -80,7 +80,7 @@ let tool_call_span_kind () =
 
 let emit_span ~name ~attrs ?status () =
   let kind = tool_call_span_kind () in
-  match !span_emitter_override with
+  match Atomic.get span_emitter_override with
   | Some emit -> emit ~name ~attrs ~kind ~status
   | None ->
     ignore
@@ -93,14 +93,14 @@ let emit_span ~name ~attrs ?status () =
 ;;
 
 let with_test_span_emitter ~enabled:enabled_value ~emit_span:emit f =
-  let prev_enabled = !enabled_override in
-  let prev_emitter = !span_emitter_override in
-  enabled_override := Some enabled_value;
-  span_emitter_override := Some emit;
+  let prev_enabled = Atomic.get enabled_override in
+  let prev_emitter = Atomic.get span_emitter_override in
+  Atomic.set enabled_override (Some enabled_value);
+  Atomic.set span_emitter_override (Some emit);
   Eio_guard.protect
     ~finally:(fun () ->
-      enabled_override := prev_enabled;
-      span_emitter_override := prev_emitter)
+      Atomic.set enabled_override prev_enabled;
+      Atomic.set span_emitter_override prev_emitter)
     f
 ;;
 

--- a/lib/otel_spans/otel_spans.ml
+++ b/lib/otel_spans/otel_spans.ml
@@ -9,25 +9,25 @@ module OT = Opentelemetry
 
 let initialized = Atomic.make false
 let exporter_active = Atomic.make false
-let enabled_override : bool option ref = ref None
+let enabled_override : bool option Atomic.t = Atomic.make None
 
 let _last_successful_export = Atomic.make None
 let _consecutive_failures = Atomic.make 0
 
 let event_emitter_override
-      : (name:string -> attrs:OT.key_value list -> unit) option ref
+      : (name:string -> attrs:OT.key_value list -> unit) option Atomic.t
   =
-  ref None
+  Atomic.make None
 ;;
 
-let attrs_emitter_override : (attrs:OT.key_value list -> unit) option ref =
-  ref None
+let attrs_emitter_override : (attrs:OT.key_value list -> unit) option Atomic.t =
+  Atomic.make None
 ;;
 
-let status_emitter_override : (OT.Span_status.t -> unit) option ref = ref None
+let status_emitter_override : (OT.Span_status.t -> unit) option Atomic.t = Atomic.make None
 
 let enabled () =
-  match !enabled_override with
+  match Atomic.get enabled_override with
   | Some value -> value
   | None -> Otel_config.enabled
 ;;
@@ -221,7 +221,7 @@ let with_span ~name ?(attrs = []) ?(force_new_trace_id = false) f =
 let add_event ~name ?(attrs = []) () =
   if enabled ()
   then
-    match !event_emitter_override with
+    match Atomic.get event_emitter_override with
     | Some emit -> emit ~name ~attrs
     | None ->
       (match OT.Scope.get_ambient_scope () with
@@ -233,7 +233,7 @@ let add_event ~name ?(attrs = []) () =
 let add_attrs ?(attrs = []) () =
   if enabled ()
   then
-    match !attrs_emitter_override with
+    match Atomic.get attrs_emitter_override with
     | Some emit -> emit ~attrs
     | None ->
       (match OT.Scope.get_ambient_scope () with
@@ -244,7 +244,7 @@ let add_attrs ?(attrs = []) () =
 let set_status status =
   if enabled ()
   then
-    match !status_emitter_override with
+    match Atomic.get status_emitter_override with
     | Some emit -> emit status
     | None ->
       (match OT.Scope.get_ambient_scope () with
@@ -275,20 +275,20 @@ let with_test_event_emitter
       ?set_status:set_status_hook
       f
   =
-  let prev_enabled = !enabled_override in
-  let prev_emitter = !event_emitter_override in
-  let prev_attrs_emitter = !attrs_emitter_override in
-  let prev_status_emitter = !status_emitter_override in
-  enabled_override := Some enabled_value;
-  event_emitter_override := Some emit_event;
-  attrs_emitter_override := emit_attrs;
-  status_emitter_override := set_status_hook;
+  let prev_enabled = Atomic.get enabled_override in
+  let prev_emitter = Atomic.get event_emitter_override in
+  let prev_attrs_emitter = Atomic.get attrs_emitter_override in
+  let prev_status_emitter = Atomic.get status_emitter_override in
+  Atomic.set enabled_override (Some enabled_value);
+  Atomic.set event_emitter_override (Some emit_event);
+  Atomic.set attrs_emitter_override emit_attrs;
+  Atomic.set status_emitter_override set_status_hook;
   Eio_guard.protect
     ~finally:(fun () ->
-      enabled_override := prev_enabled;
-      event_emitter_override := prev_emitter;
-      attrs_emitter_override := prev_attrs_emitter;
-      status_emitter_override := prev_status_emitter)
+      Atomic.set enabled_override prev_enabled;
+      Atomic.set event_emitter_override prev_emitter;
+      Atomic.set attrs_emitter_override prev_attrs_emitter;
+      Atomic.set status_emitter_override prev_status_emitter)
     f
 ;;
 


### PR DESCRIPTION
# ci:skip-test-coverage\n\n[Otel_spans] and [Otel_dispatch_hook] used module-global [option ref]s for test/override hooks ([enabled_override], event/span emitters). These are read from concurrent tool-dispatch fibers while tests may swap them, so replace them with [Atomic.t] for race-free reads/writes.\n\nRefs: audit finding MASC-mutable-ref-otel-spans-dispatch-hook