### PR TITLE
[codex] fix dashboard chat stale token retry

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -30,6 +30,7 @@ import {
   submitQueuedKeeperMessage,
   wakeKeeper,
 } from './keeper'
+import { resetDevTokenBootstrap } from './dev-token'
 
 afterEach(() => {
   vi.clearAllMocks()
@@ -39,6 +40,12 @@ afterEach(() => {
   } catch {
     // Ignore storage cleanup failures in the test environment.
   }
+  try {
+    window.sessionStorage?.clear?.()
+  } catch {
+    // Ignore storage cleanup failures in the test environment.
+  }
+  resetDevTokenBootstrap()
 })
 
 describe('sendKeeperMessageDetailed', () => {
@@ -158,6 +165,57 @@ describe('streamKeeperMessage', () => {
     const actorHeader = headers['X-MASC-Agent'] ?? headers['x-masc-agent']
     expect(actorHeader).toBe('dashboard-eager-manta')
     expect(actorHeader).not.toContain('%')
+    expect(events).toEqual(['RUN_FINISHED'])
+  })
+
+  it('refreshes a stale loopback dev token once and retries direct chat', async () => {
+    window.sessionStorage.setItem('masc_bearer_token', 'stale-token')
+    window.sessionStorage.setItem(
+      'masc_bearer_token_meta',
+      JSON.stringify({ source: 'dev', actor: 'dashboard', scope: 'worker' }),
+    )
+
+    let chatAttempts = 0
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
+      if (url === '/api/v1/keepers/chat/stream') {
+        chatAttempts += 1
+        if (chatAttempts === 1) {
+          return Promise.resolve(new Response(
+            JSON.stringify({ error: '[AuthError] Invalid token: Token mismatch' }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } },
+          ))
+        }
+        return Promise.resolve(new Response('data: {"type":"RUN_FINISHED"}\n\n', {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        }))
+      }
+      if (url === '/api/v1/dashboard/dev-token') {
+        return Promise.resolve(new Response(
+          JSON.stringify({ token: 'fresh-token', actor: 'dashboard', scope: 'worker' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ))
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const events: string[] = []
+    await streamKeeperMessage('sangsu', 'ping', {
+      onEvent: event => {
+        events.push(event.type)
+      },
+    })
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/api/v1/keepers/chat/stream',
+      '/api/v1/dashboard/dev-token',
+      '/api/v1/keepers/chat/stream',
+    ])
+    const firstHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>
+    const retryHeaders = fetchMock.mock.calls[2]?.[1]?.headers as Record<string, string>
+    expect(firstHeaders.Authorization).toBe('Bearer stale-token')
+    expect(retryHeaders.Authorization).toBe('Bearer fresh-token')
     expect(events).toEqual(['RUN_FINISHED'])
   })
 })

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -9,6 +9,10 @@ import type { KeeperConversationDetails } from '../types'
 import {
   currentDashboardActor,
   apiRequestErrorFromResponse,
+  clearStoredToken,
+  getStoredToken,
+  getStoredTokenMeta,
+  isRemoteAccess,
   jsonHeaders,
   runOperatorAction,
   fetchWithTimeout,
@@ -16,6 +20,7 @@ import {
   DEFAULT_POST_TIMEOUT_MS,
   KEEPER_LIFECYCLE_TIMEOUT_MS,
 } from './core'
+import { ensureDevToken, resetDevTokenBootstrap } from './dev-token'
 import {
   parseKeeperCompositeSnapshot,
   parseFleetCompositeSnapshot,
@@ -373,6 +378,39 @@ export interface KeeperStreamOutcome {
   terminal: boolean
 }
 
+function keeperStreamErrorMessage(raw: string, status: number): string {
+  let message = raw || `스트리밍 요청 실패 (${status})`
+  try {
+    const parsed = JSON.parse(raw) as { error?: string | { message?: string }; message?: string }
+    if (typeof parsed.error === 'string') {
+      message = parsed.error
+    } else {
+      message = parsed.error?.message ?? parsed.message ?? message
+    }
+  } catch {
+    // Keep raw text fallback.
+  }
+  return message
+}
+
+function isTokenMismatchAuthError(raw: string): boolean {
+  const normalized = raw.toLowerCase()
+  return normalized.includes('autherror')
+    && normalized.includes('invalid token')
+    && normalized.includes('token mismatch')
+}
+
+async function refreshLoopbackDevTokenAfterMismatch(): Promise<boolean> {
+  if (isRemoteAccess() || !getStoredToken()) return false
+  const meta = getStoredTokenMeta()
+  if (meta?.source === 'manual') return false
+
+  clearStoredToken()
+  resetDevTokenBootstrap()
+  await ensureDevToken()
+  return getStoredToken() !== null
+}
+
 export async function streamKeeperMessage(
   name: string,
   message: string,
@@ -401,26 +439,36 @@ export async function streamKeeperMessage(
       data: att.data,
     }))
   }
-  const res = await fetch('/api/v1/keepers/chat/stream', {
+  const requestBody = JSON.stringify(body)
+  const postStream = () => fetch('/api/v1/keepers/chat/stream', {
     method: 'POST',
     headers: {
       ...jsonHeaders(),
       Accept: 'text/event-stream',
     },
-    body: JSON.stringify(body),
+    body: requestBody,
     signal,
   })
 
+  let res = await postStream()
+
   if (!res.ok) {
-    const raw = await res.text()
-    let message = raw || `스트리밍 요청 실패 (${res.status})`
-    try {
-      const parsed = JSON.parse(raw) as { error?: { message?: string }; message?: string }
-      message = parsed.error?.message ?? parsed.message ?? message
-    } catch {
-      // Keep raw text fallback.
+    let raw = await res.text()
+    if (
+      res.status === 401
+      && isTokenMismatchAuthError(raw)
+      && await refreshLoopbackDevTokenAfterMismatch()
+    ) {
+      res = await postStream()
+      if (res.ok) {
+        raw = ''
+      } else {
+        raw = await res.text()
+      }
     }
-    throw new Error(message)
+    if (!res.ok) {
+      throw new Error(keeperStreamErrorMessage(raw, res.status))
+    }
   }
 
   if (!res.body) {


### PR DESCRIPTION
## What changed

- Retry keeper direct-chat streaming once after a loopback dev-token mismatch.
- On a stale non-manual browser token, clear the stored token, reset dev-token bootstrap state, fetch a fresh `/api/v1/dashboard/dev-token`, then retry the stream request.
- Parse string-shaped auth errors from the stream endpoint so the dashboard surfaces the useful server error text.
- Add a regression test for stale `sessionStorage` bearer token recovery.

## Root cause

Dashboard direct chat always attached the bearer token stored in `sessionStorage`. When the MASC server restarted or reminted `.masc/auth/dashboard.token`, an already-open browser tab could keep sending the stale token. The server then rejected `/api/v1/keepers/chat/stream` with `401` and `[AuthError] Invalid token: Token mismatch`.

Read-only dashboard paths can fall back to the request actor hint, but the chat mutation path fails once a stale `Authorization` header is present.

## Validation

- Reproduced live stale-token behavior with a POST to `/api/v1/keepers/chat/stream` using an intentionally stale bearer token; server returned `401` and `{"error":"[AuthError] Invalid token: Token mismatch"}`.
- `pnpm -C dashboard exec vitest run --config vitest.config.ts src/api/keeper.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm -C dashboard exec tsc --noEmit --pretty false`
- `git diff --check HEAD~1..HEAD`
