### PR TITLE
fix(exec_policy): Cwd_not_directory hint surfaces real sibling dirs (keeper path_not_found self-correction)

### DIFF
--- a/lib/exec_policy/exec_policy.ml
+++ b/lib/exec_policy/exec_policy.ml
@@ -254,6 +254,56 @@ let path_is_existing_dir ?workdir path =
   | Sys_error _ -> false
 ;;
 
+(* Largest number of sibling directory names surfaced in a
+   [Cwd_not_directory] hint. Bounds the operator-facing message when the
+   nearest existing ancestor holds many entries. *)
+let max_cwd_hint_siblings = 12
+
+let existing_sibling_dirs_hint ?workdir path =
+  let resolved = resolve_path ?base_dir:workdir path in
+  let is_dir p = try Sys.is_directory p with Sys_error _ -> false in
+  let rec nearest_existing_ancestor p =
+    let parent = Filename.dirname p in
+    if String.equal parent p
+    then None (* reached the filesystem root without an existing directory *)
+    else if is_dir parent
+    then Some parent
+    else nearest_existing_ancestor parent
+  in
+  match nearest_existing_ancestor resolved with
+  | None -> None
+  | Some ancestor ->
+    (match Sys.readdir ancestor with
+     | exception Sys_error _ -> None
+     | entries ->
+       let dirs =
+         entries
+         |> Array.to_list
+         |> List.filter (fun e -> is_dir (Filename.concat ancestor e))
+         |> List.sort String.compare
+       in
+       (match dirs with
+        | [] -> None
+        | _ ->
+          let total = List.length dirs in
+          let shown, omitted =
+            if total > max_cwd_hint_siblings
+            then
+              ( List.filteri (fun i _ -> i < max_cwd_hint_siblings) dirs
+              , total - max_cwd_hint_siblings )
+            else dirs, 0
+          in
+          let suffix =
+            if omitted > 0 then Printf.sprintf ", +%d more" omitted else ""
+          in
+          Some
+            (Printf.sprintf
+               "(existing directories under %s/: %s%s)"
+               (Filename.basename ancestor)
+               (String.concat ", " shown)
+               suffix)))
+;;
+
 (** Classification of path-like token prefixes.
     Replaces ad-hoc [String.starts_with] prefix matching with a typed
     variant so the compiler enforces exhaustive handling. *)
@@ -573,7 +623,11 @@ let validate_shell_ir_paths ?keeper_id ?base_path ?workdir shell_ir =
         then
           Error
             (Keeper_path_check_error.(
-               to_message (Cwd_not_directory { path = value; hint = None })))
+               to_message
+                 (Cwd_not_directory
+                    { path = value
+                    ; hint = existing_sibling_dirs_hint ?workdir value
+                    })))
         else Ok ()
       in
       let rec validate_path_values ~command_name expect_existing_dir = function

--- a/lib/exec_policy/exec_policy.mli
+++ b/lib/exec_policy/exec_policy.mli
@@ -53,6 +53,15 @@ val path_argument_values : string -> string list -> string list
 
 val existing_dir_path_values_of_shell_ir : Masc_exec.Shell_ir.t -> string list
 
+val existing_sibling_dirs_hint : ?workdir:string -> string -> string option
+(** For a required directory [path] that is missing on disk, enumerate the
+    real child-directory names under its nearest existing ancestor (read via
+    [Sys.readdir]) and render them as a [Cwd_not_directory] hint. Grounds
+    caller self-correction in filesystem truth (e.g. a stale
+    ["repos/masc-mcp"] yields the real ["repos/"] entries) without a rename
+    table or any substring/similarity matching. [None] when no existing
+    ancestor directory has child directories to surface. *)
+
 val validate_shell_ir_paths :
   ?keeper_id:string ->
   ?base_path:string ->

--- a/test/dune
+++ b/test/dune
@@ -1269,6 +1269,8 @@
 
 (include stanzas/test_anti_rationalization_empty_liveness.inc)
 
+(include stanzas/test_exec_policy_cwd_hint.inc)
+
 (include stanzas/test_anti_rationalization_gate2_advisory_10113.inc)
 
 (include stanzas/test_anti_rationalization_korean_10385.inc)

--- a/test/stanzas/test_exec_policy_cwd_hint.inc
+++ b/test/stanzas/test_exec_policy_cwd_hint.inc
@@ -1,0 +1,8 @@
+; Pins the filesystem-grounded Cwd_not_directory hint: a stale
+; "repos/masc-mcp" path surfaces the real "repos/" entries read via
+; Sys.readdir, with no rename table or substring matching.
+
+(test
+ (name test_exec_policy_cwd_hint)
+ (modules test_exec_policy_cwd_hint)
+ (libraries masc_test_deps))

--- a/test/test_exec_policy_cwd_hint.ml
+++ b/test/test_exec_policy_cwd_hint.ml
@@ -1,0 +1,73 @@
+(** test_exec_policy_cwd_hint — pins the filesystem-grounded hint that
+    [Exec_policy.existing_sibling_dirs_hint] fills into a
+    [Cwd_not_directory] error.
+
+    The hint must come from real directory entries read via [Sys.readdir],
+    never from a hardcoded rename table or a substring/similarity match.
+    A stale "repos/masc-mcp" path must surface the real "repos/" entries so
+    the caller self-corrects from ground truth. *)
+
+let rec mkdir_p path =
+  if not (Sys.file_exists path)
+  then (
+    mkdir_p (Filename.dirname path);
+    try Sys.mkdir path 0o755 with Sys_error _ -> ())
+;;
+
+let rec rm_rf path =
+  match Sys.is_directory path with
+  | true ->
+    Array.iter (fun e -> rm_rf (Filename.concat path e)) (Sys.readdir path);
+    (try Sys.rmdir path with Sys_error _ -> ())
+  | false -> (try Sys.remove path with Sys_error _ -> ())
+  | exception Sys_error _ -> ()
+;;
+
+let with_temp_tree f =
+  let root = Filename.temp_dir "masc_cwd_hint" "" in
+  Fun.protect ~finally:(fun () -> rm_rf root) (fun () -> f root)
+;;
+
+let test_lists_existing_sibling_dirs () =
+  with_temp_tree (fun root ->
+    mkdir_p (Filename.concat root "repos/masc");
+    mkdir_p (Filename.concat root "repos/oas");
+    let hint = Exec_policy.existing_sibling_dirs_hint ~workdir:root "repos/masc-mcp" in
+    Alcotest.(check (option string))
+      "stale repos/masc-mcp surfaces the real repos/ entries (sorted, no rename table)"
+      (Some "(existing directories under repos/: masc, oas)")
+      hint)
+;;
+
+let test_none_when_ancestor_has_no_subdirs () =
+  with_temp_tree (fun root ->
+    let hint = Exec_policy.existing_sibling_dirs_hint ~workdir:root "nope/missing" in
+    Alcotest.(check (option string))
+      "no child directories under nearest existing ancestor -> None"
+      None
+      hint)
+;;
+
+let test_ignores_plain_files () =
+  with_temp_tree (fun root ->
+    mkdir_p (Filename.concat root "repos/masc");
+    (* a plain file sibling must NOT appear in the directory listing *)
+    let oc = open_out (Filename.concat root "repos/README.md") in
+    close_out oc;
+    let hint = Exec_policy.existing_sibling_dirs_hint ~workdir:root "repos/gone" in
+    Alcotest.(check (option string))
+      "plain files are excluded; only real directories are listed"
+      (Some "(existing directories under repos/: masc)")
+      hint)
+;;
+
+let () =
+  Alcotest.run
+    "exec_policy_cwd_hint"
+    [ ( "existing_sibling_dirs_hint"
+      , [ Alcotest.test_case "lists existing sibling dirs" `Quick test_lists_existing_sibling_dirs
+        ; Alcotest.test_case "none when no subdirs" `Quick test_none_when_ancestor_has_no_subdirs
+        ; Alcotest.test_case "ignores plain files" `Quick test_ignores_plain_files
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목적

keeper Execute 실패 census(2026-06-08~14, 22,902 calls)에서 최대 단일 command-time 실패는 `path_or_cwd_error` 997건(24.0%, `path_not_found` 단독 532)이다. 대표 사례는 `masc-mcp → masc` repo rename 이후에도 keeper가 `repos/masc-mcp/...` 경로를 계속 emit하는 것. typed `{executable,argv,cwd}` schema는 이 실패를 막지 못한다 — 경로가 문법이 아니라 의미상 틀렸기 때문이다.

이 PR은 `Cwd_not_directory` 에러의 빈 `hint`(현재 `None`)를 **파일시스템 진실**로 채운다: 누락된 디렉터리의 가장 가까운 존재하는 조상 디렉터리를 `Sys.readdir`로 열거해 실제 하위 디렉터리 이름을 surface한다. stale `repos/masc-mcp`는 이제 `(existing directories under repos/: masc, oas)`를 동반해, keeper가 ground truth로부터 스스로 경로를 교정한다.

## 변경

- `lib/exec_policy/exec_policy.ml`: `existing_sibling_dirs_hint ?workdir path` 추가. `resolve_path`로 경로 해석 → 최장 존재 조상까지 walk-up → `Sys.readdir`로 실제 하위 디렉터리만 열거(정렬, `max_cwd_hint_siblings=12` 상한). `validate_shell_ir_paths`의 `Cwd_not_directory` 생성부를 `hint = None`에서 이 함수 호출로 교체.
- `lib/exec_policy/exec_policy.mli`: `existing_sibling_dirs_hint` 노출 + doc.
- `test/test_exec_policy_cwd_hint.ml` (+stanza, dune include): temp dir로 열거 동작 pin (3 케이스).

## 검증 (로컬, worktree)

- `dune build --root . lib/exec_policy` PASS
- 신규 `test_exec_policy_cwd_hint`: 3/3 PASS (stale→masc,oas 열거 / subdir 없으면 None / 평범한 파일 제외)
- 회귀: `test_keeper_path_check_error` 6/6, `test_keeper_tool_search_files_containment` 15/15, `test_circuit_breaker` 31/31 PASS

## 설계 제약 (root-fix, NOT workaround)

- **하드코딩 없음**: `masc-mcp→masc` 같은 정적 rename 테이블을 두지 않는다. 디스크의 실제 디렉터리만 읽는다.
- **string/substring 매칭 없음**: 유사도("did you mean") 추측이나 prefix 분류기가 아니다. `Sys.readdir` 열거뿐. (rename 자동교정은 하드코딩/유사도 없이는 불가능하므로 의도적으로 하지 않고, ground truth를 surface해 LLM이 교정하게 한다 — OAS tool-validation alternatives와 동일한 승인된 self-correction 패턴.)
- **typed 계약 유지**: `Keeper_path_check_error.Cwd_not_directory`의 closed-sum/`parse_prefix`/`message_prefix` 계약 불변. hint는 기존 `append_hint` 확장 지점(메시지 끝)에만 추가되어 prefix 분류기를 깨지 않는다.
- **telemetry-as-fix 아님**: counter 추가가 아니라, 실패 경로에서 agent가 다음 턴에 스스로 교정하도록 actionable ground truth를 제공한다.

## 범위 밖 (후속, evidence 필요)

keeper가 *왜* stale `repos/masc-mcp`를 emit하는지(briefing/memory의 옛 repo명)는 upstream root이며 별도 evidence가 필요하다. 이 PR은 Execute-side 자가교정 enabler에 한정한다.

RFC-WAIVED: `lib/exec_policy/` 경로 검증 진단 메시지(`hint`) 보강만 수행. credential/identity/operator-control/sandbox-containment 로직 미변경 — 검증/거부 동작은 동일하고 실패 경로의 진단 문자열만 풍부해진다.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
