### PR TITLE
fix(voice_bridge): add NDT-OK rationale for cached availability default

### DIFF
--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -524,7 +524,10 @@ let is_voice_server_available ~sw:_ ~clock ~net =
     let now = Time_compat.now () in
     let cache = Atomic.get health_cache in
     if now -. cache.check_time < cache_duration cache
-    then Option.value cache.available ~default:false
+    then
+      (* NDT-OK: [available] is None only before the first probe; defaulting to
+         false means "treat as unavailable" until a probe completes. *)
+      Option.value cache.available ~default:false
     else (
       let check () =
         let uri =


### PR DESCRIPTION
# ci:skip-test-coverage\n\nThe deterministic-boundary ratchet flagged the [Option.value ~default:false] on the cached voice-server availability as a new deterministic branch on a non-deterministic source. Add an [NDT-OK] comment explaining that [None] only occurs before the first probe and the default means 'treat as unavailable'.\n\nFollow-up to #21130.