### PR TITLE
fix(dashboard): keep workspace config follow-ups coherent

### DIFF
--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -126,8 +126,23 @@ let handle_read_resource_eio state id params =
           | "who.json" ->
               let statuses = Session.get_agent_statuses registry in
               ("application/json", Some (Yojson.Safe.pretty_to_string (`List statuses)))
-          (* `agents` / `agents.json` resource removed (2026-06-09): backed by
-             the dead .masc/agents/ registry. Live agent status = `who`. *)
+          | "agents" ->
+              let statuses = Session.get_agent_statuses registry in
+              let body =
+                if statuses = [] then "No active agents."
+                else Session.status_string registry
+              in
+              ("text/markdown", Some body)
+          | "agents.json" ->
+              let statuses = Session.get_agent_statuses registry in
+              let json =
+                `Assoc
+                  [
+                    ("replacement", `String "masc://who.json");
+                    ("agents", `List statuses);
+                  ]
+              in
+              ("application/json", Some (Yojson.Safe.pretty_to_string json))
           | "messages" | "messages/recent" ->
               let since_seq = Mcp_server.int_query_param uri "since_seq" ~default:0 in
               let limit = Mcp_server.int_query_param uri "limit" ~default:10 in

--- a/lib/server/server_routes_http_runtime_health_helpers.ml
+++ b/lib/server/server_routes_http_runtime_health_helpers.ml
@@ -28,11 +28,12 @@ let server_start_time = Unix.gettimeofday ()
 let health_path_diagnostics () =
   match current_server_state_opt () with
   | Some state ->
+      let config = Mcp_server.workspace_config state in
       Server_base_path_diagnostics.detect
         ?input_base_path:((Host_config.from_env ()).base_path_raw)
         ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
-        ~effective_base_path:(Mcp_server.workspace_config state).base_path
-        ~effective_masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state))
+        ~effective_base_path:config.base_path
+        ~effective_masc_root:(Workspace.masc_root_dir config)
         ()
   | None ->
       let effective_base_path = default_base_path () in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -174,12 +174,13 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   let config_resolution =
     startup_config_resolution ~base_path |> Config_dir_resolver.to_json
   in
+  let config = Mcp_server.workspace_config state in
   let path_diagnostics =
     Server_base_path_diagnostics.detect
       ?input_base_path
       ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
-      ~effective_base_path:(Mcp_server.workspace_config state).base_path
-      ~effective_masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state))
+      ~effective_base_path:config.base_path
+      ~effective_masc_root:(Workspace.masc_root_dir config)
       ()
     |> Server_base_path_diagnostics.to_yojson
   in
@@ -194,11 +195,12 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   state
 
 let runtime_path_diagnostics ?input_base_path (state : Mcp_server.server_state) =
+  let config = Mcp_server.workspace_config state in
   Server_base_path_diagnostics.detect
     ?input_base_path
     ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
-    ~effective_base_path:(Mcp_server.workspace_config state).base_path
-    ~effective_masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state))
+    ~effective_base_path:config.base_path
+    ~effective_masc_root:(Workspace.masc_root_dir config)
     ()
 
 let restore_persisted_sessions (state : Mcp_server.server_state) =
@@ -306,6 +308,7 @@ let sync_prompt_assets_from_binary () =
     sync.Prompt_defaults.failed
 
 let bootstrap_prompt_state (state : Mcp_server.server_state) =
+  let config = Mcp_server.workspace_config state in
   Config_dir_resolver.log_warnings ~context:"ServerBootstrap" ();
   Config_dir_resolver.log_resolution ~context:"ServerBootstrap" ();
   (* Converge runtime prompt markdown onto the binary-embedded assets
@@ -315,8 +318,8 @@ let bootstrap_prompt_state (state : Mcp_server.server_state) =
   (* Initialize prompt registry with defaults and restore saved overrides *)
   let prompt_markdown_dir =
     Prompt_defaults.bootstrap_runtime
-      ~workspace_path:(Mcp_server.workspace_config state).workspace_path
-      ~base_path:(Mcp_server.workspace_config state).base_path
+      ~workspace_path:config.workspace_path
+      ~base_path:config.base_path
   in
   let expected_prompt_dir = Config_dir_resolver.prompts_dir () in
   if prompt_markdown_dir <> expected_prompt_dir then

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -30,6 +30,46 @@ let cleanup_dir dir =
   in
   rm dir
 
+let rec mkdir_p dir =
+  if dir = "" || dir = "." || dir = "/" then ()
+  else if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755
+  end
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+
+let with_config_dir dir f =
+  let config_dir = Filename.concat (Filename.concat dir ".masc") "config" in
+  let keepers_dir = Filename.concat config_dir "keepers" in
+  mkdir_p keepers_dir;
+  let original = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "MASC_CONFIG_DIR" original;
+      Config_dir_resolver.reset ())
+    (fun () ->
+      Unix.putenv "MASC_CONFIG_DIR" config_dir;
+      Config_dir_resolver.reset ();
+      f ~config_dir ~keepers_dir)
+
+let write_keeper_toml ~keepers_dir ~name =
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+sandbox_profile = "local"
+goal = "Dashboard keeper fixture"
+|}
+
 let save_jsonl path entries =
   let body =
     entries
@@ -255,6 +295,8 @@ let test_dashboard_namespace_truth_keeper_only_workspace_not_reported_empty () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      with_config_dir dir @@ fun ~config_dir:_ ~keepers_dir ->
+      write_keeper_toml ~keepers_dir ~name:"sangsu";
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
@@ -297,6 +339,8 @@ let test_dashboard_namespace_truth_mixed_runtime_counts () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      with_config_dir dir @@ fun ~config_dir:_ ~keepers_dir ->
+      write_keeper_toml ~keepers_dir ~name:"sangsu";
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1406,7 +1406,7 @@ let test_post_get_success () =
     |> Yojson.Safe.Util.to_string
   in
   Alcotest.(check bool) "post_id not empty" true (String.length post_id > 0);
-  let ok2, body2 = dispatch "masc_board_get"
+  let ok2, body2 = dispatch "masc_board_post_get"
     (make_args [("post_id", `String post_id)]) in
   Alcotest.(check bool) "get ok" true ok2;
   Alcotest.(check bool) "get has content" true (String.length body2 > 0)
@@ -1415,7 +1415,7 @@ let test_post_get_not_found () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  let ok, body = dispatch "masc_board_get"
+  let ok, body = dispatch "masc_board_post_get"
     (make_args [("post_id", `String "nonexistent-id")]) in
   Alcotest.(check bool) "not found is idempotent success" true ok;
   Alcotest.(check bool) "body mentions gone" true


### PR DESCRIPTION
## Summary
- keep paired workspace_config reads on one snapshot for health/bootstrap diagnostics
- keep advertised masc://agents resources readable via the live who registry shape
- update board/detail and namespace-truth tests to current public tool/runtime contracts

## Verification
- scripts/check-oas-pin.sh --local-only
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build bin/main_eio.exe test/test_mcp_server_eio.exe test/test_dashboard_namespace_truth.exe test/test_tool_board_coverage.exe
- ./_build/default/test/test_mcp_server_eio.exe test eio 15 --show-errors
- ./_build/default/test/test_tool_board_coverage.exe test post_crud 28-29 --show-errors
- ./_build/default/test/test_dashboard_namespace_truth.exe test read_model 3-4 --show-errors