### PR TITLE
[RFC-0235] Voice output browser transport — P1 1-4a (server side)

### DIFF
--- a/docs/design/RFC-0235-voice-output-browser-transport-detailed.md
+++ b/docs/design/RFC-0235-voice-output-browser-transport-detailed.md
@@ -1,0 +1,279 @@
+---
+doc: "RFC-0235 detailed design"
+title: "RFC-0235 상세 설계 — voice output browser transport"
+status: Draft
+created: 2026-06-14
+rfc: "RFC-0235"
+parent: "docs/rfc/RFC-0235-voice-output-browser-transport-device-routing.md"
+base_ref: "origin/main a76d22deb"
+---
+
+# RFC-0235 상세 설계 — voice output browser transport
+
+본 문서는 [RFC-0235](../rfc/RFC-0235-voice-output-browser-transport-device-routing.md)의
+구현 명세다. RFC가 "무엇을 왜"를 합의한다면, 본 문서는 "어느 파일의 어느 함수를
+어떻게"를 다룬다. 모든 anchor는 `origin/main` (`a76d22deb`) 기준이다.
+
+---
+
+## §0 현재 코드 정밀 지도 (변경 전)
+
+| 관심 | 파일:라인 | 현재 동작 |
+|---|---|---|
+| TTS 진입 | `lib/voice/voice_bridge.ml:618` `agent_speak` | dedup → cleanup → endpoint fan-out → playback (성공 파일은 유지, 서빙불가만 삭제) |
+| dedup | `voice_bridge.ml:619` `is_dedup_hit` | 동일 메시지 최근 재생 스킵 |
+| stale 파일 정리 | `voice_bridge.ml:152-175` `cleanup_old_audio_files` | mtime > 1h (`Masc_time_constants.hour`) 파일 삭제, heartbeat에서도 호출 |
+| 합성 | `lib/voice_bridge_core/voice_bridge_transport.ml:138` `speak_via_http_tts_to_file` | ElevenLabs/OpenAI → 파일 |
+| 파일 경로 생성 | `voice_bridge_transport.ml:19-24` `make_audio_file` | `$MASC_BASE_PATH/audio/<ts>_<agent>.mp3` |
+| 서버 재생 | `lib/voice_bridge_core/voice_bridge_core.ml:256` `run_local_playback` | afplay/ffplay/mpg123/play/open exec |
+| per-agent 게이트 | `voice_bridge_core.ml:262` + `lib/voice_config/voice_config.mli:158` | `local_playback_enabled_for_agent` |
+| 삭제 (서빙불가 파일만) | `voice_bridge.ml:384,451` `Sys.remove audio_file` | 384=dedup mutex hit, 451=합성실패 — 둘 다 서빙 불가. **성공 파일은 Sys.remove 없이 유지됨**. 879는 agent_speak 무관한 tone/recording 함수 |
+| keeper 발화 → 브라우저 | `lib/keeper/keeper_chat_broadcast.ml:6-31` `chat_appended` | `{type;name;connector;ts_unix}` SSE, **모든 authenticated session** |
+| dashboard 수신 | `dashboard/src/sse-store.ts:547-561` | `noteKeeperChatAppended(name)` 호출 → chat panel refresh |
+| SSE subscriber registry | `lib/sse.mli:113-116`, `lib/types/types_core.ml:906-911` `sse_session` | `{agent_name;connected_at;last_activity;is_listening}` |
+| auth 게이트 | `lib/server/server_auth.ml:21-50` | `is_loopback_host`, `base_url_has_non_loopback_host` |
+| HTTP route 패턴 | `lib/server/server_dashboard_http_keeper_api.ml` | `/api/v1/keepers/:name/...` |
+
+---
+
+## §1 P1 상세 — 브라우저 오디오 도달 (sound reachable)
+
+### 1.1 unguessable token 파일명 — **구현 완료 (dune build EXIT=0)**
+
+**변경**: `make_audio_file` (`voice_bridge_transport.ml:19-24`). 시그니처 `agent_id:string -> string` → `unit -> string` (agent_id는 파일명에서 제거되어 더 이상 입력일 이유 없음).
+
+```ocaml
+let make_audio_file () =
+  Voice_bridge_core.ensure_audio_dir ();
+  (* token = 파일명이자 HTTP capability. agent_id는 의도적 배제: 한 keeper 운영자가
+     다른 keeper 클립을 <ts>_<agent> 추측으로 열거하지 못하게. 16 bytes = 128-bit. *)
+  let token = Random_id.hex ~bytes:16 in
+  Filename.concat (Filename.concat (Voice_bridge_core.masc_base_dir ()) "audio") (token ^ ".mp3")
+```
+
+- **의존 해결**: 기존 `lib/random_id` (`Random_id.hex ~bytes:n`, Mirage_crypto_rng 기반) 재사용. 새 난수 유틸 불필요.
+- **caller 1곳** (`voice_bridge.ml:368` `let audio_file = make_audio_file ()`) + alias(`:6`) + mli 시그니처 → 마이그레이션 완료. N-of-M 리스크 없음.
+- **token 추출**: 페이로드에 token이 필요한 곳은 `Filename.basename path |> Filename.chop_extension` (§1.4). record가 아닌 string 경로 유지 + derive — 더 작은 변경.
+- dune: `lib/voice_bridge_core/dune` libraries에 `masc.masc_random_id` 추가.
+
+### 1.2 파일 라이프사이클 — **변경 불필요 (정정)**
+
+초기 진단("합성→재생→즉시 삭제")이 틀렸음. 실제:
+
+| 라인 | 동작 | P1 처리 |
+|---|---|---|
+| 384 (dedup mutex hit) | `Sys.remove` — 서빙 불가 파일 | **유지** (dedup 스킵된 발화는 브라우저로도 가면 안 됨) |
+| 451 (합성 실패 error) | `Sys.remove` — 불완전 파일 | **유지** (서빙되면 안 됨) |
+| 성공 path (Played/Opened/Failed/Skipped, 392/413/432) | `Sys.remove` **없음** — 파일 유지 | 변경 없음 |
+| 879 | `agent_speak` 무관한 tone/recording 함수 | 무관 |
+
+- **cleanup_old_audio_files (1h TTL)** 가 성공 파일의 실제 reaper이며, 1h은 브라우저 fetch window로 충분. heartbeat + agent_speak 시작(`:641`)에서 호출 유지.
+- **결론**: P1은 라이프사이클 변경이 **필요 없다**. "이미 유지되는 파일에 HTTP 서빙만 추가"하면 끝. 근본 변경이 예상보다 작다.
+
+### 1.3 HTTP audio route — 새 모듈
+
+**새 파일**: `lib/server/server_voice_audio_route.ml` (+ `.mli`)
+
+```ocaml
+(** GET /api/v1/voice/audio/:token — serve synthesized clip by capability token.
+
+    Auth: 동일 dashboard API 게이트 (server_auth.ml is_loopback /
+    base_url_has_non_loopback_host). non-loopback 요청은 dashboard와 동일
+    credential 요구.
+
+    404: token 불일치 또는 reaped. 403: non-loopback 미인증. 200: audio/mpeg. *)
+val handler :
+  sw:Eio.Switch.t ->
+  token:string ->
+  headers:(string * string) list ->
+  unit -> [ `Ok of string * string  (* body, mime *)
+         | `NotFound
+         | `Forbidden ]
+```
+
+- `server_dashboard_http_keeper_api.ml`와 같은 등록 패턴(`/api/v1/...`)으로 라우트
+  테이블에 추가.
+- 파일은 `$MASC_BASE_PATH/audio/<token>.mp3`에서 직접 읽기. DB 매핑 불필요(token=
+  파일명).
+- MIME 고정 `audio/mpeg` (현재 합성 결과가 전부 mp3). 향후 포맷 확장 시 `mime`
+  메타데이터를 파일 옆에 저장 검토 — P1 non-goal.
+
+### 1.4 `keeper_chat_appended` 페이로드 확장
+
+**변경**: `lib/keeper/keeper_chat_broadcast.ml:6` `chat_appended` 시그니처 + payload.
+
+```ocaml
+(* 현재 *)
+val chat_appended : keeper_name:string -> source:string -> unit
+
+(* 변경 후 — audio는 선택. None이면 텍스트 전용 이벤트(기존과 동일). *)
+type audio_clip = {
+  token : string;             (* 1.1의 token. url은 dashboard base에서 조립 *)
+  mime : string;              (* "audio/mpeg" *)
+  duration_sec : float option;
+  message_text : string;      (* 자막/접근성 fallback *)
+}
+
+val chat_appended :
+  keeper_name:string ->
+  source:string ->
+  ?audio:audio_clip ->
+  unit -> unit
+```
+
+- payload에 `?audio` present 시 `("audio", `Assoc [...])` 필드 추가. absent면 기존
+  4-필드 이벤트와 bit-identical (후방호환).
+- **필드명 주의**: 기존 `connector`/`source` boundary 규칙(`chat_appended` 주석 참조)
+  준수. 새 `audio` 필드는 별개 boundary.
+- emit 지점(`server_routes_http_keeper_stream.ml:669,716` 등 caller 전수)에 `?audio`
+  전파. keeper가 `keeper_voice_speak`로 발화한 경우에만 `audio`를 채운다.
+
+### 1.5 dashboard — decode + audio element
+
+**변경**: `dashboard/src/sse-store.ts:547-561` + keeper chat panel.
+
+- SSE edge에서 `audio` 필드를 **한 번** typed record로 decode:
+  ```ts
+  type AudioClip = { token: string; mime: string; durationSec: number | null; messageText: string }
+  ```
+- chat panel이 오디오가 있는 메시지를 렌더할 때:
+  - 접근성 play 버튼 (`<button aria-label="재생">`) → 클릭 시 `new Audio(url).play()`.
+  - 자막 = `messageText`.
+  - **autoplay 금지**: 모바일 autoplay 정책 + 사용자 제스처 원칙. 자동 재생 코드 없음.
+- url 조립: `${dashboardBase}/api/v1/voice/audio/${token}`. `dashboardBase`는 이미
+  SSE/HTTP가 쓰는 base.
+
+---
+
+## §2 P2 상세 — 접속 디바이스 라우팅 ("connected device only")
+
+### 2.1 `resolve_destination`
+
+**새 모듈**: `lib/voice_destination.ml` (또는 `lib/sse_destination.ml`)
+
+```ocaml
+type playback_destination = Browsers | Local
+
+(** keeper_name에 연결된 SSE subscriber ≥1 이면 Browsers, 아니면 Local.
+    SSE registry (lib/sse.ml external_subscriber_count_with_prefix /
+    sse_session.agent_name)에서 결정. stateless — 매 호출마다 registry 읽기. *)
+val resolve_destination : keeper_name:string -> unit -> playback_destination
+```
+
+- 구현 전 확인: `external_subscriber_count_with_prefix`의 prefix가 keeper_name과
+  어떻게 매핑되는지 (`rg 'prefix\|agent_name' lib/sse.ml`). subscriber 등록 시
+  keeper_name이 prefix로 쓰이는지, 아니면 별도 인덱스인지.
+
+### 2.2 라우팅 분기 — `agent_speak`
+
+**변경**: `voice_bridge.ml` (합성 후, playback 전).
+
+```ocaml
+let dest = Voice_destination.resolve_destination ~keeper_name:agent_id in
+match dest with
+| Browsers ->
+  (* audio_clip 생성 후 keeper_chat_appended ?audio 전파.
+     run_local_playback 건너뜀 (정책 §1.5). *)
+| Local ->
+  (* 기존 run_local_playback 경로. audio_clip 없이 텍스트만 broadcast. *)
+```
+
+- `agent_speak`가 `keeper_name`을 알아야 함 — 현재는 `agent_id`만. agent_id ==
+  keeper_name인지 확인 (`safe_agent_id` / keeper 매핑). 다르면 caller에서 keeper_name
+  전파.
+
+### 2.3 브로드캐스트 스코핑 — 핵심 트레이드오프 (owner 결정 필요)
+
+현재 `chat_appended`는 **모든 authenticated session**에 브로드캐스트
+(`keeper_chat_broadcast.mli` 명시, "low-frequency chat turns"에 적합). 오디오
+이벤트의 "접속 디바이스만" 정책과 두 가지 충돌 해결:
+
+| 옵션 | 동작 | 장점 | 단점 |
+|---|---|---|---|
+| **(a) keeper-scoped broadcast** | 오디오 이벤트를 해당 keeper 접속 session에만 전송 | 정책 정확히 부합; 메타데이터(발화 시각) 노출 최소 | `chat_appended` 설계 변경; RFC-0223 P4도 같은 채널 사용 — 영향도 확인 |
+| **(b) 전송은 그대로, 브라우저 자체 필터** | 모든 session에 가되, 브라우저가 "내 keeper"일 때만 재생 | broadcast 변경 없음; 구현 단순 | 모든 운영자에게 token URL 노출(token 자체는 unguessable이라 접근 불가, but 메타데이터 노출) |
+
+**권장**: (a). "접속 디바이스만"이 token 노출이 아니라 *이벤트 자체* 스코핑을 의미한다면
+(a)가 정답. (a) 구현은 `Sse.broadcast`에 keeper_name scope 매개변수 추가 또는
+subscriber registry에서 keeper_name match 필터.
+
+**owner 결정 필요**: (a) vs (b). 이 결정이 P2 PR의 분기를 갈라놓는다.
+
+### 2.4 local suppress 정책
+
+`local_playback_enabled_for_agent` (`voice_config.mli:158`) 재해석:
+- 현재: "이 agent는 local 재생 허용"
+- 변경: "이 agent는 `Local` destination 허용" — destination이 `Browsers`면 이 플래그와
+  무관하게 local 미실행. destination이 `Local`이고 플래그 true일 때만 local 실행.
+- config escape hatch (RFC §4 P2 open question): owner가 "접속 디바이스 + local 동시"를
+  원하면 별도 config `voice.playback.always_local: bool` 추가. RFC 기본값은 false.
+
+---
+
+## §3 테스트 명세 (구체적 케이스)
+
+### Unit (OCaml, `dune runtest`)
+1. `make_audio_file` token 길이 ≥ 16 bytes (128-bit), 두 호출이 다른 token.
+2. `cleanup_old_audio_files`: 59분 파일 보존 / 61분 파일 삭제 (mtime mock).
+3. `resolve_destination`: subscriber 0 → `Local`, subscriber 1 → `Browsers`.
+4. `chat_appended ?audio:None` payload가 기존 4-필드와 동일 (후방호환).
+5. `chat_appended ?audio:(Some clip)` payload에 `audio`_assoc 포함, 4필드 round-trip.
+
+### 통합 (HTTP)
+6. `GET /api/v1/voice/audio/<valid_token>` → 200 `audio/mpeg`, body = 파일 내용.
+7. `GET /api/v1/voice/audio/<unknown>` → 404.
+8. non-loopback 미인증 → 403 (dashboard auth 게이트와 동일).
+9. reaped 파일 (cleanup 후) → 404.
+
+### 통합 (라우팅, P2)
+10. subscriber 등록 상태에서 `agent_speak` → `run_local_playback` 호출 안 됨 (mock으로
+    검증), `chat_appended ?audio` 전파됨.
+11. subscriber 없을 때 → `run_local_playback` 호출, `audio` None.
+
+### 수동 (모바일, HTTPS tunnel)
+12. 모바일 브라우저에서 keeper 발화 → play 버튼 클릭 시 재생.
+13. 접속 중 서버 스피커 무음 (정책 확인).
+14. 브라우저 탭 종료 후 다음 발화 → 서버 스피커 복원 (Local fallback).
+
+### Dashboard (vitest)
+15. `audio` 필드 있는 이벤트 decode → `AudioClip` record.
+16. `audio` 없는 이벤트 → 기존 텍스트 전용 렌더 (회귀 없음).
+17. play 버튼 클릭 → `Audio.play` 호출 (autoplay 아님).
+
+---
+
+## §4 구현 순서 + 파일 체크리스트
+
+### P1 (한 PR)
+1. `make_audio_file` record화 + caller 전수 마이그레이션 (`voice_bridge_transport.ml`,
+   callers via `rg`).
+2. `voice_bridge.ml:879` `Sys.remove` 제거 + 주석. (`:384` 제거, `:451` 유지)
+3. `lib/server/server_voice_audio_route.ml` 새 모듈 + 라우트 등록 + auth 게이트.
+4. `keeper_chat_broadcast.ml` `?audio` 확장 + caller에 `?audio` 전파
+   (`server_routes_http_keeper_stream.ml:669,716` 등).
+5. dashboard `sse-store.ts` decode + chat panel audio element + play 버튼.
+6. 테스트: §3 케이스 1-9, 15-17.
+
+### P2 (별도 PR, P1 머지 후)
+7. `lib/voice_destination.ml` `resolve_destination`.
+8. `agent_speak` 라우팅 분기 + `keeper_name` 전파.
+9. 브로드캐스트 스코핑 (owner가 (a) 선택 시 `Sse.broadcast` keeper scope).
+10. `local_playback_enabled_for_agent` 재해석 + config escape hatch.
+11. 테스트: §3 케이스 10-11, 12-14 수동.
+
+### 건드리지 않을 것 (보호)
+- OAS (`lib/oas*`) — voice는 MASC 개념, 경계 유지.
+- 기존 dedup (`is_dedup_hit`), duration probe (`audio_duration_seconds`) — 동작 변경 없음.
+- `cleanup_old_audio_files` TTL 값 (1h) — 그대로.
+- keeper_chat JSONL 스키마 — audio는 SSE 전용 페이로드, 디스크에 별도 저장 안 함.
+
+---
+
+## §5 열린 구현 질문 (owner 결정 필요)
+
+1. **브로드캐스트 스코핑 (§2.3)**: (a) keeper-scoped vs (b) 브라우저 필터. **권장 (a)**.
+2. **`Masc_random.token` 기존 유틸 존재 여부 (§1.1)**: 구현 전 `rg`로 확인. 없으면 추가.
+3. **agent_id vs keeper_name (§2.2)**: `agent_speak`가 keeper_name을 알아야. 매핑 확인.
+4. **config escape hatch (§2.4)**: "항상 local 추가 재생" config 필요 여부. RFC 기본 false.
+5. **P1/P2 단일 PR vs 분리 (RFC §4)**: 분리 권장. 병렬 재생 상태를 main에 올리지 않으려면
+   P1+P2 단일 PR도 가능 (PR 크기 증가).

--- a/docs/rfc/RFC-0235-voice-output-browser-transport-device-routing.md
+++ b/docs/rfc/RFC-0235-voice-output-browser-transport-device-routing.md
@@ -1,0 +1,278 @@
+---
+rfc: "0235"
+title: "Voice output transport: browser-addressed audio delivery with device-routed playback"
+status: Draft
+created: 2026-06-14
+updated: 2026-06-14
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0223"]
+implementation_prs: []
+---
+
+# RFC-0235: Voice output transport — browser-addressed audio delivery, device-routed playback
+
+Status: Draft · Promotes voice output from a server-local side effect to an
+addressable transport · Reuses existing channels (keeper_chat SSE, SSE
+subscriber registry) rather than introducing new stores.
+
+> Anchors cited as `file:line` were read against `origin/main` (`a76d22deb`)
+> on 2026-06-14 while writing this RFC.
+
+## §1 Problem — the keeper speaks, but only the server's speakers can hear it
+
+Voice output is a server-local side effect today, not an addressed transport.
+A keeper's utterance is synthesized to a file and played through whichever
+audio player exists on the server host; nothing about the audio reaches any
+browser. A mobile browser viewing the dashboard sees the *text* of the
+utterance but never the *sound*.
+
+### 1.1 Synthesis and playback are both server-side, end-to-end
+
+`Voice_bridge.agent_speak` (`lib/voice/voice_bridge.ml:618-675`) drives the
+whole pipeline inside the server process:
+
+1. dedup check (`is_dedup_hit`, line 619)
+2. `cleanup_old_audio_files ()` (line 641)
+3. TTS endpoint fan-out via `speak_via_http_tts_to_file`
+   (`voice_bridge_transport.ml:138`, `voice_bridge.ml:130/370`) — synthesis
+   result written to `$MASC_BASE_PATH/audio/<ts>_<agent>.mp3`
+   (`voice_bridge_transport.ml:19-24`)
+4. `run_local_playback` (`voice_bridge_core.ml:256`) — execs `afplay` /
+   `ffplay` / `mpg123` / `play` / `open` against the server host's sound
+   device (`voice_bridge_core.ml:148-162`)
+5. lifecycle: files for a *successful* utterance are already retained —
+   the Openai/Elevenlabs branch (`voice_bridge.ml:367-453`) has no
+   `Sys.remove` on its `Played`/`Opened`/`Failed`/`Skipped` exits.
+   `Sys.remove` fires only at `:384` (dedup mutex hit) and `:451`
+   (synthesis failure), both producing files that must not be served.
+   `:879` is an unrelated tone/recording helper, not `agent_speak`. The
+   real reaper for served files is `cleanup_old_audio_files` (1h TTL,
+   `voice_bridge.ml:152-175`). (Earlier draft of this RFC claimed
+   immediate deletion on every exit path; that was wrong — see §2.4.)
+
+Playback is gated per-agent by `Voice_config.local_playback_enabled_for_agent`
+(`voice_config.mli:158`, `voice_bridge_core.ml:262`). The gate's name is the
+design tell: "local" is the only destination the system models.
+
+### 1.2 No browser-side audio path exists
+
+A full scan of `dashboard/` for `new Audio(`, `AudioContext`, `MediaSource`,
+`<audio`, `createObjectURL`, or audio MIME types returns zero matches outside
+timestamp comments. The dashboard can render an utterance's text but has no
+code that could play a sound. There is nothing to "fix" client-side; the
+transport does not exist.
+
+### 1.3 A push channel and a session registry already exist — unused by voice
+
+Two capabilities this RFC needs are already in the codebase:
+
+- **Push channel.** `Keeper_chat_broadcast.chat_appended ~keeper_name ~source`
+  (`lib/keeper/keeper_chat_broadcast.ml:6-31`) emits a `keeper_chat_appended`
+  SSE event consumed by the dashboard (`dashboard/src/sse-store.ts:547-561`).
+  It is the existing path by which a keeper-originated line appears in the
+  dashboard chat panel. Its payload today is `{ name, source }` — text-chat
+  metadata only, no audio fields.
+- **Session registry.** `lib/sse.mli:113-116` exposes
+  `external_subscriber_count`, `external_subscriber_count_with_prefix`,
+  `reap_dead_external_subscribers`, `remove_external_subscribers`, and
+  `types/types_core.ml:906-911` defines
+  `type sse_session = { agent_name; connected_at; last_activity; is_listening }`.
+  The server already tracks which SSE subscribers are connected, with a
+  per-agent_name dimension.
+
+The gap is not "build a channel" or "build a registry". It is: connect voice
+output to the channel, and route it through the registry.
+
+### 1.4 "Local only" is the intended behavior of the voice subsystem, not a bug
+
+Voice was designed for a keeper that speaks into the room its server process
+occupies (the 2026-06-10 voice incident and its `run_local_playback` dedup /
+duration-probe machinery, `voice_bridge_core.ml:164-203`, exist precisely to
+make local playback behave well). Making audio reach a browser is a new
+requirement layered on top, not a defect in the existing design. This RFC
+treats local playback as a *fallback destination*, not a thing to delete.
+
+### 1.5 The owner's policy is "the connected device only"
+
+Operator decision (2026-06-14): when one or more browsers are connected, the
+utterance plays on those browsers and *not* on the server's speakers
+simultaneously. When no browser is connected, local playback remains the
+output. This rules out the cheap option ("play everywhere") and makes
+device-routed delivery a first-class requirement rather than an additive
+broadcast.
+
+## §2 Design principles
+
+1. **Addressed output, not side effect.** Voice output gains an explicit
+   destination set: `{ browsers; local }`. The default resolution is
+   `browsers` when ≥1 subscriber is connected for the keeper, else `local`.
+   The current `local`-only behavior is the `local`-destination case with no
+   subscribers present.
+2. **Reuse, do not add stores.** Audio metadata rides the existing
+   `keeper_chat_appended` event. Routing decisions read the existing SSE
+   subscriber registry. The synthesized file lives where it already lives
+   (`$MASC_BASE_PATH/audio/`). No new persistence, no new channel, no new
+   subscriber table. Adding any of those would repeat the keeper_chat ↔
+   checkpoint.messages split-brain pattern (cf. RFC-0223 §2.2).
+3. **Parse at the boundary, carry typed values inside.** The audio event
+   payload is decoded into a closed record once, at the SSE edge; the
+   dashboard matches on fields, not on string sniffing. No new string
+   classifier branches (CLAUDE.md workaround signature #2).
+4. **Lifecycle already fits the new destination.** Successful-utterance
+   files are *already* retained until the `cleanup_old_audio_files` 1h TTL
+   reaps them (`voice_bridge.ml:152-175`) — the Openai/Elevenlabs success
+   branch never calls `Sys.remove`. So P1 needs no lifecycle rewrite: the
+   1h window is already wide enough to serve as the browser fetch window.
+   The only `Sys.remove` sites (`:384` dedup, `:451` synthesis failure)
+   produce unservable files and stay as-is. (Correction of an earlier
+   draft that claimed immediate deletion on every exit path.)
+5. **OAS boundary respected.** Voice output is a MASC concept. OAS continues
+   to receive a host-assembled message list and is unaware of audio delivery
+   (mirrors RFC-0223 §2.5). All transport code lives under MASC
+   (`lib/voice*`, `lib/keeper*`, `lib/server*`, `dashboard/`).
+6. **No standing machinery without an owner decision.** No per-device
+   cursors, no "did this device ack" trackers in phase 1. Routing is
+   recomputed per utterance from the live registry — the same stateless
+   stance RFC-0223 §2.6 takes for presence. A device-ack model is named as a
+   non-goal (§5) pending evidence it is needed.
+
+## §3 Model
+
+```ocaml
+(** Where a synthesized utterance is delivered. *)
+type playback_destination = Browsers | Local
+
+(** Resolved per utterance from the live registry. [Browsers] iff at least
+    one SSE subscriber is connected for [keeper_name]; otherwise [Local].
+    The operator's "connected device only" policy (§1.5) is this function. *)
+val resolve_destination :
+  keeper_name:string -> unit -> playback_destination
+```
+
+```ocaml
+(** Audio descriptor attached to a [keeper_chat_appended] event when the
+    utterance was synthesized. Optional on the wire for backward
+    compatibility: old events have no audio fields and render as text-only. *)
+type audio_clip = {
+  url : string;              (* server-relative, e.g. "/api/v1/voice/audio/<name>" *)
+  mime : string;             (* "audio/mpeg" today *)
+  duration_sec : float option;
+  message_text : string;     (* the utterance, for accessible fallback / captions *)
+}
+```
+
+The HTTP audio endpoint serves a file from `$MASC_BASE_PATH/audio/` by a
+stable, unguessable name (the current `<ts>_<agent>.mp3` is not unguessable;
+P1 introduces a random token — see §4 P1). It is behind the same auth gate
+as the rest of the dashboard API (`lib/server/server_auth.ml`,
+`is_loopback_host` / `base_url_has_non_loopback_host` at lines 21-39), so a
+non-loopback browser hitting the endpoint presents the same credentials the
+dashboard already requires.
+
+## §4 Changes, by phase (each independently shippable)
+
+### P1 — Browser audio delivery (sound becomes reachable)
+
+| Change | Site |
+|---|---|
+| Synthesized files get an unguessable name (`<token>.mp3`, token = ≥128-bit random) instead of `<ts>_<agent>.mp3`; `make_audio_file` updated | `voice_bridge_transport.ml:19-24` |
+| **No lifecycle change needed.** Successful-utterance files are already retained (Openai/Elevenlabs branch has no `Sys.remove` on success exits); the existing `cleanup_old_audio_files` 1h TTL (`voice_bridge.ml:152-175`, called at `:641` and from heartbeat) is already the reaper and is already wide enough as a browser fetch window. `:384`/`:451` deletions (dedup / synthesis failure) stay — those files must not be served | `voice_bridge.ml` (no edit) |
+| New HTTP route `GET /api/v1/voice/audio/:token` streams the file with `audio/mpeg`, behind the dashboard auth gate; 404 + reaped-log on miss | `lib/server/` (new route module, registered alongside `server_dashboard_http_keeper_api.ml`) |
+| `keeper_chat_appended` payload gains optional `audio : { url, mime, duration_sec?, message_text }` when the utterance was synthesized; emitted in addition to the existing `local` playback when destination resolves to `Local` | `keeper_chat_broadcast.ml:6-31`, `server_routes_http_keeper_stream.ml:669/716` |
+| Dashboard decodes the `audio` field once at the SSE edge into a typed record; the keeper chat panel renders an accessible audio element driven by a user gesture (play button) — never autoplay | `dashboard/src/sse-store.ts:547-561`, keeper chat panel component |
+
+P1 notes:
+
+- **Why unguessable names.** The endpoint is auth-gated, but the filename is
+  also a capability: a logged-in operator on one keeper should not be able to
+  enumerate another keeper's clips by guessing `<ts>_<agent>`. A 128-bit
+  token closes enumeration without adding a per-clip ACL table.
+- **Why a TTL, not "delete after browser acks".** A device-ack protocol is
+  new standing machinery (§2.6 / §5). A TTL is the stateless reaper that
+  already runs; reinterpreting its window as "long enough for a browser on a
+  mobile network to fetch a few hundred KB of mp3" is the minimal honest
+  change. The window default is derived from clip duration, not a magic
+  number (cf. `playback_timeout_sec_for`, `voice_bridge_core.ml:200-203`).
+- **Why user-gesture playback, not autoplay.** Mobile Safari/Chrome block
+  unmuted autoplay without a user gesture even over HTTPS. The dashboard is
+  reachable over HTTPS via the Cloudflare tunnel, so the gesture is the only
+  remaining gate. A visible play button also serves as the accessible
+  fallback (caption = `message_text`).
+
+P1 shippable outcome: with at least one browser connected, a keeper
+utterance is fetchable and playable in the browser. Local playback still
+fires in parallel in P1 (parallel delivery is the temporary state; P2 makes
+routing exclusive). This is acknowledged as an intermediate, not the target
+shape — see the workaround self-check §7 for why it is acceptable as a
+phase boundary.
+
+### P2 — Device routing: "connected device only"
+
+| Change | Site |
+|---|---|
+| `resolve_destination ~keeper_name` reads the SSE subscriber registry for subscribers connected for `keeper_name`; returns `Browsers` iff ≥1, else `Local` | new helper, sits alongside `lib/sse.ml` or in a thin `voice_destination` module |
+| `agent_speak` resolves the destination before playback and suppresses `run_local_playback` when destination is `Browsers` | `voice_bridge.ml` (around the `run_local_playback` call site) |
+| The `audio` field on `keeper_chat_appended` is emitted only to subscribers connected for `keeper_name` (the registry already supports prefix-scoped broadcast; the event already carries `keeper_name`) | `keeper_chat_broadcast.ml`, `lib/sse.ml` |
+| `local_playback_enabled_for_agent` is reinterpreted as "is the `Local` destination ever allowed" rather than "always play locally"; when destination is `Browsers`, the agent-level flag is not consulted | `voice_config.mli:158`, `voice_bridge_core.ml:262` |
+
+P2 open question for owner review (not blocking the RFC, but blocks the P2
+PR): when destination is `Browsers`, should `Local` be fully suppressed, or
+should `Local` still fire as a "the server room hears it too" convenience?
+The operator's stated policy ("connected device only", §1.5) means fully
+suppressed. This RFC encodes "fully suppressed" as the default and flags the
+opposite as a config escape hatch only.
+
+P2 shippable outcome: a connected mobile browser is the sole listener while
+connected; the server speakers stay silent; disconnecting the browser
+restores local playback on the next utterance without restart.
+
+## §5 Non-goals / deferred
+
+| Deferred | Why | Re-entry condition |
+|---|---|---|
+| Per-device delivery ack / "did this device play it" tracking | new standing machinery; TTL reaper covers the failure mode (browser never fetches → file reaped → text-only render remains correct) | evidence that the text-only fallback is insufficient, or that delivery confirmation is needed for a keeper decision |
+| Streaming synthesis (chunked SSE audio) | ElevenLabs/OpenAI return whole files; chunking is a transport optimization for a latency budget that has not been measured | a measured latency budget showing whole-file fetch is too slow on the target network |
+| Multi-utterance queue / precedence beyond the existing `priority` arg | `agent_speak` already takes `?priority`; a client-side queue is browser UX work, not transport | a concrete ordering failure report |
+| STT (speech-to-text) browser input | out of scope; this RFC is output-only. `transcribe_audio` (`voice_bridge.ml`) is unchanged | separate RFC if bidirectional voice is wanted |
+| Voice for non-dashboard surfaces (Discord voice, Slack) | surfaces are RFC-0223's domain; audio-over-Discord is a different transport with its own auth model | separate RFC |
+| Digest / caption summarization | non-deterministic; needs its own evaluation harness (same rationale as RFC-0223 §5) | separate RFC with harness |
+
+## §6 Validation
+
+- Unit: `make_audio_file` token uniqueness/length; TTL reaper keeps files
+  within the window and reaps outside it; `resolve_destination` returns
+  `Browsers` for a keeper with a registered subscriber and `Local` without.
+- SSE payload: round-trip an `keeper_chat_appended` event with and without
+  the `audio` field; old-style event (no audio) decodes to a text-only
+  render, new-style decodes with all four fields.
+- Transport: HTTP audio endpoint returns 404 for an unknown token, 403 for
+  an unauthenticated non-loopback request, and 200 `audio/mpeg` for a valid
+  token while the file is within its TTL.
+- Routing (P2): with a subscriber registered, `run_local_playback` is not
+  called and the audio field is emitted; with no subscriber, `Local` fires
+  and no audio field is emitted.
+- Manual: on a mobile browser over the HTTPS tunnel, an utterance plays via
+  the play button; the server speakers are silent while connected; killing
+  the browser tab restores local playback on the next utterance.
+
+## §7 Workaround self-check (CLAUDE.md signatures)
+
+- **No telemetry-as-fix.** P1 adds a real transport (HTTP endpoint + SSE
+  field + client playback). P2 changes real routing. Nothing merely counts
+  a failure.
+- **No string classifier added.** The audio descriptor is a typed record
+  decoded once at the SSE boundary. The existing `source` label is reused
+  unchanged.
+- **No N-of-M.** P1 and P2 are vertical slices, each complete for its
+  concern; P2 does not "finish what P1 half-did".
+- **No cap/cooldown/dedup/repair smuggled in.** The pre-existing dedup
+  (`is_dedup_hit`) and duration-probe machinery are untouched. The TTL
+  reaper is a *redesign of the cleanup contract* (the file now has a
+  legitimate second consumer, the browser), not a repair layered on
+  immediate deletion. The P1 parallel-delivery state is a named phase
+  boundary with an explicit P2 that removes it — it is not shipped as the
+  target shape, and this RFC says so in §4 P1 and §4 P2.
+- **No test backdoor.** `resolve_destination` reads the real registry; no
+  `set_subscribers_for_test` escape hatch.

--- a/lib/keeper/keeper_chat_broadcast.ml
+++ b/lib/keeper/keeper_chat_broadcast.ml
@@ -3,21 +3,50 @@
     Mirrors [Keeper_registry_broadcast]: a pure side-effect wrapper
     around [Sse.broadcast] with a failure counter + WARN log. *)
 
-let chat_appended ~keeper_name ~source =
+(** Audio clip descriptor attached to a [keeper_chat_appended] event when
+    the utterance was synthesized (RFC-0235 P1). [token] is the capability
+    in the URL path [/api/v1/voice/audio/<token>]; the dashboard assembles
+    the full URL from its own base. [message_text] doubles as the
+    accessible caption/fallback. *)
+type audio_clip = {
+  token : string;
+  mime : string;
+  duration_sec : float option;
+  message_text : string;
+}
+
+let audio_clip_to_json (clip : audio_clip) =
+  let base =
+    [ ("token", `String clip.token)
+    ; ("mime", `String clip.mime)
+    ; ("message_text", `String clip.message_text)
+    ]
+  in
+  match clip.duration_sec with
+  | None -> base
+  | Some d -> base @ [ ("duration_sec", `Float d) ]
+
+let do_broadcast ~keeper_name ~source ~audio =
   try
     (* Field is named [connector], not [source]: the dashboard SSE
        vocabulary already reserves [source] for the journal origin
        (JournalSource), and the chat JSONL's own [source] column is a
-       different boundary. *)
-    let json =
-      `Assoc
-        [ ("type", `String "keeper_chat_appended");
-          ("name", `String keeper_name);
-          ("connector", `String source);
-          ("ts_unix", `Float (Time_compat.now ()));
-        ]
+       different boundary. [audio] is a separate boundary (RFC-0235): only
+       present when this turn synthesized a clip, and the dashboard decodes
+       it into a typed record at the SSE edge. *)
+    let base_fields =
+      [ ("type", `String "keeper_chat_appended");
+        ("name", `String keeper_name);
+        ("connector", `String source);
+        ("ts_unix", `Float (Time_compat.now ()));
+      ]
     in
-    Sse.broadcast json
+    let fields =
+      match audio with
+      | None -> base_fields
+      | Some clip -> base_fields @ [ ("audio", `Assoc (audio_clip_to_json clip)) ]
+    in
+    Sse.broadcast (`Assoc fields)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -29,3 +58,16 @@ let chat_appended ~keeper_name ~source =
       "keeper_chat_broadcast: chat_appended name=%s failed: %s"
       keeper_name
       (Printexc.to_string exn)
+
+(** Broadcast with no audio clip — the existing surface, unchanged signature
+    so all current callers stay as-is. *)
+let chat_appended ~keeper_name ~source = do_broadcast ~keeper_name ~source ~audio:None
+
+(** Broadcast with a synthesized audio clip attached (RFC-0235 P1). Used by
+    a turn that owns a voice clip ([Voice_bridge_transport.make_audio_file]
+    token); the dashboard decodes the [audio] field into a typed record and
+    renders a play button. Separate from {!chat_appended} so the rare
+    audio-bearing case does not force every caller to thread an option. *)
+let chat_appended_with_audio ~keeper_name ~source ~audio =
+  do_broadcast ~keeper_name ~source ~audio:(Some audio)
+

--- a/lib/keeper/keeper_chat_broadcast.mli
+++ b/lib/keeper/keeper_chat_broadcast.mli
@@ -3,6 +3,16 @@
     Pure side-effect wrapper — no chat store state read or written.
     Mirrors [Keeper_registry_broadcast] for lifecycle events. *)
 
+(** Audio clip descriptor attached to a [keeper_chat_appended] event when
+    the utterance was synthesized (RFC-0235 P1). See {!audio_clip} in the
+    .ml for the full contract. *)
+type audio_clip = {
+  token : string;
+  mime : string;
+  duration_sec : float option;
+  message_text : string;
+}
+
 (** Broadcast a [keeper_chat_appended] SSE event after a completed turn
     is persisted to the keeper's chat JSONL. The dashboard uses it to
     re-merge the server transcript live, so messages arriving through
@@ -18,3 +28,13 @@
     [keeper_sse_broadcast_failures] counter (site [chat_appended]) and
     logged at WARN. {!Eio.Cancel.Cancelled} propagates. *)
 val chat_appended : keeper_name:string -> source:string -> unit
+
+(** Like {!chat_appended} but attaches a synthesized audio clip
+    (RFC-0235 P1) so the dashboard can render a play button instead of
+    relying on server-local playback. Only a turn that owns a voice clip
+    ([Voice_bridge_transport.make_audio_file] token) calls this; every
+    other caller keeps using {!chat_appended}. The [audio] field is
+    decoded into a typed record at the SSE edge, never string-sniffed
+    downstream. *)
+val chat_appended_with_audio :
+  keeper_name:string -> source:string -> audio:audio_clip -> unit

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -129,6 +129,13 @@ let authority_of_label = function
   | "external" -> Some External
   | _ -> None
 
+type audio_clip = {
+  token : string;
+  mime : string;
+  duration_sec : float option;
+  message_text : string;
+}
+
 type speaker = {
   speaker_id : string option;
   speaker_name : string option;
@@ -152,6 +159,7 @@ type chat_message = {
   conversation_id : string option;
   external_message_id : string option;
   speaker : speaker option;
+  audio : audio_clip option;
   mentions : Keeper_identity.Keeper_id.t list;
       (* RFC-0232 §3.3: parsed once at append from the persisted content
          (plus connector-provided explicit mentions); [] = none.  Rows
@@ -194,9 +202,27 @@ let speaker_fields = function
       @ opt_string_field "speaker_name" sp.speaker_name
       @ [ ("speaker_authority", `String (authority_label sp.speaker_authority)) ]
 
+(* RFC-0235 P1: nested ["audio"] assoc so the clip stays one unit on the
+   JSONL row. Absent on rows written before voice transport; reads as
+   [None] (the dashboard renders text-only, matching any non-voice turn). *)
+let audio_to_json a =
+  let base =
+    [ ("token", `String a.token)
+    ; ("mime", `String a.mime)
+    ; ("message_text", `String a.message_text)
+    ]
+  in
+  match a.duration_sec with
+  | None -> base
+  | Some d -> base @ [ ("duration_sec", `Float d) ]
+
+let audio_fields = function
+  | None -> []
+  | Some a -> [ ("audio", `Assoc (audio_to_json a)) ]
+
 let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     ?tool_call_name ?surface ?conversation_id ?external_message_id ?speaker
-    ?(mentions = []) ?(kind = Row_kind.Utterance) ()
+    ?audio ?(mentions = []) ?(kind = Row_kind.Utterance) ()
     : string =
   (* RFC-0232 P5: the label is a derivation of the typed surface — the
      single site that turns a [Surface_ref.t] into the legacy [source]
@@ -260,6 +286,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     @ opt_string_field "conversation_id" conversation_id
     @ opt_string_field "external_message_id" external_message_id
     @ speaker_fields speaker
+    @ audio_fields audio
   in
   Yojson.Safe.to_string (`Assoc all_fields)
 
@@ -341,7 +368,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
 (* RFC-0223 P4: keeper-initiated message on one lane. A single
    assistant line — there is no user turn to pair it with. *)
 let append_assistant_message ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id () =
+    ?surface ?conversation_id ?audio () =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
@@ -349,7 +376,7 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line =
-      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id ()
+      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id ?audio ()
     in
     Fs_compat.append_file path (line ^ "\n")
   with
@@ -453,6 +480,33 @@ let parse_line ~file_path (line : string) : chat_message option =
                  ~path:file_path
                  ~detail:"speaker_id/speaker_name without speaker_authority");
           None
+    in
+    let audio =
+      match Json_util.assoc_member_opt "audio" json with
+      | Some (`Assoc fields) ->
+          let get k =
+            match List.assoc_opt k fields with
+            | Some (`String s) -> Some s
+            | _ -> None
+          in
+          (match get "token", get "mime" with
+           | Some token, Some mime ->
+               let duration_sec =
+                 match List.assoc_opt "duration_sec" fields with
+                 | Some (`Float f) -> Some f
+                 | _ -> None
+               in
+               let message_text = Option.value (get "message_text") ~default:"" in
+               Some { token; mime; duration_sec; message_text }
+           | _ ->
+               (* audio without token+mime is malformed; drop the field but
+                  keep the row (text-only render). *)
+               report_persistence_read_drop
+                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                 ~path:file_path
+                 ~detail:"audio field missing token/mime";
+               None)
+      | _ -> None
     in
     let attachments =
       match Json_util.assoc_member_opt "attachments" json with
@@ -558,7 +612,7 @@ let parse_line ~file_path (line : string) : chat_message option =
           Some
             { role; content; ts; attachments; tool_call_id; tool_call_name;
               source; surface; conversation_id; external_message_id; speaker;
-              mentions; kind }
+              audio; mentions; kind }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -86,6 +86,18 @@ val authority_of_label : string -> speaker_authority option
 (** Identity of the user-line author. [speaker_id] / [speaker_name] are
     absent when the route supplies none (the dashboard is a single
     authenticated operator and carries no per-user identity). *)
+type audio_clip = {
+  token : string;
+  mime : string;
+  duration_sec : float option;
+  message_text : string;
+}
+(** Persistable audio clip (RFC-0235 P1). Written on an assistant line
+    when the keeper synthesized a voice utterance; [token] is the
+    [/api/v1/voice/audio/:token] capability, [message_text] doubles as
+    the caption. Same shape as {!Keeper_chat_broadcast}'s SSE payload so
+    the two never drift. *)
+
 type speaker = {
   speaker_id : string option;
   speaker_name : string option;
@@ -114,6 +126,11 @@ type chat_message = {
           older lines, tool/assistant lines, and lines whose persisted
           [speaker_authority] label fails to parse (reported as a
           persistence read drop, row otherwise kept). *)
+  audio : audio_clip option;
+      (** RFC-0235 P1: present when this assistant line was a synthesized
+          voice utterance (keeper_voice_speak). [None] on every other
+          line and on rows written before voice transport; the dashboard
+          renders a play button when present. *)
   mentions : Keeper_identity.Keeper_id.t list;
       (** RFC-0232 §3.3: mention ids parsed once at append from the
           persisted user content (plus connector-supplied explicit
@@ -170,6 +187,7 @@ val append_assistant_message :
   content:string ->
   ?surface:Surface_ref.t ->
   ?conversation_id:string ->
+  ?audio:audio_clip ->
   unit ->
   unit
 

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -135,6 +135,35 @@ let handle_speak
          in
          if spoken
          then (
+           (* RFC-0235 P1 3b: record the utterance to the keeper's chat so a
+              connected device can read AND hear it, not just the server's
+              speakers. The audio clip carries the token of the synthesized
+              file so the dashboard can fetch /api/v1/voice/audio/<token>. *)
+           let base_dir = config.Workspace.base_path in
+           let surface = Surface_ref.Dashboard { session_id = None } in
+           Keeper_chat_store.append_assistant_message
+             ~base_dir ~keeper_name:meta.name ~content:message ~surface ();
+           let clip =
+             match Json_util.get_string json "audio_file" with
+             | Some path ->
+               let token =
+                 path |> Filename.basename |> Filename.chop_extension
+               in
+               Some
+                 { Keeper_chat_broadcast.token
+                 ; mime = "audio/mpeg"
+                 ; duration_sec = None
+                 ; message_text = message
+                 }
+             | None -> None
+           in
+           (match clip with
+            | Some c ->
+              Keeper_chat_broadcast.chat_appended_with_audio
+                ~keeper_name:meta.name ~source:"agent" ~audio:c
+            | None ->
+              Keeper_chat_broadcast.chat_appended
+                ~keeper_name:meta.name ~source:"agent");
            let memory_status =
              record_voice_output
                ~config

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -21,6 +21,7 @@
   masc.embedded_config
   masc.masc_tool_surface
   masc.operator
+  masc.voice_bridge_core
   yojson
   otoml
   base64

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -27,6 +27,7 @@ let make_routes ~port ~host ~sw ~clock =
   |> Server_routes_http_routes_attribution.add_routes
   |> Server_routes_http_routes_activity.add_routes ~sw ~clock
   |> Server_routes_http_routes_artifacts.add_routes
+  |> Server_routes_http_routes_voice.add_routes
   |> Server_routes_http_routes_multimodal.add_routes
   |> Server_routes_http_routes_autonomous.add_routes
   |> Server_routes_http_routes_resilience.add_routes

--- a/lib/server/server_routes_http_routes_voice.ml
+++ b/lib/server/server_routes_http_routes_voice.ml
@@ -1,0 +1,87 @@
+(** Voice audio clip HTTP surface (RFC-0235 P1).
+
+    Serves synthesized TTS clips to a connected dashboard browser by
+    capability token, so the browser plays the utterance instead of relying
+    on the server host's speakers ([Voice_bridge_core.run_local_playback]).
+
+      GET /api/v1/voice/audio/<token>
+
+    The token is the 128-bit [Random_id.hex] filename written by
+    [Voice_bridge_transport.make_audio_file]. Token = filename = HTTP
+    capability: no per-clip ACL table, no agent identity in the URL (the
+    legacy [<ts>_<agent>.mp3] name was enumerable).
+
+    Auth is [with_public_read] — the same gate as [artifacts/<sha256>]: the
+    unguessable token is the capability, exactly as a sha256 is for blobs.
+
+    Response (200): raw bytes, Content-Type audio/mpeg. NOT a JSON envelope:
+    the dashboard fetches this URL directly from an [<audio>]/[Audio]
+    element, which needs the media bytes, not a wrapped payload.
+
+    Errors:
+      400 — token malformed (not 32 hex chars)
+      404 — clip not on disk (never synthesized, or reaped by the 1h TTL of
+            [Voice_bridge.cleanup_old_audio_files])
+      503 — base path unresolvable *)
+
+open Server_utils
+open Server_auth
+
+module Http = Http_server_eio
+
+let token_hex_len = 32 (* Random_id.hex ~bytes:16 => 2*16 hex chars *)
+
+let is_valid_token (s : string) : bool =
+  String.length s = token_hex_len
+  && String.for_all
+       (fun c ->
+         (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'f'))
+       s
+
+(* Clip path under the same audio dir [Voice_bridge_transport.make_audio_file]
+   writes to. Reuses [Voice_bridge_core.masc_base_dir] so this route and the
+   synthesis side cannot drift apart. *)
+let clip_path ~token =
+  Filename.concat (Voice_bridge_core.masc_base_dir ()) "audio"
+  |> fun dir -> Filename.concat dir (token ^ ".mp3")
+
+let serve_clip ~token request reqd =
+  let path = clip_path ~token in
+  if not (Sys.file_exists path) then
+    (* Never synthesized, or reaped by the 1h TTL reaper. Text-only render
+       remains the dashboard fallback, so 404 is not a hard failure. *)
+    respond_public_read_json_value ~status:`Not_found request reqd
+      (`Assoc [ ("error", `String "not found"); ("token", `String token) ])
+  else (
+    (* Raw bytes — the dashboard's <audio>/Audio element fetches this URL
+       directly. [Fs_compat.load_file] returns the mp3 bytes as a string;
+       mp3 has no OCaml-string encoding hazard. content-length is explicit
+       to avoid chunked encoding, which some clients mishandle for media. *)
+    let body = Fs_compat.load_file path in
+    let headers =
+      Httpun.Headers.of_list
+        ( ("content-type", "audio/mpeg")
+        :: ("content-length", string_of_int (String.length body))
+        :: public_read_cors_headers request )
+    in
+    let response = Httpun.Response.create ~headers (`OK :> Httpun.Status.t) in
+    Httpun.Reqd.respond_with_string reqd response body)
+
+let add_routes router =
+  router
+  |> Http.Router.prefix_get "/api/v1/voice/audio/" (fun request reqd ->
+       with_public_read
+         (fun _state _req reqd ->
+           let path = Http.Request.path request in
+           match extract_path_param ~prefix:"/api/v1/voice/audio/" path with
+           | None ->
+               respond_public_read_json_value ~status:`Bad_request request reqd
+                 (`Assoc [ ("error", `String "token path parameter required") ])
+           | Some raw when not (is_valid_token raw) ->
+               respond_public_read_json_value ~status:`Bad_request request reqd
+                 (`Assoc
+                    [ ("error", `String "invalid token")
+                    ; ("reason", `String "expected 32-char hex (128-bit)")
+                    ])
+           | Some token -> serve_clip ~token request reqd)
+         request reqd)

--- a/lib/server/server_routes_http_routes_voice.mli
+++ b/lib/server/server_routes_http_routes_voice.mli
@@ -1,0 +1,9 @@
+(** Voice audio clip HTTP surface (RFC-0235 P1).
+
+    See {!Server_routes_http_routes_voice} for the full contract
+    (capability-token URLs, raw-bytes response, 1h TTL reaping). *)
+
+val add_routes : Http_server_eio.Router.t -> Http_server_eio.Router.t
+(** Register [GET /api/v1/voice/audio/:token] on the given router. Plugged
+    into the router assembly in {!Server_routes_http} alongside the
+    artifacts route. *)

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -365,7 +365,7 @@ let attempt_tts_endpoint
   let adapter = Voice_runtime_overlay.adapter_for_endpoint endpoint in
   match adapter.transport with
   | Voice_runtime_overlay.Openai_compat | Voice_runtime_overlay.Elevenlabs_direct ->
-    let audio_file = make_audio_file ~agent_id in
+    let audio_file = make_audio_file () in
     (match
        speak_via_http_tts_to_file
          endpoint

--- a/lib/voice_bridge_core/dune
+++ b/lib/voice_bridge_core/dune
@@ -11,6 +11,7 @@
   masc.config
   masc.host_config
   masc.masc_exec
+  masc.masc_random_id
   masc.voice_config
   masc.voice_runtime_overlay
   masc_core

--- a/lib/voice_bridge_core/voice_bridge_transport.ml
+++ b/lib/voice_bridge_core/voice_bridge_transport.ml
@@ -16,12 +16,17 @@ let safe_agent_id value =
     value
 ;;
 
-let make_audio_file ~agent_id =
+let make_audio_file () =
   Voice_bridge_core.ensure_audio_dir ();
-  let timestamp = int_of_float (Time_compat.now ()) in
+  (* The token is both the filename and the HTTP capability for
+     /api/v1/voice/audio/:token (RFC-0235 P1). agent_id is deliberately
+     absent from the filename: a logged-in operator viewing one keeper
+     must not be able to enumerate another keeper's clips by guessing
+     <ts>_<agent>. 16 bytes = 128-bit unguessable. *)
+  let token = Random_id.hex ~bytes:16 in
   Filename.concat
     (Filename.concat (Voice_bridge_core.masc_base_dir ()) "audio")
-    (Printf.sprintf "%d_%s.mp3" timestamp (safe_agent_id agent_id))
+    (token ^ ".mp3")
 ;;
 
 let write_text path content = Fs_compat.save_file path content

--- a/lib/voice_bridge_core/voice_bridge_transport.mli
+++ b/lib/voice_bridge_core/voice_bridge_transport.mli
@@ -1,7 +1,14 @@
 (** Transport helpers for {!Voice_bridge}. *)
 
 val safe_agent_id : string -> string
-val make_audio_file : agent_id:string -> string
+val make_audio_file : unit -> string
+(** [make_audio_file ()] returns a fresh path under
+    [$MASC_BASE_PATH/audio/<token>.mp3] where [token] is a 128-bit
+    unguessable [Random_id.hex] value. The token doubles as the HTTP
+    capability for [/api/v1/voice/audio/:token] (RFC-0235 P1). The
+    legacy [<ts>_<agent>.mp3] name exposed agent identity in the
+    filename and was enumerable; callers that need the token call
+    [Filename.basename path |> Filename.chop_extension]. *)
 val read_file : string -> string
 
 val run_voice_status

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -60,6 +60,7 @@ let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None)
   ; speaker
   ; mentions = Masc.Keeper_lane_mentions.mention_ids_of_content content
   ; kind
+  ; audio = None
   }
 ;;
 
@@ -196,6 +197,7 @@ let tool_line : Store.chat_message =
   ; speaker = None
   ; mentions = []
   ; kind = Store.Row_kind.Utterance
+  ; audio = None
   }
 ;;
 

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -25,6 +25,7 @@ let msg ?ts ?source ?speaker ~role content : Store.chat_message =
     speaker;
     mentions = [];
     kind = Store.Row_kind.Utterance;
+    audio = None;
   }
 
 let external_speaker ?name id : Store.speaker =


### PR DESCRIPTION
## RFC-0235: Voice output browser transport — P1 1-4a (server side)

Implements the server-side half of [RFC-0235](docs/rfc/RFC-0235-voice-output-browser-transport-device-routing.md): delivering synthesized voice clips to the dashboard browser so a **connected device plays keeper utterances** instead of the server-host `afplay`. Detailed design: [docs/design/RFC-0235-...-detailed.md](docs/design/RFC-0235-voice-output-browser-transport-detailed.md).

### Problem
Voice output was a server-local side effect: `Voice_bridge.agent_speak` synthesizes a file and plays it via `afplay`/`ffplay` on the host sound device. **No audio reaches any browser.** A mobile dashboard sees the utterance text but never the sound. (RFC-0223's "speaker" is talker *identity*, not an audio device — this is a separate transport.)

### What's in this PR (P1 steps 1-4a)
1. **token-named clips** — `make_audio_file` returns `<token>.mp3` where token is a 128-bit `Random_id.hex`. The legacy `<ts>_<agent>.mp3` exposed agent identity and was enumerable; the token is both filename and HTTP capability.
2. **`GET /api/v1/voice/audio/:token`** (`server_routes_http_routes_voice`) — serves the clip as raw `audio/mpeg` bytes behind `with_public_read` (same gate as `artifacts/<sha256>`: the unguessable token is the capability). 404 on miss/reaped, 400 on malformed token.
3. **`keeper_voice_speak` records the utterance** — `handle_speak` appends the spoken message to chat and broadcasts `keeper_chat_appended` carrying the audio clip. Semantics change: voice utterances are now chat records, not audio-only (owner decision).
4a. **`chat_message.audio_clip` persisted to JSONL (SSOT)** — the dashboard will render from refetched history (single source of truth), not only the live SSE event. Same five-site pattern as the speaker field (RFC-0223 P1).

### Lifecycle note (research correction)
An earlier draft claimed files were deleted on every exit path. Wrong: successful-utterance files are already retained (the Openai/Elevenlabs branch has no `Sys.remove` on success exits). The existing `cleanup_old_audio_files` 1h TTL is already the browser fetch window. **P1 needed no lifecycle rewrite.**

### What's NOT here (follow-up commits, same branch or follow-up PR)
- **4b**: repoint `Keeper_chat_broadcast.audio_clip` to `Keeper_chat_store.audio_clip` (today they are duplicate definitions of the same shape), and wire `keeper_tool_voice_runtime` to pass the clip to `append_assistant_message ?audio` so it is actually persisted (today only the SSE event carries it).
- **4c / P2**: dashboard decode + `<audio>` element (user-gesture play, no autoplay); device routing ("connected device only") via the SSE subscriber registry.

### Compiles
`dune build @install --root .` → EXIT 0. No dashboard TS changes yet (4c).

RFC-WAIVED: not applicable — voice/audio transport is outside the credential/identity/repo/operator/sandbox subsystems in CLAUDE.md `<agent_delegation>`. This PR *introduces* RFC-0235 (included in `docs/rfc/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
