### PR TITLE
fix(keeper): pin C message locale for sandbox EINTR retry marker (task-948)

### DIFF
--- a/lib/env_keeper_scrub.ml
+++ b/lib/env_keeper_scrub.ml
@@ -118,3 +118,27 @@ let filter_environment existing =
   Array.to_list existing
   |> List.filter (fun e -> is_allowed (key_of_entry e))
   |> Array.of_list
+
+(* Force a deterministic system-message locale on top of the scrubbed
+   env. libc's [strerror] is translated by [LC_MESSAGES]; on a non-C host
+   locale the EINTR message that keeper matches as a retry marker
+   ("interrupted system call", see [Keeper_turn_sandbox_runtime]) would be
+   localised and the substring match would silently miss, disabling EINTR
+   retry. We pin messages to C and leave character encoding ([LC_CTYPE] /
+   [LANG]) to the host so UTF-8 tool output is unaffected. [LC_ALL] has
+   higher POSIX precedence than [LC_MESSAGES], so a host [LC_ALL] would
+   override our pin; we neutralise it to the empty string, which POSIX
+   treats as unset (not as the "C" locale), leaving the remaining
+   categories to [LANG] / [LC_CTYPE]. *)
+let lc_messages_pin = [ "LC_ALL="; "LC_MESSAGES=C" ]
+
+let filter_environment_c_messages existing =
+  let scrubbed =
+    filter_environment existing
+    |> Array.to_list
+    |> List.filter (fun e ->
+      match key_of_entry e with
+      | "LC_ALL" | "LC_MESSAGES" -> false
+      | _ -> true)
+  in
+  Array.of_list (scrubbed @ lc_messages_pin)

--- a/lib/env_keeper_scrub.mli
+++ b/lib/env_keeper_scrub.mli
@@ -16,3 +16,11 @@ val filter_environment : string array -> string array
 (** Return a copy of the given [Unix.environment]-shaped array with only
     allowed keys retained. Entries that do not contain ['='] are kept iff
     their key is allowed. *)
+
+val filter_environment_c_messages : string array -> string array
+(** Like {!filter_environment}, but pins system messages to the C locale:
+    drops any host [LC_ALL] / [LC_MESSAGES] and appends [LC_ALL=] (empty,
+    treated by POSIX as unset) and [LC_MESSAGES=C]. Character encoding
+    ([LC_CTYPE] / [LANG]) is left to the host. Use for subprocesses whose
+    textual output MASC classifies — e.g. the EINTR retry marker in
+    [Keeper_turn_sandbox_runtime] depends on [strerror] being English. *)

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -201,7 +201,7 @@ let run_argv_with_status_retry_eintr ?timeout_sec argv =
           ~actor:`System_sandbox
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper turn sandbox command"
-          ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
+          ~env:(Env_keeper_scrub.filter_environment_c_messages (Unix.environment ()))
           ~cwd:(Sys.getcwd ())
           argv
       in
@@ -463,7 +463,7 @@ let run_argv_with_status_split_retry_eintr
       ?on_stderr_chunk
       ~run_attempt:(fun ?on_stdout_chunk ?on_stderr_chunk () ->
         let raw_source = String.concat " " argv in
-        let env = Env_keeper_scrub.filter_environment (Unix.environment ()) in
+        let env = Env_keeper_scrub.filter_environment_c_messages (Unix.environment ()) in
         let cwd = Sys.getcwd () in
         match on_stdout_chunk, on_stderr_chunk with
         | None, None ->
@@ -506,7 +506,7 @@ let run_argv_with_stdin_and_status_retry_eintr ?timeout_sec ~stdin_content argv 
           ~actor:`System_sandbox
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper turn sandbox stdin command"
-          ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
+          ~env:(Env_keeper_scrub.filter_environment_c_messages (Unix.environment ()))
           ~cwd:(Sys.getcwd ())
           ~stdin_content
           argv
@@ -534,7 +534,7 @@ let run_argv_with_stdin_and_status_split_retry_eintr
       ?on_stderr_chunk
       ~run_attempt:(fun ?on_stdout_chunk ?on_stderr_chunk () ->
         let raw_source = String.concat " " argv in
-        let env = Env_keeper_scrub.filter_environment (Unix.environment ()) in
+        let env = Env_keeper_scrub.filter_environment_c_messages (Unix.environment ()) in
         let cwd = Sys.getcwd () in
         Masc_exec.Exec_gate.run_argv_with_stdin_and_status_split
           ?timeout_sec
@@ -968,7 +968,7 @@ let run_exec_pipeline_with_status_once
           let cwd = Option.value stage_cwd ~default:cwd in
           let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
           let argv = docker_exec_pipeline_argv t ~container_name ~container_cwd command_argv in
-          { Process_eio.argv; env = Some (Env_keeper_scrub.filter_environment (Unix.environment ())); cwd = Some (Sys.getcwd ()) })
+          { Process_eio.argv; env = Some (Env_keeper_scrub.filter_environment_c_messages (Unix.environment ())); cwd = Some (Sys.getcwd ()) })
         stages
     in
     Ok

--- a/test/test_env_keeper_scrub.ml
+++ b/test/test_env_keeper_scrub.ml
@@ -106,6 +106,38 @@ let extra_allow_env_override () =
          (Env_keeper_scrub.is_allowed "CUSTOM_OK_SECRET"))
 ;;
 
+let mem entry env = Array.to_list env |> List.exists (fun e -> e = entry)
+
+(* A non-C host locale would localise strerror and silently break the
+   EINTR retry marker; filter_environment_c_messages must pin messages to
+   C while leaving character encoding to the host. *)
+let c_messages_pins_message_locale () =
+  let input =
+    [| "PATH=/usr/bin"
+     ; "LC_ALL=ko_KR.UTF-8"
+     ; "LC_MESSAGES=fr_FR.UTF-8"
+     ; "LANG=ko_KR.UTF-8"
+     ; "LC_CTYPE=ko_KR.UTF-8"
+    |]
+  in
+  let out = Env_keeper_scrub.filter_environment_c_messages input in
+  Alcotest.(check bool) "LC_MESSAGES pinned to C" true (mem "LC_MESSAGES=C" out);
+  Alcotest.(check bool) "LC_ALL neutralised to empty" true (mem "LC_ALL=" out);
+  Alcotest.(check bool) "host LC_ALL value dropped" false
+    (mem "LC_ALL=ko_KR.UTF-8" out);
+  Alcotest.(check bool) "host LC_MESSAGES value dropped" false
+    (mem "LC_MESSAGES=fr_FR.UTF-8" out);
+  (* encoding categories are left to the host so UTF-8 output survives *)
+  Alcotest.(check bool) "LANG retained" true (mem "LANG=ko_KR.UTF-8" out);
+  Alcotest.(check bool) "LC_CTYPE retained" true (mem "LC_CTYPE=ko_KR.UTF-8" out)
+;;
+
+let c_messages_pins_even_without_host_locale () =
+  let out = Env_keeper_scrub.filter_environment_c_messages [| "PATH=/usr/bin" |] in
+  Alcotest.(check bool) "LC_MESSAGES=C appended" true (mem "LC_MESSAGES=C" out);
+  Alcotest.(check bool) "LC_ALL= appended" true (mem "LC_ALL=" out)
+;;
+
 let () =
   Alcotest.run
     "env keeper scrub"
@@ -123,6 +155,12 @@ let () =
             filter_environment_keeps_only_allowed
         ; Alcotest.test_case "drops unknown keys without equals" `Quick
             filter_environment_drops_entries_without_equals
+        ] )
+    ; ( "c_messages_locale"
+      , [ Alcotest.test_case "pins message locale to C" `Quick
+            c_messages_pins_message_locale
+        ; Alcotest.test_case "pins even without host locale" `Quick
+            c_messages_pins_even_without_host_locale
         ] )
     ]
 ;;


### PR DESCRIPTION
## 요약

keeper sandbox 자식 프로세스의 EINTR 재시도 marker(`"interrupted system call"`)가 **host locale에 의존**하던 결정성 결함을 닫습니다. 2026-06-13 머지 감사 task-948.

`keeper_turn_sandbox_runtime`은 자식 명령이 EINTR로 죽으면 출력에서 `"interrupted system call"`(libc `strerror(EINTR)`의 C-locale 영어)을 substring 매칭해 재시도합니다. 그런데 `env_keeper_scrub`는 default-deny allowlist이면서도 host의 `LC_ALL`/`LANG`/`LC_*`를 **그대로 통과**시킵니다. host가 비영어 locale(예: `ko_KR.UTF-8`)이면 자식의 strerror가 영어가 아니게 되어 marker 매칭이 **silent하게 실패** → EINTR 재시도가 비활성화됩니다.

## 조사 결과 (task-948 재평가)

감사는 task-948을 "EINTR/timeout substring 분류기 → typed 교체"로 봤으나, 코드를 읽은 결과 **over-flag**였습니다:
- **timeout**: 이미 RFC-0042 typed closed-sum(`keeper_terminal_reason.of_wire`)으로 분류됨(#20843 중앙화, #20959는 typed-strengthening). 위반 아님.
- **EINTR**: `process_eio.mli`의 `run_argv_with_status : ... -> (Unix.process_status * string)` — 부모엔 `WEXITED 127`(모호) + 자식이 이미 stringify한 텍스트뿐, typed `Unix.EINTR` 신호가 **없음**. substring이 유일한 EINTR 신호 → 제거 불가(제거하면 재시도가 깨짐).

따라서 근본 수정은 "typed variant 만들기"(theater/재시도 파괴)가 아니라 **텍스트 경계를 결정론적으로 만드는 것**입니다.

## 변경

- `env_keeper_scrub.filter_environment_c_messages`: `filter_environment` 위에 system-message locale을 C로 고정. host `LC_ALL`/`LC_MESSAGES`를 드롭하고 `LC_ALL=`(빈 값=POSIX unset 취급, LC_MESSAGES override 방지) + `LC_MESSAGES=C`를 추가. 문자 인코딩(`LC_CTYPE`/`LANG`)은 host에 위임 → UTF-8 출력 무영향.
- `keeper_turn_sandbox_runtime`의 sandbox exec 5개 사이트를 이 변형으로 교체.
- `test_env_keeper_scrub`: 2개 테스트(메시지 locale 고정 + host locale 없을 때도 pin). mutation-checked(pin 비우면 둘 다 red).

## 검증

- `dune build @check` exit 0, ocamlformat clean.
- 신규 테스트 2개 green, mutation-checked.
- `c_messages`는 메시지 언어만 바꾸고 인코딩/정렬은 host 유지(테스트가 LANG/LC_CTYPE 보존 단정).

## 부수 발견 (별도 이슈 #21148)

같은 테스트 파일에서 pre-existing silent-red 발견: `allow_exact`의 `GITHUB_TOKEN`/`GH_TOKEN`이 deny_suffix `_TOKEN`에 항상 막혀 dead, 테스트는 stale `allowed` 단정. deny가 의도된 보안 동작(.mli)이라 dead 엔트리 제거 + 테스트 정정이 근본 수정이나 **credential RFC 게이트 대상**이라 이 PR 범위 밖 → #21148로 분리.

RFC-WAIVED: locale 결정성 수정. env_keeper_scrub의 credential allowlist/deny 정책(RFC-0007)은 변경하지 않음 — message-locale pinning wrapper만 추가, allow/deny 규칙 불변.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
