### PR TITLE
Fix keeper release owner-mismatch guidance

### DIFF
--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -177,7 +177,9 @@ and handle_transition ~tool_name ~start_time ctx args =
     match action, task_opt with
     | Masc_domain.Release, Some task ->
       (match Workspace.task_assignee_of_status task.task_status with
-       | Some assignee when not (Workspace.same_task_actor ctx.config assignee ctx.agent_name) ->
+       | Some assignee
+         when (not force)
+              && not (Workspace.same_task_actor ctx.config assignee ctx.agent_name) ->
          let status = Masc_domain.task_status_to_string task.task_status in
          let message =
            Printf.sprintf
@@ -541,7 +543,7 @@ and handle_transition ~tool_name ~start_time ctx args =
       let ev = if attempt = 0 then expected_version else None in
       let r = Workspace.transition_task_r ctx.config ~agent_name:ctx.agent_name
                 ~task_id ~action ?expected_version:ev ~notes ~reason
-                ?handoff_context ?prepare_verification_request
+                ~force ?handoff_context ?prepare_verification_request
                 ?compensate_verification_request
                 ?prepare_verification_verdict () in
       if is_version_mismatch r && attempt < max_cas_retries then begin

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -173,6 +173,57 @@ and handle_transition ~tool_name ~start_time ctx args =
   in
   let tasks = Workspace.get_tasks_raw ctx.config in
   let task_opt = List.find_opt (fun (t : Masc_domain.task) -> String.equal t.id task_id) tasks in
+  let release_owner_mismatch_rejection =
+    match action, task_opt with
+    | Masc_domain.Release, Some task ->
+      (match Workspace.task_assignee_of_status task.task_status with
+       | Some assignee when not (Workspace.same_task_actor ctx.config assignee ctx.agent_name) ->
+         let status = Masc_domain.task_status_to_string task.task_status in
+         let message =
+           Printf.sprintf
+             "Task %s is %s and owned by %s; %s cannot release it. Use \
+              keeper_board_post or masc_board_post to ask the current assignee \
+              for handoff/release, or claim different unowned work."
+             task_id
+             status
+             assignee
+             ctx.agent_name
+         in
+         Some
+           (Tool_result.error
+              ~failure_class:(Some Tool_result.Workflow_rejection)
+              ~tool_name
+              ~start_time
+              (workflow_rejection_payload_json
+                 ~rule_id:"task_release_requires_current_owner"
+                 ~tool_suggestion:"keeper_board_post"
+                 ~hint:
+                   "Do not retry masc_transition(action=release) for a task owned \
+                    by another keeper. Ask the current assignee for handoff/release \
+                    on the board, or inspect and claim different unowned work."
+                 ~scope_policy:"observe"
+                 ~alternatives:
+                   [ "keeper_board_post"; "masc_board_post"; "keeper_tasks_list"; "keeper_task_claim" ]
+                 ~extra_fields:
+                   [ "task_id", `String task_id
+                   ; "task_status", `String status
+                   ; "current_assignee", `String assignee
+                   ; "requested_agent", `String ctx.agent_name
+                   ]
+                 message))
+       | Some _ | None -> None)
+    | Masc_domain.Release, None -> None
+    | ( Masc_domain.Claim
+      | Masc_domain.Start
+      | Masc_domain.Done_action
+      | Masc_domain.Cancel
+      | Masc_domain.Submit_for_verification
+      | Masc_domain.Approve_verification
+      | Masc_domain.Reject_verification ), _ -> None
+  in
+  match release_owner_mismatch_rejection with
+  | Some result -> result
+  | None ->
   let terminal_verdict_noop =
     if transition_action_policy_applies transition_action_denylist
        && is_verdict_transition_action action

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -707,6 +707,55 @@ let () = test "handle_transition_release_by_nonowner_redirects_to_board_post"
     | None -> false)
 )
 
+let () = test "handle_transition_force_release_by_admin_bypasses_nonowner_redirect"
+    (fun () ->
+  let ctx_owner = make_test_ctx_with_agent "owner-agent" in
+  let _ =
+    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx_owner
+      (`Assoc [ ("title", `String "Force-release owned task") ])
+  in
+  let _ =
+    Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx_owner
+      (`Assoc [ ("task_id", `String "task-001") ])
+  in
+  let ctx_admin =
+    { ctx_owner with Task.Tool.agent_name = "admin-agent" }
+  in
+  let previous_is_admin = Atomic.get Workspace_hooks.is_admin_agent_fn in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Workspace_hooks.is_admin_agent_fn previous_is_admin)
+    (fun () ->
+       Atomic.set Workspace_hooks.is_admin_agent_fn
+         (fun ~base_path:_ ~agent_name ->
+            String.equal agent_name "admin-agent");
+       let result =
+         Task.Tool.handle_transition
+           ~tool_name:"test_tool"
+           ~start_time:0.0
+           ctx_admin
+           (`Assoc
+              [
+                ("task_id", `String "task-001");
+                ("action", `String "release");
+                ("force", `Bool true);
+              ])
+       in
+       assert (Tool_result.is_success result);
+       match
+         Workspace.get_tasks_raw ctx_owner.Task.Tool.config
+         |> List.find_opt (fun (task : Masc_domain.task) ->
+              String.equal task.id "task-001")
+       with
+       | Some { task_status = Masc_domain.Todo; _ } -> ()
+       | Some task ->
+         failwith
+           (Printf.sprintf
+              "expected forced release to return task-001 to todo, got %s"
+              (Masc_domain.task_status_to_string task.task_status))
+       | None -> failwith "missing task-001 after forced release")
+)
+
 let () = test "handle_transition_release_synthesizes_summary_from_notes" (fun () ->
   (* Field evidence (2026-04-17/18): 76/132 masc_transition failures were
      empty/missing handoff_context.summary while the caller still supplied a

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -689,9 +689,22 @@ let () = test "handle_transition_release_by_nonowner_redirects_to_board_post"
         ])
   in
   assert (not (Tool_result.is_success result));
-  assert (str_contains (Tool_result.message result) "Invalid transition");
-  assert (str_contains (Tool_result.message result) "Remediation");
+  assert ((Tool_result.failure_class result) = Some Tool_result.Workflow_rejection);
+  assert (str_contains (Tool_result.message result) "Task task-001 is claimed");
+  assert (str_contains (Tool_result.message result) "owner-agent");
   assert (str_contains (Tool_result.message result) "masc_board_post")
+  ;
+  let data = Tool_result.data result in
+  assert (Json_util.get_string data "task_id" = Some "task-001");
+  assert (Json_util.get_string data "current_assignee" = Some "owner-agent");
+  assert (
+    match Json_util.assoc_member_opt "diagnosis" data with
+    | Some diagnosis ->
+      Json_util.get_string diagnosis "rule_id"
+      = Some "task_release_requires_current_owner"
+      && Json_util.get_string diagnosis "tool_suggestion"
+         = Some "keeper_board_post"
+    | None -> false)
 )
 
 let () = test "handle_transition_release_synthesizes_summary_from_notes" (fun () ->


### PR DESCRIPTION
## Summary
- preflight `masc_transition(action=release)` when the task is owned by another logical assignee
- return a deterministic `workflow_rejection` payload with `task_id` / `current_assignee` and next-tool guidance instead of falling through to a generic invalid transition
- preserve the admin `force=true` release path so operator/admin transitions still bypass non-owner guidance intentionally
- strengthen coverage for both non-owner release guidance and admin forced release

Closes #21151

## Verification
- `ocamlformat --check lib/task/tool_task.ml test/test_tool_task_coverage.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_tool_task_coverage.exe`
- `./_build/default/test/test_tool_task_coverage.exe test coverage 17`
- `./_build/default/test/test_tool_task_coverage.exe test coverage 18`

## Note
The full test executable still has unrelated existing failures in coverage cases 7 and 35 in this environment; the targeted cases for this change pass.
