### PR TITLE
fix(keeper_memory_bank): exclude voice_output from recent-note preview

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -905,9 +905,9 @@ let append_voice_output
 let summarize_memory_bank_lines
     (lines : string list)
     ~(recent_limit : int) : keeper_memory_summary =
+  let raw_rows = lines |> List.filter_map parse_memory_bank_row in
   let parsed =
-    lines
-    |> List.filter_map parse_memory_bank_row
+    raw_rows
     |> List.map (fun (row : keeper_memory_row_raw) ->
          { kind = row.kind
          ; text = row.text
@@ -955,8 +955,21 @@ let summarize_memory_bank_lines
     | (kind, _) :: _ -> Some kind
     | [] -> None
   in
+  (* Voice output is self-generated speech.  If it surfaces as the most
+     recent note, the model treats its own spoken text as a fresh user
+     request and re-enters the voice tool in a self-echo loop (2026-06-14
+     sangsu voice repeat incident).  Keep the row in the bank for search,
+     but exclude it from the auto-injected recent-note preview. *)
   let recent_notes =
-    parsed
+    raw_rows
+    |> List.filter (fun (row : keeper_memory_row_raw) ->
+         not (String.equal row.source "voice_output"))
+    |> List.map (fun (row : keeper_memory_row_raw) ->
+         { kind = row.kind
+         ; text = row.text
+         ; priority = row.priority
+         ; ts_unix = row.ts_unix
+         })
     |> List.rev
     |> take (max 0 recent_limit)
   in

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -401,6 +401,39 @@ let test_keeper_voice_speak_text_fallback_records_memory_bank_row () =
   | None -> fail "expected fallback voice_output progress memory row"
 ;;
 
+(* Regression for the 2026-06-14 sangsu voice self-echo loop: the raw
+   voice_output row must stay durable in the memory bank, but it must not
+   appear in the auto-injected recent-note summary that drives the next
+   turn, or the model will answer its own spoken text repeatedly. *)
+let test_voice_output_row_is_excluded_from_memory_recent_notes () =
+  let config = test_config () in
+  let meta = make_keeper_meta "voice-recent-note-filter-keeper" in
+  let message = "this should not echo back as a recent note" in
+  let raw =
+    Masc.Keeper_tool_voice_runtime.handle_voice_tool
+      ~config
+      ~meta
+      ~name:"keeper_voice_speak"
+      ~args:(`Assoc [ "message", `String message ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  check bool "fallback memory recorded" true
+    Yojson.Safe.Util.(member "memory_recorded" json |> to_bool);
+  let memory_path = Masc.Keeper_types_support.keeper_memory_bank_path config meta.name in
+  let lines = read_lines memory_path in
+  let summary =
+    Masc.Keeper_memory_bank.summarize_memory_bank_lines lines ~recent_limit:4
+  in
+  let has_voice_text =
+    List.exists
+      (fun (row : Masc.Keeper_memory_bank.keeper_memory_line) ->
+         String.equal row.text message)
+      summary.recent_notes
+  in
+  check bool "voice_output source not in recent_notes" false has_voice_text
+;;
+
 let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
   Eio_main.run
   @@ fun env ->
@@ -618,6 +651,10 @@ let () =
             "keeper_voice_speak fallback records memory"
             `Quick
             test_keeper_voice_speak_text_fallback_records_memory_bank_row
+        ; test_case
+            "voice_output row is excluded from memory recent notes"
+            `Quick
+            test_voice_output_row_is_excluded_from_memory_recent_notes
         ; test_case
             "session_start does not store session_name as voice"
             `Quick


### PR DESCRIPTION
# ci:skip-test-coverage

Voice output rows were surfacing in the auto-injected memory bank recent-note summary. The model then treated its own spoken text as a fresh user request and looped back into `keeper_voice_speak`, causing the sangsu voice self-echo loop seen on 2026-06-14.

Keep the raw `voice_output` row in the bank so it remains searchable, but filter `source = "voice_output"` from `recent_notes` so the keeper is not prompted to reply to its own speech.

- Minimal change in `Keeper_memory_bank.summarize_memory_bank_lines`.
- Regression test in `test_voice_runtime_overlay.ml`.

Fixes the root cause of the repeated `svg 어디있어?` / `sangsu_portrait.svg` voice cycle.
