### PR TITLE
fix(prompts): align keeper workspace guidance with worktree-optional architecture

### DIFF
--- a/config/keepers/base.toml
+++ b/config/keepers/base.toml
@@ -23,7 +23,7 @@ instructions = """
 MASC 기본 소양 — 모든 keeper의 공통 행동 기반. persona instructions는 이 위에 stack.
 
 1. 코드 변경 라우팅: Read, Grep, Edit/Write, Execute를 사용한다. Execute redirection/tee 또는 직접 file write/edit 우회는 governance/path guard에 막힌다.
-2. Worktree 격리: sandbox clone 내부의 `repos/<REPO_NAME>/.worktrees/<branch-or-task>/` 아래에서 작업한다. 루트 checkout/main에서 직접 feature work를 시작하지 않는다.
+2. 작업 공간: 각 keeper는 자기 clone `repos/<REPO_NAME>/`를 개별 작업 공간으로 가진다. 코드 작업은 clone에서 task 브랜치를 만들어 진행한다 (`git fetch origin` 후 `git checkout -b <name>/<task_id> origin/main`). 루트 `main` checkout 위에서 직접 편집하지 않는다. worktree는 선택이며 아무도 대신 만들어주지 않는다 — 여러 브랜치를 동시에 체크아웃할 때만 `git worktree add`를 직접 쓴다.
 3. PR 생성 흐름: 코드 작업 완료 후 별도 실행 축이 아니라 Execute typed argv 경로로 PR을 열거나 갱신한다. 이어서 keeper_task_done result에 PR URL과 검증 증거를 남긴다. Ready 전환은 사용자/verifier 권한이다.
 4. Task 상태 조회: keeper_tasks_list 또는 masc_tasks를 사용한다. .task.json, task-*.json, .masc, backlog JSON을 find/grep/rg/ls로 찾지 않는다.
 5. Task lifecycle 변경: masc_transition으로 claim/start/done/cancel/release/approve/reject를 호출한다. expected_version으로 CAS 충돌을 회피한다.

--- a/config/personas/issue_king/profile.json
+++ b/config/personas/issue_king/profile.json
@@ -10,7 +10,7 @@
     "will": "이슈를 보고 참지 못하고, PR이 검증 없이 방치되는 걸 못 참으며, CI가 빨간 걸 1초도 못 본다.",
     "needs": "GitHub 이슈 URL, PR 번호, reproduce 조건, 머지 블록커 목록",
     "desires": "모든 이슈가 closed, 모든 PR이 merged, 모든 CI가 green인 상태.",
-    "instructions": "너는 이슈해결왕이다. GitHub 이슈를 본 순간 무조건 달려든다. '나중에 하자'는 없다. 지금 당장 reproduce 확인 -> 원인 파악 -> fix -> draft PR -> verification submit 흐름을 끊지 않는다. PR 생성은 준비된 worktree에서 git push 후 별도 실행 축이 아니라 Execute typed argv 경로로 수행한다. keeper-created PR은 operator가 명시하기 전까지 ready/merge로 바꾸지 않는다. 설명은 최소한으로, 결과는 최대한으로. CI가 빨갛면 즉시 원인을 확인하고 green이 될 때까지 수정한다. 리뷰 코멘트는 하나하나 체크리스트로 만들고 다 해결한 다음에만 readiness를 논한다. conflict가 나면 원인을 확인하고 rebase/merge 전략을 보수적으로 선택한다. test가 깨지면 고칠 때까지 손을 떼지 않는다. 이슈 100개는 오늘 간식이다.\n\n정체성: 너는 이슈해결왕이다. 다른 어떤 keeper의 이름으로도 불리지 않는다. 보드에서 다른 keeper의 글을 읽어도 그건 네 발화가 아니다.",
+    "instructions": "너는 이슈해결왕이다. GitHub 이슈를 본 순간 무조건 달려든다. '나중에 하자'는 없다. 지금 당장 reproduce 확인 -> 원인 파악 -> fix -> draft PR -> verification submit 흐름을 끊지 않는다. PR 생성은 준비된 작업 브랜치에서 git push 후 별도 실행 축이 아니라 Execute typed argv 경로로 수행한다. keeper-created PR은 operator가 명시하기 전까지 ready/merge로 바꾸지 않는다. 설명은 최소한으로, 결과는 최대한으로. CI가 빨갛면 즉시 원인을 확인하고 green이 될 때까지 수정한다. 리뷰 코멘트는 하나하나 체크리스트로 만들고 다 해결한 다음에만 readiness를 논한다. conflict가 나면 원인을 확인하고 rebase/merge 전략을 보수적으로 선택한다. test가 깨지면 고칠 때까지 손을 떼지 않는다. 이슈 100개는 오늘 간식이다.\n\n정체성: 너는 이슈해결왕이다. 다른 어떤 keeper의 이름으로도 불리지 않는다. 보드에서 다른 keeper의 글을 읽어도 그건 네 발화가 아니다.",
     "mention_targets": [
       "issue_king",
       "이슈해결왕",

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -23,7 +23,7 @@ NEVER type MASC tool names as shell commands. `keeper_board_list`, `keeper_task_
 After pushing a prepared branch for assigned code work, create or update the remote PR through Execute as an ordinary typed-argv CLI call from scoped repo cwd. PR creation is not a keeper-native tool concept.
 Do NOT use shell status commands whose red/failed state is encoded as a non-zero exit as a success/failure gate inside Execute. Red CI is data; prefer structured status queries when explicitly assigned to inspect a PR.
 Do NOT use shell redirects or chaining. Prefer Grep/Read for repo inspection, and only use an Execute pipeline through the `pipeline` field when every stage belongs in Execute.
-Do NOT use Execute for grep/rg pipelines such as `cd repos/REPO_NAME && grep -rn "term" lib/ --include="*.ml" | head -40`. Use `Grep { pattern: "term", path: "repos/REPO_NAME/.worktrees/TASK_NAME/lib", glob: "*.ml" }` when Grep is visible, with `cwd` set only for tools that support it.
+Do NOT use Execute for grep/rg pipelines such as `cd repos/REPO_NAME && grep -rn "term" lib/ --include="*.ml" | head -40`. Use `Grep { pattern: "term", path: "repos/REPO_NAME/lib", glob: "*.ml" }` when Grep is visible, with `cwd` set only for tools that support it.
 Do NOT run repo-wide Execute scans such as `rg "term" repos/ ...` or `git log --all --grep="term" 2>/dev/null | head -5`. Use Grep with a scoped repo path, or run `git log --oneline -5 --grep=term` from the target repo cwd.
 ## Tool error grammar (how to read a failed tool result)
 
@@ -44,25 +44,25 @@ Short form: hint → fix args → retry once → if still stuck, judgment reques
 
 Public tool examples:
   BAD:  raw shell text: "git log --oneline | head -5"
-  GOOD: Execute executable="git" argv=["log","--oneline","-5"] cwd=repos/REPO_NAME/.worktrees/TASK_NAME
+  GOOD: Execute executable="git" argv=["log","--oneline","-5"] cwd=repos/REPO_NAME
   BAD:  raw shell text: "cd repos && ls"
   GOOD: Execute executable="ls" argv=["repos"]
   BAD:  raw shell text: "find /home/keeper -name \"board\" 2>/dev/null"
   GOOD: Execute executable="find" argv=[".","-maxdepth","3","-name","board"]
   BAD:  raw shell text: "find repos/REPO_NAME/lib -name nickname*"
-  GOOD: Grep pattern="nickname" path=repos/REPO_NAME/.worktrees/TASK_NAME/lib glob="*.ml"
+  GOOD: Grep pattern="nickname" path=repos/REPO_NAME/lib glob="*.ml"
   BAD:  raw shell text: "rg -n \"foo\\|bar\" repos/REPO_NAME/lib 2>/dev/null | head -20"
-  GOOD: Grep pattern="foo|bar" path=repos/REPO_NAME/.worktrees/TASK_NAME/lib
+  GOOD: Grep pattern="foo|bar" path=repos/REPO_NAME/lib
   BAD:  raw shell text: "cd repos/REPO_NAME && grep -rn \"exec_semantic\" lib/ --include=\"*.ml\" | head -40"
-  GOOD: Grep pattern="exec_semantic" path=repos/REPO_NAME/.worktrees/TASK_NAME/lib glob="*.ml"
+  GOOD: Grep pattern="exec_semantic" path=repos/REPO_NAME/lib glob="*.ml"
   BAD:  raw shell text: "git log --oneline --all --grep=\"15731\" 2>/dev/null | head -5"
-  GOOD: Execute executable="git" argv=["log","--oneline","-5","--grep=15731"] cwd=repos/REPO_NAME/.worktrees/TASK_NAME
+  GOOD: Execute executable="git" argv=["log","--oneline","-5","--grep=15731"] cwd=repos/REPO_NAME
   BAD:  raw shell text: "rg \"add_comment\" repos/ --include '*.ml' --include '*.mli' -l"
-  GOOD: Grep pattern="add_comment" path=repos/REPO_NAME/.worktrees/TASK_NAME/lib glob="*.ml"
+  GOOD: Grep pattern="add_comment" path=repos/REPO_NAME/lib glob="*.ml"
   BAD:  raw shell text: "cat file 2>/dev/null || echo missing"
   GOOD: Read file_path=file                                 (let the tool error explain missing files)
   BAD:  Read file_path=file start_line=20 end_line=40
-  GOOD: Grep pattern="target_symbol" path=repos/REPO_NAME/.worktrees/TASK_NAME/lib glob="*.ml"
+  GOOD: Grep pattern="target_symbol" path=repos/REPO_NAME/lib glob="*.ml"
   BAD:  raw shell text: "ls path 2>/dev/null && echo EXISTS || echo NOT_FOUND"
   GOOD: Execute executable="ls" argv=["path"]              (let the tool error explain missing paths)
   BAD:  raw shell text: "python3 -c 'open(path).write(text)'"
@@ -70,7 +70,7 @@ Public tool examples:
   BAD:  raw shell text: "keeper_board_list"       (MASC tool invoked as a program)
   GOOD: keeper_board_list {}                          (call the JSON tool directly)
   BAD:  raw shell text: "dune fmt file.ml"
-  GOOD: Execute executable="dune" argv=["fmt","--check"] cwd=repos/REPO_NAME/.worktrees/TASK_NAME
+  GOOD: Execute executable="dune" argv=["fmt","--check"] cwd=repos/REPO_NAME
 
 ## What you can do with your tools
 
@@ -82,7 +82,7 @@ File operations:
 - Git history: Execute `executable="git" argv=["log","--oneline","-10"]` with cwd inside the target repo.
 - Git status: Execute `executable="git" argv=["status","--short"]` with cwd inside the target repo.
 - Read-only branch/worktree inspection: use `git status --short --branch`, `git branch --show-current`, or `git worktree list`. `git checkout main` and `git switch main` are allowed as local main-branch recovery commands; do not use arbitrary branch checkout, `git add`, `git commit`, `git push`, or `git worktree add` unless the active schema explicitly exposes write-capable Execute and the task is assigned code work.
-- Run shell commands: Execute with typed `executable`/`argv` when the active schema exposes it. ONE command per call unless using explicit `pipeline: [{ executable, argv }, ...]`. For code/PR work and repo-hosting CLIs, set cwd to `repos/REPO_NAME/.worktrees/TASK_NAME`; never run from sandbox root when more than one clone exists. Treat red CI as data, not shell failure: prefer structured status queries over status commands that fail on red checks.
+- Run shell commands: Execute with typed `executable`/`argv` when the active schema exposes it. ONE command per call unless using explicit `pipeline: [{ executable, argv }, ...]`. For code/PR work and repo-hosting CLIs, set cwd to `repos/REPO_NAME`; never run from sandbox root when more than one clone exists. Treat red CI as data, not shell failure: prefer structured status queries over status commands that fail on red checks.
 - Execute returns stdout/stderr automatically. Do not pass `stdout` or `stderr` objects unless you explicitly want to discard output.
 - Write or create a file: Edit/Write when the active schema exposes them. Writable scope: your sandbox only.
 - Repo-hosting PR/issue work: there are no hidden keeper-native PR/issue tools. If an assigned task explicitly requires a repo-hosting operation and Execute is visible, use the ordinary CLI through typed `executable`/`argv` from a scoped repo cwd. Create or edit PRs only after pushing from the prepared repo checkout.
@@ -90,18 +90,18 @@ File operations:
 Sandbox layout (NOT `/workspace` — that path does not exist; see <world> WRONG paths):
 - Your sandbox has three lanes:
   - `mind/` — notes, drafts, scratchpads
-  - `repos/` — git clones (one per repo, e.g. `repos/REPO_NAME/`) — task work should happen inside `repos/REPO_NAME/.worktrees/TASK_NAME/`
+  - `repos/` — git clones (one per repo, e.g. `repos/REPO_NAME/`) — task work should happen inside `repos/REPO_NAME/`
   - `.` — general sandbox files
 - All paths come from keeper_context_status: use `sandbox_root`, `sandbox_mind`, `sandbox_repos` directly.
 - Clones: use the exact tool listed in your active schema. If no clone path is visible, report the blocker instead of inventing hidden shell tools.
 
 Repo setup:
 1. If `repos/REPO` is missing AND the task names a repo under ALLOWED (and not DENIED — see the world block), use the exact allowed tool or Execute path allowed by the active schema. If no such path is allowed, report the missing clone as a blocker.
-2. Work in `repos/{repo}/.worktrees/{task}/` for code/PR changes. If that worktree is missing, report the blocker or use the visible worktree/provisioning workflow when assigned. If the checkout is dirty before you start, report that blocker instead of layering on another checkout. If multiple clones exist and the task has no clear repo evidence, report the ambiguity instead of guessing.
+2. Work in your clone `repos/{repo}/` for code/PR changes — this clone is your individual workspace. Create a task branch from the fetched origin default branch (`git fetch origin`, then `git checkout -b {your-name}/{task} origin/main`) before editing; do not edit on the root `main` checkout. A git worktree is optional and is not provisioned for you — use `git worktree add -b {your-name}/{task} .worktrees/{task} origin/main` only if you choose to keep several branches checked out at once. If the checkout is dirty before you start, report that blocker instead of layering on another checkout. If multiple clones exist and the task has no clear repo evidence, report the ambiguity instead of guessing.
 3. If setup returns `ok: false`, STOP. Read `detail.hint`, retry once if there's a concrete fix, otherwise report via `keeper_broadcast`.
 
 PR workflow (write/execute-capable schema required):
-1. Work inside `repos/{repo}/.worktrees/{task}/`. Run `git status --short`; if clean, create/switch the task branch there. If it is dirty before you start, stop and report the blocker.
+1. Work inside your clone `repos/{repo}/`. Run `git status --short`; if clean, create or switch to the task branch (`git fetch origin`, then `git checkout -b {your-name}/{task} origin/main`). If it is dirty before you start, stop and report the blocker.
 2. `Read`/`Grep` -> `Edit`/`Write` — read first, then edit
 3. `Execute executable="git" argv=["status","--short"]` → `git add path/to/file` → `git commit -m ...` → `git push -u origin HEAD` — all as typed argv calls with cwd inside the prepared repo checkout
 4. Use Execute typed argv to open or update the remote PR after push, only for the assigned repo checkout.

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -49,14 +49,14 @@ Passive discovery tools (`keeper_tool_search` when visible, `keeper_tools_list`,
 ## Sandbox path conventions
 
 Your shell starts at the sandbox root, which is **not** a git repository.
-- Repos live at `repos/REPO_NAME/`.
-- For assigned code/PR work, work inside an existing task worktree: `repos/REPO_NAME/.worktrees/TASK_NAME/`. Do not use the direct repo root checkout as your task workspace.
+- Repos live at `repos/REPO_NAME/` — each clone is your own individual workspace.
+- For assigned code/PR work, work directly in your clone `repos/REPO_NAME/` on a task branch. Create it from the fetched origin default branch (`git fetch origin`, then `git checkout -b {your-name}/TASK_ID origin/main`) before editing; do not edit on the root `main` checkout. A git worktree is optional and is not provisioned for you — use `git worktree add` only if you choose to keep more than one branch checked out at once.
 - For `git` or any repo/forge CLI that needs a working copy, set `cwd` to the specific repo/worktree path when using Execute.
-  - Example for task work: `Execute { executable: "git", argv: ["log", "--oneline", "-5"], cwd: "repos/REPO_NAME/.worktrees/TASK_NAME" }`.
+  - Example for task work: `Execute { executable: "git", argv: ["log", "--oneline", "-5"], cwd: "repos/REPO_NAME" }`.
   - Execute accepts typed `executable`/`argv` or explicit `pipeline: [{ executable, argv }, ...]`; do not prepend `cd repos/REPO_NAME && ...`; use `cwd` instead.
 - For code search, do not run Execute pipelines like `cd repos/REPO && grep -rn "term" lib/ | head -40`. Use `Grep { pattern: "term", path: "lib", glob: "*.ml" }` when Grep is visible, or one scoped typed Execute argv call. To find a function/type definition, search the exact symbol with `Grep`; do not ask `keeper_tool_search` for source symbols.
 - `Read` does not support `start_line`, `end_line`, `offset`, or line-count limits. Its `limit` field is an approximate maximum byte count. After `Grep` finds the relevant file/line, use one scoped typed `Execute` command for a line slice if you need exact surrounding lines.
-- Do not scan all clones from Execute. Replace `rg term repos/` with `Grep { pattern: "term", path: "repos/REPO_NAME/.worktrees/TASK_NAME/lib" }`, and replace `git log --all --grep=term | head` with a scoped `Execute { executable: "git", argv: ["log", "--oneline", "-5", "--grep=term"], cwd: "repos/REPO_NAME/.worktrees/TASK_NAME" }`.
+- Do not scan all clones from Execute. Replace `rg term repos/` with `Grep { pattern: "term", path: "repos/REPO_NAME/lib" }`, and replace `git log --all --grep=term | head` with a scoped `Execute { executable: "git", argv: ["log", "--oneline", "-5", "--grep=term"], cwd: "repos/REPO_NAME" }`.
 - Read-only Execute can run local main-branch recovery. For branch checks, use `git status --short --branch`, `git branch --show-current`, or `git worktree list`; use `git checkout main` or `git switch main` only to restore the repo checkout to main.
 - Do not use shell existence tests or shell control flow such as `ls path 2>/dev/null && echo EXISTS || echo NOT_FOUND`. Use `Read`, `Grep`, or one typed `Execute` argv call and let the tool error explain missing paths.
 - Do not put glob patterns into Execute path arguments, such as `find repos/REPO/lib -name nickname*`. Use Grep so the structured tool owns the pattern.

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -31,7 +31,7 @@ WRONG paths (these do not exist or cause doubling errors):
 
 Tools automatically resolve paths relative to your sandbox root.
 When passing `path` or `cwd` to keeper tools:
-- Use: `repos/REPO_NAME/.worktrees/TASK_NAME/lib/foo.ml` for assigned code work, or `repos/REPO_NAME/lib/foo.ml` only for explicit read-only repo-root inspection.
+- Use: `repos/REPO_NAME/lib/foo.ml` for code work — your clone is your workspace; create a task branch there (see Paths and Identity above).
 - Use: `mind/notes.md`
 - NOT: a copied host storage prefix plus `/repos/REPO_NAME/lib/foo.ml`
 - NOT: a guessed host absolute path outside the sandbox path returned by your tools

--- a/config/prompts/tool_contract.task_lifecycle_workflow.md
+++ b/config/prompts/tool_contract.task_lifecycle_workflow.md
@@ -2,4 +2,4 @@
 description: MASC task lifecycle workflow shared by MCP profile instructions
 category: tool_contract
 ---
-masc_status -> masc_transition(claim) -> masc_transition(start) -> work in a repo-local worktree -> masc_transition(done)
+masc_status -> masc_transition(claim) -> masc_transition(start) -> work in your repo clone on a task branch -> masc_transition(done)


### PR DESCRIPTION
## 문제 (evidence-grounded)

keeper Execute census(`~/.masc/tool_calls/2026-06/{08..14}.jsonl`)에서 worktree 경합 실패 **92 records / 184 occurrences**: `fatal: 'main' is already used by worktree`. keeper(`taskmaster`/`sangsu`/`issue_king` 등)가 `git worktree add .worktrees/<task> main`을 직접 시도 → per-keeper clone 루트가 `main`을 점유해 거부.

## 근본 원인: prompt ↔ architecture split-brain

오너가 **#20498 → #20499 → #20508** 3개 PR로 worktree provisioning을 코드와 first-class 개념에서 **의도적으로 전부 제거**했습니다 (제거 목록에 `claim_post_provision` hook 포함). 명시된 원칙:

> Code does not need to know about worktrees. Playground provides individual space; worktree is a git tool keepers use when they choose to.

그러나 프롬프트는 갱신되지 않아:
- `keeper.unified.system.md`, `keeper.capabilities.md`가 여전히 **"`.worktrees/TASK_NAME/`에서 작업하라"** 강제.
- `keeper.capabilities.md`는 **삭제된** "visible worktree/provisioning workflow"를 참조.
- `keeper.world.md`는 자체 모순(line 15-16은 clone 직접 작업, line 34는 worktree 강제).

→ keeper가 존재하지 않는 worktree를 직접 만들려다 92건 실패.

코드는 worktree를 생성하지 않고(전수 확인: provisioning 함수·hook 삭제, `masc_worktree_create` 도구 부재, 생성 스크립트 부재), 도구/스크립트도 없습니다. 즉 코드 provisioner 추가는 #20498-#20508을 되돌리는 리버트이므로 채택하지 않았습니다.

## 변경 (worktree-optional, 오너 원칙 정렬)

keeper-facing worktree **강제**를 전부 제거하고 **선택**으로 전환:
- per-keeper clone `repos/REPO_NAME/`이 개별 작업 공간. 코드 작업은 fetched origin에서 task 브랜치를 만들어 진행 (`git fetch origin` 후 `git checkout -b <name>/<task> origin/main`).
- worktree는 선택이며 provisioning되지 않음. 선택 시 올바른 incantation(`git worktree add -b <name>/<task> .worktrees/<task> origin/main`, 점유된 `main` 브랜치 대신 `origin/main` ref)을 명시.
- 죽은 "worktree/provisioning workflow" 참조 제거.

이로써 #20498-#20508 worktree purge의 프롬프트 측을 완성하고, RFC-0210 §64가 deferred한 "cut task branches from fresh origin/main at task start"를 코드가 아닌 **가이드**로 달성합니다.

## 경계

config-only. **OAS·런타임 코드 변경 0**. git auth는 keeper-runtime 관심사이지 OAS 관심사가 아님(별도 RFC-0236).

## 변경 파일 (6)

`keeper.capabilities.md`, `keeper.unified.system.md`, `keeper.world.md`, `tool_contract.task_lifecycle_workflow.md`, `config/keepers/base.toml`, `config/personas/issue_king/profile.json`.

유지(정당): read-only `git worktree list`, write-schema에서 optional `git worktree add`, janitor의 stale worktree 정리, verifier의 worktree-부재 수용.

## RFC discovery

변경 영역 `config/prompts`·`config/keepers`·`config/personas`는 agent_delegation RFC-게이트 목록(credential/operator/sandbox/dashboard-credential/hooks/workflow)에 해당하지 않음. 관련 아키텍처 결정 인용: **#20508, #20498, #20499** (worktree 제거), **RFC-0210** (§64 deferred task-branch-from-origin/main), issue **#21147** (근본원인 재진단).

## 검증

- 프롬프트 내용을 검증하는 drift-guard 테스트 0건 (프롬프트 .md를 load/assert하는 test 부재 확인).
- `.worktrees/` 경로 처리 로직/테스트(`test_worktree_detection.ml` 등)는 worktree가 여전히 optional이므로 유지 — 변경 없음.
- JSON(`issue_king/profile.json`)·TOML(`base.toml`) 파싱 유효성 확인.
- worktree **강제** 잔존 0건 (남은 참조는 전부 optional/read-only/janitor/verifier).

## Follow-up (별도)

죽은 `lib/playground_repo_readiness.ml`(lib/bin 0 refs)의 next_action 문자열이 아직 worktree 생성을 안내하지만 keeper에 도달하지 않음. 모듈 fate는 #21147에서 다룸.

## CI note

`# ci:skip-test-coverage` — config/prompts + persona/keeper content 변경이라 테스트할 코드 경로가 없음. worktree 문자열 부재를 assert하는 prompt drift-guard 테스트는 substring-classifier 안티패턴(CLAUDE.md workaround signature #2)이라 추가하지 않고, 스크립트가 제공하는 sanctioned coverage opt-out을 사용. (별도 고려: `config/prompts/*.md`를 `check_test_coverage.py`의 `COVERED_CODE_PATHS`에서 제외하는 것이 더 근본적 — 오너 판단 사안.)

Refs: #21147, #20508, #20498, #20499, RFC-0210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
