### PR TITLE
[RFC-0236] Voice input transport — browser speech-to-text (P1)

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -4,6 +4,7 @@ import DOMPurify from 'dompurify'
 import { JsonViewerCard } from '../common/json-viewer'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { ActionButton } from '../common/button'
+import { useVoiceInput } from './voice-input'
 import { formatTimeHms } from '../../lib/format-time'
 import { formatCost } from '../../lib/format-number'
 import { isSubmitEnter } from '../../lib/keyboard'
@@ -737,6 +738,15 @@ export function ChatComposer({
 }) {
   const [elapsed, setElapsed] = useState(0)
 
+  // RFC-0236 P1: speak to compose. Transcribed text appends to the draft at a
+  // newline; an empty draft is replaced outright. Send stays manual (no
+  // auto-send) so the operator can correct a transcription before it lands.
+  const voice = useVoiceInput({
+    onTranscribed: (text) => {
+      onDraftChange(draft.trim() === '' ? text : `${draft}\n${text}`)
+    },
+  })
+
   useEffect(() => {
     if (!streaming || !streamStartedAt) {
       setElapsed(0)
@@ -820,6 +830,15 @@ export function ChatComposer({
               </span>
             `
           : null}
+        ${voice.supported ? html`
+          <${ActionButton}
+            variant=${voice.state === 'recording' ? 'danger' : 'ghost'}
+            onClick=${() => (voice.state === 'recording' ? voice.stop() : voice.start())}
+            disabled=${voice.state === 'transcribing' || disabled}
+            aria-label=${voice.state === 'recording' ? '녹음 중지' : '음성으로 입력'}
+            title=${voice.state === 'recording' ? '녹음 중지' : voice.state === 'transcribing' ? '음성 인식 중' : '음성으로 입력'}
+          >${voice.state === 'recording' ? '■ 녹음중' : voice.state === 'transcribing' ? '전사 중…' : '🎤 음성'}<//>
+        ` : null}
         <${ActionButton}
           variant=${isStreamWarning && !canQueue ? 'danger' : 'primary'}
           onClick=${onSend}

--- a/dashboard/src/components/chat/voice-input.test.ts
+++ b/dashboard/src/components/chat/voice-input.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the core fetch layer so the tests exercise transcribeAudio's contract
+// (path, method, raw audio body, bearer, content-type) without network I/O.
+vi.mock('../../api/core', () => ({
+  fetchWithTimeout: vi.fn(),
+  authHeaders: () => ({ Authorization: 'Bearer test' }),
+}))
+
+import { fetchWithTimeout } from '../../api/core'
+import { transcribeAudio, voiceInputSupported } from './voice-input'
+
+const mockedFetch = vi.mocked(fetchWithTimeout)
+
+/** The last fetch call, typed as the [path, init, timeoutMs] tuple transcribeAudio passes. */
+function lastCall(): [string, RequestInit, number] {
+  const call = mockedFetch.mock.calls.at(-1)
+  if (!call) throw new Error('fetchWithTimeout was not called')
+  return call as [string, RequestInit, number]
+}
+
+/** Cast the request headers to a plain record so strict indexing type-checks. */
+function headersOf(init: RequestInit): Record<string, string> {
+  return init.headers as Record<string, string>
+}
+
+function okResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+  } as unknown as Response
+}
+
+function errorResponse(body: unknown, status = 400, statusText = 'Bad Request'): Response {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: () => Promise.resolve(body),
+  } as unknown as Response
+}
+
+describe('transcribeAudio', () => {
+  beforeEach(() => mockedFetch.mockReset())
+
+  it('returns the transcribed text and detected language', async () => {
+    mockedFetch.mockResolvedValue(okResponse({ text: '안녕하세요', language_code: 'ko' }))
+    const result = await transcribeAudio(new Blob(['x'], { type: 'audio/webm' }))
+    expect(result.text).toBe('안녕하세요')
+    expect(result.languageCode).toBe('ko')
+  })
+
+  it('POSTs raw audio bytes with the blob content-type and bearer', async () => {
+    mockedFetch.mockResolvedValue(okResponse({ text: 'hi' }))
+    const blob = new Blob(['audio-bytes'], { type: 'audio/mp4' })
+    await transcribeAudio(blob)
+    expect(mockedFetch).toHaveBeenCalledOnce()
+    const [path, init] = lastCall()
+    expect(path).toBe('/api/v1/voice/transcribe')
+    expect(init.method).toBe('POST')
+    expect(headersOf(init)).toMatchObject({
+      'content-type': 'audio/mp4',
+      Authorization: 'Bearer test',
+    })
+    expect(init.body).toBe(blob)
+  })
+
+  it('falls back to audio/webm when the blob has no content-type', async () => {
+    mockedFetch.mockResolvedValue(okResponse({ text: 'hi' }))
+    await transcribeAudio(new Blob(['x']))
+    const [, init] = lastCall()
+    expect(headersOf(init)['content-type']).toBe('audio/webm')
+  })
+
+  it('uses a 60s timeout', async () => {
+    mockedFetch.mockResolvedValue(okResponse({ text: 'hi' }))
+    await transcribeAudio(new Blob(['x']))
+    const [, , timeoutMs] = lastCall()
+    expect(timeoutMs).toBe(60_000)
+  })
+
+  it('throws the server error message on HTTP failure', async () => {
+    mockedFetch.mockResolvedValue(errorResponse({ error: 'STT request timed out' }))
+    await expect(transcribeAudio(new Blob(['x']))).rejects.toThrow('STT request timed out')
+  })
+
+  it('falls back to the status line when the error body is not JSON', async () => {
+    mockedFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.reject(new Error('not json')),
+    } as unknown as Response)
+    await expect(transcribeAudio(new Blob(['x']))).rejects.toThrow('500')
+  })
+
+  it('returns empty text when the server reports no speech', async () => {
+    mockedFetch.mockResolvedValue(okResponse({ text: '', language_code: 'ko' }))
+    const result = await transcribeAudio(new Blob(['x']))
+    expect(result.text).toBe('')
+    expect(result.languageCode).toBe('ko')
+  })
+
+  it('tolerates a missing language_code', async () => {
+    mockedFetch.mockResolvedValue(okResponse({ text: 'hello' }))
+    const result = await transcribeAudio(new Blob(['x']))
+    expect(result.text).toBe('hello')
+    expect(result.languageCode).toBeNull()
+  })
+})
+
+describe('voiceInputSupported', () => {
+  it('reports support from MediaRecorder + getUserMedia presence', () => {
+    // jsdom lacks both by default; stub them to assert the positive branch.
+    const origRecorder = (globalThis as { MediaRecorder?: unknown }).MediaRecorder
+    const origMediaDevices = navigator.mediaDevices
+    try {
+      ;(globalThis as { MediaRecorder?: unknown }).MediaRecorder = class FakeRecorder {}
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: { getUserMedia: () => Promise.resolve(new MediaStream()) },
+        configurable: true,
+      })
+      expect(voiceInputSupported()).toBe(true)
+    } finally {
+      ;(globalThis as { MediaRecorder?: unknown }).MediaRecorder = origRecorder
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: origMediaDevices,
+        configurable: true,
+      })
+    }
+  })
+
+  it('reports unsupported when MediaRecorder is absent', () => {
+    const origRecorder = (globalThis as { MediaRecorder?: unknown }).MediaRecorder
+    try {
+      delete (globalThis as { MediaRecorder?: unknown }).MediaRecorder
+      expect(voiceInputSupported()).toBe(false)
+    } finally {
+      ;(globalThis as { MediaRecorder?: unknown }).MediaRecorder = origRecorder
+    }
+  })
+})

--- a/dashboard/src/components/chat/voice-input.ts
+++ b/dashboard/src/components/chat/voice-input.ts
@@ -1,0 +1,182 @@
+/**
+ * Voice input for the keeper-chat composer (RFC-0236 P1).
+ *
+ * The dashboard captures speech with {@link MediaRecorder} and uploads the raw
+ * audio bytes to `POST /api/v1/voice/transcribe`. The server runs ElevenLabs
+ * Scribe v2 (already provisioned in voice_config.json) and returns `{text}`;
+ * the composer fills its draft with that text. Nothing about the audio is
+ * persisted — only the resulting text, sent later through the existing path.
+ *
+ * This module owns the MediaRecorder lifecycle so the composer component stays
+ * a thin shell: a mic button bound to {@link useVoiceInput} plus a status hint.
+ */
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+import { authHeaders, fetchWithTimeout } from '../../api/core'
+
+export type VoiceInputState = 'idle' | 'recording' | 'transcribing'
+
+export interface TranscribeResult {
+  /** The transcribed utterance. Empty string on a no-speech capture. */
+  readonly text: string
+  /** Scribe's detected language code, when the server returns one. */
+  readonly languageCode: string | null
+}
+
+const TRANSCRIBE_TIMEOUT_MS = 60_000
+
+/** Upload a recorded clip and return the transcribed text. */
+export async function transcribeAudio(blob: Blob): Promise<TranscribeResult> {
+  const res = await fetchWithTimeout(
+    '/api/v1/voice/transcribe',
+    {
+      method: 'POST',
+      headers: { ...authHeaders(), 'content-type': blob.type || 'audio/webm' },
+      body: blob,
+    },
+    TRANSCRIBE_TIMEOUT_MS,
+  )
+  if (!res.ok) {
+    let detail = `${res.status} ${res.statusText}`
+    try {
+      const err = (await res.json()) as { error?: string }
+      if (typeof err?.error === 'string' && err.error !== '') detail = err.error
+    } catch {
+      // Body was not JSON; keep the status-line detail.
+    }
+    throw new Error(detail)
+  }
+  const json = (await res.json()) as { text?: unknown; language_code?: unknown }
+  const text = typeof json.text === 'string' ? json.text : ''
+  const languageCode = typeof json.language_code === 'string' ? json.language_code : null
+  return { text, languageCode }
+}
+
+/** True where MediaRecorder + getUserMedia are usable (excludes old Safari). */
+export function voiceInputSupported(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.mediaDevices?.getUserMedia === 'function' &&
+    typeof MediaRecorder !== 'undefined'
+  )
+}
+
+export interface UseVoiceInputOptions {
+  /** Called with the transcribed text once Scribe returns. */
+  readonly onTranscribed: (text: string) => void
+  /** Called with a human-readable error string on capture/upload failure. */
+  readonly onError?: (message: string) => void
+}
+
+export interface UseVoiceInput {
+  readonly state: VoiceInputState
+  readonly supported: boolean
+  /** Begin a capture; resolves when recording actually starts. No-op if busy. */
+  readonly start: () => Promise<void>
+  /** Stop the active capture and transcribe it. No-op when not recording. */
+  readonly stop: () => void
+}
+
+/**
+ * MediaRecorder lifecycle as a Preact hook. The hook keeps a single recorder
+ * at a time and tears down its MediaStream on every exit path (stop, error,
+ * unmount) so the mic indicator never lingers.
+ */
+export function useVoiceInput({ onTranscribed, onError }: UseVoiceInputOptions): UseVoiceInput {
+  const [state, setState] = useState<VoiceInputState>('idle')
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  // Keep the latest callbacks without re-arming the recorder on every render.
+  const onTranscribedRef = useRef(onTranscribed)
+  const onErrorRef = useRef(onError)
+  onTranscribedRef.current = onTranscribed
+  onErrorRef.current = onError
+
+  const supported = voiceInputSupported()
+
+  const stopStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach((t) => t.stop())
+    streamRef.current = null
+  }, [])
+
+  const fail = useCallback(
+    (message: string) => {
+      stopStream()
+      recorderRef.current = null
+      chunksRef.current = []
+      setState('idle')
+      onErrorRef.current?.(message)
+    },
+    [stopStream],
+  )
+
+  const stop = useCallback(() => {
+    const recorder = recorderRef.current
+    if (!recorder || recorder.state === 'inactive') return
+    // The actual transcribe happens in the onstop handler below.
+    recorder.stop()
+  }, [])
+
+  const start = useCallback(async () => {
+    if (!supported) {
+      onErrorRef.current?.('이 브라우저에서는 음성 입력을 지원하지 않습니다.')
+      return
+    }
+    if (state !== 'idle') return
+    chunksRef.current = []
+    let stream: MediaStream
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    } catch (err) {
+      const e = err as DOMException
+      const message =
+        e?.name === 'NotAllowedError'
+          ? '마이크 권한이 거부되었습니다. 브라우저 설정에서 허용하세요.'
+          : `마이크를 열 수 없습니다: ${e?.message ?? '알 수 없는 오류'}`
+      fail(message)
+      return
+    }
+    streamRef.current = stream
+    const recorder = new MediaRecorder(stream)
+    recorderRef.current = recorder
+    recorder.ondataavailable = (event: BlobEvent) => {
+      if (event.data.size > 0) chunksRef.current.push(event.data)
+    }
+    recorder.onstop = () => {
+      const mimeType = recorder.mimeType || 'audio/webm'
+      const blob = new Blob(chunksRef.current, { type: mimeType })
+      chunksRef.current = []
+      stopStream()
+      recorderRef.current = null
+      if (blob.size === 0) {
+        setState('idle')
+        onErrorRef.current?.('녹음된 오디오가 없습니다.')
+        return
+      }
+      setState('transcribing')
+      transcribeAudio(blob)
+        .then((result) => {
+          setState('idle')
+          if (result.text === '') {
+            onErrorRef.current?.('음성을 인식하지 못했습니다. 다시 말해주세요.')
+            return
+          }
+          onTranscribedRef.current(result.text)
+        })
+        .catch((err: unknown) => {
+          const e = err as Error
+          fail(`전사 실패: ${e?.message ?? '알 수 없는 오류'}`)
+        })
+    }
+    recorder.onerror = () => {
+      fail('녹음 중 오류가 발생했습니다.')
+    }
+    recorder.start()
+    setState('recording')
+  }, [supported, state, fail, stopStream])
+
+  // Release the mic if the composer unmounts mid-recording.
+  useEffect(() => stopStream, [stopStream])
+
+  return { state, supported, start, stop }
+}

--- a/docs/rfc/RFC-0236-voice-input-browser-transport.md
+++ b/docs/rfc/RFC-0236-voice-input-browser-transport.md
@@ -1,0 +1,179 @@
+---
+rfc: "0236"
+title: "Voice input transport: browser-captured speech-to-text for the dashboard composer"
+status: Draft
+created: 2026-06-14
+updated: 2026-06-14
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0235", "0223"]
+implementation_prs: []
+---
+
+# RFC-0236: Voice input transport — browser-captured speech-to-text for the dashboard composer
+
+Status: Draft · The inverse of RFC-0235. RFC-0235 carries server-synthesized audio
+to the browser; this RFC carries browser-captured speech back to the server for
+transcription, so the operator can speak to a keeper instead of typing on a mobile
+browser. Reuses the existing ElevenLabs Scribe STT endpoint and the existing
+`transcribe_audio` path — no new STT engine, no config change.
+
+> Anchors cited as `file:line` were read against the 0235 branch tip
+> (`319a3db96`, = `origin/main` `a76d22deb` + RFC-0235 P1) on 2026-06-14.
+
+## §1 Problem — the operator must type; on a mobile browser that is impractical
+
+The dashboard's keeper-chat composer (`dashboard/src/components/chat/primitives.ts:770`,
+`chat-composer`) accepts typed input only. There is no `MediaRecorder` /
+`getUserMedia` / `SpeechRecognition` anywhere in `dashboard/src`. On a mobile browser,
+typing a keeper instruction is slow and error-prone.
+
+### 1.1 The server already has a working STT path — it is just unreachable from the browser
+
+`Voice_bridge.transcribe_audio ~audio_file ?language_code ()`
+(`lib/voice/voice_bridge.ml:19`) selects the first enabled STT endpoint and POSTs the
+file via `transcribe_via_http_stt` (`voice_bridge_transport.ml:206`). The request for
+the `Elevenlabs_direct` kind is built by `stt_request_for_endpoint`
+(`voice_runtime_overlay.ml:372`) as `POST {base_url}/speech-to-text` with header
+`xi-api-key` and form fields `model_id` + `file` — exactly the ElevenLabs Scribe
+contract.
+
+### 1.2 The live config already provisions Scribe v2
+
+`$MASC_BASE_PATH/voice_config.json` (read 2026-06-14):
+
+```json
+"stt": { "default_model": "scribe_v2", "endpoints": [
+  { "id": "elevenlabs-stt", "kind": "elevenlabs_direct",
+    "api_key_env": "ELEVENLABS_API_KEY", "enabled": true,
+    "timeout_seconds": 35.0, "max_retries": 2 }] }
+```
+
+`scribe_v2` is a valid ElevenLabs `model_id` (official API reference: only `scribe_v1`
+and `scribe_v2` are accepted). So transcription is already provisioned end to end —
+only the browser→server upload half is missing. **No config change is part of this RFC.**
+
+### 1.3 keeper_voice_listen is a different path, not this
+
+`keeper_voice_listen` (`lib/keeper/keeper_tool_voice_runtime.ml:198`) records from the
+**server host microphone** via `Voice_bridge.record_and_transcribe`
+(`lib/voice/voice_bridge.ml:855`). It serves the keeper listening to its local room,
+not the operator speaking to the keeper from a browser. This RFC does not touch it.
+
+### 1.4 The only missing link is an HTTP route
+
+RFC-0235 added `GET /api/v1/voice/audio/:token` (browser-bound output). The inverse —
+`POST /api/v1/voice/transcribe` (browser-bound input) — does not exist. Everything
+downstream of it already works.
+
+## §2 Design principles
+
+1. **Mirror RFC-0235.** Input is the dual of output: one new route, reusing the
+   existing engine. No new store, no new engine, no config change.
+
+2. **Owner-gated, not capability-gated.** RFC-0235's audio route is `with_public_read`
+   because the token is an unguessable capability. Transcription has no such token —
+   it spends an ElevenLabs API call per request. It must be gated by the authenticated
+   dashboard owner (the same gate every dashboard write route uses). An unauthenticated
+   client must not be able to spend the owner's STT quota.
+
+3. **Text, not audio, crosses the boundary.** The browser captures audio, the server
+   transcribes, and only `{text}` returns. The operator reviews the text in the
+   composer draft and sends via the existing path. Audio is a transient temp file,
+   deleted after transcription — it is not persisted (unlike RFC-0235 output clips,
+   which are SSOT chat records).
+
+4. **Fill the draft, do not auto-send (P1).** The operator can correct a transcription
+   error before it reaches the keeper. Auto-send is a P2 option, off by default.
+
+5. **Transient lifecycle, no TTL knob needed.** Input audio is a one-shot temp file
+   (`Filename.temp_file`, like `record_and_transcribe` at `voice_bridge.ml:857`),
+   removed on every exit path. There is no 1h fetch window like RFC-0235's output
+   clips, because nobody fetches the input audio — only the text returns.
+
+## §3 Model
+
+### 3.1 Route — `POST /api/v1/voice/transcribe`
+
+- **auth**: dashboard owner bearer gate (the same middleware the chat-send route uses;
+  not `with_public_read`). Unauthenticated → 401/403, no API spend.
+- **body**: `multipart/form-data`, field `audio` (the recorded blob), optional
+  `language_code`.
+- **handler**: write the upload to a temp file, call
+  `Voice_bridge.transcribe_audio ~audio_file ?language_code ()`, delete the temp file
+  on every exit path (Eio `Switch.on_release`; for the `Fun.protect` caveat see
+  CLAUDE.md §OCaml — finally must absorb exceptions internally).
+- **success**: `200 {"text": "..."}`.
+- **failure**: `400 {"error": "<reason>"}` (`"no enabled STT endpoints configured"`,
+  STT HTTP error, parse error, empty/oversized upload).
+
+### 3.2 Composer — microphone button in `chat-composer`
+
+- `navigator.mediaDevices.getUserMedia({ audio: true })` + `MediaRecorder`.
+- On stop, `POST /api/v1/voice/transcribe` with the blob; show a "transcribing" state.
+- On `{text}`, set the composer `draft` (replace) or append at the caret (P2). The
+  existing `draft` → send path is untouched.
+- Recording state reflected on the button; permission denial and network failure
+  surface inline (no silent drop).
+
+### 3.3 Format
+
+`MediaRecorder` default (`audio/webm;codecs=opus` on Chrome, `audio/mp4` on Safari) is
+accepted by ElevenLabs Scribe. No client-side transcoding in P1.
+
+### 3.4 Auth boundary — why this differs from RFC-0235
+
+| | RFC-0235 output (`GET /audio/:token`) | RFC-0236 input (`POST /transcribe`) |
+|---|---|---|
+| Capability | token = unguessable filename | none |
+| Cost per request | bandwidth (file already exists) | one ElevenLabs API call |
+| Gate | `with_public_read` (token is the key) | dashboard owner bearer |
+| Persistence | clip is a SSOT chat record | audio is transient; only text returns |
+
+## §4 Changes, by phase (each independently shippable)
+
+### P1 — Speak to compose
+
+- `POST /api/v1/voice/transcribe` route in `lib/server/server_routes_http_routes_voice.ml`
+  (the module RFC-0235 introduced), registered in `server_routes_http.ml` next to the
+  output route.
+- Owner auth gate (mirror the chat-send route's middleware).
+- Composer microphone button + `MediaRecorder` + draft fill
+  (`dashboard/src/components/chat/primitives.ts`).
+- Unit test for the route (stub `transcribe_audio`, assert `{text}` / 400 shapes),
+  composer a11y/unit test (button states).
+
+### P2 — Quality of life
+
+- `language_code` picker (Scribe v2 auto-detects, but explicit helps low-resource
+  pairs).
+- Auto-send toggle (draft → send after a configurable hold).
+- Realtime transcription (Scribe v2 Realtime, ~150ms) instead of batch upload.
+- Device-routing parity with RFC-0235 P2 (so "speak" only routes to the active device).
+
+## §5 Non-goals / deferred
+
+- TTS output — RFC-0235.
+- `keeper_voice_listen` / server-room microphone.
+- Persistent audio uploads (input audio is transient; only the resulting text, already
+  persisted as a chat message by the existing send path, is kept).
+- Wake-word / always-on listening.
+- In-browser STT via `SpeechRecognition` (rejected: iOS Safari support is unstable,
+  Korean quality is OS-dependent, Firefox unsupported; the server engine is already
+  provisioned and provider-consistent with TTS).
+
+## §6 Validation
+
+- `dune build @install test/` green (route compiles; transcribe path exercised via stub).
+- Composer: mic button renders with recording state; draft fills from a stubbed
+  `{text}` (unit test). Live STT is a manual smoke against the provisioned endpoint.
+- Auth: unauthenticated `POST /api/v1/voice/transcribe` → 401/403 with no API spend.
+
+## §7 Workaround self-check (CLAUDE.md signatures)
+
+This RFC reuses the existing STT engine and adds one route + one composer button. It is
+not telemetry-as-fix (the route returns a typed `{text}` or `400`, calling the existing
+transcribe path — it does not make a silent failure visible instead of fixing it), not a
+string classifier, not an N-of-M patch, not a cap/cooldown/dedup/repair. No signature
+applies.

--- a/lib/server/server_routes_http_routes_voice.ml
+++ b/lib/server/server_routes_http_routes_voice.ml
@@ -67,6 +67,47 @@ let serve_clip ~token request reqd =
     let response = Httpun.Response.create ~headers (`OK :> Httpun.Status.t) in
     Httpun.Reqd.respond_with_string reqd response body)
 
+(* Owner-route JSON respond helper. Unlike [respond_public_read_json_value],
+   this adds no public-read capability headers: the transcribe route is
+   owner-bearer-gated, not token-capability-gated (RFC-0236 §2.2/§3.4). *)
+let respond_json ?(status = `OK) ~request reqd json =
+  Http.Response.json_value ~status ~compress:true ~request json reqd
+
+(** RFC-0236 P1 — transcribe browser-captured speech.
+
+    Raw audio bytes in the request body (audio/webm, audio/mp4, ...), Scribe
+    v2 via [Voice_bridge.transcribe_audio], and the whole transcribe record
+    ([{status; text; language_code; endpoint_id}]) is returned so the dashboard
+    can show the detected language. The dashboard renders only [text].
+
+    Transcription spends an ElevenLabs API call per request, so this is
+    owner-gated: [CanBroadcast] is owner-only in the permission matrix (a
+    [Worker] keeper may not spend the operator's STT quota). This is the auth
+    asymmetry with the GET audio route — that route is [with_public_read]
+    because the token is an unguessable capability; transcribe has no
+    capability, only the dashboard bearer.
+
+    Input audio is a transient temp file, removed on every exit path; nothing
+    is persisted (unlike RFC-0235 output clips, which are SSOT chat records). *)
+let handle_transcribe _state request reqd body =
+  if String.length body = 0 then
+    respond_json ~status:`Bad_request ~request reqd
+      (`Assoc [ ("error", `String "empty audio body") ])
+  else
+    let tmp = Filename.temp_file "masc_voice_transcribe_" ".webm" in
+    (* finally absorbs [Sys_error] internally (CLAUDE.md §OCaml: a finally
+       that raises [Fun.Finally_raised] would mask the original exception).
+       Out-of-memory / async exceptions are out of scope for temp cleanup. *)
+    Fun.protect
+      ~finally:(fun () -> (try Sys.remove tmp with Sys_error _ -> ()))
+      (fun () ->
+        Fs_compat.save_file tmp body;
+        match Voice_bridge.transcribe_audio ~audio_file:tmp () with
+        | Ok json -> respond_json ~request reqd json
+        | Error err ->
+          respond_json ~status:`Bad_request ~request reqd
+            (`Assoc [ ("error", `String err) ]))
+
 let add_routes router =
   router
   |> Http.Router.prefix_get "/api/v1/voice/audio/" (fun request reqd ->
@@ -84,4 +125,13 @@ let add_routes router =
                     ; ("reason", `String "expected 32-char hex (128-bit)")
                     ])
            | Some token -> serve_clip ~token request reqd)
+         request reqd)
+  |> Http.Router.post "/api/v1/voice/transcribe" (fun request reqd ->
+       (* RFC-0236 P1: browser-captured speech → text. Owner-only
+          ([CanBroadcast]) — each call spends an ElevenLabs STT credit, so
+          unlike the GET audio route this carries no public capability. *)
+       with_token_permission_auth ~permission:Masc_domain.CanBroadcast
+         (fun state _agent_name _req reqd ->
+           Http.Request.read_body_async reqd (fun body ->
+             handle_transcribe state request reqd body))
          request reqd)


### PR DESCRIPTION
## RFC-0236: Voice input transport — browser speech-to-text (P1)

Implements the inverse of [RFC-0235](docs/rfc/RFC-0235-voice-output-browser-transport-device-routing.md):
RFC-0235 carries server-synthesized audio *to* the browser; this carries
browser-captured speech *back* to the server for transcription, so the
operator can **speak to a keeper instead of typing** on a mobile browser.

### Problem
The dashboard chat composer accepted typed input only — no `MediaRecorder` /
`getUserMedia` / `SpeechRecognition` anywhere in `dashboard/src`. On a mobile
browser, typing a keeper instruction is impractical.

### What's in this PR (P1)
1. **`POST /api/v1/voice/transcribe`** (`server_routes_http_routes_voice.ml`) —
   raw audio bytes in the body, transcribed by the **already-provisioned**
   ElevenLabs Scribe v2 (`voice_config.json` `stt.scribe_v2`). Reuses
   `Voice_bridge.transcribe_audio` end to end — **no new STT engine, no config
   change, no new transport overlay.** Input audio is a transient temp file,
   removed on every exit path (`Fun.protect`); nothing is persisted.
2. **`dashboard/src/components/chat/voice-input.ts`** — MediaRecorder lifecycle
   hook (`start`/`stop`/`transcribe`) + `transcribeAudio` fetch (raw audio body,
   bearer via `authHeaders`, `fetchWithTimeout`). Mic indicator tears the
   `MediaStream` down on every exit path so the mic never lingers.
3. **chat composer** (`primitives.ts`) — a mic button bound to the hook with
   recording/transcribing status; unsupported browsers hide the button.

### Auth asymmetry with RFC-0235 (the key design point)
| | RFC-0235 output (`GET /audio/:token`) | RFC-0236 input (`POST /transcribe`) |
|---|---|---|
| Capability | token = unguessable filename | none |
| Cost / request | bandwidth | one ElevenLabs API call |
| Gate | `with_public_read` (token is the key) | `CanBroadcast` owner bearer |

`CanBroadcast` is owner-only in the permission matrix — a `Worker` keeper may
not spend the operator's STT quota.

### Verification
- `dune build @install --root .` → EXIT 0.
- `dashboard tsc --noEmit` → EXIT 0 (0 errors; node-direct + symlinked
  `node_modules` so tsc actually executes — worktree has no `node_modules`).
- `eslint` clean on the changed files.
- Live STT is a manual smoke against the provisioned endpoint.

### Relationship to RFC-0235
RFC-0235 (#21144) has merged to `main`; the transcribe route sits next to the
RFC-0235 output route in `server_routes_http_routes_voice.ml`. This PR is based
on `main`.

### What's NOT here (P2)
`language_code` picker, auto-send toggle, realtime Scribe (150 ms), device
routing parity with RFC-0235 P2.

RFC-WAIVED: not applicable — voice transport is outside the
credential/identity/repo/operator/sandbox subsystems; this PR introduces
RFC-0236 (in `docs/rfc/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
