### PR TITLE
Fix todo task_done recovery guidance

### DIFF
--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -292,6 +292,10 @@ and handle_transition ~tool_name ~start_time ctx args =
          ?rule_id
          ?tool_suggestion
          ?hint
+         ?recoverable:
+           (match rule_id with
+            | Some "task_done_requires_claimed_or_started" -> Some true
+            | _ -> None)
          ~scope_policy:"observe"
          ~alternatives
          message)

--- a/lib/task/tool_task_payloads.ml
+++ b/lib/task/tool_task_payloads.ml
@@ -68,6 +68,7 @@ let workflow_rejection_payload_json
       ?tool_suggestion
       ?hint
       ?scope_policy
+      ?recoverable
       ?(alternatives = [])
       ?extra_fields
       message
@@ -77,6 +78,7 @@ let workflow_rejection_payload_json
     ?tool_suggestion
     ?hint
     ?scope_policy
+    ?recoverable
     ~alternatives
     ?extra_fields
     message

--- a/lib/task/tool_task_payloads.mli
+++ b/lib/task/tool_task_payloads.mli
@@ -28,6 +28,7 @@ val workflow_rejection_payload_json :
   ?tool_suggestion:string ->
   ?hint:string ->
   ?scope_policy:string ->
+  ?recoverable:bool ->
   ?alternatives:string list ->
   ?extra_fields:(string * Yojson.Safe.t) list ->
   string ->

--- a/lib/task/workflow_rejection_payload.ml
+++ b/lib/task/workflow_rejection_payload.ml
@@ -31,6 +31,7 @@ let payload_json
       ?tool_suggestion
       ?hint
       ?scope_policy
+      ?(recoverable = false)
       ?(alternatives = [])
       ?(extra_fields = [])
       message
@@ -58,7 +59,7 @@ let payload_json
     ; "error", `String message
     ; "failure_class", `String "workflow_rejection"
     ; "error_class", `String "deterministic"
-    ; "recoverable", `Bool false
+    ; "recoverable", `Bool recoverable
     ]
     @ optional_string_field "hint" hint
     @ alternatives_field

--- a/lib/task/workflow_rejection_payload.mli
+++ b/lib/task/workflow_rejection_payload.mli
@@ -5,6 +5,7 @@ val payload_json
   -> ?tool_suggestion:string
   -> ?hint:string
   -> ?scope_policy:string
+  -> ?recoverable:bool
   -> ?alternatives:string list
   -> ?extra_fields:(string * Yojson.Safe.t) list
   -> string

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1842,7 +1842,24 @@ let () = test "handle_done_todo_guidance" (fun () ->
     Task.Tool.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
   in
   assert (not (Tool_result.is_success result));
-  assert (str_contains (Tool_result.message result) "Claim/start it first")
+  assert (str_contains (Tool_result.message result) "Claim/start it first");
+  assert ((Tool_result.failure_class result) = Some Tool_result.Workflow_rejection);
+  let data = Tool_result.data result in
+  assert (Json_util.get_bool data "recoverable" = Some true);
+  assert (
+    match Json_util.assoc_member_opt "diagnosis" data with
+    | Some diagnosis ->
+      Json_util.get_string diagnosis "rule_id"
+      = Some "task_done_requires_claimed_or_started"
+      && Json_util.get_string diagnosis "tool_suggestion"
+         = Some "masc_transition"
+    | None -> false);
+  assert (
+    match Json_util.assoc_member_opt "alternatives" data with
+    | Some (`List alternatives) ->
+      List.exists (( = ) (`String "masc_transition")) alternatives
+      && List.exists (( = ) (`String "keeper_task_claim")) alternatives
+    | _ -> false)
 )
 
 (* Test handle_done reports already-done guidance instead of generic not-claimed *)


### PR DESCRIPTION
## Summary

- Mark the task_done_requires_claimed_or_started workflow rejection as recoverable=true.
- Keep other workflow rejection payloads defaulting to unrecoverable deterministic behavior.
- Strengthen handle_done_todo_guidance coverage to assert recoverability, rule id, suggested next tool, and alternatives.

Closes #21158

## Evidence

Live logs on 2026-06-14 showed keeper_task_done on todo tasks being classified as deterministic_error_workflow_rejection_blocked. The correct next step is not retrying keeper_task_done; it is masc_transition(action=claim) then action=start, so the rejection should remain deterministic but recoverable.

## Verification

- `ocamlformat --check lib/task/workflow_rejection_payload.ml lib/task/workflow_rejection_payload.mli lib/task/tool_task_payloads.ml lib/task/tool_task_payloads.mli lib/task/tool_task.ml test/test_tool_task_coverage.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_tool_task_coverage.exe`
- `./_build/default/test/test_tool_task_coverage.exe test coverage 56`
