### PR TITLE
fix(keeper): remove dead GITHUB_TOKEN allow_exact entry, assert denied (#21148)

### DIFF
--- a/lib/env_keeper_scrub.ml
+++ b/lib/env_keeper_scrub.ml
@@ -30,9 +30,12 @@ let allow_exact : string list =
   ; "HTTP_PROXY"; "HTTPS_PROXY"; "NO_PROXY"
   ; "SSL_CERT_FILE"
 
-    (* GitHub token for gh CLI / API access — explicitly projected by
-       operator into keeper secret dir, not ambient host token. *)
-  ; "GITHUB_TOKEN"; "GH_TOKEN"
+    (* GitHub tokens (GITHUB_TOKEN / GH_TOKEN) are intentionally NOT listed
+       here. They end with the [_TOKEN] deny suffix, so even if listed they
+       would be denied — the operator's ambient host token must never cross
+       into a keeper. The keeper's own GitHub token is supplied out-of-band by
+       [Keeper_secret_projection] (Docker [--env-file] / Local overlay), which
+       bypasses this allowlist. See RFC-0236 §6 and RFC-0007. *)
 
     (* Git user identity — not credentials by themselves. *)
   ; "GIT_AUTHOR_NAME"; "GIT_AUTHOR_EMAIL"

--- a/test/test_env_keeper_scrub.ml
+++ b/test/test_env_keeper_scrub.ml
@@ -8,7 +8,6 @@ let allowed_basic_envs () =
     ; "XDG_CONFIG_HOME"; "XDG_CACHE_HOME"; "XDG_DATA_HOME"
     ; "DOCKER_HOST"; "DOCKER_TLS_VERIFY"; "DOCKER_CERT_PATH"
     ; "HTTP_PROXY"; "HTTPS_PROXY"; "NO_PROXY"; "SSL_CERT_FILE"
-    ; "GITHUB_TOKEN"; "GH_TOKEN"
     ; "GIT_AUTHOR_NAME"; "GIT_AUTHOR_EMAIL"
     ; "GIT_COMMITTER_NAME"; "GIT_COMMITTER_EMAIL"
     ; "MASC_BASE_PATH"; "MASC_CONFIG_DIR"; "MASC_STORAGE_TYPE"
@@ -29,6 +28,11 @@ let denied_secret_suffixes () =
     ; "AWS_ACCESS_KEY_ID"; "AWS_SECRET_ACCESS_KEY"
     ; "MY_CUSTOM_SECRET"; "FOO_PASSWORD"; "BAR_CREDENTIALS"
     ; "MASC_ADMIN_TOKEN"; "MASC_INTERNAL_MCP_TOKEN"
+      (* Operator ambient GitHub tokens must never cross into a keeper; the
+         [_TOKEN] deny suffix enforces this. The keeper's own token is supplied
+         out-of-band by [Keeper_secret_projection], not via this allowlist.
+         See RFC-0236 §6 / RFC-0007. *)
+    ; "GITHUB_TOKEN"; "GH_TOKEN"
     ]
   in
   List.iter


### PR DESCRIPTION
## 요약

`env_keeper_scrub`의 `allow_exact`에 있던 dead `GITHUB_TOKEN`/`GH_TOKEN` 엔트리를 제거하고, `test_env_keeper_scrub`의 모순된 stale 단정(`GITHUB_TOKEN is allowed`)을 올바른 불변식(`denied`)으로 교정합니다. 2026-06-13 머지 감사 후속(#21148), task-948 작업 중 발견.

## 문제

`is_allowed key = (allow_exact || ...) && not (deny_prefix || deny_suffix)`. `GITHUB_TOKEN`/`GH_TOKEN`은 `_TOKEN` deny_suffix에 걸려 `is_allowed`가 **항상 `false`** — `allow_exact` 엔트리가 dead(deny가 항상 이김)입니다.

그런데 `test_env_keeper_scrub.ml`는 이들을 `must_allow`에 넣어 `is_allowed = true`를 단정 → **silent-red**(`GITHUB_TOKEN is allowed`: Expected true, Received false). CI Build and Test를 막지 않아 origin/main에서도 계속 red였습니다(이 exe 미배선).

## 의도는 DENIED — 3중 확정

operator의 ambient GitHub 토큰이 keeper로 넘어가면 안 된다는 것이 의도된 보안 경계입니다:
- `env_keeper_scrub.mli`: "keeper GitHub execution must use the selected MASC credential bundle, never the operator's ambient GitHub token".
- **RFC-0236 §6**: "Security regression: `test_env_keeper_scrub` stays green (operator ambient `GH_TOKEN`/`*_TOKEN` still denied)" — RFC가 이 테스트의 green(=denied 단정)을 명시적으로 기대.
- `test/test_env_git_noninteractive.ml:83-86`이 이미 `GITHUB_TOKEN denied`/`GH_TOKEN denied`를 단정하며 통과 중 — 두 테스트가 모순이었고, denied 쪽이 정본.

keeper 자신의 토큰은 `Keeper_secret_projection`(Docker `--env-file` / Local overlay)으로 별도 주입되며 이 allowlist를 우회합니다 — RFC-0236이 코드 리딩으로 확인.

## 변경

- `lib/env_keeper_scrub.ml`: dead `GITHUB_TOKEN`/`GH_TOKEN` 엔트리 제거. 재추가 방지를 위해 "왜 여기 없는지 + projected 토큰의 정당한 경로(Keeper_secret_projection)"를 주석으로 명시(RFC-0236 §6 / RFC-0007 인용).
- `test/test_env_keeper_scrub.ml`: `GITHUB_TOKEN`/`GH_TOKEN`을 `must_allow`에서 제거하고 `denied_secret_suffixes`의 `must_deny`로 이동. 거짓 `allowed` 단정을 보안 불변식(`denied`)으로 교체 — `test_env_git_noninteractive`와 일치. 누군가 이들을 allowlist에 재추가하고 동시에 `_TOKEN` deny를 풀어 경계를 열면 red로 검출.

## 동작 영향

**런타임 동작 변화 없음**: `is_allowed("GITHUB_TOKEN")`은 전후 모두 `false`. dead 엔트리 제거 + 테스트 진실성 회복뿐. RFC-0236이 추가하려는 git credential helper 경로(별도 overlay)와 직교하며, allow/deny 규칙을 변경하지 않습니다.

## 검증

- `dune build @check` exit 0.
- `test_env_keeper_scrub` green(`GITHUB_TOKEN`/`GH_TOKEN`이 denied로 단정).

RFC-WAIVED: credential 경계(RFC-0007)의 dead-code 제거 + 테스트 교정. allow/deny 정책 불변, RFC-0236 §6이 명시한 불변식과 현실을 일치시킴.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
