### PR TITLE
fix(voice): gate browser STT uploads to admin tokens

### DIFF
--- a/docs/rfc/RFC-0236-voice-input-browser-transport.md
+++ b/docs/rfc/RFC-0236-voice-input-browser-transport.md
@@ -72,11 +72,12 @@ downstream of it already works.
 1. **Mirror RFC-0235.** Input is the dual of output: one new route, reusing the
    existing engine. No new store, no new engine, no config change.
 
-2. **Owner-gated, not capability-gated.** RFC-0235's audio route is `with_public_read`
-   because the token is an unguessable capability. Transcription has no such token —
-   it spends an ElevenLabs API call per request. It must be gated by the authenticated
-   dashboard owner (the same gate every dashboard write route uses). An unauthenticated
-   client must not be able to spend the owner's STT quota.
+2. **Admin/owner-gated, not capability-gated.** RFC-0235's audio route is
+   `with_public_read` because the token is an unguessable capability. Transcription
+   has no such token — it spends an ElevenLabs API call per request. It must be gated
+   by `CanAdmin`, not `CanBroadcast`: worker tokens can broadcast/chat, but must not
+   spend the operator's STT quota. An unauthenticated or worker-token client must not
+   be able to invoke STT.
 
 3. **Text, not audio, crosses the boundary.** The browser captures audio, the server
    transcribes, and only `{text}` returns. The operator reviews the text in the
@@ -96,14 +97,16 @@ downstream of it already works.
 
 ### 3.1 Route — `POST /api/v1/voice/transcribe`
 
-- **auth**: dashboard owner bearer gate (the same middleware the chat-send route uses;
-  not `with_public_read`). Unauthenticated → 401/403, no API spend.
-- **body**: `multipart/form-data`, field `audio` (the recorded blob), optional
-  `language_code`.
+- **auth**: dashboard admin/owner bearer gate (`CanAdmin`, not `with_public_read` and
+  not `CanBroadcast`). Unauthenticated or worker-token requests -> 401/403, no API
+  spend.
+- **body**: raw recorded audio bytes. The `content-type` header is preserved by the
+  browser upload and used only to choose a temp-file suffix (`.webm`, `.mp4`, `.wav`,
+  ...), so the downstream multipart upload presents the provider a plausible filename.
 - **handler**: write the upload to a temp file, call
   `Voice_bridge.transcribe_audio ~audio_file ?language_code ()`, delete the temp file
-  on every exit path (Eio `Switch.on_release`; for the `Fun.protect` caveat see
-  CLAUDE.md §OCaml — finally must absorb exceptions internally).
+  with `Eio.Switch.on_release` on every exit path. The release hook absorbs
+  `Sys_error` internally so it does not mask the original transcribe failure.
 - **success**: `200 {"text": "..."}`.
 - **failure**: `400 {"error": "<reason>"}` (`"no enabled STT endpoints configured"`,
   STT HTTP error, parse error, empty/oversized upload).
@@ -128,7 +131,7 @@ accepted by ElevenLabs Scribe. No client-side transcoding in P1.
 |---|---|---|
 | Capability | token = unguessable filename | none |
 | Cost per request | bandwidth (file already exists) | one ElevenLabs API call |
-| Gate | `with_public_read` (token is the key) | dashboard owner bearer |
+| Gate | `with_public_read` (token is the key) | `CanAdmin` dashboard owner bearer |
 | Persistence | clip is a SSOT chat record | audio is transient; only text returns |
 
 ## §4 Changes, by phase (each independently shippable)
@@ -138,11 +141,13 @@ accepted by ElevenLabs Scribe. No client-side transcoding in P1.
 - `POST /api/v1/voice/transcribe` route in `lib/server/server_routes_http_routes_voice.ml`
   (the module RFC-0235 introduced), registered in `server_routes_http.ml` next to the
   output route.
-- Owner auth gate (mirror the chat-send route's middleware).
+- Admin/owner auth gate (`CanAdmin`); `CanBroadcast` is intentionally too broad for
+  quota-spending STT.
 - Composer microphone button + `MediaRecorder` + draft fill
   (`dashboard/src/components/chat/primitives.ts`).
-- Unit test for the route (stub `transcribe_audio`, assert `{text}` / 400 shapes),
-  composer a11y/unit test (button states).
+- Regression tests for route registration and auth-matrix invariants
+  (`Worker` can `CanBroadcast` but cannot `CanAdmin`), plus composer
+  a11y/unit tests.
 
 ### P2 — Quality of life
 
@@ -165,10 +170,16 @@ accepted by ElevenLabs Scribe. No client-side transcoding in P1.
 
 ## §6 Validation
 
-- `dune build @install test/` green (route compiles; transcribe path exercised via stub).
+- Focused OCaml build: `scripts/dune-local.sh build test/test_http_server_eio.exe
+  test/test_auth.exe test/test_types_coverage.exe`.
+- Route registration: `test_http_server_eio.exe test '^router$' 10`.
+- Auth invariant: `test_auth.exe test '^permissions$'` and
+  `test_types_coverage.exe test '^permissions$'` pin that `Worker` can broadcast but
+  cannot admin.
 - Composer: mic button renders with recording state; draft fills from a stubbed
   `{text}` (unit test). Live STT is a manual smoke against the provisioned endpoint.
-- Auth: unauthenticated `POST /api/v1/voice/transcribe` → 401/403 with no API spend.
+- Auth: unauthenticated or worker-token `POST /api/v1/voice/transcribe` → 401/403
+  with no API spend.
 
 ## §7 Workaround self-check (CLAUDE.md signatures)
 

--- a/lib/server/server_routes_http_routes_voice.ml
+++ b/lib/server/server_routes_http_routes_voice.ml
@@ -73,6 +73,23 @@ let serve_clip ~token request reqd =
 let respond_json ?(status = `OK) ~request reqd json =
   Http.Response.json_value ~status ~compress:true ~request json reqd
 
+let audio_temp_suffix request =
+  let media_type =
+    match Http.Request.header request "content-type" with
+    | None -> ""
+    | Some raw ->
+      let raw = String.lowercase_ascii (String.trim raw) in
+      (match String.index_opt raw ';' with
+       | None -> raw
+       | Some idx -> String.trim (String.sub raw 0 idx))
+  in
+  match media_type with
+  | "audio/mp4" | "audio/x-m4a" -> ".mp4"
+  | "audio/mpeg" | "audio/mp3" -> ".mp3"
+  | "audio/ogg" -> ".ogg"
+  | "audio/wav" | "audio/wave" | "audio/x-wav" -> ".wav"
+  | "audio/webm" | _ -> ".webm"
+
 (** RFC-0236 P1 — transcribe browser-captured speech.
 
     Raw audio bytes in the request body (audio/webm, audio/mp4, ...), Scribe
@@ -81,32 +98,32 @@ let respond_json ?(status = `OK) ~request reqd json =
     can show the detected language. The dashboard renders only [text].
 
     Transcription spends an ElevenLabs API call per request, so this is
-    owner-gated: [CanBroadcast] is owner-only in the permission matrix (a
-    [Worker] keeper may not spend the operator's STT quota). This is the auth
-    asymmetry with the GET audio route — that route is [with_public_read]
-    because the token is an unguessable capability; transcribe has no
-    capability, only the dashboard bearer.
+    admin/owner-gated with [CanAdmin]. [CanBroadcast] is intentionally too
+    broad here: worker tokens have it for normal chat/broadcast writes, but
+    they must not spend the operator's STT quota. This is the auth asymmetry
+    with the GET audio route — that route is [with_public_read] because the
+    token is an unguessable capability; transcribe has no capability, only the
+    dashboard bearer.
 
-    Input audio is a transient temp file, removed on every exit path; nothing
-    is persisted (unlike RFC-0235 output clips, which are SSOT chat records). *)
+    Input audio is a transient temp file registered with the Eio switch for
+    cleanup on every exit path; nothing is persisted (unlike RFC-0235 output
+    clips, which are SSOT chat records). *)
 let handle_transcribe _state request reqd body =
   if String.length body = 0 then
     respond_json ~status:`Bad_request ~request reqd
       (`Assoc [ ("error", `String "empty audio body") ])
   else
-    let tmp = Filename.temp_file "masc_voice_transcribe_" ".webm" in
-    (* finally absorbs [Sys_error] internally (CLAUDE.md §OCaml: a finally
-       that raises [Fun.Finally_raised] would mask the original exception).
-       Out-of-memory / async exceptions are out of scope for temp cleanup. *)
-    Fun.protect
-      ~finally:(fun () -> (try Sys.remove tmp with Sys_error _ -> ()))
-      (fun () ->
-        Fs_compat.save_file tmp body;
-        match Voice_bridge.transcribe_audio ~audio_file:tmp () with
-        | Ok json -> respond_json ~request reqd json
-        | Error err ->
-          respond_json ~status:`Bad_request ~request reqd
-            (`Assoc [ ("error", `String err) ]))
+    Eio.Switch.run (fun sw ->
+      let tmp = Filename.temp_file "masc_voice_transcribe_" (audio_temp_suffix request) in
+      Eio.Switch.on_release sw (fun () ->
+        try Sys.remove tmp with
+        | Sys_error _ -> ());
+      Fs_compat.save_file tmp body;
+      match Voice_bridge.transcribe_audio ~audio_file:tmp () with
+      | Ok json -> respond_json ~request reqd json
+      | Error err ->
+        respond_json ~status:`Bad_request ~request reqd
+          (`Assoc [ ("error", `String err) ]))
 
 let add_routes router =
   router
@@ -127,10 +144,10 @@ let add_routes router =
            | Some token -> serve_clip ~token request reqd)
          request reqd)
   |> Http.Router.post "/api/v1/voice/transcribe" (fun request reqd ->
-       (* RFC-0236 P1: browser-captured speech → text. Owner-only
-          ([CanBroadcast]) — each call spends an ElevenLabs STT credit, so
-          unlike the GET audio route this carries no public capability. *)
-       with_token_permission_auth ~permission:Masc_domain.CanBroadcast
+       (* RFC-0236 P1: browser-captured speech -> text. Admin/owner-only
+          ([CanAdmin]) — each call spends an ElevenLabs STT credit, so unlike
+          the GET audio route this carries no public capability. *)
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
          (fun state _agent_name _req reqd ->
            Http.Request.read_body_async reqd (fun body ->
              handle_transcribe state request reqd body))

--- a/lib/server/server_routes_http_routes_voice.mli
+++ b/lib/server/server_routes_http_routes_voice.mli
@@ -4,6 +4,10 @@
     (capability-token URLs, raw-bytes response, 1h TTL reaping). *)
 
 val add_routes : Http_server_eio.Router.t -> Http_server_eio.Router.t
-(** Register [GET /api/v1/voice/audio/:token] on the given router. Plugged
-    into the router assembly in {!Server_routes_http} alongside the
+(** Register voice HTTP routes on the given router:
+
+    - [GET /api/v1/voice/audio/:token] for capability-token TTS clip fetches.
+    - [POST /api/v1/voice/transcribe] for admin-gated browser STT uploads.
+
+    Plugged into the router assembly in {!Server_routes_http} alongside the
     artifacts route. *)

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -1149,6 +1149,10 @@ let test_worker_permissions () =
     (Masc_domain.has_permission Masc_domain.Worker Masc_domain.CanReadState);
   check bool "worker can claim" true
     (Masc_domain.has_permission Masc_domain.Worker Masc_domain.CanClaimTask);
+  check bool "worker can broadcast" true
+    (Masc_domain.has_permission Masc_domain.Worker Masc_domain.CanBroadcast);
+  check bool "worker cannot admin" false
+    (Masc_domain.has_permission Masc_domain.Worker Masc_domain.CanAdmin);
   check bool "worker cannot init" false
     (Masc_domain.has_permission Masc_domain.Worker Masc_domain.CanInit)
 

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -150,6 +150,24 @@ let test_frontend_transport_routes_present () =
     (has_route `POST "/webrtc/answer")
 ;;
 
+let test_voice_routes_present () =
+  let routes = Server_routes_http_routes_voice.add_routes (Router.create ()) in
+  let has_route meth path =
+    List.exists
+      (fun (route : Router.route) ->
+         String.equal route.path path && List.mem meth route.methods)
+      (Router.routes routes)
+  in
+  Alcotest.(check bool)
+    "GET /api/v1/voice/audio/ capability route"
+    true
+    (has_route `GET "/api/v1/voice/audio/");
+  Alcotest.(check bool)
+    "POST /api/v1/voice/transcribe route"
+    true
+    (has_route `POST "/api/v1/voice/transcribe")
+;;
+
 let test_frontend_canonical_loopback_location_localhost () =
   let headers = Httpun.Headers.of_list [ "host", "localhost:8935" ] in
   let request = Httpun.Request.create ~headers `GET "/dashboard?agent=agent_code" in
@@ -398,6 +416,7 @@ let router_tests =
     , `Quick
     , test_router_method_index_preserves_exact_405 )
   ; "frontend transport routes present", `Quick, test_frontend_transport_routes_present
+  ; "voice routes present", `Quick, test_voice_routes_present
   ; ( "frontend canonical localhost redirect"
     , `Quick
     , test_frontend_canonical_loopback_location_localhost )

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -992,6 +992,7 @@ let test_permissions_for_role_admin () =
 let test_has_permission_worker () =
   check bool "worker can read" true (Masc_domain.has_permission Masc_domain.Worker Masc_domain.CanReadState);
   check bool "worker can broadcast" true (Masc_domain.has_permission Masc_domain.Worker Masc_domain.CanBroadcast);
+  check bool "worker cannot admin" false (Masc_domain.has_permission Masc_domain.Worker Masc_domain.CanAdmin);
   check bool "worker cannot reset" false (Masc_domain.has_permission Masc_domain.Worker Masc_domain.CanReset)
 
 let test_has_permission_admin () =


### PR DESCRIPTION
## Summary

Follow-up to #21159. The merged RFC-0236 route used `CanBroadcast` for
`POST /api/v1/voice/transcribe`, but `Worker` tokens intentionally have
`CanBroadcast` for normal chat/broadcast writes. STT spends ElevenLabs quota, so
the route must require `CanAdmin`.

This PR:

- changes the transcribe route gate from `CanBroadcast` to `CanAdmin`
- keeps transient upload cleanup on `Eio.Switch.on_release`
- chooses the temp-file suffix from the request `content-type` so downstream STT
  sees a plausible filename for WebM/MP4/WAV/etc.
- corrects RFC-0236 docs to say raw audio body, `CanAdmin`, and switch-based
  cleanup
- adds regression coverage for route registration and the auth invariant
  (`Worker` can `CanBroadcast` but cannot `CanAdmin`)

## Verification

- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_http_server_eio.exe test/test_auth.exe test/test_types_coverage.exe`
- `./_build/default/test/test_http_server_eio.exe test '^router$' 10`
- `./_build/default/test/test_auth.exe test '^permissions$'`
- `./_build/default/test/test_types_coverage.exe test '^permissions$'`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/chat/voice-input.test.ts --no-file-parallelism --maxWorkers=1`
- `bash scripts/lint/spec-line-refs.sh`
- `scripts/check-ssot.sh`

## Notes

I also ran the full `test_auth.exe` and `test_types_coverage.exe` binaries while
checking the change. The new permission cases passed, but those full binaries
still contain unrelated pre-existing failures in other suites, so the PR evidence
above uses focused suites for the changed behavior.
