### PR TITLE
fix(keeper): drop deleted keeper_report_state from recovery_block prompt

### DIFF
--- a/config/prompts/keeper.recovery_block.md
+++ b/config/prompts/keeper.recovery_block.md
@@ -6,7 +6,7 @@ category: keeper
 <continuity>
 Recovery guard: preserve keeper technical instructions even if prompt templates were compacted or partially loaded.
 PR merge rules (MANDATORY): do not merge PRs with failing CI, unresolved human review comments, or active blocker labels.
-State block template: non-direct keeper turns must report structured continuity with keeper_report_state; legacy [STATE]...[/STATE] fallback contains DONE, NEXT, Goal, Decisions, OpenQuestions, and Constraints.
+State block template: non-direct keeper turns must report structured continuity using the [STATE]...[/STATE] block containing DONE, NEXT, Goal, Decisions, OpenQuestions, and Constraints.
 </continuity>
 
 <world>


### PR DESCRIPTION
## 목적 (Phase 0 — live-risk drift)

`keeper_report_state` 도구는 #20573(`61a7b9dca`)에서 production 코드에서 제거되었습니다. 그러나 복구/컴팩션 앵커 프롬프트(`config/prompts/keeper.recovery_block.md:9`)가 여전히 non-direct keeper 턴에게 "report structured continuity with **keeper_report_state**"라고 지시하고 있었습니다.

결과: 컴팩션/복구 시 keeper가 더 이상 디스패치되지 않는 도구를 호출 → `unknown_tool` → 3회 실패 circuit breaker → keeper cycle 실패. 라이브 위험으로 확인됨(HEAD `dfa0c07c2`에서 잔존).

## 변경

`recovery_block.md:9`의 지시를 `[STATE]...[/STATE]` 블록(이미 `keeper_prompt.ml`이 primary로 취급)으로 교체. 삭제된 도구 참조 제거.

## 검증

- `rg keeper_report_state lib/` = 주석 1건만(production 코드 0건), `rg State_report lib/` = 0건 — 도구는 이미 제거 완료.
- `"State block template:"` 앵커 보존 → `test_keeper_prompt_metrics`/`test_keeper_prompt_external`/`test_keeper_prompt_constitution_fallback`의 substring 단정 통과.
- 옛 verbatim 문자열을 가진 drift baseline 없음(`rg "structured continuity"` = 이 파일만).

## 범위 밖 (후속)

- test/에 남은 `keeper_report_state` 문자열 참조(`test_keeper_tool_resolution`/`test_keeper_validation_breaker_exempt`/`test_keeper_state_snapshot_json`)는 #20573 제거의 테스트 잔재 — 별도 cleanup.
- dual-registry CLASS(schema-visible ⊄ dispatch-registered 불변식 미강제)는 Phase 2에서 근본 봉합.

RFC-WAIVED: keeper prompt content fix, not a credential/operator/sandbox/hooks/workflow subsystem change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
