### PR TITLE
refactor(keeper): type the event-queue stimulus payload (RFC-0020)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -44,7 +44,6 @@ let with_in_turn_liveness_pulse =
 module Stimulus_intake = Keeper_heartbeat_stimulus_intake
 
 let stimulus_urgency_to_string = Stimulus_intake.stimulus_urgency_to_string
-let stimulus_class_to_string = Stimulus_intake.stimulus_class_to_string
 let pending_board_event_of_stimulus = Stimulus_intake.pending_board_event_of_stimulus
 let record_recovery_stimulus_turn_started =
   Stimulus_intake.record_recovery_stimulus_turn_started

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -22,13 +22,6 @@ let stimulus_urgency_to_string = function
   | Keeper_event_queue.Low -> "low"
 ;;
 
-let stimulus_class_to_string = function
-  | Keeper_event_queue.Board_signal -> "board_signal"
-  | Bootstrap -> "bootstrap"
-  | Stay_silent_recovery -> "stay_silent_recovery"
-  | Unsupported _ -> "unsupported"
-;;
-
 let pending_board_event_of_stimulus ~meta_after_triage stim =
   Keeper_world_observation.pending_board_event_of_stimulus
     ~continuity_summary:meta_after_triage.continuity_summary
@@ -68,28 +61,26 @@ let consume_single_heartbeat_stimulus
       ~meta_after_triage
       (stim : Keeper_event_queue.stimulus)
   =
-  let stimulus_class = Keeper_event_queue.classify stim in
-  let class_str = stimulus_class_to_string stimulus_class in
+  let class_str = Keeper_event_queue.payload_kind_label stim.payload in
   Otel_metric_store.inc_counter
     Keeper_metrics.(to_string StimulusConsumed)
     ~labels:[ "keeper", meta_after_triage.name; "class", class_str ]
     ();
   Log.Keeper.info
-    "turn entry: consumed stimulus stimulus_id=%s urgency=%s class=%s \
-     payload_len=%d (keeper=%s)"
+    "turn entry: consumed stimulus stimulus_id=%s urgency=%s class=%s (keeper=%s)"
     stim.post_id
     (stimulus_urgency_to_string stim.urgency)
     class_str
-    (String.length stim.payload)
     meta_after_triage.name;
-  match stimulus_class with
-  | Board_signal -> pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
-  | Bootstrap ->
+  match stim.payload with
+  | Keeper_event_queue.Board_signal _ ->
+    pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+  | Keeper_event_queue.Bootstrap ->
     Log.Keeper.info
       "turn entry: bootstrap stimulus consumed (keeper=%s)"
       meta_after_triage.name;
     []
-  | Stay_silent_recovery ->
+  | Keeper_event_queue.Stay_silent_recovery ->
     Log.Keeper.info
       "turn entry: stay-silent recovery stimulus consumed post_id=%s \
        (keeper=%s)"
@@ -99,18 +90,6 @@ let consume_single_heartbeat_stimulus
       ~ctx
       ~keeper_name:meta_after_triage.name
       stim;
-    []
-  | Unsupported prefix ->
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string UnsupportedStimulus)
-      ~labels:[ "keeper", meta_after_triage.name ]
-      ();
-    Log.Keeper.warn
-      "turn entry: unsupported stimulus consumed prefix=%S post_id=%s \
-       (keeper=%s) — wake→no_signal gap #12684"
-      prefix
-      stim.post_id
-      meta_after_triage.name;
     []
 ;;
 
@@ -129,10 +108,9 @@ let consume_board_stimulus_batch ~meta_after_triage batch =
          ();
        Log.Keeper.info
          "turn entry: consumed stimulus stimulus_id=%s urgency=%s class=board_signal \
-          payload_len=%d (keeper=%s)"
+          (keeper=%s)"
          stim.post_id
          (stimulus_urgency_to_string stim.urgency)
-         (String.length stim.payload)
          meta_after_triage.name;
        pending_board_event_of_stimulus ~meta_after_triage stim)
     batch

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -13,10 +13,6 @@ open Keeper_execution
     for [u] ([immediate] / [normal] / [low]). *)
 val stimulus_urgency_to_string : Keeper_event_queue.urgency -> string
 
-(** [stimulus_class_to_string c] returns the Otel_metric_store / log label for
-    a stimulus class. *)
-val stimulus_class_to_string : Keeper_event_queue.stimulus_class -> string
-
 (** [pending_board_event_of_stimulus ~meta_after_triage stim] wraps a
     stimulus into a pending board event, threading the keeper meta's
     continuity summary. *)

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -292,25 +292,23 @@ let select_board_wakeup_candidates
     selected, generic_dropped + total_dropped
 ;;
 
-let board_signal_kind_to_string = function
-  | Board_dispatch.Board_post_created -> "post_created"
-  | Board_dispatch.Board_comment_added -> "comment_added"
-;;
-
+(* RFC-0020: enqueue the board signal as a typed [stimulus_payload] instead of a
+   JSON-serialised string. [reason] still selects urgency at the producer; it is
+   not part of the payload (the consumer never read the prior "wake_reason"
+   field — wake-reason classification is recomputed downstream). *)
 let board_signal_stimulus ~(reason : string) (signal : Board_dispatch.board_signal) =
-  let payload =
-    `Assoc
-      [ "source", `String "board_signal"
-      ; "kind", `String (board_signal_kind_to_string signal.kind)
-      ; "post_id", `String signal.post_id
-      ; "author", `String signal.author
-      ; "title", `String signal.title
-      ; "content", `String signal.content
-      ; "hearth", Json_util.string_opt_to_json signal.hearth
-      ; ( "updated_at_unix", Json_util.float_opt_to_json signal.updated_at )
-      ; "wake_reason", `String reason
-      ]
-    |> Yojson.Safe.to_string
+  let payload : Keeper_event_queue.stimulus_payload =
+    Keeper_event_queue.Board_signal
+      { kind =
+          (match signal.kind with
+           | Board_dispatch.Board_post_created -> Keeper_event_queue.Post_created
+           | Board_dispatch.Board_comment_added -> Keeper_event_queue.Comment_added)
+      ; author = signal.author
+      ; title = signal.title
+      ; content = signal.content
+      ; hearth = signal.hearth
+      ; updated_at = signal.updated_at
+      }
   in
   { Keeper_event_queue.post_id = signal.post_id
   ; urgency =

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -7,7 +7,6 @@ type stimulus_kind =
   | Board_signal
   | Bootstrap
   | Stay_silent_recovery
-  | Unknown of string
 
 type reaction_kind =
   | Turn_started
@@ -24,7 +23,6 @@ let stimulus_kind_to_string = function
   | Board_signal -> "board_signal"
   | Bootstrap -> "bootstrap"
   | Stay_silent_recovery -> "stay_silent_recovery"
-  | Unknown value -> value
 ;;
 
 let reaction_kind_to_string = function
@@ -44,48 +42,14 @@ let option_json f = function
 
 let list_json values = `List (List.map (fun value -> `String value) values)
 
-let payload_json payload =
-  try
-    Ok (Yojson.Safe.from_string payload)
-  with
-  | Yojson.Json_error msg -> Error msg
-;;
-
-let payload_field name payload =
-  match payload_json payload with
-  | Ok (`Assoc fields) -> List.assoc_opt name fields
-  | Ok _ | Error _ -> None
-;;
-
-let payload_parse_error payload =
-  match payload_json payload with
-  | Ok _ -> None
-  | Error msg -> Some msg
-;;
-
-let payload_float_field name payload =
-  match payload_field name payload with
-  | Some (`Float value) -> Some value
-  | Some (`Int value) -> Some (float_of_int value)
-  | _ -> None
-;;
-
-let payload_preview payload =
-  let limit = 512 in
-  if String.length payload <= limit
-  then payload
-  else String.sub payload 0 limit ^ "...[truncated]"
-;;
-
 let digest_id prefix payload = prefix ^ ":" ^ Digest.to_hex (Digest.string payload)
 let board_stimulus_id ~post_id = "board:" ^ post_id
 
 let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
-  match Keeper_event_queue.classify stimulus with
-  | Board_signal -> Board_signal
-  | Bootstrap -> Bootstrap
-  | Stay_silent_recovery -> Stay_silent_recovery
-  | Unsupported prefix -> Unknown prefix
+  match stimulus.payload with
+  | Keeper_event_queue.Board_signal _ -> Board_signal
+  | Keeper_event_queue.Bootstrap -> Bootstrap
+  | Keeper_event_queue.Stay_silent_recovery -> Stay_silent_recovery
 ;;
 
 let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
@@ -99,7 +63,6 @@ let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
          [ stimulus.post_id
          ; stimulus_kind_to_string kind
          ; Printf.sprintf "%.6f" stimulus.arrived_at
-         ; stimulus.payload
          ])
 ;;
 
@@ -136,20 +99,34 @@ let base_fields ~record_kind ~event_id ~keeper_name ~recorded_at =
   ]
 ;;
 
+let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
+  match payload with
+  | Keeper_event_queue.Board_signal bs ->
+    let limit = 256 in
+    let title =
+      if String.length bs.title <= limit
+      then bs.title
+      else String.sub bs.title 0 limit ^ "...[truncated]"
+    in
+    Printf.sprintf
+      "board_signal kind=%s author=%s title=%s"
+      (match bs.kind with
+       | Keeper_event_queue.Post_created -> "post_created"
+       | Keeper_event_queue.Comment_added -> "comment_added")
+      bs.author
+      title
+  | Keeper_event_queue.Bootstrap -> "bootstrap"
+  | Keeper_event_queue.Stay_silent_recovery -> "stay_silent_recovery"
+;;
+
 let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
   let kind = stimulus_kind_of_event_queue stimulus in
   let stimulus_id = stimulus_id_of_event_queue stimulus in
   let recorded_at = Time_compat.now () in
   let board_updated_at =
-    match kind with
-    | Board_signal -> payload_float_field "updated_at_unix" stimulus.payload
-    | Bootstrap | Stay_silent_recovery | Unknown _ -> None
-  in
-  let parse_error =
-    match kind with
-    | Board_signal | Stay_silent_recovery ->
-      payload_parse_error stimulus.payload
-    | Bootstrap | Unknown _ -> None
+    match stimulus.payload with
+    | Keeper_event_queue.Board_signal bs -> bs.updated_at
+    | Keeper_event_queue.Bootstrap | Keeper_event_queue.Stay_silent_recovery -> None
   in
   `Assoc
     (base_fields
@@ -166,8 +143,7 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
              ; "urgency", `String (urgency_to_string stimulus.urgency)
              ; "arrived_at_unix", `Float stimulus.arrived_at
              ; "board_updated_at_unix", option_json (fun value -> `Float value) board_updated_at
-             ; "payload_parse_error", option_json (fun value -> `String value) parse_error
-             ; "payload_preview", `String (payload_preview stimulus.payload)
+             ; "payload_preview", `String (stimulus_payload_preview stimulus.payload)
              ] )
        ])
 ;;

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -14,7 +14,6 @@ type stimulus_kind =
   | Board_signal
   | Bootstrap
   | Stay_silent_recovery
-  | Unknown of string
 
 type reaction_kind =
   | Turn_started

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -84,7 +84,7 @@ let launch_supervised_fiber
       { post_id = "bootstrap"
       ; urgency = Keeper_event_queue.Normal
       ; arrived_at = Unix.gettimeofday ()
-      ; payload = "Keeper bootstrap signal"
+      ; payload = Keeper_event_queue.Bootstrap
       }
     in
     Keeper_registry_event_queue.enqueue ~base_path meta.name bootstrap_signal;

--- a/lib/keeper/keeper_unified_turn_stay_silent.ml
+++ b/lib/keeper/keeper_unified_turn_stay_silent.ml
@@ -1,23 +1,13 @@
 (** Stay-silent loop recovery helpers for the unified keeper turn. *)
 
-let recovery_stimulus ~now ~keeper_name ~streak ~threshold =
-  let payload =
-    `Assoc
-      [ "source", `String "stay_silent_recovery"
-      ; "keeper", `String keeper_name
-      ; "streak", `Int streak
-      ; "threshold", `Int threshold
-      ; ( "message"
-        , `String
-            "stay_silent loop threshold crossed; run a recovery cycle instead of \
-             remaining silent" )
-      ]
-    |> Yojson.Safe.to_string
-  in
+(* RFC-0020: the stay-silent recovery stimulus carries no data — the consumer
+   only branches on the kind. streak/threshold are recorded in the failure
+   reason / blocker detail by the caller, not in the stimulus payload. *)
+let recovery_stimulus ~now ~keeper_name =
   { Keeper_event_queue.post_id = "stay-silent-loop:" ^ keeper_name
   ; urgency = Keeper_event_queue.Immediate
   ; arrived_at = now
-  ; payload
+  ; payload = Keeper_event_queue.Stay_silent_recovery
   }
 ;;
 
@@ -43,11 +33,7 @@ let mark_loop_detected ~(config : Workspace.config) meta ~streak ~threshold =
     meta.Keeper_meta_contract.name
     (Some failure_reason);
   let stimulus =
-    recovery_stimulus
-      ~now:(Time_compat.now ())
-      ~keeper_name:meta.name
-      ~streak
-      ~threshold
+    recovery_stimulus ~now:(Time_compat.now ()) ~keeper_name:meta.name
   in
   Keeper_registry_event_queue.enqueue
     ~base_path:config.base_path

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -199,12 +199,15 @@ let pending_board_event_of_stimulus
   (stimulus : Keeper_event_queue.stimulus)
   : pending_board_event option
   =
-  Board_signal.of_stimulus_payload stimulus.payload
-  |> Option.map
-       (pending_board_event_of_board_signal
-          ~continuity_summary
-          ~meta
-          ~arrived_at:stimulus.arrived_at)
+  match stimulus.payload with
+  | Keeper_event_queue.Board_signal bs ->
+    Some
+      (pending_board_event_of_board_signal
+         ~continuity_summary
+         ~meta
+         ~arrived_at:stimulus.arrived_at
+         (Board_signal.board_signal_of_board_stimulus ~post_id:stimulus.post_id bs))
+  | Keeper_event_queue.Bootstrap | Keeper_event_queue.Stay_silent_recovery -> None
 ;;
 
 (** Collect recent board activity using cursor-based tracking.

--- a/lib/keeper/keeper_world_observation_board_signal.ml
+++ b/lib/keeper/keeper_world_observation_board_signal.ml
@@ -14,64 +14,27 @@ type match_result =
 
 type comment_status = [ `Never | `No_new_external | `New_external of int * string * string ]
 
-let json_string_member name fields =
-  match List.assoc_opt name fields with
-  | Some (`String value) -> Some value
-  | _ -> None
-;;
-
-let json_string_null_member name fields =
-  match List.assoc_opt name fields with
-  | Some (`String value) -> Some value
-  | Some `Null | None -> None
-  | _ -> None
-;;
-
-let json_float_null_member name fields =
-  match List.assoc_opt name fields with
-  | Some (`Float value) -> Some value
-  | Some (`Int value) -> Some (float_of_int value)
-  | Some `Null | None -> None
-  | _ -> None
-;;
-
-let board_signal_kind_of_string = function
-  | "post_created" | "post" -> Some Board_dispatch.Board_post_created
-  | "comment_added" | "comment" -> Some Board_dispatch.Board_comment_added
-  | _ -> None
-;;
-
-let of_stimulus_payload payload =
-  try
-    match Yojson.Safe.from_string payload with
-    | `Assoc fields
-      when Option.equal
-             String.equal
-             (json_string_member "source" fields)
-             (Some "board_signal") ->
-      (match
-         ( json_string_member "kind" fields
-         , json_string_member "post_id" fields
-         , json_string_member "author" fields
-         , json_string_member "title" fields
-         , json_string_member "content" fields )
-       with
-       | Some kind, Some post_id, Some author, Some title, Some content ->
-         Option.map
-           (fun kind ->
-              { Board_dispatch.kind
-              ; post_id
-              ; author
-              ; title
-              ; content
-              ; hearth = json_string_null_member "hearth" fields
-              ; updated_at = json_float_null_member "updated_at_unix" fields
-              })
-           (board_signal_kind_of_string kind)
-       | _ -> None)
-    | _ -> None
-  with
-  | Yojson.Json_error _ -> None
+(* RFC-0020: board signals are carried as a typed [Keeper_event_queue.board_stimulus]
+   end-to-end. This total conversion rebuilds the [Board_dispatch.board_signal]
+   the downstream matchers expect from the typed payload, taking the board post
+   id from the enclosing stimulus. Replaces the prior JSON re-parse of a string
+   payload (which could fail and silently drop signals). *)
+let board_signal_of_board_stimulus
+      ~(post_id : string)
+      (bs : Keeper_event_queue.board_stimulus)
+  : Board_dispatch.board_signal
+  =
+  { Board_dispatch.kind =
+      (match bs.kind with
+       | Keeper_event_queue.Post_created -> Board_dispatch.Board_post_created
+       | Keeper_event_queue.Comment_added -> Board_dispatch.Board_comment_added)
+  ; post_id
+  ; author = bs.author
+  ; title = bs.title
+  ; content = bs.content
+  ; hearth = bs.hearth
+  ; updated_at = bs.updated_at
+  }
 ;;
 
 let post_id_string (post : Board.post) = Board.Post_id.to_string post.id

--- a/lib/keeper/keeper_world_observation_board_signal.mli
+++ b/lib/keeper/keeper_world_observation_board_signal.mli
@@ -8,7 +8,12 @@ type match_result =
 
 type comment_status = [ `Never | `No_new_external | `New_external of int * string * string ]
 
-val of_stimulus_payload : string -> Board_dispatch.board_signal option
+val board_signal_of_board_stimulus
+  :  post_id:string
+  -> Keeper_event_queue.board_stimulus
+  -> Board_dispatch.board_signal
+(** Total conversion from the typed event-queue board payload to the
+    [Board_dispatch.board_signal] the matchers consume (RFC-0020). *)
 
 val post_id_string : Board.post -> string
 val compare_cursor_token : float * string -> float * string -> int

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -10,11 +10,29 @@ let urgency_rank = function
 
 type post_id = string
 
+type board_stimulus_kind =
+  | Post_created
+  | Comment_added
+
+type board_stimulus = {
+  kind : board_stimulus_kind;
+  author : string;
+  title : string;
+  content : string;
+  hearth : string option;
+  updated_at : float option;
+}
+
+type stimulus_payload =
+  | Board_signal of board_stimulus
+  | Bootstrap
+  | Stay_silent_recovery
+
 type stimulus = {
   post_id : post_id;
   urgency : urgency;
   arrived_at : float;
-  payload : string;
+  payload : stimulus_payload;
 }
 
 type t =
@@ -71,35 +89,19 @@ let sort_by_urgency (queue : t) : t =
        (fun a b -> Int.compare (urgency_rank a.urgency) (urgency_rank b.urgency))
   |> of_list
 
-type stimulus_class =
-  | Board_signal
-  | Bootstrap
-  | Stay_silent_recovery
-  | Unsupported of string
+let payload_kind_label = function
+  | Board_signal _ -> "board_signal"
+  | Bootstrap -> "bootstrap"
+  | Stay_silent_recovery -> "stay_silent_recovery"
 
-let classify (s : stimulus) : stimulus_class =
-  let has_prefix prefix =
-    let payload_len = String.length s.payload in
-    let prefix_len = String.length prefix in
-    payload_len >= prefix_len
-    && String.equal (String.sub s.payload 0 prefix_len) prefix
-  in
-  if String.equal s.payload "Keeper bootstrap signal" then Bootstrap
-  else if has_prefix "{\"source\":\"stay_silent_recovery\"" then
-    Stay_silent_recovery
-  (* Board signals carry JSON with "source":"board_signal". Lightweight
-     prefix check avoids a full Yojson parse in the data layer. *)
-  else if has_prefix "{\"source\":\"board_signal\"" then Board_signal
-  else
-    Unsupported
-      (String.sub s.payload 0 (min 40 (String.length s.payload)))
+let is_board_signal = function
+  | Board_signal _ -> true
+  | Bootstrap | Stay_silent_recovery -> false
 
 let drain_board_window ?(window_sec = 2.0) (queue : t) : stimulus list * t =
   let now = Unix.gettimeofday () in
   let is_board_in_window s =
-    match classify s with
-    | Board_signal -> Float.abs (now -. s.arrived_at) <= window_sec
-    | _ -> false
+    is_board_signal s.payload && Float.abs (now -. s.arrived_at) <= window_sec
   in
   let board, rest = List.partition is_board_in_window (to_list queue) in
   (to_list (sort_by_urgency (of_list board)), of_list rest)

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -31,11 +31,40 @@ type post_id = string
     target id, or the operator directive token. The queue does
     not interpret the value beyond equality. *)
 
+type board_stimulus_kind =
+  | Post_created
+  | Comment_added
+
+type board_stimulus = {
+  kind : board_stimulus_kind;
+  author : string;
+  title : string;
+  content : string;
+  hearth : string option;
+  updated_at : float option;
+}
+(** Typed board-signal payload carried end-to-end (RFC-0020).
+
+    This is a [keeper_runtime]-owned boundary DTO. The queue is a low-level
+    data module and must not depend on the [board] domain library, so the
+    keeper layer converts to/from [Board_dispatch.board_signal] at the
+    enqueue and drain boundaries. The board post id is not duplicated here:
+    it is the enclosing [stimulus.post_id]. *)
+
+type stimulus_payload =
+  | Board_signal of board_stimulus
+  | Bootstrap
+  | Stay_silent_recovery
+(** Closed set of stimulus kinds. Replaces the prior [payload : string] +
+    [classify] JSON-prefix round-trip: producers hold the typed value and
+    consumers match it exhaustively, so an unrecognised stimulus is
+    unrepresentable rather than silently downgraded to [Unsupported]. *)
+
 type stimulus = {
   post_id : post_id;
   urgency : urgency;
   arrived_at : float;  (** Unix timestamp, monotonic clock preferred. *)
-  payload : string;
+  payload : stimulus_payload;
 }
 
 type t
@@ -67,17 +96,12 @@ val sort_by_urgency : t -> t
 val summary : t -> string
 (** Short human-readable description for log lines. *)
 
-type stimulus_class =
-  | Board_signal   (** JSON payload with {"source":"board_signal", ...} *)
-  | Bootstrap      (** Plain string "Keeper bootstrap signal" *)
-  | Stay_silent_recovery
-      (** JSON payload with {"source":"stay_silent_recovery", ...} *)
-  | Unsupported of string  (** Unrecognized: payload prefix (max 40 chars) for audit *)
+val payload_kind_label : stimulus_payload -> string
+(** Stable short label for logs/metrics: ["board_signal"], ["bootstrap"],
+    or ["stay_silent_recovery"]. *)
 
-val classify : stimulus -> stimulus_class
-(** [classify s] discriminates the stimulus by inspecting its payload.
-    No Yojson dependency — uses lightweight prefix matching so the Event
-    Layer data module stays self-contained. *)
+val is_board_signal : stimulus_payload -> bool
+(** [true] iff the payload is a [Board_signal]. *)
 
 val drain_board_window : ?window_sec:float -> t -> stimulus list * t
 (** [drain_board_window q] separates board-signal stimuli that arrived

--- a/test/keeper_event_queue/test_keeper_event_queue.ml
+++ b/test/keeper_event_queue/test_keeper_event_queue.ml
@@ -11,7 +11,10 @@
 
 open Keeper_event_queue
 
-let make_stim ?(urgency = Normal) ?(arrived_at = 0.0) post_id payload =
+(* Stimuli are distinguished by [post_id] / [arrived_at]; the typed
+   [payload] defaults to [Bootstrap] since the queue ordering/dedup
+   logic is payload-agnostic. *)
+let make_stim ?(urgency = Normal) ?(arrived_at = 0.0) ?(payload = Bootstrap) post_id =
   { post_id; urgency; arrived_at; payload }
 
 (* ── Unit-level shape ──────────────────────────────────────────── *)
@@ -22,8 +25,8 @@ let test_empty () =
   assert (Option.is_none (dequeue empty))
 
 let test_enqueue_dequeue_fifo () =
-  let s1 = make_stim "p1" "first" in
-  let s2 = make_stim "p2" "second" in
+  let s1 = make_stim "p1" in
+  let s2 = make_stim "p2" in
   let q = enqueue (enqueue empty s1) s2 in
   assert (length q = 2);
   match dequeue q with
@@ -38,27 +41,27 @@ let test_enqueue_dequeue_fifo () =
   | None -> assert false
 
 let test_dedup_within_window () =
-  let s1 = make_stim ~arrived_at:0.0 "p1" "first" in
-  let s2 = make_stim ~arrived_at:30.0 "p1" "second" in (* within 60s *)
-  let s3 = make_stim ~arrived_at:200.0 "p1" "third" in (* outside 60s *)
+  let s1 = make_stim ~arrived_at:0.0 "p1" in
+  let s2 = make_stim ~arrived_at:30.0 "p1" in (* within 60s *)
+  let s3 = make_stim ~arrived_at:200.0 "p1" in (* outside 60s *)
   let q = enqueue (enqueue (enqueue empty s1) s2) s3 in
   let dedup = dedup_by_post_id q in
   assert (length dedup = 2);
   match dequeue dedup with
-  | Some (head, _) -> assert (head.payload = "first")
+  | Some (head, _) -> assert (head.arrived_at = 0.0) (* first survivor kept *)
   | None -> assert false
 
 let test_dedup_custom_window () =
-  let s1 = make_stim ~arrived_at:0.0 "p1" "a" in
-  let s2 = make_stim ~arrived_at:5.0 "p1" "b" in
+  let s1 = make_stim ~arrived_at:0.0 "p1" in
+  let s2 = make_stim ~arrived_at:5.0 "p1" in
   let q = enqueue (enqueue empty s1) s2 in
   assert (length (dedup_by_post_id ~window_seconds:1.0 q) = 2);
   assert (length (dedup_by_post_id ~window_seconds:10.0 q) = 1)
 
 let test_sort_by_urgency () =
-  let s_low = make_stim ~urgency:Low "p1" "low" in
-  let s_imm = make_stim ~urgency:Immediate "p2" "imm" in
-  let s_norm = make_stim ~urgency:Normal "p3" "norm" in
+  let s_low = make_stim ~urgency:Low "p1" in
+  let s_imm = make_stim ~urgency:Immediate "p2" in
+  let s_norm = make_stim ~urgency:Normal "p3" in
   let q = enqueue (enqueue (enqueue empty s_low) s_imm) s_norm in
   let sorted = sort_by_urgency q in
   match dequeue sorted with
@@ -66,23 +69,20 @@ let test_sort_by_urgency () =
   | None -> assert false
 
 let test_sort_stable_within_bucket () =
-  let s1 = make_stim ~urgency:Normal "p1" "a" in
-  let s2 = make_stim ~urgency:Normal "p2" "b" in
-  let s3 = make_stim ~urgency:Normal "p3" "c" in
+  let s1 = make_stim ~urgency:Normal "p1" in
+  let s2 = make_stim ~urgency:Normal "p2" in
+  let s3 = make_stim ~urgency:Normal "p3" in
   let q = enqueue (enqueue (enqueue empty s1) s2) s3 in
   let sorted = sort_by_urgency q in
   match dequeue sorted with
-  | Some (head, _) -> assert (head.payload = "a")
+  | Some (head, _) -> assert (head.post_id = "p1")
   | None -> assert false
 
 (* ── TLA+ invariant correspondence ─────────────────────────────── *)
 
 (* Conservation: enqueued >= dequeued at all times. *)
 let test_conservation () =
-  let stims =
-    List.init 10 (fun i ->
-        make_stim (Printf.sprintf "p%d" i) (string_of_int i))
-  in
+  let stims = List.init 10 (fun i -> make_stim (Printf.sprintf "p%d" i)) in
   let q = List.fold_left enqueue empty stims in
   let rec drain n q =
     match dequeue q with
@@ -98,28 +98,41 @@ let test_conservation () =
    choosing Skip in that state; here we only confirm the data
    channel is ready when the policy asks. *)
 let test_queue_overrides_policy () =
-  let q = enqueue empty (make_stim "p1" "data") in
+  let q = enqueue empty (make_stim "p1") in
   assert (not (is_empty q));
   match dequeue q with
-  | Some (out, _) -> assert (out.payload = "data")
+  | Some (out, _) -> assert (out.post_id = "p1")
   | None -> assert false
 
 (* EmitMatchesEvidence: dequeue only consumes stimuli that have been
    enqueued — there is no spurious Some. *)
 let test_dequeue_only_consumes_enqueued () =
   assert (Option.is_none (dequeue empty));
-  let q = enqueue empty (make_stim "p1" "x") in
+  let q = enqueue empty (make_stim "p1") in
   let _, rest = Option.get (dequeue q) in
   assert (Option.is_none (dequeue rest))
 
-let test_classify_stay_silent_recovery () =
-  let s =
-    make_stim "stay-silent-loop:k"
-      "{\"source\":\"stay_silent_recovery\",\"keeper\":\"k\",\"streak\":10}"
+(* Typed payload (RFC-0020): the kind is carried as a closed variant,
+   not classified from a JSON-prefixed string. *)
+let test_typed_payload_surface () =
+  let stay = make_stim ~payload:Stay_silent_recovery "stay-silent-loop:k" in
+  assert (String.equal (payload_kind_label stay.payload) "stay_silent_recovery");
+  assert (not (is_board_signal stay.payload));
+  let board =
+    make_stim
+      ~payload:
+        (Board_signal
+           { kind = Comment_added
+           ; author = "alice"
+           ; title = "t"
+           ; content = "c"
+           ; hearth = None
+           ; updated_at = None
+           })
+      "p9"
   in
-  match classify s with
-  | Stay_silent_recovery -> ()
-  | _ -> assert false
+  assert (is_board_signal board.payload);
+  assert (String.equal (payload_kind_label board.payload) "board_signal")
 
 let () =
   test_empty ();
@@ -131,5 +144,5 @@ let () =
   test_conservation ();
   test_queue_overrides_policy ();
   test_dequeue_only_consumes_enqueued ();
-  test_classify_stay_silent_recovery ();
+  test_typed_payload_surface ();
   print_endline "Keeper_event_queue: all tests passed"

--- a/test/keeper_event_queue_decision/test_keeper_event_queue_decision.ml
+++ b/test/keeper_event_queue_decision/test_keeper_event_queue_decision.ml
@@ -25,7 +25,7 @@ let decide ~smart_decision ~queue =
   else HS.Emit
 
 let make_stim post_id =
-  Q.{ post_id; urgency = Normal; arrived_at = 0.0; payload = "test" }
+  Q.{ post_id; urgency = Normal; arrived_at = 0.0; payload = Q.Bootstrap }
 
 let queue_with n =
   let stims = List.init n (fun i -> make_stim (Printf.sprintf "p%d" i)) in

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1,146 +1,72 @@
 let () =
   let open Keeper_event_queue in
-
-  (* --- classify: board_signal --- *)
-  let board_payload =
-    {|{"source":"board_signal","kind":"post_created","post_id":"p1","author":"a","title":"t","content":"c"}|}
+  let board_payload () =
+    Board_signal
+      { kind = Post_created
+      ; author = "a"
+      ; title = "t"
+      ; content = "c"
+      ; hearth = None
+      ; updated_at = None
+      }
   in
-  let board_stim = { post_id = "p1"; urgency = Normal; arrived_at = 0.0; payload = board_payload } in
-  (match classify board_stim with
-   | Board_signal -> ()
-   | other ->
-     Alcotest.fail (Printf.sprintf "expected Board_signal, got %s"
-       (match other with
-        | Bootstrap -> "Bootstrap"
-        | Unsupported s -> "Unsupported("^s^")"
-        | Board_signal -> "Board_signal"
-        | Stay_silent_recovery -> "Stay_silent_recovery")));
 
-  let live_comment_payload =
-    {|{"source":"board_signal","kind":"comment","post_id":"p2","author":"alice","title":"Long board event","content":"this mirrors the long live payload that used to miss the prefix check","hearth":null,"wake_reason":"scope_message"}|}
-  in
-  let live_comment_stim =
-    { post_id = "p2"; urgency = Normal; arrived_at = 0.0; payload = live_comment_payload }
-  in
-  (match classify live_comment_stim with
-   | Board_signal -> ()
-   | other ->
-     Alcotest.fail (Printf.sprintf "expected live comment Board_signal, got %s"
-       (match other with
-        | Bootstrap -> "Bootstrap"
-        | Unsupported s -> "Unsupported("^s^")"
-        | Board_signal -> "Board_signal"
-        | Stay_silent_recovery -> "Stay_silent_recovery")));
-
-  (* --- classify: bootstrap --- *)
-  let bootstrap_stim = {
-    post_id = "bootstrap"; urgency = Normal; arrived_at = 0.0;
-    payload = "Keeper bootstrap signal";
-  } in
-  (match classify bootstrap_stim with
-   | Bootstrap -> ()
-   | other ->
-     Alcotest.fail (Printf.sprintf "expected Bootstrap, got %s"
-       (match other with
-        | Board_signal -> "Board_signal"
-        | Unsupported s -> "Unsupported("^s^")"
-        | Bootstrap -> "Bootstrap"
-        | Stay_silent_recovery -> "Stay_silent_recovery")));
-
-  (* --- classify: unsupported --- *)
-  let unknown_stim = {
-    post_id = "x"; urgency = Low; arrived_at = 0.0;
-    payload = "some random payload";
-  } in
-  (match classify unknown_stim with
-   | Unsupported prefix ->
-     if String.length prefix > 40 then
-       Alcotest.fail "unsupported prefix should be truncated to 40 chars"
-   | other ->
-     Alcotest.fail (Printf.sprintf "expected Unsupported, got %s"
-       (match other with
-        | Board_signal -> "Board_signal"
-        | Bootstrap -> "Bootstrap"
-        | Stay_silent_recovery -> "Stay_silent_recovery"
-        | Unsupported _ -> "Unsupported")));
-
-  (* --- classify: malformed JSON is unsupported --- *)
-  let broken_json = {
-    post_id = "y"; urgency = Normal; arrived_at = 0.0;
-    payload = "{\"source\":\"board_signal\"";  (* truncated, no closing brace *)
-  } in
-  (match classify broken_json with
-   | Board_signal -> ()  (* prefix match succeeds, this is fine *)
-   | _ -> ());
-
-  (* --- classify: empty payload is unsupported --- *)
-  let empty_stim = { post_id = "z"; urgency = Low; arrived_at = 0.0; payload = "" } in
-  (match classify empty_stim with
-   | Unsupported _ -> ()
-   | other ->
-     Alcotest.fail (Printf.sprintf "empty payload should be Unsupported, got %s"
-       (match other with
-        | Board_signal -> "Board_signal"
-        | Bootstrap -> "Bootstrap"
-        | Unsupported _ -> "Unsupported"
-        | Stay_silent_recovery -> "Stay_silent_recovery")));
-
-  let stay_silent_recovery_stim = {
-    post_id = "stay-silent-loop:k"; urgency = Immediate; arrived_at = 0.0;
-    payload = {|{"source":"stay_silent_recovery","keeper":"k","streak":10}|};
-  } in
-  (match classify stay_silent_recovery_stim with
-   | Stay_silent_recovery -> ()
-   | other ->
-     Alcotest.fail (Printf.sprintf "expected Stay_silent_recovery, got %s"
-       (match other with
-        | Board_signal -> "Board_signal"
-        | Bootstrap -> "Bootstrap"
-        | Unsupported s -> "Unsupported("^s^")"
-        | Stay_silent_recovery -> "Stay_silent_recovery")));
+  (* --- typed payload kind labels (RFC-0020): the stimulus kind is a
+         closed variant, not classified from a JSON-prefixed string --- *)
+  assert (is_board_signal (board_payload ()));
+  assert (not (is_board_signal Bootstrap));
+  assert (String.equal (payload_kind_label (board_payload ())) "board_signal");
+  assert (String.equal (payload_kind_label Bootstrap) "bootstrap");
+  assert (String.equal (payload_kind_label Stay_silent_recovery) "stay_silent_recovery");
 
   (* --- queue operations preserved --- *)
+  let board_stim =
+    { post_id = "p1"; urgency = Normal; arrived_at = 0.0; payload = board_payload () }
+  in
+  let bootstrap_stim =
+    { post_id = "bootstrap"; urgency = Normal; arrived_at = 0.0; payload = Bootstrap }
+  in
   let q = empty in
   assert (is_empty q);
   let q = enqueue q board_stim in
   let q = enqueue q bootstrap_stim in
   assert (length q = 2);
-  let (stim, q) = match dequeue q with Some s -> s | None -> Alcotest.fail "dequeue should return item" in
+  let stim, q =
+    match dequeue q with
+    | Some s -> s
+    | None -> Alcotest.fail "dequeue should return item"
+  in
   assert (String.equal stim.post_id "p1");
   assert (length q = 1);
 
   (* --- drain_board_window: coalesces board signals within window --- *)
   let now = Unix.gettimeofday () in
-  let recent_board_1 = {
-    post_id = "rb1"; urgency = Normal; arrived_at = now;
-    payload = board_payload;
-  } in
-  let recent_board_2 = {
-    post_id = "rb2"; urgency = Immediate; arrived_at = now;
-    payload = board_payload;
-  } in
-  let old_board = {
-    post_id = "ob1"; urgency = Normal; arrived_at = 0.0;
-    payload = board_payload;
-  } in
-  let bootstrap_in_queue = {
-    post_id = "bs1"; urgency = Normal; arrived_at = now;
-    payload = "Keeper bootstrap signal";
-  } in
+  let recent_board_1 =
+    { post_id = "rb1"; urgency = Normal; arrived_at = now; payload = board_payload () }
+  in
+  let recent_board_2 =
+    { post_id = "rb2"; urgency = Immediate; arrived_at = now; payload = board_payload () }
+  in
+  let old_board =
+    { post_id = "ob1"; urgency = Normal; arrived_at = 0.0; payload = board_payload () }
+  in
+  let bootstrap_in_queue =
+    { post_id = "bs1"; urgency = Normal; arrived_at = now; payload = Bootstrap }
+  in
   let q_drain = empty in
   let q_drain = enqueue q_drain recent_board_1 in
   let q_drain = enqueue q_drain old_board in
   let q_drain = enqueue q_drain bootstrap_in_queue in
   let q_drain = enqueue q_drain recent_board_2 in
-  let (board_in_window, rest_queue) = drain_board_window ~window_sec:5.0 q_drain in
+  let board_in_window, rest_queue = drain_board_window ~window_sec:5.0 q_drain in
   assert (List.length board_in_window = 2);
   (match board_in_window with
-   | first :: _ -> assert (String.equal first.post_id "rb2")
+   | first :: _ -> assert (String.equal first.post_id "rb2") (* urgency-sorted: Immediate first *)
    | [] -> Alcotest.fail "expected at least one board signal in window");
   assert (length rest_queue = 2);
 
   (* --- drain_board_window: empty queue --- *)
-  let (empty_board, empty_rest) = drain_board_window empty in
+  let empty_board, empty_rest = drain_board_window empty in
   assert (List.length empty_board = 0);
   assert (is_empty empty_rest);
 

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -9,20 +9,17 @@ let with_temp_base f =
   f base_path
 ;;
 
-let board_payload ?updated_at ~post_id () =
-  `Assoc
-    ([ "source", `String "board_signal"
-     ; "kind", `String "post_created"
-     ; "post_id", `String post_id
-     ; "author", `String "operator"
-     ; "title", `String "Ship reaction ledger"
-     ; "content", `String "Please react"
-     ]
-     @
-     match updated_at with
-     | Some value -> [ "updated_at_unix", `Float value ]
-     | None -> [])
-  |> Yojson.Safe.to_string
+let board_payload ?updated_at ~post_id:(_ : string) () :
+  Keeper_event_queue.stimulus_payload
+  =
+  Keeper_event_queue.Board_signal
+    { kind = Keeper_event_queue.Post_created
+    ; author = "operator"
+    ; title = "Ship reaction ledger"
+    ; content = "Please react"
+    ; hearth = None
+    ; updated_at
+    }
 ;;
 
 let board_stimulus ?(post_id = "post-42") ?updated_at () :
@@ -38,19 +35,10 @@ let board_stimulus ?(post_id = "post-42") ?updated_at () :
 let stay_silent_recovery_stimulus ?(keeper_name = "silent-keeper") () :
   Keeper_event_queue.stimulus
   =
-  let payload =
-    `Assoc
-      [ "source", `String "stay_silent_recovery"
-      ; "keeper", `String keeper_name
-      ; "streak", `Int 10
-      ; "threshold", `Int 10
-      ]
-    |> Yojson.Safe.to_string
-  in
   { post_id = "stay-silent-loop:" ^ keeper_name
   ; urgency = Immediate
   ; arrived_at = 1234.5
-  ; payload
+  ; payload = Keeper_event_queue.Stay_silent_recovery
   }
 ;;
 
@@ -359,29 +347,9 @@ let test_unknown_reaction_degrades_summary () =
     (summary |> member "pending_stimulus_count" |> to_int)
 ;;
 
-let test_malformed_typed_payload_degrades_summary () =
-  with_temp_base @@ fun base_path ->
-  let keeper_name = "malformed-payload-keeper" in
-  let stimulus =
-    { Keeper_event_queue.post_id = "bad-board"
-    ; urgency = Immediate
-    ; arrived_at = 1234.5
-    ; payload = {|{"source":"board_signal"|}
-    }
-  in
-  Keeper_reaction_ledger.record_event_queue_stimulus
-    ~base_path
-    ~keeper_name
-    stimulus;
-  let summary =
-    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
-  in
-  check_member_string "malformed payload summary status" "degraded" "status" summary;
-  check bool "malformed payload requires operator action" true
-    (summary |> member "operator_action_required" |> to_bool);
-  check int "payload parse error counted" 1
-    (summary |> member "payload_parse_error_count" |> to_int)
-;;
+(* RFC-0020: the stimulus payload is a typed closed variant, so a malformed
+   payload is unrepresentable — the prior [test_malformed_typed_payload_degrades_summary]
+   covered a parse-error path that can no longer occur and was removed. *)
 
 let () =
   run
@@ -423,10 +391,6 @@ let () =
             "unknown reaction degrades summary"
             `Quick
             test_unknown_reaction_degrades_summary
-        ; test_case
-            "malformed typed payload degrades summary"
-            `Quick
-            test_malformed_typed_payload_degrades_summary
         ] )
     ]
 ;;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1036,12 +1036,14 @@ let test_health_json_surfaces_durable_paused_keepers () =
             ; urgency = Immediate
             ; arrived_at = 1234.5
             ; payload =
-                Yojson.Safe.to_string
-                  (`Assoc
-                     [ "source", `String "board_signal"
-                     ; "kind", `String "post_created"
-                     ; "post_id", `String "health-post-1"
-                     ])
+                Keeper_event_queue.Board_signal
+                  { kind = Keeper_event_queue.Post_created
+                  ; author = ""
+                  ; title = ""
+                  ; content = ""
+                  ; hearth = None
+                  ; updated_at = None
+                  }
             }
           in
           Keeper_reaction_ledger.record_event_queue_stimulus
@@ -1533,13 +1535,14 @@ let test_health_json_reaction_ledger_cursor_sweep_clears_pending () =
           ; urgency = Immediate
           ; arrived_at = updated_at +. 10.0
           ; payload =
-              Yojson.Safe.to_string
-                (`Assoc
-                   [ "source", `String "board_signal"
-                   ; "kind", `String "post_created"
-                   ; "post_id", `String post_id
-                   ; "updated_at_unix", `Float updated_at
-                   ])
+              Keeper_event_queue.Board_signal
+                { kind = Keeper_event_queue.Post_created
+                ; author = ""
+                ; title = ""
+                ; content = ""
+                ; hearth = None
+                ; updated_at = Some updated_at
+                }
           }
         in
         List.iter


### PR DESCRIPTION
## 목적 (Phase 1 — 타입드 turn-trigger substrate)

keeper Event Layer는 turn-trigger stimulus를 `payload : string`(JSON 직렬화)으로 운반하고, `Keeper_event_queue.classify`가 JSON-prefix 문자열 매칭 + `Unsupported of string` catch-all로 종류를 복원했습니다. 이는 core harness 갭으로 지목된 **typed → string → reparse 왕복**입니다: board signal producer가 typed `Board_dispatch.board_signal`을 보유 → JSON 직렬화 → consumer가 그 JSON을 *재파싱*(실패 가능, prefix 불일치 시 silent drop).

RFC-0020(event queue layer separation)을 typed payload로 확장합니다.

## 변경

`payload : string` → 닫힌 `stimulus_payload` 합타입(`Board_signal of board_stimulus | Bootstrap | Stay_silent_recovery`), `keeper_runtime` 소유.
- board 변형은 typed `board_stimulus` DTO를 운반. **경계 보존**: 저수준 `keeper_runtime` 큐가 `board` 도메인 lib에 의존하지 않도록, keeper 레이어(둘 다 보이는 곳)가 enqueue/drain 경계에서 total `board_signal_of_board_stimulus`로 변환.
- `classify` / `stimulus_class` / `Unsupported` 삭제 → 미인식 stimulus가 **표현 불가능**(silent downgrade 제거). 새 종류 추가 시 모든 consumer가 컴파일 에러로 처리 강제.
- consumer(`keeper_heartbeat_stimulus_intake`, `keeper_reaction_ledger`, `keeper_world_observation`)는 typed payload를 exhaustive match.
- reaction-ledger 감사에서 `payload_parse_error`(typed면 파싱 실패 불가)와 string-payload JSON 헬퍼 5개 제거; preview는 typed payload에서 write-time 생성.
- producer 3종은 typed payload를 직접 구성.

순 -165줄 (직렬화/파싱/분류 제거).

## 검증

- `dune build --root .` (lib + tests) exit 0.
- `test_keeper_event_queue`, `keeper_event_queue/`, `keeper_event_queue_decision/`, `test_keeper_reaction_ledger`(9/9) 전부 통과.
- `test_server_runtime_bootstrap`의 2건 실패(MCP handshake / token file)는 **pre-existing 환경 문제**: origin/main을 같은 환경에서 stash 대조 실행 → 동일 2건 동일 실패(curl connection-refused, 매번 다른 로컬 포트 = 라이브 masc 데몬 경합). event-queue 변경과 코드 경로 교집합 0.

## 워크어라운드 게이트

이 PR은 문자열 분류기를 **제거**합니다(추가 아님). `Unsupported of string` catch-all과 `classify` JSON-prefix 매칭을 닫힌 합타입으로 대체 — CLAUDE.md 워크어라운드 시그니처 #2(string 분류기)의 정반대 방향.

RFC-WAIVED: keeper Event Layer 데이터 타입 리팩터. credential/operator/sandbox/hooks/workflow subsystem 변경 아님. RFC-0020(기존) 확장.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

WORKAROUND-WAIVED: false positive — this PR REMOVES the string classifier (classify/Unsupported JSON-prefix matching) and replaces it with a closed sum type. The signature keywords appear because the body describes deleting the workaround, not adding one. Net effect is the opposite of the STRING_CLASSIFIER anti-pattern.
