### PR TITLE
Phase 3: temporal stale-fact decay with stale_factor, last_verified_at, expected_lifetime_cycles

### DIFF
--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -316,3 +316,17 @@ let read_episodes_tail ~keeper_id ~n =
   let events = read_events_tail ~keeper_id ~n in
   if events = [] then read_episode_files_tail ~keeper_id ~n else events
 ;;
+(** Post-turn stale detection: reads [n] recent facts, increments stale_factor
+    for facts without recent verification, and appends updated records. *)
+let decay_stale_facts ~keeper_id ~now ?(n = 50) () =
+  read_facts_tail ~keeper_id ~n
+  |> List.map (fun fact ->
+    let stale_factor =
+      match fact.last_verified_at with
+      | None -> Float.min 1.0 (fact.stale_factor +. 0.1)
+      | Some ts when now -. ts > 3600.0 -> Float.min 1.0 (fact.stale_factor +. 0.1)
+      | _ -> fact.stale_factor
+    in
+    { fact with stale_factor })
+  |> List.iter (append_fact ~keeper_id)
+;;

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -321,10 +321,22 @@ let read_episodes_tail ~keeper_id ~n =
 let decay_stale_facts ~keeper_id ~now ?(n = 50) () =
   read_facts_tail ~keeper_id ~n
   |> List.map (fun fact ->
+    let default_lifetime_sec = 3600.0 in
+    let default_decay = 0.1 in
+    let lifetime_sec =
+      match fact.expected_lifetime_cycles with
+      | None -> default_lifetime_sec
+      | Some cycles -> float (max 1 cycles) *. 60.0
+    in
+    let decay_rate =
+      match fact.expected_lifetime_cycles with
+      | None -> default_decay
+      | Some cycles -> default_decay /. float (max 1 cycles)
+    in
     let stale_factor =
       match fact.last_verified_at with
-      | None -> Float.min 1.0 (fact.stale_factor +. 0.1)
-      | Some ts when now -. ts > 3600.0 -> Float.min 1.0 (fact.stale_factor +. 0.1)
+      | None -> Float.min 1.0 (fact.stale_factor +. decay_rate)
+      | Some ts when now -. ts > lifetime_sec -> Float.min 1.0 (fact.stale_factor +. decay_rate)
       | _ -> fact.stale_factor
     in
     { fact with stale_factor })

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -27,6 +27,7 @@ val load_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t 
 
 val read_facts_tail : keeper_id:string -> n:int -> fact list
 val read_events_tail : keeper_id:string -> n:int -> episode list
+val decay_stale_facts : keeper_id:string -> now:float -> ?n:int -> unit -> unit
 val read_episodes_tail : keeper_id:string -> n:int -> episode list
 
 module For_testing : sig

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -28,7 +28,12 @@ let stale_penalty fact =
   1.0 -. Float.min 1.0 (Float.max 0.0 fact.stale_factor)
 ;;
 let score_fact ?(lambda = default_lambda) ?(alpha = default_alpha) ~now fact =
-  fact.confidence *. recency_factor ~lambda ~now fact.last_accessed *. access_factor ~alpha fact.access_count *. stale_penalty fact
+  let effective_lambda =
+    match fact.expected_lifetime_cycles with
+    | None -> lambda
+    | Some n -> lambda *. (1.0 +. 1.0 /. float (max 1 n))
+  in
+  fact.confidence *. recency_factor ~lambda:effective_lambda ~now fact.last_accessed *. access_factor ~alpha fact.access_count *. stale_penalty fact
 ;;
 
 let score_tool_result

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -23,8 +23,12 @@ let access_factor ~alpha access_count =
   (1.0 +. float access_count) ** alpha
 ;;
 
+(** Stale penalty: stale_factor 0.0 = no penalty, 1.0 = zero contribution. *)
+let stale_penalty fact =
+  1.0 -. Float.min 1.0 (Float.max 0.0 fact.stale_factor)
+;;
 let score_fact ?(lambda = default_lambda) ?(alpha = default_alpha) ~now fact =
-  fact.confidence *. recency_factor ~lambda ~now fact.last_accessed *. access_factor ~alpha fact.access_count
+  fact.confidence *. recency_factor ~lambda ~now fact.last_accessed *. access_factor ~alpha fact.access_count *. stale_penalty fact
 ;;
 
 let score_tool_result

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -4,7 +4,7 @@
     Episodes group related facts with a short summary and metadata for
     downstream retention scoring. *)
 
-let schema_version = "rfc0231-v1"
+let schema_version = "rfc0231-v2"
 
 type provenance_event =
   { trace_id : string
@@ -21,6 +21,8 @@ type fact =
   ; first_seen : float
   ; last_accessed : float
   ; valid_until : float option
+  ; stale_factor : float
+  ; last_verified_at : float option
   ; schema_version : string
   }
 
@@ -117,10 +119,14 @@ let fact_to_json f =
      ; "first_seen", `Float f.first_seen
      ; "last_accessed", `Float f.last_accessed
      ; "schema_version", `String f.schema_version
+     ; "stale_factor", `Float f.stale_factor
      ]
      @
      match f.valid_until with
      | Some ts -> [ "valid_until", `Float ts ]
+     | None -> [])
+     @ (match f.last_verified_at with
+     | Some ts -> [ "last_verified_at", `Float ts ]
      | None -> [])
 ;;
 
@@ -143,6 +149,8 @@ let fact_of_json (json : Yojson.Safe.t) =
           (* DET-OK: absent last_accessed inherits first_seen. *)
           let last_accessed = Option.value (json_float_field "last_accessed" fields) ~default:first_seen in
           let valid_until = json_float_field "valid_until" fields in
+          let stale_factor = Option.value (json_float_field "stale_factor" fields) ~default:0.0 in
+          let last_verified_at = json_float_field "last_verified_at" fields in
           Some
             { claim
             ; confidence = Float.max 0.0 (Float.min 1.0 confidence)
@@ -152,6 +160,8 @@ let fact_of_json (json : Yojson.Safe.t) =
             ; first_seen
             ; last_accessed
             ; valid_until
+            ; stale_factor
+            ; last_verified_at
             ; schema_version =
                 (* DET-OK: default to current schema for forward compatibility. *)
                 Option.value (json_string_field "schema_version" fields) ~default:schema_version

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -22,6 +22,7 @@ type fact =
   ; last_accessed : float
   ; valid_until : float option
   ; stale_factor : float
+  ; expected_lifetime_cycles : int option
   ; last_verified_at : float option
   ; schema_version : string
   }
@@ -128,6 +129,9 @@ let fact_to_json f =
      @ (match f.last_verified_at with
      | Some ts -> [ "last_verified_at", `Float ts ]
      | None -> [])
+     @ (match f.expected_lifetime_cycles with
+     | Some cycles -> [ "expected_lifetime_cycles", `Int cycles ]
+     | None -> [])
 ;;
 
 let fact_of_json (json : Yojson.Safe.t) =
@@ -151,6 +155,7 @@ let fact_of_json (json : Yojson.Safe.t) =
           let valid_until = json_float_field "valid_until" fields in
           let stale_factor = Option.value (json_float_field "stale_factor" fields) ~default:0.0 in
           let last_verified_at = json_float_field "last_verified_at" fields in
+          let expected_lifetime_cycles = json_int_field "expected_lifetime_cycles" fields in
           Some
             { claim
             ; confidence = Float.max 0.0 (Float.min 1.0 confidence)
@@ -162,6 +167,7 @@ let fact_of_json (json : Yojson.Safe.t) =
             ; valid_until
             ; stale_factor
             ; last_verified_at
+            ; expected_lifetime_cycles
             ; schema_version =
                 (* DET-OK: default to current schema for forward compatibility. *)
                 Option.value (json_string_field "schema_version" fields) ~default:schema_version

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -26,6 +26,7 @@ type fact =
   ; valid_until : float option
   ; stale_factor : float
   ; last_verified_at : float option
+  ; expected_lifetime_cycles : int option
   ; schema_version : string
   }
 

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -24,6 +24,8 @@ type fact =
   ; first_seen : float
   ; last_accessed : float
   ; valid_until : float option
+  ; stale_factor : float
+  ; last_verified_at : float option
   ; schema_version : string
   }
 


### PR DESCRIPTION
Implements Phase3 stale-fact lifecycle:

**Changes:**
- `stale_factor` and `last_verified_at` fields on `fact` type
- `stale_penalty` in `score_fact` (multiplicative: 1.0 - stale_factor)
- `expected_lifetime_cycles` for truth-lag compensation
- `decay_stale_facts` post-turn stale detection hook

**Formula:**
```
score = confidence * recency_factor * access_factor * stale_penalty
```

**Related:**
- PR #21175 (sangsu, Phase3a: inverse recency bonus)
- Complementary approaches: additive bonus (sangsu) + multiplicative penalty (rondo)