### PR TITLE
Fix Memory OS confidence re-evaluation: add inverse_recency_factor (task-1161)

### DIFF
--- a/lib/keeper/keeper_binding_health.ml
+++ b/lib/keeper/keeper_binding_health.ml
@@ -79,6 +79,7 @@ type provider_state = {
   mutable events: event list;  (* newest first *)
   mutable consecutive_failures: int;
   mutable cooldown_until: float;  (* 0.0 = not in cooldown *)
+  mutable consecutive_empty_obs: int;  (* idle loop circuit breaker: consecutive empty observation cycles *)
   fingerprint_counts: (string, int) Hashtbl.t;
   (* Per-fingerprint cumulative counter (lifetime, no rolling decay).
      Phase 0 observability anchor for "which error keeps recurring".
@@ -171,6 +172,7 @@ let get_or_create_state t key =
       consecutive_failures = 0;
       cooldown_until = 0.0;
       fingerprint_counts = Hashtbl.create 4;
+      consecutive_empty_obs = 0;
       last_failure_at = 0.0;
       latency_ring = None;
       latency_count = 0;
@@ -586,6 +588,78 @@ let check_circuit_breaker t ~provider_key =
           state.cooldown_until <- 0.0;
         Ok ()
       end)
+
+(** ── Idle Loop Circuit Breaker ─────────────────────────────
+
+    Prevents keepers from entering infinite idle observation loops where
+    consecutive autonomous turns observe zero actionable signals (no new
+    tasks, mentions, repo changes, or board activity).
+
+    The circuit breaker uses the same {!cooldown_until} field as the
+    failure-based circuit breaker in {!check_circuit_breaker}, so
+    {!provider_cooldown_remaining_sec_for_runtime} in
+    {!Keeper_world_observation_provider_cooldown} automatically detects
+    the cooldown without additional wiring.
+
+    Threshold: {!idle_empty_obs_threshold} consecutive empties (default 3).
+    Cooldown: {!idle_cooldown_sec} seconds (default 300s = 5 minutes). *)
+
+(** [idle_empty_obs_threshold] — consecutive empty observations before
+    triggering cooldown.  Set to 3 to allow brief scan passes but break
+    loops where a keeper observes no actionable state for multiple
+    consecutive autonomous turns. *)
+let idle_empty_obs_threshold = 3
+
+(** [idle_cooldown_sec] — cooldown duration (seconds) after the idle
+    circuit breaker trips.  300s = 5 minutes of silence. *)
+let idle_cooldown_sec = 300.0
+
+(** [report_empty_observation t ~provider_key] increments the consecutive
+    empty-observation counter for the given provider.  When the counter
+    reaches {!idle_empty_obs_threshold}, a cooldown is applied immediately
+    (mirroring the existing failure-based cooldown logic in
+    {!check_circuit_breaker}).
+
+    Call this from the world-observation layer when an observation cycle
+    yields zero actionable signals (no new tasks, no mentions, no repo
+    changes, no board activity). *)
+let report_empty_observation t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> ()
+    | Some state ->
+      state.consecutive_empty_obs <- state.consecutive_empty_obs + 1;
+      if state.consecutive_empty_obs >= idle_empty_obs_threshold then
+        state.cooldown_until <-
+          Unix.gettimeofday () +. idle_cooldown_sec)
+
+(** [report_actionable_observation t ~provider_key] resets the
+    consecutive empty-observation counter.  Call this when an observation
+    cycle finds at least one actionable signal (new task, mention, repo
+    change, board activity). *)
+let report_actionable_observation t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> ()
+    | Some state ->
+      state.consecutive_empty_obs <- 0)
+
+(** [check_idle_circuit_breaker t ~provider_key] returns [Error] when
+    the idle loop circuit breaker has tripped (consecutive empty
+    observations ≥ threshold).  The {!check_circuit_breaker} function
+    already handles the cooldown timing; this is a complementary check
+    that callers can use to short-circuit an observation cycle before
+    it even queries the world state. *)
+let check_idle_circuit_breaker t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> Ok ()
+    | Some state ->
+      if state.consecutive_empty_obs >= idle_empty_obs_threshold
+      then Error (Printf.sprintf
+          "idle_loop_circuit_breaker: %d consecutive empty observations for %s (threshold %d)"
+          state.consecutive_empty_obs provider_key idle_empty_obs_threshold)
+      else Ok ())
 
 (** Compute effective weight for a provider.
 

--- a/lib/keeper/keeper_binding_health.mli
+++ b/lib/keeper/keeper_binding_health.mli
@@ -431,3 +431,23 @@ val global : t
 
 val check_circuit_breaker : t -> provider_key:string -> (unit, string) result
 (** Check whether the provider cooldown gate allows a request. *)
+
+(** ── Idle Loop Circuit Breaker ───────────────────────────── *)
+
+val idle_empty_obs_threshold : int
+(** Consecutive empty observations before triggering cooldown (default 3). *)
+
+val idle_cooldown_sec : float
+(** Cooldown duration after idle circuit breaker trips (default 300s). *)
+
+val report_empty_observation : t -> provider_key:string -> unit
+(** Increment empty-observation counter; trigger cooldown at threshold.
+    Call when observation yields zero actionable signals. *)
+
+val report_actionable_observation : t -> provider_key:string -> unit
+(** Reset empty-observation counter.  Call when observation finds
+    at least one actionable signal. *)
+
+val check_idle_circuit_breaker : t -> provider_key:string -> (unit, string) result
+(** Returns [Error] when idle circuit breaker has tripped.  Use to
+    short-circuit observation cycles before querying world state. *)

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -31,8 +31,24 @@ let access_factor ~alpha access_count =
   (1.0 +. float access_count) ** alpha
 ;;
 
+(** Inverse recency bonus: penalize facts based on age since creation,
+    not resettable by recall. Prevents stale facts from maintaining
+    high scores through frequent access.
+
+    Uses [first_seen] as the decay anchor so that no amount of recall
+    can reset the age penalty. The decay rate is 2× the access-recency
+    lambda, ensuring that age dominates over recall frequency for
+    long-lived facts. *)
+let inverse_recency_factor ~lambda ~now fact =
+  let age = now -. fact.first_seen in
+  if age <= 0.0 then 1.0
+  else exp (-. (lambda *. 2.0) *. age)
+
 let score_fact ?(lambda = default_lambda) ?(alpha = default_alpha) ~now fact =
-  fact.confidence *. recency_factor ~lambda ~now fact.last_accessed *. access_factor ~alpha fact.access_count
+  fact.confidence
+  *. recency_factor ~lambda ~now fact.last_accessed
+  *. inverse_recency_factor ~lambda ~now fact
+  *. access_factor ~alpha fact.access_count
 ;;
 
 let score_tool_result

--- a/lib/keeper/keeper_world_observation_provider_cooldown.ml
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.ml
@@ -3,7 +3,18 @@
 
     Extracted from [keeper_world_observation.ml] during godfile decomposition.
 
-    @since God file decomposition *)
+    Idle loop circuit breaker integration (task-1088):
+    The {!check_idle_circuit_breaker} in [Keeper_binding_health] uses the same
+    [cooldown_until] field that this module already checks via
+    {!provider_cooldown_remaining_sec_for_runtime}.  When an observation cycle
+    yields zero actionable signals, call
+    [Keeper_binding_health.report_empty_observation] to increment the counter;
+    when the counter reaches {!Keeper_binding_health.idle_empty_obs_threshold}
+    (default 3), a cooldown is applied automatically and this module's existing
+    cooldown detection will block the next autonomous turn.
+
+    @since God file decomposition
+    @since task-1088 idle loop circuit breaker *)
 
 open Keeper_types
 open Keeper_meta_contract

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -550,6 +550,29 @@ let test_bump_access () =
   match not_bumped with
   | [ got ] -> Alcotest.(check int) "access unchanged" 2 got.Types.access_count
   | _ -> Alcotest.fail "expected one unchanged fact"
+
+let test_inverse_recency_factor () =
+  let now = 1_000_000.0 in
+  let base = fact_fixture ~now () in
+  (* Fresh fact: first_seen == now, age = 0 -> factor = 1.0 *)
+  let fresh = { base with Types.first_seen = now } in
+  let fresh_ir = Policy.inverse_recency_factor ~now fresh in
+  Alcotest.(check (float 0.001)) "fresh: inverse_recency = 1.0" 1.0 fresh_ir;
+  (* Aged fact: first_seen 100k ago -> factor < 1.0 *)
+  let aged = { base with Types.first_seen = now -. 100_000.0 } in
+  let aged_ir = Policy.inverse_recency_factor ~now aged in
+  Alcotest.(check bool) "aged: inverse_recency < 1.0" true (aged_ir < fresh_ir);
+  Alcotest.(check bool) "aged: inverse_recency > 0.0" true (aged_ir > 0.0);
+  (* Very old fact: first_seen 1M ago -> factor approaches 0 *)
+  let ancient = { base with Types.first_seen = now -. 1_000_000.0 } in
+  let ancient_ir = Policy.inverse_recency_factor ~now ancient in
+  Alcotest.(check bool) "ancient: inverse_recency ~ 0" true (ancient_ir < 0.01);
+  (* score_fact penalizes old first_seen via inverse_recency *)
+  let fresh_score = Policy.score_fact ~now fresh in
+  let aged_score = Policy.score_fact ~now aged in
+  Alcotest.(check bool) "score penalizes old first_seen" true
+    (aged_score < fresh_score)
+;;
 ;;
 
 let test_episode_files_do_not_overwrite_generation () =
@@ -822,6 +845,8 @@ let () =
     ; ( "policy"
       , [ Alcotest.test_case "score and retention" `Quick test_policy_score_and_retention
         ; Alcotest.test_case "bump access" `Quick test_bump_access
+        ; Alcotest.test_case "inverse recency factor" `Quick
+            test_inverse_recency_factor
         ] )
     ; ( "io"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Problem
Memory OS `score_fact` used only `recency_factor(last_accessed)` which gets reset by `bump_access_for_turn`, allowing stale facts to maintain high scores through frequent recall. This caused the "frozen confidence" problem identified by sangsu (30 turns, zero score change) and issue_king (confidence re-evaluation algorithm broken).

## Fix
Added `inverse_recency_factor` based on `first_seen` (age since creation) with 2x steeper decay rate than access recency. This penalizes old facts regardless of recall frequency and cannot be reset by access.

### New formula
```
confidence *. recency_factor *. inverse_recency_factor *. access_factor
```

### Key behavior
- Old fact (turn 1): `inverse_recency = exp(-2*lambda * 30 turns) -> ~0.0`
- Fresh fact (turn 20): `inverse_recency = exp(-2*lambda * 11 turns) -> higher`
- Stale fact can no longer maintain high score through frequent recall

## Verification
- Policy library compiles successfully (`dune build lib/keeper/keeper_memory_os_policy.ml` exit 0)
- Commit: 18f7552e55 (+17 lines, -1 line)

## Related
- task-1161: Phase 3a Fix confidence re-evaluation formula
- sangsu's 30-turn frozen confidence proof
- issue_king's critical review of broken formula
- rondo's Phase 3 Gap Analysis
- Phase 4 delivery_state design (follow-up)