### PR TITLE
Phase5+: Add GC module for stale-fact lifecycle in Memory OS

### DIFF
--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -1,0 +1,116 @@
+(** Keeper_memory_os_gc — deterministic garbage collection for stale facts.
+
+    The GC reads all facts from a keeper's JSONL fact file, scores each
+    fact using [Policy.score_fact], applies [Policy.decide_retention],
+    filters TTL-expired facts, deduplicates by claim (keeping the
+    highest-scored fact per cluster), and writes the surviving set
+    back atomically.
+
+    Design properties:
+    - Deterministic: no LLM calls, no embeddings
+    - Offline: runs locally in the keeper process
+    - Safe: writes via temp-file + rename (write_file_atomically)
+    - Idempotent: running twice produces the same result
+    - No-force: only [Discard] and [ReferenceOnly] verdicts are evicted *)
+
+open Keeper_memory_os_types
+open Keeper_memory_os_policy
+module Io = Keeper_memory_os_io
+
+(** GC result statistics. *)
+type gc_report = {
+  total_input : int;        (** facts read from disk *)
+  ttl_expired : int;        (** facts with valid_until < now *)
+  verdict_discarded : int;   (** Decide_retention → Discard *)
+  dedup_removed : int;      (** lower-scored duplicates *)
+  written : int;            (** facts written back *)
+}
+[@@deriving yojson, show]
+
+let empty_report = {
+  total_input = 0; ttl_expired = 0; verdict_discarded = 0;
+  dedup_removed = 0; written = 0;
+}
+
+(** Check if a fact's TTL has expired. *)
+let ttl_expired ~now (f : fact) =
+  match f.valid_until with
+  | None -> false
+  | Some t -> now > t
+
+(** Score a fact and apply retention verdict. *)
+let score_and_verdict ~now (f : fact) =
+  let score = score_fact ~now f in
+  let verdict = decide_retention score in
+  (f, score, verdict)
+
+(** Should this fact survive? *)
+let should_keep (_, _, verdict) =
+  match verdict with
+  | KeepVerbatim | Summarize -> true
+  | ReferenceOnly | Discard -> false
+
+(** Deduplicate by claim (case-insensitive): keep highest-scored fact. *)
+let dedup_by_claim scored =
+  let tbl : (string, fact * float * retention_verdict) Hashtbl.t =
+    Hashtbl.create 64
+  in
+  List.iter (fun item ->
+    let (f, score, verdict) = item in
+    let key = String.lowercase_ascii f.claim in
+    match Hashtbl.find_opt tbl key with
+    | None -> Hashtbl.add tbl key item
+    | Some (_, existing_score, _) when score > existing_score ->
+      Hashtbl.replace tbl key item
+    | Some _ -> ()  (* keep existing higher-scored fact *)
+  ) scored;
+  Hashtbl.fold (fun _ v acc -> v :: acc) tbl []
+
+(** Run GC on a single keeper's fact file.
+
+    Returns [Some report] if GC ran (even if no facts were removed).
+    Returns [None] if the fact file does not exist. *)
+let run_gc ~keeper_id ~now =
+  let path = Io.facts_path ~keeper_id in
+  if not (Sys.file_exists path)
+  then None
+  else begin
+    let lines = Io.read_all_jsonl path in
+    (* Parse facts, skip malformed lines. *)
+    let facts = List.filter_map (fun line ->
+      match Yojson.Safe.from_string line with
+      | json -> (
+        match fact_of_json json with
+        | Ok f -> Some f
+        | Error _ -> None  (* skip malformed *)
+      )
+    ) lines in
+    let total = List.length facts in
+    (* Filter TTL-expired facts. *)
+    let (live, expired) = List.partition (fun f -> not (ttl_expired ~now f)) facts in
+    let n_expired = List.length expired in
+    (* Score and apply retention verdict. *)
+    let scored = List.map (score_and_verdict ~now) live in
+    let (kept_by_verdict, discarded) = List.partition should_keep scored in
+    let n_discarded = List.length discarded in
+    (* Deduplicate by claim. *)
+    let deduped = dedup_by_claim kept_by_verdict in
+    let n_deduped = List.length kept_by_verdict - List.length deduped in
+    (* Write back surviving facts atomically. *)
+    let json_lines = List.map (fun (f, _, _) -> fact_to_json f) deduped in
+    let content =
+      json_lines
+      |> List.map Yojson.Safe.to_string
+      |> String.concat "\n"
+    in
+    Io.write_file_atomically path content;
+    let report = {
+      total_input = total;
+      ttl_expired = n_expired;
+      verdict_discarded = n_discarded;
+      dedup_removed = n_deduped;
+      written = List.length deduped;
+    } in
+    Some report
+  end
+;;

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -82,3 +82,20 @@ let bump_access_for_turn ~now (facts : fact list) ~(turn_text : string) : fact l
        else f)
     facts
 ;;
+
+(** Retention verdict for scored facts. *)
+type retention_verdict = KeepVerbatim | Summarize | ReferenceOnly | Discard
+[@@deriving yojson, show]
+
+(** Map a composite score to a retention decision.
+
+    Thresholds:
+    - > 0.8 → KeepVerbatim (high-confidence, recently accessed)
+    - > 0.5 → Summarize  (moderate importance, can be compressed)
+    - > 0.3 → ReferenceOnly (low importance, keep reference only)
+    - ≤ 0.3 → Discard     (negligible, safe to remove) *)
+let decide_retention score =
+  if score > 0.8 then KeepVerbatim
+  else if score > 0.5 then Summarize
+  else if score > 0.3 then ReferenceOnly
+  else Discard

--- a/test/dune
+++ b/test/dune
@@ -78,6 +78,7 @@
   test_keeper_turn_disposition
   test_keeper_turn_terminal_disposition_field
   test_keeper_memory_os
+    test_keeper_memory_os_gc
   test_keeper_reconcile_state
   test_attempt_state
   test_runtime_attempt_fsm
@@ -358,6 +359,7 @@
   test_keeper_turn_disposition
   test_keeper_turn_terminal_disposition_field
   test_keeper_memory_os
+    test_keeper_memory_os_gc
   test_keeper_reconcile_state
   test_attempt_state
   test_runtime_attempt_fsm

--- a/test/test_keeper_memory_os_gc.ml
+++ b/test/test_keeper_memory_os_gc.ml
@@ -1,0 +1,119 @@
+(** Unit tests for Keeper_memory_os_gc — deterministic garbage collection. *)
+
+open Keeper_memory_os_gc
+open Keeper_memory_os_types
+open Keeper_memory_os_policy
+
+(* --- Helpers --- *)
+
+let now = 1_700_000_000.0
+
+let fresh_fact ?(valid_until = None) ~last_accessed claim confidence =
+  { claim
+  ; confidence
+  ; created_at = now -. 1000.0
+  ; last_accessed
+  ; access_count = 1
+  ; source = "test"
+  ; category = "test"
+  ; valid_until
+  }
+
+(* --- TTL expired --- *)
+
+let test_ttl_expired () =
+  (* Fact with expired TTL *)
+  let f = fresh_fact ~valid_until:(Some (now -. 10.0)) ~last_accessed:now "old" 0.9 in
+  Alcotest.(check bool "expired" true (ttl_expired ~now f));
+  (* Fact with future TTL *)
+  let f2 = fresh_fact ~valid_until:(Some (now +. 1000.0)) ~last_accessed:now "fresh" 0.9 in
+  Alcotest.(check bool "not expired" false (ttl_expired ~now f2));
+  (* Fact with no TTL (None) *)
+  let f3 = fresh_fact ~last_accessed:now "no-ttl" 0.9 in
+  Alcotest.(check bool "no ttl" false (ttl_expired ~now f3));
+  (* Fact with TTL exactly at now (boundary: not expired) *)
+  let f4 = fresh_fact ~valid_until:(Some now) ~last_accessed:now "boundary" 0.9 in
+  Alcotest.(check bool "boundary" false (ttl_expired ~now f4))
+
+(* --- should_keep --- *)
+
+let test_should_keep () =
+  let kv = (fresh_fact ~last_accessed:now "kv" 0.9, 0.85, KeepVerbatim) in
+  Alcotest.(check bool "keep verbatim" true (should_keep kv));
+  let sm = (fresh_fact ~last_accessed:now "sm" 0.6, 0.6, Summarize) in
+  Alcotest.(check bool "keep summarize" true (should_keep sm));
+  let ro = (fresh_fact ~last_accessed:now "ro" 0.2, 0.35, ReferenceOnly) in
+  Alcotest.(check bool "drop reference" false (should_keep ro));
+  let dc = (fresh_fact ~last_accessed:now "dc" 0.1, 0.1, Discard) in
+  Alcotest.(check bool "drop discard" false (should_keep dc))
+
+(* --- dedup_by_claim --- *)
+
+let test_dedup_same_claim () =
+  let f1 = (fresh_fact ~last_accessed:now "Same Claim" 0.9, 0.85, KeepVerbatim) in
+  let f2 = (fresh_fact ~last_accessed:now "Same Claim" 0.5, 0.4, Summarize) in
+  let f3 = (fresh_fact ~last_accessed:now "Same Claim" 0.7, 0.6, Summarize) in
+  let result = dedup_by_claim [f1; f2; f3] in
+  Alcotest.(check int "keeps one" 1 (List.length result));
+  (* Should keep highest-scored *)
+  let (best_f, best_score, _) = List.hd result in
+  Alcotest.(check float "best score" ~epsilon:0.001 0.85 best_score)
+
+let test_dedup_different_claims () =
+  let f1 = (fresh_fact ~last_accessed:now "claim A" 0.9, 0.85, KeepVerbatim) in
+  let f2 = (fresh_fact ~last_accessed:now "claim B" 0.5, 0.4, Summarize) in
+  let f3 = (fresh_fact ~last_accessed:now "claim C" 0.7, 0.6, Summarize) in
+  let result = dedup_by_claim [f1; f2; f3] in
+  Alcotest.(check int "keeps all three" 3 (List.length result))
+
+let test_dedup_case_insensitive () =
+  let f1 = (fresh_fact ~last_accessed:now "UPPER Claim" 0.9, 0.85, KeepVerbatim) in
+  let f2 = (fresh_fact ~last_accessed:now "upper claim" 0.5, 0.4, Summarize) in
+  let result = dedup_by_claim [f1; f2] in
+  Alcotest.(check int "deduplicates case-insensitive" 1 (List.length result))
+
+let test_dedup_empty () =
+  let result = dedup_by_claim [] in
+  Alcotest.(check int "empty list" 0 (List.length result))
+
+(* --- score_and_verdict --- *)
+
+let test_score_and_verdict () =
+  let f = fresh_fact ~last_accessed:now "high" 0.9 in
+  let (_, score, verdict) = score_and_verdict ~now f in
+  Alcotest.(check bool "high score → KeepVerbatim" true (score > 0.8));
+  let _match_keep =
+    match verdict with KeepVerbatim -> true | _ -> false
+  in
+  Alcotest.(check bool "verdict is KeepVerbatim" true _match_keep);
+  (* Low-confidence old fact *)
+  let f2 = fresh_fact ~last_accessed:(now -. 1_000_000.0) "low" 0.1 in
+  let (_, score2, verdict2) = score_and_verdict ~now f2 in
+  Alcotest.(check bool "low score → Discard range" true (score2 < 0.3));
+  let _match_discard =
+    match verdict2 with Discard -> true | _ -> false
+  in
+  Alcotest.(check bool "verdict is Discard" true _match_discard)
+
+(* --- empty_report --- *)
+
+let test_empty_report () =
+  Alcotest.(check int "total" 0 empty_report.total_input);
+  Alcotest.(check int "ttl" 0 empty_report.ttl_expired);
+  Alcotest.(check int "verdict" 0 empty_report.verdict_discarded);
+  Alcotest.(check int "dedup" 0 empty_report.dedup_removed);
+  Alcotest.(check int "written" 0 empty_report.written)
+
+(* --- Test suite --- *)
+
+let () =
+  Alcotest.run "Keeper_memory_os_gc" [
+    Alcotest.test_case "ttl_expired" `Quick test_ttl_expired;
+    Alcotest.test_case "should_keep" `Quick test_should_keep;
+    Alcotest.test_case "dedup same claim" `Quick test_dedup_same_claim;
+    Alcotest.test_case "dedup different claims" `Quick test_dedup_different_claims;
+    Alcotest.test_case "dedup case insensitive" `Quick test_dedup_case_insensitive;
+    Alcotest.test_case "dedup empty" `Quick test_dedup_empty;
+    Alcotest.test_case "score_and_verdict" `Quick test_score_and_verdict;
+    Alcotest.test_case "empty_report" `Quick test_empty_report;
+  ]


### PR DESCRIPTION
## Summary
Implements deterministic garbage collection for Memory OS facts (`keeper_memory_os_gc.ml`).

## What it does
- Reads all facts from a keeper's JSONL fact file
- Scores each fact via `Policy.score_fact ~now`
- Applies `decide_retention` verdict (KeepVerbatim/Summarize survive, Discard/ReferenceOnly evicted)
- Filters TTL-expired facts (`valid_until < now`)
- Deduplicates by claim (case-insensitive, keeps highest-scored)
- Writes surviving facts back atomically via `write_file_atomically`

## Design properties
- **Deterministic**: no LLM calls, no embeddings
- **Offline**: runs locally in the keeper process
- **Safe**: temp-file + rename (write_file_atomically)
- **Idempotent**: running twice produces the same result
- **No-force**: only Discard and ReferenceOnly verdicts are evicted

## API
```ocaml
val run_gc : keeper_id:string -> now:float -> gc_report option
```

## Report type
```ocaml
type gc_report = {
  total_input : int;
  ttl_expired : int;
  verdict_discarded : int;
  dedup_removed : int;
  written : int;
}
```

## Context
- Connects to analyst's causal proof of stale-fact confidence inversion (9-cycle attractor)
- Complements garnet's DecayTrigger design (Phase 4): triggers detect staleness, GC removes it
- Validates garnet/executor's empirical observation: 0.99-confidence facts are stale, dedup needed

## Task
Closes task-1169