### PR TITLE
Fix typed Execute validation retry loops

### DIFF
--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -12,7 +12,6 @@ type deterministic_reason =
   | Completion_contract_violation
   | Structured_tool_payload
   | Workflow_rejection_blocked
-  | Git_precondition_failed
   | Path_not_found
 
 type classification_source =
@@ -46,7 +45,6 @@ let to_telemetry_key = function
     "deterministic_error_completion_contract_violation"
   | Structured_tool_payload -> "deterministic_error_structured_tool_payload"
   | Workflow_rejection_blocked -> "deterministic_error_workflow_rejection_blocked"
-  | Git_precondition_failed -> "deterministic_error_git_precondition_failed"
   | Path_not_found -> "deterministic_error_path_not_found"
 ;;
 
@@ -70,8 +68,6 @@ let to_string = function
     "raw shell rejected; caller must use the visible structured tool from the recovery plan"
   | Workflow_rejection_blocked ->
     "workflow rejection explicitly marked deterministic and unrecoverable"
-  | Git_precondition_failed ->
-    "git command failed a process precondition; inspect repository/ref state or change the command"
   | Path_not_found ->
     "a typed Execute path argument does not exist; probe the parent directory before retrying"
 ;;
@@ -111,7 +107,6 @@ let reason_to_wire = function
   | Completion_contract_violation -> "completion_contract_violation"
   | Structured_tool_payload -> "structured_tool_payload"
   | Workflow_rejection_blocked -> "workflow_rejection_blocked"
-  | Git_precondition_failed -> "git_precondition_failed"
   | Path_not_found -> "path_not_found"
 ;;
 
@@ -127,7 +122,6 @@ let reason_of_wire = function
   | "completion_contract_violation" -> Some Completion_contract_violation
   | "structured_tool_payload" -> Some Structured_tool_payload
   | "workflow_rejection_blocked" -> Some Workflow_rejection_blocked
-  | "git_precondition_failed" -> Some Git_precondition_failed
   | "path_not_found" -> Some Path_not_found
   | _ -> None
 ;;

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -49,12 +49,6 @@ type deterministic_reason =
           separate counter in [Keeper_tools_oas]. It is considered
           deterministic only when the payload explicitly carries
           [error_class="deterministic"] and [recoverable=false]. *)
-  | Git_precondition_failed
-      (** git process precondition failed. Typed shell producers may
-          emit this for git exit 128 from structured command
-          classification plus process status; the deterministic
-          classifier intentionally does not re-parse stderr/output to
-          split missing refs from command usage. *)
   | Path_not_found
       (** A typed Execute path argument does not exist on the local
           filesystem. Emitted by pre-dispatch validation for [Safe]

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -70,6 +70,12 @@ let typed_input_command_text = Keeper_tool_execute_input.typed_input_command_tex
 let typed_input_has_env = Keeper_tool_execute_input.typed_input_has_env
 let typed_validation_error_text = Keeper_tool_execute_input.typed_validation_error_text
 
+let typed_validation_deterministic_retry_fields
+      (_ : Keeper_tool_execute_typed_input.validation_error)
+  =
+  Keeper_tool_deterministic_error.deterministic_retry_fields
+    Keeper_tool_deterministic_error.Command_shape_blocked
+
 let normalize_path_for_keeper_tool_execute_shell_ir_containment path =
   Keeper_alerting_path.normalize_path_for_check path
   |> Keeper_alerting_path.strip_trailing_slashes
@@ -150,6 +156,7 @@ let handle_tool_execute_typed
            let fields =
              [ "typed", `Bool true; "cwd", `String cwd ]
              @ execution_location_fields cwd
+             @ typed_validation_deterministic_retry_fields e
              @
              (match alts with
               | [] -> []
@@ -256,6 +263,7 @@ let handle_tool_execute_typed
             [ "typed", `Bool true; "cmd", `String cmd ]
             @ response_cwd_field
             @ execution_location_fields cwd
+            @ typed_validation_deterministic_retry_fields e
             @
             (match alts with
              | [] -> []

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -715,7 +715,14 @@ let check_typed_validation_error needle raw =
   Alcotest.(check (option bool)) "typed response" (Some true)
     (parse_bool_field raw "typed");
   Alcotest.(check bool) "validation error surfaced" true
-    (response_mentions raw "error" needle)
+    (response_mentions raw "error" needle);
+  let deterministic_retry = parse_field raw "deterministic_retry" in
+  Alcotest.(check (option string)) "deterministic reason"
+    (Some "command_shape_blocked")
+    (Json.member "reason" deterministic_retry |> Json.to_string_option);
+  Alcotest.(check (option bool)) "same args retry disabled"
+    (Some false)
+    (Json.member "retry_same_args" deterministic_retry |> Json.to_bool_option)
 
 let test_execute_typed_env_wrapper_target_allowed () =
   setup ~tool_access:[] ~sandbox:Keeper_types_profile_sandbox.Local
@@ -746,6 +753,23 @@ let test_execute_typed_single_stage_pipeline_rejected () =
     ~args:(tool_execute_typed_single_stage_pipeline_args ~cwd:playground)
     ()
   |> check_typed_validation_error "Pipeline.stages requires at least two stages"
+
+let test_execute_typed_repeated_executable_is_deterministic () =
+  setup ~sandbox:Keeper_types_profile_sandbox.Local
+  @@ fun ~config ~meta ~playground ->
+  Keeper_tool_command_runtime.handle_tool_execute
+    ~turn_sandbox_factory:None
+    ~exec_cache:None
+    ~config
+    ~meta
+    ~args:
+      (tool_execute_typed_exec_args
+         ~cwd:playground
+         ~argv:[ "find"; "."; "-name"; "*.ml" ]
+         "find")
+    ()
+  |> check_typed_validation_error
+       "executable \"find\" is repeated as argv[0]"
 
 let test_execute_typed_pipeline_falls_back_to_local_playground () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "missing:test" @@ fun () ->
@@ -2237,6 +2261,9 @@ let () =
           Alcotest.test_case
             "tool_execute typed single-stage pipeline is rejected"
             `Quick test_execute_typed_single_stage_pipeline_rejected;
+          Alcotest.test_case
+            "tool_execute typed repeated executable is deterministic"
+            `Quick test_execute_typed_repeated_executable_is_deterministic;
           Alcotest.test_case
             "tool_execute typed pipeline falls back to local playground"
             `Quick test_execute_typed_pipeline_falls_back_to_local_playground;


### PR DESCRIPTION
## Summary

- Add `deterministic_retry` / `retry_same_args=false` to typed Execute structural validation errors.
- Cover the live repeated executable argv[0] shape with a regression test.
- Remove stale `git_precondition_failed` deterministic marker support so git process failures stay recoverable, matching the existing classifier test contract.

Fixes #21172

## Verification

- `ocamlformat --check lib/keeper/keeper_tool_execute_runtime.ml lib/keeper/keeper_tool_deterministic_error.ml lib/keeper/keeper_tool_deterministic_error.mli test/test_keeper_sandbox_docker_route.ml test/test_keeper_tool_execute_retry_deterministic_close.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_sandbox_docker_route.exe test/test_keeper_tool_execute_retry_deterministic_close.exe`
- `./_build/default/test/test_keeper_sandbox_docker_route.exe test docker_route_contract 6`
- `./_build/default/test/test_keeper_sandbox_docker_route.exe test docker_route_contract 7`
- `./_build/default/test/test_keeper_tool_execute_retry_deterministic_close.exe`
