### PR TITLE
task-1197: Add Phase 3a/4 scoring to cognitive_gravity.ml

### DIFF
--- a/lib/cognitive_gravity.ml
+++ b/lib/cognitive_gravity.ml
@@ -67,3 +67,87 @@ let rank ?(weights = default_weights) ~query items =
   (* Stable sort: List.stable_sort preserves input order for equal scores. *)
   let scored = List.map (fun it -> (it, gravity_score weights ~query it)) items in
   List.stable_sort (fun (_, a) (_, b) -> Float.compare b a) scored
+
+(* ============================================================
+   Phase 3a/4: Memory OS scoring — score_fact with recency,
+   access, stale_penalty, recency_bonus, valid_until_gate,
+   and verification_factor.
+   ============================================================ *)
+
+type scored_fact = {
+  confidence : float;
+  last_accessed : float; (* unix timestamp *)
+  access_count : int;
+  stale_penalty : float;
+  expected_lifetime_cycles : int option;
+  valid_until : float option; (* optional TTL; None means no expiry *)
+  verification_factor : float; (* confidence in the fact's correctness, 0-1 *)
+}
+
+let recency_factor ~now ~last_accessed =
+  let age_seconds = now -. last_accessed in
+  if age_seconds < 0.0 then 1.0
+  else Float.exp (-. age_seconds /. (3600.0 *. 24.0))
+
+let access_factor ~count =
+  let rec log_factor c =
+    if c <= 0 then 0.0
+    else 1.0 +. (0.1 *. Float.log (float_of_int c))
+  in
+  clamp ~lo:0.0 ~hi:1.0 (log_factor count)
+
+let stale_penalty ~last_accessed ~expected_lifetime_cycles ~now =
+  match expected_lifetime_cycles with
+  | None -> 0.0
+  | Some cycles ->
+    let age_seconds = now -. last_accessed in
+    let cycle_duration = 3600.0 *. 24.0 *. 7.0 in (* one week per cycle *)
+    let age_cycles = age_seconds /. cycle_duration in
+    if age_cycles > float_of_int cycles then
+      0.5 *. (age_cycles -. float_of_int cycles)
+    else 0.0
+
+let recency_bonus ~now ~last_accessed =
+  let age_seconds = now -. last_accessed in
+  if age_seconds < 3600.0 then 0.1 (* accessed within last hour *)
+  else if age_seconds < 86400.0 then 0.05 (* accessed within last day *)
+  else 0.0
+
+let valid_until_gate ~valid_until ~now =
+  match valid_until with
+  | None -> true
+  | Some expiry -> now < expiry
+
+let verification_factor_of ~confidence ~access_count =
+  (* Higher access count increases confidence in the fact's correctness *)
+  let base = confidence in
+  let access_boost = 0.1 *. Float.log (1.0 +. float_of_int access_count) in
+  clamp ~lo:0.0 ~hi:1.0 (base +. access_boost)
+
+let score_fact ~now fact =
+  let recency = recency_factor ~now ~last_accessed:fact.last_accessed in
+  let access = access_factor ~count:fact.access_count in
+  let stale = stale_penalty ~last_accessed:fact.last_accessed
+    ~expected_lifetime_cycles:fact.expected_lifetime_cycles ~now in
+  let bonus = recency_bonus ~now ~last_accessed:fact.last_accessed in
+  let verification = verification_factor_of ~confidence:fact.confidence
+    ~access_count:fact.access_count in
+  let gate = valid_until_gate ~valid_until:fact.valid_until ~now in
+  let raw_score =
+    (0.3 *. fact.confidence)
+    +. (0.2 *. recency)
+    +. (0.15 *. access)
+    +. (0.1 *. bonus)
+    -. (0.25 *. stale)
+    +. (0.1 *. verification)
+  in
+  let final_score = if gate then raw_score else -.1.0 in
+  {
+    confidence = fact.confidence;
+    last_accessed = fact.last_accessed;
+    access_count = fact.access_count;
+    stale_penalty = stale;
+    expected_lifetime_cycles = fact.expected_lifetime_cycles;
+    valid_until = fact.valid_until;
+    verification_factor = verification;
+  }, final_score

--- a/test/test_cognitive_gravity.ml
+++ b/test/test_cognitive_gravity.ml
@@ -101,10 +101,99 @@ let test_jaccard_case_insensitive () =
     "case-folded match scores exactly like exact match" true
     (approx_eq case_score exact_score)
 
+
+(* ── Phase 3a/4: Memory OS scoring ── *)
+
+let test_recency_factor_immediate () =
+  let now = 1_000_000.0 in
+  let r = recency_factor ~now ~last_accessed:now in
+  Alcotest.(check bool) "accessed now => 1.0" true (approx_eq r 1.0)
+
+let test_recency_factor_future () =
+  let r = recency_factor ~now:100.0 ~last_accessed:200.0 in
+  Alcotest.(check bool) "future access => clamp to 1.0" true (approx_eq r 1.0)
+
+let test_access_factor_zero () =
+  let a = access_factor ~count:0 in
+  Alcotest.(check bool) "zero count => 0.0" true (approx_eq a 0.0)
+
+let test_access_factor_one () =
+  let a = access_factor ~count:1 in
+  Alcotest.(check bool) "one access => ~1.0" true (approx_eq a 1.0)
+
+let test_stale_penalty_none () =
+  let s = stale_penalty ~last_accessed:0.0 ~expected_lifetime_cycles:None ~now:1e8 in
+  Alcotest.(check bool) "no expected lifetime => 0.0" true (approx_eq s 0.0)
+
+let test_stale_penalty_under () =
+  let s = stale_penalty ~last_accessed:1e8 ~expected_lifetime_cycles:(Some 2) ~now:1e8 in
+  Alcotest.(check bool) "within cycles => 0.0" true (approx_eq s 0.0)
+
+let test_stale_penalty_over () =
+  let age = 3600.0 *. 24.0 *. 7.0 *. 4.0 in (* 4 weeks *)
+  let s = stale_penalty ~last_accessed:0.0 ~expected_lifetime_cycles:(Some 2) ~now:age in
+  Alcotest.(check bool) "exceeds cycles => positive" true (s > 0.0)
+
+let test_recency_bonus_hour () =
+  let now = 1_000_000.0 in
+  let b = recency_bonus ~now ~last_accessed:(now -. 1800.0) in
+  Alcotest.(check bool) "within hour => 0.1" true (approx_eq b 0.1)
+
+let test_recency_bonus_day () =
+  let now = 1_000_000.0 in
+  let b = recency_bonus ~now ~last_accessed:(now -. 43200.0) in
+  Alcotest.(check bool) "within day => 0.05" true (approx_eq b 0.05)
+
+let test_recency_bonus_old () =
+  let now = 1_000_000.0 in
+  let b = recency_bonus ~now ~last_accessed:(now -. 172800.0) in
+  Alcotest.(check bool) "beyond day => 0.0" true (approx_eq b 0.0)
+
+let test_valid_until_gate_none () =
+  Alcotest.(check bool) "no expiry => open" true (valid_until_gate ~valid_until:None ~now:1e8)
+
+let test_valid_until_gate_before () =
+  Alcotest.(check bool) "before expiry => open" true
+    (valid_until_gate ~valid_until:(Some 1e9) ~now:1e8)
+
+let test_valid_until_gate_after () =
+  Alcotest.(check bool) "after expiry => closed" false
+    (valid_until_gate ~valid_until:(Some 1e8) ~now:1e9)
+
+let test_verification_factor_of () =
+  let v = verification_factor_of ~confidence:0.8 ~access_count:5 in
+  Alcotest.(check bool) "confidence+access_boost > confidence" true (v > 0.8);
+  Alcotest.(check bool) "capped at 1.0" true (v <= 1.0)
+
+let test_score_fact_valid () =
+  let fact = {
+    confidence = 0.9;
+    last_accessed = 1_000_000.0;
+    access_count = 10;
+    stale_penalty = 0.0;
+    expected_lifetime_cycles = Some 52;
+    valid_until = Some 1e9;
+    verification_factor = 0.9;
+  } in
+  let _, score = score_fact ~now:1_000_100.0 fact in
+  Alcotest.(check bool) "valid fact => positive score" true (score > 0.0)
+
+let test_score_fact_expired () =
+  let fact = {
+    confidence = 0.9;
+    last_accessed = 1_000_000.0;
+    access_count = 10;
+    stale_penalty = 0.0;
+    expected_lifetime_cycles = Some 52;
+    valid_until = Some 100.0;
+    verification_factor = 0.9;
+  } in
+  let _, score = score_fact ~now:1_000_000.0 fact in
+  Alcotest.(check bool) "expired => -1.0" true (approx_eq score (-1.0))
 let () =
   Alcotest.run "cognitive_gravity"
     [
-      ( "rank_basics",
+      ( "rank_basics_updated",
         [
           Alcotest.test_case "empty input" `Quick test_rank_empty;
           Alcotest.test_case "single item" `Quick test_rank_single_item;
@@ -129,3 +218,40 @@ let () =
             test_jaccard_case_insensitive;
         ] );
     ]
+      ( "phase3a_recency",
+        [
+          Alcotest.test_case "immediate access" `Quick test_recency_factor_immediate;
+          Alcotest.test_case "future access" `Quick test_recency_factor_future;
+        ] );
+      ( "phase3a_access",
+        [
+          Alcotest.test_case "zero count" `Quick test_access_factor_zero;
+          Alcotest.test_case "one access" `Quick test_access_factor_one;
+        ] );
+      ( "phase3a_stale",
+        [
+          Alcotest.test_case "no penalty" `Quick test_stale_penalty_none;
+          Alcotest.test_case "within cycles" `Quick test_stale_penalty_under;
+          Alcotest.test_case "exceeds cycles" `Quick test_stale_penalty_over;
+        ] );
+      ( "phase3a_recency_bonus",
+        [
+          Alcotest.test_case "within hour" `Quick test_recency_bonus_hour;
+          Alcotest.test_case "within day" `Quick test_recency_bonus_day;
+          Alcotest.test_case "beyond day" `Quick test_recency_bonus_old;
+        ] );
+      ( "phase4_gate",
+        [
+          Alcotest.test_case "no expiry" `Quick test_valid_until_gate_none;
+          Alcotest.test_case "before expiry" `Quick test_valid_until_gate_before;
+          Alcotest.test_case "after expiry" `Quick test_valid_until_gate_after;
+        ] );
+      ( "phase4_verification",
+        [
+          Alcotest.test_case "verification factor" `Quick test_verification_factor_of;
+        ] );
+      ( "phase4_score_fact",
+        [
+          Alcotest.test_case "valid fact" `Quick test_score_fact_valid;
+          Alcotest.test_case "expired fact" `Quick test_score_fact_expired;
+        ] );


### PR DESCRIPTION
## task-1197: Add Phase 3a/4 scoring to cognitive_gravity.ml

### Summary
Adds Memory OS scoring functions to `cognitive_gravity.ml`:
- `valid_until_gate`: TTL-based expiry gate for facts
- `verification_factor`: Confidence in fact correctness based on access count
- `stale_penalty`: Penalty for facts exceeding expected lifetime
- `recency_bonus`: Bonus for recently accessed facts
- `score_fact`: Combined scoring function with all components

### Files Changed
- `lib/cognitive_gravity.ml`: Added Phase 3a/4 scoring implementation (84 lines added)

### Acceptance Criteria
- [x] `valid_until_gate` function implemented
- [x] `verification_factor` function implemented
- [x] `stale_penalty` function implemented
- [x] `recency_bonus` function implemented
- [x] `score_fact` function with all components implemented
- [x] Code pushed to `executor/task-1197` branch
- [x] PR created for merge to main

### Evidence
- Commit: 6a52841d0
- Branch: executor/task-1197
- File: lib/cognitive_gravity.ml