### PR TITLE
refactor(keeper): type the board wake_reason carrier (RFC-0020) [Phase 1 PR-2]

### DIFF
--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -11,6 +11,8 @@ open Keeper_types_profile
 open Keeper_memory
 open Keeper_execution
 
+module Board_wake = Keeper_world_observation_board_signal
+
 type grpc_heartbeat_starter_fn = {
   f : 'a. ctx:'a context -> m:keeper_meta -> stop:bool Atomic.t -> (unit -> unit) option;
 }
@@ -226,14 +228,6 @@ let wakeup_all_keepers ?base_path () =
 
 let board_reactive_debounce_sec = 60.0
 
-let board_reactive_generic_wakeup_limit =
-  Keeper_config.int_of_env_default
-    "MASC_KEEPER_BOARD_GENERIC_WAKEUP_LIMIT"
-    ~default:3
-    ~min_v:0
-    ~max_v:20
-;;
-
 let board_reactive_wakeup_max =
   Keeper_config.int_of_env_default
     "MASC_KEEPER_BOARD_WAKEUP_MAX" ~default:4 ~min_v:1 ~max_v:64
@@ -249,54 +243,47 @@ let board_reactive_wakeup_allowed ~base_path ~keeper_name ~post_id =
 
 let take = List.take
 
+(* RFC-0020: select which keepers wake for a board signal from typed
+   [Board_wake.wake_reason] candidates. Explicit mentions short-circuit and
+   wake unconditionally; every other reason competes for [total_limit] slots
+   in candidate order. [None] reasons are dropped (the relevance pipeline
+   found nothing for that keeper). The prior generic ["board_activity"]
+   throttle bucket is gone: the producer never emitted it, so it never fired —
+   typing the carrier made that dead branch unrepresentable. *)
 let select_board_wakeup_candidates
-    ?(generic_limit = board_reactive_generic_wakeup_limit)
     ?(total_limit = board_reactive_wakeup_max)
     candidates =
   let explicit =
     candidates
     |> List.filter_map (fun (item, reason) ->
       match reason with
-      | Some "explicit_mention" -> Some (item, "explicit_mention")
-      | _ -> None)
+      | Some Board_wake.Explicit_mention -> Some (item, Board_wake.Explicit_mention)
+      | Some (Board_wake.Stigmergy _ | Board_wake.Thread_reply_after_self_comment)
+      | None -> None)
   in
   match explicit with
   | _ :: _ -> explicit, 0
   | [] ->
-    let selected_by_reason, generic_dropped =
-      List.fold_left
-        (fun (selected, generic_seen, generic_dropped) (item, reason) ->
-          match reason with
-          | None -> selected, generic_seen, generic_dropped
-          | Some "board_activity" ->
-            let next_seen = generic_seen + 1 in
-            if generic_seen < generic_limit then
-              (item, "board_activity") :: selected, next_seen, generic_dropped
-            else
-              selected, next_seen, generic_dropped + 1
-          | Some reason -> (item, reason) :: selected, generic_seen, generic_dropped)
-        ([], 0, 0)
+    let non_explicit =
+      List.filter_map
+        (fun (item, reason) ->
+          match reason with None -> None | Some r -> Some (item, r))
         candidates
-      |> fun (selected_rev, _generic_seen, generic_dropped) ->
-      List.rev selected_rev, generic_dropped
     in
-    let prioritized =
-      let non_generic, generic =
-        List.partition (fun (_, reason) -> reason <> "board_activity")
-          selected_by_reason
-      in
-      non_generic @ generic
-    in
-    let selected = take total_limit prioritized in
-    let total_dropped = List.length prioritized - List.length selected in
-    selected, generic_dropped + total_dropped
+    let selected = take total_limit non_explicit in
+    let dropped = List.length non_explicit - List.length selected in
+    selected, dropped
 ;;
 
-(* RFC-0020: enqueue the board signal as a typed [stimulus_payload] instead of a
-   JSON-serialised string. [reason] still selects urgency at the producer; it is
-   not part of the payload (the consumer never read the prior "wake_reason"
-   field — wake-reason classification is recomputed downstream). *)
-let board_signal_stimulus ~(reason : string) (signal : Board_dispatch.board_signal) =
+(* RFC-0020: enqueue the board signal as a typed [stimulus_payload] (PR-1).
+   [reason] is the typed {!Board_wake.wake_reason} that selected this keeper;
+   here it only picks urgency (explicit mentions are [Immediate]). It is not
+   carried in the payload — the next prompt re-derives board context from the
+   typed [Board_signal] payload, not from a wake-reason string. *)
+let board_signal_stimulus
+      ~(reason : Board_wake.wake_reason)
+      (signal : Board_dispatch.board_signal)
+  =
   let payload : Keeper_event_queue.stimulus_payload =
     Keeper_event_queue.Board_signal
       { kind =
@@ -312,9 +299,10 @@ let board_signal_stimulus ~(reason : string) (signal : Board_dispatch.board_sign
   in
   { Keeper_event_queue.post_id = signal.post_id
   ; urgency =
-      (if String.equal reason "explicit_mention"
-       then Keeper_event_queue.Immediate
-       else Keeper_event_queue.Normal)
+      (match reason with
+       | Board_wake.Explicit_mention -> Keeper_event_queue.Immediate
+       | Board_wake.Stigmergy _ | Board_wake.Thread_reply_after_self_comment ->
+         Keeper_event_queue.Normal)
   ; arrived_at = Time_compat.now ()
   ; payload
   }
@@ -360,7 +348,7 @@ let board_signal_wake_paused_keeper
 
 let board_signal_wake_keeper
       ~(config : Workspace.config)
-      ~(reason : string)
+      ~(reason : Board_wake.wake_reason)
       ~(signal : Board_dispatch.board_signal)
       (meta : keeper_meta)
   =
@@ -418,7 +406,7 @@ let wakeup_relevant_keeper_for_board_signal
                ()
            | None, _ | Some _, _ -> ());
           (match entry.phase, wake_reason with
-           | Keeper_state_machine.Paused, Some "explicit_mention" ->
+           | Keeper_state_machine.Paused, Some Board_wake.Explicit_mention ->
              Some (meta, wake_reason)
            | Keeper_state_machine.Paused, _ -> None
            | Keeper_state_machine.Running, _ -> Some (meta, wake_reason)
@@ -440,14 +428,14 @@ let wakeup_relevant_keeper_for_board_signal
         Log.Keeper.info
           "board signal wakeup: keeper=%s reason=%s post=%s paused_auto_resume=%b"
           meta.name
-          reason
+          (Board_wake.wake_reason_label reason)
           signal.post_id
           meta.paused
       | Error err ->
         Log.Keeper.warn
           "board signal wakeup failed: keeper=%s reason=%s post=%s error=%s"
           meta.name
-          reason
+          (Board_wake.wake_reason_label reason)
           signal.post_id
           err)
   in
@@ -468,10 +456,9 @@ let wakeup_relevant_keeper_for_board_signal
       ();
     Log.Keeper.info
       "board signal wakeup capped by configured fanout: dropped=%d post=%s \
-       generic_limit=%d total_limit=%d"
+       total_limit=%d"
       dropped
       signal.post_id
-      board_reactive_generic_wakeup_limit
       board_reactive_wakeup_max
   end
 ;;

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -154,18 +154,20 @@ val wakeup_all_keepers : ?base_path:string -> unit -> unit
 (** Board-reactive debounce interval (seconds), from runtime config. *)
 val board_reactive_debounce_sec : float
 
-val board_reactive_generic_wakeup_limit : int
-
 val board_reactive_wakeup_max : int
 
 val board_reactive_wakeup_allowed :
   base_path:string -> keeper_name:string -> post_id:string -> bool
 
+(** Select which keepers wake for a board signal (RFC-0020). Explicit mentions
+    short-circuit and wake unconditionally (returned with [dropped = 0]); other
+    typed reasons compete for [?total_limit] slots in candidate order. [None]
+    reasons are dropped. Returns the selected [(item, reason)] pairs and the
+    number of non-explicit candidates dropped by the cap. *)
 val select_board_wakeup_candidates :
-  ?generic_limit:int ->
   ?total_limit:int ->
-  ('a * string option) list ->
-  ('a * string) list * int
+  ('a * Keeper_world_observation_board_signal.wake_reason option) list ->
+  ('a * Keeper_world_observation_board_signal.wake_reason) list * int
 
 val wakeup_relevant_keeper_for_board_signal :
   config:Workspace.config -> Board_dispatch.board_signal -> unit

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -189,7 +189,7 @@ val board_signal_wake_reason :
   continuity_summary:string ->
   meta:Keeper_meta_contract.keeper_meta ->
   signal:Board_dispatch.board_signal ->
-  string option
+  Keeper_world_observation_board_signal.wake_reason option
 
 (** Convert a queued Event Layer stimulus back into structured board activity
     for the next keeper prompt. Returns [None] for non-board stimuli. *)

--- a/lib/keeper/keeper_world_observation_board_signal.ml
+++ b/lib/keeper/keeper_world_observation_board_signal.ml
@@ -171,25 +171,47 @@ let stigmergy_match ~(meta : keeper_meta) ~(signal : Board_dispatch.board_signal
   { overall_score = min score 50 }
 ;;
 
+(** Why a keeper woke for a board signal. Closed set replacing the prior
+    [string option] producer/consumer contract (RFC-0020): the matchers in
+    {!wake_reason} are the only producers, so a reason no matcher emits — e.g.
+    the previously dead ["board_activity"] generic bucket the consumer used to
+    match — is now unrepresentable rather than a string the consumer guesses
+    at. [None] stays an [option] at the call site: it means the relevance
+    pipeline examined the signal and found nothing for this keeper. *)
+type wake_reason =
+  | Explicit_mention
+      (** The signal mentions one of the keeper's identity targets. *)
+  | Stigmergy of { score : int }
+      (** The signal text overlaps the keeper's goal keywords; [score] is the
+          match strength from {!stigmergy_match}. *)
+  | Thread_reply_after_self_comment
+      (** A new external comment arrived on a post the keeper had commented on. *)
+
+let wake_reason_label = function
+  | Explicit_mention -> "explicit_mention"
+  | Stigmergy { score } -> "stigmergy: score=" ^ string_of_int score
+  | Thread_reply_after_self_comment -> "thread_reply_after_self_comment"
+;;
+
 let wake_reason
       ~continuity_summary
       ~(meta : keeper_meta)
       ~(signal : Board_dispatch.board_signal)
-  : string option
+  : wake_reason option
   =
   let matched = match_signal ~continuity_summary ~meta ~signal in
   if matched.explicit_mention
-  then Some "explicit_mention"
+  then Some Explicit_mention
   else (
     let stigmergy = stigmergy_match ~meta ~signal in
     if stigmergy.overall_score > 0
-    then Some ("stigmergy: score=" ^ string_of_int stigmergy.overall_score)
+    then Some (Stigmergy { score = stigmergy.overall_score })
     else (
       let self_ids = Message_scope.self_ids meta in
       match signal.kind with
       | Board_dispatch.Board_comment_added ->
         (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
-         | `New_external _ -> Some "thread_reply_after_self_comment"
+         | `New_external _ -> Some Thread_reply_after_self_comment
          | `Never | `No_new_external -> None)
       | Board_dispatch.Board_post_created -> None))
 ;;

--- a/lib/keeper/keeper_world_observation_board_signal.mli
+++ b/lib/keeper/keeper_world_observation_board_signal.mli
@@ -32,8 +32,21 @@ val check_self_comment_status
   -> post_id:string
   -> comment_status
 
+type wake_reason =
+  | Explicit_mention
+  | Stigmergy of { score : int }
+  | Thread_reply_after_self_comment
+(** Closed set of reasons a keeper wakes for a board signal (RFC-0020).
+    Replaces the prior [string option] contract; consumers match exhaustively
+    so the previously dead ["board_activity"] generic bucket is gone. *)
+
+val wake_reason_label : wake_reason -> string
+(** Stable string label for logs/metrics. *)
+
 val wake_reason
   :  continuity_summary:string
   -> meta:Keeper_meta_contract.keeper_meta
   -> signal:Board_dispatch.board_signal
-  -> string option
+  -> wake_reason option
+(** [None] means the relevance pipeline found no reason for this keeper to
+    wake (counted as [BoardSignalNoWakeTotal] by the caller). *)

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -27,7 +27,6 @@ let key_to_env =
     "heartbeat.smart_heartbeat",        "MASC_KEEPER_SMART_HEARTBEAT";
     "heartbeat.jitter_factor",          "MASC_KEEPER_HEARTBEAT_JITTER_FACTOR";
     "heartbeat.sleep_chunk_sec",        "MASC_KEEPER_SLEEP_CHUNK_SEC";
-    "heartbeat.board_generic_wakeup_limit", "MASC_KEEPER_BOARD_GENERIC_WAKEUP_LIMIT";
     "heartbeat.board_wakeup_max",       "MASC_KEEPER_BOARD_WAKEUP_MAX";
     (* [proactive] *)
     "proactive.min_interval_sec",       "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC";

--- a/lib/keeper_runtime/keeper_runtime_config.mli
+++ b/lib/keeper_runtime/keeper_runtime_config.mli
@@ -69,7 +69,6 @@ val resolve_overrides :
 
       [heartbeat]
       sleep_chunk_sec             = 1.5
-      board_generic_wakeup_limit  = 3
       board_wakeup_max            = 4
 
       [proactive]

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -106,7 +106,6 @@ let test_applies_sleep_and_throttle_overrides () =
      fairness_cooldown_sec = 3\n\
      [heartbeat]\n\
      sleep_chunk_sec = 1.5\n\
-     board_generic_wakeup_limit = 5\n\
      board_wakeup_max = 6\n\
      [turn]\n\
      capacity_limit = 3\n\
@@ -115,7 +114,7 @@ let test_applies_sleep_and_throttle_overrides () =
   let count, overrides =
     Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
   in
-  check int "applied sleep/throttle overrides" 7 count;
+  check int "applied sleep/throttle overrides" 6 count;
   check (option string) "autoboot max canonical env"
     (Some "6")
     (List.assoc_opt "MASC_KEEPER_AUTOBOOT_MAX" overrides);
@@ -125,9 +124,6 @@ let test_applies_sleep_and_throttle_overrides () =
   check (option string) "sleep chunk"
     (Some "1.5")
     (List.assoc_opt "MASC_KEEPER_SLEEP_CHUNK_SEC" overrides);
-  check (option string) "board generic wakeup limit"
-    (Some "5")
-    (List.assoc_opt "MASC_KEEPER_BOARD_GENERIC_WAKEUP_LIMIT" overrides);
   check (option string) "board wakeup max"
     (Some "6")
     (List.assoc_opt "MASC_KEEPER_BOARD_WAKEUP_MAX" overrides);

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -202,89 +202,62 @@ let test_visibility_gate_preserves_busy () =
    Skip_busy. *)
 
 module KKS = Masc.Keeper_keepalive_signal
+module KWOBS = Masc.Keeper_world_observation_board_signal
 
-let test_board_wakeup_selection_caps_generic_activity () =
-  let selected, dropped =
-    KKS.select_board_wakeup_candidates
-      ~generic_limit:2
-      [
-        "a", Some "board_activity";
-        "b", Some "board_activity";
-        "c", Some "board_activity";
-        "d", None;
-      ]
-  in
-  check (list (pair string string)) "selected generic wakeups"
-    [ "a", "board_activity"; "b", "board_activity" ]
-    selected;
-  check int "dropped generic wakeups" 1 dropped
+(* Compare selected wake reasons by their stable label so the typed variant
+   stays printable in Alcotest's (string) testable. *)
+let reason_label = KWOBS.wake_reason_label
+let labeled selected = List.map (fun (item, r) -> item, reason_label r) selected
 
 let test_board_wakeup_selection_keeps_explicit_mentions () =
   let selected, dropped =
     KKS.select_board_wakeup_candidates
-      ~generic_limit:1
       [
-        "a", Some "board_activity";
-        "b", Some "explicit_mention";
-        "c", Some "explicit_mention";
+        "a", Some KWOBS.Thread_reply_after_self_comment;
+        "b", Some KWOBS.Explicit_mention;
+        "c", Some KWOBS.Explicit_mention;
       ]
   in
+  (* Explicit mentions short-circuit: they wake unconditionally, the
+     non-explicit candidate is excluded, and there are no cap drops. *)
   check (list (pair string string)) "selected explicit wakeups"
     [ "b", "explicit_mention"; "c", "explicit_mention" ]
-    selected;
-  check int "dropped generic wakeups" 0 dropped
+    (labeled selected);
+  check int "no drops when explicit present" 0 dropped
 
-let test_board_wakeup_selection_keeps_specific_reasons_past_generic_cap () =
+let test_board_wakeup_selection_drops_none_reasons () =
   let selected, dropped =
     KKS.select_board_wakeup_candidates
-      ~generic_limit:1
       [
-        "a", Some "board_activity";
-        "b", Some "thread_reply_after_self_comment";
-        "c", Some "board_activity";
+        "a", Some KWOBS.Thread_reply_after_self_comment;
+        "b", None;
+        "c", Some (KWOBS.Stigmergy { score = 10 });
       ]
   in
-  check (list (pair string string)) "selected mixed wakeups"
-    [ "b", "thread_reply_after_self_comment"; "a", "board_activity" ]
-    selected;
-  check int "dropped generic wakeups" 1 dropped
+  (* [None] reasons (no relevance match) are dropped; real reasons survive in
+     candidate order and the stigmergy score is carried end-to-end. *)
+  check (list (pair string string)) "None dropped, real reasons kept"
+    [ "a", "thread_reply_after_self_comment"; "c", "stigmergy: score=10" ]
+    (labeled selected);
+  check int "no cap drops under total limit" 0 dropped
 
 let test_board_wakeup_selection_caps_total_non_explicit () =
-  (* Non-generic reasons are prioritized over board_activity before total cap *)
   let selected, dropped =
     KKS.select_board_wakeup_candidates
-      ~generic_limit:4
       ~total_limit:2
       [
-        "a", Some "board_activity";
-        "b", Some "thread_reply_after_self_comment";
-        "c", Some "board_activity";
-        "d", Some "thread_reply_after_self_comment";
+        "a", Some (KWOBS.Stigmergy { score = 5 });
+        "b", Some KWOBS.Thread_reply_after_self_comment;
+        "c", Some (KWOBS.Stigmergy { score = 5 });
+        "d", Some KWOBS.Thread_reply_after_self_comment;
       ]
   in
-  check (list (pair string string)) "selected total wakeups"
-    [ "b", "thread_reply_after_self_comment"; "d", "thread_reply_after_self_comment" ]
-    selected;
-  check int "dropped total wakeups" 2 dropped
-
-let test_board_wakeup_selection_total_limit_prefers_non_generic () =
-  (* A late non-generic entry must survive when a generic entry would displace it
-     under candidate order alone.  After prioritization the two non-generic items
-     fill the cap and the generic one is dropped instead. *)
-  let selected, dropped =
-    KKS.select_board_wakeup_candidates
-      ~generic_limit:5
-      ~total_limit:2
-      [
-        "a", Some "board_activity";
-        "b", Some "board_activity";
-        "c", Some "thread_reply_after_self_comment";
-      ]
-  in
-  check (list (pair string string)) "non-generic survives cap"
-    [ "c", "thread_reply_after_self_comment"; "a", "board_activity" ]
-    selected;
-  check int "dropped generic" 1 dropped
+  (* Non-explicit reasons compete for [total_limit] slots in candidate order;
+     the overflow is dropped. *)
+  check (list (pair string string)) "first two non-explicit kept in order"
+    [ "a", "stigmergy: score=5"; "b", "thread_reply_after_self_comment" ]
+    (labeled selected);
+  check int "overflow dropped" 2 dropped
 
 let test_after_wake_idle_woken_continues () =
   let next = Unix.gettimeofday () +. 60.0 in
@@ -420,16 +393,12 @@ let () =
       test_case "busy decision is preserved" `Quick test_visibility_gate_preserves_busy;
     ];
     "board_wakeup_selection", [
-      test_case "generic board activity is capped"
-        `Quick test_board_wakeup_selection_caps_generic_activity;
-      test_case "explicit mentions bypass generic cap"
+      test_case "explicit mentions bypass and win"
         `Quick test_board_wakeup_selection_keeps_explicit_mentions;
-      test_case "specific reasons survive generic cap"
-        `Quick test_board_wakeup_selection_keeps_specific_reasons_past_generic_cap;
+      test_case "None reasons are dropped, real reasons kept"
+        `Quick test_board_wakeup_selection_drops_none_reasons;
       test_case "total non-explicit fanout is capped"
         `Quick test_board_wakeup_selection_caps_total_non_explicit;
-      test_case "total limit prefers non-generic over board_activity"
-        `Quick test_board_wakeup_selection_total_limit_prefers_non_generic;
     ];
     "missed_wakeup_gap", [
       test_case "Skip_idle + Woken -> resumes (MissedWakeup spec gap)"


### PR DESCRIPTION
## 목표

turn-trigger 운반층의 두 번째 string carrier인 `wake_reason`을 닫힌 variant로 전환한다 (RFC-0020 봉합, Phase 1 PR-2). PR-1(#21174, `stimulus_payload` 타입화)과 같은 lineage이며, PR-1은 **머지됨**(main `33a5e7fec`). 이 브랜치는 새 main에 rebase되어 wake_reason 단일 커밋만 담는다.

> 이력: 원래 stacked Draft #21188로 열렸으나, PR-1 머지 시 base 브랜치 삭제로 GitHub가 #21188을 자동 CLOSE(reopen·base변경 불가). 동일 head 브랜치(rebase됨)로 main 대상 PR을 재생성.

`keeper_world_observation_board_signal.wake_reason`는 `string option`을 반환했고, consumer `keeper_keepalive_signal.select_board_wakeup_candidates`는 그 문자열을 매칭했다. 타입화 과정에서 **producer/consumer/config 3자 drift**가 컴파일러로 드러났다:

- **Producer**가 생산하는 값: `explicit_mention` / `stigmergy: score=N` / `thread_reply_after_self_comment` / `None`.
- **Consumer + 런타임 config**(`heartbeat.board_generic_wakeup_limit`, 기본 3)는 `board_activity` generic-throttle 버킷을 구현하고 있었으나, **producer가 `board_activity`를 절대 생산하지 않아** 한 번도 발화하지 않은 dead 경로였다. env override도 전무.

## 정합 결정 (Option A — 동작 보존 + dead 삭제)

`board_activity` generic-throttle는 production에서 한 번도 실행되지 않았으므로 제거해도 **런타임 동작이 불변**이다. plain 게시물(매처가 goal-무관으로 판정)은 현행대로 `None` → 드롭(REPO_WAKE_UP 감사의 의도적 제한). 닫힌 variant로 바꾸면 `board_activity` 분기가 "존재하지 않는 생성자"가 되어 dead 경로가 컴파일 타임에 제거된다.

- 대안 B("plain 게시물도 throttle-wake")는 idle keeper를 무관한 board 활동에 깨우는 **동작 변경**이라 별도 eval 붙인 RFC 대상으로 분리. 매처가 관련 글을 놓치는지는 이미 `BoardSignalNoWakeTotal` 카운터로 측정 중 — 실제 drop이 문제로 확인되면 그때 producer(매처) 개선으로 해결하는 게 순서다.

## 변경 파일

**Producer (타입 정의)**
- `lib/keeper/keeper_world_observation_board_signal.ml` / `.mli` — `type wake_reason = Explicit_mention | Stigmergy of {score:int} | Thread_reply_after_self_comment` + `wake_reason_label`. `wake_reason` 반환을 `string option` → `wake_reason option`.
- `lib/keeper/keeper_world_observation.ml`(재export 불변) / `.mli` — 반환 타입 갱신.

**Consumer (exhaustive match)**
- `lib/keeper/keeper_keepalive_signal.ml` / `.mli` — `select_board_wakeup_candidates`를 typed match로 재작성, `?generic_limit` 파라미터 + dead `board_activity` 버킷 + `board_reactive_generic_wakeup_limit` getter 삭제. `board_signal_stimulus`/`board_signal_wake_keeper`의 `~reason`를 typed로(urgency를 exhaustive match로). 로그를 `wake_reason_label`로.

**Dead config 삭제**
- `lib/keeper_runtime/keeper_runtime_config.ml` / `.mli` — `heartbeat.board_generic_wakeup_limit` ↔ `MASC_KEEPER_BOARD_GENERIC_WAKEUP_LIMIT` 매핑 + 스키마 doc 제거.

**테스트**
- `test/test_smart_heartbeat_keepalive.ml` — board_wakeup_selection 5개 → 3개(typed)로 재작성. 제거한 2개는 dead `board_activity` 스로틀을 검증하던 테스트. 신규: explicit 단락 우선, None 드롭+score 보존, total cap.

## 로컬 검증

- `dune build --root .` exit 0 (경고/에러 0). OCaml exhaustive match가 누락 call-site 0을 강제 확인.
- `test_smart_heartbeat_keepalive` 32/32, `test_keeper_event_queue`(PR-1) all pass, `test_keeper_event_queue_decision` 7 rows, `test_keeper_reaction_ledger` 9/9.
- 전체 `@runtest` baseline 대조(stash → base 재빌드 → 동일 스위트): base(PR-1, b581e180c)에서 45개 스위트가 이미 실패(RFC-0085/0086 host-config/identifier-rename/pg-env drift-guard + worktree 환경; wake_reason과 물리적으로 분리). **PR-2가 도입한 추가 실패는 `runtime_toml_override` 1건뿐**이었고(제거한 config 키를 검증하던 string-table 테스트, 컴파일러 사각지대) **이미 정합**. 정합 후 PR-2 실패 집합 == baseline → **PR-2 새 실패 0**. (`comm -23` 단일 출력으로 확정)
- **새 main(PR-1 머지본) 위 재검증**: rebase 후 `dune build --root .` exit 0(경고 0), `test_smart_heartbeat_keepalive` 32/32, `test_runtime_toml_overrides` 30/30 — PR-1의 `stimulus_payload` 변경과 통합된 트리에서 충돌·회귀 0.

## 남은 미검증

- 라이브: 재배포 후 board signal → 턴 트리거 동작(explicit/stigmergy/thread-reply 깨움, plain 드롭 카운터). worktree는 라이브 데몬 미구동.
- 관련 후속(별도 phase): `observed_triggers_of_observation`(`keeper_unified_metrics_support.ml:421`)의 string-list trigger 분류기 — wake throttle와 무관한 별도 observability surface, 미래 타입화 후보.

## RFC

RFC-0020 (keeper event queue layer separation) 봉합. RFC-0232가 lane event model에 적용한 typed-carrier 패턴을 turn-trigger 운반층에 확장.

RFC-WAIVED: keeper turn-trigger 운반층 타입화(RFC-0020 직접 봉합). credential/operator/sandbox/hooks/workflow subsystem 미해당.

WORKAROUND-WAIVED: 이 PR은 string 분류기를 *제거*한다(추가 아님). `select_board_wakeup_candidates`의 string 매칭과 dead generic-throttle를 닫힌 variant + 컴파일러 강제로 대체. PR body의 "string 분류기/classifier/board_activity" 언급은 제거 대상을 설명하는 것이며 워크어라운드 도입이 아니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
