### PR TITLE
refactor(keeper): type the cycle channel carrier (RFC-0020) [Phase 1 PR-3]

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -116,9 +116,18 @@ let compute_metrics_window
         let tokens = Safe_ops.json_int ~default:0 "context_tokens" j in
         let context_max = Safe_ops.json_int ~default:0 "context_max" j in
         let channel = Safe_ops.json_string ~default:"turn" "channel" j in
-        let is_turn = channel = "turn" in
-        let is_heartbeat = channel = "heartbeat" in
-        let is_scheduled_autonomous = channel = "scheduled_autonomous" || channel = "proactive" in
+        let parsed_channel = Keeper_world_observation.channel_of_string channel in
+        let is_turn =
+          match parsed_channel with
+          | Some Keeper_world_observation.Reactive -> true
+          | _ -> false
+        in
+        let is_heartbeat = String.equal channel "heartbeat" in
+        let is_scheduled_autonomous =
+          match parsed_channel with
+          | Some c -> Keeper_world_observation.is_autonomous c
+          | None -> false
+        in
         let is_interaction = is_turn || is_scheduled_autonomous in
         let compacted = Safe_ops.json_bool ~default:false "compacted" j in
         let gen = Safe_ops.json_int ~default:generation "generation" j in

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -211,7 +211,12 @@ let keeper_metrics_24h_json
           b.sample_points <- b.sample_points + 1;
           b.context_ratio_sum <- b.context_ratio_sum +. context_ratio;
           let channel = Safe_ops.json_string ~default:"turn" "channel" j in
-          if channel = "scheduled_autonomous" || channel = "proactive" then begin
+          let is_scheduled_autonomous =
+            match Keeper_world_observation.channel_of_string channel with
+            | Some c -> Keeper_world_observation.is_autonomous c
+            | None -> false
+          in
+          if is_scheduled_autonomous then begin
             incr proactive_points;
             b.proactive_points <- b.proactive_points + 1;
             let proactive_obj = Option.value ~default:`Null (Json_util.assoc_member_opt "proactive" j) in

--- a/lib/dashboard/dashboard_keeper_decision_log_proof.ml
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.ml
@@ -93,11 +93,13 @@ let scheduled_evidence_json stat =
     ( "latest_ts", Json_util.string_opt_to_json stat.latest_ts );
   ]
 
+(* A turn-exchange row is any cycle whose channel parses to a known typed
+   channel (Reactive / Scheduled_autonomous). Legacy spellings
+   ("reactive"/"proactive") and the non-interaction "heartbeat" marker no
+   longer count (RFC-0020 Phase 1 PR-3, owner decision 2026-06-15). *)
 let is_turn_exchange_channel = function
-  | Some "reactive" | Some "scheduled_autonomous" | Some "turn"
-  | Some "proactive" ->
-    true
-  | _ -> false
+  | Some s -> Option.is_some (Keeper_world_observation.channel_of_string s)
+  | None -> false
 
 let update_turn_span stat ts =
   {

--- a/lib/keeper/keeper_status_metrics.ml
+++ b/lib/keeper/keeper_status_metrics.ml
@@ -119,9 +119,6 @@ let empty_tool_audit_snapshot =
     tool_audit_at = None;
   }
 
-let is_scheduled_autonomous_channel =
-  Keeper_world_observation.is_autonomous_channel
-
 let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
   let interaction_points = s.turn_points + s.proactive_points in
   let intervention_share =
@@ -265,10 +262,20 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) :
           Safe_ops.json_int ~default:default_generation "generation" j
         in
         let channel = Safe_ops.json_string ~default:"turn" "channel" j in
-        let is_turn = channel = "turn" in
-        let is_heartbeat = channel = "heartbeat" in
+        let parsed_channel = Keeper_world_observation.channel_of_string channel in
+        let is_turn =
+          match parsed_channel with
+          | Some Keeper_world_observation.Reactive -> true
+          | _ -> false
+        in
+        (* "heartbeat" is a status-tick marker outside the keeper_cycle_channel
+           taxonomy, so it is matched on the raw wire string, not the typed
+           parse (which returns None for it). *)
+        let is_heartbeat = String.equal channel "heartbeat" in
         let is_scheduled_autonomous =
-          is_scheduled_autonomous_channel channel
+          match parsed_channel with
+          | Some c -> Keeper_world_observation.is_autonomous c
+          | None -> false
         in
         let is_interaction = is_turn || is_scheduled_autonomous in
         let compacted = Safe_ops.json_bool ~default:false "compacted" j in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -620,7 +620,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
                    ~latency_ms
                    ~turn_cost:(turn_cost_for_result result)
                    ~turn_generation:lifecycle.turn_generation
-                   ~channel:"turn"
+                   ~channel:Keeper_world_observation.Reactive
                    ~snapshot_source:"keeper_turn_msg"
                    ~context_ratio:lifecycle.context_ratio
                    ~context_tokens:lifecycle.context_tokens

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -165,7 +165,7 @@ val append_metrics_snapshot :
   latency_ms:int ->
   turn_cost:float ->
   turn_generation:int ->
-  channel:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
   snapshot_source:string ->
   context_ratio:float ->
   context_tokens:int ->
@@ -229,4 +229,5 @@ val accountability_evidence_refs :
   string list
 
 val decision_channel_of_observation :
-  Keeper_world_observation.world_observation -> string
+  Keeper_world_observation.world_observation ->
+  Keeper_world_observation.keeper_cycle_channel

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -155,7 +155,10 @@ let append_decision_record
         ("tool_surface", tool_surface_json result);
         ("pending_approval_count", `Int pending_approval_count);
         ("approval_mode", Json_util.string_opt_to_json approval_mode);
-        ("channel", `String (decision_channel_of_observation observation));
+        ( "channel",
+          `String
+            (Keeper_world_observation.channel_to_string
+               (decision_channel_of_observation observation)) );
         ("outcome", `String outcome);
         ("degraded_retry_applied", `Bool degraded_retry_applied);
         ( "degraded_retry_runtime",

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -15,7 +15,7 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
     ~(result : Keeper_agent_run.run_result) ~(latency_ms : int)
     ~(turn_cost : float)
     ~(turn_generation : int)
-    ~(channel : string)
+    ~(channel : Keeper_world_observation.keeper_cycle_channel)
     ~(snapshot_source : string)
     ~(context_ratio : float)
     ~(context_tokens : int)
@@ -40,7 +40,7 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
     ~keeper:meta.name
     ~context_max;
   let scheduled_autonomous_outcome =
-    if is_scheduled_autonomous_channel channel then
+    if Keeper_world_observation.is_autonomous channel then
       Some (scheduled_autonomous_outcome_for_result result)
     else None
   in
@@ -89,7 +89,7 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
      timeout-budget burn attributable to the redacted runtime lane. *)
   record_turn_latency_by_model_bucket
     ~keeper:meta.name
-    ~channel
+    ~channel:(Keeper_world_observation.channel_to_string channel)
     ~runtime_profile
     ~latency_ms;
   Otel_metric_store.inc_counter
@@ -101,7 +101,7 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
       [
         ("ts", `String (now_iso ()));
         ("ts_unix", `Float now_ts);
-        ("channel", `String channel);
+        ("channel", `String (Keeper_world_observation.channel_to_string channel));
         ("name", `String meta.name);
         ("agent_name", `String meta.agent_name);
         ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));

--- a/lib/keeper/keeper_unified_metrics_snapshot.mli
+++ b/lib/keeper/keeper_unified_metrics_snapshot.mli
@@ -8,7 +8,7 @@ val append_metrics_snapshot :
   latency_ms:int ->
   turn_cost:float ->
   turn_generation:int ->
-  channel:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
   snapshot_source:string ->
   context_ratio:float ->
   context_tokens:int ->

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -14,23 +14,20 @@ let string_contains_substring_ci = String_util.string_contains_substring_ci
 (* ── Observation / decision helpers ─────────────── *)
 
 let decision_channel_of_observation
-    (observation : Keeper_world_observation.world_observation) : string =
+    (observation : Keeper_world_observation.world_observation) :
+    Keeper_world_observation.keeper_cycle_channel =
   if observation.pending_mentions <> []
      || observation.pending_board_events <> []
      || observation.pending_scope_messages <> []
   then
-    "turn"
+    Keeper_world_observation.Reactive
   else
-    "scheduled_autonomous"
-
-let is_scheduled_autonomous_channel =
-  Keeper_world_observation.is_autonomous_channel
+    Keeper_world_observation.Scheduled_autonomous
 
 let is_scheduled_autonomous_cycle_of_observation
     (observation : Keeper_world_observation.world_observation) : bool =
-  String.equal
+  Keeper_world_observation.is_autonomous
     (decision_channel_of_observation observation)
-    "scheduled_autonomous"
 
 let scheduled_autonomous_outcome_of_result
     ~(has_text : bool) ~(has_tool_calls : bool) :

--- a/lib/keeper/keeper_unified_metrics_support.mli
+++ b/lib/keeper/keeper_unified_metrics_support.mli
@@ -102,9 +102,8 @@ val work_kind_of_turn_mode : turn_mode -> string
 val work_kind_of_json : Yojson.Safe.t -> string option
 
 val decision_channel_of_observation :
-  Keeper_world_observation.world_observation -> string
-
-val is_scheduled_autonomous_channel : string -> bool
+  Keeper_world_observation.world_observation ->
+  Keeper_world_observation.keeper_cycle_channel
 
 val is_scheduled_autonomous_cycle_of_observation :
   Keeper_world_observation.world_observation -> bool

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -84,16 +84,24 @@ let append_metrics_snapshot
       ~(lifecycle : KEC.post_turn_lifecycle)
       ~last_provider_timeout_budget
   =
-  try
-    let any_pending =
-      observation.Keeper_world_observation.pending_mentions <> []
-      || observation.pending_board_events <> []
-      || observation.pending_scope_messages <> []
-    in
-    let channel = if any_pending then "turn" else "scheduled_autonomous" in
+  let any_pending =
+    observation.Keeper_world_observation.pending_mentions <> []
+    || observation.pending_board_events <> []
+    || observation.pending_scope_messages <> []
+  in
+  (* Single typed channel for the whole cycle: post helpers + the metrics
+     snapshot + the failure-path label all derive from one value, so the
+     reactive/autonomous decision can no longer drift between sites. *)
+  let channel =
     if any_pending
-    then Keeper_turn_helpers.post_assign_task ~any_pending ~channel
-    else Keeper_turn_helpers.post_empty_queue_sleep ~any_pending ~channel;
+    then Keeper_world_observation.Reactive
+    else Keeper_world_observation.Scheduled_autonomous
+  in
+  let channel_tag = Keeper_world_observation.channel_to_string channel in
+  try
+    if any_pending
+    then Keeper_turn_helpers.post_assign_task ~any_pending ~channel:channel_tag
+    else Keeper_turn_helpers.post_empty_queue_sleep ~any_pending ~channel:channel_tag;
     KUM.append_metrics_snapshot
       ~config
       ~meta:updated_meta
@@ -116,19 +124,11 @@ let append_metrics_snapshot
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-    let channel =
-      if
-        observation.pending_mentions <> []
-        || observation.pending_board_events <> []
-        || observation.pending_scope_messages <> []
-      then "turn"
-      else "scheduled_autonomous"
-    in
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string MetricEmitDropped)
       ~labels:
         [ "keeper", updated_meta.name
-        ; "channel", channel
+        ; "channel", channel_tag
         ; "site", Keeper_metric_emit_dropped_site.(to_label Keeper_unified_turn)
         ]
       ();

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -88,8 +88,8 @@ let turn_reason_to_string =
 let skip_reason_to_string =
   Keeper_world_observation_turn_types.skip_reason_to_string
 let channel_to_string = Keeper_world_observation_turn_types.channel_to_string
-let is_autonomous_channel =
-  Keeper_world_observation_turn_types.is_autonomous_channel
+let channel_of_string = Keeper_world_observation_turn_types.channel_of_string
+let is_autonomous = Keeper_world_observation_turn_types.is_autonomous
 let verdict_reasons_to_strings =
   Keeper_world_observation_turn_types.verdict_reasons_to_strings
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -133,12 +133,15 @@ val turn_reason_to_string : turn_reason -> string
     Variant payloads are intentionally omitted. *)
 val skip_reason_to_string : skip_reason -> string
 
-(** Convert channel to string tag. *)
+(** Convert channel to its canonical wire tag ("turn" / "scheduled_autonomous"). *)
 val channel_to_string : keeper_cycle_channel -> string
 
-(** Check if a string channel tag represents an autonomous cycle
-    (scheduled_autonomous or proactive). *)
-val is_autonomous_channel : string -> bool
+(** Strict inverse of {!channel_to_string}; [None] for any non-canonical
+    string (legacy "reactive"/"proactive", "heartbeat" status-tick, …). *)
+val channel_of_string : string -> keeper_cycle_channel option
+
+(** Whether a typed channel represents an autonomous (scheduled) cycle. *)
+val is_autonomous : keeper_cycle_channel -> bool
 
 (** Extract all reasons as flat string tags from a verdict.
     Tags map 1:1 to the typed reasons carried by the verdict and do not

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -85,13 +85,29 @@ let skip_reason_to_string = function
   | No_signal -> "no_signal"
 ;;
 
+(* Canonical wire encoding. [Reactive] serialises as "turn" (the value the
+   majority of producers + the JSON default already emit); the prior
+   "reactive" spelling is dropped (RFC-0020 Phase 1 PR-3, owner decision
+   2026-06-15). *)
 let channel_to_string = function
-  | Reactive -> "reactive"
+  | Reactive -> "turn"
   | Scheduled_autonomous -> "scheduled_autonomous"
 ;;
 
-let is_autonomous_channel (channel : string) : bool =
-  String.equal channel "scheduled_autonomous" || String.equal channel "proactive"
+(* Strict parse at the persistence/telemetry read boundary: only the
+   canonical strings produced by [channel_to_string] round-trip. Legacy
+   aliases ("reactive"/"proactive") and the non-interaction "heartbeat"
+   status-tick marker return [None] — callers decide how to treat an
+   unrecognised channel rather than silently coercing it. *)
+let channel_of_string = function
+  | "turn" -> Some Reactive
+  | "scheduled_autonomous" -> Some Scheduled_autonomous
+  | _ -> None
+;;
+
+let is_autonomous = function
+  | Reactive -> false
+  | Scheduled_autonomous -> true
 ;;
 
 let verdict_reasons_to_strings = function

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -41,5 +41,12 @@ type turn_verdict =
 val turn_reason_to_string : turn_reason -> string
 val skip_reason_to_string : skip_reason -> string
 val channel_to_string : keeper_cycle_channel -> string
-val is_autonomous_channel : string -> bool
+
+(** Strict inverse of {!channel_to_string}. Returns [None] for any string
+    outside the canonical set ("turn", "scheduled_autonomous") — including
+    the legacy "reactive"/"proactive" aliases and the "heartbeat"
+    status-tick marker. *)
+val channel_of_string : string -> keeper_cycle_channel option
+
+val is_autonomous : keeper_cycle_channel -> bool
 val verdict_reasons_to_strings : turn_verdict -> string list

--- a/test/dune
+++ b/test/dune
@@ -34,6 +34,7 @@
   test_keeper_lane_mentions
   test_surface_ref
   test_keeper_turn_outcome
+  test_keeper_cycle_channel
   test_keeper_identity_id
   test_keeper_idle_threshold_contract
   test_board_activity_cache
@@ -314,6 +315,7 @@
   test_keeper_lane_mentions
   test_surface_ref
   test_keeper_turn_outcome
+  test_keeper_cycle_channel
   test_keeper_identity_id
   test_keeper_idle_threshold_contract
   test_board_activity_cache

--- a/test/test_keeper_cycle_channel.ml
+++ b/test/test_keeper_cycle_channel.ml
@@ -1,0 +1,78 @@
+(* RFC-0020 Phase 1 PR-3: typed keeper cycle channel.
+
+   The keeper cycle channel ("is this turn reactive or scheduled-
+   autonomous") is now carried by the closed [keeper_cycle_channel]
+   variant instead of a [string -> bool] classifier. These tests pin:
+   - the canonical wire codec (Reactive serialises as "turn"),
+   - the round-trip channel_of_string (channel_to_string c) = Some c,
+   - STRICT parsing: the dropped legacy spellings ("reactive"/"proactive")
+     and the non-interaction "heartbeat" marker all parse to None
+     (owner decision 2026-06-15 — legacy channel vocabulary removed),
+   - the typed is_autonomous predicate that replaces is_autonomous_channel. *)
+
+open Alcotest
+
+module KWO = Masc.Keeper_world_observation
+
+let channel : KWO.keeper_cycle_channel testable =
+  testable
+    (fun fmt c -> Format.pp_print_string fmt (KWO.channel_to_string c))
+    ( = )
+
+let all = [ KWO.Reactive; KWO.Scheduled_autonomous ]
+
+let test_to_string_canonical () =
+  check string "Reactive -> turn" "turn" (KWO.channel_to_string KWO.Reactive);
+  check string "Scheduled_autonomous -> scheduled_autonomous"
+    "scheduled_autonomous"
+    (KWO.channel_to_string KWO.Scheduled_autonomous)
+
+let test_round_trip () =
+  List.iter
+    (fun c ->
+      check (option channel) "channel_of_string (channel_to_string c) = Some c"
+        (Some c)
+        (KWO.channel_of_string (KWO.channel_to_string c)))
+    all
+
+let test_of_string_canonical () =
+  check (option channel) "turn -> Reactive" (Some KWO.Reactive)
+    (KWO.channel_of_string "turn");
+  check (option channel) "scheduled_autonomous -> Scheduled_autonomous"
+    (Some KWO.Scheduled_autonomous)
+    (KWO.channel_of_string "scheduled_autonomous")
+
+let test_of_string_strict_none () =
+  List.iter
+    (fun s -> check (option channel) s None (KWO.channel_of_string s))
+    [ (* dropped legacy spellings *)
+      "reactive";
+      "proactive";
+      (* non-interaction status-tick marker, outside the taxonomy *)
+      "heartbeat";
+      (* casing / whitespace / unknown are not coerced *)
+      "Turn";
+      "TURN";
+      " turn";
+      "scheduled-autonomous";
+      "";
+      "garbage"
+    ]
+
+let test_is_autonomous () =
+  check bool "Reactive is not autonomous" false (KWO.is_autonomous KWO.Reactive);
+  check bool "Scheduled_autonomous is autonomous" true
+    (KWO.is_autonomous KWO.Scheduled_autonomous)
+
+let () =
+  run "keeper_cycle_channel"
+    [
+      ( "codec",
+        [
+          test_case "to_string canonical" `Quick test_to_string_canonical;
+          test_case "round trip" `Quick test_round_trip;
+          test_case "of_string canonical" `Quick test_of_string_canonical;
+          test_case "of_string strict None" `Quick test_of_string_strict_none;
+        ] );
+      ("predicate", [ test_case "is_autonomous" `Quick test_is_autonomous ]);
+    ]


### PR DESCRIPTION
## 목표

turn-trigger 운반층의 세 번째 string carrier인 keeper **cycle channel**을 닫힌 타입으로 봉합한다 (RFC-0020, Phase 1 PR-3). `stimulus_payload`(#21174 머지), `wake_reason`(#21189 머지)과 같은 lineage.

`is_autonomous_channel : string -> bool`은 `"scheduled_autonomous" || "proactive"`를 매칭하는 string classifier였다. 타입화 과정에서 매핑 워크플로(6 agent)가 **같은 reactive/autonomous 개념에 5개 문자열이 drift** 중임을 드러냈다:

- `decision_channel_of_observation` / `keeper_unified_turn_success`(인라인) / `keeper_turn`(하드코딩) 은 reactive 사이클에 **"turn"** 을 방출.
- 반면 typed `channel_to_string`(이미 존재)은 같은 `Reactive`에 **"reactive"** 를 방출(`keeper_unified_turn.ml:109` 등 typed 경로). → 같은 사이클이 wire에서 "turn"이거나 "reactive".
- `is_autonomous_channel` 은 `"scheduled_autonomous" || "proactive"` 를 수용하나, **어떤 producer도 "proactive"를 channel 값으로 방출하지 않음**(코드상 dead; dashboard read-side가 옛 JSONL 대비 방어 수용).
- `keeper_status_metrics` / dashboard 는 추가로 **"heartbeat"**(status-tick 마커)를 raw-string으로 분기.

부작용 버그: typed 경로가 reactive에 "reactive"를 쓰는데 `status_metrics`는 "turn"만 interaction으로 셈 → **reactive 사이클이 interaction 집계에서 누락**되던 latent drift.

## 정합 결정 (오너 결정 2026-06-15, Option C — betray-the-past)

1. **정본 wire**: `channel_to_string` `Reactive -> "turn"`(다수 producer + JSON 기본값과 일치, 라이브 dashboard/OTel 보존), `Scheduled_autonomous -> "scheduled_autonomous"`. 모든 producer를 이 단일 codec으로 라우팅 → "turn" vs "reactive" drift 제거(위 집계 누락도 수정).
2. **strict read**: `channel_of_string`: `"turn"->Reactive`, `"scheduled_autonomous"->Scheduled_autonomous`, **그 외 전부 `None`**. legacy `"reactive"`/`"proactive"` 와 `"heartbeat"` 는 옛 영속 행에 있어도 더 이상 interaction으로 분류되지 않는다(오너 수용). `"heartbeat"` 는 taxonomy 밖 status-tick 마커라 raw-string 체크로 유지.
3. `is_autonomous : keeper_cycle_channel -> bool` 전역 예외망 match가 string classifier를 대체.
4. **`is_autonomous_channel : string -> bool` 삭제** → 컴파일러가 모든 keeper-side call-site를 전수 안내(결정론적 하네스).

## 변경 파일

**Core codec** — `keeper_world_observation_turn_types.ml`/`.mli` (+ `keeper_world_observation` 재export): `channel_to_string` 정본화, strict `channel_of_string` 추가, `is_autonomous` 추가, `is_autonomous_channel` 삭제.

**Producers (typed carry)** — `keeper_unified_metrics_support`(`decision_channel_of_observation` 반환 typed), `keeper_unified_metrics_decision`(직렬화 경계 `channel_to_string`), `keeper_unified_metrics_snapshot`(`~channel` 파라미터 typed, JSON/OTel 경계서 stringify), `keeper_unified_turn_success`(typed channel을 try 앞으로 hoist → try/handler 중복 인라인 로직 제거), `keeper_turn`(하드코딩 "turn" → `Reactive`), `keeper_unified_metrics.mli` 시그니처 2건.

**Consumers (typed parse)** — `keeper_status_metrics`, dashboard `dashboard_http_keeper_detail` / `dashboard_http_keeper_metrics` / `dashboard_keeper_decision_log_proof`: 인라인 string membership → `channel_of_string` + `is_autonomous`.

**Test** — `test/test_keeper_cycle_channel.ml`(신규, 5 케이스): to_string 정본, round-trip, of_string 정본, **of_string strict None**(legacy reactive/proactive/heartbeat + 대소문자/공백 변형), is_autonomous.

## 로컬 검증

- `dune build --root .` exit 0(경고 0). OCaml 링킹/exhaustive match가 `is_autonomous_channel` 제거 후 모든 keeper-side call-site 수정을 강제 확인.
- 영향 모듈 테스트 개별 실행 전부 통과: `test_dashboard_keeper_metrics_10286`(8), `test_keeper_compaction_noop_counter_9943`(5), `test_keeper_long_turn_9943`(7), `test_context_max_observed_9953`(7), `test_keeper_usage_trust_counter`(7), `test_keeper_unified_verification_surface`(12), `test_keeper_tool_audit_snapshot`(1), `test_keeper_decision_event`(4), `test_dashboard_attribution`(11), `test_keeper_cycle_channel`(5, 신규).
- ocamlformat: 변경 .ml/.mli 전부 clean(`dune build @fmt` diff에 내 파일 0; pre-existing dune-file diff 3건은 무관).

### 미검증 / 주의

- **전체 `dune runtest` 는 신뢰 불가**: `test/dune:1893`의 `test_rfc_0085_pr4_tool_library_proof_store` 가 **삭제된 `lib/cdal_runtime/proof_store.ml`** 를 `(deps ...)` 로 참조 → "No rule found" 로 runtest가 비결정적 부분 실행(base/main 동일, **pre-existing**, 내 변경 무관). 이 때문에 full @runtest baseline 대조 대신 영향 모듈 개별 테스트로 검증. 전체 스위트는 CI `Build and Test` 가 권위(현 main에서 green). 별도 이슈로 기록 예정.
- `test_attribution` 3건 실패는 `Attribution` 모듈만 사용(내 변경 모듈 import 0) → pre-existing, 무관.
- 라이브: 재배포 후 채널 분류(turn/scheduled_autonomous 집계, 옛 reactive/proactive/heartbeat 행 drop). worktree는 라이브 데몬 미구동.

## RFC

RFC-WAIVED: keeper turn-trigger 운반층 타입화(RFC-0020 직접 봉합). credential/operator/sandbox/hooks/workflow subsystem 미해당.

WORKAROUND-WAIVED: 이 PR은 string classifier(`is_autonomous_channel : string -> bool` + dashboard 인라인 `|| "proactive"` 분기)를 *제거*한다(추가 아님). 닫힌 variant + 컴파일러 강제 + strict parse로 대체. PR body의 "classifier/string 분류기/proactive" 언급은 제거 대상을 설명하는 것이며 워크어라운드 도입이 아니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
