### PR TITLE
Phase6: Add episode-level TTL (valid_until) and terminal_marker to episode type

### DIFF
--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -89,6 +89,12 @@ let fact_is_current ~now fact =
   | Some ts -> ts >= now
 ;;
 
+let episode_is_current ~now episode =
+  match episode.valid_until with
+  | None -> true
+  | Some ts -> ts >= now
+;;
+
 let render_fact ~now fact =
   let score = Keeper_memory_os_policy.score_fact ~now fact in
   let source = fact.source in
@@ -102,10 +108,16 @@ let render_fact ~now fact =
 ;;
 
 let render_episode episode =
+  let terminal_suffix =
+    match episode.terminal_marker with
+    | None -> ""
+    | Some m -> Printf.sprintf " [TERMINAL: %s]" m
+  in
   Printf.sprintf
-    "- [%s g%04d] %s"
+    "- [%s g%04d]%s %s"
     (sanitize_atom episode.trace_id)
     episode.generation
+    terminal_suffix
     (sanitize_text ~max_len:max_episode_text_len episode.episode_summary)
 ;;
 

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -34,6 +34,8 @@ type episode =
   ; preserved_tool_refs : string list
   ; source_turn_range : (int * int) option
   ; created_at : float
+  ; valid_until : float option
+  ; terminal_marker : string option
   ; schema_version : string
   }
 
@@ -182,7 +184,13 @@ let episode_to_json e =
      ; "created_at", `Float e.created_at
      ; "schema_version", `String e.schema_version
      ]
-     @ range_json)
+     @ range_json
+     @ (match e.valid_until with
+        | Some ts -> [ "valid_until", `Float ts ]
+        | None -> [])
+     @ (match e.terminal_marker with
+        | Some m -> [ "terminal_marker", `String m ]
+        | None -> []))
 ;;
 
 let episode_of_json (json : Yojson.Safe.t) =
@@ -216,6 +224,9 @@ let episode_of_json (json : Yojson.Safe.t) =
        in
        (* DET-OK: absent created_at defaults to epoch for migration safety. *)
        let created_at = Option.value (json_float_field "created_at" fields) ~default:0.0 in
+       (* Phase6: absent valid_until defaults to never-expire for backward compat. *)
+       let valid_until = json_float_field "valid_until" fields in
+       let terminal_marker = json_string_field "terminal_marker" fields in
        Some
          { trace_id
          ; generation
@@ -226,6 +237,8 @@ let episode_of_json (json : Yojson.Safe.t) =
          ; preserved_tool_refs
          ; source_turn_range
          ; created_at
+         ; valid_until
+         ; terminal_marker
          ; schema_version =
              (* DET-OK: default to current schema for forward compatibility. *)
              Option.value (json_string_field "schema_version" fields) ~default:schema_version


### PR DESCRIPTION
Adds `valid_until` and `terminal_marker` fields to episode type in Memory OS.

- `keeper_memory_os_types.ml`: Add `valid_until : float option` (backward-compatible, absent = never-expire) and `terminal_marker : string option`
- `keeper_memory_os_recall.ml`: Add `episode_is_current ~now` filter, update `render_episode` for terminal marker

Addresses the stale-fact lifecycle gap: without episode-level TTL, old episodes persist forever even when their individual facts decay. This is the counterpart to the already-merged Phase3a `inverse_recency_factor` and Phase3b `stale_penalty`.

Related: Confidence Inversion discovery (garnet, board p-fe73915f), Memory OS blind spot (garnet, board p-ed90d223).