### PR TITLE
fix(schedule): 손상된 durable ledger에 silent default 대신 fail-loud

### DIFF
--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -14,8 +14,51 @@ type store_error =
   | Invalid_initial_status of string
   | Invalid_status_transition of string
   | Grant_validation_failed of Schedule_domain.grant_error
+  | Corrupt_ledger of
+      { primary_err : string
+      ; recovery_err : string option
+      }
+
+(* RFC-0234: a parsed-or-absent ledger load. [Fresh] = the file is legitimately
+   absent (empty store, [default_state] is correct). [Corrupt] = the file is
+   present but neither it nor the [.last-good] recovery file parses; callers must
+   NOT collapse this to [default_state] and must NOT overwrite the on-disk file,
+   because the bytes may still hold operator pending-approval grants worth manual
+   recovery. *)
+type load_outcome =
+  | Loaded of state
+  | Fresh
+  | Corrupt of
+      { primary_err : string
+      ; recovery_err : string option
+      }
+
+(* Raised by the read-only accessors ([list_schedules]/[get_schedule]) on a
+   corrupt-but-present ledger. Read paths cannot silently return an empty list
+   (that would hide operator data) and they have no [result] channel, so they
+   fail loud. The mutating paths use [load] directly and refuse via
+   [Corrupt_ledger] instead of raising, so they never overwrite the file. *)
+exception
+  Corrupt_ledger_exn of
+    { primary_err : string
+    ; recovery_err : string option
+    }
 
 let ( let* ) = Result.bind
+
+let corrupt_message ~primary_err ~recovery_err =
+  match recovery_err with
+  | None ->
+    Printf.sprintf
+      "schedule ledger is present but unparseable (primary: %s); no .last-good \
+       recovery file exists"
+      primary_err
+  | Some recovery_err ->
+    Printf.sprintf
+      "schedule ledger is present but unparseable (primary: %s; .last-good \
+       recovery: %s)"
+      primary_err recovery_err
+;;
 
 let store_error_to_string = function
   | Schedule_already_exists -> "schedule already exists"
@@ -25,6 +68,8 @@ let store_error_to_string = function
   | Invalid_status_transition reason -> "invalid schedule status transition: " ^ reason
   | Grant_validation_failed err ->
     "grant validation failed: " ^ Schedule_domain.grant_error_to_string err
+  | Corrupt_ledger { primary_err; recovery_err } ->
+    corrupt_message ~primary_err ~recovery_err
 ;;
 
 (* NDT-OK: store boundary timestamp for projection metadata; replay uses the
@@ -102,40 +147,73 @@ let state_of_yojson = function
   | json -> Error ("state_of_yojson: " ^ Yojson.Safe.to_string json)
 ;;
 
-let read_state config =
-  ensure_dirs config;
-  let path = schedules_path config in
-  if Workspace_utils.path_exists config path then
-    match Workspace_utils.read_json_result config path with
-    | Ok json ->
-      (match state_of_yojson json with
-       | Ok state -> state
-       | Error _ ->
-         let recovery = recovery_path config in
-         if Workspace_utils.path_exists config recovery then
-           match Workspace_utils.read_json_result config recovery with
-           | Ok recovery_json ->
-             (match state_of_yojson recovery_json with
-              | Ok state -> state
-              | Error _ -> default_state ())
-           | Error _ -> default_state ()
-         else
-           default_state ())
-    | Error _ ->
-      let recovery = recovery_path config in
-      if Workspace_utils.path_exists config recovery then
-        match Workspace_utils.read_json_result config recovery with
-        | Ok recovery_json ->
-          (match state_of_yojson recovery_json with
-           | Ok state -> state
-           | Error _ -> default_state ())
-        | Error _ -> default_state ()
-      else
-        default_state ()
+(* Parse the [.last-good] recovery file. Returns [Ok state] on a clean parse, or
+   [Error message] describing why recovery is unavailable (absent or unparseable). *)
+let load_recovery config =
+  let recovery = recovery_path config in
+  if Workspace_utils.path_exists config recovery then
+    match Workspace_utils.read_json_result config recovery with
+    | Ok recovery_json -> state_of_yojson recovery_json
+    | Error read_err -> Error read_err
   else
-    default_state ()
+    Error "no .last-good recovery file"
 ;;
 
+(* Total load that distinguishes a fresh (absent) ledger from a corrupt
+   (present-but-unparseable) one. [read_json_result] folds file-read failure and
+   parse failure into a single [Error message], so an existing-but-broken primary
+   surfaces here rather than being silently swallowed. *)
+let load config : load_outcome =
+  ensure_dirs config;
+  let path = schedules_path config in
+  if not (Workspace_utils.path_exists config path) then
+    Fresh
+  else (
+    let primary =
+      match Workspace_utils.read_json_result config path with
+      | Ok json -> state_of_yojson json
+      | Error read_err -> Error read_err
+    in
+    match primary with
+    | Ok state -> Loaded state
+    | Error primary_err ->
+      (match load_recovery config with
+       | Ok state -> Loaded state
+       | Error recovery_err ->
+         Corrupt { primary_err; recovery_err = Some recovery_err }))
+;;
+
+(* Read-only accessor used by [list_schedules]/[get_schedule]. [Fresh] yields the
+   empty default (correct for an uninitialised store); [Corrupt] raises rather
+   than returning an empty list, so a corrupt ledger is operator-visible instead
+   of masquerading as "no schedules". Does not write to disk. *)
+let read_state config =
+  match load config with
+  | Loaded state -> state
+  | Fresh -> default_state ()
+  | Corrupt { primary_err; recovery_err } ->
+    raise (Corrupt_ledger_exn { primary_err; recovery_err })
+;;
+
+(* Resolve the current state for a mutation. [Corrupt] is refused as a typed
+   [Corrupt_ledger] error so the mutating function aborts BEFORE calling
+   [write_state]; this is what prevents the corrupt-but-present ledger from being
+   overwritten with an empty default on the next write. *)
+let load_for_mutation config : (state, store_error) result =
+  match load config with
+  | Loaded state -> Ok state
+  | Fresh -> Ok (default_state ())
+  | Corrupt { primary_err; recovery_err } ->
+    Error (Corrupt_ledger { primary_err; recovery_err })
+;;
+
+(* Write the primary ledger, then mirror to [.last-good]. The [.last-good] file
+   is written only here, immediately after a fully-formed in-memory [state] is
+   serialised, so it can only ever hold a parseable snapshot. The previous
+   recovery path was useless because corruption arrived on disk out-of-band
+   (e.g. schema evolution / partial write of the primary), never through this
+   serialise step. Refusing to read a corrupt primary into [state] (above) means
+   we never round-trip corruption through here either. *)
 let write_state config state =
   ensure_dirs config;
   let json = state_to_yojson state in
@@ -207,7 +285,7 @@ let validate_initial_request (request : Schedule_domain.schedule_request) =
 
 let insert_request config (request : Schedule_domain.schedule_request) =
   Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
-    let state = read_state config in
+    let* state = load_for_mutation config in
     match find_schedule state request.schedule_id with
     | Some _ -> Error Schedule_already_exists
     | None ->
@@ -220,7 +298,7 @@ let insert_request config (request : Schedule_domain.schedule_request) =
 
 let record_grant config (grant : Schedule_domain.execution_grant) =
   Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
-    let state = read_state config in
+    let* state = load_for_mutation config in
     if grant_exists state grant.grant_id then
       Error Grant_already_recorded
     else (
@@ -239,7 +317,7 @@ let record_grant config (grant : Schedule_domain.execution_grant) =
 
 let cancel_request config ~schedule_id =
   Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
-    let state = read_state config in
+    let* state = load_for_mutation config in
     match find_schedule state schedule_id with
     | None -> Error Schedule_not_found
     | Some request ->
@@ -260,7 +338,7 @@ let cancel_request config ~schedule_id =
 
 let refresh_due config ~now =
   Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
-    let state = read_state config in
+    let* state = load_for_mutation config in
     let changed = ref 0 in
     let schedules =
       List.map

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -17,10 +17,44 @@ type store_error =
   | Invalid_initial_status of string
   | Invalid_status_transition of string
   | Grant_validation_failed of Schedule_domain.grant_error
+  | Corrupt_ledger of
+      { primary_err : string
+      ; recovery_err : string option
+      }
+      (** RFC-0234: returned by mutating functions when the on-disk ledger is
+          present but neither it nor its [.last-good] recovery file parses. The
+          mutation is refused so the corrupt bytes are NOT overwritten. *)
 
 val store_error_to_string : store_error -> string
 
+(** Outcome of loading the durable ledger. [Fresh] is a legitimately absent file
+    (empty store); [Corrupt] is a present-but-unparseable file that must not be
+    silently defaulted or overwritten. *)
+type load_outcome =
+  | Loaded of state
+  | Fresh
+  | Corrupt of
+      { primary_err : string
+      ; recovery_err : string option
+      }
+
+(** Raised by [read_state]/[list_schedules]/[get_schedule] on a corrupt ledger.
+    Read paths have no [result] channel, so they fail loud instead of returning
+    an empty list. Mutating paths report [Corrupt_ledger] instead. *)
+exception
+  Corrupt_ledger_exn of
+    { primary_err : string
+    ; recovery_err : string option
+    }
+
 val schedules_path : Workspace_utils.config -> string
+
+(** Total load that distinguishes a fresh (absent) ledger from a corrupt
+    (present-but-unparseable) one. Performs no writes. *)
+val load : Workspace_utils.config -> load_outcome
+
+(** Read-only snapshot. Returns the empty [default_state] for a [Fresh] store and
+    raises {!Corrupt_ledger_exn} for a corrupt one. Never writes to disk. *)
 val read_state : Workspace_utils.config -> state
 
 val default_state : unit -> state

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -199,6 +199,100 @@ let test_recovers_from_last_good () =
   check int "recovered schedule" 1 (List.length recovered.schedules)
 ;;
 
+let recovery_path config = schedules_path config ^ ".last-good"
+
+(* Corrupt both the primary and the .last-good recovery file. After [insert_ok],
+   [write_state] has produced a parseable .last-good, so we overwrite both files
+   with non-JSON to simulate out-of-band corruption (e.g. partial write / schema
+   evolution). *)
+let corrupt_both config =
+  Workspace.write_text config (schedules_path config) "{not json";
+  Workspace.write_text config (recovery_path config) "}also not json"
+;;
+
+let test_load_fresh_when_file_absent () =
+  with_workspace
+  @@ fun config ->
+  (* A pristine workspace has no schedules.json yet. *)
+  (match Schedule_store.load config with
+   | Fresh -> ()
+   | Loaded _ -> fail "absent ledger reported as Loaded"
+   | Corrupt _ -> fail "absent ledger reported as Corrupt");
+  let state = read_state config in
+  check int "fresh store has no schedules" 0 (List.length state.schedules);
+  check int "fresh store has no grants" 0 (List.length state.grants)
+;;
+
+let test_load_corrupt_when_both_unparseable () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request ~risk_class:Read_only () in
+  ignore (insert_ok config req);
+  corrupt_both config;
+  match Schedule_store.load config with
+  | Corrupt { primary_err; recovery_err } ->
+    check bool "primary error is non-empty" true (String.length primary_err > 0);
+    check bool "recovery error reported" true (Option.is_some recovery_err)
+  | Fresh -> fail "corrupt-but-present ledger reported as Fresh"
+  | Loaded _ -> fail "corrupt ledger reported as Loaded"
+;;
+
+let test_read_state_raises_on_corrupt () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request ~risk_class:Read_only () in
+  ignore (insert_ok config req);
+  corrupt_both config;
+  match read_state config with
+  | _ -> fail "read_state silently returned a state for a corrupt ledger"
+  | exception Schedule_store.Corrupt_ledger_exn _ -> ()
+;;
+
+(* The core silent-failure-to-data-loss regression: a mutation on a corrupt
+   ledger must be refused (typed [Corrupt_ledger]) and must NOT overwrite the
+   present-but-corrupt files with an empty default. *)
+let test_mutation_refused_and_preserves_corrupt_ledger () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request ~risk_class:Read_only () in
+  ignore (insert_ok config req);
+  corrupt_both config;
+  let primary_before = Workspace.read_text config (schedules_path config) in
+  let recovery_before = Workspace.read_text config (recovery_path config) in
+  (match insert_request config (make_request ~schedule_id:"sched-2" ~risk_class:Read_only ()) with
+   | Ok _ -> fail "insert on corrupt ledger unexpectedly succeeded"
+   | Error (Corrupt_ledger _) -> ()
+   | Error err -> fail ("expected Corrupt_ledger, got: " ^ store_error_to_string err));
+  let primary_after = Workspace.read_text config (schedules_path config) in
+  let recovery_after = Workspace.read_text config (recovery_path config) in
+  check string "corrupt primary preserved" primary_before primary_after;
+  check string "corrupt recovery preserved" recovery_before recovery_after
+;;
+
+let test_cancel_refused_on_corrupt_ledger () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request ~schedule_id:"cancel-corrupt" ~risk_class:Read_only () in
+  ignore (insert_ok config req);
+  corrupt_both config;
+  match cancel_request config ~schedule_id:"cancel-corrupt" with
+  | Ok _ -> fail "cancel on corrupt ledger unexpectedly succeeded"
+  | Error (Corrupt_ledger _) -> ()
+  | Error err -> fail ("expected Corrupt_ledger, got: " ^ store_error_to_string err)
+;;
+
+(* [.last-good] must hold a parseable snapshot, never a mirror of corruption. *)
+let test_last_good_is_parseable_after_good_write () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request ~risk_class:Read_only () in
+  ignore (insert_ok config req);
+  let recovery_json = Workspace.read_json config (recovery_path config) in
+  match Schedule_store.state_of_yojson recovery_json with
+  | Ok state -> check int "last-good holds the schedule" 1 (List.length state.schedules)
+  | Error msg -> fail (".last-good is not parseable: " ^ msg)
+;;
+
 let () =
   run "Schedule_store"
     [
@@ -210,6 +304,21 @@ let () =
             test_duplicate_insert_rejected_without_bump;
           test_case "corrupt primary recovers from last-good" `Quick
             test_recovers_from_last_good;
+        ] );
+      ( "corruption",
+        [
+          test_case "absent ledger loads Fresh" `Quick
+            test_load_fresh_when_file_absent;
+          test_case "both unparseable loads Corrupt" `Quick
+            test_load_corrupt_when_both_unparseable;
+          test_case "read_state raises on corrupt ledger" `Quick
+            test_read_state_raises_on_corrupt;
+          test_case "mutation refused and corrupt ledger preserved" `Quick
+            test_mutation_refused_and_preserves_corrupt_ledger;
+          test_case "cancel refused on corrupt ledger" `Quick
+            test_cancel_refused_on_corrupt_ledger;
+          test_case "last-good is parseable after good write" `Quick
+            test_last_good_is_parseable_after_good_write;
         ] );
       ( "approval",
         [


### PR DESCRIPTION
## 목표

`schedule_store.read_state`가 손상된 durable ledger를 조용히 `default_state()`(빈 상태)로 붕괴시키던 Silent Failure를 제거한다. 기존 코드는 primary 파일과 `.last-good` 복구 파일이 **둘 다** 파싱 실패하면 빈 상태로 떨어지고 다음 쓰기에서 손상 바이트를 덮어썼다. 이 ledger에는 Destructive/Cost_bearing pending-approval grant가 들어있어, schema 진화 한 번의 파싱 실패가 운영자의 승인 대기 행을 통째로 소실시킬 수 있었다.

`state_of_yojson`은 이미 `(state, string) result`를 반환했으나 `read_state`가 그 정보를 버리고 있었다. Parse, don't validate 원칙에 맞게 경계에서 손상을 표면화한다.

## 변경

- `lib/schedule/schedule_store.ml`
  - `type load_outcome = Loaded of state | Fresh | Corrupt of { primary_err; recovery_err }` 도입. `Fresh`(파일 부재 = 정당한 빈 상태)와 `Corrupt`(present-but-unparseable)를 구분.
  - `load : config -> load_outcome` 총함수 추가. 중첩 silent `default_state()` 붕괴 블록 삭제.
  - `read_state`(read-only, result 채널 없음)는 손상 시 `Corrupt_ledger_exn`을 raise (빈 리스트 반환으로 데이터를 숨기지 않음).
  - mutating 경로는 `store_error`에 추가된 `Corrupt_ledger`로 거부 → 손상 파일을 덮어쓰지 않음.
  - `.last-good` 백업은 정상 로드/파싱 후에만 기록하도록 규율 교정(손상 mirror 방지).
- `lib/schedule/schedule_store.mli` — `load_outcome` / `Corrupt_ledger_exn` / `load` 공개, 계약 문서화.
- `test/test_schedule_store.ml` — corruption 테스트 추가.

## 로컬 검증

- `dune build --root .` → exit 0
- `dune exec --root . -- test/test_schedule_store.exe` → **15 tests, Test Successful**
  - `corruption 0` absent ledger loads Fresh
  - `corruption 1` both unparseable loads Corrupt
  - `corruption 2` read_state raises on corrupt ledger
  - `corruption 3` mutation refused and corrupt ledger preserved
  - `corruption 4` cancel refused on corrupt ledger
  - `corruption 5` last-good is parseable after good write

## 미검증

- 호출부 전수: `read_state` 소비처를 worktree 내에서 빌드로 검증했으나(전체 컴파일 green), 런타임에서 corrupt 분기를 타는 실제 운영 경로의 alert/로그 가시성은 별도 확인 필요.
- 기존 `.last-good`가 손상 primary와 byte-identical하게 적재된 레거시 파일이 있는 경우의 마이그레이션 동작은 미검증.

근거: 2026-06-12~15 머지 감사 (RFC-0234 scheduled-automation read-path Silent Failure).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
