### PR TITLE
fix(dashboard,auth): 401 재시도를 typed auth_error_code로 게이트 (substring 제거)

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -168,20 +168,22 @@ describe('streamKeeperMessage', () => {
     expect(events).toEqual(['RUN_FINISHED'])
   })
 
-  it('refreshes a stale loopback dev token once and retries direct chat', async () => {
+  const stubStaleToken = () => {
     window.sessionStorage.setItem('masc_bearer_token', 'stale-token')
     window.sessionStorage.setItem(
       'masc_bearer_token_meta',
       JSON.stringify({ source: 'dev', actor: 'dashboard', scope: 'worker' }),
     )
+  }
 
+  const stubStreamRetryFetch = (first401Body: unknown) => {
     let chatAttempts = 0
     const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       if (url === '/api/v1/keepers/chat/stream') {
         chatAttempts += 1
         if (chatAttempts === 1) {
           return Promise.resolve(new Response(
-            JSON.stringify({ error: '[AuthError] Invalid token: Token mismatch' }),
+            JSON.stringify(first401Body),
             { status: 401, headers: { 'Content-Type': 'application/json' } },
           ))
         }
@@ -199,6 +201,17 @@ describe('streamKeeperMessage', () => {
       return Promise.reject(new Error(`unexpected fetch ${url}`))
     })
     vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  it('refreshes a stale loopback dev token once and retries on typed invalid_token code', async () => {
+    stubStaleToken()
+    // The message is a generic string that would NOT match the legacy
+    // substring matcher; the typed auth_error_code drives the retry.
+    const fetchMock = stubStreamRetryFetch({
+      error: 'authentication failed',
+      auth_error_code: 'invalid_token',
+    })
 
     const events: string[] = []
     await streamKeeperMessage('sangsu', 'ping', {
@@ -217,6 +230,63 @@ describe('streamKeeperMessage', () => {
     expect(firstHeaders.Authorization).toBe('Bearer stale-token')
     expect(retryHeaders.Authorization).toBe('Bearer fresh-token')
     expect(events).toEqual(['RUN_FINISHED'])
+  })
+
+  it('retries on actor_mismatch typed code', async () => {
+    stubStaleToken()
+    const fetchMock = stubStreamRetryFetch({
+      error: 'Agent name required',
+      auth_error_code: 'actor_mismatch',
+    })
+
+    await streamKeeperMessage('sangsu', 'ping', { onEvent: () => {} })
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/api/v1/keepers/chat/stream',
+      '/api/v1/dashboard/dev-token',
+      '/api/v1/keepers/chat/stream',
+    ])
+  })
+
+  it('does NOT retry when the typed code is not a stale-token case', async () => {
+    stubStaleToken()
+    const fetchMock = vi.fn((url: string) => {
+      if (url === '/api/v1/keepers/chat/stream') {
+        return Promise.resolve(new Response(
+          JSON.stringify({
+            error: '[AuthError] Forbidden: browser cannot cross-origin HTTP mutation',
+            auth_error_code: 'same_origin_blocked',
+          }),
+          { status: 401, headers: { 'Content-Type': 'application/json' } },
+        ))
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      streamKeeperMessage('sangsu', 'ping', { onEvent: () => {} }),
+    ).rejects.toThrow()
+
+    // Only the single chat POST — no dev-token refresh, no retry.
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/api/v1/keepers/chat/stream',
+    ])
+  })
+
+  it('falls back to the legacy substring match for servers without auth_error_code', async () => {
+    stubStaleToken()
+    const fetchMock = stubStreamRetryFetch({
+      error: '[AuthError] Invalid token: Token mismatch',
+    })
+
+    await streamKeeperMessage('sangsu', 'ping', { onEvent: () => {} })
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/api/v1/keepers/chat/stream',
+      '/api/v1/dashboard/dev-token',
+      '/api/v1/keepers/chat/stream',
+    ])
   })
 })
 

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -6,6 +6,7 @@ import {
   normalizeKeeperConversationDetails,
 } from '../keeper-message'
 import type { KeeperConversationDetails } from '../types'
+import type { DashboardAuthErrorCode } from '../types/dashboard-execution'
 import {
   currentDashboardActor,
   apiRequestErrorFromResponse,
@@ -393,7 +394,39 @@ function keeperStreamErrorMessage(raw: string, status: number): string {
   return message
 }
 
-function isTokenMismatchAuthError(raw: string): boolean {
+/**
+ * Auth error codes that mean the stored bearer token is stale or wrong for
+ * the requested actor — minting a fresh dev token and retrying can recover.
+ * `same_origin_blocked` / `insufficient_role` / `missing_token` are NOT here:
+ * a token refresh cannot fix a CORS rejection, a role shortfall, or a request
+ * that simply omitted the token.
+ */
+const STALE_TOKEN_AUTH_CODES: ReadonlySet<DashboardAuthErrorCode> = new Set([
+  'invalid_token',
+  'token_expired',
+  'actor_mismatch',
+])
+
+/**
+ * Decide whether a 401 body signals a stale/wrong bearer token.
+ * Primary gate: the typed `auth_error_code` field in the JSON body
+ * (server SSOT: `lib/types/masc_error.ml:dashboard_auth_error_code`,
+ * emitted by `lib/server/server_auth.ml:auth_error_json`).
+ */
+function isStaleTokenAuthError(raw: string): boolean {
+  try {
+    const parsed = JSON.parse(raw) as { auth_error_code?: unknown }
+    const code = parsed.auth_error_code
+    if (typeof code === 'string') {
+      return STALE_TOKEN_AUTH_CODES.has(code as DashboardAuthErrorCode)
+    }
+  } catch {
+    // Not JSON — fall through to the legacy substring fallback below.
+  }
+  // WORKAROUND: legacy server fallback for servers that predate the typed
+  // `auth_error_code` 401 body. The substring shape comes from
+  // `Auth_error.InvalidToken "Token mismatch"` rendered as
+  // "[AuthError] Invalid token: Token mismatch". removal target: next release.
   const normalized = raw.toLowerCase()
   return normalized.includes('autherror')
     && normalized.includes('invalid token')
@@ -456,7 +489,7 @@ export async function streamKeeperMessage(
     let raw = await res.text()
     if (
       res.status === 401
-      && isTokenMismatchAuthError(raw)
+      && isStaleTokenAuthError(raw)
       && await refreshLoopbackDevTokenAfterMismatch()
     ) {
       res = await postStream()

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -39,6 +39,21 @@ export interface DashboardShellMetaCognitionSummary {
   top_desire?: DashboardShellMetaCognitionDesire | null
 }
 
+/**
+ * Typed auth error code emitted server-side. SSOT mapping lives in
+ * `lib/types/masc_error.ml:dashboard_auth_error_code`; carried both in the
+ * dashboard shell summary and the HTTP 401/403 error body
+ * (`lib/server/server_auth.ml:auth_error_json`).
+ */
+export type DashboardAuthErrorCode =
+  | 'missing_token'
+  | 'invalid_token'
+  | 'token_expired'
+  | 'actor_mismatch'
+  | 'insufficient_role'
+  | 'same_origin_blocked'
+  | 'unknown'
+
 export interface DashboardShellAuthSummary {
   enabled: boolean
   require_token: boolean
@@ -49,7 +64,7 @@ export interface DashboardShellAuthSummary {
   requested_agent?: string | null
   effective_agent?: string | null
   effective_role?: string | null
-  auth_error_code?: 'missing_token' | 'invalid_token' | 'token_expired' | 'actor_mismatch' | 'insufficient_role' | 'same_origin_blocked' | 'unknown' | null
+  auth_error_code?: DashboardAuthErrorCode | null
   auth_error_detail?: string | null
   can_keeper_msg: boolean
   keeper_msg_error?: string | null

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -651,9 +651,20 @@ let respond_public_read_json_value ?(status = `OK) request reqd value =
   Http_server_eio.Response.json_value ~status
     ~request ~extra_headers:(public_read_cors_headers request) value reqd
 
+(* The 401/403 body carries the typed [auth_error_code] alongside the
+   human-readable [error] string. Clients (dashboard keeper stream retry
+   gate) dispatch on the typed code instead of substring-matching the
+   message. The code is the same SSOT mapping the dashboard shell
+   summary uses ([Masc_domain.dashboard_auth_error_code]). The legacy
+   [error] field is retained for human display and backward compat. *)
 let auth_error_json err =
-  Yojson.Safe.to_string
-    (`Assoc [ ("error", `String (Masc_domain.masc_error_to_string err)) ])
+  let base = [ ("error", `String (Masc_domain.masc_error_to_string err)) ] in
+  let fields =
+    match Masc_domain.dashboard_auth_error_code err with
+    | Some code -> base @ [ ("auth_error_code", `String code) ]
+    | None -> base
+  in
+  Yojson.Safe.to_string (`Assoc fields)
 
 let respond_auth_error request reqd err =
   let status = http_status_of_auth_error err in

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -601,18 +601,11 @@ let dashboard_shell_payload_json
 let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Workspace.config)
   : Yojson.Safe.t
   =
-  let dashboard_auth_error_code = function
-    | Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken _) -> Some "invalid_token"
-    | Masc_domain.Auth (Masc_domain.Auth_error.TokenExpired _) -> Some "token_expired"
-    | Masc_domain.Auth
-        (Masc_domain.Auth_error.Forbidden
-           { agent = "browser"; action = "cross-origin HTTP mutation" }) ->
-      Some "same_origin_blocked"
-    | Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _) -> Some "insufficient_role"
-    | Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized { reason; _ }) ->
-      Some (Masc_domain.Auth_error.unauthorized_reason_to_string reason)
-    | _ -> Some "unknown"
-  in
+  (* SSOT: typed-error → dashboard auth code lives in
+     [Masc_domain.dashboard_auth_error_code] so this shell summary and
+     the HTTP 401 error body ([Server_auth.auth_error_json]) emit the
+     same code. *)
+  let dashboard_auth_error_code = Masc_domain.dashboard_auth_error_code in
   let auth_cfg = Auth.load_auth_config config.base_path in
   let token = auth_token_from_request request in
   let token_credential_result =

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -227,6 +227,36 @@ let code = function
   | RateLimitExceeded _ -> 429
   | CacheError _ -> 500
 
+(* [dashboard_auth_error_code] is the SSOT mapping from a typed
+   [masc_error] to the stable dashboard auth-error-code string that the
+   Bonsai dashboard's [DashboardShellAuthSummary.auth_error_code] /
+   keeper stream 401 retry gate consume (TS enum in
+   dashboard/src/types/dashboard-execution.ts). Introduced in #21040
+   for the shell summary; this top-level home lets both
+   [server_dashboard_http_core] (shell JSON) and [server_auth]
+   (401 error body) emit the same typed code without a second copy of
+   the classifier or a backward dependency.
+
+   The match is exhaustive on the outer [t] so a new auth-relevant
+   variant trips Warning 8 here instead of silently falling through.
+   The [Forbidden { agent = "browser"; action = "cross-origin HTTP
+   mutation" }] arm matches the literal action string produced in
+   [Server_auth.ensure_same_origin_browser_request]; that string pair
+   is a pre-existing coupling carried over verbatim from #21040, not a
+   new substring classifier. *)
+let dashboard_auth_error_code : t -> string option = function
+  | Auth (Auth_error.InvalidToken _) -> Some "invalid_token"
+  | Auth (Auth_error.TokenExpired _) -> Some "token_expired"
+  | Auth
+      (Auth_error.Forbidden
+         { agent = "browser"; action = "cross-origin HTTP mutation" }) ->
+      Some "same_origin_blocked"
+  | Auth (Auth_error.Forbidden _) -> Some "insufficient_role"
+  | Auth (Auth_error.Unauthorized { reason; _ }) ->
+      Some (Auth_error.unauthorized_reason_to_string reason)
+  | Task _ | Agent _ | System _ | RateLimitExceeded _ | CacheError _ ->
+      Some "unknown"
+
 (* [is_retryable] mirrors [Error.is_retryable] in OAS so MASC-side
    callers don't have to fall back on an OAS-only predicate when
    reasoning about a [masc_error]. Conservative — when in doubt

--- a/lib/types/masc_error.mli
+++ b/lib/types/masc_error.mli
@@ -76,6 +76,26 @@ val show : t -> string
 val to_yojson : t -> Yojson.Safe.t
 val code : t -> int
 
+val dashboard_auth_error_code : t -> string option
+(** [dashboard_auth_error_code err] maps a typed error to the stable
+    dashboard auth-error-code string consumed by the Bonsai dashboard
+    ([DashboardShellAuthSummary.auth_error_code]) and the keeper stream
+    401 retry gate (TS enum in
+    [dashboard/src/types/dashboard-execution.ts]).
+
+    SSOT for both the dashboard shell summary JSON and the HTTP 401
+    error body so the two surfaces never drift. Returns:
+    {ul
+    {- ["invalid_token"] for [Auth (InvalidToken _)];}
+    {- ["token_expired"] for [Auth (TokenExpired _)];}
+    {- ["same_origin_blocked"] for the browser cross-origin
+       [Auth (Forbidden _)] case;}
+    {- ["insufficient_role"] for any other [Auth (Forbidden _)];}
+    {- the [unauthorized_reason] code
+       (["actor_mismatch"] / ["missing_token"] / ["unknown"]) for
+       [Auth (Unauthorized _)];}
+    {- ["unknown"] for all non-auth errors.} } *)
+
 val is_retryable : t -> bool
 (** [is_retryable err] — would replaying the same operation, without
     additional caller action, have a chance of succeeding?

--- a/test/dune
+++ b/test/dune
@@ -1573,6 +1573,8 @@
 
 (include stanzas/test_masc_dirname_ssot.inc)
 
+(include stanzas/test_masc_error_dashboard_auth_code.inc)
+
 (include stanzas/test_masc_error_is_retryable.inc)
 
 (include stanzas/test_mcp_post_sse_e2e.inc)

--- a/test/stanzas/test_masc_error_dashboard_auth_code.inc
+++ b/test/stanzas/test_masc_error_dashboard_auth_code.inc
@@ -1,0 +1,9 @@
+; Per-file dune stanza for the
+; [Masc_error.dashboard_auth_error_code] SSOT mapping suite. Lives here
+; per test/stanzas/README.md to avoid the conflict-runtime hotspot in the
+; legacy grouped (tests ...) stanza.
+
+(test
+ (name test_masc_error_dashboard_auth_code)
+ (modules test_masc_error_dashboard_auth_code)
+ (libraries masc_test_deps))

--- a/test/test_masc_error_dashboard_auth_code.ml
+++ b/test/test_masc_error_dashboard_auth_code.ml
@@ -1,0 +1,50 @@
+(** Pin the typed-error -> dashboard auth-error-code mapping.
+
+    [Masc_error.dashboard_auth_error_code] is the SSOT consumed by both
+    the dashboard shell summary JSON and the HTTP 401/403 error body
+    ([Server_auth.auth_error_json]). The dashboard keeper stream retry
+    gate dispatches on these codes (TS enum in
+    dashboard/src/types/dashboard-execution.ts) instead of
+    substring-matching the error message. This suite locks the
+    per-variant mapping so a drift between the two server surfaces, or a
+    code rename, fails a test rather than silently breaking the client
+    gate. *)
+
+module E = Masc_error
+
+let check label expected actual =
+  if expected <> actual then (
+    Printf.eprintf
+      "test_masc_error_dashboard_auth_code: %s expected=%s got=%s\n" label
+      (match expected with Some s -> s | None -> "<none>")
+      (match actual with Some s -> s | None -> "<none>");
+    exit 1)
+
+let () =
+  check "invalid_token" (Some "invalid_token")
+    (E.dashboard_auth_error_code (E.Auth (E.Auth_error.InvalidToken "x")));
+  check "token_expired" (Some "token_expired")
+    (E.dashboard_auth_error_code (E.Auth (E.Auth_error.TokenExpired "agent")));
+  check "same_origin_blocked" (Some "same_origin_blocked")
+    (E.dashboard_auth_error_code
+       (E.Auth
+          (E.Auth_error.Forbidden
+             { agent = "browser"; action = "cross-origin HTTP mutation" })));
+  check "insufficient_role" (Some "insufficient_role")
+    (E.dashboard_auth_error_code
+       (E.Auth (E.Auth_error.Forbidden { agent = "alice"; action = "delete" })));
+  check "unauthorized actor_mismatch" (Some "actor_mismatch")
+    (E.dashboard_auth_error_code
+       (E.Auth
+          (E.Auth_error.Unauthorized { reason = Actor_mismatch; message = "x" })));
+  check "unauthorized missing_token" (Some "missing_token")
+    (E.dashboard_auth_error_code
+       (E.Auth
+          (E.Auth_error.Unauthorized { reason = Missing_token; message = "x" })));
+  check "unauthorized generic -> unknown" (Some "unknown")
+    (E.dashboard_auth_error_code
+       (E.Auth (E.Auth_error.Unauthorized { reason = Generic; message = "x" })));
+  check "non-auth -> unknown" (Some "unknown")
+    (E.dashboard_auth_error_code (E.Task (E.Task_error.NotFound "id")));
+  print_endline
+    "test_masc_error_dashboard_auth_code: all assertions passed"


### PR DESCRIPTION
## 목표

대시보드 keeper 스트림의 401 stale-token 재시도 게이트가 free-form 에러 문자열을 substring 매칭(`isTokenMismatchAuthError`)하던 것을, 서버가 내보내는 typed `auth_error_code`로 교체한다. 형제 PR #21040이 이미 typed enum(`'invalid_token' | 'token_expired' | 'actor_mismatch' | ...`)을 도입했는데 재시도 경로만 string sniffer를 쓰고 있었다.

검증 결과 401 응답 body가 typed code를 싣지 않아, 서버측에서 단일 SSOT(`Masc_error.dashboard_auth_error_code`)를 통해 dashboard shell summary와 401 body 양쪽에 같은 code를 내보내도록 했다(두 표면 drift 차단).

## 변경

서버 (OCaml):
- `lib/types/masc_error.ml/.mli` — `dashboard_auth_error_code : t -> string option` 추가. typed error → 안정적 wire code 문자열의 SSOT.
- `lib/server/server_auth.ml` — 401 에러 body가 `auth_error_code`를 포함하도록 직렬화.
- `lib/server/server_dashboard_http_core.ml` — shell summary가 동일 SSOT 사용(중복 매핑 제거, net 축소).
- `test/test_masc_error_dashboard_auth_code.ml` (+ stanza) — 매핑 단위 테스트.

클라이언트 (TS):
- `dashboard/src/api/keeper.ts` — `isStaleTokenAuthError`가 JSON `auth_error_code`를 primary gate로 파싱, `STALE_TOKEN_AUTH_CODES = {invalid_token, token_expired, actor_mismatch}` 닫힌 집합으로 판정. `same_origin_blocked`/`insufficient_role`/`missing_token`은 의도적 제외(토큰 refresh로 복구 불가). 기존 substring 매칭은 `WORKAROUND: legacy server fallback ... removal target: next release` 라벨 후 fallback으로 강등.
- `dashboard/src/types/dashboard-execution.ts` — 타입 정합.
- `dashboard/src/api/keeper.test.ts` — typed code 게이트 테스트.

## 로컬 검증

- `dune build --root .` → exit 0
- `dune exec --root . -- test/test_masc_error_dashboard_auth_code.exe` → all assertions passed
- `./node_modules/.bin/tsc --noEmit` (worktree node_modules는 main에서 symlink, pnpm-lock 동일) → exit 0
- `./node_modules/.bin/vitest run src/api/keeper.test.ts` → 22 passed

## 미검증

- 실제 401 응답을 받는 라이브 stale-token 시나리오의 end-to-end refresh+retry는 미검증(단위 테스트로만 게이트 동작 확인).
- legacy substring fallback 제거 시점(next release)에 구버전 서버가 잔존하는지 운영 확인 필요.

## RFC

auth 직렬화(`Masc_error.dashboard_auth_error_code`, `server_auth.ml`)를 건드리나, credential/identity 아키텍처 변경이 아니라 기존 typed error → wire-string 직렬화의 SSOT 통합이다. 자격증명 저장/식별 로직 무변경.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
