### PR TITLE
[codex] Improve Memory OS stale fact lifecycle

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -190,6 +190,7 @@
   meta_cognition_parse
   meta_cognition_interpret
   meta_cognition_digest
+  keeper_memory_os_gc
   keeper_memory_os_io
   keeper_memory_os_recall)
  (libraries

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -142,6 +142,9 @@ let fact_of_json ~trace_id ~now (json : Yojson.Safe.t) : fact option =
          ; first_seen = now
          ; last_accessed = now
          ; valid_until = None
+         ; stale_factor = 0.0
+         ; last_verified_at = Some now
+         ; expected_lifetime_cycles = None
          ; schema_version
          }
      | (Some _, Some _, Some _, Some _)

--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -1,0 +1,94 @@
+(** Keeper_memory_os_gc — deterministic garbage collection for stale facts. *)
+
+open Keeper_memory_os_types
+
+module Io = Keeper_memory_os_io
+module Policy = Keeper_memory_os_policy
+module String_map = Map.Make (String)
+module Int_set = Set.Make (Int)
+
+type gc_report =
+  { total_input : int
+  ; ttl_expired : int
+  ; verdict_discarded : int
+  ; dedup_removed : int
+  ; written : int
+  ; dry_run : bool
+  }
+
+type scored_fact =
+  { index : int
+  ; fact : fact
+  ; score : float
+  }
+
+let ttl_expired ~now fact =
+  match fact.valid_until with
+  | None -> false
+  | Some ts -> now > ts
+;;
+
+let normalized_claim_key fact =
+  fact.claim |> String.trim |> String.lowercase_ascii
+;;
+
+let verified_at fact =
+  match fact.last_verified_at with
+  | Some ts -> ts
+  | None -> fact.first_seen
+;;
+
+let better_scored candidate existing =
+  match Float.compare candidate.score existing.score with
+  | cmp when cmp > 0 -> true
+  | cmp when cmp < 0 -> false
+  | _ ->
+    (match Float.compare (verified_at candidate.fact) (verified_at existing.fact) with
+     | cmp when cmp > 0 -> true
+     | cmp when cmp < 0 -> false
+     | _ -> candidate.index < existing.index)
+;;
+
+let keep_by_verdict scored =
+  match Policy.decide_retention scored.score with
+  | Policy.KeepVerbatim -> true
+  | Policy.Discard -> false
+;;
+
+let dedup_by_claim scored =
+  let winners =
+    List.fold_left
+      (fun acc item ->
+         let key = normalized_claim_key item.fact in
+         match String_map.find_opt key acc with
+         | None -> String_map.add key item acc
+         | Some existing when better_scored item existing -> String_map.add key item acc
+         | Some _ -> acc)
+      String_map.empty
+      scored
+  in
+  let winner_indexes =
+    String_map.fold (fun _ item acc -> Int_set.add item.index acc) winners Int_set.empty
+  in
+  List.filter (fun item -> Int_set.mem item.index winner_indexes) scored
+;;
+
+let run_gc ?(dry_run = false) ~keeper_id ~now () =
+  let facts = Io.read_facts_all ~keeper_id in
+  let scored =
+    facts
+    |> List.mapi (fun index fact -> { index; fact; score = Policy.score_fact ~now fact })
+  in
+  let live, expired = List.partition (fun item -> not (ttl_expired ~now item.fact)) scored in
+  let kept_by_verdict, discarded = List.partition keep_by_verdict live in
+  let deduped = dedup_by_claim kept_by_verdict in
+  let survivors = List.map (fun item -> item.fact) deduped in
+  if not dry_run then Io.rewrite_facts_atomically ~keeper_id survivors;
+  { total_input = List.length facts
+  ; ttl_expired = List.length expired
+  ; verdict_discarded = List.length discarded
+  ; dedup_removed = List.length kept_by_verdict - List.length deduped
+  ; written = List.length survivors
+  ; dry_run
+  }
+;;

--- a/lib/keeper/keeper_memory_os_gc.mli
+++ b/lib/keeper/keeper_memory_os_gc.mli
@@ -1,0 +1,21 @@
+(** Deterministic garbage collection for Memory OS facts. *)
+
+open Keeper_memory_os_types
+
+type gc_report =
+  { total_input : int
+  ; ttl_expired : int
+  ; verdict_discarded : int
+  ; dedup_removed : int
+  ; written : int
+  ; dry_run : bool
+  }
+
+val ttl_expired : now:float -> fact -> bool
+
+val run_gc
+  :  ?dry_run:bool
+  -> keeper_id:string
+  -> now:float
+  -> unit
+  -> gc_report

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -170,6 +170,17 @@ let append_episode_bundle ~keeper_id episode =
   List.iter (append_fact ~keeper_id) episode.claims
 ;;
 
+let rewrite_facts_atomically ~keeper_id facts =
+  let path = facts_path ~keeper_id in
+  let content =
+    facts
+    |> List.map (fun fact -> fact_to_json fact |> Yojson.Safe.to_string)
+    |> String.concat "\n"
+  in
+  let content = if String.equal content "" then "" else content ^ "\n" in
+  write_file_atomically path content
+;;
+
 let save_tool_result ~keeper_id ~tool_call_id json =
   let path = tool_result_path ~keeper_id ~tool_call_id in
   write_file_atomically path (Yojson.Safe.pretty_to_string json)
@@ -245,6 +256,18 @@ let read_lines_tail path ~n =
          loop len [] 0 |> String.concat "" |> split_lines))
 ;;
 
+let read_lines_all path =
+  if not (Sys.file_exists path)
+  then []
+  else (
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let len = in_channel_length ic in
+         really_input_string ic len |> split_lines))
+;;
+
 let take_last n xs =
   let rec drop k = function
     | xs when k <= 0 -> xs
@@ -258,6 +281,11 @@ let take_last n xs =
 let parse_json_line parse line =
   try parse (Yojson.Safe.from_string line) with
   | Yojson.Json_error _ -> None
+;;
+
+let read_facts_all ~keeper_id =
+  read_lines_all (facts_path ~keeper_id)
+  |> List.filter_map (parse_json_line fact_of_json)
 ;;
 
 let read_facts_tail ~keeper_id ~n =

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -20,11 +20,13 @@ val append_fact : keeper_id:string -> fact -> unit
 val append_event : keeper_id:string -> episode -> unit
 val append_episode : keeper_id:string -> episode -> unit
 val append_episode_bundle : keeper_id:string -> episode -> unit
+val rewrite_facts_atomically : keeper_id:string -> fact list -> unit
 val save_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t -> unit
 val load_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t option
 
 (** {1 Bounded tail reads} *)
 
+val read_facts_all : keeper_id:string -> fact list
 val read_facts_tail : keeper_id:string -> n:int -> fact list
 val read_events_tail : keeper_id:string -> n:int -> episode list
 val read_episodes_tail : keeper_id:string -> n:int -> episode list

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -9,6 +9,14 @@ open Keeper_memory_os_types
 
 let default_lambda = 1.0 /. (86400.0 *. 7.0) (* half-life ~7 days *)
 let default_alpha = 0.5
+let default_truth_lambda = 1.0 /. (86400.0 *. 30.0)
+let default_cycle_seconds = 3600.0
+let default_max_access_factor = 4.0
+let default_discard_score_threshold = 0.02
+
+type retention_verdict =
+  | KeepVerbatim
+  | Discard
 
 (** Forgetting curve: recency decays exponentially with a half-life
     controlled by [lambda]. *)
@@ -20,11 +28,45 @@ let recency_factor ~lambda ~now last_accessed =
 (** Access boost: each recall incrementally increases the weight of a
     fact, governed by [alpha] (sub-linear by default). *)
 let access_factor ~alpha access_count =
-  (1.0 +. float access_count) ** alpha
+  Float.min default_max_access_factor ((1.0 +. float access_count) ** alpha)
+;;
+
+let clamp01 value =
+  Float.max 0.0 (Float.min 1.0 value)
+;;
+
+let stale_penalty fact =
+  1.0 -. clamp01 fact.stale_factor
+;;
+
+let truth_anchor fact =
+  match fact.last_verified_at with
+  | Some ts -> ts
+  | None -> fact.first_seen
+;;
+
+let truth_lambda_for_fact ~lambda fact =
+  match fact.expected_lifetime_cycles with
+  | Some cycles when cycles > 0 ->
+    1.0 /. (default_cycle_seconds *. float cycles)
+  | Some _ | None -> lambda
+;;
+
+let truth_recency_factor ?(lambda = default_truth_lambda) ~now fact =
+  let lambda = truth_lambda_for_fact ~lambda fact in
+  recency_factor ~lambda ~now (truth_anchor fact)
 ;;
 
 let score_fact ?(lambda = default_lambda) ?(alpha = default_alpha) ~now fact =
-  fact.confidence *. recency_factor ~lambda ~now fact.last_accessed *. access_factor ~alpha fact.access_count
+  fact.confidence
+  *. recency_factor ~lambda ~now fact.last_accessed
+  *. truth_recency_factor ~now fact
+  *. stale_penalty fact
+  *. access_factor ~alpha fact.access_count
+;;
+
+let decide_retention ?(discard_threshold = default_discard_score_threshold) score =
+  if score <= discard_threshold then Discard else KeepVerbatim
 ;;
 
 let score_tool_result

--- a/lib/keeper/keeper_memory_os_policy.mli
+++ b/lib/keeper/keeper_memory_os_policy.mli
@@ -5,13 +5,25 @@ open Keeper_memory_os_types
 
 val default_lambda : float
 val default_alpha : float
+val default_truth_lambda : float
+val default_max_access_factor : float
+val default_discard_score_threshold : float
+
+type retention_verdict =
+  | KeepVerbatim
+  | Discard
 
 (** Composite importance score for a fact.
 
-    Score = confidence × recency × access_boost
-    where recency follows an exponential forgetting curve and
-    access_boost is [(1 + access_count) ** alpha]. *)
+    Score = confidence × access_recency × truth_recency ×
+    stale_penalty × access_boost.  [access_recency] uses
+    [last_accessed], while [truth_recency] uses [last_verified_at] or
+    [first_seen] so recall cannot make an unverified claim fresh again. *)
 val score_fact : ?lambda:float -> ?alpha:float -> now:float -> fact -> float
+
+val truth_recency_factor : ?lambda:float -> now:float -> fact -> float
+val stale_penalty : fact -> float
+val decide_retention : ?discard_threshold:float -> float -> retention_verdict
 
 (** Score an archived tool result. *)
 val score_tool_result

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -93,9 +93,10 @@ let render_fact ~now fact =
   let score = Keeper_memory_os_policy.score_fact ~now fact in
   let source = fact.source in
   Printf.sprintf
-    "- [category=%s confidence=%.2f score=%.3f turn=%d] %s"
+    "- [category=%s confidence=%.2f stale=%.2f score=%.3f turn=%d] %s"
     (sanitize_atom fact.category)
     fact.confidence
+    fact.stale_factor
     score
     source.turn
     (sanitize_text ~max_len:max_fact_text_len fact.claim)

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -4,7 +4,7 @@
     Episodes group related facts with a short summary and metadata for
     downstream retention scoring. *)
 
-let schema_version = "rfc0231-v1"
+let schema_version = "rfc0231-v2"
 
 type provenance_event =
   { trace_id : string
@@ -21,6 +21,9 @@ type fact =
   ; first_seen : float
   ; last_accessed : float
   ; valid_until : float option
+  ; stale_factor : float
+  ; last_verified_at : float option
+  ; expected_lifetime_cycles : int option
   ; schema_version : string
   }
 
@@ -107,21 +110,37 @@ let provenance_event_of_json (json : Yojson.Safe.t) =
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
 ;;
 
+let clamp01 value =
+  Float.max 0.0 (Float.min 1.0 value)
+;;
+
+let optional_float_field key = function
+  | Some value -> [ key, `Float value ]
+  | None -> []
+;;
+
+let optional_int_field key = function
+  | Some value -> [ key, `Int value ]
+  | None -> []
+;;
+
 let fact_to_json f =
-  `Assoc
-    ([ "claim", `String f.claim
-     ; "confidence", `Float f.confidence
-     ; "category", `String f.category
-     ; "source", provenance_event_to_json f.source
-     ; "access_count", `Int f.access_count
-     ; "first_seen", `Float f.first_seen
-     ; "last_accessed", `Float f.last_accessed
-     ; "schema_version", `String f.schema_version
-     ]
-     @
-     match f.valid_until with
-     | Some ts -> [ "valid_until", `Float ts ]
-     | None -> [])
+  let fields =
+    [ "claim", `String f.claim
+    ; "confidence", `Float f.confidence
+    ; "category", `String f.category
+    ; "source", provenance_event_to_json f.source
+    ; "access_count", `Int f.access_count
+    ; "first_seen", `Float f.first_seen
+    ; "last_accessed", `Float f.last_accessed
+    ; "stale_factor", `Float f.stale_factor
+    ; "schema_version", `String f.schema_version
+    ]
+    @ optional_float_field "valid_until" f.valid_until
+    @ optional_float_field "last_verified_at" f.last_verified_at
+    @ optional_int_field "expected_lifetime_cycles" f.expected_lifetime_cycles
+  in
+  `Assoc fields
 ;;
 
 let fact_of_json (json : Yojson.Safe.t) =
@@ -143,15 +162,32 @@ let fact_of_json (json : Yojson.Safe.t) =
           (* DET-OK: absent last_accessed inherits first_seen. *)
           let last_accessed = Option.value (json_float_field "last_accessed" fields) ~default:first_seen in
           let valid_until = json_float_field "valid_until" fields in
+          let stale_factor =
+            match json_float_field "stale_factor" fields with
+            | Some value -> clamp01 value
+            | None ->
+              (* DET-OK: legacy v1 facts had no stale marker, so they start
+                 as not-explicitly-stale and are still truth-aged by policy. *)
+              0.0
+          in
+          let last_verified_at = json_float_field "last_verified_at" fields in
+          let expected_lifetime_cycles =
+            match json_int_field "expected_lifetime_cycles" fields with
+            | Some cycles when cycles > 0 -> Some cycles
+            | Some _ | None -> None
+          in
           Some
             { claim
-            ; confidence = Float.max 0.0 (Float.min 1.0 confidence)
+            ; confidence = clamp01 confidence
             ; category
             ; source
             ; access_count
             ; first_seen
             ; last_accessed
             ; valid_until
+            ; stale_factor
+            ; last_verified_at
+            ; expected_lifetime_cycles
             ; schema_version =
                 (* DET-OK: default to current schema for forward compatibility. *)
                 Option.value (json_string_field "schema_version" fields) ~default:schema_version

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -24,6 +24,9 @@ type fact =
   ; first_seen : float
   ; last_accessed : float
   ; valid_until : float option
+  ; stale_factor : float
+  ; last_verified_at : float option
+  ; expected_lifetime_cycles : int option
   ; schema_version : string
   }
 

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3,6 +3,7 @@
 module Types = Masc.Keeper_memory_os_types
 module Policy = Masc.Keeper_memory_os_policy
 module Memory_io = Masc.Keeper_memory_os_io
+module GC = Masc.Keeper_memory_os_gc
 module Librarian = Masc.Keeper_librarian
 module Librarian_runtime = Masc.Keeper_librarian_runtime
 module Prompt_names = Keeper_prompt_names
@@ -43,8 +44,15 @@ let fact_fixture ~now () =
   ; Types.first_seen = now -. 86400.0
   ; Types.last_accessed = now -. 3600.0
   ; Types.valid_until = None
+  ; Types.stale_factor = 0.0
+  ; Types.last_verified_at = Some (now -. 3600.0)
+  ; Types.expected_lifetime_cycles = None
   ; Types.schema_version = Types.schema_version
   }
+;;
+
+let days n =
+  float n *. 86400.0
 ;;
 
 let with_temp_keepers_dir f =
@@ -174,6 +182,11 @@ let test_json_roundtrip () =
   Alcotest.(check (float 0.001)) "confidence round-trip" f.confidence f2.Types.confidence;
   Alcotest.(check int) "access_count round-trip" f.access_count f2.Types.access_count;
   Alcotest.(check (float 0.001)) "first_seen round-trip" f.first_seen f2.Types.first_seen;
+  Alcotest.(check (float 0.001)) "stale_factor round-trip" f.stale_factor f2.Types.stale_factor;
+  Alcotest.(check (option (float 0.001)))
+    "last_verified_at round-trip"
+    f.last_verified_at
+    f2.Types.last_verified_at;
   let e =
     { Types.trace_id = "trace-123"
     ; Types.generation = 1
@@ -194,6 +207,27 @@ let test_json_roundtrip () =
     e2.Types.episode_summary;
   Alcotest.(check int) "claims length" 1 (List.length e2.Types.claims);
   Alcotest.(check int) "open_items length" 1 (List.length e2.Types.open_items)
+;;
+
+let test_fact_v1_json_defaults_to_safe_staleness_fields () =
+  let json =
+    `Assoc
+      [ "claim", `String "legacy fact"
+      ; "confidence", `Float 0.9
+      ; "category", `String "legacy"
+      ; "source", `Assoc [ "trace_id", `String "trace-v1"; "turn", `Int 1 ]
+      ; "access_count", `Int 0
+      ; "first_seen", `Float 10.0
+      ; "last_accessed", `Float 20.0
+      ; "schema_version", `String "rfc0231-v1"
+      ]
+  in
+  match Types.fact_of_json json with
+  | None -> Alcotest.fail "expected legacy fact to parse"
+  | Some fact ->
+    Alcotest.(check (float 0.001)) "default stale factor" 0.0 fact.Types.stale_factor;
+    Alcotest.(check (option (float 0.001))) "missing last_verified_at" None fact.last_verified_at;
+    Alcotest.(check (option int)) "missing lifetime cycles" None fact.expected_lifetime_cycles
 ;;
 
 let test_librarian_prompt_renders () =
@@ -657,6 +691,39 @@ let test_policy_score () =
     (Policy.score_fact ~now low < score)
 ;;
 
+let test_policy_truth_age_not_reset_by_access () =
+  let now = 1_000_000.0 in
+  let fresh =
+    { (fact_fixture ~now ()) with
+      Types.confidence = 0.99
+    ; Types.access_count = 0
+    ; Types.first_seen = now
+    ; Types.last_accessed = now
+    ; Types.last_verified_at = Some now
+    }
+  in
+  let stale_but_frequently_recalled =
+    { fresh with
+      Types.first_seen = now -. days 120
+    ; Types.last_verified_at = None
+    ; Types.last_accessed = now
+    ; Types.access_count = 10_000
+    }
+  in
+  Alcotest.(check bool)
+    "truth-stale fact cannot be revived by access count"
+    true
+    (Policy.score_fact ~now stale_but_frequently_recalled < Policy.score_fact ~now fresh);
+  let explicitly_stale = { fresh with Types.stale_factor = 1.0 } in
+  Alcotest.(check (float 0.001))
+    "stale_factor=1 zeroes score"
+    0.0
+    (Policy.score_fact ~now explicitly_stale);
+  match Policy.decide_retention (Policy.score_fact ~now explicitly_stale) with
+  | Policy.Discard -> ()
+  | Policy.KeepVerbatim -> Alcotest.fail "expected explicit stale fact to be discarded"
+;;
+
 let test_bump_access () =
   let now = 1_000_000.0 in
   let f = fact_fixture ~now () in
@@ -770,6 +837,71 @@ let test_jsonl_tail_reads_last_entries () =
         second.Types.episode_summary
         event.Types.episode_summary
     | events -> Alcotest.failf "expected one event, got %d" (List.length events))
+;;
+
+let test_gc_dry_run_and_rewrite () =
+  with_temp_keepers_dir (fun _keepers_dir ->
+    let keeper_id = "gc-keeper" in
+    let now = 1_000_000.0 in
+    let base = fact_fixture ~now () in
+    let keep =
+      { base with
+        Types.claim = "keep this fact"
+      ; Types.confidence = 0.95
+      ; Types.first_seen = now
+      ; Types.last_verified_at = Some now
+      ; Types.last_accessed = now
+      }
+    in
+    let expired =
+      { keep with
+        Types.claim = "expired fact"
+      ; Types.valid_until = Some (now -. 1.0)
+      }
+    in
+    let explicit_stale =
+      { keep with
+        Types.claim = "explicitly stale fact"
+      ; Types.stale_factor = 1.0
+      }
+    in
+    let duplicate_low =
+      { keep with
+        Types.claim = "Duplicate Claim"
+      ; Types.confidence = 0.80
+      ; Types.source = { keep.source with turn = 10 }
+      }
+    in
+    let duplicate_high =
+      { keep with
+        Types.claim = "duplicate claim"
+      ; Types.confidence = 0.90
+      ; Types.source = { keep.source with turn = 11 }
+      }
+    in
+    List.iter
+      (Memory_io.append_fact ~keeper_id)
+      [ keep; expired; explicit_stale; duplicate_low; duplicate_high ];
+    let dry = GC.run_gc ~dry_run:true ~keeper_id ~now () in
+    Alcotest.(check bool) "dry-run flag" true dry.GC.dry_run;
+    Alcotest.(check int) "dry-run leaves file untouched" 5
+      (List.length (Memory_io.read_facts_all ~keeper_id));
+    let report = GC.run_gc ~keeper_id ~now () in
+    Alcotest.(check int) "total input" 5 report.GC.total_input;
+    Alcotest.(check int) "ttl expired" 1 report.ttl_expired;
+    Alcotest.(check int) "verdict discarded" 1 report.verdict_discarded;
+    Alcotest.(check int) "dedup removed" 1 report.dedup_removed;
+    Alcotest.(check int) "written" 2 report.written;
+    let survivors = Memory_io.read_facts_all ~keeper_id in
+    Alcotest.(check int) "survivor count" 2 (List.length survivors);
+    Alcotest.(check bool)
+      "keeps high duplicate"
+      true
+      (List.exists (fun f -> String.equal f.Types.claim "duplicate claim") survivors);
+    Alcotest.(check bool)
+      "drops expired"
+      false
+      (List.exists (fun f -> String.equal f.Types.claim "expired fact") survivors))
 ;;
 
 let test_recall_context_empty_without_memory () =
@@ -993,6 +1125,10 @@ let () =
     "keeper_memory_os"
     [ ( "json"
       , [ Alcotest.test_case "fact and episode round-trip" `Quick test_json_roundtrip
+        ; Alcotest.test_case
+            "v1 fact json defaults staleness fields"
+            `Quick
+            test_fact_v1_json_defaults_to_safe_staleness_fields
         ; Alcotest.test_case "librarian prompt renders" `Quick test_librarian_prompt_renders
         ; Alcotest.test_case
             "librarian prompt omits private blocks"
@@ -1021,6 +1157,10 @@ let () =
         ] )
     ; ( "policy"
       , [ Alcotest.test_case "score ordering" `Quick test_policy_score
+        ; Alcotest.test_case
+            "truth age is not reset by access"
+            `Quick
+            test_policy_truth_age_not_reset_by_access
         ; Alcotest.test_case "bump access" `Quick test_bump_access
         ] )
     ; ( "io"
@@ -1036,6 +1176,10 @@ let () =
             "jsonl tail reads last entries"
             `Quick
             test_jsonl_tail_reads_last_entries
+        ; Alcotest.test_case
+            "gc dry-run and rewrite"
+            `Quick
+            test_gc_dry_run_and_rewrite
         ] )
     ; ( "recall"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary

Supersedes the current Memory OS stale-lifecycle PR stack (#21175, #21176, #21177, #21179, #21183) with a single main-based patch that compiles and keeps the behavioral surface focused.

Changes:
- upgrades Memory OS facts to schema `rfc0231-v2` with `stale_factor`, `last_verified_at`, and `expected_lifetime_cycles`
- separates recall freshness from truth freshness in `score_fact`
- caps access boost so repeated recall cannot revive an old unverified claim indefinitely
- adds deterministic retention verdicts and explicit stale penalties
- adds a deterministic GC module with TTL filtering, score-based discard, exact normalized-claim dedup, dry-run support, and atomic fact rewrite
- exposes stale metadata in recall rendering for operator/debug visibility
- keeps legacy v1 fact JSON readable with deterministic defaults

## Why

The previous scoring path let `last_accessed` and `access_count` dominate the score. A stale fact could stay highly ranked simply because it kept being recalled. The fix keeps access recency useful, but makes truth age (`last_verified_at` or `first_seen`) an independent factor that access bumps cannot reset.

This PR intentionally does not wire GC into an automatic runtime loop yet. The first safe step is a deterministic API plus focused tests. Runtime scheduling can follow once the thresholds and operational cadence are reviewed.

## Validation

- `scripts/dune-local.sh exec test/test_keeper_memory_os.exe`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`
- `git diff --check`

Focused test result: 23 `keeper_memory_os` tests passing, including new v1 migration defaults, truth-age scoring, and GC dry-run/rewrite coverage.
