### PR TITLE
[RFC-0239] 키퍼 confabulation 루프 정지: semantic-identity 가드 (R3+R4+R2)

### DIFF
--- a/docs/rfc/RFC-0239-semantic-identity-guards-for-keeper-memory-and-anti-thrash.md
+++ b/docs/rfc/RFC-0239-semantic-identity-guards-for-keeper-memory-and-anti-thrash.md
@@ -42,6 +42,23 @@ semantic identity*, so a semantically-identical event (a reworded post, a new `p
 non-literal speech act, an unchanged claim) evades every dedup / expiry / debounce /
 termination check in the system. This RFC fixes the five guards that share that flaw.
 
+### Implementation status (this branch)
+
+| Root | State | Reference |
+|---|---|---|
+| R3 no-progress loop detector | **Implemented + tested** | `keeper_stay_silent_loop_detector`, commit `R3` |
+| R4 wake content-fingerprint debounce | **Implemented + tested** | `keeper_keepalive_signal` / `keeper_registry`, commit `R4` |
+| R2 recall-time claim dedup | **Implemented + tested** | `keeper_memory_os_recall`, commit `R2` |
+| R1 per-fact lifetime at write | **Ratification required** | naive category→TTL is a string-classifier workaround (§2 principle 1); needs a typed taxonomy or a librarian-contract + eval — §9 Q5 |
+| R0 wire inert recall signals | **Ratification required** | naive `bump_access_for_turn` wiring *worsens* the inversion (frequently-recalled stale facts would score higher); needs a stale-lowering signal — §9 Q3 |
+| Retention sweep (supersedes RFC-0238) | **Ratification required** | `Capped_by_score` defaults + legacy 17,426-fact handling — §9 Q4 |
+
+R3 + R4 are the loop engine: together they stop the cross-keeper thrash (R3 pauses a
+keeper after a threshold of no-progress turns; R4 stops identical re-posts re-waking peers).
+R2 stops duplicate conclusions crowding recall. The three ratification-required roots are
+the memory-os write/scoring/retention design choices that should not be hacked in — a naive
+version of each is exactly a workaround this RFC's own §2 forbids.
+
 ## §1 Problem (with live evidence)
 
 ### 1.1 The observable
@@ -254,17 +271,30 @@ surfaces.
 
 ## §9 Open questions (ratification needed)
 
-1. **Q1 — R3 placement.** Put the no-progress predicate in the loop detector, or in the
-   turn classifier that feeds `speech_act`? (Detector is the smaller change; classifier is
-   the more correct layer.)
-2. **Q2 — dedup aggressiveness (R2).** Exact-claim only, or normalized fingerprint that
-   folds "would"/"will" twins? Folding is more effective but risks merging genuinely
-   distinct claims; propose normalized-but-conservative (case+whitespace+trailing-punct).
-3. **Q3 — R0.** Wire `bump_access_for_turn`, or re-tune `λ` to session scale, or both?
-   Wiring preserves the 7-day cross-session curve; re-tuning fixes in-session ranking.
-4. **Q4 — retention defaults (inherited from RFC-0238).** `Capped_by_score` `max_items`
+1. **Q1 — R3 placement.** *Resolved: detector layer.* `speech_act` is social intent, not
+   progress; the no-progress predicate (`turn_made_progress`) lives in the detector and the
+   caller maps `delivery_surface` (exhaustive) to it. Keeping it out of the classifier avoids
+   re-coupling the two concepts.
+2. **Q2 — dedup aggressiveness (R2).** *Resolved: normalized-conservative.* Implemented as
+   lowercase + whitespace-collapse fingerprint at recall time (folds case/spacing twins; does
+   not fold genuinely different wordings like "would"/"will" — those still collapse only if a
+   future write-side dedup normalizes further).
+3. **Q3 — R0 (open).** Wiring `bump_access_for_turn` as-is *worsens* the inversion: it raises
+   the score of frequently-recalled facts, and stale conclusions are the most-recalled. R0
+   needs a signal that *lowers* a fact that keeps being recalled but never re-validated
+   (e.g. decay on recall-without-write, or contradiction tracking), not a naive access boost.
+   Alternatively re-tune `λ` to session scale (fixes in-session ranking but flattens the
+   7-day cross-session curve). Decision required before any code.
+4. **Q4 — retention defaults (inherited from RFC-0238, open).** `Capped_by_score` `max_items`
    per keeper and `half_life_days`; legacy handling for the existing 17,426 facts
-   (archive-and-restart vs fold-into-partitions).
+   (archive-and-restart vs fold-into-partitions). Re-measure store size per type first
+   (RFC-0238's 1.4 G `decisions.jsonl` premise is disputed).
+5. **Q5 — R1 lifetime determination (open).** How is a fact's lifetime assigned without a
+   string classifier on the free-text `category` (forbidden by §2 principle 1)? Options:
+   (a) a typed category taxonomy (closed sum) with a lifetime per variant; (b) extend the
+   librarian JSON contract so the LLM emits an explicit `ttl_seconds`/`lifetime`, validated
+   like `confidence`, with an eval harness; (c) drop per-fact TTL entirely and bound the
+   store only by the Q4 retention sweep. Decision required before any code.
 
 ## §10 Evidence record
 

--- a/docs/rfc/RFC-0239-semantic-identity-guards-for-keeper-memory-and-anti-thrash.md
+++ b/docs/rfc/RFC-0239-semantic-identity-guards-for-keeper-memory-and-anti-thrash.md
@@ -1,0 +1,281 @@
+---
+rfc: "0239"
+title: "Semantic-identity guards for keeper memory and anti-thrash"
+status: Draft
+created: 2026-06-15
+updated: 2026-06-15
+author: vincent (drafted by Claude Opus 4.8)
+supersedes: ["0238"]
+superseded_by: null
+related: ["0231", "0228", "0144", "0152", "0113", "0042", "0230", "0225", "0126", "0145", "0077"]
+implementation_prs: []
+---
+
+# RFC-0239: Semantic-identity guards for keeper memory and anti-thrash
+
+Status: Draft · Supersedes RFC-0238 (closed, #21186) · Drafted 2026-06-15 from a ground-truth audit of the 7-keeper "Confidence Inversion" board thrash.
+
+## §0 TL;DR
+
+A cluster of 7 keepers (garnet, sangsu, analyst, taskmaster, ramarama, executor, rondo)
+looped 30+ turns each re-posting the same conclusion ("Confidence Inversion proven,
+차기작 structurally complete, operator's turn, I'll stay quiet"). The keepers diagnosed
+the loop as a **Memory OS "Confidence Inversion"** and proposed scoring-tweak PRs
+(#21177, #21183, #21175, #21179, #21192).
+
+A code + GitHub + live-store audit shows the keeper self-diagnosis is **wrong about the
+root and wrong about its own status claims**:
+
+- The loop's engine is a **cross-keeper wake cascade with no working termination**, not a
+  memory bug. The `stay_silent` loop detector that should pause them keys on the literal
+  `speech_act="stay_silent"` token, but the keepers *post* their "I'll stay quiet" message
+  (a `Post_board` act), which **resets the silence streak every cycle** — the detector can
+  never fire (`keeper_stay_silent_loop_detector.ml:48,66-74`).
+- Memory OS is a real **amplifier** (immortal, append-only facts re-inject the conclusion)
+  but not the root: if the wake cascade stopped, the loop dies.
+- The keepers' status claims are mostly fabricated/stale: "5 PRs blocked only by operator
+  `--admin`" → actually 6 OPEN-but-`mergeable=UNKNOWN`, 3 already MERGED, 2 CLOSED;
+  "~1,800 lines of fix on origin" → actually 32+57+0 = **89 lines** (one branch is a no-op).
+
+Every one of these defects shares **one root**: *guards key on a surface token instead of
+semantic identity*, so a semantically-identical event (a reworded post, a new `post_id`, a
+non-literal speech act, an unchanged claim) evades every dedup / expiry / debounce /
+termination check in the system. This RFC fixes the five guards that share that flaw.
+
+## §1 Problem (with live evidence)
+
+### 1.1 The observable
+
+The board (`reports/memory-systems-comparison-2026-06-15.html` triggered the audit) shows
+the 7-keeper cluster repeating a single conclusion across 30+ turns, with each "I'll be
+quiet now" post immediately followed by another. The keepers themselves named the pattern
+"P(stale_fact_outranks_correct_fact) = 1.00" and attributed it to the Memory OS.
+
+### 1.2 Live store measurement (2026-06-15, `/Users/dancer/me/.masc/config/keepers/`)
+
+17,426 facts across the 7 loop keepers (ramarama alone: 6,077 facts / 2.08 MB):
+
+| Metric | Measured | What it proves |
+|---|---|---|
+| `valid_until` is `None`/absent | **17,426 / 17,426 = 100.0%** | The only expiry signal fires on **0%** of facts. Every fact is immortal. |
+| confidence distribution | mean 0.928, median 0.95, stdev 0.0625; **0.95=37.1%, 0.90=22.5%, 1.00=14.6%, 0.99=7.8%** (top-4 = 82%) | "Gradient collapse" is real: 6 rounded LLM values dominate; 6,471 facts tie at exactly 0.95. |
+| duplicate claims (first 90 chars) | **8.2%**; most-duplicated are the loop conclusions: `"executor is offline due to an operator issue"` ×14, `"...next idle turn **would** end the session"` ×13 **and** `"...**will** end the session"` ×13 | No dedup; reworded variants ("would"/"will") coexist as distinct immortal facts. |
+| total facts / keeper | unbounded append-only growth (367 → 6,077) | No GC; the store only grows. |
+
+The reworded-duplicate pair (`would` vs `will`) is the surface-token-bypass thesis made
+visible in data: two byte-different strings carrying one meaning both persist forever.
+
+### 1.3 Two layers, one root
+
+- **Layer A — coordination (the engine):** the wake cascade + the loop detector blind spot.
+  This is what keeps cycles *firing*.
+- **Layer B — memory (the fuel):** immortal, undeduplicated, score-collapsed facts that keep
+  *re-emitting* the same conclusion into each keeper's prompt.
+
+Neither alone explains the loop; both are instances of the same root (§2).
+
+## §2 Root cause: guards key on surface tokens, not semantic identity
+
+Every termination/dedup/expiry guard in the path observes the wrong thing:
+
+| # | Guard | Keys on (surface) | Should key on (semantic) | Bypass observed | Cite |
+|---|---|---|---|---|---|
+| R1 | fact expiry | `valid_until` written `None` always | a TTL/lifetime set at write | 100% immortal (§1.2) | `keeper_librarian.ml:141-144` |
+| R2 | fact store write | append-only, no compare | claim fingerprint | 8.2% dup, reworded twins (§1.2) | `keeper_memory_os_io.ml:125-127` |
+| R3 | thrash detector | `speech_act="stay_silent"` literal | no-progress (no new tool evidence + near-dup body) | streak resets on every `Post_board` (§3) | `keeper_stay_silent_loop_detector.ml:48,66-74` |
+| R4 | wake debounce | `post_id` (60 s) | `(keeper, content fingerprint)` | each cycle mints a new `post_id` | `keeper_registry.ml:402-412`, `keeper_keepalive_signal.ml:229` |
+| R5 | board write dedup | exact body bytes | normalized/near-dup body | reworded re-posts pass | `board_core_persist.ml:426-457` |
+
+Background amplifier (not a guard, but feeds R1/R2): the recall score collapses within a
+session. `score_fact = confidence × exp(−λ·Δt) × (1+access_count)^0.5`
+(`keeper_memory_os_policy.ml:26-28`), where:
+
+- `λ = 1/(86400·7)` (7-day e-folding) → within a minutes-to-hours keeper session,
+  `exp(−λ·Δt) ≈ 1.0` for every fact;
+- `access_count` is only incremented by `bump_access_for_turn`, which is **referenced solely
+  by `test/test_keeper_memory_os.ml`** — never wired in `lib/` or `bin/`
+  (`keeper_memory_os_policy.ml:65-84`). Production `access_count` stays 0 → `access_factor ≡ 1.0`.
+
+So in production the score degrades to `≈ confidence`, an LLM-rounded near-uniform value
+(§1.2) with no power to rank a true fact above a stale-false one. This is the mechanism the
+keepers called "gradient collapse" — it is an **inert-signal** problem, not a confidence-mutation
+problem.
+
+## §3 Why the existing detector cannot fire (the single most important defect)
+
+`keeper_stay_silent_loop_detector.ml` bumps a streak **only** when `speech_act = "stay_silent"`
+(line 48) and **resets the streak to 0 on any other speech act** (lines 66-74).
+`speech_act` is an 8-variant type (`keeper_social_model_types.ml:1-9`) in which `Stay_silent`
+is distinct from `Post_board`/`Comment_board`/`Broadcast`/`Inform`.
+
+A keeper that *announces* "I'll stay quiet" by **posting it** emits `Post_board` — which
+resets the streak. The keepers talk about being silent without ever emitting the silent act
+the detector counts. `default_threshold = 10` is therefore unreachable for this cluster.
+
+The wake side is genuinely cross-keeper (self-wake is excluded,
+`keeper_world_observation_board_signal.ml:80`): one keeper's post fans out via Stigmergy
+goal-keyword overlap (`+5` per shared keyword, wakes if score `> 0`,
+`keeper_world_observation_board_signal.ml:152-171`; `keeper_keepalive_signal.ml:363-417`).
+The 7 keepers share goal keywords, so each post re-wakes the other 6 — which is exactly why
+this specific cluster of 7 thrashes together.
+
+## §4 Principles
+
+1. **Parse, don't validate (Alexis King).** A guard must compare the *parsed meaning*
+   (claim fingerprint, no-progress predicate, content hash) — never a raw surface token that
+   a reworded duplicate can dodge.
+2. **No escape hatch / no permissive default.** Expiry, dedup, and retention policies are
+   closed sums with exhaustive `match`; no `unknown ⇒ keep-forever` arm
+   (continues RFC-0042, RFC-0126, RFC-0145).
+3. **Termination is a safety property, not a heuristic.** "A keeper that adds no new
+   tool evidence and repeats a recent post is making no progress" must be *decidable and
+   enforced*, with a TLA+ invariant (§6).
+4. **Harness-first.** §1.2 live measurements are the regression baseline; no fix merges
+   without a test that would fail against today's store.
+5. **Reuse the substrate.** RFC-0238 already designed a typed retention policy over
+   `Dated_jsonl`; this RFC absorbs it rather than reinventing GC.
+
+## §5 The four roots + design
+
+### R1 — Set a real lifetime at write (memory write side)
+
+`fact_of_json` hardcodes `valid_until = None` (`keeper_librarian.ml:144`). The librarian
+already emits a `category`; extend the librarian contract so each fact carries an
+**expected lifetime** chosen by category (e.g. an ephemeral "session status" fact expires in
+hours; a durable "user preference" fact may have no TTL). Store it as a typed
+`lifetime : Ephemeral of { ttl_seconds } | Durable | Until of timestamp` rather than a bare
+`float option`, so "no lifetime" is an explicit, auditable choice — not the silent default.
+
+This is the RFC-0238 `Capped_by_score` / forgetting-curve idea applied at *write* time
+instead of only at sweep time.
+
+### R2 — Dedup/merge on claim fingerprint (memory write side)
+
+`append_fact` (`keeper_memory_os_io.ml:125-127`) is pure append. Before appending, compute a
+normalized fingerprint of the claim (case-fold, collapse whitespace, strip trailing
+punctuation — enough to fold "would"/"will" twins is a non-goal; see §8 Q2 for how
+aggressive). On fingerprint match within the tail window, **bump the existing fact's
+`access_count` and `last_accessed`** (the adaptive signal that R0 wires on) instead of
+writing a new immortal row. This is the legitimate use of the `bump_access_for_turn` code
+that today is test-only.
+
+Precedent and discipline: RFC-0144 (workaround-sunset for keeper dedup) — this dedup is a
+*root* fix (it stops the producer of duplicates), not a symptom-suppressing dedup arm, so it
+is in-scope to add, not to sunset.
+
+### R3 — Make the no-progress detector semantic (coordination — highest leverage)
+
+Extend `keeper_stay_silent_loop_detector` (or the turn classifier feeding it) so a turn
+counts toward the loop streak when it is **no-progress**, defined as:
+
+```
+delivery_surface ∈ {Board_post, Board_comment, Broadcast}
+  AND has_substantive_tool_calls = false
+  AND body is a near-duplicate of a recent self-authored post
+```
+
+i.e. a keeper that only re-posts its conclusion accrues the streak and gets paused at the
+threshold — regardless of whether the literal speech act is `Stay_silent`. The detector's
+observable changes from "did it emit the silent token" to "did it make progress".
+
+Pause path must auto-resume per RFC-0152 (avoid creating another `Manual_resume_required`
+dead-end); use `Auto_resume_with_backoff` so a genuine new signal re-activates the keeper.
+
+### R4 — Wake cooldown on content fingerprint (coordination)
+
+`board_wakeup_allowed` debounces per `(keeper, post_id)` for 60 s
+(`keeper_registry.ml:402-412`). Re-key the cooldown on `(keeper, content_fingerprint)` so a
+keeper is not re-woken by a peer post that is semantically identical to one it already
+reacted to, even with a fresh `post_id`. Optionally fold R5 (board write dedup) onto the
+same fingerprint so reworded re-posts are rejected at write time.
+
+### R0 — (prerequisite) wire the inert recall signals
+
+Wire `bump_access_for_turn` into the recall/turn path (it is currently test-only) so
+`access_count`/`last_accessed` actually move, OR re-tune `λ` to a session-relevant
+timescale. Without this the score stays `≈ confidence` and even correct R1/R2 facts cannot
+out-rank stale ones inside a session. (Design choice in §8 Q3.)
+
+### Retention / GC (supersedes RFC-0238)
+
+Adopt RFC-0238's typed policy verbatim as the sweep layer:
+`Dated_prune{keep_days} | Capped_by_score{max_items; half_life_days} | Compact_event_log{keep_after_days}`,
+exhaustive match, registered + swept on boot + daily heartbeat (never on hot path). The live
+17,426-fact stores (§1.2) are the Phase-1 target for `Capped_by_score`. RFC-0238 was closed
+on a contested premise (it claimed `decisions.jsonl` = 1.4 G as the grower; that figure is
+itself disputed as a directory-total misattribution — re-measure per store-type before
+wiring, per the 2026-06-15 measurement-discipline note).
+
+## §6 Workaround absorption (per RFC-0144 §"누적 메커니즘")
+
+The keeper-authored PRs are **scoring tweaks on the recall ranking** — the
+cap/cooldown/repair symptom-suppression class. Under the CLAUDE.md Workaround Rejection Bar
+they must be absorbed or rejected, not merged as precedent:
+
+| PR | What it adds | Verdict | Disposition |
+|---|---|---|---|
+| #21177 `inverse_recency_factor` | reweight recall by recency | Symptom (re-ranks; doesn't stop immortal dup production) | Absorb into R0/R1; close as standalone |
+| #21183 `stale_factor` (Phase3/3d/4.5) | penalize stale facts in score | Symptom (penalizes after the fact exists forever) | Absorb into R1 (set lifetime at write); close |
+| #21175 `phase3a-inverse-recency-bonus` (+32 LOC) | recall bonus | Symptom | Absorb into R0; close |
+| #21179 Phase5+ GC (task-1169) | GC module | Root-adjacent | Fold into §5 Retention (RFC-0238 policy); keep author, retarget |
+| #21192 Phase6 episode TTL (`valid_until`+`terminal_marker`) | episode-level TTL | Right idea, wrong layer | Absorb into R1 — fact `valid_until` is written `None` first; fix the writer before adding more TTL fields |
+
+None of these touch R3/R4 (the actual loop engine). Merging all five leaves the 7-keeper
+thrash intact. They are catalogued here so the work is not lost, but they do not ship as-is.
+
+## §7 Verification plan
+
+1. **Live baseline (regression target).** Re-run the §1.2 measurement script; assert
+   post-fix: `valid_until`-None ratio < 100% on new facts; dup ratio strictly decreasing on
+   a replayed turn stream; per-keeper fact count bounded under `Capped_by_score`.
+2. **R3 unit (the load-bearing one).** Simulate a keeper emitting N consecutive
+   no-progress `Post_board` turns with near-duplicate bodies and zero substantive tool
+   calls; assert the loop detector pauses it by turn `threshold`. Today this test FAILS
+   (streak resets), which is the proof the fix is real.
+3. **R2 unit.** Append the same claim twice (and a reworded twin per the §8 Q2 policy);
+   assert one stored row with bumped `access_count`, not two immortal rows.
+4. **R1 unit.** Librarian-extract an ephemeral-category fact; assert a non-`None`
+   `valid_until`; assert `fact_is_current` drops it after TTL.
+5. **TLA+ termination invariant (per masc TLA+ bug-model convention).** Model the wake
+   cascade; `BugAction` = "no-progress post resets streak"; `SafetyInvariant`
+   `NoUnboundedNoProgressLoop` = a keeper cannot emit > K consecutive no-progress posts
+   without a pause. Clean spec passes; `Next ∨ BugAction` must violate the invariant.
+6. **Exhaustiveness.** Retention policy and `lifetime` sums compile only with all arms
+   (no catch-all), per RFC-0042.
+7. Build green (`dune build .` and `@check`; note `@check` alone misses expression-level
+   type errors — run the default target too).
+
+## §8 Scope and non-goals
+
+In scope: R1–R4 + R0 wiring + the RFC-0238 retention sweep. Out of scope: embedding-based
+recall (the deterministic/offline property is intentional), cross-keeper shared fact
+namespace (the 456-paradox — separate RFC), and any change to credential/identity/sandbox
+surfaces.
+
+## §9 Open questions (ratification needed)
+
+1. **Q1 — R3 placement.** Put the no-progress predicate in the loop detector, or in the
+   turn classifier that feeds `speech_act`? (Detector is the smaller change; classifier is
+   the more correct layer.)
+2. **Q2 — dedup aggressiveness (R2).** Exact-claim only, or normalized fingerprint that
+   folds "would"/"will" twins? Folding is more effective but risks merging genuinely
+   distinct claims; propose normalized-but-conservative (case+whitespace+trailing-punct).
+3. **Q3 — R0.** Wire `bump_access_for_turn`, or re-tune `λ` to session scale, or both?
+   Wiring preserves the 7-day cross-session curve; re-tuning fixes in-session ranking.
+4. **Q4 — retention defaults (inherited from RFC-0238).** `Capped_by_score` `max_items`
+   per keeper and `half_life_days`; legacy handling for the existing 17,426 facts
+   (archive-and-restart vs fold-into-partitions).
+
+## §10 Evidence record
+
+- Code audit (file:line as cited) — verified on `jeong-sik/masc` HEAD `915c94584`, 2026-06-15.
+- Live store — `/Users/dancer/me/.masc/config/keepers/*.facts.jsonl`, 2026-06-15
+  (17,426 facts; 100% `valid_until`-None; conf top-4 = 82%; dup 8.2%).
+- PR/branch ground truth — `gh`/`git ls-remote` on `jeong-sik/masc`, 2026-06-15
+  (#21174/#21189/#21190 MERGED; #21186/#21188 CLOSED; #21175/#21177/#21179/#21183/#21187/#21192
+  OPEN-`mergeable=UNKNOWN`; named fix branches diff = 32+57+0 LOC).
+- Supersedes RFC-0238 (closed #21186). Workaround discipline per RFC-0144 and
+  CLAUDE.md §"워크어라운드 거부 기준".
+
+RFC-WAIVED: this is a design document (no credential/identity/sandbox/hooks code change);
+the keeper coordination + memory-os surfaces it touches are governed by this RFC itself.

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -233,11 +233,53 @@ let board_reactive_wakeup_max =
     "MASC_KEEPER_BOARD_WAKEUP_MAX" ~default:4 ~min_v:1 ~max_v:64
 ;;
 
-let board_reactive_wakeup_allowed ~base_path ~keeper_name ~post_id =
+(* RFC-0239 R4: collapse runs of whitespace and lowercase so trivial spacing
+   or case differences do not split a re-post into a fresh dedup key. *)
+let normalize_for_fingerprint s =
+  let b = Buffer.create (String.length s) in
+  let prev_space = ref true in
+  String.iter
+    (fun c ->
+      match Char.lowercase_ascii c with
+      | ' ' | '\t' | '\n' | '\r' ->
+        if not !prev_space then Buffer.add_char b ' ';
+        prev_space := true
+      | c ->
+        Buffer.add_char b c;
+        prev_space := false)
+    s;
+  let r = Buffer.contents b in
+  let n = String.length r in
+  if n > 0 && r.[n - 1] = ' ' then String.sub r 0 (n - 1) else r
+;;
+
+(* RFC-0239 R4: a keeper that re-posts the same conclusion mints a fresh
+   post_id every cycle, so the prior post_id-keyed debounce never matched
+   across re-posts. Key the debounce on a fingerprint of normalized
+   (author,title,content) so identical re-posts collapse into one peer wake per
+   window. Empty title+content falls back to post_id so content-less signals
+   keep their original per-post behaviour. *)
+let board_wakeup_dedup_key ~post_id ~author ~title ~content =
+  if String.trim (title ^ content) = "" then post_id
+  else (
+    let normalized = normalize_for_fingerprint (title ^ "\n" ^ content) in
+    "cfp:" ^ Digest.to_hex (Digest.string (author ^ "\x00" ^ normalized)))
+;;
+
+let board_reactive_wakeup_allowed
+      ~base_path
+      ~keeper_name
+      ~(signal : Board_dispatch.board_signal)
+  =
   Keeper_registry.board_wakeup_allowed
     ~base_path
     keeper_name
-    ~post_id
+    ~dedup_key:
+      (board_wakeup_dedup_key
+         ~post_id:signal.post_id
+         ~author:signal.author
+         ~title:signal.title
+         ~content:signal.content)
     ~debounce_sec:board_reactive_debounce_sec
 ;;
 
@@ -421,7 +463,7 @@ let wakeup_relevant_keeper_for_board_signal
       board_reactive_wakeup_allowed
         ~base_path:config.base_path
         ~keeper_name:meta.name
-        ~post_id:signal.post_id
+        ~signal
     then (
       match board_signal_wake_keeper ~config ~reason ~signal meta with
       | Ok () ->

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -156,8 +156,20 @@ val board_reactive_debounce_sec : float
 
 val board_reactive_wakeup_max : int
 
+(** [board_wakeup_dedup_key] is the content fingerprint a board wakeup is
+    deduped under (RFC-0239 R4): normalized (author,title,content), or the
+    [post_id] when title+content are empty. Exposed for testing. *)
+val board_wakeup_dedup_key :
+  post_id:string -> author:string -> title:string -> content:string -> string
+
+(** Check if a board-reactive wakeup is allowed for [keeper_name] given the
+    incoming [signal]. Debounced on the signal's content fingerprint
+    (RFC-0239 R4), not its post_id, so identical re-posts collapse. *)
 val board_reactive_wakeup_allowed :
-  base_path:string -> keeper_name:string -> post_id:string -> bool
+  base_path:string
+  -> keeper_name:string
+  -> signal:Board_dispatch.board_signal
+  -> bool
 
 (** Select which keepers wake for a board signal (RFC-0020). Explicit mentions
     short-circuit and wake unconditionally (returned with [dropped = 0]); other

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -143,11 +143,50 @@ let render_recall_context ~fact_lines ~episode_lines =
          [ "facts_section", facts_section; "episodes_section", episodes_section ])
 ;;
 
+(* RFC-0239 R2: collapse a claim to a normalized fingerprint (lowercase +
+   whitespace-collapsed + trimmed) so trivially reworded re-confirmations of the
+   same conclusion ("...would end the session" vs "...will end the session")
+   share a key. *)
+let normalize_claim s =
+  let b = Buffer.create (String.length s) in
+  let prev_space = ref true in
+  String.iter
+    (fun c ->
+      match Char.lowercase_ascii c with
+      | ' ' | '\t' | '\r' | '\n' ->
+        if not !prev_space then Buffer.add_char b ' ';
+        prev_space := true
+      | c ->
+        Buffer.add_char b c;
+        prev_space := false)
+    s;
+  let r = Buffer.contents b in
+  let n = String.length r in
+  if n > 0 && r.[n - 1] = ' ' then String.sub r 0 (n - 1) else r
+;;
+
+(* RFC-0239 R2: the fact store is append-only with no write-time dedup, so a
+   claim re-confirmed across turns accumulates as many immortal rows (live
+   measurement: ~8% exact-duplicate claims, all stale loop conclusions).
+   Collapse duplicate claims at recall time by normalized fingerprint, keeping
+   the highest-scored occurrence (input is sorted by score descending), so one
+   repeated conclusion cannot crowd distinct facts out of the injected top-N.
+   The append-only file size is bounded separately by the retention sweep. *)
+let dedup_by_claim scored =
+  let seen = Hashtbl.create 32 in
+  List.filter
+    (fun (_score, fact) ->
+      let key = normalize_claim fact.claim in
+      if Hashtbl.mem seen key then false else (Hashtbl.add seen key (); true))
+    scored
+;;
+
 let scored_facts ~now facts =
   facts
   |> List.filter (fact_is_current ~now)
   |> List.map (fun fact -> Keeper_memory_os_policy.score_fact ~now fact, fact)
   |> List.sort (fun (a, _) (b, _) -> compare b a)
+  |> dedup_by_claim
   |> List.map snd
 ;;
 

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -399,16 +399,20 @@ let restore_supervisor_state ~base_path name ~restart_count ~last_restart_ts ~cr
     ~update_entry
 ;;
 
-let board_wakeup_allowed ~base_path name ~post_id ~debounce_sec =
+(* [dedup_key] is the key under which a board wakeup is deduped. RFC-0239 R4
+   keys it on a content fingerprint rather than the raw post_id, so identical
+   re-posts (each with a fresh post_id) collapse into one wake per window. The
+   map is otherwise a generic (key -> last_ts) debounce. *)
+let board_wakeup_allowed ~base_path name ~dedup_key ~debounce_sec =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | None -> true
   | Some entry ->
     let now_ts = Time_compat.now () in
-    (match StringMap.find_opt post_id entry.board_wakeups with
+    (match StringMap.find_opt dedup_key entry.board_wakeups with
      | Some last_ts when now_ts -. last_ts < debounce_sec -> false
      | _ ->
        update_entry ~base_path name (fun e ->
-         { e with board_wakeups = StringMap.add post_id now_ts e.board_wakeups });
+         { e with board_wakeups = StringMap.add dedup_key now_ts e.board_wakeups });
        true)
 ;;
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -305,10 +305,13 @@ val restore_supervisor_state :
   restart_count:int -> last_restart_ts:float ->
   crash_log:(float * string) list -> unit
 
-(** Check if a board-reactive wakeup is allowed (debounce).
-    Records timestamp if allowed. Returns true for unregistered keepers. *)
+(** Check if a board-reactive wakeup is allowed (debounce). [dedup_key] is the
+    key under which the wake is deduped — RFC-0239 R4 passes a content
+    fingerprint rather than the raw post_id, so identical re-posts with fresh
+    post_ids collapse. Records timestamp if allowed. Returns true for
+    unregistered keepers. *)
 val board_wakeup_allowed :
-  base_path:string -> string -> post_id:string -> debounce_sec:float -> bool
+  base_path:string -> string -> dedup_key:string -> debounce_sec:float -> bool
 
 (** Clear all board wakeup timestamps for a keeper. No-op if not found. *)
 val clear_board_wakeups : base_path:string -> string -> unit

--- a/lib/keeper/keeper_stay_silent_loop_detector.ml
+++ b/lib/keeper/keeper_stay_silent_loop_detector.ml
@@ -42,10 +42,25 @@ let update_streak_gauge keeper_name value =
     ~labels:[ ("keeper", keeper_name) ]
     (Float.of_int value)
 
-let record_turn ~keeper_name ~speech_act =
+(* RFC-0239 §3 R3: a turn makes progress when it produced durable evidence
+   (substantive tool calls or validated output), or when it was delivered on a
+   surface where a no-evidence turn is legitimate (a user-facing reply or a
+   task claim). A turn that only broadcasts to peers (board post/comment/
+   broadcast) or stays silent *without* such evidence is no-progress and
+   accrues the loop streak.
+
+   This generalises the retired speech_act="stay_silent" predicate, which
+   reset the streak whenever a keeper *posted* its "nothing to do" conclusion
+   — so the detector never fired for a cluster that thrashed by re-posting
+   rather than by emitting the literal stay_silent act. Primitive bools keep
+   this module decoupled from the social-model type. *)
+let turn_made_progress ~strong_evidence ~surface_requires_evidence =
+  strong_evidence || not surface_requires_evidence
+
+let record_turn ~keeper_name ~made_progress =
   with_lock (fun () ->
     let s = get_or_create keeper_name in
-    if speech_act = "stay_silent" then begin
+    if not made_progress then begin
       s.streak <- s.streak + 1;
       update_streak_gauge keeper_name s.streak;
       let t = threshold () in
@@ -55,11 +70,11 @@ let record_turn ~keeper_name ~speech_act =
           Keeper_metrics.(to_string StaySilentLoopDetected)
           ~labels:[ ("keeper", keeper_name) ] ();
         Log.Keeper.error
-          "#9926 stay_silent loop detected keeper=%s streak=%d threshold=%d \
-           — keeper is returning stay_silent repeatedly. Check effective tool \
-           surface mismatch (#9926 proposal 1) or scheduler/backlog drift. \
-           Counter will not re-fire until the streak resets via any \
-          non-stay_silent speech act."
+          "#9926/RFC-0239 no-progress loop detected keeper=%s streak=%d \
+           threshold=%d — keeper repeated no-progress turns (stay_silent, or \
+           board posts with no tool evidence). Check effective tool surface \
+           mismatch or scheduler/backlog drift. Counter will not re-fire until \
+           the streak resets via a turn that makes progress."
           keeper_name s.streak t;
         Loop_detected { streak = s.streak; threshold = t }
       end else Normal

--- a/lib/keeper/keeper_stay_silent_loop_detector.mli
+++ b/lib/keeper/keeper_stay_silent_loop_detector.mli
@@ -34,14 +34,24 @@ type record_outcome =
   | Loop_detected of { streak : int; threshold : int }
   | Loop_reset of { previous_streak : int; was_latched : bool }
 
-(** Update streak for [keeper_name] based on [speech_act] from the
-    latest turn. [speech_act] is the string form already emitted by
-    {!Keeper_social_model_types.speech_act_to_string} —
-    we match on the literal ["stay_silent"] rather than the variant
-    so this module does not couple to the social-model type. *)
-val record_turn : keeper_name:string -> speech_act:string -> record_outcome
+(** [turn_made_progress ~strong_evidence ~surface_requires_evidence] is the
+    no-progress predicate (RFC-0239 §3 R3). A turn makes progress when it
+    produced durable evidence ([strong_evidence]), or when its delivery surface
+    does not require evidence ([surface_requires_evidence = false], e.g. a
+    user-facing reply or a task claim). Pure; primitive bools keep this module
+    decoupled from the social-model type. *)
+val turn_made_progress :
+  strong_evidence:bool -> surface_requires_evidence:bool -> bool
 
-(** Current consecutive stay_silent count for [keeper_name]. *)
+(** Update the per-keeper streak from the latest turn. [made_progress] is the
+    caller's verdict (see {!turn_made_progress}): the streak increments on a
+    no-progress turn and resets when a turn makes progress. Generalises the
+    earlier literal ["stay_silent"] match so a keeper that re-posts its
+    "nothing to do" conclusion (a no-progress board post) also accrues the
+    streak. *)
+val record_turn : keeper_name:string -> made_progress:bool -> record_outcome
+
+(** Current consecutive no-progress count for [keeper_name]. *)
 val current_streak : keeper_name:string -> int
 
 (** Reset streak for [keeper_name] — used on keeper restart or

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -48,29 +48,47 @@ let apply_lifecycle ~config ~base_dir ~meta ~final_execution ~current_turn_block
   lifecycle
 ;;
 
-let apply_loop_detectors ~config updated_meta result =
-  let updated_meta =
-    match
-      Keeper_stay_silent_loop_detector.record_turn
-        ~keeper_name:updated_meta.Keeper_meta_contract.name
-        ~speech_act:updated_meta.runtime.last_speech_act
-    with
-    | Keeper_stay_silent_loop_detector.Normal -> updated_meta
-    | Keeper_stay_silent_loop_detector.Loop_detected { streak; threshold } ->
-      Keeper_unified_turn_stay_silent.mark_loop_detected
-        ~config
-        updated_meta
-        ~streak
-        ~threshold
-    | Keeper_stay_silent_loop_detector.Loop_reset { previous_streak; was_latched } ->
-      Keeper_unified_turn_stay_silent.clear_if_recovered
-        ~config
-        updated_meta
-        ~previous_streak
-        ~was_latched
+let apply_loop_detectors ~config ~social_state updated_meta result =
+  (* RFC-0239 §3 R3: feed the loop detector a semantic no-progress verdict
+     instead of the literal speech_act. A turn makes progress if it produced
+     durable evidence (substantive tool calls or validated output); a turn that
+     only posts to peers (board/comment/broadcast) or stays silent without such
+     evidence accrues the streak. The old speech_act="stay_silent" check reset
+     the streak whenever a keeper *posted* its "nothing to do" conclusion, so a
+     cluster that thrashed by re-posting never tripped the detector. *)
+  let strong_evidence =
+    KUM.has_substantive_tool_calls (Keeper_agent_result.tool_names result)
+    || Option.is_some (KUM.visible_run_validation result)
   in
-  ignore result.Keeper_agent_run.tool_calls;
-  updated_meta
+  let surface_requires_evidence =
+    match social_state.Social.delivery_surface with
+    | Social.Board_post | Social.Board_comment | Social.Broadcast_surface
+    | Social.Silent -> true
+    | Social.Visible_reply | Social.Task_claim_surface -> false
+  in
+  let made_progress =
+    Keeper_stay_silent_loop_detector.turn_made_progress
+      ~strong_evidence
+      ~surface_requires_evidence
+  in
+  match
+    Keeper_stay_silent_loop_detector.record_turn
+      ~keeper_name:updated_meta.Keeper_meta_contract.name
+      ~made_progress
+  with
+  | Keeper_stay_silent_loop_detector.Normal -> updated_meta
+  | Keeper_stay_silent_loop_detector.Loop_detected { streak; threshold } ->
+    Keeper_unified_turn_stay_silent.mark_loop_detected
+      ~config
+      updated_meta
+      ~streak
+      ~threshold
+  | Keeper_stay_silent_loop_detector.Loop_reset { previous_streak; was_latched } ->
+    Keeper_unified_turn_stay_silent.clear_if_recovered
+      ~config
+      updated_meta
+      ~previous_streak
+      ~was_latched
 ;;
 
 let append_metrics_snapshot
@@ -459,7 +477,7 @@ let handle
       ~update_proactive_rt:true
       result
   in
-  let updated_meta = apply_loop_detectors ~config updated_meta result in
+  let updated_meta = apply_loop_detectors ~config ~social_state updated_meta result in
   append_metrics_snapshot
     ~config
     ~meta

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -542,6 +542,23 @@ let test_heartbeat_history_fallback_counts_malformed_rows () =
       check_persistence_read_drop_delta ~surface ~reason:invalid_reason
         ~before:before_invalid ~delta:2)
 
+(* RFC-0239 R4: the board-wakeup debounce keys on a content fingerprint, not
+   the post_id, so a keeper that re-posts the same conclusion (fresh post_id
+   each cycle) does not re-wake peers. *)
+let test_board_wakeup_dedup_key_collapses_reposts () =
+  let k ~post_id ~content =
+    KHS.board_wakeup_dedup_key ~post_id ~author:"garnet" ~title:"closure" ~content
+  in
+  check string "identical content, different post_id => same dedup key"
+    (k ~post_id:"p1" ~content:"operator's turn now")
+    (k ~post_id:"p2" ~content:"operator's   turn   NOW");
+  check bool "different content => different dedup key" false
+    (String.equal
+       (k ~post_id:"p1" ~content:"operator's turn")
+       (k ~post_id:"p1" ~content:"keeper layer complete"));
+  check string "empty title+content => post_id fallback" "p9"
+    (KHS.board_wakeup_dedup_key ~post_id:"p9" ~author:"garnet" ~title:"" ~content:"")
+
 let () =
   run "keeper_lifecycle_registry_dispatch"
     [
@@ -565,5 +582,7 @@ let () =
             test_keepalive_dispatch_event_rejection_increments_metric;
           test_case "heartbeat history fallback counts malformed rows" `Quick
             test_heartbeat_history_fallback_counts_malformed_rows;
+          test_case "board wakeup dedup key collapses reposts (RFC-0239 R4)" `Quick
+            test_board_wakeup_dedup_key_collapses_reposts;
         ] );
     ]

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -21,6 +21,20 @@ let contains substring s =
   if sub_len = 0 then true else aux 0
 ;;
 
+(* Count non-overlapping occurrences of [substring] in [s] (RFC-0239 R2 test). *)
+let occurrences substring s =
+  let sub_len = String.length substring in
+  let str_len = String.length s in
+  if sub_len = 0 then 0
+  else (
+    let rec aux i acc =
+      if i + sub_len > str_len then acc
+      else if String.sub s i sub_len = substring then aux (i + sub_len) (acc + 1)
+      else aux (i + 1) acc
+    in
+    aux 0 0)
+;;
+
 let index_of substring s =
   let sub_len = String.length substring in
   let str_len = String.length s in
@@ -853,6 +867,57 @@ let test_render_if_enabled_renders_persisted_memory () =
             (contains "Gated recall should surface saved facts" block))))
 ;;
 
+(* RFC-0239 R2: the append-only store keeps every re-confirmation of a claim as
+   a separate immortal row. Recall must collapse duplicate claims by normalized
+   fingerprint so one repeated conclusion does not crowd distinct facts out of
+   the injected top-N. *)
+let test_recall_dedups_repeated_claim () =
+  with_prompt_registry (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      let keeper_id = "virtual-memory-keeper" in
+      let now = 1_000_000.0 in
+      let base = fact_fixture ~now () in
+      let dup ~claim turn =
+        (* Same claim across turns, varying only case — normalize_claim folds
+           these to one fingerprint. *)
+        { base with Types.claim; Types.source = { base.source with turn } }
+      in
+      let distinct =
+        { base with
+          Types.claim = "a genuinely distinct fact"
+        ; Types.source = { base.source with turn = 9 }
+        }
+      in
+      let episode =
+        { Types.trace_id = "trace-dedup"
+        ; Types.generation = 1
+        ; Types.episode_summary = "dedup episode"
+        ; Types.claims =
+            [ dup ~claim:"Operator's turn now" 1
+            ; dup ~claim:"OPERATOR'S TURN NOW" 2
+            ; dup ~claim:"operator's turn NOW" 3
+            ; distinct
+            ]
+        ; Types.open_items = []
+        ; Types.constraints = []
+        ; Types.preserved_tool_refs = []
+        ; Types.source_turn_range = Some (1, 9)
+        ; Types.created_at = now
+        ; Types.schema_version = Types.schema_version
+        }
+      in
+      Memory_io.append_episode_bundle ~keeper_id episode;
+      let ctx = Recall.render_context ~keeper_id ~now ~max_facts:8 ~max_episodes:0 () in
+      Alcotest.(check int)
+        "repeated claim collapses to a single fact line"
+        1
+        (occurrences "operator's turn now" (String.lowercase_ascii ctx));
+      Alcotest.(check bool)
+        "distinct fact is not crowded out"
+        true
+        (contains "a genuinely distinct fact" ctx)))
+;;
+
 let test_recall_context_renders_sanitized_memory () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
@@ -1066,6 +1131,10 @@ let () =
             "render_if_enabled renders persisted memory"
             `Quick
             test_render_if_enabled_renders_persisted_memory
+        ; Alcotest.test_case
+            "dedups repeated claim (RFC-0239 R2)"
+            `Quick
+            test_recall_dedups_repeated_claim
         ] )
     ]
 ;;

--- a/test/test_stay_silent_loop_detector.ml
+++ b/test/test_stay_silent_loop_detector.ml
@@ -29,26 +29,26 @@ let ignore_outcome = function
 let test_streak_increments () =
   D.reset_all_for_test ();
   let k = "test-keeper-increments" in
-  record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome;
+  record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome;
   Alcotest.(check int) "after 1" 1 (D.current_streak ~keeper_name:k);
-  record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome;
-  record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome;
+  record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome;
+  record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome;
   Alcotest.(check int) "after 3" 3 (D.current_streak ~keeper_name:k)
 
 let test_any_other_act_resets () =
   D.reset_all_for_test ();
   let k = "test-keeper-resets" in
   for _ = 1 to 5 do
-    record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome
+    record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome
   done;
   Alcotest.(check int) "pre-reset" 5 (D.current_streak ~keeper_name:k);
-  (match record_turn ~keeper_name:k ~speech_act:"declare" with
+  (match record_turn ~keeper_name:k ~made_progress:true with
    | D.Loop_reset { previous_streak; was_latched } ->
      Alcotest.(check int) "reset previous streak" 5 previous_streak;
      Alcotest.(check bool) "reset was not latched" false was_latched
    | D.Normal | D.Loop_detected _ -> Alcotest.fail "expected loop reset");
   Alcotest.(check int) "after declare" 0 (D.current_streak ~keeper_name:k);
-  record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome;
+  record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome;
   Alcotest.(check int) "after new stay_silent" 1
     (D.current_streak ~keeper_name:k)
 
@@ -57,11 +57,11 @@ let test_threshold_crossing_fires_counter () =
   let k = "test-keeper-threshold-fires" in
   let before = detected_count k in
   for _ = 1 to D.threshold () - 1 do
-    record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome
+    record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome
   done;
   Alcotest.(check (float 0.0001)) "no fire before threshold" before
     (detected_count k);
-  (match record_turn ~keeper_name:k ~speech_act:"stay_silent" with
+  (match record_turn ~keeper_name:k ~made_progress:false with
    | D.Loop_detected { streak; threshold } ->
      Alcotest.(check int) "loop streak" threshold streak
    | D.Normal | D.Loop_reset _ -> Alcotest.fail "expected loop detection at threshold");
@@ -74,7 +74,7 @@ let test_latched_no_repeat_while_streak_grows () =
   let k = "test-keeper-latched" in
   let before = detected_count k in
   for _ = 1 to D.threshold () + 7 do
-    record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome
+    record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome
   done;
   Alcotest.(check (float 0.0001)) "latched: exactly +1 across long stay_silent run"
     (before +. 1.0) (detected_count k)
@@ -84,18 +84,18 @@ let test_latch_releases_on_reset_then_refires () =
   let k = "test-keeper-relatch" in
   let before = detected_count k in
   for _ = 1 to D.threshold () + 2 do
-    record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome
+    record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome
   done;
   Alcotest.(check (float 0.0001)) "first loop fires once"
     (before +. 1.0) (detected_count k);
   (* Break the loop with a non-stay_silent act. *)
-  (match record_turn ~keeper_name:k ~speech_act:"declare" with
+  (match record_turn ~keeper_name:k ~made_progress:true with
    | D.Loop_reset { was_latched; _ } ->
      Alcotest.(check bool) "reset releases latched loop" true was_latched
    | D.Normal | D.Loop_detected _ -> Alcotest.fail "expected latched loop reset");
   (* Start a second loop. *)
   for _ = 1 to D.threshold () + 2 do
-    record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome
+    record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome
   done;
   Alcotest.(check (float 0.0001)) "second loop fires once more"
     (before +. 2.0) (detected_count k)
@@ -105,13 +105,13 @@ let test_per_keeper_isolation () =
   let a = "test-keeper-A" in
   let b = "test-keeper-B" in
   for _ = 1 to 4 do
-    record_turn ~keeper_name:a ~speech_act:"stay_silent" |> ignore_outcome
+    record_turn ~keeper_name:a ~made_progress:false |> ignore_outcome
   done;
-  record_turn ~keeper_name:b ~speech_act:"stay_silent" |> ignore_outcome;
+  record_turn ~keeper_name:b ~made_progress:false |> ignore_outcome;
   Alcotest.(check int) "A streak" 4 (D.current_streak ~keeper_name:a);
   Alcotest.(check int) "B streak" 1 (D.current_streak ~keeper_name:b);
   (* Resetting A's streak does not touch B. *)
-  record_turn ~keeper_name:a ~speech_act:"declare" |> ignore_outcome;
+  record_turn ~keeper_name:a ~made_progress:true |> ignore_outcome;
   Alcotest.(check int) "A reset" 0 (D.current_streak ~keeper_name:a);
   Alcotest.(check int) "B unchanged" 1 (D.current_streak ~keeper_name:b)
 
@@ -129,12 +129,45 @@ let test_explicit_reset () =
   D.reset_all_for_test ();
   let k = "test-keeper-explicit-reset" in
   for _ = 1 to 5 do
-    record_turn ~keeper_name:k ~speech_act:"stay_silent" |> ignore_outcome
+    record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome
   done;
   Alcotest.(check int) "pre explicit reset" 5
     (D.current_streak ~keeper_name:k);
   D.reset ~keeper_name:k;
   Alcotest.(check int) "post explicit reset" 0
+    (D.current_streak ~keeper_name:k)
+
+(* RFC-0239 §3 R3: the no-progress predicate. A turn makes progress iff it
+   produced durable evidence OR was on a surface that does not require it. The
+   key new case is the third one: a no-evidence turn on a peer-facing surface
+   (board post) is NOT progress, so the streak accrues — the exact case the old
+   speech_act="stay_silent" check missed. *)
+let test_made_progress_predicate () =
+  Alcotest.(check bool) "evidence on evidence-required surface = progress" true
+    (D.turn_made_progress ~strong_evidence:true ~surface_requires_evidence:true);
+  Alcotest.(check bool)
+    "NO evidence on evidence-required surface (board post) = no progress" false
+    (D.turn_made_progress ~strong_evidence:false ~surface_requires_evidence:true);
+  Alcotest.(check bool) "no evidence on non-required surface (user reply) = progress"
+    true
+    (D.turn_made_progress ~strong_evidence:false ~surface_requires_evidence:false);
+  Alcotest.(check bool) "evidence on non-required surface = progress" true
+    (D.turn_made_progress ~strong_evidence:true ~surface_requires_evidence:false)
+
+let test_no_progress_board_post_accrues_streak () =
+  (* End-to-end of the R3 fix at the detector boundary: a keeper that posts to
+     the board with no evidence (made_progress=false) must accrue the streak,
+     where the old detector reset it. *)
+  D.reset_all_for_test ();
+  let k = "test-keeper-board-thrash" in
+  for _ = 1 to 4 do
+    record_turn
+      ~keeper_name:k
+      ~made_progress:
+        (D.turn_made_progress ~strong_evidence:false ~surface_requires_evidence:true)
+    |> ignore_outcome
+  done;
+  Alcotest.(check int) "board posts without evidence accrue streak" 4
     (D.current_streak ~keeper_name:k)
 
 let () =
@@ -148,6 +181,10 @@ let () =
             `Quick (with_eio test_any_other_act_resets);
           Alcotest.test_case "explicit reset"
             `Quick (with_eio test_explicit_reset);
+          Alcotest.test_case "no-progress predicate (RFC-0239 R3)"
+            `Quick (with_eio test_made_progress_predicate);
+          Alcotest.test_case "no-progress board post accrues streak (RFC-0239 R3)"
+            `Quick (with_eio test_no_progress_board_post_accrues_streak);
         ] );
       ( "threshold crossing",
         [


### PR DESCRIPTION
## 요약

키퍼 7명(garnet, sangsu, analyst, taskmaster, ramarama, executor, rondo)이 각자 30+ 턴 동안 같은 결론("Confidence Inversion 증명됨, 차기작 complete, operator 차례, 이제 조용히 있을게")을 반복 post하며 무한 thrash한 문제를 근본 수정합니다.

**진단(코드+GitHub+라이브스토어 검증)**: 키퍼들은 루프 원인을 "Memory OS Confidence Inversion"이라 자가진단했으나 **틀렸습니다**. 실제 엔진은 `stay_silent` 루프 탐지기가 `speech_act="stay_silent"` 토큰만 보는 blind spot입니다 — 키퍼가 "조용히 있을게"를 **board에 post**(`Post_board`)하면 streak가 매 사이클 0으로 리셋돼 threshold 10에 영영 도달하지 못합니다. 메모리-OS는 증폭기지 root가 아닙니다.

설계 문서: **RFC-0239** (이 PR에 동봉, `docs/rfc/RFC-0239-...md`). 통합 thesis: *모든 가드가 의미 정체성이 아니라 표면 토큰(exact body / post_id / literal speech_act / append-without-dedup)을 키로 삼아 의미적으로 동일한 이벤트가 모든 dedup·debounce·termination을 우회한다.*

## 변경 (RFC-0239의 5 root 중 깨끗이 구현 가능한 3개)

- **R3** `keeper_stay_silent_loop_detector`: 입력을 literal `speech_act` → 의미적 `made_progress`로 일반화. 증거(substantive tool calls / validated output) 없이 peer-facing 표면(board/broadcast)에 발화하거나 silent한 턴이 streak를 누적. stay_silent은 부분집합으로 보존, "일했지만 조용한" 키퍼 오탐도 동시 수정. 메트릭/모듈명 유지(대시보드 의존).
- **R4** `keeper_keepalive_signal`/`keeper_registry`: board wake debounce 키를 `post_id` → content fingerprint(정규화 author+title+content)로. 동일 재post(매 사이클 새 post_id)가 peer를 재기상시키지 못함. content 없으면 post_id fallback.
- **R2** `keeper_memory_os_recall`: append-only 스토어에 쌓인 중복 claim을 recall 시 정규화 fingerprint로 collapse(라이브 측정 8.2% 중복=stale 결론). 스토어 크기 bounding은 retention sweep(별도, 아래 ratification).

## 검증

- `dune build @check` 프로젝트 전역 green.
- `test_stay_silent_loop_detector` 11/11, `test_keeper_lifecycle_registry_dispatch` 10/10, `test_keeper_memory_os` 21/21. 각 root에 RFC-0239 회귀 테스트 추가.
- 라이브 근거: 루프 7키퍼 17,426 facts, `valid_until` 100% None, confidence 82%가 6개 라운드값 집중, 중복 8.2%(reworded "would"/"will" 쌍 포함).

## 범위 밖 — ratification 필요 (RFC-0239 §9, 의도적 미구현)

naive 구현이 RFC §2 anti-workaround 원칙을 위반하므로 설계 결정 전까지 코드화하지 않음:
- **R0(Q3)**: `bump_access_for_turn` 그대로 배선 시 자주 recall되는 stale fact의 score가 올라가 inversion을 **악화** → "stale을 내리는 신호" 설계 필요.
- **R1(Q5)**: `category`(LLM free-string)→TTL = string-classifier 워크어라운드 → typed taxonomy / librarian 계약+eval / TTL 포기 중 택.
- **retention(Q4)**: RFC-0238(closed #21186) `Capped_by_score` 비준 + store-type별 재측정.

## 키퍼 scoring PR 처분 (RFC-0144 워크어라운드-sunset)

#21177(inverse_recency)/#21183(stale_factor)/#21175/#21179/#21192(episode TTL)는 전부 recall scoring tweak(증상억제)이며 R3/R4(실제 루프 엔진)를 건드리지 않음 → 다 머지해도 thrash 안 멈춤. RFC-0239 §6에서 흡수/거부 처분.

RFC-0239 (동봉). keeper coordination + memory-os 표면, credential/identity/sandbox/hooks 아님.

WORKAROUND-WAIVED: R2 "dedup"·R4 "debounce" 키워드는 cap/cooldown/dedup/repair 시그니처에 매칭되나, 둘 다 RFC-0239가 명시한 **root fix**(의미 정체성 기반 가드)이며 증상억제가 아님. RFC §2가 오히려 workaround 버전(read-side repair / post_id-keyed cooldown)을 거부함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
