### PR TITLE
[RFC-0239 Q4] Memory OS fact store retention sweep (cap_facts)

### DIFF
--- a/docs/rfc/RFC-0239-semantic-identity-guards-for-keeper-memory-and-anti-thrash.md
+++ b/docs/rfc/RFC-0239-semantic-identity-guards-for-keeper-memory-and-anti-thrash.md
@@ -49,15 +49,17 @@ termination check in the system. This RFC fixes the five guards that share that 
 | R3 no-progress loop detector | **Implemented + tested** | `keeper_stay_silent_loop_detector`, commit `R3` |
 | R4 wake content-fingerprint debounce | **Implemented + tested** | `keeper_keepalive_signal` / `keeper_registry`, commit `R4` |
 | R2 recall-time claim dedup | **Implemented + tested** | `keeper_memory_os_recall`, commit `R2` |
-| R1 per-fact lifetime at write | **Ratification required** | naive category→TTL is a string-classifier workaround (§2 principle 1); needs a typed taxonomy or a librarian-contract + eval — §9 Q5 |
-| R0 wire inert recall signals | **Ratification required** | naive `bump_access_for_turn` wiring *worsens* the inversion (frequently-recalled stale facts would score higher); needs a stale-lowering signal — §9 Q3 |
-| Retention sweep (supersedes RFC-0238) | **Ratification required** | `Capped_by_score` defaults + legacy 17,426-fact handling — §9 Q4 |
+| Retention sweep (supersedes RFC-0238) | **Implemented + tested** | `keeper_memory_os_io.cap_facts`, Q4 commit |
+| R1 per-fact lifetime at write | **Closed — subsumed** | Q5: drop per-fact TTL (avoids the category string-classifier); store bounding is handled by the retention sweep |
+| R0 wire inert recall signals | **Closed — subsumed** | Q3: naive `bump_access_for_turn` wiring *worsens* the inversion (frequently-recalled stale facts would score higher); R2 dedup + the retention cap cover the in-session symptom. Revisit only if measurement still shows inversion |
 
 R3 + R4 are the loop engine: together they stop the cross-keeper thrash (R3 pauses a
 keeper after a threshold of no-progress turns; R4 stops identical re-posts re-waking peers).
-R2 stops duplicate conclusions crowding recall. The three ratification-required roots are
-the memory-os write/scoring/retention design choices that should not be hacked in — a naive
-version of each is exactly a workaround this RFC's own §2 forbids.
+R2 stops duplicate conclusions crowding recall, and the retention sweep bounds the
+append-only store to `fact_recall_window` (256) facts per keeper by score. R0 and R1 are
+closed as subsumed: per the Q3/Q5 ratification, the right write-side fix is one deterministic
+bounding sweep, not per-fact TTLs (an LLM-trust / string-classifier hazard) or an access
+boost (which would re-amplify the inversion).
 
 ## §1 Problem (with live evidence)
 

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -172,6 +172,29 @@ let extract_and_append_with_provider
   | Error _ as e -> e
   | Ok episode ->
     Keeper_memory_os_io.append_episode_bundle ~keeper_id episode;
+    (* RFC-0239 Q4 (supersedes RFC-0238 Capped_by_score): bound the append-only
+       fact store after each librarian write. cap_facts' hysteresis keeps this
+       off the hot path (a rewrite only fires once the store overflows the
+       trigger). A retention failure must not fail the already-succeeded
+       append, so it is logged and swallowed. *)
+    (try
+       let window = Keeper_memory_os_io.fact_recall_window in
+       ignore
+         (Keeper_memory_os_io.cap_facts
+            ~keeper_id
+            ~keep:window
+            ~trigger:(window + (window / 2))
+            ~rank:
+              (Keeper_memory_os_policy.score_fact
+                 ~now:episode.Keeper_memory_os_types.created_at)
+          : int)
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Log.Keeper.warn
+         "memory os retention sweep failed keeper=%s: %s"
+         keeper_id
+         (Printexc.to_string exn));
     Ok episode
 ;;
 

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -294,6 +294,64 @@ let read_facts_tail ~keeper_id ~n =
   |> take_last n
 ;;
 
+(* RFC-0239 Q4: the per-keeper fact recall window / retention target. The store
+   is bounded to this many facts by the retention sweep, and recall reads up to
+   this many candidates (no longer just the last 64), so score ranking selects
+   the globally best facts within the bounded store rather than the most recent
+   few. *)
+let fact_recall_window = 256
+
+let take_first n xs =
+  let rec aux k = function
+    | x :: tl when k > 0 -> x :: aux (k - 1) tl
+    | _ -> []
+  in
+  if n <= 0 then [] else aux n xs
+;;
+
+let read_all_facts ~keeper_id =
+  let path = facts_path ~keeper_id in
+  if not (Sys.file_exists path)
+  then []
+  else (
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         really_input_string ic (in_channel_length ic)
+         |> split_lines
+         |> List.filter_map (parse_json_line fact_of_json)))
+;;
+
+(* RFC-0239 Q4 (supersedes RFC-0238 Capped_by_score): bound the append-only
+   fact store. When the store exceeds [trigger], keep the [keep] highest-ranked
+   facts and atomically rewrite the file; otherwise leave it untouched. The
+   hysteresis ([trigger] > [keep]) keeps this off the per-turn hot path — a
+   rewrite happens only once every ([trigger] - [keep]) appended facts. Returns
+   the number of facts dropped. *)
+let cap_facts ~keeper_id ~keep ~trigger ~rank =
+  let path = facts_path ~keeper_id in
+  let all = read_all_facts ~keeper_id in
+  let total = List.length all in
+  if total <= trigger
+  then 0
+  else (
+    let kept =
+      all
+      |> List.stable_sort (fun a b -> Float.compare (rank b) (rank a))
+      |> take_first keep
+    in
+    let content =
+      match kept with
+      | [] -> ""
+      | _ ->
+        (kept |> List.map (fun f -> Yojson.Safe.to_string (fact_to_json f)) |> String.concat "\n")
+        ^ "\n"
+    in
+    write_file_atomically path content;
+    total - List.length kept)
+;;
+
 let read_events_tail ~keeper_id ~n =
   read_lines_tail (events_path ~keeper_id) ~n
   |> List.filter_map (parse_json_line episode_of_json)

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -31,6 +31,24 @@ val read_facts_tail : keeper_id:string -> n:int -> fact list
 val read_events_tail : keeper_id:string -> n:int -> episode list
 val read_episodes_tail : keeper_id:string -> n:int -> episode list
 
+(** {1 Retention (RFC-0239 Q4, supersedes RFC-0238 Capped_by_score)} *)
+
+(** Per-keeper fact recall window / retention target. The store is bounded to
+    this many facts; recall reads up to this many candidates (not just the last
+    few), so score ranking selects the globally best facts in the bounded
+    store. *)
+val fact_recall_window : int
+
+(** Read and parse every fact in the store (unbounded; used by retention). *)
+val read_all_facts : keeper_id:string -> fact list
+
+(** When the fact store exceeds [trigger], keep the [keep] highest-[rank]ed
+    facts and atomically rewrite the file; otherwise no-op. Returns the number
+    of facts dropped. The hysteresis ([trigger] > [keep]) keeps rewrites off the
+    per-turn hot path. *)
+val cap_facts :
+  keeper_id:string -> keep:int -> trigger:int -> rank:(fact -> float) -> int
+
 module For_testing : sig
   val with_keepers_dir : string -> (unit -> 'a) -> 'a
 end

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -195,7 +195,12 @@ let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
   let max_facts = max 0 max_facts in
   let max_episodes = max 0 max_episodes in
   let facts =
-    Keeper_memory_os_io.read_facts_tail ~keeper_id ~n:(max fact_tail_scan max_facts)
+    (* RFC-0239 Q4: read up to the bounded recall window (the retention sweep
+       caps the store to this many facts), so score ranking selects the
+       globally best facts rather than only the most recent [fact_tail_scan]. *)
+    Keeper_memory_os_io.read_facts_tail
+      ~keeper_id
+      ~n:(max fact_tail_scan Keeper_memory_os_io.fact_recall_window)
     |> scored_facts ~now
     |> take max_facts
   in

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1050,6 +1050,47 @@ let test_recall_dedups_repeated_claim () =
         (contains "a genuinely distinct fact" ctx)))
 ;;
 
+(* RFC-0239 Q4 (retention): cap_facts bounds the append-only store, keeping the
+   highest-ranked facts and dropping the rest, but only once the store exceeds
+   the trigger (hysteresis). *)
+let test_cap_facts_keeps_top_ranked () =
+  with_temp_keepers_dir (fun _keepers_dir ->
+    let keeper_id = "virtual-memory-keeper" in
+    let now = 1_000_000.0 in
+    let base = fact_fixture ~now () in
+    for i = 1 to 10 do
+      let f =
+        { base with
+          Types.claim = Printf.sprintf "fact-%02d" i
+        ; Types.confidence = 0.1 *. float_of_int i
+        ; Types.source = { base.source with turn = i }
+        }
+      in
+      Memory_io.append_fact ~keeper_id f
+    done;
+    (* rank by confidence: keep the 3 highest (fact-08/09/10), drop 7. *)
+    let dropped =
+      Memory_io.cap_facts ~keeper_id ~keep:3 ~trigger:5 ~rank:(fun f ->
+        f.Types.confidence)
+    in
+    Alcotest.(check int) "dropped count" 7 dropped;
+    let remaining = Memory_io.read_all_facts ~keeper_id in
+    Alcotest.(check int) "kept count" 3 (List.length remaining);
+    List.iter
+      (fun f ->
+        Alcotest.(check bool)
+          (Printf.sprintf "%s is a top-3 claim" f.Types.claim)
+          true
+          (List.mem f.Types.claim [ "fact-08"; "fact-09"; "fact-10" ]))
+      remaining;
+    (* below trigger now (3 <= 5): no-op, nothing dropped. *)
+    let dropped2 =
+      Memory_io.cap_facts ~keeper_id ~keep:3 ~trigger:5 ~rank:(fun f ->
+        f.Types.confidence)
+    in
+    Alcotest.(check int) "no-op below trigger" 0 dropped2)
+;;
+
 let test_recall_context_renders_sanitized_memory () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
@@ -1279,6 +1320,12 @@ let () =
             "dedups repeated claim (RFC-0239 R2)"
             `Quick
             test_recall_dedups_repeated_claim
+        ] )
+    ; ( "retention"
+      , [ Alcotest.test_case
+            "cap_facts keeps top-ranked (RFC-0239 Q4)"
+            `Quick
+            test_cap_facts_keeps_top_ranked
         ] )
     ]
 ;;


### PR DESCRIPTION
## 요약

RFC-0239의 마지막 root인 **retention sweep(Q4)**를 구현합니다. 루프 엔진(R3+R4) + recall dedup(R2)은 #21196으로 main에 머지됨 — 이 PR이 메모리 write-side bounding을 완성합니다.

RFC-0238(closed #21186) `Capped_by_score`를 supersede. append-only fact store가 무한 증식합니다(라이브: ramarama 6,077 facts / 2.08 MB, 루프 7키퍼 17,426 facts, `valid_until` 100% None). Q3/Q4/Q5 비준 결과: per-fact TTL(R1)·access-bump(R0)을 버리고 **단일 deterministic retention sweep**로 bound.

## 변경

- **`keeper_memory_os_io`**: `cap_facts ~keep ~trigger ~rank` — store가 `trigger` 초과 시 상위 `keep`개만 남기고 atomic rewrite, 아니면 no-op. hysteresis(`trigger` > `keep`)로 per-turn hot path 회피(rewrite는 ~`trigger-keep` fact마다 1회). `read_all_facts`, `fact_recall_window = 256`(cap + recall window 공유 상수).
- **`keeper_memory_os_recall`**: tail-64 대신 `fact_recall_window`까지 읽어 bounded store 전체에서 전역 top-N 선택.
- **`keeper_librarian_runtime`**: 매 librarian append 직후 sweep. 실패는 log+swallow(append는 이미 성공).
- **test**: cap_facts 상위 보존 + trigger 미만 no-op 테스트.

## 검증

- `dune build @check` 전역 green (최신 main `6ade69663` 기반).
- `test_keeper_memory_os` 25/25 pass (cap_facts + dedup 포함).

## 관계

- RFC-0239 §0 구현표 갱신: retention **Implemented**, R0/R1 **Closed — subsumed**(Q3/Q5).
- 부모 PR #21196(MERGED, R3+R4+R2). RFC-0239 문서는 main에 존재.

RFC-0239 (main 존재). keeper memory-os 표면, credential/identity/sandbox/hooks 아님.

WORKAROUND-WAIVED: `cap_facts`의 "cap"은 cap/cooldown 시그니처에 매칭되나, 이는 증상억제 cap이 아니라 RFC-0238/RFC-0239가 명시한 **deterministic retention bound**(store-size root fix)입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
