### PR TITLE
fix(keeper): harden Memory OS librarian extraction

### DIFF
--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -112,10 +112,56 @@ let string_list_field key fields =
   | None -> None
 ;;
 
+let string_list_field_or_empty key fields =
+  match List.assoc_opt key fields with
+  | None -> Some []
+  | Some _ -> string_list_field key fields
+;;
+
 let confidence_field fields =
   match number_field "confidence" fields with
   | Some confidence when confidence >= 0.0 && confidence <= 1.0 -> Some confidence
   | Some _ | None -> None
+;;
+
+let json_of_output raw =
+  let raw = String.trim raw in
+  let raw =
+    if String.starts_with ~prefix:"```" raw then (
+      match String.split_on_char '\n' raw with
+      | first :: rest when String.starts_with ~prefix:"```" first ->
+        rest
+        |> List.rev
+        |> (function
+            | last :: rest when String.starts_with ~prefix:"```" (String.trim last) ->
+              List.rev rest
+            | lines -> List.rev lines)
+        |> String.concat "\n"
+        |> String.trim
+      | _ -> raw)
+    else raw
+  in
+  match Yojson.Safe.from_string raw with
+  | json -> Some json
+  | exception Yojson.Json_error _ ->
+    let len = String.length raw in
+    let rec find_from i ch =
+      if i >= len then None
+      else if Char.equal raw.[i] ch then Some i
+      else find_from (i + 1) ch
+    in
+    let rec find_from_right i ch =
+      if i < 0 then None
+      else if Char.equal raw.[i] ch then Some i
+      else find_from_right (i - 1) ch
+    in
+    (match find_from 0 '{', find_from_right (len - 1) '}' with
+     | Some start, Some stop when start < stop ->
+       let candidate = String.sub raw start (stop - start + 1) in
+       (match Yojson.Safe.from_string candidate with
+        | json -> Some json
+        | exception Yojson.Json_error _ -> None)
+     | _ -> None)
 ;;
 
 let claim_source ~trace_id turn tool_call_id =
@@ -173,15 +219,17 @@ let episode_of_output ?now (inp : input) (raw : string) : episode option =
       (* NDT-OK: extraction timestamps are provenance/retention metadata only. *)
       Unix.gettimeofday ()
   in
-  try
-    match Yojson.Safe.from_string raw with
+  match json_of_output raw with
+  | None -> None
+  | Some json ->
+    (match json with
     | `Assoc fields ->
       (match
          string_field "episode_summary" fields
          , List.assoc_opt "claims" fields
-         , string_list_field "open_items" fields
-         , string_list_field "constraints" fields
-         , string_list_field "preserved_tool_refs" fields
+         , string_list_field_or_empty "open_items" fields
+         , string_list_field_or_empty "constraints" fields
+         , string_list_field_or_empty "preserved_tool_refs" fields
        with
        | ( Some episode_summary
          , Some (`List claim_items)
@@ -204,7 +252,5 @@ let episode_of_output ?now (inp : input) (raw : string) : episode option =
               }
           | None -> None)
        | _ -> None)
-    | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
-  with
-  | Yojson.Json_error _ -> None
+    | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None)
 ;;

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -31,6 +31,14 @@ let max_messages () =
   |> max 1
 ;;
 
+let runtime_id_for_librarian ~runtime_id =
+  match Sys.getenv_opt "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID" with
+  | Some value ->
+    let value = String.trim value in
+    if String.equal value "" then runtime_id else value
+  | None -> runtime_id
+;;
+
 let select_recent_messages ~max_messages messages =
   let max_messages = max 0 max_messages in
   let len = List.length messages in
@@ -213,6 +221,7 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id inp =
     try
       match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
       | Some sw, Some net ->
+        let runtime_id = runtime_id_for_librarian ~runtime_id in
         (match provider_for_runtime ~runtime_id with
          | Error err ->
            Log.Keeper.warn ~keeper_name:keeper_id

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -19,6 +19,10 @@ val enabled : unit -> bool
 val max_messages : unit -> int
 (** Maximum recent checkpoint messages sent to the librarian prompt. *)
 
+val runtime_id_for_librarian : runtime_id:string -> string
+(** Runtime id after applying the optional
+    [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID] override. *)
+
 val select_recent_messages
   :  max_messages:int
   -> Agent_sdk.Types.message list

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -385,6 +385,82 @@ let test_librarian_accepts_integer_confidence () =
   | None -> Alcotest.fail "expected librarian output to parse"
 ;;
 
+let test_librarian_accepts_wrapped_json_output () =
+  let inp : Librarian.input =
+    { Librarian.trace_id = "trace-wrapped-json"
+    ; generation = 5
+    ; messages = [ text_message "wrapped JSON memory" ]
+    }
+  in
+  let json = valid_librarian_output () |> Yojson.Safe.to_string in
+  let cases =
+    [ "fenced", Printf.sprintf "```json\n%s\n```" json
+    ; "prefixed", Printf.sprintf "Here is the extracted JSON:\n%s" json
+    ]
+  in
+  List.iter
+    (fun (name, raw) ->
+       match Librarian.episode_of_output ~now:1_000_000.0 inp raw with
+       | Some episode ->
+         Alcotest.(check int)
+           (name ^ " claim count")
+           1
+           (List.length episode.Types.claims)
+       | None -> Alcotest.failf "expected %s librarian output to parse" name)
+    cases
+;;
+
+let test_librarian_defaults_missing_optional_lists () =
+  let inp : Librarian.input =
+    { Librarian.trace_id = "trace-missing-lists"
+    ; generation = 6
+    ; messages = [ text_message "minimal JSON memory" ]
+    }
+  in
+  let raw =
+    `Assoc
+      [ "episode_summary", `String "Minimal valid librarian output"
+      ; ( "claims"
+        , `List
+            [ `Assoc
+                [ "claim", `String "Minimal output still records a fact."
+                ; "confidence", `Float 0.9
+                ; "category", `String "fact"
+                ; "source_turn", `Int 0
+                ]
+            ] )
+      ]
+    |> Yojson.Safe.to_string
+  in
+  match Librarian.episode_of_output ~now:1_000_000.0 inp raw with
+  | Some episode ->
+    Alcotest.(check (list string)) "open_items defaults" [] episode.Types.open_items;
+    Alcotest.(check (list string)) "constraints defaults" [] episode.Types.constraints;
+    Alcotest.(check (list string))
+      "preserved_tool_refs defaults"
+      []
+      episode.Types.preserved_tool_refs
+  | None -> Alcotest.fail "expected missing optional list fields to parse"
+;;
+
+let test_librarian_runtime_override_env () =
+  Fun.protect
+    ~finally:(fun () -> Unix.putenv "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID" "")
+    (fun () ->
+       Unix.putenv "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID" "";
+       Alcotest.(check string)
+         "empty override falls back"
+         "keeper-runtime"
+         (Librarian_runtime.runtime_id_for_librarian ~runtime_id:"keeper-runtime");
+       Unix.putenv
+         "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
+         " runpod_mtp.qwen36-35b-a3b-mtp ";
+       Alcotest.(check string)
+         "override trims"
+         "runpod_mtp.qwen36-35b-a3b-mtp"
+         (Librarian_runtime.runtime_id_for_librarian ~runtime_id:"keeper-runtime"))
+;;
+
 let test_librarian_preserves_admission_memory_text () =
   let inp : Librarian.input =
     { Librarian.trace_id = "trace-filter-transient-cap"
@@ -1244,6 +1320,18 @@ let () =
             "librarian accepts integer confidence"
             `Quick
             test_librarian_accepts_integer_confidence
+        ; Alcotest.test_case
+            "librarian accepts wrapped json output"
+            `Quick
+            test_librarian_accepts_wrapped_json_output
+        ; Alcotest.test_case
+            "librarian defaults missing optional lists"
+            `Quick
+            test_librarian_defaults_missing_optional_lists
+        ; Alcotest.test_case
+            "librarian runtime override env"
+            `Quick
+            test_librarian_runtime_override_env
         ; Alcotest.test_case
             "librarian preserves admission memory text"
             `Quick


### PR DESCRIPTION
## Summary
- Accept fenced/prefixed JSON objects from Memory OS librarian providers instead of rejecting the whole extraction.
- Default missing optional list fields (`open_items`, `constraints`, `preserved_tool_refs`) to empty arrays.
- Add `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` so librarian extraction can use a dedicated runtime instead of inheriting each keeper's main runtime.

## Verification
- `scripts/dune-local.sh build test/test_keeper_memory_os.exe`
- `./_build/default/test/test_keeper_memory_os.exe`
- `ocamlformat --check lib/keeper/keeper_librarian.ml lib/keeper/keeper_librarian_runtime.ml lib/keeper/keeper_librarian_runtime.mli test/test_keeper_memory_os.ml`
- `git diff --check`

## Runtime Evidence
- Before: recent 12h scan showed Memory OS librarian warnings dominated by invalid episode JSON, empty response, and timeout.
- After `issue_king` resume: live `/health?full=1` reports `keeper_fleet_safety.status=ok`, `blocked_count=0`, `paused_keepers.count=0`.
