### PR TITLE
[codex] Fix dashboard WebSocket same-origin upgrade

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -45,6 +45,7 @@ module Progress = Masc.Progress
 module Sse = Masc.Sse
 module Safe_ops = Safe_ops
 module Tool_board = Board_tool
+module Transport_metrics = Masc.Transport_metrics
 module Server_mcp_transport_http = Server_mcp_transport_http
 
 
@@ -215,12 +216,75 @@ let try_mcp_validation_block ~is_mcp_like ~request ~protocol_version ~origin req
   end
   else false
 
+let header_contains_token headers name token =
+  match get_header_any_case headers name with
+  | None -> false
+  | Some value ->
+    value
+    |> String.split_on_char ','
+    |> List.exists (fun part ->
+         String.equal
+           (String.lowercase_ascii (String.trim part))
+           (String.lowercase_ascii token))
+
+let header_equals_token headers name token =
+  match get_header_any_case headers name with
+  | None -> false
+  | Some value ->
+    String.equal
+      (String.lowercase_ascii (String.trim value))
+      (String.lowercase_ascii token)
+
+let is_websocket_upgrade_request request =
+  let headers = request.Httpun.Request.headers in
+  header_contains_token headers "connection" "upgrade"
+  && header_equals_token headers "upgrade" "websocket"
+
+let respond_ws_upgrade_unavailable reqd =
+  let body = {|{"error":"websocket transport disabled"}|} in
+  let headers =
+    Httpun.Headers.of_list
+      [ ("content-type", "application/json")
+      ; ("content-length", string_of_int (String.length body))
+      ]
+  in
+  let response = Httpun.Response.create ~headers `Service_unavailable in
+  safe_reqd_respond reqd response body
+
+let handle_websocket_upgrade reqd =
+  if not (Transport_metrics.ws_enabled ())
+  then respond_ws_upgrade_unavailable reqd
+  else
+    let state = current_server_state_opt () in
+    match
+      Server_mcp_transport_ws.upgrade_connection
+        ?sw:(state_switch_opt state)
+        ?clock:(state_clock_opt state)
+        reqd
+    with
+    | Ok () -> ()
+    | Error msg ->
+      let body =
+        Yojson.Safe.to_string
+          (`Assoc [ ("error", `String ("websocket upgrade failed: " ^ msg)) ])
+      in
+      let headers =
+        Httpun.Headers.of_list
+          [ ("content-type", "application/json")
+          ; ("content-length", string_of_int (String.length body))
+          ]
+      in
+      let response = Httpun.Response.create ~headers `Bad_request in
+      safe_reqd_respond reqd response body
+
 (** Method/path dispatcher for MCP-validated requests. Caller is
     responsible for rate limiting and origin/protocol-version checks
     before invoking this function. *)
 let dispatch_route ~router ~request ~path reqd =
   match request.Httpun.Request.meth, path with
   | `OPTIONS, _ -> options_handler request reqd
+  | `GET, "/ws" when is_websocket_upgrade_request request ->
+    handle_websocket_upgrade reqd
   | `GET, "/ws" ->
     let body =
       Server_routes_http_runtime.websocket_discovery_json request

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -88,7 +88,7 @@ function installWebSocketMocks(): void {
   vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
     enabled: true,
     listening: true,
-    ws_url: 'ws://127.0.0.1:8937/',
+    ws_url: 'ws://localhost:3000/ws',
   }), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
@@ -105,7 +105,7 @@ function installControlledDiscovery(): Array<(response: Response) => void> {
   return resolvers
 }
 
-function wsDiscoveryResponse(wsUrl = 'ws://127.0.0.1:8937/'): Response {
+function wsDiscoveryResponse(wsUrl = 'ws://localhost:3000/ws'): Response {
   return new Response(JSON.stringify({
     enabled: true,
     listening: true,
@@ -303,12 +303,12 @@ describe('dashboard websocket route subscriptions', () => {
     const latestConnect = connectDashboardWS({ tab: 'workspace', params: { section: 'board' } })
     expect(discoveries).toHaveLength(2)
 
-    discoveries[1]!(wsDiscoveryResponse('ws://127.0.0.1:8937/latest'))
+    discoveries[1]!(wsDiscoveryResponse('ws://localhost:3000/ws?latest'))
     await latestConnect
     expect(mockSockets).toHaveLength(1)
-    expect(mockSockets[0]!.url).toBe('ws://127.0.0.1:8937/latest')
+    expect(mockSockets[0]!.url).toBe('ws://localhost:3000/ws?latest')
 
-    discoveries[0]!(wsDiscoveryResponse('ws://127.0.0.1:8937/stale'))
+    discoveries[0]!(wsDiscoveryResponse('ws://localhost:3000/ws?stale'))
     await staleConnect
     await flushPromises()
 
@@ -368,8 +368,22 @@ describe('dashboard websocket route subscriptions', () => {
     await flushPromises()
 
     expect(mockSockets).toHaveLength(2)
-    expect(mockSockets[1]!.url).toBe('ws://127.0.0.1:8937/')
+    expect(mockSockets[1]!.url).toBe('ws://localhost:3000/ws')
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops cached websocket discovery from a different origin', async () => {
+    installWebSocketMocks()
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>
+    sessionStorage.setItem('masc.dashboard.ws.discovery.v1', JSON.stringify({
+      ws_url: 'ws://127.0.0.1:8937/',
+    }))
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(mockSockets).toHaveLength(1)
+    expect(mockSockets[0]!.url).toBe('ws://localhost:3000/ws')
   })
 
   it('invalidates cached discovery when the cached socket closes before it is ready', async () => {
@@ -377,13 +391,13 @@ describe('dashboard websocket route subscriptions', () => {
     mockSockets.length = 0
     vi.stubGlobal('WebSocket', MockWebSocket)
     const fetchMock = vi.fn()
-      .mockResolvedValueOnce(wsDiscoveryResponse('ws://127.0.0.1:8937/stale'))
-      .mockResolvedValueOnce(wsDiscoveryResponse('ws://127.0.0.1:8937/fresh'))
+      .mockResolvedValueOnce(wsDiscoveryResponse('ws://localhost:3000/ws?stale'))
+      .mockResolvedValueOnce(wsDiscoveryResponse('ws://localhost:3000/ws?fresh'))
     vi.stubGlobal('fetch', fetchMock)
 
     await connectDashboardWS({ tab: 'overview', params: {} })
     const staleSocket = mockSockets[0]!
-    expect(staleSocket.url).toBe('ws://127.0.0.1:8937/stale')
+    expect(staleSocket.url).toBe('ws://localhost:3000/ws?stale')
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
     staleSocket.close({ code: 1006, reason: 'connect failed', wasClean: false })
@@ -392,7 +406,7 @@ describe('dashboard websocket route subscriptions', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(mockSockets).toHaveLength(2)
-    expect(mockSockets[1]!.url).toBe('ws://127.0.0.1:8937/fresh')
+    expect(mockSockets[1]!.url).toBe('ws://localhost:3000/ws?fresh')
   })
 
   it('subscribes the latest route captured while hello is still in flight', async () => {

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -68,6 +68,18 @@ function sessionStorageOrNull(): Storage | null {
   }
 }
 
+function sameOriginWebSocketUrl(wsUrl: string): boolean {
+  if (typeof window === 'undefined' || typeof window.location === 'undefined') return true
+  const expectedProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  if (window.location.protocol !== 'https:' && window.location.protocol !== 'http:') return true
+  try {
+    const parsed = new URL(wsUrl, window.location.href)
+    return parsed.protocol === expectedProtocol && parsed.host === window.location.host
+  } catch {
+    return false
+  }
+}
+
 function readCachedWsUrl(): string | null {
   const storage = sessionStorageOrNull()
   if (!storage) return null
@@ -75,7 +87,12 @@ function readCachedWsUrl(): string | null {
     const raw = storage.getItem(DASHBOARD_WS_DISCOVERY_CACHE_KEY)
     if (!raw) return null
     const data = JSON.parse(raw) as { ws_url?: unknown }
-    return typeof data.ws_url === 'string' && data.ws_url.length > 0 ? data.ws_url : null
+    if (typeof data.ws_url !== 'string' || data.ws_url.length === 0) return null
+    if (!sameOriginWebSocketUrl(data.ws_url)) {
+      storage.removeItem(DASHBOARD_WS_DISCOVERY_CACHE_KEY)
+      return null
+    }
+    return data.ws_url
   } catch {
     // Eviction must not propagate: in restricted storage contexts the
     // initial getItem can throw, and a follow-up removeItem can throw too.

--- a/lib/server/server_bootstrap_http.ml
+++ b/lib/server/server_bootstrap_http.ml
@@ -66,7 +66,7 @@ let print_startup_banner
   if Server_ws_standalone.is_enabled ()
   then
     Printf.printf
-      "   GET  /ws → WebSocket discovery (standalone ws://127.0.0.1:%d/)\n%!"
+      "   GET  /ws → WebSocket upgrade or discovery (standalone fallback ws://127.0.0.1:%d/)\n%!"
       (Server_ws_standalone.configured_port ());
   if Server_webrtc_transport.is_enabled ()
   then Printf.printf "   POST /webrtc/offer, /webrtc/answer → WebRTC signaling\n%!"

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -859,6 +859,55 @@ let session_count () =
   with_sessions_rw (fun () ->
     Hashtbl.length sessions)
 
+let heartbeat_interval_s = 30.0
+
+let start_upgrade_heartbeat ?sw ?clock session_id session =
+  match sw, clock with
+  | Some sw, Some clock ->
+    Eio.Fiber.fork ~sw (fun () ->
+      let rec loop () =
+        Eio.Time.sleep clock heartbeat_interval_s;
+        if not session.closed && not (Httpun_ws.Wsd.is_closed session.wsd)
+        then (
+          let send_failed = ref false in
+          (try Httpun_ws.Wsd.send_ping session.wsd with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+             send_failed := true;
+             (match Http_server_eio.Late_response.classify_write_failure exn with
+              | Some _ ->
+                Log.Server.debug
+                  "[ws-upgrade] session %s heartbeat skipped (writer closed during \
+                   cancel race)"
+                  session_id
+              | None ->
+                Log.Server.warn
+                  "[ws-upgrade] session %s heartbeat send_ping failed: %s"
+                  session_id
+                  (Printexc.to_string exn)));
+          if !send_failed then cleanup_session session_id else loop ())
+      in
+      loop ())
+  | _ ->
+    Log.Server.debug
+      "[ws-upgrade] session %s heartbeat disabled (missing switch or clock)"
+      session_id
+
+let send_upgrade_pong session_id wsd =
+  try Httpun_ws.Wsd.send_pong wsd with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    (match Http_server_eio.Late_response.classify_write_failure exn with
+     | Some _ ->
+       Log.Server.debug
+         "[ws-upgrade] session %s send_pong skipped (writer closed during cancel race)"
+         session_id
+     | None ->
+       Log.Server.warn
+         "[ws-upgrade] session %s send_pong failed: %s"
+         session_id
+         (Printexc.to_string exn))
+
 (** Handle an HTTP upgrade request to WebSocket.
 
     Call this from the httpun request handler when path = "/ws".
@@ -868,6 +917,8 @@ let session_count () =
     @param on_message Optional callback for incoming text messages.
       Default: log and ignore. *)
 let upgrade_connection
+    ?sw
+    ?clock
     ?(on_message = fun _session_id _text -> ())
     (reqd : Httpun.Reqd.t)
   : (unit, string) result =
@@ -893,9 +944,10 @@ let upgrade_connection
               then
                 cleanup_session session_id)
             ();
+          start_upgrade_heartbeat ?sw ?clock session_id session;
           (* #10875: see cleanup_session — per-session lifecycle is DEBUG
              to avoid logging amplification during WS storm (#10701). *)
-          Log.Server.debug "WebSocket session %s connected" session_id;
+          Log.Server.debug "WebSocket session %s connected (same-origin /ws)" session_id;
           { Httpun_ws.Websocket_connection.
             frame = (fun ~opcode ~is_fin ~len payload ->
               match opcode with
@@ -903,7 +955,7 @@ let upgrade_connection
                 read_inbound_message_frame session ~on_message ~is_fin ~len
                   payload
               | `Ping ->
-                Httpun_ws.Wsd.send_pong wsd;
+                send_upgrade_pong session_id wsd;
                 Httpun_ws.Payload.close payload
               | `Connection_close ->
                 cleanup_session session_id;
@@ -992,5 +1044,4 @@ let () =
     ~ping:(fun ~session_id () -> dashboard_ping ~session_id ());
   Mcp_server_eio_protocol.register_dashboard_ack dashboard_ack
 ;;
-
 

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -57,7 +57,7 @@
     [slice_index_enabled],
     [__test_reset_env_caches],
     [read_payload_string], [handle_inbound_text],
-    [upgrade_connection], [send_to_session],
+    [send_to_session],
     [broadcast_ws]). *)
 
 (** {1 Session record} *)
@@ -173,6 +173,16 @@ val read_inbound_message_frame :
     accumulates partial-text fragments across [is_fin =
     false] frames, and invokes [on_message ~session_id
     ~body] when a final fragment arrives. *)
+
+val upgrade_connection :
+  ?sw:Eio.Switch.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?on_message:(string -> string -> unit) ->
+  Httpun.Reqd.t ->
+  (unit, string) result
+(** Handles an HTTP/1.1 [GET /ws] upgrade on the main HTTP origin.  When [sw]
+    and [clock] are provided, forks the same protocol-level heartbeat used by
+    the standalone WS listener. *)
 
 (** {1 Outbound delivery} *)
 

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -63,33 +63,120 @@ let configured_http_port () =
 let configured_http_host () =
   Env_config_core.masc_host ()
 
-let advertised_host_port request =
-  let (host, port) =
-    parse_host_port
-      (Httpun.Headers.get request.Httpun.Request.headers "host")
-      (configured_http_host ()) (configured_http_port ())
+let authority_host host =
+  match Ipaddr.of_string host with
+  | Ok (Ipaddr.V6 _) -> "[" ^ host ^ "]"
+  | Ok (Ipaddr.V4 _) | Error _ -> host
+
+let authority_of_host_port host port =
+  Printf.sprintf "%s:%d" (authority_host host) port
+
+let advertised_host_port_authority request =
+  let default_host = configured_http_host () in
+  let default_port = configured_http_port () in
+  let fallback () =
+    let host = Transport_read_model.normalize_advertised_host default_host in
+    (host, default_port, authority_of_host_port host default_port)
   in
-  (Transport_read_model.normalize_advertised_host host, port)
+  match Httpun.Headers.get request.Httpun.Request.headers "host" with
+  | None -> fallback ()
+  | Some raw -> (
+      let trimmed = String.trim raw in
+      if trimmed = "" || host_header_has_forbidden_authority_chars trimmed
+      then fallback ()
+      else
+        try
+          let uri = Uri.of_string ("http://" ^ trimmed) in
+          let parsed_host = Uri.host uri |> Option.value ~default:default_host in
+          let port_opt = Uri.port uri in
+          let port = Option.value ~default:default_port port_opt in
+          let host = Transport_read_model.normalize_advertised_host parsed_host in
+          let authority =
+            match port_opt with
+            | Some _ -> authority_of_host_port host port
+            | None ->
+              if String.equal host parsed_host
+              then authority_host host
+              else authority_of_host_port host port
+          in
+          (host, port, authority)
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | _ -> fallback ())
+
+let advertised_host_port request =
+  let host, port, _authority = advertised_host_port_authority request in
+  (host, port)
+
+let normalize_forwarded_proto raw =
+  let value =
+    raw
+    |> String.trim
+    |> String.lowercase_ascii
+    |> fun value ->
+    let len = String.length value in
+    if len >= 2 && value.[0] = '"' && value.[len - 1] = '"'
+    then String.sub value 1 (len - 2)
+    else value
+  in
+  match value with
+  | "http" | "https" -> Some value
+  | _ -> None
+
+let first_forwarded_proto raw =
+  raw
+  |> String.split_on_char ','
+  |> List.find_map (fun element ->
+       element
+       |> String.split_on_char ';'
+       |> List.find_map (fun part ->
+            match String.split_on_char '=' (String.trim part) with
+            | [ key; value ] when String.equal (String.lowercase_ascii (String.trim key)) "proto" ->
+              normalize_forwarded_proto value
+            | _ -> None))
+
+let advertised_scheme request =
+  let headers = request.Httpun.Request.headers in
+  match Httpun.Headers.get headers "x-forwarded-proto" with
+  | Some raw -> (
+      match
+        raw
+        |> String.split_on_char ','
+        |> List.find_map normalize_forwarded_proto
+      with
+      | Some scheme -> scheme
+      | None -> (
+          match Httpun.Headers.get headers "forwarded" with
+          | Some raw -> Option.value ~default:"http" (first_forwarded_proto raw)
+          | None -> "http"))
+  | None -> (
+      match Httpun.Headers.get headers "forwarded" with
+      | Some raw -> Option.value ~default:"http" (first_forwarded_proto raw)
+      | None -> "http")
+
+let advertised_base_url request =
+  let _host, _port, authority = advertised_host_port_authority request in
+  Printf.sprintf "%s://%s" (advertised_scheme request) authority
 
 let websocket_discovery_json request =
-  let (host, port) = advertised_host_port request in
+  let (host, _port) = advertised_host_port request in
   let ctx =
     Transport_read_model.make_http_context ~include_configured:true
-      ~host ~base_url:(Printf.sprintf "http://%s:%d" host port) ()
+      ~host ~base_url:(advertised_base_url request) ()
   in
   Transport_read_model.websocket_discovery_json ctx
 
 let transport_json request =
-  let (host, port) = advertised_host_port request in
+  let (host, _port) = advertised_host_port request in
   let ctx =
     Transport_read_model.make_http_context ~include_configured:true
-      ~host ~base_url:(Printf.sprintf "http://%s:%d" host port) ()
+      ~host ~base_url:(advertised_base_url request) ()
   in
   Transport_read_model.transport_status_json ctx
 
 let agent_card_json request =
   let (host, port) = advertised_host_port request in
-  let base_url = Printf.sprintf "http://%s:%d" host port in
+  let base_url = advertised_base_url request in
   let build = Build_identity.current () in
   `Assoc
     [

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -77,6 +77,12 @@ val advertised_host_port :
     [(configured_http_host (), configured_http_port ())] when
     the header is absent. *)
 
+val advertised_base_url : Httpun.Request.t -> string
+(** [advertised_base_url request] returns the browser-visible HTTP(S) base URL.
+    It derives the authority from [Host:] and the scheme from
+    [X-Forwarded-Proto] / [Forwarded: proto=...] when present, falling back to
+    local [http]. *)
+
 (** {1 Discovery / status JSON} *)
 
 val websocket_discovery_json : Httpun.Request.t -> Yojson.Safe.t

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -728,10 +728,12 @@ let get_bindings ~host ~port : binding list =
       @ [
           {
             protocol = Ws;
-            url =
-              Printf.sprintf "ws://%s:%d/" host
-                Env_config.Transport.ws_port;
-            options = [ ("mode", "standalone"); ("discovery_path", "/ws") ];
+            url = Printf.sprintf "ws://%s:%d/ws" host port;
+            options =
+              [ ("mode", "same_origin_upgrade")
+              ; ("discovery_path", "/ws")
+              ; ("standalone_port", string_of_int Env_config.Transport.ws_port)
+              ];
           };
         ]
     else

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -18,6 +18,23 @@ let trim_trailing_slashes value =
 
 ;;
 
+let websocket_scheme_for_http_scheme = function
+  | Some scheme ->
+    (match String.lowercase_ascii scheme with
+     | "https" | "wss" -> "wss"
+     | "http" | "ws" -> "ws"
+     | _ -> "ws")
+  | None -> "ws"
+;;
+
+let websocket_url_from_base_url base_url =
+  let uri = Uri.of_string (trim_trailing_slashes base_url) in
+  let uri =
+    Uri.with_scheme uri (Some (websocket_scheme_for_http_scheme (Uri.scheme uri)))
+  in
+  (Uri.to_string uri |> trim_trailing_slashes) ^ "/ws"
+;;
+
 let configured_http_port () = Env_config_core.masc_http_port_int ()
 let configured_http_host () = Env_config_core.masc_host ()
 
@@ -156,15 +173,21 @@ let get_ws_session_count () =
 let websocket_discovery_json (ctx : http_context) =
   let enabled = Transport_metrics.ws_enabled () in
   let port = Env_config.Transport.ws_port in
-  let reachable = Transport_metrics.ws_listening () || tcp_port_reachable port in
+  let standalone_listening = Transport_metrics.ws_listening () in
+  let upgrade_available = enabled in
+  let listening = upgrade_available || standalone_listening in
+  let reachable = listening || tcp_port_reachable port in
+  let standalone_ws_url = Printf.sprintf "ws://%s:%d/" ctx.host port in
   let base_fields =
     [ "enabled", `Bool enabled ]
     @ maybe_configured_fields ~include_configured:ctx.include_configured enabled
-    @ [ "listening", `Bool (Transport_metrics.ws_listening ())
+    @ [ "listening", `Bool listening
       ; "reachable", `Bool reachable
       ; "listen_status", `String (Atomic.get Transport_metrics.ws_listen_status)
-      ; "mode", `String "standalone"
+      ; "mode", `String "same_origin_upgrade"
       ; "discovery_path", `String "/ws"
+      ; "upgrade_path", `String "/ws"
+      ; "standalone_listening", `Bool standalone_listening
       ; "session_count", `Int (get_ws_session_count ())
       ]
   in
@@ -173,7 +196,9 @@ let websocket_discovery_json (ctx : http_context) =
     then
       base_fields
       @ [ "ws_port", `Int port
-        ; "ws_url", `String (Printf.sprintf "ws://%s:%d/" ctx.host port)
+        ; "ws_url", `String (websocket_url_from_base_url ctx.base_url)
+        ; "standalone_ws_port", `Int port
+        ; "standalone_ws_url", `String standalone_ws_url
         ]
     else base_fields
   in
@@ -288,4 +313,3 @@ let transport_status_json (ctx : http_context) =
     ; "enabled_protocols", enabled_protocols_json ()
     ]
 ;;
-

--- a/lib/transport_read_model.mli
+++ b/lib/transport_read_model.mli
@@ -90,9 +90,9 @@ val context_from_env :
 val websocket_discovery_json : http_context -> Yojson.Safe.t
 (** [websocket_discovery_json ctx] returns the WebSocket
     discovery payload used by browser dashboards to learn the
-    [ws://]/[wss://] URL.  Includes the configured-port +
-    runtime-listening fields when [ctx.include_configured] is
-    [true]. *)
+    same-origin [ws://]/[wss://] upgrade URL.  Includes the
+    legacy standalone configured-port + runtime-listening fields
+    when [ctx.include_configured] is [true]. *)
 
 val transport_status_json : http_context -> Yojson.Safe.t
 (** [transport_status_json ctx] returns the full transport
@@ -117,4 +117,3 @@ type webrtc_status =
 val register_grpc_service_name : string -> unit
 val register_grpc_health_service_name : string -> unit
 val register_webrtc_status : (unit -> webrtc_status) -> unit
-

--- a/test/test_transport_read_model.ml
+++ b/test/test_transport_read_model.ml
@@ -120,6 +120,37 @@ let test_transport_status_reports_streamable_http_protocol () =
   check bool "enabled_protocols includes canonical json-rpc path" true
     (List.mem "json-rpc" enabled_protocols)
 
+let test_websocket_discovery_uses_same_origin_upgrade_url () =
+  let json = TRM.websocket_discovery_json (make_context ()) in
+  check string "mode" "same_origin_upgrade"
+    Yojson.Safe.Util.(json |> member "mode" |> to_string);
+  check string "upgrade path" "/ws"
+    Yojson.Safe.Util.(json |> member "upgrade_path" |> to_string);
+  check string "ws_url uses http listener" "ws://127.0.0.1:8935/ws"
+    Yojson.Safe.Util.(json |> member "ws_url" |> to_string);
+  check string "standalone retained for diagnostics" "ws://127.0.0.1:8937/"
+    Yojson.Safe.Util.(json |> member "standalone_ws_url" |> to_string)
+
+let test_websocket_discovery_uses_wss_for_https_base_url () =
+  let ctx =
+    TRM.make_http_context
+      ~base_url:"https://example.com/root/"
+      ~host:"example.com"
+      ()
+  in
+  let json = TRM.websocket_discovery_json ctx in
+  check string "wss preserves base path" "wss://example.com/root/ws"
+    Yojson.Safe.Util.(json |> member "ws_url" |> to_string)
+
+let test_advertised_base_url_uses_forwarded_proto_without_internal_port () =
+  let headers =
+    Httpun.Headers.of_list
+      [ "host", "masc.example.com"; "x-forwarded-proto", "https" ]
+  in
+  let request = Httpun.Request.create ~headers `GET "/ws" in
+  check string "forwarded https base" "https://masc.example.com"
+    (Server_routes_http_runtime.advertised_base_url request)
+
 let test_context_from_env_uses_default_loopback_base_url () =
   with_env "MASC_HTTP_BASE_URL" None (fun () ->
       with_env "MASC_HOST" (Some "0.0.0.0") (fun () ->
@@ -165,6 +196,12 @@ let () =
              test_transport_status_http_shape_extends_tool_shape;
            test_case "transport status includes json-rpc protocol" `Quick
              test_transport_status_reports_streamable_http_protocol;
+           test_case "websocket same-origin URL" `Quick
+             test_websocket_discovery_uses_same_origin_upgrade_url;
+           test_case "websocket HTTPS URL" `Quick
+             test_websocket_discovery_uses_wss_for_https_base_url;
+           test_case "forwarded base URL" `Quick
+             test_advertised_base_url_uses_forwarded_proto_without_internal_port;
          ] );
       ( "env",
         [


### PR DESCRIPTION
## Summary

Fix the dashboard WebSocket path so browser clients use the same HTTP origin for `/ws` instead of being sent to the standalone loopback WS port.

## Root Cause

`GET /ws` on the main HTTP listener only returned discovery JSON, and that JSON advertised `ws://127.0.0.1:8937/`. That works only from the same machine. Mobile Safari, HTTPS tunnels, and reverse-proxy paths either cannot reach that loopback port or reject the plain `ws://` URL from an HTTPS page, so the dashboard falls back to SSE and feels slow.

## Changes

- Route HTTP/1.1 `GET /ws` upgrade requests to `Server_mcp_transport_ws.upgrade_connection`.
- Keep `fetch('/ws')` as discovery JSON for the dashboard client.
- Advertise `ws(s)://<current-http-origin>/ws` as the primary `ws_url`.
- Preserve the standalone WS port as diagnostic/fallback metadata.
- Respect `Host`, `X-Forwarded-Proto`, and `Forwarded: proto=...` when building public runtime URLs.
- Add heartbeat/pong write guards to same-origin upgrade sessions.
- Drop stale dashboard WS discovery cache entries when they point at a different origin.

## Validation

- `scripts/dune-local.sh build bin/main_eio.exe test/test_transport_read_model.exe`
- `scripts/dune-local.sh exec ./test/test_transport_read_model.exe`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/dashboard-ws.test.ts`
- Isolated smoke on temp ports: `/ws` discovery returned `ws://127.0.0.1:19535/ws`; raw HTTP/1.1 WebSocket handshake returned `101 Switching Protocols`.

## Notes

`test/test_transport_coverage.exe` currently fails on an unrelated REST/OpenAPI catalog issue where `/api/v1/agents` parses as `unknown` instead of `masc_agents`.
