### PR TITLE
refactor(keeper): type the agent-runtime status carrier (RFC-0089)

### DIFF
--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -126,10 +126,20 @@ let json_bool key json default =
 let json_float_opt key json =
   Safe_ops.json_float_opt key json
 
-let agent_status_text agent_status =
-  json_string_opt "status" agent_status
-  |> Option.value ~default:"unknown"
-  |> String.lowercase_ascii
+(* RFC-0089 (String Classifier to Typed Variant). The agent-status snapshot
+   blob's "status" field is produced exclusively by [parse_agent_status], which
+   serializes a typed [Masc_domain.agent_status] (active | busy | listening |
+   inactive). Parse it back into the closed ADT here so the liveness/surface
+   consumers below match the four constructors exhaustively instead of comparing
+   string literals — the compiler then rejects any arm naming a value outside
+   the domain. The previous string-literal matches carried dead "idle"/"offline"
+   arms (keeper_health vocabulary this producer never emits); those vanish under
+   the typed match. Unknown / absent / garbage "status" parses to [None],
+   preserving the old "unknown"-default semantics (neither live nor inactive). *)
+let agent_runtime_status_opt agent_status : Masc_domain.agent_status option =
+  match json_string_opt "status" agent_status with
+  | Some s -> Masc_domain.agent_status_of_string_opt (String.lowercase_ascii s)
+  | None -> None
 
 let agent_last_seen_ts_opt agent_status =
   match json_string_opt "last_seen" agent_status with
@@ -140,16 +150,16 @@ let agent_last_seen_ago_s agent_status =
   json_float_opt "last_seen_ago_s" agent_status |> Option.value ~default:max_float
 
 let agent_runtime_has_live_signal agent_status =
-  match agent_status_text agent_status with
-  | "active" | "busy" | "listening" | "idle" ->
+  match agent_runtime_status_opt agent_status with
+  | Some (Masc_domain.Active | Masc_domain.Busy | Masc_domain.Listening) ->
       agent_last_seen_ago_s agent_status <= agent_staleness_threshold_s
-  | _ -> false
+  | Some Masc_domain.Inactive | None -> false
 
 let agent_runtime_has_live_work agent_status =
-  match agent_status_text agent_status with
-  | "active" | "busy" | "listening" ->
+  match agent_runtime_status_opt agent_status with
+  | Some (Masc_domain.Active | Masc_domain.Busy | Masc_domain.Listening) ->
       agent_last_seen_ago_s agent_status <= agent_staleness_threshold_s
-  | _ -> false
+  | Some Masc_domain.Inactive | None -> false
 
 let string_contains_ci = String_util.contains_substring_ci
 
@@ -344,11 +354,7 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
   | Fiber_dead -> KH_dead
   | Fiber_alive | Fiber_unknown ->
   let agent_exists = json_bool "exists" agent_status false in
-  let agent_status_text =
-    json_string_opt "status" agent_status
-    |> Option.value ~default:"unknown"
-    |> String.lowercase_ascii
-  in
+  let agent_runtime_status = agent_runtime_status_opt agent_status in
   let last_seen_ago_s =
     json_float_opt "last_seen_ago_s" agent_status |> Option.value ~default:max_float
   in
@@ -366,7 +372,7 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
   in
   if
     (not keepalive_running)
-    && (not agent_exists || agent_status_text = "offline" || agent_status_text = "inactive")
+    && (not agent_exists || agent_runtime_status = Some Masc_domain.Inactive)
   then KH_offline
   (* H-4 fix: true zombies are stale regardless of keepalive state *)
   else if is_zombie then KH_stale
@@ -509,15 +515,14 @@ let keeper_surface_status
     |> Option.value ~default:"offline"
     |> keeper_health_or_offline ~source:"keeper_surface_status"
   in
-  let agent_runtime_status =
-    json_string_opt "status" agent_status |> Option.map String.lowercase_ascii
-  in
+  let agent_runtime_status = agent_runtime_status_opt agent_status in
   match health_state with
   | KH_healthy -> (
       match agent_runtime_status with
-      | Some (("active" | "busy" | "listening" | "idle") as status) -> status
-      | Some ("offline" | "inactive") -> "offline"
-      | _ -> "active")
+      | Some ((Masc_domain.Active | Masc_domain.Busy | Masc_domain.Listening) as s) ->
+          Masc_domain.string_of_agent_status s
+      | Some Masc_domain.Inactive -> "offline"
+      | None -> "active")
   | KH_idle -> "idle"
   | KH_stale | KH_degraded | KH_zombie | KH_dead -> "inactive"
   | KH_offline -> "offline"

--- a/lib/keeper/keeper_status_runtime.mli
+++ b/lib/keeper/keeper_status_runtime.mli
@@ -6,7 +6,13 @@ val active_model_of_meta : keeper_meta -> string
 val active_model_label_of_meta : keeper_meta -> string
 val next_model_hint_of_meta : keeper_meta -> string option
 val string_of_fiber_health : fiber_health -> string
-val agent_status_text : Yojson.Safe.t -> string
+(** Parse the "status" field of an agent-status snapshot blob (produced by
+    {!parse_agent_status}) into the closed [Masc_domain.agent_status] ADT.
+    Returns [None] when the field is absent or not one of the four canonical
+    lowercase labels, so callers classify the closed domain exhaustively
+    instead of comparing string literals. *)
+val agent_runtime_status_opt : Yojson.Safe.t -> Masc_domain.agent_status option
+
 val agent_runtime_has_live_signal : Yojson.Safe.t -> bool
 val parse_agent_status : Workspace.config -> agent_name:string -> Yojson.Safe.t
 val keeper_reply_snapshot_of_history :

--- a/lib/operator/operator_control_snapshot_runtime_status.ml
+++ b/lib/operator/operator_control_snapshot_runtime_status.ml
@@ -10,9 +10,13 @@ let remote_confirm_ttl_seconds = 900.0
 
 let runtime_status_from_live_signal (agent_status_json : Yojson.Safe.t) =
   let runtime_status =
-    match Keeper_status_runtime.agent_status_text agent_status_json with
-    | ("active" | "busy" | "listening" | "idle") as status -> Some status
-    | _ -> None
+    (* Mirror the keeper_status_runtime typed parse: the agent-status blob's
+       "status" field only ever holds active|busy|listening|inactive, so match
+       the closed ADT and drop the dead "idle" arm the compiler can now reject. *)
+    match Keeper_status_runtime.agent_runtime_status_opt agent_status_json with
+    | Some ((Masc_domain.Active | Masc_domain.Busy | Masc_domain.Listening) as s) ->
+        Some (Masc_domain.string_of_agent_status s)
+    | Some Masc_domain.Inactive | None -> None
   in
   let has_live_signal =
     Keeper_status_runtime.agent_runtime_has_live_signal agent_status_json

--- a/lib/server/server_dashboard_http_core_entities.ml
+++ b/lib/server/server_dashboard_http_core_entities.ml
@@ -92,10 +92,18 @@ let dashboard_tasks_safe config = Workspace.get_tasks_safe config
 let dashboard_agents_safe config = Workspace.get_active_agents config
 
 let active_agent_summary_json json =
+  (* RFC-0089: classify the agent "status" via the closed agent_status ADT
+     (Masc_domain.agent_status_of_string_opt) instead of string literals, so a
+     new status constructor forces a compile error here too. Behavior is
+     unchanged: only Active/Busy/Listening yield a summary; Inactive and any
+     other/absent value yield None. *)
   match Json_util.assoc_string_opt "status" json with
   | Some status ->
-    (match String.lowercase_ascii (String.trim status) with
-     | "active" | "busy" | "listening" ->
+    (match
+       Masc_domain.agent_status_of_string_opt
+         (String.lowercase_ascii (String.trim status))
+     with
+     | Some (Masc_domain.Active | Masc_domain.Busy | Masc_domain.Listening) ->
        let agent_type =
          Json_util.assoc_string_opt "agent_type" json
          |> Option.value ~default:"unknown"
@@ -103,8 +111,7 @@ let active_agent_summary_json json =
          |> String.lowercase_ascii
        in
        Some agent_type
-     | "inactive" -> None
-     | _ -> None)
+     | Some Masc_domain.Inactive | None -> None)
   | None -> None
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -1439,6 +1439,8 @@
 
 (include stanzas/test_keeper_agent_run_sandbox_source.inc)
 
+(include stanzas/test_keeper_agent_runtime_status.inc)
+
 (include stanzas/test_keeper_autoboot_supervisor_start_10125.inc)
 
 (include stanzas/test_keeper_checkpoint_classify.inc)

--- a/test/stanzas/test_keeper_agent_runtime_status.inc
+++ b/test/stanzas/test_keeper_agent_runtime_status.inc
@@ -1,0 +1,8 @@
+; Per-file dune stanza for the typed agent_runtime_status carrier suite
+; (RFC-0089). Lives here per test/stanzas/README.md to avoid the
+; conflict-runtime hotspot in the legacy grouped (tests ...) stanza.
+
+(test
+ (name test_keeper_agent_runtime_status)
+ (modules test_keeper_agent_runtime_status)
+ (libraries masc_test_deps masc masc_types alcotest))

--- a/test/test_keeper_agent_runtime_status.ml
+++ b/test/test_keeper_agent_runtime_status.ml
@@ -1,0 +1,103 @@
+(* RFC-0089 (String Classifier to Typed Variant) — typed agent_runtime_status.
+
+   keeper_status_runtime parses the agent-status snapshot blob's "status" field
+   into the closed [Masc_domain.agent_status] ADT instead of comparing string
+   literals. These tests pin:
+   (1) the four canonical labels parse to their constructors,
+   (2) keeper_health vocabulary ("idle"/"offline") and garbage parse to [None]
+       — these were the dead string arms the old literal matches carried,
+   (3) the liveness predicate and surface-status derivation classify the closed
+       domain (so removing the dead arms is behavior-preserving on the reachable
+       domain and well-defined on the unreachable one). *)
+
+module K = Masc.Keeper_status_runtime
+open Alcotest
+
+let blob pairs : Yojson.Safe.t = `Assoc pairs
+let status s = blob [ ("status", `String s) ]
+
+let test_known_labels_parse () =
+  let check_one label ctor =
+    check bool
+      (Printf.sprintf "%s parses to constructor" label)
+      true
+      (K.agent_runtime_status_opt (status label) = Some ctor)
+  in
+  check_one "active" Masc_domain.Active;
+  check_one "busy" Masc_domain.Busy;
+  check_one "listening" Masc_domain.Listening;
+  check_one "inactive" Masc_domain.Inactive
+
+let test_case_insensitive () =
+  check bool "ACTIVE is lowercased before parse" true
+    (K.agent_runtime_status_opt (status "ACTIVE") = Some Masc_domain.Active)
+
+let test_outside_domain_is_none () =
+  (* "idle"/"offline"/"stale"/"zombie" are keeper_health labels, never
+     agent_status. The old literal matches carried them as dead arms; the
+     typed parser maps them (and any garbage) to None. *)
+  List.iter
+    (fun s ->
+      check bool
+        (Printf.sprintf "%S -> None" s)
+        true
+        (K.agent_runtime_status_opt (status s) = None))
+    [ "idle"; "offline"; "stale"; "zombie"; "garbage"; "" ]
+
+let test_absent_status_is_none () =
+  check bool "blob without status field -> None" true
+    (K.agent_runtime_status_opt (blob [ ("exists", `Bool true) ]) = None)
+
+let test_live_signal () =
+  let live s = blob [ ("status", `String s); ("last_seen_ago_s", `Float 1.0) ] in
+  let stale s =
+    blob [ ("status", `String s); ("last_seen_ago_s", `Float 9999.0) ]
+  in
+  check bool "active recent -> live" true
+    (K.agent_runtime_has_live_signal (live "active"));
+  check bool "listening recent -> live" true
+    (K.agent_runtime_has_live_signal (live "listening"));
+  check bool "active stale -> not live" false
+    (K.agent_runtime_has_live_signal (stale "active"));
+  check bool "inactive recent -> not live" false
+    (K.agent_runtime_has_live_signal (live "inactive"));
+  (* dead-arm removal: "idle" is no longer treated as a live signal *)
+  check bool "idle recent -> not live (dead arm gone)" false
+    (K.agent_runtime_has_live_signal (live "idle"))
+
+let test_surface_status () =
+  let diag h = blob [ ("health_state", `String h) ] in
+  check string "healthy + active -> active" "active"
+    (K.keeper_surface_status ~agent_status:(status "active")
+       ~diagnostic:(diag "healthy"));
+  check string "healthy + inactive -> offline" "offline"
+    (K.keeper_surface_status ~agent_status:(status "inactive")
+       ~diagnostic:(diag "healthy"));
+  (* idle blob -> None -> default "active"; the old code surfaced "idle" here,
+     but that input is unreachable from parse_agent_status. *)
+  check string "healthy + idle-blob -> active (default)" "active"
+    (K.keeper_surface_status ~agent_status:(status "idle")
+       ~diagnostic:(diag "healthy"));
+  check string "kh_idle health -> idle" "idle"
+    (K.keeper_surface_status ~agent_status:(status "active")
+       ~diagnostic:(diag "idle"));
+  check string "kh_stale health -> inactive" "inactive"
+    (K.keeper_surface_status ~agent_status:(status "active")
+       ~diagnostic:(diag "stale"))
+
+let () =
+  run "keeper_agent_runtime_status"
+    [
+      ( "agent_runtime_status_opt",
+        [
+          test_case "known labels parse" `Quick test_known_labels_parse;
+          test_case "case-insensitive" `Quick test_case_insensitive;
+          test_case "outside-domain -> None" `Quick test_outside_domain_is_none;
+          test_case "absent -> None" `Quick test_absent_status_is_none;
+        ] );
+      ( "predicates",
+        [
+          test_case "live signal" `Quick test_live_signal;
+          test_case "surface status" `Quick test_surface_status;
+        ] );
+    ]


### PR DESCRIPTION
## 목적
keeper agent-status `status` carrier를 string 리터럴 분류 → 닫힌 `Masc_domain.agent_status` variant 매칭으로 전환합니다. (RFC-0089 "String Classifier to Typed Variant — direct replacement, no lint", backend OCaml.)

## 배경 (근본 원인)
`parse_agent_status`가 유일한 producer로 typed `agent.status`를 `"status"` 문자열로 평탄화한 뒤, 6개 소비자가 그 문자열을 리터럴로 재분류했습니다. 비교 리터럴에 `"idle"`/`"offline"`이 섞여 있었는데, 이 둘은 `keeper_health` 어휘(`KH_idle`/`KH_offline`)로 **agent_status producer가 절대 방출하지 않는 dead arm**입니다. string carrier라 컴파일러가 이 죽은 가지를 잡지 못했습니다.

## 변경
- `agent_runtime_status_opt : Yojson.Safe.t -> Masc_domain.agent_status option` 도입 — read 경계에서 1회 파싱(parse-don't-validate). 미존재/미지정/garbage는 `None`.
- 소비자 7곳을 닫힌 ADT(`Active|Busy|Listening|Inactive`) exhaustive match로 전환:
  - `keeper_status_runtime.ml`: `agent_runtime_has_live_signal`, `agent_runtime_has_live_work`, `keeper_health_state`(KH_offline 조건), `keeper_surface_status`(KH_healthy 분기)
  - `operator_control_snapshot_runtime_status.ml`: `runtime_status_from_live_signal`
  - `server_dashboard_http_core_entities.ml`: `active_agent_summary_json` (동일 SSOT 파서 경유 — N-of-M 회피)
- `agent_status_text`(string accessor, 유일 caller가 operator) 제거.
- wire format 불변 — `parse_agent_status`는 동일 JSON을 그대로 직렬화.
- 신규 `test/test_keeper_agent_runtime_status.ml` 6 케이스 (이 소비자들은 기존 테스트 전무).

## 범위 밖 (의도적, 침묵 아님)
다음은 agent_status가 아니라 **더 넓은 status 어휘**(idle/offline/paused를 distinct하게 처리 = surface/display status)를 분류하므로 agent_status ADT로 강요하면 행위가 깨집니다. 별도 typed-domain 작업(후속):
- `server_dashboard_http_execution_surfaces.ml:459` `patched_keeper_status` (`offline→"offline"` vs default `"idle"` 구별)
- `dashboard_utils.ml:54` `status_rank` (`idle→1` 구별)
- `operator_control_snapshot_runtime_status.ml:58` `align_keeper_runtime_status` (`surface_status` 파생 문자열)

## 검증
- `dune build --root . @check` exit 0 (keeper+operator+server lib + 전체 test 컴파일).
- 신규 test 6/6 통과.
- **적대적 검증 워크플로** 3 관점 (fresh-context, file:line 근거 강제, 결과 spot-check):
  - provenance: `parse_agent_status` 단일 producer + `status ∈ {active,busy,listening,inactive}` 확인 → `claim_holds`.
  - behavior preservation: 5개 함수 전부 reachable 도메인에서 old=new, dead arm만 제거 → `claim_holds`.
  - migration completeness(N-of-M): 처음 6곳만 고쳤을 때 `claim_refuted` — server 2 사이트 지적. spot-check 결과 1곳(core_entities `active_agent_summary_json`)은 순수 agent_status라 **본 PR에 포함**, 다른 1곳(execution_surfaces)은 broader 어휘라 범위 밖으로 확정. 이 PR이 그 발견을 반영한 결과입니다.
- Site 2(`active_agent_summary_json`)는 분류 로직이 전적으로 `agent_status_of_string_opt`(신규 test가 망라)에 위임되는 thin wrapper라 별도 server-lib test 스탠자는 추가하지 않았습니다. 행위 보존은 위 검증으로 확인.

WORKAROUND-WAIVED: string classifier를 *제거*하고 닫힌 variant로 대체합니다(추가 아님). STRING_CLASSIFIER 게이트 시그니처는 false-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
