### PR TITLE
fix(keeper): tune memory os librarian timeout

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -31,6 +31,12 @@ let max_messages () =
   |> max 1
 ;;
 
+let default_timeout_sec () =
+  Keeper_memory_bank_env.memory_env_float_logged
+    "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC"
+    ~default:Env_config_governance.Inference.timeout_seconds
+;;
+
 let runtime_id_for_librarian ~runtime_id =
   match Sys.getenv_opt "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID" with
   | Some value ->
@@ -237,11 +243,14 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id inp =
                provider_cfg.Llm_provider.Provider_config.model_id
            else (
              let clock = Eio_context.get_clock_opt () in
+             let timeout_sec =
+               Option.value timeout_sec ~default:(default_timeout_sec ())
+             in
              match
                extract_and_append_with_provider
                  ?complete
                  ?clock
-                 ?timeout_sec
+                 ~timeout_sec
                  ~sw
                  ~net
                  ~keeper_id

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -19,6 +19,11 @@ val enabled : unit -> bool
 val max_messages : unit -> int
 (** Maximum recent checkpoint messages sent to the librarian prompt. *)
 
+val default_timeout_sec : unit -> float
+(** Provider timeout for post-turn extraction. Defaults to governance inference
+    timeout and can be overridden with
+    [MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC]. *)
+
 val runtime_id_for_librarian : runtime_id:string -> string
 (** Runtime id after applying the optional
     [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID] override. *)

--- a/lib/keeper/keeper_memory_bank_env.ml
+++ b/lib/keeper/keeper_memory_bank_env.ml
@@ -1,7 +1,8 @@
 (** Env-var parsing helpers for the keeper memory bank.
 
-    Three primitives — [memory_env_opt] strips empty/whitespace,
+    Four primitives — [memory_env_opt] strips empty/whitespace,
     [memory_env_int_logged] adds int parsing with WARN-on-invalid,
+    [memory_env_float_logged] adds positive-float parsing, and
     [memory_env_bool_logged] adds bool parsing with the same shape —
     plus the two .mli-exposed consumers [memory_llm_summary_enabled]
     and [max_memory_text_length] that use them.
@@ -26,6 +27,18 @@ let memory_env_int_logged name ~default =
        | None ->
            Log.Keeper.warn
              "invalid %s=%S; using default %d"
+             name raw default;
+           default)
+
+let memory_env_float_logged name ~default =
+  match memory_env_opt name with
+  | None -> default
+  | Some raw ->
+      (match float_of_string_opt raw with
+       | Some n when n > 0.0 -> n
+       | _ ->
+           Log.Keeper.warn
+             "invalid %s=%S; using default %.3f"
              name raw default;
            default)
 

--- a/lib/keeper/keeper_memory_bank_env.mli
+++ b/lib/keeper/keeper_memory_bank_env.mli
@@ -2,6 +2,7 @@
 
 val memory_env_opt : string -> string option
 val memory_env_int_logged : string -> default:int -> int
+val memory_env_float_logged : string -> default:float -> float
 val memory_env_bool_logged : string -> default:bool -> bool
 val memory_llm_summary_enabled : unit -> bool
 val max_memory_text_length : unit -> int

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -461,6 +461,29 @@ let test_librarian_runtime_override_env () =
          (Librarian_runtime.runtime_id_for_librarian ~runtime_id:"keeper-runtime"))
 ;;
 
+let test_librarian_timeout_override_env () =
+  let env = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC" in
+  Fun.protect
+    ~finally:(fun () -> Unix.putenv env "")
+    (fun () ->
+       Unix.putenv env "";
+       let default = Librarian_runtime.default_timeout_sec () in
+       Alcotest.(check (float 0.001))
+         "empty timeout override falls back"
+         default
+         (Librarian_runtime.default_timeout_sec ());
+       Unix.putenv env "180.5";
+       Alcotest.(check (float 0.001))
+         "positive timeout override parses"
+         180.5
+         (Librarian_runtime.default_timeout_sec ());
+       Unix.putenv env "-1";
+       Alcotest.(check (float 0.001))
+         "invalid timeout override falls back"
+         default
+         (Librarian_runtime.default_timeout_sec ()))
+;;
+
 let test_librarian_preserves_admission_memory_text () =
   let inp : Librarian.input =
     { Librarian.trace_id = "trace-filter-transient-cap"
@@ -1332,6 +1355,10 @@ let () =
             "librarian runtime override env"
             `Quick
             test_librarian_runtime_override_env
+        ; Alcotest.test_case
+            "librarian timeout override env"
+            `Quick
+            test_librarian_timeout_override_env
         ; Alcotest.test_case
             "librarian preserves admission memory text"
             `Quick


### PR DESCRIPTION
Summary
- add MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC for post-turn Memory OS librarian extraction
- add a positive float parser for keeper memory env vars
- keep direct test overrides able to pass timeout_sec explicitly

Why
The live runtime stopped the earlier invalid/empty JSON failure mode after #21205, but the first post-restart librarian call still failed on provider timeout: memory os librarian failed runtime=glm-coding.glm-5-turbo: librarian provider timed out.

This separates the librarian timeout budget from the shared governance inference timeout so operators can tune this non-critical post-turn extraction path without changing broader inference behavior.

Verification
- scripts/dune-local.sh build test/test_keeper_memory_os.exe
- ./_build/default/test/test_keeper_memory_os.exe
- ocamlformat --check lib/keeper/keeper_memory_bank_env.ml lib/keeper/keeper_memory_bank_env.mli lib/keeper/keeper_librarian_runtime.ml lib/keeper/keeper_librarian_runtime.mli test/test_keeper_memory_os.ml
- git diff --check