### PR TITLE
[codex] Fix keeper detail dashboard test selector

### DIFF
--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -330,7 +330,7 @@ describe('KeeperDetailPage', () => {
     keepers.value = [analyst]
 
     const { container } = render(html`<${KeeperDetailPage} />`)
-    expect(screen.getByText('analyst')).toBeTruthy()
+    expect(screen.getByRole('heading', { level: 2, name: 'analyst' })).toBeTruthy()
     expect(screen.getByText('direct chat analyst')).toBeTruthy()
     expect(screen.queryByText('FSM Hub (6축 상태 머신)')).toBeNull()
     const pageText = container.textContent ?? ''


### PR DESCRIPTION
## Summary

- Narrow the existing Keeper detail page assertion from raw text lookup to the page header heading.
- This follows up #21210, where the new roster/context rails correctly render the keeper name in multiple places and made the previous `getByText('analyst')` assertion ambiguous.

## Impact

Test-only change. Runtime dashboard behavior is unchanged.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/components/keeper-detail.test.ts --no-file-parallelism --maxWorkers=1`
- Before the follow-up branch, local full dashboard test also passed after this selector fix: `pnpm test` (Preact: 512 files / 6584 tests, Solid: 7 files / 85 tests).