### PR TITLE
[codex] Add keeper chat workspace surface

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -357,7 +357,7 @@ export function App() {
           `}
 
         <main id="main-content" tabindex=${-1} class=${compactChromeMode ? 'min-w-0 flex-1 overflow-hidden bg-[var(--shell-main-bg)] backdrop-blur-lg' : 'min-w-0 flex-1 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-main-bg)] backdrop-blur-lg max-[1100px]:min-h-0'}>
-          <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : focusMode ? 'dashboard-main-scroll h-full overflow-y-auto p-3 max-[520px]:p-2 max-[768px]:pb-16' : 'dashboard-main-scroll h-full overflow-y-auto p-4 max-[768px]:pb-16'}>
+          <div class=${isCodeSurface || widgetSoloMode || keeperDetailMode ? 'h-full overflow-hidden p-0' : focusMode ? 'dashboard-main-scroll h-full overflow-y-auto p-3 max-[520px]:p-2 max-[768px]:pb-16' : 'dashboard-main-scroll h-full overflow-y-auto p-4 max-[768px]:pb-16'}>
             <${DashboardMain} />
           </div>
         </main>

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1385,7 +1385,7 @@ export function DashboardMain() {
     `
   }
 
-  if (immersiveSurface) {
+  if (immersiveSurface || keeperDetailRoute) {
     return html`
       <div class=${`animate-in fade-in slide-in-from-bottom-2 duration-[var(--t-slow)] fill-mode-both h-full min-h-0 overflow-hidden ${namespaceTruthInitializing.value ? 'grid grid-rows-[auto_minmax(0,1fr)]' : ''}`}>
         ${warmingBanner}

--- a/dashboard/src/components/keeper-detail-page.test.ts
+++ b/dashboard/src/components/keeper-detail-page.test.ts
@@ -1,9 +1,10 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, describe, expect, it } from 'vitest'
-import { keepers } from '../store'
-import type { Keeper } from '../types'
-import { KeeperContextRail, KeeperDetailRosterRail } from './keeper-detail-page'
+import { keepers, tasks } from '../store'
+import type { Keeper, Task } from '../types'
+import { KeeperWorkspaceRail } from './keeper-workspace/keeper-workspace-rail'
+import { KeeperWorkspaceRoster } from './keeper-workspace/keeper-workspace-roster'
 
 function makeKeeper(overrides: Partial<Keeper> = {}): Keeper {
   return {
@@ -11,23 +12,25 @@ function makeKeeper(overrides: Partial<Keeper> = {}): Keeper {
     status: 'active',
     phase: 'Running',
     lifecycle_phase: 'Running',
-    model: 'claude-sonnet-4',
-    runtime_id: 'oas-seoul-1',
+    active_model_label: 'claude-sonnet-4',
+    runtime_canonical: 'oas-seoul-1',
     short_goal: 'runtime lane cleanup',
     context_ratio: 0.62,
     context_tokens: 124_000,
     context_max: 200_000,
-    goal_progress: {
-      active_goal_count: 1,
-      linked_task_count: 3,
-      open_task_count: 2,
-      done_task_count: 1,
-      blocked_task_count: 0,
-      convergence: 0.5,
-    },
     recent_tool_names: ['masc_trace_window', 'masc_board_metrics'],
     ...overrides,
   } as Keeper
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'T-1',
+    title: 'runtime lane cleanup',
+    status: 'in_progress',
+    assignee: 'sangsu',
+    ...overrides,
+  } as Task
 }
 
 function renderInto(ui: ReturnType<typeof html>) {
@@ -38,9 +41,10 @@ function renderInto(ui: ReturnType<typeof html>) {
 
 afterEach(() => {
   keepers.value = []
+  tasks.value = []
 })
 
-describe('KeeperDetailRosterRail', () => {
+describe('KeeperWorkspaceRoster', () => {
   it('renders the selected keeper list with status counts and search', () => {
     keepers.value = [
       makeKeeper(),
@@ -48,27 +52,28 @@ describe('KeeperDetailRosterRail', () => {
       makeKeeper({ name: 'dust', status: 'offline', phase: 'Stopped', lifecycle_phase: 'Stopped' }),
     ]
 
-    const container = renderInto(html`<${KeeperDetailRosterRail} activeKeeperName="sangsu" />`)
+    const container = renderInto(html`<${KeeperWorkspaceRoster} activeName="sangsu" />`)
 
-    expect(container.textContent).toContain('3 / 3')
-    expect(container.textContent).toContain('실행 1')
-    expect(container.textContent).toContain('정지 1')
-    expect(container.textContent).toContain('오프 1')
-    expect(container.querySelector('input[name="keeper_detail_roster_search"]')).not.toBeNull()
-    expect(container.querySelector('[aria-current="page"]')?.textContent).toContain('sangsu')
+    expect(container.textContent).toContain('전체3')
+    expect(container.textContent).toContain('실행중1')
+    expect(container.textContent).toContain('실행 중')
+    expect(container.textContent).toContain('대기 · 일시정지')
+    expect(container.textContent).toContain('중지 · 종료됨')
+    expect(container.querySelector('.kw-roster-search')).not.toBeNull()
+    expect(container.querySelector('[aria-current="true"]')?.textContent).toContain('sangsu')
   })
 })
 
-describe('KeeperContextRail', () => {
+describe('KeeperWorkspaceRail', () => {
   it('renders current keeper runtime, context, task, and tool summary', () => {
-    const container = renderInto(html`<${KeeperContextRail} keeper=${makeKeeper()} />`)
+    tasks.value = [makeTask()]
+    const container = renderInto(html`<${KeeperWorkspaceRail} keeper=${makeKeeper()} onToggleDetail=${() => {}} />`)
 
-    expect(container.textContent).toContain('현재 Keeper')
+    expect(container.textContent).toContain('런타임 · 처리량')
     expect(container.textContent).toContain('claude-sonnet-4')
     expect(container.textContent).toContain('oas-seoul-1')
     expect(container.textContent).toContain('62%')
-    expect(container.textContent).toContain('열림 2')
-    expect(container.textContent).toContain('완료 1')
+    expect(container.textContent).toContain('T-1')
     expect(container.textContent).toContain('masc_trace_window')
   })
 })

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -15,7 +15,6 @@ import {
   selectedKeeper,
   clearKeeperDetailSelection,
   closeKeeperDetail,
-  openKeeperDetail,
 } from './keeper-detail-state'
 import {
   refreshAfterRuntimeAction,
@@ -27,23 +26,16 @@ import {
   useKeeperRuntimeTraceEvidence,
 } from './keeper-detail-hooks'
 import { evidenceFreshData } from './keeper-detail-evidence-state'
-import { KeeperLifecycleButtons } from './keeper-detail-lifecycle'
+import { KeeperLifecycleButtons, KeeperClearContextDialog } from './keeper-detail-lifecycle'
 import {
   KeeperDetailHeaderInfo,
   KeeperDetailMissingState,
 } from './keeper-detail-shell'
 import { KeeperDetailBody } from './keeper-detail-body'
+import { KeeperWorkspaceRoster } from './keeper-workspace/keeper-workspace-roster'
+import { KeeperWorkspaceChat } from './keeper-workspace/keeper-workspace-chat'
+import { KeeperWorkspaceRail } from './keeper-workspace/keeper-workspace-rail'
 import { ringFocusClasses } from './common/ring'
-import { TextInput } from './common/input'
-import { TimeAgo } from './common/time-ago'
-import { StatusDot } from './common/status-dot'
-import { KeeperBadge } from './keeper-badge'
-import { AgentPresence } from './common/agent-presence'
-import { keeperActivityDisplay } from '../lib/keeper-runtime-display'
-import { isKeeperOffline, isKeeperPaused } from '../lib/keeper-predicates'
-import { summarizeKeeperMonitoring } from '../lib/monitoring-runtime'
-import { formatTokens } from '../lib/format-number'
-import type { Keeper } from '../types'
 
 const CLOSE_BUTTON_FOCUS_CLASS = ringFocusClasses({
   tone: 'accent-medium',
@@ -51,272 +43,6 @@ const CLOSE_BUTTON_FOCUS_CLASS = ringFocusClasses({
   offset: 2,
   offsetSurface: 'page',
 })
-
-function keeperSearchTerms(keeper: Keeper): string {
-  return [
-    keeper.name,
-    keeper.agent_name,
-    keeper.keeper_id,
-    keeper.koreanName,
-    keeper.short_goal,
-    keeper.goal,
-    keeper.runtime_id,
-    keeper.runtime_canonical,
-    keeper.sandbox_profile,
-  ].filter((value): value is string => typeof value === 'string' && value.trim() !== '')
-    .join(' ')
-    .toLowerCase()
-}
-
-function keeperSortRank(keeper: Keeper): number {
-  if (isKeeperOffline(keeper)) return 4
-  if (isKeeperPaused(keeper)) return 3
-  if (keeper.needs_attention || keeper.runtime_blocker_class) return 1
-  return 2
-}
-
-function keeperModelLabel(keeper: Keeper): string {
-  return keeper.last_model_used_label
-    ?? keeper.last_model_used
-    ?? keeper.active_model_label
-    ?? keeper.active_model
-    ?? keeper.primary_model
-    ?? keeper.model
-    ?? 'model 미상'
-}
-
-function keeperRuntimeLabel(keeper: Keeper): string {
-  const runtimeRef = keeper.runtime_ref
-    ? [keeper.runtime_ref.group, keeper.runtime_ref.item].filter((value): value is string => Boolean(value)).join(' / ')
-    : null
-  return keeper.selected_runtime_canonical
-    ?? keeper.runtime_canonical
-    ?? keeper.runtime_id
-    ?? runtimeRef
-    ?? keeper.sandbox_profile
-    ?? 'runtime 미상'
-}
-
-function keeperWorkPreview(keeper: Keeper): string {
-  return keeper.recent_output_preview
-    ?? keeper.recent_input_preview
-    ?? keeper.short_goal
-    ?? keeper.goal
-    ?? keeper.agent?.current_task
-    ?? '최근 작업 요약 없음'
-}
-
-function keeperContextMeta(keeper: Keeper): { pct: number; detail: string | null } | null {
-  const ratio = keeper.context_ratio ?? keeper.context?.context_ratio
-  if (typeof ratio !== 'number' || !Number.isFinite(ratio)) return null
-  const pct = Math.max(0, Math.min(100, Math.round(ratio * 100)))
-  const tokens = keeper.context_tokens ?? keeper.context?.context_tokens
-  const max = keeper.context_max ?? keeper.context?.context_max
-  const detail =
-    typeof tokens === 'number' && typeof max === 'number'
-      ? `${formatTokens(tokens)} / ${formatTokens(max)}`
-      : typeof tokens === 'number'
-        ? formatTokens(tokens)
-        : null
-  return { pct, detail }
-}
-
-function keeperDotClass(keeper: Keeper): string {
-  if (isKeeperOffline(keeper)) return 'bg-[var(--color-fg-disabled)]'
-  if (isKeeperPaused(keeper)) return 'bg-[var(--color-status-warn)]'
-  if (keeper.needs_attention || keeper.runtime_blocker_class) return 'bg-[var(--color-status-err)]'
-  return 'bg-[var(--color-status-ok)]'
-}
-
-export function KeeperDetailRosterRail({ activeKeeperName }: { activeKeeperName: string }) {
-  const [query, setQuery] = useState('')
-  const normalizedQuery = query.trim().toLowerCase()
-  const rows = keepers.value
-    .filter(keeper => normalizedQuery === '' || keeperSearchTerms(keeper).includes(normalizedQuery))
-    .sort((left, right) => {
-      const rank = keeperSortRank(left) - keeperSortRank(right)
-      return rank !== 0 ? rank : left.name.localeCompare(right.name)
-    })
-  const activeCount = keepers.value.filter(keeper => !isKeeperOffline(keeper) && !isKeeperPaused(keeper)).length
-  const pausedCount = keepers.value.filter(isKeeperPaused).length
-  const offlineCount = keepers.value.filter(isKeeperOffline).length
-
-  return html`
-    <aside class="keeper-detail-roster-rail flex min-h-0 flex-col overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] shadow-none xl:sticky xl:top-[calc(var(--header-h)+0.75rem)] xl:max-h-[calc(100svh-var(--header-h)-1.5rem)]" aria-label="Keeper 목록">
-      <div class="shrink-0 border-b border-[var(--color-border-default)] px-4 py-3">
-        <div class="flex items-center justify-between gap-3">
-          <div>
-            <div class="text-3xs font-semibold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-muted)]">Keepers</div>
-            <div class="mt-1 text-sm font-semibold text-[var(--color-fg-primary)]">${rows.length} / ${keepers.value.length}</div>
-          </div>
-          <div class="flex flex-wrap justify-end gap-1.5 text-3xs">
-            <span class="rounded-[var(--r-0)] border border-[var(--ok-20)] bg-[var(--ok-10)] px-2 py-1 text-[var(--color-status-ok)]">실행 ${activeCount}</span>
-            <span class="rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-[var(--color-status-warn)]">정지 ${pausedCount}</span>
-            <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1 text-[var(--color-fg-muted)]">오프 ${offlineCount}</span>
-          </div>
-        </div>
-        <label class="mt-3 block">
-          <span class="sr-only">Keeper 검색</span>
-          <${TextInput}
-            name="keeper_detail_roster_search"
-            ariaLabel="Keeper 이름 · 네임스페이스 검색"
-            autoComplete="off"
-            placeholder="이름 · 네임스페이스 검색..."
-            value=${query}
-            onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          />
-        </label>
-      </div>
-      <div class="min-h-0 flex-1 overflow-y-auto py-2 custom-scrollbar">
-        ${rows.length === 0
-          ? html`<div class="px-4 py-8 text-center text-xs leading-relaxed text-[var(--color-fg-muted)]">검색 결과가 없습니다.</div>`
-          : rows.map(keeper => {
-              const selected = keeper.name === activeKeeperName
-              const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
-              const monitoring = summarizeKeeperMonitoring(keeper)
-              const work = keeperWorkPreview(keeper)
-              return html`
-                <button
-                  key=${keeper.name}
-                  type="button"
-                  class=${`keeper-detail-roster-row mx-2 flex w-[calc(100%-1rem)] min-w-0 items-start gap-3 rounded-[var(--r-1)] border px-3 py-3 text-left transition-colors ${ringFocusClasses({ tone: 'accent-fg', width: 2 })}
-                    ${selected
-                      ? 'border-[var(--accent-30)] bg-[var(--accent-10)]'
-                      : 'border-transparent bg-transparent hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-surface)]'}`}
-                  aria-current=${selected ? 'page' : undefined}
-                  onClick=${() => openKeeperDetail(keeper)}
-                >
-                  <${KeeperBadge} id=${keeper.name} size="lg" variant="sigil" beat=${!isKeeperOffline(keeper) && !isKeeperPaused(keeper)} />
-                  <span class="min-w-0 flex-1">
-                    <span class="flex min-w-0 items-center gap-2">
-                      <span class="truncate text-sm font-semibold text-[var(--color-fg-secondary)]">${keeper.koreanName ?? keeper.name}</span>
-                      <${StatusDot} size="xs" class=${keeperDotClass(keeper)} ariaLabel=${monitoring.band.label} />
-                    </span>
-                    <span class="mt-1 flex min-w-0 items-center gap-1.5 text-3xs text-[var(--color-fg-muted)]">
-                      <span class="truncate">${monitoring.phase.label}</span>
-                      <span aria-hidden="true">·</span>
-                      <span class="truncate">${keeper.name}</span>
-                    </span>
-                    <span class="mt-1 block truncate text-3xs text-[var(--color-fg-muted)]" title=${work}>${work}</span>
-                  </span>
-                  <span class="shrink-0 text-3xs tabular-nums text-[var(--color-fg-disabled)]">
-                    ${activity.timestamp
-                      ? html`<${TimeAgo} timestamp=${activity.timestamp} />`
-                      : activity.ageSeconds != null
-                        ? `${Math.round(activity.ageSeconds / 60)}m`
-                        : '—'}
-                  </span>
-                </button>
-              `
-            })}
-      </div>
-    </aside>
-  `
-}
-
-export function KeeperContextRail({ keeper }: { keeper: Keeper }) {
-  const monitoring = summarizeKeeperMonitoring(keeper)
-  const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
-  const context = keeperContextMeta(keeper)
-  const recentTools = [
-    ...(keeper.recent_tool_names ?? []),
-    ...(keeper.latest_tool_names ?? []),
-  ].filter((name, index, arr) => name.trim() !== '' && arr.indexOf(name) === index)
-  const goalProgress = keeper.goal_progress
-  const ownedTaskParts = [
-    goalProgress?.open_task_count != null ? `열림 ${goalProgress.open_task_count}` : null,
-    goalProgress?.done_task_count != null ? `완료 ${goalProgress.done_task_count}` : null,
-    (goalProgress?.blocked_task_count ?? keeper.blocked_task_count) != null
-      ? `차단 ${goalProgress?.blocked_task_count ?? keeper.blocked_task_count}`
-      : null,
-  ].filter((part): part is string => part !== null)
-
-  return html`
-    <aside class="keeper-detail-context-rail hidden min-h-0 flex-col gap-4 rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] p-4 shadow-none 2xl:flex 2xl:sticky 2xl:top-[calc(var(--header-h)+0.75rem)] 2xl:max-h-[calc(100svh-var(--header-h)-1.5rem)] 2xl:overflow-y-auto custom-scrollbar" aria-label="선택한 Keeper 상태">
-      <section class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
-        <div class="flex items-start justify-between gap-3">
-          <div class="min-w-0">
-            <div class="text-3xs font-semibold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-muted)]">현재 Keeper</div>
-            <h3 class="m-0 mt-1 truncate text-lg font-semibold text-[var(--color-fg-primary)]">${keeper.koreanName ?? keeper.name}</h3>
-            <div class="mt-1 truncate text-2xs font-mono text-[var(--color-fg-muted)]">${keeper.name}</div>
-          </div>
-          <${KeeperBadge} id=${keeper.name} size="lg" variant="sigil" beat=${!isKeeperOffline(keeper) && !isKeeperPaused(keeper)} />
-        </div>
-        <div class="mt-4 flex flex-wrap gap-2">
-          <${AgentPresence} status=${keeper.status} detail=${monitoring.phase.label} size="sm" />
-          <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-3xs text-[var(--color-fg-muted)]">${monitoring.band.label}</span>
-        </div>
-      </section>
-
-      <section class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
-        <div class="grid grid-cols-2 gap-3">
-          <div>
-            <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">모델</div>
-            <div class="mt-1 break-words text-xs font-semibold text-[var(--color-fg-primary)]">${keeperModelLabel(keeper)}</div>
-          </div>
-          <div>
-            <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">런타임</div>
-            <div class="mt-1 break-words text-xs font-semibold text-[var(--color-fg-primary)]">${keeperRuntimeLabel(keeper)}</div>
-          </div>
-          <div>
-            <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">턴</div>
-            <div class="mt-1 text-xs font-semibold text-[var(--color-fg-primary)]">${keeper.turn_count ?? keeper.total_turns ?? '—'}</div>
-          </div>
-          <div>
-            <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">최근 활동</div>
-            <div class="mt-1 text-xs font-semibold text-[var(--color-fg-primary)]">
-              ${activity.timestamp
-                ? html`<${TimeAgo} timestamp=${activity.timestamp} />`
-                : activity.ageSeconds != null
-                  ? `${Math.round(activity.ageSeconds / 60)}m 전`
-                  : '기록 없음'}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      ${context ? html`
-        <section class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
-          <div class="flex items-center justify-between gap-3">
-            <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">컨텍스트 점유</div>
-            <div class="text-sm font-semibold tabular-nums text-[var(--color-fg-primary)]">${context.pct}%</div>
-          </div>
-          <div class="mt-3 h-2 overflow-hidden rounded-[var(--r-0)] bg-[var(--color-bg-hover)]">
-            <div
-              class=${`h-full rounded-[var(--r-0)] ${context.pct > 85 ? 'bg-[var(--color-status-err)]' : context.pct > 62 ? 'bg-[var(--color-status-warn)]' : 'bg-[var(--color-status-ok)]'}`}
-              style=${`width:${context.pct}%`}
-            ></div>
-          </div>
-          ${context.detail ? html`<div class="mt-2 text-3xs font-mono text-[var(--color-fg-muted)]">${context.detail}</div>` : null}
-        </section>
-      ` : null}
-
-      <section class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
-        <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">소유 태스크</div>
-        <div class="mt-2 text-xs leading-relaxed text-[var(--color-fg-primary)]">
-          ${ownedTaskParts.length > 0 ? ownedTaskParts.join(' · ') : '태스크 집계 없음'}
-        </div>
-        ${keeper.short_goal || keeper.goal
-          ? html`<p class="m-0 mt-3 text-xs leading-relaxed text-[var(--color-fg-secondary)]">${keeper.short_goal ?? keeper.goal}</p>`
-          : null}
-      </section>
-
-      <section class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
-        <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">최근 도구 호출</div>
-        <div class="mt-3 flex flex-col gap-2">
-          ${recentTools.length > 0
-            ? recentTools.slice(0, 5).map(tool => html`
-                <div class="flex min-w-0 items-center gap-2 text-xs text-[var(--color-fg-primary)]">
-                  <${StatusDot} size="xs" class="bg-[var(--color-status-ok)]" />
-                  <span class="truncate font-mono">${tool}</span>
-                </div>
-              `)
-            : html`<div class="text-xs text-[var(--color-fg-muted)]">최근 도구 호출 없음</div>`}
-        </div>
-      </section>
-    </aside>
-  `
-}
 
 // Removed `KeeperRouteFocusPanel` (2026-05-19): the panel duplicated the
 // sticky page header (`KeeperDetailHeaderInfo`) — same keeper name and
@@ -341,7 +67,20 @@ export function KeeperDetailPage() {
     keepers.value.length,
   )
   if (!keeper) {
-    return html`<${KeeperDetailMissingState} keeperName=${keeperName} onClose=${closeKeeperDetail} />`
+    // Keep the roster mounted so the operator can switch to a live keeper
+    // in place (a stale-watchdog kill or dead deep link must not strand the
+    // 3-pane shell). `data-detail="open"` drops the empty rail column and
+    // gives the missing-state card the full conversation span.
+    return html`
+      <div class="kw-grid" data-detail="open">
+        <${KeeperWorkspaceRoster} activeName=${keeperName} />
+        <div class="kw-detail">
+          <div class="kw-detail-scroll">
+            <${KeeperDetailMissingState} keeperName=${keeperName} onClose=${closeKeeperDetail} />
+          </div>
+        </div>
+      </div>
+    `
   }
 
   const titleId = `keeper-detail-title-${keeper.name}`
@@ -354,6 +93,9 @@ export function KeeperDetailPage() {
   const [clearPending, setClearPending] = useState(false)
   const [purgePending, setPurgePending] = useState(false)
   const [checkpointRefreshToken, setCheckpointRefreshToken] = useState(0)
+  // 3-pane workspace is the default conversation view; "상세 보기" flips to
+  // the full tabbed KeeperDetailBody (FSM / 진단 / 정체성 / 설정 / 디버그).
+  const [detailOpen, setDetailOpen] = useState(false)
   // Latest transition's wall_clock_at_decision, in unix seconds.  Used by
   // the header KeeperPhaseAndStage to render "현재 phase에 머문 시간" without
   // requiring a new backend field — derivation is plan-approved trade-off.
@@ -374,6 +116,7 @@ export function KeeperDetailPage() {
     prevKeeperRef.current = keeper.name
     setDiagOpen(shouldOpenDiagnostics)
     setPhaseEnteredAtSec(null)
+    setDetailOpen(false)
   }
   useEffect(() => {
     selectedKeeper.value = keeper
@@ -468,69 +211,112 @@ export function KeeperDetailPage() {
     })()
   }
 
-  return html`
-    <div class="keeper-detail-v2-shell mx-auto grid w-full max-w-[1760px] grid-cols-1 gap-4 pb-8 xl:grid-cols-[minmax(17rem,20rem)_minmax(0,1fr)] 2xl:grid-cols-[minmax(17rem,20rem)_minmax(0,1fr)_minmax(18rem,21rem)]" data-route-focused-keeper=${keeper.name}>
-      <${KeeperDetailRosterRail} activeKeeperName=${keeper.name} />
-
-      <main class="flex min-w-0 flex-col gap-5">
-        <div class="sm:sticky sm:top-0 z-20 w-full overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] shadow-none backdrop-blur-xl">
-          <div class="flex flex-col items-stretch justify-between gap-3 px-4 py-2.5 sm:flex-row sm:items-center sm:px-5">
-            <${KeeperDetailHeaderInfo}
-              keeper=${keeper}
-              titleId=${titleId}
-              phaseEnteredAtSec=${phaseEnteredAtSec}
-              onClose=${closeKeeperDetail}
-            />
-            <div class="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
-              <button
-                type="button"
-                class="py-1 px-3 rounded-[var(--r-1)] text-2xs font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] transition-colors"
-                onClick=${() => setClearDialogOpen(true)}
-              >비우기</button>
-              <button
-                type="button"
-                disabled=${purgePending}
-                class="py-1 px-3 rounded-[var(--r-1)] text-2xs font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                onClick=${submitPurgeKeeper}
-              >${purgePending ? '삭제 중...' : '완전 삭제'}</button>
-              <${KeeperLifecycleButtons} keeper=${keeper} effectiveStatus=${effectiveStatus} />
-              <button
-                type="button"
-                onClick=${() => closeKeeperDetail()}
-                class=${`flex items-center justify-center size-8 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)] transition-colors cursor-pointer text-sm ${CLOSE_BUTTON_FOCUS_CLASS}`}
-                aria-label="키퍼 상세 종료"
-              >
-                <svg aria-hidden="true" width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg>
-              </button>
-            </div>
+  // Full tabbed detail (FSM / 진단 / 정체성 / 설정 / 디버그) — the original
+  // detail-page layout, preserved verbatim and surfaced behind "상세 보기".
+  const detailContent = html`
+    <div class="mx-auto flex w-full max-w-[1380px] flex-col gap-5 pb-8" data-route-focused-keeper=${keeper.name}>
+      <div class="sm:sticky sm:top-0 z-20 mx-auto w-full max-w-[1180px] overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] shadow-none backdrop-blur-xl">
+        <div class="flex flex-col items-stretch justify-between gap-3 px-4 py-2.5 sm:flex-row sm:items-center sm:px-5">
+          <${KeeperDetailHeaderInfo}
+            keeper=${keeper}
+            titleId=${titleId}
+            phaseEnteredAtSec=${phaseEnteredAtSec}
+            onClose=${() => setDetailOpen(false)}
+          />
+          <div class="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
+            <button
+              type="button"
+              class="py-1 px-3 rounded-[var(--r-1)] text-2xs font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] transition-colors"
+              onClick=${() => setClearDialogOpen(true)}
+            >비우기</button>
+            <button
+              type="button"
+              disabled=${purgePending}
+              class="py-1 px-3 rounded-[var(--r-1)] text-2xs font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick=${submitPurgeKeeper}
+            >${purgePending ? '삭제 중...' : '완전 삭제'}</button>
+            <${KeeperLifecycleButtons} keeper=${keeper} effectiveStatus=${effectiveStatus} />
+            <button
+              type="button"
+              onClick=${() => closeKeeperDetail()}
+              class=${`flex items-center justify-center size-8 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)] transition-colors cursor-pointer text-sm ${CLOSE_BUTTON_FOCUS_CLASS}`}
+              aria-label="키퍼 상세 종료"
+            >
+              <svg aria-hidden="true" width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg>
+            </button>
           </div>
         </div>
+      </div>
 
-        <${KeeperDetailBody}
-          keeper=${keeper}
-          compositeSnapshot=${compositeSnapshot}
-          runtimeTrace=${runtimeTrace}
-          compositeEvidence=${compositeEvidence}
-          runtimeTraceEvidence=${runtimeTraceEvidence}
-          diagOpen=${diagOpen}
-          onDiagToggle=${setDiagOpen}
-          checkpointRefreshToken=${checkpointRefreshToken}
-          clearDialogOpen=${clearDialogOpen}
-          clearPending=${clearPending}
-          clearReason=${clearReason}
+      <${KeeperDetailBody}
+        keeper=${keeper}
+        compositeSnapshot=${compositeSnapshot}
+        runtimeTrace=${runtimeTrace}
+        compositeEvidence=${compositeEvidence}
+        runtimeTraceEvidence=${runtimeTraceEvidence}
+        diagOpen=${diagOpen}
+        onDiagToggle=${setDiagOpen}
+        checkpointRefreshToken=${checkpointRefreshToken}
+        clearDialogOpen=${clearDialogOpen}
+        clearPending=${clearPending}
+        clearReason=${clearReason}
+        preserveSystemPrompt=${preserveSystemPrompt}
+        onClearClose=${() => {
+          if (clearPending) return
+          setClearDialogOpen(false)
+        }}
+        onClearReasonInput=${setClearReason}
+        onPreserveToggle=${setPreserveSystemPrompt}
+        onClearSubmit=${submitClearContext}
+        onSocialSweep=${() => { void runSocialSweep() }}
+      />
+    </div>
+  `
+
+  return html`
+    <div class="kw-grid" data-detail=${detailOpen ? 'open' : 'closed'} data-route-focused-keeper=${keeper.name}>
+      <${KeeperWorkspaceRoster} activeName=${keeper.name} />
+      ${detailOpen
+        ? html`
+            <div class="kw-detail">
+              <div class="kw-detail-head">
+                <button type="button" class="kw-act" onClick=${() => setDetailOpen(false)}>← 대화로</button>
+                <strong class="text-sm font-semibold text-[var(--color-fg-primary)]">${keeper.name} · 상세</strong>
+                <span class="flex-1"></span>
+                <button
+                  type="button"
+                  class=${`kw-act ${CLOSE_BUTTON_FOCUS_CLASS}`}
+                  onClick=${() => closeKeeperDetail()}
+                >← Keepers</button>
+              </div>
+              <div class="kw-detail-scroll">${detailContent}</div>
+            </div>
+          `
+        : html`
+            <${KeeperWorkspaceChat}
+              keeper=${keeper}
+              detailOpen=${false}
+              onToggleDetail=${() => setDetailOpen(true)}
+              onClear=${() => setClearDialogOpen(true)}
+            />
+            <${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => setDetailOpen(true)} />
+          `}
+    </div>
+    ${!detailOpen
+      ? html`<${KeeperClearContextDialog}
+          keeperName=${keeper.name}
+          open=${clearDialogOpen}
+          pending=${clearPending}
+          reason=${clearReason}
           preserveSystemPrompt=${preserveSystemPrompt}
-          onClearClose=${() => {
+          onClose=${() => {
             if (clearPending) return
             setClearDialogOpen(false)
           }}
-          onClearReasonInput=${setClearReason}
+          onReasonInput=${setClearReason}
           onPreserveToggle=${setPreserveSystemPrompt}
-          onClearSubmit=${submitClearContext}
-          onSocialSweep=${() => { void runSocialSweep() }}
-        />
-      </main>
-
-      <${KeeperContextRail} keeper=${keeper} />
-    </div>
+          onSubmit=${submitClearContext}
+        />`
+      : null}
   `
 }

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -330,18 +330,25 @@ describe('KeeperDetailPage', () => {
     keepers.value = [analyst]
 
     const { container } = render(html`<${KeeperDetailPage} />`)
-    expect(screen.getByRole('heading', { level: 2, name: 'analyst' })).toBeTruthy()
+    // 3-pane workspace renders (roster | conversation | context rail) without
+    // tripping the monitoring error boundary.
+    expect(container.querySelector('.kw-grid')).toBeTruthy()
+    expect(container.querySelector('.kw-roster')).toBeTruthy()
+    expect(container.querySelector('.kw-rail')).toBeTruthy()
+    // The keeper name appears in the roster row and the chat header.
+    expect(screen.getAllByText('analyst').length).toBeGreaterThanOrEqual(1)
+    // The reused chat engine is mounted in the conversation pane.
     expect(screen.getByText('direct chat analyst')).toBeTruthy()
+    // FSM Hub is detail-only, not in the default conversation view.
     expect(screen.queryByText('FSM Hub (6축 상태 머신)')).toBeNull()
-    const pageText = container.textContent ?? ''
-    expect(pageText.indexOf('대화 / 세션')).toBeGreaterThanOrEqual(0)
-    expect(pageText.indexOf('운영 상태 개요')).toBe(-1)
+    expect(mocks.selectKeeper).toHaveBeenCalledWith('analyst')
+
+    // "상세" flips to the full tabbed detail (KeeperDetailBody is reused).
+    fireEvent.click(screen.getByRole('button', { name: '상세' }))
     const statusTab = screen.getByRole('tab', { name: '상태' })
     fireEvent.click(statusTab)
     expect(statusTab.getAttribute('aria-selected')).toBe('true')
     expect(screen.getByText('운영 상태 개요')).toBeTruthy()
-    expect(screen.queryByText('대화 / 세션')).toBeNull()
-    expect(mocks.selectKeeper).toHaveBeenCalledWith('analyst')
   })
 
   // Removed test 'surfaces and clears keeper route focus...' (2026-05-19):

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -380,7 +380,7 @@ export function KeeperConversationPanel({
 }: {
   keeperName: string
   placeholder: string
-  layout?: 'default' | 'primary'
+  layout?: 'default' | 'primary' | 'workspace'
 }) {
   const [draft, setDraft] = useState('')
   const [showMetadata, setShowMetadata] = useState(readKeeperChatMetadataVisible())
@@ -535,6 +535,126 @@ export function KeeperConversationPanel({
   const cancelQueue = () => {
     clearInputQueue(keeperName)
     bumpQueue()
+  }
+
+  if (layout === 'workspace') {
+    // 3-pane workspace: identity + lifecycle live in the ChatHeader above
+    // this panel, so the workspace layout drops the panel's own header and
+    // renders just the spacious thread + composer. All chat state/handlers
+    // (draft, queue, attachments, streaming, search, toggles) are reused
+    // unchanged — only the chrome differs. Spacing comes from keeper-workspace.css.
+    return html`
+      <div
+        class="flex min-h-0 flex-1 flex-col"
+        data-keeper-chat-layout="workspace"
+        onPaste=${handlePaste}
+      >
+        <div class="kw-chat-toolbar">
+          <${TextInput}
+            class="max-w-50"
+            name="keeper_chat_search"
+            ariaLabel="대화 내용 검색"
+            autoComplete="off"
+            placeholder="대화 검색..."
+            value=${searchQuery}
+            onInput=${(e: Event) => { setSearchQuery((e.target as HTMLInputElement).value) }}
+          />
+          ${hasQuery
+            ? html`<span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 text-2xs font-medium text-[var(--color-fg-secondary)]" data-chat-search-count>
+                ${transcriptEntries.length} / ${visibleThread.length}
+              </span>`
+            : null}
+          <span class="spacer"></span>
+          <${GhostButton} onClick=${toggleMetadata} ariaExpanded=${showMetadata}>
+            ${showMetadata ? '메타데이터 숨김' : '메타데이터'}
+          <//>
+          <${GhostButton}
+            onClick=${toggleInternal}
+            ariaExpanded=${showInternal}
+            class=${showInternal ? 'border-[var(--info-border)] text-[var(--info-fg)]' : ''}
+          >
+            ${showInternal ? '내부 숨김' : '내부 메시지'}
+          </${GhostButton}>
+          ${!historyExpanded
+            ? html`
+                <${GhostButton} disabled=${hydrating} onClick=${() => { void expandHistory() }}>
+                  ${hydrating
+                    ? '불러오는 중...'
+                    : rawThread.length === 0
+                      ? '이력 불러오기'
+                      : `전체 이력 (${thread.length})`}
+                <//>
+              `
+            : null}
+        </div>
+
+        ${chatAccess.message
+          ? html`
+              <div class="mx-10 mt-3 rounded-[var(--r-2)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-xs leading-loose text-[var(--warn-bright)]">
+                ${chatAccess.message}
+              </div>
+            `
+          : null}
+
+        <div class="kw-thread">
+          <div class="kw-thread-inner">
+            <${ChatTranscript}
+              entries=${transcriptEntries}
+              emptyText=${transcriptEmptyText}
+              showMetadata=${showMetadata}
+              variant="messenger"
+              size="primary"
+            />
+          </div>
+        </div>
+
+        ${!showInternal && hiddenCount > 0
+          ? html`
+              <div class="mx-10 mb-2 rounded-[var(--r-2)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs leading-paragraph text-[var(--warn-bright)]">
+                ${hiddenCount}개의 내부 메시지가 숨겨져 있습니다. "내부 메시지"로 볼 수 있습니다.
+              </div>
+            `
+          : null}
+
+        <div class="kw-composer-wrap">
+          <div class="kw-composer-inner">
+            ${queueCount > 0
+              ? html`
+                  <div class="mb-2 flex items-center gap-2 text-2xs text-[var(--color-fg-muted)]" data-chat-queue-row>
+                    <span>${queueCount}개 메시지 대기 중</span>
+                    <button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>모두 취소</button>
+                  </div>
+                `
+              : null}
+            <${AttachmentChips} attachments=${selectedAttachments} onRemove=${removeAttachment} />
+            <div class="flex items-end gap-2">
+              <${AttachButton} disabled=${composerDisabled} onFiles=${(files: FileList | null) => { void addFiles(files) }} />
+              <div class="min-w-0 flex-1">
+                <${ChatComposer}
+                  draft=${draft}
+                  placeholder=${chatAccess.blocked
+                    ? '현재 actor는 direct keeper chat 권한이 없습니다'
+                    : sending
+                      ? '응답 중 — 지금 보내면 대기열에 추가됩니다'
+                      : placeholder}
+                  disabled=${composerDisabled}
+                  streaming=${sending}
+                  streamStartedAt=${streamStartedAt}
+                  lastEventAt=${lastSignalAt}
+                  queueEnabled=${true}
+                  queueCount=${queueCount}
+                  onDraftChange=${setDraft}
+                  onSend=${() => { void submit() }}
+                  onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
+                  layout="primary"
+                />
+              </div>
+            </div>
+            ${error ? html`<div class="mt-2 text-xs text-[var(--bad-light)] leading-relaxed">${error}</div>` : null}
+          </div>
+        </div>
+      </div>
+    `
   }
 
   if (layout === 'primary') {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -1,0 +1,117 @@
+// Keeper Workspace — conversation pane (center). A spacious ChatHeader
+// (identity + lifecycle actions) above the reused KeeperConversationPanel
+// (layout="workspace"). The header replaces the old narrow detail-page
+// header; the panel reuses the full chat engine unchanged.
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+import type { Keeper } from '../../types'
+import { KeeperConversationPanel } from '../keeper-shared'
+import { KeeperLifecycleButtons } from '../keeper-detail-lifecycle'
+import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
+import {
+  WorkspaceSigil,
+  StatusDot,
+  keeperBucket,
+  bucketDotTone,
+  keeperPhaseLabel,
+  statePillTone,
+  keeperModelLabel,
+  keeperRuntimeLabel,
+} from './keeper-workspace-shared'
+
+/** Latest per-turn throughput from the metrics series (no scalar field). */
+function latestTps(keeper: Keeper): number | null {
+  const series = keeper.metrics_series ?? []
+  for (let i = series.length - 1; i >= 0; i -= 1) {
+    const v = series[i]?.wall_tokens_per_second
+    if (typeof v === 'number' && v > 0) return Math.round(v)
+  }
+  return null
+}
+
+function keeperScope(keeper: Keeper): string | null {
+  return keeper.skill_primary ?? null
+}
+
+function ChatHeader({
+  keeper,
+  detailOpen,
+  onToggleDetail,
+  onClear,
+}: {
+  keeper: Keeper
+  detailOpen: boolean
+  onToggleDetail: () => void
+  onClear: () => void
+}): VNode {
+  const bucket = keeperBucket(keeper)
+  const tone = bucketDotTone(bucket)
+  const pill = statePillTone(bucket)
+  const model = keeperModelLabel(keeper)
+  const runtime = keeperRuntimeLabel(keeper)
+  const scope = keeperScope(keeper)
+  const tps = latestTps(keeper)
+  const live = bucket === 'running'
+
+  return html`
+    <div class="kw-chat-head">
+      <${WorkspaceSigil} id=${keeper.name} size=${46} beat=${live} />
+      <div class="kw-chat-id">
+        <div class="kw-chat-name-row">
+          <h2 class="kw-chat-name">${keeper.koreanName ?? keeper.name}</h2>
+          <span class=${`kw-state-pill ${pill}`} title=${keeperDisplayStatus(keeper)}>
+            <${StatusDot} tone=${tone} pulse=${live} />${keeperPhaseLabel(keeper)}
+          </span>
+        </div>
+        <div class="kw-chat-sub">
+          ${scope ? html`<span><span class="k">scope</span><span class="mono">${scope}</span></span>` : null}
+          ${model ? html`<span><span class="k">모델</span><span class="mono">${model}</span></span>` : null}
+          ${runtime ? html`<span><span class="k">런타임</span><span class="mono">${runtime}</span></span>` : null}
+          ${live && tps !== null
+            ? html`<span class="kw-tps-live"><span class="kw-tps-dot"></span><span class="k">tok/s</span><span class="mono">${tps}</span></span>`
+            : null}
+        </div>
+      </div>
+      <div class="kw-chat-actions">
+        <${KeeperLifecycleButtons} keeper=${keeper} effectiveStatus=${keeperDisplayStatus(keeper)} />
+        <button type="button" class="kw-act danger" title="컨텍스트 비우기" onClick=${onClear}>비우기</button>
+        <button
+          type="button"
+          class="kw-act"
+          aria-pressed=${detailOpen ? 'true' : 'false'}
+          title="상세 (상태 · 진단 · 정체성 · 설정 · 디버그)"
+          onClick=${onToggleDetail}
+        >${detailOpen ? '대화로' : '상세'}</button>
+      </div>
+    </div>
+  `
+}
+
+export function KeeperWorkspaceChat({
+  keeper,
+  detailOpen,
+  onToggleDetail,
+  onClear,
+}: {
+  keeper: Keeper
+  detailOpen: boolean
+  onToggleDetail: () => void
+  onClear: () => void
+}): VNode {
+  return html`
+    <section class="kw-chat" role="region" aria-label=${`${keeper.name} 대화`}>
+      <${ChatHeader}
+        keeper=${keeper}
+        detailOpen=${detailOpen}
+        onToggleDetail=${onToggleDetail}
+        onClear=${onClear}
+      />
+      <${KeeperConversationPanel}
+        keeperName=${keeper.name}
+        placeholder=${`${keeper.name} 에게 메시지…  (⌘+Enter 전송)`}
+        layout="workspace"
+      />
+    </section>
+  `
+}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -1,0 +1,99 @@
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { tasks } from '../../store'
+import { KeeperWorkspaceRail } from './keeper-workspace-rail'
+import type { Keeper, Task } from '../../types'
+
+function mkKeeper(partial: Partial<Keeper>): Keeper {
+  return { name: 'masc-improver', status: 'running', ...partial } as Keeper
+}
+function mkTask(partial: Partial<Task>): Task {
+  return { id: 'T-0', title: 'task', ...partial } as Task
+}
+
+let host: HTMLElement
+
+beforeEach(() => {
+  tasks.value = [
+    mkTask({ id: 'T-4412', title: '세그먼트 리텐션 대시보드', status: 'in_progress', assignee: 'masc-improver' }),
+    mkTask({ id: 'T-9999', title: '남의 태스크', status: 'todo', assignee: 'someone-else' }),
+  ]
+  host = document.createElement('div')
+  document.body.appendChild(host)
+})
+
+afterEach(() => {
+  render(null, host)
+  host.remove()
+  tasks.value = []
+})
+
+describe('KeeperWorkspaceRail', () => {
+  const keeper = mkKeeper({
+    active_model_label: 'sonnet-4.6',
+    runtime_canonical: 'oas·seoul-1',
+    context_ratio: 0.62,
+    context_tokens: 124000,
+    context_max: 200000,
+    recent_tool_names: ['masc_amplitude_query', 'masc_board_metrics'],
+  })
+
+  it('renders the runtime / throughput vitals', () => {
+    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
+    expect(host.textContent).toContain('런타임 · 처리량')
+    expect(host.textContent).toContain('sonnet-4.6')
+    expect(host.textContent).toContain('oas·seoul-1')
+  })
+
+  it('renders the context-window occupancy percent', () => {
+    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
+    expect(host.textContent).toContain('컨텍스트 점유')
+    expect(host.textContent).toContain('62%')
+    expect(host.textContent).toContain('124.0k')
+  })
+
+  it('lists only the keeper-owned tasks', () => {
+    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
+    expect(host.textContent).toContain('T-4412')
+    expect(host.textContent).not.toContain('T-9999')
+  })
+
+  it('renders recent tool calls', () => {
+    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
+    expect(host.textContent).toContain('최근 도구 호출')
+    expect(host.textContent).toContain('masc_amplitude_query')
+  })
+
+  it('renders the attention section from live blocked-task signal', () => {
+    const k = mkKeeper({ blocked_task_count: 2 })
+    render(html`<${KeeperWorkspaceRail} keeper=${k} onToggleDetail=${() => {}} />`, host)
+    expect(host.textContent).toContain('주의')
+    expect(host.textContent).toContain('차단된 태스크 2건')
+  })
+
+  it('omits the attention section when there is nothing to surface', () => {
+    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
+    expect(host.textContent).not.toContain('차단된 태스크')
+  })
+
+  it('renders the auto-compact threshold label', () => {
+    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
+    expect(host.textContent).toContain('compact 85%')
+  })
+
+  it('fires onToggleDetail from the 상세 보기 button', () => {
+    const onToggle = vi.fn()
+    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${onToggle} />`, host)
+    const btn = host.querySelector('.kw-detail-btn') as HTMLElement
+    expect(btn).toBeTruthy()
+    btn.click()
+    expect(onToggle).toHaveBeenCalled()
+  })
+
+  it('shows the empty state when no tasks are owned', () => {
+    tasks.value = []
+    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
+    expect(host.textContent).toContain('할당된 태스크 없음')
+  })
+})

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -1,0 +1,197 @@
+// Keeper Workspace — context rail (right). Runtime/throughput, context-window
+// occupancy, owned tasks, recent tool calls, and the "상세 보기" toggle that
+// surfaces the full KeeperDetailBody. All data comes from the live Keeper
+// object + the tasks store — no new fetches.
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+import { tasks } from '../../store'
+import type { Keeper, Task } from '../../types'
+import { keeperModelLabel, keeperRuntimeLabel } from './keeper-workspace-shared'
+
+const COMPACT_AT = 85 // auto-compaction threshold (%) — matches runtime default
+
+function contextPercent(keeper: Keeper): number {
+  const ratio = keeper.context_ratio ?? keeper.context?.context_ratio ?? 0
+  return Math.max(0, Math.min(100, Math.round(ratio * 100)))
+}
+
+function formatK(n: number | null | undefined): string | null {
+  if (typeof n !== 'number') return null
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`
+}
+
+/** Newest-last per-turn throughput series for the rail sparkline. */
+function tpsSeries(keeper: Keeper): number[] {
+  return (keeper.metrics_series ?? [])
+    .map(p => (typeof p.wall_tokens_per_second === 'number' ? Math.max(0, p.wall_tokens_per_second) : 0))
+    .slice(-24)
+}
+
+function ownedTasks(keeper: Keeper): Task[] {
+  return tasks.value.filter(t => t.assignee === keeper.name || (keeper.agent_name != null && t.assignee === keeper.agent_name))
+}
+
+function taskStateClass(status: Task['status']): string {
+  if (status === 'awaiting_verification') return 'review'
+  return ''
+}
+
+type AttentionItem = { sev: 'bad' | 'warn'; text: string }
+
+/** Attention items from the same live signals the roster badge counts
+ *  (blocked tasks + explicit flag). No fabricated severities — the section
+ *  is omitted entirely when there is nothing to surface. */
+function attentionItems(keeper: Keeper): AttentionItem[] {
+  const items: AttentionItem[] = []
+  const blocked = keeper.blocked_task_count ?? 0
+  if (blocked > 0) items.push({ sev: 'bad', text: `차단된 태스크 ${blocked}건` })
+  const awaiting = ownedTasks(keeper).filter(t => t.status === 'awaiting_verification')
+  if (awaiting.length > 0) items.push({ sev: 'warn', text: `검증 대기 ${awaiting.length}건` })
+  if (items.length === 0 && keeper.needs_attention === true) {
+    items.push({ sev: 'warn', text: '점검이 필요합니다' })
+  }
+  return items
+}
+
+function AttentionSection({ keeper }: { keeper: Keeper }): VNode | null {
+  const items = attentionItems(keeper)
+  if (items.length === 0) return null
+  return html`
+    <div class="kw-sec">
+      <h4>주의 <span class="kw-kp-att">${items.length}</span></h4>
+      <div class="kw-att-list">
+        ${items.map((it, i) => html`
+          <div class=${`kw-att-item ${it.sev}`} key=${`${it.text}-${i}`}>
+            <span class="kw-att-dot" aria-hidden="true"></span>
+            <span class="kw-att-text" title=${it.text}>${it.text}</span>
+          </div>
+        `)}
+      </div>
+    </div>
+  `
+}
+
+function ContextSection({ keeper }: { keeper: Keeper }): VNode {
+  const pct = contextPercent(keeper)
+  const hot = pct >= COMPACT_AT
+  const tokens = formatK(keeper.context_tokens ?? keeper.context?.context_tokens ?? null)
+  const max = formatK(keeper.context_max ?? keeper.context?.context_max ?? null)
+  return html`
+    <div class="kw-sec">
+      <h4>컨텍스트 점유</h4>
+      <div class="kw-card">
+        <div class="flex items-baseline justify-between">
+          <span class="text-xs text-[var(--color-fg-secondary)]">윈도우 사용량</span>
+          <span class=${`font-mono text-sm ${hot ? 'text-[var(--color-status-err)]' : 'text-[var(--color-accent-fg)]'}`}>${pct}%</span>
+        </div>
+        <div class="kw-meter-wrap">
+          <div class=${`kw-meter${hot ? ' hot' : ''}`}><span style=${{ width: `${pct}%` }}></span></div>
+          <span class="kw-meter-mark" style=${{ left: `${COMPACT_AT}%` }} title=${`자동 compact 임계치 ${COMPACT_AT}%`}>
+            <i class="kw-meter-mark-lbl">compact ${COMPACT_AT}%</i>
+          </span>
+        </div>
+        ${tokens || max
+          ? html`<div class="kw-ctx-tok">
+              <span class="mono">${tokens ?? '—'}</span>
+              <span aria-hidden="true">/</span>
+              <span class="mono">${max ?? '—'}</span>
+              <span class="lbl">사용 / 전체 윈도우</span>
+            </div>`
+          : null}
+      </div>
+    </div>
+  `
+}
+
+function ThroughputSection({ keeper }: { keeper: Keeper }): VNode {
+  const model = keeperModelLabel(keeper)
+  const runtime = keeperRuntimeLabel(keeper)
+  const series = tpsSeries(keeper)
+  const peak = Math.max(1, ...series)
+  const latest = series.length ? series[series.length - 1] : 0
+  return html`
+    <div class="kw-sec">
+      <h4>런타임 · 처리량</h4>
+      <div class="kw-vitals">
+        <div class="kw-vital"><div class="vk">모델</div><div class="vv" title=${model ?? ''}>${model ?? '—'}</div></div>
+        <div class="kw-vital"><div class="vk">런타임</div><div class="vv" title=${runtime ?? ''}>${runtime ?? '—'}</div></div>
+      </div>
+      ${series.length >= 2
+        ? html`<div class="kw-card mt-2">
+            <div class="flex items-baseline justify-between">
+              <span class="font-mono text-base text-[var(--color-status-ok)]">${latest}</span>
+              <span class="text-2xs text-[var(--color-fg-muted)]">tok/s</span>
+            </div>
+            <div class="mt-2 flex h-7 items-end gap-0.5" aria-hidden="true">
+              ${series.map(v => html`<span class="flex-1 rounded-[1px] bg-[var(--color-status-ok)]" style=${{ height: `${Math.max(6, (v / peak) * 100)}%`, opacity: 0.35 + 0.65 * (v / peak) }}></span>`)}
+            </div>
+          </div>`
+        : null}
+    </div>
+  `
+}
+
+function OwnedTasksSection({ keeper }: { keeper: Keeper }): VNode {
+  const owned = ownedTasks(keeper)
+  return html`
+    <div class="kw-sec">
+      <h4>소유 태스크</h4>
+      <div class="kw-list">
+        ${owned.length
+          ? owned.map(t => html`
+              <div class="kw-tasktag" key=${t.id}>
+                <span class="tid">${t.id}</span>
+                <span class="ttl" title=${t.title}>${t.title}</span>
+                ${t.status ? html`<span class=${`tstate ${taskStateClass(t.status)}`}>${t.status}</span>` : null}
+              </div>
+            `)
+          : html`<div class="kw-list-empty">할당된 태스크 없음</div>`}
+      </div>
+    </div>
+  `
+}
+
+function RecentToolsSection({ keeper }: { keeper: Keeper }): VNode | null {
+  const names = (keeper.recent_tool_names ?? keeper.latest_tool_names ?? []).slice(0, 8)
+  if (names.length === 0) return null
+  return html`
+    <div class="kw-sec">
+      <h4>최근 도구 호출</h4>
+      <div class="kw-list">
+        ${names.map((n, i) => html`
+          <div class="kw-tool" key=${`${n}-${i}`}>
+            <span class="kw-dot ok" aria-hidden="true"></span>
+            <span class="nm" title=${n}>${n}</span>
+          </div>
+        `)}
+      </div>
+    </div>
+  `
+}
+
+export function KeeperWorkspaceRail({
+  keeper,
+  onToggleDetail,
+}: {
+  keeper: Keeper
+  onToggleDetail: () => void
+}): VNode {
+  return html`
+    <aside class="kw-rail" aria-label="키퍼 컨텍스트">
+      <div class="kw-rail-scroll">
+        <${AttentionSection} keeper=${keeper} />
+        <${ThroughputSection} keeper=${keeper} />
+        <${ContextSection} keeper=${keeper} />
+        <${OwnedTasksSection} keeper=${keeper} />
+        <${RecentToolsSection} keeper=${keeper} />
+        <div class="kw-sec">
+          <button type="button" class="kw-detail-btn" onClick=${onToggleDetail}>
+            <span>상세 보기</span>
+            <span class="sub">상태 · 진단 · 정체성 · 설정 →</span>
+          </button>
+        </div>
+      </div>
+    </aside>
+  `
+}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -1,0 +1,84 @@
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { fireEvent } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../router', async (orig) => ({
+  ...(await orig<typeof import('../../router')>()),
+  navigate: vi.fn(),
+}))
+
+import { navigate } from '../../router'
+import { keepers } from '../../store'
+import { KeeperWorkspaceRoster } from './keeper-workspace-roster'
+import type { Keeper } from '../../types'
+
+function mk(partial: Partial<Keeper>): Keeper {
+  return { name: 'k', status: 'running', ...partial } as Keeper
+}
+
+const FIXTURE: Keeper[] = [
+  mk({ name: 'masc-improver', status: 'running', lifecycle_phase: 'Running' }),
+  mk({ name: 'sangsu', status: 'running', paused: true, lifecycle_phase: 'Paused' }),
+  mk({ name: 'rama', status: 'stopped', lifecycle_phase: 'Stopped', needs_attention: true }),
+]
+
+let host: HTMLElement
+
+beforeEach(() => {
+  keepers.value = FIXTURE
+  vi.mocked(navigate).mockClear()
+  host = document.createElement('div')
+  document.body.appendChild(host)
+})
+
+afterEach(() => {
+  render(null, host)
+  host.remove()
+  keepers.value = []
+})
+
+describe('KeeperWorkspaceRoster', () => {
+  it('renders status groups with keeper rows', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    const groups = Array.from(host.querySelectorAll('.kw-roster-group')).map(g => g.textContent)
+    expect(groups).toContain('실행 중')
+    expect(groups).toContain('대기 · 일시정지')
+    expect(groups).toContain('중지 · 종료됨')
+    expect(host.querySelectorAll('.kw-kp-row').length).toBe(3)
+  })
+
+  it('marks the active keeper row', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    const active = host.querySelector('.kw-kp-row[aria-current="true"]') as HTMLElement
+    expect(active?.textContent).toContain('masc-improver')
+  })
+
+  it('shows filter chip counts (all / running / attention)', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    const chips = Array.from(host.querySelectorAll('.kw-rfilter')).map(c => c.textContent)
+    // 전체 3, 실행중 1 (only masc-improver), 주의 1 (rama)
+    expect(chips.some(c => c?.includes('전체') && c?.includes('3'))).toBe(true)
+    expect(chips.some(c => c?.includes('실행중') && c?.includes('1'))).toBe(true)
+    expect(chips.some(c => c?.includes('주의') && c?.includes('1'))).toBe(true)
+  })
+
+  it('navigates to the keeper route on row click', () => {
+    const onSelect = vi.fn()
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" onSelect=${onSelect} />`, host)
+    const rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
+    const sangsuRow = rows.find(r => r.textContent?.includes('sangsu'))
+    sangsuRow?.click()
+    expect(navigate).toHaveBeenCalledWith('monitoring', { section: 'agents', keeper: 'sangsu' })
+    expect(onSelect).toHaveBeenCalledWith('sangsu')
+  })
+
+  it('filters by search query', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    const search = host.querySelector('.kw-roster-search') as HTMLInputElement
+    fireEvent.input(search, { target: { value: 'rama' } })
+    const rows = host.querySelectorAll('.kw-kp-row')
+    expect(rows.length).toBe(1)
+    expect(rows[0]?.textContent).toContain('rama')
+  })
+})

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -1,0 +1,155 @@
+// Keeper Workspace — roster pane (left). Search + status filter chips +
+// status-grouped keeper rows. Ported from the v2 design (rails.jsx Roster),
+// wired to the live `keepers` store. Selecting a row routes to that keeper,
+// which swaps the conversation + rail panes (same route shape the detail
+// page already used, so deep links keep working).
+
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+import type { VNode } from 'preact'
+import { keepers } from '../../store'
+import { navigate } from '../../router'
+import { selectKeeper } from '../../keeper-runtime'
+import { keeperActivityDisplay } from '../../lib/keeper-runtime-display'
+import type { Keeper } from '../../types'
+import {
+  WorkspaceSigil,
+  StatusDot,
+  keeperBucket,
+  bucketDotTone,
+  keeperPhaseLabel,
+  type KeeperBucket,
+} from './keeper-workspace-shared'
+
+type RosterFilter = 'all' | 'run' | 'att'
+
+const GROUP_ORDER: { bucket: KeeperBucket; label: string }[] = [
+  { bucket: 'running', label: '실행 중' },
+  { bucket: 'paused', label: '대기 · 일시정지' },
+  { bucket: 'offline', label: '중지 · 종료됨' },
+]
+
+/** Blocked tasks + explicit attention flag → the roster attention badge. */
+function attentionCount(keeper: Keeper): number {
+  return keeper.blocked_task_count ?? 0
+}
+function needsAttention(keeper: Keeper): boolean {
+  return keeper.needs_attention === true || attentionCount(keeper) > 0
+}
+
+/** ns proxy: keepers have no namespace field; the skill path is the closest
+ *  real scope signal, with the model as fallback. */
+function keeperScope(keeper: Keeper): string | null {
+  return keeper.skill_primary ?? keeper.active_model ?? keeper.model ?? null
+}
+
+function matchesQuery(keeper: Keeper, q: string): boolean {
+  if (!q) return true
+  const hay = `${keeper.name} ${keeper.koreanName ?? ''} ${keeperScope(keeper) ?? ''} ${keeper.model ?? ''}`.toLowerCase()
+  return hay.includes(q.toLowerCase())
+}
+
+function RosterRow({ keeper, active, onSelect }: { keeper: Keeper; active: boolean; onSelect: (name: string) => void }) {
+  const bucket = keeperBucket(keeper)
+  const tone = bucketDotTone(bucket)
+  const att = attentionCount(keeper)
+  const scope = keeperScope(keeper)
+  const activity = keeperActivityDisplay(keeper)
+  return html`
+    <button
+      type="button"
+      class="kw-kp-row"
+      aria-current=${active ? 'true' : 'false'}
+      onClick=${() => onSelect(keeper.name)}
+    >
+      <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${bucket === 'running'} />
+      <div class="kw-kp-meta">
+        <div class="kw-kp-name">${keeper.koreanName ?? keeper.name}</div>
+        <div class="kw-kp-sub">
+          <span class="kw-kp-state"><${StatusDot} tone=${tone} pulse=${bucket === 'running'} />${keeperPhaseLabel(keeper)}</span>
+          ${scope ? html`<span aria-hidden="true">·</span><span class="kw-kp-handle">${scope}</span>` : null}
+        </div>
+      </div>
+      <div class="kw-kp-right">
+        ${activity.source !== 'none' ? html`<span class="kw-kp-time">${activity.label}</span>` : null}
+        ${att > 0 ? html`<span class="kw-kp-att" title=${`주의 ${att}건`}>${att}</span>` : null}
+      </div>
+    </button>
+  `
+}
+
+export function KeeperWorkspaceRoster({
+  activeName,
+  onSelect,
+}: {
+  activeName: string
+  onSelect?: (name: string) => void
+}): VNode {
+  const [query, setQuery] = useState('')
+  const [filter, setFilter] = useState<RosterFilter>('all')
+
+  const all = keepers.value
+  const counts = {
+    all: all.length,
+    run: all.filter(k => keeperBucket(k) === 'running').length,
+    att: all.filter(needsAttention).length,
+  }
+
+  const visible = all.filter(k => {
+    if (filter === 'run' && keeperBucket(k) !== 'running') return false
+    if (filter === 'att' && !needsAttention(k)) return false
+    return matchesQuery(k, query)
+  })
+
+  const select = (name: string) => {
+    selectKeeper(name)
+    navigate('monitoring', { section: 'agents', keeper: name })
+    onSelect?.(name)
+  }
+
+  const filterChips: { id: RosterFilter; label: string }[] = [
+    { id: 'all', label: '전체' },
+    { id: 'run', label: '실행중' },
+    { id: 'att', label: '주의' },
+  ]
+
+  return html`
+    <aside class="kw-roster" aria-label="키퍼 로스터">
+      <div class="kw-roster-head">
+        <input
+          class="kw-roster-search"
+          type="text"
+          placeholder="이름 · 스코프 검색…"
+          aria-label="키퍼 검색"
+          value=${query}
+          onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
+        />
+      </div>
+      <div class="kw-roster-filters" role="group" aria-label="상태 필터">
+        ${filterChips.map(chip => html`
+          <button
+            type="button"
+            class="kw-rfilter"
+            aria-pressed=${filter === chip.id ? 'true' : 'false'}
+            onClick=${() => setFilter(chip.id)}
+          >
+            ${chip.label}<span class="n">${counts[chip.id]}</span>
+          </button>
+        `)}
+      </div>
+      <div class="kw-roster-list">
+        ${GROUP_ORDER.map(group => {
+          const rows = visible.filter(k => keeperBucket(k) === group.bucket)
+          if (rows.length === 0) return null
+          return html`
+            <div>
+              <div class="kw-roster-group">${group.label}</div>
+              ${rows.map(k => html`<${RosterRow} key=${k.name} keeper=${k} active=${k.name === activeName} onSelect=${select} />`)}
+            </div>
+          `
+        })}
+        ${visible.length === 0 ? html`<div class="kw-roster-empty">일치하는 키퍼가 없습니다</div>` : null}
+      </div>
+    </aside>
+  `
+}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
@@ -1,0 +1,82 @@
+import { render } from 'preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  keeperBucket,
+  bucketDotTone,
+  statePillTone,
+  keeperModelLabel,
+  keeperRuntimeLabel,
+  keeperPhaseLabel,
+  WorkspaceSigil,
+} from './keeper-workspace-shared'
+import { html } from 'htm/preact'
+import type { Keeper } from '../../types'
+
+function mk(partial: Partial<Keeper>): Keeper {
+  return { name: 'k', status: 'running', ...partial } as Keeper
+}
+
+describe('keeperBucket', () => {
+  it('classifies a running keeper', () => {
+    expect(keeperBucket(mk({ status: 'running' }))).toBe('running')
+  })
+  it('classifies a paused keeper from the paused flag', () => {
+    expect(keeperBucket(mk({ status: 'running', paused: true }))).toBe('paused')
+  })
+  it('classifies a stopped keeper as offline', () => {
+    expect(keeperBucket(mk({ status: 'stopped' }))).toBe('offline')
+  })
+})
+
+describe('bucketDotTone / statePillTone', () => {
+  it('maps buckets to dot tones', () => {
+    expect(bucketDotTone('running')).toBe('ok')
+    expect(bucketDotTone('paused')).toBe('warn')
+    expect(bucketDotTone('offline')).toBe('idle')
+  })
+  it('maps buckets to pill tones', () => {
+    expect(statePillTone('running')).toBe('run')
+    expect(statePillTone('paused')).toBe('warn')
+    expect(statePillTone('offline')).toBe('off')
+  })
+})
+
+describe('keeperModelLabel', () => {
+  it('prefers active_model_label, then active_model, then model', () => {
+    expect(keeperModelLabel(mk({ active_model_label: 'A', active_model: 'B', model: 'C' }))).toBe('A')
+    expect(keeperModelLabel(mk({ active_model: 'B', model: 'C' }))).toBe('B')
+    expect(keeperModelLabel(mk({ model: 'C' }))).toBe('C')
+    expect(keeperModelLabel(mk({}))).toBeNull()
+  })
+})
+
+describe('keeperRuntimeLabel', () => {
+  it('prefers runtime_canonical then selected_runtime_canonical', () => {
+    expect(keeperRuntimeLabel(mk({ runtime_canonical: 'oas·seoul-1' }))).toBe('oas·seoul-1')
+    expect(keeperRuntimeLabel(mk({ selected_runtime_canonical: 'local·docker' }))).toBe('local·docker')
+    expect(keeperRuntimeLabel(mk({}))).toBeNull()
+  })
+})
+
+describe('keeperPhaseLabel', () => {
+  it('prefers the typed lifecycle phase', () => {
+    expect(keeperPhaseLabel(mk({ lifecycle_phase: 'Running' }))).toBe('Running')
+    expect(keeperPhaseLabel(mk({ phase: 'Compacting' }))).toBe('Compacting')
+  })
+})
+
+describe('WorkspaceSigil', () => {
+  let host: HTMLElement
+  afterEach(() => {
+    if (host) render(null, host)
+  })
+  it('renders the 2-letter sigil with the keeper color slot', () => {
+    host = document.createElement('div')
+    render(html`<${WorkspaceSigil} id="masc-improver" size=${46} />`, host)
+    const el = host.querySelector('.kw-sigil') as HTMLElement
+    expect(el).toBeTruthy()
+    expect(el.textContent).toBe('MS') // canonical sigil for masc-improver
+    expect(el.style.background).toContain('--color-keeper-6') // canonical slot 6
+    expect(el.style.width).toBe('46px')
+  })
+})

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -1,0 +1,86 @@
+// Keeper Workspace — shared presentational helpers (sigil avatar, status dot,
+// phase/group derivation). Kept separate so the roster + chat header + rail
+// agree on a single status vocabulary instead of each re-deriving it.
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+import { kSlot, kSigil } from '../keeper-badge'
+import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
+import { isKeeperOffline, isKeeperPaused } from '../../lib/keeper-predicates'
+import type { Keeper } from '../../types'
+
+/** Coarse lifecycle bucket used both for the dot tone and roster grouping. */
+export type KeeperBucket = 'running' | 'paused' | 'offline'
+
+export function keeperBucket(keeper: Keeper): KeeperBucket {
+  if (isKeeperOffline(keeper)) return 'offline'
+  if (isKeeperPaused(keeper)) return 'paused'
+  return 'running'
+}
+
+export type DotTone = 'ok' | 'warn' | 'bad' | 'idle'
+
+export function bucketDotTone(bucket: KeeperBucket): DotTone {
+  if (bucket === 'running') return 'ok'
+  if (bucket === 'paused') return 'warn'
+  return 'idle'
+}
+
+const DOT_CLASS: Record<DotTone, string> = {
+  ok: 'kw-dot ok',
+  warn: 'kw-dot warn',
+  bad: 'kw-dot bad',
+  idle: 'kw-dot',
+}
+
+export function StatusDot({ tone, pulse }: { tone: DotTone; pulse?: boolean }): VNode {
+  return html`<span class=${`${DOT_CLASS[tone]}${pulse ? ' pulse' : ''}`} aria-hidden="true"></span>`
+}
+
+/** Canonical color + 2-letter sigil avatar at an arbitrary size (KeeperBadge
+ *  tops out at 24px; the chat hero needs 46px). Reuses the same kSlot/kSigil
+ *  registry so colors match the rest of the dashboard. */
+export function WorkspaceSigil({
+  id,
+  size,
+  beat = false,
+}: {
+  id: string
+  size: number
+  beat?: boolean
+}): VNode {
+  const slot = kSlot(id)
+  const sigil = kSigil(id)
+  const style = {
+    width: `${size}px`,
+    height: `${size}px`,
+    fontSize: `${Math.round(size * 0.42)}px`,
+    background: `var(--color-keeper-${slot})`,
+    boxShadow: beat ? `0 0 10px rgb(var(--color-keeper-${slot}-glow) / 0.6)` : undefined,
+  }
+  return html`<span class="kw-sigil" style=${style} title=${id} aria-label=${id}>${sigil}</span>`
+}
+
+/** Phase label shown in the roster sub-row and the chat header state pill.
+ *  Prefers the typed FSM phase, falls back to the display-status mapper. */
+export function keeperPhaseLabel(keeper: Keeper): string {
+  return keeper.lifecycle_phase ?? keeper.phase ?? keeperDisplayStatus(keeper)
+}
+
+/** The state-pill modifier class for the chat header. */
+export function statePillTone(bucket: KeeperBucket): 'run' | 'warn' | 'off' {
+  if (bucket === 'running') return 'run'
+  if (bucket === 'paused') return 'warn'
+  return 'off'
+}
+
+/** Current model label, reading the populated fields directly
+ *  (keeperDisplayModel is a stub that returns null upstream). */
+export function keeperModelLabel(keeper: Keeper): string | null {
+  return keeper.active_model_label ?? keeper.active_model ?? keeper.model ?? null
+}
+
+/** Current runtime label for the header/rail. */
+export function keeperRuntimeLabel(keeper: Keeper): string | null {
+  return keeper.runtime_canonical ?? keeper.selected_runtime_canonical ?? null
+}

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -98,6 +98,21 @@ function currentSection(): StatusSection {
 export function Status() {
   const section = currentSection()
 
+  // Keeper detail (monitoring/agents/keeper=<name>) is a full-bleed 3-pane
+  // workspace that owns its own scroll. Render it in a height-filling
+  // container instead of the default vertical section stack, otherwise the
+  // `flex-col gap-5` wrapper collapses the workspace's `height: 100%`.
+  const keeperParam = route.value.params.keeper
+  if (section === 'agents' && typeof keeperParam === 'string' && keeperParam.trim() !== '') {
+    return html`
+      <div class="h-full min-h-0">
+        <${Suspense} fallback=${sectionFallback(sectionLabel('agents'))}>
+          <${LazyAgentsUnified} />
+        <//>
+      </div>
+    `
+  }
+
   return html`
     <div class="flex flex-col gap-5">
       <div class="transition-opacity duration-[var(--t-slow)]">

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -35,6 +35,7 @@ import './styles/ops.css'
 import './styles/tools.css'
 import './styles/provider-matrix.css'
 import './styles/paper-theme.css'
+import './styles/keeper-workspace.css'
 
 import { render } from 'preact'
 import { html } from 'htm/preact'

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -1,0 +1,287 @@
+/* Keeper Workspace — 3-pane chat surface (roster | conversation | context rail).
+ *
+ * Ported from the v2 design package (keeper-v2/styles/v2.css + craft.css,
+ * "spacious" density). The design's raw palette vars (--bg-deep, --volt,
+ * --text-mid …) are mapped onto the dashboard's token system here so the
+ * layout inherits theme/skin changes:
+ *
+ *   --bg-deep        → --color-bg-page          --volt        → --color-accent-fg
+ *   --bg-panel       → --color-bg-panel-alt     --volt-dim    → --color-accent-fg-dim
+ *   --bg-card        → --color-bg-surface       --volt-wash   → --accent-10
+ *   --bg-card-hover  → --color-bg-hover         --volt-glow   → --color-accent-glow
+ *   --border-main    → --color-border-default   --status-ok   → --color-status-ok
+ *   --border-soft    → --color-border-divider   --status-warn → --color-status-warn
+ *   --border-strong  → --color-border-strong    --status-bad  → --color-status-err
+ *   --text-bright    → --color-fg-primary       --text-mid    → --color-fg-secondary
+ *   --text-dim       → --color-fg-muted
+ *
+ * Component markup lives in src/components/keeper-workspace/*. Structural and
+ * spacing rules sit here (rather than inline utilities) because the design is
+ * spacing-dense and reads 1:1 against the source CSS this way — matching the
+ * dashboard's existing chat.css / rail.css / center.css convention.
+ */
+
+/* ── Shell grid: roster | conversation | context rail ───────────── */
+.kw-grid {
+  display: grid;
+  grid-template-columns:
+    var(--kw-roster-w, 286px)
+    minmax(0, 1fr)
+    var(--kw-rail-w, 312px);
+  height: 100%;
+  min-height: 0;
+  background: var(--color-bg-page);
+  color: var(--color-fg-primary);
+}
+
+/* Detail ("상세 보기") takes over the conversation + rail span as a
+ * single scrollable column; roster stays for keeper switching. */
+.kw-grid[data-detail="open"] { grid-template-columns: var(--kw-roster-w, 286px) minmax(0, 1fr); }
+
+@media (max-width: 1180px) {
+  .kw-grid { grid-template-columns: var(--kw-roster-w, 248px) minmax(0, 1fr); }
+  .kw-grid .kw-rail { display: none; }
+}
+/* Below 860px the rail is already gone; roster + conversation stack in one
+ * column. A dedicated mobile pane-switcher is deferred (no JS sets it yet),
+ * so we do not ship the unreachable data-mobile-pane hide rules. */
+@media (max-width: 860px) {
+  .kw-grid { grid-template-columns: minmax(0, 1fr); }
+}
+
+/* ════ ROSTER (left) ════════════════════════════════════════════ */
+.kw-roster {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid var(--color-border-default);
+  background: linear-gradient(180deg, var(--color-bg-panel-alt), var(--color-bg-page) 60%);
+}
+.kw-roster-head { padding: 15px 14px; border-bottom: 1px solid var(--color-border-divider); }
+.kw-roster-search {
+  width: 100%;
+  font-size: 12.5px;
+  padding: 8px 11px;
+  background: var(--color-bg-page);
+  color: var(--color-fg-primary);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  outline: none;
+}
+.kw-roster-search:focus { border-color: var(--color-accent-fg-dim); box-shadow: 0 0 0 2px var(--accent-10); }
+.kw-roster-search::placeholder { color: var(--color-fg-muted); }
+
+.kw-roster-filters { display: flex; gap: 5px; padding: 10px 14px; flex-wrap: wrap; border-bottom: 1px solid var(--color-border-divider); }
+.kw-rfilter {
+  font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase;
+  padding: 4px 10px; border-radius: 9999px; cursor: pointer;
+  border: 1px solid var(--color-border-default); background: transparent; color: var(--color-fg-muted);
+  display: inline-flex; gap: 5px; align-items: center;
+  transition: color .15s, border-color .15s, background .15s;
+}
+.kw-rfilter:hover { color: var(--color-fg-secondary); border-color: var(--color-border-strong); }
+.kw-rfilter[aria-pressed="true"] { color: var(--color-bg-page); background: var(--color-accent-fg); border-color: var(--color-accent-fg); font-weight: 600; }
+.kw-rfilter .n { opacity: 0.75; }
+
+.kw-roster-list { flex: 1; overflow-y: auto; padding: 9px 8px; }
+.kw-roster-group {
+  font-size: 9.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--color-fg-muted);
+  padding: 12px 8px 5px;
+}
+.kw-roster-empty { padding: 30px 12px; text-align: center; color: var(--color-fg-muted); font-size: 12px; }
+
+.kw-kp-row {
+  display: grid; grid-template-columns: 38px 1fr auto; gap: 10px; align-items: center;
+  width: 100%; text-align: left;
+  padding: 10px 10px; border-radius: var(--r-2); cursor: pointer;
+  border: 1px solid transparent; background: transparent;
+  transition: background .14s, border-color .14s;
+  position: relative;
+}
+.kw-kp-row:hover { background: var(--color-bg-surface); }
+.kw-kp-row[aria-current="true"] { background: var(--color-bg-surface); border-color: var(--color-accent-fg-dim); box-shadow: inset 0 0 0 1px var(--accent-10); }
+.kw-kp-row[aria-current="true"]::before {
+  content: ""; position: absolute; left: -8px; top: 9px; bottom: 9px; width: 3px;
+  background: var(--color-accent-fg); border-radius: 0 3px 3px 0;
+  box-shadow: 0 0 10px rgb(var(--color-accent-glow) / 0.6);
+}
+.kw-kp-meta { min-width: 0; }
+.kw-kp-name { font-weight: 600; font-size: 13.5px; color: var(--color-fg-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kw-kp-sub { display: flex; align-items: center; gap: 6px; font-size: 10.5px; color: var(--color-fg-muted); margin-top: 2px; min-width: 0; }
+.kw-kp-state { display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; }
+.kw-kp-handle { font-family: var(--font-mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.kw-kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; flex: none; }
+.kw-kp-time { font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-muted); }
+.kw-kp-att {
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 600;
+  min-width: 16px; text-align: center; padding: 1px 5px; border-radius: 9999px;
+  color: var(--color-status-err);
+  background: rgb(var(--color-status-err-glow) / 0.16);
+  border: 1px solid rgb(var(--color-status-err-glow) / 0.35);
+}
+
+/* shared sigil avatar (roster + chat hero) — color from --color-keeper-N */
+.kw-sigil {
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: var(--r-2); font-family: var(--font-mono); font-weight: 700;
+  color: var(--color-bg-page); flex: none;
+}
+
+/* status dot */
+.kw-dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; flex: none; background: var(--color-fg-muted); }
+.kw-dot.ok { background: var(--color-status-ok); box-shadow: 0 0 7px var(--color-status-ok); }
+.kw-dot.warn { background: var(--color-status-warn); box-shadow: 0 0 7px var(--color-status-warn); }
+.kw-dot.bad { background: var(--color-status-err); box-shadow: 0 0 7px var(--color-status-err); }
+.kw-dot.pulse { animation: kw-dot-pulse 1.8s ease-in-out infinite; }
+@keyframes kw-dot-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+/* ════ CONVERSATION (center) ════════════════════════════════════ */
+.kw-chat { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--color-bg-page); }
+
+.kw-chat-head {
+  flex: none; padding: 18px 28px 16px;
+  border-bottom: 1px solid var(--color-border-default);
+  background: linear-gradient(180deg, var(--color-bg-panel-alt), var(--color-bg-page));
+  display: flex; align-items: center; gap: 16px;
+}
+.kw-chat-id { min-width: 0; flex: 1; }
+.kw-chat-name-row { display: flex; align-items: center; gap: 11px; flex-wrap: wrap; }
+.kw-chat-name { font-size: 20px; font-weight: 600; letter-spacing: 0.01em; color: var(--color-fg-primary); margin: 0; white-space: nowrap; }
+.kw-chat-sub { display: flex; align-items: center; gap: 10px; margin-top: 5px; font-size: 11px; color: var(--color-fg-muted); flex-wrap: wrap; }
+.kw-chat-sub > span { white-space: nowrap; display: inline-flex; align-items: center; gap: 5px; }
+.kw-chat-sub .k { font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--color-fg-muted); }
+.kw-chat-sub .mono { font-family: var(--font-mono); color: var(--color-fg-secondary); }
+
+.kw-state-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11px; letter-spacing: 0.04em; padding: 4px 10px; border-radius: 9999px;
+  background: var(--color-bg-surface); border: 1px solid var(--color-border-default); color: var(--color-fg-secondary);
+}
+.kw-state-pill.run { color: var(--color-status-ok); border-color: rgb(var(--color-status-ok-glow) / 0.45); background: rgb(var(--color-status-ok-glow) / 0.10); }
+.kw-state-pill.warn { color: var(--color-status-warn); border-color: rgb(var(--color-status-warn-glow) / 0.45); }
+.kw-state-pill.off { color: var(--color-fg-muted); }
+
+.kw-tps-live { display: inline-flex; align-items: center; gap: 5px; color: var(--color-status-ok); }
+.kw-tps-live .mono { color: var(--color-status-ok); }
+.kw-tps-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-status-ok); box-shadow: 0 0 6px var(--color-status-ok); animation: kw-tps-pulse 1.1s ease-in-out infinite; }
+@keyframes kw-tps-pulse { 0%, 100% { opacity: 0.45; } 50% { opacity: 1; } }
+
+.kw-chat-actions { display: flex; gap: 7px; align-items: center; flex: none; }
+.kw-act {
+  font-size: 11px; letter-spacing: 0.04em;
+  padding: 7px 12px; border-radius: var(--r-1); cursor: pointer;
+  border: 1px solid var(--color-border-default); background: var(--color-bg-surface); color: var(--color-fg-secondary);
+  white-space: nowrap; transition: color .15s, border-color .15s, background .15s;
+}
+.kw-act:hover { color: var(--color-fg-primary); border-color: var(--color-border-strong); background: var(--color-bg-hover); }
+.kw-act:disabled { opacity: 0.5; cursor: not-allowed; }
+.kw-act.danger:hover { color: var(--color-status-err); border-color: rgb(var(--color-status-err-glow) / 0.5); }
+
+/* thread: the conversation panel renders ChatTranscript + composer inside.
+ * Provide the spacious rhythm + centered max-width column here. */
+.kw-thread {
+  flex: 1; min-height: 0; display: flex; flex-direction: column;
+  padding: 0;
+}
+.kw-thread-inner {
+  width: 100%; max-width: var(--kw-thread-w, 980px); margin: 0 auto;
+  flex: 1; min-height: 0; display: flex; flex-direction: column;
+}
+/* Spacious overrides for the reused ChatTranscript (chat/primitives.ts).
+ * Two-class specificity beats its single-class Tailwind gap/padding. */
+.kw-thread-inner .chat-transcript {
+  gap: 30px;
+  padding-left: 40px;
+  padding-right: 40px;
+  padding-top: 34px;
+}
+.kw-composer-wrap {
+  flex: none;
+  border-top: 1px solid var(--color-border-default);
+  background: linear-gradient(0deg, var(--color-bg-panel-alt), var(--color-bg-page));
+  padding: 14px 0 18px;
+}
+.kw-composer-inner { width: 100%; max-width: var(--kw-thread-w, 980px); margin: 0 auto; padding: 0 40px; }
+
+.kw-chat-toolbar {
+  flex: none; display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  padding: 8px 40px; border-bottom: 1px solid var(--color-border-divider);
+  background: var(--color-bg-page);
+}
+.kw-chat-toolbar .spacer { flex: 1; }
+
+/* ════ CONTEXT RAIL (right) ═════════════════════════════════════ */
+.kw-rail {
+  display: flex; flex-direction: column; min-height: 0; overflow: hidden;
+  border-left: 1px solid var(--color-border-default);
+  background: linear-gradient(180deg, var(--color-bg-panel-alt), var(--color-bg-page) 70%);
+}
+.kw-rail-scroll { overflow-y: auto; padding: 20px; display: flex; flex-direction: column; gap: 22px; }
+.kw-sec h4 {
+  font-weight: 600; text-transform: uppercase; letter-spacing: 0.16em;
+  font-size: 11px; color: var(--color-fg-secondary); margin: 0 0 9px;
+  display: flex; align-items: center; gap: 7px;
+}
+.kw-card { background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: var(--r-2); padding: 12px 13px; }
+
+.kw-vitals { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--color-border-divider); border: 1px solid var(--color-border-default); border-radius: var(--r-2); overflow: hidden; }
+.kw-vital { background: var(--color-bg-surface); padding: 9px 11px; min-width: 0; }
+.kw-vital .vk { font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-fg-secondary); font-weight: 600; }
+.kw-vital .vv { font-family: var(--font-mono); font-size: 13px; color: var(--color-fg-primary); margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.kw-meter-wrap { position: relative; margin-top: 18px; }
+.kw-meter { height: 7px; border-radius: 9999px; background: var(--color-bg-page); border: 1px solid var(--color-border-divider); overflow: hidden; }
+.kw-meter > span { display: block; height: 100%; background: linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg)); }
+.kw-meter.hot > span { background: linear-gradient(90deg, var(--color-status-warn), var(--color-status-err)); }
+.kw-meter-mark { position: absolute; top: -2px; width: 1px; height: 11px; background: rgb(var(--color-status-warn-glow) / 0.75); transform: translateX(-50%); pointer-events: none; }
+.kw-meter-mark-lbl {
+  position: absolute; bottom: 11px; left: 50%; transform: translateX(-50%);
+  font-style: normal; font-size: 8.5px; letter-spacing: 0.04em; white-space: nowrap;
+  color: var(--color-status-warn); opacity: 0.85;
+}
+.kw-ctx-tok { display: flex; align-items: baseline; gap: 5px; margin-top: 8px; font-size: 11px; }
+.kw-ctx-tok .mono { font-family: var(--font-mono); color: var(--color-fg-secondary); }
+.kw-ctx-tok .lbl { margin-left: auto; color: var(--color-fg-muted); font-size: 10px; }
+
+.kw-list { display: flex; flex-direction: column; gap: 7px; }
+.kw-list-empty { font-size: 12px; color: var(--color-fg-muted); }
+.kw-tasktag { display: flex; align-items: center; gap: 8px; padding: 7px 9px; border-radius: var(--r-1); background: var(--color-bg-page); border: 1px solid var(--color-border-divider); font-size: 12px; color: var(--color-fg-primary); }
+.kw-tasktag .tid { font-family: var(--font-mono); font-size: 10.5px; color: var(--color-accent-fg); flex: none; }
+.kw-tasktag .ttl { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 1; }
+.kw-tasktag .tstate { font-size: 10px; flex: none; color: var(--color-fg-muted); }
+.kw-tasktag .tstate.review { color: var(--color-status-warn); }
+
+.kw-tool { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--color-fg-secondary); }
+.kw-tool .nm { font-family: var(--font-mono); font-size: 11.5px; color: var(--color-fg-primary); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.kw-detail-btn {
+  width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  padding: 11px 13px; border-radius: var(--r-2); cursor: pointer;
+  border: 1px solid var(--color-border-default); background: var(--color-bg-surface); color: var(--color-fg-primary);
+  font-size: 12.5px; font-weight: 600; transition: background .15s, border-color .15s;
+}
+.kw-detail-btn:hover { background: var(--color-bg-hover); border-color: var(--color-border-strong); }
+.kw-detail-btn .sub { font-weight: 400; color: var(--color-fg-muted); font-size: 11px; }
+
+/* ════ DETAIL ("상세 보기") — reuse KeeperDetailBody, scrollable column ══ */
+.kw-detail { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--color-bg-page); }
+.kw-detail-head {
+  flex: none; display: flex; align-items: center; gap: 10px;
+  padding: 12px 18px; border-bottom: 1px solid var(--color-border-default);
+  background: var(--color-bg-panel-alt);
+}
+.kw-detail-scroll { flex: 1; min-height: 0; overflow-y: auto; padding: 18px; }
+
+/* ════ ATTENTION (rail, top) ════════════════════════════════════ */
+.kw-att-list { display: flex; flex-direction: column; gap: 6px; }
+.kw-att-item {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px; border-radius: var(--r-1); font-size: 12px;
+  background: var(--color-bg-page); border: 1px solid var(--color-border-divider); color: var(--color-fg-secondary);
+}
+.kw-att-item.bad { border-color: rgb(var(--color-status-err-glow) / 0.35); background: rgb(var(--color-status-err-glow) / 0.08); color: var(--color-fg-primary); }
+.kw-att-item.warn { border-color: rgb(var(--color-status-warn-glow) / 0.35); background: rgb(var(--color-status-warn-glow) / 0.08); }
+.kw-att-dot { width: 7px; height: 7px; border-radius: 50%; flex: none; background: var(--color-fg-muted); }
+.kw-att-item.bad .kw-att-dot { background: var(--color-status-err); box-shadow: 0 0 6px var(--color-status-err); }
+.kw-att-item.warn .kw-att-dot { background: var(--color-status-warn); box-shadow: 0 0 6px var(--color-status-warn); }
+.kw-att-text { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }


### PR DESCRIPTION
## What changed

- Extract the Keeper detail roster, conversation, and context rail into `keeper-workspace/*` components.
- Make the keeper detail route a full-height workspace: roster on the left, chat-first center pane, context rail on the right.
- Keep the full existing `KeeperDetailBody` available behind the detail toggle for status, diagnostics, identity, config, and debug views.
- Add focused workspace tests and update the older keeper detail page tests for the new component boundaries.

## Why

This follows the v2 design direction for a Keeper-list plus conversation-window workflow while keeping the runtime/provider boundary in MASC dashboard code only.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec vitest run --config vitest.config.ts src/components/keeper-detail-page.test.ts src/components/keeper-detail.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts src/components/keeper-workspace/keeper-workspace-roster.test.ts src/components/keeper-workspace/keeper-workspace-shared.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm run build`