### PR TITLE
[codex] remove keeper stay silent legacy

### DIFF
--- a/docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md
+++ b/docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md
@@ -301,7 +301,7 @@ PR-3 (retry loop body) 가 *전체 LOC delta 의 60%+ 차지* — 별도 RFC sub
 
 - `lib/keeper/keeper_unified_turn.ml` = 1641 LOC (post-PR-4-c).
 - `run_keeper_cycle` body (L22-L1640) = 1618 LOC — still single mega-function.
-- Sibling sub-modules total: 1858 LOC across 13 files (`keeper_unified_turn_{phase_gate, runtime_resolution, pre_dispatch, retry_setup, terminal_error, attempt_watchdog, livelock_block, phase_plan, event_bus, failure, stay_silent, success, types}`).
+- Sibling sub-modules total: 1858 LOC across 13 files (`keeper_unified_turn_{phase_gate, runtime_resolution, pre_dispatch, retry_setup, terminal_error, attempt_watchdog, livelock_block, phase_plan, event_bus, failure, no_progress, success, types}`).
 
 ### 8.3 PR-4-d / PR-4-e 보류 결정
 

--- a/docs/rfc/RFC-0239-semantic-identity-guards-for-keeper-memory-and-anti-thrash.md
+++ b/docs/rfc/RFC-0239-semantic-identity-guards-for-keeper-memory-and-anti-thrash.md
@@ -30,7 +30,7 @@ root and wrong about its own status claims**:
   memory bug. The `stay_silent` loop detector that should pause them keys on the literal
   `speech_act="stay_silent"` token, but the keepers *post* their "I'll stay quiet" message
   (a `Post_board` act), which **resets the silence streak every cycle** — the detector can
-  never fire (`keeper_stay_silent_loop_detector.ml:48,66-74`).
+  never fire (`keeper_no_progress_loop_detector.ml:48,66-74`).
 - Memory OS is a real **amplifier** (immortal, append-only facts re-inject the conclusion)
   but not the root: if the wake cascade stopped, the loop dies.
 - The keepers' status claims are mostly fabricated/stale: "5 PRs blocked only by operator
@@ -46,7 +46,7 @@ termination check in the system. This RFC fixes the five guards that share that 
 
 | Root | State | Reference |
 |---|---|---|
-| R3 no-progress loop detector | **Implemented + tested** | `keeper_stay_silent_loop_detector`, commit `R3` |
+| R3 no-progress loop detector | **Implemented + tested** | `keeper_no_progress_loop_detector`, commit `R3` |
 | R4 wake content-fingerprint debounce | **Implemented + tested** | `keeper_keepalive_signal` / `keeper_registry`, commit `R4` |
 | R2 recall-time claim dedup | **Implemented + tested** | `keeper_memory_os_recall`, commit `R2` |
 | Retention sweep (supersedes RFC-0238) | **Implemented + tested** | `keeper_memory_os_io.cap_facts`, Q4 commit |
@@ -101,7 +101,7 @@ Every termination/dedup/expiry guard in the path observes the wrong thing:
 |---|---|---|---|---|---|
 | R1 | fact expiry | `valid_until` written `None` always | a TTL/lifetime set at write | 100% immortal (§1.2) | `keeper_librarian.ml:141-144` |
 | R2 | fact store write | append-only, no compare | claim fingerprint | 8.2% dup, reworded twins (§1.2) | `keeper_memory_os_io.ml:125-127` |
-| R3 | thrash detector | `speech_act="stay_silent"` literal | no-progress (no new tool evidence + near-dup body) | streak resets on every `Post_board` (§3) | `keeper_stay_silent_loop_detector.ml:48,66-74` |
+| R3 | thrash detector | `speech_act="stay_silent"` literal | no-progress (no new tool evidence + near-dup body) | streak resets on every `Post_board` (§3) | `keeper_no_progress_loop_detector.ml:48,66-74` |
 | R4 | wake debounce | `post_id` (60 s) | `(keeper, content fingerprint)` | each cycle mints a new `post_id` | `keeper_registry.ml:402-412`, `keeper_keepalive_signal.ml:229` |
 | R5 | board write dedup | exact body bytes | normalized/near-dup body | reworded re-posts pass | `board_core_persist.ml:426-457` |
 
@@ -122,7 +122,7 @@ problem.
 
 ## §3 Why the existing detector cannot fire (the single most important defect)
 
-`keeper_stay_silent_loop_detector.ml` bumps a streak **only** when `speech_act = "stay_silent"`
+`keeper_no_progress_loop_detector.ml` bumps a streak **only** when `speech_act = "stay_silent"`
 (line 48) and **resets the streak to 0 on any other speech act** (lines 66-74).
 `speech_act` is an 8-variant type (`keeper_social_model_types.ml:1-9`) in which `Stay_silent`
 is distinct from `Post_board`/`Comment_board`/`Broadcast`/`Inform`.
@@ -184,7 +184,7 @@ is in-scope to add, not to sunset.
 
 ### R3 — Make the no-progress detector semantic (coordination — highest leverage)
 
-Extend `keeper_stay_silent_loop_detector` (or the turn classifier feeding it) so a turn
+Extend `keeper_no_progress_loop_detector` (or the turn classifier feeding it) so a turn
 counts toward the loop streak when it is **no-progress**, defined as:
 
 ```

--- a/docs/rfc/RFC-0242-typed-continuity-summary-filter.md
+++ b/docs/rfc/RFC-0242-typed-continuity-summary-filter.md
@@ -29,7 +29,7 @@ Status: Draft · Extends RFC-0239 (semantic-identity guards) · Drafted 2026-06-
 > the scrubber smarter.
 >
 > v2 also corrects four factual errors in v1 (call-site count, marker-list
-> inventory, #21065 attribution, and the stay_silent loop-detector state) and
+> inventory, #21065 attribution, and the no-progress loop-detector state) and
 > redesigns the inert-next-item handling (§3.6) after an adversarial audit showed v1
 > would have relocated the `inert_next_markers` list rather than removed it.
 
@@ -88,7 +88,7 @@ What does **not** disappear, and which this RFC refuses to disguise: deciding
 whether a turn was substantive is a real judgment. The honest part is that it has a
 **structural** answer that already exists in the codebase — RFC-0239 R3's
 tool-evidence signal (`turn_made_progress`,
-`keeper_stay_silent_loop_detector.ml:57`) — so the inert judgment moves off the
+`keeper_no_progress_loop_detector.ml:57`) — so the inert judgment moves off the
 `next_items` *text* entirely (§3.6), rather than relocating the substring list. The
 genuinely irreducible residue (§5) is narrow.
 
@@ -178,8 +178,8 @@ Consequences of the current shape:
 - The compiler cannot see that `decisions` is being filtered, so a new backward
   field is silently un-filtered until someone adds a marker.
 - The continuity filter is a **laggard**: RFC-0239 R3 already moved the sibling
-  `stay_silent` loop detector off the literal token. The detector's comment
-  (`keeper_stay_silent_loop_detector.ml:45-56`) records that the
+  no-progress loop detector off the literal token. The detector's comment
+  (`keeper_no_progress_loop_detector.ml:45-56`) records that the
   `speech_act="stay_silent"` predicate was **retired** because a keeper could evade
   it by *posting* its "nothing to do" conclusion; it now uses the structural bools
   `turn_made_progress ~strong_evidence ~surface_requires_evidence` (line 57). The
@@ -267,7 +267,7 @@ to snapshot-build. That is the same list wearing a type.
 
 The correct signal already exists and is structural: RFC-0239 R3's
 `turn_made_progress ~strong_evidence ~surface_requires_evidence`
-(`keeper_stay_silent_loop_detector.ml:57`) decides whether a turn produced durable
+(`keeper_no_progress_loop_detector.ml:57`) decides whether a turn produced durable
 work (substantive tool calls / validated output) **without reading any prose**. The
 continuity path adopts the same signal:
 
@@ -397,7 +397,7 @@ target: §7 step 5.)
 ## §9 Relation to RFC-0239
 
 RFC-0239 fixes five guards that key on surface tokens, and its R3 already replaced
-the `stay_silent` loop detector's literal-token predicate with a structural
+the no-progress loop detector's literal-token predicate with a structural
 tool-evidence signal (`turn_made_progress`). This RFC fixes the continuity-summary
 content filter — the laggard that still keys on the token R3 abandoned — by (a)
 removing the structural cause (the unenforced record and its prose round-trip) and

--- a/lib/dune
+++ b/lib/dune
@@ -108,7 +108,7 @@
   keeper_unified_metrics_json_support
   keeper_unified_metrics_support
   keeper_unified_turn_event_bus
-  keeper_unified_turn_stay_silent
+  keeper_unified_turn_no_progress
   keeper_unified_turn_success
   keeper_unified_turn_failure
   keeper_unified_turn_phase_plan

--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -143,8 +143,7 @@ let risk_of_keeper (k : Keeper_tool_name.t) : risk_level =
   | Board_post_get | Board_list | Board_post | Board_search | Board_stats
   | Board_sub_board_get | Board_sub_board_list | Board_vote | Broadcast
   | Context_status | Handoff | Library_read | Library_search | Memory_search
-  | Memory_write | Search_files | Stay_silent | Surface_read | Tasks_audit
-  | Tasks_list | Time_now
+  | Memory_write | Search_files | Surface_read | Tasks_audit | Tasks_list | Time_now
   | Tool_search | Tools_list | Voice_agent | Voice_listen
   | Voice_session_end | Voice_session_start | Voice_sessions | Voice_speak -> Low
   | Board_sub_board_create | Board_sub_board_update | Task_claim | Task_create | Task_done

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -80,9 +80,9 @@ let consume_single_heartbeat_stimulus
       "turn entry: bootstrap stimulus consumed (keeper=%s)"
       meta_after_triage.name;
     []
-  | Keeper_event_queue.Stay_silent_recovery ->
+  | Keeper_event_queue.No_progress_recovery ->
     Log.Keeper.info
-      "turn entry: stay-silent recovery stimulus consumed post_id=%s \
+      "turn entry: no-progress recovery stimulus consumed post_id=%s \
        (keeper=%s)"
       stim.post_id
       meta_after_triage.name;

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -40,7 +40,7 @@ type heartbeat_event_intake = {
 (** [consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim]
     increments Otel_metric_store, logs the consumption, and returns a list of
     pending board events derived from [stim] (empty for non-board
-    classes). [Stay_silent_recovery] also writes a reaction-ledger entry. *)
+    classes). [No_progress_recovery] also writes a reaction-ledger entry. *)
 val consume_single_heartbeat_stimulus
   :  ctx:_ context
   -> meta_after_triage:keeper_meta

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -108,7 +108,7 @@ type proactive_runtime =
   ; last_preview : string
   ; consecutive_noop_count : int
     (** Consecutive autonomous cycles where only observation tools
-          (board_list, stay_silent, context_status) were used with no
+          (board_list, context_status, other passive reads) were used with no
           substantive action.  Resets to 0 on any productive cycle.
           Used by [effective_scheduled_autonomous_cooldown] for exponential
           backoff: cooldown *= 2^min(n, 3), capping at 8x. *)
@@ -154,7 +154,7 @@ type blocker_class =
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation
-  | Stay_silent_loop
+  | No_progress_loop
   | Fiber_unresolved
     (** 2026-05-05: turn fiber finished without invoking [resolve_done]
         (cancelled mid-turn, raised an exception not handled by the
@@ -199,7 +199,7 @@ let blocker_class_to_string = function
   | Turn_timeout -> "turn_timeout"
   | Turn_livelock_blocked -> "turn_livelock_blocked"
   | Completion_contract_violation -> "completion_contract_violation"
-  | Stay_silent_loop -> "stay_silent_loop"
+  | No_progress_loop -> "no_progress_loop"
   | Fiber_unresolved -> "fiber_unresolved"
   | Stale_turn_timeout -> "stale_turn_timeout"
   | Stale_fleet_batch -> "stale_fleet_batch"
@@ -225,7 +225,7 @@ let blocker_class_of_serialized_string = function
   | "turn_timeout" -> Some Turn_timeout
   | "turn_livelock_blocked" -> Some Turn_livelock_blocked
   | "completion_contract_violation" -> Some Completion_contract_violation
-  | "stay_silent_loop" -> Some Stay_silent_loop
+  | "no_progress_loop" -> Some No_progress_loop
   | "fiber_unresolved" -> Some Fiber_unresolved
   | "stale_turn_timeout" -> Some Stale_turn_timeout
   | "stale_fleet_batch" -> Some Stale_fleet_batch
@@ -272,7 +272,7 @@ let blocker_class_continue_gate = function
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation
-  | Stay_silent_loop
+  | No_progress_loop
   | Fiber_unresolved
   | Stale_turn_timeout
   | Stale_fleet_batch

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -151,7 +151,7 @@ type blocker_class =
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation
-  | Stay_silent_loop
+  | No_progress_loop
   | Fiber_unresolved
   | Stale_turn_timeout
   | Stale_fleet_batch

--- a/lib/keeper/keeper_no_progress_loop_detector.ml
+++ b/lib/keeper/keeper_no_progress_loop_detector.ml
@@ -1,8 +1,7 @@
 let default_threshold = 10
 
-(* Step 14(b) of the bloodflow restoration plan inlined the env knob
-   [MASC_STAY_SILENT_LOOP_THRESHOLD]: hyperparameters belong in code,
-   not in [Sys.getenv_opt]. *)
+(* Step 14(b) of the bloodflow restoration plan inlined the old threshold env
+   knob: hyperparameters belong in code, not in [Sys.getenv_opt]. *)
 let threshold () = default_threshold
 
 type record_outcome =
@@ -20,7 +19,7 @@ type keeper_state = {
 
 let state : (string, keeper_state) Hashtbl.t = Hashtbl.create 16
 
-(* Eio.Mutex: stay-silent records originate from keeper turn fibers in a
+(* Eio.Mutex: no-progress records originate from keeper turn fibers in a
    single domain. Stdlib.Mutex with PTHREAD_MUTEX_ERRORCHECK turns fiber
    contention into EDEADLK (memory: feedback_eio-mutex-vs-stdlib). *)
 let mutex = Eio.Mutex.create ()
@@ -38,7 +37,7 @@ let get_or_create keeper_name =
 
 let update_streak_gauge keeper_name value =
   Otel_metric_store.set_gauge
-    "masc_keeper_stay_silent_streak"
+    "masc_keeper_no_progress_streak"
     ~labels:[ ("keeper", keeper_name) ]
     (Float.of_int value)
 
@@ -67,12 +66,12 @@ let record_turn ~keeper_name ~made_progress =
       if s.streak >= t && not s.detected_latched then begin
         s.detected_latched <- true;
         Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string StaySilentLoopDetected)
+          Keeper_metrics.(to_string NoProgressLoopDetected)
           ~labels:[ ("keeper", keeper_name) ] ();
         Log.Keeper.error
           "#9926/RFC-0239 no-progress loop detected keeper=%s streak=%d \
-           threshold=%d — keeper repeated no-progress turns (stay_silent, or \
-           board posts with no tool evidence). Check effective tool surface \
+           threshold=%d — keeper repeated no-progress turns (silent speech act \
+           or board posts with no tool evidence). Check effective tool surface \
            mismatch or scheduler/backlog drift. Counter will not re-fire until \
            the streak resets via a turn that makes progress."
           keeper_name s.streak t;

--- a/lib/keeper/keeper_no_progress_loop_detector.mli
+++ b/lib/keeper/keeper_no_progress_loop_detector.mli
@@ -1,8 +1,8 @@
-(** Stay-silent loop detector for keeper lifecycle (#9926).
+(** No-progress loop detector for keeper lifecycle (#9926).
 
     masc-improver evidence from 2026-04-24: a single keeper spent
     13.3 hours of LLM time and burned 4.19M tokens across 40+
-    consecutive [stay_silent] turns, because the scheduler kept
+    consecutive no-progress turns, because the scheduler kept
     firing ticks on a keeper whose effective tool surface could not satisfy
     any backlog task.
 
@@ -14,14 +14,13 @@
     Pure in-memory; no file I/O. The caller owns durable recovery wiring
     because it has access to keeper meta, registry, and base path.
 
-    Threshold source: code constant [10]. The retired
-    [MASC_STAY_SILENT_LOOP_THRESHOLD] env knob is intentionally ignored so
-    runtime behavior cannot drift per process.
+    Threshold source: code constant [10]. The retired threshold env knob is
+    intentionally ignored so runtime behavior cannot drift per process.
 
     Observability contract:
-    - [masc_keeper_stay_silent_streak{keeper=X}] gauge carries the
+    - [masc_keeper_no_progress_streak{keeper=X}] gauge carries the
       current streak length (0..N).
-    - [masc_keeper_stay_silent_loop_detected_total{keeper=X}]
+    - [masc_keeper_no_progress_loop_detected_total{keeper=X}]
       counter increments each time the streak crosses the
       threshold. Latched: does not increment again until the
       streak resets to 0.
@@ -46,7 +45,7 @@ val turn_made_progress :
 (** Update the per-keeper streak from the latest turn. [made_progress] is the
     caller's verdict (see {!turn_made_progress}): the streak increments on a
     no-progress turn and resets when a turn makes progress. Generalises the
-    earlier literal ["stay_silent"] match so a keeper that re-posts its
+    earlier literal silent speech-act match so a keeper that re-posts its
     "nothing to do" conclusion (a no-progress board post) also accrues the
     streak. *)
 val record_turn : keeper_name:string -> made_progress:bool -> record_outcome

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -6,7 +6,7 @@ type cursor =
 type stimulus_kind =
   | Board_signal
   | Bootstrap
-  | Stay_silent_recovery
+  | No_progress_recovery
 
 type reaction_kind =
   | Turn_started
@@ -22,7 +22,7 @@ let schema = "keeper.reaction_ledger.v1"
 let stimulus_kind_to_string = function
   | Board_signal -> "board_signal"
   | Bootstrap -> "bootstrap"
-  | Stay_silent_recovery -> "stay_silent_recovery"
+  | No_progress_recovery -> "no_progress_recovery"
 ;;
 
 let reaction_kind_to_string = function
@@ -49,7 +49,7 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   match stimulus.payload with
   | Keeper_event_queue.Board_signal _ -> Board_signal
   | Keeper_event_queue.Bootstrap -> Bootstrap
-  | Keeper_event_queue.Stay_silent_recovery -> Stay_silent_recovery
+  | Keeper_event_queue.No_progress_recovery -> No_progress_recovery
 ;;
 
 let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
@@ -116,7 +116,7 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       bs.author
       title
   | Keeper_event_queue.Bootstrap -> "bootstrap"
-  | Keeper_event_queue.Stay_silent_recovery -> "stay_silent_recovery"
+  | Keeper_event_queue.No_progress_recovery -> "no_progress_recovery"
 ;;
 
 let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
@@ -126,7 +126,7 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
   let board_updated_at =
     match stimulus.payload with
     | Keeper_event_queue.Board_signal bs -> bs.updated_at
-    | Keeper_event_queue.Bootstrap | Keeper_event_queue.Stay_silent_recovery -> None
+    | Keeper_event_queue.Bootstrap | Keeper_event_queue.No_progress_recovery -> None
   in
   `Assoc
     (base_fields
@@ -466,7 +466,7 @@ let summarize_rows ~keeper_name ~limit rows =
   let note_stimulus_kind = function
     | Some "board_signal"
     | Some "bootstrap"
-    | Some "stay_silent_recovery" -> ()
+    | Some "no_progress_recovery" -> ()
     | Some _ | None -> incr unsupported_stimulus_count
   in
   let note_payload_parse_error row =

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -13,7 +13,7 @@ type cursor =
 type stimulus_kind =
   | Board_signal
   | Bootstrap
-  | Stay_silent_recovery
+  | No_progress_recovery
 
 type reaction_kind =
   | Turn_started

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -116,7 +116,7 @@ let blocker_class_indicates_overflow (klass : blocker_class) : bool =
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation
-  | Stay_silent_loop
+  | No_progress_loop
   | Fiber_unresolved
   | Stale_turn_timeout
   | Stale_fleet_batch

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -26,7 +26,6 @@ type model_id = Keeper_social_model_types.model_id =
   | Magentic_ledger_v1
 
 type transition_reason = Keeper_social_model_types.transition_reason =
-  | Tool_only_stay_silent
   | Tool_only_comment_board
   | Tool_only_post_board
   | Tool_only_broadcast

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -27,7 +27,6 @@ type model_id = Keeper_social_model_types.model_id =
   | Magentic_ledger_v1
 
 type transition_reason = Keeper_social_model_types.transition_reason =
-  | Tool_only_stay_silent
   | Tool_only_comment_board
   | Tool_only_post_board
   | Tool_only_broadcast

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -164,7 +164,7 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Admission_queue_wait_timeout
     | Turn_timeout_after_queue_wait
     | Turn_timeout
-    | Stay_silent_loop
+    | No_progress_loop
     | Stale_fleet_batch
     | Sdk_max_turns_exceeded
     | Sdk_token_budget_exceeded

--- a/lib/keeper/keeper_supervisor_types.ml
+++ b/lib/keeper/keeper_supervisor_types.ml
@@ -137,7 +137,7 @@ let paused_meta_legacy_auto_resume_after_sec (meta : keeper_meta) =
           | Turn_timeout_after_queue_wait
           | Turn_livelock_blocked
           | Completion_contract_violation
-          | Stay_silent_loop
+          | No_progress_loop
           | Fiber_unresolved
           | Stale_turn_timeout
           | Stale_fleet_batch

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -69,7 +69,6 @@ let is_masc_mcp_descriptor (d : Keeper_tool_descriptor.t) =
   | Tool_edit_file
   | Tool_write_file
   | Tool_time_now
-  | Tool_stay_silent
   | Tool_tools_list
   | Tool_tool_search
   | Tool_context_status

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -31,7 +31,6 @@ type runtime_handler =
   | Tool_edit_file
   | Tool_write_file
   | Tool_time_now
-  | Tool_stay_silent
   | Tool_tools_list
   | Tool_tool_search
   | Tool_context_status
@@ -121,7 +120,6 @@ let runtime_handler_to_string = function
   | Tool_edit_file -> "tool_edit_file"
   | Tool_write_file -> "tool_write_file"
   | Tool_time_now -> "tool_time_now"
-  | Tool_stay_silent -> "tool_stay_silent"
   | Tool_tools_list -> "tool_tools_list"
   | Tool_tool_search -> "tool_tool_search"
   | Tool_context_status -> "tool_context_status"

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -36,7 +36,6 @@ type runtime_handler =
   | Tool_edit_file
   | Tool_write_file
   | Tool_time_now
-  | Tool_stay_silent
   | Tool_tools_list
   | Tool_tool_search
   | Tool_context_status

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -414,7 +414,6 @@ let tool_tutor_for_validation ~tool_name ~input =
      | Keeper_tool_descriptor.Tool_edit_file
      | Keeper_tool_descriptor.Tool_write_file
      | Keeper_tool_descriptor.Tool_time_now
-     | Keeper_tool_descriptor.Tool_stay_silent
      | Keeper_tool_descriptor.Tool_tools_list
      | Keeper_tool_descriptor.Tool_tool_search
      | Keeper_tool_descriptor.Tool_context_status

--- a/lib/keeper/keeper_tool_diversity.ml
+++ b/lib/keeper/keeper_tool_diversity.ml
@@ -100,9 +100,8 @@ let compute_diversity ~(available_tools : string list)
   let threshold = max 1 (total_calls / 100) in
   let underused = available_tools
     |> List.filter (fun tool ->
-      not (String.equal tool "keeper_stay_silent")
-      && (not (SS.mem tool used_set)
-          || List.exists (fun s -> s.name = tool && s.count < threshold) stats))
+      not (SS.mem tool used_set)
+      || List.exists (fun s -> s.name = tool && s.count < threshold) stats)
   in
   { total_calls; unique_tools; available_tools = n_available;
     entropy = raw_h; normalized_entropy = norm_h;

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -17,10 +17,6 @@ let handle_time_now ~args:_ =
     (`Assoc [ "now_iso", `String now_iso; "now_unix", `Float now_unix ])
 ;;
 
-let handle_stay_silent ~args:_ =
-  Yojson.Safe.to_string (`Assoc [ "status", `String "silent" ])
-;;
-
 let handle_tools_list ~(meta : keeper_meta) ~args:_ =
   Keeper_tool_shared_runtime.keeper_tools_list_json ~meta
 ;;

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -16,8 +16,6 @@ open Keeper_types_profile
 
 val handle_time_now : args:Yojson.Safe.t -> string
 
-val handle_stay_silent : args:Yojson.Safe.t -> string
-
 val handle_tools_list : meta:keeper_meta -> args:Yojson.Safe.t -> string
 
 val handle_tool_search

--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -57,23 +57,10 @@ let claim_context_tool_names : string list =
 ;;
 
 let completion_tool_names : string list =
-  (* Stay_silent is the explicit "no work for me this turn" decisive no-op.
-     LLM evaluates the situation via passive reads, then signals stay_silent to
-     terminate the turn intentionally. Classifying it as Completion lets the
-     contract accept the turn as satisfied; abuse is bounded separately by
-     keeper_stay_silent_loop_detector (consecutive speech-act metric + circuit
-     breaker). Without this, 4+ events/day were rejected as passive_only even
-     though the LLM had decided no fit (sangsu/janitor/taskmaster on 2026-04-27
-     00:17-00:58 UTC, idle_seconds 28-40h, claimable_count 44-46). *)
   "masc_deliver"
   :: List.map
        Keeper_tool_name.to_string
-       Keeper_tool_name.
-         [ Stay_silent
-         ; Task_done
-         ; Task_force_done
-         ; Task_force_release
-         ]
+       Keeper_tool_name.[ Task_done; Task_force_done; Task_force_release ]
 ;;
 
 let is_claim_tool_name name =
@@ -89,13 +76,6 @@ let is_claim_context_tool_name name =
 let is_completion_tool_name name =
   let name = Keeper_tool_resolution.canonical_tool_name name in
   List.mem name completion_tool_names
-;;
-
-let is_stay_silent_tool_name name =
-  let name = Keeper_tool_resolution.canonical_tool_name name in
-  match Keeper_tool_name.of_string name with
-  | Some Stay_silent -> true
-  | _ -> false
 ;;
 
 let is_keeper_observation_alias name =
@@ -163,20 +143,17 @@ let classify_tool_progress_with_outcome name outcome =
 ;;
 
 let is_owned_task_progress_tool_name name =
-  if is_stay_silent_tool_name name
+  let name = Keeper_tool_resolution.canonical_tool_name name in
+  if is_claim_context_tool_name name
   then false
+  else if is_completion_tool_name name
+  then true
+  else if Keeper_tool_capability_axis.supports Board_activity name
+  then true
   else (
-    let name = Keeper_tool_resolution.canonical_tool_name name in
-    if is_claim_context_tool_name name
-    then false
-    else if is_completion_tool_name name
-    then true
-    else if Keeper_tool_capability_axis.supports Board_activity name
-    then true
-    else (
-      match effect_domain_for_tool_name name with
-      | Some (Tool_catalog.Playground_write | Tool_catalog.Host_repo_write) -> true
-      | Some Tool_catalog.Masc_workspace | Some Tool_catalog.Read_only | None -> false))
+    match effect_domain_for_tool_name name with
+    | Some (Tool_catalog.Playground_write | Tool_catalog.Host_repo_write) -> true
+    | Some Tool_catalog.Masc_workspace | Some Tool_catalog.Read_only | None -> false)
 ;;
 
 let is_passive_status_tool_name name =

--- a/lib/keeper/keeper_tool_progress.mli
+++ b/lib/keeper/keeper_tool_progress.mli
@@ -48,16 +48,12 @@ val classify_tool_progress_with_outcome
 (** Canonical names of claim-context tools (Task_claim). *)
 val claim_context_tool_names : string list
 
-(** Canonical names of completion tools (Task_done variants, Stay_silent,
-    Deliver, etc.). *)
+(** Canonical names of completion tools (Task_done variants, Deliver, etc.). *)
 val completion_tool_names : string list
 
 val is_claim_tool_name : string -> bool
 val is_claim_context_tool_name : string -> bool
 val is_completion_tool_name : string -> bool
-
-(** [true] iff the canonicalized name is the historical keeper_stay_silent tool. *)
-val is_stay_silent_tool_name : string -> bool
 
 (** Extract OAS completion-contract satisfying-tool hints from an error reason.
     Returns [] when the reason has no hint or the hint is empty. *)

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -35,8 +35,7 @@ let keeper_voice_tool_schemas =
 
 (** Tools that bypass policy restrictions.  Survival-critical only:
     session control (extend_turns), token budget awareness
-    (context_status), tool discovery (tool_search), and the
-    no-op safety valve (stay_silent).
+    (context_status), and tool discovery (tool_search).
     keeper_tools_list moved to BM25-discoverable: it is a debugging
     aid, not survival-critical, and occupied a slot that small models
     wasted on meta-introspection instead of productive action.
@@ -44,7 +43,7 @@ let keeper_voice_tool_schemas =
 let core_always_tools =
   List.map
     Keeper_tool_name.to_string
-    Keeper_tool_name.[ Context_status; Stay_silent; Tool_search ]
+    Keeper_tool_name.[ Context_status; Tool_search ]
   @ [ "extend_turns" ]
 ;;
 

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -49,7 +49,6 @@ let handle_filesystem ctx descriptor args =
   | Tool_execute
   | Tool_search_files
   | Tool_time_now
-  | Tool_stay_silent
   | Tool_tools_list
   | Tool_tool_search
   | Tool_context_status
@@ -104,7 +103,6 @@ let handle_shell_ir ctx descriptor args =
   | Tool_edit_file
   | Tool_write_file
   | Tool_time_now
-  | Tool_stay_silent
   | Tool_tools_list
   | Tool_tool_search
   | Tool_context_status
@@ -138,8 +136,6 @@ let handle_in_process ctx descriptor args =
   match descriptor.Keeper_tool_descriptor.runtime_handler with
   | Tool_time_now ->
     Some (Keeper_tool_in_process_runtime.handle_time_now ~args)
-  | Tool_stay_silent ->
-    Some (Keeper_tool_in_process_runtime.handle_stay_silent ~args)
   | Tool_tools_list ->
     Some (Keeper_tool_in_process_runtime.handle_tools_list ~meta:ctx.meta ~args)
   | Tool_tool_search ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -666,16 +666,13 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
                     tool_names
                     |> List.exists (fun tool_name ->
                            let trimmed = String.trim tool_name in
-                           trimmed <> ""
-                           && not (String.equal trimmed "keeper_stay_silent"))
+                           trimmed <> "")
                   in
                   let tool_refs =
                     tool_names
                     |> List.filter_map (fun tool_name ->
                            let trimmed = String.trim tool_name in
-                           if trimmed = ""
-                              || String.equal trimmed "keeper_stay_silent"
-                           then None
+                           if trimmed = "" then None
                            else Some ("tool:" ^ trimmed))
                   in
                   let turn_refs =

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -373,11 +373,10 @@ let accountability_evidence_refs
     ~(result : Keeper_agent_run.run_result)
     ~(validated_evidence : Agent_sdk.Raw_trace.run_validation option) =
   let tool_refs =
-    let stay_silent = "keeper_stay_silent" in
     Keeper_agent_result.tool_names result
     |> List.filter_map (fun tool_name ->
            let trimmed = String.trim tool_name in
-           if trimmed = "" || String.equal trimmed stay_silent then None
+           if trimmed = "" then None
            else Some ("tool:" ^ trimmed))
   in
   let validation_refs =

--- a/lib/keeper/keeper_unified_turn_no_progress.ml
+++ b/lib/keeper/keeper_unified_turn_no_progress.ml
@@ -1,26 +1,26 @@
-(** Stay-silent loop recovery helpers for the unified keeper turn. *)
+(** No-progress loop recovery helpers for the unified keeper turn. *)
 
-(* RFC-0020: the stay-silent recovery stimulus carries no data — the consumer
+(* RFC-0020: the no-progress recovery stimulus carries no data — the consumer
    only branches on the kind. streak/threshold are recorded in the failure
    reason / blocker detail by the caller, not in the stimulus payload. *)
 let recovery_stimulus ~now ~keeper_name =
-  { Keeper_event_queue.post_id = "stay-silent-loop:" ^ keeper_name
+  { Keeper_event_queue.post_id = "no-progress-loop:" ^ keeper_name
   ; urgency = Keeper_event_queue.Immediate
   ; arrived_at = now
-  ; payload = Keeper_event_queue.Stay_silent_recovery
+  ; payload = Keeper_event_queue.No_progress_recovery
   }
 ;;
 
 let mark_loop_detected ~(config : Workspace.config) meta ~streak ~threshold =
   let detail =
     Printf.sprintf
-      "stay_silent loop detected: streak=%d threshold=%d; manual pause applied"
+      "no_progress loop detected: streak=%d threshold=%d; manual pause applied"
       streak
       threshold
   in
   let failure_reason =
     Keeper_registry.Provider_runtime_error
-      { code = "stay_silent_loop"
+      { code = "no_progress_loop"
       ; detail
       ; provider_id = None
       ; http_status = None
@@ -48,7 +48,7 @@ let mark_loop_detected ~(config : Workspace.config) meta ~streak ~threshold =
    | Eio.Cancel.Cancelled _ as exn -> raise exn
    | exn ->
      Log.Keeper.warn
-       "%s: failed to persist stay-silent recovery stimulus in reaction ledger: %s"
+       "%s: failed to persist no-progress recovery stimulus in reaction ledger: %s"
        meta.name
          (Printexc.to_string exn));
   let blocked_meta =
@@ -59,7 +59,7 @@ let mark_loop_detected ~(config : Workspace.config) meta ~streak ~threshold =
            Some
              (Keeper_meta_contract.blocker_info_of_class
                 ~detail
-                Keeper_meta_contract.Stay_silent_loop)
+                Keeper_meta_contract.No_progress_loop)
        })
     meta
   in
@@ -72,7 +72,7 @@ let mark_loop_detected ~(config : Workspace.config) meta ~streak ~threshold =
   with
   | Ok paused_meta ->
     Log.Keeper.warn
-      "%s: stay_silent loop escalated to blocker and manual pause \
+      "%s: no_progress loop escalated to blocker and manual pause \
        (streak=%d threshold=%d)"
       meta.name
       streak
@@ -81,7 +81,7 @@ let mark_loop_detected ~(config : Workspace.config) meta ~streak ~threshold =
   | Error pause_err ->
     Keeper_registry.wakeup ~base_path:config.base_path meta.name;
     Log.Keeper.error
-      "%s: stay_silent loop pause sync failed: %s; recovery stimulus queued \
+      "%s: no_progress loop pause sync failed: %s; recovery stimulus queued \
        instead (streak=%d threshold=%d)"
       meta.name
       pause_err
@@ -97,20 +97,20 @@ let clear_if_recovered ~(config : Workspace.config) meta ~previous_streak ~was_l
                Some (Keeper_registry.Provider_runtime_error { code; _ })
            ; _
            }
-      when String.equal code "stay_silent_loop" ->
+      when String.equal code "no_progress_loop" ->
       Keeper_registry.set_failure_reason
         ~base_path:config.base_path
         meta.name
         None;
       Log.Keeper.info
-        "%s: stay_silent loop recovered after non-silent turn \
+        "%s: no_progress loop recovered after progress turn \
          (previous_streak=%d)"
         meta.name
         previous_streak
     | _ -> ()
   end;
   match meta.runtime.last_blocker with
-  | Some { Keeper_meta_contract.klass = Keeper_meta_contract.Stay_silent_loop; _ } ->
+  | Some { Keeper_meta_contract.klass = Keeper_meta_contract.No_progress_loop; _ } ->
     Keeper_meta_contract.map_runtime (fun rt -> { rt with last_blocker = None }) meta
   | _ -> meta
 ;;

--- a/lib/keeper/keeper_unified_turn_no_progress.mli
+++ b/lib/keeper/keeper_unified_turn_no_progress.mli
@@ -1,4 +1,4 @@
-(** Stay-silent loop recovery helpers for the unified keeper turn. *)
+(** No-progress loop recovery helpers for the unified keeper turn. *)
 
 val mark_loop_detected
   :  config:Workspace.config

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -67,24 +67,24 @@ let apply_loop_detectors ~config ~social_state updated_meta result =
     | Social.Visible_reply | Social.Task_claim_surface -> false
   in
   let made_progress =
-    Keeper_stay_silent_loop_detector.turn_made_progress
+    Keeper_no_progress_loop_detector.turn_made_progress
       ~strong_evidence
       ~surface_requires_evidence
   in
   match
-    Keeper_stay_silent_loop_detector.record_turn
+    Keeper_no_progress_loop_detector.record_turn
       ~keeper_name:updated_meta.Keeper_meta_contract.name
       ~made_progress
   with
-  | Keeper_stay_silent_loop_detector.Normal -> updated_meta
-  | Keeper_stay_silent_loop_detector.Loop_detected { streak; threshold } ->
-    Keeper_unified_turn_stay_silent.mark_loop_detected
+  | Keeper_no_progress_loop_detector.Normal -> updated_meta
+  | Keeper_no_progress_loop_detector.Loop_detected { streak; threshold } ->
+    Keeper_unified_turn_no_progress.mark_loop_detected
       ~config
       updated_meta
       ~streak
       ~threshold
-  | Keeper_stay_silent_loop_detector.Loop_reset { previous_streak; was_latched } ->
-    Keeper_unified_turn_stay_silent.clear_if_recovered
+  | Keeper_no_progress_loop_detector.Loop_reset { previous_streak; was_latched } ->
+    Keeper_unified_turn_no_progress.clear_if_recovered
       ~config
       updated_meta
       ~previous_streak

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -207,7 +207,7 @@ let pending_board_event_of_stimulus
          ~meta
          ~arrived_at:stimulus.arrived_at
          (Board_signal.board_signal_of_board_stimulus ~post_id:stimulus.post_id bs))
-  | Keeper_event_queue.Bootstrap | Keeper_event_queue.Stay_silent_recovery -> None
+  | Keeper_event_queue.Bootstrap | Keeper_event_queue.No_progress_recovery -> None
 ;;
 
 (** Collect recent board activity using cursor-based tracking.

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -155,11 +155,7 @@ let tools_include_keeper tool tools =
   List.exists (keeper_tool_name_matches tool) tools
 
 let inferred_tool_surface tools =
-  if tools = [ "keeper_stay_silent" ] then
-    Some
-      ( { speech_act = Types.Stay_silent; delivery_surface = Types.Silent }
-      , Types.Tool_only_stay_silent )
-  else if tools_include_keeper "keeper_board_comment" tools then
+  if tools_include_keeper "keeper_board_comment" tools then
     Some
       ( {
           speech_act = Types.Comment_board;

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
@@ -88,7 +88,6 @@ let need_of_phase ~(phase : Fsm.phase)
       | _ -> None)
 
 let should_overlay_ledger = function
-  | Types.Tool_only_stay_silent
   | Types.Tool_only_comment_board
   | Types.Tool_only_post_board
   | Types.Tool_only_broadcast
@@ -159,7 +158,6 @@ let adapt_tool_only_turn (state : Types.social_state)
         },
         Types.Tool_only_progress_ledger,
         true )
-  | Types.Tool_only_stay_silent
   | Types.Tool_only_comment_board
   | Types.Tool_only_post_board
   | Types.Tool_only_broadcast

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -203,7 +203,7 @@ type t =
   | ExecuteLocalExecution
   | DockerRuntimeDiscarded
   | ProactiveSkip
-  | StaySilentLoopDetected
+  | NoProgressLoopDetected
   | UsageTrust
   | UsageAnomalyReason
   | ConfigEnvParseFailures
@@ -436,7 +436,7 @@ let to_string = function
   | ExecuteLocalExecution -> "masc_keeper_execute_local_execution_total"
   | DockerRuntimeDiscarded -> "masc_keeper_docker_runtime_discarded_total"
   | ProactiveSkip -> "masc_keeper_proactive_skip_total"
-  | StaySilentLoopDetected -> "masc_keeper_stay_silent_loop_detected_total"
+  | NoProgressLoopDetected -> "masc_keeper_no_progress_loop_detected_total"
   | UsageTrust -> "masc_keeper_usage_trust_total"
   | UsageAnomalyReason -> "masc_keeper_usage_anomaly_reason_total"
   | ConfigEnvParseFailures -> "masc_keeper_config_env_parse_failures_total"
@@ -511,7 +511,7 @@ let all : t list =
     ProviderTimeoutWatchdogTermination; StaleTerminationThresholdBreached; StaleTerminationBatch; StaleBroadcastEmitFailures;
     OasRunTimeout; RuntimeSaturationSignal; ToolUseFailure; ToolNotAllowed;
     TurnGateRejectedTerminal; ReceiptUnmappedDisposition; ExecuteNetworkUpgrade; ExecuteLocalExecution;
-    DockerRuntimeDiscarded; ProactiveSkip; StaySilentLoopDetected; UsageTrust;
+    DockerRuntimeDiscarded; ProactiveSkip; NoProgressLoopDetected; UsageTrust;
     UsageAnomalyReason; ConfigEnvParseFailures; PostTurnWireinFailures; RecurringFailures;
     TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; RuntimeHttpProbeJsonParseFailures;
     PromptSegmentBytes; PromptTemplateRenderOutcome; ToolCallParamCompleteness; KeeperTurnInstructionHash;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -194,7 +194,7 @@ type t =
   | ExecuteLocalExecution
   | DockerRuntimeDiscarded
   | ProactiveSkip
-  | StaySilentLoopDetected
+  | NoProgressLoopDetected
   | UsageTrust
   | UsageAnomalyReason
   | ConfigEnvParseFailures

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -26,7 +26,7 @@ type board_stimulus = {
 type stimulus_payload =
   | Board_signal of board_stimulus
   | Bootstrap
-  | Stay_silent_recovery
+  | No_progress_recovery
 
 type stimulus = {
   post_id : post_id;
@@ -92,11 +92,11 @@ let sort_by_urgency (queue : t) : t =
 let payload_kind_label = function
   | Board_signal _ -> "board_signal"
   | Bootstrap -> "bootstrap"
-  | Stay_silent_recovery -> "stay_silent_recovery"
+  | No_progress_recovery -> "no_progress_recovery"
 
 let is_board_signal = function
   | Board_signal _ -> true
-  | Bootstrap | Stay_silent_recovery -> false
+  | Bootstrap | No_progress_recovery -> false
 
 let drain_board_window ?(window_sec = 2.0) (queue : t) : stimulus list * t =
   let now = Unix.gettimeofday () in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -54,7 +54,7 @@ type board_stimulus = {
 type stimulus_payload =
   | Board_signal of board_stimulus
   | Bootstrap
-  | Stay_silent_recovery
+  | No_progress_recovery
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
     [classify] JSON-prefix round-trip: producers hold the typed value and
     consumers match it exhaustively, so an unrecognised stimulus is
@@ -98,7 +98,7 @@ val summary : t -> string
 
 val payload_kind_label : stimulus_payload -> string
 (** Stable short label for logs/metrics: ["board_signal"], ["bootstrap"],
-    or ["stay_silent_recovery"]. *)
+    or ["no_progress_recovery"]. *)
 
 val is_board_signal : stimulus_payload -> bool
 (** [true] iff the payload is a [Board_signal]. *)

--- a/lib/keeper_social/keeper_social_model_types.ml
+++ b/lib/keeper_social/keeper_social_model_types.ml
@@ -21,7 +21,6 @@ type model_id =
   | Magentic_ledger_v1
 
 type transition_reason =
-  | Tool_only_stay_silent
   | Tool_only_comment_board
   | Tool_only_post_board
   | Tool_only_broadcast
@@ -130,7 +129,6 @@ let normalize_social_model value =
       | None -> model_id_to_string default_model_id
 
 let transition_reason_to_string = function
-  | Tool_only_stay_silent -> "tool_only:stay_silent"
   | Tool_only_comment_board -> "tool_only:comment_board"
   | Tool_only_post_board -> "tool_only:post_board"
   | Tool_only_broadcast -> "tool_only:broadcast"

--- a/lib/keeper_social/keeper_social_model_types.mli
+++ b/lib/keeper_social/keeper_social_model_types.mli
@@ -21,7 +21,6 @@ type model_id =
   | Magentic_ledger_v1
 
 type transition_reason =
-  | Tool_only_stay_silent
   | Tool_only_comment_board
   | Tool_only_post_board
   | Tool_only_broadcast

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -36,7 +36,6 @@ type t =
   | Memory_search
   | Memory_write
   | Search_files
-  | Stay_silent
   | Surface_read
   | Surface_post
   | Person_note_set
@@ -86,7 +85,6 @@ let to_string = function
   | Memory_search -> "keeper_memory_search"
   | Memory_write -> "keeper_memory_write"
   | Search_files -> "tool_search_files"
-  | Stay_silent -> "keeper_stay_silent"
   | Surface_read -> "keeper_surface_read"
   | Surface_post -> "keeper_surface_post"
   | Person_note_set -> "keeper_person_note_set"
@@ -137,7 +135,6 @@ let of_string = function
   | "keeper_memory_search" -> Some Memory_search
   | "keeper_memory_write" -> Some Memory_write
   | "tool_search_files" -> Some Search_files
-  | "keeper_stay_silent" -> Some Stay_silent
   | "keeper_surface_read" -> Some Surface_read
   | "keeper_surface_post" -> Some Surface_post
   | "keeper_person_note_set" -> Some Person_note_set
@@ -205,7 +202,6 @@ let is_keeper_board_tool = function
   | Memory_search
   | Memory_write
   | Search_files
-  | Stay_silent
   | Surface_read
   | Surface_post
   | Person_note_set

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -34,7 +34,6 @@ type t =
   | Memory_search
   | Memory_write
   | Search_files
-  | Stay_silent
   | Surface_read
   | Surface_post
   | Person_note_set

--- a/lib/otel_metric_store/otel_builtin_metric_names.ml
+++ b/lib/otel_metric_store/otel_builtin_metric_names.ml
@@ -155,7 +155,7 @@ include Otel_identity_metric_names
 (* Centralized metric constants for inline string replacement.
    keeper_hooks_oas.ml, keeper_guards.ml, keeper_execution_receipt.ml,
    keeper_tool_execute_runtime.ml, keeper_sandbox_docker.ml,
-   keeper_heartbeat_snapshot.ml, keeper_stay_silent_loop_detector.ml,
+   keeper_heartbeat_snapshot.ml, keeper_no_progress_loop_detector.ml,
    keeper_unified_metrics.ml. *)
 (* OAS after-turn response metadata was accepted but omitted its response model
    field. This is provider response-shape telemetry, not keeper policy

--- a/lib/otel_metric_store/otel_builtin_metric_names.mli
+++ b/lib/otel_metric_store/otel_builtin_metric_names.mli
@@ -119,7 +119,7 @@ include module type of Otel_policy_metric_names
 
 (** Total stimuli consumed at turn entry, classified by [stimulus_class].
     Labels: [keeper], [class]
-    (board_signal|bootstrap|stay_silent_recovery|unsupported).
+    (board_signal|bootstrap|no_progress_recovery|unsupported).
     Pairs with [masc_keeper_unsupported_stimulus_total] for unsupported-only
     drill-down with payload prefix. *)
 

--- a/test/dune
+++ b/test/dune
@@ -237,7 +237,7 @@
   test_keeper_sandbox_docker_route
   test_keeper_tool_search_files_via_field
   test_env_git_noninteractive
-  test_stay_silent_loop_detector
+  test_no_progress_loop_detector
   test_cap_blocker_structured_error
   test_context_overflow_action_tracker
   test_keeper_fs_edit_patch
@@ -518,7 +518,7 @@
   test_keeper_sandbox_docker_route
   test_keeper_tool_search_files_via_field
   test_env_git_noninteractive
-  test_stay_silent_loop_detector
+  test_no_progress_loop_detector
   test_cap_blocker_structured_error
   test_context_overflow_action_tracker
   test_keeper_fs_edit_patch

--- a/test/keeper_event_queue/test_keeper_event_queue.ml
+++ b/test/keeper_event_queue/test_keeper_event_queue.ml
@@ -115,8 +115,8 @@ let test_dequeue_only_consumes_enqueued () =
 (* Typed payload (RFC-0020): the kind is carried as a closed variant,
    not classified from a JSON-prefixed string. *)
 let test_typed_payload_surface () =
-  let stay = make_stim ~payload:Stay_silent_recovery "stay-silent-loop:k" in
-  assert (String.equal (payload_kind_label stay.payload) "stay_silent_recovery");
+  let stay = make_stim ~payload:No_progress_recovery "no-progress-loop:k" in
+  assert (String.equal (payload_kind_label stay.payload) "no_progress_recovery");
   assert (not (is_board_signal stay.payload));
   let board =
     make_stim

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -34,7 +34,7 @@ let all_variants : blocker_class list =
   ; Turn_timeout
   ; Turn_livelock_blocked
   ; Completion_contract_violation
-  ; Stay_silent_loop
+  ; No_progress_loop
   ; Fiber_unresolved
   ; Stale_turn_timeout
   ; Stale_fleet_batch

--- a/test/test_context_overflow_action_tracker.ml
+++ b/test/test_context_overflow_action_tracker.ml
@@ -1,7 +1,7 @@
 (* test/test_context_overflow_action_tracker.ml
 
    #9935: detector for imminent→action pairing on context
-   overflow events. Mirrors the #9931 stay_silent detector
+   overflow events. Mirrors the #9931 no-progress detector
    pattern (latched per-episode counter + per-keeper state).
 
    Invariants:

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -144,19 +144,19 @@ let make_meta name =
   | Ok meta -> meta
   | Error err -> fail ("parse base: " ^ err)
 
-let test_stay_silent_loop_detection_pauses_keeper () =
-  let base_path = temp_dir "masc-stay-silent-pause-" in
+let test_no_progress_loop_detection_pauses_keeper () =
+  let base_path = temp_dir "masc-no-progress-pause-" in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
        let config = Masc.Workspace.default_config base_path in
        ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       let keeper_name = "stay-silent-paused" in
+       let keeper_name = "no-progress-paused" in
        let meta = make_meta keeper_name in
        Masc.Keeper_registry.clear ();
        ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
        let paused_meta =
-         Masc.Keeper_unified_turn_stay_silent.mark_loop_detected
+         Masc.Keeper_unified_turn_no_progress.mark_loop_detected
            ~config
            meta
            ~streak:10
@@ -169,14 +169,14 @@ let test_stay_silent_loop_detection_pauses_keeper () =
          None
        paused_meta.auto_resume_after_sec;
        (match paused_meta.runtime.last_blocker with
-        | Some { Keeper_meta_contract.klass = Stay_silent_loop; detail } ->
+        | Some { Keeper_meta_contract.klass = No_progress_loop; detail } ->
           check
             string
             "blocker detail"
-            "stay_silent loop detected: streak=10 threshold=10; manual pause applied"
+            "no_progress loop detected: streak=10 threshold=10; manual pause applied"
             detail
-        | Some _ -> fail "expected Stay_silent_loop blocker"
-        | None -> fail "expected stay_silent loop blocker");
+        | Some _ -> fail "expected No_progress_loop blocker"
+        | None -> fail "expected no_progress loop blocker");
        match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
        | Some entry ->
          check bool "registry meta paused" true entry.Masc.Keeper_registry.meta.paused
@@ -283,10 +283,10 @@ let () =
           test_case "legacy blocker string rejected" `Quick
             test_legacy_last_blocker_string_rejected;
         ] );
-      ( "stay_silent loop",
+      ( "no_progress loop",
         [
           test_case "loop detection pauses keeper for manual resume" `Quick
-            test_stay_silent_loop_detection_pauses_keeper;
+            test_no_progress_loop_detection_pauses_keeper;
         ] );
       ( "idle-detected loop",
         [

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -17,7 +17,7 @@ let () =
   assert (not (is_board_signal Bootstrap));
   assert (String.equal (payload_kind_label (board_payload ())) "board_signal");
   assert (String.equal (payload_kind_label Bootstrap) "bootstrap");
-  assert (String.equal (payload_kind_label Stay_silent_recovery) "stay_silent_recovery");
+  assert (String.equal (payload_kind_label No_progress_recovery) "no_progress_recovery");
 
   (* --- queue operations preserved --- *)
   let board_stim =

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -32,13 +32,13 @@ let board_stimulus ?(post_id = "post-42") ?updated_at () :
   }
 ;;
 
-let stay_silent_recovery_stimulus ?(keeper_name = "silent-keeper") () :
+let no_progress_recovery_stimulus ?(keeper_name = "no-progress-keeper") () :
   Keeper_event_queue.stimulus
   =
-  { post_id = "stay-silent-loop:" ^ keeper_name
+  { post_id = "no-progress-loop:" ^ keeper_name
   ; urgency = Immediate
   ; arrived_at = 1234.5
-  ; payload = Keeper_event_queue.Stay_silent_recovery
+  ; payload = Keeper_event_queue.No_progress_recovery
   }
 ;;
 
@@ -270,10 +270,10 @@ let test_summary_cursor_ack_respects_post_id_tiebreaker () =
     (complete_summary |> member "pending_stimulus_count" |> to_int)
 ;;
 
-let test_stay_silent_recovery_stimulus_is_typed () =
+let test_no_progress_recovery_stimulus_is_typed () =
   with_temp_base @@ fun base_path ->
-  let keeper_name = "silent-keeper" in
-  let stimulus = stay_silent_recovery_stimulus ~keeper_name () in
+  let keeper_name = "no-progress-keeper" in
+  let stimulus = no_progress_recovery_stimulus ~keeper_name () in
   Keeper_reaction_ledger.record_event_queue_stimulus
     ~base_path
     ~keeper_name
@@ -283,18 +283,18 @@ let test_stay_silent_recovery_stimulus_is_typed () =
     |> latest_row
   in
   check_member_string
-    "stay-silent stimulus kind"
-    "stay_silent_recovery"
+    "no-progress stimulus kind"
+    "no_progress_recovery"
     "kind"
     (row |> member "stimulus");
   check string "stable stimulus prefix" "stimulus:"
     (String.sub (row |> member "stimulus_id" |> to_string) 0 9)
 ;;
 
-let test_stay_silent_recovery_reaction_clears_pending () =
+let test_no_progress_recovery_reaction_clears_pending () =
   with_temp_base @@ fun base_path ->
-  let keeper_name = "silent-keeper" in
-  let stimulus = stay_silent_recovery_stimulus ~keeper_name () in
+  let keeper_name = "no-progress-keeper" in
+  let stimulus = no_progress_recovery_stimulus ~keeper_name () in
   Keeper_reaction_ledger.record_event_queue_stimulus
     ~base_path
     ~keeper_name
@@ -380,13 +380,13 @@ let () =
             `Quick
             test_summary_cursor_ack_respects_post_id_tiebreaker
         ; test_case
-            "stay-silent recovery stimulus is typed"
+            "no-progress recovery stimulus is typed"
             `Quick
-            test_stay_silent_recovery_stimulus_is_typed
+            test_no_progress_recovery_stimulus_is_typed
         ; test_case
-            "stay-silent recovery reaction clears pending"
+            "no-progress recovery reaction clears pending"
             `Quick
-            test_stay_silent_recovery_reaction_clears_pending
+            test_no_progress_recovery_reaction_clears_pending
         ; test_case
             "unknown reaction degrades summary"
             `Quick

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -1,14 +1,14 @@
-(* test/test_stay_silent_loop_detector.ml
+(* test/test_no_progress_loop_detector.ml
 
    #9926: detector observability contract. Pins:
-   - Streak increments on consecutive "stay_silent" speech_act
-   - Streak resets to 0 on any non-stay_silent act
+   - Streak increments on consecutive no-progress turns
+   - Streak resets to 0 on any progress turn
    - Detected-counter only bumps once per loop episode (latched)
    - Reset latches on streak reset
    - Threshold is the product constant
    - Per-keeper isolation *)
 
-module D = Masc.Keeper_stay_silent_loop_detector
+module D = Masc.Keeper_no_progress_loop_detector
 module Metrics = Masc.Otel_metric_store
 
 (* Detector now uses Eio.Mutex (was Stdlib.Mutex; the latter raised EDEADLK
@@ -18,7 +18,7 @@ let with_eio f () = Eio_main.run @@ fun _env -> f ()
 
 let detected_count keeper =
   Metrics.metric_value_or_zero
-    "masc_keeper_stay_silent_loop_detected_total"
+    "masc_keeper_no_progress_loop_detected_total"
     ~labels:[ ("keeper", keeper) ] ()
 
 let record_turn = D.record_turn
@@ -49,7 +49,7 @@ let test_any_other_act_resets () =
    | D.Normal | D.Loop_detected _ -> Alcotest.fail "expected loop reset");
   Alcotest.(check int) "after declare" 0 (D.current_streak ~keeper_name:k);
   record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome;
-  Alcotest.(check int) "after new stay_silent" 1
+  Alcotest.(check int) "after new no-progress turn" 1
     (D.current_streak ~keeper_name:k)
 
 let test_threshold_crossing_fires_counter () =
@@ -76,7 +76,7 @@ let test_latched_no_repeat_while_streak_grows () =
   for _ = 1 to D.threshold () + 7 do
     record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome
   done;
-  Alcotest.(check (float 0.0001)) "latched: exactly +1 across long stay_silent run"
+  Alcotest.(check (float 0.0001)) "latched: exactly +1 across long no-progress run"
     (before +. 1.0) (detected_count k)
 
 let test_latch_releases_on_reset_then_refires () =
@@ -88,7 +88,7 @@ let test_latch_releases_on_reset_then_refires () =
   done;
   Alcotest.(check (float 0.0001)) "first loop fires once"
     (before +. 1.0) (detected_count k);
-  (* Break the loop with a non-stay_silent act. *)
+  (* Break the loop with a progress turn. *)
   (match record_turn ~keeper_name:k ~made_progress:true with
    | D.Loop_reset { was_latched; _ } ->
      Alcotest.(check bool) "reset releases latched loop" true was_latched
@@ -119,11 +119,11 @@ let test_threshold_constant_is_10 () =
   Alcotest.(check int) "default threshold" 10 (D.threshold ())
 
 let test_threshold_env_is_ignored () =
-  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" "25";
+  Unix.putenv "MASC_NO_PROGRESS_LOOP_THRESHOLD" "25";
   Alcotest.(check int) "env ignored" 10 (D.threshold ());
-  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" "notanumber";
+  Unix.putenv "MASC_NO_PROGRESS_LOOP_THRESHOLD" "notanumber";
   Alcotest.(check int) "non-numeric → default" 10 (D.threshold ());
-  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" ""
+  Unix.putenv "MASC_NO_PROGRESS_LOOP_THRESHOLD" ""
 
 let test_explicit_reset () =
   D.reset_all_for_test ();
@@ -141,7 +141,7 @@ let test_explicit_reset () =
    produced durable evidence OR was on a surface that does not require it. The
    key new case is the third one: a no-evidence turn on a peer-facing surface
    (board post) is NOT progress, so the streak accrues — the exact case the old
-   speech_act="stay_silent" check missed. *)
+   literal silent speech-act check missed. *)
 let test_made_progress_predicate () =
   Alcotest.(check bool) "evidence on evidence-required surface = progress" true
     (D.turn_made_progress ~strong_evidence:true ~surface_requires_evidence:true);
@@ -171,13 +171,13 @@ let test_no_progress_board_post_accrues_streak () =
     (D.current_streak ~keeper_name:k)
 
 let () =
-  Alcotest.run "keeper_stay_silent_loop_detector"
+  Alcotest.run "keeper_no_progress_loop_detector"
     [
       ( "streak semantics",
         [
-          Alcotest.test_case "increments on stay_silent"
+          Alcotest.test_case "increments on no-progress"
             `Quick (with_eio test_streak_increments);
-          Alcotest.test_case "any other act resets"
+          Alcotest.test_case "progress resets"
             `Quick (with_eio test_any_other_act_resets);
           Alcotest.test_case "explicit reset"
             `Quick (with_eio test_explicit_reset);


### PR DESCRIPTION
## Summary
- Remove the legacy `keeper_stay_silent` tool vocabulary, runtime handler, core tool registration, completion-progress path, and social-model tool-only inference.
- Rename the no-progress loop detector/recovery/blocker surfaces from stay-silent names to `no_progress_*`, including metrics and tests.
- Update docs and test names so the remaining `stay_silent` references are only the social-model speech act / prompt concept.

## Validation
- `env DUNE_BUILD_DIR=/private/tmp/masc-no-progress-build MASC_DUNE_ALLOW_BARE_DUNE=1 opam exec -- dune build --root . lib/masc.cmxa test/test_no_progress_loop_detector.exe test/test_keeper_auto_pause_blocker_persist_12683.exe test/test_keeper_reaction_ledger.exe test/test_keeper_event_queue.exe test/keeper_event_queue/test_keeper_event_queue.exe test/test_blocker_class_exhaustiveness.exe`
- `/private/tmp/masc-no-progress-build/default/test/test_no_progress_loop_detector.exe`
- `/private/tmp/masc-no-progress-build/default/test/test_keeper_auto_pause_blocker_persist_12683.exe`
- `/private/tmp/masc-no-progress-build/default/test/test_keeper_reaction_ledger.exe`
- `/private/tmp/masc-no-progress-build/default/test/test_keeper_event_queue.exe`
- `/private/tmp/masc-no-progress-build/default/test/keeper_event_queue/test_keeper_event_queue.exe`
- `/private/tmp/masc-no-progress-build/default/test/test_blocker_class_exhaustiveness.exe`
- `git diff --check` / `git diff --cached --check`
- `rg` sweep for legacy tool/detector/recovery names returned no repo matches.

## Side-effect check
- Live `/health?full=1` was ok with paused/blocker/pending stimulus counts at 0.
- Current live `.masc` still has historical/free-text `keeper_stay_silent` mentions in keeper meta/log artifacts; repo config scan is clean, but deployed runtime config should be synced after merge if those live instructions are still authoritative.