### PR TITLE
refactor(keeper): type the keeper surface_status carrier (RFC-0089)

### DIFF
--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -507,6 +507,40 @@ let augment_keeper_diagnostic_json
         :: filtered)
   | other -> other
 
+(* RFC-0089 — the keeper "surface status" is the display status that
+   [keeper_surface_status] derives from (keeper_health × agent_status). It is
+   carried on the wire as a string and re-classified by literal in the operator
+   align step, the server row patcher, and the dashboard pressure ranker. Close
+   it into a sum so the producer builds it exhaustively and those consumers
+   match it via [surface_status_of_string_opt] instead of comparing literals.
+   "paused" is NOT part of this domain — it is a control-plane override
+   (meta.paused) applied one layer above, at operator_control_snapshot. *)
+type surface_status =
+  | Surface_active
+  | Surface_busy
+  | Surface_listening
+  | Surface_inactive
+  | Surface_offline
+  | Surface_idle
+
+let surface_status_to_string = function
+  | Surface_active -> "active"
+  | Surface_busy -> "busy"
+  | Surface_listening -> "listening"
+  | Surface_inactive -> "inactive"
+  | Surface_offline -> "offline"
+  | Surface_idle -> "idle"
+
+let surface_status_of_string_opt s =
+  match String.lowercase_ascii (String.trim s) with
+  | "active" -> Some Surface_active
+  | "busy" -> Some Surface_busy
+  | "listening" -> Some Surface_listening
+  | "inactive" -> Some Surface_inactive
+  | "offline" -> Some Surface_offline
+  | "idle" -> Some Surface_idle
+  | _ -> None
+
 let keeper_surface_status
     ~(agent_status : Yojson.Safe.t)
     ~(diagnostic : Yojson.Safe.t) =
@@ -516,16 +550,20 @@ let keeper_surface_status
     |> keeper_health_or_offline ~source:"keeper_surface_status"
   in
   let agent_runtime_status = agent_runtime_status_opt agent_status in
-  match health_state with
-  | KH_healthy -> (
-      match agent_runtime_status with
-      | Some ((Masc_domain.Active | Masc_domain.Busy | Masc_domain.Listening) as s) ->
-          Masc_domain.string_of_agent_status s
-      | Some Masc_domain.Inactive -> "offline"
-      | None -> "active")
-  | KH_idle -> "idle"
-  | KH_stale | KH_degraded | KH_zombie | KH_dead -> "inactive"
-  | KH_offline -> "offline"
+  let surface =
+    match health_state with
+    | KH_healthy -> (
+        match agent_runtime_status with
+        | Some Masc_domain.Active -> Surface_active
+        | Some Masc_domain.Busy -> Surface_busy
+        | Some Masc_domain.Listening -> Surface_listening
+        | Some Masc_domain.Inactive -> Surface_offline
+        | None -> Surface_active)
+    | KH_idle -> Surface_idle
+    | KH_stale | KH_degraded | KH_zombie | KH_dead -> Surface_inactive
+    | KH_offline -> Surface_offline
+  in
+  surface_status_to_string surface
 
 let keeper_diagnostic_json
     ~(meta : keeper_meta)

--- a/lib/keeper/keeper_status_runtime.mli
+++ b/lib/keeper/keeper_status_runtime.mli
@@ -54,6 +54,23 @@ val keeper_health_state :
   unit ->
   keeper_health
 
+(** Keeper display status derived from (keeper_health x agent_status). Closed so
+    consumers that classify it match exhaustively. "paused" is a control-plane
+    override applied above this layer, not a member of this domain. *)
+type surface_status =
+  | Surface_active
+  | Surface_busy
+  | Surface_listening
+  | Surface_inactive
+  | Surface_offline
+  | Surface_idle
+
+val surface_status_to_string : surface_status -> string
+
+(** Parse a wire/display status string into {!surface_status}; [None] when the
+    value is outside the six labels (e.g. "paused" or drift). *)
+val surface_status_of_string_opt : string -> surface_status option
+
 val keeper_surface_status :
   agent_status:Yojson.Safe.t ->
   diagnostic:Yojson.Safe.t ->

--- a/lib/operator/operator_control_snapshot_runtime_status.ml
+++ b/lib/operator/operator_control_snapshot_runtime_status.ml
@@ -48,14 +48,16 @@ let align_keeper_runtime_status
   if not keepalive_running
   then surface_status
   else (
-    let normalized_surface = String.lowercase_ascii (String.trim surface_status) in
     let runtime_status =
       if health_state_allows_runtime_status_override diagnostic
       then runtime_status_from_live_signal agent_status_json
       else None
     in
-    match normalized_surface, runtime_status with
-    | ("inactive" | "offline"), Some status -> status
+    (* RFC-0089: override only when the surface status is inactive/offline.
+       Classify via the typed surface_status SSOT instead of string literals. *)
+    match Keeper_status_runtime.surface_status_of_string_opt surface_status, runtime_status with
+    | Some (Keeper_status_runtime.Surface_inactive | Keeper_status_runtime.Surface_offline), Some status ->
+      status
     | _ -> surface_status)
 ;;
 

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -455,10 +455,17 @@ let patched_keeper_status row ~keepalive_running =
   if not keepalive_running
   then `String "offline"
   else (
-    match keeper_agent_status_opt row with
-    | Some (("busy" | "active" | "listening" | "idle") as status) -> `String status
-    | Some ("offline" | "inactive") -> `String "offline"
-    | _ -> `String "idle")
+    (* RFC-0089: classify the row's display status via the typed surface_status
+       SSOT. busy/active/listening/idle pass through; inactive/offline collapse
+       to "offline"; anything outside the domain defaults to "idle". *)
+    match
+      Option.bind (keeper_agent_status_opt row)
+        Keeper_status_runtime.surface_status_of_string_opt
+    with
+    | Some ((Surface_busy | Surface_active | Surface_listening | Surface_idle) as s) ->
+      `String (Keeper_status_runtime.surface_status_to_string s)
+    | Some (Surface_offline | Surface_inactive) -> `String "offline"
+    | None -> `String "idle")
 ;;
 
 let patch_keeper_row ~keeper_name ~event ~keepalive_running = function

--- a/test/dune
+++ b/test/dune
@@ -1531,6 +1531,8 @@
 
 (include stanzas/test_keeper_supervisor_finally_cancel_swallow.inc)
 
+(include stanzas/test_keeper_surface_status.inc)
+
 (include stanzas/test_failing_minimum_essential.inc)
 
 (include stanzas/test_keeper_memory_write.inc)

--- a/test/stanzas/test_keeper_surface_status.inc
+++ b/test/stanzas/test_keeper_surface_status.inc
@@ -1,0 +1,8 @@
+; Per-file dune stanza for the typed keeper surface_status suite (RFC-0089).
+; Lives here per test/stanzas/README.md to avoid the conflict-runtime hotspot
+; in the legacy grouped (tests ...) stanza.
+
+(test
+ (name test_keeper_surface_status)
+ (modules test_keeper_surface_status)
+ (libraries masc_test_deps masc alcotest))

--- a/test/test_keeper_surface_status.ml
+++ b/test/test_keeper_surface_status.ml
@@ -1,0 +1,96 @@
+(* RFC-0089 (String Classifier to Typed Variant) — keeper surface_status.
+
+   keeper_surface_status derives a display status from (keeper_health x
+   agent_status) and emits it as a string; the operator align step and the
+   server row patcher re-classify that string by literal. These tests pin:
+   (1) surface_status_of_string_opt parses the six labels and rejects values
+       outside the domain ("paused" override, drift, garbage),
+   (2) to_string is the inverse on the closed domain,
+   (3) keeper_surface_status produces the expected wire string for each
+       (keeper_health x agent_status) combination — behavior preserved. *)
+
+module K = Masc.Keeper_status_runtime
+open Alcotest
+
+let blob pairs : Yojson.Safe.t = `Assoc pairs
+let diag h = blob [ ("health_state", `String h) ]
+let status s = blob [ ("status", `String s) ]
+
+let test_of_string_known () =
+  let one label ctor =
+    check bool
+      (Printf.sprintf "%s parses" label)
+      true
+      (K.surface_status_of_string_opt label = Some ctor)
+  in
+  one "active" K.Surface_active;
+  one "busy" K.Surface_busy;
+  one "listening" K.Surface_listening;
+  one "inactive" K.Surface_inactive;
+  one "offline" K.Surface_offline;
+  one "idle" K.Surface_idle;
+  check bool "case + whitespace insensitive" true
+    (K.surface_status_of_string_opt "  OFFLINE " = Some K.Surface_offline)
+
+let test_of_string_outside_domain () =
+  (* "paused" is a control-plane override, not a surface_status; the rest are
+     drift/garbage. All must parse to None. *)
+  List.iter
+    (fun s ->
+      check bool
+        (Printf.sprintf "%S -> None" s)
+        true
+        (K.surface_status_of_string_opt s = None))
+    [ "paused"; "error"; "stale"; "zombie"; "unknown"; "" ]
+
+let test_to_string_inverse () =
+  List.iter
+    (fun ctor ->
+      check bool "to_string then of_string round-trips" true
+        (K.surface_status_of_string_opt (K.surface_status_to_string ctor)
+        = Some ctor))
+    [
+      K.Surface_active;
+      K.Surface_busy;
+      K.Surface_listening;
+      K.Surface_inactive;
+      K.Surface_offline;
+      K.Surface_idle;
+    ]
+
+let test_producer_behavior () =
+  let surface ~health ~agent_status =
+    K.keeper_surface_status ~agent_status ~diagnostic:(diag health)
+  in
+  (* KH_healthy maps agent_status through *)
+  check string "healthy+active -> active" "active"
+    (surface ~health:"healthy" ~agent_status:(status "active"));
+  check string "healthy+busy -> busy" "busy"
+    (surface ~health:"healthy" ~agent_status:(status "busy"));
+  check string "healthy+listening -> listening" "listening"
+    (surface ~health:"healthy" ~agent_status:(status "listening"));
+  check string "healthy+inactive -> offline" "offline"
+    (surface ~health:"healthy" ~agent_status:(status "inactive"));
+  check string "healthy+unknown -> active (default)" "active"
+    (surface ~health:"healthy" ~agent_status:(status "idle"));
+  (* keeper_health drives the rest regardless of agent_status *)
+  check string "idle health -> idle" "idle"
+    (surface ~health:"idle" ~agent_status:(status "active"));
+  check string "stale health -> inactive" "inactive"
+    (surface ~health:"stale" ~agent_status:(status "active"));
+  check string "offline health -> offline" "offline"
+    (surface ~health:"offline" ~agent_status:(status "active"))
+
+let () =
+  run "keeper_surface_status"
+    [
+      ( "surface_status_of_string_opt",
+        [
+          test_case "known labels" `Quick test_of_string_known;
+          test_case "outside domain -> None" `Quick test_of_string_outside_domain;
+          test_case "to_string inverse" `Quick test_to_string_inverse;
+        ] );
+      ( "keeper_surface_status",
+        [ test_case "producer behavior preserved" `Quick test_producer_behavior ]
+      );
+    ]


### PR DESCRIPTION
## 목적
keeper display status(`keeper_surface_status` 산출)를 string 리터럴 분류 → 닫힌 `surface_status` variant로 전환합니다 (RFC-0089, #21213 후속 — #21213이 명시적으로 남긴 broader-어휘 작업).

## 배경
`keeper_surface_status`가 (keeper_health × agent_status)에서 display status를 유도해 string으로 방출 → operator `align_keeper_runtime_status`와 server `patched_keeper_status`가 그 string을 리터럴로 재분류. 도메인 = `{active,busy,listening,inactive,offline,idle}`.

## 변경 (cascade 회피 설계)
- 닫힌 `surface_status` sum + `surface_status_to_string`/`surface_status_of_string_opt` SSOT 도입 (keeper_status_runtime).
- `keeper_surface_status`가 내부적으로 typed 값을 구성하고 `to_string`으로 직렬화 → **반환 시그니처는 string 유지**(wire format·전 caller 불변, 반환타입 cascade 없음). 새 surface 값은 producer의 exhaustive `to_string`에서 컴파일 에러.
- 분류기 2곳을 SSOT 파싱 + exhaustive 매칭으로 전환: operator `align_keeper_runtime_status`, server `patched_keeper_status`.
- 신규 test 4 케이스 (of_string 6라벨/도메인밖 None, to_string 역함수, producer 행위 보존).

## 범위 밖 (의도적 — 매핑으로 확정)
매핑 워크플로(wf_b3c8dadb, 3 agent)가 "surface status처럼 보이는" 9개 사이트를 어휘별로 분해 → 대부분 **다른 닫힌 도메인**이라 같은 ADT 강요는 conflation 버그:
- `dashboard_utils status_rank` / `dashboard_briefing` = **agent_status** (idle arm dead)
- `feature_proof status_rank` / `active_status_rank` / `tone_rank` = feature_proof / task_status / tone (**이미 typed**)
- `pipeline_stage_of_lifecycle_event` = pipeline_stage `{crashed,failing,overflowed,compacting...}` (broader)
- `worker_state_of_agent` / judge runtime = worker_state / judge (별도)
- `is_keeper_offline` / `pressure_rank` = is-offline 술어("error" 포함, surface_status 밖)
- `"paused"`는 control-plane override(`meta.paused`) 단일 라벨로 유지 (이 도메인 멤버 아님).

## 검증
- `dune build --root . @check` exit 0 (keeper+operator+server lib + 전체 test 컴파일).
- 신규 test 4/4 통과.

WORKAROUND-WAIVED: string classifier를 *제거*하고 닫힌 variant로 대체합니다(추가 아님). STRING_CLASSIFIER 게이트 시그니처는 false-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
