### PR TITLE
refactor(keeper): state_snapshot_source를 closed variant로 (RFC-0242 §3.2)

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -72,7 +72,7 @@ let finalize
   in
   let resume_merge =
     pre_dispatch_compacted
-    || String.equal state_snapshot_source "synthesized"
+    || Keeper_memory_policy.state_snapshot_source_is_synthetic state_snapshot_source
     || is_budget_exhausted result.stop_reason
   in
   let { Keeper_agent_run_sidecar.working_state = _

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -17,7 +17,7 @@ val run :
   response_text:string ->
   actual_tools:string list ->
   state_snapshot:Keeper_memory_policy.keeper_state_snapshot ->
-  state_snapshot_source:string ->
+  state_snapshot_source:Keeper_memory_policy.state_snapshot_source ->
   librarian_messages:Agent_sdk.Types.message list ->
   post_turn_t0:float ->
   runtime_id:string ->

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -2,7 +2,7 @@
 
 type finalized = {
   state_snapshot : Keeper_memory_policy.keeper_state_snapshot;
-  state_snapshot_source : string;
+  state_snapshot_source : Keeper_memory_policy.state_snapshot_source;
   response_text : string;
 }
 
@@ -20,16 +20,16 @@ let state_snapshot ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_to
       ()
   =
   match reported_state_snapshot with
-  | Some snapshot -> (snapshot, "model_structured_state_tool")
+  | Some snapshot -> (snapshot, Keeper_memory_policy.Structured_state_tool)
   | None ->
     (match
        Keeper_memory_policy.parse_structured_state_snapshot_from_reply
          raw_response_text
      with
-     | Some snapshot -> (snapshot, "model_structured_state")
+     | Some snapshot -> (snapshot, Keeper_memory_policy.Structured_state_reply)
      | None ->
        (match Keeper_memory_policy.parse_state_snapshot_from_reply raw_response_text with
-        | Some snapshot -> (snapshot, "model_state_block")
+        | Some snapshot -> (snapshot, Keeper_memory_policy.State_block)
         | None ->
           let stop_reason_str = stop_reason_label stop_reason in
           let synth =
@@ -43,20 +43,25 @@ let state_snapshot ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_to
             "state metadata missing, synthesized from %d tools (stop=%s)"
             (List.length actual_keeper_tool_names)
             stop_reason_str;
-          (synth, "synthesized")))
+          (synth, Keeper_memory_policy.Synthesized)))
 ;;
 
 let response_text ~state_snapshot ~state_snapshot_source ~raw_response_text =
+  let is_structured_reply =
+    match (state_snapshot_source : Keeper_memory_policy.state_snapshot_source) with
+    | Structured_state_reply -> true
+    | Structured_state_tool | State_block | Synthesized -> false
+  in
   let fallback =
     match
       Keeper_text_processing.state_snapshot_reply_fallback (Some state_snapshot)
     with
     | Some _ as fallback -> fallback
-    | None when String.equal state_snapshot_source "model_structured_state" ->
+    | None when is_structured_reply ->
       Some "State updated."
     | None -> None
   in
-  if String.equal state_snapshot_source "model_structured_state" then
+  if is_structured_reply then
     Keeper_text_processing.user_visible_reply_text ?fallback ""
   else
     match fallback with

--- a/lib/keeper/keeper_agent_run_response_text.mli
+++ b/lib/keeper/keeper_agent_run_response_text.mli
@@ -2,7 +2,7 @@
 
 type finalized = {
   state_snapshot : Keeper_memory_policy.keeper_state_snapshot;
-  state_snapshot_source : string;
+  state_snapshot_source : Keeper_memory_policy.state_snapshot_source;
   response_text : string;
 }
 

--- a/lib/keeper/keeper_agent_run_sidecar.ml
+++ b/lib/keeper/keeper_agent_run_sidecar.ml
@@ -166,7 +166,7 @@ let save_sidecars
         ("generation", `Int generation);
         ("keeper_turn_id", `Int keeper_turn_id);
         ("oas_turn_count", `Int oas_turn_count);
-        ("source", `String state_snapshot_source);
+        ("source", `String (Keeper_memory_policy.state_snapshot_source_to_string state_snapshot_source));
         ("active_open_loop_count", `Int active_open_loop_count);
         ("working_state", Keeper_working_state.to_json working_state);
       ]
@@ -251,7 +251,7 @@ let save_sidecars
             `List
               (List.map (fun id -> `String id) working_state.prompt_digest_ids)
           );
-          ("source", `String state_snapshot_source);
+          ("source", `String (Keeper_memory_policy.state_snapshot_source_to_string state_snapshot_source));
         ])
     Keeper_runtime_manifest.State_snapshot_sidecar_saved;
   append_manifest ~site:"working_state_sidecar"
@@ -272,7 +272,7 @@ let save_sidecars
             `List
               (List.map (fun id -> `String id) working_state.prompt_digest_ids)
           );
-          ("source", `String state_snapshot_source);
+          ("source", `String (Keeper_memory_policy.state_snapshot_source_to_string state_snapshot_source));
         ])
     Keeper_runtime_manifest.Working_state_sidecar_saved;
   { working_state; state_snapshot_saved = state_snapshot_saved

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -693,18 +693,24 @@ let append_memory_notes_from_reply
     ~(turn : int)
     ~(reply : string)
     () : (int * string list) =
-  let (snapshot, source) =
+  (* [source] is the per-note provenance written to the memory-bank JSONL — a
+     separate vocabulary from the turn-cascade [state_snapshot_source]. The
+     turn-cascade source (when present) is rendered to its wire string and carries
+     its typed synthetic-ness; the internal fallback labels are never synthetic.
+     RFC-0242 §3.2: the candidate gate now receives the [is_synthetic] bit, not a
+     string to re-classify. *)
+  let (snapshot, source, is_synthetic) =
     match snapshot with
     | Some s ->
-      let source =
-        match state_snapshot_source with
-        | Some source -> source
-        | None -> "message_metadata"
-      in
-      (s, source)
+      (match state_snapshot_source with
+       | Some src ->
+         ( s,
+           Keeper_memory_policy.state_snapshot_source_to_string src,
+           Keeper_memory_policy.state_snapshot_source_is_synthetic src )
+       | None -> (s, "message_metadata", false))
     | None ->
       (match parse_state_snapshot_from_reply reply with
-    | Some s -> (s, "reply_state_block")
+    | Some s -> (s, "reply_state_block", false)
     | None ->
         (* Deterministic fallback: use keeper meta fields as memory source.
            This guarantees memory write regardless of LLM output format.
@@ -720,10 +726,10 @@ let append_memory_notes_from_reply
             open_questions = [];
             constraints = [];
           },
-          "meta_goal_fallback" ))
+          "meta_goal_fallback", false ))
   in
   let selection =
-    memory_candidates_from_snapshot_source ~state_snapshot_source:source snapshot
+    memory_candidates_from_snapshot_gated ~is_synthetic snapshot
   in
   let notes = selection.selected in
   if selection.dropped_by_total_cap > 0 || selection.dropped_by_kind <> [] then

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -255,12 +255,13 @@ val memory_candidates_from_snapshot :
 (** Lift snapshot fields into candidate triples and run the cap +
     selection pipeline. *)
 
-val memory_candidates_from_snapshot_source :
-  state_snapshot_source:string ->
+val memory_candidates_from_snapshot_gated :
+  is_synthetic:bool ->
   keeper_state_snapshot ->
   candidate_selection_result
-(** Source-aware variant used by post-turn persistence. Runtime-synthesized
-    snapshots are resume aids, not model-authored durable memory. *)
+(** Gated variant used by post-turn persistence. When [is_synthetic] (the
+    snapshot was fabricated from run metadata, not model-authored), no durable
+    memory candidates are produced — synthetic snapshots are resume aids only. *)
 
 (** {1 Bank wire format} *)
 
@@ -339,7 +340,7 @@ val append_memory_notes_from_reply :
   Workspace.config ->
   Keeper_meta_contract.keeper_meta ->
   ?snapshot:keeper_state_snapshot ->
-  ?state_snapshot_source:string ->
+  ?state_snapshot_source:Keeper_memory_policy.state_snapshot_source ->
   turn:int -> reply:string -> unit -> int * string list
 (** Persist new memory rows derived from a turn's [reply] (and
     optional [snapshot]); returns [(rows_written, drop_reasons)]. *)

--- a/lib/keeper/keeper_memory_bank_selection.ml
+++ b/lib/keeper/keeper_memory_bank_selection.ml
@@ -275,7 +275,7 @@ let memory_candidates_from_snapshot
   in
   select_memory_candidates raw
 
-let memory_candidates_from_snapshot_source ~state_snapshot_source snapshot =
-  if state_snapshot_source_is_synthetic state_snapshot_source
+let memory_candidates_from_snapshot_gated ~is_synthetic snapshot =
+  if is_synthetic
   then empty_candidate_selection
   else memory_candidates_from_snapshot snapshot

--- a/lib/keeper/keeper_memory_bank_selection.mli
+++ b/lib/keeper/keeper_memory_bank_selection.mli
@@ -193,9 +193,10 @@ val is_meaningful_memory_text : string -> bool
 val memory_candidates_from_snapshot :
   keeper_state_snapshot -> candidate_selection_result
 
-val memory_candidates_from_snapshot_source :
-  state_snapshot_source:string ->
+val memory_candidates_from_snapshot_gated :
+  is_synthetic:bool ->
   keeper_state_snapshot ->
   candidate_selection_result
-  (** Source-aware variant used by post-turn persistence. Runtime-synthesized
-      snapshots are resume aids, not model-authored durable memory. *)
+  (** Gated variant used by post-turn persistence. When [is_synthetic] (the
+      snapshot was fabricated from run metadata, not model-authored), no durable
+      memory candidates are produced — synthetic snapshots are resume aids only. *)

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -109,10 +109,31 @@ let empty_keeper_state_snapshot = {
   constraints = [];
 }
 
-let state_snapshot_source_is_synthetic source =
-  let source = String.trim source in
-  String.equal source "synthesized"
-  || String.starts_with ~prefix:"synthesized_" source
+(* Provenance of a turn's continuity snapshot, produced by the four-way
+   extraction cascade in [Keeper_agent_run_response_text]. Serialized to the turn
+   sidecar via [state_snapshot_source_to_string]; nothing parses it back in OCaml,
+   so there is no [of_string]. RFC-0242 §3.2 replaces the prior untyped string +
+   [String.starts_with ~prefix:"synthesized_"] classifier (the prefix matched no
+   producer — dead permissive match). *)
+type state_snapshot_source =
+  | Structured_state_tool
+      (* Reported by the removed [keeper_report_state] tool. Currently
+         unreachable: [reported_state_snapshot] is hard-[None]
+         (keeper_agent_run_finalize_response.ml:reported_state_snapshot_from_checkpoint).
+         Removed when RFC-0242 §3.1 wires an enforced structured producer. *)
+  | Structured_state_reply (* Parsed from a JSON object in the model's reply. *)
+  | State_block (* Parsed from a [STATE] prose block in the reply. *)
+  | Synthesized (* Fabricated from run metadata when no state was emitted. *)
+
+let state_snapshot_source_to_string = function
+  | Structured_state_tool -> "model_structured_state_tool"
+  | Structured_state_reply -> "model_structured_state"
+  | State_block -> "model_state_block"
+  | Synthesized -> "synthesized"
+
+let state_snapshot_source_is_synthetic = function
+  | Synthesized -> true
+  | Structured_state_tool | Structured_state_reply | State_block -> false
 
 type keeper_memory_line = {
   kind: string;

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -70,10 +70,24 @@ val empty_keeper_state_snapshot : keeper_state_snapshot
 (** All-empty snapshot used as a default when no [STATE] block was
     emitted. *)
 
-val state_snapshot_source_is_synthetic : string -> bool
-(** True for runtime-synthesized continuity snapshots. Synthetic snapshots may
-    remain in checkpoints/sidecars for resume, but must not be promoted as
-    model-authored durable memory or active work. *)
+(** Provenance of a turn's continuity snapshot (RFC-0242 §3.2, replacing the prior
+    untyped string discriminant). [Structured_state_tool] is currently unreachable
+    (the reporting tool was removed) and is retired by RFC-0242 §3.1. *)
+type state_snapshot_source =
+  | Structured_state_tool
+  | Structured_state_reply
+  | State_block
+  | Synthesized
+
+val state_snapshot_source_to_string : state_snapshot_source -> string
+(** Wire rendering for the turn sidecar [source] field. Stable strings:
+    [model_structured_state_tool] / [model_structured_state] / [model_state_block]
+    / [synthesized]. *)
+
+val state_snapshot_source_is_synthetic : state_snapshot_source -> bool
+(** True only for [Synthesized]. Synthetic snapshots may remain in
+    checkpoints/sidecars for resume, but must not be promoted as model-authored
+    durable memory or active work. *)
 
 type compaction_source =
   | Pre_dispatch_hygiene

--- a/lib/memory.mli
+++ b/lib/memory.mli
@@ -102,7 +102,7 @@ val append_from_reply :
   Workspace.config ->
   Keeper_meta_contract.keeper_meta ->
   ?snapshot:state_snapshot ->
-  ?state_snapshot_source:string ->
+  ?state_snapshot_source:Keeper_memory_policy.state_snapshot_source ->
   turn:int ->
   reply:string ->
   unit ->

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -183,8 +183,8 @@ let test_synthetic_snapshot_source_drops_memory_candidates () =
       ~response_text:"Continuation checkpoint saved; keeper remains scheduled"
   in
   let selection =
-    Keeper_memory_bank.memory_candidates_from_snapshot_source
-      ~state_snapshot_source:"synthesized"
+    Keeper_memory_bank.memory_candidates_from_snapshot_gated
+      ~is_synthetic:true
       snapshot
   in
   Alcotest.(check int)

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -193,7 +193,7 @@ let test_finalizer_uses_structured_state_source () =
   Alcotest.(check string)
     "source"
     "model_structured_state"
-    state_snapshot_source;
+    (KMP.state_snapshot_source_to_string state_snapshot_source);
   Alcotest.(check (option string))
     "progress"
     (Some "Structured progress")
@@ -247,7 +247,7 @@ let test_finalizer_prefers_reported_state_snapshot () =
   Alcotest.(check string)
     "source"
     "model_structured_state_tool"
-    state_snapshot_source;
+    (KMP.state_snapshot_source_to_string state_snapshot_source);
   Alcotest.(check (option string))
     "progress"
     (Some "Reported through keeper_report_state")

--- a/test/test_keeper_working_state.ml
+++ b/test/test_keeper_working_state.ml
@@ -307,7 +307,7 @@ let save_through_sidecar ~session_dir ~resume_merge ~next_items ~keeper_turn_id 
        ~oas_turn_count:1
        ~session_dir
        ~state_snapshot:(snapshot_with ~next_items ())
-       ~state_snapshot_source:"model_state_block"
+       ~state_snapshot_source:Masc.Keeper_memory_policy.State_block
        ~resume_merge
        ~append_manifest:noop_manifest
        ())


### PR DESCRIPTION
## 목표

RFC-0242(MERGED) §7 구현 첫 실탄. 턴 continuity-snapshot provenance를 untyped `string` → **닫힌 variant**로, 그리고 memory-candidate 게이트를 string 분류에서 `~is_synthetic:bool`로 디커플.

## 무엇이 문제였나

- `state_snapshot_source : string`을 `String.equal`로 3곳에서 비교(response_text ×2, finalize ×1).
- `state_snapshot_source_is_synthetic`가 `String.starts_with ~prefix:"synthesized_"`로 게이트 — **이 prefix는 어떤 producer도 생산하지 않는 dead permissive-match**(Unknown→Permissive 스멜).
- selection(`memory_candidates_from_snapshot_source`)이 source 문자열을 받아 내부에서 다시 `is_synthetic` 분류 → 분류가 selection 레이어로 누수.

## 변경 (15파일, +96/-48)

- 닫힌 `state_snapshot_source` variant 추가: `Structured_state_tool | Structured_state_reply | State_block | Synthesized` + `state_snapshot_source_to_string`(sidecar wire 경계용). **되읽는 OCaml reader 없음 → `of_string` 안 만듦**(Simplicity First).
- `state_snapshot_source_is_synthetic`: exhaustive typed match. dead `starts_with` 제거.
- selection 디커플: `memory_candidates_from_snapshot_source ~state_snapshot_source:string` → `memory_candidates_from_snapshot_gated ~is_synthetic:bool`. caller가 경계에서 비트 계산.
- **두 provenance 어휘 분리 유지**: memory-bank note의 `message_metadata`/`reply_state_block`/`meta_goal_fallback`은 JSONL에 영속되는 별도 어휘 → string 유지(턴-cascade source와 force-merge 안 함). 내부 라벨은 전부 non-synthetic이라 `false`로 직접 결정.

wire 문자열 보존(`model_structured_state_tool` / `model_structured_state` / `model_state_block` / `synthesized`) → sidecar/dashboard 호환. `Structured_state_tool`은 현재 unreachable(reporting tool 제거됨), RFC-0242 §3.1에서 retire.

## 로컬 검증

- `dune build --root . lib/` exit 0 (9개 lib 파일 typed 전파, 컴파일러가 전 call-site 강제).
- 3 스위트 실제 실행 통과: `test_keeper_state_snapshot_json`(18), `test_keeper_memory_write`(17, synthetic→0 candidates 포함), `test_keeper_working_state`(17).
- leftover 스캔: old 함수명/string 비교/`synthesized_` 코드 0건(주석만 남음).

## 범위 / 남은 것

- 본 PR은 §7 step 1의 **§3.2 부분만**. §3.1(structured schema 강제 배선)은 별도 — 조사 결과 `keeper_deliberation`조차 provider 강제가 아니라 reply-JSON 파싱 관행이라, "진짜 provider structured-output 배선" 가능 여부 선행 조사 필요.
- memory-bank note provenance 타입화는 별도 follow-up(영속 JSONL 어휘).
- ⚠️ 전체 `dune runtest`는 cdal `proof_store.ml` dangling dep(이슈 #21191)로 신뢰 불가 → 영향 스위트 개별 실행으로 검증, 나머지는 CI 위임.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>