### PR TITLE
[codex] Add local SearXNG WebSearch helper

### DIFF
--- a/docs/ENV-CONTRACT.md
+++ b/docs/ENV-CONTRACT.md
@@ -139,7 +139,31 @@ Because every flag here is `request_dynamic` on the Execute path
 (read at tool-invocation time), operators can flip a flag without a
 restart and the next `Execute` call picks it up.
 
-### 5. Test-only boot overrides
+### 5. WebSearch provider selection (`request_dynamic` inside the process)
+
+The WebSearch backend reads these values while handling each search request.
+Changing the parent shell after the server has already started still requires a
+process restart; changing the process env inside the running process is picked
+up on the next WebSearch call.
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `MASC_SEARXNG_URL` | `http://localhost:8888` | Enables the self-hosted SearXNG provider and gives it first priority when present. Use `scripts/searxng-local.sh start` to run a Docker-backed local instance with JSON output enabled. |
+| `MASC_WEB_SEARCH_PROVIDER` | `auto` | Pins one provider instead of auto order selection. |
+| `MASC_WEB_SEARCH_PROVIDER_ORDER` | built-in order | Overrides provider order for auto mode. |
+| `MASC_WEB_SEARCH_FALLBACKS` | built-in fallback order | Overrides fallback providers after the primary provider fails. |
+| `MASC_WEB_SEARCH_TIMEOUT_SEC` | `15` | Per-provider request timeout. |
+| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | `30.0` | In-process WebSearch cache TTL. |
+| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | `30.0` | In-process WebSearch rate-limit window. |
+| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | `30` | In-process WebSearch rate-limit ceiling per window. |
+
+Representative code paths:
+
+- [`tool_misc_web_search.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/tool_misc_web_search.ml)
+- [`env_config_runtime.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/config/env_config_runtime.ml)
+- [`masc_network_defaults.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/config/masc_network_defaults.ml)
+
+### 6. Test-only boot overrides
 
 The following flags exist only to make OCaml test executables deterministic:
 

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -212,6 +212,11 @@ MASC_WEB_SEARCH_PROVIDER=brave
 MASC_WEB_SEARCH_FALLBACKS=ddg,bing_rss
 BRAVE_SEARCH_API_KEY=...  # optional; without provider credentials the tool falls back to scraping
 
+# Local SearXNG provider for MASC-owned WebSearch / WebFetch
+scripts/searxng-local.sh start
+export MASC_SEARXNG_URL=http://localhost:8888
+scripts/searxng-local.sh smoke "Tortoise Glass Museum"
+
 # Query all tools via API after initialize
 curl -sS "http://127.0.0.1:${PORT}/mcp" \
   -H "Accept: application/json, text/event-stream" \
@@ -228,6 +233,8 @@ Keeper WebSearch/WebFetch backend 메모:
 - `web_search` / `web_fetch` are not OAS-owned capabilities; Keeper agents should call the MASC-owned public aliases shown in their tool list (`WebSearch` / `WebFetch`).
 - `WebSearch { includeContent: true }`는 keeper가 바로 읽는 `content_text`와 결과별 raw `page_content`를 best-effort로 붙인다. `WebFetch`는 선택한 단일 URL을 더 깊게 읽을 때 쓴다.
 - `MASC_SEARXNG_URL` 설정 시 self-hosted SearXNG가 최우선 provider로 작동한다.
+- 로컬 검색 품질이 필요하면 `scripts/searxng-local.sh start`로 Docker SearXNG를 올리고 `MASC_SEARXNG_URL=http://localhost:8888`만 MASC 프로세스에 넘긴다. 별도 WebSearch MCP wrapper는 필요 없다.
+- `scripts/searxng-local.sh status|smoke|logs|stop`으로 로컬 provider를 점검한다. 기본 config는 `${MASC_BASE_PATH:-$HOME/me}/.local/share/masc-searxng/settings.yml`에 생성되며 MASC가 쓰는 JSON search format을 켠다.
 - 기본 auto 모드는 공식 provider key가 있으면 `searxng`, `brave`, `tavily`, `exa`, `bing_api` 순으로 먼저 시도한다.
 - 공식 provider가 없거나 실패하면 `duckduckgo`, `bing_rss` 순으로 fallback 한다.
 - env:

--- a/scripts/searxng-local.sh
+++ b/scripts/searxng-local.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Local SearXNG helper for the MASC-owned WebSearch backend.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+IMAGE="${MASC_SEARXNG_IMAGE:-searxng/searxng:latest}"
+CONTAINER="${MASC_SEARXNG_CONTAINER:-masc-searxng}"
+HOST="${MASC_SEARXNG_HOST:-127.0.0.1}"
+PORT="${MASC_SEARXNG_PORT:-8888}"
+CONTAINER_PORT="${MASC_SEARXNG_CONTAINER_PORT:-8080}"
+BASE_PATH="${MASC_BASE_PATH:-$HOME/me}"
+CONFIG_DIR="${MASC_SEARXNG_CONFIG_DIR:-$BASE_PATH/.local/share/masc-searxng}"
+TIMEOUT_SEC="${MASC_SEARXNG_SMOKE_TIMEOUT_SEC:-10}"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/searxng-local.sh <start|status|smoke|logs|stop> [args]
+
+Commands:
+  start          Create settings.yml if needed and start the Docker container.
+  status         Print container status and probe /healthz when running.
+  smoke [query]  Run a JSON search request. Defaults to "Tortoise Glass Museum".
+  logs [lines]   Show recent container logs. Defaults to 80 lines.
+  stop           Stop the container without removing it.
+
+Environment:
+  MASC_SEARXNG_URL          URL MASC should use. Defaults to http://localhost:8888.
+  MASC_SEARXNG_CONFIG_DIR   Config directory. Defaults to $MASC_BASE_PATH/.local/share/masc-searxng.
+  MASC_SEARXNG_PORT         Host port. Defaults to 8888.
+  MASC_SEARXNG_CONTAINER    Container name. Defaults to masc-searxng.
+  MASC_SEARXNG_IMAGE        Docker image. Defaults to searxng/searxng:latest.
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_docker() {
+  command -v docker >/dev/null 2>&1 || die "docker is required"
+}
+
+searxng_url() {
+  printf '%s\n' "${MASC_SEARXNG_URL:-http://localhost:$PORT}"
+}
+
+generate_secret() {
+  if [ -n "${MASC_SEARXNG_SECRET_KEY:-}" ]; then
+    printf '%s\n' "$MASC_SEARXNG_SECRET_KEY"
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+  elif command -v uuidgen >/dev/null 2>&1; then
+    uuidgen
+  else
+    printf 'masc-local-searxng-%s\n' "$(date +%s)"
+  fi
+}
+
+ensure_settings() {
+  local settings="$CONFIG_DIR/settings.yml"
+  if [ -f "$settings" ]; then
+    return 0
+  fi
+
+  mkdir -p "$CONFIG_DIR"
+  local secret
+  secret="$(generate_secret)"
+  cat >"$settings" <<EOF
+use_default_settings: true
+
+search:
+  formats:
+    - html
+    - json
+
+server:
+  bind_address: "0.0.0.0"
+  port: $CONTAINER_PORT
+  limiter: false
+  secret_key: "$secret"
+EOF
+  echo "[searxng-local] wrote $settings" >&2
+}
+
+container_exists() {
+  docker inspect "$CONTAINER" >/dev/null 2>&1
+}
+
+container_running() {
+  [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null || true)" = "true" ]
+}
+
+cmd_start() {
+  require_docker
+  ensure_settings
+
+  if container_exists; then
+    if container_running; then
+      echo "[searxng-local] container already running: $CONTAINER"
+    else
+      docker start "$CONTAINER" >/dev/null
+      echo "[searxng-local] started existing container: $CONTAINER"
+    fi
+  else
+    docker run \
+      --name "$CONTAINER" \
+      -d \
+      --restart unless-stopped \
+      -p "$HOST:$PORT:$CONTAINER_PORT" \
+      -v "$CONFIG_DIR:/etc/searxng:ro" \
+      "$IMAGE" >/dev/null
+    echo "[searxng-local] started new container: $CONTAINER"
+  fi
+
+  echo "export MASC_SEARXNG_URL=$(searxng_url)"
+  echo "[searxng-local] run: $REPO_ROOT/scripts/searxng-local.sh smoke"
+}
+
+cmd_status() {
+  require_docker
+
+  if ! container_exists; then
+    echo "[searxng-local] container missing: $CONTAINER"
+    exit 1
+  fi
+
+  docker ps \
+    --filter "name=^/${CONTAINER}$" \
+    --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+
+  if container_running; then
+    curl -fsS --max-time "$TIMEOUT_SEC" "$(searxng_url)/healthz" >/dev/null
+    echo "[searxng-local] healthz ok: $(searxng_url)"
+  fi
+}
+
+cmd_smoke() {
+  local query="${*:-Tortoise Glass Museum}"
+  local payload
+  payload="$(
+    curl -fsS \
+      --max-time "$TIMEOUT_SEC" \
+      --get "$(searxng_url)/search" \
+      --data-urlencode "q=$query" \
+      --data "format=json"
+  )"
+
+  if command -v jq >/dev/null 2>&1; then
+    local count
+    count="$(printf '%s\n' "$payload" | jq '.results | length')"
+    if [ "$count" -lt 1 ]; then
+      die "search returned no results for query: $query"
+    fi
+    printf '%s\n' "$payload" \
+      | jq -r '.results[:5][] | [.title, .url] | @tsv'
+  else
+    printf '%s\n' "$payload"
+  fi
+}
+
+cmd_logs() {
+  require_docker
+  local lines="${1:-80}"
+  docker logs --tail "$lines" "$CONTAINER"
+}
+
+cmd_stop() {
+  require_docker
+  if ! container_exists; then
+    echo "[searxng-local] container missing: $CONTAINER"
+    return 0
+  fi
+  docker stop "$CONTAINER" >/dev/null
+  echo "[searxng-local] stopped: $CONTAINER"
+}
+
+case "${1:-}" in
+  start)
+    shift
+    cmd_start "$@"
+    ;;
+  status)
+    shift
+    cmd_status "$@"
+    ;;
+  smoke)
+    shift
+    cmd_smoke "$@"
+    ;;
+  logs)
+    shift
+    cmd_logs "$@"
+    ;;
+  stop)
+    shift
+    cmd_stop "$@"
+    ;;
+  -h|--help|"")
+    usage
+    ;;
+  *)
+    usage
+    die "unknown command: $1"
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Add `scripts/searxng-local.sh` for local Docker-backed SearXNG start/status/smoke/logs/stop operations.
- Document the MASC-owned `WebSearch` / `WebFetch` path using `MASC_SEARXNG_URL=http://localhost:8888` instead of adding a separate WebSearch MCP wrapper.
- Add WebSearch provider env vars to `docs/ENV-CONTRACT.md` with the request-time behavior and restart caveat.

## Why

MASC already supports SearXNG through the internal `masc_web_search` backend and keeper-facing `WebSearch` alias, but local setup was not reproducible. That made search failures look like a missing external MCP problem instead of a missing local SearXNG provider/config problem.

## Impact

Operators can run a local provider with JSON output enabled and point MASC at it through the existing `MASC_SEARXNG_URL` setting. No OCaml runtime behavior changes are included.

## Validation

- `bash -n scripts/searxng-local.sh`
- `shellcheck scripts/searxng-local.sh`
- `scripts/searxng-local.sh status`
- `scripts/searxng-local.sh smoke 'Tortoise Glass Museum'` returned the official YouTube MV result (`https://www.youtube.com/watch?v=Dd8aF07DK4w`)
- `bash scripts/check-doc-truth.sh`