### PR TITLE
refactor(goal): derive goal phase/action enums from Goal_phase ADT (RFC-0089)

### DIFF
--- a/lib/goal/goal_phase.ml
+++ b/lib/goal/goal_phase.ml
@@ -40,6 +40,20 @@ let of_yojson = function
   | json ->
       Error ("goal_phase_of_yojson: " ^ Yojson.Safe.to_string json)
 
+(* Every phase, declaration order. SSOT for the MCP schema enum and the
+   workspace_goals validator so neither hand-rolls the string set (RFC-0089;
+   the #8372 anti-pattern). [to_string] is the exhaustive compile-time witness:
+   a new constructor breaks it; the round-trip test guards this list. *)
+let all =
+  [ Executing
+  ; Awaiting_verification
+  ; Awaiting_approval
+  ; Blocked
+  ; Paused
+  ; Completed
+  ; Dropped
+  ]
+
 type action =
   | Request_complete
   | Approve_completion
@@ -61,6 +75,20 @@ let action_to_string = function
   | Operator_unblock -> "operator_unblock"
   | Drop -> "drop"
   | Reopen -> "reopen"
+
+(* Every action, declaration order. SSOT for the schema/validator action enum
+   (see [all]). [action_to_string] is the exhaustive witness. *)
+let all_actions =
+  [ Request_complete
+  ; Approve_completion
+  ; Reject_completion
+  ; Pause
+  ; Resume
+  ; Operator_block
+  ; Operator_unblock
+  ; Drop
+  ; Reopen
+  ]
 
 let action_of_string = function
   | "request_complete" -> Some Request_complete

--- a/lib/goal/goal_phase.mli
+++ b/lib/goal/goal_phase.mli
@@ -28,6 +28,10 @@ val to_yojson : t -> Yojson.Safe.t
 
 val of_yojson : Yojson.Safe.t -> (t, string) result
 
+val all : t list
+(** Every phase in declaration order. SSOT for callers that need the full
+    string set (MCP schema enum, validator) via [List.map to_string all]. *)
+
 (** Operator / system actions that may drive a transition. *)
 type action =
   | Request_complete
@@ -43,6 +47,10 @@ type action =
 val action_to_string : action -> string
 val action_of_string : string -> action option
 val parse_action : string -> action option
+
+val all_actions : action list
+(** Every action in declaration order. SSOT for the schema/validator action
+    enum via [List.map action_to_string all_actions]. *)
 
 (** Outcome of {!decide_transition}. [Move_to] is a direct phase
     change; [Open_verification] / [Open_approval] gate completion

--- a/lib/tool_schemas/dune
+++ b/lib/tool_schemas/dune
@@ -26,7 +26,8 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries masc_types masc_core masc.task_handlers masc.masc_tool_surface))
+ (libraries masc_types masc_core masc.task_handlers masc.masc_tool_surface
+   masc.masc_goal))
 
 ;; RFC-0057 Phase 0 — capture bin/gen_tool_descriptors.exe stdout into
 ;; tool_descriptors_gen.ml. %{exe:...} gives dune the build-graph dep

--- a/lib/tool_schemas/tool_schemas_workspace_extra.ml
+++ b/lib/tool_schemas/tool_schemas_workspace_extra.ml
@@ -4,29 +4,14 @@
 open Masc_domain
 
 let goal_horizon_enum = [ "short"; "mid"; "long" ]
-let goal_phase_enum =
-  [
-    "executing";
-    "awaiting_verification";
-    "awaiting_approval";
-    "blocked";
-    "paused";
-    "completed";
-    "dropped";
-  ]
+(* RFC-0089: the phase/action enums advertised to MCP clients are derived from
+   the Goal_phase ADT (the goal lifecycle SSOT), the same source the
+   workspace_goals validator uses, so the schema can never advertise a value the
+   validator rejects (or vice versa). *)
+let goal_phase_enum = List.map Goal_phase.to_string Goal_phase.all
 
 let goal_transition_action_enum =
-  [
-    "request_complete";
-    "approve_completion";
-    "reject_completion";
-    "pause";
-    "resume";
-    "operator_block";
-    "operator_unblock";
-    "drop";
-    "reopen";
-  ]
+  List.map Goal_phase.action_to_string Goal_phase.all_actions
 
 let goal_vote_decision_enum = [ "approve"; "reject" ]
 let goal_inherit_mode_enum = [ "extend"; "replace" ]

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -57,28 +57,13 @@ let validation_error_result
 let goal_horizon_strings = [ "short"; "mid"; "long" ]
 let goal_status_strings = [ "active"; "paused"; "done"; "dropped" ]
 
-let goal_phase_strings =
-  [ "executing"
-  ; "awaiting_verification"
-  ; "awaiting_approval"
-  ; "blocked"
-  ; "paused"
-  ; "completed"
-  ; "dropped"
-  ]
-;;
+(* RFC-0089: derive the accepted-value sets from the Goal_phase ADT (the goal
+   lifecycle SSOT) instead of hand-rolling them here, so the validator, the MCP
+   schema enum, and the type can never drift apart. *)
+let goal_phase_strings = List.map Goal_phase.to_string Goal_phase.all
 
 let goal_transition_action_strings =
-  [ "request_complete"
-  ; "approve_completion"
-  ; "reject_completion"
-  ; "pause"
-  ; "resume"
-  ; "operator_block"
-  ; "operator_unblock"
-  ; "drop"
-  ; "reopen"
-  ]
+  List.map Goal_phase.action_to_string Goal_phase.all_actions
 ;;
 
 let goal_vote_decision_strings = [ "approve"; "reject" ]

--- a/test/dune
+++ b/test/dune
@@ -1411,6 +1411,8 @@
 
 (include stanzas/test_git_fetch_retry_script.inc)
 
+(include stanzas/test_goal_phase_all.inc)
+
 (include stanzas/test_goal_phase_awaiting_verification_10411.inc)
 
 (include stanzas/test_governance_cases_snapshot.inc)

--- a/test/stanzas/test_goal_phase_all.inc
+++ b/test/stanzas/test_goal_phase_all.inc
@@ -1,0 +1,8 @@
+; Per-file dune stanza for Goal_phase.all / all_actions completeness (RFC-0089).
+; Lives here per test/stanzas/README.md to avoid the conflict-runtime hotspot
+; in the legacy grouped (tests ...) stanza.
+
+(test
+ (name test_goal_phase_all)
+ (modules test_goal_phase_all)
+ (libraries masc_goal alcotest))

--- a/test/test_goal_phase_all.ml
+++ b/test/test_goal_phase_all.ml
@@ -1,0 +1,81 @@
+(* RFC-0089 — Goal_phase.all / all_actions are the SSOT for the MCP goal schema
+   enums and the workspace_goals validator, both built as
+   [List.map to_string all]. This guards those lists: every entry round-trips
+   through of_string, the derived string set has no duplicates, and it matches
+   the expected set AND order (so deriving does not silently change the
+   advertised enum order). to_string / action_to_string are the exhaustive
+   compile-time witnesses; this test guards the [all] / [all_actions] lists. *)
+
+module GP = Goal_phase
+open Alcotest
+
+let test_phase_roundtrip () =
+  List.iter
+    (fun p ->
+      check bool
+        (Printf.sprintf "phase %s round-trips" (GP.to_string p))
+        true
+        (GP.of_string (GP.to_string p) = Some p))
+    GP.all
+
+let test_phase_set () =
+  let strs = List.map GP.to_string GP.all in
+  check int "phase count" 7 (List.length GP.all);
+  check int "no duplicate phase strings"
+    (List.length strs)
+    (List.length (List.sort_uniq String.compare strs));
+  check (list string) "phase set and order"
+    [
+      "executing";
+      "awaiting_verification";
+      "awaiting_approval";
+      "blocked";
+      "paused";
+      "completed";
+      "dropped";
+    ]
+    strs
+
+let test_action_roundtrip () =
+  List.iter
+    (fun a ->
+      check bool
+        (Printf.sprintf "action %s round-trips" (GP.action_to_string a))
+        true
+        (GP.action_of_string (GP.action_to_string a) = Some a))
+    GP.all_actions
+
+let test_action_set () =
+  let strs = List.map GP.action_to_string GP.all_actions in
+  check int "action count" 9 (List.length GP.all_actions);
+  check int "no duplicate action strings"
+    (List.length strs)
+    (List.length (List.sort_uniq String.compare strs));
+  check (list string) "action set and order"
+    [
+      "request_complete";
+      "approve_completion";
+      "reject_completion";
+      "pause";
+      "resume";
+      "operator_block";
+      "operator_unblock";
+      "drop";
+      "reopen";
+    ]
+    strs
+
+let () =
+  run "goal_phase_all"
+    [
+      ( "phase",
+        [
+          test_case "round-trip" `Quick test_phase_roundtrip;
+          test_case "set and order" `Quick test_phase_set;
+        ] );
+      ( "action",
+        [
+          test_case "round-trip" `Quick test_action_roundtrip;
+          test_case "set and order" `Quick test_action_set;
+        ] );
+    ]


### PR DESCRIPTION
## 목적
goal phase/transition-action 어휘를 손나열 중복 → `Goal_phase` ADT 파생으로 통합합니다 (RFC-0089, "하드코딩 처단" — scattered-hardcoding hunt 발견).

## 배경 (schema↔validator split-brain 위험)
goal phase(7) + transition-action(9) 문자열 집합이 **두 곳에 손으로 중복**돼 있었습니다:
- `workspace_goals.ml` — 검증기(허용값 리스트)
- `tool_schemas_workspace_extra.ml` — MCP 스키마 enum(클라이언트에 광고)

현재 두 copy는 동일하나 독립적 → `Goal_phase.t`에 phase/action을 추가하면 스키마는 광고하는데 검증기가 거부(또는 반대)하는 split-brain이 가능합니다. 게다가 `Goal_phase` ADT가 이미 두 어휘를 typed로 보유 → enum 손나열은 기존 ADT 중복(#8372 안티패턴).

## 변경
- `Goal_phase.all : t list` + `all_actions : action list` 추가 (선언 순서; goal lifecycle SSOT 모듈).
- 검증기·스키마 양쪽을 `List.map to_string all` / `List.map action_to_string all_actions`로 파생 → ADT가 단일 출처.
- `to_string`/`action_to_string`이 exhaustive 컴파일 witness(새 생성자 → 컴파일 에러 → 양쪽 자동 반영). 신규 `test_goal_phase_all`이 `all`/`all_actions`를 가드(round-trip + 집합/순서 pin).
- `tool_schemas` dune에 `masc.masc_goal` dep 추가 (schema→goal domain 방향, 사이클 없음).

## 범위 밖 (별 ADT/모듈 — 후속)
- goal horizon(Short/Mid/Long) + status(Active/Paused/Done/Dropped) = `goal_store` ADT (별 모듈)
- vote(approve/reject) = ADT 없음 (2값)
본 PR은 `Goal_phase` 전용 SSOT 모듈이 소유한 phase+action 두 어휘를 완결합니다.

## 검증
- `dune build --root . @check` exit 0 (masc_goal + masc + masc_tool_schemas + 신규 dep).
- 신규 test 4 케이스 통과 (phase/action round-trip + 집합·순서).

RFC-WAIVED: Goal_phase ADT(이미 존재)에서 goal phase/action enum을 파생하는 집중 리팩터입니다. credential/operator_control/sandbox/connector/hooks/workflow 등 RFC-게이트 표면을 건드리지 않습니다 — 매칭된 RFC(credential/connector/identity/TurnRecord 등)는 goal-enum 통합과 무관. 패턴 umbrella는 RFC-0089(String Classifier to Typed Variant).

WORKAROUND-WAIVED: 손나열 enum을 *제거*하고 ADT 파생으로 대체합니다(추가 아님). STRING_CLASSIFIER 게이트 시그니처는 false-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
