### PR TITLE
feat(keeper): turn-seeded deterministic lexical recall (RFC-0244 P1)

### DIFF
--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -57,12 +57,67 @@ let truth_recency_factor ?(lambda = default_truth_lambda) ~now fact =
   recency_factor ~lambda ~now (truth_anchor fact)
 ;;
 
-let score_fact ?(lambda = default_lambda) ?(alpha = default_alpha) ~now fact =
+let normalize_word_char = function
+  | 'A'..'Z' as c -> Char.lowercase_ascii c
+  | ('a'..'z' | '0'..'9') as c -> c
+  | _ -> ' '
+;;
+
+(* RFC-0244: split text into a deduped set of lowercased word tokens (length > 2).
+   Shared SSOT so the turn-seeded recall factor ([lexical_relevance]) and the
+   keyword access bump ([bump_access_for_turn]) tokenize identically. Deterministic
+   and offline — no embedding model. *)
+let tokenize text =
+  String.map normalize_word_char text
+  |> String.split_on_char ' '
+  |> List.map String.trim
+  |> List.filter (fun s -> String.length s > 2)
+  |> List.sort_uniq String.compare
+;;
+
+(* RFC-0244: maximum multiplicative boost a fully turn-relevant fact receives. A
+   fact whose claim covers all of the turn's distinct tokens scores [1 + gain]× its
+   base; one covering none scores 1× (unchanged). *)
+let default_relevance_gain = 1.5
+
+(** Deterministic lexical relevance multiplier for turn-seeded recall.
+
+    [seed_tokens] is the current turn's token set. [[]] (autonomous wake / no turn,
+    or a turn with no usable tokens) yields [1.0] = multiplicative identity, so the
+    seedless ranking is byte-identical to pre-RFC-0244. With a seed, a fact is
+    boosted by the fraction of the turn's distinct tokens its claim covers
+    (token-set intersection, not substring — so ["test"] does not match ["latest"]).
+    The result is bounded in [[1.0, 1.0 +. gain]] and monotone in coverage.
+
+    Trade-off vs an embedding recall: this misses synonymy and paraphrase; it gains
+    determinism, reproducibility, and zero added dependency (the design tenet). *)
+let lexical_relevance ?(gain = default_relevance_gain) ~seed_tokens fact =
+  match seed_tokens with
+  | [] -> 1.0
+  | _ ->
+    let claim_tokens = tokenize fact.claim in
+    let matched =
+      List.fold_left
+        (fun acc tok -> if List.mem tok claim_tokens then acc + 1 else acc)
+        0
+        seed_tokens
+    in
+    1.0 +. (gain *. (float matched /. float (List.length seed_tokens)))
+;;
+
+let score_fact
+      ?(lambda = default_lambda)
+      ?(alpha = default_alpha)
+      ?(seed_tokens = [])
+      ~now
+      fact
+  =
   fact.confidence
   *. recency_factor ~lambda ~now fact.last_accessed
   *. truth_recency_factor ~now fact
   *. stale_penalty fact
   *. access_factor ~alpha fact.access_count
+  *. lexical_relevance ~seed_tokens fact
 ;;
 
 let decide_retention ?(discard_threshold = default_discard_score_threshold) score =
@@ -95,23 +150,17 @@ let string_contains substring str =
   if sub_len = 0 then true else aux 0
 ;;
 
-let normalize_word_char = function
-  | 'A'..'Z' as c -> Char.lowercase_ascii c
-  | ('a'..'z' | '0'..'9') as c -> c
-  | _ -> ' '
-;;
+(** Bumps access counters for facts whose claims share a turn keyword. A cheap,
+    deterministic heuristic (no embedding model) kept offline. Tokenization uses the
+    [tokenize] SSOT (shared with the recall relevance factor); the claim match here
+    stays substring-based ([string_contains]) for its coarse access-bump purpose.
 
-(** Bumps access counters for facts whose claims semantically match the
-    current turn keywords. This is intentionally a cheap heuristic (no
-    embedding model) to keep the system deterministic and offline. *)
+    Note: this is a write (it mutates [access_count]/[last_accessed]). It is NOT
+    wired into recall, which is intentionally one-way at prompt time; the
+    turn-seeded ranking boost lives in [lexical_relevance] (read-only) instead. A
+    persistent variant belongs in the librarian write-path (RFC-0244 §2.1, deferred). *)
 let bump_access_for_turn ~now (facts : fact list) ~(turn_text : string) : fact list =
-  let tokens =
-    String.map normalize_word_char turn_text
-    |> String.split_on_char ' '
-    |> List.map String.trim
-    |> List.filter (fun s -> String.length s > 2)
-    |> List.sort_uniq String.compare
-  in
+  let tokens = tokenize turn_text in
   let score_claim claim =
     let lower = String.lowercase_ascii claim in
     List.fold_left (fun acc tok -> if string_contains tok lower then acc + 1 else acc) 0 tokens

--- a/lib/keeper/keeper_memory_os_policy.mli
+++ b/lib/keeper/keeper_memory_os_policy.mli
@@ -16,10 +16,31 @@ type retention_verdict =
 (** Composite importance score for a fact.
 
     Score = confidence × access_recency × truth_recency ×
-    stale_penalty × access_boost.  [access_recency] uses
+    stale_penalty × access_boost × lexical_relevance.  [access_recency] uses
     [last_accessed], while [truth_recency] uses [last_verified_at] or
-    [first_seen] so recall cannot make an unverified claim fresh again. *)
-val score_fact : ?lambda:float -> ?alpha:float -> now:float -> fact -> float
+    [first_seen] so recall cannot make an unverified claim fresh again.
+
+    [seed_tokens] (RFC-0244) is the current turn's token set; when omitted (or
+    empty) [lexical_relevance] is [1.0] and the score is byte-identical to the
+    pre-RFC-0244 formula. *)
+val score_fact
+  :  ?lambda:float
+  -> ?alpha:float
+  -> ?seed_tokens:string list
+  -> now:float
+  -> fact
+  -> float
+
+(** RFC-0244: deduped set of lowercased word tokens (length > 2). The shared SSOT
+    tokenizer for turn-seeded recall and the keyword access bump. *)
+val tokenize : string -> string list
+
+(** RFC-0244: deterministic lexical relevance multiplier in [[1.0, 1.0 +. gain]].
+    [seed_tokens = []] yields [1.0] (multiplicative identity). With a seed, a fact
+    is boosted by the fraction of the turn's distinct tokens its claim covers
+    (token-set intersection). Pure function of [(seed_tokens, fact.claim)] — offline,
+    no embedding. *)
+val lexical_relevance : ?gain:float -> seed_tokens:string list -> fact -> float
 
 val truth_recency_factor : ?lambda:float -> now:float -> fact -> float
 val stale_penalty : fact -> float

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -89,8 +89,8 @@ let fact_is_current ~now fact =
   | Some ts -> ts >= now
 ;;
 
-let render_fact ~now fact =
-  let score = Keeper_memory_os_policy.score_fact ~now fact in
+let render_fact ~now ?(seed_tokens = []) fact =
+  let score = Keeper_memory_os_policy.score_fact ~seed_tokens ~now fact in
   let source = fact.source in
   Printf.sprintf
     "- [category=%s confidence=%.2f stale=%.2f score=%.3f turn=%d] %s"
@@ -159,33 +159,35 @@ let dedup_by_claim scored =
     scored
 ;;
 
-let scored_facts ~now facts =
+let scored_facts ~now ?(seed_tokens = []) facts =
   facts
   |> List.filter (fact_is_current ~now)
-  |> List.map (fun fact -> Keeper_memory_os_policy.score_fact ~now fact, fact)
+  |> List.map (fun fact -> Keeper_memory_os_policy.score_fact ~seed_tokens ~now fact, fact)
   |> List.sort (fun (a, _) (b, _) -> compare b a)
   |> dedup_by_claim
   |> List.map snd
 ;;
 
-let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
+let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes ?(seed_tokens = []) () =
   let max_facts = max 0 max_facts in
   let max_episodes = max 0 max_episodes in
   let facts =
     (* RFC-0239 Q4: read up to the bounded recall window (the retention sweep
        caps the store to this many facts), so score ranking selects the
-       globally best facts rather than only the most recent [fact_tail_scan]. *)
+       globally best facts rather than only the most recent [fact_tail_scan].
+       RFC-0244: [seed_tokens] (current turn) reranks via lexical relevance; an
+       empty seed leaves the ranking unchanged. *)
     Keeper_memory_os_io.read_facts_tail
       ~keeper_id
       ~n:(max fact_tail_scan Keeper_memory_os_io.fact_recall_window)
-    |> scored_facts ~now
+    |> scored_facts ~now ~seed_tokens
     |> take max_facts
   in
   let episodes = Keeper_memory_os_io.read_episodes_tail ~keeper_id ~n:max_episodes in
   match facts, episodes with
   | [], [] -> ""
   | _ ->
-    let fact_lines = List.map (render_fact ~now) facts in
+    let fact_lines = List.map (render_fact ~now ~seed_tokens) facts in
     let episode_lines = List.map render_episode episodes in
     (match render_recall_context ~fact_lines ~episode_lines with
      | Ok context -> context
@@ -199,9 +201,15 @@ let render_context
       ~now
       ?(max_facts = default_max_facts)
       ?(max_episodes = default_max_episodes)
+      ?seed
       ()
   =
-  try render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () with
+  let seed_tokens =
+    match seed with
+    | None -> []
+    | Some s -> Keeper_memory_os_policy.tokenize s
+  in
+  try render_context_exn ~keeper_id ~now ~max_facts ~max_episodes ~seed_tokens () with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     Log.Keeper.warn
@@ -219,11 +227,11 @@ let enabled () =
     ~default:true
 ;;
 
-let render_if_enabled ~keeper_id ~now () =
+let render_if_enabled ~keeper_id ~now ?seed () =
   if not (enabled ())
   then None
   else (
-    match String.trim (render_context ~keeper_id ~now ()) with
+    match String.trim (render_context ~keeper_id ~now ?seed ()) with
     | "" -> None
     | block -> Some block)
 ;;

--- a/lib/keeper/keeper_memory_os_recall.mli
+++ b/lib/keeper/keeper_memory_os_recall.mli
@@ -9,15 +9,25 @@ val render_context
   -> now:float
   -> ?max_facts:int
   -> ?max_episodes:int
+  -> ?seed:string
   -> unit
   -> string
+(** [?seed] (RFC-0244) is the current-turn text. When present, facts are reranked
+    by deterministic lexical relevance to it; when absent, the output is identical
+    to the pre-RFC-0244 recency/score ranking. *)
 
 val enabled : unit -> bool
 (** Kill-switch flag [MASC_KEEPER_MEMORY_OS_RECALL] (default [true]).
     Read side of Memory OS; the write side (librarian) is gated
     separately by [MASC_KEEPER_MEMORY_OS_LIBRARIAN]. *)
 
-val render_if_enabled : keeper_id:string -> now:float -> unit -> string option
-(** [render_if_enabled ~keeper_id ~now ()] is [Some block] when the
+val render_if_enabled
+  :  keeper_id:string
+  -> now:float
+  -> ?seed:string
+  -> unit
+  -> string option
+(** [render_if_enabled ~keeper_id ~now ?seed ()] is [Some block] when the
     flag is on and the store yields advisory content, [None] otherwise.
+    [?seed] (RFC-0244) is the current-turn text used for lexical reranking.
     Intended for the [extra_system_context] assembly site. *)

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -347,10 +347,24 @@ let assemble_hooks
                      persisted facts/episodes (read side; the write side is
                      the librarian wired in #20897). Opt-in via
                      MASC_KEEPER_MEMORY_OS_RECALL. *)
+                  let recall_seed =
+                    (* RFC-0244: the current turn's user text seeds lexical
+                       reranking. Mirrors the [last_user_text] fold in
+                       [compute_tool_surface]; "" (no user turn) tokenizes to the
+                       empty set, so recall falls back to the seedless ranking. *)
+                    List.fold_left
+                      (fun acc (m : Agent_sdk.Types.message) ->
+                         match m.role with
+                         | Agent_sdk.Types.User -> Agent_sdk.Types.text_of_content m.content
+                         | _ -> acc)
+                      ""
+                      messages
+                  in
                   match
                     Keeper_memory_os_recall.render_if_enabled
                       ~keeper_id:meta.name
                       ~now:(Time_compat.now ())
+                      ~seed:recall_seed
                       ()
                   with
                   | None -> ctx

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -852,6 +852,56 @@ let test_bump_access () =
   | _ -> Alcotest.fail "expected one unchanged fact"
 ;;
 
+(* RFC-0244: turn-seeded lexical relevance. *)
+
+let test_lexical_relevance_identity_for_empty_seed () =
+  let now = 1_000_000.0 in
+  Alcotest.(check (float 1e-9))
+    "empty seed is the multiplicative identity"
+    1.0
+    (Policy.lexical_relevance ~seed_tokens:[] (fact_fixture ~now ()))
+;;
+
+let test_lexical_relevance_is_deterministic () =
+  let now = 1_000_000.0 in
+  let fact = { (fact_fixture ~now ()) with Types.claim = "alpha bravo charlie delta" } in
+  let seed = Policy.tokenize "alpha bravo" in
+  Alcotest.(check (float 1e-12))
+    "pure function: identical inputs yield identical output"
+    (Policy.lexical_relevance ~seed_tokens:seed fact)
+    (Policy.lexical_relevance ~seed_tokens:seed fact)
+;;
+
+let test_lexical_relevance_monotone_in_coverage () =
+  let now = 1_000_000.0 in
+  let seed = Policy.tokenize "alpha bravo charlie" in
+  let full = { (fact_fixture ~now ()) with Types.claim = "alpha bravo charlie" } in
+  let partial = { (fact_fixture ~now ()) with Types.claim = "alpha only here" } in
+  let none = { (fact_fixture ~now ()) with Types.claim = "delta echo foxtrot" } in
+  let rf = Policy.lexical_relevance ~seed_tokens:seed full in
+  let rp = Policy.lexical_relevance ~seed_tokens:seed partial in
+  let rn = Policy.lexical_relevance ~seed_tokens:seed none in
+  Alcotest.(check bool) "full coverage > partial" true (rf > rp);
+  Alcotest.(check bool) "partial coverage > none" true (rp > rn);
+  Alcotest.(check (float 1e-9)) "no coverage = identity" 1.0 rn
+;;
+
+let test_score_fact_seed_boosts_match () =
+  let now = 1_000_000.0 in
+  let fact = { (fact_fixture ~now ()) with Types.claim = "deploy pipeline rollback" } in
+  let base = Policy.score_fact ~now fact in
+  let seedless_explicit = Policy.score_fact ~seed_tokens:[] ~now fact in
+  let matched =
+    Policy.score_fact ~seed_tokens:(Policy.tokenize "rollback the deploy") ~now fact
+  in
+  let unrelated =
+    Policy.score_fact ~seed_tokens:(Policy.tokenize "weather forecast today") ~now fact
+  in
+  Alcotest.(check (float 1e-12)) "omitted seed == empty seed" base seedless_explicit;
+  Alcotest.(check bool) "matching turn boosts score" true (matched > base);
+  Alcotest.(check (float 1e-12)) "non-matching turn leaves score unchanged" base unrelated
+;;
+
 let test_episode_files_do_not_overwrite_generation () =
   with_temp_keepers_dir (fun _keepers_dir ->
     let keeper_id = "episode-unique-keeper" in
@@ -1096,6 +1146,90 @@ let test_render_if_enabled_renders_persisted_memory () =
             "block carries the persisted claim"
             true
             (contains "Gated recall should surface saved facts" block))))
+;;
+
+(* RFC-0244: a seed reranks recall — the lexically matching fact is lifted above a
+   higher-base-confidence fact it would otherwise lose to. *)
+let test_render_context_seed_reranks_selection () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun _keepers_dir ->
+        let keeper_id = "rfc0244-rerank-keeper" in
+        let now = 1_000_000.0 in
+        (* [fact_a] has the higher base confidence, so it wins the seedless
+           ranking; [fact_b] is lower base but fully covers the seed, so the
+           lexical boost must lift it above [fact_a]. *)
+        let fact_a =
+          { (fact_fixture ~now ()) with
+            Types.claim = "alpha bravo charlie unrelated"
+          ; Types.confidence = 0.90
+          }
+        in
+        let fact_b =
+          { (fact_fixture ~now ()) with
+            Types.claim = "delta echo foxtrot golf"
+          ; Types.confidence = 0.80
+          }
+        in
+        let episode =
+          { Types.trace_id = "trace-rerank"
+          ; Types.generation = 1
+          ; Types.episode_summary = "rerank fixture"
+          ; Types.claims = [ fact_a; fact_b ]
+          ; Types.open_items = []
+          ; Types.constraints = []
+          ; Types.preserved_tool_refs = []
+          ; Types.source_turn_range = Some (1, 2)
+          ; Types.created_at = now
+          ; Types.schema_version = Types.schema_version
+          }
+        in
+        Memory_io.append_episode_bundle ~keeper_id episode;
+        let seedless = Recall.render_context ~keeper_id ~now ~max_facts:1 () in
+        let seeded =
+          Recall.render_context ~keeper_id ~now ~max_facts:1 ~seed:"delta echo foxtrot" ()
+        in
+        Alcotest.(check bool)
+          "seedless keeps the higher-confidence fact"
+          true
+          (contains "alpha bravo charlie" seedless
+           && not (contains "delta echo foxtrot" seedless));
+        Alcotest.(check bool)
+          "seed lifts the lexically matching fact above it"
+          true
+          (contains "delta echo foxtrot" seeded
+           && not (contains "alpha bravo charlie" seeded)))))
+;;
+
+(* RFC-0244: an empty seed is byte-identical to the seedless path (no behavior
+   change when there is no turn text). *)
+let test_render_context_empty_seed_matches_seedless () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun _keepers_dir ->
+        let keeper_id = "rfc0244-empty-seed-keeper" in
+        let now = 1_000_000.0 in
+        let fact =
+          { (fact_fixture ~now ()) with Types.claim = "deploy pipeline rollback note" }
+        in
+        let episode =
+          { Types.trace_id = "trace-empty-seed"
+          ; Types.generation = 1
+          ; Types.episode_summary = "empty seed fixture"
+          ; Types.claims = [ fact ]
+          ; Types.open_items = []
+          ; Types.constraints = []
+          ; Types.preserved_tool_refs = []
+          ; Types.source_turn_range = Some (1, 2)
+          ; Types.created_at = now
+          ; Types.schema_version = Types.schema_version
+          }
+        in
+        Memory_io.append_episode_bundle ~keeper_id episode;
+        Alcotest.(check string)
+          "empty seed is byte-identical to seedless"
+          (Recall.render_context ~keeper_id ~now ())
+          (Recall.render_context ~keeper_id ~now ~seed:"" ()))))
 ;;
 
 (* RFC-0239 R2: the append-only store keeps every re-confirmation of a claim as
@@ -1547,6 +1681,22 @@ let () =
             "reobserve_fact updates signals (RFC-0243)"
             `Quick
             test_reobserve_fact_updates_signals
+        ; Alcotest.test_case
+            "lexical_relevance identity for empty seed (RFC-0244)"
+            `Quick
+            test_lexical_relevance_identity_for_empty_seed
+        ; Alcotest.test_case
+            "lexical_relevance is deterministic (RFC-0244)"
+            `Quick
+            test_lexical_relevance_is_deterministic
+        ; Alcotest.test_case
+            "lexical_relevance monotone in coverage (RFC-0244)"
+            `Quick
+            test_lexical_relevance_monotone_in_coverage
+        ; Alcotest.test_case
+            "score_fact seed boosts matching fact (RFC-0244)"
+            `Quick
+            test_score_fact_seed_boosts_match
         ] )
     ; ( "io"
       , [ Alcotest.test_case
@@ -1595,6 +1745,14 @@ let () =
             "render_if_enabled renders persisted memory"
             `Quick
             test_render_if_enabled_renders_persisted_memory
+        ; Alcotest.test_case
+            "seed reranks recall selection (RFC-0244)"
+            `Quick
+            test_render_context_seed_reranks_selection
+        ; Alcotest.test_case
+            "empty seed matches seedless (RFC-0244)"
+            `Quick
+            test_render_context_empty_seed_matches_seedless
         ; Alcotest.test_case
             "dedups repeated claim (RFC-0239 R2)"
             `Quick


### PR DESCRIPTION
## 무엇 (RFC-0244 Phase 1 구현)

Memory OS recall에 **현재 턴 seed + 결정론적 lexical relevance**를 추가합니다. RFC-0244(`docs/rfc/RFC-0244-memory-os-recall-turn-seeded-lexical-retrieval.md`, 이미 main 머지됨)의 Phase 1.

## 왜

recall이 query-less였습니다: `render_if_enabled`가 `keeper_id`+`now`만 받아 **매 턴 같은 candidate set을 랭킹** — 키퍼가 지금 무슨 작업 중인지 무시. 현재 턴 텍스트는 호출부(`keeper_run_tools_hooks.ml:282`) scope에 이미 있었는데 recall에 안 넘겼습니다. (RFC-0243은 랭킹 *신호*를 살렸고, 이건 *query 부재*를 고칩니다.)

## 변경

- `score_fact`에 6번째 factor `lexical_relevance ~seed_tokens` 추가 — seed 토큰이 fact.claim 토큰을 덮는 비율(token-set 교집합), `[1.0, 1.0+gain]` bounded, coverage에 단조.
- `render_context`/`render_if_enabled`에 `?seed:string` 추가. **`seed=None`(또는 토큰 없는 턴)이면 1.0 = byte-identical** → autonomous wake 등 seedless 경로 불변.
- hook이 현재 턴 user 텍스트를 `~seed`로 주입(`compute_tool_surface`의 `last_user_text` fold 미러링).
- `tokenize`를 SSOT로 추출 — `lexical_relevance`와 `bump_access_for_turn`이 공유(중복 토크나이저 제거).

### 의도적으로 안 한 것
`bump_access_for_turn`(turn 매처)을 recall에 **배선하지 않음**: 그 함수는 write(access_count 변경)인데, `recall.mli`가 "intentionally one-way at prompt time"을 명시하므로 recall에 넣으면 불변식 위반. 영속 변형은 librarian write-path로 deferred(RFC-0244 §2.1). turn 랭킹 부스트는 read-only `lexical_relevance`가 담당.

## 설계 tenet (사용자 결정 2026-06-15)
**결정론적 lexical**, 임베딩 reject — offline/재현가능/무의존성 유지. `lexical_relevance`는 `(seed_tokens, claim)`의 순수 함수, 네트워크/임베딩 0. Trade-off: synonymy/paraphrase 못 잡음(RFC §2.1에 명시).

## 검증
- 신규 테스트 6: lexical_relevance identity(빈 seed=1.0)/determinism/monotonicity, score_fact boost, **end-to-end 재랭킹 선택**(낮은 base confidence fact가 seed 매칭으로 상위), empty-seed byte-identical invariance.
- **39/39 keeper_memory_os 테스트 green** (RFC-0243 33 + 신규 6).
- `dune build` 전체 default target green (모든 downstream 소비자 컴파일 확인).
- backward-compat: 시그니처 변경 전부 additive optional. RFC-0243 `~rank:(score_fact ~now)` 부분적용은 `~now`가 optional 뒤라 `fact -> float` 타입 유지.

## Workaround screening (CLAUDE.md)
워크어라운드 아님 — query-less recall의 근본 fix. `lexical_relevance`는 **연속 랭킹 가중치**이지 classifier 분기가 아니며(behavior 분기 없음, closed sum-type을 string으로 압축 안 함), telemetry-as-fix/N-of-M/catch-all 해당 없음. `seed=None`은 total explicit branch.

WORKAROUND-WAIVED: lexical relevance는 ranking factor(분류기 아님), RFC-0244 §3 사전 스크리닝 통과.

## 관련
- 거버닝 RFC: RFC-0244 (main `adb7778f`)
- 선행: RFC-0243 (confidence mutability)
- 후속(roadmap): RFC-0244 P2 provenance, P3 layered consolidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
