### PR TITLE
refactor(server): route SSE stream primers through the sse_retry_ms SSOT (RFC-0089)

### DIFF
--- a/lib/server/server_activity_http.ml
+++ b/lib/server/server_activity_http.ml
@@ -297,8 +297,8 @@ let handle_stream ~deps ~state request reqd =
   info_ref := Some info;
   ignore
     (send_raw info
-       (Printf.sprintf ": activity-stream after=%d\nretry: 3000\n\n"
-          after_seq));
+       (Server_mcp_transport_http_headers.sse_comment_with_retry
+          ~comment:(Printf.sprintf "activity-stream after=%d" after_seq)));
   let replay =
     Activity_graph.list_events (Mcp_server.workspace_config state) ~kinds
       ~after_seq ~limit:replay_limit ()

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -210,7 +210,12 @@ let handle_presence_events ~deps request reqd =
             }
           in
           register_sse_conn ~session_id ~info;
-          if not (send_raw info ": presence-stream\nretry: 3000\n\n") then
+          if
+            not
+              (send_raw info
+                 (Server_mcp_transport_http_headers.sse_comment_with_retry
+                    ~comment:"presence-stream"))
+          then
             Log.Server.debug "presence prime send failed for session %s"
               info.session_id;
           match deps.get_runtime_result () with

--- a/lib/server/server_mcp_transport_http_headers.ml
+++ b/lib/server/server_mcp_transport_http_headers.ml
@@ -192,6 +192,13 @@ let sse_prime_event () =
   let id = Sse.next_id () in
   Printf.sprintf "retry: %d\nid: %d\n\n" sse_retry_ms id
 
+(* RFC-0089: SSE comment line + reconnect [retry:] directive, sourced from the
+   [sse_retry_ms] SSOT. Stream priming sites (presence, activity) used to inline
+   "retry: 3000", which would silently diverge from [sse_retry_ms] if the
+   reconnect interval were ever tuned. *)
+let sse_comment_with_retry ~comment =
+  Printf.sprintf ": %s\nretry: %d\n\n" comment sse_retry_ms
+
 let sse_ping_interval_s = 30.0
 
 let get_last_event_id (request : Httpun.Request.t) =

--- a/lib/server/server_mcp_transport_http_headers.mli
+++ b/lib/server/server_mcp_transport_http_headers.mli
@@ -152,6 +152,12 @@ val sse_prime_event : unit -> string
     from {!Sse.next_id}.  The trailing double-newline is the SSE
     frame terminator — required by the spec. *)
 
+val sse_comment_with_retry : comment:string -> string
+(** [sse_comment_with_retry ~comment] returns an SSE comment frame
+    [[": <comment>\nretry: <sse_retry_ms>\n\n"]].  Stream priming sites
+    (presence, activity) use this so their reconnect interval stays sourced
+    from {!sse_retry_ms} instead of an inlined literal. *)
+
 val sse_ping_interval_s : float
 (** Pinned at [30.0] seconds.  Ping fibers use this interval to
     write the SSE comment frame [": ping\n\n"] so middleboxes do

--- a/test/dune
+++ b/test/dune
@@ -1653,6 +1653,8 @@
 
 (include stanzas/test_social_state_cap_on_load.inc)
 
+(include stanzas/test_sse_retry_ssot.inc)
+
 (include stanzas/test_sse_storm_e2e.inc)
 
 (include stanzas/test_start_masc_script.inc)

--- a/test/stanzas/test_sse_retry_ssot.inc
+++ b/test/stanzas/test_sse_retry_ssot.inc
@@ -1,0 +1,8 @@
+; Per-file dune stanza for the SSE retry-interval SSOT suite (RFC-0089).
+; Lives here per test/stanzas/README.md to avoid the conflict-runtime hotspot
+; in the legacy grouped (tests ...) stanza.
+
+(test
+ (name test_sse_retry_ssot)
+ (modules test_sse_retry_ssot)
+ (libraries masc.server alcotest))

--- a/test/test_sse_retry_ssot.ml
+++ b/test/test_sse_retry_ssot.ml
@@ -1,0 +1,39 @@
+(* RFC-0089 — SSE reconnect-interval SSOT. The presence-stream and
+   activity-stream primers build their "retry:" directive via
+   [sse_comment_with_retry], sourced from [sse_retry_ms], instead of inlining
+   "retry: 3000" (which would silently diverge if the interval were tuned). *)
+
+module H = Server_mcp_transport_http_headers
+open Alcotest
+
+let contains s sub =
+  let ls = String.length s and lsub = String.length sub in
+  let rec go i = (i + lsub <= ls) && (String.sub s i lsub = sub || go (i + 1)) in
+  lsub = 0 || go 0
+
+let test_frame_derives_from_ssot () =
+  check string "presence frame is sourced from sse_retry_ms"
+    (Printf.sprintf ": presence-stream\nretry: %d\n\n" H.sse_retry_ms)
+    (H.sse_comment_with_retry ~comment:"presence-stream")
+
+let test_comment_interpolated_retry_constant () =
+  let a = H.sse_comment_with_retry ~comment:"activity-stream after=7" in
+  let b = H.sse_comment_with_retry ~comment:"presence-stream" in
+  check bool "distinct comments yield distinct frames" true (a <> b);
+  let retry_line = Printf.sprintf "retry: %d" H.sse_retry_ms in
+  check bool "activity frame carries sse_retry_ms" true (contains a retry_line);
+  check bool "presence frame carries sse_retry_ms" true (contains b retry_line);
+  check bool "frame is an SSE comment (leading ': ')" true
+    (String.length a >= 2 && String.sub a 0 2 = ": ")
+
+let () =
+  run "sse_comment_with_retry"
+    [
+      ( "ssot",
+        [
+          test_case "frame derives from sse_retry_ms" `Quick
+            test_frame_derives_from_ssot;
+          test_case "comment interpolated, retry constant" `Quick
+            test_comment_interpolated_retry_constant;
+        ] );
+    ]


### PR DESCRIPTION
## 목적
SSE `retry:` directive(클라이언트 재연결 간격)를 단일 SSOT(`sse_retry_ms`) 경유로 통합합니다 (RFC-0089, scattered-hardcoding hunt 발견).

## 배경
`server_mcp_transport_http_headers.sse_retry_ms`(=3000)가 SSOT이고 `sse_prime_event`가 이를 사용하나, presence-stream primer(`server_mcp_transport_http_agui.ml:213`)와 activity-stream primer(`server_activity_http.ml:300`)는 인라인 `retry: 3000`으로 우회했습니다. `sse_retry_ms`를 조정하면 이 두 스트림만 옛 간격을 광고하는 silent drift.

## 변경
- headers 모듈에 `sse_comment_with_retry ~comment` 추가 — `retry:` 값을 `sse_retry_ms`에서 만드는 SSE comment frame.
- presence/activity primer 두 곳을 이 helper 경유로 전환 (인라인 `retry: 3000` 제거).
- wire 동작 불변(`sse_retry_ms`=3000). 신규 test 2 케이스(frame이 sse_retry_ms에서 파생됨 + comment 보간/retry 상수).

## 검증
- `dune build --root . @check` exit 0 (masc.server + 전체 test).
- 신규 test 통과.

RFC-WAIVED: SSE retry 상수 SSOT 통합 집중 리팩터. credential/operator_control/sandbox/hooks/workflow 등 RFC-게이트 표면 무관. 패턴 umbrella는 RFC-0089(String Classifier to Typed Variant — 본 건은 그 SSOT 변형).
WORKAROUND-WAIVED: 인라인 리터럴을 *제거*하고 SSOT 경유로 대체합니다(추가 아님). 게이트 시그니처는 false-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
