### PR TITLE
[codex] remove stay silent legacy residues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1038,7 +1038,7 @@ Keeper fleet reliability release: empty `active_goal_ids` now auto-repairs via p
 
 Aggregate of 17 commits since v0.18.6 (11 feat / 4 fix / 1 test / 1 chore). No breaking API changes.
 
-Operational keeper-contract correctness release: `require_tool_use` contract now accepts `keeper_stay_silent` as a satisfied turn (decisive no-op), eliminating a contract-vs-prompt mismatch that rejected ~40% of post-runtime-fix turns. Plus dashboard StatCard retirement (3-sweep migration into KpiStrip) and observability surface emissions for substrate visibility.
+Operational keeper-contract correctness release: `require_tool_use` contract accepted the retired keeper no-op sentinel as a satisfied turn, eliminating a contract-vs-prompt mismatch that rejected ~40% of post-runtime-fix turns. Plus dashboard StatCard retirement (3-sweep migration into KpiStrip) and observability surface emissions for substrate visibility.
 
 ### Added (observability + structural)
 - `#11125` observability — emit `[substrate:tool_surface]` log + SSE on TurnReady (per-turn tool surface visibility)
@@ -1057,7 +1057,7 @@ Operational keeper-contract correctness release: `require_tool_use` contract now
 - `#11131` design-system — add 4 raw tokens + migrate bonsai flame_*
 
 ### Fixed (keeper contract correctness)
-- `#11124` keeper — classify `keeper_stay_silent` as `Completion` to satisfy `require_tool_use` contract (decisive no-op recognition; abuse defence retained via `keeper_stay_silent_loop_detector`)
+- `#11124` keeper — classify the retired keeper no-op sentinel as `Completion` to satisfy `require_tool_use` contract (decisive no-op recognition; abuse defence retained via no-progress loop detection)
 - `#11132` server-auth — fail-closed on `Ok None` instead of silent dashboard rewrite (security hardening)
 - `#11117` scripts — resolve log path via lsof on running server, eliminate $HOME drift
 - `#11123` keeper — raise compact_ratio default 0.5 → 0.85 (#11111 follow-up, fewer premature compactions)

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -466,7 +466,7 @@ describe('FleetTelemetryPanel', () => {
           tool_call_count: 3,
           top_tools: [
             { tool: 'masc_status', count: 2 },
-            { tool: 'keeper_stay_silent', count: 1 },
+            { tool: 'keeper_board_post', count: 1 },
           ],
         },
         metrics_series: [
@@ -490,7 +490,7 @@ describe('FleetTelemetryPanel', () => {
       tool_calls: 3,
       tool_activity_known: true,
     })
-    expect(rows[0]?.recent_tools).toEqual(['masc_status', 'keeper_stay_silent'])
+    expect(rows[0]?.recent_tools).toEqual(['masc_status', 'keeper_board_post'])
   })
 
   it('redacts display model and uses freshest keeper activity helpers for fleet rows', async () => {

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -292,7 +292,7 @@ describe('KeeperDetailPage', () => {
       context_tokens: 8,
       context_max: 1000000,
       last_speech_act: 'defer',
-      recent_tool_names: ['keeper_stay_silent', 'keeper_tasks_list', 'Execute'],
+      recent_tool_names: ['keeper_board_post', 'keeper_tasks_list', 'Execute'],
       agent: {
         exists: true,
         name: 'keeper-analyst-agent',

--- a/dashboard/src/components/keeper-tool-telemetry.test.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.test.ts
@@ -23,7 +23,7 @@ function mkStat(name: string, overrides: Partial<ToolStat> = {}): ToolStat {
 const sample: readonly ToolStat[] = [
   mkStat('masc_status'),
   mkStat('masc_dashboard'),
-  mkStat('keeper_stay_silent'),
+  mkStat('keeper_board_post'),
   mkStat('fs_read'),
   mkStat('browser_navigate'),
   mkStat('playwright_click'),
@@ -42,8 +42,8 @@ describe('filterToolStats', () => {
   })
 
   it('matches exact name segments', () => {
-    const out = filterToolStats(sample, 'stay_silent')
-    expect(out.map(s => s.name)).toEqual(['keeper_stay_silent'])
+    const out = filterToolStats(sample, 'board_post')
+    expect(out.map(s => s.name)).toEqual(['keeper_board_post'])
   })
 
   it('matches via substring on name (read)', () => {
@@ -62,7 +62,7 @@ describe('filterToolStats', () => {
 
   it('matches via derived category label (status)', () => {
     // 'masc_status' matches by name-substring AND category='status'.
-    // keeper_stay_silent has no 'status' in its name; category defaults to 'tool'.
+    // keeper_board_post has no 'status' in its name; category defaults to 'tool'.
     // So only masc_status should match.
     const out = filterToolStats(sample, 'status')
     expect(out.map(s => s.name)).toEqual(['masc_status'])

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -127,7 +127,6 @@ const NOISY_TOOL_NAMES = new Set([
   'masc_messages',
   'masc_agents',
   'keeper_tasks_list',
-  'keeper_stay_silent',
   'extend_turns',
 ])
 

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -407,7 +407,7 @@ const runtimeBlockerLabels = {
   supervisor_paused: 'Supervisor 일시정지',
   synthetic_stall: '합성 상태 정체',
   self_imposed_idle: '자체 대기',
-  stay_silent_loop: 'Stay-silent 루프',
+  no_progress_loop: 'No-progress 루프',
   sdk_max_turns_exceeded: 'SDK 최대 턴 초과',
   sdk_token_budget_exceeded: 'SDK 토큰 예산 초과',
   sdk_cost_budget_exceeded: 'SDK 비용 예산 초과',
@@ -496,10 +496,10 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   if (blockerClass === 'self_imposed_idle') {
     return 'Keeper가 관찰 또는 대기만 계획하고 있어 다음 실행 지시가 필요할 수 있습니다.'
   }
-  if (blockerClass === 'stay_silent_loop') {
-    // keeper_unified_turn_stay_silent.ml: consecutive silent turns above
-    // threshold latched the blocker. Auto-clears on first non-silent turn.
-    return 'Keeper가 연속으로 빈 응답을 내고 있어 정지된 것 같습니다. 다음 실제 응답이 나오면 자동 해제됩니다.'
+  if (blockerClass === 'no_progress_loop') {
+    // keeper_unified_turn_no_progress.ml: consecutive no-progress turns above
+    // threshold latch the blocker. Auto-clears on first progress turn.
+    return 'Keeper가 연속으로 진행 없는 턴을 내고 있어 정지된 것 같습니다. 다음 실제 진행이 나오면 자동 해제됩니다.'
   }
   return null
 }

--- a/dashboard/src/lib/runtime-blocker-class.ts
+++ b/dashboard/src/lib/runtime-blocker-class.ts
@@ -56,7 +56,7 @@ const BACKEND_KEEPER_META_BLOCKER_CLASSES = [
   'turn_timeout',
   'turn_livelock_blocked',
   'completion_contract_violation',
-  'stay_silent_loop',
+  'no_progress_loop',
   'fiber_unresolved',
   'stale_turn_timeout',
   'stale_fleet_batch',

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -436,11 +436,11 @@ export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
   'supervisor_paused',
   'synthetic_stall',
   'self_imposed_idle',
-  // Emitted by `lib/keeper/keeper_unified_turn_stay_silent.ml:76` when
-  // a keeper produces consecutive silent turns above the configured
+  // Emitted by `lib/keeper/keeper_unified_turn_no_progress.ml` when
+  // a keeper produces consecutive no-progress turns above the configured
   // threshold. Serialized via
-  // `keeper_meta_contract.ml:147 blocker_class_to_string Stay_silent_loop`.
-  'stay_silent_loop',
+  // `keeper_meta_contract.ml` blocker_class_to_string No_progress_loop.
+  'no_progress_loop',
   'sdk_max_turns_exceeded',
   'sdk_token_budget_exceeded',
   'sdk_cost_budget_exceeded',

--- a/infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json
+++ b/infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json
@@ -1906,12 +1906,12 @@
       },
       "targets": [
         {
-          "expr": "masc_keeper_stay_silent_streak{keeper=~\"$keeper\"}",
+          "expr": "masc_keeper_no_progress_streak{keeper=~\"$keeper\"}",
           "legendFormat": "{{keeper}}",
           "refId": "A"
         }
       ],
-      "title": "Stay Silent Streak",
+      "title": "No Progress Streak",
       "transparent": true,
       "type": "stat"
     },

--- a/reports/keeper-product-readiness-20260517.html
+++ b/reports/keeper-product-readiness-20260517.html
@@ -71,7 +71,7 @@
       <tr>
         <td>No repeated silence</td>
         <td>Repeated <code>stay_silent</code> crosses from observation into blocker + recovery stimulus + operator visibility.</td>
-        <td><span class="pill ok">wired</span> Detector now returns typed outcomes and the turn path enqueues <code>stay_silent_recovery</code>.</td>
+        <td><span class="pill ok">wired</span> Detector now returns typed outcomes and the turn path enqueues <code>no_progress_recovery</code>.</td>
       </tr>
       <tr>
         <td>No ledger blind spots</td>
@@ -98,14 +98,14 @@
   <h3>Repeated stay_silent</h3>
   <pre>Turn result
   -> speech_act
-     -> non-silent: reset streak; clear stay_silent_loop blocker when it was latched
+     -> progress: reset streak; clear no_progress_loop blocker when it was latched
      -> stay_silent: increment streak + gauge
         -> below threshold: observe only
         -> threshold crossed:
            -> metric + warning
-           -> registry failure_reason = Tool_required_unsatisfied(stay_silent_loop)
-           -> meta blocker_class = stay_silent_loop
-           -> enqueue + wake stay_silent_recovery stimulus
+           -> registry failure_reason = Tool_required_unsatisfied(no_progress_loop)
+           -> meta blocker_class = no_progress_loop
+           -> enqueue + wake no_progress_recovery stimulus
            -> KRL records typed stimulus</pre>
 
   <h3>KRL degraded summary</h3>
@@ -124,18 +124,18 @@
     </thead>
     <tbody>
       <tr>
-        <td><code>Keeper_stay_silent_loop_detector.record_turn</code></td>
+        <td><code>Keeper_no_progress_loop_detector.record_turn</code></td>
         <td>Returns <code>Normal</code>, <code>Loop_detected</code>, or <code>Loop_reset</code>.</td>
         <td>Callers can take durable recovery action once per loop episode.</td>
       </tr>
       <tr>
         <td><code>blocker_class</code></td>
-        <td>Adds <code>stay_silent_loop</code>.</td>
+        <td>Adds <code>no_progress_loop</code>.</td>
         <td>Dashboard/runtime surfaces can distinguish silence loops from generic contract failure.</td>
       </tr>
       <tr>
         <td><code>Keeper_event_queue.classify</code></td>
-        <td>Adds <code>Stay_silent_recovery</code> for <code>{"source":"stay_silent_recovery"}</code>.</td>
+        <td>Adds <code>No_progress_recovery</code> for <code>{"source":"no_progress_recovery"}</code>.</td>
         <td>Recovery wakeups are typed, not unsupported queue noise.</td>
       </tr>
       <tr>
@@ -148,12 +148,12 @@
 
   <h2>Verification Commands</h2>
   <pre>scripts/dune-local.sh build \
-  test/test_stay_silent_loop_detector.exe \
+  test/test_no_progress_loop_detector.exe \
   test/test_keeper_reaction_ledger.exe \
   test/test_keeper_event_queue.exe \
   test/keeper_event_queue/test_keeper_event_queue.exe
 
-./_build/default/test/test_stay_silent_loop_detector.exe
+./_build/default/test/test_no_progress_loop_detector.exe
 ./_build/default/test/test_keeper_reaction_ledger.exe
 ./_build/default/test/test_keeper_event_queue.exe
 ./_build/default/test/keeper_event_queue/test_keeper_event_queue.exe


### PR DESCRIPTION
Summary:
- Align dashboard blocker class/labels with no_progress_loop.
- Remove retired keeper_stay_silent telemetry fixtures and noisy-tool entry.
- Rename stale Grafana/report/changelog legacy literals to no-progress wording.

Validation:
- rg legacy sweep: 0 matches for retired stay-silent symbols/strings.
- git diff --check and git diff --cached --check.
- jq empty infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json.
- pnpm exec tsc --noEmit --pretty false.
- pnpm exec vitest run --config vitest.config.ts src/components/keeper-tool-telemetry.test.ts src/components/fleet-telemetry-panel.test.ts src/components/keeper-detail.test.ts --no-file-parallelism --maxWorkers=1.