### PR TITLE
feat(dashboard): enrich keeper roster rows and enlarge workspace chrome fonts

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -81,4 +81,33 @@ describe('KeeperWorkspaceRoster', () => {
     expect(rows.length).toBe(1)
     expect(rows[0]?.textContent).toContain('rama')
   })
+
+  it('shows a work-preview line per row, preferring recent output', () => {
+    keepers.value = [
+      mk({ name: 'with-output', status: 'running', recent_output_preview: '리뷰 코멘트 정리 중' }),
+    ]
+    render(html`<${KeeperWorkspaceRoster} activeName="with-output" />`, host)
+    const work = host.querySelector('.kw-kp-work') as HTMLElement
+    expect(work?.textContent).toBe('리뷰 코멘트 정리 중')
+    // title mirrors the text so truncated previews stay inspectable on hover
+    expect(work?.getAttribute('title')).toBe('리뷰 코멘트 정리 중')
+  })
+
+  it('falls through the work-preview precedence chain', () => {
+    keepers.value = [
+      // recent_output/input absent -> short_goal wins over goal/current_task
+      mk({ name: 'goal-only', status: 'running', short_goal: 'WIP 게이트 수정', goal: '무시됨' }),
+    ]
+    render(html`<${KeeperWorkspaceRoster} activeName="goal-only" />`, host)
+    const work = host.querySelector('.kw-kp-work') as HTMLElement
+    expect(work?.textContent).toBe('WIP 게이트 수정')
+  })
+
+  it('renders the empty-work fallback when no preview source exists', () => {
+    keepers.value = [mk({ name: 'bare', status: 'stopped' })]
+    render(html`<${KeeperWorkspaceRoster} activeName="bare" />`, host)
+    const work = host.querySelector('.kw-kp-work') as HTMLElement
+    expect(work?.textContent).toBe('최근 작업 요약 없음')
+    expect(work?.getAttribute('title')).toBe('')
+  })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -43,6 +43,18 @@ function keeperScope(keeper: Keeper): string | null {
   return keeper.skill_primary ?? keeper.active_model ?? keeper.model ?? null
 }
 
+/** One-line "what is this keeper doing" preview so rows carry real content
+ *  instead of reading bare. Same precedence as the detail page's work
+ *  preview (recent output → input → goal → current task). */
+function keeperWorkPreview(keeper: Keeper): string | null {
+  return keeper.recent_output_preview
+    ?? keeper.recent_input_preview
+    ?? keeper.short_goal
+    ?? keeper.goal
+    ?? keeper.agent?.current_task
+    ?? null
+}
+
 function matchesQuery(keeper: Keeper, q: string): boolean {
   if (!q) return true
   const hay = `${keeper.name} ${keeper.koreanName ?? ''} ${keeperScope(keeper) ?? ''} ${keeper.model ?? ''}`.toLowerCase()
@@ -55,6 +67,7 @@ function RosterRow({ keeper, active, onSelect }: { keeper: Keeper; active: boole
   const att = attentionCount(keeper)
   const scope = keeperScope(keeper)
   const activity = keeperActivityDisplay(keeper)
+  const work = keeperWorkPreview(keeper)
   return html`
     <button
       type="button"
@@ -62,13 +75,14 @@ function RosterRow({ keeper, active, onSelect }: { keeper: Keeper; active: boole
       aria-current=${active ? 'true' : 'false'}
       onClick=${() => onSelect(keeper.name)}
     >
-      <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${bucket === 'running'} />
+      <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${bucket === 'running'} />
       <div class="kw-kp-meta">
         <div class="kw-kp-name">${keeper.koreanName ?? keeper.name}</div>
         <div class="kw-kp-sub">
           <span class="kw-kp-state"><${StatusDot} tone=${tone} pulse=${bucket === 'running'} />${keeperPhaseLabel(keeper)}</span>
           ${scope ? html`<span aria-hidden="true">·</span><span class="kw-kp-handle">${scope}</span>` : null}
         </div>
+        <div class="kw-kp-work" title=${work ?? ''}>${work ?? '최근 작업 요약 없음'}</div>
       </div>
       <div class="kw-kp-right">
         ${activity.source !== 'none' ? html`<span class="kw-kp-time">${activity.label}</span>` : null}

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -60,7 +60,7 @@
 .kw-roster-head { padding: 15px 14px; border-bottom: 1px solid var(--color-border-divider); }
 .kw-roster-search {
   width: 100%;
-  font-size: 12.5px;
+  font-size: 13px;
   padding: 8px 11px;
   background: var(--color-bg-page);
   color: var(--color-fg-primary);
@@ -85,15 +85,15 @@
 
 .kw-roster-list { flex: 1; overflow-y: auto; padding: 9px 8px; }
 .kw-roster-group {
-  font-size: 9.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--color-fg-muted);
+  font-size: 10.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--color-fg-muted);
   padding: 12px 8px 5px;
 }
-.kw-roster-empty { padding: 30px 12px; text-align: center; color: var(--color-fg-muted); font-size: 12px; }
+.kw-roster-empty { padding: 30px 12px; text-align: center; color: var(--color-fg-muted); font-size: 12.5px; }
 
 .kw-kp-row {
-  display: grid; grid-template-columns: 38px 1fr auto; gap: 10px; align-items: center;
+  display: grid; grid-template-columns: 40px 1fr auto; gap: 11px; align-items: start;
   width: 100%; text-align: left;
-  padding: 10px 10px; border-radius: var(--r-2); cursor: pointer;
+  padding: 11px 10px; border-radius: var(--r-2); cursor: pointer;
   border: 1px solid transparent; background: transparent;
   transition: background .14s, border-color .14s;
   position: relative;
@@ -106,11 +106,12 @@
   box-shadow: 0 0 10px rgb(var(--color-accent-glow) / 0.6);
 }
 .kw-kp-meta { min-width: 0; }
-.kw-kp-name { font-weight: 600; font-size: 13.5px; color: var(--color-fg-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.kw-kp-sub { display: flex; align-items: center; gap: 6px; font-size: 10.5px; color: var(--color-fg-muted); margin-top: 2px; min-width: 0; }
+.kw-kp-name { font-weight: 600; font-size: 15px; color: var(--color-fg-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kw-kp-sub { display: flex; align-items: center; gap: 6px; font-size: 11.5px; color: var(--color-fg-muted); margin-top: 3px; min-width: 0; }
 .kw-kp-state { display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; }
 .kw-kp-handle { font-family: var(--font-mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-.kw-kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; flex: none; }
+.kw-kp-work { margin-top: 4px; font-size: 11.5px; color: var(--color-fg-muted); line-height: 1.4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kw-kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; flex: none; padding-top: 2px; }
 .kw-kp-time { font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-muted); }
 .kw-kp-att {
   font-family: var(--font-mono); font-size: 9.5px; font-weight: 600;
@@ -147,9 +148,9 @@
 .kw-chat-id { min-width: 0; flex: 1; }
 .kw-chat-name-row { display: flex; align-items: center; gap: 11px; flex-wrap: wrap; }
 .kw-chat-name { font-size: 20px; font-weight: 600; letter-spacing: 0.01em; color: var(--color-fg-primary); margin: 0; white-space: nowrap; }
-.kw-chat-sub { display: flex; align-items: center; gap: 10px; margin-top: 5px; font-size: 11px; color: var(--color-fg-muted); flex-wrap: wrap; }
+.kw-chat-sub { display: flex; align-items: center; gap: 10px; margin-top: 6px; font-size: 12px; color: var(--color-fg-muted); flex-wrap: wrap; }
 .kw-chat-sub > span { white-space: nowrap; display: inline-flex; align-items: center; gap: 5px; }
-.kw-chat-sub .k { font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--color-fg-muted); }
+.kw-chat-sub .k { font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--color-fg-muted); }
 .kw-chat-sub .mono { font-family: var(--font-mono); color: var(--color-fg-secondary); }
 
 .kw-state-pill {
@@ -219,15 +220,15 @@
 .kw-rail-scroll { overflow-y: auto; padding: 20px; display: flex; flex-direction: column; gap: 22px; }
 .kw-sec h4 {
   font-weight: 600; text-transform: uppercase; letter-spacing: 0.16em;
-  font-size: 11px; color: var(--color-fg-secondary); margin: 0 0 9px;
+  font-size: 12px; color: var(--color-fg-secondary); margin: 0 0 9px;
   display: flex; align-items: center; gap: 7px;
 }
 .kw-card { background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: var(--r-2); padding: 12px 13px; }
 
 .kw-vitals { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--color-border-divider); border: 1px solid var(--color-border-default); border-radius: var(--r-2); overflow: hidden; }
 .kw-vital { background: var(--color-bg-surface); padding: 9px 11px; min-width: 0; }
-.kw-vital .vk { font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-fg-secondary); font-weight: 600; }
-.kw-vital .vv { font-family: var(--font-mono); font-size: 13px; color: var(--color-fg-primary); margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kw-vital .vk { font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-fg-secondary); font-weight: 600; }
+.kw-vital .vv { font-family: var(--font-mono); font-size: 14px; color: var(--color-fg-primary); margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .kw-meter-wrap { position: relative; margin-top: 18px; }
 .kw-meter { height: 7px; border-radius: 9999px; background: var(--color-bg-page); border: 1px solid var(--color-border-divider); overflow: hidden; }
@@ -239,20 +240,20 @@
   font-style: normal; font-size: 8.5px; letter-spacing: 0.04em; white-space: nowrap;
   color: var(--color-status-warn); opacity: 0.85;
 }
-.kw-ctx-tok { display: flex; align-items: baseline; gap: 5px; margin-top: 8px; font-size: 11px; }
+.kw-ctx-tok { display: flex; align-items: baseline; gap: 5px; margin-top: 8px; font-size: 11.5px; }
 .kw-ctx-tok .mono { font-family: var(--font-mono); color: var(--color-fg-secondary); }
-.kw-ctx-tok .lbl { margin-left: auto; color: var(--color-fg-muted); font-size: 10px; }
+.kw-ctx-tok .lbl { margin-left: auto; color: var(--color-fg-muted); font-size: 10.5px; }
 
 .kw-list { display: flex; flex-direction: column; gap: 7px; }
-.kw-list-empty { font-size: 12px; color: var(--color-fg-muted); }
-.kw-tasktag { display: flex; align-items: center; gap: 8px; padding: 7px 9px; border-radius: var(--r-1); background: var(--color-bg-page); border: 1px solid var(--color-border-divider); font-size: 12px; color: var(--color-fg-primary); }
-.kw-tasktag .tid { font-family: var(--font-mono); font-size: 10.5px; color: var(--color-accent-fg); flex: none; }
+.kw-list-empty { font-size: 12.5px; color: var(--color-fg-muted); }
+.kw-tasktag { display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-radius: var(--r-1); background: var(--color-bg-page); border: 1px solid var(--color-border-divider); font-size: 12.5px; color: var(--color-fg-primary); }
+.kw-tasktag .tid { font-family: var(--font-mono); font-size: 11px; color: var(--color-accent-fg); flex: none; }
 .kw-tasktag .ttl { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 1; }
 .kw-tasktag .tstate { font-size: 10px; flex: none; color: var(--color-fg-muted); }
 .kw-tasktag .tstate.review { color: var(--color-status-warn); }
 
-.kw-tool { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--color-fg-secondary); }
-.kw-tool .nm { font-family: var(--font-mono); font-size: 11.5px; color: var(--color-fg-primary); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kw-tool { display: flex; align-items: center; gap: 8px; font-size: 12.5px; color: var(--color-fg-secondary); }
+.kw-tool .nm { font-family: var(--font-mono); font-size: 12px; color: var(--color-fg-primary); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .kw-detail-btn {
   width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 8px;


### PR DESCRIPTION
## 요약

Keeper 대화 워크스페이스(3-페인)의 로스터 행을 풍부하게 만들고 chrome 폰트를 한 단계 키웁니다. 사용자 피드백("왼쪽 로스터가 허전하다", "폰트가 좀 작다") 대응.

## 배경

#21216이 keeper-workspace 3-페인을 main에 도입한 뒤, 로스터 행이 이름+상태줄만 있어 비어 보이고 chrome 폰트가 작다는 피드백이 있었습니다.

## 변경

- **로스터 행 풍부화**: 작업 미리보기 1줄 추가(`recent output → input → goal → current task`, 없으면 `최근 작업 요약 없음`), 3줄 행 상단 정렬, sigil 38→40px.
- **chrome 폰트 상향**: 로스터 이름/sub/그룹, 레일 vitals/h4/list, 채팅 sub, 컨텍스트 토큰을 한 단계씩. 대화 본문은 이미 `text-base`라 무변경.
- CSS + 로스터 마크업만 변경. 채팅 엔진은 건드리지 않음.

## 검증

- `tsc --noEmit` 0, `eslint` 0.
- 워크스페이스 테스트 통과(23), `keeper-detail` 통합 테스트 통과(21).
- `vite build` 성공.
