### PR TITLE
fix(keeper): gate memory librarian completions

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -37,6 +37,17 @@ let default_timeout_sec () =
     ~default:Env_config_governance.Inference.timeout_seconds
 ;;
 
+let provider_slot_busy = "librarian provider slot busy"
+
+let provider_slot = Eio.Semaphore.make 1
+
+let provider_slot_wait_sec () =
+  Keeper_memory_bank_env.memory_env_float_logged
+    "MASC_KEEPER_MEMORY_OS_LIBRARIAN_SLOT_WAIT_SEC"
+    ~default:0.25
+  |> max 0.001
+;;
+
 let runtime_id_for_librarian ~runtime_id =
   match Sys.getenv_opt "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID" with
   | Some value ->
@@ -143,6 +154,18 @@ let with_timeout ?clock ~timeout_sec f =
      | Eio.Time.Timeout -> None)
 ;;
 
+let with_provider_slot ?clock f =
+  match
+    with_timeout ?clock ~timeout_sec:(provider_slot_wait_sec ()) (fun () ->
+      Eio.Semaphore.acquire provider_slot)
+  with
+  | None -> Error provider_slot_busy
+  | Some () ->
+    (* fun-protect-finally-ok: [Eio.Semaphore.release] only returns the
+       provider slot; it does not wait, acquire, or perform I/O. *)
+    Fun.protect ~finally:(fun () -> Eio.Semaphore.release provider_slot) f
+;;
+
 let extract_with_provider
     ?(complete = default_complete)
     ?clock
@@ -156,20 +179,21 @@ let extract_with_provider
   | Error _ as e -> e
   | Ok messages ->
     let provider_cfg = provider_for_librarian provider_cfg in
-    (match
-       with_timeout ?clock ~timeout_sec (fun () ->
-         complete ~sw ~net ?clock ~config:provider_cfg ~messages ())
-     with
-     | None -> Error "librarian provider timed out"
-     | Some (Error err) -> Error (http_error_message err)
-     | Some (Ok response) ->
-       let raw = Agent_sdk_response.text_of_response response |> String.trim in
-       if String.equal raw ""
-       then Error "librarian provider returned empty response"
-       else (
-         match Keeper_librarian.episode_of_output inp raw with
-         | Some episode -> Ok episode
-         | None -> Error "librarian provider returned invalid episode JSON"))
+    with_provider_slot ?clock (fun () ->
+      match
+        with_timeout ?clock ~timeout_sec (fun () ->
+          complete ~sw ~net ?clock ~config:provider_cfg ~messages ())
+      with
+      | None -> Error "librarian provider timed out"
+      | Some (Error err) -> Error (http_error_message err)
+      | Some (Ok response) ->
+        let raw = Agent_sdk_response.text_of_response response |> String.trim in
+        if String.equal raw ""
+        then Error "librarian provider returned empty response"
+        else (
+          match Keeper_librarian.episode_of_output inp raw with
+          | Some episode -> Ok episode
+          | None -> Error "librarian provider returned invalid episode JSON"))
 ;;
 
 let extract_and_append_with_provider
@@ -269,6 +293,10 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id inp =
                  episode.Keeper_memory_os_types.trace_id
                  episode.generation
                  (List.length episode.claims)
+             | Error err when String.equal err provider_slot_busy ->
+               Log.Keeper.info ~keeper_name:keeper_id
+                 "memory os librarian skipped runtime=%s: provider slot busy"
+                 runtime_id
              | Error err ->
                Otel_metric_store.inc_counter
                  Keeper_metrics.(to_string EpisodeCreateFailures)

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -166,6 +166,16 @@ let with_eio f =
   @@ fun sw -> f ~sw ~net:(Eio.Stdenv.net env) ~clock:(Eio.Stdenv.clock env)
 ;;
 
+let wait_for_ref ~clock label r =
+  try
+    Eio.Time.with_timeout_exn clock 1.0 (fun () ->
+      while Option.is_none !r do
+        Eio.Fiber.yield ()
+      done)
+  with
+  | Eio.Time.Timeout -> Alcotest.failf "timed out waiting for %s" label
+;;
+
 let episode_fixture ~now ~trace_id ~generation ~summary =
   let fact =
     { (fact_fixture ~now ()) with
@@ -784,6 +794,78 @@ let test_librarian_runtime_appends_episode_bundle () =
             "Integer confidence survives parsing"
             fact.Types.claim
         | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
+;;
+
+let test_librarian_runtime_provider_slot_gate () =
+  with_prompt_registry (fun () ->
+    with_eio (fun ~sw ~net ~clock ->
+      let env_name = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_SLOT_WAIT_SEC" in
+      let previous = Sys.getenv_opt env_name in
+      Fun.protect
+        ~finally:(fun () ->
+          match previous with
+          | Some value -> Unix.putenv env_name value
+          | None -> Unix.putenv env_name "")
+        (fun () ->
+          Unix.putenv env_name "0.01";
+          let entered, resolve_entered = Eio.Promise.create () in
+          let release, resolve_release = Eio.Promise.create () in
+          let provider_calls = Atomic.make 0 in
+          let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+            let n = Atomic.fetch_and_add provider_calls 1 in
+            if n = 0
+            then (
+              Eio.Promise.resolve resolve_entered ();
+              Eio.Promise.await release;
+              Ok (fake_response (valid_librarian_output () |> Yojson.Safe.to_string)))
+            else
+              Ok (fake_response (valid_librarian_output () |> Yojson.Safe.to_string))
+          in
+          let input trace_id : Librarian.input =
+            { Librarian.trace_id
+            ; generation = 1
+            ; messages = [ text_message "remember this bounded fact" ]
+            }
+          in
+          let first = ref None in
+          let second = ref None in
+          Eio.Fiber.fork ~sw (fun () ->
+            first
+            := Some
+                 (Librarian_runtime.extract_with_provider
+                    ~complete
+                    ~clock
+                    ~timeout_sec:1.0
+                    ~sw
+                    ~net
+                    ~provider_cfg:(test_provider_cfg ())
+                    (input "trace-slot-a")));
+          Eio.Promise.await entered;
+          Eio.Fiber.fork ~sw (fun () ->
+            second
+            := Some
+                 (Librarian_runtime.extract_with_provider
+                    ~complete
+                    ~clock
+                    ~timeout_sec:1.0
+                    ~sw
+                    ~net
+                    ~provider_cfg:(test_provider_cfg ())
+                    (input "trace-slot-b")));
+          wait_for_ref ~clock "second librarian result" second;
+          Eio.Promise.resolve resolve_release ();
+          wait_for_ref ~clock "first librarian result" first;
+          (match !second with
+           | Some (Error "librarian provider slot busy") -> ()
+           | Some (Error msg) -> Alcotest.failf "unexpected busy error: %s" msg
+           | Some (Ok _) -> Alcotest.fail "expected second librarian call to skip"
+           | None -> Alcotest.fail "second result missing");
+          (match !first with
+           | Some (Ok episode) ->
+             Alcotest.(check string) "first trace" "trace-slot-a" episode.Types.trace_id
+           | Some (Error msg) -> Alcotest.failf "first call failed: %s" msg
+           | None -> Alcotest.fail "first result missing");
+          Alcotest.(check int) "only one provider call entered" 1 (Atomic.get provider_calls))))
 ;;
 
 let test_policy_score () =
@@ -1531,6 +1613,10 @@ let () =
             "librarian runtime appends episode bundle"
             `Quick
             test_librarian_runtime_appends_episode_bundle
+        ; Alcotest.test_case
+            "librarian runtime provider slot gate"
+            `Quick
+            test_librarian_runtime_provider_slot_gate
         ] )
     ; ( "policy"
       , [ Alcotest.test_case "score ordering" `Quick test_policy_score


### PR DESCRIPTION
## Summary
- serialize Memory OS librarian direct-completion calls through a small provider slot
- skip busy librarian attempts without incrementing episode failure counters
- add a regression test covering concurrent librarian calls

## Why
Live runtime is configured with MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID=ollama_cloud.deepseek-v4-flash, but post-turn librarian calls still produced repeated empty response / invalid episode JSON WARNs. One concrete risk is that the librarian path bypasses keeper runtime scheduling and can stampede the same provider from many keeper turns at once.

This PR does not claim to fix all malformed JSON output from the model. It removes the local concurrency amplifier and leaves remaining malformed single-call output visible as real provider/model quality signal.

## Verification
- scripts/dune-local.sh build test/test_keeper_memory_os.exe
- ./_build/default/test/test_keeper_memory_os.exe (34 tests)
