### PR TITLE
fix(dashboard): drop stale pending keeper requests

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -267,6 +267,28 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     ])
     expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
   })
+
+  it('drops a stale pending request when the server no longer knows request_id', async () => {
+    upsertPendingKeeperChatRequest({
+      requestId: 'kmsg_echo_1',
+      keeperName: 'echo',
+      message: '어디까지 했어?',
+      submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
+    })
+    fetchQueuedKeeperMessageResult.mockRejectedValue(
+      new Error(
+        'GET /api/v1/gate/message/requests/kmsg_echo_1: {"error":{"message":"request_id not found"}}',
+      ),
+    )
+    fetchKeeperChatHistory.mockResolvedValue([])
+
+    await resumePendingKeeperChatRequests('echo')
+
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+    expect(keeperThreads.value.echo).toEqual([])
+    expect(keeperActionErrors.value.echo).toBeNull()
+    expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1)
+  })
 })
 
 // ─── Status / runtime actions (exports untested before this block) ──

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -37,6 +37,7 @@ import {
   normalizeKeeperProbeResult,
   normalizeKeeperRecoverResult,
   normalizeStatusDetail,
+  removeThreadEntries,
   setActiveStream,
   setRecordValue,
   setStatusDetail,
@@ -190,6 +191,19 @@ function pendingAssistantEntryId(requestId: string): string {
   return `pending-assistant-${requestId}`
 }
 
+function isMissingQueuedKeeperRequestError(err: unknown): boolean {
+  const record = isRecord(err) ? err : null
+  const method = asString(record?.method, '').trim().toUpperCase()
+  const status = typeof record?.status === 'number' ? record.status : null
+  const path = asString(record?.path, '').trim()
+  const message = err instanceof Error ? err.message : ''
+  if (method === 'GET' && status === 404 && path.startsWith('/api/v1/gate/message/requests/')) {
+    return message.includes('request_id not found')
+  }
+  return message.includes('/api/v1/gate/message/requests/')
+    && message.includes('request_id not found')
+}
+
 function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
   const existing = keeperThreads.value[request.keeperName] ?? []
   const userId = pendingUserEntryId(request.requestId)
@@ -274,6 +288,15 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       return
     }
   } catch (err) {
+    if (isMissingQueuedKeeperRequestError(err)) {
+      removePendingKeeperChatRequest(request.requestId)
+      removeThreadEntries(request.keeperName, [
+        pendingUserEntryId(request.requestId),
+        assistantId,
+      ])
+      await hydrateKeeperChatHistory(request.keeperName, { force: true })
+      return
+    }
     const message = err instanceof Error ? err.message : `Failed to resume ${request.keeperName} chat request`
     setRecordValue(keeperActionErrors, request.keeperName, `대기 중 메시지 복구 실패: ${message}`)
   } finally {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -279,6 +279,18 @@ export function appendThreadEntry(name: string, entry: KeeperConversationEntry):
   }
 }
 
+export function removeThreadEntries(name: string, entryIds: readonly string[]): void {
+  if (entryIds.length === 0) return
+  const removeIds = new Set(entryIds)
+  const existing = keeperThreads.value[name] ?? []
+  const next = existing.filter(entry => !removeIds.has(entry.id))
+  if (next.length === existing.length) return
+  keeperThreads.value = {
+    ...keeperThreads.value,
+    [name]: next,
+  }
+}
+
 /** Insert [entry] immediately before the entry with id [beforeId].
  *  Falls back to append when [beforeId] is absent. Used to keep live
  *  tool-call entries above the streaming assistant bubble so the final


### PR DESCRIPTION
## Summary
- Treat `GET /api/v1/gate/message/requests/:id` 404 `request_id not found` during pending chat resume as stale local pending state.
- Remove the matching pending request and placeholder thread entries, then force-hydrate keeper chat history without surfacing `대기 중 메시지 복구 실패`.
- Add regression coverage for stale pending request recovery.

## Root Cause
The dashboard can keep a pending keeper chat request in localStorage after the server-side queued request record is gone, for example after restart or pruning. On reload, the resume path polled the old `request_id` and surfaced the expected 404 as a user-visible recovery error.

## Validation
- `pnpm exec vitest run --config vitest.config.ts src/keeper-actions.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run lint`