### PR TITLE
refactor(otel): route OTLP probe port through the otel_default_port SSOT (RFC-0089)

### DIFF
--- a/lib/otel_spans/otel_spans.ml
+++ b/lib/otel_spans/otel_spans.ml
@@ -81,6 +81,12 @@ let setup_exporter_with ?(enabled = Otel_config.enabled) ~endpoint ~setup () =
           endpoint (Printexc.to_string exn)
   end
 
+(** [port_of_uri uri] returns the explicit port of [uri], falling back to the
+    configured OTLP default ([Masc_network_defaults.otel_default_port]) when the
+    URI omits one. Keeps the OTLP port in a single source of truth. *)
+let port_of_uri uri =
+  Option.value (Uri.port uri) ~default:Masc_network_defaults.otel_default_port
+
 (** Probe OTLP collector endpoint via TCP connect with DNS resolution.
     Lightweight: resolves host, opens connection, and immediately closes.
     Returns [true] if the collector is reachable. *)
@@ -88,7 +94,7 @@ let probe_endpoint ~(env : Eio_unix.Stdenv.base) endpoint =
   try
     let uri = Uri.of_string endpoint in
     let host = Option.value (Uri.host uri) ~default:"localhost" in
-    let port = Option.value (Uri.port uri) ~default:4318 in
+    let port = port_of_uri uri in
     let net = env#net in
     let addrs = Eio.Net.getaddrinfo_stream net host ~service:(string_of_int port) in
     match addrs with

--- a/lib/otel_spans/otel_spans.mli
+++ b/lib/otel_spans/otel_spans.mli
@@ -37,6 +37,11 @@ val setup_exporter_with :
     No-op when OTel is explicitly disabled. *)
 val setup_exporter : sw:Eio.Switch.t -> Eio_unix.Stdenv.base -> unit
 
+(** [port_of_uri uri] returns the explicit port of [uri], or the configured
+    OTLP default ([Masc_network_defaults.otel_default_port]) when the URI omits
+    one. Pure; keeps the OTLP port in a single source of truth. *)
+val port_of_uri : Uri.t -> int
+
 (** Flush pending spans and remove the OTLP backend.
     Safe to call when disabled (no-op). Resets [is_exporter_active] to [false]. *)
 val shutdown : ?enabled:bool -> unit -> unit

--- a/test/dune
+++ b/test/dune
@@ -1335,6 +1335,8 @@
 
 (include stanzas/test_otel_runtime_observables.inc)
 
+(include stanzas/test_otel_port_ssot.inc)
+
 (include stanzas/test_otel_zero_fill.inc)
 
 (include stanzas/test_workspace_bootstrap.inc)

--- a/test/stanzas/test_otel_port_ssot.inc
+++ b/test/stanzas/test_otel_port_ssot.inc
@@ -1,0 +1,8 @@
+; Per-file dune stanza for the OTLP port SSOT suite (RFC-0089).
+; Lives here per test/stanzas/README.md to avoid the conflict-runtime hotspot
+; in the legacy grouped (tests ...) stanza.
+
+(test
+ (name test_otel_port_ssot)
+ (modules test_otel_port_ssot)
+ (libraries masc.otel_spans masc.config uri alcotest))

--- a/test/test_otel_port_ssot.ml
+++ b/test/test_otel_port_ssot.ml
@@ -1,0 +1,33 @@
+(* RFC-0089 — OTLP port SSOT. [Otel_spans.probe_endpoint] resolves the OTLP
+   port via [port_of_uri], which falls back to
+   [Masc_network_defaults.otel_default_port] instead of inlining 4318 (which
+   would silently diverge if the configured default were tuned). *)
+
+open Alcotest
+
+let test_explicit_port_wins () =
+  check int "explicit URI port is preserved" 9999
+    (Otel_spans.port_of_uri (Uri.of_string "http://collector:9999/v1/traces"))
+
+let test_missing_port_falls_back_to_ssot () =
+  check int "URI without a port resolves to the OTLP default SSOT"
+    Masc_network_defaults.otel_default_port
+    (Otel_spans.port_of_uri (Uri.of_string "http://collector/v1/traces"))
+
+let test_ssot_default_value_pinned () =
+  (* 4318 is the OTLP/HTTP default port. Pinning it here guards the single
+     source of truth so a drive-by edit to the constant is caught. *)
+  check int "otel_default_port is the OTLP/HTTP default" 4318
+    Masc_network_defaults.otel_default_port
+
+let () =
+  run "otel_port_ssot"
+    [
+      ( "ssot",
+        [
+          test_case "explicit port wins" `Quick test_explicit_port_wins;
+          test_case "missing port falls back to SSOT" `Quick
+            test_missing_port_falls_back_to_ssot;
+          test_case "default value pinned" `Quick test_ssot_default_value_pinned;
+        ] );
+    ]


### PR DESCRIPTION
## 목적
OTLP reachability probe의 포트 기본값을 단일 SSOT(`Masc_network_defaults.otel_default_port`) 경유로 통합합니다 (RFC-0089, scattered-hardcoding hunt 발견).

## 배경
endpoint 기본값은 이미 `otel_config.ml`이 `otel_default_url` SSOT를 사용합니다. 그러나 `otel_spans.probe_endpoint`는 endpoint URI에 포트가 없을 때 `~default:4318`로 인라인 리터럴을 써서 `otel_default_port`(=4318)를 중복했습니다. SSOT를 조정하면 이 probe만 옛 포트로 fallback하는 silent drift.

## 변경
- `Otel_spans.port_of_uri : Uri.t -> int` 순수 helper 추가 — 포트 없는 URI는 `Masc_network_defaults.otel_default_port`로 fallback.
- `probe_endpoint`를 이 helper 경유로 전환 (인라인 `4318` 제거).
- `.mli`에 노출 (네트워크 I/O 없이 단언 가능). wire 동작 불변(`otel_default_port`=4318).
- 신규 test 3 케이스(explicit port 보존 / 포트 없으면 SSOT fallback / SSOT 값 4318 pin).

## 검증
- `dune build --root . @check` exit 0.
- `test_otel_port_ssot` 3/3 통과.

RFC-WAIVED: OTLP 포트 상수 SSOT 통합 집중 리팩터. credential/operator_control/sandbox/hooks/workflow 등 RFC-게이트 표면 무관. 패턴 umbrella는 RFC-0089(String Classifier to Typed Variant — 본 건은 그 SSOT 변형).
WORKAROUND-WAIVED: 인라인 리터럴을 *제거*하고 SSOT 경유로 대체합니다(추가 아님). 게이트 시그니처는 false-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
