### PR TITLE
refactor(config): extract nickname word lists to a shared Nickname_words SSOT (RFC-0089)

### DIFF
--- a/lib/auth/auth_nickname.ml
+++ b/lib/auth/auth_nickname.ml
@@ -1,73 +1,12 @@
 (** Generated credential alias nickname helpers for Auth. *)
 
 ;;
-let nickname_adjectives =
-  [| "swift"
-   ; "brave"
-   ; "calm"
-   ; "eager"
-   ; "fierce"
-   ; "gentle"
-   ; "happy"
-   ; "jolly"
-   ; "keen"
-   ; "lucky"
-   ; "merry"
-   ; "noble"
-   ; "proud"
-   ; "quick"
-   ; "witty"
-   ; "bold"
-   ; "cool"
-   ; "deft"
-   ; "fair"
-   ; "grand"
-   ; "hale"
-   ; "jade"
-   ; "kind"
-   ; "lean"
-   ; "neat"
-   ; "pale"
-   ; "rare"
-   ; "sage"
-   ; "tame"
-   ; "warm"
-  |]
-;;
-
-let nickname_animals =
-  [| "fox"
-   ; "bear"
-   ; "wolf"
-   ; "hawk"
-   ; "lion"
-   ; "tiger"
-   ; "eagle"
-   ; "otter"
-   ; "panda"
-   ; "koala"
-   ; "raven"
-   ; "falcon"
-   ; "badger"
-   ; "beaver"
-   ; "whale"
-   ; "shark"
-   ; "crane"
-   ; "heron"
-   ; "moose"
-   ; "viper"
-   ; "cobra"
-   ; "gecko"
-   ; "lemur"
-   ; "llama"
-   ; "manta"
-   ; "orca"
-   ; "rhino"
-   ; "sloth"
-   ; "tapir"
-   ; "zebra"
-  |]
-;;
+(* Adjective/animal vocabulary comes from the shared [Nickname_words] SSOT
+   (masc.config). Auth previously inlined a copy to avoid depending on
+   [Nickname]; reading the shared lists keeps this classifier from drifting away
+   from the generator. *)
+let nickname_adjectives = Nickname_words.adjectives
+let nickname_animals = Nickname_words.animals
 
 let array_contains arr value =
   let rec loop idx =
@@ -104,16 +43,14 @@ let extract_generated_nickname_prefix name =
   | _ -> None
 ;;
 
-(* Inline copy of Nickname.is_generated_nickname / extract_agent_type.
-   Auth lives below masc_workspace in the module graph and cannot depend on
-   it. The nickname pattern — stable-prefix + adjective + animal
-   [+ hex4] — is duplicated here so auth can canonicalize generated
-   aliases without depending on Nickname. Keeper aliases use a
-   different canonical shape
-   (keeper-<name>-agent) and must resolve to the middle segment so
-   keeper-scoped credentials can be stored under the stable keeper name
-   rather than the transport alias. Covered by the nickname fallback
-   tests. *)
+(* The nickname classification logic (shape check + prefix extraction) mirrors
+   Nickname's, kept inline because auth lives below masc_workspace in the module
+   graph and cannot depend on Nickname. The adjective/animal word lists are no
+   longer duplicated — they come from the shared Nickname_words (masc.config)
+   above, so the two paths cannot drift. Keeper aliases use a different
+   canonical shape (keeper-<name>-agent) and must resolve to the middle segment
+   so keeper-scoped credentials can be stored under the stable keeper name
+   rather than the transport alias. Covered by the nickname fallback tests. *)
 let is_generated_nickname_shape name = List.length (String.split_on_char '-' name) >= 3
 
 let keeper_transport_alias_stable_name name =

--- a/lib/config/dune
+++ b/lib/config/dune
@@ -21,6 +21,7 @@
   masc_grpc_transport
   masc_network_defaults
   masc_time_constants
+  nickname_words
   playground_paths)
  (wrapped false)
  ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.

--- a/lib/config/nickname_words.ml
+++ b/lib/config/nickname_words.ml
@@ -1,0 +1,74 @@
+(** Shared adjective/animal word lists for MASC agent nicknames.
+
+    Single source of truth consumed by both the workspace-side generator
+    ([Nickname.generate]) and the auth-side classifier ([Auth_nickname]). Auth
+    sits below masc_workspace in the module graph and cannot depend on
+    [Nickname]; it previously kept an inline copy of these lists. Both paths now
+    read from here so the adjective/animal vocabulary cannot drift between the
+    generator and the classifier. *)
+
+let adjectives =
+  [| "swift"
+   ; "brave"
+   ; "calm"
+   ; "eager"
+   ; "fierce"
+   ; "gentle"
+   ; "happy"
+   ; "jolly"
+   ; "keen"
+   ; "lucky"
+   ; "merry"
+   ; "noble"
+   ; "proud"
+   ; "quick"
+   ; "witty"
+   ; "bold"
+   ; "cool"
+   ; "deft"
+   ; "fair"
+   ; "grand"
+   ; "hale"
+   ; "jade"
+   ; "kind"
+   ; "lean"
+   ; "neat"
+   ; "pale"
+   ; "rare"
+   ; "sage"
+   ; "tame"
+   ; "warm"
+  |]
+
+let animals =
+  [| "fox"
+   ; "bear"
+   ; "wolf"
+   ; "hawk"
+   ; "lion"
+   ; "tiger"
+   ; "eagle"
+   ; "otter"
+   ; "panda"
+   ; "koala"
+   ; "raven"
+   ; "falcon"
+   ; "badger"
+   ; "beaver"
+   ; "whale"
+   ; "shark"
+   ; "crane"
+   ; "heron"
+   ; "moose"
+   ; "viper"
+   ; "cobra"
+   ; "gecko"
+   ; "lemur"
+   ; "llama"
+   ; "manta"
+   ; "orca"
+   ; "rhino"
+   ; "sloth"
+   ; "tapir"
+   ; "zebra"
+  |]

--- a/lib/config/nickname_words.mli
+++ b/lib/config/nickname_words.mli
@@ -1,0 +1,7 @@
+(** Shared adjective/animal word lists for MASC agent nicknames — the single
+    source of truth for both the generator ([Nickname]) and the auth-side
+    classifier ([Auth_nickname]). Keeping one copy prevents the two paths from
+    drifting. *)
+
+val adjectives : string array
+val animals : string array

--- a/lib/workspace/nickname.ml
+++ b/lib/workspace/nickname.ml
@@ -1,24 +1,9 @@
 (** Nickname generator for MASC agents - Docker-style adjective+animal *)
 
-(* Adjectives - positive, memorable, easy to pronounce *)
-let adjectives = [|
-  "swift"; "brave"; "calm"; "eager"; "fierce";
-  "gentle"; "happy"; "jolly"; "keen"; "lucky";
-  "merry"; "noble"; "proud"; "quick"; "witty";
-  "bold"; "cool"; "deft"; "fair"; "grand";
-  "hale"; "jade"; "kind"; "lean"; "neat";
-  "pale"; "rare"; "sage"; "tame"; "warm";
-|]
-
-(* Animals - recognizable, memorable *)
-let animals = [|
-  "fox"; "bear"; "wolf"; "hawk"; "lion";
-  "tiger"; "eagle"; "otter"; "panda"; "koala";
-  "raven"; "falcon"; "badger"; "beaver"; "whale";
-  "shark"; "crane"; "heron"; "moose"; "viper";
-  "cobra"; "gecko"; "lemur"; "llama"; "manta";
-  "orca"; "rhino"; "sloth"; "tapir"; "zebra";
-|]
+(* Adjective/animal vocabulary is the shared [Nickname_words] SSOT (masc.config)
+   so the generator and the auth-side classifier cannot drift. *)
+let adjectives = Nickname_words.adjectives
+let animals = Nickname_words.animals
 
 (* RNG for nickname generation.  [Random.State.t] is NOT fiber-safe —
    the previous doc comment claiming otherwise was incorrect.  Guard

--- a/test/dune
+++ b/test/dune
@@ -1337,6 +1337,8 @@
 
 (include stanzas/test_otel_zero_fill.inc)
 
+(include stanzas/test_nickname_words_ssot.inc)
+
 (include stanzas/test_workspace_bootstrap.inc)
 
 (include stanzas/test_workspace_base_path_cache.inc)

--- a/test/stanzas/test_nickname_words_ssot.inc
+++ b/test/stanzas/test_nickname_words_ssot.inc
@@ -1,0 +1,8 @@
+; Per-file dune stanza for the nickname word-list SSOT suite (RFC-0089).
+; Lives here per test/stanzas/README.md to avoid the conflict-runtime hotspot
+; in the legacy grouped (tests ...) stanza.
+
+(test
+ (name test_nickname_words_ssot)
+ (modules test_nickname_words_ssot)
+ (libraries masc.config masc.masc_workspace masc.auth alcotest))

--- a/test/test_nickname_words_ssot.ml
+++ b/test/test_nickname_words_ssot.ml
@@ -1,0 +1,50 @@
+(* RFC-0089 — nickname word-list SSOT. The agent-nickname adjective/animal
+   vocabulary lives once in [Nickname_words] (masc.config). The workspace-side
+   generator ([Nickname]) and the auth-side classifier ([Auth_nickname]) both
+   read it, so a name the generator produces is always recognized by the auth
+   classifier — the two lists can no longer drift. *)
+
+open Alcotest
+
+let test_word_list_sizes () =
+  check int "30 adjectives" 30 (Array.length Nickname_words.adjectives);
+  check int "30 animals" 30 (Array.length Nickname_words.animals)
+
+let test_canonical_words_present () =
+  check bool "\"swift\" is an adjective" true
+    (Array.exists (String.equal "swift") Nickname_words.adjectives);
+  check bool "\"fox\" is an animal" true
+    (Array.exists (String.equal "fox") Nickname_words.animals)
+
+let test_cross_module_agreement () =
+  (* Both modules consult the same shared lists, so a dictionary-shaped name is
+     accepted by the strict generator-side check and the auth-side extractor. *)
+  check bool "Nickname strict-accepts a shared-vocabulary name" true
+    (Nickname.is_dictionary_generated_nickname "qa-swift-fox");
+  check (option string) "Auth extracts the agent prefix from the same name"
+    (Some "qa")
+    (Auth_nickname.extract_agent_type_prefix "qa-swift-fox")
+
+let test_generator_output_recognized () =
+  (* Whatever adjective/animal [generate] picks, it is from the shared list, so
+     the strict classifier always recognizes its own output. *)
+  check bool "generated nickname is recognized as dictionary-generated" true
+    (Nickname.is_dictionary_generated_nickname (Nickname.generate "qa"))
+
+let test_non_dictionary_rejected () =
+  check bool "non-dictionary adjective is rejected (the list is consulted)" false
+    (Nickname.is_dictionary_generated_nickname "qa-notword-fox")
+
+let () =
+  run "nickname_words_ssot"
+    [
+      ( "ssot",
+        [
+          test_case "word-list sizes pinned" `Quick test_word_list_sizes;
+          test_case "canonical words present" `Quick test_canonical_words_present;
+          test_case "cross-module agreement" `Quick test_cross_module_agreement;
+          test_case "generator output recognized" `Quick
+            test_generator_output_recognized;
+          test_case "non-dictionary rejected" `Quick test_non_dictionary_rejected;
+        ] );
+    ]


### PR DESCRIPTION
## 목적
agent nickname의 adjective/animal word list(각 30단어)를 단일 SSOT(`Nickname_words`, masc.config)로 통합합니다 (RFC-0089, scattered-hardcoding hunt 발견).

## 배경
같은 60단어가 두 곳에 정의돼 있었습니다:
- `Nickname`(masc.masc_workspace) — 생성기.
- `Auth_nickname`(masc.auth) — credential-alias 분류기. 무거운 workspace lib 의존을 피하려 word list를 **의도적으로 inline 복사**(주석으로 문서화됨).

두 리스트는 현재 동일하나(라이브 버그 없음), 한쪽 수정이 전파되지 않는 **잠재 drift**가 있었습니다 — 생성기에 단어를 추가해도 auth 분류기는 인식 못 함.

## 변경 (의존성 역전)
- `auth`·`workspace`가 둘 다 이미 의존하는 `masc.config`에 `Nickname_words` 모듈 신설 — adjectives/animals 단일 출처(사이클 없음).
- 두 소비자는 alias(`let adjectives = Nickname_words.adjectives`)로 전환 → downstream 사용처·분류 로직 무수정(cascade 없음).
- auth의 inline-copy 제거 + 주석 정정. 분류/shape 로직은 그대로 inline 유지(auth는 여전히 `Nickname` 의존 불가). **데이터만 단일화, 동작 불변.**
- 신규 test 5(리스트 크기 pin / canonical 단어 존재 / cross-module 일치: 생성기 출력을 auth 분류기가 인식 / 비-사전 단어 거부).

## 검증
- `dune build --root . @check` exit 0.
- `test_nickname_words_ssot` 5/5 통과.

RFC-WAIVED: word list 상수(adjective/animal 단어)의 중복 제거 리팩터로, credential/identity/auth **동작**을 바꾸지 않음 — 분류 로직은 byte-identical, 데이터 출처만 단일화. RFC-게이트 표면(credential 발급/identity 결정) 무관. 패턴 umbrella는 RFC-0089(String Classifier to Typed Variant — 본 건은 그 dedup/SSOT 변형).
WORKAROUND-WAIVED: inline-copy 중복을 *제거*하고 공유 모듈로 대체합니다(추가 아님, drift 위험 영구 제거). 게이트 시그니처는 false-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
