### PR TITLE
pre_compact: publish keeper snapshot to Masc_event_bus after SSE broadcast

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -306,6 +306,14 @@ let compact_if_needed_typed
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->
           Log.Harness.warn "[pre_compact] sse broadcast failed: %s" (Printexc.to_string exn)));
+    (match pre_compact_event with
+     | None -> ()
+     | Some _ ->
+       Keeper_event_publisher.publish_keeper_snapshot
+         ~keeper_name:meta.name
+         ~generation:meta.runtime.generation
+         ~context_ratio:ratio
+         ~message_count:msg_count);
     let messages, pair_repair_stats =
       let msgs_after_compact =
         (* Issue #8597 #1: dropped [~system_prompt] arg — compact


### PR DESCRIPTION
## Summary

Adds `Keeper_event_publisher.publish_keeper_snapshot` call after `Sse.broadcast` in `record_pre_compact_callback` to ensure compaction events are published to the MASC-owned Event_bus.

## Context

- Part of OAS boundary compliance (#4955, #8597)
- MASC domain events must route through `Masc_event_bus`, not onto OAS's shared bus
- Follows the same pattern as `keeper_heartbeat_snapshot.ml` (line 468)

## Changes

`lib/keeper/keeper_compact_policy.ml`:
- Added `Keeper_event_publisher.publish_keeper_snapshot` call after SSE broadcast completes (or fails)
- Uses `meta.name`, `meta.runtime.generation`, `ratio`, `msg_count` — all in scope

## Testing

- Compiles against existing `Keeper_event_publisher` interface
- Same pattern validated in `keeper_heartbeat_snapshot.ml`
- `match pre_compact_event with | None -> ()` handles the optional case safely