### PR TITLE
fix(dashboard): reconcile keeper chat stream failures

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -254,6 +254,29 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     ])
   })
 
+  it('reconciles a stream network failure when the server history has the completed reply', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-15T13:08:38Z'))
+    try {
+      streamKeeperMessage.mockRejectedValue(new TypeError('network error'))
+      fetchKeeperChatHistory.mockResolvedValue([
+        { role: 'user', content: '진행 상황?', ts: 1_781_528_918 },
+        { role: 'assistant', content: '서버에는 답변이 저장됐습니다.', ts: 1_781_528_920 },
+      ])
+
+      await sendKeeperThreadMessage('echo', '진행 상황?')
+
+      const thread = keeperThreads.value.echo ?? []
+      expect(thread.map(entry => [entry.role, entry.text, entry.delivery])).toEqual([
+        ['user', '진행 상황?', 'history'],
+        ['assistant', '서버에는 답변이 저장됐습니다.', 'history'],
+      ])
+      expect(keeperActionErrors.value.echo).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('resumes a pending request from storage and finalizes the transcript', async () => {
     upsertPendingKeeperChatRequest({
       requestId: 'kmsg_echo_1',

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -15,6 +15,7 @@ import { isAbortError } from './lib/async-state'
 import type {
   KeeperConversationAttachment,
   KeeperConversationDelivery,
+  KeeperConversationEntry,
   KeeperDiagnostic,
   KeeperStatusDetail,
 } from './types'
@@ -180,9 +181,68 @@ const CHAT_APPENDED_REFRESH_DELAY_MS = 400
 const PENDING_KEEPER_CHAT_POLL_MS = 2_000
 const QUEUED_KEEPER_REQUEST_LOST_MESSAGE =
   '서버 재시작으로 대기 중이던 요청을 찾을 수 없습니다. 메시지를 다시 보내주세요.'
+const STREAM_FAILURE_HISTORY_SKEW_MS = 30_000
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function entryTimeMs(entry: KeeperConversationEntry): number | null {
+  if (!entry.timestamp) return null
+  const ms = Date.parse(entry.timestamp)
+  return Number.isFinite(ms) ? ms : null
+}
+
+function hasServerAssistantAfterLocalMessage(
+  entries: readonly KeeperConversationEntry[],
+  message: string,
+  sentAtMs: number | null,
+): boolean {
+  const expectedText = message.trim()
+  if (!expectedText) return false
+  let matchedUser = false
+
+  for (const entry of entries) {
+    const tsMs = entryTimeMs(entry)
+    if (
+      sentAtMs !== null
+      && tsMs !== null
+      && tsMs < sentAtMs - STREAM_FAILURE_HISTORY_SKEW_MS
+    ) {
+      continue
+    }
+
+    if (entry.role === 'user' && entry.text.trim() === expectedText) {
+      matchedUser = true
+      continue
+    }
+
+    if (matchedUser && entry.role === 'assistant' && entry.text.trim() !== '') {
+      return true
+    }
+  }
+
+  return false
+}
+
+async function reconcileStreamFailureFromServerHistory(
+  keeperName: string,
+  message: string,
+  localUserId: string,
+  localAssistantId: string,
+): Promise<boolean> {
+  const localUser = (keeperThreads.value[keeperName] ?? [])
+    .find(entry => entry.id === localUserId) ?? null
+  const sentAtMs = localUser ? entryTimeMs(localUser) : null
+  const history = await fetchKeeperChatHistory(keeperName)
+  const historyEntries = chatHistoryEntriesFromRest(keeperName, history)
+  if (!hasServerAssistantAfterLocalMessage(historyEntries, message, sentAtMs)) {
+    return false
+  }
+
+  mergeServerHistoryEntries(keeperName, historyEntries)
+  removeThreadEntries(keeperName, [localUserId, localAssistantId])
+  return true
 }
 
 function pendingUserEntryId(requestId: string): string {
@@ -536,6 +596,23 @@ export async function sendKeeperThreadMessage(
       error: errorMessage,
     })
     if (requestTerminalSeen && requestId) removePendingKeeperChatRequest(requestId)
+    try {
+      const reconciled = await reconcileStreamFailureFromServerHistory(
+        keeperName,
+        message,
+        localId,
+        assistantId,
+      )
+      if (reconciled) {
+        setRecordValue(keeperActionErrors, keeperName, null)
+        return
+      }
+    } catch (reconcileErr) {
+      console.warn(
+        `[keeper] stream failure history reconciliation failed for ${keeperName}`,
+        reconcileErr instanceof Error ? reconcileErr.message : reconcileErr,
+      )
+    }
     setRecordValue(keeperActionErrors, keeperName, errorMessage)
     throw err
   } finally {

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -9,6 +9,7 @@ import {
   keeperThreads,
   mergeServerHistoryEntries,
   normalizeStatusDetail,
+  removeThreadEntries,
   setStatusDetail,
 } from './keeper-state'
 import type { KeeperConversationEntry } from './types'
@@ -221,6 +222,17 @@ describe('thread history merge & persistence', () => {
 
     const ids = (keeperThreads.value.echo ?? []).map(e => e.id)
     expect(ids).toEqual(['tool-1', 'reply-1', 'tail-1'])
+  })
+
+  it('removes only the requested local thread entries', () => {
+    appendThreadEntry('echo', entry({ id: 'user-1', role: 'user', text: 'question' }))
+    appendThreadEntry('echo', entry({ id: 'reply-1', role: 'assistant', text: '' }))
+    appendThreadEntry('echo', entry({ id: 'reply-2', role: 'assistant', text: 'answer' }))
+
+    removeThreadEntries('echo', ['reply-1', 'missing'])
+
+    const ids = (keeperThreads.value.echo ?? []).map(e => e.id)
+    expect(ids).toEqual(['user-1', 'reply-2'])
   })
 
   it('caps the thread window at THREAD_ENTRY_CAP', () => {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -358,6 +358,18 @@ export function finalizeAssistantEntry(
   }))
 }
 
+export function removeThreadEntries(name: string, entryIds: readonly string[]): void {
+  if (entryIds.length === 0) return
+  const ids = new Set(entryIds)
+  const existing = keeperThreads.value[name] ?? []
+  const next = existing.filter(entry => !ids.has(entry.id))
+  if (next.length === existing.length) return
+  keeperThreads.value = {
+    ...keeperThreads.value,
+    [name]: next,
+  }
+}
+
 // Dedup key for merging server history with locally-appended entries.
 // Compares role + text only: the server stamps a message pair with its
 // completion time while the local entry carries the send time, so

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -358,18 +358,6 @@ export function finalizeAssistantEntry(
   }))
 }
 
-export function removeThreadEntries(name: string, entryIds: readonly string[]): void {
-  if (entryIds.length === 0) return
-  const ids = new Set(entryIds)
-  const existing = keeperThreads.value[name] ?? []
-  const next = existing.filter(entry => !ids.has(entry.id))
-  if (next.length === existing.length) return
-  keeperThreads.value = {
-    ...keeperThreads.value,
-    [name]: next,
-  }
-}
-
 // Dedup key for merging server history with locally-appended entries.
 // Compares role + text only: the server stamps a message pair with its
 // completion time while the local entry carries the send time, so


### PR DESCRIPTION
## Summary

- Reconcile keeper direct-chat stream failures by refetching server chat history after a non-abort stream error.
- If the server history already contains the sent user message followed by an assistant reply, merge that history and remove the temporary local `(empty reply)` error card.
- Avoid automatic POST retry so transient Cloudflare/browser failures cannot duplicate a keeper instruction.

## Verification

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/keeper-actions.test.ts src/keeper-state.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard typecheck`
- `pnpm exec eslint src/keeper-actions.ts src/keeper-actions.test.ts src/keeper-state.ts src/keeper-state.test.ts` from `dashboard/`
- `git diff --check`

Note: targeted eslint exits 0; existing config ignores `keeper-state.ts` and `keeper-state.test.ts` with warnings.
