### PR TITLE
fix(dashboard): resume keeper chat after stream cut

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -280,6 +280,41 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
   })
 
+  it('marks a recovered orphan request as lost instead of polling forever', async () => {
+    upsertPendingKeeperChatRequest({
+      requestId: 'kmsg_echo_1',
+      keeperName: 'echo',
+      message: '어디까지 했어?',
+      submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
+    })
+    fetchQueuedKeeperMessageResult.mockResolvedValue({
+      requestId: 'kmsg_echo_1',
+      keeperName: 'echo',
+      status: 'lost',
+      result: {
+        reason: 'keeper_msg request was accepted but no live worker owns it',
+      },
+    })
+    queuedKeeperMessageError.mockImplementation((result: { status: string; result?: { reason?: string } }) => (
+      result.result?.reason ?? 'request lost'
+    ))
+    queuedKeeperMessageToReply.mockImplementation((result: { result?: { reply?: string; reason?: string } }) => ({
+      text: result.result?.reason ?? '(empty reply)',
+      details: null,
+    }))
+    fetchKeeperChatHistory.mockResolvedValue([])
+
+    await resumePendingKeeperChatRequests('echo')
+
+    expect(fetchQueuedKeeperMessageResult).toHaveBeenCalledWith('kmsg_echo_1')
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread.map(entry => [entry.role, entry.text, entry.delivery, entry.error])).toEqual([
+      ['user', '어디까지 했어?', 'error', 'keeper_msg request was accepted but no live worker owns it'],
+      ['assistant', 'keeper_msg request was accepted but no live worker owns it', 'error', 'keeper_msg request was accepted but no live worker owns it'],
+    ])
+  })
+
   it('keeps the user message visible when the server no longer knows request_id', async () => {
     upsertPendingKeeperChatRequest({
       requestId: 'kmsg_echo_1',

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -226,7 +226,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(invalidateDashboardCache).not.toHaveBeenCalled()
   })
 
-  it('keeps a queued request resumable when the stream cuts before terminal', async () => {
+  it('polls a queued request immediately when the stream cuts before terminal', async () => {
     streamKeeperMessage.mockImplementation(emitting([
       {
         type: 'CUSTOM',
@@ -234,11 +234,23 @@ describe('sendKeeperThreadMessage stream outcome', () => {
         value: { request_id: 'kmsg_echo_1', status: 'queued' },
       },
     ], false))
+    fetchQueuedKeeperMessageResult.mockResolvedValue({
+      requestId: 'kmsg_echo_1',
+      keeperName: 'echo',
+      status: 'done',
+      ok: true,
+      result: { reply: 'polling으로 복구됨' },
+    })
+    fetchKeeperChatHistory.mockResolvedValue([])
 
     await sendKeeperThreadMessage('echo', '진행 상황?')
 
-    expect(pendingKeeperChatRequestsForKeeper('echo')).toMatchObject([
-      { requestId: 'kmsg_echo_1', keeperName: 'echo', message: '진행 상황?' },
+    expect(fetchQueuedKeeperMessageResult).toHaveBeenCalledWith('kmsg_echo_1')
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread.map(entry => [entry.role, entry.text, entry.delivery])).toEqual([
+      ['user', '진행 상황?', 'delivered'],
+      ['assistant', 'polling으로 복구됨', 'delivered'],
     ])
   })
 
@@ -268,7 +280,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
   })
 
-  it('drops a stale pending request when the server no longer knows request_id', async () => {
+  it('keeps the user message visible when the server no longer knows request_id', async () => {
     upsertPendingKeeperChatRequest({
       requestId: 'kmsg_echo_1',
       keeperName: 'echo',
@@ -285,8 +297,12 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     await resumePendingKeeperChatRequests('echo')
 
     expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
-    expect(keeperThreads.value.echo).toEqual([])
-    expect(keeperActionErrors.value.echo).toBeNull()
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread.map(entry => [entry.role, entry.text, entry.delivery])).toEqual([
+      ['user', '어디까지 했어?', 'error'],
+      ['assistant', '', 'error'],
+    ])
+    expect(keeperActionErrors.value.echo).toContain('서버 재시작')
     expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1)
   })
 })

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -178,6 +178,8 @@ export async function hydrateKeeperChatHistory(
 const chatRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
 const CHAT_APPENDED_REFRESH_DELAY_MS = 400
 const PENDING_KEEPER_CHAT_POLL_MS = 2_000
+const QUEUED_KEEPER_REQUEST_LOST_MESSAGE =
+  '서버 재시작으로 대기 중이던 요청을 찾을 수 없습니다. 메시지를 다시 보내주세요.'
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -290,10 +292,19 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
   } catch (err) {
     if (isMissingQueuedKeeperRequestError(err)) {
       removePendingKeeperChatRequest(request.requestId)
-      removeThreadEntries(request.keeperName, [
-        pendingUserEntryId(request.requestId),
-        assistantId,
-      ])
+      finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
+        delivery: 'error',
+        error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
+      })
+      finalizeAssistantEntry(request.keeperName, assistantId, {
+        text: '',
+        rawText: '',
+        delivery: 'error',
+        streamState: null,
+        timestamp: new Date().toISOString(),
+        error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
+      })
+      setRecordValue(keeperActionErrors, request.keeperName, QUEUED_KEEPER_REQUEST_LOST_MESSAGE)
       await hydrateKeeperChatHistory(request.keeperName, { force: true })
       return
     }
@@ -453,6 +464,17 @@ export async function sendKeeperThreadMessage(
     const finalText = finalEntry?.text.trim() ?? ''
 
     if (!outcome.terminal) {
+      if (requestId) {
+        removeThreadEntries(keeperName, [localId, assistantId])
+        await resumePendingKeeperChatRequest({
+          requestId,
+          keeperName,
+          message,
+          submittedAt: Date.now(),
+          ...(attachments ? { attachments } : {}),
+        })
+        return
+      }
       // The SSE connection closed without RUN_FINISHED / RUN_ERROR —
       // keep the partial text but mark the entry so the operator can
       // tell a cut stream from a completed reply.


### PR DESCRIPTION
## Summary
- poll queued keeper chat requests immediately when the SSE stream cuts after KEEPER_QUEUE_REQUEST
- preserve the user's sent message and show a retry-needed error when a queued request is lost after server restart
- update keeper action tests for the recovered and lost-request paths

## Verification
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/keeper-actions.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard exec eslint src/keeper-actions.ts src/keeper-actions.test.ts