### PR TITLE
[codex] fix dashboard websocket discovery

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -240,8 +240,10 @@ let is_websocket_upgrade_request request =
   header_contains_token headers "connection" "upgrade"
   && header_equals_token headers "upgrade" "websocket"
 
-let respond_ws_upgrade_unavailable reqd =
-  let body = {|{"error":"websocket transport disabled"}|} in
+let respond_ws_upgrade_unavailable ?(message = "websocket transport disabled") reqd =
+  let body =
+    Yojson.Safe.to_string (`Assoc [ ("error", `String message) ])
+  in
   let headers =
     Httpun.Headers.of_list
       [ ("content-type", "application/json")
@@ -255,27 +257,9 @@ let handle_websocket_upgrade reqd =
   if not (Transport_metrics.ws_enabled ())
   then respond_ws_upgrade_unavailable reqd
   else
-    let state = current_server_state_opt () in
-    match
-      Server_mcp_transport_ws.upgrade_connection
-        ?sw:(state_switch_opt state)
-        ?clock:(state_clock_opt state)
-        reqd
-    with
-    | Ok () -> ()
-    | Error msg ->
-      let body =
-        Yojson.Safe.to_string
-          (`Assoc [ ("error", `String ("websocket upgrade failed: " ^ msg)) ])
-      in
-      let headers =
-        Httpun.Headers.of_list
-          [ ("content-type", "application/json")
-          ; ("content-length", string_of_int (String.length body))
-          ]
-      in
-      let response = Httpun.Response.create ~headers `Bad_request in
-      safe_reqd_respond reqd response body
+    respond_ws_upgrade_unavailable
+      ~message:"same-origin websocket upgrade is disabled; use /ws discovery ws_url"
+      reqd
 
 (** Method/path dispatcher for MCP-validated requests. Caller is
     responsible for rate limiting and origin/protocol-version checks

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -184,9 +184,9 @@ let websocket_discovery_json (ctx : http_context) =
     @ [ "listening", `Bool listening
       ; "reachable", `Bool reachable
       ; "listen_status", `String (Atomic.get Transport_metrics.ws_listen_status)
-      ; "mode", `String "same_origin_upgrade"
+      ; "mode", `String "standalone"
       ; "discovery_path", `String "/ws"
-      ; "upgrade_path", `String "/ws"
+      ; "upgrade_path", `String "/"
       ; "standalone_listening", `Bool standalone_listening
       ; "session_count", `Int (get_ws_session_count ())
       ]
@@ -196,9 +196,11 @@ let websocket_discovery_json (ctx : http_context) =
     then
       base_fields
       @ [ "ws_port", `Int port
-        ; "ws_url", `String (websocket_url_from_base_url ctx.base_url)
+        ; "ws_url", `String standalone_ws_url
         ; "standalone_ws_port", `Int port
         ; "standalone_ws_url", `String standalone_ws_url
+        ; "same_origin_upgrade_path", `String "/ws"
+        ; "same_origin_ws_url", `String (websocket_url_from_base_url ctx.base_url)
         ]
     else base_fields
   in

--- a/test/test_transport_read_model.ml
+++ b/test/test_transport_read_model.ml
@@ -120,18 +120,18 @@ let test_transport_status_reports_streamable_http_protocol () =
   check bool "enabled_protocols includes canonical json-rpc path" true
     (List.mem "json-rpc" enabled_protocols)
 
-let test_websocket_discovery_uses_same_origin_upgrade_url () =
+let test_websocket_discovery_uses_standalone_url () =
   let json = TRM.websocket_discovery_json (make_context ()) in
-  check string "mode" "same_origin_upgrade"
+  check string "mode" "standalone"
     Yojson.Safe.Util.(json |> member "mode" |> to_string);
-  check string "upgrade path" "/ws"
+  check string "upgrade path" "/"
     Yojson.Safe.Util.(json |> member "upgrade_path" |> to_string);
-  check string "ws_url uses http listener" "ws://127.0.0.1:8935/ws"
+  check string "ws_url uses standalone listener" "ws://127.0.0.1:8937/"
     Yojson.Safe.Util.(json |> member "ws_url" |> to_string);
-  check string "standalone retained for diagnostics" "ws://127.0.0.1:8937/"
-    Yojson.Safe.Util.(json |> member "standalone_ws_url" |> to_string)
+  check string "same-origin retained for diagnostics" "ws://127.0.0.1:8935/ws"
+    Yojson.Safe.Util.(json |> member "same_origin_ws_url" |> to_string)
 
-let test_websocket_discovery_uses_wss_for_https_base_url () =
+let test_websocket_discovery_retains_same_origin_wss_diagnostic () =
   let ctx =
     TRM.make_http_context
       ~base_url:"https://example.com/root/"
@@ -140,7 +140,7 @@ let test_websocket_discovery_uses_wss_for_https_base_url () =
   in
   let json = TRM.websocket_discovery_json ctx in
   check string "wss preserves base path" "wss://example.com/root/ws"
-    Yojson.Safe.Util.(json |> member "ws_url" |> to_string)
+    Yojson.Safe.Util.(json |> member "same_origin_ws_url" |> to_string)
 
 let test_advertised_base_url_uses_forwarded_proto_without_internal_port () =
   let headers =
@@ -196,10 +196,10 @@ let () =
              test_transport_status_http_shape_extends_tool_shape;
            test_case "transport status includes json-rpc protocol" `Quick
              test_transport_status_reports_streamable_http_protocol;
-           test_case "websocket same-origin URL" `Quick
-             test_websocket_discovery_uses_same_origin_upgrade_url;
-           test_case "websocket HTTPS URL" `Quick
-             test_websocket_discovery_uses_wss_for_https_base_url;
+           test_case "websocket standalone URL" `Quick
+             test_websocket_discovery_uses_standalone_url;
+           test_case "websocket HTTPS diagnostic URL" `Quick
+             test_websocket_discovery_retains_same_origin_wss_diagnostic;
            test_case "forwarded base URL" `Quick
              test_advertised_base_url_uses_forwarded_proto_without_internal_port;
          ] );


### PR DESCRIPTION
## Summary

- route dashboard WebSocket discovery back to the standalone WS listener as the primary `ws_url`
- keep same-origin WS URL as a diagnostic field instead of the advertised client target
- make same-origin `/ws` upgrade fail fast with a JSON 503 so stale browser caches can reconnect through discovery instead of hanging

## Root Cause

The dashboard was discovering `ws://<http-host>/ws` as the primary WebSocket URL, but that same-origin upgrade path accepts the connection without producing a `dashboard/hello` response. The browser then stays open until the dashboard RPC timeout/reconnect loop marks `Client WS` disconnected. The standalone WS listener responds correctly to the same `dashboard/hello` payload.

## Validation

- `scripts/dune-local.sh build bin/main_eio.exe test/test_transport_read_model.exe`
- `./_build/default/test/test_transport_read_model.exe`
- isolated runtime on `127.0.0.1:18935` with `MASC_KEEPER_BOOTSTRAP_ENABLED=0 MASC_GRPC_ENABLED=0 MASC_WEBRTC_ENABLED=0 MASC_WS_PORT=18937`
- `/ws` discovery returned `mode=standalone`, `ws_url=ws://127.0.0.1:18937/`
- Playwright browser WS probe sent `dashboard/hello` and received JSON-RPC result over `ws://127.0.0.1:18937/`
- cached same-origin upgrade probe returned HTTP 503 with `same-origin websocket upgrade is disabled; use /ws discovery ws_url`