### PR TITLE
feat(dashboard): surface keeper error states and slim the chat header

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -13,26 +13,10 @@ import {
   WorkspaceSigil,
   StatusDot,
   keeperBucket,
-  bucketDotTone,
+  keeperStatusTone,
   keeperPhaseLabel,
   statePillTone,
-  keeperModelLabel,
-  keeperRuntimeLabel,
 } from './keeper-workspace-shared'
-
-/** Latest per-turn throughput from the metrics series (no scalar field). */
-function latestTps(keeper: Keeper): number | null {
-  const series = keeper.metrics_series ?? []
-  for (let i = series.length - 1; i >= 0; i -= 1) {
-    const v = series[i]?.wall_tokens_per_second
-    if (typeof v === 'number' && v > 0) return Math.round(v)
-  }
-  return null
-}
-
-function keeperScope(keeper: Keeper): string | null {
-  return keeper.skill_primary ?? null
-}
 
 function ChatHeader({
   keeper,
@@ -46,31 +30,23 @@ function ChatHeader({
   onClear: () => void
 }): VNode {
   const bucket = keeperBucket(keeper)
-  const tone = bucketDotTone(bucket)
-  const pill = statePillTone(bucket)
-  const model = keeperModelLabel(keeper)
-  const runtime = keeperRuntimeLabel(keeper)
-  const scope = keeperScope(keeper)
-  const tps = latestTps(keeper)
+  const tone = keeperStatusTone(keeper)
+  const pill = statePillTone(tone)
   const live = bucket === 'running'
 
+  // Single-row header: identity + status + actions only. Runtime / model /
+  // throughput / scope live in the context rail (ThroughputSection) — the
+  // canonical home — so the header stays slim and the conversation gets the
+  // vertical space instead of a redundant metadata sub-row.
   return html`
     <div class="kw-chat-head">
-      <${WorkspaceSigil} id=${keeper.name} size=${46} beat=${live} />
+      <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${live} />
       <div class="kw-chat-id">
         <div class="kw-chat-name-row">
           <h2 class="kw-chat-name">${keeper.koreanName ?? keeper.name}</h2>
           <span class=${`kw-state-pill ${pill}`} title=${keeperDisplayStatus(keeper)}>
             <${StatusDot} tone=${tone} pulse=${live} />${keeperPhaseLabel(keeper)}
           </span>
-        </div>
-        <div class="kw-chat-sub">
-          ${scope ? html`<span><span class="k">scope</span><span class="mono">${scope}</span></span>` : null}
-          ${model ? html`<span><span class="k">모델</span><span class="mono">${model}</span></span>` : null}
-          ${runtime ? html`<span><span class="k">런타임</span><span class="mono">${runtime}</span></span>` : null}
-          ${live && tps !== null
-            ? html`<span class="kw-tps-live"><span class="kw-tps-dot"></span><span class="k">tok/s</span><span class="mono">${tps}</span></span>`
-            : null}
         </div>
       </div>
       <div class="kw-chat-actions">

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -107,6 +107,9 @@ function ContextSection({ keeper }: { keeper: Keeper }): VNode {
 function ThroughputSection({ keeper }: { keeper: Keeper }): VNode {
   const model = keeperModelLabel(keeper)
   const runtime = keeperRuntimeLabel(keeper)
+  // scope (skill_primary) used to live in the chat header sub-row; folded here
+  // so the slim single-row header loses no information.
+  const scope = keeper.skill_primary ?? null
   const series = tpsSeries(keeper)
   const peak = Math.max(1, ...series)
   const latest = series.length ? series[series.length - 1] : 0
@@ -116,6 +119,7 @@ function ThroughputSection({ keeper }: { keeper: Keeper }): VNode {
       <div class="kw-vitals">
         <div class="kw-vital"><div class="vk">모델</div><div class="vv" title=${model ?? ''}>${model ?? '—'}</div></div>
         <div class="kw-vital"><div class="vk">런타임</div><div class="vv" title=${runtime ?? ''}>${runtime ?? '—'}</div></div>
+        ${scope ? html`<div class="kw-vital" style=${{ gridColumn: '1 / -1' }}><div class="vk">scope</div><div class="vv" title=${scope}>${scope}</div></div>` : null}
       </div>
       ${series.length >= 2
         ? html`<div class="kw-card mt-2">

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -16,7 +16,7 @@ import {
   WorkspaceSigil,
   StatusDot,
   keeperBucket,
-  bucketDotTone,
+  keeperStatusTone,
   keeperPhaseLabel,
   type KeeperBucket,
 } from './keeper-workspace-shared'
@@ -63,7 +63,7 @@ function matchesQuery(keeper: Keeper, q: string): boolean {
 
 function RosterRow({ keeper, active, onSelect }: { keeper: Keeper; active: boolean; onSelect: (name: string) => void }) {
   const bucket = keeperBucket(keeper)
-  const tone = bucketDotTone(bucket)
+  const tone = keeperStatusTone(keeper)
   const att = attentionCount(keeper)
   const scope = keeperScope(keeper)
   const activity = keeperActivityDisplay(keeper)

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
@@ -2,7 +2,7 @@ import { render } from 'preact'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   keeperBucket,
-  bucketDotTone,
+  keeperStatusTone,
   statePillTone,
   keeperModelLabel,
   keeperRuntimeLabel,
@@ -28,16 +28,36 @@ describe('keeperBucket', () => {
   })
 })
 
-describe('bucketDotTone / statePillTone', () => {
-  it('maps buckets to dot tones', () => {
-    expect(bucketDotTone('running')).toBe('ok')
-    expect(bucketDotTone('paused')).toBe('warn')
-    expect(bucketDotTone('offline')).toBe('idle')
+describe('keeperStatusTone', () => {
+  it('maps a running keeper to ok', () => {
+    expect(keeperStatusTone(mk({ status: 'running' }))).toBe('ok')
   })
-  it('maps buckets to pill tones', () => {
-    expect(statePillTone('running')).toBe('run')
-    expect(statePillTone('paused')).toBe('warn')
-    expect(statePillTone('offline')).toBe('off')
+  it('surfaces error phases as bad (not a healthy green dot)', () => {
+    // Failing/Overflowed are neither offline nor paused, so keeperBucket
+    // classifies them as "running"; the tone must still flag them.
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Failing' }))).toBe('bad')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Overflowed' }))).toBe('bad')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Crashed' }))).toBe('bad')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Dead' }))).toBe('bad')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Zombie' }))).toBe('bad')
+  })
+  it('maps transient / attention phases to warn', () => {
+    expect(keeperStatusTone(mk({ status: 'running', paused: true }))).toBe('warn')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Compacting' }))).toBe('warn')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'HandingOff' }))).toBe('warn')
+  })
+  it('maps stopped / unbooted to idle', () => {
+    expect(keeperStatusTone(mk({ status: 'stopped' }))).toBe('idle')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Offline' }))).toBe('idle')
+  })
+})
+
+describe('statePillTone', () => {
+  it('maps health tones to pill modifier classes', () => {
+    expect(statePillTone('ok')).toBe('run')
+    expect(statePillTone('warn')).toBe('warn')
+    expect(statePillTone('bad')).toBe('bad')
+    expect(statePillTone('idle')).toBe('off')
   })
 })
 
@@ -59,9 +79,15 @@ describe('keeperRuntimeLabel', () => {
 })
 
 describe('keeperPhaseLabel', () => {
-  it('prefers the typed lifecycle phase', () => {
-    expect(keeperPhaseLabel(mk({ lifecycle_phase: 'Running' }))).toBe('Running')
-    expect(keeperPhaseLabel(mk({ phase: 'Compacting' }))).toBe('Compacting')
+  it('maps the FSM phase to a Korean label (no raw PascalCase enum leak)', () => {
+    expect(keeperPhaseLabel(mk({ lifecycle_phase: 'Running' }))).toBe('실행 중')
+    expect(keeperPhaseLabel(mk({ lifecycle_phase: 'Compacting' }))).toBe('압축 중')
+    expect(keeperPhaseLabel(mk({ lifecycle_phase: 'Failing' }))).toBe('오류 발생')
+    expect(keeperPhaseLabel(mk({ lifecycle_phase: 'HandingOff' }))).toBe('인계 중')
+  })
+  it('falls back to the status token when no friendly label exists', () => {
+    // keeperDisplayStatus returns the raw status string for unmapped tokens.
+    expect(keeperPhaseLabel(mk({ status: 'bootstrapping' }))).toBe('bootstrapping')
   })
 })
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -20,12 +20,6 @@ export function keeperBucket(keeper: Keeper): KeeperBucket {
 
 export type DotTone = 'ok' | 'warn' | 'bad' | 'idle'
 
-export function bucketDotTone(bucket: KeeperBucket): DotTone {
-  if (bucket === 'running') return 'ok'
-  if (bucket === 'paused') return 'warn'
-  return 'idle'
-}
-
 const DOT_CLASS: Record<DotTone, string> = {
   ok: 'kw-dot ok',
   warn: 'kw-dot warn',
@@ -61,16 +55,64 @@ export function WorkspaceSigil({
   return html`<span class="kw-sigil" style=${style} title=${id} aria-label=${id}>${sigil}</span>`
 }
 
-/** Phase label shown in the roster sub-row and the chat header state pill.
- *  Prefers the typed FSM phase, falls back to the display-status mapper. */
-export function keeperPhaseLabel(keeper: Keeper): string {
-  return keeper.lifecycle_phase ?? keeper.phase ?? keeperDisplayStatus(keeper)
+/** Friendly (Korean) label per canonical status token. Keyed on the tokens
+ *  keeperDisplayStatus emits (lib/keeper-runtime-display.ts keeperLifecycleStatus),
+ *  so the roster row + header pill read the same vocabulary as the rest of the
+ *  dashboard instead of the raw PascalCase FSM enum (e.g. "Compacting"). */
+const PHASE_LABEL_KO: Record<string, string> = {
+  running: '실행 중',
+  paused: '일시정지',
+  compacting: '압축 중',
+  handoff: '인계 중',
+  draining: '정리 중',
+  restarting: '재시작 중',
+  failing: '오류 발생',
+  overflowed: '컨텍스트 초과',
+  stopped: '중지됨',
+  unbooted: '미기동',
+  crashed: '비정상 종료',
+  dead: '종료됨',
+  zombie: '응답 없음',
+  unknown: '알 수 없음',
 }
 
-/** The state-pill modifier class for the chat header. */
-export function statePillTone(bucket: KeeperBucket): 'run' | 'warn' | 'off' {
-  if (bucket === 'running') return 'run'
-  if (bucket === 'paused') return 'warn'
+/** Phase label shown in the roster sub-row and the chat header state pill.
+ *  Routes through keeperDisplayStatus so error/transient phases surface with
+ *  the same token vocabulary the rest of the dashboard uses, then maps to a
+ *  Korean label. Previously returned the raw `lifecycle_phase` enum, which
+ *  leaked "Running"/"Compacting"/"HandingOff" into the UI. */
+export function keeperPhaseLabel(keeper: Keeper): string {
+  const token = keeperDisplayStatus(keeper)
+  return PHASE_LABEL_KO[token] ?? token
+}
+
+/** Error phases that must not render as a healthy green dot. */
+const ERROR_STATUS_TOKENS = new Set(['failing', 'overflowed', 'crashed', 'dead', 'zombie'])
+/** Transient / attention phases that warrant a warn (amber) dot. */
+const WARN_STATUS_TOKENS = new Set(['paused', 'compacting', 'handoff', 'draining', 'restarting'])
+
+/** Health tone for the status dot + header pill.
+ *
+ *  Distinct from keeperBucket, which only groups running/paused/offline for
+ *  the roster: a Failing or Overflowed keeper is neither offline nor paused,
+ *  so the bucket classifies it as "running" and it would render a green dot
+ *  while actually degraded. This maps the canonical status token to a tone so
+ *  error phases surface as `bad` (the .kw-dot.bad / .kw-state-pill.bad styles
+ *  that were otherwise unreachable). */
+export function keeperStatusTone(keeper: Keeper): DotTone {
+  const token = keeperDisplayStatus(keeper)
+  if (ERROR_STATUS_TOKENS.has(token)) return 'bad'
+  if (WARN_STATUS_TOKENS.has(token)) return 'warn'
+  if (token === 'running') return 'ok'
+  return 'idle'
+}
+
+/** The state-pill modifier class for the chat header, derived from the health
+ *  tone so error phases get the `bad` pill rather than collapsing to `off`. */
+export function statePillTone(tone: DotTone): 'run' | 'warn' | 'bad' | 'off' {
+  if (tone === 'ok') return 'run'
+  if (tone === 'warn') return 'warn'
+  if (tone === 'bad') return 'bad'
   return 'off'
 }
 

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -139,19 +139,18 @@
 /* ════ CONVERSATION (center) ════════════════════════════════════ */
 .kw-chat { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--color-bg-page); }
 
+/* Single-row header (identity + status + actions). Slimmer than the old
+ * two-row variant — the runtime/model/throughput sub-row moved to the rail —
+ * so the conversation below gets the reclaimed vertical space. */
 .kw-chat-head {
-  flex: none; padding: 18px 28px 16px;
+  flex: none; padding: 12px 28px;
   border-bottom: 1px solid var(--color-border-default);
   background: linear-gradient(180deg, var(--color-bg-panel-alt), var(--color-bg-page));
-  display: flex; align-items: center; gap: 16px;
+  display: flex; align-items: center; gap: 14px;
 }
 .kw-chat-id { min-width: 0; flex: 1; }
 .kw-chat-name-row { display: flex; align-items: center; gap: 11px; flex-wrap: wrap; }
-.kw-chat-name { font-size: 20px; font-weight: 600; letter-spacing: 0.01em; color: var(--color-fg-primary); margin: 0; white-space: nowrap; }
-.kw-chat-sub { display: flex; align-items: center; gap: 10px; margin-top: 6px; font-size: 12px; color: var(--color-fg-muted); flex-wrap: wrap; }
-.kw-chat-sub > span { white-space: nowrap; display: inline-flex; align-items: center; gap: 5px; }
-.kw-chat-sub .k { font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--color-fg-muted); }
-.kw-chat-sub .mono { font-family: var(--font-mono); color: var(--color-fg-secondary); }
+.kw-chat-name { font-size: 19px; font-weight: 600; letter-spacing: 0.01em; color: var(--color-fg-primary); margin: 0; white-space: nowrap; }
 
 .kw-state-pill {
   display: inline-flex; align-items: center; gap: 6px;
@@ -159,13 +158,9 @@
   background: var(--color-bg-surface); border: 1px solid var(--color-border-default); color: var(--color-fg-secondary);
 }
 .kw-state-pill.run { color: var(--color-status-ok); border-color: rgb(var(--color-status-ok-glow) / 0.45); background: rgb(var(--color-status-ok-glow) / 0.10); }
-.kw-state-pill.warn { color: var(--color-status-warn); border-color: rgb(var(--color-status-warn-glow) / 0.45); }
+.kw-state-pill.warn { color: var(--color-status-warn); border-color: rgb(var(--color-status-warn-glow) / 0.45); background: rgb(var(--color-status-warn-glow) / 0.10); }
+.kw-state-pill.bad { color: var(--color-status-err); border-color: rgb(var(--color-status-err-glow) / 0.50); background: rgb(var(--color-status-err-glow) / 0.12); }
 .kw-state-pill.off { color: var(--color-fg-muted); }
-
-.kw-tps-live { display: inline-flex; align-items: center; gap: 5px; color: var(--color-status-ok); }
-.kw-tps-live .mono { color: var(--color-status-ok); }
-.kw-tps-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-status-ok); box-shadow: 0 0 6px var(--color-status-ok); animation: kw-tps-pulse 1.1s ease-in-out infinite; }
-@keyframes kw-tps-pulse { 0%, 100% { opacity: 0.45; } 50% { opacity: 1; } }
 
 .kw-chat-actions { display: flex; gap: 7px; align-items: center; flex: none; }
 .kw-act {


### PR DESCRIPTION
## 요약

keeper-workspace 3-페인(#21216/#21229 후속)에 대한 사용자 피드백 3건을 반영합니다 — status 표시 오류, "직접 대화" 높이가 너무 좁음, 상단 정보 이동.

## 변경

### 1. status 정확성 (고장 키퍼가 초록으로 위장되던 문제)
`keeperBucket`은 running/paused/offline 3-bucket이라, `Failing`/`Overflowed`(offline도 paused도 아님)는 **running으로 분류돼 초록 dot/pill**로 보였습니다. `keeperStatusTone(keeper)`를 추가해 canonical status token을 ok/warn/bad/idle로 매핑 — `Failing`/`Overflowed`/`Crashed`/`Dead`/`Zombie`가 `bad`로 표시됩니다(그동안 도달 불가였던 `.kw-dot.bad` / `.kw-state-pill.bad` 스타일 활성화). roster 행 + 채팅 헤더 dot 양쪽에 적용.

### 2. status 어휘 통일 (raw enum 누출 제거)
`keeperPhaseLabel`이 raw PascalCase `lifecycle_phase`(`"Running"`/`"Compacting"`/`"HandingOff"`)를 그대로 노출하던 것을 `keeperDisplayStatus` + 한국어 라벨 맵 경유로 변경. `statePillTone`은 health tone 기반으로 바뀌어 `bad`를 포함.

### 3. 대화 높이 + 상단 정보
채팅 헤더 sub-row(scope/모델/런타임/tps)는 우측 rail의 `ThroughputSection`과 **중복**이라 제거하고, 헤더를 단일 행(정체성+status+액션)으로 슬림화(sigil 46→40, 패딩 18/16→12). 유일하게 rail에 없던 `scope`(skill_primary)는 rail 카드로 흡수 → 정보 손실 0. 대화 영역이 그만큼 세로 공간을 회수. dead `.kw-chat-sub` / `.kw-tps-*` CSS 제거.

## 검증

- vitest: keeper-workspace 30/30, keeper-detail 23/23
- tsc 0, eslint 0, vite build OK

## 미검증 (Draft 유지 사유)

픽셀/시각 미관은 로컬에서 직접 확인하지 못했습니다 — Chrome 확장 미연결 + repo에 Playwright 없음. 구조/정확성은 테스트로 검증했으나, 실제 :8935 렌더 확인 후 Ready 전환이 맞습니다.
