### PR TITLE
fix(memory-os): default consolidation fiber OFF until librarian taxonomy fix (#21241)

### DIFF
--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -81,11 +81,19 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      failures are caught so a corrupt store cannot cancel sibling fibers. The
      kill switch mirrors the recall gate ([MASC_KEEPER_MEMORY_OS_RECALL]); when
      disabled the shared store simply stops being refreshed (recall still reads
-     whatever is there). *)
+     whatever is there).
+
+     Default OFF until #21241: a read-only dry-run over the live fleet found the
+     only >=2-keeper-corroborated [fact]/[constraint] claims are ephemeral
+     lifecycle/coordination boilerplate ("checkpoint saved", "no tasks") that the
+     librarian mislabels as [category=fact]. Promoting them would inject prompt
+     noise via recall's [shared via] line, with no durable knowledge. Re-enable
+     (flip the default, or set the env true) once the librarian taxonomy emits
+     ephemeral events as a non-promotable category (#21241, RFC-0244 §2.3). *)
   if
     Keeper_memory_bank_env.memory_env_bool_logged
       "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
-      ~default:true
+      ~default:false
   then
     fork_logged_fiber
       ~sw


### PR DESCRIPTION
## 무엇

RFC-0244 Tier 2 consolidation maintenance fiber의 kill switch(`MASC_KEEPER_MEMORY_OS_CONSOLIDATION`) 기본값을 **`true` → `false`**로 변경. consolidator/recall 코드는 그대로(정확). 프로덕션 caller(fiber)만 기본 off.

## 왜

머지된 shared tier(#21237)를 **라이브 fleet에 read-only dry-run**한 결과(15 keepers, 6017 facts; `normalize_claim` 정확 복제 + eligible/group/noisy-OR), ≥2 distinct keeper가 corroborate한 승격 후보 19건이 **전부 운영 boilerplate**였다 — 내구성 있는 cross-keeper 지식 0건.

```
eligible(fact/constraint>=0.5)=5112  distinct_claims=4664  WOULD_PROMOTE(>=2 keepers)=19
모두: "checkpoint saved"/"remains scheduled"(8 wording fragment) + "curation submitted"/"no tasks"/"agent desire all none"
```

근본 원인은 consolidator가 아니라 **librarian taxonomy**: 휘발성 lifecycle/coordination 이벤트가 `category=fact`로 잘못 태깅돼 category 화이트리스트(default-deny)가 못 거른다. 자세히 #21241.

fiber를 기본 on으로 두면 recall이 keeper 프롬프트에 boilerplate를 `shared via k1,k2`로 주입(노이즈). 그래서 **producer(librarian)가 ephemeral 이벤트를 non-promotable 카테고리로 emit할 때까지**(#21241) 기본 off.

substring 필터로 boilerplate를 거르는 건 CLAUDE.md string-classifier 안티패턴이라 하지 않음 — gate의 안전 기본값만 변경.

## 재활성화 조건

#21241(librarian taxonomy) fix 후 default를 true로 되돌리거나 env를 true로 설정.

## 검증

- `dune build lib/server/ bin/main_eio.exe` exit 0.
- 동작 변경 없음(unit test는 consolidator를 직접 호출, fiber gate 기본값 미의존). 1줄 default + 주석.

## 관련
- #21237 (shared tier impl, MERGED `72fc3d1902`), #21234 (RFC docs, MERGED), #21241 (librarian taxonomy follow-up), RFC-0244 §2.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
