### PR TITLE
refactor(keeper): close residual role string-downgrade in recent_direct_line projection

### DIFF
--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -34,8 +34,22 @@ let is_keeper_authored_message author =
   Option.is_some (Keeper_identity.canonical_keeper_name_from_agent_name author)
 ;;
 
+(* RFC-0232 P1: the direct-line role is a closed sum, not a string label.
+   The projection has exactly three shapes (a tool row is shown as its call
+   name); [to_label] is the single place the display vocabulary lives, so the
+   renderer never re-derives semantics from a free string. *)
+type direct_line_role =
+  | User
+  | Assistant
+  | Tool_call
+
+let direct_line_role_to_label = function
+  | User -> "user"
+  | Assistant -> "assistant"
+  | Tool_call -> "tool_call"
+
 type recent_direct_line = {
-  role_label : string;
+  role : direct_line_role;
   speaker_label : string option;
   content : string;
 }
@@ -93,7 +107,7 @@ let recent_direct_conversation_of_messages
       match m.role with
       | Keeper_chat_store.Role.User ->
         Some
-          { role_label = "user"
+          { role = User
           ; speaker_label = Some (speaker_display m)
           ; content
           }
@@ -105,7 +119,7 @@ let recent_direct_conversation_of_messages
             | Some _ -> None
             | None ->
               Some
-                { role_label = "assistant"
+                { role = Assistant
                 ; speaker_label = None
                 ; content
                 }))
@@ -117,7 +131,7 @@ let recent_direct_conversation_of_messages
            if name = "" then None
            else
              Some
-               { role_label = "tool_call"
+               { role = Tool_call
                ; speaker_label = None
                ; content = name
                }))
@@ -148,7 +162,8 @@ let render_recent_direct_conversation_context
         | None -> ""
         | Some value -> Printf.sprintf "/%s" value
       in
-      Printf.sprintf "- %s%s: %s" line.role_label speaker line.content
+      Printf.sprintf "- %s%s: %s"
+        (direct_line_role_to_label line.role) speaker line.content
     in
     String.concat "\n"
       ([

--- a/lib/keeper/keeper_world_observation_message_scope.mli
+++ b/lib/keeper/keeper_world_observation_message_scope.mli
@@ -20,8 +20,21 @@ val is_self_author
 
 val is_keeper_authored_message : string -> bool
 
+type direct_line_role =
+  | User
+  | Assistant
+  | Tool_call
+(** RFC-0232 P1: closed-sum role for a direct-conversation line, replacing the
+    former [role_label : string]. The renderer derives the display label from
+    this via {!direct_line_role_to_label}; no consumer re-derives semantics
+    from a free string. *)
+
+val direct_line_role_to_label : direct_line_role -> string
+(** Display vocabulary SSOT: [User -> "user"], [Assistant -> "assistant"],
+    [Tool_call -> "tool_call"]. *)
+
 type recent_direct_line = {
-  role_label : string;
+  role : direct_line_role;
   speaker_label : string option;
   content : string;
 }

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -129,7 +129,10 @@ let roles messages =
   List.map (fun (m : K.chat_message) -> K.Role.to_label m.role) messages
 
 let recent_roles lines =
-  List.map (fun (line : MS.recent_direct_line) -> line.role_label) lines
+  List.map
+    (fun (line : MS.recent_direct_line) ->
+      MS.direct_line_role_to_label line.role)
+    lines
 
 let test_append_turn_roundtrip () =
   let base_dir = temp_base_path "keeper-chat-store-turn" in


### PR DESCRIPTION
## Summary

Close the one remaining role string-downgrade in the keeper world-observation
layer: the `recent_direct_line` projection struct.

RFC-0232 ("typed lane event model") is fully shipped — P1 (`Role.t` + positional
watermark, #20896), P2 (turn outcome, #20914), P3 (`Keeper_id.t`, #20932),
P4 (persisted mentions, #20951), P5 (`Surface_ref`, #20976) all merged. The
lane's `chat_message.role` is already the closed sum `Keeper_chat_store.Role.t`.

After those landed, #21044 ("ground direct chat in recent transcript") added a
**new** projection struct, `recent_direct_line`, that re-stringified the
already-typed role back to `role_label : string` and rendered it by raw
interpolation — reintroducing exactly the string-derived-semantics hazard
RFC-0232 §3.1 removed from the lane itself. A second role vocabulary
(`"tool_call"`) drifts from `Role.t`'s `"tool"`.

This PR replaces the field with a closed sum
`direct_line_role = User | Assistant | Tool_call` plus a single
`direct_line_role_to_label` SSOT; the renderer derives the label from the
variant. **No wire or display change** — labels remain `user` / `assistant` /
`tool_call`, so the keeper prompt text is byte-identical.

This is follow-on hygiene in RFC-0232's spirit (close a string downgrade at a
module boundary), not a new RFC phase — RFC-0232's five phases are complete.

## Changed files

- `lib/keeper/keeper_world_observation_message_scope.ml` — closed sum + producer + renderer
- `lib/keeper/keeper_world_observation_message_scope.mli` — expose `direct_line_role` + `direct_line_role_to_label`
- `test/test_keeper_chat_store.ml` — `recent_roles` helper reads the typed field via `to_label`

## Verification

- `dune build @check` and `dune build lib/keeper` green; all 48 CI checks green.
- keeper_chat_store role-rendering tests pass (`recent_direct_context_*`).
- The one local raw-exe failure `test_direct_owner_context_excludes_connector_turns`
  is **pre-existing and environmental**: it reproduces identically on a clean
  `origin/main` baseline worktree (21 pass / 1 fail, same assertion), caused by
  the FileSystem backend lacking an Eio fs context under raw-exe invocation
  (the suite forces `MASC_STORAGE_TYPE=filesystem` via `dune runtest`). It is
  orthogonal to role rendering. CI `dune runtest` exercises the proper path and
  is green.

RFC-WAIVED: no credential/identity/sandbox/hooks change; this types a display
projection struct in the keeper observation layer.
