### PR TITLE
[codex] fix keeper voice self echo

### DIFF
--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -101,11 +101,14 @@ let recent_direct_conversation_of_messages
         (match m.kind with
          | Keeper_chat_store.Row_kind.Transport_failure -> None
          | Keeper_chat_store.Row_kind.Utterance ->
-           Some
-             { role_label = "assistant"
-             ; speaker_label = None
-             ; content
-             })
+           (match m.audio with
+            | Some _ -> None
+            | None ->
+              Some
+                { role_label = "assistant"
+                ; speaker_label = None
+                ; content
+                }))
       | Keeper_chat_store.Role.Tool ->
         (match m.tool_call_name with
          | None -> None

--- a/lib/keeper/keeper_world_observation_message_scope.mli
+++ b/lib/keeper/keeper_world_observation_message_scope.mli
@@ -27,7 +27,9 @@ type recent_direct_line = {
 }
 (** Bounded transcript line for direct-chat continuity. Tool rows retain
     only the call name; assistant transport failures are omitted because
-    they are server failures, not keeper utterances. *)
+    they are server failures, not keeper utterances. Assistant rows carrying
+    synthesized voice audio are also omitted from this prompt context so the
+    keeper does not quote its own spoken output back into the next turn. *)
 
 val recent_direct_conversation_of_messages
   :  ?limit:int

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -249,6 +249,32 @@ let test_recent_direct_context_omits_transport_failure_as_self_reply () =
       Alcotest.(check bool) "failure text is not a self utterance" false
         (contains_substring rendered "Keeper request failed"))
 
+let test_recent_direct_context_omits_voice_audio_self_echo () =
+  let base_dir = temp_base_path "keeper-chat-recent-voice" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-recent-voice" in
+      K.append_assistant_message ~base_dir ~keeper_name
+        ~content:"I will say this out loud now."
+        ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
+        ~audio:
+          { K.token = "voice-token-1"
+          ; mime = "audio/mpeg"
+          ; duration_sec = None
+          ; message_text = "I will say this out loud now."
+          }
+        ();
+      let lines =
+        K.load ~base_dir ~keeper_name
+        |> MS.recent_direct_conversation_of_messages
+      in
+      Alcotest.(check (list string)) "voice self-output is not prompt context"
+        [] (recent_roles lines);
+      let rendered = MS.render_recent_direct_conversation_context lines in
+      Alcotest.(check bool) "spoken text is not re-injected" false
+        (contains_substring rendered "I will say this out loud now."))
+
 let test_direct_owner_context_excludes_connector_turns () =
   let base_dir = temp_base_path "keeper-chat-direct-owner-gate" in
   Fun.protect
@@ -840,6 +866,8 @@ let () =
             test_recent_direct_context_renders_prior_reply_and_tool_evidence;
           Alcotest.test_case "recent context omits transport failure as reply" `Quick
             test_recent_direct_context_omits_transport_failure_as_self_reply;
+          Alcotest.test_case "recent context omits voice audio self echo" `Quick
+            test_recent_direct_context_omits_voice_audio_self_echo;
           Alcotest.test_case "recent context is owner-direct only" `Quick
             test_direct_owner_context_excludes_connector_turns;
           Alcotest.test_case "append_turn redacts projected secrets" `Quick

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -44,6 +44,7 @@ let test_empty_targets () =
 ;;
 
 let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None)
+    ?(audio = None)
     ?(kind = Store.Row_kind.Utterance) content
   : Store.chat_message
   =
@@ -60,7 +61,7 @@ let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None)
   ; speaker
   ; mentions = Masc.Keeper_lane_mentions.mention_ids_of_content content
   ; kind
-  ; audio = None
+  ; audio
   }
 ;;
 
@@ -233,6 +234,31 @@ let test_transport_failure_does_not_clear () =
     (contents (MS.pending_mentions_of_messages ~targets answered))
 ;;
 
+let test_voice_audio_self_output_is_not_recent_context () =
+  let audio =
+    Some
+      { Store.token = "voice-token-1"
+      ; mime = "audio/mpeg"
+      ; duration_sec = None
+      ; message_text = "saying this out loud"
+      }
+  in
+  let messages =
+    [ msg ~role:Store.Role.User ~ts:(Some 10.0) "please say it out loud"
+    ; msg ~role:Store.Role.Assistant ~ts:(Some 11.0) ~audio
+        "saying this out loud"
+    ; msg ~role:Store.Role.Assistant ~ts:(Some 12.0) "text follow-up"
+    ]
+  in
+  let lines = MS.recent_direct_conversation_of_messages messages in
+  check (list string) "voice audio assistant row omitted from prompt context"
+    [ "user"; "assistant" ]
+    (List.map (fun (line : MS.recent_direct_line) -> line.role_label) lines);
+  check (list string) "spoken text is not quoted back"
+    [ "please say it out loud"; "text follow-up" ]
+    (List.map (fun (line : MS.recent_direct_line) -> line.content) lines)
+;;
+
 let test_assistant_append_empties_pending () =
   (* Appending the keeper's own line can only shrink pending — for any
      prefix of a lane, prefix @ [assistant] has no pending mentions or
@@ -291,6 +317,8 @@ let () =
         ; test_case "tool_lines_do_not_clear" `Quick test_tool_lines_do_not_clear
         ; test_case "transport_failure_does_not_clear" `Quick
             test_transport_failure_does_not_clear
+        ; test_case "voice_audio_self_output_not_recent_context" `Quick
+            test_voice_audio_self_output_is_not_recent_context
         ; test_case "assistant_append_empties_pending" `Quick
             test_assistant_append_empties_pending
         ] )


### PR DESCRIPTION
## Summary

- Prevent synthesized voice output rows from being reused as recent direct prompt context.
- Keep voice/audio rows in durable chat history for UI playback while excluding them only from the model prompt transcript.
- Add regression coverage for both pure message-scope behavior and persisted chat-store rows with audio metadata.

## Root cause

`keeper_voice_speak` stores spoken text as an assistant chat row with audio metadata. The recent direct conversation builder treated that row like a normal assistant utterance, so a later keeper turn could see its own spoken text quoted back in prompt context and repeat it via the voice tool. Existing memory-bank filtering already avoided voice rows in memory summaries, but the durable chat transcript path was still re-injecting them.

## Validation

- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --root . --build-dir _build-voice-echo test/test_keeper_mention_scope.exe test/test_keeper_chat_store.exe`
- `./_build-voice-echo/default/test/test_keeper_mention_scope.exe` -> pass, 22 tests
- `./_build-voice-echo/default/test/test_keeper_chat_store.exe test tool_call_persistence 4` -> pass, new regression only
- `./_build-voice-echo/default/test/test_keeper_chat_store.exe` -> new regression passes, but the existing local `tool_call_persistence 5 recent context is owner-direct only` case still fails because the test falls back to the Memory backend without an Eio fs context