### PR TITLE
style(dashboard): keeper-workspace 대화 영역 세로 공간 확보

### DIFF
--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -143,7 +143,7 @@
  * two-row variant — the runtime/model/throughput sub-row moved to the rail —
  * so the conversation below gets the reclaimed vertical space. */
 .kw-chat-head {
-  flex: none; padding: 12px 28px;
+  flex: none; padding: 10px 28px;
   border-bottom: 1px solid var(--color-border-default);
   background: linear-gradient(180deg, var(--color-bg-panel-alt), var(--color-bg-page));
   display: flex; align-items: center; gap: 14px;
@@ -183,25 +183,33 @@
   width: 100%; max-width: var(--kw-thread-w, 980px); margin: 0 auto;
   flex: 1; min-height: 0; display: flex; flex-direction: column;
 }
-/* Spacious overrides for the reused ChatTranscript (chat/primitives.ts).
- * Two-class specificity beats its single-class Tailwind gap/padding. */
+/* Overrides for the reused ChatTranscript (chat/primitives.ts).
+ * Two-class specificity beats its single-class Tailwind gap/padding.
+ * Gap + top inset are tightened from the original 30px/34px so more of the
+ * conversation is visible at once — the prior values left the transcript
+ * feeling cramped (few messages on screen) despite filling the column. */
 .kw-thread-inner .chat-transcript {
-  gap: 30px;
+  gap: 22px;
   padding-left: 40px;
   padding-right: 40px;
-  padding-top: 34px;
+  padding-top: 20px;
 }
 .kw-composer-wrap {
   flex: none;
   border-top: 1px solid var(--color-border-default);
   background: linear-gradient(0deg, var(--color-bg-panel-alt), var(--color-bg-page));
-  padding: 14px 0 18px;
+  padding: 12px 0 14px;
 }
 .kw-composer-inner { width: 100%; max-width: var(--kw-thread-w, 980px); margin: 0 auto; padding: 0 40px; }
+/* Composer floor: the reused ChatComposer applies min-h-30 (120px) to an empty
+ * textarea, permanently reserving space the transcript (its flex:1 sibling)
+ * would otherwise take. Lower the floor to ~2 rows, scoped to the workspace;
+ * control-textarea keeps resize:vertical so a long draft can be dragged taller. */
+.kw-composer-inner .control-textarea { min-height: 80px; }
 
 .kw-chat-toolbar {
   flex: none; display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
-  padding: 8px 40px; border-bottom: 1px solid var(--color-border-divider);
+  padding: 6px 40px; border-bottom: 1px solid var(--color-border-divider);
   background: var(--color-bg-page);
 }
 .kw-chat-toolbar .spacer { flex: 1; }


### PR DESCRIPTION
## 목적

3-pane keeper-workspace 채팅 컬럼의 "직접 대화" 영역이 세로로 좁다는 피드백 해소. 높이 체인은 정상(transcript가 `flex:1`로 컬럼을 채움)임을 확인했고, 좁게 느껴진 원인은 **컬럼 내부 세로 공간 소비자**였음:

- 빈 ChatComposer가 `min-h-30`(120px)으로 영구 점유
- transcript 상단 inset 34px + 메시지 간 gap 30px → 한 화면에 메시지가 적게 보임

## 변경 (전부 CSS-only, 워크스페이스 스코프)

`chat/primitives.ts`를 건드리지 않아 다른 `ChatComposer`/`ChatTranscript` consumer에는 영향이 없습니다.

| 대상 | 변경 |
|------|------|
| composer textarea floor | 120px → 80px (`.kw-composer-inner .control-textarea`, `resize:vertical` 유지) |
| transcript padding-top | 34px → 20px |
| 메시지 간 gap | 30px → 22px |
| composer-wrap padding | 14/18 → 12/14 |
| header padding(세로) | 12 → 10 |
| toolbar padding(세로) | 8 → 6 |

순효과: transcript에 약 68px 환원 + 메시지 밀도 향상.

## 검증

- `pnpm build` 통과 (worktree 소스)
- 빌드 번들에 새 값 확인: `control-textarea{min-height:80px}`, `padding-top:20px`, `gap:22px`
- 라이브 서버(`:8935`) 서빙 디렉토리에 빌드 반영 후 index.html이 새 CSS 해시 참조 확인
- CSS-only 변경이라 단위 테스트/타입에 영향 없음 (`.ml/.mli` 0개 → OCaml pre-commit hook은 `--no-verify`, 사유 명시)

## 트레이드오프

composer 기본 높이가 2행으로 줄어듭니다. 긴 프롬프트 작성 시 `resize:vertical`로 드래그하거나 내부 스크롤 사용. 더 큰 기본 입력창을 선호하면 composer floor만 되돌릴 수 있음. 자동 높이 증가(auto-grow)는 공유 컴포넌트(`primitives.ts`) 변경이 필요해 범위 밖(필요 시 별도 PR).

WORKAROUND-WAIVED: 직접적인 레이아웃 스페이싱 조정. telemetry-as-fix / string 분류기 / N-of-M / cap-cooldown-dedup-repair 시그니처 없음.
