### PR TITLE
refactor(keeper): assemble the world-state prompt as a typed ordered layer fold

### DIFF
--- a/lib/keeper/keeper_context_layers.ml
+++ b/lib/keeper/keeper_context_layers.ml
@@ -1,0 +1,50 @@
+(** See [keeper_context_layers.mli] for the contract. *)
+
+type layer_id =
+  | Active_goals
+  | Connected_surfaces
+  | Namespace_state
+  | Context_health
+  | Autonomous_trigger
+  | Continuity
+  | Pending_mentions
+  | Scope_messages
+  | Claimable_work
+  | Board_activity
+
+(* Prefix-cache ordering: emit larger, more stable sections first so providers
+   can reuse a longer shared prefix across cycles; highly volatile reactive
+   signals stay later in the same user message. *)
+let ordered =
+  [ Active_goals
+  ; Connected_surfaces
+  ; Namespace_state
+  ; Context_health
+  ; Autonomous_trigger
+  ; Continuity
+  ; Pending_mentions
+  ; Scope_messages
+  ; Claimable_work
+  ; Board_activity
+  ]
+;;
+
+(* Exhaustive over [layer_id]: adding a variant breaks this match at compile
+   time, forcing both a position here and (via the [content_of] match at the
+   call site) a rendering for the new layer. *)
+let order_index = function
+  | Active_goals -> 0
+  | Connected_surfaces -> 1
+  | Namespace_state -> 2
+  | Context_health -> 3
+  | Autonomous_trigger -> 4
+  | Continuity -> 5
+  | Pending_mentions -> 6
+  | Scope_messages -> 7
+  | Claimable_work -> 8
+  | Board_activity -> 9
+;;
+
+let assemble ~content_of =
+  ordered |> List.filter_map content_of |> String.concat ""
+;;

--- a/lib/keeper/keeper_context_layers.mli
+++ b/lib/keeper/keeper_context_layers.mli
@@ -1,0 +1,42 @@
+(** Keeper_context_layers — the keeper world-state user message as an ordered
+    set of typed context layers.
+
+    Each layer owns exactly one observation signal and renders to [Some text]
+    when its signal is present this turn, [None] when it carries nothing. The
+    render order is a single declared SSOT ({!ordered}) rather than the implicit
+    order of imperative buffer writes, so reordering or adding a section is a
+    typed, reviewable change instead of an edit buried in a long procedure.
+
+    The build is a pure fold: {!assemble} concatenates, in {!ordered} order, the
+    [Some] renderings produced by a caller-supplied [content_of]. [content_of]
+    is written as an exhaustive match on {!layer_id} at the call site, so adding
+    a layer fails to compile until the producing site renders it. *)
+
+type layer_id =
+  | Active_goals
+  | Connected_surfaces
+  | Namespace_state
+  | Context_health
+  | Autonomous_trigger
+  | Continuity
+  | Pending_mentions
+  | Scope_messages
+  | Claimable_work
+  | Board_activity
+
+val ordered : layer_id list
+(** The canonical render order: larger, more stable sections first so providers
+    can reuse a longer shared prefix across cycles (prefix-cache ordering);
+    highly volatile reactive signals stay later. Every {!layer_id} appears
+    exactly once — cross-checked against {!order_index} in
+    [test_keeper_context_layers]. *)
+
+val order_index : layer_id -> int
+(** Position of a layer in {!ordered} (0-based). Exhaustive over {!layer_id}, so
+    a new variant forces an arm here as well as in any [content_of]. *)
+
+val assemble : content_of:(layer_id -> string option) -> string
+(** [assemble ~content_of] renders each layer in {!ordered} via [content_of] and
+    concatenates the [Some] results in order; a [None] layer contributes
+    nothing. The concatenation is byte-exact — each [content_of] result is
+    expected to carry its own header and trailing separators. *)

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -637,23 +637,17 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
   in
   (* User message: structured world observation — reactive triggers + resource state only.
      Metacognition sections (tool activity, cycle outcome, diversity, behavioral stats)
-     removed in #6814; telemetry preserved in decision_audit and independent paths. *)
-  let ubuf = Buffer.create 1024 in
-  Buffer.add_string ubuf "## Current World State\n\n";
-  (* Prefix-cache ordering: emit larger, more stable sections first so
-     providers can reuse a longer shared prefix across cycles. Highly
-     volatile reactive signals stay later in the same user message. *)
-  (* 1. Active goals — stable turn context *)
-  if observation.active_goals <> [] then (
-    Buffer.add_string ubuf
-      (Printf.sprintf "### Active Goals (%d)\n"
-         (List.length observation.active_goals));
-    Buffer.add_string ubuf (format_goals observation.active_goals);
-    Buffer.add_string ubuf "\n\n");
-  (* 2. Connected surfaces — connector presence, changes only on
-     bind/unbind or transport flaps (RFC-0223 P2). Omitted when only
-     the implicit dashboard is attached: every keeper has the
-     dashboard, so dashboard-only presence carries no signal. *)
+     removed in #6814; telemetry preserved in decision_audit and independent paths.
+
+     The body is an ordered fold of typed context layers (Keeper_context_layers).
+     [content_of] below is an exhaustive match on [layer_id], so adding a
+     world-state signal fails to compile until this match renders it, and the
+     section order is the module's declared [ordered] SSOT rather than the
+     implicit order of buffer writes. Byte-identical to the prior imperative
+     buffer: each arm carries its own header and trailing separators, and
+     [assemble] concatenates the present layers in [ordered] order. *)
+  (* Prefix-cache ordering rationale and per-layer notes live on the matching
+     arms of [content_of] and in Keeper_context_layers.ordered. *)
   let connector_presence =
     List.filter
       (fun (p : Gate_surface.surface_presence) ->
@@ -664,141 +658,180 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
             true)
       observation.connected_surfaces
   in
-  if connector_presence <> [] then (
-    Buffer.add_string ubuf "### Connected Surfaces\n";
-    List.iter
-      (fun p ->
-        Buffer.add_string ubuf
-          (Printf.sprintf "- %s\n" (format_surface_presence p)))
-      observation.connected_surfaces;
-    Buffer.add_string ubuf (connected_surface_discretion_prompt ());
-    Buffer.add_char ubuf '\n';
-    Buffer.add_char ubuf '\n');
-  (* 3. Namespace state — usually lower churn than inbox/board detail *)
-  if
-    observation.unclaimed_task_count > 0
-    || observation.claimable_task_count > 0
-    || observation.provider_capacity_blocked_task_count > 0
-    || observation.failed_task_count > 0
-    || observation.running_keeper_fiber_count > 0
-  then (
-    Buffer.add_string ubuf "### Namespace State\n";
-    if observation.unclaimed_task_count > 0 then
-      Buffer.add_string ubuf
-        (Printf.sprintf "- Unclaimed tasks: %d\n"
-           observation.unclaimed_task_count);
-    if observation.claimable_task_count > 0 then
-      Buffer.add_string ubuf
-        (Printf.sprintf "- Claimable tasks for this keeper: %d\n"
-           observation.claimable_task_count);
-    if observation.unclaimed_task_count > 0
-       && observation.claimable_task_count = 0
-    then
-      Buffer.add_string ubuf
-        "- Claimable tasks for this keeper: 0\n";
-    let keeper_or_scope_blocked =
-      max 0
-        (observation.unclaimed_task_count
-         - observation.claimable_task_count)
-    in
-    if keeper_or_scope_blocked > 0 then
-      Buffer.add_string ubuf
-        (Printf.sprintf
-           "- Blocked by keeper/tool/goal scope: %d\n"
-           keeper_or_scope_blocked);
-    if observation.provider_capacity_blocked_task_count > 0 then
-      Buffer.add_string ubuf
-        (Printf.sprintf
-           "- Provider-capacity blocked claimable tasks: %d\n"
-           observation.provider_capacity_blocked_task_count);
-    if observation.failed_task_count > 0 then
-      Buffer.add_string ubuf
-        (Printf.sprintf "- Failed tasks: %d\n" observation.failed_task_count);
-    Buffer.add_string ubuf
-      (Printf.sprintf
-         "- Running keeper fibers: %d\n"
-         observation.running_keeper_fiber_count);
-    Buffer.add_char ubuf '\n');
-  (* 4. Context health — stable resource framing *)
-  Buffer.add_string ubuf
-    (Printf.sprintf "### Context\n- Utilization: %.0f%%\n- Idle: %ds\n"
-       (observation.context_ratio *. 100.0)
-       observation.idle_seconds);
-  (* 5. Autonomous trigger — lower churn than reactive inboxes *)
   let turn_decision =
     Keeper_world_observation.keeper_cycle_decision ~meta observation
   in
   let autonomous_trigger =
     autonomous_trigger_lines ~decision:turn_decision ~observation
   in
-  if autonomous_trigger <> [] then (
-    Buffer.add_string ubuf "\n### Autonomous Trigger\n";
-    Buffer.add_string ubuf (String.concat "\n" autonomous_trigger);
-    Buffer.add_char ubuf '\n');
-  (* 6. Continuity — usually large and moderately stable, so keep it
-     before highly volatile reactive sections for better prefix reuse.
-     Inject only forward-looking fields (Goal, Next plan, Next, OpenQuestions,
-     Constraints). Backward-looking fields (Done, Progress, Decisions) are
-     stripped to avoid a prose-level echo loop where the LLM re-reads its own
-     prior narrative and reproduces a near-identical one. The full summary
-     remains persisted in meta.continuity_summary for audit. *)
   let continuity_for_prompt =
     Keeper_memory_policy.filter_forward_looking_summary
       observation.continuity_summary
   in
-  if
-    continuity_for_prompt <> ""
-    && observation.continuity_summary <> "No continuity snapshot available."
-  then (
-    Buffer.add_string ubuf "\n### Continuity\n";
-    Buffer.add_string ubuf
-      "- Advisory only: ignore prior silence/wait directives until you re-verify them against the live world state.\n";
-    Buffer.add_string ubuf
-      "- If this turn was still scheduled or backlog/repo signals remain, investigate that mismatch instead of echoing the prior idle conclusion.\n";
-    Buffer.add_string ubuf continuity_for_prompt;
-    Buffer.add_char ubuf '\n');
-  (* 7. Pending mentions — reactive trigger *)
-  if observation.pending_mentions <> [] then (
-    Buffer.add_string ubuf
-      (Printf.sprintf "### Pending Mentions (%d)\n"
-         (List.length observation.pending_mentions));
-    Buffer.add_string ubuf (format_mentions observation.pending_mentions);
-    Buffer.add_string ubuf "\n\n");
-  (* 8. Scope messages — reactive trigger *)
-  if observation.pending_scope_messages <> [] then (
-    Buffer.add_string ubuf
-      (Printf.sprintf "### Scope Messages (%d recent)\n"
-         (List.length observation.pending_scope_messages));
-    Buffer.add_string ubuf
-      (format_scope_messages observation.pending_scope_messages);
-    Buffer.add_string ubuf "\n\n");
-  (* 9. Claimable work — advisory operational guidance.
-     Body lives at config/prompts/keeper.immediate_task_move.md. The OCaml
-     side only owns the section header and the trailing blank line; the
-     bullet prose stays in the markdown file alongside the other keeper
-     prompts (see fallback_externalized_bullet for the in-binary mirror). *)
-  if show_claim_guidance then (
-    Buffer.add_string ubuf "### Claimable Work\n";
-    Buffer.add_string ubuf
-      (load_externalized_bullet
-         ~enabled:true
-         Keeper_prompt_names.immediate_task_move);
-    Buffer.add_char ubuf '\n');
-  (* 10. Board activity — reactive trigger *)
-  if observation.pending_board_events <> [] then (
-    Buffer.add_string ubuf
-      (Printf.sprintf "### Board Activity (%d new)\n"
-         (List.length observation.pending_board_events));
-    Buffer.add_string ubuf (format_board_events observation.pending_board_events);
-    if
-      tool_allowed "keeper_board_curation_submit"
-      && List.length observation.pending_board_events >= 2
-    then
-      Buffer.add_string ubuf
-        "\n- Curation due: after reading enough context, call keeper_board_curation_submit with a concise snapshot for this board window.";
-    Buffer.add_string ubuf "\n\n");
+  let content_of : Keeper_context_layers.layer_id -> string option = function
+    (* 1. Active goals — stable turn context. *)
+    | Keeper_context_layers.Active_goals ->
+      if observation.active_goals <> [] then
+        Some
+          (Printf.sprintf "### Active Goals (%d)\n"
+             (List.length observation.active_goals)
+          ^ format_goals observation.active_goals
+          ^ "\n\n")
+      else None
+    (* 2. Connected surfaces — connector presence, changes only on bind/unbind
+       or transport flaps (RFC-0223 P2). Omitted when only the implicit
+       dashboard is attached: every keeper has the dashboard, so dashboard-only
+       presence carries no signal. *)
+    | Keeper_context_layers.Connected_surfaces ->
+      if connector_presence <> [] then (
+        let ubuf = Buffer.create 256 in
+        Buffer.add_string ubuf "### Connected Surfaces\n";
+        List.iter
+          (fun p ->
+            Buffer.add_string ubuf
+              (Printf.sprintf "- %s\n" (format_surface_presence p)))
+          observation.connected_surfaces;
+        Buffer.add_string ubuf (connected_surface_discretion_prompt ());
+        Buffer.add_char ubuf '\n';
+        Buffer.add_char ubuf '\n';
+        Some (Buffer.contents ubuf))
+      else None
+    (* 3. Namespace state — usually lower churn than inbox/board detail. *)
+    | Keeper_context_layers.Namespace_state ->
+      if
+        observation.unclaimed_task_count > 0
+        || observation.claimable_task_count > 0
+        || observation.provider_capacity_blocked_task_count > 0
+        || observation.failed_task_count > 0
+        || observation.running_keeper_fiber_count > 0
+      then (
+        let ubuf = Buffer.create 256 in
+        Buffer.add_string ubuf "### Namespace State\n";
+        if observation.unclaimed_task_count > 0 then
+          Buffer.add_string ubuf
+            (Printf.sprintf "- Unclaimed tasks: %d\n"
+               observation.unclaimed_task_count);
+        if observation.claimable_task_count > 0 then
+          Buffer.add_string ubuf
+            (Printf.sprintf "- Claimable tasks for this keeper: %d\n"
+               observation.claimable_task_count);
+        if observation.unclaimed_task_count > 0
+           && observation.claimable_task_count = 0
+        then
+          Buffer.add_string ubuf
+            "- Claimable tasks for this keeper: 0\n";
+        let keeper_or_scope_blocked =
+          max 0
+            (observation.unclaimed_task_count
+             - observation.claimable_task_count)
+        in
+        if keeper_or_scope_blocked > 0 then
+          Buffer.add_string ubuf
+            (Printf.sprintf
+               "- Blocked by keeper/tool/goal scope: %d\n"
+               keeper_or_scope_blocked);
+        if observation.provider_capacity_blocked_task_count > 0 then
+          Buffer.add_string ubuf
+            (Printf.sprintf
+               "- Provider-capacity blocked claimable tasks: %d\n"
+               observation.provider_capacity_blocked_task_count);
+        if observation.failed_task_count > 0 then
+          Buffer.add_string ubuf
+            (Printf.sprintf "- Failed tasks: %d\n"
+               observation.failed_task_count);
+        Buffer.add_string ubuf
+          (Printf.sprintf
+             "- Running keeper fibers: %d\n"
+             observation.running_keeper_fiber_count);
+        Buffer.add_char ubuf '\n';
+        Some (Buffer.contents ubuf))
+      else None
+    (* 4. Context health — stable resource framing. *)
+    | Keeper_context_layers.Context_health ->
+      Some
+        (Printf.sprintf "### Context\n- Utilization: %.0f%%\n- Idle: %ds\n"
+           (observation.context_ratio *. 100.0)
+           observation.idle_seconds)
+    (* 5. Autonomous trigger — lower churn than reactive inboxes. *)
+    | Keeper_context_layers.Autonomous_trigger ->
+      if autonomous_trigger <> [] then
+        Some
+          ("\n### Autonomous Trigger\n"
+          ^ String.concat "\n" autonomous_trigger
+          ^ "\n")
+      else None
+    (* 6. Continuity — usually large and moderately stable, so keep it before
+       highly volatile reactive sections for better prefix reuse. Inject only
+       forward-looking fields (Goal, Next plan, Next, OpenQuestions,
+       Constraints). Backward-looking fields (Done, Progress, Decisions) are
+       stripped to avoid a prose-level echo loop where the LLM re-reads its own
+       prior narrative and reproduces a near-identical one. The full summary
+       remains persisted in meta.continuity_summary for audit. *)
+    | Keeper_context_layers.Continuity ->
+      if
+        continuity_for_prompt <> ""
+        && observation.continuity_summary <> "No continuity snapshot available."
+      then
+        Some
+          ("\n### Continuity\n"
+          ^ "- Advisory only: ignore prior silence/wait directives until you re-verify them against the live world state.\n"
+          ^ "- If this turn was still scheduled or backlog/repo signals remain, investigate that mismatch instead of echoing the prior idle conclusion.\n"
+          ^ continuity_for_prompt
+          ^ "\n")
+      else None
+    (* 7. Pending mentions — reactive trigger. *)
+    | Keeper_context_layers.Pending_mentions ->
+      if observation.pending_mentions <> [] then
+        Some
+          (Printf.sprintf "### Pending Mentions (%d)\n"
+             (List.length observation.pending_mentions)
+          ^ format_mentions observation.pending_mentions
+          ^ "\n\n")
+      else None
+    (* 8. Scope messages — reactive trigger. *)
+    | Keeper_context_layers.Scope_messages ->
+      if observation.pending_scope_messages <> [] then
+        Some
+          (Printf.sprintf "### Scope Messages (%d recent)\n"
+             (List.length observation.pending_scope_messages)
+          ^ format_scope_messages observation.pending_scope_messages
+          ^ "\n\n")
+      else None
+    (* 9. Claimable work — advisory operational guidance. Body lives at
+       config/prompts/keeper.immediate_task_move.md. The OCaml side only owns
+       the section header and the trailing blank line; the bullet prose stays in
+       the markdown file alongside the other keeper prompts (see
+       fallback_externalized_bullet for the in-binary mirror). *)
+    | Keeper_context_layers.Claimable_work ->
+      if show_claim_guidance then
+        Some
+          ("### Claimable Work\n"
+          ^ load_externalized_bullet
+              ~enabled:true
+              Keeper_prompt_names.immediate_task_move
+          ^ "\n")
+      else None
+    (* 10. Board activity — reactive trigger. *)
+    | Keeper_context_layers.Board_activity ->
+      if observation.pending_board_events <> [] then (
+        let ubuf = Buffer.create 256 in
+        Buffer.add_string ubuf
+          (Printf.sprintf "### Board Activity (%d new)\n"
+             (List.length observation.pending_board_events));
+        Buffer.add_string ubuf
+          (format_board_events observation.pending_board_events);
+        if
+          tool_allowed "keeper_board_curation_submit"
+          && List.length observation.pending_board_events >= 2
+        then
+          Buffer.add_string ubuf
+            "\n- Curation due: after reading enough context, call keeper_board_curation_submit with a concise snapshot for this board window.";
+        Buffer.add_string ubuf "\n\n";
+        Some (Buffer.contents ubuf))
+      else None
+  in
   let user_message =
-    Buffer.contents ubuf
+    "## Current World State\n\n" ^ Keeper_context_layers.assemble ~content_of
   in
   let sanitized_system = sanitize_retired_tool_names system_prompt in
   let sanitized_user = sanitize_retired_tool_names user_message in

--- a/test/dune
+++ b/test/dune
@@ -37,6 +37,7 @@
   test_keeper_cycle_channel
   test_keeper_identity_id
   test_keeper_idle_threshold_contract
+  test_keeper_context_layers
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection
@@ -318,6 +319,7 @@
   test_keeper_cycle_channel
   test_keeper_identity_id
   test_keeper_idle_threshold_contract
+  test_keeper_context_layers
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection

--- a/test/test_keeper_context_layers.ml
+++ b/test/test_keeper_context_layers.ml
@@ -1,0 +1,93 @@
+(* Keeper_context_layers — pure ordered-fold of the keeper world-state user
+   message. These tests pin the two properties the typed fold replaces an
+   imperative buffer to guarantee: a single declared render order, and that the
+   assembled body is exactly the in-order concatenation of the present layers
+   (a [None] layer contributes nothing). *)
+
+open Alcotest
+module L = Masc.Keeper_context_layers
+
+(* The full constructor set, listed independently of [L.ordered] so a drift
+   between the two is observable here rather than silently dropping a section. *)
+let all_layers =
+  [
+    L.Active_goals;
+    L.Connected_surfaces;
+    L.Namespace_state;
+    L.Context_health;
+    L.Autonomous_trigger;
+    L.Continuity;
+    L.Pending_mentions;
+    L.Scope_messages;
+    L.Claimable_work;
+    L.Board_activity;
+  ]
+
+let test_ordered_is_complete_permutation () =
+  check int "ordered length matches constructor count" (List.length all_layers)
+    (List.length L.ordered);
+  List.iter
+    (fun id ->
+      check bool
+        (Printf.sprintf "ordered contains layer at index %d" (L.order_index id))
+        true
+        (List.mem id L.ordered))
+    all_layers
+
+let test_order_index_matches_position () =
+  List.iteri
+    (fun i id ->
+      check int
+        (Printf.sprintf "order_index agrees with position %d" i)
+        i (L.order_index id))
+    L.ordered
+
+let test_order_index_is_injective () =
+  let indices = List.map L.order_index all_layers in
+  let sorted = List.sort_uniq compare indices in
+  check int "order_index distinct across all layers"
+    (List.length all_layers) (List.length sorted)
+
+let test_assemble_concatenates_present_in_order () =
+  (* Render a label for three layers spread across the order (positions 0, 3, 9)
+     and nothing for the rest; assemble must yield them in ordered order. *)
+  let content_of = function
+    | L.Active_goals -> Some "A"
+    | L.Context_health -> Some "C"
+    | L.Board_activity -> Some "B"
+    | _ -> None
+  in
+  check string "present layers concatenated in ordered order" "ACB"
+    (L.assemble ~content_of)
+
+let test_assemble_empty_when_all_absent () =
+  check string "no layers -> empty body" "" (L.assemble ~content_of:(fun _ -> None))
+
+let test_assemble_all_present_follows_ordered () =
+  (* Each layer renders its own order index; the result must read 0..9. *)
+  let content_of id = Some (string_of_int (L.order_index id)) in
+  check string "every layer present -> indices in order" "0123456789"
+    (L.assemble ~content_of)
+
+let () =
+  run "keeper_context_layers"
+    [
+      ( "ordering",
+        [
+          test_case "ordered is a complete permutation" `Quick
+            test_ordered_is_complete_permutation;
+          test_case "order_index matches ordered position" `Quick
+            test_order_index_matches_position;
+          test_case "order_index is injective" `Quick
+            test_order_index_is_injective;
+        ] );
+      ( "assemble",
+        [
+          test_case "concatenates present layers in order" `Quick
+            test_assemble_concatenates_present_in_order;
+          test_case "empty when all absent" `Quick
+            test_assemble_empty_when_all_absent;
+          test_case "all present follows ordered" `Quick
+            test_assemble_all_present_follows_ordered;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Replace the imperative `Buffer` that builds the keeper world-state user message
with a typed ordered layer fold.

`keeper_unified_prompt.build_prompt` assembled the `## Current World State`
message with a ~160-line `Buffer.add_string` procedure: ten sections whose order
lived only in `(* 1. *)..(* 10. *)` comments and whose presence was ad-hoc
`if observation.X <> [] then ...` guards. Nothing forced a new context signal to
be rendered, and no single place owned the section order.

This extracts a pure `Keeper_context_layers` module:

- `type layer_id` — closed sum of the ten sections.
- `val ordered : layer_id list` — the render order as a declared SSOT
  (prefix-cache ordering: stable sections first).
- `val order_index : layer_id -> int` — exhaustive, so a new variant forces an
  arm here.
- `val assemble : content_of:(layer_id -> string option) -> string` — pure fold;
  renders each layer in `ordered` order and concatenates the `Some` results.

`build_prompt` now supplies `content_of` as an **exhaustive match** on
`layer_id`. Adding a context signal fails to compile until the producing site
renders it; reordering is a change to `ordered`, not a comment.

## Byte-identical

Each match arm returns exactly the bytes its old buffer block appended (header +
body + trailing separators); `assemble` concatenates the present layers in
`ordered` order behind the same `"## Current World State\n\n"` header. No wire or
prompt-text change.

## Changed files

- `lib/keeper/keeper_context_layers.{ml,mli}` — new pure module (layer_id, ordered, order_index, assemble)
- `lib/keeper/keeper_unified_prompt.ml` — build_prompt uses the exhaustive `content_of` fold
- `test/test_keeper_context_layers.ml` + `test/dune` — pure unit tests

## Verification

- `dune build .` and `dune build lib/keeper` green; changed files pass `ocamlformat --check`.
- New `test_keeper_context_layers` (6 cases): `ordered` complete permutation,
  `order_index` matches position + injective, `assemble` concatenates present
  layers in order / empty when absent / all-present reads `0..9`.
- 79 existing build_prompt tests pass unchanged, notably
  `test_keeper_surface_presence_prompt` (Connected Surfaces — the section whose
  presence guard and iteration differ) and `test_keeper_prompt_metrics` (pins
  the `PromptSegmentBytes` gauge = exact user_message byte length).

## Scope

Part of the typed-harness contract **C5** (context = disjoint-signal ordered
composing layers; from the MASC/OAS typed-harness map). A per-layer byte budget
/ circuit breaker is intentionally **out of scope** here — it changes output and
needs section-size data — and is a follow-on now that the layers are typed.

RFC-WAIVED: no credential/identity/sandbox/hooks/operator change; this is a
byte-identical refactor of keeper prompt assembly. Not in the agent-delegation
RFC-gated subsystem list.
