### PR TITLE
fix(memory-os): librarian durability gate + per-category criteria (#21241)

### DIFF
--- a/config/prompts/keeper.librarian.episode_extraction.md
+++ b/config/prompts/keeper.librarian.episode_extraction.md
@@ -4,16 +4,25 @@ category: keeper
 template_variables: [conversation_history]
 ---
 
-You are a librarian for an AI agent. Read a bounded slice of the agent's conversation history and extract a structured memory episode.
+You are a librarian for an AI agent. Read a bounded slice of the agent's conversation history and extract a structured memory episode. Your output feeds a long-lived, cross-keeper memory store, so a stored claim must be worth re-reading later by a DIFFERENT agent on a different day.
 
-Rules:
-1. Extract only grounded facts, decisions, constraints, durable preferences, blockers, and open items.
-2. Do not preserve emotional fillers, repeated catchphrases, or stylistic noise unless they encode a durable fact.
-3. Do NOT extract ephemeral lifecycle or coordination self-state — these are operational telemetry, not durable knowledge, and must not become claims. Examples to exclude: "a continuation checkpoint was saved", "the keeper remains scheduled for the next cycle", "no claimable/unclaimed tasks", "board curation was submitted", "the agent's desire/intention/blocker/need are all none". Capture the durable decision or constraint behind an action, never the act of running a cycle or calling a tool.
-4. Never copy hidden reasoning, private runtime state, or tool payload content into claims.
-5. Each claim must include an approximate source_turn from the conversation slice. Use source_tool_call_id only when a tool call id is explicitly visible.
-6. Confidence must be a JSON number between 0.0 and 1.0. Use 0.1-0.4 when uncertain and state the uncertainty in the claim text.
-7. The output must be strict JSON only, with no markdown formatting.
+Durability gate (apply to EVERY candidate before writing it as a claim):
+A candidate qualifies only if it would still be TRUE and USEFUL to another keeper on a later day, independent of this run. If it describes the act of running this cycle, calling a tool, saving/loading a checkpoint, being scheduled or woken, the current task queue, or the keeper's present desire/intention/blocker/need, it FAILS the gate. Drop it — do not store it, and do not relabel it to fit a category. Capture the durable decision, fact, or constraint behind an action, never the act itself.
+
+Category criteria — choose the FIRST that fits; if none fits cleanly, the candidate fails the durability gate, so drop it:
+- code_change: a concrete, lasting change to code or configuration (a file/function was modified, a setting now has value X), described so it is verifiable later.
+- constraint: a rule, limit, policy, invariant, or boundary that bounds future action (must / must not / only / at most). Includes a decision that establishes such a rule.
+- blocker: a specific external obstacle that prevents progress and persists beyond this turn (a dependency is missing, an API is down, a credential is absent). Not the keeper merely having no task to do.
+- goal: a durable objective or target the agent is working toward, beyond the current turn.
+- preference: a stable, stated preference about how work should be done (style, tooling, process) that holds across turns.
+- fact: an externally verifiable statement about the world, the codebase, or the system that stays true across cycles and is NOT about this keeper's own run. Use fact only when none of the above fit and the durability gate passes. fact is the last resort, never the default — if you are unsure whether something is a fact, it usually fails the durability gate and should be dropped.
+
+Additional rules:
+1. Do not preserve emotional fillers, repeated catchphrases, or stylistic noise unless they encode a durable fact.
+2. Never copy hidden reasoning, private runtime state, or tool payload content into claims.
+3. Each claim must include an approximate source_turn from the conversation slice. Use source_tool_call_id only when a tool call id is explicitly visible.
+4. confidence must be a JSON number between 0.0 and 1.0. Use 0.1-0.4 when uncertain and state the uncertainty in the claim text.
+5. open_items and constraints are episode-level summary arrays, separate from a claim's category. A claim already categorized as constraint does not need to be repeated in the constraints array.
 
 Output schema:
 {
@@ -35,4 +44,4 @@ Output schema:
 Conversation history:
 {{conversation_history}}
 
-Respond with ONLY the JSON object.
+Respond with ONLY the JSON object, no markdown.

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -283,7 +283,7 @@ let test_librarian_prompt_renders () =
       (contains "[turn=0 role=user] Please remember the project constraint." prompt);
     match
       ( index_of "[turn=0 role=user] Please remember the project constraint." prompt
-      , index_of "Respond with ONLY the JSON object." prompt )
+      , index_of "Respond with ONLY the JSON object" prompt )
     with
     | Some conversation_at, Some respond_at ->
       Alcotest.(check bool)


### PR DESCRIPTION
## 목표

memory-os librarian이 keeper의 ephemeral lifecycle/coordination self-state("a checkpoint was saved", "no claimable tasks", "remains scheduled")를 durable `category="fact"` claim으로 저장하던 producer-레벨 결함을 고친다. consolidator가 `[Fact; Constraint]`를 cross-keeper `_shared` tier로 승격하므로, 이 오라벨이 공유 store를 운영 boilerplate로 오염시킨다.

라이브 dry-run 측정: 6,400 facts 중 would-promote 19건이 전부 boilerplate, 0건 durable. confidence(중앙값 0.95)는 durability 신호가 아님.

## 근본 원인 (전체 프롬프트 품질 점검에서 식별)

category enum이 옵션만 나열하고 **어느 걸 언제 쓰는지 기준이 0줄** → 모델이 애매한 내용을 제일 generic한 `fact`로 default. 이는 단발 버그가 아니라 6개 분류기 프롬프트(librarian / deliberation / dashboard judges / verifiers)에 반복되는 "enum without selection criteria" 패턴의 한 인스턴스다. 이 PR은 그 중 producer(librarian)를 고친다.

## 변경

- `config/prompts/keeper.librarian.episode_extraction.md`:
  - 모든 candidate에 적용하는 **positive durability gate** 추가 — "다른 keeper에게 다른 날에도 참이고 유용한가? 이 run의 행위를 서술하면 drop". #21248에서 넣었던 open-ended 부정 예시 나열(band-aid)을 대체.
  - 각 category에 한 줄 판별 기준 부여, `fact`를 명시적 **최후 수단**으로 강등("never the default").
  - 중복된 strict-JSON Rule 제거(최종 지시 한 줄로 통합).
  - 닫힌 enum 불변(#21248의 closed category sum + Unknown fallback로 파싱). on-disk JSON 포맷 불변(마이그레이션 없음).
- `test/test_keeper_memory_os.ml`: prompt-render 테스트의 최종-지시 앵커를 안정적 substring으로 갱신(최종 문구가 바뀜). 순서 검사 의도 보존.

## 로컬 검증

- `dune build --root . test/test_keeper_memory_os.exe` → exit 0
- `test_keeper_memory_os.exe` → **48 tests, 0 failure** (render + category codec 포함)
- 변경 범위: 2 파일(프롬프트 데이터 + 테스트 앵커). 코드 컴파일 영향 없음(프롬프트는 런타임에 `config/prompts`에서 읽힘).

## 의도적 trade-off

durability gate가 "애매하면 drop" 쪽으로 편향됨 → 공유 store에는 precision > recall이 맞지만, 진짜 fact 일부를 떨굴 수 있음(허용).

## 남은 후속 (이 PR 밖)

- enum-criteria 하우스 룰 sweep: 나머지 5개 분류기 프롬프트(deliberation / governance_judge / operator_judge / action_verifier / anti_rationalization)에 'choose this when…' 기준 주입.
- incantation 중복 제거 + Shell IR/transition FSM 강제(core_behavior ~80% 중복, STATE 스키마 2중).
- tool-surface lint: 프롬프트 enum을 `mcp_server_eio_tool_profile.ml` 레지스트리와 대조(`masc_claim_next`/`keeper_task_start` 유령 도구 확인됨).
- fiber 재활성화는 별도: producer가 깨끗해진 뒤 store wipe + dry-run 재측정.

Refs #21241, RFC-0244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
