### PR TITLE
feat(keeper): bound librarian parse-retry instead of dropping unparseable episodes (C6)

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -96,6 +96,46 @@ let message role text =
   Agent_sdk.Types.make_message ~role [ Agent_sdk.Types.Text text ]
 ;;
 
+(* Bounded parse-retry for librarian extraction (typed-harness contract C6).
+
+   The librarian asks a provider for a JSON episode. When the provider returns a
+   non-empty response that does not parse into the typed episode
+   ([Keeper_librarian.episode_of_output] -> None), the prior behavior dropped the
+   episode and only incremented [EpisodeCreateFailures]: a counter makes the loss
+   visible but does not recover it (the telemetry-as-fix shape CLAUDE.md rejects).
+   Instead, re-ask the provider with a corrective nudge up to
+   [librarian_max_parse_retries] times before giving up. Transport failures
+   (timeout / HTTP error) are NOT retried here — they are a provider-availability
+   problem, not the model-output problem this bound addresses. *)
+let librarian_max_parse_retries = 2
+
+let parse_retry_nudge =
+  "Your previous response could not be parsed as the required JSON episode \
+   object. Respond with ONLY a single JSON object — no markdown fences, no \
+   prose — containing: episode_summary (string), claims (array of objects with \
+   claim, confidence, category, source_turn), open_items, constraints, \
+   preserved_tool_refs."
+
+type attempt_outcome =
+  | Parsed of Keeper_memory_os_types.episode
+  | Unparseable of string
+    (* provider returned output we could not parse into an episode — retryable *)
+  | Transport_failed of string (* timeout / HTTP error — not retried here *)
+
+let rec run_with_parse_retries ~max_retries ~attempt messages =
+  match attempt messages with
+  | Parsed episode -> Ok episode
+  | Transport_failed msg -> Error msg
+  | Unparseable msg ->
+    if max_retries <= 0
+    then Error msg
+    else
+      run_with_parse_retries
+        ~max_retries:(max_retries - 1)
+        ~attempt
+        (messages @ [ message Agent_sdk.Types.User parse_retry_nudge ])
+;;
+
 let render_prompt key variables =
   match Prompt_registry.render_prompt_template key variables with
   | Ok text ->
@@ -180,20 +220,26 @@ let extract_with_provider
   | Ok messages ->
     let provider_cfg = provider_for_librarian provider_cfg in
     with_provider_slot ?clock (fun () ->
-      match
-        with_timeout ?clock ~timeout_sec (fun () ->
-          complete ~sw ~net ?clock ~config:provider_cfg ~messages ())
-      with
-      | None -> Error "librarian provider timed out"
-      | Some (Error err) -> Error (http_error_message err)
-      | Some (Ok response) ->
-        let raw = Agent_sdk_response.text_of_response response |> String.trim in
-        if String.equal raw ""
-        then Error "librarian provider returned empty response"
-        else (
-          match Keeper_librarian.episode_of_output inp raw with
-          | Some episode -> Ok episode
-          | None -> Error "librarian provider returned invalid episode JSON"))
+      let attempt messages =
+        match
+          with_timeout ?clock ~timeout_sec (fun () ->
+            complete ~sw ~net ?clock ~config:provider_cfg ~messages ())
+        with
+        | None -> Transport_failed "librarian provider timed out"
+        | Some (Error err) -> Transport_failed (http_error_message err)
+        | Some (Ok response) ->
+          let raw = Agent_sdk_response.text_of_response response |> String.trim in
+          if String.equal raw ""
+          then Unparseable "librarian provider returned empty response"
+          else (
+            match Keeper_librarian.episode_of_output inp raw with
+            | Some episode -> Parsed episode
+            | None -> Unparseable "librarian provider returned invalid episode JSON")
+      in
+      run_with_parse_retries
+        ~max_retries:librarian_max_parse_retries
+        ~attempt
+        messages)
 ;;
 
 let extract_and_append_with_provider

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -41,6 +41,29 @@ val provider_for_librarian
   :  Llm_provider.Provider_config.t
   -> Llm_provider.Provider_config.t
 
+val librarian_max_parse_retries : int
+(** Additional provider attempts after an initial unparseable response before
+    [extract_with_provider] gives up (the initial attempt is not counted). *)
+
+val parse_retry_nudge : string
+(** Corrective instruction appended to the message list on each parse-retry. *)
+
+type attempt_outcome =
+  | Parsed of Keeper_memory_os_types.episode
+  | Unparseable of string
+  | Transport_failed of string
+
+val run_with_parse_retries
+  :  max_retries:int
+  -> attempt:(Agent_sdk.Types.message list -> attempt_outcome)
+  -> Agent_sdk.Types.message list
+  -> (Keeper_memory_os_types.episode, string) result
+(** Drive [attempt] over a growing message list. Returns immediately on [Parsed]
+    (Ok) and [Transport_failed] (Error); on [Unparseable], appends
+    {!parse_retry_nudge} and retries up to [max_retries] times before returning
+    the last error. Pure given a pure [attempt] — the provider side effect lives
+    in the [attempt] supplied by {!extract_with_provider}. *)
+
 val extract_with_provider
   :  ?complete:complete_fn
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t

--- a/test/dune
+++ b/test/dune
@@ -33,6 +33,7 @@
   test_broadcast_wakeup_policy
   test_keeper_mention_scope
   test_keeper_lane_mentions
+  test_keeper_librarian_retry
   test_surface_ref
   test_keeper_turn_outcome
   test_keeper_cycle_channel
@@ -317,6 +318,7 @@
   test_broadcast_wakeup_policy
   test_keeper_mention_scope
   test_keeper_lane_mentions
+  test_keeper_librarian_retry
   test_surface_ref
   test_keeper_turn_outcome
   test_keeper_cycle_channel

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -1,0 +1,108 @@
+(* Bounded parse-retry policy for librarian extraction (typed-harness contract
+   C6). The retry combinator is pure given a pure [attempt], so these drive it
+   with a stub instead of a provider and pin the policy in isolation:
+   - parse success returns immediately (no retry),
+   - an unparseable response is retried with a corrective nudge,
+   - retries are bounded by [max_retries] (initial attempt not counted),
+   - a transport failure is surfaced without retry,
+   - exactly one nudge is appended per retry. *)
+
+open Alcotest
+module R = Masc.Keeper_librarian_runtime
+module Lib = Masc.Keeper_librarian
+module Types = Agent_sdk.Types
+
+(* A minimal valid episode, parsed from known-good JSON, reused as the [Parsed]
+   payload so the stub does not have to fabricate the record by hand. *)
+let sample_episode () =
+  let raw =
+    {|{"episode_summary":"s","claims":[{"claim":"c","confidence":0.9,"category":"fact","source_turn":0}],"open_items":[],"constraints":[],"preserved_tool_refs":[]}|}
+  in
+  let inp = { Lib.trace_id = "t"; generation = 0; messages = [] } in
+  match Lib.episode_of_output ~now:1_000_000.0 inp raw with
+  | Some ep -> ep
+  | None -> Alcotest.fail "fixture episode failed to parse"
+
+let nudge_count messages =
+  List.length
+    (List.filter
+       (fun (m : Types.message) ->
+         List.exists
+           (function
+             | Types.Text t -> String.equal t R.parse_retry_nudge
+             | _ -> false)
+           m.content)
+       messages)
+
+let test_succeeds_first_attempt () =
+  let ep = sample_episode () in
+  let calls = ref 0 in
+  let attempt _msgs =
+    incr calls;
+    R.Parsed ep
+  in
+  (match R.run_with_parse_retries ~max_retries:2 ~attempt [] with
+   | Ok _ -> ()
+   | Error e -> Alcotest.failf "expected Ok, got Error %s" e);
+  check int "no retry when first attempt parses" 1 !calls
+
+let test_retries_then_succeeds () =
+  let ep = sample_episode () in
+  let calls = ref 0 in
+  let attempt _msgs =
+    incr calls;
+    if !calls < 2 then R.Unparseable "bad json" else R.Parsed ep
+  in
+  (match R.run_with_parse_retries ~max_retries:2 ~attempt [] with
+   | Ok _ -> ()
+   | Error e -> Alcotest.failf "expected Ok after retry, got %s" e);
+  check int "one retry to recover" 2 !calls
+
+let test_bounded_then_fails () =
+  let calls = ref 0 in
+  let attempt _msgs =
+    incr calls;
+    R.Unparseable "still bad"
+  in
+  (match R.run_with_parse_retries ~max_retries:2 ~attempt [] with
+   | Ok _ -> Alcotest.fail "expected Error after exhausting retries"
+   | Error e -> check string "last error surfaced" "still bad" e);
+  check int "initial attempt + max_retries" 3 !calls
+
+let test_transport_not_retried () =
+  let calls = ref 0 in
+  let attempt _msgs =
+    incr calls;
+    R.Transport_failed "timeout"
+  in
+  (match R.run_with_parse_retries ~max_retries:2 ~attempt [] with
+   | Ok _ -> Alcotest.fail "expected Error"
+   | Error e -> check string "transport error surfaced" "timeout" e);
+  check int "transport failure is not retried" 1 !calls
+
+let test_nudge_appended_each_retry () =
+  let ep = sample_episode () in
+  let seen = ref [] in
+  let calls = ref 0 in
+  let attempt msgs =
+    incr calls;
+    seen := msgs :: !seen;
+    if !calls < 3 then R.Unparseable "bad" else R.Parsed ep
+  in
+  let _ = R.run_with_parse_retries ~max_retries:3 ~attempt [] in
+  (* Attempt 1 sees 0 nudges, attempt 2 sees 1, attempt 3 sees 2. *)
+  let counts = List.rev_map nudge_count !seen in
+  check (list int) "one nudge added per retry" [ 0; 1; 2 ] counts
+
+let () =
+  run "keeper_librarian_retry"
+    [
+      ( "parse_retry",
+        [
+          test_case "succeeds on first attempt" `Quick test_succeeds_first_attempt;
+          test_case "retries then succeeds" `Quick test_retries_then_succeeds;
+          test_case "bounded then fails" `Quick test_bounded_then_fails;
+          test_case "transport not retried" `Quick test_transport_not_retried;
+          test_case "nudge appended each retry" `Quick test_nudge_appended_each_retry;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Recover unparseable Memory OS librarian responses with a bounded retry instead
of dropping the episode behind a failure counter.

When the librarian asks a provider for a JSON episode and the provider returns a
non-empty but unparseable response, `extract_with_provider` returned `Error` and
`run_best_effort` dropped the episode while bumping the `EpisodeCreateFailures`
counter. The counter makes the loss observable but does not recover it — the
telemetry-as-fix shape the CLAUDE.md workaround bar rejects, on the memory-write
path.

This re-asks the provider with a corrective nudge up to
`librarian_max_parse_retries` (2) times before giving up.

## Design

- `run_with_parse_retries` is a **pure combinator** over a typed
  `attempt_outcome = Parsed | Unparseable | Transport_failed`. Control flow keys
  on the variant, not on the error string.
- **Parse failures** (empty / invalid episode JSON) retry; **transport
  failures** (timeout / HTTP error) are surfaced without retry — they are a
  provider-availability problem, not the model-output problem this bound
  addresses.
- The existing tolerant parse (code-fence strip + brace-range fallback) and the
  strict typed episode parse (`fact_of_json` requires claim/confidence/category/
  source_turn; `category` is a closed sum via RFC-0244) are unchanged.
- The retry policy is separated from the Eio completion, so it is unit-testable
  without a provider.

## Changed files

- `lib/keeper/keeper_librarian_runtime.{ml,mli}` — `attempt_outcome`, `run_with_parse_retries`, `parse_retry_nudge`, `librarian_max_parse_retries`; `extract_with_provider` drives the typed attempt through the bound.
- `test/test_keeper_librarian_retry.ml` + `test/dune` — pure policy tests.

## Verification

- `dune build lib bin` green; changed files pass `ocamlformat --check`.
- New `test_keeper_librarian_retry` (5 cases): first-attempt success does not
  retry (1 call); one unparseable then parse succeeds (2 calls); all-unparseable
  fails after initial + 2 retries (3 calls); a transport failure is not retried
  (1 call); exactly one nudge is appended per retry (`[0;1;2]`).
- `test_keeper_memory_os` unchanged (48 tests pass).

## Scope

Part of the typed-harness contract **C6** (structured output recovered by a
bounded retry over a typed parse, not a silent drop). This is the librarian
slice; the state-snapshot sink slice (re-introduce a schema-validated snapshot
producer; overlaps R5/RFC-0242) is tracked separately. Provider-side
`output_schema` enforcement is intentionally not added here — the librarian's
direct-completion provider may not honor schema-constrained decoding, and the
retry is the provider-agnostic recovery.

RFC-WAIVED: no credential/identity/sandbox/hooks/operator change; this is a
recovery-on-parse-failure change on the keeper memory-os extraction path,
governed by the C6 contract. Not in the agent-delegation RFC-gated subsystem
list.
