### PR TITLE
fix(keeper): suppress wake storms and preserve operator pauses

### DIFF
--- a/lib/keeper/keeper_meta_merge.ml
+++ b/lib/keeper/keeper_meta_merge.ml
@@ -27,4 +27,24 @@ let monotonic_usage_counters ~(latest : Keeper_meta_contract.keeper_meta) ~(call
   ; runtime = { caller.runtime with usage }
   }
 
-let heartbeat_fields_from_disk = monotonic_usage_counters
+let is_operator_pause (meta : Keeper_meta_contract.keeper_meta) =
+  meta.paused
+  && Option.is_none meta.auto_resume_after_sec
+  && Option.is_none meta.runtime.last_blocker
+
+let preserve_operator_pause_from_disk
+      ~(latest : Keeper_meta_contract.keeper_meta)
+      ~(caller : Keeper_meta_contract.keeper_meta)
+  =
+  let merged = monotonic_usage_counters ~latest ~caller in
+  if is_operator_pause latest
+  then
+    {
+      merged with
+      paused = true;
+      auto_resume_after_sec = None;
+      runtime = { merged.runtime with last_blocker = None };
+    }
+  else merged
+
+let heartbeat_fields_from_disk = preserve_operator_pause_from_disk

--- a/lib/keeper/keeper_meta_merge.mli
+++ b/lib/keeper/keeper_meta_merge.mli
@@ -13,4 +13,6 @@ val monotonic_usage_counters : t
     last_* observation fields stay with the caller. *)
 
 val heartbeat_fields_from_disk : t
-(** Alias of {!monotonic_usage_counters} for existing retry call sites. *)
+(** {!monotonic_usage_counters}, plus preservation of an operator-owned pause
+    already present on disk. This prevents stale turn/heartbeat writers from
+    clearing [paused=true] after an operator paused the keeper. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -160,6 +160,10 @@ let trimmed_env_opt name =
 
 let discord_bot_token_opt () = trimmed_env_opt "DISCORD_BOT_TOKEN"
 
+let broadcast_mention_wakeup_action = function
+  | Some target when String.trim target <> "" -> `Wake_keeper target
+  | Some _ | None -> `Suppress_no_target
+
 module For_testing = struct
   type queued_chat_projection = {
     payload_channel : string;
@@ -171,6 +175,7 @@ module For_testing = struct
 
   let autoboot_proactive_warmup_sec = autoboot_proactive_warmup_sec
   let board_sse_event_params = board_sse_event_params
+  let broadcast_mention_wakeup_action = broadcast_mention_wakeup_action
 
   let queued_chat_projection queued_message : queued_chat_projection =
     let projection = queued_chat_projection queued_message in
@@ -542,18 +547,19 @@ let start_keeper_loops
         "board: Activity_graph.emit kind=%s failed: %s"
         activity_kind
         (Printexc.to_string exn));
-  (* Wire broadcast → keeper wakeup: any broadcast wakes keepers so they
-     can react to new tasks, mentions, or workspace activity immediately.
-     SSOT: Workspace_broadcast.on_broadcast_mention is the single ref wired here. *)
+  (* Wire broadcast -> keeper wakeup. Explicit mentions wake the target
+     keeper immediately; unmentioned broadcasts remain passive SSE/message
+     fanout so one broad announcement cannot create a fleet-wide turn storm.
+     Board signals have their own capped keeper wake path above. *)
   let broadcast_mention_handler =
     fun mention ->
-    match mention with
-    | Some target ->
+    match broadcast_mention_wakeup_action mention with
+    | `Wake_keeper target ->
       Keeper_keepalive.wakeup_keeper ~base_path:(Mcp_server.workspace_config state).base_path target;
       Log.Keeper.info "broadcast mention → wakeup keeper %s" target
-    | None ->
-      Keeper_keepalive.wakeup_all_keepers ~base_path:(Mcp_server.workspace_config state).base_path ();
-      Log.Keeper.info "broadcast → wakeup all keepers (reactive push)"
+    | `Suppress_no_target ->
+      Log.Keeper.info
+        "broadcast without mention -> keeper wakeup suppressed (passive fanout)"
   in
   Workspace_broadcast.on_broadcast_mention := broadcast_mention_handler;
   (* Orchestrator needs synchronous registration for shutdown hook *)

--- a/lib/server/server_bootstrap_loops.mli
+++ b/lib/server/server_bootstrap_loops.mli
@@ -38,6 +38,9 @@ module For_testing : sig
 
   val board_sse_event_params : Board_dispatch.board_sse_event -> Yojson.Safe.t
 
+  val broadcast_mention_wakeup_action :
+    string option -> [ `Suppress_no_target | `Wake_keeper of string ]
+
   val queued_chat_projection :
     Keeper_chat_queue.queued_message -> queued_chat_projection
 end

--- a/test/dune
+++ b/test/dune
@@ -30,6 +30,7 @@
 (tests
  (names
   test_keeper_reactive_wake_backlog_gate
+  test_broadcast_wakeup_policy
   test_keeper_mention_scope
   test_keeper_lane_mentions
   test_surface_ref
@@ -313,6 +314,7 @@
  (modules
   test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate
+  test_broadcast_wakeup_policy
   test_keeper_mention_scope
   test_keeper_lane_mentions
   test_surface_ref

--- a/test/test_broadcast_wakeup_policy.ml
+++ b/test/test_broadcast_wakeup_policy.ml
@@ -1,0 +1,31 @@
+open Alcotest
+
+module Broadcast_wakeup = Server_bootstrap_loops.For_testing
+
+let test_mention_wakes_target () =
+  match Broadcast_wakeup.broadcast_mention_wakeup_action (Some "rondo") with
+  | `Wake_keeper "rondo" -> ()
+  | `Wake_keeper other -> failf "unexpected wake target: %s" other
+  | `Suppress_no_target -> fail "expected explicit mention to wake target"
+
+let test_none_is_passive () =
+  match Broadcast_wakeup.broadcast_mention_wakeup_action None with
+  | `Suppress_no_target -> ()
+  | `Wake_keeper target -> failf "unexpected no-target wake: %s" target
+
+let test_blank_is_passive () =
+  match Broadcast_wakeup.broadcast_mention_wakeup_action (Some "  ") with
+  | `Suppress_no_target -> ()
+  | `Wake_keeper target -> failf "unexpected blank-target wake: %s" target
+
+let () =
+  run
+    "broadcast_wakeup_policy"
+    [
+      ( "mention_policy"
+      , [
+          test_case "explicit mention wakes target" `Quick test_mention_wakes_target
+        ; test_case "no mention is passive" `Quick test_none_is_passive
+        ; test_case "blank mention is passive" `Quick test_blank_is_passive
+        ] )
+    ]

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -199,6 +199,62 @@ let test_monotonic_usage_counters_on_cas_retry () =
     check int "last_* observation stays with the caller" 777
       final.runtime.usage.last_latency_ms)
 
+let test_operator_pause_survives_stale_heartbeat_retry () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Workspace.default_config base_dir in
+    ignore (Workspace.init config ~agent_name:(Some "operator"));
+    let m0 = make_meta ~name:"operator-pause-cas" in
+    (match Keeper_meta_store.write_meta config m0 with
+     | Ok () -> ()
+     | Error e -> fail ("seed write failed: " ^ e));
+    let stale_turn_view = match Keeper_meta_store.read_meta config "operator-pause-cas" with
+      | Ok (Some m) -> m
+      | _ -> fail "seed read failed"
+    in
+    let operator_pause =
+      { stale_turn_view with
+        paused = true;
+        auto_resume_after_sec = None;
+        runtime = { stale_turn_view.runtime with last_blocker = None };
+        updated_at = Keeper_meta_contract.now_iso ();
+      }
+    in
+    (match Keeper_meta_store.write_meta config operator_pause with
+     | Ok () -> ()
+     | Error e -> fail ("operator pause write failed: " ^ e));
+    let stale_completion =
+      { stale_turn_view with
+        paused = false;
+        runtime =
+          { stale_turn_view.runtime with
+            usage =
+              { stale_turn_view.runtime.usage with
+                total_turns = stale_turn_view.runtime.usage.total_turns + 1;
+              };
+          };
+        updated_at = Keeper_meta_contract.now_iso ();
+      }
+    in
+    (match
+       Keeper_meta_store.write_meta_with_merge
+         ~merge:Keeper_meta_merge.heartbeat_fields_from_disk config stale_completion
+     with
+     | Ok () -> ()
+     | Error e -> fail ("stale retry write failed: " ^ e));
+    let final = match Keeper_meta_store.read_meta config "operator-pause-cas" with
+      | Ok (Some m) -> m
+      | _ -> fail "final read failed"
+    in
+    check bool "operator pause survives stale retry" true final.paused;
+    check bool "auto resume stays disabled" true
+      (Option.is_none final.auto_resume_after_sec);
+    check bool "stale blocker stays cleared" true
+      (Option.is_none final.runtime.last_blocker))
+
 (* RFC-0237: the [write_meta ~force:true] escape hatch is removed, so the
    counter-rewind path the four keeper-internal sites carried
    (keeper_tool_surface / keeper_tool_surface_ops / keeper_keepalive /
@@ -273,6 +329,8 @@ let () =
             test_retry_succeeds_after_concurrent_bump;
           test_case "usage counters stay monotonic on stale retry (RFC-0225 §3.2)"
             `Quick test_monotonic_usage_counters_on_cas_retry;
+          test_case "operator pause survives stale heartbeat retry"
+            `Quick test_operator_pause_survives_stale_heartbeat_retry;
           test_case "stale write conflicts without force (RFC-0237 escape hatch closed)"
             `Quick test_stale_write_conflicts_without_force;
         ] );


### PR DESCRIPTION
## Summary

- suppress no-target broadcast wake fanout so broad workspace broadcasts stay passive instead of waking the whole keeper fleet
- preserve operator-owned pause state across stale meta CAS retry/merge writes

## Validation

- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_broadcast_wakeup_policy.exe test/test_keeper_meta_cas_retry.exe bin/main_eio.exe`
- `_build/default/test/test_broadcast_wakeup_policy.exe` (3 tests)
- `_build/default/test/test_keeper_meta_cas_retry.exe` (6 tests)

## Notes

- Discord stale gateway reader input handling landed separately in `origin/main` via #21261.
- The explicit directive/operator-pause durable behavior landed separately in `origin/main` via #21263; this PR keeps the remaining broadcast and stale-meta retry fixes.
- Opened as draft because this branch is deployed locally and should stay visible under PR/CI coverage before merge.
