### PR TITLE
fix(discord): ignore stale gateway reader inputs

### DIFF
--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -129,6 +129,20 @@ let set_presence (status : Discord_gateway_state.presence_status) =
   | Some mb ->
     Eio.Stream.add mb (Discord_gateway_state.Status_change status)
 
+let reader_should_continue_after_input = function
+  | Discord_gateway_state.Wss_closed _ -> false
+  | Discord_gateway_state.Connect_requested
+  | Discord_gateway_state.Frame_received _
+  | Discord_gateway_state.Frame_parse_error _
+  | Discord_gateway_state.Heartbeat_tick
+  | Discord_gateway_state.Heartbeat_ack_timeout
+  | Discord_gateway_state.Backoff_elapsed
+  | Discord_gateway_state.Status_change _ -> true
+
+module For_testing = struct
+  let reader_should_continue_after_input = reader_should_continue_after_input
+end
+
 let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
   let config : Discord_gateway_state.config = {
     token; intents; bot_user_id = None; trigger_policy;
@@ -156,6 +170,23 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
      used for the last reconnect attempt. *)
   let has_connected_before = ref false in
   let last_reconnect_was_resume = ref false in
+
+  let connection_is_current conn =
+    match !conn_ref with
+    | Some current -> current == conn
+    | None -> false
+  in
+
+  let enqueue_if_current conn input =
+    if connection_is_current conn then begin
+      Eio.Stream.add input_mailbox input;
+      true
+    end else begin
+      Log.Discord.debug
+        "dropping Discord gateway input from inactive WSS connection";
+      false
+    end
+  in
 
   let clock = Eio.Stdenv.clock env in
   Eio.Fiber.fork ~sw (fun () ->
@@ -186,36 +217,46 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
 
   let reader_loop conn =
     let rec loop () =
-      match Discord_wss_connection.read conn with
+      if not (connection_is_current conn) then
+        Log.Discord.debug "stopping inactive Discord gateway reader"
+      else match Discord_wss_connection.read conn with
+      | exception Eio.Cancel.Cancelled _ -> ()
       | exception End_of_file ->
-        Eio.Stream.add input_mailbox
-          (Discord_gateway_state.Wss_closed { code = 1006; reason = "eof" })
+        let (_ : bool) =
+          enqueue_if_current conn
+            (Discord_gateway_state.Wss_closed { code = 1006; reason = "eof" })
+        in
+        ()
       | exception e ->
-        Eio.Stream.add input_mailbox
-          (Discord_gateway_state.Wss_closed
-             { code = 1011; reason = Printexc.to_string e })
+        let (_ : bool) =
+          enqueue_if_current conn
+            (Discord_gateway_state.Wss_closed
+               { code = 1011; reason = Printexc.to_string e })
+        in
+        ()
       | frame ->
         (match frame_to_input frame with
          | Some inp ->
-           (* Side-channel: track heartbeat ACK arrival for I/O-layer
-              liveness detection.  The [when] guard avoids a fragile
-              catch-all on the [input] type — the state machine still
-              receives every input unchanged. *)
-           (match inp with
-            | Discord_gateway_state.Frame_received f
-              when f.op = Discord_gateway_state.Op_heartbeat_ack ->
-              Atomic.set heartbeat_ack_ok true
-            | Discord_gateway_state.Frame_received _
-            | Discord_gateway_state.Connect_requested
-            | Discord_gateway_state.Frame_parse_error _
-            | Discord_gateway_state.Wss_closed _
-            | Discord_gateway_state.Heartbeat_tick
-            | Discord_gateway_state.Heartbeat_ack_timeout
-            | Discord_gateway_state.Backoff_elapsed
-            | Discord_gateway_state.Status_change _ -> ());
-           Eio.Stream.add input_mailbox inp
-         | None -> ());
-        loop ()
+           if enqueue_if_current conn inp then begin
+             (* Side-channel: track heartbeat ACK arrival for I/O-layer
+                liveness detection.  The [when] guard avoids a fragile
+                catch-all on the [input] type — the state machine still
+                receives every input unchanged. *)
+             (match inp with
+              | Discord_gateway_state.Frame_received f
+                when f.op = Discord_gateway_state.Op_heartbeat_ack ->
+                Atomic.set heartbeat_ack_ok true
+              | Discord_gateway_state.Frame_received _
+              | Discord_gateway_state.Connect_requested
+              | Discord_gateway_state.Frame_parse_error _
+              | Discord_gateway_state.Wss_closed _
+              | Discord_gateway_state.Heartbeat_tick
+              | Discord_gateway_state.Heartbeat_ack_timeout
+              | Discord_gateway_state.Backoff_elapsed
+              | Discord_gateway_state.Status_change _ -> ());
+             if reader_should_continue_after_input inp then loop ()
+           end
+         | None -> loop ())
     in
     loop ()
   in
@@ -250,9 +291,9 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
          resolves the inner session switch's close-signal promise,
          which lets that switch return, which cancels reader/writer
          fibers and releases the socket + TLS flow. The reader's
-         pending read raises Cancelled; our reader_loop exception
-         arm pushes a redundant Wss_closed input that the state
-         machine no-ops because it is already in Reconnect_pending. *)
+         pending read raises Cancelled; reader_loop treats cancellation
+         as terminal so a stale reader cannot enqueue a late Wss_closed
+         for the next connection. *)
       Discord_observability.record_gateway_close ~code;
       (match !conn_ref with
        | Some c -> Discord_wss_connection.close c

--- a/lib/gate/discord_gateway_client.mli
+++ b/lib/gate/discord_gateway_client.mli
@@ -115,3 +115,8 @@ val set_presence : Discord_gateway_state.presence_status -> unit
     the request is logged and dropped.
 
     Thread-safe: may be called from any fiber. *)
+
+module For_testing : sig
+  val reader_should_continue_after_input :
+    Discord_gateway_state.input -> bool
+end

--- a/test/dune
+++ b/test/dune
@@ -1317,6 +1317,8 @@
 
 (include stanzas/test_discord_gateway_state.inc)
 
+(include stanzas/test_discord_gateway_client.inc)
+
 (include stanzas/test_discord_presence_bridge.inc)
 
 (include stanzas/test_discord_observability.inc)

--- a/test/stanzas/test_discord_gateway_client.inc
+++ b/test/stanzas/test_discord_gateway_client.inc
@@ -1,0 +1,5 @@
+; Focused I/O-layer policy tests for Discord_gateway_client.
+(test
+ (name test_discord_gateway_client)
+ (modules test_discord_gateway_client)
+ (libraries alcotest yojson masc.gate))

--- a/test/test_discord_gateway_client.ml
+++ b/test/test_discord_gateway_client.ml
@@ -1,0 +1,47 @@
+open Alcotest
+
+module Client = Discord_gateway_client
+module State = Discord_gateway_state
+
+let dummy_frame : State.frame =
+  { op = State.Op_hello
+  ; s = None
+  ; t = None
+  ; d = `Assoc [ ("heartbeat_interval", `Int 41_250) ]
+  }
+
+let check_continue label input expected =
+  check bool label expected
+    (Client.For_testing.reader_should_continue_after_input input)
+
+let test_reader_stops_after_close_input () =
+  check_continue "close input stops reader"
+    (State.Wss_closed { code = 1000; reason = "remote close" })
+    false
+
+let test_reader_continues_after_non_close_inputs () =
+  let cases =
+    [ "connect", State.Connect_requested
+    ; "frame", State.Frame_received dummy_frame
+    ; "parse_error", State.Frame_parse_error "bad json"
+    ; "heartbeat_tick", State.Heartbeat_tick
+    ; "heartbeat_ack_timeout", State.Heartbeat_ack_timeout
+    ; "backoff_elapsed", State.Backoff_elapsed
+    ; "status_change", State.Status_change State.Online
+    ]
+  in
+  List.iter
+    (fun (label, input) -> check_continue label input true)
+    cases
+
+let () =
+  run "discord_gateway_client"
+    [
+      ( "reader_policy"
+      , [
+          test_case "stops after WSS close input" `Quick
+            test_reader_stops_after_close_input
+        ; test_case "continues after non-close inputs" `Quick
+            test_reader_continues_after_non_close_inputs
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- guard Discord gateway reader inputs with the active WSS connection identity before enqueueing them into the FSM mailbox
- stop a reader after a WSS close input so the same remote close does not enqueue a follow-up EOF as a second close event
- treat reader cancellation as terminal, avoiding late Wss_closed events after Close_wss clears conn_ref
- add focused reader-policy tests for close vs non-close inputs

## Why
Process inspection of the live runtime showed high CPU spikes with many Discord/Cloudflare :443 sockets in CLOSE_WAIT plus repeated gateway READY / remote close / invalid_session / identify logs. The likely race is an old reader enqueueing a late EOF or frame after a reconnect has already opened a newer WSS; without connection identity, the FSM can interpret that stale input as belonging to the current connection and close the new session.

## Validation
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/gate/discord_gateway_client.ml test/test_discord_gateway_client.exe test/test_discord_gateway_state.exe bin/main_eio.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec test/test_discord_gateway_client.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec test/test_discord_gateway_state.exe
- git diff --check

## Live verification
- Restarted local live tmux runtime from combined CPU-fix worktree HEAD 49c8eaf1f, which includes this fix plus PR #21255.
- /health?full=1 reports commit 49c8eaf1f, repo_root=/Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/live-cpu-fixes-20260616, websocket mode=standalone.
- Post-restart sample showed the process mostly idle in camlIomux__Poll/poll, not in a Discord reconnect hot loop.
- lsof showed one Discord Gateway :443 ESTABLISHED socket and no Discord CLOSE_WAIT buildup.