### PR TITLE
fix(runtime): reject unknown thinking-control-format instead of silent downgrade (RFC-0089)

### DIFF
--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -301,25 +301,31 @@ let parse_providers (toml : Otoml.t)
 (* --- Layer 2: Models --- *)
 
 let parse_thinking_control_format ~(path : string) (raw : string)
-  : Runtime_schema.thinking_control_format
+  : (Runtime_schema.thinking_control_format, parse_error list) result
   =
   match String.lowercase_ascii (String.trim raw) with
   | "" | "none" | "no-thinking-control" | "no_thinking_control" ->
-    Runtime_schema.No_thinking_control
-  | "thinking-object" | "thinking_object" -> Runtime_schema.Thinking_object
-  | "chat-template-kwargs" | "chat_template_kwargs" -> Runtime_schema.Chat_template_kwargs
-  | "chat-template-token" | "chat_template_token" -> Runtime_schema.Chat_template_token
-  | "reasoning-effort" | "reasoning_effort" -> Runtime_schema.Reasoning_effort
+    Ok Runtime_schema.No_thinking_control
+  | "thinking-object" | "thinking_object" -> Ok Runtime_schema.Thinking_object
+  | "chat-template-kwargs" | "chat_template_kwargs" -> Ok Runtime_schema.Chat_template_kwargs
+  | "chat-template-token" | "chat_template_token" -> Ok Runtime_schema.Chat_template_token
+  | "reasoning-effort" | "reasoning_effort" -> Ok Runtime_schema.Reasoning_effort
   | other ->
-    Log.Runtime.warn "runtime_toml: %s.capabilities.thinking-control-format = %S — expected one of \
-         none|thinking-object|chat-template-kwargs|chat-template-token|reasoning-effort, defaulting to none"
-        path
-        other;
-    Runtime_schema.No_thinking_control
+    (* Unknown enum members fail the load, mirroring how this parser already
+       rejects unknown protocols / credential types. A silent downgrade to
+       No_thinking_control hid config typos that disable thinking control for a
+       model that needs it. *)
+    Error
+      (error
+         (path ^ ".thinking-control-format")
+         (Printf.sprintf
+            "unknown thinking-control-format %S — expected one of \
+             none|thinking-object|chat-template-kwargs|chat-template-token|reasoning-effort"
+            other))
 ;;
 
 let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
-  : Runtime_schema.model_capabilities
+  : (Runtime_schema.model_capabilities, parse_error list) result
   =
   let b key = Otoml.find_or ~default:false tbl Otoml.get_boolean [ key ] in
   let b_default_true key = Otoml.find_or ~default:true tbl Otoml.get_boolean [ key ] in
@@ -334,32 +340,35 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
           n;
       None
   in
-  let thinking_control_format =
+  let thinking_control_format_result =
     match Otoml.find_opt tbl Otoml.get_string [ "thinking-control-format" ] with
-    | None -> Runtime_schema.No_thinking_control
+    | None -> Ok Runtime_schema.No_thinking_control
     | Some raw -> parse_thinking_control_format ~path raw
   in
-  { Runtime_schema.max_output_tokens = positive_int_opt_field "max-output-tokens"
-  ; supports_tool_choice = b "supports-tool-choice"
-  ; supports_extended_thinking = b "supports-extended-thinking"
-  ; supports_reasoning_budget = b "supports-reasoning-budget"
-  ; thinking_control_format
-  ; supports_image_input = b "supports-image-input"
-  ; supports_audio_input = b "supports-audio-input"
-  ; supports_video_input = b "supports-video-input"
-  ; supports_multimodal_inputs = b "supports-multimodal-inputs"
-  ; supports_response_format_json = b "supports-response-format-json"
-  ; supports_structured_output = b "supports-structured-output"
-  ; supports_native_streaming = b "supports-native-streaming"
-  ; supports_caching = b "supports-caching"
-  ; supports_prompt_caching = b "supports-prompt-caching"
-  ; prompt_cache_alignment = positive_int_opt_field "prompt-cache-alignment"
-  ; supports_top_k = b "supports-top-k"
-  ; supports_min_p = b "supports-min-p"
-  ; supports_seed = b "supports-seed"
-  ; emits_usage_tokens = b_default_true "emits-usage-tokens"
-  ; supports_computer_use = b "supports-computer-use"
-  }
+  Result.map
+    (fun thinking_control_format ->
+      { Runtime_schema.max_output_tokens = positive_int_opt_field "max-output-tokens"
+      ; supports_tool_choice = b "supports-tool-choice"
+      ; supports_extended_thinking = b "supports-extended-thinking"
+      ; supports_reasoning_budget = b "supports-reasoning-budget"
+      ; thinking_control_format
+      ; supports_image_input = b "supports-image-input"
+      ; supports_audio_input = b "supports-audio-input"
+      ; supports_video_input = b "supports-video-input"
+      ; supports_multimodal_inputs = b "supports-multimodal-inputs"
+      ; supports_response_format_json = b "supports-response-format-json"
+      ; supports_structured_output = b "supports-structured-output"
+      ; supports_native_streaming = b "supports-native-streaming"
+      ; supports_caching = b "supports-caching"
+      ; supports_prompt_caching = b "supports-prompt-caching"
+      ; prompt_cache_alignment = positive_int_opt_field "prompt-cache-alignment"
+      ; supports_top_k = b "supports-top-k"
+      ; supports_min_p = b "supports-min-p"
+      ; supports_seed = b "supports-seed"
+      ; emits_usage_tokens = b_default_true "emits-usage-tokens"
+      ; supports_computer_use = b "supports-computer-use"
+      })
+    thinking_control_format_result
 ;;
 
 let parse_model (id : string) (tbl : Otoml.t)
@@ -391,9 +400,11 @@ let parse_model (id : string) (tbl : Otoml.t)
       Otoml.find_opt tbl Otoml.get_integer [ "max-thinking-budget" ]
     in
     let streaming = Otoml.find_or ~default:true tbl Otoml.get_boolean [ "streaming" ] in
-    let capabilities =
-      Otoml.find_opt tbl Fun.id [ "capabilities" ]
-      |> Option.map (parse_model_capabilities ~path:(path ^ ".capabilities"))
+    let capabilities_result =
+      match Otoml.find_opt tbl Fun.id [ "capabilities" ] with
+      | None -> Ok None
+      | Some t ->
+        Result.map Option.some (parse_model_capabilities ~path:(path ^ ".capabilities") t)
     in
     let match_prefixes =
       match Otoml.find_opt tbl Fun.id [ "match-prefixes" ] with
@@ -416,18 +427,20 @@ let parse_model (id : string) (tbl : Otoml.t)
            Log.Runtime.warn "runtime_toml: %s.match-prefixes — expected string array, ignoring" path;
            [])
     in
-    Ok
-      { Runtime_schema.id
-      ; api_name
-      ; tools_support
-      ; max_context
-      ; thinking_support
-      ; preserve_thinking
-      ; max_thinking_budget
-      ; streaming
-      ; capabilities
-      ; match_prefixes
-      })
+    Result.map
+      (fun capabilities ->
+        { Runtime_schema.id
+        ; api_name
+        ; tools_support
+        ; max_context
+        ; thinking_support
+        ; preserve_thinking
+        ; max_thinking_budget
+        ; streaming
+        ; capabilities
+        ; match_prefixes
+        })
+      capabilities_result)
 ;;
 
 let parse_models (toml : Otoml.t)

--- a/test/dune
+++ b/test/dune
@@ -1341,6 +1341,8 @@
 
 (include stanzas/test_nickname_words_ssot.inc)
 
+(include stanzas/test_thinking_control_format_unknown_error.inc)
+
 (include stanzas/test_workspace_bootstrap.inc)
 
 (include stanzas/test_workspace_base_path_cache.inc)

--- a/test/stanzas/test_thinking_control_format_unknown_error.inc
+++ b/test/stanzas/test_thinking_control_format_unknown_error.inc
@@ -1,0 +1,8 @@
+; Per-file dune stanza for the thinking-control-format unknown->Error suite
+; (RFC-0089). Lives here per test/stanzas/README.md to avoid the
+; conflict-runtime hotspot in the legacy grouped (tests ...) stanza.
+
+(test
+ (name test_thinking_control_format_unknown_error)
+ (modules test_thinking_control_format_unknown_error)
+ (libraries masc.runtime alcotest))

--- a/test/test_thinking_control_format_unknown_error.ml
+++ b/test/test_thinking_control_format_unknown_error.ml
@@ -1,0 +1,53 @@
+(* RFC-0089 — runtime.toml thinking-control-format is a closed enum. An unknown
+   value now fails the whole config load (Error), mirroring how this parser
+   already rejects unknown protocols / credential types, instead of silently
+   downgrading to No_thinking_control (which hid config typos that disable
+   thinking control for a model that needs it).
+
+   Driven through the public [parse_string] entry. The valid and invalid TOMLs
+   differ only in the thinking-control-format value, isolating it as the cause
+   of the load failure. *)
+
+open Alcotest
+
+let toml_with_tcf tcf =
+  Printf.sprintf
+    {|[models.m]
+max-context = 1000
+
+[models.m.capabilities]
+thinking-control-format = "%s"
+|}
+    tcf
+
+let model_without_capabilities = {|[models.m]
+max-context = 1000
+|}
+
+let is_error = function Ok _ -> false | Error _ -> true
+let is_ok = function Ok _ -> true | Error _ -> false
+
+let test_valid_value_loads () =
+  check bool "valid thinking-control-format loads" true
+    (is_ok (Runtime_toml.parse_string (toml_with_tcf "reasoning-effort")))
+
+let test_unknown_value_fails_load () =
+  check bool "unknown thinking-control-format fails the load (Error)" true
+    (is_error (Runtime_toml.parse_string (toml_with_tcf "bogus-format")))
+
+let test_absent_capabilities_loads () =
+  (* No capabilities table at all is fine — absence defaults to no control. *)
+  check bool "model without a capabilities table loads" true
+    (is_ok (Runtime_toml.parse_string model_without_capabilities))
+
+let () =
+  run "thinking_control_format_unknown_error"
+    [
+      ( "parse_string",
+        [
+          test_case "valid value loads" `Quick test_valid_value_loads;
+          test_case "unknown value fails load" `Quick test_unknown_value_fails_load;
+          test_case "absent capabilities loads" `Quick
+            test_absent_capabilities_loads;
+        ] );
+    ]


### PR DESCRIPTION
## 목적
`runtime.toml`의 `[models.*.capabilities].thinking-control-format`(닫힌 enum)에 **알 수 없는 값이 오면 silent downgrade 대신 load 실패(Error)** 하도록 합니다 (RFC-0089, typed-harness 캠페인 P2 "unknown→Error").

## 배경
기존 `parse_thinking_control_format`는 미인식 값을 WARN 로그 후 `No_thinking_control`로 조용히 매핑했습니다 → config 오타가 숨겨짐: thinking control이 필요한 모델이 조용히 control 없이 실행. 이 파서는 이미 다른 unknown enum(protocol, credential type)을 모두 **Error로 load 실패** 처리하는데, 이 필드만 유일한 permissive 예외였습니다 (CLAUDE.md AI 안티패턴 #2 "Unknown→Permissive Default").

## 변경 (parse-don't-validate)
- `parse_thinking_control_format` → `result` 반환. unknown 값은 `parse_error` 생성.
- `parse_model_capabilities`/`parse_model`이 result를 전파 → unknown 값이 `parse_model`의 error accumulation에 합류해 **전체 load 실패**(`partition_results`가 하나라도 실패하면 Error = 파일의 fail-fast 설계와 일치).
- 세 함수 모두 파일 내부 전용(.mli 미노출) → **public 시그니처 변경 없음, cascade 봉쇄**.
- 정상 값·capabilities 테이블 부재는 영향 없음.

## 검증
- `dune build --root . @check` exit 0 (전체 코드베이스, cascade 무파손).
- 신규 test 3 (public `parse_string` 경유 end-to-end: 정상값 load / unknown값 load 실패 / capabilities 부재 load — 정상·unknown TOML은 tcf 값만 달라 원인 격리).

## 동작 변경 주의
오타난 `thinking-control-format`을 가진 runtime.toml은 이제 **load에 실패**합니다(기존엔 경고 후 무시). 의도된 fail-fast이며, 오너의 "config/TOML SSOT + fail-fast" 선호 및 파일의 unknown-enum 컨벤션과 일치.

RFC-WAIVED: runtime.toml 파서의 unknown-enum 처리 일관성 회복(silent downgrade 제거). credential/operator_control/sandbox/hooks/workflow RFC-게이트 표면과 무관(config 값 검증 강화일 뿐, 정책/스키마 변경 아님). 패턴 umbrella는 RFC-0089(String Classifier to Typed Variant — 본 건은 그 unknown→Error 변형).
WORKAROUND-WAIVED: permissive-default 워크어라운드를 *제거*하고 typed Error로 대체합니다(symptom 억제 추가 아님). 게이트 시그니처는 false-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
