### PR TITLE
fix(keeper): keep operator pauses durable

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -105,6 +105,16 @@ let persist_directive_meta_update
     Keeper_registry.update_meta ~base_path:entry.base_path entry.name updated_meta
 ;;
 
+let directive_paused_meta (meta : keeper_meta) paused =
+  {
+    meta with
+    paused;
+    auto_resume_after_sec = None;
+    runtime = { meta.runtime with last_blocker = None };
+    updated_at = now_iso ();
+  }
+;;
+
 let set_keeper_paused_state ~agent_name paused =
   with_keeper_entry_by_identity
     ~identity:agent_name
@@ -116,7 +126,7 @@ let set_keeper_paused_state ~agent_name paused =
         ();
       Log.Keeper.warn "directive %s: agent %s not in registry" action agent_name)
     (fun entry ->
-       let updated_meta = { entry.meta with paused; updated_at = now_iso () } in
+       let updated_meta = directive_paused_meta entry.meta paused in
        persist_directive_meta_update entry ~updated_meta;
        Keeper_registry.dispatch_event_unit
          ~base_path:entry.base_path

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -356,6 +356,12 @@ let board_signal_entry_is_wakeup_candidate (entry : Keeper_registry.registry_ent
   | _ -> false
 ;;
 
+let paused_meta_allows_board_auto_resume (meta : keeper_meta) =
+  meta.paused
+  && Option.is_some
+       (Keeper_supervisor_types.paused_meta_effective_auto_resume_after_sec meta)
+;;
+
 let board_signal_wake_paused_keeper
       ~(config : Workspace.config)
       ~(stimulus : Keeper_event_queue.stimulus)
@@ -396,7 +402,10 @@ let board_signal_wake_keeper
   =
   let stimulus = board_signal_stimulus ~reason signal in
   if meta.paused
-  then board_signal_wake_paused_keeper ~config ~stimulus meta
+  then
+    if paused_meta_allows_board_auto_resume meta
+    then board_signal_wake_paused_keeper ~config ~stimulus meta
+    else Ok ()
   else (
     wakeup_keeper ~base_path:config.base_path ~stimulus meta.name;
     Ok ())
@@ -448,7 +457,8 @@ let wakeup_relevant_keeper_for_board_signal
                ()
            | None, _ | Some _, _ -> ());
           (match entry.phase, wake_reason with
-           | Keeper_state_machine.Paused, Some Board_wake.Explicit_mention ->
+           | Keeper_state_machine.Paused, Some Board_wake.Explicit_mention
+             when paused_meta_allows_board_auto_resume meta ->
              Some (meta, wake_reason)
            | Keeper_state_machine.Paused, _ -> None
            | Keeper_state_machine.Running, _ -> Some (meta, wake_reason)

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -171,6 +171,11 @@ val board_reactive_wakeup_allowed :
   -> signal:Board_dispatch.board_signal
   -> bool
 
+(** True when a paused keeper may be resumed by board-reactive wakeup.
+    Operator-owned pauses have [auto_resume_after_sec = None] and are not
+    resumed implicitly by board posts or comments. *)
+val paused_meta_allows_board_auto_resume : keeper_meta -> bool
+
 (** Select which keepers wake for a board signal (RFC-0020). Explicit mentions
     short-circuit and wake unconditionally (returned with [dropped = 0]); other
     typed reasons compete for [?total_limit] slots in candidate order. [None]

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -479,6 +479,8 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
                 {
                   meta with
                   paused;
+                  auto_resume_after_sec = None;
+                  runtime = { meta.runtime with last_blocker = None };
                   updated_at = Keeper_meta_contract.now_iso ();
                 }
               in
@@ -677,6 +679,8 @@ let handle_keeper_bulk_directive_post state _agent_name req reqd body_str =
                    {
                      meta with
                      paused = target;
+                     auto_resume_after_sec = None;
+                     runtime = { meta.runtime with last_blocker = None };
                      updated_at = Keeper_meta_contract.now_iso ();
                    }
                  in

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -209,6 +209,36 @@ module KWOBS = Masc.Keeper_world_observation_board_signal
 let reason_label = KWOBS.wake_reason_label
 let labeled selected = List.map (fun (item, r) -> item, reason_label r) selected
 
+let make_board_resume_meta ?(paused = false) ?auto_resume_after_sec name =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("keeper-" ^ name));
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "test");
+        ("sandbox_profile", `String "local");
+        ("network_mode", `String "inherit");
+        ("tool_access", `List []);
+      ]
+  in
+  match Keeper_meta_json_parse.meta_of_json json with
+  | Error err -> fail ("meta_of_json failed: " ^ err)
+  | Ok meta -> { meta with paused; auto_resume_after_sec }
+
+let test_board_auto_resume_rejects_operator_pause () =
+  let meta = make_board_resume_meta ~paused:true "operator-paused" in
+  check bool "operator pause is not board-auto-resumable" false
+    (KKS.paused_meta_allows_board_auto_resume meta)
+
+let test_board_auto_resume_allows_auto_paused_keeper () =
+  let meta =
+    make_board_resume_meta ~paused:true ~auto_resume_after_sec:3600.0
+      "auto-paused"
+  in
+  check bool "auto-paused keeper is board-auto-resumable" true
+    (KKS.paused_meta_allows_board_auto_resume meta)
+
 let test_board_wakeup_selection_keeps_explicit_mentions () =
   let selected, dropped =
     KKS.select_board_wakeup_candidates
@@ -399,6 +429,10 @@ let () =
         `Quick test_board_wakeup_selection_drops_none_reasons;
       test_case "total non-explicit fanout is capped"
         `Quick test_board_wakeup_selection_caps_total_non_explicit;
+      test_case "operator pauses are not board-auto-resumed"
+        `Quick test_board_auto_resume_rejects_operator_pause;
+      test_case "auto-paused keepers can be board-auto-resumed"
+        `Quick test_board_auto_resume_allows_auto_paused_keeper;
     ];
     "missed_wakeup_gap", [
       test_case "Skip_idle + Woken -> resumes (MissedWakeup spec gap)"


### PR DESCRIPTION
## Summary
- prevent board-reactive wakeups from auto-resuming operator-owned paused keepers
- make operator pause/resume directives clear auto-resume timers and stale blockers
- add regression coverage for board auto-resume eligibility

## Runtime evidence
- process inspection showed live PID 13655 no longer had Discord CLOSE_WAIT buildup after the stale reader fix
- remaining CPU spikes correlate with active keeper/autoboot work, and bulk pause was not durable because board signals could flip paused keepers back to active

## Validation
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_smart_heartbeat_keepalive.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec test/test_smart_heartbeat_keepalive.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/server/server_dashboard_http_keeper_api_post.ml
- git diff --check