### PR TITLE
fix(keeper): suppress no-target broadcast wake fanout

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -160,6 +160,10 @@ let trimmed_env_opt name =
 
 let discord_bot_token_opt () = trimmed_env_opt "DISCORD_BOT_TOKEN"
 
+let broadcast_mention_wakeup_action = function
+  | Some target when String.trim target <> "" -> `Wake_keeper target
+  | Some _ | None -> `Suppress_no_target
+
 module For_testing = struct
   type queued_chat_projection = {
     payload_channel : string;
@@ -171,6 +175,7 @@ module For_testing = struct
 
   let autoboot_proactive_warmup_sec = autoboot_proactive_warmup_sec
   let board_sse_event_params = board_sse_event_params
+  let broadcast_mention_wakeup_action = broadcast_mention_wakeup_action
 
   let queued_chat_projection queued_message : queued_chat_projection =
     let projection = queued_chat_projection queued_message in
@@ -542,18 +547,19 @@ let start_keeper_loops
         "board: Activity_graph.emit kind=%s failed: %s"
         activity_kind
         (Printexc.to_string exn));
-  (* Wire broadcast → keeper wakeup: any broadcast wakes keepers so they
-     can react to new tasks, mentions, or workspace activity immediately.
-     SSOT: Workspace_broadcast.on_broadcast_mention is the single ref wired here. *)
+  (* Wire broadcast -> keeper wakeup. Explicit mentions wake the target
+     keeper immediately; unmentioned broadcasts remain passive SSE/message
+     fanout so one broad announcement cannot create a fleet-wide turn storm.
+     Board signals have their own capped keeper wake path above. *)
   let broadcast_mention_handler =
     fun mention ->
-    match mention with
-    | Some target ->
+    match broadcast_mention_wakeup_action mention with
+    | `Wake_keeper target ->
       Keeper_keepalive.wakeup_keeper ~base_path:(Mcp_server.workspace_config state).base_path target;
       Log.Keeper.info "broadcast mention → wakeup keeper %s" target
-    | None ->
-      Keeper_keepalive.wakeup_all_keepers ~base_path:(Mcp_server.workspace_config state).base_path ();
-      Log.Keeper.info "broadcast → wakeup all keepers (reactive push)"
+    | `Suppress_no_target ->
+      Log.Keeper.info
+        "broadcast without mention -> keeper wakeup suppressed (passive fanout)"
   in
   Workspace_broadcast.on_broadcast_mention := broadcast_mention_handler;
   (* Orchestrator needs synchronous registration for shutdown hook *)

--- a/lib/server/server_bootstrap_loops.mli
+++ b/lib/server/server_bootstrap_loops.mli
@@ -38,6 +38,9 @@ module For_testing : sig
 
   val board_sse_event_params : Board_dispatch.board_sse_event -> Yojson.Safe.t
 
+  val broadcast_mention_wakeup_action :
+    string option -> [ `Suppress_no_target | `Wake_keeper of string ]
+
   val queued_chat_projection :
     Keeper_chat_queue.queued_message -> queued_chat_projection
 end

--- a/test/dune
+++ b/test/dune
@@ -30,6 +30,7 @@
 (tests
  (names
   test_keeper_reactive_wake_backlog_gate
+  test_broadcast_wakeup_policy
   test_keeper_mention_scope
   test_keeper_lane_mentions
   test_surface_ref
@@ -311,6 +312,7 @@
  (modules
   test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate
+  test_broadcast_wakeup_policy
   test_keeper_mention_scope
   test_keeper_lane_mentions
   test_surface_ref

--- a/test/test_broadcast_wakeup_policy.ml
+++ b/test/test_broadcast_wakeup_policy.ml
@@ -1,0 +1,31 @@
+open Alcotest
+
+module Broadcast_wakeup = Server_bootstrap_loops.For_testing
+
+let test_mention_wakes_target () =
+  match Broadcast_wakeup.broadcast_mention_wakeup_action (Some "rondo") with
+  | `Wake_keeper "rondo" -> ()
+  | `Wake_keeper other -> failf "unexpected wake target: %s" other
+  | `Suppress_no_target -> fail "expected explicit mention to wake target"
+
+let test_none_is_passive () =
+  match Broadcast_wakeup.broadcast_mention_wakeup_action None with
+  | `Suppress_no_target -> ()
+  | `Wake_keeper target -> failf "unexpected no-target wake: %s" target
+
+let test_blank_is_passive () =
+  match Broadcast_wakeup.broadcast_mention_wakeup_action (Some "  ") with
+  | `Suppress_no_target -> ()
+  | `Wake_keeper target -> failf "unexpected blank-target wake: %s" target
+
+let () =
+  run
+    "broadcast_wakeup_policy"
+    [
+      ( "mention_policy"
+      , [
+          test_case "explicit mention wakes target" `Quick test_mention_wakes_target
+        ; test_case "no mention is passive" `Quick test_none_is_passive
+        ; test_case "blank mention is passive" `Quick test_blank_is_passive
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- suppress keeper wakeups for broadcast messages without an explicit mention
- preserve passive SSE/message fanout for untargeted broadcasts
- add regression coverage for explicit, blank, and absent mention cases

## Validation
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_broadcast_wakeup_policy.exe bin/main_eio.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec test/test_broadcast_wakeup_policy.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec test/test_keeper_reactive_wake_backlog_gate.exe
- git diff --check

## Note
- supersedes closed, unmerged #21255 from the same change set