### PR TITLE
feat(dashboard): keeper-workspace 레일에 rich 최근 도구 호출

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -5,6 +5,22 @@ import { tasks } from '../../store'
 import { KeeperWorkspaceRail } from './keeper-workspace-rail'
 import type { Keeper, Task } from '../../types'
 
+// The recent-tool-calls section now lazy-loads via fetchKeeperToolCalls (rather
+// than rendering keeper.recent_tool_names). Stub it so these rail tests never hit
+// the network; its rendering is covered directly in keeper-workspace-tool-calls.test.ts.
+vi.mock('../../api/dashboard', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/dashboard')>()
+  return {
+    ...actual,
+    fetchKeeperToolCalls: vi.fn().mockResolvedValue({
+      keeper: 'masc-improver',
+      count: 0,
+      source: 'tool_call_io',
+      entries: [],
+    }),
+  }
+})
+
 function mkKeeper(partial: Partial<Keeper>): Keeper {
   return { name: 'masc-improver', status: 'running', ...partial } as Keeper
 }
@@ -57,12 +73,6 @@ describe('KeeperWorkspaceRail', () => {
     render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
     expect(host.textContent).toContain('T-4412')
     expect(host.textContent).not.toContain('T-9999')
-  })
-
-  it('renders recent tool calls', () => {
-    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
-    expect(host.textContent).toContain('최근 도구 호출')
-    expect(host.textContent).toContain('masc_amplitude_query')
   })
 
   it('renders the attention section from live blocked-task signal', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -1,13 +1,15 @@
 // Keeper Workspace — context rail (right). Runtime/throughput, context-window
 // occupancy, owned tasks, recent tool calls, and the "상세 보기" toggle that
-// surfaces the full KeeperDetailBody. All data comes from the live Keeper
-// object + the tasks store — no new fetches.
+// surfaces the full KeeperDetailBody. Most data comes from the live Keeper
+// object + the tasks store; the recent-tool-calls section lazy-loads the rich
+// per-call store (see keeper-workspace-tool-calls.ts).
 
 import { html } from 'htm/preact'
 import type { VNode } from 'preact'
 import { tasks } from '../../store'
 import type { Keeper, Task } from '../../types'
 import { keeperModelLabel, keeperRuntimeLabel } from './keeper-workspace-shared'
+import { KeeperWorkspaceRecentTools } from './keeper-workspace-tool-calls'
 
 const COMPACT_AT = 85 // auto-compaction threshold (%) — matches runtime default
 
@@ -156,24 +158,6 @@ function OwnedTasksSection({ keeper }: { keeper: Keeper }): VNode {
   `
 }
 
-function RecentToolsSection({ keeper }: { keeper: Keeper }): VNode | null {
-  const names = (keeper.recent_tool_names ?? keeper.latest_tool_names ?? []).slice(0, 8)
-  if (names.length === 0) return null
-  return html`
-    <div class="kw-sec">
-      <h4>최근 도구 호출</h4>
-      <div class="kw-list">
-        ${names.map((n, i) => html`
-          <div class="kw-tool" key=${`${n}-${i}`}>
-            <span class="kw-dot ok" aria-hidden="true"></span>
-            <span class="nm" title=${n}>${n}</span>
-          </div>
-        `)}
-      </div>
-    </div>
-  `
-}
-
 export function KeeperWorkspaceRail({
   keeper,
   onToggleDetail,
@@ -188,7 +172,7 @@ export function KeeperWorkspaceRail({
         <${ThroughputSection} keeper=${keeper} />
         <${ContextSection} keeper=${keeper} />
         <${OwnedTasksSection} keeper=${keeper} />
-        <${RecentToolsSection} keeper=${keeper} />
+        <${KeeperWorkspaceRecentTools} keeperName=${keeper.name} />
         <div class="kw-sec">
           <button type="button" class="kw-detail-btn" onClick=${onToggleDetail}>
             <span>상세 보기</span>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-tool-calls.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-tool-calls.test.ts
@@ -1,0 +1,77 @@
+import { render } from 'preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import { html } from 'htm/preact'
+import { RecentToolList, toolCallRowKey } from './keeper-workspace-tool-calls'
+import type { ToolCallEntry } from '../../api/dashboard'
+
+function entry(partial: Partial<ToolCallEntry>): ToolCallEntry {
+  return {
+    ts: 1_700_000_000_000,
+    keeper: 'analyst',
+    tool: 'masc_status',
+    input: {},
+    output: '',
+    success: true,
+    duration_ms: 120,
+    ...partial,
+  }
+}
+
+describe('toolCallRowKey', () => {
+  it('disambiguates same-tool retries by ts + turn', () => {
+    const a = entry({ tool: 'masc_status', ts: 1, turn: 1 })
+    const b = entry({ tool: 'masc_status', ts: 1, turn: 2 })
+    expect(toolCallRowKey(a)).not.toBe(toolCallRowKey(b))
+  })
+})
+
+describe('RecentToolList', () => {
+  let host: HTMLElement
+  afterEach(() => {
+    if (host) render(null, host)
+  })
+
+  function mount(entries: ToolCallEntry[], expandedKey: string | null = null) {
+    host = document.createElement('div')
+    render(
+      html`<${RecentToolList} entries=${entries} expandedKey=${expandedKey} onToggle=${() => {}} />`,
+      host,
+    )
+    return host
+  }
+
+  it('renders the tool name and duration for each call', () => {
+    mount([entry({ tool: 'masc_board_post', duration_ms: 1500 })])
+    const name = host.querySelector('.kw-toolcall-head .nm') as HTMLElement
+    expect(name.textContent).toBe('masc_board_post')
+    const dur = host.querySelector('.kw-toolcall-head .dur') as HTMLElement
+    // formatMsCompact renders ms/s — assert it produced a non-empty duration.
+    expect(dur.textContent?.trim().length).toBeGreaterThan(0)
+  })
+
+  it('flags a failed call with the bad status dot (not a green ok dot)', () => {
+    mount([entry({ tool: 'masc_done', success: false })])
+    expect(host.querySelector('.kw-toolcall-head .kw-dot.bad')).toBeTruthy()
+    expect(host.querySelector('.kw-toolcall-head .kw-dot.ok')).toBeFalsy()
+  })
+
+  it('uses the ok dot for a successful call', () => {
+    mount([entry({ success: true })])
+    expect(host.querySelector('.kw-toolcall-head .kw-dot.ok')).toBeTruthy()
+  })
+
+  it('shows input/output only for the expanded row', () => {
+    const e = entry({ tool: 'masc_status', input: { scope: 'fleet' }, output: 'done-ok' })
+    const key = toolCallRowKey(e)
+    // collapsed: no body
+    mount([e], null)
+    expect(host.querySelector('.kw-toolcall-body')).toBeFalsy()
+    render(null, host)
+    // expanded: body shows input + output text
+    mount([e], key)
+    const body = host.querySelector('.kw-toolcall-body') as HTMLElement
+    expect(body).toBeTruthy()
+    expect(body.textContent).toContain('fleet')
+    expect(body.textContent).toContain('done-ok')
+  })
+})

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-tool-calls.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-tool-calls.ts
@@ -1,0 +1,135 @@
+// Keeper Workspace — rich recent-tool-calls section for the context rail.
+//
+// The rail previously rendered keeper.recent_tool_names (a flat string[] from
+// the keeper snapshot) with a hardcoded "ok" dot — no status, duration, age, or
+// args/result. The richer per-call data already exists server-side: the durable
+// tool-call store is served by GET /api/v1/keepers/:name/tool-calls and decoded
+// by fetchKeeperToolCalls -> ToolCallEntry. This section lazy-loads that for the
+// selected keeper (one fetch per selection, refreshed on tool-activity SSE) and
+// renders compact rows with a real success/failure dot, duration, relative age,
+// and click-to-expand input/output. No backend change — pure consumption.
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+import { useCallback, useEffect } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+import { fetchKeeperToolCalls } from '../../api/dashboard'
+import type { ToolCallEntry, ToolCallsResponse } from '../../api/dashboard'
+import { useManagedAsyncResource } from '../../lib/use-managed-async-resource'
+import { lastEvent } from '../../sse'
+import { isKeeperToolActivityEvent, sseEventMatchesKeeper } from '../keeper-sse-match'
+import { formatMsCompact } from '../../lib/format-number'
+import { formatTimeAgo } from '../../lib/format-time'
+import { formatInput, formatOutput } from '../keeper-tool-call-inspector'
+import { StatusDot } from './keeper-workspace-shared'
+
+// Match the v2 rails RecentTool list length — a short tail, not full history.
+const RECENT_LIMIT = 10
+
+/** Stable identity for a tool-call row (ts + tool + turn disambiguates retries
+ *  within the same second). */
+export function toolCallRowKey(entry: ToolCallEntry): string {
+  return `${entry.ts}-${entry.tool}-${entry.turn ?? ''}`
+}
+
+/** Pure presentational list — newest first. Separated from the data loader so it
+ *  can be tested without mocking fetch/SSE. */
+export function RecentToolList({
+  entries,
+  expandedKey,
+  onToggle,
+}: {
+  entries: ToolCallEntry[]
+  expandedKey: string | null
+  onToggle: (key: string) => void
+}): VNode {
+  return html`
+    <div class="kw-list">
+      ${entries.map((e) => {
+        const key = toolCallRowKey(e)
+        const open = expandedKey === key
+        const tone = e.success ? 'ok' : 'bad'
+        return html`
+          <div class=${`kw-toolcall${open ? ' open' : ''}`} key=${key}>
+            <button
+              type="button"
+              class="kw-toolcall-head"
+              aria-expanded=${open ? 'true' : 'false'}
+              onClick=${() => onToggle(key)}
+            >
+              <${StatusDot} tone=${tone} pulse=${false} />
+              <span class="nm" title=${e.tool}>${e.tool}</span>
+              <span class="dur" title="지속시간">${formatMsCompact(e.duration_ms)}</span>
+              <span class="age" title="경과">${formatTimeAgo(e.ts)}</span>
+            </button>
+            ${open
+              ? html`
+                  <div class="kw-toolcall-body">
+                    <div class="kw-tc-block">
+                      <div class="kw-tc-lbl">입력</div>
+                      <pre>${formatInput(e.input)}</pre>
+                    </div>
+                    <div class="kw-tc-block">
+                      <div class="kw-tc-lbl">출력</div>
+                      <pre>${formatOutput(e.output)}</pre>
+                    </div>
+                  </div>
+                `
+              : null}
+          </div>
+        `
+      })}
+    </div>
+  `
+}
+
+/** Data loader + section wrapper. Returns null while empty so the section stays
+ *  hidden until the keeper has tool-call history (matches the old behavior of
+ *  omitting the section when there were no recent tool names). */
+export function KeeperWorkspaceRecentTools({ keeperName }: { keeperName: string }): VNode | null {
+  const resource = useManagedAsyncResource<ToolCallsResponse | null>(null)
+  const expandedKey = useSignal<string | null>(null)
+
+  const load = useCallback(
+    (signal: AbortSignal) => fetchKeeperToolCalls(keeperName, RECENT_LIMIT, { signal }),
+    [keeperName],
+  )
+
+  // External-system sync: load on keeper change, cancel in-flight on unmount.
+  useEffect(() => {
+    void resource.load(load)
+    return () => {
+      resource.cancel()
+    }
+  }, [load, resource])
+
+  // Refresh when this keeper emits a tool-activity event (same trigger the full
+  // inspector uses), so the rail stays current without polling.
+  useEffect(() => {
+    const unsubscribe = lastEvent.subscribe((event) => {
+      if (!event) return
+      if (!isKeeperToolActivityEvent(event)) return
+      if (!sseEventMatchesKeeper(event, keeperName)) return
+      void resource.load(load)
+    })
+    return () => {
+      unsubscribe()
+    }
+  }, [keeperName, load, resource])
+
+  const entries = (resource.state.value.data?.entries ?? []).slice(-RECENT_LIMIT).reverse()
+  if (entries.length === 0) return null
+
+  return html`
+    <div class="kw-sec">
+      <h4>최근 도구 호출</h4>
+      <${RecentToolList}
+        entries=${entries}
+        expandedKey=${expandedKey.value}
+        onToggle=${(key: string) => {
+          expandedKey.value = expandedKey.value === key ? null : key
+        }}
+      />
+    </div>
+  `
+}

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -255,8 +255,30 @@
 .kw-tasktag .tstate { font-size: 10px; flex: none; color: var(--color-fg-muted); }
 .kw-tasktag .tstate.review { color: var(--color-status-warn); }
 
-.kw-tool { display: flex; align-items: center; gap: 8px; font-size: 12.5px; color: var(--color-fg-secondary); }
-.kw-tool .nm { font-family: var(--font-mono); font-size: 12px; color: var(--color-fg-primary); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* Recent tool calls: compact rows (status dot + name + duration + age) that
+ * expand on click to reveal input/output. Replaces the old names-only .kw-tool. */
+.kw-toolcall { border-radius: var(--r-1); }
+.kw-toolcall.open { background: var(--color-bg-page); border: 1px solid var(--color-border-divider); }
+.kw-toolcall-head {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  padding: 3px 6px; border-radius: var(--r-1); cursor: pointer;
+  background: none; border: none; text-align: left; color: var(--color-fg-secondary);
+  font-size: 12.5px;
+}
+.kw-toolcall-head:hover { background: var(--color-bg-hover); }
+.kw-toolcall-head .nm { font-family: var(--font-mono); font-size: 12px; color: var(--color-fg-primary); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kw-toolcall-head .dur { font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-muted); flex: none; }
+.kw-toolcall-head .age { font-size: 10.5px; color: var(--color-fg-muted); flex: none; white-space: nowrap; }
+.kw-toolcall-body { padding: 4px 8px 8px; display: flex; flex-direction: column; gap: 6px; }
+.kw-tc-block { display: flex; flex-direction: column; gap: 2px; }
+.kw-tc-lbl { font-size: 10px; letter-spacing: 0.04em; color: var(--color-fg-muted); text-transform: uppercase; }
+.kw-tc-block pre {
+  margin: 0; max-height: 160px; overflow: auto;
+  font-family: var(--font-mono); font-size: 11px; line-height: 1.45;
+  color: var(--color-fg-secondary); white-space: pre-wrap; word-break: break-word;
+  background: var(--color-bg-surface); border: 1px solid var(--color-border-divider);
+  border-radius: var(--r-0); padding: 6px 8px;
+}
 
 .kw-detail-btn {
   width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 8px;


### PR DESCRIPTION
## 목적

keeper-workspace 컨텍스트 레일의 "최근 도구 호출" 섹션을 v2 RecentTool 수준으로 끌어올립니다. 기존엔 `keeper.recent_tool_names`(스냅샷의 flat `string[]`)를 **하드코딩 ok 점**으로만 표시 — 상태·지속시간·경과·args/result 전무.

## 핵심: 백엔드 변경 없음 (이미 존재)

rich per-call 데이터는 서버에 이미 있습니다 — 영속 store가 `GET /api/v1/keepers/:name/tool-calls`로 서빙되고 TS `fetchKeeperToolCalls → ToolCallEntry`(ts/tool/input/output/success/duration_ms)로 디코드됩니다. 이 PR은 그 데이터를 **소비**할 뿐입니다.

## 변경

- **신규 `keeper-workspace-tool-calls.ts`**: 선택된 키퍼의 tool-call store를 lazy-load(tool-activity SSE에 갱신 — 풀 인스펙터와 동일 트리거)하고 컴팩트 행 렌더:
  - 실제 성공/실패 `StatusDot` (기존 하드코딩 ok 제거)
  - `formatMsCompact` 지속시간, `formatTimeAgo` 경과
  - 클릭 시 input/output 확장 (`formatInput`/`formatOutput` 재사용)
- **`keeper-workspace-rail.ts`**: names-only `RecentToolsSection` + dead `.kw-tool` CSS 제거, `KeeperWorkspaceRecentTools`로 교체.
- **테스트**: `keeper-workspace-tool-calls.test.ts`(순수 리스트 — 이름·지속시간·ok/bad 점·확장), `keeper-workspace-rail.test.ts`는 `fetchKeeperToolCalls` 스텁.

## 검증

- `tsc --noEmit` exit 0, `eslint` exit 0
- vitest: keeper-workspace 4파일 34 통과 (신규 5 포함)
- `pnpm build` 통과
- CSS-only가 아니므로(`.ts` 포함) coverage 게이트 대비 테스트 동반

## 트레이드오프

레일 섹션이 스냅샷 동기 렌더 → 키퍼 선택 시 1회 fetch(지연 후 표시)로 바뀝니다. 데이터 없으면 섹션 숨김(기존 동작과 동일). args/result는 store 크기만큼 노출.

WORKAROUND-WAIVED: 기존 백엔드 store/엔드포인트의 직접 소비. telemetry-as-fix / string 분류기 / N-of-M / cap-cooldown-dedup-repair 시그니처 없음.
