### PR TITLE
fix(keeper): preserve operator pause on stale meta retry

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -105,6 +105,16 @@ let persist_directive_meta_update
     Keeper_registry.update_meta ~base_path:entry.base_path entry.name updated_meta
 ;;
 
+let directive_paused_meta (meta : keeper_meta) paused =
+  {
+    meta with
+    paused;
+    auto_resume_after_sec = None;
+    runtime = { meta.runtime with last_blocker = None };
+    updated_at = now_iso ();
+  }
+;;
+
 let set_keeper_paused_state ~agent_name paused =
   with_keeper_entry_by_identity
     ~identity:agent_name
@@ -116,7 +126,7 @@ let set_keeper_paused_state ~agent_name paused =
         ();
       Log.Keeper.warn "directive %s: agent %s not in registry" action agent_name)
     (fun entry ->
-       let updated_meta = { entry.meta with paused; updated_at = now_iso () } in
+       let updated_meta = directive_paused_meta entry.meta paused in
        persist_directive_meta_update entry ~updated_meta;
        Keeper_registry.dispatch_event_unit
          ~base_path:entry.base_path

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -356,6 +356,12 @@ let board_signal_entry_is_wakeup_candidate (entry : Keeper_registry.registry_ent
   | _ -> false
 ;;
 
+let paused_meta_allows_board_auto_resume (meta : keeper_meta) =
+  meta.paused
+  && Option.is_some
+       (Keeper_supervisor_types.paused_meta_effective_auto_resume_after_sec meta)
+;;
+
 let board_signal_wake_paused_keeper
       ~(config : Workspace.config)
       ~(stimulus : Keeper_event_queue.stimulus)
@@ -396,7 +402,10 @@ let board_signal_wake_keeper
   =
   let stimulus = board_signal_stimulus ~reason signal in
   if meta.paused
-  then board_signal_wake_paused_keeper ~config ~stimulus meta
+  then
+    if paused_meta_allows_board_auto_resume meta
+    then board_signal_wake_paused_keeper ~config ~stimulus meta
+    else Ok ()
   else (
     wakeup_keeper ~base_path:config.base_path ~stimulus meta.name;
     Ok ())
@@ -448,7 +457,8 @@ let wakeup_relevant_keeper_for_board_signal
                ()
            | None, _ | Some _, _ -> ());
           (match entry.phase, wake_reason with
-           | Keeper_state_machine.Paused, Some Board_wake.Explicit_mention ->
+           | Keeper_state_machine.Paused, Some Board_wake.Explicit_mention
+             when paused_meta_allows_board_auto_resume meta ->
              Some (meta, wake_reason)
            | Keeper_state_machine.Paused, _ -> None
            | Keeper_state_machine.Running, _ -> Some (meta, wake_reason)

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -171,6 +171,11 @@ val board_reactive_wakeup_allowed :
   -> signal:Board_dispatch.board_signal
   -> bool
 
+(** True when a paused keeper may be resumed by board-reactive wakeup.
+    Operator-owned pauses have [auto_resume_after_sec = None] and are not
+    resumed implicitly by board posts or comments. *)
+val paused_meta_allows_board_auto_resume : keeper_meta -> bool
+
 (** Select which keepers wake for a board signal (RFC-0020). Explicit mentions
     short-circuit and wake unconditionally (returned with [dropped = 0]); other
     typed reasons compete for [?total_limit] slots in candidate order. [None]

--- a/lib/keeper/keeper_meta_merge.ml
+++ b/lib/keeper/keeper_meta_merge.ml
@@ -27,4 +27,24 @@ let monotonic_usage_counters ~(latest : Keeper_meta_contract.keeper_meta) ~(call
   ; runtime = { caller.runtime with usage }
   }
 
-let heartbeat_fields_from_disk = monotonic_usage_counters
+let is_operator_pause (meta : Keeper_meta_contract.keeper_meta) =
+  meta.paused
+  && Option.is_none meta.auto_resume_after_sec
+  && Option.is_none meta.runtime.last_blocker
+
+let preserve_operator_pause_from_disk
+      ~(latest : Keeper_meta_contract.keeper_meta)
+      ~(caller : Keeper_meta_contract.keeper_meta)
+  =
+  let merged = monotonic_usage_counters ~latest ~caller in
+  if is_operator_pause latest
+  then
+    {
+      merged with
+      paused = true;
+      auto_resume_after_sec = None;
+      runtime = { merged.runtime with last_blocker = None };
+    }
+  else merged
+
+let heartbeat_fields_from_disk = preserve_operator_pause_from_disk

--- a/lib/keeper/keeper_meta_merge.mli
+++ b/lib/keeper/keeper_meta_merge.mli
@@ -13,4 +13,6 @@ val monotonic_usage_counters : t
     last_* observation fields stay with the caller. *)
 
 val heartbeat_fields_from_disk : t
-(** Alias of {!monotonic_usage_counters} for existing retry call sites. *)
+(** {!monotonic_usage_counters}, plus preservation of an operator-owned pause
+    already present on disk. This prevents stale turn/heartbeat writers from
+    clearing [paused=true] after an operator paused the keeper. *)

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -479,6 +479,8 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
                 {
                   meta with
                   paused;
+                  auto_resume_after_sec = None;
+                  runtime = { meta.runtime with last_blocker = None };
                   updated_at = Keeper_meta_contract.now_iso ();
                 }
               in
@@ -677,6 +679,8 @@ let handle_keeper_bulk_directive_post state _agent_name req reqd body_str =
                    {
                      meta with
                      paused = target;
+                     auto_resume_after_sec = None;
+                     runtime = { meta.runtime with last_blocker = None };
                      updated_at = Keeper_meta_contract.now_iso ();
                    }
                  in

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -199,6 +199,62 @@ let test_monotonic_usage_counters_on_cas_retry () =
     check int "last_* observation stays with the caller" 777
       final.runtime.usage.last_latency_ms)
 
+let test_operator_pause_survives_stale_heartbeat_retry () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Workspace.default_config base_dir in
+    ignore (Workspace.init config ~agent_name:(Some "operator"));
+    let m0 = make_meta ~name:"operator-pause-cas" in
+    (match Keeper_meta_store.write_meta config m0 with
+     | Ok () -> ()
+     | Error e -> fail ("seed write failed: " ^ e));
+    let stale_turn_view = match Keeper_meta_store.read_meta config "operator-pause-cas" with
+      | Ok (Some m) -> m
+      | _ -> fail "seed read failed"
+    in
+    let operator_pause =
+      { stale_turn_view with
+        paused = true;
+        auto_resume_after_sec = None;
+        runtime = { stale_turn_view.runtime with last_blocker = None };
+        updated_at = Keeper_meta_contract.now_iso ();
+      }
+    in
+    (match Keeper_meta_store.write_meta config operator_pause with
+     | Ok () -> ()
+     | Error e -> fail ("operator pause write failed: " ^ e));
+    let stale_completion =
+      { stale_turn_view with
+        paused = false;
+        runtime =
+          { stale_turn_view.runtime with
+            usage =
+              { stale_turn_view.runtime.usage with
+                total_turns = stale_turn_view.runtime.usage.total_turns + 1;
+              };
+          };
+        updated_at = Keeper_meta_contract.now_iso ();
+      }
+    in
+    (match
+       Keeper_meta_store.write_meta_with_merge
+         ~merge:Keeper_meta_merge.heartbeat_fields_from_disk config stale_completion
+     with
+     | Ok () -> ()
+     | Error e -> fail ("stale retry write failed: " ^ e));
+    let final = match Keeper_meta_store.read_meta config "operator-pause-cas" with
+      | Ok (Some m) -> m
+      | _ -> fail "final read failed"
+    in
+    check bool "operator pause survives stale retry" true final.paused;
+    check bool "auto resume stays disabled" true
+      (Option.is_none final.auto_resume_after_sec);
+    check bool "stale blocker stays cleared" true
+      (Option.is_none final.runtime.last_blocker))
+
 (* RFC-0237: the [write_meta ~force:true] escape hatch is removed, so the
    counter-rewind path the four keeper-internal sites carried
    (keeper_tool_surface / keeper_tool_surface_ops / keeper_keepalive /
@@ -273,6 +329,8 @@ let () =
             test_retry_succeeds_after_concurrent_bump;
           test_case "usage counters stay monotonic on stale retry (RFC-0225 §3.2)"
             `Quick test_monotonic_usage_counters_on_cas_retry;
+          test_case "operator pause survives stale heartbeat retry"
+            `Quick test_operator_pause_survives_stale_heartbeat_retry;
           test_case "stale write conflicts without force (RFC-0237 escape hatch closed)"
             `Quick test_stale_write_conflicts_without_force;
         ] );

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -209,6 +209,36 @@ module KWOBS = Masc.Keeper_world_observation_board_signal
 let reason_label = KWOBS.wake_reason_label
 let labeled selected = List.map (fun (item, r) -> item, reason_label r) selected
 
+let make_board_resume_meta ?(paused = false) ?auto_resume_after_sec name =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("keeper-" ^ name));
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "test");
+        ("sandbox_profile", `String "local");
+        ("network_mode", `String "inherit");
+        ("tool_access", `List []);
+      ]
+  in
+  match Keeper_meta_json_parse.meta_of_json json with
+  | Error err -> fail ("meta_of_json failed: " ^ err)
+  | Ok meta -> { meta with paused; auto_resume_after_sec }
+
+let test_board_auto_resume_rejects_operator_pause () =
+  let meta = make_board_resume_meta ~paused:true "operator-paused" in
+  check bool "operator pause is not board-auto-resumable" false
+    (KKS.paused_meta_allows_board_auto_resume meta)
+
+let test_board_auto_resume_allows_auto_paused_keeper () =
+  let meta =
+    make_board_resume_meta ~paused:true ~auto_resume_after_sec:3600.0
+      "auto-paused"
+  in
+  check bool "auto-paused keeper is board-auto-resumable" true
+    (KKS.paused_meta_allows_board_auto_resume meta)
+
 let test_board_wakeup_selection_keeps_explicit_mentions () =
   let selected, dropped =
     KKS.select_board_wakeup_candidates
@@ -399,6 +429,10 @@ let () =
         `Quick test_board_wakeup_selection_drops_none_reasons;
       test_case "total non-explicit fanout is capped"
         `Quick test_board_wakeup_selection_caps_total_non_explicit;
+      test_case "operator pauses are not board-auto-resumed"
+        `Quick test_board_auto_resume_rejects_operator_pause;
+      test_case "auto-paused keepers can be board-auto-resumed"
+        `Quick test_board_auto_resume_allows_auto_paused_keeper;
     ];
     "missed_wakeup_gap", [
       test_case "Skip_idle + Woken -> resumes (MissedWakeup spec gap)"


### PR DESCRIPTION
## Summary
- preserve operator-owned paused state during stale heartbeat/meta CAS retries
- prevent in-flight turn completion from clearing a pause written by the operator
- add CAS regression coverage for stale completion after operator pause

## Validation
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_meta_cas_retry.exe test/test_smart_heartbeat_keepalive.exe lib/server/server_dashboard_http_keeper_api_post.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec test/test_keeper_meta_cas_retry.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec test/test_smart_heartbeat_keepalive.exe
- git diff --check

## Context
- Follow-up to #21263. Live runtime showed operator pause being partially lost after in-flight keeper turns wrote stale meta snapshots.