### PR TITLE
fix(keeper): install agent_sdk in Docker sandbox

### DIFF
--- a/Dockerfile.keeper-sandbox
+++ b/Dockerfile.keeper-sandbox
@@ -8,10 +8,10 @@
 # - The host docker socket is typically mounted for DinD operations.
 # - Keeper GitHub/SSH credential bundles are projected at /tmp/keeper-creds.
 
-FROM ubuntu:24.04
+FROM ocaml/opam:debian-12-ocaml-5.4
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    OPAMROOT=/opt/opam
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -20,30 +20,45 @@ RUN apt-get update \
       coreutils \
       curl \
       findutils \
-      gcc \
       git \
       gh \
       jq \
+      libffi-dev \
+      libgmp-dev \
+      libprotobuf-dev \
+      libsqlite3-dev \
+      libssl-dev \
+      libzstd-dev \
       make \
       nodejs \
       npm \
-      ocaml-nox \
-      opam \
       openssh-client \
+      pkg-config \
+      protobuf-compiler \
       python3 \
       ripgrep \
       tree \
+      zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 
-# Install dune 3.22 via opam.
-# Ubuntu 24.04's ocaml-dune apt package provides dune 3.14 only;
-# the repo dune-project requires (lang dune 3.22).
-RUN opam init --disable-sandboxing --root "$OPAMROOT" --bare -y \
- && opam switch create default ocaml-system --root "$OPAMROOT" -y \
- && opam install --root "$OPAMROOT" -y dune.3.22.0 ppxlib ppx_deriving_yojson ppx_let ppx_deriving bisect_ppx ocaml-protoc-plugin \
- && rm -rf "$OPAMROOT/repo" "$OPAMROOT/.opam-switch/sources"
+# Install the same OCaml dependency closure that keeper repo tasks use.
+# This is not just a shell-tool image: Docker keepers run repo-local dune
+# builds, so the image must contain the pinned OAS agent_sdk libraries.
+USER opam
+WORKDIR /tmp/masc-deps
+COPY --chown=opam:opam dune-project masc.opam ./
+COPY --chown=opam:opam scripts/oas-agent-sdk-pin.sh scripts/opam-pin-external-deps.sh scripts/
+RUN opam update \
+ && opam exec -- bash -lc \
+      "opam install -y dune.3.22.0 ocamlfind \
+       && scripts/opam-pin-external-deps.sh \
+       && opam install . --deps-only -y" \
+ && opam clean -a -c -s --logs
 
-ENV PATH="/opt/opam/default/bin:${PATH}"
+USER root
+ENV OPAMROOT="/home/opam/.opam"
+ENV PATH="/home/opam/.opam/default/bin:${PATH}"
+ENV DUNE_CACHE="disabled"
 
 VOLUME ["/tmp/keeper-creds"]
 

--- a/config/keepers/issue_king.toml
+++ b/config/keepers/issue_king.toml
@@ -4,8 +4,6 @@ base = "base.toml"
 # (loader template, not bootable). See fix/base-toml-goal-required PR.
 autoboot_enabled = true
 persona_name = "issue_king"
-sandbox_profile = "local"
-network_mode = "inherit"
 will = "이슈를 보고 참지 못하고, PR이 검증 없이 방치되는 걸 못 참으며, CI가 빨간 걸 1초도 못 본다."
 needs = "GitHub 이슈 URL, PR 번호, reproduce 조건, 머지 블록커 목록"
 desires = "모든 이슈가 closed, 모든 PR이 merged, 모든 CI가 green인 상태."

--- a/scripts/check-sandbox-dune-version.sh
+++ b/scripts/check-sandbox-dune-version.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # check-sandbox-dune-version.sh
 #
-# CI gate: verify that the dune version installed in Dockerfile.keeper-sandbox
-# meets or exceeds the (lang dune X.Y) requirement in dune-project.
+# CI gate: verify that Dockerfile.keeper-sandbox is aligned with the repo
+# build contract: dune is new enough and the image installs the pinned OCaml
+# dependency closure used by keeper repo tasks.
 #
 # Rationale: Ubuntu 24.04's ocaml-dune apt package provides dune 3.14 while
 # the repo dune-project requires (lang dune 3.22).  This script is wired into
@@ -46,5 +47,21 @@ else
          "$sandbox_ver" "$req_ver" >&2
   printf '  Fix: update Dockerfile.keeper-sandbox to install dune >= %s\n' \
          "$req_ver" >&2
+  exit 1
+fi
+
+if grep -q 'scripts/opam-pin-external-deps.sh' "$repo_root/Dockerfile.keeper-sandbox" \
+   && grep -q 'opam install . --deps-only -y' "$repo_root/Dockerfile.keeper-sandbox"; then
+  printf 'OK: sandbox installs repo opam dependency closure\n'
+else
+  printf 'FAIL: Dockerfile.keeper-sandbox does not install pinned repo dependencies\n' >&2
+  printf '  Fix: run scripts/opam-pin-external-deps.sh and opam install . --deps-only -y during image build\n' >&2
+  exit 1
+fi
+
+if grep -q 'agent_sdk.llm_provider' "$repo_root/scripts/keeper-sandbox-smoke.sh"; then
+  printf 'OK: sandbox smoke checks agent_sdk.llm_provider availability\n'
+else
+  printf 'FAIL: keeper-sandbox-smoke.sh must verify agent_sdk.llm_provider is available\n' >&2
   exit 1
 fi

--- a/scripts/keeper-sandbox-integration-test.sh
+++ b/scripts/keeper-sandbox-integration-test.sh
@@ -162,6 +162,8 @@ run_test "T16: dune" none \
   'dune --version >/dev/null' true
 run_test "T16: dune version >= dune-project" none \
   'actual=$(dune --version); printf "%s\n%s\n" "$MASC_REQ_DUNE_VER" "$actual" | sort -V -C' true
+run_test "T16: agent_sdk findlib packages" none \
+  'ocamlfind query agent_sdk >/dev/null && ocamlfind query agent_sdk.llm_provider >/dev/null' true
 
 # T17: gh check (gh binary exists)
 run_test "T17: gh binary" none \

--- a/scripts/keeper-sandbox-smoke.sh
+++ b/scripts/keeper-sandbox-smoke.sh
@@ -17,6 +17,18 @@ trap 'rm -rf "$tmpdir"' EXIT
 playground="$tmpdir/playground"
 mkdir -p "$playground"
 printf 'alpha\nbeta\ngamma\n' > "$playground/demo.txt"
+cat > "$playground/dune-project" <<'EOF'
+(lang dune 3.22)
+(name keeper_sandbox_probe)
+EOF
+cat > "$playground/dune" <<'EOF'
+(executable
+ (name probe)
+ (libraries agent_sdk agent_sdk.llm_provider))
+EOF
+cat > "$playground/probe.ml" <<'EOF'
+let () = ()
+EOF
 
 # Extract required dune version from dune-project: (lang dune X.Y)
 req_dune_ver="$(grep -E '^\(lang dune\b' "$repo_root/dune-project" \
@@ -34,7 +46,7 @@ docker run --rm -i \
   "$image_tag" \
   bash -l -s <<'BASH'
     set -euo pipefail
-    for cmd in sh bash git gh rg tree jq python3 node npm make opam dune; do
+    for cmd in sh bash git gh rg tree jq python3 node npm make opam dune ocamlfind; do
       command -v "$cmd" >/dev/null
     done
     # Verify sandbox dune version meets dune-project requirement (Fix C: sandbox launch invariant)
@@ -44,6 +56,9 @@ docker run --rm -i \
       exit 1
     fi
     printf "OK: sandbox dune %s >= required %s\n" "$actual_dune" "$MASC_REQ_DUNE_VER"
+    ocamlfind query agent_sdk >/dev/null
+    ocamlfind query agent_sdk.llm_provider >/dev/null
+    dune build ./probe.exe
     test "$(cat demo.txt)" = $'alpha\nbeta\ngamma'
     rg beta demo.txt >/dev/null
     printf "delta\n" >> append.txt

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -255,7 +255,10 @@ let test_voice_audio_self_output_is_not_recent_context () =
   let lines = MS.recent_direct_conversation_of_messages messages in
   check (list string) "voice audio assistant row omitted from prompt context"
     [ "user"; "assistant" ]
-    (List.map (fun (line : MS.recent_direct_line) -> line.role_label) lines);
+    (List.map
+       (fun (line : MS.recent_direct_line) ->
+         MS.direct_line_role_to_label line.role)
+       lines);
   check (list string) "spoken text is not quoted back"
     [ "please say it out loud"; "text follow-up" ]
     (List.map (fun (line : MS.recent_direct_line) -> line.content) lines)

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -794,24 +794,6 @@ let test_bundled_keeper_profiles_resolve_prompt_self_model () =
              require_nonempty_option path "needs" defaults.needs;
              require_nonempty_option path "desires" defaults.desires))
 
-let test_bundled_issue_king_uses_local_sandbox () =
-  let repo = repo_root () in
-  Fun.protect
-    ~finally:(fun () -> Config_dir_resolver.reset ())
-    (fun () ->
-      with_env_restore [ "MASC_CONFIG_DIR"; "MASC_PERSONAS_DIR" ] (fun () ->
-          Unix.putenv "MASC_CONFIG_DIR" (Filename.concat repo "config");
-          Unix.putenv "MASC_PERSONAS_DIR"
-            (Filename.concat (Filename.concat repo "config") "personas");
-          Config_dir_resolver.reset ();
-          match KTP.load_keeper_profile_defaults_result "issue_king" with
-          | Error e -> fail (Printf.sprintf "issue_king failed to resolve: %s" e)
-          | Ok defaults ->
-            check (option string) "issue_king sandbox" (Some "local")
-              (Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile);
-            check (option string) "issue_king network" (Some "inherit")
-              (Option.map KTP.network_mode_to_string defaults.network_mode)))
-
 let with_temp_dir prefix f =
   let dir = Filename.temp_file prefix "" in
   Sys.remove dir;
@@ -1883,8 +1865,6 @@ let () =
           test_case "skips bad files" `Quick test_discover_skips_bad_files;
           test_case "bundled keeper profiles resolve prompt self-model" `Quick
             test_bundled_keeper_profiles_resolve_prompt_self_model;
-          test_case "bundled issue_king uses local sandbox" `Quick
-            test_bundled_issue_king_uses_local_sandbox;
           test_case "persona resolver omits unspecified tool_access" `Quick
             test_persona_resolver_omits_unspecified_tool_access;
           test_case "persona defaults load self-model fields" `Quick


### PR DESCRIPTION
## Summary
- Revert the merged issue_king local/inherit sandbox workaround so issue_king uses the Docker sandbox path again.
- Build the keeper sandbox from the OCaml opam base image and install the pinned repo dependency closure, including OAS agent_sdk and agent_sdk.llm_provider.
- Strengthen sandbox smoke/integration checks to verify agent_sdk.llm_provider is available inside the container and that dune can build a minimal probe against it.

## Verification
- scripts/check-sandbox-dune-version.sh
- scripts/check-oas-pin.sh --local-only
- git diff --check origin/main..HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_keeper_toml.exe ./test/test_env_config_sandbox.exe
- ./_build/default/test/test_keeper_toml.exe && ./_build/default/test/test_env_config_sandbox.exe
- scripts/keeper-sandbox-smoke.sh
- scripts/keeper-sandbox-integration-test.sh