### PR TITLE
Phase 0-2 + P3-1 foundations (land unpushed local main commit)

### DIFF
--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -177,6 +177,22 @@ let privileged_keeper_tool_names : string list =
 
 let keeper_backend_tool_name name = name
 
+let keeper_wrapped_server_tool_alias name =
+  match name with
+  | "masc_board_post" -> "keeper_board_post"
+  | "masc_board_comment" -> "keeper_board_comment"
+  | "masc_board_list" -> "keeper_board_list"
+  | "masc_tasks" -> "keeper_tasks_list"
+  | "masc_broadcast" -> "keeper_broadcast"
+  | _ -> name
+;;
+
+let keeper_wrapped_server_tools : string list =
+  [ "masc_board_post"; "masc_board_comment"; "masc_board_list";
+    "masc_tasks"; "masc_broadcast";
+  ]
+;;
+
 let public_projection_seeds_from (public_tool_source_schemas : Masc_domain.tool_schema list) :
     capability_seed list =
   let public_schemas =
@@ -230,7 +246,30 @@ let public_projection_seeds_from (public_tool_source_schemas : Masc_domain.tool_
       else
         with_spawned
     in
-    with_local_worker
+    let with_keeper_wrapper =
+      if List.mem name keeper_wrapped_server_tools then
+        let alias_name = keeper_wrapped_server_tool_alias name in
+        let alias_schema =
+          match
+            List.find_opt
+              (fun (s : Masc_domain.tool_schema) -> String.equal s.name alias_name)
+              Tool_shard.all_keeper_tool_schemas
+          with
+          | Some s -> s
+          | None -> schema
+        in
+        with_local_worker
+        @ [
+            make_seed ~capability_id:name ~risk_class:Audited
+              ~audiences:[ Keeper_agent ]
+              ~supports_audit_evidence:true
+              ~supports_direct_user_discovery:false
+              ~surface:Keeper_standard ~backend_tool_name:alias_name alias_schema;
+          ]
+      else
+        with_local_worker
+    in
+    with_keeper_wrapper
   in
   public_schemas |> List.concat_map make_public_seed
 
@@ -393,11 +432,6 @@ let keeper_safe_tool_names : string list =
 
 let keeper_privileged_tool_names : string list =
   privileged_keeper_tool_names
-
-let keeper_wrapped_server_tools : string list =
-  [ "masc_board_post"; "masc_board_comment"; "masc_board_list";
-    "masc_tasks"; "masc_broadcast";
-  ]
 
 let keeper_wrapped_internal_tools : string list =
   keeper_all_tool_names

--- a/lib/event_log/event_log.ml
+++ b/lib/event_log/event_log.ml
@@ -1,0 +1,97 @@
+(** Event_log — single canonical event stream for MASC.
+
+    P2-2 foundation: a time-ordered, uniquely identified in-memory event
+    log that REST, SSE, and the keeper event bus can all publish into.
+    JSONL persistence and subscriber fan-out are deliberate follow-ups. *)
+
+type source = string
+
+type event_id = string
+
+type event =
+  { id : event_id
+  ; ts_unix : float
+  ; source : source
+  ; kind : string
+  ; payload : Yojson.Safe.t
+  }
+
+(* Bounded in-memory ring. Newest events are at the head, so [recent]
+   can return a prefix without a full sort. *)
+let max_events = 10_000
+let events : event list ref = ref []
+let mutex = Eio.Mutex.create ()
+
+let rng = Random.State.make_self_init ()
+let rng_mutex = Eio.Mutex.create ()
+
+let generate_id () =
+  let ts = Int64.of_float (Time_compat.now () *. 1000.0) in
+  let uuid = Eio.Mutex.use_ro rng_mutex (fun () -> Uuidm.v4_gen rng ()) in
+  Printf.sprintf "%013Ld_%s" ts (Uuidm.to_string uuid)
+;;
+
+let rec drop_last = function
+  | [] -> []
+  | [ _ ] -> []
+  | x :: xs -> x :: drop_last xs
+;;
+
+let publish ~source ~kind payload =
+  let event =
+    { id = generate_id ()
+    ; ts_unix = Time_compat.now ()
+    ; source
+    ; kind
+    ; payload
+    }
+  in
+  Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+    events := event :: !events;
+    if List.length !events > max_events then events := drop_last !events);
+  event.id
+;;
+
+let rec take n = function
+  | _ when n <= 0 -> []
+  | [] -> []
+  | x :: xs -> x :: take (n - 1) xs
+;;
+
+let recent ?since_id n =
+  let n = max 0 n in
+  Eio.Mutex.use_ro mutex (fun () ->
+    match since_id with
+    | None -> take n !events
+    | Some since_id ->
+      let drop = ref true in
+      let after, _count =
+        List.fold_left
+          (fun (acc, remaining) e ->
+             if remaining <= 0 then acc, 0
+             else if !drop
+             then (
+               if String.equal e.id since_id then drop := false;
+               acc, remaining)
+             else e :: acc, remaining - 1)
+          ([], n)
+          !events
+      in
+      List.rev after)
+;;
+
+let to_json e =
+  `Assoc
+    [ ("id", `String e.id)
+    ; ("ts_unix", `Float e.ts_unix)
+    ; ("source", `String e.source)
+    ; ("kind", `String e.kind)
+    ; ("payload", e.payload)
+    ]
+;;
+
+module For_testing = struct
+  let reset () =
+    Eio.Mutex.use_rw ~protect:true mutex (fun () -> events := [])
+  ;;
+end

--- a/lib/event_log/event_log.mli
+++ b/lib/event_log/event_log.mli
@@ -1,0 +1,38 @@
+(** Event_log — single canonical event stream for MASC.
+
+    P2-2 foundation: a time-ordered, uniquely identified in-memory event
+    log that REST, SSE, and the keeper event bus can all publish into.
+    JSONL persistence and subscriber fan-out are deliberate follow-ups. *)
+
+type source = string
+(** Publisher tag, e.g. ["rest"], ["sse"], ["event_bus"], ["tool_call"]. *)
+
+type event_id = string
+(** Canonical event identifier. Lexicographically sortable and unique:
+    [<unix-ms>_<uuidv4>]. *)
+
+type event =
+  { id : event_id
+  ; ts_unix : float
+  ; source : source
+  ; kind : string
+  ; payload : Yojson.Safe.t
+  }
+(** A single canonical event record. *)
+
+val publish : source:source -> kind:string -> Yojson.Safe.t -> event_id
+(** Append an event to the log and return its canonical id. Thread-safe
+    under Eio. *)
+
+val recent : ?since_id:event_id -> int -> event list
+(** Return the [n] most recent events, newest first. If [since_id] is
+    provided, skip events newer than it and return the next [n]
+    (pagination-style). *)
+
+val to_json : event -> Yojson.Safe.t
+(** Serialize an event to JSON. *)
+
+module For_testing : sig
+  val reset : unit -> unit
+  (** Clear the in-memory log. Only for test isolation. *)
+end

--- a/lib/keeper/keeper_prompt_token_integrity.ml
+++ b/lib/keeper/keeper_prompt_token_integrity.ml
@@ -1,0 +1,142 @@
+(** Keeper_prompt_token_integrity — scan rendered prompts and continuity
+    summaries for keeper_*/masc_* tokens and verify each one resolves through
+    the policy tool-name chain.
+
+    P0-3: Rendered Prompt Token Scanner. Emits the
+    [masc_keeper_prompt_unknown_tool_tokens_total] CI metric for every token
+    that does not resolve via [Keeper_tool_resolution.resolve]. *)
+
+(* ── Types ────────────────────────────────────────────────────────── *)
+
+type source =
+  | System_prompt
+  | User_message
+  | Continuity
+
+type token_kind =
+  | Keeper
+  | Masc
+
+let source_to_string = function
+  | System_prompt -> "system_prompt"
+  | User_message -> "user_message"
+  | Continuity -> "continuity"
+
+let kind_to_string = function
+  | Keeper -> "keeper"
+  | Masc -> "masc"
+
+(* ── Token extraction ─────────────────────────────────────────────── *)
+
+let is_tool_token_char = function
+  | 'A' .. 'Z'
+  | 'a' .. 'z'
+  | '0' .. '9'
+  | '_'
+  | '-'
+  | '*' -> true
+  | _ -> false
+
+let token_kind_at pos text len :
+    token_kind option =
+  if pos + 7 <= len
+     && text.[pos] = 'k'
+     && text.[pos + 1] = 'e'
+     && text.[pos + 2] = 'e'
+     && text.[pos + 3] = 'p'
+     && text.[pos + 4] = 'e'
+     && text.[pos + 5] = 'r'
+     && text.[pos + 6] = '_'
+  then Some Keeper
+  else if
+    pos + 5 <= len
+    && text.[pos] = 'm'
+    && text.[pos + 1] = 'a'
+    && text.[pos + 2] = 's'
+    && text.[pos + 3] = 'c'
+    && text.[pos + 4] = '_'
+  then Some Masc
+  else None
+
+let is_token_start pos text = pos = 0 || not (is_tool_token_char text.[pos - 1])
+
+(** Find all keeper_*/masc_* tokens in [text]. Each token is returned as
+    [(kind, raw_name, position)]. The scan is linear in the length of the
+    input. *)
+let find_tokens text : (token_kind * string) list =
+  let len = String.length text in
+  let tokens = ref [] in
+  let i = ref 0 in
+  while !i < len do
+    match token_kind_at !i text len with
+    | Some kind when is_token_start !i text ->
+        let prefix_len =
+          match kind with
+          | Keeper -> 7
+          | Masc -> 5
+        in
+        let j = ref (!i + prefix_len) in
+        while !j < len && is_tool_token_char text.[!j] do
+          incr j
+        done;
+        let name = String.sub text !i (!j - !i) in
+        tokens := (kind, name) :: !tokens;
+        i := !j
+    | _ -> incr i
+  done;
+  List.rev !tokens
+
+let dedup_strings xs = List.sort_uniq String.compare xs
+
+(** Deduplicate tokens by [(kind, normalized name)], preserving the first
+    occurrence's original spelling for logging. *)
+let dedup_tokens tokens =
+  let seen = Hashtbl.create 16 in
+  List.filter
+    (fun (kind, name) ->
+       let key = (kind, String.lowercase_ascii name) in
+       if Hashtbl.mem seen key then false
+       else (Hashtbl.add seen key (); true))
+    tokens
+
+(* ── Verification ─────────────────────────────────────────────────── *)
+
+let verify_token ~keeper_name ~source (kind, name) : string option =
+  let normalized = String.lowercase_ascii name in
+  match Keeper_tool_resolution.resolve normalized with
+  | Keeper_tool_resolution.Resolved _ | Keeper_tool_resolution.Alias_to _ ->
+      None
+  | Keeper_tool_resolution.Unknown _ ->
+      Otel_metric_store.inc_counter
+        (Keeper_metrics.to_string PromptUnknownToolTokens)
+        ~labels:
+          [ ("keeper", keeper_name)
+          ; ("source", source_to_string source)
+          ; ("kind", kind_to_string kind)
+          ]
+        ();
+      Log.Keeper.warn
+        "keeper_prompt_token_integrity: unknown %s token %S in %s for keeper %s"
+        (kind_to_string kind)
+        name
+        (source_to_string source)
+        keeper_name;
+      Some normalized
+
+let scan_text ~keeper_name ~source text : string list =
+  find_tokens text
+  |> dedup_tokens
+  |> List.filter_map (verify_token ~keeper_name ~source)
+  |> dedup_strings
+
+let scan_rendered_prompt
+      ~keeper_name
+      ~system_prompt
+      ~user_message
+      ~continuity_summary =
+  let system_unknowns = scan_text ~keeper_name ~source:System_prompt system_prompt in
+  let user_unknowns = scan_text ~keeper_name ~source:User_message user_message in
+  let continuity_unknowns =
+    scan_text ~keeper_name ~source:Continuity continuity_summary
+  in
+  system_unknowns @ user_unknowns @ continuity_unknowns |> dedup_strings

--- a/lib/keeper/keeper_prompt_token_integrity.mli
+++ b/lib/keeper/keeper_prompt_token_integrity.mli
@@ -1,0 +1,31 @@
+(** Keeper_prompt_token_integrity — scan rendered prompts and continuity
+    summaries for keeper_*/masc_* tokens and verify each one resolves through
+    the policy tool-name chain.
+
+    P0-3: Rendered Prompt Token Scanner. Emits the
+    [masc_keeper_prompt_unknown_tool_tokens_total] CI metric for every token
+    that does not resolve via [Keeper_tool_resolution.resolve]. *)
+
+(** Which prompt/continuity surface a token came from. *)
+type source =
+  | System_prompt
+  | User_message
+  | Continuity
+
+val source_to_string : source -> string
+
+(** Scan a single text surface. Unknown tokens are deduplicated within the
+    surface, the counter is incremented once per unknown token, and a warning
+    is logged. Returns the deduplicated list of unknown token names in the
+    order they were first seen. *)
+val scan_text : keeper_name:string -> source:source -> string -> string list
+
+(** Scan the rendered system prompt, user message, and raw continuity summary.
+    Returns the deduplicated list of unknown token names across all three
+    surfaces. *)
+val scan_rendered_prompt :
+  keeper_name:string ->
+  system_prompt:string ->
+  user_message:string ->
+  continuity_summary:string ->
+  string list

--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -45,6 +45,7 @@ let get_net_opt () = Eio_context.get_net_opt ()
 let string_of_tag (tag : Tool_dispatch.module_tag) : string =
   match tag with
   | Mod_external -> "external"
+  | Mod_keeper_task -> "keeper_task"
   | Mod_library -> "library"
   | Mod_task -> "task"
   | Mod_shard -> "shard"
@@ -152,6 +153,12 @@ let dispatch
       Some
         (workflow_err
            (Printf.sprintf "tool '%s' is a keeper management tool (use MCP client)" name))
+    | Mod_keeper_task ->
+      Some
+        (workflow_err
+           (Printf.sprintf
+              "tool '%s' is a keeper task tool; use the keeper in-process task handler"
+              name))
     | Mod_operator ->
       Some
         (workflow_err

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -122,6 +122,7 @@ type t =
   | CycleExceptions
   | SnapshotWriteFailures
   | StateSnapshotSkippedNoState
+  | PromptUnknownToolTokens
   | ProgressUpdatedLineFailures
   | SseBroadcastFailures
   | WorkspaceHeartbeatFailures
@@ -348,6 +349,8 @@ let to_string = function
   | SnapshotWriteFailures -> "masc_keeper_snapshot_write_failures_total"
   | StateSnapshotSkippedNoState ->
     "masc_keeper_state_snapshot_skipped_no_state_total"
+  | PromptUnknownToolTokens ->
+    "masc_keeper_prompt_unknown_tool_tokens_total"
   | ProgressUpdatedLineFailures -> "masc_keeper_progress_updated_line_failures_total"
   | SseBroadcastFailures -> "masc_keeper_sse_broadcast_failures_total"
   | WorkspaceHeartbeatFailures -> "masc_keeper_workspace_heartbeat_failures_total"
@@ -491,7 +494,8 @@ let all : t list =
     ToolPolicyFailures; ReconcileFailures; DecisionAuditFlushFailures; OasCancel;
     ClaimAutoProvision; TomlInvalid; PersonaDriftMissing; WorkspaceInitFailures;
     PresenceSyncFailures; SelfPreservationUniversal; StaleStormPaused; ProviderTimeoutLoopPaused;
-    CycleExceptions; SnapshotWriteFailures; StateSnapshotSkippedNoState; ProgressUpdatedLineFailures;
+    CycleExceptions; SnapshotWriteFailures; StateSnapshotSkippedNoState; PromptUnknownToolTokens;
+    ProgressUpdatedLineFailures;
     SseBroadcastFailures; WorkspaceHeartbeatFailures; TurnMetricsSnapshotFailures; OasExecutionErrors;
     EpisodeCreateFailures; MemoryActivityEmitFailures; SupervisorSweepFailures; TomlReconcileSweepFailures;
     TomlReconcileDedup; ReconcileDisabled; ToolUsageFlushFailures; TurnTimeoutCommitted;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -113,6 +113,7 @@ type t =
   | CycleExceptions
   | SnapshotWriteFailures
   | StateSnapshotSkippedNoState
+  | PromptUnknownToolTokens
   | ProgressUpdatedLineFailures
   | SseBroadcastFailures
   | WorkspaceHeartbeatFailures

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -56,6 +56,57 @@ type t =
   | Voice_sessions
   | Voice_speak
 
+let all : t list =
+  [ Execute
+  ; Board_comment
+  ; Board_comment_vote
+  ; Board_curation_read
+  ; Board_curation_submit
+  ; Board_post_get
+  ; Board_list
+  ; Board_post
+  ; Board_search
+  ; Board_stats
+  ; Board_sub_board_create
+  ; Board_sub_board_delete
+  ; Board_sub_board_get
+  ; Board_sub_board_list
+  ; Board_sub_board_update
+  ; Board_vote
+  ; Broadcast
+  ; Context_status
+  ; Fs_edit
+  ; Fs_write
+  ; Fs_read
+  ; Ide_annotate
+  ; Handoff
+  ; Library_read
+  ; Library_search
+  ; Memory_search
+  ; Memory_write
+  ; Search_files
+  ; Surface_read
+  ; Surface_post
+  ; Person_note_set
+  ; Task_claim
+  ; Task_create
+  ; Task_done
+  ; Task_force_done
+  ; Task_force_release
+  ; Tasks_audit
+  ; Tasks_list
+  ; Time_now
+  ; Tool_search
+  ; Tools_list
+  ; Voice_agent
+  ; Voice_listen
+  ; Voice_session_end
+  ; Voice_session_start
+  ; Voice_sessions
+  ; Voice_speak
+  ]
+;;
+
 let to_string = function
   | Execute -> "tool_execute"
   | Board_comment -> "keeper_board_comment"

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -54,6 +54,9 @@ type t =
   | Voice_sessions
   | Voice_speak
 
+val all : t list
+(** All keeper tool-name variants. *)
+
 val to_string : t -> string
 val of_string : string -> t option
 val pp : Format.formatter -> t -> unit

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -341,6 +341,15 @@ let execute_tool_eio
                      (make_keeper_tool_ctx ())
                      ~name
                      ~args:coerced_args
+                 | Mod_keeper_task ->
+                   Some
+                     (Tool_result.error
+                        ~failure_class:(Some Tool_result.Workflow_rejection)
+                        ~tool_name:name
+                        ~start_time
+                        (Printf.sprintf
+                           "tool '%s' is a keeper task tool; use the keeper in-process task handler"
+                           name))
                  (* Removed tool families are intentionally not dispatchable. *)
                  | Mod_shard ->
                    let ok, json = Tool_shard.execute name coerced_args in

--- a/lib/reasoning_dialect.ml
+++ b/lib/reasoning_dialect.ml
@@ -1,0 +1,90 @@
+(** Reasoning_dialect — OAS reasoning control library (P3-1). *)
+
+open Llm_provider.Provider_config
+
+type provider_kind = Llm_provider.Provider_config.provider_kind
+
+type dialect =
+  | No_reasoning
+  | Openai_o1 of { reasoning_effort : string }
+  | Anthropic_extended of { budget_tokens : int option }
+  | Kimi_thinking of { budget_tokens : int option }
+  | Generic_thinking of { budget_tokens : int option }
+
+type replay_policy =
+  | Include
+  | Exclude
+  | Summarize
+
+type continuation_boundary =
+  | Stop_at_tool_call
+  | Stop_at_turn_end
+  | No_boundary
+
+type t =
+  { dialect : dialect
+  ; provider : provider_kind
+  ; model_id : string
+  ; supports_reasoning : bool
+  ; continuation_boundary : continuation_boundary
+  ; replay_policy : replay_policy
+  }
+
+let openai_reasoning_effort model_id =
+  (* o1-series model ids may carry suffixes such as o1-preview or
+     o1-mini. The effort knob is model-family-level for now. *)
+  if String.starts_with ~prefix:"o1-mini" model_id then "low"
+  else if String.starts_with ~prefix:"o1-preview" model_id then "high"
+  else "medium"
+;;
+
+let classify ~provider ~(model_id : string) ~enable_thinking ~thinking_budget =
+  match provider with
+  | Anthropic when Option.is_some enable_thinking ->
+    Anthropic_extended { budget_tokens = thinking_budget }
+  | Kimi when Option.is_some enable_thinking ->
+    Kimi_thinking { budget_tokens = thinking_budget }
+  | OpenAI_compat when String.starts_with ~prefix:"o1" model_id ->
+    Openai_o1 { reasoning_effort = openai_reasoning_effort model_id }
+  | _ ->
+    if Option.is_some enable_thinking
+    then Generic_thinking { budget_tokens = thinking_budget }
+    else No_reasoning
+;;
+
+let default_boundary = function
+  | No_reasoning -> No_boundary
+  | Openai_o1 _ -> Stop_at_tool_call
+  | Anthropic_extended _ -> Stop_at_tool_call
+  | Kimi_thinking _ -> Stop_at_turn_end
+  | Generic_thinking _ -> Stop_at_tool_call
+;;
+
+let replay_policy_of_config ~supports_reasoning ~preserve_thinking =
+  match preserve_thinking with
+  | Some true -> Include
+  | Some false -> Exclude
+  | None -> if supports_reasoning then Summarize else Exclude
+;;
+
+let of_provider_config (cfg : Llm_provider.Provider_config.t) =
+  let dialect =
+    classify ~provider:cfg.kind ~model_id:cfg.model_id
+      ~enable_thinking:cfg.enable_thinking
+      ~thinking_budget:cfg.thinking_budget
+  in
+  let supports_reasoning =
+    match dialect with
+    | No_reasoning -> false
+    | _ -> true
+  in
+  { dialect
+  ; provider = cfg.kind
+  ; model_id = cfg.model_id
+  ; supports_reasoning
+  ; continuation_boundary = default_boundary dialect
+  ; replay_policy =
+      replay_policy_of_config ~supports_reasoning
+        ~preserve_thinking:cfg.preserve_thinking
+  }
+;;

--- a/lib/reasoning_dialect.mli
+++ b/lib/reasoning_dialect.mli
@@ -1,0 +1,43 @@
+(** Reasoning_dialect — OAS reasoning control library (P3-1).
+
+    Maps a provider configuration to a provider/model-specific reasoning
+    dialect, a continuation boundary policy, and a replay policy.  This is
+    the registry-style layer called by caller sites that need to know
+    whether and how reasoning traces should be produced, persisted, and
+    replayed. *)
+
+type provider_kind = Llm_provider.Provider_config.provider_kind
+
+(** Provider/model reasoning dialect. *)
+type dialect =
+  | No_reasoning
+  | Openai_o1 of { reasoning_effort : string }
+  | Anthropic_extended of { budget_tokens : int option }
+  | Kimi_thinking of { budget_tokens : int option }
+  | Generic_thinking of { budget_tokens : int option }
+
+(** Whether reasoning traces may be replayed into later contexts. *)
+type replay_policy =
+  | Include
+  | Exclude
+  | Summarize
+
+(** When a reasoning pass should hand control back to the caller. *)
+type continuation_boundary =
+  | Stop_at_tool_call
+  | Stop_at_turn_end
+  | No_boundary
+
+(** Resolved reasoning control for a provider configuration. *)
+type t =
+  { dialect : dialect
+  ; provider : provider_kind
+  ; model_id : string
+  ; supports_reasoning : bool
+  ; continuation_boundary : continuation_boundary
+  ; replay_policy : replay_policy
+  }
+
+val of_provider_config : Llm_provider.Provider_config.t -> t
+(** Resolve the reasoning dialect and policies from a provider config.
+    Pure: no IO, no side effects. *)

--- a/lib/relation_materializer.mli
+++ b/lib/relation_materializer.mli
@@ -14,6 +14,11 @@
 
     @since 2.112.0 *)
 
+val build_batch_mutation :
+  agent:string -> peers:string list -> context:string -> string
+(** Build a single batched GraphQL mutation with aliased fields.
+    Exposed primarily for unit testing the batching/escape logic. *)
+
 val on_agent_session_ended :
   leaving_agent:string ->
   active_agents:string list ->

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -83,17 +83,15 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      disabled the shared store simply stops being refreshed (recall still reads
      whatever is there).
 
-     Default OFF until #21241: a read-only dry-run over the live fleet found the
-     only >=2-keeper-corroborated [fact]/[constraint] claims are ephemeral
-     lifecycle/coordination boilerplate ("checkpoint saved", "no tasks") that the
-     librarian mislabels as [category=fact]. Promoting them would inject prompt
-     noise via recall's [shared via] line, with no durable knowledge. Re-enable
-     (flip the default, or set the env true) once the librarian taxonomy emits
-     ephemeral events as a non-promotable category (#21241, RFC-0244 §2.3). *)
+     P2-1: enabled by default.  The #21241 librarian taxonomy fix already
+     typed [default_promote_categories] so [Unknown] and other non-objective
+     labels are default-denied; remaining ephemeral [Fact] mis-labels are a
+     librarian prompt issue and are gated below by requiring >=2 distinct
+     keepers.  Operators can still disable via MASC_KEEPER_MEMORY_OS_CONSOLIDATION=0. *)
   if
     Keeper_memory_bank_env.memory_env_bool_logged
       "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
-      ~default:false
+      ~default:true
   then
     fork_logged_fiber
       ~sw
@@ -121,6 +119,55 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
          | exn ->
            Log.Server.warn
              "memory_os_consolidation: tick crashed: %s"
+             (Printexc.to_string exn));
+        Eio.Time.sleep clock interval;
+        loop ()
+      in
+      loop ());
+  (* RFC-0239 Q4: Memory OS Tier-1 fact GC. Removes TTL-expired facts,
+     verdict-discarded rows, and duplicate claims from each keeper's own
+     fact store. Per-keeper like writes, so it cannot race cross-keeper
+     consolidation; it is the production caller that makes [run_gc] live. *)
+  fork_logged_fiber
+    ~sw
+    ~on_error:(log_server_fiber_crash "memory_os_gc")
+    (fun () ->
+      let interval = 300.0 in
+      let rec loop () =
+        (try
+           let keeper_ids = Keeper_memory_os_io.list_fact_store_keeper_ids () in
+           List.iter
+             (fun keeper_id ->
+                try
+                  let report =
+                    Keeper_memory_os_gc.run_gc
+                      ~keeper_id
+                      ~now:(Time_compat.now ())
+                      ()
+                  in
+                  if report.Keeper_memory_os_gc.total_input > 0
+                  then
+                    Log.Server.debug
+                      "memory_os_gc keeper=%s input=%d ttl=%d verdict=%d dedup=%d written=%d"
+                      keeper_id
+                      report.Keeper_memory_os_gc.total_input
+                      report.Keeper_memory_os_gc.ttl_expired
+                      report.Keeper_memory_os_gc.verdict_discarded
+                      report.Keeper_memory_os_gc.dedup_removed
+                      report.Keeper_memory_os_gc.written
+                with
+                | Eio.Cancel.Cancelled _ as e -> raise e
+                | exn ->
+                  Log.Server.warn
+                    "memory_os_gc keeper=%s failed: %s"
+                    keeper_id
+                    (Printexc.to_string exn))
+             keeper_ids
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Server.warn
+             "memory_os_gc sweep failed: %s"
              (Printexc.to_string exn));
         Eio.Time.sleep clock interval;
         loop ()

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -465,8 +465,18 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     ~requested:requested_backend_mode_before_enforcement
     ~effective:initial_backend_mode;
 
-  (* 2. All init in background fiber — protected so failures don't kill HTTP *)
+  (* 2. All init in background fiber — isolated on its own switch so a
+     failure in any init-time subsystem (keepers, maintenance, dashboard
+     refresh, etc.) cancels only that subtree and leaves the HTTP accept
+     loop running on the parent switch.  This is P1-5 Hierarchical
+     Supervision Phase 1.
+
+     [create_server_state] still attaches to the parent switch because
+     the resulting [server_state] (and its switch reference) is used by
+     the HTTP request path; we only want background init/maintenance
+     fibers to live on the child switch. *)
   Eio.Fiber.fork ~sw (fun () ->
+    Eio.Switch.run @@ fun init_sw ->
     let governance_level = Env_config_core.governance_level () in
     let init_state_blocking () =
       let t0 = Eio.Time.now clock in

--- a/lib/tool/tool_catalog_inference.ml
+++ b/lib/tool/tool_catalog_inference.ml
@@ -20,4 +20,8 @@ let effect_domain_to_string = function
   | Playground_write -> "playground_write"
   | Host_repo_write -> "host_repo_write"
 
-let inferred_effect_domain _name = None
+let inferred_effect_domain name =
+  match name with
+  | "tool_read_file" -> Some Read_only
+  | _ -> None
+;;

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -273,6 +273,7 @@ type module_tag = Tool_tag_types.module_tag =
   | Mod_library | Mod_external
   | Mod_inline
   | Mod_shard
+  | Mod_keeper_task
 
 let tag_registry : (string, module_tag) Hashtbl.t = Hashtbl.create 512
 let tag_registry_initialized = Atomic.make false
@@ -317,6 +318,9 @@ let mint_token ~name =
     errors (#9784). Handler-only registrations are intentionally invisible. *)
 let all_registered_names () =
   with_dispatch_ro (fun () -> Hashtbl.fold (fun n _ a -> n :: a) tag_registry [])
+
+let all_schema_names () =
+  with_dispatch_ro (fun () -> Hashtbl.fold (fun n _ a -> n :: a) schema_registry [])
 
 (* #9784: Unknown tool errors must include closest-name suggestions so the
    LLM can self-correct on the next turn. Jaccard works well for snake_case

--- a/lib/tool/tool_dispatch.mli
+++ b/lib/tool/tool_dispatch.mli
@@ -170,6 +170,7 @@ type module_tag =
   | Mod_external
   | Mod_inline
   | Mod_shard
+  | Mod_keeper_task
 
 val register_module_tag : schemas:Masc_domain.tool_schema list -> tag:module_tag -> unit
 (** Register tool names from a schema list with a module tag. *)
@@ -195,6 +196,10 @@ val is_tag_registry_initialized : unit -> bool
 val all_registered_names : unit -> string list
 (** Every tool name registered in the tag registry. Handler-only
     registrations are intentionally invisible. Iteration order is
+    unspecified. *)
+
+val all_schema_names : unit -> string list
+(** Every tool name registered in the schema registry. Iteration order is
     unspecified. *)
 
 val find_similar_names :

--- a/lib/tool/tool_tag_types.ml
+++ b/lib/tool/tool_tag_types.ml
@@ -28,6 +28,7 @@ type module_tag =
   | Mod_external
   | Mod_inline
   | Mod_shard
+  | Mod_keeper_task
 
 type effect_domain =
   | Read_only

--- a/lib/tool/tool_tag_types.mli
+++ b/lib/tool/tool_tag_types.mli
@@ -26,6 +26,7 @@ type module_tag =
   | Mod_external
   | Mod_inline
   | Mod_shard
+  | Mod_keeper_task
 
 (** Inferred effect classification for a tool. *)
 type effect_domain =

--- a/lib/unified_tool_registry.ml
+++ b/lib/unified_tool_registry.ml
@@ -1,0 +1,179 @@
+(** Unified Tool Registry Ratchet — P0-1.
+
+    Single registration flow that brings together the four previously
+    scattered tool-name sources:
+
+    - [Keeper_tool_name] (keeper-owned typed vocabulary)
+    - [Config.raw_all_tool_schemas] (authoritative LLM schema inventory)
+    - [Keeper_tool_registry.core_always_tools] (mandatory survival tools)
+    - [Keeper_tool_task_runtime] task-operation handlers
+
+    The flow registers a dispatch tag (+ schema) for every name that does not
+    already have one, then enforces the startup invariant that every
+    LLM-visible schema resolves to a tag.
+
+    Design notes:
+    - We never overwrite an existing tag. Modules that already register via
+      [Tool_spec] keep their precise tag; this ratchet only fills the gaps.
+    - [Mod_keeper_task] is introduced as the canonical tag for the closed
+      keeper task-operation cluster. Real execution still flows through the
+      keeper internal runtime, but the tag makes the cluster first-class in
+      the unified registry.
+    - Descriptors and other keeper-internal handlers are classified as
+      [Mod_external] for registry-completeness; they are not dispatched
+      through the neutral Tool substrate. *)
+
+module TD = Tool_dispatch
+
+let empty_input_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc []
+    ; "required", `List []
+    ]
+
+let minimal_schema name =
+  { Masc_domain.name
+  ; description = Printf.sprintf "Unified registry schema for %s" name
+  ; input_schema = empty_input_schema
+  }
+
+let find_raw_schema name =
+  List.find_opt
+    (fun (s : Masc_domain.tool_schema) -> String.equal s.name name)
+    Config.raw_all_tool_schemas
+
+let schema_for_name name =
+  match find_raw_schema name with
+  | Some s -> s
+  | None -> minimal_schema name
+
+(** Closed set of keeper task-operation names handled by
+    [Keeper_tool_task_runtime.handle_keeper_task_tool]. Derived from
+    [Keeper_tool_name] so the registry and the typed handler cluster stay
+    in sync. *)
+let keeper_task_tool_names =
+  List.map
+    Keeper_tool_name.to_string
+    Keeper_tool_name.
+      [ Tasks_list
+      ; Tasks_audit
+      ; Task_force_release
+      ; Task_force_done
+      ; Broadcast
+      ; Task_create
+      ; Task_claim
+      ; Task_done
+      ]
+
+let is_keeper_task_tool_name name = List.mem name keeper_task_tool_names
+
+(** Derive a dispatch tag from a tool name. This is the SSOT heuristic used
+    by the ratchet; any name it returns [None] for must either be invisible
+    or be handled by an explicit [Tool_spec] registration that already
+    populated the tag registry. *)
+let tag_of_name name : TD.module_tag option =
+  let open TD in
+  let prefix p = String.starts_with ~prefix:p name in
+  if prefix "masc_plan_" then Some Mod_plan
+  else if prefix "masc_run_" then Some Mod_run
+  else if prefix "masc_agent_" then Some Mod_agent
+  else if prefix "masc_task_" then Some Mod_task
+  else if prefix "masc_workspace_" then Some Mod_state
+  else if prefix "masc_control_" then Some Mod_control
+  else if prefix "masc_agent_timeline_" then Some Mod_agent_timeline
+  else if prefix "masc_schedule_" then Some Mod_schedule
+  else if prefix "masc_misc_" then Some Mod_misc
+  else if prefix "masc_local_runtime_" then Some Mod_local_runtime
+  else if prefix "masc_library_" then Some Mod_library
+  else if prefix "masc_operator_" then Some Mod_operator
+  else if prefix "masc_external_" then Some Mod_external
+  else if prefix "masc_inline_" then Some Mod_inline
+  else if prefix "masc_shard_" then Some Mod_shard
+  else if prefix "masc_compact_" then Some Mod_compact
+  else if prefix "masc_board_" then Some Mod_inline
+  else if prefix "masc_keeper_" then Some Mod_external
+  else if String.equal name "masc_surface_audit" then Some Mod_inline
+  else if is_keeper_task_tool_name name then Some Mod_keeper_task
+  else if prefix "keeper_" then Some Mod_external
+  else if
+    List.mem
+      name
+      [ "tool_execute"
+      ; "tool_read_file"
+      ; "tool_edit_file"
+      ; "tool_write_file"
+      ; "tool_search_files"
+      ]
+  then Some Mod_external
+  else if String.equal name "extend_turns" then Some Mod_external
+  else None
+
+(** Register a tag + schema only if the name is not already in the tag
+    registry. Existing [Tool_spec] registrations are preserved. *)
+let register_name_if_missing name tag =
+  if Option.is_none (TD.lookup_tag name)
+  then TD.register_module_tag ~schemas:[ schema_for_name name ] ~tag
+
+(** 1. Register every LLM-visible schema from [Config.raw_all_tool_schemas]
+    that does not already have a tag. *)
+let register_visible_raw_schemas () =
+  Config.raw_all_tool_schemas
+  |> List.iter (fun (schema : Masc_domain.tool_schema) ->
+       if Tool_catalog.is_visible schema.name
+       then
+         match tag_of_name schema.name with
+         | Some tag -> register_name_if_missing schema.name tag
+         | None -> register_name_if_missing schema.name TD.Mod_external)
+
+(** 2. Register the mandatory core-always tools. Most already have schemas
+    in [raw_all_tool_schemas]; [extend_turns] gets a placeholder schema so
+    the tag/schema registries stay in lockstep. *)
+let register_core_always_tools () =
+  Keeper_tool_registry.core_always_tools
+  |> List.iter (fun name ->
+       match tag_of_name name with
+       | Some tag -> register_name_if_missing name tag
+       | None -> register_name_if_missing name TD.Mod_external)
+
+(** 3. Register every name in [Keeper_tool_name.all] that is missing from
+    the registry. This covers keeper-internal tools and ratchets the task
+    cluster to [Mod_keeper_task]. *)
+let register_keeper_tool_names () =
+  Keeper_tool_name.all
+  |> List.iter (fun t ->
+       let name = Keeper_tool_name.to_string t in
+       match tag_of_name name with
+       | Some tag -> register_name_if_missing name tag
+       | None -> register_name_if_missing name TD.Mod_external)
+
+(** Run the complete unified registration flow. Safe to call multiple times
+    (subsequent calls are no-ops for already-registered names). *)
+let register_all () =
+  register_visible_raw_schemas ();
+  register_core_always_tools ();
+  register_keeper_tool_names ()
+
+(** Names of LLM-visible schemas that still lack a dispatch tag. Empty when
+    the ratchet is complete. *)
+let visible_schemas_missing_tags () =
+  Config.visible_tool_schemas ()
+  |> List.filter (fun (s : Masc_domain.tool_schema) ->
+       Option.is_none (TD.lookup_tag s.name))
+  |> List.map (fun (s : Masc_domain.tool_schema) -> s.name)
+
+(** Startup invariant: every LLM-visible schema has a dispatch tag.
+    Raises [Failure] if the invariant is violated so boot cannot proceed
+    with a half-registered surface. *)
+let enforce_visible_tag_coverage () =
+  match visible_schemas_missing_tags () with
+  | [] -> ()
+  | missing ->
+    let msg =
+      Printf.sprintf
+        "P0-1 invariant violation: %d LLM-visible schema(s) lack a dispatch tag: %s"
+        (List.length missing)
+        (String.concat ", " missing)
+    in
+    Log.Server.error "%s" msg;
+    failwith msg

--- a/lib/unified_tool_registry.mli
+++ b/lib/unified_tool_registry.mli
@@ -1,0 +1,25 @@
+(** Unified Tool Registry Ratchet — P0-1.
+
+    Single registration flow that fills dispatch-tag/schema gaps across
+    [Keeper_tool_name], [Config.raw_all_tool_schemas],
+    [Keeper_tool_registry.core_always_tools], and the keeper task runtime.
+
+    The flow is invoked once at startup by the MCP composition root; it is
+    idempotent and preserves tags already registered via [Tool_spec]. *)
+
+val tag_of_name : string -> Tool_dispatch.module_tag option
+(** Derive the canonical dispatch tag for a tool name from naming heuristics.
+    Returns [None] for names that have no clear neutral-tool mapping; those
+    must be covered by an explicit [Tool_spec] registration. *)
+
+val register_all : unit -> unit
+(** Register tags (+ placeholder schemas where needed) for all names in the
+    unified name sources that are not already present in the tag registry. *)
+
+val visible_schemas_missing_tags : unit -> string list
+(** Return the names of LLM-visible schemas that still lack a dispatch tag.
+    Empty when the ratchet is complete. *)
+
+val enforce_visible_tag_coverage : unit -> unit
+(** Startup invariant: raises [Failure] if any LLM-visible schema lacks a
+    dispatch tag. *)

--- a/scripts/ci_verify_linked_modules.sh
+++ b/scripts/ci_verify_linked_modules.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# ci_verify_linked_modules.sh — Verify that listed OCaml modules are actually
+# linked into a built executable.
+#
+# OCaml's dead-code elimination / selective linking can drop whole modules if
+# no live reference reaches them from the program entry point. This script
+# uses nm(1) to confirm that expected module symbols are present in the
+# binary, catching "merged in source but absent from the binary" regressions.
+#
+# Usage:
+#   scripts/ci_verify_linked_modules.sh [path/to/binary.exe]
+#
+# Default binary: _build/default/bin/main_eio.exe
+
+set -euo pipefail
+
+BINARY="${1:-_build/default/bin/main_eio.exe}"
+
+if [ ! -f "$BINARY" ]; then
+  echo "ERROR: binary not found: $BINARY" >&2
+  echo "Run 'dune build bin/main_eio.exe' first." >&2
+  exit 1
+fi
+
+# Modules that must be present in the binary. Add more module basenames here
+# as the "merged but not linked" risk grows.
+REQUIRED_MODULES=(
+  keeper_memory_os_types
+  keeper_memory_os_policy
+  keeper_memory_os_io
+  keeper_memory_os_consolidator
+  keeper_memory_os_recall
+  keeper_memory_os_gc
+)
+
+MISSING=()
+
+# OCaml emits symbols such as camlKeeper_memory_os_policy__entry or
+# camlKeeper_memory_os_policy__foo. A case-insensitive grep for the module
+# basename is sufficient to prove linkage.
+#
+# Note: macOS grep -q on a large symbol table can return 1 even when matches
+# exist (observed with ~13MB nm output).  Use grep -c and compare the count.
+symbols=$(nm "$BINARY" 2>/dev/null || true)
+for mod in "${REQUIRED_MODULES[@]}"; do
+  count=$(echo "$symbols" | grep -ic -- "${mod}")
+  if [ "$count" -eq 0 ]; then
+    MISSING+=("$mod")
+  fi
+done
+
+if [ "${#MISSING[@]}" -ne 0 ]; then
+  echo "ERROR: the following modules are NOT linked into $BINARY:" >&2
+  for mod in "${MISSING[@]}"; do
+    echo "  - $mod" >&2
+  done
+  echo "They may be declared in lib/dune but never referenced from the entry point." >&2
+  exit 1
+fi
+
+echo "OK: all ${#REQUIRED_MODULES[@]} required modules are linked into $BINARY."

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -22,8 +22,8 @@ let init_eio_clock ?sw env =
 
 let init_keeper_tool_registry () =
   if not (Tool_dispatch.is_tag_registry_initialized ()) then
-    let _ = Masc.Mcp_server_eio.governance_defaults in
-    ()
+    (Masc.Unified_tool_registry.register_all ();
+     Masc.Unified_tool_registry.enforce_visible_tag_coverage ())
 
 (** Test fixture parser for [keeper_meta] JSON.
 

--- a/test/dune
+++ b/test/dune
@@ -307,7 +307,10 @@
   test_blocker_class_exhaustiveness
   test_workspace_goal_index
   test_log_severity_outcome_level
-  test_env_keeper_scrub)
+  test_env_keeper_scrub
+  test_event_log
+  test_relation_materializer
+  test_reasoning_dialect)
  (modules
   test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate
@@ -595,7 +598,10 @@
   test_blocker_class_exhaustiveness
   test_workspace_goal_index
   test_log_severity_outcome_level
-  test_env_keeper_scrub)
+  test_env_keeper_scrub
+  test_event_log
+  test_relation_materializer
+  test_reasoning_dialect)
  (libraries masc_test_deps multimodal))
 
 ; Focused CI gate for runtime TOML validity.
@@ -783,6 +789,7 @@
   ; test_proof_criteria removed (team session cleanup)
   ; test_tree_index removed (CP purge)
   test_tool_registry
+  test_tool_registry_consistency
   test_tool_dispatch
   test_tool_spec
   test_tool_catalog_system_internal_hidden
@@ -792,6 +799,7 @@
   test_tool_hooks
   test_governance_pipeline
   test_keeper_agent_isolation
+  test_keeper_prompt_token_integrity
   test_sse_external_sub
   test_ws_transport
   test_webrtc_signaling
@@ -964,6 +972,7 @@
   test_yojson_type_error_board
   ; test_tree_index removed (CP purge)
   test_tool_registry
+  test_tool_registry_consistency
   test_tool_dispatch
   test_tool_spec
   test_tool_catalog_system_internal_hidden
@@ -973,6 +982,7 @@
   test_tool_hooks
   test_governance_pipeline
   test_keeper_agent_isolation
+  test_keeper_prompt_token_integrity
   test_sse_external_sub
   test_ws_transport
   test_webrtc_signaling

--- a/test/test_event_log.ml
+++ b/test/test_event_log.ml
@@ -1,0 +1,83 @@
+(** Test Event_log canonical id and ordering (P2-2). *)
+
+open Masc
+
+let event_log_test name f =
+  Alcotest.test_case name `Quick (fun () ->
+    Eio_main.run (fun env ->
+      let clock = Eio.Stdenv.clock env in
+      let mono_clock = Eio.Stdenv.mono_clock env in
+      let net = Eio.Stdenv.net env in
+      Eio.Switch.run (fun sw ->
+        Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
+          Event_log.For_testing.reset ();
+          f ()))))
+;;
+
+let publish_returns_id () =
+  let id =
+    Event_log.publish ~source:"test" ~kind:"ping" (`Assoc [ ("x", `Int 1) ])
+  in
+  Alcotest.(check bool) "id non-empty" true (String.length id > 0);
+  Alcotest.(check bool) "id contains underscore" true (String.contains id '_')
+;;
+
+let recent_newest_first () =
+  let id1 =
+    Event_log.publish ~source:"test" ~kind:"first" (`Assoc [ ("n", `Int 1) ])
+  in
+  Unix.sleepf 0.001;
+  let id2 =
+    Event_log.publish ~source:"test" ~kind:"second" (`Assoc [ ("n", `Int 2) ])
+  in
+  let recent = Event_log.recent 2 in
+  Alcotest.(check int) "two events" 2 (List.length recent);
+  Alcotest.(check string) "first recent is newest" id2 (List.hd recent).id;
+  Alcotest.(check string) "second recent is older" id1 (List.nth recent 1).id
+;;
+
+let recent_since_id_pagination () =
+  let _id1 =
+    Event_log.publish ~source:"test" ~kind:"a" (`Assoc [ ("n", `Int 1) ])
+  in
+  Unix.sleepf 0.001;
+  let id2 =
+    Event_log.publish ~source:"test" ~kind:"b" (`Assoc [ ("n", `Int 2) ])
+  in
+  Unix.sleepf 0.001;
+  let id3 =
+    Event_log.publish ~source:"test" ~kind:"c" (`Assoc [ ("n", `Int 3) ])
+  in
+  let recent = Event_log.recent ~since_id:id3 1 in
+  Alcotest.(check int) "one event after id3" 1 (List.length recent);
+  Alcotest.(check string) "event is id2" id2 (List.hd recent).id
+;;
+
+let to_json_roundtrip () =
+  let id =
+    Event_log.publish ~source:"rest" ~kind:"tool_call"
+      (`Assoc [ ("tool", `String "x") ])
+  in
+  match Event_log.recent 1 with
+  | [ e ] ->
+    let json = Event_log.to_json e in
+    Alcotest.(check string) "json id" id
+      (Safe_ops.json_string ~default:"" "id" json);
+    Alcotest.(check string) "json source" "rest"
+      (Safe_ops.json_string ~default:"" "source" json);
+    Alcotest.(check string) "json kind" "tool_call"
+      (Safe_ops.json_string ~default:"" "kind" json)
+  | _ -> Alcotest.fail "expected one event"
+;;
+
+let () =
+  Alcotest.run
+    "Event_log P2-2"
+    [ ( "canonical_event_log"
+      , [ event_log_test "publish returns canonical id" publish_returns_id
+        ; event_log_test "recent newest first" recent_newest_first
+        ; event_log_test "recent since_id pagination" recent_since_id_pagination
+        ; event_log_test "to_json roundtrip" to_json_roundtrip
+        ] )
+    ]
+;;

--- a/test/test_keeper_prompt_token_integrity.ml
+++ b/test/test_keeper_prompt_token_integrity.ml
@@ -1,0 +1,135 @@
+(* test/test_keeper_prompt_token_integrity.ml
+
+   P0-3: verify that [Keeper_prompt_token_integrity] finds keeper_*/masc_*
+   tokens in rendered prompts/continuity, resolves known tokens, reports
+   unknown tokens, and increments [masc_keeper_prompt_unknown_tool_tokens_total]. *)
+
+module Scanner = Masc.Keeper_prompt_token_integrity
+module Metrics = Masc.Otel_metric_store
+
+let metric_name = Keeper_metrics.(to_string PromptUnknownToolTokens)
+let keeper = "test-keeper-p0-3"
+
+let total_unknown () = Metrics.metric_total metric_name
+
+let test_known_tokens_are_not_reported () =
+  let prompt =
+    String.concat " "
+      [ "Use keeper_board_post to post, keeper_task_claim to claim,"
+      ; "masc_keeper_status to inspect, and extend_turns when needed."
+      ; "For direct execution, call Execute."
+      ]
+  in
+  let before = total_unknown () in
+  let unknowns =
+    Scanner.scan_text ~keeper_name:keeper ~source:System_prompt prompt
+  in
+  Alcotest.(check (list string))
+    "known tokens produce no unknowns" [] unknowns;
+  Alcotest.(check (float 0.0001))
+    "metric unchanged" before (total_unknown ())
+
+let test_unknown_token_reported () =
+  let prompt = "Call keeper_p0_3_fictional_tool to proceed." in
+  let before = total_unknown () in
+  let unknowns =
+    Scanner.scan_text ~keeper_name:keeper ~source:User_message prompt
+  in
+  Alcotest.(check (list string))
+    "unknown keeper token is reported"
+    [ "keeper_p0_3_fictional_tool" ]
+    unknowns;
+  Alcotest.(check (float 0.0001))
+    "metric +1" (before +. 1.0) (total_unknown ())
+
+let test_unknown_masc_token_reported () =
+  let prompt = "Use masc_p0_3_unknown_gadget for diagnostics." in
+  let before = total_unknown () in
+  let unknowns =
+    Scanner.scan_text ~keeper_name:keeper ~source:Continuity prompt
+  in
+  Alcotest.(check (list string))
+    "unknown masc token is reported"
+    [ "masc_p0_3_unknown_gadget" ]
+    unknowns;
+  Alcotest.(check (float 0.0001))
+    "metric +1" (before +. 1.0) (total_unknown ())
+
+let test_deduplicates_within_surface () =
+  (* The same unknown token repeated three times should emit only one counter
+     increment for this surface. *)
+  let prompt =
+    "keeper_p0_3_dup appears here and keeper_p0_3_dup there and \
+     keeper_p0_3_dup everywhere."
+  in
+  let before = total_unknown () in
+  let unknowns =
+    Scanner.scan_text ~keeper_name:keeper ~source:System_prompt prompt
+  in
+  Alcotest.(check (list string))
+    "deduplicated to a single token" [ "keeper_p0_3_dup" ] unknowns;
+  Alcotest.(check (float 0.0001))
+    "metric +1 for the surface" (before +. 1.0) (total_unknown ())
+
+let test_token_boundaries () =
+  (* Tokens embedded inside larger words or prefixed with tool-token chars
+     should not be matched. *)
+  let prompt =
+    "mykeeper_foo xkeeper_baz foo-keeper_bar keeper_qux"
+  in
+  let unknowns =
+    Scanner.scan_text ~keeper_name:keeper ~source:User_message prompt
+  in
+  Alcotest.(check (list string))
+    "only standalone keeper_qux is matched"
+    [ "keeper_qux" ]
+    unknowns
+
+let test_rendered_prompt_scans_all_surfaces () =
+  let system_prompt = "Known keeper_board_post is fine." in
+  let user_message = "Unknown masc_p0_3_prompt_probe here." in
+  let continuity_summary = "Unknown keeper_p0_3_continuity_probe here." in
+  let before = total_unknown () in
+  let unknowns =
+    Scanner.scan_rendered_prompt
+      ~keeper_name:keeper
+      ~system_prompt
+      ~user_message
+      ~continuity_summary
+  in
+  Alcotest.(check (list string))
+    "returns both distinct unknown tokens"
+    [ "keeper_p0_3_continuity_probe"; "masc_p0_3_prompt_probe" ]
+    unknowns;
+  Alcotest.(check (float 0.0001))
+    "metric +2 across surfaces" (before +. 2.0) (total_unknown ())
+
+let test_case_insensitive_resolution () =
+  (* Mixed-case token text should normalize to lowercase before resolution. *)
+  let prompt = "Use KEEPER_BOARD_POST and Masc_Keeper_Status." in
+  let unknowns =
+    Scanner.scan_text ~keeper_name:keeper ~source:System_prompt prompt
+  in
+  Alcotest.(check (list string))
+    "mixed-case known tokens resolve" [] unknowns
+
+let () =
+  Alcotest.run "keeper_prompt_token_integrity_p0_3"
+    [
+      ( "resolution",
+        [
+          Alcotest.test_case "known tokens not reported" `Quick
+            test_known_tokens_are_not_reported;
+          Alcotest.test_case "unknown keeper token reported" `Quick
+            test_unknown_token_reported;
+          Alcotest.test_case "unknown masc token reported" `Quick
+            test_unknown_masc_token_reported;
+          Alcotest.test_case "deduplicates within surface" `Quick
+            test_deduplicates_within_surface;
+          Alcotest.test_case "token boundaries" `Quick test_token_boundaries;
+          Alcotest.test_case "rendered prompt scans all surfaces" `Quick
+            test_rendered_prompt_scans_all_surfaces;
+          Alcotest.test_case "case insensitive resolution" `Quick
+            test_case_insensitive_resolution;
+        ] );
+    ]

--- a/test/test_reasoning_dialect.ml
+++ b/test/test_reasoning_dialect.ml
@@ -1,0 +1,83 @@
+(** Test Reasoning_dialect registry (P3-1). *)
+
+open Masc
+
+let cfg ?(enable_thinking = None) ?(thinking_budget = None)
+    ?(preserve_thinking = None) ~kind ~model_id () =
+  let base =
+    Llm_provider.Provider_config.make ~kind ~model_id
+      ~base_url:"http://localhost" ()
+  in
+  { base with
+    Llm_provider.Provider_config.enable_thinking
+  ; thinking_budget
+  ; preserve_thinking
+  }
+;;
+
+let anthropic_reasoning () =
+  let d =
+    Reasoning_dialect.of_provider_config
+      (cfg ~kind:Llm_provider.Provider_config.Anthropic
+         ~model_id:"claude-opus-4" ~enable_thinking:(Some true)
+         ~thinking_budget:(Some 16000) ())
+  in
+  Alcotest.(check bool) "supports reasoning" true d.supports_reasoning;
+  (match d.dialect with
+   | Reasoning_dialect.Anthropic_extended { budget_tokens = Some 16000 } -> ()
+   | _ -> Alcotest.fail "expected Anthropic_extended with budget 16000");
+  Alcotest.(check bool) "stop at tool call" true
+    (d.continuation_boundary = Reasoning_dialect.Stop_at_tool_call)
+;;
+
+let openai_o1_reasoning () =
+  let d =
+    Reasoning_dialect.of_provider_config
+      (cfg ~kind:Llm_provider.Provider_config.OpenAI_compat ~model_id:"o1-mini" ())
+  in
+  Alcotest.(check bool) "supports reasoning" true d.supports_reasoning;
+  (match d.dialect with
+   | Reasoning_dialect.Openai_o1 { reasoning_effort = "low" } -> ()
+   | _ -> Alcotest.fail "expected Openai_o1 with low effort");
+  Alcotest.(check bool) "stop at tool call" true
+    (d.continuation_boundary = Reasoning_dialect.Stop_at_tool_call)
+;;
+
+let no_reasoning () =
+  let d =
+    Reasoning_dialect.of_provider_config
+      (cfg ~kind:Llm_provider.Provider_config.OpenAI_compat ~model_id:"gpt-4o" ())
+  in
+  Alcotest.(check bool) "does not support reasoning" false
+    d.supports_reasoning;
+  Alcotest.(check bool) "no dialect" true
+    (d.dialect = Reasoning_dialect.No_reasoning);
+  Alcotest.(check bool) "no boundary" true
+    (d.continuation_boundary = Reasoning_dialect.No_boundary);
+  Alcotest.(check bool) "exclude replay" true
+    (d.replay_policy = Reasoning_dialect.Exclude)
+;;
+
+let preserve_thinking_replay () =
+  let d =
+    Reasoning_dialect.of_provider_config
+      (cfg ~kind:Llm_provider.Provider_config.Anthropic
+         ~model_id:"claude-opus-4" ~enable_thinking:(Some true)
+         ~preserve_thinking:(Some true) ())
+  in
+  Alcotest.(check bool) "include replay" true
+    (d.replay_policy = Reasoning_dialect.Include)
+;;
+
+let () =
+  Alcotest.run
+    "Reasoning_dialect P3-1"
+    [ ( "registry"
+      , [ Alcotest.test_case "anthropic reasoning" `Quick anthropic_reasoning
+        ; Alcotest.test_case "openai o1 reasoning" `Quick openai_o1_reasoning
+        ; Alcotest.test_case "no reasoning" `Quick no_reasoning
+        ; Alcotest.test_case "preserve thinking replay" `Quick
+            preserve_thinking_replay
+        ] )
+    ]
+;;

--- a/test/test_relation_materializer.ml
+++ b/test/test_relation_materializer.ml
@@ -1,0 +1,58 @@
+(** Test Relation_materializer GraphQL batching (P2-3). *)
+
+open Masc
+
+let batch_empty_peers () =
+  let mutation =
+    Relation_materializer.build_batch_mutation ~agent:"alice" ~peers:[]
+      ~context:"test"
+  in
+  Alcotest.(check string) "empty peers -> empty mutation body" "mutation {  }"
+    mutation
+;;
+
+let batch_includes_agent_and_peers () =
+  let mutation =
+    Relation_materializer.build_batch_mutation ~agent:"alice"
+      ~peers:[ "bob"; "charlie" ] ~context:"session"
+  in
+  Alcotest.(check bool) "contains mutation keyword" true
+    (String_util.contains_substring mutation "mutation");
+  Alcotest.(check bool) "contains agent alice" true
+    (String_util.contains_substring mutation "alice");
+  Alcotest.(check bool) "contains peer bob" true
+    (String_util.contains_substring mutation "bob");
+  Alcotest.(check bool) "contains peer charlie" true
+    (String_util.contains_substring mutation "charlie");
+  Alcotest.(check bool) "contains context" true
+    (String_util.contains_substring mutation "session");
+  Alcotest.(check bool) "contains alias c0" true
+    (String_util.contains_substring mutation "c0:");
+  Alcotest.(check bool) "contains alias c1" true
+    (String_util.contains_substring mutation "c1:")
+;;
+
+let batch_escapes_quotes () =
+  let mutation =
+    Relation_materializer.build_batch_mutation ~agent:"a\"lice"
+      ~peers:[ "bo\"b" ] ~context:"c\"tx"
+  in
+  Alcotest.(check bool) "escaped agent quote" true
+    (String_util.contains_substring mutation "a\\\"lice");
+  Alcotest.(check bool) "escaped peer quote" true
+    (String_util.contains_substring mutation "bo\\\"b");
+  Alcotest.(check bool) "escaped context quote" true
+    (String_util.contains_substring mutation "c\\\"tx")
+;;
+
+let () =
+  Alcotest.run
+    "Relation_materializer P2-3"
+    [ ( "graphql_batching"
+      , [ Alcotest.test_case "empty peers" `Quick batch_empty_peers
+        ; Alcotest.test_case "includes agent and peers" `Quick
+            batch_includes_agent_and_peers
+        ; Alcotest.test_case "escapes quotes" `Quick batch_escapes_quotes
+        ] )
+    ]
+;;

--- a/test/test_tool_capability_typed.ml
+++ b/test/test_tool_capability_typed.ml
@@ -71,7 +71,7 @@ let test_has_catalog_inferred_capabilities () =
   (check bool)
     "static inline metadata grants Mcp_context_required"
     true
-    (Tool_capability.has Mcp_context_required "masc_agents");
+    (Tool_capability.has Mcp_context_required "masc_messages");
   (check bool)
     "static destructive metadata grants Destructive"
     true

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -1,0 +1,135 @@
+open Masc
+
+(** P0-2: Registry consistency tests for the Tool_dispatch registries.
+
+    Asserts that:
+    1. The runtime schema-registry key set equals the tag-registry key set.
+    2. Mandatory (core-always) tools are present in the tag/schema registries.
+    3. Retired tool names are absent from the tag/schema/handler registries.
+
+    These invariants are foundational for the MASC/Keeper/OAS overhaul:
+    every tool that can be dispatched must have both a tag (for token
+    validation) and a schema (for input validation), and retired surfaces
+    must not leak back into the runtime registry. *)
+
+let init () = Masc_test_deps.init_keeper_tool_registry ()
+
+let sorted_set names = List.sort_uniq String.compare names
+
+let assert_same_set ~label ~expected ~actual =
+  let expected = sorted_set expected in
+  let actual = sorted_set actual in
+  if expected <> actual
+  then (
+    let missing = List.filter (fun n -> not (List.mem n actual)) expected in
+    let extra = List.filter (fun n -> not (List.mem n expected)) actual in
+    Printf.printf "[%s] missing from actual: [%s]\n" label
+      (String.concat "; " missing);
+    Printf.printf "[%s] extra in actual: [%s]\n" label
+      (String.concat "; " extra);
+    Alcotest.fail (Printf.sprintf "%s set mismatch" label))
+;;
+
+let tag_registry_names () = Tool_dispatch.all_registered_names ()
+let schema_registry_names () = Tool_dispatch.all_schema_names ()
+
+let schema_inventory_names () =
+  List.map (fun (s : Masc_domain.tool_schema) -> s.name) Config.raw_all_tool_schemas
+;;
+
+let test_schema_set_equals_tag_registry_set () =
+  init ();
+  let tags = tag_registry_names () in
+  let schemas = schema_registry_names () in
+  Printf.printf "TAGS (%d): %s\n" (List.length tags)
+    (String.concat "; " (List.sort String.compare tags));
+  Printf.printf "INVENTORY (%d): %s\n" (List.length (schema_inventory_names ()))
+    (String.concat "; " (List.sort String.compare (schema_inventory_names ())));
+  Alcotest.(check int)
+    "tag_registry_count equals schema_registry_count"
+    (Tool_dispatch.tag_registry_count ())
+    (List.length schemas);
+  assert_same_set
+    ~label:"tag_registry vs schema_registry"
+    ~expected:tags
+    ~actual:schemas
+;;
+
+let test_mandatory_tools_are_registered () =
+  init ();
+  let mandatory = Keeper_tool_registry.core_always_tools in
+  List.iter
+    (fun name ->
+      Alcotest.(check bool)
+        (Printf.sprintf "mandatory tool %s has tag" name)
+        true
+        (Option.is_some (Tool_dispatch.lookup_tag name));
+      Alcotest.(check bool)
+        (Printf.sprintf "mandatory tool %s has schema" name)
+        true
+        (Option.is_some (Tool_dispatch.lookup_schema name)))
+    mandatory
+;;
+
+let test_retired_tools_are_absent () =
+  init ();
+  let retired_front_door_tools =
+    [ "masc_operator_snapshot"
+    ; "masc_operator_digest"
+    ; "masc_operator_action"
+    ; "masc_operator_confirm"
+    ; "masc_operator_judgment_write"
+    ; "masc_surface_audit"
+    ; "masc_operation_start"
+    ; "masc_dispatch_tick"
+    ; "masc_goal_review"
+    ]
+  in
+  let retired_tool_admin_surface =
+    [ "masc_tool_admin_snapshot"
+    ; "masc_tool_admin_update"
+    ; "tool_admin_snapshot"
+    ; "tool_admin_update"
+    ]
+  in
+  let retired_masc_tool_shard =
+    [ "masc_tool_list"
+    ; "masc_tool_grant"
+    ; "masc_tool_revoke"
+    ]
+  in
+  let retired_tools =
+    retired_front_door_tools @ retired_tool_admin_surface @ retired_masc_tool_shard
+    |> sorted_set
+  in
+  let leaked_tag =
+    List.filter (fun name -> Option.is_some (Tool_dispatch.lookup_tag name)) retired_tools
+  in
+  let leaked_schema =
+    List.filter (fun name -> Option.is_some (Tool_dispatch.lookup_schema name)) retired_tools
+  in
+  let leaked_handler =
+    List.filter (fun name -> Tool_dispatch.is_registered name) retired_tools
+  in
+  Alcotest.(check (list string)) "retired tools absent from tag registry" [] leaked_tag;
+  Alcotest.(check (list string)) "retired tools absent from schema registry" [] leaked_schema;
+  Alcotest.(check (list string)) "retired tools absent from handler registry" [] leaked_handler
+;;
+
+let () =
+  let open Alcotest in
+  run
+    "Tool_registry_consistency"
+    [ ( "registry_sets"
+      , [ test_case "schema set equals tag_registry set" `Quick
+            test_schema_set_equals_tag_registry_set
+        ] )
+    ; ( "mandatory_tools"
+      , [ test_case "mandatory tools are registered" `Quick
+            test_mandatory_tools_are_registered
+        ] )
+    ; ( "retired_tools"
+      , [ test_case "retired tools are absent" `Quick test_retired_tools_are_absent
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목적
masc main 체크아웃(repo root)에 **미푸시 로컬 커밋**으로 얹혀 있던 캠페인 foundations 배치(`53325d6cf`)를 정식 PR로 origin에 landing합니다.

## 배경 (왜 PR로 올리나)
- repo root의 로컬 main이 origin/main(`5398153a4`)보다 **1 커밋 ahead**였고, `53325d6cf`는 **origin에 없었습니다**.
- 그 결과 `lib/unified_tool_registry.*`(registry ratchet)가 디스크/로컬에만 존재 → 후속 작업(예: `register_all`/`enforce_visible_tag_coverage`를 부트에 배선하는 P2 wiring)을 origin 기준으로 진행 불가.
- 미푸시 직접-커밋 상태를 정식 워크플로(브랜치 → PR → CI → 머지)로 전환합니다. **로컬 main HEAD·working tree·미커밋 WIP는 건드리지 않았습니다**(브랜치는 `53325d6cf` committed history만 가리킴).

## 내용 (커밋 `53325d6cf` "Phase 0-2 + P3-1 foundations", 오너 authored, 27파일)
- **P0**: unified tool registry ratchet, registry consistency tests, rendered prompt token scanner, Memory OS link verification script.
- **P1**: capability/reasoning schema fixes, hierarchical supervision switch isolation.
- **P2**: Memory OS consolidation/GC wiring, Event Log canonical id, Relational Materializer tests.
- **P3-1**: OAS Reasoning Control Library (`Reasoning_dialect`).

## 검증
- 대형 owner 배치이며 코드 변경 없이 그대로 publish — 로컬 pre-validate 생략, **CI에 위임**.
- 머지는 **오너 리뷰 후**. 본 PR은 자동 머지하지 않습니다.

## 주의
- `53325d6cf`는 P0~P3을 한 커밋에 묶은 multi-phase 배치입니다. 본래 phase별 분리가 granularity 원칙에 맞으나, 오너 authored 단일 커밋이라 임의 분할하지 않고 그대로 landing합니다.
- repo root에는 본 커밋 외에 별도 미커밋 WIP(voice/chat + 신규 `lib/eval_harness/`)가 활발히 진행 중 — 본 PR과 무관하며 건드리지 않았습니다.

RFC-WAIVED: 기존 owner-authored 로컬 커밋을 origin에 정식 landing하는 PR로, 에이전트가 새로 작성한 코드 변경이 아님. RFC discovery 게이트는 신규 agent 변경 대상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
