### PR TITLE
fix(dashboard): don't trip SSE fallback on clean WS close

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -372,6 +372,45 @@ describe('dashboard websocket route subscriptions', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('clears lastError on a clean close so the SSE fallback does not engage', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    const subscribe = parseRpc(socket, 1)
+    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: { snapshot: { seq: 1, slices: {} } } })
+    await flushPromises()
+    expect(dashboardWsReady.value).toBe(true)
+
+    // Server-initiated clean close (wasClean=true) is not a degraded-WS error:
+    // lastError stays null so the SSE fallback (dashboard-transport-fallback.ts)
+    // does not fire. reconnect still runs.
+    socket.close({ code: 1001, reason: 'server restart', wasClean: true })
+    expect(dashboardWsLastError.value).toBe(null)
+    expect(dashboardWsReady.value).toBe(false)
+  })
+
+  it('sets lastError on an abnormal close so the SSE fallback can engage', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    const subscribe = parseRpc(socket, 1)
+    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: { snapshot: { seq: 1, slices: {} } } })
+    await flushPromises()
+    expect(dashboardWsReady.value).toBe(true)
+
+    socket.close({ code: 1006, reason: 'connect failed', wasClean: false })
+    expect(dashboardWsLastError.value).not.toBe(null)
+    expect(dashboardWsLastError.value).toContain('code=1006')
+  })
+
   it('drops cached websocket discovery from a different origin', async () => {
     installWebSocketMocks()
     const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -663,11 +663,19 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     if (socket !== ws) return
     const wasReady = dashboardWsReady.value
     const closeError = new Error(formatCloseEventError(event))
+    // Clean close (wasClean=true) is server-initiated (shutdown/redeploy/idle),
+    // not a degraded-WS error. Leaving lastError set on a clean close would trip
+    // the SSE fallback (dashboard-transport-fallback.ts) for every clean close ->
+    // reconnect window, producing the "dashboard keeps falling back to SSE"
+    // symptom. Abnormal closes (wasClean=false: network drop, code 1006/1011)
+    // keep lastError set so the fallback still engages. reconnect runs either
+    // way; pending RPCs are rejected either way (socket is gone).
+    const clean = event.wasClean === true
     clearHeartbeatTimer()
     batch(() => {
       dashboardWsConnected.value = false
       dashboardWsReady.value = false
-      dashboardWsLastError.value = closeError.message
+      dashboardWsLastError.value = clean ? null : closeError.message
     })
     if (!wasReady) clearCachedWsUrl()
     lastSubscribeKey = ''


### PR DESCRIPTION
## Summary

Fixes the "dashboard keeps falling back to SSE" symptom. The WS `onclose` handler set `dashboardWsLastError` unconditionally on **every** close — including clean (`wasClean=true`) server-initiated closes (shutdown / redeploy / idle). The SSE fallback effect engages on `ready=false + lastError truthy`, so every clean close flipped the dashboard to SSE fallback for the duration of the reconnect window.

## Root cause (verified against `origin/main`)

`dashboard/src/dashboard-ws.ts` `onclose` — `dashboardWsLastError.value = closeError.message` regardless of close code or `wasClean`. No classification between normal and abnormal close.

`dashboard/src/dashboard-transport-fallback.ts` fallback effect engages whenever `!(connected && ready) && lastError` is truthy.

Combined: any close (even a graceful server restart) → `lastError` set → SSE fallback toggled on for the reconnect window → toggled back off when WS recovers. The toggle is the user-visible "keeps falling back", and each transition is also a window for stale-delta churn at the WS/SSE boundary.

## What this is NOT (audit findings)

A transport-leak audit verified the adjacent candidates were **not** the root:

- **Server-side SSE resume exists end-to-end.** `lib/sse.ml` assigns a monotonic `next_id` (`:375`), emits the `id:` line (`:332,357`), and the transport replays via `Sse.get_events_after_for_kind` after parsing `Last-Event-ID` (`lib/server/server_mcp_transport_http.ml:567,642`). The native `EventSource` re-sends `Last-Event-ID` automatically. So "no resume / no gap recovery" is false for the observer path.
- **WS RPC timeout already exists.** `sendRpc` (`dashboard-ws.ts:365`) arms a `DASHBOARD_WS_RPC_TIMEOUT_MS` (30s) timer; a dropped pong already triggers reconnect. So "missing pong-timeout" is not the defect here.

This PR addresses the real driver: the fallback flips on for benign closes.

## Change

Classify the close by `wasClean`:

- **Clean close** (`wasClean=true`): leave `dashboardWsLastError = null` → fallback does **not** engage. `reconnect` still runs; pending RPCs are still rejected (the socket is gone either way).
- **Abnormal close** (`wasClean=false`, code 1006/1011, network drop): unchanged — `lastError` stays set so the fallback can still engage when WS is genuinely degraded.

## Verification

- `tsc --noEmit` — clean
- `vitest` `dashboard-ws.test.ts` + `dashboard-transport-fallback.test.ts` — 31/31 passed
- `eslint` changed files — clean
- New regression tests: clean close (`code=1001, wasClean=true`) clears `lastError`; abnormal close (`code=1006, wasClean=false`) sets it.

## Not a workaround

Typed close-code classification (a browser-provided boolean), not a rate cap / cooldown / dedup on the fallback rate. The fallback still engages on genuinely abnormal closes. No RFC waiver needed.

Co-Authored-By: Claude <noreply@anthropic.com>
