### PR TITLE
feat(board): 운영자 게이트 게시글 고정(pinned)

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -39,6 +39,11 @@ export async function deleteBoardPost(postId: string): Promise<boolean> {
   return resp.ok
 }
 
+export async function setBoardPostPinned(postId: string, pinned: boolean): Promise<boolean> {
+  const resp = await post<{ ok: boolean }>('/api/v1/dashboard/board/pin', { post_id: postId, pinned })
+  return resp.ok
+}
+
 export async function deleteTask(taskId: string): Promise<boolean> {
   const resp = await post<{ ok: boolean }>('/api/v1/dashboard/tasks/delete', { task_id: taskId })
   return resp.ok

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -477,6 +477,7 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
         if (rawKind === 'human' || rawKind === 'direct') return 'direct'
         return rawKind === 'automation' || rawKind === 'system' ? rawKind : undefined
       })(),
+    pinned: raw.pinned === true,
     classification_reason: asString(raw.classification_reason, '').trim() || null,
     title,
     body,

--- a/dashboard/src/components/board/board-state.test.ts
+++ b/dashboard/src/components/board/board-state.test.ts
@@ -240,6 +240,19 @@ describe('splitVisiblePosts', () => {
     expect(result.groups).toEqual([])
     expect(result.totalDirect).toBe(0)
   })
+
+  it('floats pinned posts to the top of their category, preserving order otherwise', () => {
+    boardHiddenCategories.value = new Set()
+    const posts = [
+      makePost({ id: 'a' }),
+      makePost({ id: 'b', pinned: true }),
+      makePost({ id: 'c' }),
+    ]
+    const result = splitVisiblePosts(posts)
+    const group = result.groups.find(g => g.posts.length === 3)
+    expect(group).toBeDefined()
+    expect(group!.posts.map(p => p.id)).toEqual(['b', 'a', 'c'])
+  })
 })
 
 describe('filterHint', () => {

--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -274,6 +274,15 @@ export function splitVisiblePosts(posts: readonly BoardPost[]): VisibleBoardGrou
     else { totalDirect += 1 }
   })
 
+  // Operator-pinned posts float to the top of their category. Array.sort is
+  // stable, so the existing order within the pinned / unpinned subsets is kept.
+  const pinnedFirst = (a: BoardPost, b: BoardPost): number =>
+    Number(b.pinned ?? false) - Number(a.pinned ?? false)
+  buckets.article.posts.sort(pinnedFirst)
+  buckets.review.posts.sort(pinnedFirst)
+  buckets.notice.posts.sort(pinnedFirst)
+  buckets.system.posts.sort(pinnedFirst)
+
   const groups = (Object.entries(buckets) as [ContentCategory, typeof buckets.article][])
     .map(([category, b]) => ({ category, posts: b.posts, total: b.total, hidden: b.hidden }))
     .filter(g => g.total > 0)
@@ -386,6 +395,7 @@ export async function loadPostDetail(postId: string) {
       created_at: data.created_at,
       updated_at: data.updated_at,
       post_kind: data.post_kind,
+      pinned: data.pinned,
       classification_reason: data.classification_reason,
       flair: data.flair,
       hearth: data.hearth,

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -209,6 +209,33 @@ describe('BoardSurface Component', () => {
     expect(screen.getByText(/기술 탐색: test topic/)).toBeInTheDocument()
   })
 
+  it('renders a 고정 badge for a pinned post', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-pinned',
+        title: '고정된 공지',
+        body: 'pinned content here',
+        author: 'ani1999',
+        pinned: true,
+      }),
+    ]
+    render(h(BoardSurface, null))
+    expect(screen.getByTitle('고정된 게시글')).toBeInTheDocument()
+  })
+
+  it('omits the 고정 badge for an unpinned post', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-plain',
+        title: '일반 글',
+        body: 'plain content here',
+        author: 'ani1999',
+      }),
+    ]
+    render(h(BoardSurface, null))
+    expect(screen.queryByTitle('고정된 게시글')).not.toBeInTheDocument()
+  })
+
   it('renders post authors as keyboard-discoverable links', () => {
     boardPosts.value = [
       makePost({

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -18,7 +18,7 @@ import { CursorPagination } from '../common/pagination'
 import { stripStateBlocks } from '../../keeper-message'
 import { navigate, navigateToPost, route } from '../../router'
 import { votePost } from '../../api/board'
-import { deleteBoardPost } from '../../api/actions'
+import { deleteBoardPost, setBoardPostPinned } from '../../api/actions'
 import { registerBoardHearthsRefresh } from '../../sse-store'
 import { boardLatencyMetrics, type BoardLatencyMetric } from '../../board-metrics'
 import { MessageWorkspaceTimeline } from './message-workspace-timeline'
@@ -695,6 +695,19 @@ function PostCard({ post }: { post: BoardPost }) {
     }
   }
 
+  const handlePin = async (event: Event) => {
+    event.stopPropagation()
+    const next = !post.pinned
+    try {
+      await setBoardPostPinned(post.id, next)
+      showToast(next ? '게시글을 고정했습니다' : '고정을 해제했습니다', 'success')
+      refreshBoard()
+    } catch (err) {
+      console.warn(`[board] pin toggle failed (post=${post.id})`, err instanceof Error ? err.message : err)
+      showToast('고정 변경에 실패했습니다', 'error')
+    }
+  }
+
   const openPost = () => navigateToPost(post.id)
   const handlePostKeyDown = (event: KeyboardEvent) => {
     if (event.key !== 'Enter' && event.key !== ' ') return
@@ -780,6 +793,7 @@ function PostCard({ post }: { post: BoardPost }) {
           <span class="text-2xs text-[var(--color-fg-muted)]">댓글 ${post.comment_count}</span>
 
           <!-- Category badges -->
+          ${post.pinned ? html`<span class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border bg-[var(--accent-10)] text-[var(--color-accent-fg)] border-[var(--accent-20)]" title="고정된 게시글">📌 고정</span>` : null}
           <span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${categoryBadgeColor(cat)}">${categoryLabel(cat)}</span>
           ${post.flair ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border bg-[var(--cyan-16)] text-[var(--color-accent-fg)] border-[var(--cyan-16)]">flair:${post.flair}</span>` : null}
           ${qualityPercent !== null ? html`
@@ -793,11 +807,21 @@ function PostCard({ post }: { post: BoardPost }) {
           ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
           <${ModerationBadge} status=${post.moderation_status} reportCount=${post.report_count} targetLabel="게시글" />
 
-          <!-- Delete button — reveal on row hover via opacity utilities -->
+          <!-- Pin toggle (owner-gated server-side) + delete — reveal on row hover -->
+          <${ActionButton}
+            variant="ghost"
+            size="sm"
+            class="ml-auto !py-0.5 opacity-0 group-hover:opacity-100"
+            onClick=${handlePin}
+            pressed=${post.pinned ?? false}
+            ariaLabel=${post.pinned ? `고정 해제: ${post.id}` : `고정: ${post.id}`}
+          >
+            ${post.pinned ? '고정 해제' : '고정'}
+          <//>
           <${ActionButton}
             variant="danger"
             size="sm"
-            class="ml-auto !py-0.5 opacity-0 group-hover:opacity-100"
+            class="!py-0.5 opacity-0 group-hover:opacity-100"
             onClick=${handleDelete}
             disabled=${isDeleting}
             ariaBusy=${isDeleting}

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -590,10 +590,11 @@ export function PostDetail({ post }: { post: BoardPost }) {
           </div>
 
           <!-- Badges -->
-          ${(post.flair || post.hearth || post.visibility || post.expires_at || post.classification_reason || qualityPercent !== null || (post.moderation_status && post.moderation_status !== 'none') || (post.report_count ?? 0) > 0)
+          ${(post.pinned || post.flair || post.hearth || post.visibility || post.expires_at || post.classification_reason || qualityPercent !== null || (post.moderation_status && post.moderation_status !== 'none') || (post.report_count ?? 0) > 0)
             ? html`
                 <div class="flex flex-col gap-2">
                   <div class="flex gap-1.5 flex-wrap">
+                    ${post.pinned ? html`<span class="inline-flex items-center gap-0.5 px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border bg-[var(--accent-10)] text-[var(--color-accent-fg)] border-[var(--accent-20)]" title="고정된 게시글">📌 고정</span>` : null}
                     ${post.flair ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border bg-[var(--cyan-16)] text-[var(--color-accent-fg)] border-[var(--cyan-16)]">flair:${post.flair}</span>` : null}
                     ${post.hearth ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
                     ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}

--- a/dashboard/src/store-reconcile.test.ts
+++ b/dashboard/src/store-reconcile.test.ts
@@ -82,6 +82,14 @@ describe('reconcileBoardPosts', () => {
     expect(result[0]).toBe(updated)
   })
 
+  it('detects change when pinned differs without updated_at changing', () => {
+    const post = makePost({ pinned: false })
+    const prev = [post]
+    const updated = { ...post, pinned: true }
+    const result = reconcileBoardPosts(prev, [updated])
+    expect(result[0]).toBe(updated)
+  })
+
   it('detects change when array length differs (new post added)', () => {
     const existing = makePost({ id: 'p-1' })
     const prev = [existing]

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -987,6 +987,7 @@ function canReuseBoardPost(previous: BoardPost, next: BoardPost): boolean {
     && previous.vote_balance === next.vote_balance
     && previous.comment_count === next.comment_count
     && previous.post_kind === next.post_kind
+    && previous.pinned === next.pinned
     && previous.classification_reason === next.classification_reason
     && previous.title === next.title
     && previous.body === next.body

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -169,6 +169,7 @@ export interface BoardPost {
   author: string
   author_identity?: BoardActorIdentity | null
   post_kind?: 'direct' | 'automation' | 'system'
+  pinned?: boolean
   classification_reason?: string | null
   title: string
   body: string

--- a/lib/board/board_core_json.ml
+++ b/lib/board/board_core_json.ml
@@ -25,6 +25,7 @@ let post_to_yojson (p : post) : Yojson.Safe.t =
      ; "votes_down", `Int p.votes_down
      ; "score", `Int (p.votes_up - p.votes_down)
      ; "reply_count", `Int p.reply_count
+     ; "pinned", `Bool p.pinned
      ]
      @ (match p.hearth with
         | Some h -> [ "hearth", `String h ]

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -484,6 +484,7 @@ let create_post_with_outcome
                     ; votes_up = 0
                     ; votes_down = 0
                     ; reply_count = 0
+                    ; pinned = false
                     ; hearth
                     ; thread_id
                     }

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -610,6 +610,10 @@ let set_thread_id ~post_id ~thread_id =
   match backend () with
   | Jsonl store -> Board.set_thread_id store ~post_id ~thread_id
 
+let set_pinned ~post_id ~pinned =
+  match backend () with
+  | Jsonl store -> Board.set_pinned store ~post_id ~pinned
+
 let delete_post ~post_id =
   match backend () with
   | Jsonl store -> Board.delete_post store ~post_id

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -164,6 +164,13 @@ val set_thread_id :
   thread_id:string ->
   (unit, Board.board_error) Result.t
 
+val set_pinned :
+  post_id:string ->
+  pinned:bool ->
+  (unit, Board.board_error) Result.t
+(** Sets the [pinned] flag on a post (operator pin). Owner-gated at the
+    HTTP boundary; persists across restart. *)
+
 val search :
   query:string ->
   limit:int ->

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -575,6 +575,32 @@ let set_thread_id store ~post_id ~thread_id : (unit, board_error) Result.t =
             Ok ()
       )
 
+(** Set a post's [pinned] flag (operator-curated pin, owner-gated at the HTTP
+    boundary). Persists immediately via [append_post] (like [create_post])
+    rather than only marking dirty for the flusher: pinning is a low-frequency
+    operator action that must survive a restart in the flush window, unlike
+    [vote] (high-frequency, flusher-batched) or [set_thread_id] (in-memory). *)
+let set_pinned store ~post_id ~pinned : (unit, board_error) Result.t =
+  match Post_id.of_string post_id with
+  | Error e -> Error e
+  | Ok pid ->
+      let result =
+        with_lock store (fun () ->
+          match Hashtbl.find_opt store.posts (Post_id.to_string pid) with
+          | None -> Error (Post_not_found post_id)
+          | Some post ->
+              let now = Time_compat.now () in
+              let updated = { post with pinned; updated_at = now } in
+              Hashtbl.replace store.posts (Post_id.to_string pid) updated;
+              invalidate_post_caches store;
+              Ok updated)
+      in
+      match result with
+      | Error e -> Error e
+      | Ok updated ->
+          with_persist_lock store (fun () -> append_post updated);
+          Ok ()
+
 let posts_jsonl_snapshot store =
   let buf = Buffer.create 4096 in
   Hashtbl.iter (fun _ (pst : post) ->
@@ -978,6 +1004,7 @@ let post_to_yojson_with_karma (p : post) ~author_karma : Yojson.Safe.t =
     ("votes_down", `Int p.votes_down);
     ("score", `Int (p.votes_up - p.votes_down));
     ("reply_count", `Int p.reply_count);
+    ("pinned", `Bool p.pinned);
   ] @ (match p.hearth with Some h -> [("hearth", `String h)] | None -> [])
     @ (match p.thread_id with Some t -> [("thread_id", `String t)] | None -> [])
     @ (match p.meta_json with Some meta -> [("meta", meta)] | None -> []))

--- a/lib/board/board_votes.mli
+++ b/lib/board/board_votes.mli
@@ -156,6 +156,15 @@ val set_thread_id :
     Conversation linker to bridge a Board post to a
     persisted Conversation thread. *)
 
+val set_pinned :
+  store ->
+  post_id:string ->
+  pinned:bool ->
+  (unit, board_error) Result.t
+(** Sets the post's [pinned] flag (operator-curated pin).
+    Marks the post dirty so the change persists to
+    posts.jsonl and survives restart. *)
+
 val delete_post :
   store -> post_id:string -> (unit, board_error) Result.t
 (** Removes the post and every comment under it from the

--- a/lib/board/board_votes_json.ml
+++ b/lib/board/board_votes_json.ml
@@ -36,6 +36,8 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
     let reply_count = Safe_ops.json_int ~default:0 "reply_count" json in
     let hearth = Safe_ops.json_string_opt "hearth" json in
     let thread_id = Safe_ops.json_string_opt "thread_id" json in
+    (* Missing on legacy rows persisted before the pin field existed -> default false. *)
+    let pinned = Safe_ops.json_bool ~default:false "pinned" json in
     let post_kind_opt =
       match Safe_ops.json_string_opt "post_kind" json with
       | Some raw -> post_kind_of_string raw
@@ -103,6 +105,7 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
             ; votes_up
             ; votes_down
             ; reply_count
+            ; pinned
             ; hearth
             ; thread_id
             })

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -158,6 +158,7 @@ type post = {
   votes_up: int;
   votes_down: int;
   reply_count: int;
+  pinned: bool;              (* Operator-curated pin (owner-gated): floats the post to the top of its category *)
   hearth: string option;     (* Topic category within the Board *)
   thread_id: string option;  (* Linked Conversation thread *)
 }

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -104,6 +104,7 @@ type post = {
   votes_up : int;
   votes_down : int;
   reply_count : int;
+  pinned : bool;
   hearth : string option;
   thread_id : string option;
 }

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -327,6 +327,30 @@ let add_delete_action_routes router =
          )
        ) request reqd)
 
+  (* Pin is an operator-curated board mutation: same CanAdmin gate and auth
+     helper as board/delete, so it lives alongside it rather than as an
+     agent-facing MCP tool (which would let any keeper self-pin). *)
+  |> Http.Router.post "/api/v1/dashboard/board/pin" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun _state _agent_name req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let json = Yojson.Safe.from_string body_str in
+             match Safe_ops.json_string_opt "post_id" json with
+             | None ->
+                 respond_error ~request:req reqd (invalid_request "post_id")
+             | Some post_id ->
+             let pinned = Safe_ops.json_bool ~default:true "pinned" json in
+             match Board_dispatch.set_pinned ~post_id ~pinned with
+             | Ok () -> respond_ok ~request:req reqd
+             | Error err ->
+                 respond_error ~status:`Not_found ~request:req reqd
+                   (Board_types.show_board_error err)
+           with Yojson.Json_error _ ->
+             respond_error ~request:req reqd (invalid_request "post_id")
+         )
+       ) request reqd)
+
   |> Http.Router.post "/api/v1/dashboard/tasks/delete" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
          (fun state _agent_name req reqd ->

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -894,6 +894,42 @@ let test_set_thread_id () =
               Alcotest.(check (option string)) "thread_id set"
                 (Some "thread-abc") p.thread_id
 
+let test_set_pinned () =
+  match
+    Board_dispatch.create_post ~author:"pin-test" ~content:"pin me"
+      ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      let pid = Board.Post_id.to_string post.id in
+      Alcotest.(check bool) "post starts unpinned" false post.pinned;
+      (match Board_dispatch.set_pinned ~post_id:pid ~pinned:true with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok () -> ());
+      (match Board_dispatch.get_post ~post_id:pid with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok p -> Alcotest.(check bool) "pinned set in memory" true p.pinned);
+      (* set_pinned marks the post dirty, so the flag must survive a restart
+         (unlike set_thread_id which is in-memory only). *)
+      Board.reset_global_for_test ();
+      Board_dispatch.reset_for_test ();
+      Board_dispatch.init_jsonl ();
+      (match Board_dispatch.get_post ~post_id:pid with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok p -> Alcotest.(check bool) "pinned survives restart" true p.pinned);
+      (match Board_dispatch.set_pinned ~post_id:pid ~pinned:false with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok () -> ());
+      match Board_dispatch.get_post ~post_id:pid with
+      | Error e -> Alcotest.fail (Board.show_board_error e)
+      | Ok p -> Alcotest.(check bool) "unpinned after toggle off" false p.pinned
+
+let test_set_pinned_missing_post () =
+  match Board_dispatch.set_pinned ~post_id:"never-existed" ~pinned:true with
+  | Ok () -> Alcotest.fail "expected Post_not_found"
+  | Error (Board.Post_not_found _) -> ()
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+
 let test_flush () =
   Board_dispatch.flush ()
 
@@ -1322,6 +1358,8 @@ let () =
       Alcotest.test_case "search" `Quick (with_eio test_search);
       Alcotest.test_case "hearths" `Quick (with_eio test_hearths);
       Alcotest.test_case "set_thread_id" `Quick (with_eio test_set_thread_id);
+      Alcotest.test_case "set_pinned toggle + restart" `Quick (with_eio test_set_pinned);
+      Alcotest.test_case "set_pinned missing post" `Quick (with_eio test_set_pinned_missing_post);
       Alcotest.test_case "flush" `Quick (with_eio test_flush);
     ];
     "validation", [


### PR DESCRIPTION
## 목표

Board 게시글에 **운영자 큐레이션 핀(고정)** 기능을 추가합니다. v2 디자인의 "Board pinned" 표면을 풀스택(백엔드 포함)으로 구현합니다.

## 설계 결정 — 누가 핀할 수 있는가 (경계)

핀은 **owner(CanAdmin) 권한 게이트의 대시보드 전용 HTTP route**로 노출합니다 (board delete route와 동일 패턴).

- **MCP tool로 만들지 않은 이유**: tool로 노출하면 모든 키퍼가 자기 글을 핀할 수 있는 self-promotion 레버가 생깁니다. 또한 닫힌 enum `Board_name` + `capability_registry` + `tool_resource_axis` + `tool_catalog` + `catalog_surfaces` + `keeper_tool_name` + `board_tool_adapter` 등 ~15개 등록 표면을 건드려야 합니다.
- route 방식은 `authorize_token_bound_permission_request ~permission:CanAdmin`(RFC-0236 음성 route와 동일)을 재사용하므로 tool 등록 표면을 전혀 건드리지 않습니다.

## 변경 파일

### 백엔드 (OCaml)
- `lib/board_types/board_types.{ml,mli}` — `post` record에 `pinned: bool` 추가 (.mli도 미러)
- `lib/board/board_core_json.ml` — `post_to_yojson`(영속용 인코더)에 `pinned` emit
- `lib/board/board_votes.ml` — `post_to_yojson_with_karma`(대시보드 API 인코더)에 `pinned` emit + `set_pinned` mutator (즉시 `append_post` 영속)
- `lib/board/board_votes_json.ml` — `post_of_yojson`에 `pinned` 파싱 (`Safe_ops.json_bool ~default:false`, legacy row 하위호환)
- `lib/board/board_core_persist.ml` — 신규 post 생성 시 `pinned = false`
- `lib/board/board_dispatch.{ml,mli}` — `set_pinned ~post_id ~pinned` facade
- `lib/server/server_dashboard_http_delete_actions.ml` — `POST /api/v1/dashboard/board/pin` (CanAdmin 게이트)

### 프론트엔드 (Preact + htm)
- `dashboard/src/types/core.ts` — `BoardPost.pinned?: boolean`
- `dashboard/src/api/board.ts` — `normalizeBoardPost`에서 `pinned` 디코드
- `dashboard/src/api/actions.ts` — `setBoardPostPinned(postId, pinned)`
- `dashboard/src/components/board/board-surface.ts` — 📌 고정 badge + 고정/해제 토글 버튼(hover, 서버 CanAdmin 강제)
- `dashboard/src/components/board/post-detail.ts` — detail 패널 고정 badge
- `dashboard/src/components/board/board-state.ts` — `splitVisiblePosts` 카테고리 내 pinned-first 안정 정렬 + `loadPostDetail`에 pinned 복사(silent-drop 방지)
- `dashboard/src/store.ts` — `canReuseBoardPost` 메모에 `pinned` 비교(핀 변경 시 리렌더)

## 인코더 2개 모두 갱신 (write↔read 라운드트립)
post 인코더가 둘입니다: `post_to_yojson`(jsonl 영속 + tool-route 응답)과 `post_to_yojson_with_karma`(대시보드 피드). 한쪽만 고치면 "저장되는데 안 보임" 또는 그 반대의 split-brain이 되므로 둘 다 emit합니다.

## 로컬 검증
- OCaml 풀 빌드(`dune build --root .`): exit 0
- 신규 OCaml 테스트: `set_pinned` 토글+재시작 영속, 없는 post 404 → 통과
- 신규 TS 테스트: pinned-first 정렬, 고정 badge 렌더 유무, reconcile 리렌더 → 통과
- `tsc --noEmit`: 0 errors / `eslint`: 0 errors / `vitest`: 전부 통과 / `vite build`: exit 0

## 알려진 pre-existing 실패 (이 PR과 무관)
아래 3건은 `origin/main`과 byte-identical한 테스트/코드(`git diff origin/main` 0줄, `board_core_classify.ml` 무변경)에서도 동일하게 실패하는 기존 drift입니다 — 본 PR이 유발하지 않았고, 분류 도메인이라 범위 밖입니다:
- `test_board_ttl` "keeper provenance upgrade": post_kind는 automation으로 정상 분류되나 기대 `classification_reason` 문자열 포맷이 옛 버전
- `test_board_dispatch` "reclassify dry-run and apply": 동일 분류기 drift
- `test_board_api_e2e` "missing post returns 404": 404는 정상 반환되나 에러 body 텍스트가 "Post not found" 미포함

RFC-WAIVED: board 도메인 기능 추가(pinned 필드 + CanAdmin route). credential/identity/repo_manager/operator/sandbox/hooks/workflow subsystem 미해당.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
