### PR TITLE
feat(keeper): producer-assigned chat message id, dashboard keys off it (R3)

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -106,6 +106,19 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out?.speaker_authority).toBeUndefined()
   })
 
+  it('passes the R3 producer-assigned id through when present', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({ id: 'msg-0001700000000000-0' }),
+    )
+    expect(out?.id).toBe('msg-0001700000000000-0')
+  })
+
+  it('accepts rows without an id (pre-R3 backend during the deploy window)', () => {
+    const out = safeParseKeeperChatHistoryMessage(validMessage())
+    expect(out).not.toBeNull()
+    expect(out?.id).toBeUndefined()
+  })
+
   it('composes in a filter chain — drops garbage entries silently', () => {
     const raw: unknown[] = [
       validMessage(),

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -44,6 +44,13 @@ export const SurfaceRefSchema = object({
 })
 
 export const KeeperChatHistoryMessageSchema = object({
+  // R3: producer-assigned stable message id (keeper_chat_store.ml mints it
+  // at append and the read boundary stamps legacy rows, so the backend now
+  // emits it on every row). Left optional for the deploy window — a
+  // dashboard deployed ahead of the backend would otherwise drop every
+  // message; the consumer falls back to a stable content-derived id when
+  // it is absent.
+  id: optional(string()),
   role: string(),
   content: string(),
   ts: number(),

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -231,3 +231,52 @@ describe('thread history merge & persistence', () => {
     expect(keeperThreads.value.echo?.[0]?.id).toBe('e-5')
   })
 })
+
+describe('R3 producer-assigned message id', () => {
+  it('keys history entries off the server-minted id when present', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      { id: 'msg-0001700000000000-0', role: 'user', content: 'hi', ts: 1_780_000_000 },
+      { id: 'msg-0001700000000000-1', role: 'assistant', content: 'hello', ts: 1_780_000_000 },
+    ])
+    expect(entries.map(e => e.id)).toEqual([
+      'msg-0001700000000000-0',
+      'msg-0001700000000000-1',
+    ])
+  })
+
+  it('derives a stable content-keyed id when a row predates R3 (no id)', () => {
+    const first = chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'same text', ts: 1_780_000_000 },
+    ])
+    const second = chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'same text', ts: 1_780_000_000 },
+    ])
+    // Deterministic across calls — the former id was index/timestamp
+    // derived; the fallback is content derived so it never shifts.
+    expect(first[0]?.id).toBeTruthy()
+    expect(first[0]?.id).toBe(second[0]?.id)
+  })
+
+  it('keeps the fallback id stable regardless of page position (the old index bug)', () => {
+    const alone = chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'stable', ts: 1_780_000_000 },
+    ])
+    const shifted = chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'earlier', ts: 1_779_000_000 },
+      { role: 'assistant', content: 'reply', ts: 1_779_000_000 },
+      { role: 'user', content: 'stable', ts: 1_780_000_000 },
+    ])
+    const aloneId = alone.find(e => e.rawText === 'stable')?.id
+    const shiftedId = shifted.find(e => e.rawText === 'stable')?.id
+    expect(aloneId).toBeTruthy()
+    expect(shiftedId).toBe(aloneId)
+  })
+
+  it('gives different content different fallback ids', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'one', ts: 1_780_000_000 },
+      { role: 'user', content: 'two', ts: 1_780_000_000 },
+    ])
+    expect(entries[0]?.id).not.toBe(entries[1]?.id)
+  })
+})

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -216,9 +216,23 @@ export function normalizeKeeperRecoverResult(raw: unknown): KeeperRecoverResult 
 
 // --- Thread state management ---
 
+// Stable fallback id for a message whose backend predates R3 and so
+// carries no producer-assigned id. Derived from the content (not the merge
+// index) so it does not shift when history pages are merged.
+function fallbackHistoryEntryId(
+  role: string,
+  timestamp: string | null | undefined,
+  text: string,
+): string {
+  let hash = 5381
+  for (let i = 0; i < text.length; i += 1) {
+    hash = ((hash << 5) + hash + text.charCodeAt(i)) | 0
+  }
+  return `${role}-${timestamp ?? 'entry'}-${(hash >>> 0).toString(36)}`
+}
+
 function normalizeHistoryEntry(
   raw: unknown,
-  index: number,
   keeperName?: string,
   previousSource: KeeperConversationSource | null = null,
 ): KeeperConversationEntry | null {
@@ -233,7 +247,11 @@ function normalizeHistoryEntry(
   const label = role === 'assistant' && keeperName ? keeperName : roleLabel(role)
   const surface = isRecord(raw.surface) ? (raw.surface as unknown as SurfaceRef) : null
   return {
-    id: `${role}-${timestamp ?? 'entry'}-${index}`,
+    // R3: key off the producer-assigned server id when present so the
+    // render key is stable across history-page merges (the former
+    // `${role}-${ts}-${index}` shifted with the merge index and remounted
+    // bubbles). Pre-R3 rows fall back to a stable content-derived id.
+    id: asString(raw.id) ?? fallbackHistoryEntryId(role, timestamp, rawText),
     role,
     source,
     label,
@@ -253,8 +271,8 @@ export function normalizeStatusDetail(name: string, text: string, rawStatus: unk
     ? (() => {
         let previousSource: KeeperConversationSource | null = null
         return parsed.history_tail
-          .map((entry, index) => {
-            const normalized = normalizeHistoryEntry(entry, index, name, previousSource)
+          .map((entry) => {
+            const normalized = normalizeHistoryEntry(entry, name, previousSource)
             previousSource = normalized?.source ?? previousSource
             return normalized
           })
@@ -365,6 +383,14 @@ export function finalizeAssistantEntry(
 // produced duplicate bubbles on every history merge. Source is also
 // excluded — REST history has no source field, so the derived source
 // can differ from the local one for the same message.
+//
+// R3 made every history entry carry the producer-assigned server id, so
+// render keys are now stable; this optimistic-vs-server dedup still keys
+// on role+text because a locally-appended entry is created before the
+// server mints its id and so cannot match by id yet. Replacing it with id
+// equality needs a send-response id handshake (the POST returning the
+// minted id for the optimistic entry to adopt) — tracked as the R3
+// follow-up, deliberately out of this change's scope.
 function sameConversationEntry(
   left: KeeperConversationEntry,
   right: KeeperConversationEntry,
@@ -403,6 +429,7 @@ export function mergeServerHistoryEntries(
 }
 
 interface RestChatHistoryMessage {
+  id?: string
   role: string
   content: string
   ts: number
@@ -445,7 +472,7 @@ export function chatHistoryEntriesFromRest(
 ): KeeperConversationEntry[] {
   let previousSource: KeeperConversationSource | null = null
   const entries: KeeperConversationEntry[] = []
-  messages.forEach((message, index) => {
+  messages.forEach((message) => {
     if (message.role === 'tool') {
       // Tool rows do not participate in user/assistant source chaining.
       const toolEntry = toolHistoryEntry(message)
@@ -453,8 +480,7 @@ export function chatHistoryEntriesFromRest(
       return
     }
     const normalized = normalizeHistoryEntry(
-      { role: message.role, content: message.content, ts_unix: message.ts },
-      index,
+      { id: message.id, role: message.role, content: message.content, ts_unix: message.ts },
       keeperName,
       previousSource,
     )

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -143,6 +143,13 @@ type speaker = {
 }
 
 type chat_message = {
+  id : string;
+      (* R3: producer-assigned stable message id.  Minted once at append
+         by [encode_line] (the sole writer) and read back verbatim, so the
+         dashboard keys off a server identity instead of synthesising an
+         index-derived id at render.  Rows written before R3 carry no
+         persisted id and are given a deterministic one at the read
+         boundary ([legacy_message_id]); the field is therefore total. *)
   role : Role.t;
   content : string;
   ts : float option;
@@ -220,6 +227,33 @@ let audio_fields = function
   | None -> []
   | Some a -> [ ("audio", `Assoc (audio_to_json a)) ]
 
+(* R3: producer-assigned message id.  [encode_line] is the sole writer, so
+   minting here makes it impossible to persist a row without an id.  The
+   process-monotonic counter disambiguates the user/tool/assistant rows of
+   one turn (they share a timestamp); the microsecond timestamp orders ids
+   across processes.  Minted ids are persisted, so reads are deterministic
+   even though the mint itself is not. *)
+let message_id_counter = Atomic.make 0
+
+let mint_message_id ~ts =
+  let n = Atomic.fetch_and_add message_id_counter 1 in
+  Printf.sprintf "msg-%016.0f-%d" (ts *. 1_000_000.) n
+
+(* Rows written before R3 carry no persisted id.  Derive a stable one at
+   the read boundary from the row's timestamp and content so the dashboard
+   keys off a single deterministic id and never synthesises an
+   index-derived one that shifts when history pages are merged.  Two
+   byte-identical legacy rows collapse to the same id, which is acceptable:
+   they are indistinguishable and predate the per-row identity. *)
+let legacy_message_id ~ts ~content =
+  let ts_part =
+    match ts with
+    | Some t -> Printf.sprintf "%016.0f" (t *. 1_000_000.)
+    | None -> "nots"
+  in
+  Printf.sprintf "legacy-%s-%s" ts_part
+    (String.sub (Digest.to_hex (Digest.string content)) 0 12)
+
 let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     ?tool_call_name ?surface ?conversation_id ?external_message_id ?speaker
     ?audio ?(mentions = []) ?(kind = Row_kind.Utterance) ()
@@ -234,6 +268,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     | Some s -> [ ("surface", Surface_ref.to_json s) ]
   in
   let base_fields = [
+    ("id", `String (mint_message_id ~ts));
     ("role", `String (Role.to_label role));
     ("content", `String content);
     ("ts", `Float ts);
@@ -254,7 +289,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     match attachments with
     | None | Some [] -> []
     | Some atts ->
-        let att_json = List.map (fun att ->
+        let att_json = List.map (fun (att : attachment) ->
           `Assoc [
             ("id", `String att.id);
             ("type", `String att.att_type);
@@ -609,8 +644,13 @@ let parse_line ~file_path (line : string) : chat_message option =
             ~detail:"tool chat row missing non-empty tool_call_name";
           None
       | Some role ->
+          let id =
+            match opt_string "id" with
+            | Some persisted -> persisted
+            | None -> legacy_message_id ~ts ~content
+          in
           Some
-            { role; content; ts; attachments; tool_call_id; tool_call_name;
+            { id; role; content; ts; attachments; tool_call_id; tool_call_name;
               source; surface; conversation_id; external_message_id; speaker;
               audio; mentions; kind }
   with Yojson.Json_error detail ->
@@ -782,7 +822,8 @@ let to_json_array (messages : chat_message list) : Yojson.Safe.t =
     (List.map
        (fun m ->
          `Assoc
-           ([ ("role", `String (Role.to_label m.role));
+           ([ ("id", `String m.id);
+              ("role", `String (Role.to_label m.role));
               ("content", `String m.content);
             ] @ (match m.ts with
                  | Some t -> [("ts", `Float t)]
@@ -803,7 +844,7 @@ let to_json_array (messages : chat_message list) : Yojson.Safe.t =
               @ (match m.attachments with
                  | None | Some [] -> []
                  | Some atts ->
-                     let att_json = List.map (fun att ->
+                     let att_json = List.map (fun (att : attachment) ->
                        `Assoc [
                          ("id", `String att.id);
                          ("type", `String att.att_type);

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -105,6 +105,13 @@ type speaker = {
 }
 
 type chat_message = {
+  id : string;
+      (** R3: producer-assigned stable message id, minted once at append by
+          the sole writer ({!encode_line}) and read back verbatim, so the
+          dashboard keys off a server identity rather than synthesising an
+          index-derived id at render.  Rows written before R3 carry no
+          persisted id and are given a deterministic one at the read
+          boundary, so the field is total. *)
   role : Role.t;
   content : string;
   ts : float option;

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -540,7 +540,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
     else
       payload.message
   in
-  let attachment_json att =
+  let attachment_json (att : Keeper_chat_store.attachment) =
     `Assoc
       [ ("id", `String att.Keeper_chat_store.id);
         ("type", `String att.att_type);

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -106,7 +106,9 @@ let test_merge_batch () =
       (String.equal m.Keeper_chat_queue.content "first\n\nsecond\n\nthird");
     check
       "attachments concatenate in order"
-      (List.map (fun a -> a.Keeper_chat_store.id) m.Keeper_chat_queue.attachments
+      (List.map
+         (fun (a : Keeper_chat_store.attachment) -> a.Keeper_chat_store.id)
+         m.Keeper_chat_queue.attachments
        = [ "a"; "b" ]);
     check "timestamp is the first message's" (m.Keeper_chat_queue.timestamp = 1.0);
     check

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -187,6 +187,72 @@ let test_legacy_lines_parse_without_new_fields () =
       | messages ->
           Alcotest.failf "expected 2 messages, got %d" (List.length messages))
 
+(* R3: every persisted row carries a producer-assigned id that is
+   non-empty, unique within a turn, and stable across reloads. *)
+let test_message_id_minted_unique_and_stable () =
+  let base_dir = temp_base_path "keeper-chat-store-id" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-id" in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"run the checks"
+        ~user_attachments:[] ~assistant_content:"all green" ();
+      let ids_of () =
+        List.map (fun (m : K.chat_message) -> m.id) (K.load ~base_dir ~keeper_name)
+      in
+      let ids = ids_of () in
+      List.iter
+        (fun id ->
+          Alcotest.(check bool) "row id is non-empty" true (String.length id > 0))
+        ids;
+      Alcotest.(check int) "ids are unique across the turn" (List.length ids)
+        (List.length (List.sort_uniq String.compare ids));
+      Alcotest.(check (list string)) "ids stable across reloads" ids (ids_of ()))
+
+(* R3: rows written before the id field load with a deterministic id
+   derived at the read boundary, so it is stable across reloads and two
+   distinct rows get distinct ids — no index-derived synthesis. *)
+let test_legacy_row_gets_deterministic_id () =
+  let base_dir = temp_base_path "keeper-chat-store-legacy-id" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-legacy-id" in
+      let path = chat_path ~base_dir ~keeper_name in
+      write_file path
+        ({|{"role":"user","content":"hello","ts":1.0}|} ^ "\n"
+        ^ {|{"role":"assistant","content":"world","ts":1.0}|} ^ "\n");
+      let ids_of () =
+        List.map (fun (m : K.chat_message) -> m.id) (K.load ~base_dir ~keeper_name)
+      in
+      let first = ids_of () in
+      Alcotest.(check int) "two legacy rows loaded" 2 (List.length first);
+      List.iter
+        (fun id ->
+          Alcotest.(check bool) "legacy id non-empty" true (String.length id > 0))
+        first;
+      Alcotest.(check (list string)) "legacy ids deterministic across reloads"
+        first (ids_of ());
+      match first with
+      | [ a; b ] ->
+          Alcotest.(check bool) "distinct legacy rows get distinct ids" true (a <> b)
+      | _ -> Alcotest.fail "expected 2 legacy ids")
+
+(* R3: the /chat/history payload surfaces the id so the dashboard keys off
+   it instead of synthesising one. *)
+let test_to_json_array_exposes_id () =
+  let base_dir = temp_base_path "keeper-chat-store-id-json" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-id-json" in
+      K.append_user_message ~base_dir ~keeper_name ~content:"hi" ();
+      match K.to_json_array (K.load ~base_dir ~keeper_name) with
+      | `List (`Assoc fields :: _) ->
+          Alcotest.(check bool) "payload row carries an id" true
+            (List.mem_assoc "id" fields)
+      | _ -> Alcotest.fail "expected a non-empty json array of assoc rows")
+
 let test_recent_direct_context_renders_prior_reply_and_tool_evidence () =
   let base_dir = temp_base_path "keeper-chat-recent-context" in
   Fun.protect
@@ -862,6 +928,12 @@ let () =
             test_append_turn_roundtrip;
           Alcotest.test_case "legacy lines parse" `Quick
             test_legacy_lines_parse_without_new_fields;
+          Alcotest.test_case "message id minted unique and stable (R3)" `Quick
+            test_message_id_minted_unique_and_stable;
+          Alcotest.test_case "legacy row gets deterministic id (R3)" `Quick
+            test_legacy_row_gets_deterministic_id;
+          Alcotest.test_case "to_json_array exposes id (R3)" `Quick
+            test_to_json_array_exposes_id;
           Alcotest.test_case "recent context renders reply and tool evidence" `Quick
             test_recent_direct_context_renders_prior_reply_and_tool_evidence;
           Alcotest.test_case "recent context omits transport failure as reply" `Quick

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -48,7 +48,8 @@ let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None)
     ?(kind = Store.Row_kind.Utterance) content
   : Store.chat_message
   =
-  { role
+  { id = "test-msg"
+  ; role
   ; content
   ; ts
   ; attachments = None
@@ -185,7 +186,8 @@ let test_none_ts_assistant_still_clears () =
 ;;
 
 let tool_line : Store.chat_message =
-  { role = Store.Role.Tool
+  { id = "test-tool"
+  ; role = Store.Role.Tool
   ; content = "{}"
   ; ts = Some 10.5
   ; attachments = None

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -12,6 +12,7 @@ module SR = Masc.Keeper_surface_read
 
 let msg ?ts ?source ?speaker ~role content : Store.chat_message =
   {
+    id = "test-msg";
     role;
     content;
     ts;


### PR DESCRIPTION
## Summary

Give every keeper chat row a producer-assigned stable id and have the
dashboard key off it, replacing a client-synthesised `${role}-${ts}-${index}`
id whose index shifted on every history-page merge (remounting bubbles).

## Problem

`keeper_chat_store` minted no per-message id — not in the persisted JSONL
row, the `/chat/history` payload, nor the in-memory record. The dashboard
synthesised `${role}-${timestamp}-${index}` at consume time
(`keeper-state.ts`) and used it as the lit-html render key. Because that id
is index-derived it shifted when history pages merged, so the same message
remounted; reconciliation then fell back to a role+text dedup
(`sameConversationEntry`) that collides on duplicate text.

## Change

**Backend (producer mints once):**
- `chat_message` gains a total `id : string`. `encode_line` (the sole
  writer) stamps every row `msg-<ts-micros>-<process-counter>`; the read
  boundary stamps pre-R3 rows a deterministic `legacy-<ts>-<content-hash>`,
  so the field is never absent downstream (parse, don't validate).
- `to_json_array` surfaces `id` in the `/chat/history` payload.
- The SSE `keeper_chat_appended` event is unchanged — it carries no message
  body, only a refetch trigger, so there is no id to assign there.

**Dashboard (consume the server id):**
- `KeeperChatHistoryMessageSchema` gains `id: optional(string())` — optional
  only for the deploy window, matching the file's documented backend-ahead
  rationale.
- History entries key off the server `id`; an absent id falls back to a
  stable content-derived id (no longer the merge index).
- `tool` rows keep their `tool-<tool_call_id>` convention (already a stable
  id shared with the live stream path).

**Out of scope (documented follow-up):** the optimistic-local-vs-server
dedup still keys on role+text — a locally-appended entry has no server id
yet. Moving it to id equality needs a send-response id handshake; noted at
the dedup site.

## Field-inference note

Adding `chat_message.id` collided with `attachment.id` in record field
inference (same module, `attachment` defined first). The four
attachment-access lambdas are annotated `(att : attachment)`, and three
test fixtures that build a `chat_message` inline gain a placeholder id. No
behavioural change.

## Verification

- `DUNE_CACHE=disabled dune build --root .` green; changed `.ml/.mli` pass
  `ocamlformat --check`.
- `test_keeper_chat_store` +3 cases (id minted unique+stable; legacy
  deterministic id; `to_json_array` exposes id). One pre-existing local
  failure (`owner-direct recent transcript`) reproduces on origin/main
  without this change — a local Eio-fs/backend env artifact, verified in a
  clean baseline worktree.
- dashboard `tsc --noEmit` + `eslint src` clean; `keeper-state` /
  `keeper-chat-history` vitest +6 cases (server id used; stable
  position-independent fallback; schema passes id through and accepts its
  absence).

## Scope

Typed-harness contract **C3** (producer mints identity once, carried
through). Removes a client-synthesised unstable id and the render-key churn
it caused.

RFC-WAIVED: no credential/identity/sandbox/operator-control/hooks change —
keeper chat persistence + dashboard chat reconciliation only; not in the
agent-delegation RFC-gated subsystem list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
