### PR TITLE
feat(logs): typed categories, FSM filters, and fix false-positive keeper directive warns

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -128,6 +128,8 @@ export async function fetchLogs(opts?: {
   level?: string
   module?: string
   since_seq?: number
+  category?: string
+  exclude_category?: string
 }): Promise<LogsResponse> {
   const params = new URLSearchParams()
   if (opts?.limit) params.set('limit', String(opts.limit))
@@ -136,6 +138,8 @@ export async function fetchLogs(opts?: {
   if (typeof opts?.since_seq === 'number' && opts.since_seq >= 0) {
     params.set('since_seq', String(opts.since_seq))
   }
+  if (opts?.category) params.set('category', opts.category)
+  if (opts?.exclude_category) params.set('exclude_category', opts.exclude_category)
   const qs = params.toString()
   const raw = await get<unknown>(`/api/v1/dashboard/logs${qs ? `?${qs}` : ''}`)
   return parseLogsResponse(raw)

--- a/dashboard/src/api/schemas/logs.ts
+++ b/dashboard/src/api/schemas/logs.ts
@@ -37,6 +37,7 @@ const LogEntrySchema = object({
   message: string(),
   keeper_name: optional(nullable(string())),
   turn_id: optional(nullable(number())),
+  category: optional(nullable(string())),
   details: optional(nullable(record(string(), unknown()))),
 })
 
@@ -74,6 +75,8 @@ export interface LogsQuery {
   min_level?: number
   module?: string
   since_seq?: number | null
+  category?: string
+  exclude_category?: string
 }
 
 export interface LogsResponse {

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -15,6 +15,7 @@ function entry(overrides: Partial<LogEntry>): LogEntry {
     keeper_name: null,
     turn_id: null,
     details: null,
+    category: null,
     ...overrides,
   }
 }

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -54,6 +54,8 @@ const logLimit = signal(200)
 const providerLogProvider = signal('')
 const providerLogLines = signal(200)
 const latestSeq = signal<number | null>(null)
+const categoryFilter = signal('')
+const hideFsmTransitions = signal(false)
 
 const POLL_INTERVAL_MS = 3000
 const LOG_ROW_HEIGHT = 92
@@ -78,6 +80,41 @@ const SOURCE_LABELS: Record<string, string> = {
   legacy_traceln: 'trace line',
   client_tool_host: 'client tool-host',
   sse: 'sse',
+}
+
+const CATEGORIES: readonly string[] = [
+  'fsm',
+  'lifecycle',
+  'directive',
+  'heartbeat',
+  'presence',
+  'task',
+  'tool',
+  'memory',
+  'telemetry',
+  'routine',
+  'boundary',
+  'uncategorized',
+]
+
+const CATEGORY_LABELS: Record<string, string> = {
+  fsm: 'FSM',
+  lifecycle: 'Lifecycle',
+  directive: 'Directive',
+  heartbeat: 'Heartbeat',
+  presence: 'Presence',
+  task: 'Task',
+  tool: 'Tool',
+  memory: 'Memory',
+  telemetry: 'Telemetry',
+  routine: 'Routine',
+  boundary: 'Boundary',
+  uncategorized: 'Uncategorized',
+}
+
+function categoryLabel(category: string | null | undefined): string | null {
+  if (!category) return null
+  return CATEGORY_LABELS[category] ?? category
 }
 
 type LoadMode = 'reset' | 'delta'
@@ -310,6 +347,8 @@ async function loadLogs(mode: LoadMode = 'reset') {
         limit: logLimit.value,
         level: levelFilter.value,
         module: appliedModuleFilter.value || undefined,
+        category: categoryFilter.value || undefined,
+        exclude_category: hideFsmTransitions.value ? 'fsm' : undefined,
       })
       const entries = sortLogEntries(resp.entries).slice(0, Math.max(1, logLimit.value))
       latestSeq.value = latestLogSeq(entries)
@@ -328,6 +367,8 @@ async function loadLogs(mode: LoadMode = 'reset') {
       level: levelFilter.value,
       module: appliedModuleFilter.value || undefined,
       since_seq: latestSeq.value ?? undefined,
+      category: categoryFilter.value || undefined,
+      exclude_category: hideFsmTransitions.value ? 'fsm' : undefined,
     })
     if (requestId !== latestRequestId) return
 
@@ -387,6 +428,7 @@ function renderLogRow(entry: LogEntry) {
   const sourceClass = sourceTone(source)
   const renderedMessage = renderLogMessage(entry)
   const routeLinks = logRouteLinks(entry)
+  const category = categoryLabel(entry.category)
   const diagnosticChip = failure
     ? html`<${StatusChip} tone="bad" uppercase=${false}>${failure.cause_code}</${StatusChip}>`
     : null
@@ -416,6 +458,9 @@ function renderLogRow(entry: LogEntry) {
       </div>
       <div class="flex flex-wrap items-start gap-1">
         <${StatusChip} tone=${sourceClass}>${sourceLabel(source)}</${StatusChip}>
+        ${category
+          ? html`<${MetaTag}>${category}</${MetaTag}>`
+          : null}
         ${clientName
           ? html`<${StatusChip} tone="border-[var(--color-accent-soft)] text-[var(--color-accent-fg)]" uppercase=${false}>${clientName}</${StatusChip}>`
           : null}
@@ -649,6 +694,8 @@ export function LogViewer() {
     const unsubscribeLevel = levelFilter.subscribe(restart)
     const unsubscribeModule = appliedModuleFilter.subscribe(restart)
     const unsubscribeLimit = logLimit.subscribe(restart)
+    const unsubscribeCategory = categoryFilter.subscribe(restart)
+    const unsubscribeHideFsm = hideFsmTransitions.subscribe(restart)
     const unsubscribeAutoRefresh = autoRefresh.subscribe(restart)
 
     return () => {
@@ -658,6 +705,8 @@ export function LogViewer() {
       unsubscribeLevel()
       unsubscribeModule()
       unsubscribeLimit()
+      unsubscribeCategory()
+      unsubscribeHideFsm()
       unsubscribeAutoRefresh()
     }
   }, [])
@@ -764,6 +813,31 @@ export function LogViewer() {
               options=${['100', '200', '500', '1000', '3000']}
               onInput=${(v: string) => { logLimit.value = parseInt(v, 10) }}
             />
+
+            <${Select}
+              class="logs-select px-3 py-2 text-xs"
+              name="log-category"
+              ariaLabel="Category"
+              value=${categoryFilter.value}
+              options=${[
+                { value: '', label: 'All categories' },
+                ...CATEGORIES.map(category => ({
+                  value: category,
+                  label: CATEGORY_LABELS[category] ?? category,
+                })),
+              ]}
+              onInput=${(v: string) => { categoryFilter.value = v }}
+            />
+
+            <label class="logs-hide-fsm-label flex items-center gap-1.5 cursor-pointer text-2xs text-[var(--color-fg-muted)]">
+              <${Checkbox}
+                name="log-hide-fsm"
+                ariaLabel="Hide FSM transitions"
+                checked=${hideFsmTransitions.value}
+                onChange=${(checked: boolean) => { hideFsmTransitions.value = checked }}
+              />
+              Hide FSM transitions
+            </label>
           </div>
 
           <div class="logs-actions flex flex-wrap gap-3 items-center text-2xs text-[color:var(--color-fg-muted)]">

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -101,7 +101,11 @@ let persist_directive_meta_update
       Keeper_metrics.(to_string WriteMetaFailures)
       ~labels:[ "keeper", entry.name; "site", "directive_persist" ]
       ();
-    Log.Keeper.warn "directive meta persist failed for %s: %s" entry.name msg;
+    Log.Keeper.emit
+      Log.Warn
+      ~category:Log.Heartbeat
+      ~details:(`Assoc [ "keeper", `String entry.name; "error", `String msg ])
+      (Printf.sprintf "directive meta persist failed for %s: %s" entry.name msg);
     Keeper_registry.update_meta ~base_path:entry.base_path entry.name updated_meta
 ;;
 
@@ -115,6 +119,39 @@ let directive_paused_meta (meta : keeper_meta) paused =
   }
 ;;
 
+let log_directive_agent_not_in_registry ~agent_name ~action =
+  let known_keeper () =
+    match Keeper_tool_shared_runtime.find_registry_meta ~keeper_name:agent_name ~source_layer:"directive" with
+    | Some _ -> true
+    | None ->
+      (match Keeper_identity.canonical_keeper_name_from_agent_name agent_name with
+       | None -> false
+       | Some canonical_name ->
+         Option.is_some
+           (Keeper_tool_shared_runtime.find_registry_meta
+              ~keeper_name:canonical_name
+              ~source_layer:"directive"))
+  in
+  if known_keeper ()
+  then
+    Log.Keeper.emit
+      Log.Debug
+      ~category:Log.Directive
+      ~details:
+        (`Assoc
+          [ "agent_name", `String agent_name
+          ; "action", `String action
+          ; "reason", `String "not_yet_registered"
+          ])
+      (Printf.sprintf "directive %s: agent %s not yet registered" action agent_name)
+  else
+    Log.Keeper.emit
+      Log.Warn
+      ~category:Log.Directive
+      ~details:(`Assoc [ "agent_name", `String agent_name; "action", `String action ])
+      (Printf.sprintf "directive %s: agent %s not in registry" action agent_name)
+;;
+
 let set_keeper_paused_state ~agent_name paused =
   with_keeper_entry_by_identity
     ~identity:agent_name
@@ -124,7 +161,7 @@ let set_keeper_paused_state ~agent_name paused =
         Keeper_metrics.(to_string DirectiveFailures)
         ~labels:[ "keeper", agent_name; "site", "pause_resume_not_in_registry" ]
         ();
-      Log.Keeper.warn "directive %s: agent %s not in registry" action agent_name)
+      log_directive_agent_not_in_registry ~agent_name ~action)
     (fun entry ->
        let updated_meta = directive_paused_meta entry.meta paused in
        persist_directive_meta_update entry ~updated_meta;
@@ -153,7 +190,7 @@ let wakeup_keeper_by_agent_name ~agent_name =
         Keeper_metrics.(to_string DirectiveFailures)
         ~labels:[ "keeper", agent_name; "site", "wakeup_not_in_registry" ]
         ();
-      Log.Keeper.warn "directive wakeup: agent %s not in registry" agent_name)
+      log_directive_agent_not_in_registry ~agent_name ~action:"wakeup")
     (fun entry -> wakeup_keeper ~base_path:entry.base_path entry.name)
 ;;
 
@@ -165,7 +202,7 @@ let assign_keeper_task_from_directive ~agent_name ~task_id =
         Keeper_metrics.(to_string DirectiveFailures)
         ~labels:[ "keeper", agent_name; "site", "claim_not_in_registry" ]
         ();
-      Log.Keeper.warn "directive claim: agent %s not in registry" agent_name)
+      log_directive_agent_not_in_registry ~agent_name ~action:"claim")
     (fun entry ->
        let updated_meta =
          { entry.meta with current_task_id = Some task_id; updated_at = now_iso () }
@@ -186,10 +223,18 @@ let assign_keeper_task_from_directive ~agent_name ~task_id =
 let process_directive ~agent_name directive =
   match directive with
   | "pause" ->
-    Log.Keeper.info "directive: pausing keeper %s" agent_name;
+    Log.Keeper.emit
+      Log.Info
+      ~category:Log.Directive
+      ~details:(`Assoc [ "agent_name", `String agent_name; "action", `String "pause" ])
+      (Printf.sprintf "directive: pausing keeper %s" agent_name);
     set_keeper_paused_state ~agent_name true
   | "resume" ->
-    Log.Keeper.info "directive: resuming keeper %s" agent_name;
+    Log.Keeper.emit
+      Log.Info
+      ~category:Log.Directive
+      ~details:(`Assoc [ "agent_name", `String agent_name; "action", `String "resume" ])
+      (Printf.sprintf "directive: resuming keeper %s" agent_name);
     set_keeper_paused_state ~agent_name false
   | "wakeup" ->
     (* Auto-resume on wakeup: dashboard "깨우기" surfaces a single button,
@@ -217,24 +262,52 @@ let process_directive ~agent_name directive =
     Keeper_turn_livelock.reset_keeper_livelock ~keeper:agent_name;
     if entry_paused
     then (
-      Log.Keeper.info "directive: waking up %s (was paused — auto-resuming)" agent_name;
+      Log.Keeper.emit
+        Log.Info
+        ~category:Log.Directive
+        ~details:(`Assoc [ "agent_name", `String agent_name; "action", `String "wakeup_auto_resume" ])
+        (Printf.sprintf "directive: waking up %s (was paused — auto-resuming)" agent_name);
       set_keeper_paused_state ~agent_name false)
     else (
-      Log.Keeper.debug "directive: waking up %s" agent_name;
+      Log.Keeper.emit
+        Log.Debug
+        ~category:Log.Directive
+        ~details:(`Assoc [ "agent_name", `String agent_name; "action", `String "wakeup" ])
+        (Printf.sprintf "directive: waking up %s" agent_name);
       wakeup_keeper_by_agent_name ~agent_name)
   | s when String.length s > 6 && String.starts_with s ~prefix:"claim:" ->
     let task_id = String.sub s 6 (String.length s - 6) in
     (match Keeper_id.Task_id.of_string task_id with
      | Ok parsed_task_id ->
-       Log.Keeper.info "directive: server assigned task %s to %s" task_id agent_name;
+       Log.Keeper.emit
+         Log.Info
+         ~category:Log.Directive
+         ~details:
+           (`Assoc
+             [ "agent_name", `String agent_name
+             ; "action", `String "claim"
+             ; "task_id", `String task_id
+             ])
+         (Printf.sprintf "directive: server assigned task %s to %s" task_id agent_name);
        assign_keeper_task_from_directive ~agent_name ~task_id:parsed_task_id
      | Error err ->
-       Log.Keeper.warn
-         "directive: ignoring invalid task assignment for %s (%s): %s"
-         agent_name
-         task_id
-         err)
-  | unknown -> Log.Keeper.warn "unknown gRPC directive for %s: %s" agent_name unknown
+       Log.Keeper.emit
+         Log.Warn
+         ~category:Log.Directive
+         ~details:
+           (`Assoc
+             [ "agent_name", `String agent_name
+             ; "action", `String "claim"
+             ; "task_id", `String task_id
+             ; "error", `String err
+             ])
+         (Printf.sprintf "directive: ignoring invalid task assignment for %s (%s): %s" agent_name task_id err))
+  | unknown ->
+    Log.Keeper.emit
+      Log.Warn
+      ~category:Log.Directive
+      ~details:(`Assoc [ "agent_name", `String agent_name; "directive", `String unknown ])
+      (Printf.sprintf "unknown gRPC directive for %s: %s" agent_name unknown)
 ;;
 
 (* ── gRPC heartbeat stream ── *)
@@ -250,10 +323,16 @@ let reconcile_current_task_id_for_heartbeat ~config ~agent_name =
       Keeper_metrics.(to_string ReconcileFailures)
       ~labels:[ "keeper", agent_name; "phase", "grpc_heartbeat" ]
       ();
-    Log.Keeper.warn
-      "gRPC heartbeat: failed to reconcile current_task_id for %s: %s"
-      agent_name
-      (Printexc.to_string exn);
+    Log.Keeper.emit
+      Log.Warn
+      ~category:Log.Heartbeat
+      ~details:
+        (`Assoc
+          [ "keeper", `String agent_name; "error", `String (Printexc.to_string exn) ])
+      (Printf.sprintf
+         "gRPC heartbeat: failed to reconcile current_task_id for %s: %s"
+         agent_name
+         (Printexc.to_string exn));
     false
 ;;
 
@@ -328,7 +407,11 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
          Keeper_metrics.(to_string WriteMetaFailures)
          ~labels:[ "keeper", synced.name; "phase", "bootstrap" ]
          ();
-       Log.Keeper.warn "write_meta failed (bootstrap): %s" e);
+       Log.Keeper.emit
+         Log.Warn
+         ~category:Log.Heartbeat
+         ~details:(`Assoc [ "keeper", `String synced.name; "error", `String e ])
+         (Printf.sprintf "write_meta failed (bootstrap): %s" e));
     synced
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -337,7 +420,11 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
       Keeper_metrics.(to_string WriteMetaFailures)
       ~labels:[ "keeper", m.name; "phase", "bootstrap-catch" ]
       ();
-    Log.Keeper.error "workspace presence bootstrap failed: %s" (Printexc.to_string exn);
+    Log.Keeper.emit
+      Log.Error
+      ~category:Log.Heartbeat
+      ~details:(`Assoc [ "keeper", `String m.name; "error", `String (Printexc.to_string exn) ])
+      (Printf.sprintf "workspace presence bootstrap failed: %s" (Printexc.to_string exn));
     m
 ;;
 
@@ -382,10 +469,18 @@ let dispatch_fiber_started ~base_path keeper_name =
       Keeper_metrics.(to_string DispatchEventFailures)
       ~labels:[ "keeper", keeper_name; "site", "fiber_started_rejected" ]
       ();
-    Log.Keeper.warn
-      "keeper %s: Fiber_started rejected during launch: %s"
-      keeper_name
-      (Keeper_state_machine.transition_error_to_string err)
+    Log.Keeper.emit
+      Log.Warn
+      ~category:Log.Fsm
+      ~details:
+        (`Assoc
+          [ "keeper", `String keeper_name
+          ; "error", `String (Keeper_state_machine.transition_error_to_string err)
+          ])
+      (Printf.sprintf
+         "keeper %s: Fiber_started rejected during launch: %s"
+         keeper_name
+         (Keeper_state_machine.transition_error_to_string err))
 ;;
 
 (* ── Registry lifecycle helpers ── *)
@@ -462,9 +557,11 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
       Keeper_metrics.(to_string HeartbeatFailures)
       ~labels:[ "keeper", m.name; "phase", "identity_drift_unrepairable" ]
       ();
-    Log.Keeper.error
-      "start_keepalive skipped %s: identity drift could not be repaired"
-      m.name
+    Log.Keeper.emit
+      Log.Error
+      ~category:Log.Heartbeat
+      ~details:(`Assoc [ "keeper", `String m.name; "reason", `String "identity_drift_unrepairable" ])
+      (Printf.sprintf "start_keepalive skipped %s: identity drift could not be repaired" m.name)
   | Some m ->
     let existing_entry =
       Keeper_registry.get ~base_path:ctx.config.base_path m.name
@@ -488,14 +585,27 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
     in
     (match existing_entry with
      | Some entry when reclaimable_stale_entry entry ->
-       Log.Keeper.info
-         "start_keepalive: reclaiming stale registered entry %s phase=%s"
-         m.name
-         (Keeper_state_machine.phase_to_string entry.phase);
+       Log.Keeper.emit
+         Log.Info
+         ~category:Log.Heartbeat
+         ~details:
+           (`Assoc
+             [ "keeper", `String m.name
+             ; "phase", `String (Keeper_state_machine.phase_to_string entry.phase)
+             ])
+         (Printf.sprintf
+            "start_keepalive: reclaiming stale registered entry %s phase=%s"
+            m.name
+            (Keeper_state_machine.phase_to_string entry.phase));
        Keeper_registry.unregister ~base_path:ctx.config.base_path m.name
      | _ -> ());
     if Keeper_registry.is_registered ~base_path:ctx.config.base_path m.name
-    then Log.Keeper.info "start_keepalive: skipped %s (already registered)" m.name
+    then
+      Log.Keeper.emit
+        Log.Info
+        ~category:Log.Heartbeat
+        ~details:(`Assoc [ "keeper", `String m.name ])
+        (Printf.sprintf "start_keepalive: skipped %s (already registered)" m.name)
     else
       match Keeper_registry.spawn_slots_decision () with
       | Error reason ->
@@ -578,10 +688,18 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
               Keeper_metrics.(to_string CleanupTrackingFailures)
               ~labels:[ "keeper", live_meta.name; "site", "heartbeat_finally" ]
               ();
-            Log.Keeper.warn
-              "%s: cleanup_tracking in heartbeat finally raised: %s"
-              live_meta.name
-              (Printexc.to_string e)
+            Log.Keeper.emit
+              Log.Warn
+              ~category:Log.Heartbeat
+              ~details:
+                (`Assoc
+                  [ "keeper", `String live_meta.name
+                  ; "error", `String (Printexc.to_string e)
+                  ])
+              (Printf.sprintf
+                 "%s: cleanup_tracking in heartbeat finally raised: %s"
+                 live_meta.name
+                 (Printexc.to_string e))
         in
         Eio_guard.protect
           (fun () ->
@@ -614,10 +732,18 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
                    Keeper_metrics.(to_string HeartbeatFailures)
                    ~labels:[ "keeper", live_meta.name; "phase", "loop_crash" ]
                    ();
-                 Log.Keeper.error
-                   "heartbeat loop for %s crashed: %s"
-                   live_meta.name
-                   (Printexc.to_string exn);
+                 Log.Keeper.emit
+                   Log.Error
+                   ~category:Log.Heartbeat
+                   ~details:
+                     (`Assoc
+                       [ "keeper", `String live_meta.name
+                       ; "error", `String (Printexc.to_string exn)
+                       ])
+                   (Printf.sprintf
+                      "heartbeat loop for %s crashed: %s"
+                      live_meta.name
+                      (Printexc.to_string exn));
                  record_crash (Keeper_registry.Exception (Printexc.to_string exn))))
           ~finally:safe_cleanup_tracking))
 ;;

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -628,12 +628,24 @@ let rec dispatch_event_with_audit
       (Keeper_state_machine.attribution_of_transition ~event result);
     (match result with
      | Ok tr when tr.new_phase <> tr.prev_phase ->
-       Log.Keeper.info
-         "registry: phase transition name=%s old=%s new=%s event=%s"
-         name
-         (Keeper_state_machine.phase_to_string tr.prev_phase)
-         (Keeper_state_machine.phase_to_string tr.new_phase)
-         (Keeper_state_machine.event_to_string event);
+       let from_phase_str = Keeper_state_machine.phase_to_string tr.prev_phase in
+       let to_phase_str = Keeper_state_machine.phase_to_string tr.new_phase in
+       let event_str = Keeper_state_machine.event_to_string event in
+       Log.Keeper.emit
+         Log.Info
+         ~category:Log.Fsm
+         ~details:
+           (`Assoc
+             [ "from_phase", `String from_phase_str
+             ; "to_phase", `String to_phase_str
+             ; "event", `String event_str
+             ])
+         (Printf.sprintf
+            "registry: phase transition name=%s old=%s new=%s event=%s"
+            name
+            from_phase_str
+            to_phase_str
+            event_str);
        (* Record transition in audit ring buffer for dashboard API *)
        Keeper_transition_audit.record_transition
          ~keeper_name:name
@@ -720,27 +732,51 @@ let rec dispatch_event_with_audit
                 (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason })
               ->
               record_followup_dispatch_rejection followup_event;
-              Log.Keeper.error
-                "registry(%s): followup dispatch failed: %s -> %s (%s)"
-                name
-                (Keeper_state_machine.phase_to_string from_phase)
-                (Keeper_state_machine.phase_to_string to_phase)
-                reason
+              let from_phase_str = Keeper_state_machine.phase_to_string from_phase in
+              let to_phase_str = Keeper_state_machine.phase_to_string to_phase in
+              Log.Keeper.emit
+                Log.Error
+                ~category:Log.Fsm
+                ~details:
+                  (`Assoc
+                    [ "from_phase", `String from_phase_str
+                    ; "to_phase", `String to_phase_str
+                    ; "reason", `String reason
+                    ])
+                (Printf.sprintf
+                   "registry(%s): followup dispatch failed: %s -> %s (%s)"
+                   name
+                   from_phase_str
+                   to_phase_str
+                   reason)
             | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
               record_followup_dispatch_rejection followup_event;
-              Log.Keeper.warn
-                "registry(%s): followup skipped, already terminal: %s (event: %s)"
-                name
-                (Keeper_state_machine.phase_to_string current)
-                attempted_event
+              let current_phase_str = Keeper_state_machine.phase_to_string current in
+              Log.Keeper.emit
+                Log.Warn
+                ~category:Log.Fsm
+                ~details:
+                  (`Assoc
+                    [ "current_phase", `String current_phase_str
+                    ; "attempted_event", `String attempted_event
+                    ])
+                (Printf.sprintf
+                   "registry(%s): followup skipped, already terminal: %s (event: %s)"
+                   name
+                   current_phase_str
+                   attempted_event)
             | Error (Keeper_state_machine.Precondition_violation { event = ev; reason })
               ->
               record_followup_dispatch_rejection followup_event;
-              Log.Keeper.warn
-                "registry(%s): followup skipped, precondition violated: %s (%s)"
-                name
-                ev
-                reason)
+              Log.Keeper.emit
+                Log.Warn
+                ~category:Log.Fsm
+                ~details:(`Assoc [ "event", `String ev; "reason", `String reason ])
+                (Printf.sprintf
+                   "registry(%s): followup skipped, precondition violated: %s (%s)"
+                   name
+                   ev
+                   reason))
          (List.filter_map
             (followup_event_of_entry_action ~phase:tr.new_phase)
             tr.entry_actions);
@@ -781,10 +817,17 @@ let rec dispatch_event_with_audit
          Keeper_metrics.(to_string LifecycleDispatchRejections)
          ~labels:[ "event", Keeper_state_machine.event_to_string event ]
          ();
-       Log.Keeper.warn
-         "registry: dispatch_event rejected name=%s error=%s"
-         name
-         (Keeper_state_machine.transition_error_to_string e);
+       let event_str = Keeper_state_machine.event_to_string event in
+       let error_str = Keeper_state_machine.transition_error_to_string e in
+       Log.Keeper.emit
+         Log.Warn
+         ~category:Log.Fsm
+         ~details:
+           (`Assoc
+             [ "event", `String event_str
+             ; "error", `String error_str
+             ])
+         (Printf.sprintf "registry: dispatch_event rejected name=%s error=%s" name error_str);
        Error e)
 ;;
 
@@ -813,10 +856,16 @@ let dispatch_event_unit ~base_path ?(origin = Generic_dispatch) name event =
   match dispatch_event_and_log ~base_path ~origin name event with
   | Ok _ -> ()
   | Error e ->
-    Log.Keeper.warn
-      "%s: dispatch_event failed: %s"
-      name
-      (Keeper_state_machine.transition_error_to_string e)
+    let error_str = Keeper_state_machine.transition_error_to_string e in
+    Log.Keeper.emit
+      Log.Warn
+      ~category:Log.Fsm
+      ~details:
+        (`Assoc
+          [ "event", `String (Keeper_state_machine.event_to_string event)
+          ; "error", `String error_str
+          ])
+      (Printf.sprintf "%s: dispatch_event failed: %s" name error_str)
 ;;
 
 let dispatch_event_with_audit_and_log
@@ -868,11 +917,15 @@ let prepare_fiber_launch ~base_path name =
           reset.  Log so the race is at least visible — caller
           (server_runtime_bootstrap.ml) is responsible for ensuring
           register_with_state has happened before this point. *)
-     Log.Keeper.warn
-       "registry: prepare_fiber_launch name=%s base_path=%s: entry not registered, \
-        skipping flag reset"
-       name
-       base_path);
+     Log.Keeper.emit
+       Log.Warn
+       ~category:Log.Fsm
+       ~details:(`Assoc [ "keeper", `String name; "base_path", `String base_path ])
+       (Printf.sprintf
+          "registry: prepare_fiber_launch name=%s base_path=%s: entry not registered, \
+           skipping flag reset"
+          name
+          base_path));
   dispatch_event ~base_path name Keeper_state_machine.Fiber_started
 ;;
 

--- a/lib/keeper/keeper_registry_entry_action_dispatch.ml
+++ b/lib/keeper/keeper_registry_entry_action_dispatch.ml
@@ -16,12 +16,23 @@ let execute_observability
   =
   match action with
   | Keeper_state_machine.Publish_lifecycle { event_name; detail } ->
-    Log.Keeper.info
-      "registry: lifecycle name=%s phase=%s event=%s detail=%s"
-      name
-      (Keeper_state_machine.phase_to_string phase)
-      event_name
-      detail;
+    let phase_str = Keeper_state_machine.phase_to_string phase in
+    Log.Keeper.emit
+      Log.Info
+      ~category:Log.Lifecycle
+      ~details:
+        (`Assoc
+          [ "name", `String name
+          ; "phase", `String phase_str
+          ; "event", `String event_name
+          ; "detail", `String detail
+          ])
+      (Printf.sprintf
+         "registry: lifecycle name=%s phase=%s event=%s detail=%s"
+         name
+         phase_str
+         event_name
+         detail);
     let (_ignore_ts : float) = ts_unix in
     ()
   | Start_compaction

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -25,9 +25,22 @@ let guard_transition ?ctx ~keeper_name ~turn_id ~from_state ~to_state () =
          sequenced after [wrap_unit] would never run, so the
          diagnostic warn has to precede it for operators to see
          *which* transition violated. *)
-      Log.Keeper.warn ~keeper_name ~turn_id
-        "[fsm:transition:violation] %s -> %s (%s)"
-        violation.from_state violation.to_state violation.reason;
+      Log.Keeper.emit
+        Log.Warn
+        ~keeper_name
+        ~turn_id
+        ~category:Log.Fsm
+        ~details:
+          (`Assoc
+            [ "from_state", `String violation.from_state
+            ; "to_state", `String violation.to_state
+            ; "reason", `String violation.reason
+            ])
+        (Printf.sprintf
+           "[fsm:transition:violation] %s -> %s (%s)"
+           violation.from_state
+           violation.to_state
+           violation.reason);
       let stage = violation.from_state ^ "->" ^ violation.to_state in
       (* [Invalid_argument] (not [assert false]) carries an explicit
          message into the re-raise backtrace.  Operators reading a
@@ -116,12 +129,25 @@ let emit_transition ?ctx ~keeper_name ~turn_id ?prev state =
     | Some action, _ -> transition_action_label action
     | None, None -> "initial"
     | None, Some _ ->
-        Log.Keeper.warn ~keeper_name ~turn_id
-          "[fsm:transition:unclassified] %s -> %s — classify_transition \
-           has no arm for this (from, to) pair; add one in \
-           lib/turn_fsm/turn_fsm.ml::classify_transition so the \
-           audit trail captures the action"
-          prev_label state_label;
+        Log.Keeper.emit
+          Log.Warn
+          ~keeper_name
+          ~turn_id
+          ~category:Log.Fsm
+          ~details:
+            (`Assoc
+              [ "from_state", `String prev_label
+              ; "to_state", `String state_label
+              ; "action", `String "unclassified"
+              ; "reason", `String "classify_transition has no arm for this (from, to) pair"
+              ])
+          (Printf.sprintf
+             "[fsm:transition:unclassified] %s -> %s — classify_transition \
+              has no arm for this (from, to) pair; add one in \
+              lib/turn_fsm/turn_fsm.ml::classify_transition so the \
+              audit trail captures the action"
+             prev_label
+             state_label);
         "unclassified"
   in
   let stop_label =
@@ -131,9 +157,27 @@ let emit_transition ?ctx ~keeper_name ~turn_id ?prev state =
           c.stop_signaled_before c.stop_signaled_after
     | None -> ""
   in
-  Log.Keeper.info ~keeper_name ~turn_id
-    "[fsm:transition] %s -> %s action=%s%s" prev_label state_label action_label
-    stop_label;
+  let stop_details =
+    match ctx with
+    | Some c ->
+      [ "stop_signaled_before", `Bool c.stop_signaled_before
+      ; "stop_signaled_after", `Bool c.stop_signaled_after
+      ]
+    | None -> []
+  in
+  Log.Keeper.emit
+    Log.Info
+    ~keeper_name
+    ~turn_id
+    ~category:Log.Fsm
+    ~details:
+      (`Assoc
+        ([ "from_state", `String prev_label
+         ; "to_state", `String state_label
+         ; "action", `String action_label
+         ]
+         @ stop_details))
+    (Printf.sprintf "[fsm:transition] %s -> %s action=%s%s" prev_label state_label action_label stop_label);
   Keeper_transition_audit.record_turn_fsm_transition
     ~keeper_name
     { turn_fsm_turn_id = turn_id

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -15,6 +15,50 @@ type source =
 
 type event_class = Routine
 
+type category =
+  | Fsm
+  | Lifecycle
+  | Directive
+  | Heartbeat
+  | Presence
+  | Task
+  | Tool
+  | Memory
+  | Telemetry
+  | Routine
+  | Boundary
+  | Uncategorized
+
+let category_to_string : category -> string = function
+  | Fsm -> "fsm"
+  | Lifecycle -> "lifecycle"
+  | Directive -> "directive"
+  | Heartbeat -> "heartbeat"
+  | Presence -> "presence"
+  | Task -> "task"
+  | Tool -> "tool"
+  | Memory -> "memory"
+  | Telemetry -> "telemetry"
+  | Routine -> "routine"
+  | Boundary -> "boundary"
+  | Uncategorized -> "uncategorized"
+
+let category_of_string_opt s : category option =
+  match String.lowercase_ascii (String.trim s) with
+  | "fsm" -> Some Fsm
+  | "lifecycle" -> Some Lifecycle
+  | "directive" -> Some Directive
+  | "heartbeat" -> Some Heartbeat
+  | "presence" -> Some Presence
+  | "task" -> Some Task
+  | "tool" -> Some Tool
+  | "memory" -> Some Memory
+  | "telemetry" -> Some Telemetry
+  | "routine" -> Some Routine
+  | "boundary" -> Some Boundary
+  | "uncategorized" -> Some Uncategorized
+  | _ -> None
+
 (** Current log level (Atomic for thread safety in OCaml 5) *)
 let current_level = Atomic.make 1 (* Info = 1 *)
 
@@ -55,7 +99,7 @@ let source_to_string = function
   | Legacy_traceln -> "legacy_traceln"
   | Client_tool_host -> "client_tool_host"
 
-let event_class_to_string = function
+let event_class_to_string : event_class -> string = function
   | Routine -> "routine"
 
 let has_prefix ~prefix value = String.starts_with ~prefix value
@@ -174,6 +218,7 @@ module Ring = struct
     turn_id : int option;
     message : string;
     details : Yojson.Safe.t;
+    category : category option;
   }
 
   (* Dashboard operators commonly inspect tool-call history over hours, not
@@ -191,6 +236,7 @@ module Ring = struct
       turn_id = None;
       message = "";
       details = `Null;
+      category = None;
     }
   let total = Atomic.make 0 (* total entries ever written *)
 
@@ -257,6 +303,10 @@ module Ring = struct
       | Some i -> `Int i
       | None -> `Null
     in
+    let category_json = match e.category with
+      | Some c -> `String (category_to_string c)
+      | None -> `Null
+    in
     `Assoc [
       ("seq", `Int e.seq);
       ("ts", `String e.ts);
@@ -267,6 +317,7 @@ module Ring = struct
       ("turn_id", turn_id_json);
       ("message", `String e.message);
       ("details", e.details);
+      ("category", category_json);
     ]
 
   let sink_matches_path path oc =
@@ -441,10 +492,16 @@ module Ring = struct
                    (Printf.sprintf "field turn_id: expected int or null, got %s"
                       (Yojson.Safe.to_string other)))
         in
+        let category =
+          match Yojson.Safe.Util.member "category" json with
+          | `String s -> category_of_string_opt s
+          | _ -> None
+        in
         {
           seq; ts; level; source; module_name;
           keeper_name; turn_id; message;
           details = Yojson.Safe.Util.member "details" json;
+          category;
         }
     | _ ->
         raise
@@ -547,6 +604,7 @@ module Ring = struct
       ?(details = `Null)
       ?keeper_name
       ?turn_id
+      ?category
       ~level
       ~module_name
       ~message
@@ -563,6 +621,7 @@ module Ring = struct
         turn_id;
         message;
         details;
+        category;
       } in
     buf.(idx) <- entry;
     if !file_channel <> None then
@@ -570,7 +629,10 @@ module Ring = struct
 
   let recent ?(limit = 200) ?(min_level = 0) ?(module_filter = "")
       ?since_seq
-      ?(order = `Newest_first) () : entry list =
+      ?(order = `Newest_first)
+      ?category_filter
+      ?exclude_category
+      () : entry list =
     let t = Atomic.get total in
     if t = 0 then []
     else begin
@@ -589,7 +651,30 @@ module Ring = struct
         let module_ok = module_filter = "" ||
           String.lowercase_ascii e.module_name =
           String.lowercase_ascii module_filter in
-        if level_ok && module_ok then begin
+        let category_ok =
+          match category_filter with
+          | None -> true
+          | Some filter ->
+              let filter_lower = String.lowercase_ascii filter in
+              if String.equal filter_lower "uncategorized" then
+                Option.is_none e.category
+              else
+                match e.category with
+                | Some c -> String.equal (category_to_string c) filter_lower
+                | None -> false
+        in
+        let exclude_ok =
+          match exclude_category with
+          | None -> true
+          | Some cats ->
+              match e.category with
+              | None -> true
+              | Some c ->
+                  let c_lower = String.lowercase_ascii (category_to_string c) in
+                  not (List.exists (fun ex ->
+                    String.equal c_lower (String.lowercase_ascii ex)) cats)
+        in
+        if level_ok && module_ok && category_ok && exclude_ok then begin
           entries := e :: !entries;
           incr count
         end;
@@ -672,7 +757,7 @@ module Ring = struct
 end
 
 (** Log a message at given level with optional context *)
-let log level ?(ctx : string option) fmt =
+let log level ?(ctx : string option) ?category fmt =
   Printf.ksprintf (fun msg ->
     if should_log level then begin
       let level_str = level_to_string level in
@@ -682,11 +767,11 @@ let log level ?(ctx : string option) fmt =
         | None -> Printf.sprintf "[%s] [%s]" (timestamp ()) level_str
       in
       Console_sink.write (prefix ^ " " ^ msg);
-      Ring.push ~level ~module_name ~message:msg ()
+      Ring.push ~level ~module_name ~message:msg ?category ()
     end
   ) fmt
 
-let emit level ?(module_name = "") ?(details = `Null) message =
+let emit level ?(module_name = "") ?(details = `Null) ?category message =
   if should_log level then begin
     let level_str = level_to_string level in
     let prefix =
@@ -696,7 +781,7 @@ let emit level ?(module_name = "") ?(details = `Null) message =
         Printf.sprintf "[%s] [%s] [%s]" (timestamp ()) level_str module_name
     in
     Console_sink.write (prefix ^ " " ^ message);
-    Ring.push ~level ~module_name ~message ~details ()
+    Ring.push ~level ~module_name ~message ~details ?category ()
   end
 
 let details_with_event_class event_class details =
@@ -712,20 +797,20 @@ let details_with_event_class event_class details =
       `Assoc (event_class_field :: fields)
   | payload -> `Assoc [ event_class_field; ("payload", payload) ]
 
-let emit_event event_class level ?module_name ?(details = `Null) message =
+let emit_event event_class level ?module_name ?(details = `Null) ?category message =
   emit level ?module_name ~details:(details_with_event_class event_class details)
-    message
+    ?category message
 
-let emit_routine ?module_name ?(details = `Null) message =
+let emit_routine ?module_name ?(details = `Null) ?category message =
   match routine_level () with
   | None -> ()
-  | Some level -> emit_event Routine level ?module_name ~details message
+  | Some level -> emit_event Routine level ?module_name ~details ?category message
 
 (** Convenience functions *)
-let debug ?ctx fmt = log Debug ?ctx fmt
-let info ?ctx fmt = log Info ?ctx fmt
-let warn ?ctx fmt = log Warn ?ctx fmt
-let error ?ctx fmt = log Error ?ctx fmt
+let debug ?ctx ?category fmt = log Debug ?ctx ?category fmt
+let info ?ctx ?category fmt = log Info ?ctx ?category fmt
+let warn ?ctx ?category fmt = log Warn ?ctx ?category fmt
+let error ?ctx ?category fmt = log Error ?ctx ?category fmt
 
 (* RFC-0079: [~level] is now required for the mirror functions. The old
    [?level] option backed [infer_legacy_level], a string-prefix classifier
@@ -753,6 +838,7 @@ module type LOGGER = sig
     ?details:Yojson.Safe.t ->
     ?keeper_name:string ->
     ?turn_id:int ->
+    ?category:category ->
     string ->
     unit
 
@@ -760,23 +846,24 @@ module type LOGGER = sig
     ?details:Yojson.Safe.t ->
     ?keeper_name:string ->
     ?turn_id:int ->
+    ?category:category ->
     ('a, unit, string, unit) format4 ->
     'a
 
   val debug :
-    ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
+    ?keeper_name:string -> ?turn_id:int -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
 
   val info :
-    ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
+    ?keeper_name:string -> ?turn_id:int -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
 
   val warn :
-    ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
+    ?keeper_name:string -> ?turn_id:int -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
 
   val warning :
-    ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
+    ?keeper_name:string -> ?turn_id:int -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
 
   val error :
-    ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
+    ?keeper_name:string -> ?turn_id:int -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
 end
 
 (** Module-specific loggers.
@@ -804,7 +891,7 @@ module Make (M : sig val name : string end) = struct
     in
     level_to_int level >= threshold
 
-  let emit level ?(details = `Null) ?keeper_name ?turn_id message =
+  let emit level ?(details = `Null) ?keeper_name ?turn_id ?category message =
     if should_log_module level then begin
       let level_str = level_to_string level in
       let prefix = match keeper_name with
@@ -816,28 +903,28 @@ module Make (M : sig val name : string end) = struct
               (timestamp ()) level_str M.name
       in
       Console_sink.write (prefix ^ " " ^ message);
-      Ring.push ?keeper_name ?turn_id
+      Ring.push ?keeper_name ?turn_id ?category
         ~level ~module_name:M.name ~message ~details ()
     end
 
-  let log_module level ?keeper_name ?turn_id fmt =
-    Printf.ksprintf (fun msg -> emit level ?keeper_name ?turn_id msg) fmt
+  let log_module level ?keeper_name ?turn_id ?category fmt =
+    Printf.ksprintf (fun msg -> emit level ?keeper_name ?turn_id ?category msg) fmt
 
-  let routine ?(details = `Null) ?keeper_name ?turn_id fmt =
+  let routine ?(details = `Null) ?keeper_name ?turn_id ?category fmt =
     Printf.ksprintf
       (fun msg ->
          match routine_level () with
          | None -> ()
          | Some level ->
              emit level ~details:(details_with_event_class Routine details)
-               ?keeper_name ?turn_id msg)
+               ?keeper_name ?turn_id ?category msg)
       fmt
 
-  let debug ?keeper_name ?turn_id fmt = log_module Debug ?keeper_name ?turn_id fmt
-  let info ?keeper_name ?turn_id fmt = log_module Info ?keeper_name ?turn_id fmt
-  let warn ?keeper_name ?turn_id fmt = log_module Warn ?keeper_name ?turn_id fmt
+  let debug ?keeper_name ?turn_id ?category fmt = log_module Debug ?keeper_name ?turn_id ?category fmt
+  let info ?keeper_name ?turn_id ?category fmt = log_module Info ?keeper_name ?turn_id ?category fmt
+  let warn ?keeper_name ?turn_id ?category fmt = log_module Warn ?keeper_name ?turn_id ?category fmt
   let warning = warn
-  let error ?keeper_name ?turn_id fmt = log_module Error ?keeper_name ?turn_id fmt
+  let error ?keeper_name ?turn_id ?category fmt = log_module Error ?keeper_name ?turn_id ?category fmt
 end
 
 (** Pre-defined module loggers *)

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -13,6 +13,28 @@ type event_class = Routine
 val event_class_to_string : event_class -> string
 (** Convert a structured event class to its stable JSON label. *)
 
+(** Log categories for dashboard filtering. *)
+type category =
+  | Fsm
+  | Lifecycle
+  | Directive
+  | Heartbeat
+  | Presence
+  | Task
+  | Tool
+  | Memory
+  | Telemetry
+  | Routine
+  | Boundary
+  | Uncategorized
+
+val category_to_string : category -> string
+(** Canonical lowercase wire label for a {!category}. *)
+
+val category_of_string_opt : string -> category option
+(** Parse a category from its wire label.  Returns [None] for
+    unrecognised input. *)
+
 val level_to_string : level -> string
 (** Convert level to string representation. *)
 
@@ -45,21 +67,21 @@ val format_utc_date_of : float -> string
     for unit tests; production code calls [Ring.date_string] which
     delegates here. *)
 
-val log : level -> ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
+val log : level -> ?ctx:string -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
 (** Log a message at the given level with optional context. *)
 
-val emit : level -> ?module_name:string -> ?details:Yojson.Safe.t -> string -> unit
+val emit : level -> ?module_name:string -> ?details:Yojson.Safe.t -> ?category:category -> string -> unit
 (** Log a preformatted structured message with optional JSON details. *)
 
-val emit_routine : ?module_name:string -> ?details:Yojson.Safe.t -> string -> unit
+val emit_routine : ?module_name:string -> ?details:Yojson.Safe.t -> ?category:category -> string -> unit
 (** Log repeatable housekeeping/telemetry through the central routine policy.
     The effective level is controlled by [MASC_LOG_ROUTINE_LEVEL] and defaults
     to [Debug]. Set it to [off] to suppress routine events entirely. *)
 
-val debug : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
-val info : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
-val warn : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
-val error : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
+val debug : ?ctx:string -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
+val info : ?ctx:string -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
+val warn : ?ctx:string -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
+val error : ?ctx:string -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
 
 (** Mirror source kinds carried on every [Ring.entry]. *)
 type source =
@@ -100,6 +122,7 @@ module Ring : sig
     turn_id : int option;
     message : string;
     details : Yojson.Safe.t;
+    category : category option;
   }
 
   exception Entry_decode_error of string
@@ -121,6 +144,8 @@ module Ring : sig
     ?module_filter:string ->
     ?since_seq:int ->
     ?order:[< `Newest_first | `Oldest_first > `Newest_first ] ->
+    ?category_filter:string ->
+    ?exclude_category:string list ->
     unit ->
     entry list
 
@@ -149,18 +174,19 @@ val client_tool_host_error :
     [M.name] controls the env-var key MASC_LOG_{NAME}_LEVEL
     and the context prefix in log output. *)
 module type LOGGER = sig
-  val emit : level -> ?details:Yojson.Safe.t -> ?keeper_name:string -> ?turn_id:int -> string -> unit
+  val emit : level -> ?details:Yojson.Safe.t -> ?keeper_name:string -> ?turn_id:int -> ?category:category -> string -> unit
   val routine :
     ?details:Yojson.Safe.t ->
     ?keeper_name:string ->
     ?turn_id:int ->
+    ?category:category ->
     ('a, unit, string, unit) format4 ->
     'a
-  val debug : ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
-  val info : ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
-  val warn : ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
-  val warning : ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
-  val error : ?keeper_name:string -> ?turn_id:int -> ('a, unit, string, unit) format4 -> 'a
+  val debug : ?keeper_name:string -> ?turn_id:int -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
+  val info : ?keeper_name:string -> ?turn_id:int -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
+  val warn : ?keeper_name:string -> ?turn_id:int -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
+  val warning : ?keeper_name:string -> ?turn_id:int -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
+  val error : ?keeper_name:string -> ?turn_id:int -> ?category:category -> ('a, unit, string, unit) format4 -> 'a
 end
 
 module Make (_ : sig val name : string end) : LOGGER

--- a/lib/server/server_dashboard_logs_json.ml
+++ b/lib/server/server_dashboard_logs_json.ml
@@ -25,6 +25,8 @@ let build
       ~min_level
       ~module_filter
       ~since_seq
+      ~category_filter
+      ~exclude_category
       (entries : Log.Ring.entry list)
   : Yojson.Safe.t
   =
@@ -65,6 +67,11 @@ let build
              ; "min_level", `Int min_level
              ; "module", `String module_filter
              ; "since_seq", Json_util.int_option_to_yojson since_seq
+             ; "category", Json_util.string_opt_to_json category_filter
+             ; ( "exclude_category"
+               , match exclude_category with
+                 | None -> `Null
+                 | Some xs -> `List (List.map (fun x -> `String x) xs) )
              ] )
        ; "returned", `Int (List.length entries)
        ; "latest_seq", Json_util.int_option_to_yojson (entry_seq_json newest)

--- a/lib/server/server_dashboard_logs_json.mli
+++ b/lib/server/server_dashboard_logs_json.mli
@@ -10,5 +10,7 @@ val build
   -> min_level:int
   -> module_filter:string
   -> since_seq:int option
+  -> category_filter:string option
+  -> exclude_category:string list option
   -> Log.Ring.entry list
   -> Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -529,12 +529,26 @@ let add_routes ~sw ~clock router =
              | Some v -> v
              | None -> ""
            in
+           let category_filter = Server_utils.query_param req "category" in
+           let exclude_category =
+             match Server_utils.query_param req "exclude_category" with
+             | None -> None
+             | Some raw ->
+                 let parts = String.split_on_char ',' raw in
+                 let trimmed = List.map String.trim parts in
+                 let non_empty = List.filter (fun s -> s <> "") trimmed in
+                 match non_empty with
+                 | [] -> None
+                 | xs -> Some xs
+           in
            let entries =
-             Log.Ring.recent ~limit ~min_level ~module_filter ?since_seq ()
+             Log.Ring.recent ~limit ~min_level ~module_filter ?since_seq
+               ?category_filter ?exclude_category ()
            in
            let json =
              dashboard_logs_json ~config:(Mcp_server.workspace_config state) ~limit
-               ~level_filter ~applied_level ~min_level ~module_filter ~since_seq entries
+               ~level_filter ~applied_level ~min_level ~module_filter ~since_seq
+               ~category_filter ~exclude_category entries
            in
            Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_dashboard_setup.mli
+++ b/lib/server/server_routes_http_routes_dashboard_setup.mli
@@ -13,6 +13,8 @@ val dashboard_logs_json :
   min_level:int ->
   module_filter:string ->
   since_seq:int option ->
+  category_filter:string option ->
+  exclude_category:string list option ->
   Log.Ring.entry list ->
   Yojson.Safe.t
 

--- a/test/test_log_ring_encoder.ml
+++ b/test/test_log_ring_encoder.ml
@@ -12,9 +12,9 @@
 
 let entry_of ?(seq = 0) ?(ts = "2026-05-14T00:00:00Z") ?(level = Log.Info)
     ?(source = Log.Structured) ?(module_name = "Test") ?keeper_name ?turn_id
-    ?(message = "hello") ?(details = `Null) () : Log.Ring.entry =
+    ?(message = "hello") ?(details = `Null) ?(category = None) () : Log.Ring.entry =
   { Log.Ring.seq; ts; level; source; module_name; keeper_name; turn_id;
-    message; details }
+    message; details; category }
 
 let assoc_field name = function
   | `Assoc fields -> List.assoc_opt name fields
@@ -57,7 +57,7 @@ let test_wire_format_field_set () =
   let json = Log.Ring.entry_to_json e in
   let expected_keys =
     [ "seq"; "ts"; "level"; "source"; "module"; "keeper_name";
-      "turn_id"; "message"; "details" ]
+      "turn_id"; "message"; "details"; "category" ]
   in
   let absent_legacy_keys =
     [ "raw_level"; "normalized_level"; "legacy_classified" ]

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -161,6 +161,7 @@ let test_entry_to_json_keeper_name_none_serializes_system () =
     turn_id = None;
     message = "test message";
     details = `Null;
+    category = None;
   } in
   let json = Log.Ring.entry_to_json entry in
   let keeper_name_val =
@@ -180,6 +181,7 @@ let test_entry_to_json_keeper_name_some_preserves () =
     turn_id = None;
     message = "test message";
     details = `Null;
+    category = None;
   } in
   let json = Log.Ring.entry_to_json entry in
   let keeper_name_val =


### PR DESCRIPTION
## Summary
Adds typed log categories and dashboard filtering, surfaces FSM transitions with structured details, and quiets the false-positive keeper directive "not in registry" warnings during boot.

## Changes
- Log.category closed sum + JSONL/ring support + category_filter / exclude_category.
- Categorized Keeper logs (Directive, Heartbeat, Fsm, Lifecycle).
- Registry/turn FSM transitions now carry from_phase / to_phase / event / action details.
- Dashboard log viewer: category select, Hide FSM transitions toggle, category chips.
- Known-but-not-yet-registered keepers downgrade directive not-in-registry from WARN to DEBUG.

## Verification
- dune build lib/masc_log, lib/keeper, bin/main_eio.exe pass
- test_log_ring_encoder, test_masc_log pass
- Dashboard pnpm typecheck + logs.test.ts pass

## Open follow-up
Other modules (MCP, ModelClient, Memory, etc.) still log as Uncategorized and can be categorized incrementally.
