### PR TITLE
fix(keeper): preserve reasoning carrier and FSM completion

### DIFF
--- a/docs/observability/keeper-turn-fsm-metrics.md
+++ b/docs/observability/keeper-turn-fsm-metrics.md
@@ -140,9 +140,9 @@ Source-of-truth cross-reference (after Step 4 caller adoption):
 | `Awaiting_provider → Streaming` | `keeper_unified_turn.ml:803` (pre-`run_turn`) | #11358 |
 | `Streaming → Streaming` (SupervisorRequestsStop in Eio.Cancel handler) | `keeper_unified_turn.ml:867` | fix |
 | `Streaming → Failed provider_error` (retry exhausted) | `keeper_unified_turn.ml:1446` | #11363 |
-| `Streaming → Completing` | `keeper_unified_turn.ml:2092` (stop_reason) | #11308 |
+| `Streaming → Completing` | `keeper_unified_turn_success.ml` | #11308 |
 | `Streaming → Cancelled supervisor_stop` (HonorStopSignal, Eio.Cancel) | `keeper_unified_turn.ml:884` | Cycle 1b-iv |
-| `Completing → Done` (success exit) | `keeper_unified_turn.ml:2119` | #11288 |
+| `Completing → Done` (success exit) | `keeper_unified_turn_success.ml` | #11288 |
 
 Pending edges (require `keeper_agent_run.ml run_turn` adoption — volume risk):
 - `Streaming ⇄ Awaiting_tool_result` per tool call

--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -48,7 +48,16 @@ let content_blocks_of_json
            | Some "thinking" ->
              (match Json_util.get_string j "thinking" with
               | Some content ->
-                Some (Agent_sdk.Types.Thinking { thinking_type = "thinking"; content })
+                let thinking_type =
+                  match Json_util.get_string j "thinking_type" with
+                  | Some thinking_type -> thinking_type
+                  | None ->
+                    (* DET-OK: older context/checkpoint JSON predates the
+                       explicit carrier tag; "thinking" is the historical
+                       wire value for those persisted rows. *)
+                    "thinking"
+                in
+                Some (Agent_sdk.Types.Thinking { thinking_type; content })
               | None -> None)
            | Some "redacted_thinking" ->
              (match Json_util.get_string j "data" with

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -900,16 +900,6 @@ dominant source of the observed CAS race exhaustion after
                   Error err
                 | Ok result ->
                   let final_execution = !last_execution in
-                  Keeper_turn_fsm.emit_transition
-                    ~keeper_name:meta.name
-                    ~turn_id:keeper_turn_id
-                    ~prev:Keeper_turn_fsm.Streaming
-                    Keeper_turn_fsm.Completing;
-                  Keeper_turn_fsm.emit_transition
-                    ~keeper_name:meta.name
-                    ~turn_id:keeper_turn_id
-                    ~prev:Keeper_turn_fsm.Completing
-                    Keeper_turn_fsm.Done;
                   finalize_trajectory_acc
                     ~config
                     ~keeper_name:meta.name

--- a/test/dune
+++ b/test/dune
@@ -594,7 +594,6 @@
   test_keeper_event_queue
   test_keeper_relevance_check
   test_actionable_path_action
-  test_keeper_turn_fsm_wired_sites
   test_effective_oas_env
   test_workspace_routes_keeper
   test_workspace_tree_exclusions
@@ -1574,6 +1573,8 @@
 (include stanzas/test_keeper_tool_matrix.inc)
 
 (include stanzas/test_keeper_tool_policy_paths.inc)
+
+(include stanzas/test_keeper_turn_fsm_wired_sites.inc)
 
 (include stanzas/test_keeper_turn_fsm_tla_parity.inc)
 

--- a/test/stanzas/test_keeper_turn_fsm_wired_sites.inc
+++ b/test/stanzas/test_keeper_turn_fsm_wired_sites.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_turn_fsm_wired_sites)
+ (modules test_keeper_turn_fsm_wired_sites)
+ (libraries masc_test_deps))

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -171,6 +171,41 @@ let test_roundtrip_text_preserved () =
   Alcotest.(check string) "text preserved"
     (text_of original) (text_of reparsed)
 
+let test_roundtrip_preserves_thinking_type () =
+  let original : T.message =
+    {
+      T.role = T.Assistant;
+      content =
+        [
+          T.Thinking { thinking_type = "reasoning"; content = "chain" };
+          T.Thinking
+            { thinking_type = "anthropic-signature"; content = "signed" };
+          T.RedactedThinking "encrypted";
+          T.Text "done";
+        ];
+      name = None;
+      tool_call_id = None;
+      metadata = [];
+    }
+  in
+  let json = C.message_to_json original in
+  let reparsed = C.message_of_json json in
+  match reparsed.content with
+  | [
+   T.Thinking { thinking_type = first_type; content = first_content };
+   T.Thinking { thinking_type = second_type; content = second_content };
+   T.RedactedThinking blob;
+   T.Text text;
+  ] ->
+      Alcotest.(check string) "first thinking type" "reasoning" first_type;
+      Alcotest.(check string) "first thinking content" "chain" first_content;
+      Alcotest.(check string)
+        "second thinking type" "anthropic-signature" second_type;
+      Alcotest.(check string) "second thinking content" "signed" second_content;
+      Alcotest.(check string) "redacted thinking" "encrypted" blob;
+      Alcotest.(check string) "text" "done" text
+  | _ -> Alcotest.fail "expected thinking, thinking, redacted thinking, text"
+
 let () =
   Alcotest.run "keeper_context_core_dedup"
     [
@@ -189,6 +224,8 @@ let () =
             test_message_of_json_rejects_flat_content;
           Alcotest.test_case "round-trip text preserved" `Quick
             test_roundtrip_text_preserved;
+          Alcotest.test_case "round-trip thinking type preserved" `Quick
+            test_roundtrip_preserves_thinking_type;
         ] );
       ( "text_of_history_jsonl_json",
         [

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -257,7 +257,10 @@ let test_voice_audio_self_output_is_not_recent_context () =
   let lines = MS.recent_direct_conversation_of_messages messages in
   check (list string) "voice audio assistant row omitted from prompt context"
     [ "user"; "assistant" ]
-    (List.map (fun (line : MS.recent_direct_line) -> MS.direct_line_role_to_label line.role) lines);
+    (List.map
+       (fun (line : MS.recent_direct_line) ->
+         MS.direct_line_role_to_label line.role)
+       lines);
   check (list string) "spoken text is not quoted back"
     [ "please say it out loud"; "text follow-up" ]
     (List.map (fun (line : MS.recent_direct_line) -> line.content) lines)

--- a/test/test_keeper_turn_fsm_wired_sites.ml
+++ b/test/test_keeper_turn_fsm_wired_sites.ml
@@ -1,21 +1,12 @@
-(** test_keeper_turn_fsm_wired_sites — Step 4 wiring marker.
+(** test_keeper_turn_fsm_wired_sites — turn FSM wiring markers.
 
     [test_keeper_turn_fsm_emit] pins the [Keeper_turn_fsm.emit_transition]
     *type surface*: a future signature drift fails compile.
 
-    But a future PR could *delete* one of the 11 wired
-    [emit_transition] call sites in [keeper_unified_turn.ml]
-    without breaking the build -- the build doesn't care if a
-    function is called.  Result: the fleet observability stack
-    silently regresses (Otel_metric_store counter loses a series, the
-    Grafana dashboard's panel goes flat, [bin/masc-trace]
-    timeline jumps over a state).
-
-    This marker reads [lib/keeper/keeper_unified_turn.ml]
-    and asserts that the [Keeper_turn_fsm.emit_transition] call
-    count meets the documented floor.  A delete fails this
-    test with a clear message; an add (more emits) is a no-op
-    on this test (the floor is a >=, not an =).
+    These markers read the source files that own the scheduled-turn
+    transitions. They catch accidental deletion and the subtler case where
+    success completion is emitted in both the caller and the success handler,
+    which would double-count completed turns in observability data.
 
     Cross-reference: [docs/observability/keeper-turn-fsm-metrics.md]
     "Wiring sites" table lists every emit call with its PR. *)
@@ -38,10 +29,9 @@ let rec find_repo_root dir =
     let parent = Filename.dirname dir in
     if String.equal parent dir then None else find_repo_root parent
 
-let locate_keeper_unified_turn () =
+let locate_repo_file rel =
   match find_repo_root (Sys.getcwd ()) with
-  | Some root ->
-      Filename.concat root "lib/keeper/keeper_unified_turn.ml"
+  | Some root -> Filename.concat root rel
   | None ->
       Alcotest.fail "could not locate dune-project ancestor of cwd"
 
@@ -59,33 +49,27 @@ let count_substring haystack needle =
     in
     loop 0 0
 
-(** Documented floor: 15 wired sites in [keeper_unified_turn.ml]
-    after Steps 4b/4c/4d/4g/4i/4j + SupervisorRequestsStop/HonorStopSignal.  Composition:
+(** Documented floor for the scheduled-turn source files that still emit
+    directly after the 2026 extraction pass:
 
-    | Step | site                                                  | count |
-    |------|-------------------------------------------------------|-------|
-    | 4c   | run_keeper_cycle entry [Idle -> Phase_gating]         | 1     |
-    | fix  | SupervisorRequestsStop at entry [Phase_gating -> Phase_gating] | 1 |
-    | fix  | HonorStopSignal at entry [Phase_gating -> Cancelled supervisor_stop] | 1 |
-    | 4b   | phase-gate skip [Phase_gating -> Done]                | 1     |
-    | 4g   | phase pass [Phase_gating -> Runtime_routing]          | 1     |
-    | 4b   | ollama saturated failure                              | 1     |
-    | 4b   | runtime build error                                   | 1     |
-    | 4g   | livelock Started [Runtime_routing -> Awaiting_provider] | 1   |
-    | 4b   | livelock Blocked                                      | 1     |
-    | 4i   | run_turn pre-call [Awaiting_provider -> Streaming]    | 1     |
-    | fix  | SupervisorRequestsStop in Eio.Cancel [Streaming -> Streaming] | 1 |
-    | 4j   | retry_loop exhaustion [Streaming -> Failed]           | 1     |
-    | 4d   | stop_reason [Streaming -> Completing]                 | 1     |
-    | 4c   | success exit [Completing -> Done]                     | 1     |
-    | Cycle 1b-iv | Eio.Cancel HonorStopSignal [Streaming -> Cancelled supervisor_stop] | 1 |
-    *)
-let documented_floor = 15
+    - [keeper_unified_turn.ml] owns entry, routing, pre-dispatch, streaming
+      failure/cancellation, and pre-provider transitions.
+    - [keeper_unified_turn_success.ml] owns the successful
+      [Streaming -> Completing -> Done] pair.
+
+    Other extracted handlers may emit their own terminal transitions; this test
+    intentionally does not count those modules. *)
+let documented_floor = 7
 
 let test_emit_call_count_floor () =
-  let path = locate_keeper_unified_turn () in
-  let body = read_file path in
-  let n = count_substring body "Keeper_turn_fsm.emit_transition" in
+  let unified_path = locate_repo_file "lib/keeper/keeper_unified_turn.ml" in
+  let success_path =
+    locate_repo_file "lib/keeper/keeper_unified_turn_success.ml"
+  in
+  let n =
+    count_substring (read_file unified_path) "Keeper_turn_fsm.emit_transition"
+    + count_substring (read_file success_path) "Keeper_turn_fsm.emit_transition"
+  in
   if n < documented_floor then
     Alcotest.failf
       "Keeper_turn_fsm.emit_transition call count regressed: \
@@ -101,6 +85,23 @@ let test_emit_call_count_floor () =
        documented_floor n)
     true (n >= documented_floor)
 
+let test_success_completion_transitions_owned_once () =
+  let unified =
+    read_file (locate_repo_file "lib/keeper/keeper_unified_turn.ml")
+  in
+  let success =
+    read_file (locate_repo_file "lib/keeper/keeper_unified_turn_success.ml")
+  in
+  Alcotest.(check int)
+    "success completion transitions not emitted by caller" 0
+    (count_substring unified "Keeper_turn_fsm.Completing");
+  Alcotest.(check int)
+    "success handler owns two completion-state references" 2
+    (count_substring success "Keeper_turn_fsm.Completing");
+  Alcotest.(check int)
+    "success handler owns one done transition" 1
+    (count_substring success "Keeper_turn_fsm.Done")
+
 let () =
   Alcotest.run "keeper_turn_fsm_wired_sites"
     [
@@ -109,5 +110,8 @@ let () =
           Alcotest.test_case
             "emit_transition call count meets documented floor"
             `Quick test_emit_call_count_floor;
+          Alcotest.test_case
+            "success completion transitions are single-owned"
+            `Quick test_success_completion_transitions_owned_once;
         ] );
     ]


### PR DESCRIPTION
## Summary

- Preserve `thinking_type` when MASC reloads keeper context/checkpoint `Thinking` blocks from JSON.
- Remove duplicate scheduled-turn success FSM completion emits from `keeper_unified_turn.ml`; `keeper_unified_turn_success.ml` is the single owner for `Streaming -> Completing -> Done`.
- Register and extend focused regression tests for reasoning carrier round-trip and FSM completion ownership.
- Align the mention-scope voice-audio regression with the typed `recent_direct_line.role` API so Health can compile current main contracts.

## Why

Provider reasoning/thinking carriers must survive tool-loop and history replay boundaries without being collapsed into a generic `thinking` block. The duplicate FSM completion emit also inflated successful scheduled-turn transition telemetry and made observability less trustworthy.

## Validation

- `MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_context_core_dedup.exe test/test_keeper_turn_fsm_wired_sites.exe test/test_keeper_mention_scope.exe`
- `./_build/default/test/test_keeper_context_core_dedup.exe`
- `./_build/default/test/test_keeper_turn_fsm_wired_sites.exe`
- `./_build/default/test/test_keeper_mention_scope.exe`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`
- `ocamlformat --check lib/keeper/keeper_context_core_message_json.ml test/test_keeper_mention_scope.ml test/test_keeper_context_core_dedup.ml test/test_keeper_turn_fsm_wired_sites.ml lib/keeper/keeper_unified_turn.ml lib/keeper/keeper_unified_turn_success.ml`
- `git diff --check`

Focused validation passed after rebasing onto current `origin/main` and after the CI-failure follow-up patch.