### PR TITLE
[codex] Improve dashboard render stability

### DIFF
--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -198,6 +198,27 @@ describe('parseSSEMessage', () => {
     expect(msg?.type).toBe('oas:slot_scheduler_observed')
   })
 
+  it('keeps oas telemetry tuple payloads instead of logging schema drift', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const msg = parseSSEMessage({
+      type: 'oas:telemetry_event',
+      event_type: 'telemetry_event',
+      ts_unix: 1781584363.694713,
+      payload: [
+        'Streaming_first_chunk',
+        {
+          provider: 'openai_compat',
+          model: 'deepseek-v4-flash',
+          ttfrc_ms: 3988.802909851074,
+        },
+      ],
+    })
+    expect(msg).not.toBeNull()
+    expect(msg?.type).toBe('oas:telemetry_event')
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
   it('silently ignores MCP JSON-RPC control notifications on the SSE stream', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     expect(parseSSEMessage({

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -274,7 +274,7 @@ export const SSEMessageSchema = schema<SSEMessage>((value) => {
     }
   }
 
-  if (value.payload != null && !isRecord(value.payload)) {
+  if (value.payload != null && !isRecord(value.payload) && !value.type.startsWith('oas:')) {
     return fail('payload', 'Expected payload object')
   }
   if (value.attribution != null) {

--- a/dashboard/src/store-reconcile.test.ts
+++ b/dashboard/src/store-reconcile.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { reconcileBoardPosts } from './store'
-import type { BoardPost } from './types'
+import { reconcileBoardPosts, reconcileKeepers } from './store'
+import type { BoardPost, Keeper } from './types'
 
 function makePost(overrides: Partial<BoardPost> = {}): BoardPost {
   return {
@@ -117,5 +117,107 @@ describe('reconcileBoardPosts', () => {
     expect(result).not.toBe(prev)
     expect(result[0]).toBe(b)
     expect(result[1]).toBe(a)
+  })
+})
+
+function makeKeeper(overrides: Partial<Keeper> = {}): Keeper {
+  return {
+    name: 'rondo',
+    status: 'idle',
+    runtime_class: 'keeper',
+    pipeline_stage: 'idle',
+    phase: 'Running',
+    updated_at: '2026-06-16T04:00:00Z',
+    last_activity_ago_s: 125,
+    last_turn_ago_s: 125,
+    recent_tool_names: ['keeper_task_claim'],
+    latest_tool_names: ['keeper_task_claim'],
+    latest_tool_call_count: 1,
+    active_goal_ids: ['goal-1'],
+    ...overrides,
+  }
+}
+
+describe('reconcileKeepers', () => {
+  it('returns next array as-is when prev is empty', () => {
+    const next = [makeKeeper()]
+    expect(reconcileKeepers([], next)).toBe(next)
+  })
+
+  it('keeps array and row references for relative-age drift within the same display bucket', () => {
+    const keeper = makeKeeper({ last_activity_ago_s: 125.2, last_turn_ago_s: 128.7 })
+    const prev = [keeper]
+    const next = [
+      makeKeeper({
+        last_activity_ago_s: 179.9,
+        last_turn_ago_s: 170.5,
+      }),
+    ]
+
+    const result = reconcileKeepers(prev, next)
+
+    expect(result).toBe(prev)
+    expect(result[0]).toBe(keeper)
+  })
+
+  it('updates when a relative age crosses its display bucket', () => {
+    const keeper = makeKeeper({ last_activity_ago_s: 125 })
+    const updated = makeKeeper({ last_activity_ago_s: 185 })
+
+    const result = reconcileKeepers([keeper], [updated])
+
+    expect(result[0]).toBe(updated)
+  })
+
+  it('keeps row references for nested cooldown countdown drift within the same display bucket', () => {
+    const keeper = makeKeeper({
+      diagnostic: {
+        summary: 'Keeper is inside its proactive cooldown window.',
+        health_state: 'healthy',
+        quiet_reason: 'min_gap',
+        next_action_path: 'direct_message',
+        last_reply_status: 'never',
+        next_eligible_at_s: 281.1,
+      },
+    })
+    const next = makeKeeper({
+      diagnostic: {
+        summary: 'Keeper is inside its proactive cooldown window.',
+        health_state: 'healthy',
+        quiet_reason: 'min_gap',
+        next_action_path: 'direct_message',
+        last_reply_status: 'never',
+        next_eligible_at_s: 275.5,
+      },
+    })
+
+    const result = reconcileKeepers([keeper], [next])
+
+    expect(result[0]).toBe(keeper)
+  })
+
+  it('updates immediately for meaningful keeper state changes', () => {
+    const keeper = makeKeeper({ status: 'idle', pipeline_stage: 'idle' })
+    const updated = makeKeeper({ status: 'offline', pipeline_stage: 'failing' })
+
+    const result = reconcileKeepers([keeper], [updated])
+
+    expect(result[0]).toBe(updated)
+  })
+
+  it('preserves unchanged rows in a mixed update', () => {
+    const unchanged = makeKeeper({ name: 'rondo' })
+    const changed = makeKeeper({ name: 'sangsu', status: 'idle' })
+    const updatedChanged = makeKeeper({ name: 'sangsu', status: 'offline' })
+    const prev = [unchanged, changed]
+
+    const result = reconcileKeepers(
+      prev,
+      [{ ...unchanged, last_activity_ago_s: 130 }, updatedChanged],
+    )
+
+    expect(result).not.toBe(prev)
+    expect(result[0]).toBe(unchanged)
+    expect(result[1]).toBe(updatedChanged)
   })
 })

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -182,6 +182,96 @@ export function setKeeperFilterToAll(allNames: readonly string[]): void {
   selectedKeeperFilter.value = new Set(allNames)
 }
 
+const KEEPER_RELATIVE_AGE_FIELDS = new Set<string>([
+  'keeper_age_s',
+  'last_activity_ago_s',
+  'last_turn_ago_s',
+  'last_handoff_ago_s',
+  'last_compaction_ago_s',
+  'last_proactive_ago_s',
+  'next_eligible_at_s',
+])
+
+function relativeAgeRenderBucket(value: unknown): unknown {
+  if (value == null) return null
+  if (typeof value !== 'number' || !Number.isFinite(value)) return value
+  const seconds = Math.max(0, value)
+  const bucketSeconds =
+    seconds < 60
+      ? 10
+      : seconds < 3_600
+        ? 60
+        : 300
+  return Math.floor(seconds / bucketSeconds)
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stableValueEqual(left: unknown, right: unknown, key?: string): boolean {
+  if (key && KEEPER_RELATIVE_AGE_FIELDS.has(key)) {
+    return relativeAgeRenderBucket(left) === relativeAgeRenderBucket(right)
+  }
+  if (Object.is(left, right)) return true
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) return false
+    if (left.length !== right.length) return false
+    return left.every((value, index) => stableValueEqual(value, right[index]))
+  }
+  if (isPlainRecord(left) || isPlainRecord(right)) {
+    if (!isPlainRecord(left) || !isPlainRecord(right)) return false
+    const keys = new Set([...Object.keys(left), ...Object.keys(right)])
+    for (const key of keys) {
+      if (!stableValueEqual(left[key], right[key], key)) return false
+    }
+    return true
+  }
+  return false
+}
+
+function keeperRenderEqual(previous: Keeper, next: Keeper): boolean {
+  const previousRecord = previous as unknown as Record<string, unknown>
+  const nextRecord = next as unknown as Record<string, unknown>
+  const keys = new Set([...Object.keys(previousRecord), ...Object.keys(nextRecord)])
+  for (const key of keys) {
+    if (KEEPER_RELATIVE_AGE_FIELDS.has(key)) {
+      if (relativeAgeRenderBucket(previousRecord[key]) !== relativeAgeRenderBucket(nextRecord[key])) {
+        return false
+      }
+      continue
+    }
+    if (!stableValueEqual(previousRecord[key], nextRecord[key], key)) return false
+  }
+  return true
+}
+
+/** Reconcile keeper rows so high-frequency execution snapshots do not
+ *  recreate the whole roster/detail tree for clock-only drift.
+ *
+ *  The backend emits relative age fields as floating seconds, so every
+ *  fresh snapshot can differ even when the keeper's actual state did not.
+ *  Keep those fields at display-resolution while still updating immediately
+ *  for status, lifecycle, model, goal, blocker, tool, and context changes.
+ */
+export function reconcileKeepers(previous: Keeper[], next: Keeper[]): Keeper[] {
+  if (previous.length === 0) return next
+  const previousByName = new Map(previous.map(keeper => [keeper.name, keeper]))
+  let changed = previous.length !== next.length
+  const merged = next.map((keeper, index) => {
+    const old = previousByName.get(keeper.name)
+    if (!changed && previous[index]?.name !== keeper.name) {
+      changed = true
+    }
+    if (old && keeperRenderEqual(old, keeper)) {
+      return old
+    }
+    changed = true
+    return keeper
+  })
+  return changed ? merged : previous
+}
+
 // --- Board state ---
 
 export const boardPosts = signal<BoardPost[]>([])
@@ -915,7 +1005,7 @@ export function hydrateExecutionSnapshot(data: DashboardExecutionResponse): void
     .map(normalizeMessage)
     .filter((row): row is Message => row !== null)
   messages.value = workspaceChanged ? executionMessages : mergeMessages(messages.value, executionMessages)
-  keepers.value = normalizeKeepers(data.keepers)
+  keepers.value = reconcileKeepers(keepers.value, normalizeKeepers(data.keepers))
   const normalizedWorkerBriefs = (Array.isArray(data.worker_support_briefs) ? data.worker_support_briefs : Array.isArray(data.worker_briefs) ? data.worker_briefs : [])
     .map(normalizeExecutionWorkerSupportBrief)
     .filter((row): row is DashboardExecutionWorkerSupportBrief => row !== null)


### PR DESCRIPTION
## Summary

- Reconcile keeper rows during execution snapshot hydration so clock-only drift does not recreate the whole keeper roster/detail tree.
- Treat relative countdown fields such as `last_activity_ago_s` and nested `diagnostic.next_eligible_at_s` at display-resolution while still updating immediately for meaningful keeper state changes.
- Accept OAS bridge telemetry tuple payloads in the SSE parser to avoid dropping valid `oas:telemetry_event` frames as schema drift.

## Root cause

The dashboard execution snapshot path normalized `keepers` and assigned the fresh array directly on every hydrate. Live payloads include floating relative age/countdown values, so unchanged keeper state still produced new row objects and drove unnecessary Preact signal invalidation through the agent roster/detail view.

## Validation

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/store-reconcile.test.ts src/schemas/sse.test.ts`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard lint`
- `pnpm --dir dashboard build`
- `git diff --check origin/main...HEAD`

Note: local build succeeded with the existing Vite chunk/static-dynamic import warnings.