### PR TITLE
P3-4: wire RFC-0235 voice output into dashboard chat

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -134,4 +134,38 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(cleaned).toHaveLength(3)
     expect(cleaned.map(m => m.role)).toEqual(['user', 'assistant', 'system'])
   })
+
+  it('passes RFC-0235 audio clips through (snake_case history shape)', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        role: 'assistant',
+        audio: {
+          token: 'clip-123',
+          audio_url: 'https://cdn.example/voice/clip-123.mp3',
+          mime: 'audio/mpeg',
+          duration_sec: 12.34,
+          message_text: 'hello',
+          device_id: ' living-room',
+        },
+      }),
+    )
+    expect(out?.audio).toEqual({
+      token: 'clip-123',
+      audio_url: 'https://cdn.example/voice/clip-123.mp3',
+      mime: 'audio/mpeg',
+      duration_sec: 12.34,
+      message_text: 'hello',
+      device_id: ' living-room',
+    })
+  })
+
+  it('passes malformed audio objects through so the consumer can validate safely', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({ audio: { token: 'only-token' } }),
+    )
+    expect(out).not.toBeNull()
+    // The boundary keeps the raw object; normalization filters out invalid
+    // clips without dropping the whole history row.
+    expect(out?.audio).toEqual({ token: 'only-token' })
+  })
 })

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -23,6 +23,7 @@ import {
   record,
   safeParse,
   string,
+  unknown,
   type InferOutput,
 } from 'valibot'
 
@@ -42,6 +43,25 @@ export const SurfaceRefSchema = object({
   label: optional(string()),
   address: optional(record(string(), string())),
 })
+
+// RFC-0235 P1/P3: synthesized voice clip. Backend uses snake_case in
+// history rows (lib/keeper/keeper_chat_store.ml) and camelCase in SSE
+// payloads (lib/keeper/keeper_chat_broadcast.ml). We accept both at the
+// boundary and let normalizers canonicalize to camelCase.
+export const KeeperChatHistoryAudioClipSchema = object({
+  token: string(),
+  audio_url: optional(string()),
+  audioUrl: optional(string()),
+  mime: string(),
+  duration_sec: optional(number()),
+  durationSec: optional(number()),
+  message_text: optional(string()),
+  messageText: optional(string()),
+  device_id: optional(string()),
+  deviceId: optional(string()),
+})
+
+export type KeeperChatHistoryAudioClip = InferOutput<typeof KeeperChatHistoryAudioClipSchema>
 
 export const KeeperChatHistoryMessageSchema = object({
   // R3: producer-assigned stable message id (keeper_chat_store.ml mints it
@@ -76,6 +96,10 @@ export const KeeperChatHistoryMessageSchema = object({
   speaker_id: optional(string()),
   speaker_name: optional(string()),
   speaker_authority: optional(string()),
+  // RFC-0235 P1/P3: audio clip field. The wire object is accepted as
+  // `unknown` at the boundary so malformed clips do not cause the whole
+  // message to be dropped; `normalizeAudioClip` validates before use.
+  audio: optional(unknown()),
 })
 
 export type KeeperChatHistoryMessage = InferOutput<typeof KeeperChatHistoryMessageSchema>

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -254,6 +254,39 @@ describe('ChatTranscript', () => {
     expect(label).toContain('응답 중')
     expect(label).not.toContain('...')
   })
+
+  it('renders an audio player for assistant entries with an RFC-0235 clip', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'a1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: 'hello operator',
+            audio: {
+              token: 'clip-1',
+              audioUrl: '/api/v1/voice/audio/clip-1',
+              mime: 'audio/mpeg',
+              durationSec: 5,
+              messageText: 'hello operator',
+              deviceId: null,
+            },
+          }),
+        ]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+
+    const player = container.querySelector('[data-chat-audio-clip]')
+    expect(player).not.toBeNull()
+    const audio = container.querySelector('audio')
+    expect(audio).not.toBeNull()
+    expect(audio?.getAttribute('src')).toBe('/api/v1/voice/audio/clip-1')
+    expect(container.textContent).toContain('0:05')
+  })
 })
 
 describe('ChatComposer queue & stall', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -8,7 +8,7 @@ import { useVoiceInput } from './voice-input'
 import { formatTimeHms } from '../../lib/format-time'
 import { formatCost } from '../../lib/format-number'
 import { isSubmitEnter } from '../../lib/keyboard'
-import type { KeeperConversationAttachment, KeeperConversationDetails, KeeperConversationEntry, SurfaceRef } from '../../types'
+import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, SurfaceRef } from '../../types'
 
 function surfaceLink(surface?: SurfaceRef | null): { url: string; label: string; icon: string } | null {
   if (!surface || !surface.kind) return null
@@ -269,6 +269,40 @@ function renderAttachmentCard(attachment: KeeperConversationAttachment) {
   `
 }
 
+function formatAudioDuration(seconds?: number | null): string {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) return ''
+  const totalSec = Math.round(seconds)
+  const min = Math.floor(totalSec / 60)
+  const sec = totalSec % 60
+  return `${min}:${sec.toString().padStart(2, '0')}`
+}
+
+// RFC-0235 P1/P3: user-gesture play button for synthesized assistant
+// voice clips. Uses the native `<audio controls>` element (no autoplay).
+function AudioPlayer({ clip }: { clip: KeeperConversationAudioClip }) {
+  const duration = formatAudioDuration(clip.durationSec)
+  return html`
+    <div
+      class="flex items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1.5"
+      data-chat-audio-clip
+    >
+      <audio
+        controls
+        preload="none"
+        src=${clip.audioUrl ?? `/api/v1/voice/audio/${encodeURIComponent(clip.token)}`}
+        class="h-8 max-w-[16rem]"
+        aria-label=${clip.messageText || '음성 메시지'}
+      />
+      ${duration
+        ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]">${duration}</span>`
+        : null}
+      ${clip.deviceId
+        ? html`<span class="text-2xs text-[var(--color-fg-muted)]" title=${`device: ${clip.deviceId}`}>🔊</span>`
+        : null}
+    </div>
+  `
+}
+
 function ChatMessageBubble({
   entry,
   showMetadata = true,
@@ -477,6 +511,9 @@ function ChatMessageBubble({
               ${attachments.map(attachment => renderAttachmentCard(attachment))}
             </div>
           `
+        : null}
+      ${entry.audio
+        ? html`<${AudioPlayer} clip=${entry.audio} />`
         : null}
       ${entry.error
         ? html`

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -31,6 +31,7 @@ import {
   keeperStreamLastEventAt,
   keeperThreads,
   appendThreadEntry,
+  attachKeeperAudioClip,
   chatHistoryEntriesFromRest,
   clearActiveStream,
   finalizeAssistantEntry,
@@ -390,11 +391,18 @@ export async function resumePendingKeeperChatRequests(name: string): Promise<voi
  *  persisted transcript so messages arriving through other connectors
  *  (Discord, Slack, agent MCP) appear without a page reload. Keepers
  *  whose transcript was never hydrated are skipped — the mount
- *  hydration fetches the full window when the panel first opens. */
-export function noteKeeperChatAppended(name: string): void {
+ *  hydration fetches the full window when the panel first opens.
+ *
+ *  If the event carries an RFC-0235 audio clip, we first try to attach
+ *  it to the matching assistant bubble that is already streaming. A
+ *  failed match still falls back to the history re-merge (the clip is
+ *  persisted server-side too). */
+export function noteKeeperChatAppended(name: string, audio?: unknown): void {
   const keeperName = name.trim()
   if (!keeperName) return
   if (!hydratedChatKeepers.has(keeperName)) return
+  const attached = audio != null && attachKeeperAudioClip(keeperName, audio)
+  if (attached) return
   const pending = chatRefreshTimers.get(keeperName)
   if (pending) clearTimeout(pending)
   chatRefreshTimers.set(keeperName, setTimeout(() => {

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -3,11 +3,13 @@ import { beforeEach } from 'vitest'
 import {
   THREAD_ENTRY_CAP,
   appendThreadEntry,
+  attachKeeperAudioClip,
   chatHistoryEntriesFromRest,
   insertThreadEntryBefore,
   isVisibleDirectConversationEntry,
   keeperThreads,
   mergeServerHistoryEntries,
+  normalizeAudioClip,
   normalizeStatusDetail,
   removeThreadEntries,
   setStatusDetail,
@@ -290,5 +292,116 @@ describe('R3 producer-assigned message id', () => {
       { role: 'user', content: 'two', ts: 1_780_000_000 },
     ])
     expect(entries[0]?.id).not.toBe(entries[1]?.id)
+  })
+})
+
+describe('RFC-0235 audio clip normalization', () => {
+  beforeEach(() => {
+    keeperThreads.value = {}
+  })
+
+  function entry(partial: Partial<KeeperConversationEntry>): KeeperConversationEntry {
+    return {
+      id: 'e-1',
+      role: 'user',
+      source: 'direct_user',
+      label: '사용자',
+      text: 'hello',
+      rawText: 'hello',
+      timestamp: '2026-06-10T00:00:00.000Z',
+      delivery: 'delivered',
+      streamState: null,
+      details: null,
+      ...partial,
+    }
+  }
+
+  it('normalizes snake_case history audio fields with a URL fallback', () => {
+    const clip = normalizeAudioClip({
+      token: 'clip-abc',
+      mime: 'audio/mpeg',
+      duration_sec: 7.5,
+      message_text: 'hello',
+      device_id: 'living-room',
+    })
+    expect(clip).toEqual({
+      token: 'clip-abc',
+      audioUrl: '/api/v1/voice/audio/clip-abc',
+      mime: 'audio/mpeg',
+      durationSec: 7.5,
+      messageText: 'hello',
+      deviceId: 'living-room',
+    })
+  })
+
+  it('preserves an explicit audio_url from SSE payloads', () => {
+    const clip = normalizeAudioClip({
+      token: 'clip-def',
+      audioUrl: 'https://cdn.example/voice/clip-def.mp3',
+      mime: 'audio/mpeg',
+      messageText: 'hi',
+    })
+    expect(clip?.audioUrl).toBe('https://cdn.example/voice/clip-def.mp3')
+  })
+
+  it('returns null for malformed audio objects', () => {
+    expect(normalizeAudioClip(null)).toBeNull()
+    expect(normalizeAudioClip({ token: 'x' })).toBeNull()
+    expect(normalizeAudioClip({ token: 'x', mime: 42 })).toBeNull()
+  })
+
+  it('carries audio clips through REST history into conversation entries', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        content: 'hello there',
+        ts: 1_780_000_000,
+        audio: {
+          token: 'hist-clip',
+          mime: 'audio/mpeg',
+          duration_sec: 3,
+          message_text: 'hello there',
+        },
+      },
+    ])
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.audio?.token).toBe('hist-clip')
+    expect(entries[0]?.audio?.audioUrl).toBe('/api/v1/voice/audio/hist-clip')
+  })
+
+  it('attaches an SSE audio clip to the matching streaming assistant entry', () => {
+    appendThreadEntry('echo', entry({
+      id: 'reply-1',
+      role: 'assistant',
+      source: 'direct_assistant',
+      text: 'hello operator',
+      rawText: 'hello operator',
+      delivery: 'streaming',
+    }))
+    const attached = attachKeeperAudioClip('echo', {
+      token: 'live-clip',
+      mime: 'audio/mpeg',
+      message_text: 'hello operator',
+      duration_sec: 4,
+    })
+    expect(attached).toBe(true)
+    expect(keeperThreads.value.echo?.[0]?.audio?.token).toBe('live-clip')
+  })
+
+  it('does not attach when no assistant text matches', () => {
+    appendThreadEntry('echo', entry({
+      id: 'reply-1',
+      role: 'assistant',
+      source: 'direct_assistant',
+      text: 'different text',
+      rawText: 'different text',
+    }))
+    const attached = attachKeeperAudioClip('echo', {
+      token: 'live-clip',
+      mime: 'audio/mpeg',
+      message_text: 'hello operator',
+    })
+    expect(attached).toBe(false)
+    expect(keeperThreads.value.echo?.[0]?.audio).toBeUndefined()
   })
 })

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -2,6 +2,7 @@ import { signal } from '@preact/signals'
 import { formatKeeperVisibleReply } from './keeper-message'
 import { isRecord, asString, asNumber, asBoolean, toIsoTimestamp } from './components/common/normalize'
 import type {
+  KeeperConversationAudioClip,
   KeeperConversationEntry,
   KeeperConversationRole,
   KeeperConversationSource,
@@ -110,6 +111,65 @@ export function isVisibleDirectConversationEntry(entry: KeeperConversationEntry)
     && entry.source !== 'internal_assistant'
     && entry.source !== 'tool_result'
     && entry.source !== 'system'
+}
+
+// --- Audio helpers (RFC-0235 P1/P3) ---
+
+/** Canonicalize an audio clip from the wire into the dashboard type.
+ *  Accepts both snake_case (history rows) and camelCase (SSE payloads).
+ *  Falls back to `/api/v1/voice/audio/<token>` when the backend did not
+ *  emit a full URL, so every persisted clip is playable. */
+export function normalizeAudioClip(raw: unknown): KeeperConversationAudioClip | null {
+  if (!isRecord(raw)) return null
+  const token = asString(raw.token)
+  const mime = asString(raw.mime)
+  if (!token || !mime) return null
+  const explicitUrl = asString(raw.audio_url) ?? asString(raw.audioUrl)
+  const audioUrl = explicitUrl && explicitUrl.trim() !== ''
+    ? explicitUrl
+    : `/api/v1/voice/audio/${encodeURIComponent(token)}`
+  const duration = asNumber(raw.duration_sec) ?? asNumber(raw.durationSec)
+  const messageText = asString(raw.message_text) ?? asString(raw.messageText) ?? ''
+  const deviceId = asString(raw.device_id) ?? asString(raw.deviceId)
+  return {
+    token,
+    audioUrl,
+    mime,
+    durationSec: duration ?? null,
+    messageText,
+    deviceId: deviceId ?? null,
+  }
+}
+
+/** Try to attach an audio clip to the most recent assistant entry whose
+ *  rendered text matches the clip's message text. Returns true if a match
+ *  was found and updated. This handles the live SSE path: the assistant
+ *  bubble is already streaming when the synthesized audio event arrives. */
+export function attachKeeperAudioClip(name: string, rawAudio: unknown): boolean {
+  const clip = normalizeAudioClip(rawAudio)
+  if (!clip) return false
+  const targetText = formatKeeperVisibleReply(clip.messageText).trim()
+  const rawTarget = clip.messageText.trim()
+  const existing = keeperThreads.value[name] ?? []
+  let updated = false
+  const next = existing.map((entry) => {
+    if (updated) return entry
+    if (entry.role !== 'assistant') return entry
+    const entryText = entry.text.trim()
+    const entryRawText = (entry.rawText ?? entry.text).trim()
+    if (
+      (targetText && entryText === targetText)
+      || (rawTarget && entryRawText === rawTarget)
+    ) {
+      updated = true
+      return { ...entry, audio: clip }
+    }
+    return entry
+  })
+  if (updated) {
+    keeperThreads.value = { ...keeperThreads.value, [name]: next }
+  }
+  return updated
 }
 
 // --- Normalizers ---
@@ -246,6 +306,7 @@ function normalizeHistoryEntry(
   const timestamp = toIsoTimestamp(raw.ts_unix) ?? toIsoTimestamp(raw.timestamp)
   const label = role === 'assistant' && keeperName ? keeperName : roleLabel(role)
   const surface = isRecord(raw.surface) ? (raw.surface as unknown as SurfaceRef) : null
+  const audio = normalizeAudioClip(raw.audio) ?? null
   return {
     // R3: key off the producer-assigned server id when present so the
     // render key is stable across history-page merges (the former
@@ -262,6 +323,7 @@ function normalizeHistoryEntry(
     streamState: null,
     details: null,
     surface,
+    audio,
   }
 }
 
@@ -437,6 +499,7 @@ interface RestChatHistoryMessage {
   tool_call_name?: string
   source?: string
   surface?: SurfaceRef
+  audio?: unknown
 }
 
 /** Convert a persisted tool-call row into the same entry shape the live
@@ -480,7 +543,13 @@ export function chatHistoryEntriesFromRest(
       return
     }
     const normalized = normalizeHistoryEntry(
-      { id: message.id, role: message.role, content: message.content, ts_unix: message.ts },
+      {
+        id: message.id,
+        role: message.role,
+        content: message.content,
+        ts_unix: message.ts,
+        audio: message.audio,
+      },
       keeperName,
       previousSource,
     )

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -171,6 +171,43 @@ describe('SSEMessageSchema', () => {
     })
     expect(r.success).toBe(true)
   })
+
+  it('accepts keeper_chat_appended with RFC-0235 audio clip', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'keeper_chat_appended',
+      name: 'keeper-1',
+      connector: 'agent',
+      ts_unix: 1_712_000_000,
+      audio: {
+        token: 'clip-123',
+        mime: 'audio/mpeg',
+        message_text: 'hello operator',
+        audio_url: 'https://cdn.example/voice/clip-123.mp3',
+        duration_sec: 5.2,
+        device_id: 'dashboard',
+      },
+    })
+    expect(r.success).toBe(true)
+    if (r.success) {
+      expect(r.data.audio).toEqual({
+        token: 'clip-123',
+        mime: 'audio/mpeg',
+        message_text: 'hello operator',
+        audio_url: 'https://cdn.example/voice/clip-123.mp3',
+        duration_sec: 5.2,
+        device_id: 'dashboard',
+      })
+    }
+  })
+
+  it('rejects malformed audio clip on keeper_chat_appended', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'keeper_chat_appended',
+      name: 'keeper-1',
+      audio: { token: 'clip-123' },
+    })
+    expect(r.success).toBe(false)
+  })
 })
 
 describe('parseSSEMessage', () => {

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -8,6 +8,7 @@
 import type {
   Attribution,
   AttributionOutcome,
+  SSEAudioClip,
   SSEEvent,
   SSEEventType,
 } from '../types/sse'
@@ -154,6 +155,25 @@ function fail<T = never>(path: string | undefined, message: string): SafeParseRe
 
 import { isRecord } from '../lib/type-guards'
 
+function isOptionalString(value: unknown): boolean {
+  return value == null || typeof value === 'string'
+}
+
+function isOptionalNumber(value: unknown): boolean {
+  return value == null || (typeof value === 'number' && Number.isFinite(value))
+}
+
+export function isSSEAudioClip(value: unknown): value is SSEAudioClip {
+  if (!isRecord(value)) return false
+  if (typeof value.token !== 'string') return false
+  if (typeof value.mime !== 'string') return false
+  if (typeof value.message_text !== 'string') return false
+  if (!isOptionalString(value.audio_url)) return false
+  if (!isOptionalNumber(value.duration_sec)) return false
+  if (!isOptionalString(value.device_id)) return false
+  return true
+}
+
 function isIgnorableMcpNotification(value: unknown): boolean {
   if (!isRecord(value)) return false
   if (value.jsonrpc !== '2.0') return false
@@ -280,6 +300,9 @@ export const SSEMessageSchema = schema<SSEMessage>((value) => {
   if (value.attribution != null) {
     const attribution = AttributionSchema.safeParse(value.attribution)
     if (!attribution.success) return attribution
+  }
+  if (value.audio != null && !isSSEAudioClip(value.audio)) {
+    return fail('audio', 'Expected audio clip object')
   }
 
   return ok(value as unknown as SSEMessage)

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -41,7 +41,7 @@ const showToast = vi.fn<(message: string, kind?: string, durationMs?: number) =>
 const replayOasRuntimeTelemetry = vi.fn<() => Promise<void>>(async () => {})
 const hydrateFleetCompositeSnapshot = vi.fn<(payload: unknown) => void>()
 const hydrateGoalTreeSnapshot = vi.fn<(payload: unknown) => boolean>(() => true)
-const noteKeeperChatAppended = vi.fn<(name: string) => void>()
+const noteKeeperChatAppended = vi.fn<(name: string, audio?: unknown) => void>()
 
 async function flushAsyncWork(): Promise<void> {
   await vi.dynamicImportSettled()
@@ -334,7 +334,27 @@ describe('setupSSEReaction reconnect hydration', () => {
     })
     await flushAsyncWork()
 
-    expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo')
+    expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo', undefined)
+  })
+
+  it('forwards RFC-0235 audio clips on keeper_chat_appended to the chat handler', async () => {
+    const { sseStore } = await loadSseStore()
+    const audio = {
+      token: 'clip-1',
+      mime: 'audio/mpeg',
+      message_text: 'hello',
+      duration_sec: 3,
+    }
+
+    sseStore.routeServerPushEvent({
+      type: 'keeper_chat_appended',
+      name: 'echo',
+      connector: 'agent',
+      audio,
+    })
+    await flushAsyncWork()
+
+    expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo', audio)
   })
 
   it('routes board reaction changes through the board refresh budget', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -545,13 +545,13 @@ export function hydrateServerPushEvent(event: SSEEvent): boolean {
   }
 
   if (event.type === 'keeper_chat_appended') {
-    const payload = event as unknown as { name?: string }
+    const payload = event as unknown as { name?: string; audio?: unknown }
     const name = typeof payload.name === 'string' ? payload.name : ''
     if (name) {
       // Dynamic import keeps sse-store decoupled from the keeper action
       // layer (same pattern as the agent-failed notification above).
       void import('./keeper-runtime')
-        .then(mod => { mod.noteKeeperChatAppended(name) })
+        .then(mod => { mod.noteKeeperChatAppended(name, payload.audio) })
         .catch(err => {
           console.debug('[SSE] keeper chat refresh unavailable', err instanceof Error ? err.message : '')
         })

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -737,6 +737,19 @@ export interface KeeperConversationAttachment {
   data: string
 }
 
+// RFC-0235 P1: synthesized voice clip attached to an assistant chat row.
+// `audioUrl` is the absolute/relative URL the dashboard uses for playback;
+// `token` is the capability in `/api/v1/voice/audio/<token>` used as a
+// fallback when the backend did not emit a full URL.
+export interface KeeperConversationAudioClip {
+  token: string
+  audioUrl?: string | null
+  mime: string
+  durationSec?: number | null
+  messageText: string
+  deviceId?: string | null
+}
+
 export type KeeperConversationStreamState =
   | 'opening'
   | 'thinking'
@@ -775,6 +788,7 @@ export interface KeeperConversationEntry {
   details?: KeeperConversationDetails | null
   error?: string | null
   surface?: SurfaceRef | null
+  audio?: KeeperConversationAudioClip | null
 }
 
 export interface KeeperStatusDetail {

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -226,6 +226,23 @@ export interface SSEEvent {
   audit_summary?: string
   audit_severity?: string
   audit_payload?: unknown
+  // RFC-0235 P1/P3: synthesized voice clip attached to keeper_chat_appended.
+  // Backend emits `audio: { token, mime, message_text, audio_url?,
+  // duration_sec?, device_id? }`. Optional; assistant transcript rows
+  // render a user-gesture play button when present.
+  audio?: SSEAudioClip
+}
+
+// RFC-0235 P1: nested audio payload inside `keeper_chat_appended` events.
+// Naming mirrors the backend JSON keys; normalizers map to camelCase on
+// the way into `KeeperConversationAudioClip`.
+export interface SSEAudioClip {
+  token: string
+  mime: string
+  message_text: string
+  audio_url?: string | null
+  duration_sec?: number | null
+  device_id?: string | null
 }
 
 // --- Journal ---

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -858,5 +858,6 @@ let to_json_array (messages : chat_message list) : Yojson.Safe.t =
                          ("data", `String att.data);
                        ]
                      ) atts in
-                     [("attachments", `List att_json)])))
+                     [("attachments", `List att_json)])
+              @ audio_fields m.audio))
        messages)

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -149,9 +149,7 @@ let handle_speak
               file so the dashboard can fetch /api/v1/voice/audio/<token>. *)
            let base_dir = config.Workspace.base_path in
            let surface = Surface_ref.Dashboard { session_id = None } in
-           Keeper_chat_store.append_assistant_message
-             ~base_dir ~keeper_name:meta.name ~content:message ~surface ();
-           let clip =
+           let clip : Keeper_chat_store.audio_clip option =
              match Json_util.get_string json "audio_file" with
              | Some path ->
                let token =
@@ -161,7 +159,7 @@ let handle_speak
                  Printf.sprintf "/api/v1/voice/audio/%s" token
                in
                Some
-                 { Keeper_chat_broadcast.token
+                 { Keeper_chat_store.token
                  ; audio_url = Some audio_url
                  ; mime = "audio/mpeg"
                  ; duration_sec = None
@@ -170,10 +168,21 @@ let handle_speak
                  }
              | None -> None
            in
+           Keeper_chat_store.append_assistant_message
+             ~base_dir ~keeper_name:meta.name ~content:message ~surface ?audio:clip ();
            (match clip with
             | Some c ->
               Keeper_chat_broadcast.chat_appended_with_audio
-                ~keeper_name:meta.name ~source:"agent" ~audio:c
+                ~keeper_name:meta.name
+                ~source:"agent"
+                ~audio:
+                  { Keeper_chat_broadcast.token = c.token
+                  ; audio_url = c.audio_url
+                  ; mime = c.mime
+                  ; duration_sec = c.duration_sec
+                  ; message_text = c.message_text
+                  ; device_id = c.device_id
+                  }
             | None ->
               Keeper_chat_broadcast.chat_appended
                 ~keeper_name:meta.name ~source:"agent");


### PR DESCRIPTION
## Summary
Closes the dashboard side of RFC-0235 P1/P3 voice output: synthesized assistant voice clips now flow from backend persistence through SSE/history into the chat UI as a user-gesture play button.

## Backend fixes
- `lib/keeper/keeper_chat_store.ml`: emit the `audio` field in `to_json_array` history responses.
- `lib/keeper/keeper_tool_voice_runtime.ml`: build and persist the audio clip alongside the assistant message before broadcasting, so clips survive history reloads.

## Dashboard changes
- `src/types/core.ts`: add `KeeperConversationAudioClip` and `audio` on `KeeperConversationEntry`.
- `src/api/schemas/keeper-chat-history.ts`: accept `audio` on history rows (snake_case + camelCase) without dropping the whole row when malformed.
- `src/types/sse.ts` / `src/schemas/sse.ts`: validate `audio` on `keeper_chat_appended` events.
- `src/keeper-state.ts`: `normalizeAudioClip` canonicalizes wire shapes and falls back to `/api/v1/voice/audio/<token>`; `attachKeeperAudioClip` attaches SSE clips to the matching streaming assistant bubble.
- `src/keeper-actions.ts`: `noteKeeperChatAppended` now consumes optional audio first, then falls back to history re-merge.
- `src/sse-store.ts`: forward `audio` from `keeper_chat_appended` events to the chat handler.
- `src/components/chat/primitives.ts`: render `<audio controls>` for assistant entries with a clip (no autoplay).

## Tests
- `src/api/schemas/keeper-chat-history.test.ts`
- `src/schemas/sse.test.ts`
- `src/keeper-state.test.ts`
- `src/sse-store.test.ts`
- `src/components/chat/primitives.test.ts`

## Verification
- `dune build @check` ✅
- `test/test_voice_runtime_overlay.exe` ✅ (18 tests)
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Dashboard suite: 515/516 passed; one unrelated pre-existing failure in `keeper-detail-page.test.ts` (`masc_trace_window` text expectation).
- `test_keeper_chat_store.exe`: unrelated pre-existing `tool_call_persistence` failure remains.