### PR TITLE
test(dashboard): sync stale KeeperWorkspaceRail test after #21266 migration

### DIFF
--- a/dashboard/src/components/keeper-detail-page.test.ts
+++ b/dashboard/src/components/keeper-detail-page.test.ts
@@ -65,7 +65,7 @@ describe('KeeperWorkspaceRoster', () => {
 })
 
 describe('KeeperWorkspaceRail', () => {
-  it('renders current keeper runtime, context, task, and tool summary', () => {
+  it('renders current keeper runtime, context, and owned task', () => {
     tasks.value = [makeTask()]
     const container = renderInto(html`<${KeeperWorkspaceRail} keeper=${makeKeeper()} onToggleDetail=${() => {}} />`)
 
@@ -74,6 +74,12 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('oas-seoul-1')
     expect(container.textContent).toContain('62%')
     expect(container.textContent).toContain('T-1')
-    expect(container.textContent).toContain('masc_trace_window')
+    // The rail no longer renders keeper.recent_tool_names; #21266 migrated the
+    // recent-tool section to KeeperWorkspaceRecentTools, which lazy-loads per-call
+    // data via fetchKeeperToolCalls and returns null when nothing is fetched. That
+    // behavior is covered (with the fetch stubbed) in keeper-workspace-tool-calls.test.ts
+    // and keeper-workspace-rail.test.ts; asserting recent_tool_names here tested
+    // removed behavior. Do not re-add a fetch mock + tool assertion (would duplicate
+    // canonical coverage).
   })
 })


### PR DESCRIPTION
## 증상

`dashboard/src/components/keeper-detail-page.test.ts > KeeperWorkspaceRail`가 main에서 실패합니다. 단언 `expect(container.textContent).toContain('masc_trace_window')`(line 77)가 실패 — 렌더 출력이 런타임/모델/컨텍스트/소유태스크에서 끝나고 도구 요약 섹션이 없습니다.

## 정본 판정 — 테스트가 stale (프로덕션 코드는 정상)

PR #21266(`5398153a4`, "rich recent tool-calls in keeper-workspace rail")이 rail의 최근 도구 렌더를 **의도적으로 마이그레이션**했습니다:

- 이전: `KeeperWorkspaceRail`이 `keeper.recent_tool_names`(flat string[])를 직접 렌더
- 이후: `KeeperWorkspaceRecentTools`(`keeper-workspace-tool-calls.ts`)가 `fetchKeeperToolCalls`로 per-call 데이터를 lazy-load. fetch 결과가 없으면 `null` 반환(`keeper-workspace-tool-calls.ts:121`) → 도구 섹션 자체가 생략됨

#21266은 **canonical 테스트 `keeper-workspace-rail.test.ts`는 갱신**(옛 단언 제거 + `fetchKeeperToolCalls` mock 추가)했으나, **별도 파일의 중복 테스트 `keeper-detail-page.test.ts`를 누락**했습니다(이 파일은 #21216/#21210이 마지막 수정, #21266 미접촉 — `git show 5398153a4 --stat`에 해당 경로 없음).

근거:
- `keeper-workspace-rail.ts:175`가 `<KeeperWorkspaceRecentTools keeperName=keeper.name />`를 렌더 — `recent_tool_names`를 더는 읽지 않음
- `rg masc_trace_window dashboard/src` → 오직 이 테스트 파일에만 등장(fixture + 단언). 어떤 프로덕션 컴포넌트도 소비하지 않음
- 새 동작은 sibling 테스트 13건(`keeper-workspace-rail.test.ts` 8 + `keeper-workspace-tool-calls.test.ts` 5)이 fetch stub과 함께 이미 커버

## 변경

중복 테스트의 `masc_trace_window` 단언만 제거하고 제목을 실제 단언에 맞게 정정, canonical 커버리지를 가리키는 주석 추가. **프로듀서/소스 코드 변경 없음**. 나머지 5개 실단언(런타임·처리량/claude-sonnet-4/oas-seoul-1/62%/T-1)은 유지 — 살아있는 테스트.

워크어라운드 아님: 실제 버그를 가리는 단언 약화가 아니라, 의도적으로 제거된 동작을 테스트하던 중복 단언을 정리. 해당 동작은 canonical하게 다른 곳에서 검증됨.

## 검증
- `vitest run keeper-detail-page.test.ts` → 2 passed
- `vitest run keeper-workspace-rail.test.ts keeper-workspace-tool-calls.test.ts` → 13 passed (새 동작 커버 입증)
- `tsc --noEmit` → 0

RFC-WAIVED: dashboard 테스트 1파일 동기화(프로덕션 동작 미변경). credential/identity/repo/operator/sandbox/hooks/workflow subsystem 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
