### PR TITLE
style(dashboard): apply v2 design-system chrome to left rail and status tray

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -335,7 +335,7 @@ export function App() {
             ${mobileMenuOpen.value ? html`
               <button type="button" aria-label="Close navigation" tabindex=${-1} class="hidden max-[768px]:block fixed inset-0 z-40 cursor-pointer bg-black/50" onClick=${() => { mobileMenuOpen.value = false }}></button>
             ` : null}
-            <aside id="dashboard-side-rail" aria-label="Sidebar navigation" class="${sidebarCollapsed.value ? 'w-14' : 'w-55'} shrink-0 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] max-[1100px]:w-full max-[1100px]:max-h-75 max-[768px]:fixed max-[768px]:inset-y-0 max-[768px]:left-0 max-[768px]:z-50 max-[768px]:m-0 max-[768px]:w-72 max-[768px]:max-h-none max-[768px]:rounded-none max-[768px]:border-r ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
+            <aside id="dashboard-side-rail" aria-label="Sidebar navigation" class="v2-shell-rail ${sidebarCollapsed.value ? 'w-14' : 'w-55'} shrink-0 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] max-[1100px]:w-full max-[1100px]:max-h-75 max-[768px]:fixed max-[768px]:inset-y-0 max-[768px]:left-0 max-[768px]:z-50 max-[768px]:m-0 max-[768px]:w-72 max-[768px]:max-h-none max-[768px]:rounded-none max-[768px]:border-r ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
               <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
             </aside>
           `}

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute } from './dashboard-shell'
+import { DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, SideRail } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 import { dashboardLoading } from '../store'
@@ -847,5 +847,47 @@ describe('dashboardHealthChips', () => {
     })
     expect(cdal?.detail).toContain('stale=3')
     expect(cdal?.detail).toContain('current_missing_task_scope=5')
+  })
+})
+
+describe('SideRail v2 chrome', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    route.value = {
+      tab: 'monitoring',
+      params: { section: 'agents' },
+      postId: null,
+    }
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders v2 structural classes and highlights the active surface', () => {
+    render(h(SideRail, { collapsed: false, onToggle: () => {} }), container)
+
+    expect(container.querySelector('.nav-brand')).not.toBeNull()
+    expect(container.querySelector('.nav-sec')).not.toBeNull()
+    expect(container.querySelector('.nav-link.active')).not.toBeNull()
+    expect(container.querySelector('.nav-link.active')?.textContent).toContain('Monitor')
+
+    const sublist = container.querySelector('.nav-sublist')
+    expect(sublist).not.toBeNull()
+    const activeSublink = sublist?.querySelector('.nav-sublink.active')
+    expect(activeSublink).not.toBeNull()
+    expect(activeSublink?.textContent).toContain('Keeper Fleet')
+  })
+
+  it('renders collapsed icon-only links with v2 classes', () => {
+    render(h(SideRail, { collapsed: true, onToggle: () => {} }), container)
+
+    const links = container.querySelectorAll('.nav-link-collapsed')
+    expect(links.length).toBeGreaterThan(0)
+    expect(container.querySelector('.nav-link-collapsed.active')).not.toBeNull()
   })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1048,7 +1048,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="nav-link-collapsed flex h-7 w-full items-center justify-center rounded-[var(--r-0)] border cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSurfaceActive ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-secondary)]'}"
+                  class="nav-link-collapsed flex h-7 w-full items-center justify-center rounded-[var(--r-0)] border cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSurfaceActive ? 'active border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-secondary)]'}"
                   title=${surface.label}
                   aria-label=${surface.label}
                   ariaCurrent=${isSurfaceActive ? 'page' : undefined}
@@ -1064,7 +1064,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="nav-link flex min-h-7 w-full items-center gap-1.5 rounded-[var(--r-0)] border px-1.5 py-1 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSurfaceActive ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--color-fg-secondary)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent bg-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-secondary)]'}"
+                  class="nav-link flex min-h-7 w-full items-center gap-1.5 rounded-[var(--r-0)] border px-1.5 py-1 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSurfaceActive ? 'active border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--color-fg-secondary)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent bg-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-secondary)]'}"
                   ariaCurrent=${isSurfaceActive && sections.length === 0 ? 'page' : undefined}
                 >
                   <span class="nav-icon flex size-5 shrink-0 items-center justify-center rounded-[var(--r-0)] ${isSurfaceActive ? 'bg-[var(--select-10)] text-[var(--select)]' : 'bg-[var(--color-bg-surface)] text-[var(--color-fg-muted)]'}" aria-hidden="true">
@@ -1084,7 +1084,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                           <${RouteLink}
                             tab=${surface.id}
                             params=${item.params}
-                            class="nav-sublink block w-full rounded-[var(--r-0)] border px-2 py-0.5 text-left font-mono text-[var(--fs-10)] uppercase leading-5 tracking-[var(--track-sub)] cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSectionActive ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-primary)]'}"
+                            class="nav-sublink block w-full rounded-[var(--r-0)] border px-2 py-0.5 text-left font-mono text-[var(--fs-10)] uppercase leading-5 tracking-[var(--track-sub)] cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSectionActive ? 'active border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-primary)]'}"
                             ariaCurrent=${isSectionActive ? 'page' : undefined}
                           >
                             <div class="truncate">${item.label}</div>

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1017,15 +1017,15 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
 
   return html`
     <nav class="flex flex-col h-full" aria-label="Dashboard navigation">
-      <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} border-b border-[var(--color-border-default)] px-2 pt-2 pb-2">
+      <div class="nav-brand flex items-center ${collapsed ? 'justify-center' : 'justify-between'} border-b border-[var(--color-border-default)] px-2 pt-2 pb-2">
         ${!collapsed ? html`
           <div class="px-1 leading-none">
-            <div class="font-mono text-[var(--fs-9)] font-bold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-disabled)]">MASC</div>
-            <div class="mt-1 font-mono text-[var(--fs-11)] font-semibold uppercase tracking-[0.14em] text-[var(--color-fg-secondary)]">Cockpit</div>
+            <div class="nb-title font-mono text-[var(--fs-9)] font-bold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-disabled)]">MASC</div>
+            <div class="nb-sub mt-1 font-mono text-[var(--fs-11)] font-semibold uppercase tracking-[0.14em] text-[var(--color-fg-secondary)]">Cockpit</div>
           </div>
         ` : null}
         <button type="button"
-          class=${`flex size-6 items-center justify-center rounded-[var(--r-0)] border border-transparent text-[var(--color-fg-muted)] cursor-pointer transition-[background-color,border-color,color] duration-[var(--t-med)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-fg-secondary)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`}
+          class=${`nav-collapse flex size-6 items-center justify-center rounded-[var(--r-0)] border border-transparent text-[var(--color-fg-muted)] cursor-pointer transition-[background-color,border-color,color] duration-[var(--t-med)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-fg-secondary)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`}
           aria-label=${collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           onClick=${onToggle}
           title=${collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
@@ -1036,7 +1036,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
 
       <div class="flex-1 overflow-y-auto px-2 py-2">
         ${!collapsed ? html`
-          <div class="px-1 pb-1.5 font-mono text-[var(--fs-9)] font-bold uppercase tracking-[0.2em] text-[var(--color-fg-disabled)]">Surfaces</div>
+          <div class="nav-sec px-1 pb-1.5 font-mono text-[var(--fs-9)] font-bold uppercase tracking-[0.2em] text-[var(--color-fg-disabled)]">Surfaces</div>
         ` : null}
         <div class="flex flex-col gap-1">
           ${visibleSurfaces.map(surface => {
@@ -1048,35 +1048,35 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="flex h-7 w-full items-center justify-center rounded-[var(--r-0)] border cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSurfaceActive ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-secondary)]'}"
+                  class="nav-link-collapsed flex h-7 w-full items-center justify-center rounded-[var(--r-0)] border cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSurfaceActive ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-secondary)]'}"
                   title=${surface.label}
                   aria-label=${surface.label}
                   ariaCurrent=${isSurfaceActive ? 'page' : undefined}
                 >
-                  <span aria-hidden="true"><${SurfaceIcon} icon=${surface.icon} size=${15} /></span>
+                  <span class="nav-icon" aria-hidden="true"><${SurfaceIcon} icon=${surface.icon} size=${15} /></span>
                   <span class="sr-only">${surface.label}</span>
                 <//>
               `
             }
 
             return html`
-              <div class="flex flex-col gap-0.5 border-t border-[var(--color-border-divider)] pt-1 first:border-t-0 first:pt-0">
+              <div class="nav-group flex flex-col gap-0.5 border-t border-[var(--color-border-divider)] pt-1 first:border-t-0 first:pt-0">
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="flex min-h-7 w-full items-center gap-1.5 rounded-[var(--r-0)] border px-1.5 py-1 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSurfaceActive ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--color-fg-secondary)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent bg-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-secondary)]'}"
+                  class="nav-link flex min-h-7 w-full items-center gap-1.5 rounded-[var(--r-0)] border px-1.5 py-1 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSurfaceActive ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--color-fg-secondary)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent bg-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-secondary)]'}"
                   ariaCurrent=${isSurfaceActive && sections.length === 0 ? 'page' : undefined}
                 >
-                  <span class="flex size-5 shrink-0 items-center justify-center rounded-[var(--r-0)] ${isSurfaceActive ? 'bg-[var(--select-10)] text-[var(--select)]' : 'bg-[var(--color-bg-surface)] text-[var(--color-fg-muted)]'}" aria-hidden="true">
+                  <span class="nav-icon flex size-5 shrink-0 items-center justify-center rounded-[var(--r-0)] ${isSurfaceActive ? 'bg-[var(--select-10)] text-[var(--select)]' : 'bg-[var(--color-bg-surface)] text-[var(--color-fg-muted)]'}" aria-hidden="true">
                     <${SurfaceIcon} icon=${surface.icon} size=${13} />
                   </span>
-                  <div class="flex-1 min-w-0">
+                  <div class="nav-label flex-1 min-w-0">
                     <div class="truncate font-mono text-[var(--fs-11)] font-semibold uppercase leading-4 tracking-[var(--track-caps)] ${isSurfaceActive ? 'text-[var(--select)]' : ''}">${surface.label}</div>
                   </div>
                 <//>
 
                 ${sections.length > 1 ? html`
-                  <div class="ml-2.5 flex flex-col gap-px border-l border-[var(--color-border-divider)] pl-2.5" role="list">
+                  <div class="nav-sublist ml-2.5 flex flex-col gap-px border-l border-[var(--color-border-divider)] pl-2.5" role="list">
                     ${sections.map(item => {
                       const isSectionActive = isSurfaceActive && currentSection?.id === item.id
                       return html`
@@ -1084,7 +1084,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                           <${RouteLink}
                             tab=${surface.id}
                             params=${item.params}
-                            class="block w-full rounded-[var(--r-0)] border px-2 py-0.5 text-left font-mono text-[var(--fs-10)] uppercase leading-5 tracking-[var(--track-sub)] cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSectionActive ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-primary)]'}"
+                            class="nav-sublink block w-full rounded-[var(--r-0)] border px-2 py-0.5 text-left font-mono text-[var(--fs-10)] uppercase leading-5 tracking-[var(--track-sub)] cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSectionActive ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-primary)]'}"
                             ariaCurrent=${isSectionActive ? 'page' : undefined}
                           >
                             <div class="truncate">${item.label}</div>
@@ -1100,7 +1100,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
         </div>
       </div>
 
-      <div class="shrink-0 border-t border-[var(--color-border-default)] px-2 py-2">
+      <div class="nav-footer shrink-0 border-t border-[var(--color-border-default)] px-2 py-2">
         <${HealthIndicator} collapsed=${collapsed} />
       </div>
     </nav>

--- a/dashboard/src/components/status-tray.test.ts
+++ b/dashboard/src/components/status-tray.test.ts
@@ -314,4 +314,28 @@ describe('DashboardStatusTray', () => {
 
     expect(screen.queryByTestId('dashboard-status-tray-popover')).not.toBeInTheDocument()
   })
+
+  it('renders v2 chrome classes and tone badges on tray buttons', () => {
+    render(h(DashboardStatusTray, { sideRailCollapsed: false }))
+
+    const tray = screen.getByTestId('dashboard-status-tray')
+    expect(tray.classList.contains('v2-status-tray')).toBe(true)
+
+    const bar = tray.querySelector('.v2-tray-bar')
+    expect(bar).not.toBeNull()
+
+    const buttons = tray.querySelectorAll('.tray-button')
+    expect(buttons.length).toBe(4)
+
+    for (const key of ['transport', 'fleet', 'activity', 'attention'] as const) {
+      const btn = screen.getByTestId(`dashboard-status-tray-${key}`)
+      expect(btn.classList.contains('tray-button')).toBe(true)
+      expect(btn.querySelector('.tray-button-icon')).not.toBeNull()
+      expect(btn.querySelector('.tray-button-label')).not.toBeNull()
+      expect(btn.querySelector('.tray-button-value')).not.toBeNull()
+    }
+
+    const transportBtn = screen.getByTestId('dashboard-status-tray-transport')
+    expect(transportBtn.className).toMatch(/tone-(ok|warn|err|muted)/)
+  })
 })

--- a/dashboard/src/components/status-tray.ts
+++ b/dashboard/src/components/status-tray.ts
@@ -95,20 +95,6 @@ interface DashboardStatusTrayProps {
 
 const TRAY_ORDER: StatusTrayKey[] = ['transport', 'fleet', 'activity', 'attention']
 
-const TONE_CLASS: Record<StatusTrayTone, string> = {
-  ok: 'border-[var(--color-status-ok)] bg-[var(--ok-soft)] text-[var(--color-status-ok)]',
-  warn: 'border-[var(--color-status-warn)] bg-[var(--warn-soft)] text-[var(--color-status-warn)]',
-  err: 'border-[var(--color-status-err)] bg-[var(--bad-soft)] text-[var(--color-status-err)]',
-  muted: 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)]',
-}
-
-const PANEL_TONE_CLASS: Record<StatusTrayTone, string> = {
-  ok: 'border-[var(--ok-30)]',
-  warn: 'border-[var(--warn-30)]',
-  err: 'border-[var(--bad-30)]',
-  muted: 'border-[var(--color-border-default)]',
-}
-
 const ITEM_META = {
   transport: { icon: Radio, title: 'Transport' },
   fleet: { icon: Users, title: 'Fleet' },
@@ -150,17 +136,6 @@ function countKeeperAttention(keeperInput: readonly Keeper[]): number {
   return keeperInput.filter(keeper => {
     if (keeper.needs_attention) return true
     if (hasExecutionAttentionEvidence(keeper)) return true
-    // Terminal/crashed lifecycle states. The previous version inspected
-    // `keeper.status` for `'crash' | 'dead' | 'zombie'`, but the
-    // backend `Keeper.status` emit (`patched_keeper_status` in
-    // `lib/server/server_dashboard_http_execution_surfaces.ml:424-432`)
-    // only ever produces `'offline' | 'busy' | 'active' | 'listening' | 'idle'`.
-    // None of those crashed-state tokens are emitted into the status
-    // slot — they belong to `Keeper.phase` (typed `KeeperPhase` union
-    // in `core.ts:879-892`), normalised by `toKeeperPhase` at the wire
-    // boundary. Comparing typed phase tokens here means crashed keepers
-    // actually get counted as attention rather than silently slipping
-    // past an axis-confused string match.
     return isKeeperCrashed(keeper)
   }).length
 }
@@ -324,7 +299,7 @@ function TrayButton({
   return html`
     <button
       type="button"
-      class=${`inline-flex h-9 shrink-0 items-center gap-2 rounded-[var(--r-1)] border border-solid px-2.5 text-left shadow-[var(--shadow-1)] transition-colors hover:bg-[var(--color-bg-hover)] max-[520px]:gap-1.5 max-[520px]:px-2 ${TONE_CLASS[item.tone]} ${active ? 'ring-2 ring-[var(--select-20)]' : ''} ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 1, offsetSurface: 'surface' })}`}
+      class=${`tray-button tone-${item.tone} ${active ? 'active' : ''} inline-flex h-9 shrink-0 items-center gap-2 rounded-[var(--r-1)] border border-solid px-2.5 text-left shadow-[var(--shadow-1)] transition-colors hover:bg-[var(--color-bg-hover)] max-[520px]:gap-1.5 max-[520px]:px-2 ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 1, offsetSurface: 'surface' })}`}
       title=${`${meta.title}: ${item.detail}`}
       aria-label=${`${meta.title}: ${item.value}. ${item.detail}`}
       aria-haspopup="dialog"
@@ -333,12 +308,12 @@ function TrayButton({
       data-testid=${`dashboard-status-tray-${item.key}`}
       onClick=${onClick}
     >
-      <span class="inline-flex size-4 shrink-0 items-center justify-center" aria-hidden="true">
+      <span class="tray-button-icon inline-flex size-4 shrink-0 items-center justify-center" aria-hidden="true">
         <${Icon} size=${14} strokeWidth=${2} />
       </span>
       <span class="grid min-w-0 grid-cols-1">
-        <span class="font-mono text-3xs uppercase leading-none tracking-[var(--track-caps)] opacity-75 max-[520px]:sr-only">${item.label}</span>
-        <span class="max-w-24 truncate text-xs font-semibold leading-tight tracking-normal">${item.value}</span>
+        <span class="tray-button-label font-mono text-3xs uppercase leading-none tracking-[var(--track-caps)] opacity-75 max-[520px]:sr-only">${item.label}</span>
+        <span class="tray-button-value max-w-24 truncate text-xs font-semibold leading-tight tracking-normal">${item.value}</span>
       </span>
     </button>
   `
@@ -351,13 +326,13 @@ function JournalPreviewList({ entries }: { entries: readonly JournalEntry[] }) {
   return html`
     <ul class="m-0 grid list-none gap-1 p-0">
       ${entries.map(entry => html`
-        <li class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
-          <div class="flex min-w-0 items-center gap-2">
-            <span class="min-w-0 truncate text-xs font-medium text-[var(--color-fg-secondary)]">${entry.agent || entry.author || 'system'}</span>
+        <li class="tray-journal-item min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
+          <div class="tray-journal-meta flex min-w-0 items-center gap-2">
+            <span class="tray-journal-agent min-w-0 truncate text-xs font-medium text-[var(--color-fg-secondary)]">${entry.agent || entry.author || 'system'}</span>
             <span class="shrink-0 font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${entry.kind ?? 'system'}</span>
             <span class="ml-auto shrink-0 text-3xs text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${entry.timestamp} /></span>
           </div>
-          <div class="mt-1 truncate text-xs text-[var(--color-fg-muted)]">${clip(entry.preview ?? entry.narrativeText ?? entry.text, 120)}</div>
+          <div class="tray-journal-preview mt-1 truncate text-xs text-[var(--color-fg-muted)]">${clip(entry.preview ?? entry.narrativeText ?? entry.text, 120)}</div>
         </li>
       `)}
     </ul>
@@ -376,17 +351,17 @@ function PopoverContent({
     return html`
       <div class="grid gap-3">
         <div>
-          <div class="text-sm font-semibold text-[var(--color-fg-secondary)]">${item.value}</div>
-          <div class="mt-1 text-xs text-[var(--color-fg-muted)]">${item.detail}</div>
+          <div class="tray-popover-label font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${item.label}</div>
+          <div class="tray-popover-detail mt-0.5 text-sm font-semibold text-[var(--color-fg-secondary)]">${item.detail}</div>
         </div>
         <div class="grid grid-cols-2 gap-2">
-          <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
-            <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Reconnects</div>
-            <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.reconnectCount}</div>
+          <div class="tray-stat rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
+            <div class="tray-stat-label font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Reconnects</div>
+            <div class="tray-stat-value mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.reconnectCount}</div>
           </div>
-          <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
-            <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">WS deltas</div>
-            <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.wsEventCount60s}/60s</div>
+          <div class="tray-stat rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
+            <div class="tray-stat-label font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">WS deltas</div>
+            <div class="tray-stat-value mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.wsEventCount60s}/60s</div>
           </div>
         </div>
       </div>
@@ -396,20 +371,20 @@ function PopoverContent({
     return html`
       <div class="grid gap-3">
         <div class="grid grid-cols-3 gap-2">
-          <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
-            <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Fresh</div>
-            <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.freshKeepers}/${summary.counts.totalKeepers}</div>
+          <div class="tray-stat rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
+            <div class="tray-stat-label font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Fresh</div>
+            <div class="tray-stat-value mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.freshKeepers}/${summary.counts.totalKeepers}</div>
           </div>
-          <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
-            <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Stale</div>
-            <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.staleKeepers}</div>
+          <div class="tray-stat rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
+            <div class="tray-stat-label font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Stale</div>
+            <div class="tray-stat-value mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.staleKeepers}</div>
           </div>
-          <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
-            <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Attention</div>
-            <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.keeperAttention}</div>
+          <div class="tray-stat rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
+            <div class="tray-stat-label font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Attention</div>
+            <div class="tray-stat-value mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.keeperAttention}</div>
           </div>
         </div>
-        <${RouteLink} tab="monitoring" class="inline-flex w-fit items-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]">
+        <${RouteLink} tab="monitoring" class="tray-action-link inline-flex w-fit items-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]">
           Open monitoring
         <//>
       </div>
@@ -419,7 +394,7 @@ function PopoverContent({
     return html`
       <div class="grid gap-3">
         <${JournalPreviewList} entries=${summary.latestJournalEntries} />
-        <${RouteLink} tab="logs" class="inline-flex w-fit items-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]">
+        <${RouteLink} tab="logs" class="tray-action-link inline-flex w-fit items-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]">
           Open logs
         <//>
       </div>
@@ -428,17 +403,17 @@ function PopoverContent({
   return html`
     <div class="grid gap-3">
       <div class="grid grid-cols-3 gap-2">
-        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
-          <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Errors</div>
-          <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.unacknowledgedErrors}</div>
+        <div class="tray-stat rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
+          <div class="tray-stat-label font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Errors</div>
+          <div class="tray-stat-value mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.unacknowledgedErrors}</div>
         </div>
-        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
-          <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Keepers</div>
-          <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.keeperAttention}</div>
+        <div class="tray-stat rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
+          <div class="tray-stat-label font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Keepers</div>
+          <div class="tray-stat-value mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.keeperAttention}</div>
         </div>
-        <div class="rounded-[var(--r-1)] border ${summary.counts.pendingVerificationTasks >= 3 ? 'border-[var(--warn-20)] bg-[var(--warn-10)]' : 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]'} px-2 py-1.5">
-          <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] ${summary.counts.pendingVerificationTasks >= 3 ? 'text-[var(--warn-bright)]' : 'text-[var(--color-fg-muted)]'}">Verify</div>
-          <div class="mt-0.5 text-sm font-semibold tabular-nums ${summary.counts.pendingVerificationTasks >= 3 ? 'text-[var(--warn-bright)]' : ''}">${summary.counts.pendingVerificationTasks}</div>
+        <div class="tray-stat ${summary.counts.pendingVerificationTasks >= 3 ? 'tone-warn' : ''} rounded-[var(--r-1)] border ${summary.counts.pendingVerificationTasks >= 3 ? 'border-[var(--warn-20)] bg-[var(--warn-10)]' : 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]'} px-2 py-1.5">
+          <div class="tray-stat-label font-mono text-3xs uppercase tracking-[var(--track-caps)] ${summary.counts.pendingVerificationTasks >= 3 ? 'text-[var(--warn-bright)]' : 'text-[var(--color-fg-muted)]'}">Verify</div>
+          <div class="tray-stat-value mt-0.5 text-sm font-semibold tabular-nums ${summary.counts.pendingVerificationTasks >= 3 ? 'text-[var(--warn-bright)]' : ''}">${summary.counts.pendingVerificationTasks}</div>
         </div>
       </div>
       ${summary.counts.unacknowledgedErrors > 0 ? html`
@@ -506,7 +481,7 @@ export function DashboardStatusTray({ sideRailCollapsed = false }: DashboardStat
   return html`
     <aside
       ref=${trayRef}
-      class=${`dashboard-status-tray fixed z-40 max-w-[calc(100vw-1.5rem)] ${sideRailOffset} max-[1100px]:left-2 max-[1100px]:right-2 max-[1100px]:max-w-none ${codeOffset}`}
+      class=${`v2-status-tray dashboard-status-tray fixed z-40 max-w-[calc(100vw-1.5rem)] ${sideRailOffset} max-[1100px]:left-2 max-[1100px]:right-2 max-[1100px]:max-w-none ${codeOffset}`}
       aria-label="Dashboard status tray"
       data-testid="dashboard-status-tray"
     >
@@ -516,16 +491,16 @@ export function DashboardStatusTray({ sideRailCollapsed = false }: DashboardStat
           data-testid="dashboard-status-tray-popover"
           role="dialog"
           aria-label=${`${activeItem.label} details`}
-          class=${`absolute bottom-full left-0 mb-2 w-[22rem] max-w-[calc(100vw-1rem)] rounded-[var(--r-2)] border border-solid bg-[var(--color-bg-panel)] p-3 text-[var(--color-fg-primary)] shadow-[var(--shadow-panel)] backdrop-blur-xl ${PANEL_TONE_CLASS[activeItem.tone]} max-[520px]:w-full`}
+          class=${`tray-popover tone-${activeItem.tone} absolute bottom-full left-0 mb-2 w-[22rem] max-w-[calc(100vw-1rem)] rounded-[var(--r-2)] border border-solid bg-[var(--color-bg-panel)] p-3 text-[var(--color-fg-primary)] shadow-[var(--shadow-panel)] backdrop-blur-xl max-[520px]:w-full`}
         >
-          <div class="mb-3 flex min-w-0 items-start justify-between gap-3">
+          <div class="tray-popover-head mb-3 flex min-w-0 items-start justify-between gap-3">
             <div class="min-w-0">
-              <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${activeItem.label}</div>
-              <div class="mt-0.5 truncate text-sm font-semibold text-[var(--color-fg-secondary)]">${activeItem.detail}</div>
+              <div class="tray-popover-label font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${activeItem.label}</div>
+              <div class="tray-popover-detail mt-0.5 truncate text-sm font-semibold text-[var(--color-fg-secondary)]">${activeItem.detail}</div>
             </div>
             <button
               type="button"
-              class=${`inline-flex size-7 shrink-0 items-center justify-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-xs text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 1, offsetSurface: 'surface' })}`}
+              class=${`tray-popover-close inline-flex size-7 shrink-0 items-center justify-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-xs text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 1, offsetSurface: 'surface' })}`}
               aria-label="Close status tray details"
               onClick=${() => { setActiveKey(null) }}
             >
@@ -536,7 +511,7 @@ export function DashboardStatusTray({ sideRailCollapsed = false }: DashboardStat
         </div>
       ` : null}
 
-      <div class="inline-flex max-w-full items-center gap-1 overflow-x-auto rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-header-bg)] p-1 shadow-[var(--shadow-panel)] backdrop-blur-xl [scrollbar-width:none]">
+      <div class="v2-tray-bar inline-flex max-w-full items-center gap-1 overflow-x-auto rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-header-bg)] p-1 shadow-[var(--shadow-panel)] backdrop-blur-xl [scrollbar-width:none]">
         ${TRAY_ORDER.map(key => html`
           <${TrayButton}
             item=${summary.items[key]}

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -33,6 +33,7 @@
 @import "./tools.css";
 @import "./ui.css";
 @import "./responsive.css";
+@import "./v2-shell.css";
 @import "./a11y.css"; /* after feature styles so reduced-motion overrides win */
 
 /* Strangler Fig migration bridge — bridges legacy CSS hooks to

--- a/dashboard/src/styles/v2-shell.css
+++ b/dashboard/src/styles/v2-shell.css
@@ -1,0 +1,514 @@
+/* MASC v2 — chrome overrides for the left side rail and bottom-right status tray.
+ * Scoped to .v2-shell-rail and .v2-status-tray so the rest of the dashboard
+ * keeps the legacy token ladder until it is migrated surface-by-surface.
+ *
+ * Source: /Users/dancer/Downloads/v2/_ds/masc-design-system-a925c77f-042a-40f5-ac15-0675a4a58d3f/ui_kits/dashboard/styles/nav.css
+ *         /Users/dancer/Downloads/v2/_ds/masc-design-system-a925c77f-042a-40f5-ac15-0675a4a58d3f/ui_kits/dashboard/styles/topbar.css
+ */
+
+.v2-shell-rail,
+.v2-status-tray {
+  /* v5 Observatory dark-fantasy palette, calibrated against the v2
+     colors_and_type.css "Dark Fantasy" theme. */
+  --v2-ink:         #0a0e18;
+  --v2-velvet:      #0f1524;
+  --v2-card:        #131a2a;
+  --v2-card-soft:   #161d30;
+  --v2-raised:      #1a2238;
+  --v2-border-soft: rgba(120, 140, 180, 0.09);
+  --v2-border:      rgba(120, 140, 180, 0.13);
+  --v2-border-strong: rgba(140, 160, 200, 0.18);
+  --v2-text:        #b8c4dc;
+  --v2-text-bright: #e8eef8;
+  --v2-text-dim:    #5a6a88;
+  --v2-text-faint:  #4a5a78;
+  --v2-accent-brass: #8a6a28;
+  --v2-accent-brass-dim: #5a4618;
+  --v2-ok:          #5a7a3a;
+  --v2-warn:        #a06a1a;
+  --v2-bad:         #a01818;
+
+  /* Re-use the generated type stacks (Cinzel display, Noto Sans KR UI). */
+  --v2-font-display: var(--font-display);
+  --v2-font-ui:      var(--font-ui);
+  --v2-font-mono:    var(--font-mono);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   LEFT RAIL
+   ═══════════════════════════════════════════════════════════════ */
+
+#dashboard-side-rail.v2-shell-rail {
+  background:
+    linear-gradient(180deg, #18110c 0%, #0e0806 100%);
+  border-right: 1px solid var(--v2-border-soft);
+  color: var(--v2-text);
+  box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.35);
+}
+
+#dashboard-side-rail.v2-shell-rail nav {
+  font-family: var(--v2-font-ui);
+}
+
+/* Brand / collapse header */
+#dashboard-side-rail.v2-shell-rail .nav-brand {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--v2-border-soft);
+  margin-bottom: 8px;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-brand .nb-title {
+  font-family: var(--v2-font-display);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--v2-text-bright);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-brand .nb-sub {
+  font-family: var(--v2-font-mono);
+  font-size: 9.5px;
+  color: var(--v2-text-faint);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-brand .nav-collapse {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--v2-border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--v2-text-dim);
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-brand .nav-collapse:hover {
+  border-color: var(--v2-accent-brass-dim);
+  color: var(--v2-accent-brass);
+  background: rgba(138, 106, 40, 0.06);
+}
+
+/* Section label (e.g. "Surfaces") */
+#dashboard-side-rail.v2-shell-rail .nav-sec {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px 4px;
+  font-family: var(--v2-font-mono);
+  font-size: 9.5px;
+  color: var(--v2-text-faint);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  user-select: none;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-sec::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, var(--v2-border-strong), transparent);
+}
+
+/* Surface groups */
+#dashboard-side-rail.v2-shell-rail .nav-group {
+  border-top: 1px solid var(--v2-border-soft);
+  padding-top: 4px;
+  margin-top: 4px;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-group:first-child {
+  border-top: 0;
+  padding-top: 0;
+  margin-top: 0;
+}
+
+/* Main surface link */
+#dashboard-side-rail.v2-shell-rail .nav-link {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0 8px;
+  padding: 7px 10px;
+  border-radius: 5px;
+  border: 1px solid transparent;
+  color: var(--v2-text);
+  font-family: var(--v2-font-ui);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-link:hover {
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--v2-accent-brass);
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-link:hover .nav-icon {
+  color: var(--v2-accent-brass);
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-link.active {
+  background: rgba(90, 122, 58, 0.10);
+  color: var(--v2-text-bright);
+  box-shadow: inset 3px 0 0 var(--v2-ok);
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-link.active .nav-icon {
+  color: var(--v2-text-bright);
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-link .nav-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  color: var(--v2-text-dim);
+  transition: color 120ms ease;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-link .nav-icon > svg {
+  width: 14px;
+  height: 14px;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-link .nav-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Section sub-links */
+#dashboard-side-rail.v2-shell-rail .nav-sublist {
+  margin: 2px 8px 4px 20px;
+  padding-left: 8px;
+  border-left: 1px solid var(--v2-border-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-sublink {
+  display: block;
+  width: 100%;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  color: var(--v2-text-dim);
+  font-family: var(--v2-font-ui);
+  font-size: 11px;
+  letter-spacing: 0.03em;
+  text-decoration: none;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-sublink:hover {
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--v2-text);
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-sublink.active {
+  background: rgba(90, 122, 58, 0.08);
+  color: var(--v2-text-bright);
+  box-shadow: inset 2px 0 0 var(--v2-ok);
+}
+
+/* Collapsed rail: icon-only surface buttons */
+#dashboard-side-rail.v2-shell-rail .nav-link-collapsed {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin: 2px auto;
+  border-radius: 5px;
+  border: 1px solid transparent;
+  color: var(--v2-text-dim);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-link-collapsed:hover {
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--v2-accent-brass);
+  border-color: var(--v2-border);
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-link-collapsed.active {
+  background: rgba(90, 122, 58, 0.10);
+  color: var(--v2-text-bright);
+  border-color: var(--v2-ok);
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-link-collapsed .nav-icon > svg {
+  width: 15px;
+  height: 15px;
+}
+
+/* Health indicator footer */
+#dashboard-side-rail.v2-shell-rail .nav-footer {
+  border-top: 1px solid var(--v2-border-soft);
+  padding: 8px 12px;
+  color: var(--v2-text-dim);
+  font-family: var(--v2-font-mono);
+  font-size: 10px;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   STATUS TRAY
+   ═══════════════════════════════════════════════════════════════ */
+
+aside.v2-status-tray .v2-tray-bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--v2-border);
+  border-radius: 6px;
+  background: var(--v2-ink);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.02);
+  backdrop-filter: blur(12px);
+}
+
+aside.v2-status-tray .tray-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 8px;
+  border: 1px solid var(--v2-border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--v2-text-dim);
+  font-family: var(--v2-font-ui);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+aside.v2-status-tray .tray-button:hover {
+  background: rgba(255, 255, 255, 0.025);
+}
+
+aside.v2-status-tray .tray-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 1px var(--v2-accent-brass), 0 0 0 3px rgba(138, 106, 40, 0.22);
+}
+
+aside.v2-status-tray .tray-button .tray-button-label {
+  font-family: var(--v2-font-mono);
+  font-size: 8.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+aside.v2-status-tray .tray-button .tray-button-value {
+  font-family: var(--v2-font-mono);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--v2-text-bright);
+}
+
+aside.v2-status-tray .tray-button .tray-button-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+aside.v2-status-tray .tray-button .tray-button-icon > svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Tone variants */
+aside.v2-status-tray .tray-button.tone-ok {
+  color: var(--v2-ok);
+  border-color: color-mix(in oklab, var(--v2-ok) 35%, transparent);
+  background: color-mix(in oklab, var(--v2-ok) 8%, transparent);
+}
+
+aside.v2-status-tray .tray-button.tone-warn {
+  color: var(--v2-warn);
+  border-color: color-mix(in oklab, var(--v2-warn) 35%, transparent);
+  background: color-mix(in oklab, var(--v2-warn) 8%, transparent);
+}
+
+aside.v2-status-tray .tray-button.tone-err {
+  color: var(--v2-bad);
+  border-color: color-mix(in oklab, var(--v2-bad) 35%, transparent);
+  background: color-mix(in oklab, var(--v2-bad) 8%, transparent);
+}
+
+aside.v2-status-tray .tray-button.tone-muted {
+  color: var(--v2-text-dim);
+  border-color: var(--v2-border);
+  background: transparent;
+}
+
+aside.v2-status-tray .tray-button.active {
+  box-shadow: inset 0 0 0 1px currentColor;
+}
+
+/* Tray popover */
+aside.v2-status-tray .tray-popover {
+  background: var(--v2-ink);
+  border: 1px solid var(--v2-border-strong);
+  border-radius: 6px;
+  color: var(--v2-text);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(0, 0, 0, 0.35);
+}
+
+aside.v2-status-tray .tray-popover.tone-ok   { border-color: color-mix(in oklab, var(--v2-ok)   45%, var(--v2-border-strong)); }
+aside.v2-status-tray .tray-popover.tone-warn { border-color: color-mix(in oklab, var(--v2-warn) 45%, var(--v2-border-strong)); }
+aside.v2-status-tray .tray-popover.tone-err  { border-color: color-mix(in oklab, var(--v2-bad)  45%, var(--v2-border-strong)); }
+
+aside.v2-status-tray .tray-popover .tray-popover-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+aside.v2-status-tray .tray-popover .tray-popover-label {
+  font-family: var(--v2-font-mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--v2-text-faint);
+}
+
+aside.v2-status-tray .tray-popover .tray-popover-detail {
+  font-family: var(--v2-font-ui);
+  font-size: 13px;
+  color: var(--v2-text-bright);
+  line-height: 1.3;
+}
+
+aside.v2-status-tray .tray-popover .tray-popover-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--v2-border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--v2-text-dim);
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease;
+}
+
+aside.v2-status-tray .tray-popover .tray-popover-close:hover {
+  border-color: var(--v2-accent-brass-dim);
+  color: var(--v2-accent-brass);
+}
+
+/* Stat cells used inside the popover */
+aside.v2-status-tray .tray-stat {
+  border: 1px solid var(--v2-border);
+  border-radius: 4px;
+  background: var(--v2-card);
+  padding: 8px 10px;
+}
+
+aside.v2-status-tray .tray-stat .tray-stat-label {
+  font-family: var(--v2-font-mono);
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--v2-text-faint);
+}
+
+aside.v2-status-tray .tray-stat .tray-stat-value {
+  margin-top: 3px;
+  font-family: var(--v2-font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--v2-text-bright);
+}
+
+aside.v2-status-tray .tray-stat.tone-warn .tray-stat-value {
+  color: var(--v2-warn);
+}
+
+aside.v2-status-tray .tray-stat.tone-err .tray-stat-value {
+  color: var(--v2-bad);
+}
+
+/* Journal list inside the activity popover */
+aside.v2-status-tray .tray-journal-item {
+  border: 1px solid var(--v2-border);
+  border-radius: 4px;
+  background: var(--v2-card-soft);
+  padding: 8px 10px;
+}
+
+aside.v2-status-tray .tray-journal-item + .tray-journal-item {
+  margin-top: 6px;
+}
+
+aside.v2-status-tray .tray-journal-item .tray-journal-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--v2-text-dim);
+}
+
+aside.v2-status-tray .tray-journal-item .tray-journal-agent {
+  color: var(--v2-text-bright);
+  font-weight: 500;
+}
+
+aside.v2-status-tray .tray-journal-item .tray-journal-preview {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--v2-text-dim);
+  line-height: 1.4;
+}
+
+/* Inline action link used in popovers */
+aside.v2-status-tray .tray-action-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: 4px;
+  background: var(--v2-card);
+  color: var(--v2-text);
+  font-family: var(--v2-font-ui);
+  font-size: 11px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease;
+}
+
+aside.v2-status-tray .tray-action-link:hover {
+  border-color: var(--v2-accent-brass-dim);
+  color: var(--v2-accent-brass);
+}


### PR DESCRIPTION
Applies the updated MASC v2 Dark Fantasy design system to the first two chrome surfaces: the left side rail and the bottom status tray.

### What changed
- Added `dashboard/src/styles/v2-shell.css` with scoped v2 tokens and component overrides (nav brand, links, sub-links, tray buttons, popover, stat cells).
- Imported the new stylesheet in `global.css`.
- Added v2 structural classes to `SideRail` (`nav-brand`, `nav-link`, `nav-sublink`, etc.) and `DashboardStatusTray` (`v2-status-tray`, `tray-button`, `tray-popover`, etc.).
- Kept all existing behaviour, data-testid attributes, and aria contracts.

### Verification
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `vitest run dashboard-shell.test.ts status-tray.test.ts` ✅ (32 tests)
- `eslint src/components/dashboard-shell.ts src/components/status-tray.ts` ✅

### Scope note
This is intentionally scoped to left/right chrome only; content surfaces will follow in later PRs.