### PR TITLE
fix(board): human-readable classification reason + 404 body (not derived show)

### DIFF
--- a/lib/board/board_core_classify.ml
+++ b/lib/board/board_core_classify.ml
@@ -229,10 +229,10 @@ let post_classification_reason (p : post) =
             "Direct board post without automation override (source=%s)." source
       | Human_post, None ->
           "Direct board post without automation provenance."
-      | Automation_post, Some "agent_board_post" | Automation_post, Some "keeper_board_post" ->
+      | Automation_post, Some (("agent_board_post" | "keeper_board_post") as source) ->
           Printf.sprintf
-            "Automation classification based on board automation provenance, author=%s, and the automation post_kind contract."
-            author
+            "Automation classification based on source=%s, author=%s, and the automation post_kind contract."
+            source author
       | Automation_post, Some "dashboard_board_post" ->
           "Dashboard board post classified as automation for a bound agent author."
       | Automation_post, Some source ->

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -1109,8 +1109,14 @@ let board_post_detail_json ~include_moderation ~blind_votes ~config ~voter
     ~response_format ~post_id =
   match Board_dispatch.get_post ~post_id with
   | Error err ->
+      (* Render a human-readable message (e.g. "Post not found: <id>") via the
+         shared Board_tool.board_error_to_string, matching the 404 contract in
+         the .mli and the convention already used for board errors in
+         server_routes_http_routes_activity.ml. The derived [show_board_error]
+         leaked the internal OCaml constructor name ("Post_not_found(...)") into
+         the public HTTP body. *)
       (`Not_found, Printf.sprintf {|{"error":"%s"}|}
-         (String.escaped (Board_types.show_board_error err)))
+         (String.escaped (Board_tool.board_error_to_string err)))
   | Ok post ->
       let author = Board.Agent_id.to_string post.author in
       let author_karma = Board_dispatch.get_agent_karma ~agent_name:author in

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -309,7 +309,7 @@ val board_post_detail_json :
 
     | Outcome | Status | Body |
     |---|---|---|
-    | Post missing | [404 Not Found] | [{"error":"Post not found"}] |
+    | Post missing | [404 Not Found] | [{"error":"Post not found: <id>"}] |
     | Found | [200 OK] | per response_format |
 
     Comment fetch errors (rare) silently degrade to empty


### PR DESCRIPTION
## 증상

board 관련 OCaml 테스트 3건이 로컬에서 실패했습니다. 조사(+적대 검증) 결과 2건은 **프로듀서가 문서화된 출력 계약을 위반**, 1건은 **비재현(환경)** 이었습니다.

## CASE 1 — classification_reason (프로듀서 수정)

`test_board_ttl.ml` "keeper provenance upgrade"가 기대하는 문자열:
```
Automation classification based on source=keeper_board_post, author=dm-keeper, and the automation post_kind contract.
```
하지만 `board_core_classify.ml:232`의 병합된 agent/keeper automation 분기는 source를 버리고 generic 문자열(`board automation provenance`)을 emit했습니다. 이는 바로 위 `Human_post` 분기의 `(source=%s)` 관습(`board_core_classify.ml:229`)과도 어긋납니다.

수정: `as source` 바인딩으로 source를 명명 — 테스트와 sibling 관습 둘 다 만족. **테스트가 아니라 프로듀서를 고침**(기대 문자열을 generic으로 바꾸면 source 식별자를 버리는 워크어라운드가 됨).

## CASE 3 — 404 error payload (프로듀서 수정, `.mli` 계약 위반)

`server_routes_http_runtime.ml`의 `board_post_detail_json` 404 분기가 derived `[@@deriving show]` 산출물(`Board_types.show_board_error`)을 그대로 body에 넣어, **내부 OCaml 생성자명**(`Post_not_found("...")`)을 공개 HTTP API로 누출했습니다. 이는 같은 파일 `.mli:312`의 계약 `{"error":"Post not found"}`를 위반합니다(`test_board_api_e2e.ml`가 substring `Post not found`를 기대 → 언더스코어 때문에 실패).

수정: server의 나머지 board 에러 렌더(`server_routes_http_routes_activity.ml` 4곳)와 동일하게 SSOT `Board_tool.board_error_to_string`를 사용 → 모든 board_error 변형에 human 메시지. `.mli` 예시는 실제 출력(`{"error":"Post not found: <id>"}`)에 맞게 갱신.

## CASE 2 — reclassify (변경 없음)

`test_board_dispatch.ml` "reclassify dry-run and apply"는 HEAD에서 재현되지 않음(60/60 green, 3회). 보고된 로컬 실패는 환경(stale `_build`) 추정. passing 테스트를 선제 수정하지 않음.

## 검증 (`DUNE_CACHE=disabled dune build --root .` exit 0 — `.mli` 변경)
- `test_board_ttl.exe` → `[OK] keeper provenance upgrade`, 13 tests Successful
- `test_board_dispatch.exe` → 60 tests Successful (CASE2 비재현 확정)
- `MASC_E2E_TESTS=true test_board_api_e2e.exe` → `[OK] missing post returns 404`, 1 test Successful
- `rg "board automation provenance" lib/ test/` → 0 (옛 문자열 완전 제거)
- agent_board_post reason 문자열을 단언하는 테스트 없음(분기 동시 변경 안전)

워크어라운드 아님: 두 수정 모두 프로듀서를 계약(.mli / sibling 관습)에 맞게 교정. 기존 실패 테스트가 회귀 가드이며 이제 통과.

RFC-WAIVED: board 도메인 분류 문자열 + HTTP 404 payload 교정(read-only 렌더). credential/identity/repo_manager/operator/sandbox/hooks/workflow subsystem 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
