### PR TITLE
refactor(dashboard): remove dead task-worktree projection (TaskWorktreeInfo)

### DIFF
--- a/dashboard/src/components/goals/task-wall.test.ts
+++ b/dashboard/src/components/goals/task-wall.test.ts
@@ -53,12 +53,6 @@ describe('TaskWall', () => {
         status: 'claimed',
         priority: 1,
         assignee: 'keeper-alpha',
-        worktree: {
-          branch: 'feature/task-wall-long-branch',
-          path: '/tmp/worktree',
-          git_root: '/tmp/repo',
-          repo_name: 'masc',
-        },
       }),
       makeTask({
         id: 'task-unassigned',
@@ -92,7 +86,7 @@ describe('TaskWall', () => {
     const alphaColumn = screen.getByLabelText('keeper-alpha 태스크 2건')
     const alphaButtons = within(alphaColumn).getAllByRole('button')
     expect(alphaButtons[0]).toHaveAccessibleName(
-      '태스크 task-alpha-high 열기: Alpha higher priority, branch feature/task-wall-long-branch',
+      '태스크 task-alpha-high 열기: Alpha higher priority',
     )
     expect(alphaButtons[1]).toHaveAccessibleName('태스크 task-alpha-low 열기: Alpha lower priority')
   })

--- a/dashboard/src/components/goals/task-wall.ts
+++ b/dashboard/src/components/goals/task-wall.ts
@@ -95,31 +95,21 @@ export function TaskWall() {
               <span class="text-text-muted">${col.tasks.length}</span>
             </div>
             <ul class="flex flex-col gap-0.5">
-              ${col.tasks.map(t => {
-                const branch = t.worktree?.branch
-                const titleAttr = branch
-                  ? `${t.id} · ${t.status ?? 'unknown'} · branch: ${branch}`
-                  : `${t.id} · ${t.status ?? 'unknown'}`
-                return html`
+              ${col.tasks.map(t => html`
                 <li key=${t.id}>
                   <button
                     type="button"
                     class="flex w-full items-center gap-1.5 rounded-[var(--r-0)] border border-[var(--color-border-default)]/50 bg-[var(--color-bg-surface)] px-1.5 py-0.5 text-left text-2xs hover:border-[var(--accent-40)] hover:bg-[var(--accent-10)]"
-                    title=${titleAttr}
-                    aria-label=${branch
-                      ? `태스크 ${t.id} 열기: ${t.title}, branch ${branch}`
-                      : `태스크 ${t.id} 열기: ${t.title}`}
+                    title=${`${t.id} · ${t.status ?? 'unknown'}`}
+                    aria-label=${`태스크 ${t.id} 열기: ${t.title}`}
                     onClick=${() => navigate('workspace', { section: 'planning', task: t.id })}
                   >
                     <span aria-hidden="true" class="text-text-muted">${statusGlyph(t.status)}</span>
                     <span class="font-mono text-text-disabled">${t.id.slice(0, 6)}</span>
                     <span class="grow truncate">${t.title}</span>
-                    ${branch
-                      ? html`<span class="shrink-0 rounded-[var(--r-0)] bg-[var(--color-bg-elevated)] px-1 text-3xs font-mono text-text-muted" aria-label="worktree branch">${branch.length > 14 ? branch.slice(0, 13) + '…' : branch}</span>`
-                      : null}
                   </button>
                 </li>
-              `})}
+              `)}
             </ul>
           </div>
         `)}

--- a/dashboard/src/components/ide/execute-output-drawer.test.ts
+++ b/dashboard/src/components/ide/execute-output-drawer.test.ts
@@ -107,7 +107,7 @@ describe('ExecuteOutputDrawer event mapping', () => {
     })
   })
 
-  it('builds operational routes from Execute output task, goal, git branch, cursor, and keeper', () => {
+  it('builds operational routes from Execute output task, goal, cursor, and keeper', () => {
     const links = executeOutputRouteLinks({
       keeperName: 'sangsu',
       taskId: 'task-123',
@@ -115,12 +115,6 @@ describe('ExecuteOutputDrawer event mapping', () => {
         id: 'task-123',
         title: 'Runtime task',
         goal_id: 'goal-ide',
-        worktree: {
-          branch: 'feat/runtime',
-          path: '/tmp/runtime',
-          git_root: '/tmp/runtime',
-          repo_name: 'masc',
-        },
       }],
       cursor: {
         keeper_id: 'sangsu',
@@ -137,7 +131,6 @@ describe('ExecuteOutputDrawer event mapping', () => {
       'Code',
       'Goal',
       'Task',
-      'Git',
       'Telemetry',
       'Keeper',
     ])
@@ -209,12 +202,6 @@ describe('ExecuteOutputDrawer event mapping', () => {
       title: 'Runtime task',
       goal_id: 'goal-ide',
       status: 'in_progress',
-      worktree: {
-        branch: 'feat/runtime',
-        path: '/tmp/runtime',
-        git_root: '/tmp/runtime',
-        repo_name: 'masc',
-      },
     }]
     cursorOverlaySignal.value = {
       cursors: new Map([['sangsu', {
@@ -253,16 +240,15 @@ describe('ExecuteOutputDrawer event mapping', () => {
       'Code',
       'Goal',
       'Task',
-      'Git',
       'Telemetry',
       'Keeper',
     ])
     const badge = mounted.querySelector<HTMLElement>('.execute-output-context-badge')
-    expect(badge?.textContent?.trim()).toBe('CTX 6')
-    expect(badge?.getAttribute('data-context-route-count')).toBe('6')
-    expect(badge?.getAttribute('title')).toBe('Linked context: Code, Goal, Task, Git, Telemetry, Keeper')
+    expect(badge?.textContent?.trim()).toBe('CTX 5')
+    expect(badge?.getAttribute('data-context-route-count')).toBe('5')
+    expect(badge?.getAttribute('title')).toBe('Linked context: Code, Goal, Task, Telemetry, Keeper')
     expect(badge?.getAttribute('aria-label'))
-      .toBe('Execute output has 6 linked context routes: Code, Goal, Task, Git, Telemetry, Keeper')
+      .toBe('Execute output has 5 linked context routes: Code, Goal, Task, Telemetry, Keeper')
 
     fireEvent.click(routeLinks.find(link => link.textContent === 'Code')!)
     expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=42&surface=Terminal&label=Execute+output+task-123&source_id=execute-output%3Asangsu%3Atask-123&keeper=sangsu')

--- a/dashboard/src/components/ide/execute-output-drawer.ts
+++ b/dashboard/src/components/ide/execute-output-drawer.ts
@@ -176,7 +176,6 @@ export function executeOutputRouteLinks({
     sourceId: sourceParts.join(':'),
     goalId: task?.goal_id ?? undefined,
     taskId: taskId ?? undefined,
-    gitRef: task?.worktree?.branch,
     keeperId,
     telemetry: true,
     telemetryQuery: taskId ?? keeperId,

--- a/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
@@ -106,15 +106,13 @@ describe('IdeKeeperWorkPanel', () => {
       container.querySelectorAll<HTMLButtonElement>('.ide-keeper-work-card .ide-keeper-work-links button'),
     )
     expect(container.querySelector('.ide-keeper-work-card .ide-keeper-work-route-count')?.textContent)
-      .toBe('CTX 5')
+      .toBe('CTX 4')
     expect(taskLinks.map(link => link.textContent)).toEqual([
       'Goal',
       'Task',
-      'Git',
       'Telemetry',
       'Keeper',
     ])
-    expect(buttonByText(container, 'Git').title).toBe('Git fix/runtime')
     expect(buttonByText(container, 'Telemetry').title)
       .toBe('Fleet telemetry event log · session sess-151 · operation op-151 · query op-151')
 
@@ -134,12 +132,6 @@ describe('IdeKeeperWorkPanel', () => {
         title: 'Wire keeper queue context',
         status: 'in_progress',
         goal_id: 'goal-next',
-        worktree: {
-          branch: 'feat/keeper-queue',
-          path: '/workspace/.worktrees/keeper-queue',
-          git_root: '/workspace',
-          repo_name: 'masc',
-        },
         execution_links: {
           session_id: 'sess-next',
         },
@@ -165,7 +157,6 @@ describe('IdeKeeperWorkPanel', () => {
     expect(queueButtons.map(button => button.textContent)).toEqual([
       'Goal',
       'Task',
-      'Git',
       'Telemetry',
       'Keeper',
     ])
@@ -215,12 +206,6 @@ function taskFixture(partial: Partial<Task> = {}): Task {
     title: 'Fix agent-code runtime config',
     status: 'claimed',
     assignee: 'sangsu',
-    worktree: {
-      branch: 'fix/runtime',
-      path: '/workspace/.worktrees/fix-runtime',
-      git_root: '/workspace',
-      repo_name: 'masc',
-    },
     ...partial,
   }
 }

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -50,14 +50,6 @@ const QUEUED_TASK_STYLE = {
   paddingTop: 'var(--sp-2)',
   borderTop: '1px solid var(--color-border-divider)',
 }
-const QUEUED_TASK_META_STYLE = {
-  overflow: 'hidden',
-  color: 'var(--color-fg-muted)',
-  fontSize: 'var(--fs-11)',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-}
-
 export function IdeKeeperWorkPanel({ keeperName }: IdeKeeperWorkPanelProps) {
   const summary = keeperWorkSummary(keeperName, keepers.value, tasks.value)
   const keeper = summary.keeper
@@ -114,9 +106,6 @@ export function IdeKeeperWorkPanel({ keeperName }: IdeKeeperWorkPanelProps) {
                 <span>${currentTask.status ?? 'unknown'}</span>
               </div>
               <strong title=${currentTask.title}>${currentTask.title}</strong>
-              ${currentTask.worktree
-                ? html`<span title=${currentTask.worktree.path}>${currentTask.worktree.branch} · ${currentTask.worktree.repo_name}</span>`
-                : null}
               ${TaskRouteLinks(currentTask, summary.currentGoalId, summary.displayName)}
             </div>
           `
@@ -186,9 +175,6 @@ function QueuedTaskCards(
             <span>${task.status ?? 'unknown'}</span>
           </div>
           <strong title=${task.title}>${task.title}</strong>
-          ${task.worktree
-            ? html`<span style=${QUEUED_TASK_META_STYLE} title=${task.worktree.path}>${task.worktree.branch} · ${task.worktree.repo_name}</span>`
-            : null}
           ${TaskRouteLinks(task, fallbackGoalId, keeperId)}
         </div>
       `)}
@@ -239,7 +225,6 @@ function TaskRouteLinks(task: Task, fallbackGoalId: string | null, keeperId: str
   return KeeperWorkRouteLinks(routeLinksForContext({
     goalId: task.goal_id ?? fallbackGoalId ?? undefined,
     taskId: task.id,
-    gitRef: task.worktree?.branch,
     sessionId: execution.sessionId ?? undefined,
     operationId: execution.operationId ?? undefined,
     telemetryQuery: execution.telemetryQuery ?? undefined,

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -91,14 +91,6 @@ export function normalizeTask(raw: unknown): Task | null {
   const id = asString(raw.id)
   const title = asString(raw.title)
   if (!id || !title) return null
-  const worktree = isRecord(raw.worktree)
-    ? {
-        branch: asString(raw.worktree.branch, ''),
-        path: asString(raw.worktree.path, ''),
-        git_root: asString(raw.worktree.git_root, ''),
-        repo_name: asString(raw.worktree.repo_name, ''),
-      }
-    : null
   const contract = isRecord(raw.contract)
     ? {
         strict: asBoolean(raw.contract.strict),
@@ -140,7 +132,6 @@ export function normalizeTask(raw: unknown): Task | null {
     assignee: asString(raw.assignee),
     assignee_kind: asString(raw.assignee_kind) ?? null,
     description: asString(raw.description),
-    worktree,
     created_at: asString(raw.created_at),
     updated_at: asString(raw.updated_at),
     completed_at: asString(raw.completed_at),

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -57,7 +57,6 @@ export interface Task {
   assignee?: string
   assignee_kind?: string | null
   description?: string
-  worktree?: TaskWorktreeInfo | null
   created_at?: string
   updated_at?: string
   completed_at?: string
@@ -65,13 +64,6 @@ export interface Task {
   handoff_context?: TaskHandoffContext | null
   gate?: TaskGateSnapshot | null
   execution_links?: TaskExecutionLinks | null
-}
-
-export interface TaskWorktreeInfo {
-  branch: string
-  path: string
-  git_root: string
-  repo_name: string
 }
 
 interface TaskExecutionLinks {


### PR DESCRIPTION
## 목표

dead `TaskWorktreeInfo` projection을 제거합니다. 사용자 지시("task하고 worktree하고 엮지마라")에 따라 task↔worktree 결합을 코드에서 걷어냅니다.

## 근본 원인 — server-starved projection (runtime-dead)

`store-normalizers.ts`의 `normalizeTask`가 task-level `worktree` 키(`TaskWorktreeInfo`: branch/path/git_root/repo_name)를 디코드하지만, **OCaml 서버의 어떤 task 인코더도 그 키를 emit하지 않습니다**:
- `lib/types/types_core.ml` `task_to_yojson` / `task_status_to_yojson` — `worktree` 키 없음
- `lib/dashboard/dashboard_execution.ml` `task_json`(tasks 리스트 직렬화) — `worktree` 키 없음
- `rg '"worktree"' lib/` → `git worktree list` 쉘 인자(별도 worktree-status 엔드포인트)만 매칭

따라서 `task.worktree`는 런타임에 항상 undefined였고, 3개 소비처가 읽지만 렌더(branch/repo 표시, "Git" 라우트 링크)는 **production에 등장한 적이 없습니다**. 즉 UI에서의 task↔worktree 결합은 이미 죽은 코드입니다.

## 처리 — disposition (B) full 조정 삭제

naive하게 디코드만 지우면 소비처에서 tsc가 깨지므로(소비처가 필드 참조), end-to-end로 제거:

| 파일 | 제거 |
|------|------|
| `types/core.ts` | `Task.worktree?` 필드 + `TaskWorktreeInfo` 인터페이스 |
| `store-normalizers.ts` | worktree 디코드 블록 + 할당 |
| `task-wall.ts` | worktree branch 배지 + branch title/aria 텍스트 |
| `ide-keeper-work-panel.ts` | current/queued worktree 표시 + `gitRef` 라우트 입력 + 미사용된 `QUEUED_TASK_META_STYLE` |
| `execute-output-drawer.ts` | `gitRef` 라우트 입력 |
| 3개 컴포넌트 테스트 | worktree fixture + fixtured worktree에서 파생되던 "Git" 링크 / CTX 카운트 단언 |

복원(server emitter 배선)을 택하지 않은 이유: 그것은 정확히 "task와 worktree를 엮는" 행위이므로 지시에 반함. 아키텍처도 worktree를 first-class에서 걷어내는 방향(#20498/#20499/#20508).

## 건드리지 않은 것

별도의 worktree-centric 표면 — `GET /api/dashboard/worktree-status` SSE, `ide-presence-strip.ts`의 `WorktreeEntry` — 은 이 projection과 무관하며 그대로 둡니다. (이게 유일한 live worktree 기능)

## 검증
- `tsc --noEmit` → 0 (모든 소비처 정리 확인, dangling ref 없음)
- `rg "TaskWorktreeInfo|\.worktree\b" dashboard/src`(ide-presence-strip 제외) → 0
- 영향 테스트: task-wall / ide-keeper-work-panel / execute-output-drawer / store-normalizers → 30 passed
- `eslint`(8파일) → 0 errors
- 전체 vitest → 6655 passed (1 실패는 `use-focus-scope.test.ts` flaky — 단독 실행 7/7 통과, 본 변경과 무관한 별도 도메인)

RFC-WAIVED: dashboard dead-projection 제거(read-only UI/type 정리). credential/identity/repo_manager/operator/sandbox/hooks/workflow subsystem 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
