### PR TITLE
feat(memory-os): add episode TTL recall guard

### DIFF
--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -257,6 +257,8 @@ let episode_of_output ?now (inp : input) (raw : string) : episode option =
               ; preserved_tool_refs
               ; source_turn_range = source_turn_range claims
               ; created_at = now
+              ; valid_until = None
+              ; terminal_marker = None
               ; schema_version
               }
           | None -> None)

--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -22,7 +22,7 @@ type scored_fact =
   ; score : float
   }
 
-let ttl_expired ~now fact =
+let ttl_expired ~now (fact : fact) =
   match fact.valid_until with
   | None -> false
   | Some ts -> now > ts

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -10,6 +10,7 @@ let default_max_episodes = 2
    without crowding out keeper-local memory. *)
 let default_max_shared_facts = 4
 let fact_tail_scan = 64
+let episode_tail_scan = 32
 let max_fact_text_len = 260
 let max_episode_text_len = 360
 let max_atom_len = 48
@@ -88,8 +89,14 @@ let sanitize_atom text =
     | c -> c)
 ;;
 
-let fact_is_current ~now fact =
+let fact_is_current ~now (fact : fact) =
   match fact.valid_until with
+  | None -> true
+  | Some ts -> ts >= now
+;;
+
+let episode_is_current ~now (episode : episode) =
+  match episode.valid_until with
   | None -> true
   | Some ts -> ts >= now
 ;;
@@ -127,10 +134,16 @@ let render_shared_fact ~now ?(seed_tokens = []) fact =
 ;;
 
 let render_episode episode =
+  let terminal =
+    match episode.terminal_marker with
+    | None -> ""
+    | Some marker -> Printf.sprintf " terminal=%s" (sanitize_atom marker)
+  in
   Printf.sprintf
-    "- [%s g%04d] %s"
+    "- [%s g%04d%s] %s"
     (sanitize_atom episode.trace_id)
     episode.generation
+    terminal
     (sanitize_text ~max_len:max_episode_text_len episode.episode_summary)
 ;;
 
@@ -260,7 +273,13 @@ let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes ?(seed_tokens = 
       |> List.filter (fun f -> not (List.mem (normalize_claim f.claim) private_keys))
       |> take default_max_shared_facts
   in
-  let episodes = Keeper_memory_os_io.read_episodes_tail ~keeper_id ~n:max_episodes in
+  let episodes =
+    Keeper_memory_os_io.read_episodes_tail
+      ~keeper_id
+      ~n:(max max_episodes episode_tail_scan)
+    |> List.filter (episode_is_current ~now)
+    |> take max_episodes
+  in
   match facts, shared_facts, episodes with
   | [], [], [] -> ""
   | _ ->

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -129,6 +129,8 @@ type episode =
   ; preserved_tool_refs : string list
   ; source_turn_range : (int * int) option
   ; created_at : float
+  ; valid_until : float option
+  ; terminal_marker : string option
   ; schema_version : string
   }
 
@@ -347,7 +349,11 @@ let episode_to_json e =
      ; "created_at", `Float e.created_at
      ; "schema_version", `String e.schema_version
      ]
-     @ range_json)
+     @ range_json
+     @ optional_float_field "valid_until" e.valid_until
+     @ (match e.terminal_marker with
+        | Some marker -> [ "terminal_marker", `String marker ]
+        | None -> []))
 ;;
 
 let episode_of_json (json : Yojson.Safe.t) =
@@ -381,6 +387,9 @@ let episode_of_json (json : Yojson.Safe.t) =
        in
        (* DET-OK: absent created_at defaults to epoch for migration safety. *)
        let created_at = Option.value (json_float_field "created_at" fields) ~default:0.0 in
+       (* DET-OK: legacy episodes had no TTL or terminal marker. *)
+       let valid_until = json_float_field "valid_until" fields in
+       let terminal_marker = json_string_field "terminal_marker" fields in
        Some
          { trace_id
          ; generation
@@ -391,6 +400,8 @@ let episode_of_json (json : Yojson.Safe.t) =
          ; preserved_tool_refs
          ; source_turn_range
          ; created_at
+         ; valid_until
+         ; terminal_marker
          ; schema_version =
              (* DET-OK: default to current schema for forward compatibility. *)
              Option.value (json_string_field "schema_version" fields) ~default:schema_version

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -107,6 +107,8 @@ type episode =
   ; preserved_tool_refs : string list
   ; source_turn_range : (int * int) option
   ; created_at : float
+  ; valid_until : float option
+  ; terminal_marker : string option
   ; schema_version : string
   }
 

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -197,6 +197,8 @@ let episode_fixture ~now ~trace_id ~generation ~summary =
   ; Types.preserved_tool_refs = []
   ; Types.source_turn_range = Some (0, 0)
   ; Types.created_at = now
+  ; Types.valid_until = None
+  ; Types.terminal_marker = None
   ; Types.schema_version = Types.schema_version
   }
 ;;
@@ -224,6 +226,8 @@ let test_json_roundtrip () =
     ; Types.preserved_tool_refs = [ "call_a" ]
     ; Types.source_turn_range = Some (5, 5)
     ; Types.created_at = now
+    ; Types.valid_until = Some (now +. days 1)
+    ; Types.terminal_marker = Some "handoff_complete"
     ; Types.schema_version = Types.schema_version
     }
   in
@@ -233,7 +237,15 @@ let test_json_roundtrip () =
     e.episode_summary
     e2.Types.episode_summary;
   Alcotest.(check int) "claims length" 1 (List.length e2.Types.claims);
-  Alcotest.(check int) "open_items length" 1 (List.length e2.Types.open_items)
+  Alcotest.(check int) "open_items length" 1 (List.length e2.Types.open_items);
+  Alcotest.(check (option (float 0.001)))
+    "episode valid_until round-trip"
+    e.valid_until
+    e2.Types.valid_until;
+  Alcotest.(check (option string))
+    "episode terminal_marker round-trip"
+    e.terminal_marker
+    e2.Types.terminal_marker
 ;;
 
 let test_fact_v1_json_defaults_to_safe_staleness_fields () =
@@ -1321,6 +1333,8 @@ let test_render_if_enabled_renders_persisted_memory () =
           ; Types.preserved_tool_refs = []
           ; Types.source_turn_range = Some (1, 2)
           ; Types.created_at = now
+          ; Types.valid_until = None
+          ; Types.terminal_marker = None
           ; Types.schema_version = Types.schema_version
           }
         in
@@ -1367,6 +1381,8 @@ let test_render_context_seed_reranks_selection () =
           ; Types.preserved_tool_refs = []
           ; Types.source_turn_range = Some (1, 2)
           ; Types.created_at = now
+          ; Types.valid_until = None
+          ; Types.terminal_marker = None
           ; Types.schema_version = Types.schema_version
           }
         in
@@ -1408,6 +1424,8 @@ let test_render_context_empty_seed_matches_seedless () =
           ; Types.preserved_tool_refs = []
           ; Types.source_turn_range = Some (1, 2)
           ; Types.created_at = now
+          ; Types.valid_until = None
+          ; Types.terminal_marker = None
           ; Types.schema_version = Types.schema_version
           }
         in
@@ -1416,6 +1434,71 @@ let test_render_context_empty_seed_matches_seedless () =
           "empty seed is byte-identical to seedless"
           (Recall.render_context ~keeper_id ~now ())
           (Recall.render_context ~keeper_id ~now ~seed:"" ()))))
+;;
+
+let test_recall_filters_expired_episodes () =
+  with_prompt_registry (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      let keeper_id = "episode-ttl-keeper" in
+      let now = 1_000_000.0 in
+      let expired =
+        { (episode_fixture
+             ~now
+             ~trace_id:"trace-expired"
+             ~generation:1
+             ~summary:"expired episode should not render")
+          with
+          Types.valid_until = Some (now -. 1.0)
+        }
+      in
+      let active =
+        { (episode_fixture
+             ~now
+             ~trace_id:"trace-active"
+             ~generation:2
+             ~summary:"active episode should render")
+          with
+          Types.valid_until = Some (now +. 1.0)
+        }
+      in
+      Memory_io.append_episode_bundle ~keeper_id expired;
+      Memory_io.append_episode_bundle ~keeper_id active;
+      let ctx = Recall.render_context ~keeper_id ~now ~max_facts:0 ~max_episodes:4 () in
+      Alcotest.(check bool)
+        "expired episode summary is omitted"
+        false
+        (contains "expired episode should not render" ctx);
+      Alcotest.(check bool)
+        "active episode summary remains"
+        true
+        (contains "active episode should render" ctx)))
+;;
+
+let test_recall_renders_terminal_episode_marker () =
+  with_prompt_registry (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      let keeper_id = "episode-terminal-keeper" in
+      let now = 1_000_000.0 in
+      let episode =
+        { (episode_fixture
+             ~now
+             ~trace_id:"trace-terminal"
+             ~generation:3
+             ~summary:"terminal handoff summary")
+          with
+          Types.terminal_marker = Some "handoff_complete"
+        }
+      in
+      Memory_io.append_episode_bundle ~keeper_id episode;
+      let ctx = Recall.render_context ~keeper_id ~now ~max_facts:0 ~max_episodes:1 () in
+      Alcotest.(check bool)
+        "terminal marker is visible in episode line"
+        true
+        (contains "terminal=handoff_complete" ctx);
+      Alcotest.(check bool)
+        "terminal summary still renders"
+        true
+        (contains "terminal handoff summary" ctx)))
 ;;
 
 (* RFC-0239 R2: the append-only store keeps every re-confirmation of a claim as
@@ -1454,6 +1537,8 @@ let test_recall_dedups_repeated_claim () =
         ; Types.preserved_tool_refs = []
         ; Types.source_turn_range = Some (1, 9)
         ; Types.created_at = now
+        ; Types.valid_until = None
+        ; Types.terminal_marker = None
         ; Types.schema_version = Types.schema_version
         }
       in
@@ -1545,6 +1630,8 @@ let test_recall_context_renders_sanitized_memory () =
         ; Types.preserved_tool_refs = []
         ; Types.source_turn_range = Some (4, 6)
         ; Types.created_at = now
+        ; Types.valid_until = None
+        ; Types.terminal_marker = None
         ; Types.schema_version = Types.schema_version
         }
       in
@@ -1611,6 +1698,8 @@ let test_recall_context_preserves_admission_memory () =
         ; Types.preserved_tool_refs = []
         ; Types.source_turn_range = Some (7, 7)
         ; Types.created_at = now
+        ; Types.valid_until = None
+        ; Types.terminal_marker = None
         ; Types.schema_version = Types.schema_version
         }
       in
@@ -1624,6 +1713,8 @@ let test_recall_context_preserves_admission_memory () =
         ; Types.preserved_tool_refs = []
         ; Types.source_turn_range = Some (8, 8)
         ; Types.created_at = now +. 1.0
+        ; Types.valid_until = None
+        ; Types.terminal_marker = None
         ; Types.schema_version = Types.schema_version
         }
       in
@@ -2076,6 +2167,8 @@ let mk_episode ?(trace_id = "trace-ep") ?(generation = 0) ~created_at claim_stri
   ; Types.preserved_tool_refs = []
   ; Types.source_turn_range = None
   ; Types.created_at
+  ; Types.valid_until = None
+  ; Types.terminal_marker = None
   ; Types.schema_version = Types.schema_version
   }
 ;;
@@ -2505,6 +2598,14 @@ let () =
             "empty seed matches seedless (RFC-0244)"
             `Quick
             test_render_context_empty_seed_matches_seedless
+        ; Alcotest.test_case
+            "expired episodes are omitted"
+            `Quick
+            test_recall_filters_expired_episodes
+        ; Alcotest.test_case
+            "terminal episode marker is rendered"
+            `Quick
+            test_recall_renders_terminal_episode_marker
         ; Alcotest.test_case
             "dedups repeated claim (RFC-0239 R2)"
             `Quick


### PR DESCRIPTION
## Summary
- Add optional episode-level valid_until and terminal_marker fields to Memory OS episode schema/codecs.
- Filter expired episodes out of recall context while preserving backward-compatible defaults for legacy episode JSON.
- Render terminal episode markers in recall episode lines.

## Why this is intentionally narrow
- Kept the useful, small slice from the stale generated PR set: episode TTL/terminal marker handling.
- Did not carry over duplicated circuit-breaker modules, broad economy/profile/event-bus changes, misplaced cognitive_gravity Memory OS scoring, or unsafe contradict-scoring rewrites.

## Verification
- ocamlformat --check lib/keeper/keeper_memory_os_types.ml lib/keeper/keeper_memory_os_types.mli lib/keeper/keeper_memory_os_recall.ml lib/keeper/keeper_memory_os_gc.ml lib/keeper/keeper_librarian.ml test/test_keeper_memory_os.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec test/test_keeper_memory_os.exe
