### PR TITLE
style(dashboard): apply v2 design-system chrome to header and health strip

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -1,6 +1,41 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from 'vitest'
-import { shouldUseCompactDashboardChrome } from './app'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { h, render } from 'preact'
+import { App, shouldUseCompactDashboardChrome } from './app'
+
+describe('App v2 header chrome', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    render(h(App, {}), container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders v2 shell header and health strip scopes', () => {
+    expect(container.querySelector('header.v2-shell-header')).not.toBeNull()
+    expect(container.querySelector('[data-testid="dashboard-health-strip"].v2-health-strip')).not.toBeNull()
+  })
+
+  it('renders v2 header structural classes', () => {
+    expect(container.querySelector('.v2-header-brand')).not.toBeNull()
+    expect(container.querySelector('.v2-header-mark')).not.toBeNull()
+    expect(container.querySelector('.v2-header-crumb')).not.toBeNull()
+    expect(container.querySelector('.v2-header-title')).not.toBeNull()
+    expect(container.querySelector('.v2-header-actions')).not.toBeNull()
+    expect(container.querySelector('.v2-shell-tabs')).not.toBeNull()
+  })
+
+  it('renders health chips with the shared chip class', () => {
+    const chip = container.querySelector('.dashboard-health-chip')
+    expect(chip).not.toBeNull()
+  })
+})
 
 describe('shouldUseCompactDashboardChrome', () => {
   it('uses compact chrome for keeper detail routes', () => {

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -254,7 +254,7 @@ export function App() {
       data-keeper-detail-mode=${keeperDetailMode ? 'true' : 'false'}
     >
       <${SkipLink} />
-      <header class="${compactChromeMode ? 'hidden' : 'relative'} z-10 shrink-0 border-b border-[var(--color-border-default)] bg-[var(--shell-header-bg)] px-3 py-1.5 backdrop-blur-xl">
+      <header class="${compactChromeMode ? 'hidden' : 'relative v2-shell-header'} z-10 shrink-0 border-b border-[var(--color-border-default)] bg-[var(--shell-header-bg)] px-3 py-1.5">
         <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[var(--accent-15)] to-transparent"></div>
         <div class="flex w-full items-center justify-between gap-3 max-[1080px]:flex-col max-[1080px]:items-stretch">
           <div class="flex min-w-0 flex-1 items-center gap-3 max-[860px]:flex-wrap">
@@ -268,12 +268,12 @@ export function App() {
               >
                 ${mobileMenuOpen.value ? html`<${X} size=${20} />` : html`<${Menu} size=${20} />`}
               </button>
-              <div class="flex min-w-0 items-stretch overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
-                <div class="flex w-12 shrink-0 flex-col items-center justify-center border-r border-[var(--color-border-default)] bg-[var(--accent-10)] px-2 py-1 font-mono text-3xs font-semibold uppercase leading-none tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">
+              <div class="v2-header-brand flex min-w-0 items-stretch overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
+                <div class="v2-header-mark flex w-12 shrink-0 flex-col items-center justify-center border-r border-[var(--color-border-default)] bg-[var(--accent-10)] px-2 py-1 font-display text-2xs font-semibold uppercase leading-none tracking-[0.12em] text-[var(--color-accent-fg)]">
                   MASC
                 </div>
                 <div class="min-w-0 px-2.5 py-1">
-                  <div class="flex items-center gap-1.5 font-mono text-[var(--fs-9)] uppercase leading-none tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+                  <div class="v2-header-crumb flex items-center gap-1.5 font-ui text-[var(--fs-10)] uppercase leading-none tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
                     <span>${currentView?.label ?? 'Surface'}</span>
                     ${currentSection && currentSection.label !== currentView?.label
                       ? html`
@@ -282,7 +282,7 @@ export function App() {
                         `
                       : null}
                   </div>
-                  <h1 class="mt-1 min-w-0 truncate text-xs font-semibold leading-tight tracking-normal text-[var(--color-fg-secondary)]">
+                  <h1 class="v2-header-title mt-1 min-w-0 truncate font-display text-xs font-semibold leading-tight tracking-normal text-[var(--color-fg-secondary)]">
                     ${currentSection?.label ?? currentView?.label ?? 'Multi-Agent Namespace Console'}
                   </h1>
                 </div>
@@ -292,7 +292,7 @@ export function App() {
             <${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab=${currentTab} />
           </div>
 
-          <div class="flex shrink-0 flex-wrap items-center justify-end gap-2 max-[1080px]:justify-between">
+          <div class="v2-header-actions flex shrink-0 flex-wrap items-center justify-end gap-2 max-[1080px]:justify-between">
             <${EmergencyStopControl} />
             <${Suspense} fallback=${authStatusFallback()}>
               <${LazyAuthStatus} />

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -705,7 +705,7 @@ export function DashboardHealthStrip() {
 
   return html`
     <div
-      class="flex shrink-0 flex-wrap items-center gap-2 border-b border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-3 py-1.5 text-2xs"
+      class="v2-health-strip flex shrink-0 flex-wrap items-center gap-2 border-b border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-3 py-1.5 text-2xs"
       role="status"
       aria-label="Dashboard runtime health"
       data-testid="dashboard-health-strip"
@@ -716,14 +716,14 @@ export function DashboardHealthStrip() {
           key=${chip.key}
           tab=${chip.route.tab}
           params=${chip.route.params}
-          class=${`inline-flex min-h-6 items-center rounded-[var(--r-1)] border px-2 py-0.5 font-medium transition-opacity hover:opacity-80 ${healthChipClass(chip.tone)}`}
+          class=${`dashboard-health-chip inline-flex min-h-6 items-center rounded-[var(--r-1)] border px-2 py-0.5 font-medium transition-opacity hover:opacity-80 ${healthChipClass(chip.tone)}`}
           title=${chip.detail}
           data-testid=${`dashboard-health-chip-${chip.key}`}
         >${chip.label}<//>
       ` : html`
         <span
           key=${chip.key}
-          class=${`inline-flex min-h-6 items-center rounded-[var(--r-1)] border px-2 py-0.5 font-medium ${healthChipClass(chip.tone)}`}
+          class=${`dashboard-health-chip inline-flex min-h-6 items-center rounded-[var(--r-1)] border px-2 py-0.5 font-medium ${healthChipClass(chip.tone)}`}
           title=${chip.detail}
           data-testid=${`dashboard-health-chip-${chip.key}`}
         >

--- a/dashboard/src/components/dashboard-surface-tabs.ts
+++ b/dashboard/src/components/dashboard-surface-tabs.ts
@@ -36,7 +36,7 @@ export function DashboardSurfaceTabs({ items, currentTab }: DashboardSurfaceTabs
   const hasMatchingTab = items.some(item => item.id === currentTab)
 
   return html`
-    <nav class="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] max-[520px]:w-full max-[768px]:hidden" aria-label="Dashboard surfaces">
+    <nav class="v2-shell-tabs min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] max-[520px]:w-full max-[768px]:hidden" aria-label="Dashboard surfaces">
       <div
         role="tablist"
         aria-label="Dashboard surfaces"

--- a/dashboard/src/styles/v2-shell.css
+++ b/dashboard/src/styles/v2-shell.css
@@ -7,7 +7,9 @@
  */
 
 .v2-shell-rail,
-.v2-status-tray {
+.v2-status-tray,
+.v2-shell-header,
+.v2-health-strip {
   /* v5 Observatory dark-fantasy palette, calibrated against the v2
      colors_and_type.css "Dark Fantasy" theme. */
   --v2-ink:         #0a0e18;
@@ -511,4 +513,192 @@ aside.v2-status-tray .tray-action-link {
 aside.v2-status-tray .tray-action-link:hover {
   border-color: var(--v2-accent-brass-dim);
   color: var(--v2-accent-brass);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   HEADER + HEALTH STRIP — v2 token bridge
+   Re-sets the dashboard legacy token ladder to the v2 navy/brass
+   palette for these two chrome surfaces only.
+   ═══════════════════════════════════════════════════════════════ */
+
+:is(.v2-shell-header, .v2-health-strip) {
+  /* Surfaces */
+  --bg-0: var(--v2-ink);
+  --bg-1: var(--v2-velvet);
+  --bg-2: var(--v2-card);
+  --bg-3: var(--v2-card-soft);
+  --bg-4: var(--v2-raised);
+
+  --color-bg-0: var(--v2-ink);
+  --color-bg-1: var(--v2-velvet);
+  --color-bg-2: var(--v2-card);
+  --color-bg-3: var(--v2-card-soft);
+  --color-bg-4: var(--v2-raised);
+  --color-bg-page: var(--v2-ink);
+  --color-bg-surface: var(--v2-velvet);
+  --color-bg-panel-alt: var(--v2-card);
+  --color-bg-elevated: var(--v2-card-soft);
+  --color-bg-hover: var(--v2-raised);
+
+  /* Hairlines */
+  --line-1: var(--v2-border);
+  --line-2: var(--v2-border-strong);
+  --line-3: var(--v2-border-soft);
+
+  --color-line-1: var(--v2-border);
+  --color-line-2: var(--v2-border-strong);
+  --color-line-3: var(--v2-border-soft);
+  --color-border-default: var(--v2-border);
+  --color-border-strong: var(--v2-border-strong);
+  --color-border-divider: var(--v2-border-soft);
+
+  /* Text */
+  --fg-1: var(--v2-text-bright);
+  --fg-2: var(--v2-text);
+  --fg-3: var(--v2-text-dim);
+  --fg-4: var(--v2-text-faint);
+
+  --color-fg-1: var(--v2-text-bright);
+  --color-fg-2: var(--v2-text);
+  --color-fg-3: var(--v2-text-dim);
+  --color-fg-4: var(--v2-text-faint);
+  --color-fg-primary: var(--v2-text-bright);
+  --color-fg-secondary: var(--v2-text);
+  --color-fg-muted: var(--v2-text-dim);
+  --color-fg-disabled: var(--v2-text-faint);
+
+  /* Brass accent */
+  --brass-1: #c4a265;
+  --brass-2: #a08040;
+  --brass-3: var(--v2-accent-brass-dim);
+  --brass-glow: 196 162 101;
+  --brass-soft: rgb(196 162 101 / .10);
+  --brass-fg: var(--brass-1);
+
+  --color-brass-1: var(--brass-1);
+  --color-brass-2: var(--brass-2);
+  --color-brass-3: var(--brass-3);
+  --color-brass-glow: var(--brass-glow);
+  --color-brass-soft: var(--brass-soft);
+  --color-brass-fg: var(--brass-fg);
+  --color-accent-fg: var(--brass-1);
+  --color-accent-fg-dim: var(--brass-3);
+  --color-accent-glow: var(--brass-glow);
+  --accent-12: rgb(var(--brass-glow) / .12);
+  --accent-22: rgb(var(--brass-glow) / .22);
+
+  /* Status */
+  --ok: var(--v2-ok);
+  --warn: var(--v2-warn);
+  --err: var(--v2-bad);
+  --ok-glow: 90 122 58;
+  --warn-glow: 160 106 26;
+  --err-glow: 160 24 24;
+
+  --color-ok: var(--v2-ok);
+  --color-warn: var(--v2-warn);
+  --color-err: var(--v2-bad);
+  --color-status-ok: var(--v2-ok);
+  --color-status-warn: var(--v2-warn);
+  --color-status-err: var(--v2-bad);
+  --color-ok-glow: var(--ok-glow);
+  --color-warn-glow: var(--warn-glow);
+  --color-err-glow: var(--err-glow);
+
+  /* Status soft/alpha slots used by chips and badges */
+  --ok-soft: rgb(90 122 58 / .10);
+  --ok-10: rgb(90 122 58 / .10);
+  --ok-30: rgb(90 122 58 / .30);
+  --ok-fg: #9abc7a;
+  --ok-border: rgb(90 122 58 / .35);
+
+  --warn-soft: rgb(160 106 26 / .12);
+  --warn-10: rgb(160 106 26 / .10);
+  --warn-12: rgb(160 106 26 / .12);
+  --warn-20: rgb(160 106 26 / .20);
+  --warn-fg: #d49a3a;
+  --warn-bright: #e0a040;
+  --warn-border: rgb(160 106 26 / .35);
+
+  --err-soft: rgb(160 24 24 / .12);
+  --bad-soft: rgb(160 24 24 / .15);
+  --bad-10: rgb(160 24 24 / .10);
+  --bad-30: rgb(160 24 24 / .30);
+  --err-fg: #d06060;
+  --bad-light: #e07070;
+  --err-border: rgb(160 24 24 / .40);
+
+  --color-ok-soft: var(--ok-soft);
+  --color-warn-soft: var(--warn-soft);
+  --color-err-soft: var(--err-soft);
+}
+
+/* ── Header chrome ── */
+.v2-shell-header {
+  /* Subtle brass hairline at the bottom edge (matches v2 topbar). */
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.4), inset 0 -1px 0 rgba(138, 106, 40, 0.12);
+}
+
+.v2-shell-header .v2-header-brand {
+  border-color: var(--v2-border);
+  background: var(--v2-card);
+}
+
+.v2-shell-header .v2-header-mark {
+  border-color: var(--v2-border);
+  background: rgba(138, 106, 40, 0.10);
+  color: var(--brass-1);
+}
+
+.v2-shell-header .v2-header-crumb {
+  color: var(--v2-text-dim);
+}
+
+.v2-shell-header .v2-header-crumb .text-\[var\(--color-warn\)\] {
+  color: var(--v2-warn);
+}
+
+.v2-shell-header .v2-header-title {
+  color: var(--v2-text);
+}
+
+/* Surface tabs inside the header */
+.v2-shell-tabs [role="tablist"] {
+  border-color: var(--v2-border);
+  background: var(--v2-card-soft);
+}
+
+.v2-shell-tabs [role="tab"] {
+  border-color: transparent;
+  color: var(--v2-text-dim);
+}
+
+.v2-shell-tabs [role="tab"]:hover {
+  border-color: var(--v2-border);
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--v2-text);
+}
+
+.v2-shell-tabs [role="tab"][aria-selected="true"] {
+  border-color: var(--v2-accent-brass-dim);
+  background: rgba(196, 162, 101, 0.12);
+  color: var(--brass-1);
+  box-shadow: inset 0 -1px 0 var(--v2-accent-brass-dim);
+}
+
+/* Header action area (emergency stop, auth, connection, theme, build) */
+.v2-shell-header .v2-header-actions {
+  color: var(--v2-text-dim);
+}
+
+/* ── Health strip chrome ── */
+.v2-health-strip {
+  border-color: var(--v2-border-soft);
+  background: var(--v2-ink);
+}
+
+.v2-health-strip .dashboard-health-chip {
+  font-family: var(--v2-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
 }


### PR DESCRIPTION
Scopes the top header bar and the runtime health strip with the v2 Dark Fantasy / navy-brass palette.\n\n### Changes\n- Add `.v2-shell-header` / `.v2-health-strip` scopes and bridge legacy dashboard tokens to v2 colors.\n- Add v2 structural classes for brand mark, crumb, title, header actions, and surface tabs.\n- Add `.dashboard-health-chip` shared class to health-strip pills.\n- Extend `app.test.ts` to assert the new chrome classes.\n\n### Verification\n- `pnpm typecheck` ✅\n- `pnpm lint` ✅\n- `pnpm build` ✅\n- `pnpm vitest run app.test.ts dashboard-shell.test.ts dashboard-surface-tabs.test.ts status-tray.test.ts` ✅