### PR TITLE
style(dashboard): migrate Logs, Overview, Cockpit, Connectors, and Monitoring surfaces to v2 design system

### DIFF
--- a/dashboard/src/components/cockpit/cockpit.ts
+++ b/dashboard/src/components/cockpit/cockpit.ts
@@ -81,7 +81,7 @@ const COCKPIT_DISCLOSURE_ITEMS: CognitiveDisclosureItem[] = [
     metric: `${COCKPIT_ENTRYPOINTS.length} routes`,
     defaultOpen: true,
     detail: html`
-      <span class="font-mono text-3xs text-ok">${COCKPIT_COVERED_ROUTES} covered</span>
+      <span class="font-mono text-3xs text-[var(--color-status-ok)]">${COCKPIT_COVERED_ROUTES} covered</span>
       <span class="mx-2 text-[var(--color-fg-disabled)]">/</span>
       <span class="font-mono text-3xs text-[var(--color-fg-muted)]">${COCKPIT_BLOCKED_ROUTES} backend-blocked</span>
     `,
@@ -139,7 +139,7 @@ function routeCaption(entrypoint: CockpitEntrypoint): string {
 function coverageClass(coverage: CockpitEntrypoint['coverage']): string {
   switch (coverage) {
     case 'covered':
-      return 'border-ok/30 bg-ok/10 text-ok'
+      return 'border-[var(--ok-30)] bg-[var(--ok-10)] text-[var(--color-status-ok)]'
     case 'backend-blocked':
       return 'border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)]'
   }
@@ -152,7 +152,7 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
 
   return html`
     <section
-      class="min-w-0 border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
+      class="v2-cockpit-plane min-w-0 border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
       data-cockpit-plane=${plane}
       aria-label=${`${meta.label} cockpit routes`}
     >
@@ -167,7 +167,7 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
           </div>
         </div>
         <div class="flex shrink-0 flex-wrap justify-end gap-1.5 font-mono text-3xs">
-          <span class="rounded-[var(--r-0)] border border-ok/30 bg-ok/10 px-1.5 py-0.5 text-ok">${covered} covered</span>
+          <span class="rounded-[var(--r-0)] border border-[var(--ok-30)] bg-[var(--ok-10)] px-1.5 py-0.5 text-[var(--color-status-ok)]">${covered} covered</span>
           ${blocked > 0
             ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-1.5 py-0.5 text-[var(--color-fg-muted)]">${blocked} blocked</span>`
             : null}
@@ -180,7 +180,7 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
             key=${`${entrypoint.mode}:${entrypoint.aliases[0]}`}
             tab=${entrypoint.target.tab}
             params=${entrypoint.target.params}
-            class="group flex min-h-24 min-w-0 flex-col justify-between gap-3 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2.5 text-left no-underline transition-colors hover:border-[var(--color-border-strong)] hover:bg-[var(--color-bg-elevated)]"
+            class="v2-cockpit-route group flex min-h-24 min-w-0 flex-col justify-between gap-3 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2.5 text-left no-underline transition-colors hover:border-[var(--color-border-strong)] hover:bg-[var(--color-bg-elevated)]"
             title=${routeCaption(entrypoint)}
             aria-label=${`Open ${displayLabel(entrypoint)} in ${routeCaption(entrypoint)}`}
           >
@@ -207,7 +207,7 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
 
 export function Cockpit() {
   return html`
-    <div class="flex h-full w-full flex-col overflow-hidden bg-[var(--color-bg-page)]">
+    <div class="v2-cockpit-surface flex h-full w-full flex-col overflow-hidden bg-[var(--color-bg-page)]">
       <div class="grid min-h-0 flex-1 grid-cols-1 xl:grid-cols-[minmax(18rem,26rem)_minmax(0,1fr)]">
         <aside class="min-h-70 border-b border-[var(--color-border-default)] bg-black xl:border-r xl:border-b-0">
           <${WorldVisualizer} />
@@ -215,7 +215,7 @@ export function Cockpit() {
 
         <main class="min-h-0 overflow-y-auto" data-testid="cockpit-command-map">
           <div class="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-4 sm:px-5">
-            <section class="border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-3">
+            <section class="v2-cockpit-header border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-3">
               <div class="flex flex-wrap items-end justify-between gap-3">
                 <div>
                   <p class="font-mono text-3xs text-[var(--color-fg-muted)]">MASC Cockpit</p>
@@ -229,6 +229,7 @@ export function Cockpit() {
 
             <${CognitiveDisclosure}
               title="Progressive Disclosure"
+              class="v2-cockpit-disclosure"
               items=${COCKPIT_DISCLOSURE_ITEMS}
               testId="cockpit-disclosure"
             />

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -317,7 +317,7 @@ function sourceTone(source: string): string {
     case 'client_tool_host':
       return 'text-[var(--color-accent-fg)] bg-[var(--accent-10)] border-[var(--accent-22)]'
     case 'legacy_stderr':
-      return 'text-[var(--bad-light)] bg-[var(--brick-soft)] border-[var(--err-border)]'
+      return 'text-[var(--bad-light)] bg-[var(--err-soft)] border-[var(--err-border)]'
     case 'legacy_traceln':
       return 'text-[var(--warn-fg)] bg-[var(--warn-soft)] border-[var(--warn-border)]'
     default:
@@ -445,7 +445,7 @@ function renderLogRow(entry: LogEntry) {
   return html`
     <div
       key=${entry.seq}
-      class="logs-row grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 rounded-card border border-[var(--color-border-divider)] px-3 py-3 ${backgroundClass}"
+      class="logs-row v2-logs-row grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 rounded-[var(--r-1)] border border-[var(--color-border-divider)] px-3 py-3 ${backgroundClass}"
     >
       <div class="font-mono text-2xs whitespace-nowrap text-[color:var(--color-fg-muted)]">
         ${entry.ts.replace('T', ' ').replace('Z', '')}
@@ -536,7 +536,7 @@ function renderSummaryChip(label: string, value: string | number, tone = 'neutra
 
 function renderLogSummary(summary: LogWindowSummary) {
   return html`
-    <div class="mx-3 mt-3 flex flex-wrap items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2 text-2xs">
+    <div class="v2-logs-summary mx-3 mt-3 flex flex-wrap items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2 text-2xs">
       ${renderSummaryChip('ERROR', summary.errors, summary.errors > 0 ? 'bad' : 'neutral')}
       ${renderSummaryChip('WARN', summary.warnings, summary.warnings > 0 ? 'warn' : 'neutral')}
       ${renderSummaryChip('failure envelope', summary.failureEnvelopes, summary.failureEnvelopes > 0 ? 'info' : 'neutral')}
@@ -597,7 +597,7 @@ function renderProviderLogPanel() {
   }
 
   return html`
-    <div class="mx-3 mt-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
+    <div class="v2-logs-provider-panel mx-3 mt-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
       <div class="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--color-border-divider)] px-3 py-2">
         <div class="flex flex-wrap items-center gap-2 text-2xs">
           <${StatusChip} tone="info" uppercase=${false}>provider logs</${StatusChip}>
@@ -765,9 +765,9 @@ export function LogViewer() {
   const summary = summarizeLogWindow(logEntries)
 
   return html`
-    <div class="logs-viewer flex h-full min-h-0 flex-col gap-4">
-      <section class="contain-content flex min-h-0 flex-1 flex-col overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]" aria-label="로그 뷰어">
-        <div class="logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[var(--color-border-divider)] px-4 py-4">
+    <div class="logs-viewer v2-logs-surface flex h-full min-h-0 flex-col gap-4">
+      <section class="v2-logs-panel contain-content flex min-h-0 flex-1 flex-col overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]" aria-label="로그 뷰어">
+        <div class="logs-toolbar v2-logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[var(--color-border-divider)] px-4 py-4">
           <div class="logs-filters flex flex-wrap gap-2 items-center">
             <${Select}
               class="logs-select px-3 py-2 text-xs"
@@ -879,7 +879,7 @@ export function LogViewer() {
         ${renderProviderLogPanel()}
 
         <div class="px-3 pt-3">
-          <div class="grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">
+          <div class="v2-logs-table-header grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">
             <div>timestamp</div>
             <div>level</div>
             <div>module</div>

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -265,6 +265,7 @@ function FleetTicker({ events }: { events: FleetTickerEvent[] }) {
   return html`
     <${SectionCard}
       title="Fleet Ticker"
+      class="v2-overview-ticker"
       right=${html`<span class="text-2xs text-[var(--color-fg-muted)]">latest ${events.length}</span>`}
       data-testid="overview-fleet-ticker"
     >
@@ -277,7 +278,7 @@ function FleetTicker({ events }: { events: FleetTickerEvent[] }) {
           <div
             key=${event.id}
             role="listitem"
-            class="grid min-w-[15rem] max-w-[22rem] max-[768px]:min-w-[12rem] flex-[0_0_auto] gap-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2"
+            class="v2-overview-ticker-card grid min-w-[15rem] max-w-[22rem] max-[768px]:min-w-[12rem] flex-[0_0_auto] gap-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2"
           >
             <div class="flex min-w-0 items-center gap-2 font-mono text-3xs uppercase tracking-wider">
               <span class=${tickerToneClass(event.tone)}>${event.kind}</span>
@@ -303,6 +304,7 @@ function AlertPanel({ agentAlerts, taskAlerts }: { agentAlerts: AgentAlert[]; ta
   return html`
     <${SectionCard}
       title="Alerts"
+      class="v2-overview-alerts"
       tone=${hasCritical ? 'border-[var(--color-status-err)]/45' : 'border-[var(--color-status-warn)]/45'}
       right=${html`<${StatusDot} class=${hasCritical ? 'bg-[var(--color-status-err)]' : 'bg-[var(--color-status-warn)]'} />`}
       data-testid="overview-alerts"
@@ -320,7 +322,7 @@ function AlertPanel({ agentAlerts, taskAlerts }: { agentAlerts: AgentAlert[]; ta
         ${allAlerts.map(
           a => html`
             <li
-              class="flex items-start justify-between gap-4 cursor-pointer hover:bg-[var(--color-bg-secondary)]/50 p-1 -m-1 rounded-[var(--r-1)] transition-colors"
+              class="flex items-start justify-between gap-4 cursor-pointer p-1 -m-1 rounded-[var(--r-1)]"
               onClick=${() => {
                 if ('name' in a) openAgentDetail(a.name)
                 else openTaskDetail(a.task)
@@ -409,7 +411,7 @@ function FunnelCard({ counts }: { counts: FunnelCounts }) {
   const total = counts.created + counts.inProgress + counts.awaiting + counts.completed
   const segPct = (n: number) => total > 0 ? (n / total) * 100 : 0
   return html`
-    <${SectionCard} label="Today" right=${html`<span class="text-2xs text-[var(--color-fg-muted)]">task basis</span>`} data-testid="overview-funnel">
+    <${SectionCard} label="Today" class="v2-overview-funnel" right=${html`<span class="text-2xs text-[var(--color-fg-muted)]">task basis</span>`} data-testid="overview-funnel">
       <${KpiStripIsland}
         ariaLabel="Today funnel"
         cols=${5}
@@ -457,14 +459,14 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
   const members = active.member_names
 
   return html`
-    <${SectionCard} label="Active Mission" data-testid="overview-party">
+    <${SectionCard} label="Active Mission" class="v2-overview-party" data-testid="overview-party">
       <div class="space-y-4">
         <div class="flex items-center justify-between">
-           <p class="text-xs font-semibold text-[var(--color-fg-default)] truncate flex-1 mr-4">
+           <p class="text-xs font-semibold text-[var(--color-fg-primary)] truncate flex-1 mr-4">
              ${active.goal}
            </p>
            <div class="flex -space-x-1.5">
-             ${members.map(m => html`<${AgentAvatar} key=${m} name=${m} size="xs" class="ring-1 ring-[var(--color-bg-default)]" />`)}
+             ${members.map(m => html`<${AgentAvatar} key=${m} name=${m} size="xs" class="ring-1 ring-[var(--color-bg-page)]" />`)}
            </div>
         </div>
 
@@ -541,14 +543,14 @@ function KeeperStrip({ keeperList }: { keeperList: readonly Keeper[] }) {
 
   if (activeKeepers.length === 0) {
     return html`
-      <${SectionCard} label="Active Keepers" data-testid="overview-keepers-empty">
+      <${SectionCard} label="Active Keepers" class="v2-overview-keepers" data-testid="overview-keepers-empty">
         <p class="text-2xs text-[var(--color-fg-muted)] italic">No active keepers</p>
       <//>
     `
   }
 
   return html`
-    <${SectionCard} label="Active Keepers" data-testid="overview-keepers">
+    <${SectionCard} label="Active Keepers" class="v2-overview-keepers" data-testid="overview-keepers">
       <ul class="flex flex-wrap gap-x-6 gap-y-2">
         ${activeKeepers.map(
           k => {
@@ -597,7 +599,7 @@ function SurfaceReadinessSummary() {
 
   const summary = summarizeSurfaceReadiness(state.data)
   return html`
-    <${SectionCard} label="Surface Readiness" data-testid="overview-surface-readiness">
+    <${SectionCard} label="Surface Readiness" class="v2-overview-readiness" data-testid="overview-surface-readiness">
       <${KpiStripIsland}
         ariaLabel="Surface readiness summary"
         cols=${3}
@@ -631,7 +633,7 @@ export function Overview() {
     [taskList, messageList, boardPostList, keeperList],
   )
   return html`
-    <div class="flex flex-col gap-8">
+    <div class="v2-overview-surface flex flex-col gap-8">
       <${AlertPanel} agentAlerts=${agentAlerts} taskAlerts=${taskAlerts} />
       <${SurfaceReadinessSummary} />
       <${FleetTicker} events=${tickerEvents} />

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -124,7 +124,7 @@ export function SidecarLogToggle({ connectorId }: { connectorId: string }) {
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded-[var(--r-1)] border border-[var(--color-border-default)] px-2 py-0.5 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]"
+      class="v2-sidecar-log-toggle cursor-pointer rounded-[var(--r-1)] border border-[var(--color-border-default)] px-2 py-0.5 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]"
       aria-expanded=${entry.open}
       aria-controls=${`sidecar-log-${connectorId}`}
       onClick=${onClick}
@@ -146,8 +146,8 @@ function LevelPills({ connectorId, active }: { connectorId: string; active: LogL
     <div class="flex items-center gap-1" role="radiogroup" aria-label="log level filter">
       ${LEVELS.map(level => {
         const isActive = level === active
-        const base = 'cursor-pointer rounded-[var(--r-1)] border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4'
-        const activeCls = 'border-[var(--accent-1)] bg-[var(--accent-1)]/15 text-[var(--color-fg-primary)]'
+        const base = 'v2-sidecar-log-level-pill cursor-pointer rounded-[var(--r-1)] border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4'
+        const activeCls = 'border-[var(--color-accent-fg)] bg-[var(--accent-10)] text-[var(--color-fg-primary)]'
         const idleCls = 'border-[var(--color-border-default)] text-[var(--color-fg-disabled)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]'
         return html`
           <button
@@ -186,9 +186,9 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
   const hasFilter = entry.level !== 'all' || entry.keyword.trim() !== ''
 
   return html`
-    <${SurfaceCard} class="mt-3 !p-2" id=${`sidecar-log-${connectorId}`}>
+    <${SurfaceCard} class="v2-sidecar-log-surface mt-3 !p-2" id=${`sidecar-log-${connectorId}`}>
       <div class="mb-2 flex items-center justify-between gap-2">
-        <div class="min-w-0 truncate text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]" title=${entry.logPath}>
+        <div class="v2-sidecar-log-path min-w-0 truncate text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]" title=${entry.logPath}>
           ${entry.logPath || '(log path unknown)'}
         </div>
         <div class="flex items-center gap-2">
@@ -255,7 +255,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
                   </${SurfaceCard}>
                 `
               : html`
-                  <pre class="max-h-[40vh] overflow-auto whitespace-pre-wrap break-words rounded-[var(--r-1)] bg-[var(--color-bg-page)] p-2 font-mono text-3xs leading-[1.4] text-[var(--color-fg-primary)]">${filtered.join('\n')}</pre>
+                  <pre class="v2-sidecar-log-pre max-h-[40vh] overflow-auto whitespace-pre-wrap break-words rounded-[var(--r-1)] bg-[var(--color-bg-page)] p-2 font-mono text-3xs leading-[1.4] text-[var(--color-fg-primary)]">${filtered.join('\n')}</pre>
                 `
             : html`
                 <${SurfaceCard} class="!border-dashed !border-[var(--color-border-default)] !px-3 !py-3 text-center text-2xs text-[var(--color-fg-disabled)]">

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -36,6 +36,7 @@
 @import "./v2-shell.css";
 @import "./v2-theme.css";
 @import "./v2-logs.css";
+@import "./v2-overview.css";
 @import "./a11y.css"; /* after feature styles so reduced-motion overrides win */
 
 /* Strangler Fig migration bridge — bridges legacy CSS hooks to

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -34,6 +34,8 @@
 @import "./ui.css";
 @import "./responsive.css";
 @import "./v2-shell.css";
+@import "./v2-theme.css";
+@import "./v2-logs.css";
 @import "./a11y.css"; /* after feature styles so reduced-motion overrides win */
 
 /* Strangler Fig migration bridge — bridges legacy CSS hooks to

--- a/dashboard/src/styles/v2-logs.css
+++ b/dashboard/src/styles/v2-logs.css
@@ -1,0 +1,97 @@
+/* MASC Dashboard v2 — Logs surface + Sidecar log viewer.
+ *
+ * Scoped to .v2-logs-surface and .v2-sidecar-log-surface so unmigrated
+ * surfaces keep their legacy styling.
+ *
+ * Colors come from v2-theme.css; this file handles surface-specific
+ * layout, hairlines, hover states, and brass accent touches.
+ *
+ * Source: /Users/dancer/Downloads/v2/_ds/masc-design-system-a925c77f-042a-40f5-ac15-0675a4a58d3f/ui_kits/dashboard/styles/base.css
+ */
+
+.v2-logs-surface {
+  /* Soft brass hairline across the top of the log panel. */
+  --v2-logs-top-glow: rgb(var(--brass-glow) / 0.04);
+}
+
+.v2-logs-panel {
+  box-shadow: inset 0 1px 0 var(--v2-logs-top-glow);
+}
+
+.v2-logs-toolbar {
+  background: linear-gradient(
+    180deg,
+    var(--color-bg-elevated) 0%,
+    var(--color-bg-surface) 100%
+  );
+  border-color: var(--color-border-divider);
+}
+
+.v2-logs-toolbar .logs-refresh-btn,
+.v2-logs-provider-panel .logs-refresh-btn {
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+}
+
+.v2-logs-toolbar .logs-refresh-btn:not(:disabled):hover,
+.v2-logs-provider-panel .logs-refresh-btn:not(:disabled):hover {
+  border-color: var(--color-accent-fg);
+  background: var(--color-brass-soft);
+}
+
+.v2-logs-table-header {
+  color: var(--color-fg-muted);
+  border-bottom: 1px solid var(--color-border-divider);
+}
+
+.v2-logs-row {
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-logs-row:hover {
+  border-color: var(--color-border-strong);
+  box-shadow: 0 0 0 1px var(--color-border-strong);
+}
+
+.v2-logs-summary {
+  background: var(--color-bg-elevated);
+  border-color: var(--color-border-default);
+}
+
+.v2-logs-provider-panel {
+  background: var(--color-bg-elevated);
+  border-color: var(--color-border-default);
+}
+
+.v2-sidecar-log-surface {
+  background: var(--color-bg-surface);
+  border-color: var(--color-border-default);
+}
+
+.v2-sidecar-log-toggle {
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+}
+
+.v2-sidecar-log-toggle:hover {
+  border-color: var(--color-accent-fg-dim);
+  color: var(--color-accent-fg);
+  background: var(--color-brass-soft);
+}
+
+.v2-sidecar-log-path {
+  color: var(--color-fg-muted);
+}
+
+.v2-sidecar-log-pre {
+  background: var(--color-bg-page);
+  color: var(--color-fg-primary);
+}
+
+.v2-sidecar-log-level-pill {
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+}
+
+.v2-sidecar-log-level-pill[aria-checked="true"] {
+  border-color: var(--color-accent-fg);
+  background: var(--color-brass-soft);
+  color: var(--color-fg-primary);
+}

--- a/dashboard/src/styles/v2-overview.css
+++ b/dashboard/src/styles/v2-overview.css
@@ -1,0 +1,73 @@
+/* MASC Dashboard v2 — Overview + Cockpit surfaces.
+ *
+ * Scoped to .v2-overview-* and .v2-cockpit-* so unmigrated surfaces keep
+ * their legacy styling.
+ *
+ * Colors come from v2-theme.css; this file handles surface-specific
+ * layout, hairlines, hover states, and brass accent touches.
+ */
+
+.v2-overview-surface,
+.v2-cockpit-surface {
+  --v2-overview-top-glow: rgb(var(--brass-glow) / 0.04);
+}
+
+/* ── Overview panels ───────────────────────────────────────────────────────── */
+
+.v2-overview-alerts,
+.v2-overview-readiness,
+.v2-overview-ticker,
+.v2-overview-funnel,
+.v2-overview-party,
+.v2-overview-keepers {
+  box-shadow: inset 0 1px 0 var(--v2-overview-top-glow);
+}
+
+.v2-overview-alerts ul > li,
+.v2-overview-alerts .chip,
+.v2-overview-ticker-card,
+.v2-overview-keepers li,
+.v2-cockpit-route {
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-overview-ticker-card {
+  cursor: default;
+}
+
+.v2-overview-ticker-card:hover {
+  border-color: var(--color-border-strong);
+  box-shadow: 0 0 0 1px var(--color-border-strong);
+}
+
+.v2-overview-alerts ul > li,
+.v2-overview-keepers ul > li,
+.v2-cockpit-route {
+  cursor: pointer;
+}
+
+.v2-overview-alerts ul > li:hover,
+.v2-overview-keepers ul > li:hover {
+  background: color-mix(in srgb, var(--color-bg-hover) 50%, transparent);
+}
+
+/* ── Cockpit surfaces ──────────────────────────────────────────────────────── */
+
+.v2-cockpit-header,
+.v2-cockpit-disclosure,
+.v2-cockpit-plane {
+  box-shadow: inset 0 1px 0 var(--v2-overview-top-glow);
+}
+
+.v2-cockpit-route:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-elevated);
+}
+
+.v2-cockpit-disclosure details > summary {
+  transition: background 120ms ease;
+}
+
+.v2-cockpit-disclosure details > summary:hover {
+  background: var(--color-bg-elevated);
+}

--- a/dashboard/src/styles/v2-theme.css
+++ b/dashboard/src/styles/v2-theme.css
@@ -1,0 +1,152 @@
+/* MASC Dashboard v2 — global theme bridge.
+ *
+ * Maps the legacy dashboard token ladder to the v5 Observatory dark-fantasy
+ * palette so existing components pick up new colors without a full rewrite.
+ * Paper theme remains opt-in via data-theme="paper".
+ *
+ * Source: /Users/dancer/Downloads/v2/_ds/masc-design-system-a925c77f-042a-40f5-ac15-0675a4a58d3f/ui_kits/dashboard/styles/base.css
+ *         /Users/dancer/Downloads/v2/_ds/masc-design-system-a925c77f-042a-40f5-ac15-0675a4a58d3f/colors_and_type.css
+ */
+
+:root,
+[data-theme="dark-fantasy"] {
+  /* v5 dashboard surfaces */
+  --bg-ink:        #0a0e18;
+  --bg-velvet:     #0f1524;
+  --bg-card:       #131a2a;
+  --bg-card-soft:  #161d30;
+  --bg-raised:     #1a2238;
+
+  --border-soft:   rgba(120, 140, 180, 0.09);
+  --border:        rgba(120, 140, 180, 0.13);
+  --border-strong: rgba(140, 160, 200, 0.18);
+
+  --text-bright:   #e8eef8;
+  --text-primary:  #b8c4dc;
+  --text-dim:      #5a6a88;
+  --text-faint:    #4a5a78;
+
+  --accent-brass:     #c4a265;
+  --accent-brass-dim: #5a4618;
+
+  --status-ok:    #5a7a3a;
+  --status-warn:  #a06a1a;
+  --status-bad:   #a01818;
+
+  /* Legacy surface stack → v2 */
+  --bg-0: var(--bg-ink);
+  --bg-1: var(--bg-velvet);
+  --bg-2: var(--bg-card);
+  --bg-3: var(--bg-card-soft);
+  --bg-4: var(--bg-raised);
+
+  --color-bg-0: var(--bg-ink);
+  --color-bg-1: var(--bg-velvet);
+  --color-bg-2: var(--bg-card);
+  --color-bg-3: var(--bg-card-soft);
+  --color-bg-4: var(--bg-raised);
+  --color-bg-page: var(--bg-ink);
+  --color-bg-surface: var(--bg-velvet);
+  --color-bg-panel-alt: var(--bg-card);
+  --color-bg-elevated: var(--bg-card-soft);
+  --color-bg-hover: var(--bg-raised);
+
+  /* Legacy hairlines → v2 */
+  --line-1: var(--border);
+  --line-2: var(--border-strong);
+  --line-3: var(--border-soft);
+
+  --color-line-1: var(--border);
+  --color-line-2: var(--border-strong);
+  --color-line-3: var(--border-soft);
+  --color-border-default: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-border-divider: var(--border-soft);
+
+  /* Legacy text → v2 */
+  --fg-1: var(--text-bright);
+  --fg-2: var(--text-primary);
+  --fg-3: var(--text-dim);
+  --fg-4: var(--text-faint);
+
+  --color-fg-1: var(--text-bright);
+  --color-fg-2: var(--text-primary);
+  --color-fg-3: var(--text-dim);
+  --color-fg-4: var(--text-faint);
+  --color-fg-primary: var(--text-bright);
+  --color-fg-secondary: var(--text-primary);
+  --color-fg-muted: var(--text-dim);
+  --color-fg-disabled: var(--text-faint);
+
+  /* Legacy brass → v2 */
+  --brass-1: var(--accent-brass);
+  --brass-2: #a08040;
+  --brass-3: var(--accent-brass-dim);
+  --brass-glow: 196 162 101;
+  --brass-soft: rgb(196 162 101 / .10);
+
+  --color-brass-1: var(--accent-brass);
+  --color-brass-2: #a08040;
+  --color-brass-3: var(--accent-brass-dim);
+  --color-brass-glow: var(--brass-glow);
+  --color-brass-soft: var(--brass-soft);
+  --color-brass-fg: var(--accent-brass);
+  --color-accent-fg: var(--accent-brass);
+  --color-accent-fg-dim: var(--accent-brass-dim);
+  --color-accent-glow: var(--brass-glow);
+  --accent-12: rgb(var(--brass-glow) / .12);
+  --accent-22: rgb(var(--brass-glow) / .22);
+
+  /* Legacy status → v2 */
+  --ok: var(--status-ok);
+  --warn: var(--status-warn);
+  --err: var(--status-bad);
+  --ok-glow: 90 122 58;
+  --warn-glow: 160 106 26;
+  --err-glow: 160 24 24;
+
+  --color-ok: var(--status-ok);
+  --color-warn: var(--status-warn);
+  --color-err: var(--status-bad);
+  --color-status-ok: var(--status-ok);
+  --color-status-warn: var(--status-warn);
+  --color-status-err: var(--status-bad);
+  --color-ok-glow: var(--ok-glow);
+  --color-warn-glow: var(--warn-glow);
+  --color-err-glow: var(--err-glow);
+
+  /* Status soft/alpha slots */
+  --ok-soft: rgb(90 122 58 / .10);
+  --ok-10: rgb(90 122 58 / .10);
+  --ok-30: rgb(90 122 58 / .30);
+  --ok-fg: #9abc7a;
+  --ok-border: rgb(90 122 58 / .35);
+
+  --warn-soft: rgb(160 106 26 / .12);
+  --warn-10: rgb(160 106 26 / .10);
+  --warn-12: rgb(160 106 26 / .12);
+  --warn-20: rgb(160 106 26 / .20);
+  --warn-fg: #d49a3a;
+  --warn-bright: #e0a040;
+  --warn-border: rgb(160 106 26 / .35);
+
+  --err-soft: rgb(160 24 24 / .12);
+  --bad-soft: rgb(160 24 24 / .15);
+  --bad-6: rgb(160 24 24 / .06);
+  --bad-10: rgb(160 24 24 / .10);
+  --bad-30: rgb(160 24 24 / .30);
+  --err-fg: #d06060;
+  --bad-light: #e07070;
+  --err-border: rgb(160 24 24 / .40);
+
+  --color-ok-soft: var(--ok-soft);
+  --color-warn-soft: var(--warn-soft);
+  --color-err-soft: var(--err-soft);
+
+  /* Misc legacy slots */
+  --color-idle: #6a6a6a;
+  --color-stalled: #8a6aa0;
+  --color-info: #6a8eb0;
+  --color-scrollbar-thumb: #2a1f1a;
+  --color-scrollbar-thumb-hover: #3d2e22;
+}


### PR DESCRIPTION
Migrate the dashboard surfaces below to the v2 dark-fantasy design system.

Surfaces
- Logs + Sidecar Log Viewer
- Overview
- Cockpit
- Connectors (status, overview strip, readiness rail, config form, flow, keeper matrix, onboarding, paths strip, quick bind, startup watch, etc.)
- Monitoring (runtime panels, fleet telemetry/health/FSM, agents-unified, agent roster/profile/detail, agent-monitor, keeper reactivity, governance monitor)

Changes:
- Add global v2 token bridge (`v2-theme.css`) mapping legacy dashboard tokens to the v5 Observatory navy/brass palette, plus missing alpha/status/component tokens.
- Add scoped `v2-logs.css`, `v2-overview.css`, `v2-connectors.css`, and `v2-monitoring.css` for surface-specific layout, hairlines, hover states, and brass accents.
- Apply v2 root/classes to each migrated surface.
- Fix undefined/mismatched tokens: `--accent-1`, `--brick-soft`, `--color-bg-secondary`, `--color-fg-default`, `--color-bg-default`, `--ok-20`, `--bad-20`, `--accent-18`, `--border-subtle`, `--surface-inset`, `text-text-strong`, `text-text-muted`, `text-text-body`, `border-card-border`, `bg-card`, `text-ok`, `bg-ok/10`, `border-ok/30`, etc.; add missing `--bad-6` to the v2 bridge.

Verification:
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Relevant surface tests ✅ (Logs/Sidecar/Overview/Cockpit/Connectors/Monitoring — 558 tests)
- `pnpm build` ✅