### PR TITLE
feat(dashboard): surface tool-call output in chat ToolCallBubble

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -45,6 +45,7 @@ const TARGET_FILES = [
   'src/sse.ts',
   'src/sse-store.ts',
   'src/tab-refresh.ts',
+  'src/tool-call-output-store.ts',
   'src/types/sse.ts',
 ]
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2591,6 +2591,11 @@ export type ToolCallEntry = {
   lane?: string
   // RFC-0233: canonical execution identity minted at dispatch (absent on pre-PR-1 rows)
   execution_id?: string
+  // RFC-0233 PR-2: provider call id (oas-event join key). Equals the chat tool
+  // row's tool_call_id for the same execution, so the chat ToolCallBubble can
+  // join this entry's output onto the transcript. Absent when the call carried
+  // no provider id (synthesised tc-<position> rows) or on pre-PR-2 logs.
+  tool_use_id?: string
 }
 
 export type ToolCallsResponse = TelemetryFreshnessMetadata & {
@@ -2642,6 +2647,7 @@ function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
     task_id: asString(raw.task_id),
     lane: asString(raw.lane),
     execution_id: asString(raw.execution_id),
+    tool_use_id: asString(raw.tool_use_id),
   }
 }
 

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -2,7 +2,42 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { KeeperConversationEntry } from '../../types'
+import type { ToolCallEntry } from '../../api/dashboard'
 import { ChatComposer, ChatTranscript } from './primitives'
+import { recordToolCallOutputs, resetToolCallOutputs } from '../../tool-call-output-store'
+
+const flushUi = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 30))
+
+function toolEntry(
+  overrides: Partial<KeeperConversationEntry> & Pick<KeeperConversationEntry, 'id'>,
+): KeeperConversationEntry {
+  return {
+    role: 'tool',
+    source: 'tool_result',
+    label: 'keeper_context_status',
+    text: '{}',
+    rawText: '{}',
+    timestamp: '2026-03-24T00:00:00.000Z',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+    ...overrides,
+  }
+}
+
+function toolCallOutput(overrides: Partial<ToolCallEntry> & Pick<ToolCallEntry, 'tool_use_id'>): ToolCallEntry {
+  return {
+    ts: 0,
+    keeper: 'sangsu',
+    tool: 'keeper_context_status',
+    input: {},
+    output: 'context window ok',
+    success: true,
+    duration_ms: 12,
+    ...overrides,
+  }
+}
 
 function entry(
   overrides: Partial<KeeperConversationEntry> & Pick<KeeperConversationEntry, 'id' | 'text'>,
@@ -35,6 +70,115 @@ describe('ChatTranscript', () => {
   afterEach(() => {
     render(null, container)
     container.remove()
+    resetToolCallOutputs()
+  })
+
+  it('surfaces tool output joined by tool_use_id in the collapsed preview', () => {
+    recordToolCallOutputs([toolCallOutput({ tool_use_id: 'toolu_x', output: 'context window 42%' })])
+    render(
+      html`<${ChatTranscript}
+        entries=${[toolEntry({ id: 'tool-toolu_x' })]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+
+    const bubble = container.querySelector('[data-chat-variant="tool-call"]')
+    expect(bubble).not.toBeNull()
+    // No-argument tool (`{}`): the collapsed glance shows the result, not args.
+    expect(bubble?.textContent).toContain('context window 42%')
+    // Success status marker is rendered in the header.
+    expect(bubble?.textContent).toContain('✓')
+  })
+
+  it('marks a failed tool call with the error status glyph', () => {
+    recordToolCallOutputs([
+      toolCallOutput({ tool_use_id: 'toolu_y', success: false, output: 'boom' }),
+    ])
+    render(
+      html`<${ChatTranscript}
+        entries=${[toolEntry({ id: 'tool-toolu_y' })]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+
+    const bubble = container.querySelector('[data-chat-variant="tool-call"]')
+    expect(bubble?.textContent).toContain('✗')
+  })
+
+  it('falls back to arguments and shows no status until output arrives', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[toolEntry({ id: 'tool-toolu_pending', text: '{"path":"a.ml"}' })]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+
+    const bubble = container.querySelector('[data-chat-variant="tool-call"]')
+    expect(bubble?.textContent).toContain('a.ml')
+    expect(bubble?.textContent).not.toContain('✓')
+    expect(bubble?.textContent).not.toContain('✗')
+  })
+
+  it('renders args and output in labelled sections when expanded', async () => {
+    recordToolCallOutputs([toolCallOutput({ tool_use_id: 'toolu_z', output: 'EXPANDED OUTPUT' })])
+    render(
+      html`<${ChatTranscript}
+        entries=${[toolEntry({ id: 'tool-toolu_z', text: '{"k":"v"}' })]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+
+    const toggle = container.querySelector('[data-chat-variant="tool-call"] button') as HTMLButtonElement
+    toggle.click()
+    await flushUi()
+
+    const bubble = container.querySelector('[data-chat-variant="tool-call"]')
+    expect(bubble?.textContent).toContain('arguments')
+    expect(bubble?.textContent).toContain('output')
+    expect(bubble?.textContent).toContain('EXPANDED OUTPUT')
+  })
+
+  it('shows a waiting hint for a no-arg tool whose output has not landed, when expanded', async () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[toolEntry({ id: 'tool-toolu_wait' })]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+
+    const toggle = container.querySelector('[data-chat-variant="tool-call"] button') as HTMLButtonElement
+    toggle.click()
+    await flushUi()
+
+    const bubble = container.querySelector('[data-chat-variant="tool-call"]')
+    expect(bubble?.textContent).toContain('출력 대기 중')
+  })
+
+  it('re-renders to show output when it arrives after the bubble mounted', async () => {
+    // Real-world path: the bubble renders before the tool-call hydration
+    // lands (output is always late). Reading the store signal during render
+    // subscribes the bubble, so a later record() must update it.
+    render(
+      html`<${ChatTranscript}
+        entries=${[toolEntry({ id: 'tool-toolu_late' })]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+    let bubble = container.querySelector('[data-chat-variant="tool-call"]')
+    expect(bubble?.textContent).not.toContain('late output here')
+
+    recordToolCallOutputs([toolCallOutput({ tool_use_id: 'toolu_late', output: 'late output here' })])
+    await flushUi()
+
+    bubble = container.querySelector('[data-chat-variant="tool-call"]')
+    expect(bubble?.textContent).toContain('late output here')
+    expect(bubble?.textContent).toContain('✓')
   })
 
   it('keeps saved delivery badges in the default transcript', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -9,6 +9,8 @@ import { formatTimeHms } from '../../lib/format-time'
 import { formatCost } from '../../lib/format-number'
 import { isSubmitEnter } from '../../lib/keyboard'
 import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, SurfaceRef } from '../../types'
+import type { ToolCallOutputBlob } from '../../api/dashboard'
+import { lookupToolCallOutput } from '../../tool-call-output-store'
 
 function surfaceLink(surface?: SurfaceRef | null): { url: string; label: string; icon: string } | null {
   if (!surface || !surface.kind) return null
@@ -587,22 +589,60 @@ function ChatMessageBubble({
   `
 }
 
+// Pretty-print a JSON-looking string; leave anything else untouched. Shared by
+// the argument and output renderers so both read consistently.
+function prettyJsonish(text: string): string {
+  const trimmed = text.trimStart()
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      return JSON.stringify(JSON.parse(text), null, 2)
+    } catch {
+      // not valid JSON — show as-is
+    }
+  }
+  return text
+}
+
+// Reduce a tool-call output (inline string or externalised blob descriptor)
+// to display text. Large outputs (e.g. keeper_context_status) are externalised
+// to the blob store and only a ~200-char preview is persisted (#20910); the
+// chat surfaces that preview and flags it truncated. The full bytes remain in
+// the dedicated tool-call inspector via on-demand artifact hydration.
+function toolOutputDisplay(
+  output: string | ToolCallOutputBlob,
+): { text: string; truncated: boolean } {
+  if (typeof output === 'object' && output !== null && '_blob' in output) {
+    return { text: prettyJsonish(output._blob.preview), truncated: true }
+  }
+  return { text: prettyJsonish(typeof output === 'string' ? output : ''), truncated: false }
+}
+
+const EMPTY_ARG_TEXTS = new Set(['', '{}', '[]'])
+const TOOL_BUBBLE_PREVIEW_MAX = 120
+
 // Compact collapsible card for tool call entries in the chat transcript.
 function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
   const [expanded, setExpanded] = useState(false)
   const timestamp = timeLabel(entry.timestamp)
   const toolName = entry.label || 'tool'
-  const argsText = entry.text || ''
-  const isJson = argsText.trimStart().startsWith('{') || argsText.trimStart().startsWith('[')
-  let displayText = argsText
-  if (isJson) {
-    try {
-      displayText = JSON.stringify(JSON.parse(argsText), null, 2)
-    } catch {
-      // keep original
-    }
-  }
-  const preview = displayText.length > 120 ? displayText.slice(0, 120) + '...' : displayText
+  const displayArgs = prettyJsonish(entry.text || '')
+  const hasArgs = !EMPTY_ARG_TEXTS.has(displayArgs.trim())
+
+  // Tool results never travel on the chat stream — they are joined here from
+  // the tool-call output store by this row's id (`tool-<tool_use_id>`). Null
+  // until that hydration lands, or for rows whose call had no provider id.
+  const outputEntry = lookupToolCallOutput(entry.id)
+  const outputView = outputEntry ? toolOutputDisplay(outputEntry.output) : null
+  const hasOutput = outputView !== null && outputView.text.trim() !== ''
+
+  // Collapsed glance prefers the result (the useful part for no-argument tools
+  // like keeper_context_status, whose args are just `{}`); falls back to the
+  // arguments until the output arrives.
+  const previewSource = hasOutput ? outputView.text : displayArgs
+  const preview =
+    previewSource.length > TOOL_BUBBLE_PREVIEW_MAX
+      ? previewSource.slice(0, TOOL_BUBBLE_PREVIEW_MAX) + '...'
+      : previewSource
 
   return html`
     <article
@@ -617,6 +657,13 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       >
         <span class="inline-flex size-5 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] text-3xs font-mono font-bold text-[var(--color-fg-muted)]">T</span>
         <span class="font-mono text-xs font-medium text-[var(--color-accent-fg)] truncate">${toolName}</span>
+        ${outputEntry
+          ? html`<span
+              class=${`text-2xs ${outputEntry.success ? 'text-[var(--color-ok-fg)]' : 'text-[var(--color-status-err)]'}`}
+              title=${outputEntry.success ? 'tool succeeded' : 'tool failed'}
+              aria-label=${outputEntry.success ? 'tool succeeded' : 'tool failed'}
+            >${outputEntry.success ? '✓' : '✗'}</span>`
+          : null}
         ${timestamp
           ? html`<span class="ml-auto text-2xs tabular-nums text-[var(--color-fg-muted)]">${timestamp}</span>`
           : null}
@@ -624,8 +671,31 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       </button>
       ${expanded
         ? html`
-            <div class="border-t border-[var(--color-border-default)] px-3 py-2">
-              <pre class="text-2xs font-mono whitespace-pre-wrap break-all text-[var(--color-fg-secondary)] max-h-64 overflow-y-auto">${displayText}</pre>
+            <div class="flex flex-col gap-2 border-t border-[var(--color-border-default)] px-3 py-2">
+              ${hasArgs
+                ? html`
+                    <div>
+                      <div class="mb-1 text-3xs font-semibold uppercase tracking-5 text-[var(--color-fg-muted)]">arguments</div>
+                      <pre class="text-2xs font-mono whitespace-pre-wrap break-all text-[var(--color-fg-secondary)] max-h-48 overflow-y-auto">${displayArgs}</pre>
+                    </div>
+                  `
+                : null}
+              ${hasOutput
+                ? html`
+                    <div>
+                      <div class="mb-1 flex items-center gap-1 text-3xs font-semibold uppercase tracking-5 text-[var(--color-fg-muted)]">
+                        <span>output</span>
+                        ${outputView.truncated
+                          ? html`<span class="font-normal normal-case text-[var(--color-fg-muted)]">· truncated, see tool inspector</span>`
+                          : null}
+                      </div>
+                      <pre class="text-2xs font-mono whitespace-pre-wrap break-all text-[var(--color-fg-secondary)] max-h-64 overflow-y-auto">${outputView.text}</pre>
+                    </div>
+                  `
+                : null}
+              ${!hasArgs && !hasOutput
+                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">출력 대기 중…</div>`
+                : null}
             </div>
           `
         : html`

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -9,6 +9,8 @@ import {
   queuedKeeperMessageToReply,
   streamKeeperMessage,
 } from './api/keeper'
+import { fetchKeeperToolCalls } from './api/dashboard'
+import { recordToolCallOutputs } from './tool-call-output-store'
 import { asString, isRecord } from './components/common/normalize'
 import { invalidateDashboardCache, refreshDashboard } from './store'
 import { isAbortError } from './lib/async-state'
@@ -163,6 +165,11 @@ export async function hydrateKeeperChatHistory(
     const history = await fetchKeeperChatHistory(keeperName)
     if (history.length === 0) return
     mergeServerHistoryEntries(keeperName, chatHistoryEntriesFromRest(keeperName, history))
+    // Tool outputs live on a separate surface (the chat stream carries only
+    // arguments); fetch them so ToolCallBubble can show results. Fire-and-
+    // forget so transcript hydration latency is unchanged, and the store
+    // update re-renders the affected bubbles when it lands.
+    void hydrateKeeperToolOutputs(keeperName)
   } catch (err) {
     // Allow a later mount to retry instead of caching the failure.
     hydratedChatKeepers.delete(keeperName)
@@ -171,6 +178,24 @@ export async function hydrateKeeperChatHistory(
     setRecordValue(keeperActionErrors, keeperName, `이전 대화 불러오기 실패: ${message}`)
   } finally {
     setRecordValue(keeperHydrating, keeperName, false)
+  }
+}
+
+// Recent-window size for the tool-call output fetch; mirrors the inspector's
+// fetchKeeperToolCalls(name, 100) so the chat join covers the same horizon.
+const TOOL_OUTPUT_FETCH_LIMIT = 100
+
+/** Best-effort hydration of tool-call outputs into the shared store so the
+ *  chat ToolCallBubble can join results onto transcript rows by tool_use_id.
+ *  Failures are swallowed (logged): the transcript must render with or without
+ *  tool outputs. */
+async function hydrateKeeperToolOutputs(keeperName: string): Promise<void> {
+  try {
+    const response = await fetchKeeperToolCalls(keeperName, TOOL_OUTPUT_FETCH_LIMIT)
+    recordToolCallOutputs(response.entries)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.warn(`[keeper] tool-call output hydration failed for ${keeperName}:`, message)
   }
 }
 

--- a/dashboard/src/tool-call-output-store.test.ts
+++ b/dashboard/src/tool-call-output-store.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { ToolCallEntry } from './api/dashboard'
+import {
+  lookupToolCallOutput,
+  recordToolCallOutputs,
+  resetToolCallOutputs,
+  toolCallOutputsById,
+} from './tool-call-output-store'
+
+function toolCall(overrides: Partial<ToolCallEntry> = {}): ToolCallEntry {
+  return {
+    ts: 0,
+    keeper: 'sangsu',
+    tool: 'keeper_context_status',
+    input: {},
+    output: 'context ok',
+    success: true,
+    duration_ms: 12,
+    ...overrides,
+  }
+}
+
+describe('tool-call-output-store', () => {
+  afterEach(() => {
+    resetToolCallOutputs()
+  })
+
+  it('records entries keyed by tool_use_id', () => {
+    recordToolCallOutputs([toolCall({ tool_use_id: 'toolu_abc', output: 'hello' })])
+    expect(toolCallOutputsById.value.get('toolu_abc')?.output).toBe('hello')
+  })
+
+  it('looks up by the chat entry id, stripping the tool- prefix', () => {
+    recordToolCallOutputs([toolCall({ tool_use_id: 'toolu_abc', output: 'hello' })])
+    expect(lookupToolCallOutput('tool-toolu_abc')?.output).toBe('hello')
+  })
+
+  it('looks up by a bare tool_use_id (no prefix) as well', () => {
+    recordToolCallOutputs([toolCall({ tool_use_id: 'toolu_abc', output: 'hello' })])
+    expect(lookupToolCallOutput('toolu_abc')?.output).toBe('hello')
+  })
+
+  it('returns null for an unknown id', () => {
+    recordToolCallOutputs([toolCall({ tool_use_id: 'toolu_abc' })])
+    expect(lookupToolCallOutput('tool-missing')).toBeNull()
+  })
+
+  it('skips entries without a tool_use_id (no stable join key)', () => {
+    recordToolCallOutputs([toolCall({ tool_use_id: undefined })])
+    expect(toolCallOutputsById.value.size).toBe(0)
+  })
+
+  it('overwrites an earlier entry for the same id (idempotent re-hydration)', () => {
+    recordToolCallOutputs([toolCall({ tool_use_id: 'toolu_abc', output: 'first' })])
+    recordToolCallOutputs([toolCall({ tool_use_id: 'toolu_abc', output: 'second' })])
+    expect(lookupToolCallOutput('tool-toolu_abc')?.output).toBe('second')
+  })
+
+  it('replaces the map reference on change so signal subscribers re-render', () => {
+    const before = toolCallOutputsById.value
+    recordToolCallOutputs([toolCall({ tool_use_id: 'toolu_abc' })])
+    expect(toolCallOutputsById.value).not.toBe(before)
+  })
+
+  it('does not replace the map reference when nothing changed', () => {
+    const before = toolCallOutputsById.value
+    recordToolCallOutputs([toolCall({ tool_use_id: undefined })])
+    expect(toolCallOutputsById.value).toBe(before)
+  })
+
+  it('preserves an externalised blob output descriptor', () => {
+    recordToolCallOutputs([
+      toolCall({
+        tool_use_id: 'toolu_blob',
+        output: { _blob: { sha256: 'abc', bytes: 9000, mime: 'application/json', preview: 'preview…' } },
+      }),
+    ])
+    const stored = lookupToolCallOutput('tool-toolu_blob')?.output
+    expect(typeof stored).toBe('object')
+    expect(stored).toMatchObject({ _blob: { preview: 'preview…' } })
+  })
+})

--- a/dashboard/src/tool-call-output-store.ts
+++ b/dashboard/src/tool-call-output-store.ts
@@ -1,0 +1,55 @@
+// Tool-call output store.
+//
+// The keeper chat stream never carries tool *results* — TOOL_CALL_END only
+// flips a row to "delivered" (keeper-stream.ts), and the persisted chat
+// history row holds the arguments only (keeper_chat_store). The output lives
+// on a separate surface, GET /api/v1/keepers/:name/tool-calls, keyed by the
+// provider-minted tool_use_id (RFC-0233 PR-2). That id is globally unique and
+// equals the chat tool row's tool_call_id for the same execution
+// (keeper_chat_store.normalize_tool_call_id passes a non-empty call id through
+// verbatim), so a single global id→entry map lets the chat ToolCallBubble
+// derive its output by stripping the `tool-` prefix off its entry id. No
+// per-keeper scoping is needed because tool_use_ids do not collide across
+// keepers.
+import { signal } from '@preact/signals'
+import type { ToolCallEntry } from './api/dashboard'
+
+// Chat tool entries id their rows `tool-<tool_call_id>` on both the live
+// stream and history paths (keeper-stream.ts / keeper-state.ts).
+const TOOL_ENTRY_ID_PREFIX = 'tool-'
+
+// Global join table: tool_use_id → the tool-call IO entry (input + output).
+// Replaced (not mutated) on each merge so signal subscribers re-render.
+export const toolCallOutputsById = signal<Map<string, ToolCallEntry>>(new Map())
+
+/** Merge tool-call entries into the store, keyed by tool_use_id. Entries
+ *  without a tool_use_id are skipped — they have no stable join key to the
+ *  chat transcript (and their output was not persisted either, since the log
+ *  only writes tool_use_id when non-empty). A later fetch overwrites an
+ *  earlier entry for the same id, so re-hydration stays idempotent. */
+export function recordToolCallOutputs(entries: readonly ToolCallEntry[]): void {
+  let changed = false
+  const next = new Map(toolCallOutputsById.value)
+  for (const entry of entries) {
+    if (!entry.tool_use_id) continue
+    next.set(entry.tool_use_id, entry)
+    changed = true
+  }
+  if (changed) toolCallOutputsById.value = next
+}
+
+/** Look up the tool-call IO entry for a chat tool row by its entry id
+ *  (`tool-<tool_use_id>`). Returns null until the tool-call hydration lands,
+ *  or for rows whose call carried no provider id. Reads the signal value, so
+ *  a component calling this during render subscribes to store updates. */
+export function lookupToolCallOutput(toolEntryId: string): ToolCallEntry | null {
+  const toolUseId = toolEntryId.startsWith(TOOL_ENTRY_ID_PREFIX)
+    ? toolEntryId.slice(TOOL_ENTRY_ID_PREFIX.length)
+    : toolEntryId
+  return toolCallOutputsById.value.get(toolUseId) ?? null
+}
+
+/** Test/teardown helper: drop all recorded outputs. */
+export function resetToolCallOutputs(): void {
+  toolCallOutputsById.value = new Map()
+}


### PR DESCRIPTION
## Summary

The keeper chat transcript's tool-call bubbles rendered only the tool
**arguments**. For no-argument tools (`keeper_context_status`,
`keeper_tools_list`) that meant the card showed `{}` and nothing else — there
was no way to see what the tool returned. This surfaces the **output** in the
chat bubble.

## Why output was missing

- The chat stream never carries tool results: `TOOL_CALL_END` only flips the
  row to `delivered` (keeper-stream.ts).
- The persisted chat-history row holds the arguments only (keeper_chat_store).
- Tool output lives on a separate surface, `GET
  /api/v1/keepers/:name/tool-calls`, keyed by the provider `tool_use_id`
  (RFC-0233 PR-2).

So the bubble had no output to render. The fix joins the two surfaces.

## Change (frontend only — no backend change)

The chat tool entry id is `tool-<tool_call_id>`; the tool-call log entry carries
the same id as `tool_use_id`. The `/tool-calls` response already includes
`tool_use_id` (raw JSONL passthrough) — the frontend just never decoded it.

- **api/dashboard.ts** — decode `tool_use_id` on `ToolCallEntry`.
- **tool-call-output-store.ts** (new) — a global `tool_use_id -> entry` signal
  map. `tool_use_id` is globally unique (no keeper scoping). The map is replaced
  (not mutated) on merge so signal subscribers re-render; lookup strips the
  `tool-` prefix off a chat entry id.
- **keeper-actions.ts** — best-effort, fire-and-forget tool-call hydration on
  chat-history load. Because every refresh path (mount, `keeper_chat_appended`
  debounce, recovery) routes through `hydrateKeeperChatHistory`, one call site
  covers them all. A failed fetch is logged and swallowed — the transcript
  renders with or without outputs.
- **primitives.ts `ToolCallBubble`** — expanded view shows labelled
  `arguments` + `output` sections; the collapsed glance prefers the result (the
  useful part for no-arg tools whose args are just `{}`) and falls back to args
  until output lands; a ✓/✗ glyph reflects success; externalised blob outputs
  (e.g. `keeper_context_status`, #20910) show the persisted preview flagged
  truncated, with the full bytes still reachable via the dedicated tool-call
  inspector.

Output always arrives **after** the bubble mounts, so the bubble derives output
from the store by key at render time — the same kind of derive it already does
for `displayText` from `entry.text` — rather than mutating late results onto the
immutable entry on every poll.

## Verification against live data

Joined real `.masc` data: **58 of 82** `keeper_context_status` /
`keeper_tools_list` chat tool rows match a `tool_use_id` in the tool-call log,
and **all 58 matched rows have non-empty output** (`keeper_context_status`
inline string ~1.7 KB; `keeper_tools_list` externalised blob with a ~349-byte
preview of `{"ok":true,"result":{"workspace":[...]}}`). The 24 unmatched are
older rows outside the recent fetch window — they degrade gracefully (args /
waiting hint), never worse than today.

## Tests

- Store unit tests: record/lookup, `tool-` prefix + bare lookup, skip entries
  without a `tool_use_id`, idempotent overwrite, reference-replace-on-change,
  blob descriptor preserved.
- `ToolCallBubble`: join surfaces output in the collapsed preview, ✓/✗ status,
  args fallback with no status until output arrives, labelled args+output when
  expanded, waiting hint for a no-arg tool with no output yet, and **late-arrival
  re-render** (renders before output, records after, asserts the bubble updates
  — proves the signal subscription).
- `tsc --noEmit` + `eslint src` clean; full dashboard vitest **6676 green**.

## Notes / known bounds

The output store grows per browser session, bounded by distinct `tool_use_id`s
fetched (100 per keeper per hydration, overwritten by id). Realistically a few
thousand small entries — matches the dashboard's existing per-session signal
memory model.

RFC-WAIVED: dashboard chat transcript rendering only — no
credential / identity / sandbox / operator-control / hooks change; not in the
agent-delegation RFC-gated subsystem list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
