### PR TITLE
fix(keeper): recency-gate cross-keeper consolidation so stale agreements fade

### DIFF
--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -19,6 +19,7 @@
 open Keeper_memory_os_types
 
 module Io = Keeper_memory_os_io
+module Policy = Keeper_memory_os_policy
 
 (* Which categories are objective enough to share across keepers is a
    compile-time property of the closed [category] taxonomy
@@ -38,6 +39,34 @@ let default_confidence_threshold = 0.5
    the smallest set that distinguishes corroboration from a single keeper's echo
    (RFC-0244 §2.2). *)
 let default_min_keepers = 2
+
+(* A shared fact must reflect CURRENTLY-affirmed corroboration, not a one-time
+   historical agreement. Each contributor's confidence is discounted by how long
+   ago it was last verified ([Policy.truth_recency_factor], anchored on
+   [last_verified_at]); an observation no keeper has re-affirmed decays below the
+   [threshold] and the claim drops out of the shared tier on the next sweep —
+   without deleting anything, since each sweep rebuilds [_shared] wholesale.
+
+   This wires into consolidation the truth-recency that recall scoring already
+   applied. Eligibility previously gated on RAW [confidence] only, so a one-time
+   agreement at confidence 1.0 stayed eligible forever: stale coordination
+   boilerplate (mislabelled [Fact] before the librarian taxonomy fix) was
+   re-promoted on every sweep and never left the shared store. *)
+let default_promotion_recency_days = 2.0
+
+(* 1/e decay over [days] (the [Policy.default_truth_lambda] convention),
+   env-overridable. Shorter than recall's 30-day truth horizon: the shared tier
+   is a strong cross-agent claim, so it should require more recent
+   re-affirmation. Non-positive overrides fall back to the default. *)
+let promotion_recency_lambda () =
+  let days =
+    Keeper_memory_bank_env.memory_env_float_logged
+      "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RECENCY_DAYS"
+      ~default:default_promotion_recency_days
+  in
+  let days = if days > 0.0 then days else default_promotion_recency_days in
+  1.0 /. (86400.0 *. days)
+;;
 
 let clamp01 v = Float.max 0.0 (Float.min 1.0 v)
 
@@ -59,8 +88,9 @@ type contribution =
   ; fact : fact
   }
 
-let eligible ~threshold fact =
-  fact.confidence >= threshold && is_promotable fact.category
+let eligible ~recency_lambda ~now ~threshold fact =
+  fact.confidence *. Policy.truth_recency_factor ~lambda:recency_lambda ~now fact >= threshold
+  && is_promotable fact.category
 ;;
 
 (* Pick the representative fact for a claim group: highest confidence, then
@@ -141,12 +171,13 @@ let promote_facts
       ~keeper_facts
       ()
   =
+  let recency_lambda = promotion_recency_lambda () in
   let groups : (string, contribution list) Hashtbl.t = Hashtbl.create 256 in
   List.iter
     (fun (keeper_id, facts) ->
        List.iter
          (fun fact ->
-            if eligible ~threshold fact
+            if eligible ~recency_lambda ~now ~threshold fact
             then (
               let key = normalize_claim fact.claim in
               let prev = Option.value (Hashtbl.find_opt groups key) ~default:[] in

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -2102,6 +2102,37 @@ let test_consolidator_below_threshold_excluded () =
   Alcotest.(check int) "below-threshold contributor excluded" 0 (List.length shared)
 ;;
 
+(* A shared fact must reflect recent corroboration. A contributor whose
+   [last_verified_at] is old has its confidence decayed below the floor by
+   [Policy.truth_recency_factor], so a 2-keeper claim with one stale contributor
+   is not promoted — even at raw confidence 1.0. The same claim with two FRESH
+   contributors promotes, proving the gate is recency, not the claim text. *)
+let test_consolidator_stale_contributor_excluded () =
+  let now = 2_000_000.0 in
+  let fresh c = mk_shared_fixture ~now ~confidence:1.0 c in
+  let stale c =
+    { (mk_shared_fixture ~now ~confidence:1.0 c) with
+      Types.last_verified_at = Some (now -. days 5)
+    }
+  in
+  let stale_pair =
+    [ "alpha", [ fresh "recency gated claim" ]; "beta", [ stale "recency gated claim" ] ]
+  in
+  let _c, shared_stale = Consolidator.promote_facts ~now ~keeper_facts:stale_pair () in
+  Alcotest.(check int)
+    "stale contributor does not corroborate (not promoted)"
+    0
+    (List.length shared_stale);
+  let fresh_pair =
+    [ "alpha", [ fresh "recency gated claim" ]; "beta", [ fresh "recency gated claim" ] ]
+  in
+  let _c2, shared_fresh = Consolidator.promote_facts ~now ~keeper_facts:fresh_pair () in
+  Alcotest.(check int)
+    "the same claim with two fresh contributors promotes (gate is recency, not claim)"
+    1
+    (List.length shared_fresh)
+;;
+
 (* Output is a deterministic function of the input: keeper input order does not
    change the result (observed_by sorted, claim order sorted). *)
 let test_consolidator_deterministic () =
@@ -2666,6 +2697,10 @@ let () =
             "below-threshold contributor excluded"
             `Quick
             test_consolidator_below_threshold_excluded
+        ; Alcotest.test_case
+            "stale contributor excluded (truth-recency promotion gate)"
+            `Quick
+            test_consolidator_stale_contributor_excluded
         ; Alcotest.test_case
             "deterministic regardless of input order"
             `Quick


### PR DESCRIPTION
## 목적

cross-keeper consolidation의 `eligible`이 raw `confidence`만 보고 승격을 결정해서, **한 번 합의된 claim이 confidence 1.0이면 영원히 eligible**이었습니다. 그 결과 14:39 librarian taxonomy 수정 *이전*에 `fact`로 잘못 라벨된 coordination boilerplate가 매 sweep마다 `_shared`로 재승격되어 공유 메모리에서 영영 사라지지 않았습니다 (`_shared` 17개가 100% boilerplate).

이 PR은 각 contributor의 confidence를 `Policy.truth_recency_factor`(`last_verified_at` 기준)로 할인합니다. 어떤 keeper도 최근 재확인하지 않은 관측은 floor 아래로 감쇠하여, 다음 sweep에서 claim이 `_shared`에서 탈락합니다 — 삭제 없이 (sweep이 `_shared`를 매번 통째로 재구성하므로). recall scoring이 이미 쓰던 truth-recency를 promotion 경계에 배선 = 죽어있던 stale 처리를 되살림 (리포트의 "stale 해결 전무" 결함).

half-life는 env-overridable (`MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RECENCY_DAYS`, 기본 2일), recall의 30일보다 짧음 — 공유 cross-agent claim은 더 최근 재확인을 요구해야 하므로.

## 라이브 데이터 측정 (read-only dry-run, 같은 store·같은 바이너리 A/B)

```
BEFORE (raw confidence, ≈ 기존 동작): would_promote=17, claims_considered=5044
AFTER  (2-day recency gate):          would_promote=9,  claims_considered=2203
```

`BEFORE=17`이 실제 라이브 `_shared`(17)와 정확히 일치 = A/B 충실성 자기검증. 탈락한 8개는 전부 stale boilerplate ("board curation submitted" 4변형, "no claimable/unclaimed tasks", "desire/intention/blocker/need all none", "warned about keeper_stay_silent").

## 정직한 한계 (이 PR이 _shared를 "고치지" 않음)

47% 감소이지만 **부분적**입니다. 살아남은 9개 중 7개가 여전히 checkpoint boilerplate ("checkpoint saved / remains scheduled" 변형)입니다 — checkpoint는 모든 keeper가 매 cycle 저장해 *항상 fresh하게* 재corroborate되므로 recency로는 못 막습니다. 이 잔존분은 producer 라벨링이 처리해야 하고(14:39 프롬프트가 신규 checkpoint를 ephemeral로 라벨), 그 producer fix(유입 차단) + 이 recency gate(기존 backlog를 ~1.4일 지평에서 노화 탈락)가 **함께** durable-only로 수렴하는 구조입니다. 다만 수렴 자체는 아직 증명되지 않았습니다 (내일 라이브 관측 또는 future-`now` 시뮬 필요). 지금의 9는 수렴 중 스냅샷으로 해석.

## 변경

- `lib/keeper/keeper_memory_os_consolidator.ml`: `eligible`을 recency-가중 effective confidence로 (per-keeper noisy-OR는 raw 유지 — 승격된 fact는 fresh 재확인됨). env lambda는 sweep당 1회 계산.
- `test/test_keeper_memory_os.ml`: stale contributor 제외 + 같은 claim이 두 fresh contributor면 승격(게이트가 recency지 claim이 아님 증명). 68/68 green.

기존 consolidator 테스트 전부 유지 (recent-fixture facts는 2일 recency에 영향 없음).

RFC-0244/0247 (memory-os) 계열. 결정론적, string 매칭 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
