### PR TITLE
fix(dashboard): label chat tool-call args as input, mark empty {} no-args

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -49,6 +49,48 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('[data-chat-delivery="saved"]')).not.toBeNull()
   })
 
+  it('renders no-argument tool call (args "{}") as "입력 없음", not a bare {}', () => {
+    // Regression: keeper_tools_list streams args `{}` (no params). The old
+    // ToolCallBubble rendered `T keeper_tools_list ▸ {}`, which read as an
+    // empty RESULT. The fix labels args as "입력" and renders `{}` as
+    // "입력 없음" so operators do not mistake a no-arg call for a no-result call.
+    render(
+      html`<${ChatTranscript}
+        entries=${[entry({
+          id: 'tool-1',
+          role: 'tool',
+          source: 'tool_result',
+          label: 'keeper_tools_list',
+          text: '{}',
+        })]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+    expect(container.textContent).toContain('keeper_tools_list')
+    expect(container.textContent).toContain('입력')
+    expect(container.textContent).toContain('입력 없음')
+  })
+
+  it('labels tool-call arguments as "입력" and shows the arg JSON', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[entry({
+          id: 'tool-2',
+          role: 'tool',
+          source: 'tool_result',
+          label: 'keeper_board_post',
+          text: '{"title":"hi"}',
+        })]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+    expect(container.textContent).toContain('입력')
+    expect(container.textContent).toContain('keeper_board_post')
+    expect(container.textContent).toContain('"title"')
+  })
+
   it('hides saved badges in messenger mode but keeps live state badges', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -588,12 +588,26 @@ function ChatMessageBubble({
 }
 
 // Compact collapsible card for tool call entries in the chat transcript.
+// `entry.text` carries the tool call's INPUT arguments only — accumulated
+// arg JSON from TOOL_CALL_ARGS (keeper-stream.ts) or the persisted arg row
+// (keeper-state.ts:507 "text = accumulated argument JSON"). The tool's
+// OUTPUT (result) is NOT in this entry; it lands in the live trace via
+// `appendLiveToolCall` (sse.ts) and renders in the trace / activity panels.
+// Without an explicit "입력" (input) label and an empty-args marker, a
+// no-argument tool like keeper_tools_list renders as `▸ {}`, which reads as
+// "empty result". This surface labels args as input and renders `{}` as
+// "입력 없음". Root fix (chat stream tool_result event so the result renders
+// inline) is tracked separately as Step 2.
 function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
   const [expanded, setExpanded] = useState(false)
   const timestamp = timeLabel(entry.timestamp)
   const toolName = entry.label || 'tool'
   const argsText = entry.text || ''
-  const isJson = argsText.trimStart().startsWith('{') || argsText.trimStart().startsWith('[')
+  const trimmed = argsText.trim()
+  // No-argument tools stream `{}` or empty text; render as "입력 없음"
+  // instead of a bare `{}` that reads as an empty result.
+  const isEmptyArgs = trimmed === '' || trimmed === '{}'
+  const isJson = !isEmptyArgs && (trimmed.startsWith('{') || trimmed.startsWith('['))
   let displayText = argsText
   if (isJson) {
     try {
@@ -602,7 +616,9 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       // keep original
     }
   }
-  const preview = displayText.length > 120 ? displayText.slice(0, 120) + '...' : displayText
+  const preview = isEmptyArgs
+    ? '입력 없음'
+    : (displayText.length > 120 ? displayText.slice(0, 120) + '...' : displayText)
 
   return html`
     <article
@@ -617,6 +633,7 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       >
         <span class="inline-flex size-5 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] text-3xs font-mono font-bold text-[var(--color-fg-muted)]">T</span>
         <span class="font-mono text-xs font-medium text-[var(--color-accent-fg)] truncate">${toolName}</span>
+        <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] px-1.5 py-0.5 text-3xs font-medium text-[var(--color-fg-muted)]">입력</span>
         ${timestamp
           ? html`<span class="ml-auto text-2xs tabular-nums text-[var(--color-fg-muted)]">${timestamp}</span>`
           : null}
@@ -625,7 +642,11 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       ${expanded
         ? html`
             <div class="border-t border-[var(--color-border-default)] px-3 py-2">
-              <pre class="text-2xs font-mono whitespace-pre-wrap break-all text-[var(--color-fg-secondary)] max-h-64 overflow-y-auto">${displayText}</pre>
+              ${isEmptyArgs
+                ? html`<div class="text-2xs font-mono text-[var(--color-fg-muted)]">입력 없음 (매개변수가 없는 도구)</div>`
+                : html`<pre class="text-2xs font-mono whitespace-pre-wrap break-all text-[var(--color-fg-secondary)] max-h-64 overflow-y-auto">${displayText}</pre>`
+              }
+              <div class="mt-2 text-3xs text-[var(--color-fg-muted)]">출력(결과)은 도구 실행 추적 패널에서 확인</div>
             </div>
           `
         : html`


### PR DESCRIPTION
## 배경

대시보드 chat transcript에서 keeper 도구 호출이 빈 `{}`로 표시되어, keeper가 자기 도구를 못 받는 것처럼 보이는 현상을 수정합니다.

## 원인 (코드 기반 진단)

`ToolCallBubble`(`chat/primitives.ts`)이 `entry.text`를 그대로 렌더링했습니다. 이 필드는 도구 호출의 **입력 args**만 담습니다:

- 실시간: `TOOL_CALL_ARGS` 이벤트로 누적된 arg JSON (`keeper-stream.ts:89-99`)
- history 로드: 영속화된 arg row (`keeper-state.ts:507` 주석 "text = accumulated argument JSON")

**출력(result)은 이 entry에 결코 들어오지 않습니다.** result는 `sse.ts:613-624`의 `appendLiveToolCall` → live trace로 갑니다.

입력이 없는 도구(예: `keeper_tools_list`)는 args `{}`를 스트리밍하므로, `T keeper_tools_list ▸ {}`로 표시되었고 이게 빈 결과로 오해되었습니다.

라이브 로그 검증: keeper 도구 응답은 항상 344바이트 이상(`keeper_tools_list` 344B, `keeper_context_status` 344~1994B, 전 기간 전수). 빈 응답을 반환한 적이 없습니다. 즉 keeper 도구 결함이 아니라 **대시보드 표시 문제**였습니다.

## 변경 (Step 1)

- `entry.text`를 **"입력"** 라벨과 함께 표시
- 빈 args `{}` / `""` → **"입력 없음 (매개변수가 없는 도구)"** 렌더링 (bare `{}` 대신)
- expanded 상태에서 **"출력(결과)은 도구 실행 추적 패널에서 확인"** 안내
- 결함 배경/근본을 코드 주석으로 명시

## 검증

- `vitest primitives.test.ts`: **18 passed** (기존 16 + 신규 2 — no-arg → "입력 없음", arg → "입력"+JSON)
- `vitest primitives.a11y.test.ts`: **5 passed** (접근성 회귀 없음)
- `tsc --noEmit`: **EXIT 0** (`--listFiles`로 primitives 3개 파일 실제 검사 확인)

## 한계 + Step 2 (근본, 별도 PR/RFC)

Step 1은 `{}` 오해를 해소하지, chat에서 결과를 직접 보여주지는 않습니다. 결과는 여전히 추적 패널에만 있습니다.

**Step 2** (별도): 백엔드 `server_routes_http_keeper_stream.ml`에 `Tool_call_result { tool_call_id; content }` chat-stream 이벤트 추가 → `keeper-stream.ts`에서 entry의 result 갱신 → `KeeperConversationEntry`에 `toolResult` 필드 → `ToolCallBubble`에 "결과" 영역 분리 렌더링. 백엔드(OCaml) + 프론트 3-4파일, SSE 흐름 변경이라 RFC 후 진행 예정.

## 체크

- RFC: dashboard chat UI는 RFC 강제 subsystem(credential / repo / operator / sandbox / hooks / workflow)에 해당하지 않음. 해당 없음.
- Workaround: 아님. 빈 응답을 암묵적으로 삼키던 표시 결함(입력/출력 불구분)을 명시적으로 처리.

Co-Authored-By: Claude <noreply@anthropic.com>
