### PR TITLE
fix(board): stop leaking show_board_error into HTTP/MCP error surfaces (7 sites)

### DIFF
--- a/lib/board_tool_adapter/board_tool_sub_board.ml
+++ b/lib/board_tool_adapter/board_tool_sub_board.ml
@@ -48,11 +48,7 @@ let handle_sub_board_create ~tool_name ~start_time args : Tool_result.result =
            (Printf.sprintf "SubBoard created: %s (/%s)" sb.Board.name sb.Board.slug))
       ()
   | Error e ->
-    Tool_result.make_err
-      ~tool_name
-      ~class_:Tool_result.Workflow_rejection
-      ~start_time
-      (Board.show_board_error e)
+    Board_tool_format.error_of_board_error ~tool_name ~start_time e
 ;;
 
 let handle_sub_board_list ~tool_name ~start_time _args : Tool_result.result =
@@ -100,11 +96,7 @@ let handle_sub_board_get ~tool_name ~start_time args : Tool_result.result =
               sb.post_count))
       ()
   | Error e ->
-    Tool_result.make_err
-      ~tool_name
-      ~class_:Tool_result.Workflow_rejection
-      ~start_time
-      (Board.show_board_error e)
+    Board_tool_format.error_of_board_error ~tool_name ~start_time e
 ;;
 
 let handle_sub_board_update ~tool_name ~start_time args : Tool_result.result =
@@ -139,11 +131,7 @@ let handle_sub_board_update ~tool_name ~start_time args : Tool_result.result =
            (Printf.sprintf "SubBoard updated: %s (/%s)" sb.Board.name sb.Board.slug))
       ()
   | Error e ->
-    Tool_result.make_err
-      ~tool_name
-      ~class_:Tool_result.Workflow_rejection
-      ~start_time
-      (Board.show_board_error e)
+    Board_tool_format.error_of_board_error ~tool_name ~start_time e
 ;;
 
 let handle_sub_board_delete ~tool_name ~start_time args : Tool_result.result =
@@ -156,9 +144,5 @@ let handle_sub_board_delete ~tool_name ~start_time args : Tool_result.result =
       ~data:(`String (Printf.sprintf "SubBoard deleted: %s" sub_board_id))
       ()
   | Error e ->
-    Tool_result.make_err
-      ~tool_name
-      ~class_:Tool_result.Workflow_rejection
-      ~start_time
-      (Board.show_board_error e)
+    Board_tool_format.error_of_board_error ~tool_name ~start_time e
 ;;

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -321,7 +321,7 @@ let add_delete_action_routes router =
              | Ok () -> respond_ok ~request:req reqd
              | Error err ->
                  respond_error ~status:`Not_found ~request:req reqd
-                   (Board_types.show_board_error err)
+                   (Board_tool.board_error_to_string err)
            with Yojson.Json_error _ ->
              respond_error ~request:req reqd (invalid_request "post_id")
          )
@@ -345,7 +345,7 @@ let add_delete_action_routes router =
              | Ok () -> respond_ok ~request:req reqd
              | Error err ->
                  respond_error ~status:`Not_found ~request:req reqd
-                   (Board_types.show_board_error err)
+                   (Board_tool.board_error_to_string err)
            with Yojson.Json_error _ ->
              respond_error ~request:req reqd (invalid_request "post_id")
          )
@@ -584,7 +584,7 @@ let add_delete_action_routes router =
                                      (match Board_dispatch.delete_post ~post_id:target_id with
                                       | Ok () -> None
                                       | Error e ->
-                                          Some (Board_types.show_board_error e))
+                                          Some (Board_tool.board_error_to_string e))
                                  | Board_moderation.Target_comment ->
                                      (* Comment removal not yet backed by dispatch; note only *)
                                      None)


### PR DESCRIPTION
## 배경 — #2(#21286)와 동일 패턴 (show 누출)

탐색 sweep에서 찾은, 방금 머지된 404 fix와 **같은 누출** 7곳입니다. `show_board_error`는 `[@@deriving show]` 프린터라, 계약 경계(HTTP body, MCP tool result)에 넣으면 내부 OCaml 생성자명(`Post_not_found("p-abc")`)이 노출됩니다.

## 변경 (7 사이트)

### HTTP (3) — `server_dashboard_http_delete_actions.ml`
| 라인 | 라우트 |
|------|--------|
| :324 | `POST /api/v1/dashboard/board/delete` |
| :348 | `POST /api/v1/dashboard/board/pin` |
| :587 | moderation Remove → `delete_warning` |

`respond_error`가 메시지를 HTTP JSON `error` 필드에 넣으므로 → `Board_tool.board_error_to_string` 사용 (`server_routes_http_routes_activity.ml`의 기존 관습과 일치).

### MCP tool result (4) — `board_tool_sub_board.ml:55/107/146/163`
`Tool_result.make_err`에 `show_board_error` + 하드코딩된 `~class_:Workflow_rejection`을 쓰던 4개 분기를 sibling 관습 `Board_tool_format.error_of_board_error`로 교체. 이는 human 메시지 렌더 + **변형별 class 도출**(Post/Comment_not_found→Workflow_rejection, 그 외→Runtime_failure)까지 개선 (`board_tool_post.ml`/`board_tool_handlers.ml`와 동일).

## 검증
- `dune build @check` (DUNE_CACHE=disabled --root .) → PASS
- `test_board_dispatch.exe` → 60/60
- `rg show_board_error <두 파일>` → 0

워크어라운드 아님: derived show를 경계에서 제거하고 SSOT human 렌더로 교체(추가 아님). 기존 sibling 관습 준수.

RFC-WAIVED: board 에러 렌더를 기존 관습으로 통일(HTTP/MCP). credential/identity/repo_manager/operator/sandbox/hooks/workflow subsystem 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
