### PR TITLE
test(keeper-memory-os): fix broken fresh-fact recall test merged via #21303

### DIFF
--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1398,10 +1398,14 @@ let test_recall_omits_marker_for_fresh_fact () =
         match Recall.render_if_enabled ~keeper_id ~now () with
         | None -> Alcotest.fail "expected Some block for a persisted fresh fact"
         | Some block ->
+          (* Match the rendered marker's tail ("...ago — verify]"), not the bare
+             "[stale:" token — the recall wrapper prompt itself contains the
+             literal example "[stale: ... — verify]" (no age), so a looser check
+             would match the advisory prose rather than an actual fact marker. *)
           Alcotest.(check bool)
             "fresh fact carries no staleness marker"
             false
-            (contains "[stale:" block))))
+            (contains "ago — verify]" block))))
 ;;
 
 (* RFC-0244: a seed reranks recall — the lexically matching fact is lifted above a


### PR DESCRIPTION
## 목표

`main` 복구: PR #21303(recall staleness worded-age)이 컨베이어벨트 admin-merge로 **테스트 수정 직전에** 머지되어, `test_keeper_memory_os`의 `recall 8 (fresh fact)` 테스트가 깨진 채 main에 들어갔다.

## 원인

`fresh fact gets no staleness marker` 테스트가 `contains "[stale:" block`로 검사했는데, recall wrapper 프롬프트 자체가 안내 문구로 리터럴 `"[stale: ... — verify]"`를 포함한다. 따라서 fresh fact(마커 없음)에서도 wrapper 문구가 매칭되어 거짓 실패.

## 변경

assertion을 실제 렌더 마커의 꼬리 `"ago — verify]"`로 좁힌다 (wrapper 예시 문구에는 age/`ago`가 없으므로 실제 fact 마커에만 매칭). 테스트 전용, 프로덕션 코드 변경 없음.

## 검증

`dune build test/test_keeper_memory_os.exe` + 실행: **69/69 green** (recall 7 stale OK, recall 8 fresh OK).

경위: PR #21303이 머지된 뒤 push된 수정 커밋(`80965c459`)이 orphan이 되어 main에 도달하지 못함 → 본 PR로 cherry-pick 복구. 근거: masc 컨베이어벨트 admin-merge 패턴.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
