### PR TITLE
style(dashboard): migrate Connectors and Monitoring surfaces to v2 design system

### DIFF
--- a/dashboard/src/components/agent-detail-journal.ts
+++ b/dashboard/src/components/agent-detail-journal.ts
@@ -15,7 +15,7 @@ export function AgentJournalStream({ agentName }: { agentName: string }) {
     : '실시간 활동 스트림'
 
   return html`
-    <${CollapsibleSection} title=${title} mountWhenOpen=${true}>
+    <${CollapsibleSection} class="v2-monitoring-detail" title=${title} mountWhenOpen=${true}>
       ${entries.length === 0
         ? html`<${EmptyState} message="아직 활동 기록이 없습니다" compact />`
         : html`

--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -120,7 +120,7 @@ export function AgentDetailMemory({ agentName }: Props) {
   const isFilteringEpisodes = episodeQuery.value.trim() !== ''
 
   return html`
-    <${CollapsibleSection} title="협업 & 기억" mountWhenOpen=${true}>
+    <${CollapsibleSection} class="v2-monitoring-detail" title="협업 & 기억" mountWhenOpen=${true}>
       <div class="space-y-4">
         <!-- Hebbian collaboration -->
         <div>

--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -118,9 +118,9 @@ function taskEventIcon(type: string): string {
 
 function taskEventColor(type: string): string {
   switch (type) {
-    case 'task_completed': return 'text-ok'
-    case 'task_cancelled': return 'text-bad'
-    default: return 'text-accent-fg'
+    case 'task_completed': return 'text-[var(--color-status-ok)]'
+    case 'task_cancelled': return 'text-[var(--bad-light)]'
+    default: return 'text-[var(--color-accent-fg)]'
   }
 }
 
@@ -164,9 +164,9 @@ function SessionMeta({ agentName }: { agentName: string }) {
   return html`
     <div class="flex flex-wrap gap-2 mb-4">
       ${meta.map(m => html`
-        <span key=${m.label} class="inline-flex items-center gap-1.5 text-2xs font-medium py-1 px-2.5 bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] rounded-[var(--r-1)] text-text-muted">
-          <span class="text-text-dim">${m.label}</span>
-          <span class="text-text-strong font-mono text-3xs">${m.value}</span>
+        <span key=${m.label} class="inline-flex items-center gap-1.5 text-2xs font-medium py-1 px-2.5 bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] rounded-[var(--r-1)] text-[var(--color-fg-muted)]">
+          <span class="text-[var(--color-fg-muted)]">${m.label}</span>
+          <span class="text-[var(--color-fg-primary)] font-mono text-3xs">${m.value}</span>
         </span>
       `)}
     </div>
@@ -178,7 +178,7 @@ function TaskEventTimeline({ events }: { events: AgentTimelineEvent[] }) {
 
   return html`
     <div class="mt-4">
-      <div class="text-2xs font-semibold uppercase tracking-wider text-text-muted mb-2">태스크 이력</div>
+      <div class="text-2xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-2">태스크 이력</div>
       <div class="flex flex-col gap-1">
         ${events.map((evt, idx) => {
           const title = detailStr(evt.detail, 'title') || detailStr(evt.detail, 'task_id')
@@ -187,7 +187,7 @@ function TaskEventTimeline({ events }: { events: AgentTimelineEvent[] }) {
           return html`
             <div key=${idx} class="flex items-center gap-2 py-1.5 px-3 rounded-[var(--r-1)] hover:bg-[var(--color-bg-surface)] transition-colors">
               <span class="text-3xs font-bold uppercase tracking-wider ${color} bg-[var(--color-bg-elevated)] px-2 py-0.5 rounded-[var(--r-1)]">${icon}</span>
-              <span class="text-xs text-text-body flex-1 truncate">${title}</span>
+              <span class="text-xs text-[var(--color-fg-secondary)] flex-1 truncate">${title}</span>
               ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
             </div>
           `
@@ -207,10 +207,10 @@ function BroadcastReport({ report, index }: { report: { ts: string; content: str
     : report.content
 
   return html`
-    <div class="border border-card-border/60 rounded-[var(--r-1)] bg-card/30 overflow-hidden hover:border-[var(--accent-20)] transition-colors">
+    <div class="border border-[var(--color-border-default)]/60 rounded-[var(--r-1)] bg-[var(--color-bg-surface)]/30 overflow-hidden hover:border-[var(--accent-20)] transition-colors">
       <button
         type="button"
-        class=${`w-full flex items-center justify-between px-4 py-2.5 bg-[var(--color-bg-surface)] border-b border-card-border/40 cursor-pointer select-none text-left ${ringFocusClasses()}`}
+        class=${`w-full flex items-center justify-between px-4 py-2.5 bg-[var(--color-bg-surface)] border-b border-[var(--color-border-default)]/40 cursor-pointer select-none text-left ${ringFocusClasses()}`}
         onClick=${() => setExpanded(!expanded)}
         aria-expanded=${expanded}
       >
@@ -219,7 +219,7 @@ function BroadcastReport({ report, index }: { report: { ts: string; content: str
           <${TimeAgo} timestamp=${report.ts} />
         </div>
         ${isLong ? html`
-          <span class="text-3xs text-text-dim font-medium">
+          <span class="text-3xs text-[var(--color-fg-muted)] font-medium">
             ${expanded ? '접기' : '펼치기'}
           </span>
         ` : null}
@@ -256,23 +256,23 @@ export function AgentSessionReport({ agentName }: { agentName: string }) {
   const hasQuery = query.trim() !== ''
 
   return html`
-    <${SectionCard} label="세션 활동 리포트" class="mb-5">
+    <${SectionCard} label="세션 활동 리포트" class="v2-monitoring-panel mb-5">
       <${SessionMeta} agentName=${agentName} />
 
       ${summary ? html`
         <div class="flex gap-3 flex-wrap mb-4">
           ${summary.tasks_completed > 0 ? html`
-            <div class="flex items-center gap-1.5 text-xs font-medium text-ok bg-ok/10 border border-ok/20 px-3 py-1.5 rounded-[var(--r-1)]">
+            <div class="flex items-center gap-1.5 text-xs font-medium text-[var(--color-status-ok)] bg-[var(--ok-10)] border border-[var(--ok-20)] px-3 py-1.5 rounded-[var(--r-1)]">
               <span class="font-bold">${summary.tasks_completed}</span> 완료
             </div>
           ` : null}
           ${summary.tasks_claimed > 0 ? html`
-            <div class="flex items-center gap-1.5 text-xs font-medium text-accent-fg bg-[var(--accent-10)] border border-[var(--accent-20)] px-3 py-1.5 rounded-[var(--r-1)]">
+            <div class="flex items-center gap-1.5 text-xs font-medium text-[var(--color-accent-fg)] bg-[var(--accent-10)] border border-[var(--accent-20)] px-3 py-1.5 rounded-[var(--r-1)]">
               <span class="font-bold">${summary.tasks_claimed}</span> 수임
             </div>
           ` : null}
           ${summary.messages_sent > 0 ? html`
-            <div class="flex items-center gap-1.5 text-xs font-medium text-text-muted bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] px-3 py-1.5 rounded-[var(--r-1)]">
+            <div class="flex items-center gap-1.5 text-xs font-medium text-[var(--color-fg-muted)] bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] px-3 py-1.5 rounded-[var(--r-1)]">
               <span class="font-bold">${summary.messages_sent}</span> 메시지
             </div>
           ` : null}
@@ -289,7 +289,7 @@ export function AgentSessionReport({ agentName }: { agentName: string }) {
             onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
           />
           ${hasQuery ? html`
-            <span class="text-2xs text-text-muted whitespace-nowrap">
+            <span class="text-2xs text-[var(--color-fg-muted)] whitespace-nowrap">
               ${filteredItems} / ${totalItems}
             </span>
           ` : null}
@@ -303,13 +303,13 @@ export function AgentSessionReport({ agentName }: { agentName: string }) {
           `)}
         </div>
       ` : hasQuery && reports.length > 0 ? html`
-        <div class="text-xs text-text-muted py-3">검색 결과 없음 (리포트)</div>
+        <div class="text-xs text-[var(--color-fg-muted)] py-3">검색 결과 없음 (리포트)</div>
       ` : null}
 
       <${TaskEventTimeline} events=${filteredTaskEvents} />
 
       ${hasQuery && filteredTaskEvents.length === 0 && taskEvents.length > 0 ? html`
-        <div class="text-xs text-text-muted py-2">검색 결과 없음 (태스크)</div>
+        <div class="text-xs text-[var(--color-fg-muted)] py-2">검색 결과 없음 (태스크)</div>
       ` : null}
     <//>
   `

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -147,7 +147,7 @@ export function AgentTimelineSection() {
   const filterActive = activeCategory !== 'all' || query.trim() !== ''
 
   return html`
-    <${CollapsibleSection} title=${`활동 타임라인 (${summary?.total_events ?? 0})`} mountWhenOpen=${true}>
+    <${CollapsibleSection} class="v2-monitoring-detail" title=${`활동 타임라인 (${summary?.total_events ?? 0})`} mountWhenOpen=${true}>
       ${summary ? html`
         <div class="flex gap-1.5 flex-wrap mb-2">
           ${summary.tasks_completed > 0 ? html`<${SummaryBadge}>완료 ${summary.tasks_completed}<//>` : null}

--- a/dashboard/src/components/agent-detail-worker.ts
+++ b/dashboard/src/components/agent-detail-worker.ts
@@ -21,7 +21,7 @@ export function AgentWorkerBrief({ agentName }: { agentName: string }) {
   if (!worker) return null
 
   return html`
-    <${CollapsibleSection} title="워커 상태" mountWhenOpen=${true}>
+    <${CollapsibleSection} class="v2-monitoring-detail" title="워커 상태" mountWhenOpen=${true}>
       <div class="flex flex-col gap-1.5">
         <${WorkerInfoRow}>
           <${DetailLabel}>상태</${DetailLabel}>

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -119,9 +119,9 @@ function filterTaskHistories(
 
 function TaskSummary({ task }: { task: Task }) {
   return html`
-    <div class="flex items-center gap-3 border border-card-border bg-card/40 hover:bg-card/60 transition-colors px-3 py-2.5 rounded-[var(--r-1)] shadow-[var(--shadow-1)]">
+    <div class="flex items-center gap-3 border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/40 hover:bg-[var(--color-bg-surface)]/60 transition-colors px-3 py-2.5 rounded-[var(--r-1)]">
       <${IdPill}>${task.id}<//>
-      <span class="flex-1 text-sm text-text-strong font-medium truncate">${task.title}</span>
+      <span class="flex-1 text-sm text-[var(--color-fg-primary)] font-medium truncate">${task.title}</span>
       <${StatusBadge} status=${task.status} />
     </div>
   `
@@ -129,11 +129,11 @@ function TaskSummary({ task }: { task: Task }) {
 
 function TaskHistoryPanel({ row }: { row: TaskHistoryRow }) {
   return html`
-    <div class="border border-card-border rounded-[var(--r-1)] bg-card/40 p-4 shadow-[var(--shadow-1)] hover:border-[var(--accent-30)] transition-colors group">
+    <div class="border border-[var(--color-border-default)] rounded-[var(--r-1)] bg-[var(--color-bg-surface)]/40 p-4 hover:border-[var(--accent-30)] transition-colors group">
       <div class="mb-3">
         <${IdPill} class="group-hover:bg-[var(--accent-20)] transition-colors">${row.taskId}<//>
       </div>
-      <pre class="m-0 whitespace-pre-wrap text-xs leading-relaxed text-text-body font-mono opacity-90">${row.text || '작업 이력 없음'}</pre>
+      <pre class="m-0 whitespace-pre-wrap text-xs leading-relaxed text-[var(--color-fg-secondary)] font-mono opacity-90">${row.text || '작업 이력 없음'}</pre>
     </div>
   `
 }
@@ -248,7 +248,7 @@ export function AgentDetailOverlay() {
       onClose=${closeAgentDetail}
       initialFocusRef=${closeButtonRef}
       overlayClass="agent-detail-overlay fixed inset-0 z-[60] bg-[var(--dialog-overlay-bg)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-[var(--t-med)]"
-      panelClass="w-[min(1080px,100%)] max-h-[90vh] overflow-y-auto rounded-[var(--r-1)] border border-card-border bg-bg-1/95 backdrop-blur-sm shadow-[var(--elev-6-shadow)] ring-1 ring-white/5"
+      panelClass="v2-monitoring-detail w-[min(1080px,100%)] max-h-[90vh] overflow-y-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/95 backdrop-blur-sm shadow-[var(--elev-6-shadow)] ring-1 ring-white/5"
     >
       <div class="p-6 flex flex-col gap-5">
         <div class="flex justify-between items-start gap-4">
@@ -256,45 +256,45 @@ export function AgentDetailOverlay() {
             <div class="flex items-center gap-4">
               ${agentEmoji ? html`<div class="size-12 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] flex items-center justify-center text-3xl shadow-inset">${agentEmoji}</div>` : ''}
               <div>
-                <h2 id=${titleId} class="m-0 flex items-baseline gap-3 text-text-strong text-2xl font-bold tracking-tight">
+                <h2 id=${titleId} class="m-0 flex items-baseline gap-3 text-[var(--color-fg-primary)] text-2xl font-bold tracking-tight">
                   ${displayName}
-                  ${koreanName ? html`<span class="text-sm text-text-dim font-medium tracking-normal">(${koreanName})</span>` : ''}
-                  ${showSecondaryLabel ? html`<span class="font-mono text-xs text-text-dim bg-[var(--color-bg-elevated)] px-2 py-0.5 rounded-[var(--r-1)]">${secondaryLabel}</span>` : ''}
+                  ${koreanName ? html`<span class="text-sm text-[var(--color-fg-muted)] font-medium tracking-normal">(${koreanName})</span>` : ''}
+                  ${showSecondaryLabel ? html`<span class="font-mono text-xs text-[var(--color-fg-muted)] bg-[var(--color-bg-elevated)] px-2 py-0.5 rounded-[var(--r-1)]">${secondaryLabel}</span>` : ''}
                 </h2>
                 <div class="flex items-center gap-2 mt-2 flex-wrap">
                   <${StatusBadge} status=${unified.canonical} />
-                  ${unified.description !== unified.label ? html`<span class="text-3xs font-medium py-1 px-2 border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-text-muted whitespace-nowrap rounded-[var(--r-1)]" title=${unified.description}>${unified.description}</span>` : null}
+                  ${unified.description !== unified.label ? html`<span class="text-3xs font-medium py-1 px-2 border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] whitespace-nowrap rounded-[var(--r-1)]" title=${unified.description}>${unified.description}</span>` : null}
                   ${isArchivedParticipant ? html`<${IdPill}>이전 세션 참여자<//>` : null}
                   ${!agent && missionBrief?.archived_reason
-                    ? html`<span class="text-xs text-text-dim italic">${missionBrief.archived_reason}</span>`
+                    ? html`<span class="text-xs text-[var(--color-fg-muted)] italic">${missionBrief.archived_reason}</span>`
                     : null}
                 </div>
               </div>
             </div>
-            <div class="mt-2 flex gap-3 flex-wrap text-text-muted text-sm font-medium">
+            <div class="mt-2 flex gap-3 flex-wrap text-[var(--color-fg-muted)] text-sm font-medium">
               ${agent?.current_task || missionBrief?.current_work
-                ? html`<span class="bg-card/40 px-3 py-1.5 rounded-[var(--r-1)] border border-card-border shadow-1">태스크: <span class="text-text-strong">${agent?.current_task ?? missionBrief?.current_work}</span></span>`
+                ? html`<span class="bg-[var(--color-bg-surface)]/40 px-3 py-1.5 rounded-[var(--r-1)] border border-[var(--color-border-default)]">태스크: <span class="text-[var(--color-fg-primary)]">${agent?.current_task ?? missionBrief?.current_work}</span></span>`
                 : null}
-              ${lastSeenAt ? html`<span class="bg-card/40 px-3 py-1.5 rounded-[var(--r-1)] border border-card-border shadow-1">마지막 확인: <span class="text-text-strong"><${TimeAgo} timestamp=${lastSeenAt} /></span></span>` : null}
+              ${lastSeenAt ? html`<span class="bg-[var(--color-bg-surface)]/40 px-3 py-1.5 rounded-[var(--r-1)] border border-[var(--color-border-default)]">마지막 확인: <span class="text-[var(--color-fg-primary)]"><${TimeAgo} timestamp=${lastSeenAt} /></span></span>` : null}
             </div>
             ${keeper || continuitySummary || missionBrief?.related_session_id
               ? html`
-                  <div class="mt-1 flex gap-3 flex-wrap text-text-muted text-sm font-medium">
+                  <div class="mt-1 flex gap-3 flex-wrap text-[var(--color-fg-muted)] text-sm font-medium">
                     ${keeper
                       ? html`<span class="flex items-center gap-1.5">연결된 키퍼:
                           <button
                             type="button"
-                            class=${`text-text-strong font-semibold hover:text-accent-fg underline underline-offset-2 decoration-dotted transition-colors ${ringFocusClasses({ tone: 'accent-soft', width: 2 })} rounded-[var(--r-1)]`}
+                            class=${`text-[var(--color-fg-primary)] font-semibold hover:text-[var(--color-accent-fg)] underline underline-offset-2 decoration-dotted transition-colors ${ringFocusClasses({ tone: 'accent-soft', width: 2 })} rounded-[var(--r-1)]`}
                             onClick=${() => { closeAgentDetail(); openKeeperDetail(keeper) }}
                             title="키퍼 상세 페이지 열기"
                             aria-label="${keeper.name} 키퍼 상세 보기"
                           >${keeper.name}</button>
                           <${KeeperPhaseBadge} phase=${keeper.phase} compact=${true} />
-                          ${keeperIdentity ? html`<span class="text-text-dim text-xs"><span aria-hidden="true">· </span>${keeperIdentity}</span>` : ''}
+                          ${keeperIdentity ? html`<span class="text-[var(--color-fg-muted)] text-xs"><span aria-hidden="true">· </span>${keeperIdentity}</span>` : ''}
                         </span>`
                       : null}
-                    ${missionBrief?.related_session_id ? html`<span class="flex items-center gap-1.5">세션: <strong class="font-mono text-text-strong text-xs bg-[var(--color-bg-elevated)] px-1.5 rounded-[var(--r-1)]">${missionBrief.related_session_id}</strong></span>` : null}
-                    ${continuitySummary ? html`<span class="text-accent-fg/90 bg-[var(--accent-10)] px-2 py-0.5 rounded-[var(--r-1)] border border-[var(--accent-10)]">${continuitySummary}</span>` : null}
+                    ${missionBrief?.related_session_id ? html`<span class="flex items-center gap-1.5">세션: <strong class="font-mono text-[var(--color-fg-primary)] text-xs bg-[var(--color-bg-elevated)] px-1.5 rounded-[var(--r-1)]">${missionBrief.related_session_id}</strong></span>` : null}
+                    ${continuitySummary ? html`<span class="text-[var(--color-accent-fg)]/90 bg-[var(--accent-10)] px-2 py-0.5 rounded-[var(--r-1)] border border-[var(--accent-10)]">${continuitySummary}</span>` : null}
                   </div>
                 `
               : null}
@@ -303,7 +303,7 @@ export function AgentDetailOverlay() {
             <${ActionButton}
               variant="ghost"
               size="lg"
-              class="px-4 py-2 text-sm rounded-[var(--r-1)] bg-card/60 shadow-1"
+              class="px-4 py-2 text-sm rounded-[var(--r-1)] bg-[var(--color-bg-surface)]/60"
               onClick=${() => { void refreshAgentDetail() }}
               disabled=${loading.value}
             >
@@ -312,7 +312,7 @@ export function AgentDetailOverlay() {
             <${ActionButton}
               variant="danger"
               size="lg"
-              class="px-4 py-2 text-sm rounded-[var(--r-1)] shadow-1"
+              class="px-4 py-2 text-sm rounded-[var(--r-1)]"
               onClick=${handlePurge}
               disabled=${purgePending.value}
             >
@@ -321,7 +321,7 @@ export function AgentDetailOverlay() {
             <button
               ref=${closeButtonRef}
               type="button"
-              class=${`px-4 py-2 text-sm font-semibold rounded-[var(--r-1)] border border-transparent bg-[var(--color-bg-hover)] text-text-strong hover:bg-[var(--color-bg-hover)] transition-colors duration-[var(--t-med)] shadow-1 ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`}
+              class=${`px-4 py-2 text-sm font-semibold rounded-[var(--r-1)] border border-transparent bg-[var(--color-bg-hover)] text-[var(--color-fg-primary)] hover:bg-[var(--color-bg-hover)] transition-colors duration-[var(--t-med)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`}
               onClick=${closeAgentDetail}
             >
               닫기
@@ -341,7 +341,7 @@ export function AgentDetailOverlay() {
           <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">
             작업 필터
             ${isFilteringTasks
-              ? html`<span class="ml-2 normal-case tracking-normal text-text-muted">할당 ${visibleOwnedTasks.length}/${ownedTasks.length} · 이력 ${visibleHistories.length}/${historyRows.length}</span>`
+              ? html`<span class="ml-2 normal-case tracking-normal text-[var(--color-fg-muted)]">할당 ${visibleOwnedTasks.length}/${ownedTasks.length} · 이력 ${visibleHistories.length}/${historyRows.length}</span>`
               : null}
           </div>
           <${TextInput}
@@ -362,7 +362,7 @@ export function AgentDetailOverlay() {
           <${SectionCard} label="최근 활동">
             ${lines.length === 0
               ? html`<div class="h-full min-h-30"><${EmptyState} message="최근 활동 메시지가 없습니다" compact /></div>`
-              : html`<div role="log" aria-label="최근 활동 로그" class="max-h-60 overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-xs text-text-body leading-relaxed rounded-[var(--r-1)] shadow-[var(--shadow-1)] hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
+              : html`<div role="log" aria-label="최근 활동 로그" class="max-h-60 overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/40 px-3 py-2.5 font-mono text-xs text-[var(--color-fg-secondary)] leading-relaxed rounded-[var(--r-1)] hover:bg-[var(--color-bg-surface)]/60 transition-colors">${line}</div>`)}</div>`}
           <//>
         </div>
 
@@ -380,9 +380,9 @@ export function AgentDetailOverlay() {
                   ['속도', agentFitness.value.speed_score],
                   ['종합', agentFitness.value.overall_fitness],
                 ] as [string, number][]).map(([label, val]) => html`
-                  <div class="rounded-[var(--r-1)] border border-card-border/50 bg-card/30 p-3 text-center">
-                    <div class="text-3xs font-semibold uppercase tracking-wider text-text-muted mb-1">${label}</div>
-                    <div class="text-lg font-bold ${val >= 0.7 ? 'text-ok' : val >= 0.4 ? 'text-[var(--color-status-warn)]' : 'text-bad'}">${formatPct(val)}</div>
+                  <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)]/50 bg-[var(--color-bg-surface)]/30 p-3 text-center">
+                    <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)] mb-1">${label}</div>
+                    <div class="text-lg font-bold ${val >= 0.7 ? 'text-[var(--color-status-ok)]' : val >= 0.4 ? 'text-[var(--color-status-warn)]' : 'text-[var(--bad-light)]'}">${formatPct(val)}</div>
                   </div>
                 `)}
               </div>
@@ -396,7 +396,7 @@ export function AgentDetailOverlay() {
           <${SectionCard} label="직접 멘션">
             <div class="grid grid-cols-[1fr_auto] gap-3">
               <${TextInput}
-                class="px-4 py-2.5 rounded-[var(--r-1)] bg-card/60 text-text-strong text-sm placeholder:text-text-dim shadow-inset"
+                class="px-4 py-2.5 rounded-[var(--r-1)] bg-[var(--color-bg-surface)]/60 text-[var(--color-fg-primary)] text-sm placeholder:text-[var(--color-fg-muted)] shadow-inset"
                 value=${mentionText.value}
                 name="agent_direct_mention"
                 ariaLabel="직접 멘션 메시지"
@@ -409,7 +409,7 @@ export function AgentDetailOverlay() {
               <${ActionButton}
                 variant="primary"
                 size="lg"
-                class="px-5 py-2.5 text-sm shadow-1 shadow-accent-fg/20"
+                class="px-5 py-2.5 text-sm shadow-accent-fg/20"
                 onClick=${() => { void submitMention() }}
                 disabled=${sendingMention.value || mentionText.value.trim() === ''}
               >

--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -151,7 +151,7 @@ export function AgentLiveTimeline({ name }: { name: string }) {
   }, [filtered.length])
 
   return html`
-    <div class="flex flex-col gap-2">
+    <div class="v2-monitoring-detail flex flex-col gap-2">
       <div class="flex items-center justify-between gap-2 flex-wrap">
         <${FilterChips} chips=${FILTER_CHIPS} active=${activeFilter} />
         <div class="flex items-center gap-2 text-2xs">

--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -31,7 +31,7 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
   const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
 
   return html`
-    <div class="agent-runtime-strip">
+    <div class="v2-monitoring-detail agent-runtime-strip">
       <div class="flex items-center gap-1.5 text-sm">
         <${PipelineStageBadge} stage=${stage} />
       </div>

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -349,7 +349,7 @@ export function AgentProfile({ name }: { name: string }) {
   const isKeeper = keeper != null
 
   return html`
-    <div class="px-1 ${isKeeper ? 'ff-profile--keeper' : ''}">
+    <div class="v2-monitoring-surface px-1 ${isKeeper ? 'ff-profile--keeper' : ''}">
       <div class="flex gap-2 mb-3">
         <${ActionButton} variant="ghost" onClick=${() => navigate('monitoring', { section: 'agents' })}>← 목록<//>
         <${ActionButton} variant="ghost" onClick=${() => { void loadProfile(name) }} disabled=${profileLoading}>

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -989,7 +989,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     : null
 
   return html`
-    <div class="agent-page flex w-full flex-col gap-5 px-0 py-1">
+    <div class="v2-monitoring-surface agent-page flex w-full flex-col gap-5 px-0 py-1">
       <section class="monitor-surface-card monitor-surface-card-strong p-5" aria-label="에이전트 디렉터리">
         <div class="flex flex-col gap-5">
           <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -83,7 +83,7 @@ export function AgentsUnified() {
   }))
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="v2-monitoring-surface flex flex-col gap-4">
       <${FilterChips}
         chips=${viewChips}
         value=${currentView}

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -413,7 +413,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
     const hint = getFieldHint(inProcess.envVar)
     return html`
       <${SurfaceCard}
-        class="mt-3 !border-[var(--accent-20)] !bg-[var(--accent-10)]/5 !p-3 text-2xs"
+        class="mt-3 !border-[var(--accent-22)] !bg-[var(--accent-12)]/5 !p-3 text-2xs v2-connector-config-form"
         id=${`connector-config-${connectorId}`}
         data-in-process-config-panel
       >
@@ -429,7 +429,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
         ${hint === null
           ? null
           : html`
-              <${SurfaceCard} class="mt-2 !border-[var(--accent-20)] !bg-[var(--accent-10)]/5 !px-2 !py-1 text-3xs text-[var(--color-accent-fg)]" data-field-hint=${inProcess.envVar}>
+              <${SurfaceCard} class="mt-2 !border-[var(--accent-22)] !bg-[var(--accent-12)]/5 !px-2 !py-1 text-3xs text-[var(--color-accent-fg)]" data-field-hint=${inProcess.envVar}>
                 <span>${hint.where}</span>
                 ${hint.url
                   ? html`
@@ -467,7 +467,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
 
   if (entry.loading) {
     return html`
-      <${SurfaceCard} class="mt-3 !p-3" id=${`connector-config-${connectorId}`}>
+      <${SurfaceCard} class="mt-3 !p-3 v2-connector-config-form" id=${`connector-config-${connectorId}`}>
         <${LoadingState}>config schema 불러오는 중...<//>
       </${SurfaceCard}>
     `
@@ -475,12 +475,12 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
 
   if (entry.error !== null) {
     return html`
-      <${SurfaceCard} class="mt-3 !border-[var(--bad-20)] !bg-[var(--bad-10)] !p-3 text-2xs text-[var(--bad-light)]" id=${`connector-config-${connectorId}`} role="alert">
+      <${SurfaceCard} class="mt-3 !border-[var(--err-border)] !bg-[var(--bad-10)] !p-3 text-2xs text-[var(--bad-light)] v2-connector-config-form" id=${`connector-config-${connectorId}`} role="alert">
         <div class="font-semibold">schema 가져오기 실패</div>
         <div class="mt-1 text-3xs opacity-80">${entry.error}</div>
         <button
           type="button"
-          class="mt-2 cursor-pointer rounded-[var(--r-1)] border border-[var(--bad-20)] px-2 py-1 text-3xs hover:bg-[var(--bad-10)]"
+          class="mt-2 cursor-pointer rounded-[var(--r-1)] border border-[var(--err-border)] px-2 py-1 text-3xs hover:bg-[var(--bad-10)]"
           aria-label="config schema 다시 가져오기"
           onClick=${() => fetchSchema(connectorId)}
         >다시 시도</button>
@@ -490,7 +490,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
 
   if (entry.fields.length === 0) {
     return html`
-      <${SurfaceCard} class="mt-3 !p-3 text-2xs text-[var(--color-fg-disabled)]" id=${`connector-config-${connectorId}`}>
+      <${SurfaceCard} class="mt-3 !p-3 text-2xs text-[var(--color-fg-disabled)] v2-connector-config-form" id=${`connector-config-${connectorId}`}>
         schema가 비어있습니다. backend가 sidecar venv를 못 찾았을 수 있어요.
       </${SurfaceCard}>
     `
@@ -499,7 +499,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
   const envBlock = buildEnvBlock(entry)
 
   return html`
-    <${SurfaceCard} class="mt-3 !p-3" id=${`connector-config-${connectorId}`} role="form" aria-label="${connectorId} 설정">
+    <${SurfaceCard} class="mt-3 !p-3 v2-connector-config-form" id=${`connector-config-${connectorId}`} role="form" aria-label="${connectorId} 설정">
       <div class="mb-2 flex items-center justify-between">
         <div class="text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">
           ${entry.fields.length} fields · ${entry.fields.filter(f => f.required).length} required
@@ -579,7 +579,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
               const hint = getFieldHint(field.name)
               if (hint === null) return null
               return html`
-                <${SurfaceCard} class="!border-[var(--accent-20)] !bg-[var(--accent-10)]/5 !px-2 !py-1 text-3xs text-[var(--color-accent-fg)]" data-field-hint=${field.name}>
+                <${SurfaceCard} class="!border-[var(--accent-22)] !bg-[var(--accent-12)]/5 !px-2 !py-1 text-3xs text-[var(--color-accent-fg)]" data-field-hint=${field.name}>
                   <span class="mr-1" aria-hidden="true">📍</span>
                   <span>${hint.where}</span>
                   ${hint.url

--- a/dashboard/src/components/connector-flow.ts
+++ b/dashboard/src/components/connector-flow.ts
@@ -90,7 +90,7 @@ export function ConnectorFlowSection({ connector, gate }: {
 
   return html`
     <${SurfaceCard}
-      class="mt-3 !bg-[var(--color-bg-elevated)] !px-3 !py-2.5 text-2xs"
+      class="mt-3 !bg-[var(--color-bg-elevated)] !px-3 !py-2.5 text-2xs v2-connector-flow"
       data-connector-flow=${connector?.connector_id ?? ''}
     >
       <div class="mb-1.5 text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-disabled)]">

--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -230,7 +230,7 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
   const gridCols = `grid-template-columns: minmax(160px, 1fr) repeat(${matrix.columns.length}, minmax(80px, 1fr)) minmax(90px, auto);`
 
   return html`
-    <${SurfaceCard} class="mb-4 !border-[var(--color-border-default)] !bg-[var(--color-bg-surface)] !p-3" data-panel="connector-keeper-matrix" aria-label="Keeper × Connector 매트릭스">
+    <${SurfaceCard} class="mb-4 !border-[var(--color-border-default)] !bg-[var(--color-bg-surface)] !p-3 v2-connector-keeper-matrix" data-panel="connector-keeper-matrix" aria-label="Keeper × Connector 매트릭스">
       <header class="mb-2 flex items-baseline justify-between gap-3">
         <div>
           <h4 class="text-xs font-semibold uppercase tracking-4 text-[var(--color-fg-primary)]">

--- a/dashboard/src/components/connector-onboarding.ts
+++ b/dashboard/src/components/connector-onboarding.ts
@@ -77,7 +77,7 @@ function OnboardingCard({ connectorId }: { connectorId: KnownConnectorId }) {
 
 export function ConnectorOnboardingGrid() {
   return html`
-    <div>
+    <div class="v2-connector-onboarding">
       <div class="mb-3">
         <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">아직 연결된 사이드카가 없습니다</h3>
         <div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">

--- a/dashboard/src/components/connector-overview-skeleton.ts
+++ b/dashboard/src/components/connector-overview-skeleton.ts
@@ -84,7 +84,7 @@ export function ConnectorOverviewSkeleton({
   const count = overviewSkeletonTileCount()
   const grid = overviewSkeletonGridClasses()
   return html`<div
-    class=${`${grid} ${cx ?? ''}`}
+    class=${`${grid} ${cx ?? ''} v2-connector-overview-skeleton`}
     role="status"
     aria-label="커넥터 상태 불러오는 중"
     aria-live="polite"

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -195,7 +195,7 @@ export function summarizeOverviewTile(
   if (stateLabel === 'stale' || stateLabel === 'disconnected' || connector.gate_healthy === false) {
     return {
       badge: '주의',
-      badgeClass: 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]',
+      badgeClass: 'border-[var(--err-border)] bg-[var(--bad-10)] text-[var(--bad-light)]',
       detail: stateLabel === 'stale'
         ? 'heartbeat가 stale 상태입니다 · 로그와 gate 상태를 확인하세요'
         : stateLabel === 'disconnected'
@@ -216,7 +216,7 @@ export function summarizeOverviewTile(
 
   return {
     badge: '정상',
-    badgeClass: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)]',
+    badgeClass: 'border-[var(--ok-border)] bg-[var(--ok-10)] text-[var(--color-status-ok)]',
     detail: `실행 중 · ${bindingCount} ${bindingCount === 1 ? 'binding' : 'bindings'} active`,
   }
 }
@@ -262,7 +262,7 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
     <${SurfaceCard}
       class=${`flex min-w-0 flex-col gap-3 !bg-[var(--color-bg-surface)] !p-3 transition-colors ${
         selected
-          ? '!border-[var(--color-accent-fg)] shadow-[0_0_0_1px_var(--accent-18)]'
+          ? '!border-[var(--color-accent-fg)] shadow-[0_0_0_1px_var(--accent-22)]'
           : '!border-[var(--color-border-default)] hover:!border-[var(--color-border-default)]'
       }`}
       data-overview-tile=${id}
@@ -286,7 +286,7 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
             ${uptimeLabel !== null
               ? html`
                   <span
-                    class="rounded-[var(--r-0)] border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-px text-3xs font-normal text-[var(--color-status-ok)]/80"
+                    class="rounded-[var(--r-0)] border border-[var(--ok-border)] bg-[var(--ok-10)] px-1.5 py-px text-3xs font-normal text-[var(--color-status-ok)]/80"
                     data-uptime-chip
                     title="last_ready_at 기준 경과 시간"
                   >${uptimeLabel}</span>
@@ -371,8 +371,8 @@ const TILE_ACTION_TONE_CLASS: Record<'start' | 'stop', string> = {
   // across per-tile + bulk controls. The per-tile button is deliberately
   // block-width and text-xs so it reads as the primary action of the
   // tile, distinct from the smaller pill row above.
-  start: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)] hover:bg-[var(--ok-10)]',
-  stop: 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-10)]',
+  start: 'border-[var(--ok-border)] bg-[var(--ok-10)] text-[var(--color-status-ok)] hover:bg-[var(--ok-10)]',
+  stop: 'border-[var(--err-border)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-10)]',
 }
 
 /** The prominent per-tile Start/Stop button. Reference UIs (Vercel
@@ -442,7 +442,7 @@ const TILE_NOTICE_TONE_CLASS: Record<'error' | 'stale', string> = {
   // Rose for hard errors (sidecar reported an explicit failure),
   // amber for stale (data hasn't refreshed but no explicit error).
   // Matches Sentry \"issue\" rose + Vercel \"warning\" amber convention.
-  error: 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]',
+  error: 'border-[var(--err-border)] bg-[var(--bad-10)] text-[var(--bad-light)]',
   stale: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]',
 }
 
@@ -706,7 +706,7 @@ function IncidentBanner({ droppedIds }: { droppedIds: string[] }) {
     .join(', ')
   return html`
     <${SurfaceCard}
-      class="mb-2 flex items-center gap-2 !border-[var(--bad-20)] !bg-[var(--bad-10)] !px-3 !py-1.5 text-2xs font-semibold text-[var(--bad-light)]"
+      class="mb-2 flex items-center gap-2 !border-[var(--err-border)] !bg-[var(--bad-10)] !px-3 !py-1.5 text-2xs font-semibold text-[var(--bad-light)]"
       data-incident-banner
       role="alert"
     >
@@ -748,13 +748,13 @@ export function ConnectorOverviewStrip({
   const droppedIds = detectRecentDrops(stripMemory.value, connectors, Date.now())
   const summary = summarizeConnectorStrip(connectors, keeperCount)
   return html`
-    <${SurfaceCard} class="mb-4 !p-3" data-overview-strip-root>
+    <${SurfaceCard} class="mb-4 !p-3 v2-connector-overview-strip" data-overview-strip-root>
       <${IncidentBanner} droppedIds=${droppedIds} />
       <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
         <div class="flex flex-wrap items-center gap-2">
           <${StatusSummaryLine} summary=${summary} connectors=${connectors} />
           ${discordTriggerPolicy && discordTriggerPolicy !== 'unknown'
-            ? html`<span class="rounded-[var(--r-0)] border border-[var(--border-subtle)] bg-[var(--surface-inset)] px-2 py-0.5 text-3-xs font-medium text-[var(--color-fg-secondary)]">trigger: ${discordTriggerPolicy}</span>`
+            ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-medium text-[var(--color-fg-secondary)]">trigger: ${discordTriggerPolicy}</span>`
             : null
           }
         </div>

--- a/dashboard/src/components/connector-paths-strip.ts
+++ b/dashboard/src/components/connector-paths-strip.ts
@@ -83,7 +83,7 @@ export function ConnectorPathsStrip({ connectors }: { connectors: GateConnectorI
   const open = pathsExpanded.value
   return html`
     <${SurfaceCard}
-      class="mb-3 !border-[var(--color-border-default)] !bg-[var(--color-bg-surface)]"
+      class="mb-3 !border-[var(--color-border-default)] !bg-[var(--color-bg-surface)] v2-connector-paths-strip"
       data-panel="connector-paths-strip"
     >
       <button

--- a/dashboard/src/components/connector-quick-bind.ts
+++ b/dashboard/src/components/connector-quick-bind.ts
@@ -102,7 +102,7 @@ export function QuickBindForm({ connectorId, keepers }: {
 
   return html`
     <${SurfaceCard}
-      class="mt-3 flex flex-wrap items-end gap-2 !border-dashed !border-[var(--color-border-default)] !bg-[var(--color-bg-surface)] !px-3 !py-2.5"
+      class="mt-3 flex flex-wrap items-end gap-2 !border-dashed !border-[var(--color-border-default)] !bg-[var(--color-bg-surface)] !px-3 !py-2.5 v2-connector-quick-bind"
       data-quick-bind=${connectorId}
     >
       <div class="min-w-0 flex-1 basis-[160px]">

--- a/dashboard/src/components/connector-readiness-rail.ts
+++ b/dashboard/src/components/connector-readiness-rail.ts
@@ -70,7 +70,7 @@ export interface RailPill {
 const TONE: Record<RailState, { bg: string; border: string; text: string; dot: string; icon: string; gradient: string }> = {
   ok: {
     bg: 'bg-[var(--ok-10)]',
-    border: 'border-[var(--ok-20)]',
+    border: 'border-[var(--ok-border)]',
     text: 'text-[var(--color-status-ok)]',
     dot: 'bg-[var(--ok-10)]',
     icon: '✓',
@@ -89,7 +89,7 @@ const TONE: Record<RailState, { bg: string; border: string; text: string; dot: s
   },
   bad: {
     bg: 'bg-[var(--bad-10)]',
-    border: 'border-[var(--bad-20)]',
+    border: 'border-[var(--err-border)]',
     text: 'text-[var(--bad-light)]',
     dot: 'bg-[var(--bad-10)]',
     icon: '⊘',
@@ -173,7 +173,7 @@ export function ConnectorReadinessRail({ pills }: { pills: RailPill[] }) {
   // strip, and labels truncate symmetrically when the tile is narrow instead
   // of each pill truncating at a different point.
   return html`
-    <div class="mt-2 grid grid-cols-4 items-stretch gap-2" data-rail-layout="grid-4">
+    <div class="mt-2 grid grid-cols-4 items-stretch gap-2 v2-connector-readiness-rail" data-rail-layout="grid-4">
       ${pills.map(pill => html`<${Pill} pill=${pill} />`)}
     </div>
   `

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -957,6 +957,25 @@ describe('ConnectorStatusPanel', () => {
     expect(novaText).not.toContain('model ')
     expect(novaText).toContain('runtime keeper-nova-agent')
   })
+
+  it('mounts under the v2 connector status surface class', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse())
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    const root = container.querySelector('.v2-connector-status')
+    expect(root).not.toBeNull()
+  })
 })
 
 describe('filterKeeperGroups', () => {

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -300,7 +300,7 @@ function healthTone(health: string): { dot: string; badge: string; label: string
     case 'healthy':
       return {
         dot: 'var(--green)',
-        badge: 'border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)]',
+        badge: 'border border-[var(--ok-border)] bg-[var(--ok-10)] text-[var(--color-status-ok)]',
         label: 'healthy',
       }
     case 'degraded':
@@ -312,7 +312,7 @@ function healthTone(health: string): { dot: string; badge: string; label: string
     case 'failing':
       return {
         dot: 'var(--red)',
-        badge: 'border border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]',
+        badge: 'border border-[var(--err-border)] bg-[var(--bad-10)] text-[var(--bad-light)]',
         label: 'failing',
       }
     default:
@@ -439,10 +439,10 @@ export function connectorCardBorderClass(label: string): string {
 function connectorStateTone(connector: GateConnectorInfo | null): string {
   const label = connectorStateLabel(connector)
   if (label === 'connected') {
-    return 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--color-status-ok)]'
+    return 'border-[var(--ok-border)] bg-[var(--ok-10)] text-[var(--color-status-ok)]'
   }
   if (label === 'disconnected') {
-    return 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]'
+    return 'border-[var(--err-border)] bg-[var(--bad-10)] text-[var(--bad-light)]'
   }
   return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
 }
@@ -838,7 +838,7 @@ function ConnectorLivePanel({
             ? html`
                 <button
                   type="button"
-                  class="cursor-pointer rounded-[var(--r-1)] border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-0.5 text-3xs uppercase tracking-4 text-[var(--bad-light)] hover:bg-[var(--bad-10)] disabled:opacity-50"
+                  class="cursor-pointer rounded-[var(--r-1)] border border-[var(--err-border)] bg-[var(--bad-10)] px-2 py-0.5 text-3xs uppercase tracking-4 text-[var(--bad-light)] hover:bg-[var(--bad-10)] disabled:opacity-50"
                   disabled=${isActionLoading}
                   aria-label=${`stop ${connectorName} sidecar`}
                   onClick=${() => { void stopSidecar(connectorId) }}
@@ -1401,7 +1401,7 @@ function ChannelCard({ ch }: { ch: ChannelInfo }) {
 
       ${lastError
         ? html`
-            <${SurfaceCard} class="mt-3 !border-[var(--bad-20)] !bg-[var(--bad-10)] !px-3 !py-2 text-2xs text-[var(--bad-light)]">
+            <${SurfaceCard} class="mt-3 !border-[var(--err-border)] !bg-[var(--bad-10)] !px-3 !py-2 text-2xs text-[var(--bad-light)]">
               <div class="mb-1 uppercase tracking-5 text-[var(--bad-light)]/80">
                 ${ch.last_error_kind || 'error'} · ${timeAgo(ch.last_error_at)}
               </div>
@@ -1448,7 +1448,7 @@ function BindingRow({ binding }: { binding: BindingInfo }) {
       </div>
       ${lastError
         ? html`
-            <${SurfaceCard} class="mt-2 !border-[var(--bad-20)] !bg-[var(--bad-10)] !px-2 !py-1 text-3xs text-[var(--bad-light)]">
+            <${SurfaceCard} class="mt-2 !border-[var(--err-border)] !bg-[var(--bad-10)] !px-2 !py-1 text-3xs text-[var(--bad-light)]">
               ${binding.last_error_kind || 'error'} · ${lastError}
             </${SurfaceCard}>
           `
@@ -1460,7 +1460,7 @@ function BindingRow({ binding }: { binding: BindingInfo }) {
 function EventRow({ event }: { event: GateEventInfo }) {
   const isError = Boolean(event.error)
   const badgeClass = isError
-    ? 'border border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]'
+    ? 'border border-[var(--err-border)] bg-[var(--bad-10)] text-[var(--bad-light)]'
     : 'border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-disabled)]'
 
   return html`
@@ -1679,7 +1679,7 @@ export function ConnectorStatusPanel() {
     : findKnownConnector(allConnectors, focusedConnectorId) ?? placeholderConnector(focusedConnectorId)
 
   return html`
-    <div class="contain-content">
+    <div class="contain-content v2-connector-status">
       <div class="mb-3 flex items-center justify-between gap-3">
         <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">${filterId ? CONNECTOR_DISPLAY_NAMES[filterId as KnownConnectorId] ?? '커넥터' : '커넥터'}</h3>
         ${filterId

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -977,12 +977,12 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
   return html`
     <section
       data-testid="fleet-fsm-matrix"
-      class="contain-content rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]"
+      class="v2-monitoring-panel contain-content rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]"
       aria-label="Fleet FSM 통합 상태"
     >
       <header class="flex flex-wrap items-baseline gap-3 border-b border-[var(--color-border-default)] p-3">
         <h2 class="text-sm font-semibold text-[var(--color-fg-muted)]">Fleet 통합 (KSM × KTC × KDP × KCL × KMC × KCB)</h2>
-        <span class="text-xs text-[var(--color-fg-muted)]0">
+        <span class="text-xs text-[var(--color-fg-muted)]">
           키퍼 ${data.count}명 · ${unixSecondsToDate(data.generated_at).toLocaleTimeString()} 업데이트
         </span>
         <${TextInput}
@@ -1147,7 +1147,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                                     key=${key}
                                     data-runtime-action
                                     data-runtime-action-type=${action.action_type}
-                                    class="self-start rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-semibold ${runtimeActionTone(action)} hover:bg-[var(--color-bg-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+                                    class="v2-monitoring-action self-start rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-semibold ${runtimeActionTone(action)} hover:bg-[var(--color-bg-hover)] disabled:cursor-not-allowed disabled:opacity-50"
                                     title=${action.reason}
                                     aria-label=${action.reason}
                                     disabled=${busy}
@@ -1168,7 +1168,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                             <button
                               type="button"
                               data-runtime-assist
-                              class="self-start rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-semibold text-[var(--color-accent-fg)] hover:bg-[var(--color-bg-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+                              class="v2-monitoring-action self-start rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-semibold text-[var(--color-accent-fg)] hover:bg-[var(--color-bg-hover)] disabled:cursor-not-allowed disabled:opacity-50"
                               title="현재 원인/증거를 keeper LLM에 보내 감독형 진단을 요청합니다"
                               aria-label="감독형 진단 요청"
                               disabled=${assisting}
@@ -1194,7 +1194,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                             data-cell
                             data-axis=${a.key}
                             data-runtime-phase-conflict=${cell.runtimePhaseConflict ? 'true' : 'false'}
-                            class="inline-block self-start rounded-[var(--r-1)] border px-2 py-0.5 ${cell.className}"
+                            class="v2-monitoring-fsm-cell inline-block self-start rounded-[var(--r-1)] border px-2 py-0.5 ${cell.className}"
                             title=${cell.title}
                           >${cell.label}</span>
                           <div

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -628,7 +628,7 @@ export function FleetHealthPanel() {
   const view = activeView.value
 
   return html`
-    <div class="contain-content flex flex-col gap-4">
+    <div class="v2-monitoring-surface contain-content flex flex-col gap-4">
       <div class="text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Keeper tool operations</div>
       <${FilterChips}
         chips=${VIEW_CHIPS}

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -801,7 +801,7 @@ export function FleetTelemetryPanel() {
   const offlineCount = value.rows.length - activeCount
 
   return html`
-    <div class="contain-content flex flex-col gap-4 p-4">
+    <div class="v2-monitoring-surface contain-content flex flex-col gap-4 p-4">
       <div class="flex items-start justify-between gap-3">
         <div class="flex items-center gap-3">
           <h2 class="text-sm font-medium">Keeper 텔레메트리</h2>

--- a/dashboard/src/components/governance-monitor.ts
+++ b/dashboard/src/components/governance-monitor.ts
@@ -131,7 +131,7 @@ export function GovernanceMonitor() {
   const isFiltering = query.value.trim() !== ''
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="v2-monitoring-surface flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
         <${Select}
           class="px-2 py-1 text-xs"

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -263,7 +263,7 @@ export function KeeperLiveTruthPanel({
 
   return html`
     <div
-      class="w-full max-w-[calc(100vw-3rem)] rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-4 lg:max-w-none"
+      class="v2-monitoring-detail w-full max-w-[calc(100vw-3rem)] rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-4 lg:max-w-none"
       data-testid="keeper-live-truth"
     >
       <div class="flex flex-wrap items-start justify-between gap-3">
@@ -354,7 +354,7 @@ export function KeeperSecretProjectionPanel({
   if (!projection) {
     return html`
       <div
-        class="rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-4"
+        class="v2-monitoring-detail rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-4"
         data-testid="keeper-secret-projection"
       >
         <div class="flex items-center justify-between gap-3">
@@ -381,7 +381,7 @@ export function KeeperSecretProjectionPanel({
 
   return html`
     <div
-      class="rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-4"
+      class="v2-monitoring-detail rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-4"
       data-testid="keeper-secret-projection"
     >
       <div class="flex flex-wrap items-start justify-between gap-3">

--- a/dashboard/src/components/keeper-reactivity-monitor.ts
+++ b/dashboard/src/components/keeper-reactivity-monitor.ts
@@ -132,7 +132,7 @@ function AutoPausePanel({ allKeepers }: { allKeepers: Keeper[] }) {
   }
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="v2-monitoring-surface flex flex-col gap-4">
       ${pausedKeepers.length > 0 ? html`
         <div>
           <div class="mb-2 text-2xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">

--- a/dashboard/src/components/keeper-runtime-model-editor.ts
+++ b/dashboard/src/components/keeper-runtime-model-editor.ts
@@ -142,12 +142,12 @@ function RuntimeCatalogSummary({
       <div class="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
         <div class="min-w-0">
           <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">provider</div>
-          <div class="truncate text-sm font-semibold text-text-strong">${provider}</div>
+          <div class="truncate text-sm font-semibold text-[var(--color-fg-primary)]">${provider}</div>
           <div class="truncate font-mono text-3xs text-[var(--color-fg-muted)]">${entry.protocol ?? MISSING_DATA_DASH} · ${entry.auth_kind ?? 'auth unknown'}</div>
         </div>
         <div class="min-w-0">
           <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">model</div>
-          <div class="truncate text-sm font-semibold text-text-strong">${model}</div>
+          <div class="truncate text-sm font-semibold text-[var(--color-fg-primary)]">${model}</div>
           <div class="truncate font-mono text-3xs text-[var(--color-fg-muted)]">${formatContextTokens(entry.max_context)}</div>
         </div>
       </div>
@@ -164,7 +164,7 @@ function RuntimeCatalogSummary({
 function EditorHeader() {
   return html`
     <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-      <span class="text-2xs font-bold uppercase tracking-[var(--track-caps)] text-accent-fg">런타임</span>
+      <span class="text-2xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">런타임</span>
       <span class="text-3xs text-[var(--color-fg-muted)]">keeper가 다음 턴에 호출할 runtime lane</span>
     </div>
   `
@@ -206,9 +206,9 @@ export function KeeperRuntimeModelEditor({ keeperName }: { keeperName: string })
     // the operator is not left at the same dead-end the card exists to fix.
     const kind = config.sources.default_source_kind ?? 'unknown'
     return html`
-      <div class="flex flex-col gap-2 rounded-[var(--r-4)] border border-card-border/60 bg-card/35 px-4 py-3 shadow-[var(--shadow-1)]">
+      <div class="v2-monitoring-card flex flex-col gap-2 rounded-[var(--r-4)] border border-[var(--color-border-default)]/60 bg-[var(--color-bg-surface)]/35 px-4 py-3">
         <${EditorHeader} />
-        <div class="text-sm font-semibold text-text-strong">${current || MISSING_DATA_DASH}</div>
+        <div class="text-sm font-semibold text-[var(--color-fg-primary)]">${current || MISSING_DATA_DASH}</div>
         ${canonical && canonical !== current
           ? html`<div class="text-2xs text-[var(--color-fg-muted)]">정규화: ${canonical}</div>`
           : null}
@@ -254,9 +254,9 @@ export function KeeperRuntimeModelEditor({ keeperName }: { keeperName: string })
   }
 
   return html`
-    <div class="flex flex-col gap-2 rounded-[var(--r-4)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-4 py-3 shadow-[var(--shadow-1)]">
+    <div class="v2-monitoring-card flex flex-col gap-2 rounded-[var(--r-4)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-4 py-3">
       <${EditorHeader} />
-      <div class="text-2xs text-[var(--color-fg-muted)]">현재 <span class="font-semibold text-text-strong">${current || MISSING_DATA_DASH}</span></div>
+      <div class="text-2xs text-[var(--color-fg-muted)]">현재 <span class="font-semibold text-[var(--color-fg-primary)]">${current || MISSING_DATA_DASH}</span></div>
       <${InlineSelectRow}
         label="runtime"
         value=${effective}

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -289,7 +289,7 @@ export function RuntimeEnvironmentEditor({
   }
 
   return html`
-    <div class="border-t border-[var(--color-border-divider)] pt-3" data-testid="runtime-environment-editor">
+    <div class="v2-monitoring-detail border-t border-[var(--color-border-divider)] pt-3" data-testid="runtime-environment-editor">
       <div class="mb-3 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
         <div class="min-w-0">
           <div class="text-2xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">

--- a/dashboard/src/components/runtime-health-snapshot.ts
+++ b/dashboard/src/components/runtime-health-snapshot.ts
@@ -186,6 +186,7 @@ export function RuntimeHealthSnapshot() {
 
   return html`
     <${SectionCard}
+      class="v2-monitoring-panel"
       label="런타임 상태 체크"
       status=${status}
       right=${html`

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -457,7 +457,7 @@ export function RuntimeMonitor() {
   const providerProbes = providerProbeMap(probe)
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="v2-monitoring-surface flex flex-col gap-4">
       <div class="flex items-center gap-3 flex-wrap">
         <${Select}
           class="px-2 py-1 text-xs"
@@ -516,18 +516,18 @@ export function RuntimeMonitor() {
             ? providers?.providers.map(provider => {
                 const liveProbe = providerProbes.get(providerRuntimeKey(provider)) ?? null
                 return html`
-                <article class="p-4 rounded-[var(--r-1)] border border-card-border bg-card/40 backdrop-blur-sm shadow-[var(--shadow-1)] flex flex-col gap-2">
+                <article class="p-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/40 backdrop-blur-sm flex flex-col gap-2">
                   <div class="flex justify-between gap-3 items-start flex-wrap">
                     <div class="grid gap-1">
-                      <strong class="text-sm text-text-strong">${provider.runtime_id ?? provider.provider}</strong>
-                      <span class="text-xs text-text-muted">${provider.provider_id ?? '(unknown provider)'}</span>
+                      <strong class="text-sm text-[var(--color-fg-primary)]">${provider.runtime_id ?? provider.provider}</strong>
+                      <span class="text-xs text-[var(--color-fg-muted)]">${provider.provider_id ?? '(unknown provider)'}</span>
                     </div>
                     <div class="flex items-center gap-2 flex-wrap justify-end">
                       <${StatusChip} tone=${runtimeProviderTone(provider)}>${runtimeStatusLabel(provider)}<//>
                       <${StatusChip} tone=${runtimeProbeTone(liveProbe)} uppercase=${false}>live ${runtimeProbeLabel(liveProbe)}<//>
                     </div>
                   </div>
-                  <div class="grid grid-cols-2 gap-3 text-xs text-text-body">
+                  <div class="grid grid-cols-2 gap-3 text-xs text-[var(--color-fg-secondary)]">
                     <div>model · ${provider.model_api_name ?? provider.model_id ?? '-'}</div>
                     <div>default · ${provider.is_default_runtime ? 'yes' : 'no'}</div>
                     <div>transport · ${provider.runtime_kind ?? provider.transport ?? '-'}</div>
@@ -538,7 +538,7 @@ export function RuntimeMonitor() {
                     <div>auth · ${runtimeProbeAuthLabel(liveProbe)}</div>
                   </div>
                   ${liveProbe?.probe_url || provider.endpoint_url
-                    ? html`<div class="truncate text-2xs text-text-muted" title=${liveProbe?.probe_url ?? provider.endpoint_url ?? ''}>
+                    ? html`<div class="truncate text-2xs text-[var(--color-fg-muted)]" title=${liveProbe?.probe_url ?? provider.endpoint_url ?? ''}>
                         probe · ${liveProbe?.probe_url ?? provider.endpoint_url}
                       </div>`
                     : null}
@@ -546,7 +546,7 @@ export function RuntimeMonitor() {
                     ? html`<div class="text-2xs text-[var(--status-bad)]">${liveProbe.error}</div>`
                     : null}
                   ${provider.discovery
-                    ? html`<div class="grid grid-cols-2 gap-3 text-xs text-text-body pt-2 border-t border-card-border/50">
+                    ? html`<div class="grid grid-cols-2 gap-3 text-xs text-[var(--color-fg-secondary)] pt-2 border-t border-[var(--color-border-default)]/50">
                         <div>discovery · ${provider.discovery.healthy ? 'healthy' : 'degraded'}</div>
                         <div>ctx · ${formatNumber(provider.discovery.ctx_size)}</div>
                         <div>slots · ${formatNumber(provider.discovery.busy_slots)}/${formatNumber(provider.discovery.total_slots)}</div>
@@ -597,11 +597,11 @@ export function RuntimeMonitor() {
                   metric.coverage_status === 'none'
                   || metric.coverage_status === 'partial'
                   || metric.coverage_status === 'error_only'
-                let articleClass = 'p-4 rounded-[var(--r-1)] border border-card-border bg-card/40 backdrop-blur-sm shadow-[var(--shadow-1)] flex flex-col gap-2'
+                let articleClass = 'p-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/40 backdrop-blur-sm flex flex-col gap-2'
                 if (isFailing) {
-                  articleClass = 'p-4 rounded-[var(--r-1)] border border-[var(--status-bad)] bg-[var(--status-bad)]/5 backdrop-blur-sm shadow-[var(--shadow-1)] flex flex-col gap-2'
+                  articleClass = 'p-4 rounded-[var(--r-1)] border border-[var(--status-bad)] bg-[var(--status-bad)]/5 backdrop-blur-sm flex flex-col gap-2'
                 } else if (hasCoverageGap) {
-                  articleClass = 'p-4 rounded-[var(--r-1)] border border-[var(--status-warn)] bg-[var(--status-warn)]/5 backdrop-blur-sm shadow-[var(--shadow-1)] flex flex-col gap-2'
+                  articleClass = 'p-4 rounded-[var(--r-1)] border border-[var(--status-warn)] bg-[var(--status-warn)]/5 backdrop-blur-sm flex flex-col gap-2'
                 }
                 const runtimeLabel = metric.model_id
                 const ariaLabel = isFailing
@@ -616,8 +616,8 @@ export function RuntimeMonitor() {
                 >
                   <div class="flex justify-between gap-3 items-start flex-wrap">
                     <div class="grid gap-1">
-                      <strong class="text-sm text-text-strong">${runtimeLabel}</strong>
-                      <span class="text-xs text-text-muted">entries ${formatNumber(metric.entry_count)} · fallback ${formatNumber(metric.fallback_count)}</span>
+                      <strong class="text-sm text-[var(--color-fg-primary)]">${runtimeLabel}</strong>
+                      <span class="text-xs text-[var(--color-fg-muted)]">entries ${formatNumber(metric.entry_count)} · fallback ${formatNumber(metric.fallback_count)}</span>
                       ${metricCoverageText(metric)
                         ? html`<span class="text-2xs ${hasCoverageGap ? 'text-[var(--status-warn)]' : 'text-[var(--color-fg-muted)]'}">${metricCoverageText(metric)}</span>`
                         : null}
@@ -659,7 +659,7 @@ export function RuntimeMonitor() {
                         : null}
                     </div>
                   </div>
-                  <div class="grid grid-cols-3 gap-3 text-xs text-text-body">
+                  <div class="grid grid-cols-3 gap-3 text-xs text-[var(--color-fg-secondary)]">
                     <div>latency avg/p95 · ${fmtCoverageAwareNumber(metric, metric.avg_latency_ms, 1)} / ${fmtCoverageAwareNumber(metric, metric.p95_latency_ms, 1)} ms</div>
                     <div>wall tok/s p50/p95 · ${fmtCoverageAwareNumber(metric, metric.p50_tok_per_sec, 1)} / ${fmtCoverageAwareNumber(metric, metric.p95_tok_per_sec, 1)}</div>
                     <div>cost · ${fmtCoverageAwareCost(metric, metric.total_cost_usd)}</div>
@@ -667,10 +667,10 @@ export function RuntimeMonitor() {
                     <div>reasoning/cache · ${fmtCoverageAwareNumber(metric, metric.total_reasoning_tokens)} / ${fmtCoverageAwareNumber(metric, metric.total_cache_read_tokens)}</div>
                     <div>tools · ${formatNumber(metric.avg_tool_calls_per_turn, 1)}/turn (${formatNumber(metric.total_tool_calls)})</div>
                     ${metric.prompt_p50_tok_per_sec != null || metric.prompt_p95_tok_per_sec != null
-                      ? html`<div class="col-span-3 text-text-muted">prefill tok/s p50/p95 · ${formatNumber(metric.prompt_p50_tok_per_sec, 1)} / ${formatNumber(metric.prompt_p95_tok_per_sec, 1)} (prompt_eval only; complements wall + hw rows)</div>`
+                      ? html`<div class="col-span-3 text-[var(--color-fg-muted)]">prefill tok/s p50/p95 · ${formatNumber(metric.prompt_p50_tok_per_sec, 1)} / ${formatNumber(metric.prompt_p95_tok_per_sec, 1)} (prompt_eval only; complements wall + hw rows)</div>`
                       : null}
                     ${metric.hw_decode_p50_tok_per_sec != null
-                      ? html`<div class="col-span-3 text-text-muted">hw tok/s p50/p95 · ${formatNumber(metric.hw_decode_p50_tok_per_sec, 1)} / ${formatNumber(metric.hw_decode_p95_tok_per_sec, 1)} (decode-only; excludes queue/prefill/thinking)</div>`
+                      ? html`<div class="col-span-3 text-[var(--color-fg-muted)]">hw tok/s p50/p95 · ${formatNumber(metric.hw_decode_p50_tok_per_sec, 1)} / ${formatNumber(metric.hw_decode_p95_tok_per_sec, 1)} (decode-only; excludes queue/prefill/thinking)</div>`
                       : null}
                   </div>
                   ${(() => {
@@ -727,7 +727,7 @@ export function RuntimeMonitor() {
                         ${expandedModel.value === metric.model_id ? '▾' : '▸'} recent ${metric.recent_entries?.length ?? 0} turns
                       </button>
                       ${expandedModel.value === metric.model_id
-                        ? html`<div class="mt-1 border-t border-card-border/50 pt-2">
+                        ? html`<div class="mt-1 border-t border-[var(--color-border-default)]/50 pt-2">
                             <${Table}
                               columns=${recentEntryColumns}
                               rows=${metric.recent_entries ?? []}

--- a/dashboard/src/components/runtime-panel.test.ts
+++ b/dashboard/src/components/runtime-panel.test.ts
@@ -209,4 +209,14 @@ describe('RuntimePanel', () => {
     const filterChips = container.querySelector('[data-testid="filter-chips"]')
     expect(filterChips?.getAttribute('data-value')).toBe('providers')
   })
+
+  it('wraps the panel in the v2 monitoring surface class', async () => {
+    route.value.params = {}
+    const { RuntimePanel } = await loadRuntimePanel()
+    render(html`<${RuntimePanel} />`, container)
+    await flushUi()
+
+    const surface = container.querySelector('.v2-monitoring-surface')
+    expect(surface).not.toBeNull()
+  })
 })

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -110,8 +110,8 @@ function HiddenDiagnosticsLinks() {
     >
       <div class="flex flex-col gap-3">
         <div>
-          <div class="text-sm font-semibold text-text-strong">Diagnostics</div>
-          <div class="mt-1 max-w-2xl text-xs leading-relaxed text-text-muted">
+          <div class="text-sm font-semibold text-[var(--color-fg-primary)]">Diagnostics</div>
+          <div class="mt-1 max-w-2xl text-xs leading-relaxed text-[var(--color-fg-muted)]">
             These are routeable support surfaces, not primary Monitor lanes. Use them when a keeper-facing runtime incident points at infrastructure or stale rollout state.
           </div>
         </div>
@@ -123,8 +123,8 @@ function HiddenDiagnosticsLinks() {
               params=${{ section: link.section }}
               class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2 transition-colors hover:border-[var(--color-border-strong)] hover:bg-[var(--color-bg-elevated)]"
             >
-              <span class="block text-xs font-semibold text-text-strong">${link.label}</span>
-              <span class="mt-1 block text-2xs leading-relaxed text-text-muted">${link.detail}</span>
+              <span class="block text-xs font-semibold text-[var(--color-fg-primary)]">${link.label}</span>
+              <span class="mt-1 block text-2xs leading-relaxed text-[var(--color-fg-muted)]">${link.detail}</span>
             <//>
           `)}
         </div>
@@ -137,7 +137,7 @@ export function RuntimePanel() {
   const view = activeView.value
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="v2-monitoring-surface flex flex-col gap-4">
       <div class="flex flex-col gap-2">
         <${FilterChips}
           chips=${PRIMARY_VIEW_CHIPS}

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -180,6 +180,7 @@ export function RuntimeTomlEditor() {
 
   return html`
     <${SectionCard}
+      class="v2-monitoring-panel"
       label="runtime.toml"
       testId="runtime-toml-editor"
       right=${html`

--- a/dashboard/src/components/sidecar-startup-watch.ts
+++ b/dashboard/src/components/sidecar-startup-watch.ts
@@ -95,7 +95,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
   const elapsedSec = startAt !== null ? Math.floor((Date.now() - startAt) / 1000) : 0
 
   return html`
-    <${SurfaceCard} class="mt-2 flex items-center gap-2 !border-[var(--warn-20)] !bg-[var(--warn-10)] !px-3 !py-2 text-2xs text-[var(--color-status-warn)]" data-startup-warning=${connectorId}>
+    <${SurfaceCard} class="mt-2 flex items-center gap-2 !border-[var(--warn-20)] !bg-[var(--warn-10)] !px-3 !py-2 text-2xs text-[var(--color-status-warn)] v2-sidecar-startup-watch" data-startup-warning=${connectorId}>
       <span class="text-base leading-none" aria-hidden="true">⚠</span>
       <div class="min-w-0 flex-1">
         <div class="font-semibold" data-startup-warning-elapsed=${String(elapsedSec)}>기동 응답 없음 (${elapsedSec}s 경과)</div>

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -37,6 +37,7 @@
 @import "./v2-theme.css";
 @import "./v2-logs.css";
 @import "./v2-overview.css";
+@import "./v2-connectors.css";
 @import "./a11y.css"; /* after feature styles so reduced-motion overrides win */
 
 /* Strangler Fig migration bridge — bridges legacy CSS hooks to

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -38,6 +38,7 @@
 @import "./v2-logs.css";
 @import "./v2-overview.css";
 @import "./v2-connectors.css";
+@import "./v2-monitoring.css";
 @import "./a11y.css"; /* after feature styles so reduced-motion overrides win */
 
 /* Strangler Fig migration bridge — bridges legacy CSS hooks to

--- a/dashboard/src/styles/v2-connectors.css
+++ b/dashboard/src/styles/v2-connectors.css
@@ -1,0 +1,118 @@
+/* MASC Dashboard v2 — Connectors surface.
+ *
+ * Scoped to .v2-connector-* and .v2-sidecar-startup-* so unmigrated
+ * surfaces keep their legacy styling.
+ *
+ * Colors come from v2-theme.css; this file handles surface-specific
+ * layout, hairlines, hover states, and brass accent touches.
+ */
+
+.v2-connector-status,
+.v2-connector-overview-strip,
+.v2-connector-overview-skeleton,
+.v2-connector-onboarding,
+.v2-connector-keeper-matrix,
+.v2-connector-paths-strip,
+.v2-connector-readiness-rail,
+.v2-connector-quick-bind,
+.v2-connector-flow,
+.v2-connector-config-form,
+.v2-sidecar-startup-watch {
+  --v2-connector-top-glow: rgb(var(--brass-glow) / 0.04);
+}
+
+/* ── Panels (SurfaceCard containers) ───────────────────────────────────────── */
+
+.v2-connector-status [data-surface-card],
+.v2-connector-overview-strip [data-surface-card],
+.v2-connector-onboarding [data-surface-card],
+.v2-connector-keeper-matrix [data-surface-card],
+.v2-connector-paths-strip [data-surface-card],
+.v2-connector-quick-bind [data-surface-card],
+.v2-connector-flow [data-surface-card],
+.v2-connector-config-form [data-surface-card],
+.v2-sidecar-startup-watch [data-surface-card] {
+  box-shadow: inset 0 1px 0 var(--v2-connector-top-glow);
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-connector-status [data-surface-card]:hover,
+.v2-connector-overview-strip [data-surface-card]:hover,
+.v2-connector-onboarding [data-surface-card]:hover,
+.v2-connector-keeper-matrix [data-surface-card]:hover,
+.v2-connector-paths-strip [data-surface-card]:hover,
+.v2-connector-quick-bind [data-surface-card]:hover,
+.v2-connector-flow [data-surface-card]:hover,
+.v2-connector-config-form [data-surface-card]:hover,
+.v2-sidecar-startup-watch [data-surface-card]:hover {
+  border-color: var(--color-border-strong);
+}
+
+/* ── Overview strip ────────────────────────────────────────────────────────── */
+
+.v2-connector-overview-strip {
+  background: var(--color-bg-surface);
+  border-color: var(--color-border-default);
+}
+
+.v2-connector-overview-strip [data-overview-tile] [data-surface-card] {
+  background: var(--color-bg-surface);
+  border-color: var(--color-border-default);
+}
+
+.v2-connector-overview-strip [data-overview-tile] [data-surface-card]:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-elevated);
+}
+
+/* ── Readiness rail ────────────────────────────────────────────────────────── */
+
+.v2-connector-readiness-rail [data-rail-pill] {
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease, filter 120ms ease;
+}
+
+.v2-connector-readiness-rail [data-rail-pill]:not(:disabled):hover {
+  border-color: var(--color-border-strong);
+}
+
+/* ── Quick bind ───────────────────────────────────────────────────────────── */
+
+.v2-connector-quick-bind [data-surface-card] {
+  background: var(--color-bg-surface);
+  border-color: var(--color-border-default);
+}
+
+/* ── Config form sections ─────────────────────────────────────────────────── */
+
+.v2-connector-config-form [data-surface-card] {
+  background: var(--color-bg-surface);
+  border-color: var(--color-border-default);
+}
+
+/* ── Flow nodes ───────────────────────────────────────────────────────────── */
+
+.v2-connector-flow [data-surface-card] {
+  background: var(--color-bg-elevated);
+  border-color: var(--color-border-default);
+}
+
+/* ── Startup watch banner ─────────────────────────────────────────────────── */
+
+.v2-sidecar-startup-watch [data-surface-card] {
+  background: var(--color-warn-soft);
+  border-color: var(--warn-border);
+}
+
+/* ── Action buttons ────────────────────────────────────────────────────────── */
+
+.v2-connector-status [data-action-button]:not(:disabled),
+.v2-connector-overview-strip [data-action-button]:not(:disabled),
+.v2-connector-onboarding [data-action-button]:not(:disabled),
+.v2-connector-keeper-matrix [data-action-button]:not(:disabled),
+.v2-connector-paths-strip [data-action-button]:not(:disabled),
+.v2-connector-quick-bind [data-action-button]:not(:disabled),
+.v2-connector-flow [data-action-button]:not(:disabled),
+.v2-connector-config-form [data-action-button]:not(:disabled),
+.v2-sidecar-startup-watch [data-action-button]:not(:disabled) {
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease, box-shadow 120ms ease;
+}

--- a/dashboard/src/styles/v2-monitoring.css
+++ b/dashboard/src/styles/v2-monitoring.css
@@ -1,0 +1,132 @@
+/* MASC Dashboard v2 — Monitoring surface.
+ *
+ * Scoped to .v2-monitoring-* so unmigrated surfaces keep their legacy
+ * styling. Covers Runtime, Fleet, Agent roster/profile/detail, Keeper
+ * runtime/reactivity, and Governance monitor lanes.
+ *
+ * Colors come from v2-theme.css; this file handles surface-specific
+ * layout, soft brass top glow, hairlines, hover states, and consistent
+ * borders for tables/cards/panels.
+ */
+
+.v2-monitoring-surface,
+.v2-monitoring-panel,
+.v2-monitoring-card,
+.v2-monitoring-row,
+.v2-monitoring-action,
+.v2-monitoring-table,
+.v2-monitoring-detail {
+  --v2-monitoring-top-glow: rgb(var(--brass-glow) / 0.04);
+}
+
+/* ── Panels / cards ───────────────────────────────────────────────────────── */
+
+.v2-monitoring-panel,
+.v2-monitoring-card {
+  box-shadow: inset 0 1px 0 var(--v2-monitoring-top-glow);
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-monitoring-card:hover {
+  border-color: var(--color-border-strong);
+}
+
+/* ── Rows (roster, tables, lists) ─────────────────────────────────────────── */
+
+.v2-monitoring-row,
+.v2-monitoring-panel table tbody tr,
+.v2-monitoring-detail table tbody tr,
+.v2-monitoring-table tbody tr {
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-monitoring-row:hover,
+.v2-monitoring-panel table tbody tr:hover,
+.v2-monitoring-detail table tbody tr:hover,
+.v2-monitoring-table tbody tr:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-elevated);
+}
+
+/* ── Action buttons ───────────────────────────────────────────────────────── */
+
+.v2-monitoring-action:not(:disabled),
+.v2-monitoring-panel .v2-monitoring-action:not(:disabled),
+.v2-monitoring-card .v2-monitoring-action:not(:disabled) {
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-monitoring-action:not(:disabled):hover {
+  border-color: var(--color-accent-fg);
+  background: var(--color-brass-soft);
+}
+
+/* ── Telemetry / health / FSM tables ──────────────────────────────────────── */
+
+.v2-monitoring-table,
+.v2-monitoring-panel table,
+.v2-monitoring-detail table {
+  border-color: var(--color-border-default);
+}
+
+.v2-monitoring-table thead,
+.v2-monitoring-panel table thead,
+.v2-monitoring-detail table thead {
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.v2-monitoring-table th,
+.v2-monitoring-panel table th,
+.v2-monitoring-detail table th {
+  color: var(--color-fg-muted);
+}
+
+.v2-monitoring-table td,
+.v2-monitoring-panel table td,
+.v2-monitoring-detail table td {
+  color: var(--color-fg-secondary);
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+/* ── Detail sections ──────────────────────────────────────────────────────── */
+
+.v2-monitoring-detail {
+  box-shadow: inset 0 1px 0 var(--v2-monitoring-top-glow);
+}
+
+/* ── Runtime panel / TOML editor chrome ───────────────────────────────────── */
+
+.v2-monitoring-panel .v2-monitoring-toolbar {
+  background: linear-gradient(
+    180deg,
+    var(--color-bg-elevated) 0%,
+    var(--color-bg-surface) 100%
+  );
+  border-color: var(--color-border-divider);
+}
+
+.v2-monitoring-panel .v2-monitoring-code-frame {
+  background: var(--color-bg-page);
+  border-color: var(--color-border-default);
+}
+
+/* ── Agent roster rows ────────────────────────────────────────────────────── */
+
+.v2-monitoring-roster-row {
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-monitoring-roster-row:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-elevated);
+}
+
+/* ── FSM matrix cells ─────────────────────────────────────────────────────── */
+
+.v2-monitoring-fsm-cell {
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-monitoring-fsm-cell:hover {
+  border-color: var(--color-border-strong);
+}

--- a/dashboard/src/styles/v2-theme.css
+++ b/dashboard/src/styles/v2-theme.css
@@ -94,8 +94,22 @@
   --color-accent-fg: var(--accent-brass);
   --color-accent-fg-dim: var(--accent-brass-dim);
   --color-accent-glow: var(--brass-glow);
+  --accent-6: rgb(var(--brass-glow) / .06);
+  --accent-8: rgb(var(--brass-glow) / .08);
+  --accent-10: rgb(var(--brass-glow) / .10);
   --accent-12: rgb(var(--brass-glow) / .12);
+  --accent-15: rgb(var(--brass-glow) / .15);
+  --accent-18: rgb(var(--brass-glow) / .18);
+  --accent-20: rgb(var(--brass-glow) / .20);
   --accent-22: rgb(var(--brass-glow) / .22);
+  --accent-25: rgb(var(--brass-glow) / .25);
+  --accent-30: rgb(var(--brass-glow) / .30);
+  --accent-35: rgb(var(--brass-glow) / .35);
+  --accent-36: rgb(var(--brass-glow) / .36);
+  --accent-40: rgb(var(--brass-glow) / .40);
+  --accent-50: rgb(var(--brass-glow) / .50);
+  --color-accent: var(--accent-brass);
+  --color-accent-soft: var(--brass-soft);
 
   /* Legacy status → v2 */
   --ok: var(--status-ok);
@@ -117,7 +131,14 @@
 
   /* Status soft/alpha slots */
   --ok-soft: rgb(90 122 58 / .10);
+  --ok-6: rgb(90 122 58 / .06);
+  --ok-8: rgb(90 122 58 / .08);
   --ok-10: rgb(90 122 58 / .10);
+  --ok-12: rgb(90 122 58 / .12);
+  --ok-20: rgb(90 122 58 / .20);
+  --ok-22: rgb(90 122 58 / .22);
+  --ok-25: rgb(90 122 58 / .25);
+  --ok-28: rgb(90 122 58 / .28);
   --ok-30: rgb(90 122 58 / .30);
   --ok-fg: #9abc7a;
   --ok-border: rgb(90 122 58 / .35);
@@ -126,6 +147,9 @@
   --warn-10: rgb(160 106 26 / .10);
   --warn-12: rgb(160 106 26 / .12);
   --warn-20: rgb(160 106 26 / .20);
+  --warn-22: rgb(160 106 26 / .22);
+  --warn-25: rgb(160 106 26 / .25);
+  --warn-30: rgb(160 106 26 / .30);
   --warn-fg: #d49a3a;
   --warn-bright: #e0a040;
   --warn-border: rgb(160 106 26 / .35);
@@ -133,7 +157,13 @@
   --err-soft: rgb(160 24 24 / .12);
   --bad-soft: rgb(160 24 24 / .15);
   --bad-6: rgb(160 24 24 / .06);
+  --bad-8: rgb(160 24 24 / .08);
   --bad-10: rgb(160 24 24 / .10);
+  --bad-12: rgb(160 24 24 / .12);
+  --bad-20: rgb(160 24 24 / .20);
+  --bad-22: rgb(160 24 24 / .22);
+  --bad-25: rgb(160 24 24 / .25);
+  --bad-28: rgb(160 24 24 / .28);
   --bad-30: rgb(160 24 24 / .30);
   --err-fg: #d06060;
   --bad-light: #e07070;
@@ -149,4 +179,30 @@
   --color-info: #6a8eb0;
   --color-scrollbar-thumb: #2a1f1a;
   --color-scrollbar-thumb-hover: #3d2e22;
+
+  /* Legacy component tokens → v2 */
+  --text: var(--color-fg-primary);
+  --bg-subtle: var(--color-bg-elevated);
+  --border-subtle: var(--border-soft);
+  --color-border-subtle: var(--border-soft);
+  --surface-inset: var(--color-bg-page);
+  --input-border: var(--color-border-strong);
+  --input-bg: var(--color-bg-page);
+  --shadow-1: 0 1px 2px 0 rgb(0 0 0 / .18);
+  --shadow-panel: 0 1px 3px 0 rgb(0 0 0 / .18);
+  --elev-6-shadow: 0 18px 45px -6px rgb(0 0 0 / .35);
+
+  /* Legacy purple / stalled / paused → v2 warn/idle */
+  --purple: #9a7ab0;
+  --purple-12: rgb(154 122 176 / .12);
+  --purple-24: rgb(154 122 176 / .24);
+  --stalled-fg: #b090c8;
+  --paused: var(--status-warn);
+  --paused-10: var(--warn-10);
+  --paused-20: var(--warn-20);
+
+  /* Legacy gold → v2 brass */
+  --gold-8: rgb(196 162 101 / .08);
+  --gold-10: rgb(196 162 101 / .10);
+  --gold-15: rgb(196 162 101 / .15);
 }


### PR DESCRIPTION
Continues the v2 dark-fantasy design-system migration after #21292.

Surfaces
- Connectors (status, overview strip, readiness rail, config form, flow, keeper matrix, onboarding, paths strip, quick bind, startup watch)
- Monitoring (runtime panels, fleet telemetry/health/FSM, agents-unified, agent roster/profile/detail, agent-monitor, keeper reactivity, governance monitor)

Changes:
- Add scoped `v2-connectors.css` and `v2-monitoring.css` for surface-specific layout, hairlines, hover states, and brass accents.
- Extend the global `v2-theme.css` token bridge with missing alpha/status/component tokens.
- Apply v2 root/classes to each migrated surface.
- Fix undefined/mismatched tokens (`--accent-1`, `--brick-soft`, `--color-bg-secondary`, `--color-fg-default`, `--color-bg-default`, `--ok-20`, `--bad-20`, `--accent-18`, `--border-subtle`, `--surface-inset`, `text-text-strong`, `text-text-muted`, `text-text-body`, `border-card-border`, `bg-card`, `text-ok`, `bg-ok/10`, `border-ok/30`, etc.).

Verification:
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm vitest run src/components/connector-*.test.ts src/components/sidecar-startup-watch.test.ts src/components/runtime-monitor.test.ts src/components/runtime-panel.test.ts src/components/runtime-toml-editor.test.ts src/components/runtime-environment-editor.test.ts src/components/runtime-health-snapshot.test.ts src/components/keeper-runtime-model-editor.test.ts src/components/keeper-detail-runtime.test.ts src/components/fleet-telemetry-panel.test.ts src/components/fleet-health-panel.test.ts src/components/fleet-fsm-matrix.test.ts src/components/fleet-data-core.test.ts src/components/agents-unified.test.ts src/components/agent-roster.test.ts src/components/agent-detail-timeline.test.ts src/components/agent-detail-state.test.ts src/components/agent-monitor/*.test.ts src/components/keeper-reactivity-monitor.test.ts src/components/governance-monitor.test.ts` ✅ (484 tests)
- `pnpm build` ✅