### PR TITLE
feat(keeper): structural board trust partition (RFC-0248 PR-2)

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -121,7 +121,21 @@ let provenance_label (p : Keeper_world_observation.observation_provenance) : str
   | Unknown -> "unknown"
 ;;
 
-let format_board_event_line
+(* RFC-0248 PR-2: a trust-tagged board line. The decision "render this line as
+   operator-reachable instruction, or keep it inside the observational-data
+   envelope?" is made exactly once, in [board_line_of_event]. The variant then
+   carries the trust boundary to the point of rendering: there is no longer a
+   function that renders a list of board events as a bare string, so a future
+   edit cannot accidentally drop fleet narrative (self/peer/automation/unknown)
+   into the instruction stream — the confabulation path PR-1 fenced at render
+   time becomes a compile error. Trusted lines render via
+   [render_trusted_lines]; observation lines render ONLY via
+   [render_observation_lines], the sole site that applies the envelope. *)
+type board_line =
+  | Trusted_line of string
+  | Observation_line of string
+
+let format_board_event_text
     (event : Keeper_world_observation.pending_board_event) : string =
   let kind = provenance_label event.provenance in
   let mention_note =
@@ -159,9 +173,22 @@ let format_board_event_line
     event.preview
 ;;
 
-let format_board_events
-    (events : Keeper_world_observation.pending_board_event list) : string =
-  String.concat "\n" (List.map format_board_event_line events)
+let board_line_of_event
+    (event : Keeper_world_observation.pending_board_event) : board_line =
+  let line = format_board_event_text event in
+  (* Same predicate as the prior runtime [is_trusted]: trusted = NOT quarantined
+     (human direction) OR an explicit @mention (the actionable channel). The tag
+     is fixed here; neither renderer can override it. *)
+  if (not (Keeper_world_observation.should_quarantine event.provenance))
+     || event.explicit_mention
+  then Trusted_line line
+  else Observation_line line
+;;
+
+let render_trusted_lines (lines : board_line list) : string =
+  lines
+  |> List.filter_map (function Trusted_line s -> Some s | Observation_line _ -> None)
+  |> String.concat "\n"
 ;;
 
 (* RFC-0247: observational-data envelope. Fleet-authored board narrative is
@@ -181,6 +208,23 @@ let observation_data_envelope_header =
 ;;
 
 let observation_data_envelope_footer = "\n--- end observational-data ---\n"
+;;
+
+(* RFC-0248 PR-2: the SOLE renderer for observation lines. Applying the envelope
+   is structurally mandatory — there is no function that turns an
+   [Observation_line] into a bare string, so fleet narrative cannot reach the
+   instruction stream. Returns [None] when there are no observations so the
+   caller adds nothing. Output is byte-identical to the PR-1 render-time
+   partition that wrapped the quarantined list. *)
+let render_observation_lines (lines : board_line list) : string option =
+  match
+    lines |> List.filter_map (function Observation_line s -> Some s | Trusted_line _ -> None)
+  with
+  | [] -> None
+  | obs ->
+    Some
+      (observation_data_envelope_header ^ String.concat "\n" obs
+       ^ observation_data_envelope_footer)
 ;;
 
 let line_block label value =
@@ -849,26 +893,22 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
        keeper_board_post_get / keeper_board_post_comment to verify. *)
     | Keeper_context_layers.Board_activity ->
       if observation.pending_board_events <> [] then (
-        let is_trusted (event : Keeper_world_observation.pending_board_event) =
-          (not (Keeper_world_observation.should_quarantine event.provenance))
-          || event.explicit_mention
-        in
-        let trusted, quarantined =
-          List.partition is_trusted observation.pending_board_events
-        in
+        (* RFC-0248 PR-2: each event becomes a trust-tagged [board_line] once,
+           then the typed renderers place it. Trusted lines render as
+           instruction; observation lines render ONLY inside the envelope. The
+           type makes dropping fleet narrative into the instruction stream a
+           compile error. *)
+        let lines = List.map board_line_of_event observation.pending_board_events in
         let ubuf = Buffer.create 256 in
         Buffer.add_string ubuf
           (Printf.sprintf "### Board Activity (%d new)\n"
              (List.length observation.pending_board_events));
-        (match trusted with
-         | [] -> ()
-         | _ -> Buffer.add_string ubuf (format_board_events trusted));
-        (match quarantined with
-         | [] -> ()
-         | _ ->
-           Buffer.add_string ubuf observation_data_envelope_header;
-           Buffer.add_string ubuf (format_board_events quarantined);
-           Buffer.add_string ubuf observation_data_envelope_footer);
+        (match render_trusted_lines lines with
+         | "" -> ()
+         | trusted -> Buffer.add_string ubuf trusted);
+        (match render_observation_lines lines with
+         | None -> ()
+         | Some envelope -> Buffer.add_string ubuf envelope);
         if
           tool_allowed "keeper_board_curation_submit"
           && List.length observation.pending_board_events >= 2

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -102,6 +102,52 @@ let test_single_board_event_skips_curation_gate () =
   check bool "board_curation absent" false
     (List.mem "board_curation" affordances)
 
+(* RFC-0248 PR-2 behavioral proof: the trust boundary reaches the assembled
+   prompt. A fleet-authored board event (peer/self/automation) renders ONLY
+   inside the observational-data envelope; a human-authored event renders as
+   trusted instruction without it. This closes the test gap left since PR-1,
+   whose provenance tests covered classification only, not prompt rendering. *)
+let contains_sub sub s =
+  let sub_len = String.length sub in
+  let s_len = String.length s in
+  let rec aux i =
+    if i + sub_len > s_len then false
+    else if String.sub s i sub_len = sub then true
+    else aux (i + 1)
+  in
+  if sub_len = 0 then true else aux 0
+;;
+
+let test_quarantined_board_event_wraps_in_envelope () =
+  Masc_test_deps.init_keeper_tool_registry ();
+  let peer_event =
+    {
+      sample_board_event with
+      post_id = "peer-post-1";
+      author = "keeper-ramarama-agent";
+      preview = "I assert the build is green.";
+      provenance = WO.Peer_keeper;
+    }
+  in
+  let human_event =
+    { sample_board_event with post_id = "human-1"; provenance = WO.Human_direct }
+  in
+  let obs_peer = { base_observation with pending_board_events = [ peer_event ] } in
+  let obs_human = { base_observation with pending_board_events = [ human_event ] } in
+  let _, peer_msg =
+    Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
+      ~observation:obs_peer ()
+  in
+  let _, human_msg =
+    Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
+      ~observation:obs_human ()
+  in
+  check bool "peer (fleet) event wrapped in observational-data envelope" true
+    (contains_sub "observational-data" peer_msg);
+  check bool "human event NOT wrapped in envelope (trusted instruction)" false
+    (contains_sub "observational-data" human_msg)
+;;
+
 let test_task_claim_requires_matched_backlog () =
   let obs =
     { base_observation with unclaimed_task_count = 3; claimable_task_count = 0 }
@@ -185,6 +231,9 @@ let () =
             `Quick test_board_curation_affordance_requires_multi_event_window;
           test_case "affordance: single board event skips curation gate" `Quick
             test_single_board_event_skips_curation_gate;
+          test_case
+            "trust: quarantined board event wraps in envelope (RFC-0248 PR-2)"
+            `Quick test_quarantined_board_event_wraps_in_envelope;
           test_case "affordance: task claim requires matched backlog" `Quick
             test_task_claim_requires_matched_backlog;
           test_case "affordance: task claim present for claimable backlog" `Quick


### PR DESCRIPTION
## Summary

RFC-0248 PR-2 makes the board trust boundary **compile-enforced** (PR-1 fenced it at render time).

PR-1 (#21294) wrapped fleet-authored board narrative (self/peer/automation/unknown provenance) in an observational-data envelope, but the rendering used a single type-agnostic `format_board_events` for both trusted and quarantined lines — the envelope was only a `Buffer.add_string` ordering convention. A future edit rendering a quarantined event outside the envelope would silently inject fleet narrative as trusted instruction (the exact confabulation regression PR-1 prevents).

PR-2 replaces it with a typed variant:

```ocaml
type board_line = Trusted_line of string | Observation_line of string
```

- `board_line_of_event` tags each event once (same predicate as PR-1: `not should_quarantine provenance`, or explicit @mention).
- `render_trusted_lines` / `render_observation_lines` are the only renderers.
- `render_observation_lines` is the **sole** site that applies the envelope.

There is no longer a function that renders a list of board events as a bare string → dropping fleet narrative into the instruction stream becomes a compile error.

## Why a typed variant, not a runtime check?

The confabulation root is structural: the same string-producing function served both trust tiers. Removing it (not wrapping a classifier around it) makes the illegal state unrepresentable. This matches the campaign's typed-invariant principle (CLAUDE.md workaround-rejection bar: no string classifiers / cap-cooldown-dedup).

## Byte-identical output

Constructive equivalence: `render_trusted_lines` = `format_board_events trusted`; `render_observation_lines` = `header ^ concat ^ footer`. Zero scoring/prompt behavior change.

## Verification

- `dune build` + `@check`: exit 0
- ocamlformat `@fmt`: clean
- `test_keeper_unified_verification_surface`: **13/13** — incl. a new behavioral test proving peer event → envelope, human event → no envelope (closes the PR-1 gap where only provenance *classification* was tested, not envelope *rendering*).
- `test_keeper_observation_provenance`: 6/6.

## RFC

Continues RFC-0248 (announce-as-data). PR-1 = #21294 (merged). No new RFC number.

Co-Authored-By: Claude <noreply@anthropic.com>
