### PR TITLE
fix(keeper-event-bridge): demote duplicate oas:event turn/tool logs to routine

### DIFF
--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -49,6 +49,19 @@ let emit_native_event_log (evt : Agent_sdk.Event_bus.event) (json : Yojson.Safe.
     Log.Oas_event.routine ~details:json "%s" message
   in
   let log message = log_at Log.Info message in
+  (* Per-turn and per-tool lifecycle is emitted at [routine] (default Debug), not
+     Info, because it is a redundant TEXT rendering of events already carried by
+     two authoritative planes: (1) for keeper agents, the keeper hook logs the
+     richer "[Keeper] ... tool_call ... outcome=... out_len=" / "[Keeper/...] turn="
+     lines at Info; (2) for every agent, [Event_log.publish] + [Sse.broadcast]
+     (see [prepare_pending_event]) carry the structured stream the dashboard and
+     REST/SSE subscribers actually consume. Demoting these four high-frequency
+     arms removes the Info-level console doubling without losing the data — it
+     stays retrievable at Debug and the structured/SSE planes are untouched. This
+     is deduplication against an existing SSOT, not symptom suppression: there is
+     no recurring failure being hidden. Agent- and context-level lifecycle below
+     stay at Info (no keeper-hook duplicate, low frequency). [TurnReady] already
+     uses [log_routine] for the same reason. *)
   match evt.payload with
   | Agent_sdk.Event_bus.AgentStarted { agent_name; task_id } ->
     log (Printf.sprintf "agent started agent=%s task_id=%s" agent_name task_id)
@@ -60,13 +73,14 @@ let emit_native_event_log (evt : Agent_sdk.Event_bus.event) (json : Yojson.Safe.
          task_id
          elapsed)
   | Agent_sdk.Event_bus.TurnStarted { agent_name; turn } ->
-    log (Printf.sprintf "turn started agent=%s turn=%d" agent_name turn)
+    log_routine (Printf.sprintf "turn started agent=%s turn=%d" agent_name turn)
   | Agent_sdk.Event_bus.TurnCompleted { agent_name; turn } ->
-    log (Printf.sprintf "turn completed agent=%s turn=%d" agent_name turn)
+    log_routine (Printf.sprintf "turn completed agent=%s turn=%d" agent_name turn)
   | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; _ } ->
-    log (Printf.sprintf "tool called agent=%s tool_name=%s" agent_name tool_name)
+    log_routine (Printf.sprintf "tool called agent=%s tool_name=%s" agent_name tool_name)
   | Agent_sdk.Event_bus.ToolCompleted { agent_name; tool_name; _ } ->
-    log (Printf.sprintf "tool completed agent=%s tool_name=%s" agent_name tool_name)
+    log_routine
+      (Printf.sprintf "tool completed agent=%s tool_name=%s" agent_name tool_name)
   | Agent_sdk.Event_bus.TurnReady { agent_name; turn; tool_names } ->
     (* [substrate:tool_surface] — deterministic per-turn snapshot of the
          tool list the LLM actually sees this turn (after guardrails,


### PR DESCRIPTION
## 목표

키퍼 도구/턴 호출이 콘솔에 "2번 찍히는" 현상 제거. 원인은 이중 실행이 아니라 **이중 로깅 평면**.

## 진단 (근거)

OAS 이벤트는 `prepare_pending_event`에서 3곳으로 분기:
1. `emit_native_event_log` → `[oas:event]` **텍스트 로그** (사람용)
2. `Event_log.publish` → 구조화 in-memory 스트림 (REST/SSE/replay 소비)
3. `Sse.broadcast` → 라이브 SSE push

**SSE 대시보드는 ②③(구조화)를 소비하지 ① 텍스트 로그를 파싱하지 않는다.** 따라서 ① 강등은 대시보드에 무해. 게다가 keeper 에이전트는 `[Keeper] ... tool_call ... outcome= out_len=` / `[Keeper/...] turn=` 라인을 keeper 훅이 이미 Info로 찍는다. 결과적으로 도구 1회가 콘솔에 3줄(oas:event 2 + keeper 훅 1)로 나와 "2번" 느낌.

## 변경

`keeper_event_bridge.ml`의 고빈도 4개 arm(`TurnStarted`/`TurnCompleted`/`ToolCalled`/`ToolCompleted`)을 `log`(Info) → `log_routine`(기본 Debug)으로 강등. `TurnReady`가 이미 쓰는 동일 패턴.
- 데이터 손실 없음: Debug로 회수 가능, 구조화 스트림·SSE·keeper 훅 Info SSOT 그대로.
- 저빈도 lifecycle(`AgentStarted/Completed`, `Context*`)은 Info 유지 (keeper 훅 중복 없음).

## 워크어라운드 아님

반복 실패 증상을 숨기는 log-demote가 아니라, **이미 존재하는 SSOT(keeper 훅 + 구조화 Event_log)에 대한 중복 텍스트 렌더 제거**. 숨기는 증상 없음. 주석에 근거 명시.

## 검증

`dune build --root . @check` REAL_EXIT=0. 로그 레벨 라우팅용 OCaml 캡처 하네스가 없어 단위 테스트는 추가하지 않음(brittle 전역 로그 캡처 날조 회피) — 검증은 컴파일 + 기존 routine 메커니즘 + 코드리뷰.

RFC-WAIVED: log-level adjustment in keeper_event_bridge, no architecture/credential/operator change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
