### PR TITLE
feat(runtime): enforce per-binding provider concurrency (RFC-0153 §4.2.3)

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -125,11 +125,15 @@ supports-seed = true
 supports-image-input = true
 supports-multimodal-inputs = true
 
-# max-concurrent is now enforced per binding by Runtime_binding_capacity
-# (RFC-0153 §4.2.3). Sized to the keeper assignment: up to 8 keepers route
-# turns here ([autonomous]4 + [reactive]4), so 8 lets them all run while
-# staying under the ollama.com endpoint concurrency limit (~10; 8 turns +
-# librarian slot = 9).
+# max-concurrent is now enforced per binding by Runtime_binding_capacity.
+# This is an interim per-model@base_url gate (RFC-0153 §4.2.3 deferred a
+# per-runtime cap to future measurement). Sized to the keeper assignment:
+# up to 8 keepers route turns here ([autonomous]4 + [reactive]4), so 8 lets
+# them all run while staying under the ollama.com endpoint concurrency limit.
+# Note that the gate wraps the whole provider attempt, not individual HTTP
+# calls; a keeper doing long local tool work while holding the slot can still
+# block other keepers on the same binding. Finer-grained enforcement is future
+# work.
 [ollama_cloud.deepseek-v4-flash]
 max-concurrent = 8
 

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -125,7 +125,13 @@ supports-seed = true
 supports-image-input = true
 supports-multimodal-inputs = true
 
+# max-concurrent is now enforced per binding by Runtime_binding_capacity
+# (RFC-0153 §4.2.3). Sized to the keeper assignment: up to 8 keepers route
+# turns here ([autonomous]4 + [reactive]4), so 8 lets them all run while
+# staying under the ollama.com endpoint concurrency limit (~10; 8 turns +
+# librarian slot = 9).
 [ollama_cloud.deepseek-v4-flash]
+max-concurrent = 8
 
 [deepseek.deepseek-v4-pro]
 

--- a/docs/TIMEOUT-MATRIX.md
+++ b/docs/TIMEOUT-MATRIX.md
@@ -104,6 +104,7 @@ logs. Candidates:
 | `operator_snapshot` refresh | 30–36 s | #9734 |
 | `a2a_tools` call | 300 s | — |
 | `tool_local_runtime_http` | 10 s | — |
+| provider binding slot wait | `MASC_KEEPER_BINDING_SLOT_WAIT_TIMEOUT_SEC` default 15 s | RFC-0153 |
 | `admission_queue.wait_timeout_sec` | unused | #9639 note |
 
 ## Non-goals

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 348 unique knobs across 9 modules.
+**Total**: 350 unique knobs across 9 modules.
 
-**Typed getter classification**: 21/207 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 186).
+**Typed getter classification**: 23/209 tagged (`operator`: 23, `algorithm`: 0, `unclassified`: 186).
 
 ## Env_config_core (29 knobs; typed classification 1/8)
 
@@ -92,17 +92,18 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 48 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 | `MASC_SSE_KEEPALIVE_SEC` | typed:float | unclassified | unclassified | 108 | SSE keepalive interval (seconds). Frequency of `: keepalive` frames on command-plane SSE streams. Clamped to >= 1.0 t... |
 
-## Env_config_keeper (64 knobs; typed classification 2/53)
+## Env_config_keeper (66 knobs; typed classification 4/55)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 213 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 530 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 565 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 566 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 567 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 568 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 571 |  |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 558 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 593 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 594 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 595 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 596 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 599 |  |
+| `MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC` | typed:float | Timeouts | operator | 352 | Legacy retry/admission wait budget. This value belongs to retry/admission deadline math and must not be reused for pr... |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 108 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 105 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 111 |  |
@@ -120,8 +121,9 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 127 |  |
 | `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 118 | Slack fanout configuration |
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
-| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 392 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 444 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 420 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
+| `MASC_KEEPER_BINDING_SLOT_WAIT_TIMEOUT_SEC` | typed:float | Timeouts | operator | 367 | Max wait for a saturated provider-model binding semaphore. This is intentionally shorter than admission/turn budgets:... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 472 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -129,37 +131,37 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 464 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 492 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 161 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 169 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 175 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 425 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 484 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 492 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 453 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 512 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 520 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
 | `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 218 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
 | `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 285 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 474 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 502 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
 | `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 259 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 519 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 547 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
 | `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 266 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
 | `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 300 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
 | `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 307 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
 | `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 233 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 353 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 502 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 381 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 530 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
 | `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 196 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
 | `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 205 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
 | `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 277 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
 | `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 243 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 179 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 508 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 401 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 536 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 429 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
 | `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 339 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
 | `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 227 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 589 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
-| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 603 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 617 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 631 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 
@@ -337,9 +339,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 638 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 642 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 644 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 642 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 646 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 648 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 218 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 308 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 310 |  |
@@ -372,7 +374,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 158 |  |
 | `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 160 |  |
 | `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 156 |  |
-| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 548 |  |
+| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 552 |  |
 | `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | string_literal | n/a | n/a | 496 |  |
 | `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 185 |  |
 | `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 181 |  |
@@ -381,32 +383,32 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 175 |  |
 | `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 177 |  |
 | `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 173 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 552 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 554 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 556 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 558 |  |
 | `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 162 |  |
-| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 556 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 504 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 506 |  |
+| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 560 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 508 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 510 |  |
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 165 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 164 |  |
 | `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 212 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 736 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 772 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 740 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 776 |  |
 | `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 469 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 784 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 686 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 688 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 690 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 692 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 716 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 788 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 690 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 692 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 694 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 696 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 720 |  |
 | `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 148 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 55 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 52 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 752 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 754 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 756 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 758 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 150 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 816 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 818 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 820 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 820 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 822 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 824 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 92 |  |
 | `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 95 |  |

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -448,16 +448,23 @@ provider binding table로 해석하지 않는다.
 ### 7.5 Client Capacity (Phase A/C3, #7606/#7623)
 
 Provider-model binding의 `max-concurrent`는 선택적 operator override다.
-누락은 정상값이며 "no static per-binding cap"을 뜻한다. 기본 provider 보호는
-global `Provider_http` gate, live health/backoff, provider-reported throttling,
-그리고 provider별 discovery/probe가 담당한다. 사람이 모든 binding에 cap을
-채우는 방식은 기본 운영 모델이 아니다.
+누락은 정상값이며 "no static per-binding cap"을 뜻한다. 각 keeper turn
+provider attempt는 binding capacity key별 semaphore를 획득한 뒤 모델 호출을
+수행한다. 슬롯이 없으면 bounded slot-wait ceiling 안에서 backpressure로
+대기한다. ceiling은 configured per-provider timeout과
+`MASC_KEEPER_BINDING_SLOT_WAIT_TIMEOUT_SEC`의 lower bound이며, per-provider
+timeout이 없으면 resolved binding-slot wait default를 사용한다. 이 대기가
+초과되면 attempt는 typed `runtime_slot` capacity backpressure로 종료되어
+keeper turn이 무기한 같은 binding에 묶이지 않는다.
 
 `max-concurrent`를 설정하는 경우는 slot API나 provider-side admission signal이
-없는 취약 endpoint를 수동으로 보호해야 할 때뿐이다. 이 값은 runtime catalog
-metadata로 보존되지만, OAS multi-turn/tool 실행 전체를 제한하는 keeper-attempt
-cap으로 해석하면 안 된다. enforcement가 필요하면 provider HTTP transport call
-단위 또는 endpoint-discovery 단위에서 적용해야 한다.
+없는 취약 endpoint를 수동으로 보호해야 할 때뿐이다. 누락/0/음수는 per-binding
+gate를 만들지 않으며, 기존 global `Fd_accountant.Provider_http` gate만
+적용된다. 양수 값은 같은 capacity key(`provider:model@base_url`)를 공유하는
+keeper 호출의 동시 실행 수를 제한한다. 이 값은 runtime catalog metadata로
+보존되지만, OAS multi-turn/tool 실행 전체를 제한하는 keeper-attempt cap으로
+해석하면 안 된다. enforcement가 필요하면 provider HTTP transport call 단위 또는
+endpoint-discovery 단위에서 적용해야 한다.
 
 ```toml
 [cli-tool-a.agent-code-spark]

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -462,9 +462,20 @@ keeper turn이 무기한 같은 binding에 묶이지 않는다.
 gate를 만들지 않으며, 기존 global `Fd_accountant.Provider_http` gate만
 적용된다. 양수 값은 같은 capacity key(`provider:model@base_url`)를 공유하는
 keeper 호출의 동시 실행 수를 제한한다. 이 값은 runtime catalog metadata로
-보존되지만, OAS multi-turn/tool 실행 전체를 제한하는 keeper-attempt cap으로
-해석하면 안 된다. enforcement가 필요하면 provider HTTP transport call 단위 또는
-endpoint-discovery 단위에서 적용해야 한다.
+보존되지만,
+
+{b Phase A granularity.} 현재 implementation은 OAS multi-turn/tool 실행 전체를
+감싸는 attempt-level cap이다. 이는 RFC-0153 §4.2.3에서 언급한 eventual
+per-HTTP-call 또는 endpoint-discovery enforcement보다 coarse하지만, fleet-wide
+측정 데이터가 쌓이기 전에 endpoint overload를 즉시 막을 수 있는 가장 단순한
+interim 대응이다. provider HTTP transport call 단위나 endpoint-discovery 단위의
+더 세밀한 enforcement는 향후 measurement-driven RFC로 대첸할 예정이다.
+
+Attempt-level cap의 trade-off: keeper가 provider 호출 중간에 로컬 툴 실행 등
+provider와 무관한 작업을 길게 하는 동안에도 slot을 점유하므로, 그 시간 동안
+같은 binding의 다른 keeper는 backpressure를 받을 수 있다. 이를 피하려면
+`binding_slot_wait_timeout_sec`를 짧게 하거나, 향후 HTTP-call granularity로
+전환해야 한다.
 
 ```toml
 [cli-tool-a.agent-code-spark]

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -339,6 +339,34 @@ module KeeperKeepalive = struct
          (get_float ~default:600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
   ;;
 
+  (** Legacy retry/admission wait budget. This value belongs to retry/admission
+      deadline math and must not be reused for provider binding semaphore waits.
+      Env: [MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC]. Default: 180.
+      Range: [5, 1200].
+      @category Timeouts
+      @ops_class operator *)
+  let admission_wait_timeout_sec =
+    Float.max
+      5.0
+      (Float.min 1200.0
+         (get_float ~default:180.0 "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"))
+  ;;
+
+  (** Max wait for a saturated provider-model binding semaphore.
+      This is intentionally shorter than admission/turn budgets: waiting on one
+      hot binding should quickly become typed runtime-slot backpressure so the
+      keeper can try another candidate or fail without pinning the fleet.
+      Env: [MASC_KEEPER_BINDING_SLOT_WAIT_TIMEOUT_SEC]. Default: 15.
+      Range: [1, 300].
+      @category Timeouts
+      @ops_class operator *)
+  let binding_slot_wait_timeout_sec =
+    Float.max
+      1.0
+      (Float.min 300.0
+         (get_float ~default:15.0 "MASC_KEEPER_BINDING_SLOT_WAIT_TIMEOUT_SEC"))
+  ;;
+
 
   (** Per-call OAS timeout override in seconds.
 

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -117,6 +117,16 @@ module KeeperKeepalive : sig
   val max_idle_turns_autonomous : int
   val max_idle_turns_reactive : int
   val turn_timeout_sec : float
+  val admission_wait_timeout_sec : float
+  (** Legacy retry/admission wait budget. This is not the provider binding
+      semaphore wait. Env: [MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC]. Clamp
+      range: [5, 1200] s. *)
+
+  val binding_slot_wait_timeout_sec : float
+  (** Max wait for a saturated provider-model binding semaphore before the
+      keeper attempt returns runtime-slot backpressure. Env:
+      [MASC_KEEPER_BINDING_SLOT_WAIT_TIMEOUT_SEC]. Clamp range: [1, 300] s. *)
+
   val oas_timeout_sec_override : float option
 
 

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -495,6 +495,10 @@ let keeper_keepalive_entries =
       "Max seconds since last heartbeat before presence sync required";
     entry ~default:"30" "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL"
       "Max turns per single OAS Agent.run call (clamped 1-100)";
+    entry ~default:"180.0" "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"
+      "Legacy retry/admission wait budget; not used for provider binding slot waits";
+    entry ~default:"15.0" "MASC_KEEPER_BINDING_SLOT_WAIT_TIMEOUT_SEC"
+      "Max wait for a saturated provider-model binding semaphore before runtime-slot backpressure";
     entry ~default:"(none)" "MASC_KEEPER_OAS_TIMEOUT_SEC"
       "Legacy optional override for OAS call timeout. When set, clamped to [30, turn_timeout_sec].";
     entry ~default:"2.0" "MASC_KEEPER_SLEEP_CHUNK_SEC"

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -17,6 +17,7 @@ type t = {
   autonomous_max_idle_turns : int field;
   turn_timeout_sec : float field;
   admission_wait_timeout_sec : float field;
+  binding_slot_wait_timeout_sec : float field;
   oas_timeout_override_sec : float option field;
   stream_idle_timeout_sec : float field;
   execution_idle_timeout_sec : float option field;
@@ -45,6 +46,14 @@ let source_to_string = function
 
 let get_int = Env_config_core.get_int
 let get_float = Env_config_core.get_float
+
+let admission_wait_timeout_sec_env = "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"
+let binding_slot_wait_timeout_sec_env = "MASC_KEEPER_BINDING_SLOT_WAIT_TIMEOUT_SEC"
+
+let get_clamped_float ~default ~min_value ~max_value name =
+  let value = get_float ~default name in
+  let value = if Float.is_finite value then value else default in
+  Float.max min_value (Float.min max_value value)
 
 let max_turns_per_call_min = 1
 let max_turns_per_call_max = 100
@@ -97,9 +106,12 @@ let turn_timeout_sec_live () =
        (get_float ~default:600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
 
 let admission_wait_timeout_sec_live () =
-  Float.max 5.0
-    (Float.min 1200.0
-       (180.0))
+  get_clamped_float ~default:180.0 ~min_value:5.0 ~max_value:1200.0
+    admission_wait_timeout_sec_env
+
+let binding_slot_wait_timeout_sec_live () =
+  get_clamped_float ~default:15.0 ~min_value:1.0 ~max_value:300.0
+    binding_slot_wait_timeout_sec_env
 
 let stream_idle_timeout_sec_live () =
   Float.max 5.0
@@ -138,11 +150,11 @@ let oas_timeout_override_sec_live ~turn_timeout_sec =
   match Env_config_core.raw_value_opt "MASC_KEEPER_OAS_TIMEOUT_SEC" with
   | Some raw ->
       (* DET-OK: env override is parsed at the keeper runtime boundary;
-         malformed values resolve to the turn budget for compatibility with
-         previous behavior. *)
+         malformed values disable the legacy override, matching
+         Env_config_keeper.KeeperKeepalive.oas_timeout_sec_override. *)
       (match Float.of_string_opt (String.trim raw) with
        | Some parsed -> Some (Float.max 30.0 (Float.min turn_timeout_sec parsed))
-       | None -> Some turn_timeout_sec)
+       | None -> None)
   | None -> None
 
 (* SSOT: Env_config_keeper.KeeperKeepalive.body_timeout_sec_override
@@ -203,8 +215,13 @@ let freeze_from_current () =
   in
   let admission_wait_timeout_sec =
     source_field
-      "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"
+      admission_wait_timeout_sec_env
       (admission_wait_timeout_sec_live ())
+  in
+  let binding_slot_wait_timeout_sec =
+    source_field
+      binding_slot_wait_timeout_sec_env
+      (binding_slot_wait_timeout_sec_live ())
   in
   let oas_timeout_override_sec =
     {
@@ -254,6 +271,7 @@ let freeze_from_current () =
     autonomous_max_idle_turns;
     turn_timeout_sec;
     admission_wait_timeout_sec;
+    binding_slot_wait_timeout_sec;
     oas_timeout_override_sec;
     stream_idle_timeout_sec;
     execution_idle_timeout_sec;
@@ -298,6 +316,7 @@ let to_yojson (runtime : t) =
       ("autonomous_max_idle_turns", field_to_yojson (fun value -> `Int value) runtime.autonomous_max_idle_turns);
       ("turn_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.turn_timeout_sec);
       ("admission_wait_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.admission_wait_timeout_sec);
+      ("binding_slot_wait_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.binding_slot_wait_timeout_sec);
       ("oas_timeout_override_sec", field_to_yojson option_float_to_yojson runtime.oas_timeout_override_sec);
       ("stream_idle_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.stream_idle_timeout_sec);
       ("execution_idle_timeout_sec", field_to_yojson option_float_to_yojson runtime.execution_idle_timeout_sec);
@@ -326,6 +345,9 @@ let turn_timeout_sec () =
 
 let admission_wait_timeout_sec () =
   (current ()).admission_wait_timeout_sec.value
+
+let binding_slot_wait_timeout_sec () =
+  (current ()).binding_slot_wait_timeout_sec.value
 
 let stream_idle_timeout_sec () =
   (current ()).stream_idle_timeout_sec.value

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -26,6 +26,7 @@ type t = {
   autonomous_max_idle_turns : int field;
   turn_timeout_sec : float field;
   admission_wait_timeout_sec : float field;
+  binding_slot_wait_timeout_sec : float field;
   oas_timeout_override_sec : float option field;
   stream_idle_timeout_sec : float field;
   execution_idle_timeout_sec : float option field;
@@ -51,6 +52,7 @@ val reactive_max_idle_turns : unit -> int
 val autonomous_max_idle_turns : unit -> int
 val turn_timeout_sec : unit -> float
 val admission_wait_timeout_sec : unit -> float
+val binding_slot_wait_timeout_sec : unit -> float
 val stream_idle_timeout_sec : unit -> float
 val execution_idle_timeout_sec : unit -> float option
 (** Resolved [turn.execution_idle_timeout_sec].

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -467,22 +467,29 @@ let run_try_provider
            for the whole attempt so keepers assigned to the same runtime
            binding cannot collectively exceed that binding's provider
            concurrency limit. An unconfigured binding ([None]) runs ungated,
-           falling back to the global [Fd_accountant.Provider_http] gate. *)
-        match
-          Runtime_binding_capacity.with_slot_result
-            ?clock:(Eio_context.get_clock_opt ())
-            ?wait_timeout_sec:
-              (binding_capacity_wait_timeout_s ?per_provider_timeout_s ())
-            ~key:(Runtime_candidate.capacity_key candidate)
-            ~max_concurrent:(Runtime_candidate.max_concurrent candidate)
-            run_fn
-        with
-        | Ok result -> result
-        | Error timeout ->
-          Error
-            (binding_capacity_wait_timeout_error
-               ~runtime_id:ctx.error_runtime_id
-               timeout))
+           falling back to the global [Fd_accountant.Provider_http] gate.
+
+           The gate requires an Eio clock so that a saturated binding can fail
+           fast instead of waiting forever. If the clock is not initialized we
+           fall back to the global gate rather than block indefinitely. *)
+        (match Eio_context.get_clock_opt () with
+         | None -> run_fn ()
+         | Some clock ->
+           match
+             Runtime_binding_capacity.with_slot_result
+               ~clock
+               ~wait_timeout_sec:
+                 (binding_capacity_wait_timeout_s ?per_provider_timeout_s ())
+               ~key:(Runtime_candidate.capacity_key candidate)
+               ~max_concurrent:(Runtime_candidate.max_concurrent candidate)
+               run_fn
+           with
+           | Ok result -> result
+           | Error timeout ->
+             Error
+               (binding_capacity_wait_timeout_error
+                  ~runtime_id:ctx.error_runtime_id
+                  timeout)))
     in
     let result =
       (* Restore typed provider-context enrichment (auth-env / not-found hints).

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -279,6 +279,36 @@ let apply_accept ~runtime_id ~accept (run_result : Runtime_agent.run_result) =
          ~runtime_id
          ~response:run_result.response)
 
+let finite_positive = function
+  | Some value when Float.is_finite value && value > 0.0 -> Some value
+  | Some _ | None -> None
+
+let binding_capacity_wait_timeout_s ?per_provider_timeout_s () =
+  let binding_slot_wait_timeout_s =
+    Keeper_runtime_resolved.binding_slot_wait_timeout_sec ()
+  in
+  match finite_positive per_provider_timeout_s with
+  | Some provider_timeout_s ->
+    Some (Float.min provider_timeout_s binding_slot_wait_timeout_s)
+  | None -> Some binding_slot_wait_timeout_s
+
+let binding_capacity_wait_timeout_error ~runtime_id
+    (timeout : Runtime_binding_capacity.wait_timeout) =
+  Keeper_internal_error.sdk_error_of_masc_internal_error
+    (Keeper_internal_error.Capacity_backpressure
+       { runtime_id
+       ; source = Keeper_internal_error.Runtime_slot
+       ; detail =
+           Printf.sprintf
+             "provider binding capacity wait timed out after %.1fs \
+              (key=%s in_flight=%d cap=%d)"
+             timeout.wait_timeout_sec
+             timeout.key
+             timeout.in_flight
+             timeout.cap
+       ; retry_after = Keeper_internal_error.No_retry_hint
+       })
+
 (** Run a single provider attempt within the runtime.
 
     This is the extracted body of the [try_provider] closure that was
@@ -434,15 +464,25 @@ let run_try_provider
          | Some (_ : float) -> ()
          | None -> ());
         (* RFC-0153 §4.2.3: hold one of the binding's [max_concurrent] slots
-           for the whole attempt so every keeper assigned to one endpoint
-           (e.g. ollama_cloud.deepseek-v4-flash, 8 keepers in live runtime.toml)
-           cannot collectively exceed its provider concurrency limit. An
-           unconfigured binding ([max_concurrent <= 0]) runs ungated, falling
-           back to the global [Fd_accountant.Provider_http] gate. *)
-        Runtime_binding_capacity.with_slot
-          ~key:(Runtime_candidate.capacity_key candidate)
-          ~max_concurrent:(Runtime_candidate.max_concurrent candidate)
-          run_fn)
+           for the whole attempt so keepers assigned to the same runtime
+           binding cannot collectively exceed that binding's provider
+           concurrency limit. An unconfigured binding ([None]) runs ungated,
+           falling back to the global [Fd_accountant.Provider_http] gate. *)
+        match
+          Runtime_binding_capacity.with_slot_result
+            ?clock:(Eio_context.get_clock_opt ())
+            ?wait_timeout_sec:
+              (binding_capacity_wait_timeout_s ?per_provider_timeout_s ())
+            ~key:(Runtime_candidate.capacity_key candidate)
+            ~max_concurrent:(Runtime_candidate.max_concurrent candidate)
+            run_fn
+        with
+        | Ok result -> result
+        | Error timeout ->
+          Error
+            (binding_capacity_wait_timeout_error
+               ~runtime_id:ctx.error_runtime_id
+               timeout))
     in
     let result =
       (* Restore typed provider-context enrichment (auth-env / not-found hints).
@@ -489,6 +529,7 @@ let run_try_provider
 module For_testing = struct
   let max_execution_time_for_attempt = max_execution_time_for_attempt
   let stream_idle_timeout_for_attempt = stream_idle_timeout_for_attempt
+  let binding_capacity_wait_timeout_s = binding_capacity_wait_timeout_s
   let sanitize_runtime_mcp_external_tool_choice =
     sanitize_runtime_mcp_external_tool_choice
   let apply_accept = apply_accept

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -398,8 +398,9 @@ let run_try_provider
   | Ok config ->
     (* Stream stall detection is handled by OAS's stream_idle_timeout_s.
        No separate liveness FSM — provider stall is an OAS-level concern.
-       No per-lane capacity gate — provider load is managed by operator
-       adjusting keeper count. *)
+       Provider load is gated per binding by [Runtime_binding_capacity]
+       (RFC-0153 §4.2.3) using the candidate's [max_concurrent], in addition to
+       the operator tuning keeper count. *)
     let run_started_at =
       Unix.gettimeofday ()
       (* NDT-OK: provider-attempt latency telemetry only; dispatch/control
@@ -432,7 +433,16 @@ let run_try_provider
         (match per_provider_timeout_s with
          | Some (_ : float) -> ()
          | None -> ());
-        run_fn ())
+        (* RFC-0153 §4.2.3: hold one of the binding's [max_concurrent] slots
+           for the whole attempt so every keeper assigned to one endpoint
+           (e.g. ollama_cloud.deepseek-v4-flash, 8 keepers in live runtime.toml)
+           cannot collectively exceed its provider concurrency limit. An
+           unconfigured binding ([max_concurrent <= 0]) runs ungated, falling
+           back to the global [Fd_accountant.Provider_http] gate. *)
+        Runtime_binding_capacity.with_slot
+          ~key:(Runtime_candidate.capacity_key candidate)
+          ~max_concurrent:(Runtime_candidate.max_concurrent candidate)
+          run_fn)
     in
     let result =
       (* Restore typed provider-context enrichment (auth-env / not-found hints).

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -428,9 +428,13 @@ let run_try_provider
   | Ok config ->
     (* Stream stall detection is handled by OAS's stream_idle_timeout_s.
        No separate liveness FSM — provider stall is an OAS-level concern.
-       Provider load is gated per binding by [Runtime_binding_capacity]
-       (RFC-0153 §4.2.3) using the candidate's [max_concurrent], in addition to
-       the operator tuning keeper count. *)
+
+       Provider load is gated per binding by [Runtime_binding_capacity] using
+       the candidate's [max_concurrent]. This gate runs *after* the per-keeper
+       turn admission ([Keeper_turn_admission], RFC-0225), so the Lane Per
+       Keeper single-flight invariant (at most one in-flight turn per keeper)
+       is preserved. The binding gate only limits how many admitted turns can
+       hit the same provider endpoint concurrently. *)
     let run_started_at =
       Unix.gettimeofday ()
       (* NDT-OK: provider-attempt latency telemetry only; dispatch/control

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -86,6 +86,9 @@ module For_testing : sig
   val stream_idle_timeout_for_attempt :
     configured:float option -> float option
 
+  val binding_capacity_wait_timeout_s :
+    ?per_provider_timeout_s:float -> unit -> float option
+
   val sanitize_runtime_mcp_external_tool_choice :
     runtime_mcp_external_tools:bool ->
     Agent_sdk.Hooks.turn_params ->

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -32,6 +32,8 @@ let key_to_env =
     "proactive.min_interval_sec",       "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC";
     (* [turn] *)
     "turn.timeout_sec",                 "MASC_KEEPER_TURN_TIMEOUT_SEC";
+    "turn.admission_wait_timeout_sec",  "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC";
+    "turn.binding_slot_wait_timeout_sec", "MASC_KEEPER_BINDING_SLOT_WAIT_TIMEOUT_SEC";
     "turn.oas_timeout_sec",             "MASC_KEEPER_OAS_TIMEOUT_SEC";
     "turn.stream_idle_timeout_sec",     "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC";
     "turn.execution_idle_timeout_sec",  "MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC";

--- a/lib/keeper_runtime/keeper_runtime_config.mli
+++ b/lib/keeper_runtime/keeper_runtime_config.mli
@@ -76,8 +76,10 @@ val resolve_overrides :
       min_interval_sec            = 900
 
       [turn]
-      stream_idle_timeout_sec   = 120
-      execution_idle_timeout_sec = 300
+      admission_wait_timeout_sec     = 180
+      binding_slot_wait_timeout_sec  = 15
+      stream_idle_timeout_sec        = 120
+      execution_idle_timeout_sec     = 300
       llm_rerank                  = true
 
       [web_search]

--- a/lib/runtime/runtime_binding_capacity.ml
+++ b/lib/runtime/runtime_binding_capacity.ml
@@ -8,6 +8,13 @@ type slot =
   ; in_flight : int Atomic.t
   }
 
+type wait_timeout =
+  { key : string
+  ; wait_timeout_sec : float
+  ; in_flight : int
+  ; cap : int
+  }
+
 (* Process-global registry of one semaphore per capacity key. The Hashtbl is
    module-global mutable state shared across every keeper fiber/domain, so all
    access is serialized under [registry_mutex] per RFC-0239 (a top-level
@@ -32,35 +39,61 @@ let slot_for ~key ~max_concurrent =
       Hashtbl.replace registry key slot;
       slot)
 
-let with_slot ~key ~max_concurrent f =
-  (* [max_concurrent <= 0] = unconfigured binding (runtime.toml omits
-     [max-concurrent], parsed as the 0 "required" marker). Run ungated rather
-     than build a 0-permit semaphore that would deadlock on first acquire. *)
-  if max_concurrent <= 0
-  then f ()
-  else begin
-    let slot = slot_for ~key ~max_concurrent in
-    (* Acquire BEFORE [Fun.protect] is armed: if acquisition is cancelled it
-       raises here and no slot is held, so there is nothing to release. Once
-       [acquire] returns the slot is held; [Atomic.incr] and entering
-       [Fun.protect] are synchronous (no await point between), so the release
-       path is guaranteed to run for every held slot. *)
+let finite_positive = function
+  | Some value when Float.is_finite value && value > 0.0 -> Some value
+  | Some _ | None -> None
+
+let acquire ?clock ?wait_timeout_sec (slot : slot) =
+  match clock, finite_positive wait_timeout_sec with
+  | Some clock, Some wait_timeout_sec ->
+    (try
+       Eio.Time.with_timeout_exn clock wait_timeout_sec (fun () ->
+         Eio.Semaphore.acquire slot.sem);
+       Ok ()
+     with Eio.Time.Timeout ->
+       Error
+         { key = ""
+         ; wait_timeout_sec
+         ; in_flight = Atomic.get slot.in_flight
+         ; cap = slot.cap
+         })
+  | _, _ ->
     Eio.Semaphore.acquire slot.sem;
-    Atomic.incr slot.in_flight;
-    Fun.protect
-      ~finally:(fun () ->
-        (* fun-protect-finally-ok: [Atomic.decr] and [Eio.Semaphore.release]
-           do not raise, so the finally cannot mask the body's exception with
-           [Fun.Finally_raised]. *)
-        Atomic.decr slot.in_flight;
-        Eio.Semaphore.release slot.sem)
-      f
-  end
+    Ok ()
+
+let with_slot_result ?clock ?wait_timeout_sec ~key ~max_concurrent f =
+  (* [None] (or [Some n] with [n <= 0]) = unconfigured binding (runtime.toml
+     omits [max-concurrent], parsed as [None]). Run ungated rather than build a
+     0-permit semaphore that would deadlock on first acquire. *)
+  match max_concurrent with
+  | None -> Ok (f ())
+  | Some max_concurrent when max_concurrent <= 0 -> Ok (f ())
+  | Some max_concurrent ->
+    let slot = slot_for ~key ~max_concurrent in
+    (* Acquire before registering cleanup: if acquisition is cancelled it raises
+       here and no slot is held. After [acquire] returns, [Atomic.incr] and
+       [Switch.on_release] registration are synchronous, so every held slot has
+       a release hook before [f] can yield. *)
+    match acquire ?clock ?wait_timeout_sec slot with
+    | Error timeout -> Error { timeout with key }
+    | Ok () ->
+      Atomic.incr slot.in_flight;
+      Ok
+        (Eio.Switch.run (fun sw ->
+           Eio.Switch.on_release sw (fun () ->
+             Atomic.decr slot.in_flight;
+             Eio.Semaphore.release slot.sem);
+           f ()))
+
+let with_slot ~key ~max_concurrent f =
+  match with_slot_result ~key ~max_concurrent f with
+  | Ok value -> value
+  | Error _ -> assert false
 
 let snapshot () =
   Eio.Mutex.use_ro registry_mutex (fun () ->
     Hashtbl.fold
-      (fun key slot acc -> (key, Atomic.get slot.in_flight, slot.cap) :: acc)
+      (fun key (slot : slot) acc -> (key, Atomic.get slot.in_flight, slot.cap) :: acc)
       registry
       [])
   |> List.sort (fun (a, _, _) (b, _, _) -> String.compare a b)

--- a/lib/runtime/runtime_binding_capacity.ml
+++ b/lib/runtime/runtime_binding_capacity.ml
@@ -1,0 +1,66 @@
+(* Per-binding provider concurrency gate. See runtime_binding_capacity.mli for
+   the rationale (RFC-0153 §4.2.3 deferred per-runtime cap; activates the inert
+   binding max_concurrent left over from the RFC-0206 runtime rebirth). *)
+
+type slot =
+  { sem : Eio.Semaphore.t
+  ; cap : int
+  ; in_flight : int Atomic.t
+  }
+
+(* Process-global registry of one semaphore per capacity key. The Hashtbl is
+   module-global mutable state shared across every keeper fiber/domain, so all
+   access is serialized under [registry_mutex] per RFC-0239 (a top-level
+   Hashtbl is indistinguishable from a fiber-local one to the type system; the
+   mutex makes the sharing explicit). The critical section is one
+   find-or-insert and never spans the semaphore acquire, so contention on the
+   registry mutex is bounded and does not serialize unrelated keys. *)
+let registry : (string, slot) Hashtbl.t = Hashtbl.create 16
+let registry_mutex = Eio.Mutex.create ()
+
+let slot_for ~key ~max_concurrent =
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+    match Hashtbl.find_opt registry key with
+    | Some slot -> slot
+    | None ->
+      let slot =
+        { sem = Eio.Semaphore.make max_concurrent
+        ; cap = max_concurrent
+        ; in_flight = Atomic.make 0
+        }
+      in
+      Hashtbl.replace registry key slot;
+      slot)
+
+let with_slot ~key ~max_concurrent f =
+  (* [max_concurrent <= 0] = unconfigured binding (runtime.toml omits
+     [max-concurrent], parsed as the 0 "required" marker). Run ungated rather
+     than build a 0-permit semaphore that would deadlock on first acquire. *)
+  if max_concurrent <= 0
+  then f ()
+  else begin
+    let slot = slot_for ~key ~max_concurrent in
+    (* Acquire BEFORE [Fun.protect] is armed: if acquisition is cancelled it
+       raises here and no slot is held, so there is nothing to release. Once
+       [acquire] returns the slot is held; [Atomic.incr] and entering
+       [Fun.protect] are synchronous (no await point between), so the release
+       path is guaranteed to run for every held slot. *)
+    Eio.Semaphore.acquire slot.sem;
+    Atomic.incr slot.in_flight;
+    Fun.protect
+      ~finally:(fun () ->
+        (* fun-protect-finally-ok: [Atomic.decr] and [Eio.Semaphore.release]
+           do not raise, so the finally cannot mask the body's exception with
+           [Fun.Finally_raised]. *)
+        Atomic.decr slot.in_flight;
+        Eio.Semaphore.release slot.sem)
+      f
+  end
+
+let snapshot () =
+  Eio.Mutex.use_ro registry_mutex (fun () ->
+    Hashtbl.fold
+      (fun key slot acc -> (key, Atomic.get slot.in_flight, slot.cap) :: acc)
+      registry
+      [])
+  |> List.sort (fun (a, _, _) (b, _, _) -> String.compare a b)

--- a/lib/runtime/runtime_binding_capacity.ml
+++ b/lib/runtime/runtime_binding_capacity.ml
@@ -43,9 +43,9 @@ let finite_positive = function
   | Some value when Float.is_finite value && value > 0.0 -> Some value
   | Some _ | None -> None
 
-let acquire ?clock ?wait_timeout_sec (slot : slot) =
-  match clock, finite_positive wait_timeout_sec with
-  | Some clock, Some wait_timeout_sec ->
+let acquire ~clock ~wait_timeout_sec (slot : slot) =
+  match finite_positive (Some wait_timeout_sec) with
+  | Some wait_timeout_sec ->
     (try
        Eio.Time.with_timeout_exn clock wait_timeout_sec (fun () ->
          Eio.Semaphore.acquire slot.sem);
@@ -57,11 +57,10 @@ let acquire ?clock ?wait_timeout_sec (slot : slot) =
          ; in_flight = Atomic.get slot.in_flight
          ; cap = slot.cap
          })
-  | _, _ ->
-    Eio.Semaphore.acquire slot.sem;
-    Ok ()
+  | None ->
+    invalid_arg "Runtime_binding_capacity.acquire: wait_timeout_sec must be finite and positive"
 
-let with_slot_result ?clock ?wait_timeout_sec ~key ~max_concurrent f =
+let with_slot_result ~clock ~wait_timeout_sec ~key ~max_concurrent f =
   (* [None] (or [Some n] with [n <= 0]) = unconfigured binding (runtime.toml
      omits [max-concurrent], parsed as [None]). Run ungated rather than build a
      0-permit semaphore that would deadlock on first acquire. *)
@@ -74,7 +73,7 @@ let with_slot_result ?clock ?wait_timeout_sec ~key ~max_concurrent f =
        here and no slot is held. After [acquire] returns, [Atomic.incr] and
        [Switch.on_release] registration are synchronous, so every held slot has
        a release hook before [f] can yield. *)
-    match acquire ?clock ?wait_timeout_sec slot with
+    match acquire ~clock ~wait_timeout_sec slot with
     | Error timeout -> Error { timeout with key }
     | Ok () ->
       Atomic.incr slot.in_flight;
@@ -84,11 +83,6 @@ let with_slot_result ?clock ?wait_timeout_sec ~key ~max_concurrent f =
              Atomic.decr slot.in_flight;
              Eio.Semaphore.release slot.sem);
            f ()))
-
-let with_slot ~key ~max_concurrent f =
-  match with_slot_result ~key ~max_concurrent f with
-  | Ok value -> value
-  | Error _ -> assert false
 
 let snapshot () =
   Eio.Mutex.use_ro registry_mutex (fun () ->

--- a/lib/runtime/runtime_binding_capacity.ml
+++ b/lib/runtime/runtime_binding_capacity.ml
@@ -1,6 +1,13 @@
-(* Per-binding provider concurrency gate. See runtime_binding_capacity.mli for
-   the rationale (RFC-0153 §4.2.3 deferred per-runtime cap; activates the inert
-   binding max_concurrent left over from the RFC-0206 runtime rebirth). *)
+(* Per-binding provider concurrency gate.
+
+   RFC-0153 §4.2.3 deferred a per-runtime cap to post-merge measurement. This
+   module implements a coarser interim per-binding cap ([provider:model@base_url]
+   keyed semaphore) because the live ollama.com endpoint showed that the global
+   [Fd_accountant.Provider_http] gate (default 16, shared across every provider)
+   cannot hold a single over-subscribed endpoint under its own limit. The
+   [max_concurrent] binding field, previously parsed but inert, is now enforced
+   by this gate. A future RFC may narrow the granularity to per-HTTP-call or
+   per-endpoint once we have fleet-wide concurrency measurements. *)
 
 type slot =
   { sem : Eio.Semaphore.t
@@ -39,26 +46,8 @@ let slot_for ~key ~max_concurrent =
       Hashtbl.replace registry key slot;
       slot)
 
-let finite_positive = function
-  | Some value when Float.is_finite value && value > 0.0 -> Some value
-  | Some _ | None -> None
-
-let acquire ~clock ~wait_timeout_sec (slot : slot) =
-  match finite_positive (Some wait_timeout_sec) with
-  | Some wait_timeout_sec ->
-    (try
-       Eio.Time.with_timeout_exn clock wait_timeout_sec (fun () ->
-         Eio.Semaphore.acquire slot.sem);
-       Ok ()
-     with Eio.Time.Timeout ->
-       Error
-         { key = ""
-         ; wait_timeout_sec
-         ; in_flight = Atomic.get slot.in_flight
-         ; cap = slot.cap
-         })
-  | None ->
-    invalid_arg "Runtime_binding_capacity.acquire: wait_timeout_sec must be finite and positive"
+let finite_positive value =
+  Float.is_finite value && value > 0.0
 
 let with_slot_result ~clock ~wait_timeout_sec ~key ~max_concurrent f =
   (* [None] (or [Some n] with [n <= 0]) = unconfigured binding (runtime.toml
@@ -68,21 +57,48 @@ let with_slot_result ~clock ~wait_timeout_sec ~key ~max_concurrent f =
   | None -> Ok (f ())
   | Some max_concurrent when max_concurrent <= 0 -> Ok (f ())
   | Some max_concurrent ->
+    if not (finite_positive wait_timeout_sec)
+    then
+      invalid_arg
+        "Runtime_binding_capacity.with_slot_result: wait_timeout_sec must be \
+         finite and positive";
     let slot = slot_for ~key ~max_concurrent in
-    (* Acquire before registering cleanup: if acquisition is cancelled it raises
-       here and no slot is held. After [acquire] returns, [Atomic.incr] and
-       [Switch.on_release] registration are synchronous, so every held slot has
-       a release hook before [f] can yield. *)
-    match acquire ~clock ~wait_timeout_sec slot with
-    | Error timeout -> Error { timeout with key }
-    | Ok () ->
-      Atomic.incr slot.in_flight;
+    (* Cancellation-safe acquisition:
+
+       1. The semaphore permit is acquired inside the same [Eio.Switch.run] that
+          registers the release hook.
+       2. The [acquired] flag starts as [false]. If [Eio.Semaphore.acquire]
+          raises (timeout, cancellation, or other), the release hook sees
+          [false] and does nothing.
+       3. Only after [acquire] returns successfully do we set [acquired := true]
+          and increment [in_flight]. At that point the release hook is already
+          registered, so any subsequent cancellation cannot leak the permit or
+          the counter.
+
+       This removes the window between "acquire succeeded" and "release hook
+       registered" that existed in the previous version. *)
+    try
       Ok
         (Eio.Switch.run (fun sw ->
+           let acquired = ref false in
            Eio.Switch.on_release sw (fun () ->
-             Atomic.decr slot.in_flight;
-             Eio.Semaphore.release slot.sem);
+             if !acquired
+             then (
+               Atomic.decr slot.in_flight;
+               Eio.Semaphore.release slot.sem));
+           Eio.Time.with_timeout_exn clock wait_timeout_sec (fun () ->
+             Eio.Semaphore.acquire slot.sem);
+           acquired := true;
+           Atomic.incr slot.in_flight;
            f ()))
+    with
+    | Eio.Time.Timeout ->
+      Error
+        { key
+        ; wait_timeout_sec
+        ; in_flight = Atomic.get slot.in_flight
+        ; cap = slot.cap
+        }
 
 let snapshot () =
   Eio.Mutex.use_ro registry_mutex (fun () ->

--- a/lib/runtime/runtime_binding_capacity.mli
+++ b/lib/runtime/runtime_binding_capacity.mli
@@ -1,21 +1,26 @@
-(** Per-binding provider concurrency gate (RFC-0153 §4.2.3).
+(** Per-binding provider concurrency gate.
 
-    Activates the [max_concurrent] binding limit (runtime.toml
-    [<provider>.<model>] [max-concurrent], RFC-0058 §3.4) that
-    {!Runtime_candidate} already carries but the runtime rebirth (RFC-0206)
-    left inert: [register_http_probe_capable] discards it and the
-    [Runtime_client_capacity] machinery was gutted to no-ops
-    ([declared_client_capacity] returns [None]). Before this module the only
-    active provider gate was the single global [Fd_accountant.Provider_http]
-    semaphore (default 16), shared across every provider — so it cannot hold a
-    single over-subscribed endpoint under its own limit when several keepers are
+    RFC-0153 §4.2.3 deferred a per-runtime cap to post-merge measurement. This
+    module activates the binding [max_concurrent] field (runtime.toml
+    [<provider>.<model>] [max-concurrent], RFC-0058 §3.4) as an interim
+    per-binding gate. The previous global [Fd_accountant.Provider_http]
+    semaphore (default 16, shared across every provider) could not hold a single
+    over-subscribed endpoint under its own limit when several keepers were
     assigned to the same runtime binding.
 
     The gate is a process-global registry of one [Eio.Semaphore.t] per capacity
     key (provider:model@base_url — see {!Runtime_candidate.capacity_key}).
-    Acquisition can either block until a slot is free or, when the caller
-    supplies a clock and wait timeout, fail as bounded backpressure. The holder
-    is released when its turn completes, errors, or is cancelled. *)
+    Acquisition is bounded by a mandatory caller-supplied timeout; a saturated
+    key fails as typed backpressure rather than blocking forever. The holder is
+    released on normal return, exception, or fiber cancellation.
+
+    {b Note on granularity:} the current enforcement wraps the whole provider
+    attempt (multi-turn + local tool execution), which is coarser than the
+    eventual per-HTTP-call target mentioned in RFC-0153. This is an intentional
+    interim trade-off: it is simple to reason about and immediately protects
+    endpoints from keeper-storm overload. Finer-grained HTTP-call or
+    endpoint-discovery enforcement is future work once fleet-wide concurrency
+    data is available. *)
 
 type wait_timeout =
   { key : string

--- a/lib/runtime/runtime_binding_capacity.mli
+++ b/lib/runtime/runtime_binding_capacity.mli
@@ -24,42 +24,29 @@ type wait_timeout =
   ; cap : int
   }
 
-val with_slot : key:string -> max_concurrent:int option -> (unit -> 'a) -> 'a
-(** [with_slot ~key ~max_concurrent f] runs [f] while holding one of the
-    configured slots for [key].
-
-    [None] (or [Some n] with [n <= 0]) disables the gate for that key and runs
-    [f] immediately. [None] is the normal runtime.toml "unset" marker
-    (RFC-0058, {!Runtime_toml.parse_binding_fields}); an unconfigured binding
-    must fall back to the existing global gate, never be throttled to a
-    [Eio.Semaphore.make 0] deadlock.
-
-    The slot is released on normal return, exception, or fiber cancellation via
-    [Eio.Switch.on_release]. If [f] never acquires because acquisition is
-    cancelled, no slot is held and none is released.
-
-    The cap for a key is fixed at first acquisition. runtime.toml is
-    startup-only ("restart masc-mcp after edits"), so a key's cap does not
-    change within a process lifetime; a later call with a different
-    [max_concurrent] for the same key reuses the first semaphore and is
-    ignored. *)
-
 val with_slot_result :
-  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
-  ?wait_timeout_sec:float ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  wait_timeout_sec:float ->
   key:string ->
   max_concurrent:int option ->
   (unit -> 'a) ->
   ('a, wait_timeout) result
-(** [with_slot_result] is the bounded-acquire variant for hot keeper paths.
+(** [with_slot_result] acquires a binding slot with a mandatory timeout.
 
-    When [clock] and a positive finite [wait_timeout_sec] are both supplied,
-    waiting for a saturated key is capped by that duration. A timeout returns
-    [Error wait_timeout] without running [f] and without acquiring a slot.
+    Waiting for a saturated key is capped by [wait_timeout_sec]. A timeout
+    returns [Error wait_timeout] without running [f] and without acquiring a
+    slot.
 
-    Missing [clock], missing timeout, non-positive timeout, or
-    [None]/non-positive [max_concurrent] preserves [with_slot]'s
-    unbounded/ungated behavior. *)
+    [None] (or [Some n] with [n <= 0]) disables the gate for that key and runs
+    [f] immediately, returning [Ok (f ())]. An unconfigured binding must fall
+    back to the existing global gate, never be throttled to a
+    [Eio.Semaphore.make 0] deadlock.
+
+    The slot is released on normal return, exception, or fiber cancellation via
+    [Eio.Switch.on_release].
+
+    The cap for a key is fixed at first acquisition. runtime.toml is
+    startup-only, so a key's cap does not change within a process lifetime. *)
 
 val snapshot : unit -> (string * int * int) list
 (** [(key, in_flight, cap)] for every key that has been gated at least once.

--- a/lib/runtime/runtime_binding_capacity.mli
+++ b/lib/runtime/runtime_binding_capacity.mli
@@ -1,0 +1,47 @@
+(** Per-binding provider concurrency gate (RFC-0153 §4.2.3).
+
+    Activates the [max_concurrent] binding limit (runtime.toml
+    [<provider>.<model>] [max-concurrent], RFC-0058 §3.4) that
+    {!Runtime_candidate} already carries but the runtime rebirth (RFC-0206)
+    left inert: [register_http_probe_capable] discards it and the
+    [Runtime_client_capacity] machinery was gutted to no-ops
+    ([declared_client_capacity] returns [None]). Before this module the only
+    active provider gate was the single global [Fd_accountant.Provider_http]
+    semaphore (default 16), shared across every provider — so it cannot hold a
+    single over-subscribed endpoint (e.g. ollama.com, ~10 concurrent) under its
+    own limit when several keepers are assigned to it (live runtime.toml
+    assigns 8 keepers to [ollama_cloud.deepseek-v4-flash]).
+
+    The gate is a process-global registry of one [Eio.Semaphore.t] per capacity
+    key (provider:model@base_url — see {!Runtime_candidate.capacity_key}).
+    Acquisition blocks until a slot is free: this is backpressure (the caller
+    waits its turn on the endpoint), not failure. The wait is bounded by the
+    caller's existing OAS stream/body timeout — the holder is released when its
+    turn completes, errors, or is cancelled. *)
+
+val with_slot : key:string -> max_concurrent:int -> (unit -> 'a) -> 'a
+(** [with_slot ~key ~max_concurrent f] runs [f] while holding one of the
+    [max_concurrent] slots for [key].
+
+    [max_concurrent <= 0] disables the gate for that key and runs [f]
+    immediately. [0] is the runtime.toml "unset/required" marker (RFC-0058,
+    {!Runtime_toml.parse_binding_fields}); an unconfigured binding must fall
+    back to the existing global gate, never be throttled to a
+    [Eio.Semaphore.make 0] deadlock.
+
+    The slot is released on normal return, exception, or fiber cancellation
+    (release cannot raise, so the [Fun.protect] finally is total). If [f]
+    never acquires because acquisition is cancelled, no slot is held and none
+    is released.
+
+    The cap for a key is fixed at first acquisition. runtime.toml is
+    startup-only ("restart masc-mcp after edits"), so a key's cap does not
+    change within a process lifetime; a later call with a different
+    [max_concurrent] for the same key reuses the first semaphore and is
+    ignored. *)
+
+val snapshot : unit -> (string * int * int) list
+(** [(key, in_flight, cap)] for every key that has been gated at least once.
+    Observability surface for dashboard/health: [in_flight = cap] means the
+    endpoint is saturated and further turns on that binding are waiting.
+    Ordered by key. *)

--- a/lib/runtime/runtime_binding_capacity.mli
+++ b/lib/runtime/runtime_binding_capacity.mli
@@ -8,37 +8,58 @@
     ([declared_client_capacity] returns [None]). Before this module the only
     active provider gate was the single global [Fd_accountant.Provider_http]
     semaphore (default 16), shared across every provider — so it cannot hold a
-    single over-subscribed endpoint (e.g. ollama.com, ~10 concurrent) under its
-    own limit when several keepers are assigned to it (live runtime.toml
-    assigns 8 keepers to [ollama_cloud.deepseek-v4-flash]).
+    single over-subscribed endpoint under its own limit when several keepers are
+    assigned to the same runtime binding.
 
     The gate is a process-global registry of one [Eio.Semaphore.t] per capacity
     key (provider:model@base_url — see {!Runtime_candidate.capacity_key}).
-    Acquisition blocks until a slot is free: this is backpressure (the caller
-    waits its turn on the endpoint), not failure. The wait is bounded by the
-    caller's existing OAS stream/body timeout — the holder is released when its
-    turn completes, errors, or is cancelled. *)
+    Acquisition can either block until a slot is free or, when the caller
+    supplies a clock and wait timeout, fail as bounded backpressure. The holder
+    is released when its turn completes, errors, or is cancelled. *)
 
-val with_slot : key:string -> max_concurrent:int -> (unit -> 'a) -> 'a
+type wait_timeout =
+  { key : string
+  ; wait_timeout_sec : float
+  ; in_flight : int
+  ; cap : int
+  }
+
+val with_slot : key:string -> max_concurrent:int option -> (unit -> 'a) -> 'a
 (** [with_slot ~key ~max_concurrent f] runs [f] while holding one of the
-    [max_concurrent] slots for [key].
+    configured slots for [key].
 
-    [max_concurrent <= 0] disables the gate for that key and runs [f]
-    immediately. [0] is the runtime.toml "unset/required" marker (RFC-0058,
-    {!Runtime_toml.parse_binding_fields}); an unconfigured binding must fall
-    back to the existing global gate, never be throttled to a
+    [None] (or [Some n] with [n <= 0]) disables the gate for that key and runs
+    [f] immediately. [None] is the normal runtime.toml "unset" marker
+    (RFC-0058, {!Runtime_toml.parse_binding_fields}); an unconfigured binding
+    must fall back to the existing global gate, never be throttled to a
     [Eio.Semaphore.make 0] deadlock.
 
-    The slot is released on normal return, exception, or fiber cancellation
-    (release cannot raise, so the [Fun.protect] finally is total). If [f]
-    never acquires because acquisition is cancelled, no slot is held and none
-    is released.
+    The slot is released on normal return, exception, or fiber cancellation via
+    [Eio.Switch.on_release]. If [f] never acquires because acquisition is
+    cancelled, no slot is held and none is released.
 
     The cap for a key is fixed at first acquisition. runtime.toml is
     startup-only ("restart masc-mcp after edits"), so a key's cap does not
     change within a process lifetime; a later call with a different
     [max_concurrent] for the same key reuses the first semaphore and is
     ignored. *)
+
+val with_slot_result :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?wait_timeout_sec:float ->
+  key:string ->
+  max_concurrent:int option ->
+  (unit -> 'a) ->
+  ('a, wait_timeout) result
+(** [with_slot_result] is the bounded-acquire variant for hot keeper paths.
+
+    When [clock] and a positive finite [wait_timeout_sec] are both supplied,
+    waiting for a saturated key is capped by that duration. A timeout returns
+    [Error wait_timeout] without running [f] and without acquiring a slot.
+
+    Missing [clock], missing timeout, non-positive timeout, or
+    [None]/non-positive [max_concurrent] preserves [with_slot]'s
+    unbounded/ungated behavior. *)
 
 val snapshot : unit -> (string * int * int) list
 (** [(key, in_flight, cap)] for every key that has been gated at least once.

--- a/scripts/test_check_test_coverage.py
+++ b/scripts/test_check_test_coverage.py
@@ -30,14 +30,44 @@ class CheckTestCoverageTest(unittest.TestCase):
         )
 
     def test_changed_covered_files_include_dashboard_and_config(self):
-        with mock.patch(
-            "check_test_coverage.run_diff_or_fail",
-            return_value="lib/a.ml\ndashboard/app.ts\nconfig/runtime.toml\n",
-        ) as run_diff:
+        with mock.patch.dict(
+            os.environ, {"GITHUB_BASE_REF": "main"}, clear=False
+        ):
+            with mock.patch(
+                "check_test_coverage.run_diff_or_fail",
+                return_value="lib/a.ml\ndashboard/app.ts\nconfig/runtime.toml\n",
+            ) as run_diff:
+                self.assertEqual(
+                    coverage.get_changed_covered_files(),
+                    ["lib/a.ml", "dashboard/app.ts", "config/runtime.toml"],
+                )
+
             self.assertEqual(
-                coverage.get_changed_covered_files(),
-                ["lib/a.ml", "dashboard/app.ts", "config/runtime.toml"],
+                run_diff.call_args.args[0],
+                [
+                    "git",
+                    "diff",
+                    "--name-only",
+                    "origin/main...HEAD",
+                    "--",
+                    "lib/",
+                    "dashboard/",
+                    "config/",
+                ],
             )
+
+    def test_changed_covered_files_uses_pr_base_ref(self):
+        with mock.patch.dict(
+            os.environ, {"GITHUB_BASE_REF": "codex/runtime-cap-policy"}, clear=False
+        ):
+            with mock.patch(
+                "check_test_coverage.run_diff_or_fail",
+                return_value="lib/a.ml\n",
+            ) as run_diff:
+                self.assertEqual(
+                    coverage.get_changed_covered_files(),
+                    ["lib/a.ml"],
+                )
 
         self.assertEqual(
             run_diff.call_args.args[0],
@@ -45,7 +75,7 @@ class CheckTestCoverageTest(unittest.TestCase):
                 "git",
                 "diff",
                 "--name-only",
-                "origin/main...HEAD",
+                "origin/codex/runtime-cap-policy...HEAD",
                 "--",
                 "lib/",
                 "dashboard/",

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-06-10T13:37:43Z (HEAD: 75c984bec)
+Generated: 2026-06-17T08:22:53Z (HEAD: b6b1e9ca40)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -50,7 +50,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | AuditLog.tla | AuditLog | manual | 2 | 1 | clean={inv:TypeOK, inv:CacheConsistency} buggy={inv:CacheConsistency} | a3c241509eb1 |
 | AuditLogAppendOrder.tla | AuditLogAppendOrder | manual | 2 | 1 | clean={inv:TypeOK, inv:MutexExclusion} buggy={inv:MutexExclusion} | 5cafd04c9e66 |
 | AuditLogDurableBeforeAck.tla | AuditLogDurableBeforeAck | manual | 2 | 1 | clean={inv:TypeOK, inv:Durability} buggy={inv:Durability} | 2e72a23b081e |
-| Bounded.tla | Bounded | manual | 2 | 1 | clean={inv:TypeOK, inv:Termination, inv:TokenBudget} buggy={inv:Termination, inv:TokenBudget} | d22f3d75f262 |
+| Bounded.tla | Bounded | manual | 2 | 1 | clean={inv:TypeOK, inv:Termination, inv:TokenBudget} buggy={inv:Termination, inv:TokenBudget} | ec6a6727109c |
 | Cancellation.tla | Cancellation | manual | 2 | 1 | clean={inv:TypeOK, inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} buggy={inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} | bbed415483ac |
 | KeeperContinueGate.tla | KeeperContinueGate | manual | 2 | 1 | clean={inv:Safety, prop:PendingEventuallyResolves} buggy={inv:ApprovedResolutionClearsFailure} | 7f71fad0d4cb |
 | KeeperContractViolated.tla | KeeperContractViolated | manual | 2 | 1 | clean={inv:Safety} buggy={inv:Safety} | ef2f8d4eb972 |
@@ -113,7 +113,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperCompactionLifecycle.tla | KeeperCompactionLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:OverflowEventuallyLeavesOverflow, prop:CompactingEventuallyStops} buggy={inv:CompactingAlignsAll} | 004f6c25b9cc |
 | KeeperCompositeLifecycle.tla | KeeperCompositeLifecycle | manual | 5 | 4 | clean={inv:SafetyInvariant, inv:NoMidFlightTransitionToHandingOff, prop:EventualMeasurementResolves, prop:RecoveryEventuallyCompletes, prop:OverflowedEventuallyResolves} buggy-attempt={inv:ToolSurfaceFeedsAttempt} buggy-compaction={inv:CompactionAtomicity, inv:PhaseTurnAlignment} buggy-mid-flight-handoff={inv:NoMidFlightTransitionToHandingOff} buggy-post-turn={inv:PostTurnConsumesAttempt} | b6a56404aa81 |
 | KeeperConditionsGovernPhase.tla | KeeperConditionsGovernPhase | manual | 2 | 1 | clean={inv:Safety, prop:HandoffEventuallyAcknowledged} buggy={inv:TypeOK, prop:HandoffEventuallyAcknowledged} | 44cbd1093f09 |
-| KeeperContextLifecycle.tla | KeeperContextLifecycle | manual | 4 | 2 | clean={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction, prop:CompactionProgress, prop:EventualTurnCompletion, prop:AllKeepersTerminate} buggy={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} ci-buggy={inv:ContextIsolation, inv:ResumeIdentity} ci={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} | cce167c40ab7 |
+| KeeperContextLifecycle.tla | KeeperContextLifecycle | manual | 4 | 2 | clean={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction, prop:CompactionProgress, prop:EventualTurnCompletion, prop:AllKeepersTerminate} buggy={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} ci-buggy={inv:ContextIsolation, inv:ResumeIdentity} ci={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} | c2798612d26c |
 | KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | 24fa34eea3a2 |
 | KeeperCounterCausality.tla | KeeperCounterCausality | manual | 2 | 1 | clean={inv:Safety} buggy={inv:CausePresentWhenCounted} | d023c2b8bff7 |
 | KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} | 241668542408 |

--- a/specs/boundary/Bounded.tla
+++ b/specs/boundary/Bounded.tla
@@ -1,7 +1,9 @@
 ---- MODULE Bounded ----
-\* Boundary spec for the bounded execution loop (lib/bounded.ml).
+\* Boundary spec for the bounded execution loop.
 \*
-\* Source declares formal-verification intent up front (lib/bounded.ml:3-9):
+\* The source implementation (formerly lib/bounded.ml, now split into
+\* lib/bounded_event_dedupe and lib/bounded_proc) declares formal-verification
+\* intent up front:
 \*
 \*     Provides formal guarantees:
 \*     - Termination: Always terminates via hard_max_iterations
@@ -16,7 +18,7 @@
 \* classes. A follow-up spec can grow them once these invariants are
 \* paid for.
 \*
-\* Source loop (lib/bounded.ml:296-320):
+\* Source loop shape:
 \*
 \*     let rec loop () =
 \*       if state.turns >= constraints.hard_max_iterations then

--- a/test/dune
+++ b/test/dune
@@ -664,6 +664,7 @@
 
 (tests
  (names
+  test_runtime_binding_capacity
   test_runtime_params
   test_config_dir_resolver
   test_workspace_coverage
@@ -848,6 +849,7 @@
   test_board_attachment_meta
   test_board_moderation)
  (modules
+  test_runtime_binding_capacity
   test_runtime_params
   test_config_dir_resolver
   test_workspace_coverage

--- a/test/test_runtime_binding_capacity.ml
+++ b/test/test_runtime_binding_capacity.ml
@@ -97,6 +97,24 @@ let test_release_on_exception () =
   check bool "slot released after exception" true !ran
 ;;
 
+(* The protected body may return a [Result.Error] value (e.g. provider Rate
+   Limit). The slot must still be released so the next acquire on the same key
+   can proceed. *)
+let test_release_on_error_result () =
+  Eio_main.run @@ fun env ->
+  let key = "error-result-key" in
+  let result =
+    with_slot_exn ~clock:env#clock ~key ~max_concurrent:(Some 1) (fun () ->
+      Error "provider rate limit")
+  in
+  check (result string string) "body error is returned" (Error "provider rate limit") result;
+  let ran = ref false in
+  with_slot_exn ~clock:env#clock ~key ~max_concurrent:(Some 1) (fun () ->
+    ran := true;
+    Ok ());
+  check bool "slot released after Error return" true !ran
+;;
+
 (* A fiber cancelled while holding a slot must run the [Switch.on_release]
    cleanup. The second cap-1 acquire proves the semaphore permit was restored;
    the snapshot proves bookkeeping returned to zero. *)
@@ -188,6 +206,7 @@ let () =
             test_caps_concurrency;
           test_case "None runs ungated" `Quick test_none_is_ungated;
           test_case "releases slot on exception" `Quick test_release_on_exception;
+          test_case "releases slot on Error return" `Quick test_release_on_error_result;
           test_case "releases slot on cancellation" `Quick
             test_release_on_cancellation;
           test_case "bounded acquire times out while saturated" `Quick

--- a/test/test_runtime_binding_capacity.ml
+++ b/test/test_runtime_binding_capacity.ml
@@ -1,0 +1,95 @@
+(* Tests for Runtime_binding_capacity — the per-binding provider concurrency
+   gate (RFC-0153 §4.2.3). Verifies the gate caps simultaneous holders at
+   [max_concurrent], runs ungated for the unconfigured [0] marker, releases the
+   slot on exception, and keeps distinct keys independent. *)
+
+open Alcotest
+
+let bump_peak peak observed =
+  let rec loop () =
+    let p = Atomic.get peak in
+    if observed > p && not (Atomic.compare_and_set peak p observed) then loop ()
+  in
+  loop ()
+
+(* 6 fibers, cap 2: at most 2 may hold a slot at once. Each holder yields
+   several times so admitted fibers overlap in scheduling, making the observed
+   peak deterministically equal to the cap rather than racing below it. *)
+let test_caps_concurrency () =
+  Eio_main.run @@ fun _env ->
+  let cur = Atomic.make 0 and peak = Atomic.make 0 in
+  let body () =
+    Runtime_binding_capacity.with_slot ~key:"cap-test" ~max_concurrent:2
+      (fun () ->
+        let observed = Atomic.fetch_and_add cur 1 + 1 in
+        bump_peak peak observed;
+        for _ = 1 to 5 do
+          Eio.Fiber.yield ()
+        done;
+        Atomic.decr cur)
+  in
+  Eio.Fiber.all (List.init 6 (fun _ -> body));
+  check int "peak holders equals cap" 2 (Atomic.get peak);
+  check int "all slots drained" 0 (Atomic.get cur)
+
+(* [max_concurrent <= 0] = unconfigured binding: run ungated, create no
+   semaphore (so a 0-permit deadlock is impossible and the key is absent from
+   the snapshot). *)
+let test_zero_is_ungated () =
+  Eio_main.run @@ fun _env ->
+  let ran = Atomic.make 0 in
+  Eio.Fiber.all
+    (List.init 4 (fun _ ->
+         fun () ->
+           Runtime_binding_capacity.with_slot ~key:"ungated" ~max_concurrent:0
+             (fun () -> Atomic.incr ran)));
+  check int "all ran ungated" 4 (Atomic.get ran);
+  let has_ungated =
+    List.exists
+      (fun (k, _, _) -> String.equal k "ungated")
+      (Runtime_binding_capacity.snapshot ())
+  in
+  check bool "ungated key creates no slot" false has_ungated
+
+(* An exception inside the body must still release the slot; the next acquire
+   on a cap-1 key must then proceed instead of deadlocking. *)
+let test_release_on_exception () =
+  Eio_main.run @@ fun _env ->
+  let key = "exc-key" in
+  (try
+     Runtime_binding_capacity.with_slot ~key ~max_concurrent:1 (fun () ->
+         failwith "boom")
+   with Failure _ -> ());
+  let ran = ref false in
+  Runtime_binding_capacity.with_slot ~key ~max_concurrent:1 (fun () ->
+      ran := true);
+  check bool "slot released after exception" true !ran
+
+(* Distinct keys get distinct semaphores sized by their own cap; the snapshot
+   reports each key's configured cap. *)
+let test_distinct_keys () =
+  Eio_main.run @@ fun _env ->
+  Runtime_binding_capacity.with_slot ~key:"A" ~max_concurrent:2 (fun () -> ());
+  Runtime_binding_capacity.with_slot ~key:"B" ~max_concurrent:3 (fun () -> ());
+  let cap_of k =
+    List.find_map
+      (fun (key, _, cap) -> if String.equal key k then Some cap else None)
+      (Runtime_binding_capacity.snapshot ())
+  in
+  check (option int) "key A cap 2" (Some 2) (cap_of "A");
+  check (option int) "key B cap 3" (Some 3) (cap_of "B")
+
+let () =
+  run "runtime_binding_capacity"
+    [
+      ( "gate",
+        [
+          test_case "caps simultaneous holders at max_concurrent" `Quick
+            test_caps_concurrency;
+          test_case "max_concurrent <= 0 runs ungated" `Quick
+            test_zero_is_ungated;
+          test_case "releases slot on exception" `Quick
+            test_release_on_exception;
+          test_case "distinct keys are independent" `Quick test_distinct_keys;
+        ] );
+    ]

--- a/test/test_runtime_binding_capacity.ml
+++ b/test/test_runtime_binding_capacity.ml
@@ -1,7 +1,8 @@
 (* Tests for Runtime_binding_capacity — the per-binding provider concurrency
-   gate (RFC-0153 §4.2.3). Verifies the gate caps simultaneous holders at
-   [max_concurrent], runs ungated for the unconfigured [0] marker, releases the
-   slot on exception, and keeps distinct keys independent. *)
+   gate (RFC-0153 §4.2.3). Verifies the gate caps simultaneous holders at the
+   configured positive cap, runs ungated when no cap is configured, releases the
+   slot on exception/cancellation, bounds saturated-key wait, and keeps distinct
+   keys independent. *)
 
 open Alcotest
 
@@ -19,7 +20,7 @@ let test_caps_concurrency () =
   Eio_main.run @@ fun _env ->
   let cur = Atomic.make 0 and peak = Atomic.make 0 in
   let body () =
-    Runtime_binding_capacity.with_slot ~key:"cap-test" ~max_concurrent:2
+    Runtime_binding_capacity.with_slot ~key:"cap-test" ~max_concurrent:(Some 2)
       (fun () ->
         let observed = Atomic.fetch_and_add cur 1 + 1 in
         bump_peak peak observed;
@@ -32,16 +33,16 @@ let test_caps_concurrency () =
   check int "peak holders equals cap" 2 (Atomic.get peak);
   check int "all slots drained" 0 (Atomic.get cur)
 
-(* [max_concurrent <= 0] = unconfigured binding: run ungated, create no
+(* [None] = unconfigured binding: run ungated, create no
    semaphore (so a 0-permit deadlock is impossible and the key is absent from
    the snapshot). *)
-let test_zero_is_ungated () =
+let test_none_is_ungated () =
   Eio_main.run @@ fun _env ->
   let ran = Atomic.make 0 in
   Eio.Fiber.all
     (List.init 4 (fun _ ->
          fun () ->
-           Runtime_binding_capacity.with_slot ~key:"ungated" ~max_concurrent:0
+           Runtime_binding_capacity.with_slot ~key:"ungated" ~max_concurrent:None
              (fun () -> Atomic.incr ran)));
   check int "all ran ungated" 4 (Atomic.get ran);
   let has_ungated =
@@ -57,20 +58,83 @@ let test_release_on_exception () =
   Eio_main.run @@ fun _env ->
   let key = "exc-key" in
   (try
-     Runtime_binding_capacity.with_slot ~key ~max_concurrent:1 (fun () ->
+     Runtime_binding_capacity.with_slot ~key ~max_concurrent:(Some 1) (fun () ->
          failwith "boom")
    with Failure _ -> ());
   let ran = ref false in
-  Runtime_binding_capacity.with_slot ~key ~max_concurrent:1 (fun () ->
+  Runtime_binding_capacity.with_slot ~key ~max_concurrent:(Some 1) (fun () ->
       ran := true);
   check bool "slot released after exception" true !ran
+
+(* A fiber cancelled while holding a slot must run the [Switch.on_release]
+   cleanup. The second cap-1 acquire proves the semaphore permit was restored;
+   the snapshot proves bookkeeping returned to zero. *)
+let test_release_on_cancellation () =
+  Eio_main.run @@ fun _env ->
+  let key = "cancel-key" in
+  let entered, resolve_entered = Eio.Promise.create () in
+  (try
+     Eio.Switch.run @@ fun sw ->
+     Eio.Fiber.fork ~sw (fun () ->
+       Runtime_binding_capacity.with_slot ~key ~max_concurrent:(Some 1) (fun () ->
+         Eio.Promise.resolve resolve_entered ();
+         let never, _resolve_never = Eio.Promise.create () in
+         Eio.Promise.await never));
+     Eio.Promise.await entered;
+     Eio.Switch.fail sw Exit
+   with Exit -> ());
+  let in_flight =
+    Runtime_binding_capacity.snapshot ()
+    |> List.find_map (fun (slot_key, count, _) ->
+      if String.equal slot_key key then Some count else None)
+  in
+  check (option int) "cancelled slot bookkeeping drained" (Some 0) in_flight;
+  let ran = ref false in
+  Runtime_binding_capacity.with_slot ~key ~max_concurrent:(Some 1) (fun () ->
+      ran := true);
+  check bool "slot reacquired after cancellation" true !ran
+
+(* A saturated key should be able to fail a bounded acquire without running the
+   protected body. This prevents one stuck holder from making every same-binding
+   waiter block forever. *)
+let test_acquire_wait_timeout () =
+  Eio_main.run @@ fun env ->
+  let key = "wait-timeout-key" in
+  let entered, resolve_entered = Eio.Promise.create () in
+  let release_holder, resolve_release_holder = Eio.Promise.create () in
+  Eio.Switch.run @@ fun sw ->
+  Eio.Fiber.fork ~sw (fun () ->
+    Runtime_binding_capacity.with_slot ~key ~max_concurrent:(Some 1) (fun () ->
+      Eio.Promise.resolve resolve_entered ();
+      Eio.Promise.await release_holder));
+  Eio.Promise.await entered;
+  let ran = ref false in
+  let result =
+    Runtime_binding_capacity.with_slot_result
+      ~clock:env#clock
+      ~wait_timeout_sec:0.001
+      ~key
+      ~max_concurrent:(Some 1)
+      (fun () -> ran := true)
+  in
+  check bool "timed-out acquire does not run body" false !ran;
+  (match result with
+   | Ok () -> fail "bounded acquire unexpectedly succeeded"
+   | Error { key = timeout_key; in_flight; cap; _ } ->
+     check string "timeout key" key timeout_key;
+     check int "holder still in flight" 1 in_flight;
+     check int "cap reported" 1 cap);
+  Eio.Promise.resolve resolve_release_holder ();
+  Runtime_binding_capacity.with_slot ~key ~max_concurrent:(Some 1) (fun () ->
+      ran := true);
+  check bool "slot reacquired after holder released" true !ran
 
 (* Distinct keys get distinct semaphores sized by their own cap; the snapshot
    reports each key's configured cap. *)
 let test_distinct_keys () =
   Eio_main.run @@ fun _env ->
-  Runtime_binding_capacity.with_slot ~key:"A" ~max_concurrent:2 (fun () -> ());
-  Runtime_binding_capacity.with_slot ~key:"B" ~max_concurrent:3 (fun () -> ());
+  Runtime_binding_capacity.with_slot ~key:"A" ~max_concurrent:(Some 2) (fun () -> ());
+  Runtime_binding_capacity.with_slot ~key:"B" ~max_concurrent:(Some 3) (fun () -> ());
   let cap_of k =
     List.find_map
       (fun (key, _, cap) -> if String.equal key k then Some cap else None)
@@ -86,10 +150,14 @@ let () =
         [
           test_case "caps simultaneous holders at max_concurrent" `Quick
             test_caps_concurrency;
-          test_case "max_concurrent <= 0 runs ungated" `Quick
-            test_zero_is_ungated;
+          test_case "None runs ungated" `Quick
+            test_none_is_ungated;
           test_case "releases slot on exception" `Quick
             test_release_on_exception;
+          test_case "releases slot on cancellation" `Quick
+            test_release_on_cancellation;
+          test_case "bounded acquire times out while saturated" `Quick
+            test_acquire_wait_timeout;
           test_case "distinct keys are independent" `Quick test_distinct_keys;
         ] );
     ]

--- a/test/test_runtime_binding_capacity.ml
+++ b/test/test_runtime_binding_capacity.ml
@@ -2,7 +2,11 @@
    gate (RFC-0153 §4.2.3). Verifies the gate caps simultaneous holders at the
    configured positive cap, runs ungated when no cap is configured, releases the
    slot on exception/cancellation, bounds saturated-key wait, and keeps distinct
-   keys independent. *)
+   keys independent.
+
+   The public API only exposes the bounded [with_slot_result]; the helper below
+   unwraps [Ok] so the tests behave like the old unbounded variant while still
+   carrying a safety timeout. *)
 
 open Alcotest
 
@@ -12,15 +16,32 @@ let bump_peak peak observed =
     if observed > p && not (Atomic.compare_and_set peak p observed) then loop ()
   in
   loop ()
+;;
+
+let with_slot_exn ~clock ~key ~max_concurrent f =
+  match
+    Runtime_binding_capacity.with_slot_result
+      ~clock
+      ~wait_timeout_sec:60.0
+      ~key
+      ~max_concurrent
+      f
+  with
+  | Ok v -> v
+  | Error _ -> fail "with_slot_exn unexpectedly timed out"
+;;
 
 (* 6 fibers, cap 2: at most 2 may hold a slot at once. Each holder yields
    several times so admitted fibers overlap in scheduling, making the observed
    peak deterministically equal to the cap rather than racing below it. *)
 let test_caps_concurrency () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
   let cur = Atomic.make 0 and peak = Atomic.make 0 in
   let body () =
-    Runtime_binding_capacity.with_slot ~key:"cap-test" ~max_concurrent:(Some 2)
+    with_slot_exn
+      ~clock:env#clock
+      ~key:"cap-test"
+      ~max_concurrent:(Some 2)
       (fun () ->
         let observed = Atomic.fetch_and_add cur 1 + 1 in
         bump_peak peak observed;
@@ -32,18 +53,22 @@ let test_caps_concurrency () =
   Eio.Fiber.all (List.init 6 (fun _ -> body));
   check int "peak holders equals cap" 2 (Atomic.get peak);
   check int "all slots drained" 0 (Atomic.get cur)
+;;
 
 (* [None] = unconfigured binding: run ungated, create no
    semaphore (so a 0-permit deadlock is impossible and the key is absent from
    the snapshot). *)
 let test_none_is_ungated () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
   let ran = Atomic.make 0 in
   Eio.Fiber.all
     (List.init 4 (fun _ ->
-         fun () ->
-           Runtime_binding_capacity.with_slot ~key:"ungated" ~max_concurrent:None
-             (fun () -> Atomic.incr ran)));
+       fun () ->
+         with_slot_exn
+           ~clock:env#clock
+           ~key:"ungated"
+           ~max_concurrent:None
+           (fun () -> Atomic.incr ran)));
   check int "all ran ungated" 4 (Atomic.get ran);
   let has_ungated =
     List.exists
@@ -51,38 +76,45 @@ let test_none_is_ungated () =
       (Runtime_binding_capacity.snapshot ())
   in
   check bool "ungated key creates no slot" false has_ungated
+;;
 
 (* An exception inside the body must still release the slot; the next acquire
    on a cap-1 key must then proceed instead of deadlocking. *)
 let test_release_on_exception () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
   let key = "exc-key" in
   (try
-     Runtime_binding_capacity.with_slot ~key ~max_concurrent:(Some 1) (fun () ->
-         failwith "boom")
-   with Failure _ -> ());
+     with_slot_exn
+       ~clock:env#clock
+       ~key
+       ~max_concurrent:(Some 1)
+       (fun () -> failwith "boom")
+   with
+   | Failure _ -> ());
   let ran = ref false in
-  Runtime_binding_capacity.with_slot ~key ~max_concurrent:(Some 1) (fun () ->
-      ran := true);
+  with_slot_exn ~clock:env#clock ~key ~max_concurrent:(Some 1) (fun () ->
+    ran := true);
   check bool "slot released after exception" true !ran
+;;
 
 (* A fiber cancelled while holding a slot must run the [Switch.on_release]
    cleanup. The second cap-1 acquire proves the semaphore permit was restored;
    the snapshot proves bookkeeping returned to zero. *)
 let test_release_on_cancellation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
   let key = "cancel-key" in
   let entered, resolve_entered = Eio.Promise.create () in
   (try
      Eio.Switch.run @@ fun sw ->
      Eio.Fiber.fork ~sw (fun () ->
-       Runtime_binding_capacity.with_slot ~key ~max_concurrent:(Some 1) (fun () ->
+       with_slot_exn ~clock:env#clock ~key ~max_concurrent:(Some 1) (fun () ->
          Eio.Promise.resolve resolve_entered ();
          let never, _resolve_never = Eio.Promise.create () in
          Eio.Promise.await never));
      Eio.Promise.await entered;
      Eio.Switch.fail sw Exit
-   with Exit -> ());
+   with
+   | Exit -> ());
   let in_flight =
     Runtime_binding_capacity.snapshot ()
     |> List.find_map (fun (slot_key, count, _) ->
@@ -90,9 +122,10 @@ let test_release_on_cancellation () =
   in
   check (option int) "cancelled slot bookkeeping drained" (Some 0) in_flight;
   let ran = ref false in
-  Runtime_binding_capacity.with_slot ~key ~max_concurrent:(Some 1) (fun () ->
-      ran := true);
+  with_slot_exn ~clock:env#clock ~key ~max_concurrent:(Some 1) (fun () ->
+    ran := true);
   check bool "slot reacquired after cancellation" true !ran
+;;
 
 (* A saturated key should be able to fail a bounded acquire without running the
    protected body. This prevents one stuck holder from making every same-binding
@@ -104,7 +137,7 @@ let test_acquire_wait_timeout () =
   let release_holder, resolve_release_holder = Eio.Promise.create () in
   Eio.Switch.run @@ fun sw ->
   Eio.Fiber.fork ~sw (fun () ->
-    Runtime_binding_capacity.with_slot ~key ~max_concurrent:(Some 1) (fun () ->
+    with_slot_exn ~clock:env#clock ~key ~max_concurrent:(Some 1) (fun () ->
       Eio.Promise.resolve resolve_entered ();
       Eio.Promise.await release_holder));
   Eio.Promise.await entered;
@@ -125,16 +158,17 @@ let test_acquire_wait_timeout () =
      check int "holder still in flight" 1 in_flight;
      check int "cap reported" 1 cap);
   Eio.Promise.resolve resolve_release_holder ();
-  Runtime_binding_capacity.with_slot ~key ~max_concurrent:(Some 1) (fun () ->
-      ran := true);
+  with_slot_exn ~clock:env#clock ~key ~max_concurrent:(Some 1) (fun () ->
+    ran := true);
   check bool "slot reacquired after holder released" true !ran
+;;
 
 (* Distinct keys get distinct semaphores sized by their own cap; the snapshot
    reports each key's configured cap. *)
 let test_distinct_keys () =
-  Eio_main.run @@ fun _env ->
-  Runtime_binding_capacity.with_slot ~key:"A" ~max_concurrent:(Some 2) (fun () -> ());
-  Runtime_binding_capacity.with_slot ~key:"B" ~max_concurrent:(Some 3) (fun () -> ());
+  Eio_main.run @@ fun env ->
+  with_slot_exn ~clock:env#clock ~key:"A" ~max_concurrent:(Some 2) (fun () -> ());
+  with_slot_exn ~clock:env#clock ~key:"B" ~max_concurrent:(Some 3) (fun () -> ());
   let cap_of k =
     List.find_map
       (fun (key, _, cap) -> if String.equal key k then Some cap else None)
@@ -142,18 +176,18 @@ let test_distinct_keys () =
   in
   check (option int) "key A cap 2" (Some 2) (cap_of "A");
   check (option int) "key B cap 3" (Some 3) (cap_of "B")
+;;
 
 let () =
-  run "runtime_binding_capacity"
+  run
+    "runtime_binding_capacity"
     [
       ( "gate",
         [
           test_case "caps simultaneous holders at max_concurrent" `Quick
             test_caps_concurrency;
-          test_case "None runs ungated" `Quick
-            test_none_is_ungated;
-          test_case "releases slot on exception" `Quick
-            test_release_on_exception;
+          test_case "None runs ungated" `Quick test_none_is_ungated;
+          test_case "releases slot on exception" `Quick test_release_on_exception;
           test_case "releases slot on cancellation" `Quick
             test_release_on_cancellation;
           test_case "bounded acquire times out while saturated" `Quick

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -141,13 +141,15 @@ let test_applies_turn_execution_overrides () =
      llm_rerank_runtime = \"tool_rerank_fast\"\n\
      temperature = 0.65\n\
      max_output_tokens = 8192\n\
+     admission_wait_timeout_sec = 111\n\
+     binding_slot_wait_timeout_sec = 22\n\
      stream_idle_timeout_sec = 90\n\
      execution_idle_timeout_sec = 95\n"
   in
   let count, overrides =
     Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
   in
-  check int "applied 6" 6 count;
+  check int "applied 8" 8 count;
   check (option string) "llm rerank"
     (Some "true")
     (List.assoc_opt "MASC_KEEPER_LLM_RERANK" overrides);
@@ -160,6 +162,12 @@ let test_applies_turn_execution_overrides () =
   check (option string) "max output tokens"
     (Some "8192")
     (List.assoc_opt "MASC_KEEPER_UNIFIED_MAX_TOKENS" overrides);
+  check (option string) "admission wait timeout"
+    (Some "111")
+    (List.assoc_opt "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC" overrides);
+  check (option string) "binding slot wait timeout"
+    (Some "22")
+    (List.assoc_opt "MASC_KEEPER_BINDING_SLOT_WAIT_TIMEOUT_SEC" overrides);
   check (option string) "stream idle timeout"
     (Some "90")
     (List.assoc_opt "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC" overrides);
@@ -460,6 +468,64 @@ let test_resolved_execution_idle_timeout_zero_disables () =
     "toml"
     (Keeper_runtime_resolved.source_to_string runtime.execution_idle_timeout_sec.source)
 
+let test_resolved_admission_wait_timeout_uses_toml () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\nadmission_wait_timeout_sec = 90\n";
+  (match Keeper_runtime_config.load_and_apply ~base_path with
+   | Error msg -> failf "unexpected error: %s" msg
+   | Ok _ -> ());
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (float 0.0001) "admission wait timeout from toml"
+    90.0 runtime.admission_wait_timeout_sec.value;
+  check string "admission wait timeout source"
+    "toml"
+    (Keeper_runtime_resolved.source_to_string
+       runtime.admission_wait_timeout_sec.source)
+
+let test_resolved_binding_slot_wait_timeout_defaults_to_short_backpressure () =
+  with_clean_boot_overrides @@ fun () ->
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (float 0.0001) "binding slot wait timeout default"
+    15.0 runtime.binding_slot_wait_timeout_sec.value;
+  check (option (float 0.0001)) "binding wait uses slot limit"
+    (Some 15.0)
+    (Keeper_turn_driver_try_provider.For_testing.binding_capacity_wait_timeout_s
+       ())
+
+let test_resolved_binding_slot_wait_timeout_uses_toml () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\nbinding_slot_wait_timeout_sec = 45\n";
+  (match Keeper_runtime_config.load_and_apply ~base_path with
+   | Error msg -> failf "unexpected error: %s" msg
+   | Ok _ -> ());
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (float 0.0001) "binding slot wait timeout from toml"
+    45.0 runtime.binding_slot_wait_timeout_sec.value;
+  check string "binding slot wait timeout source"
+    "toml"
+    (Keeper_runtime_resolved.source_to_string
+       runtime.binding_slot_wait_timeout_sec.source);
+  check (option (float 0.0001)) "per-provider timeout remains lower bound"
+    (Some 10.0)
+    (Keeper_turn_driver_try_provider.For_testing.binding_capacity_wait_timeout_s
+       ~per_provider_timeout_s:10.0 ())
+
+let test_invalid_oas_timeout_env_does_not_create_override () =
+  with_clean_boot_overrides @@ fun () ->
+  with_env "MASC_KEEPER_OAS_TIMEOUT_SEC" (Some "not-a-float") @@ fun () ->
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (option (float 0.0001)) "invalid oas timeout disables override"
+    None runtime.oas_timeout_override_sec.value;
+  check (float 0.0001) "resolved call timeout falls back to turn timeout"
+    runtime.turn_timeout_sec.value
+    (Keeper_runtime_resolved.oas_call_timeout_sec ())
+
 let test_resolved_runtime_prefers_env_over_toml () =
   with_clean_boot_overrides @@ fun () ->
   with_base_path @@ fun base_path ->
@@ -588,6 +654,10 @@ let () =
         ; test_case "execution idle timeout default disabled" `Quick test_resolved_execution_idle_timeout_default_disabled
         ; test_case "execution idle timeout uses toml" `Quick test_resolved_execution_idle_timeout_uses_toml
         ; test_case "execution idle timeout zero disables" `Quick test_resolved_execution_idle_timeout_zero_disables
+        ; test_case "admission wait timeout uses toml" `Quick test_resolved_admission_wait_timeout_uses_toml
+        ; test_case "binding slot wait default is short backpressure" `Quick test_resolved_binding_slot_wait_timeout_defaults_to_short_backpressure
+        ; test_case "binding slot wait timeout uses toml" `Quick test_resolved_binding_slot_wait_timeout_uses_toml
+        ; test_case "invalid oas timeout env disables override" `Quick test_invalid_oas_timeout_env_does_not_create_override
         ; test_case "resolved runtime prefers env over toml" `Quick test_resolved_runtime_prefers_env_over_toml
         ; test_case "cli subprocess idle default 120s" `Quick test_resolved_cli_subprocess_idle_default_120s
         ; test_case "cli subprocess idle from toml" `Quick test_resolved_cli_subprocess_idle_from_toml


### PR DESCRIPTION
## 목표

`runtime.toml`의 provider-model binding별 `max-concurrent` 값을 실제 keeper turn 실행 경로에서 enforce한다. 여러 keeper가 같은 runtime binding에 배정된 경우, 단일 provider endpoint를 process-wide global HTTP gate만으로 보호하지 못하던 문제를 binding capacity key 단위 backpressure로 막는다.

---

## 🔄 AS-IS vs TO-BE 구조적 개선점 분석 (Structural Improvements)

## 📊 AS-IS vs TO-BE 구조적 개선점 분석 매트릭스

| 영역 | AS-IS (기존 설계) | TO-BE (개선 후) | 기술적 변경 상세 |
| :--- | :--- | :--- | :--- |
| **동시성 강제 범위** | `Fd_accountant.Provider_http` 전역 세마포어만 존재 (Provider 단위 격리 불가) | `Runtime_binding_capacity` 모듈에서 `provider:model@base_url` 키 기반 `Eio.Semaphore` 레지스트리 관리 | 모델별/엔드포인트별 독립적인 동시성 제어 경로 신설 |
| **세마포어 획득 대기 전략** | 무제한 블로킹 (설정 무시 또는 180s 하드코딩) | `Eio.Semaphore.acquire` 타임아웃 래핑 (기본 15s, `MASC_KEEPER_BINDING_SLOT_WAIT_TIMEOUT_SEC`) | 바운딩 슬롯 포화 시 교착 상태 및 캐스케이딩 스타크 방지 |
| **리소스 해제(Relase) 보장** | 명시적 해제 로직 부재 (예외/취소 시 Permit 유실 위험) | `Eio.Switch.on_release` 훅을 통한 트랜잭셔널 보장 (Normal/Exception/Cancel 안전) | 세마포어 누수로 인한 프로세스 전체 영구 데드락 원천 차단 |
| **에러 전파 분류** | 대기 타임아웃 시 일반 예외 또는 무한 대기 | `Capacity_backpressure(Runtime_slot)` 타입 구체화 및 상위 턴 드라이버로의 타입 안전한 전파 | Keeper 루프의 백오프/재시도 로직과 바운딩 백프레셔 에러의 명확한 분리 |
| **설정 파싱 및 환경변수 매핑** | `MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC` 오용, Env 값 무시 및 180s 상수 반환 | `env_config_keeper.ml`에 신규 턴 튜너블 추가, Env→TOML→Resolved 파이프라인 정합성 복구 | `MASC_KEEPER_OAS_TIMEOUT_SEC` 무효값 처리 로직 수정 및 설정 드리프트 방지 |

---

## 🔄 아키텍처 전환 다이어그램

```mermaid
graph TD
    subgraph AS_IS["AS-IS: Ungated Global Client"]
        A1[Keeper Turn: run_try_provider] -->|직접 실행| B1(Fd_accountant.Provider_http)
        B1 -->|공유 세마포어| C1[External Provider API]
        C1 -->|과부하| D1[Rate Limit / 429 Ban]
        A1 -.->|무한 대기 / 180s 하드코딩| E1[Cascading Stuck & Deadlock]
        F1[Exception / Cancel] -.->|Permit 유실| G1[세마포어 누수]
    end

    subgraph TO_BE["TO-BE: Keyed Backpressure & Safe Cleanup"]
        A2[Keeper Turn: run_try_provider] -->|capacity_key 조회| B2{Runtime_binding_capacity}
        B2 -->|슬롯 avail| C2[Eio.Semaphore.acquire]
        B2 -->|슬롯 포화| D2[bounded_wait 최대 15s]
        D2 -->|Timeout 발생| E2[Capacity_backpressure 반환]
        C2 -->|Eio.Switch.on_release 등록| F2[Provider API 호출]
        F2 -->|정상/예외/취소| G2[on_release 훅 트리거]
        G2 -->|Permit 확정 해제| B2
    end
```

---

## ⚡ Adversarial Critique & Vulnerability Report (적대적 비판 및 취약성 검증)

이 PR은 겉보기에는 세마포어를 도입해 동시성을 제어하는 것처럼 보이나, OCaml/Eio의 다중 코어 런타임 특성과 상태 동기화 문제를 완전히 간과한 치명적인 결함들을 내포하고 있습니다. 아래 3가지 심각한 취약점을 지적합니다.

### 1. Multi-Domain Race Condition: `Runtime_binding_capacity` 레지스트리의 원자성 붕괴
`runtime_binding_capacity.ml`에서 프로세스 글로벌 세마포어 레지스트리를 관리한다고 명시했으나, Eio 환경에서 도메인 간(Domain, OCaml 5의 병렬 실행 단위) 상태 공유는 암묵적으로 스레드 안전(thread-safety)이 보장되지 않습니다. 
특히 `capacity_key`를 해시맵(또는 유사 자료구조)에서 조회하고, 없으면 새로운 `Eio.Semaphore`를 생성해 레지스트리에 삽입하는 **Check-then-Act** 로직이 원자적(Atomic)으로 보장되지 않는 경우, 두 개 이상의 도메인에서 동시에 동일한 `provider:model@base_url` 키에 대해 세마포어 생성을 시도할 수 있습니다. 
이는 하나의 바인딩에 대해 두 개의 독립적인 세마포어가 레지스트리에 존재하게 만들어, `max-concurrent` 제한이 사실상 무력화되는 치명적인 동시성 경쟁 상태(Race Condition)를 유발합니다. `Eio.Mutex`나 `Atomic` 참조를 통한 Lock-free 자료구조로 보호되지 않는 한 이 설계는 프로덕션 멀티코어 환경에서 즉시 붕괴합니다.

### 2. Phantom Slot & Cancel-Safety Illusion: `Eio.Switch.on_release`의 의미론적 오용
PR 설명은 "예외, 취소 모두에서 `Eio.Switch.on_release`가 permit을 회수한다"고 주장하지만, 이는 Eio의 취소 의미론(Cancel Semantics)에 대한 근본적인 오해입니다. 
`Eio.Switch.on_release`는 해당 스위치가 종료될 때 호출되는 것이지, **Fiber가 취소되었을 때 즉시 호출되는 것이 아닙니다.** 만약 Keeper 턴 드라이버(`keeper_turn_driver_try_provider.ml`) 내에서 슬롯을 획득한 뒤, HTTP 요청 중에 상위 스위치가 종료되거나 별도의 취소 신호가 들어온다면, 실제 세마포어 해제는 스위치의 정리 루틴(GC 또는 이벤트 루프 드레인)이 돌 때 지연될 수 있습니다.
이 지연 시간 동안 해당 `capacity_key`의 슬롯은 이미 반환되어야 할 Permit을 묶어두는 **Phantom Slot(유령 슬롯)** 현상을 발생시킵니다. 슬롯 대기 타임아웃이 15초로 짧게 설정된 상황에서, 해제 지연으로 인해 유휴(idle) 상태임에도 불구하고 전체 풀이 포화된 것으로 판단, 연쇄적인 `Capacity_backpressure` 에러를 유발하여 시스템의 가용성을 자체적으로 거부(Self-Denial of Service)할 것입니다.

### 3. Uncoordinated Rebirth & Permit Orphaning: RFC-0206 런타임 재시작 생명주기와의 충돌
PR 본문에서 "RFC-0206 runtime rebirth 이후 실제 실행 경로에서 enforce되지 않았다"고 원인을 짚었음에도 불구하고, 도입된 `Runtime_binding_capacity`의 생명주기 관리는 완전히 누락되어 있습니다.
`Runtime_candidate`와 `Keeper_runtime_resolved`는 Rebirth(런타임 설정 핫리로드) 과정에서 교체될 수 있습니다. 그러나 process-global 레지스트리로 구축된 세마포어 풀은 이 Rebirth 이벤트를 관측하지 못합니다.
만약 운영자가 `runtime.toml`에서 특정 바인딩의 `max-concurrent`를 10에서 2로 낮춰 Rebirth를触发한다면 어떻게 됩니까? 기존 레지스트리에는 여전히 카운트 10의 세마포어가 남아있어 새로운 설정이 무시됩니다. 반대로 키가 변경되어 기존 세마포어에 대한 참조가 사라진다면, 해당 세마포어 내에 이미 획득된 상태로 남아있는 Permit들은 영원히 해제되지 않은 채 메모리에 고립(Orphaned)됩니다. 글로벌 레지스트리에 대한 명시적인 `reset()` 또는 버전 태깅(Versioning) 로직 없이 Rebirth 아키텍처 위에 상태풀(Stateful) 글로벌 객체를 얹는 것은 자발적인 메모리 누수 및 설정 드리프트(Config Drift) 버그의 방치입니다.
