### PR TITLE
fix(dashboard): decode runtime config_path + telemetry active_coverage_gap_count

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -152,6 +152,7 @@ describe('fetchDashboardExecutionTrust', () => {
       health: 'coverage_gap',
       stale_reason: 'execution_receipt_append_failed',
       coverage_gap_count: 1,
+      active_coverage_gap_count: 1,
       coverage_gaps: [
         {
           schema: 'masc.telemetry_coverage_gap.v1',
@@ -178,6 +179,7 @@ describe('fetchDashboardExecutionTrust', () => {
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/execution-trust')
     expect(result.coverage_gap_count).toBe(1)
+    expect(result.active_coverage_gap_count).toBe(1)
     expect(result.dashboard_surface_envelope).toMatchObject({
       schema: 'masc.dashboard_surface.v1',
       surface: '/api/v1/dashboard/execution-trust',
@@ -1819,6 +1821,7 @@ describe('fetchRuntimeProviders', () => {
             },
           },
         ],
+        config_path: '/Users/dancer/me/.masc/runtime.toml',
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1829,6 +1832,7 @@ describe('fetchRuntimeProviders', () => {
     const result = await fetchRuntimeProviders()
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/providers')
+    expect(result.config_path).toBe('/Users/dancer/me/.masc/runtime.toml')
     expect(result.summary?.default_runtime_id).toBe('runpod_mtp.qwen')
     expect(result.providers[0]?.provider).toBe('runpod_mtp.qwen')
     expect(result.providers[0]?.provider_id).toBe('runpod_mtp')

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -594,6 +594,9 @@ export interface DashboardRuntimeProvidersResponse {
     default_runtime_id?: string | null
   } | null
   providers: DashboardRuntimeProviderSnapshot[]
+  // Resolved filesystem path of the runtime.toml the server actually loaded
+  // (Runtime.config_path); answers "which config is live" in the monitor.
+  config_path?: string | null
 }
 
 export interface BucketMetric {
@@ -764,6 +767,7 @@ function decodeRuntimeProvidersResponse(raw: unknown): DashboardRuntimeProviders
     providers: asRecordArray(raw.providers)
       .map(decodeRuntimeProviderSnapshot)
       .filter((provider): provider is DashboardRuntimeProviderSnapshot => provider !== null),
+    config_path: asNullableString(raw.config_path),
   }
 }
 
@@ -2375,6 +2379,9 @@ export type TelemetryFreshnessMetadata = {
   exists?: boolean
   coverage_gaps?: TelemetryCoverageGap[]
   coverage_gap_count?: number
+  // Count of gaps not yet recovered (source latest_ts < gap ts), distinct from
+  // the total coverage_gap_count — the actionable "still failing" number.
+  active_coverage_gap_count?: number
 }
 
 export type DashboardSurfaceEnvelope = {
@@ -2486,6 +2493,7 @@ function decodeTelemetryFreshnessMetadata(raw: Record<string, unknown>): Telemet
     exists: asBoolean(raw.exists),
     coverage_gaps: coverageGaps,
     coverage_gap_count: asNumber(raw.coverage_gap_count, coverageGaps.length),
+    active_coverage_gap_count: asNumber(raw.active_coverage_gap_count),
   }
 }
 

--- a/dashboard/src/components/common/source-health.test.ts
+++ b/dashboard/src/components/common/source-health.test.ts
@@ -67,6 +67,33 @@ describe('coverageGapDisplay', () => {
     })
   })
 
+  it('appends the active (unrecovered) count when it is a strict subset of the total', () => {
+    const display = coverageGapDisplay({
+      source: 'tool_call_io',
+      stale_reason: 'tool_call_io_append_failed',
+      coverage_gap_count: 3,
+      active_coverage_gap_count: 1,
+    })
+    expect(display?.summary).toBe('Tool-call log write failed · 3 recorded gaps · 1 active')
+  })
+
+  it('omits the active suffix when all gaps are active or none are', () => {
+    const allActive = coverageGapDisplay({
+      source: 'tool_call_io',
+      stale_reason: 'tool_call_io_append_failed',
+      coverage_gap_count: 2,
+      active_coverage_gap_count: 2,
+    })
+    expect(allActive?.summary).toBe('Tool-call log write failed · 2 recorded gaps')
+    const noneActive = coverageGapDisplay({
+      source: 'tool_call_io',
+      stale_reason: 'tool_call_io_append_failed',
+      coverage_gap_count: 2,
+      active_coverage_gap_count: 0,
+    })
+    expect(noneActive?.summary).toBe('Tool-call log write failed · 2 recorded gaps')
+  })
+
   it('selects the newest gap (last element) when multiple gaps are present', () => {
     // Backends emit coverage_gaps in oldest→newest order; the UI must show the
     // most recent incident, not the first one in the list.

--- a/dashboard/src/components/common/source-health.ts
+++ b/dashboard/src/components/common/source-health.ts
@@ -198,9 +198,16 @@ export function coverageGapDisplay(d: TelemetryFreshnessMetadata): CoverageGapDi
     .filter((entry): entry is [string, string] => entry[1] != null)
     .map(([label, value]) => `${label} ${value}`)
 
+  // Surface the still-unrecovered count when it is a strict subset of the
+  // total (source latest_ts has caught up on the rest); skip when all gaps are
+  // active or none are, to avoid a redundant "N active" on the total.
+  const active = d.active_coverage_gap_count
+  const activeSuffix =
+    typeof active === 'number' && active > 0 && active < count ? ` · ${active} active` : ''
+
   return {
     count,
-    summary: `${title} · ${recordedGapCount(count)}`,
+    summary: `${title} · ${recordedGapCount(count)}${activeSuffix}`,
     details,
     structured: {
       reason,

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -511,6 +511,9 @@ export function RuntimeMonitor() {
             delta=${{ direction: probe?.probe?.summary?.failed ? 'down' : 'flat', text: runtimeProbeSummaryText(probe) }}
           />
         </div>
+        ${providers?.config_path
+          ? html`<div class="mb-3 break-all font-mono text-2xs text-[var(--color-fg-muted)]">config · ${providers.config_path}</div>`
+          : null}
         <div class="flex flex-col gap-3">
           ${(providers?.providers ?? []).length > 0
             ? providers?.providers.map(provider => {


### PR DESCRIPTION
## Summary

Two more backend-emitted fields dropped at the decode boundary (same class as #21298), both **decoded *and* rendered** here so the data reaches an actual slot (no decode-only).

Part of the sweep in `reports/dashboard-decode-boundary-audit-20260616.md`.

## Gaps fixed

- **`config_path`** (`server_dashboard_http_runtime_info.ml :1305` — `Runtime.config_path`): the resolved `runtime.toml` path the server actually loaded. `GET /api/v1/providers` emitted it; `decodeRuntimeProvidersResponse` dropped it. Now decoded onto `DashboardRuntimeProvidersResponse` and rendered as a muted `config · <path>` line under the runtime-monitor tiles — answers "which config is live".
- **`active_coverage_gap_count`** (`telemetry_unified.ml :219`): the count of gaps **not yet recovered** (`source latest_ts < gap ts`), distinct from the total `coverage_gap_count`. `decodeTelemetryFreshnessMetadata` read the total but not the active count. Now decoded onto `TelemetryFreshnessMetadata` and surfaced in `coverageGapDisplay`'s summary as `· N active` when it is a strict subset of the total (skipped when all/none active, to avoid a redundant suffix). One change to the shared helper lights it up on every panel that renders a coverage gap.

## Deferred (intentionally)

The summary endpoint's separate top-level `coverage_gaps` array (audit gap #3) is **not** in this PR — it needs a new failures section in the summary view, not a decode one-liner. Shipping decode-only would move the same drop one layer up, so it is split out.

## Verification

- tsc + eslint clean; +1 `config_path` decode, +1 `active_coverage_gap_count` decode, +2 `coverageGapDisplay` active-suffix cases (subset shows, all/none omit).
- providers / source-health / runtime-monitor / tool-telemetry vitest green.

RFC-WAIVED: dashboard runtime-monitor + telemetry rendering only — no credential / identity / sandbox / operator-control / hooks change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
