### PR TITLE
fix(dashboard): decode keeper-trust latest_event_at + causal-event trace_id

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1230,6 +1230,7 @@ describe('dashboard goals decoding', () => {
                 task_id: 'task-1',
                 blocker_class: 'blocked_before_worktree',
               },
+              latest_event_at: '2026-04-23T00:09:30Z',
             },
             execution: {
               tools_used: ['keeper_task_claim'],
@@ -1253,6 +1254,7 @@ describe('dashboard goals decoding', () => {
               summary: 'Waiting for operator approval before resuming.',
               severity: 'warn',
               next_human_action: 'resolve_approval',
+              trace_id: 'trace-approval-42',
             },
           },
           latest_causal_event: {
@@ -1301,6 +1303,7 @@ describe('dashboard goals decoding', () => {
             task_id: 'task-1',
             blocker_class: 'blocked_before_worktree',
           },
+          latest_event_at: '2026-04-23T00:09:30Z',
         },
         execution_summary: {
           provider_attempt_count: 2,
@@ -1316,6 +1319,7 @@ describe('dashboard goals decoding', () => {
           kind: 'approval_pending',
           keeper_turn_id: 42,
           title: 'Approval pending',
+          trace_id: 'trace-approval-42',
         },
       },
       latest_causal_event: {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1265,6 +1265,7 @@ function decodeGoalKeeperTrustLatestEvent(raw: unknown): GoalKeeperTrustLatestEv
     summary,
     severity,
     next_human_action: asNullableString(raw.next_human_action),
+    trace_id: asNullableString(raw.trace_id),
   }
 }
 
@@ -1283,6 +1284,7 @@ function decodeGoalKeeperTrustApprovalState(raw: unknown): GoalKeeperTrustApprov
           blocker_class: asNullableString(pendingFirst.blocker_class),
         }
       : null,
+    latest_event_at: asNullableString(raw.latest_event_at),
   }
 }
 

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -1222,7 +1222,7 @@ function KeeperCard({ keeper }: { keeper: GoalDetailKeeper }) {
           ` : null}
           <div class="mt-2 flex flex-wrap gap-2 text-3xs text-text-muted">
             ${trust?.approval_state?.state ? html`
-              <span>승인 상태 ${trust.approval_state.state}</span>
+              <span>승인 상태 ${trust.approval_state.state}${trust.approval_state.latest_event_at ? html` · <${TimeAgo} timestamp=${trust.approval_state.latest_event_at} />` : null}</span>
             ` : null}
             ${pendingApprovalId ? html`
               <span>승인 ID ${pendingApprovalId}</span>
@@ -1280,6 +1280,9 @@ function KeeperCard({ keeper }: { keeper: GoalDetailKeeper }) {
             ` : null}
             ${latestEvent.next_human_action ? html`
               <span>next ${latestEvent.next_human_action}</span>
+            ` : null}
+            ${latestEvent.trace_id ? html`
+              <span class="font-mono" title=${latestEvent.trace_id}>trace ${latestEvent.trace_id.slice(0, 8)}</span>
             ` : null}
           </div>
         </div>

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -385,6 +385,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
             state: 'pending',
             summary: '1 approval request waiting',
             pending_count: 1,
+            latest_event_at: '2026-04-23T00:09:30Z',
           },
           execution_summary: {
             sandbox_summary: 'docker / none',
@@ -402,6 +403,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
             summary: 'Waiting for operator approval before resuming.',
             severity: 'warn',
             next_human_action: 'resolve_approval',
+            trace_id: 'trace-approval-42',
           },
         },
       },
@@ -417,6 +419,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
         state: 'pending',
         summary: '1 approval request waiting',
         pending_count: 1,
+        latest_event_at: '2026-04-23T00:09:30Z',
       },
       execution_summary: {
         sandbox_summary: 'docker / none',
@@ -427,6 +430,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
         keeper_turn_id: 42,
         title: 'Approval pending',
         summary: 'Waiting for operator approval before resuming.',
+        trace_id: 'trace-approval-42',
       },
     })
   })

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -331,6 +331,7 @@ function normalizeKeeperTrustLatestEvent(raw: unknown): KeeperTrustLatestEvent |
     summary,
     severity,
     next_human_action: asString(raw.next_human_action) ?? null,
+    trace_id: asString(raw.trace_id) ?? null,
   }
 }
 
@@ -375,6 +376,7 @@ export function normalizeKeeperTrust(raw: unknown): Keeper['trust'] {
                 blocker_class: asString(approvalRaw.pending_first.blocker_class) ?? null,
               }
             : null,
+          latest_event_at: asString(approvalRaw.latest_event_at) ?? null,
         }
       : null,
     execution_summary: isRecord(executionRaw)

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -511,6 +511,8 @@ export interface KeeperTrustLatestEvent {
   summary: string
   severity: 'ok' | 'warn' | 'bad'
   next_human_action?: string | null
+  // Trace id for deep-linking the causal event to its distributed trace.
+  trace_id?: string | null
 }
 
 export interface KeeperTrustApprovalPendingFirst {
@@ -525,6 +527,8 @@ export interface KeeperTrustApprovalState {
   summary?: string | null
   pending_count?: number | null
   pending_first?: KeeperTrustApprovalPendingFirst | null
+  // ISO8601 timestamp of the last approval-audit event.
+  latest_event_at?: string | null
 }
 
 export interface KeeperTrustExecutionSummary {

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -854,6 +854,9 @@ export interface GoalKeeperTrustLatestEvent {
   summary: string
   severity: 'ok' | 'warn' | 'bad' | string
   next_human_action?: string | null
+  // OTel/Jaeger trace id of the causal event (keeper_runtime_trust_timeline.ml),
+  // for deep-linking the latest event to its distributed trace.
+  trace_id?: string | null
 }
 
 export interface GoalKeeperTrustApprovalState {
@@ -866,6 +869,10 @@ export interface GoalKeeperTrustApprovalState {
     task_id?: string | null
     blocker_class?: string | null
   } | null
+  // ISO8601 timestamp of the last approval-audit event
+  // (keeper_runtime_trust_snapshot.ml) — when the approval state last changed,
+  // not derivable from `state` alone.
+  latest_event_at?: string | null
 }
 
 export interface GoalKeeperTrustExecutionSummary {


### PR DESCRIPTION
## Summary

Two keeper runtime-trust fields the backend emits but **both** decode paths dropped (same class as #21298). Keeper trust is decoded twice — the API decoder (`decodeGoalKeeperTrust*`) and the store-side `normalizeKeeperTrust*` — and both omitted these, so neither the goal-detail nor the mission/operator surface could carry them.

Final part of the sweep in `reports/dashboard-decode-boundary-audit-20260616.md`.

## Gaps fixed

- **`latest_event_at`** (`keeper_runtime_trust_snapshot.ml`): ISO8601 timestamp of the last approval-audit event — *when* the approval state last changed, not derivable from `state`. Rendered next to "승인 상태" in goal-tree.
- **`trace_id`** (`keeper_runtime_trust_timeline.ml:68`): the OTel/Jaeger trace id of the latest causal event. Rendered as a mono `trace <id>` chip in the latest keeper-event card (matching the keeper-detail-debug "추적 ID" convention), correlating the event to its distributed trace.

## Deferred by design (the rest of the trust cluster)

`latest_event_kind`, `auto_approved`, `completion_contract_result` are **not** in this PR. The audit confirmed them as real drops but tempered each: `state` is *derived from* `latest_event_kind`; `auto_approved` overlaps the rule match; `completion_contract_result`'s backend collapse already passes non-standard values through. Low marginal value over what is already shown, so the 2-path plumbing is not worth it without a concrete need. (Also deferred: the telemetry summary top-level `coverage_gaps` array, which needs a new failures render section — see PR #21316 note.)

## Change

- `dashboard.ts` + `dashboard-execution.ts`: decode/type `trace_id` on `GoalKeeperTrustLatestEvent`, `latest_event_at` on `GoalKeeperTrustApprovalState`.
- `keeper-store-normalize.ts` + `core.ts`: same on the store-side types.
- `goal-tree.ts`: render both.

## Verification

- tsc + eslint clean; both fields asserted through the API decode path and the store normalize path.
- goal-detail / store-normalize / goal-tree vitest green.

RFC-WAIVED: dashboard goal-tree trust rendering only — no credential / identity / sandbox / operator-control / hooks change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
