### PR TITLE
build(keeper-sandbox): bake full masc dev toolchain into image

### DIFF
--- a/Dockerfile.keeper-sandbox
+++ b/Dockerfile.keeper-sandbox
@@ -7,6 +7,14 @@
 #     REQUIRE_USERNS=false
 # - The host docker socket is typically mounted for DinD operations.
 # - Keeper GitHub/SSH credential bundles are projected at /tmp/keeper-creds.
+#
+# Dev environment: the full masc OCaml toolchain (OCaml 5.4 + dune 3.22 + all
+# masc opam dependencies, including the first-party pins) is baked in at BUILD
+# time. Keepers therefore build/test masc offline — runtime stays network-none
+# and read-only-rootfs hardened; no live `opam install` is needed or granted.
+# Recipe mirrors Dockerfile.worker-runtime (opam-pin-external-deps.sh +
+# `opam install . --deps-only`) so the dep set tracks masc.opam, not a
+# hand-maintained list. Pin bumps require an image rebuild to stay aligned.
 
 FROM ubuntu:24.04
 
@@ -24,24 +32,44 @@ RUN apt-get update \
       git \
       gh \
       jq \
+      m4 \
       make \
       nodejs \
       npm \
-      ocaml-nox \
       opam \
       openssh-client \
       python3 \
       ripgrep \
       tree \
+      pkg-config \
+      libssl-dev \
+      libsqlite3-dev \
+      libgmp-dev \
+      libffi-dev \
+      libzstd-dev \
+      zlib1g-dev \
+      libprotobuf-dev \
+      protobuf-compiler \
  && rm -rf /var/lib/apt/lists/*
 
-# Install dune 3.22 via opam.
-# Ubuntu 24.04's ocaml-dune apt package provides dune 3.14 only;
-# the repo dune-project requires (lang dune 3.22).
+# Bake the full masc dev toolchain at build time. dune-project + *.opam give
+# `opam install . --deps-only` the exact masc dependency set; the pin script
+# resolves the first-party packages (agent_sdk, mcp_protocol, ocaml-webrtc,
+# grpc-direct, compact-protocol) from their git sources. Build-time network is
+# available here; the runtime sandbox is not affected.
+WORKDIR /opt/masc-src
+COPY dune-project ./
+COPY *.opam ./
+COPY scripts ./scripts
+
 RUN opam init --disable-sandboxing --root "$OPAMROOT" --bare -y \
- && opam switch create default ocaml-system --root "$OPAMROOT" -y \
- && opam install --root "$OPAMROOT" -y dune.3.22.0 ppxlib ppx_deriving_yojson ppx_let ppx_deriving bisect_ppx ocaml-protoc-plugin \
- && rm -rf "$OPAMROOT/repo" "$OPAMROOT/.opam-switch/sources"
+ && opam switch create default ocaml-base-compiler.5.4.0 --root "$OPAMROOT" -y \
+ && eval "$(opam env --root "$OPAMROOT" --set-switch)" \
+ && scripts/opam-pin-external-deps.sh \
+ && opam install -y dune.3.22.0 \
+ && opam install . --deps-only -y \
+ && opam clean -a -c -y \
+ && rm -rf "$OPAMROOT/.opam-switch/sources" "$OPAMROOT/repo" /root/.cache
 
 ENV PATH="/opt/opam/default/bin:${PATH}"
 


### PR DESCRIPTION
## 목표

키퍼 샌드박스 이미지에 **masc dev 환경 전체를 빌드타임에 pre-bake**. 키퍼가 OCaml(masc) 빌드/테스트를 오프라인으로 수행 가능하게.

## 배경

- 키퍼는 masc(OCaml) 작업이 본업인데 샌드박스 이미지엔 `dune` + ppx 몇 개뿐.
- 런타임 샌드박스는 의도적으로 **Network_none + read-only rootfs** 하드닝 → 라이브 `opam install` 불가(그리고 줘서도 안 됨).
- 처음엔 네트워크 egress + rootfs 완화를 검토했으나, 그건 command-semantics + sandbox-runtime + TLA(`SandboxDispatch.tla`) + RFC가 걸린 격리 해제. 대신 **빌드타임 pre-bake**로 격리를 전혀 안 풀고 목적 달성.

## 변경 (`Dockerfile.keeper-sandbox` 1파일)

1. opam 스위치 `ocaml-system`(Ubuntu 24.04=OCaml 4.14) → `ocaml-base-compiler.5.4.0` (masc 요구 ≥5.4).
2. C 빌드 의존성 추가: pkg-config, libssl/libsqlite3/libgmp/libffi/libzstd/zlib-dev, protobuf.
3. masc manifests(`dune-project`,`*.opam`)+`scripts/` COPY 후 **worker-runtime와 동일 레시피**: `opam-pin-external-deps.sh`(first-party 핀) + `opam install . --deps-only`.
4. `opam clean` + sources/repo strip로 이미지 축소.

## 보안/격리

런타임 하드닝 **변경 없음** — network-none, read-only rootfs, cap-drop 그대로. 네트워크/쓰기는 **빌드타임에만** 사용. command-semantics/TLA/런타임 정책 무변경.

## 검증

- 빌드가 곧 테스트: `bash scripts/build-keeper-sandbox-image.sh` (또는 `docker build -f Dockerfile.keeper-sandbox .`).
- ⚠️ 사용자가 로컬 빌드 검증 중 — green 확인 후 Ready 전환. 빌드 길음(OCaml 5.4 + 전 의존성 컴파일).

## 트레이드오프

first-party 핀(agent_sdk 등) bump 시 이미지 재빌드 필요(어떤 pre-bake든 동일). Dockerfile 헤더에 명시.

RFC-WAIVED: build-time toolchain bake only; no runtime containment/network/rootfs/command-semantics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
