### PR TITLE
style(dashboard): v2 foundation tokens, surface CSS skeletons, and invalid utility fixes

### DIFF
--- a/dashboard/src/components/goals/task-detail-overlay.class.test.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.class.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const SOURCE = resolve(__dirname, 'task-detail-overlay.ts')
+
+describe('TaskDetailOverlay source class hygiene', () => {
+  it('uses a valid rounded top utility on the sticky header', () => {
+    const src = readFileSync(SOURCE, 'utf-8')
+    expect(src).toContain('rounded-t-[var(--r-1)]')
+    expect(src).not.toContain('rounded-[var(--r-1)]-t-2xl')
+  })
+})

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -425,7 +425,7 @@ export function TaskDetailOverlay() {
       panelClass="w-full max-w-[900px] max-h-[90vh] overflow-y-auto bg-[var(--color-bg-surface)] rounded-[var(--r-1)] border border-[var(--dialog-panel-border)] shadow-[0_24px_64px_var(--black-50)]"
     >
       ${'' /* Sticky Header */}
-      <div class="sticky top-0 z-10 flex items-center justify-between gap-4 px-6 py-4 border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] backdrop-blur-sm rounded-[var(--r-1)]-t-2xl">
+      <div class="sticky top-0 z-10 flex items-center justify-between gap-4 px-6 py-4 border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] backdrop-blur-sm rounded-t-[var(--r-1)]">
         <div class="flex-1 min-w-0">
           <h2 id=${titleId} class="text-lg font-semibold text-text-strong break-words">${task.title}</h2>
           <div class="mt-1.5 flex flex-wrap items-center gap-2">

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -39,6 +39,11 @@
 @import "./v2-overview.css";
 @import "./v2-connectors.css";
 @import "./v2-monitoring.css";
+@import "./v2-command.css";
+@import "./v2-workspace.css";
+@import "./v2-monitoring-leftovers.css";
+@import "./v2-lab.css";
+@import "./v2-ide.css";
 @import "./a11y.css"; /* after feature styles so reduced-motion overrides win */
 
 /* Strangler Fig migration bridge — bridges legacy CSS hooks to
@@ -227,3 +232,22 @@ tbody tr:hover {
 @utility ok { border-color: var(--ok-22); }
 @utility warn { border-color: var(--warn-soft); }
 @utility bad { border-color: rgb(var(--err-glow) / .15); }
+
+/* Legacy utility aliases surfaced by unmigrated components.
+   These are defined here so foundation PR preserves layout without
+   touching every component file; they are removed once consumers
+   switch to standard Tailwind utilities. */
+@utility leading-paragraph { line-height: 1.45; }
+@utility leading-airy { line-height: 1.6; }
+@utility tracking-3 { letter-spacing: 0.03em; }
+@utility text-md { font-size: var(--font-size-md); }
+@utility min-w-35 { min-width: 140px; }
+@utility min-w-45 { min-width: 180px; }
+@utility max-w-65 { max-width: 260px; }
+@utility max-w-190 { max-width: 760px; }
+@utility max-h-70 { max-height: 280px; }
+@utility max-h-75 { max-height: 300px; }
+@utility max-h-130 { max-height: 520px; }
+@utility max-h-150 { max-height: 600px; }
+@utility min-h-65 { min-height: 260px; }
+@utility min-h-75 { min-height: 300px; }

--- a/dashboard/src/styles/v2-command.css
+++ b/dashboard/src/styles/v2-command.css
@@ -1,0 +1,13 @@
+/* MASC Dashboard v2 — Command / Operations surface.
+ *
+ * Scoped to .v2-command-* so unmigrated surfaces keep their legacy styling.
+ *
+ * Colors come from v2-theme.css; this file handles surface-specific
+ * layout, hairlines, hover states, and brass accent touches.
+ */
+
+.v2-command-surface,
+.v2-command-panel,
+.v2-command-action {
+  --v2-command-top-glow: rgb(var(--brass-glow) / 0.04);
+}

--- a/dashboard/src/styles/v2-ide.css
+++ b/dashboard/src/styles/v2-ide.css
@@ -1,0 +1,14 @@
+/* MASC Dashboard v2 — Code / IDE surface.
+ *
+ * Scoped to .v2-ide-* so unmigrated surfaces keep their legacy styling.
+ *
+ * Colors come from v2-theme.css; this file handles surface-specific
+ * layout, hairlines, hover states, and brass accent touches.
+ */
+
+.v2-ide-surface,
+.v2-ide-panel,
+.v2-ide-rail,
+.v2-ide-toolbar {
+  --v2-ide-top-glow: rgb(var(--brass-glow) / 0.04);
+}

--- a/dashboard/src/styles/v2-lab.css
+++ b/dashboard/src/styles/v2-lab.css
@@ -1,0 +1,13 @@
+/* MASC Dashboard v2 — Lab surface (Tools + Safety Harness).
+ *
+ * Scoped to .v2-lab-* so unmigrated surfaces keep their legacy styling.
+ *
+ * Colors come from v2-theme.css; this file handles surface-specific
+ * layout, hairlines, hover states, and brass accent touches.
+ */
+
+.v2-lab-surface,
+.v2-lab-panel,
+.v2-lab-card {
+  --v2-lab-top-glow: rgb(var(--brass-glow) / 0.04);
+}

--- a/dashboard/src/styles/v2-monitoring-leftovers.css
+++ b/dashboard/src/styles/v2-monitoring-leftovers.css
@@ -1,0 +1,14 @@
+/* MASC Dashboard v2 — Monitoring leftover surfaces.
+ *
+ * Scoped to .v2-monitoring-leftover-* (and extends .v2-monitoring-*)
+ * for Observatory, Journey, Cognition, Transport Health, Feature Health,
+ * Cost Dashboard, and Telemetry Unified.
+ *
+ * Colors come from v2-theme.css and v2-monitoring.css.
+ */
+
+.v2-monitoring-leftover-surface,
+.v2-monitoring-leftover-panel,
+.v2-monitoring-leftover-detail {
+  --v2-monitoring-leftover-top-glow: rgb(var(--brass-glow) / 0.04);
+}

--- a/dashboard/src/styles/v2-theme.css
+++ b/dashboard/src/styles/v2-theme.css
@@ -205,4 +205,26 @@
   --gold-8: rgb(196 162 101 / .08);
   --gold-10: rgb(196 162 101 / .10);
   --gold-15: rgb(196 162 101 / .15);
+
+  /* Card tokens used by unmigrated surfaces */
+  --color-card: var(--bg-card);
+  --color-card-border: var(--border);
+
+  /* Bad/error semantic aliases */
+  --color-bad: var(--bad);
+  --color-bad-fg: var(--bad-light);
+  --color-bad-soft: var(--bad-soft);
+  --bad-muted: rgb(var(--err-glow) / .25);
+
+  /* Warning / danger fg aliases */
+  --color-warning-fg: var(--warn-fg);
+  --color-danger-fg: var(--err-fg);
+
+  /* Text / accent aliases */
+  --color-text-disabled: var(--color-fg-disabled);
+  --color-accent-muted: var(--color-brass-2);
+  --track-section: var(--track-caps);
+
+  /* Form-fitting gold bright alias */
+  --ff-gold-bright: var(--color-accent-fg);
 }

--- a/dashboard/src/styles/v2-workspace.css
+++ b/dashboard/src/styles/v2-workspace.css
@@ -1,0 +1,13 @@
+/* MASC Dashboard v2 — Workspace surface (Board + Planning/Goals).
+ *
+ * Scoped to .v2-workspace-* so unmigrated surfaces keep their legacy styling.
+ *
+ * Colors come from v2-theme.css; this file handles surface-specific
+ * layout, hairlines, hover states, and brass accent touches.
+ */
+
+.v2-workspace-surface,
+.v2-workspace-panel,
+.v2-workspace-detail {
+  --v2-workspace-top-glow: rgb(var(--brass-glow) / 0.04);
+}


### PR DESCRIPTION
Prepares the shared token bridge and empty v2 stylesheets for the remaining dashboard surface migrations (Command, Workspace, Monitoring leftovers, Lab, IDE).\n\nChanges:\n- Add missing v2 tokens: --color-card, --color-card-border, --color-bad*, --color-warning-fg, --color-danger-fg, --color-text-disabled, --color-accent-muted, --track-section, --ff-gold-bright.\n- Create v2-command.css, v2-workspace.css, v2-monitoring-leftovers.css, v2-lab.css, v2-ide.css skeletons.\n- Import new stylesheets in global.css.\n- Define legacy utility aliases (leading-paragraph, leading-airy, tracking-3, text-md, min/max width/height spacing utilities) so unmigrated components keep layout.\n- Fix malformed rounded class in goals/task-detail-overlay.ts and add regression test.\n\nVerification:\n- pnpm typecheck ✅\n- pnpm lint ✅\n- pnpm vitest run src/components/goals/task-detail-overlay.class.test.ts ✅\n- pnpm build ✅