### PR TITLE
fix(dashboard): surface proactive keeper work in roster previews

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -60,6 +60,7 @@ import {
   keeperActivityDisplay,
   keeperRuntimeBlockerHint,
   keeperRuntimeBlockerLabel,
+  keeperWorkPreview,
 } from '../lib/keeper-runtime-display'
 // RFC-0135 PR-4: roster card derives its blocker note through the typed
 // KeeperOperationalState SSOT so the headline (`현재 차단` vs `이전 차단`
@@ -891,12 +892,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     const monitoringEvidence = keeperMonitoring ? summarizeMonitoringEvidence(keeperMonitoring) : null
     const fsmPhase = keeperRuntime ? keeperPhaseForDisplay(keeperRuntime, compositeForMonitoring) : null
     const isKeeper = keeperRuntime != null
-    const goalSummary = keeperRuntime?.short_goal ?? keeperRuntime?.goal ?? agent.current_task ?? null
-    const currentWork =
-      keeperRuntime?.recent_output_preview
-      ?? keeperRuntime?.recent_input_preview
-      ?? goalSummary
-      ?? null
+    // Shared precedence (incl. last_proactive_preview); fall back to the agent
+    // context's current_task for agents without a keeper runtime.
+    const currentWork = keeperWorkPreview(keeperRuntime) ?? agent.current_task ?? null
     const activityDisplay = keeperRuntime
       ? keeperActivityDisplay(keeperRuntime, agent.last_seen)
       : null
@@ -904,11 +902,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     const lastActivityAt = activityDisplay?.timestamp ?? agent.last_seen ?? null
     const lastActivityLabel = activityDisplay?.label ?? '최근 활동'
     const contextMeta = rosterContextMeta(keeperRuntime ?? null)
-    const workPreview =
-      trimText(keeperRuntime?.recent_output_preview, 140)
-      ?? trimText(keeperRuntime?.recent_input_preview, 140)
-      ?? trimText(goalSummary, 140)
-      ?? '최근 활동 요약 없음'
+    const workPreview = trimText(currentWork, 140) ?? '최근 활동 요약 없음'
     const summaryText = workPreview
     const compositeForKeeper: KeeperCompositeSnapshot | null = keeperRuntime
       ? compositeByKeeperKey.get(keeperRuntime.name)

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -362,7 +362,11 @@ export function keeperWorkSummary(
       trust?.next_human_action,
       keeper?.next_human_action,
     ),
-    recentOutput: firstNonEmptyString(keeper?.recent_output_preview, keeper?.recent_input_preview),
+    recentOutput: firstNonEmptyString(
+      keeper?.recent_output_preview,
+      keeper?.recent_input_preview,
+      keeper?.last_proactive_preview,
+    ),
     recentTools: keeper?.recent_tool_names ?? keeper?.latest_tool_names ?? EMPTY_TOOLS,
     runtimeBlocker: firstNonEmptyString(keeper?.runtime_blocker_summary, keeper?.last_blocker),
   }

--- a/dashboard/src/components/keeper-detail-activity-summary.ts
+++ b/dashboard/src/components/keeper-detail-activity-summary.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
 import { TimeAgo } from './common/time-ago'
 import { formatDuration } from '../lib/format-time'
-import { keeperActivityDisplay } from '../lib/keeper-runtime-display'
+import { keeperActivityDisplay, keeperWorkPreview } from '../lib/keeper-runtime-display'
 import type { Keeper } from '../types'
 
 // SSOT: 활동 시간 표시는 raw `keeper.last_heartbeat`를 직접 읽지 않고
@@ -10,11 +10,12 @@ import type { Keeper } from '../types'
 // "26초 전 / 18시간 전 / 27일 전" 3중 표시 모순을 봉인한다.
 export function KeeperActivitySummary({ keeper }: { keeper: Keeper }) {
   const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
+  const workPreview = keeperWorkPreview(keeper)
   const hasActivitySignal = activity.source !== 'none' && activity.source !== 'created'
   const hasActivity =
     hasActivitySignal ||
     keeper.last_speech_act ||
-    keeper.recent_output_preview ||
+    workPreview ||
     keeper.memory_recent_note ||
     (keeper.k2k_count ?? 0) > 0
 
@@ -51,9 +52,9 @@ export function KeeperActivitySummary({ keeper }: { keeper: Keeper }) {
         ? html`<span class="text-2xs text-[var(--color-fg-muted)] px-2.5 py-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] truncate max-w-90" title=${keeper.memory_recent_note}>${keeper.memory_recent_note}</span>`
         : null}
     </div>
-    ${keeper.recent_output_preview
+    ${workPreview
       ? html`<div class="py-2 px-3 rounded-[var(--r-1)] bg-[var(--accent-6)] border border-[var(--accent-12)] text-xs text-[var(--color-fg-primary)] leading-relaxed">
-          <div class="line-clamp-2">${keeper.recent_output_preview}</div>
+          <div class="line-clamp-2">${workPreview}</div>
         </div>`
       : null}
   `

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -103,6 +103,23 @@ describe('KeeperWorkspaceRoster', () => {
     expect(work?.textContent).toBe('WIP 게이트 수정')
   })
 
+  it('surfaces last_proactive_preview for a proactive-only keeper', () => {
+    // A proactive keeper never broadcasts, so the message-bus previews
+    // (recent_output/input) and goal/current_task stay empty; its work lives
+    // only in last_proactive_preview. The roster must read it rather than
+    // rendering the bare placeholder.
+    keepers.value = [
+      mk({
+        name: 'executor',
+        status: 'running',
+        last_proactive_preview: 'Continuation checkpoint saved; scheduled next cycle.',
+      }),
+    ]
+    render(html`<${KeeperWorkspaceRoster} activeName="executor" />`, host)
+    const work = host.querySelector('.kw-kp-work') as HTMLElement
+    expect(work?.textContent).toBe('Continuation checkpoint saved; scheduled next cycle.')
+  })
+
   it('renders the empty-work fallback when no preview source exists', () => {
     keepers.value = [mk({ name: 'bare', status: 'stopped' })]
     render(html`<${KeeperWorkspaceRoster} activeName="bare" />`, host)

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -10,7 +10,7 @@ import type { VNode } from 'preact'
 import { keepers } from '../../store'
 import { navigate } from '../../router'
 import { selectKeeper } from '../../keeper-runtime'
-import { keeperActivityDisplay } from '../../lib/keeper-runtime-display'
+import { keeperActivityDisplay, keeperWorkPreview } from '../../lib/keeper-runtime-display'
 import type { Keeper } from '../../types'
 import {
   WorkspaceSigil,
@@ -41,18 +41,6 @@ function needsAttention(keeper: Keeper): boolean {
  *  real scope signal, with the model as fallback. */
 function keeperScope(keeper: Keeper): string | null {
   return keeper.skill_primary ?? keeper.active_model ?? keeper.model ?? null
-}
-
-/** One-line "what is this keeper doing" preview so rows carry real content
- *  instead of reading bare. Same precedence as the detail page's work
- *  preview (recent output → input → goal → current task). */
-function keeperWorkPreview(keeper: Keeper): string | null {
-  return keeper.recent_output_preview
-    ?? keeper.recent_input_preview
-    ?? keeper.short_goal
-    ?? keeper.goal
-    ?? keeper.agent?.current_task
-    ?? null
 }
 
 function matchesQuery(keeper: Keeper, q: string): boolean {

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -8,6 +8,7 @@ import {
   keeperPauseDisplay,
   keeperRuntimeBlockerHint,
   keeperRuntimeBlockerLabel,
+  keeperWorkPreview,
 } from './keeper-runtime-display'
 
 /** Minimal Keeper stub with only the fields relevant to status classification. */
@@ -434,5 +435,45 @@ describe('keeperActivityDisplay', () => {
     })
     expect(result.source).toBe('created')
     expect(result.label).toBe('생성')
+  })
+})
+
+describe('keeperWorkPreview', () => {
+  it('prefers a message output over the proactive preview and goals', () => {
+    expect(
+      keeperWorkPreview(
+        makeKeeper({
+          recent_output_preview: '메시지 출력',
+          last_proactive_preview: 'proactive',
+          short_goal: '목표',
+        }),
+      ),
+    ).toBe('메시지 출력')
+  })
+
+  it('surfaces last_proactive_preview when message previews are empty', () => {
+    // The proactive-only keeper: no broadcast (recent_output/input empty), no
+    // goal/current_task — work lives solely in last_proactive_preview.
+    expect(
+      keeperWorkPreview(
+        makeKeeper({
+          recent_output_preview: '',
+          recent_input_preview: null,
+          last_proactive_preview: 'Continuation checkpoint saved.',
+        }),
+      ),
+    ).toBe('Continuation checkpoint saved.')
+  })
+
+  it('falls through to short_goal then goal then current_task', () => {
+    expect(keeperWorkPreview(makeKeeper({ short_goal: 'short', goal: 'long' }))).toBe('short')
+    expect(keeperWorkPreview(makeKeeper({ goal: 'long' }))).toBe('long')
+    expect(keeperWorkPreview(makeKeeper({ agent: { current_task: 'task-7' } }))).toBe('task-7')
+  })
+
+  it('returns null when no signal exists', () => {
+    expect(keeperWorkPreview(makeKeeper({}))).toBeNull()
+    expect(keeperWorkPreview(null)).toBeNull()
+    expect(keeperWorkPreview(undefined)).toBeNull()
   })
 })

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -546,3 +546,27 @@ export function keeperRuntimeHint(keeper: Keeper | null | undefined): string | n
   if (blocker) return `차단 요인 · ${blocker}`
   return null
 }
+
+/** One-line "what is this keeper doing" preview, shared by every keeper roster
+ *  and summary surface so they agree on precedence.
+ *
+ *  Precedence: a real message output (recent_output/input_preview) first, then
+ *  the most recent proactive turn's preview, then the goal / current-task
+ *  fallbacks. The proactive preview matters because a proactive-only keeper
+ *  never broadcasts — `recent_output_preview` is message-bus derived and stays
+ *  empty for it — so its work surfaces solely through `last_proactive_preview`.
+ *  Reading only the message fields left every proactive keeper rendering the
+ *  bare "최근 작업 요약 없음" placeholder while the live signal sat unread on the
+ *  same card (last_proactive_preview populated 13/15 in the fleet, all five
+ *  message/goal fields 0/15). Returns null when no signal exists. */
+export function keeperWorkPreview(keeper: Keeper | null | undefined): string | null {
+  if (!keeper) return null
+  return firstNonEmptyString(
+    keeper.recent_output_preview,
+    keeper.recent_input_preview,
+    keeper.last_proactive_preview,
+    keeper.short_goal,
+    keeper.goal,
+    keeper.agent?.current_task,
+  )
+}


### PR DESCRIPTION
## 증상
키퍼 워크스페이스 좌측 로스터에서 전 키퍼가 항상 `최근 작업 요약 없음`으로 표시됨 — 실제로는 proactive turn을 활발히 돌리는 중인데도 "노는 것"처럼 보임.

## 근본 원인 (field-selection)
로스터/요약 4개 사이트가 work preview를 다음 5개 필드로만 읽음:
`recent_output_preview ?? recent_input_preview ?? short_goal ?? goal ?? agent.current_task`

이 5개는 전부 메시지버스(broadcast) · MASC task claim · goal 설정에서 파생됨. proactive-only 키퍼는 broadcast를 안 하고, goal을 안 잡고, `agent.current_task`도 설정하지 않아 5개가 전부 빈값. 반면 진짜 활동 신호 `last_proactive_preview`는 같은 카드에 채워져 있는데 아무도 안 읽음.

라이브 실측 (`/api/v1/dashboard/execution`, 키퍼 15명): last_proactive_preview 13/15 채워짐, 읽던 5개 필드 0/15. 예: `executor` autonomous_turn_count=570, 43초 전 proactive turn.

## 수정
4개 사이트가 같은 precedence를 복붙 → 사이트별 패치는 N-of-M 안티패턴. 공유 헬퍼 `keeperWorkPreview()`를 `lib/keeper-runtime-display.ts`에 추출하고 precedence에 `last_proactive_preview` 포함, 4개 사이트가 모두 경유:
- keeper-workspace-roster.ts (스크린샷 로스터)
- agent-roster.ts
- keeper-detail-activity-summary.ts
- ide-keeper-work-panel.ts (출력 전용 필드라 last_proactive_preview만 fallback)

precedence: `recent_output_preview ?? recent_input_preview ?? last_proactive_preview ?? short_goal ?? goal ?? agent.current_task`. 메시지 출력 있으면 기존대로 우선, 없으면 proactive 출력 폴백.

## 검증
- tsc --noEmit 0 errors
- vitest 전체 517 files / 6698 tests 통과
- 신규 회귀 테스트: 헬퍼 단위 4건 + 로스터 proactive-only 1건

백엔드 변경 없음 — 데이터는 normalize 경계까지 이미 도달, UI가 읽는 필드만 교정.