### PR TITLE
style(dashboard): migrate Command / Operations surface to v2

### DIFF
--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -140,6 +140,32 @@ describe('Governance surface', () => {
     expect(container.textContent).not.toContain('심의 의견 제출')
   }, 20000)
 
+  it('wraps the governance view in the v2 command surface class', async () => {
+    const response: DashboardGovernanceResponse = {
+      generated_at: '2026-03-26T00:00:00Z',
+      summary: { judge_online: false },
+      items: [],
+      activity: [],
+      judgments: [],
+      pending_actions: [],
+    }
+
+    const { Governance } = await loadComponentWithApi({
+      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(response),
+      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
+      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+    })
+
+    render(html`<${Governance} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('.v2-command-surface')).not.toBeNull()
+    expect(container.querySelector('.v2-command-panel')).not.toBeNull()
+  }, 20000)
+
   it('auto-refreshes the live judge surface while visible', async () => {
     const response: DashboardGovernanceResponse = {
       generated_at: '2026-04-21T00:00:00Z',

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -115,7 +115,7 @@ function GovernanceSummaryStrip() {
         <${ActionButton}
           variant="ghost"
           size="sm"
-          class="rounded-[var(--r-1)] border-transparent bg-[var(--color-bg-surface)] px-2.5 py-1 text-xs font-semibold text-text-muted hover:bg-[var(--color-bg-hover)] hover:text-text-strong"
+          class="v2-command-action rounded-[var(--r-1)] border-transparent bg-[var(--color-bg-surface)] px-2.5 py-1 text-xs font-semibold text-text-muted hover:bg-[var(--color-bg-hover)] hover:text-text-strong"
           onClick=${refreshGovernance}
           disabled=${governanceLoading.value}
         >
@@ -239,7 +239,7 @@ function JudgmentsSection() {
       : 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-text-muted'
     return html`
       <div data-testid="live-judge-empty">
-        <${SectionCard} label=${title} class="section mb-5" variant="compact">
+        <${SectionCard} label=${title} class="section mb-5 v2-command-panel" variant="compact">
           <${EmptyState} message=${message} compact />
           ${lastSeen || meta ? html`
             <div class="mt-1 flex flex-wrap items-center justify-center gap-2 text-2xs ${tone === 'warn' ? 'text-warn' : 'text-text-dim'}">
@@ -255,10 +255,10 @@ function JudgmentsSection() {
   }
 
   return html`
-    <${SectionCard} label=${title} class="section mb-5" variant="compact">
+    <${SectionCard} label=${title} class="section mb-5 v2-command-panel" variant="compact">
       <div class="flex flex-col gap-2.5">
         ${judgments.map(j => html`
-          <div class="rounded-[var(--r-1)] border border-card-border bg-card/34 p-3.5 text-sm" data-testid="judgment-item">
+          <div class="v2-command-row rounded-[var(--r-1)] border border-card-border bg-card/34 p-3.5 text-sm" data-testid="judgment-item">
             <div class="flex items-center gap-2 mb-1.5">
               <span class="inline-flex items-center rounded-[var(--r-1)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-1.5 py-0.5 text-3xs font-bold text-accent-fg">${j.target_kind ?? 'unknown'}</span>
               <span class="font-medium text-text-strong">${j.target_id ?? ''}</span>
@@ -387,7 +387,7 @@ function KeeperApprovalAlertBanner() {
       <${ActionButton}
         variant=${isCritical ? 'danger' : 'primary'}
         size="md"
-        class="shrink-0"
+        class="v2-command-action shrink-0"
         onClick=${scrollToKeeperApprovalSection}
       >
         Review now
@@ -500,7 +500,7 @@ function KeeperApprovalQueueSection() {
     : 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-text-muted text-2xs px-2 py-0.5 font-bold'
   return html`
     <div id="keeper-hitl-approval" data-testid="keeper-hitl-approval">
-    <${SectionCard} label="Keeper HITL Approval Queue" class="section mb-5" variant="compact">
+    <${SectionCard} label="Keeper HITL Approval Queue" class="section mb-5 v2-command-panel" variant="compact">
       <div class="mb-3 flex items-center justify-between gap-3">
         <div class="text-xs text-text-muted">
           Keeper tool calls above the risk threshold wait here.
@@ -535,7 +535,7 @@ function KeeperApprovalQueueSection() {
               ${visibleItems.map(item => {
                 const disabled = actingId === item.id
                 return html`
-                  <div class="rounded-[var(--r-1)] border border-card-border bg-card/34 p-4 shadow-[var(--shadow-1)]" data-testid="governance-approval-item">
+                  <div class="v2-command-row rounded-[var(--r-1)] border border-card-border bg-card/34 p-4 shadow-[var(--shadow-1)]" data-testid="governance-approval-item">
                     <div class="flex flex-wrap items-start gap-2.5">
                       <span class="inline-flex items-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs font-bold text-text-muted">
                         keeper ${item.keeper_name}
@@ -572,7 +572,7 @@ function KeeperApprovalQueueSection() {
                         <${ActionButton}
                           variant="primary"
                           size="md"
-                          class="min-w-[110px]"
+                          class="v2-command-action min-w-[110px]"
                           onClick=${() => void respondToKeeperApproval(item.id, 'approve')}
                           disabled=${Boolean(actingId)}
                         >
@@ -581,7 +581,7 @@ function KeeperApprovalQueueSection() {
                         <${ActionButton}
                           variant="ghost"
                           size="md"
-                          class="min-w-[110px]"
+                          class="v2-command-action min-w-[110px]"
                           onClick=${() => void respondToKeeperApproval(item.id, 'approve', true)}
                           disabled=${Boolean(actingId)}
                         >
@@ -590,7 +590,7 @@ function KeeperApprovalQueueSection() {
                         <${ActionButton}
                           variant="danger"
                           size="md"
-                          class="min-w-[110px]"
+                          class="v2-command-action min-w-[110px]"
                           onClick=${() => void respondToKeeperApproval(item.id, 'reject')}
                           disabled=${Boolean(actingId)}
                         >
@@ -612,7 +612,7 @@ function ApprovalRulesSection() {
   const rules = governanceData.value?.approval_rules ?? []
   const actingId = governanceApprovalActing.value
   return html`
-    <${SectionCard} label="Always Rules" class="section mb-5" variant="compact">
+    <${SectionCard} label="Always Rules" class="section mb-5 v2-command-panel" variant="compact">
       <div class="mb-3 text-xs text-text-muted">
         Auto-approval rules derived from approved requests. Critical, destructive shell/git, and manual-decision states are never auto-approved even when a rule exists.
       </div>
@@ -623,7 +623,7 @@ function ApprovalRulesSection() {
               ${rules.map((rule: KeeperApprovalRule) => {
                 const deleting = actingId === `rule:${rule.id}`
                 return html`
-                  <div class="rounded-[var(--r-1)] border border-card-border bg-card/34 p-4 shadow-[var(--shadow-1)]" data-testid="governance-approval-rule">
+                  <div class="v2-command-row rounded-[var(--r-1)] border border-card-border bg-card/34 p-4 shadow-[var(--shadow-1)]" data-testid="governance-approval-rule">
                     <div class="flex flex-wrap items-start gap-2.5">
                       <span class="inline-flex items-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs font-bold text-text-muted">
                         keeper ${rule.keeper_name}
@@ -647,6 +647,7 @@ function ApprovalRulesSection() {
                       <${ActionButton}
                         variant="danger"
                         size="sm"
+                        class="v2-command-action"
                         onClick=${() => void deleteKeeperApprovalRule(rule.id)}
                         disabled=${Boolean(actingId)}
                       >
@@ -672,7 +673,7 @@ export function Governance() {
   }, [])
 
   return html`
-    <div class="flex flex-col gap-0.5">
+    <div class="v2-command-surface flex flex-col gap-0.5">
       <${KeeperApprovalAlertBanner} />
       <${GovernanceSummaryStrip} />
       <${KeeperApprovalQueueSection} />

--- a/dashboard/src/components/lab-inspector.test.ts
+++ b/dashboard/src/components/lab-inspector.test.ts
@@ -1,0 +1,50 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function flushUi(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+async function loadInspector() {
+  vi.resetModules()
+  vi.doMock('./feature-health', () => ({
+    FeatureHealth: () => html`<div data-testid="feature-health">FeatureHealth</div>`,
+  }))
+  vi.doMock('./server-config', () => ({
+    ServerConfig: () => html`<div data-testid="server-config">ServerConfig</div>`,
+  }))
+  vi.doMock('./excuse-patterns', () => ({
+    ExcusePatterns: () => html`<div data-testid="excuse-patterns">ExcusePatterns</div>`,
+  }))
+  return import('./lab-inspector')
+}
+
+describe('LabInspector', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.doUnmock('./feature-health')
+    vi.doUnmock('./server-config')
+    vi.doUnmock('./excuse-patterns')
+  })
+
+  it('wraps the inspector in the v2 command surface class', async () => {
+    const { LabInspector } = await loadInspector()
+    render(html`<${LabInspector} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('.v2-command-surface')).not.toBeNull()
+    expect(container.querySelector('.v2-command-panel')).not.toBeNull()
+  })
+})

--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -110,8 +110,8 @@ export function LabInspector() {
   const current = inspectorSection.value
 
   return html`
-    <div class="flex flex-col gap-4">
-      <${SectionCard} label="운영 인스펙터" class="section">
+    <div class="v2-command-surface flex flex-col gap-4">
+      <${SectionCard} label="운영 인스펙터" class="section v2-command-panel">
         <div class="flex flex-col gap-3">
           <div class="flex flex-wrap gap-2">
             <${InspectorTabButton} id="overview" label="개요" />

--- a/dashboard/src/components/operations-panel.test.ts
+++ b/dashboard/src/components/operations-panel.test.ts
@@ -98,6 +98,14 @@ describe('OperationsPanel', () => {
     expect(labels).toContain('Inspector')
   })
 
+  it('wraps the panel in the v2 command surface class', async () => {
+    const { OperationsPanel } = await loadPanel()
+    render(html`<${OperationsPanel} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('.v2-command-surface')).not.toBeNull()
+  })
+
   it('falls back to default for unknown view param', async () => {
     route.value.params = { section: 'operations', view: 'unknown' }
     const { OperationsPanel } = await loadPanel()

--- a/dashboard/src/components/operations-panel.ts
+++ b/dashboard/src/components/operations-panel.ts
@@ -38,7 +38,7 @@ export function OperationsPanel() {
   const view = currentView()
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="v2-command-surface flex flex-col gap-4">
       <${FilterChips}
         chips=${VIEW_CHIPS}
         value=${view}

--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -138,6 +138,44 @@ describe('Ops surface', () => {
     expect(items[2]?.textContent).toContain('키퍼 메시지는 잠시 보류')
   }, 120000)
 
+  it('wraps the ops view in the v2 command surface class', async () => {
+    const {
+      Ops,
+      route,
+      operatorActionLog,
+      operatorDigestError,
+      operatorError,
+      operatorWorkspaceDigest,
+      operatorSnapshot,
+      hydratedWorkflowId,
+    } = await loadOps()
+
+    route.value = { tab: 'command', params: { section: 'operations' }, postId: null } as RouteState
+    hydratedWorkflowId.value = null
+    operatorError.value = null
+    operatorDigestError.value = null
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+    operatorWorkspaceDigest.value = {
+      target_type: 'namespace',
+      attention_items: [],
+      recommended_actions: [],
+      recent_reviews: [],
+    } as unknown as OperatorDigest
+    operatorActionLog.value = []
+
+    render(html`<${Ops} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('.v2-command-surface')).not.toBeNull()
+  }, 60000)
+
   it('does not render its own keeper roster or fleet pointer (lives on Monitor → Keeper Fleet)', async () => {
     const {
       Ops,

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -208,7 +208,7 @@ export function Ops() {
   ])
 
   return html`
-    <section class="flex flex-col gap-4" aria-label="Operations panel">
+    <section class="v2-command-surface flex flex-col gap-4" aria-label="Operations panel">
       ${operatorError.value ? html`<section class="ops-banner rounded-[var(--r-1)] py-3 px-3.5 border border-[var(--color-border-default)] error" role="alert">${operatorError.value}</section>` : null}
       ${operatorDigestError.value ? html`<section class="ops-banner rounded-[var(--r-1)] py-3 px-3.5 border border-[var(--color-border-default)] error" role="alert">${operatorDigestError.value}</section>` : null}
 
@@ -235,7 +235,7 @@ export function Ops() {
           <${ComposerV2} workspaceId="ops" />
         </div>
 
-        <section class="${CARD_STANDARD} grid gap-3 order-2 max-[1200px]:order-1" aria-label="Recent operator activity">
+        <section class="${CARD_STANDARD} v2-command-panel grid gap-3 order-2 max-[1200px]:order-1" aria-label="Recent operator activity">
           <div>
             <h2 class="text-sm font-semibold text-[var(--color-fg-secondary)]">Recent Activity</h2>
             <p class="mt-1 text-xs text-[var(--color-fg-muted)]">Interventions and review outcomes, newest first. Governance queues stay in the governance view.</p>

--- a/dashboard/src/styles/v2-command.css
+++ b/dashboard/src/styles/v2-command.css
@@ -8,6 +8,100 @@
 
 .v2-command-surface,
 .v2-command-panel,
-.v2-command-action {
+.v2-command-card,
+.v2-command-row,
+.v2-command-action,
+.v2-command-table,
+.v2-command-detail {
   --v2-command-top-glow: rgb(var(--brass-glow) / 0.04);
+}
+
+/* ── Panels / cards ───────────────────────────────────────────────────────── */
+
+.v2-command-panel,
+.v2-command-card,
+.v2-command-surface [data-surface-card] {
+  box-shadow: inset 0 1px 0 var(--v2-command-top-glow);
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-command-panel:hover,
+.v2-command-card:hover,
+.v2-command-surface [data-surface-card]:hover {
+  border-color: var(--color-border-strong);
+}
+
+/* ── Rows (lists, tables) ─────────────────────────────────────────────────── */
+
+.v2-command-row,
+.v2-command-table tbody tr,
+.v2-command-panel table tbody tr,
+.v2-command-detail table tbody tr {
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-command-row:hover,
+.v2-command-table tbody tr:hover,
+.v2-command-panel table tbody tr:hover,
+.v2-command-detail table tbody tr:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-elevated);
+}
+
+/* ── Action buttons ───────────────────────────────────────────────────────── */
+
+.v2-command-action:not(:disabled),
+.v2-command-panel .v2-command-action:not(:disabled),
+.v2-command-surface [data-action-button]:not(:disabled) {
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-command-action:not(:disabled):hover,
+.v2-command-surface [data-action-button]:not(:disabled):hover {
+  border-color: var(--color-accent-fg);
+  background: var(--color-brass-soft);
+}
+
+/* ── Tables ───────────────────────────────────────────────────────────────── */
+
+.v2-command-table,
+.v2-command-panel table,
+.v2-command-detail table {
+  border-color: var(--color-border-default);
+}
+
+.v2-command-table thead,
+.v2-command-panel table thead,
+.v2-command-detail table thead {
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.v2-command-table th,
+.v2-command-panel table th,
+.v2-command-detail table th {
+  color: var(--color-fg-muted);
+}
+
+.v2-command-table td,
+.v2-command-panel table td,
+.v2-command-detail table td {
+  color: var(--color-fg-secondary);
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+/* ── Detail sections ──────────────────────────────────────────────────────── */
+
+.v2-command-detail {
+  box-shadow: inset 0 1px 0 var(--v2-command-top-glow);
+}
+
+/* ── Composer / raw panel chrome inside the command surface ───────────────── */
+
+.v2-command-surface .v2-command-composer {
+  box-shadow: inset 0 1px 0 var(--v2-command-top-glow);
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-command-surface .v2-command-composer:hover {
+  border-color: var(--color-border-strong);
 }


### PR DESCRIPTION
Phase 1 of the dashboard v2 surface migration.

- Applies `.v2-command-surface` wrappers to OperationsPanel, Ops, Governance, and LabInspector.
- Adds `.v2-command-panel`, `.v2-command-row`, and `.v2-command-action` markers where appropriate.
- Fills `dashboard/src/styles/v2-command.css` with scoped v2 chrome (top glow, card/panel/row hover, action transitions, table hairlines).
- Keeps shared primitives (SurfaceCard/SectionCard/ActionButton) untouched; styling is driven through their existing `data-*` attributes.
- Adds coverage-ratchet tests asserting the v2 surface class on OperationsPanel, Ops, Governance, and LabInspector.

Local verification: `pnpm typecheck`, `pnpm lint`, targeted vitest runs, and `pnpm build` all pass.