### PR TITLE
perf(main_eio): reduce CPU/GC pressure from metric store, UTF-8, and dashboard trust snapshots

### DIFF
--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -201,18 +201,29 @@ let is_disallowed_control_char (c : char) : bool =
 
 let sanitize_text_utf8 (s : string) : string =
   let len = String.length s in
-  let rec has_invalid_or_control i =
-    if i >= len then false
+  let rec ascii_clean i =
+    if i >= len then true
     else
-      let dec = String.get_utf_8_uchar s i in
-      let dlen = Uchar.utf_decode_length dec in
-      if dlen > 0 && Uchar.utf_decode_is_valid dec then
-        if dlen = 1 && is_disallowed_control_char s.[i] then true
-        else has_invalid_or_control (i + dlen)
-      else true
+      let c = Char.code s.[i] in
+      if c >= 128 then false
+      else if c < 32 && c <> 9 && c <> 10 && c <> 13 then false
+      else if c = 127 then false
+      else ascii_clean (i + 1)
   in
-  if not (has_invalid_or_control 0) then s
+  if ascii_clean 0 then s
   else
+    let rec has_invalid_or_control i =
+      if i >= len then false
+      else
+        let dec = String.get_utf_8_uchar s i in
+        let dlen = Uchar.utf_decode_length dec in
+        if dlen > 0 && Uchar.utf_decode_is_valid dec then
+          if dlen = 1 && is_disallowed_control_char s.[i] then true
+          else has_invalid_or_control (i + dlen)
+        else true
+    in
+    if not (has_invalid_or_control 0) then s
+    else
     let buf = Buffer.create len in
     let rec loop i =
       if i >= len then ()

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -3,6 +3,60 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_runtime_trust_timeline
 
+(** Short-lived cache for [snapshot_json]. The result is expensive to compute
+    (tail-reads decision log, tool-call log, receipts, approval audit, and
+    pending approvals) and is requested repeatedly by dashboard renders. The
+    cache key includes runtime generation and last-turn timestamp so normal
+    keeper progress invalidates it automatically. *)
+module Snapshot_cache = struct
+  type key =
+    { base_path : string
+    ; keeper_name : string
+    ; generation : int
+    ; last_turn_ts : float
+    }
+
+  type entry =
+    { value : Yojson.Safe.t
+    ; expires_at : float
+    }
+
+  let tbl : (key, entry) Hashtbl.t = Hashtbl.create 64
+  let mu = Stdlib.Mutex.create ()
+  let ttl_sec = 0.5
+  let max_size = 256
+
+  let clear_expired ~now =
+    let expired =
+      Hashtbl.fold (fun k e acc -> if e.expires_at <= now then k :: acc else acc) tbl []
+    in
+    List.iter (Hashtbl.remove tbl) expired
+
+  let clear () =
+    Stdlib.Mutex.protect mu (fun () -> Hashtbl.clear tbl)
+
+  let get ~now key =
+    Stdlib.Mutex.protect mu (fun () ->
+        match Hashtbl.find_opt tbl key with
+        | Some entry when entry.expires_at > now -> Some entry.value
+        | _ -> None)
+
+  let set ~now key value =
+    Stdlib.Mutex.protect mu (fun () ->
+        clear_expired ~now;
+        if Hashtbl.length tbl >= max_size
+        then (
+          (* Cap memory: drop expired entries, and if still full clear the
+             whole table rather than keeping stale entries. *)
+          clear_expired ~now;
+          if Hashtbl.length tbl >= max_size then Hashtbl.clear tbl);
+        Hashtbl.replace tbl key { value; expires_at = now +. ttl_sec })
+end
+
+module For_testing = struct
+  let clear_snapshot_cache = Snapshot_cache.clear
+end
+
 let terminal_reason_from_decision json =
   match json_member "terminal_reason" json with
   | `Assoc _ as terminal_reason -> Keeper_turn_terminal.of_json terminal_reason
@@ -756,7 +810,7 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
   |> take 12
   |> fun items -> `List items
 
-let snapshot_json ~(config : Workspace.config) ~(meta : keeper_meta) =
+let snapshot_json_inner ~(config : Workspace.config) ~(meta : keeper_meta) =
   let registry_entry =
     Keeper_registry.get ~base_path:config.base_path meta.name
   in
@@ -891,3 +945,19 @@ let snapshot_json ~(config : Workspace.config) ~(meta : keeper_meta) =
             Json_util.string_opt_to_json entry.last_event_bus_correlation
         | None -> `Null );
     ]
+
+let snapshot_json ~(config : Workspace.config) ~(meta : keeper_meta) =
+  let cache_key =
+    { Snapshot_cache.base_path = config.base_path
+    ; keeper_name = meta.name
+    ; generation = meta.runtime.generation
+    ; last_turn_ts = meta.runtime.usage.last_turn_ts
+    }
+  in
+  let now = Time_compat.now () in
+  match Snapshot_cache.get ~now cache_key with
+  | Some value -> value
+  | None ->
+      let value = snapshot_json_inner ~config ~meta in
+      Snapshot_cache.set ~now cache_key value;
+      value

--- a/lib/keeper/keeper_runtime_trust_snapshot.mli
+++ b/lib/keeper/keeper_runtime_trust_snapshot.mli
@@ -3,3 +3,7 @@ val snapshot_json :
 
 val summary_json :
   config:Workspace.config -> meta:Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
+
+module For_testing : sig
+  val clear_snapshot_cache : unit -> unit
+end

--- a/lib/otel_metric_store/otel_metric_store_core.ml
+++ b/lib/otel_metric_store/otel_metric_store_core.ml
@@ -28,10 +28,9 @@ let metrics_mutex = Stdlib.Mutex.create ()
 let last_deadlock_backtrace : string option Atomic.t = Atomic.make None
 
 let with_lock f =
-  let bt0 = Printexc.get_callstack 64 in
   (try Stdlib.Mutex.lock metrics_mutex with
    | Sys_error msg as exn ->
-     let trace = Printexc.raw_backtrace_to_string bt0 in
+     let trace = Printexc.raw_backtrace_to_string (Printexc.get_callstack 64) in
      let dump = Printf.sprintf "Otel_metric_store.with_lock: %s\nCaller stack:\n%s" msg trace in
      Atomic.set last_deadlock_backtrace (Some dump);
      Log.Metrics.error "Otel_metric_store mutex deadlock: %s" dump;

--- a/lib/otel_metrics/otel_metrics.ml
+++ b/lib/otel_metrics/otel_metrics.ml
@@ -35,6 +35,37 @@ let metric_of_sample (s : sample) : M.t =
     M.sum ~name:s.name ~is_monotonic:false
       ~aggregation_temporality:M.Aggregation_temporality_cumulative [ dp ]
 
+(** Group samples by [(name, kind)] so that samples sharing the same metric
+    identity become a single [M.t] with multiple data points. This reduces the
+    number of protobuf metrics emitted per OTel export tick. *)
+let metrics_of_samples (samples : sample list) : M.t list =
+  let groups : (string * kind, sample list) Hashtbl.t = Hashtbl.create 16 in
+  List.iter
+    (fun s ->
+       let key = (s.name, s.kind) in
+       match Hashtbl.find_opt groups key with
+       | None -> Hashtbl.add groups key [ s ]
+       | Some ss -> Hashtbl.replace groups key (s :: ss))
+    samples;
+  Hashtbl.fold
+    (fun (name, kind) ss acc ->
+       let dps =
+         List.rev_map
+           (fun s -> M.float ~attrs:(attrs_of_labels s.labels) s.value)
+           ss
+       in
+       let metric =
+         match kind with
+         | Counter ->
+           M.sum ~name ~is_monotonic:true
+             ~aggregation_temporality:M.Aggregation_temporality_cumulative dps
+         | Gauge -> M.gauge ~name dps
+         | Histogram ->
+           M.sum ~name ~is_monotonic:false
+             ~aggregation_temporality:M.Aggregation_temporality_cumulative dps
+       in
+       metric :: acc)
+    groups []
+
 let register_source (f : unit -> sample list) : unit =
-  Opentelemetry.Metrics_callbacks.register (fun () ->
-      List.map metric_of_sample (f ()))
+  Opentelemetry.Metrics_callbacks.register (fun () -> metrics_of_samples (f ()))


### PR DESCRIPTION
## Summary

Targeted optimizations based on the `sample` profile of `main_eio.exe`.

## Changes

1. **Otel_metric_store_core**: move `Printexc.get_callstack` out of the hot path. It was captured on every `with_lock` invocation; now only captured when the lock actually raises `Sys_error`.

2. **Safe_ops.sanitize_text_utf8**: add an ASCII fast-path. Most strings are plain ASCII; scan bytes directly and skip the expensive `String.get_utf_8_uchar` decode loop for the common case.

3. **Otel_metrics**: group samples by `(name, kind)` before emitting protobuf. Reduces the number of `Metrics.t` records and OTLP messages per export tick.

4. **Keeper_runtime_trust_snapshot.snapshot_json**: add a short-lived TTL cache. The snapshot is expensive (tail-reads decision log, tool-call log, receipts, approval audit, pending approvals) and requested repeatedly by dashboard renders. Cache key includes runtime `generation` and `last_turn_ts` so normal keeper progress invalidates it automatically.

## Verification

- `dune build -p masc` passes.
- `test_keeper_runtime_trust_snapshot` passes.
- `test_safe_ops` passes.
- Pre-existing failures (also on `main`): `test_otel_zero_fill`, `test_dashboard_http_core`.
