### PR TITLE
style(dashboard): migrate Workspace / Board surfaces to v2

### DIFF
--- a/dashboard/src/components/board/board-moderation-surface.test.ts
+++ b/dashboard/src/components/board/board-moderation-surface.test.ts
@@ -77,12 +77,13 @@ describe('BoardModerationSurface', () => {
   })
 
   it('renders queue entries with moderation state', async () => {
-    render(h(BoardModerationSurface, null))
+    const { container } = render(h(BoardModerationSurface, null))
 
     expect(await screen.findByText('post-1')).toBeTruthy()
     expect(screen.getByText('spam')).toBeTruthy()
     expect(screen.getByText('keeper-a')).toBeTruthy()
     expect(screen.getByText('open')).toBeTruthy()
+    expect(container.querySelector('.v2-workspace-surface')).not.toBeNull()
     expect(fetchQueueMock).toHaveBeenCalledWith(expect.objectContaining({
       resolved: false,
       signal: expect.any(AbortSignal),

--- a/dashboard/src/components/board/board-moderation-surface.ts
+++ b/dashboard/src/components/board/board-moderation-surface.ts
@@ -234,7 +234,7 @@ export function BoardModerationSurface() {
   }
 
   return html`
-    <section class="flex min-w-0 flex-col gap-4" aria-label="Board moderation">
+    <section class="v2-workspace-surface flex min-w-0 flex-col gap-4" aria-label="Board moderation">
       <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div class="min-w-0">
           <h2 class="text-base font-semibold text-[var(--color-fg-primary)]">Board Moderation</h2>
@@ -253,6 +253,7 @@ export function BoardModerationSurface() {
           <${ActionButton}
             variant="ghost"
             size="sm"
+            class="v2-workspace-action"
             onClick=${() => { void load() }}
             disabled=${queueControlsDisabled}
             ariaLabel="Refresh moderation queue"
@@ -265,7 +266,7 @@ export function BoardModerationSurface() {
         </div>
       </div>
 
-      <form class="grid gap-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3" onSubmit=${submitFlag}>
+      <form class="v2-workspace-panel grid gap-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3" onSubmit=${submitFlag}>
         <div class="grid gap-3 lg:grid-cols-[0.7fr_1fr_0.8fr_0.8fr_auto] lg:items-end">
           <label class="grid gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
             Target
@@ -316,6 +317,7 @@ export function BoardModerationSurface() {
             type="submit"
             variant="primary"
             size="md"
+            class="v2-workspace-action"
             disabled=${!canSubmit}
             ariaBusy=${submitting}
             testId="moderation-flag-submit"

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -190,6 +190,11 @@ describe('BoardSurface Component', () => {
     expect(screen.getByText(/아직 게시글이 없습니다/)).toBeInTheDocument()
   })
 
+  it('wraps the board surface in the v2 workspace surface class', () => {
+    const { container } = render(h(BoardSurface, null))
+    expect(container.querySelector('.v2-workspace-surface')).not.toBeNull()
+  })
+
   it('renders loading state when loading', () => {
     boardLoading.value = true
     render(h(BoardSurface, null))

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -211,7 +211,7 @@ function renderCategorySection(
   }
 
   return html`
-    <${SectionCard} label=${`${label} (${total})`} class="mb-4">
+    <${SectionCard} label=${`${label} (${total})`} class="mb-4 v2-workspace-panel">
       <div class="flex flex-col gap-2">
         ${posts.slice(0, limit).map(post => html`<${PostCard} key=${post.id} post=${post} />`)}
       </div>
@@ -547,7 +547,7 @@ function SortBar() {
             <${ActionButton}
               variant="danger"
               size="md"
-              class="!px-3"
+              class="v2-workspace-action !px-3"
               onClick=${bulkDeleteSelected}
               disabled=${bulkDeleting.value}
               ariaBusy=${bulkDeleting.value}
@@ -597,7 +597,7 @@ function BoardSummary() {
   const visibleCount = grouped.groups.reduce((sum, g) => sum + g.posts.length, 0)
   const metrics = boardLatencyMetrics.value
   return html`
-    <div class="flex flex-wrap items-center gap-2 mb-4 px-3 py-2.5 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-xs text-[var(--color-fg-muted)]">
+    <div class="v2-workspace-panel flex flex-wrap items-center gap-2 mb-4 px-3 py-2.5 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-xs text-[var(--color-fg-muted)]">
       <span class="font-semibold text-[var(--color-fg-secondary)] tabular-nums text-md">${visibleCount}</span>
       <span>개 표시 중</span>
       ${grouped.groups.map(g => {
@@ -615,7 +615,7 @@ function BoardSummary() {
       <${ActionButton}
         variant="ghost"
         size="sm"
-        class="${lastBoardRefreshAt.value ? '' : 'ml-auto'} !px-2"
+        class="v2-workspace-action ${lastBoardRefreshAt.value ? '' : 'ml-auto'} !px-2"
         onClick=${() => navigate('workspace', { section: 'board', focus: 'curation' })}
         ariaLabel="보드 큐레이션 열기"
       >
@@ -627,7 +627,7 @@ function BoardSummary() {
       <${ActionButton}
         variant="ghost"
         size="sm"
-        class="!px-2"
+        class="v2-workspace-action !px-2"
         onClick=${() => navigate('workspace', { section: 'board', focus: 'karma' })}
         ariaLabel="보드 카르마 열기"
       >
@@ -720,7 +720,7 @@ function PostCard({ post }: { post: BoardPost }) {
       role="button"
       tabIndex=${0}
       aria-label=${`게시글 열기: ${stripInlineMarkdown(post.title)}`}
-      class=${`board-post group w-full flex gap-3 rounded-[var(--r-1)] p-4 border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-hover)] hover:border-[var(--accent-20)] transition-[background-color,border-color] duration-[var(--t-med)] cursor-pointer text-left ${ringFocusClasses()}`}
+      class=${`board-post v2-workspace-row group w-full flex gap-3 rounded-[var(--r-1)] p-4 border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-hover)] hover:border-[var(--accent-20)] transition-[background-color,border-color] duration-[var(--t-med)] cursor-pointer text-left ${ringFocusClasses()}`}
       onClick=${openPost}
       onKeyDown=${handlePostKeyDown}
     >
@@ -811,7 +811,7 @@ function PostCard({ post }: { post: BoardPost }) {
           <${ActionButton}
             variant="ghost"
             size="sm"
-            class="ml-auto !py-0.5 opacity-0 group-hover:opacity-100"
+            class="v2-workspace-action ml-auto !py-0.5 opacity-0 group-hover:opacity-100"
             onClick=${handlePin}
             pressed=${post.pinned ?? false}
             ariaLabel=${post.pinned ? `고정 해제: ${post.id}` : `고정: ${post.id}`}
@@ -821,7 +821,7 @@ function PostCard({ post }: { post: BoardPost }) {
           <${ActionButton}
             variant="danger"
             size="sm"
-            class="!py-0.5 opacity-0 group-hover:opacity-100"
+            class="v2-workspace-action !py-0.5 opacity-0 group-hover:opacity-100"
             onClick=${handleDelete}
             disabled=${isDeleting}
             ariaBusy=${isDeleting}
@@ -891,11 +891,13 @@ export function BoardSurface() {
   if (postId) {
     return post
       ? html`
-          <${BoardSummary} />
-          <${PostDetail} post=${post} />
+          <div class="v2-workspace-surface">
+            <${BoardSummary} />
+            <${PostDetail} post=${post} />
+          </div>
         `
       : html`
-          <div>
+          <div class="v2-workspace-surface">
             <${BoardSummary} />
             <button type="button"
               class="mb-4 px-3 py-1.5 rounded-[var(--r-1)] text-xs font-medium text-[var(--color-fg-muted)] bg-transparent border border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] transition-colors cursor-pointer"
@@ -910,7 +912,7 @@ export function BoardSurface() {
 
   if (focus === 'mention-inbox') {
     return html`
-      <div>
+      <div class="v2-workspace-surface">
         <${BoardSummary} />
         <${MentionInbox} />
       </div>
@@ -919,7 +921,7 @@ export function BoardSurface() {
 
   if (focus === 'messages-workspace') {
     return html`
-      <div>
+      <div class="v2-workspace-surface">
         <${BoardSummary} />
         <${MessageWorkspaceTimeline} />
       </div>
@@ -928,7 +930,7 @@ export function BoardSurface() {
 
   if (focus === 'state-block') {
     return html`
-      <div>
+      <div class="v2-workspace-surface">
         <${BoardSummary} />
         <${StateBlockMessages} />
       </div>
@@ -937,7 +939,7 @@ export function BoardSurface() {
 
   if (focus === 'curation') {
     return html`
-      <div>
+      <div class="v2-workspace-surface">
         <${BoardSummary} />
         <${BoardCurationPanel} />
       </div>
@@ -946,7 +948,7 @@ export function BoardSurface() {
 
   if (focus === 'karma') {
     return html`
-      <div>
+      <div class="v2-workspace-surface">
         <${BoardSummary} />
         <${BoardKarmaPanel} />
       </div>
@@ -954,7 +956,7 @@ export function BoardSurface() {
   }
 
   return html`
-    <div>
+    <div class="v2-workspace-surface">
       <${BoardSummary} />
       <${SortBar} />
       ${hint ? html`

--- a/dashboard/src/components/board/sub-board-surface.test.ts
+++ b/dashboard/src/components/board/sub-board-surface.test.ts
@@ -41,13 +41,14 @@ describe('SubBoardSurface', () => {
   })
 
   it('renders fetched sub-boards with access and membership state', async () => {
-    render(h(SubBoardSurface, null))
+    const { container } = render(h(SubBoardSurface, null))
 
     expect(await screen.findByText('Operations')).toBeTruthy()
     expect(screen.getByText('/ops')).toBeTruthy()
     expect(screen.getAllByText('Members only').length).toBeGreaterThan(0)
     expect(screen.getByText('2 members')).toBeTruthy()
     expect(screen.getByText('3 posts')).toBeTruthy()
+    expect(container.querySelector('.v2-workspace-surface')).not.toBeNull()
   })
 
   it('creates a sub-board with generated slug and trimmed members', async () => {

--- a/dashboard/src/components/board/sub-board-surface.ts
+++ b/dashboard/src/components/board/sub-board-surface.ts
@@ -52,7 +52,7 @@ interface SubBoardRowProps {
 
 function SubBoardRow({ board, onEdit, onDelete, deleting }: SubBoardRowProps) {
   return html`
-    <${SurfaceCard} variant="compact" testId=${`sub-board-row-${board.slug}`}>
+    <${SurfaceCard} variant="compact" class="v2-workspace-row" testId=${`sub-board-row-${board.slug}`}>
       <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div class="min-w-0 space-y-2">
           <div class="flex min-w-0 flex-wrap items-center gap-2">
@@ -86,6 +86,7 @@ function SubBoardRow({ board, onEdit, onDelete, deleting }: SubBoardRowProps) {
             <${ActionButton}
               variant="ghost"
               size="sm"
+              class="v2-workspace-action"
               onClick=${() => onEdit(board)}
               ariaLabel="Edit sub-board"
             >
@@ -94,6 +95,7 @@ function SubBoardRow({ board, onEdit, onDelete, deleting }: SubBoardRowProps) {
             <${ActionButton}
               variant="ghost"
               size="sm"
+              class="v2-workspace-action"
               onClick=${() => onDelete(board)}
               disabled=${deleting}
               ariaLabel="Delete sub-board"
@@ -234,7 +236,7 @@ export function SubBoardSurface() {
   }
 
   return html`
-    <section class="flex min-w-0 flex-col gap-4" aria-label="Sub-boards">
+    <section class="v2-workspace-surface flex min-w-0 flex-col gap-4" aria-label="Sub-boards">
       <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div class="min-w-0">
           <h2 class="text-base font-semibold text-[var(--color-fg-primary)]">Sub-Boards</h2>
@@ -243,6 +245,7 @@ export function SubBoardSurface() {
         <${ActionButton}
           variant="ghost"
           size="sm"
+          class="v2-workspace-action"
           onClick=${() => { void load() }}
           disabled=${loading}
           ariaLabel="Refresh sub-boards"
@@ -255,7 +258,7 @@ export function SubBoardSurface() {
       </div>
 
       ${!editingBoard ? html`
-        <form class="grid gap-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3" onSubmit=${submit}>
+        <form class="v2-workspace-panel grid gap-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3" onSubmit=${submit}>
           <div class="grid gap-3 lg:grid-cols-[1fr_0.8fr_0.8fr]">
             <label class="grid gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
               Name
@@ -319,6 +322,7 @@ export function SubBoardSurface() {
               type="submit"
               variant="primary"
               size="md"
+              class="v2-workspace-action"
               disabled=${!canSubmit}
               ariaBusy=${submitting}
               testId="sub-board-create"
@@ -331,10 +335,10 @@ export function SubBoardSurface() {
           </div>
         </form>
       ` : html`
-        <form class="grid gap-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3" onSubmit=${submitEdit}>
+        <form class="v2-workspace-panel grid gap-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3" onSubmit=${submitEdit}>
           <div class="flex items-center justify-between">
             <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">Edit /${editingBoard.slug}</h3>
-            <${ActionButton} variant="ghost" size="sm" onClick=${cancelEdit} ariaLabel="Cancel edit">Cancel<//>
+            <${ActionButton} variant="ghost" size="sm" class="v2-workspace-action" onClick=${cancelEdit} ariaLabel="Cancel edit">Cancel<//>
           </div>
           <div class="grid gap-3 lg:grid-cols-[1fr_0.8fr]">
             <label class="grid gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
@@ -382,6 +386,7 @@ export function SubBoardSurface() {
               type="submit"
               variant="primary"
               size="md"
+              class="v2-workspace-action"
               disabled=${editSubmitting}
               ariaBusy=${editSubmitting}
             >
@@ -399,7 +404,7 @@ export function SubBoardSurface() {
         ? html`<${LoadingState}>Loading sub-boards...<//>`
         : boards.length === 0
           ? html`
-            <div class="rounded-[var(--r-1)] border border-dashed border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
+            <div class="v2-workspace-panel rounded-[var(--r-1)] border border-dashed border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
               <${EmptyState} message="No sub-boards yet. Create one above when a board category needs owner, member, or access policy. Plain board categories stay as hearth tags until a Sub-board is explicitly created." compact />
             </div>
           `

--- a/dashboard/src/styles/v2-workspace.css
+++ b/dashboard/src/styles/v2-workspace.css
@@ -8,6 +8,89 @@
 
 .v2-workspace-surface,
 .v2-workspace-panel,
+.v2-workspace-card,
+.v2-workspace-row,
+.v2-workspace-action,
+.v2-workspace-table,
 .v2-workspace-detail {
   --v2-workspace-top-glow: rgb(var(--brass-glow) / 0.04);
+}
+
+/* ── Panels / cards ───────────────────────────────────────────────────────── */
+
+.v2-workspace-panel,
+.v2-workspace-card,
+.v2-workspace-surface [data-surface-card] {
+  box-shadow: inset 0 1px 0 var(--v2-workspace-top-glow);
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-workspace-panel:hover,
+.v2-workspace-card:hover,
+.v2-workspace-surface [data-surface-card]:hover {
+  border-color: var(--color-border-strong);
+}
+
+/* ── Rows (lists, tables) ─────────────────────────────────────────────────── */
+
+.v2-workspace-row,
+.v2-workspace-table tbody tr,
+.v2-workspace-panel table tbody tr,
+.v2-workspace-detail table tbody tr {
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-workspace-row:hover,
+.v2-workspace-table tbody tr:hover,
+.v2-workspace-panel table tbody tr:hover,
+.v2-workspace-detail table tbody tr:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-elevated);
+}
+
+/* ── Action buttons ───────────────────────────────────────────────────────── */
+
+.v2-workspace-action:not(:disabled),
+.v2-workspace-panel .v2-workspace-action:not(:disabled),
+.v2-workspace-surface [data-action-button]:not(:disabled) {
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-workspace-action:not(:disabled):hover,
+.v2-workspace-surface [data-action-button]:not(:disabled):hover {
+  border-color: var(--color-accent-fg);
+  background: var(--color-brass-soft);
+}
+
+/* ── Tables ───────────────────────────────────────────────────────────────── */
+
+.v2-workspace-table,
+.v2-workspace-panel table,
+.v2-workspace-detail table {
+  border-color: var(--color-border-default);
+}
+
+.v2-workspace-table thead,
+.v2-workspace-panel table thead,
+.v2-workspace-detail table thead {
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.v2-workspace-table th,
+.v2-workspace-panel table th,
+.v2-workspace-detail table th {
+  color: var(--color-fg-muted);
+}
+
+.v2-workspace-table td,
+.v2-workspace-panel table td,
+.v2-workspace-detail table td {
+  color: var(--color-fg-secondary);
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+/* ── Detail sections ──────────────────────────────────────────────────────── */
+
+.v2-workspace-detail {
+  box-shadow: inset 0 1px 0 var(--v2-workspace-top-glow);
 }


### PR DESCRIPTION
Phase 2 of the dashboard v2 surface migration.

- Fills `dashboard/src/styles/v2-workspace.css` with scoped v2 chrome.
- Wraps `BoardSurface`, `SubBoardSurface`, and `BoardModerationSurface` roots in `.v2-workspace-surface`.
- Adds `.v2-workspace-panel`, `.v2-workspace-row`, and `.v2-workspace-action` markers to board summary bars, category cards, post rows, sub-board rows/forms, and moderation forms/actions.
- Keeps shared primitives untouched; styling is driven through existing `data-*\] attributes on SurfaceCard/SectionCard/ActionButton.
- Adds coverage-ratchet assertions to board-surface, sub-board-surface, and board-moderation-surface tests.

Local verification: `pnpm typecheck`, `pnpm lint`, targeted vitest runs, and `pnpm build` all pass.