### PR TITLE
feat(dashboard): migrate Planning & Goals surfaces to v2 workspace markers

### DIFF
--- a/dashboard/src/components/goal-loop-panel.test.ts
+++ b/dashboard/src/components/goal-loop-panel.test.ts
@@ -99,9 +99,10 @@ describe('GoalLoopPanel', () => {
   })
 
   it('renders phase table, audit, and next action', () => {
-    render(html`<${GoalLoopPanel} initialStatus=${blockedStatus()} />`)
+    const { container } = render(html`<${GoalLoopPanel} initialStatus=${blockedStatus()} />`)
 
     expect(screen.getByTestId('goal-loop-panel')).toBeTruthy()
+    expect(container.querySelector('.v2-workspace-surface')).not.toBeNull()
     expect(screen.getByRole('grid', { name: /goal loop phases/i })).toBeTruthy()
     expect(screen.getByTestId('goal-loop-audit-catalog').textContent).toContain('INCOMPLETE')
     expect(screen.getByTestId('goal-loop-corpus-missing').textContent).toContain('187')

--- a/dashboard/src/components/goal-loop-panel.ts
+++ b/dashboard/src/components/goal-loop-panel.ts
@@ -141,7 +141,7 @@ function PhaseBlock({
   const phaseStatus = status.phases[phase].status
   return html`
     <div
-      class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2"
+      class="v2-workspace-panel min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2"
       data-testid=${`goal-loop-phase-${phase}`}
     >
       <div class="mb-2 flex items-center justify-between gap-2">
@@ -545,20 +545,22 @@ export function GoalLoopPanel({ initialStatus }: GoalLoopPanelProps) {
   }, [initialStatus, refresh])
 
   if (loading && status === null) {
-    return html`<${LoadingState}>Loading GOAL LOOP...<//>`
+    return html`<div class="v2-workspace-surface"><${LoadingState}>Loading GOAL LOOP...<//></div>`
   }
 
   if (status === null) {
     return html`
-      <${SectionCard} label="GOAL LOOP" data-testid="goal-loop-panel">
-        <div class="text-xs text-[var(--color-status-err)]">${error ?? 'status unavailable'}</div>
-      <//>
+      <div class="v2-workspace-surface">
+        <${SectionCard} label="GOAL LOOP" data-testid="goal-loop-panel">
+          <div class="text-xs text-[var(--color-status-err)]">${error ?? 'status unavailable'}</div>
+        <//>
+      </div>
     `
   }
 
   return html`
-    <div class="flex flex-col gap-4" data-testid="goal-loop-panel">
-      <div class="flex flex-wrap items-center justify-between gap-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+    <div class="v2-workspace-surface flex flex-col gap-4" data-testid="goal-loop-panel">
+      <div class="v2-workspace-panel flex flex-wrap items-center justify-between gap-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
         <div class="min-w-0">
           <div class="flex flex-wrap items-center gap-2">
             <span class="font-mono text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
@@ -574,6 +576,7 @@ export function GoalLoopPanel({ initialStatus }: GoalLoopPanelProps) {
         <${ActionButton}
           variant="ghost"
           size="sm"
+          class="v2-workspace-action"
           ariaLabel="Refresh GOAL LOOP status"
           title="Refresh GOAL LOOP status"
           onClick=${refresh}

--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -185,8 +185,9 @@ describe('GoalTree', () => {
     mocks.fetchDashboardGoalsTree.mockResolvedValue(treePayload)
     mocks.fetchDashboardGoalDetail.mockResolvedValue(detailPayload)
 
-    render(html`<${GoalTree} />`)
+    const { container } = render(html`<${GoalTree} />`)
 
+    expect(container.querySelector('.v2-workspace-surface')).not.toBeNull()
     await waitFor(() => {
       expect(screen.getByTestId('goal-detail-panel').getAttribute('data-selected-goal-id'))
         .toBe('goal-child')

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -955,7 +955,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
     <div class="flex flex-col" style="margin-left:${indent}px">
       <button
         type="button"
-        class="${headerBase} ${hasContent ? 'cursor-pointer' : ''} ${ringFocusClasses()}"
+        class="v2-workspace-row ${headerBase} ${hasContent ? 'cursor-pointer' : ''} ${ringFocusClasses()}"
         onClick=${() => {
           selectGoal(node.id)
           if (hasContent) toggleNode(node.id)
@@ -1642,8 +1642,8 @@ export function GoalTree() {
   const isFiltering = query.trim() !== '' || activePhaseFilter !== 'all'
 
   return html`
-    <div class="flex flex-col gap-5">
-      <section class=${GOAL_PANEL} aria-label="목표 관리자">
+    <div class="v2-workspace-surface flex flex-col gap-5">
+      <section class="${GOAL_PANEL} v2-workspace-panel" aria-label="목표 관리자">
         <div class="mb-4 flex flex-wrap items-start justify-between gap-4">
           <div class="max-w-190">
             <h3 class="text-2xl font-semibold tracking-[-0.02em] text-text-strong">목표 관리자</h3>
@@ -1658,16 +1658,17 @@ export function GoalTree() {
                 onInput=${(e: Event) => { filterQuery.value = (e.target as HTMLInputElement).value }}
                 class="min-w-45 max-w-65 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-xs text-text-body placeholder:text-text-dim focus:outline-none focus:border-accent-fg"
               />
-              <${ActionButton} variant="ghost" size="sm" onClick=${() => expandAll(data.tree)}>
+              <${ActionButton} variant="ghost" size="sm" class="v2-workspace-action" onClick=${() => expandAll(data.tree)}>
                 모두 펼치기
               <//>
-              <${ActionButton} variant="ghost" size="sm" onClick=${collapseAll}>
+              <${ActionButton} variant="ghost" size="sm" class="v2-workspace-action" onClick=${collapseAll}>
                 모두 접기
               <//>
             ` : null}
             <${ActionButton}
               variant="ghost"
               size="md"
+              class="v2-workspace-action"
               disabled=${loading}
               onClick=${() => { void refreshTree() }}
             >

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -224,7 +224,7 @@ export function Planning() {
       : '아직 등록된 항목이 없습니다.'
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="v2-workspace-surface flex flex-col gap-4">
       <section class="${DECK_PANEL}" aria-label="계획 상태 요약">
         <div class="${DECK_HEAD}">
           <div class="max-w-190">
@@ -235,6 +235,7 @@ export function Planning() {
           <${ActionButton}
             variant="ghost"
             size="md"
+            class="v2-workspace-action"
             disabled=${goalsLoading.value}
             onClick=${() => { refreshGoals() }}
           >

--- a/dashboard/src/components/planning-focus-panel.ts
+++ b/dashboard/src/components/planning-focus-panel.ts
@@ -171,7 +171,7 @@ function FocusFrame({
   children: unknown
 }) {
   return html`
-    <section class="rounded-[var(--r-1)] border border-card-border/70 bg-[var(--color-bg-surface)] p-3" aria-label=${title}>
+    <section class="v2-workspace-panel rounded-[var(--r-1)] border border-card-border/70 bg-[var(--color-bg-surface)] p-3" aria-label=${title}>
       <header class="flex flex-wrap items-start justify-between gap-3">
         <div>
           <div class="font-mono text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-text-muted">planning focus</div>
@@ -207,7 +207,7 @@ function StaleFocus({ entries }: { entries: StaleEntry[] }) {
       ` : html`
         <ul class="grid gap-2" data-testid="planning-focus-stale">
           ${entries.slice(0, 8).map(entry => html`
-            <li key=${entry.task.id} class="grid gap-2 rounded-[var(--r-1)] border border-warn/25 bg-warn/5 px-3 py-2 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+            <li key=${entry.task.id} class="v2-workspace-row grid gap-2 rounded-[var(--r-1)] border border-warn/25 bg-warn/5 px-3 py-2 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
               <div class="min-w-0">
                 <button
                   type="button"
@@ -256,7 +256,7 @@ function LedgerFocus({ rows }: { rows: AccountabilityRow[] }) {
       ` : html`
         <ul class="grid gap-2" data-testid="planning-focus-ledger">
           ${(activeRows.length > 0 ? activeRows : rows).slice(0, 8).map(row => html`
-            <li key=${row.principal} class="rounded-[var(--r-1)] border border-card-border/60 bg-black/10 p-3">
+            <li key=${row.principal} class="v2-workspace-row rounded-[var(--r-1)] border border-card-border/60 bg-black/10 p-3">
               <div class="flex flex-wrap items-start justify-between gap-3">
                 <div class="min-w-0">
                   ${row.principal === 'unassigned' ? html`
@@ -336,7 +336,7 @@ function MatrixFocus({ rows }: { rows: AccountabilityRow[] }) {
             </thead>
             <tbody>
               ${rows.slice(0, 12).map(row => html`
-                <tr key=${row.principal}>
+                <tr key=${row.principal} class="v2-workspace-row">
                   <th class="border-t border-card-border/50 px-2 py-2 text-left font-mono text-2xs text-text-strong">${row.principal}</th>
                   ${STATUS_BUCKETS.map(status => html`<${MatrixCell} key=${status} value=${row.counts[status]} tone=${status} />`)}
                   <td class="border-t border-card-border/50 px-2 py-2 text-right font-mono text-2xs tabular-nums ${row.stale > 0 ? 'text-warn' : 'text-text-dim'}">${row.stale}</td>

--- a/dashboard/src/components/planning-panel.test.ts
+++ b/dashboard/src/components/planning-panel.test.ts
@@ -64,9 +64,10 @@ describe('PlanningPanel', () => {
   afterEach(() => cleanup())
 
   it('renders GoalTree by default', () => {
-    render(html`<${PlanningPanel} />`)
+    const { container } = render(html`<${PlanningPanel} />`)
     expect(screen.getByTestId('goal-tree')).toBeTruthy()
     expect(screen.queryByTestId('planning')).toBeNull()
+    expect(container.querySelector('.v2-workspace-surface')).not.toBeNull()
   })
 
   it('renders Planning when view=default', () => {

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -115,7 +115,7 @@ function PlanningRouteFocusPanel() {
 
   return html`
     <section
-      class="rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-3 py-2"
+      class="v2-workspace-panel rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-3 py-2"
       data-testid="planning-route-focus"
       data-route-focused-goal=${goalId ?? undefined}
       data-route-focused-task=${taskId ?? undefined}
@@ -149,7 +149,7 @@ function PlanningRouteFocusPanel() {
         </div>
         <button
           type="button"
-          class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-text-muted transition-colors hover:border-[var(--color-border-strong)] hover:text-text-strong"
+          class="v2-workspace-action rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-text-muted transition-colors hover:border-[var(--color-border-strong)] hover:text-text-strong"
           onClick=${clearPlanningRouteFocus}
         >
           CLEAR
@@ -211,7 +211,7 @@ function WorkspaceHealthPanel() {
   const warnCount = workspaceCount(snapshot, 'warn')
   const evidenceCount = workspaceCount(snapshot, 'evidence')
   return html`
-    <section class="rounded-[var(--r-1)] border border-card-border/70 bg-[var(--color-bg-surface)] p-3" aria-label="협력 상태">
+    <section class="v2-workspace-panel rounded-[var(--r-1)] border border-card-border/70 bg-[var(--color-bg-surface)] p-3" aria-label="협력 상태">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div>
           <div class="text-sm font-semibold text-text-strong">협력 상태</div>
@@ -266,7 +266,7 @@ export function PlanningPanel() {
   const view = activeView.value
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="v2-workspace-surface flex flex-col gap-4">
       <${FilterChips}
         chips=${VIEW_CHIPS}
         value=${view}


### PR DESCRIPTION
## Summary

Phase 3 of the dashboard v2 surface migration: apply v2 workspace surface markers to the Planning & Goals section.

## Changes

- Wrapped surface roots with `.v2-workspace-surface`.
- Marked panels/cards with `.v2-workspace-panel`.
- Marked list rows with `.v2-workspace-row`.
- Marked action buttons with `.v2-workspace-action`.

### Components updated

- `PlanningPanel`
- `PlanningFocusPanel`
- `GoalLoopPanel`
- `Planning`
- `GoalTree`

### Tests updated

- `planning-panel.test.ts`
- `goal-loop-panel.test.ts`
- `goals/goal-tree.test.ts`

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Targeted vitest runs for touched test files ✅
- `pnpm build` ✅

## Scope notes

- Does not include `repository-management` or `verification-requests-panel`; those belong to separate workspace sections.
- No CSS changes needed; `v2-workspace.css` was filled in Phase 2.