### PR TITLE
feat(dashboard): migrate Monitoring leftovers to v2 monitoring markers

### DIFF
--- a/dashboard/src/components/cognition-plane.test.ts
+++ b/dashboard/src/components/cognition-plane.test.ts
@@ -68,6 +68,7 @@ describe('CognitionPlane', () => {
     render(html`<${CognitionPlane} />`, container)
     await flushUi()
 
+    expect(container.querySelector('.v2-monitoring-surface')).not.toBeNull()
     expect(container.textContent).toContain('Keeper')
     expect(container.textContent).toContain('Keeper Fleet')
     expect(container.querySelector('[data-testid="agents-unified"]')).toBeNull()

--- a/dashboard/src/components/cognition-plane.ts
+++ b/dashboard/src/components/cognition-plane.ts
@@ -114,7 +114,7 @@ export function CognitionPlane() {
   const view = currentView()
 
   return html`
-    <div class="flex flex-col gap-5">
+    <div class="v2-monitoring-surface flex flex-col gap-5">
       <${FilterChips}
         chips=${VIEW_CHIPS}
         value=${view}

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -1221,7 +1221,7 @@ function CostDashboardContent({ view }: { view: CostView }) {
 
 export function CostDashboard({ view = 'cost' }: { view?: CostView }) {
   return html`
-    <div class="contain-content flex flex-col gap-4">
+    <div class="v2-monitoring-surface contain-content flex flex-col gap-4">
       <${CostDashboardContent} view=${view} />
     </div>
   `

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -205,8 +205,8 @@ export function FeatureHealth() {
   }, [])
 
   return html`
-    <div class="space-y-4">
-      <${SectionCard} label="기능 상태" class="section">
+    <div class="v2-monitoring-surface flex flex-col gap-4">
+      <${SectionCard} label="기능 상태" class="section v2-monitoring-panel">
         <${AsyncContainer}
           state=${featureHealth.state}
           loadingMessage="기능 상태 데이터를 불러오는 중..."
@@ -230,7 +230,7 @@ export function FeatureHealth() {
                     </div>
                     <button
                       type="button"
-                      class="rounded-[var(--r-1)] border border-[var(--color-border-default)] px-2.5 py-1 text-2xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--color-fg-secondary)]"
+                      class="v2-monitoring-action rounded-[var(--r-1)] border border-[var(--color-border-default)] px-2.5 py-1 text-2xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--color-fg-secondary)]"
                       onClick=${() => { void loadFeatureHealth() }}
                     >새로고침</button>
                   </div>

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -477,8 +477,8 @@ export function JourneyPanel() {
   const state = resource.state.value
 
   return html`
-    <div class="flex flex-col gap-4">
-      <${SurfaceCard} class="flex flex-col gap-4">
+    <div class="v2-monitoring-surface flex flex-col gap-4">
+      <${SurfaceCard} class="v2-monitoring-panel flex flex-col gap-4">
         <div class="flex flex-wrap items-start justify-between gap-4">
           <div class="min-w-0">
             <div class="flex flex-wrap items-center gap-2">
@@ -513,7 +513,7 @@ export function JourneyPanel() {
                   testId="journey-keeper-select"
                   onInput=${(value: string) => setSelectedKeeper(value)}
                 />
-                <${ActionButton} variant="ghost" size="md" onClick=${refresh} disabled=${state.loading || !selectedKeeper}>
+                <${ActionButton} variant="ghost" size="md" class="v2-monitoring-action" onClick=${refresh} disabled=${state.loading || !selectedKeeper}>
                   ${state.loading ? 'Refreshing...' : 'Refresh'}
                 <//>
               </div>
@@ -525,7 +525,7 @@ export function JourneyPanel() {
             <div class="flex flex-col gap-3">
               <${ErrorState} message=${state.error} />
               <div>
-                <${ActionButton} variant="ghost" size="sm" onClick=${refresh} disabled=${state.loading || !selectedKeeper}>Retry<//>
+                <${ActionButton} variant="ghost" size="sm" class="v2-monitoring-action" onClick=${refresh} disabled=${state.loading || !selectedKeeper}>Retry<//>
               </div>
             </div>
           `

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -207,7 +207,7 @@ export function Observatory() {
   const data = state.value
 
   return html`
-    <div class="flex flex-col gap-5">
+    <div class="v2-monitoring-surface flex flex-col gap-5">
       <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div class="flex flex-col gap-0.5">
           <h3 class="text-sm font-semibold text-text-strong">Observatory</h3>
@@ -230,7 +230,7 @@ export function Observatory() {
         </div>
       ` : null}
 
-      <div class="flex flex-col gap-2 rounded-[var(--r-1)] border border-card-border bg-card/30 p-4">
+      <div class="v2-monitoring-panel flex flex-col gap-2 rounded-[var(--r-1)] border border-card-border bg-card/30 p-4">
         <${TimeAxis} windowStart=${data.windowStart} windowEnd=${data.windowEnd} />
         <${EventTrack}
           events=${data.events}

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -105,7 +105,7 @@ export function Status() {
   const keeperParam = route.value.params.keeper
   if (section === 'agents' && typeof keeperParam === 'string' && keeperParam.trim() !== '') {
     return html`
-      <div class="h-full min-h-0">
+      <div class="v2-monitoring-surface h-full min-h-0">
         <${Suspense} fallback=${sectionFallback(sectionLabel('agents'))}>
           <${LazyAgentsUnified} />
         <//>
@@ -114,7 +114,7 @@ export function Status() {
   }
 
   return html`
-    <div class="flex flex-col gap-5">
+    <div class="v2-monitoring-surface flex flex-col gap-5">
       <div class="transition-opacity duration-[var(--t-slow)]">
         <${Suspense} fallback=${sectionFallback(sectionLabel(section))}>
           ${renderSection(section)}

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -1312,8 +1312,8 @@ export function TelemetryUnified() {
   const condensed = useMemo(() => condensedStats(displayItems), [displayItems])
 
   return html`
-    <div class="flex flex-col gap-4">
-      <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
+    <div class="v2-monitoring-surface flex flex-col gap-4">
+      <div class="v2-monitoring-panel rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
         <div class="text-xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">런타임 진단</div>
         <div class="mt-2 flex flex-wrap gap-2">
           <span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs text-[var(--color-fg-disabled)]">MASC: keeper/tool/agent store</span>

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -209,6 +209,7 @@ describe('TransportHealthPanel', () => {
     render(html`<${TransportHealthPanel} />`, container)
     await flushUi()
 
+    expect(container.querySelector('.v2-monitoring-surface')).not.toBeNull()
     expect(fetchTransportHealth).toHaveBeenCalled()
     expect(container.textContent).toContain('WebRTC')
     expect(container.textContent).toContain('시그널링')

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -415,7 +415,7 @@ export function TransportHealthPanel() {
   const truthLine = transportTruthLine(data)
 
   return html`
-    <div class="space-y-4">
+    <div class="v2-monitoring-surface flex flex-col gap-4">
       <div class="flex items-start justify-between gap-4">
         <div>
           <div class="flex items-center gap-2">
@@ -433,7 +433,7 @@ export function TransportHealthPanel() {
         <${ActionButton}
           variant="subtle"
           size="sm"
-          class="text-3xs"
+          class="v2-monitoring-action text-3xs"
           onClick=${() => void refreshTransportHealth()}
         >새로고침<//>
       </div>


### PR DESCRIPTION
## Summary

Phase 4 of the dashboard v2 surface migration: apply v2 monitoring surface markers to the remaining Monitor surfaces.

## Changes

- Wrapped surface roots with `.v2-monitoring-surface`.
- Marked key panels/cards with `.v2-monitoring-panel`.
- Marked refresh/retry actions with `.v2-monitoring-action`.

### Components updated

- `Status` (monitoring surface wrapper)
- `FeatureHealth`
- `TransportHealthPanel`
- `CognitionPlane`
- `Observatory`
- `JourneyPanel`
- `CostDashboard`
- `TelemetryUnified`

### Tests updated

- `transport-health.test.ts`
- `cognition-plane.test.ts`

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Targeted vitest runs for touched test files ✅
- `pnpm build` ✅

## Scope notes

- Already-migrated monitoring components (`AgentsUnified`, `RuntimePanel`, `FleetHealthPanel`, etc.) keep their existing markers.
- No CSS changes needed; `v2-monitoring.css` is already imported.