### PR TITLE
feat(dashboard): migrate Lab / Tools & Harness to v2 lab markers

### DIFF
--- a/dashboard/src/components/harness-health.test.ts
+++ b/dashboard/src/components/harness-health.test.ts
@@ -186,6 +186,7 @@ describe('HarnessHealth', () => {
     render(html`<${HarnessHealth} />`, container)
     await flushUi()
 
+    expect(container.querySelector('.v2-lab-surface')).not.toBeNull()
     expect(get).toHaveBeenCalledWith('/api/v1/dashboard/harness-health')
     expect(container.textContent).toContain('안전 감시')
     expect(container.textContent).toContain('감시 흐름도')

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -276,7 +276,7 @@ export function HarnessHealth() {
             <div class="flex items-center gap-2">
               <button
                 type="button"
-                class="rounded-[var(--r-1)] border border-[var(--color-border-default)] px-2.5 py-1 text-2xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-accent-fg)] hover:text-[var(--color-fg-primary)]"
+                class="v2-lab-action rounded-[var(--r-1)] border border-[var(--color-border-default)] px-2.5 py-1 text-2xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-accent-fg)] hover:text-[var(--color-fg-primary)]"
                 onClick=${() => { void loadHarnessHealth() }}
               >새로고침</button>
             </div>
@@ -318,12 +318,12 @@ export function HarnessHealth() {
   }
 
   return html`
-    <div class="space-y-4">
-      <${SectionCard} label="안전 감시" class="section">
+    <div class="v2-lab-surface flex flex-col gap-4">
+      <${SectionCard} label="안전 감시" class="section v2-lab-panel">
         ${overviewContent}
       <//>
 
-      <${SectionCard} label="감시 흐름도" class="section">
+      <${SectionCard} label="감시 흐름도" class="section v2-lab-panel">
         ${!data || !flowSource ? html`
           <${EmptySignal} text="감시 흐름 데이터가 없습니다." />
         ` : html`

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -17,7 +17,7 @@ export function Lab() {
   const section = currentSection()
 
   return html`
-    <div class="space-y-6">
+    <div class="v2-lab-surface flex flex-col gap-6">
       ${section === 'tools' ? html`
         <${Tools} />
       ` : null}

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -87,6 +87,7 @@ describe('Tools', () => {
     render(html`<${Tools} />`, container)
     await flush()
 
+    expect(container.querySelector('.v2-lab-surface')).not.toBeNull()
     expect(mocks.loadTools).toHaveBeenCalledTimes(1)
     expect(container.textContent).toContain('ConfigResolutionPanel')
     expect(container.textContent).toContain('예약 자동화 FSM')

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -45,11 +45,11 @@ export function Tools() {
   }, [])
 
   return html`
-    <div>
+    <div class="v2-lab-surface flex flex-col gap-4">
       <div class="flex gap-2 mb-4">
-        <${ActionButton} variant=${activeView.value === 'inventory' ? 'primary' : 'ghost'} size="md"
+        <${ActionButton} variant=${activeView.value === 'inventory' ? 'primary' : 'ghost'} size="md" class="v2-lab-action"
           onClick=${() => { activeView.value = 'inventory' }}>인벤토리<//>
-        <${ActionButton} variant=${activeView.value === 'executor' ? 'primary' : 'ghost'} size="md"
+        <${ActionButton} variant=${activeView.value === 'executor' ? 'primary' : 'ghost'} size="md" class="v2-lab-action"
           onClick=${() => { activeView.value = 'executor' }}>도구 실행기<//>
       </div>
       ${activeView.value === 'executor' ? html`<${ToolExecutor} />` : html`<div>
@@ -60,11 +60,11 @@ export function Tools() {
 
       <${PromptRegistryPanel} />
 
-      <${SectionCard} label="예약 자동화 FSM" class="section mb-4">
+      <${SectionCard} label="예약 자동화 FSM" class="section v2-lab-panel mb-4">
         <${ScheduledAutomationPanel} automation=${data?.scheduled_automation ?? null} />
       <//>
 
-      <${SectionCard} label="시스템 도구 목록" class="section mb-4">
+      <${SectionCard} label="시스템 도구 목록" class="section v2-lab-panel mb-4">
         <${FullInventoryView}
           inventory=${inventory}
           loading=${loading}
@@ -72,7 +72,7 @@ export function Tools() {
         />
       <//>
 
-      <${SectionCard} label="도구 사용 현황" class="section mb-4">
+      <${SectionCard} label="도구 사용 현황" class="section v2-lab-panel mb-4">
         ${usage
           ? html`
               <div class="text-xs text-[var(--color-fg-muted)] mb-2">

--- a/dashboard/src/styles/v2-lab.css
+++ b/dashboard/src/styles/v2-lab.css
@@ -8,6 +8,83 @@
 
 .v2-lab-surface,
 .v2-lab-panel,
-.v2-lab-card {
+.v2-lab-card,
+.v2-lab-row,
+.v2-lab-action,
+.v2-lab-table,
+.v2-lab-detail {
   --v2-lab-top-glow: rgb(var(--brass-glow) / 0.04);
+}
+
+/* ── Panels / cards ───────────────────────────────────────────────────────── */
+
+.v2-lab-panel,
+.v2-lab-card,
+.v2-lab-surface [data-surface-card] {
+  box-shadow: inset 0 1px 0 var(--v2-lab-top-glow);
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-lab-panel:hover,
+.v2-lab-card:hover,
+.v2-lab-surface [data-surface-card]:hover {
+  border-color: var(--color-border-strong);
+}
+
+/* ── Rows (lists, tables) ─────────────────────────────────────────────────── */
+
+.v2-lab-row,
+.v2-lab-table tbody tr,
+.v2-lab-panel table tbody tr,
+.v2-lab-detail table tbody tr {
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-lab-row:hover,
+.v2-lab-table tbody tr:hover,
+.v2-lab-panel table tbody tr:hover,
+.v2-lab-detail table tbody tr:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-elevated);
+}
+
+/* ── Action buttons ───────────────────────────────────────────────────────── */
+
+.v2-lab-action:not(:disabled),
+.v2-lab-panel .v2-lab-action:not(:disabled),
+.v2-lab-surface [data-action-button]:not(:disabled) {
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-lab-action:not(:disabled):hover,
+.v2-lab-surface [data-action-button]:not(:disabled):hover {
+  border-color: var(--color-accent-fg);
+  background: var(--color-brass-soft);
+}
+
+/* ── Tables ───────────────────────────────────────────────────────────────── */
+
+.v2-lab-table,
+.v2-lab-panel table,
+.v2-lab-detail table {
+  border-color: var(--color-border-default);
+}
+
+.v2-lab-table thead,
+.v2-lab-panel table thead,
+.v2-lab-detail table thead {
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.v2-lab-table th,
+.v2-lab-panel table th,
+.v2-lab-detail table th {
+  color: var(--color-fg-muted);
+}
+
+.v2-lab-table td,
+.v2-lab-panel table td,
+.v2-lab-detail table td {
+  color: var(--color-fg-secondary);
+  border-bottom: 1px solid var(--color-border-default);
 }


### PR DESCRIPTION
## Summary

Phase 5 of the dashboard v2 surface migration: apply v2 lab surface markers to the Lab surface (Tools + Safety Harness).

## Changes

- Wrapped surface roots with `.v2-lab-surface`.
- Marked SectionCards with `.v2-lab-panel`.
- Marked view/refresh actions with `.v2-lab-action`.
- Filled `v2-lab.css` with panel/card/row/action/table rules consistent with `v2-command.css` and `v2-monitoring.css`.

### Components updated

- `Lab`
- `Tools`
- `HarnessHealth`

### Tests updated

- `tools/tools-main.test.ts`
- `harness-health.test.ts`

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Targeted vitest runs for touched test files ✅
- `pnpm build` ✅

## Scope notes

- Tool-executor and nested tool panels are rendered inside the marked `Tools` surface; they inherit the scoped styles.