### PR TITLE
feat(dashboard): migrate Code / IDE to v2 ide markers

### DIFF
--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -116,6 +116,7 @@ describe('IdeShell', () => {
 
     render(h(IdeShell, {}), container)
 
+    expect(container.querySelector('.v2-ide-surface')).not.toBeNull()
     expect(buttonByText(container, 'Time').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Tools').getAttribute('aria-pressed')).toBe('false')

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -641,7 +641,7 @@ export function IdeShell() {
 
   return html`
     <section
-      class="ide-plane-shell"
+      class="ide-plane-shell v2-ide-surface"
       role="region"
       aria-label="Code IDE shell"
       data-terminal-open=${terminalOpen ? 'true' : 'false'}
@@ -698,7 +698,7 @@ export function IdeShell() {
         class="ide-plane-grid"
         role="presentation"
       >
-        <div class="ide-plane-tree">
+        <div class="ide-plane-tree v2-ide-panel">
           <${IdeExplorer}
             fileTreeStore=${workspaceStore.fileTreeStore}
             workspaceSource=${workspaceStore.workspaceSource}
@@ -711,7 +711,7 @@ export function IdeShell() {
           />
         </div>
         <div
-          class="ide-plane-editor"
+          class="ide-plane-editor v2-ide-panel"
         >
           <${IdeEditor}
             activeView=${activeView}
@@ -731,7 +731,7 @@ export function IdeShell() {
           ? null
           : html`
             <div
-              class="ide-plane-conversation"
+              class="ide-plane-conversation v2-ide-panel"
               data-testid="ide-right-rail"
             >
               <div
@@ -754,7 +754,7 @@ export function IdeShell() {
         ${railsCollapsed
           ? null
           : html`
-            <div class="ide-plane-activity" style=${{ minHeight: 0 }}>
+            <div class="ide-plane-activity v2-ide-panel" style=${{ minHeight: 0 }}>
               <${IdeActivityPanel}
                 activeFile=${activeFilePath}
                 annotations=${annotations}

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -31,7 +31,7 @@ const VIEW_TABS: ReadonlyArray<{ readonly id: ViewTab; readonly label: string }>
 ]
 
 const TOOLBAR_BUTTON_BASE =
-  'h-7 shrink-0 cursor-pointer rounded-[var(--r-1)] px-2 font-mono text-2xs uppercase tracking-[var(--track-caps)] transition-colors'
+  'v2-ide-action h-7 shrink-0 cursor-pointer rounded-[var(--r-1)] px-2 font-mono text-2xs uppercase tracking-[var(--track-caps)] transition-colors'
 
 export const IDE_LAYERS: ReadonlyArray<OverlayLayer> = [
   { kind: 'time', label: 'Time', description: '변경 timestamp gradient' },
@@ -168,7 +168,7 @@ export function IdeToolbar({
       role="toolbar"
       aria-label="IDE editor toolbar"
       data-testid="ide-toolbar"
-      class="ide-toolbar"
+      class="ide-toolbar v2-ide-toolbar"
       data-has-rails=${onRailsToggle ? 'true' : 'false'}
     >
       <div

--- a/dashboard/src/styles/v2-ide.css
+++ b/dashboard/src/styles/v2-ide.css
@@ -8,7 +8,102 @@
 
 .v2-ide-surface,
 .v2-ide-panel,
+.v2-ide-card,
 .v2-ide-rail,
-.v2-ide-toolbar {
+.v2-ide-toolbar,
+.v2-ide-action,
+.v2-ide-row,
+.v2-ide-table,
+.v2-ide-detail {
   --v2-ide-top-glow: rgb(var(--brass-glow) / 0.04);
+}
+
+/* ── Surface chrome ────────────────────────────────────────────────────────── */
+
+.v2-ide-surface .ide-plane-statusbar,
+.v2-ide-toolbar {
+  border-color: var(--color-border-default);
+}
+
+/* ── Panels / cards ───────────────────────────────────────────────────────── */
+
+.v2-ide-panel,
+.v2-ide-card,
+.v2-ide-surface [data-surface-card] {
+  box-shadow: inset 0 1px 0 var(--v2-ide-top-glow);
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-ide-panel:hover,
+.v2-ide-card:hover,
+.v2-ide-surface [data-surface-card]:hover {
+  border-color: var(--color-border-strong);
+}
+
+/* ── Rails ────────────────────────────────────────────────────────────────── */
+
+.v2-ide-rail,
+.v2-ide-panel.ide-plane-tree,
+.v2-ide-panel.ide-plane-conversation,
+.v2-ide-panel.ide-plane-activity {
+  border-color: var(--color-border-default);
+}
+
+/* ── Toolbar buttons ──────────────────────────────────────────────────────── */
+
+.v2-ide-action:not(:disabled),
+.v2-ide-toolbar .v2-ide-action:not(:disabled),
+.v2-ide-surface [data-action-button]:not(:disabled) {
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-ide-action:not(:disabled):hover,
+.v2-ide-toolbar .v2-ide-action:not(:disabled):hover,
+.v2-ide-surface [data-action-button]:not(:disabled):hover {
+  border-color: var(--color-accent-fg);
+  background: var(--color-brass-soft);
+}
+
+/* ── Rows (lists, tables) ─────────────────────────────────────────────────── */
+
+.v2-ide-row,
+.v2-ide-table tbody tr,
+.v2-ide-panel table tbody tr,
+.v2-ide-detail table tbody tr {
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.v2-ide-row:hover,
+.v2-ide-table tbody tr:hover,
+.v2-ide-panel table tbody tr:hover,
+.v2-ide-detail table tbody tr:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-elevated);
+}
+
+/* ── Tables ───────────────────────────────────────────────────────────────── */
+
+.v2-ide-table,
+.v2-ide-panel table,
+.v2-ide-detail table {
+  border-color: var(--color-border-default);
+}
+
+.v2-ide-table thead,
+.v2-ide-panel table thead,
+.v2-ide-detail table thead {
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.v2-ide-table th,
+.v2-ide-panel table th,
+.v2-ide-detail table th {
+  color: var(--color-fg-muted);
+}
+
+.v2-ide-table td,
+.v2-ide-panel table td,
+.v2-ide-detail table td {
+  color: var(--color-fg-secondary);
+  border-bottom: 1px solid var(--color-border-default);
 }


### PR DESCRIPTION
## Summary

Phase 6 (final) of the dashboard v2 surface migration: apply v2 IDE surface markers to the Code / IDE shell.

## Changes

- Wrapped `IdeShell` root with `.v2-ide-surface`.
- Marked main IDE panes (tree, editor, conversation, activity) with `.v2-ide-panel`.
- Marked `IdeToolbar` with `.v2-ide-toolbar` and toolbar buttons with `.v2-ide-action`.
- Filled `v2-ide.css` with surface chrome, panel, rail, toolbar, action, row, and table rules consistent with the other v2 surfaces.

### Tests updated

- `ide/ide-shell.test.ts`

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Targeted vitest runs for touched test files ✅
- `pnpm build` ✅

## Scope notes

- This completes the dashboard v2 surface migration across all top-level surfaces (Command, Connectors, Workspace, Monitoring, Lab, Code).