### PR TITLE
feat(shell-ir): parallel/async/visibility/approval level-up

### DIFF
--- a/lib/exec/command_gate/dune
+++ b/lib/exec/command_gate/dune
@@ -9,4 +9,4 @@
  (name masc_exec_command_gate)
  (public_name masc.masc_exec_command_gate)
  (wrapped true)
- (libraries masc_exec masc_exec_bash_parser))
+ (libraries masc_exec masc_exec_bash_parser logs))

--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -389,35 +389,6 @@ let parse_only_to_stages (parsed : SI.t PD.t) :
      | Nested_pipeline -> Error (`Too_complex Unsupported_nested_pipeline))
 ;;
 
-let gate_typed ~ir ~syntax_policy ~path_policy ~sandbox () : verdict =
-  (* Typed callers have already crossed their schema boundary, so this
-     entrypoint intentionally skips raw-string parsing while preserving
-     the same policy and verdict surface as [gate_raw]. *)
-  match parse_only_to_stages (PD.Parsed ir) with
-  | Error (`Cannot_parse reason) -> Cannot_parse { reason }
-  | Error (`Too_complex reason) -> Too_complex { reason }
-  | Ok stages -> apply_policy ~syntax_policy ~path_policy ~sandbox ~stages
-;;
-
-let gate_raw ~text ~syntax_policy ~path_policy ~sandbox () : verdict =
-  match Masc_exec_bash_parser.Bash.parse_string text with
-  | PD.Parsed ir -> gate_typed ~ir ~syntax_policy ~path_policy ~sandbox ()
-  | PD.Parse_error _ -> Cannot_parse { reason = Parse_error }
-  | PD.Parse_aborted reason -> Cannot_parse { reason = Parse_aborted reason }
-  | PD.Too_complex reason ->
-    Too_complex { reason = Unsupported_construct reason }
-;;
-
-let lower_typed_pipeline ~stages ~sandbox () : verdict =
-  match stages with
-  | [] -> Cannot_parse { reason = Parse_error }
-  | _ ->
-    let stages = stages_with_sandbox ~sandbox stages in
-    (match make_context ~stages with
-     | None -> Cannot_parse { reason = Parse_error }
-     | Some context -> Allow context)
-;;
-
 let verdict_tag = function
   | Allow _ -> "allow"
   | Reject _ -> "reject"
@@ -453,6 +424,74 @@ let too_complex_reason_tag = function
   | Unsupported_construct `Background -> "background"
   | Unsupported_construct `Redirect -> "redirect"
   | Unsupported_construct (`Unknown_construct _) -> "unknown_construct"
+;;
+
+let log_verdict ~source = function
+  | Allow _ -> ()
+  | Reject { context; reason; diagnostic } ->
+    Logs.warn (fun m ->
+      m
+        "Shell_command_gate.reject source=%s verdict=%s reason=%s diagnostic=%s stage_bins=%s"
+        source
+        (verdict_tag (Reject { context; reason; diagnostic }))
+        (reject_reason_tag reason)
+        diagnostic
+        (String.concat "," context.stage_bins))
+  | Cannot_parse { reason } ->
+    Logs.warn (fun m ->
+      m
+        "Shell_command_gate.cannot_parse source=%s verdict=%s reason=%s"
+        source
+        (verdict_tag (Cannot_parse { reason }))
+        (parse_reason_tag reason))
+  | Too_complex { reason } ->
+    Logs.warn (fun m ->
+      m
+        "Shell_command_gate.too_complex source=%s verdict=%s reason=%s"
+        source
+        (verdict_tag (Too_complex { reason }))
+        (too_complex_reason_tag reason))
+;;
+
+let gate_typed ~ir ~syntax_policy ~path_policy ~sandbox () : verdict =
+  (* Typed callers have already crossed their schema boundary, so this
+     entrypoint intentionally skips raw-string parsing while preserving
+     the same policy and verdict surface as [gate_raw]. *)
+  let verdict =
+    match parse_only_to_stages (PD.Parsed ir) with
+    | Error (`Cannot_parse reason) -> Cannot_parse { reason }
+    | Error (`Too_complex reason) -> Too_complex { reason }
+    | Ok stages -> apply_policy ~syntax_policy ~path_policy ~sandbox ~stages
+  in
+  log_verdict ~source:"typed" verdict;
+  verdict
+;;
+
+let gate_raw ~text ~syntax_policy ~path_policy ~sandbox () : verdict =
+  let verdict =
+    match Masc_exec_bash_parser.Bash.parse_string text with
+    | PD.Parsed ir -> gate_typed ~ir ~syntax_policy ~path_policy ~sandbox ()
+    | PD.Parse_error _ -> Cannot_parse { reason = Parse_error }
+    | PD.Parse_aborted reason -> Cannot_parse { reason = Parse_aborted reason }
+    | PD.Too_complex reason ->
+      Too_complex { reason = Unsupported_construct reason }
+  in
+  log_verdict ~source:"raw" verdict;
+  verdict
+;;
+
+let lower_typed_pipeline ~stages ~sandbox () : verdict =
+  let verdict =
+    match stages with
+    | [] -> Cannot_parse { reason = Parse_error }
+    | _ ->
+      let stages = stages_with_sandbox ~sandbox stages in
+      (match make_context ~stages with
+       | None -> Cannot_parse { reason = Parse_error }
+       | Some context -> Allow context)
+  in
+  log_verdict ~source:"typed_pipeline" verdict;
+  verdict
 ;;
 
 let stage_count context = List.length context.stage_bins

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -546,3 +546,66 @@ let dispatch_decided ?base_host_env ?on_output_chunk (envelope : Shell_ir_risk.d
    | Shell_ir_risk.R2_Irreversible ->
        ());
   dispatch ?base_host_env ?on_output_chunk envelope.Shell_ir_risk.ir
+
+(** Start a classified dispatch in a new fiber and return a promise for the
+    result. Cancellation propagates through the switch; other exceptions are
+    converted to a structured error result rather than leaving the promise
+    unresolved. *)
+let dispatch_async ?base_host_env ?on_output_chunk ~sw envelope =
+  let promise, resolver = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    let result =
+      try dispatch_decided ?base_host_env ?on_output_chunk envelope
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+        { status = Unix.WEXITED 1
+        ; stdout = ""
+        ; stderr = Printexc.to_string exn
+        }
+    in
+    Eio.Promise.resolve resolver result);
+  promise
+;;
+
+(** Extract a representative argv from an IR for semantic classification.
+    For pipelines we use the last stage, which is the command whose exit
+    status and output the caller usually cares about. *)
+let argv_of_ir (ir : Shell_ir.t) =
+  let simple_argv (s : Shell_ir.simple) =
+    Exec_program.to_string s.bin :: List.map resolve_arg s.args
+  in
+  match ir with
+  | Shell_ir.Simple s -> simple_argv s
+  | Pipeline stages ->
+    (match List.rev stages with
+     | [] -> []
+     | Shell_ir.Simple s :: _ -> simple_argv s
+     | Pipeline _ :: _ -> [])
+;;
+
+type dispatch_outcome = {
+  status : Unix.process_status;
+  stdout : string;
+  stderr : string;
+  semantic : Exec_semantic.t;
+}
+
+(** Like [dispatch_decided], but returns a structured outcome that includes
+    the post-execution semantic classification. *)
+let dispatch_decided_outcome ?base_host_env ?on_output_chunk envelope =
+  let result = dispatch_decided ?base_host_env ?on_output_chunk envelope in
+  let argv = argv_of_ir envelope.Shell_ir_risk.ir in
+  let semantic =
+    Exec_semantic.interpret
+      ~argv
+      ~status:result.status
+      ~stdout:result.stdout
+      ~stderr:result.stderr
+  in
+  { status = result.status
+  ; stdout = result.stdout
+  ; stderr = result.stderr
+  ; semantic
+  }
+;;

--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -40,6 +40,36 @@ val dispatch_decided :
 (** RFC-0160 S3: dispatch a risk-classified IR.  The phantom type
     ensures the IR has passed through [Shell_ir_risk.classify]. *)
 
+val dispatch_async :
+  ?base_host_env:string array ->
+  ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
+  sw:Eio.Switch.t ->
+  Shell_ir_risk.decided Shell_ir_risk.decided_ir ->
+  dispatch_result Eio.Promise.t
+(** Start a classified Shell IR dispatch in a new fiber and return a
+    promise for its result. Cancellation of [sw] propagates to the
+    forked fiber; successful completion resolves the promise with the
+    {!dispatch_result}. *)
+
+type dispatch_outcome = {
+  status : Unix.process_status;
+  stdout : string;
+  stderr : string;
+  semantic : Exec_semantic.t;
+}
+(** Structured dispatch result that carries a post-execution semantic
+    classification alongside raw status and captured output. *)
+
+val dispatch_decided_outcome :
+  ?base_host_env:string array ->
+  ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
+  Shell_ir_risk.decided Shell_ir_risk.decided_ir ->
+  dispatch_outcome
+(** Like {!dispatch_decided}, but returns a {!dispatch_outcome} with
+    [Exec_semantic.interpret] applied to the result. The semantic class
+    is derived from the executed command's argv, exit status, and
+    captured output. *)
+
 val dispatch_pipeline :
   ?base_host_env:string array ->
   ?stdin_content:string ->

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -433,6 +433,21 @@ let handle_tool_execute_typed
             error_json
               ~fields:(("blocked_cmd", `String cmd_for_log) :: typed_error_fields)
               e
+          | Error (Keeper_tool_execute_shell_ir.Approval_required { summary; bin }) ->
+            Log.Keeper.warn
+              "shell_ir approval_required keeper=%s cmd=%s bin=%s summary=%s"
+              meta.name
+              cmd_for_log
+              bin
+              summary;
+            typed_error_json summary
+          | Error (Keeper_tool_execute_shell_ir.Policy_denied { reason }) ->
+            Log.Keeper.warn
+              "shell_ir policy_denied keeper=%s cmd=%s reason=%s"
+              meta.name
+              cmd_for_log
+              reason;
+            typed_error_json reason
           | Ok result ->
             let elapsed_ms =
               (* NDT-OK: second wall-clock read closes the elapsed telemetry

--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -66,6 +66,8 @@ let try_handle
     | Error Cannot_parse -> error_json ~fields "Cannot parse command"
     | Error Too_complex -> error_json ~fields "Command too complex"
     | Error (Path_reject e) -> error_json ~fields:[ "blocked_cmd", `String cmd ] e
+    | Error (Approval_required { summary; _ }) -> error_json ~fields summary
+    | Error (Policy_denied { reason }) -> error_json ~fields reason
     | Ok result -> on_ok result
   in
   let sandbox_read_error ~target msg =

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -70,6 +70,8 @@ type dispatch_error =
   | Cannot_parse
   | Too_complex
   | Path_reject of string
+  | Approval_required of { summary : string; bin : string }
+  | Policy_denied of { reason : string }
 
 let validate_paths ?keeper_id ?base_path ~workdir ir =
   Exec_policy.validate_shell_ir_paths ?keeper_id ?base_path ~workdir ir
@@ -143,4 +145,65 @@ let dispatch
     ?base_host_env
     ?on_output_chunk
     (classify ir)
+;;
+
+(** Extract the last simple stage from an IR for per-command approval policy.
+    For a [Simple] IR it is the command itself; for a pipeline it is the
+    final stage, whose risk class and binary usually drive the approval
+    decision. *)
+let last_simple_of_ir ir =
+  match ir with
+  | Masc_exec.Shell_ir.Simple s -> Some s
+  | Masc_exec.Shell_ir.Pipeline stages ->
+    (match List.rev stages with
+     | Masc_exec.Shell_ir.Simple s :: _ -> Some s
+     | _ -> None)
+;;
+
+(** Same pipeline as [dispatch_classified], but inserts the capability-based
+    approval policy gate between the typed gate and path validation.
+    [Ask] and [Deny] are surfaced as typed errors so the keeper runtime
+    can log them and return a structured failure to the model. *)
+let dispatch_classified_with_approval
+      ?allow_pipes
+      ?redirect_allowed
+      ?keeper_id
+      ?base_path
+      ~workdir
+      ~sandbox
+      ?base_host_env
+      ?on_output_chunk
+      ~agent_id
+      ~approval_config
+      envelope
+  =
+  let ir = envelope.Masc_exec.Shell_ir_risk.ir in
+  match last_simple_of_ir ir with
+  | None -> Error Cannot_parse
+  | Some simple ->
+    let caps = Masc_exec.Capability_check.of_ir ir in
+    let overlay = Masc_exec.Approval_config.lookup approval_config ~actor:agent_id in
+    let raw_source = Format.asprintf "%a" Masc_exec.Shell_ir.pp ir in
+    let summary = "Shell IR command approval check" in
+    let policy_input = { Masc_exec.Approval_policy.raw_source; summary } in
+    (match Masc_exec.Approval_policy.decide policy_input ~overlay ~caps ~simple with
+     | Allow _trusted | Suggest_confirm (_trusted, _) ->
+       dispatch_classified
+         ?allow_pipes
+         ?redirect_allowed
+         ?keeper_id
+         ?base_path
+         ~workdir
+         ~sandbox
+         ?base_host_env
+         ?on_output_chunk
+         envelope
+     | Ask _request ->
+       Error
+         (Approval_required
+            { summary
+            ; bin = Masc_exec.Exec_program.to_string simple.Masc_exec.Shell_ir.bin
+            })
+     | Deny { reason = _; caps = _ } ->
+       Error (Policy_denied { reason = "approval policy denied" }))
 ;;

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
@@ -37,6 +37,8 @@ type dispatch_error =
   | Cannot_parse
   | Too_complex
   | Path_reject of string
+  | Approval_required of { summary : string; bin : string }
+  | Policy_denied of { reason : string }
 
 val validate_paths :
   ?keeper_id:string ->
@@ -71,6 +73,24 @@ val dispatch_classified :
     defaults to [true] for the historical tool execute path; legacy code-shell
     callers pass [false].  [?on_output_chunk] is forwarded to the host
     dispatch path for live output streaming. *)
+
+val dispatch_classified_with_approval :
+  ?allow_pipes:bool ->
+  ?redirect_allowed:bool ->
+  ?keeper_id:string ->
+  ?base_path:string ->
+  workdir:string ->
+  sandbox:Masc_exec.Sandbox_target.t ->
+  ?base_host_env:string array ->
+  ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
+  agent_id:Masc_exec.Agent_id.t ->
+  approval_config:Masc_exec.Approval_config.t ->
+  Masc_exec.Shell_ir_risk.decided Masc_exec.Shell_ir_risk.decided_ir ->
+  (Masc_exec.Exec_dispatch.dispatch_result, dispatch_error) result
+(** Same pipeline as {!dispatch_classified}, but inserts the capability-based
+    approval policy gate between the typed gate and path validation.
+    [Ask] produces [Approval_required]; [Deny] produces [Policy_denied].
+    [Allow] and [Suggest_confirm] proceed to dispatch with telemetry. *)
 
 val dispatch :
   ?allow_pipes:bool ->

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -249,6 +249,35 @@ let guarded_dispatch ~(token : Tool_token.t) ~args () : Tool_result.result optio
   result
 ;;
 
+(** Run multiple independent tool calls concurrently.
+
+    Each element of [calls] goes through {!guarded_dispatch}, preserving the
+    same telemetry/hook/observer lifecycle. Results are returned in input
+    order. A positive [max_concurrency] bounds parallel fan-out with an
+    [Eio.Semaphore]; otherwise concurrency is limited only by the parent
+    switch. *)
+let dispatch_many ?max_concurrency ~sw calls =
+  let _ = sw in
+  let sem =
+    match max_concurrency with
+    | Some n when n > 0 -> Some (Eio.Semaphore.make n)
+    | _ -> None
+  in
+  let run_one (token, args) =
+    let result =
+      match sem with
+      | None -> guarded_dispatch ~token ~args ()
+      | Some sem ->
+        Eio.Semaphore.acquire sem;
+        Eio_guard.protect
+          ~finally:(fun () -> Eio.Semaphore.release sem)
+          (fun () -> guarded_dispatch ~token ~args ())
+    in
+    (token, result)
+  in
+  Eio.Fiber.List.map run_one calls
+;;
+
 (** Number of registered tool names. *)
 let registered_count () = Hashtbl.length registry
 

--- a/lib/tool/tool_dispatch.mli
+++ b/lib/tool/tool_dispatch.mli
@@ -138,6 +138,19 @@ val guarded_dispatch
     fan-out. The dispatch return is typed [Tool_result.result option]; the old
     [dispatch]/[dispatch_structured] entry points are gone. *)
 
+val dispatch_many
+  :  ?max_concurrency:int
+  -> sw:Eio.Switch.t
+  -> (Tool_token.t * Yojson.Safe.t) list
+  -> (Tool_token.t * Tool_result.result option) list
+(** Run multiple independent tool calls concurrently.
+
+    Each call executes through {!guarded_dispatch} (pre-hooks, handler,
+    result transformer, observers) under the provided [sw]. The result list
+    preserves the input order. When [max_concurrency] is provided and
+    positive, a semaphore caps the number of calls running in parallel;
+    otherwise calls fan out with unbounded concurrency. *)
+
 (** {1 Introspection} *)
 
 (* RFC-0084 host-config-cleanup-J — [val v2_enabled] removed.


### PR DESCRIPTION
## Summary

Shell IR / Tools subsystem level-up: parallel dispatch, async dispatch, structured results, visibility, and intermediate approval gate.

## Completed

- **Phase 1 — Parallel multi-tool dispatch**: Added `Tool_dispatch.dispatch_many` with optional `max_concurrency` semaphore.
- **Phase 2 — Async Shell IR dispatch**: Added `Exec_dispatch.dispatch_async` returning `dispatch_result Eio.Promise.t`.
- **Phase 3 — Structured result envelope**: Added `Exec_dispatch.dispatch_outcome` carrying `Exec_semantic.t` classification.
- **Phase 4 — Visibility**: `Shell_command_gate` now emits `Logs.warn` on Reject/Cannot_parse/Too_complex verdicts.
- **Phase 5 — Intermediate approval gate**: Added `Keeper_tool_execute_shell_ir.dispatch_classified_with_approval` wiring `Approval_policy.decide`.

## Still TODO (in follow-up commits)

- [ ] B: Wire `dispatch_classified_with_approval` into actual keeper runtime with feature flag.
- [ ] C: Add unit tests for `dispatch_many`, `dispatch_async`, `dispatch_outcome`, and approval gate.
- [ ] D: Design/implement MCP async task model (`progress_token`, polling, SSE).

## Verification

- Local type checker passes for `lib/tool`, `lib/exec`, `lib/exec/command_gate`, `lib/keeper_tooling`, `lib/keeper`.
- `test/test_exec_shell_command_gate`: 19/19 pass.
- `test/test_keeper_guards`: 26/26 pass.
- `test/test_tool_dispatch`: 1 pre-existing failure on main (`masc_status -> Mod_state`), unrelated to this change.

## Local build notes

Used `MASC_SKIP_PIN_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1` because the shared opam switch and live Dune process are currently pinned to another worktree's state.