### PR TITLE
feat(dashboard): apply remaining v2 foundation markers and lock with tests

### DIFF
--- a/dashboard/src/components/cockpit/cockpit.test.ts
+++ b/dashboard/src/components/cockpit/cockpit.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import '@testing-library/jest-dom'
 
 import { route } from '../../router'
+import { COCKPIT_ENTRYPOINTS } from '../../cockpit-entrypoints'
 import { Cockpit } from './cockpit'
 
 vi.mock('../world-visualizer', () => ({
@@ -31,6 +32,12 @@ describe('Cockpit command map', () => {
     expect(document.querySelectorAll('[data-cockpit-plane]')).toHaveLength(5)
     expect(document.querySelector('[data-cockpit-plane="work"]')).toHaveTextContent('2 covered')
     expect(document.querySelector('[data-cockpit-plane="ide"]')).toHaveTextContent('Source')
+
+    expect(document.querySelector('.v2-cockpit-surface')).not.toBeNull()
+    expect(document.querySelector('.v2-cockpit-header')).not.toBeNull()
+    expect(document.querySelector('.v2-cockpit-disclosure')).not.toBeNull()
+    expect(document.querySelectorAll('.v2-cockpit-plane')).toHaveLength(5)
+    expect(document.querySelectorAll('.v2-cockpit-route')).toHaveLength(COCKPIT_ENTRYPOINTS.length)
   })
 
   it('renders progressive disclosure levels over the route map', () => {

--- a/dashboard/src/components/connector-config-form.test.ts
+++ b/dashboard/src/components/connector-config-form.test.ts
@@ -167,6 +167,7 @@ describe('ConnectorConfigForm', () => {
     expect(mockedPost).not.toHaveBeenCalled()
     const panel = container.querySelector('[data-in-process-config-panel]')
     expect(panel).toBeTruthy()
+    expect(container.querySelector('.v2-connector-config-form')).not.toBeNull()
     expect(panel?.textContent).toContain('server in-process')
     expect(panel?.textContent).toContain('DISCORD_BOT_TOKEN')
     expect(panel?.textContent).not.toContain('Save')

--- a/dashboard/src/components/connector-flow.test.ts
+++ b/dashboard/src/components/connector-flow.test.ts
@@ -132,6 +132,7 @@ describe('ConnectorFlowSection render', () => {
       html`<${ConnectorFlowSection} connector=${mkConnector()} gate=${mkGate()} />`,
       container,
     )
+    expect(container.querySelector('.v2-connector-flow')).not.toBeNull()
     const section = container.querySelector('[data-connector-flow="discord"]')!
     expect(section).toBeTruthy()
     expect(section.querySelector('[data-flow-stats]')?.textContent).toContain('12')

--- a/dashboard/src/components/connector-keeper-matrix.test.ts
+++ b/dashboard/src/components/connector-keeper-matrix.test.ts
@@ -117,6 +117,7 @@ describe('ConnectorKeeperMatrix', () => {
     const keepers = [mkKeeper('alpha'), mkKeeper('beta')]
     const matrix = deriveMatrix(connectors, keepers)
     render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
+    expect(container.querySelector('.v2-connector-keeper-matrix')).not.toBeNull()
     const cells = container.querySelectorAll('[data-matrix-cell]')
     // 2 keepers × 4 connectors = 8 cells
     expect(cells.length).toBe(8)

--- a/dashboard/src/components/connector-onboarding.test.ts
+++ b/dashboard/src/components/connector-onboarding.test.ts
@@ -26,6 +26,7 @@ describe('ConnectorOnboardingGrid', () => {
   it('renders one card per external sidecar in stable order (in-process omitted)', () => {
     render(html`<${ConnectorOnboardingGrid} />`, container)
 
+    expect(container.querySelector('.v2-connector-onboarding')).not.toBeNull()
     const text = container.textContent ?? ''
     // Discord is in-process (RFC-0203 §Phase 3) — no onboarding card.
     expect(text).not.toContain('Discord')

--- a/dashboard/src/components/connector-overview-skeleton.test.ts
+++ b/dashboard/src/components/connector-overview-skeleton.test.ts
@@ -37,6 +37,7 @@ describe('ConnectorOverviewSkeleton component', () => {
 
   it('renders exactly one tile per known connector', () => {
     render(html`<${ConnectorOverviewSkeleton} />`, container)
+    expect(container.querySelector('.v2-connector-overview-skeleton')).not.toBeNull()
     const tiles = container.querySelectorAll('[data-overview-skeleton-tile]')
     expect(tiles.length).toBe(KNOWN_CONNECTOR_IDS.length)
   })

--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -50,6 +50,7 @@ describe('ConnectorOverviewStrip', () => {
       html`<${ConnectorOverviewStrip} connectors=${[]} keeperCount=${0} />`,
       container,
     )
+    expect(container.querySelector('.v2-connector-overview-strip')).not.toBeNull()
     const tiles = container.querySelectorAll('[data-overview-tile]')
     expect(tiles.length).toBe(4)
     const ids = Array.from(tiles).map(t => t.getAttribute('data-overview-tile'))

--- a/dashboard/src/components/connector-paths-strip.test.ts
+++ b/dashboard/src/components/connector-paths-strip.test.ts
@@ -70,6 +70,7 @@ describe('ConnectorPathsStrip', () => {
   it('mounts the paths strip panel', () => {
     render(html`<${ConnectorPathsStrip} connectors=${[]} />`, container)
     expect(container.querySelector('[data-panel="connector-paths-strip"]')).not.toBeNull()
+    expect(container.querySelector('.v2-connector-paths-strip')).not.toBeNull()
   })
 
   it('is collapsed by default — body rows are absent until expanded', () => {

--- a/dashboard/src/components/connector-quick-bind.test.ts
+++ b/dashboard/src/components/connector-quick-bind.test.ts
@@ -34,6 +34,7 @@ describe('QuickBindForm', () => {
 
   it('renders a channel input + keeper select + Bind button', () => {
     render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a'), mkKeeper('kpr-b')]} />`, container)
+    expect(container.querySelector('.v2-connector-quick-bind')).not.toBeNull()
     const form = container.querySelector('[data-quick-bind="discord"]')!
     expect(form.querySelector('input[placeholder*="1234567890"]')).toBeTruthy()
     const options = form.querySelectorAll('select option')

--- a/dashboard/src/components/connector-readiness-rail.test.ts
+++ b/dashboard/src/components/connector-readiness-rail.test.ts
@@ -93,6 +93,7 @@ describe('ConnectorReadinessRail rendering', () => {
       noop,
     )
     render(html`<${ConnectorReadinessRail} pills=${pills} />`, container)
+    expect(container.querySelector('.v2-connector-readiness-rail')).not.toBeNull()
     const rendered = container.querySelectorAll('[data-rail-pill]')
     expect(rendered.length).toBe(4)
 

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, SideRail } from './dashboard-shell'
+import { DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, SideRail } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 import { dashboardLoading } from '../store'
@@ -889,5 +889,32 @@ describe('SideRail v2 chrome', () => {
     const links = container.querySelectorAll('.nav-link-collapsed')
     expect(links.length).toBeGreaterThan(0)
     expect(container.querySelector('.nav-link-collapsed.active')).not.toBeNull()
+  })
+})
+
+describe('DashboardHealthStrip v2 chrome', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response('{}'))),
+    )
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders with the v2-health-strip marker class', () => {
+    render(h(DashboardHealthStrip, {}), container)
+
+    const strip = container.querySelector('[data-testid="dashboard-health-strip"]')
+    expect(strip).not.toBeNull()
+    expect(strip?.classList.contains('v2-health-strip')).toBe(true)
   })
 })

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -235,6 +235,47 @@ describe('LogViewer Code links', () => {
   // throws LogsSchemaDriftError instead of silently dropping bad rows,
   // so there is no "parser dropped N rows" state to render here.
 
+  it('renders v2 surface marker classes for CSS scoping', async () => {
+    const fetchLogs = vi.fn().mockResolvedValue({
+      total: 1,
+      entries: [{
+        seq: 1,
+        ts: '2026-05-14T00:00:00Z',
+        level: 'INFO',
+        source: 'structured',
+        module: 'keeper_tool',
+        message: 'read file',
+        details: { file_path: 'lib/runtime.ml', line: 12 },
+      }],
+    })
+    const fetchProviderLogsCatalog = vi.fn().mockResolvedValue({
+      providers: [{
+        id: 'ollama',
+        display_name: 'Ollama Local',
+        protocol: 'ollama-http',
+        enabled: true,
+        path: '~/.ollama/logs/server.log',
+        resolved_path: '/Users/dancer/.ollama/logs/server.log',
+        default_lines: 200,
+        max_bytes: 1048576,
+      }],
+    })
+    const fetchProviderLogTail = vi.fn().mockResolvedValue({
+      provider: { id: 'ollama', display_name: 'Ollama Local', protocol: 'ollama-http' },
+      entries: [{ line: 1, text: 'tail line' }],
+    })
+    const { LogViewer } = await loadLogs(fetchLogs, { fetchProviderLogsCatalog, fetchProviderLogTail })
+    const { container } = render(h(LogViewer, {}))
+
+    await waitFor(() => expect(container.querySelector('.v2-logs-surface')).not.toBeNull())
+    expect(container.querySelector('.v2-logs-panel')).not.toBeNull()
+    expect(container.querySelector('.v2-logs-toolbar')).not.toBeNull()
+    expect(container.querySelector('.v2-logs-table-header')).not.toBeNull()
+    expect(container.querySelector('.v2-logs-row')).not.toBeNull()
+    expect(container.querySelector('.v2-logs-summary')).not.toBeNull()
+    expect(container.querySelector('.v2-logs-provider-panel')).not.toBeNull()
+  })
+
   it('does not render Code links for unsafe absolute log file paths', async () => {
     const fetchLogs = vi.fn().mockResolvedValue({
       total: 1,

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { h } from 'preact'
+import { cleanup, render } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
 import {
   computeFunnelCounts,
   formatTargetRatio,
@@ -10,6 +12,7 @@ import {
   deriveTaskAlerts,
   deriveFleetTickerEvents,
   type FunnelCounts,
+  Overview,
 } from './overview'
 
 // bar-seg ratio helper (mirrors FunnelCard inline logic)
@@ -498,5 +501,19 @@ describe('deriveTaskAlerts', () => {
   it('returns assignee in alert when present', () => {
     const tasks: Task[] = [makeTask({ id: 't1', status: 'awaiting_verification', updated_at: STALE_UPDATED, assignee: 'agent-x' })]
     expect(deriveTaskAlerts(tasks, NOW)[0]!.assignee).toBe('agent-x')
+  })
+})
+
+describe('Overview v2 marker classes', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('applies v2 surface and panel marker classes on render', () => {
+    const { container } = render(h(Overview, null))
+
+    expect(container.querySelector('.v2-overview-surface')).not.toBeNull()
+    expect(container.querySelector('.v2-overview-funnel')).not.toBeNull()
+    expect(container.querySelector('.v2-overview-keepers')).not.toBeNull()
   })
 })

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -448,7 +448,7 @@ export function progressPct(session: DashboardMissionSessionCard | null): number
 function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | null }) {
   if (!active) {
     return html`
-      <${SectionCard} label="Active mission" data-testid="overview-party-empty">
+      <${SectionCard} label="Active mission" class="v2-overview-party" data-testid="overview-party-empty">
         <p class="text-2xs text-[var(--color-fg-muted)] italic">No active mission</p>
       <//>
     `

--- a/dashboard/src/components/sidecar-log-viewer.test.ts
+++ b/dashboard/src/components/sidecar-log-viewer.test.ts
@@ -119,6 +119,13 @@ describe('SidecarLogViewer DOM', () => {
     await flushUi()
     await flushUi()
 
+    // v2 surface marker classes for CSS scoping
+    expect(container.querySelector('.v2-sidecar-log-toggle')).not.toBeNull()
+    expect(container.querySelector('.v2-sidecar-log-surface')).not.toBeNull()
+    expect(container.querySelector('.v2-sidecar-log-path')).not.toBeNull()
+    expect(container.querySelector('.v2-sidecar-log-pre')).not.toBeNull()
+    expect(container.querySelector('.v2-sidecar-log-level-pill')).not.toBeNull()
+
     // Before filter: match-count shows total
     const pre = container.querySelector('pre') as HTMLPreElement
     expect(pre.textContent).toContain('hb')

--- a/dashboard/src/components/sidecar-startup-watch.test.ts
+++ b/dashboard/src/components/sidecar-startup-watch.test.ts
@@ -87,6 +87,7 @@ describe('StartupCheckBanner rendering', () => {
       markStartAttempt('discord')
       vi.setSystemTime(t0 + 6_000) // 6s past grace (GRACE=5s)
       render(html`<${StartupCheckBanner} connectorId="discord" sidecarUp=${false} />`, container)
+      expect(container.querySelector('.v2-sidecar-startup-watch')).not.toBeNull()
       const elapsed = container.querySelector('[data-startup-warning-elapsed]')
       expect(elapsed).toBeTruthy()
       expect(elapsed!.getAttribute('data-startup-warning-elapsed')).toBe('6')


### PR DESCRIPTION
## Summary

Apply the remaining dashboard v2 foundation marker classes to the surfaces not covered by the phased migration (Connectors, Logs, Overview/Cockpit, Shell) and add tests to lock them in.

## Changes

### Connectors
- Audited all connector components; every expected v2-connector-* / v2-sidecar-startup-* marker was already present.
- Added surface-marker assertions to every connector test file.

### Logs
- Audited LogViewer and SidecarLogViewer; all expected v2-logs-* and v2-sidecar-log-* markers were already present.
- Added a dedicated test asserting the full set of log v2 markers, plus assertions in the sidecar log viewer test.

### Overview / Cockpit
- Added the missing v2-overview-party marker to the empty-state mission party SectionCard.
- Added surface/panel/route marker assertions to overview.test.ts and cockpit.test.ts.

### Shell
- Audited shell chrome (dashboard-shell, status-tray, dashboard-surface-tabs, app); all expected v2-shell-*, v2-status-tray, and v2-health-strip markers were already present.
- Added a test locking the v2-health-strip marker on DashboardHealthStrip.

## Verification

- pnpm typecheck (from dashboard/) — pass
- pnpm lint (from dashboard/) — pass
- Targeted vitest runs for all touched test files — 283 tests across 15 files passed
- pnpm build (from dashboard/) — pass

## Scope notes

- This completes the v2 foundation marker coverage for every top-level dashboard surface.
- No legacy styles were removed; only marker classes were added/appended.