### PR TITLE
perf(dashboard): isolate keepers signal out of keeper-detail render body

### DIFF
--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -1,5 +1,7 @@
 import { html } from 'htm/preact'
+import { memo } from 'preact/compat'
 import { useState, useRef, useEffect } from 'preact/hooks'
+import type { Keeper } from '../types'
 import { route } from '../router'
 import { keepers } from '../store'
 import { selectKeeper } from '../keeper-runtime'
@@ -58,8 +60,17 @@ export function KeeperDetailPage() {
       ? route.value.params.keeper?.trim()
       : ''
   if (!keeperName) return null
+  return html`<${KeeperDetailResolver} keeperName=${keeperName} />`
+}
 
-  // Resolve the active keeper. See [resolveKeeperForDetail] for semantics.
+// P0 render-perf: isolate the `keepers` signal subscription here. A heartbeat,
+// turn, or phase update on *any* keeper mutates the global `keepers` array and
+// would otherwise re-render the whole detail subtree (chat + rail + body,
+// ~1,400 LOC). keeper identity is reference-stable via `reconcileKeepers`, so
+// memoizing KeeperDetailContent below skips the heavy subtree whenever the
+// resolved keeper object did not change — which is every heartbeat that is
+// not this keeper's phase transition.
+function KeeperDetailResolver({ keeperName }: { keeperName: string }) {
   const keeper = resolveKeeperForDetail(
     keeperName,
     findKeeper(keeperName),
@@ -82,7 +93,10 @@ export function KeeperDetailPage() {
       </div>
     `
   }
+  return html`<${KeeperDetailContent} keeper=${keeper} />`
+}
 
+const KeeperDetailContent = memo(function KeeperDetailContent({ keeper }: { keeper: Keeper }) {
   const titleId = `keeper-detail-title-${keeper.name}`
   const effectiveStatus = keeperDisplayStatus(keeper)
   const shouldOpenDiagnostics = keeperNeedsDiagnosticAttention(keeper)
@@ -319,4 +333,4 @@ export function KeeperDetailPage() {
         />`
       : null}
   `
-}
+})


### PR DESCRIPTION
## Problem

The keeper detail page re-rendered its full subtree — chat + rail + body, ~1400 LOC — on **every** heartbeat/turn/phase update of **any** keeper, causing severe jank (the reported "mouse stutter" in keeper detail).

## Root cause

`KeeperDetailPage` read the global `keepers` signal directly in its render body:
- `findKeeper(name)` → `keepers.value.find(...)` (`lib/keeper-utils.ts`)
- `keepers.value.length` for the missing-state branch

Any keeper's heartbeat mutates the `keepers` array (`store.ts` reconcile path), so the entire heavy detail subtree re-executed on every push — regardless of whether *this* keeper changed.

## Fix

Split into three layers so the `keepers` subscription is isolated to a narrow component:

1. **`KeeperDetailPage`** — thin wrapper, reads `route` → `keeperName` only (route changes are legitimate and infrequent).
2. **`KeeperDetailResolver`** — the **only** `keepers` subscriber; resolves the keeper or renders the missing-state.
3. **`KeeperDetailContent`** — `memo`'d heavy subtree.

`keeper` identity is reference-stable via `reconcileKeepers` (`store.ts`: reuse the old object when `keeperRenderEqual`), so `KeeperDetailContent` skips on unrelated heartbeats and only re-renders on this keeper's actual phase transition.

## Verification

- `tsc --noEmit`: 0 errors
- `keeper-detail.test.ts` + `keeper-detail-page.test.ts`: 23/23 green
- `eslint src/components/keeper-detail-page.ts`: clean
- Rebased on latest `origin/main`, re-verified

## Out of scope (separate root causes, tracked separately)

- "Refresh while chatting breaks layout" — needs `data-detail` confirmation once the server is stable.
- 8935 repeated OOM — server-side keeper memory-OS / model-concurrency overload (RFC-0246 redesign).

Co-Authored-By: Claude <noreply@anthropic.com>
