### PR TITLE
fix(keeper): gate proactive preview on typed turn outcome (RFC-0232)

### DIFF
--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -56,6 +56,19 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
   in
   let has_substantive_tools = has_substantive_tool_calls tool_names in
   let has_text = String.trim result.response_text <> "" in
+  (* RFC-0232: a budget-exhausted turn substitutes a synthetic continuation
+     notice for the model reply (runtime_agent.ml MaxTurnsExceeded arm). That
+     text is display-only ("no consumer may sniff this string"); gate the
+     visible-output *preview* on the typed turn outcome rather than on the raw
+     string being non-empty, so the dashboard stops showing the canned
+     "Continuation checkpoint saved; ..." sentence as if it were work output.
+     Scope is deliberately narrow: only last_preview is gated here — has_text
+     still drives the visible/noop/autonomous counters unchanged. *)
+  let is_visible_reply =
+    Keeper_turn_outcome.equal
+      (Keeper_turn_outcome.of_stop_reason result.stop_reason)
+      Keeper_turn_outcome.Visible_reply
+  in
   let validated_evidence = visible_run_validation result in
   let has_validated_evidence = Option.is_some validated_evidence in
   let visible_tool_signal_present =
@@ -170,14 +183,16 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
         last_preview =
           (if not update_proactive_rt || not is_scheduled_autonomous_cycle
            then rt.proactive_rt.last_preview
-           else if has_text then short_preview result.response_text
-           else if has_substantive_tools then
-             Printf.sprintf "(tools: %s)" (String.concat ", " tool_names)
            else
-             (match validated_evidence with
-              | Some v -> validated_evidence_preview v
-              | None -> rt.proactive_rt.last_preview)
-          );
+             select_proactive_preview
+               ~previous:rt.proactive_rt.last_preview
+               ~has_text
+               ~is_visible_reply
+               ~has_substantive_tools
+               ~tool_names
+               ~response_text:result.response_text
+               ~validated_evidence_preview:
+                 (Option.map validated_evidence_preview validated_evidence));
         consecutive_noop_count =
           (if update_proactive_rt && is_scheduled_autonomous_cycle then
              if is_noop_cycle ~has_text ~tools_used:tool_names

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -367,6 +367,30 @@ let validated_evidence_preview
       Printf.sprintf "(validated evidence: %s)"
         (String.concat ", " names)
 
+(* RFC-0232: the scheduled-autonomous "what is this keeper doing" preview, by
+   precedence. [is_visible_reply] is the typed turn outcome
+   ([Keeper_turn_outcome.of_stop_reason]) — a budget-exhausted turn substitutes
+   a synthetic continuation notice for the reply text, which is display-only and
+   must not be sniffed as model output, so visible model text only wins when the
+   outcome is [Visible_reply]. Then substantive tool calls, then validated
+   evidence, else the prior preview is kept (never overwritten with a synthetic
+   filler). Pure so the precedence is unit-testable without a keeper_meta. *)
+let select_proactive_preview
+    ~(previous : string)
+    ~(has_text : bool)
+    ~(is_visible_reply : bool)
+    ~(has_substantive_tools : bool)
+    ~(tool_names : string list)
+    ~(response_text : string)
+    ~(validated_evidence_preview : string option)
+  : string =
+  if has_text && is_visible_reply then short_preview response_text
+  else if has_substantive_tools then
+    Printf.sprintf "(tools: %s)" (String.concat ", " tool_names)
+  else match validated_evidence_preview with
+    | Some preview -> preview
+    | None -> previous
+
 let accountability_evidence_refs
     ~(trace_id : string)
     ~(turn_number : int)

--- a/lib/keeper/keeper_unified_metrics_support.mli
+++ b/lib/keeper/keeper_unified_metrics_support.mli
@@ -109,3 +109,17 @@ val is_scheduled_autonomous_cycle_of_observation :
   Keeper_world_observation.world_observation -> bool
 
 val response_requests_confirmation : string -> bool
+
+val select_proactive_preview :
+  previous:string ->
+  has_text:bool ->
+  is_visible_reply:bool ->
+  has_substantive_tools:bool ->
+  tool_names:string list ->
+  response_text:string ->
+  validated_evidence_preview:string option ->
+  string
+(** RFC-0232 scheduled-autonomous work preview, by precedence: visible model
+    text (only when [is_visible_reply], so the synthetic continuation notice on
+    a budget-exhausted turn is not shown as output) -> substantive tool calls ->
+    validated evidence -> [previous]. Pure for unit testing. *)

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -3,6 +3,41 @@ open Alcotest
 module KAR = Masc.Keeper_agent_run
 module KTN = Keeper_tool_name
 module KTP = Masc.Keeper_tool_progress
+module KUS = Masc.Keeper_unified_metrics_support
+
+(* RFC-0232: a budget-exhausted (Continuation_checkpoint) turn substitutes a
+   synthetic continuation notice for the reply text. That text is display-only;
+   the work preview must gate visible model text on [is_visible_reply] so the
+   canned "Continuation checkpoint saved; ..." sentence never surfaces as
+   output. These pin the preview precedence. *)
+let test_preview_shows_visible_model_text () =
+  check string "visible reply -> model text wins" "real answer"
+    (KUS.select_proactive_preview ~previous:"old" ~has_text:true
+       ~is_visible_reply:true ~has_substantive_tools:false ~tool_names:[]
+       ~response_text:"real answer" ~validated_evidence_preview:None)
+
+let test_preview_drops_continuation_notice () =
+  (* has_text is true (the synthetic notice is non-empty) but the outcome is
+     not a visible reply -> the notice must NOT become the preview. With no
+     tools and no evidence, the prior preview is kept. *)
+  check string "checkpoint notice does not overwrite preview" "old"
+    (KUS.select_proactive_preview ~previous:"old" ~has_text:true
+       ~is_visible_reply:false ~has_substantive_tools:false ~tool_names:[]
+       ~response_text:"Continuation checkpoint saved; keeper remains scheduled."
+       ~validated_evidence_preview:None)
+
+let test_preview_falls_back_to_tools_then_evidence () =
+  check string "checkpoint with tools -> tool summary"
+    "(tools: keeper_task_claim)"
+    (KUS.select_proactive_preview ~previous:"old" ~has_text:true
+       ~is_visible_reply:false ~has_substantive_tools:true
+       ~tool_names:[ "keeper_task_claim" ]
+       ~response_text:"Continuation checkpoint saved; keeper remains scheduled."
+       ~validated_evidence_preview:None);
+  check string "no text, no tools -> validated evidence" "(validated evidence)"
+    (KUS.select_proactive_preview ~previous:"old" ~has_text:false
+       ~is_visible_reply:true ~has_substantive_tools:false ~tool_names:[]
+       ~response_text:"" ~validated_evidence_preview:(Some "(validated evidence)"))
 
 let test_claim_tool_classification_covers_supported_claim_tools () =
   check
@@ -170,6 +205,20 @@ let () =
             "material progress does not special-case worktree reuse text"
             `Quick
             test_material_progress_does_not_special_case_worktree_reuse_text
+        ] )
+    ; ( "preview_precedence"
+      , [ test_case
+            "visible reply shows model text"
+            `Quick
+            test_preview_shows_visible_model_text
+        ; test_case
+            "continuation notice does not overwrite preview"
+            `Quick
+            test_preview_drops_continuation_notice
+        ; test_case
+            "falls back to tools then validated evidence"
+            `Quick
+            test_preview_falls_back_to_tools_then_evidence
         ] )
     ]
 ;;


### PR DESCRIPTION
Closes #21333. Supersedes the UI-only surfacing in #21324 (그건 prose를 *표시*만 했고, 이게 prose 누수 자체를 막는 근본).

## 근본 (RFC-0232 conformance)
scheduled-autonomous "최근 작업" preview가 reply text를 **문자열 비-empty면 무조건** 채택했음. budget-exhausted 턴에서 `runtime_agent`가 합성 continuation notice("Continuation checkpoint saved; ...")를 reply text로 치환하는데(`runtime_agent.ml:705-709`, *"no consumer may sniff this string"*, RFC-0232 P2), `has_text`가 그걸 못 거름 → `last_preview` → `last_proactive_preview` → 대시보드 로스터.

라이브 fleet 실측(15 키퍼): 5/15가 동일 합성 보일러플레이트.

## Fix (plumbing 0)
`Keeper_agent_result`는 이미 `stop_reason`을 들고 있고, `Keeper_turn_outcome.of_stop_reason`이 이미 `Visible_reply | Continuation_checkpoint`로 분류(`test_keeper_turn_outcome`에서 단위 테스트됨). preview의 visible-text 분기를 **`is_visible_reply`로 게이트** → `Continuation_checkpoint` 턴은 tool 요약 → validated evidence → 이전 preview 유지로 폴백, 합성 filler 안 씀.

precedence를 pure 함수 `Keeper_unified_metrics_support.select_proactive_preview`로 추출 — 묻힌 휴리스틱이 아니라 명시적·testable. **scope 좁힘**: `last_preview`만 게이트, `has_text`는 visible/noop/autonomous 카운터에 그대로 → noop/cooldown 회귀 없음.

## 검증
- `DUNE_CACHE=disabled dune build --root .` **풀빌드 green** (.mli 변경 native link 포함)
- `test_keeper_unified_claim_progress` **9/9** — 신규 3: visible→model text / **continuation notice가 preview 안 덮음** / tools→evidence 폴백

## 범위 밖 (후속)
`keeper_tool_response.ml:16`의 "Completed without a textual reply. Tools used: ..." 제조(Completed 턴이라 stop_reason 게이트로 안 잡힘)는 별개 사이트 — #21333에 명시.