### PR TITLE
fix(keeper): stop synthesizing reply text for empty-body tool turns (RFC-0232)

### DIFF
--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -381,16 +381,15 @@ let apply_output_to_result ~(meta : keeper_meta)
   | Stay_silent, Silent when tool_names = [] ->
       ({ result with response_text = "" }, state)
   | _ ->
-      let response_text =
-        match
-          Keeper_tool_response.normalize_response_text
-            ~text:visible_response_body
-            ~tool_names ()
-        with
-        | Ok normalized -> normalized
-        | Error _ -> visible_response_body
-      in
-      ({ result with response_text }, state)
+      (* RFC-0232: carry the real reply text verbatim. Previously an empty body
+         with tool calls was replaced by the synthetic
+         "Completed without a textual reply. Tools used: ..." string, which
+         leaked into the dashboard work preview as if it were model output (no
+         consumer sniffs it). Keeping the body empty lets downstream surfaces
+         (select_proactive_preview) fall back to the typed tool summary. The
+         lane-persistence reply is rendered separately in keeper_agent_run and
+         is intentionally left non-empty (#20870 watermark-stall failure mode). *)
+      ({ result with response_text = visible_response_body }, state)
 
 let apply_to_result ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)


### PR DESCRIPTION
#21333의 두 번째(마지막) 사이트. #21337(stop_reason 게이트)이 못 잡는 `Completed` 턴 케이스.

## 근본
BDI social model의 default arm이 빈 reply body(툴은 돌았고 모델 텍스트 없음)를 `normalize_response_text`로 **"Completed without a textual reply. Tools used: ..." 합성**. 이게 `result.response_text` → `update_metrics_from_result` → 대시보드 work preview로 흘러, 툴-only 턴이 캔 문장을 작업 출력처럼 표시(라이브 fleet 1/15, mad-improver act=post_board).

`Completed` 턴이라 stop_reason은 `Visible_reply` → #21337 게이트로 안 잡힘.

## Fix
real reply body를 verbatim으로 전달. 빈 body는 "" 유지 → `select_proactive_preview`(#21337)가 typed `"(tools: ...)"` 요약으로 폴백. 합성 문자열은 **아무도 sniff 안 함**(grep 확인).

**scope**: social-model `result.response_text`(metrics/preview/display)만 변경. lane-persistence reply는 `keeper_agent_run.ml`에서 별도 렌더, **의도적으로 non-empty 유지** — 빈 reply를 persist하면 lane watermark stall → 키퍼 동일 메시지 재응답(RFC-0232 / #20870 bitten 실패 모드). 그래서 거긴 안 건드림.

## 검증
- `DUNE_CACHE=disabled dune build --root . lib/` green (.mli 무변경)
- `test_social_state_cap` 6/6, `test_keeper_unified_claim_progress` 9/9
- 다운스트림 폴백(빈 텍스트+툴 → "(tools: X)")은 #21337의 `select_proactive_preview` 단위 테스트가 이미 커버. apply_to_result 통합 테스트는 keeper_meta+run_result+BDI `_` arm 강제가 필요해 비례적으로 생략, 변경 자체는 fabrication 제거(pass-through).

이로써 #21333의 두 합성 사이트(runtime_agent continuation = #21337, bdi tool-only = 이 PR) 모두 닫힘.