### PR TITLE
feat(voice): allow public read for /api/v1/voice/audio/<token>

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -783,6 +783,10 @@ let is_public_read_path path =
   || String.starts_with ~prefix:"/api/v1/multimodal/list" path
   || String.starts_with ~prefix:"/api/v1/multimodal/get/" path
   || String.starts_with ~prefix:"/api/v1/multimodal/provenance/" path
+  (* Voice TTS audio clips: unguessable token filenames act as the
+     capability, and the browser <audio> element cannot send a bearer
+     token in its request headers. *)
+  || String.starts_with ~prefix:"/api/v1/voice/audio/" path
 
 let resolve_agent_name_for_auth ~base_path request ~token :
     (string option, Masc_domain.masc_error) result =


### PR DESCRIPTION
Browser `<audio>` elements cannot send `Authorization` headers, so TTS clips served by unguessable token filenames must be public-read.

- Adds `/api/v1/voice/audio/` to `is_public_read_path` whitelist in `lib/server/server_auth.ml`.
- Matches existing public-read pattern used for multimodal artifact endpoints.

Closes voice web playback auth blocker.