### PR TITLE
feat(dashboard): apply keeper-v2 foundation bridge — tokens, virtual-list, roster

### DIFF
--- a/dashboard/src/components/common/virtual-list.test.ts
+++ b/dashboard/src/components/common/virtual-list.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
@@ -127,5 +126,195 @@ describe('VirtualList', () => {
     )
     const child = container.querySelector('[data-vl-key]')
     expect(child).not.toBeNull()
+  })
+
+  it('applies content-visibility to fallback rows using fixed itemHeight', () => {
+    const container = document.createElement('div')
+    const few = items.slice(0, 5)
+    render(
+      h(VirtualList<Item>, {
+        items: few,
+        itemHeight: 40,
+        renderItem: (item) => h('div', { key: item.id }, item.name),
+        getKey: (item) => item.id,
+      }),
+      container,
+    )
+    const rows = container.querySelectorAll('.virtual-list-fallback-row')
+    expect(rows.length).toBe(5)
+    for (const row of rows) {
+      const style = (row as HTMLElement).style
+      expect(style.contentVisibility).toBe('auto')
+      expect(style.containIntrinsicSize).toBe('auto 40px')
+    }
+  })
+
+  it('applies content-visibility to fallback rows using estimatedItemHeight', () => {
+    const container = document.createElement('div')
+    const few = items.slice(0, 5)
+    render(
+      h(VirtualList<Item>, {
+        items: few,
+        estimatedItemHeight: 48,
+        renderItem: (item) => h('div', { key: item.id }, item.name),
+        getKey: (item) => item.id,
+      }),
+      container,
+    )
+    const row = container.querySelector('.virtual-list-fallback-row') as HTMLElement
+    expect(row.style.contentVisibility).toBe('auto')
+    expect(row.style.containIntrinsicSize).toBe('auto 48px')
+  })
+
+  it('calls onEndReached once when scrolled near the bottom in fixed-height mode', async () => {
+    const container = document.createElement('div')
+    const onEndReached = vi.fn()
+    render(
+      h(VirtualList<Item>, {
+        items,
+        itemHeight: 40,
+        renderItem: (item) => h('div', { key: item.id }, item.name),
+        getKey: (item) => item.id,
+        onEndReached,
+      }),
+      container,
+    )
+    const el = container.querySelector('.virtual-list-spacer')?.parentElement as HTMLElement
+    Object.defineProperty(el, 'scrollHeight', { value: 2000, configurable: true })
+    Object.defineProperty(el, 'clientHeight', { value: 300, configurable: true })
+    el.scrollTop = 1700
+    el.dispatchEvent(new Event('scroll'))
+    await new Promise((resolve) => { setTimeout(resolve, 30) })
+    expect(onEndReached).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onEndReached once when scrolled near the bottom in dynamic mode', async () => {
+    const container = document.createElement('div')
+    const onEndReached = vi.fn()
+    render(
+      h(VirtualList<Item>, {
+        items,
+        estimatedItemHeight: 40,
+        renderItem: (item) => h('div', { key: item.id }, item.name),
+        getKey: (item) => item.id,
+        onEndReached,
+      }),
+      container,
+    )
+    const el = container.querySelector('.virtual-list-spacer')?.parentElement as HTMLElement
+    Object.defineProperty(el, 'scrollHeight', { value: 2000, configurable: true })
+    Object.defineProperty(el, 'clientHeight', { value: 300, configurable: true })
+    el.scrollTop = 1550
+    el.dispatchEvent(new Event('scroll'))
+    await new Promise((resolve) => { setTimeout(resolve, 30) })
+    expect(onEndReached).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onEndReached when not near the bottom', async () => {
+    const container = document.createElement('div')
+    const onEndReached = vi.fn()
+    render(
+      h(VirtualList<Item>, {
+        items,
+        itemHeight: 40,
+        renderItem: (item) => h('div', { key: item.id }, item.name),
+        getKey: (item) => item.id,
+        onEndReached,
+      }),
+      container,
+    )
+    const el = container.querySelector('.virtual-list-spacer')?.parentElement as HTMLElement
+    Object.defineProperty(el, 'scrollHeight', { value: 2000, configurable: true })
+    Object.defineProperty(el, 'clientHeight', { value: 300, configurable: true })
+    el.scrollTop = 1000
+    el.dispatchEvent(new Event('scroll'))
+    await new Promise((resolve) => { setTimeout(resolve, 30) })
+    expect(onEndReached).not.toHaveBeenCalled()
+  })
+
+  it('resets onEndReached after scrolling away from bottom so it can fire again', async () => {
+    const container = document.createElement('div')
+    const onEndReached = vi.fn()
+    render(
+      h(VirtualList<Item>, {
+        items,
+        itemHeight: 40,
+        renderItem: (item) => h('div', { key: item.id }, item.name),
+        getKey: (item) => item.id,
+        onEndReached,
+      }),
+      container,
+    )
+    const el = container.querySelector('.virtual-list-spacer')?.parentElement as HTMLElement
+    Object.defineProperty(el, 'scrollHeight', { value: 2000, configurable: true })
+    Object.defineProperty(el, 'clientHeight', { value: 300, configurable: true })
+
+    el.scrollTop = 1700
+    el.dispatchEvent(new Event('scroll'))
+    await new Promise((resolve) => { setTimeout(resolve, 30) })
+    expect(onEndReached).toHaveBeenCalledTimes(1)
+
+    el.scrollTop = 1000
+    el.dispatchEvent(new Event('scroll'))
+    await new Promise((resolve) => { setTimeout(resolve, 30) })
+
+    el.scrollTop = 1700
+    el.dispatchEvent(new Event('scroll'))
+    await new Promise((resolve) => { setTimeout(resolve, 30) })
+    expect(onEndReached).toHaveBeenCalledTimes(2)
+  })
+
+  it('updates measured heights via ResizeObserver in dynamic mode', async () => {
+    const OriginalResizeObserver = global.ResizeObserver
+    const callbacks: Array<(entries: ResizeObserverEntry[]) => void> = []
+    const observed = new Set<Element>()
+    global.ResizeObserver = class MockResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        callbacks.push(callback as (entries: ResizeObserverEntry[]) => void)
+      }
+
+      observe(target: Element) {
+        observed.add(target)
+      }
+
+      disconnect() {
+        observed.clear()
+      }
+    } as unknown as typeof ResizeObserver
+
+    const container = document.createElement('div')
+    render(
+      h(VirtualList<Item>, {
+        items,
+        estimatedItemHeight: 40,
+        renderItem: (item) => h('div', { key: item.id }, item.name),
+        getKey: (item) => item.id,
+      }),
+      container,
+    )
+
+    await new Promise((resolve) => { setTimeout(resolve, 30) })
+
+    const child = container.querySelector('[data-vl-key]') as HTMLElement
+    expect(child).not.toBeNull()
+    expect(observed.has(child)).toBe(true)
+    expect(callbacks.length).toBeGreaterThan(0)
+
+    const mockEntry = {
+      target: child,
+      borderBoxSize: [{ blockSize: 88 }],
+      contentRect: { height: 88 },
+    } as unknown as ResizeObserverEntry
+    for (const cb of callbacks) {
+      cb([mockEntry])
+    }
+
+    const spacer = container.querySelector('.virtual-list-spacer') as HTMLElement
+    await vi.waitFor(() => {
+      const height = parseInt(spacer.style.height, 10)
+      return height > 2000
+    }, { timeout: 1000 })
+
+    global.ResizeObserver = OriginalResizeObserver
   })
 })

--- a/dashboard/src/components/common/virtual-list.ts
+++ b/dashboard/src/components/common/virtual-list.ts
@@ -22,6 +22,7 @@ interface VirtualListProps<T> {
   renderItem: (item: T, index: number) => ComponentChildren
   getKey: (item: T) => string
   className?: string
+  onEndReached?: () => void
 }
 
 interface VisibleRange {
@@ -44,6 +45,19 @@ function binarySearchOffset(offsets: number[], target: number): number {
   return lo
 }
 
+function readRowHeight(entry: ResizeObserverEntry): number {
+  const blockSize = entry.borderBoxSize?.[0]?.blockSize
+  if (typeof blockSize === 'number' && blockSize > 0) {
+    return Math.round(blockSize)
+  }
+  const contentHeight = entry.contentRect?.height
+  if (typeof contentHeight === 'number' && contentHeight > 0) {
+    return Math.round(contentHeight)
+  }
+  const target = entry.target as HTMLElement
+  return Math.round(target.getBoundingClientRect().height)
+}
+
 export function VirtualList<T>({
   items,
   itemHeight,
@@ -52,16 +66,24 @@ export function VirtualList<T>({
   renderItem,
   getKey,
   className = '',
+  onEndReached,
 }: VirtualListProps<T>) {
   // Hooks must be called unconditionally (Rules of Hooks)
   const containerRef = useRef<HTMLDivElement>(null)
   const heightsRef = useRef<Map<string, number>>(new Map())
+  const endReachedCalledRef = useRef(false)
   const [range, setRange] = useState<VisibleRange>({ start: 0, end: 30 })
   const [measureTick, setMeasureTick] = useState(0)
   const [effectiveOverscan, setEffectiveOverscan] = useState(overscan)
   const virtualize = items.length > ACTIVATION_THRESHOLD
 
   const dynamicMode = itemHeight === undefined
+
+  // Allow onEndReached to fire again after the dataset grows (typical infinite
+  // scroll pattern: new items load while the user remains near the bottom).
+  useEffect(() => {
+    endReachedCalledRef.current = false
+  }, [items.length])
 
   // PR-4.9: FPS adaptive quality — shrink overscan when frame rate drops.
   useEffect(() => {
@@ -72,6 +94,21 @@ export function VirtualList<T>({
       else setEffectiveOverscan(overscan)
     })
   }, [virtualize, overscan])
+
+  // Discard cached heights for items that are no longer present so the map
+  // does not grow unbounded across reordering / filtering.
+  useEffect(() => {
+    if (items.length === 0) {
+      heightsRef.current.clear()
+      return
+    }
+    const validKeys = new Set(items.map(getKey))
+    for (const key of heightsRef.current.keys()) {
+      if (!validKeys.has(key)) {
+        heightsRef.current.delete(key)
+      }
+    }
+  }, [items, getKey])
 
   const offsets = useMemo(() => {
     if (!dynamicMode) return [] as number[]
@@ -92,6 +129,7 @@ export function VirtualList<T>({
     if (!el) return
 
     let disposed = false
+    const endThreshold = dynamicMode ? estimatedItemHeight * 5 : itemHeight! * 4
 
     const recompute = () => {
       const os = effectiveOverscan
@@ -120,12 +158,27 @@ export function VirtualList<T>({
       }
     }
 
+    const checkEndReached = () => {
+      if (!onEndReached || disposed) return
+      const remaining = el.scrollHeight - el.scrollTop - el.clientHeight
+      const nearBottom = remaining < endThreshold
+      if (nearBottom && !endReachedCalledRef.current) {
+        endReachedCalledRef.current = true
+        onEndReached()
+      } else if (!nearBottom) {
+        endReachedCalledRef.current = false
+      }
+    }
+
     let ticking = false
     const onScroll = () => {
       if (ticking || disposed) return
       ticking = true
       requestAnimationFrame(() => {
-        if (!disposed) recompute()
+        if (!disposed) {
+          recompute()
+          checkEndReached()
+        }
         ticking = false
       })
     }
@@ -135,6 +188,7 @@ export function VirtualList<T>({
     })
 
     recompute()
+    checkEndReached()
     el.addEventListener('scroll', onScroll, { passive: true })
     ro.observe(el)
 
@@ -143,7 +197,7 @@ export function VirtualList<T>({
       el.removeEventListener('scroll', onScroll)
       ro.disconnect()
     }
-  }, [virtualize, items.length, itemHeight, effectiveOverscan, dynamicMode, offsets])
+  }, [virtualize, items.length, itemHeight, effectiveOverscan, dynamicMode, offsets, estimatedItemHeight, onEndReached])
 
   // Observe child heights in dynamic mode
   useEffect(() => {
@@ -155,12 +209,11 @@ export function VirtualList<T>({
     const ro = new ResizeObserver((entries) => {
       let changed = false
       for (const entry of entries) {
-        const target = entry.target as HTMLElement
-        const key = target.dataset.vlKey
+        const key = (entry.target as HTMLElement).dataset.vlKey
         if (!key) continue
-        const h = entry.borderBoxSize?.[0]?.blockSize ?? target.getBoundingClientRect().height
+        const h = readRowHeight(entry)
         const prev = heightsRef.current.get(key)
-        if (prev !== h) {
+        if (prev !== h && h > 0) {
           heightsRef.current.set(key, h)
           changed = true
         }
@@ -183,11 +236,25 @@ export function VirtualList<T>({
     }
   }, [virtualize, dynamicMode, range.start, range.end])
 
-  // Below threshold: render all items directly, no virtualization
+  // Below threshold: render all items directly, no virtualization. Apply
+  // content-visibility to each row so the browser can skip layout/paint for
+  // off-screen rows while keeping them in the DOM (Ctrl-F / a11y friendly).
   if (!virtualize) {
+    const fallbackRowHeight = itemHeight ?? estimatedItemHeight
     return html`
       <div class=${className}>
-        ${items.map((item, i) => renderItem(item, i))}
+        ${items.map((item, i) => html`
+          <div
+            key=${getKey(item)}
+            class="virtual-list-fallback-row"
+            style=${{
+              contentVisibility: 'auto',
+              containIntrinsicSize: `auto ${fallbackRowHeight}px`,
+            }}
+          >
+            ${renderItem(item, i)}
+          </div>
+        `)}
       </div>
     `
   }

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -127,4 +127,22 @@ describe('KeeperWorkspaceRoster', () => {
     expect(work?.textContent).toBe('최근 작업 요약 없음')
     expect(work?.getAttribute('title')).toBe('')
   })
+
+  it('uses content-visibility:auto on plain-list rows below the virtualization threshold', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    expect(host.querySelector('.virtual-list-spacer')).toBeNull()
+    const rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows.every(r => r.style.contentVisibility === 'auto')).toBe(true)
+  })
+
+  it('switches to VirtualList once the flattened roster exceeds the threshold', () => {
+    // 60 rows plus 1 group header = 61 items, which is over WINDOW_AT (60).
+    keepers.value = Array.from({ length: 60 }, (_, i) =>
+      mk({ name: `keeper-${i}`, status: 'running', lifecycle_phase: 'Running' }),
+    )
+    render(html`<${KeeperWorkspaceRoster} activeName="keeper-0" />`, host)
+    expect(host.querySelector('.virtual-list-spacer')).not.toBeNull()
+    expect(host.querySelector('.kw-roster-list')).not.toBeNull()
+  })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -12,6 +12,7 @@ import { navigate } from '../../router'
 import { selectKeeper } from '../../keeper-runtime'
 import { keeperActivityDisplay, keeperWorkPreview } from '../../lib/keeper-runtime-display'
 import type { Keeper } from '../../types'
+import { VirtualList } from '../common/virtual-list'
 import {
   WorkspaceSigil,
   StatusDot,
@@ -28,6 +29,16 @@ const GROUP_ORDER: { bucket: KeeperBucket; label: string }[] = [
   { bucket: 'paused', label: '대기 · 일시정지' },
   { bucket: 'offline', label: '중지 · 종료됨' },
 ]
+
+/** Flattened roster item used by the virtualized render path. */
+type RosterItem =
+  | { type: 'header'; bucket: KeeperBucket; label: string }
+  | { type: 'row'; keeper: Keeper }
+
+/** Switch to the shared VirtualList once the roster is long enough that DOM
+ *  weight matters. Below this we keep the identical grouped DOM structure and
+ *  rely on content-visibility:auto for cheap off-screen skipping. */
+const WINDOW_AT = 60
 
 /** Blocked tasks + explicit attention flag → the roster attention badge. */
 function attentionCount(keeper: Keeper): number {
@@ -49,7 +60,17 @@ function matchesQuery(keeper: Keeper, q: string): boolean {
   return hay.includes(q.toLowerCase())
 }
 
-function RosterRow({ keeper, active, onSelect }: { keeper: Keeper; active: boolean; onSelect: (name: string) => void }) {
+function RosterRow({
+  keeper,
+  active,
+  onSelect,
+  style,
+}: {
+  keeper: Keeper
+  active: boolean
+  onSelect: (name: string) => void
+  style?: string
+}) {
   const bucket = keeperBucket(keeper)
   const tone = keeperStatusTone(keeper)
   const att = attentionCount(keeper)
@@ -60,6 +81,7 @@ function RosterRow({ keeper, active, onSelect }: { keeper: Keeper; active: boole
     <button
       type="button"
       class="kw-kp-row"
+      style=${style}
       aria-current=${active ? 'true' : 'false'}
       onClick=${() => onSelect(keeper.name)}
     >
@@ -115,6 +137,31 @@ export function KeeperWorkspaceRoster({
     { id: 'att', label: '주의' },
   ]
 
+  // Flatten groups → [{ type: 'header'|'row', ... }] for windowing.
+  const items: RosterItem[] = []
+  for (const group of GROUP_ORDER) {
+    const rows = visible.filter(k => keeperBucket(k) === group.bucket)
+    if (rows.length === 0) continue
+    items.push({ type: 'header', bucket: group.bucket, label: group.label })
+    for (const keeper of rows) {
+      items.push({ type: 'row', keeper })
+    }
+  }
+
+  const useVirtual = items.length > WINDOW_AT
+  const rowStyle = 'content-visibility:auto;contain-intrinsic-size:auto 58px'
+
+  function renderItem(item: RosterItem): VNode {
+    if (item.type === 'header') {
+      return html`<div class="kw-roster-group">${item.label}</div>`
+    }
+    return html`<${RosterRow} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} />`
+  }
+
+  function getKey(item: RosterItem): string {
+    return item.type === 'header' ? `h:${item.bucket}` : item.keeper.name
+  }
+
   return html`
     <aside class="kw-roster" aria-label="키퍼 로스터">
       <div class="kw-roster-head">
@@ -139,19 +186,28 @@ export function KeeperWorkspaceRoster({
           </button>
         `)}
       </div>
-      <div class="kw-roster-list">
-        ${GROUP_ORDER.map(group => {
-          const rows = visible.filter(k => keeperBucket(k) === group.bucket)
-          if (rows.length === 0) return null
-          return html`
-            <div>
-              <div class="kw-roster-group">${group.label}</div>
-              ${rows.map(k => html`<${RosterRow} key=${k.name} keeper=${k} active=${k.name === activeName} onSelect=${select} />`)}
-            </div>
-          `
-        })}
-        ${visible.length === 0 ? html`<div class="kw-roster-empty">일치하는 키퍼가 없습니다</div>` : null}
-      </div>
+      ${visible.length === 0
+        ? html`<div class="kw-roster-list"><div class="kw-roster-empty">일치하는 키퍼가 없습니다</div></div>`
+        : useVirtual
+          ? html`<${VirtualList}
+              items=${items}
+              estimatedItemHeight=${58}
+              className="kw-roster-list"
+              renderItem=${renderItem}
+              getKey=${getKey}
+            />`
+          : html`<div class="kw-roster-list">
+              ${GROUP_ORDER.map(group => {
+                const rows = visible.filter(k => keeperBucket(k) === group.bucket)
+                if (rows.length === 0) return null
+                return html`
+                  <div>
+                    <div class="kw-roster-group">${group.label}</div>
+                    ${rows.map(k => html`<${RosterRow} key=${k.name} keeper=${k} active=${k.name === activeName} onSelect=${select} style=${rowStyle} />`)}
+                  </div>
+                `
+              })}
+            </div>`}
     </aside>
   `
 }

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -481,4 +481,35 @@
   --space-6: 32px;
   --space-7: 48px;
   --space-8: 64px;
+
+  /* Keeper v2 token bridge — aliases for importing v2 stylesheets.
+     Maps the v2 surface vocabulary to the existing dashboard semantic
+     token ladder. Tokens that already exist in tokens.generated.css /
+     tokens.css (e.g. --font-*, --shadow-card, --radius-pill) are
+     intentionally not duplicated. */
+  --bg-deep: var(--bg-root);
+  --bg-panel-alt: var(--color-bg-panel-alt);
+  --bg-card: var(--color-bg-elevated);
+  --bg-card-hover: var(--color-bg-hover);
+  --bg-sunken: var(--bg-deepest);
+  --border-main: var(--border-base);
+  --border-soft: var(--border-subtle);
+  --text-bright: var(--text-strong);
+  --text-primary: var(--text-body);
+  --text-mid: var(--text-muted);
+  --volt: var(--accent);
+  --volt-strong: var(--color-accent-fg);
+  --volt-dim: var(--color-accent-fg-dim);
+  --volt-wash: var(--accent-10);
+  --volt-glow: rgb(var(--brass-glow) / .22);
+  --volt-ink: var(--bg-root);
+  --status-ok: var(--ok);
+  --status-warn: var(--warn);
+  --status-bad: var(--bad);
+  --status-idle: var(--idle);
+  --status-busy: var(--info);
+  --sp-9: var(--space-5);
+  --sp-10: var(--space-6);
+  --radius-2xs: var(--radius-xs);
+  --shadow-pop: var(--shadow-cmd-palette);
 }


### PR DESCRIPTION
## Summary
Ports the first batch of keeper-v2 foundations into the MASC dashboard:

1. **Token bridge** — adds keeper-v2 CSS custom-property aliases (`--bg-deep`, `--bg-panel`, `--text-*`, `--volt-*`, `--sp-*`, `--radius-*`, `--shadow-*`, status colors, etc.) to `variables.css`, mapped to the existing dashboard semantic token ladder. This lets future PRs drop in v2 stylesheets without token-not-found errors.
2. **VirtualList improvements** — adds `onEndReached`, `content-visibility:auto` fallback rows below the virtualization threshold, dynamic-height cache pruning, and safer row-height measurement.
3. **Keeper roster virtualization** — applies the `keeper-v2/rails.jsx` pattern: use `VirtualList` when the flattened roster exceeds 60 items, otherwise render a plain grouped list with `content-visibility:auto`.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Targeted vitest run (`virtual-list`, `virtual-list.a11y`, `keeper-workspace-roster`) ✅
- `pnpm tokens:check` ✅

## Follow-up work
This is the first in a series of PRs to apply the keeper-v2 package. Next candidates:
- Copilot dock (`dock.jsx` / `dock.css`)
- Settings surface (`settings.jsx`)
- Turn inspector styling (`turn-inspector.jsx` / `inspector.css`)
- Memory graph / goal dossier (`organisms-4.jsx` / `memory.css`)
- v2 surface finish (`craft.css` density/motion/bubble variants)

## Notes
- No component behavior was intentionally changed beyond the roster virtualization path.
- The full `pnpm test` suite is left to CI because the serial Preact+Solid run exceeds local foreground timeouts.
