### PR TITLE
refactor(keeper): immutable turn state for lifecycle, event bus, and runtime budget

### DIFF
--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -171,15 +171,15 @@ let post_empty_queue_sleep ~(any_pending : bool) ~(channel : string) =
 
 (* TurnComplete (KeeperTaskAcquisition.tla, Cycle 45 follow-up to
    PR #11716): the [run_keeper_cycle] body has produced an [Ok meta]
-   for this cycle. The post-action invariant pins that the
-   [cycle_completed] ref was actually toggled before the result is
-   returned -- catches a regression where a future refactor splits
-   the bottom of [run_keeper_cycle] into branches that forget to
-   record completion. The ref is single-fiber by construction: each
-   [run_keeper_cycle] invocation runs in its own fiber, and the ref
+   for this cycle. The post-action invariant pins that
+   [cycle_completed] is true before the result is returned -- catches
+   a regression where a future refactor splits the bottom of
+   [run_keeper_cycle] into branches that forget to record completion.
+   The immutable [turn_state] is single-fiber by construction: each
+   [run_keeper_cycle] invocation runs in its own fiber, and the state
    is allocated fresh inside the function. *)
-let post_turn_complete_task ~(cycle_completed : bool ref) = ignore cycle_completed
-[@@fsm_guard "!cycle_completed = true"]
+let post_turn_complete_task ~(cycle_completed : bool) = ignore cycle_completed
+[@@fsm_guard "cycle_completed = true"]
 ;;
 
 let pre_dispatch_tool_surface : Keeper_execution_receipt.tool_surface =

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -57,7 +57,7 @@ val post_assign_task : any_pending:bool -> channel:string -> unit
 val post_empty_queue_sleep : any_pending:bool -> channel:string -> unit
 (** FSM guard post-action for [EmptyQueueSleep]. *)
 
-val post_turn_complete_task : cycle_completed:bool ref -> unit
+val post_turn_complete_task : cycle_completed:bool -> unit
 (** FSM guard post-action for [TurnComplete]. *)
 
 val pre_dispatch_tool_surface : Keeper_execution_receipt.tool_surface

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -10,6 +10,7 @@ open Keeper_meta_store
 open Keeper_types_profile
 open Keeper_context_runtime
 module EC = Keeper_error_classify
+module StringMap = Set_util.StringMap
 
 type runtime_execution = {
   runtime_id : string;
@@ -526,9 +527,9 @@ let make_post_turn_resilience_executor
 let post_turn_resilience_handles
     ~(config : Workspace.config)
     ~(meta : keeper_meta) : post_turn_resilience_handles =
-  let paused_meta = ref None in
+  let paused_meta = Atomic.make None in
   let sync_lifecycle_meta lifecycle =
-    match !paused_meta with
+    match Atomic.get paused_meta with
     | None -> lifecycle
     | Some paused ->
         { lifecycle with
@@ -571,7 +572,7 @@ let post_turn_resilience_handles
     | Ok audit_store ->
         let executor =
           make_post_turn_resilience_executor ~config ~meta
-            ~on_paused:(fun meta -> paused_meta := Some meta)
+            ~on_paused:(fun meta -> Atomic.set paused_meta (Some meta))
         in
         {
           resilience_audit_store = Some audit_store;
@@ -644,26 +645,40 @@ let enqueue_partial_commit_continue_gate
    per (keeper_name, primary_budget, runtime_budget) because runtime config
    is static at startup.  Logging per turn produces 15-20 duplicates per
    keeper per minute under load. Track the same tuple we've already
-   announced and skip subsequent identical log lines. Keeper turns run on
-   concurrent Eio fibers, so the Hashtbl is protected by an [Eio.Mutex.t]. *)
-let runtime_budget_logged : (string * int * int, unit) Hashtbl.t =
-  Hashtbl.create 16
+   announced and skip subsequent identical log lines. The cache is an
+   immutable [StringMap] under an [Atomic.t] so concurrent turns can update
+   it without an Eio mutex. *)
+let runtime_budget_logged : unit StringMap.t Atomic.t =
+  Atomic.make StringMap.empty
 
-let runtime_budget_logged_mu = Eio.Mutex.create ()
+let runtime_budget_log_key ~keeper_name ~primary_budget ~runtime_budget =
+  Printf.sprintf "%s|%d|%d" keeper_name primary_budget runtime_budget
 
 let resolved_max_context_for_turn ~(meta : keeper_meta) : int =
   let resolution =
     Keeper_context_runtime.resolve_max_context_resolution_of_meta meta
   in
   if resolution.primary_budget < resolution.runtime_budget then begin
-    let key = (meta.name, resolution.primary_budget, resolution.runtime_budget) in
-    Eio.Mutex.use_rw ~protect:true runtime_budget_logged_mu (fun () ->
-      if not (Hashtbl.mem runtime_budget_logged key) then begin
-        Hashtbl.add runtime_budget_logged key ();
-        Log.Keeper.info
-          "%s: mixed runtime context budget primary=%d runtime_max=%d; using primary for initial turn budget"
-          meta.name resolution.primary_budget resolution.runtime_budget
-      end)
+    let key =
+      runtime_budget_log_key
+        ~keeper_name:meta.name
+        ~primary_budget:resolution.primary_budget
+        ~runtime_budget:resolution.runtime_budget
+    in
+    let rec log_once () =
+      let old = Atomic.get runtime_budget_logged in
+      if StringMap.mem key old
+      then ()
+      else
+        let new_map = StringMap.add key () old in
+        if Atomic.compare_and_set runtime_budget_logged old new_map
+        then
+          Log.Keeper.info
+            "%s: mixed runtime context budget primary=%d runtime_max=%d; using primary for initial turn budget"
+            meta.name resolution.primary_budget resolution.runtime_budget
+        else log_once ()
+    in
+    log_once ()
   end;
    (match resolution.requested_override with
     | Some requested ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -37,10 +37,9 @@ let run_keeper_cycle
      EmptyQueueSleep=scheduled_autonomous else, TurnComplete=run_turn body,
      TaskRejected=NoTaskOrphan invariant (every claim reaches Ok/Error). *)
   (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete bracket — the
-     ref is set to true on the [Ok updated_meta] return at the end of
-     this function; an [Error _] branch leaves it false and skips the
-     wrap, mirroring the spec's "completed-on-success" semantics. *)
-  let cycle_completed = ref false in
+     cycle_completed flag is set to true on the [Ok updated_meta] return at
+     the end of this function; an [Error _] branch leaves it false and
+     skips the wrap, mirroring the spec's "completed-on-success" semantics. *)
   (* 0. Phase gate + state-aware runtime routing.
      The gate owns turn executability; select_runtime remains a total helper
      so dashboards/tests can inspect the same routing contract for blocked
@@ -62,54 +61,73 @@ let run_keeper_cycle
     }
   in
   let turn_start = Mtime_clock.now () in
-  let seq_ref = ref 0 in
-  let append_manifest ?status ?decision ?runtime_id ?clock_refs ~site event =
-    let decision =
+  let initial_turn_state : Keeper_unified_turn_types.turn_state =
+    { cycle_completed = false
+    ; manifest_seq = 0
+    ; post_commit_failure_reason = None
+    ; paused_meta_override = None
+    ; current_turn_blocker_info = None
+    ; last_execution = None
+    ; last_provider_timeout_budget = None
+    ; degraded_retry_info = None
+    ; runtime_rotation_attempts = []
+    ; failure_reason = None
+    ; retry_phase_started_at = None
+    }
+  in
+  let append_manifest (turn_state : Keeper_unified_turn_execution.turn_state)
+        ?status ?decision ?runtime_id ?clock_refs ~site event =
+    let decision, manifest_seq =
       let decision =
         match decision with
         | Some value -> value
         | None -> `Assoc []
       in
-      let clock_refs =
-        match clock_refs with
-        | Some value -> value
-        | None ->
-          seq_ref := !seq_ref + 1;
-          let elapsed_ms =
-            let ns =
-              Mtime.Span.to_uint64_ns
-                (Mtime.span turn_start (Mtime_clock.now ()))
-            in
-            Some (Int64.to_int (Int64.div ns 1_000_000L))
+      match clock_refs with
+      | Some value ->
+        ( Some (Keeper_runtime_manifest.with_clock_refs ~clock_refs:value decision)
+        , turn_state.manifest_seq )
+      | None ->
+        let manifest_seq = turn_state.manifest_seq + 1 in
+        let elapsed_ms =
+          let ns =
+            Mtime.Span.to_uint64_ns
+              (Mtime.span turn_start (Mtime_clock.now ()))
           in
+          Some (Int64.to_int (Int64.div ns 1_000_000L))
+        in
+        let clock_refs =
           Keeper_runtime_manifest.clock_refs_for_context
             runtime_manifest_context ~event ?elapsed_ms
-            ~logical_seq:!seq_ref ()
-      in
-      Some
-        (Keeper_runtime_manifest.with_clock_refs
-           ~clock_refs
-           decision)
+            ~logical_seq:manifest_seq ()
+        in
+        Some (Keeper_runtime_manifest.with_clock_refs ~clock_refs decision), manifest_seq
     in
     Keeper_runtime_manifest.make_for_context runtime_manifest_context ~event
       ?runtime_id ?status ?decision ()
-    |> Keeper_runtime_manifest.append_best_effort ~site config
+    |> Keeper_runtime_manifest.append_best_effort ~site config;
+    { turn_state with manifest_seq }
   in
-  let append_phase_gate_decision turn_plan =
-    append_manifest ~site:"phase_gate_decided"
+  let append_phase_gate_decision
+        (turn_state : Keeper_unified_turn_execution.turn_state)
+        turn_plan
+    =
+    append_manifest turn_state ~site:"phase_gate_decided"
       ~status:(turn_plan_manifest_status turn_plan)
       ~decision:(turn_plan_manifest_decision turn_plan)
       Keeper_runtime_manifest.Phase_gate_decided
   in
-  append_manifest ~site:"turn_started"
-    ~decision:
-      (`Assoc
-        [
-          ( "channel",
-            `String (Keeper_world_observation.channel_to_string channel) );
-          ("usage_total_turns", `Int meta.runtime.usage.total_turns);
-        ])
-    Keeper_runtime_manifest.Turn_started;
+  let turn_state =
+    append_manifest initial_turn_state ~site:"turn_started"
+      ~decision:
+        (`Assoc
+          [
+            ( "channel",
+              `String (Keeper_world_observation.channel_to_string channel) );
+            ("usage_total_turns", `Int meta.runtime.usage.total_turns);
+          ])
+      Keeper_runtime_manifest.Turn_started
+  in
   Keeper_turn_fsm.emit_transition
     ~keeper_name:meta.name
     ~turn_id:keeper_turn_id
@@ -131,20 +149,25 @@ let run_keeper_cycle
      State-aware runtime routing (TLA+ KeeperCoreTriad.SelectRuntime)
      resumes inside [main_path]; at that point [phase_opt] is whatever
      the registry returned for an executable phase. *)
-  let main_path phase_opt =
+  let main_path (turn_state : Keeper_unified_turn_execution.turn_state) phase_opt
+    : (keeper_meta, Agent_sdk.Error.sdk_error) result
+      * Keeper_unified_turn_execution.turn_state
+    =
       let _ = phase_opt in
       let effective_runtime_id = Keeper_meta_contract.runtime_id_of_meta meta in
-      append_manifest
-        ~site:"runtime_routed"
-        ~runtime_id:effective_runtime_id
-        (* RFC-0132-EXEMPT: internal observability — manifest decision reason label, not a redacted public surface *)
-        ~decision:(`Assoc [ "reason", `String "runtime" ])
-        Keeper_runtime_manifest.Runtime_routed;
+      let turn_state =
+        append_manifest turn_state
+          ~site:"runtime_routed"
+          ~runtime_id:effective_runtime_id
+          (* RFC-0132-EXEMPT: internal observability — manifest decision reason label, not a redacted public surface *)
+          ~decision:(`Assoc [ "reason", `String "runtime" ])
+          Keeper_runtime_manifest.Runtime_routed
+      in
       (* Concrete runtime health/capacity is owned by OAS/provider adapters.
          Keeper routing no longer rewrites runtimes from provider cooldown or
          process-queue probes. *)
       (match None with
-       | Some meta_after_skip -> Ok meta_after_skip
+       | Some meta_after_skip -> Ok meta_after_skip, turn_state
        | None ->
          (* RFC-0136 PR-3: pre-dispatch validation extracted to
             [Keeper_unified_turn_pre_dispatch].  profile_defaults stays
@@ -198,7 +221,7 @@ let run_keeper_cycle
               ~turn_id:keeper_turn_id
               ~prev:Keeper_turn_fsm.Runtime_routing
               (Keeper_turn_fsm.Failed failure_reason);
-            Error err
+            Error err, turn_state
           | Ok initial_execution ->
             record_pre_dispatch_terminal_observation
               ~config
@@ -229,14 +252,15 @@ let run_keeper_cycle
                  ()
              with
              | Keeper_turn_livelock.Blocked reason ->
-               Keeper_unified_turn_livelock_block.handle
-                 ~config
-                 ~meta
-                 ~generation
-                 ~keeper_turn_id
-                 ~turn_id
-                 ~initial_execution
-                 ~reason
+               ( Keeper_unified_turn_livelock_block.handle
+                   ~config
+                   ~meta
+                   ~generation
+                   ~keeper_turn_id
+                   ~turn_id
+                   ~initial_execution
+                   ~reason
+               , turn_state )
              | Keeper_turn_livelock.Started _ ->
                Keeper_turn_fsm.emit_transition
                  ~keeper_name:meta.name
@@ -314,9 +338,9 @@ let run_keeper_cycle
          Uses the OAS Event_bus (ToolCalled + ToolCompleted) rather than
          MASC-side observers. The per-turn subscription is scoped by
          [filter_agent meta.name], so no cross-keeper contamination. *)
-               let post_commit_failure_reason = ref None in
-               let paused_meta_override = ref None in
-               let current_turn_blocker_info = ref None in
+               let turn_state =
+                 { turn_state with last_execution = Some initial_execution }
+               in
                let turn_event_bus_state =
                  Keeper_unified_turn_event_bus.create ~keeper_name:meta.name ()
                in
@@ -382,33 +406,7 @@ let run_keeper_cycle
                     meta.name
                     Keeper_registry.Decision_active_guard_ok
                 | _ -> ());
-               let last_execution = ref initial_execution in
-               let last_provider_timeout_budget : provider_timeout_budget option ref =
-                 ref None
-               in
-               let degraded_retry_info = ref None in
-               let runtime_rotation_attempts = ref [] in
-               let record_runtime_rotation_attempt
-                     ?productive_phase_elapsed_ms
-                     ?retry_phase_elapsed_ms
-                     ~(from_runtime : string)
-                     ~(retry : EC.degraded_retry)
-                     ~(outcome : Keeper_execution_receipt.runtime_rotation_outcome)
-                     (err : Agent_sdk.Error.sdk_error)
-                 =
-                 let attempt : Keeper_execution_receipt.runtime_rotation_attempt =
-                   Keeper_unified_turn_rotation_attempt.build
-                     ~recorded_at:(now_iso ())
-                     ?productive_phase_elapsed_ms
-                     ?retry_phase_elapsed_ms
-                     ~from_runtime
-                     ~retry
-                     ~outcome
-                     err
-                 in
-                 runtime_rotation_attempts := attempt :: !runtime_rotation_attempts
-               in
-               let run_result, latency_ms =
+               let (run_result, turn_state), latency_ms =
                  (* Cancel-safe cleanup (#9747): stdlib [Fun.protect] wraps cleanup
            exceptions in [Fun.Finally_raised], losing the outer
            [Eio.Cancel.Cancelled]. Cleanup here swallows Cancelled (the
@@ -445,14 +443,13 @@ let run_keeper_cycle
                  match
                    Keeper_context_runtime.timed (fun () ->
                      match Eio_context.get_clock () with
-                     | Error msg -> Error (Agent_sdk.Error.Internal msg)
+                     | Error msg -> Error (Agent_sdk.Error.Internal msg), turn_state
                      | Ok clock ->
                        start_background_turn_event_bus_drain ~clock;
                        let { Keeper_unified_turn_retry_setup.timeout_sec
                            ; turn_started_at
                            ; turn_deadline
                            ; remaining_turn_budget_s
-                           ; retry_phase_started_at
                            ; elapsed_ms
                            ; current_turn_phase_elapsed_ms
                            ; keeper_profile
@@ -466,51 +463,46 @@ let run_keeper_cycle
                            ~channel
                            ~turn_affordances
                        in
-                        Keeper_unified_turn_execution.run
-                          { attempt = 1
-                          ; base_dir
-                          ; build_turn_prompt
-                          ; runtime_rotation_attempts
-                          ; channel
-                          ; cleanup
-                          ; committed_mutating_tools_snapshot
-                          ; config
-                          ; current_turn_blocker_info
-                          ; degraded_retry_info
-                          ; drain_turn_event_bus
-                          ; event_bus_integrity_error_snapshot
-                          ; failure_reason = ref None
-                          ; generation
-                          ; keeper_turn_id
-                          ; last_execution
-                          ; last_provider_timeout_budget
-                          ; max_cost_usd
-                          ; meta
-                          ; turn_ctx_cell
-                          ; observation
-                          ; post_commit_failure_reason
-                          ; profile_defaults
-                          ; prompt_timeout_estimate_tokens
-                          ; record_runtime_rotation_attempt
-                          ; shared_context
-                          ; trajectory_acc
-                          ; turn_affordances
-                          ; turn_id = keeper_turn_id
-                          }
-                          ~initial_execution
-                          ~timeout_sec
-                          ~remaining_turn_budget_s
-                          ~retry_phase_started_at
-                          ~current_turn_phase_elapsed_ms
-                          ~keeper_profile
-                          ~max_turns
-                          ~max_idle_turns
-                          ~user_message
-                          ~registry_base_path
-                          ~degraded_retry_slot_phase_budget_sec
-                          ~record_streaming_cancelled_observation
-                          ~runtime_id_of_meta
-                          ~start_background_turn_event_bus_drain
+                       let run_result, turn_state =
+                         Keeper_unified_turn_execution.run
+                           { attempt = 1
+                           ; base_dir
+                           ; build_turn_prompt
+                           ; channel
+                           ; cleanup
+                           ; committed_mutating_tools_snapshot
+                           ; config
+                           ; drain_turn_event_bus
+                           ; event_bus_integrity_error_snapshot
+                           ; generation
+                           ; keeper_turn_id
+                           ; max_cost_usd
+                           ; meta
+                           ; turn_ctx_cell
+                           ; observation
+                           ; profile_defaults
+                           ; prompt_timeout_estimate_tokens
+                           ; shared_context
+                           ; trajectory_acc
+                           ; turn_affordances
+                           ; turn_id = keeper_turn_id
+                           }
+                           ~initial_execution
+                           ~turn_state
+                           ~timeout_sec
+                           ~remaining_turn_budget_s
+                           ~current_turn_phase_elapsed_ms
+                           ~keeper_profile
+                           ~max_turns
+                           ~max_idle_turns
+                           ~user_message
+                           ~registry_base_path
+                           ~degraded_retry_slot_phase_budget_sec
+                           ~record_streaming_cancelled_observation
+                           ~runtime_id_of_meta
+                           ~start_background_turn_event_bus_drain
+                       in
+                       run_result, turn_state
                     )
                  with
                  | result ->
@@ -541,25 +533,27 @@ let run_keeper_cycle
                    then "observed"
                    else "empty"
                in
-               append_manifest ~site:"event_bus_correlated"
-                 ~status:event_bus_manifest_status
-                 ~clock_refs:
-                   (Keeper_runtime_manifest.clock_refs_for_context
-                      runtime_manifest_context
-                      ~event:Keeper_runtime_manifest.Event_bus_correlated
-                      ?event_bus_correlation_id:turn_event_bus.correlation_id
-                      ?event_bus_run_id:turn_event_bus.run_id
-                      ?caused_by:turn_event_bus.caused_by ())
-                 ~decision:
-                   (Keeper_runtime_manifest.with_payload_role ~payload_role:Operator_evidence
-                      (turn_event_bus_manifest_decision turn_event_bus))
-                 Keeper_runtime_manifest.Event_bus_correlated;
+               let turn_state =
+                 append_manifest turn_state ~site:"event_bus_correlated"
+                   ~status:event_bus_manifest_status
+                   ~clock_refs:
+                     (Keeper_runtime_manifest.clock_refs_for_context
+                        runtime_manifest_context
+                        ~event:Keeper_runtime_manifest.Event_bus_correlated
+                        ?event_bus_correlation_id:turn_event_bus.correlation_id
+                        ?event_bus_run_id:turn_event_bus.run_id
+                        ?caused_by:turn_event_bus.caused_by ())
+                   ~decision:
+                     (Keeper_runtime_manifest.with_payload_role ~payload_role:Operator_evidence
+                        (turn_event_bus_manifest_decision turn_event_bus))
+                   Keeper_runtime_manifest.Event_bus_correlated
+               in
                let run_result =
                  match event_bus_integrity_error_snapshot () with
                  | Some integrity_err -> Error integrity_err
                  | None -> run_result
                in
-               let degraded_retry_info = !degraded_retry_info in
+               let degraded_retry_info = turn_state.degraded_retry_info in
                let degraded_retry_applied = Option.is_some degraded_retry_info in
                let degraded_retry_runtime =
                  Option.map
@@ -586,11 +580,13 @@ let run_keeper_cycle
                     Keeper_metrics.(to_string Turns)
                     ~labels:[ "keeper", meta.name; "outcome", "input_required" ]
                     ();
-                  cycle_completed := true;
-                  post_turn_complete_task ~cycle_completed;
-                  Ok meta
+                  let turn_state =
+                    { turn_state with cycle_completed = true }
+                  in
+                  post_turn_complete_task ~cycle_completed:turn_state.cycle_completed;
+                  Ok meta, turn_state
                 | Error err ->
-                  let final_execution = !last_execution in
+                  let final_execution = Option.get turn_state.last_execution in
                   finalize_trajectory_acc
                     ~config
                     ~keeper_name:meta.name
@@ -702,7 +698,7 @@ let run_keeper_cycle
                       ~reason:e_str
                   in
                   let failure_meta_base =
-                    match !paused_meta_override with
+                    match turn_state.paused_meta_override with
                     | Some paused_meta -> paused_meta
                     | None -> meta
                   in
@@ -734,7 +730,7 @@ let run_keeper_cycle
                                { kind = Keeper_registry.Post_commit_failure
                                ; detail = e_str
                                })
-                          !post_commit_failure_reason
+                          turn_state.post_commit_failure_reason
                       in
                       Keeper_registry.set_failure_reason
                         ~base_path:config.base_path
@@ -866,7 +862,7 @@ dominant source of the observed CAS race exhaustion after
                              { kind = Keeper_registry.Post_commit_failure
                              ; detail = e_str
                              })
-                        !post_commit_failure_reason
+                        turn_state.post_commit_failure_reason
                     in
                     Keeper_registry.set_failure_reason
                       ~base_path:config.base_path
@@ -897,9 +893,9 @@ dominant source of the observed CAS race exhaustion after
                     Keeper_metrics.(to_string TurnCompleted)
                     ~labels:[("keeper", meta.name)]
                     ();
-                  Error err
+                  Error err, turn_state
                 | Ok result ->
-                  let final_execution = !last_execution in
+                  let final_execution = Option.get turn_state.last_execution in
                   finalize_trajectory_acc
                     ~config
                     ~keeper_name:meta.name
@@ -918,27 +914,35 @@ dominant source of the observed CAS race exhaustion after
                       ~degraded_retry_applied
                       ~degraded_retry_runtime
                       ~fallback_reason
-                      ~last_provider_timeout_budget:!last_provider_timeout_budget
-                      ~current_turn_blocker_info:!current_turn_blocker_info
+                      ~last_provider_timeout_budget:turn_state.last_provider_timeout_budget
+                      ~current_turn_blocker_info:turn_state.current_turn_blocker_info
                       ~keeper_turn_id
                       result
                   in
                   (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete post-action. *)
-                  cycle_completed := true;
-                  post_turn_complete_task ~cycle_completed;
-                  Ok updated_meta))))
+                  let turn_state =
+                    { turn_state with cycle_completed = true }
+                  in
+                  post_turn_complete_task ~cycle_completed:turn_state.cycle_completed;
+                  Ok updated_meta, turn_state))))
   in
-  match
+  let append_phase_gate_decision_for_gate turn_plan turn_state =
+    append_phase_gate_decision turn_state turn_plan
+  in
+  let phase_gate_outcome, turn_state =
     Keeper_unified_turn_phase_gate.decide_and_record
       ~config
       ~meta
       ~generation
       ~keeper_turn_id
-      ~append_phase_gate_decision
+      ~append_phase_gate_decision:append_phase_gate_decision_for_gate
+      ~turn_state
       ~registry_base_path
-  with
+  in
+  match phase_gate_outcome with
   | Keeper_unified_turn_phase_gate.Phase_gate_terminal_ok meta -> Ok meta
   | Keeper_unified_turn_phase_gate.Phase_gate_terminal_error err -> Error err
   | Keeper_unified_turn_phase_gate.Phase_gate_proceed phase_opt ->
-    main_path phase_opt
+    let result, _turn_state = main_path turn_state phase_opt in
+    result
 ;;

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -97,7 +97,7 @@ val record_turn_tool_events
   -> keeper_name:string
   -> turn_tool_event_tracker
   -> Agent_sdk.Event_bus.event list
-  -> unit
+  -> turn_tool_event_tracker
 
 val turn_tool_event_integrity_error
   :  turn_tool_event_tracker

--- a/lib/keeper/keeper_unified_turn_event_bus.ml
+++ b/lib/keeper/keeper_unified_turn_event_bus.ml
@@ -1,12 +1,15 @@
 (** Turn-scoped OAS event-bus state for [Keeper_unified_turn]. *)
 
+type event_bus_state =
+  { summary : Keeper_turn_runtime_budget.turn_event_bus_summary
+  ; tracker : Keeper_unified_turn_types.turn_tool_event_tracker
+  }
+
 type t =
   { keeper_name : string
   ; event_bus_sub : Agent_sdk_metrics_bridge.handle option
-  ; tool_event_tracker : Keeper_unified_turn_types.turn_tool_event_tracker
   ; drain_cancel : Eio.Cancel.t option ref
-  ; turn_event_bus_mu : Eio.Mutex.t
-  ; turn_event_bus : Keeper_turn_runtime_budget.turn_event_bus_summary ref
+  ; state : event_bus_state Atomic.t
   }
 
 let create ~keeper_name () =
@@ -22,55 +25,55 @@ let create ~keeper_name () =
   in
   { keeper_name
   ; event_bus_sub
-  ; tool_event_tracker = Keeper_unified_turn_types.create_turn_tool_event_tracker ()
   ; drain_cancel = ref None
-  ; turn_event_bus_mu = Eio.Mutex.create ()
-  ; turn_event_bus = ref Keeper_turn_runtime_budget.empty_turn_event_bus_summary
+  ; state =
+      Atomic.make
+        { summary = Keeper_turn_runtime_budget.empty_turn_event_bus_summary
+        ; tracker = Keeper_unified_turn_types.create_turn_tool_event_tracker ()
+        }
   }
 ;;
 
-let with_turn_event_bus_lock t f =
-  Eio.Mutex.use_rw ~protect:true t.turn_event_bus_mu f
-;;
-
-let process_tool_events_for_side_effects t events =
-  Keeper_unified_turn_types.record_turn_tool_events
-    ~keeper_name:t.keeper_name
-    t.tool_event_tracker
-    events
-;;
-
 let drain ?(site = "unspecified") t =
-  with_turn_event_bus_lock t (fun () ->
-    let events =
-      match t.event_bus_sub, Keeper_event_bus.get () with
-      | Some sub, Some _bus -> Agent_sdk_metrics_bridge.drain sub
-      | _ -> []
+  let events =
+    match t.event_bus_sub, Keeper_event_bus.get () with
+    | Some sub, Some _bus -> Agent_sdk_metrics_bridge.drain sub
+    | _ -> []
+  in
+  let outcome = if events = [] then "empty" else "drained" in
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string EventBusDrain)
+    ~labels:[ "site", site; "outcome", outcome ]
+    ();
+  let rec update () =
+    let old = Atomic.get t.state in
+    let new_tracker =
+      Keeper_unified_turn_types.record_turn_tool_events
+        ~keeper_name:t.keeper_name
+        old.tracker
+        events
     in
-    let outcome = if events = [] then "empty" else "drained" in
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string EventBusDrain)
-      ~labels:[ "site", site; "outcome", outcome ]
-      ();
-    process_tool_events_for_side_effects t events;
-    let summary = Keeper_turn_runtime_budget.summarize_turn_event_bus events in
-    t.turn_event_bus
-    := Keeper_turn_runtime_budget.merge_turn_event_bus_summary
-         !(t.turn_event_bus)
-         summary;
-    !(t.turn_event_bus))
+    let new_summary =
+      Keeper_turn_runtime_budget.merge_turn_event_bus_summary
+        old.summary
+        (Keeper_turn_runtime_budget.summarize_turn_event_bus events)
+    in
+    let new_state = { summary = new_summary; tracker = new_tracker } in
+    if Atomic.compare_and_set t.state old new_state
+    then new_summary
+    else update ()
+  in
+  update ()
 ;;
 
 let committed_mutating_tools t =
-  with_turn_event_bus_lock t (fun () ->
-    Keeper_unified_turn_types.committed_mutating_tools_from_events
-      t.tool_event_tracker)
+  (Atomic.get t.state).tracker
+  |> Keeper_unified_turn_types.committed_mutating_tools_from_events
 ;;
 
 let integrity_error t =
-  with_turn_event_bus_lock t (fun () ->
-    Keeper_unified_turn_types.turn_tool_event_integrity_error
-      t.tool_event_tracker)
+  (Atomic.get t.state).tracker
+  |> Keeper_unified_turn_types.turn_tool_event_integrity_error
 ;;
 
 let start_background_drain ~clock t =

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -26,41 +26,29 @@ type retry_loop_input =
   ; attempted_runtimes : string list
   }
 
+(** [run] operates on the immutable [Keeper_unified_turn_types.turn_state]
+    accumulator instead of casual [ref] cells. *)
+
 type ctx =
   { attempt : int
   ; base_dir : string
   ; build_turn_prompt :
       base_system_prompt:string -> messages:Agent_sdk.Types.message list ->
       Keeper_agent_run.turn_prompt
-  ; runtime_rotation_attempts : Keeper_execution_receipt.runtime_rotation_attempt list ref
   ; channel : Keeper_world_observation.keeper_cycle_channel
   ; cleanup : unit -> unit
   ; committed_mutating_tools_snapshot : unit -> string list
   ; config : Workspace.config
-  ; current_turn_blocker_info : blocker_info option ref
-  ; degraded_retry_info : EC.degraded_retry option ref
   ; drain_turn_event_bus : ?site:string -> unit -> Keeper_turn_runtime_budget.turn_event_bus_summary
   ; event_bus_integrity_error_snapshot : unit -> Agent_sdk.Error.sdk_error option
-  ; failure_reason : Keeper_turn_fsm.failure_reason option ref
   ; generation : int
   ; keeper_turn_id : int
-  ; last_execution : runtime_execution ref
-  ; last_provider_timeout_budget : provider_timeout_budget option ref
   ; max_cost_usd : float option
   ; meta : keeper_meta
   ; turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell
   ; observation : Keeper_world_observation.world_observation
-  ; post_commit_failure_reason : Keeper_registry.failure_reason option ref
   ; profile_defaults : Keeper_types_profile.keeper_profile_defaults
   ; prompt_timeout_estimate_tokens : int
-  ; record_runtime_rotation_attempt
-      : ?productive_phase_elapsed_ms:int
-      -> ?retry_phase_elapsed_ms:int
-      -> from_runtime:string
-      -> retry:EC.degraded_retry
-      -> outcome:Keeper_execution_receipt.runtime_rotation_outcome
-      -> Agent_sdk.Error.sdk_error
-      -> unit
   ; shared_context : Agent_sdk.Context.t option
   ; trajectory_acc : Trajectory.accumulator
   ; turn_affordances : string list
@@ -69,10 +57,10 @@ type ctx =
 
 let run (ctx : ctx)
       ~(initial_execution : runtime_execution)
+      ~(turn_state : turn_state)
       ~(timeout_sec : float)
       ~(remaining_turn_budget_s : unit -> float)
-      ~(retry_phase_started_at : float option ref)
-      ~(current_turn_phase_elapsed_ms : unit -> int * int option)
+      ~(current_turn_phase_elapsed_ms : float option -> int * int option)
       ~(keeper_profile : Keeper_types_profile.keeper_profile_defaults)
       ~(max_turns : int)
       ~(max_idle_turns : int)
@@ -82,7 +70,7 @@ let run (ctx : ctx)
       ~(record_streaming_cancelled_observation : ?cancel_reason:string -> config:Workspace.config -> run_meta:keeper_meta -> run_generation:int -> runtime_id:string -> keeper_turn_id:int -> unit -> unit)
       ~(runtime_id_of_meta : keeper_meta -> string)
       ~(start_background_turn_event_bus_drain : clock:float Eio.Time.clock_ty Eio.Resource.t -> unit)
-  : (Keeper_agent_run.run_result, Agent_sdk.Error.sdk_error) result
+  : (Keeper_agent_run.run_result, Agent_sdk.Error.sdk_error) result * turn_state
 =
   let { config
       ; meta
@@ -98,26 +86,18 @@ let run (ctx : ctx)
       ; turn_affordances
       ; max_cost_usd
       ; trajectory_acc
-      ; last_execution
-      ; last_provider_timeout_budget
-      ; degraded_retry_info
-      ; runtime_rotation_attempts
-      ; current_turn_blocker_info
-      ; post_commit_failure_reason
       ; profile_defaults
       ; prompt_timeout_estimate_tokens
       ; cleanup
       ; drain_turn_event_bus
       ; event_bus_integrity_error_snapshot
       ; committed_mutating_tools_snapshot
-      ; record_runtime_rotation_attempt
-      ; failure_reason
       ; attempt = _attempt
       } =
     ctx
   in
   (match Eio_context.get_clock () with
-   | Error msg -> Error (Agent_sdk.Error.Internal msg)
+   | Error msg -> Error (Agent_sdk.Error.Internal msg), turn_state
    | Ok clock ->
    let do_run
         ~(execution : runtime_execution)
@@ -125,94 +105,123 @@ let run (ctx : ctx)
         ~run_generation
         ~is_retry
         ~oas_timeout_s
+        ~(turn_state : turn_state)
     =
-    last_execution := execution;
-    Otel_genai.with_keeper_turn_span
-      ~keeper_name:run_meta.name
-      ~agent_name:run_meta.agent_name
-      ~runtime_id:execution.runtime_id
-      ~trace_id:
-        (Keeper_id.Trace_id.to_string run_meta.runtime.trace_id)
-      ~generation:run_generation
-      ~max_context:execution.max_context
-      ~max_turns
-      ~max_idle_turns
-      ~channel:(Keeper_world_observation.channel_to_string channel)
-      ~is_retry
-      ~current_task_id:
-        (Option.map
-           Keeper_id.Task_id.to_string
-           run_meta.current_task_id)
-      (fun trace_link ->
-         Keeper_registry.mark_turn_provider_attempt_started
-           ~base_path:config.base_path
-           meta.name;
-         Keeper_unified_turn_attempt_watchdog.dispatch
-           ~clock
-           ~keeper_name:meta.name
-           ~attempt_watchdog_s:None
-           ~on_cancelled:(fun reason ->
-             record_streaming_cancelled_observation
-               ~cancel_reason:reason
-               ~config
-               ~run_meta
-               ~run_generation
-               ~runtime_id:execution.runtime_id
-               ~keeper_turn_id
-               ())
-           ~run:(fun () ->
-             (* Emit before the provider/tool run so operator forensics can see
-                that the keeper entered Streaming. [dispatch] observes external
-                cancellation only; it must not impose a MASC wall-clock timeout
-                around active tool execution. *)
-             Keeper_turn_fsm.emit_transition
-               ~keeper_name:meta.name
-               ~turn_id:keeper_turn_id
-               ~prev:Keeper_turn_fsm.Awaiting_provider
-               Keeper_turn_fsm.Streaming;
-             Keeper_agent_run.run_turn
-               ~config
-               ~meta:run_meta
-               ~turn_ctx_cell
-               ~base_dir
-               ~max_context:execution.max_context
-               ~build_turn_prompt
-               ~user_message
-               ~runtime_id:execution.runtime_id
-               ~world_observation:observation
-               ~turn_affordances
-               ~generation:run_generation
-               ~max_turns
-               ~max_idle_turns
-               ~history_user_source:"world_state_prompt"
-               ~history_assistant_source:"internal_assistant"
-               ~degraded_retry_applied:
-                 (Option.is_some !degraded_retry_info)
-               ?degraded_retry_runtime:
-                 (Option.map
-                    (fun (retry : EC.degraded_retry) ->
-                       retry.next_runtime)
-                    !degraded_retry_info)
-               ?fallback_reason:
-                 (Option.map
-                    (fun (retry : EC.degraded_retry) ->
-                       retry.fallback_reason)
-                    !degraded_retry_info)
-               ~runtime_rotation_attempts:
-                 (List.rev !runtime_rotation_attempts)
-               ~temperature:execution.temperature
-               ~max_tokens:execution.max_tokens
-               ~oas_timeout_s
-               ~oas_timeout_is_explicit:false
-               ?max_cost_usd
-               ~trajectory_acc
-               ~is_retry
-               ?shared_context
-               ?event_bus:(Keeper_event_bus.get ())
-               ?trace_link:(trace_link ())
-               ()))
+    let turn_state =
+      { turn_state with last_execution = Some execution }
+    in
+    let result =
+      Otel_genai.with_keeper_turn_span
+        ~keeper_name:run_meta.name
+        ~agent_name:run_meta.agent_name
+        ~runtime_id:execution.runtime_id
+        ~trace_id:
+          (Keeper_id.Trace_id.to_string run_meta.runtime.trace_id)
+        ~generation:run_generation
+        ~max_context:execution.max_context
+        ~max_turns
+        ~max_idle_turns
+        ~channel:(Keeper_world_observation.channel_to_string channel)
+        ~is_retry
+        ~current_task_id:
+          (Option.map
+             Keeper_id.Task_id.to_string
+             run_meta.current_task_id)
+        (fun trace_link ->
+           Keeper_registry.mark_turn_provider_attempt_started
+             ~base_path:config.base_path
+             meta.name;
+           Keeper_unified_turn_attempt_watchdog.dispatch
+             ~clock
+             ~keeper_name:meta.name
+             ~attempt_watchdog_s:None
+             ~on_cancelled:(fun reason ->
+               record_streaming_cancelled_observation
+                 ~cancel_reason:reason
+                 ~config
+                 ~run_meta
+                 ~run_generation
+                 ~runtime_id:execution.runtime_id
+                 ~keeper_turn_id
+                 ())
+             ~run:(fun () ->
+               (* Emit before the provider/tool run so operator forensics can see
+                  that the keeper entered Streaming. [dispatch] observes external
+                  cancellation only; it must not impose a MASC wall-clock timeout
+                  around active tool execution. *)
+               Keeper_turn_fsm.emit_transition
+                 ~keeper_name:meta.name
+                 ~turn_id:keeper_turn_id
+                 ~prev:Keeper_turn_fsm.Awaiting_provider
+                 Keeper_turn_fsm.Streaming;
+               Keeper_agent_run.run_turn
+                 ~config
+                 ~meta:run_meta
+                 ~turn_ctx_cell
+                 ~base_dir
+                 ~max_context:execution.max_context
+                 ~build_turn_prompt
+                 ~user_message
+                 ~runtime_id:execution.runtime_id
+                 ~world_observation:observation
+                 ~turn_affordances
+                 ~generation:run_generation
+                 ~max_turns
+                 ~max_idle_turns
+                 ~history_user_source:"world_state_prompt"
+                 ~history_assistant_source:"internal_assistant"
+                 ~degraded_retry_applied:
+                   (Option.is_some turn_state.degraded_retry_info)
+                 ?degraded_retry_runtime:
+                   (Option.map
+                      (fun (retry : EC.degraded_retry) ->
+                         retry.next_runtime)
+                      turn_state.degraded_retry_info)
+                 ?fallback_reason:
+                   (Option.map
+                      (fun (retry : EC.degraded_retry) ->
+                         retry.fallback_reason)
+                      turn_state.degraded_retry_info)
+                 ~runtime_rotation_attempts:
+                   (List.rev turn_state.runtime_rotation_attempts)
+                 ~temperature:execution.temperature
+                 ~max_tokens:execution.max_tokens
+                 ~oas_timeout_s
+                 ~oas_timeout_is_explicit:false
+                 ?max_cost_usd
+                 ~trajectory_acc
+                 ~is_retry
+                 ?shared_context
+                 ?event_bus:(Keeper_event_bus.get ())
+                 ?trace_link:(trace_link ())
+                 ()))
+    in
+    result, turn_state
   in
-  let rec retry_loop (input : retry_loop_input) =
+  let record_runtime_rotation_attempt
+        turn_state
+        ~productive_phase_elapsed_ms
+        ?retry_phase_elapsed_ms
+        ~(from_runtime : string)
+        ~(retry : EC.degraded_retry)
+        ~(outcome : Keeper_execution_receipt.runtime_rotation_outcome)
+        (err : Agent_sdk.Error.sdk_error)
+    =
+    let attempt : Keeper_execution_receipt.runtime_rotation_attempt =
+      Keeper_unified_turn_rotation_attempt.build
+        ~recorded_at:(now_iso ())
+        ~productive_phase_elapsed_ms
+        ?retry_phase_elapsed_ms
+        ~from_runtime
+        ~retry
+        ~outcome
+        err
+    in
+    { turn_state with
+      runtime_rotation_attempts = attempt :: turn_state.runtime_rotation_attempts
+    }
+  in
+  let rec retry_loop (input : retry_loop_input) (turn_state : turn_state) =
     let { run_meta
         ; execution
         ; run_generation
@@ -256,7 +265,6 @@ let run (ctx : ctx)
           ~attempted_runtimes
           err
     in
-    let attempt_provider_timeout_budget = ref None in
     let max_turns =
       match channel with
       | Keeper_world_observation.Reactive ->
@@ -267,7 +275,7 @@ let run (ctx : ctx)
         .effective_max_turns_per_call_scheduled_autonomous
           keeper_profile
     in
-    let attempt_result =
+    let attempt_result, turn_state =
       let allow_wall_clock_retry_budget =
         allow_wall_clock_retry_budget_for_attempt
           ~is_retry
@@ -284,14 +292,18 @@ let run (ctx : ctx)
           ~estimated_input_tokens:prompt_timeout_estimate_tokens
           ~remaining_turn_budget_s:(remaining_turn_budget_s ())
       in
-      attempt_provider_timeout_budget := Some provider_timeout_budget;
-      last_provider_timeout_budget := Some provider_timeout_budget;
+      let turn_state =
+        { turn_state with
+          last_provider_timeout_budget = Some provider_timeout_budget
+        }
+      in
       do_run
         ~execution
         ~run_meta
         ~run_generation
         ~is_retry
         ~oas_timeout_s:provider_timeout_budget.effective_timeout_sec
+        ~turn_state
     in
     match attempt_result with
     | Ok result ->
@@ -307,7 +319,7 @@ let run (ctx : ctx)
       Keeper_registry.mark_turn_runtime_done
         ~base_path:config.base_path
         meta.name;
-      Ok result
+      Ok result, turn_state
     | Error err ->
       (* RFC-XXXX: reclassify_provider_timeout_for_attempt removed.
          The per-attempt wall-clock watchdog no longer fires, so the
@@ -346,7 +358,7 @@ let run (ctx : ctx)
           ~labels:[ "keeper", meta.name; "reason", reason ]
           ();
         mark_terminal_error err;
-        Error err)
+        Error err, turn_state)
       else if committed_tools <> []
       then (
         let reclassified, failure_reason =
@@ -369,7 +381,11 @@ let run (ctx : ctx)
                       err
                 } )
         in
-        post_commit_failure_reason := Some failure_reason;
+        let turn_state =
+          { turn_state with
+            post_commit_failure_reason = Some failure_reason
+          }
+        in
         let err_preview =
           short_preview (Agent_sdk.Error.to_string err)
         in
@@ -402,7 +418,7 @@ let run (ctx : ctx)
           ~labels:[ "keeper", meta.name ]
           ();
         mark_terminal_error reclassified;
-        Error reclassified)
+        Error reclassified, turn_state)
       else (
         match
           next_fail_open_runtime_for_turn_with_budget
@@ -440,16 +456,19 @@ let run (ctx : ctx)
            with
            | Error fail_open_err ->
              let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
-               current_turn_phase_elapsed_ms ()
+               current_turn_phase_elapsed_ms turn_state.retry_phase_started_at
              in
-             record_runtime_rotation_attempt
-               ~productive_phase_elapsed_ms
-               ?retry_phase_elapsed_ms
-               ~from_runtime:execution.runtime_id
-               ~retry:degraded_retry
-               ~outcome:
-                 Keeper_execution_receipt.Rotation_setup_failed
-               fail_open_err;
+             let turn_state =
+               record_runtime_rotation_attempt
+                 turn_state
+                 ~productive_phase_elapsed_ms
+                 ?retry_phase_elapsed_ms
+                 ~from_runtime:execution.runtime_id
+                 ~retry:degraded_retry
+                 ~outcome:
+                   Keeper_execution_receipt.Rotation_setup_failed
+                 fail_open_err
+             in
              Log.Keeper.warn
                "%s: recoverable runtime failure in %s suggested \
                 degraded retry to %s (reason=%s), but retry setup \
@@ -462,25 +481,33 @@ let run (ctx : ctx)
                (short_preview
                   (Agent_sdk.Error.to_string fail_open_err));
              mark_terminal_error fail_open_err;
-             Error fail_open_err
+             Error fail_open_err, turn_state
            | Ok next_execution ->
              let next_execution_runtime_id =
                next_execution.runtime_id
              in
-             if Option.is_none !retry_phase_started_at
-             then retry_phase_started_at := Some (Eio.Time.now clock);
-             let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
-               current_turn_phase_elapsed_ms ()
+             let turn_state =
+               if Option.is_none turn_state.retry_phase_started_at
+               then { turn_state with retry_phase_started_at = Some (Eio.Time.now clock) }
+               else turn_state
              in
-             record_runtime_rotation_attempt
-               ~productive_phase_elapsed_ms
-               ?retry_phase_elapsed_ms
-               ~from_runtime:execution.runtime_id
-               ~retry:degraded_retry
-               ~outcome:
-                 Keeper_execution_receipt.Rotation_retry_scheduled
-               err;
-             degraded_retry_info := Some degraded_retry;
+             let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
+               current_turn_phase_elapsed_ms turn_state.retry_phase_started_at
+             in
+             let turn_state =
+               record_runtime_rotation_attempt
+                 turn_state
+                 ~productive_phase_elapsed_ms
+                 ?retry_phase_elapsed_ms
+                 ~from_runtime:execution.runtime_id
+                 ~retry:degraded_retry
+                 ~outcome:
+                   Keeper_execution_receipt.Rotation_retry_scheduled
+                 err
+             in
+             let turn_state =
+               { turn_state with degraded_retry_info = Some degraded_retry }
+             in
              Log.Keeper.warn
                "%s: recoverable runtime failure in %s; rotation \
                 retry on runtime=%s reason=%s max_context=%d \
@@ -511,7 +538,8 @@ let run (ctx : ctx)
                ; allow_degraded_wall_clock_retry_budget = true
                ; attempted_runtimes =
                    next_execution_runtime_id :: attempted_runtimes
-               })
+               }
+               turn_state)
         | Degraded_retry_slot_phase_exhausted degraded_retry ->
           Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
             ~keeper_name:meta.name
@@ -523,16 +551,19 @@ let run (ctx : ctx)
             ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
             ~error_message:(Some (Agent_sdk.Error.to_string err));
           let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
-            current_turn_phase_elapsed_ms ()
+            current_turn_phase_elapsed_ms turn_state.retry_phase_started_at
           in
-          record_runtime_rotation_attempt
-            ~productive_phase_elapsed_ms
-            ?retry_phase_elapsed_ms
-            ~from_runtime:execution.runtime_id
-            ~retry:degraded_retry
-            ~outcome:
-              Keeper_execution_receipt.Rotation_slot_phase_exhausted
-            err;
+          let turn_state =
+            record_runtime_rotation_attempt
+              turn_state
+              ~productive_phase_elapsed_ms
+              ?retry_phase_elapsed_ms
+              ~from_runtime:execution.runtime_id
+              ~retry:degraded_retry
+              ~outcome:
+                Keeper_execution_receipt.Rotation_slot_phase_exhausted
+              err
+          in
           Log.Keeper.warn
             "%s: recoverable runtime failure in %s suggested \
              degraded retry to %s (reason=%s), but productive slot \
@@ -547,7 +578,7 @@ let run (ctx : ctx)
             (timeout_sec -. remaining_turn_budget_s ())
             (short_preview (Agent_sdk.Error.to_string err));
           mark_terminal_error err;
-          Error err
+          Error err, turn_state
         | No_degraded_retry
           when EC.is_transient_network_error err
                && attempt <= EC.max_transient_retries () ->
@@ -600,6 +631,7 @@ let run (ctx : ctx)
             ; allow_degraded_wall_clock_retry_budget = false
             ; attempted_runtimes
             }
+            turn_state
         | No_degraded_retry when EC.is_context_overflow err ->
           Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
             ~keeper_name:meta.name
@@ -619,15 +651,19 @@ let run (ctx : ctx)
               ~turn_event_bus:current_turn_event_bus
               err
           in
-          current_turn_blocker_info
-          := Some
-               { klass = Sdk_token_budget_exceeded
-               ; detail =
-                   Keeper_state_machine.event_to_string
-                     overflow_event
-                   ^ ": "
-                   ^ Agent_sdk.Error.to_string err
-               };
+          let turn_state =
+            { turn_state with
+              current_turn_blocker_info =
+                Some
+                  { klass = Sdk_token_budget_exceeded
+                  ; detail =
+                      Keeper_state_machine.event_to_string
+                        overflow_event
+                      ^ ": "
+                      ^ Agent_sdk.Error.to_string err
+                  }
+            }
+          in
           Otel_metric_store.inc_counter
             Keeper_metrics.(to_string OasExecutionErrors)
             ~labels:
@@ -643,7 +679,7 @@ let run (ctx : ctx)
             meta.name
             (short_preview (Agent_sdk.Error.to_string err));
           mark_terminal_error err;
-          Error err
+          Error err, turn_state
         | No_degraded_retry ->
           Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
             ~keeper_name:meta.name
@@ -655,7 +691,7 @@ let run (ctx : ctx)
             ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
             ~error_message:(Some (Agent_sdk.Error.to_string err));
           mark_terminal_error err;
-          Error err)
+          Error err, turn_state)
   in
   (* Do not wrap the full keeper turn in a cumulative wall-clock timeout.
      Long voice/OAS turns can keep making stream or tool progress beyond the
@@ -663,15 +699,19 @@ let run (ctx : ctx)
      attempt liveness, tool-level timeouts, max-turn limits, and the optional
      supervisor stale-turn watchdog. Retry admission must not reintroduce the
      cumulative wall-clock cap between provider attempts. *)
-  retry_loop
-    { run_meta = meta
-    ; execution = initial_execution
-    ; run_generation = generation
-    ; attempt = 1
-    ; is_retry = false
-    ; allow_degraded_wall_clock_retry_budget = false
-    ; attempted_runtimes =
-        [ initial_execution.runtime_id
-        ]
-    }
+  let result, turn_state =
+    retry_loop
+      { run_meta = meta
+      ; execution = initial_execution
+      ; run_generation = generation
+      ; attempt = 1
+      ; is_retry = false
+      ; allow_degraded_wall_clock_retry_budget = false
+      ; attempted_runtimes =
+          [ initial_execution.runtime_id
+          ]
+      }
+      turn_state
+  in
+  result, turn_state
 )

--- a/lib/keeper/keeper_unified_turn_phase_gate.ml
+++ b/lib/keeper/keeper_unified_turn_phase_gate.ml
@@ -21,7 +21,10 @@ let decide_and_record
       ~(generation : int)
       ~(keeper_turn_id : int)
       ~(append_phase_gate_decision :
-         Keeper_unified_turn_phase_plan.turn_plan -> unit)
+         Keeper_unified_turn_phase_plan.turn_plan
+         -> Keeper_unified_turn_types.turn_state
+         -> Keeper_unified_turn_types.turn_state)
+      ~(turn_state : Keeper_unified_turn_types.turn_state)
       ~(registry_base_path : string)
   =
   let supervisor_stop_at_entry =
@@ -36,7 +39,7 @@ let decide_and_record
         ~keeper_turn_id
         ~supervisor_stop_at_entry:true None
     in
-    append_phase_gate_decision turn_plan;
+    let turn_state = append_phase_gate_decision turn_plan turn_state in
     Log.Keeper.info
       ~keeper_name:meta.name
       ~turn_id:keeper_turn_id
@@ -66,7 +69,7 @@ let decide_and_record
       ~turn_id:keeper_turn_id
       ~prev:Keeper_turn_fsm.Phase_gating
       (Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_supervisor_stop);
-    Phase_gate_terminal_ok meta)
+    Phase_gate_terminal_ok meta, turn_state)
   else (
     match
       Keeper_registry.get_phase ~base_path:registry_base_path meta.name
@@ -78,7 +81,7 @@ let decide_and_record
           ~supervisor_stop_at_entry:false (Some phase)
       in
       let phase_string = Keeper_state_machine.phase_to_string phase in
-      append_phase_gate_decision turn_plan;
+      let turn_state = append_phase_gate_decision turn_plan turn_state in
       Log.Keeper.info
         ~keeper_name:meta.name
         ~turn_id:keeper_turn_id
@@ -105,7 +108,7 @@ let decide_and_record
         ~turn_id:keeper_turn_id
         ~prev:Keeper_turn_fsm.Phase_gating
         Keeper_turn_fsm.Done;
-      Phase_gate_terminal_ok meta
+      Phase_gate_terminal_ok meta, turn_state
     | None ->
       let turn_plan =
         Keeper_unified_turn_phase_plan.decide_turn_plan_at_phase_gate
@@ -118,7 +121,7 @@ let decide_and_record
           "%s: keeper registry phase lookup returned None before dispatch"
           meta.name
       in
-      append_phase_gate_decision turn_plan;
+      let turn_state = append_phase_gate_decision turn_plan turn_state in
       Log.Keeper.error
         ~keeper_name:meta.name
         ~turn_id:keeper_turn_id
@@ -145,17 +148,17 @@ let decide_and_record
         ~prev:Keeper_turn_fsm.Phase_gating
         (Keeper_turn_fsm.Failed
            (Keeper_turn_fsm.Failure_runtime_error terminal_reason_code));
-      Phase_gate_terminal_error (Agent_sdk.Error.Internal error_message)
+      Phase_gate_terminal_error (Agent_sdk.Error.Internal error_message), turn_state
     | phase_opt ->
       let turn_plan =
         Keeper_unified_turn_phase_plan.decide_turn_plan_at_phase_gate
           ~keeper_turn_id
           ~supervisor_stop_at_entry:false phase_opt
       in
-      append_phase_gate_decision turn_plan;
+      let turn_state = append_phase_gate_decision turn_plan turn_state in
       Keeper_turn_fsm.emit_transition
         ~keeper_name:meta.name
         ~turn_id:keeper_turn_id
         ~prev:Keeper_turn_fsm.Phase_gating
         Keeper_turn_fsm.Runtime_routing;
-      Phase_gate_proceed phase_opt)
+      Phase_gate_proceed phase_opt, turn_state)

--- a/lib/keeper/keeper_unified_turn_phase_gate.mli
+++ b/lib/keeper/keeper_unified_turn_phase_gate.mli
@@ -27,9 +27,12 @@ val decide_and_record
   -> generation:int
   -> keeper_turn_id:int
   -> append_phase_gate_decision:
-       (Keeper_unified_turn_phase_plan.turn_plan -> unit)
+       (Keeper_unified_turn_phase_plan.turn_plan
+        -> Keeper_unified_turn_types.turn_state
+        -> Keeper_unified_turn_types.turn_state)
+  -> turn_state:Keeper_unified_turn_types.turn_state
   -> registry_base_path:string
-  -> phase_gate_outcome
+  -> phase_gate_outcome * Keeper_unified_turn_types.turn_state
 (** Run the phase gate logic, including all FSM transitions,
     observability records, and runtime-manifest decisions.
 
@@ -49,6 +52,11 @@ val decide_and_record
     @param generation Current generation counter.
     @param keeper_turn_id Turn identifier assigned at function entry.
     @param append_phase_gate_decision Callback closing over the
-      caller's [runtime_manifest_context]; called once per outcome.
+      caller's [runtime_manifest_context]; takes the current
+      [turn_state] and returns the updated state with the manifest
+      decision appended. Called once per outcome.
+    @param turn_state Immutable turn-state accumulator at phase-gate
+      entry. The returned state reflects any manifest decision appended
+      by the gate.
     @param registry_base_path Pre-resolved [config.base_path] reused
       from the caller's setup. *)

--- a/lib/keeper/keeper_unified_turn_retry_setup.ml
+++ b/lib/keeper/keeper_unified_turn_retry_setup.ml
@@ -3,9 +3,8 @@ type retry_setup =
   ; turn_started_at : float
   ; turn_deadline : float
   ; remaining_turn_budget_s : unit -> float
-  ; retry_phase_started_at : float option ref
   ; elapsed_ms : float -> int
-  ; current_turn_phase_elapsed_ms : unit -> int * int option
+  ; current_turn_phase_elapsed_ms : float option -> int * int option
   ; keeper_profile : Keeper_types_profile.keeper_profile_defaults
   ; max_idle_turns : int
   ; max_turns : int
@@ -16,11 +15,10 @@ let build ~now ~keeper_name ~channel ~turn_affordances =
   let turn_started_at = now () in
   let turn_deadline = turn_started_at +. timeout_sec in
   let remaining_turn_budget_s () = Float.max 0.0 (turn_deadline -. now ()) in
-  let retry_phase_started_at = ref None in
   let elapsed_ms seconds = int_of_float (Float.max 0.0 seconds *. 1000.0) in
-  let current_turn_phase_elapsed_ms () =
+  let current_turn_phase_elapsed_ms retry_phase_started_at =
     let now_s = now () in
-    match !retry_phase_started_at with
+    match retry_phase_started_at with
     | None -> elapsed_ms (now_s -. turn_started_at), Some 0
     | Some retry_started_at ->
       ( elapsed_ms (retry_started_at -. turn_started_at)
@@ -42,7 +40,6 @@ let build ~now ~keeper_name ~channel ~turn_affordances =
   ; turn_started_at
   ; turn_deadline
   ; remaining_turn_budget_s
-  ; retry_phase_started_at
   ; elapsed_ms
   ; current_turn_phase_elapsed_ms
   ; keeper_profile

--- a/lib/keeper/keeper_unified_turn_retry_setup.mli
+++ b/lib/keeper/keeper_unified_turn_retry_setup.mli
@@ -8,9 +8,8 @@ type retry_setup =
   ; turn_started_at : float
   ; turn_deadline : float
   ; remaining_turn_budget_s : unit -> float
-  ; retry_phase_started_at : float option ref
   ; elapsed_ms : float -> int
-  ; current_turn_phase_elapsed_ms : unit -> int * int option
+  ; current_turn_phase_elapsed_ms : float option -> int * int option
   ; keeper_profile : Keeper_types_profile.keeper_profile_defaults
   ; max_idle_turns : int
   ; max_turns : int

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -5,6 +5,24 @@
     Re-included from Keeper_unified_turn so existing callers continue to
     use [Keeper_unified_turn.<name>] unchanged. *)
 
+module StringMap = Set_util.StringMap
+
+(** Immutable per-turn accumulator that replaces the casual [ref] cells
+    previously threaded through [run_keeper_cycle] and the retry loop. *)
+type turn_state =
+  { cycle_completed : bool
+  ; manifest_seq : int
+  ; post_commit_failure_reason : Keeper_registry.failure_reason option
+  ; paused_meta_override : Keeper_meta_contract.keeper_meta option
+  ; current_turn_blocker_info : Keeper_meta_contract.blocker_info option
+  ; last_execution : Keeper_turn_runtime_budget.runtime_execution option
+  ; last_provider_timeout_budget : Keeper_turn_runtime_budget.provider_timeout_budget option
+  ; degraded_retry_info : Keeper_error_classify.degraded_retry option
+  ; runtime_rotation_attempts : Keeper_execution_receipt.runtime_rotation_attempt list
+  ; failure_reason : Keeper_turn_fsm.failure_reason option
+  ; retry_phase_started_at : float option
+  }
+
 let turn_event_bus_manifest_decision
       (summary : Keeper_turn_runtime_budget.turn_event_bus_summary)
   =
@@ -189,16 +207,17 @@ let registry_failure_reason_of_terminal_reason
 ;;
 
 (** Tracker for matching ToolCalled/ToolCompleted event pairs within a
-    single keeper turn. Internal mutability ([Hashtbl] + [Queue] + mutable
-    fields); external API is pure-ish (push/pop are O(1) imperative). *)
+    single keeper turn. Pure immutable accumulator: a map from tool name to
+    the FIFO list of pending inputs, a list of committed mutating tools, and
+    the first integrity error observed while matching events. *)
 type turn_tool_event_tracker =
-  { pending_tool_inputs : (string, Yojson.Safe.t Queue.t) Hashtbl.t
-  ; mutable mutating_tools_committed : string list
-  ; mutable integrity_error : Agent_sdk.Error.sdk_error option
+  { pending_tool_inputs : Yojson.Safe.t list StringMap.t
+  ; mutating_tools_committed : string list
+  ; integrity_error : Agent_sdk.Error.sdk_error option
   }
 
 let create_turn_tool_event_tracker () =
-  { pending_tool_inputs = Hashtbl.create 8
+  { pending_tool_inputs = StringMap.empty
   ; mutating_tools_committed = []
   ; integrity_error = None
   }
@@ -211,21 +230,24 @@ let committed_mutating_tools_from_events tracker =
 ;;
 
 let push_turn_tool_input tracker tool_name input =
-  let q =
-    match Hashtbl.find_opt tracker.pending_tool_inputs tool_name with
-    | Some q -> q
-    | None ->
-      let q = Queue.create () in
-      Hashtbl.add tracker.pending_tool_inputs tool_name q;
-      q
+  let inputs =
+    match StringMap.find_opt tool_name tracker.pending_tool_inputs with
+    | Some inputs -> inputs @ [ input ]
+    | None -> [ input ]
   in
-  Queue.add input q
+  { tracker with pending_tool_inputs = StringMap.add tool_name inputs tracker.pending_tool_inputs }
 ;;
 
 let pop_turn_tool_input tracker tool_name =
-  match Hashtbl.find_opt tracker.pending_tool_inputs tool_name with
-  | Some q when not (Queue.is_empty q) -> Some (Queue.pop q)
-  | _ -> None
+  match StringMap.find_opt tool_name tracker.pending_tool_inputs with
+  | Some (input :: rest) ->
+    let pending =
+      match rest with
+      | [] -> StringMap.remove tool_name tracker.pending_tool_inputs
+      | _ -> StringMap.add tool_name rest tracker.pending_tool_inputs
+    in
+    Some input, { tracker with pending_tool_inputs = pending }
+  | _ -> None, tracker
 ;;
 
 let record_unmatched_tool_completed
@@ -247,10 +269,13 @@ let record_unmatched_tool_completed
   let mutating_tool_committed =
     tool_committed && Keeper_tool_dispatch_runtime.has_mutating_side_effect tool_name
   in
-  if mutating_tool_committed
-  then tracker.mutating_tools_committed <- tool_name :: tracker.mutating_tools_committed;
+  let tracker =
+    if mutating_tool_committed
+    then { tracker with mutating_tools_committed = tool_name :: tracker.mutating_tools_committed }
+    else tracker
+  in
   match tracker.integrity_error with
-  | Some _ -> ()
+  | Some _ -> tracker
   | None ->
     let base_error = Agent_sdk.Error.Internal message in
     let error =
@@ -258,7 +283,7 @@ let record_unmatched_tool_completed
       then Keeper_error_classify.reclassify_error_after_side_effect ~tool_names:[ tool_name ] base_error
       else base_error
     in
-    tracker.integrity_error <- Some error
+    { tracker with integrity_error = Some error }
 ;;
 
 let record_turn_tool_events
@@ -267,21 +292,20 @@ let record_turn_tool_events
       ~(keeper_name : string)
       (tracker : turn_tool_event_tracker)
       (events : Agent_sdk.Event_bus.event list)
-  : unit
+  : turn_tool_event_tracker
   =
-  List.iter
-    (fun (evt : Agent_sdk.Event_bus.event) ->
+  List.fold_left
+    (fun tracker (evt : Agent_sdk.Event_bus.event) ->
        match evt.payload with
        | Agent_sdk.Event_bus.ToolCalled { tool_name; input; _ } ->
          push_turn_tool_input tracker tool_name input
        | Agent_sdk.Event_bus.ToolCompleted { tool_name; output = Ok _; _ } ->
          (match pop_turn_tool_input tracker tool_name with
-          | Some input ->
+          | Some input, tracker ->
             if has_mutating_side_effect_with_input ~tool_name ~input
-            then
-              tracker.mutating_tools_committed
-              <- tool_name :: tracker.mutating_tools_committed
-          | None ->
+            then { tracker with mutating_tools_committed = tool_name :: tracker.mutating_tools_committed }
+            else tracker
+          | None, tracker ->
             record_unmatched_tool_completed
               tracker
               ~keeper_name
@@ -290,15 +314,16 @@ let record_turn_tool_events
               ~tool_committed:true)
        | Agent_sdk.Event_bus.ToolCompleted { tool_name; output = Error _; _ } ->
          (match pop_turn_tool_input tracker tool_name with
-          | Some _ -> ()
-          | None ->
+          | Some _, tracker -> tracker
+          | None, tracker ->
             record_unmatched_tool_completed
               tracker
               ~keeper_name
               ~tool_name
               ~outcome:"error"
               ~tool_committed:false)
-       | _ -> ())
+       | _ -> tracker)
+    tracker
     events
 ;;
 

--- a/lib/keeper/keeper_unified_turn_types.mli
+++ b/lib/keeper/keeper_unified_turn_types.mli
@@ -6,6 +6,22 @@
     Keeper_unified_turn. Re-included by it so existing callers continue
     to use [Keeper_unified_turn.<name>] unchanged. *)
 
+(** Immutable per-turn accumulator that replaces the casual [ref] cells
+    previously threaded through [run_keeper_cycle] and the retry loop. *)
+type turn_state =
+  { cycle_completed : bool
+  ; manifest_seq : int
+  ; post_commit_failure_reason : Keeper_registry.failure_reason option
+  ; paused_meta_override : Keeper_meta_contract.keeper_meta option
+  ; current_turn_blocker_info : Keeper_meta_contract.blocker_info option
+  ; last_execution : Keeper_turn_runtime_budget.runtime_execution option
+  ; last_provider_timeout_budget : Keeper_turn_runtime_budget.provider_timeout_budget option
+  ; degraded_retry_info : Keeper_error_classify.degraded_retry option
+  ; runtime_rotation_attempts : Keeper_execution_receipt.runtime_rotation_attempt list
+  ; failure_reason : Keeper_turn_fsm.failure_reason option
+  ; retry_phase_started_at : float option
+  }
+
 val turn_event_bus_manifest_decision :
   Keeper_turn_runtime_budget.turn_event_bus_summary -> Yojson.Safe.t
 
@@ -20,45 +36,50 @@ val registry_failure_reason_of_terminal_reason :
   Keeper_registry.failure_reason option
 
 (** Tracker for matching ToolCalled/ToolCompleted event pairs within a
-    single keeper turn. *)
-type turn_tool_event_tracker = {
-  pending_tool_inputs : (string, Yojson.Safe.t Queue.t) Hashtbl.t;
-  mutable mutating_tools_committed : string list;
-  mutable integrity_error : Agent_sdk.Error.sdk_error option;
-}
+    single keeper turn. The value is an immutable accumulator; every
+    operation returns an updated tracker. *)
+type turn_tool_event_tracker
 
 val create_turn_tool_event_tracker : unit -> turn_tool_event_tracker
 val turn_tool_event_integrity_error :
   turn_tool_event_tracker -> Agent_sdk.Error.sdk_error option
 val committed_mutating_tools_from_events :
   turn_tool_event_tracker -> string list
+
+(** Append [input] to the pending FIFO queue for [tool_name]. Returns the
+    updated tracker. *)
 val push_turn_tool_input :
-  turn_tool_event_tracker -> string -> Yojson.Safe.t -> unit
+  turn_tool_event_tracker -> string -> Yojson.Safe.t -> turn_tool_event_tracker
+
+(** Remove and return the oldest pending input for [tool_name], or [None]
+    if the queue is empty. Returns the updated tracker as the second
+    component. *)
 val pop_turn_tool_input :
-  turn_tool_event_tracker -> string -> Yojson.Safe.t option
+  turn_tool_event_tracker -> string -> Yojson.Safe.t option * turn_tool_event_tracker
 
 (** Record an unmatched [ToolCompleted] (no prior [ToolCalled]) into the
     tracker. Logs an integrity error via [Log.Keeper.error], appends to
-    [tracker.mutating_tools_committed] when [tool_committed] AND the tool
-    has a mutating side-effect, and stores the first observed integrity
-    error in [tracker.integrity_error]. *)
+    the committed mutating tools when [tool_committed] AND the tool has a
+    mutating side-effect, and stores the first observed integrity error.
+    Returns the updated tracker. *)
 val record_unmatched_tool_completed :
   turn_tool_event_tracker ->
   keeper_name:string ->
   tool_name:string ->
   outcome:string ->
   tool_committed:bool ->
-  unit
+  turn_tool_event_tracker
 
 (** Drive the tracker over a batch of [Agent_sdk.Event_bus.event]s,
     matching [ToolCalled] <-> [ToolCompleted] pairs and recording
-    integrity violations + committed mutating tools. *)
+    integrity violations + committed mutating tools. Returns the updated
+    tracker. *)
 val record_turn_tool_events :
   ?has_mutating_side_effect_with_input:(tool_name:string -> input:Yojson.Safe.t -> bool) ->
   keeper_name:string ->
   turn_tool_event_tracker ->
   Agent_sdk.Event_bus.event list ->
-  unit
+  turn_tool_event_tracker
 
 (** Record the observation for a streaming turn cancelled externally.
     Reads the fiber_stop flag from [Keeper_registry], emits FSM


### PR DESCRIPTION
## Summary

Replace careless mutable state in the keeper turn lifecycle with safe immutable patterns threaded explicitly through the turn loop.

## Changes

- Introduce an immutable `turn_state` record in `Keeper_unified_turn_types` and thread it through `run_keeper_cycle` and the retry loop, replacing casual `ref` accumulators:
  - `cycle_completed`, `manifest_seq`, `post_commit_failure_reason`, `paused_meta_override`
  - `current_turn_blocker_info`, `last_execution`, `last_provider_timeout_budget`
  - `degraded_retry_info`, `runtime_rotation_attempts`, `failure_reason`, `retry_phase_started_at`
- Convert `turn_tool_event_tracker` from mutable `Hashtbl`/`Queue`/mutable-list to an immutable `StringMap`-based value; all operations return updated trackers.
- Replace the mutable `turn_event_bus_summary ref` + `Eio.Mutex.t` in `Keeper_unified_turn_event_bus` with an `Atomic.t` of an immutable `{ summary; tracker }` state. `drain_cancel` stays a `ref` because it holds an Eio resource handle.
- Replace the captured `paused_meta` `ref` and the `Hashtbl` + mutex log-dedup cache in `Keeper_turn_runtime_budget` with `Atomic.t`-backed immutable state.

## Verification

- [x] `scripts/dune-local.sh build @check` passes
- [x] Relevant keeper turn tests pass:
  - `test/test_keeper_turn_disposition.ml`
  - `test/test_keeper_unified_tool_event_order_source.ml`
  - `test/test_runtime_per_keeper_routing.ml`
  - `test/test_keeper_unified_context_overflow.ml`

## Notes

Build run with `MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1` because the current opam switch had drifted from this worktree's pinned `agent_sdk` commit.
