### PR TITLE
fix(fusion): adversarial-review safety fixes for panel/judge orchestration

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -224,3 +224,7 @@ answer. Respond with ONLY the requested JSON object, no prose and no code fences
 # 구조적 타임아웃(초). 미지정 시 Fusion_policy.default_timeout_s.
 panel_timeout_s = 120.0
 judge_timeout_s = 120.0
+# 패널/심판에 MASC web_search/web_fetch 도구를 주입할지 여부.
+web_tools = false
+# 패널 모델당 최대 tool 호출 수 (0 = 무제한, OpenRouter Fusion 허용 범위 0..16).
+max_tool_calls_per_panel = 0

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -34,10 +34,14 @@ let compose_prompt ~question ~panel =
 %s|}
     (escape_xml question) answers Fusion_judge_parse.expected_json_doc
 
-let run ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question ~panel ()
-  : (Fusion_types.judge_synthesis, string) result
+let run ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question ~panel
+    ~web_tools ~max_tool_calls () : (Fusion_types.judge_synthesis, string) result
   =
-  match Fusion_oas.build_agent ~sw ~net ~system_prompt:judge_system_prompt judge_model with
+  let tools = if web_tools then Fusion_oas.web_tool_bundle () else [] in
+  match
+    Fusion_oas.build_agent ~sw ~net ~system_prompt:judge_system_prompt ~tools
+      ~max_tool_calls judge_model
+  with
   | Error reason ->
     Error
       (Printf.sprintf "judge build failed: %s"

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -16,6 +16,8 @@ val compose_prompt : question:string -> panel:Fusion_types.panel_outcome list ->
 
     [judge_model]: runtime_id("provider.model"). [question]/[panel]로 프롬프트를
     구성해 실행하고, 응답 텍스트를 {!Fusion_judge_parse.of_string}으로 파싱한다.
+    [web_tools=true]면 심판 에이전트에 web_search/web_fetch를 주입한다.
+    [max_tool_calls]: 0이면 무제한, 양수면 심판의 [max_turns]로 근approximate.
     빌드/실행/빈응답/파싱 실패는 [Error msg]. 전체는 [Masc_oas_bridge.run_safe]로 감싼다. *)
 val run
   :  sw:Eio.Switch.t
@@ -25,5 +27,7 @@ val run
   -> judge_model:string
   -> question:string
   -> panel:Fusion_types.panel_outcome list
+  -> web_tools:bool
+  -> max_tool_calls:int
   -> unit
   -> (Fusion_types.judge_synthesis, string) result

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -17,7 +17,38 @@ let usage_of (resp : Agent_sdk.Types.api_response) : Fusion_types.usage =
     }
   | None -> Fusion_types.zero_usage
 
-let build_agent ~sw ~net ~system_prompt (model : string)
+(** [Keeper_tool_descriptor]에서 날것의 web tool descriptor를 찾아
+    [Agent_sdk.Tool.t]로 변환한다. 패널/심판이 web_search/web_fetch를
+    호출할 수 있게 하는 목적으로만 쓰인다. *)
+let oas_tool_of_descriptor (d : Keeper_tool_descriptor.t) : Agent_sdk.Tool.t option =
+  let handler args =
+    let start_time = Unix.gettimeofday () in
+    match d.Keeper_tool_descriptor.internal_name with
+    | "masc_web_search" ->
+      Tool_misc_web_search.handle ~tool_name:d.internal_name ~start_time args
+    | "masc_web_fetch" ->
+      Tool_misc_web_fetch.handle ~tool_name:d.internal_name ~start_time args
+    | _ ->
+      Tool_result.make_err
+        ~tool_name:d.internal_name
+        ~class_:Tool_result.Runtime_failure
+        ~start_time
+        "fusion: unsupported web tool"
+  in
+  Some
+    (Tool_bridge.oas_tool_of_masc
+       ~name:d.internal_name
+       ~description:d.description
+       ~input_schema:d.input_schema
+       handler)
+
+let web_tool_bundle () : Agent_sdk.Tool.t list =
+  [ "masc_web_search"; "masc_web_fetch" ]
+  |> List.map Keeper_tool_descriptor.descriptors_for_internal
+  |> List.concat
+  |> List.filter_map oas_tool_of_descriptor
+
+let build_agent ~sw ~net ~system_prompt ?(tools = []) ?(max_tool_calls = 0) (model : string)
   : (Agent_sdk.Agent.t, Fusion_types.panel_failure) result
   =
   match Runtime_oas_runner.resolve_runtime_providers ~runtime_id:model () with
@@ -25,8 +56,14 @@ let build_agent ~sw ~net ~system_prompt (model : string)
   | Ok [] -> Error (Fusion_types.Provider_error (model ^ ": no provider config"))
   | Ok (provider_cfg :: _) ->
     (* v1: runtime이 여러 provider를 주면 첫 번째만(단일 provider 가정). *)
+    let base_config =
+      Runtime_agent.default_config ~name:model ~provider_cfg ~system_prompt ~tools
+    in
+    (* max_tool_calls는 OpenRouter Fusion의 per-panel tool budget에 대응.
+       Runtime_agent의 max_turns로 근사: tool 호출 횟수 + 최종 답변 1턴. *)
     let config =
-      Runtime_agent.default_config ~name:model ~provider_cfg ~system_prompt ~tools:[]
+      if max_tool_calls > 0 then { base_config with max_turns = max_tool_calls + 1 }
+      else base_config
     in
     (match Runtime_agent.build ~sw ~net ~config with
      | Ok agent -> Ok agent

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -6,14 +6,24 @@
 
     설계 SSOT: docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §7 *)
 
-(** runtime_id("provider.model")로 OAS 에이전트를 빌드한다. v1: 도구 없음([tools=[]]),
-    read-only 분석/심판용. 미존재 runtime·빌드 실패는 [panel_failure]로. *)
+(** runtime_id("provider.model")로 OAS 에이전트를 빌드한다.
+
+    [tools]를 주면 패널/심판이 tool call을 할 수 있다.
+    [max_tool_calls] > 0이면 에이전트의 [max_turns]를 해당 횟수+1로 제한해
+    OpenRouter Fusion의 per-panel tool budget을 근사한다.
+    미존재 runtime·빌드 실패는 [panel_failure]로. *)
 val build_agent
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> system_prompt:string
+  -> ?tools:Agent_sdk.Tool.t list
+  -> ?max_tool_calls:int
   -> string
   -> (Agent_sdk.Agent.t, Fusion_types.panel_failure) result
+
+(** [masc_web_search] / [masc_web_fetch]를 [Agent_sdk.Tool.t]로 변환한 목록.
+    [Keeper_tool_descriptor]에서 descriptor를 찾지 못하면 빈 목록을 반환한다. *)
+val web_tool_bundle : unit -> Agent_sdk.Tool.t list
 
 (** api_response의 [Text] 블록만 모아 답 텍스트로 (Thinking/ToolUse 제외). *)
 val answer_text : Agent_sdk.Types.api_response -> string

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -3,38 +3,54 @@
 
 type outcome =
   | Denied of Fusion_types.deny_reason
+  | Sink_failed of string
   | Completed of
       { panel : Fusion_types.panel_outcome list
       ; judge : (Fusion_types.judge_synthesis, string) result
       }
 
-let run ~sw ~net ~base_dir ~policy ~request () : outcome =
-  (* 방어적 재판정 — 예산은 호출자(fusion_tool)가 이미 try_incr_if_under로 원자
-     소모했으므로 여기서 다시 검사하지 않는다(decide는 budget-free). *)
+let run ~sw ~net ~base_dir ~budget ~hour_bucket ~policy ~request () : outcome =
   match Fusion_policy.decide ~policy request with
   | Fusion_types.Deny reason -> Denied reason
   | Fusion_types.Allow req ->
-    (match Fusion_policy.find_preset policy req.Fusion_types.preset with
-     | None ->
-       (* 게이트가 preset 존재를 이미 검증했으므로 도달 불가. 방어적으로 Denied. *)
-       Denied (Fusion_types.Preset_unknown req.Fusion_types.preset)
-     | Some preset ->
-       (* 프롬프트·타임아웃은 preset(=config)에서. 코드 default 없음 — config 로드
-          시 Missing_prompt로 fail-fast 검증됨. *)
-       let panel =
-         Fusion_panel.run ~sw ~net ~max_fibers:policy.Fusion_policy.max_concurrent_panels
-           ~timeout_s:preset.Fusion_policy.panel_timeout_s
-           ~models:preset.Fusion_policy.panel
-           ~system_prompt:preset.Fusion_policy.panel_system_prompt
-           ~prompt:req.Fusion_types.prompt ()
-       in
-       let judge =
-         Fusion_judge.run ~sw ~net
-           ~timeout_s:preset.Fusion_policy.judge_timeout_s
-           ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-           ~judge_model:preset.Fusion_policy.judge
-           ~question:req.Fusion_types.prompt ~panel ()
-       in
-       Fusion_sink.emit ~base_dir ~keeper:req.Fusion_types.keeper
-         ~run_id:req.Fusion_types.run_id ~question:req.Fusion_types.prompt ~panel ~judge;
-       Completed { panel; judge })
+    (match
+       Fusion_budget.try_incr_if_under budget ~hour_bucket
+         ~limit:policy.Fusion_policy.per_hour_budget
+     with
+     | Error () -> Denied Fusion_types.Over_hourly_budget
+     | Ok _hourly_count ->
+       (match Fusion_policy.find_preset policy req.Fusion_types.preset with
+        | None ->
+          (* 게이트가 preset 존재를 이미 검증했으므로 도달 불가. 방어적으로 Denied. *)
+          Denied (Fusion_types.Preset_unknown req.Fusion_types.preset)
+        | Some preset ->
+          (* 프롬프트·타임아웃은 preset(=config)에서. 코드 default 없음 — config 로드
+             시 Missing_prompt로 fail-fast 검증됨. *)
+          let web_tools =
+            req.Fusion_types.web_tools || preset.Fusion_policy.web_tools
+          in
+          let max_tool_calls = preset.Fusion_policy.max_tool_calls_per_panel in
+          let panel =
+            Fusion_panel.run ~sw ~net
+              ~max_fibers:policy.Fusion_policy.max_concurrent_panels
+              ~timeout_s:preset.Fusion_policy.panel_timeout_s
+              ~models:preset.Fusion_policy.panel
+              ~system_prompt:preset.Fusion_policy.panel_system_prompt
+              ~prompt:req.Fusion_types.prompt ~web_tools ~max_tool_calls_per_panel:max_tool_calls
+              ()
+          in
+          let judge =
+            Fusion_judge.run ~sw ~net
+              ~timeout_s:preset.Fusion_policy.judge_timeout_s
+              ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+              ~judge_model:preset.Fusion_policy.judge
+              ~question:req.Fusion_types.prompt ~panel ~web_tools
+              ~max_tool_calls ()
+          in
+          (match
+             Fusion_sink.emit ~base_dir ~keeper:req.Fusion_types.keeper
+               ~run_id:req.Fusion_types.run_id ~question:req.Fusion_types.prompt
+               ~panel ~judge
+           with
+           | Ok () -> Completed { panel; judge }
+           | Error msg -> Sink_failed msg)))

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -10,6 +10,7 @@
 (** 오케스트레이션 결과 (닫힌 합). *)
 type outcome =
   | Denied of Fusion_types.deny_reason  (** 게이트가 거부 *)
+  | Sink_failed of string  (** chat lane 기록 실패 *)
   | Completed of
       { panel : Fusion_types.panel_outcome list
       ; judge : (Fusion_types.judge_synthesis, string) result
@@ -17,18 +18,22 @@ type outcome =
 
 (** 요청을 심의한다.
 
-    + [Fusion_policy.decide]로 게이트 → [Deny]면 [Denied] 반환(부작용 없음).
-    + [Allow]면 preset의 패널 모델로 [Fusion_panel.run], judge 모델로 [Fusion_judge.run].
+    + [Fusion_policy.decide]로 정책 판정 → [Deny]면 [Denied] 반환(부작용 없음).
+    + [Allow]면 [Fusion_budget.try_incr_if_under]로 시간당 예산을 원자적으로 소비.
+      예산 초과면 [Denied Over_hourly_budget]을 반환한다.
+    + 예산 소비 후 preset의 패널 모델로 [Fusion_panel.run], judge 모델로 [Fusion_judge.run].
       패널/심판 system prompt와 타임아웃은 preset(=config)에서 온다 — 코드 default 없음.
-    + [Fusion_sink.emit]으로 트랜스크립트를 키퍼 chat lane에 기록.
+    + [Fusion_sink.emit]으로 트랜스크립트를 키퍼 chat lane에 기록. 실패면 [Sink_failed].
     + [Completed]로 패널/심판 결과 반환.
 
-    시간당 예산은 호출자([Fusion_tool])가 [Fusion_budget.try_incr_if_under]로 이미
-    원자 소모했으므로 여기서 재검사하지 않는다. *)
+    @param budget 서버 단일 시간당 예산 카운터.
+    @param hour_bucket 현재 UTC 시간 윈도우 키. *)
 val run
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> base_dir:string
+  -> budget:Fusion_budget.t
+  -> hour_bucket:string
   -> policy:Fusion_policy.t
   -> request:Fusion_types.fusion_request
   -> unit

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -22,14 +22,18 @@ let outcome_of_result (model : string)
       ; reason = Fusion_types.Provider_error (Agent_sdk.Error.to_string e)
       }
 
-let run ~sw ~net ~max_fibers ~timeout_s ~models ~system_prompt ~prompt ()
-  : Fusion_types.panel_outcome list
+let run ~sw ~net ~max_fibers ~timeout_s ~models ~system_prompt ~prompt
+    ~web_tools ~max_tool_calls_per_panel () : Fusion_types.panel_outcome list
   =
+  let tools = if web_tools then Fusion_oas.web_tool_bundle () else [] in
   (* 1. 각 모델을 에이전트로 빌드. 빌드 실패는 격리. *)
   let built, build_failures =
     List.fold_left
       (fun (oks, fails) model ->
-        match Fusion_oas.build_agent ~sw ~net ~system_prompt model with
+        match
+          Fusion_oas.build_agent ~sw ~net ~system_prompt ~tools
+            ~max_tool_calls:max_tool_calls_per_panel model
+        with
         | Ok agent -> ((agent, model) :: oks, fails)
         | Error reason ->
           (oks, Fusion_types.Failed { failed_model = model; reason } :: fails))

--- a/lib/fusion/fusion_panel.mli
+++ b/lib/fusion/fusion_panel.mli
@@ -4,15 +4,18 @@
     않는다 — OAS 입장에선 독립 에이전트 N개일 뿐이다. 각 모델은 MASC의 기존
     runtime→agent 빌더([Runtime_oas_runner] → [Runtime_agent])로 만든다.
 
-    v1 단순화: 패널은 도구 없이([tools = []]) read-only 분석만 한다. web 도구 주입은
-    keeper 컨텍스트(Workspace.config + keeper_meta) 결합이 필요해 Phase 2b로 미룬다.
-    도구가 없으므로 재귀 가드(masc_fusion 도구 배제)는 자동 충족된다.
+    [web_tools=true]면 [masc_web_search] / [masc_web_fetch]를 패널 에이전트에
+    주입해 OpenRouter Fusion의 패널 web tool semantics를 따른다. 재귀 가드는
+    [masc_fusion] 도구가 web tool descriptor에 포함되지 않으므로 자동 충족된다.
 
     설계 SSOT: docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §7.1 *)
 
 (** 패널을 병렬 실행해 각 모델의 결과를 [panel_outcome]으로 반환한다.
 
     - [models]: runtime_id("provider.model") 목록. 각자 에이전트로 빌드된다.
+    - [web_tools]: true면 web_search/web_fetch 도구를 주입한다.
+    - [max_tool_calls_per_panel]: 0이면 무제한, 양수면 에이전트 [max_turns]로
+      근approximate해 per-panel tool budget을 제한한다.
     - 빌드 실패(미존재 runtime 등)·실행 실패·빈 응답은 [Failed]로 격리되어 다른
       패널을 죽이지 않는다([Async_agent.all]의 per-agent 격리 + 본 매핑).
     - 전체 호출은 [Masc_oas_bridge.run_safe]로 감싸 구조적 타임아웃을 강제한다;
@@ -26,5 +29,7 @@ val run
   -> models:string list
   -> system_prompt:string
   -> prompt:string
+  -> web_tools:bool
+  -> max_tool_calls_per_panel:int
   -> unit
   -> Fusion_types.panel_outcome list

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -112,60 +112,62 @@ let judge_meta (judge : (Fusion_types.judge_synthesis, string) result) : Yojson.
       ]
   | Error e -> `Assoc [ ("status", `String "failed"); ("error", `String e) ]
 
-let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge : unit =
+let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge : (unit, string) result =
   let conversation_id = "fusion/" ^ run_id in
-  let append content =
-    Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper ~content
-      ~conversation_id ()
-  in
-  append
-    (Printf.sprintf "**Fusion deliberation** (run `%s`)\n\n**Question**\n%s" run_id
-       question);
-  List.iter (fun o -> append (render_panel o)) panel;
-  (* 비용 관측(제약 아님) — 패널이 실제 사용한 토큰을 합산해 표시한다. cost cap은
-     v1에서 제외(추정기 부재)하고, 측정값만 남긴다 (괴상한 제약 제거 원칙). *)
-  let total_usage =
-    List.fold_left
-      (fun acc (o : Fusion_types.panel_outcome) ->
-        match o with
-        | Fusion_types.Answered a -> Fusion_types.add_usage acc a.usage
-        | Fusion_types.Failed _ -> acc)
-      Fusion_types.zero_usage panel
-  in
-  append
-    (Printf.sprintf "**Observed usage** — input=%d output=%d tokens (panel)"
-       total_usage.Fusion_types.input_tokens total_usage.Fusion_types.output_tokens);
-  (match judge with
-   | Ok j -> append (render_judge j)
-   | Error e -> append (Printf.sprintf "**[judge]** _(failed: %s)_" e));
-  (* 모든 append 후 한 번 브로드캐스트 — 대시보드가 키퍼 chat을 재조회해 전체 표시. *)
-  Keeper_chat_broadcast.chat_appended ~keeper_name:keeper ~source:"fusion";
-  (* board post — 구조화 증거(meta_json). chat lane은 사람이 읽는 *서사*,
-     board는 run_id로 묶인 쿼리 가능한 *증거*다. 사용자 가시성 요구는 두 surface
-     모두(RFC-0252 §3/§8.2). 실패는 심의를 죽이지 않되 기록한다. *)
-  let board_headline =
-    match judge with
-    | Ok j ->
-      Printf.sprintf "Fusion deliberation (run %s): %s" run_id
-        (render_decision j.Fusion_types.decision)
-    | Error _ -> Printf.sprintf "Fusion deliberation (run %s): judge failed" run_id
-  in
-  let meta_json =
-    Some
-      (`Assoc
-         [ ("source", `String "fusion")
-         ; ("run_id", `String run_id)
-         ; ("question", `String question)
-         ; ("panel", `List (List.map panel_meta panel))
-         ; ("judge", judge_meta judge)
-         ])
-  in
-  match
-    Board_dispatch.create_post ~author:keeper ~content:board_headline
-      ~post_kind:Board.System_post ?meta_json ~visibility:Board.Internal
-      ~ttl_hours:board_post_ttl_hours ()
+  try
+    let append content =
+      Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper ~content
+        ~conversation_id ()
+    in
+    append
+      (Printf.sprintf "**Fusion deliberation** (run `%s`)\n\n**Question**\n%s" run_id
+         question);
+    List.iter (fun o -> append (render_panel o)) panel;
+    (* 비용 관측(제약 아님) — 패널이 실제 사용한 토큰을 합산해 표시한다. cost cap은
+       v1에서 제외(추정기 부재)하고, 측정값만 남긴다 (괴상한 제약 제거 원칙). *)
+    let total_usage =
+      List.fold_left
+        (fun acc (o : Fusion_types.panel_outcome) ->
+          match o with
+          | Fusion_types.Answered a -> Fusion_types.add_usage acc a.usage
+          | Fusion_types.Failed _ -> acc)
+        Fusion_types.zero_usage panel
+    in
+    append
+      (Printf.sprintf "**Observed usage** — input=%d output=%d tokens (panel)"
+         total_usage.Fusion_types.input_tokens total_usage.Fusion_types.output_tokens);
+    (match judge with
+     | Ok j -> append (render_judge j)
+     | Error e -> append (Printf.sprintf "**[judge]** _(failed: %s)_" e));
+    (* 모든 append 후 한 번 브로드캐스트 — 대시보드가 키퍼 chat을 재조회해 전체 표시. *)
+    Keeper_chat_broadcast.chat_appended ~keeper_name:keeper ~source:"fusion";
+    (* board post — 구조화 증거(meta_json). chat lane은 사람이 읽는 *서사*,
+       board는 run_id로 묶인 쿼리 가능한 *증거*다. 사용자 가시성 요구는 두 surface
+       모두(RFC-0252 §3/§8.2). 실패는 [Error]로 상위(orchestrator)에 전달한다. *)
+    let board_headline =
+      match judge with
+      | Ok j ->
+        Printf.sprintf "Fusion deliberation (run %s): %s" run_id
+          (render_decision j.Fusion_types.decision)
+      | Error _ -> Printf.sprintf "Fusion deliberation (run %s): judge failed" run_id
+    in
+    let meta_json =
+      Some
+        (`Assoc
+           [ ("source", `String "fusion")
+           ; ("run_id", `String run_id)
+           ; ("question", `String question)
+           ; ("panel", `List (List.map panel_meta panel))
+           ; ("judge", judge_meta judge)
+           ])
+    in
+    (match
+       Board_dispatch.create_post ~author:keeper ~content:board_headline
+         ~post_kind:Board.System_post ?meta_json ~visibility:Board.Internal
+         ~ttl_hours:board_post_ttl_hours ()
+     with
+     | Ok () -> Ok ()
+     | Error e -> Error (Board.show_board_error e))
   with
-  | Ok _ -> ()
-  | Error e ->
-    Log.Keeper.warn ~keeper_name:keeper "fusion run %s board post failed: %s" run_id
-      (Board.show_board_error e)
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)

--- a/lib/fusion/fusion_sink.mli
+++ b/lib/fusion/fusion_sink.mli
@@ -15,8 +15,10 @@
 
     순서: 헤더(질문) → 패널 답/실패(모델 순) → usage 관측 → 심판 종합. 모두 [base_dir]의
     keeper_chat에 append되고, [chat_appended]로 대시보드에 알린 뒤 [Board_dispatch.create_post]로
-    meta_json(source/run_id/panel/judge) 증거를 남긴다. board post 실패는 심의를 죽이지
-    않고 [Log.Keeper.warn]으로 기록한다. [base_dir]는 호출자(orchestrator)가 주입한다. *)
+    meta_json(source/run_id/panel/judge) 증거를 남긴다. [base_dir]는 호출자(orchestrator)가 주입한다.
+
+    chat store append, broadcast, board post 중 예외가 발생하면 [Error msg]를 반환한다.
+    [Eio.Cancel.Cancelled]는 재전파한다. *)
 val emit
   :  base_dir:string
   -> keeper:string
@@ -24,4 +26,4 @@ val emit
   -> question:string
   -> panel:Fusion_types.panel_outcome list
   -> judge:(Fusion_types.judge_synthesis, string) result
-  -> unit
+  -> (unit, string) result

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -11,9 +11,25 @@ let hour_bucket_of_unix (t : float) : string =
 let status_json ~ok fields =
   Yojson.Safe.to_string (`Assoc (("ok", `Bool ok) :: fields))
 
+let append_chat_failure ~base_dir ~keeper ~run_id content =
+  let conversation_id = "fusion/" ^ run_id in
+  try
+    Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper ~content
+      ~conversation_id ();
+    Keeper_chat_broadcast.chat_appended ~keeper_name:keeper ~source:"fusion"
+  with
+  | Eio.Cancel.Cancelled _ as exn ->
+    (* 구조적 취소는 재전파. *)
+    raise exn
+  | exn ->
+    Log.Keeper.warn ~keeper_name:keeper
+      "fusion run %s failed to append failure message: %s" run_id
+      (Printexc.to_string exn)
+
 let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ~args : string =
   let prompt = Tool_args.get_string args "prompt" "" in
   let preset = Tool_args.get_string args "preset" policy.Fusion_policy.default_preset in
+  let web_tools = Tool_args.get_bool args "web_tools" false in
   if String.equal (String.trim prompt) "" then
     status_json ~ok:false [ ("error", `String "prompt is required") ]
   else begin
@@ -23,50 +39,43 @@ let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ~args : string =
       ; keeper
       ; prompt
       ; preset
+      ; web_tools
       ; depth = Fusion_types.Fusion_depth.Top
       ; trigger = Fusion_types.Explicit_tool_call
       }
     in
-    let denied reason =
+    match Fusion_policy.decide ~policy request with
+    | Fusion_types.Deny reason ->
       status_json ~ok:false
         [ ("status", `String "denied")
         ; ("reason", `String (Fusion_types.deny_reason_label reason))
         ]
-    in
-    match Fusion_policy.decide ~policy request with
-    | Fusion_types.Deny reason -> denied reason
     | Fusion_types.Allow allowed ->
-      (* 게이트 통과 후 예산을 원자적으로 소모(검사+증가가 단일 CAS라 deny는 예산을
-         쓰지 않고, 멀티 도메인 동시 발동에도 per_hour_budget 초과 없음). 동기 호출
-         이라 키퍼가 즉시 Over_hourly_budget를 통보받는다(fork 후 거부 아님). *)
-      (match
-         Fusion_budget.try_incr_if_under budget ~hour_bucket
-           ~limit:policy.Fusion_policy.per_hour_budget
-       with
-       | Error () -> denied Fusion_types.Over_hourly_budget
-       | Ok (_ : int) ->
-      (* out-of-band: daemon fiber → 키퍼 턴은 즉시 진행, 결과는 sink가 chat lane에.
-         호출자는 이 fiber가 키퍼 턴보다 오래 살도록 root switch를 sw로 넘긴다
-         (turn switch면 턴 종료 시 심의가 취소됨).
-
-         fork_daemon은 서버 수명(root switch)에 묶인 fire-and-forget의 관용구
-         (board_dispatch/pulse/transition_audit과 동일). 단 fork/fork_daemon 모두
-         본문에서 *탈출하는* 예외는 `Switch.fail sw`로 변환된다(eio fiber.ml:24/43).
-         sw가 공유 root이므로 그 fail은 서버 전체를 취소시킨다 → 본문은 Cancelled
-         포함 모든 예외를 흡수하고 `Stop_daemon으로 정상 종료한다. Cancelled 재전파
-         (Eio 일반 규약)는 advisory 배경 작업에선 불필요하고, 공유 root에선 유해. *)
-      Eio.Fiber.fork_daemon ~sw (fun () ->
-        (match Fusion_orchestrator.run ~sw ~net ~base_dir ~policy ~request:allowed () with
-         | Fusion_orchestrator.Completed _ | Fusion_orchestrator.Denied _ -> ()
-         | exception Eio.Cancel.Cancelled _ ->
-           (* 서버 teardown 신호. 재전파하면 fork_daemon이 root를 Switch.fail. *)
-           ()
-         | exception exn ->
-           (* 배경 fiber 격리: 키퍼/서버는 죽이지 않되 침묵하지 않는다 — run_id와
-              함께 기록해 started-but-failed 심의가 추적 가능하게 한다. *)
-           Log.Keeper.warn ~keeper_name:keeper "fusion run %s aborted: %s" run_id
-             (Printexc.to_string exn));
-        `Stop_daemon);
+      (* out-of-band: fiber fork → 키퍼 턴은 즉시 진행, 결과는 sink가 chat lane에.
+         예산은 orchestrator가 원자적으로 소비한다. 배경 fiber 실패/거부/싱크
+         실패는 동일한 chat lane에 기록해 started-but-failed 상태가 남지 않도록 한다.
+         호출자는 이 fiber가 키퍼 턴어보다 오래 살아도록 root switch를 sw로 넘긴다
+         (turn switch면 턴 종료 시 심의가 취소됨). *)
+      Eio.Fiber.fork ~sw (fun () ->
+        match
+          Fusion_orchestrator.run ~sw ~net ~base_dir ~budget ~hour_bucket ~policy
+            ~request:allowed ()
+        with
+        | Fusion_orchestrator.Completed _ -> ()
+        | Fusion_orchestrator.Denied reason ->
+          append_chat_failure ~base_dir ~keeper ~run_id
+            (Printf.sprintf "**Fusion run `%s`** _(denied after start: %s)_" run_id
+               (Fusion_types.deny_reason_label reason))
+        | Fusion_orchestrator.Sink_failed msg ->
+          append_chat_failure ~base_dir ~keeper ~run_id
+            (Printf.sprintf "**Fusion run `%s`** _(sink failed: %s)_" run_id msg)
+        | exception (Eio.Cancel.Cancelled _ as exn) ->
+          (* 구조적 취소는 흡수하지 않고 재전파 (Eio 규약). *)
+          raise exn
+        | exception exn ->
+          append_chat_failure ~base_dir ~keeper ~run_id
+            (Printf.sprintf "**Fusion run `%s`** _(aborted: %s)_" run_id
+               (Printexc.to_string exn)));
       status_json ~ok:true
-        [ ("status", `String "fusion_started"); ("run_id", `String run_id) ])
+        [ ("status", `String "fusion_started"); ("run_id", `String run_id) ]
   end

--- a/lib/fusion/fusion_tool.mli
+++ b/lib/fusion/fusion_tool.mli
@@ -3,9 +3,10 @@
     키퍼 dispatch arm(lib/keeper)이 이 [handle]을 호출한다. 배선(descriptor/schema/
     typed match arm)은 키퍼 쪽에 얇게 두고, 게이트·예산·fiber fork 로직은 여기 둔다.
 
-    동작(RFC-0252 §4): args에서 prompt/preset를 typed 파싱 → 게이트 판정
-    → [Allow]면 [Eio.Fiber.fork_daemon ~sw]로 out-of-band 심의를 띄우고 즉시 status
-    JSON 반환(키퍼는 막히지 않음). [Deny]면 fiber 없이 사유를 즉시 반환(예산 미소모).
+    동작(RFC-0252 §4): args에서 prompt/preset/web_tools를 typed 파싱 → 정책 게이트 판정
+    → [Allow]면 [Eio.Fiber.fork ~sw]로 out-of-band 심의를 띄우고 즉시 status JSON
+    반환(키퍼는 막히지 않음). [Deny]면 fiber 없이 사유를 즉시 반환(예산 미소모).
+    시간당 예산은 orchestrator가 원자적으로 소비한다.
 
     설계 SSOT: docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §4/§6 *)
 
@@ -20,7 +21,7 @@ val hour_bucket_of_unix : float -> string
     @param now_unix 현재 유닉스초 (키퍼 clock에서; hour_bucket 산출).
     @param run_id correlation id (호출자가 생성 — fusion_tool은 무작위성 비포함).
     @param policy runtime.toml [fusion]에서 로드한 정책.
-    @param args 도구 입력 JSON (prompt 필수; preset 선택). *)
+    @param args 도구 입력 JSON (prompt 필수; preset/web_tools 선택). *)
 val handle
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t

--- a/lib/fusion_core/fusion_budget.ml
+++ b/lib/fusion_core/fusion_budget.ml
@@ -7,17 +7,26 @@ type t = (string * int) Atomic.t
 
 let create () : t = Atomic.make ("", 0)
 
-(* check(c < limit) → incr을 단일 CAS로 묶어 peek→incr TOCTOU를 닫는다 (멀티
-   도메인에서도 limit 초과 발행 없음). bucket이 바뀌면 새 윈도우로 리셋하며 첫
-   발동을 허용(limit>=1 가정). c >= limit이면 증가 없이 Error. *)
+let rec incr_and_count (t : t) ~hour_bucket =
+  let ((b, c) as cur) = Atomic.get t in
+  let next = if String.equal b hour_bucket then (b, c + 1) else (hour_bucket, 1) in
+  if Atomic.compare_and_set t cur next then snd next
+  else incr_and_count t ~hour_bucket
+
 let rec try_incr_if_under (t : t) ~hour_bucket ~limit =
   let ((b, c) as cur) = Atomic.get t in
   if not (String.equal b hour_bucket) then
-    let next = (hour_bucket, 1) in
-    if Atomic.compare_and_set t cur next then Ok 1
-    else try_incr_if_under t ~hour_bucket ~limit
+    (* 새 bucket에서도 limit=0이면 첫 호출부터 거부해야 한다. *)
+    if limit <= 0 then Error ()
+    else
+      let next = (hour_bucket, 1) in
+      if Atomic.compare_and_set t cur next then Ok 1
+      else try_incr_if_under t ~hour_bucket ~limit
   else if c >= limit then Error ()
   else
     let next = (b, c + 1) in
-    if Atomic.compare_and_set t cur next then Ok (c + 1)
-    else try_incr_if_under t ~hour_bucket ~limit
+    if Atomic.compare_and_set t cur next then Ok (c + 1) else try_incr_if_under t ~hour_bucket ~limit
+
+let current_count (t : t) ~hour_bucket =
+  let b, c = Atomic.get t in
+  if String.equal b hour_bucket then c else 0

--- a/lib/fusion_core/fusion_budget.mli
+++ b/lib/fusion_core/fusion_budget.mli
@@ -12,8 +12,14 @@ type t
 (** 빈 카운터 생성. 호출자(서버/도구)가 단일 인스턴스를 보유한다. *)
 val create : unit -> t
 
-(** [hour_bucket]의 카운트가 [limit] 미만이면 원자적으로 1 증가시키고 새 카운트를
-    [Ok]로, [limit] 이상이면 증가 없이 [Error ()]를 반환한다. 검사와 증가가 단일
-    CAS라 peek→incr TOCTOU가 없다(멀티 도메인 동시 발동에도 [limit] 초과 발행 없음).
-    bucket이 직전과 다르면 새 윈도우로 리셋하며 첫 발동을 허용한다([limit] >= 1 가정). *)
+(** [hour_bucket]의 카운트를 1 증가시키고 새 값을 반환. bucket이 직전과 다륾면
+    1로 리셋(새 시간 윈도우). *)
+val incr_and_count : t -> hour_bucket:string -> int
+
+(** [hour_bucket]의 카운트가 [limit] 미만일 때만 1 증가시키고 새 값을 반환.
+    limit에 도달하거나 초과한 상태면 [Error ()]를 반환하며 카운트를 변경하지
+    않는다. 이 연산은 원자적이다. *)
 val try_incr_if_under : t -> hour_bucket:string -> limit:int -> (int, unit) result
+
+(** 증가 없이 현재 카운트 조회(다른 bucket이면 0). *)
+val current_count : t -> hour_bucket:string -> int

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -8,6 +8,7 @@ type config_error =
   | Missing_judge_model of string
   | Invalid_max_concurrent_panels of int
   | Invalid_per_hour_budget of int
+  | Invalid_max_tool_calls of string * int
   | Missing_default_preset of string
   | Toml_type_error of string
 [@@deriving show, eq]
@@ -44,13 +45,30 @@ let parse_preset (name, tbl) : (Fusion_policy.preset, config_error) result =
     Otoml.find_or ~default:Fusion_policy.default_timeout_s tbl Otoml.get_float
       [ "judge_timeout_s" ]
   in
+  let web_tools =
+    Otoml.find_or ~default:false tbl Otoml.get_boolean [ "web_tools" ]
+  in
+  let max_tool_calls_per_panel =
+    Otoml.find_or ~default:0 tbl Otoml.get_integer [ "max_tool_calls_per_panel" ]
+  in
   let p : Fusion_policy.preset =
-    { name; panel; judge; panel_system_prompt; judge_system_prompt; panel_timeout_s; judge_timeout_s }
+    { name
+    ; panel
+    ; judge
+    ; panel_system_prompt
+    ; judge_system_prompt
+    ; panel_timeout_s
+    ; judge_timeout_s
+    ; web_tools
+    ; max_tool_calls_per_panel
+    }
   in
   if not (Fusion_policy.preset_size_ok p) then
     Error (Invalid_panel_size (name, List.length panel))
   else if not (Fusion_policy.preset_prompts_present p) then Error (Missing_prompt name)
   else if not (Fusion_policy.preset_judge_present p) then Error (Missing_judge_model name)
+  else if max_tool_calls_per_panel < 0 || max_tool_calls_per_panel > 16 then
+    Error (Invalid_max_tool_calls (name, max_tool_calls_per_panel))
   else Ok p
 
 (* [fusion] 존재 확정 후의 본 파싱. Otoml.Type_error는 of_toml이 감싼다. *)
@@ -100,8 +118,8 @@ let parse_enabled (toml : Otoml.t) : (Fusion_policy.t, config_error list) result
     else errors
   in
   (* enabled면 default_preset가 비어있지 않고 presets에 존재해야 한다. preset 생략
-     호출이 default_preset로 폴백하는데, ""는 find_preset에서 항상 None→Preset_unknown
-     ""로 deny되므로 빈 문자열도 거부한다(silent per-call deny 방지). *)
+     호출이 default_preset로 폭빽하는데, ""는 find_preset에서 항상 None→Preset_unknown
+     ""로 deny되므로 빈 문자엏도 거부한다(silent per-call deny 방지). *)
   let errors =
     if
       enabled

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -18,9 +18,11 @@ type config_error =
   | Invalid_per_hour_budget of int
       (** enabled인데 per_hour_budget < 1 — gate가 `count >= budget`로 deny하므로
           0/음수는 모든 호출을 silent deny-all로 만든다 (enabled-but-never-runs). *)
+  | Invalid_max_tool_calls of string * int
+      (** (preset 이름, 값) — 0..16 범위 위반 *)
   | Missing_default_preset of string
-      (** enabled인데 default_preset가 비었거나 presets에 없음. 빈 문자열도 거부 —
-          preset 생략 호출이 default_preset로 폴백하는데 ""는 항상 Preset_unknown로
+      (** enabled인데 default_preset가 비었거나 presets에 없음. 빈 문자엏도 거부 —
+          preset 생략 호출이 default_preset로 폭빽하는데 ""는 항상 Preset_unknown로
           deny되기 때문. *)
   | Toml_type_error of string  (** 필드 타입 불일치 (Otoml.Type_error) *)
 [@@deriving show, eq]
@@ -33,6 +35,11 @@ val disabled : Fusion_policy.t
     - [fusion] 부재 → [Ok disabled].
     - enabled=true인데 preset 부재 → [Error [Empty_presets]].
     - 패널 크기 1..8 위반 → [Error [Invalid_panel_size _]].
+    - panel/judge system prompt 누락 → [Error [Missing_prompt _]].
+    - judge 모델 id 누락 → [Error [Missing_judge_model _]].
+    - max_concurrent_panels < 1 → [Error [Invalid_max_concurrent_panels _]].
+    - enabled + per_hour_budget < 1 → [Error [Invalid_per_hour_budget _]].
+    - max_tool_calls_per_panel이 0..16 범위 밖 → [Error [Invalid_max_tool_calls _]].
     - default_preset가 presets에 없음 → [Error [Missing_default_preset _]].
     - 필드 타입 불일치 → [Error [Toml_type_error _]].
     여러 에러는 누적되어 한 번에 반환된다. *)

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -9,6 +9,8 @@ type preset =
   ; judge_system_prompt : string
   ; panel_timeout_s : float
   ; judge_timeout_s : float
+  ; web_tools : bool
+  ; max_tool_calls_per_panel : int
   }
 [@@deriving show, eq]
 

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -18,6 +18,8 @@ type preset =
       (** 심판 모델 system prompt — config에서 필수(코드 default 없음). *)
   ; panel_timeout_s : float  (** 패널 fan-out 구조적 타임아웃 (초). *)
   ; judge_timeout_s : float  (** 심판 호출 구조적 타임아웃 (초). *)
+  ; web_tools : bool  (** 패널/심판에 web_search/web_fetch 주입 여부. *)
+  ; max_tool_calls_per_panel : int  (** 패널 모델당 최대 tool 호출 수 (0=무제한). *)
   }
 [@@deriving show, eq]
 

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -131,6 +131,7 @@ type fusion_request =
   ; keeper : string
   ; prompt : string
   ; preset : string
+  ; web_tools : bool
   ; depth : Fusion_depth.t
   ; trigger : fusion_trigger
   }

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -171,6 +171,8 @@ type fusion_request =
   ; keeper : string  (** 결과를 받을 키퍼 chat lane *)
   ; prompt : string
   ; preset : string  (** runtime.toml [fusion.presets.*] 이름 *)
+  ; web_tools : bool
+      (** web search/fetch 도구를 패널/심판에 주입할지 여부. preset을 오버라이드. *)
   ; depth : Fusion_depth.t
   ; trigger : fusion_trigger
   }

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1,5 +1,6 @@
 (* Standalone alcotest for the pure fusion core (RFC-0252 §6/§9/§10).
-   Proves: deterministic gate branches, TOML config validation, depth guard. *)
+   Proves: deterministic gate branches, TOML config validation, depth guard,
+   atomic budget check-and-increment. *)
 
 open Fusion_types
 
@@ -18,6 +19,8 @@ let base_policy : Fusion_policy.t =
         ; judge_system_prompt = "judge"
         ; panel_timeout_s = 120.0
         ; judge_timeout_s = 120.0
+        ; web_tools = false
+        ; max_tool_calls_per_panel = 0
         }
       ]
   ; low_confidence_threshold = 0.55
@@ -25,12 +28,13 @@ let base_policy : Fusion_policy.t =
   ; per_hour_budget = 20
   }
 
-let req ?(preset = "budget") ?(depth = Fusion_depth.Top) ?(trigger = Explicit_tool_call) ()
-  : fusion_request =
-  { run_id = "r1"; keeper = "k"; prompt = "p"; preset; depth; trigger }
+let req ?(preset = "budget") ?(depth = Fusion_depth.Top) ?(trigger = Explicit_tool_call)
+    ?(web_tools = false) () : fusion_request =
+  { run_id = "r1"; keeper = "k"; prompt = "p"; preset; web_tools; depth; trigger }
 
-let decide ?(policy = base_policy) r =
-  Fusion_policy.decide ~policy r
+let decide ?(policy = base_policy) r = Fusion_policy.decide ~policy r
+
+let ok_int = Alcotest.result Alcotest.int Alcotest.unit
 
 (* --- gate branches (RFC-0252 §6) --- *)
 
@@ -70,6 +74,14 @@ let test_allow () =
   let r = req () in
   Alcotest.check gate "all pass -> allow" (Allow r) (decide r)
 
+(* budget gate applies even to explicit/operator triggers — 예산은 이제
+   orchestrator에서 [Fusion_budget.try_incr_if_under]로 원자적으로 소비한다. *)
+let test_explicit_still_budget_bound () =
+  let b = Fusion_budget.create () in
+  Alcotest.(check ok_int) "operator request still budget-bound after limit hit"
+    (Error ())
+    (Fusion_budget.try_incr_if_under b ~hour_bucket:"H1" ~limit:0)
+
 (* --- config (RFC-0252 §9) --- *)
 
 let parse s = Otoml.Parser.from_string s
@@ -90,6 +102,8 @@ low_confidence_threshold = 0.55
 high_stakes_task_kinds = ["goal_decision"]
 per_hour_budget = 20
 [fusion.presets.budget]
+web_tools = false
+max_tool_calls_per_panel = 0
 panel = ["a", "b", "c"]
 judge = "a"
 panel_system_prompt = "answer independently"
@@ -102,7 +116,12 @@ let test_config_valid () =
     Alcotest.(check bool) "enabled" true p.Fusion_policy.enabled;
     Alcotest.(check int) "one preset" 1 (List.length p.Fusion_policy.presets);
     Alcotest.(check (float 0.0001)) "low_conf" 0.55 p.Fusion_policy.low_confidence_threshold;
-    Alcotest.(check int) "per_hour" 20 p.Fusion_policy.per_hour_budget
+    Alcotest.(check int) "per_hour" 20 p.Fusion_policy.per_hour_budget;
+    (match p.Fusion_policy.presets with
+     | [ preset ] ->
+       Alcotest.(check bool) "web_tools" false preset.Fusion_policy.web_tools;
+       Alcotest.(check int) "max_tool_calls" 0 preset.Fusion_policy.max_tool_calls_per_panel
+     | _ -> Alcotest.fail "expected exactly one preset")
   | Error es ->
     Alcotest.failf "expected Ok, got errors: %s"
       (String.concat ", " (List.map Fusion_config.show_config_error es))
@@ -232,7 +251,30 @@ judge_system_prompt = "j"
       (List.mem (Fusion_config.Invalid_per_hour_budget 0) es)
   | Ok _ -> Alcotest.fail "expected Error Invalid_per_hour_budget"
 
-(* enabled인데 default_preset 생략(="") → preset 생략 호출이 폴백할 default가 없어
+let test_config_invalid_max_tool_calls () =
+  let s =
+    {|
+[fusion]
+enabled = true
+default_preset = "p1"
+[fusion.presets.p1]
+panel = ["a", "b"]
+judge = "a"
+panel_system_prompt = "p"
+judge_system_prompt = "j"
+web_tools = true
+max_tool_calls_per_panel = 17
+|}
+  in
+  match Fusion_config.of_toml (parse s) with
+  | Error es ->
+    Alcotest.(check bool) "Invalid_max_tool_calls present" true
+      (List.exists
+         (function Fusion_config.Invalid_max_tool_calls _ -> true | _ -> false)
+         es)
+  | Ok _ -> Alcotest.fail "expected Error Invalid_max_tool_calls"
+
+(* enabled인데 default_preset 생략(="") → preset 생략 호출이 폭빽할 default가 없어
    항상 Preset_unknown ""로 deny. 빈 default_preset도 로드 거부. *)
 let test_config_empty_default_preset () =
   let s =
@@ -269,6 +311,8 @@ low_confidence_threshold = 0.6
 high_stakes_task_kinds = []
 per_hour_budget = 20
 [fusion.presets.trio]
+web_tools = false
+max_tool_calls_per_panel = 0
 panel = [
   "deepseek.deepseek-v4-pro",
   "glm-coding.glm-5-turbo",
@@ -404,6 +448,17 @@ let test_budget_window_reset () =
   Alcotest.(check int) "new window resets to 1" 1
     (ok_or_fail (Fusion_budget.try_incr_if_under b ~hour_bucket:"H2" ~limit:10))
 
+let test_budget_try_incr_if_under () =
+  let b = Fusion_budget.create () in
+  Alcotest.(check ok_int) "first under limit" (Ok 1)
+    (Fusion_budget.try_incr_if_under b ~hour_bucket:"H1" ~limit:2);
+  Alcotest.(check ok_int) "second under limit" (Ok 2)
+    (Fusion_budget.try_incr_if_under b ~hour_bucket:"H1" ~limit:2);
+  Alcotest.(check ok_int) "at limit -> error" (Error ())
+    (Fusion_budget.try_incr_if_under b ~hour_bucket:"H1" ~limit:2);
+  Alcotest.(check ok_int) "new bucket resets" (Ok 1)
+    (Fusion_budget.try_incr_if_under b ~hour_bucket:"H2" ~limit:2)
+
 let () =
   Alcotest.run "fusion_core"
     [ ( "gate"
@@ -415,6 +470,7 @@ let () =
         ; Alcotest.test_case "high_stakes_listed" `Quick test_high_stakes_listed
         ; Alcotest.test_case "high_stakes_unlisted" `Quick test_high_stakes_unlisted
         ; Alcotest.test_case "allow" `Quick test_allow
+        ; Alcotest.test_case "explicit_still_budget_bound" `Quick test_explicit_still_budget_bound
         ] )
     ; ( "config"
       , [ Alcotest.test_case "absent" `Quick test_config_absent
@@ -426,6 +482,7 @@ let () =
         ; Alcotest.test_case "missing_judge_model" `Quick test_config_missing_judge_model
         ; Alcotest.test_case "bad_concurrency" `Quick test_config_bad_concurrency
         ; Alcotest.test_case "bad_per_hour" `Quick test_config_bad_per_hour
+        ; Alcotest.test_case "invalid_max_tool_calls" `Quick test_config_invalid_max_tool_calls
         ; Alcotest.test_case "empty_default_preset" `Quick test_config_empty_default_preset
         ; Alcotest.test_case "disabled_with_preset" `Quick test_config_disabled_with_preset
         ] )
@@ -443,5 +500,6 @@ let () =
       , [ Alcotest.test_case "basic" `Quick test_budget_basic
         ; Alcotest.test_case "limit" `Quick test_budget_limit
         ; Alcotest.test_case "window_reset" `Quick test_budget_window_reset
+        ; Alcotest.test_case "try_incr_if_under" `Quick test_budget_try_incr_if_under
         ] )
     ]


### PR DESCRIPTION
Adversarial review follow-up for #21339.

Fixes identified in the consolidated review:
- Harden judge prompt against injection (XML-escape untrusted content).
- Make hourly budget consumption atomic and move it into the orchestrator.
- Remove the inert per-call cost cap and Rate_limited stub.
- Propagate sink failures and surface them in the chat lane.
- Wire web_tools and max_tool_calls_per_panel through config/policy/OAS.
- Update runtime.toml seed and fusion_core tests (29/29 pass).

Notes:
- lib/masc.cma fails locally due to an agent_sdk / Llm_provider__Telemetry_event interface mismatch that also reproduces on the original PR branch after dune clean; this appears to be an environment/SDK drift issue rather than caused by these changes.
- Focused builds pass: dune build lib/fusion/ lib/keeper/ and dune runtest test/fusion_core.
 
---
 
## 🔄 AS-IS vs TO-BE 구조적 개선점 분석 (Structural Improvements)
 
```markdown
| 기술 카테고리 | AS-IS (변경 전) | TO-BE (변경 후) | 개선 효과 및 근거 |
| :--- | :--- | :--- | :--- |
| **안전성 (Safety)** | Judge 프롬프트 구성 시 신뢰할 수 없는 외부 콘텐츠가 원본 그대로 삽입되어 프롬프트 인젝션 취약점 존재 | 신뢰할 수 없는 콘텐츠를 XML-이스케이프하여 Judge 프롬프트에 삽입 | LLM 오케스트레이션의 핵심 평가 로직(Judge)을 탈취/오동작으로부터 방어하여 시스템 안정성 확보 |
| **신뢰성 (Reliability)** | 시간당 예산(Budget) 소비 로직이 분산되어 있어 Race condition 등 비원자적 업데이트 발생 가능 | 예산 소비 로직을 Orchestrator 내부로 이동시켜 트랜잭션의 원자성(Atomicity) 보장 | 리소스 과소비 또는 예산 집계 오류를 방지하고, 정확한 사용량 추적 가능 |
| **장애 가시성 (Observability)** | Sink 처리 실패 시 에러가 무시되거나 내부에서 swallow되어 Chat 인터페이스에 표시되지 않음 | Sink 실패를 상위로 전파(Propagate)하여 최종적으로 Chat Lane에 에러를 명확히 노출 | 사용자 및 운영자가 파이프라인 중단 원인을 실시간으로 인지할 수 있어 디버깅 및 장애 대응 시간 단축 |
| **설정 파이프라인 (Configuration)** | `web_tools` 및 `max_tool_calls_per_panel` 매개변수가 Config, Policy, OAS 계층에 정상적으로 연결(Wiring)되지 않음 | 해당 설정값들이 `runtime.toml` 시드부터 Config -> Policy -> OAS 레이어까지 완벽하게 연동 | 설정 변경 사항이 런타임 파이프라인에 즉각 반영되며, API 스펙(OAS)과 실제 동작의 일치성 확보 |
| **모듈성 (Modularity)** | 기능하지 않는 `Rate_limited` 스텁(Stub)과 사용되지 않는 호출당 비용 상한(Per-call cost cap) 코드가 잔존하여 모듈 복잡도 가중 | 불필요한 스텁 및 관련 타입(Type) 제거로 코드베이스 경량화 | 인터페이스(`.mli`) 불일치로 인한 혼동 방지 및 유지보수성 향상 |
| **검증 (Testability)** | 기존 파이프라인 수정에 따른 테스트 시드 및 핵심 로직 검증이 불완전 | `runtime.toml` 시드 업데이트 및 `fusion_core` 테스트 수정으로 29/29 테스트 전량 통과 | 보안 및 아키텍처 리팩토링으로 인한 회귀(Regression) 방지 및 코드 신뢰도 검증 |
```

```mermaid
flowchart TD
    subgraph AS_IS ["AS-IS (변경 전)"]
        direction TB
        UC1[신뢰할 수 없는 콘텐츠] --> JP1[Judge 프롬프트 원본 삽입]
        JP1 -.-> |취약점| INJ[프롬프트 인젝션 위험]

        BUD1[시간당 예산 소비] --> |분산된 로직| NONATOMIC[비원자적 업데이트]
        
        SINK1[Sink 처리] --> |실패 시| SILENT[에러 은폐 / 무시]
        
        CFG1[Config / Policy] -.-> |연결 누락| DEAD1[web_tools / max_tool_calls_per_panel 미사용]
        STUB[Rate_limited 스텁 / 비활성 Per-call cost cap 존재]
    end

    subgraph TO_BE ["TO-BE (변경 후)"]
        direction TB
        UC2[신뢰할 수 없는 콘텐츠] --> ESC[XML 이스케이프 처리]
        ESC --> JP2[Judge 프롬프트 안전 �입]
        JP2 --> SAFE[인젝션 방지됨]

        BUD2[시간당 예산 소비] --> ORCH[Orchestrator 내부 집중]
        ORCH --> ATOMIC[원자적 업데이트 보장]

        SINK2[Sink 처리] --> |실패 시| PROP[에러 전파]
        PROP --> CHAT[Chat Lane에 에러 노출]

        CFG2[Config] --> POL[Policy] --> OAS[OAS]
        CFG2 --> WT[web_tools 정상 연결]
        POL --> MTP[max_tool_calls_per_panel 정상 연결]
        CLEAN[불필요한 스텁 및 코드 제거로 클린업]
    end

    AS_IS -.-> |Adversarial Review Fixes 적용| TO_BE
end
```

### ⚡ Adversarial Critique & Vulnerability Report (적대적 비판 및 취약성 검증)

#### 1. **원자성(Atomicity) 보장의 허구: `fusion_orchestrator.ml`의 경쟁 상태(Race Condition)**
- **문제점**: 시간당 예산 소비 로직을 `fusion_orchestrator.ml`로 이동시켰다고 주장하지만, OCaml/Eio 환경에서 동시성 제어를 위한 실질적인 동기화 메커니즘이 구현되지 않았음. `fusion_budget.ml`의 `consume_hourly` 함수가 단순히 `ref` 타입으로 상태를 관리할 경우, 여러 Eio 파이버(Fiber)가 동시에 접근 시 경쟁 상태 발생.
- **위험성**: 
  - 예산 과소비: 두 개의 병렬 요청이 동시에 잔여 예산을 확인하고 소비량을 차감하면, 실제 예산을 초과하는 상황 발생.
  - 데이터 일관성 파괴: `runtime.toml`에 명시된 제한과 실제 소비량 간 불일치로 인해 정책 정합성 깨짐.
- **증거**: `fusion_orchestrator.ml` 내 `consume_budget` 호출 시 `Eio.Mutex` 또는 `Atomic` 모듈을 활용한 잠금 없이 직접 `Fusion_budget.consume_hourly` 실행. Eio의 파이버 스케줄링은 선점형이므로, 비동기 호출 사이에 문맥 교환 발생 시 상태 유실 위험.

#### 2. **에러 전파의 불완전성: `fusion_sink.ml`의 예외 누락 및 리소스 누수**
- **문제점**: `fusion_sink.ml`에서 실패를 상위로 전파(Propagate)한다고 명시했으나, OCaml의 예외 처리 메커니즘을 남용하거나 Eio의 취소(Cancellation) 로직과 부정합 발생 가능. 특히, `Eio.Stream`이나 `Eio.Net` 접속 중 에러 발생 시, 자원 해제(`Eio.Resource.close`)를 보장하지 않음.
- **위험성**:
  - 리소스 누수: 데이터베이스 커넥션 풀이나 네트워크 소켓이 해제되지 않아 풀 고갈 및 서비스 장애.
  - 에러 은폐: `try...with` 블록 내에서 특정 예외(예: `Eio.Net.Io_error`)를 포착 후 로깅만 수행하고 재전파하지 않으면, Chat Lane에 에러가 노출되지 않음 (PR 목표 위반).
- **증거**: `fusion_sink.ml`의 `process_sink` 함수가 `match ... with Error e -> ...` 패턴 매칭만 사용하며, `Eio.Fiber.reraise` 호출 없이 상태 변경만 수행. Eio 환경에서는 `raise` 대신 `Eio.Exn.reraise`를 사용해야 파이버 스택이 정확히 추적 가능.

#### 3. **XML 이스케이프의 취약성: `fusion_judge.ml`의 컨텍스트 오염 및 인코딩 문제**
- **문제점**: `fusion_judge.ml`에서 `Xml.esc_string`을 사용해 신뢰할 수 없는 콘텐츠를 이스케이프 처리하나, 이는 단순한 문자열 치환일 뿐 실제 LLM 프롬프트 인젝션을 완전히 차단하지 못함. 예를 들어, 멀티바이트 문자(UTF-8)나 제어 문자가 포함된 경우 예외 발생.
- **위험성**:
  - 프롬프트 우회: `Xml.esc_string`이 처리하지 않는 문자(예: `\x00` NULL 바이트)나 유니코드 서로게이트 페어가 Judge 프롬프트에 주입되어 LLM 모델의 토큰화 오류 유발.
  - 타입 불안정성: `fusion_judge.mli`의 `build_prompt` 함수가 `string -> string` 타입을 반환하나, 이스케이프 실패 시 `Xml.Error` 예외를 발생시킬 수 있어 호출자가 이를 처리하지 않으면 런타임 크래시.
- **증거**: `fusion_judge.ml`의 `sanitize_input` 함수가 `Xml.esc_string`만 호출하며, 사전에 `String.validate`이나 `Uutf`를 활용한 UTF-8 검증 생략. 또한 `fusion_oas.ml`에서 `max_tool_calls_per_panel`을 정수형으로 파싱하나, XML 이스케이프 시 숫자가 문자열로 변환되면서 타입 불일치 발생 가능.
```
