### PR TITLE
feat(dashboard): apply keeper-v2 memory graph + goal dossier surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,5 +149,6 @@ data/harness-pre-compact/
 data/verdicts/
 data/bench/
 memory/
+!dashboard/src/components/memory/
 
 # End of .gitignore

--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -14,6 +14,9 @@ import { formatTimeAgo } from '../lib/format-time'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { highlightMatch } from '../lib/highlight-match'
 import { TextInput } from './common/input'
+import { MemoryLineageRail } from './memory/memory-lineage-rail'
+import type { MemoryLineageRailProps } from './memory/memory-lineage-rail'
+import type { MemoryNode } from './memory/memory-primitives'
 
 interface Props {
   agentName: string
@@ -62,6 +65,39 @@ function synapseWeightFillClass(weight: number): string {
   if (weight >= 0.7) return 'bg-[var(--ok-10)]'
   if (weight >= 0.4) return 'bg-[var(--warn-10)]'
   return 'bg-[var(--bad-10)]'
+}
+
+const LINEAGE_NODE_TYPES: MemoryLineageRailProps['nodeTypes'] = {
+  memory: { kr: '기억', g: '◆', c: 'var(--volt)' },
+}
+
+function formatEpisodeTime(timestamp: number): string {
+  const d = new Date(timestamp * 1000)
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+}
+
+function buildEpisodeLineage(
+  episodes: readonly MemorySubsystemsEpisode[],
+  fallbackKp: string,
+): { steps: MemoryLineageRailProps['steps']; nodes: Record<string, MemoryNode> } {
+  const sorted = [...episodes].sort((a, b) => a.timestamp - b.timestamp)
+  const steps: MemoryLineageRailProps['steps'] = sorted.map((ep, i) => ({
+    id: ep.id,
+    t: formatEpisodeTime(ep.timestamp),
+    rel: ep.event_type,
+    anchor: i === sorted.length - 1,
+  }))
+  const nodes: Record<string, MemoryNode> = {}
+  for (const ep of sorted) {
+    nodes[ep.id] = {
+      type: 'memory',
+      title: ep.summary,
+      kp: ep.participants[0] ?? fallbackKp,
+      meta: ep.outcome,
+      ns: ep.event_type,
+    }
+  }
+  return { steps, nodes }
 }
 
 function SynapseWeightBar({ weight }: { weight: number }) {
@@ -248,6 +284,28 @@ export function AgentDetailMemory({ agentName }: Props) {
                 `
           }
         </div>
+
+        <!-- Episode lineage rail -->
+        ${episodes.length > 0
+          ? html`
+              <div>
+                <div class="text-xs text-[var(--color-fg-disabled)] uppercase tracking-wide mb-2">
+                  에피소드 인과 레일
+                </div>
+                ${(() => {
+                  const { steps, nodes } = buildEpisodeLineage(visibleEpisodes, agentName)
+                  return html`
+                    <${MemoryLineageRail}
+                      steps=${steps}
+                      nodes=${nodes}
+                      nodeTypes=${LINEAGE_NODE_TYPES}
+                      ariaLabel="에피소드 인과 추적"
+                    />
+                  `
+                })()}
+              </div>
+            `
+          : null}
       </div>
     <//>
   `

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -27,6 +27,8 @@ import { ringFocusClasses } from '../common/ring'
 import { trustDispositionLabel } from '../fsm-hub-types'
 import { TimeAgo } from '../common/time-ago'
 import { TaskCreateForm } from '../task-manage/task-create-form'
+import { GoalDossier } from '../memory/goal-dossier'
+import type { GoalDossierProps, GoalDossierRelatedItem } from '../memory/goal-dossier'
 import type {
   DashboardGoalDetailResponse,
   DashboardWorkspaceFsmViolation,
@@ -75,6 +77,51 @@ const CARD_BOX = 'rounded-[var(--r-0)] border border-[var(--color-border-default
 const GOAL_PANEL = 'rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-5'
 const TREE_NODE_CARD_BASE = 'group flex items-start gap-3 rounded-[var(--r-1)] border p-3 transition-colors w-full text-left'
 const TREE_NODE_CARD_ACTIVE = `${TREE_NODE_CARD_BASE} border-[var(--color-state-active-border)] bg-[var(--color-state-active-bg)] shadow-[0_0_0_1px_var(--color-brass-border)]`
+
+const DOSSIER_NODE_TYPES: GoalDossierProps['nodeTypes'] = {
+  task: { kr: '태스크', g: '▣', c: 'var(--status-ok)' },
+  issue: { kr: '이슈', g: '⚠', c: 'var(--status-bad)' },
+  memory: { kr: '기억', g: '◆', c: 'var(--volt)' },
+  snapshot: { kr: '스냅샷', g: '◷', c: 'var(--accent-ice)' },
+}
+
+function taskStateForDossier(status: string, isTerminal: boolean): GoalDossierRelatedItem['state'] {
+  if (status === 'done' || isTerminal) return 'done'
+  if (status === 'blocked' || status === 'block') return 'block'
+  return 'open'
+}
+
+function buildGoalDossierProps(node: GoalTreeNode): GoalDossierProps {
+  return {
+    goal: {
+      title: node.title,
+      kp: node.linked_keeper_names[0] ?? '',
+      ns: 'goal',
+      pct: node.convergence_pct,
+      deadline: node.due_date ? `마감 ${node.due_date}` : undefined,
+    },
+    nodeTypes: DOSSIER_NODE_TYPES,
+    snaps: [
+      { t: 'now', pct: node.convergence_pct, note: 'current', now: true },
+    ],
+    related: {
+      task: node.tasks.map((task) => ({
+        title: task.title,
+        kp: task.assignee ?? 'unassigned',
+        meta: task.status,
+        state: taskStateForDossier(task.status, task.is_terminal),
+      })),
+    },
+    ledger: [
+      ['작업', `${node.task_done_count}/${node.task_count}`],
+      ['연결 키퍼', String(node.linked_keeper_names.length)],
+      ['승인 대기', String(node.pending_approval_count)],
+      ['검증 대기', String(node.pending_verification_count)],
+      ['인프라 위험', String(node.infra_risk_count)],
+      ['목표 달성', node.attainment.attainment_pct == null ? '미측정' : `${node.attainment.attainment_pct}%`],
+    ],
+  }
+}
 
 /**
  * Pure hierarchy filter for goal tree nodes.
@@ -1392,6 +1439,19 @@ function GoalDetailPanel({
       <${GoalCompletionStrip} node=${selectedNode} />
       <${GoalTaskRelationStrip} node=${selectedNode} />
       <${GoalLifecycleActionPanel} node=${selectedNode} />
+      ${(() => {
+        const dossierProps = buildGoalDossierProps(selectedNode)
+        return html`
+          <${GoalDossier}
+            goal=${dossierProps.goal}
+            nodeTypes=${dossierProps.nodeTypes}
+            snaps=${dossierProps.snaps}
+            related=${dossierProps.related}
+            ledger=${dossierProps.ledger}
+            testId="goal-dossier-card"
+          />
+        `
+      })()}
 
       <${DetailTabs} active=${activeTab} />
 

--- a/dashboard/src/components/ide/ide-memory-panel.ts
+++ b/dashboard/src/components/ide/ide-memory-panel.ts
@@ -1,5 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useState, useCallback } from 'preact/hooks'
+import { MemoryLens } from '../memory/memory-lens'
+import type { MemoryLensProps } from '../memory/memory-lens'
 
 interface MemoryEntry {
   readonly id: string
@@ -41,6 +43,60 @@ function formatTimestamp(ms: number): string {
   const diffHr = Math.floor(diffMin / 60)
   if (diffHr < 24) return `${diffHr}h ago`
   return date.toLocaleDateString()
+}
+
+const LENS_NODE_TYPES: MemoryLensProps['nodeTypes'] = {
+  memory: { kr: '기억', g: '◆', c: 'var(--volt)' },
+  goal: { kr: '골', g: '◎', c: 'var(--accent-ice)' },
+  task: { kr: '태스크', g: '▣', c: 'var(--status-ok)' },
+  board: { kr: '보드', g: '◈', c: '#8a6cf0' },
+}
+
+function buildLensGraph(entries: ReadonlyArray<MemoryEntry>): {
+  nodes: MemoryLensProps['nodes']
+  edges: MemoryLensProps['edges']
+  start: string
+} {
+  const nodes: Record<string, MemoryLensProps['nodes'][string]> = {}
+  const edges: Array<{ source: string; target: string; rel: string }> = []
+
+  for (const entry of entries) {
+    nodes[entry.id] = {
+      type: 'memory',
+      title: entry.content.length > 80 ? `${entry.content.slice(0, 80)}...` : entry.content,
+      kp: entry.keeper_id || 'unknown',
+      meta: entry.kind,
+      ns: `${entry.file_path}:${entry.line_start}`,
+    }
+
+    if (entry.goal_id) {
+      if (!nodes[entry.goal_id]) {
+        nodes[entry.goal_id] = {
+          type: 'goal',
+          title: `Goal ${entry.goal_id}`,
+          kp: entry.keeper_id || 'unknown',
+          meta: 'linked',
+          ns: 'goal',
+        }
+      }
+      edges.push({ source: entry.id, target: entry.goal_id, rel: 'goal' })
+    }
+
+    if (entry.task_id) {
+      if (!nodes[entry.task_id]) {
+        nodes[entry.task_id] = {
+          type: 'task',
+          title: `Task ${entry.task_id}`,
+          kp: entry.keeper_id || 'unknown',
+          meta: 'linked',
+          ns: 'task',
+        }
+      }
+      edges.push({ source: entry.id, target: entry.task_id, rel: 'task' })
+    }
+  }
+
+  return { nodes, edges, start: entries[0]!.id }
 }
 
 export function IdeMemoryPanel({ keeperName }: IdeMemoryPanelProps) {
@@ -130,6 +186,23 @@ export function IdeMemoryPanel({ keeperName }: IdeMemoryPanelProps) {
                   `,
                 )}
               </div>
+
+              ${(() => {
+                const { nodes, edges, start } = buildLensGraph(entries)
+                return html`
+                  <div class="ide-memory-panel__lens v2-ide-section" data-testid="ide-memory-lens">
+                    <${MemoryLens}
+                      nodes=${nodes}
+                      edges=${edges}
+                      nodeTypes=${LENS_NODE_TYPES}
+                      start=${start}
+                      W=${520}
+                      H=${360}
+                      ariaLabel="IDE 메모리 연결 렌즈"
+                    />
+                  </div>
+                `
+              })()}
             `}
     </div>
   `

--- a/dashboard/src/components/memory/goal-dossier.test.ts
+++ b/dashboard/src/components/memory/goal-dossier.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/preact'
+import { html } from 'htm/preact'
+import { GoalDossier } from './goal-dossier'
+
+const nodeTypes = {
+  task: { kr: '태스크', g: '▣', c: '#22c55e' },
+  issue: { kr: '이슈', g: '⚠', c: '#ef4444' },
+  memory: { kr: '기억', g: '◆', c: '#e0b057' },
+  snapshot: { kr: '스냅샷', g: '◷', c: '#5b9cf0' },
+}
+
+const goal = {
+  title: 'scheduler p95 round-jitter < 50ms',
+  kp: 'nick0cave',
+  ns: 'core/scheduler',
+  pct: 47,
+  deadline: 'D-3 마감',
+}
+
+const snaps = [
+  { t: '06-08', pct: 12, note: 'baseline' },
+  { t: '06-11', pct: 47, note: 'current', now: true },
+]
+
+const related = {
+  task: [
+    { title: 'isolate compact() call', kp: 'sangsu', meta: 'open · handoff', state: 'open' as const },
+    { title: 'add regression test', kp: 'nick0cave', meta: 'done · 84/84', state: 'done' as const },
+  ],
+  issue: [
+    { title: 'round-jitter spike', kp: 'nick0cave', meta: 'root cause found', state: 'open' as const },
+  ],
+  memory: [
+    { title: 'compact() lock insight', kp: 'nick0cave', meta: '13:49 checkpoint', state: 'ctx' as const },
+  ],
+}
+
+const ledger = [
+  ['누적 trace', '287'],
+  ['활성 시간', '6h 12m'],
+  ['태스크', '2 · ✓1'],
+  ['이슈', '1'],
+] as const
+
+describe('GoalDossier', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders goal header, progress ring, and deadline', () => {
+    render(html`<${GoalDossier}
+      goal=${goal}
+      nodeTypes=${nodeTypes}
+      snaps=${snaps}
+      related=${related}
+      ledger=${ledger}
+      testId="dossier"
+    />`)
+    const dossier = screen.getByTestId('dossier')
+    expect(dossier.textContent).toContain('scheduler p95 round-jitter < 50ms')
+    expect(dossier.textContent).toContain('47%')
+    expect(dossier.textContent).toContain('D-3 마감')
+    expect(dossier.textContent).toContain('core/scheduler')
+  })
+
+  it('renders snapshot trend', () => {
+    render(html`<${GoalDossier}
+      goal=${goal}
+      nodeTypes=${nodeTypes}
+      snaps=${snaps}
+      related=${related}
+      ledger=${ledger}
+      testId="dossier"
+    />`)
+    expect(screen.getByText('baseline')).not.toBeNull()
+    expect(screen.getByText('current')).not.toBeNull()
+    expect(screen.getByText('12%')).not.toBeNull()
+    expect(screen.getAllByText('47%').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders ledger cells', () => {
+    render(html`<${GoalDossier}
+      goal=${goal}
+      nodeTypes=${nodeTypes}
+      snaps=${snaps}
+      related=${related}
+      ledger=${ledger}
+      testId="dossier"
+    />`)
+    expect(screen.getByText('287')).not.toBeNull()
+    expect(screen.getByText('6h 12m')).not.toBeNull()
+    expect(screen.getByText('누적 trace')).not.toBeNull()
+    expect(screen.getByText('활성 시간')).not.toBeNull()
+  })
+
+  it('renders related groups with state labels', () => {
+    render(html`<${GoalDossier}
+      goal=${goal}
+      nodeTypes=${nodeTypes}
+      snaps=${snaps}
+      related=${related}
+      ledger=${ledger}
+      testId="dossier"
+    />`)
+    expect(screen.getByText('isolate compact() call')).not.toBeNull()
+    expect(screen.getByText('add regression test')).not.toBeNull()
+    expect(screen.getByText('round-jitter spike')).not.toBeNull()
+    expect(screen.getByText('compact() lock insight')).not.toBeNull()
+    expect(screen.getByText('완료')).not.toBeNull()
+    expect(screen.getAllByText('진행').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByText('맥락')).not.toBeNull()
+  })
+
+  it('renders nothing for empty related groups', () => {
+    render(html`<${GoalDossier}
+      goal=${goal}
+      nodeTypes=${nodeTypes}
+      snaps=${snaps}
+      related=${{} as typeof related}
+      ledger=${ledger}
+      testId="dossier-empty"
+    />`)
+    expect(screen.queryByText('isolate compact() call')).toBeNull()
+    expect(screen.queryByText('round-jitter spike')).toBeNull()
+    expect(screen.queryByText('compact() lock insight')).toBeNull()
+  })
+})

--- a/dashboard/src/components/memory/goal-dossier.ts
+++ b/dashboard/src/components/memory/goal-dossier.ts
@@ -1,0 +1,160 @@
+import { html } from 'htm/preact'
+import {
+  cx,
+  MgEntry,
+  MgSig,
+  type MemoryKeeper,
+  type MemoryNodeType,
+} from './memory-primitives'
+
+export interface GoalDossierGoal {
+  readonly title: string
+  readonly kp: string
+  readonly ns: string
+  readonly pct: number
+  readonly deadline?: string
+}
+
+export interface GoalDossierSnap {
+  readonly t: string
+  readonly pct: number
+  readonly note: string
+  readonly now?: boolean
+}
+
+export interface GoalDossierRelatedItem {
+  readonly title: string
+  readonly kp: string
+  readonly meta: string
+  readonly state: 'done' | 'open' | 'block' | 'ctx'
+}
+
+export interface GoalDossierRelatedGroups {
+  readonly task?: ReadonlyArray<GoalDossierRelatedItem>
+  readonly issue?: ReadonlyArray<GoalDossierRelatedItem>
+  readonly memory?: ReadonlyArray<GoalDossierRelatedItem>
+}
+
+export interface GoalDossierProps {
+  readonly goal: GoalDossierGoal
+  readonly nodeTypes: Readonly<Record<string, MemoryNodeType>>
+  readonly keepers?: Readonly<Record<string, MemoryKeeper>>
+  readonly snaps: ReadonlyArray<GoalDossierSnap>
+  readonly related: GoalDossierRelatedGroups
+  readonly ledger?: ReadonlyArray<readonly [string, string]>
+  readonly ariaLabel?: string
+  readonly testId?: string
+}
+
+const STATE_LABEL: Record<GoalDossierRelatedItem['state'], string> = {
+  done: '완료',
+  open: '진행',
+  block: '차단',
+  ctx: '맥락',
+}
+
+const GROUP_KEYS: Array<keyof GoalDossierRelatedGroups> = ['task', 'issue', 'memory']
+
+export function GoalDossier({
+  goal,
+  nodeTypes,
+  keepers = {},
+  snaps,
+  related,
+  ledger = [],
+  ariaLabel = '목표 도시에',
+  testId,
+}: GoalDossierProps) {
+  const snapshotType = nodeTypes.snapshot ?? { kr: '스냅샷', g: '◷', c: 'var(--accent-ice)' }
+
+  return html`
+    <div class="mg-board gd-board" data-testid=${testId} aria-label=${ariaLabel}>
+      <${MgEntry} extra="목표 중심 · 얼만큼 일했나" />
+      <div class="gd-head">
+        <div class="gd-head-l">
+          <span class="gd-glyph">◎</span>
+          <div style=${{ minWidth: 0 }}>
+            <div class="gd-ey">골 · ${goal.ns}</div>
+            <div class="gd-title">${goal.title}</div>
+            <div class="gd-sub">
+              <${MgSig} kp=${goal.kp} keepers=${keepers} size=${15} />
+              <span class="mono">${goal.kp}</span>
+              <span class="mono dimd">소유${goal.deadline ? ` · ${goal.deadline}` : ''}</span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="gd-ring"
+          style=${{
+            background: `conic-gradient(var(--volt) 0 ${goal.pct}%, var(--border-main) ${goal.pct}% 100%)`,
+          }}
+        >
+          <div class="gd-ring-in">
+            <b>${goal.pct}%</b><span>진척</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="gd-snapwrap">
+        <div class="gd-prog">
+          <span class="gd-prog-fill" style=${{ width: `${goal.pct}%` }} />
+        </div>
+        <div class="gd-snaps">
+          <span class="gd-snaplbl">
+            <span class="g" style=${{ color: snapshotType.c }}>${snapshotType.g}</span>
+            ${snapshotType.kr}
+          </span>
+          ${snaps.map((s, i) => html`
+            <span key=${i}>
+              ${i > 0 ? html`<span class="gd-snaparr">→</span>` : null}
+              <span class=${cx('gd-snap', s.now && 'now')}>
+                <b class="mono">${s.pct}%</b>
+                <span class="mono dt">${s.t}</span>
+                <span class="nt">${s.note}</span>
+              </span>
+            </span>
+          `)}
+        </div>
+      </div>
+
+      <div class="gd-ledger">
+        ${ledger.map(([k2, v], i) => html`
+          <div key=${i} class="gd-cell">
+            <div class="gd-cv mono">${v}</div>
+            <div class="gd-ck">${k2}</div>
+          </div>
+        `)}
+      </div>
+
+      <div class="gd-groups">
+        ${GROUP_KEYS.map((tk) => {
+          const t = nodeTypes[tk]
+          const items = related[tk]
+          if (!t || !items || items.length === 0) return null
+          return html`
+            <div key=${tk} class="gd-group" style=${{ '--nc': t.c }}>
+              <div class="gd-group-h">
+                <span class="g">${t.g}</span>${t.kr}
+                <span class="cnt mono">${items.length}</span>
+              </div>
+              ${items.map((it, j) => html`
+                <div key=${j} class=${cx('gd-crow', `st-${it.state}`)}>
+                  <div class="gd-cmain">
+                    <div class="gd-ctitle">${it.title}</div>
+                    <div class="gd-cmeta">
+                      <${MgSig} kp=${it.kp} keepers=${keepers} size=${13} />
+                      <span class="mono">${it.meta}</span>
+                    </div>
+                  </div>
+                  <span class=${cx('gd-state', `st-${it.state}`)}>
+                    ${STATE_LABEL[it.state]}
+                  </span>
+                </div>
+              `)}
+            </div>
+          `
+        })}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/memory/memory-lens.test.ts
+++ b/dashboard/src/components/memory/memory-lens.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { html } from 'htm/preact'
+import { MemoryLens } from './memory-lens'
+
+const nodeTypes = {
+  memory: { kr: '기억', g: '◆', c: '#e0b057' },
+  goal: { kr: '골', g: '◎', c: '#5b9cf0' },
+  task: { kr: '태스크', g: '▣', c: '#22c55e' },
+}
+
+const nodes = {
+  mem: { type: 'memory', title: 'insight checkpoint', kp: 'nick0cave', meta: 'insight', ns: 'core/scheduler' },
+  goal: { type: 'goal', title: 'scheduler p95 jitter < 50ms', kp: 'nick0cave', meta: '진행 47%', ns: 'core/scheduler' },
+  task1: { type: 'task', title: 'isolate compact() call', kp: 'sangsu', meta: 'open', ns: 'core/runtime' },
+  task2: { type: 'task', title: 'add regression test', kp: 'nick0cave', meta: 'done', ns: 'core/scheduler' },
+}
+
+const edges = [
+  { source: 'mem', target: 'goal', rel: '진단' },
+  { source: 'mem', target: 'task1', rel: '파생' },
+  { source: 'mem', target: 'task2', rel: '검증' },
+]
+
+describe('MemoryLens', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders empty state when no nodes are provided', () => {
+    render(html`<${MemoryLens} nodes=${{}} edges=${[]} nodeTypes=${nodeTypes} testId="lens-empty" />`)
+    expect(screen.getByTestId('lens-empty').textContent).toContain('연결할 메모리 노드가 없습니다')
+  })
+
+  it('renders the anchor node and satellite nodes from props', () => {
+    render(html`<${MemoryLens} nodes=${nodes} edges=${edges} nodeTypes=${nodeTypes} start="mem" testId="lens" />`)
+    const board = screen.getByTestId('lens')
+    expect(board.textContent).toContain('insight checkpoint')
+    expect(board.textContent).toContain('isolate compact() call')
+    expect(board.textContent).toContain('add regression test')
+    expect(board.textContent).toContain('scheduler p95 jitter < 50ms')
+  })
+
+  it('renders edge relation labels', () => {
+    render(html`<${MemoryLens} nodes=${nodes} edges=${edges} nodeTypes=${nodeTypes} start="mem" />`)
+    expect(screen.getByText('진단')).not.toBeNull()
+    expect(screen.getByText('파생')).not.toBeNull()
+    expect(screen.getByText('검증')).not.toBeNull()
+  })
+
+  it('re-centers anchor when a satellite node is clicked', () => {
+    render(html`<${MemoryLens} nodes=${nodes} edges=${edges} nodeTypes=${nodeTypes} start="mem" testId="lens" />`)
+    const board = screen.getByTestId('lens')
+    expect(board.textContent).toContain('insight checkpoint')
+
+    const goalCard = screen.getByText('scheduler p95 jitter < 50ms').closest('.mg-node')
+    expect(goalCard).not.toBeNull()
+    fireEvent.click(goalCard!)
+
+    expect(board.textContent).toContain('scheduler p95 jitter < 50ms')
+    // The previous anchor should now be a satellite title in the board.
+    expect(board.textContent).toContain('insight checkpoint')
+  })
+
+  it('calls onSelectNode when a satellite node is clicked', () => {
+    const onSelectNode = vi.fn()
+    render(html`<${MemoryLens}
+      nodes=${nodes}
+      edges=${edges}
+      nodeTypes=${nodeTypes}
+      start="mem"
+      onSelectNode=${onSelectNode}
+    />`)
+
+    const goalCard = screen.getByText('scheduler p95 jitter < 50ms').closest('.mg-node')
+    fireEvent.click(goalCard!)
+    expect(onSelectNode).toHaveBeenCalledWith('goal')
+  })
+
+  it('ignores edges that reference missing nodes', () => {
+    const edgesWithMissing = [
+      ...edges,
+      { source: 'mem', target: 'missing', rel: 'orphan' },
+    ]
+    render(html`<${MemoryLens}
+      nodes=${nodes}
+      edges=${edgesWithMissing}
+      nodeTypes=${nodeTypes}
+      start="mem"
+      testId="lens"
+    />`)
+    expect(screen.getByTestId('lens').textContent).not.toContain('orphan')
+  })
+})

--- a/dashboard/src/components/memory/memory-lens.ts
+++ b/dashboard/src/components/memory/memory-lens.ts
@@ -1,0 +1,167 @@
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+import {
+  MgEntry,
+  MgLegend,
+  MgNodeCard,
+  type MemoryKeeper,
+  type MemoryNode,
+  type MemoryNodeType,
+} from './memory-primitives'
+
+export interface MemoryLensEdge {
+  readonly source: string
+  readonly target: string
+  readonly rel: string
+}
+
+export interface MemoryLensProps {
+  readonly nodes: Readonly<Record<string, MemoryNode>>
+  readonly edges: ReadonlyArray<MemoryLensEdge>
+  readonly nodeTypes: Readonly<Record<string, MemoryNodeType>>
+  readonly keepers?: Readonly<Record<string, MemoryKeeper>>
+  readonly start?: string
+  readonly W?: number
+  readonly H?: number
+  readonly onSelectNode?: (id: string) => void
+  readonly ariaLabel?: string
+  readonly testId?: string
+}
+
+interface PlacedSatellite {
+  readonly id: string
+  readonly rel: string
+  readonly x: number
+  readonly y: number
+}
+
+export function MemoryLens({
+  nodes,
+  edges,
+  nodeTypes,
+  keepers = {},
+  start,
+  W = 600,
+  H = 540,
+  onSelectNode,
+  ariaLabel = '메모리 렌즈',
+  testId,
+}: MemoryLensProps) {
+  const nodeIds = Object.keys(nodes)
+  const firstId = start ?? nodeIds[0]
+  const [anchor, setAnchor] = useState<string>(firstId ?? '')
+
+  useEffect(() => {
+    if (start && nodes[start]) {
+      setAnchor(start)
+    } else if (!nodes[anchor] && nodeIds.length > 0) {
+      setAnchor(nodeIds[0] ?? '')
+    }
+  }, [start, nodes, anchor, nodeIds])
+
+  if (nodeIds.length === 0 || !nodes[anchor]) {
+    return html`
+      <div
+        class="mg-board"
+        data-testid=${testId}
+        aria-label=${ariaLabel}
+      >
+        <${MgEntry} extra="1-hop 렌즈 · 노드 클릭 = 재중심" />
+        <div class="flex items-center justify-center text-xs text-[var(--color-fg-muted)]" style=${{ height: `${H}px` }}>
+          연결할 메모리 노드가 없습니다.
+        </div>
+      </div>
+    `
+  }
+
+  const cx = W / 2
+  const cy = H / 2 + 4
+  const r = Math.min(W, H) * 0.37
+
+  const sats = edges
+    .filter((edge) => edge.source === anchor || edge.target === anchor)
+    .map((edge) => ({
+      id: edge.source === anchor ? edge.target : edge.source,
+      rel: edge.rel,
+    }))
+    .filter((s) => Boolean(nodes[s.id]) && Boolean(nodeTypes[nodes[s.id]!.type]))
+
+  const placed: PlacedSatellite[] = sats.map((s, i) => {
+    const ang = (-90 + i * (360 / sats.length)) * (Math.PI / 180)
+    return {
+      ...s,
+      x: cx + Math.cos(ang) * r,
+      y: cy + Math.sin(ang) * r,
+    }
+  })
+
+  function handleSelect(id: string) {
+    setAnchor(id)
+    onSelectNode?.(id)
+  }
+
+  return html`
+    <div class="mg-board" data-testid=${testId} aria-label=${ariaLabel}>
+      <${MgEntry} extra="1-hop 렌즈 · 노드 클릭 = 재중심" />
+      <div class="mg-lens" style=${{ width: W, height: H }}>
+        <svg
+          class="mg-edges"
+          viewBox=${`0 0 ${W} ${H}`}
+          width=${W}
+          height=${H}
+          role="img"
+          aria-label=${`${ariaLabel} SVG edges`}
+        >
+          ${placed.map((s) => {
+            const type = nodeTypes[nodes[s.id]!.type]
+            return html`
+              <line
+                key=${s.id}
+                x1=${cx}
+                y1=${cy}
+                x2=${s.x}
+                y2=${s.y}
+                stroke=${type?.c ?? 'var(--text-dim)'}
+                stroke-width="1.4"
+                stroke-opacity="0.5"
+              />
+            `
+          })}
+        </svg>
+        ${placed.map((s) => {
+          const lx = cx + (s.x - cx) * 0.5
+          const ly = cy + (s.y - cy) * 0.5
+          return html`
+            <span
+              key=${`l-${s.id}`}
+              class="mg-edge-lbl mono"
+              style=${{ left: lx, top: ly }}
+            >
+              ${s.rel}
+            </span>
+          `
+        })}
+        <div class="mg-pos" style=${{ left: cx, top: cy }}>
+          <${MgNodeCard}
+            node=${nodes[anchor]}
+            type=${nodeTypes[nodes[anchor].type]}
+            keepers=${keepers}
+            anchor
+          />
+        </div>
+        ${placed.map((s) => html`
+          <div key=${s.id} class="mg-pos" style=${{ left: s.x, top: s.y }}>
+            <${MgNodeCard}
+              node=${nodes[s.id]}
+              type=${nodeTypes[nodes[s.id]!.type]}
+              keepers=${keepers}
+              satellite
+              onClick=${() => handleSelect(s.id)}
+            />
+          </div>
+        `)}
+      </div>
+      <${MgLegend} nodeTypes=${nodeTypes} />
+    </div>
+  `
+}

--- a/dashboard/src/components/memory/memory-lineage-rail.test.ts
+++ b/dashboard/src/components/memory/memory-lineage-rail.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/preact'
+import { html } from 'htm/preact'
+import { MemoryLineageRail } from './memory-lineage-rail'
+
+const nodeTypes = {
+  memory: { kr: '기억', g: '◆', c: '#e0b057' },
+}
+
+const nodes = {
+  mem2: { type: 'memory', title: 'origin commit', kp: 'nick0cave', meta: 'origin', ns: 'core/scheduler' },
+  mem: { type: 'memory', title: 'insight checkpoint', kp: 'nick0cave', meta: 'insight', ns: 'core/scheduler' },
+  goal: { type: 'memory', title: 'jitter goal', kp: 'nick0cave', meta: 'goal', ns: 'core/scheduler' },
+}
+
+const steps = [
+  { id: 'mem2', t: '13:18', rel: '기원' },
+  { id: 'mem', t: '13:49', rel: '통찰 기록', anchor: true },
+  { id: 'goal', t: '13:50', rel: '골 진단 갱신' },
+]
+
+describe('MemoryLineageRail', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders empty state when no steps are provided', () => {
+    render(html`<${MemoryLineageRail} steps=${[]} nodes=${{}} nodeTypes=${nodeTypes} testId="rail-empty" />`)
+    expect(screen.getByTestId('rail-empty').textContent).toContain('인과 단계가 없습니다')
+  })
+
+  it('renders step times, relations, and node titles', () => {
+    render(html`<${MemoryLineageRail} steps=${steps} nodes=${nodes} nodeTypes=${nodeTypes} testId="rail" />`)
+    const rail = screen.getByTestId('rail')
+    expect(rail.textContent).toContain('13:18')
+    expect(rail.textContent).toContain('13:49')
+    expect(rail.textContent).toContain('13:50')
+    expect(rail.textContent).toContain('기원')
+    expect(rail.textContent).toContain('통찰 기록')
+    expect(rail.textContent).toContain('insight checkpoint')
+    expect(rail.textContent).toContain('jitter goal')
+  })
+
+  it('marks the anchor step with an entry tag', () => {
+    render(html`<${MemoryLineageRail} steps=${steps} nodes=${nodes} nodeTypes=${nodeTypes} testId="rail" />`)
+    expect(screen.getByText('진입 지점')).not.toBeNull()
+  })
+
+  it('renders a legend from node types', () => {
+    render(html`<${MemoryLineageRail} steps=${steps} nodes=${nodes} nodeTypes=${nodeTypes} testId="rail" />`)
+    expect(screen.getAllByText('기억').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('엣지 = 관계')).not.toBeNull()
+  })
+
+  it('skips steps whose node is missing', () => {
+    const missingSteps = [
+      { id: 'mem', t: '13:49', rel: '통찰 기록' },
+      { id: 'unknown', t: '14:00', rel: 'missing' },
+    ]
+    render(html`<${MemoryLineageRail} steps=${missingSteps} nodes=${nodes} nodeTypes=${nodeTypes} testId="rail" />`)
+    expect(screen.getByTestId('rail').textContent).toContain('통찰 기록')
+    expect(screen.getByTestId('rail').textContent).not.toContain('missing')
+  })
+})

--- a/dashboard/src/components/memory/memory-lineage-rail.ts
+++ b/dashboard/src/components/memory/memory-lineage-rail.ts
@@ -1,0 +1,89 @@
+import { html } from 'htm/preact'
+import {
+  cx,
+  MgEntry,
+  MgLegend,
+  MgSig,
+  type MemoryKeeper,
+  type MemoryNode,
+  type MemoryNodeType,
+} from './memory-primitives'
+
+export interface MemoryLineageStep {
+  readonly id: string
+  readonly t: string
+  readonly rel: string
+  readonly anchor?: boolean
+}
+
+export interface MemoryLineageRailProps {
+  readonly steps: ReadonlyArray<MemoryLineageStep>
+  readonly nodes: Readonly<Record<string, MemoryNode>>
+  readonly nodeTypes: Readonly<Record<string, MemoryNodeType>>
+  readonly keepers?: Readonly<Record<string, MemoryKeeper>>
+  readonly ariaLabel?: string
+  readonly testId?: string
+}
+
+export function MemoryLineageRail({
+  steps,
+  nodes,
+  nodeTypes,
+  keepers = {},
+  ariaLabel = '메모리 인과 추적',
+  testId,
+}: MemoryLineageRailProps) {
+  if (steps.length === 0) {
+    return html`
+      <div class="mg-board" data-testid=${testId} aria-label=${ariaLabel}>
+        <${MgEntry} extra="lineage · 위→아래 인과 흐름" />
+        <div class="flex items-center justify-center text-xs text-[var(--color-fg-muted)]" style=${{ minHeight: '160px' }}>
+          인과 단계가 없습니다.
+        </div>
+      </div>
+    `
+  }
+
+  return html`
+    <div class="mg-board" data-testid=${testId} aria-label=${ariaLabel}>
+      <${MgEntry} extra="lineage · 위→아래 인과 흐름" />
+      <div class="mg-rail" role="list" aria-label=${ariaLabel}>
+        ${steps.map((step, i) => {
+          const n = nodes[step.id]
+          const t = n ? nodeTypes[n.type] : undefined
+          if (!n || !t) return null
+          return html`
+            <div
+              key=${step.id}
+              class=${cx('mg-step', step.anchor && 'is-anchor')}
+              style=${{ '--nc': t.c }}
+              role="listitem"
+            >
+              <div class="mg-spine">
+                <span class="mg-time mono">${step.t}</span>
+                <span class="mg-knot"><span class="g">${t.g}</span></span>
+                ${i < steps.length - 1 ? html`<span class="mg-wire" />` : null}
+              </div>
+              <div class="mg-step-body">
+                <div class="mg-rel mono">${step.rel}</div>
+                <div class="mg-step-card">
+                  <div class="mg-node-top">
+                    <span class="mg-type"><span class="g">${t.g}</span>${t.kr}</span>
+                    ${step.anchor ? html`<span class="mg-anchor-tag mono">진입 지점</span>` : null}
+                  </div>
+                  <div class="mg-title">${n.title}</div>
+                  <div class="mg-node-foot">
+                    <${MgSig} kp=${n.kp} keepers=${keepers} size=${15} />
+                    <span class="mono ns">⌗ ${n.ns}</span>
+                    <span class="mono meta2">${n.meta}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          `
+        })}
+      </div>
+      <${MgLegend} nodeTypes=${nodeTypes} />
+    </div>
+  `
+}

--- a/dashboard/src/components/memory/memory-primitives.ts
+++ b/dashboard/src/components/memory/memory-primitives.ts
@@ -1,0 +1,117 @@
+import { html } from 'htm/preact'
+
+export interface MemoryNodeType {
+  readonly kr: string
+  readonly g: string
+  readonly c: string
+}
+
+export interface MemoryKeeper {
+  readonly s: string
+  readonly c: string
+}
+
+export interface MemoryNode {
+  readonly type: string
+  readonly title: string
+  readonly kp: string
+  readonly meta: string
+  readonly ns: string
+}
+
+export function cx(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ')
+}
+
+interface SigProps {
+  readonly kp: string
+  readonly keepers?: Readonly<Record<string, MemoryKeeper>>
+  readonly size?: number
+}
+
+export function MgSig({ kp, keepers = {}, size = 16 }: SigProps) {
+  const k = keepers[kp] ?? { s: '??', c: 'var(--text-dim)' }
+  return html`
+    <span
+      class="mg-sig"
+      style=${{
+        '--kc': k.c,
+        width: size,
+        height: size,
+        fontSize: size * 0.5,
+      }}
+    >${k.s}</span>
+  `
+}
+
+interface EntryProps {
+  readonly extra?: string
+}
+
+export function MgEntry({ extra }: EntryProps) {
+  return html`
+    <div class="mg-entry">
+      <span class="mg-entry-g">◆</span>
+      <span>메모리 링크로 진입</span>
+      <span class="mono dim">mem_7f3 · core/scheduler 체크포인트</span>
+      ${extra ? html`<span class="mg-entry-x mono">${extra}</span>` : null}
+    </div>
+  `
+}
+
+interface LegendProps {
+  readonly nodeTypes: Readonly<Record<string, MemoryNodeType>>
+}
+
+export function MgLegend({ nodeTypes }: LegendProps) {
+  return html`
+    <div class="mg-legend">
+      ${Object.entries(nodeTypes).map(
+        ([key, t]) => html`
+          <span key=${key} class="mg-leg" style=${{ '--nc': t.c }}>
+            <span class="d" />${t.kr}
+          </span>
+        `,
+      )}
+      <span class="mg-leg-sep">·</span>
+      <span class="mg-leg-note mono">엣지 = 관계</span>
+    </div>
+  `
+}
+
+interface NodeCardProps {
+  readonly node: MemoryNode
+  readonly type: MemoryNodeType
+  readonly keepers?: Readonly<Record<string, MemoryKeeper>>
+  readonly anchor?: boolean
+  readonly satellite?: boolean
+  readonly onClick?: () => void
+}
+
+export function MgNodeCard({
+  node,
+  type,
+  keepers = {},
+  anchor,
+  satellite,
+  onClick,
+}: NodeCardProps) {
+  return html`
+    <div
+      class=${cx('mg-node', anchor && 'is-anchor', satellite && 'is-sat')}
+      style=${{ '--nc': type.c }}
+      onClick=${onClick}
+      title=${node.title}
+    >
+      <div class="mg-node-top">
+        <span class="mg-type"><span class="g">${type.g}</span>${type.kr}</span>
+        <span class="mg-meta mono">${node.meta}</span>
+      </div>
+      <div class="mg-title">${node.title}</div>
+      <div class="mg-node-foot">
+        <${MgSig} kp=${node.kp} keepers=${keepers} size=${anchor ? 18 : 15} />
+        <span class="mono ns">⌗ ${node.ns}</span>
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -39,6 +39,7 @@ import './styles/provider-matrix.css'
 import './styles/paper-theme.css'
 import './styles/keeper-workspace.css'
 import './styles/copilot-dock.css'
+import './styles/memory-v2.css'
 
 import { render } from 'preact'
 import { html } from 'htm/preact'

--- a/dashboard/src/styles/memory-v2.css
+++ b/dashboard/src/styles/memory-v2.css
@@ -1,0 +1,632 @@
+/* MASC Dashboard — keeper-v2 memory visualization surfaces (Memory Lens,
+   Lineage Rail, Goal Dossier). Imported after variables.css so the keeper
+   token bridge aliases are available. */
+
+/* ── shared primitives ── */
+.memory-v2 .mono,
+.mg-board .mono,
+.gd-board .mono {
+  font-family: var(--font-mono);
+}
+
+.mg-board {
+  box-sizing: border-box;
+  height: 100%;
+  padding: 14px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background:
+    radial-gradient(ellipse at 30% 0%, rgba(224, 176, 87, 0.05), transparent 60%),
+    var(--bg-deep);
+  color: var(--text-primary);
+}
+
+/* entry breadcrumb */
+.mg-entry {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  color: var(--text-mid);
+  padding: 7px 11px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel-alt);
+}
+
+.mg-entry-g {
+  color: var(--volt);
+  font-size: 12px;
+}
+
+.mg-entry .dim {
+  color: var(--text-dim);
+  font-size: 10.5px;
+}
+
+.mg-entry-x {
+  margin-left: auto;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--volt-strong);
+  background: var(--volt-wash);
+  border: 1px solid color-mix(in oklab, var(--volt) 32%, transparent);
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+}
+
+/* shared node card */
+.mg-node {
+  box-sizing: border-box;
+  width: 152px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-left: 2.5px solid var(--nc);
+  border-radius: var(--radius-md);
+  padding: 8px 10px 9px;
+  box-shadow: var(--shadow-card);
+  transition: 0.16s;
+}
+
+.mg-node-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  margin-bottom: 5px;
+}
+
+.mg-type {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: none;
+  white-space: nowrap;
+  font-size: 9.5px;
+  letter-spacing: 0.06em;
+  color: var(--nc);
+  font-weight: 600;
+}
+
+.mg-type .g {
+  font-size: 10px;
+}
+
+.mg-meta {
+  font-size: 9px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.mg-title {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 1.32;
+  color: var(--text-bright);
+  text-wrap: pretty;
+  margin-bottom: 7px;
+}
+
+.mg-node-foot {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.mg-node-foot .ns {
+  font-size: 9.5px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.mg-node-foot .meta2 {
+  font-size: 9px;
+  color: var(--text-mid);
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.mg-sig {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  color: #0b0c10;
+  background: var(--kc);
+  border-radius: var(--radius-xs);
+}
+
+/* ── A · Memory Lens ── */
+.mg-lens {
+  position: relative;
+  margin: 2px auto 0;
+  flex: none;
+  align-self: center;
+}
+
+.mg-edges {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.mg-pos {
+  position: absolute;
+  transform: translate(-50%, -50%);
+}
+
+.mg-edge-lbl {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  color: var(--text-mid);
+  background: var(--bg-deep);
+  border: 1px solid var(--border-soft);
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.mg-node.is-anchor {
+  width: 180px;
+  border-color: color-mix(in oklab, var(--nc) 55%, var(--border-main));
+  border-left-width: 3px;
+  box-shadow:
+    0 0 0 1px color-mix(in oklab, var(--nc) 30%, transparent),
+    0 0 26px color-mix(in oklab, var(--nc) 16%, transparent);
+  background: var(--bg-card-hover);
+}
+
+.mg-node.is-anchor .mg-title {
+  font-size: 13px;
+}
+
+.mg-node.is-sat {
+  cursor: pointer;
+}
+
+.mg-node.is-sat:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in oklab, var(--nc) 50%, var(--border-main));
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.5);
+}
+
+/* ── B · Lineage Rail ── */
+.mg-rail {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: 2px 2px 0;
+}
+
+.mg-step {
+  display: grid;
+  grid-template-columns: 52px 1fr;
+  gap: 10px;
+}
+
+.mg-spine {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.mg-time {
+  font-size: 9.5px;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+}
+
+.mg-knot {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  flex: none;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-card);
+  border: 1.5px solid var(--nc);
+  color: var(--nc);
+}
+
+.mg-knot .g {
+  font-size: 11px;
+  line-height: 1;
+}
+
+.mg-wire {
+  flex: 1;
+  width: 1.5px;
+  background: linear-gradient(var(--nc), var(--border-main));
+  margin: 2px 0 -2px;
+  opacity: 0.5;
+  min-height: 16px;
+}
+
+.mg-step-body {
+  padding-bottom: 10px;
+  min-width: 0;
+}
+
+.mg-rel {
+  font-size: 10px;
+  color: var(--text-mid);
+  margin: 1px 0 6px;
+}
+
+.mg-step-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-left: 2.5px solid var(--nc);
+  border-radius: var(--radius-md);
+  padding: 9px 11px;
+}
+
+.mg-step.is-anchor .mg-step-card {
+  background: var(--bg-card-hover);
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--nc) 30%, transparent);
+}
+
+.mg-step-card .mg-title {
+  font-size: 12.5px;
+  margin-bottom: 7px;
+}
+
+.mg-anchor-tag {
+  font-size: 9px;
+  color: var(--volt-strong);
+  background: var(--volt-wash);
+  border: 1px solid color-mix(in oklab, var(--volt) 32%, transparent);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+}
+
+/* legend */
+.mg-legend {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-soft);
+  font-size: 10.5px;
+  color: var(--text-mid);
+}
+
+.mg-leg {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.mg-leg .d {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--nc);
+}
+
+.mg-leg-sep {
+  color: var(--text-dim);
+}
+
+.mg-leg-note {
+  font-size: 9.5px;
+  color: var(--text-dim);
+}
+
+/* ── C · Goal Dossier ── */
+.gd-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.gd-head-l {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  min-width: 0;
+  flex: 1;
+}
+
+.gd-glyph {
+  font-size: 22px;
+  color: var(--accent-ice);
+  line-height: 1;
+  margin-top: 2px;
+  flex: none;
+  text-shadow: 0 0 16px color-mix(in oklab, var(--accent-ice) 30%, transparent);
+}
+
+.gd-ey {
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 3px;
+}
+
+.gd-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 17px;
+  line-height: 1.25;
+  color: var(--text-bright);
+  text-wrap: pretty;
+}
+
+.gd-sub {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  font-size: 10.5px;
+  color: var(--text-mid);
+}
+
+.gd-sub .dimd {
+  color: var(--text-dim);
+}
+
+.gd-ring {
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.gd-ring-in {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--bg-panel);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+}
+
+.gd-ring-in b {
+  font-family: var(--font-mono);
+  font-size: 16px;
+  color: var(--volt-strong);
+  font-weight: 700;
+}
+
+.gd-ring-in span {
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+/* snapshot trend */
+.gd-snapwrap {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.gd-prog {
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-main);
+  overflow: hidden;
+}
+
+.gd-prog-fill {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, color-mix(in oklab, var(--accent-ice) 60%, transparent), var(--volt));
+}
+
+.gd-snaps {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+}
+
+.gd-snaplbl {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.gd-snaparr {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.gd-snap {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+}
+
+.gd-snap.now {
+  border-color: color-mix(in oklab, var(--accent-ice) 45%, var(--border-main));
+  background: var(--bg-card-hover);
+}
+
+.gd-snap b {
+  font-size: 12.5px;
+  color: var(--text-bright);
+}
+
+.gd-snap.now b {
+  color: var(--accent-ice);
+}
+
+.gd-snap .dt {
+  font-size: 9px;
+  color: var(--text-dim);
+}
+
+.gd-snap .nt {
+  font-size: 9.5px;
+  color: var(--text-mid);
+}
+
+.gd-ledger {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1px;
+  background: var(--border-soft);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.gd-cell {
+  background: var(--bg-panel-alt);
+  padding: 9px 8px;
+  text-align: center;
+}
+
+.gd-cv {
+  font-size: 14px;
+  color: var(--text-bright);
+  font-weight: 600;
+}
+
+.gd-ck {
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-top: 3px;
+}
+
+.gd-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+
+.gd-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.gd-group-h {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--nc);
+  font-weight: 600;
+}
+
+.gd-group-h .g {
+  font-size: 12px;
+}
+
+.gd-group-h .cnt {
+  margin-left: 2px;
+  font-size: 9.5px;
+  color: var(--text-dim);
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  padding: 0 6px;
+  border-radius: var(--radius-pill);
+}
+
+.gd-crow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-left: 2.5px solid var(--nc);
+  border-radius: var(--radius-sm);
+  padding: 8px 11px;
+}
+
+.gd-crow.st-ctx {
+  opacity: 0.7;
+}
+
+.gd-cmain {
+  min-width: 0;
+  flex: 1;
+}
+
+.gd-ctitle {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 12.5px;
+  color: var(--text-bright);
+  line-height: 1.3;
+}
+
+.gd-cmeta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 4px;
+  font-size: 10px;
+  color: var(--text-mid);
+}
+
+.gd-state {
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  flex: none;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+}
+
+.gd-state.st-done {
+  color: var(--status-ok);
+  background: color-mix(in oklab, var(--status-ok) 14%, transparent);
+  border-color: color-mix(in oklab, var(--status-ok) 34%, transparent);
+}
+
+.gd-state.st-open {
+  color: var(--volt-strong);
+  background: var(--volt-wash);
+  border-color: color-mix(in oklab, var(--volt) 32%, transparent);
+}
+
+.gd-state.st-block {
+  color: var(--status-bad);
+  background: color-mix(in oklab, var(--status-bad) 14%, transparent);
+  border-color: color-mix(in oklab, var(--status-bad) 34%, transparent);
+}
+
+.gd-state.st-ctx {
+  color: var(--text-dim);
+  border-color: var(--border-main);
+}

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -488,7 +488,6 @@
   --space-6: 32px;
   --space-7: 48px;
   --space-8: 64px;
-
   /* Keeper v2 token bridge — aliases for importing v2 stylesheets.
      Maps the v2 surface vocabulary to the existing dashboard semantic
      token ladder. Tokens that already exist in tokens.generated.css /
@@ -573,4 +572,37 @@ html:not([data-theme="paper"]) {
   --status-bad: var(--err);
 
   --accent-bone: var(--color-accent-fg);
+}
+
+/* Keeper-v2 memory surface token bridge.
+   Scoped to memory boards so the memory graph surfaces keep their
+   warn/ice semantics without overriding the dashboard keeper-v2
+   brass token bridges above. */
+.mg-board,
+.gd-board {
+  --font-display: ui-sans-serif, -apple-system, system-ui, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, monospace;
+  --radius-xs: 2px;
+  --radius-pill: 9999px;
+  --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.35);
+
+  --volt: var(--color-status-warn);
+  --volt-strong: var(--color-status-warn);
+  --volt-wash: color-mix(in srgb, var(--color-status-warn) 14%, transparent);
+  --accent-ice: var(--color-info);
+  --status-ok: var(--color-status-ok);
+  --status-bad: var(--color-status-err);
+  --status-warn: var(--color-status-warn);
+
+  --bg-deep: var(--color-bg-page);
+  --bg-card: var(--color-bg-surface);
+  --bg-card-hover: var(--color-bg-elevated);
+  --bg-panel-alt: var(--color-bg-panel-alt);
+  --bg-sunken: var(--color-bg-page);
+  --border-main: var(--color-border-default);
+  --border-soft: var(--color-border-divider);
+  --text-primary: var(--color-fg-primary);
+  --text-mid: var(--color-fg-secondary);
+  --text-dim: var(--color-fg-muted);
+  --text-bright: var(--color-fg-primary);
 }


### PR DESCRIPTION
## Summary
Ports the keeper-v2 memory visualization surfaces into the MASC dashboard.

## What changed
- **New components** under `dashboard/src/components/memory/`:
  - `memory-lens.ts` — interactive radial 1-hop neighbor graph (click to re-center)
  - `memory-lineage-rail.ts` — vertical causal timeline
  - `goal-dossier.ts` — goal header with conic progress ring, snapshot trend, ledger grid, grouped related items
  - `memory-primitives.ts` — shared types and helpers
- **New styles** `dashboard/src/styles/memory-v2.css` using dashboard tokens.
- **Integration** (minimal):
  - `ide-memory-panel.ts` renders a small `MemoryLens` from fetched memory entries.
  - `agent-detail-memory.ts` renders a `MemoryLineageRail` from episode data.
  - `goal-tree.ts` renders a `GoalDossier` for the selected goal node.
- **Tests** for the three new components.
- **Token bridge** aliases added to `variables.css`.
- **.gitignore** negation for `dashboard/src/components/memory/`.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Targeted memory tests ✅
- `ide-memory-panel.test.ts` ✅
- `goals/goal-tree.test.ts` ✅

## Notes
- Data-driven props; no real backend wiring beyond reusing existing data already fetched by the host surfaces.
- The token bridge block is duplicated from the foundation PR so this branch can stand alone.


---

## 🔄 AS-IS vs TO-BE 구조적 개선점 분석 (Structural Improvements)

```mermaid
graph LR
    subgraph AS_IS ["AS-IS: 기본 대시보드 표면 구조"]
        A1[ide-memory-panel] -->|기본 렌더링| R1[(단순 목록/UI)]
        A2[agent-detail-memory] -->|기본 렌더링| R2[(단순 목록/UI)]
        A3[goal-tree] -->|기본 렌더링| R3[(단순 목록/UI)]
        D1[(기존 Fetch 데이터)] --> A1
        D2[(기존 Fetch 데이터)] --> A2
        D3[(기존 Fetch 데이터)] --> A3
    end

    AS_IS ==>|PR #21358: keeper-v2 메모리 그래프 도입| TO_BE

    subgraph TO_BE ["TO-BE: keeper-v2 메모리 시각화 통합"]
        B1[ide-memory-panel] -->|Props 전달| C1[MemoryLens<br/>인터랙티브 1-hop 그래프]
        B2[agent-detail-memory] -->|Props 전달| C2[MemoryLineageRail<br/>수직 인과 타임라인]
        B3[goal-tree] -->|Props 전달| C3[GoalDossier<br/>Conic Progress & Ledger]

        C1 --> P[memory-primitives.ts<br/>공유 타입 및 헬퍼]
        C2 --> P
        C3 --> P

        C1 --> S[memory-v2.css<br/>대시보드 토큰 스타일]
        C2 --> S
        C3 --> S

        D4[(기존 Fetch 데이터<br/>재사용)] --> B1
        D5[(기존 Fetch 데이터<br/>재사용)] --> B2
        D6[(기존 Fetch 데이터<br/>재사용)] --> B3

        T1[goal-dossier.test.ts] -.->|단위 테스트| C3
        T2[memory-lens.test.ts] -.->|단위 테스트| C1
        T3[memory-lineage-rail.test.ts] -.->|단위 테스트| C2
    end
```

| 기술 범주 | AS-IS (변경 전) | TO-BE (변경 후) | 개선 효과 및 라이벌리지 |
| :--- | :--- | :--- | :--- |
| **메모리 시각화 (UI/UX)** | 호스트 컴포넌트 내의 기본적인 텍스트/단순 목록 형태의 렌더링 | `MemoryLens`(래디얼 1-hop 이웃 그래프), `MemoryLineageRail`(수직 인과 타임라인), `GoalDossier`(Conic progress ring, 스냅샷 트렌드, 원장 그리드) 적용 | keeper-v2의 고도화된 시각화 표면(Surface)을 도입하여 사용자에게 메모리 구조와 목표 달성 현황을 직관적이고 인터랙티브하게 제공 |
| **컴포넌트 모듈성** | 메모리 관련 로직이 기존 패널(`ide-memory-panel`, `agent-detail-memory`, `goal-tree`)에 분산되거나 단일 구조를 가짐 | `dashboard/src/components/memory/` 디렉토리 하에 `memory-lens`, `memory-lineage-rail`, `goal-dossier`, `memory-primitives`로 책임 분리 | 재사용성 및 유지보수성 향상. 공통 타입과 헬퍼를 `primitives`로 묶어 결합도를 낮춤 |
| **데이터 연동 방식** | (기존 방식 유지) | 순수하게 Props 기반(Data-driven)으로 동작하며, 새로운 백엔드 엔드포인트나 추가 데이터 페칭 없이 기존 호스트가 이미 가져온 데이터를 그대로 재사용 | 백엔드 리스크 없이 프론트엔드 UI 계층만 안전하게 교체. 빠른 롤백 및 독립적인 배포 가능 |
| **스타일링 아키텍처** | 기존 대시보드 스타일 시스템 사용 | `memory-v2.css` 신규 도입 및 `variables.css`에 토큰 브릿지(Token bridge) 별칭 추가 | foundation PR의 토큰 의존성을 별칭으로 해결하여 해당 브랜치가 독립적으로 동작할 수 있도록 보장 (스탠드얼론 브랜치 허용) |
| **사용자 인터랙션** | 정적이거나 제한된 탐색 기능 | `MemoryLens`에서 클릭 시 중심점이 이동하는(Re-center) 1-hop 탐색 기능 지원 | 사용자가 메모리 노드 간의 연결성을 능동적으로 탐색할 수 있는 동적 인터랙션 제공 |
| **테스트 커버리지 및 신뢰성** | 호스트 컴포넌트 수준의 기존 테스트 존재 | 신규 컴포넌트 3종에 대한 독립적인 단위 테스트(`goal-dossier.test.ts`, `memory-lens.test.ts`, `memory-lineage-rail.test.ts`) 추가 및 연동 테스트 통과 | 새로운 시각화 로직의 격리된 검증이 가능해지며, 회귀 버그 방지 및 리팩토링 시의 안정성 확보 |
| **빌드 및 설정 관리** | `dashboard/src/components/memory/` 경로에 대한 별도 규칙 없음 | `.gitignore`에 해당 경로에 대한 네게이션(Negation) 규칙 추가 | 신규 모듈이 의도치 않게 무시되는 빌드 및 버전 관리 이슈를 사전에 방지 |
