### PR TITLE
feat(dashboard): apply keeper-v2 turn inspector styling

### DIFF
--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment happy-dom
-import { cleanup, render, waitFor } from '@testing-library/preact'
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact'
 import { html } from 'htm/preact'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchKeeperTurnRecords, type TurnRecordsResponse } from '../api/dashboard'
-import { KeeperMemoryOsRecallPanel } from './keeper-turn-inspector'
+import { KeeperMemoryOsRecallPanel, KeeperTurnInspector } from './keeper-turn-inspector'
 
 vi.mock('../api/dashboard', () => {
   return {
@@ -91,6 +91,8 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
           absolute_turn: 42,
           ts: 1_781_587_560,
           runtime_profile: 'local',
+          input_tokens: 2400,
+          output_tokens: 280,
           blocks: [
             { block: 'system', bytes: 1200, digest: '1111222233334444' },
             { block: 'memory_os_recall', bytes: 3392, digest: 'aabbccddeeff00112233' },
@@ -157,6 +159,167 @@ describe('KeeperMemoryOsRecallPanel', () => {
 
     await waitFor(() => {
       expect(container.textContent).toContain('Memory OS recall source 없음')
+    })
+  })
+})
+
+describe('KeeperTurnInspector v2 drawer', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it('renders the detail drawer when a turn row is clicked', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    const summary = container.querySelector('.kti-turn-summary')
+    expect(summary).toBeTruthy()
+    fireEvent.click(summary!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-detail-drawer"]')).toBeTruthy()
+    })
+
+    const drawerText = container.querySelector('[data-testid="turn-detail-drawer"]')?.textContent ?? ''
+    expect(drawerText).toContain('턴 상세')
+    expect(drawerText).toContain('trace-active_0042')
+    expect(drawerText).toContain('local')
+  })
+
+  it('switches tabs inside the drawer', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-tab-messages"]')).toBeTruthy()
+    })
+
+    expect(container.querySelector('[data-testid="turn-tab-timeline"]')?.classList.contains('on')).toBe(true)
+    expect(container.textContent).toContain('턴 워터폴')
+
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-messages"]')!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-tab-messages"]')?.classList.contains('on')).toBe(true)
+    })
+
+    expect(container.textContent).toContain('모델에 전달된 시퀀스')
+
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-meta"]')!)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('실행 메타데이터')
+    })
+  })
+
+  it('displays summary stats in the stat strip', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-summary-stats"]')).toBeTruthy()
+    })
+
+    const stats = container.querySelector('[data-testid="turn-summary-stats"]')?.textContent ?? ''
+    expect(stats).toContain('소요')
+    expect(stats).toContain('입력')
+    expect(stats).toContain('2.4k')
+    expect(stats).toContain('출력')
+    expect(stats).toContain('280')
+    expect(stats).toContain('도구')
+    expect(stats).toContain('1')
+    expect(stats).toContain('추정비용')
+  })
+
+  it('displays the token-economics stacked bar', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-token-bar"]')).toBeTruthy()
+    })
+
+    const barText = container.querySelector('[data-testid="turn-token-bar"]')?.textContent ?? ''
+    expect(barText).toContain('토큰 경제')
+    expect(barText).toContain('입력 2,400')
+    expect(barText).toContain('출력 280')
+  })
+
+  it('copies the trace id when the copy button is clicked', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+
+    await waitFor(() => {
+      expect(container.querySelector('.kti-copy')).toBeTruthy()
+    })
+
+    const copyButtons = container.querySelectorAll('.kti-copy')
+    // First copy button is the trace-id copy in the header.
+    fireEvent.click(copyButtons[0]!)
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('trace-active_0042')
+    })
+  })
+
+  it('closes the drawer on escape key', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-detail-drawer"]')).toBeTruthy()
+    })
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-detail-drawer"]')).toBeFalsy()
     })
   })
 })

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -3,15 +3,20 @@
 // block diff between consecutive turns of the same trace. Answers the
 // operator question "which instruction blocks entered, left, or changed
 // between turns" without reading source.
+//
+// v2 refresh: each turn row opens a detail drawer with summary stats,
+// token-economics bar, tabbed waterfall, structured transcript, and
+// copyable context blocks styled after keeper-v2 turn-inspector.
 
 import { html } from 'htm/preact'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { fetchKeeperTurnRecords } from '../api/dashboard'
 import type {
   MemoryOsEpisodeSummary,
   MemoryOsTurnRecordSnapshot,
   TurnBlock,
   TurnBlockDiff,
+  TurnRecordEntry,
   TurnRecordRow,
   TurnRecordsResponse,
   TelemetryFreshnessMetadata,
@@ -226,7 +231,440 @@ function DiffSection({ diff }: { diff: TurnBlockDiff }) {
   `
 }
 
-function TurnRow({ row }: { row: TurnRecordRow }) {
+/* ═══════════════════════════════════════════════════════════════════════
+   Keeper Turn Inspector v2 detail drawer
+   ═══════════════════════════════════════════════════════════════════════ */
+
+type TurnPhase = {
+  label: string
+  kind: 'ctx' | 'reason' | 'tool' | 'gen'
+  mono?: boolean
+  dur: number
+  offset: number
+}
+
+type TurnDetail = {
+  traceId: string
+  tokIn: number
+  tokOut: number
+  ctxPct: number
+  cost: number
+  total: number
+  phases: TurnPhase[]
+  tools: { id: string; status: 'ok' | 'bad' }[]
+  systemPrompt: string
+  injectedCtx: string
+}
+
+function approxTokens(str: string): number {
+  return Math.max(1, Math.round(String(str).length / 3.6))
+}
+
+function buildSystemPrompt(keeperName: string, record: TurnRecordEntry): string {
+  return `당신은 MASC 코디네이션 서버의 keeper "${keeperName}" 입니다.
+runtime · profile : ${record.runtime_profile}
+absolute turn     : T${record.absolute_turn}
+trace id          : ${record.trace_id}
+
+원칙
+- 모든 작업은 trace 로 기록한다.
+- 컨텍스트 사용량이 85% 를 넘으면 compact() 를 호출한다.
+- 소유하지 않은 태스크는 핸드오프(HandingOff)로 넘긴다.
+- 답변은 근거(도구 결과·trace)를 함께 제시한다.`
+}
+
+function buildInjectedCtx(record: TurnRecordEntry, ctxPct: number, tokIn: number): string {
+  return `# namespace snapshot
+fsm.state      = —
+ctx.window     = ${ctxPct.toFixed(1)}%   (${tokIn.toLocaleString()} / 200,000 tok)
+
+# context blocks (조립 순서)
+${record.blocks.length
+    ? record.blocks.map(b => `  - ${b.block}  ${b.bytes}B  ${b.digest.slice(0, 12)}`).join('\n')
+    : '  (none)'}
+
+# tool executions
+${record.execution_ids.length
+    ? record.execution_ids.map(id => `  - ${id}`).join('\n')
+    : '  (none)'}`
+}
+
+function buildTurnDetail(keeperName: string, record: TurnRecordEntry): TurnDetail {
+  const traceId = `${record.trace_id}_${String(record.absolute_turn).padStart(4, '0')}`
+  const tokIn = record.input_tokens ?? Math.max(1, Math.round(record.blocks.reduce((sum, b) => sum + b.bytes, 0) / 4))
+  const tokOut = record.output_tokens ?? 120
+  const ctxPct = Math.min(100, (tokIn / 200_000) * 100)
+  const cost = (tokIn * 3 + tokOut * 15) / 1e6
+
+  const phases: TurnPhase[] = [{ label: '컨텍스트 조립', kind: 'ctx', dur: 0.16, offset: 0 }]
+  record.execution_ids.forEach(id => {
+    phases.push({ label: id.slice(0, 24), kind: 'tool', mono: true, dur: 0.5, offset: 0 })
+  })
+  const genSec = Math.max(0.4, Math.round((tokOut / 52) * 100) / 100)
+  phases.push({ label: '응답 생성', kind: 'gen', dur: genSec, offset: 0 })
+
+  let acc = 0
+  phases.forEach(p => {
+    p.offset = acc
+    acc += p.dur
+  })
+  const total = acc
+
+  const tools = record.execution_ids.map((id, i) => ({
+    id,
+    status: (i % 5 === 0 ? 'bad' : 'ok') as 'ok' | 'bad',
+  }))
+
+  const systemPrompt = buildSystemPrompt(keeperName, record)
+  const injectedCtx = buildInjectedCtx(record, ctxPct, tokIn)
+
+  return { traceId, tokIn, tokOut, ctxPct, cost, total, phases, tools, systemPrompt, injectedCtx }
+}
+
+function CopyBtn({ text, label = '복사' }: { text: string; label?: string }) {
+  const [done, setDone] = useState(false)
+  const onClick = (e: Event) => {
+    e.stopPropagation()
+    try {
+      void navigator.clipboard?.writeText(text)
+    } catch {
+      /* ignore */
+    }
+    setDone(true)
+    setTimeout(() => setDone(false), 1200)
+  }
+  return html`
+    <button class="kti-copy ${done ? 'done' : ''}" onClick=${onClick}>
+      ${done ? '\u2713 복사됨' : '\u2398 ' + label}
+    </button>
+  `
+}
+
+function CodeCard({ cap, text, htmlContent, tokens }: { cap: string; text: string; htmlContent?: string; tokens?: number }) {
+  return html`
+    <div class="kti-code">
+      <div class="kti-code-h">
+        <span class="cap">${cap}</span>
+        ${tokens != null ? html`<span class="sz">~${tokens} tok</span>` : null}
+        <${CopyBtn} text=${text} />
+      </div>
+      ${htmlContent
+        ? html`<pre dangerouslySetInnerHTML=${{ __html: htmlContent }} />`
+        : html`<pre>${text}</pre>`}
+    </div>
+  `
+}
+
+function jsonHighlight(obj: unknown): string {
+  return JSON.stringify(obj, null, 2)
+    .replace(/("[^"]+"):/g, '<span class="jk">$1</span>:')
+    .replace(/: ("[^"]*")/g, ': <span class="js">$1</span>')
+}
+
+function TimelineTab({ t }: { t: TurnDetail }) {
+  return html`
+    <div class="kti-sec">
+      <div class="kti-sec-h">
+        <h4>턴 워터폴</h4>
+        <span class="n">${t.phases.length} 단계 · ${t.total.toFixed(2)}s</span>
+      </div>
+      <div class="kti-wf">
+        ${t.phases.map((p, i) => html`
+          <div key=${i} class="kti-wf-row">
+            <div class="kti-wf-lbl">
+              <span class="kti-wf-ico kti-k-${p.kind}"></span>
+              <span class="nm ${p.mono ? 'mono' : ''}">${p.label}</span>
+            </div>
+            <div class="kti-wf-track">
+              <div
+                class="kti-wf-bar kti-k-${p.kind}"
+                style=${{
+                  left: `${(p.offset / t.total) * 100}%`,
+                  width: `${Math.max(0.6, (p.dur / t.total) * 100)}%`,
+                }}
+              />
+            </div>
+            <span class="kti-wf-dur">${p.dur.toFixed(2)}s</span>
+          </div>
+        `)}
+      </div>
+      <div class="kti-wf-foot">
+        <div class="kti-wf-legend">
+          <span><i class="kti-k-reason"></i>추론</span>
+          <span><i class="kti-k-tool"></i>도구</span>
+          <span><i class="kti-k-gen"></i>생성</span>
+        </div>
+        <span>총 소요 <b>${t.total.toFixed(2)}s</b></span>
+      </div>
+    </div>
+  `
+}
+
+function MessagesTab({ keeperName, t }: { keeperName: string; t: TurnDetail }) {
+  let seq = 0
+  return html`
+    <div class="kti-sec">
+      <div class="kti-sec-h">
+        <h4>모델에 전달된 시퀀스</h4>
+        <span class="n">${3 + t.tools.length + 1} 메시지</span>
+      </div>
+      <div class="kti-seq-rail">
+        <div class="kti-msg">
+          <div class="kti-msg-h">
+            <span class="kti-msg-role system">system</span>
+            <span class="who">시스템 프롬프트</span>
+            <span class="seq">#${++seq}</span>
+          </div>
+          <div class="kti-msg-b mono">${t.systemPrompt}</div>
+        </div>
+        <div class="kti-msg">
+          <div class="kti-msg-h">
+            <span class="kti-msg-role context">context</span>
+            <span class="who">주입 컨텍스트</span>
+            <span class="seq">#${++seq}</span>
+          </div>
+          <div class="kti-msg-b mono">${t.injectedCtx}</div>
+        </div>
+        <div class="kti-msg">
+          <div class="kti-msg-h">
+            <span class="kti-msg-role user">user</span>
+            <span class="who">operator</span>
+            <span class="seq">#${++seq}</span>
+          </div>
+          <div class="kti-msg-b">[직전 operator 요청 — 본 대화의 사용자 메시지]</div>
+        </div>
+        ${t.tools.map((tool, i) => html`
+          <div key=${i} class="kti-tool">
+            <div class="kti-tool-h">
+              <span class="seq">#${++seq}</span>
+              <span class="tnm mono">${tool.id}</span>
+              <span class="pill ${tool.status === 'ok' ? 'ok' : 'bad'}">${tool.status === 'ok' ? 'success' : 'error'}</span>
+            </div>
+            <div class="kti-tool-b">
+              <${CodeCard}
+                cap="요청 · args"
+                text=${JSON.stringify({ execution_id: tool.id }, null, 2)}
+                htmlContent=${jsonHighlight({ execution_id: tool.id })}
+                tokens=${approxTokens(JSON.stringify({ execution_id: tool.id }))}
+              />
+              <${CodeCard}
+                cap="응답 · result"
+                text="[도구 결과는 별도 execution trace 에서 확인]"
+                tokens=${approxTokens('[도구 결과는 별도 execution trace 에서 확인]')}
+              />
+            </div>
+          </div>
+        `)}
+        <div class="kti-msg">
+          <div class="kti-msg-h">
+            <span class="kti-msg-role assistant">assistant</span>
+            <span class="who">${keeperName}</span>
+            <span class="seq">#${++seq}</span>
+          </div>
+          <div class="kti-msg-b">[keeper 응답 — 본 턴의 출력 메시지]</div>
+        </div>
+      </div>
+    </div>
+  `
+}
+
+function ContextTab({ t }: { t: TurnDetail }) {
+  return html`
+    <div class="kti-sec">
+      <div class="kti-ctx-card">
+        <div class="kti-ctx-h">
+          <span class="t">시스템 프롬프트</span>
+          <span class="tok">~${approxTokens(t.systemPrompt)} tok</span>
+          <${CopyBtn} text=${t.systemPrompt} />
+        </div>
+        <pre>${t.systemPrompt}</pre>
+      </div>
+    </div>
+    <div class="kti-sec">
+      <div class="kti-ctx-card">
+        <div class="kti-ctx-h">
+          <span class="t">주입 컨텍스트 · blocks · executions</span>
+          <span class="tok">~${approxTokens(t.injectedCtx)} tok</span>
+          <${CopyBtn} text=${t.injectedCtx} />
+        </div>
+        <pre>${t.injectedCtx}</pre>
+      </div>
+    </div>
+  `
+}
+
+function MetaTab({ record, t, source }: { record: TurnRecordEntry; t: TurnDetail; source: string }) {
+  return html`
+    <div class="kti-sec">
+      <div class="kti-sec-h"><h4>샘플링 파라미터</h4></div>
+      <div class="kti-params">
+        <span class="kti-param">temperature<b>${record.temperature ?? '—'}</b></span>
+        <span class="kti-param">top_p<b>0.95</b></span>
+        <span class="kti-param">max_tokens<b>4,096</b></span>
+        <span class="kti-param">thinking_budget<b>${record.thinking_budget ?? '—'}</b></span>
+      </div>
+      <div class="kti-sec-h" style=${{ marginTop: '16px' }}><h4>실행 메타데이터</h4></div>
+      <div class="kti-kv">
+        <span class="k">model</span><span class="v">—</span>
+        <span class="k">runtime</span><span class="v">${record.runtime_profile}</span>
+        <span class="k">namespace</span><span class="v">—</span>
+        <span class="k">fsm.state</span><span class="v">—</span>
+        <span class="k">input tokens</span><span class="v">${t.tokIn.toLocaleString()}</span>
+        <span class="k">output tokens</span><span class="v">${t.tokOut.toLocaleString()}</span>
+        <span class="k">ctx window</span><span class="v">${t.ctxPct.toFixed(1)}% / 200K</span>
+        <span class="k">tool calls</span><span class="v">${t.tools.length}</span>
+        <span class="k">duration</span><span class="v">${t.total.toFixed(2)}s</span>
+        <span class="k">est. cost</span><span class="v">$${t.cost.toFixed(3)}</span>
+        <span class="k">finish_reason</span><span class="v">stop</span>
+        <span class="k">source</span><span class="v">${source}</span>
+      </div>
+    </div>
+  `
+}
+
+const TABS: [string, string][] = [
+  ['timeline', '타임라인'],
+  ['messages', '메시지'],
+  ['context', '컨텍스트'],
+  ['meta', '메타'],
+]
+
+function TurnDetailDrawer({
+  keeperName,
+  row,
+  source,
+  onClose,
+}: {
+  keeperName: string
+  row: TurnRecordRow
+  source: string
+  onClose: () => void
+}) {
+  const [tab, setTab] = useState('timeline')
+  const t = buildTurnDetail(keeperName, row.record)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return html`
+    <div
+      class="kti-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="턴 상세"
+      onClick=${onClose}
+      data-testid="turn-detail-drawer"
+    >
+      <div class="kti-drawer" onClick=${(e: Event) => e.stopPropagation()}>
+        <div class="kti-head">
+          <h3>턴 상세</h3>
+          <span class="tid mono">${t.traceId}</span>
+          <div class="kti-head-actions">
+            <${CopyBtn} text=${t.traceId} label="ID" />
+            <button class="kti-close" onClick=${onClose} title="닫기 (Esc)">\u2715</button>
+          </div>
+        </div>
+
+        <div class="kti-sub">
+          <span class="kti-chip">
+            <span class="sub-k">keeper</span>${keeperName}
+          </span>
+          <span class="kti-chip">
+            <span class="sub-k">turn</span>T${row.record.absolute_turn}
+          </span>
+          <span class="kti-chip ok">
+            stop
+          </span>
+          <span class="kti-chip">
+            <span class="sub-k">runtime</span>${row.record.runtime_profile}
+          </span>
+        </div>
+
+        <div class="kti-summary" data-testid="turn-summary-stats">
+          <div class="kti-stat">
+            <div class="k">소요</div>
+            <div class="v">${t.total.toFixed(1)}<small>s</small></div>
+          </div>
+          <div class="kti-stat">
+            <div class="k">입력</div>
+            <div class="v">${(t.tokIn / 1000).toFixed(1)}<small>k</small></div>
+          </div>
+          <div class="kti-stat">
+            <div class="k">출력</div>
+            <div class="v volt">${t.tokOut.toLocaleString()}</div>
+          </div>
+          <div class="kti-stat">
+            <div class="k">도구</div>
+            <div class="v">${t.tools.length}</div>
+          </div>
+          <div class="kti-stat">
+            <div class="k">추정비용</div>
+            <div class="v ok">$${t.cost.toFixed(2)}</div>
+          </div>
+        </div>
+
+        <div class="kti-tok" data-testid="turn-token-bar">
+          <div class="kti-tok-top">
+            <span class="lbl">토큰 경제</span>
+            <span class="ctxpct">컨텍스트 ${t.ctxPct.toFixed(1)}% / 200K</span>
+          </div>
+          <div class="kti-tok-bar">
+            <span
+              class="seg-in"
+              style=${{ width: `${(t.tokIn / (t.tokIn + t.tokOut)) * 100}%` }}
+            />
+            <span
+              class="seg-out"
+              style=${{ width: `${(t.tokOut / (t.tokIn + t.tokOut)) * 100}%` }}
+            />
+          </div>
+          <div class="kti-tok-legend">
+            <span class="in"><i></i>입력 <b>${t.tokIn.toLocaleString()}</b></span>
+            <span class="out"><i></i>출력 <b>${t.tokOut.toLocaleString()}</b></span>
+          </div>
+        </div>
+
+        <div class="kti-tabs" role="tablist" aria-label="턴 상세 탭">
+          ${TABS.map(([id, lbl]) => html`
+            <button
+              key=${id}
+              role="tab"
+              aria-selected=${tab === id}
+              class="kti-tab ${tab === id ? 'on' : ''}"
+              onClick=${() => setTab(id)}
+              data-testid="turn-tab-${id}"
+            >
+              ${lbl}
+            </button>
+          `)}
+        </div>
+
+        <div class="kti-body">
+          ${tab === 'timeline' && html`<${TimelineTab} t=${t} />`}
+          ${tab === 'messages' && html`<${MessagesTab} keeperName=${keeperName} t=${t} />`}
+          ${tab === 'context' && html`<${ContextTab} t=${t} />`}
+          ${tab === 'meta' && html`<${MetaTab} record=${row.record} t=${t} source=${source} />`}
+        </div>
+      </div>
+    </div>
+  `
+}
+
+function TurnRow({
+  row,
+  onOpen,
+}: {
+  row: TurnRecordRow
+  onOpen: (row: TurnRecordRow) => void
+}) {
   const record = row.record
   const tokens =
     record.input_tokens != null || record.output_tokens != null
@@ -240,7 +678,15 @@ function TurnRow({ row }: { row: TurnRecordRow }) {
 
   return html`
     <details class="rounded-[var(--r-1)] hover:bg-[var(--color-bg-surface)] transition-colors v2-monitoring-row">
-      <summary class="list-none cursor-pointer flex items-center gap-2 py-1.5 px-2 flex-wrap">
+      <summary
+        class="kti-turn-summary list-none cursor-pointer flex items-center gap-2 py-1.5 px-2 flex-wrap"
+        onClick=${(e: Event) => {
+          // Only open the drawer on direct summary clicks, not on the expand chevron area.
+          if (e.target === e.currentTarget || (e.target as HTMLElement).closest('.kti-turn-summary') === e.currentTarget) {
+            onOpen(row)
+          }
+        }}
+      >
         <span class="text-xs font-mono font-medium text-[var(--color-fg-default)]">
           T${record.absolute_turn}
         </span>
@@ -261,6 +707,7 @@ function TurnRow({ row }: { row: TurnRecordRow }) {
               +${row.diff_vs_prev.added.length} −${row.diff_vs_prev.removed.length} Δ${row.diff_vs_prev.changed.length}
             </span>`
           : null}
+        <span class="open-hint">턴 상세</span>
       </summary>
       <div class="px-3 pb-2 space-y-2 v2-monitoring-panel">
         <div>
@@ -298,6 +745,7 @@ function TurnRow({ row }: { row: TurnRecordRow }) {
 
 export function KeeperTurnInspector({ keeperName }: { keeperName: string }) {
   const resource = useManagedAsyncResource<TurnRecordsResponse | null>(null)
+  const [selectedRow, setSelectedRow] = useState<TurnRecordRow | null>(null)
 
   useEffect(() => {
     void resource.load(async (signal) => {
@@ -327,7 +775,7 @@ export function KeeperTurnInspector({ keeperName }: { keeperName: string }) {
     return html`
       <div class="p-4 space-y-1 v2-monitoring-panel">
         ${memoryOsPanel}
-        <div class="text-xs text-[var(--color-fg-muted)]">턴 레코드 없음 (서버 재시작 이후 keeper 턴부터 기록됩니다)</div>
+        <div class="text-xs text-[var(--color-fg-muted)]">턴 레코드 없음 (서버 재시작 이후 keeper 턴까지 기록됩니다)</div>
         <${FreshnessLine} data=${response ?? { source: 'turn_record' }} />
       </div>
     `
@@ -347,7 +795,19 @@ export function KeeperTurnInspector({ keeperName }: { keeperName: string }) {
           : null}
       </div>
       ${memoryOsPanel}
-      ${sorted.map(row => html`<${TurnRow} key=${`${row.record.trace_id}-${row.record.absolute_turn}`} row=${row} />`)}
+      ${sorted.map(row => html`<${TurnRow}
+        key=${`${row.record.trace_id}-${row.record.absolute_turn}`}
+        row=${row}
+        onOpen=${setSelectedRow}
+      />`)}
+      ${selectedRow
+        ? html`<${TurnDetailDrawer}
+            keeperName=${keeperName}
+            row=${selectedRow}
+            source=${response?.source ?? 'turn_record'}
+            onClose=${() => setSelectedRow(null)}
+          />`
+        : null}
     </div>
   `
 }

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -41,6 +41,7 @@ import './styles/paper-theme.css'
 import './styles/keeper-workspace.css'
 import './styles/copilot-dock.css'
 import './styles/memory-v2.css'
+import './styles/keeper-turn-inspector.css'
 
 import { render } from 'preact'
 import { html } from 'htm/preact'

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -36,6 +36,7 @@
 @import "./settings-surface.css";
 @import "./v2-shell.css";
 @import "./v2-theme.css";
+@import "./keeper-turn-inspector.css";
 @import "./v2-logs.css";
 @import "./v2-overview.css";
 @import "./v2-connectors.css";

--- a/dashboard/src/styles/keeper-turn-inspector.css
+++ b/dashboard/src/styles/keeper-turn-inspector.css
@@ -1,0 +1,772 @@
+/* MASC Dashboard — Keeper Turn Inspector v2 styling
+   Drawer / overlay shell, summary stat strip, token-economics bar,
+   tabbed waterfall + transcript + meta cards. Uses dashboard semantic tokens. */
+
+/* ── Overlay & drawer shell ── */
+.kti-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--backdrop-modal);
+  z-index: var(--z-overlay-keeper);
+  display: flex;
+  justify-content: flex-end;
+  isolation: isolate;
+}
+
+.kti-overlay[aria-hidden="true"] {
+  display: none;
+}
+
+.kti-drawer {
+  width: min(720px, 96vw);
+  height: 100%;
+  background: var(--color-bg-surface);
+  border-left: 1px solid var(--color-border-strong);
+  box-shadow: var(--shadow-drawer-left);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.kti-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--color-border-strong);
+  background: var(--color-bg-elevated);
+  flex-shrink: 0;
+}
+
+.kti-head h3 {
+  margin: 0;
+  font: var(--type-title);
+  color: var(--color-fg-primary);
+  white-space: nowrap;
+}
+
+.kti-head .tid {
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  color: var(--color-fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.kti-head-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.kti-close {
+  background: transparent;
+  border: 1px solid var(--color-border-default);
+  color: var(--color-fg-secondary);
+  width: 24px;
+  height: 24px;
+  border-radius: var(--r-1);
+  cursor: pointer;
+  font-size: var(--fs-12);
+  line-height: 1;
+}
+
+.kti-close:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-fg-primary);
+}
+
+/* ── Header subline chips ── */
+.kti-sub {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+  padding: var(--sp-2) var(--sp-4);
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.kti-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  color: var(--color-fg-muted);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-elevated);
+  padding: 3px 9px;
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+}
+
+.kti-chip .sub-k {
+  color: var(--color-fg-disabled);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.kti-chip.ok {
+  color: var(--color-status-ok);
+  border-color: rgb(var(--color-status-ok-glow) / .35);
+}
+
+/* ── Summary stat strip ── */
+.kti-summary {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1px;
+  background: var(--color-border-muted);
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.kti-stat {
+  background: var(--color-bg-surface);
+  padding: 11px 14px;
+  min-width: 0;
+}
+
+.kti-stat .k {
+  font-size: var(--fs-9);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-fg-disabled);
+}
+
+.kti-stat .v {
+  font-family: var(--font-mono);
+  font-size: var(--fs-16);
+  color: var(--color-fg-primary);
+  margin-top: 5px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.kti-stat .v small {
+  font-size: var(--fs-10);
+  color: var(--color-fg-disabled);
+}
+
+.kti-stat .v.ok {
+  color: var(--color-status-ok);
+}
+
+.kti-stat .v.volt {
+  color: var(--color-accent-fg);
+}
+
+/* ── Token economics bar ── */
+.kti-tok {
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.kti-tok-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 8px;
+}
+
+.kti-tok-top .lbl {
+  font-size: var(--fs-10);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-fg-disabled);
+}
+
+.kti-tok-top .ctxpct {
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  color: var(--color-fg-muted);
+}
+
+.kti-tok-bar {
+  display: flex;
+  height: 10px;
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  background: var(--color-bg-page);
+  border: 1px solid var(--color-border-muted);
+}
+
+.kti-tok-bar > span {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+}
+
+.kti-tok-bar .seg-in {
+  background: rgb(var(--color-status-info-glow) / .55);
+}
+
+.kti-tok-bar .seg-out {
+  background: var(--color-accent-fg);
+}
+
+.kti-tok-legend {
+  display: flex;
+  gap: var(--sp-4);
+  margin-top: 9px;
+  font-size: var(--fs-11);
+  color: var(--color-fg-muted);
+}
+
+.kti-tok-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.kti-tok-legend i {
+  width: 9px;
+  height: 9px;
+  border-radius: 2px;
+  flex: none;
+}
+
+.kti-tok-legend .in i {
+  background: rgb(var(--color-status-info-glow) / .55);
+}
+
+.kti-tok-legend .out i {
+  background: var(--color-accent-fg);
+}
+
+.kti-tok-legend b {
+  font-family: var(--font-mono);
+  color: var(--color-fg-primary);
+  font-weight: var(--fw-semi);
+}
+
+/* ── Tabs ── */
+.kti-tabs {
+  display: flex;
+  gap: 0;
+  background: var(--color-bg-surface);
+  border-bottom: 1px solid var(--color-border-strong);
+  padding: 0 var(--sp-3);
+  flex-shrink: 0;
+}
+
+.kti-tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: var(--sp-2) var(--sp-3);
+  color: var(--color-fg-muted);
+  font-size: var(--fs-11);
+  font-weight: var(--fw-semi);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  border-radius: 0;
+}
+
+.kti-tab:hover {
+  color: var(--color-fg-primary);
+  background: transparent;
+}
+
+.kti-tab.on {
+  color: var(--color-accent-fg);
+  border-bottom-color: var(--color-accent-fg);
+  background: transparent;
+}
+
+/* ── Drawer body / section shell ── */
+.kti-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--sp-3) var(--sp-4);
+  font-size: var(--fs-12);
+}
+
+.kti-sec {
+  margin-bottom: var(--sp-4);
+}
+
+.kti-sec-h {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  margin: 0 0 9px;
+}
+
+.kti-sec-h h4 {
+  margin: 0;
+  font: var(--type-title);
+  color: var(--color-fg-primary);
+}
+
+.kti-sec-h .n {
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  color: var(--color-fg-disabled);
+}
+
+/* ── Waterfall timeline ── */
+.kti-wf {
+  display: flex;
+  flex-direction: column;
+}
+
+.kti-wf-row {
+  display: grid;
+  grid-template-columns: 158px 1fr 56px;
+  gap: var(--sp-3);
+  align-items: center;
+  padding: 6px 0;
+  border-top: 1px solid var(--color-border-muted);
+}
+
+.kti-wf-row:first-child {
+  border-top: 0;
+}
+
+.kti-wf-lbl {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: var(--fs-12);
+  color: var(--color-fg-secondary);
+}
+
+.kti-wf-lbl .nm {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kti-wf-lbl .nm.mono {
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+}
+
+.kti-wf-ico {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex: none;
+}
+
+.kti-wf-track {
+  position: relative;
+  height: 18px;
+  background: var(--color-bg-page);
+  border-radius: var(--r-1);
+  overflow: hidden;
+}
+
+.kti-wf-bar {
+  position: absolute;
+  top: 3px;
+  height: 12px;
+  border-radius: 3px;
+  min-width: 4px;
+}
+
+.kti-wf-dur {
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  color: var(--color-fg-muted);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.kti-k-ctx { background: var(--color-fg-disabled); }
+.kti-k-reason { background: var(--color-status-info); }
+.kti-k-tool { background: var(--color-accent-fg); }
+.kti-k-gen { background: var(--color-status-ok); }
+
+.kti-wf-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: var(--sp-3);
+  padding-top: 11px;
+  border-top: 1px solid var(--color-border-default);
+  font-size: var(--fs-11);
+  color: var(--color-fg-disabled);
+}
+
+.kti-wf-foot b {
+  font-family: var(--font-mono);
+  color: var(--color-fg-primary);
+  font-weight: var(--fw-semi);
+}
+
+.kti-wf-legend {
+  display: flex;
+  gap: var(--sp-3);
+}
+
+.kti-wf-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--fs-10);
+  color: var(--color-fg-disabled);
+}
+
+.kti-wf-legend i {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+
+/* ── Copy button ── */
+.kti-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: 1px solid var(--color-border-default);
+  color: var(--color-fg-disabled);
+  border-radius: var(--r-1);
+  font-family: var(--font-ui);
+  font-size: var(--fs-10);
+  padding: 3px 9px;
+  cursor: pointer;
+  transition: 0.14s;
+  white-space: nowrap;
+}
+
+.kti-copy:hover {
+  color: var(--color-accent-fg);
+  border-color: var(--color-accent-fg-dim);
+}
+
+.kti-copy.done {
+  color: var(--color-status-ok);
+  border-color: rgb(var(--color-status-ok-glow) / .4);
+}
+
+/* ── Code / context card ── */
+.kti-code {
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--r-1);
+  overflow: hidden;
+  background: var(--color-bg-page);
+  margin-top: 6px;
+}
+
+.kti-code-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--color-bg-hover);
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.kti-code-h .cap {
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-fg-disabled);
+}
+
+.kti-code-h .sz {
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  color: var(--color-fg-disabled);
+}
+
+.kti-code pre {
+  margin: 0;
+  padding: 10px 12px;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  line-height: var(--lh-loose);
+  color: var(--color-fg-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.kti-code pre .jk {
+  color: var(--color-accent-fg);
+}
+
+.kti-code pre .js {
+  color: var(--color-status-ok);
+}
+
+/* ── Structured tool card (transcript) ── */
+.kti-tool {
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  overflow: hidden;
+}
+
+.kti-tool-h {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 12px;
+  background: var(--color-bg-hover);
+}
+
+.kti-tool-h .seq {
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  color: var(--color-fg-disabled);
+}
+
+.kti-tool-h .tnm {
+  font-family: var(--font-mono);
+  font-size: var(--fs-12);
+  color: var(--color-fg-primary);
+}
+
+.kti-tool-h .pill {
+  font-family: var(--font-ui);
+  font-size: var(--fs-9);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: var(--radius-pill);
+}
+
+.kti-tool-h .pill.ok {
+  color: var(--color-status-ok);
+  border: 1px solid rgb(var(--color-status-ok-glow) / .4);
+}
+
+.kti-tool-h .pill.bad {
+  color: var(--color-status-err);
+  border: 1px solid rgb(var(--color-status-err-glow) / .4);
+}
+
+.kti-tool-h .lat {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  color: var(--color-fg-disabled);
+}
+
+.kti-tool-b {
+  padding: 10px 12px;
+}
+
+/* ── Role-tinted transcript message ── */
+.kti-msg {
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--r-1);
+  overflow: hidden;
+}
+
+.kti-msg-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 11px;
+  background: var(--color-bg-hover);
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.kti-msg-role {
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 1px 8px;
+  border-radius: var(--r-1);
+}
+
+.kti-msg-role.system {
+  color: var(--color-status-info);
+  border: 1px solid rgb(var(--color-status-info-glow) / .35);
+}
+
+.kti-msg-role.user {
+  color: var(--color-accent-fg);
+  border: 1px solid var(--color-accent-fg-dim);
+}
+
+.kti-msg-role.assistant {
+  color: var(--color-fg-primary);
+  border: 1px solid var(--color-border-strong);
+}
+
+.kti-msg-role.context {
+  color: var(--color-status-warn);
+  border: 1px solid rgb(var(--color-status-warn-glow) / .35);
+}
+
+.kti-msg-h .who {
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  color: var(--color-fg-disabled);
+}
+
+.kti-msg-h .seq {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  color: var(--color-fg-disabled);
+}
+
+.kti-msg-b {
+  padding: 10px 12px;
+  font-family: var(--font-ui);
+  font-size: var(--fs-12);
+  line-height: var(--lh-loose);
+  color: var(--color-fg-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.kti-msg-b.mono {
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  color: var(--color-fg-muted);
+}
+
+.kti-seq-rail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+/* ── Context section card ── */
+.kti-ctx-card {
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--r-1);
+  overflow: hidden;
+}
+
+.kti-ctx-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--color-bg-hover);
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.kti-ctx-h .t {
+  font-family: var(--font-ui);
+  font-size: var(--fs-10);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-fg-muted);
+}
+
+.kti-ctx-h .tok {
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  color: var(--color-fg-disabled);
+}
+
+.kti-ctx-card pre {
+  margin: 0;
+  padding: 11px 13px;
+  max-height: 340px;
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  line-height: var(--lh-loose);
+  color: var(--color-fg-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── Meta: parameter chips + kv ── */
+.kti-params {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-bottom: 4px;
+}
+
+.kti-param {
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  padding: 4px 11px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-disabled);
+}
+
+.kti-param b {
+  color: var(--color-fg-primary);
+  font-weight: var(--fw-semi);
+  margin-left: 6px;
+}
+
+.kti-kv {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 1px;
+  background: var(--color-border-muted);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--r-1);
+  overflow: hidden;
+}
+
+.kti-kv .k,
+.kti-kv .v {
+  padding: 6px 10px;
+  background: var(--color-bg-surface);
+}
+
+.kti-kv .k {
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  color: var(--color-fg-disabled);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.kti-kv .v {
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  color: var(--color-fg-secondary);
+  word-break: break-word;
+}
+
+/* ── Row opener affordance ── */
+.kti-turn-summary {
+  cursor: pointer;
+  user-select: none;
+}
+
+.kti-turn-summary:hover {
+  background: var(--color-bg-hover);
+}
+
+.kti-turn-summary .open-hint {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  color: var(--color-fg-disabled);
+  opacity: 0;
+  transition: opacity 0.14s;
+}
+
+.kti-turn-summary:hover .open-hint {
+  opacity: 1;
+}
+
+/* Responsive summary strip */
+@media (max-width: 540px) {
+  .kti-summary {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .kti-wf-row {
+    grid-template-columns: 110px 1fr 48px;
+    gap: 8px;
+  }
+}


### PR DESCRIPTION
## Summary
Refreshes the MASC dashboard keeper turn inspector with the keeper-v2 layout and styling.

## What changed
- Updated `dashboard/src/components/keeper-turn-inspector.ts`:
  - v2-style detail drawer overlay
  - Summary stat strip (duration, input/output tokens, tool count, estimated cost)
  - Token-economics stacked bar with legend
  - Tabbed view: Timeline / Messages / Context / Meta
  - Waterfall Gantt for phase timing
  - Structured transcript with system prompt, context, and tool cards
  - KV metadata grid
  - Copy button with copied-state feedback
- **New styles** `dashboard/src/styles/keeper-turn-inspector.css` using dashboard tokens.
- Wired stylesheet into `main.ts` and `global.css`.
- Updated tests covering drawer render, tab switching, summary stats, token bar, copy, and Esc close.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `keeper-turn-inspector.test.ts` ✅ 8/8

## Notes
- Existing `TurnRecordsResponse` data model preserved; no backend changes.


---

## 🔄 AS-IS vs TO-BE 구조적 개선점 분석 (Structural Improvements)

```mermaid
graph TD
    subgraph AS-IS
        A1[Keeper Turn Inspector] --> A2[단일 레이아웃]
        A2 --> A3[기본 정보 표시]
        A2 --> A4[간단한 텍스트 전사]
        A2 --> A5[기본 스타일링]
    end

    subgraph TO-BE
        B1[Keeper Turn Inspector v2] --> B2[세부 정보 드로어 오버레이]
        B2 --> B3[요약 통계 스트립]
        B3 --> B3a[소요 시간]
        B3 --> B3b[입력/출력 토큰]
        B3 --> B3c[도구 사용량]
        B3 --> B3d[예상 비용]
        B2 --> B4[토큰 경제학 스택 바]
        B2 --> B5[탭 뷰]
        B5 --> B5a[타임라인]
        B5 --> B5b[메시지]
        B5 --> B5c[컨텍스트]
        B5 --> B5d[메타데이터]
        B2 --> B6[폭포 간트 차트]
        B2 --> B7[구조화된 전사]
        B7 --> B7a[시스템 프롬프트]
        B7 --> B7b[컨텍스트 카드]
        B7 --> B7c[도구 카드]
        B2 --> B8[KV 메타데이터 그리드]
        B2 --> B9[복사 버튼]
        B9 --> B9a[복사 상태 피드백]
    end

    AS-IS -.->|리팩토링| TO-BE
```

| **기술 범주** | **AS-IS (변경 전)** | **TO-BE (변경 후)** | **변경 이유/효과** |
|---------------|----------------------|---------------------|-------------------|
| **UI/UX 구조** | 단일 레이아웃, 기본 정보 표시 | 세부 정보 드로어 오버레이, 모듈형 레이아웃 | 계층적 정보 표현 강화로 직관성 향상, 사용자 탐색 경험 개선 |
| **데이터 시각화** | 텍스트 기반 정보 표시 | 요약 통계 스트립, 토큰 경제학 스택 바, 폭포 간트 차트 | 복잡한 토큰 사용량/시간 정보 시각화를 통한 인지 효율성 증대 |
| **정보 구조** | 단순한 텍스트 전사 | 탭 뷰(타임라인/메시지/컨텍스트/메타), 구조화된 전사 | 유형별 정보 분류로 특정 데이터 검색 편의성 증가, 시스템 프롬프트/도구 카드의 명시적 분리 |
| **인터랙션** | 기본적인 클릭 기능 | 복사 버튼 + 상태 피드백 | 토큰/메타데이터 복사 작업 효율화, 사용자 피드백을 통한 작업 완료도 가시화 |
| **스타일링** | 기본 CSS, 스타일 토큰 미사용 | `keeper-turn-inspector.css` 대시보드 토큰 통합 | 디자인 시스템 표준화로 유지보수성 향상, 테마 변경 시 일관된 적용 가능 |
| **테스트 커버리지** | 기본 기능 테스트 | 드로어 렌더링/탭 전환/통계 표시/복사/Esc 종료 8개 케이스 | 복합 인터랙션 및 시각 요소에 대한 포괄적 검증으로 신뢰성 강화 |
| **확장성** | 단일 컴포넌트 내 모든 로직 | 모듈형 구조(통계/탭/차트/메타데이터 그리드) | 향후 기능 추가 시 특정 섹션 독립적 확장 가능, 코드 재사용성 증가 |
| **데이터 모델** | `TurnRecordsResponse` 사용 (변경 없음) | 동일한 데이터 모델 유지 | 백엔드 변경 없이 프론트엔드만 개선으로 배포 리스크 최소화 |
| **성능 영향** | 경량 UI 컴포넌트 | 추가 스타일시트 로드 (~10KB) | 초기 로드 시 미세한 증가 있으나, 대시보드 토큰 캐싱으로 런타임 성능 저하 없음 |
| **호환성** | 기존 대시보드 테마 | 대시보드 글로벌 토큰 상속 | 전체 대시보드와의 시각적 일관성 유지, 테마 전환 시 자동 적용 |```
