### PR TITLE
feat(dashboard): apply keeper-v2 rich chat blocks

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import type { KeeperConversationEntry } from '../../types'
+import type { ChatBlock, KeeperConversationEntry } from '../../types'
 import type { ToolCallEntry } from '../../api/dashboard'
 import { ChatComposer, ChatTranscript } from './primitives'
 import { recordToolCallOutputs, resetToolCallOutputs } from '../../tool-call-output-store'
@@ -620,5 +620,255 @@ describe('ChatComposer IME composition guard', () => {
       new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true, bubbles: true }),
     )
     expect(sent).toBe(0)
+  })
+})
+
+describe('Keeper v2 chat blocks', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  function renderBlocks(blocks: ChatBlock[]) {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'b1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: '',
+            blocks,
+          }),
+        ]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+  }
+
+  it('renders a callout block', () => {
+    renderBlocks([{ t: 'callout', severity: 'warn', html: '<strong>주의</strong>' }])
+
+    const callout = container.querySelector('[data-chat-block="callout"]')
+    expect(callout).not.toBeNull()
+    expect(callout?.classList.contains('warn')).toBe(true)
+    expect(callout?.textContent).toContain('주의')
+  })
+
+  it('renders a markdown table with numeric and muted cell flags', () => {
+    renderBlocks([
+      {
+        t: 'table',
+        head: ['name', { v: 'count', num: true }],
+        rows: [['a', { v: '42', num: true }], ['b', { v: 'n/a', muted: true }]],
+      },
+    ])
+
+    const table = container.querySelector('[data-chat-block="table"]')
+    expect(table).not.toBeNull()
+    const nums = [...container.querySelectorAll('.chat-block-cell-num')].map((el) => el.textContent)
+    expect(nums).toContain('count')
+    expect(nums).toContain('42')
+    const muted = container.querySelector('.chat-block-cell-muted')
+    expect(muted?.textContent).toBe('n/a')
+  })
+
+  it('renders a code block with caption', () => {
+    renderBlocks([{ t: 'code', cap: 'config.ml', html: 'let x = 1' }])
+
+    const code = container.querySelector('[data-chat-block="code"]')
+    expect(code).not.toBeNull()
+    expect(code?.textContent).toContain('config.ml')
+    expect(code?.textContent).toContain('let x = 1')
+  })
+
+  it('renders a shell block with prompt and exit status', () => {
+    renderBlocks([
+      {
+        t: 'shell',
+        title: 'keeper@worktree',
+        lines: [
+          { t: 'cmd', v: 'ls' },
+          { t: 'out', v: 'file.txt' },
+        ],
+        exit: 1,
+        dur: '0.3s',
+      },
+    ])
+
+    const shell = container.querySelector('[data-chat-block="shell"]')
+    expect(shell).not.toBeNull()
+    expect(shell?.textContent).toContain('keeper@worktree')
+    expect(shell?.textContent).toContain('$ ls')
+    expect(shell?.textContent).toContain('file.txt')
+    expect(shell?.textContent).toContain('exit 1')
+  })
+
+  it('renders an artifact card with open/download buttons', () => {
+    renderBlocks([{ t: 'artifact', kind: 'json', name: 'report.json', size: '12 KB', note: '3 items' }])
+
+    const artifact = container.querySelector('[data-chat-block="artifact"]')
+    expect(artifact).not.toBeNull()
+    expect(artifact?.textContent).toContain('report.json')
+    expect(artifact?.textContent).toContain('JSON')
+    const buttons = [...(artifact?.querySelectorAll('button') ?? [])].map((b) => b.textContent)
+    expect(buttons).toContain('열기')
+    expect(buttons).toContain('다운로드')
+  })
+
+  it('renders an attach card with inline svg', () => {
+    renderBlocks([
+      {
+        t: 'attach',
+        name: 'shape.svg',
+        dims: '64×64',
+        svg: '<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="red"/></svg>',
+        via: 'vision',
+        size: '1 KB',
+      },
+    ])
+
+    const attach = container.querySelector('[data-chat-block="attach"]')
+    expect(attach).not.toBeNull()
+    expect(attach?.textContent).toContain('shape.svg')
+    expect(attach?.textContent).toContain('64×64')
+    expect(attach?.querySelector('svg')).not.toBeNull()
+  })
+
+  it('renders a voice memo with waveform bars and transcript', () => {
+    renderBlocks([
+      {
+        t: 'voice',
+        secs: 14,
+        wave: [0.2, 0.5, 0.8, 0.3, 0.6],
+        via: 'whisper',
+        size: '24 KB',
+        transcript: 'hello world',
+      },
+    ])
+
+    const voice = container.querySelector('[data-chat-block="voice"]')
+    expect(voice).not.toBeNull()
+    expect(voice?.querySelectorAll('.chat-block-vbar').length).toBe(5)
+    expect(voice?.textContent).toContain('hello world')
+    expect(voice?.textContent).toContain('whisper')
+  })
+
+  it('toggles the voice memo play button label', async () => {
+    renderBlocks([{ t: 'voice', secs: 2, wave: [0.2, 0.5] }])
+
+    const play = container.querySelector('[data-chat-block="voice"] button') as HTMLButtonElement
+    expect(play?.textContent?.trim()).toBe('▶')
+    play.click()
+    await flushUi()
+    expect(play?.textContent?.trim()).toBe('❙❙')
+    play.click()
+    await flushUi()
+    expect(play?.textContent?.trim()).toBe('▶')
+  })
+
+  it('renders an image block', () => {
+    renderBlocks([{ t: 'image', src: '/img/screen.png', cap: '실행 화면' }])
+
+    const img = container.querySelector('[data-chat-block="image"] img') as HTMLImageElement | null
+    expect(img).not.toBeNull()
+    expect(img?.getAttribute('src')).toBe('/img/screen.png')
+    expect(container.textContent).toContain('실행 화면')
+  })
+
+  it('renders an svg block', () => {
+    renderBlocks([{ t: 'svg', svg: '<svg viewBox="0 0 10 10"><circle cx="5" cy="5" r="5"/></svg>', cap: 'diagram' }])
+
+    const svg = container.querySelector('[data-chat-block="svg"] svg')
+    expect(svg).not.toBeNull()
+    expect(container.textContent).toContain('diagram')
+  })
+
+  it('renders a trace block and expands a tool step', async () => {
+    renderBlocks([
+      {
+        t: 'trace',
+        trace: [
+          { kind: 'think', text: 'planning' },
+          { kind: 'tool', name: 'keeper_context_status', status: 'ok', dur: '0.2s', args: { path: 'a' }, result: '{"ok":true}' },
+        ],
+      },
+    ])
+
+    const trace = container.querySelector('[data-chat-block="trace"]')
+    expect(trace).not.toBeNull()
+    expect(trace?.textContent).toContain('planning')
+    expect(trace?.textContent).toContain('keeper_context_status')
+
+    const toolRow = container.querySelector('[data-chat-trace-step="tool"] .chat-block-tstep-row.click') as HTMLElement | null
+    expect(toolRow).not.toBeNull()
+    toolRow?.click()
+    await flushUi()
+
+    expect(trace?.textContent).toContain('args')
+    expect(trace?.textContent).toContain('"path"')
+    expect(trace?.textContent).toContain('result')
+  })
+
+  it('renders a link unfurl card with extracted hostname', () => {
+    renderBlocks([
+      {
+        t: 'link',
+        url: 'https://example.com/post',
+        title: 'Example post',
+        desc: 'A useful article',
+      },
+    ])
+
+    const link = container.querySelector('[data-chat-block="link"]') as HTMLAnchorElement | null
+    expect(link).not.toBeNull()
+    expect(link?.getAttribute('href')).toBe('https://example.com/post')
+    expect(link?.textContent).toContain('Example post')
+    expect(link?.textContent).toContain('example.com')
+  })
+
+  it('renders a broadcast card with recipient ack labels', () => {
+    renderBlocks([
+      {
+        t: 'broadcast',
+        scope: '@fleet',
+        via: 'keeper-net',
+        note: 'standby',
+        recipients: [
+          { id: 'masc', ack: 'acked', at: '12:00' },
+          { id: 'sangsu', ack: 'delivered' },
+        ],
+      },
+    ])
+
+    const bcast = container.querySelector('[data-chat-block="broadcast"]')
+    expect(bcast).not.toBeNull()
+    expect(bcast?.textContent).toContain('브로드캐스트')
+    expect(bcast?.textContent).toContain('standby')
+    expect(bcast?.textContent).toContain('확인함')
+    expect(bcast?.textContent).toContain('전달됨')
+    expect(bcast?.textContent).toContain('1/2 확인')
+  })
+
+  it('falls back to markdown text when blocks are not provided', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[entry({ id: 'm1', text: 'plain markdown reply' })]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+
+    expect(container.textContent).toContain('plain markdown reply')
+    expect(container.querySelector('[data-chat-blocks]')).toBeNull()
   })
 })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -8,6 +8,7 @@ import { useVoiceInput } from './voice-input'
 import { formatTimeHms } from '../../lib/format-time'
 import { formatCost } from '../../lib/format-number'
 import { isSubmitEnter } from '../../lib/keyboard'
+import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatLinkBlock, ChatShellBlock, ChatTableBlock, ChatTraceStep, ChatVoiceBlock } from '../../types'
 import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, SurfaceRef } from '../../types'
 import type { ToolCallOutputBlob } from '../../api/dashboard'
 import { lookupToolCallOutput } from '../../tool-call-output-store'
@@ -205,6 +206,446 @@ function attachmentMeta(attachment: KeeperConversationAttachment): string {
   return [attachment.mimeType, formatAttachmentSize(attachment.size)].filter(Boolean).join(' · ')
 }
 
+// --- Keeper v2 rich block helpers -------------------------------------------------
+
+function linkifyHtml(raw: string): string {
+  if (!raw || raw.indexOf('http') === -1 || raw.indexOf('<a ') !== -1) return raw
+  return raw.replace(
+    /(^|[\s(>])(https?:\/\/[^\s<)]+[^\s<).,!?:;])/g,
+    '$1<a class="inline-link" href="$2" target="_blank" rel="noopener noreferrer">$2</a>',
+  )
+}
+
+function sanitizeHtml(raw: string): string {
+  return DOMPurify.sanitize(raw)
+}
+
+function renderInlineHtml(raw: string): { __html: string } {
+  return { __html: sanitizeHtml(linkifyHtml(raw)) }
+}
+
+function highlightJson(obj: unknown): string {
+  const s = JSON.stringify(obj, null, 2)
+  return sanitizeHtml(
+    s
+      .replace(/("[^"]+"):/g, '<span class="chat-json-key">$1</span>:')
+      .replace(/: ("[^"]*")/g, ': <span class="chat-json-str">$1</span>'),
+  )
+}
+
+function traceDur(trace: ChatTraceStep[]): string | null {
+  let sum = 0
+  let has = false
+  trace.forEach((st) => {
+    if (st.kind !== 'tool') return
+    const m = st.dur?.match(/([\d.]+)s/)
+    if (m?.[1]) {
+      sum += parseFloat(m[1])
+      has = true
+    }
+  })
+  return has ? `${Math.round(sum * 10) / 10}s` : null
+}
+
+function ChatTextBlock({ html: htmlContent }: { html: string }) {
+  return html`<p class="mb-2 text-base leading-airy text-[var(--color-fg-primary)]" dangerouslySetInnerHTML=${renderInlineHtml(htmlContent)} />`
+}
+
+function ChatHeadingBlock({ html: htmlContent }: { html: string }) {
+  return html`<h4 class="mb-1 mt-2 text-sm font-semibold text-[var(--color-fg-secondary)]" dangerouslySetInnerHTML=${renderInlineHtml(htmlContent)} />`
+}
+
+function ChatListBlock({ items }: { items: string[] }) {
+  return html`
+    <ul class="my-1 list-disc pl-5 text-base leading-airy text-[var(--color-fg-primary)]">
+      ${items.map((it, i) => html`<li key=${i} dangerouslySetInnerHTML=${renderInlineHtml(it)} />`)}
+    </ul>
+  `
+}
+
+function ChatCalloutBlock({ severity = 'warn', html: htmlContent }: ChatCalloutBlock) {
+  const icon = severity === 'bad' ? '✕' : severity === 'info' ? 'ℹ' : '⚠'
+  return html`
+    <div class="chat-block-callout ${severity}" data-chat-block="callout">
+      <span class="shrink-0">${icon}</span>
+      <span class="min-w-0" dangerouslySetInnerHTML=${renderInlineHtml(htmlContent)} />
+    </div>
+  `
+}
+
+function ChatTableBlock({ head, rows }: ChatTableBlock) {
+  const cell = (c: ChatTableBlock['head'][number]) => (typeof c === 'object' ? c : { v: c })
+  return html`
+    <table class="chat-block-table" data-chat-block="table">
+      <thead>
+        <tr>
+          ${head.map((h, i) => {
+            const c = cell(h)
+            return html`<th key=${i} class=${c.num ? 'chat-block-cell-num' : ''}>${c.v}</th>`
+          })}
+        </tr>
+      </thead>
+      <tbody>
+        ${rows.map((row, ri) => html`
+          <tr key=${ri}>
+            ${row.map((c0, ci) => {
+              const c = cell(c0)
+              return html`<td key=${ci} class="${c.num ? 'chat-block-cell-num' : ''} ${c.muted ? 'chat-block-cell-muted' : ''}">${c.v}</td>`
+            })}
+          </tr>
+        `)}
+      </tbody>
+    </table>
+  `
+}
+
+function ChatCodeBlock({ cap, html: htmlContent }: { cap?: string; html: string }) {
+  return html`
+    <div class="chat-block-code" data-chat-block="code">
+      ${cap ? html`<div class="chat-block-code-cap">${cap}</div>` : null}
+      <pre class="m-0 overflow-x-auto p-3 text-2xs leading-relaxed"><code dangerouslySetInnerHTML=${{ __html: sanitizeHtml(htmlContent) }} /></pre>
+    </div>
+  `
+}
+
+function ChatShellBlock({ title, lines, exit, dur }: ChatShellBlock) {
+  return html`
+    <div class="chat-block-shell" data-chat-block="shell">
+      <div class="chat-block-shell-bar">
+        <span class="chat-block-shell-dot r"></span>
+        <span class="chat-block-shell-dot y"></span>
+        <span class="chat-block-shell-dot g"></span>
+        <span class="chat-block-shell-title">${title || 'keeper@worktree'}</span>
+      </div>
+      <pre class="m-0 p-3 text-2xs leading-relaxed">
+        ${lines.map((ln, i) => html`
+          <div key=${i} class="chat-block-shell-line ${ln.t || ''}">
+            ${ln.t === 'cmd' ? html`<span class="chat-block-shell-prompt">$ </span>` : null}
+            <span dangerouslySetInnerHTML=${{ __html: sanitizeHtml(ln.v) }} />
+          </div>
+        `)}
+      </pre>
+      ${typeof exit === 'number'
+        ? html`<div class="chat-block-shell-exit ${exit === 0 ? 'ok' : 'fail'}">exit ${exit}${dur ? ` · ${dur}` : ''}</div>`
+        : null}
+    </div>
+  `
+}
+
+function ChatArtifactBlock({ kind, name, size, note }: { kind?: string; name: string; size?: string; note?: string }) {
+  const icon = kind === 'md' ? '⌹' : kind === 'svg' ? '◫' : kind === 'json' ? '{ }' : '⎙'
+  return html`
+    <div class="chat-block-artifact" data-chat-block="artifact">
+      <span class="chat-block-artifact-icon">${icon}</span>
+      <div class="min-w-0 flex-1">
+        <div class="chat-block-artifact-name">${name}</div>
+        <div class="chat-block-artifact-sub">
+          ${(kind || 'file').toUpperCase()}${size ? ` · ${size}` : ''}${note ? ` · ${note}` : ''}
+        </div>
+      </div>
+      <button type="button" class="chat-block-artifact-btn" aria-label="열기">열기</button>
+      <button type="button" class="chat-block-artifact-btn" aria-label="다운로드">다운로드</button>
+    </div>
+  `
+}
+
+function ChatAttachBlock({ name, dims, svg, ph, via, size }: { name: string; dims?: string; svg?: string; ph?: string; via?: string; size?: string }) {
+  return html`
+    <figure class="chat-block-attach" data-chat-block="attach">
+      <div class="chat-block-attach-hd">
+        <span>◫</span>
+        <span class="chat-block-attach-name">${name}</span>
+        ${dims ? html`<span class="chat-block-attach-dims">${dims}</span>` : null}
+      </div>
+      <div class="chat-block-attach-frame">
+        ${svg
+          ? html`<span dangerouslySetInnerHTML=${{ __html: sanitizeHtml(svg) }} />`
+          : html`<div class="chat-block-attach-ph">${ph || '첨부 이미지'}</div>`}
+      </div>
+      <figcaption class="chat-block-attach-cap">
+        <span>이미지 첨부</span>${via ? ` · ${via}` : ''}${size ? ` · ${size}` : ''}
+      </figcaption>
+    </figure>
+  `
+}
+
+function ChatVoiceBlock(b: ChatVoiceBlock) {
+  const secs = b.secs ?? 14
+  const [playing, setPlaying] = useState(false)
+  const [prog, setProg] = useState(0)
+
+  useEffect(() => {
+    if (!playing) return
+    const start = performance.now() - prog * secs * 1000
+    let raf = 0
+    const tick = (now: number) => {
+      const p = Math.min(1, (now - start) / (secs * 1000))
+      setProg(p)
+      if (p >= 1) {
+        setPlaying(false)
+        return
+      }
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [playing])
+
+  const toggle = () => {
+    if (prog >= 1) setProg(0)
+    setPlaying((p) => !p)
+  }
+
+  const bars = b.wave ?? []
+  const fmt = (s: number) => `${Math.floor(s / 60)}:${String(Math.round(s) % 60).padStart(2, '0')}`
+  const shown = playing || prog > 0 ? prog * secs : secs
+
+  return html`
+    <div class="chat-block-voice" data-chat-block="voice">
+      <div class="chat-block-voice-row">
+        <button type="button" class="chat-block-voice-play ${playing ? 'on' : ''}" onClick=${toggle} aria-label=${playing ? '일시정지' : '재생'}>
+          ${playing ? '❙❙' : '▶'}
+        </button>
+        <div class="chat-block-voice-wave">
+          ${bars.map((h, i) => html`
+            <span
+              key=${i}
+              class="chat-block-vbar ${(i + 0.5) / bars.length <= prog ? 'on' : ''}"
+              style=${{ height: `${Math.round(5 + h * 21)}px` }}
+            />
+          `)}
+        </div>
+        <span class="chat-block-voice-dur">${fmt(shown)}</span>
+      </div>
+      ${b.via || b.size
+        ? html`
+            <div class="chat-block-voice-meta">
+              ${b.via ? html`<span>◌ ${b.via}</span>` : null}
+              ${b.size ? html`<span>${b.size}</span>` : null}
+            </div>
+          `
+        : null}
+      ${b.transcript
+        ? html`
+            <div class="chat-block-voice-tx">
+              <span>받아쓰기</span>
+              <span>${b.transcript}</span>
+            </div>
+          `
+        : null}
+    </div>
+  `
+}
+
+function ChatImageBlock({ src, ph, cap }: { src?: string; ph?: string; cap?: string }) {
+  return html`
+    <figure class="chat-block-media" data-chat-block="image">
+      <div class="chat-block-media-frame">
+        ${src
+          ? html`<img src=${src} alt=${cap || ''} class="max-h-52 w-full rounded-[var(--r-1)] object-contain" />`
+          : html`<div class="chat-block-media-ph">${ph || '실행 화면'}</div>`}
+      </div>
+      ${cap ? html`<figcaption class="chat-block-media-cap">${cap}</figcaption>` : null}
+    </figure>
+  `
+}
+
+function ChatSvgBlock({ svg, cap }: { svg: string; cap?: string }) {
+  return html`
+    <figure class="chat-block-media" data-chat-block="svg">
+      <div class="chat-block-media-frame" dangerouslySetInnerHTML=${{ __html: sanitizeHtml(svg) }} />
+      ${cap ? html`<figcaption class="chat-block-media-cap">${cap}</figcaption>` : null}
+    </figure>
+  `
+}
+
+function ChatTraceStep({ step }: { step: ChatTraceStep }) {
+  const [open, setOpen] = useState(false)
+
+  if (step.kind === 'think') {
+    return html`
+      <div class="chat-block-tstep think" data-chat-trace-step="think">
+        <span class="chat-block-tnode"></span>
+        <div class="min-w-0 flex-1">
+          <div class="chat-block-tstep-row">
+            <span class="chat-block-tstep-kind">Thinking</span>
+            <span>${step.text}</span>
+          </div>
+        </div>
+      </div>
+    `
+  }
+
+  if (step.kind === 'reason') {
+    const exp = !!step.detail
+    return html`
+      <div class="chat-block-tstep reason ${open ? 'exp' : ''}" data-chat-trace-step="reason">
+        <span class="chat-block-tnode"></span>
+        <div class="min-w-0 flex-1">
+          <div class="chat-block-tstep-row ${exp ? 'click' : ''}" onClick=${() => { if (exp) setOpen((o) => !o) }}>
+            <span class="chat-block-tstep-kind">Reasoning</span>
+            <span class="chat-block-tstep-text" dangerouslySetInnerHTML=${{ __html: sanitizeHtml(step.text) }} />
+            ${exp ? html`<span class="chat-block-tstep-chev">▶</span>` : null}
+          </div>
+          ${exp && open
+            ? html`<div class="chat-block-reason-detail" dangerouslySetInnerHTML=${{ __html: sanitizeHtml(step.detail ?? '') }} />`
+            : null}
+        </div>
+      </div>
+    `
+  }
+
+  return html`
+    <div class="chat-block-tstep tool ${open ? 'exp' : ''}" data-chat-trace-step="tool">
+      <span class="chat-block-tnode"></span>
+      <div class="min-w-0 flex-1">
+        <div class="chat-block-tstep-row click" onClick=${() => setOpen((o) => !o)}>
+          <span class="chat-block-tstep-kind">Tool</span>
+          <span class="chat-block-tstep-name">${step.name}</span>
+          <span class="chat-block-tstep-status ${step.status === 'ok' ? 'ok' : 'bad'}"></span>
+          <span class="chat-block-tstep-dur">${step.dur}</span>
+          <span class="chat-block-tstep-chev">▶</span>
+        </div>
+        ${open
+          ? html`
+              <div class="chat-block-tool-body">
+                ${step.args !== undefined
+                  ? html`
+                      <div class="chat-block-tool-label">args</div>
+                      <pre class="m-0 overflow-x-auto text-2xs" dangerouslySetInnerHTML=${{ __html: highlightJson(step.args) }} />
+                    `
+                  : null}
+                ${step.result !== undefined
+                  ? html`
+                      <div class="chat-block-tool-label">result</div>
+                      <pre class="m-0 overflow-x-auto text-2xs" dangerouslySetInnerHTML=${{ __html: sanitizeHtml(step.result) }} />
+                    `
+                  : null}
+              </div>
+            `
+          : null}
+      </div>
+    </div>
+  `
+}
+
+function ChatTraceBlock({ trace }: { trace: ChatTraceStep[] }) {
+  const [open, setOpen] = useState(true)
+  const toolN = trace.filter((s) => s.kind === 'tool').length
+  const dur = traceDur(trace)
+
+  return html`
+    <div class="chat-block-trace ${open ? 'open' : ''}" data-chat-block="trace">
+      <button
+        type="button"
+        class="chat-block-trace-hd"
+        onClick=${() => setOpen((o) => !o)}
+        aria-expanded=${open}
+      >
+        <span class="chat-block-trace-chev">${open ? '▾' : '▸'}</span>
+        <span>◈</span>
+        <span class="chat-block-trace-label">작업 과정</span>
+        <span class="chat-block-trace-count">${trace.length}단계</span>
+        <span class="chat-block-trace-meta">
+          ${toolN > 0 ? html`<span>도구 ${toolN}</span>` : null}
+          ${dur ? html`<span class="tnum">${dur}</span>` : null}
+        </span>
+      </button>
+      ${open
+        ? html`
+            <div class="chat-block-trace-steps">
+              <span class="chat-block-trace-rail"></span>
+              ${trace.map((s, i) => html`<${ChatTraceStep} key=${i} step=${s} />`)}
+            </div>
+          `
+        : null}
+    </div>
+  `
+}
+
+function ChatLinkBlock(b: ChatLinkBlock) {
+  let host = b.meta
+  try {
+    host = new URL(b.url).hostname.replace(/^www\./, '')
+  } catch {
+    host = b.meta
+  }
+  return html`
+    <a
+      class="chat-block-linkcard ${b.kind || ''}"
+      href=${b.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      data-chat-block="link"
+    >
+      <span class="chat-block-linkcard-fav">${b.fav || (host ? host.slice(0, 1).toUpperCase() : '↗')}</span>
+      <span class="chat-block-linkcard-body">
+        <span class="chat-block-linkcard-title">${b.title}</span>
+        ${b.desc ? html`<span class="chat-block-linkcard-desc">${b.desc}</span>` : null}
+        <span class="chat-block-linkcard-meta">${b.meta || host}</span>
+      </span>
+      <span class="chat-block-linkcard-go">↗</span>
+    </a>
+  `
+}
+
+const BROADCAST_ACK_LABEL: Record<string, string> = { acked: '확인함', read: '읽음', delivered: '전달됨' }
+
+function ChatBroadcastBlock(b: ChatBroadcastBlock) {
+  const ackN = b.recipients.filter((r) => r.ack === 'acked').length
+  return html`
+    <div class="chat-block-broadcast" data-chat-block="broadcast">
+      <div class="chat-block-broadcast-hd">
+        <span>⊚ 브로드캐스트</span>
+        <span class="chat-block-broadcast-scope">${b.scope}</span>
+        <span class="chat-block-broadcast-via">${b.via}</span>
+        <span class="chat-block-broadcast-count">${ackN}/${b.recipients.length} 확인</span>
+      </div>
+      <div class="chat-block-broadcast-note">${b.note}</div>
+      <div class="chat-block-broadcast-rcpts">
+        ${b.recipients.map((r, i) => html`
+          <div key=${i} class="chat-block-broadcast-rcpt ${r.ack}">
+            <span class="chat-block-broadcast-avatar">${r.id.slice(0, 2).toUpperCase()}</span>
+            <span class="chat-block-broadcast-id">${r.id}</span>
+            <span class="chat-block-broadcast-ack">
+              ${BROADCAST_ACK_LABEL[r.ack] || r.ack}${r.at ? ` · ${r.at}` : ''}
+            </span>
+          </div>
+        `)}
+      </div>
+    </div>
+  `
+}
+
+function ChatBlock({ block }: { block: ChatBlock }) {
+  switch (block.t) {
+    case 'p': return html`<${ChatTextBlock} html=${block.html} />`
+    case 'h4': return html`<${ChatHeadingBlock} html=${block.html} />`
+    case 'ul': return html`<${ChatListBlock} items=${block.items} />`
+    case 'callout': return html`<${ChatCalloutBlock} severity=${block.severity} html=${block.html} />`
+    case 'table': return html`<${ChatTableBlock} head=${block.head} rows=${block.rows} />`
+    case 'code': return html`<${ChatCodeBlock} cap=${block.cap} html=${block.html} />`
+    case 'shell': return html`<${ChatShellBlock} title=${block.title} lines=${block.lines} exit=${block.exit} dur=${block.dur} />`
+    case 'artifact': return html`<${ChatArtifactBlock} kind=${block.kind} name=${block.name} size=${block.size} note=${block.note} />`
+    case 'attach': return html`<${ChatAttachBlock} name=${block.name} dims=${block.dims} svg=${block.svg} ph=${block.ph} via=${block.via} size=${block.size} />`
+    case 'voice': return html`<${ChatVoiceBlock} secs=${block.secs} wave=${block.wave} via=${block.via} size=${block.size} transcript=${block.transcript} />`
+    case 'image': return html`<${ChatImageBlock} src=${block.src} ph=${block.ph} cap=${block.cap} />`
+    case 'svg': return html`<${ChatSvgBlock} svg=${block.svg} cap=${block.cap} />`
+    case 'trace': return html`<${ChatTraceBlock} trace=${block.trace} />`
+    case 'link': return html`<${ChatLinkBlock} url=${block.url} title=${block.title} desc=${block.desc} meta=${block.meta} fav=${block.fav} kind=${block.kind} />`
+    case 'broadcast': return html`<${ChatBroadcastBlock} scope=${block.scope} via=${block.via} note=${block.note} recipients=${block.recipients} />`
+    default: return null
+  }
+}
+
+function ChatBlocks({ blocks }: { blocks: ChatBlock[] }) {
+  return html`
+    <div class="flex flex-col gap-3" data-chat-blocks>
+      ${blocks.map((b, i) => html`<${ChatBlock} key=${i} block=${b} />`)}
+    </div>
+  `
+}
+
 function LiveMessagePlaceholder({ label }: { label: string }) {
   return html`
     <div
@@ -319,11 +760,12 @@ function ChatMessageBubble({
   const [messageCollapsed, setMessageCollapsed] = useState(true)
   const expanded = showMetadata && expandedRaw
   const rawExpanded = showMetadata && rawExpandedRaw
+  const hasBlocks = entry.blocks && entry.blocks.length > 0
   const liveLabel = liveMessageLabel(entry)
   const messageText = liveLabel ? '' : entry.text || '(empty reply)'
   const messageLength = messageText.length
   const collapseThreshold = 1200
-  const isCollapsible = messageLength > collapseThreshold
+  const isCollapsible = !hasBlocks && messageLength > collapseThreshold
   const tone = bubbleTone(entry)
   const isMessenger = variant === 'messenger'
   const detailItems = detailSummary(entry.details)
@@ -483,15 +925,19 @@ function ChatMessageBubble({
       ${liveLabel
         ? html`<${LiveMessagePlaceholder} label=${liveLabel} />`
         : html`
-            <div
-              class=${`markdown-body whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)] ${isCollapsible && messageCollapsed ? 'max-h-96 overflow-hidden' : ''}`}
-              dangerouslySetInnerHTML=${{
-                __html: DOMPurify.sanitize(
-                  marked.parse(messageText) as string,
-                  { ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'a', 'hr'] }
-                )
-              }}
-            />
+            ${hasBlocks
+              ? html`<${ChatBlocks} blocks=${entry.blocks!} />`
+              : html`
+                  <div
+                    class=${`markdown-body whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)] ${isCollapsible && messageCollapsed ? 'max-h-96 overflow-hidden' : ''}`}
+                    dangerouslySetInnerHTML=${{
+                      __html: DOMPurify.sanitize(
+                        marked.parse(messageText) as string,
+                        { ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'a', 'hr'] }
+                      )
+                    }}
+                  />
+                `}
             ${entry.delivery === 'streaming'
               ? html`<span class="inline-block ml-0.5 animate-pulse text-[var(--color-status-info)]" aria-hidden="true">▍</span>`
               : null}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -23,6 +23,7 @@ import './styles/keyframes.css'
 
 // Global utilities and layout
 import './styles/global.css'
+import './styles/chat-blocks-v2.css'
 
 // Component-specific styles
 import './styles/ui.css'

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -1,0 +1,706 @@
+/* Keeper v2 rich chat blocks — ported into dashboard chat primitives.
+   Tokens come from the dashboard semantic system (tokens.css / variables.css). */
+
+/* ── Callout (info / warn / bad) ─────────────────────────────── */
+.chat-block-callout {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  border: 1px solid var(--warn-border);
+  border-radius: var(--r-1);
+  padding: 10px 12px;
+  background: var(--color-warn-soft);
+  color: var(--color-warn-fg);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-body);
+}
+
+.chat-block-callout.info {
+  border-color: var(--info-border);
+  background: var(--color-info-soft);
+  color: var(--color-info-fg);
+}
+
+.chat-block-callout.warn {
+  border-color: var(--warn-border);
+  background: var(--color-warn-soft);
+  color: var(--color-warn-fg);
+}
+
+.chat-block-callout.bad {
+  border-color: var(--err-border);
+  background: var(--bad-soft);
+  color: var(--color-status-err);
+}
+
+/* ── Trace (collapsible reasoning / tool steps) ──────────────── */
+.chat-block-trace {
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  overflow: hidden;
+}
+
+.chat-block-trace-hd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  background: transparent;
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-xs);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--t-fast);
+}
+
+.chat-block-trace-hd:hover {
+  background: var(--color-bg-hover);
+}
+
+.chat-block-trace-chev {
+  color: var(--color-fg-muted);
+  font-size: var(--fs-2xs);
+}
+
+.chat-block-trace-label {
+  font-weight: var(--fw-semi);
+}
+
+.chat-block-trace-count,
+.chat-block-trace-meta {
+  color: var(--color-fg-muted);
+  font-size: var(--fs-2xs);
+}
+
+.chat-block-trace-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.chat-block-trace-steps {
+  position: relative;
+  padding: 8px 12px 12px 28px;
+}
+
+.chat-block-trace-rail {
+  position: absolute;
+  left: 12px;
+  top: 8px;
+  bottom: 12px;
+  width: 1px;
+  background: var(--color-border-default);
+}
+
+.chat-block-tstep {
+  display: flex;
+  gap: 10px;
+  font-size: var(--fs-sm);
+  color: var(--color-fg-secondary);
+}
+
+.chat-block-tstep + .chat-block-tstep {
+  margin-top: 8px;
+}
+
+.chat-block-tnode {
+  width: 7px;
+  height: 7px;
+  margin-top: 6px;
+  border-radius: 50%;
+  background: var(--color-border-strong);
+  flex-shrink: 0;
+}
+
+.chat-block-tstep-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.chat-block-tstep-row.click {
+  cursor: pointer;
+}
+
+.chat-block-tstep-kind {
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-semi);
+  text-transform: uppercase;
+  letter-spacing: var(--track-caps);
+  color: var(--color-fg-muted);
+}
+
+.chat-block-tstep-name {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--color-fg-secondary);
+}
+
+.chat-block-tstep-status {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.chat-block-tstep-status.ok {
+  background: var(--color-status-ok);
+}
+
+.chat-block-tstep-status.bad {
+  background: var(--color-status-err);
+}
+
+.chat-block-tstep-dur {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+  margin-left: auto;
+}
+
+.chat-block-tstep-chev {
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+}
+
+.chat-block-tstep-text {
+  min-width: 0;
+}
+
+.chat-block-reason-detail {
+  margin-top: 6px;
+  padding: 8px 10px;
+  border-radius: var(--r-0);
+  background: var(--color-bg-panel-alt);
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-body);
+}
+
+.chat-block-tool-body {
+  margin-top: 6px;
+  padding: 8px 10px;
+  border-radius: var(--r-0);
+  background: var(--color-bg-panel-alt);
+}
+
+.chat-block-tool-body pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.chat-block-tool-label {
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-semi);
+  text-transform: uppercase;
+  letter-spacing: var(--track-caps);
+  color: var(--color-fg-muted);
+  margin-bottom: 4px;
+}
+
+.chat-json-key {
+  color: var(--syn-key);
+}
+
+.chat-json-str {
+  color: var(--syn-str);
+}
+
+/* ── Code / Shell ────────────────────────────────────────────── */
+.chat-block-code,
+.chat-block-shell {
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-panel-alt);
+  overflow: hidden;
+}
+
+.chat-block-code pre,
+.chat-block-shell pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.chat-block-code-cap {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--color-border-default);
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--track-caps);
+}
+
+.chat-block-shell-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.chat-block-shell-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.chat-block-shell-dot.r {
+  background: var(--color-status-err);
+}
+
+.chat-block-shell-dot.y {
+  background: var(--color-status-warn);
+}
+
+.chat-block-shell-dot.g {
+  background: var(--color-status-ok);
+}
+
+.chat-block-shell-title {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+  margin-left: 6px;
+}
+
+.chat-block-shell-line.err {
+  color: var(--color-status-err);
+}
+
+.chat-block-shell-prompt {
+  color: var(--color-fg-muted);
+  user-select: none;
+}
+
+.chat-block-shell-exit {
+  padding: 6px 10px;
+  border-top: 1px solid var(--color-border-default);
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+}
+
+.chat-block-shell-exit.ok {
+  color: var(--color-status-ok);
+}
+
+.chat-block-shell-exit.fail {
+  color: var(--color-status-err);
+}
+
+/* ── Markdown table ──────────────────────────────────────────── */
+.chat-block-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--fs-sm);
+}
+
+.chat-block-table thead th {
+  text-align: left;
+  padding: 6px 8px;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semi);
+  color: var(--color-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--track-caps);
+  border-bottom: 1px solid var(--color-border-default);
+  background: var(--color-bg-panel-alt);
+}
+
+.chat-block-table tbody td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--color-border-default);
+  color: var(--color-fg-secondary);
+  vertical-align: top;
+}
+
+.chat-block-cell-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-block-cell-muted {
+  color: var(--color-fg-muted);
+}
+
+/* ── Artifact file card ──────────────────────────────────────── */
+.chat-block-artifact {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  padding: 10px 12px;
+}
+
+.chat-block-artifact-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--r-1);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-panel-alt);
+  color: var(--color-fg-muted);
+  font-size: var(--fs-lg);
+}
+
+.chat-block-artifact-name {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--color-fg-secondary);
+}
+
+.chat-block-artifact-sub {
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+  margin-top: 2px;
+}
+
+.chat-block-artifact-btn {
+  padding: 4px 10px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-0);
+  background: var(--color-bg-panel-alt);
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-2xs);
+  cursor: pointer;
+  transition: background var(--t-fast);
+}
+
+.chat-block-artifact-btn:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-fg-primary);
+}
+
+/* ── Attach media card ───────────────────────────────────────── */
+.chat-block-attach {
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  overflow: hidden;
+}
+
+.chat-block-attach-hd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.chat-block-attach-name {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--color-fg-secondary);
+}
+
+.chat-block-attach-dims {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+  margin-left: auto;
+}
+
+.chat-block-attach-frame {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  background: var(--color-bg-panel-alt);
+  padding: 12px;
+}
+
+.chat-block-attach-frame svg {
+  max-height: 180px;
+  width: auto;
+}
+
+.chat-block-attach-ph {
+  color: var(--color-fg-muted);
+  font-size: var(--fs-sm);
+}
+
+.chat-block-attach-cap {
+  padding: 6px 10px;
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+}
+
+/* ── Voice memo ──────────────────────────────────────────────── */
+.chat-block-voice {
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  padding: 10px 12px;
+}
+
+.chat-block-voice-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.chat-block-voice-play {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 50%;
+  background: var(--color-bg-panel-alt);
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-xs);
+  cursor: pointer;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+
+.chat-block-voice-play:hover,
+.chat-block-voice-play.on {
+  background: var(--color-accent-fg);
+  border-color: var(--color-accent-fg);
+  color: var(--bg-0);
+}
+
+.chat-block-voice-wave {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  height: 28px;
+  flex: 1;
+}
+
+.chat-block-vbar {
+  width: 3px;
+  border-radius: 2px;
+  background: var(--color-fg-muted);
+  opacity: 0.45;
+  transition: background var(--t-fast), opacity var(--t-fast);
+}
+
+.chat-block-vbar.on {
+  background: var(--color-accent-fg);
+  opacity: 1;
+}
+
+.chat-block-voice-dur {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--color-fg-secondary);
+}
+
+.chat-block-voice-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+}
+
+.chat-block-voice-tx {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: var(--fs-xs);
+  color: var(--color-fg-secondary);
+}
+
+.chat-block-voice-tx span:first-child {
+  color: var(--color-fg-muted);
+  flex-shrink: 0;
+}
+
+/* ── Image / SVG media ───────────────────────────────────────── */
+.chat-block-media {
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  overflow: hidden;
+}
+
+.chat-block-media-frame {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  background: var(--color-bg-panel-alt);
+  padding: 12px;
+}
+
+.chat-block-media-frame img {
+  max-height: 208px;
+  width: 100%;
+  object-fit: contain;
+  border-radius: var(--r-1);
+}
+
+.chat-block-media-frame svg {
+  max-height: 208px;
+  width: auto;
+}
+
+.chat-block-media-ph {
+  color: var(--color-fg-muted);
+  font-size: var(--fs-sm);
+}
+
+.chat-block-media-cap {
+  padding: 8px 10px;
+  font-size: var(--fs-xs);
+  color: var(--color-fg-secondary);
+  border-top: 1px solid var(--color-border-default);
+}
+
+/* ── Link unfurl card ────────────────────────────────────────── */
+.chat-block-linkcard {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  padding: 10px 12px;
+  text-decoration: none;
+  transition: background var(--t-fast), border-color var(--t-fast);
+}
+
+.chat-block-linkcard:hover {
+  background: var(--color-bg-hover);
+  border-color: var(--color-border-strong);
+}
+
+.chat-block-linkcard-fav {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--r-1);
+  background: var(--color-bg-panel-alt);
+  color: var(--color-fg-muted);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semi);
+  flex-shrink: 0;
+}
+
+.chat-block-linkcard-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.chat-block-linkcard-title {
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semi);
+  color: var(--color-fg-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-block-linkcard-desc {
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.chat-block-linkcard-meta {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+}
+
+.chat-block-linkcard-go {
+  color: var(--color-fg-muted);
+  font-size: var(--fs-sm);
+}
+
+/* ── Broadcast card ──────────────────────────────────────────── */
+.chat-block-broadcast {
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  padding: 10px 12px;
+}
+
+.chat-block-broadcast-hd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: var(--fs-xs);
+  color: var(--color-fg-secondary);
+  margin-bottom: 6px;
+}
+
+.chat-block-broadcast-scope,
+.chat-block-broadcast-via,
+.chat-block-broadcast-count {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+}
+
+.chat-block-broadcast-count {
+  margin-left: auto;
+}
+
+.chat-block-broadcast-note {
+  font-size: var(--fs-sm);
+  color: var(--color-fg-primary);
+  line-height: var(--lh-body);
+  margin-bottom: 8px;
+}
+
+.chat-block-broadcast-rcpts {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.chat-block-broadcast-rcpt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: var(--r-0);
+  background: var(--color-bg-panel-alt);
+  font-size: var(--fs-2xs);
+}
+
+.chat-block-broadcast-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-border-strong);
+  color: var(--color-fg-primary);
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-semi);
+}
+
+.chat-block-broadcast-id {
+  color: var(--color-fg-secondary);
+}
+
+.chat-block-broadcast-ack {
+  color: var(--color-fg-muted);
+  margin-left: auto;
+}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -746,6 +746,63 @@ export interface KeeperConversationAudioClip {
   deviceId?: string | null
 }
 
+// --- Keeper v2 rich chat blocks (optional; when present the bubble renderer
+// uses them instead of plain markdown text). See ChatMessageBubble in
+// src/components/chat/primitives.ts.
+
+export type ChatTextBlock = { t: 'p'; html: string }
+export type ChatHeadingBlock = { t: 'h4'; html: string }
+export type ChatListBlock = { t: 'ul'; items: string[] }
+
+export type ChatCalloutSeverity = 'info' | 'warn' | 'bad'
+export type ChatCalloutBlock = { t: 'callout'; severity?: ChatCalloutSeverity; html: string }
+
+export type ChatTableCellValue = string | { v: string; num?: boolean; muted?: boolean }
+export type ChatTableBlock = { t: 'table'; head: ChatTableCellValue[]; rows: ChatTableCellValue[][] }
+
+export type ChatCodeBlock = { t: 'code'; cap?: string; html: string }
+
+export type ChatShellLine = { t?: 'cmd' | 'out' | 'err'; v: string }
+export type ChatShellBlock = { t: 'shell'; title?: string; lines: ChatShellLine[]; exit?: number; dur?: string }
+
+export type ChatArtifactBlock = { t: 'artifact'; kind?: string; name: string; size?: string; note?: string }
+
+export type ChatAttachBlock = { t: 'attach'; name: string; dims?: string; svg?: string; ph?: string; via?: string; size?: string }
+
+export type ChatVoiceBlock = { t: 'voice'; secs?: number; wave?: number[]; via?: string; size?: string; transcript?: string }
+
+export type ChatImageBlock = { t: 'image'; src?: string; ph?: string; cap?: string }
+export type ChatSvgBlock = { t: 'svg'; svg: string; cap?: string }
+
+export type ChatTraceThinkStep = { kind: 'think'; text: string }
+export type ChatTraceReasonStep = { kind: 'reason'; text: string; detail?: string }
+export type ChatTraceToolStep = { kind: 'tool'; name: string; status?: 'ok' | 'err'; dur?: string; args?: unknown; result?: string }
+export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTraceToolStep
+export type ChatTraceBlock = { t: 'trace'; trace: ChatTraceStep[] }
+
+export type ChatLinkBlock = { t: 'link'; url: string; title: string; desc?: string; meta?: string; fav?: string; kind?: string }
+
+export type ChatBroadcastAck = 'acked' | 'read' | 'delivered' | string
+export type ChatBroadcastRecipient = { id: string; ack: ChatBroadcastAck; at?: string }
+export type ChatBroadcastBlock = { t: 'broadcast'; scope: string; via?: string; note: string; recipients: ChatBroadcastRecipient[] }
+
+export type ChatBlock =
+  | ChatTextBlock
+  | ChatHeadingBlock
+  | ChatListBlock
+  | ChatCalloutBlock
+  | ChatTableBlock
+  | ChatCodeBlock
+  | ChatShellBlock
+  | ChatArtifactBlock
+  | ChatAttachBlock
+  | ChatVoiceBlock
+  | ChatImageBlock
+  | ChatSvgBlock
+  | ChatTraceBlock
+  | ChatLinkBlock
+  | ChatBroadcastBlock
+
 export type KeeperConversationStreamState =
   | 'opening'
   | 'thinking'
@@ -781,6 +838,7 @@ export interface KeeperConversationEntry {
   delivery: KeeperConversationDelivery
   streamState?: KeeperConversationStreamState
   attachments?: KeeperConversationAttachment[]
+  blocks?: ChatBlock[]
   details?: KeeperConversationDetails | null
   error?: string | null
   surface?: SurfaceRef | null


### PR DESCRIPTION
## Summary
Ports the keeper-v2 rich chat block renderer into the MASC dashboard chat primitives.

## What changed
- **Types** `dashboard/src/types/core.ts`:
  - Added `ChatBlock` discriminated union covering: `p`, `h4`, `ul`, `callout`, `table`, `code`, `shell`, `artifact`, `attach`, `voice`, `image`, `svg`, `trace`, `link`, `broadcast`
  - Added optional `blocks?: ChatBlock[]` to `KeeperConversationEntry`
- **Chat primitives** `dashboard/src/components/chat/primitives.ts`:
  - `ChatMessageBubble` renders block streams when `entry.blocks` is present, falling back to the existing markdown path.
  - Added renderers for every new block type.
- **New styles** `dashboard/src/styles/chat-blocks-v2.css` using dashboard tokens.
- **Wiring** — imported the new stylesheet in `main.ts`.
- **Tests** `dashboard/src/components/chat/primitives.test.ts` — 38 tests covering all block types and fallback behavior.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `chat/primitives.test.ts` ✅ 38/38

## Notes
- Keeps the existing markdown-only path untouched; block rendering is opt-in via `entry.blocks`.
- DOMPurify sanitization is used for inline HTML blocks.
- No backend wiring changes.
