### PR TITLE
feat(dashboard): apply keeper-v2 telemetry primitives

### DIFF
--- a/dashboard/src/components/common/telemetry-v2.test.ts
+++ b/dashboard/src/components/common/telemetry-v2.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  TelemetryBars,
+  Waterfall,
+  FsmLifeline,
+  TpsLive,
+  SegmentedProgress,
+  StreamingCaret,
+} from './telemetry-v2'
+
+describe('TelemetryBars', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders provided values as vertical bars', () => {
+    render(
+      html`<${TelemetryBars} values=${[{ h: 20 }, { h: 80, hot: true }]} />`,
+      container,
+    )
+    const bars = container.querySelectorAll('.telemetry-bars__bar')
+    expect(bars.length).toBe(2)
+    expect(bars[0]?.getAttribute('style')).toContain('height: 20.00%')
+    expect(bars[1]?.classList.contains('is-hot')).toBe(true)
+  })
+
+  it('clamps out-of-range heights', () => {
+    render(
+      html`<${TelemetryBars} values=${[{ h: -10 }, { h: 150 }]} />`,
+      container,
+    )
+    const bars = container.querySelectorAll('.telemetry-bars__bar')
+    expect(bars[0]?.getAttribute('style')).toContain('height: 0.00%')
+    expect(bars[1]?.getAttribute('style')).toContain('height: 100.00%')
+  })
+
+  it('generates demo bars when values omitted', () => {
+    render(html`<${TelemetryBars} count=${6} />`, container)
+    expect(container.querySelectorAll('.telemetry-bars__bar').length).toBe(6)
+  })
+
+  it('passes testId through', () => {
+    render(html`<${TelemetryBars} count=${2} testId="trace-bars" />`, container)
+    expect(container.querySelector('[data-testid="trace-bars"]')).toBeTruthy()
+  })
+
+  it('exposes role=img for accessibility', () => {
+    render(html`<${TelemetryBars} values=${[{ h: 50 }]} />`, container)
+    expect(container.querySelector('.telemetry-bars')?.getAttribute('role')).toBe('img')
+  })
+})
+
+describe('Waterfall', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  const rows = [
+    { kind: 'ctx' as const, label: 'context', left: 0, width: 20, dur: '120ms' },
+    { kind: 'reason' as const, label: 'reason', mono: true, left: 25, width: 30, dur: '180ms' },
+    { kind: 'tool' as const, label: 'tool_call', mono: true, left: 60, width: 25, dur: '90ms' },
+    { kind: 'gen' as const, label: 'generate', left: 88, width: 12, dur: '40ms' },
+  ]
+
+  it('renders rows with correct kinds', () => {
+    render(html`<${Waterfall} rows=${rows} total=${'430ms'} />`, container)
+    expect(container.querySelectorAll('.waterfall__row').length).toBe(4)
+    expect(container.querySelectorAll('.waterfall__bar--ctx').length).toBe(1)
+    expect(container.querySelectorAll('.waterfall__bar--gen').length).toBe(1)
+  })
+
+  it('renders total footer', () => {
+    render(html`<${Waterfall} rows=${rows} total=${'430ms'} />`, container)
+    const foot = container.querySelector('.waterfall__foot')
+    expect(foot?.textContent).toContain('total')
+    expect(foot?.textContent).toContain('430ms')
+  })
+
+  it('positions bars by left/width percentages', () => {
+    render(html`<${Waterfall} rows=${rows.slice(0, 1)} />`, container)
+    const bar = container.querySelector('.waterfall__bar') as HTMLElement
+    expect(bar.getAttribute('style')).toContain('left: 0.00%')
+    expect(bar.getAttribute('style')).toContain('width: 20.00%')
+  })
+
+  it('applies mono class when requested', () => {
+    render(html`<${Waterfall} rows=${rows.slice(1, 2)} />`, container)
+    const name = container.querySelector('.waterfall__name')
+    expect(name?.classList.contains('waterfall__name--mono')).toBe(true)
+  })
+
+  it('renders a legend', () => {
+    render(html`<${Waterfall} rows=${[]} />`, container)
+    const legend = container.querySelector('.waterfall__legend')
+    expect(legend?.textContent).toContain('ctx')
+    expect(legend?.textContent).toContain('reason')
+    expect(legend?.textContent).toContain('tool')
+    expect(legend?.textContent).toContain('gen')
+  })
+})
+
+describe('FsmLifeline', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders steps with done/cur/pending states', () => {
+    const steps = [
+      { label: 'Boot', state: 'done' },
+      { label: 'Load', state: 'done' },
+      { label: 'Run', state: 'cur' },
+      { label: 'Idle' },
+    ]
+    render(html`<${FsmLifeline} steps=${steps} />`, container)
+    const stepEls = container.querySelectorAll('.fsm-lifeline-v2__step')
+    expect(stepEls.length).toBe(4)
+    expect(stepEls[0]?.classList.contains('fsm-lifeline-v2__step--done')).toBe(true)
+    expect(stepEls[2]?.classList.contains('fsm-lifeline-v2__step--cur')).toBe(true)
+  })
+
+  it('exposes role=list and listitem', () => {
+    render(html`<${FsmLifeline} steps=${[{ label: 'A' }]} />`, container)
+    expect(container.querySelector('.fsm-lifeline-v2')?.getAttribute('role')).toBe('list')
+    expect(container.querySelector('.fsm-lifeline-v2__step')?.getAttribute('role')).toBe('listitem')
+  })
+})
+
+describe('TpsLive', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders rate and unit', () => {
+    render(html`<${TpsLive} rate=${73} />`, container)
+    expect(container.textContent).toContain('73 tok/s')
+  })
+
+  it('renders a live dot', () => {
+    render(html`<${TpsLive} />`, container)
+    expect(container.querySelector('.tps-live__dot')).toBeTruthy()
+  })
+
+  it('includes aria-label on value', () => {
+    render(html`<${TpsLive} rate=${55} />`, container)
+    const value = container.querySelector('.tps-live__value')
+    expect(value?.getAttribute('aria-label')).toBe('55 tokens per second')
+  })
+})
+
+describe('SegmentedProgress', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders segments in ratio', () => {
+    render(html`<${SegmentedProgress} done=${50} wip=${30} blocked=${10} total=${100} />`, container)
+    const segs = container.querySelectorAll('.segmented-progress__seg')
+    expect(segs.length).toBe(4)
+    expect(segs[0]?.getAttribute('style')).toContain('flex-grow: 50')
+    expect(segs[0]?.classList.contains('segmented-progress__seg--done')).toBe(true)
+    expect(segs[1]?.classList.contains('segmented-progress__seg--wip')).toBe(true)
+    expect(segs[2]?.classList.contains('segmented-progress__seg--blocked')).toBe(true)
+  })
+
+  it('omits zero segments', () => {
+    render(html`<${SegmentedProgress} done=${80} wip=${0} blocked=${0} />`, container)
+    const segs = container.querySelectorAll('.segmented-progress__seg')
+    expect(segs.length).toBe(1) // only done; rest is also 0 so omitted
+  })
+
+  it('uses provided total for ratio', () => {
+    render(html`<${SegmentedProgress} done=${1} wip=${1} blocked=${1} total=${12} />`, container)
+    const segs = container.querySelectorAll('.segmented-progress__seg')
+    expect(segs[segs.length - 1]?.getAttribute('style')).toContain('flex-grow: 9')
+  })
+})
+
+describe('StreamingCaret', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders a caret span', () => {
+    render(html`<${StreamingCaret} />`, container)
+    expect(container.querySelector('.streaming-caret')).toBeTruthy()
+  })
+
+  it('is aria-hidden', () => {
+    render(html`<${StreamingCaret} />`, container)
+    const caret = container.querySelector('.streaming-caret')
+    expect(caret?.getAttribute('aria-hidden')).toBe('true')
+  })
+})

--- a/dashboard/src/components/common/telemetry-v2.ts
+++ b/dashboard/src/components/common/telemetry-v2.ts
@@ -1,0 +1,269 @@
+// Telemetry v2 molecules — port of keeper-v2 design-system visualization atoms.
+//
+// These components are prop-driven only (no backend wiring) and are intended
+// for reuse in monitoring surfaces: trace counts, turn phase waterfalls,
+// keeper FSM steppers, throughput chips, and streaming indicators.
+//
+// Existing dashboard equivalents:
+//   - Sparkline       -> common/sparkline.ts (Canvas-based, kept in place)
+//   - ProgressBar     -> common/progress-bar.ts (single-value, kept in place)
+//   - SegmentedBar    -> common/distribution-bars.ts (stacked labeled split)
+// We add here the v2 shapes that were missing: TelemetryBars, Waterfall,
+// FsmLifeline, TpsLive, SegmentedProgress, and StreamingCaret.
+
+import { html } from 'htm/preact'
+import { useMemo } from 'preact/hooks'
+
+/* ════════════════════════════════════════════════════════════════
+   TELEMETRY BARS — vertical/horizontal density bars for trace counts
+   ════════════════════════════════════════════════════════════════ */
+
+export interface TelemetryBar {
+  /** 0–100 bar height / length. */
+  h: number
+  /** Optional "hot" highlight. */
+  hot?: boolean
+}
+
+export interface TelemetryBarsProps {
+  /** Predefined bars; if omitted, random demo bars are generated. */
+  values?: TelemetryBar[]
+  /** Number of demo bars when values is omitted. */
+  count?: number
+  /** Fraction of bars to mark hot in demo mode (default 0.22). */
+  hotRate?: number
+  class?: string
+  testId?: string
+}
+
+function clampPct(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(100, value))
+}
+
+export function TelemetryBars({
+  values,
+  count = 24,
+  hotRate = 0.22,
+  class: cx,
+  testId,
+}: TelemetryBarsProps) {
+  const bars = useMemo(
+    () =>
+      values?.length
+        ? values.map(b => ({ h: clampPct(b.h), hot: b.hot === true }))
+        : Array.from({ length: count }, () => ({
+            h: 18 + Math.random() * 80,
+            hot: Math.random() < hotRate,
+          })),
+    [values, count, hotRate],
+  )
+
+  return html`
+    <div
+      class=${`telemetry-bars ${cx ?? ''}`.trim()}
+      role="img"
+      aria-label=${`Telemetry bars: ${bars.length} samples`}
+      data-testid=${testId}
+    >
+      ${bars.map(
+        (b, i) =>
+          html`<div
+            key=${i}
+            class=${`telemetry-bars__bar ${b.hot ? 'is-hot' : ''}`}
+            style=${`height: ${b.h.toFixed(2)}%;`}
+          />`,
+      )}
+    </div>
+  `
+}
+
+/* ════════════════════════════════════════════════════════════════
+   WATERFALL — Gantt-style timing bars for turn phases
+   ════════════════════════════════════════════════════════════════ */
+
+export type WaterfallKind = 'ctx' | 'reason' | 'tool' | 'gen'
+
+export interface WaterfallRow {
+  kind: WaterfallKind
+  label: string
+  /** Render label in mono font. */
+  mono?: boolean
+  /** Start offset as % of total timeline. */
+  left: number
+  /** Duration as % of total timeline. */
+  width: number
+  /** Human duration string. */
+  dur: string
+}
+
+export interface WaterfallProps {
+  rows?: WaterfallRow[]
+  total?: string
+  class?: string
+  testId?: string
+}
+
+const WATERFALL_KIND_LABEL: Record<WaterfallKind, string> = {
+  ctx: 'ctx',
+  reason: 'reason',
+  tool: 'tool',
+  gen: 'gen',
+}
+
+export function Waterfall({ rows = [], total, class: cx, testId }: WaterfallProps) {
+  return html`
+    <div class=${`waterfall ${cx ?? ''}`.trim()} data-testid=${testId}>
+      ${rows.map(
+        (r, i) => html`
+          <div key=${i} class="waterfall__row">
+            <div class="waterfall__label">
+              <span class=${`waterfall__ico waterfall__ico--${r.kind}`} aria-hidden="true" />
+              <span class=${`waterfall__name ${r.mono ? 'waterfall__name--mono' : ''}`}>
+                ${r.label}
+              </span>
+            </div>
+            <div class="waterfall__track" aria-hidden="true">
+              <div
+                class=${`waterfall__bar waterfall__bar--${r.kind}`}
+                style=${`left: ${clampPct(r.left).toFixed(2)}%; width: ${clampPct(r.width).toFixed(2)}%;`}
+              />
+            </div>
+            <div class="waterfall__dur">${r.dur}</div>
+          </div>
+        `,
+      )}
+      <div class="waterfall__foot">
+        <span>total <b>${total ?? '—'}</b></span>
+        <div class="waterfall__legend">
+          ${(Object.keys(WATERFALL_KIND_LABEL) as WaterfallKind[]).map(
+            kind => html`
+              <span key=${kind}>
+                <i class=${`waterfall__ico waterfall__ico--${kind}`} aria-hidden="true" />
+                ${WATERFALL_KIND_LABEL[kind]}
+              </span>
+            `,
+          )}
+        </div>
+      </div>
+    </div>
+  `
+}
+
+/* ════════════════════════════════════════════════════════════════
+   FSM LIFELINE — vertical stepper showing keeper FSM states
+   ════════════════════════════════════════════════════════════════ */
+
+export interface FsmStep {
+  label: string
+  /** 'done' | 'cur' | anything else for pending. */
+  state?: string
+}
+
+export interface FsmLifelineProps {
+  steps?: FsmStep[]
+  class?: string
+  testId?: string
+}
+
+export function FsmLifeline({ steps = [], class: cx, testId }: FsmLifelineProps) {
+  return html`
+    <div
+      class=${`fsm-lifeline-v2 ${cx ?? ''}`.trim()}
+      role="list"
+      aria-label="Keeper FSM lifeline"
+      data-testid=${testId}
+    >
+      ${steps.map(
+        (s, i) => html`
+          <div key=${i} class=${`fsm-lifeline-v2__step fsm-lifeline-v2__step--${s.state ?? ''}`} role="listitem">
+            <span class="fsm-lifeline-v2__pip" aria-hidden="true" />
+            <span class="fsm-lifeline-v2__label">${s.label}</span>
+          </div>
+        `,
+      )}
+    </div>
+  `
+}
+
+/* ════════════════════════════════════════════════════════════════
+   TPS LIVE — live tokens-per-second chip
+   ════════════════════════════════════════════════════════════════ */
+
+export interface TpsLiveProps {
+  rate?: number
+  class?: string
+  testId?: string
+}
+
+export function TpsLive({ rate = 41, class: cx, testId }: TpsLiveProps) {
+  return html`
+    <span class=${`tps-live ${cx ?? ''}`.trim()} data-testid=${testId}>
+      <span class="tps-live__dot" aria-hidden="true" />
+      <span class="tps-live__value" aria-label="${rate} tokens per second">${rate} tok/s</span>
+    </span>
+  `
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SEGMENTED PROGRESS — stacked segmented progress bar
+   ════════════════════════════════════════════════════════════════ */
+
+export interface SegmentedProgressProps {
+  done?: number
+  wip?: number
+  blocked?: number
+  /** Total value for flex ratio; defaults to sum of segments clamped to at least 1. */
+  total?: number
+  class?: string
+  testId?: string
+}
+
+export function SegmentedProgress({
+  done = 0,
+  wip = 0,
+  blocked = 0,
+  total,
+  class: cx,
+  testId,
+}: SegmentedProgressProps) {
+  const segments = useMemo(() => {
+    const d = Math.max(0, done)
+    const w = Math.max(0, wip)
+    const b = Math.max(0, blocked)
+    const t = total != null && Number.isFinite(total) && total > 0 ? total : Math.max(1, d + w + b)
+    const rest = Math.max(0, t - d - w - b)
+    return [
+      { key: 'done', value: d, cls: 'segmented-progress__seg--done' },
+      { key: 'wip', value: w, cls: 'segmented-progress__seg--wip' },
+      { key: 'blocked', value: b, cls: 'segmented-progress__seg--blocked' },
+      { key: 'rest', value: rest, cls: 'segmented-progress__seg--rest' },
+    ].filter(s => s.value > 0)
+  }, [done, wip, blocked, total])
+
+  return html`
+    <div
+      class=${`segmented-progress ${cx ?? ''}`.trim()}
+      role="img"
+      aria-label=${`Progress: ${done} done, ${wip} in progress, ${blocked} blocked`}
+      data-testid=${testId}
+    >
+      ${segments.map(
+        s => html`<div key=${s.key} class=${`segmented-progress__seg ${s.cls}`} style=${`flex: ${s.value};`} />`,
+      )}
+    </div>
+  `
+}
+
+/* ════════════════════════════════════════════════════════════════
+   STREAMING CARET — blinking caret for streaming text
+   ════════════════════════════════════════════════════════════════ */
+
+export interface StreamingCaretProps {
+  class?: string
+  testId?: string
+}
+
+export function StreamingCaret({ class: cx, testId }: StreamingCaretProps) {
+  return html`<span class=${`streaming-caret ${cx ?? ''}`.trim()} aria-hidden="true" data-testid=${testId} />`
+}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -45,6 +45,7 @@ import './styles/memory-v2.css'
 import './styles/keeper-turn-inspector.css'
 import './styles/ide-v2.css'
 import './styles/work-v2.css'
+import './styles/telemetry-v2.css'
 
 import { render } from 'preact'
 import { html } from 'htm/preact'

--- a/dashboard/src/styles/telemetry-v2.css
+++ b/dashboard/src/styles/telemetry-v2.css
@@ -1,0 +1,295 @@
+/* MASC Dashboard v2 — Telemetry + state-visualization molecules
+ * (keeper-v2 port). Scoped classes so they coexist with legacy
+ * dashboard components without collisions.
+ */
+
+/* ───────────────────────────────────────────────────────────────
+   TELEMETRY BARS
+   ─────────────────────────────────────────────────────────────── */
+
+.telemetry-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--sp-0h);
+  height: 92px;
+  padding: var(--sp-0h) var(--sp-0h) 0;
+}
+
+.telemetry-bars__bar {
+  flex: 1;
+  min-width: 0;
+  min-height: 2px;
+  background: linear-gradient(
+    180deg,
+    var(--color-accent-fg-dim),
+    color-mix(in oklab, var(--color-accent-fg-dim) 50%, var(--color-bg-surface))
+  );
+  border-radius: var(--r-0) var(--r-0) 0 0;
+  transition: height var(--t-slow) ease;
+}
+
+.telemetry-bars__bar.is-hot {
+  background: linear-gradient(
+    180deg,
+    var(--color-accent-fg),
+    var(--color-accent-fg-dim)
+  );
+  box-shadow: 0 0 9px rgb(var(--brass-glow) / 0.45);
+}
+
+/* ───────────────────────────────────────────────────────────────
+   WATERFALL
+   ─────────────────────────────────────────────────────────────── */
+
+.waterfall {
+  display: flex;
+  flex-direction: column;
+  font-size: var(--fs-12);
+  color: var(--color-fg-secondary);
+}
+
+.waterfall__row {
+  display: grid;
+  grid-template-columns: 158px 1fr 56px;
+  gap: var(--sp-2);
+  align-items: center;
+  padding: var(--sp-1h) 0;
+  border-top: 1px solid var(--color-border-default);
+}
+
+.waterfall__row:first-child {
+  border-top: 0;
+}
+
+.waterfall__label {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.waterfall__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.waterfall__name--mono {
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+}
+
+.waterfall__ico {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--r-0);
+  flex: none;
+}
+
+.waterfall__ico--ctx { background: var(--color-status-ok); }
+.waterfall__ico--reason { background: var(--color-accent-fg); }
+.waterfall__ico--tool { background: var(--color-status-warn); }
+.waterfall__ico--gen { background: var(--color-status-info); }
+
+.waterfall__track {
+  position: relative;
+  height: 18px;
+  background: var(--color-bg-elevated);
+  border-radius: var(--r-0);
+  overflow: hidden;
+}
+
+.waterfall__bar {
+  position: absolute;
+  top: 3px;
+  height: 12px;
+  border-radius: 3px;
+  min-width: 4px;
+}
+
+.waterfall__bar--ctx { background: var(--color-status-ok); }
+.waterfall__bar--reason { background: var(--color-accent-fg); }
+.waterfall__bar--tool { background: var(--color-status-warn); }
+.waterfall__bar--gen { background: var(--color-status-info); }
+
+.waterfall__dur {
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  color: var(--color-fg-muted);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.waterfall__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: var(--sp-2);
+  padding-top: var(--sp-2);
+  border-top: 1px solid var(--color-border-strong);
+  font-size: var(--fs-11);
+  color: var(--color-fg-muted);
+}
+
+.waterfall__foot b {
+  font-family: var(--font-mono);
+  color: var(--color-fg-primary);
+  font-weight: var(--fw-semi);
+}
+
+.waterfall__legend {
+  display: flex;
+  gap: var(--sp-2);
+}
+
+.waterfall__legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-0h);
+  font-size: var(--fs-10);
+  color: var(--color-fg-muted);
+}
+
+/* ───────────────────────────────────────────────────────────────
+   FSM LIFELINE
+   ─────────────────────────────────────────────────────────────── */
+
+.fsm-lifeline-v2 {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.fsm-lifeline-v2__step {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: var(--sp-0h) var(--sp-0h);
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  color: var(--color-fg-muted);
+  position: relative;
+}
+
+.fsm-lifeline-v2__pip {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-bg-elevated);
+  flex: none;
+  z-index: 1;
+}
+
+.fsm-lifeline-v2__step--done {
+  color: var(--color-fg-secondary);
+}
+
+.fsm-lifeline-v2__step--done .fsm-lifeline-v2__pip {
+  background: var(--color-fg-muted);
+  border-color: var(--color-fg-muted);
+}
+
+.fsm-lifeline-v2__step--cur {
+  color: var(--color-accent-fg);
+}
+
+.fsm-lifeline-v2__step--cur .fsm-lifeline-v2__pip {
+  background: var(--color-accent-fg);
+  border-color: var(--color-accent-fg);
+  box-shadow: 0 0 10px rgb(var(--brass-glow) / 0.5);
+}
+
+.fsm-lifeline-v2__step:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  left: 8.5px;
+  top: 16px;
+  bottom: -5px;
+  width: 1px;
+  background: var(--color-border-default);
+}
+
+.fsm-lifeline-v2__step--done:not(:last-child)::after {
+  background: var(--color-fg-muted);
+}
+
+/* ───────────────────────────────────────────────────────────────
+   TPS LIVE
+   ─────────────────────────────────────────────────────────────── */
+
+.tps-live {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-0h);
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  color: var(--color-status-ok);
+  font-variant-numeric: tabular-nums;
+}
+
+.tps-live__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-status-ok);
+  box-shadow: 0 0 6px var(--color-status-ok);
+  animation: tps-live-pulse 1.1s ease-in-out infinite;
+}
+
+@keyframes tps-live-pulse {
+  0%, 100% { opacity: 0.45; }
+  50% { opacity: 1; }
+}
+
+/* ───────────────────────────────────────────────────────────────
+   SEGMENTED PROGRESS
+   ─────────────────────────────────────────────────────────────── */
+
+.segmented-progress {
+  display: flex;
+  gap: 1.5px;
+  width: 100%;
+  height: 6px;
+  background: var(--color-bg-elevated);
+  border-radius: var(--r-1);
+  overflow: hidden;
+}
+
+.segmented-progress__seg {
+  height: 100%;
+  min-width: 0;
+}
+
+.segmented-progress__seg--done { background: var(--color-status-ok); }
+.segmented-progress__seg--wip { background: var(--color-accent-fg); }
+.segmented-progress__seg--blocked { background: var(--color-status-err); }
+.segmented-progress__seg--rest { background: transparent; }
+
+/* ───────────────────────────────────────────────────────────────
+   STREAMING CARET
+   ─────────────────────────────────────────────────────────────── */
+
+.streaming-caret {
+  display: inline-block;
+  width: 7px;
+  height: 13px;
+  background: var(--color-accent-fg);
+  margin-left: var(--sp-0h);
+  vertical-align: -2px;
+  animation: streaming-caret-blink 1s steps(2) infinite;
+}
+
+@keyframes streaming-caret-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* Reduced motion: disable the live dot + caret animations */
+@media (prefers-reduced-motion: reduce) {
+  .tps-live__dot,
+  .streaming-caret {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
Ports the keeper-v2 telemetry and state-visualization molecules into the MASC dashboard.

## What changed
- **New component** `dashboard/src/components/common/telemetry-v2.ts` with:
  - `TelemetryBars` — vertical/horizontal density bars
  - `Waterfall` — Gantt-style turn-phase timing bars
  - `FsmLifeline` — vertical keeper FSM stepper
  - `TpsLive` — live tokens-per-second chip
  - `SegmentedProgress` — stacked segmented progress bar
  - `StreamingCaret` — blinking streaming caret
- **New styles** `dashboard/src/styles/telemetry-v2.css` using dashboard tokens.
- **Wiring** — imported stylesheet in `main.ts`.
- **Tests** `dashboard/src/components/common/telemetry-v2.test.ts` — 20 tests.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `telemetry-v2.test.ts` ✅ 20/20

## Notes
- Existing dashboard equivalents (Canvas Sparkline, ProgressBar, DistributionBars) were intentionally kept; this PR fills the missing v2 shapes.
- All components are prop-driven; no backend wiring.


---

## 🔄 AS-IS vs TO-BE 구조적 개선점 분석 (Structural Improvements)

```mermaid
flowchart LR
    subgraph AS_IS [AS-IS: 기존 대시보드 아키텍처]
        A1[Dashboard main.ts] --> A2[v1 컴포넌트]
        A2 --> A3[Canvas Sparkline]
        A2 --> A4[ProgressBar]
        A2 --> A5[DistributionBars]
        A6[Keeper-v2 시각화 요구사항] -.->|미지원| A7((형태 누락\nMissing Shapes))
    end

    subgraph TO_BE [TO-BE: keeper-v2 텔레메트리 적용 후]
        B1[Dashboard main.ts] --> B2[Global Styles Import]
        B1 --> B3[v1 컴포넌트 유지]
        B1 --> B4[telemetry-v2.ts]
        B2 --> B5[telemetry-v2.css\nDashboard Tokens 적용]
        B4 --> B6[TelemetryBars]
        B4 --> B7[Waterfall]
        B4 --> B8[FsmLifeline]
        B4 --> B9[TpsLive]
        B4 --> B10[SegmentedProgress]
        B4 --> B11[StreamingCaret]
        B12[External Props] ==>|상태 주입| B4
        B13[telemetry-v2.test.ts] -.->|20개 테스트 검증| B4
    end

    AS_IS ==>|PR #21365 적용| TO_BE
```

| 기술 카테고리 | AS-IS (변경 전) | TO-BE (변경 후) | 개선 효과 및 레터럴 |
| :--- | :--- | :--- | :--- |
| **모듈성 (Modularity)** | 기존 v1 원시(Primitive) 컴포넌트(`Canvas Sparkline`, `ProgressBar`, `DistributionBars`)만 존재 | `telemetry-v2.ts` 파일에 6개의 새로운 독립적인 v2 원시 컴포넌트 추가 | 기존 v1 컴포넌트를 유지하면서 v2 형태를 안전하게 분리하여 추가. 단일 책임 원칙 준수 및 결합도 저감 |
| **UI 다양성 (Visualization)** | Keeper-v2에서 요구하는 세밀한 텔레메트리 시각화 형태(간트 스타일, FSM 스테퍼 등) 미지원 | `TelemetryBars`, `Waterfall`, `FsmLifeline`, `TpsLive`, `SegmentedProgress`, `StreamingCaret` 6종 확보 | 밀도 바, 턴-페이즈 타이밍, 토큰 처리 속도 등 다각적인 데이터 표현이 가능해져 대시보드의 정보 전달력 극대화 |
| **상태 관리 (State Management)** | 해당 없음 (신규 컴포넌트 부재) | 모든 v2 컴포넌트가 순수하게 Prop-driven 방식으로 설계됨 | 백엔드와의 직접적인 결합 없이 상위 컴포넌트에서 데이터를 주입받아 렌더링. 재사용성 및 테스트 용이성 확보 |
| **안전성 및 신뢰성 (Reliability)** | 텔레메트리 v2 관련 컴포넌트에 대한 테스트 커버리지 0% | `telemetry-v2.test.ts`에 20개의 단위 테스트 작성 및 통과 (`pnpm typecheck`, `pnpm lint` 전부 통과) | 렌더링 및 Prop 변화에 대한 회귀 방지. 정적 타이핑(TypeScript) 및 린팅을 통한 코드 신뢰도 견고화 |
| **스타일 아키텍처 (Styling)** | 기존 대시보드 스타일링만 존재 | `telemetry-v2.css` 신규 생성 및 `main.ts`에 글로벌 임포트 추가. 대시보드 디자인 토큰(Dashboard Tokens) 사용 | 새로운 컴포넌트들이 기존 대시보드의 디자인 시스템과 일관된 시각적 톤앤매너를 유지하도록 아키텍처 수준에서 강제 |
