### PR TITLE
fix(keeper): remediate SSOT drift across turn lifecycle, registry, and task dispatch

### DIFF
--- a/dashboard/src/composite-signals.ts
+++ b/dashboard/src/composite-signals.ts
@@ -2,9 +2,11 @@
 //
 // The SSE stream emits [keeper_composite_changed] with a name + wall-clock
 // envelope whenever a registry mutation may have changed the composite
-// snapshot. Subscribers observe [compositeTick] and re-fetch the full
-// payload from [/api/v1/keepers/:name/composite] — keeping the registry
-// as the single writer.
+// snapshot. This event is *signal-only freshness transport*; the payload is
+// intentionally not the authoritative read model. Subscribers observe
+// [compositeTick] and re-fetch the full payload from
+// [/api/v1/keepers/:name/composite] — keeping the registry as the single
+// writer. See docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md §Read Model Rules.
 
 import { signal } from '@preact/signals'
 

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -39,6 +39,7 @@ const requestNamespaceTruthNow = vi.fn<() => void>()
 const requestNamespaceTruth = vi.fn<() => void>()
 const showToast = vi.fn<(message: string, kind?: string, durationMs?: number) => void>()
 const replayOasRuntimeTelemetry = vi.fn<() => Promise<void>>(async () => {})
+const compositeTick = signal({ name: '', ts_unix: 0 })
 const hydrateFleetCompositeSnapshot = vi.fn<(payload: unknown) => void>()
 const hydrateGoalTreeSnapshot = vi.fn<(payload: unknown) => boolean>(() => true)
 const noteKeeperChatAppended = vi.fn<(name: string, audio?: unknown) => void>()
@@ -86,7 +87,7 @@ async function loadSseStore() {
     applyOasRuntimeEvent: vi.fn(),
   }))
   vi.doMock('./composite-signals', () => ({
-    compositeTick: signal({ name: '', ts_unix: 0 }),
+    compositeTick,
     hydrateFleetCompositeSnapshot,
   }))
   vi.doMock('./goal-tree-state', () => ({
@@ -98,7 +99,7 @@ async function loadSseStore() {
   vi.doMock('./router', () => ({ route }))
   const sseStore = await import('./sse-store')
   const sse = await import('./sse')
-  return { sseStore, sse }
+  return { sseStore, sse, compositeTick }
 }
 
 describe('setupSSEReaction reconnect hydration', () => {
@@ -137,6 +138,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     boardOffset.value = 0
     keeperHeartbeats.value = new Map()
     serverStatus.value = null
+    compositeTick.value = { name: '', ts_unix: 0 }
   })
 
   afterEach(() => {
@@ -355,6 +357,23 @@ describe('setupSSEReaction reconnect hydration', () => {
     await flushAsyncWork()
 
     expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo', audio)
+  })
+
+  it('treats keeper_composite_changed as a signal-only tick and does not hydrate from the event payload', async () => {
+    const { sseStore, compositeTick } = await loadSseStore()
+
+    sseStore.routeServerPushEvent({
+      type: 'keeper_composite_changed',
+      name: 'qa-king',
+      ts_unix: 1710000000.123,
+      // Any payload-like fields must be ignored; the authoritative read is the
+      // per-keeper composite HTTP endpoint.
+      payload: { unexpected: true },
+    })
+    await flushAsyncWork()
+
+    expect(compositeTick.value).toEqual({ name: 'qa-king', ts_unix: 1710000000.123 })
+    expect(hydrateFleetCompositeSnapshot).not.toHaveBeenCalled()
   })
 
   it('routes board reaction changes through the board refresh budget', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -536,6 +536,11 @@ export function hydrateServerPushEvent(event: SSEEvent): boolean {
     return true
   }
 
+  // Signal-only freshness tick for keeper composite state. The SSE payload
+  // carries only the keeper name and a wall-clock timestamp; it is *not* the
+  // authoritative composite snapshot. Consumers that need the new state must
+  // observe [compositeTick] and re-fetch [/api/v1/keepers/:name/composite]
+  // from the registry. See docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md §Read Model Rules.
   if (event.type === 'keeper_composite_changed') {
     const payload = event as unknown as { name?: string; ts_unix?: number }
     const name = typeof payload.name === 'string' ? payload.name : ''

--- a/docs/spec/04-turn-lifecycle.md
+++ b/docs/spec/04-turn-lifecycle.md
@@ -445,7 +445,7 @@ MASC keeper hot path는 단일 provider run만 사용하며(`oas_dispatch_mode =
 
 | ID | Question | Related code | Status |
 |----|----------|--------------|--------|
-| OQ-TURN-001 | `Cancelled_*` cancel reason이 run_turn 내부에서 `safe_emit_turn_end` catch-all로 소비되는 부분을 `Switch.on_release`로 명시적으로 FSM에 연결할 것인가? | `lib/keeper/keeper_agent_run.ml:148` | Open (RISKY) |
+| OQ-TURN-001 | `Cancelled_*` cancel reason이 run_turn 내부에서 `safe_emit_turn_end` catch-all로 소비되는 부분을 `Switch.on_release`로 명시적으로 FSM에 연결할 것인가? | `lib/keeper/keeper_agent_run.ml:178` | Partially addressed — observation `phase` now preserves cancellation terminal state through the finally block; full typed FSM `Cancelled _` transition routing remains open. |
 | OQ-TURN-002 | `Awaiting_provider → Streaming` 및 `Streaming ⇄ Awaiting_tool_result` transition을 run_turn 내부에서 emit할 것인가? | `lib/keeper/keeper_agent_run.ml` | Open |
 | OQ-TURN-003 | Direct message path도 FSM transition을 emit할 것인가? 현재는 autonomous path 위주로 기록된다. | `lib/keeper/keeper_turn.ml` | Open |
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -135,40 +135,48 @@ let run_turn
     ; duration_ms = None
     ; timestamp_ms = observation_timestamp_ms ()
     };
-  (* Cancel-safe cleanup (#9747): stdlib [Fun.protect] wraps finally
-     exceptions in [Fun.Finally_raised], masking the outer
-     [Eio.Cancel.Cancelled] raised by the turn body during fleet-wide
-     cancellation. Swallow Cancelled in the finally (the outer one is
-     already in flight) and log non-cancel exceptions instead of
-     propagating them. Mirrors the pattern used in
-     [keeper_unified_turn.ml] (#9747 iter 1). *)
+  (* Cancel-safe cleanup (#9747): [Eio_guard.protect] already uses
+     [Eio.Switch.on_release], so cleanup runs under cooperative cancellation
+     and does not mask the outer [Eio.Cancel.Cancelled]. We still need to
+     preserve the *terminal state* through the finally block: a cancelled
+     turn must emit phase="cancelled" in the observation event so receipts
+     and registry consumers agree with the FSM terminal [Cancelled _].
+     The [turn_cancelled] ref is set only when the turn body actually raises
+     [Eio.Cancel.Cancelled]; the finally block inspects it to pick the
+     observation phase. *)
   let turn_start_time = Unix.gettimeofday () in
-  let safe_emit_turn_end =
-    let emit_observation_turn_end () =
-      let duration_ms = int_of_float ((Unix.gettimeofday () -. turn_start_time) *. 1000.0) in
-      let turn_id = match meta.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "turn-" ^ meta.name in
-      Agent_observation.emit_turn_event
-        { base_path = config.base_path
-        ; turn_id
-        ; keeper_id = meta.name
-        ; phase = "completed"
-        ; model_used = None
-        ; tools_used = []
-        ; stop_reason = None
-        ; duration_ms = Some duration_ms
-        ; timestamp_ms = observation_timestamp_ms ()
-        }
+  let turn_cancelled = ref None in
+  let emit_observation_turn_end ~phase ~stop_reason () =
+    let duration_ms = int_of_float ((Unix.gettimeofday () -. turn_start_time) *. 1000.0) in
+    let turn_id = match meta.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "turn-" ^ meta.name in
+    Agent_observation.emit_turn_event
+      { base_path = config.base_path
+      ; turn_id
+      ; keeper_id = meta.name
+      ; phase
+      ; model_used = None
+      ; tools_used = []
+      ; stop_reason
+      ; duration_ms = Some duration_ms
+      ; timestamp_ms = observation_timestamp_ms ()
+      }
+  in
+  let safe_emit_turn_end () =
+    let phase, stop_reason =
+      match !turn_cancelled with
+      | Some exn -> "cancelled", Some (Printexc.to_string exn)
+      | None -> "completed", None
     in
-    fun () ->
-      (try emit_observation_turn_end ()
-       with Eio.Cancel.Cancelled _ as ce -> raise ce
-       | exn ->
-         Log.Keeper.warn "keeper:%s emit_observation_turn_end failed: %s"
-           meta.name (Printexc.to_string exn));
-      Turn_helpers.emit_turn_end_safely ~keeper_name:meta.name ()
+    (try emit_observation_turn_end ~phase ~stop_reason ()
+     with Eio.Cancel.Cancelled _ as ce -> raise ce
+     | exn ->
+       Log.Keeper.warn "keeper:%s emit_observation_turn_end failed: %s"
+         meta.name (Printexc.to_string exn));
+    Turn_helpers.emit_turn_end_safely ~keeper_name:meta.name ()
   in
   Eio_guard.protect ~finally:safe_emit_turn_end
   @@ fun () ->
+  try
   (* RFC-0107 §3.3 Phase C.1 wiring — turn-scoped Eio.Switch.
      Resources opened during a turn (HTTP connections, sandbox exec
      handles, retry sub-tasks via [Keeper_turn_driver_try_provider])
@@ -711,3 +719,7 @@ let run_turn
             ]
           ());
        receipt_result)
+with
+| Eio.Cancel.Cancelled _ as ce ->
+  turn_cancelled := Some ce;
+  raise ce

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -251,15 +251,15 @@ let turn_progress_callbacks ~config ~keeper_name ~downstream ~turn_id =
       ~event_kind
   in
   let yield_on_tool = Env_config.Slot.yield_enabled () in
+  (* SSOT-DRIFT-REMEDIATION: Streaming⇄Awaiting_tool_result FSM transitions
+     are now emitted from the turn-scoped OAS Event_bus observation in
+     [Keeper_unified_turn_event_bus], so they appear unconditionally even
+     when [yield_on_tool=false]. The yield/resume hooks below only handle
+     the optional slot-yield behaviour and its registry progress events. *)
   let on_yield =
     if yield_on_tool then
       Some
         (fun () ->
-          Keeper_turn_fsm.emit_transition
-            ~keeper_name
-            ~turn_id
-            ~prev:Keeper_turn_fsm.Streaming
-            Keeper_turn_fsm.Awaiting_tool_result;
           record_turn_progress "slot_yield";
           Log.Misc.debug "keeper %s: slot yielded (tool execution)" keeper_name)
     else None
@@ -268,11 +268,6 @@ let turn_progress_callbacks ~config ~keeper_name ~downstream ~turn_id =
     if yield_on_tool then
       Some
         (fun () ->
-          Keeper_turn_fsm.emit_transition
-            ~keeper_name
-            ~turn_id
-            ~prev:Keeper_turn_fsm.Awaiting_tool_result
-            Keeper_turn_fsm.Streaming;
           record_turn_progress "slot_resume";
           Log.Misc.debug "keeper %s: slot resumed (next LLM turn)" keeper_name)
     else None

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -81,21 +81,25 @@ let set_turn_selected_model ~base_path name selected_model =
 ;;
 
 let prepare_turn_retry_after_compaction ~base_path name =
-  let changed = ref false in
-  let now = Time_compat.now () in
-  update_entry_if_registered ~base_path name (fun e ->
-    update_current_turn e (fun obs ->
-      validate_turn_phase_transition ~from:obs.turn_phase ~to_:(Packed Turn_prompting);
-      changed := true;
-      { (stamp_turn_progress ~now ~event_kind:"retry_after_compaction" obs) with
-        turn_phase = Packed Turn_prompting
-      ; decision_stage = Packed Decision_guard_ok
+  (* Routed through [set_turn_phase_with] so the compaction-retry reset uses
+     the same resolver / guard / broadcast pathway as [set_turn_phase]. *)
+  set_turn_phase_with
+    ~base_path
+    name
+    ~event_kind:"retry_after_compaction"
+    ~target:(Packed Turn_prompting)
+    ~update_obs:(fun obs ->
+      { obs with
+        decision_stage = Packed Decision_guard_ok
       ; selected_model = None
-      }));
-  if !changed then broadcast_composite_changed ~name ~ts_unix:now
+      })
 ;;
 
 let mark_turn_gate_rejected_by_name name =
+  (* Name-only gate-rejection lookup (legacy server surface does not carry
+     base_path).  The phase transition itself is routed through
+     [set_turn_phase_with] so it shares the resolver / guard / broadcast
+     pathway with [set_turn_phase]. *)
   let target =
     StringMap.fold
       (fun _k v acc ->
@@ -108,20 +112,22 @@ let mark_turn_gate_rejected_by_name name =
   match target with
   | None -> ()
   | Some entry ->
-    let changed = ref false in
-    let now = Time_compat.now () in
-    update_entry ~base_path:entry.base_path name (fun e ->
-      update_current_turn e (fun obs ->
-        validate_turn_phase_transition ~from:obs.turn_phase ~to_:(Packed Turn_finalizing);
-        changed := true;
-        { (stamp_turn_progress ~now ~event_kind:"gate_rejected" obs) with
-          decision_stage = Packed Decision_gate_rejected
-        ; turn_phase = Packed Turn_finalizing
-        }));
-    if !changed then broadcast_composite_changed ~name ~ts_unix:now
+    set_turn_phase_with
+      ~base_path:entry.base_path
+      name
+      ~event_kind:"gate_rejected"
+      ~target:(Packed Turn_finalizing)
+      ~update_obs:(fun obs -> { obs with decision_stage = Packed Decision_gate_rejected })
 ;;
 
 let mark_turn_finished ~base_path name =
+  (* Terminal turn lifecycle step: freeze [current_turn_observation] into
+     [last_completed_turn] and clear the live observation.  This is
+     intentionally NOT routed through [set_turn_phase_with]: it mutates the
+     turn container (Some -> None) rather than transitioning the turn_phase
+     sub-FSM.  It remains a separate, justified channel; the drift audit
+     concern is the phase-transition setters that were duplicating resolver
+     logic. *)
   let completed_turn_to_record = ref None in
   let changed = ref false in
   let now = Time_compat.now () in

--- a/lib/keeper/keeper_registry_broadcast.ml
+++ b/lib/keeper/keeper_registry_broadcast.ml
@@ -6,6 +6,10 @@
     + log on failure. No registry state touched. *)
 
 let composite_changed ~name ~ts_unix =
+  (* Signal-only freshness tick: name + timestamp. The authoritative read
+     model is the per-keeper composite HTTP endpoint; consumers must
+     re-fetch [/api/v1/keepers/:name/composite]. See
+     docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md §Read Model Rules. *)
   try
     let json =
       `Assoc

--- a/lib/keeper/keeper_registry_broadcast.mli
+++ b/lib/keeper/keeper_registry_broadcast.mli
@@ -2,8 +2,14 @@
 
     Pure side-effect wrappers — no registry state read or written. *)
 
-(** Broadcast a [keeper_composite_changed] SSE event on both the main
-    broadcast channel and the presence stream.
+(** Broadcast a signal-only [keeper_composite_changed] SSE event on both
+    the main broadcast channel and the presence stream.
+
+    The payload is intentionally minimal: keeper [name] + wall-clock
+    [ts_unix]. It is *not* the authoritative composite snapshot.
+    Consumers must re-fetch [/api/v1/keepers/:name/composite] to observe
+    the new state. See docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
+    §Read Model Rules.
 
     Exceptions from [Sse.broadcast] are caught, counted on the
     [keeper_lifecycle_dispatch_rejections] Otel_metric_store counter (with

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -501,6 +501,42 @@ let set_turn_phase_direct ~base_path name ~event_kind (turn_phase : packed_turn_
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
+let set_turn_phase_with ~base_path name ~event_kind ~target ~update_obs =
+  (* RFC-0072 Phase 4b + Phase 5 variant: resolve the turn_phase transition
+     and let the caller apply additional observation mutations atomically in
+     the same CAS.  This keeps multi-field setters (gate rejection,
+     compaction retry) on the same resolver / guard / broadcast pathway as
+     [set_turn_phase] instead of calling the legacy
+     [validate_turn_phase_transition] directly.  Idempotent self-loops are
+     no-ops and do not emit a broadcast, matching [set_turn_phase].  The
+     [event_kind] label is forwarded to [raise_turn_phase_transition_violation]
+     via [wrap_unit] so guard metrics name the actual caller. *)
+  let changed = ref false in
+  let now = Time_compat.now () in
+  update_entry_if_registered ~base_path name (fun e ->
+    update_current_turn e (fun obs ->
+      match resolve_turn_phase_transition ~from:obs.turn_phase ~target with
+      | Resolved_turn_idempotent -> obs
+      | Resolved_turn_transition _ ->
+        changed := true;
+        let obs' =
+          { (stamp_turn_progress ~now ~event_kind obs) with turn_phase = target }
+        in
+        update_obs obs'
+      | Resolved_turn_violation violation ->
+        Keeper_fsm_guard_runtime.wrap_unit
+          ~action:"turn_phase_transition"
+          ~stage:"guard"
+          (fun () ->
+             raise_turn_phase_transition_violation
+               ~where:event_kind
+               ~from:obs.turn_phase
+               ~to_:target
+               ~violation);
+        obs));
+  if !changed then broadcast_composite_changed ~name ~ts_unix:now
+;;
+
 let mark_turn_runtime_exhausted ~base_path name =
   set_turn_decision_stage ~base_path name Decision_active_tool_policy_selected;
   set_turn_phase_direct

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -167,6 +167,93 @@ let preflight_keeper_msg ctx args : (unit, string) result =
         | Ok () ->
           Keeper_turn_helpers.ensure_local_discovery_ready effective_models)))
 
+(* -- Direct-message turn FSM wrapper ---------------------------------------- *)
+
+(** Run a direct [masc_keeper_msg] turn with the same typed FSM transitions
+    emitted by the autonomous [Keeper_unified_turn.run_keeper_cycle] path.
+
+    Direct turns historically called [Keeper_agent_run.run_turn] directly,
+    which left them invisible to [Keeper_turn_fsm] telemetry and violated
+    the SSOT contract audited in
+    [docs/audit/2026-06-13-masc-fsm-drift-audit.md] (finding #3).  This
+    wrapper emits the canonical start sequence
+    [Idle -> Phase_gating -> Runtime_routing -> Awaiting_provider -> Streaming]
+    before invoking [f], then records the matching terminal state
+    ([Done], [Failed], or [Cancelled]) from the result or exception.
+
+    The wrapper is intentionally thin: it does not duplicate metrics,
+    receipt, or meta writes — those remain in
+    [run_keeper_msg_turn_admitted].  It only restores FSM observability so
+    direct and autonomous turns share the same state-machine read model. *)
+let run_direct_turn_with_fsm ~(keeper_name : string) ~(turn_id : int) f =
+  Keeper_turn_fsm.emit_transition
+    ~keeper_name
+    ~turn_id
+    ~prev:Keeper_turn_fsm.Idle
+    Keeper_turn_fsm.Phase_gating;
+  Keeper_turn_fsm.emit_transition
+    ~keeper_name
+    ~turn_id
+    ~prev:Keeper_turn_fsm.Phase_gating
+    Keeper_turn_fsm.Runtime_routing;
+  Keeper_turn_fsm.emit_transition
+    ~keeper_name
+    ~turn_id
+    ~prev:Keeper_turn_fsm.Runtime_routing
+    Keeper_turn_fsm.Awaiting_provider;
+  Keeper_turn_fsm.emit_transition
+    ~keeper_name
+    ~turn_id
+    ~prev:Keeper_turn_fsm.Awaiting_provider
+    Keeper_turn_fsm.Streaming;
+  try
+    let result = f () in
+    (match result with
+     | Ok _ ->
+       Keeper_turn_fsm.emit_transition
+         ~keeper_name
+         ~turn_id
+         ~prev:Keeper_turn_fsm.Streaming
+         Keeper_turn_fsm.Completing;
+       Keeper_turn_fsm.emit_transition
+         ~keeper_name
+         ~turn_id
+         ~prev:Keeper_turn_fsm.Completing
+         Keeper_turn_fsm.Done
+     | Error err ->
+       let reason =
+         Keeper_turn_fsm.Failure_provider_error
+           { kind = Keeper_agent_error.sdk_error_kind err
+           ; detail = Agent_sdk.Error.to_string err
+           }
+       in
+       Keeper_turn_fsm.emit_transition
+         ~keeper_name
+         ~turn_id
+         ~prev:Keeper_turn_fsm.Streaming
+         (Keeper_turn_fsm.Failed reason));
+    result
+  with
+  | Eio.Cancel.Cancelled _ as e ->
+    (* Cooperative cancellation must be preserved and reflected as a
+       terminal [Cancelled] state, not swallowed as a successful completion.
+       See [KeeperTurnFSM.tla] [HonorStopSignal] and the audit finding #5. *)
+    Keeper_turn_fsm.emit_transition
+      ~keeper_name
+      ~turn_id
+      ~prev:Keeper_turn_fsm.Streaming
+      (Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_supervisor_stop);
+    raise e
+  | exn ->
+    Keeper_turn_fsm.emit_transition
+      ~keeper_name
+      ~turn_id
+      ~prev:Keeper_turn_fsm.Streaming
+      (Keeper_turn_fsm.Failed
+         (Keeper_turn_fsm.Failure_unexpected_exception
+            { exn = Printexc.to_string exn; backtrace = None }));
+    raise exn
+
 (* -- handle_keeper_msg: orchestrator ---------------------------------------- *)
 
 (* Body of [handle_keeper_msg], runnable only while holding the keeper's
@@ -235,6 +322,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
     | Ok meta0 ->
       let turn_task_id = Printf.sprintf "keeper_turn_%s_%d"
         name (int_of_float (Time_compat.now () *. 1000.0)) in
+      let keeper_turn_id = meta0.runtime.usage.total_turns + 1 in
       let turn_tracker = Progress.start_tracking ~task_id:turn_task_id ~total_steps:5 () in
       Progress.Tracker.step turn_tracker ~message:"Preparing keeper turn configuration" ();
       let meta = meta0 in
@@ -497,27 +585,31 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
             let turn_ctx_cell = Keeper_tool_call_log.create_turn_ctx_cell () in
             let run_result, latency_ms =
               Keeper_context_runtime.timed (fun () ->
-                  Keeper_agent_run.run_turn
-                    ~config:ctx.config ~meta ~turn_ctx_cell ~base_dir
-                    ~max_context:max_runtime_context
-                    ~build_turn_prompt
-                    ~user_message:message
-                    ~runtime_id:
-                      (                         (turn_runtime_id))
-                    ~world_observation
-                    ~turn_affordances
-                    (* A kmsg turn is user-triggered, i.e. reactive: it must
-                       use the reactive idle budget so the graduated idle hook
-                       (nudge -> final warning -> graceful Skip) can run its
-                       course before the OAS loop guard aborts the run. *)
-                    ~max_idle_turns:
-                      (Keeper_runtime_resolved.reactive_max_idle_turns ())
-                    ?oas_timeout_s:keeper_msg_oas_timeout_s
-                    ~generation:meta.runtime.generation
-                    ?on_event
-                    ~trajectory_acc
-                    ?event_bus:(Keeper_event_bus.get ())
-                    ())
+                  run_direct_turn_with_fsm
+                    ~keeper_name:meta.name
+                    ~turn_id:keeper_turn_id
+                    (fun () ->
+                       Keeper_agent_run.run_turn
+                         ~config:ctx.config ~meta ~turn_ctx_cell ~base_dir
+                         ~max_context:max_runtime_context
+                         ~build_turn_prompt
+                         ~user_message:message
+                         ~runtime_id:
+                           (                         (turn_runtime_id))
+                         ~world_observation
+                         ~turn_affordances
+                         (* A kmsg turn is user-triggered, i.e. reactive: it must
+                            use the reactive idle budget so the graduated idle hook
+                            (nudge -> final warning -> graceful Skip) can run its
+                            course before the OAS loop guard aborts the run. *)
+                         ~max_idle_turns:
+                           (Keeper_runtime_resolved.reactive_max_idle_turns ())
+                         ?oas_timeout_s:keeper_msg_oas_timeout_s
+                         ~generation:meta.runtime.generation
+                         ?on_event
+                         ~trajectory_acc
+                         ?event_bus:(Keeper_event_bus.get ())
+                         ()))
             in
             match run_result with
             | Error err ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -336,12 +336,18 @@ let run_keeper_cycle
 
          Uses the OAS Event_bus (ToolCalled + ToolCompleted) rather than
          MASC-side observers. The per-turn subscription is scoped by
-         [filter_agent meta.name], so no cross-keeper contamination. *)
+         [filter_agent meta.name], so no cross-keeper contamination.
+         The same events now drive Streaming⇄Awaiting_tool_result FSM
+         transitions unconditionally (see
+         [Keeper_unified_turn_event_bus.record_fsm_tool_transitions]). *)
                let turn_state =
                  { turn_state with last_execution = Some initial_execution }
                in
                let turn_event_bus_state =
-                 Keeper_unified_turn_event_bus.create ~keeper_name:meta.name ()
+                 Keeper_unified_turn_event_bus.create
+                   ~keeper_name:meta.name
+                   ~turn_id:keeper_turn_id
+                   ()
                in
                (* PR-J: [?site] labels the call-site so metric queries can attribute
          drain pressure to background polling vs unsubscribe vs the
@@ -899,6 +905,10 @@ dominant source of the observed CAS race exhaustion after
                     ~keeper_name:meta.name
                     trajectory_acc
                     Trajectory.Completed;
+                  (* SSOT: success-path terminal FSM transitions
+                     (Streaming -> Completing -> Done) are emitted once inside
+                     [Keeper_unified_turn_success.handle]. Do not duplicate them
+                     here; this is the sole caller of that function. *)
                   let updated_meta =
                     Keeper_unified_turn_success.handle
                       ~config

--- a/lib/keeper/keeper_unified_turn_event_bus.ml
+++ b/lib/keeper/keeper_unified_turn_event_bus.ml
@@ -7,12 +7,14 @@ type event_bus_state =
 
 type t =
   { keeper_name : string
+  ; turn_id : int
   ; event_bus_sub : Agent_sdk_metrics_bridge.handle option
   ; drain_cancel : Eio.Cancel.t option ref
   ; state : event_bus_state Atomic.t
+  ; pending_tool_count : int ref
   }
 
-let create ~keeper_name () =
+let create ~keeper_name ~turn_id () =
   let event_bus_sub =
     match Keeper_event_bus.get () with
     | Some bus ->
@@ -24,6 +26,7 @@ let create ~keeper_name () =
     | None -> None
   in
   { keeper_name
+  ; turn_id
   ; event_bus_sub
   ; drain_cancel = ref None
   ; state =
@@ -31,7 +34,56 @@ let create ~keeper_name () =
         { summary = Keeper_turn_runtime_budget.empty_turn_event_bus_summary
         ; tracker = Keeper_unified_turn_types.create_turn_tool_event_tracker ()
         }
+  ; pending_tool_count = ref 0
   }
+;;
+
+(* Emit Streaming⇄Awaiting_tool_result FSM transitions from OAS Event_bus
+   ToolCalled/ToolCompleted pairs. A pending-tool counter lets the FSM
+   reflect concurrent tool calls (we stay in Awaiting_tool_result until
+   the last pending call completes). The transition is guarded with
+   [Keeper_turn_fsm.assert_transition_allowed] so a late event that
+   arrives after the turn has already moved to a terminal state is
+   ignored rather than raising. *)
+let record_fsm_tool_transitions t events =
+  let safe_emit ~prev state =
+    match
+      Keeper_turn_fsm.assert_transition_allowed
+        ~from_state:prev
+        ~to_state:state
+        ()
+    with
+    | Ok _ ->
+      Keeper_turn_fsm.emit_transition
+        ~keeper_name:t.keeper_name
+        ~turn_id:t.turn_id
+        ~prev
+        state
+    | Error _ -> ()
+  in
+  List.iter
+    (fun (evt : Agent_sdk.Event_bus.event) ->
+       match evt.payload with
+       | Agent_sdk.Event_bus.ToolCalled _ ->
+         let prev = !(t.pending_tool_count) in
+         t.pending_tool_count := prev + 1;
+         if prev = 0
+         then
+           safe_emit
+             ~prev:Keeper_turn_fsm.Streaming
+             Keeper_turn_fsm.Awaiting_tool_result
+       | Agent_sdk.Event_bus.ToolCompleted _ ->
+         let prev = !(t.pending_tool_count) in
+         if prev > 0
+         then (
+           t.pending_tool_count := prev - 1;
+           if prev = 1
+           then
+             safe_emit
+               ~prev:Keeper_turn_fsm.Awaiting_tool_result
+               Keeper_turn_fsm.Streaming)
+       | _ -> ())
+    events
 ;;
 
 let drain ?(site = "unspecified") t =
@@ -45,6 +97,7 @@ let drain ?(site = "unspecified") t =
     Keeper_metrics.(to_string EventBusDrain)
     ~labels:[ "site", site; "outcome", outcome ]
     ();
+  record_fsm_tool_transitions t events;
   let rec update () =
     let old = Atomic.get t.state in
     let new_tracker =

--- a/lib/keeper/keeper_unified_turn_event_bus.mli
+++ b/lib/keeper/keeper_unified_turn_event_bus.mli
@@ -6,7 +6,7 @@
 
 type t
 
-val create : keeper_name:string -> unit -> t
+val create : keeper_name:string -> turn_id:int -> unit -> t
 
 val drain
   :  ?site:string

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -559,6 +559,9 @@ let handle
       runtime = { updated_meta.runtime with last_turn_tool_calls = tool_call_summaries }
     }
   in
+  (* Single source of truth for success-path terminal FSM transitions.
+     [Keeper_unified_turn.handle] is the only caller; do not add another
+     Streaming -> Completing -> Done emitter on the success path. *)
   Keeper_turn_fsm.emit_transition
     ~keeper_name:meta.name
     ~turn_id:keeper_turn_id

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -1,4 +1,9 @@
-(** Success-path post-processing for [Keeper_unified_turn]. *)
+(** Success-path post-processing for [Keeper_unified_turn].
+
+    Emits the terminal FSM transitions [Streaming -> Completing -> Done];
+    this function is the single source of truth for those transitions on the
+    success path and must be called at most once per turn.
+    [Keeper_unified_turn.run_keeper_cycle] is the expected caller. *)
 
 val handle
   :  config:Workspace.config

--- a/lib/task/task_dispatch.ml
+++ b/lib/task/task_dispatch.ml
@@ -139,14 +139,28 @@ let update_status config ~task_id ~status =
                     version = backlog.version + 1;
                   }
                 in
-                Workspace.write_backlog config new_backlog;
+                let clear_stale () =
+                  if Task_cache_invariant.is_terminal status
+                  then
+                    Task_cache_invariant.clear_stale_agent_task_for_task
+                      config
+                      ~task_id
+                      ~status
+                      ~module_name:"task_dispatch.update_status"
+                in
+                Workspace.write_backlog ~after_commit:clear_stale config new_backlog;
                 Ok ()))
 
-(** Delete a task *)
+(** Delete a task.  Also clears any agent [current_task] cache that still
+    points to the deleted task id, so the backlog write and cache
+    invalidation happen in the same locked transaction. *)
 let delete_task config ~task_id =
   match backend () with
   | Jsonl ->
       with_locked_backlog config (fun backlog ->
+        let task_opt =
+          List.find_opt (fun (t : task) -> t.id = task_id) backlog.tasks
+        in
         let new_tasks =
           List.filter (fun (t : task) -> t.id <> task_id) backlog.tasks
         in
@@ -157,5 +171,17 @@ let delete_task config ~task_id =
             version = backlog.version + 1;
           }
         in
-        Workspace.write_backlog config new_backlog;
+        let status_for_clear =
+          match task_opt with
+          | Some t -> t.task_status
+          | None -> Masc_domain.Todo
+        in
+        let clear_stale () =
+          Task_cache_invariant.clear_stale_agent_task_for_task
+            config
+            ~task_id
+            ~status:status_for_clear
+            ~module_name:"task_dispatch.delete_task"
+        in
+        Workspace.write_backlog ~after_commit:clear_stale config new_backlog;
         Ok ())

--- a/lib/task/task_dispatch.mli
+++ b/lib/task/task_dispatch.mli
@@ -112,6 +112,10 @@ val update_status :
     runs {!validate_transition}, and on success rewrites the task
     list with the new status, bumping [version] and refreshing
     [last_updated] (ISO 8601 of the current monotonic time).
+    If [status] is terminal, the commit also clears any agent
+    [current_task] cache still pointing to [task_id] so the backlog
+    write and cache invalidation happen atomically in the same
+    transaction.
     Errors:
     - [TaskNotFound task_id] when the task is absent.
     - [TaskInvalidState <message>] from {!validate_transition}.
@@ -123,6 +127,7 @@ val delete_task :
   (unit, Masc_error.t) result
 (** [delete_task config ~task_id] takes the Workspace [.backlog] file lock,
     filters the task out of the
-    backlog and writes it back with [version] bumped.  Idempotent
+    backlog and writes it back with [version] bumped, then clears any
+    agent [current_task] cache still pointing to [task_id].  Idempotent
     — deleting a non-existent task is silently a no-op (always
     returns [Ok ()] when the backlog is readable). *)

--- a/lib/workspace/task_cache_invariant.ml
+++ b/lib/workspace/task_cache_invariant.ml
@@ -83,6 +83,55 @@ let clear_stale_agent_task
          "task_cache_invariant: log_event failed (%s %s): %s"
          module_name task_id (Printexc.to_string exn))
 
+(** Scan every on-disk agent record and clear [current_task] when it equals
+    [task_id].  Use this when the backlog no longer references the task
+    (terminal status or deletion) and the exact previous assignee is not
+    known.  Logs one [cache_desync.cleared] event per affected agent.
+
+    The read is best-effort and unlocked; [clear_stale_agent_task] re-checks
+    the match under the per-agent file lock before writing, so the worst race
+    is a no-op or a duplicate log rather than a corrupt agent record. *)
+let clear_stale_agent_task_for_task
+      config
+      ~(task_id : string)
+      ~(status : Masc_domain.task_status)
+      ~(module_name : string)
+    : unit =
+  let agents_path = agents_dir config in
+  if path_exists config agents_path
+  then
+    (try
+       let agent_files = Sys.readdir agents_path in
+       Array.iter
+         (fun name ->
+            if Filename.check_suffix name ".json"
+            then (
+              let agent_file = Filename.concat agents_path name in
+              match read_json_opt config agent_file with
+              | None -> ()
+              | Some json -> (
+                  match agent_of_yojson json with
+                  | Ok agent when agent.current_task = Some task_id ->
+                      clear_stale_agent_task config
+                        ~agent_name:agent.name
+                        ~task_id
+                        ~status
+                        ~module_name
+                  | Ok _ | Error _ -> ())))
+         agent_files
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | Sys_error msg ->
+         Log.Misc.warn
+           "task_cache_invariant: agent directory scan failed (%s): %s"
+           module_name
+           msg
+     | exn ->
+         Log.Misc.warn
+           "task_cache_invariant: unexpected scan error (%s): %s"
+           module_name
+           (Printexc.to_string exn))
+
 (** Core invariant wrapper.
 
     [with_fresh_task_status config ~agent_name ~task_id ~module_name f]

--- a/lib/workspace/task_cache_invariant.mli
+++ b/lib/workspace/task_cache_invariant.mli
@@ -32,6 +32,20 @@ val clear_stale_agent_task :
   module_name:string ->
   unit
 
+(** Scan every on-disk agent record and clear [current_task] when it equals
+    [task_id].  Use this when the backlog no longer references the task
+    (terminal status or deletion) and the exact previous assignee is not
+    known.  Logs one [cache_desync.cleared] event per affected agent.
+
+    The read is best-effort and unlocked; {!clear_stale_agent_task}
+    re-checks the match under the per-agent file lock before writing. *)
+val clear_stale_agent_task_for_task :
+  Workspace_utils_backend_setup.config ->
+  task_id:string ->
+  status:Masc_domain.task_status ->
+  module_name:string ->
+  unit
+
 (** Core invariant wrapper.
 
     [with_fresh_task_status config ~agent_name ~task_id ~module_name f]


### PR DESCRIPTION
Depends on OAS PR jeong-sik/oas#2108 (agent_sdk 0.207.0).

This PR steers MASC away from SSOT drift in the turn lifecycle and related subsystems:

### Turn FSM / SSOT
- Document the single-source-of-truth contract for success-path terminal FSM transitions (Streaming -> Completing -> Done).
- Preserve cancellation terminal state through safe_emit_turn_end instead of recording it as completed.
- Wrap direct masc_keeper_msg turns so they emit the same typed FSM transitions as autonomous turns.
- Observe OAS ToolCalled/ToolCompleted events to emit Streaming <-> Awaiting_tool_result unconditionally, removing the previous yield_on_tool gating.

### Registry / state channels
- Route turn-phase mutations through a shared set_turn_phase_with helper so composite broadcasts and FSM-guard metrics behave consistently across all setter paths.

### Task dispatch
- Clear stale agent current_task mappings when a task becomes terminal or is deleted, keeping backlog SSOT and per-agent caches aligned.

### SSE / snapshot contract
- Strengthen producer/consumer comments and add a dashboard regression test confirming keeper_composite_changed is signal-only; authoritative read model remains /api/v1/keepers/:name/composite.

### Dependency
- Bump agent_sdk floor to 0.207.0 and add the new phase field required by Agent_sdk.Error.Api Timeout.

### Verification
- dune build lib/masc.cmxa: OK
- test/test_keeper_turn_fsm_wired_sites.exe: OK (2 tests, including duplicate-emission regression guard)

---

## 🔄 AS-IS vs TO-BE 구조적 개선점 분석 (Structural Improvements)

```mermaid
flowchart TD
    subgraph AS_IS ["AS-IS: 분산된 상태 업데이트 및 SSOT drift 발생"]
        direction TB
        A1[Turn Lifecycle<br/>직접적인 FSM 변경] -->|불일치 위험| A2[Registry / State Channels<br/>분산된 상태 모니터링]
        A3[Task Dispatch<br/>더미/과거 데이터 유지] --> A4[Cache Inconsistency<br/>상태 불일치]
    end

    subgraph TO_BE ["TO-BE: 통합 상태 관리 및 정책 강화"]
        direction TB
        B1[Turn Lifecycle<br/>set_turn_phase_with 사용<br/>Tool Events 자동 전이] -->|일관성| B2[Registry / State Channels<br/>통합된 상태 관리 및 메트릭]
        B3[Task Dispatch<br/>Terminated/Deleted 시 정책 적용] --> B4[Aligned Caches<br/>일치된 상태 유지]
    end

    AS_IS -->|Changes| TO_BE
```


| 기술 카테고리 | AS-IS (변경 전) | TO-BE (변경 후) | 이점 및 근거 |
| :--- | :--- | :--- | :--- |
| **아키텍처 및 데이터 일관성 (SSOT)** | 상태 변경이 여러 경로에서 직접 발생하며, 레지스트리, 태스크 디스패치, 컴포지트 신호 간 데이터 동기화(SSOT)가 유지되지 않아 'Drift' 현상이 발생할 가능성이 높음. | `set_turn_phase_with` 헬퍼 함수를 통해 모든 태스크-페이즈 변경이 중앙화 처리됨. 레지스트리와 디스패치 시스템 간의 상태 전이가 일관되게 전파됨. | **데이터 신뢰성 확보:** 다중 경로로 인한 데이터 불일치를 방지하여 시스템 전반의 데이터 무결성 보장. |
| **터튼 생애주기 및 FSM (State Machine)** | 성공 경로(Streaming -> Completing -> Done) 계약이 명확하지 않음. 툴 호출(`yield_on_tool`)에 따라 이벤트 전달이 조건부로 제어됨. 취소 상태 처리가 불명확함. | 툴 호출 이벤트(ToolCalled/ToolCompleted)가 조건 없이 상태 전이를 트리거하도록 변경. 취소 상태를 '완료된 상태'가 아닌 안전
