### PR TITLE
feat(dashboard): apply keeper-v2 work surface

### DIFF
--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { cleanup, render, screen } from '@testing-library/preact'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import '@testing-library/jest-dom'
 
 const routeSignal = signal({
@@ -10,12 +10,17 @@ const routeSignal = signal({
   postId: null,
 })
 
+const navigateMock = vi.hoisted(() => vi.fn())
+
 vi.mock('../router', () => ({
   get route() { return routeSignal },
+  navigate: navigateMock,
 }))
 
-vi.mock('./board/board-surface', () => ({
-  BoardSurface: () => html`<div data-testid="board-surface">Board</div>`,
+vi.mock('../store', () => ({
+  goals: signal([]),
+  tasks: signal([]),
+  keepers: signal([]),
 }))
 
 vi.mock('./board/board-moderation-surface', () => ({
@@ -38,10 +43,20 @@ vi.mock('./repository-management', () => ({
   RepositoryManagement: () => html`<div data-testid="repository-panel">Repositories</div>`,
 }))
 
+import { goals, keepers, tasks } from '../store'
 import { Work } from './work'
 
 describe('Work', () => {
-  afterEach(() => cleanup())
+  afterEach(() => {
+    cleanup()
+    navigateMock.mockClear()
+  })
+
+  beforeEach(() => {
+    goals.value = []
+    tasks.value = []
+    keepers.value = []
+  })
 
   it('renders the SubBoard surface for the workspace sub-boards section', () => {
     routeSignal.value = {
@@ -53,7 +68,7 @@ describe('Work', () => {
     render(html`<${Work} />`)
 
     expect(screen.getByTestId('sub-board-surface')).toBeTruthy()
-    expect(screen.queryByTestId('board-surface')).toBeNull()
+    expect(screen.queryByTestId('work-kpis')).toBeNull()
   })
 
   it('renders the board moderation surface for the workspace moderation section', () => {
@@ -66,10 +81,10 @@ describe('Work', () => {
     render(html`<${Work} />`)
 
     expect(screen.getByTestId('board-moderation-surface')).toBeTruthy()
-    expect(screen.queryByTestId('board-surface')).toBeNull()
+    expect(screen.queryByTestId('work-kpis')).toBeNull()
   })
 
-  it('falls back to the board surface for unknown workspace sections', () => {
+  it('falls back to the v2 work surface for unknown workspace sections', () => {
     routeSignal.value = {
       tab: 'workspace',
       params: { section: 'unknown' },
@@ -78,6 +93,108 @@ describe('Work', () => {
 
     render(html`<${Work} />`)
 
-    expect(screen.getByTestId('board-surface')).toBeTruthy()
+    expect(screen.getByTestId('work-kpis')).toBeTruthy()
+  })
+
+  describe('v2 work surface', () => {
+    it('renders KPI counts from goals and tasks', () => {
+      goals.value = [
+        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-2', horizon: 'mid', title: 'Goal Two', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+      ]
+      tasks.value = [
+        { id: 'J-1', title: 'Job one', goal_id: 'G-1', status: 'done' },
+        { id: 'J-2', title: 'Job two', goal_id: 'G-1', status: 'in_progress' },
+        { id: 'J-3', title: 'Job three', goal_id: 'G-2', status: 'cancelled' },
+      ]
+
+      render(html`<${Work} />`)
+
+      expect(screen.getByTestId('kpi-goals').textContent).toBe('2')
+      expect(screen.getByTestId('kpi-jobs').textContent).toBe('3')
+      expect(screen.getByTestId('kpi-done').textContent).toBe('1')
+      expect(screen.getByTestId('kpi-blocked').textContent).toBe('1')
+    })
+
+    it('renders a collapsed goal card per goal and expands on click', () => {
+      goals.value = [
+        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+      ]
+      tasks.value = [
+        { id: 'J-1', title: 'Job one', goal_id: 'G-1', status: 'todo' },
+      ]
+
+      render(html`<${Work} />`)
+
+      const card = screen.getByTestId('goal-card')
+      expect(card).toBeTruthy()
+      expect(screen.queryByTestId('job-row')).toBeNull()
+
+      fireEvent.click(card.querySelector('.wk-goal-h')!)
+
+      expect(screen.getByTestId('job-row')).toBeTruthy()
+      expect(screen.getByText('Job one')).toBeTruthy()
+    })
+
+    it('renders job rows with state, id, title, and blocker note', () => {
+      goals.value = [
+        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+      ]
+      tasks.value = [
+        { id: 'J-1', title: 'Blocked job', goal_id: 'G-1', status: 'cancelled', handoff_context: { summary: '', reason: 'dependency missing' } },
+      ]
+
+      const { container } = render(html`<${Work} />`)
+
+      // Cancelled tasks make this goal auto-expand and add the has-block border.
+      const card = container.querySelector('[data-goal-id="G-1"]')
+      expect(card).toBeTruthy()
+      expect(card?.querySelector('.wk-jobs')).toBeTruthy()
+
+      const row = screen.getByTestId('job-row')
+      expect(row).toBeTruthy()
+      expect(screen.getByText('Blocked job')).toBeTruthy()
+      expect(screen.getByTestId('job-blocker').textContent).toContain('dependency missing')
+    })
+
+    it('navigates to keeper workspace when keeper assignment is clicked', () => {
+      goals.value = [
+        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+      ]
+      tasks.value = [
+        { id: 'J-1', title: 'Assigned job', goal_id: 'G-1', status: 'in_progress', assignee: 'sangsu' },
+      ]
+      keepers.value = [
+        { name: 'sangsu', status: 'idle' },
+      ]
+
+      render(html`<${Work} />`)
+
+      fireEvent.click(screen.getByTestId('goal-card').querySelector('.wk-goal-h')!)
+
+      const keeperButton = screen.getByTestId('job-keeper')
+      expect(keeperButton).toBeTruthy()
+      fireEvent.click(keeperButton)
+
+      expect(navigateMock).toHaveBeenCalledWith('monitoring', { section: 'agents', view: 'keepers', keeper: 'sangsu' })
+    })
+
+    it('auto-expands high-priority goals and goals with blocked jobs', () => {
+      goals.value = [
+        { id: 'G-1', horizon: 'short', title: 'Normal goal', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-2', horizon: 'mid', title: 'High goal', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-3', horizon: 'long', title: 'Blocked goal', priority: 3, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+      ]
+      tasks.value = [
+        { id: 'J-1', title: 'Blocked job', goal_id: 'G-3', status: 'cancelled' },
+      ]
+
+      const { container } = render(html`<${Work} />`)
+
+      // G-2 (high priority) and G-3 (blocked) should be expanded; G-1 should be collapsed.
+      expect(container.querySelector('[data-goal-id="G-1"]')?.querySelector('.wk-jobs')).toBeNull()
+      expect(container.querySelector('[data-goal-id="G-2"]')?.querySelector('.wk-jobs')).toBeTruthy()
+      expect(container.querySelector('[data-goal-id="G-3"]')?.querySelector('.wk-jobs')).toBeTruthy()
+    })
   })
 })

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -1,16 +1,19 @@
-// MASC Dashboard — Work Tab (Phase 7: planning with goal-tree sub-view)
-// board + planning + verification.
+// MASC Dashboard — Work Tab (keeper-v2 goal/job layout)
+// Surface: KPI header + collapsible goal cards + segmented progress + job rows.
 
 import { html } from 'htm/preact'
 import { lazy, Suspense } from 'preact/compat'
-import { route } from '../router'
-import { BoardSurface } from './board/board-surface'
+import { useMemo, useState } from 'preact/hooks'
+import { route, navigate } from '../router'
+import { goals, tasks, keepers } from '../store'
 import { BoardModerationSurface } from './board/board-moderation-surface'
 import { SubBoardSurface } from './board/sub-board-surface'
 import { PlanningPanel } from './planning-panel'
 import { VerificationRequestsPanel } from './verification-requests-panel'
 import { ErrorBoundary } from './common/error-boundary'
 import { LoadingState } from './common/feedback-state'
+import { KeeperBadge } from './keeper-badge'
+import type { Goal, Task, Keeper } from '../types'
 
 type WorkSection = 'board' | 'sub-boards' | 'moderation' | 'planning' | 'repositories' | 'verification'
 
@@ -22,6 +25,312 @@ function isWorkSection(v: string | undefined): v is WorkSection {
   return v === 'board' || v === 'sub-boards' || v === 'moderation' || v === 'planning' || v === 'repositories' || v === 'verification'
 }
 
+// ── Job state mapping ───────────────────────────────────────────────────────
+
+type JobStateKey = 'done' | 'wip' | 'review' | 'blocked' | 'todo'
+
+interface JobState {
+  label: string
+  cls: JobStateKey
+}
+
+const JOB_STATE: Record<JobStateKey, JobState> = {
+  done: { label: '완료', cls: 'done' },
+  wip: { label: '진행 중', cls: 'wip' },
+  review: { label: '리뷰', cls: 'review' },
+  blocked: { label: '막힘', cls: 'blocked' },
+  todo: { label: '대기', cls: 'todo' },
+}
+
+function jobStateForTask(task: Task): JobState {
+  switch (task.status) {
+    case 'done': return JOB_STATE.done
+    case 'in_progress':
+    case 'claimed': return JOB_STATE.wip
+    case 'awaiting_verification': return JOB_STATE.review
+    case 'cancelled': return JOB_STATE.blocked
+    case 'todo':
+    default: return JOB_STATE.todo
+  }
+}
+
+function blockerNoteForTask(task: Task): string | null {
+  if (task.status === 'cancelled') {
+    return task.handoff_context?.reason
+      ?? task.handoff_context?.failure_mode
+      ?? 'cancelled'
+  }
+  if (task.status === 'awaiting_verification') {
+    return task.handoff_context?.reason ?? '검증 대기'
+  }
+  return task.handoff_context?.failure_mode ?? null
+}
+
+// ── Priority mapping ────────────────────────────────────────────────────────
+
+interface PriorityState {
+  label: string
+  cls: 'high' | 'normal' | 'low'
+}
+
+const HIGH_PRIORITY: PriorityState = { label: '높음', cls: 'high' }
+const NORMAL_PRIORITY: PriorityState = { label: '보통', cls: 'normal' }
+const LOW_PRIORITY: PriorityState = { label: '낮음', cls: 'low' }
+
+function priorityStateForGoal(goal: Goal): PriorityState {
+  if (goal.priority === 1) return HIGH_PRIORITY
+  if (goal.priority === 2) return NORMAL_PRIORITY
+  return LOW_PRIORITY
+}
+
+// ── Keeper lookup ───────────────────────────────────────────────────────────
+
+function keeperByName(name: string | null | undefined): Keeper | undefined {
+  if (!name) return undefined
+  return keepers.value.find(k => k.name === name)
+}
+
+function leadKeeperForGoal(goal: Goal): Keeper | undefined {
+  // Prefer a keeper that lists this goal as active.
+  const active = keepers.value.find(k => k.active_goal_ids?.includes(goal.id))
+  if (active) return active
+
+  // Fall back to the most frequent task assignee for this goal.
+  const goalTasks = tasks.value.filter(t => t.goal_id === goal.id)
+  const counts = new Map<string, number>()
+  for (const t of goalTasks) {
+    if (t.assignee) counts.set(t.assignee, (counts.get(t.assignee) ?? 0) + 1)
+  }
+  let topName: string | undefined
+  let topCount = 0
+  for (const [name, count] of counts) {
+    if (count > topCount) {
+      topName = name
+      topCount = count
+    }
+  }
+  return topName ? keeperByName(topName) : undefined
+}
+
+function openKeeperWorkspace(name: string): void {
+  navigate('monitoring', { section: 'agents', view: 'keepers', keeper: name })
+}
+
+// ── Progress aggregation ────────────────────────────────────────────────────
+
+interface GoalProgressCounts {
+  done: number
+  wip: number
+  blocked: number
+  total: number
+}
+
+function goalProgressCounts(goal: Goal): GoalProgressCounts {
+  const goalTasks = tasks.value.filter(t => t.goal_id === goal.id)
+  const counts: GoalProgressCounts = { done: 0, wip: 0, blocked: 0, total: goalTasks.length }
+  for (const t of goalTasks) {
+    const state = jobStateForTask(t).cls
+    if (state === 'done') counts.done++
+    else if (state === 'blocked') counts.blocked++
+    else if (state === 'wip' || state === 'review') counts.wip++
+  }
+  return counts
+}
+
+function workspaceNamespace(): string {
+  return 'masc-mcp'
+}
+
+// ── Sub-components ──────────────────────────────────────────────────────────
+
+function GoalProgressBar({ counts }: { counts: GoalProgressCounts }) {
+  const n = Math.max(counts.total, 1)
+  const pct = (x: number) => (x / n) * 100
+  return html`
+    <div class="wk-prog" aria-hidden="true">
+      ${counts.done > 0 ? html`<span class="wk-seg done" style=${{ width: `${pct(counts.done)}%` }}></span>` : null}
+      ${counts.wip > 0 ? html`<span class="wk-seg wip" style=${{ width: `${pct(counts.wip)}%` }}></span>` : null}
+      ${counts.blocked > 0 ? html`<span class="wk-seg blocked" style=${{ width: `${pct(counts.blocked)}%` }}></span>` : null}
+    </div>
+  `
+}
+
+function JobRow({ task }: { task: Task }) {
+  const state = jobStateForTask(task)
+  const keeper = keeperByName(task.assignee)
+  const blocker = blockerNoteForTask(task)
+
+  return html`
+    <div class=${`wk-job ${state.cls}`} data-testid="job-row" data-job-id=${task.id}>
+      <span class=${`wk-job-dot ${state.cls}`} aria-hidden="true"></span>
+      <span class="wk-job-id mono">${task.id}</span>
+      <span class="wk-job-title">
+        ${task.title}
+        ${blocker ? html`<span class="wk-job-block" data-testid="job-blocker">⚠ ${blocker}</span>` : null}
+      </span>
+      <span class="wk-spacer"></span>
+      <span class=${`wk-job-state ${state.cls}`}>${state.label}</span>
+      ${keeper
+        ? html`
+          <button
+            type="button"
+            class="wk-job-kp"
+            data-testid="job-keeper"
+            onClick=${() => openKeeperWorkspace(keeper.name)}
+            title=${`${keeper.name} 대화 열기`}
+          >
+            <${KeeperBadge} id=${keeper.name} size="sm" variant="sigil" />
+            <span class="mono">${keeper.name}</span>
+          </button>
+        `
+        : html`<span class="wk-job-kp none mono">미배정</span>`}
+    </div>
+  `
+}
+
+function GoalCard({
+  goal,
+  open,
+  onToggle,
+}: {
+  goal: Goal
+  open: boolean
+  onToggle: () => void
+}) {
+  const progress = goalProgressCounts(goal)
+  const lead = leadKeeperForGoal(goal)
+  const priority = priorityStateForGoal(goal)
+  const goalTasks = tasks.value.filter(t => t.goal_id === goal.id)
+  const hasBlock = progress.blocked > 0
+
+  return html`
+    <div class=${`wk-goal ${open ? 'open' : ''} ${hasBlock ? 'has-block' : ''}`} data-testid="goal-card" data-goal-id=${goal.id}>
+      <button type="button" class="wk-goal-h" onClick=${onToggle} aria-expanded=${open}>
+        <span class="wk-caret" aria-hidden="true">${open ? '\u25BE' : '\u25B8'}</span>
+        <span class=${`wk-pri ${priority.cls}`}>${priority.label}</span>
+        <span class="wk-goal-id mono">${goal.id}</span>
+        <span class="wk-goal-title">${goal.title}</span>
+        <span class="wk-goal-ns mono">${goal.horizon}</span>
+        <span class="wk-spacer"></span>
+        ${goal.due_date ? html`<span class="wk-due mono">${goal.due_date}</span>` : null}
+        ${lead ? html`
+          <span class="wk-lead" title=${`리드 · ${lead.name}`}>
+            <${KeeperBadge} id=${lead.name} size="md" variant="sigil" />
+          </span>
+        ` : null}
+      </button>
+      <div class="wk-goal-sub">
+        <${GoalProgressBar} counts=${progress} />
+        <span class="wk-prog-lbl mono">
+          ${progress.done}/${progress.total}${progress.blocked > 0 ? ` · 막힘 ${progress.blocked}` : ''}
+        </span>
+        ${goal.metric ? html`<span class="wk-metric mono" title="목표 지표">${goal.metric}</span>` : null}
+      </div>
+      ${open ? html`
+        <div class="wk-jobs">
+          ${goal.last_review_note ? html`<div class="wk-note">${goal.last_review_note}</div>` : null}
+          ${goalTasks.map(task => html`<${JobRow} key=${task.id} task=${task} />`)}
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
+function WorkSurfaceV2() {
+  const goalList = goals.value
+  const allTasks = tasks.value
+
+  const [openSet, setOpenSet] = useState<Set<string>>(() => {
+    const initial = new Set<string>()
+    for (const g of goalList) {
+      const progress = goalProgressCounts(g)
+      if (g.priority === 1 || progress.blocked > 0) initial.add(g.id)
+    }
+    return initial
+  })
+
+  const toggleGoal = (id: string) => {
+    setOpenSet(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const totals = useMemo(() => {
+    let totalJobs = 0
+    let doneJobs = 0
+    let blockedJobs = 0
+    for (const g of goalList) {
+      const p = goalProgressCounts(g)
+      totalJobs += p.total
+      doneJobs += p.done
+      blockedJobs += p.blocked
+    }
+    return {
+      goals: goalList.length,
+      jobs: totalJobs,
+      done: doneJobs,
+      blocked: blockedJobs,
+    }
+  }, [goalList, allTasks])
+
+  return html`
+    <main class="wk-surface">
+      <div class="wk-scroll">
+        <div class="wk-inner">
+          <header class="wk-head">
+            <div>
+              <h1>작업 · 목표</h1>
+              <p class="wk-sub">
+                <span title="최상위 조정 범위">namespace <span class="mono">${workspaceNamespace()}</span></span>
+                · <span>목표 ${totals.goals}</span>
+                · <span>job ${totals.jobs}</span>
+                · <span>완료 ${totals.done}</span>
+                ${totals.blocked > 0 ? html`<span> · <span class="wk-blk-n">막힘 ${totals.blocked}</span></span>` : null}
+              </p>
+            </div>
+            <button type="button" class="wk-newgoal" title="새 목표 생성 — 다음 단계에서 설계">＋ 새 목표</button>
+          </header>
+
+          <section class="wk-kpis" data-testid="work-kpis">
+            <div class="wk-kpi">
+              <div class="wk-kpi-k">활성 목표</div>
+              <div class="wk-kpi-v volt" data-testid="kpi-goals">${totals.goals}</div>
+            </div>
+            <div class="wk-kpi">
+              <div class="wk-kpi-k">전체 job</div>
+              <div class="wk-kpi-v" data-testid="kpi-jobs">${totals.jobs}</div>
+            </div>
+            <div class="wk-kpi">
+              <div class="wk-kpi-k">완료</div>
+              <div class=${`wk-kpi-v ${totals.done > 0 ? 'ok' : ''}`} data-testid="kpi-done">${totals.done}</div>
+            </div>
+            <div class="wk-kpi">
+              <div class="wk-kpi-k">막힘</div>
+              <div class=${`wk-kpi-v ${totals.blocked > 0 ? 'bad' : ''}`} data-testid="kpi-blocked">${totals.blocked}</div>
+            </div>
+          </section>
+
+          <div class="wk-list">
+            ${goalList.map(g => html`
+              <${GoalCard}
+                key=${g.id}
+                goal=${g}
+                open=${openSet.has(g.id)}
+                onToggle=${() => toggleGoal(g.id)}
+              />
+            `)}
+          </div>
+
+          <div class="wk-foot mono">Goal → job → keeper · job 의 keeper 를 누른면 해당 keeper 대화로 이동</div>
+        </div>
+      </div>
+    </main>
+  `
+}
+
 export function Work() {
   const current: WorkSection = isWorkSection(route.value.params.section)
     ? route.value.params.section
@@ -31,7 +340,7 @@ export function Work() {
     <div class="v2-workspace-surface flex min-w-0 flex-col gap-3">
       <div class="min-w-0 transition-opacity duration-[var(--t-slow)]">
         <${ErrorBoundary} label=${current}>
-          ${current === 'board' ? html`<${BoardSurface} />`
+          ${current === 'board' ? html`<${WorkSurfaceV2} />`
             : current === 'sub-boards' ? html`<${SubBoardSurface} />`
             : current === 'moderation' ? html`<${BoardModerationSurface} />`
             : current === 'planning' ? html`<${PlanningPanel} />`
@@ -42,7 +351,7 @@ export function Work() {
             `
             : html`<${VerificationRequestsPanel} />`
           }
-        </>
+        <//>
       </div>
     </div>
   `

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -44,6 +44,7 @@ import './styles/copilot-dock.css'
 import './styles/memory-v2.css'
 import './styles/keeper-turn-inspector.css'
 import './styles/ide-v2.css'
+import './styles/work-v2.css'
 
 import { render } from 'preact'
 import { html } from 'htm/preact'

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -1,0 +1,411 @@
+/* MASC Dashboard — Work surface v2 (keeper-v2 goal/job layout).
+ *
+ * Ported from keeper-v2/styles/v2.css .wk-* rules. The design's raw
+ * palette vars (--bg-deep, --volt, --text-mid …) are bridged through
+ * variables.css aliases so the layout inherits dashboard theme changes.
+ */
+
+/* ── Surface shell ────────────────────────────────────────────────────────── */
+.wk-surface {
+  /* Work-v2 surface token bridge — scoped so the v2 skin tokens do not
+     clobber dashboard-wide semantic tokens in :root. */
+  --bg-panel: var(--color-bg-panel-alt);
+  --border-highlight: var(--border-strong);
+  --text-dim: var(--text-muted);
+  --pad-surface: 18px;
+  --pad-card: 14px;
+  --gap-card: 12px;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-pill: 999px;
+  --font-display: ui-sans-serif, -apple-system, system-ui, sans-serif;
+  --font-ui: ui-sans-serif, -apple-system, system-ui, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: var(--bg-deep);
+}
+
+.wk-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--pad-surface, 18px);
+}
+
+.wk-inner {
+  max-width: 1280px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.wk-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.wk-head h1 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 22px;
+  color: var(--text-bright);
+  margin: 0;
+}
+
+.wk-sub {
+  margin-top: 5px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.wk-sub .mono {
+  color: var(--text-mid);
+}
+
+.wk-blk-n {
+  color: var(--status-bad);
+}
+
+/* ── KPI strip ────────────────────────────────────────────────────────────── */
+.wk-kpis {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--border-soft);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.wk-kpi {
+  background: var(--bg-panel);
+  padding: 13px 15px;
+}
+
+.wk-kpi-k {
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.wk-kpi-v {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 23px;
+  color: var(--text-bright);
+  margin-top: 5px;
+}
+
+.wk-kpi-v.ok { color: var(--status-ok); }
+.wk-kpi-v.bad { color: var(--status-bad); }
+.wk-kpi-v.warn { color: var(--status-warn); }
+.wk-kpi-v.volt { color: var(--volt-strong); }
+
+/* ── Goal list ────────────────────────────────────────────────────────────── */
+.wk-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.wk-goal {
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.wk-goal.has-block {
+  border-color: color-mix(in oklab, var(--status-bad) 32%, var(--border-main));
+}
+
+.wk-goal-h {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 13px 15px 11px;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+}
+
+.wk-goal-h:hover {
+  background: color-mix(in oklab, var(--volt) 3%, transparent);
+}
+
+.wk-caret {
+  flex: none;
+  color: var(--text-dim);
+  font-size: 11px;
+  width: 12px;
+}
+
+.wk-pri {
+  flex: none;
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-soft);
+  color: var(--text-dim);
+}
+
+.wk-pri.high {
+  color: var(--status-bad);
+  border-color: color-mix(in oklab, var(--status-bad) 40%, transparent);
+  background: color-mix(in oklab, var(--status-bad) 10%, transparent);
+}
+
+.wk-pri.normal {
+  color: var(--volt-strong);
+  border-color: color-mix(in oklab, var(--volt) 32%, transparent);
+}
+
+.wk-pri.low {
+  color: var(--text-dim);
+}
+
+.wk-goal-id {
+  flex: none;
+  font-size: 11.5px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+
+.wk-goal-title {
+  font-family: var(--font-ui);
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.wk-goal-ns {
+  flex: none;
+  font-size: 11px;
+  color: var(--text-mid);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-soft);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-mono);
+}
+
+.wk-spacer {
+  flex: 1;
+}
+
+.wk-due {
+  flex: none;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+
+.wk-lead {
+  flex: none;
+  display: inline-flex;
+}
+
+.wk-goal-sub {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 0 15px 13px 37px;
+}
+
+/* ── Segmented progress bar ───────────────────────────────────────────────── */
+.wk-prog {
+  flex: none;
+  width: 300px;
+  max-width: 42%;
+  height: 6px;
+  display: flex;
+  gap: 1.5px;
+  background: var(--bg-sunken);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+
+.wk-seg {
+  height: 100%;
+}
+
+.wk-seg.done { background: var(--status-ok); }
+.wk-seg.wip { background: var(--volt); }
+.wk-seg.blocked { background: var(--status-bad); }
+
+.wk-prog-lbl {
+  flex: none;
+  font-size: 11px;
+  color: var(--text-mid);
+  font-family: var(--font-mono);
+}
+
+.wk-metric {
+  margin-left: auto;
+  flex: none;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+
+/* ── Job list ─────────────────────────────────────────────────────────────── */
+.wk-jobs {
+  border-top: 1px solid var(--border-soft);
+  padding: 10px 15px 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.wk-note {
+  font-size: 12px;
+  color: var(--text-mid);
+  line-height: 1.5;
+  padding: 2px 0 9px;
+  border-bottom: 1px dashed var(--border-soft);
+  margin-bottom: 7px;
+}
+
+.wk-job {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 8px;
+  border-radius: var(--radius-xs);
+}
+
+.wk-job:hover {
+  background: var(--bg-sunken);
+}
+
+.wk-job-dot {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-dim);
+}
+
+.wk-job-dot.done { background: var(--status-ok); }
+.wk-job-dot.wip { background: var(--volt); }
+.wk-job-dot.review { background: var(--status-warn); }
+.wk-job-dot.blocked { background: var(--status-bad); }
+
+.wk-job-id {
+  flex: none;
+  font-size: 11px;
+  color: var(--text-dim);
+  min-width: 52px;
+  font-family: var(--font-mono);
+}
+
+.wk-job-title {
+  font-size: 13px;
+  color: var(--text-primary);
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.wk-job.done .wk-job-title {
+  color: var(--text-mid);
+}
+
+.wk-job-block {
+  font-size: 11px;
+  color: var(--status-bad);
+}
+
+.wk-job-state {
+  flex: none;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+}
+
+.wk-job-state.done { color: var(--status-ok); }
+.wk-job-state.wip { color: var(--volt-strong); }
+.wk-job-state.review { color: var(--status-warn); }
+.wk-job-state.blocked { color: var(--status-bad); }
+
+.wk-job-kp {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  min-width: 130px;
+  padding: 3px 6px;
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  background: none;
+  cursor: pointer;
+  color: var(--text-mid);
+  font-size: 11.5px;
+  white-space: nowrap;
+  transition: border-color 0.15s ease, color 0.15s ease;
+  font: inherit;
+}
+
+.wk-job-kp:hover {
+  border-color: var(--border-highlight);
+  color: var(--text-bright);
+}
+
+.wk-job-kp.none {
+  color: var(--text-dim);
+  cursor: default;
+}
+
+/* ── Footer / new goal button ─────────────────────────────────────────────── */
+.wk-newgoal {
+  width: auto;
+  margin: 0;
+  flex: none;
+  align-self: center;
+  white-space: nowrap;
+}
+
+.wk-foot {
+  margin: 16px 2px 4px;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .wk-kpis {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .wk-goal-h {
+    flex-wrap: wrap;
+  }
+
+  .wk-goal-sub {
+    flex-wrap: wrap;
+  }
+
+  .wk-prog {
+    width: 100%;
+    max-width: none;
+  }
+}


### PR DESCRIPTION
## Summary
Refreshes the MASC dashboard Work surface with the keeper-v2 goal/job layout.

## What changed
- Updated `dashboard/src/components/work.ts`:
  - KPI header strip (active goals, total jobs, done, blocked)
  - Collapsible goal cards with priority badge, id, title, horizon/namespace, due date, lead-keeper sigil
  - Segmented progress bar per goal (done / wip / blocked)
  - Expandable job rows with state dot, id, title, blocker note, state label, assigned keeper button
  - Auto-expansion for high-priority goals and goals with blocked jobs
  - Existing store data model preserved; task statuses mapped to v2 job states
- **New styles** `dashboard/src/styles/work-v2.css` using dashboard tokens.
- **Token bridge** aliases extended in `variables.css`.
- **Wiring** — imported `work-v2.css` in `main.ts`.
- **Tests** `dashboard/src/components/work.test.ts` updated — 8/8 pass.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `work.test.ts` ✅ 8/8
- `keeper-badge.test.ts` + `dashboard-shell.test.ts` sanity ✅ 38/38

## Notes
- No backend or type changes.
- Keeper assignment click navigates to the keeper workspace using existing routing.


---

## 🔄 AS-IS vs TO-BE 구조적 개선점 분석 (Structural Improvements)

```mermaid
graph TD
    subgraph AS-IS
        A[work.ts] --> B[목표/작업 표면 UI]
        B --> C[기존 스타일링]
        C --> D[variables.css 토큰]
        E[main.ts] --> F[기본 CSS import]
    end

    subgraph TO-BE
        B --> G[KPI 헤더 스트립]
        B --> H[접을 수 있는 목표 카드]
        H --> I[우선순위 배지/상태 표시]
        B --> J[확장 가능한 작업 행]
        J --> K[차단된 작업 노트]
        H --> L[자동 확장 로직]
        M[work-v2.css] --> H
        M --> J
        E --> N[work-v2.css import]
        O[확장된 토큰 별칭] --> M
    end

    P[Store 데이터] -->|동일한 데이터 모델| B
    B -->|작업 상태 매핑| Q[v2 작업 상태]
```

### AS-IS vs TO-BE 비교 매트릭스

| 카테고리 | AS-IS (PR 전) | TO-BE (PR 후) | 이점/사유 |
|---------|--------------|---------------|-----------|
| **UI/UX 구조** | 단일 수준의 목표/작업 표면 | 계층적 UI (KPI 헤더 → 목표 카드 → 작업 행) | 정보 계층화로 핵심 KPI 즉시 노출, 사용자 인지적 부하 감소 |
| **컴포넌트 로직** | 모든 목표/작업 기본 표시 | 고우선순위/차단된 목표 자동 확장 | 중요 정보 프리로딩, 클릭 횟수 최소화 |
| **스타일링 시스템** | 기존 CSS 변수 사용 | 전용 `work-v2.css` + 대시보드 토큰 통합 | 디자인 시스템 일관성 강화, 테마 변경 용이성 |
| **데이터 처리** | 기존 작업 상태 유지 | v2 작업 상태로 매핑 (상태→상태 점 변환) | v2 작업 상태 시스템 전환 without 레거시 코드 |
| **성능** | 초기 모든 요소 렌더링 | 차단된 요소만 자동 확장, 기본 접힘 상태 | 불필요한 DOM 렌더링 감소, 초기 로딩 성능 향상 |
| **테스팅** | 기존 테스트 수준 | 신규 UI 요소 테스트 통과 (8/8) | 신규 기능 안정성 보장, 리팩터링 리스크 최소화 |
| **모듈성** | 단일 컴포넌트 집중 | 분리된 스타일링 모듈(`work-v2.css`) | 유지보수성 향상, 재사용성 증대 |
| **기능적 안정성** | 기존 데이터 모덌 의존 | 저장소 데이터 모델 변경 없음 | 백엔드/타입 변경 리스크 제로 |
