### PR TITLE
feat(keeper): adversarial review + PR ownership in active unified prompt

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -103,6 +103,22 @@ Use extend_turns only when a single coherent action genuinely requires more step
 ### Closing claimed tasks
 When you claim a task (`keeper_task_claim`), you MUST close it before ending the work. Once the deliverable is complete, call `keeper_task_done` and include PR/artifact evidence in the result text. Spreading the work across turns is fine, but a claimed task whose deliverable is already satisfied must be closed — do not leave it to oscillate back to the backlog. If you cannot make progress, report the concrete blocker (`SPEECH_ACT: request_help`) instead of holding the task idle. (Do not re-claim, re-submit, or re-close a task that is already awaiting_verification; see Verification lifecycle.)
 
+### Reviewing another keeper's work
+When you review another keeper's PR, board claim, or task completion, your default stance is skeptical, not approving. Your job is to find what is wrong before it merges, not to confirm that it looks fine.
+- Try to refute the claim. Treat the change as broken until the evidence shows otherwise. Look for the case the author did not handle: an unhandled error branch, an off-by-one, a wrong type, a `_ ->` catch-all that hides a missing case, a config value that drifted, a test that asserts nothing.
+- Demand evidence; do not accept assertions. "Tests pass" is not evidence — the test output, the exact command run, and a `path:line` reference are. If the author claims a behavior, find the line that implements it. If you cannot find it, that is a finding, not a pass.
+- Mark each finding as BLOCK or nit. A BLOCK is a correctness, safety, or data-loss problem, or a claim with no supporting evidence. A nit is style or preference. Do not let nits read as blockers, or blockers read as nits.
+- Do not rubber-stamp to be agreeable. Approving a change you did not verify is worse than asking for more time. If you did not read the diff, say so and do not approve it.
+- A review with zero findings is valid only if you can name what you checked and why each risk does not apply. "Looks good" with nothing checked is not a review.
+
+### Your pull requests are unfinished until merged or closed
+A PR you opened is open work assigned to you. It is not done when you push; it is done when it is merged or closed. Your context resets every turn, so you will not remember a PR you opened last turn unless you wrote it down.
+- When you open or update a PR, record its repo and number in your `keeper_task_done` result text and in a durable surface (board post or decision record). Future turns recall it with `keeper_memory_search`; a PR you cannot recall is a PR you will abandon.
+- Before claiming new backlog work, recall your own open PRs. If one has an unaddressed review comment, a failing check, or a merge conflict, that is your highest-priority claimable work — handle it before starting something new.
+- Respond to every BLOCK or NEEDS_WORK review with a fix or a reasoned, evidence-backed rebuttal. Never silently dismiss another keeper's review, and never merge a PR that has an unresolved BLOCK — only the original reviewer or the operator can clear it.
+- Do not merge a PR that has zero cross-agent reviews. Before any merge, confirm through the review surface that at least one non-dismissed review exists.
+- When a merge conflict appears, find its cause before resolving it. Choose rebase or merge deliberately; do not discard another keeper's change just to make the conflict disappear.
+
 ### Possible actions (pick one per turn)
 - Reply to a pending mention in the current namespace conversation
 - Claim and work on one fitting task (`keeper_task_claim`, if available)
@@ -111,7 +127,9 @@ When you claim a task (`keeper_task_claim`), you MUST close it before ending the
 - Search knowledge library (`keeper_library_search` / `keeper_library_read`, if available)
 - Run shell commands to investigate (`Execute { executable: "git", argv: ["log", "--oneline", "-10"], cwd: "repos/REPO" }`, if available)
 - Search the web (`WebSearch` with `includeContent: true`) for tech context or documentation, read `content_text` first, then fetch (`WebFetch`) selected pages when a deeper read or citation is needed
-- Recall past context (`keeper_memory_search`, if available) before repeating past work
+- Recall past context (`keeper_memory_search`, if available) before repeating past work, including your own open PRs
+- Address an open PR you authored: a review comment, a failing check, or a merge conflict on it is claimable work
+- Review another keeper's PR or board claim skeptically (try to refute it; cite `path:line` evidence) rather than approving on sight
 - Search code patterns (`Grep { pattern: "regex", path: "lib", type: "ml" }`, if available)
 - Audit failed tasks (`keeper_tasks_audit`, if available) before deciding there is nothing to do
 - Inspect repo changes (`Read`, `Grep`) and git history with Execute from the repo cwd.


### PR DESCRIPTION
## 목적

Keeper가 (1) 적대적 리뷰를 하지 않고, (2) 자기가 올린 PR을 기억/추적하지 못하며, (3) 리뷰·충돌 대응을 하지 않는 문제를, **프롬프트로 지원 가능한 범위**에서 보강한다.

## 진단 (근거)

활성 턴 루프는 `keeper_unified_turn.ml:276` → `Keeper_unified_prompt.build_prompt`이고, 시스템 프롬프트 = `keeper.unified.system.md` + Turn Intent 뿐이다. `build_turn_prompt`는 레거시 `build_keeper_system_prompt`의 출력(`~base_system_prompt:_`)을 **명시적으로 무시**한다 (코드 주석: "use our unified system prompt").

따라서:
- `keeper.constitution.md`의 "PR merge rules (MANDATORY)"(리뷰 dismiss 금지, 무리뷰 머지 금지)는 **활성 unified 루프에 도달하지 않는다** — dead rule. 적대적 리뷰/리뷰 대응이 안 되는 구조적 근본 원인 중 하나.
- 적대적 *코드* 리뷰 지침은 양쪽 프롬프트에 0건. `verification.anti_rationalization.md`는 *task 완료* 검증용이지 코드 리뷰용이 아니다.

## 변경

`keeper.unified.system.md`(활성 경로로 확정된 유일한 파일)에 두 섹션 추가:

- **Reviewing another keeper's work** — 기본 스탠스를 회의(skeptical)로. 주장 반증 시도, `path:line` 증거 요구, BLOCK/nit 구분, rubber-stamp 금지. constitution의 MANDATORY 머지 규율을 활성 경로로 이식.
- **Your pull requests are unfinished until merged or closed** — PR 식별자를 durable memory에 기록하고 후속 턴에 `keeper_memory_search`로 recall (Anthropic agentic-memory 패턴). 자기 PR의 리뷰/CI/충돌을 최우선 claimable work로, BLOCK 리뷰엔 fix 또는 증거 기반 반박.

Possible actions 목록에 PR 후속 대응·적대적 리뷰를 명시 선택지로 추가.

## 이 PR로 해결되지 않는 것 (구조 — 프롬프트 범위 밖)

목표 2·3의 신뢰성 있는 해결은 프롬프트로 불가능하며, 별도 작업이 필요하다:

- 키퍼 자신이 연 PR의 **리뷰 코멘트 / CI 실패 / merge conflict 상태를 턴 신호로 주입하는 producer가 없다.** `keeper_external_attention.ml`에 `Github of { repo; notification_id }` 변형은 **타입으로만 존재하고 이를 채우는 producer가 0건**이다. proactive 턴은 "structured work"가 있을 때만 열리므로(`core_behavior.md`), 보이지 않는 PR 신호엔 턴 자체가 열리지 않는다.
- 프롬프트는 신호가 *있을 때* 행동을 강제할 수 있을 뿐, 신호를 *만들 수* 없다. 이를 프롬프트로 위조하면 "있는 척"(telemetry-as-fix 류) 안티패턴이 된다.

→ 후속: GitHub PR-review/CI/conflict → `Github` external-attention 이벤트 producer (별도 이슈/RFC). 추가로 constitution/core_behavior의 dead-rule을 unified 경로에 정식 배선할지 결정 필요.

## 검증

- 순수 `.md` 콘텐츠 변경, 새 `{{template variable}}` 없음, frontmatter 불변 → OCaml 재빌드 불필요.
- `test_prompt_registry_defaults.ml`은 unified.system의 template_variables `[identity_header, trait_lines, instructions_block, goal_lines]`만 검증 — 변경 없음. `test_prompt_asset_sync.ml`은 합성 fixture 사용 — 무관.
- 배포: 라이브 키퍼 반영은 repo `config/prompts/` → `.masc/config/prompts/` 동기화 + prompt registry reload(또는 서버 재시작)가 필요. 이 PR은 SSOT 변경만 담는다.

## RFC

RFC-WAIVED: prompt-content only, no gated subsystem touched (credential/operator/sandbox/hooks/workflow 비대상).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🔄 AS-IS vs TO-BE 구조적 개선점 분석 (Structural Improvements)

```mermaid
flowchart TB
    subgraph AS_IS["AS-IS: 활성 턴 루프 프롬프트 파이프라인"]
        direction TB
        A1["keeper.constitution.md<br/>'PR merge rules (MANDATORY)'<br/>리뷰 dismiss 금지, 무리뷰 머지 금지"]
        A2["build_keeper_system_prompt<br/>(레거시)"]
        A3["build_turn_prompt<br/>'use our unified system prompt'<br/>→ 레거시 출력 명시적 무시"]
        A4["keeper.unified.system.md<br/>(활성 경로 유일 파일)"]
        A5["적대적 리뷰 지침: 0건"]
        A6["PR 소유권/추적 지침: 0건"]
        A7["verification.anti_rationalization.md<br/>(task 완료 검증용, 코드 리뷰용 아님)"]

        A1 -->|Dead Rule| A2
        A2 -->|무시됨| A3
        A3 --> A4
        A4 --> A5
        A4 --> A6
        A4 -.-> A7

        style A1 fill:#fdd,stroke:#c00,stroke-dasharray:5 5
        style A5 fill:#fdd,stroke:#c00
        style A6 fill:#fdd,stroke:#c00
    end

    subgraph TO_BE["TO-BE: 활성 턴 루프 프롬프트 파이프라인"]
        direction TB
        B1["keeper.unified.system.md<br/>(활성 경로 유일 파일)"]
        B2["✦ Reviewing another keeper's work<br/>- 회의(skeptical) 스탠스<br/>- 주장 반증 시도<br/>- path:line 증거 요구<br/>- BLOCK/nit 구분<br/>- rubber-stamp 금지<br/>- constitution MANDATORY 머지 규율 이식"]
        B3["✦ Your PRs are unfinished until merged/closed<br/>- PR 식별자 → durable memory 기록<br/>- 후속 턴에 keeper_memory_search로 recall<br/>- 자기 PR 리뷰/CI/충돌 = 최우선 claimable work<br/>- BLOCK 리뷰 → fix 또는 증거 기반 반박"]
        B4["Possible actions 목록 확장<br/>- PR 후속 대응 (명시 선택지)<br/>- 적대적 리뷰 (명시 선택지)"]

        B1 --> B2
        B1 --> B3
        B1 --> B4

        style B2 fill:#dfd,stroke:#0a0
        style B3 fill:#dfd,stroke:#0a0
        style B4 fill:#dfd,stroke:#0a0
    end

    subgraph UNSOLVED["구조적 미해결 (프롬프트 범위 밖)"]
        direction TB
        C1["keeper_external_attention.ml<br/>Github 변형: 타입만 존재<br/>Producer: 0건"]
        C2["PR 리뷰 코멘트 / CI 실패 /<br/>merge conflict → 턴 신호 주입 불가"]
        C3["core_behavior: 'structured work' 있을 때만<br/>proactive 턴 오픈 → 보이지 않는 PR 신호엔 턴 자체 미오픈"]

        C1 --> C2 --> C3

        style C1 fill:#ffe0b2,stroke:#e65100
        style C2 fill:#ffe0b2,stroke:#e65100
        style C3 fill:#ffe0b2,stroke:#e65100
    end

    AS_IS -->|PR #21374 변경| TO_BE
    TO_BE -.->|"신호 부재 시 무력"| UNSOLVED
```

| 기술 범주 | AS-IS (변경 전) | TO-BE (변경 후) | 근거 및 효과 |
|:---|:---|:---|:---|
| **적대적 코드 리뷰 지침** | 양쪽 프롬프트(레거시/통합) 모두 0건. `verification.anti_rationalization.md`는 task 완료 검증용이지 코드 리뷰용이 아님 | `keeper.unified.system.md`에 "Reviewing another keeper's work" 섹션 신설: 회의(skeptical) 스탠스, 주장 반증 시도, `path:line` 증거 요구, BLOCK/nit 명확 구분, rubber-stamp 금지 | 코드 리뷰에 대한 구체적 행동 지침이 활성 경로에 최초로 부착됨. 기존에는 리뷰 행동을 규정하는 프롬프트가 없어 rubber-stamp 등이 구조적으로 방지되지 않음 |
| **PR 머지 규율 (MANDATORY)** | `keeper.constitution.md`에 "PR merge rules (MANDATORY)" 존재(리뷰 dismiss 금지, 무리뷰 머지 금지) → `build_turn_prompt`가 레거시 출력을 명시적 무시하므로 **활성 unified 루프에 도달하지 않는 dead rule** | constitution의 MANDATORY 머지 규율을 활성 경로인 `keeper.unified.system.md` 내 "Reviewing another keeper's work" 섹션으로 이식 | dead rule을 활성 경로로 배선하여 실제 턴에서 규율이 적용되도록 구조적 결함 해결 |
| **PR 소유권 및 추적** | 키퍼가 자신이 올린 PR을 기억/추적하는 지침 0건. durable memory에 PR 식별자를 기록하거나 recall하는 패턴 없음 | "Your pull requests are unfinished until merged or closed" 섹션 신설: PR 식별자를 durable memory에 기록, 후속 턴에서 `keeper_memory_search`로 recall (Anthropic agentic-memory 패턴 적용) | PR 상태가 턴 간에 지속적으로 추적 가능해짐. 단, 실제 신호 주입은 producer가 없어 후속 작업 필요 (PR 설명에 명시) |
| **자기 PR 리뷰/CI/충돌 대응** | 대응 지침 0건. 자기 PR의 리뷰 코멘트/CI 실패/merge conflict를 claimable work로 인식하지 못함 | 자기 PR의 리뷰/CI/충돌을 **최우선 claimable work**로 규정. BLOCK 리뷰에 대해서는 fix 또는 증거 기반 반박을 명시 | 프롬프트 레벨에서 행동 우선순위가 명확해짐. 다만 실제 턴 신호로 주입되려면 `Github` external-attention 이벤트 producer가 필요 (구조적 한계) |
| **Possible actions 명시성** | PR 후속 대응, 적대적 리뷰가 명시적 선택지로 없음 | Possible actions 목록에 PR 후속 대응·적대적 리뷰를 명시 선택지로 추가 | 키퍼가 행동 선택 시 해당 옵션을 인지하고 선택할 수 있도록 가이드레일 제공 |
| **레거시 프롬프트와의 관계** | `build_keeper_system_prompt`가 constitution 등을 조합하나, `build_turn_prompt`에서 `~base_system_prompt:_`로 명시적 무시 (코드 주석: "use our unified system prompt") | 변경 없음 (레거시 경로는 그대로 dead state). 대신 unified 경로에 필요 규칙을 직접 이식하는 방식 채택 | 레거시 경로 수정 대신 활성 경로에 직접 배선하여 즉시 효과 발휘. constitution/core_behavior의 다른 dead rule 통합은 별도 결정 사항 |
| **신호 주입 파이프라인 (구조)** | `keeper_external_attention.ml`에 `Github of { repo; notification_id }` 변형이 **타입으로만 존재**, 이를 채우는 producer **0건**. proactive 턴은 "structured work"가 있을 때만 열림 | **변경 없음** — 프롬프트 범위 밖으로 명시적 한계 설정 | 프롬프트는 신호가 *있을 때* 행동을 강제할 수 있을 뿐, 신호를 *만들 수* 없음. 신호 없이 "있는 척"하면 telemetry-as-fix 안티패턴이 됨. 후속 작업으로 producer 개발 필요 |
| **빌드/테스트 영향** | — | 순수 `.md` 콘텐츠 변경, 새 `{{template variable}}` 없음, frontmatter 불변 → OCaml 재빌드 불필요. `test_prompt_registry_defaults.ml`(template_variables 검증) 변경 없음. `test_prompt_asset_sync.ml`(합성 fixture) 무관 | 프롬프트 전용 변경으로 배포 리스크 최소화. repo `config/prompts/` → `.masc/config/prompts/` 동기화 + prompt registry reload 또는 서버 재시작만으로 반영 가능 |
| **보안/권한 영향** | — | credential/operator/sandbox/hooks/workflow 비대상 (RFC-WAIVED) | gated subsystem 접근 없으므로 보안 영향 범위 제로 |
