### PR TITLE
feat(dashboard): apply keeper-v2 board surface

### DIFF
--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -93,6 +93,12 @@ export const newPostHearth = signal('')
 export const newPostFlair = signal('')
 export const newPostSubmitting = signal(false)
 
+// ── Signals: v2 board surface chrome ───────────────────────────────
+export const selectedBoardPostId = signal<string | null>(null)
+export const boardFilterMode = signal<'all' | 'state' | 'mod'>('all')
+export const boardComposerMode = signal<'post' | 'mention' | 'state'>('post')
+export const boardComposerDraft = signal('')
+
 // ── Pagination ─────────────────────────────────────────────────────
 export const PAGE_SIZE = 20
 export const visibleLimit = signal(PAGE_SIZE)
@@ -369,6 +375,59 @@ export function postVisibilityAuditLabel(post: BoardPost): string {
 export function visibilityBadgeColor(vis: string): string {
   if (vis === 'internal') return 'bg-[var(--color-bg-hover)] text-[var(--purple)] border-[var(--color-border-strong)]'
   return 'bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] border-[var(--color-border-default)]'
+}
+
+// ── State block helpers for v2 board cards ─────────────────────────
+export interface ParsedStateBlock {
+  from: string
+  to: string
+  ctx: string
+  action: string
+}
+
+/**
+ * Parse a `[STATE]...[/STATE]` block into a structured transition view.
+ * Falls back to key/value lines when the canonical keys are absent.
+ */
+export function parseStateBlock(text: string): ParsedStateBlock | null {
+  const start = text.indexOf('[STATE]')
+  if (start < 0) return null
+  const bodyStart = start + '[STATE]'.length
+  const end = text.indexOf('[/STATE]', bodyStart)
+  if (end < 0) return null
+  const raw = text.slice(bodyStart, end).trim()
+  if (!raw) return null
+
+  const lines = raw.split('\n').map(line => line.trim()).filter(Boolean)
+  const entries = new Map<string, string>()
+  for (const line of lines) {
+    const colon = line.indexOf(':')
+    if (colon < 0) continue
+    const key = line.slice(0, colon).trim()
+    const value = line.slice(colon + 1).trim()
+    if (key) entries.set(key.toLowerCase(), value)
+  }
+
+  const from = entries.get('from') ?? entries.get('current') ?? ''
+  const to = entries.get('to') ?? entries.get('next') ?? entries.get('goal') ?? ''
+  const ctx = entries.get('ctx') ?? entries.get('context') ?? entries.get('where') ?? ''
+  const action = entries.get('action') ?? entries.get('do') ?? entries.get('step') ?? ''
+
+  // Require at least a transition target or action to treat it as a state block.
+  if (!to && !action && !from) return null
+  return { from, to, ctx, action }
+}
+
+export function postHasStateBlock(post: BoardPost): boolean {
+  if (post.meta?.state_block) return true
+  return parseStateBlock(post.body) !== null
+}
+
+export function getPostStateBlock(post: BoardPost): ParsedStateBlock | null {
+  if (post.meta?.state_block) {
+    return parseStateBlock(`[STATE]\n${String(post.meta.state_block)}\n[/STATE]`)
+  }
+  return parseStateBlock(post.body)
 }
 
 // ── Data operations ────────────────────────────────────────────────

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -4,8 +4,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { BoardSurface } from './board-surface'
 import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter, boardHasMore, boardLoadingMore, messages, shellAuthSummary } from '../../store'
 import { route } from '../../router'
-import { PAGE_SIZE, boardFlairs, boardFlairsError, boardHearths, boardHearthsError, categoryVisibleLimits, contentCategory, newPostFlair, newPostHearth, newPostSubmitting, showNewPostForm, subBoardOptions, subBoardOptionsError } from './board-state'
-import { boardLatencyMetrics, resetBoardLatencyMetrics } from '../../board-metrics'
+import { PAGE_SIZE, boardFlairs, boardFlairsError, boardHearths, boardHearthsError, categoryVisibleLimits, contentCategory, selectedBoardPostId, boardFilterMode, boardComposerMode } from './board-state'
+import { resetBoardLatencyMetrics } from '../../board-metrics'
 import type { BoardPost } from '../../types'
 
 import '@testing-library/jest-dom'
@@ -125,11 +125,8 @@ describe('contentCategory', () => {
   })
 })
 
-// ── Board component rendering tests ───────────────────────────────
+// ── Board v2 component rendering tests ────────────────────────────
 describe('BoardSurface Component', () => {
-  // PR #13152 review: vi.stubGlobal('fetch') in beforeEach without a matching
-  // unstub leaks the mocked fetch into later tests in the same worker.  Add
-  // an explicit afterEach that restores all stubbed globals.
   afterEach(async () => {
     cleanup()
     await vi.dynamicImportSettled()
@@ -167,19 +164,16 @@ describe('BoardSurface Component', () => {
       { name: 'bug', emoji: '🐛', label: 'Bug Report' },
     ]
     boardFlairsError.value = false
-    subBoardOptions.value = []
-    subBoardOptionsError.value = false
     resetBoardLatencyMetrics()
-    showNewPostForm.value = false
-    newPostHearth.value = ''
-    newPostFlair.value = ''
-    newPostSubmitting.value = false
     categoryVisibleLimits.value = {
       article: PAGE_SIZE,
       review: PAGE_SIZE,
       notice: PAGE_SIZE,
       system: PAGE_SIZE,
     }
+    selectedBoardPostId.value = null
+    boardFilterMode.value = 'all'
+    boardComposerMode.value = 'post'
     messages.value = []
     shellAuthSummary.value = null
     route.value = { params: {} } as any
@@ -190,16 +184,17 @@ describe('BoardSurface Component', () => {
     expect(screen.getByText(/아직 게시글이 없습니다/)).toBeInTheDocument()
   })
 
-  it('wraps the board surface in the v2 workspace surface class', () => {
+  it('wraps the board surface in the v2 board surface class', () => {
     const { container } = render(h(BoardSurface, null))
-    expect(container.querySelector('.v2-workspace-surface')).not.toBeNull()
+    expect(container.querySelector('.v2-board-surface')).not.toBeNull()
   })
 
-  it('marks the sort bar and new-post form as v2 workspace panels', () => {
+  it('keeps v2 workspace panels for category cards', () => {
+    boardPosts.value = [
+      makePost({ id: 'post-1', title: '기술 탐색: test topic', body: 'content', author: 'keeper' }),
+    ]
     const { container } = render(h(BoardSurface, null))
-    const panels = container.querySelectorAll('.v2-workspace-panel')
-    expect(panels.length).toBeGreaterThanOrEqual(2)
-    expect(container.querySelector('.v2-workspace-action')).not.toBeNull()
+    expect(container.querySelectorAll('.v2-workspace-panel').length).toBeGreaterThanOrEqual(1)
   })
 
   it('renders loading state when loading', () => {
@@ -317,7 +312,7 @@ describe('BoardSurface Component', () => {
     expect(screen.getByText('flair:insight')).toBeInTheDocument()
   })
 
-  it('renders post moderation projection badges', () => {
+  it('renders moderation status badge on post cards', () => {
     boardPosts.value = [
       makePost({
         id: 'post-flagged',
@@ -331,7 +326,7 @@ describe('BoardSurface Component', () => {
 
     render(h(BoardSurface, null))
 
-    expect(screen.getByLabelText('게시글 moderation 신고됨 2건')).toHaveTextContent('신고됨 2')
+    expect(screen.getByText('모더레이션 대기')).toBeInTheDocument()
   })
 
   it('renders vote-blind post scores as hidden until voting', () => {
@@ -350,34 +345,7 @@ describe('BoardSurface Component', () => {
 
     render(h(BoardSurface, null))
 
-    expect(screen.getByLabelText('점수 투표 후 공개')).toHaveTextContent('투표 후 공개')
-  })
-
-  it('renders board visibility audit details on post cards', () => {
-    boardPosts.value = [
-      makePost({
-        id: 'post-audit',
-        title: 'Audit visible',
-        body: 'content',
-        author: 'ani1999',
-        votes: null,
-        vote_balance: null,
-        vote_blind: true,
-        comment_count: 13,
-        created_at: '2026-04-17T00:00:00Z',
-        updated_at: '2026-04-17T01:00:00Z',
-      }),
-    ]
-
-    render(h(BoardSurface, null))
-
-    const audit = screen.getByLabelText(/게시글 표시 감사:/)
-    expect(audit).toHaveTextContent('표시 중')
-    expect(audit).toHaveTextContent('내부')
-    expect(audit).toHaveTextContent('댓글 13개')
-    expect(audit).toHaveTextContent('점수 투표 후 공개')
-    expect(audit).toHaveTextContent('최근 갱신됨')
-    expect(audit).toHaveTextContent('정렬 최신순')
+    expect(screen.getByLabelText('점수 투표 후 공개')).toHaveTextContent(/투표 후 공개/)
   })
 
   it('renders contributor quality badges on post cards', () => {
@@ -397,37 +365,111 @@ describe('BoardSurface Component', () => {
 
     render(h(BoardSurface, null))
 
-    expect(screen.getByLabelText('기여자 품질 72점 · 강함')).toHaveTextContent('품질 72')
+    expect(screen.getByLabelText(/기여자 품질 72점/)).toHaveTextContent('품질 72')
+  })
+
+  it('renders a state block panel when the post body contains one', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-state',
+        title: 'State transition',
+        body: '[STATE]\nfrom: idle\nto: running\nctx: ops\naction: start\n[/STATE]',
+        author: 'ani1999',
+      }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByTestId('bd-stateblock')).toBeInTheDocument()
+    expect(screen.getByText('상태 전이')).toBeInTheDocument()
+    expect(screen.getByText(/idle/)).toBeInTheDocument()
+  })
+
+  it('renders sub-board rail and filters posts by sub-board', () => {
+    boardHearths.value = [
+      { name: 'ops', count: 1 },
+      { name: 'review', count: 0 },
+    ]
+    boardPosts.value = [
+      makePost({ id: 'post-ops', title: 'Ops note', body: 'ops', author: 'keeper', hearth: 'ops' }),
+      makePost({ id: 'post-review', title: 'Review note', body: 'review', author: 'keeper', hearth: 'review' }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByTestId('bd-sub-all')).toBeInTheDocument()
+    expect(screen.getByTestId('bd-sub-ops')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('bd-sub-ops'))
+
+    expect(boardHearthFilter.value).toBe('ops')
+  })
+
+  it('renders filter chips for state and moderation', () => {
+    boardPosts.value = [
+      makePost({ id: 'post-state', title: 'State', body: '[STATE]\nGoal: x\n[/STATE]', author: 'keeper' }),
+      makePost({ id: 'post-mod', title: 'Mod', body: 'mod', author: 'keeper', moderation_status: 'flagged' }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByTestId('bd-filter-all')).toBeInTheDocument()
+    expect(screen.getByTestId('bd-filter-state')).toBeInTheDocument()
+    expect(screen.getByTestId('bd-filter-mod')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('bd-filter-state'))
+    expect(boardFilterMode.value).toBe('state')
+  })
+
+  it('opens a thread detail side panel when a post is selected', () => {
+    boardPosts.value = [
+      makePost({ id: 'post-1', title: 'Selectable post', body: 'body', author: 'keeper', comment_count: 3 }),
+    ]
+
+    render(h(BoardSurface, null))
+    fireEvent.click(screen.getByTestId('bd-post-post-1'))
+
+    expect(screen.getByTestId('bd-thread-detail')).toBeInTheDocument()
+    expect(screen.getByText('스레드')).toBeInTheDocument()
+  })
+
+  it('switches composer mode tabs', () => {
+    render(h(BoardSurface, null))
+
+    expect(screen.getByTestId('bd-comp-tab-post')).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.click(screen.getByTestId('bd-comp-tab-mention'))
+    expect(boardComposerMode.value).toBe('mention')
+
+    fireEvent.click(screen.getByTestId('bd-comp-tab-state'))
+    expect(boardComposerMode.value).toBe('state')
   })
 
   it('routes the mention inbox focus to the message surface', () => {
     route.value = { params: { focus: 'mention-inbox' } } as any
-    messages.value = [{ id: 'm-1', from: 'sojin', content: '@dashboard needs review' }]
+    messages.value = [{ id: 'm-1', from: 'sojin', content: '@dashboard needs review', timestamp: new Date().toISOString() }]
 
     render(h(BoardSurface, null))
 
     expect(screen.getByRole('heading', { name: 'Mention inbox' })).toBeInTheDocument()
-    expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
   })
 
   it('routes the message workspace focus to the workspace timeline surface', () => {
     route.value = { params: { focus: 'messages-workspace' } } as any
-    messages.value = [{ id: 'm-workspace', from: 'sangsu', workspace: 'ops', content: 'workspace update' }]
+    messages.value = [{ id: 'm-workspace', from: 'sangsu', workspace: 'ops', content: 'workspace update', timestamp: new Date().toISOString() }]
 
     render(h(BoardSurface, null))
 
     expect(screen.getByRole('heading', { name: 'Workspace timeline' })).toBeInTheDocument()
-    expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
   })
 
   it('routes the state-block focus to the message surface', () => {
     route.value = { params: { focus: 'state-block' } } as any
-    messages.value = [{ id: 'm-state', from: 'sangsu', content: '[STATE]\nGoal: keep context\n[/STATE]' }]
+    messages.value = [{ id: 'm-state', from: 'sangsu', content: '[STATE]\nGoal: keep context\n[/STATE]', timestamp: new Date().toISOString() }]
 
     render(h(BoardSurface, null))
 
     expect(screen.getByRole('heading', { name: 'State-block messages' })).toBeInTheDocument()
-    expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
   })
 
   it('routes the curation focus to the board curation surface', async () => {
@@ -442,7 +484,6 @@ describe('BoardSurface Component', () => {
     render(h(BoardSurface, null))
 
     expect(await screen.findByRole('heading', { name: 'AI curation snapshot' })).toBeInTheDocument()
-    expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
   })
 
   it('routes the karma focus to the board karma surface', async () => {
@@ -462,45 +503,6 @@ describe('BoardSurface Component', () => {
     render(h(BoardSurface, null))
 
     expect(await screen.findByRole('heading', { name: 'Karma ledger' })).toBeInTheDocument()
-    expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
-  })
-
-  it('renders compact board latency metrics when samples exist', () => {
-    boardPosts.value = [
-      makePost({
-        id: 'post-1',
-        title: 'Latency sample',
-        body: 'content',
-        author: 'keeper',
-      }),
-    ]
-    boardLatencyMetrics.value = {
-      ...boardLatencyMetrics.value,
-      list: {
-        last_latency_ms: 42,
-        last_ok: true,
-        sample_count: 1,
-        failure_count: 0,
-        last_error: null,
-      },
-      reaction_toggle: {
-        last_latency_ms: 17,
-        last_ok: false,
-        sample_count: 1,
-        failure_count: 1,
-        last_error: 'network down',
-      },
-    }
-
-    render(h(BoardSurface, null))
-
-    expect(screen.getByLabelText('목록 지연 42밀리초')).toHaveTextContent('목록 42ms')
-    const failedChip = screen.getByLabelText('리액션 지연 17밀리초 실패')
-    expect(failedChip).toHaveTextContent('리액션 17ms 실패')
-    expect(failedChip.className).toContain('text-[var(--color-status-err)]')
-    expect(failedChip.className).toContain('border-[var(--bad-30)]')
-    expect(failedChip.className).not.toContain('color-status-bad')
-    expect(failedChip.className).not.toContain('bad-25')
   })
 
   it('hides system posts by default', () => {
@@ -515,74 +517,6 @@ describe('BoardSurface Component', () => {
     ]
     render(h(BoardSurface, null))
     expect(screen.queryByText('System Post')).not.toBeInTheDocument()
-  })
-
-  it('applies a hearth filter from the server hearth list', () => {
-    boardHearths.value = [{ name: 'ops', count: 2 }]
-    boardPosts.value = [
-      makePost({
-        id: 'post-ops',
-        title: 'Ops note',
-        body: 'ops content',
-        author: 'keeper',
-        hearth: 'ops',
-      }),
-    ]
-
-    render(h(BoardSurface, null))
-    fireEvent.click(screen.getByRole('button', { name: 'hearth ops 2 posts' }))
-
-    expect(boardHearthFilter.value).toBe('ops')
-    expect(screen.getByRole('button', { name: 'hearth ops 2 posts' })).toHaveAttribute('aria-pressed', 'true')
-  })
-
-  it('keeps hearth refresh available without showing an error for a valid empty list', () => {
-    boardHearths.value = []
-    boardHearthsError.value = false
-
-    render(h(BoardSurface, null))
-
-    expect(screen.queryByText('hearth 목록을 불러오지 못했습니다')).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'hearth 목록 새로고침' })).toBeInTheDocument()
-  })
-
-  it('shows the hearth load error only after a failed refresh', () => {
-    boardHearths.value = []
-    boardHearthsError.value = true
-
-    render(h(BoardSurface, null))
-
-    expect(screen.getByText('hearth 목록을 불러오지 못했습니다')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'hearth 목록 새로고침' })).toBeInTheDocument()
-  })
-
-  it('prefills the compose hearth from the active hearth filter', () => {
-    boardHearthFilter.value = 'ops'
-
-    render(h(BoardSurface, null))
-    fireEvent.click(screen.getByRole('button', { name: '+ 새 글 작성' }))
-
-    expect(screen.getByLabelText('새 글 category')).toHaveValue('ops')
-    expect(newPostHearth.value).toBe('ops')
-  })
-
-  it('renders explicit flair selection in the post composer', () => {
-    render(h(BoardSurface, null))
-    fireEvent.click(screen.getByRole('button', { name: '+ 새 글 작성' }))
-
-    const flair = screen.getByLabelText('새 글 flair')
-    expect(flair).toBeInTheDocument()
-    fireEvent.change(flair, { target: { value: 'bug' } })
-    expect(newPostFlair.value).toBe('bug')
-  })
-
-  it('disables compose cancel while a post is submitting', () => {
-    showNewPostForm.value = true
-    newPostSubmitting.value = true
-
-    render(h(BoardSurface, null))
-
-    expect(screen.getByRole('button', { name: '취소' })).toBeDisabled()
   })
 
   it('uses shared cursor pagination for category expansion', () => {

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useCallback, useMemo, useState } from 'preact/hooks'
-import { RefreshCw, Sparkles, Trophy } from 'lucide-preact'
+import { Sparkles, Trophy } from 'lucide-preact'
 import { ActionButton } from '../common/button'
 import { SectionCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
@@ -11,97 +11,67 @@ import { LoadingState } from '../common/feedback-state'
 import { TextInput } from '../common/input'
 import { Select } from '../common/select'
 import { Checkbox } from '../common/checkbox'
-import { RichComposer } from '../common/rich-composer'
-import { isSubmitEnter } from '../../lib/keyboard'
 import { RichContent } from '../common/rich-content'
 import { CursorPagination } from '../common/pagination'
 import { stripStateBlocks } from '../../keeper-message'
-import { navigate, navigateToPost, route } from '../../router'
+import { navigate, route } from '../../router'
 import { votePost } from '../../api/board'
+import { createPost } from '../../api'
 import { deleteBoardPost, setBoardPostPinned } from '../../api/actions'
 import { registerBoardHearthsRefresh } from '../../sse-store'
 import { boardLatencyMetrics, type BoardLatencyMetric } from '../../board-metrics'
 import { MessageWorkspaceTimeline } from './message-workspace-timeline'
 import { BoardCurationPanel } from './board-curation-panel'
 import { BoardKarmaPanel } from './board-karma-panel'
-import { MentionInbox } from './mention-inbox'
-import { ModerationBadge } from './moderation-badge'
-import { PostDetail } from './post-detail'
+import { MentionInbox, MentionInboxPanel } from './mention-inbox'
+import { PostDetail, CommentThread, CommentForm } from './post-detail'
 import { ReactionBar } from './reaction-bar'
 import { StateBlockMessages } from './state-block-messages'
+import { ComposerV2 } from './composer-v2'
+import type { ComposerV2Mode } from './composer-v2'
 import {
   boardActorAvatarKey,
   boardActorDisplayName,
   boardActorTitle,
   contributorQualityBadgeClass,
-  contributorQualityBandLabel,
   contributorQualityPercent,
   navigateToAuthor,
   stripInlineMarkdown,
 } from '../../lib/board-utils'
-import { hasRichMarkdownSignals } from '../common/rich-content-utils'
 import { ringFocusClasses } from '../common/ring'
 import {
   boardPosts,
-  boardSortMode,
-  boardHiddenCategories,
-  boardAuthorFilter,
   boardHearthFilter,
   boardHearths,
-  boardHearthsLoading,
-  boardHearthsError,
   boardFlairs,
-  boardFlairsLoading,
-  boardFlairsError,
-  subBoardOptions,
-  subBoardOptionsLoading,
-  subBoardOptionsError,
-  boardExcludeAutomation,
   boardLoading,
   boardLoadingMore,
   boardHasMore,
   lastBoardRefreshAt,
   refreshBoard,
   loadMoreBoardPosts,
-  SORT_MODES,
+  PAGE_SIZE,
   CONTENT_CATEGORIES,
+  categoryVisibleLimits,
   detailPost,
   detailLoading,
   detailPostId,
-  showNewPostForm,
-  newPostTitle,
-  newPostContent,
-  newPostHearth,
-  newPostFlair,
-  newPostSubmitting,
-  PAGE_SIZE,
-  categoryVisibleLimits,
-  visibleLimit,
-  automationVisibleLimit,
-  systemVisibleLimit,
+  detailComments,
   deletingPostId,
   selectedPostIds,
-  bulkDeleting,
   loadPostDetail,
-  submitNewPost,
   togglePostSelection,
-  bulkDeleteSelected,
   splitVisiblePosts,
-  filterHint,
-  isUpdated,
-  contentCategory,
   categoryLabel,
-  categoryBadgeColor,
-  authorAvatar,
-  visibilityLabel,
-  visibilityBadgeColor,
-  postVisibilityAuditLabel,
-  postVisibilityAuditDetails,
   refreshBoardHearths,
   refreshBoardFlairs,
-  loadSubBoardOptionsForPost,
+  selectedBoardPostId,
+  boardFilterMode,
+  boardComposerMode,
+  postHasStateBlock,
+  getPostStateBlock,
 } from './board-state'
-import type { BoardPost, ContentCategory } from './board-state'
+import type { BoardPost, ContentCategory, ParsedStateBlock } from './board-state'
 
 /**
  * Pure filter for board posts.
@@ -248,331 +218,6 @@ function CategorySection({ group }: { group: { category: ContentCategory; posts:
   return renderCategorySection(group.category, group.posts, group.total, group.hidden)
 }
 
-// ── New post form ──────────────────────────────────────────────────
-function NewPostForm() {
-  useEffect(() => {
-    if (showNewPostForm.value && boardFlairs.value.length === 0 && !boardFlairsLoading.value) {
-      void refreshBoardFlairs()
-    }
-    if (showNewPostForm.value && subBoardOptions.value.length === 0 && !subBoardOptionsLoading.value) {
-      void loadSubBoardOptionsForPost()
-    }
-  }, [showNewPostForm.value])
-
-  if (!showNewPostForm.value) {
-    return html`
-      <button type="button"
-        class="v2-workspace-action w-full py-2.5 rounded-[var(--r-1)] border border-dashed border-[var(--color-border-default)] text-sm text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-fg-primary)] transition-colors bg-transparent"
-        onClick=${() => {
-          newPostHearth.value = boardHearthFilter.value
-          showNewPostForm.value = true
-        }}
-      >+ 새 글 작성</button>
-    `
-  }
-
-  const subBoardSelectOptions = subBoardOptions.value.map(sb => ({ value: sb.slug, label: sb.name }))
-  const activeHearth = newPostHearth.value.trim()
-  const selectedSubBoardOptions = activeHearth
-    && !subBoardSelectOptions.some(option => option.value === activeHearth)
-    ? [{ value: activeHearth, label: activeHearth }, ...subBoardSelectOptions]
-    : subBoardSelectOptions
-  const categorySelectOptions = [
-    { value: '', label: 'No category' },
-    ...selectedSubBoardOptions,
-  ]
-  const activeFlair = newPostFlair.value.trim()
-  const flairSelectOptions = [
-    { value: '', label: 'No flair' },
-    ...boardFlairs.value.map(flair => ({
-      value: flair.name,
-      label: `${flair.emoji ? `${flair.emoji} ` : ''}${flair.label}`,
-    })),
-  ]
-  const selectedFlairOptions = activeFlair
-    && !flairSelectOptions.some(option => option.value === activeFlair)
-    ? [{ value: activeFlair, label: activeFlair }, ...flairSelectOptions]
-    : flairSelectOptions
-
-  return html`
-    <div class="v2-workspace-panel p-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] grid gap-3">
-      <${TextInput}
-        name="board_post_title"
-        ariaLabel="새 글 제목"
-        autoComplete="off"
-        placeholder="제목"
-        value=${newPostTitle.value}
-        onInput=${(e: Event) => { newPostTitle.value = (e.target as HTMLInputElement).value }}
-      />
-      <${RichComposer}
-        value=${newPostContent.value}
-        onValueChange=${(next: string) => { newPostContent.value = next }}
-        rows=${8}
-        placeholder="내용을 입력하세요. Markdown, 코드 스니펫, URL, 이미지 링크를 그대로 붙일 수 있습니다."
-        helpText="예: ts 코드펜스, 일반 URL 링크 카드, 단독 이미지 URL 자동 인라인"
-        previewLimit=${2}
-      />
-      <div class="grid gap-3 md:grid-cols-2">
-        <label class="grid gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
-          Category
-          <${Select}
-            value=${newPostHearth.value}
-            options=${categorySelectOptions}
-            disabled=${newPostSubmitting.value || subBoardOptionsLoading.value}
-            ariaLabel="새 글 category"
-            onInput=${(value: string) => { newPostHearth.value = value }}
-          />
-        </label>
-        <label class="grid gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
-          Flair
-          <${Select}
-            value=${newPostFlair.value}
-            options=${selectedFlairOptions}
-            disabled=${newPostSubmitting.value || boardFlairsLoading.value}
-            ariaLabel="새 글 flair"
-            onInput=${(value: string) => { newPostFlair.value = value }}
-          />
-        </label>
-      </div>
-      ${boardFlairsError.value ? html`
-        <div class="text-2xs text-[var(--color-status-warn)]">Flair 목록을 불러오지 못했습니다. 직접 [flair:name] prefix를 사용할 수 있습니다.</div>
-      ` : null}
-      ${subBoardOptionsError.value ? html`
-        <div class="text-2xs text-[var(--color-status-warn)]">Sub-board 목록을 불러오지 못했습니다. Category 값을 직접 입력하려면 현재 Board 필터를 먼저 선택하세요.</div>
-      ` : null}
-      <div class="flex gap-2 justify-end">
-        <button type="button"
-          class="v2-workspace-action px-3 py-1.5 rounded-[var(--r-1)] text-sm border border-[var(--color-border-default)] bg-transparent text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--color-bg-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
-          disabled=${newPostSubmitting.value}
-          onClick=${() => {
-            showNewPostForm.value = false
-            newPostTitle.value = ''
-            newPostContent.value = ''
-            newPostHearth.value = ''
-            newPostFlair.value = ''
-          }}
-        >취소</button>
-        <button type="button"
-          class="v2-workspace-action px-4 py-1.5 rounded-[var(--r-1)] text-sm font-medium border border-[var(--info-border)] bg-[var(--color-accent-soft)] text-[var(--color-accent-fg)] cursor-pointer hover:bg-[var(--accent-20)] disabled:opacity-50"
-          disabled=${newPostSubmitting.value || !newPostTitle.value.trim() || !newPostContent.value.trim()}
-          onClick=${() => { void submitNewPost() }}
-        >${newPostSubmitting.value ? '등록 중...' : '등록'}</button>
-      </div>
-    </div>
-  `
-}
-
-function setBoardHearthFilter(nextHearth: string) {
-  if (boardHearthFilter.value === nextHearth) return
-  boardHearthFilter.value = nextHearth
-  visibleLimit.value = PAGE_SIZE
-  automationVisibleLimit.value = PAGE_SIZE
-  systemVisibleLimit.value = PAGE_SIZE
-  categoryVisibleLimits.value = {
-    article: PAGE_SIZE,
-    review: PAGE_SIZE,
-    notice: PAGE_SIZE,
-    system: PAGE_SIZE,
-  }
-  refreshBoard()
-}
-
-function HearthFilterBar() {
-  const hearths = boardHearths.value
-  const active = boardHearthFilter.value
-  const activeInList = active !== '' && hearths.some(hearth => hearth.name === active)
-
-  const chipClass = (selected: boolean) => `px-2.5 py-1 rounded-[var(--r-1)] text-2xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer ${
-    selected
-      ? 'bg-[var(--color-accent-soft)] text-[var(--color-accent-fg)] border-[var(--accent-20)]'
-      : 'bg-transparent text-[var(--color-fg-muted)] border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]'
-  }`
-
-  // PR #13152 review (P2): when initial refreshBoardHearths() fails the
-  // list ends up empty + not loading, and the original early-return hid
-  // the entire bar — including the refresh button — leaving users with no
-  // in-UI retry path.  Render a minimal bar (refresh button only) in that
-  // state so the manual retry stays reachable.
-  if (hearths.length === 0 && active === '' && !boardHearthsLoading.value) {
-    return html`
-      <div class="flex items-center gap-1.5 flex-wrap">
-        ${boardHearthsError.value ? html`
-          <span class="text-2xs text-[var(--color-fg-muted)]" aria-hidden="true">hearth 목록을 불러오지 못했습니다</span>
-        ` : null}
-        <button
-          type="button"
-          class="v2-workspace-action px-2 py-1 rounded-[var(--r-1)] text-2xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-transparent hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] disabled:opacity-50"
-          aria-label="hearth 목록 새로고침"
-          disabled=${boardHearthsLoading.value}
-          onClick=${() => { void refreshBoardHearths() }}
-        >
-          <${RefreshCw} size=${12} class=${boardHearthsLoading.value ? 'animate-spin' : ''} aria-hidden="true" />
-        </button>
-      </div>
-    `
-  }
-
-  return html`
-    <div class="flex items-center gap-1.5 flex-wrap">
-      <span class="text-2xs font-semibold text-[var(--color-fg-muted)]" aria-hidden="true">#</span>
-      <button
-        type="button"
-        class=${`v2-workspace-action ${chipClass(active === '')}`}
-        aria-pressed=${active === ''}
-        aria-label="전체 hearth"
-        onClick=${() => setBoardHearthFilter('')}
-      >전체</button>
-      ${hearths.map(hearth => html`
-        <button
-          key=${hearth.name}
-          type="button"
-          class=${`v2-workspace-action ${chipClass(active === hearth.name)}`}
-          aria-pressed=${active === hearth.name}
-          aria-label=${`hearth ${hearth.name} ${hearth.count} posts`}
-          onClick=${() => setBoardHearthFilter(hearth.name)}
-        >${hearth.name} <span class="tabular-nums opacity-70">${hearth.count}</span></button>
-      `)}
-      ${active !== '' && !activeInList ? html`
-        <button
-          type="button"
-          class=${`v2-workspace-action ${chipClass(true)}`}
-          aria-pressed="true"
-          aria-label=${`hearth ${active}`}
-          onClick=${() => setBoardHearthFilter(active)}
-        >${active}</button>
-      ` : null}
-      <button
-        type="button"
-        class="v2-workspace-action px-2 py-1 rounded-[var(--r-1)] text-2xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-transparent hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] disabled:opacity-50"
-        aria-label="hearth 목록 새로고침"
-        disabled=${boardHearthsLoading.value}
-        onClick=${() => { void refreshBoardHearths() }}
-      >
-        <${RefreshCw} size=${12} class=${boardHearthsLoading.value ? 'animate-spin' : ''} aria-hidden="true" />
-      </button>
-    </div>
-  `
-}
-
-// ── Sort bar ───────────────────────────────────────────────────────
-function SortBar() {
-  const current = boardSortMode.value
-  const grouped = splitVisiblePosts(boardPosts.value)
-  return html`
-    <div class="v2-workspace-panel flex flex-col gap-3 mb-4 p-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
-      <div class="flex items-center gap-1.5 flex-wrap">
-        ${SORT_MODES.map(mode => html`
-          <button type="button"
-            class="v2-workspace-action px-3 py-1.5 rounded-[var(--r-1)] text-xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer
-              ${current === mode.id
-                ? 'bg-[var(--ok-soft)] text-[var(--color-status-ok)] border-[var(--ok-30)]'
-                : 'bg-transparent text-[var(--color-fg-muted)] border-transparent hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]'
-              }"
-            onClick=${() => {
-              boardSortMode.value = mode.id
-              visibleLimit.value = PAGE_SIZE
-              automationVisibleLimit.value = PAGE_SIZE
-              systemVisibleLimit.value = PAGE_SIZE
-              refreshBoard()
-            }}
-          >
-            ${mode.label}
-          </button>
-        `)}
-      </div>
-      <${HearthFilterBar} />
-      <div class="flex items-center gap-2 flex-wrap">
-        ${grouped.groups.map(g => {
-          const meta = CONTENT_CATEGORIES.find(c => c.id === g.category)
-          const isHidden = boardHiddenCategories.value.has(g.category)
-          return html`
-            <button type="button"
-              class="v2-workspace-action px-2.5 py-1 rounded-[var(--r-1)] text-2xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer
-                ${isHidden
-                  ? 'bg-[var(--accent-12)] text-[var(--color-accent-fg)] border-[var(--accent-18)] line-through opacity-60'
-                  : 'bg-transparent text-[var(--color-fg-muted)] border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)]'
-                }"
-              onClick=${() => {
-                const next = new Set(boardHiddenCategories.value)
-                if (next.has(g.category)) next.delete(g.category)
-                else next.add(g.category)
-                boardHiddenCategories.value = next
-              }}
-            >
-              ${meta?.icon ?? ''} ${meta?.label ?? g.category} (${g.total})
-            </button>
-          `
-        })}
-        <button type="button"
-          class="v2-workspace-action px-2.5 py-1 rounded-[var(--r-1)] text-2xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer
-            ${boardExcludeAutomation.value
-              ? 'bg-[var(--accent-12)] text-[var(--color-accent-fg)] border-[var(--accent-18)]'
-              : 'bg-transparent text-[var(--color-fg-muted)] border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)]'
-            }"
-          aria-pressed=${boardExcludeAutomation.value}
-          aria-label="자동화 게시글 숨김 토글"
-          title="자동화 게시글 숨김 — direct/system 만 표시"
-          onClick=${() => {
-            boardExcludeAutomation.value = !boardExcludeAutomation.value
-            visibleLimit.value = PAGE_SIZE
-            automationVisibleLimit.value = PAGE_SIZE
-            systemVisibleLimit.value = PAGE_SIZE
-            refreshBoard()
-          }}
-        >
-          ${boardExcludeAutomation.value ? '🤖 숨김' : '🤖 자동화 포함'}
-        </button>
-        <${TextInput}
-          type="text"
-          placeholder="작성자"
-          ariaLabel="작성자 필터"
-          value=${boardAuthorFilter.value}
-          class="!bg-transparent !px-2.5 !py-1 !text-2xs !font-medium w-28"
-          onKeyDown=${(e: KeyboardEvent) => {
-            if (isSubmitEnter(e)) {
-              boardAuthorFilter.value = (e.target as HTMLInputElement).value.trim()
-              refreshBoard()
-            }
-          }}
-          onBlur=${(e: FocusEvent) => {
-            const val = (e.target as HTMLInputElement).value.trim()
-            if (val !== boardAuthorFilter.value) {
-              boardAuthorFilter.value = val
-              refreshBoard()
-            }
-          }}
-        />
-        <div class="ml-auto flex items-center gap-2">
-          ${selectedPostIds.value.size > 0 ? html`
-            <${ActionButton}
-              variant="danger"
-              size="md"
-              class="v2-workspace-action !px-3"
-              onClick=${bulkDeleteSelected}
-              disabled=${bulkDeleting.value}
-              ariaBusy=${bulkDeleting.value}
-              ariaLabel="선택한 게시글 일괄 삭제"
-            >
-              ${bulkDeleting.value ? '삭제 중...' : `선택 삭제 (${selectedPostIds.value.size})`}
-            <//>
-            <button type="button"
-              class="v2-workspace-action px-2 py-1 rounded-[var(--r-1)] text-2xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)]"
-              onClick=${() => { selectedPostIds.value = new Set() }}
-            >선택 해제</button>
-          ` : null}
-          <button type="button"
-            class="v2-workspace-action px-3 py-1 rounded-[var(--r-1)] text-2xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] disabled:opacity-50 disabled:cursor-not-allowed"
-            onClick=${refreshBoard}
-            disabled=${boardLoading.value}
-          >
-            ${boardLoading.value ? '새로고침 중...' : '새로고침'}
-          </button>
-        </div>
-      </div>
-    </div>
-  `
-}
-
 // ── Board summary stats (compact inline) ─────────────────────────
 function renderLatencyChip(label: string, metric: BoardLatencyMetric) {
   if (metric.last_latency_ms === null) return null
@@ -640,28 +285,44 @@ function BoardSummary() {
   `
 }
 
-// ── Post card (list item) ──────────────────────────────────────────
+// ── Author sigil (v2) ──────────────────────────────────────────────
+function BdAuthor({ name, size = 24 }: { name: string; size?: number }) {
+  const label = name.slice(0, 2).toUpperCase()
+  const isOperator = name.toLowerCase() === 'operator' || name.toLowerCase() === 'dashboard'
+  return html`<span class=${`bd-sigil ${isOperator ? 'op' : ''}`} style=${{ width: size, height: size }}>${label}</span>`
+}
+
+// ── State block chip (v2) ──────────────────────────────────────────
+function BdStateBlock({ block }: { block: ParsedStateBlock }) {
+  return html`
+    <div class="bd-stateblock" data-testid="bd-stateblock">
+      ${block.from ? html`<span class="sk">상태 전이</span><span class="sv">${block.from} → <span class="hl">${block.to}</span></span>` : null}
+      ${!block.from && block.to ? html`<span class="sk">다음 상태</span><span class="sv"><span class="hl">${block.to}</span></span>` : null}
+      ${block.ctx ? html`<span class="sk">컨텍스트</span><span class="sv">${block.ctx}</span>` : null}
+      ${block.action ? html`<span class="sk">조치</span><span class="sv">${block.action}</span>` : null}
+    </div>
+  `
+}
+
+// ── Post card (v2 list item) ───────────────────────────────────────
 function PostCard({ post }: { post: BoardPost }) {
-  const cat = contentCategory(post)
   const isDeleting = deletingPostId.value === post.id
   const previewBody = stripStateBlocks(post.body)
-  const richPreview = hasRichMarkdownSignals(previewBody)
   const authorLabel = boardActorDisplayName(post.author, post.author_identity)
   const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
   const authorTitle = boardActorTitle(post.author, post.author_identity)
-  const qualityPercent = contributorQualityPercent(post.contributor_quality)
-  const qualityBand = contributorQualityBandLabel(post.contributor_quality)
-  const qualityTitle = qualityPercent === null
-    ? undefined
-    : `기여자 품질 ${qualityPercent}점 · ${qualityBand}`
   const upvoteActive = post.current_vote === 'up'
   const downvoteActive = post.current_vote === 'down'
   const voteScoreLabel = post.vote_blind ? '투표 후 공개' : String(post.votes ?? 0)
   const voteScoreAria = post.vote_blind ? '점수 투표 후 공개' : `점수 ${post.votes ?? 0}`
-  const auditLabel = postVisibilityAuditLabel(post)
-  const auditDetails = postVisibilityAuditDetails(post)
-  const sortLabel = SORT_MODES.find(mode => mode.id === boardSortMode.value)?.label ?? boardSortMode.value
-  const reactionPreview = post.reactions?.some(summary => summary.count > 0 || summary.reacted || summary.has_reacted)
+  const stateBlock = getPostStateBlock(post)
+  const hasState = stateBlock !== null
+  const isMod = post.moderation_status && post.moderation_status !== 'none' && post.moderation_status !== 'approved'
+  const qualityPercent = contributorQualityPercent(post.contributor_quality)
+  const qualityTitle = qualityPercent === null
+    ? undefined
+    : `기여자 품질 ${qualityPercent}점`
+  const selected = selectedBoardPostId.value === post.id
 
   const handleVote = async (dir: 'up' | 'down', event: Event) => {
     event.stopPropagation()
@@ -708,7 +369,10 @@ function PostCard({ post }: { post: BoardPost }) {
     }
   }
 
-  const openPost = () => navigateToPost(post.id)
+  const openPost = () => {
+    selectedBoardPostId.value = post.id
+    void loadPostDetail(post.id)
+  }
   const handlePostKeyDown = (event: KeyboardEvent) => {
     if (event.key !== 'Enter' && event.key !== ' ') return
     event.preventDefault()
@@ -720,130 +384,43 @@ function PostCard({ post }: { post: BoardPost }) {
       role="button"
       tabIndex=${0}
       aria-label=${`게시글 열기: ${stripInlineMarkdown(post.title)}`}
-      class=${`board-post v2-workspace-row group w-full flex gap-3 rounded-[var(--r-1)] p-4 border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] hover:bg-[var(--color-bg-hover)] hover:border-[var(--color-border-strong)] transition-[background-color,border-color] duration-[var(--t-med)] cursor-pointer text-left ${ringFocusClasses()}`}
+      class=${`bd-post group ${selected ? 'sel' : ''} ${ringFocusClasses()}`}
+      data-testid=${`bd-post-${post.id}`}
       onClick=${openPost}
       onKeyDown=${handlePostKeyDown}
     >
-      <!-- Select checkbox -->
-      <div class="flex items-start pt-1">
+      <div class="bd-post-h">
+        <${BdAuthor} name=${authorAvatarKey} />
+        <a
+          class="who"
+          href=${`#monitoring/agents/${encodeURIComponent(post.author_identity?.raw ?? post.author)}`}
+          title=${authorTitle}
+          onClick=${(e: Event) => {
+            e.stopPropagation()
+            navigateToAuthor(post.author, e, post.author_identity)
+          }}
+        >${authorLabel}</a>
+        ${post.pinned ? html`<span class="bd-badge pin" title="고정된 게시글">고정</span>` : null}
+        ${hasState ? html`<span class="bd-badge state">상태 블록</span>` : null}
+        ${isMod ? html`<span class="bd-badge mod">모더레이션 대기</span>` : null}
+        ${post.flair ? html`<span class="bd-badge">flair:${post.flair}</span>` : null}
+        ${qualityPercent !== null ? html`<span class="bd-badge ${contributorQualityBadgeClass(post.contributor_quality)}" aria-label=${qualityTitle} title=${qualityTitle}>품질 ${qualityPercent}</span>` : null}
+        ${boardHearthFilter.value === '' && post.hearth ? html`<span class="bd-badge">${post.hearth}</span>` : null}
+        <span class="ts"><${TimeAgo} timestamp=${post.created_at} /></span>
         <${Checkbox}
           ariaLabel=${`게시글 선택: ${post.id}`}
-          class="!w-3.5 !h-3.5"
+          class="!w-3.5 !h-3.5 ml-1"
           checked=${selectedPostIds.value.has(post.id)}
           onClick=${(e: Event) => togglePostSelection(post.id, e)}
         />
       </div>
-
-      <!-- Vote column -->
-      <div class="flex flex-col items-center gap-0.5 pt-0.5 min-w-14">
-        <button type="button"
-          aria-label="추천"
-          aria-pressed=${upvoteActive ? 'true' : 'false'}
-          disabled=${upvoteActive}
-          class=${`vote-btn upvote v2-workspace-action w-7 h-5 flex items-center justify-center rounded-[var(--r-1)] text-2xs transition-colors border-0 bg-transparent ${upvoteActive ? 'active text-[var(--warn-bright)] bg-[var(--warn-10)] cursor-default' : 'text-[var(--color-fg-muted)] hover:text-[var(--warn-bright)] hover:bg-[var(--warn-10)] cursor-pointer'}`}
-          onClick=${(event: Event) => handleVote('up', event)}
-        ><span aria-hidden="true">▲</span></button>
-        <span
-          class=${post.vote_blind
-            ? 'max-w-14 text-center text-[10px] font-medium leading-tight text-[var(--color-fg-muted)]'
-            : 'text-sm font-bold tabular-nums text-[var(--color-fg-primary)]'}
-          aria-label=${voteScoreAria}
-          title=${voteScoreLabel}
-        >${voteScoreLabel}</span>
-        <button type="button"
-          aria-label="비추천"
-          aria-pressed=${downvoteActive ? 'true' : 'false'}
-          disabled=${downvoteActive}
-          class=${`vote-btn downvote v2-workspace-action w-7 h-5 flex items-center justify-center rounded-[var(--r-1)] text-2xs transition-colors border-0 bg-transparent ${downvoteActive ? 'active text-[var(--color-accent-fg)] bg-[var(--accent-10)] cursor-default' : 'text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] hover:bg-[var(--accent-10)] cursor-pointer'}`}
-          onClick=${(event: Event) => handleVote('down', event)}
-        ><span aria-hidden="true">▼</span></button>
+      <div class="bd-post-title">${stripInlineMarkdown(post.title)}</div>
+      ${stateBlock ? html`<${BdStateBlock} block=${stateBlock} />` : null}
+      <div class="bd-post-body">
+        <${RichContent} text=${previewBody} previewLimit=${1} />
       </div>
-
-      <!-- Post body -->
-      <div class="flex-1 min-w-0">
-        <!-- Title -->
-        <div class="text-md font-bold text-[var(--color-fg-primary)] leading-snug mb-1.5 group-hover:text-[var(--color-accent-fg)] transition-colors">${stripInlineMarkdown(post.title)}</div>
-
-        <!-- Content preview: rendered markdown, height-capped -->
-        <div class="board-post-preview text-sm text-[var(--color-fg-primary)] leading-paragraph mb-2.5 overflow-hidden relative ${richPreview ? 'max-h-[12rem]' : 'max-h-[4.8em]'}">
-          <${RichContent} text=${previewBody} class="board-post-preview__content" previewLimit=${1} />
-          <div class="absolute bottom-0 left-0 right-0 ${richPreview ? 'h-10' : 'h-6'} bg-gradient-to-t from-[var(--color-bg-elevated)] to-transparent pointer-events-none" />
-        </div>
-
-        <!-- Footer: author + meta + badges -->
-        <div class="flex items-center gap-2 flex-wrap">
-          <!-- Author line -->
-          <span class="text-xs text-[var(--color-fg-secondary)]">${authorAvatar(authorAvatarKey)}</span>
-          <a
-            class="text-xs font-medium text-[var(--color-fg-secondary)] hover:text-[var(--color-accent-fg)] transition-colors cursor-pointer"
-            href=${`#monitoring/agents/${encodeURIComponent(post.author_identity?.raw ?? post.author)}`}
-            title=${authorTitle}
-            onClick=${(e: Event) => {
-              e.preventDefault()
-              navigateToAuthor(post.author, e, post.author_identity)
-            }}
-          >${authorLabel}</a>
-          <span class="text-2xs text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>
-          ${isUpdated(post) ? html`<span class="text-2xs text-[var(--color-fg-disabled)]">(수정됨)</span>` : null}
-
-          <!-- Separator -->
-          <span class="text-[var(--color-fg-disabled)]">|</span>
-
-          <!-- Counts -->
-          <span class="text-2xs text-[var(--color-fg-secondary)]">댓글 ${post.comment_count}</span>
-
-          <!-- Category badges -->
-          ${post.pinned ? html`<span class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-[var(--r-1)] text-2xs font-medium border bg-[var(--accent-10)] text-[var(--color-accent-fg)] border-[var(--accent-20)]" title="고정된 게시글">📌 고정</span>` : null}
-          <span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-2xs font-medium border ${categoryBadgeColor(cat)}">${categoryLabel(cat)}</span>
-          ${post.flair ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-2xs font-medium border bg-[var(--cyan-16)] text-[var(--color-accent-fg)] border-[var(--cyan-16)]">flair:${post.flair}</span>` : null}
-          ${qualityPercent !== null ? html`
-            <span
-              class=${`inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-2xs font-medium border ${contributorQualityBadgeClass(post.contributor_quality)}`}
-              aria-label=${qualityTitle}
-              title=${qualityTitle}
-            >품질 ${qualityPercent}</span>
-          ` : null}
-          ${post.hearth ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-2xs font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
-          ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-2xs font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
-          <${ModerationBadge} status=${post.moderation_status} reportCount=${post.report_count} targetLabel="게시글" />
-
-          <!-- Pin toggle (owner-gated server-side) + delete — reveal on row hover -->
-          <${ActionButton}
-            variant="ghost"
-            size="sm"
-            class="v2-workspace-action ml-auto !py-0.5 opacity-0 group-hover:opacity-100"
-            onClick=${handlePin}
-            pressed=${post.pinned ?? false}
-            ariaLabel=${post.pinned ? `고정 해제: ${post.id}` : `고정: ${post.id}`}
-          >
-            ${post.pinned ? '고정 해제' : '고정'}
-          <//>
-          <${ActionButton}
-            variant="danger"
-            size="sm"
-            class="v2-workspace-action !py-0.5 opacity-0 group-hover:opacity-100"
-            onClick=${handleDelete}
-            disabled=${isDeleting}
-            ariaBusy=${isDeleting}
-            ariaLabel=${`게시글 삭제: ${post.id}`}
-          >
-            ${isDeleting ? '삭제 중...' : '삭제'}
-          <//>
-        </div>
-        <div
-          class="mt-2 flex items-center gap-1.5 flex-wrap text-2xs text-[var(--color-fg-secondary)]"
-          aria-label=${`게시글 표시 감사: ${auditLabel}; 현재 정렬 ${sortLabel}`}
-          title=${`${auditLabel} · 현재 정렬 ${sortLabel}`}
-        >
-          <span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] border border-[var(--ok-30)] bg-[var(--ok-soft)] text-[var(--color-status-ok)] font-medium">표시 중</span>
-          <span>${auditDetails}</span>
-          <span class="text-[var(--color-fg-muted)]">· 정렬 ${sortLabel}</span>
-        </div>
-        <div
-          class=${reactionPreview ? 'mt-2' : 'mt-2 opacity-75 transition-opacity group-hover:opacity-100'}
-          onClick=${(event: Event) => event.stopPropagation()}
-          onKeyDown=${(event: KeyboardEvent) => event.stopPropagation()}
-        >
+      <div class="bd-post-foot">
+        <div onClick=${(event: Event) => event.stopPropagation()} onKeyDown=${(event: KeyboardEvent) => event.stopPropagation()}>
           <${ReactionBar}
             targetType="post"
             targetId=${post.id}
@@ -851,8 +428,357 @@ function PostCard({ post }: { post: BoardPost }) {
             initialSummaries=${post.reactions ?? []}
           />
         </div>
+        <span class="karma" aria-label=${voteScoreAria} title=${voteScoreLabel}>karma <b>${voteScoreLabel}</b></span>
+        <button type="button"
+          aria-label="추천"
+          aria-pressed=${upvoteActive ? 'true' : 'false'}
+          disabled=${upvoteActive}
+          class="bd-react ${upvoteActive ? 'mine' : ''}"
+          onClick=${(event: Event) => handleVote('up', event)}
+        >▲</button>
+        <button type="button"
+          aria-label="비추천"
+          aria-pressed=${downvoteActive ? 'true' : 'false'}
+          disabled=${downvoteActive}
+          class="bd-react ${downvoteActive ? 'mine' : ''}"
+          onClick=${(event: Event) => handleVote('down', event)}
+        >▼</button>
+        <span class="replies">답글 ${post.comment_count}</span>
+        <span class="ml-auto hidden group-hover:inline-flex items-center gap-1">
+          <${ActionButton}
+            variant="ghost"
+            size="sm"
+            class="v2-workspace-action !py-0.5"
+            onClick=${handlePin}
+            pressed=${post.pinned ?? false}
+            ariaLabel=${post.pinned ? `고정 해제: ${post.id}` : `고정: ${post.id}`}
+          >${post.pinned ? '고정 해제' : '고정'}<//>
+          <${ActionButton}
+            variant="danger"
+            size="sm"
+            class="v2-workspace-action !py-0.5"
+            onClick=${handleDelete}
+            disabled=${isDeleting}
+            ariaBusy=${isDeleting}
+            ariaLabel=${`게시글 삭제: ${post.id}`}
+          >${isDeleting ? '삭제 중...' : '삭제'}<//>
+        </span>
       </div>
     </article>
+  `
+}
+
+// ── v2 board chrome ────────────────────────────────────────────────
+const SUB_BOARD_GLYPHS: Record<string, string> = {
+  all: '＃',
+  ops: '⚙',
+  review: '⚖',
+  notice: '▣',
+  default: '＃',
+}
+
+function BdRail({ activeSub, onSub, onMentions }: {
+  activeSub: string
+  onSub: (sub: string) => void
+  onMentions: () => void
+}) {
+  const hearths = boardHearths.value
+  const allCount = boardPosts.value.length
+  const modCount = boardPosts.value.filter(p => p.moderation_status && p.moderation_status !== 'none' && p.moderation_status !== 'approved').length
+
+  return html`
+    <nav class="bd-rail" aria-label="서브보드">
+      <h4>서브보드</h4>
+      <button
+        type="button"
+        class=${`bd-sub ${activeSub === '' ? 'on' : ''}`}
+        onClick=${() => onSub('')}
+        data-testid="bd-sub-all"
+      >
+        <span class="glyph">${SUB_BOARD_GLYPHS.all}</span>
+        <span style=${{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>전체</span>
+        <span class="n">${allCount}</span>
+      </button>
+      ${hearths.map(hearth => html`
+        <button
+          key=${hearth.name}
+          type="button"
+          class=${`bd-sub ${activeSub === hearth.name ? 'on' : ''}`}
+          onClick=${() => onSub(hearth.name)}
+          data-testid=${`bd-sub-${hearth.name}`}
+        >
+          <span class="glyph">${SUB_BOARD_GLYPHS[hearth.name] ?? SUB_BOARD_GLYPHS.default}</span>
+          <span style=${{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>${hearth.name}</span>
+          <span class="n">${hearth.count}</span>
+        </button>
+      `)}
+      <div class="div"></div>
+      <h4>큐</h4>
+      <button type="button" class="bd-sub" onClick=${() => { boardFilterMode.value = 'mod'; onMentions() }} data-testid="bd-queue-mod">
+        <span class="glyph">⚑</span>
+        모더레이션
+        <span class="n">${modCount}</span>
+      </button>
+      <button type="button" class="bd-sub" onClick=${onMentions} data-testid="bd-queue-mentions">
+        <span class="glyph">＠</span>
+        멘션 인박스
+        <span class="n">${boardPosts.value.length}</span>
+      </button>
+    </nav>
+  `
+}
+
+function BdFeedHead({ activeFilter, onFilter, count }: {
+  activeFilter: 'all' | 'state' | 'mod'
+  onFilter: (filter: 'all' | 'state' | 'mod') => void
+  count: number
+}) {
+  const activeHearth = boardHearthFilter.value
+  const title = activeHearth === '' ? '전체 피드' : `#${activeHearth}`
+  const filters: Array<{ key: 'all' | 'state' | 'mod'; label: string }> = [
+    { key: 'all', label: '전체' },
+    { key: 'state', label: '상태 블록' },
+    { key: 'mod', label: '모더레이션' },
+  ]
+
+  return html`
+    <div class="bd-feed-head">
+      <h2>${title}</h2>
+      <span class="ns">${count}개 포스트</span>
+      <span class="spacer"></span>
+      ${filters.map(f => html`
+        <button
+          key=${f.key}
+          type="button"
+          class=${`bd-filter ${activeFilter === f.key ? 'on' : ''}`}
+          onClick=${() => onFilter(f.key)}
+          data-testid=${`bd-filter-${f.key}`}
+        >${f.label}</button>
+      `)}
+    </div>
+  `
+}
+
+function BdThreadDetail({ post, onClose }: { post: BoardPost; onClose: () => void }) {
+  useEffect(() => {
+    if (detailPostId.value !== post.id) {
+      void loadPostDetail(post.id)
+    }
+  }, [post.id])
+
+  const authorLabel = boardActorDisplayName(post.author, post.author_identity)
+  const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
+
+  return html`
+    <aside class="bd-detail" data-testid="bd-thread-detail">
+      <div class="bd-detail-h">
+        <h3>스레드</h3>
+        <button type="button" class="bd-detail-x" onClick=${onClose} aria-label="닫기">✕</button>
+      </div>
+      <div class="bd-detail-scroll">
+        <div class="bd-th">
+          <${BdAuthor} name=${authorAvatarKey} size=${26} />
+          <div>
+            <div class="bd-th-hd"><span class="who">${authorLabel}</span><span class="ts"><${TimeAgo} timestamp=${post.created_at} /></span></div>
+            <div class="bd-th-body">
+              <div class="text-sm font-semibold mb-1">${stripInlineMarkdown(post.title)}</div>
+              <${RichContent} text=${stripStateBlocks(post.body)} previewLimit=${4} />
+            </div>
+          </div>
+        </div>
+        ${detailLoading.value
+          ? html`<${LoadingState}>댓글 불러오는 중...<//>`
+          : html`<${CommentThread} comments=${detailComments.value} postId=${post.id} />`}
+        <${CommentForm} postId=${post.id} />
+      </div>
+    </aside>
+  `
+}
+
+function BdDetail({ post, onClose }: { post: BoardPost | null; onClose: () => void }) {
+  if (post) return html`<${BdThreadDetail} post=${post} onClose=${onClose} />`
+  return html`
+    <aside class="bd-detail" data-testid="bd-mention-detail">
+      <div class="bd-detail-h"><h3>멘션 인박스</h3></div>
+      <div class="bd-detail-scroll">
+        <${MentionInboxPanel} />
+      </div>
+    </aside>
+  `
+}
+
+function BdComposer() {
+  const mode = boardComposerMode.value
+  const [localTitle, setLocalTitle] = useState('')
+  const [localBody, setLocalBody] = useState('')
+  const [localHearth, setLocalHearth] = useState(boardHearthFilter.value)
+  const [localFlair, setLocalFlair] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (boardHearthFilter.value !== localHearth) {
+      setLocalHearth(boardHearthFilter.value)
+    }
+  }, [boardHearthFilter.value])
+
+  const tabs: Array<{ key: 'post' | 'mention' | 'state'; label: string }> = [
+    { key: 'post', label: '게시' },
+    { key: 'mention', label: '멘션' },
+    { key: 'state', label: '상태 블록' },
+  ]
+
+  const placeholder = mode === 'post'
+    ? `${boardHearthFilter.value ? `#${boardHearthFilter.value}` : '보드'}에 게시…`
+    : mode === 'mention'
+      ? '@keeper 를 멘션해 직접 지시…'
+      : '상태 블록 발행 — 상태 키:값 형식'
+
+  const composerMode: ComposerV2Mode = mode === 'post' ? 'broadcast' : mode === 'mention' ? 'dm' : 'state-block'
+
+  async function submitPost(event?: Event): Promise<void> {
+    event?.stopPropagation()
+    const title = localTitle.trim()
+    const body = localBody.trim()
+    if (!title || !body) return
+    setSubmitting(true)
+    try {
+      const contentWithFlair = localFlair
+        ? `[flair:${localFlair}]\n${body.replace(/^\[flair:[a-z]+\]\s*/i, '')}`
+        : body
+      await createPost(title, contentWithFlair, 'dashboard-user', { hearth: localHearth || undefined })
+      setLocalTitle('')
+      setLocalBody('')
+      setLocalFlair('')
+      showToast('글을 등록했습니다', 'success')
+      refreshBoard()
+    } catch (err) {
+      console.warn('[board] post submit failed', err instanceof Error ? err.message : err)
+      showToast('글 등록에 실패했습니다', 'error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return html`
+    <div class="bd-composer" data-testid="bd-composer">
+      <div class="bd-comp-tabs" role="tablist" aria-label="Composer mode">
+        ${tabs.map(tab => html`
+          <button
+            key=${tab.key}
+            type="button"
+            role="tab"
+            aria-selected=${mode === tab.key ? 'true' : 'false'}
+            class=${`bd-comp-tab ${mode === tab.key ? 'on' : ''}`}
+            onClick=${() => { boardComposerMode.value = tab.key }}
+            data-testid=${`bd-comp-tab-${tab.key}`}
+          >${tab.label}</button>
+        `)}
+      </div>
+      ${mode === 'post' ? html`
+        <div class="bd-comp-box grid gap-2">
+          <input
+            type="text"
+            class="bg-transparent border-0 outline-0 text-[var(--text-bright)] text-sm placeholder:text-[var(--text-dim)]"
+            placeholder="제목"
+            value=${localTitle}
+            onInput=${(e: Event) => setLocalTitle((e.target as HTMLInputElement).value)}
+            data-testid="bd-composer-title"
+          />
+          <textarea
+            rows=${2}
+            class="bg-transparent border-0 outline-0 text-[var(--text-bright)] text-sm placeholder:text-[var(--text-dim)] resize-none"
+            placeholder=${placeholder}
+            value=${localBody}
+            onInput=${(e: Event) => setLocalBody((e.target as HTMLTextAreaElement).value)}
+            data-testid="bd-composer-body"
+          />
+          <div class="flex gap-2">
+            <${Select}
+              value=${localHearth}
+              options=${[{ value: '', label: 'No category' }, ...boardHearths.value.map(h => ({ value: h.name, label: h.name }))]}
+              ariaLabel="게시 category"
+              onInput=${(value: string) => setLocalHearth(value)}
+            />
+            <${Select}
+              value=${localFlair}
+              options=${[{ value: '', label: 'No flair' }, ...boardFlairs.value.map(f => ({ value: f.name, label: `${f.emoji ? `${f.emoji} ` : ''}${f.label}` }))]}
+              ariaLabel="게시 flair"
+              onInput=${(value: string) => setLocalFlair(value)}
+            />
+            <button
+              type="button"
+              class="send ml-auto"
+              disabled=${!localTitle.trim() || !localBody.trim() || submitting}
+              onClick=${(e: Event) => { void submitPost(e) }}
+              data-testid="bd-composer-send"
+            >${submitting ? '등록 중...' : '게시 ↑'}</button>
+          </div>
+        </div>
+      ` : html`
+        <div class="bd-comp-box">
+          <${ComposerV2}
+            workspaceId=${localHearth || 'default'}
+            mode=${composerMode}
+            showModeSelector=${false}
+            modeLabels=${{ broadcast: '게시', dm: '멘션', 'state-block': '상태 블록' }}
+          />
+        </div>
+      `}
+    </div>
+  `
+}
+
+function BdFeed({ posts }: { posts: BoardPost[] }) {
+  const [contentQuery, setContentQuery] = useState('')
+  const filteredPosts = useMemo(
+    () => filterBoardPosts(posts, contentQuery),
+    [posts, contentQuery],
+  )
+  const isFiltering = contentQuery.trim() !== ''
+  const visibleGroups = splitVisiblePosts(filteredPosts)
+
+  const modeFilteredGroups = visibleGroups.groups.map(g => ({
+    ...g,
+    posts: g.posts.filter(post => {
+      if (boardFilterMode.value === 'state') return postHasStateBlock(post)
+      if (boardFilterMode.value === 'mod') return post.moderation_status && post.moderation_status !== 'none' && post.moderation_status !== 'approved'
+      return true
+    }),
+  }))
+  const filteredByMode = modeFilteredGroups.flatMap(g => g.posts)
+
+  return html`
+    <section class="bd-feed">
+      <${BdFeedHead}
+        activeFilter=${boardFilterMode.value}
+        onFilter=${(filter: 'all' | 'state' | 'mod') => { boardFilterMode.value = filter }}
+        count=${filteredByMode.length}
+      />
+      <div class="bd-list">
+        <div class="mb-3 flex items-center gap-2">
+          <${TextInput}
+            type="search"
+            value=${contentQuery}
+            placeholder="제목/본문에서 검색"
+            ariaLabel="게시글 본문 필터"
+            onInput=${(e: Event) => setContentQuery((e.target as HTMLInputElement).value)}
+            class="min-w-45 max-w-80 flex-1 !px-2 !py-1 !text-xs"
+          />
+        </div>
+        ${isFiltering && filteredByMode.length === 0 && posts.length > 0
+          ? html`<div class="bd-empty">필터 결과 없음 (${posts.length} items)</div>`
+          : filteredByMode.length === 0 && boardLoading.value
+            ? html`<${LoadingState}>게시판 불러오는 중...<//>`
+            : filteredByMode.length === 0
+              ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
+              : modeFilteredGroups.map(g =>
+                  g.posts.length > 0
+                    ? html`<${CategorySection} key=${g.category} group=${{ category: g.category, posts: g.posts, total: g.total, hidden: g.hidden }} />`
+                    : null,
+                )}
+      </div>
+      <${BdComposer} />
+    </section>
   `
 }
 
@@ -868,16 +794,8 @@ export function BoardSurface() {
   useEffect(() => {
     if (boardFlairs.value.length === 0) void refreshBoardFlairs()
   }, [])
-  const [contentQuery, setContentQuery] = useState('')
-  const rawPosts = boardPosts.value
-  const filteredPosts = useMemo(
-    () => filterBoardPosts(rawPosts, contentQuery),
-    [rawPosts, contentQuery],
-  )
-  const isFiltering = contentQuery.trim() !== ''
-  const grouped = splitVisiblePosts(filteredPosts)
+  const grouped = splitVisiblePosts(boardPosts.value)
   const posts = grouped.groups.flatMap(g => g.posts)
-  const hint = filterHint(grouped)
   const focus = route.value.params.focus ?? null
   const postId = route.value.params.post ?? null
   const post = postId
@@ -955,40 +873,26 @@ export function BoardSurface() {
     `
   }
 
+  const activeSub = boardHearthFilter.value
+  const selectedPost = selectedBoardPostId.value
+    ? posts.find(p => p.id === selectedBoardPostId.value) ?? null
+    : null
+
   return html`
-    <div class="v2-workspace-surface">
-      <${BoardSummary} />
-      <${SortBar} />
-      ${hint ? html`
-        <div class="v2-workspace-panel mb-4 px-3 py-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-xs text-[var(--color-fg-muted)]">
-          ${hint}
-        </div>
-      ` : null}
-      <div class="mb-4">
-        <${NewPostForm} />
-      </div>
-      <div class="mb-3 flex items-center gap-2">
-        <${TextInput}
-          type="search"
-          value=${contentQuery}
-          placeholder="제목/본문에서 검색"
-          ariaLabel="게시글 본문 필터"
-          onInput=${(e: Event) => setContentQuery((e.target as HTMLInputElement).value)}
-          class="min-w-45 max-w-80 flex-1 !px-2 !py-1 !text-xs"
+    <div class="v2-board-surface">
+      <div class=${`bd-body ${selectedPost ? '' : 'no-detail'}`}>
+        <${BdRail}
+          activeSub=${activeSub}
+          onSub=${(sub: string) => {
+            boardHearthFilter.value = sub
+            selectedBoardPostId.value = null
+            refreshBoard()
+          }}
+          onMentions=${() => { selectedBoardPostId.value = null }}
         />
+        <${BdFeed} posts=${boardPosts.value} />
+        ${selectedPost ? html`<${BdDetail} post=${selectedPost} onClose=${() => { selectedBoardPostId.value = null }} />` : null}
       </div>
-      ${isFiltering && posts.length === 0 && rawPosts.length > 0
-        ? html`<div class="py-4 text-center text-xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${rawPosts.length} items)</div>`
-          : posts.length === 0 && boardLoading.value
-          ? html`<${LoadingState}>게시판 불러오는 중...<//>`
-          : posts.length === 0
-            ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
-            : html`
-                ${boardLoading.value ? html`<div class="mb-2 text-2xs text-[var(--color-fg-muted)] animate-pulse">업데이트 중...</div>` : null}
-                ${grouped.groups.map(g => html`
-                  <${CategorySection} key=${g.category} group=${g} />
-                `)}
-              `}
     </div>
   `
 }

--- a/dashboard/src/components/board/composer-v2.ts
+++ b/dashboard/src/components/board/composer-v2.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useCallback, useEffect, useState } from 'preact/hooks'
 import { AtSign, Braces, Megaphone, Send, UserRound } from 'lucide-preact'
 import { currentDashboardActor, sendBroadcast } from '../../api'
 import {
@@ -98,8 +98,29 @@ export function buildComposerV2Request(input: {
   }
 }
 
-export function ComposerV2({ workspaceId }: { workspaceId?: string | null }) {
-  const [mode, setMode] = useState<ComposerV2Mode>('broadcast')
+interface ComposerV2Props {
+  workspaceId?: string | null
+  mode?: ComposerV2Mode
+  onModeChange?: (mode: ComposerV2Mode) => void
+  showModeSelector?: boolean
+  modeLabels?: Partial<Record<ComposerV2Mode, string>>
+}
+
+export function ComposerV2({
+  workspaceId,
+  mode: controlledMode,
+  onModeChange,
+  showModeSelector = true,
+  modeLabels = {},
+}: ComposerV2Props) {
+  const [internalMode, setInternalMode] = useState<ComposerV2Mode>(controlledMode ?? 'broadcast')
+  const mode = controlledMode ?? internalMode
+  const setMode = useCallback((next: ComposerV2Mode) => {
+    if (controlledMode === undefined) {
+      setInternalMode(next)
+    }
+    onModeChange?.(next)
+  }, [controlledMode, onModeChange])
   const [draft, setDraft] = useState('')
   const [keeperTarget, setKeeperTarget] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -197,27 +218,30 @@ export function ComposerV2({ workspaceId }: { workspaceId?: string | null }) {
   return html`
     <section class="v2-workspace-panel rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-3" aria-label="Composer v2">
       <div class="flex flex-wrap items-center gap-2">
-        <div class="inline-flex rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-0.5" role="group" aria-label="Composer v2 mode">
-          ${MODE_OPTIONS.map(option => {
-            const selected = mode === option.value
-            const Icon = modeIcon(option.value)
-            return html`
-              <${ActionButton}
-                variant="ghost"
-                size="sm"
-                pressed=${selected}
-                ariaLabel=${`${option.label} mode`}
-                title=${option.description}
-                onClick=${() => { chooseMode(option.value) }}
-                disabled=${busy}
-                class="inline-flex items-center gap-1.5"
-              >
-                <${Icon} size=${13} aria-hidden="true" />
-                ${option.label}
-              <//>
-            `
-          })}
-        </div>
+        ${showModeSelector ? html`
+          <div class="inline-flex rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-0.5" role="group" aria-label="Composer v2 mode">
+            ${MODE_OPTIONS.map(option => {
+              const selected = mode === option.value
+              const Icon = modeIcon(option.value)
+              const label = modeLabels[option.value] ?? option.label
+              return html`
+                <${ActionButton}
+                  variant="ghost"
+                  size="sm"
+                  pressed=${selected}
+                  ariaLabel=${`${label} mode`}
+                  title=${option.description}
+                  onClick=${() => { chooseMode(option.value) }}
+                  disabled=${busy}
+                  class="inline-flex items-center gap-1.5"
+                >
+                  <${Icon} size=${13} aria-hidden="true" />
+                  ${label}
+                <//>
+              `
+            })}
+          </div>
+        ` : null}
         <span class="inline-flex items-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1 text-2xs font-medium text-[var(--color-fg-muted)]" aria-label=${`Target workspace: ${workspace}`}>
           #${workspace}
         </span>

--- a/dashboard/src/components/board/mention-inbox.ts
+++ b/dashboard/src/components/board/mention-inbox.ts
@@ -233,3 +233,36 @@ export function MentionInbox() {
     </section>
   `
 }
+
+/** Compact mention inbox for the board v2 right-hand detail rail. */
+export function MentionInboxPanel() {
+  const actorName = currentDashboardActorName()
+  const targetCandidates = mentionTargetCandidates(shellAuthSummary.value, actorName)
+  const targetKey = targetCandidates.join('|')
+  const model = useMemo(
+    () => buildMentionInboxModel(messages.value, targetCandidates),
+    [targetKey, messages.value],
+  )
+  const total = model.forMe.length + model.others.length
+
+  if (total === 0) {
+    return html`<${EmptyState} message="멘션 메시지가 없습니다" compact />`
+  }
+
+  return html`
+    <div class="bd-mention-panel" data-testid="bd-mention-panel">
+      <div class="bd-mention-stats">
+        <div class="bd-mention-stat">
+          <div class="k">For me</div>
+          <div class="v">${model.forMe.length}</div>
+        </div>
+        <div class="bd-mention-stat">
+          <div class="k">Others</div>
+          <div class="v">${model.others.length}</div>
+        </div>
+      </div>
+      <${MentionLane} title="For me" rows=${model.forMe} emptyMessage="현재 actor 대상 멘션이 없습니다" />
+      <${MentionLane} title="Other mentions" rows=${model.others} emptyMessage="다른 대상 멘션이 없습니다" />
+    </div>
+  `
+}

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -489,7 +489,7 @@ function CommentRouteFocusPanel({
 }
 
 // ── Comment form ───────────────────────────────────────────────────
-function CommentForm({ postId }: { postId: string }) {
+export function CommentForm({ postId }: { postId: string }) {
   return html`
     <div class="mt-4">
       <${RichComposer}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -30,6 +30,7 @@ import './styles/chat-blocks-v2.css'
 // Component-specific styles
 import './styles/ui.css'
 import './styles/board.css'
+import './styles/board-v2.css'
 /* chat.css: styles merged into global.css @utility blocks (#3915) */
 import './styles/dashboard.css'
 import './styles/governance.css'

--- a/dashboard/src/styles/board-v2.css
+++ b/dashboard/src/styles/board-v2.css
@@ -1,0 +1,673 @@
+/* MASC keeper-v2 — Board surface layout and chrome.
+   Scoped under .v2-board-surface so legacy board.css utilities stay intact.
+   Token bridge lives in variables.css. */
+
+/* ════ SHELL ════ */
+.v2-board-surface {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: var(--bg-deep);
+}
+
+.v2-board-surface .bd-body {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 200px minmax(0, 1fr) minmax(290px, 360px);
+}
+
+.v2-board-surface .bd-body.no-detail {
+  grid-template-columns: 200px minmax(0, 1fr);
+}
+
+/* ════ LEFT RAIL (sub-boards + queues) ════ */
+.v2-board-surface .bd-rail {
+  border-right: 1px solid var(--border-main);
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%);
+  padding: 14px 9px;
+  overflow-y: auto;
+  min-width: 0;
+}
+
+.v2-board-surface .bd-rail h4 {
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin: 0 0 8px 7px;
+  font-weight: 500;
+}
+
+.v2-board-surface .bd-sub {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  padding: 7px 9px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  background: none;
+  color: var(--text-mid);
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  cursor: pointer;
+  transition: 0.13s;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.v2-board-surface .bd-sub:hover {
+  background: var(--bg-card);
+  color: var(--text-bright);
+}
+
+.v2-board-surface .bd-sub.on {
+  background: var(--bg-card);
+  color: var(--volt-strong);
+  border-color: var(--volt-dim);
+}
+
+.v2-board-surface .bd-sub .glyph {
+  font-size: 11px;
+  color: var(--text-dim);
+  width: 13px;
+  text-align: center;
+  flex: none;
+}
+
+.v2-board-surface .bd-sub.on .glyph {
+  color: var(--volt-strong);
+}
+
+.v2-board-surface .bd-sub .n {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  flex: none;
+}
+
+.v2-board-surface .bd-sub .unread {
+  margin-left: auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--volt);
+  box-shadow: 0 0 7px var(--volt-glow);
+  flex: none;
+}
+
+.v2-board-surface .bd-rail .div {
+  height: 1px;
+  background: var(--border-soft);
+  margin: 12px 4px;
+}
+
+/* ════ FEED ════ */
+.v2-board-surface .bd-feed {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.v2-board-surface .bd-feed-head {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 18px;
+  border-bottom: 1px solid var(--border-main);
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+}
+
+.v2-board-surface .bd-feed-head h2 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--text-bright);
+  margin: 0;
+  white-space: nowrap;
+}
+
+.v2-board-surface .bd-feed-head .ns {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-dim);
+}
+
+.v2-board-surface .bd-feed-head .spacer {
+  flex: 1;
+}
+
+.v2-board-surface .bd-filter {
+  font-family: var(--font-ui);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-main);
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: 0.14s;
+  white-space: nowrap;
+}
+
+.v2-board-surface .bd-filter.on {
+  color: var(--volt-ink);
+  background: var(--volt);
+  border-color: var(--volt);
+  font-weight: 600;
+}
+
+.v2-board-surface .bd-filter:not(.on):hover {
+  color: var(--text-mid);
+  border-color: var(--border-highlight);
+}
+
+.v2-board-surface .bd-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.v2-board-surface .bd-list::-webkit-scrollbar {
+  width: 9px;
+}
+
+.v2-board-surface .bd-list::-webkit-scrollbar-thumb {
+  background: var(--border-main);
+  border-radius: var(--radius-md);
+}
+
+/* ════ POST CARD ════ */
+.v2-board-surface .bd-post {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  padding: var(--pad-card);
+  cursor: pointer;
+  transition: 0.14s;
+}
+
+.v2-board-surface .bd-post:hover {
+  border-color: var(--border-highlight);
+  background: var(--bg-card);
+}
+
+.v2-board-surface .bd-post.sel {
+  border-color: var(--volt-dim);
+  box-shadow: inset 0 0 0 1px var(--volt-wash);
+  background: var(--bg-card);
+}
+
+.v2-board-surface .bd-post-h {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.v2-board-surface .bd-post-h .who {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 12.5px;
+  color: var(--text-bright);
+}
+
+.v2-board-surface .bd-post-h .ts {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-left: auto;
+  flex: none;
+}
+
+.v2-board-surface .bd-badge {
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: var(--radius-xs);
+  border: 1px solid var(--border-main);
+  color: var(--text-dim);
+  background: var(--bg-deep);
+  white-space: nowrap;
+  flex: none;
+}
+
+.v2-board-surface .bd-badge.state {
+  color: var(--info);
+  border-color: color-mix(in oklab, var(--info) 35%, transparent);
+}
+
+.v2-board-surface .bd-badge.pin {
+  color: var(--volt-strong);
+  border-color: var(--volt-dim);
+}
+
+.v2-board-surface .bd-badge.mod {
+  color: var(--status-warn);
+  border-color: color-mix(in oklab, var(--status-warn) 40%, transparent);
+}
+
+.v2-board-surface .bd-post-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-bright);
+  margin-top: 8px;
+  line-height: 1.4;
+}
+
+.v2-board-surface .bd-post-body {
+  font-size: 12.5px;
+  color: var(--text-mid);
+  line-height: 1.55;
+  margin-top: 5px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.v2-board-surface .bd-post-body code,
+.v2-board-surface .bd-th-body code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-soft);
+  padding: 0 4px;
+  border-radius: var(--radius-xs);
+  color: var(--volt-strong);
+}
+
+.v2-board-surface .bd-post-body .mention,
+.v2-board-surface .bd-th-body .mention {
+  color: var(--info);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.v2-board-surface .bd-post-foot {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 10px;
+}
+
+.v2-board-surface .bd-react {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-soft);
+  background: var(--bg-deep);
+  color: var(--text-mid);
+  cursor: pointer;
+  transition: 0.13s;
+}
+
+.v2-board-surface .bd-react:hover {
+  border-color: var(--volt-dim);
+  color: var(--volt-strong);
+}
+
+.v2-board-surface .bd-react.mine {
+  border-color: var(--volt-dim);
+  background: var(--volt-wash);
+  color: var(--volt-strong);
+}
+
+.v2-board-surface .bd-post-foot .replies {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-dim);
+}
+
+.v2-board-surface .bd-post-foot .karma {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.v2-board-surface .bd-post-foot .karma b {
+  color: var(--volt-strong);
+  font-weight: 600;
+}
+
+/* State block post */
+.v2-board-surface .bd-stateblock {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 14px;
+  margin-top: 9px;
+  padding: 9px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-sunken);
+  border: 1px dashed var(--border-main);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.v2-board-surface .bd-stateblock .sk {
+  color: var(--text-dim);
+}
+
+.v2-board-surface .bd-stateblock .sv {
+  color: var(--text-mid);
+}
+
+.v2-board-surface .bd-stateblock .sv.hl {
+  color: var(--info);
+}
+
+/* ════ COMPOSER ════ */
+.v2-board-surface .bd-composer {
+  flex: none;
+  border-top: 1px solid var(--border-main);
+  background: linear-gradient(0deg, var(--bg-panel), var(--bg-deep));
+  padding: 10px 18px 14px;
+}
+
+.v2-board-surface .bd-comp-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.v2-board-surface .bd-comp-tab {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  padding: 4px 11px;
+  border-radius: 4px 4px 0 0;
+  border: 1px solid transparent;
+  background: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.v2-board-surface .bd-comp-tab.on {
+  color: var(--volt-strong);
+  border-color: var(--border-main);
+  border-bottom-color: var(--bg-deep);
+  background: var(--bg-card);
+}
+
+.v2-board-surface .bd-comp-box {
+  display: flex;
+  gap: 10px;
+  align-items: flex-end;
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  padding: 5px 5px 5px 13px;
+}
+
+.v2-board-surface .bd-comp-box:focus-within {
+  border-color: var(--volt-dim);
+  box-shadow: 0 0 0 3px var(--volt-wash);
+}
+
+.v2-board-surface .bd-comp-box textarea {
+  flex: 1;
+  resize: none;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text-bright);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  line-height: 1.5;
+  padding: 8px 0;
+  min-height: 21px;
+  max-height: 120px;
+}
+
+.v2-board-surface .bd-comp-box textarea::placeholder {
+  color: var(--text-dim);
+}
+
+.v2-board-surface .bd-comp-box .send {
+  flex: none;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--volt-dim);
+  background: var(--volt-wash);
+  color: var(--volt-strong);
+  cursor: pointer;
+  transition: 0.13s;
+}
+
+.v2-board-surface .bd-comp-box .send:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.v2-board-surface .bd-comp-box .send:not(:disabled):hover {
+  background: var(--volt);
+  color: var(--volt-ink);
+}
+
+/* ════ DETAIL RAIL (thread + mention inbox) ════ */
+.v2-board-surface .bd-detail {
+  border-left: 1px solid var(--border-main);
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.v2-board-surface .bd-detail-h {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.v2-board-surface .bd-detail-h h3 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-mid);
+  margin: 0;
+  flex: 1;
+}
+
+.v2-board-surface .bd-detail-x {
+  background: none;
+  border: 0;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 3px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.v2-board-surface .bd-detail-x:hover {
+  color: var(--text-bright);
+  background: var(--bg-card);
+}
+
+.v2-board-surface .bd-detail-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+
+.v2-board-surface .bd-th {
+  display: grid;
+  grid-template-columns: 26px 1fr;
+  gap: 9px;
+}
+
+.v2-board-surface .bd-th-hd {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+}
+
+.v2-board-surface .bd-th-hd .who {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--text-bright);
+}
+
+.v2-board-surface .bd-th-hd .ts {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-dim);
+}
+
+.v2-board-surface .bd-th-body {
+  font-size: 12.5px;
+  color: var(--text-primary);
+  line-height: 1.6;
+  margin-top: 3px;
+}
+
+.v2-board-surface .bd-mention-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 9px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  cursor: pointer;
+  transition: 0.13s;
+}
+
+.v2-board-surface .bd-mention-row:hover {
+  border-color: var(--border-highlight);
+}
+
+.v2-board-surface .bd-mention-row .txt {
+  font-size: 11.5px;
+  color: var(--text-mid);
+  line-height: 1.5;
+  min-width: 0;
+}
+
+.v2-board-surface .bd-mention-row .txt b {
+  color: var(--text-bright);
+  font-weight: 600;
+}
+
+.v2-board-surface .bd-mention-row .ts {
+  margin-left: auto;
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-dim);
+}
+
+/* Mention inbox compact panel overrides */
+.v2-board-surface .bd-detail .bd-mention-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.v2-board-surface .bd-detail .bd-mention-stats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+
+.v2-board-surface .bd-detail .bd-mention-stat {
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+}
+
+.v2-board-surface .bd-detail .bd-mention-stat .k {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.v2-board-surface .bd-detail .bd-mention-stat .v {
+  margin-top: 3px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+/* ════ AUTHOR SIGIL ════ */
+.v2-board-surface .bd-sigil {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--text-bright);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-soft);
+  flex: none;
+}
+
+.v2-board-surface .bd-sigil.op {
+  background: var(--volt-wash);
+  color: var(--volt-strong);
+  border-color: var(--volt-dim);
+}
+
+/* ════ EMPTY / HINT ════ */
+.v2-board-surface .bd-empty {
+  padding: 26px 0;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+/* ════ RESPONSIVE ════ */
+@media (max-width: 1280px) {
+  .v2-board-surface .bd-body {
+    grid-template-columns: 170px minmax(0, 1fr);
+  }
+
+  .v2-board-surface .bd-detail {
+    display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .v2-board-surface .bd-body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .v2-board-surface .bd-rail {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
Refreshes the MASC dashboard Board surface with the keeper-v2 layout and interactions.

## What changed
- Updated `dashboard/src/components/board/board-surface.ts`:
  - v2 sub-board rail with counts
  - Filter chips (all / state block / moderation)
  - v2 post cards with author sigil, badges, title, state block, body, reactions, karma, replies
  - Thread detail / mention inbox side panel (`BdDetail`)
  - Composer-v2 with mode tabs (post / mention / state block)
- Updated `dashboard/src/components/board/composer-v2.ts`, `post-detail.ts`, `mention-inbox.ts`, `board-state.ts` for v2 styling and behavior.
- **New styles** `dashboard/src/styles/board-v2.css` using dashboard tokens.
- **Token bridge** aliases extended in `variables.css`.
- **Wiring** — imported `board-v2.css` in `main.ts`.
- **Tests** `dashboard/src/components/board/board-surface.test.ts` updated for v2 layout.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Full board suite ✅ 13 files, 140 tests passed

## Notes
- Existing board data model and routing preserved.
- No backend changes.
