### PR TITLE
refactor(keeper): immutable state for sandbox guard, holders, livelock, and FSM metrics

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -173,7 +173,9 @@ let set_keeper_paused_state ~agent_name paused =
           else Keeper_state_machine.Operator_resume);
        if not paused
        then (
-         Keeper_turn_livelock.reset_keeper_livelock ~keeper:entry.name;
+         Keeper_turn_livelock.reset_keeper_livelock
+           ~base_path:entry.base_path
+           ~keeper:entry.name;
          (* tla-lint: allow-mutation: fiber signal — Atomic flag wakes the keeper from Eio.Promise.await *)
          Atomic.set entry.fiber_wakeup true;
          (* Cycle 43: KeeperHeartbeat.tla WakeupSignal post-condition.
@@ -259,7 +261,12 @@ let process_directive ~agent_name directive =
          | Some meta -> meta.paused
          | None -> false)
     in
-    Keeper_turn_livelock.reset_keeper_livelock ~keeper:agent_name;
+    (match Keeper_registry_lookup.find_by_agent_name agent_name with
+     | Some e ->
+       Keeper_turn_livelock.reset_keeper_livelock
+         ~base_path:e.base_path
+         ~keeper:agent_name
+     | None -> ());
     if entry_paused
     then (
       Log.Keeper.emit

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -135,6 +135,7 @@ let register_with_state
     ; last_error = None
     ; last_failure_reason = None
     ; turn_consecutive_failures = 0
+    ; livelock_state = Atomic.make None
     ; board_wakeups = StringMap.empty
     ; board_cursor_ts = 0.0
     ; board_cursor_post_id = None
@@ -217,6 +218,7 @@ let register_restarting ~base_path name meta
     ; last_error = None
     ; last_failure_reason = None
     ; turn_consecutive_failures = 0
+    ; livelock_state = Atomic.make None
     ; board_wakeups = StringMap.empty
     ; board_cursor_ts = 0.0
     ; board_cursor_post_id = None

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -64,6 +64,12 @@ let is_idle (stage : compaction_stage) =
   | Compaction_compacting | Compaction_done -> false
 ;;
 
+type livelock_attempt_state =
+  { turn_id : int
+  ; attempts : int
+  ; first_started_at : float
+  }
+
 type turn_measurement =
   { tm_captured_at : float
   ; tm_auto_rules : Keeper_state_machine.auto_rule_summary
@@ -93,6 +99,7 @@ type registry_entry =
   ; last_error : string option
   ; last_failure_reason : failure_reason option
   ; turn_consecutive_failures : int
+  ; livelock_state : livelock_attempt_state option Atomic.t
   ; board_wakeups : float StringMap.t
   ; board_cursor_ts : float
   ; board_cursor_post_id : string option

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -407,6 +407,12 @@ val raise_compaction_transition_violation
   -> violation:compaction_transition_spec_violation
   -> 'a
 
+type livelock_attempt_state = {
+  turn_id : int;
+  attempts : int;
+  first_started_at : float;
+}
+
 type turn_measurement = {
   tm_captured_at : float;
   tm_auto_rules : Keeper_state_machine.auto_rule_summary;
@@ -445,6 +451,9 @@ type registry_entry = {
   last_error : string option;
   last_failure_reason : failure_reason option;
   turn_consecutive_failures : int;
+  livelock_state : livelock_attempt_state option Atomic.t;
+      (** Per-keeper turn-livelock retry history, updated via CAS on this
+          per-entry atomic so it is part of the keeper SSOT. *)
   board_wakeups : float StringMap.t;
   board_cursor_ts : float;
   board_cursor_post_id : string option;

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -602,7 +602,9 @@ let sweep_and_recover (ctx : _ context) =
                 resumed_meta
             with
             | Ok () ->
-              Keeper_turn_livelock.reset_keeper_livelock ~keeper:name;
+              Keeper_turn_livelock.reset_keeper_livelock
+                ~base_path:ctx.config.base_path
+                ~keeper:name;
               (match Keeper_registry.get_phase ~base_path:ctx.config.base_path name with
                | Some _ ->
                  Keeper_registry.dispatch_event_unit

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -385,7 +385,9 @@ let launch_supervised_fiber
              fresh restart, making recovery impossible.  Clear the
              per-keeper livelock bookkeeping during cleanup so the next
              restart starts with a fresh counter. *)
-            Keeper_turn_livelock.reset_keeper_livelock ~keeper:meta.name;
+            Keeper_turn_livelock.reset_keeper_livelock
+              ~base_path
+              ~keeper:meta.name;
             (* ETA-LIVELOCK: keep the typed-escalation classifier in
                lock-step with the upstream livelock bookkeeping so a
                restarted keeper sees the first block at ERROR again.

--- a/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
+++ b/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
@@ -72,7 +72,9 @@ let resume_keeper_after_reconcile_gate
     resumed_meta.name
     None;
   Keeper_registry.reset_turn_failures ~base_path:ctx.config.base_path resumed_meta.name;
-  Keeper_turn_livelock.reset_keeper_livelock ~keeper:resumed_meta.name;
+  Keeper_turn_livelock.reset_keeper_livelock
+    ~base_path:ctx.config.base_path
+    ~keeper:resumed_meta.name;
   (* ETA-LIVELOCK: keep typed-escalation classifier aligned with the
      resume path so the resumed keeper's first livelock block emits at
      ERROR (not silently demoted to DEBUG from a previous lifetime). *)

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -65,18 +65,16 @@ let guard_transition ?ctx ~keeper_name ~turn_id ~from_state ~to_state () =
         (fun () -> invalid_arg detail)
 
 (* Per-keeper last-transition wallclock, used to record the dwell time
-   spent in [prev] state when a transition fires. Keeper turns run on
-   concurrent Eio fibers, so serialize Hashtbl access with an [Eio.Mutex.t].
-   Stale entries left behind by terminal transitions are bounded by keeper
-   count. *)
-let last_transition_at : (string, float) Hashtbl.t = Hashtbl.create 64
-let last_transition_mu = Eio.Mutex.create ()
+   spent in [prev] state when a transition fires. Kept as an immutable
+   [StringMap] under an [Atomic.t] and updated with a CAS loop so
+   concurrent Eio fibers do not need a mutex. Stale entries left behind
+   by terminal transitions are bounded by keeper count. *)
+module StringMap = Set_util.StringMap
+
+let last_transition_at : float StringMap.t Atomic.t = Atomic.make StringMap.empty
 
 let observe_phase_dwell ~keeper_name ~from_label =
-  match
-    Eio.Mutex.use_ro last_transition_mu (fun () ->
-      Hashtbl.find_opt last_transition_at keeper_name)
-  with
+  match StringMap.find_opt keeper_name (Atomic.get last_transition_at) with
   | None -> ()
   | Some prev_at ->
     let now = Unix.gettimeofday () in
@@ -99,8 +97,8 @@ let emit_transition ?ctx ~keeper_name ~turn_id ?prev state =
   (match prev with
    | Some _ -> observe_phase_dwell ~keeper_name ~from_label:prev_label
    | None -> ());
-  Eio.Mutex.use_rw ~protect:true last_transition_mu (fun () ->
-    Hashtbl.replace last_transition_at keeper_name now);
+  Lockfree_atomic.update last_transition_at (fun m ->
+    StringMap.add keeper_name now m);
   let classified =
     match prev with
     | Some from_state ->

--- a/lib/keeper/keeper_turn_holders.ml
+++ b/lib/keeper/keeper_turn_holders.ml
@@ -1,11 +1,15 @@
 (* keeper_turn_holders — provider timeout strike budget.
 
    Keeper turn execution no longer enters a keeper-owned runtime gate. This
-   module only tracks provider timeout strikes per keeper. *)
+   module only tracks provider timeout strikes per keeper.
+
+   State is stored as an immutable [StringMap] under an [Atomic.t] so
+   concurrent updates are lock-free. *)
 
 open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
+module StringMap = Set_util.StringMap
 
 (* Provider timeout strikes. *)
 let provider_timeout_strike_limit = 3
@@ -19,23 +23,23 @@ let classify_provider_timeout_strike ~strikes =
   else Provider_timeout_warn
 ;;
 
-let budget_exhaustions_mutex = Stdlib.Mutex.create ()
-let budget_exhaustions : (string, int) Hashtbl.t = Hashtbl.create 16
+let state : int StringMap.t Atomic.t = Atomic.make StringMap.empty
 
-let update_budget_exhaustions f =
-  Stdlib.Mutex.lock budget_exhaustions_mutex;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock budget_exhaustions_mutex)
-    f
+let update_state f =
+  let rec loop () =
+    let cur = Atomic.get state in
+    let result, next = f cur in
+    if Atomic.compare_and_set state cur next then result else loop ()
+  in
+  loop ()
 ;;
 
 let bump_budget_exhaustion_seeded ~keeper_name ~prior_strikes =
-  update_budget_exhaustions (fun () ->
+  update_state (fun cur ->
     (* DET-OK: budget_exhaustions is advisory; absence = 0 strikes (no exhaustion recorded) *)
-    let current = Option.value ~default:0 (Hashtbl.find_opt budget_exhaustions keeper_name) in
+    let current = Option.value ~default:0 (StringMap.find_opt keeper_name cur) in
     let next = max current prior_strikes + 1 in
-    Hashtbl.replace budget_exhaustions keeper_name next;
-    next)
+    next, StringMap.add keeper_name next cur)
 ;;
 
 let bump_budget_exhaustion ~keeper_name =
@@ -43,17 +47,15 @@ let bump_budget_exhaustion ~keeper_name =
 ;;
 
 let reset_budget_exhaustion ~keeper_name =
-  update_budget_exhaustions (fun () ->
-    Hashtbl.remove budget_exhaustions keeper_name)
+  update_state (fun cur -> (), StringMap.remove keeper_name cur)
 ;;
 
 let peek_budget_exhaustion_for_test ~keeper_name =
-  update_budget_exhaustions (fun () ->
+  update_state (fun cur ->
     (* DET-OK: budget_exhaustions is advisory; absence = 0 strikes (no exhaustion recorded) *)
-    Option.value ~default:0 (Hashtbl.find_opt budget_exhaustions keeper_name))
+    Option.value ~default:0 (StringMap.find_opt keeper_name cur), cur)
 ;;
 
 let set_budget_exhaustion_for_test ~keeper_name ~strikes =
-  update_budget_exhaustions (fun () ->
-    Hashtbl.replace budget_exhaustions keeper_name strikes)
+  update_state (fun cur -> (), StringMap.add keeper_name strikes cur)
 ;;

--- a/lib/keeper/keeper_turn_livelock.ml
+++ b/lib/keeper/keeper_turn_livelock.ml
@@ -8,44 +8,18 @@
     keeper has tried turn 91 twelve times" until an operator greps
     log lines.
 
-    Per-keeper in-memory state tracks the most recent turn id seen and
-    the attempt count for that id.  When the same id starts again we emit
-    a re-attempt counter.  When the id moves strictly backwards we emit a
-    regression counter (rare; indicative of the write_meta race).  When
-    the id advances normally we reset the per-keeper bookkeeping.  The
-    guarded entrypoint enforces a per-turn retry/age budget before the
-    dispatcher marks the turn live.
+    Per-keeper state is stored in the registry entry
+    ([Keeper_registry_types.livelock_attempt_state option Atomic.t])
+    and updated via CAS on that per-entry atomic so a keeper's retry
+    history is part of the SSOT.  The previous separate [Hashtbl] +
+    [Eio.Mutex.t] has been removed. *)
 
-    State is process-local: a server restart resets the counters,
-    which is intentional — the issue's fleet-wide signal comes from
-    in-process retry storms, not cross-restart divergence. *)
+open Keeper_types
+open Keeper_meta_contract
+open Keeper_types_profile
+open Keeper_registry_types
 
-type attempt_state = {
-  turn_id : int;
-  attempts : int;
-  first_started_at : float;
-}
-
-(* Eio.Mutex: keeper turn lifecycle is invoked from Eio fibers in a single
-   domain. Stdlib.Mutex is PTHREAD_MUTEX_ERRORCHECK on OCaml 5 and raises
-   "Resource deadlock avoided" the moment two fibers on the same OS thread
-   contend (memory: feedback_eio-mutex-vs-stdlib). All callbacks below are
-   pure Hashtbl ops with no yielding effects, so use_rw is a drop-in. *)
-let mu = Eio.Mutex.create ()
-let state : (string, attempt_state) Hashtbl.t = Hashtbl.create 16
-
-(** Reset for tests so each test starts clean.  Public so the test
-    harness can call it without poking at internals. *)
-let reset_for_tests () =
-  Eio.Mutex.use_rw ~protect:true mu (fun () -> Hashtbl.clear state)
-
-(** Remove the attempt state for a single keeper.  Called by the
-    supervisor when a keeper fiber is cleaned up after a crash so
-    that the next restart begins with a fresh counter rather than
-    inheriting the previous stuck turn's exhaustion. *)
-let reset_keeper_livelock ~(keeper : string) : unit =
-  Eio.Mutex.use_rw ~protect:true mu (fun () ->
-    Hashtbl.remove state keeper)
+type attempt_state = Keeper_registry_types.livelock_attempt_state
 
 (** [start_outcome] records what happened on a [record_turn_start]
     call.  Returned so callers (tests, future gating logic) don't
@@ -107,93 +81,156 @@ let gate_reason_kind = function
 
 let gate_reason_to_string = function
   | Attempts_exhausted { attempts; max_attempts; _ } ->
-      Printf.sprintf "attempts_exhausted attempts=%d max_attempts=%d"
-        attempts max_attempts
+    Printf.sprintf
+      "attempts_exhausted attempts=%d max_attempts=%d"
+      attempts
+      max_attempts
   | Stuck_age_exceeded { attempts; age_sec; threshold_sec; _ } ->
-      Printf.sprintf
-        "stuck_age_exceeded attempts=%d age_sec=%.1f threshold_sec=%.1f"
-        attempts age_sec threshold_sec
+    Printf.sprintf
+      "stuck_age_exceeded attempts=%d age_sec=%.1f threshold_sec=%.1f"
+      attempts
+      age_sec
+      threshold_sec
 
-let classify_and_update_start ~now ~(keeper : string) ~(turn_id : int)
-    : start_outcome =
-  match Hashtbl.find_opt state keeper with
+let classify_and_update_start ~now ~(turn_id : int) (prev : attempt_state option)
+  : attempt_state option * start_outcome
+  =
+  match prev with
   | None ->
-    Hashtbl.replace state keeper
-      { turn_id; attempts = 1; first_started_at = now };
-    Fresh
-  | Some prev when prev.turn_id < turn_id ->
-    Hashtbl.replace state keeper
-      { turn_id; attempts = 1; first_started_at = now };
-    Fresh
-  | Some prev when prev.turn_id = turn_id ->
-    let attempts = prev.attempts + 1 in
-    Hashtbl.replace state keeper { prev with attempts };
-    Reattempt
-      { previous_attempts = prev.attempts;
-        first_started_at = prev.first_started_at }
-  | Some prev (* prev.turn_id > turn_id *) ->
+    Some { turn_id; attempts = 1; first_started_at = now }, Fresh
+  | Some p when p.turn_id < turn_id ->
+    Some { turn_id; attempts = 1; first_started_at = now }, Fresh
+  | Some p when p.turn_id = turn_id ->
+    let attempts = p.attempts + 1 in
+    ( Some { p with attempts }
+    , Reattempt
+        { previous_attempts = p.attempts; first_started_at = p.first_started_at } )
+  | Some p (* p.turn_id > turn_id *) ->
     (* Strictly backwards.  Reset bookkeeping so the next start
        at this lower id counts as Fresh, not Reattempt. *)
-    Hashtbl.replace state keeper
-      { turn_id; attempts = 1; first_started_at = now };
-    Regression { previous_turn_id = prev.turn_id }
+    ( Some { turn_id; attempts = 1; first_started_at = now }
+    , Regression { previous_turn_id = p.turn_id } )
 
-let record_turn_start ~(keeper : string) ~(turn_id : int) : start_outcome =
+let with_registered_entry ~base_path ~keeper f =
+  match Keeper_registry.get ~base_path keeper with
+  | None -> None
+  | Some entry -> Some (f entry)
+
+(** Read the current livelock state for [keeper] without modifying it. *)
+let current_state_opt ~base_path ~keeper : attempt_state option =
+  with_registered_entry ~base_path ~keeper (fun entry ->
+    Atomic.get entry.livelock_state)
+  |> Option.join
+
+(** Apply [f] to the current livelock state of a registered keeper and
+    write back the result via CAS on the per-entry atomic.  Returns
+    [Some result] when the keeper is registered, [None] otherwise. *)
+let update_state ~base_path ~keeper f =
+  with_registered_entry ~base_path ~keeper (fun entry ->
+    let rec loop () =
+      let old_state = Atomic.get entry.livelock_state in
+      let new_state, result = f old_state in
+      if Atomic.compare_and_set entry.livelock_state old_state new_state
+      then result
+      else loop ()
+    in
+    loop ())
+
+let record_turn_start ~base_path ~keeper ~turn_id : start_outcome =
   let outcome =
-    Eio.Mutex.use_rw ~protect:true mu (fun () ->
-      classify_and_update_start ~now:(now_unix ()) ~keeper ~turn_id)
+    match
+      update_state ~base_path ~keeper (fun prev ->
+        classify_and_update_start ~now:(now_unix ()) ~turn_id prev)
+    with
+    | Some outcome -> outcome
+    | None -> Fresh
   in
-  (* Counter emissions outside the lock — Otel_metric_store calls allocate
-     and can recurse; minimise critical-section scope. *)
   record_started_metrics ~keeper outcome
 
-let guard_and_record_turn_start ?(now = now_unix) ~(keeper : string)
-    ~(turn_id : int) ~(max_attempts : int) ~(stuck_after_sec : float) () :
-    guarded_start_outcome =
+let guard_and_record_turn_start
+      ?(now = now_unix)
+      ~base_path
+      ~keeper
+      ~turn_id
+      ~max_attempts
+      ~stuck_after_sec
+      ()
+  : guarded_start_outcome
+  =
   let max_attempts = Int.max 1 max_attempts in
   let stuck_after_sec = Float.max 0.0 stuck_after_sec in
   let now_value = now () in
   let outcome =
-    Eio.Mutex.use_rw ~protect:true mu (fun () ->
-      match Hashtbl.find_opt state keeper with
+    match
+      update_state ~base_path ~keeper (fun current ->
+        match current with
         | Some prev when prev.turn_id = turn_id ->
           let age_sec = now_value -. prev.first_started_at in
-          if prev.attempts >= max_attempts then
-            Blocked
-              (Attempts_exhausted
-                 { attempts = prev.attempts;
-                   max_attempts;
-                   first_started_at = prev.first_started_at })
-          else if age_sec >= stuck_after_sec then
-            Blocked
-              (Stuck_age_exceeded
-                 { attempts = prev.attempts;
-                   age_sec;
-                   threshold_sec = stuck_after_sec;
-                   first_started_at = prev.first_started_at })
+          if prev.attempts >= max_attempts
+          then (
+            current
+            , Blocked
+                (Attempts_exhausted
+                   { attempts = prev.attempts
+                   ; max_attempts
+                   ; first_started_at = prev.first_started_at }))
+          else if age_sec >= stuck_after_sec
+          then (
+            current
+            , Blocked
+                (Stuck_age_exceeded
+                   { attempts = prev.attempts
+                   ; age_sec
+                   ; threshold_sec = stuck_after_sec
+                   ; first_started_at = prev.first_started_at }))
           else
-            Started
-              (classify_and_update_start ~now:now_value ~keeper ~turn_id)
+            let new_state, started =
+              classify_and_update_start ~now:now_value ~turn_id current
+            in
+            new_state, Started started
         | _ ->
-          Started (classify_and_update_start ~now:now_value ~keeper ~turn_id))
+          let new_state, started =
+            classify_and_update_start ~now:now_value ~turn_id current
+          in
+          new_state, Started started)
+    with
+    | Some outcome -> outcome
+    | None -> Started Fresh
   in
   (match outcome with
    | Started started -> ignore (record_started_metrics ~keeper started)
    | Blocked reason ->
      Otel_metric_store.inc_counter
        Keeper_metrics.(to_string TurnLivelockBlocks)
-       ~labels:[ ("keeper", keeper); ("reason", gate_reason_kind reason) ] ());
+       ~labels:[ ("keeper", keeper); ("reason", gate_reason_kind reason) ]
+       ());
   outcome
 
 (** Read current attempt state for [keeper] without modifying it.
     Useful for diagnostics and future gating logic that wants to
     decide BEFORE incrementing. *)
-let current_state ~(keeper : string) : attempt_state option =
-  Eio.Mutex.use_rw ~protect:true mu (fun () -> Hashtbl.find_opt state keeper)
+let current_state ~base_path ~keeper : attempt_state option =
+  current_state_opt ~base_path ~keeper
 
 (** [seconds_since_first_attempt ~keeper] returns the age of the
     current turn's FIRST attempt for [keeper], or [None] if no state
     exists.  Pure read. *)
-let seconds_since_first_attempt ~(keeper : string) : float option =
-  current_state ~keeper
+let seconds_since_first_attempt ~base_path ~keeper : float option =
+  current_state_opt ~base_path ~keeper
   |> Option.map (fun s -> now_unix () -. s.first_started_at)
+
+(** Reset for tests so each test starts clean.  Public so the test
+    harness can call it without poking at internals. *)
+let reset_for_tests () =
+  List.iter
+    (fun entry -> Atomic.set entry.livelock_state None)
+    (Keeper_registry.all ())
+
+(** Remove the attempt state for a single keeper.  Called by the
+    supervisor when a keeper fiber is cleaned up after a crash so
+    that the next restart begins with a fresh counter rather than
+    inheriting the previous stuck turn's exhaustion. *)
+let reset_keeper_livelock ~base_path ~keeper : unit =
+  match Keeper_registry.get ~base_path keeper with
+  | Some entry -> Atomic.set entry.livelock_state None
+  | None -> ()

--- a/lib/keeper/keeper_turn_livelock.mli
+++ b/lib/keeper/keeper_turn_livelock.mli
@@ -8,14 +8,13 @@
 
     [guard_and_record_turn_start] can also gate dispatch once a
     turn exhausts its retry budget or stays stuck too long.
-    State is process-local; a server restart resets the
-    bookkeeping. *)
 
-type attempt_state = {
-  turn_id : int;
-  attempts : int;
-  first_started_at : float;  (** Unix seconds. *)
-}
+    The state is stored in the keeper registry entry and updated via
+    CAS on the per-entry atomic so a keeper's retry history is part of
+    the SSOT.  The previous separate [Hashtbl] + [Eio.Mutex.t] has
+    been removed. *)
+
+type attempt_state = Keeper_registry_types.livelock_attempt_state
 
 type start_outcome =
   | Fresh
@@ -39,15 +38,17 @@ type guarded_start_outcome =
   | Started of start_outcome
   | Blocked of gate_reason
 
-(** [record_turn_start ~keeper ~turn_id] increments the
+(** [record_turn_start ~base_path ~keeper ~turn_id] increments the
     [masc_keeper_turn_starts_total] counter and, when the start
     classifies as [Reattempt] or [Regression], the matching
     counter as well.  Returns the classification for the caller.
     Thread-safe across keeper fibers / domains. *)
-val record_turn_start : keeper:string -> turn_id:int -> start_outcome
+val record_turn_start :
+  base_path:string -> keeper:string -> turn_id:int -> start_outcome
 
 val guard_and_record_turn_start :
   ?now:(unit -> float) ->
+  base_path:string ->
   keeper:string ->
   turn_id:int ->
   max_attempts:int ->
@@ -67,11 +68,12 @@ val gate_reason_to_string : gate_reason -> string
 
 (** Read-only view of the current attempt state for a keeper.
     Returns [None] when no state has been recorded yet. *)
-val current_state : keeper:string -> attempt_state option
+val current_state : base_path:string -> keeper:string -> attempt_state option
 
 (** Convenience wrapper — Unix seconds since the FIRST attempt of
     the current turn id.  [None] when no state exists. *)
-val seconds_since_first_attempt : keeper:string -> float option
+val seconds_since_first_attempt :
+  base_path:string -> keeper:string -> float option
 
 (** Reset the in-memory state.  Intended for unit tests; the live
     server resets state implicitly on process restart. *)
@@ -81,4 +83,4 @@ val reset_for_tests : unit -> unit
     supervisor when a keeper fiber is cleaned up after a crash so
     that the next restart begins with a fresh counter rather than
     inheriting the previous stuck turn's exhaustion. *)
-val reset_keeper_livelock : keeper:string -> unit
+val reset_keeper_livelock : base_path:string -> keeper:string -> unit

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -233,18 +233,27 @@ let retryable_eintr_status ~attempts_left st ~stdout ~stderr =
   | _ -> false
 ;;
 
+type chunk = [ `Stdout of string | `Stderr of string ]
+
+type guard_state = {
+  held_chunks : chunk list;
+  saw_retry_marker : bool;
+  pass_through : bool;
+  visible_flushed : bool;
+  marker_scan_tail : string;
+  release_scheduled : bool;
+  prefix_release_deferrals : int;
+  closed : bool;
+}
+
+type action =
+  | Emit of chunk
+  | Schedule_release
+
 type retry_stream_guard = {
   on_stdout_chunk : (string -> unit) option;
   on_stderr_chunk : (string -> unit) option;
-  held_chunks : [ `Stdout of string | `Stderr of string ] list ref;
-  mutable saw_retry_marker : bool;
-  mutable pass_through : bool;
-  mutable visible_flushed : bool;
-  mutable marker_scan_tail : string;
-  mutable release_scheduled : bool;
-  mutable prefix_release_deferrals : int;
-  mutable closed : bool;
-  mu : Stdlib.Mutex.t;
+  state : guard_state Atomic.t;
 }
 
 let retry_eintr_marker = "interrupted system call"
@@ -252,10 +261,16 @@ let retry_stream_guard_release_delay_sec = 0.2
 let retry_stream_guard_prefix_deferral_limit = 1
 let retry_eintr_marker_lower = String.lowercase_ascii retry_eintr_marker
 
-let with_retry_guard_lock guard f =
-  Stdlib.Mutex.lock guard.mu;
-  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock guard.mu) f
-;;
+let initial_guard_state = {
+  held_chunks = [];
+  saw_retry_marker = false;
+  pass_through = false;
+  visible_flushed = false;
+  marker_scan_tail = "";
+  release_scheduled = false;
+  prefix_release_deferrals = 0;
+  closed = false;
+}
 
 let retry_marker_tail text =
   let max_len = max 0 (String.length retry_eintr_marker - 1) in
@@ -279,11 +294,13 @@ let retry_marker_prefix_pending tail =
   loop max_len
 ;;
 
-let update_retry_marker_scan guard chunk =
-  let scan_text = guard.marker_scan_tail ^ chunk in
-  if String_util.contains_substring_ci scan_text retry_eintr_marker
-  then guard.saw_retry_marker <- true;
-  guard.marker_scan_tail <- retry_marker_tail scan_text
+let update_retry_marker_scan state chunk =
+  let scan_text = state.marker_scan_tail ^ chunk in
+  let saw_marker = String_util.contains_substring_ci scan_text retry_eintr_marker in
+  { state with
+    saw_retry_marker = state.saw_retry_marker || saw_marker;
+    marker_scan_tail = retry_marker_tail scan_text
+  }
 ;;
 
 let invoke_guard_output_callback f chunk =
@@ -298,57 +315,102 @@ let invoke_guard_output_callback f chunk =
       (Printexc.to_string exn)
 ;;
 
-let mark_guard_visible guard =
-  with_retry_guard_lock guard (fun () -> guard.visible_flushed <- true)
+let chunk_has_visible_callback ~on_stdout_chunk ~on_stderr_chunk = function
+  | `Stdout _ -> Option.is_some on_stdout_chunk
+  | `Stderr _ -> Option.is_some on_stderr_chunk
 ;;
 
 let emit_guard_chunk guard = function
   | `Stdout chunk ->
     (match guard.on_stdout_chunk with
      | None -> ()
-     | Some f ->
-       mark_guard_visible guard;
-       invoke_guard_output_callback f chunk)
+     | Some f -> invoke_guard_output_callback f chunk)
   | `Stderr chunk ->
     (match guard.on_stderr_chunk with
      | None -> ()
-     | Some f ->
-       mark_guard_visible guard;
-       invoke_guard_output_callback f chunk)
+     | Some f -> invoke_guard_output_callback f chunk)
 ;;
 
-let take_guard_held_chunks_locked guard =
-  let chunks = List.rev !(guard.held_chunks) in
-  guard.held_chunks := [];
-  chunks
+let perform_action guard = function
+  | Emit chunk -> emit_guard_chunk guard chunk
+  | Schedule_release -> ()
 ;;
 
-let emit_guard_chunks guard chunks = List.iter (emit_guard_chunk guard) chunks
-
-let guard_chunk_has_visible_callback guard = function
-  | `Stdout _ -> Option.is_some guard.on_stdout_chunk
-  | `Stderr _ -> Option.is_some guard.on_stderr_chunk
+let transition ~on_stdout_chunk ~on_stderr_chunk state chunk =
+  let text =
+    match chunk with
+    | `Stdout s -> s
+    | `Stderr s -> s
+  in
+  let state = update_retry_marker_scan state text in
+  if
+    state.pass_through
+    && not state.saw_retry_marker
+    && not (retry_marker_prefix_pending state.marker_scan_tail)
+  then
+    let visible_flushed =
+      state.visible_flushed
+      || chunk_has_visible_callback ~on_stdout_chunk ~on_stderr_chunk chunk
+    in
+    { state with visible_flushed }, [ Emit chunk ]
+  else
+    let held_chunks = chunk :: state.held_chunks in
+    let should_schedule =
+      (not state.release_scheduled)
+      && not state.closed
+      && not state.saw_retry_marker
+    in
+    let state =
+      { state with
+        held_chunks;
+        release_scheduled = state.release_scheduled || should_schedule
+      }
+    in
+    let actions = if should_schedule then [ Schedule_release ] else [] in
+    state, actions
 ;;
 
-let guard_release_chunks guard =
-  with_retry_guard_lock guard (fun () ->
-    guard.release_scheduled <- false;
-    if guard.closed || guard.saw_retry_marker
-    then [], false
-    else if
-      retry_marker_prefix_pending guard.marker_scan_tail
-      && guard.prefix_release_deferrals < retry_stream_guard_prefix_deferral_limit
-    then (
-      guard.prefix_release_deferrals <- guard.prefix_release_deferrals + 1;
-      guard.release_scheduled <- true;
-      [], true)
-    else (
-      guard.pass_through <- true;
-      guard.prefix_release_deferrals <- 0;
-      let chunks = take_guard_held_chunks_locked guard in
-      if List.exists (guard_chunk_has_visible_callback guard) chunks
-      then guard.visible_flushed <- true;
-      chunks, false))
+let release_transition ~on_stdout_chunk ~on_stderr_chunk state =
+  if state.closed || state.saw_retry_marker
+  then { state with release_scheduled = false }, []
+  else if
+    retry_marker_prefix_pending state.marker_scan_tail
+    && state.prefix_release_deferrals < retry_stream_guard_prefix_deferral_limit
+  then
+    ( { state with
+        prefix_release_deferrals = state.prefix_release_deferrals + 1;
+        release_scheduled = true }
+    , [] )
+  else
+    let chunks = List.rev state.held_chunks in
+    let visible_flushed =
+      state.visible_flushed
+      || List.exists (chunk_has_visible_callback ~on_stdout_chunk ~on_stderr_chunk) chunks
+    in
+    let state =
+      { state with
+        pass_through = true;
+        prefix_release_deferrals = 0;
+        held_chunks = [];
+        visible_flushed;
+        release_scheduled = false
+      }
+    in
+    let actions = List.map (fun chunk -> Emit chunk) chunks in
+    state, actions
+;;
+
+let close_transition ~on_stdout_chunk ~on_stderr_chunk ~retryable state =
+  let state = { state with closed = true; release_scheduled = false } in
+  if retryable
+  then { state with held_chunks = [] }, []
+  else
+    let chunks = List.rev state.held_chunks in
+    let visible_flushed =
+      state.visible_flushed
+      || List.exists (chunk_has_visible_callback ~on_stdout_chunk ~on_stderr_chunk) chunks
+    in
+    { state with held_chunks = []; visible_flushed }, List.map (fun chunk -> Emit chunk) chunks
 ;;
 
 (* Docker EINTR retry output arrives as a short burst. Release ordinary held
@@ -359,37 +421,44 @@ let rec schedule_guard_release guard =
   | Some sw, Some clock ->
     Eio.Fiber.fork ~sw (fun () ->
       Eio.Time.sleep clock retry_stream_guard_release_delay_sec;
-      let chunks, reschedule = guard_release_chunks guard in
-      emit_guard_chunks guard chunks;
-      if reschedule then schedule_guard_release guard)
+      let rec apply () =
+        let old_state = Atomic.get guard.state in
+        let new_state, actions =
+          release_transition
+            ~on_stdout_chunk:guard.on_stdout_chunk
+            ~on_stderr_chunk:guard.on_stderr_chunk
+            old_state
+        in
+        if Atomic.compare_and_set guard.state old_state new_state
+        then actions
+        else apply ()
+      in
+      let actions = apply () in
+      List.iter (perform_action guard) actions;
+      if List.memq Schedule_release actions then schedule_guard_release guard)
   | _ ->
     (* Without Eio context there is no safe live timer surface for user
        callbacks. Held chunks are emitted when the attempt completes. *)
     ()
 ;;
 
-let guard_attempt_callback guard stream chunk =
-  let item = stream chunk in
-  let chunks, should_schedule_release =
-    with_retry_guard_lock guard (fun () ->
-      update_retry_marker_scan guard chunk;
-      if
-        guard.pass_through
-        && not guard.saw_retry_marker
-        && not (retry_marker_prefix_pending guard.marker_scan_tail)
-      then [ item ], false
-      else (
-        guard.held_chunks := item :: !(guard.held_chunks);
-        let should_schedule_release =
-          (not guard.release_scheduled)
-          && not guard.closed
-          && not guard.saw_retry_marker
-        in
-        if should_schedule_release then guard.release_scheduled <- true;
-        [], should_schedule_release))
+let guard_attempt_callback guard chunk =
+  let rec apply () =
+    let old_state = Atomic.get guard.state in
+    let new_state, actions =
+      transition
+        ~on_stdout_chunk:guard.on_stdout_chunk
+        ~on_stderr_chunk:guard.on_stderr_chunk
+        old_state
+        chunk
+    in
+    if Atomic.compare_and_set guard.state old_state new_state
+    then actions
+    else apply ()
   in
-  emit_guard_chunks guard chunks;
-  if should_schedule_release then schedule_guard_release guard
+  let actions = apply () in
+  List.iter (perform_action guard) actions;
+  if List.memq Schedule_release actions then schedule_guard_release guard
 ;;
 
 let run_split_retry_eintr_with_live_callbacks
@@ -402,15 +471,7 @@ let run_split_retry_eintr_with_live_callbacks
     let guard =
       { on_stdout_chunk
       ; on_stderr_chunk
-      ; held_chunks = ref []
-      ; saw_retry_marker = false
-      ; pass_through = false
-      ; visible_flushed = false
-      ; marker_scan_tail = ""
-      ; release_scheduled = false
-      ; prefix_release_deferrals = 0
-      ; closed = false
-      ; mu = Stdlib.Mutex.create ()
+      ; state = Atomic.make initial_guard_state
       }
     in
     let has_output_callback =
@@ -418,12 +479,12 @@ let run_split_retry_eintr_with_live_callbacks
     in
     let attempt_on_stdout_chunk =
       if has_output_callback
-      then Some (guard_attempt_callback guard (fun chunk -> `Stdout chunk))
+      then Some (fun chunk -> guard_attempt_callback guard (`Stdout chunk))
       else None
     in
     let attempt_on_stderr_chunk =
       if has_output_callback
-      then Some (guard_attempt_callback guard (fun chunk -> `Stderr chunk))
+      then Some (fun chunk -> guard_attempt_callback guard (`Stderr chunk))
       else None
     in
     let st, stdout, stderr =
@@ -433,19 +494,26 @@ let run_split_retry_eintr_with_live_callbacks
         ()
     in
     let retryable = retryable_eintr_status ~attempts_left st ~stdout ~stderr in
-    let should_retry, chunks =
-      with_retry_guard_lock guard (fun () ->
-        guard.closed <- true;
-        if retryable
-        then (
-          let _dropped_retry_prefix = take_guard_held_chunks_locked guard in
-          true, [])
-        else false, take_guard_held_chunks_locked guard)
+    let actions =
+      let rec apply () =
+        let old_state = Atomic.get guard.state in
+        let new_state, actions =
+          close_transition
+            ~on_stdout_chunk:guard.on_stdout_chunk
+            ~on_stderr_chunk:guard.on_stderr_chunk
+            ~retryable
+            old_state
+        in
+        if Atomic.compare_and_set guard.state old_state new_state
+        then actions
+        else apply ()
+      in
+      apply ()
     in
-    if should_retry
+    if retryable
     then loop (attempts_left - 1)
     else (
-      emit_guard_chunks guard chunks;
+      List.iter (perform_action guard) actions;
       st, stdout, stderr)
   in
   loop max_eintr_retries

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -227,7 +227,9 @@ let update_keeper ?(preserve_prompt_defaults = false)
      recorded a `pause_human` receipt, while current guards may persist
      [meta.paused = true].  A follow-up `masc_keeper_up` should clear the
      stale in-memory counter in both cases. *)
-  Keeper_turn_livelock.reset_keeper_livelock ~keeper:old.name;
+  Keeper_turn_livelock.reset_keeper_livelock
+    ~base_path:ctx.config.base_path
+    ~keeper:old.name;
   (* ETA-LIVELOCK: align typed-escalation classifier with the
      livelock counter reset so an operator-triggered keeper_up
      restores the next block to ERROR (not silent DEBUG demotion

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -245,6 +245,7 @@ let run_keeper_cycle
             let turn_id = keeper_turn_id in
             (match
                Keeper_turn_livelock.guard_and_record_turn_start
+                 ~base_path:registry_base_path
                  ~keeper:meta.name
                  ~turn_id
                  ~max_attempts:(turn_livelock_max_attempts ())

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -390,7 +390,9 @@ let record_streaming_cancelled_observation
          only legacy watchdog/provider_timeout receipts clear the counter, and
          only for the affected keeper. Current runtime code must not emit this
          reason from a MASC-created wall-clock timeout around tool execution. *)
-      Keeper_turn_livelock.reset_keeper_livelock ~keeper:run_meta.name;
+      Keeper_turn_livelock.reset_keeper_livelock
+        ~base_path:config.base_path
+        ~keeper:run_meta.name;
       Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_provider_timeout
     | _ ->
       (* supervisor_stop, external_cancel, or any future reason *)

--- a/test/test_keeper_turn_livelock_10121.ml
+++ b/test/test_keeper_turn_livelock_10121.ml
@@ -36,11 +36,27 @@ let () =
 
 module L = Masc.Keeper_turn_livelock
 module Metrics = Masc.Otel_metric_store
+module KR = Masc.Keeper_registry
+module KMC = Masc.Keeper_meta_contract
 
-(* Keeper_turn_livelock now uses Eio.Mutex (was Stdlib.Mutex; the latter
-   raised EDEADLK whenever two Eio fibers contended). Every public entry
-   needs an Eio fiber context, so wrap each Alcotest test body in
-   Eio_main.run. *)
+(* Keeper_turn_livelock state now lives in the keeper registry entry and is
+   updated through the registry CAS loop. Tests therefore register a minimal
+   keeper entry before exercising the public functions. *)
+let base_path () = Sys.getenv "MASC_BASE_PATH"
+
+let register_keeper keeper =
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc [ ("name", `String keeper); ("agent_name", `String keeper) ])
+    with
+    | Ok meta -> meta
+    | Error e -> failwith (Printf.sprintf "register_keeper %s: %s" keeper e)
+  in
+  ignore (KR.register ~base_path:(base_path ()) keeper meta : KR.registry_entry)
+
+(* Keeper_turn_livelock public entry points need an Eio fiber context, so
+   wrap each Alcotest test body in Eio_main.run. *)
 let with_eio f () = Eio_main.run @@ fun _env -> f ()
 
 let starts_for ~keeper =
@@ -68,10 +84,12 @@ let blocks_for ~keeper ~reason =
 let test_fresh_first_start () =
   L.reset_for_tests ();
   let keeper = "test-keeper-fresh-10121" in
+  register_keeper keeper;
+  let base = base_path () in
   let before_starts = starts_for ~keeper in
   let before_scheduled = scheduled_for ~keeper in
   let before_reattempts = reattempts_for ~keeper in
-  let outcome = L.record_turn_start ~keeper ~turn_id:1 in
+  let outcome = L.record_turn_start ~base_path:base ~keeper ~turn_id:1 in
   Alcotest.(check bool) "outcome is Fresh" true (outcome = L.Fresh);
   Alcotest.(check (float 0.0001))
     "starts +1"
@@ -88,9 +106,11 @@ let test_fresh_first_start () =
 let test_same_turn_classifies_as_reattempt () =
   L.reset_for_tests ();
   let keeper = "test-keeper-reattempt-10121" in
+  register_keeper keeper;
+  let base = base_path () in
   let before_reattempts = reattempts_for ~keeper in
-  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:91 in
-  let outcome = L.record_turn_start ~keeper ~turn_id:91 in
+  let _ : L.start_outcome = L.record_turn_start ~base_path:base ~keeper ~turn_id:91 in
+  let outcome = L.record_turn_start ~base_path:base ~keeper ~turn_id:91 in
   (match outcome with
    | L.Reattempt { previous_attempts; _ } ->
      Alcotest.(check int) "previous_attempts is 1" 1 previous_attempts
@@ -105,9 +125,11 @@ let test_same_turn_classifies_as_reattempt () =
 let test_reattempt_count_grows_monotonically () =
   L.reset_for_tests ();
   let keeper = "test-keeper-12x-10121" in
-  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:91 in
+  register_keeper keeper;
+  let base = base_path () in
+  let _ : L.start_outcome = L.record_turn_start ~base_path:base ~keeper ~turn_id:91 in
   let counts = List.init 11 (fun _ ->
-    match L.record_turn_start ~keeper ~turn_id:91 with
+    match L.record_turn_start ~base_path:base ~keeper ~turn_id:91 with
     | L.Reattempt { previous_attempts; _ } -> previous_attempts
     | _ -> -1
   ) in
@@ -121,17 +143,19 @@ let test_reattempt_count_grows_monotonically () =
 let test_forward_advance_resets () =
   L.reset_for_tests ();
   let keeper = "test-keeper-advance-10121" in
-  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:5 in
-  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:5 in
+  register_keeper keeper;
+  let base = base_path () in
+  let _ : L.start_outcome = L.record_turn_start ~base_path:base ~keeper ~turn_id:5 in
+  let _ : L.start_outcome = L.record_turn_start ~base_path:base ~keeper ~turn_id:5 in
   let before_reattempts = reattempts_for ~keeper in
-  let outcome = L.record_turn_start ~keeper ~turn_id:6 in
+  let outcome = L.record_turn_start ~base_path:base ~keeper ~turn_id:6 in
   Alcotest.(check bool) "advance is Fresh" true (outcome = L.Fresh);
   Alcotest.(check (float 0.0001))
     "advance does not increment reattempts"
     before_reattempts (reattempts_for ~keeper);
   (* And the next start at the new id classifies as Reattempt
      against the NEW id, not the old one. *)
-  let outcome2 = L.record_turn_start ~keeper ~turn_id:6 in
+  let outcome2 = L.record_turn_start ~base_path:base ~keeper ~turn_id:6 in
   match outcome2 with
   | L.Reattempt { previous_attempts; _ } ->
     Alcotest.(check int)
@@ -143,9 +167,11 @@ let test_forward_advance_resets () =
 let test_backward_turn_classifies_as_regression () =
   L.reset_for_tests ();
   let keeper = "test-keeper-regression-10121" in
-  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:91 in
+  register_keeper keeper;
+  let base = base_path () in
+  let _ : L.start_outcome = L.record_turn_start ~base_path:base ~keeper ~turn_id:91 in
   let before_regressions = regressions_for ~keeper in
-  let outcome = L.record_turn_start ~keeper ~turn_id:90 in
+  let outcome = L.record_turn_start ~base_path:base ~keeper ~turn_id:90 in
   (match outcome with
    | L.Regression { previous_turn_id } ->
      Alcotest.(check int) "previous_turn_id is 91" 91 previous_turn_id
@@ -159,9 +185,12 @@ let test_keeper_isolation () =
   L.reset_for_tests ();
   let a = "test-keeper-iso-A-10121" in
   let b = "test-keeper-iso-B-10121" in
+  register_keeper a;
+  register_keeper b;
+  let base = base_path () in
   let before_b = reattempts_for ~keeper:b in
-  let _ : L.start_outcome = L.record_turn_start ~keeper:a ~turn_id:1 in
-  let _ : L.start_outcome = L.record_turn_start ~keeper:a ~turn_id:1 in
+  let _ : L.start_outcome = L.record_turn_start ~base_path:base ~keeper:a ~turn_id:1 in
+  let _ : L.start_outcome = L.record_turn_start ~base_path:base ~keeper:a ~turn_id:1 in
   Alcotest.(check (float 0.0001))
     "keeper B unaffected by keeper A reattempts"
     before_b (reattempts_for ~keeper:b)
@@ -172,10 +201,12 @@ let test_keeper_isolation () =
 let test_seconds_since_first_attempt () =
   L.reset_for_tests ();
   let keeper = "test-keeper-stuck-time-10121" in
-  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:1 in
+  register_keeper keeper;
+  let base = base_path () in
+  let _ : L.start_outcome = L.record_turn_start ~base_path:base ~keeper ~turn_id:1 in
   Unix.sleepf 0.05;
-  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:1 in
-  match L.seconds_since_first_attempt ~keeper with
+  let _ : L.start_outcome = L.record_turn_start ~base_path:base ~keeper ~turn_id:1 in
+  match L.seconds_since_first_attempt ~base_path:base ~keeper with
   | None -> Alcotest.fail "expected Some elapsed seconds"
   | Some t ->
     Alcotest.(check bool)
@@ -185,10 +216,13 @@ let test_seconds_since_first_attempt () =
 let test_guard_blocks_after_max_attempts () =
   L.reset_for_tests ();
   let keeper = "test-keeper-guard-max-10121" in
+  register_keeper keeper;
+  let base = base_path () in
   let now = ref 1000.0 in
   let call () =
     L.guard_and_record_turn_start
       ~now:(fun () -> !now)
+      ~base_path:base
       ~keeper
       ~turn_id:91
       ~max_attempts:3
@@ -224,10 +258,13 @@ let test_guard_blocks_after_max_attempts () =
 let test_guard_blocks_on_stuck_age () =
   L.reset_for_tests ();
   let keeper = "test-keeper-guard-age-10121" in
+  register_keeper keeper;
+  let base = base_path () in
   let now = ref 10.0 in
   let call () =
     L.guard_and_record_turn_start
       ~now:(fun () -> !now)
+      ~base_path:base
       ~keeper
       ~turn_id:24
       ~max_attempts:10
@@ -252,9 +289,12 @@ let test_guard_blocks_on_stuck_age () =
 let test_guard_forward_advance_resets () =
   L.reset_for_tests ();
   let keeper = "test-keeper-guard-advance-10121" in
+  register_keeper keeper;
+  let base = base_path () in
   let call turn_id =
     L.guard_and_record_turn_start
       ~now:(fun () -> 100.0)
+      ~base_path:base
       ~keeper
       ~turn_id
       ~max_attempts:2
@@ -282,10 +322,13 @@ let test_guard_forward_advance_resets () =
 let test_reset_clears_stuck_age_for_provider_timeout () =
   L.reset_for_tests ();
   let keeper = "test-keeper-reset-stuck-age-10121" in
+  register_keeper keeper;
+  let base = base_path () in
   let now = ref 10.0 in
   let call () =
     L.guard_and_record_turn_start
       ~now:(fun () -> !now)
+      ~base_path:base
       ~keeper
       ~turn_id:24
       ~max_attempts:10
@@ -298,7 +341,7 @@ let test_reset_clears_stuck_age_for_provider_timeout () =
   (* Age now far exceeds the threshold; without the reset this is the exact
      scenario [test_guard_blocks_on_stuck_age] proves blocks. *)
   now := 1810.0;
-  L.reset_keeper_livelock ~keeper;
+  L.reset_keeper_livelock ~base_path:base ~keeper;
   (match call () with
    | L.Started L.Fresh -> ()
    | L.Blocked (L.Stuck_age_exceeded _) ->


### PR DESCRIPTION
## Summary

Continue the mutable → immutable refactor in the keeper turn subsystem (P5–P8).

## Changes

- **P5 — `Keeper_turn_sandbox_runtime`**: refactor the streaming `retry_stream_guard` from a record with mutable fields + `held_chunks list ref` + `Stdlib.Mutex.t` into an immutable `guard_state` value. Provide a `transition : guard_state -> chunk -> guard_state * action list` function and apply it under `Atomic.set`/mutex-protected swap in the streaming callback.
- **P6 — `Keeper_turn_holders`**: move provider timeout strike counts out of the separate mutex-protected `Hashtbl` and into the CAS-managed registry entry (or an `Atomic.t` of a `StringMap`). Remove the advisory `budget_exhaustions_mutex`.
- **P7 — `Keeper_turn_livelock`**: merge per-keeper livelock state into `registry_entry` as an `Atomic.t` of `livelock_attempt_state option`, updated via the existing registry CAS loop. Remove the separate `Hashtbl` + `Eio.Mutex.t`.
- **P8 — `Keeper_turn_fsm`**: replace `last_transition_at : (string, float) Hashtbl.t` + `Eio.Mutex.t` with an `Atomic.t` of `float StringMap.t` and update it via CAS.

## Verification

- [x] `scripts/dune-local.sh build @check` passes.
- [ ] Full `dune runtest` is currently blocked by an `agent_sdk` opam pin drift between worktrees. `test/test_keeper_turn_livelock_10121.ml` and other tests will be re-run once the switch pin is reconciled.

## Notes

Build run with `MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1` because the current opam switch had drifted from this worktree's pinned `agent_sdk` commit.
