### PR TITLE
feat(dashboard): apply keeper-v2 connectors surface

### DIFF
--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -166,6 +166,23 @@ describe('ConnectorOverviewStrip', () => {
     expect(container.querySelector('[data-incident-banner]')).toBeNull()
   })
 
+  it('respects filterQuery and hides non-matching tiles', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[
+          mkConnector({ connector_id: 'discord', display_name: 'Discord', available: true }),
+          mkConnector({ connector_id: 'slack', display_name: 'Slack', available: true }),
+        ]}
+        keeperCount=${0}
+        filterQuery="slack"
+      />`,
+      container,
+    )
+    expect(container.querySelector('[data-overview-tile="slack"]')).not.toBeNull()
+    expect(container.querySelector('[data-overview-tile="discord"]')).toBeNull()
+    expect(container.querySelector('[data-overview-tile="imessage"]')).toBeNull()
+  })
+
   it('does not render the old celebration banner even when all 4 sidecars are up', () => {
     _testResetBulkInflight()
     const allUp = ['discord', 'imessage', 'slack', 'telegram'].map(id => mkConnector({ connector_id: id, available: true }))

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -158,7 +158,31 @@ interface OverviewProps {
   discordTriggerPolicy?: string
   selectedConnectorId?: KnownConnectorId | null
   onSelectConnector?: (connectorId: KnownConnectorId) => void
+  onOpenConfig?: (connectorId: KnownConnectorId) => void
   detailTargetId?: string
+  filterQuery?: string
+}
+
+/** Pure: decide whether a connector tile matches the toolbar query.
+ *  Empty/whitespace queries always match so the default grid stays intact. */
+function tileMatchesQuery(
+  id: KnownConnectorId,
+  connector: GateConnectorInfo | null,
+  query: string | undefined,
+): boolean {
+  const needle = (query ?? '').trim().toLowerCase()
+  if (needle === '') return true
+  const haystack = [
+    id,
+    CONNECTOR_DISPLAY_NAMES[id] ?? '',
+    connector?.display_name ?? '',
+    connector?.channel ?? '',
+    connector?.status ?? '',
+    connector?.bot_user_name ?? '',
+  ]
+    .join(' ')
+    .toLowerCase()
+  return haystack.includes(needle)
 }
 
 function findConnector(connectors: GateConnectorInfo[], id: string): GateConnectorInfo | null {
@@ -221,12 +245,13 @@ export function summarizeOverviewTile(
   }
 }
 
-function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector, detailTargetId }: {
+function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector, onOpenConfig, detailTargetId }: {
   id: KnownConnectorId
   connector: GateConnectorInfo | null
   keeperCount: number
   selected: boolean
   onSelectConnector?: (connectorId: KnownConnectorId) => void
+  onOpenConfig?: (connectorId: KnownConnectorId) => void
   detailTargetId: string
 }) {
   const sidecarUp = connector?.available === true
@@ -268,44 +293,57 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
       data-overview-tile=${id}
       data-overview-selected=${selected ? 'true' : 'false'}
     >
-      <button
-        type="button"
-        class="flex min-w-0 cursor-pointer items-start gap-3 text-left"
-        onClick=${() => selectConnector(true)}
-        aria-label=${`${displayName} 상세 보기`}
-        aria-pressed=${selected ? 'true' : 'false'}
-      >
-        <span
-          class="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--r-1)] text-base"
-          style=${accent}
-        >${channelIcon(id)}</span>
-        <span class="min-w-0 flex-1">
-          <span class="flex items-center gap-2">
-            <span class="block truncate text-sm font-semibold text-[var(--color-fg-primary)]">${displayName}</span>
-            <span class=${`rounded-[var(--r-0)] border px-2 py-0.5 text-3xs font-medium ${summary.badgeClass}`}>${summary.badge}</span>
-            ${uptimeLabel !== null
-              ? html`
-                  <span
-                    class="rounded-[var(--r-0)] border border-[var(--ok-border)] bg-[var(--ok-10)] px-1.5 py-px text-3xs font-normal text-[var(--color-status-ok)]/80"
-                    data-uptime-chip
-                    title="last_ready_at 기준 경과 시간"
-                  >${uptimeLabel}</span>
-                `
-              : null}
+      <div class="flex items-start gap-2">
+        <button
+          type="button"
+          class="flex min-w-0 flex-1 cursor-pointer items-start gap-3 text-left"
+          onClick=${() => selectConnector(true)}
+          aria-label=${`${displayName} 상세 보기`}
+          aria-pressed=${selected ? 'true' : 'false'}
+        >
+          <span
+            class="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--r-1)] text-base"
+            style=${accent}
+          >${channelIcon(id)}</span>
+          <span class="min-w-0 flex-1">
+            <span class="flex items-center gap-2">
+              <span class="block truncate text-sm font-semibold text-[var(--color-fg-primary)]">${displayName}</span>
+              <span class=${`rounded-[var(--r-0)] border px-2 py-0.5 text-3xs font-medium ${summary.badgeClass}`}>${summary.badge}</span>
+              ${uptimeLabel !== null
+                ? html`
+                    <span
+                      class="rounded-[var(--r-0)] border border-[var(--ok-border)] bg-[var(--ok-10)] px-1.5 py-px text-3xs font-normal text-[var(--color-status-ok)]/80"
+                      data-uptime-chip
+                      title="last_ready_at 기준 경과 시간"
+                    >${uptimeLabel}</span>
+                  `
+                : null}
+            </span>
+            <span class="mt-1 block text-2xs leading-5 text-[var(--color-fg-disabled)]" data-overview-summary>${summary.detail}</span>
+            ${(() => {
+              const identity = formatTileIdentityLine(connector)
+              return identity !== null
+                ? html`<span
+                    class="mt-1 block truncate text-3xs text-[var(--color-fg-disabled)]"
+                    data-tile-identity=${id}
+                    title=${identity}
+                  >${identity}</span>`
+                : null
+            })()}
           </span>
-          <span class="mt-1 block text-2xs leading-5 text-[var(--color-fg-disabled)]" data-overview-summary>${summary.detail}</span>
-          ${(() => {
-            const identity = formatTileIdentityLine(connector)
-            return identity !== null
-              ? html`<span
-                  class="mt-1 block truncate text-3xs text-[var(--color-fg-disabled)]"
-                  data-tile-identity=${id}
-                  title=${identity}
-                >${identity}</span>`
-              : null
-          })()}
-        </span>
-      </button>
+        </button>
+        ${onOpenConfig
+          ? html`
+              <button
+                type="button"
+                class="shrink-0 cursor-pointer rounded-[var(--r-1)] border border-[var(--color-border-default)] px-1.5 py-1 text-xs text-[var(--color-fg-disabled)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]"
+                aria-label=${`${displayName} 설정 열기`}
+                title="설정"
+                onClick=${() => { onOpenConfig(id) }}
+              >⚙</button>
+            `
+          : null}
+      </div>
       <${ConnectorReadinessRail} pills=${pills} />
       <span class=${`text-3xs uppercase tracking-4 ${selected ? 'text-[var(--accent-1)]' : 'text-[var(--color-fg-disabled)]'}`}>
         ${selected ? 'Selected' : 'View Details'}
@@ -723,7 +761,9 @@ export function ConnectorOverviewStrip({
   discordTriggerPolicy,
   selectedConnectorId = null,
   onSelectConnector,
+  onOpenConfig,
   detailTargetId = 'connector-detail-panel',
+  filterQuery = '',
 }: OverviewProps) {
   useEffect(() => {
     stripMemory.value = updateStripMemory(stripMemory.value, connectors, Date.now())
@@ -760,17 +800,20 @@ export function ConnectorOverviewStrip({
         </div>
         <${BulkActions} connectors=${connectors} />
       </div>
-      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        ${KNOWN_CONNECTOR_IDS.map(id => html`
-          <${OverviewTile}
-            id=${id}
-            connector=${findConnector(connectors, id)}
-            keeperCount=${keeperCount}
-            selected=${selectedConnectorId === id}
-            onSelectConnector=${onSelectConnector}
-            detailTargetId=${detailTargetId}
-          />
-        `)}
+      <div class="cn-grid">
+        ${KNOWN_CONNECTOR_IDS
+          .filter(id => tileMatchesQuery(id, findConnector(connectors, id), filterQuery))
+          .map(id => html`
+            <${OverviewTile}
+              id=${id}
+              connector=${findConnector(connectors, id)}
+              keeperCount=${keeperCount}
+              selected=${selectedConnectorId === id}
+              onSelectConnector=${onSelectConnector}
+              onOpenConfig=${onOpenConfig}
+              detailTargetId=${detailTargetId}
+            />
+          `)}
       </div>
     </${SurfaceCard}>
   `

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -1100,3 +1100,135 @@ describe('filterKeeperGroups', () => {
     expect(rows).toHaveLength(3)
   })
 })
+
+describe('ConnectorStatusPanel v2 surface layout', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(async () => {
+    const { resetConnectorStatusState } = await import('./connector-status')
+    resetConnectorStatusState()
+    render(null, container)
+    container.remove()
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.doUnmock('../api/core')
+    vi.doUnmock('../api/gate')
+    vi.doUnmock('../sse')
+    vi.doUnmock('./common/toast')
+  })
+
+  it('renders the keeper-v2 surface header, toolbar, and gate strip', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse())
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('.cn-surf-head')).not.toBeNull()
+    expect(container.querySelector('.cn-toolbar')).not.toBeNull()
+    expect(container.querySelector('[data-testid="connector-search-input"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="connector-add-button"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="connector-gate-strip"]')).not.toBeNull()
+    expect(container.textContent).toContain('Gate')
+    expect(container.textContent).toContain('Add connector')
+  })
+
+  it('filters connector tiles from the toolbar search input', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const discord = sampleConnectorsResponse().connectors[0]
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse({
+      connectors: [
+        discord,
+        {
+          ...discord,
+          connector_id: 'imessage',
+          display_name: 'iMessage',
+          channel: 'imessage',
+          status_path: '/tmp/imessage_status.json',
+          binding_store_path: '/tmp/imessage_bindings.json',
+          audit_path: '/tmp/imessage_binding_audit.jsonl',
+          names_path: '/tmp/imessage_names.json',
+          configured_bindings: [{ channel_id: 'imsg-workspace', keeper_name: 'nova' }],
+          recent_audit: [],
+        },
+      ],
+      total: 2,
+      active_count: 2,
+    }))
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    expect(container.querySelectorAll('[data-overview-tile]').length).toBe(4)
+
+    const searchInput = container.querySelector('[data-testid="connector-search-input"]') as HTMLInputElement
+    searchInput.value = 'imessage'
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    expect(container.querySelector('[data-overview-tile="imessage"]')).not.toBeNull()
+    expect(container.querySelector('[data-overview-tile="discord"]')).toBeNull()
+
+    searchInput.value = ''
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    expect(container.querySelectorAll('[data-overview-tile]').length).toBe(4)
+  })
+
+  it('opens the detail config drawer from a tile config button', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse())
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    const configButton = container.querySelector<HTMLButtonElement>('button[aria-label="Discord 설정 열기"]')
+    expect(configButton).not.toBeNull()
+    configButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    const drawer = container.querySelector('[data-testid="connector-detail-drawer"]')
+    expect(drawer).not.toBeNull()
+    expect(drawer!.textContent).toContain('Discord 설정')
+    expect(drawer!.textContent).toContain('connection')
+    expect(drawer!.textContent).toContain('config')
+    expect(drawer!.textContent).toContain('events')
+
+    const configTab = Array.from(drawer!.querySelectorAll('button')).find(b => b.textContent === 'config')
+    expect(configTab).not.toBeUndefined()
+    configTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(drawer!.textContent).toContain('server in-process')
+  })
+})

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -20,7 +20,7 @@ import {
   type GateKeeperInfo,
   type GateStatusData,
 } from '../api/gate'
-import { formatElapsedCompact, formatTimeAgoEn } from '../lib/format-time'
+import { formatTimeAgoEn } from '../lib/format-time'
 import { ErrorState } from './common/feedback-state'
 import { ConnectorOverviewSkeleton } from './connector-overview-skeleton'
 import { lastEvent } from '../sse'
@@ -171,6 +171,9 @@ function emptyConnectorUiState(): ConnectorUiState {
 
 const connectorUiState = signal<Record<string, ConnectorUiState>>({})
 const selectedConnectorId = signal<KnownConnectorId | null>(null)
+const connectorSearchQuery = signal('')
+const configDrawerConnectorId = signal<KnownConnectorId | null>(null)
+const configDrawerTab = signal<'connection' | 'config' | 'events'>('connection')
 
 function getConnectorUiState(connectorId: string): ConnectorUiState {
   return connectorUiState.value[connectorId] ?? emptyConnectorUiState()
@@ -290,8 +293,6 @@ const CHANNEL_ICONS: Record<string, string> = {
 export function channelIcon(ch: string): string {
   return CHANNEL_ICONS[ch] ?? '\u{1F517}'
 }
-
-const formatUptime = formatElapsedCompact
 
 const timeAgo = formatTimeAgoEn
 
@@ -1614,6 +1615,261 @@ function GateAnalyticsSection({
   `
 }
 
+function formatConnectorTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '-'
+  const ts = Date.parse(iso)
+  return Number.isNaN(ts) ? iso : new Date(ts).toLocaleString()
+}
+
+function ConnectorsSurfaceHeader({
+  filterId,
+  connectorCount,
+  activeCount,
+  onRefresh,
+}: {
+  filterId: KnownConnectorId | null
+  connectorCount: number
+  activeCount: number
+  onRefresh: () => void
+}) {
+  return html`
+    <header class="cn-surf-head">
+      <div>
+        <div class="eyebrow">Gate</div>
+        <h1>${filterId ? CONNECTOR_DISPLAY_NAMES[filterId] ?? '커넥터' : '커넥터'}</h1>
+        <div class="cn-surf-sub">
+          외부 게이트 ${connectorCount}개 · <b>${activeCount} active</b> ·
+          <span class="mono">GET /api/v1/gate/connectors</span>
+        </div>
+      </div>
+      <div class="cn-surf-actions">
+        <button
+          type="button"
+          class="cn-act"
+          aria-label="게이트 새로고침"
+          onClick=${onRefresh}
+        >게이트 새로고침 ↻</button>
+        <button
+          type="button"
+          class="cn-act primary"
+          aria-label="커넥터 추가"
+          onClick=${() => { showToast('Add connector: keeper-v2 connector catalog coming soon', 'warning') }}
+        >＋ Add connector</button>
+      </div>
+    </header>
+  `
+}
+
+function ConnectorsToolbar({
+  query,
+  onQuery,
+}: {
+  query: string
+  onQuery: (value: string) => void
+}) {
+  return html`
+    <div class="cn-toolbar">
+      <${TextInput}
+        type="search"
+        value=${query}
+        placeholder="Filter connectors by name, channel, or status"
+        ariaLabel="커넥터 필터"
+        testId="connector-search-input"
+        class="cn-search"
+        onInput=${(e: Event) => { onQuery((e.target as HTMLInputElement).value) }}
+      />
+      <${ActionButton}
+        variant="primary"
+        size="sm"
+        testId="connector-add-button"
+        onClick=${() => { showToast('Add connector: keeper-v2 connector catalog coming soon', 'warning') }}
+      >＋ Add connector<//>
+    </div>
+  `
+}
+
+function GateStatusStrip({
+  gate,
+  connectors,
+}: {
+  gate: GateStatusData | null
+  connectors: GateConnectorInfo[]
+}) {
+  const healthy = gate !== null && connectors.some(c => c.gate_healthy === true)
+  function statusClass(): string {
+    if (healthy) return 'run'
+    if (gate === null) return 'off'
+    return 'pause'
+  }
+  function statusLabel(): string {
+    if (healthy) return 'healthy'
+    if (gate === null) return 'unknown'
+    return 'degraded'
+  }
+  function resolveGeneratedAt(): string {
+    if (connectors[0]?.updated_at) return formatConnectorTimestamp(connectors[0].updated_at)
+    if (gate?.recent_events?.[0]?.timestamp) return formatConnectorTimestamp(gate.recent_events[0].timestamp)
+    return '-'
+  }
+  const generatedAt = resolveGeneratedAt()
+
+  return html`
+    <div class="cn-gate-strip" data-testid="connector-gate-strip">
+      <span>
+        <span class=${`status-dot ${statusClass()}`}></span>
+        gate <b>${statusLabel()}</b>
+      </span>
+      <span class="sep"></span>
+      <span class="mono">base ${connectors[0]?.gate_base_url || DEFAULT_MASC_ORIGIN}</span>
+      <span class="sep"></span>
+      <span>
+        health check <b class="mono">${gate?.recent_events?.[0]?.timestamp
+          ? timeAgo(gate.recent_events[0].timestamp)
+          : 'pending'}</b>
+      </span>
+      <span class="sep"></span>
+      <span>binding source <b>${connectors[0]?.binding_source || 'store + runtime'}</b></span>
+      <span style=${{ marginLeft: 'auto' }} class="mono">generated_at ${generatedAt}</span>
+    </div>
+  `
+}
+
+function ConnectorDetailDrawer({
+  connectorId,
+  connector,
+  onClose,
+}: {
+  connectorId: KnownConnectorId
+  connector: GateConnectorInfo | null
+  onClose: () => void
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  useEffect(() => {
+    openConnectorConfig(connectorId)
+  }, [connectorId])
+
+  const displayName = CONNECTOR_DISPLAY_NAMES[connectorId] ?? connectorId
+  const tab = configDrawerTab.value
+  const auditRows = connector?.recent_audit ?? []
+
+  return html`
+    <div class="cn-drawer-overlay" onClick=${onClose} data-testid="connector-detail-drawer">
+      <div class="cn-drawer" onClick=${(e: Event) => { e.stopPropagation() }}>
+        <div class="cn-drawer-hd">
+          <div>
+            <h3>${channelIcon(connector?.channel ?? connectorId)} ${displayName} 설정</h3>
+            <span class="id">${connectorId}</span>
+          </div>
+          <button
+            type="button"
+            class="cn-drawer-close"
+            aria-label="닫기 (Esc)"
+            onClick=${onClose}
+          >✕</button>
+        </div>
+        <div class="cn-drawer-tabs">
+          ${(['connection', 'config', 'events'] as const).map(t => html`
+            <button
+              type="button"
+              class=${`cn-drawer-tab ${tab === t ? 'on' : ''}`}
+              onClick=${() => { configDrawerTab.value = t }}
+            >${t}</button>
+          `)}
+        </div>
+        <div class="cn-drawer-body">
+          ${tab === 'connection' && html`
+            <div class="cn-drawer-section">
+              <h4>연결 상태</h4>
+              <div class="text-2xs text-[var(--color-fg-secondary)]">
+                status <span class="font-mono text-[var(--color-fg-primary)]">${connectorStateLabel(connector)}</span>
+                ${connector?.gate_healthy !== null
+                  ? html` · gate <span class="font-mono text-[var(--color-fg-primary)]">${connector?.gate_healthy ? 'healthy' : 'unhealthy'}</span>`
+                  : null}
+                ${connector?.updated_at ? html` · heartbeat <span class="font-mono text-[var(--color-fg-primary)]">${timeAgo(connector.updated_at)}</span>` : null}
+              </div>
+              ${connector?.error
+                ? html`
+                    <div class="mt-2 rounded-[var(--r-1)] border border-[var(--err-border)] bg-[var(--bad-10)] px-2 py-1 text-2xs text-[var(--bad-light)]">
+                      ⚠ ${connector.error}
+                    </div>
+                  `
+                : null}
+            </div>
+            <div class="cn-drawer-section">
+              <h4>Bindings</h4>
+              ${connector?.configured_bindings?.length
+                ? html`
+                    <div class="space-y-1">
+                      ${connector.configured_bindings.map(b => html`
+                        <div class="flex items-center gap-2 text-2xs" data-drawer-binding=${b.channel_id}>
+                          <span class="font-mono text-[var(--color-fg-primary)]">${b.channel_id}</span>
+                          <span class="text-[var(--color-fg-disabled)]">→</span>
+                          <span class="font-mono text-[var(--color-fg-primary)]">${b.keeper_name}</span>
+                        </div>
+                      `)}
+                    </div>
+                  `
+                : html`<div class="text-2xs text-[var(--color-fg-disabled)]">바인딩 없음 — 알림 전용 게이트</div>`}
+            </div>
+          `}
+          ${tab === 'config' && html`
+            <div class="cn-drawer-section">
+              <div class="mb-2 flex items-center justify-between">
+                <h4>Config</h4>
+                <button
+                  type="button"
+                  class="cn-test-btn"
+                  onClick=${() => { showToast(`${displayName} connection test placeholder`, 'warning') }}
+                >Test connection</button>
+              </div>
+              <${ConnectorConfigForm} connectorId=${connectorId} />
+            </div>
+          `}
+          ${tab === 'events' && html`
+            <div class="cn-drawer-section">
+              <h4>Event log</h4>
+              ${auditRows.length
+                ? html`
+                    <table class="w-full border-collapse text-2xs">
+                      <thead>
+                        <tr class="text-left text-[var(--color-fg-disabled)]">
+                          <th class="pb-1">시각</th>
+                          <th class="pb-1">액션</th>
+                          <th class="pb-1">Keeper</th>
+                          <th class="pb-1">Actor</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        ${auditRows.map(a => html`
+                          <tr class="border-t border-[var(--color-border-default)]">
+                            <td class="py-1 font-mono text-[var(--color-fg-secondary)]">${formatConnectorTimestamp(a.timestamp)}</td>
+                            <td class="py-1 text-[var(--color-fg-primary)]">${a.action}</td>
+                            <td class="py-1 font-mono text-[var(--color-fg-secondary)]">${a.keeper_name}</td>
+                            <td class="py-1 text-[var(--color-fg-secondary)]">${a.actor_name}</td>
+                          </tr>
+                        `)}
+                      </tbody>
+                    </table>
+                  `
+                : html`<div class="text-2xs text-[var(--color-fg-disabled)]">최근 감사 로그 없음</div>`}
+            </div>
+          `}
+        </div>
+      </div>
+    </div>
+  `
+}
+
 export function ConnectorStatusPanel() {
   useEffect(() => {
     void refresh()
@@ -1678,19 +1934,27 @@ export function ConnectorStatusPanel() {
     ? visibleConnectors[0] ?? placeholderConnector(focusedConnectorId)
     : findKnownConnector(allConnectors, focusedConnectorId) ?? placeholderConnector(focusedConnectorId)
 
+  const connectorCount = allConnectors.length
+  const activeCount = allConnectors.filter(c => connectorStateLabel(c) === 'connected').length
+
   return html`
-    <div class="contain-content v2-connector-status">
-      <div class="mb-3 flex items-center justify-between gap-3">
-        <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">${filterId ? CONNECTOR_DISPLAY_NAMES[filterId as KnownConnectorId] ?? '커넥터' : '커넥터'}</h3>
-        ${filterId
-          ? html`
-              <div class="text-right text-3xs uppercase tracking-5 text-[var(--color-fg-disabled)]">
-                <div>${d ? `success ${d.success_rate_pct}%` : `${visibleConnectors.length} connector${visibleConnectors.length !== 1 ? 's' : ''}`}</div>
-                <div>${d ? `uptime ${formatUptime(d.uptime_seconds)}` : '게이트 메트릭 없음'}</div>
-              </div>
-            `
-          : null}
-      </div>
+    <div class="contain-content v2-connector-status v2-connectors-surface">
+      <${ConnectorsSurfaceHeader}
+        filterId=${filterId as KnownConnectorId | null}
+        connectorCount=${connectorCount}
+        activeCount=${activeCount}
+        onRefresh=${() => { void refresh() }}
+      />
+
+      ${!filterId
+        ? html`
+            <${ConnectorsToolbar}
+              query=${connectorSearchQuery.value}
+              onQuery=${(value: string) => { connectorSearchQuery.value = value }}
+            />
+            <${GateStatusStrip} gate=${d} connectors=${allConnectors} />
+          `
+        : null}
 
       ${!filterId
         ? html`
@@ -1700,7 +1964,12 @@ export function ConnectorStatusPanel() {
               discordTriggerPolicy=${snapshot.connectors?.discord_trigger_policy}
               selectedConnectorId=${focusedConnectorId}
               onSelectConnector=${(connectorId: KnownConnectorId) => { selectedConnectorId.value = connectorId }}
+              onOpenConfig=${(connectorId: KnownConnectorId) => {
+                configDrawerConnectorId.value = connectorId
+                configDrawerTab.value = 'connection'
+              }}
               detailTargetId="connector-detail-panel"
+              filterQuery=${connectorSearchQuery.value}
             />
           `
         : null}
@@ -1757,6 +2026,16 @@ export function ConnectorStatusPanel() {
         : null}
 
       <${GateAnalyticsSection} gate=${d} gateError=${snapshot.gateError} />
+
+      ${configDrawerConnectorId.value
+        ? html`
+            <${ConnectorDetailDrawer}
+              connectorId=${configDrawerConnectorId.value}
+              connector=${findKnownConnector(allConnectors, configDrawerConnectorId.value)}
+              onClose=${() => { configDrawerConnectorId.value = null }}
+            />
+          `
+        : null}
     </div>
   `
 }
@@ -1765,4 +2044,7 @@ export function resetConnectorStatusState() {
   connectorStatusResource.reset(EMPTY_SNAPSHOT)
   connectorUiState.value = {}
   selectedConnectorId.value = null
+  connectorSearchQuery.value = ''
+  configDrawerConnectorId.value = null
+  configDrawerTab.value = 'connection'
 }

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -45,6 +45,7 @@ import './styles/memory-v2.css'
 import './styles/keeper-turn-inspector.css'
 import './styles/ide-v2.css'
 import './styles/work-v2.css'
+import './styles/connectors-v2.css'
 
 import { render } from 'preact'
 import { html } from 'htm/preact'

--- a/dashboard/src/styles/connectors-v2.css
+++ b/dashboard/src/styles/connectors-v2.css
@@ -1,0 +1,658 @@
+/* MASC Dashboard — Keeper-v2 Connectors surface layout.
+ *
+ * Ports the keeper-v2 prototype (connectors.jsx / surfaces.css) onto the
+ * existing dashboard token ladder.  This stylesheet is scoped to the
+ * .v2-connectors-surface container; legacy connector surfaces keep their
+ * previous styling.
+ */
+
+.v2-connectors-surface {
+  --cn-pad: var(--pad-surface, 22px 26px 40px);
+  --cn-card-min: 280px;
+  --cn-drawer-width: 460px;
+
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: var(--bg-deep);
+  color: var(--text-bright);
+}
+
+/* ── Surface header ─────────────────────────────────────────────────────── */
+
+.cn-surf-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.cn-surf-head .eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 5px;
+}
+
+.cn-surf-head h1 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 22px;
+  letter-spacing: 0.02em;
+  color: var(--text-bright);
+  margin: 0;
+}
+
+.cn-surf-sub {
+  margin-top: 5px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.cn-surf-sub b {
+  color: var(--volt-strong);
+  font-weight: 600;
+}
+
+.cn-surf-sub .mono {
+  color: var(--text-mid);
+}
+
+.cn-surf-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.cn-act {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  padding: 7px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-main);
+  background: var(--bg-panel);
+  color: var(--text-mid);
+  cursor: pointer;
+  transition: 0.14s;
+  white-space: nowrap;
+}
+
+.cn-act:hover {
+  border-color: var(--volt-dim);
+  color: var(--volt-strong);
+  background: var(--bg-card);
+}
+
+.cn-act.primary {
+  border-color: var(--volt-dim);
+  background: var(--volt-wash);
+  color: var(--volt-strong);
+}
+
+.cn-act.primary:hover {
+  background: var(--volt);
+  color: var(--volt-ink);
+}
+
+/* ── Toolbar (search + add) ─────────────────────────────────────────────── */
+
+.cn-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.cn-search {
+  flex: 1;
+  min-width: 180px;
+  max-width: 360px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 7px 11px;
+  background: var(--bg-sunken);
+  color: var(--text-bright);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  outline: none;
+}
+
+.cn-search::placeholder {
+  color: var(--text-dim);
+}
+
+.cn-search:focus {
+  border-color: var(--volt-dim);
+  box-shadow: 0 0 0 2px var(--volt-wash);
+}
+
+/* ── Gate status strip ──────────────────────────────────────────────────── */
+
+.cn-gate-strip {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 16px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  background: var(--bg-panel);
+  margin-bottom: 16px;
+  font-size: 12px;
+  color: var(--text-mid);
+  flex-wrap: wrap;
+}
+
+.cn-gate-strip .sep {
+  width: 1px;
+  height: 16px;
+  background: var(--border-soft);
+}
+
+.cn-gate-strip b {
+  color: var(--text-bright);
+  font-weight: 600;
+}
+
+.cn-gate-strip .mono {
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.cn-gate-strip .status-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-dim);
+}
+
+.cn-gate-strip .status-dot.run {
+  background: var(--status-ok);
+  box-shadow: 0 0 8px rgb(var(--ok-glow) / 0.45);
+}
+
+.cn-gate-strip .status-dot.pause {
+  background: var(--status-warn);
+}
+
+.cn-gate-strip .status-dot.off {
+  background: var(--status-bad);
+}
+
+/* ── Connector card grid ────────────────────────────────────────────────── */
+
+.cn-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(var(--cn-card-min), 1fr));
+  gap: var(--gap-card);
+  margin-bottom: 16px;
+}
+
+.cn-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: border-color 0.14s ease, background 0.14s ease;
+}
+
+.cn-card:hover {
+  border-color: var(--border-highlight);
+  background: var(--bg-card);
+}
+
+.cn-card.stale {
+  border-color: color-mix(in oklab, var(--status-warn) 35%, var(--border-main));
+}
+
+.cn-card.down {
+  border-color: color-mix(in oklab, var(--status-bad) 30%, var(--border-main));
+}
+
+.cn-h {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 13px 15px;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--bg-panel-alt);
+}
+
+.cn-glyph {
+  width: 34px;
+  height: 34px;
+  flex: none;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-main);
+  background: var(--bg-deep);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  color: var(--volt-strong);
+}
+
+.cn-h .meta {
+  min-width: 0;
+  flex: 1;
+}
+
+.cn-h .nm {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-bright);
+}
+
+.cn-h .ch {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 3px;
+}
+
+.cn-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-main);
+  background: var(--bg-deep);
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.cn-status-pill.run {
+  border-color: var(--ok-border);
+  background: var(--ok-10);
+  color: var(--status-ok);
+}
+
+.cn-status-pill.pause {
+  border-color: var(--warn-border);
+  background: var(--warn-10);
+  color: var(--status-warn);
+}
+
+.cn-status-pill .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.cn-status-pill.run .dot {
+  animation: cn-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes cn-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.cn-config {
+  margin-left: 8px;
+  width: 26px;
+  height: 26px;
+  flex: none;
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: 0.14s;
+}
+
+.cn-config:hover {
+  border-color: var(--volt-dim);
+  color: var(--volt-strong);
+}
+
+.cn-kv {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: var(--border-soft);
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.cn-kv .cell {
+  background: var(--bg-panel);
+  padding: 8px 15px;
+}
+
+.cn-kv .k {
+  font-size: 8.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.cn-kv .v {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-mid);
+  margin-top: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cn-kv .v.hl {
+  color: var(--volt-strong);
+}
+
+.cn-caps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  padding: 10px 15px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.cn-cap {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-main);
+  color: var(--text-dim);
+  background: var(--bg-deep);
+  white-space: nowrap;
+}
+
+.cn-bind {
+  padding: 10px 15px 13px;
+  flex: 1;
+}
+
+.cn-bind h5 {
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin: 0 0 9px;
+  font-weight: 600;
+}
+
+.cn-bind-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 0;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  border-bottom: 1px dashed var(--border-soft);
+}
+
+.cn-bind-row:last-child {
+  border-bottom: 0;
+}
+
+.cn-bind-row .chn {
+  color: var(--text-mid);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cn-bind-row .arr {
+  color: var(--text-dim);
+  flex: none;
+}
+
+.cn-bind-none {
+  font-size: 11px;
+  color: var(--text-dim);
+  padding: 4px 0;
+}
+
+/* ── Audit log section ──────────────────────────────────────────────────── */
+
+.cn-audit {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+}
+
+.cn-audit-h {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.cn-audit-h h3 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-mid);
+  margin: 0;
+}
+
+.cn-audit-legend {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+.cn-audit table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11.5px;
+}
+
+.cn-audit th {
+  text-align: left;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  font-weight: 500;
+  padding: 4px 10px 8px 0;
+  border-bottom: 1px solid var(--border-main);
+}
+
+.cn-audit td {
+  padding: 7px 10px 7px 0;
+  border-bottom: 1px solid var(--border-soft);
+  color: var(--text-mid);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  white-space: nowrap;
+}
+
+.cn-audit td.act {
+  color: var(--text-bright);
+  font-family: var(--font-ui);
+  font-size: 11.5px;
+  white-space: normal;
+}
+
+.cn-audit tr:last-child td {
+  border-bottom: 0;
+}
+
+/* ── Detail drawer (config / test / events) ─────────────────────────────── */
+
+.cn-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.cn-drawer {
+  width: min(100%, var(--cn-drawer-width));
+  height: 100%;
+  background: var(--bg-deep);
+  border-left: 1px solid var(--border-main);
+  display: flex;
+  flex-direction: column;
+  box-shadow: -8px 0 40px rgba(0, 0, 0, 0.35);
+}
+
+.cn-drawer-hd {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border-main);
+  background: var(--bg-panel);
+}
+
+.cn-drawer-hd h3 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 15px;
+  color: var(--text-bright);
+  margin: 0;
+}
+
+.cn-drawer-hd .id {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+.cn-drawer-close {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-main);
+  background: var(--bg-card);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: 0.14s;
+}
+
+.cn-drawer-close:hover {
+  border-color: var(--volt-dim);
+  color: var(--volt-strong);
+}
+
+.cn-drawer-tabs {
+  flex: none;
+  display: flex;
+  gap: 2px;
+  padding: 10px 16px 0;
+  border-bottom: 1px solid var(--border-main);
+  background: var(--bg-panel);
+}
+
+.cn-drawer-tab {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  padding: 7px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: 0.14s;
+}
+
+.cn-drawer-tab:hover {
+  color: var(--text-bright);
+}
+
+.cn-drawer-tab.on {
+  color: var(--volt-strong);
+  border-bottom-color: var(--volt-strong);
+}
+
+.cn-drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.cn-drawer-section {
+  margin-bottom: 20px;
+}
+
+.cn-drawer-section h4 {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin: 0 0 10px;
+}
+
+.cn-test-btn {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  padding: 6px 11px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-main);
+  background: var(--bg-card);
+  color: var(--text-mid);
+  cursor: pointer;
+  transition: 0.14s;
+}
+
+.cn-test-btn:hover {
+  border-color: var(--volt-dim);
+  color: var(--volt-strong);
+}
+
+/* ── Empty / placeholder states ─────────────────────────────────────────── */
+
+.cn-empty {
+  padding: 26px 0;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .cn-surf-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .cn-surf-actions {
+    justify-content: flex-start;
+  }
+
+  .cn-gate-strip {
+    gap: 10px;
+  }
+
+  .cn-gate-strip .sep {
+    display: none;
+  }
+
+  .cn-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .cn-drawer {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
Refreshes the MASC dashboard Connectors surface with the keeper-v2 layout and styling.

## What changed
- Updated `dashboard/src/components/connector-status.ts`:
  - v2 header, search/filter toolbar, gate health strip
  - "Add connector" placeholder
  - Detail drawer with Connection / Config / Events tabs and Test button
- Updated `dashboard/src/components/connector-overview-strip.ts`:
  - v2 card grid layout
  - Per-tile config button
  - `filterQuery` prop for toolbar search
- **New styles** `dashboard/src/styles/connectors-v2.css` using dashboard tokens.
- **Wiring** — imported stylesheet in `main.ts`.
- **Tests** updated/added for v2 layout, filtering, and drawer tabs.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `connector-status.test.ts` ✅ 33/33
- `connector-overview-strip.test.ts` ✅ 67/67
- `connector-config-form.test.ts` ✅ 16/16

## Notes
- Existing connectors data model and routing preserved.
- No backend changes.
