### PR TITLE
OTel/Grafana integration cleanup: runtime selection, tool types, and dashboard fixes

### DIFF
--- a/infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json
+++ b/infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json
@@ -239,7 +239,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Rate of turn phase duration observations by phase name.",
+      "description": "Average dwell time per turn phase.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -252,7 +252,7 @@
             "pointSize": 0,
             "showPoints": "never"
           },
-          "unit": "ops"
+          "unit": "s"
         }
       },
       "gridPos": {
@@ -278,12 +278,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (from) (rate(masc_keeper_turn_phase_duration_seconds_count_total{keeper=~\"$keeper\"}[$__rate_interval]))",
+          "expr": "sum by (from) (rate(masc_keeper_turn_phase_duration_seconds_sum{keeper=~\"$keeper\"}[$__rate_interval])) / sum by (from) (rate(masc_keeper_turn_phase_duration_seconds_count_total{keeper=~\"$keeper\"}[$__rate_interval]))",
           "legendFormat": "{{from}}",
           "refId": "A"
         }
       ],
-      "title": "Turn Phase Duration",
+      "title": "Turn Phase Average Duration",
       "transparent": true,
       "type": "timeseries"
     },
@@ -403,6 +403,214 @@
         "y": 17
       },
       "panels": [],
+      "title": "Runtime Selection",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Runtime selections per minute by source.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 18
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (source) (rate(masc_keeper_runtime_selected_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{source}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Runtime Selected / min by Source",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Fallback selections per minute by reason.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 18
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (fallback_reason) (rate(masc_keeper_runtime_selected_total{keeper=~\"$keeper\",source=\"fallback\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{fallback_reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Fallback Reasons",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Provider cooldown skips per minute.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 18
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum (rate(masc_keeper_provider_cooldown_skip_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "cooldown skips",
+          "refId": "A"
+        }
+      ],
+      "title": "Cooldown Skips / min",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Runtime rotations per minute.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 18
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum (rate(masc_keeper_runtime_rotation_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "rotations",
+          "refId": "A"
+        }
+      ],
+      "title": "Runtime Rotations / min",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [],
       "title": "FSM State Machine",
       "type": "row"
     },
@@ -431,7 +639,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 18
+        "y": 27
       },
       "options": {
         "legend": {
@@ -484,7 +692,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 18
+        "y": 27
       },
       "options": {
         "legend": {
@@ -530,7 +738,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 18
+        "y": 27
       },
       "options": {
         "colorMode": "value",
@@ -578,7 +786,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 35
       },
       "options": {
         "legend": {
@@ -628,7 +836,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 35
       },
       "options": {
         "legend": {
@@ -658,7 +866,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 43
       },
       "panels": [],
       "title": "Prompt & Instruction Monitoring",
@@ -689,7 +897,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 35
+        "y": 44
       },
       "options": {
         "legend": {
@@ -782,7 +990,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 35
+        "y": 44
       },
       "options": {
         "legend": {
@@ -829,7 +1037,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 35
+        "y": 44
       },
       "options": {
         "legend": {
@@ -874,7 +1082,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 52
       },
       "options": {
         "legend": {
@@ -924,7 +1132,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 52
       },
       "options": {
         "legend": {
@@ -954,7 +1162,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 60
       },
       "panels": [],
       "title": "Tool Calls",
@@ -985,7 +1193,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 52
+        "y": 61
       },
       "options": {
         "legend": {
@@ -1063,7 +1271,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 52
+        "y": 61
       },
       "options": {
         "barWidth": 0.5,
@@ -1113,7 +1321,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 52
+        "y": 61
       },
       "options": {
         "legend": {
@@ -1163,7 +1371,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 60
+        "y": 69
       },
       "options": {
         "legend": {
@@ -1213,7 +1421,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 60
+        "y": 69
       },
       "options": {
         "legend": {
@@ -1263,7 +1471,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 60
+        "y": 69
       },
       "options": {
         "legend": {
@@ -1288,12 +1496,110 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Tool dispatches per minute by tool type.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 77
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (tool_type) (rate(tool_dispatch_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{tool_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tool Calls / min by Type",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Tools rejected by policy per minute by tool type.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 77
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (tool_type) (rate(masc_keeper_tool_not_allowed_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{tool_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tools Not Allowed / min by Type",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 68
+        "y": 85
       },
       "panels": [],
       "title": "Token & Cost",
@@ -1324,7 +1630,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 69
+        "y": 86
       },
       "options": {
         "legend": {
@@ -1377,7 +1683,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 69
+        "y": 86
       },
       "options": {
         "legend": {
@@ -1462,7 +1768,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 69
+        "y": 86
       },
       "options": {
         "legend": {
@@ -1527,7 +1833,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 77
+        "y": 94
       },
       "options": {
         "colorMode": "value",
@@ -1592,7 +1898,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 77
+        "y": 94
       },
       "options": {
         "reduceOptions": {
@@ -1650,7 +1956,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 77
+        "y": 94
       },
       "options": {
         "colorMode": "value",
@@ -1678,7 +1984,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 85
+        "y": 102
       },
       "panels": [],
       "title": "Context & Idle",
@@ -1689,49 +1995,31 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Maximum observed context utilization ratio per keeper.",
+      "description": "Maximum observed context bucket count per keeper.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
-          "decimals": 2,
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.7
-              },
-              {
-                "color": "red",
-                "value": 0.9
-              }
-            ]
-          },
-          "unit": "ratiounit"
+          "unit": "short"
         }
       },
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 86
+        "y": 103
       },
       "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
         },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -1740,9 +2028,9 @@
           "refId": "A"
         }
       ],
-      "title": "Context Utilization",
+      "title": "Context Max Observations",
       "transparent": true,
-      "type": "gauge"
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -1779,7 +2067,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 86
+        "y": 103
       },
       "options": {
         "colorMode": "value",
@@ -1836,7 +2124,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 86
+        "y": 103
       },
       "options": {
         "colorMode": "value",
@@ -1893,7 +2181,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 86
+        "y": 103
       },
       "options": {
         "colorMode": "value",
@@ -1940,7 +2228,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 94
+        "y": 111
       },
       "options": {
         "legend": {
@@ -1970,7 +2258,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 102
+        "y": 119
       },
       "panels": [],
       "title": "Compaction & Memory",
@@ -2001,7 +2289,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 103
+        "y": 120
       },
       "options": {
         "legend": {
@@ -2050,7 +2338,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 103
+        "y": 120
       },
       "options": {
         "legend": {
@@ -2112,7 +2400,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 103
+        "y": 120
       },
       "options": {
         "reduceOptions": {
@@ -2159,7 +2447,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 111
+        "y": 128
       },
       "options": {
         "legend": {
@@ -2247,7 +2535,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 111
+        "y": 128
       },
       "options": {
         "legend": {
@@ -2283,7 +2571,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 119
+        "y": 136
       },
       "panels": [],
       "title": "Health & Errors",
@@ -2314,7 +2602,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 120
+        "y": 137
       },
       "options": {
         "legend": {
@@ -2364,7 +2652,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 120
+        "y": 137
       },
       "options": {
         "legend": {
@@ -2414,7 +2702,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 120
+        "y": 137
       },
       "options": {
         "legend": {
@@ -2480,7 +2768,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 128
+        "y": 145
       },
       "options": {
         "legend": {
@@ -2534,7 +2822,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 128
+        "y": 145
       },
       "options": {
         "legend": {

--- a/infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json
+++ b/infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json
@@ -79,7 +79,7 @@
       "description": "99th percentile dashboard snapshot latency.",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(masc_dashboard_snapshot_latency_seconds_bucket_total[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.99, sum(rate(masc_dashboard_snapshot_latency_seconds_bucket[5m])) by (le)) * 1000",
           "legendFormat": "p99",
           "refId": "A"
         }
@@ -305,11 +305,170 @@
       }
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "panels": [],
+      "title": "Runtime & Provider Selection",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "description": "Runtime selections per minute by source.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 17
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (source) (rate(masc_keeper_runtime_selected_total[5m])) * 60",
+          "legendFormat": "{{source}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Runtime Selected / min by Source",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "description": "99th percentile LLM provider request latency.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 17
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(masc_llm_provider_request_latency_seconds_bucket_total[5m])) by (le)) * 1000",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ],
+      "title": "Provider Request Latency p99",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "description": "99th percentile time to first response chunk.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 17
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(gen_ai_client_operation_time_to_first_chunk_bucket_total[5m])) by (le)) * 1000",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ],
+      "title": "LLM Time To First Chunk p99",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
       "type": "timeseries",
       "title": "LLM Calls / min",
       "gridPos": {
         "x": 0,
-        "y": 16,
+        "y": 25,
         "w": 24,
         "h": 8
       },
@@ -320,7 +479,7 @@
       "description": "GenAI client calls per minute.",
       "targets": [
         {
-          "expr": "sum(rate(gen_ai_client_operation_duration_count_total[5m])) * 60",
+          "expr": "sum(rate(masc_llm_provider_requests_started_total[5m])) * 60",
           "legendFormat": "calls/min",
           "refId": "A"
         }
@@ -350,10 +509,10 @@
     },
     {
       "type": "barchart",
-      "title": "Token Usage / min",
+      "title": "Provider Token Usage / min",
       "gridPos": {
         "x": 0,
-        "y": 24,
+        "y": 33,
         "w": 12,
         "h": 8
       },
@@ -364,9 +523,14 @@
       "description": "Token usage rate by type (input / output).",
       "targets": [
         {
-          "expr": "sum by (token_type) (rate(gen_ai_client_token_usage[5m])) * 60",
-          "legendFormat": "{{token_type}}",
+          "expr": "sum(rate(masc_llm_provider_input_tokens_total[5m])) * 60",
+          "legendFormat": "input",
           "refId": "A"
+        },
+        {
+          "expr": "sum(rate(masc_llm_provider_output_tokens_total[5m])) * 60",
+          "legendFormat": "output",
+          "refId": "B"
         }
       ],
       "fieldConfig": {
@@ -392,7 +556,7 @@
       "title": "Goal Attainment %",
       "gridPos": {
         "x": 12,
-        "y": 32,
+        "y": 41,
         "w": 12,
         "h": 8
       },
@@ -428,7 +592,7 @@
       "title": "Active Keepers",
       "gridPos": {
         "x": 0,
-        "y": 40,
+        "y": 49,
         "w": 8,
         "h": 8
       },
@@ -462,7 +626,7 @@
       "title": "Keeper Compactions / min",
       "gridPos": {
         "x": 8,
-        "y": 48,
+        "y": 57,
         "w": 16,
         "h": 8
       },
@@ -480,7 +644,7 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "ms",
+          "unit": "cpm",
           "color": {
             "mode": "palette-classic"
           },
@@ -505,7 +669,7 @@
       "title": "Goal Attainment Measured",
       "gridPos": {
         "x": 0,
-        "y": 56,
+        "y": 65,
         "w": 8,
         "h": 8
       },
@@ -541,7 +705,7 @@
       "title": "Keeper Input Tokens / min",
       "gridPos": {
         "x": 8,
-        "y": 64,
+        "y": 73,
         "w": 16,
         "h": 8
       },
@@ -584,7 +748,7 @@
       "title": "Board Signal Wakeups / min",
       "gridPos": {
         "x": 0,
-        "y": 72,
+        "y": 81,
         "w": 24,
         "h": 8
       },
@@ -627,7 +791,7 @@
       "title": "OCaml Heap Memory",
       "gridPos": {
         "x": 0,
-        "y": 80,
+        "y": 89,
         "w": 12,
         "h": 8
       },
@@ -670,7 +834,7 @@
       "title": "GC Major Allocation Rate",
       "gridPos": {
         "x": 12,
-        "y": 88,
+        "y": 97,
         "w": 12,
         "h": 8
       },
@@ -713,7 +877,7 @@
       "title": "Recent Traces",
       "gridPos": {
         "x": 0,
-        "y": 96,
+        "y": 105,
         "w": 24,
         "h": 16
       },
@@ -750,7 +914,7 @@
       "title": "Keeper Instruction Monitoring",
       "gridPos": {
         "x": 0,
-        "y": 112,
+        "y": 121,
         "w": 24,
         "h": 1
       },
@@ -766,7 +930,7 @@
       "title": "Prompt Segment Bytes",
       "gridPos": {
         "x": 0,
-        "y": 113,
+        "y": 122,
         "w": 12,
         "h": 8
       },
@@ -814,7 +978,7 @@
       "title": "Template Render Outcome",
       "gridPos": {
         "x": 12,
-        "y": 113,
+        "y": 122,
         "w": 6,
         "h": 8
       },
@@ -848,7 +1012,7 @@
       "title": "Tool Call Param Completeness",
       "gridPos": {
         "x": 18,
-        "y": 113,
+        "y": 122,
         "w": 6,
         "h": 8
       },
@@ -887,7 +1051,7 @@
       "title": "Turn Instruction Hash",
       "gridPos": {
         "x": 0,
-        "y": 121,
+        "y": 130,
         "w": 24,
         "h": 6
       },
@@ -920,13 +1084,74 @@
       }
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 136
+      },
+      "panels": [],
+      "title": "Tool Calls",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "description": "Tool dispatches per minute by tool type.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 137
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (tool_type) (rate(tool_dispatch_total[5m])) * 60",
+          "legendFormat": "{{tool_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tool Calls / min by Type",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
       "id": 1,
       "type": "row",
       "title": "Fleet Health \u2014 Freeze Forensics",
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 127,
+        "y": 145,
         "w": 24,
         "h": 1
       },
@@ -938,7 +1163,7 @@
       "title": "Eio Loop Lag",
       "gridPos": {
         "x": 0,
-        "y": 128,
+        "y": 146,
         "w": 8,
         "h": 8
       },
@@ -988,7 +1213,7 @@
       "title": "Console Sink (writer health)",
       "gridPos": {
         "x": 8,
-        "y": 128,
+        "y": 146,
         "w": 8,
         "h": 8
       },
@@ -1042,7 +1267,7 @@
       "title": "Store Size (masc-root)",
       "gridPos": {
         "x": 16,
-        "y": 128,
+        "y": 146,
         "w": 8,
         "h": 8
       },
@@ -1075,7 +1300,7 @@
       "title": "Event Bus Backpressure",
       "gridPos": {
         "x": 0,
-        "y": 136,
+        "y": 154,
         "w": 8,
         "h": 8
       },
@@ -1109,10 +1334,10 @@
     {
       "id": 6,
       "type": "timeseries",
-      "title": "Snapshot Loop Duty Cycle",
+      "title": "Average Snapshot Latency",
       "gridPos": {
         "x": 8,
-        "y": 136,
+        "y": 154,
         "w": 8,
         "h": 8
       },
@@ -1126,35 +1351,29 @@
             "drawStyle": "line",
             "fillOpacity": 10
           },
-          "unit": "percentunit",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0.3
-              },
-              {
-                "color": "red",
-                "value": 0.7
-              }
-            ]
-          }
+          "unit": "s"
         },
         "overrides": []
       },
       "targets": [
         {
-          "expr": "rate(masc_dashboard_snapshot_latency_seconds[5m])",
+          "expr": "rate(masc_dashboard_snapshot_latency_seconds_sum[5m]) / rate(masc_dashboard_snapshot_latency_seconds_count_total[5m])",
           "legendFormat": "duty (s/s)",
           "refId": "A"
         }
       ],
-      "description": "Fraction of wall-clock the 2s dashboard snapshot loop spends computing. ~1.0 = the loop re-parses continuously (pre-#20677 behaviour)."
+      "description": "Average dashboard snapshot latency.",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     },
     {
       "id": 7,
@@ -1162,7 +1381,7 @@
       "title": "Telemetry Read Cost",
       "gridPos": {
         "x": 16,
-        "y": 136,
+        "y": 154,
         "w": 8,
         "h": 8
       },
@@ -1200,7 +1419,7 @@
       "title": "FD Open vs Limit",
       "gridPos": {
         "x": 0,
-        "y": 144,
+        "y": 162,
         "w": 8,
         "h": 8
       },
@@ -1237,7 +1456,7 @@
       "title": "Transition Audit Queue",
       "gridPos": {
         "x": 8,
-        "y": 144,
+        "y": 162,
         "w": 8,
         "h": 8
       },
@@ -1274,7 +1493,7 @@
       "title": "Watchdog Fires (24h)",
       "gridPos": {
         "x": 16,
-        "y": 144,
+        "y": 162,
         "w": 8,
         "h": 8
       },
@@ -1316,7 +1535,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 152,
+        "y": 170,
         "w": 24,
         "h": 1
       },
@@ -1328,7 +1547,7 @@
       "title": "Time To First Chunk (avg)",
       "gridPos": {
         "x": 0,
-        "y": 153,
+        "y": 171,
         "w": 8,
         "h": 8
       },
@@ -1378,7 +1597,7 @@
       "title": "OAS Bridge Timeouts / Cancels",
       "gridPos": {
         "x": 8,
-        "y": 153,
+        "y": 171,
         "w": 8,
         "h": 8
       },
@@ -1414,7 +1633,7 @@
       "title": "Provider Errors by Reason",
       "gridPos": {
         "x": 16,
-        "y": 153,
+        "y": 171,
         "w": 8,
         "h": 8
       },
@@ -1446,7 +1665,7 @@
       "title": "HTTP Pool Occupancy",
       "gridPos": {
         "x": 0,
-        "y": 161,
+        "y": 179,
         "w": 8,
         "h": 8
       },
@@ -1489,7 +1708,7 @@
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 169,
+        "y": 187,
         "w": 24,
         "h": 1
       },
@@ -1501,7 +1720,7 @@
       "title": "Discord Gateway Events / min",
       "gridPos": {
         "x": 0,
-        "y": 170,
+        "y": 188,
         "w": 8,
         "h": 8
       },
@@ -1539,7 +1758,7 @@
       "title": "Discord Inbound Dispatch / min",
       "gridPos": {
         "x": 8,
-        "y": 170,
+        "y": 188,
         "w": 8,
         "h": 8
       },
@@ -1572,7 +1791,7 @@
       "title": "Discord Ambient Capture / min",
       "gridPos": {
         "x": 16,
-        "y": 170,
+        "y": 188,
         "w": 8,
         "h": 8
       },
@@ -1605,7 +1824,7 @@
       "title": "Discord Reconnects, Closes, ACK Timeouts",
       "gridPos": {
         "x": 0,
-        "y": 178,
+        "y": 196,
         "w": 12,
         "h": 8
       },
@@ -1648,7 +1867,7 @@
       "title": "Discord Outbound Replies / min",
       "gridPos": {
         "x": 12,
-        "y": 178,
+        "y": 196,
         "w": 12,
         "h": 8
       },

--- a/lib/keeper/keeper_hooks_oas_response_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_response_metrics.ml
@@ -196,6 +196,7 @@ let record_keeper_tool_duration_metric
     ; label_provider, summary.provider
     ; label_tool, summary.tool_name
     ; label_outcome, summary.outcome
+    ; "tool_type", Tool_telemetry.tool_type_of_name summary.tool_name
     ]
   in
   let duration_seconds = summary.duration_ms /. ms_per_second in

--- a/lib/keeper/keeper_no_progress_loop_detector.ml
+++ b/lib/keeper/keeper_no_progress_loop_detector.ml
@@ -37,7 +37,7 @@ let get_or_create keeper_name =
 
 let update_streak_gauge keeper_name value =
   Otel_metric_store.set_gauge
-    "masc_keeper_no_progress_streak"
+    Keeper_metrics.(to_string NoProgressStreak)
     ~labels:[ ("keeper", keeper_name) ]
     (Float.of_int value)
 

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -139,6 +139,7 @@ let record_route_outcome ~tool ~routed_to ~result =
       [ "tool", safe_tool_label tool
       ; "routed_to", safe_routed_to_label routed_to
       ; "result", result
+      ; "tool_type", Tool_telemetry.tool_type_of_name tool
       ]
     ();
   (* Instruction monitoring: track per-tool invocation completeness.

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -563,7 +563,12 @@ let execute_keeper_tool_call_with_outcome
        in
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string ToolNotAllowed)
-         ~labels:[ "keeper", meta.name; "tool", name; "reason", reason ]
+         ~labels:
+           [ "keeper", meta.name
+           ; "tool", name
+           ; "reason", reason
+           ; "tool_type", Tool_telemetry.tool_type_of_name name
+           ]
          ();
        make_executed_tool_result
          (Yojson.Safe.to_string

--- a/lib/keeper/keeper_tool_registered_runtime.ml
+++ b/lib/keeper/keeper_tool_registered_runtime.ml
@@ -94,7 +94,7 @@ let handle_masc_tool
                  propagation now 3/3 = 100% per RFC-0084 §2.1 North Star. *)
                let tag_dispatch_with_telemetry () =
                  let result, _outcome =
-                   Tool_telemetry.with_span ~force_new_trace_id:true ~tool_name:name (fun _trace_id_thunk ->
+                   Tool_telemetry.with_span ~force_new_trace_id:true ~surface:"keeper" ~tool_name:name (fun _trace_id_thunk ->
                      let r =
                        !Keeper_tool_shared_runtime.tag_dispatch_fn
                          ~config

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -155,6 +155,15 @@ let run_keeper_cycle
     =
       let _ = phase_opt in
       let effective_runtime_id = Keeper_meta_contract.runtime_id_of_meta meta in
+      let source =
+        match Runtime.runtime_id_for_keeper meta.name with
+        | Some id when String.trim id <> "" -> "assigned"
+        | _ -> "default"
+      in
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string RuntimeSelected)
+        ~labels:[("keeper", meta.name); ("runtime_id", effective_runtime_id); ("source", source)]
+        ();
       let turn_state =
         append_manifest turn_state
           ~site:"runtime_routed"

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -430,15 +430,36 @@ let run (ctx : ctx)
             err
         with
         | Degraded_retry_allowed degraded_retry ->
+          let fallback_reason =
+            EC.degraded_retry_reason_to_string degraded_retry.fallback_reason
+          in
           Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
             ~keeper_name:meta.name
             ~runtime_id:execution.runtime_id
             ~decision:Degraded_retry_allowed
-            ~reason:(EC.degraded_retry_reason_to_string degraded_retry.fallback_reason)
+            ~reason:fallback_reason
             ~next_runtime:(Some degraded_retry.next_runtime)
             ~attempt
             ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
             ~error_message:(Some (Agent_sdk.Error.to_string err));
+          Otel_metric_store.inc_counter
+            Keeper_metrics.(to_string RuntimeSelected)
+            ~labels:
+              [ ("keeper", meta.name)
+              ; ("runtime_id", degraded_retry.next_runtime)
+              ; ("source", "fallback")
+              ; ("fallback_reason", fallback_reason)
+              ]
+            ();
+          Otel_metric_store.inc_counter
+            Keeper_metrics.(to_string RuntimeRotation)
+            ~labels:
+              [ ("keeper", meta.name)
+              ; ("from_runtime", execution.runtime_id)
+              ; ("to_runtime", degraded_retry.next_runtime)
+              ; ("reason", fallback_reason)
+              ]
+            ();
           (match
              Keeper_unified_turn_pre_dispatch
              .build_runtime_execution

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -864,7 +864,15 @@ let keeper_cycle_decision
           if
             Option.is_some provider_cooldown_remaining_sec
             && Option.is_none provider_cooldown_fail_open
-          then
+          then (
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string ProviderCooldownSkip)
+              ~labels:
+                [ ("keeper", meta.name)
+                ; ("from_runtime", runtime_id)
+                ; ("to_runtime", "skipped")
+                ]
+              ();
             Skip
               { reasons =
                   ( Provider_cooldown_pending
@@ -872,7 +880,7 @@ let keeper_cycle_decision
                           Option.value ~default:0 provider_cooldown_remaining_sec
                       }
                   , [] )
-              }
+              })
           else if should_run
           then (
             let run_reasons =

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -107,7 +107,6 @@ type t =
   | OllamaSaturationSkip
   | TaskLoadFailures
   | ToolSelectionFailures
-  | ToolPolicyFailures
   | ReconcileFailures
   | DecisionAuditFlushFailures
   | OasCancel
@@ -196,6 +195,8 @@ type t =
   | StaleBroadcastEmitFailures
   | OasRunTimeout
   | RuntimeSaturationSignal
+  | RuntimeSelected
+  | RuntimeRotation
   | ToolUseFailure
   | ToolNotAllowed
   | TurnGateRejectedTerminal
@@ -205,6 +206,7 @@ type t =
   | DockerRuntimeDiscarded
   | ProactiveSkip
   | NoProgressLoopDetected
+  | NoProgressStreak
   | UsageTrust
   | UsageAnomalyReason
   | ConfigEnvParseFailures
@@ -333,7 +335,6 @@ let to_string = function
   | OllamaSaturationSkip -> "masc_keeper_ollama_saturation_skip_total"
   | TaskLoadFailures -> "masc_keeper_task_load_failures_total"
   | ToolSelectionFailures -> "masc_keeper_tool_selection_failures_total"
-  | ToolPolicyFailures -> "masc_keeper_tool_policy_failures_total"
   | ReconcileFailures -> "masc_keeper_reconcile_failures_total"
   | DecisionAuditFlushFailures -> "masc_keeper_decision_audit_flush_failures_total"
   | OasCancel -> "masc_keeper_oas_cancel_total"
@@ -431,6 +432,8 @@ let to_string = function
   | StaleBroadcastEmitFailures -> "masc_keeper_stale_broadcast_emit_failures"
   | OasRunTimeout -> "masc_keeper_oas_run_timeout_total"
   | RuntimeSaturationSignal -> "masc_keeper_runtime_saturation_signal_total"
+  | RuntimeSelected -> "masc_keeper_runtime_selected_total"
+  | RuntimeRotation -> "masc_keeper_runtime_rotation_total"
   | ToolUseFailure -> "masc_keeper_tool_use_failure_total"
   | ToolNotAllowed -> "masc_keeper_tool_not_allowed_total"
   | TurnGateRejectedTerminal -> "masc_keeper_turn_gate_rejected_terminal_total"
@@ -440,6 +443,7 @@ let to_string = function
   | DockerRuntimeDiscarded -> "masc_keeper_docker_runtime_discarded_total"
   | ProactiveSkip -> "masc_keeper_proactive_skip_total"
   | NoProgressLoopDetected -> "masc_keeper_no_progress_loop_detected_total"
+  | NoProgressStreak -> "masc_keeper_no_progress_streak"
   | UsageTrust -> "masc_keeper_usage_trust_total"
   | UsageAnomalyReason -> "masc_keeper_usage_anomaly_reason_total"
   | ConfigEnvParseFailures -> "masc_keeper_config_env_parse_failures_total"
@@ -491,7 +495,7 @@ let all : t list =
     LifecycleDispatchRejections; RecordingErrorDedup; PausedStatePersistErrors; UnexpectedToolPartialTolerance;
     ToolCallTotal; ProfileConfigConflicts; OasTimeoutClassifications; NoToolProvider;
     ProactiveOutcome; OllamaSaturationSkip; TaskLoadFailures; ToolSelectionFailures;
-    ToolPolicyFailures; ReconcileFailures; DecisionAuditFlushFailures; OasCancel;
+    ReconcileFailures; DecisionAuditFlushFailures; OasCancel;
     ClaimAutoProvision; TomlInvalid; PersonaDriftMissing; WorkspaceInitFailures;
     PresenceSyncFailures; SelfPreservationUniversal; StaleStormPaused; ProviderTimeoutLoopPaused;
     CycleExceptions; SnapshotWriteFailures; StateSnapshotSkippedNoState; PromptUnknownToolTokens;
@@ -513,9 +517,9 @@ let all : t list =
     NearExhaustionTotal; RestartAttempts; RestartOutcomes; ConsecutiveIdle;
     LastProductiveTs; ProviderTimeoutStrike; StaleTerminationTotal; StaleTerminationByClass;
     ProviderTimeoutWatchdogTermination; StaleTerminationThresholdBreached; StaleTerminationBatch; StaleBroadcastEmitFailures;
-    OasRunTimeout; RuntimeSaturationSignal; ToolUseFailure; ToolNotAllowed;
+    OasRunTimeout; RuntimeSaturationSignal; RuntimeSelected; RuntimeRotation; ToolUseFailure; ToolNotAllowed;
     TurnGateRejectedTerminal; ReceiptUnmappedDisposition; ExecuteNetworkUpgrade; ExecuteLocalExecution;
-    DockerRuntimeDiscarded; ProactiveSkip; NoProgressLoopDetected; UsageTrust;
+    DockerRuntimeDiscarded; ProactiveSkip; NoProgressLoopDetected; NoProgressStreak; UsageTrust;
     UsageAnomalyReason; ConfigEnvParseFailures; PostTurnWireinFailures; RecurringFailures;
     TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; RuntimeHttpProbeJsonParseFailures;
     PromptSegmentBytes; PromptTemplateRenderOutcome; ToolCallParamCompleteness; KeeperTurnInstructionHash;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -98,7 +98,6 @@ type t =
   | OllamaSaturationSkip
   | TaskLoadFailures
   | ToolSelectionFailures
-  | ToolPolicyFailures
   | ReconcileFailures
   | DecisionAuditFlushFailures
   | OasCancel
@@ -187,6 +186,8 @@ type t =
   | StaleBroadcastEmitFailures
   | OasRunTimeout
   | RuntimeSaturationSignal
+  | RuntimeSelected
+  | RuntimeRotation
   | ToolUseFailure
   | ToolNotAllowed
   | TurnGateRejectedTerminal
@@ -196,6 +197,7 @@ type t =
   | DockerRuntimeDiscarded
   | ProactiveSkip
   | NoProgressLoopDetected
+  | NoProgressStreak
   | UsageTrust
   | UsageAnomalyReason
   | ConfigEnvParseFailures

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -510,7 +510,7 @@ let execute_tool_eio
                the keeper turn migration in PR-7. *)
             let dispatch_internal_with_telemetry () =
               let result, _outcome =
-                Tool_telemetry.with_span ~force_new_trace_id:true ~tool_name:name (fun _trace_id_thunk ->
+                Tool_telemetry.with_span ~force_new_trace_id:true ~surface:"mcp" ~tool_name:name (fun _trace_id_thunk ->
                   let r = dispatch_internal_keeper_runtime_tool () in
                   (* Route through the shared dispatch finalizer so MCP
                      internal-keeper-runtime calls run the same result
@@ -547,7 +547,7 @@ let execute_tool_eio
                     Tool_telemetry.with_span for 4-tuple emission. *)
                  let dispatch_tag_with_telemetry tag =
                    let result, _outcome =
-                     Tool_telemetry.with_span ~force_new_trace_id:true ~tool_name:name (fun _trace_id_thunk ->
+                     Tool_telemetry.with_span ~force_new_trace_id:true ~surface:"mcp" ~tool_name:name (fun _trace_id_thunk ->
                        let r = dispatch_by_tag tag in
                        (* Keep external MCP tools/call on the same
                           post-dispatch contract as internal keeper calls. *)

--- a/lib/otel_metric_store.ml
+++ b/lib/otel_metric_store.ml
@@ -108,7 +108,21 @@ let init () =
   reg "mcp.client.session.duration"
     [ 0.1; 0.5; 1.0; 5.0; 10.0; 60.0; 300.0; 600.0 ];
   reg "mcp.server.session.duration"
-    [ 0.1; 0.5; 1.0; 5.0; 10.0; 60.0; 300.0; 600.0 ]
+    [ 0.1; 0.5; 1.0; 5.0; 10.0; 60.0; 300.0; 600.0 ];
+  reg "gen_ai.client.operation.duration"
+    [ 0.1; 0.25; 0.5; 1.0; 2.5; 5.0; 10.0; 30.0; 60.0 ];
+  reg "gen_ai.client.operation.time_to_first_chunk"
+    [ 0.01; 0.05; 0.1; 0.25; 0.5; 1.0; 2.5; 5.0; 10.0; 30.0 ];
+  reg "gen_ai.client.operation.time_per_output_chunk"
+    [ 0.001; 0.005; 0.01; 0.05; 0.1; 0.25; 0.5; 1.0; 2.5; 5.0 ];
+  reg "masc_llm_provider_request_latency_seconds"
+    [ 0.1; 0.25; 0.5; 1.0; 2.5; 5.0; 10.0; 30.0; 60.0 ];
+  reg "masc_llm_provider_streaming_first_chunk_seconds"
+    [ 0.01; 0.05; 0.1; 0.25; 0.5; 1.0; 2.5; 5.0; 10.0 ];
+  reg "masc_inference_queue_wait_seconds"
+    [ 0.1; 0.25; 0.5; 1.0; 2.5; 5.0; 10.0; 30.0; 60.0 ];
+  reg "masc_sse_broadcast_duration_seconds"
+    [ 0.001; 0.005; 0.01; 0.05; 0.1; 0.5; 1.0; 5.0; 10.0 ]
 ;;
 
 let () = init ()

--- a/lib/runtime/dune
+++ b/lib/runtime/dune
@@ -37,6 +37,7 @@
   time_compat
   masc.dated_jsonl
   masc.masc_process
-  masc.otel_spans)
+  masc.otel_spans
+  masc.otel_metric_store)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/runtime/runtime_metrics.ml
+++ b/lib/runtime/runtime_metrics.ml
@@ -15,7 +15,12 @@ let metric_provider_cooldown = "masc_runtime_provider_cooldown_total"
 let metric_runtime_metrics_eviction = "masc_runtime_metrics_eviction_total"
 let metric_runtime_audit_failure = "masc_runtime_audit_failure_total"
 
-let on_provider_cooldown ~provider:_ ~reason:_ = ()
+let on_provider_cooldown ~provider ~reason =
+  Otel_metric_store_core.inc_counter
+    metric_provider_cooldown
+    ~labels:[("provider", provider); ("reason", reason)]
+    ()
+;;
 
 let on_runtime_metrics_eviction () = ()
 

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -138,12 +138,23 @@ type trace_id = string
 
 type span_wrapper =
   ?force_new_trace_id:bool
+  -> ?surface:string
   -> tool_name:string
   -> ((unit -> (trace_id * trace_id) option) -> Tool_result.result option * string)
   -> Tool_result.result option * string
 
 let identity_span_wrapper : span_wrapper =
-  fun ?force_new_trace_id:_ ~tool_name:_ body -> body (fun () -> None)
+  fun ?force_new_trace_id:_ ?surface:_ ~tool_name:_ body -> body (fun () -> None)
+;;
+
+let surface_of_tool_name name =
+  let name = String.lowercase_ascii (String.trim name) in
+  if String.starts_with ~prefix:"masc_" name
+     || String.starts_with ~prefix:"mcp__masc__" name
+  then "mcp"
+  else if String.starts_with ~prefix:"keeper_" name
+  then "keeper"
+  else "internal"
 ;;
 
 let span_wrapper_ref : span_wrapper ref = ref identity_span_wrapper
@@ -206,7 +217,10 @@ let guarded_dispatch ~(token : Tool_token.t) ~args () : Tool_result.result optio
     (* Injected telemetry span wrapper (default identity). The composition
        root registers [Tool_telemetry.with_span] so this lib stays free of
        the Otel/Otel_metric_store stack. *)
-    !span_wrapper_ref ~tool_name:token.name (fun _trace_id_thunk ->
+    !span_wrapper_ref
+      ~tool_name:token.name
+      ~surface:(surface_of_tool_name token.name)
+      (fun _trace_id_thunk ->
       let name = token.name in
       let r =
         match run_pre_hooks ~name ~args with

--- a/lib/tool/tool_dispatch.mli
+++ b/lib/tool/tool_dispatch.mli
@@ -92,6 +92,7 @@ type trace_id = string
 
 type span_wrapper =
   ?force_new_trace_id:bool
+  -> ?surface:string
   -> tool_name:string
   -> ((unit -> (trace_id * trace_id) option) -> Tool_result.result option * string)
   -> Tool_result.result option * string

--- a/lib/tool_telemetry.ml
+++ b/lib/tool_telemetry.ml
@@ -3,6 +3,36 @@
 
 type trace_id = string
 
+let tool_type_of_name name =
+  let name = String.lowercase_ascii (String.trim name) in
+  if String.starts_with ~prefix:"masc_" name
+  then "mcp"
+  else if String.starts_with ~prefix:"mcp__masc__" name
+  then "mcp"
+  else if String.starts_with ~prefix:"keeper_board_" name
+       || String.starts_with ~prefix:"board_" name
+  then "board"
+  else if String.starts_with ~prefix:"memory_" name
+  then "memory"
+  else if String.starts_with ~prefix:"library_" name
+       || String.starts_with ~prefix:"surface_" name
+  then "read"
+  else if name = "grep"
+       || name = "search"
+       || name = "search_files"
+       || String.starts_with ~prefix:"search_files" name
+  then "read"
+  else if String.starts_with ~prefix:"read" name
+  then "read"
+  else if String.starts_with ~prefix:"write" name
+  then "write"
+  else if String.starts_with ~prefix:"edit" name
+  then "write"
+  else if String.starts_with ~prefix:"execute" name
+  then "execute"
+  else "other"
+;;
+
 let counter_name = "tool_dispatch_total"
 let counter_registered = ref false
 
@@ -12,21 +42,26 @@ let register_metrics () =
     Otel_metric_store.register_counter
       ~name:counter_name
       ~help:
-        "Total tool dispatches by tool name and outcome label (RFC-0084 §2.1 \
-         4-tuple emission invariant)."
-      ~labels:[ "tool", ""; "outcome", "" ]
+        "Total tool dispatches by tool name, outcome, surface, and tool_type \
+         (RFC-0084 §2.1 4-tuple emission invariant)."
+      ~labels:[ "tool", ""; "outcome", ""; "surface", ""; "tool_type", "" ]
       ();
     counter_registered := true
   end
 ;;
 
-let with_span ?(force_new_trace_id = false) ~tool_name f =
+let with_span ?(force_new_trace_id = false) ?(surface = "unknown") ~tool_name f =
   let span_name = "tool_dispatch." ^ tool_name in
   Otel_spans.with_span ~name:span_name ~force_new_trace_id (fun trace_id_thunk ->
     let result, outcome = f trace_id_thunk in
     Otel_metric_store.inc_counter
       counter_name
-      ~labels:[ "tool", tool_name; "outcome", outcome ]
+      ~labels:
+        [ "tool", tool_name
+        ; "outcome", outcome
+        ; "surface", surface
+        ; "tool_type", tool_type_of_name tool_name
+        ]
       ();
     result, outcome)
 ;;

--- a/lib/tool_telemetry.mli
+++ b/lib/tool_telemetry.mli
@@ -19,10 +19,14 @@
 
 type trace_id = string
 
+(** [tool_type_of_name name] returns a low-cardinality category for [name]
+    based on known tool prefixes/names. *)
+val tool_type_of_name : string -> string
+
 (** [with_span ~tool_name f] opens an OTel span named
     {v tool_dispatch.<tool_name> v}, invokes [f] inside the span, and
-    increments [tool_dispatch_total] with labels [tool = tool_name] and
-    [outcome = <outcome returned by f>].
+    increments [tool_dispatch_total] with labels [tool = tool_name],
+    [outcome = <outcome returned by f>], [surface], and [tool_type].
 
     [f] receives a thunk that returns [Some (trace_id_hex, span_id_hex)] when an
     OTel span is active, [None] otherwise (e.g. when the exporter is disabled).
@@ -32,11 +36,12 @@ type trace_id = string
     [Dispatch_outcome.t]. *)
 val with_span
   :  ?force_new_trace_id:bool
+  -> ?surface:string
   -> tool_name:string
   -> ((unit -> (trace_id * trace_id) option) -> 'a * string)
   -> 'a * string
 
 (** Register the [tool_dispatch_total] Otel_metric_store counter with labels
-    [tool] and [outcome]. Call once at server startup. Subsequent calls
-    are idempotent (no-op). *)
+    [tool], [outcome], [surface], and [tool_type]. Call once at server
+    startup. Subsequent calls are idempotent (no-op). *)
 val register_metrics : unit -> unit

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -254,7 +254,7 @@ let () =
               register_full ~tool_name:tool ~handler:echo_handler ();
               let calls = ref [] in
               let probe : Tool_dispatch.span_wrapper =
-                fun ?force_new_trace_id:_ ~tool_name body ->
+                fun ?force_new_trace_id:_ ?surface:_ ~tool_name body ->
                   calls := tool_name :: !calls;
                   body (fun () -> Some ("probe-trace", "probe-trace"))
               in
@@ -273,7 +273,7 @@ let () =
               let tool = "__test_span_wrap_b" in
               register_full ~tool_name:tool ~handler:echo_handler ();
               let calls = ref 0 in
-              Tool_dispatch.set_span_wrapper (fun ?force_new_trace_id:_ ~tool_name:_ body ->
+              Tool_dispatch.set_span_wrapper (fun ?force_new_trace_id:_ ?surface:_ ~tool_name:_ body ->
                   incr calls;
                   body (fun () -> None));
               Tool_dispatch.clear_hooks ();


### PR DESCRIPTION
## Summary

Connects missing OTel/Grafana integration pieces and consolidates duplicated/confusing telemetry.

## Changes

### Grafana dashboards
- Fixes broken PromQL queries (wrong histogram suffixes, non-existent series, misleading units).
- Renames/repurposes semantically broken panels (`Context Utilization` -> `Context Max Observations`, `Snapshot Loop Duty Cycle` -> `Average Snapshot Latency`).
- Adds new panels for runtime selection, tool calls by `tool_type`, provider request latency p99, and LLM time-to-first-chunk p99.

### OTel metrics
- Adds `NoProgressStreak`, `RuntimeSelected`, `RuntimeRotation` metric variants.
- Registers histogram buckets for GenAI operation/streaming durations and provider/queue/SSE latencies.
- Instruments runtime selection decisions (assigned/default/fallback), degraded rotation, and provider cooldown skips.
- Adds `tool_type` and `surface` labels to tool dispatch and keeper tool metrics.

### Build fixes
- Adds required `phase` field to `Agent_sdk.Retry.Timeout` record constructions (pre-existing agent_sdk pin drift).

## Validation

- `scripts/dune-local.sh build lib/keeper lib/runtime lib/tool lib/otel_metric_store lib/keeper_metrics` passes.
- `test/test_guarded_dispatch_telemetry.exe` passes.
- Grafana dashboards reload cleanly from the worktree provisioning; no provisioning errors.

## Notes

- Two pre-existing test failures remain unrelated to these changes:
  - `test_oas_timeout_budget_strike.exe` fails because it reads source files via relative paths inside the dune sandbox.
  - `test_tool_dispatch.exe` `static_tag_routing` case fails on main as well (tag lookup state issue).
