### PR TITLE
feat(dashboard): apply final leftover v2 markers to unmarked surfaces

### DIFF
--- a/dashboard/src/components/copilot-dock.test.ts
+++ b/dashboard/src/components/copilot-dock.test.ts
@@ -54,6 +54,7 @@ describe('CopilotDock', () => {
     expect(dock.state.value.open).toBe(false)
     const btn = container.querySelector('[data-testid="copilot-dock-topbar-button"]')
     expect(btn).not.toBeNull()
+    expect(btn?.classList.contains('v2-shell-action')).toBe(true)
     ;(btn as HTMLButtonElement).click()
     expect(dock.state.value.open).toBe(true)
   })
@@ -72,6 +73,8 @@ describe('CopilotDock', () => {
     const dock = renderDock()
     dock.open()
     await waitFor(() => expect(container.querySelector('[data-testid="copilot-dock"]')).not.toBeNull())
+
+    expect(container.querySelector('.v2-shell-surface')).not.toBeNull()
 
     const closeBtn = container.querySelector('[title="닫기 (Esc)"]')
     expect(closeBtn).not.toBeNull()

--- a/dashboard/src/components/copilot-dock.ts
+++ b/dashboard/src/components/copilot-dock.ts
@@ -470,7 +470,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
   return html`
     <aside
       ref=${rootRef}
-      class=${`dock ${docked ? 'docked' : 'float'}`}
+      class=${`v2-shell-surface dock ${docked ? 'docked' : 'float'}`}
       style=${floatStyle}
       data-screen-label="Copilot 도크"
       data-testid="copilot-dock"
@@ -621,7 +621,7 @@ export function CopilotDockFab({ dock }: { dock: CopilotDockApi }) {
   return html`
     <button
       type="button"
-      class="dock-fab"
+      class="v2-shell-action dock-fab"
       onClick=${dock.open}
       data-testid="copilot-dock-fab"
       aria-label="Open Copilot Dock"
@@ -638,7 +638,7 @@ export function CopilotDockTopBarButton({ dock }: { dock: CopilotDockApi }) {
   return html`
     <button
       type="button"
-      class=${`topbar-copilot ${on ? 'on' : ''}`}
+      class=${`v2-shell-action topbar-copilot ${on ? 'on' : ''}`}
       onClick=${dock.toggle}
       data-testid="copilot-dock-topbar-button"
       aria-label="Toggle Copilot Dock"

--- a/dashboard/src/components/excuse-patterns.test.ts
+++ b/dashboard/src/components/excuse-patterns.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { ExcusePatterns } from './excuse-patterns'
+
+vi.mock('../api/dashboard', () => ({
+  fetchExcusePatterns: vi.fn().mockResolvedValue([]),
+  updateExcusePatterns: vi.fn().mockResolvedValue(undefined),
+}))
+
+const flush = () => new Promise<void>((r) => setTimeout(() => r(), 10))
+
+describe('ExcusePatterns', () => {
+  it('renders the v2 command panel marker', async () => {
+    const container = document.createElement('div')
+    render(html`<${ExcusePatterns} />`, container)
+    await flush()
+
+    expect(container.querySelector('.v2-command-panel')).not.toBeNull()
+  })
+})

--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -53,7 +53,7 @@ export function ExcusePatterns() {
 
   if (s.status === 'loading') {
     return html`
-      <${SectionCard} label="Anti-Rationalization 핑계 패턴">
+      <${SectionCard} label="Anti-Rationalization 핑계 패턴" class="v2-command-panel">
         <${LoadingState}>핑계 패턴 불러오는 중...<//>
       <//>
     `
@@ -61,7 +61,7 @@ export function ExcusePatterns() {
 
   if (s.status === 'error') {
     return html`
-      <${SectionCard} label="Anti-Rationalization 핑계 패턴">
+      <${SectionCard} label="Anti-Rationalization 핑계 패턴" class="v2-command-panel">
         <div class="p-4 text-[var(--color-status-err)]" role="alert">패턴 로드 실패: ${s.message}</div>
       <//>
     `
@@ -71,7 +71,7 @@ export function ExcusePatterns() {
   const jsonStr = data ? JSON.stringify(data, null, 2) : '[]'
 
   return html`
-    <${SectionCard} label="Anti-Rationalization 핑계 패턴">
+    <${SectionCard} label="Anti-Rationalization 핑계 패턴" class="v2-command-panel">
       <div class="p-4">
         <p class="text-sm text-[var(--color-fg-muted)] mb-4">
           이 패턴들은 에이전트 completion note 와 매칭됩니다. 매칭되면 해당 task 는 거부됩니다.

--- a/dashboard/src/components/flow-control/flow-control-panel.test.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.test.ts
@@ -99,6 +99,7 @@ describe('FlowControlPanel', () => {
     render(html`<${FlowControlPanel} />`, container)
     await flushUi()
 
+    expect(container.querySelector('.v2-command-surface')).not.toBeNull()
     expect(container.textContent).toContain('Flow Control')
     expect(container.textContent).toContain('Pause')
     expect(container.textContent).toContain('Resume')

--- a/dashboard/src/components/flow-control/flow-control-panel.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.ts
@@ -40,7 +40,8 @@ export function FlowControlPanel() {
     ? 'OAS runtime'
     : admission?.throttle_owner ?? 'unknown'
   return html`
-    <${SurfaceCard} variant="compact" class="mb-4">
+    <div class="v2-command-surface flex flex-col gap-4">
+      <${SurfaceCard} variant="compact" class="v2-command-panel mb-4">
       <div class="flex items-center gap-3 mb-3">
         <h3 class="text-sm text-[var(--color-fg-secondary)] font-medium">Flow Control</h3>
         <${CountBadge} tone=${stateTone(state)}>${stateLabel(state)}<//>
@@ -66,7 +67,7 @@ export function FlowControlPanel() {
     <//>
 
     ${'' /* ── Maintenance ── */}
-    <${SurfaceCard} variant="compact">
+    <${SurfaceCard} variant="compact" class="v2-command-panel">
       <details>
         <summary class="cursor-pointer text-sm text-[var(--color-fg-secondary)] font-medium select-none py-1">Maintenance</summary>
         <div class="mt-3 flex flex-wrap gap-2">
@@ -88,5 +89,6 @@ export function FlowControlPanel() {
         ` : null}
       </details>
     <//>
+    </div>
   `
 }

--- a/dashboard/src/components/ide/ide-breadcrumb.ts
+++ b/dashboard/src/components/ide/ide-breadcrumb.ts
@@ -85,7 +85,6 @@ export function IdeBreadcrumb() {
       role="navigation"
       aria-label="File breadcrumb"
       data-testid="ide-breadcrumb"
-<<<<<<< HEAD
       class="ide-breadcrumb v2-ide-toolbar ide-v2-crumb flex items-center gap-1.5 border-b border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] px-3 py-1 font-mono text-2xs"
     >
       <span aria-hidden="true" style=${{ fontSize: '12px', lineHeight: '16px' }}>${icon}</span>

--- a/dashboard/src/components/repo-detail-panel.ts
+++ b/dashboard/src/components/repo-detail-panel.ts
@@ -208,7 +208,7 @@ export function RepoDetailPanel() {
   const branchesLoading = branchState.status === 'loading'
 
   return html`
-    <div class="flex flex-col gap-4">
+    <div class="v2-workspace-surface flex flex-col gap-4">
       <div class="flex items-center justify-between">
         <div class="flex items-center gap-3">
           <h2 class="text-lg font-semibold text-[var(--color-fg-secondary)]">${repo.name}</h2>

--- a/dashboard/src/components/repo-sidebar.ts
+++ b/dashboard/src/components/repo-sidebar.ts
@@ -136,7 +136,7 @@ export function RepoSidebar() {
 
   if (state.status === 'loading') {
     return html`
-      <div class="flex flex-col h-full">
+      <div class="v2-workspace-surface flex flex-col h-full">
         <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--color-border-default)]">
           <span class="text-sm font-bold text-[var(--color-fg-secondary)]">저장소</span>
         </div>
@@ -147,7 +147,7 @@ export function RepoSidebar() {
 
   if (state.status === 'error') {
     return html`
-      <div class="flex flex-col h-full">
+      <div class="v2-workspace-surface flex flex-col h-full">
         <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--color-border-default)]">
           <span class="text-sm font-bold text-[var(--color-fg-secondary)]">저장소</span>
           <button
@@ -169,7 +169,7 @@ export function RepoSidebar() {
   const selected = selectedRepoId.value
 
   return html`
-    <div class="flex flex-col h-full">
+    <div class="v2-workspace-surface flex flex-col h-full">
       <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--color-border-default)]">
         <span class="text-sm font-bold text-[var(--color-fg-secondary)]">
           저장소 <span class="text-[var(--color-fg-secondary)] font-normal">(${repos.length})</span>

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -36,6 +36,7 @@ describe('SettingsSurface', () => {
   it('renders the surface and category navigation', () => {
     render(html`<${SettingsSurface} />`, container)
 
+    expect(container.querySelector('.v2-shell-surface')).not.toBeNull()
     expect(container.querySelector('[data-testid="settings-surface"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="settings-nav-account"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="settings-nav-runtime"]')).not.toBeNull()

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -365,7 +365,7 @@ export function SettingsSurface() {
   const cur = SET_SECTIONS.find(s => s[0] === sec) ?? SET_SECTIONS[0]!
 
   return html`
-    <main class="settings-surf" data-screen-label="설정" data-testid="settings-surface">
+    <main class="v2-shell-surface settings-surf" data-screen-label="설정" data-testid="settings-surface">
       <div class="set-shell">
         <nav class="set-nav" aria-label="Settings categories">
           <div class="set-nav-h">

--- a/dashboard/src/components/task-manage/task-create-form.test.ts
+++ b/dashboard/src/components/task-manage/task-create-form.test.ts
@@ -33,6 +33,7 @@ describe('TaskCreateForm', () => {
   it('renders collapsed state with add button', () => {
     const container = document.createElement('div')
     render(html`<${TaskCreateForm} />`, container)
+    expect(container.querySelector('.v2-workspace-surface')).not.toBeNull()
     expect(container.textContent).toContain('태스크 추가')
   })
 
@@ -55,6 +56,7 @@ describe('TaskCreateForm', () => {
     render(html`<${TaskCreateForm} />`, container)
     showTaskCreate.value = true
     await flush()
+    expect(container.querySelector('.v2-workspace-surface')).not.toBeNull()
     expect(container.textContent).toContain('새 태스크')
     expect(container.textContent).toContain('backlog에 추가')
     expect(container.textContent).toContain('취소')

--- a/dashboard/src/components/task-manage/task-create-form.ts
+++ b/dashboard/src/components/task-manage/task-create-form.ts
@@ -24,7 +24,7 @@ export function TaskCreateForm(props: { goalId?: string | null; goalTitle?: stri
   const linkedGoalTitle = props.goalTitle?.trim() || null
   if (!showTaskCreate.value) {
     return html`
-      <div class="flex flex-col gap-3">
+      <div class="v2-workspace-surface flex flex-col gap-3">
         <div class="text-xs leading-relaxed text-text-muted">
           ${linkedGoalId
             ? html`
@@ -48,7 +48,7 @@ export function TaskCreateForm(props: { goalId?: string | null; goalTitle?: stri
   }
 
   return html`
-    <div class="rounded-[var(--r-1)] border border-card-border/70 bg-[var(--color-bg-surface)] p-4">
+    <div class="v2-workspace-surface rounded-[var(--r-1)] border border-card-border/70 bg-[var(--color-bg-surface)] p-4">
       <div class="mb-3 flex items-start justify-between gap-3">
         <div>
           <h3 class="text-base font-semibold text-text-strong">새 태스크</h3>


### PR DESCRIPTION
## Summary

Apply v2 marker classes to the remaining surface components that still had no v2-* markers after the exhaustive pass.

## Components updated

- **CopilotDock** — `.v2-shell-surface` on the dock, `.v2-shell-action` on FAB/top-bar buttons
- **ExcusePatterns** — `.v2-command-panel` on all SectionCards
- **FlowControlPanel** — `.v2-command-surface` wrapper + `.v2-command-panel` on SurfaceCards
- **RepoDetailPanel** — `.v2-workspace-surface`
- **RepoSidebar** — `.v2-workspace-surface`
- **SettingsSurface** — `.v2-shell-surface`
- **TaskCreateForm** — `.v2-workspace-surface`

## Tests

- Added/updated assertions in `copilot-dock.test.ts`, `flow-control-panel.test.ts`, `settings-surface.test.ts`, `task-create-form.test.ts`
- Added new `excuse-patterns.test.ts`

## Verification

- `pnpm typecheck` — pass
- `pnpm lint` — pass
- touched vitest test files — 32 tests passed
- `pnpm build` — pass

## Notes

- Memory (`memory/*`), keeper-v2 primitives, telemetry-panel, observatory/cursor-line, and small cross-cutting primitives were intentionally left as-is (they either use their own v2 CSS surface or are atomic components).