### PR TITLE
feat(dashboard): apply keeper-v2 tweaks panel + craft layer

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -60,6 +60,14 @@ import {
   useCopilotDock,
   useCopilotDockShortcuts,
 } from './components/copilot-dock'
+import {
+  TweaksPanel,
+  TweaksPanelToggle,
+  tweaksDensity,
+  tweaksFontScale,
+  tweaksMotion,
+  tweaksBubble,
+} from './components/tweaks-panel'
 
 // Sidebar collapsed state persists across reloads — a user who picks
 // the dense layout keeps it. Namespaced key avoids clashing with any
@@ -258,10 +266,15 @@ export function App() {
 
   return html`
     <div
-      class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--color-bg-page)] text-[var(--color-fg-primary)]"
+      class="v2-app flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--color-bg-page)] text-[var(--color-fg-primary)]"
       data-widget-solo=${widgetSoloMode ? 'true' : 'false'}
       data-focus-mode=${focusMode ? 'true' : 'false'}
       data-keeper-detail-mode=${keeperDetailMode ? 'true' : 'false'}
+      data-density=${tweaksDensity.value}
+      data-motion=${tweaksMotion.value}
+      data-bubble=${tweaksBubble.value}
+      data-font-scale=${tweaksFontScale.value}
+      style=${{ '--twk-font-scale': String(tweaksFontScale.value) }}
     >
       <${SkipLink} />
       <header class="${compactChromeMode ? 'hidden' : 'relative v2-shell-header'} z-10 shrink-0 border-b border-[var(--color-border-default)] bg-[var(--shell-header-bg)] px-3 py-1.5">
@@ -312,6 +325,7 @@ export function App() {
             <${ErrorCounterBadge} />
             <div class="max-[768px]:hidden"><${TransportBeacon} /></div>
             <div class="max-[768px]:hidden"><${ThemeSwitch} /></div>
+            <div class="max-[768px]:hidden"><${TweaksPanelToggle} /></div>
             <div class="max-[768px]:hidden"><${BuildIdentityBadge} /></div>
           </div>
         </div>
@@ -376,6 +390,7 @@ export function App() {
       <${ToastContainer} />
       <${ConfirmDialogOverlay} />
       <${BundleStalenessBanner} />
+      <${TweaksPanel} />
       <${Suspense} fallback=${null}>
         <${LazyCommandPalette} />
       <//>

--- a/dashboard/src/components/tweaks-panel.test.ts
+++ b/dashboard/src/components/tweaks-panel.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { fireEvent } from '@testing-library/preact'
+import {
+  TweaksPanel,
+  TweaksPanelToggle,
+  tweaksBubble,
+  tweaksDensity,
+  tweaksFontScale,
+  tweaksMotion,
+  tweaksOpen,
+} from './tweaks-panel'
+
+describe('TweaksPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    tweaksOpen.value = false
+    tweaksDensity.value = 'regular'
+    tweaksMotion.value = 'subtle'
+    tweaksBubble.value = 'card'
+    tweaksFontScale.value = 100
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('toggle button opens and closes the panel', async () => {
+    render(html`<${TweaksPanelToggle} />`, container)
+
+    const btn = container.querySelector('[data-testid="tweaks-panel-toggle"]') as HTMLButtonElement
+    expect(btn).not.toBeNull()
+    expect(btn.getAttribute('aria-expanded')).toBe('false')
+
+    await fireEvent.click(btn)
+    expect(tweaksOpen.value).toBe(true)
+
+    render(html`<${TweaksPanelToggle} />`, container)
+    expect(btn.getAttribute('aria-expanded')).toBe('true')
+
+    await fireEvent.click(btn)
+    expect(tweaksOpen.value).toBe(false)
+  })
+
+  it('renders controls when open', () => {
+    tweaksOpen.value = true
+    render(html`<${TweaksPanel} />`, container)
+
+    const panel = container.querySelector('[data-testid="tweaks-panel"]')
+    expect(panel).not.toBeNull()
+    expect(container.querySelectorAll('[data-testid="twk-seg"]').length).toBeGreaterThanOrEqual(3)
+    expect(container.querySelector('[data-testid="twk-slider"]')).not.toBeNull()
+  })
+
+  it('does not render when closed', () => {
+    tweaksOpen.value = false
+    render(html`<${TweaksPanel} />`, container)
+    expect(container.querySelector('[data-testid="tweaks-panel"]')).toBeNull()
+  })
+
+  it('density control updates the signal', async () => {
+    tweaksOpen.value = true
+    render(html`<${TweaksPanel} />`, container)
+
+    const seg = container.querySelector('[data-testid="twk-seg"]') as HTMLElement
+    const compactBtn = Array.from(seg.querySelectorAll('button')).find(
+      b => b.getAttribute('data-value') === 'compact',
+    ) as HTMLButtonElement
+
+    expect(compactBtn).not.toBeNull()
+    await fireEvent.click(compactBtn)
+    expect(tweaksDensity.value).toBe('compact')
+    expect(compactBtn.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('motion control updates the signal', async () => {
+    tweaksOpen.value = true
+    render(html`<${TweaksPanel} />`, container)
+
+    const seg = container.querySelectorAll('[data-testid="twk-seg"]')[1] as HTMLElement
+    const livelyBtn = Array.from(seg.querySelectorAll('button')).find(
+      b => b.getAttribute('data-value') === 'lively',
+    ) as HTMLButtonElement
+
+    await fireEvent.click(livelyBtn)
+    expect(tweaksMotion.value).toBe('lively')
+  })
+
+  it('bubble control updates the signal', async () => {
+    tweaksOpen.value = true
+    render(html`<${TweaksPanel} />`, container)
+
+    const seg = container.querySelectorAll('[data-testid="twk-seg"]')[2] as HTMLElement
+    const flatBtn = Array.from(seg.querySelectorAll('button')).find(
+      b => b.getAttribute('data-value') === 'flat',
+    ) as HTMLButtonElement
+
+    await fireEvent.click(flatBtn)
+    expect(tweaksBubble.value).toBe('flat')
+  })
+
+  it('font scale slider updates the signal', async () => {
+    tweaksOpen.value = true
+    render(html`<${TweaksPanel} />`, container)
+
+    const slider = container.querySelector('[data-testid="twk-slider"] input') as HTMLInputElement
+    slider.value = '110'
+    await fireEvent.input(slider)
+
+    expect(tweaksFontScale.value).toBe(110)
+  })
+
+  it('close button hides the panel', async () => {
+    tweaksOpen.value = true
+    render(html`<${TweaksPanel} />`, container)
+
+    const close = container.querySelector('[data-testid="tweaks-panel-close"]') as HTMLButtonElement
+    await fireEvent.click(close)
+
+    expect(tweaksOpen.value).toBe(false)
+  })
+})

--- a/dashboard/src/components/tweaks-panel.ts
+++ b/dashboard/src/components/tweaks-panel.ts
@@ -1,0 +1,302 @@
+// TweaksPanel — keeper-v2 craft controls ported to the MASC dashboard.
+//
+// Exposes four taste axes as persistent UI preferences:
+//   density   — compact / regular / spacious
+//   motion    — off / subtle / lively
+//   bubble    — flat / card
+//   fontScale — 80% – 125%
+//
+// Values are mirrored to the app root via data-* attributes so
+// craft-v2.css can drive spacing, motion and message styling without
+// re-rendering individual components. The panel itself is a floating,
+// draggable chrome surface scoped to its own CSS class names.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { useCallback, useEffect, useRef } from 'preact/hooks'
+import { persistentSignal } from '../lib/persistent-signal'
+import { ringFocusClasses } from './common/ring'
+import { Settings2, X } from 'lucide-preact'
+
+export type Density = 'compact' | 'regular' | 'spacious'
+export type Motion = 'off' | 'subtle' | 'lively'
+export type Bubble = 'flat' | 'card'
+
+const DENSITY_OPTIONS: Density[] = ['compact', 'regular', 'spacious']
+const MOTION_OPTIONS: Motion[] = ['off', 'subtle', 'lively']
+const BUBBLE_OPTIONS: Bubble[] = ['flat', 'card']
+
+const densitySignal = persistentSignal<Density>({
+  key: 'dashboard:tweaks:density',
+  defaultValue: 'regular',
+})
+
+const motionSignal = persistentSignal<Motion>({
+  key: 'dashboard:tweaks:motion',
+  defaultValue: 'subtle',
+})
+
+const bubbleSignal = persistentSignal<Bubble>({
+  key: 'dashboard:tweaks:bubble',
+  defaultValue: 'card',
+})
+
+const fontScaleSignal = persistentSignal<number>({
+  key: 'dashboard:tweaks:font-scale',
+  defaultValue: 100,
+})
+
+/** Readable exports for consumers that need to react in signals. */
+export const tweaksDensity = densitySignal
+export const tweaksMotion = motionSignal
+export const tweaksBubble = bubbleSignal
+export const tweaksFontScale = fontScaleSignal
+
+/** Panel open/closed state (not persisted — starts closed). */
+export const tweaksOpen = signal(false)
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n))
+}
+
+function formatLabel(key: string): string {
+  return key.charAt(0).toUpperCase() + key.slice(1)
+}
+
+interface SegmentedControlProps<T extends string> {
+  value: T
+  options: readonly T[]
+  onChange: (value: T) => void
+  'aria-label'?: string
+}
+
+function SegmentedControl<T extends string>({
+  value,
+  options,
+  onChange,
+  'aria-label': ariaLabel,
+}: SegmentedControlProps<T>) {
+  return html`
+    <div
+      class="twk-seg"
+      role="radiogroup"
+      aria-label=${ariaLabel}
+      data-testid="twk-seg"
+    >
+      ${options.map((o) => html`
+        <button
+          type="button"
+          key=${o}
+          role="radio"
+          class=${`twk-seg-b ${value === o ? 'on' : ''}`}
+          aria-checked=${value === o}
+          data-active=${value === o ? 'true' : 'false'}
+          data-value=${o}
+          onClick=${() => onChange(o)}
+        >
+          ${formatLabel(o)}
+        </button>
+      `)}
+    </div>
+  `
+}
+
+interface SliderProps {
+  value: number
+  min: number
+  max: number
+  step?: number
+  suffix?: string
+  'aria-label'?: string
+  onChange: (value: number) => void
+}
+
+function Slider({
+  value,
+  min,
+  max,
+  step = 1,
+  suffix = '',
+  'aria-label': ariaLabel,
+  onChange,
+}: SliderProps) {
+  return html`
+    <div class="twk-slider-row" data-testid="twk-slider">
+      <input
+        type="range"
+        class="twk-slider"
+        min=${min}
+        max=${max}
+        step=${step}
+        value=${value}
+        aria-label=${ariaLabel}
+        onInput=${(e: Event) => onChange(Number((e.target as HTMLInputElement).value))}
+      />
+      <span class="twk-slider-val" aria-hidden="true">${value}${suffix}</span>
+    </div>
+  `
+}
+
+interface RowProps {
+  label: string
+  hint?: string
+  children: unknown
+}
+
+function Row({ label, hint, children }: RowProps) {
+  return html`
+    <div class="twk-row" data-testid="twk-row">
+      <div class="twk-row-l">
+        <div class="twk-row-label">${label}</div>
+        ${hint ? html`<div class="twk-row-hint">${hint}</div>` : null}
+      </div>
+      <div class="twk-row-c">${children}</div>
+    </div>
+  `
+}
+
+/** Header toggle button for the top bar. */
+export function TweaksPanelToggle() {
+  const open = tweaksOpen.value
+  const title = open
+    ? 'Close display tweaks'
+    : 'Open display tweaks (density, motion, bubbles, font scale)'
+  return html`
+    <button
+      type="button"
+      class=${`v2-shell-action flex items-center justify-center gap-1.5 cursor-pointer rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2.5 py-[5px] text-2xs text-[var(--color-fg-muted)] transition-colors duration-[var(--t-med)] hover:border-[var(--accent-20)] hover:text-[var(--color-fg-secondary)] ${open ? 'border-[var(--color-accent-fg)] text-[var(--color-accent-fg)]' : ''} ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })}`}
+      aria-label=${title}
+      title=${title}
+      aria-expanded=${open}
+      data-testid="tweaks-panel-toggle"
+      onClick=${() => { tweaksOpen.value = !tweaksOpen.value }}
+    >
+      <${Settings2} size=${14} />
+      <span class="max-[1080px]:hidden">Tweaks</span>
+    </button>
+  `
+}
+
+/** Floating tweaks panel. */
+export function TweaksPanel() {
+  const open = tweaksOpen.value
+  const dragRef = useRef<HTMLDivElement>(null)
+  const offsetRef = useRef({ x: 16, y: 16 })
+  const PAD = 16
+
+  const clampToViewport = useCallback(() => {
+    const panel = dragRef.current
+    if (!panel) return
+    const w = panel.offsetWidth
+    const h = panel.offsetHeight
+    const maxRight = Math.max(PAD, window.innerWidth - w - PAD)
+    const maxBottom = Math.max(PAD, window.innerHeight - h - PAD)
+    offsetRef.current = {
+      x: clamp(offsetRef.current.x, PAD, maxRight),
+      y: clamp(offsetRef.current.y, PAD, maxBottom),
+    }
+    panel.style.right = `${offsetRef.current.x}px`
+    panel.style.bottom = `${offsetRef.current.y}px`
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    clampToViewport()
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(clampToViewport) : null
+    if (ro) ro.observe(document.documentElement)
+    else window.addEventListener('resize', clampToViewport)
+    return () => {
+      if (ro) ro.disconnect()
+      else window.removeEventListener('resize', clampToViewport)
+    }
+  }, [open, clampToViewport])
+
+  const onDragStart = useCallback((e: MouseEvent) => {
+    const panel = dragRef.current
+    if (!panel) return
+    const r = panel.getBoundingClientRect()
+    const sx = e.clientX
+    const sy = e.clientY
+    const startRight = window.innerWidth - r.right
+    const startBottom = window.innerHeight - r.bottom
+    const move = (ev: MouseEvent) => {
+      offsetRef.current = {
+        x: startRight - (ev.clientX - sx),
+        y: startBottom - (ev.clientY - sy),
+      }
+      clampToViewport()
+    }
+    const up = () => {
+      window.removeEventListener('mousemove', move)
+      window.removeEventListener('mouseup', up)
+    }
+    window.addEventListener('mousemove', move)
+    window.addEventListener('mouseup', up)
+  }, [clampToViewport])
+
+  if (!open) return null
+
+  return html`
+    <div
+      ref=${dragRef}
+      class="twk-panel"
+      data-testid="tweaks-panel"
+      style=${{ right: `${offsetRef.current.x}px`, bottom: `${offsetRef.current.y}px` }}
+    >
+      <div
+        class="twk-panel-hd"
+        onMouseDown=${onDragStart}
+        data-testid="tweaks-panel-header"
+      >
+        <b>Display tweaks</b>
+        <button
+          type="button"
+          class="twk-panel-close"
+          aria-label="Close tweaks"
+          data-testid="tweaks-panel-close"
+          onMouseDown=${(e: MouseEvent) => e.stopPropagation()}
+          onClick=${() => { tweaksOpen.value = false }}
+        >
+          <${X} size=${14} />
+        </button>
+      </div>
+      <div class="twk-panel-body">
+        <${Row} label="Density" hint="Spacing across lists and cards">
+          <${SegmentedControl}
+            value=${densitySignal.value}
+            options=${DENSITY_OPTIONS}
+            aria-label="Density"
+            onChange=${(v: Density) => { densitySignal.value = v }}
+          />
+        <//>
+        <${Row} label="Motion" hint="Transitions and micro-animations">
+          <${SegmentedControl}
+            value=${motionSignal.value}
+            options=${MOTION_OPTIONS}
+            aria-label="Motion"
+            onChange=${(v: Motion) => { motionSignal.value = v }}
+          />
+        <//>
+        <${Row} label="Bubble" hint="Message bubble style">
+          <${SegmentedControl}
+            value=${bubbleSignal.value}
+            options=${BUBBLE_OPTIONS}
+            aria-label="Bubble style"
+            onChange=${(v: Bubble) => { bubbleSignal.value = v }}
+          />
+        <//>
+        <${Row} label="Font scale" hint="Base text size">
+          <${Slider}
+            value=${fontScaleSignal.value}
+            min=${80}
+            max=${125}
+            step=${5}
+            suffix="%"
+            aria-label="Font scale"
+            onChange=${(v: number) => { fontScaleSignal.value = v }}
+          />
+        <//>
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -45,6 +45,7 @@ import './styles/memory-v2.css'
 import './styles/keeper-turn-inspector.css'
 import './styles/ide-v2.css'
 import './styles/work-v2.css'
+import './styles/craft-v2.css'
 
 import { render } from 'preact'
 import { html } from 'htm/preact'

--- a/dashboard/src/styles/craft-v2.css
+++ b/dashboard/src/styles/craft-v2.css
@@ -1,0 +1,334 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Dashboard — Craft v2 layer
+   Ported from keeper-v2/styles/craft.css.
+
+   Loaded after component styles. A polish pass driven by attributes on
+   the app root:
+     data-density = compact | regular | spacious
+     data-motion  = off | subtle | lively
+     data-bubble  = flat | card
+     data-font-scale = 80 .. 125
+
+   Purely additive — refines spacing, motion and message finish on top
+   of the existing token system.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Motion tokens ────────────────────────────────────────────── */
+.v2-app {
+  --ease-out: cubic-bezier(0.22, 0.61, 0.36, 1);
+  --ease-spring: cubic-bezier(0.34, 1.32, 0.5, 1);
+  --dur-fast: 110ms;
+  --dur: 170ms;
+  --dur-slow: 260ms;
+  --lift: -2px;
+  --press: 1px;
+}
+
+/* ── Font scale ───────────────────────────────────────────────── */
+.v2-app[data-font-scale] {
+  font-size: calc(var(--twk-font-scale, 100) * 1%);
+}
+
+/* ── Density ──────────────────────────────────────────────────── */
+.v2-app[data-density="spacious"] {
+  --twk-pad-surface: 32px 42px 60px;
+  --twk-pad-card: 16px 18px;
+  --twk-gap-card: 18px;
+  --twk-gap-row: 11px;
+}
+
+.v2-app[data-density="regular"] {
+  --twk-pad-surface: 22px 26px 40px;
+  --twk-pad-card: 12px 14px;
+  --twk-gap-card: 14px;
+  --twk-gap-row: 8px;
+}
+
+.v2-app[data-density="compact"] {
+  --twk-pad-surface: 15px 18px 30px;
+  --twk-pad-card: 9px 11px;
+  --twk-gap-card: 10px;
+  --twk-gap-row: 6px;
+}
+
+/* Apply density breathing rhythm to the main scroll surface and cards. */
+.v2-app[data-density] .dashboard-main-scroll {
+  padding: var(--twk-pad-surface);
+}
+
+.v2-app[data-density] .card,
+.v2-app[data-density] [class*="-card"]:not(.twk-panel):not(.twk-panel *) {
+  padding: var(--twk-pad-card);
+}
+
+.v2-app[data-density] .dashboard-main-scroll > * + * {
+  margin-top: var(--twk-gap-card);
+}
+
+/* ── Motion ───────────────────────────────────────────────────── */
+.v2-app[data-motion]:not([data-motion="off"]) button,
+.v2-app[data-motion]:not([data-motion="off"]) [role="button"],
+.v2-app[data-motion]:not([data-motion="off"]) a,
+.v2-app[data-motion]:not([data-motion="off"]) input,
+.v2-app[data-motion]:not([data-motion="off"]) select,
+.v2-app[data-motion]:not([data-motion="off"]) textarea {
+  transition: background var(--dur) var(--ease-out),
+              border-color var(--dur) var(--ease-out),
+              color var(--dur) var(--ease-out),
+              box-shadow var(--dur) var(--ease-out),
+              transform var(--dur-fast) var(--ease-out);
+}
+
+/* Press sink on active controls. */
+.v2-app[data-motion]:not([data-motion="off"]) button:active,
+.v2-app[data-motion]:not([data-motion="off"]) [role="button"]:active {
+  transform: translateY(var(--press));
+}
+
+/* Lively tier. */
+.v2-app[data-motion="lively"] {
+  --lift: -3px;
+}
+
+.v2-app[data-motion="lively"] .card:hover,
+.v2-app[data-motion="lively"] [class*="-card"]:not(.twk-panel):not(.twk-panel *):hover {
+  transition-timing-function: var(--ease-spring);
+}
+
+/* Off tier — kill motion (also reduced-motion is respected via base). */
+.v2-app[data-motion="off"] *,
+.v2-app[data-motion="off"] *::before,
+.v2-app[data-motion="off"] *::after {
+  transition: none !important;
+  animation: none !important;
+}
+
+/* Keyboard focus ring consistency. */
+.v2-app a:focus-visible,
+.v2-app button:focus-visible,
+.v2-app [role="button"]:focus-visible,
+.v2-app [tabindex]:not([tabindex="-1"]):focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-bg-page), 0 0 0 4px var(--color-accent-fg-dim, var(--accent-15));
+}
+
+/* ── Bubble style ─────────────────────────────────────────────── */
+.v2-app[data-bubble="flat"] .bubble {
+  background: transparent;
+  border-color: transparent;
+  border-radius: 0;
+  padding: 2px 0 0;
+}
+
+.v2-app[data-bubble="flat"] .bubble.user {
+  background: transparent;
+  border: 0;
+  border-left: 2px solid var(--color-accent-fg-dim, var(--accent-15));
+  border-radius: 0;
+  padding: 2px 0 2px 16px;
+}
+
+/* ── Scrollbar treatment ──────────────────────────────────────── */
+.v2-app .dashboard-main-scroll::-webkit-scrollbar,
+.v2-app .v2-shell-rail::-webkit-scrollbar {
+  width: 10px;
+}
+
+.v2-app .dashboard-main-scroll::-webkit-scrollbar-thumb,
+.v2-app .v2-shell-rail::-webkit-scrollbar-thumb {
+  background: var(--color-border-default);
+  border-radius: var(--r-2, 6px);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+.v2-app * {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border-default) transparent;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   Tweaks panel chrome — self-contained, does not depend on the
+   attribute-driven craft rules above.
+   ═══════════════════════════════════════════════════════════════ */
+.twk-panel {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 2147483646;
+  width: 280px;
+  max-height: calc(100vh - 32px);
+  display: flex;
+  flex-direction: column;
+  background: color-mix(in oklab, var(--color-bg-surface) 92%, transparent);
+  color: var(--color-fg-primary);
+  backdrop-filter: blur(24px) saturate(160%);
+  border: 1px solid var(--color-border-default);
+  border-radius: 14px;
+  box-shadow: var(--shadow-panel, 0 12px 40px rgba(0, 0, 0, 0.18));
+  font-family: var(--font-ui), ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-size: 11.5px;
+  line-height: 1.4;
+  overflow: hidden;
+}
+
+.twk-panel-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 8px 10px 14px;
+  cursor: move;
+  user-select: none;
+  border-bottom: 1px solid var(--color-border-divider, var(--color-border-default));
+}
+
+.twk-panel-hd b {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.twk-panel-close {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--color-fg-muted);
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out);
+}
+
+.twk-panel-close:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-fg-primary);
+}
+
+.twk-panel-body {
+  padding: 12px 14px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+}
+
+.twk-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.twk-row-l {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.twk-row-label {
+  font-weight: 500;
+  color: var(--color-fg-secondary);
+}
+
+.twk-row-hint {
+  font-size: 10.5px;
+  color: var(--color-fg-muted);
+}
+
+.twk-row-c {
+  display: flex;
+  align-items: center;
+}
+
+/* Segmented control */
+.twk-seg {
+  position: relative;
+  display: flex;
+  padding: 2px;
+  border-radius: 8px;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-default);
+  user-select: none;
+  width: 100%;
+}
+
+.twk-seg-b {
+  appearance: none;
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  border: 0;
+  background: transparent;
+  color: var(--color-fg-muted);
+  font: inherit;
+  font-weight: 500;
+  min-height: 24px;
+  border-radius: 6px;
+  cursor: pointer;
+  padding: 4px 6px;
+  line-height: 1.2;
+  transition: color var(--dur-fast) var(--ease-out), background var(--dur-fast) var(--ease-out);
+}
+
+.twk-seg-b:hover {
+  color: var(--color-fg-secondary);
+}
+
+.twk-seg-b.on {
+  background: var(--color-bg-hover);
+  color: var(--color-fg-primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+/* Slider */
+.twk-slider-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+}
+
+.twk-slider {
+  appearance: none;
+  -webkit-appearance: none;
+  flex: 1;
+  height: 4px;
+  margin: 6px 0;
+  border-radius: 999px;
+  background: var(--color-border-strong, var(--color-border-default));
+  outline: none;
+}
+
+.twk-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--color-fg-primary);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+}
+
+.twk-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--color-fg-primary);
+  border: 1px solid var(--color-border-strong);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+}
+
+.twk-slider-val {
+  color: var(--color-fg-muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 3ch;
+  text-align: right;
+}


### PR DESCRIPTION
## Summary
Ports the keeper-v2 Tweaks Panel and craft layer into the MASC dashboard.

## What changed
- **New component** `dashboard/src/components/tweaks-panel.ts`:
  - Floating tweaks panel with density/motion/bubble/font-scale controls
  - Top-bar toggle button
  - Persistence via localStorage signals (`dashboard:tweaks:*`)
- **New styles** `dashboard/src/styles/craft-v2.css`:
  - Attribute-driven density/motion/bubble/font-scale layer scoped to `.v2-app`
- **Integration** in `dashboard/src/app.ts`:
  - Applied `data-density`, `data-motion`, `data-bubble`, `data-font-scale` to the app root
  - Added tweaks toggle button to the top bar
- **Tests** `dashboard/src/components/tweaks-panel.test.ts` — 8 tests.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `tweaks-panel.test.ts` + `settings-surface.test.ts` + `app.test.ts` ✅ 19/19

## Notes
- Preferences are local-only; no backend changes.
