### PR TITLE
feat(dashboard): apply remaining keeper-v2 surface styles

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -26,6 +26,7 @@ import './styles/keyframes.css'
 // Global utilities and layout
 import './styles/global.css'
 import './styles/chat-blocks-v2.css'
+import './styles/surfaces-v2.css'
 
 // Component-specific styles
 import './styles/ui.css'

--- a/dashboard/src/styles/surfaces-v2.css
+++ b/dashboard/src/styles/surfaces-v2.css
@@ -1,0 +1,1051 @@
+/* MASC Dashboard — keeper-v2 surface shell + overview + cockpit leftovers.
+ *
+ * Ports the sections of keeper-v2/styles/surfaces.css that are not covered
+ * by the existing v2-* files (board, connectors, ide, work, settings) into
+ * the dashboard token ladder. The required v2 vocabulary is already bridged
+ * in variables.css (e.g. --bg-deep, --border-main, --volt, --text-*).
+ */
+
+/* Local type-ladder tokens so the ported type-ladder selectors keep their
+ * source shape while pointing at the dashboard scale. */
+:root {
+  --fs-t1: 22px;
+  --fw-t1: var(--fw-semi);
+  --tr-t1: -0.005em;
+
+  --fs-t2: var(--fs-16);
+  --fw-t2: var(--fw-semi);
+  --tr-t2: var(--track-normal);
+
+  --fs-t3: var(--fs-11);
+  --fw-t3: var(--fw-semi);
+  --tr-t3: 0.14em;
+
+  --fs-t4: var(--fs-9);
+  --fw-t4: var(--fw-semi);
+  --tr-t4: 0.2em;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   SHARED SURFACE SHELL
+   ═══════════════════════════════════════════════════════════════ */
+
+.surf {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: var(--bg-deep);
+}
+
+.surf-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--pad-surface);
+}
+
+.surf-scroll::-webkit-scrollbar {
+  width: 9px;
+}
+
+.surf-scroll::-webkit-scrollbar-thumb {
+  background: var(--border-main);
+  border-radius: var(--radius-md);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+.surf-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.surf-head h1 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 22px;
+  letter-spacing: 0.02em;
+  color: var(--text-bright);
+  margin: 0;
+}
+
+.surf-head .eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 5px;
+}
+
+.surf-sub {
+  margin-top: 5px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.surf-sub b {
+  color: var(--volt-strong);
+  font-weight: 600;
+}
+
+.surf-sub .mono {
+  color: var(--text-mid);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   COLLAPSIBLE RAILS
+   ═══════════════════════════════════════════════════════════════ */
+
+.v2-body {
+  transition: grid-template-columns 0.22s ease;
+}
+
+/* roster mini mode: sigils only */
+.roster.mini .roster-head,
+.roster.mini .roster-filters {
+  display: none;
+}
+
+.roster.mini .roster-group {
+  padding: 10px 0 4px;
+  text-align: center;
+  letter-spacing: 0;
+  font-size: 8px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.roster.mini .kp-row {
+  grid-template-columns: 38px;
+  justify-content: center;
+  padding: 6px 0;
+  justify-items: center;
+}
+
+.roster.mini .kp-meta,
+.roster.mini .kp-right {
+  display: none;
+}
+
+.roster.mini .kp-row.sel::before {
+  left: -4px;
+}
+
+.roster.mini .roster-list {
+  padding: 6px 4px;
+}
+
+.rail-toggle {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 17px;
+  height: 52px;
+  z-index: 30;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  color: var(--text-dim);
+  font-size: 10px;
+  padding: 0;
+  transition: 0.15s;
+}
+
+.rail-toggle:hover {
+  color: var(--volt-strong);
+  border-color: var(--volt-dim);
+  background: var(--bg-card-hover);
+}
+
+.rail-toggle.left {
+  left: 0;
+  border-left: 0;
+  border-radius: 0 6px 6px 0;
+}
+
+.rail-toggle.right {
+  right: 0;
+  border-right: 0;
+  border-radius: 6px 0 0 6px;
+}
+
+.chat-wrap {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+}
+
+.chat-wrap .chat {
+  flex: 1;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   OVERVIEW
+   ═══════════════════════════════════════════════════════════════ */
+
+.ov {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: var(--bg-deep);
+}
+
+.ov-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--pad-surface);
+  max-width: 1280px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.ov-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.ov-head h1 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 22px;
+  color: var(--text-bright);
+  margin: 0;
+}
+
+.ov-sub {
+  margin-top: 5px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.ov-sub b {
+  color: var(--volt-strong);
+}
+
+.ov-sub .mono {
+  color: var(--text-mid);
+}
+
+.ov-clock {
+  font-size: 18px;
+  color: var(--text-mid);
+}
+
+.ov-clock span {
+  font-size: 10px;
+  color: var(--text-dim);
+  letter-spacing: 0.14em;
+}
+
+.ov-kpis {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1px;
+  background: var(--border-soft);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.ov-kpi {
+  background: var(--bg-panel);
+  padding: 13px 15px;
+}
+
+.ov-kpi-k {
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.ov-kpi-v {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 23px;
+  color: var(--text-bright);
+  margin-top: 5px;
+}
+
+.ov-kpi-v small {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.ov-kpi-v.ok { color: var(--status-ok); }
+.ov-kpi-v.bad { color: var(--status-bad); }
+.ov-kpi-v.warn { color: var(--status-warn); }
+.ov-kpi-v.volt { color: var(--volt-strong); }
+
+.ov-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
+  gap: var(--gap-card);
+  margin-bottom: 16px;
+}
+
+.ov-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  padding: var(--pad-card);
+  min-width: 0;
+}
+
+.ov-card-h {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.ov-card-h h3 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-mid);
+  margin: 0;
+  white-space: nowrap;
+}
+
+.ov-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--status-bad);
+  background: color-mix(in oklab, var(--status-bad) 14%, transparent);
+  border: 1px solid color-mix(in oklab, var(--status-bad) 35%, transparent);
+  padding: 1px 8px;
+  border-radius: var(--radius-pill);
+}
+
+.ov-legend {
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+.ov-link {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  color: var(--volt-strong);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 2px 0;
+}
+
+.ov-link:hover {
+  text-decoration: underline;
+}
+
+.ov-attn-list {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.ov-attn-row {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 9px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  cursor: pointer;
+  transition: 0.14s;
+}
+
+.ov-attn-row:hover {
+  border-color: var(--border-highlight);
+  background: var(--bg-card-hover);
+}
+
+.ov-attn-meta {
+  min-width: 0;
+  flex: 1;
+}
+
+.ov-attn-name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-bright);
+  display: flex;
+  gap: 9px;
+  align-items: baseline;
+}
+
+.ov-attn-ns {
+  font-size: 10px;
+  color: var(--text-dim);
+  font-weight: 400;
+}
+
+.ov-attn-reason {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  margin-top: 3px;
+  color: var(--text-mid);
+}
+
+.ov-attn-reason.sev-bad { color: var(--status-bad); }
+.ov-attn-reason.sev-warn { color: var(--status-warn); }
+
+.ov-attn-act {
+  flex: none;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  padding: 6px 11px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-main);
+  background: var(--bg-panel-alt);
+  color: var(--text-mid);
+  cursor: pointer;
+  transition: 0.14s;
+  white-space: nowrap;
+}
+
+.ov-attn-act:hover {
+  color: var(--volt-strong);
+  border-color: var(--volt-dim);
+}
+
+.ov-empty {
+  padding: 26px 0;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.ov-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: 92px;
+  padding: 4px 2px 0;
+}
+
+.ov-bar {
+  flex: 1;
+  min-width: 0;
+  background: linear-gradient(180deg, var(--volt-dim), color-mix(in oklab, var(--volt-dim) 50%, var(--bg-card)));
+  border-radius: 2px 2px 0 0;
+}
+
+.ov-bar.hot {
+  background: linear-gradient(180deg, var(--volt), var(--volt-dim));
+  box-shadow: 0 0 9px var(--volt-glow);
+}
+
+.ov-tel-foot {
+  display: flex;
+  gap: 22px;
+  margin-top: 12px;
+  padding-top: 11px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.ov-tel-stat .k {
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  display: block;
+}
+
+.ov-tel-stat .v {
+  font-size: 13px;
+  color: var(--text-mid);
+  margin-top: 3px;
+  display: block;
+}
+
+.ov-fleet-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(215px, 1fr));
+  gap: 9px;
+}
+
+.ov-keeper {
+  text-align: left;
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  padding: 11px 12px;
+  cursor: pointer;
+  transition: 0.14s;
+  min-width: 0;
+  font-family: var(--font-ui);
+}
+
+.ov-keeper:hover {
+  border-color: var(--volt-dim);
+  background: var(--bg-card-hover);
+  box-shadow: 0 0 0 2px var(--volt-wash);
+}
+
+.ov-keeper-top {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.ov-keeper-id {
+  min-width: 0;
+  flex: 1;
+}
+
+.ov-keeper-name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 12.5px;
+  color: var(--text-bright);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ov-keeper-state {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-top: 2px;
+}
+
+.ov-keeper-att {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  min-width: 16px;
+  text-align: center;
+  padding: 1px 5px;
+  border-radius: var(--radius-pill);
+  color: var(--status-bad);
+  background: color-mix(in oklab, var(--status-bad) 16%, transparent);
+  border: 1px solid color-mix(in oklab, var(--status-bad) 35%, transparent);
+  flex: none;
+}
+
+.ov-keeper-ns {
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-top: 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ov-keeper-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 7px;
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+.ov-mini-meter {
+  flex: 1;
+  height: 4px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-soft);
+  overflow: hidden;
+}
+
+.ov-mini-meter span {
+  display: block;
+  height: 100%;
+  background: var(--volt-dim);
+}
+
+.ov-mini-meter span.hot {
+  background: var(--status-bad);
+}
+
+.ov-keeper-ctx {
+  flex: none;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   COCKPIT — Command Map
+   ═══════════════════════════════════════════════════════════════ */
+
+.cp-body {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+}
+
+.cp-world {
+  border-right: 1px solid var(--border-main);
+  background: var(--bg-deepest);
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.cp-world-cv {
+  position: relative;
+  flex: 1;
+  min-height: 300px;
+}
+
+.cp-ring {
+  position: absolute;
+  border: 1px solid rgba(224, 176, 87, 0.10);
+  border-radius: 50%;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.cp-node {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  transition: 0.15s;
+  z-index: 2;
+}
+
+.cp-node:hover {
+  transform: translate(-50%, -50%) scale(1.12);
+}
+
+.cp-node .nm {
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.cp-node.off {
+  opacity: 0.4;
+}
+
+.cp-world-foot {
+  flex: none;
+  padding: 12px 14px;
+  border-top: 1px solid var(--border-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: color-mix(in srgb, var(--bg-deepest) 70%, transparent);
+}
+
+.cp-world-foot .row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10.5px;
+  color: var(--text-dim);
+}
+
+.cp-world-foot .row b {
+  font-family: var(--font-mono);
+  color: var(--text-mid);
+  font-weight: 500;
+}
+
+.cp-world-title {
+  position: absolute;
+  top: 14px;
+  left: 16px;
+  z-index: 3;
+}
+
+.cp-world-title .t {
+  font-family: var(--font-display);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-mid);
+}
+
+.cp-world-title .s {
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-top: 3px;
+}
+
+.cp-main {
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--pad-surface);
+}
+
+.cp-main::-webkit-scrollbar {
+  width: 9px;
+}
+
+.cp-main::-webkit-scrollbar-thumb {
+  background: var(--border-main);
+  border-radius: var(--radius-md);
+}
+
+.cp-inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-card);
+}
+
+.cp-modebar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cp-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-start;
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-main);
+  background: var(--bg-panel);
+  color: var(--text-mid);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  transition: 0.15s;
+}
+
+.cp-mode .ml {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-mid);
+}
+
+.cp-mode .ms {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--text-dim);
+}
+
+.cp-mode:hover {
+  border-color: var(--border-highlight);
+}
+
+.cp-mode.on {
+  border-color: var(--volt);
+  background: var(--volt-wash);
+  box-shadow: 0 0 0 2px var(--volt-wash);
+}
+
+.cp-mode.on .ml {
+  color: var(--volt-strong);
+}
+
+.cp-disc {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.cp-disc-h {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.cp-disc-h h3 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-mid);
+  margin: 0;
+  white-space: nowrap;
+}
+
+.cp-disc-rows {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--border-soft);
+}
+
+.cp-disc-row {
+  background: var(--bg-panel);
+  padding: 11px 14px;
+}
+
+.cp-disc-row .lvl {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--volt-strong);
+}
+
+.cp-disc-row .ttl {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-bright);
+  margin-top: 4px;
+}
+
+.cp-disc-row .sum {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 3px;
+  line-height: 1.5;
+}
+
+.cp-disc-row .mtr {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-mid);
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+  margin-top: 7px;
+}
+
+.cp-plane {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.cp-plane-h {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--bg-panel-alt);
+}
+
+.cp-plane-h .lft {
+  display: flex;
+  gap: 10px;
+  min-width: 0;
+}
+
+.cp-plane-ico {
+  width: 30px;
+  height: 30px;
+  flex: none;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-main);
+  background: var(--bg-deep);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--volt-strong);
+}
+
+.cp-plane-ico svg {
+  width: 15px;
+  height: 15px;
+}
+
+.cp-plane-h h2 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-bright);
+  margin: 0;
+}
+
+.cp-plane-h .sum {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 2px;
+}
+
+.cp-plane-h .chips {
+  display: flex;
+  gap: 6px;
+  flex: none;
+}
+
+.cp-cov {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  padding: 2px 8px;
+  border-radius: var(--radius-xs);
+  border: 1px solid;
+  white-space: nowrap;
+}
+
+.cp-cov.ok {
+  color: var(--status-ok);
+  border-color: color-mix(in oklab, var(--status-ok) 35%, transparent);
+  background: color-mix(in oklab, var(--status-ok) 9%, transparent);
+}
+
+.cp-cov.blk {
+  color: var(--text-dim);
+  border-color: var(--border-main);
+  background: var(--bg-deep);
+}
+
+.cp-routes {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(225px, 1fr));
+  gap: 8px;
+  padding: 12px 14px;
+}
+
+.cp-route {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 86px;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-soft);
+  background: var(--bg-deep);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  transition: 0.15s;
+  min-width: 0;
+}
+
+.cp-route:hover {
+  border-color: var(--border-highlight);
+  background: var(--bg-card);
+}
+
+.cp-route:hover .arr {
+  color: var(--volt-strong);
+}
+
+.cp-route-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.cp-route .rl {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-bright);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cp-route .rc {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-dim);
+  margin-top: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cp-route .arr {
+  color: var(--text-dim);
+  flex: none;
+  transition: 0.15s;
+  font-size: 12px;
+}
+
+.cp-route .cp-cov {
+  align-self: flex-start;
+}
+
+/* responsive */
+@media (max-width: 1280px) {
+  .ov-kpis { grid-template-columns: repeat(3, 1fr); }
+  .ov-grid { grid-template-columns: 1fr; }
+  .cp-body { grid-template-columns: minmax(0, 1fr); }
+  .cp-world { display: none; }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   TYPE LADDER — authoritative heading normalization
+   ═══════════════════════════════════════════════════════════════ */
+
+/* T1 — surface / subject title */
+.ov-head h1,
+.surf-head h1,
+.chat-id h2 {
+  font-family: var(--font-display);
+  font-weight: var(--fw-t1);
+  font-size: var(--fs-t1);
+  letter-spacing: var(--tr-t1);
+  text-transform: none;
+  color: var(--text-bright);
+  margin: 0;
+}
+
+/* T2 — region / panel title */
+.cp-plane-h h2,
+.bd-feed-head h2 {
+  font-family: var(--font-display);
+  font-weight: var(--fw-t2);
+  font-size: var(--fs-t2);
+  letter-spacing: var(--tr-t2);
+  text-transform: none;
+  color: var(--text-bright);
+  margin: 0;
+}
+
+/* T3 — card / section header */
+.ov-card-h h3,
+.cp-disc-h h3,
+.roster-title h3,
+.ctx-sec h4 {
+  font-family: var(--font-display);
+  font-weight: var(--fw-t3);
+  font-size: var(--fs-t3);
+  letter-spacing: var(--tr-t3);
+  text-transform: uppercase;
+  color: var(--text-mid);
+  margin: 0;
+  white-space: nowrap;
+}
+
+/* T4 — micro label */
+.bd-rail h4,
+.cn-bind h5,
+.ide-tree h4 {
+  font-family: var(--font-ui);
+  font-weight: var(--fw-t4);
+  font-size: var(--fs-t4);
+  letter-spacing: var(--tr-t4);
+  text-transform: uppercase;
+  color: var(--text-dim);
+}

--- a/dashboard/src/styles/surfaces-v2.test.ts
+++ b/dashboard/src/styles/surfaces-v2.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import './surfaces-v2.css'
+
+function makeContainer(): HTMLDivElement {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  return container
+}
+
+describe('surfaces-v2 CSS classes', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = makeContainer()
+  })
+
+  afterEach(() => {
+    container.remove()
+  })
+
+  it('shared surface shell markup uses surf and surf-scroll classes', () => {
+    container.innerHTML = '<div class="surf"><div class="surf-scroll"></div></div>'
+    const surf = container.querySelector('.surf') as HTMLElement
+    const scroll = container.querySelector('.surf-scroll') as HTMLElement
+    expect(surf).not.toBeNull()
+    expect(scroll).not.toBeNull()
+    expect(surf.classList.contains('surf')).toBe(true)
+    expect(scroll.classList.contains('surf-scroll')).toBe(true)
+  })
+
+  it('overview KPI grid markup uses ov-kpis and ov-kpi classes', () => {
+    container.innerHTML = '<div class="ov-kpis"><div class="ov-kpi"></div></div>'
+    const grid = container.querySelector('.ov-kpis') as HTMLElement
+    const cell = container.querySelector('.ov-kpi') as HTMLElement
+    expect(grid).not.toBeNull()
+    expect(cell).not.toBeNull()
+    expect(grid.classList.contains('ov-kpis')).toBe(true)
+    expect(cell.classList.contains('ov-kpi')).toBe(true)
+  })
+
+  it('overview card renders with header', () => {
+    container.innerHTML =
+      '<div class="ov-card"><div class="ov-card-h"><h3>Title</h3></div></div>'
+    const card = container.querySelector('.ov-card') as HTMLElement
+    expect(card).not.toBeNull()
+    expect(card.classList.contains('ov-card')).toBe(true)
+    expect(card.querySelector('.ov-card-h')).not.toBeNull()
+  })
+
+  it('cockpit body markup uses cp-body, cp-world and cp-main classes', () => {
+    container.innerHTML =
+      '<div class="cp-body"><div class="cp-world"></div><div class="cp-main"></div></div>'
+    const body = container.querySelector('.cp-body') as HTMLElement
+    const world = container.querySelector('.cp-world') as HTMLElement
+    const main = container.querySelector('.cp-main') as HTMLElement
+    expect(body).not.toBeNull()
+    expect(world).not.toBeNull()
+    expect(main).not.toBeNull()
+    expect(body.classList.contains('cp-body')).toBe(true)
+    expect(world.classList.contains('cp-world')).toBe(true)
+    expect(main.classList.contains('cp-main')).toBe(true)
+  })
+
+  it('cockpit route renders', () => {
+    container.innerHTML = '<button class="cp-route"><span class="rl">Route</span></button>'
+    const route = container.querySelector('.cp-route') as HTMLElement
+    expect(route).not.toBeNull()
+    expect(route.classList.contains('cp-route')).toBe(true)
+    expect(route.querySelector('.rl')).not.toBeNull()
+  })
+
+  it('type ladder selector targets ov-head h1', () => {
+    container.innerHTML = '<div class="ov-head"><h1>Overview</h1></div>'
+    const h1 = container.querySelector('.ov-head h1') as HTMLElement
+    expect(h1).not.toBeNull()
+    expect(h1.tagName).toBe('H1')
+  })
+})


### PR DESCRIPTION
## Summary
Ports the remaining keeper-v2 surface styles not covered by earlier PRs.

## What changed
- **New styles** `dashboard/src/styles/surfaces-v2.css`:
  - Shared surface shell (`.surf`, `.surf-scroll`, `.surf-head`, `.surf-sub`)
  - Collapsible rails (`.rail-toggle`, `.chat-wrap`, `.roster.mini`)
  - Overview surface (`.ov-*`, KPI strip, cards, attention rows, fleet grid)
  - Cockpit / Command Map surface (`.cp-*`, planes, routes, disclosure, world map)
  - Type ladder (T1–T4 heading normalization)
- **Tests** `dashboard/src/styles/surfaces-v2.test.ts` — 6 tests.
- **Wiring** — imported `surfaces-v2.css` in `main.ts`.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `surfaces-v2.test.ts` ✅ 6/6
- `pnpm build` ✅

## Notes
- Sections already covered by board/ide/connectors/work/settings PRs were intentionally skipped.
- No backend changes.
