### PR TITLE
refactor(dashboard): auto-import keeper-v2 surface CSS via import.meta.glob

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -6,8 +6,6 @@ import './styles/tokens.generated.css'
 import './styles/tokens.css'
 import './styles/variables.css'
 import './styles/primitives.css'
-import './styles/indicators-v2.css'
-import './styles/primitives-v2.css'
 import './styles/layout.css'
 import './styles/layers.css'
 import './styles/kpi.css'
@@ -31,7 +29,6 @@ import './styles/surfaces-v2.css'
 // Component-specific styles
 import './styles/ui.css'
 import './styles/board.css'
-import './styles/board-v2.css'
 /* chat.css: styles merged into global.css @utility blocks (#3915) */
 import './styles/dashboard.css'
 import './styles/governance.css'
@@ -42,7 +39,6 @@ import './styles/provider-matrix.css'
 import './styles/paper-theme.css'
 import './styles/keeper-workspace.css'
 import './styles/copilot-dock.css'
-import './styles/memory-v2.css'
 import './styles/keeper-turn-inspector.css'
 import './styles/ide-v2.css'
 import './styles/work-v2.css'
@@ -50,6 +46,16 @@ import './styles/design-canvas.css'
 import './styles/connectors-v2.css'
 import './styles/telemetry-v2.css'
 import './styles/craft-v2.css'
+
+// Keeper-v2 surface stylesheets are auto-imported by filename convention:
+// every dashboard/src/styles/*-v2.css is injected here at build time. A new v2
+// surface adds only its own stylesheet file — it must NOT add a per-surface
+// import line to main.ts. Per-surface import edits all landed in this one block
+// and serialized into repeated merge conflicts across parallel surface PRs;
+// the glob removes that shared anchor. Ordering note: all *-v2.css load at this
+// point (after variables.css and dashboard.css), preserving the cases where a
+// v2 rule overrides its v1 counterpart (.gd-board, .mg-board, .ide-plane-shell).
+import.meta.glob('./styles/*-v2.css', { eager: true })
 
 import { render } from 'preact'
 import { html } from 'htm/preact'


### PR DESCRIPTION
## 문제

병렬 keeper-v2 surface PR들이 전부 `dashboard/src/main.ts`의 **같은 import 블록**에 `import './styles/<surface>-v2.css'` 한 줄을 추가합니다. 그래서 하나가 머지되면 main.ts가 바뀌어 나머지 형제가 그 앵커에서 재충돌합니다. 한 세션에서만 #21360/#21365/#21373/#21378/#21382/#21384/#21386이 이 패턴으로 반복 충돌했습니다 (sequential re-conflict).

## 변경

6개 개별 `*-v2.css` import → `import.meta.glob('./styles/*-v2.css', { eager: true })` 한 줄.

이후 새 v2 surface는 **`<surface>-v2.css` 파일만 추가**하면 자동 주입됩니다. main.ts를 건드리지 않으므로 공유 앵커가 사라집니다.

## 순서 안전성

- v2 stylesheet들은 selector-disjoint(cross-v2 충돌 0건, `:root`/`@layer`/CSS변수 0개) → glob의 알파벳순 주입은 cascade-safe.
- v2↔non-v2 충돌 3건(`.gd-board`,`.mg-board`,`.ide-plane-shell`)은 "v2가 v1 override" 패턴. glob을 기존 최신 v2 위치(variables.css·dashboard.css 뒤)에 배치해 **현재 승자 보존**.
- `keeper-turn-inspector.css`는 `-v2` 접미사가 없어 glob에 안 잡힘 → 명시 import 유지.

## 검증

- `tsc --noEmit`: clean
- `vite build`: exit 0
- 빌드 번들에 v2 전용 셀렉터 전부 주입 확인: `.sigil`/`.rfilter`/`.meter`(primitives) `.bd-`(board) `.ide-plane-shell`(ide) `.gd-board`/`.mg-board`(memory) `.spinner`(indicators)

## 후속 (fleet 컨벤션)

새 v2 surface PR은 main.ts에 import 줄을 추가하면 안 됩니다 — 파일명 규약(`<surface>-v2.css`)만 따르면 됩니다. board/goal로 fleet에 공지 예정.

RFC-WAIVED: dashboard CSS import 와이어링만 변경. credential/identity/operator/sandbox/hooks 등 게이트 경로 무관.
