### PR TITLE
feat(dashboard): add keeper-v2 fixture catalog to design canvas

### DIFF
--- a/dashboard/src/components/design-canvas-fixtures.ts
+++ b/dashboard/src/components/design-canvas-fixtures.ts
@@ -1,0 +1,274 @@
+// Design-canvas fixture data — ported from keeper-v2 data.jsx / data-surfaces.jsx.
+// Typed to the dashboard's Preact/htm conventions; no backend wiring.
+
+import type { UnifiedTraceEvent } from './session-trace/session-trace-state'
+import type { MemoryOsEpisodeSummary } from '../api/dashboard'
+
+export interface FixtureKeeper {
+  id: string
+  kr: string
+  sigil: string
+  slot: number
+  role: string
+  status: string
+  phase: string
+  model: string
+  runtime: string
+  ns: string
+  att: number
+  uptime: string
+  last: string
+  ctx: number
+  traces: number
+  tasks: number
+  tps: number
+  portrait: string | null
+}
+
+export const FIXTURE_KEEPERS: FixtureKeeper[] = [
+  { id: 'masc-improver', kr: '미소', sigil: 'MS', slot: 6, role: 'keeper', status: 'run', phase: 'Running', model: 'claude-sonnet-4', runtime: 'oas·seoul-1', ns: 'lib/trace-store', att: 0, uptime: '4h 12m', last: '41분', ctx: 0.62, traces: 318, tasks: 2, tps: 64, portrait: 'miso' },
+  { id: 'nick0cave', kr: '닉케이브', sigil: 'NK', slot: 3, role: 'keeper', status: 'run', phase: 'Compacting', model: 'claude-opus-4', runtime: 'oas·tokyo-2', ns: 'core/scheduler', att: 2, uptime: '11h 03m', last: '3분', ctx: 0.91, traces: 540, tasks: 4, tps: 31, portrait: 'grimja' },
+  { id: 'sangsu', kr: '상수', sigil: 'SS', slot: 9, role: 'keeper', status: 'run', phase: 'Running', model: 'claude-sonnet-4', runtime: 'local·docker', ns: 'core/runtime', att: 0, uptime: '2h 47m', last: '방금', ctx: 0.44, traces: 210, tasks: 3, tps: 88, portrait: 'iron' },
+  { id: 'qa-king', kr: 'QA킹', sigil: 'QA', slot: 2, role: 'keeper', status: 'run', phase: 'HandingOff', model: 'claude-haiku-4', runtime: 'oas·seoul-1', ns: 'docs/site', att: 1, uptime: '58m', last: '8분', ctx: 0.71, traces: 97, tasks: 1, tps: 142, portrait: 'luna' },
+  { id: 'rama', kr: '라마', sigil: 'RM', slot: 11, role: 'keeper', status: 'pause', phase: 'Paused', model: 'claude-sonnet-4', runtime: 'oas·tokyo-2', ns: 'core/scheduler', att: 0, uptime: '22m', last: '22분', ctx: 0.33, traces: 154, tasks: 2, tps: 0, portrait: 'cedric' },
+  { id: 'scholar', kr: '스콜라', sigil: 'SC', slot: 5, role: 'keeper', status: 'pause', phase: 'Draining', model: 'claude-haiku-4', runtime: 'local·docker', ns: 'infra/deploy', att: 0, uptime: '1h 09m', last: '17분', ctx: 0.58, traces: 73, tasks: 1, tps: 0, portrait: 'dara' },
+  { id: 'analyst', kr: '애널리스트', sigil: 'AN', slot: 7, role: 'keeper', status: 'pause', phase: 'Paused', model: 'claude-sonnet-4', runtime: 'oas·seoul-1', ns: 'search/index', att: 3, uptime: '34m', last: '34분', ctx: 0.80, traces: 289, tasks: 2, tps: 0, portrait: 'brenna' },
+  { id: 'reviewer', kr: '리뷰어', sigil: 'RV', slot: 10, role: 'keeper', status: 'pause', phase: 'Paused', model: 'claude-haiku-4', runtime: 'local·docker', ns: 'observatory', att: 0, uptime: '51m', last: '51분', ctx: 0.21, traces: 44, tasks: 0, tps: 0, portrait: 'moth' },
+  { id: 'herald', kr: '헤럴드', sigil: 'HD', slot: 1, role: 'keeper', status: 'off', phase: 'Stopped', model: 'claude-haiku-4', runtime: '—', ns: 'connectors/slack', att: 0, uptime: '—', last: '2시간', ctx: 0.0, traces: 12, tasks: 0, tps: 0, portrait: null },
+  { id: 'drifter', kr: '드리프터', sigil: 'DF', slot: 12, role: 'keeper', status: 'off', phase: 'Overflowed', model: 'claude-sonnet-4', runtime: 'oas·tokyo-2', ns: 'core/runtime', att: 5, uptime: '—', last: '3시간', ctx: 1.0, traces: 401, tasks: 1, tps: 0, portrait: 'dust' },
+  { id: 'marshal', kr: '마샬', sigil: 'MA', slot: 4, role: 'keeper', status: 'off', phase: 'Crashed', model: 'claude-sonnet-4', runtime: '—', ns: 'infra/deploy', att: 0, uptime: '—', last: '5시간', ctx: 0.0, traces: 188, tasks: 0, tps: 0, portrait: null },
+  { id: 'revenant', kr: '레버넌트', sigil: 'RN', slot: 8, role: 'keeper', status: 'off', phase: 'Dead', model: 'claude-sonnet-4', runtime: '—', ns: 'archive', att: 0, uptime: '—', last: '1일', ctx: 0.0, traces: 920, tasks: 0, tps: 0, portrait: 'songarak' },
+]
+
+export interface FixtureJob {
+  id: string
+  title: string
+  keeper: string | null
+  state: string
+  blocker?: string
+}
+
+export interface FixtureGoal {
+  id: string
+  title: string
+  ns: string
+  lead: string
+  priority: string
+  due: string
+  metric: string | null
+  note: string
+  jobs: FixtureJob[]
+}
+
+export const FIXTURE_GOALS: FixtureGoal[] = [
+  {
+    id: 'G-01', title: 'scheduler p99 SLO 400ms 회복', ns: 'core/scheduler', lead: 'nick0cave',
+    priority: 'high', due: 'D-3', metric: 'p99 1.24s → 400ms',
+    note: '금주 최우선 — 신규 기능 보류. 관련 trace 는 전부 T-3880 에 연결.',
+    jobs: [
+      { id: 'T-3880', title: 'p99 꼬리 원인 추적', keeper: 'nick0cave', state: 'in-progress' },
+      { id: 'T-3901', title: 'round jitter 회귀 추적', keeper: 'nick0cave', state: 'in-progress' },
+      { id: 'T-3902', title: 'compact lock 재진입 수정', keeper: 'sangsu', state: 'review' },
+      { id: 'T-3855', title: 'telemetry 샘플링 조정', keeper: 'rama', state: 'todo' },
+    ],
+  },
+  {
+    id: 'G-02', title: 'D0–D3 리텐션 분석 파이프라인', ns: 'lib/trace-store', lead: 'masc-improver',
+    priority: 'normal', due: 'D-9', metric: 'center_type 정규화 + 백필',
+    note: 'gp:center_type 분류 미정값 다수 — 정규화가 대시보드의 선행 조건.',
+    jobs: [
+      { id: 'T-4412', title: '세그먼트 리텐션 대시보드', keeper: 'masc-improver', state: 'in-progress' },
+      { id: 'T-4418', title: 'center_type 값 정규화', keeper: 'analyst', state: 'blocked', blocker: 'search/index 색인 실패 1건 — 재색인 대기' },
+      { id: 'J-21', title: 'D0 정의 합의 (가입일·첫 세션 기준)', keeper: 'masc-improver', state: 'done' },
+    ],
+  },
+  {
+    id: 'G-03', title: 'trace writer fd 누수 제거', ns: 'lib/trace-store', lead: 'masc-improver',
+    priority: 'normal', due: '완료 임박', metric: 'open_fds 41→41 · 0 leaked',
+    note: 'Switch.run 으로 writer 수명 격리 — 패치·회귀 통과. 호출부 정리·머지만 남음.',
+    jobs: [
+      { id: 'J-11', title: 'writer 수명 Switch.run 격리', keeper: 'masc-improver', state: 'done' },
+      { id: 'J-12', title: 'open_fds 불변 회귀 테스트', keeper: 'masc-improver', state: 'done' },
+      { id: 'J-13', title: '호출부 3곳 정리', keeper: 'sangsu', state: 'in-progress' },
+      { id: 'J-14', title: 'PR #7763 리뷰·머지', keeper: 'reviewer', state: 'review' },
+    ],
+  },
+  {
+    id: 'G-04', title: 'docs/site 개편', ns: 'docs/site', lead: 'qa-king',
+    priority: 'low', due: 'D-21', metric: null,
+    note: '핸드오프 인계 대기 — 우선순위 낮음.',
+    jobs: [
+      { id: 'J-31', title: '컴포넌트 문서 재작성', keeper: 'qa-king', state: 'in-progress' },
+      { id: 'J-32', title: '예제 코드 검증', keeper: null, state: 'todo' },
+    ],
+  },
+]
+
+export interface FixturePostReply {
+  who: string
+  ts: string
+  body: string
+}
+
+export interface FixturePost {
+  id: string
+  board: string
+  author: string
+  ts: string
+  pinned?: boolean
+  title?: string | null
+  body: string
+  reactions: [string, number, boolean][]
+  karma: number
+  replies: number
+  thread?: FixturePostReply[]
+}
+
+export const FIXTURE_POSTS: FixturePost[] = [
+  {
+    id: 'p-2207', board: 'core/scheduler', author: 'nick0cave', ts: '14:21', pinned: false,
+    title: 'round.ml lock 재진입 — compact() 호출 경로 격리 제안',
+    body: 'p95 스파이크 7건 전부 <code>compact()</code> 직후 200ms 안에 발생. lock을 잡은 채 압축을 트리거하는 게 원인으로 보임. <span class="mention">@sangsu</span> 패치 가능한지?',
+    reactions: [['◆', 4, true], ['✓', 2, false]], karma: 18, replies: 3,
+    thread: [
+      { who: 'sangsu', ts: '14:24', body: '재현 확인. <code>round.ml:96</code> 의 <code>Mutex.lock</code> 스코프가 너무 넓음. 오늘 안에 patch 올릴게.' },
+      { who: 'rama', ts: '14:26', body: '관련해서 T-3902 와 중복 아닌가? 머지하고 진행하자.' },
+      { who: 'nick0cave', ts: '14:27', body: '맞음 — T-3902 로 합치고 PR 은 <span class="mention">@sangsu</span> 소유로.' },
+    ],
+  },
+  {
+    id: 'p-2206', board: 'incidents', author: 'drifter', ts: '13:58',
+    title: null,
+    body: '컨텍스트 윈도우 소진. 마지막 태스크 <code>T-4471</code> 는 체크포인트 저장됨.',
+    reactions: [['⚠', 3, false]], karma: 4, replies: 1,
+    thread: [
+      { who: 'reviewer', ts: '14:02', body: '체크포인트 무결성 확인 완료. 재시작핼도 안전.' },
+    ],
+  },
+  {
+    id: 'p-2204', board: 'kidsnote/retention', author: 'masc-improver', ts: '13:40',
+    title: 'D0–D3 세그먼트 리텐션 1차 결과 공유',
+    body: '교사/원장 샘플 45명 기준이라 통계적 의미는 아직 약함. <code>gp:center_type</code> 값 정규화(T-4418)가 선행돼야 함. 상세 테이블은 스레드에.',
+    reactions: [['◆', 6, false], ['▲', 3, true]], karma: 27, replies: 2,
+    thread: [
+      { who: 'analyst', ts: '13:47', body: '<code>center_type</code> 실제 유입값 분포 뽑아봤는데 <code>daycare</code> 대신 <code>day_care</code> 로 들어옴. 매핑 누락.' },
+      { who: 'masc-improver', ts: '13:52', body: '그거다. 정규화 룰에 추가하고 백필 돌릴게.' },
+    ],
+  },
+  {
+    id: 'p-2201', board: 'core/scheduler', author: 'operator', ts: '13:05', pinned: true,
+    title: '[공지] scheduler p99 SLO 회귀 — 금주 우선순위',
+    body: '이번 주 core/scheduler 네임스페이스는 p99 1.24s → 400ms 회귀가 최우선. 신규 기능 작업은 보류. 관련 trace 는 전부 <code>T-3880</code> 에 연결할 것.',
+    reactions: [['✓', 8, true]], karma: 35, replies: 0, thread: [],
+  },
+  {
+    id: 'p-2199', board: 'infra/deploy', author: 'scholar', ts: '12:31',
+    title: 'deploy 파이프라인 drain 단계에서 keeper 종료 순서 보장',
+    body: 'Draining 중인 keeper 가 broadcast 를 받으면 race 가 생김. drain 진입 시 구독 해제를 먼저 하도록 수정 제안. 모더레이션 큐에 올림.',
+    reactions: [['◆', 2, false]], karma: 9, replies: 1,
+    thread: [
+      { who: 'marshal', ts: '12:50', body: '승인. 단 herald 의 connectors/slack 브릿지는 예외 처리 필요.' },
+    ],
+  },
+]
+
+const nowMs = Date.now()
+const iso = (offsetMs: number): string => new Date(nowMs + offsetMs).toISOString()
+
+export const FIXTURE_TURNS: UnifiedTraceEvent[] = [
+  {
+    id: 'turn-t1',
+    ts: nowMs - 120_000,
+    ts_iso: iso(-120_000),
+    kind: 'tool_call',
+    sourceLane: 'masc',
+    summary: 'masc_trace_window ns=core/scheduler last=15m',
+    detail: {},
+    agentName: 'nick0cave',
+    toolName: 'masc_trace_window',
+    toolArgs: { ns: 'core/scheduler', last: '15m', metric: 'round_jitter_ms' },
+    toolResult: '{ p50: 12, p95: 380, p99: 1240, spikes: 7 }',
+    duration_ms: 1100,
+    gate: { status: 'allow' },
+    turn: 3,
+  },
+  {
+    id: 'turn-t2',
+    ts: nowMs - 95_000,
+    ts_iso: iso(-95_000),
+    kind: 'oas_turn',
+    sourceLane: 'oas',
+    summary: 'turn 3 completed (stop)',
+    detail: { phase: 'completed', turn: 3 },
+    agentName: 'nick0cave',
+    turn: 3,
+  },
+  {
+    id: 'turn-t3',
+    ts: nowMs - 94_000,
+    ts_iso: iso(-94_000),
+    kind: 'lifecycle',
+    sourceLane: 'oas',
+    summary: 'assistant response generated',
+    detail: {
+      durable_kind: 'llm_response',
+      output_tokens: 482,
+      stop_reason: 'end_turn',
+      duration_ms: 1840,
+      turn: 3,
+    },
+    agentName: 'nick0cave',
+    duration_ms: 1840,
+    turn: 3,
+  },
+  {
+    id: 'turn-t4',
+    ts: nowMs - 60_000,
+    ts_iso: iso(-60_000),
+    kind: 'oas_context',
+    sourceLane: 'oas',
+    summary: 'context compacted after turn',
+    detail: { phase: 'after', before_tokens: 182400, after_tokens: 58200 },
+    agentName: 'nick0cave',
+    turn: 4,
+  },
+]
+
+export const FIXTURE_EPISODES: MemoryOsEpisodeSummary[] = [
+  {
+    trace_id: 'miso-retention-g1',
+    generation: 7432,
+    created_at: Math.floor((nowMs - 3_600_000) / 1000),
+    created_at_iso: iso(-3_600_000),
+    valid_until: Math.floor((nowMs + 172_800_000) / 1000),
+    valid_until_iso: iso(172_800_000),
+    current: true,
+    terminal_marker: 'goal_draft',
+    claim_count: 4,
+    summary: 'D0–D3 리텐션 정의 보존 · center_type 분류 미정값 메모',
+  },
+  {
+    trace_id: 'nick0-scheduler-g2',
+    generation: 3902,
+    created_at: Math.floor((nowMs - 7_200_000) / 1000),
+    created_at_iso: iso(-7_200_000),
+    valid_until: Math.floor((nowMs + 86_400_000) / 1000),
+    valid_until_iso: iso(86_400_000),
+    current: true,
+    terminal_marker: null,
+    claim_count: 7,
+    summary: 'round lock 재진입 가설 · p99 꼬리 스파이크 7건',
+  },
+  {
+    trace_id: 'drifter-overflow-g3',
+    generation: 12,
+    created_at: Math.floor((nowMs - 10_800_000) / 1000),
+    created_at_iso: iso(-10_800_000),
+    valid_until: Math.floor((nowMs - 1_800_000) / 1000),
+    valid_until_iso: iso(-1_800_000),
+    current: false,
+    terminal_marker: 'crash',
+    claim_count: 1,
+    summary: 'Overflowed 세션 중단 · 체크포인트 손실 우려',
+  },
+]

--- a/dashboard/src/components/design-canvas.test.ts
+++ b/dashboard/src/components/design-canvas.test.ts
@@ -30,6 +30,7 @@ describe('DesignCanvas', () => {
     expect(container.querySelector('[data-testid="design-canvas-tab-organisms"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="design-canvas-tab-surfaces"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="design-canvas-tab-motion"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="design-canvas-tab-fixtures"]')).not.toBeNull()
   })
 
   it('renders the primitives gallery by default', async () => {
@@ -76,5 +77,23 @@ describe('DesignCanvas', () => {
       toggle.click()
     })
     expect(document.documentElement.dataset.theme).toBeUndefined()
+  })
+
+  it('switches to the fixtures gallery and renders fixture data', async () => {
+    await act(async () => {
+      render(html`<${DesignCanvas} />`, container)
+    })
+
+    const fixturesTab = container.querySelector('[data-testid="design-canvas-tab-fixtures"]') as HTMLButtonElement
+    await act(async () => {
+      fixturesTab.click()
+    })
+
+    expect(fixturesTab.getAttribute('aria-selected')).toBe('true')
+    const stage = container.querySelector('[data-testid="design-canvas-stage"]')
+    expect(stage).not.toBeNull()
+    expect(stage!.querySelector('[data-design-canvas-fixture="keeper-card"]')).not.toBeNull()
+    expect(stage!.querySelector('[data-design-canvas-fixture="post-card"]')).not.toBeNull()
+    expect(stage!.querySelector('[data-design-canvas-fixture="episode-card"]')).not.toBeNull()
   })
 })

--- a/dashboard/src/components/design-canvas.ts
+++ b/dashboard/src/components/design-canvas.ts
@@ -17,6 +17,23 @@ import { CountBadge } from './common/badge'
 import { PanelCard } from './common/panel-card'
 import { SurfaceCard } from './common/card'
 import { Sparkline } from './common/sparkline'
+import { Table } from './common/table'
+import { TimeAgo } from './common/time-ago'
+import { KeeperBadge } from './keeper-badge'
+import { SessionTraceEntry } from './session-trace/session-trace-entry'
+import { keeperStateTone } from './common/status-chip'
+import {
+  FIXTURE_KEEPERS,
+  FIXTURE_GOALS,
+  FIXTURE_POSTS,
+  FIXTURE_TURNS,
+  FIXTURE_EPISODES,
+  type FixtureKeeper,
+  type FixtureGoal,
+  type FixtureJob,
+  type FixturePost,
+} from './design-canvas-fixtures'
+import type { MemoryOsEpisodeSummary } from '../api/dashboard'
 
 export type DesignCanvasCategory =
   | 'primitives'
@@ -24,6 +41,7 @@ export type DesignCanvasCategory =
   | 'organisms'
   | 'surfaces'
   | 'motion'
+  | 'fixtures'
 
 const CATEGORIES: { id: DesignCanvasCategory; label: string }[] = [
   { id: 'primitives', label: 'Primitives' },
@@ -31,6 +49,7 @@ const CATEGORIES: { id: DesignCanvasCategory; label: string }[] = [
   { id: 'organisms', label: 'Organisms' },
   { id: 'surfaces', label: 'Surfaces' },
   { id: 'motion', label: 'Motion' },
+  { id: 'fixtures', label: 'Fixtures' },
 ]
 
 function useDesignCanvasTheme() {
@@ -336,6 +355,233 @@ function MotionGallery() {
   `
 }
 
+function SectionStack({ title, children }: { title: string; children: unknown }) {
+  return html`
+    <div class="dc-section" data-design-canvas-section>
+      <h3 class="dc-section-title">${title}</h3>
+      <div class="dc-fixtures-stack">${children}</div>
+    </div>
+  `
+}
+
+function jobStateTone(state: string): string {
+  switch (state) {
+    case 'done':
+      return 'ok'
+    case 'in-progress':
+      return 'info'
+    case 'review':
+      return 'warn'
+    case 'blocked':
+      return 'bad'
+    case 'todo':
+    default:
+      return 'neutral'
+  }
+}
+
+function priorityTone(priority: string): string {
+  switch (priority) {
+    case 'high':
+      return 'bad'
+    case 'normal':
+      return 'info'
+    case 'low':
+    default:
+      return 'neutral'
+  }
+}
+
+function FixtureKeeperCard({ keeper }: { keeper: FixtureKeeper }) {
+  return html`
+    <${SurfaceCard}
+      class="w-[260px]"
+      variant="compact"
+      data-design-canvas-fixture="keeper-card"
+    >
+      <div class="flex items-center justify-between gap-2 mb-2">
+        <${KeeperBadge} id=${keeper.id} name=${keeper.kr} variant="full" />
+        <${StatusChip} tone=${keeperStateTone(keeper.phase)}>${keeper.phase}<//>
+      </div>
+      <${Vitals}
+        items=${[
+          { k: 'NS', v: keeper.ns, tone: 'default' },
+          { k: 'CTX', v: `${Math.round(keeper.ctx * 100)}%`, tone: keeper.ctx >= 0.85 ? 'warn' : 'default' },
+          { k: 'TRACES', v: keeper.traces, tone: 'default' },
+          { k: 'TASKS', v: keeper.tasks, tone: 'default' },
+          { k: 'TPS', v: keeper.tps, tone: keeper.tps > 0 ? 'volt' : 'default' },
+        ]}
+      />
+      <${Meter} pct=${Math.round(keeper.ctx * 100)} hot=${keeper.ctx >= 0.85} />
+      <div class="text-3xs text-[var(--color-fg-muted)] mt-2">${keeper.model} · ${keeper.runtime}</div>
+    <//>
+  `
+}
+
+function FixtureGoalsTable() {
+  const columns = [
+    { key: 'id', header: 'ID' },
+    { key: 'title', header: 'Title' },
+    {
+      key: 'lead',
+      header: 'Lead',
+      render: (row: FixtureGoal) => html`<${KeeperBadge} id=${row.lead} variant="sigil" />`,
+    },
+    {
+      key: 'priority',
+      header: 'Priority',
+      render: (row: FixtureGoal) => html`<${StatusChip} tone=${priorityTone(row.priority)} uppercase=${false}>${row.priority}<//>`,
+    },
+    { key: 'due', header: 'Due' },
+    {
+      key: 'metric',
+      header: 'Metric',
+      render: (row: FixtureGoal) => row.metric ?? html`<span class="text-[var(--color-fg-muted)]">—</span>`,
+    },
+  ]
+
+  return html`
+    <div class="overflow-x-auto rounded-[var(--r-1)] border border-[var(--color-border-default)]">
+      <${Table}
+        columns=${columns}
+        rows=${FIXTURE_GOALS}
+        getRowId=${(row: FixtureGoal) => row.id}
+        aria-label="Fixture goals"
+      />
+    </div>
+  `
+}
+
+function FixtureJobsTable() {
+  const rows = FIXTURE_GOALS.flatMap((goal) =>
+    goal.jobs.map((job) => ({ ...job, goalId: goal.id, goalTitle: goal.title })),
+  )
+
+  const columns = [
+    { key: 'id', header: 'ID' },
+    { key: 'title', header: 'Title' },
+    {
+      key: 'keeper',
+      header: 'Keeper',
+      render: (row: FixtureJob & { goalId: string; goalTitle: string }) =>
+        row.keeper ? html`<${KeeperBadge} id=${row.keeper} variant="sigil" />` : html`<span class="text-[var(--color-fg-muted)]">unassigned</span>`,
+    },
+    {
+      key: 'state',
+      header: 'State',
+      render: (row: FixtureJob & { goalId: string; goalTitle: string }) => html`<${StatusChip} tone=${jobStateTone(row.state)} uppercase=${false}>${row.state}<//>`,
+    },
+    {
+      key: 'blocker',
+      header: 'Blocker',
+      render: (row: FixtureJob & { goalId: string; goalTitle: string }) => row.blocker ?? html`<span class="text-[var(--color-fg-muted)]">—</span>`,
+    },
+  ]
+
+  return html`
+    <div class="overflow-x-auto rounded-[var(--r-1)] border border-[var(--color-border-default)]">
+      <${Table}
+        columns=${columns}
+        rows=${rows}
+        getRowId=${(row: FixtureJob & { goalId: string; goalTitle: string }) => row.id}
+        aria-label="Fixture jobs"
+      />
+    </div>
+  `
+}
+
+function FixturePostCard({ post }: { post: FixturePost }) {
+  return html`
+    <${SurfaceCard}
+      class="w-[320px]"
+      variant="compact"
+      data-design-canvas-fixture="post-card"
+    >
+      <div class="flex items-center justify-between gap-2 mb-2">
+        <${KeeperBadge} id=${post.author} variant="full" />
+        <${StatusChip} tone="neutral" uppercase=${false}>${post.board}<//>
+      </div>
+      ${post.title ? html`<h4 class="text-sm font-semibold text-[var(--color-fg-secondary)] mb-1">${post.title}</h4>` : null}
+      <div
+        class="text-sm leading-relaxed text-[var(--color-fg-primary)] line-clamp-4"
+        dangerouslySetInnerHTML=${{ __html: post.body }}
+      />
+      <div class="flex flex-wrap items-center gap-2 mt-3">
+        ${post.reactions.map(([emoji, count, reacted]) => html`
+          <${StatusChip} key=${emoji} tone=${reacted ? 'info' : 'neutral'} uppercase=${false}>${emoji} ${count}<//>
+        `)}
+        <span class="text-3xs text-[var(--color-fg-muted)]">karma ${post.karma}</span>
+        <span class="text-3xs text-[var(--color-fg-muted)]">replies ${post.replies}</span>
+      </div>
+    <//>
+  `
+}
+
+function FixtureEpisodeCard({ episode }: { episode: MemoryOsEpisodeSummary }) {
+  return html`
+    <${SurfaceCard}
+      class="w-[260px]"
+      variant="compact"
+      data-design-canvas-fixture="episode-card"
+    >
+      <div class="flex items-center justify-between gap-2 mb-2">
+        <span class="font-mono text-2xs text-[var(--color-fg-secondary)]">${episode.trace_id}</span>
+        <${StatusChip} tone=${episode.current ? 'ok' : 'warn'} uppercase=${false}>${episode.current ? 'current' : 'expired'}<//>
+      </div>
+      <div class="text-xs text-[var(--color-fg-secondary)] line-clamp-3 mb-2">${episode.summary}</div>
+      <div class="flex items-center justify-between text-3xs text-[var(--color-fg-muted)]">
+        <span>g${episode.generation.toString().padStart(4, '0')} · ${episode.claim_count} claims</span>
+        ${episode.terminal_marker ? html`<span class="font-mono">${episode.terminal_marker}</span>` : null}
+      </div>
+      ${episode.valid_until_iso
+        ? html`<div class="mt-2 text-3xs text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${episode.valid_until_iso} mode="both" /></div>`
+        : null}
+    <//>
+  `
+}
+
+function FixturesGallery() {
+  return html`
+    <${SectionStack} title="Fixtures">
+      <${Artboard} title="Keepers">
+        <div class="dc-fixtures-row">
+          ${FIXTURE_KEEPERS.map((keeper) => html`<${FixtureKeeperCard} key=${keeper.id} keeper=${keeper} />`)}
+        </div>
+      <//>
+
+      <${Artboard} title="Goals">
+        <div class="dc-fixtures-table-wrap">
+          <${FixtureGoalsTable} />
+        </div>
+      <//>
+
+      <${Artboard} title="Jobs">
+        <div class="dc-fixtures-table-wrap">
+          <${FixtureJobsTable} />
+        </div>
+      <//>
+
+      <${Artboard} title="Posts">
+        <div class="dc-fixtures-row">
+          ${FIXTURE_POSTS.map((post) => html`<${FixturePostCard} key=${post.id} post=${post} />`)}
+        </div>
+      <//>
+
+      <${Artboard} title="Turns">
+        <div class="dc-fixtures-stack">
+          ${FIXTURE_TURNS.map((event) => html`<${SessionTraceEntry} key=${event.id} event=${event} />`)}
+        </div>
+      <//>
+
+      <${Artboard} title="Episodes">
+        <div class="dc-fixtures-row">
+          ${FIXTURE_EPISODES.map((episode) => html`<${FixtureEpisodeCard} key=${`${episode.trace_id}-${episode.generation}`} episode=${episode} />`)}
+        </div>
+      <//>
+    <//>
+  `
+}
+
 export function DesignCanvas() {
   const [category, setCategory] = useState<DesignCanvasCategory>('primitives')
   const { theme, toggle } = useDesignCanvasTheme()
@@ -380,6 +626,7 @@ export function DesignCanvas() {
         ${category === 'organisms' ? html`<${OrganismsGallery} />` : null}
         ${category === 'surfaces' ? html`<${SurfacesGallery} />` : null}
         ${category === 'motion' ? html`<${MotionGallery} />` : null}
+        ${category === 'fixtures' ? html`<${FixturesGallery} />` : null}
       </div>
     </div>
   `

--- a/dashboard/src/styles/design-canvas.css
+++ b/dashboard/src/styles/design-canvas.css
@@ -228,6 +228,22 @@
   min-height: 120px;
 }
 
+.dc-fixtures-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.dc-fixtures-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.dc-fixtures-table-wrap {
+  overflow-x: auto;
+}
+
 .dc-rail-dot {
   width: 10px;
   height: 10px;


### PR DESCRIPTION
## Summary
Ports the keeper-v2 fixture data catalog into the MASC dashboard Design Canvas.

## What changed
- **New file** `dashboard/src/components/design-canvas-fixtures.ts`:
  - Typed fixture data for keepers, goals, jobs, posts, turns, episodes
- Updated `dashboard/src/components/design-canvas.ts`:
  - New **Fixtures** tab/gallery
  - Renders keepers, goals/jobs, posts, turns, episodes using existing dashboard components
- Updated `dashboard/src/styles/design-canvas.css` with fixtures gallery styles.
- Updated `design-canvas.test.ts` with fixtures tab assertion.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Design-canvas + related components ✅ 62/62
- Solid suite ✅ 85/85

## Notes
- No backend wiring; all data is static fixtures.
