### PR TITLE
fix(keeper): registry-driven strip of stale tool tokens in prompts

### DIFF
--- a/lib/keeper/keeper_prompt_token_integrity.ml
+++ b/lib/keeper/keeper_prompt_token_integrity.ml
@@ -26,6 +26,11 @@ let kind_to_string = function
   | Keeper -> "keeper"
   | Masc -> "masc"
 
+let keeper_prefix = "keeper_"
+let masc_prefix = "masc_"
+let keeper_prefix_len = String.length keeper_prefix
+let masc_prefix_len = String.length masc_prefix
+
 (* ── Token extraction ─────────────────────────────────────────────── *)
 
 let is_tool_token_char = function
@@ -40,7 +45,7 @@ let is_tool_token_char = function
 let token_kind_at pos text len :
     token_kind option =
   let lc offset = Char.lowercase_ascii text.[pos + offset] in
-  if pos + 7 <= len
+  if pos + keeper_prefix_len <= len
      && lc 0 = 'k'
      && lc 1 = 'e'
      && lc 2 = 'e'
@@ -50,7 +55,7 @@ let token_kind_at pos text len :
      && lc 6 = '_'
   then Some Keeper
   else if
-    pos + 5 <= len
+    pos + masc_prefix_len <= len
     && lc 0 = 'm'
     && lc 1 = 'a'
     && lc 2 = 's'
@@ -71,9 +76,10 @@ let is_env_var_shaped name =
   not !has_lower
 
 (** Find all keeper_*/masc_* tokens in [text]. Each token is returned as
-    [(kind, raw_name, position)]. The scan is linear in the length of the
-    input. *)
-let find_tokens text : (token_kind * string) list =
+    [(kind, raw_name, start, end_excl)]. The scan is linear in the length of
+    the input and is shared by both verification and sanitization so the two
+    passes cannot drift on prefix/boundary semantics. *)
+let find_tokens text : (token_kind * string * int * int) list =
   let len = String.length text in
   let tokens = ref [] in
   let i = ref 0 in
@@ -82,15 +88,15 @@ let find_tokens text : (token_kind * string) list =
     | Some kind when is_token_start !i text ->
         let prefix_len =
           match kind with
-          | Keeper -> 7
-          | Masc -> 5
+          | Keeper -> keeper_prefix_len
+          | Masc -> masc_prefix_len
         in
         let j = ref (!i + prefix_len) in
         while !j < len && is_tool_token_char text.[!j] do
           incr j
         done;
         let name = String.sub text !i (!j - !i) in
-        tokens := (kind, name) :: !tokens;
+        tokens := (kind, name, !i, !j) :: !tokens;
         i := !j
     | _ -> incr i
   done;
@@ -139,6 +145,7 @@ let verify_token ~keeper_name ~source (kind, name) : string option =
 
 let scan_text ~keeper_name ~source text : string list =
   find_tokens text
+  |> List.map (fun (kind, name, _, _) -> kind, name)
   |> dedup_tokens
   |> List.filter_map (verify_token ~keeper_name ~source)
   |> dedup_strings
@@ -157,50 +164,67 @@ let scan_rendered_prompt
 
 (* ── Registry-driven sanitization ─────────────────────────────────── *)
 
-(** Remove keeper_*/masc_* tokens that do not resolve to a live tool, driven
+let stale_tool_token_placeholder = "<stale_tool_token>"
+
+(** Sanitize keeper_*/masc_* tokens that do not resolve to a live tool, driven
     by [Keeper_tool_resolution] (the same source of truth the scanner uses).
 
-    Root fix for stale tool names leaking into prompts: the legacy
+    This is a presentation-layer band-aid for stale tool names that have
+    already leaked into prompt/continuity text. The legacy
     [Keeper_unified_prompt.sanitize_retired_tool_names] is a hardcoded
     retired-prefix list that must be hand-edited on every tool rename and
     silently misses renames it does not enumerate (e.g. masc_board_get ->
     masc_board_post_get). This pass instead asks the registry: any
     lowercase masc_/keeper_ token that resolves is kept; one that does not
     (a removed/renamed tool, or a hallucinated name frozen in an injected
-    episode) is dropped so the model never sees it as a callable tool.
+    episode) is replaced with [stale_tool_token_placeholder] so the model
+    never sees it as a callable tool while the surrounding sentence stays
+    grammatically intact.
 
     Env-var-shaped tokens (all-uppercase, e.g. MASC_BASE_PATH) are kept —
     they are not tool invocations and stripping them would mangle legitimate
-    configuration prose. A resolved alias is also kept. *)
-let strip_unresolved_tool_tokens text : string =
+    configuration prose. A resolved alias is also kept.
+
+    When [~keeper_name] is provided, every replacement emits a counter on
+    [masc_keeper_prompt_token_stripped_total] and a warning log so the
+    producer-side alarm is not lost. *)
+let strip_unresolved_tool_tokens ?keeper_name text : string =
+  let tokens = find_tokens text in
   let len = String.length text in
   let buf = Buffer.create len in
-  let i = ref 0 in
-  while !i < len do
-    match token_kind_at !i text len with
-    | Some kind when is_token_start !i text ->
-        let prefix_len =
-          match kind with
-          | Keeper -> 7
-          | Masc -> 5
-        in
-        let j = ref (!i + prefix_len) in
-        while !j < len && is_tool_token_char text.[!j] do
-          incr j
-        done;
-        let name = String.sub text !i (!j - !i) in
-        let keep =
-          is_env_var_shaped name
-          ||
-          match Keeper_tool_resolution.resolve (String.lowercase_ascii name) with
-          | Keeper_tool_resolution.Resolved _ | Keeper_tool_resolution.Alias_to _ ->
-              true
-          | Keeper_tool_resolution.Unknown _ -> false
-        in
-        if keep then Buffer.add_string buf name;
-        i := !j
-    | _ ->
-        Buffer.add_char buf text.[!i];
-        incr i
-  done;
+  let pos = ref 0 in
+  List.iter
+    (fun (kind, name, start, end_excl) ->
+       Buffer.add_substring buf text !pos (start - !pos);
+       let keep =
+         is_env_var_shaped name
+         ||
+         match Keeper_tool_resolution.resolve (String.lowercase_ascii name) with
+         | Keeper_tool_resolution.Resolved _ | Keeper_tool_resolution.Alias_to _ ->
+             true
+         | Keeper_tool_resolution.Unknown _ -> false
+       in
+       if keep then
+         Buffer.add_substring buf text start (end_excl - start)
+       else (
+         (match keeper_name with
+          | Some keeper ->
+              Otel_metric_store.inc_counter
+                (Keeper_metrics.to_string PromptTokenStripped)
+                ~labels:
+                  [ ("keeper", keeper)
+                  ; ("kind", kind_to_string kind)
+                  ; ("tool", String.lowercase_ascii name)
+                  ]
+                ();
+              Log.Keeper.warn
+                "keeper_prompt_token_integrity: stripped %s token %S from prompt for keeper %s"
+                (kind_to_string kind)
+                name
+                keeper
+          | None -> ());
+         Buffer.add_string buf stale_tool_token_placeholder);
+       pos := end_excl)
+    tokens;
+  Buffer.add_substring buf text !pos (len - !pos);
   Buffer.contents buf

--- a/lib/keeper/keeper_prompt_token_integrity.ml
+++ b/lib/keeper/keeper_prompt_token_integrity.ml
@@ -61,6 +61,15 @@ let token_kind_at pos text len :
 
 let is_token_start pos text = pos = 0 || not (is_tool_token_char text.[pos - 1])
 
+(* 도구 토큰은 소문자(masc_board_list, keeper_memory_search)이고 환경변수는
+   대문자(MASC_BASE_PATH)다. 알파벳이 하나도 소문자가 아니면 env 변수로 보고
+   도구 토큰 판정에서 제외한다 — masc_/keeper_ 접두 휴리스틱이 도구가 아닌
+   식별자를 오탐하지 않게 한다. *)
+let is_env_var_shaped name =
+  let has_lower = ref false in
+  String.iter (fun c -> if c >= 'a' && c <= 'z' then has_lower := true) name;
+  not !has_lower
+
 (** Find all keeper_*/masc_* tokens in [text]. Each token is returned as
     [(kind, raw_name, position)]. The scan is linear in the length of the
     input. *)
@@ -103,8 +112,12 @@ let dedup_tokens tokens =
 (* ── Verification ─────────────────────────────────────────────────── *)
 
 let verify_token ~keeper_name ~source (kind, name) : string option =
-  let normalized = String.lowercase_ascii name in
-  match Keeper_tool_resolution.resolve normalized with
+  if is_env_var_shaped name then None
+    (* all-uppercase masc_/keeper_ 토큰은 도구가 아니라 env 변수(MASC_BASE_PATH 등).
+       도구명은 소문자 관례이므로 flag/strip 대상에서 제외 — 접두 휴리스틱 오탐 방지. *)
+  else
+    let normalized = String.lowercase_ascii name in
+    match Keeper_tool_resolution.resolve normalized with
   | Keeper_tool_resolution.Resolved _ | Keeper_tool_resolution.Alias_to _ ->
       None
   | Keeper_tool_resolution.Unknown _ ->
@@ -141,3 +154,53 @@ let scan_rendered_prompt
     scan_text ~keeper_name ~source:Continuity continuity_summary
   in
   system_unknowns @ user_unknowns @ continuity_unknowns |> dedup_strings
+
+(* ── Registry-driven sanitization ─────────────────────────────────── *)
+
+(** Remove keeper_*/masc_* tokens that do not resolve to a live tool, driven
+    by [Keeper_tool_resolution] (the same source of truth the scanner uses).
+
+    Root fix for stale tool names leaking into prompts: the legacy
+    [Keeper_unified_prompt.sanitize_retired_tool_names] is a hardcoded
+    retired-prefix list that must be hand-edited on every tool rename and
+    silently misses renames it does not enumerate (e.g. masc_board_get ->
+    masc_board_post_get). This pass instead asks the registry: any
+    lowercase masc_/keeper_ token that resolves is kept; one that does not
+    (a removed/renamed tool, or a hallucinated name frozen in an injected
+    episode) is dropped so the model never sees it as a callable tool.
+
+    Env-var-shaped tokens (all-uppercase, e.g. MASC_BASE_PATH) are kept —
+    they are not tool invocations and stripping them would mangle legitimate
+    configuration prose. A resolved alias is also kept. *)
+let strip_unresolved_tool_tokens text : string =
+  let len = String.length text in
+  let buf = Buffer.create len in
+  let i = ref 0 in
+  while !i < len do
+    match token_kind_at !i text len with
+    | Some kind when is_token_start !i text ->
+        let prefix_len =
+          match kind with
+          | Keeper -> 7
+          | Masc -> 5
+        in
+        let j = ref (!i + prefix_len) in
+        while !j < len && is_tool_token_char text.[!j] do
+          incr j
+        done;
+        let name = String.sub text !i (!j - !i) in
+        let keep =
+          is_env_var_shaped name
+          ||
+          match Keeper_tool_resolution.resolve (String.lowercase_ascii name) with
+          | Keeper_tool_resolution.Resolved _ | Keeper_tool_resolution.Alias_to _ ->
+              true
+          | Keeper_tool_resolution.Unknown _ -> false
+        in
+        if keep then Buffer.add_string buf name;
+        i := !j
+    | _ ->
+        Buffer.add_char buf text.[!i];
+        incr i
+  done;
+  Buffer.contents buf

--- a/lib/keeper/keeper_prompt_token_integrity.mli
+++ b/lib/keeper/keeper_prompt_token_integrity.mli
@@ -29,3 +29,10 @@ val scan_rendered_prompt :
   user_message:string ->
   continuity_summary:string ->
   string list
+
+(** Remove keeper_*/masc_* tokens that do not resolve to a live tool via
+    [Keeper_tool_resolution]. Registry-driven root fix for stale tool names
+    leaking into prompts, replacing the hardcoded retired-prefix list. Resolved
+    tools and aliases are kept; env-var-shaped (all-uppercase, e.g.
+    [MASC_BASE_PATH]) tokens are kept (not tool invocations). *)
+val strip_unresolved_tool_tokens : string -> string

--- a/lib/keeper/keeper_prompt_token_integrity.mli
+++ b/lib/keeper/keeper_prompt_token_integrity.mli
@@ -30,9 +30,15 @@ val scan_rendered_prompt :
   continuity_summary:string ->
   string list
 
-(** Remove keeper_*/masc_* tokens that do not resolve to a live tool via
-    [Keeper_tool_resolution]. Registry-driven root fix for stale tool names
-    leaking into prompts, replacing the hardcoded retired-prefix list. Resolved
-    tools and aliases are kept; env-var-shaped (all-uppercase, e.g.
-    [MASC_BASE_PATH]) tokens are kept (not tool invocations). *)
-val strip_unresolved_tool_tokens : string -> string
+(** Sanitize keeper_*/masc_* tokens that do not resolve to a live tool via
+    [Keeper_tool_resolution]. Registry-driven presentation-layer band-aid for
+    stale tool names leaking into prompts, replacing the hardcoded
+    retired-prefix list. Resolved tools and aliases are kept; env-var-shaped
+    (all-uppercase, e.g. [MASC_BASE_PATH]) tokens are kept (not tool
+    invocations). Unresolved tokens are replaced with
+    [<stale_tool_token>] to avoid leaving semantic holes in sentences.
+
+    When [~keeper_name] is supplied, each replacement emits
+    [masc_keeper_prompt_token_stripped_total] and a warning log so the
+    producer-side alarm is not silenced. *)
+val strip_unresolved_tool_tokens : ?keeper_name:string -> string -> string

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -740,6 +740,14 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     Keeper_memory_policy.filter_forward_looking_summary
       observation.continuity_summary
   in
+  (* Strip stale tool tokens from the continuity surface before it is embedded
+     in the user message. The ratchet below scans the pre-strip text so the
+     producer-side alarm is preserved. *)
+  let sanitized_continuity_for_prompt =
+    Keeper_prompt_token_integrity.strip_unresolved_tool_tokens
+      ~keeper_name:meta.name
+      continuity_for_prompt
+  in
   let content_of : Keeper_context_layers.layer_id -> string option = function
     (* 1. Active goals — stable turn context. *)
     | Keeper_context_layers.Active_goals ->
@@ -848,7 +856,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
           ("\n### Continuity\n"
           ^ "- Advisory only: ignore prior silence/wait directives until you re-verify them against the live world state.\n"
           ^ "- If this turn was still scheduled or backlog/repo signals remain, investigate that mismatch instead of echoing the prior idle conclusion.\n"
-          ^ continuity_for_prompt
+          ^ sanitized_continuity_for_prompt
           ^ "\n")
       else None
     (* 7. Pending mentions — reactive trigger. *)
@@ -941,7 +949,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
       ~keeper_name:meta.name
       ~system_prompt:explicit_rename_system
       ~user_message:explicit_rename_user
-      ~continuity_summary:meta.continuity_summary
+      ~continuity_summary:continuity_for_prompt
   in
   let sanitized_system =
     explicit_rename_system

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -922,8 +922,19 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
   let user_message =
     "## Current World State\n\n" ^ Keeper_context_layers.assemble ~content_of
   in
-  let sanitized_system = sanitize_retired_tool_names system_prompt in
-  let sanitized_user = sanitize_retired_tool_names user_message in
+  (* 1차: 명시적 rename 치환(keeper_bash->execute_command 등)은 하드코딩 유지.
+     2차: registry-driven strip — rename/제거되어 더 이상 resolve되지 않는 도구
+     토큰을 Keeper_tool_resolution 기준으로 제거한다. 하드코딩 목록이 놓치는
+     stale 토큰(주입된 옛 episode의 죽은 도구명 등)을 단일 소스로 자동 정리하고,
+     warn-only ratchet이 세던 누수를 실제로 막는다. env 변수(대문자)는 보존. *)
+  let sanitized_system =
+    sanitize_retired_tool_names system_prompt
+    |> Keeper_prompt_token_integrity.strip_unresolved_tool_tokens
+  in
+  let sanitized_user =
+    sanitize_retired_tool_names user_message
+    |> Keeper_prompt_token_integrity.strip_unresolved_tool_tokens
+  in
   (* set_gauge only: a stray inc_counter here used to create this
      (name, labels) cell as Counter first, so the system_prompt series
      kept Counter kind, carried a non-monotonic byte length, and exported

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -924,16 +924,34 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
   in
   (* 1차: 명시적 rename 치환(keeper_bash->execute_command 등)은 하드코딩 유지.
      2차: registry-driven strip — rename/제거되어 더 이상 resolve되지 않는 도구
-     토큰을 Keeper_tool_resolution 기준으로 제거한다. 하드코딩 목록이 놓치는
+     토큰을 Keeper_tool_resolution 기준으로 치환한다. 하드코딩 목록이 놓치는
      stale 토큰(주입된 옛 episode의 죽은 도구명 등)을 단일 소스로 자동 정리하고,
-     warn-only ratchet이 세던 누수를 실제로 막는다. env 변수(대문자)는 보존. *)
+     문장 속에서 토큰 자리를 [<stale_tool_token>] placeholder로 남겨 의미적
+     구멍을 피한다. env 변수(대문자)는 보존. *)
+  let explicit_rename_system = sanitize_retired_tool_names system_prompt in
+  let explicit_rename_user = sanitize_retired_tool_names user_message in
+  (* P0-3: rendered prompt token integrity ratchet. Scan the prompt surfaces
+     *before* the registry-driven strip so stale tokens that are about to be
+     replaced still increment [PromptUnknownToolTokens] and are logged. The
+     strip pass additionally emits [PromptTokenStripped] per removed token, but
+     running the ratchet first preserves the producer-side alarm signal that
+     would otherwise be silently dropped after removal. *)
+  let (_ : string list) =
+    Keeper_prompt_token_integrity.scan_rendered_prompt
+      ~keeper_name:meta.name
+      ~system_prompt:explicit_rename_system
+      ~user_message:explicit_rename_user
+      ~continuity_summary:meta.continuity_summary
+  in
   let sanitized_system =
-    sanitize_retired_tool_names system_prompt
+    explicit_rename_system
     |> Keeper_prompt_token_integrity.strip_unresolved_tool_tokens
+         ~keeper_name:meta.name
   in
   let sanitized_user =
-    sanitize_retired_tool_names user_message
+    explicit_rename_user
     |> Keeper_prompt_token_integrity.strip_unresolved_tool_tokens
+         ~keeper_name:meta.name
   in
   (* set_gauge only: a stray inc_counter here used to create this
      (name, labels) cell as Counter first, so the system_prompt series
@@ -964,16 +982,4 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     (Keeper_metrics.to_string KeeperTurnInstructionHash)
     ~labels:[("keeper", meta.name)]
     prompt_hash;
-  (* P0-3: rendered prompt token integrity ratchet. Every prompt that reaches
-     an LLM is scanned for keeper_*/masc_* tokens; any token that does not
-     resolve through [Keeper_tool_resolution] is counted by
-     [PromptUnknownToolTokens] and logged. This catches stale tool names that
-     survive the [sanitize_retired_tool_names] pass or leak into continuity. *)
-  let (_ : string list) =
-    Keeper_prompt_token_integrity.scan_rendered_prompt
-      ~keeper_name:meta.name
-      ~system_prompt:sanitized_system
-      ~user_message:sanitized_user
-      ~continuity_summary:meta.continuity_summary
-  in
   ( sanitized_system, sanitized_user )

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -122,6 +122,7 @@ type t =
   | SnapshotWriteFailures
   | StateSnapshotSkippedNoState
   | PromptUnknownToolTokens
+  | PromptTokenStripped
   | ProgressUpdatedLineFailures
   | SseBroadcastFailures
   | WorkspaceHeartbeatFailures
@@ -352,6 +353,8 @@ let to_string = function
     "masc_keeper_state_snapshot_skipped_no_state_total"
   | PromptUnknownToolTokens ->
     "masc_keeper_prompt_unknown_tool_tokens_total"
+  | PromptTokenStripped ->
+    "masc_keeper_prompt_token_stripped_total"
   | ProgressUpdatedLineFailures -> "masc_keeper_progress_updated_line_failures_total"
   | SseBroadcastFailures -> "masc_keeper_sse_broadcast_failures_total"
   | WorkspaceHeartbeatFailures -> "masc_keeper_workspace_heartbeat_failures_total"
@@ -499,6 +502,7 @@ let all : t list =
     ClaimAutoProvision; TomlInvalid; PersonaDriftMissing; WorkspaceInitFailures;
     PresenceSyncFailures; SelfPreservationUniversal; StaleStormPaused; ProviderTimeoutLoopPaused;
     CycleExceptions; SnapshotWriteFailures; StateSnapshotSkippedNoState; PromptUnknownToolTokens;
+    PromptTokenStripped;
     ProgressUpdatedLineFailures;
     SseBroadcastFailures; WorkspaceHeartbeatFailures; TurnMetricsSnapshotFailures; OasExecutionErrors;
     EpisodeCreateFailures; MemoryActivityEmitFailures; SupervisorSweepFailures; TomlReconcileSweepFailures;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -113,6 +113,7 @@ type t =
   | SnapshotWriteFailures
   | StateSnapshotSkippedNoState
   | PromptUnknownToolTokens
+  | PromptTokenStripped
   | ProgressUpdatedLineFailures
   | SseBroadcastFailures
   | WorkspaceHeartbeatFailures

--- a/test/test_keeper_prompt_token_integrity.ml
+++ b/test/test_keeper_prompt_token_integrity.ml
@@ -42,20 +42,22 @@ let test_unknown_token_reported () =
   Alcotest.(check (float 0.0001))
     "metric +1" (before +. 1.0) (total_unknown ())
 
-let test_unknown_capitalized_token_reported () =
-  (* Prefix matching must be case-insensitive so capitalized stale tokens are
-     caught, not silently missed. *)
-  let prompt = "Call KEEPER_P0_3_FICTIONAL_TOOL to proceed." in
+let test_all_uppercase_token_is_env_var_not_reported () =
+  (* All-uppercase masc_/keeper_ tokens are env-var-shaped (MASC_BASE_PATH,
+     KEEPER_FOO), not tool invocations — tool names are lowercase by
+     convention. They are skipped rather than flagged, so config prose
+     mentioning env vars does not produce false-positive unknown-token WARNs.
+     (Mixed-case stale tokens with at least one lowercase letter are still
+     normalized and checked — see [test_case_insensitive_resolution].) *)
+  let prompt = "Set KEEPER_P0_3_FICTIONAL_ENV before proceeding." in
   let before = total_unknown () in
   let unknowns =
     Scanner.scan_text ~keeper_name:keeper ~source:System_prompt prompt
   in
   Alcotest.(check (list string))
-    "capitalized unknown keeper token is reported"
-    [ "keeper_p0_3_fictional_tool" ]
-    unknowns;
+    "all-uppercase env-var-shaped token is not reported" [] unknowns;
   Alcotest.(check (float 0.0001))
-    "metric +1" (before +. 1.0) (total_unknown ())
+    "metric unchanged" before (total_unknown ())
 
 let test_unknown_masc_token_reported () =
   let prompt = "Use masc_p0_3_unknown_gadget for diagnostics." in
@@ -128,6 +130,32 @@ let test_case_insensitive_resolution () =
   Alcotest.(check (list string))
     "mixed-case known tokens resolve" [] unknowns
 
+(* ── strip_unresolved_tool_tokens (registry-driven sanitization) ── *)
+
+let test_strip_removes_unresolved_lowercase_token () =
+  (* A stale/removed lowercase tool name is dropped (its chars removed,
+     surrounding text untouched) so the model never sees it as a callable
+     tool; a resolving tool in the same text is preserved. *)
+  let text = "First call masc_p0_3_dead_gadget then keeper_board_post." in
+  Alcotest.(check string)
+    "dead token removed, resolved tool kept"
+    "First call  then keeper_board_post."
+    (Scanner.strip_unresolved_tool_tokens text)
+
+let test_strip_keeps_env_var_shaped_token () =
+  (* All-uppercase env-var-shaped tokens are not tool invocations; stripping
+     them would mangle legitimate configuration prose. *)
+  let text = "Set MASC_BASE_PATH=/srv before launch." in
+  Alcotest.(check string)
+    "env var preserved verbatim" text
+    (Scanner.strip_unresolved_tool_tokens text)
+
+let test_strip_is_identity_when_all_resolve () =
+  let text = "Use keeper_board_post and masc_keeper_status only." in
+  Alcotest.(check string)
+    "no change when every token resolves" text
+    (Scanner.strip_unresolved_tool_tokens text)
+
 let () =
   Alcotest.run "keeper_prompt_token_integrity_p0_3"
     [
@@ -137,8 +165,8 @@ let () =
             test_known_tokens_are_not_reported;
           Alcotest.test_case "unknown keeper token reported" `Quick
             test_unknown_token_reported;
-          Alcotest.test_case "unknown capitalized keeper token reported" `Quick
-            test_unknown_capitalized_token_reported;
+          Alcotest.test_case "all-uppercase token is env-var, not reported"
+            `Quick test_all_uppercase_token_is_env_var_not_reported;
           Alcotest.test_case "unknown masc token reported" `Quick
             test_unknown_masc_token_reported;
           Alcotest.test_case "deduplicates within surface" `Quick
@@ -148,5 +176,14 @@ let () =
             test_rendered_prompt_scans_all_surfaces;
           Alcotest.test_case "case insensitive resolution" `Quick
             test_case_insensitive_resolution;
+        ] );
+      ( "sanitization",
+        [
+          Alcotest.test_case "strip removes unresolved lowercase token" `Quick
+            test_strip_removes_unresolved_lowercase_token;
+          Alcotest.test_case "strip keeps env-var-shaped token" `Quick
+            test_strip_keeps_env_var_shaped_token;
+          Alcotest.test_case "strip is identity when all resolve" `Quick
+            test_strip_is_identity_when_all_resolve;
         ] );
     ]

--- a/test/test_keeper_prompt_token_integrity.ml
+++ b/test/test_keeper_prompt_token_integrity.ml
@@ -8,9 +8,11 @@ module Scanner = Masc.Keeper_prompt_token_integrity
 module Metrics = Masc.Otel_metric_store
 
 let metric_name = Keeper_metrics.(to_string PromptUnknownToolTokens)
+let stripped_metric_name = Keeper_metrics.(to_string PromptTokenStripped)
 let keeper = "test-keeper-p0-3"
 
 let total_unknown () = Metrics.metric_total metric_name
+let total_stripped () = Metrics.metric_total stripped_metric_name
 
 let test_known_tokens_are_not_reported () =
   let prompt =
@@ -133,13 +135,13 @@ let test_case_insensitive_resolution () =
 (* ── strip_unresolved_tool_tokens (registry-driven sanitization) ── *)
 
 let test_strip_removes_unresolved_lowercase_token () =
-  (* A stale/removed lowercase tool name is dropped (its chars removed,
-     surrounding text untouched) so the model never sees it as a callable
-     tool; a resolving tool in the same text is preserved. *)
+  (* A stale/removed lowercase tool name is replaced with a placeholder so
+     the model never sees it as a callable tool and the sentence keeps its
+     shape; a resolving tool in the same text is preserved. *)
   let text = "First call masc_p0_3_dead_gadget then keeper_board_post." in
   Alcotest.(check string)
-    "dead token removed, resolved tool kept"
-    "First call  then keeper_board_post."
+    "dead token replaced, resolved tool kept"
+    "First call <stale_tool_token> then keeper_board_post."
     (Scanner.strip_unresolved_tool_tokens text)
 
 let test_strip_keeps_env_var_shaped_token () =
@@ -155,6 +157,18 @@ let test_strip_is_identity_when_all_resolve () =
   Alcotest.(check string)
     "no change when every token resolves" text
     (Scanner.strip_unresolved_tool_tokens text)
+
+let test_strip_emits_stripped_metric () =
+  (* When [~keeper_name] is supplied, each replaced token increments
+     [masc_keeper_prompt_token_stripped_total] with the tool dimension so
+     the strip action remains observable even though the text was sanitized. *)
+  let text = "Run masc_p0_3_dead_gadget and keeper_p0_3_dead_tool now." in
+  let before = total_stripped () in
+  let _ = Scanner.strip_unresolved_tool_tokens ~keeper_name:keeper text in
+  Alcotest.(check (float 0.0001))
+    "stripped metric +2 for two distinct dead tools"
+    (before +. 2.0)
+    (total_stripped ())
 
 let () =
   Alcotest.run "keeper_prompt_token_integrity_p0_3"
@@ -179,11 +193,13 @@ let () =
         ] );
       ( "sanitization",
         [
-          Alcotest.test_case "strip removes unresolved lowercase token" `Quick
+          Alcotest.test_case "strip replaces unresolved lowercase token" `Quick
             test_strip_removes_unresolved_lowercase_token;
           Alcotest.test_case "strip keeps env-var-shaped token" `Quick
             test_strip_keeps_env_var_shaped_token;
           Alcotest.test_case "strip is identity when all resolve" `Quick
             test_strip_is_identity_when_all_resolve;
+          Alcotest.test_case "strip emits stripped metric" `Quick
+            test_strip_emits_stripped_metric;
         ] );
     ]


### PR DESCRIPTION
## 문제

키퍼 albini의 system_prompt에서 `keeper_prompt_token_integrity`가 4개 토큰을 "unknown masc token"으로 WARN:
`masc_who`, `masc_board_get`, `masc_coordination_fsm_snapshot`, `MASC_BASE_PATH`.

## 근본 원인

- 이 토큰들은 **2026-05-23~25 함대 전역 `no_tool_capable_provider` 실패 episode**(institutional memory)에 동결된 에러 페이로드의 `required_tool_names` 배열에서 옴. institutional memory는 키퍼 공유 → albini 프롬프트에 재생.
- 프롬프트 도구명 위생이 두 약한 메커니즘에 의존:
  1. `sanitize_retired_tool_names` = **하드코딩 retired-prefix 목록**. 도구 rename마다 수동 추가해야 하고, 열거 안 된 rename은 조용히 누락 (`masc_board_get` ≠ 실제 `masc_board_post_get`/`masc_board_list`).
  2. `keeper_prompt_token_integrity` 스캐너 = **warn-only ratchet**. 누수를 세기만 하고 안 고침.

(legacy 실패 episode 41+1개는 런타임 store에서 이미 prune됨. 현재 코드엔 이런 episode를 쓰는 라이브 writer가 없음 — 기록측은 고칠 대상 없음.)

## 변경

| | |
|---|---|
| `strip_unresolved_tool_tokens` | registry-driven: `Keeper_tool_resolution`(스캐너와 동일 SSOT)로 resolve 안 되는 `keeper_*`/`masc_*` 토큰을 프롬프트에서 제거. rename/제거를 단일 소스가 자동 처리, warn-only ratchet을 실제 fix로 뒷받침. |
| `is_env_var_shaped` | all-uppercase 토큰(`MASC_BASE_PATH`)은 env 변수지 도구 아님(도구명=소문자 관례) → flag/strip 양쪽에서 제외. config prose 안 망가뜨리고 false-positive 제거. |
| 배선 | `keeper_unified_prompt`에서 explicit-rename pass **후** strip 적용(rename이 먼저여야 함 — strip이 먼저면 옛 이름을 그냥 drop). |

## 트레이드오프 / 범위

- `sanitize_retired_tool_names`의 *removal* 항목(keeper_bash/shell/fs…)은 이제 strip이 커버 → 추후 deprecate 가능. *rename* 항목은 유지(strip은 rename 못함). 이번엔 리스크 최소화로 둘 다 보존.
- all-uppercase 제외로 "대문자 stale 도구명"은 미검출(도구는 소문자라 드문 케이스). 기존 `test_unknown_capitalized_token_reported`의 전제(대문자도 flag)를 env-var 인지로 갱신.

## 검증

- `test_all_uppercase_token_is_env_var_not_reported` + strip 3케이스(unresolved 소문자 제거 / env-var 보존 / 전부 resolve 시 identity).
- lib/keeper 로컬 빌드 불가(agent_sdk opam pin) → ocamlformat --check 4파일 통과, CI Build and Test가 타입 검증.

RFC-WAIVED: keeper_prompt_token_integrity / keeper_unified_prompt는 credential/identity/operator/sandbox/dashboard-credential/hooks/workflow gated subsystem이 아님. 2파일 focused 수정, 설계는 코드 주석 + 본 본문에 기재.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
---
 
## 🔄 AS-IS vs TO-BE 구조적 개선점 분석 (Structural Improvements)
 
# AS-IS vs TO-BE 비교 매트릭스

| 관심사 | AS-IS (Before PR) | TO-BE (After PR) | 취약성 잔존 여부 |
| :--- | :--- | :--- | :--- |
| **Stale 토큰 탐지** | `keeper_prompt_token_integrity` 단순 WARN 카운터 (ratchet). 수정 불가 | 동일 스캐너 유지 + `strip_unresolved_tool_tokens`으로 실제 제거 수행 | **Y** (스캐너와 스트리퍼의 레지스트리 조회 시점 불일치 위험) |
| **Retired 도구명 처리** | `sanitize_retired_tool_names`의 하드코딩 prefix 매칭에 전적으로 의존 | 레지스트리(`Keeper_tool_resolution`) 기반 동적 resolve 실패 토큰 제거 추가 | **Y** (기존 하드코딩 로직과의 순차 실행 시 사이드 이펙트) |
| **대문자 토큰 처리** | `test_unknown_capitalized_token_reported` 전제하에 모든 토큰을 도구명으로 간주 | `is_env_var_shaped` 추가하여 ALL-UPPERCASE 토큰을 env-var로 분류하고 strip 예외 처리 | **Y** (정규식 기반 heuristic의 false-negative 취약성) |
| **파이프라인 순서** | `sanitize_retired_tool_names` 단독 실행 | rename explicit pass $\rightarrow$ `strip_unresolved_tool_tokens` 순차 실행 | **Y** (순차 파이프라인의 원자성 결여) |
| **테스트 커버리지** | 대문자 토큰 WARN 테스트 존재 | 소문자 미해결 제거, env-var 보존, 전체 resolve 시 identity 테스트 추가 | **Y** (Eio 비동기 컨텍스트 및 멀티코어 경쟁 상태 테스트 누락) |

```mermaid
flowchart TD
    subgraph AS_IS ["AS-IS: 취약한 단방향 파이프라인"]
        direction TB
        A1[Institutional Memory Payload] --> A2[sanitize_retired_tool_names<br/>하드코딩 Prefix 매칭]
        A2 --> A3[keeper_prompt_token_integrity<br/>WARN-ONLY Ratchet]
        A3 -.->|수정 불가| A4[Albini System Prompt<br/>Stale 토큰 잔존]
    end

    subgraph TO_BE ["TO-BE: 레지스트리 기반 2-Pass 파이프라인"]
        direction TB
        B1[Institutional Memory Payload] --> B2[Explicit Rename Pass]
        B2 --> B3[is_env_var_shaped<br/>ALL-UPPERCASE 필터링]
        B3 --> B4[strip_unresolved_tool_tokens<br/>Keeper_tool_resolution SSOT 조회]
        B4 --> B5[keeper_prompt_token_integrity<br/>WARN-ONLY Ratchet]
        B5 --> B6[Albini System Prompt<br/>정화된 토큰]
        
        B4 -.->|Race Condition 가능성| B7[(Keeper_tool_resolution<br/>SSOT Registry)]
    end

    AS_IS -.->|리팩토링| TO_BE

    style A4 fill:#ffcccc,stroke:#ff0000,stroke-width:2px
    style B7 fill:#fff3cd,stroke:#ffc107,stroke-width:2px
    style B6 fill:#d4edda,stroke:#28a745,stroke-width:2px
```

# ⚡ Adversarial Critique & Vulnerability Report (적대적 비판 및 취약성 검증)

이 PR은 "WARN-only에서 실제 fix로 전환"한다는 거창한 명분을 내세우고 있으나, OCaml의 멀티코어 런타임 특성과 Eio의 비동기 흐름, 그리고 상태 의존성을 철저히 무시한 채 문제를 단순한 문자열 치환 수준으로 전락시켰다. 다음 3가지 치명적인 결함을 확인한다.

## 1. `Keeper_tool_resolution` SSOT 레지스트리 조회의 Time-of-Check to Time-of-Use (TOCTOU) 경쟁 상태 및 원자성 결여

`keeper_unified_prompt.ml` 내부에서 명시된 파이프라인 순서는 *Rename $\rightarrow$ Strip*이다. 그러나 이 두 단계는 독립적인 순차 루프 또는 `String.map`/정규식 치환의 연속으로 구현될 것이며, **각 단계 간의 상태 스냅샷이 보장되지 않는다.**

더 심각한 것은 `strip_unresolved_tool_tokens`가 `Keeper_tool_resolution`을 읽을 때의 동시성 문제다. 만약 이 모듈이 Eio fiber 상에서 실행되며, 플랫폼의 도구 레지스트리가 핫리로드(Hot-reload)되거나 다른 fiber에 의해 업데이트되는 구조라면:
- **스캐너(`keeper_prompt_token_integrity`)가 읽는 레지스트리 상태**와 **스트리퍼가 읽는 레지스트리 상태**가 미세하게 다를 수 있다.
- 스캐너는 "Unknown"으로 카운트하고, 밀리초 뒤 스트리퍼는 해당 토큰이 갑자기 resolve되어 방치하는, 혹은 그 반대의 상태가 발생한다.
- PR 설명에서 "스캐너와 동일 SSOT"라고 주장하지만, 멀티코어 OCaml(5.0+ 도메인) 환경에서 메모리 가시성(Memory Visibility) 보장 없이 레지스트리 맵을 읽는 것은 **Data Race**를 유발한다. `Keeper_tool_resolution`이 수정 불가능한(Immutable) 데이터 구조로 매번 교체되지 않는 한, 이 스트리핑 로직은 경쟁 상태에 매우 취약하다.

## 2. `is_env_var_shaped` Heuristic의 탈을 쓴 False-Negative 백도어 및 정규식 탈출 취약성

ALL-UPPERCASE 토큰을 env-var로 간주하고 스트리핑을 예외 처리하는 것은 재앙적인 설계 결정이다. 
- **공격 표면 확장:** 공격자(또는 오염된 Institutional Memory)가 의도적으로 `KEEPER_SECRET_TOOL`과 같은 대문자 토큰을 주입하면, 이 로직은 이를 '환경 변수'로 위장시켜 무조건 프롬프트에 유지시킨다. 기존의 WARN 라인조차 무시되므로 탐지조차 불가능해진다.
- **정규식/문자열 검사 로직의 결함:** OCaml의 `Str` 모듈이나 기본 문자열 함수를 사용해 `^[A-Z0-9_]+$` 형태를 검사할 경우, 프롬프트 내에 포함된 JSON 스키마나 YAML 블록 내부의 대문자 문자열(ex: `{"STATUS": "OK"}`)이 토큰 파서에 의해 잘못 추출되어 env-var로 오인될 가능성이 존재한다. 토큰 파싱의 문맥(Context-free) 특성과 대문자 필터링의 결합은 예측 불가능한 부작용을 낳는다.
- 기존 테스트(`test_unknown_capitalized_token_reported`)의 '전제'를 테스트 코드 수정으로 강제 갱신한 것은, 취약점을 테스트에서 숨긴 것에 불과하다.

## 3. 에러 전파 차단(Error Propagation Gaps) 및 텔레메트리 파편화로 인한 조용한 프롬프트 손상

이 PR의 가장 큰 위험은 **조용한 실패(Silent Failure)**를 정책으로 채택했다는 점이다.
- 기존에는 `keeper_prompt_token_integrity`가 최소한 WARN 텔레메트리를 발생시켜 모니터링 대시보드에 잔존 문제를 알렸다. 그러나 `strip_unresolved_tool_tokens`가 토큰을 제거해버리면, **스캐너가 이를 "unknown"으로 감지할 기회조차 사라진다.**
- 프롬프트에서 중요한 도구 호출 토큰이 레지스트리 일시적 장애(네트워크 플릭커링, DB 커넥션 타임아웃 등)로 인해 잠시 resolve되지 않았을 때, 기존 시스템은 WARN을 띄워 human-in-the-loop가 개입할 여지를 주었으나, 개정된 시스템은 **조용히 토큰을 잘라내어 키퍼의 능력을 마비시킨다.**
- `keeper_unified_prompt.ml`에서 strip 로직이 예외를 삼키고(Swallow) 빈 문자열이나 잘려나간 프롬프트를 하위 단계로 전달할 경우, Albini 모델은 왜特定 도구를 사용하지 못하는지 알 수 없다.
- 테스트 파일(`test_keeper_prompt_token_integrity.ml`)을 확인해보면, 단순한 문자열 입력/출력 비교(Unit test)만 존재할 것이다. Eio 스위치(Switch) 내부에서 발생하는 비동기 IO 타임아웃 시 레지스트리가 빈 맵을 반환하는 상황, 혹은 `strip_unresolved_tool_tokens` 내부에서 발생하는 예외가 `keeper_unified_prompt`의 Eio 파이프라인을 어떻게 종료시키는지에 대한 **결함 주입(Fault Injection) 테스트가 전무**하다. 이는 프로덕션에서 프롬프트 파이프라인이 파편화되는 치명한 원인이 된다.
