### PR TITLE
feat(dashboard): apply keeper-v2 update batch 5 — state surfaces + keeper config + log filter

### DIFF
--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -6,8 +6,7 @@ import { SectionCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
 import { showToast } from '../common/toast'
 import { requestConfirm } from '../common/confirm-dialog'
-import { EmptyState } from '../common/feedback-state'
-import { LoadingState } from '../common/feedback-state'
+import { EmptyState, LoadingState } from '../state-surfaces'
 import { TextInput } from '../common/input'
 import { Select } from '../common/select'
 import { Checkbox } from '../common/checkbox'
@@ -587,7 +586,7 @@ function BdThreadDetail({ post, onClose }: { post: BoardPost; onClose: () => voi
           </div>
         </div>
         ${detailLoading.value
-          ? html`<${LoadingState}>댓글 불러오는 중...<//>`
+          ? html`<${LoadingState} title="댓글 불러오는 중…" />`
           : html`<${CommentThread} comments=${detailComments.value} postId=${post.id} />`}
         <${CommentForm} postId=${post.id} />
       </div>
@@ -768,9 +767,9 @@ function BdFeed({ posts }: { posts: BoardPost[] }) {
         ${isFiltering && filteredByMode.length === 0 && posts.length > 0
           ? html`<div class="bd-empty">필터 결과 없음 (${posts.length} items)</div>`
           : filteredByMode.length === 0 && boardLoading.value
-            ? html`<${LoadingState}>게시판 불러오는 중...<//>`
+            ? html`<${LoadingState} title="게시판 불러오는 중…" />`
             : filteredByMode.length === 0
-              ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
+              ? html`<${EmptyState} title="아직 게시글이 없습니다" hint="에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
               : modeFilteredGroups.map(g =>
                   g.posts.length > 0
                     ? html`<${CategorySection} key=${g.category} group=${{ category: g.category, posts: g.posts, total: g.total, hidden: g.hidden }} />`
@@ -822,8 +821,8 @@ export function BoardSurface() {
               onClick=${() => navigate('workspace', { section: 'board' })}
             >← 게시판으로 돌아가기</button>
             ${detailLoading.value
-              ? html`<${LoadingState}>글 불러오는 중...<//>`
-              : html`<${EmptyState} message="글을 찾지 못했습니다" compact />`}
+              ? html`<${LoadingState} title="글 불러오는 중…" />`
+              : html`<${EmptyState} title="글을 찾지 못했습니다" compact />`}
           </div>
         `
   }

--- a/dashboard/src/components/keeper-config-panel-v2.test.ts
+++ b/dashboard/src/components/keeper-config-panel-v2.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
+import { html } from 'htm/preact'
+import { KeeperConfigPanel } from './keeper-config-panel-v2'
+
+describe('KeeperConfigPanel v2', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders the drawer with keeper identity', () => {
+    render(
+      html`<${KeeperConfigPanel} keeper=${{ id: 'sangsu', ns: 'masc-mcp' }} />`,
+      container,
+    )
+
+    expect(container.querySelector('[data-testid="keeper-config-panel"]')).not.toBeNull()
+    expect(container.textContent).toContain('keeper 설정')
+    expect(container.textContent).toContain('sangsu')
+    expect(container.textContent).toContain('masc-mcp')
+  })
+
+  it('calls onClose when the close button is clicked', async () => {
+    const onClose = vi.fn()
+    render(
+      html`<${KeeperConfigPanel} keeper=${{ id: 'sangsu' }} asOverlay onClose=${onClose} />`,
+      container,
+    )
+
+    const closeButton = container.querySelector('[data-testid="kcp-close"]') as HTMLButtonElement | null
+    expect(closeButton).not.toBeNull()
+    await fireEvent.click(closeButton!)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates persona textarea', () => {
+    render(
+      html`<${KeeperConfigPanel} keeper=${{ id: 'sangsu' }} base=${{ persona: 'helpful' }} />`,
+      container,
+    )
+
+    const textarea = container.querySelector('[data-testid="kcp-persona"]') as HTMLTextAreaElement | null
+    expect(textarea).not.toBeNull()
+    expect(textarea!.value).toBe('helpful')
+
+    textarea!.value = 'diligent'
+    textarea!.dispatchEvent(new Event('input', { bubbles: true }))
+
+    expect(textarea!.value).toBe('diligent')
+  })
+
+  it('updates instructions textarea', () => {
+    render(
+      html`<${KeeperConfigPanel} keeper=${{ id: 'sangsu' }} base=${{ instructions: 'do x' }} />`,
+      container,
+    )
+
+    const textarea = container.querySelector('[data-testid="kcp-instructions"]') as HTMLTextAreaElement | null
+    expect(textarea).not.toBeNull()
+    expect(textarea!.value).toBe('do x')
+  })
+
+  it('renders traits as pills', () => {
+    render(
+      html`<${KeeperConfigPanel}
+        keeper=${{ id: 'sangsu' }}
+        base=${{ traits: ['calm', 'precise'] }}
+      />`,
+      container,
+    )
+
+    expect(container.textContent).toContain('calm')
+    expect(container.textContent).toContain('precise')
+  })
+
+  it('switches the selected model', async () => {
+    render(html`<${KeeperConfigPanel} keeper=${{ id: 'sangsu' }} />`, container)
+
+    const seg = container.querySelector('[data-testid="kcp-seg"]') as HTMLElement | null
+    expect(seg).not.toBeNull()
+    const buttons = Array.from(seg!.querySelectorAll('button')) as HTMLButtonElement[]
+    expect(buttons.length).toBe(3)
+
+    expect(buttons[1]!.getAttribute('data-active')).toBe('true')
+    await fireEvent.click(buttons[2]!)
+    expect(buttons[1]!.getAttribute('data-active')).toBe('false')
+    expect(buttons[2]!.getAttribute('data-active')).toBe('true')
+  })
+
+  it('toggles a permission', async () => {
+    render(
+      html`<${KeeperConfigPanel}
+        keeper=${{ id: 'sangsu' }}
+        permissions=${{ '읽기': true, '쓰기': false }}
+      />`,
+      container,
+    )
+
+    const toggles = Array.from(container.querySelectorAll('[data-testid="kcp-toggle"]')) as HTMLButtonElement[]
+    expect(toggles.length).toBe(2)
+    expect(toggles[0]!.getAttribute('aria-checked')).toBe('true')
+    expect(toggles[1]!.getAttribute('aria-checked')).toBe('false')
+
+    await fireEvent.click(toggles[1]!)
+    expect(toggles[1]!.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('renders the save button', () => {
+    render(html`<${KeeperConfigPanel} keeper=${{ id: 'sangsu' }} />`, container)
+    const saveButton = container.querySelector('[data-testid="kcp-save"]') as HTMLButtonElement | null
+    expect(saveButton).not.toBeNull()
+    expect(saveButton!.textContent).toContain('저장 · 재시작 없이 적용')
+  })
+
+  it('renders overlay wrapper when asOverlay is true', () => {
+    render(html`<${KeeperConfigPanel} keeper=${{ id: 'sangsu' }} asOverlay />`, container)
+    expect(container.querySelector('[data-testid="kcp-overlay"]')).not.toBeNull()
+  })
+})

--- a/dashboard/src/components/keeper-config-panel-v2.ts
+++ b/dashboard/src/components/keeper-config-panel-v2.ts
@@ -1,0 +1,257 @@
+// MASC Dashboard — Keeper config panel v2 (organisms-5 port)
+// Local-state-only config drawer. No backend wiring.
+
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+import type { ComponentChildren, JSX } from 'preact'
+import { ActionButton } from './common/button'
+
+type CSSProperties = JSX.CSSProperties
+
+interface KeeperIdentity {
+  id?: string
+  ns?: string
+  model?: string
+  runtime?: string
+}
+
+interface KeeperBase {
+  persona?: string
+  instructions?: string
+  traits?: string[]
+}
+
+interface InheritRow {
+  tag: string
+  txt: string
+}
+
+interface KeeperConfigPanelProps {
+  keeper?: KeeperIdentity
+  base?: KeeperBase
+  inherit?: InheritRow[]
+  models?: string[]
+  runtimes?: string[]
+  permissions?: Record<string, boolean>
+  asOverlay?: boolean
+  onClose?: () => void
+  onPromptsLink?: () => void
+  style?: CSSProperties
+}
+
+function Section({ title, children }: { title: string; children: ComponentChildren }) {
+  return html`
+    <div class="kcp-section">
+      <h4 class="kcp-section-title">${title}</h4>
+      ${children}
+    </div>
+  `
+}
+
+function KvRows({ rows = [] }: { rows?: { k: string; v?: string }[] }) {
+  return html`
+    <div class="kcp-codectx">
+      ${rows.map((r, i) => html`
+        <div key=${i} class="kcp-cc-row">
+          <span class="kcp-cc-k">${r.k}</span>
+          <span class="kcp-cc-v mono">${r.v ?? ''}</span>
+        </div>
+      `)}
+    </div>
+  `
+}
+
+function InheritRows({ rows = [], note }: { rows?: InheritRow[]; note?: ComponentChildren }) {
+  return html`
+    <div class="kcp-inherit">
+      ${rows.map((r, i) => html`
+        <div key=${i} class="kcp-inh-row">
+          <span class="kcp-inh-tag">${r.tag}</span>
+          <span class="kcp-inh-txt mono">${r.txt}</span>
+        </div>
+      `)}
+      ${note ? html`<div class="kcp-inh-note">${note}</div>` : null}
+    </div>
+  `
+}
+
+function TraitPill({ children }: { children: ComponentChildren }) {
+  return html`<span class="kcp-trait">${children}</span>`
+}
+
+function Toggle({ on, onChange }: { on: boolean; onChange: (v: boolean) => void }) {
+  return html`
+    <button
+      type="button"
+      class=${`kcp-toggle ${on ? 'on' : ''}`}
+      role="switch"
+      aria-checked=${on}
+      data-testid="kcp-toggle"
+      onClick=${() => onChange(!on)}
+    >
+      <span class="kcp-toggle-knob"></span>
+    </button>
+  `
+}
+
+function Segmented({
+  options,
+  value,
+  onChange,
+}: {
+  options: string[]
+  value: string
+  onChange: (v: string) => void
+}) {
+  return html`
+    <div class="kcp-seg" data-testid="kcp-seg">
+      ${options.map(o => html`
+        <button
+          type="button"
+          key=${o}
+          class=${`kcp-seg-b ${value === o ? 'on' : ''}`}
+          data-active=${value === o ? 'true' : 'false'}
+          onClick=${() => onChange(o)}
+        >
+          ${o}
+        </button>
+      `)}
+    </div>
+  `
+}
+
+const DEFAULT_MODELS = ['claude-haiku-4', 'claude-sonnet-4', 'claude-opus-4']
+const DEFAULT_RUNTIMES = ['oas·seoul-1', 'oas·tokyo-2', 'local·docker']
+const DEFAULT_PERMISSIONS = {
+  '읽기': true,
+  '쓰기': true,
+  'git': false,
+  '외부 호출': false,
+}
+
+export function KeeperConfigPanel({
+  keeper = {},
+  base = {},
+  inherit = [],
+  models = DEFAULT_MODELS,
+  runtimes = DEFAULT_RUNTIMES,
+  permissions = DEFAULT_PERMISSIONS,
+  asOverlay = false,
+  onClose,
+  onPromptsLink,
+  style,
+}: KeeperConfigPanelProps) {
+  const [persona, setPersona] = useState(base.persona ?? '')
+  const [instr, setInstr] = useState(base.instructions ?? '')
+  const [model, setModel] = useState(keeper.model ?? models[1] ?? '')
+  const [rt, setRt] = useState(keeper.runtime ?? runtimes[0] ?? '')
+  const [perm, setPerm] = useState(permissions)
+
+  const drawer = html`
+    <div
+      class="kcp-drawer"
+      onClick=${(e: Event) => e.stopPropagation()}
+      style=${asOverlay ? style : { position: 'static', width: '100%', height: '100%', boxShadow: 'none', borderRadius: 0, ...style }}
+      data-testid="keeper-config-panel"
+    >
+      <div class="kcp-hd">
+        <h3 class="kcp-hd-title">keeper 설정</h3>
+        <span class="kcp-hd-id mono">${keeper.id}</span>
+        ${onClose
+          ? html`
+            <button
+              type="button"
+              class="kcp-close"
+              data-testid="kcp-close"
+              onClick=${onClose}
+              title="닫기 (Esc)"
+            >
+              ✕
+            </button>
+          `
+          : null}
+      </div>
+
+      <div class="kcp-body">
+        <${Section} title="정체성 · 배정">
+          <div class="kcp-note">
+            아래는 배정·파생된 사실 — 여기서 바꾸지 않습니다. worktree는 keeper가 basepath 아래에 자동 생성·관리합니다.
+          </div>
+          <${KvRows} rows=${[
+            { k: 'namespace', v: keeper.ns },
+            { k: 'repo · branch', v: `masc-mcp · keeper/${keeper.id}` },
+          ]} />
+        <//>
+
+        <${Section} title="상속 — 공유 베이스 (read-only)">
+          <${InheritRows}
+            rows=${inherit}
+            note=${html`
+              <span>전 keeper 공유 · </span>
+              <button type="button" class="kcp-link" onClick=${onPromptsLink}>
+                operator 설정 · Keeper 기본 · 프롬프트 →
+              </button>
+            `}
+          />
+        <//>
+
+        <${Section} title="③ 성격 (persona) — 이 keeper">
+          <textarea
+            class="kcp-textarea"
+            rows=${2}
+            value=${persona}
+            data-testid="kcp-persona"
+            onInput=${(e: Event) => setPersona((e.target as HTMLTextAreaElement).value)}
+          />
+          <div class="kcp-traits">
+            ${(base.traits ?? []).map((t, i) => html`<${TraitPill} key=${i}>${t}<//>`)}
+          </div>
+        <//>
+
+        <${Section} title="④ 지침 (instructions) — 이 keeper">
+          <textarea
+            class="kcp-textarea"
+            rows=${5}
+            value=${instr}
+            data-testid="kcp-instructions"
+            onInput=${(e: Event) => setInstr((e.target as HTMLTextAreaElement).value)}
+          />
+        <//>
+
+        <${Section} title="모델">
+          <${Segmented} options=${models} value=${model} onChange=${setModel} />
+        <//>
+
+        <${Section} title="기본 런타임">
+          <${Segmented} options=${runtimes} value=${rt} onChange=${setRt} />
+        <//>
+
+        <${Section} title="도구 권한">
+          ${Object.keys(perm).map(k => html`
+            <div key=${k} class="kcp-perm-row">
+              <span class="kcp-perm-label">${k}</span>
+              <${Toggle}
+                on=${perm[k] ?? false}
+                onChange=${(v: boolean) => setPerm(p => ({ ...p, [k]: v }))}
+              />
+            </div>
+          `)}
+        <//>
+
+        <${ActionButton} variant="primary" block testId="kcp-save">
+          저장 · 재시작 없이 적용
+        <//>
+      </div>
+    </div>
+  `
+
+  if (asOverlay) {
+    return html`
+      <div class="kcp-overlay" onClick=${onClose} data-testid="kcp-overlay">
+        ${drawer}
+      </div>
+    `
+  }
+
+  return drawer
+}

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -215,6 +215,34 @@ function RolePill({ children }: { children: ComponentChildren }) {
   return html`<span class="set-rolepill">${children}</span>`
 }
 
+function LogFilter({
+  filter,
+  active,
+  onClick,
+}: {
+  filter: LogFilter
+  active: boolean
+  onClick: () => void
+}) {
+  const label =
+    filter === 'all' ? 'All'
+    : filter === 'tool' ? 'Tool'
+    : filter === 'success' ? 'Success'
+    : 'Failure'
+
+  return html`
+    <button
+      type="button"
+      class=${`log-f ${active ? 'on' : ''}`}
+      data-filter=${filter}
+      data-active=${active ? 'true' : 'false'}
+      onClick=${onClick}
+    >
+      ${label}
+    </button>
+  `
+}
+
 function LogViewer() {
   const [filter, setFilter] = useState<LogFilter>('all')
   const rows = SYS_LOG.filter(r => {
@@ -231,16 +259,12 @@ function LogViewer() {
     <div class="log-view" data-testid="log-viewer">
       <div class="log-filters">
         ${filters.map(f => html`
-          <button
-            type="button"
+          <${LogFilter}
             key=${f}
-            class=${`log-f ${filter === f ? 'on' : ''}`}
-            data-filter=${f}
-            data-active=${filter === f ? 'true' : 'false'}
+            filter=${f}
+            active=${filter === f}
             onClick=${() => setFilter(f)}
-          >
-            ${f === 'all' ? 'All' : f === 'tool' ? 'Tool' : f === 'success' ? 'Success' : 'Failure'}
-          </button>
+          />
         `)}
         <span class="log-live"><span class="tps-dot"></span>tail -f</span>
       </div>

--- a/dashboard/src/components/state-surfaces.test.ts
+++ b/dashboard/src/components/state-surfaces.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { EmptyState, ErrorState, LoadingState } from './state-surfaces'
+
+describe('EmptyState', () => {
+  it('renders glyph, title and hint', () => {
+    const container = document.createElement('div')
+    render(
+      html`<${EmptyState} glyph="◌" title="Nothing here" hint="Add an item to get started" />`,
+      container,
+    )
+
+    const root = container.querySelector('[data-testid="empty-state"]')
+    expect(root).not.toBeNull()
+    expect(container.textContent).toContain('Nothing here')
+    expect(container.textContent).toContain('Add an item to get started')
+    expect(container.querySelector('.kv-state-g')?.textContent).toBe('◌')
+  })
+
+  it('renders an action button that calls onAction', () => {
+    const onAction = vi.fn()
+    const container = document.createElement('div')
+    render(
+      html`<${EmptyState} title="Empty" action="Create" onAction=${onAction} />`,
+      container,
+    )
+
+    const button = container.querySelector('button')
+    expect(button).not.toBeNull()
+    button!.click()
+    expect(onAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits action when onAction is missing', () => {
+    const container = document.createElement('div')
+    render(html`<${EmptyState} title="Empty" action="Create" />`, container)
+    expect(container.querySelector('button')).toBeNull()
+  })
+})
+
+describe('ErrorState', () => {
+  it('renders glyph, title and detail', () => {
+    const container = document.createElement('div')
+    render(
+      html`<${ErrorState} title="Failed" detail="connection refused" />`,
+      container,
+    )
+
+    const root = container.querySelector('[data-testid="error-state"]')
+    expect(root).not.toBeNull()
+    expect(container.textContent).toContain('Failed')
+    expect(container.textContent).toContain('connection refused')
+    expect(container.querySelector('.kv-state-g')?.textContent).toBe('⚠')
+  })
+
+  it('renders a retry button that calls onAction', () => {
+    const onAction = vi.fn()
+    const container = document.createElement('div')
+    render(html`<${ErrorState} title="Failed" onAction=${onAction} />`, container)
+
+    const button = container.querySelector('button')
+    expect(button).not.toBeNull()
+    expect(button!.textContent).toContain('다시 시도')
+    button!.click()
+    expect(onAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses custom action label', () => {
+    const container = document.createElement('div')
+    render(html`<${ErrorState} title="Failed" action="Reload" onAction=${() => {}} />`, container)
+    expect(container.querySelector('button')?.textContent).toContain('Reload')
+  })
+})
+
+describe('LoadingState', () => {
+  it('renders the default title and skeleton rows', () => {
+    const container = document.createElement('div')
+    render(html`<${LoadingState} />`, container)
+
+    expect(container.querySelector('[data-testid="loading-state"]')).not.toBeNull()
+    expect(container.textContent).toContain('불러오는 중…')
+    expect(container.querySelectorAll('.kv-skel-row').length).toBe(3)
+  })
+
+  it('renders a custom title and row count', () => {
+    const container = document.createElement('div')
+    render(html`<${LoadingState} title="Loading posts…" rows=${5} />`, container)
+
+    expect(container.textContent).toContain('Loading posts…')
+    expect(container.querySelectorAll('.kv-skel-row').length).toBe(5)
+  })
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})

--- a/dashboard/src/components/state-surfaces.ts
+++ b/dashboard/src/components/state-surfaces.ts
@@ -1,0 +1,140 @@
+// MASC Dashboard v2 — empty / error / loading state surfaces
+// Ported from keeper-v2 organisms-5 (organisms-5.jsx). Local-only, no backend.
+
+import { html } from 'htm/preact'
+import type { JSX } from 'preact'
+import { ActionButton } from './common/button'
+
+type CSSProperties = JSX.CSSProperties
+
+interface StateSurfaceBaseProps {
+  compact?: boolean
+  class?: string
+  style?: CSSProperties
+}
+
+interface EmptyStateProps extends StateSurfaceBaseProps {
+  glyph?: string
+  title?: string
+  hint?: string
+  action?: string
+  onAction?: () => void
+}
+
+interface ErrorStateProps extends StateSurfaceBaseProps {
+  glyph?: string
+  title?: string
+  detail?: string
+  action?: string
+  onAction?: () => void
+}
+
+interface LoadingStateProps extends StateSurfaceBaseProps {
+  title?: string
+  rows?: number
+}
+
+function stateClasses(kind: 'empty' | 'error' | 'loading', compact: boolean, cx?: string): string {
+  const base = `kv-state ${kind}`
+  const mods = [compact ? 'compact' : '', cx ?? ''].filter(Boolean).join(' ')
+  return mods ? `${base} ${mods}` : base
+}
+
+/** Empty state surface — glyph, title, optional hint and primary action. */
+export function EmptyState({
+  glyph = '◌',
+  title,
+  hint,
+  action,
+  onAction,
+  compact,
+  class: cx,
+  style,
+}: EmptyStateProps) {
+  return html`
+    <div
+      class=${stateClasses('empty', compact ?? false, cx)}
+      data-testid="empty-state"
+      role="status"
+      style=${style}
+    >
+      <div class="kv-state-g" aria-hidden="true">${glyph}</div>
+      ${title ? html`<div class="kv-state-t">${title}</div>` : null}
+      ${hint ? html`<div class="kv-state-h">${hint}</div>` : null}
+      ${action && onAction
+        ? html`
+          <div class="kv-state-a">
+            <${ActionButton} variant="primary" size="sm" onClick=${onAction}>${action}<//>
+          </div>
+        `
+        : null}
+    </div>
+  `
+}
+
+/** Error state surface — glyph, title, optional detail and retry action. */
+export function ErrorState({
+  glyph = '⚠',
+  title,
+  detail,
+  action = '다시 시도',
+  onAction,
+  compact,
+  class: cx,
+  style,
+}: ErrorStateProps) {
+  return html`
+    <div
+      class=${stateClasses('error', compact ?? false, cx)}
+      data-testid="error-state"
+      role="alert"
+      style=${style}
+    >
+      <div class="kv-state-g" aria-hidden="true">${glyph}</div>
+      ${title ? html`<div class="kv-state-t">${title}</div>` : null}
+      ${detail ? html`<div class="kv-state-h mono">${detail}</div>` : null}
+      ${onAction
+        ? html`
+          <div class="kv-state-a">
+            <${ActionButton} variant="ghost" size="sm" onClick=${onAction}>${action}<//>
+          </div>
+        `
+        : null}
+    </div>
+  `
+}
+
+/** Loading state surface — animated bar plus skeleton rows. */
+export function LoadingState({
+  title = '불러오는 중…',
+  rows = 3,
+  compact,
+  class: cx,
+  style,
+}: LoadingStateProps) {
+  return html`
+    <div
+      class=${stateClasses('loading', compact ?? false, cx)}
+      data-testid="loading-state"
+      role="status"
+      aria-live="polite"
+      style=${style}
+    >
+      <div class="kv-state-g" aria-hidden="true">⟳</div>
+      <div class="kv-skel-list">
+        ${Array.from({ length: rows }).map(
+          (_, i) => html`
+            <div key=${i} class="kv-skel-row">
+              <span class="kv-skel-av" />
+              <span class="kv-skel-lines">
+                <span class="kv-skel-line" />
+                <span class="kv-skel-line short" />
+              </span>
+            </div>
+          `,
+        )}
+      </div>
+      <div class="kv-state-h">${title}</div>
+    </div>
+  `
+}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -50,6 +50,7 @@ import './styles/design-canvas.css'
 import './styles/connectors-v2.css'
 import './styles/telemetry-v2.css'
 import './styles/craft-v2.css'
+import './styles/states.css'
 
 import { render } from 'preact'
 import { html } from 'htm/preact'

--- a/dashboard/src/styles/states.css
+++ b/dashboard/src/styles/states.css
@@ -1,0 +1,389 @@
+/* MASC Dashboard v2 — empty / error / loading state surfaces
+   Ported from keeper-v2 styles/states.css. Maps the v2 token ladder to
+   existing dashboard semantic tokens via the keeper-v2 bridge. */
+
+.kv-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  padding: var(--space-6) var(--space-5);
+  text-align: center;
+  min-height: 200px;
+}
+
+.kv-state.compact {
+  padding: var(--space-4) var(--space-4);
+  min-height: 120px;
+}
+
+.kv-state-g {
+  width: 52px;
+  height: 52px;
+  display: grid;
+  place-items: center;
+  font-size: 24px;
+  border-radius: 50%;
+  color: var(--text-dim);
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+}
+
+.kv-state.error .kv-state-g {
+  color: var(--status-bad);
+  border-color: color-mix(in oklab, var(--status-bad) 45%, var(--border-main));
+  background: color-mix(in oklab, var(--status-bad) 9%, var(--bg-card));
+}
+
+.kv-state-t {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--text-bright);
+  letter-spacing: -0.01em;
+}
+
+.kv-state-h {
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text-mid);
+  max-width: 320px;
+}
+
+.kv-state.error .kv-state-h {
+  color: var(--status-bad);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  padding: 7px 11px;
+}
+
+.kv-state-a {
+  margin-top: 4px;
+}
+
+/* Loading skeleton */
+.kv-state.loading {
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: var(--space-3);
+  min-height: 0;
+}
+
+.kv-skel-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  width: 100%;
+}
+
+.kv-skel-row {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.kv-skel-av {
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  flex: none;
+}
+
+.kv-skel-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.kv-skel-line {
+  height: 10px;
+  border-radius: 4px;
+  width: 70%;
+}
+
+.kv-skel-line.short {
+  width: 40%;
+}
+
+.kv-skel-av,
+.kv-skel-line {
+  background: linear-gradient(
+    100deg,
+    var(--bg-card) 30%,
+    color-mix(in oklab, var(--text-dim) 18%, var(--bg-card)) 50%,
+    var(--bg-card) 70%
+  );
+  background-size: 220% 100%;
+  animation: kv-skel-sweep 1.3s ease-in-out infinite;
+}
+
+@keyframes kv-skel-sweep {
+  from {
+    background-position: 180% 0;
+  }
+  to {
+    background-position: -40% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kv-skel-av,
+  .kv-skel-line {
+    animation: none;
+  }
+}
+
+/* ── Keeper config panel v2 (organisms-5 port) ─────────────────────── */
+
+.kcp-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal);
+  display: flex;
+  justify-content: flex-end;
+  background: var(--backdrop-modal);
+}
+
+.kcp-drawer {
+  width: 420px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel);
+  border-left: 1px solid var(--border-base);
+  box-shadow: var(--shadow-3);
+  overflow: hidden;
+}
+
+.kcp-hd {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-bottom: 1px solid var(--border-base);
+}
+
+.kcp-hd-title {
+  margin: 0;
+  font-size: var(--fs-md);
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.kcp-hd-id {
+  margin-left: auto;
+  font-size: var(--fs-xs);
+  color: var(--text-mid);
+}
+
+.kcp-close {
+  padding: 4px 8px;
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-mid);
+  cursor: pointer;
+}
+
+.kcp-close:hover {
+  background: var(--bg-card);
+  color: var(--text-bright);
+}
+
+.kcp-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.kcp-section-title {
+  margin: 0 0 var(--space-2);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.kcp-note {
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-mid);
+  margin-bottom: var(--space-3);
+}
+
+.kcp-codectx {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-soft);
+}
+
+.kcp-cc-row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+  font-size: 12px;
+}
+
+.kcp-cc-k {
+  color: var(--text-mid);
+}
+
+.kcp-cc-v {
+  color: var(--text-bright);
+}
+
+.kcp-inherit {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-soft);
+}
+
+.kcp-inh-row {
+  display: flex;
+  gap: var(--space-2);
+  font-size: 12px;
+}
+
+.kcp-inh-tag {
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--accent-10);
+  color: var(--volt);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.kcp-inh-txt {
+  color: var(--text-bright);
+}
+
+.kcp-inh-note {
+  margin-top: var(--space-2);
+  font-size: 11px;
+  color: var(--text-mid);
+}
+
+.kcp-link {
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--volt);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.kcp-textarea {
+  width: 100%;
+  padding: var(--space-3);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  background: var(--bg-sunken);
+  color: var(--text-bright);
+  font: inherit;
+  resize: vertical;
+}
+
+.kcp-textarea:focus {
+  outline: none;
+  border-color: var(--volt);
+}
+
+.kcp-traits {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.kcp-trait {
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-10);
+  color: var(--volt);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.kcp-seg {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  background: var(--bg-sunken);
+}
+
+.kcp-seg-b {
+  padding: 4px 10px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-mid);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.kcp-seg-b.on {
+  background: var(--accent-10);
+  color: var(--volt);
+  font-weight: 600;
+}
+
+.kcp-perm-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.kcp-perm-label {
+  font-size: 13px;
+  color: var(--text-bright);
+}
+
+.kcp-toggle {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-pill);
+  background: var(--bg-sunken);
+  cursor: pointer;
+  transition: background var(--t-fast) var(--ease);
+}
+
+.kcp-toggle.on {
+  background: var(--ok);
+  border-color: var(--ok);
+}
+
+.kcp-toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text-bright);
+  transition: transform var(--t-fast) var(--ease);
+}
+
+.kcp-toggle.on .kcp-toggle-knob {
+  transform: translateX(18px);
+}


### PR DESCRIPTION
## Summary
Ports the keeper-v2 v8 update batch 5 into the MASC dashboard.

## What changed
- **New component** `dashboard/src/components/state-surfaces.ts`:
  - `EmptyState`, `ErrorState`, `LoadingState` (with skeleton animation)
- **New styles** `dashboard/src/styles/states.css` using dashboard tokens.
- **New component** `dashboard/src/components/keeper-config-panel-v2.ts`:
  - Per-keeper config drawer from `organisms-5.jsx`
  - Identity facts, inherited base prompts, persona/instructions editors
  - Model/runtime segmented controls and tool-permission toggles
  - Local-state only; no backend calls
- **Settings surface** `settings-surface.ts`: extracted `LogFilter` component per v8 change.
- **Board surface** `board-surface.ts`: uses new `LoadingState`/`EmptyState` for loading/empty paths.
- **Tests** for state surfaces, keeper-config-panel-v2, and settings log filter.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- State surfaces ✅ 8/8
- Keeper config panel v2 ✅ 9/9
- Settings surface ✅ 6/6
- Board surface ✅ 37/37

## Notes
- Existing `keeper-config-panel.ts` was left untouched because it has backend-wired consumers. The v2 panel is additive.
