### PR TITLE
feat(dashboard): keeper-v2 Phase A/B/C — nav wiring, mobile shell, new surfaces

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -1,23 +1,31 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h, render } from 'preact'
+import { waitFor } from '@testing-library/preact'
 import { App, shouldUseCompactDashboardChrome } from './app'
 
 describe('App v2 header chrome', () => {
   let container: HTMLDivElement
+  const originalHash = window.location.hash
 
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
-    render(h(App, {}), container)
+    window.location.hash = originalHash
   })
 
   afterEach(() => {
     render(null, container)
     container.remove()
+    window.location.hash = originalHash
   })
 
+  function renderApp() {
+    render(h(App, {}), container)
+  }
+
   it('renders v2 app shell wrapper with density/motion/bubble/surface attributes', () => {
+    renderApp()
     const app = container.querySelector('.v2-app')
     expect(app).not.toBeNull()
     expect(app?.getAttribute('data-density')).toBe('regular')
@@ -27,11 +35,13 @@ describe('App v2 header chrome', () => {
   })
 
   it('renders v2 shell header and health strip scopes', () => {
+    renderApp()
     expect(container.querySelector('header.v2-shell-header')).not.toBeNull()
     expect(container.querySelector('[data-testid="dashboard-health-strip"].v2-health-strip')).not.toBeNull()
   })
 
   it('renders v2 header structural classes', () => {
+    renderApp()
     expect(container.querySelector('.v2-header-brand')).not.toBeNull()
     expect(container.querySelector('.v2-header-mark')).not.toBeNull()
     expect(container.querySelector('.v2-header-crumb')).not.toBeNull()
@@ -43,8 +53,38 @@ describe('App v2 header chrome', () => {
   })
 
   it('renders health chips with the shared chip class', () => {
+    renderApp()
     const chip = container.querySelector('.dashboard-health-chip')
     expect(chip).not.toBeNull()
+  })
+
+  it('sets data-mobile based on the viewport width', () => {
+    window.innerWidth = 760
+    renderApp()
+    const app = container.querySelector('.v2-app')
+    expect(app?.getAttribute('data-mobile')).toBe('true')
+  })
+
+  it('hides MobileBottomBar when the mobile side-rail drawer is open', async () => {
+    window.innerWidth = 760
+    renderApp()
+
+    const menuButton = container.querySelector('button[aria-controls="dashboard-side-rail"]') as HTMLElement | null
+    expect(menuButton).not.toBeNull()
+    menuButton!.click()
+
+    await waitFor(() => {
+      expect(container.querySelector('nav[aria-label="Primary mobile navigation"]')).toBeNull()
+    })
+  })
+
+  it('hides MobileBottomBar on keeper detail routes', () => {
+    window.location.hash = '#monitoring/agents?keeper=sangsu'
+    window.innerWidth = 760
+    renderApp()
+
+    const bottomNav = container.querySelector('nav[aria-label="Primary mobile navigation"]')
+    expect(bottomNav).toBeNull()
   })
 })
 

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -52,6 +52,7 @@ import { Menu, X } from 'lucide-preact'
 import { useKeyboardShortcutHost } from '../design-system/headless-preact/use-keyboard-shortcut'
 import { globalShortcutManager } from './lib/global-shortcut-manager'
 import { useKeeperPinShortcuts } from './components/ide/use-keeper-pin-shortcuts'
+import { useIsMobile } from './hooks/use-is-mobile'
 import { isWidgetSoloRoute } from './components/widget-solo'
 import {
   CopilotDock,
@@ -251,6 +252,8 @@ export function App() {
   const dock = useCopilotDock()
   useCopilotDockShortcuts(dock)
 
+  const isMobile = useIsMobile()
+
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
   const currentSection = currentSectionForRoute(route.value)
@@ -270,6 +273,7 @@ export function App() {
       data-widget-solo=${widgetSoloMode ? 'true' : 'false'}
       data-focus-mode=${focusMode ? 'true' : 'false'}
       data-keeper-detail-mode=${keeperDetailMode ? 'true' : 'false'}
+      data-mobile=${isMobile ? 'true' : 'false'}
       data-density=${tweaksDensity.value}
       data-motion=${tweaksMotion.value}
       data-bubble=${tweaksBubble.value}
@@ -386,7 +390,7 @@ export function App() {
           ${dock.state.value.open ? html`<${CopilotDock} dock=${dock} />` : null}
         </div>
       </div>
-      ${!compactChromeMode ? html`<${MobileBottomBar} currentTab=${currentTab} onMenuToggle=${() => { mobileMenuOpen.value = !mobileMenuOpen.value }} />` : null}
+      ${!compactChromeMode && !mobileMenuOpen.value && !keeperDetailMode ? html`<${MobileBottomBar} currentTab=${currentTab} onMenuToggle=${() => { mobileMenuOpen.value = !mobileMenuOpen.value }} />` : null}
       ${!dock.state.value.open && !compactChromeMode ? html`<${CopilotDockFab} dock=${dock} />` : null}
 
       ${selectedAgentName.value

--- a/dashboard/src/components/design-canvas.test.ts
+++ b/dashboard/src/components/design-canvas.test.ts
@@ -30,6 +30,8 @@ describe('DesignCanvas', () => {
     expect(container.querySelector('[data-testid="design-canvas-tab-organisms"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="design-canvas-tab-surfaces"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="design-canvas-tab-motion"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="design-canvas-tab-craft"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="design-canvas-tab-states"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="design-canvas-tab-fixtures"]')).not.toBeNull()
   })
 
@@ -77,6 +79,38 @@ describe('DesignCanvas', () => {
       toggle.click()
     })
     expect(document.documentElement.dataset.theme).toBeUndefined()
+  })
+
+  it('switches to the craft gallery', async () => {
+    await act(async () => {
+      render(html`<${DesignCanvas} />`, container)
+    })
+
+    const craftTab = container.querySelector('[data-testid="design-canvas-tab-craft"]') as HTMLButtonElement
+    await act(async () => {
+      craftTab.click()
+    })
+
+    expect(craftTab.getAttribute('aria-selected')).toBe('true')
+    const stage = container.querySelector('[data-testid="design-canvas-stage"]')
+    expect(stage!.querySelector('[data-design-canvas-organism="craft-card"]')).not.toBeNull()
+    expect(stage!.querySelector('[data-design-canvas-organism="tool-call-card"]')).not.toBeNull()
+  })
+
+  it('switches to the states gallery', async () => {
+    await act(async () => {
+      render(html`<${DesignCanvas} />`, container)
+    })
+
+    const statesTab = container.querySelector('[data-testid="design-canvas-tab-states"]') as HTMLButtonElement
+    await act(async () => {
+      statesTab.click()
+    })
+
+    expect(statesTab.getAttribute('aria-selected')).toBe('true')
+    const stage = container.querySelector('[data-testid="design-canvas-stage"]')
+    expect(stage!.textContent).toContain('Keeper lifecycle pills')
+    expect(stage!.textContent).toContain('Meter thresholds')
   })
 
   it('switches to the fixtures gallery and renders fixture data', async () => {

--- a/dashboard/src/components/design-canvas.ts
+++ b/dashboard/src/components/design-canvas.ts
@@ -41,6 +41,8 @@ export type DesignCanvasCategory =
   | 'organisms'
   | 'surfaces'
   | 'motion'
+  | 'craft'
+  | 'states'
   | 'fixtures'
 
 const CATEGORIES: { id: DesignCanvasCategory; label: string }[] = [
@@ -49,6 +51,8 @@ const CATEGORIES: { id: DesignCanvasCategory; label: string }[] = [
   { id: 'organisms', label: 'Organisms' },
   { id: 'surfaces', label: 'Surfaces' },
   { id: 'motion', label: 'Motion' },
+  { id: 'craft', label: 'Craft' },
+  { id: 'states', label: 'States' },
   { id: 'fixtures', label: 'Fixtures' },
 ]
 
@@ -355,6 +359,84 @@ function MotionGallery() {
   `
 }
 
+function CraftsGallery() {
+  return html`
+    <${Section} title="Craft">
+      <${Artboard} title="Workbench card">
+        <div data-design-canvas-organism="craft-card">
+          <${PanelCard} title="craft-surface">
+            <div class="dc-stat-row">
+              <${StatCell} label="Drafted" value="12" tone="ok" />
+              <${StatCell} label="Review" value="3" tone="warn" />
+              <${StatCell} label="Blocked" value="1" tone="bad" />
+            </div>
+            <div class="mt-3 flex flex-wrap gap-2">
+              <${StatusChip} tone="info">prompt<//>
+              <${StatusChip} tone="neutral">fixture<//>
+              <${CountBadge} tone="accent">v2<//>
+            </div>
+          <//>
+        </div>
+      <//>
+
+      <${Artboard} title="Tool-call card">
+        <${SurfaceCard} variant="compact" data-design-canvas-organism="tool-call-card">
+          <div class="flex items-center gap-2 mb-2">
+            <span class="size-5 inline-flex items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] text-2xs font-mono font-bold text-[var(--color-fg-secondary)]">T</span>
+            <span class="font-mono text-sm font-semibold text-[var(--color-accent-fg)]">edit_file</span>
+          </div>
+          <div class="text-2xs font-mono text-[var(--color-fg-secondary)] truncate">{"path":"src/components/lab.ts"}</div>
+          <div class="mt-2 flex items-center gap-2">
+            <${StatusChip} tone="ok" uppercase=${false}>success<//>
+            <span class="text-3xs text-[var(--color-fg-disabled)]">240 ms</span>
+          </div>
+        <//>
+      <//>
+
+      <${Artboard} title="Inspector row">
+        <div class="dc-surface-rail">
+          <div class="dc-rail-dot ok"></div>
+          <div class="dc-rail-dot warn"></div>
+          <div class="dc-rail-dot bad"></div>
+          <div class="dc-rail-dot info"></div>
+        </div>
+      <//>
+    <//>
+  `
+}
+
+function StatesGallery() {
+  return html`
+    <${Section} title="States">
+      <${Artboard} title="Keeper lifecycle pills">
+        <div class="dc-row-wrap">
+          <${StatusChip} tone="ok">active<//>
+          <${StatusChip} tone="warn">degraded<//>
+          <${StatusChip} tone="bad">crashed<//>
+          <${StatusChip} tone="info">paused<//>
+          <${StatusChip} tone="neutral">offline<//>
+        </div>
+      <//>
+
+      <${Artboard} title="Delivery badges">
+        <div class="dc-row-wrap">
+          <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-2xs font-semibold uppercase tracking-2 text-[var(--color-fg-secondary)]">delivered</span>
+          <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-2xs font-semibold uppercase tracking-2 text-[var(--color-status-warn)]">sending</span>
+          <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-2xs font-semibold uppercase tracking-2 text-[var(--color-status-err)]">error</span>
+        </div>
+      <//>
+
+      <${Artboard} title="Meter thresholds">
+        <div class="dc-stack-v">
+          <${Meter} pct=${24} />
+          <${Meter} pct=${68} />
+          <${Meter} pct=${94} hot=${true} />
+        </div>
+      <//>
+    <//>
+  `
+}
+
 function SectionStack({ title, children }: { title: string; children: unknown }) {
   return html`
     <div class="dc-section" data-design-canvas-section>
@@ -626,6 +708,8 @@ export function DesignCanvas() {
         ${category === 'organisms' ? html`<${OrganismsGallery} />` : null}
         ${category === 'surfaces' ? html`<${SurfacesGallery} />` : null}
         ${category === 'motion' ? html`<${MotionGallery} />` : null}
+        ${category === 'craft' ? html`<${CraftsGallery} />` : null}
+        ${category === 'states' ? html`<${StatesGallery} />` : null}
         ${category === 'fixtures' ? html`<${FixturesGallery} />` : null}
       </div>
     </div>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { act } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Keeper } from '../../types'
+
+const mockKeeper: Keeper = {
+  name: 'sangsu',
+  koreanName: '상수',
+  status: 'running',
+}
+
+async function loadChat() {
+  vi.resetModules()
+  vi.doMock('./keeper-workspace-shared', () => ({
+    WorkspaceSigil: ({ id }: { id: string }) => html`<span data-testid="kw-sigil">${id}</span>`,
+    StatusDot: ({ tone }: { tone: string }) => html`<span data-testid="kw-status-dot" data-tone=${tone}></span>`,
+    keeperBucket: () => 'running',
+    keeperStatusTone: () => 'ok',
+    keeperPhaseLabel: () => '실행 중',
+    statePillTone: () => 'run',
+  }))
+  vi.doMock('../keeper-detail-lifecycle', () => ({
+    KeeperLifecycleButtons: () => html`<span data-testid="kw-lifecycle-buttons">Lifecycle</span>`,
+  }))
+  vi.doMock('../keeper-shared', () => ({
+    KeeperConversationPanel: () => html`<div data-testid="kw-conversation-panel">Conversation</div>`,
+  }))
+  vi.doMock('../keeper-turn-inspector', () => ({
+    KeeperTurnInspector: ({ keeperName }: { keeperName: string }) =>
+      html`<div data-testid="kw-turn-inspector" data-keeper=${keeperName}>TurnInspector</div>`,
+  }))
+  vi.doMock('../../lib/keeper-runtime-display', () => ({
+    keeperDisplayStatus: () => 'running',
+  }))
+  return import('./keeper-workspace-chat')
+}
+
+describe('KeeperWorkspaceChat', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    vi.resetModules()
+    vi.doUnmock('./keeper-workspace-shared')
+    vi.doUnmock('../keeper-detail-lifecycle')
+    vi.doUnmock('../keeper-shared')
+    vi.doUnmock('../keeper-turn-inspector')
+    vi.doUnmock('../../lib/keeper-runtime-display')
+  })
+
+  it('renders the chat header and conversation panel', async () => {
+    const { KeeperWorkspaceChat } = await loadChat()
+
+    await act(async () => {
+      render(html`
+        <${KeeperWorkspaceChat}
+          keeper=${mockKeeper}
+          detailOpen=${false}
+          onToggleDetail=${vi.fn()}
+          onClear=${vi.fn()}
+        />
+      `, container)
+    })
+
+    expect(container.querySelector('[data-testid="kw-sigil"]')?.textContent).toBe('sangsu')
+    expect(container.querySelector('[data-testid="kw-conversation-panel"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="kw-chat-turn-inspector-btn"]')).not.toBeNull()
+  })
+
+  it('opens the turn inspector drawer when the turn inspector button is clicked', async () => {
+    const { KeeperWorkspaceChat } = await loadChat()
+
+    await act(async () => {
+      render(html`
+        <${KeeperWorkspaceChat}
+          keeper=${mockKeeper}
+          detailOpen=${false}
+          onToggleDetail=${vi.fn()}
+          onClear=${vi.fn()}
+        />
+      `, container)
+    })
+
+    expect(container.querySelector('[data-testid="kw-chat-turn-inspector-drawer"]')).toBeNull()
+
+    const btn = container.querySelector('[data-testid="kw-chat-turn-inspector-btn"]') as HTMLButtonElement
+    await act(async () => {
+      btn.click()
+    })
+
+    const drawer = container.querySelector('[data-testid="kw-chat-turn-inspector-drawer"]')
+    expect(drawer).not.toBeNull()
+    expect(container.querySelector('[data-testid="kw-turn-inspector"]')?.getAttribute('data-keeper')).toBe('sangsu')
+
+    const close = container.querySelector('[data-testid="kw-chat-turn-inspector-close"]') as HTMLButtonElement
+    await act(async () => {
+      close.click()
+    })
+
+    expect(container.querySelector('[data-testid="kw-chat-turn-inspector-drawer"]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -4,10 +4,12 @@
 // header; the panel reuses the full chat engine unchanged.
 
 import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
 import type { VNode } from 'preact'
 import type { Keeper } from '../../types'
 import { KeeperConversationPanel } from '../keeper-shared'
 import { KeeperLifecycleButtons } from '../keeper-detail-lifecycle'
+import { KeeperTurnInspector } from '../keeper-turn-inspector'
 import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
 import {
   WorkspaceSigil,
@@ -23,11 +25,13 @@ function ChatHeader({
   detailOpen,
   onToggleDetail,
   onClear,
+  onOpenTurnInspector,
 }: {
   keeper: Keeper
   detailOpen: boolean
   onToggleDetail: () => void
   onClear: () => void
+  onOpenTurnInspector: () => void
 }): VNode {
   const bucket = keeperBucket(keeper)
   const tone = keeperStatusTone(keeper)
@@ -51,6 +55,13 @@ function ChatHeader({
       </div>
       <div class="kw-chat-actions">
         <${KeeperLifecycleButtons} keeper=${keeper} effectiveStatus=${keeperDisplayStatus(keeper)} />
+        <button
+          type="button"
+          class="kw-act v2-monitoring-action"
+          title="턴 검사"
+          onClick=${onOpenTurnInspector}
+          data-testid="kw-chat-turn-inspector-btn"
+        >턴 검사</button>
         <button type="button" class="kw-act danger v2-monitoring-action" title="컨텍스트 비우기" onClick=${onClear}>비우기</button>
         <button
           type="button"
@@ -59,6 +70,48 @@ function ChatHeader({
           title="상세 (상태 · 진단 · 정체성 · 설정 · 디버그)"
           onClick=${onToggleDetail}
         >${detailOpen ? '대화로' : '상세'}</button>
+      </div>
+    </div>
+  `
+}
+
+function TurnInspectorDrawer({
+  keeperName,
+  open,
+  onClose,
+}: {
+  keeperName: string
+  open: boolean
+  onClose: () => void
+}) {
+  if (!open) return null
+
+  return html`
+    <div
+      class="fixed inset-0 z-50 flex justify-end bg-black/40"
+      role="dialog"
+      aria-modal="true"
+      aria-label="턴 검사"
+      data-testid="kw-chat-turn-inspector-drawer"
+      onClick=${onClose}
+    >
+      <div
+        class="h-full w-full max-w-2xl overflow-y-auto bg-[var(--color-bg-page)] shadow-2xl"
+        onClick=${(e: Event) => e.stopPropagation()}
+      >
+        <div class="sticky top-0 z-10 flex items-center justify-between border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-3 v2-monitoring-toolbar">
+          <div>
+            <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">턴 검사</h3>
+            <p class="text-2xs text-[var(--color-fg-muted)]">${keeperName}</p>
+          </div>
+          <button
+            type="button"
+            class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-2xs text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-hover)]"
+            onClick=${onClose}
+            data-testid="kw-chat-turn-inspector-close"
+          >닫기</button>
+        </div>
+        <${KeeperTurnInspector} keeperName=${keeperName} />
       </div>
     </div>
   `
@@ -75,6 +128,8 @@ export function KeeperWorkspaceChat({
   onToggleDetail: () => void
   onClear: () => void
 }): VNode {
+  const [turnInspectorOpen, setTurnInspectorOpen] = useState(false)
+
   return html`
     <section class="kw-chat v2-monitoring-surface" role="region" aria-label=${`${keeper.name} 대화`}>
       <${ChatHeader}
@@ -82,11 +137,17 @@ export function KeeperWorkspaceChat({
         detailOpen=${detailOpen}
         onToggleDetail=${onToggleDetail}
         onClear=${onClear}
+        onOpenTurnInspector=${() => setTurnInspectorOpen(true)}
       />
       <${KeeperConversationPanel}
         keeperName=${keeper.name}
         placeholder=${`${keeper.name} 에게 메시지…  (⌘+Enter 전송)`}
         layout="workspace"
+      />
+      <${TurnInspectorDrawer}
+        keeperName=${keeper.name}
+        open=${turnInspectorOpen}
+        onClose=${() => setTurnInspectorOpen(false)}
       />
     </section>
   `

--- a/dashboard/src/components/lab-perf.ts
+++ b/dashboard/src/components/lab-perf.ts
@@ -1,0 +1,131 @@
+// LabPerf — keeper-v2 performance playground for the Lab tab.
+//
+// Renders a live FPS meter (via the existing fps-adaptive utility) and a
+// VirtualList demo that reuses the common VirtualList component. Data is
+// synthetic; the surface is meant to exercise production rendering primitives.
+
+import { html } from 'htm/preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { VirtualList } from './common/virtual-list'
+import { onFpsChange } from '../utils/fps-adaptive'
+
+interface PerfLogRow {
+  id: string
+  t: string
+  level: 'info' | 'warn' | 'error'
+  keeper: string
+  msg: string
+}
+
+const LEVELS: PerfLogRow['level'][] = ['info', 'info', 'info', 'warn', 'error']
+const KEEPERS = ['iron-claw', 'luna', 'vex', 'atlas', 'nimbus', 'ember', 'drift', 'sable', 'onyx', 'quill', 'pike', 'wren']
+const MSGS = [
+  'masc_amplitude_query 완료',
+  'edit_file 적용',
+  '컨텍스트 임계치 접근',
+  'masc_compact 완료 (−61%)',
+  'masc_trace_window 실패',
+  'HandingOff 인계 시작',
+  'preflight green',
+  'round-lock 재진입 차단',
+  'PR 코멘트 동기화',
+  'masc_git_blame 0.4s',
+]
+
+function generateRows(count: number): PerfLogRow[] {
+  return Array.from({ length: count }, (_, i) => {
+    const level = LEVELS[(i * 7) % LEVELS.length] ?? 'info'
+    const keeper = KEEPERS[i % KEEPERS.length] ?? 'unknown'
+    const msg = MSGS[(i * 3) % MSGS.length] ?? ''
+    const hh = String(16 - Math.floor(i / 900) % 16).padStart(2, '0')
+    const mm = String((i * 13) % 60).padStart(2, '0')
+    const ss = String((i * 29) % 60).padStart(2, '0')
+    return {
+      id: `perf-log-${i}`,
+      t: `${hh}:${mm}:${ss}`,
+      level,
+      keeper,
+      msg,
+    }
+  })
+}
+
+function FpsBadge() {
+  const [fps, setFps] = useState(60)
+
+  useEffect(() => {
+    return onFpsChange(setFps)
+  }, [])
+
+  const tone = fps >= 55 ? 'ok' : fps >= 30 ? 'warn' : 'bad'
+  const toneClass = {
+    ok: 'text-[var(--color-status-ok)] border-[var(--ok-20)] bg-[var(--ok-10)]',
+    warn: 'text-[var(--color-status-warn)] border-[var(--warn-20)] bg-[var(--warn-10)]',
+    bad: 'text-[var(--color-status-err)] border-[var(--err-border)] bg-[var(--bad-soft)]',
+  }[tone]
+
+  return html`
+    <span
+      class=${`inline-flex items-center gap-2 rounded-[var(--r-0)] border px-2.5 py-1 text-2xs font-semibold ${toneClass}`}
+      data-testid="lab-perf-fps"
+    >
+      <span class="size-2 rounded-full ${tone === 'ok' ? 'bg-[var(--color-status-ok)]' : tone === 'warn' ? 'bg-[var(--color-status-warn)]' : 'bg-[var(--color-status-err)]'}" aria-hidden="true"></span>
+      <span>${fps} fps</span>
+    </span>
+  `
+}
+
+function LogRow({ row }: { row: PerfLogRow }) {
+  const levelClass = {
+    info: 'text-[var(--color-fg-muted)]',
+    warn: 'text-[var(--color-status-warn)]',
+    error: 'text-[var(--color-status-err)]',
+  }[row.level]
+
+  return html`
+    <div class="flex items-center gap-3 px-3 py-2 text-xs font-mono border-b border-[var(--color-border-muted)] last:border-b-0">
+      <span class="w-14 shrink-0 text-[var(--color-fg-disabled)]">${row.t}</span>
+      <span class=${`w-11 shrink-0 uppercase text-2xs tracking-wider ${levelClass}`}>${row.level}</span>
+      <span class="w-24 shrink-0 truncate text-[var(--color-fg-secondary)]">${row.keeper}</span>
+      <span class="min-w-0 flex-1 truncate text-[var(--color-fg-primary)]">${row.msg}</span>
+    </div>
+  `
+}
+
+export function LabPerf() {
+  const rows = useMemo(() => generateRows(2000), [])
+
+  return html`
+    <div class="v2-lab-surface flex flex-col gap-6" data-testid="lab-perf-surface">
+      <div class="flex items-center justify-between gap-4 v2-monitoring-toolbar">
+        <div>
+          <h2 class="text-base font-semibold text-[var(--color-fg-primary)]">Performance</h2>
+          <p class="text-2xs text-[var(--color-fg-muted)]">FPS meter + VirtualList windowing demo</p>
+        </div>
+        <${FpsBadge} />
+      </div>
+
+      <div class="v2-monitoring-panel rounded-[var(--r-2)] border border-[var(--color-border-default)] p-4">
+        <div class="mb-3 flex items-center justify-between gap-3">
+          <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">
+            VirtualList · ${rows.length.toLocaleString()} rows
+          </div>
+          <span class="text-2xs text-[var(--color-fg-disabled)]">fixed 36 px rows</span>
+        </div>
+        <div class="h-80 overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)]">
+          <${VirtualList}
+            items=${rows}
+            itemHeight=${36}
+            getKey=${(row: PerfLogRow) => row.id}
+            renderItem=${(row: PerfLogRow) => html`<${LogRow} row=${row} />`}
+            className="h-full"
+          />
+        </div>
+        <p class="mt-3 text-2xs leading-relaxed text-[var(--color-fg-muted)]">
+          동일한 <code class="rounded bg-[var(--color-bg-muted)] px-1 py-0.5">LogRow</code> 컴포넌트를
+          VirtualList로 윈도잉하면 보이는 슬라이스(+overscan)만 렌더링됩니다.
+        </p>
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/lab.test.ts
+++ b/dashboard/src/components/lab.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const route = { value: { tab: 'lab' as string, params: {} as Record<string, string> } }
+
+async function loadLab() {
+  vi.resetModules()
+  vi.doMock('../router', () => ({ route }))
+  vi.doMock('./tools/tools-main', () => ({
+    Tools: () => html`<div data-testid="lab-tools">Tools</div>`,
+  }))
+  vi.doMock('./harness-health', () => ({
+    HarnessHealth: () => html`<div data-testid="lab-harness">Harness</div>`,
+  }))
+  vi.doMock('./design-canvas', () => ({
+    DesignCanvas: () => html`<div data-testid="lab-design-canvas">DesignCanvas</div>`,
+  }))
+  vi.doMock('./lab-perf', () => ({
+    LabPerf: () => html`<div data-testid="lab-perf">LabPerf</div>`,
+  }))
+  vi.doMock('./memory/memory-explore', () => ({
+    MemoryExplore: () => html`<div data-testid="lab-memory-explore">MemoryExplore</div>`,
+  }))
+  return import('./lab')
+}
+
+describe('Lab', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    route.value = { tab: 'lab', params: { section: 'tools' } }
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../router')
+    vi.doUnmock('./tools/tools-main')
+    vi.doUnmock('./harness-health')
+    vi.doUnmock('./design-canvas')
+    vi.doUnmock('./lab-perf')
+    vi.doUnmock('./memory/memory-explore')
+  })
+
+  it('renders tools section by default', async () => {
+    route.value.params = { section: 'tools' }
+    const { Lab } = await loadLab()
+
+    render(html`<${Lab} />`, container)
+    expect(container.querySelector('[data-testid="lab-surface"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="lab-tools"]')).not.toBeNull()
+  })
+
+  it('renders harness section', async () => {
+    route.value.params = { section: 'harness' }
+    const { Lab } = await loadLab()
+
+    render(html`<${Lab} />`, container)
+    expect(container.querySelector('[data-testid="lab-harness"]')).not.toBeNull()
+  })
+
+  it('renders design-canvas section', async () => {
+    route.value.params = { section: 'design-canvas' }
+    const { Lab } = await loadLab()
+
+    render(html`<${Lab} />`, container)
+    expect(container.querySelector('[data-testid="lab-design-canvas"]')).not.toBeNull()
+  })
+
+  it('renders performance section', async () => {
+    route.value.params = { section: 'performance' }
+    const { Lab } = await loadLab()
+
+    render(html`<${Lab} />`, container)
+    expect(container.querySelector('[data-testid="lab-perf"]')).not.toBeNull()
+  })
+
+  it('renders memory-explore section', async () => {
+    route.value.params = { section: 'memory-explore' }
+    const { Lab } = await loadLab()
+
+    render(html`<${Lab} />`, container)
+    expect(container.querySelector('[data-testid="lab-memory-explore"]')).not.toBeNull()
+  })
+
+  it('falls back to tools for unknown lab section', async () => {
+    route.value.params = { section: 'unknown' }
+    const { Lab } = await loadLab()
+
+    render(html`<${Lab} />`, container)
+    expect(container.querySelector('[data-testid="lab-tools"]')).not.toBeNull()
+  })
+})

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -3,12 +3,19 @@ import { route } from '../router'
 import { Tools } from './tools/tools-main'
 import { HarnessHealth } from './harness-health'
 import { DesignCanvas } from './design-canvas'
+import { LabPerf } from './lab-perf'
+import { MemoryExplore } from './memory/memory-explore'
 
-type LabSection = 'tools' | 'harness' | 'design-canvas'
+type LabSection = 'tools' | 'harness' | 'design-canvas' | 'performance' | 'memory-explore'
 
 function currentSection(): LabSection {
   const section = route.value.params.section
-  if (section === 'harness' || section === 'design-canvas') {
+  if (
+    section === 'harness'
+    || section === 'design-canvas'
+    || section === 'performance'
+    || section === 'memory-explore'
+  ) {
     return section
   }
   return 'tools'
@@ -18,7 +25,7 @@ export function Lab() {
   const section = currentSection()
 
   return html`
-    <div class="v2-lab-surface flex flex-col gap-6">
+    <div class="v2-lab-surface flex flex-col gap-6" data-testid="lab-surface">
       ${section === 'tools' ? html`
         <${Tools} />
       ` : null}
@@ -29,6 +36,14 @@ export function Lab() {
 
       ${section === 'design-canvas' ? html`
         <${DesignCanvas} />
+      ` : null}
+
+      ${section === 'performance' ? html`
+        <${LabPerf} />
+      ` : null}
+
+      ${section === 'memory-explore' ? html`
+        <${MemoryExplore} />
       ` : null}
     </div>
   `

--- a/dashboard/src/components/memory/memory-explore.test.ts
+++ b/dashboard/src/components/memory/memory-explore.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/preact'
+import { html } from 'htm/preact'
+import { MemoryExplore } from './memory-explore'
+
+describe('MemoryExplore', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the surface header', () => {
+    render(html`<${MemoryExplore} />`)
+    expect(screen.getByTestId('memory-explore-surface')).not.toBeNull()
+    expect(screen.getByText('Memory Linkage Explore')).not.toBeNull()
+  })
+
+  it('renders MemoryLens with the initial anchor node', () => {
+    render(html`<${MemoryExplore} />`)
+    const lens = screen.getByTestId('memory-explore-lens')
+    expect(lens).not.toBeNull()
+    expect(lens.textContent).toContain('compact()가 라운드 락 보유 중 호출돼 round-jitter 발생')
+  })
+
+  it('renders MemoryLineageRail steps', () => {
+    render(html`<${MemoryExplore} />`)
+    const lineage = screen.getByTestId('memory-explore-lineage')
+    expect(lineage).not.toBeNull()
+    expect(lineage.textContent).toContain('13:49')
+    expect(lineage.textContent).toContain('통찰 기록')
+  })
+
+  it('renders GoalDossier with goal title and progress', () => {
+    render(html`<${MemoryExplore} />`)
+    const dossier = screen.getByTestId('memory-explore-dossier')
+    expect(dossier).not.toBeNull()
+    expect(dossier.textContent).toContain('scheduler p95 round-jitter < 50ms')
+    expect(dossier.textContent).toContain('47%')
+  })
+
+  it('renders related task/issue/memory groups', () => {
+    render(html`<${MemoryExplore} />`)
+    expect(screen.getAllByText('compact() 호출부를 라운드 락 밖으로 격리').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('round-jitter p95 380ms 스파이크 (7회)')).not.toBeNull()
+    expect(screen.getByText('compact()가 라운드 락 보유 중 호출 (insight)')).not.toBeNull()
+  })
+})

--- a/dashboard/src/components/memory/memory-explore.ts
+++ b/dashboard/src/components/memory/memory-explore.ts
@@ -1,0 +1,177 @@
+// MemoryExplore — keeper-v2 memory linkage exploration surface.
+//
+// Composes MemoryLens, MemoryLineageRail, and GoalDossier into a single Lab
+// section that demonstrates how a memory checkpoint fans out to goals, tasks,
+// and board posts. All data is mock/sample.
+
+import { html } from 'htm/preact'
+import { MemoryLens } from './memory-lens'
+import { MemoryLineageRail } from './memory-lineage-rail'
+import { GoalDossier } from './goal-dossier'
+import type { MemoryNode, MemoryNodeType, MemoryKeeper } from './memory-primitives'
+
+const NODE_TYPES: Record<string, MemoryNodeType> = {
+  memory: { kr: '기억', g: '◆', c: 'var(--volt)' },
+  goal: { kr: '골', g: '◎', c: 'var(--accent-ice)' },
+  task: { kr: '태스크', g: '▣', c: 'var(--status-ok)' },
+  board: { kr: '보드', g: '◈', c: '#8a6cf0' },
+  issue: { kr: '이슈', g: '⚠', c: 'var(--accent-viscera)' },
+  snapshot: { kr: '스냅샷', g: '◷', c: 'var(--accent-ice)' },
+}
+
+const KEEPERS: Record<string, MemoryKeeper> = {
+  nick0cave: { s: 'NK', c: '#e0a82e' },
+  sangsu: { s: 'SS', c: '#5b9cf0' },
+  operator: { s: 'OP', c: '#e0b057' },
+}
+
+const NODES: Record<string, MemoryNode> = {
+  mem: {
+    type: 'memory',
+    title: 'compact()가 라운드 락 보유 중 호출돼 round-jitter 발생',
+    kp: 'nick0cave',
+    meta: 'insight · 체크포인트',
+    ns: 'core/scheduler',
+  },
+  mem2: {
+    type: 'memory',
+    title: 'c7be26acfb — compact() 최초 도입 커밋',
+    kp: 'nick0cave',
+    meta: 'origin · 회귀 출발점',
+    ns: 'core/scheduler',
+  },
+  goal: {
+    type: 'goal',
+    title: 'scheduler p95 round-jitter < 50ms',
+    kp: 'nick0cave',
+    meta: '진행 47% · D-3',
+    ns: 'core/scheduler',
+  },
+  task1: {
+    type: 'task',
+    title: 'compact() 호출부를 라운드 락 밖으로 격리',
+    kp: 'sangsu',
+    meta: 'open · 핸드오프 수신',
+    ns: 'core/runtime',
+  },
+  task2: {
+    type: 'task',
+    title: 'round-lock 재진입 회귀 테스트 추가',
+    kp: 'nick0cave',
+    meta: 'done · 84/84',
+    ns: 'core/scheduler',
+  },
+  board: {
+    type: 'board',
+    title: 'scheduler 공지 — drifter restart 승인 대기',
+    kp: 'operator',
+    meta: '@operator 멘션',
+    ns: 'core/scheduler',
+  },
+}
+
+const EDGES = [
+  { source: 'mem', target: 'goal', rel: '진단' },
+  { source: 'mem', target: 'task1', rel: '파생' },
+  { source: 'mem', target: 'task2', rel: '검증' },
+  { source: 'mem', target: 'board', rel: '게시' },
+  { source: 'mem', target: 'mem2', rel: '기원' },
+  { source: 'goal', target: 'task1', rel: '해소' },
+  { source: 'goal', target: 'task2', rel: '해소' },
+  { source: 'board', target: 'task1', rel: '승인 대기' },
+]
+
+const LINEAGE_STEPS = [
+  { id: 'mem2', t: '13:18', rel: '기원 — 이 커밋이 회귀의 출발점' },
+  { id: 'mem', t: '13:49', rel: '통찰 기록 — 락 보유 중 compact() 호출 확인', anchor: true },
+  { id: 'goal', t: '13:50', rel: '골 진단 갱신 — jitter 목표에 연결' },
+  { id: 'task1', t: '13:52', rel: '태스크 파생 → sangsu 핸드오프' },
+  { id: 'board', t: '13:55', rel: '보드 게시 — restart 승인 요청' },
+  { id: 'task2', t: '14:08', rel: '회귀 테스트 통과 84/84' },
+]
+
+const GOAL = {
+  title: 'scheduler p95 round-jitter < 50ms',
+  kp: 'nick0cave',
+  ns: 'core/scheduler',
+  pct: 47,
+  deadline: 'D-3 마감',
+}
+
+const SNAPS = [
+  { t: '06-08', pct: 12, note: 'baseline' },
+  { t: '06-09', pct: 28, note: '회귀 테스트 통과' },
+  { t: '06-11', pct: 47, note: '현재', now: true },
+]
+
+const RELATED = {
+  task: [
+    { title: 'compact() 호출부를 라운드 락 밖으로 격리', kp: 'sangsu', meta: 'open · 핸드오프 수신', state: 'open' as const },
+    { title: 'round-lock 재진입 회귀 테스트 추가', kp: 'nick0cave', meta: 'done · 84/84', state: 'done' as const },
+  ],
+  issue: [
+    { title: 'round-jitter p95 380ms 스파이크 (7회)', kp: 'nick0cave', meta: '원인 규명됨 · L93 lock', state: 'open' as const },
+    { title: 'drifter overflow → restart 대기', kp: 'operator', meta: 'blocked · 승인 대기', state: 'block' as const },
+  ],
+  memory: [
+    { title: 'compact()가 라운드 락 보유 중 호출 (insight)', kp: 'nick0cave', meta: '13:49 체크포인트', state: 'ctx' as const },
+    { title: 'c7be26acfb — compact() 최초 도입 커밋', kp: 'nick0cave', meta: 'origin', state: 'ctx' as const },
+  ],
+}
+
+const LEDGER = [
+  ['누적 trace', '287'],
+  ['활성 시간', '6h 12m'],
+  ['태스크', '2 · ✓1'],
+  ['이슈', '2'],
+  ['기억', '2'],
+  ['참여 keeper', '3'],
+] as const
+
+export function MemoryExplore() {
+  return html`
+    <div class="v2-lab-surface flex flex-col gap-6" data-testid="memory-explore-surface">
+      <div class="flex items-center justify-between gap-4 v2-monitoring-toolbar">
+        <div>
+          <h2 class="text-base font-semibold text-[var(--color-fg-primary)]">Memory Linkage Explore</h2>
+          <p class="text-2xs text-[var(--color-fg-muted)]">메모리 체크포인트 → 골 → 태스크 → 보드 연결망</p>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <div class="v2-monitoring-panel rounded-[var(--r-2)] border border-[var(--color-border-default)] overflow-hidden">
+          <${MemoryLens}
+            nodes=${NODES}
+            edges=${EDGES}
+            nodeTypes=${NODE_TYPES}
+            keepers=${KEEPERS}
+            start="mem"
+            testId="memory-explore-lens"
+          />
+        </div>
+
+        <div class="v2-monitoring-panel rounded-[var(--r-2)] border border-[var(--color-border-default)] overflow-hidden">
+          <${MemoryLineageRail}
+            steps=${LINEAGE_STEPS}
+            nodes=${NODES}
+            nodeTypes=${NODE_TYPES}
+            keepers=${KEEPERS}
+            testId="memory-explore-lineage"
+          />
+        </div>
+      </div>
+
+      <div class="v2-monitoring-panel rounded-[var(--r-2)] border border-[var(--color-border-default)] overflow-hidden">
+        <${GoalDossier}
+          goal=${GOAL}
+          nodeTypes=${NODE_TYPES}
+          keepers=${KEEPERS}
+          snaps=${SNAPS}
+          related=${RELATED}
+          ledger=${LEDGER}
+          testId="memory-explore-dossier"
+        />
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -27,6 +27,10 @@ vi.mock('./board/board-moderation-surface', () => ({
   BoardModerationSurface: () => html`<div data-testid="board-moderation-surface">Moderation</div>`,
 }))
 
+vi.mock('./board/board-surface', () => ({
+  BoardSurface: () => html`<div data-testid="board-surface">Board</div>`,
+}))
+
 vi.mock('./board/sub-board-surface', () => ({
   SubBoardSurface: () => html`<div data-testid="sub-board-surface">Sub-Boards</div>`,
 }))
@@ -81,6 +85,19 @@ describe('Work', () => {
     render(html`<${Work} />`)
 
     expect(screen.getByTestId('board-moderation-surface')).toBeTruthy()
+    expect(screen.queryByTestId('work-kpis')).toBeNull()
+  })
+
+  it('renders the board feed surface for the workspace board section', () => {
+    routeSignal.value = {
+      tab: 'workspace',
+      params: { section: 'board' },
+      postId: null,
+    }
+
+    render(html`<${Work} />`)
+
+    expect(screen.getByTestId('board-surface')).toBeTruthy()
     expect(screen.queryByTestId('work-kpis')).toBeNull()
   })
 

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -7,6 +7,7 @@ import { useMemo, useState } from 'preact/hooks'
 import { route, navigate } from '../router'
 import { goals, tasks, keepers } from '../store'
 import { BoardModerationSurface } from './board/board-moderation-surface'
+import { BoardSurface } from './board/board-surface'
 import { SubBoardSurface } from './board/sub-board-surface'
 import { PlanningPanel } from './planning-panel'
 import { VerificationRequestsPanel } from './verification-requests-panel'
@@ -15,14 +16,14 @@ import { LoadingState } from './common/feedback-state'
 import { KeeperBadge } from './keeper-badge'
 import type { Goal, Task, Keeper } from '../types'
 
-type WorkSection = 'board' | 'sub-boards' | 'moderation' | 'planning' | 'repositories' | 'verification'
+type WorkSection = 'work' | 'board' | 'sub-boards' | 'moderation' | 'planning' | 'repositories' | 'verification'
 
 const LazyRepositoryManagement = lazy(async () => ({
   default: (await import('./repository-management')).RepositoryManagement,
 }))
 
 function isWorkSection(v: string | undefined): v is WorkSection {
-  return v === 'board' || v === 'sub-boards' || v === 'moderation' || v === 'planning' || v === 'repositories' || v === 'verification'
+  return v === 'work' || v === 'board' || v === 'sub-boards' || v === 'moderation' || v === 'planning' || v === 'repositories' || v === 'verification'
 }
 
 // ── Job state mapping ───────────────────────────────────────────────────────
@@ -334,13 +335,14 @@ function WorkSurfaceV2() {
 export function Work() {
   const current: WorkSection = isWorkSection(route.value.params.section)
     ? route.value.params.section
-    : 'board'
+    : 'work'
 
   return html`
     <div class="v2-workspace-surface flex min-w-0 flex-col gap-3">
       <div class="min-w-0 transition-opacity duration-[var(--t-slow)]">
         <${ErrorBoundary} label=${current}>
-          ${current === 'board' ? html`<${WorkSurfaceV2} />`
+          ${current === 'work' ? html`<${WorkSurfaceV2} />`
+            : current === 'board' ? html`<${BoardSurface} />`
             : current === 'sub-boards' ? html`<${SubBoardSurface} />`
             : current === 'moderation' ? html`<${BoardModerationSurface} />`
             : current === 'planning' ? html`<${PlanningPanel} />`

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -49,12 +49,16 @@ describe('lab navigation', () => {
       'tools',
       'harness',
       'design-canvas',
+      'performance',
+      'memory-explore',
     ])
 
     expect(labSections.map(item => item.label)).toEqual([
       'Tools',
       'Safety Harness',
       'Design Canvas',
+      'Performance',
+      'Memory Explore',
     ])
   })
 })

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -30,6 +30,7 @@ type SurfaceSectionId =
   // ConnectorOverviewStrip rather than top-level navigation.
   | 'connector-status'      // all connectors with internal connector picker
   // workspace
+  | 'work'           // Goal/job breakdown surface
   | 'board'
   | 'sub-boards'     // Phase 2: SubBoard named spaces within the board
   | 'moderation'     // Board moderation queue and actions
@@ -123,9 +124,9 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     id: 'workspace',
     label: 'Workspace',
     icon: 'workspace',
-    description: 'Board, planning, repositories, and verification',
+    description: 'Work goals, board feed, planning, repositories, and verification',
     defaultTab: 'workspace',
-    defaultParams: { section: 'board' },
+    defaultParams: { section: 'work' },
     tabs: ['workspace'],
   },
   {
@@ -258,6 +259,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     },
   ],
   workspace: [
+    {
+      id: 'work',
+      label: 'Work',
+      description: 'Goal/job breakdown and keeper assignment board.',
+      params: { section: 'work' },
+    },
     {
       id: 'board',
       label: 'Board',

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -41,6 +41,8 @@ type SurfaceSectionId =
   | 'tools'
   | 'harness'
   | 'design-canvas'
+  | 'performance'
+  | 'memory-explore'
   // code (Stage 5 IDE plane — shell only in PR-1, 4-pane content in PR-2+)
   | 'ide-shell'
 
@@ -318,8 +320,20 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'design-canvas',
       label: 'Design Canvas',
-      description: 'keeper-v2 design-system preview surface for primitives, molecules, organisms, surfaces, and motion.',
+      description: 'keeper-v2 design-system preview surface for primitives, molecules, organisms, surfaces, motion, craft, and states.',
       params: { section: 'design-canvas' },
+    },
+    {
+      id: 'performance',
+      label: 'Performance',
+      description: 'FPS meter and VirtualList windowing demo.',
+      params: { section: 'performance' },
+    },
+    {
+      id: 'memory-explore',
+      label: 'Memory Explore',
+      description: 'Memory Lens, Lineage Rail, and Goal Dossier composition.',
+      params: { section: 'memory-explore' },
     },
   ],
   code: [

--- a/dashboard/src/hooks/use-is-mobile.test.ts
+++ b/dashboard/src/hooks/use-is-mobile.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { waitFor } from '@testing-library/preact'
+import { useIsMobile } from './use-is-mobile'
+
+function TestHarness({ breakpoint }: { breakpoint?: number }) {
+  const isMobile = useIsMobile({ breakpoint })
+  return html`<span data-testid="result" data-is-mobile=${String(isMobile)} />`
+}
+
+describe('useIsMobile', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('returns true when viewport width is at the default 760px breakpoint', () => {
+    window.innerWidth = 760
+    render(html`<${TestHarness} />`, container)
+
+    const result = container.querySelector('[data-testid="result"]')
+    expect(result?.getAttribute('data-is-mobile')).toBe('true')
+  })
+
+  it('returns false when viewport width is above the default breakpoint', () => {
+    window.innerWidth = 1024
+    render(html`<${TestHarness} />`, container)
+
+    const result = container.querySelector('[data-testid="result"]')
+    expect(result?.getAttribute('data-is-mobile')).toBe('false')
+  })
+
+  it('respects a custom breakpoint', () => {
+    window.innerWidth = 900
+    render(html`<${TestHarness} breakpoint=${1000} />`, container)
+
+    const result = container.querySelector('[data-testid="result"]')
+    expect(result?.getAttribute('data-is-mobile')).toBe('true')
+  })
+
+  it('reacts to window resize events', async () => {
+    window.innerWidth = 1024
+    render(html`<${TestHarness} />`, container)
+
+    const result = container.querySelector('[data-testid="result"]')
+    expect(result?.getAttribute('data-is-mobile')).toBe('false')
+
+    window.innerWidth = 360
+    window.dispatchEvent(new Event('resize'))
+
+    await waitFor(() => {
+      expect(result?.getAttribute('data-is-mobile')).toBe('true')
+    })
+  })
+})

--- a/dashboard/src/hooks/use-is-mobile.ts
+++ b/dashboard/src/hooks/use-is-mobile.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'preact/hooks'
+
+export interface UseIsMobileOptions {
+  /**
+   * Viewport width threshold in pixels. Widths at or below this value are
+   * considered mobile. Defaults to 760px to align with the dashboard's
+   * mobile chrome breakpoint.
+   */
+  breakpoint?: number
+}
+
+/**
+ * Tracks whether the viewport width is at or below the given breakpoint.
+ * Defaults to 760px. Safe to call in SSR / test environments where
+   * `window` may be undefined.
+ */
+export function useIsMobile(options: UseIsMobileOptions = {}): boolean {
+  const { breakpoint = 760 } = options
+
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    return window.innerWidth <= breakpoint
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const update = () => {
+      setIsMobile(window.innerWidth <= breakpoint)
+    }
+
+    update()
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [breakpoint])
+
+  return isMobile
+}


### PR DESCRIPTION
## Summary

Apply the remaining keeper-v2 design gaps in three phases:

### Phase A — Navigation wiring
- Workspace `section=board` now renders the real `BoardSurface` feed.
- Added `section=work` for the existing `WorkSurfaceV2` goal/job breakdown.
- Updated section nav so Work is the default Workspace section.

### Phase B — Mobile shell improvements
- Added `useIsMobile` hook (`src/hooks/use-is-mobile.ts`) with a 760px default breakpoint.
- `app.ts` now sets `data-mobile` on the root and hides the mobile bottom bar when the side-rail drawer is open or a keeper detail overlay is active, removing the overlapping nav surfaces.

### Phase C — New surfaces
- **Lab Performance** (`src/components/lab-perf.ts`): live FPS badge + VirtualList demo.
- **Memory Linkage Explore** (`src/components/memory/memory-explore.ts`): composite surface of `MemoryLens`, `MemoryLineageRail`, and `GoalDossier`.
- **Design Canvas** now has `craft` and `states` galleries.
- **Keeper chat** header has a 턴 검사 button that opens the existing `KeeperTurnInspector` drawer.
- New Lab sections registered in navigation: `performance`, `memory-explore`.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- touched vitest test files — 82 tests passed
- `pnpm build` ✅

## Notes

- Marker-only / wiring-only changes; no existing runtime behavior was removed.
- The design gap analysis reports are saved under `~/me/memory/keeper-v2-gap-*.md`.