### PR TITLE
feat(keeper): adversarial review verdict + author wake-on-fail (PoC)

### DIFF
--- a/config/prompts/verification.adversarial_review.md
+++ b/config/prompts/verification.adversarial_review.md
@@ -1,0 +1,39 @@
+---
+description: Adversarial reviewer — inspect submitted work and return a verdict
+category: verification
+template_variables: [task_title, task_description, evidence_refs]
+---
+
+You are an adversarial reviewer. Your job is to find what is wrong with this
+work before it is accepted — not to confirm that it looks fine. Treat the work
+as broken until you have inspected it and the evidence says otherwise.
+
+<task_title>{{task_title}}</task_title>
+<task_description>{{task_description}}</task_description>
+<evidence_refs>{{evidence_refs}}</evidence_refs>
+
+evidence_refs is free text written by the author. It may be a pull-request URL,
+a branch, a file path, a commit, or a mix. Work out what it points at and
+inspect it yourself with the tools you have — read the diff, open the files,
+search the surrounding code. Judge the actual change, not the description.
+
+How to review:
+- Try to refute the work. Look for the case the author did not handle: an
+  unhandled error path, an off-by-one, a wrong type, a catch-all that hides a
+  missing case, a non-atomic read-modify-write, a config value that drifted, a
+  test that asserts nothing, a claim in the description that the code does not
+  implement.
+- Ground every objection in the code you actually read. State the specific
+  place (path:line) and what is wrong there. An objection you cannot locate in
+  the change is not a finding.
+- Separate a blocker from a preference. A blocker is a correctness, safety, or
+  data-loss problem, or a claim with no support in the code. A preference is
+  style. Say which one each point is.
+- Do not approve to be agreeable. Passing work you did not inspect is the worst
+  outcome. If you could not inspect it, say so and do not pass it.
+
+Then call report_verdict exactly once:
+- PASS — you inspected the change and found no blocker.
+- WARN — acceptable, but with concerns the author should see.
+- FAIL — a blocker, or you could not verify the work. The reason must name the
+  specific problems (with path:line) so the author can fix and resubmit.

--- a/lib/keeper/keeper_adversarial_review.ml
+++ b/lib/keeper/keeper_adversarial_review.ml
@@ -8,7 +8,24 @@ type review_input = {
 
 let prompt_name = "verification.adversarial_review"
 
-let build_prompt (input : review_input) : string =
+let template_variable_regex = Re.Pcre.re {|\{\{([^}]+)\}\}|} |> Re.compile
+
+let remaining_template_variables rendered =
+  Re.all template_variable_regex rendered
+  |> List.map (fun g -> Re.Group.get g 1 |> String.trim)
+  |> List.filter (fun name -> name <> "")
+  |> List.sort_uniq String.compare
+
+let validate_no_remaining_variables rendered =
+  match remaining_template_variables rendered with
+  | [] -> Ok rendered
+  | vars ->
+    Error
+      (Printf.sprintf
+         "Rendered prompt still contains unreplaced template variables: %s"
+         (String.concat ", " vars))
+
+let build_prompt (input : review_input) : (string, string) result =
   match
     Prompt_registry.render_prompt_template prompt_name
       [
@@ -17,53 +34,105 @@ let build_prompt (input : review_input) : string =
         ("evidence_refs", input.evidence_refs);
       ]
   with
-  | Ok p -> p
-  | Error msg ->
-    Log.Keeper.warn
-      "adversarial_review: prompt %s render failed (%s); using raw template"
-      prompt_name msg;
-    Prompt_registry.get_prompt prompt_name
+  | Error msg -> Error msg
+  | Ok rendered -> validate_no_remaining_variables rendered
+
+let parse_json_payload text =
+  let trimmed = String.trim text in
+  let attempt s =
+    try Some (Yojson.Safe.from_string s) with
+    | Yojson.Json_error _ -> None
+  in
+  match attempt trimmed with
+  | Some json -> Some json
+  | None ->
+    let len = String.length trimmed in
+    if len = 0 then None
+    else
+      let start_opt =
+        let brace = try Some (String.index trimmed '{') with Not_found -> None in
+        let bracket = try Some (String.index trimmed '[') with Not_found -> None in
+        match brace, bracket with
+        | Some i, Some j -> Some (min i j)
+        | Some i, None -> Some i
+        | None, Some j -> Some j
+        | None, None -> None
+      in
+      match start_opt with
+      | None -> None
+      | Some start ->
+        let closing = if trimmed.[start] = '{' then '}' else ']' in
+        let rec find_last idx =
+          if idx < 0 then None
+          else if trimmed.[idx] = closing then Some idx
+          else find_last (idx - 1)
+        in
+        match find_last (len - 1) with
+        | None -> None
+        | Some fin -> attempt (String.sub trimmed start (fin - start + 1))
+
+let parse_verdict_from_text text =
+  match parse_json_payload text with
+  | None ->
+    Error "model did not return a structured verdict (no JSON payload found)"
+  | Some json -> Verifier_core.parse_verdict_from_json json
 
 (* Mirrors [Verifier_oas.verify]: structured verdict via the [report_verdict]
-   tool, with a lenient text fallback. The judgment itself is the model's; this
-   only routes its structured output back as a typed [Verifier_core.verdict]. *)
+   tool, with a structured JSON fallback if the model answers in free text.
+   The judgment itself is the model's; this only routes its structured output
+   back as a typed [Verifier_core.verdict]. *)
 let run_review ~runtime_id (input : review_input) :
     (Verifier_core.verdict, string) result =
-  let prompt = build_prompt input in
-  let verdict_ref = ref None in
-  let dispatch ~name ~args =
-    let start_time = Time_compat.now () in
-    match Verifier_core.parse_verdict_from_json args with
-    | Ok v ->
-      verdict_ref := Some v;
-      Tool_result.error ~tool_name:name ~start_time
-        (Printf.sprintf "Verdict recorded: %s" (Verifier_core.verdict_to_string v))
-    | Error msg ->
-      Log.Keeper.warn "adversarial_review: verdict parse failed: %s" msg;
-      Tool_result.error ~tool_name:name ~start_time
-        (Printf.sprintf "Invalid verdict format: %s" msg)
-  in
-  match
-    Keeper_turn_driver_wrappers.run_named_with_masc_tools ~runtime_id
-      ~goal:prompt
-      ~masc_tools:[ Verifier_core.report_verdict_schema ]
-      ~dispatch
-      ~temperature:Runtime_provider_defaults.deterministic_temperature
-      ~approval:Approval_callbacks.auto_approve ()
-  with
-  | Ok result -> (
-    match !verdict_ref with
-    | Some v -> Ok v
-    | None ->
-      (* Model answered in text instead of calling report_verdict. *)
-      let text = Agent_sdk_response.text_of_response result.response in
-      Verifier_core.parse_verdict text)
-  | Error err -> Error (Agent_sdk.Error.to_string err)
+  match build_prompt input with
+  | Error msg ->
+    Log.Keeper.warn "adversarial_review: prompt render/validation failed: %s" msg;
+    Error msg
+  | Ok prompt ->
+    let verdict_ref = ref None in
+    let dispatch ~name ~args =
+      let start_time = Time_compat.now () in
+      match !verdict_ref with
+      | Some v ->
+        let msg =
+          Printf.sprintf
+            "Verdict already recorded (%s); only one report_verdict call is allowed"
+            (Verifier_core.verdict_to_string v)
+        in
+        Log.Keeper.warn "adversarial_review: %s" msg;
+        Tool_result.error ~tool_name:name ~start_time msg
+      | None -> (
+        match Verifier_core.parse_verdict_from_json args with
+        | Ok v ->
+          verdict_ref := Some v;
+          Tool_result.ok ~tool_name:name ~start_time
+            (Printf.sprintf "Verdict recorded: %s" (Verifier_core.verdict_to_string v))
+        | Error msg ->
+          Log.Keeper.warn "adversarial_review: verdict parse failed: %s" msg;
+          Tool_result.error ~tool_name:name ~start_time
+            (Printf.sprintf "Invalid verdict format: %s" msg))
+    in
+    match
+      Keeper_turn_driver_wrappers.run_named_with_masc_tools ~runtime_id
+        ~goal:prompt
+        ~masc_tools:[ Verifier_core.report_verdict_schema ]
+        ~dispatch
+        ~temperature:Runtime_provider_defaults.deterministic_temperature
+        ~approval:Approval_callbacks.auto_approve ()
+    with
+    | Ok result -> (
+      match !verdict_ref with
+      | Some v -> Ok v
+      | None ->
+        (* Model answered in text instead of calling report_verdict. *)
+        let text = Agent_sdk_response.text_of_response result.response in
+        parse_verdict_from_text text)
+    | Error err -> Error (Agent_sdk.Error.to_string err)
 
 (* Identity routing: the work's author is known, so waking them is structural,
    not a judgment. Dedup is content-addressed on (task_id, reason) so a given
    rejection wakes the author exactly once. *)
-let wake_author ~base_path ~(input : review_input) ~reason : unit =
+let wake_author ~base_path ~(input : review_input) ~reason :
+    (unit, string) result =
   let dedupe_key =
     Printf.sprintf "adversarial_review:%s:%s" input.task_id
       (Digest.to_hex (Digest.string reason))
@@ -99,21 +168,24 @@ let wake_author ~base_path ~(input : review_input) ~reason : unit =
     }
   in
   match Keeper_external_attention.record ~base_path item with
-  | `Recorded | `Duplicate _ -> ()
+  | `Recorded | `Duplicate _ -> Ok ()
   | `Error error ->
-    Log.Keeper.warn "adversarial_review: wake author %s failed: %s"
-      input.author_keeper error
+    let msg =
+      Printf.sprintf "adversarial_review: wake author %s failed: %s"
+        input.author_keeper error
+    in
+    Log.Keeper.warn "%s" msg;
+    Error msg
 
 let act_on_verdict ~base_path ~(input : review_input)
-    (verdict : Verifier_core.verdict) : unit =
+    (verdict : Verifier_core.verdict) : (unit, string) result =
   match verdict with
   | Verifier_core.Fail reason -> wake_author ~base_path ~input ~reason
-  | Verifier_core.Pass | Verifier_core.Warn _ -> ()
+  | Verifier_core.Pass | Verifier_core.Warn _ -> Ok ()
 
 let review_and_wake_on_fail ~base_path ~runtime_id (input : review_input) :
     (Verifier_core.verdict, string) result =
   match run_review ~runtime_id input with
   | Error _ as e -> e
   | Ok verdict ->
-    act_on_verdict ~base_path ~input verdict;
-    Ok verdict
+    Result.map (fun () -> verdict) (act_on_verdict ~base_path ~input verdict)

--- a/lib/keeper/keeper_adversarial_review.ml
+++ b/lib/keeper/keeper_adversarial_review.ml
@@ -1,0 +1,119 @@
+type review_input = {
+  task_id : string;
+  task_title : string;
+  task_description : string;
+  author_keeper : string;
+  evidence_refs : string;
+}
+
+let prompt_name = "verification.adversarial_review"
+
+let build_prompt (input : review_input) : string =
+  match
+    Prompt_registry.render_prompt_template prompt_name
+      [
+        ("task_title", input.task_title);
+        ("task_description", input.task_description);
+        ("evidence_refs", input.evidence_refs);
+      ]
+  with
+  | Ok p -> p
+  | Error msg ->
+    Log.Keeper.warn
+      "adversarial_review: prompt %s render failed (%s); using raw template"
+      prompt_name msg;
+    Prompt_registry.get_prompt prompt_name
+
+(* Mirrors [Verifier_oas.verify]: structured verdict via the [report_verdict]
+   tool, with a lenient text fallback. The judgment itself is the model's; this
+   only routes its structured output back as a typed [Verifier_core.verdict]. *)
+let run_review ~runtime_id (input : review_input) :
+    (Verifier_core.verdict, string) result =
+  let prompt = build_prompt input in
+  let verdict_ref = ref None in
+  let dispatch ~name ~args =
+    let start_time = Time_compat.now () in
+    match Verifier_core.parse_verdict_from_json args with
+    | Ok v ->
+      verdict_ref := Some v;
+      Tool_result.error ~tool_name:name ~start_time
+        (Printf.sprintf "Verdict recorded: %s" (Verifier_core.verdict_to_string v))
+    | Error msg ->
+      Log.Keeper.warn "adversarial_review: verdict parse failed: %s" msg;
+      Tool_result.error ~tool_name:name ~start_time
+        (Printf.sprintf "Invalid verdict format: %s" msg)
+  in
+  match
+    Keeper_turn_driver_wrappers.run_named_with_masc_tools ~runtime_id
+      ~goal:prompt
+      ~masc_tools:[ Verifier_core.report_verdict_schema ]
+      ~dispatch
+      ~temperature:Runtime_provider_defaults.deterministic_temperature
+      ~approval:Approval_callbacks.auto_approve ()
+  with
+  | Ok result -> (
+    match !verdict_ref with
+    | Some v -> Ok v
+    | None ->
+      (* Model answered in text instead of calling report_verdict. *)
+      let text = Agent_sdk_response.text_of_response result.response in
+      Verifier_core.parse_verdict text)
+  | Error err -> Error (Agent_sdk.Error.to_string err)
+
+(* Identity routing: the work's author is known, so waking them is structural,
+   not a judgment. Dedup is content-addressed on (task_id, reason) so a given
+   rejection wakes the author exactly once. *)
+let wake_author ~base_path ~(input : review_input) ~reason : unit =
+  let dedupe_key =
+    Printf.sprintf "adversarial_review:%s:%s" input.task_id
+      (Digest.to_hex (Digest.string reason))
+  in
+  let event_id = Keeper_external_attention.event_id_of_dedupe_key dedupe_key in
+  let conversation_id = Printf.sprintf "review:%s" input.task_id in
+  let item : Keeper_external_attention.item =
+    {
+      event_id;
+      dedupe_key;
+      keeper_name = input.author_keeper;
+      conversation = { conversation_id; surface = Surface_ref.Agent };
+      external_message = None;
+      source_label = "adversarial_review";
+      actor =
+        {
+          actor_id = Some "adversarial_review";
+          display_name = Some "Adversarial reviewer";
+          authority = Keeper_chat_store.External;
+        };
+      urgency = Keeper_external_attention.System;
+      content_preview = reason;
+      content_ref = None;
+      received_at = Time_compat.now ()
+      (* NDT-OK: attention received_at is evidence and pending-order only; it
+         does not branch deterministic policy. *);
+      metadata =
+        [
+          ("kind", "review_rejected");
+          ("task_id", input.task_id);
+          ("verdict", "FAIL");
+        ];
+    }
+  in
+  match Keeper_external_attention.record ~base_path item with
+  | `Recorded | `Duplicate _ -> ()
+  | `Error error ->
+    Log.Keeper.warn "adversarial_review: wake author %s failed: %s"
+      input.author_keeper error
+
+let act_on_verdict ~base_path ~(input : review_input)
+    (verdict : Verifier_core.verdict) : unit =
+  match verdict with
+  | Verifier_core.Fail reason -> wake_author ~base_path ~input ~reason
+  | Verifier_core.Pass | Verifier_core.Warn _ -> ()
+
+let review_and_wake_on_fail ~base_path ~runtime_id (input : review_input) :
+    (Verifier_core.verdict, string) result =
+  match run_review ~runtime_id input with
+  | Error _ as e -> e
+  | Ok verdict ->
+    act_on_verdict ~base_path ~input verdict;
+    Ok verdict

--- a/lib/keeper/keeper_adversarial_review.ml
+++ b/lib/keeper/keeper_adversarial_review.ml
@@ -8,34 +8,13 @@ type review_input = {
 
 let prompt_name = "verification.adversarial_review"
 
-let template_variable_regex = Re.Pcre.re {|\{\{([^}]+)\}\}|} |> Re.compile
-
-let remaining_template_variables rendered =
-  Re.all template_variable_regex rendered
-  |> List.map (fun g -> Re.Group.get g 1 |> String.trim)
-  |> List.filter (fun name -> name <> "")
-  |> List.sort_uniq String.compare
-
-let validate_no_remaining_variables rendered =
-  match remaining_template_variables rendered with
-  | [] -> Ok rendered
-  | vars ->
-    Error
-      (Printf.sprintf
-         "Rendered prompt still contains unreplaced template variables: %s"
-         (String.concat ", " vars))
-
 let build_prompt (input : review_input) : (string, string) result =
-  match
-    Prompt_registry.render_prompt_template prompt_name
-      [
-        ("task_title", input.task_title);
-        ("task_description", input.task_description);
-        ("evidence_refs", input.evidence_refs);
-      ]
-  with
-  | Error msg -> Error msg
-  | Ok rendered -> validate_no_remaining_variables rendered
+  Prompt_registry.render_prompt_template prompt_name
+    [
+      ("task_title", input.task_title);
+      ("task_description", input.task_description);
+      ("evidence_refs", input.evidence_refs);
+    ]
 
 let parse_json_payload text =
   let trimmed = String.trim text in
@@ -129,14 +108,11 @@ let run_review ~runtime_id (input : review_input) :
     | Error err -> Error (Agent_sdk.Error.to_string err)
 
 (* Identity routing: the work's author is known, so waking them is structural,
-   not a judgment. Dedup is content-addressed on (task_id, reason) so a given
-   rejection wakes the author exactly once. *)
+   not a judgment. Dedup is keyed on the stable task-level FAIL outcome so
+   reason wording drift cannot repeatedly wake the author for the same task. *)
 let wake_author ~base_path ~(input : review_input) ~reason :
     (unit, string) result =
-  let dedupe_key =
-    Printf.sprintf "adversarial_review:%s:%s" input.task_id
-      (Digest.to_hex (Digest.string reason))
-  in
+  let dedupe_key = Printf.sprintf "adversarial_review:%s:fail" input.task_id in
   let event_id = Keeper_external_attention.event_id_of_dedupe_key dedupe_key in
   let conversation_id = Printf.sprintf "review:%s" input.task_id in
   let item : Keeper_external_attention.item =

--- a/lib/keeper/keeper_adversarial_review.mli
+++ b/lib/keeper/keeper_adversarial_review.mli
@@ -1,0 +1,45 @@
+(** Keeper_adversarial_review — adversarial review of submitted work as an
+    agentic verdict, with author wake-on-fail.
+
+    Decoupled from [Verifier_oas] (the OAS per-tool gate) and from
+    [Anti_rationalization] (the completion-notes judge): this module has its
+    own prompt ([config/prompts/verification.adversarial_review.md]), its own
+    entry point, and its own output. It shares only the generic judging engine
+    ([Keeper_turn_driver_wrappers.run_named_with_masc_tools]) and the
+    [Verifier_core] verdict surface.
+
+    The verdict is the LLM's judgment — there is no rule, heuristic, or string
+    match deciding pass/fail here. The only deterministic parts are identity
+    (which keeper authored the work, hence who to wake) and event-id dedup (a
+    given verdict wakes the author at most once). *)
+
+type review_input = {
+  task_id : string;
+  task_title : string;
+  task_description : string;
+  author_keeper : string;
+  evidence_refs : string;
+}
+
+val build_prompt : review_input -> string
+(** Render the adversarial review prompt from
+    [config/prompts/verification.adversarial_review.md]. *)
+
+val run_review :
+  runtime_id:string -> review_input -> (Verifier_core.verdict, string) result
+(** Run the adversarial reviewer agent and read its structured verdict via the
+    [report_verdict] tool, falling back to text parsing if the model answers in
+    free text. *)
+
+val act_on_verdict :
+  base_path:string -> input:review_input -> Verifier_core.verdict -> unit
+(** On [Fail], record an external-attention item waking [author_keeper] with
+    the verdict reason so the author's next turn sees it. [Pass]/[Warn] do
+    nothing. Dedup is by (task_id, reason) so the same rejection wakes once. *)
+
+val review_and_wake_on_fail :
+  base_path:string ->
+  runtime_id:string ->
+  review_input ->
+  (Verifier_core.verdict, string) result
+(** [run_review] followed by [act_on_verdict] on the resulting verdict. *)

--- a/lib/keeper/keeper_adversarial_review.mli
+++ b/lib/keeper/keeper_adversarial_review.mli
@@ -13,8 +13,8 @@
     free-text fallback parses a JSON payload with
     [Verifier_core.parse_verdict_from_json]; it does not use string matching to
     decide pass/fail. The only deterministic parts are identity (which keeper
-    authored the work, hence who to wake) and event-id dedup (a given verdict
-    wakes the author at most once).
+    authored the work, hence who to wake) and event-id dedup (a given task-level
+    FAIL wakes the author at most once).
 
     This module is a proof-of-concept. It is not yet wired to a keeper
     lifecycle trigger; integration with the tool registration in #21357 is the
@@ -31,8 +31,8 @@ type review_input = {
 val build_prompt : review_input -> (string, string) result
 (** Render the adversarial review prompt from
     [config/prompts/verification.adversarial_review.md]. Returns [Error] if
-    template variables cannot be replaced or if any [{{...}}] placeholders
-    remain after rendering (fail-closed). *)
+    the prompt registry cannot replace one of the prompt's declared template
+    variables. Literal [{{...}}] text inside substituted values is preserved. *)
 
 val run_review :
   runtime_id:string -> review_input -> (Verifier_core.verdict, string) result
@@ -46,9 +46,10 @@ val act_on_verdict :
   base_path:string -> input:review_input -> Verifier_core.verdict -> (unit, string) result
 (** On [Fail], record an external-attention item waking [author_keeper] with
     the verdict reason so the author's next turn sees it. [Pass]/[Warn] do
-    nothing and return [Ok ()]. Dedup is by (task_id, reason) so the same
-    rejection wakes once. Returns [Error] if recording the attention item
-    fails, so the caller can decide whether to fail-closed. *)
+    nothing and return [Ok ()]. Dedup is by (task_id, verdict-class), so a
+    repeated FAIL for the same task wakes once even when the model phrases the
+    reason differently. Returns [Error] if recording the attention item fails,
+    so the caller can decide whether to fail-closed. *)
 
 val review_and_wake_on_fail :
   base_path:string ->

--- a/lib/keeper/keeper_adversarial_review.mli
+++ b/lib/keeper/keeper_adversarial_review.mli
@@ -8,10 +8,17 @@
     ([Keeper_turn_driver_wrappers.run_named_with_masc_tools]) and the
     [Verifier_core] verdict surface.
 
-    The verdict is the LLM's judgment — there is no rule, heuristic, or string
-    match deciding pass/fail here. The only deterministic parts are identity
-    (which keeper authored the work, hence who to wake) and event-id dedup (a
-    given verdict wakes the author at most once). *)
+    The verdict is the LLM's judgment. On the structured [report_verdict] path
+    there is no rule, heuristic, or string match deciding pass/fail. The
+    free-text fallback parses a JSON payload with
+    [Verifier_core.parse_verdict_from_json]; it does not use string matching to
+    decide pass/fail. The only deterministic parts are identity (which keeper
+    authored the work, hence who to wake) and event-id dedup (a given verdict
+    wakes the author at most once).
+
+    This module is a proof-of-concept. It is not yet wired to a keeper
+    lifecycle trigger; integration with the tool registration in #21357 is the
+    next step. *)
 
 type review_input = {
   task_id : string;
@@ -21,21 +28,27 @@ type review_input = {
   evidence_refs : string;
 }
 
-val build_prompt : review_input -> string
+val build_prompt : review_input -> (string, string) result
 (** Render the adversarial review prompt from
-    [config/prompts/verification.adversarial_review.md]. *)
+    [config/prompts/verification.adversarial_review.md]. Returns [Error] if
+    template variables cannot be replaced or if any [{{...}}] placeholders
+    remain after rendering (fail-closed). *)
 
 val run_review :
   runtime_id:string -> review_input -> (Verifier_core.verdict, string) result
 (** Run the adversarial reviewer agent and read its structured verdict via the
-    [report_verdict] tool, falling back to text parsing if the model answers in
-    free text. *)
+    [report_verdict] tool. If the model answers in free text, the fallback
+    attempts to parse a JSON payload and decode it with
+    [Verifier_core.parse_verdict_from_json]; it never uses string matching to
+    decide pass/fail. *)
 
 val act_on_verdict :
-  base_path:string -> input:review_input -> Verifier_core.verdict -> unit
+  base_path:string -> input:review_input -> Verifier_core.verdict -> (unit, string) result
 (** On [Fail], record an external-attention item waking [author_keeper] with
     the verdict reason so the author's next turn sees it. [Pass]/[Warn] do
-    nothing. Dedup is by (task_id, reason) so the same rejection wakes once. *)
+    nothing and return [Ok ()]. Dedup is by (task_id, reason) so the same
+    rejection wakes once. Returns [Error] if recording the attention item
+    fails, so the caller can decide whether to fail-closed. *)
 
 val review_and_wake_on_fail :
   base_path:string ->

--- a/test/dune
+++ b/test/dune
@@ -2203,3 +2203,10 @@
  (name test_keeper_global_shared_refs_atomic)
  (modules test_keeper_global_shared_refs_atomic)
  (libraries alcotest masc masc.compaction_trigger))
+
+; Adversarial review wake-on-fail routing (PoC).
+
+(test
+ (name test_keeper_adversarial_review)
+ (modules test_keeper_adversarial_review)
+ (libraries masc_test_deps))

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -63,12 +63,17 @@ let input ~author : AR.review_input =
 let pending base ~keeper =
   EA.pending_for_keeper ~base_path:base ~keeper_name:keeper ~limit:50 ()
 
+let check_ok = function
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail msg
+
 let test_fail_wakes_author () =
   with_temp_base (fun base ->
       let author = "builder-keeper" in
       check int "no pending before" 0 (List.length (pending base ~keeper:author));
       AR.act_on_verdict ~base_path:base ~input:(input ~author)
-        (VC.Fail "unhandled error path at foo.ml:10");
+        (VC.Fail "unhandled error path at foo.ml:10")
+      |> check_ok;
       let items = pending base ~keeper:author in
       check int "one pending after fail" 1 (List.length items);
       let item = List.hd items in
@@ -78,14 +83,16 @@ let test_fail_wakes_author () =
 let test_pass_does_not_wake () =
   with_temp_base (fun base ->
       let author = "builder-keeper" in
-      AR.act_on_verdict ~base_path:base ~input:(input ~author) VC.Pass;
+      AR.act_on_verdict ~base_path:base ~input:(input ~author) VC.Pass
+      |> check_ok;
       check int "no pending after pass" 0
         (List.length (pending base ~keeper:author)))
 
 let test_warn_does_not_wake () =
   with_temp_base (fun base ->
       let author = "builder-keeper" in
-      AR.act_on_verdict ~base_path:base ~input:(input ~author) (VC.Warn "minor");
+      AR.act_on_verdict ~base_path:base ~input:(input ~author) (VC.Warn "minor")
+      |> check_ok;
       check int "no pending after warn" 0
         (List.length (pending base ~keeper:author)))
 
@@ -93,8 +100,8 @@ let test_fail_dedup_same_reason () =
   with_temp_base (fun base ->
       let author = "builder-keeper" in
       let v = VC.Fail "same reason" in
-      AR.act_on_verdict ~base_path:base ~input:(input ~author) v;
-      AR.act_on_verdict ~base_path:base ~input:(input ~author) v;
+      AR.act_on_verdict ~base_path:base ~input:(input ~author) v |> check_ok;
+      AR.act_on_verdict ~base_path:base ~input:(input ~author) v |> check_ok;
       check int "dedup: still one pending" 1
         (List.length (pending base ~keeper:author)))
 

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -9,12 +9,47 @@ open Alcotest
 module AR = Masc.Keeper_adversarial_review
 module EA = Masc.Keeper_external_attention
 module VC = Masc.Verifier_core
+module PR = Prompt_registry
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Sys.readdir path
+      |> Array.iter (fun e -> rm_rf (Filename.concat path e));
+      Unix.rmdir path)
+    else
+      Sys.remove path
 
 let with_temp_base f =
   let base = Filename.temp_file "adv_review_test" "" in
   Sys.remove base;
   Sys.mkdir base 0o755;
-  f base
+  Fun.protect ~finally:(fun () -> rm_rf base) (fun () -> f base)
+
+let write_prompt_file dir ~variables body =
+  let path = Filename.concat dir "verification.adversarial_review.md" in
+  let content =
+    Printf.sprintf
+      "---\ndescription: test adversarial review prompt\ncategory: \
+       verification\ntemplate_variables: [%s]\n---\n\n%s"
+      (String.concat ", " variables)
+      body
+  in
+  Out_channel.with_open_text path (fun oc -> Out_channel.output_string oc content)
+
+let with_prompt_dir ~variables body f =
+  let dir = Filename.temp_file "adv_review_prompt" "" in
+  Sys.remove dir;
+  Sys.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      rm_rf dir;
+      PR.clear ())
+    (fun () ->
+      write_prompt_file dir ~variables body;
+      PR.set_markdown_dir dir;
+      PR.load_prompts_from_directory dir;
+      f ())
 
 let input ~author : AR.review_input =
   {
@@ -63,6 +98,34 @@ let test_fail_dedup_same_reason () =
       check int "dedup: still one pending" 1
         (List.length (pending base ~keeper:author)))
 
+let test_build_prompt_replaces_variables () =
+  with_prompt_dir
+    ~variables:[ "task_title"; "task_description"; "evidence_refs" ]
+    "Title: {{task_title}}\nDescription: {{task_description}}\nEvidence: {{evidence_refs}}\n"
+    (fun () ->
+      match AR.build_prompt (input ~author:"builder-keeper") with
+      | Ok rendered ->
+        check bool "contains title" true
+          (try
+             ignore (Str.search_forward (Str.regexp_string "Add immutable cache") rendered 0);
+             true
+           with Not_found -> false);
+        check bool "no raw braces" true
+          (try
+             ignore (Str.search_forward (Str.regexp_string "{{") rendered 0);
+             false
+           with Not_found -> true)
+      | Error msg -> fail msg)
+
+let test_build_prompt_fails_closed_on_unresolved_variable () =
+  with_prompt_dir
+    ~variables:[ "task_title"; "task_description"; "evidence_refs"; "unknown_var" ]
+    "Missing {{unknown_var}}"
+    (fun () ->
+      match AR.build_prompt (input ~author:"builder-keeper") with
+      | Ok rendered -> fail ("expected error, got: " ^ rendered)
+      | Error msg -> check bool "error reported" true (String.length msg > 0))
+
 let () =
   Alcotest.run "keeper-adversarial-review"
     [
@@ -72,5 +135,12 @@ let () =
           test_case "pass no wake" `Quick test_pass_does_not_wake;
           test_case "warn no wake" `Quick test_warn_does_not_wake;
           test_case "fail dedup same reason" `Quick test_fail_dedup_same_reason;
+        ] );
+      ( "render-fail-closed",
+        [
+          test_case "build_prompt replaces all variables" `Quick
+            test_build_prompt_replaces_variables;
+          test_case "build_prompt errors on unresolved variable" `Quick
+            test_build_prompt_fails_closed_on_unresolved_variable;
         ] );
     ]

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -1,0 +1,76 @@
+(** Tests for [Keeper_adversarial_review] wake-on-fail routing.
+
+    The LLM judgment ([run_review]) needs a runtime and is exercised through
+    the shared engine elsewhere; here we verify the deterministic part: a [Fail]
+    verdict records an attention item for the author keeper, [Pass]/[Warn] do
+    not, and the same rejection deduplicates. *)
+
+open Alcotest
+module AR = Masc.Keeper_adversarial_review
+module EA = Masc.Keeper_external_attention
+module VC = Masc.Verifier_core
+
+let with_temp_base f =
+  let base = Filename.temp_file "adv_review_test" "" in
+  Sys.remove base;
+  Sys.mkdir base 0o755;
+  f base
+
+let input ~author : AR.review_input =
+  {
+    task_id = "task-42";
+    task_title = "Add immutable cache";
+    task_description = "Refactor link cache to immutable map";
+    author_keeper = author;
+    evidence_refs = "PR #123";
+  }
+
+let pending base ~keeper =
+  EA.pending_for_keeper ~base_path:base ~keeper_name:keeper ~limit:50 ()
+
+let test_fail_wakes_author () =
+  with_temp_base (fun base ->
+      let author = "builder-keeper" in
+      check int "no pending before" 0 (List.length (pending base ~keeper:author));
+      AR.act_on_verdict ~base_path:base ~input:(input ~author)
+        (VC.Fail "unhandled error path at foo.ml:10");
+      let items = pending base ~keeper:author in
+      check int "one pending after fail" 1 (List.length items);
+      let item = List.hd items in
+      check bool "reason carried in preview" true
+        (String.length item.EA.content_preview > 0))
+
+let test_pass_does_not_wake () =
+  with_temp_base (fun base ->
+      let author = "builder-keeper" in
+      AR.act_on_verdict ~base_path:base ~input:(input ~author) VC.Pass;
+      check int "no pending after pass" 0
+        (List.length (pending base ~keeper:author)))
+
+let test_warn_does_not_wake () =
+  with_temp_base (fun base ->
+      let author = "builder-keeper" in
+      AR.act_on_verdict ~base_path:base ~input:(input ~author) (VC.Warn "minor");
+      check int "no pending after warn" 0
+        (List.length (pending base ~keeper:author)))
+
+let test_fail_dedup_same_reason () =
+  with_temp_base (fun base ->
+      let author = "builder-keeper" in
+      let v = VC.Fail "same reason" in
+      AR.act_on_verdict ~base_path:base ~input:(input ~author) v;
+      AR.act_on_verdict ~base_path:base ~input:(input ~author) v;
+      check int "dedup: still one pending" 1
+        (List.length (pending base ~keeper:author)))
+
+let () =
+  Alcotest.run "keeper-adversarial-review"
+    [
+      ( "wake-on-fail",
+        [
+          test_case "fail wakes author" `Quick test_fail_wakes_author;
+          test_case "pass no wake" `Quick test_pass_does_not_wake;
+          test_case "warn no wake" `Quick test_warn_does_not_wake;
+          test_case "fail dedup same reason" `Quick test_fail_dedup_same_reason;
+        ] );
+    ]

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -3,7 +3,7 @@
     The LLM judgment ([run_review]) needs a runtime and is exercised through
     the shared engine elsewhere; here we verify the deterministic part: a [Fail]
     verdict records an attention item for the author keeper, [Pass]/[Warn] do
-    not, and the same rejection deduplicates. *)
+    not, and repeated task-level FAIL verdicts deduplicate. *)
 
 open Alcotest
 module AR = Masc.Keeper_adversarial_review
@@ -60,6 +60,9 @@ let input ~author : AR.review_input =
     evidence_refs = "PR #123";
   }
 
+let input_with_evidence ~author evidence_refs : AR.review_input =
+  { (input ~author) with evidence_refs }
+
 let pending base ~keeper =
   EA.pending_for_keeper ~base_path:base ~keeper_name:keeper ~limit:50 ()
 
@@ -96,13 +99,16 @@ let test_warn_does_not_wake () =
       check int "no pending after warn" 0
         (List.length (pending base ~keeper:author)))
 
-let test_fail_dedup_same_reason () =
+let test_fail_dedup_different_reasons () =
   with_temp_base (fun base ->
       let author = "builder-keeper" in
-      let v = VC.Fail "same reason" in
-      AR.act_on_verdict ~base_path:base ~input:(input ~author) v |> check_ok;
-      AR.act_on_verdict ~base_path:base ~input:(input ~author) v |> check_ok;
-      check int "dedup: still one pending" 1
+      AR.act_on_verdict ~base_path:base ~input:(input ~author)
+        (VC.Fail "error path at foo.ml:10")
+      |> check_ok;
+      AR.act_on_verdict ~base_path:base ~input:(input ~author)
+        (VC.Fail "same bug, different wording at foo.ml:11")
+      |> check_ok;
+      check int "dedup: still one pending for the task" 1
         (List.length (pending base ~keeper:author)))
 
 let test_build_prompt_replaces_variables () =
@@ -133,6 +139,27 @@ let test_build_prompt_fails_closed_on_unresolved_variable () =
       | Ok rendered -> fail ("expected error, got: " ^ rendered)
       | Error msg -> check bool "error reported" true (String.length msg > 0))
 
+let test_build_prompt_preserves_literal_braces_in_values () =
+  with_prompt_dir
+    ~variables:[ "task_title"; "task_description"; "evidence_refs" ]
+    "Evidence: {{evidence_refs}}\n"
+    (fun () ->
+      let evidence_refs = {|snippet: "{{ .Release.Name }}"|} in
+      match
+        AR.build_prompt
+          (input_with_evidence ~author:"builder-keeper" evidence_refs)
+      with
+      | Ok rendered ->
+        check bool "literal braces from value preserved" true
+          (try
+             ignore
+               (Str.search_forward
+                  (Str.regexp_string {|{{ .Release.Name }}|})
+                  rendered 0);
+             true
+           with Not_found -> false)
+      | Error msg -> fail msg)
+
 let () =
   Alcotest.run "keeper-adversarial-review"
     [
@@ -141,7 +168,8 @@ let () =
           test_case "fail wakes author" `Quick test_fail_wakes_author;
           test_case "pass no wake" `Quick test_pass_does_not_wake;
           test_case "warn no wake" `Quick test_warn_does_not_wake;
-          test_case "fail dedup same reason" `Quick test_fail_dedup_same_reason;
+          test_case "fail dedup different reasons" `Quick
+            test_fail_dedup_different_reasons;
         ] );
       ( "render-fail-closed",
         [
@@ -149,5 +177,7 @@ let () =
             test_build_prompt_replaces_variables;
           test_case "build_prompt errors on unresolved variable" `Quick
             test_build_prompt_fails_closed_on_unresolved_variable;
+          test_case "build_prompt preserves literal braces in values" `Quick
+            test_build_prompt_preserves_literal_braces_in_values;
         ] );
     ]


### PR DESCRIPTION
## Purpose

This is a narrow PoC for moving part of the `review -> work -> retry` loop into MASC itself instead of depending on GitHub review flow.

The implemented slice is intentionally limited: run an adversarial review prompt through the existing keeper/OAS runtime path, parse a typed `Verifier_core.verdict`, and wake the task author only when the verdict is `FAIL`.

## Current implementation

| Surface | Current behavior |
|---|---|
| `config/prompts/verification.adversarial_review.md` | Externalized adversarial review prompt. The prompt asks for contradiction, concrete evidence, and `BLOCK` vs nit separation. |
| `lib/keeper/keeper_adversarial_review.{ml,mli}` | `run_review` renders the prompt via `Prompt_registry.render_prompt_template`, runs `run_named_with_masc_tools`, then parses the `report_verdict` output through `Verifier_core`. |
| `lib/keeper/keeper_adversarial_review.{ml,mli}` | `act_on_verdict` records `external_attention` only for `Verifier_core.Fail`; `Pass` and `Warn` do not wake the author. |
| `lib/keeper/keeper_adversarial_review.{ml,mli}` | Wake dedup is task-level for failed reviews: `adversarial_review:<task_id>:fail`. It no longer depends on reason wording drift. |
| `test/test_keeper_adversarial_review.ml` | Covers FAIL wake, PASS/WARN no-wake, FAIL dedup across different reasons, prompt rendering, unresolved template failure, and literal `{{...}}` preservation inside substituted values. |

## Important boundaries

- No deterministic verdict classifier was added. Verdict meaning still comes from the model/tool result and is parsed through `Verifier_core`.
- Prompt template validation is delegated to `Prompt_registry.render_prompt_template`; the PR no longer maintains a local template-variable regex.
- Existing `masc_keeper_adversarial_review` tool surface is a separate `Adversarial_eval` diff-review path. It does not currently prove this new `Keeper_adversarial_review.run_review` path.
- This PR is not wired into a lifecycle trigger yet. It provides the isolated verdict-to-author-wake primitive.

## Verification

Latest verified head: `9ffb2bd5ae67c1e90df66f9f2c8e26de41289b8f`.

Local checks:

```console
$ ocamlformat --inplace lib/keeper/keeper_adversarial_review.ml lib/keeper/keeper_adversarial_review.mli test/test_keeper_adversarial_review.ml
$ scripts/dune-local.sh build test/test_keeper_adversarial_review.exe
$ ./_build/default/test/test_keeper_adversarial_review.exe
Test Successful. 7 tests run.
$ git diff --check
```

GitHub checks on head `9ffb2bd5ae67c1e90df66f9f2c8e26de41289b8f` are green as of 2026-06-18 18:10 KST:

- `Build and Test`: success
- `TLA+ Model Checking`: success
- `CI Gate`: success
- lint/format/ratchet checks: success
- `Dashboard`: skipped by workflow, not a failure

## Real-world verification status

Confirmed today:

- The deterministic side effect is covered locally: a `FAIL` verdict records external attention for the task author, and repeated failed verdicts for the same task dedup to one event even if the reason text changes.
- Prompt rendering is covered locally through the same `Prompt_registry` path used by runtime prompt templates.
- Remote CI builds the PR head successfully.

Not yet confirmed as an end-to-end live runtime loop:

- The running local MASC server reports build commit `f9635d5b87` from `/Users/dancer/me/workspace/yousleepwhen/masc/_build/default/bin/main_eio.exe`, while this PR head is `9ffb2bd5ae`. The current live server is therefore not running this PR.
- No current lifecycle trigger or shipped CLI command calls `Keeper_adversarial_review.review_and_wake_on_fail`.
- The existing live `masc_keeper_adversarial_review` tool is wired to `Adversarial_eval.evaluate`, not this new module.

So the answer is: partial real-world verification is possible now, but full real-world verification is not yet possible without one more integration step.

The next practical verification slice is a small sandbox harness or trigger that calls `Keeper_adversarial_review.review_and_wake_on_fail` with:

- a real `runtime_id`
- a throwaway `base_path`
- a test author keeper identity
- a known task/evidence payload

That would validate the real model call plus the author wake side effect without touching production live state. A production-grade loop still needs the follow-up trigger/deposit wiring and observability/cap controls.

## RFC

RFC-WAIVED: isolated new keeper module and prompt; existing verifier, credential, operator, and hook paths are unchanged.
