### PR TITLE
fix(keeper/rfc): close Atomic RMW race in self-preservation escape_state and restore RFC ledger monotonicity

### DIFF
--- a/lib/core/atomic_util.ml
+++ b/lib/core/atomic_util.ml
@@ -1,0 +1,14 @@
+(** Lock-free atomic update helpers.
+
+    These are thin wrappers around [Stdlib.Atomic.compare_and_set] that retry
+    until the read-modify-write succeeds. They are safe to call from multiple
+    OCaml 5 domains or Eio fibers operating on the same [Atomic.t]. *)
+
+let update r f =
+  let rec loop () =
+    let current = Atomic.get r in
+    let next = f current in
+    if not (Atomic.compare_and_set r current next) then loop ()
+  in
+  loop ()
+;;

--- a/lib/core/atomic_util.mli
+++ b/lib/core/atomic_util.mli
@@ -1,0 +1,6 @@
+(** Lock-free atomic update helpers. *)
+
+(** [update r f] atomically replaces the contents of [r] with [f (Atomic.get r)],
+    retrying with a fresh read if a concurrent writer changed [r] between the read
+    and the compare-and-set. *)
+val update : 'a Atomic.t -> ('a -> 'a) -> unit

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -27,6 +27,7 @@
   string_util
   list_util
   set_util
+  atomic_util
   read_drop_reason
   actor_types
   actor_mailbox

--- a/lib/keeper/keeper_supervisor_self_preservation.ml
+++ b/lib/keeper/keeper_supervisor_self_preservation.ml
@@ -62,6 +62,15 @@ let update_suppression_streak dominant_key =
   loop ()
 ;;
 
+let reset_suppression_streak () =
+  let rec loop () =
+    let current = Atomic.get escape_state in
+    let next = { current with consecutive_suppressions = 0 } in
+    if not (Atomic.compare_and_set escape_state current next) then loop ()
+  in
+  loop ()
+;;
+
 let publish_suppression
       ~publish_lifecycle
       ~suppressed_count
@@ -130,6 +139,11 @@ module For_testing = struct
   let should_warn_partial_suppression_streak =
     should_warn_partial_suppression_streak
   ;;
+
+  let update_suppression_streak = update_suppression_streak
+  let reset_suppression_streak = reset_suppression_streak
+  let consecutive_suppressions () = (Atomic.get escape_state).consecutive_suppressions
+  let last_dominant_cohort () = (Atomic.get escape_state).last_dominant_cohort
 end
 
 let apply ~keepers_dir ~publish_lifecycle ~total_keepers to_restart =
@@ -195,13 +209,7 @@ let apply ~keepers_dir ~publish_lifecycle ~total_keepers to_restart =
              streak_at_probe
              ratio
              dominant_key;
-           let rec reset_loop () =
-             let current = Atomic.get escape_state in
-             let next = { current with consecutive_suppressions = 0 } in
-             if not (Atomic.compare_and_set escape_state current next)
-             then reset_loop ()
-           in
-           reset_loop ()
+           reset_suppression_streak ()
          | None -> log_suppression ~ratio ~n_total ~dominant_key ~suppressed_count);
         publish_suppression
           ~publish_lifecycle

--- a/lib/keeper/keeper_supervisor_self_preservation.ml
+++ b/lib/keeper/keeper_supervisor_self_preservation.ml
@@ -47,16 +47,19 @@ let dominant_cohort cohorts =
 ;;
 
 let update_suppression_streak dominant_key =
-  let current = Atomic.get escape_state in
-  if String.equal current.last_dominant_cohort dominant_key
-  then
-    Atomic.set escape_state
-      { current with
-        consecutive_suppressions = current.consecutive_suppressions + 1
-      }
-  else
-    Atomic.set escape_state
-      { last_dominant_cohort = dominant_key; consecutive_suppressions = 1 }
+  let rec loop () =
+    let current = Atomic.get escape_state in
+    let next =
+      if String.equal current.last_dominant_cohort dominant_key
+      then
+        { current with
+          consecutive_suppressions = current.consecutive_suppressions + 1
+        }
+      else { last_dominant_cohort = dominant_key; consecutive_suppressions = 1 }
+    in
+    if not (Atomic.compare_and_set escape_state current next) then loop ()
+  in
+  loop ()
 ;;
 
 let publish_suppression
@@ -184,15 +187,21 @@ let apply ~keepers_dir ~publish_lifecycle ~total_keepers to_restart =
         let suppressed_count = List.length suppressed_names in
         (match probe_entry with
          | Some probe_name ->
+           let streak_at_probe = (Atomic.get escape_state).consecutive_suppressions in
            Log.Keeper.warn
              "self-preservation probe: allowing %s through after %d consecutive \
               same-cohort suppressions (ratio=%.2f, cohort=%s)"
              probe_name
-             (Atomic.get escape_state).consecutive_suppressions
+             streak_at_probe
              ratio
              dominant_key;
-           Atomic.set escape_state
-             { (Atomic.get escape_state) with consecutive_suppressions = 0 }
+           let rec reset_loop () =
+             let current = Atomic.get escape_state in
+             let next = { current with consecutive_suppressions = 0 } in
+             if not (Atomic.compare_and_set escape_state current next)
+             then reset_loop ()
+           in
+           reset_loop ()
          | None -> log_suppression ~ratio ~n_total ~dominant_key ~suppressed_count);
         publish_suppression
           ~publish_lifecycle

--- a/lib/keeper/keeper_supervisor_self_preservation.ml
+++ b/lib/keeper/keeper_supervisor_self_preservation.ml
@@ -47,28 +47,18 @@ let dominant_cohort cohorts =
 ;;
 
 let update_suppression_streak dominant_key =
-  let rec loop () =
-    let current = Atomic.get escape_state in
-    let next =
-      if String.equal current.last_dominant_cohort dominant_key
-      then
-        { current with
-          consecutive_suppressions = current.consecutive_suppressions + 1
-        }
-      else { last_dominant_cohort = dominant_key; consecutive_suppressions = 1 }
-    in
-    if not (Atomic.compare_and_set escape_state current next) then loop ()
-  in
-  loop ()
+  Atomic_util.update escape_state (fun current ->
+    if String.equal current.last_dominant_cohort dominant_key
+    then
+      { current with
+        consecutive_suppressions = current.consecutive_suppressions + 1
+      }
+    else { last_dominant_cohort = dominant_key; consecutive_suppressions = 1 })
 ;;
 
 let reset_suppression_streak () =
-  let rec loop () =
-    let current = Atomic.get escape_state in
-    let next = { current with consecutive_suppressions = 0 } in
-    if not (Atomic.compare_and_set escape_state current next) then loop ()
-  in
-  loop ()
+  Atomic_util.update escape_state (fun current ->
+    { current with consecutive_suppressions = 0 })
 ;;
 
 let publish_suppression

--- a/lib/keeper/keeper_supervisor_self_preservation.mli
+++ b/lib/keeper/keeper_supervisor_self_preservation.mli
@@ -4,6 +4,10 @@ val reset_for_test : unit -> unit
 
 module For_testing : sig
   val should_warn_partial_suppression_streak : streak:int -> bool
+  val update_suppression_streak : string -> unit
+  val reset_suppression_streak : unit -> unit
+  val consecutive_suppressions : unit -> int
+  val last_dominant_cohort : unit -> string
 end
 
 val apply

--- a/test/test_keeper_immutable_state_refactor.ml
+++ b/test/test_keeper_immutable_state_refactor.ml
@@ -29,6 +29,57 @@ let test_self_preservation_reset_for_test () =
   check unit "reset returns unit" () (KSP.reset_for_test ())
 ;;
 
+let test_update_suppression_streak_increments_same_cohort () =
+  KSP.reset_for_test ();
+  KSP.For_testing.update_suppression_streak "c1";
+  check string "cohort after first update" "c1" (KSP.For_testing.last_dominant_cohort ());
+  check int "count after first update" 1 (KSP.For_testing.consecutive_suppressions ());
+  KSP.For_testing.update_suppression_streak "c1";
+  check int "count after second update" 2 (KSP.For_testing.consecutive_suppressions ());
+  KSP.For_testing.update_suppression_streak "c1";
+  check int "count after third update" 3 (KSP.For_testing.consecutive_suppressions ())
+;;
+
+let test_update_suppression_streak_resets_on_cohort_change () =
+  KSP.reset_for_test ();
+  KSP.For_testing.update_suppression_streak "c1";
+  check string "cohort set" "c1" (KSP.For_testing.last_dominant_cohort ());
+  check int "count after first cohort" 1 (KSP.For_testing.consecutive_suppressions ());
+  KSP.For_testing.update_suppression_streak "c2";
+  check string "cohort changed" "c2" (KSP.For_testing.last_dominant_cohort ());
+  check int "count reset on change" 1 (KSP.For_testing.consecutive_suppressions ());
+  KSP.For_testing.update_suppression_streak "c2";
+  check int "count increments new cohort" 2 (KSP.For_testing.consecutive_suppressions ())
+;;
+
+let test_reset_suppression_streak_zeroes_count () =
+  KSP.reset_for_test ();
+  KSP.For_testing.update_suppression_streak "c1";
+  KSP.For_testing.update_suppression_streak "c1";
+  KSP.For_testing.update_suppression_streak "c1";
+  check int "count before reset" 3 (KSP.For_testing.consecutive_suppressions ());
+  KSP.For_testing.reset_suppression_streak ();
+  check int "count after reset" 0 (KSP.For_testing.consecutive_suppressions ());
+  check string "cohort preserved" "c1" (KSP.For_testing.last_dominant_cohort ())
+;;
+
+let test_update_suppression_streak_concurrent () =
+  KSP.reset_for_test ();
+  let n = 100 in
+  let domains =
+    List.init 4 (fun _ ->
+      Domain.spawn (fun () ->
+        for _ = 1 to n do
+          KSP.For_testing.update_suppression_streak "c"
+        done))
+  in
+  List.iter Domain.join domains;
+  check string "cohort after concurrent updates" "c"
+    (KSP.For_testing.last_dominant_cohort ());
+  check int "count after concurrent updates" (4 * n)
+    (KSP.For_testing.consecutive_suppressions ())
+;;
+
 (* ── Link-task idempotency cache (immutable Map + Atomic CAS) ──────────── *)
 
 let test_link_task_cache_mark_and_query () =
@@ -85,6 +136,14 @@ let () =
       , [ test_case "warn thresholds" `Quick
             test_should_warn_partial_suppression_streak
         ; test_case "reset for test" `Quick test_self_preservation_reset_for_test
+        ; test_case "streak increments same cohort" `Quick
+            test_update_suppression_streak_increments_same_cohort
+        ; test_case "streak resets on cohort change" `Quick
+            test_update_suppression_streak_resets_on_cohort_change
+        ; test_case "streak reset zeroes count" `Quick
+            test_reset_suppression_streak_zeroes_count
+        ; test_case "streak increments concurrently" `Quick
+            test_update_suppression_streak_concurrent
         ] )
     ; ( "link-task-cache"
       , [ test_case "mark and query" `Quick test_link_task_cache_mark_and_query


### PR DESCRIPTION
## Summary\n\nThe P9-P12 immutable refactor converted [Keeper_supervisor_self_preservation.escape_state] from a mutable record to an [Atomic.t] of an immutable record, but left the read-modify-write of the streak counter as a non-atomic [Atomic.get] + [Atomic.set] sequence. Because [escape_state] is module-global and can be written from concurrent supervisor fibers/domains (multiple server/base-path pulses, Eio yields, or future scheduler changes), this can lose updates or reset a peer's streak.\n\n## Changes\n\n- Introduce [Atomic_util.update] in [masc_core] as a reusable CAS-retry helper.\n- Replace the get/set sequence in [update_suppression_streak] and the probe reset with [Atomic_util.update], removing duplicated CAS-retry loops.\n- Expose the new streak accessors through [KSP.For_testing] and add sequential and concurrent-domain regression tests.\n\n## Notes on review points\n\n- **Concurrent-writer premise**: [escape_state] is shared across all supervisor instances in the process. While one sweep is sequential, different server/base-path pulses run under separate Eio fibers and can yield/interleave with each other; the new regression test also exercises concurrent-domain writers. CAS makes the RMW correct without relying on current scheduler serialization.\n- **.next-number jump (0252 → 0254)**: [RFC-0253-dashboard-v2-spacing-token-scale.md] already existed on [main], but the ledger still pointed to [0252], so every PR failed [scripts/rfc_enforcer.py --check-ledger-monotonic]. The bump to [0254] restores monotonicity; no new RFC document is missing.\n\n## Verification\n\n- [x] [dune build lib/keeper/keeper_supervisor_self_preservation.ml] passes locally.\n- [x] New sequential/concurrent streak tests pass locally.\n- [x] Existing regression tests for the refactor still pass.\n- [x] CI Build and Test, Meta Guards, Lint, RFC enforcer, and Test Coverage Check are green.
 
---
 
## 🔄 AS-IS vs TO-BE 구조적 개선점 분석 (Structural Improvements)
 
| 비교 항목 | AS-IS (PR 전) | TO-BE (PR 후) |
| :--- | :--- | :--- |
| **상태 동기화 메커니즘** | `Atomic.get` 후 로직 처리 후 `Atomic.set`의 비원자적 분리 수행 (Read-Modify-Write 경합 조건 존재) | `Atomic_util.update`를 통한 CAS(Compare-And-Swap) 기반 원자적 RMW 루프 적용 |
| **모듈 의존성 (lib/core/dune)** | `keeper_supervisor_self_preservation` 내부에 인라인된 CAS 재시도 로직 포함 | `masc_core` 내 `lib/core/atomic_util.ml/mli` 신규 모듈 추가 및 재사용성 강제 |
| **테스트 커버리지** | 순차적(Sequential) 스트릭 테스트만 존재 | `For_testing` 인터페이스 노출 및 `test_keeper_immutable_state_refactor.ml`에 멀티코어/멀티도메인 동시성 경합 테스트 추가 |
| **RFC 원장(Ledger) 상태** | `.next-number`가 `0252`로 유지되어 `rfc_enforcer.py`의 단조성(Monotonicity) 검증 지속적 실패 | `.next-number`를 `0254`로 강제 점프시켜 원장 단조성 복구 (0253은 기존 존재) |

```mermaid
graph TD
    subgraph AS_IS ["AS-IS: 경합 조건 (Race Condition)"]
        direction TB
        F1[Fiber 1: Atomic.get] --> F2[Streak 계산]
        F3[Fiber 2: Atomic.get] --> F4[Streak 계산]
        F2 --> F5[Atomic.set - 유실됨]
        F4 --> F6[Atomic.set - 덮어씀]
        F5 -.->|Lost Update| R1((Global escape_state))
        F6 --> R1
    end

    subgraph TO_BE ["TO-BE: CAS 기반 원자성 보장"]
        direction TB
        T1[Fiber 1: Atomic_util.update 호출] --> T2[현재 상태 스냅샷 읽기]
        T2 --> T3[새 상태 계산]
        T3 --> T4{CAS 성공?}
        T4 -- No --> T2
        T4 -- Yes --> T5[상태 업데이트 완료]

        T6[Fiber 2: Atomic_util.update 호출] --> T7[현재 상태 스냅샷 읽기]
        T7 --> T8[새 상태 계산]
        T8 --> T9{CAS 성공?}
        T9 -- No --> T7
        T9 -- Yes --> T10[상태 업데이트 완료]

        T5 --> R2((Global escape_state))
        T10 --> R2
    end

    AS_IS -.->|PR #21402| TO_BE
```

## ⚡ Adversarial Critique & Vulnerability Report (적대적 비판 및 취약성 검증)

이 PR은 멀티코어 환경에서의 동시성 문제를 인지했다는 점에서 긍정적이나, OCaml 5의 멀티도메인 아키텍처와 Eio의 파이버 스케줄링 특성을 단순히 'CAS 루프'로만 해결하려는 근시안적인 접근으로 심각한 비기능적 결함을 내포하고 있다.

### 1. `Atomic_util.update`의 무한 루프(Livelock) 병목 및 Eio 파이버 선점성(Premption) 붕괴
`lib/core/atomic_util.ml`에 구현된 CAS-retry 헬퍼는 고전적인 스피락(Spinlock) 변형이다. OCaml 5의 도메인 간 경합이 발생할 경우, CAS가 지속적으로 실패하여 CPU 사이클을 낭비하는 라이브락(Livelock) 상태에 빠질 위험이 있다. 더 심각한 것은 Eio의 협동적 멀티태스킹(Cooperative Multitasking) 모델이다. 만약 `Atomic_util.update`의 재시도 루프 내에 `Eio.Yield.yield` 호출이 없다면, 해당 파이버는 점유한 도메인의 실행 흐름을 독점하여 동일 도메인 내의 다른 Eio 파이버가 기아(Starvation) 상태에 빠지게 된다. 단순한 `while` 루프 안에서 `Atomic.compare_and_set`만 호출하는 구조는 Eio 런타임의 스케줄링 보장을 깨뜨리는 치명적인 설계 결함이다.

### 2. 모듈 글로벌 상태와 텔레메트리(Telemetry) 불일치 - 관찰 가능성 파괴
`keeper_supervisor_self_preservation.ml`의 `escape_state`를 모듈 글로벌 `Atomic.t`로 유지하는 것 자체가 분산 추적 및 메트릭 수집 관점에서 재앙이다. 스트릭(Streak) 카운터가 여러 파이버/도메인에 의해 CAS를 통해 비결정적으로 업데이트될 때, 특정 스트릭 값 변화가 어떤 `server/base-path` 펄스(Pulse)에 의해 발생했는지 추적하는 것이 불가능해진다. 텔레메트리 이벤트를 발행하는 타이밍과 `Atomic.set`(혹은 CAS 성공) 타이밍 사이에 Eio yield가 끼어들 경우, 모니터링 시스템에 올라가는 스트릭 값과 실제 메모리 상태 간의 불일치가 발생하여 알림(Alert)의 오탐(False Positive)이나 누락이 발생한다. 상태 업데이트와 텔레메트리 기록이 하나의 원자적 트랜잭션으로 묶이지 않은 구조적 한계가 존재한다.

### 3. 단조성(Monotonicity) 강제 점프(.next-number 0252 -> 0254)의 잠재적 프로덕션 파이프라인 훼손
PR 설명의 "0253은 이미 main에 존재하므로 0254로 점프한다"는 논리는 로컬 빌드에서는 통과할 수 있으나, 프로덕션 CI/CD 파이프라인의 상태 머신(State Machine)을 무너뜨릴 수 있는 백도어(Backdoor)다. `scripts/rfc_enforcer.py --check-ledger-monotonic`가 내부적으로 `+2`의 점프를 허용하는 로직을 가지고 있지 않다면, 이 PR은 단순히 "기존 버그를 숨기기 위해 원장(Ledger)의 꼬리를 잘라낸" 것에 불과하다. 만약 다른 브랜치에서 0253을 참조하는 PR이 병합되거나, 0253의 존재 여부를 가정하는 스크립트가 있다면, 이 강제 점프는 향후 빌드 파이프라인을 교착(Deadlock) 상태로 만들 것이다. RFC 원장 무결성을 복구하는 올바른 방법은 누락된 커밋을 찾아 `git rebase`로 히스토리를 수정하는 것이지, 런타임/스크립트 검증 값을 하드코딩으로 뛰어넘는 것이 아니다.

### 4. `For_testing` 인터페이스 노출로 인한 모듈 경계(Modularity) 위반 및 테스트 오염
`keeper_supervisor_self_preservation.mli`에 `KSP.For_testing` 모듈을 추가하여 내부 상태(스트릭 접근자)를 외부로 노출한 것은 OCaml의 강력한 추상화 경계를 훼손한다. `test_keeper_immutable_state_refactor.ml`에서 이 인터페이스를 통해 글로벌 `Atomic.t`에 직접 접근해 동시성 테스트를 수행하는 것은, 테스트 코드가 프로덕션 코드의 캡슐화를 깨고 구현 세부사항(Implementation Detail)에 강결합됨을 의미한다. 향후 `escape_state`의 저장 방식이 `Atomic.t`에서 다른 동시성 자료구조(예: Eio의 `Fiber.Mutex` 보호 하의 Tref 등)로 변경될 경우, 테스트 코드뿐만 아니라 MLI 인터페이스 전체가 파괴되어 리팩토링의 발목을 잡게 된다. 동시성 테스트는 공개된 행위(Behavior) 기반으로 작성되어야 하며, 내부 원자 상태를 테스트를 위해 `For_testing`으로 빼내는 것은 안티 패턴이다.
