### PR TITLE
feat(dashboard): add keeper-v2 design-system UI kits (experimental)

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -49,6 +49,11 @@ import './styles/telemetry-v2.css'
 import './styles/craft-v2.css'
 import './styles/states.css'
 
+/*
+ * EXPERIMENTAL: keeper-v2 DS UI kits — may conflict with existing v2-* styles; enable after review
+ * import './styles/ds-ui-kits.css'
+ */
+
 // Keeper-v2 surface stylesheets are auto-imported by filename convention:
 // every dashboard/src/styles/*-v2.css is injected here at build time. A new v2
 // surface adds only its own stylesheet file — it must NOT add a per-surface

--- a/dashboard/src/styles/ds-cockpit-kit/center.css
+++ b/dashboard/src/styles/ds-cockpit-kit/center.css
@@ -1,0 +1,64 @@
+/* center.css — waterfall, event feed, activity */
+.wf { position: relative; padding: var(--sp-3); min-height: 100%; }
+.wf-scale {
+  display: flex; justify-content: space-between;
+  font-family: var(--font-mono); font-size: 10px; color: var(--fg-3);
+  padding: 0 2px 4px; border-bottom: 1px solid var(--line-1); margin-bottom: 6px;
+}
+.wf-track {
+  display: grid; grid-template-columns: 100px minmax(0, 1fr); gap: var(--sp-2);
+  padding: 3px 0; align-items: center; min-height: 20px;
+}
+.wf-track:hover { background: var(--bg-2); }
+.wf-track .track-label {
+  font-size: var(--fs-11); color: var(--fg-2); font-family: var(--font-mono);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.wf-track .track-bars {
+  position: relative; height: 14px; background: var(--bg-2); border-radius: 2px;
+  min-width: 0;
+}
+.wf-bar {
+  position: absolute; top: 2px; height: 10px; border-radius: 1px; min-width: 2px;
+}
+.wf-bar.s-err { background: var(--err); }
+.wf-bar.s-info { background: var(--info); }
+.wf-bar.s-tool { background: var(--brass-2); }
+.wf-bar.s-text { background: var(--info); opacity: .6; }
+.wf-bar.s-noop { background: var(--idle); opacity: .4; }
+.wf-bar:hover { outline: 1px solid var(--fg-1); z-index: 2; }
+
+.wf-scale-ctrl { display: flex; gap: 2px; margin-left: auto; }
+.wf-scale-ctrl button {
+  background: var(--bg-2); border: 1px solid var(--line-1);
+  color: var(--fg-3); font: 10px/1 var(--font-mono);
+  padding: 3px 7px; cursor: pointer; border-radius: 2px; letter-spacing: .03em;
+}
+.wf-scale-ctrl button:hover { color: var(--fg-1); }
+.wf-scale-ctrl button.is-active { background: var(--bg-3); border-color: var(--brass-3); color: var(--brass-1); }
+.wf-scale-ctrl + .pane-meta { margin-left: var(--sp-3); }
+
+.feed-row {
+  display: grid;
+  grid-template-columns: 60px 14px 70px 80px minmax(0, 1fr);
+  gap: var(--sp-2); padding: 3px var(--sp-3);
+  font-family: var(--font-mono); font-size: var(--fs-11);
+  align-items: baseline; border-bottom: 1px solid transparent; min-width: 0;
+  cursor: pointer;
+}
+.feed-row:hover { background: var(--bg-2); }
+.feed-row.is-active { background: var(--bg-3); border-bottom-color: var(--line-2); }
+.feed-ts { color: var(--fg-3); }
+.feed-kind { font-size: 10px; color: var(--fg-2); text-transform: uppercase; letter-spacing: .04em; }
+.feed-kind.k-tool { color: var(--brass-1); }
+.feed-kind.k-error { color: var(--err); }
+.feed-kind.k-noop { color: var(--idle); }
+.feed-kind.k-text { color: var(--info); }
+.feed-kind.k-claim { color: var(--ok); }
+.feed-actor { color: var(--fg-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.feed-body {
+  color: var(--fg-1);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font-family: var(--font-sans); font-size: var(--fs-12);
+}
+.feed-row.is-error .feed-body { color: var(--err); }

--- a/dashboard/src/styles/ds-cockpit-kit/drawer.css
+++ b/dashboard/src/styles/ds-cockpit-kit/drawer.css
@@ -1,0 +1,162 @@
+/* drawer.css — inspector overlay */
+.drawer {
+  position: fixed;
+  top: calc(var(--h-topbar) + var(--h-kpi) + var(--h-lifeline));
+  right: 0;
+  bottom: var(--h-composer);
+  width: 520px; max-width: 90vw;
+  background: var(--bg-1);
+  border-left: 1px solid var(--line-2);
+  box-shadow: -8px 0 24px rgb(0 0 0 / .4);
+  transform: translateX(100%);
+  transition: transform var(--t-fast) var(--ease);
+  display: flex; flex-direction: column; z-index: 20;
+}
+.drawer.is-open { transform: translateX(0); }
+.drawer-head {
+  height: 40px; flex-shrink: 0;
+  padding: 0 var(--sp-4);
+  display: flex; align-items: center; justify-content: space-between;
+  background: var(--bg-2); border-bottom: 1px solid var(--line-2);
+}
+.drawer-close {
+  background: transparent;
+  border: 1px solid var(--line-2);
+  color: var(--fg-2);
+  width: 24px; height: 24px;
+  border-radius: var(--r-1); cursor: pointer;
+  font-size: 12px; line-height: 1;
+}
+.drawer-close:hover { background: var(--bg-3); color: var(--fg-1); }
+.drawer-tabs {
+  display: flex; gap: 0;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-2);
+  padding: 0 var(--sp-3); flex-shrink: 0;
+}
+.drawer-tab {
+  background: transparent; border: none;
+  border-bottom: 2px solid transparent;
+  padding: 8px 12px; color: var(--fg-3);
+  font-size: var(--fs-11); font-weight: 600;
+  letter-spacing: .06em; text-transform: uppercase;
+  cursor: pointer; border-radius: 0; position: relative;
+}
+.drawer-tab:hover { color: var(--fg-1); background: transparent; }
+.drawer-tab.is-active { color: var(--brass-1); border-bottom-color: var(--brass-1); background: transparent; }
+.drawer-tab.has-data::after {
+  content: ""; position: absolute; top: 6px; right: 4px;
+  width: 4px; height: 4px; background: var(--brass-1); border-radius: 50%;
+}
+.drawer-body {
+  flex: 1; min-height: 0; overflow: auto;
+  padding: var(--sp-3) var(--sp-4); font-size: var(--fs-12);
+}
+
+.chip-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 4px 0; }
+.chip {
+  font-family: var(--font-mono); font-size: 10px;
+  padding: 2px 6px; background: var(--bg-2);
+  border: 1px solid var(--line-1); border-radius: var(--r-1);
+  color: var(--fg-2); letter-spacing: .02em;
+}
+.chip-err { background: rgb(196 106 90 / .1); border-color: rgb(196 106 90 / .3); color: var(--err); }
+.chip.k-tool { color: var(--brass-1); border-color: var(--brass-3); }
+.chip.k-claim { color: var(--ok); border-color: rgb(107 158 107 / .4); }
+.chip.k-text { color: var(--info); border-color: rgb(106 142 176 / .4); }
+.chip.k-noop { color: var(--fg-3); }
+.chip.k-error { color: var(--err); border-color: rgb(196 106 90 / .4); }
+
+.pre {
+  font-family: var(--font-mono); font-size: 10.5px; line-height: 1.45;
+  color: var(--fg-1); background: var(--bg-0);
+  border: 1px solid var(--line-1); border-radius: var(--r-1);
+  padding: 8px 10px; overflow: auto; max-height: 280px;
+  white-space: pre-wrap; word-break: break-word; margin: 4px 0 8px;
+}
+.pre.is-raw { max-height: 360px; }
+
+.tool-block {
+  border: 1px solid var(--line-1);
+  border-radius: var(--r-1);
+  margin-bottom: 10px;
+  background: var(--bg-2); overflow: hidden;
+}
+.tool-name {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 10px; background: var(--bg-3);
+  border-bottom: 1px solid var(--line-1); font-size: var(--fs-12);
+}
+.json-section { border-bottom: 1px solid var(--line-1); }
+.json-section:last-child { border-bottom: none; }
+.json-head {
+  display: flex; align-items: center; gap: 6px;
+  padding: 5px 10px; cursor: pointer; user-select: none;
+  font-size: var(--fs-11);
+}
+.json-head:hover { background: var(--bg-3); }
+.json-head .chev { color: var(--fg-3); font-size: 9px; transition: transform var(--t-fast); }
+.json-section.is-collapsed .chev { transform: rotate(-90deg); }
+.json-section.is-collapsed .pre { display: none; }
+.json-section .pre { margin: 0 10px 8px; max-height: 240px; }
+
+.fsm-lifeline {
+  display: flex; flex-wrap: wrap; gap: 2px;
+  padding: 6px; background: var(--bg-0);
+  border: 1px solid var(--line-1); border-radius: var(--r-1);
+  margin-top: 4px; max-height: 120px; overflow-y: auto;
+}
+.fsm-lifeline .ll-cell { width: 8px; height: 14px; }
+.fsm-trans-list { display: flex; flex-direction: column; gap: 2px; margin-top: 4px; }
+.fsm-trans {
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 6px; border-radius: var(--r-1); font-size: var(--fs-11);
+}
+.fsm-trans:hover { background: var(--bg-2); }
+.fsm-trans.is-active { background: var(--bg-3); outline: 1px solid var(--brass-3); }
+
+.bar {
+  display: inline-block; flex: 1; height: 6px;
+  background: var(--bg-2); border-radius: 3px; overflow: hidden;
+  vertical-align: middle; position: relative; min-width: 40px;
+}
+.bar-fill { display: block; height: 100%; background: var(--fg-3); }
+.bar-fill.k-tool { background: var(--brass-2); }
+.bar-fill.k-claim { background: var(--ok); }
+.bar-fill.k-text { background: var(--info); }
+.bar-fill.k-noop { background: var(--idle); }
+.bar-fill.k-error { background: var(--err); }
+
+/* ── Domain-detail drawer (tasks/goals/memory) ── */
+.dd-tag-row { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 10px; }
+.dd-section { margin-bottom: 14px; }
+.dd-section .label {
+  font-size: 10px; color: var(--fg-3);
+  text-transform: uppercase; letter-spacing: .06em;
+  margin-bottom: 4px; font-family: var(--font-mono);
+}
+.dd-text {
+  font-size: var(--fs-12); color: var(--fg-1); line-height: 1.5;
+  white-space: pre-wrap; word-break: break-word;
+}
+.dd-text.muted { color: var(--fg-2); }
+.dd-goal-stack { display: flex; flex-direction: column; gap: 4px; }
+.dd-goal-row {
+  display: grid; grid-template-columns: 48px 1fr;
+  gap: 8px; align-items: start;
+  padding: 6px 8px; border-radius: var(--r-1);
+  background: var(--bg-2); border: 1px solid var(--line-1);
+  font-size: var(--fs-12);
+}
+.dd-goal-row.is-active { border-color: var(--brass-3); background: var(--bg-3); }
+.dd-goal-tag {
+  font-family: var(--font-mono); font-size: 10px;
+  color: var(--fg-3); text-transform: uppercase;
+  letter-spacing: .05em;
+}
+.dd-goal-row.is-active .dd-goal-tag { color: var(--brass-1); }
+
+.chip.k-active   { color: var(--ok); border-color: rgb(107 158 107 / .4); }
+.chip.k-blocked  { color: var(--warn); border-color: rgb(194 157 94 / .4); }
+.chip.k-stalled  { color: var(--idle); }
+.chip.k-done     { color: var(--info); border-color: rgb(106 142 176 / .4); }

--- a/dashboard/src/styles/ds-cockpit-kit/index.css
+++ b/dashboard/src/styles/ds-cockpit-kit/index.css
@@ -1,0 +1,28 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Cockpit — keeper-v2 design-system UI kit index
+   Cascade order: tokens → layout → chrome → zones → views → overlays.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* tokens first — everything else references these vars */
+@import url("tokens.css");
+
+/* shell / grid */
+@import url("layout.css");
+
+/* chrome */
+@import url("sidebar.css");
+@import url("rail.css");
+
+/* main content area */
+@import url("center.css");
+
+/* zone chrome */
+@import url("kpi.css");
+@import url("lifeline.css");
+@import url("ticker.css");
+
+/* views */
+@import url("swimlanes.css");
+
+/* overlays */
+@import url("drawer.css");

--- a/dashboard/src/styles/ds-cockpit-kit/kpi.css
+++ b/dashboard/src/styles/ds-cockpit-kit/kpi.css
@@ -1,0 +1,40 @@
+/* kpi.css */
+.zone-kpi {
+  grid-area: kpi;
+  display: grid;
+  grid-template-columns: repeat(12, minmax(72px, 1fr));
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-1);
+  overflow-x: auto; overflow-y: hidden;
+  scrollbar-width: thin;
+}
+.kpi-cell {
+  position: relative; padding: 6px 10px;
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column; justify-content: space-between;
+  min-width: 0; overflow: hidden;
+}
+.kpi-cell .kpi-label { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kpi-cell:last-child { border-right: none; }
+.kpi-cell:hover { background: var(--bg-2); }
+.kpi-label {
+  font-size: 10px; font-weight: 600; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--fg-3); line-height: 1;
+}
+.kpi-row { display: flex; align-items: baseline; gap: 6px; min-width: 0; }
+.kpi-value {
+  font-family: var(--font-mono); font-size: var(--fs-20); font-weight: 500;
+  color: var(--fg-1); font-variant-numeric: tabular-nums; line-height: 1;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;
+}
+.kpi-unit { font-size: 10px; color: var(--fg-3); text-transform: uppercase; letter-spacing: .06em; }
+.kpi-delta { font-family: var(--font-mono); font-size: 10px; font-variant-numeric: tabular-nums; }
+.kpi-delta.up { color: var(--ok); }
+.kpi-delta.down { color: var(--err); }
+.kpi-delta.flat { color: var(--fg-4); }
+.kpi-spark { position: absolute; bottom: 4px; right: 4px; opacity: .6; pointer-events: none; }
+.kpi-cell.is-crit .kpi-value { color: var(--err); }
+.kpi-cell.is-warn .kpi-value { color: var(--warn); }
+.spark path, .spark polyline { fill: none; stroke: var(--brass-1); stroke-width: 1; opacity: .7; }
+.spark.s-err polyline { stroke: var(--err); }
+.spark.s-ok polyline { stroke: var(--ok); }

--- a/dashboard/src/styles/ds-cockpit-kit/layout.css
+++ b/dashboard/src/styles/ds-cockpit-kit/layout.css
@@ -1,0 +1,154 @@
+/* layout.css — cockpit grid + zones */
+.cockpit {
+  display: grid;
+  height: 100vh;
+  grid-template-columns: var(--w-sidebar) minmax(0, 1fr) var(--w-rail);
+  grid-template-rows: var(--h-topbar) var(--h-ticker) var(--h-kpi) var(--h-lifeline) minmax(0, 1fr) var(--h-composer);
+  grid-template-areas:
+    "topbar   topbar   topbar"
+    "ticker   ticker   ticker"
+    "kpi      kpi      kpi"
+    "lifeline lifeline lifeline"
+    "sidebar  center   rail"
+    "composer composer composer";
+  background: var(--bg-0);
+  overflow: hidden;
+}
+
+.zone-topbar {
+  grid-area: topbar;
+  display: flex; align-items: center; gap: var(--sp-4);
+  padding: 0 var(--sp-4);
+  background: var(--bg-1); border-bottom: 1px solid var(--line-1);
+  font-size: var(--fs-12); color: var(--fg-2);
+  min-width: 0; overflow: hidden;
+}
+.topbar-brand { font-weight: 600; color: var(--fg-1); letter-spacing: .02em; flex-shrink: 0; }
+.topbar-brand .brand-dot {
+  display: inline-block; width: 7px; height: 7px;
+  background: var(--brass-1); border-radius: 50%; margin-right: 8px;
+  box-shadow: 0 0 6px rgb(var(--brass-glow) / .5);
+}
+.topbar-sep { width: 1px; height: 14px; background: var(--line-2); flex-shrink: 0; }
+.topbar-crumbs { display: flex; gap: var(--sp-2); color: var(--fg-3); min-width: 0; overflow: hidden; }
+.topbar-crumbs b { color: var(--fg-1); font-weight: 500; }
+.topbar-spacer { flex: 1; }
+.topbar-pills { display: flex; gap: var(--sp-2); flex-shrink: 0; }
+.topbar-pill {
+  font-size: var(--fs-11); padding: 2px 8px;
+  border: 1px solid var(--line-2); border-radius: var(--r-1);
+  color: var(--fg-2); font-variant-numeric: tabular-nums;
+}
+.topbar-clock {
+  font-family: var(--font-mono); font-size: var(--fs-12);
+  color: var(--fg-2); font-variant-numeric: tabular-nums; flex-shrink: 0;
+}
+
+.zone-sidebar {
+  grid-area: sidebar;
+  background: var(--bg-1); border-right: 1px solid var(--line-1);
+  overflow: hidden; display: flex; flex-direction: column;
+  min-width: 0; min-height: 0;
+}
+
+.zone-center {
+  grid-area: center;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
+  min-width: 0; min-height: 0;
+  overflow: hidden;
+}
+
+.zone-rail {
+  grid-area: rail;
+  background: var(--bg-1); border-left: 1px solid var(--line-1);
+  overflow-y: auto; display: flex; flex-direction: column;
+  min-width: 0; min-height: 0;
+}
+
+.zone-composer {
+  grid-area: composer;
+  background: var(--bg-1); border-top: 1px solid var(--line-2);
+  display: flex; align-items: center; gap: var(--sp-3);
+  padding: 0 var(--sp-4);
+}
+.composer-input {
+  flex: 1; background: var(--bg-2);
+  border: 1px solid var(--line-2); border-radius: var(--r-1);
+  color: var(--fg-1); font: var(--fs-13)/1 var(--font-sans);
+  padding: 8px 12px; height: 32px; min-width: 0;
+}
+.composer-input::placeholder { color: var(--fg-4); }
+.composer-input:focus { border-color: var(--brass-3); outline: none; }
+
+.pane { display: flex; flex-direction: column; min-height: 0; min-width: 0; border-bottom: 1px solid var(--line-1); }
+.pane:last-child { border-bottom: none; }
+.pane-head {
+  height: 28px; flex-shrink: 0;
+  padding: 0 var(--sp-3);
+  display: flex; align-items: center; gap: var(--sp-3);
+  background: var(--bg-1); border-bottom: 1px solid var(--line-1);
+  font-size: var(--fs-11);
+}
+.pane-head .label { color: var(--fg-2); }
+.pane-head .pane-meta {
+  margin-left: auto; color: var(--fg-3);
+  font-family: var(--font-mono); font-size: 10px;
+}
+.pane-body { flex: 1; min-height: 0; overflow: auto; background: var(--bg-0); }
+
+.top-tabs { display: flex; gap: 2px; }
+.top-tabs button {
+  background: transparent; border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--fg-3); font-size: var(--fs-11); font-weight: 600;
+  letter-spacing: .06em; text-transform: uppercase;
+  padding: 4px 10px; cursor: pointer; border-radius: 0;
+}
+.top-tabs button:hover { color: var(--fg-1); background: transparent; }
+.top-tabs button.is-active { color: var(--brass-1); border-bottom-color: var(--brass-1); }
+
+.pane-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  border-bottom: none; min-height: 0; min-width: 0;
+}
+.pane-col {
+  display: flex; flex-direction: column;
+  min-height: 0; min-width: 0;
+  border-right: 1px solid var(--line-1);
+}
+.pane-col:last-child { border-right: none; }
+
+.empty, .loading {
+  display: flex; align-items: center; justify-content: center;
+  height: 100%; color: var(--fg-3); font-size: var(--fs-12); gap: var(--sp-2);
+}
+
+/* narrow viewports — drop the right rail so center gets real estate */
+@media (max-width: 1200px) {
+  .cockpit {
+    grid-template-columns: var(--w-sidebar) minmax(0, 1fr);
+    grid-template-areas:
+      "topbar   topbar"
+      "ticker   ticker"
+      "kpi      kpi"
+      "lifeline lifeline"
+      "sidebar  center"
+      "composer composer";
+  }
+  .zone-rail { display: none; }
+}
+@media (max-width: 900px) {
+  .cockpit {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "topbar"
+      "ticker"
+      "kpi"
+      "lifeline"
+      "center"
+      "composer";
+  }
+  .zone-sidebar { display: none; }
+}

--- a/dashboard/src/styles/ds-cockpit-kit/lifeline.css
+++ b/dashboard/src/styles/ds-cockpit-kit/lifeline.css
@@ -1,0 +1,53 @@
+/* lifeline.css */
+.zone-lifeline {
+  grid-area: lifeline;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-1);
+  display: grid;
+  grid-template-columns: var(--w-sidebar) minmax(0, 1fr) auto;
+  align-items: center;
+  overflow: hidden;
+}
+.lifeline-label {
+  padding: 0 var(--sp-3);
+  border-right: 1px solid var(--line-1);
+  height: 100%;
+  display: flex; align-items: center; gap: 6px;
+  font-size: var(--fs-11); color: var(--fg-3);
+  letter-spacing: .08em; text-transform: uppercase; font-weight: 600;
+  overflow: hidden; min-width: 0;
+}
+.lifeline-label .active-name {
+  color: var(--brass-1); text-transform: none;
+  font-family: var(--font-mono); letter-spacing: 0; font-weight: 500;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.lifeline-cells {
+  display: flex; gap: 1px;
+  padding: 4px var(--sp-3);
+  height: 100%; align-items: center;
+  overflow-x: auto; overflow-y: hidden; white-space: nowrap; min-width: 0;
+}
+.ll-cell {
+  display: inline-block; flex: 0 0 auto;
+  width: 10px; height: 16px; border-radius: 1px;
+  background: var(--bg-3); cursor: pointer;
+  transition: transform var(--t-fast) var(--ease), outline-color var(--t-fast);
+  outline: 1px solid transparent;
+}
+.ll-cell:hover { transform: scaleY(1.25); outline-color: var(--fg-2); }
+.ll-cell.is-active { outline-color: var(--brass-1); transform: scaleY(1.25); }
+.ll-cell.k-tool { background: var(--brass-2); }
+.ll-cell.k-claim { background: var(--ok); }
+.ll-cell.k-text { background: var(--info); }
+.ll-cell.k-noop { background: var(--idle); opacity: .5; }
+.ll-cell.k-error { background: var(--err); }
+.ll-gap { width: 4px; height: 16px; flex: 0 0 auto; border-left: 1px dashed var(--line-2); opacity: .4; }
+.lifeline-legend {
+  display: flex; gap: var(--sp-3);
+  padding: 0 var(--sp-3); border-left: 1px solid var(--line-1);
+  height: 100%; align-items: center;
+  font-size: 10px; color: var(--fg-3); font-family: var(--font-mono); flex-shrink: 0;
+}
+.lifeline-legend .lg { display: flex; align-items: center; gap: 4px; }
+.lifeline-legend .sw { width: 8px; height: 8px; border-radius: 1px; }

--- a/dashboard/src/styles/ds-cockpit-kit/rail.css
+++ b/dashboard/src/styles/ds-cockpit-kit/rail.css
@@ -1,0 +1,148 @@
+/* rail.css — ops card stack */
+.ops-card { border-bottom: 1px solid var(--line-1); }
+.ops-card:last-child { border-bottom: none; }
+.ops-head {
+  height: 28px; padding: 0 var(--sp-3);
+  display: flex; align-items: center; gap: var(--sp-2);
+  cursor: pointer; user-select: none; font-size: var(--fs-11);
+}
+.ops-head:hover { background: var(--bg-2); }
+.ops-head .label { flex: 1; color: var(--fg-2); }
+.ops-head .chev { color: var(--fg-3); font-size: 10px; transition: transform var(--t-fast) var(--ease); }
+.ops-card.is-collapsed .chev { transform: rotate(-90deg); }
+.ops-card.is-collapsed .ops-body { display: none; }
+.ops-body { padding: var(--sp-3) var(--sp-3) var(--sp-4); font-size: var(--fs-12); line-height: 1.4; color: var(--fg-2); }
+
+.stat-row {
+  display: grid; grid-template-columns: 80px minmax(0, 1fr);
+  gap: var(--sp-2); padding: 3px 0;
+  font-size: var(--fs-12); min-width: 0;
+}
+.stat-row .k {
+  color: var(--fg-3); font-size: var(--fs-11);
+  font-weight: 500; letter-spacing: .04em; text-transform: uppercase; padding-top: 1px;
+}
+.stat-row .v {
+  color: var(--fg-1); font-variant-numeric: tabular-nums;
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.stat-row .v.wrap { white-space: normal; overflow: visible; text-overflow: clip; }
+
+.goal-text {
+  font-size: var(--fs-12); color: var(--fg-1); line-height: 1.5;
+  background: var(--bg-2); border-left: 2px solid var(--brass-3);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: 0 var(--r-1) var(--r-1) 0; margin: 4px 0 8px;
+}
+.goal-text.is-short { border-left-color: var(--brass-1); }
+.goal-text.is-mid { border-left-color: var(--brass-2); }
+.goal-text.is-long { border-left-color: var(--brass-3); }
+
+.blocker-banner {
+  background: rgb(196 106 90 / .08);
+  border: 1px solid rgb(196 106 90 / .3);
+  border-left: 3px solid var(--err);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--r-1);
+  font-size: var(--fs-12); color: var(--fg-1); line-height: 1.4;
+  margin-bottom: 6px;
+}
+.blocker-banner .blocker-class {
+  font-family: var(--font-mono); font-size: var(--fs-11);
+  color: var(--err); text-transform: uppercase; letter-spacing: .05em; margin-bottom: 4px;
+}
+
+.cascade-models { display: flex; flex-direction: column; gap: 2px; padding: 2px 0; }
+.cascade-model {
+  display: flex; align-items: center; gap: 6px;
+  padding: 3px 6px; background: var(--bg-2);
+  border-radius: var(--r-1); font-size: var(--fs-11);
+}
+
+/* Tool chips */
+.tool-chips {
+  display: flex; flex-wrap: wrap; gap: 4px;
+  padding: 3px 0 2px;
+}
+.tool-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 7px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-2);
+  line-height: 1.4;
+}
+.tool-chip.is-last {
+  border-color: var(--brass-1);
+  color: var(--brass-1);
+  background: rgb(var(--brass-glow) / 0.08);
+}
+.tool-count {
+  font-size: 9px; color: var(--fg-3);
+  padding: 0 3px; background: var(--bg-3);
+  border-radius: 6px; margin-left: 2px;
+}
+.tool-chip.is-last .tool-count {
+  color: var(--brass-1);
+  background: rgb(var(--brass-glow) / 0.15);
+}
+
+/* Tool Timeline (inspector tab) */
+.tl-stats { display: flex; flex-direction: column; gap: 0; }
+.tl-track {
+  position: relative;
+  height: 60px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-1);
+  margin: 6px 0 4px;
+  overflow: hidden;
+}
+.tl-axis {
+  position: absolute; left: 0; right: 0; bottom: 0;
+  height: 18px; border-top: 1px dashed var(--line-2);
+}
+.tl-tick {
+  position: absolute; top: 0; bottom: 0;
+  border-left: 1px dashed var(--line-2);
+}
+.tl-tick span {
+  position: absolute; top: 2px; left: 4px;
+  font-family: var(--font-mono); font-size: 9px;
+  color: var(--fg-3);
+}
+.tl-dots {
+  position: absolute; left: 0; right: 0;
+  top: 8px; bottom: 22px;
+}
+.tl-dot {
+  position: absolute;
+  width: 7px; height: 7px; border-radius: 50%;
+  top: 50%; transform: translate(-50%, -50%);
+  cursor: pointer;
+  border: 1px solid rgb(0 0 0 / 0.3);
+  transition: transform .1s;
+}
+.tl-dot:hover { transform: translate(-50%, -50%) scale(1.6); z-index: 2; }
+.tl-dot.is-err {
+  box-shadow: 0 0 0 1px var(--err);
+}
+
+.tl-legend {
+  display: flex; flex-direction: column; gap: 0;
+  max-height: 180px; overflow-y: auto;
+}
+.tl-legend-row {
+  display: flex; align-items: center; gap: 6px;
+  padding: 3px 2px;
+  font-size: 11px;
+  border-bottom: 1px dotted var(--line-2);
+}
+.tl-legend-row:last-child { border-bottom: none; }
+.tl-swatch {
+  width: 8px; height: 8px; border-radius: 2px;
+  flex-shrink: 0;
+}

--- a/dashboard/src/styles/ds-cockpit-kit/sidebar.css
+++ b/dashboard/src/styles/ds-cockpit-kit/sidebar.css
@@ -1,0 +1,138 @@
+/* sidebar.css */
+
+/* ── Domain rail tabs (top of sidebar) ── */
+.sb-railtabs {
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  background: var(--bg-0);
+  border-bottom: 1px solid var(--line-2);
+  flex-shrink: 0;
+}
+.sb-railtab {
+  background: transparent; border: none; border-right: 1px solid var(--line-1);
+  border-bottom: 2px solid transparent;
+  padding: 8px 4px 6px; cursor: pointer;
+  display: flex; flex-direction: column; align-items: center; gap: 2px;
+  color: var(--fg-3);
+}
+.sb-railtab:last-child { border-right: none; }
+.sb-railtab:hover { background: var(--bg-2); color: var(--fg-1); }
+.sb-railtab.is-active {
+  background: var(--bg-1); color: var(--brass-1);
+  border-bottom-color: var(--brass-1);
+}
+.sb-railtab-glyph {
+  font-size: 14px; line-height: 1;
+  font-family: var(--font-mono);
+}
+.sb-railtab-label {
+  font-size: 9px; letter-spacing: .04em; text-transform: uppercase;
+  font-family: var(--font-mono); line-height: 1;
+}
+
+.sb-body {
+  flex: 1; min-height: 0;
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+
+/* ── Generic sidebar items (tasks / goals / decisions / memory) ── */
+.sb-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  border-bottom: 1px solid var(--line-1);
+  align-items: start;
+}
+.sb-item:hover { background: var(--bg-2); }
+.sb-item.is-active { background: var(--bg-3); border-left-color: var(--brass-1); }
+.sb-item-main { min-width: 0; }
+.sb-item-title {
+  font-size: var(--fs-12); color: var(--fg-1);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  line-height: 1.35;
+}
+.sb-item-sub {
+  font-size: 10px; color: var(--fg-3);
+  margin-top: 2px; font-variant-numeric: tabular-nums;
+}
+.sb-item-tag {
+  font-family: var(--font-mono); font-size: 9px;
+  padding: 2px 5px; border-radius: var(--r-1);
+  background: var(--bg-3); color: var(--fg-3);
+  border: 1px solid var(--line-1);
+  letter-spacing: .04em; text-transform: uppercase;
+  line-height: 1.2; align-self: start;
+  margin-top: 1px;
+}
+.sb-tag-active   { color: var(--ok);    border-color: rgb(107 158 107 / .4); }
+.sb-tag-blocked  { color: var(--warn);  border-color: rgb(194 157 94 / .4); }
+.sb-tag-stalled  { color: var(--idle);  }
+.sb-tag-done     { color: var(--info);  border-color: rgb(106 142 176 / .4); }
+.sb-tag-short    { color: var(--ok);    border-color: rgb(107 158 107 / .4); }
+.sb-tag-mid      { color: var(--brass-1); border-color: var(--brass-3); }
+.sb-tag-long     { color: var(--info);  border-color: rgb(106 142 176 / .4); }
+.sb-tag-tool     { color: var(--brass-1); border-color: var(--brass-3); }
+.sb-tag-claim    { color: var(--ok);    border-color: rgb(107 158 107 / .4); }
+.sb-tag-text     { color: var(--info);  border-color: rgb(106 142 176 / .4); }
+.sb-tag-error    { color: var(--err);   border-color: rgb(196 106 90 / .4); }
+.sb-tag-noop     { color: var(--fg-4); }
+.sb-tag-cont     { color: var(--brass-1); border-color: var(--brass-3); }
+.sb-tag-spk      { color: var(--info); }
+.sb-tag-note     { color: var(--fg-3); }
+
+.sb-empty {
+  padding: 20px 12px; color: var(--fg-3);
+  font-size: var(--fs-11); text-align: center;
+}
+
+.sb-filter-4 { grid-template-columns: repeat(4, 1fr); }
+
+.sidebar-head {
+  padding: 10px 12px 6px;
+  display: flex; align-items: center; justify-content: space-between;
+  flex-shrink: 0;
+}
+.sidebar-head .count {
+  font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-3);
+}
+.sb-filter {
+  display: grid; grid-template-columns: repeat(5, 1fr); gap: 2px;
+  padding: 0 8px 6px; border-bottom: 1px solid var(--line-1); flex-shrink: 0;
+}
+.sb-tab {
+  background: var(--bg-2);
+  border: 1px solid var(--line-1);
+  border-radius: var(--r-1);
+  color: var(--fg-3);
+  font-size: 10px; font-family: var(--font-mono);
+  letter-spacing: .04em; padding: 4px 2px; cursor: pointer;
+  display: flex; flex-direction: column; align-items: center; gap: 1px; line-height: 1;
+}
+.sb-tab:hover { background: var(--bg-3); color: var(--fg-1); }
+.sb-tab.is-active { background: var(--bg-3); border-color: var(--brass-3); color: var(--brass-1); }
+.sb-tab-count { font-size: 10px; color: var(--fg-4); font-variant-numeric: tabular-nums; }
+.sb-tab.is-active .sb-tab-count { color: var(--brass-1); }
+.sb-search { padding: 6px 8px; border-bottom: 1px solid var(--line-1); flex-shrink: 0; }
+.sb-search input {
+  width: 100%; background: var(--bg-2);
+  border: 1px solid var(--line-1); border-radius: var(--r-1);
+  color: var(--fg-1); font: 11px/1 var(--font-mono);
+  padding: 5px 8px; height: 24px;
+}
+.sb-search input:focus { border-color: var(--brass-3); outline: none; }
+.sidebar-list { flex: 1; min-height: 0; padding: 0 0 8px; overflow-y: auto; }
+.keeper-row {
+  display: grid; grid-template-columns: 8px minmax(0, 1fr) auto;
+  align-items: center; gap: 8px;
+  padding: 6px 12px 6px 10px; cursor: pointer;
+  border-left: 2px solid transparent;
+  font-size: var(--fs-12); min-width: 0;
+}
+.keeper-row:hover { background: var(--bg-2); }
+.keeper-row.is-active { background: var(--bg-3); border-left-color: var(--brass-1); }
+.keeper-row .name { color: var(--fg-1); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.keeper-row.is-active .name { color: var(--brass-1); }
+.keeper-row .meta { font-family: var(--font-mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }

--- a/dashboard/src/styles/ds-cockpit-kit/swimlanes.css
+++ b/dashboard/src/styles/ds-cockpit-kit/swimlanes.css
@@ -1,0 +1,469 @@
+/* swimlanes.css — fleet timeline (v2)
+   Visual system:
+   - track: holds time, density heatmap (bg), grid (mid), glyphs (fg)
+   - glyph: shape = kind, width = latency, color = kind, outline = error
+   - cluster: pill with count when glyphs would overlap
+   - now: single full-height column (between axis + all lanes)
+   - crosshair: selection mark per-lane, brass
+*/
+
+:root {
+  --sl-label-w: 180px;
+  --sl-row-h: 22px;
+  --sl-row-h-tall: 28px;
+  --sl-row-h-compact: 18px;
+}
+
+.sl-toolbar {
+  display: flex; align-items: center; gap: 6px;
+  padding: 0 var(--sp-3); height: 28px;
+  background: linear-gradient(to bottom, var(--bg-1), var(--bg-1) 80%, var(--bg-0));
+  border-bottom: 1px solid var(--line-2);
+  font-size: var(--fs-11); flex-shrink: 0;
+  white-space: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+.sl-toolbar .label {
+  color: var(--fg-3); letter-spacing: .08em; font-weight: 600;
+  font-size: 10px;
+}
+.sl-tb-brand { display: inline-flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.sl-tb-sep {
+  width: 1px; height: 14px;
+  background: var(--line-2);
+  flex-shrink: 0;
+  margin: 0 2px;
+}
+.sl-tb-toggles { display: inline-flex; gap: 8px; flex-shrink: 0; }
+.sl-toolbar .pane-meta {
+  color: var(--fg-2);
+  font-family: var(--font-mono); font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+.sl-range {
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 10px;
+  color: var(--fg-4);
+  flex-shrink: 0;
+  padding-left: var(--sp-3);
+}
+.sl-range b { color: var(--fg-2); font-weight: 500; }
+
+.sl-toggle {
+  display: inline-flex; align-items: center; gap: 4px;
+  font: 10px/1 var(--font-mono); color: var(--fg-3);
+  cursor: pointer; user-select: none;
+  letter-spacing: .04em;
+}
+.sl-toggle input {
+  appearance: none;
+  width: 9px; height: 9px; margin: 0;
+  border: 1px solid var(--line-2); border-radius: 2px;
+  background: var(--bg-2); cursor: pointer;
+  position: relative; flex-shrink: 0;
+}
+.sl-toggle input:checked {
+  background: var(--brass-3); border-color: var(--brass-2);
+}
+.sl-toggle input:checked::after {
+  content: ""; position: absolute; inset: 1px;
+  background: var(--brass-1); border-radius: 1px;
+}
+
+.wf-scale-ctrl {
+  display: inline-flex;
+  gap: 1px;
+  flex-shrink: 0;
+}
+.wf-scale-ctrl button {
+  padding: 3px 6px;
+  font-size: 10px;
+  min-width: 22px;
+}
+.wf-scale-density button {
+  min-width: 20px; text-align: center;
+  font-family: var(--font-mono);
+}
+
+/* ─── axis ─── */
+.sl-axis {
+  display: grid;
+  grid-template-columns: var(--sl-label-w) minmax(0, 1fr);
+  height: 24px; flex-shrink: 0;
+  background: var(--bg-1); border-bottom: 1px solid var(--line-1);
+  position: relative;
+}
+.sl-axis-label {
+  display: flex; align-items: center; padding: 0 var(--sp-3);
+  border-right: 1px solid var(--line-1);
+  color: var(--fg-3); font-size: 9px; letter-spacing: .1em;
+}
+.sl-axis-track { position: relative; }
+.sl-tick {
+  position: absolute; top: 6px;
+  transform: translateX(-50%);
+  font-family: var(--font-mono); font-size: 10px;
+  color: var(--fg-4); white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.sl-tick.is-major { color: var(--fg-2); }
+
+.sl-now-mark {
+  position: absolute; top: 4px;
+  transform: translateX(-50%);
+  font: 9px/1 var(--font-mono); color: var(--brass-1);
+  letter-spacing: .12em;
+  padding: 2px 4px;
+  background: var(--bg-0);
+  border: 1px solid var(--brass-3);
+  border-radius: 2px;
+  z-index: 3;
+}
+
+/* ─── grid wrap ─── */
+.sl-grid-wrap {
+  position: relative;
+  padding: 2px 0 6px;
+  background: var(--bg-0);
+  overflow: auto;
+  min-height: 0;
+  flex: 1;
+}
+.sl-density-compact { --sl-row-current-h: var(--sl-row-h-compact); }
+.sl-density-normal  { --sl-row-current-h: var(--sl-row-h); }
+.sl-density-tall    { --sl-row-current-h: var(--sl-row-h-tall); }
+
+/* now-column spans all lanes */
+.sl-now-column {
+  position: absolute; top: 0; bottom: 0;
+  width: 1px;
+  background: linear-gradient(to bottom,
+    rgb(var(--brass-glow) / .0),
+    rgb(var(--brass-glow) / .7) 6%,
+    rgb(var(--brass-glow) / .7) 94%,
+    rgb(var(--brass-glow) / .0));
+  box-shadow: 0 0 4px rgb(var(--brass-glow) / .5);
+  pointer-events: none;
+  z-index: 4;
+}
+.sl-grid-wrap[data-pulse="true"] .sl-now-column {
+  animation: sl-pulse 2.6s ease-in-out infinite;
+}
+@keyframes sl-pulse {
+  0%, 100% { opacity: .5; }
+  50% { opacity: 1; }
+}
+
+/* ─── lane row ─── */
+.sl-row {
+  display: grid;
+  grid-template-columns: var(--sl-label-w) minmax(0, 1fr);
+  height: var(--sl-row-current-h, var(--sl-row-h));
+  align-items: center;
+  border-bottom: 1px solid var(--line-1);
+  cursor: pointer;
+  transition: background var(--t-fast);
+}
+.sl-row:hover { background: rgb(255 255 255 / .02); }
+.sl-row.is-active { background: var(--bg-2); }
+.sl-row.is-active .sl-name { color: var(--brass-1); }
+.sl-row.is-active .sl-status.dot-running { box-shadow: 0 0 6px rgb(var(--brass-glow) / .8); }
+
+/* status tinted backgrounds — very subtle */
+.sl-row.st-error     { background: rgb(196 106 90 / .04); }
+.sl-row.st-error.is-active { background: rgb(196 106 90 / .10); }
+.sl-row.st-blocker   { background: rgb(201 162 74 / .04); }
+.sl-row.st-blocker.is-active { background: rgb(201 162 74 / .09); }
+.sl-row.st-running   { background: rgb(var(--brass-glow) / .02); }
+
+/* collapsed empty lane — smaller, muted */
+.sl-row-collapsed {
+  height: 14px;
+  opacity: .45;
+  border-bottom: 1px solid transparent;
+}
+.sl-row-collapsed:hover { opacity: .9; }
+.sl-row-collapsed .sl-label { font-size: 10px; }
+.sl-row-collapsed .sl-meta { font-size: 9px; }
+.sl-track-empty { position: relative; }
+.sl-empty-note {
+  position: absolute; left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  font: 9px/1 var(--font-mono); color: var(--fg-4);
+  letter-spacing: .08em;
+}
+
+/* ─── lane label ─── */
+.sl-label {
+  display: flex; align-items: center; gap: 6px;
+  padding: 0 var(--sp-3);
+  height: 100%;
+  border-right: 1px solid var(--line-1);
+  min-width: 0; overflow: hidden;
+  font-size: var(--fs-11);
+  position: relative;
+  z-index: 1;
+  background: inherit;
+}
+.sl-status {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0; background: var(--idle);
+}
+.sl-status.dot-running { background: var(--ok); box-shadow: 0 0 4px var(--ok); }
+.sl-status.dot-error { background: var(--err); }
+.sl-status.dot-blocker { background: var(--warn); }
+.sl-status.dot-stalled { background: var(--stalled); }
+.sl-status.dot-idle { background: var(--idle); }
+
+.sl-name {
+  color: var(--fg-1); font-weight: 500;
+  flex: 1; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+.sl-meta {
+  font-family: var(--font-mono); font-size: 10px;
+  color: var(--fg-3); flex-shrink: 0;
+  display: flex; gap: 3px;
+}
+.sl-meta b { color: var(--fg-1); font-weight: 500; }
+.sl-meta .err { color: var(--err); }
+
+/* mini-sparkline in label */
+.sl-spark {
+  display: inline-flex; align-items: flex-end;
+  height: 10px; width: 28px;
+  gap: 1px; flex-shrink: 0;
+  opacity: .55;
+}
+.sl-row:hover .sl-spark,
+.sl-row.is-active .sl-spark { opacity: 1; }
+.sl-spark-bar {
+  flex: 1; min-width: 1px;
+  background: var(--fg-3);
+  border-radius: 1px 1px 0 0;
+}
+.sl-spark-bar.is-err { background: var(--err); }
+.sl-row.is-active .sl-spark-bar { background: var(--brass-2); }
+.sl-row.is-active .sl-spark-bar.is-err { background: var(--err); }
+
+/* ─── track ─── */
+.sl-track {
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* density heatmap: sits behind grid + glyphs */
+.sl-heatmap {
+  position: absolute; inset: 0;
+  pointer-events: none;
+}
+.sl-grid-wrap[data-heatmap="false"] .sl-heatmap { display: none; }
+.sl-heat {
+  position: absolute; top: 2px; bottom: 2px;
+  background: var(--brass-2);
+}
+.sl-heat.is-err { background: var(--err); }
+
+.sl-grid {
+  position: absolute; top: 0; bottom: 0;
+  width: 1px;
+  background: var(--line-1);
+  opacity: .4;
+  pointer-events: none;
+}
+.sl-grid.is-major {
+  background: var(--line-2);
+  opacity: .7;
+}
+
+.sl-crosshair {
+  position: absolute; top: 0; bottom: 0;
+  width: 1px;
+  background: var(--brass-1);
+  opacity: .8;
+  pointer-events: none;
+  box-shadow: 0 0 3px rgb(var(--brass-glow) / .7);
+  z-index: 2;
+}
+
+/* ─── glyphs ─── */
+.sl-glyph {
+  position: absolute; top: 50%;
+  transform: translate(-50%, -50%);
+  width: var(--w, 0.5%);
+  height: 60%;
+  cursor: pointer;
+  z-index: 2;
+  display: flex; align-items: center; justify-content: center;
+}
+.sl-glyph-mark {
+  display: block; width: 100%; height: 100%;
+  min-width: 3px;
+  background: var(--fg-3);
+  border-radius: 1px;
+  transition: transform var(--t-fast) var(--ease), box-shadow var(--t-fast);
+}
+
+/* tool = filled bar, brass */
+.sl-glyph.k-tool .sl-glyph-mark {
+  background: var(--brass-2);
+}
+/* claim = diamond, green */
+.sl-glyph.k-claim .sl-glyph-mark {
+  background: var(--ok);
+  transform: rotate(45deg) scale(.75);
+  border-radius: 1px;
+  min-width: 5px;
+  width: 5px; height: 5px;
+  margin: auto;
+}
+.sl-glyph.k-claim {
+  width: auto !important;
+  min-width: 7px;
+}
+/* text = thin line, info */
+.sl-glyph.k-text .sl-glyph-mark {
+  background: var(--info);
+  opacity: .75;
+  height: 40%;
+  min-width: 2px;
+}
+/* noop = tiny dim tick */
+.sl-glyph.k-noop {
+  width: 2px !important;
+  height: 30% !important;
+}
+.sl-glyph.k-noop .sl-glyph-mark {
+  background: var(--fg-4);
+  min-width: 2px;
+  opacity: .6;
+}
+/* error = cross, red */
+.sl-glyph.k-error .sl-glyph-mark {
+  background: var(--err);
+  min-width: 8px;
+  width: 8px; height: 8px;
+  clip-path: polygon(20% 0, 50% 30%, 80% 0, 100% 20%, 70% 50%, 100% 80%, 80% 100%, 50% 70%, 20% 100%, 0 80%, 30% 50%, 0 20%);
+}
+.sl-glyph.k-error {
+  width: auto !important;
+  min-width: 10px;
+  z-index: 3;
+}
+
+.sl-glyph.is-err .sl-glyph-mark {
+  outline: 1px solid var(--err);
+  outline-offset: 1px;
+}
+.sl-glyph:hover {
+  z-index: 5;
+}
+.sl-glyph:hover .sl-glyph-mark {
+  transform: scale(1.5);
+  box-shadow: 0 0 6px currentColor;
+  filter: brightness(1.25);
+}
+.sl-glyph.k-claim:hover .sl-glyph-mark {
+  transform: rotate(45deg) scale(1.1);
+}
+.sl-glyph.is-active {
+  z-index: 4;
+}
+.sl-glyph.is-active .sl-glyph-mark {
+  box-shadow: 0 0 0 2px var(--bg-0), 0 0 0 3px var(--brass-1), 0 0 6px rgb(var(--brass-glow) / .7);
+  transform: scale(1.3);
+  filter: brightness(1.2);
+}
+.sl-glyph.k-claim.is-active .sl-glyph-mark {
+  transform: rotate(45deg) scale(1.05);
+}
+
+/* ─── handoff overlay ─── */
+.sl-handoff-svg {
+  position: absolute;
+  top: 0; left: 0;
+  pointer-events: none;
+  z-index: 3;
+  overflow: visible;
+}
+.sl-grid-wrap[data-handoffs="false"] .sl-handoff-svg { display: none; }
+
+.sl-ho { pointer-events: auto; cursor: pointer; }
+.sl-ho-hit {
+  fill: none;
+  stroke: transparent;
+  stroke-width: 10;
+  pointer-events: stroke;
+}
+.sl-ho-line {
+  fill: none;
+  stroke: var(--brass-3);
+  stroke-width: 1;
+  opacity: .35;
+  stroke-linecap: round;
+  transition: stroke var(--t-fast), stroke-width var(--t-fast), opacity var(--t-fast);
+  stroke-dasharray: 2 3;
+}
+.sl-ho-head {
+  fill: var(--brass-2);
+  opacity: .6;
+  transition: r var(--t-fast), fill var(--t-fast), opacity var(--t-fast);
+}
+.sl-ho-tail {
+  fill: var(--brass-3);
+  opacity: .45;
+}
+.sl-ho.is-involved .sl-ho-line { stroke: var(--brass-1); opacity: .65; stroke-dasharray: none; }
+.sl-ho.is-involved .sl-ho-head { fill: var(--brass-1); opacity: .9; }
+.sl-ho:hover .sl-ho-line {
+  stroke: var(--brass-1);
+  stroke-width: 1.6;
+  opacity: 1;
+  stroke-dasharray: none;
+  filter: drop-shadow(0 0 3px rgb(var(--brass-glow) / .7));
+}
+.sl-ho:hover .sl-ho-head { fill: var(--brass-1); opacity: 1; }
+.sl-ho.is-active .sl-ho-line {
+  stroke: var(--brass-1);
+  stroke-width: 1.8;
+  opacity: 1;
+  stroke-dasharray: none;
+}
+.sl-ho.is-active .sl-ho-head { fill: var(--brass-1); opacity: 1; }
+
+/* cluster pill */
+.sl-cluster {
+  position: absolute; top: 50%;
+  transform: translate(-50%, -50%);
+  min-width: 14px; height: 14px;
+  padding: 0 3px;
+  border-radius: 7px;
+  font: 600 9px/14px var(--font-mono);
+  text-align: center;
+  cursor: pointer;
+  z-index: 3;
+  background: var(--bg-3);
+  color: var(--fg-1);
+  border: 1px solid var(--line-3);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+  transition: transform var(--t-fast) var(--ease), box-shadow var(--t-fast);
+}
+.sl-cluster.k-tool { border-color: var(--brass-3); color: var(--brass-1); }
+.sl-cluster.k-claim { border-color: var(--ok); color: var(--ok); }
+.sl-cluster.k-error,
+.sl-cluster.is-err {
+  background: var(--err);
+  border-color: var(--err);
+  color: var(--bg-0);
+}
+.sl-cluster:hover {
+  transform: translate(-50%, -50%) scale(1.2);
+  box-shadow: 0 0 0 2px var(--bg-0), 0 0 0 3px var(--brass-1);
+  z-index: 5;
+}

--- a/dashboard/src/styles/ds-cockpit-kit/ticker.css
+++ b/dashboard/src/styles/ds-cockpit-kit/ticker.css
@@ -1,0 +1,83 @@
+/* styles/ticker.css — Fleet Ticker strip, stock-tape aesthetic */
+
+.zone-ticker {
+  grid-area: ticker;
+  background: linear-gradient(to bottom, var(--bg-1), var(--bg-0));
+  border-bottom: 1px solid var(--line-2);
+  overflow: hidden;
+  position: relative;
+}
+.zone-ticker::before,
+.zone-ticker::after {
+  content: ""; position: absolute; top: 0; bottom: 0; width: 40px; z-index: 2;
+  pointer-events: none;
+}
+.zone-ticker::before { left: 0; background: linear-gradient(to right, var(--bg-1), transparent); }
+.zone-ticker::after  { right: 0; background: linear-gradient(to left,  var(--bg-1), transparent); }
+
+.tk-rail {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  height: 100%;
+  padding: 0 var(--sp-2);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+}
+.tk-rail::-webkit-scrollbar { display: none; }
+
+.tk-item {
+  display: flex; align-items: center; gap: 6px;
+  flex-shrink: 0;
+  padding: 6px 14px;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--line-1);
+  border-radius: 0;
+  cursor: pointer;
+  transition: background .12s ease;
+  font-family: var(--font-mono);
+  position: relative;
+}
+.tk-item:last-child { border-right: none; }
+.tk-item:hover { background: var(--bg-2); color: var(--fg-1); }
+.tk-item.is-active {
+  background: var(--bg-3);
+  box-shadow: inset 0 -2px 0 var(--brass-1);
+}
+.tk-item.is-active .tk-sym { color: var(--brass-1); }
+
+.tk-dot { display: inline-flex; }
+
+.tk-sym {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .06em;
+  color: var(--fg-1);
+  min-width: 36px;
+}
+.tk-price {
+  font-size: 11px;
+  color: var(--fg-2);
+  min-width: 34px;
+  text-align: right;
+}
+
+.tk-spark {
+  width: 70px; height: 18px; flex-shrink: 0;
+  display: block;
+}
+
+.tk-delta {
+  font-size: 10px;
+  letter-spacing: .02em;
+  min-width: 42px;
+  text-align: right;
+  color: var(--fg-3);
+}
+.tk-arrow { display: inline-block; margin-right: 2px; font-size: 8px; }
+
+.tk-item.tk-up   .tk-delta { color: var(--ok); }
+.tk-item.tk-down .tk-delta { color: var(--err); }
+.tk-item.tk-flat .tk-delta { color: var(--fg-3); }

--- a/dashboard/src/styles/ds-cockpit-kit/tokens.css
+++ b/dashboard/src/styles/ds-cockpit-kit/tokens.css
@@ -1,0 +1,157 @@
+/* MASC Cockpit — Dark Brass tokens
+   Color discipline: bg is almost-black with 2-3% warm tint.
+   Brass accent used ONLY for active/running state. Status colors
+   reserved for data, never chrome. Everything else is grayscale. */
+
+:root {
+  /* Surface stack — 4 steps from bg to floating */
+  --bg-0: #0c0b08;         /* page bg */
+  --bg-1: #141210;         /* topbar / composer */
+  --bg-2: #1a1815;         /* panel surface */
+  --bg-3: #211e1a;         /* elevated card */
+  --bg-4: #2a2621;         /* hover / active row */
+
+  /* Hairlines — warm neutral, barely visible */
+  --line-1: #2a2520;       /* default border */
+  --line-2: #3a332c;       /* emphasized border */
+  --line-3: #4a4137;       /* divider between zones */
+
+  /* Text — 4 steps, never pure white */
+  --fg-1: #f0e9dc;         /* primary */
+  --fg-2: #b8ad9a;         /* secondary */
+  --fg-3: #7a7065;         /* tertiary / labels */
+  --fg-4: #4a453e;         /* disabled / placeholder */
+
+  /* Brass — the ONE accent. Used for: running state, focused row,
+     active tab underline, primary button. Nothing else. */
+  --brass-1: #d4a14a;
+  --brass-2: #b8843a;
+  --brass-3: #8a5f28;
+  --brass-glow: 212 161 74;  /* rgb triplet for alpha */
+
+  /* Status — muted, desaturated. Never neon. */
+  --ok:     #6b9e6b;       /* done, success */
+  --warn:   #c9a24a;       /* at-risk, degraded */
+  --err:    #c46a5a;       /* failed, blocker */
+  --info:   #6a8eb0;       /* pending, queued */
+  --idle:   #6a6a6a;       /* silent, noop */
+  --stalled:#8a6aa0;       /* stalled, drift */
+
+  /* Type scale — tabular, compact */
+  --font-sans: ui-sans-serif, -apple-system, "SF Pro Text", "Inter", system-ui, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+
+  --fs-11: 11px;           /* micro labels, badges */
+  --fs-12: 12px;           /* table body, metadata */
+  --fs-13: 13px;           /* default body */
+  --fs-14: 14px;           /* card titles */
+  --fs-16: 16px;           /* KPI medium */
+  --fs-20: 20px;           /* KPI large */
+  --fs-28: 28px;           /* hero number */
+
+  --lh-tight: 1.2;
+  --lh-body: 1.45;
+
+  /* Spacing — 4px base */
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 20px;
+  --sp-6: 24px;
+
+  /* Radius — small only; this is an ops tool */
+  --r-1: 3px;
+  --r-2: 5px;
+  --r-3: 8px;
+
+  /* Elevation */
+  --shadow-1: 0 1px 0 rgb(0 0 0 / .4), 0 0 0 1px var(--line-1);
+  --shadow-2: 0 2px 8px rgb(0 0 0 / .5), 0 0 0 1px var(--line-2);
+
+  /* Zone heights */
+  --h-topbar: 36px;
+  --h-ticker: 32px;
+  --h-kpi: 56px;
+  --h-lifeline: 28px;
+  --h-composer: 48px;
+
+  /* Grid widths */
+  --w-sidebar: 168px;
+  --w-rail: 300px;
+
+  /* Motion */
+  --ease: cubic-bezier(.2, .7, .2, 1);
+  --t-fast: 120ms;
+  --t-med: 200ms;
+}
+
+/* Reset / base */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; height: 100%; }
+body {
+  background: var(--bg-0);
+  color: var(--fg-1);
+  font: var(--fs-13)/var(--lh-body) var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "cv08", "ss01";
+}
+code, kbd, samp, pre, .mono { font-family: var(--font-mono); }
+
+/* Utilities */
+.tnum { font-variant-numeric: tabular-nums; }
+.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.clamp-3 { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+.muted { color: var(--fg-3); }
+.dim { color: var(--fg-2); }
+
+/* Status dot — 6px solid, used in rows & KPI */
+.dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; vertical-align: middle; }
+.dot-ok { background: var(--ok); }
+.dot-warn { background: var(--warn); }
+.dot-err { background: var(--err); }
+.dot-info { background: var(--info); }
+.dot-idle { background: var(--idle); }
+.dot-stalled { background: var(--stalled); }
+.dot-running { background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--brass-glow) / .6); }
+
+/* Label — small-caps lock-up used on every panel title */
+.label {
+  font-size: var(--fs-11);
+  font-weight: 600;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+
+/* Scrollbar — thin, warm */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--line-2); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--line-3); }
+
+/* Focus */
+:focus-visible {
+  outline: 1px solid var(--brass-1);
+  outline-offset: 1px;
+}
+
+/* Buttons — minimal chrome */
+button, .btn {
+  font: inherit;
+  background: transparent;
+  color: var(--fg-2);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-1);
+  padding: 4px 10px;
+  cursor: pointer;
+  transition: background var(--t-fast) var(--ease), color var(--t-fast) var(--ease);
+}
+button:hover, .btn:hover { background: var(--bg-3); color: var(--fg-1); }
+button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1); border-color: var(--brass-3); }

--- a/dashboard/src/styles/ds-dashboard-kit/a2a.css
+++ b/dashboard/src/styles/ds-dashboard-kit/a2a.css
@@ -1,0 +1,38 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · a2a
+   Agent-to-agent dialogue rows
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ─── A2A DIALOGUE ────────────────────────────────────── */
+.a2a { display: flex; flex-direction: column; gap: 4px; padding: 4px 0; }
+.a2a-msg {
+  display: grid;
+  grid-template-columns: 48px 26px auto 26px auto 1fr auto;
+  align-items: center; gap: 8px;
+  padding: 7px 10px;
+  border: 1px solid var(--hair);
+  background: linear-gradient(180deg, rgba(26,18,12,0.5), rgba(14,10,8,0.6));
+  font-size: 11.5px; position: relative;
+  transition: border-color 140ms ease;
+}
+.a2a-msg:hover { border-color: var(--accent-brass-dim); }
+.a2a-msg .t { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); letter-spacing: 0.02em; font-variant-numeric: tabular-nums; }
+.a2a-msg .av { width: 22px; height: 22px; border: 1px solid var(--border-main); object-fit: cover; filter: sepia(0.15) contrast(1.05) brightness(0.92); }
+.a2a-msg .arrow { color: var(--text-dim); font-family: var(--font-mono); text-align: center; font-size: 14px; }
+.a2a-msg .body { display: flex; align-items: baseline; gap: 10px; min-width: 0; }
+.a2a-msg .title { font-weight: 600; color: var(--text-bright); white-space: nowrap; }
+.a2a-msg .sub { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.a2a-msg .kind {
+  font-size: 8.5px; letter-spacing: 0.22em; text-transform: uppercase; font-weight: 700;
+  padding: 2px 7px; border: 1px solid currentColor; font-family: var(--font-display);
+  color: var(--text-dim);
+}
+.a2a-msg.handoff .kind { color: var(--accent-brass); }
+.a2a-msg.request .kind { color: #7aa3d4; }
+.a2a-msg.reply .kind   { color: var(--ok); }
+.a2a-msg.hilt .kind    { color: var(--bad); }
+.a2a-msg.alert .kind   { color: var(--warn); }
+.a2a-msg.hilt, .a2a-msg.alert {
+  border-color: color-mix(in oklab, currentColor 20%, var(--hair));
+  background: linear-gradient(180deg, rgba(40,16,12,0.35), rgba(14,10,8,0.6));
+}

--- a/dashboard/src/styles/ds-dashboard-kit/alert.css
+++ b/dashboard/src/styles/ds-dashboard-kit/alert.css
@@ -1,0 +1,53 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · alert
+   Top alert strip — chip cluster
+   ═══════════════════════════════════════════════════════════════ */
+
+
+/* ═══════════════════════════════════════════════════════════════
+   ADVANCED — alert strip, drawer, command palette, A2A thread
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ─── ALERT STRIP ─────────────────────────────────────── */
+.alert-strip {
+  grid-column: 2 / 4; grid-row: 2 / 3;
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 16px; overflow: hidden;
+  background:
+    repeating-linear-gradient(90deg, rgba(138,106,40,0.02) 0 18px, transparent 18px 22px),
+    linear-gradient(180deg, #181108, #110b07);
+  border-bottom: 1px solid var(--border-main);
+  box-shadow: inset 0 -1px 0 rgba(138,106,40,0.1);
+  position: relative; z-index: 2;
+}
+.alert-strip::before {
+  content: "ATTENTION"; font-family: var(--font-display); font-size: 8.5px;
+  letter-spacing: 0.36em; font-weight: 700; color: var(--accent-brass);
+  padding: 3px 8px; border: 1px solid var(--hair-brass);
+  margin-right: 4px; flex-shrink: 0;
+  background: rgba(138,106,40,0.06);
+}
+.alert-chip {
+  display: flex; align-items: center; gap: 7px;
+  padding: 4px 10px 4px 8px; border: 1px solid var(--hair);
+  background: rgba(14,10,8,0.55); flex-shrink: 0; cursor: pointer;
+  transition: border-color 140ms ease, background 140ms ease;
+  max-width: 340px;
+}
+.alert-chip:hover { border-color: var(--accent-brass-dim); background: rgba(26,18,12,0.8); }
+.alert-chip svg { width: 11px; height: 11px; color: var(--text-dim); flex-shrink: 0; }
+.alert-chip .k { font-size: 8.5px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--text-dim); font-weight: 600; }
+.alert-chip .t { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 200px; }
+.alert-chip .m { font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 180px; }
+.alert-chip .sep { width: 1px; height: 12px; background: var(--border-main); }
+.alert-chip.bad   { border-color: color-mix(in oklab, var(--bad) 45%, transparent); background: linear-gradient(180deg, rgba(60,12,12,0.4), rgba(20,8,6,0.6)); }
+.alert-chip.bad svg  { color: var(--bad); }
+.alert-chip.bad .k   { color: var(--bad); }
+.alert-chip.warn { border-color: color-mix(in oklab, var(--warn) 40%, transparent); }
+.alert-chip.warn svg { color: var(--warn); }
+.alert-chip.warn .k  { color: var(--warn); }
+.alert-chip.info svg { color: var(--accent-brass); }
+.alert-chip.info .k  { color: var(--accent-brass); }
+.alert-scroll-wrap { flex: 1; min-width: 0; overflow: hidden; display: flex; align-items: center; gap: 8px; }
+.alert-strip .r { margin-left: auto; font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); letter-spacing: 0.1em; white-space: nowrap; }
+.alert-strip .r b { color: var(--accent-brass); font-weight: 500; }

--- a/dashboard/src/styles/ds-dashboard-kit/approvals.css
+++ b/dashboard/src/styles/ds-dashboard-kit/approvals.css
@@ -1,0 +1,42 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · approvals
+   HILT approval cards — critical / destructive / info
+   ═══════════════════════════════════════════════════════════════ */
+
+/* approvals (top priority) */
+.approvals { display: flex; flex-direction: column; gap: 6px; position: relative; }
+.approval {
+  border: 1px solid var(--hair); background: rgba(20,12,8,0.6);
+  padding: 8px 10px; position: relative; transition: border-color 160ms ease;
+  isolation: isolate;
+}
+.approval.bad {
+  border-color: var(--bad);
+  background: linear-gradient(180deg, rgba(60,12,12,0.55), rgba(20,8,6,0.6));
+  box-shadow: inset 0 0 0 1px rgba(160,24,24,0.18);
+}
+.approval.warn { border-color: var(--hair-brass); }
+.approval:hover { border-color: var(--border-highlight); }
+.approval .ah { display: flex; align-items: center; gap: 8px; margin-bottom: 3px; }
+.approval .ak { font-family: var(--font-mono); font-size: 8.5px; letter-spacing: 0.1em; color: var(--accent-brass); text-transform: uppercase; background: rgba(138,106,40,0.08); padding: 1px 5px; border: 1px solid var(--hair-brass); }
+.approval.bad .ak { color: var(--bad); border-color: var(--bad); background: rgba(160,24,24,0.08); }
+.approval .aid { font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); letter-spacing: 0.08em; margin-left: auto; }
+.approval .at { font-family: var(--font-ui); font-size: 12px; color: var(--text-bright); line-height: 1.3; margin: 3px 0 2px; }
+.approval .ad { font-family: var(--font-mono); font-size: 10px; color: var(--text-primary); line-height: 1.3; margin-bottom: 5px; }
+.approval .am { display: flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); }
+.approval .am img { width: 12px; height: 12px; object-fit: cover; border: 1px solid var(--border-main); filter: sepia(0.15) contrast(1.05) brightness(0.92); opacity: 0.85; }
+.approval .am .age { margin-left: auto; color: var(--bad); }
+.approval.warn .am .age { color: var(--warn); }
+.approval.info .am .age { color: var(--accent-brass); }
+.approval .actions { display: flex; gap: 4px; margin-top: 7px; }
+.approval .actions button {
+  flex: 1; font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.18em;
+  text-transform: uppercase; padding: 5px 0; background: transparent;
+  border: 1px solid var(--border-highlight); color: var(--text-primary); cursor: pointer;
+  transition: all 120ms ease;
+}
+.approval .actions button.approve { border-color: var(--ok); color: var(--ok); }
+.approval .actions button.approve:hover { background: rgba(90,122,58,0.12); }
+.approval .actions button.deny    { border-color: var(--bad); color: var(--bad); }
+.approval .actions button.deny:hover { background: rgba(160,24,24,0.1); }
+.approval .actions button.defer:hover { background: rgba(138,106,40,0.08); color: var(--accent-brass); border-color: var(--accent-brass-dim); }

--- a/dashboard/src/styles/ds-dashboard-kit/aside.css
+++ b/dashboard/src/styles/ds-dashboard-kit/aside.css
@@ -1,0 +1,52 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · aside
+   Right rail container + shared h4 heading + v5 card softening
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ═══ RIGHT ASIDE ═══ */
+.aside {
+  background: linear-gradient(180deg, #16100a, #0e0806);
+  border-left: 1px solid var(--border-main);
+  padding: 14px 14px 30px; overflow: auto;
+  display: flex; flex-direction: column; gap: 16px;
+  grid-column: 3 / 4; grid-row: 2 / 5;
+  min-width: 0; min-height: 0;
+}
+.aside h4 {
+  font-family: var(--font-display); font-size: 10.5px; letter-spacing: 0.22em; font-weight: 600;
+  color: var(--accent-brass); text-transform: uppercase; margin: 0 0 8px;
+  display: flex; align-items: center; gap: 9px;
+  position: relative; z-index: 2;
+  background: linear-gradient(180deg, #16100a 70%, rgba(22,16,10,0));
+  padding-bottom: 4px;
+}
+.aside h4::after { content: ""; flex: 1; height: 1px; background: linear-gradient(90deg, var(--border-highlight), transparent); }
+.aside h4 svg { width: 12px; height: 12px; color: var(--accent-brass); }
+.aside h4 .r {
+  font-family: var(--font-mono); font-size: 10px; color: var(--text-dim);
+  margin-left: auto; font-variant-numeric: tabular-nums; letter-spacing: 0.04em; text-transform: none;
+}
+
+/* ═══ v5 refinements — aside-wide softer cards ═══ */
+/* ─── Focus/Approvals/Systems/Chronicle — softer ─── */
+.aside h4 {
+  font-family: var(--font-display);
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--text);
+  border-bottom: 1px solid var(--border-soft);
+}
+.approval {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+}
+.approval.critical { border-left: 3px solid var(--bad); }
+.approval.destructive { border-left: 3px solid var(--warn); }
+.focus, .sys-list, .evs { background: transparent; }
+.focus-in {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+}

--- a/dashboard/src/styles/ds-dashboard-kit/base.css
+++ b/dashboard/src/styles/ds-dashboard-kit/base.css
@@ -1,0 +1,76 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · base
+   CSS vars, reset, scrollbar, body noise bg
+   ═══════════════════════════════════════════════════════════════ */
+
+
+:root {
+  /* Override global type stacks: use normal/neutral fonts for this dashboard.
+     Keep Cinzel only on the brand wordmark (scoped below). */
+  --font-ui:      'Pretendard Variable', Pretendard, 'Noto Sans KR', -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-display: 'Pretendard Variable', Pretendard, 'Noto Sans KR', -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-body:    'Pretendard Variable', Pretendard, 'Noto Sans KR', -apple-system, 'Segoe UI', Roboto, sans-serif;
+
+  --hair:        rgba(120, 100, 80, 0.14);
+  --hair-strong: rgba(160, 140, 110, 0.28);
+  --hair-brass:  rgba(138, 106, 40, 0.35);
+  --ok:   var(--status-ok);
+  --warn: var(--status-warn);
+  --bad:  var(--status-bad);
+
+  /* Tool frame palette — desaturated for info-density */
+  --t-llm:   #4a5a7a;
+  --t-tool:  #8a6a28;
+  --t-fs:    #6a5a40;
+  --t-net:   #3a5a48;
+  --t-db:    #6a3a5a;
+  --t-think: #3a3a48;
+  --t-err:   #a01818;
+  --t-judge: #c4922a;
+  --t-hilt:  #c94a3a;
+
+  --nav-w:   220px;
+  --aside-w: 340px;
+  --head-h:  52px;
+  --hud-h:   60px;
+  --alert-h: 34px;
+}
+
+/* ─── Base ─────────────────────────────────────────────── */
+* { box-sizing: border-box; }
+html, body { height: 100%; margin: 0; }
+body {
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  background:
+    radial-gradient(ellipse 50% 40% at 8% 6%, rgba(138,106,40,0.05), transparent 55%),
+    radial-gradient(ellipse 35% 50% at 94% 96%, rgba(160,24,24,0.06), transparent 60%),
+    linear-gradient(170deg, #0e0806 0%, #14100c 60%, #080504 100%);
+  overflow: hidden; /* shell manages scrolling */
+}
+body::before {
+  content: ""; position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' seed='5'/><feColorMatrix values='0 0 0 0 0.1  0 0 0 0 0.08  0 0 0 0 0.06  0 0 0 0.6 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.3'/></svg>");
+  mix-blend-mode: multiply; opacity: 0.8;
+}
+
+/* Scroll chrome */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 0; }
+::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
+
+/* ═══ v5 overrides ═══ */
+
+:root[data-theme="dark-fantasy"] {
+  /* softened neutrals — v5 is calmer */
+  --bg-ink:         #0a0e18;
+  --bg-velvet:      #0f1524;
+  --bg-card:        #131a2a;
+  --bg-card-soft:   #161d30;
+  --bg-raised:      #1a2238;
+  --border-soft:    rgba(120,140,180,0.09);
+  --border:         rgba(120,140,180,0.13);
+  --border-strong:  rgba(140,160,200,0.18);
+  --hilt-show:      block;
+}

--- a/dashboard/src/styles/ds-dashboard-kit/chronicle.css
+++ b/dashboard/src/styles/ds-dashboard-kit/chronicle.css
@@ -1,0 +1,25 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · chronicle
+   Timestamped event ledger — ok/warn/bad/judge/hilt
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Chronicle */
+.evs { display: flex; flex-direction: column; }
+.ev {
+  display: grid; grid-template-columns: 44px 10px 1fr; gap: 8px;
+  padding: 6px 0; border-bottom: 1px dashed var(--border-main); align-items: baseline;
+}
+.ev:last-child { border-bottom: 0; }
+.ev .t { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); font-variant-numeric: tabular-nums; }
+.ev .mk { position: relative; height: 8px; }
+.ev .mk .d { display: block; width: 7px; height: 7px; border-radius: 50%; background: var(--text-dim); margin-top: 3px; }
+.ev.ok .mk .d    { background: var(--ok); box-shadow: 0 0 4px var(--ok); }
+.ev.warn .mk .d  { background: var(--warn); box-shadow: 0 0 4px var(--warn); }
+.ev.bad .mk .d   { background: var(--bad); box-shadow: 0 0 5px var(--accent-blood-glow); }
+.ev.judge .mk .d { background: var(--t-judge); box-shadow: 0 0 4px var(--t-judge); }
+.ev.hilt .mk .d  { background: var(--t-hilt); box-shadow: 0 0 4px var(--t-hilt); }
+.ev .b { font-family: var(--font-body); font-size: 12px; color: var(--text-primary); line-height: 1.4; }
+.ev .b em { color: var(--text-bright); font-style: italic; }
+.ev .b code { font-family: var(--font-mono); font-size: 10px; color: var(--accent-brass); background: rgba(138,106,40,0.08); padding: 0 4px; border: 1px solid var(--border-main); }
+.ev .b .bad { color: var(--bad); }
+.ev.bad .b code { color: var(--bad); background: rgba(160,24,24,0.08); }

--- a/dashboard/src/styles/ds-dashboard-kit/cmdk.css
+++ b/dashboard/src/styles/ds-dashboard-kit/cmdk.css
@@ -1,0 +1,22 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · cmdk
+   Floating ⌘K hint + cursor overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ─── CMD-K HINT BUTTON ──────────────────────────────── */
+.cmdk-hint {
+  position: fixed; right: 18px; bottom: 16px; z-index: 25;
+  display: flex; align-items: center; gap: 7px;
+  padding: 7px 11px; border: 1px solid var(--accent-brass-dim);
+  background: linear-gradient(180deg, #1c140e, #120b07);
+  color: var(--accent-brass); font-family: var(--font-display);
+  font-size: 10px; letter-spacing: 0.22em; font-weight: 600;
+  cursor: pointer; box-shadow: 0 4px 12px rgba(0,0,0,0.5), inset 0 1px 0 rgba(138,106,40,0.2);
+  transition: all 140ms ease;
+}
+.cmdk-hint:hover { background: rgba(138,106,40,0.12); color: var(--text-bright); }
+.cmdk-hint svg { width: 12px; height: 12px; }
+
+/* swimlane row click cursor */
+.lane { cursor: pointer; }
+.mini-keeper { cursor: pointer; }

--- a/dashboard/src/styles/ds-dashboard-kit/density.css
+++ b/dashboard/src/styles/ds-dashboard-kit/density.css
@@ -1,0 +1,9 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · density
+   data-density="comfy" overrides
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Density — tight vs comfy */
+[data-density="comfy"] .main { gap: 16px; }
+[data-density="comfy"] .sec-body > div { padding: 14px; }
+[data-density="comfy"] .page-header { padding: 18px 26px 14px; }

--- a/dashboard/src/styles/ds-dashboard-kit/drawer.css
+++ b/dashboard/src/styles/ds-dashboard-kit/drawer.css
@@ -1,0 +1,96 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · drawer
+   Keeper detail drawer — head · stats · trace · bars
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ─── KEEPER DRAWER ──────────────────────────────────── */
+.drawer-backdrop {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.55); backdrop-filter: blur(2px);
+  opacity: 0; pointer-events: none; transition: opacity 180ms ease; z-index: 40;
+}
+.drawer-backdrop.on { opacity: 1; pointer-events: auto; }
+.drawer {
+  position: fixed; top: 0; right: 0; bottom: 0; width: 520px;
+  background: linear-gradient(180deg, #1a140e 0%, #120b07 100%);
+  border-left: 1px solid var(--accent-brass-dim);
+  box-shadow: -10px 0 40px rgba(0,0,0,0.6), inset 1px 0 0 rgba(138,106,40,0.25);
+  transform: translateX(100%); transition: transform 220ms cubic-bezier(.2,.8,.2,1);
+  z-index: 50; display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.drawer.on { transform: translateX(0); }
+.drawer-head {
+  padding: 14px 18px; border-bottom: 1px solid var(--border-highlight);
+  display: grid; grid-template-columns: 48px 1fr auto; gap: 14px; align-items: center;
+  background: linear-gradient(180deg, rgba(138,106,40,0.08), transparent);
+}
+.drawer-head img { width: 48px; height: 48px; object-fit: cover; border: 1px solid var(--accent-brass-dim); filter: sepia(0.15) contrast(1.05); }
+.drawer-head .nm { font-family: var(--font-display); font-size: 18px; font-weight: 700; color: var(--accent-brass); letter-spacing: 0.04em; }
+.drawer-head .meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); margin-top: 2px; letter-spacing: 0.06em; }
+.drawer-head .close {
+  background: transparent; border: 1px solid var(--border-main); color: var(--text-dim);
+  width: 28px; height: 28px; font-family: var(--font-mono); font-size: 14px; cursor: pointer;
+  transition: all 140ms ease;
+}
+.drawer-head .close:hover { color: var(--bad); border-color: var(--bad); }
+
+.drawer-stats {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid var(--border-main);
+}
+.drawer-stats > div { padding: 9px 12px; border-right: 1px solid var(--border-main); }
+.drawer-stats > div:last-child { border-right: 0; }
+.drawer-stats .k { font-size: 8.5px; letter-spacing: 0.24em; color: var(--text-dim); text-transform: uppercase; }
+.drawer-stats .v { font-family: var(--font-display); font-size: 14px; color: var(--text-bright); margin-top: 2px; font-weight: 600; }
+.drawer-stats .s { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); margin-top: 1px; }
+
+.drawer-body { flex: 1; overflow: auto; padding: 14px 16px 20px; }
+.drawer-sec-title {
+  font-family: var(--font-display); font-size: 10px; letter-spacing: 0.26em; font-weight: 600;
+  color: var(--accent-brass); text-transform: uppercase; margin: 6px 0 8px;
+  display: flex; align-items: center; gap: 9px;
+}
+.drawer-sec-title::after { content: ""; flex: 1; height: 1px; background: linear-gradient(90deg, var(--border-highlight), transparent); }
+.drawer-sec-title:not(:first-child) { margin-top: 20px; }
+
+.trace { display: flex; flex-direction: column; border-left: 1px dotted var(--border-highlight); padding-left: 0; }
+.trace-turn {
+  display: grid; grid-template-columns: 28px 70px 1fr auto; align-items: baseline;
+  gap: 10px; padding: 7px 0 7px 10px; border-bottom: 1px dotted var(--border-main);
+  position: relative; font-size: 11.5px;
+}
+.trace-turn::before {
+  content: ""; position: absolute; left: -4px; top: 14px; width: 7px; height: 7px;
+  background: var(--accent-brass-dim); border: 1px solid var(--bg-deep);
+  border-radius: 50%;
+}
+.trace-turn.think::before { background: var(--t-llm); }
+.trace-turn.tool::before  { background: var(--t-tool); }
+.trace-turn.judge::before { background: var(--t-judge); }
+.trace-turn.hilt::before  { background: var(--bad); }
+.trace-turn.fail::before  { background: var(--bad); }
+.trace-turn.overflow::before,
+.trace-turn.compact::before { background: var(--accent-brass); }
+.trace-turn .n { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); font-variant-numeric: tabular-nums; }
+.trace-turn .tag {
+  font-family: var(--font-display); font-size: 8.5px; font-weight: 700;
+  letter-spacing: 0.22em; text-transform: uppercase; padding: 2px 6px;
+  border: 1px solid currentColor; color: var(--text-dim); text-align: center;
+}
+.trace-turn.think .tag { color: #7aa3d4; }
+.trace-turn.tool  .tag { color: var(--t-tool); }
+.trace-turn.judge .tag { color: var(--t-judge); }
+.trace-turn.hilt  .tag { color: var(--bad); }
+.trace-turn.fail  .tag { color: var(--bad); }
+.trace-turn.overflow .tag,
+.trace-turn.compact  .tag { color: var(--accent-brass); }
+.trace-turn .body { color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; }
+.trace-turn .meta { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); white-space: nowrap; font-variant-numeric: tabular-nums; }
+
+/* drawer metric bars */
+.drawer-bars { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.drawer-bar { border: 1px solid var(--hair); padding: 8px 10px; }
+.drawer-bar .lbl { font-size: 8.5px; letter-spacing: 0.24em; color: var(--text-dim); text-transform: uppercase; }
+.drawer-bar .val { font-family: var(--font-display); font-size: 13px; color: var(--text-bright); margin-top: 2px; font-weight: 600; }
+.drawer-bar .bar { height: 3px; background: rgba(14,10,8,0.8); border: 1px solid var(--border-main); margin-top: 5px; position: relative; overflow: hidden; }
+.drawer-bar .bar b { position: absolute; left: 0; top: 0; bottom: 0; background: var(--accent-brass); display: block; }

--- a/dashboard/src/styles/ds-dashboard-kit/focus.css
+++ b/dashboard/src/styles/ds-dashboard-kit/focus.css
@@ -1,0 +1,24 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · focus
+   Focused keeper card — portrait + stats + vials
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Focus keeper */
+.focus { position: relative; padding: 12px; background: linear-gradient(180deg, #241a12, #14100a); border: 1px solid var(--hair-brass); }
+.focus::before { content: ""; position: absolute; inset: 3px; border: 1px solid var(--border-highlight); pointer-events: none; }
+.focus-in { position: relative; z-index: 1; }
+.focus .who { display: flex; align-items: center; gap: 10px; }
+.focus .who img { width: 24px; height: 24px; object-fit: cover; border: 1px solid var(--accent-brass-dim); filter: sepia(0.15) contrast(1.05) brightness(0.92); opacity: 0.92; }
+.focus .fn { font-family: var(--font-display); font-size: 14px; color: var(--accent-brass); letter-spacing: 0.06em; font-weight: 600; text-transform: none; line-height: 1.05; }
+.focus .fr { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); margin-top: 2px; letter-spacing: 0.04em; }
+.focus .stats { display: grid; grid-template-columns: 1fr 1fr; gap: 6px 10px; margin-top: 10px; }
+.focus .stat .l { font-size: 8px; letter-spacing: 0.2em; color: var(--text-dim); text-transform: uppercase; }
+.focus .stat .v { font-family: var(--font-mono); font-size: 11px; color: var(--text-bright); margin-top: 1px; font-variant-numeric: tabular-nums; }
+.focus .stat .v.bad { color: var(--bad); }
+.focus .stat .v.ok  { color: var(--ok); }
+.focus .stat .v.warn{ color: var(--warn); }
+.vial { height: 6px; background: #0a0604; border: 1px solid var(--border-main); position: relative; overflow: hidden; margin-top: 3px; }
+.vial > span { display: block; height: 100%; background: linear-gradient(90deg, #3d5a28, #6a9a44); transition: width 300ms ease; }
+.vial.warn > span { background: linear-gradient(90deg, #6a5218, #c4922a); }
+.vial.bad  > span { background: linear-gradient(90deg, #5a0f0f, #a01818); }
+.vial::after { content: ""; position: absolute; inset: 0; background-image: repeating-linear-gradient(90deg, transparent 0 19px, rgba(0,0,0,0.45) 19px 20px); pointer-events: none; }

--- a/dashboard/src/styles/ds-dashboard-kit/goals.css
+++ b/dashboard/src/styles/ds-dashboard-kit/goals.css
@@ -1,0 +1,71 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · goals
+   Goal cards with progress bars + job expansion
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── GOAL STACK ── */
+.goals-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; }
+.goal {
+  border: 1px solid var(--hair); background: rgba(14,10,8,0.45);
+  padding: 10px 12px 9px; position: relative;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+.goal.pri {
+  border-color: var(--hair-brass);
+  background: linear-gradient(180deg, rgba(58,42,22,0.45), rgba(14,10,8,0.5));
+}
+.goal:hover { border-color: var(--border-highlight); }
+.goal .gh { display: flex; align-items: center; gap: 8px; }
+.goal .gh .gt { font-family: var(--font-display); font-size: 12px; letter-spacing: 0.02em; font-weight: 600; color: var(--text-bright); text-transform: none; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.goal.pri .gh .gt { color: var(--accent-brass); }
+.goal .gh .gid { font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); letter-spacing: 0.1em; }
+.goal .gh .gtog { background: transparent; border: 0; color: var(--text-dim); cursor: pointer; font-family: var(--font-mono); font-size: 12px; padding: 0 2px; }
+.goal .gh .gtog:hover { color: var(--accent-brass); }
+.goal .gbar {
+  margin-top: 8px; height: 7px; background: #0a0604;
+  border: 1px solid var(--border-main); position: relative; overflow: hidden;
+}
+.goal .gbar > .done  { height: 100%; background: linear-gradient(90deg, #3d5a28, #6a9a44); box-shadow: 0 0 6px rgba(106,154,68,0.3); transition: width 300ms ease; }
+.goal .gbar > .wip   { height: 100%; background: linear-gradient(90deg, #6a5218, #c4922a); position: absolute; top: 0; transition: all 300ms ease; }
+.goal .gbar > .block { height: 100%; background: linear-gradient(90deg, #5a0f0f, #a01818); position: absolute; top: 0; transition: all 300ms ease; }
+.goal .gmeta { display: flex; gap: 9px; font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); margin-top: 6px; font-variant-numeric: tabular-nums; align-items: center; }
+.goal .gmeta .d { color: var(--ok); } .goal .gmeta .w { color: var(--accent-brass); } .goal .gmeta .b { color: var(--bad); }
+.goal .gmeta .lbl { color: var(--text-dim); letter-spacing: 0.06em; }
+.goal .gmeta .workers { margin-left: auto; display: flex; gap: 3px; }
+.goal .gmeta .workers img { width: 13px; height: 13px; object-fit: cover; border: 1px solid var(--border-main); filter: sepia(0.15) contrast(1.05) brightness(0.92); opacity: 0.85; }
+.goal .gmeta .workers img.dead { filter: grayscale(1) brightness(0.5); border-color: var(--bad); }
+
+/* Jobs expansion */
+.jobs {
+  margin-top: 8px; display: grid; grid-template-rows: 0fr; overflow: hidden;
+  transition: grid-template-rows 240ms ease;
+}
+.jobs > div { min-height: 0; }
+.goal.open .jobs { grid-template-rows: 1fr; }
+.jobs-list { padding-top: 6px; border-top: 1px dashed var(--border-main); }
+.job {
+  display: grid; grid-template-columns: 10px 1fr auto auto; gap: 7px; align-items: center;
+  padding: 3px 0; font-family: var(--font-mono); font-size: 10px; color: var(--text-primary);
+  border-bottom: 1px dotted var(--border-main);
+}
+.job:last-child { border-bottom: 0; }
+.job .dot { width: 6px; height: 6px; border-radius: 1px; }
+.job.done  .dot { background: var(--ok); }
+.job.wip   .dot { background: var(--accent-brass); box-shadow: 0 0 4px var(--accent-brass); }
+.job.block .dot { background: var(--bad); box-shadow: 0 0 5px var(--bad); }
+.job.todo  .dot { background: var(--text-dim); }
+.job.done  .t   { color: var(--text-dim); text-decoration: line-through; text-decoration-color: var(--border-highlight); }
+.job .t { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.job .k { color: var(--accent-brass); font-size: 9px; }
+.job.block .k { color: var(--bad); }
+.job .id { color: var(--text-dim); font-size: 9px; }
+
+/* v5 refinements */
+/* Goals — soften */
+.goal {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.goal.pri { border-color: rgba(200,80,60,0.22); }
+.gbar { background: var(--bg-card-soft); }

--- a/dashboard/src/styles/ds-dashboard-kit/hud.css
+++ b/dashboard/src/styles/ds-dashboard-kit/hud.css
@@ -1,0 +1,22 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · hud
+   6-cell stats strip under topbar
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ═══ HUD STRIP ═══ */
+.hud {
+  /* hud */ grid-column: 2 / 3; grid-row: 3 / 4;
+  display: grid; grid-template-columns: repeat(6, 1fr);
+  background: linear-gradient(180deg, #1a140e, #140d08);
+  border-bottom: 1px solid var(--border-highlight);
+}
+.hud > div { padding: 9px 14px; border-right: 1px solid var(--border-main); position: relative; }
+.hud > div:last-child { border-right: 0; }
+.hud .k { font-size: 9px; letter-spacing: 0.26em; text-transform: uppercase; color: var(--text-dim); }
+.hud .v { font-family: var(--font-display); font-size: 13px; letter-spacing: 0.06em; font-weight: 600; color: var(--text-bright); margin-top: 3px; text-transform: none; font-variant-numeric: tabular-nums; }
+.hud .v.ok   { color: var(--ok); }
+.hud .v.warn { color: var(--warn); }
+.hud .v.bad  { color: var(--bad); }
+.hud .v.brass{ color: var(--accent-brass); }
+.hud .sub { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); margin-top: 1px; font-variant-numeric: tabular-nums; }
+.hud .sub .spark { display: inline-block; vertical-align: -2px; margin-left: 4px; }

--- a/dashboard/src/styles/ds-dashboard-kit/index.css
+++ b/dashboard/src/styles/ds-dashboard-kit/index.css
@@ -1,0 +1,40 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 — stylesheet index
+   Cascade order matters: base → shell → chrome → sections → overlays.
+   v5 refinements are merged into each component file.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* foundations */
+@import url("base.css");
+@import url("shell.css");
+@import url("primitives.css");
+
+/* chrome */
+@import url("topbar.css");
+@import url("nav.css");
+@import url("hud.css");
+@import url("alert.css");
+
+/* main region */
+@import url("main.css");
+@import url("goals.css");
+@import url("swim.css");
+@import url("swim-vertical.css");
+@import url("pressure.css");
+@import url("a2a.css");
+
+/* right rail */
+@import url("aside.css");
+@import url("approvals.css");
+@import url("focus.css");
+@import url("systems.css");
+@import url("chronicle.css");
+
+/* overlays */
+@import url("drawer.css");
+@import url("palette.css");
+@import url("cmdk.css");
+@import url("tweaks.css");
+
+/* modifiers */
+@import url("density.css");

--- a/dashboard/src/styles/ds-dashboard-kit/main.css
+++ b/dashboard/src/styles/ds-dashboard-kit/main.css
@@ -1,0 +1,99 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · main
+   Main scroll region · section head · sec-body · sec-tabs
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ═══ MAIN ═══ */
+.main { grid-column: 2 / 3; grid-row: 4 / 5; overflow: auto; padding: 14px 18px 40px; min-width: 0; min-height: 0; }
+
+/* Section head */
+.sec-head {
+  display: flex; align-items: center; gap: 12px;
+  padding: 14px 0 8px; position: sticky; top: 0; z-index: 2;
+  background: linear-gradient(180deg, #120c08 70%, transparent);
+  user-select: none;
+}
+.sec-head > button.toggle {
+  background: transparent; border: 1px solid var(--border-main); color: var(--text-dim);
+  width: 20px; height: 20px; display: grid; place-items: center; cursor: pointer;
+  font-family: var(--font-mono); font-size: 12px; line-height: 1;
+  transition: all 120ms ease;
+}
+.sec-head > button.toggle:hover { color: var(--accent-brass); border-color: var(--accent-brass-dim); }
+.sec-head > button.toggle.open { transform: rotate(90deg); color: var(--accent-brass); border-color: var(--accent-brass-dim); }
+
+.sec-head svg.sh-glyph { width: 14px; height: 14px; color: var(--accent-brass); }
+.sec-head h3 {
+  font-family: var(--font-display); font-size: 12px; letter-spacing: 0.2em; font-weight: 600;
+  color: var(--accent-brass); text-transform: uppercase; margin: 0;
+}
+.sec-head .sub { font-family: var(--font-mono); color: var(--text-dim); font-size: 10.5px; letter-spacing: 0.04em; }
+.sec-head .hr { flex: 1; height: 1px; background: linear-gradient(90deg, var(--border-highlight) 0%, var(--border-main) 60%, transparent 100%); }
+.sec-head .r { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); font-variant-numeric: tabular-nums; }
+.sec-head .r b { color: var(--text-bright); font-weight: 400; }
+
+.sec-body {
+  overflow: hidden; transition: grid-template-rows 260ms ease, opacity 200ms ease, margin 200ms ease;
+  display: grid; grid-template-rows: 1fr; opacity: 1; margin-bottom: 10px;
+}
+.sec-body > div { min-height: 0; }
+.sec-body.collapsed { grid-template-rows: 0fr; opacity: 0.0; margin-bottom: 0; }
+
+/* Tabs for scope */
+.sec-tabs { display: inline-flex; gap: 2px; }
+.sec-tabs button {
+  font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.2em;
+  text-transform: uppercase; padding: 4px 9px; background: transparent;
+  border: 1px solid var(--border-main); color: var(--text-dim); cursor: pointer;
+  transition: all 120ms ease;
+}
+.sec-tabs button.on {
+  color: var(--accent-brass); border-color: var(--hair-brass);
+  background: rgba(138,106,40,0.07);
+}
+.sec-tabs button:hover { color: var(--accent-brass); }
+
+/* v5 refinements — card surface cleanup */
+/* ─── Card surface cleanup — softer borders, less gradient ─── */
+.sec-head {
+  border-bottom: 1px solid var(--border-soft);
+  background: transparent;
+}
+.sec-head h3 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 13.5px;
+  color: var(--text-bright);
+  letter-spacing: -0.005em;
+}
+.sec-head .sub {
+  font-size: 10.5px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+.sec-head .r {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-dim);
+}
+.sec-head .r b { color: var(--text); font-weight: 500; }
+.sec-tabs-group { display: flex; gap: 8px; align-items: center; }
+
+.sec-tabs button {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  padding: 4px 10px;
+  font-size: 10.5px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.02em;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 140ms;
+}
+.sec-tabs button:hover { color: var(--text); border-color: var(--border-strong); }
+.sec-tabs button.on {
+  background: rgba(138,106,40,0.12);
+  border-color: rgba(138,106,40,0.35);
+  color: var(--accent-brass);
+}

--- a/dashboard/src/styles/ds-dashboard-kit/nav.css
+++ b/dashboard/src/styles/ds-dashboard-kit/nav.css
@@ -1,0 +1,131 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · nav
+   Left rail — sections, links, mini-keeper roster
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ═══ LEFT NAV ═══ */
+.nav {
+  background: linear-gradient(180deg, #18110c, #0e0806);
+  border-right: 1px solid var(--border-main);
+  overflow: auto; padding: 10px 0 30px;
+  display: flex; flex-direction: column;
+  grid-column: 1 / 2; grid-row: 2 / 5;
+}
+.nav-sec {
+  padding: 14px 16px 5px; font-size: 8px; letter-spacing: 0.3em;
+  text-transform: uppercase; color: var(--text-dim);
+  display: flex; align-items: center; gap: 8px; user-select: none;
+}
+.nav-sec::after { content: ""; flex: 1; height: 1px; background: linear-gradient(90deg, var(--border-highlight), transparent); }
+
+.nav a {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 16px; color: var(--text-primary); font-size: 11px;
+  text-decoration: none; letter-spacing: 0.08em;
+  border-left: 2px solid transparent; cursor: pointer; position: relative;
+  transition: background 120ms ease, color 120ms ease;
+}
+.nav a svg { width: 13px; height: 13px; color: var(--text-dim); flex-shrink: 0; }
+.nav a:hover { color: var(--accent-brass); background: rgba(138,106,40,0.05); }
+.nav a:hover svg { color: var(--accent-brass); }
+.nav a.active {
+  color: var(--accent-brass); border-left-color: var(--accent-brass);
+  background: linear-gradient(90deg, rgba(138,106,40,0.1), transparent 70%);
+}
+.nav a.active svg { color: var(--accent-brass); }
+.nav a .tail {
+  margin-left: auto; font-family: var(--font-mono); font-size: 10px;
+  color: var(--text-dim); font-variant-numeric: tabular-nums;
+}
+.nav a .tail.bad { color: var(--bad); }
+.nav a .tail.warn{ color: var(--warn); }
+.nav a .tail.brass{ color: var(--accent-brass); }
+
+/* Roster strip in nav */
+.nav-roster {
+  margin: 8px 10px 0; padding: 8px;
+  border: 1px solid var(--hair);
+  background: rgba(14,10,8,0.4);
+}
+.nav-roster .nrt { font-size: 8px; letter-spacing: 0.3em; color: var(--text-dim); text-transform: uppercase; margin-bottom: 6px; display: flex; align-items: center; gap: 6px; }
+.nav-roster .nrt::after { content: ""; flex: 1; height: 1px; background: var(--border-main); }
+.mini-keeper { display: flex; align-items: center; gap: 7px; padding: 4px 0; border-bottom: 1px dotted var(--border-main); cursor: pointer; }
+.mini-keeper:last-child { border-bottom: 0; }
+.mini-keeper:hover { background: rgba(138,106,40,0.04); }
+.mini-keeper.selected { background: rgba(138,106,40,0.08); }
+.mini-keeper .mkimg { width: 14px; height: 14px; object-fit: cover; border: 1px solid var(--border-main); filter: sepia(0.15) contrast(1.05) brightness(0.92); flex-shrink: 0; opacity: 0.88; }
+.mini-keeper .mkmain { flex: 1; min-width: 0; line-height: 1.1; }
+.mini-keeper .mknm { font-family: var(--font-display); font-size: 11px; letter-spacing: 0.02em; font-weight: 600; color: var(--text-bright); text-transform: none; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mini-keeper .mksub { font-family: var(--font-mono); font-size: 8.5px; color: var(--text-dim); margin-top: 1px; }
+.mini-keeper .mkst { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.mini-keeper .mkst.running    { background: var(--ok);    box-shadow: 0 0 5px var(--ok); }
+.mini-keeper .mkst.compacting { background: var(--accent-brass); box-shadow: 0 0 5px var(--accent-brass); }
+.mini-keeper .mkst.paused     { background: var(--warn);  box-shadow: 0 0 5px var(--warn); }
+.mini-keeper .mkst.dead       { background: var(--bad);   box-shadow: 0 0 5px var(--bad); }
+.mini-keeper.dead .mkimg { filter: grayscale(1) contrast(1.1) brightness(0.55); border-color: var(--bad); }
+.mini-keeper.dead .mknm  { color: var(--text-dim); text-decoration: line-through; text-decoration-color: var(--bad); }
+
+/* v5 refinements */
+/* ─── Nav refinements — add brand block + softer dividers ─── */
+.nav {
+  background: var(--bg-ink);
+  border-right: 1px solid var(--border-soft);
+  padding-top: 0;
+}
+.nav-brand {
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--border-soft);
+  margin-bottom: 8px;
+}
+.nav-brand .nb-t {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-faint);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.nav-brand .nb-s {
+  font-family: var(--font-display);
+  font-size: 14px;
+  color: var(--text-bright);
+  font-weight: 500;
+  margin-top: 2px;
+}
+.nav-sec {
+  color: var(--text-faint);
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  padding: 10px 16px 4px;
+}
+.nav a {
+  border-radius: 5px;
+  margin: 0 8px;
+  padding: 7px 10px;
+  gap: 9px;
+  color: var(--text);
+  font-size: 12px;
+}
+.nav a:hover { background: rgba(255,255,255,0.025); }
+.nav a.active {
+  background: rgba(90,122,58,0.10);
+  color: var(--text-bright);
+  box-shadow: inset 3px 0 0 var(--ok);
+}
+.nav a svg { width: 14px; height: 14px; opacity: 0.75; }
+.nav a .tail {
+  font-size: 9.5px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.04);
+  color: var(--text-dim);
+  border: 1px solid var(--border-soft);
+}
+.nav a .tail.bad { background: rgba(200,40,40,0.12); color: #ef8080; border-color: rgba(200,40,40,0.25); }
+.nav a .tail.warn { background: rgba(180,140,40,0.12); color: #e5c072; border-color: rgba(180,140,40,0.25); }
+
+.nav-roster { margin-top: 12px; border-top: 1px solid var(--border-soft); padding-top: 8px; }
+.nav-roster .nrt {
+  font-family: var(--font-mono); font-size: 9.5px;
+  color: var(--text-faint); letter-spacing: 0.14em;
+  padding: 4px 16px 6px;
+}

--- a/dashboard/src/styles/ds-dashboard-kit/palette.css
+++ b/dashboard/src/styles/ds-dashboard-kit/palette.css
@@ -1,0 +1,61 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · palette
+   ⌘K command palette
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ─── COMMAND PALETTE ────────────────────────────────── */
+.palette-backdrop {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.45); backdrop-filter: blur(3px);
+  opacity: 0; pointer-events: none; transition: opacity 150ms ease; z-index: 80;
+}
+.palette-backdrop.on { opacity: 1; pointer-events: auto; }
+.palette {
+  position: fixed; top: 15%; left: 50%; transform: translateX(-50%) scale(0.96);
+  width: min(640px, 90vw); max-height: 62vh; display: flex; flex-direction: column;
+  background: linear-gradient(180deg, #1c140e, #120b07);
+  border: 1px solid var(--accent-brass-dim);
+  box-shadow: 0 30px 80px rgba(0,0,0,0.7), inset 0 1px 0 rgba(138,106,40,0.2);
+  opacity: 0; pointer-events: none; transition: all 150ms ease; z-index: 90;
+}
+.palette.on { opacity: 1; transform: translateX(-50%) scale(1); pointer-events: auto; }
+.palette-bar {
+  display: flex; align-items: center; gap: 10px; padding: 12px 14px;
+  border-bottom: 1px solid var(--border-highlight);
+}
+.palette-bar svg { width: 14px; height: 14px; color: var(--accent-brass); }
+.palette-input {
+  flex: 1; background: transparent; border: 0; color: var(--text-bright);
+  font-family: var(--font-ui); font-size: 14px; outline: none;
+  letter-spacing: 0.02em;
+}
+.palette-input::placeholder { color: var(--text-dim); }
+.palette-esc { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); padding: 3px 7px; border: 1px solid var(--border-main); letter-spacing: 0.14em; }
+.palette-list { flex: 1; overflow: auto; padding: 6px 0; }
+.palette-item {
+  display: grid; grid-template-columns: 50px 1fr auto; gap: 12px;
+  padding: 9px 14px; align-items: center; cursor: pointer;
+  border-left: 2px solid transparent;
+  transition: background 100ms ease, border-color 100ms ease;
+}
+.palette-item:hover, .palette-item.sel {
+  background: rgba(138,106,40,0.08); border-left-color: var(--accent-brass);
+}
+.palette-item .kind {
+  font-family: var(--font-display); font-size: 8.5px; letter-spacing: 0.22em;
+  color: var(--text-dim); text-transform: uppercase; font-weight: 600;
+}
+.palette-item.action .kind { color: var(--accent-brass); }
+.palette-item.nav .kind    { color: #7aa3d4; }
+.palette-item.set .kind    { color: var(--text-dim); }
+.palette-item .t { font-size: 13px; color: var(--text-bright); }
+.palette-item .sub { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); margin-top: 1px; }
+.palette-item .chord { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); padding: 2px 6px; border: 1px solid var(--border-main); letter-spacing: 0.08em; }
+.palette-foot {
+  display: flex; gap: 14px; padding: 8px 14px; border-top: 1px solid var(--border-main);
+  font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim);
+}
+.palette-foot kbd {
+  font-family: var(--font-mono); font-size: 9px; padding: 1px 5px;
+  border: 1px solid var(--border-main); background: rgba(14,10,8,0.6);
+  color: var(--text-primary); margin-right: 3px;
+}

--- a/dashboard/src/styles/ds-dashboard-kit/pressure.css
+++ b/dashboard/src/styles/ds-dashboard-kit/pressure.css
@@ -1,0 +1,21 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · pressure
+   Stacked pressure chart — context · cpu · mem · msg/s
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Pressure chart ── */
+.pressure { border: 1px solid var(--hair); background: rgba(14,10,8,0.42); }
+.pressure-row {
+  display: grid; grid-template-columns: 228px 1fr;
+  border-bottom: 1px solid var(--hair);
+  background: linear-gradient(180deg, rgba(20,14,10,0.5), rgba(8,5,4,0.4));
+}
+.pressure-row:last-child { border-bottom: 0; }
+.pressure-row .p-lbl {
+  border-right: 1px solid var(--hair); padding: 10px 12px;
+  display: flex; align-items: center; gap: 9px;
+}
+.pressure-row .p-lbl .pt { font-family: var(--font-display); font-size: 11px; letter-spacing: 0.18em; color: var(--accent-brass); text-transform: uppercase; }
+.pressure-row .p-lbl .pm { font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); margin-left: auto; font-variant-numeric: tabular-nums; }
+.pressure-row .p-svg { height: 56px; }
+.pressure-row svg { display: block; width: 100%; height: 100%; }

--- a/dashboard/src/styles/ds-dashboard-kit/primitives.css
+++ b/dashboard/src/styles/ds-dashboard-kit/primitives.css
@@ -1,0 +1,244 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC · Dashboard v5 — primitives CSS
+   Styling for shared molecules: portrait, stateDot, keeperChip,
+   statCell, pill, empty. Name-prefixed .p-* so they never clash
+   with existing component classes.
+   ══════════════════════════════════════════════════════════════ */
+
+/* ─── Portrait ────────────────────────────────────────────── */
+.p-portrait {
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  object-fit: cover;
+  border: 1px solid var(--border);
+  background: var(--surface-1);
+  filter: grayscale(0.08) contrast(1.02);
+}
+.p-portrait.p-xs { width: 16px; height: 16px; border-radius: 3px; }
+.p-portrait.p-sm { width: 20px; height: 20px; border-radius: 4px; }
+.p-portrait.p-md { width: 28px; height: 28px; border-radius: 5px; }
+.p-portrait.p-lg { width: 44px; height: 44px; border-radius: 6px; }
+.p-portrait.dead {
+  filter: grayscale(1) brightness(0.55) contrast(0.95);
+  opacity: 0.75;
+}
+
+/* Operator badge — text stand-in for portrait */
+.p-op {
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  background: color-mix(in oklab, var(--accent-brass) 14%, transparent);
+  color: var(--accent-brass);
+  font-family: var(--font-display);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  border: 1px solid color-mix(in oklab, var(--accent-brass) 30%, transparent);
+}
+
+/* ─── State dot ───────────────────────────────────────────── */
+.p-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--text-dim);
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--bg-base) 60%, transparent);
+}
+.p-dot.running    { background: var(--ok); }
+.p-dot.compacting { background: var(--warn); }
+.p-dot.paused     { background: color-mix(in oklab, var(--warn) 55%, var(--text-dim)); }
+.p-dot.dead       { background: var(--bad); }
+.p-dot.ok         { background: var(--ok); }
+.p-dot.warn       { background: var(--warn); }
+.p-dot.bad        { background: var(--bad); }
+.p-dot.op         { background: var(--accent-brass); }
+
+.p-dot[data-pulse="1"]::after {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  background: inherit;
+  opacity: 0.35;
+  animation: p-dot-pulse 1.6s ease-out infinite;
+}
+.p-dot[data-pulse="1"] { position: relative; }
+@keyframes p-dot-pulse {
+  0%   { transform: scale(1);   opacity: 0.35; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+
+/* ─── KeeperChip — portrait + name + sub + dot ────────────── */
+.p-keeperchip {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  align-items: center;
+  padding: 5px 8px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+  min-width: 0;
+}
+.p-keeperchip:hover {
+  background: color-mix(in oklab, var(--surface-2) 55%, transparent);
+  border-color: var(--border);
+}
+.p-keeperchip.selected {
+  background: color-mix(in oklab, var(--accent-brass) 10%, transparent);
+  border-color: color-mix(in oklab, var(--accent-brass) 30%, transparent);
+}
+.p-keeperchip.dead .p-kc-name { color: var(--text-dim); }
+.p-kc-main { min-width: 0; }
+.p-kc-name {
+  font-family: var(--font-display);
+  font-size: 11px;
+  color: var(--text-bright);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.p-kc-sub {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ─── StatCell — label · value · sub ──────────────────────── */
+.p-statcell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 8px;
+  border-radius: 3px;
+  background: color-mix(in oklab, var(--surface-1) 55%, transparent);
+  border: 1px solid var(--border);
+  min-width: 0;
+}
+.p-sc-lbl {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-dim);
+}
+.p-sc-val {
+  font-family: var(--font-display);
+  font-size: 13px;
+  color: var(--text-bright);
+  line-height: 1.15;
+}
+.p-sc-val.mono { font-family: var(--font-mono); font-size: 12px; }
+.p-sc-val.ok   { color: var(--ok); }
+.p-sc-val.warn { color: var(--warn); }
+.p-sc-val.bad  { color: var(--bad); }
+.p-sc-sub {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-dim);
+}
+
+/* ─── Pill ────────────────────────────────────────────────── */
+.p-pill {
+  display: inline-block;
+  padding: 1px 6px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border-radius: 2px;
+  border: 1px solid var(--border);
+  background: color-mix(in oklab, var(--surface-2) 45%, transparent);
+  color: var(--text-dim);
+}
+.p-pill.ok   { color: var(--ok);   border-color: color-mix(in oklab, var(--ok)   40%, transparent); background: color-mix(in oklab, var(--ok)   12%, transparent); }
+.p-pill.warn { color: var(--warn); border-color: color-mix(in oklab, var(--warn) 40%, transparent); background: color-mix(in oklab, var(--warn) 12%, transparent); }
+.p-pill.bad  { color: var(--bad);  border-color: color-mix(in oklab, var(--bad)  40%, transparent); background: color-mix(in oklab, var(--bad)  12%, transparent); }
+.p-pill.brass{ color: var(--accent-brass); border-color: color-mix(in oklab, var(--accent-brass) 40%, transparent); background: color-mix(in oklab, var(--accent-brass) 12%, transparent); }
+
+/* ─── Empty state — for list containers with zero rows ─────── */
+.p-empty {
+  display: grid;
+  place-items: center;
+  gap: 6px;
+  padding: 18px 12px;
+  border: 1px dashed var(--border);
+  border-radius: 4px;
+  background: color-mix(in oklab, var(--surface-1) 30%, transparent);
+  text-align: center;
+}
+.p-empty-g {
+  width: 20px;
+  height: 20px;
+  opacity: 0.4;
+  fill: var(--text-dim);
+}
+.p-empty-m {
+  font-family: var(--font-display);
+  font-size: 11px;
+  color: var(--text-bright);
+  letter-spacing: 0.03em;
+}
+.p-empty-s {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-dim);
+  max-width: 240px;
+}
+
+/* ─── Skeleton shimmer — for loading states ───────────────── */
+.p-skel {
+  position: relative;
+  overflow: hidden;
+  background: color-mix(in oklab, var(--surface-1) 70%, transparent);
+  border-radius: 3px;
+  border: 1px solid var(--border);
+}
+.p-skel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    color-mix(in oklab, var(--text-bright) 5%, transparent) 50%,
+    transparent 100%);
+  transform: translateX(-100%);
+  animation: p-skel-shimmer 1.4s ease-in-out infinite;
+}
+@keyframes p-skel-shimmer {
+  100% { transform: translateX(100%); }
+}
+
+/* ─── Error state — for failed-to-load sections ───────────── */
+.p-error {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in oklab, var(--bad) 40%, transparent);
+  background: color-mix(in oklab, var(--bad) 6%, transparent);
+  border-radius: 3px;
+  color: var(--text-bright);
+}
+.p-error-title {
+  font-family: var(--font-display);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--bad);
+}
+.p-error-body {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-dim);
+}

--- a/dashboard/src/styles/ds-dashboard-kit/shell.css
+++ b/dashboard/src/styles/ds-dashboard-kit/shell.css
@@ -1,0 +1,67 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · shell
+   Fixed grid shell — nav | main | aside
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ─── Shell ────────────────────────────────────────────── */
+.shell {
+  position: fixed; inset: 0; z-index: 1;
+  display: grid;
+  grid-template-columns: var(--nav-w) 1fr var(--aside-w);
+  grid-template-rows: var(--head-h) var(--alert-h) var(--hud-h) 1fr;
+}
+
+/* ═══ v5 overrides — insert page header row ═══ */
+/* ─── Shell grid — insert page header above alert-strip ──── */
+.shell {
+  grid-template-rows: auto auto auto auto 1fr !important;
+  grid-template-areas:
+    "topbar topbar topbar"
+    "nav    page   page"
+    "nav    alert  alert"
+    "nav    hud    aside"
+    "nav    main   aside" !important;
+}
+.page-header {
+  grid-area: page;
+  padding: 14px 22px 10px;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--bg-velvet);
+}
+.page-header .ph-crumb {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-dim);
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+.page-header .ph-title {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 500;
+  color: var(--text-bright);
+  letter-spacing: -0.01em;
+  margin: 0 0 4px;
+  display: flex; align-items: baseline; gap: 10px;
+}
+.page-header .ph-tag {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 400;
+  color: var(--text-dim);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: rgba(255,255,255,0.02);
+}
+.page-header .ph-sub {
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.5;
+  margin: 0;
+  max-width: 920px;
+  text-wrap: pretty;
+}
+.page-header .ph-sub b { color: var(--text); font-weight: 500; }

--- a/dashboard/src/styles/ds-dashboard-kit/swim-vertical.css
+++ b/dashboard/src/styles/ds-dashboard-kit/swim-vertical.css
@@ -1,0 +1,271 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · swim-vertical
+   Vertical swimlane — top=NOW, keepers as columns
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ═══════════════════════════════════════════════════════════════════
+   VERTICAL SWIMLANE
+   top = NOW, bottom = past. Keepers are columns.
+   ═══════════════════════════════════════════════════════════════════ */
+
+.swim-vertical {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  height: 580px;
+}
+
+/* header: time label + keeper column headers */
+.swim-vertical .v-head {
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-card-soft);
+}
+.swim-vertical .v-axis-head {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-faint);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 10px 10px;
+  border-right: 1px solid var(--border);
+  display: flex; align-items: center;
+}
+.swim-vertical .v-col-heads {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+}
+.vcol-head {
+  padding: 10px 12px;
+  border-right: 1px solid var(--border-soft);
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  cursor: pointer;
+  transition: background 120ms;
+}
+.vcol-head:last-child { border-right: none; }
+.vcol-head:hover { background: rgba(255,255,255,0.015); }
+.vcol-head.selected {
+  background: rgba(90,122,58,0.08);
+  box-shadow: inset 0 -2px 0 var(--ok);
+}
+.vcol-head.dead {
+  background: rgba(160,24,24,0.05);
+  opacity: 0.72;
+}
+.vcol-head .vimg {
+  width: 30px; height: 30px; border-radius: 50%;
+  border: 1px solid var(--border);
+  cursor: zoom-in;
+}
+.vcol-head.dead .vimg { filter: saturate(0.3) brightness(0.75); }
+.vcol-head .vmeta { min-width: 0; flex: 1; }
+.vcol-head .vmeta .n {
+  font-family: var(--font-display);
+  font-size: 12.5px;
+  color: var(--text-bright);
+  font-weight: 500;
+}
+.vcol-head .vmeta .sub {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-top: 1px;
+}
+.vcol-head .ctx.warn { color: var(--warn); }
+.vcol-head .ctx.bad  { color: var(--bad); }
+
+/* body: axis + column grid */
+.swim-vertical .v-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  position: relative;
+  min-height: 0;
+}
+.swim-vertical .v-axis {
+  position: relative;
+  border-right: 1px solid var(--border);
+  background: var(--bg-card-soft);
+}
+.vtk {
+  position: absolute;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 10px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-faint);
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+.vtk span {
+  background: var(--bg-card-soft);
+  padding: 1px 4px;
+}
+.vtk.maj { color: var(--text-dim); }
+.vtk.now span {
+  color: var(--accent-brass);
+  font-weight: 600;
+}
+/* tick lines extend across columns */
+.vtk::before {
+  content: '';
+  position: absolute;
+  right: 0;
+  top: 50%;
+  width: 5px;
+  height: 1px;
+  background: var(--border);
+}
+
+.swim-vertical .v-cols {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  position: relative;
+}
+/* full-width NOW line */
+.swim-vertical .v-cols::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0; right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--accent-brass), transparent);
+  opacity: 0.5;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.vcol {
+  position: relative;
+  border-right: 1px solid var(--border-soft);
+  cursor: pointer;
+  overflow: hidden;
+  background: transparent;
+  transition: background 120ms;
+}
+.vcol:last-child { border-right: none; }
+.vcol:hover { background: rgba(255,255,255,0.012); }
+.vcol.selected { background: rgba(90,122,58,0.05); }
+.vcol.dead { opacity: 0.6; }
+
+/* FSM band — leftmost 4px colored strip showing FSM state over time */
+.v-fsm-band {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 4px;
+  pointer-events: none;
+}
+.v-fsm {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  opacity: 0.75;
+}
+
+/* Tool events — labels stacked down the center-left */
+.v-tool-col {
+  position: absolute;
+  left: 10px;
+  top: 0; bottom: 0;
+  width: 110px;
+  pointer-events: none;
+}
+.v-tool {
+  position: absolute;
+  left: 0;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  padding: 1px 5px 1px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100px;
+  transform: translateY(-50%);
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  pointer-events: auto;
+}
+.v-tool.t-llm  { border-color: color-mix(in oklab, var(--t-llm)  55%, transparent); color: var(--t-llm); }
+.v-tool.t-tool { border-color: color-mix(in oklab, var(--t-tool) 55%, transparent); color: var(--t-tool); }
+.v-tool.t-net  { border-color: color-mix(in oklab, var(--t-net)  55%, transparent); color: var(--t-net); }
+.v-tool.t-db   { border-color: color-mix(in oklab, var(--t-db)   55%, transparent); color: var(--t-db); }
+.v-tool.t-err  { border-color: color-mix(in oklab, var(--t-err)  55%, transparent); color: var(--t-err); background: rgba(200,80,60,0.08); }
+
+/* Judge — small circles on right edge */
+.v-judge-col {
+  position: absolute;
+  right: 24px;
+  top: 0; bottom: 0;
+  width: 14px;
+  pointer-events: none;
+}
+.v-judge {
+  position: absolute;
+  width: 9px; height: 9px;
+  border-radius: 50%;
+  background: var(--ok);
+  box-shadow: 0 0 0 2px var(--bg-card);
+  transform: translate(0, -50%);
+  pointer-events: auto;
+}
+.v-judge.fail { background: var(--bad); }
+
+/* HILT — thin red stripes on rightmost edge */
+.v-hilt-col {
+  position: absolute;
+  right: 6px;
+  top: 0; bottom: 0;
+  width: 10px;
+  pointer-events: none;
+  display: var(--hilt-show);
+}
+.v-hilt {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  background: rgba(200,80,60,0.55);
+  border-left: 2px solid var(--bad);
+  pointer-events: auto;
+}
+.v-hilt.resolved {
+  background: rgba(138,106,40,0.35);
+  border-left-color: var(--accent-brass);
+}
+
+/* NOW line inside each column */
+.swim-vertical .v-now-line {
+  display: none;
+}
+
+/* Crosshair line in vertical mode */
+.swim-vertical .v-hover-line {
+  position: absolute;
+  left: 70px;
+  right: 0;
+  height: 1px;
+  background: rgba(138,106,40,0.55);
+  pointer-events: none;
+  display: none;
+  z-index: 5;
+}
+.swim-vertical .v-hover-line::after {
+  content: attr(title);
+  position: absolute;
+  right: 6px;
+  top: -8px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--accent-brass);
+  background: var(--bg-card);
+  padding: 1px 5px;
+  border: 1px solid rgba(138,106,40,0.4);
+  border-radius: 3px;
+}

--- a/dashboard/src/styles/ds-dashboard-kit/swim.css
+++ b/dashboard/src/styles/ds-dashboard-kit/swim.css
@@ -1,0 +1,170 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · swim
+   Horizontal swimlane — lanes, tracks, frames, judge, hilt
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── KEEPER SWIMLANE ── */
+.swim {
+  border: 1px solid var(--hair); background: rgba(14,10,8,0.42);
+  margin-top: 4px;
+}
+.swim-head {
+  display: grid; grid-template-columns: 228px 1fr;
+  border-bottom: 1px solid var(--hair);
+}
+.swim-head .spacer {
+  padding: 8px 12px; border-right: 1px solid var(--hair);
+  font-size: 9px; letter-spacing: 0.24em; text-transform: uppercase; color: var(--text-dim);
+  display: flex; align-items: center;
+}
+.swim-axis { position: relative; height: 28px; background: linear-gradient(180deg, #140d08, #0e0806); font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+.swim-axis .tk { position: absolute; top: 0; bottom: 0; border-left: 1px solid var(--hair); }
+.swim-axis .tk.maj { border-left-color: var(--hair-strong); }
+.swim-axis .tk span { position: absolute; top: 8px; left: 4px; white-space: nowrap; }
+.swim-axis .now { position: absolute; top: 0; bottom: 0; border-left: 1px solid var(--accent-brass); box-shadow: 0 0 6px var(--hair-brass); }
+.swim-axis .now span { position: absolute; top: 8px; left: 4px; color: var(--accent-brass); white-space: nowrap; }
+
+.lane { display: grid; grid-template-columns: 228px 1fr; border-bottom: 1px solid var(--hair); position: relative; transition: background 160ms ease; cursor: pointer; }
+.lane:last-child { border-bottom: 0; }
+.lane:hover { background: rgba(138,106,40,0.03); }
+.lane.selected { background: linear-gradient(90deg, rgba(138,106,40,0.07), transparent 65%); }
+.lane.selected::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--accent-brass); box-shadow: 0 0 8px var(--hair-brass); z-index: 2; }
+.lane.dead { opacity: 0.55; }
+
+.lane-meta {
+  border-right: 1px solid var(--hair);
+  padding: 8px 10px 7px;
+  display: flex; flex-direction: column; gap: 3px;
+  background: linear-gradient(180deg, rgba(28,20,14,0.5), rgba(14,10,8,0.5));
+}
+.lane-meta .row1 { display: flex; align-items: center; gap: 8px; }
+.lane-meta .pw img { width: 18px; height: 18px; object-fit: cover; border: 1px solid var(--border-main); filter: sepia(0.15) contrast(1.05) brightness(0.92); display: block; opacity: 0.9; }
+.lane.dead .lane-meta .pw img { filter: grayscale(1) contrast(1.1) brightness(0.5); border-color: var(--bad); }
+.lane-meta .n { font-family: var(--font-display); font-size: 11px; letter-spacing: 0.04em; font-weight: 600; color: var(--text-bright); text-transform: none; line-height: 1.1; }
+.lane.dead .lane-meta .n { color: var(--text-dim); text-decoration: line-through; text-decoration-color: var(--bad); }
+.lane-meta .sub { font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); margin-top: 1px; }
+.lane-meta .row2 { display: flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 9px; font-variant-numeric: tabular-nums; margin-top: 3px; }
+.lane-meta .row2 .ctx { color: var(--text-bright); }
+.lane-meta .row2 .ctx.warn { color: var(--warn); }
+.lane-meta .row2 .ctx.bad { color: var(--bad); }
+.lane-meta .row2 .sep { color: var(--border-highlight); }
+.lane-meta .row2 .m { color: var(--text-dim); }
+.lane-meta .row2 .mini-vial { flex: 1; height: 4px; background: #0a0604; border: 1px solid var(--border-main); margin-left: 4px; position: relative; }
+.lane-meta .row2 .mini-vial > span { display: block; height: 100%; }
+
+/* tracks */
+.tracks {
+  position: relative; padding: 3px 0;
+  background: repeating-linear-gradient(to right, transparent 0 99px, rgba(120,100,80,0.035) 99px 100px);
+}
+.track { position: relative; height: 13px; margin: 1px 0; }
+.track .lbl {
+  position: absolute; left: 3px; top: 1px;
+  font-family: var(--font-mono); font-size: 8px; color: var(--text-dim);
+  letter-spacing: 0.2em; text-transform: uppercase; z-index: 1;
+  pointer-events: none; opacity: 0.4;
+}
+
+.fsm-seg {
+  position: absolute; top: 1px; height: 11px;
+  font-family: var(--font-mono); font-size: 8.5px;
+  color: rgba(0,0,0,0.6); padding: 0 4px; line-height: 11px;
+  overflow: hidden; white-space: nowrap;
+  border-right: 1px solid rgba(0,0,0,0.35);
+  transition: opacity 200ms ease;
+}
+.fsm-seg.dead       { color: var(--bad); }
+.fsm-seg.offline    { color: var(--text-dim); }
+.fsm-seg.paused     { color: rgba(0,0,0,0.55); }
+.fsm-seg.crashed    { color: #fff; }
+.fsm-seg.restarting { color: #fff; }
+
+.frame {
+  position: absolute; top: 1px; height: 11px;
+  font-family: var(--font-mono); font-size: 8.5px; color: #0a0706;
+  padding: 0 3px; line-height: 11px;
+  overflow: hidden; white-space: nowrap;
+  border: 1px solid transparent; cursor: default;
+  transition: opacity 200ms ease;
+}
+.frame:hover { border-color: var(--text-bright); z-index: 3; box-shadow: 0 0 8px rgba(0,0,0,0.75); }
+.frame.t-llm   { background: var(--t-llm); }
+.frame.t-tool  { background: var(--t-tool); }
+.frame.t-fs    { background: var(--t-fs); }
+.frame.t-net   { background: var(--t-net); }
+.frame.t-db    { background: var(--t-db); }
+.frame.t-think { background: var(--t-think); color: #a89880; }
+.frame.t-err   { background: var(--t-err); color: #fff; }
+
+.judge {
+  position: absolute; top: 0; width: 12px; height: 12px;
+  transform: rotate(45deg); transform-origin: center;
+  background: var(--t-judge); border: 1px solid #6a4a10; cursor: pointer;
+}
+.judge.fail { background: var(--t-err); border-color: #400; box-shadow: 0 0 5px var(--accent-blood-glow); }
+.judge::after { content: ""; position: absolute; inset: 2px; border: 1px solid rgba(0,0,0,0.45); }
+
+.hilt {
+  position: absolute; top: 0; height: 12px;
+  background: repeating-linear-gradient(-45deg, var(--t-hilt) 0 3px, #7a2414 3px 6px);
+  border: 1px solid var(--t-hilt);
+  font-family: var(--font-mono); font-size: 8px; color: #fff;
+  padding: 0 3px; line-height: 10px; letter-spacing: 0.08em;
+  overflow: hidden; white-space: nowrap; cursor: pointer; z-index: 2;
+}
+.hilt.resolved {
+  background: repeating-linear-gradient(-45deg, #6a5a40 0 3px, #3a2a14 3px 6px);
+  border-color: var(--accent-brass-dim);
+}
+
+.now-line {
+  position: absolute; top: 0; bottom: 0; width: 1px;
+  background: var(--accent-brass); box-shadow: 0 0 5px var(--hair-brass);
+  pointer-events: none; z-index: 4;
+}
+.crosshair {
+  position: absolute; top: 0; bottom: 0; width: 1px;
+  background: rgba(232,216,184,0.35); pointer-events: none; z-index: 5;
+  display: none;
+}
+.crosshair-lbl {
+  position: fixed; transform: translate(-50%, -120%);
+  font-family: var(--font-mono); font-size: 10px; color: var(--text-bright);
+  background: #0c0806; padding: 2px 7px; border: 1px solid var(--hair-strong);
+  white-space: nowrap; pointer-events: none; z-index: 10; display: none;
+}
+
+/* legend */
+.legend { display: inline-flex; gap: 12px; font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); align-items: center; flex-wrap: wrap; }
+.legend .lg-i { display: inline-flex; align-items: center; gap: 4px; letter-spacing: 0.04em; }
+.legend .sw { width: 10px; height: 8px; display: inline-block; border: 1px solid rgba(0,0,0,0.3); }
+.legend .di { width: 9px; height: 9px; display: inline-block; background: var(--t-judge); transform: rotate(45deg); }
+.legend .di.fail { background: var(--t-err); }
+.legend .hi { width: 12px; height: 9px; display: inline-block; background: repeating-linear-gradient(-45deg, var(--t-hilt) 0 2px, #7a2414 2px 4px); }
+
+/* v5 refinements — legend + container */
+/* Swimlane legend block */
+.swim-legend {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 4px;
+  margin-bottom: 6px;
+}
+.legend { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+.lg-i { display: inline-flex; align-items: center; gap: 5px; }
+.lg-i .sw { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+.lg-i .di { width: 7px; height: 7px; border-radius: 50%; background: var(--ok); display: inline-block; }
+.lg-i .di.fail { background: var(--bad); }
+.lg-i .hi { width: 14px; height: 4px; background: rgba(200,80,60,0.5); border-radius: 2px; display: inline-block; }
+.lg-sep { color: var(--border-strong); }
+.legend-meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.legend-meta b { color: var(--text); font-weight: 500; }
+
+/* Swim container — softer */
+.swim {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}

--- a/dashboard/src/styles/ds-dashboard-kit/systems.css
+++ b/dashboard/src/styles/ds-dashboard-kit/systems.css
@@ -1,0 +1,52 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · systems
+   Collapsible system group + rows + bars + FSM chip cloud
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Systems list */
+.sys-list { display: flex; flex-direction: column; gap: 0; }
+.sys-group {
+  border: 1px solid var(--hair); background: rgba(14,10,8,0.4);
+  margin-bottom: 4px;
+}
+.sys-group-head {
+  display: flex; align-items: center; gap: 8px; padding: 6px 8px;
+  cursor: pointer; user-select: none;
+  border-bottom: 1px solid transparent;
+  transition: background 120ms ease;
+}
+.sys-group-head:hover { background: rgba(138,106,40,0.04); }
+.sys-group.open .sys-group-head { border-bottom-color: var(--hair); }
+.sys-group-head .arr { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); transition: transform 160ms ease; width: 8px; }
+.sys-group.open .sys-group-head .arr { transform: rotate(90deg); color: var(--accent-brass); }
+.sys-group-head .sn { font-family: var(--font-display); font-size: 10px; letter-spacing: 0.22em; color: var(--text-primary); text-transform: uppercase; flex: 1; }
+.sys-group.open .sys-group-head .sn { color: var(--accent-brass); }
+.sys-group-head .dots { display: inline-flex; gap: 3px; }
+.sys-group-head .dots .d { width: 6px; height: 6px; border-radius: 50%; background: var(--ok); }
+.sys-group-head .dots .d.warn { background: var(--warn); box-shadow: 0 0 4px var(--warn); }
+.sys-group-head .dots .d.bad  { background: var(--bad);  box-shadow: 0 0 4px var(--bad); }
+.sys-group-body { display: grid; grid-template-rows: 0fr; transition: grid-template-rows 220ms ease; }
+.sys-group-body > div { min-height: 0; overflow: hidden; }
+.sys-group.open .sys-group-body { grid-template-rows: 1fr; }
+.sys-row { display: grid; grid-template-columns: 1fr auto; padding: 6px 10px; border-top: 1px dashed var(--border-main); gap: 8px; align-items: center; }
+.sys-row:first-child { border-top: 0; }
+.sys-row .snm { font-family: var(--font-ui); font-size: 10.5px; color: var(--text-primary); letter-spacing: 0.04em; }
+.sys-row .smt { font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); margin-top: 1px; }
+.sys-row .sv  { font-family: var(--font-mono); font-size: 10px; color: var(--text-bright); font-variant-numeric: tabular-nums; text-align: right; }
+.sys-row .sv.bad  { color: var(--bad); }
+.sys-row .sv.warn { color: var(--warn); }
+.sys-row .sbar { grid-column: 1/-1; height: 3px; background: #0a0604; border: 1px solid var(--border-main); position: relative; overflow: hidden; margin-top: 5px; }
+.sys-row .sbar > span { display: block; height: 100%; background: linear-gradient(90deg, #5a7a3a, #8aaa4a); transition: width 300ms ease; }
+.sys-row.warn .sbar > span { background: linear-gradient(90deg, #6a5218, #c4922a); }
+.sys-row.bad  .sbar > span { background: linear-gradient(90deg, #5a0f0f, #a01818); }
+
+/* FSM chip cloud */
+.fsm-map { display: grid; grid-template-columns: repeat(3, 1fr); gap: 3px; }
+.fsm-chip {
+  font-size: 8px; letter-spacing: 0.14em; text-transform: uppercase;
+  padding: 4px 5px; text-align: center; border: 1px solid var(--border-main); background: #0e0806;
+  color: var(--text-dim); transition: all 160ms ease;
+}
+.fsm-chip.now    { color: var(--accent-brass); border-color: var(--hair-brass); background: rgba(138,106,40,0.1); box-shadow: inset 0 0 0 1px rgba(138,106,40,0.25); }
+.fsm-chip.past   { color: var(--text-primary); border-color: var(--border-highlight); }
+.fsm-chip.danger { color: var(--bad); border-color: var(--bad); opacity: 0.55; }

--- a/dashboard/src/styles/ds-dashboard-kit/topbar.css
+++ b/dashboard/src/styles/ds-dashboard-kit/topbar.css
@@ -1,0 +1,69 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · topbar
+   Brand · crumbs · roster-glance · clock · pills
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ═══ TOPBAR ═══ */
+.topbar {
+  grid-column: 1/-1; grid-row: 1 / 2;
+  display: flex; align-items: center; gap: 16px; padding: 0 18px;
+  background: linear-gradient(180deg, #1c140e, #14100c);
+  border-bottom: 1px solid var(--border-highlight);
+  box-shadow: 0 2px 0 rgba(0,0,0,0.4), inset 0 -1px 0 rgba(138,106,40,0.12);
+  position: relative; z-index: 3;
+}
+.brand { display: flex; align-items: center; gap: 10px; cursor: default; }
+.brand svg { width: 20px; height: 20px; color: var(--accent-brass); }
+.wm { font-family: 'Cinzel', 'Pretendard Variable', serif; font-size: 13px; letter-spacing: 0.28em; color: var(--text-bright); text-transform: uppercase; }
+.wm .blood { color: var(--accent-blood); text-shadow: 0 0 6px var(--accent-blood-glow); }
+
+.crumbs { display: flex; align-items: center; gap: 8px; font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--text-dim); }
+.crumbs .sep { color: var(--border-highlight); }
+.crumbs strong { color: var(--accent-brass); font-weight: 400; }
+
+/* live roster glance inside topbar */
+.roster-glance {
+  margin-left: 12px; display: flex; align-items: center; gap: 14px;
+  padding: 0 14px; border-left: 1px solid var(--border-main); border-right: 1px solid var(--border-main);
+  height: 34px;
+}
+.rg-stat { display: flex; flex-direction: column; line-height: 1; }
+.rg-stat .lbl { font-size: 8px; letter-spacing: 0.24em; color: var(--text-dim); text-transform: uppercase; }
+.rg-stat .val { font-family: var(--font-mono); font-size: 13px; color: var(--text-bright); margin-top: 3px; font-variant-numeric: tabular-nums; letter-spacing: 0.02em; }
+.rg-stat .val.ok   { color: var(--ok); }
+.rg-stat .val.warn { color: var(--warn); }
+.rg-stat .val.bad  { color: var(--bad); }
+.rg-stat .val.brass{ color: var(--accent-brass); }
+
+.top-right { margin-left: auto; display: flex; align-items: center; gap: 8px; }
+.clock { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); font-variant-numeric: tabular-nums; letter-spacing: 0.08em; white-space: nowrap; }
+.clock b { color: var(--text-bright); font-weight: 400; }
+
+.pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase;
+  padding: 4px 9px; border: 1px solid var(--border-main);
+  background: rgba(14,10,8,0.6); color: var(--text-primary); cursor: default;
+  font-family: var(--font-ui);
+}
+.pill .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; box-shadow: 0 0 6px currentColor; }
+.pill.ok   { color: var(--ok);  border-color: color-mix(in oklab, var(--ok) 35%, transparent); }
+.pill.warn { color: var(--warn);border-color: color-mix(in oklab, var(--warn) 35%, transparent); }
+.pill.bad  { color: var(--bad); border-color: color-mix(in oklab, var(--bad) 40%, transparent); }
+.pill.brass{ color: var(--accent-brass); border-color: var(--hair-brass); }
+
+.pill .k { color: var(--text-dim); letter-spacing: 0.15em; }
+.pill .v { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.04em; text-transform: none; }
+
+/* v5 refinements */
+/* ─── Topbar refinements ─── */
+.topbar {
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--bg-ink);
+}
+.topbar .crumbs,
+.topbar .crumbs strong { font-size: 11px; }
+.top-right .pill {
+  background: transparent;
+  border-color: var(--border);
+}

--- a/dashboard/src/styles/ds-dashboard-kit/tweaks.css
+++ b/dashboard/src/styles/ds-dashboard-kit/tweaks.css
@@ -1,0 +1,29 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC Observatory v5 · tweaks
+   Floating Tweaks panel + flash animation
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Tweaks panel */
+#tweaks {
+  position: fixed; right: 16px; bottom: 16px; width: 280px;
+  background: linear-gradient(180deg, #1a140e, #0e0806);
+  border: 1px solid var(--hair-brass);
+  padding: 12px 14px; display: none; z-index: 50;
+  box-shadow: 0 10px 32px rgba(0,0,0,0.6), inset 0 0 0 1px rgba(138,106,40,0.1);
+  font-family: var(--font-ui); font-size: 11px;
+}
+#tweaks.on { display: block; }
+#tweaks h5 { margin: 0 0 8px; font-family: var(--font-display); font-size: 11px; letter-spacing: 0.22em; color: var(--accent-brass); text-transform: uppercase; }
+#tweaks .row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 5px 0; border-bottom: 1px solid var(--border-main); }
+#tweaks .row:last-child { border-bottom: 0; }
+#tweaks .row .l { color: var(--text-dim); font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; }
+#tweaks .row .seg { display: inline-flex; gap: 2px; }
+#tweaks .row .seg button { font: inherit; font-size: 9px; padding: 3px 7px; letter-spacing: 0.14em; text-transform: uppercase; background: transparent; border: 1px solid var(--border-main); color: var(--text-dim); cursor: pointer; }
+#tweaks .row .seg button.on { color: var(--accent-brass); border-color: var(--hair-brass); background: rgba(138,106,40,0.06); }
+
+/* Smooth-update flash — applied briefly when a value changes */
+@keyframes flash {
+  0%   { background-color: rgba(138,106,40,0.25); }
+  100% { background-color: transparent; }
+}
+.flash { animation: flash 600ms ease-out; }

--- a/dashboard/src/styles/ds-ui-kits.css
+++ b/dashboard/src/styles/ds-ui-kits.css
@@ -1,0 +1,9 @@
+/* ═══════════════════════════════════════════════════════════════
+   EXPERIMENTAL: keeper-v2 design-system UI kits
+   These stylesheets are delivered as an opt-in, experimental layer.
+   They may conflict with existing v2-* styles; enable only after review.
+   ═══════════════════════════════════════════════════════════════ */
+
+@import url("./ds-dashboard-kit/index.css");
+@import url("./ds-cockpit-kit/index.css");
+@import url("./ds-viewer-kit/index.css");

--- a/dashboard/src/styles/ds-ui-kits.test.ts
+++ b/dashboard/src/styles/ds-ui-kits.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const STYLES_DIR = resolve(__dirname)
+
+function kitDir(name: string): string {
+  return resolve(STYLES_DIR, name)
+}
+
+describe('keeper-v2 DS UI kit asset delivery', () => {
+  it('delivers dashboard kit files and index.css', () => {
+    const dir = kitDir('ds-dashboard-kit')
+    expect(existsSync(dir)).toBe(true)
+    const files = readdirSync(dir)
+    expect(files).toContain('index.css')
+    expect(files).toContain('base.css')
+    expect(files).toContain('shell.css')
+    expect(files).toContain('primitives.css')
+    expect(files.length).toBeGreaterThan(10)
+  })
+
+  it('delivers cockpit kit files and index.css', () => {
+    const dir = kitDir('ds-cockpit-kit')
+    expect(existsSync(dir)).toBe(true)
+    const files = readdirSync(dir)
+    expect(files).toContain('index.css')
+    expect(files).toContain('tokens.css')
+    expect(files).toContain('layout.css')
+    expect(files).toContain('swimlanes.css')
+    expect(files.length).toBeGreaterThan(5)
+  })
+
+  it('delivers viewer kit files and index.css', () => {
+    const dir = kitDir('ds-viewer-kit')
+    expect(existsSync(dir)).toBe(true)
+    const files = readdirSync(dir)
+    expect(files).toContain('index.css')
+    expect(files).toContain('tokens.css')
+    expect(files).toContain('shell.css')
+    expect(files).toContain('theme-paper.css')
+    expect(files.length).toBeGreaterThan(5)
+  })
+
+  it('imports all three kit indices from ds-ui-kits.css', () => {
+    const css = readFileSync(resolve(STYLES_DIR, 'ds-ui-kits.css'), 'utf-8')
+    expect(css).toContain('@import url("./ds-dashboard-kit/index.css")')
+    expect(css).toContain('@import url("./ds-cockpit-kit/index.css")')
+    expect(css).toContain('@import url("./ds-viewer-kit/index.css")')
+  })
+})

--- a/dashboard/src/styles/ds-viewer-kit/composer.css
+++ b/dashboard/src/styles/ds-viewer-kit/composer.css
@@ -1,0 +1,67 @@
+/* ─── Composer — interject + action buttons ─────────────── */
+
+.v-composer {
+  display: flex;
+  gap: var(--sp-2);
+  align-items: center;
+  padding: var(--sp-3) var(--sp-5);
+  border-top: 1px solid var(--line);
+  background: var(--surf-panel);
+}
+.v-composer .c-input {
+  flex: 1;
+  min-width: 0;
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  background: var(--surf-sink);
+  color: var(--text-bright);
+  font-family: var(--font-ui);
+  font-size: var(--fs-3);
+  transition: border-color 0.12s;
+}
+.v-composer .c-input:focus {
+  outline: none;
+  border-color: var(--line-accent);
+  background: var(--bg);
+}
+.v-composer .c-input::placeholder { color: var(--text-dim); }
+
+.v-composer .c-btn {
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  background: var(--surf-raised);
+  color: var(--text-bright);
+  font-family: var(--font-display);
+  font-size: var(--fs-3);
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: all 0.12s;
+  white-space: nowrap;
+  line-height: 1.3;
+}
+.v-composer .c-btn:hover {
+  border-color: var(--line-accent);
+  background: color-mix(in oklab, var(--accent-brass) 8%, var(--surf-raised));
+}
+.v-composer .c-btn.primary {
+  color: var(--accent-brass);
+  border-color: var(--line-accent);
+  background: color-mix(in oklab, var(--accent-brass) 12%, transparent);
+  font-weight: 500;
+}
+.v-composer .c-btn.danger {
+  color: var(--bad);
+  border-color: color-mix(in oklab, var(--bad) 40%, transparent);
+}
+.v-composer .c-btn.danger:hover {
+  background: color-mix(in oklab, var(--bad) 12%, transparent);
+  border-color: color-mix(in oklab, var(--bad) 55%, transparent);
+}
+.v-composer .c-sep {
+  width: 1px;
+  height: 22px;
+  background: var(--line);
+  margin: 0 var(--sp-1);
+}

--- a/dashboard/src/styles/ds-viewer-kit/context.css
+++ b/dashboard/src/styles/ds-viewer-kit/context.css
@@ -1,0 +1,150 @@
+/* ─── Context stack view — system/user/tool prompt hierarchy ── */
+
+.ctx-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+/* Budget bar at top */
+.ctx-budget {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--sp-3);
+  align-items: center;
+  padding: var(--sp-3) var(--sp-3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  background: var(--surf-raised);
+  margin-bottom: var(--sp-3);
+}
+.ctx-budget-label {
+  font-family: var(--font-display);
+  font-size: var(--fs-1);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-dim);
+  font-weight: 500;
+}
+.ctx-budget-bar {
+  position: relative;
+  height: 8px;
+  border-radius: var(--r-1);
+  background: var(--surf-sink);
+  overflow: hidden;
+  border: 1px solid var(--line);
+}
+.ctx-budget-bar > span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: linear-gradient(90deg,
+    var(--accent-brass) 0%,
+    color-mix(in oklab, var(--accent-brass) 70%, var(--warn)) 80%,
+    var(--warn) 100%);
+  transition: width 0.5s ease-out;
+}
+.ctx-budget-bar .tick {
+  position: absolute;
+  top: -2px; bottom: -2px;
+  width: 1px;
+  background: var(--warn);
+}
+.ctx-budget-val {
+  font-family: var(--font-mono);
+  font-size: var(--fs-3);
+  color: var(--text-bright);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+}
+.ctx-budget-val b { color: var(--accent-brass); font-weight: 500; }
+
+/* ─ Context slot rows ─ */
+.ctx-slot {
+  display: grid;
+  grid-template-columns: 66px 16px 1fr auto;
+  gap: var(--sp-3);
+  align-items: center;
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  background: var(--surf-raised);
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.ctx-slot:hover {
+  background: var(--surf-hover);
+  border-color: var(--line-strong);
+}
+.ctx-slot.selected {
+  background: var(--surf-selected);
+  border-color: var(--line-accent);
+  box-shadow: inset 2px 0 0 var(--accent-brass);
+}
+
+.ctx-role {
+  font-family: var(--font-display);
+  font-size: var(--fs-1);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 500;
+  padding: 2px var(--sp-2);
+  border-radius: var(--r-1);
+  text-align: center;
+}
+.ctx-slot[data-role="system"]    .ctx-role { color: var(--accent-brass); background: color-mix(in oklab, var(--accent-brass) 14%, transparent); }
+.ctx-slot[data-role="user"]      .ctx-role { color: var(--text-bright); background: color-mix(in oklab, var(--surface-2) 65%, transparent); }
+.ctx-slot[data-role="assistant"] .ctx-role { color: var(--ok); background: color-mix(in oklab, var(--ok) 12%, transparent); }
+.ctx-slot[data-role="tool"]      .ctx-role { color: var(--ph-tool); background: color-mix(in oklab, var(--ph-tool) 18%, transparent); }
+
+.ctx-badge {
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--text-dim);
+  background: var(--surf-sink);
+  border: 1px solid var(--line);
+}
+.ctx-slot.pinned .ctx-badge {
+  background: color-mix(in oklab, var(--accent-brass) 30%, transparent);
+  color: var(--accent-brass);
+  border-color: var(--line-accent);
+}
+.ctx-slot.pinned .ctx-badge::before { content: "●"; }
+.ctx-slot.warn .ctx-badge           { color: var(--warn); border-color: color-mix(in oklab, var(--warn) 40%, transparent); background: color-mix(in oklab, var(--warn) 15%, transparent); }
+.ctx-slot.warn .ctx-badge::before   { content: "!"; }
+.ctx-slot.block .ctx-badge          { color: var(--bad); border-color: color-mix(in oklab, var(--bad) 40%, transparent); background: color-mix(in oklab, var(--bad) 15%, transparent); }
+.ctx-slot.block .ctx-badge::before  { content: "×"; }
+.ctx-slot.old                       { opacity: 0.55; }
+
+.ctx-main { min-width: 0; }
+.ctx-kind {
+  font-family: var(--font-ui);
+  font-size: var(--fs-3);
+  color: var(--text-bright);
+  letter-spacing: 0.01em;
+  line-height: var(--lh-tight);
+}
+.ctx-note {
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+
+.ctx-tokens {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2);
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  letter-spacing: 0.02em;
+}
+.ctx-tokens b {
+  color: var(--text-bright);
+  font-weight: 500;
+}

--- a/dashboard/src/styles/ds-viewer-kit/header.css
+++ b/dashboard/src/styles/ds-viewer-kit/header.css
@@ -1,0 +1,103 @@
+/* ─── Viewer keeper header (above tabs) ──────────────────── */
+
+.v-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--sp-4);
+  align-items: center;
+  padding: var(--sp-3) var(--sp-5);
+  border-bottom: 1px solid var(--line);
+  background: var(--surf-panel);
+}
+
+.v-header .vh-portrait {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--r-3);
+  border: 1px solid var(--line-strong);
+  object-fit: cover;
+  box-shadow:
+    0 1px 3px rgba(0,0,0,0.5),
+    inset 0 0 0 1px color-mix(in oklab, var(--accent-brass) 15%, transparent);
+}
+.v-header .vh-portrait.dead {
+  filter: grayscale(1) brightness(0.55);
+}
+
+.v-header .vh-main { min-width: 0; overflow: hidden; }
+.v-header .vh-name {
+  font-family: var(--font-display);
+  font-size: var(--fs-6);
+  font-weight: 600;
+  color: var(--text-bright);
+  letter-spacing: 0.015em;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  line-height: var(--lh-tight);
+  min-width: 0;
+}
+.v-header .vh-name .nm {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.v-header .vh-sub {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2);
+  color: var(--text-dim);
+  margin-top: var(--sp-1);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+  font-variant-numeric: tabular-nums;
+  min-width: 0;
+}
+.v-header .vh-sub > span { min-width: 0; }
+.v-header .vh-sub .job {
+  max-width: 22ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+  vertical-align: bottom;
+}
+.v-header .vh-sub .sep { opacity: 0.4; }
+.v-header .vh-sub b { color: var(--text-bright); font-weight: 500; }
+
+.v-header .vh-actions {
+  display: flex;
+  gap: var(--sp-1);
+}
+.v-header .vh-actions .btn {
+  font-family: var(--font-display);
+  font-size: var(--fs-3);
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--r-2);
+  border: 1px solid var(--line);
+  background: var(--surf-raised);
+  color: var(--text-bright);
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  transition: all 0.12s;
+  line-height: 1.4;
+}
+.v-header .vh-actions .btn:hover {
+  border-color: var(--line-accent);
+  background: color-mix(in oklab, var(--accent-brass) 10%, var(--surf-raised));
+}
+.v-header .vh-actions .btn.danger {
+  color: var(--bad);
+  border-color: color-mix(in oklab, var(--bad) 35%, transparent);
+}
+.v-header .vh-actions .btn.danger:hover {
+  background: color-mix(in oklab, var(--bad) 12%, transparent);
+  border-color: color-mix(in oklab, var(--bad) 55%, transparent);
+}
+.v-header .vh-actions .btn.primary {
+  color: var(--accent-brass);
+  border-color: var(--line-accent);
+  background: color-mix(in oklab, var(--accent-brass) 10%, transparent);
+}

--- a/dashboard/src/styles/ds-viewer-kit/index.css
+++ b/dashboard/src/styles/ds-viewer-kit/index.css
@@ -1,0 +1,31 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC · Viewer v5 — stylesheet index
+   Cascade: base (shared) → shell → chrome → views → overlays
+   ═══════════════════════════════════════════════════════════════ */
+
+/* tokens first — everything else references these vars */
+@import url("tokens.css");
+
+/* shell + chrome */
+@import url("shell.css");
+@import url("topbar.css");
+@import url("sidebar.css");
+@import url("header.css");
+@import url("tabs.css");
+
+/* views */
+@import url("tape.css");
+@import url("context.css");
+@import url("waterfall.css");
+
+/* right rail */
+@import url("inspector.css");
+
+/* footer + overlays */
+@import url("composer.css");
+@import url("tweaks.css");
+@import url("split.css");
+@import url("states.css");
+
+/* themes (applied via [data-theme="…"] on <html>) */
+@import url("theme-paper.css");

--- a/dashboard/src/styles/ds-viewer-kit/inspector.css
+++ b/dashboard/src/styles/ds-viewer-kit/inspector.css
@@ -1,0 +1,208 @@
+/* ─── Inspector (right rail) ───────────────────────────── */
+
+.v-inspector {
+  border-left: 1px solid var(--line);
+  background: var(--surf-rail);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+/* ─ Tabs ─ */
+.v-insp-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in oklab, var(--surface-2) 35%, transparent);
+  flex: 0 0 auto;
+}
+.v-insp-tab {
+  flex: 1;
+  padding: var(--sp-2) var(--sp-1);
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  font-family: var(--font-display);
+  font-size: var(--fs-1);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 500;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.12s, background 0.12s;
+}
+.v-insp-tab:hover {
+  color: var(--text-bright);
+  background: var(--surf-hover);
+}
+.v-insp-tab.on {
+  color: var(--accent-brass);
+  border-bottom-color: var(--accent-brass);
+}
+
+/* ─ Body ─ */
+.v-insp-body {
+  padding: var(--sp-4);
+  font-family: var(--font-ui);
+  font-size: var(--fs-3);
+  color: var(--text-bright);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+  overflow-y: auto;
+}
+
+.v-insp-sec-title {
+  font-family: var(--font-display);
+  font-size: var(--fs-1);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-dim);
+  font-weight: 500;
+  padding-bottom: var(--sp-1);
+  border-bottom: 1px solid var(--line);
+  margin-bottom: var(--sp-2);
+}
+
+/* ─ Tool call detail ─ */
+.tc-row {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: var(--sp-2);
+  padding: var(--sp-1) 0;
+  font-size: var(--fs-2);
+  align-items: baseline;
+  min-width: 0;
+}
+.tc-row .l {
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: var(--fs-1);
+  font-family: var(--font-display);
+  font-weight: 500;
+}
+.tc-row .v {
+  min-width: 0;
+  color: var(--text-bright);
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+.tc-row .v.ok   { color: var(--ok); }
+.tc-row .v.warn { color: var(--warn); }
+.tc-row .v.bad  { color: var(--bad); }
+
+.tc-args {
+  margin-top: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--surf-sink);
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  font-family: var(--font-mono);
+  font-size: var(--fs-2);
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-bright);
+  line-height: 1.5;
+}
+
+/* ─ Judge scores ─ */
+.jd-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  background: var(--surf-raised);
+  align-items: center;
+}
+.jd-row.pass {
+  border-color: color-mix(in oklab, var(--ok) 35%, transparent);
+  background: color-mix(in oklab, var(--ok) 8%, transparent);
+}
+.jd-row.fail {
+  border-color: color-mix(in oklab, var(--bad) 35%, transparent);
+  background: color-mix(in oklab, var(--bad) 8%, transparent);
+}
+.jd-n {
+  font-family: var(--font-ui);
+  font-size: var(--fs-3);
+  color: var(--text-bright);
+}
+.jd-mark {
+  font-family: var(--font-display);
+  font-size: var(--fs-3);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.jd-row.pass .jd-mark { color: var(--ok); }
+.jd-row.fail .jd-mark { color: var(--bad); }
+
+/* ─ Siblings list ─ */
+.sib-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--sp-2);
+  align-items: center;
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--r-2);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.sib-row:hover { background: var(--surf-hover); }
+.sib-row img {
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-2);
+  object-fit: cover;
+  border: 1px solid var(--line);
+}
+.sib-row img.dead { filter: grayscale(1) brightness(0.5); }
+.sib-n {
+  font-family: var(--font-ui);
+  font-size: var(--fs-3);
+  color: var(--text-bright);
+}
+.sib-s {
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─ Thread (chain of consequences) ─ */
+.thr-step {
+  display: grid;
+  grid-template-columns: 14px 1fr;
+  gap: var(--sp-2);
+  padding: var(--sp-1) 0;
+  font-size: var(--fs-3);
+  align-items: start;
+}
+.thr-step .dot {
+  margin-top: 6px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-brass);
+  box-shadow: 0 0 0 2px var(--bg);
+}
+.thr-step.err .dot  { background: var(--bad); }
+.thr-step.warn .dot { background: var(--warn); }
+.thr-step .body {
+  color: var(--text-bright);
+  line-height: var(--lh-body);
+  font-family: var(--font-ui);
+}
+.thr-step .meta {
+  color: var(--text-dim);
+  font-size: var(--fs-1);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}

--- a/dashboard/src/styles/ds-viewer-kit/shell.css
+++ b/dashboard/src/styles/ds-viewer-kit/shell.css
@@ -1,0 +1,51 @@
+/* ─── Viewer shell layout ────────────────────────────────── */
+/* 4-zone grid: topbar · sidebar · main · inspector
+   rail / panel / sink 로 배경 대비를 벌려 zone 구분을 시각화. */
+
+.v-shell {
+  display: grid;
+  grid-template-columns: 232px 1fr 360px;
+  grid-template-rows: 48px 1fr;
+  grid-template-areas:
+    "topbar topbar topbar"
+    "sidebar main inspector";
+  height: 100vh;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text-bright);
+  overflow: hidden;
+}
+
+/* Split mode — inspector 자리에 second keeper 스택 */
+.v-shell[data-split="1"] {
+  grid-template-columns: 232px 1fr 1fr;
+  grid-template-areas:
+    "topbar topbar topbar"
+    "sidebar main main-2";
+}
+
+.v-topbar    { grid-area: topbar; z-index: 2; }
+.v-sidebar   { grid-area: sidebar; }
+.v-main      {
+  grid-area: main;
+  display: grid;
+  grid-template-rows: auto auto auto 1fr auto;
+  min-height: 0;
+  min-width: 0;
+  background: var(--surf-panel);
+}
+.v-inspector { grid-area: inspector; }
+.v-main-2    { grid-area: main-2; display: none; }
+.v-shell[data-split="1"] .v-main-2 { display: grid; }
+.v-shell[data-split="1"] .v-inspector { display: none; }
+
+/* narrower viewports — collapse inspector into tab */
+@media (max-width: 1320px) {
+  .v-shell {
+    grid-template-columns: 208px 1fr;
+    grid-template-areas:
+      "topbar topbar"
+      "sidebar main";
+  }
+  .v-inspector { display: none; }
+}

--- a/dashboard/src/styles/ds-viewer-kit/sidebar.css
+++ b/dashboard/src/styles/ds-viewer-kit/sidebar.css
@@ -1,0 +1,84 @@
+/* ─── Viewer sidebar (left rail · keeper switcher) ─────────── */
+
+.v-sidebar {
+  border-right: 1px solid var(--line);
+  background: var(--surf-rail);
+  overflow-y: auto;
+  padding: var(--sp-3) var(--sp-2) var(--sp-5);
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.v-sb-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: var(--sp-1) var(--sp-2) var(--sp-2);
+}
+.v-sb-title {
+  font-family: var(--font-display);
+  font-size: var(--fs-1);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  font-weight: 500;
+}
+.v-sb-count {
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--text-bright);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+}
+
+.v-sb-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+/* Keeper row — density packed for 8+ keepers at once */
+.v-sidebar .p-keeperchip {
+  padding: var(--sp-2) var(--sp-2);
+  border-radius: var(--r-2);
+  border: 1px solid transparent;
+  border-left: 2px solid transparent;
+  transition: background 0.12s, border-color 0.12s;
+}
+.v-sidebar .p-keeperchip:hover {
+  background: var(--surf-hover);
+  border-color: var(--line);
+  border-left-color: var(--line-strong);
+}
+.v-sidebar .p-keeperchip.selected {
+  border-left-color: var(--accent-brass);
+  background: var(--surf-selected);
+  border-color: var(--line-accent);
+}
+
+.v-sb-sep {
+  height: 1px;
+  background: var(--line);
+  margin: var(--sp-3) var(--sp-1);
+}
+
+.v-sb-back {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-2);
+  font-family: var(--font-ui);
+  font-size: var(--fs-3);
+  color: var(--text-dim);
+  text-decoration: none;
+  border-radius: var(--r-2);
+  transition: color 0.12s, background 0.12s;
+  margin-top: auto;
+}
+.v-sb-back:hover {
+  color: var(--accent-brass);
+  background: var(--surf-hover);
+}
+.v-sb-back svg { width: 13px; height: 13px; flex: 0 0 auto; }

--- a/dashboard/src/styles/ds-viewer-kit/split.css
+++ b/dashboard/src/styles/ds-viewer-kit/split.css
@@ -1,0 +1,84 @@
+/* ─── Split view — 2 keepers side-by-side ──────────────────
+   Inspector zone is replaced by `.v-main-2`, a second
+   tape column with its own header + keeper picker.
+   Both columns share the tape timestamp axis via CSS var.
+   ─────────────────────────────────────────────────────────── */
+
+.v-main-2 {
+  grid-template-rows: auto 1fr;
+  min-height: 0; min-width: 0;
+  border-left: 1px solid var(--line);
+  background: var(--surf-panel);
+}
+
+.sp2-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--sp-3);
+  align-items: center;
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--line);
+  background: var(--surf-raised);
+}
+.sp2-head img {
+  width: 32px; height: 32px;
+  border-radius: var(--r-2);
+  border: 1px solid var(--line-strong);
+  object-fit: cover;
+}
+.sp2-head img.dead { filter: grayscale(1) brightness(0.55); }
+.sp2-head .nm {
+  font-family: var(--font-display);
+  font-size: var(--fs-5);
+  font-weight: 600;
+  color: var(--text-bright);
+  line-height: var(--lh-tight);
+}
+.sp2-head .sub {
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--text-dim);
+  margin-top: 2px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+}
+.sp2-head select {
+  background: var(--surf-sink);
+  color: var(--text-bright);
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  padding: var(--sp-1) var(--sp-2);
+  font-family: var(--font-ui);
+  font-size: var(--fs-3);
+  cursor: pointer;
+}
+.sp2-head select:focus {
+  outline: none;
+  border-color: var(--line-accent);
+}
+
+.sp2-body {
+  overflow-y: auto;
+  padding: var(--sp-4) var(--sp-5);
+  min-height: 0;
+}
+
+/* Shared timeline marker — brass rule across both columns */
+.sp-marker {
+  height: 1px;
+  background: color-mix(in oklab, var(--accent-brass) 30%, transparent);
+  margin: var(--sp-2) calc(-1 * var(--sp-5));
+  position: relative;
+}
+.sp-marker::after {
+  content: attr(data-t);
+  position: absolute;
+  right: var(--sp-5);
+  top: -7px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--accent-brass);
+  background: var(--surf-panel);
+  padding: 0 var(--sp-1);
+  letter-spacing: 0.04em;
+}

--- a/dashboard/src/styles/ds-viewer-kit/states.css
+++ b/dashboard/src/styles/ds-viewer-kit/states.css
@@ -1,0 +1,129 @@
+/* ─── Viewer state banners & inline notices ─────────────────
+   non-running keeper를 선택했을 때 tape 상단에 noticable banner.
+   색: paused → warn, dead → bad.
+   ─────────────────────────────────────────────────────────── */
+
+.v-banner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--sp-3);
+  align-items: center;
+  padding: var(--sp-3) var(--sp-5);
+  border-bottom: 1px solid var(--line);
+  background: var(--surf-raised);
+  color: var(--text-bright);
+  font-family: var(--font-ui);
+  font-size: var(--fs-3);
+  line-height: var(--lh-tight);
+}
+.v-banner .bn-glyph {
+  width: 24px; height: 24px;
+  display: grid; place-items: center;
+  border-radius: 50%;
+  border: 1px solid var(--line);
+  color: var(--text-dim);
+}
+.v-banner .bn-glyph svg { width: 13px; height: 13px; fill: currentColor; }
+.v-banner .bn-title {
+  font-family: var(--font-display);
+  font-size: var(--fs-4);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.v-banner .bn-body {
+  font-size: var(--fs-3);
+  color: var(--text-dim);
+  margin-top: 2px;
+}
+.v-banner .bn-body b { color: var(--text-bright); font-weight: 500; }
+.v-banner .bn-actions { display: flex; gap: var(--sp-1); }
+.v-banner .bn-btn {
+  padding: var(--sp-1) var(--sp-3);
+  border: 1px solid currentColor;
+  border-radius: var(--r-2);
+  background: transparent;
+  color: inherit;
+  font-family: var(--font-display);
+  font-size: var(--fs-2);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background 0.12s;
+}
+.v-banner .bn-btn:hover {
+  background: color-mix(in oklab, currentColor 14%, transparent);
+}
+
+/* ─ Tone variants ─ */
+.v-banner.warn {
+  background: color-mix(in oklab, var(--warn) 10%, var(--surf-raised));
+  border-bottom-color: color-mix(in oklab, var(--warn) 35%, transparent);
+  color: var(--warn);
+}
+.v-banner.warn .bn-glyph {
+  border-color: color-mix(in oklab, var(--warn) 45%, transparent);
+  background: color-mix(in oklab, var(--warn) 18%, transparent);
+  color: var(--warn);
+}
+
+.v-banner.bad {
+  background: color-mix(in oklab, var(--bad) 10%, var(--surf-raised));
+  border-bottom-color: color-mix(in oklab, var(--bad) 35%, transparent);
+  color: var(--bad);
+}
+.v-banner.bad .bn-glyph {
+  border-color: color-mix(in oklab, var(--bad) 45%, transparent);
+  background: color-mix(in oklab, var(--bad) 18%, transparent);
+  color: var(--bad);
+}
+
+.v-banner.info {
+  background: color-mix(in oklab, var(--accent-brass) 8%, var(--surf-raised));
+  border-bottom-color: var(--line-accent);
+  color: var(--accent-brass);
+}
+.v-banner.info .bn-glyph {
+  border-color: var(--line-accent);
+  background: color-mix(in oklab, var(--accent-brass) 16%, transparent);
+  color: var(--accent-brass);
+}
+
+/* ─── Tape skeleton (loading / compact in-flight) ──────────── */
+.tape-sk-row {
+  display: grid;
+  grid-template-columns: 68px 16px 1fr;
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid transparent;
+  border-radius: var(--r-2);
+}
+.tape-sk-rail {
+  display: flex; justify-content: center; padding-top: 7px;
+}
+.tape-sk-dot {
+  width: 9px; height: 9px; border-radius: 50%;
+  border: 1.5px dashed var(--line-strong);
+}
+.tape-sk-line {
+  height: 8px;
+  background: color-mix(in oklab, var(--surf-raised) 100%, transparent);
+  border-radius: var(--r-1);
+  margin-bottom: var(--sp-1);
+  position: relative;
+  overflow: hidden;
+}
+.tape-sk-line::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    color-mix(in oklab, var(--accent-brass) 12%, transparent) 50%,
+    transparent 100%);
+  animation: shimmer 1.6s linear infinite;
+}
+@keyframes shimmer {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}

--- a/dashboard/src/styles/ds-viewer-kit/tabs.css
+++ b/dashboard/src/styles/ds-viewer-kit/tabs.css
@@ -1,0 +1,83 @@
+/* ─── View tabs (Tape / Context / Waterfall) ───────────────── */
+
+.v-tabs {
+  display: flex;
+  align-items: stretch;
+  gap: var(--sp-1);
+  padding: 0 var(--sp-5);
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in oklab, var(--surface-1) 45%, transparent);
+}
+
+.v-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-3) calc(var(--sp-3) - 1px);
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  font-family: var(--font-display);
+  font-size: var(--fs-3);
+  letter-spacing: 0.04em;
+  font-weight: 500;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.12s, border-color 0.12s, background 0.12s;
+  position: relative;
+}
+.v-tab svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+.v-tab .cnt {
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--text-dim);
+  background: var(--surf-raised);
+  padding: 1px var(--sp-1);
+  border-radius: var(--r-1);
+  border: 1px solid var(--line);
+  font-variant-numeric: tabular-nums;
+  min-width: 18px;
+  text-align: center;
+}
+.v-tab:hover {
+  color: var(--text-bright);
+  background: var(--surf-hover);
+}
+.v-tab.on {
+  color: var(--accent-brass);
+  border-bottom-color: var(--accent-brass);
+}
+.v-tab.on .cnt {
+  color: var(--accent-brass);
+  border-color: var(--line-accent);
+  background: color-mix(in oklab, var(--accent-brass) 10%, transparent);
+}
+
+.v-tabs-hr {
+  flex: 1;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: -1px;
+}
+
+.v-tabs-meta {
+  align-self: center;
+  font-family: var(--font-mono);
+  font-size: var(--fs-2);
+  color: var(--text-dim);
+  padding: 0 var(--sp-1);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+}
+.v-tabs-meta b { color: var(--text-bright); font-weight: 500; }
+
+/* View surface */
+.v-view {
+  overflow-y: auto;
+  min-height: 0;
+  padding: var(--sp-4) var(--sp-5);
+}

--- a/dashboard/src/styles/ds-viewer-kit/tape.css
+++ b/dashboard/src/styles/ds-viewer-kit/tape.css
@@ -1,0 +1,203 @@
+/* ─── Tape view — turn-by-turn message log ─────────────────────
+   Hierarchy:
+     · timestamp gutter  (mono, dim, tabular)         → "when"
+     · rail + node       (phase color)                → "what kind"
+     · body              (sans for reading, mono for tool I/O only)
+   Rhythm: 4px baseline. Content is the star — UI chrome fades.
+   ─────────────────────────────────────────────────────────── */
+
+.tape {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.tape-empty { margin-top: var(--sp-6); }
+
+/* ─ Turn row ─ */
+.tape-turn {
+  display: grid;
+  grid-template-columns: 68px 16px 1fr;
+  gap: var(--sp-3);
+  align-items: start;
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid transparent;
+  border-radius: var(--r-2);
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.tape-turn:hover {
+  background: var(--surf-hover);
+  border-color: var(--line);
+}
+.tape-turn.selected {
+  background: var(--surf-selected);
+  border-color: var(--line-accent);
+  box-shadow: inset 2px 0 0 var(--accent-brass);
+}
+
+/* ─ Timestamp gutter ─ */
+.tape-ts {
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  padding-top: 3px;
+  line-height: var(--lh-tight);
+}
+.tape-ts .n {
+  display: block;
+  color: var(--accent-brass);
+  font-size: var(--fs-1);
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+/* ─ Rail + node ─ */
+.tape-rail {
+  position: relative;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  padding-top: 7px;
+}
+.tape-rail::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: calc(-1 * var(--sp-3));
+  width: 1px;
+  background: var(--line);
+  transform: translateX(-0.5px);
+}
+.tape-turn:last-child .tape-rail::before { display: none; }
+.tape-node {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  border: 1.5px solid var(--text-dim);
+  background: var(--bg);
+  position: relative;
+  z-index: 1;
+}
+
+/* Phase → node color */
+.tape-turn.think .tape-node    { border-color: var(--ph-think); }
+.tape-turn.tool  .tape-node    { border-color: var(--ph-tool);  background: var(--ph-tool); }
+.tape-turn.judge .tape-node    { border-color: var(--ph-judge); background: var(--ph-judge); }
+.tape-turn.judge.fail .tape-node { border-color: var(--ph-fail); background: var(--ph-fail); }
+.tape-turn.hilt  .tape-node    { border-color: var(--ph-hilt);  background: var(--ph-hilt); }
+.tape-turn.overflow .tape-node { border-color: var(--ph-hilt);  background: transparent; }
+.tape-turn.compact  .tape-node { border-color: var(--ph-think); background: transparent; }
+.tape-turn.fail  .tape-node    { border-color: var(--ph-fail);  background: var(--ph-fail); }
+
+/* ─ Body ─ */
+.tape-body { min-width: 0; }
+.tape-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+  margin-bottom: var(--sp-1);
+}
+.tape-phase {
+  display: inline-block;
+  padding: 1px var(--sp-2);
+  font-family: var(--font-display);
+  font-size: var(--fs-1);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 500;
+  border-radius: var(--r-1);
+  border: 1px solid var(--line);
+  background: var(--surf-raised);
+  color: var(--text-dim);
+}
+.tape-turn.think .tape-phase {
+  color: var(--ph-think);
+  border-color: var(--line-accent);
+  background: color-mix(in oklab, var(--ph-think) 10%, transparent);
+}
+.tape-turn.tool .tape-phase  {
+  color: var(--ph-tool);
+  border-color: color-mix(in oklab, var(--ph-tool) 40%, transparent);
+  background: color-mix(in oklab, var(--ph-tool) 10%, transparent);
+}
+.tape-turn.judge .tape-phase {
+  color: var(--ph-judge);
+  border-color: color-mix(in oklab, var(--ph-judge) 40%, transparent);
+  background: color-mix(in oklab, var(--ph-judge) 10%, transparent);
+}
+.tape-turn.hilt .tape-phase  {
+  color: var(--ph-hilt);
+  border-color: color-mix(in oklab, var(--ph-hilt) 40%, transparent);
+  background: color-mix(in oklab, var(--ph-hilt) 12%, transparent);
+}
+.tape-turn.fail .tape-phase  {
+  color: var(--ph-fail);
+  border-color: color-mix(in oklab, var(--ph-fail) 40%, transparent);
+  background: color-mix(in oklab, var(--ph-fail) 12%, transparent);
+}
+.tape-turn.overflow .tape-phase,
+.tape-turn.compact  .tape-phase { color: var(--ph-hilt); }
+
+.tape-meta {
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+}
+
+/* ─ Content ─
+   Default: sans-serif for reading. Tool I/O: mono for structure.
+   body 는 grid 자식 — min-width:0 필수. */
+.tape-content {
+  min-width: 0;
+  font-family: var(--font-ui);
+  font-size: var(--fs-4);
+  color: var(--text-bright);
+  line-height: var(--lh-body);
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
+}
+.tape-turn.tool .tape-content {
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+  font-size: var(--fs-3);
+  letter-spacing: 0.01em;
+  /* tool path는 한 줄 유지, 넘치면 말줄임 — 긴 URL이 UI를 깨지 않게 */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tape-turn.tool.expanded .tape-content {
+  white-space: pre-wrap;
+  overflow: visible;
+  word-break: break-all;
+}
+.tape-turn.tool .tape-content strong,
+.tape-turn.tool .tape-content b {
+  color: var(--text-bright);
+  font-weight: 500;
+}
+
+/* Auto-follow sticky pill */
+.tape-followhint {
+  position: sticky;
+  bottom: var(--sp-2);
+  align-self: center;
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--r-2);
+  background: color-mix(in oklab, var(--accent-brass) 20%, var(--surface-1));
+  border: 1px solid var(--line-accent);
+  font-family: var(--font-display);
+  font-size: var(--fs-1);
+  color: var(--accent-brass);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  backdrop-filter: blur(6px);
+}

--- a/dashboard/src/styles/ds-viewer-kit/theme-paper.css
+++ b/dashboard/src/styles/ds-viewer-kit/theme-paper.css
@@ -1,0 +1,1176 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC · Viewer v5 — Paper (Operator White) theme · v2
+
+   목표: Datadog/Grafana/Linear 계열 전문가용 모니터링 UI.
+   장식성 제로. 정보 밀도·정렬·가독성에만 자원을 쓴다.
+
+   설계 축
+     · 바탕은 진짜 흰색 계열 (#FFFFFF / #FAFBFC / #F4F5F7).
+     · 텍스트는 거의 검정 (#16181D). 2차 텍스트까지만 쓰고 이하는
+       데이터 테이블 외엔 등장 금지.
+     · 보더는 hairline black 10~18%. 박스 그림자는 거의 안 씀.
+     · accent 는 단 하나: blue #2D6CDF.
+     · status 는 semantic: green(ok) · orange(warn) · red(bad) · gray.
+     · radius 3px. 모든 숫자 tabular-nums.
+     · 4px baseline. 8의 배수로 컴포넌트 높이 맞춤.
+   ═══════════════════════════════════════════════════════════════ */
+
+[data-theme="paper"] {
+  color-scheme: light;
+
+  /* ─── 바탕 ─── */
+  --paper:     #FFFFFF;
+  --paper-2:   #FAFBFC;
+  --paper-3:   #F4F5F7;
+  --paper-4:   #EBEDF0;
+  --paper-5:   #DEE1E6;
+
+  /* ─── 잉크 ─── */
+  --ink:       #16181D;
+  --ink-2:     #2F3137;
+  --ink-3:     #4A4D55;
+  --ink-4:     #6B6F78;
+  --ink-5:     #8C9099;
+  --ink-6:     #BFC3CA;
+
+  /* ─── 라인 ─── */
+  --hairline:       rgba(22, 24, 29, 0.08);
+  --hairline-2:     rgba(22, 24, 29, 0.14);
+  --hairline-3:     rgba(22, 24, 29, 0.28);
+
+  /* ─── Accent ─── */
+  --blue:       #2D6CDF;
+  --blue-2:     #1E54BC;
+  --blue-wash:  #E8F0FD;
+  --blue-line:  #BFD4F5;
+
+  /* ─── Status ─── */
+  --green:      #17803D;
+  --green-wash: #DCFCE7;
+  --green-line: #BBF7D0;
+  --orange:     #B45309;
+  --orange-wash:#FEF3C7;
+  --orange-line:#FDE68A;
+  --red:        #B42318;
+  --red-wash:   #FEE4E2;
+  --red-line:   #FECDCA;
+  --gray:       #6B6F78;
+  --gray-wash:  #F4F5F7;
+
+  /* colors_and_type.css — 전역 토큰 오버라이드 */
+  --bg-deep:        var(--paper-3);
+  --bg-panel:       var(--paper-2);
+  --bg-panel-alt:   var(--paper);
+  --bg-card:        var(--paper);
+  --bg-card-hover:  var(--paper-4);
+  --border-main:        var(--hairline);
+  --border-highlight:   var(--hairline-2);
+  --text-bright:    var(--ink);
+  --text-primary:   var(--ink-2);
+  --text-dim:       var(--ink-4);
+  --accent-brass:      var(--blue);
+  --accent-brass-dim:  var(--blue-2);
+  --accent-blood:      var(--red);
+  --accent-blood-dim:  var(--red-line);
+  --accent-viscera:    var(--orange);
+  --accent-bile:       var(--green);
+  --accent-mold:       var(--green);
+  --accent-bone:       var(--ink);
+  --accent-ink:        var(--blue);
+  --accent-ember:      var(--orange);
+  --accent-glow:       transparent;
+  --accent-blood-glow: transparent;
+  --status-ok:     var(--green);
+  --status-warn:   var(--orange);
+  --status-bad:    var(--red);
+  --status-idle:   var(--gray);
+
+  /* v5 tokens.css override */
+  --bg:             var(--paper-3);
+  --surface-1:      var(--paper);
+  --surface-2:      var(--paper-2);
+  --bg-base:        var(--paper-3);
+  --border:         var(--hairline);
+  --ok:             var(--green);
+  --warn:           var(--orange);
+  --bad:            var(--red);
+
+  --surf-rail:      var(--paper-2);
+  --surf-panel:     var(--paper);
+  --surf-raised:    var(--paper);
+  --surf-sink:      var(--paper-3);
+  --surf-hover:     var(--paper-4);
+  --surf-selected:  var(--blue-wash);
+
+  --line:           var(--hairline);
+  --line-strong:    var(--hairline-2);
+  --line-accent:    var(--blue);
+
+  /* Phase */
+  --ph-think:  var(--blue);
+  --ph-tool:   #4F5462;
+  --ph-fs:     #7B5E3C;
+  --ph-net:    #0E7490;
+  --ph-db:     #6D28D9;
+  --ph-judge:  var(--green);
+  --ph-hilt:   var(--orange);
+  --ph-fail:   var(--red);
+  --ph-meta:   var(--ink-5);
+
+  /* Shadows — 거의 없음 */
+  --shadow-panel:  none;
+  --shadow-card:   none;
+  --shadow-raised: 0 1px 2px rgba(22,24,29,0.04), 0 0 0 1px var(--hairline);
+  --shadow-glow:   none;
+  --shadow-inset:  none;
+
+  --scrollbar-thumb:       #C8CBD1;
+  --scrollbar-thumb-hover: #9DA2AB;
+
+  /* ─── Font override ─── */
+  --font-display: 'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, 'Noto Sans KR', sans-serif;
+  --font-body:    'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, 'Noto Sans KR', sans-serif;
+  --font-ui:      'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, 'Noto Sans KR', sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+/* 장식성 제거 */
+[data-theme="paper"] body {
+  background: var(--paper-3);
+  color: var(--ink-2);
+  font-family: var(--font-ui);
+}
+[data-theme="paper"] h1,
+[data-theme="paper"] h2,
+[data-theme="paper"] h3,
+[data-theme="paper"] h4,
+[data-theme="paper"] .display {
+  font-family: var(--font-display);
+  text-transform: none;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  text-shadow: none;
+  font-weight: 600;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   TOPBAR — 48px, tight
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .v-topbar {
+  background: var(--paper);
+  border-bottom: 1px solid var(--hairline-2);
+  box-shadow: none;
+  padding: 0 16px;
+  gap: 14px;
+}
+[data-theme="paper"] .v-topbar::after { content: none; }
+[data-theme="paper"] .v-topbar .brand {
+  padding: 4px 6px;
+  gap: 7px;
+  border-radius: 3px;
+}
+[data-theme="paper"] .v-topbar .brand svg {
+  color: var(--blue);
+  width: 18px;
+  height: 18px;
+}
+[data-theme="paper"] .brand .wm {
+  color: var(--ink);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  font-family: var(--font-display);
+  font-size: 13px;
+  text-transform: none;
+}
+[data-theme="paper"] .brand .wm .blood {
+  color: var(--ink);
+  font-style: normal;
+}
+[data-theme="paper"] .v-topbar .crumbs {
+  font-size: 12px;
+  color: var(--ink-4);
+  gap: 6px;
+}
+[data-theme="paper"] .v-topbar .crumbs a {
+  color: var(--ink-3);
+  text-decoration: none;
+}
+[data-theme="paper"] .v-topbar .crumbs a:hover {
+  color: var(--blue);
+}
+[data-theme="paper"] .v-topbar .crumbs strong {
+  color: var(--ink);
+  font-family: var(--font-ui);
+  font-weight: 600;
+  letter-spacing: 0;
+}
+[data-theme="paper"] .v-topbar .crumbs .sep {
+  opacity: 0.6;
+  color: var(--ink-5);
+}
+[data-theme="paper"] .v-topbar .clock {
+  font-size: 11px;
+  color: var(--ink-4);
+  letter-spacing: 0;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+[data-theme="paper"] .v-topbar .clock b {
+  color: var(--ink);
+  font-weight: 600;
+}
+/* topbar pill → 아주 작은 status chip */
+[data-theme="paper"] .v-topbar .pill {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  padding: 2px 7px;
+  background: var(--paper);
+  border: 1px solid var(--hairline-2);
+  color: var(--ink-3);
+  border-radius: 3px;
+  font-weight: 500;
+  gap: 5px;
+  height: 22px;
+}
+[data-theme="paper"] .v-topbar .pill.ok {
+  color: var(--green);
+  border-color: var(--green-line);
+  background: var(--green-wash);
+}
+[data-theme="paper"] .v-topbar .pill .dot {
+  width: 6px; height: 6px;
+  box-shadow: none;
+}
+[data-theme="paper"] .v-topbar .pill .k { opacity: 0.7; }
+[data-theme="paper"] .v-topbar .pill .v { color: inherit; font-weight: 600; }
+
+[data-theme="paper"] .v-split-toggle {
+  padding: 3px 9px;
+  height: 22px;
+  border-radius: 3px;
+  border: 1px solid var(--hairline-2);
+  background: var(--paper);
+  color: var(--ink-3);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  gap: 5px;
+}
+[data-theme="paper"] .v-split-toggle:hover {
+  background: var(--paper-4);
+  border-color: var(--hairline-3);
+  color: var(--ink);
+}
+[data-theme="paper"] .v-split-toggle.on {
+  background: var(--blue-wash);
+  border-color: var(--blue-line);
+  color: var(--blue);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SIDEBAR — 232px
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .v-sidebar {
+  background: var(--paper-2);
+  border-right: 1px solid var(--hairline-2);
+  padding: 10px 8px 16px;
+  gap: 2px;
+}
+[data-theme="paper"] .v-sb-head {
+  padding: 6px 8px 8px;
+}
+[data-theme="paper"] .v-sb-title {
+  color: var(--ink-4);
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+[data-theme="paper"] .v-sb-count {
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+}
+[data-theme="paper"] .v-sb-list {
+  gap: 1px;
+}
+[data-theme="paper"] .v-sidebar .p-keeperchip {
+  padding: 8px 10px;
+  border-radius: 3px;
+  border: 1px solid transparent;
+  border-left: 2px solid transparent;
+  transition: background 0.12s, border-color 0.12s;
+  gap: 8px;
+  min-height: 44px;
+}
+[data-theme="paper"] .v-sidebar .p-keeperchip:hover {
+  background: var(--paper-4);
+  border-color: transparent;
+  border-left-color: var(--hairline-3);
+}
+[data-theme="paper"] .v-sidebar .p-keeperchip.selected {
+  background: var(--blue-wash);
+  border-color: transparent;
+  border-left-color: var(--blue);
+}
+[data-theme="paper"] .p-keeperchip .p-kc-name,
+[data-theme="paper"] .p-keeperchip .p-kc-main {
+  font-family: var(--font-ui);
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--ink);
+  font-size: 12.5px;
+  line-height: 1.3;
+}
+[data-theme="paper"] .p-keeperchip .p-kc-sub,
+[data-theme="paper"] .p-keeperchip .p-kc-meta {
+  font-family: var(--font-mono);
+  color: var(--ink-4);
+  font-size: 10.5px;
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.3;
+  margin-top: 2px;
+}
+[data-theme="paper"] .v-sb-sep {
+  height: 1px;
+  background: var(--hairline);
+  margin: 12px 4px;
+}
+[data-theme="paper"] .v-sb-back {
+  padding: 8px;
+  color: var(--ink-4);
+  font-size: 12px;
+  font-family: var(--font-ui);
+  letter-spacing: 0;
+  text-transform: none;
+  border-radius: 3px;
+  gap: 6px;
+}
+[data-theme="paper"] .v-sb-back:hover {
+  color: var(--blue);
+  background: var(--paper-4);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   HEADER — 선택 키퍼 요약 줄
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .v-header {
+  background: var(--paper);
+  border-bottom: 1px solid var(--hairline);
+  padding: 12px 20px;
+  gap: 14px;
+  align-items: center;
+  grid-template-columns: auto 1fr auto;
+}
+[data-theme="paper"] .v-header .vh-portrait {
+  width: 40px;
+  height: 40px;
+  border-radius: 4px;
+  border: 1px solid var(--hairline-2);
+  box-shadow: none;
+}
+[data-theme="paper"] .v-header .vh-portrait.dead {
+  filter: grayscale(1) brightness(0.9);
+  opacity: 0.55;
+}
+[data-theme="paper"] .v-header .vh-name {
+  font-family: var(--font-display);
+  color: var(--ink);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  gap: 8px;
+  line-height: 1.3;
+}
+[data-theme="paper"] .v-header .vh-sub {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-4);
+  margin-top: 3px;
+  gap: 8px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+}
+[data-theme="paper"] .v-header .vh-sub b {
+  color: var(--ink);
+  font-weight: 600;
+}
+[data-theme="paper"] .v-header .vh-sub .sep {
+  color: var(--ink-6);
+  opacity: 1;
+}
+[data-theme="paper"] .v-header .vh-actions { gap: 4px; }
+[data-theme="paper"] .v-header .vh-actions .btn {
+  font-family: var(--font-ui);
+  font-size: 11.5px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  padding: 5px 10px;
+  border-radius: 3px;
+  background: var(--paper);
+  border: 1px solid var(--hairline-2);
+  color: var(--ink-2);
+  line-height: 1.3;
+  height: 26px;
+}
+[data-theme="paper"] .v-header .vh-actions .btn:hover {
+  background: var(--paper-4);
+  border-color: var(--hairline-3);
+  color: var(--ink);
+}
+[data-theme="paper"] .v-header .vh-actions .btn.danger {
+  color: var(--red);
+  border-color: var(--red-line);
+  background: var(--paper);
+}
+[data-theme="paper"] .v-header .vh-actions .btn.danger:hover {
+  background: var(--red-wash);
+}
+[data-theme="paper"] .v-header .vh-actions .btn.primary {
+  background: var(--blue);
+  border-color: var(--blue);
+  color: #fff;
+}
+[data-theme="paper"] .v-header .vh-actions .btn.primary:hover {
+  background: var(--blue-2);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   TABS (main view)
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .v-tabs {
+  background: var(--paper);
+  border-bottom: 1px solid var(--hairline-2);
+  padding: 0 20px;
+  gap: 2px;
+}
+[data-theme="paper"] .v-tab {
+  padding: 10px 12px 9px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--ink-3);
+  border-bottom: 2px solid transparent;
+  gap: 7px;
+}
+[data-theme="paper"] .v-tab:hover {
+  color: var(--ink);
+  background: transparent;
+}
+[data-theme="paper"] .v-tab.on {
+  color: var(--ink);
+  border-bottom-color: var(--blue);
+}
+[data-theme="paper"] .v-tab svg { width: 13px; height: 13px; }
+[data-theme="paper"] .v-tab .cnt {
+  background: var(--paper-4);
+  color: var(--ink-3);
+  border: 0;
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+  min-width: 18px;
+  font-weight: 600;
+}
+[data-theme="paper"] .v-tab.on .cnt {
+  background: var(--blue);
+  color: #fff;
+  border: 0;
+}
+[data-theme="paper"] .v-tabs-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-4);
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+[data-theme="paper"] .v-tabs-meta b { color: var(--ink); font-weight: 600; }
+
+/* ══════════════════════════════════════════════════════════════
+   VIEW SURFACE
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .v-view {
+  background: var(--paper-2);
+  padding: 12px 20px;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   TAPE — Datadog log row
+   timestamp · rail · body
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .tape { gap: 0; }
+
+[data-theme="paper"] .tape-turn {
+  grid-template-columns: 72px 16px 1fr;
+  gap: 12px;
+  padding: 8px 10px 8px 8px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  background: transparent;
+  align-items: start;
+  margin: 0;
+}
+[data-theme="paper"] .tape-turn + .tape-turn {
+  border-top: 1px solid var(--hairline);
+  border-radius: 0;
+}
+[data-theme="paper"] .tape-turn:hover {
+  background: var(--paper);
+  border-color: var(--hairline);
+}
+[data-theme="paper"] .tape-turn.selected {
+  background: var(--blue-wash);
+  border-color: var(--blue-line);
+  box-shadow: inset 2px 0 0 var(--blue);
+}
+
+/* timestamp gutter — 고정 폭, 2줄: #N + t */
+[data-theme="paper"] .tape-ts {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-5);
+  text-align: right;
+  padding-top: 3px;
+  letter-spacing: 0;
+  line-height: 1.35;
+}
+[data-theme="paper"] .tape-ts .n {
+  color: var(--ink-3);
+  font-weight: 600;
+  font-size: 10.5px;
+  letter-spacing: 0;
+  display: block;
+}
+
+/* rail · node */
+[data-theme="paper"] .tape-rail { padding-top: 5px; }
+[data-theme="paper"] .tape-rail::before {
+  background: var(--hairline-2);
+}
+[data-theme="paper"] .tape-node {
+  width: 8px;
+  height: 8px;
+  border-width: 1.5px;
+  border-color: var(--ink-5);
+  background: var(--paper);
+}
+[data-theme="paper"] .tape-turn.think .tape-node { border-color: var(--blue); background: var(--paper); }
+[data-theme="paper"] .tape-turn.tool  .tape-node { border-color: #4F5462; background: #4F5462; }
+[data-theme="paper"] .tape-turn.judge .tape-node { border-color: var(--green); background: var(--green); }
+[data-theme="paper"] .tape-turn.judge.fail .tape-node { border-color: var(--red); background: var(--red); }
+[data-theme="paper"] .tape-turn.hilt  .tape-node { border-color: var(--orange); background: var(--orange); }
+[data-theme="paper"] .tape-turn.fail  .tape-node { border-color: var(--red); background: var(--red); }
+[data-theme="paper"] .tape-turn.overflow .tape-node,
+[data-theme="paper"] .tape-turn.compact  .tape-node {
+  border-color: var(--orange); background: var(--paper);
+}
+
+[data-theme="paper"] .tape-body { min-width: 0; }
+[data-theme="paper"] .tape-head {
+  gap: 8px;
+  margin-bottom: 4px;
+  align-items: center;
+}
+
+/* phase chip — 통일된 크기 */
+[data-theme="paper"] .tape-phase {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  height: 16px;
+  line-height: 14px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 3px;
+  border: 0;
+  background: var(--paper-4);
+  color: var(--ink-3);
+}
+[data-theme="paper"] .tape-turn.think .tape-phase { background: var(--blue-wash);   color: var(--blue); }
+[data-theme="paper"] .tape-turn.tool  .tape-phase { background: #E6E8EC;             color: #373B44; }
+[data-theme="paper"] .tape-turn.judge .tape-phase { background: var(--green-wash);  color: var(--green); }
+[data-theme="paper"] .tape-turn.hilt  .tape-phase,
+[data-theme="paper"] .tape-turn.overflow .tape-phase,
+[data-theme="paper"] .tape-turn.compact  .tape-phase { background: var(--orange-wash); color: var(--orange); }
+[data-theme="paper"] .tape-turn.fail  .tape-phase { background: var(--red-wash);    color: var(--red); }
+
+[data-theme="paper"] .tape-meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-4);
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+/* body content */
+[data-theme="paper"] .tape-content {
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--ink);
+}
+[data-theme="paper"] .tape-turn.tool .tape-content {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--ink-3);
+  letter-spacing: 0;
+}
+[data-theme="paper"] .tape-turn.tool .tape-content strong,
+[data-theme="paper"] .tape-turn.tool .tape-content b {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+[data-theme="paper"] .tape-followhint {
+  background: var(--blue);
+  border-color: var(--blue);
+  color: #fff;
+  border-radius: 3px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  padding: 4px 10px;
+  backdrop-filter: none;
+  box-shadow: 0 4px 12px rgba(45,108,223,0.24);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   INSPECTOR — 360px right rail
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .v-inspector {
+  background: var(--paper-2);
+  border-left: 1px solid var(--hairline-2);
+}
+[data-theme="paper"] .v-insp-tabs {
+  background: var(--paper);
+  border-bottom: 1px solid var(--hairline-2);
+}
+[data-theme="paper"] .v-insp-tab {
+  font-family: var(--font-ui);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  padding: 10px 6px 9px;
+}
+[data-theme="paper"] .v-insp-tab:hover {
+  color: var(--ink);
+  background: transparent;
+}
+[data-theme="paper"] .v-insp-tab.on {
+  color: var(--ink);
+  border-bottom-color: var(--blue);
+}
+[data-theme="paper"] .v-insp-body {
+  padding: 14px 16px;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--ink-2);
+}
+[data-theme="paper"] .v-insp-sec-title {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--hairline);
+  margin-bottom: 8px;
+}
+
+/* Inspector key/value rows — 정렬 일관 */
+[data-theme="paper"] .tc-row {
+  grid-template-columns: 84px 1fr;
+  gap: 10px;
+  padding: 4px 0;
+  align-items: baseline;
+  font-size: 11.5px;
+}
+[data-theme="paper"] .tc-row .l {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+}
+[data-theme="paper"] .tc-row .v {
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+}
+[data-theme="paper"] .tc-row .v.ok   { color: var(--green); }
+[data-theme="paper"] .tc-row .v.warn { color: var(--orange); }
+[data-theme="paper"] .tc-row .v.bad  { color: var(--red); }
+
+[data-theme="paper"] .tc-args {
+  margin-top: 8px;
+  padding: 8px 10px;
+  background: var(--paper-3);
+  border: 1px solid var(--hairline);
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--ink);
+}
+
+/* Judge rows */
+[data-theme="paper"] .jd-row {
+  padding: 8px 10px;
+  border: 1px solid var(--hairline);
+  border-radius: 3px;
+  background: var(--paper);
+}
+[data-theme="paper"] .jd-row.pass {
+  border-color: var(--green-line);
+  background: var(--green-wash);
+}
+[data-theme="paper"] .jd-row.fail {
+  border-color: var(--red-line);
+  background: var(--red-wash);
+}
+[data-theme="paper"] .jd-n {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--ink);
+  font-weight: 500;
+}
+[data-theme="paper"] .jd-mark {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+[data-theme="paper"] .jd-row.pass .jd-mark { color: var(--green); }
+[data-theme="paper"] .jd-row.fail .jd-mark { color: var(--red); }
+
+/* Siblings */
+[data-theme="paper"] .sib-row {
+  padding: 5px 6px;
+  border-radius: 3px;
+  gap: 10px;
+}
+[data-theme="paper"] .sib-row:hover { background: var(--paper-4); }
+[data-theme="paper"] .sib-row img {
+  width: 22px; height: 22px;
+  border-radius: 3px;
+  border: 1px solid var(--hairline-2);
+}
+[data-theme="paper"] .sib-n {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--ink);
+  font-weight: 500;
+}
+[data-theme="paper"] .sib-s {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-4);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Thread */
+[data-theme="paper"] .thr-step {
+  padding: 4px 0;
+  font-size: 12px;
+}
+[data-theme="paper"] .thr-step .dot {
+  background: var(--blue);
+  box-shadow: 0 0 0 2px var(--paper-2);
+}
+[data-theme="paper"] .thr-step.err .dot  { background: var(--red); }
+[data-theme="paper"] .thr-step.warn .dot { background: var(--orange); }
+[data-theme="paper"] .thr-step .body {
+  color: var(--ink);
+  font-family: var(--font-ui);
+  line-height: 1.5;
+}
+[data-theme="paper"] .thr-step .meta {
+  color: var(--ink-4);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   CONTEXT
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .ctx-budget {
+  padding: 10px 12px;
+  border: 1px solid var(--hairline);
+  border-radius: 3px;
+  background: var(--paper);
+  margin-bottom: 12px;
+  gap: 14px;
+}
+[data-theme="paper"] .ctx-budget-label {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  font-weight: 600;
+}
+[data-theme="paper"] .ctx-budget-bar {
+  background: var(--paper-3);
+  border: 1px solid var(--hairline);
+  height: 8px;
+}
+[data-theme="paper"] .ctx-budget-bar > span {
+  background: linear-gradient(90deg, var(--blue) 0%, var(--blue) 70%, var(--orange) 100%);
+}
+[data-theme="paper"] .ctx-budget-val {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink-4);
+  font-variant-numeric: tabular-nums;
+}
+[data-theme="paper"] .ctx-budget-val b { color: var(--ink); font-weight: 600; }
+
+[data-theme="paper"] .ctx-slot {
+  padding: 8px 10px;
+  border: 1px solid var(--hairline);
+  border-radius: 3px;
+  background: var(--paper);
+  gap: 12px;
+}
+[data-theme="paper"] .ctx-slot:hover {
+  background: var(--paper-4);
+  border-color: var(--hairline-2);
+}
+[data-theme="paper"] .ctx-slot.selected {
+  background: var(--blue-wash);
+  border-color: var(--blue-line);
+  box-shadow: inset 2px 0 0 var(--blue);
+}
+[data-theme="paper"] .ctx-role {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+[data-theme="paper"] .ctx-slot[data-role="system"]    .ctx-role { color: var(--blue);   background: var(--blue-wash); }
+[data-theme="paper"] .ctx-slot[data-role="user"]      .ctx-role { color: var(--ink);    background: var(--paper-4); }
+[data-theme="paper"] .ctx-slot[data-role="assistant"] .ctx-role { color: var(--green);  background: var(--green-wash); }
+[data-theme="paper"] .ctx-slot[data-role="tool"]      .ctx-role { color: #373B44;       background: #E6E8EC; }
+[data-theme="paper"] .ctx-kind {
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  color: var(--ink);
+  letter-spacing: 0;
+  font-weight: 500;
+}
+[data-theme="paper"] .ctx-note {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-4);
+  margin-top: 2px;
+}
+[data-theme="paper"] .ctx-tokens {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-4);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+}
+[data-theme="paper"] .ctx-tokens b { color: var(--ink); font-weight: 600; }
+
+/* ══════════════════════════════════════════════════════════════
+   WATERFALL
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .wf-axis {
+  background: var(--paper);
+  border-bottom: 1px solid var(--hairline-2);
+  backdrop-filter: none;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  padding: 8px 0;
+}
+[data-theme="paper"] .wf-axis-ticks {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-4);
+  letter-spacing: 0;
+  text-transform: none;
+  font-weight: 400;
+}
+[data-theme="paper"] .wf-row {
+  border-bottom: 1px solid var(--hairline);
+  height: 30px;
+}
+[data-theme="paper"] .wf-row:hover { background: var(--paper-4); }
+[data-theme="paper"] .wf-row.selected {
+  background: var(--blue-wash);
+  box-shadow: inset 2px 0 0 var(--blue);
+}
+[data-theme="paper"] .wf-name {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--ink);
+  letter-spacing: 0;
+}
+[data-theme="paper"] .wf-name .wf-status {
+  width: 7px; height: 7px;
+  box-shadow: none;
+}
+[data-theme="paper"] .wf-bar {
+  background: var(--blue);
+  border: 0;
+  border-radius: 2px;
+  top: 9px; bottom: 9px;
+}
+[data-theme="paper"] .wf-row[data-status="warn"] .wf-bar {
+  background: var(--orange); border: 0;
+}
+[data-theme="paper"] .wf-row[data-status="err"] .wf-bar,
+[data-theme="paper"] .wf-row[data-status="timeout"] .wf-bar {
+  background: var(--red); border: 0;
+}
+[data-theme="paper"] .wf-row[data-status="hilt"] .wf-bar {
+  background: repeating-linear-gradient(45deg,
+    var(--orange) 0 6px,
+    color-mix(in oklab, var(--orange) 55%, var(--paper)) 6px 12px);
+  border: 0;
+}
+[data-theme="paper"] .wf-bar-label {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-shadow: 0 1px 1px rgba(0,0,0,0.2);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   COMPOSER
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .v-composer {
+  background: var(--paper);
+  border-top: 1px solid var(--hairline);
+  padding: 10px 20px;
+  gap: 6px;
+}
+[data-theme="paper"] .v-composer .c-input {
+  padding: 6px 10px;
+  border: 1px solid var(--hairline-2);
+  border-radius: 3px;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  height: 30px;
+}
+[data-theme="paper"] .v-composer .c-input:focus {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px var(--blue-wash);
+  background: var(--paper);
+}
+[data-theme="paper"] .v-composer .c-input::placeholder { color: var(--ink-5); }
+[data-theme="paper"] .v-composer .c-btn {
+  padding: 5px 12px;
+  border-radius: 3px;
+  background: var(--paper);
+  border: 1px solid var(--hairline-2);
+  color: var(--ink-2);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  height: 30px;
+}
+[data-theme="paper"] .v-composer .c-btn:hover {
+  background: var(--paper-4);
+  border-color: var(--hairline-3);
+  color: var(--ink);
+}
+[data-theme="paper"] .v-composer .c-btn.primary {
+  background: var(--blue);
+  border-color: var(--blue);
+  color: #fff;
+}
+[data-theme="paper"] .v-composer .c-btn.primary:hover {
+  background: var(--blue-2);
+  color: #fff;
+}
+[data-theme="paper"] .v-composer .c-btn.danger {
+  color: var(--red);
+  border-color: var(--red-line);
+}
+[data-theme="paper"] .v-composer .c-btn.danger:hover {
+  background: var(--red-wash);
+}
+[data-theme="paper"] .v-composer .c-sep {
+  width: 1px;
+  height: 20px;
+  background: var(--hairline);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   TWEAKS panel
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .v-tweaks {
+  background: var(--paper);
+  border: 1px solid var(--hairline-2);
+  box-shadow: 0 10px 30px rgba(22,24,29,0.10), 0 2px 6px rgba(22,24,29,0.05);
+  border-radius: 4px;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   BUTTONS · PILLS global reset inside paper
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .btn {
+  text-transform: none;
+  letter-spacing: 0;
+  font-family: var(--font-ui);
+  font-weight: 500;
+  font-size: 12px;
+  padding: 5px 10px;
+  border-radius: 3px;
+  background: var(--paper);
+  border: 1px solid var(--hairline-2);
+  color: var(--ink-2);
+}
+[data-theme="paper"] .btn:hover {
+  background: var(--paper-4);
+  border-color: var(--hairline-3);
+  color: var(--ink);
+}
+[data-theme="paper"] .btn.primary {
+  background: var(--blue);
+  border-color: var(--blue);
+  color: #fff;
+}
+[data-theme="paper"] .pill,
+[data-theme="paper"] .p-pill {
+  background: var(--paper);
+  border: 1px solid var(--hairline-2);
+  color: var(--ink-3);
+  text-transform: none;
+  letter-spacing: 0;
+  font-family: var(--font-ui);
+  font-weight: 500;
+  font-size: 11px;
+  padding: 1px 7px;
+  height: 18px;
+  border-radius: 3px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+[data-theme="paper"] .pill.ok,    [data-theme="paper"] .p-pill.ok    { background: var(--green-wash);  border-color: var(--green-line);  color: var(--green); }
+[data-theme="paper"] .pill.warn,  [data-theme="paper"] .p-pill.warn  { background: var(--orange-wash); border-color: var(--orange-line); color: var(--orange); }
+[data-theme="paper"] .pill.bad,   [data-theme="paper"] .p-pill.bad   { background: var(--red-wash);    border-color: var(--red-line);    color: var(--red); }
+[data-theme="paper"] .pill.brass, [data-theme="paper"] .p-pill.brass { background: var(--blue-wash);   border-color: var(--blue-line);   color: var(--blue); }
+
+/* ══════════════════════════════════════════════════════════════
+   INPUT global
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .input {
+  background: var(--paper);
+  border: 1px solid var(--hairline-2);
+  color: var(--ink);
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+[data-theme="paper"] .input:focus {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px var(--blue-wash);
+  outline: none;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   LINK
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] a {
+  color: var(--blue);
+  border-bottom: 0;
+}
+[data-theme="paper"] a:hover { color: var(--blue-2); text-decoration: underline; }
+
+/* ══════════════════════════════════════════════════════════════
+   PORTRAIT · FRAME · TEXTURE — 장식 제거
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .p-portrait {
+  border-radius: 3px;
+  box-shadow: inset 0 0 0 1px var(--hairline-2);
+  filter: none;
+}
+[data-theme="paper"] .p-portrait.dead {
+  filter: grayscale(1) brightness(0.9);
+  opacity: 0.55;
+}
+[data-theme="paper"] .frame-gothic,
+[data-theme="paper"] .frame-arch,
+[data-theme="paper"] .frame-sarc {
+  border-radius: 3px;
+  box-shadow: none;
+  clip-path: none;
+  border: 1px solid var(--hairline-2);
+}
+[data-theme="paper"] .frame-gothic::before,
+[data-theme="paper"] .frame-gothic::after,
+[data-theme="paper"] .frame-arch::before { content: none; }
+[data-theme="paper"] .tex-parchment,
+[data-theme="paper"] .tex-blood,
+[data-theme="paper"] .tex-wax,
+[data-theme="paper"] .tex-scratch,
+[data-theme="paper"] .tex-mold,
+[data-theme="paper"] .tex-viscera { background-image: none; }
+
+/* ══════════════════════════════════════════════════════════════
+   SCROLLBAR
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] ::-webkit-scrollbar { width: 10px; height: 10px; }
+[data-theme="paper"] ::-webkit-scrollbar-track { background: transparent; }
+[data-theme="paper"] ::-webkit-scrollbar-thumb {
+  background: #C8CBD1;
+  border: 2px solid var(--paper-2);
+  border-radius: 6px;
+}
+[data-theme="paper"] ::-webkit-scrollbar-thumb:hover { background: #9DA2AB; }
+
+/* ══════════════════════════════════════════════════════════════
+   STATE BANNER
+   ══════════════════════════════════════════════════════════════ */
+[data-theme="paper"] .v-banner {
+  border-radius: 3px;
+  border-width: 1px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  padding: 8px 14px;
+}

--- a/dashboard/src/styles/ds-viewer-kit/tokens.css
+++ b/dashboard/src/styles/ds-viewer-kit/tokens.css
@@ -1,0 +1,117 @@
+/* ═══════════════════════════════════════════════════════════════
+   MASC · Viewer v5 — design tokens
+   하나의 스케일로 모든 간격 · 라디우스 · 폰트크기를 통제한다.
+   의도적으로 작은 수의 토큰만 노출 — 선택지가 적을수록 일관된다.
+   ═══════════════════════════════════════════════════════════════ */
+
+:root {
+  /* ─── Spacing — 4px baseline (0 1 2 3 4 5 6 7 8) ───
+     UI 컴포넌트는 이 스케일 밖의 값을 쓰지 않는다. */
+  --sp-0:  0;
+  --sp-1:  4px;
+  --sp-2:  8px;
+  --sp-3:  12px;
+  --sp-4:  16px;
+  --sp-5:  20px;
+  --sp-6:  24px;
+  --sp-7:  32px;
+  --sp-8:  40px;
+
+  /* ─── Radius ───
+     전체적으로 작게. 이 디자인은 고딕 · 정확함이 주제. */
+  --r-1: 2px;   /* pills, chips, small buttons */
+  --r-2: 3px;   /* cards, inputs, main buttons */
+  --r-3: 5px;   /* portrait, larger panels */
+
+  /* ─── Font sizes ───
+     밀도 높은 작업도구 기준. 본문 12px, 보조 10.5px, UI 캡션 9.5px.
+     더 작은 값 금지 — 이하는 의미를 잃는다. */
+  --fs-1:  9.5px;   /* section labels, micro-meta */
+  --fs-2:  10.5px;  /* chips, counts, secondary meta */
+  --fs-3:  11.5px;  /* button labels, tabs, sidebar rows */
+  --fs-4:  12.5px;  /* body text, tape content (up from 11.5) */
+  --fs-5:  14px;    /* sub-header */
+  --fs-6:  17px;    /* header name */
+
+  --lh-tight: 1.35;
+  --lh-body:  1.55;
+
+  /* ─── Surface depth ───
+     바닥(bg) ↓ surface-panel ↓ surface-raised ↑ surface-sink(↓).
+     대비를 기존보다 살짝 벌려 zone 구분이 한눈에 보이게. */
+  --bg:              var(--bg-base);
+  --surf-rail:       color-mix(in oklab, var(--surface-1) 92%, black 8%);
+  --surf-panel:      color-mix(in oklab, var(--surface-1) 75%, transparent);
+  --surf-raised:     color-mix(in oklab, var(--surface-2) 65%, transparent);
+  --surf-sink:       color-mix(in oklab, var(--bg-base) 92%, black 8%);
+  --surf-hover:      color-mix(in oklab, var(--surface-2) 50%, transparent);
+  --surf-selected:   color-mix(in oklab, var(--accent-brass) 10%, transparent);
+
+  /* ─── Border rhythm ─── */
+  --line:            var(--border);
+  --line-strong:     color-mix(in oklab, var(--border) 60%, white 40%);
+  --line-accent:     color-mix(in oklab, var(--accent-brass) 45%, transparent);
+
+  /* ─── Phase colors ───
+     다이얼의 밝기를 통일해 한 화면에 섞여도 소음이 적게. */
+  --ph-think:  var(--accent-brass);
+  --ph-tool:   #6a8aae;
+  --ph-fs:     #8a7a5a;
+  --ph-net:    #5a8a6e;
+  --ph-db:     #8a5a7a;
+  --ph-judge:  var(--ok);
+  --ph-hilt:   var(--warn);
+  --ph-fail:   var(--bad);
+  --ph-meta:   var(--text-dim);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   Text overflow 공통 유틸 — 어떤 컴포넌트든 동일 규칙.
+
+     .tx-trunc       한 줄 말줄임. 부모에 min-width:0 필수.
+     .tx-trunc-2     두 줄 말줄임.
+     .tx-wrap        break-word + text-wrap:pretty + hyphens auto.
+     .tx-mono-path   긴 경로/URL — 한 줄 유지하되 왼쪽 말줄임 (꼬리가 중요).
+     .tx-break-any   마지막 수단: 어느 문자든 줄바꿈 허용.
+
+   부모 컨테이너가 grid/flex일 때 `min-width:0`을 꼭 주어야 한다.
+   이게 없으면 truncate가 터진다.
+   ════════════════════════════════════════════════════════════ */
+.tx-trunc {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tx-trunc-2 {
+  min-width: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+}
+.tx-wrap {
+  min-width: 0;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
+}
+.tx-mono-path {
+  min-width: 0;
+  font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+  text-align: left;
+  unicode-bidi: plaintext;
+}
+.tx-break-any {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+/* grid/flex 자식이 자동으로 축소 가능하도록 — 유틸 클래스 */
+.min-w-0 { min-width: 0; }

--- a/dashboard/src/styles/ds-viewer-kit/topbar.css
+++ b/dashboard/src/styles/ds-viewer-kit/topbar.css
@@ -1,0 +1,150 @@
+/* ─── Viewer topbar ──────────────────────────────────────── */
+
+.v-topbar {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  padding: 0 var(--sp-4);
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(180deg,
+    color-mix(in oklab, var(--surface-2) 96%, transparent) 0%,
+    color-mix(in oklab, var(--surface-1) 96%, transparent) 100%);
+  position: relative;
+}
+.v-topbar::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -1px 0;
+  height: 1px;
+  background: linear-gradient(90deg,
+    transparent, color-mix(in oklab, var(--accent-brass) 40%, transparent) 50%, transparent);
+}
+
+.v-topbar .brand {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  text-decoration: none;
+  color: var(--text-bright);
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--r-2);
+  transition: background 0.12s;
+}
+.v-topbar .brand:hover {
+  background: var(--surf-hover);
+}
+.v-topbar .brand svg {
+  width: 22px; height: 22px; color: var(--accent-brass);
+}
+.v-topbar .wm {
+  font-family: var(--font-display);
+  font-size: var(--fs-5);
+  letter-spacing: 0.14em;
+  font-weight: 600;
+}
+.v-topbar .wm .blood {
+  color: var(--bad);
+  font-style: italic;
+}
+
+.v-topbar .crumbs {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-family: var(--font-ui);
+  font-size: var(--fs-3);
+  color: var(--text-dim);
+}
+.v-topbar .crumbs a {
+  color: var(--text-dim);
+  text-decoration: none;
+  transition: color 0.12s;
+}
+.v-topbar .crumbs a:hover {
+  color: var(--accent-brass);
+}
+.v-topbar .crumbs .sep { opacity: 0.5; font-family: var(--font-mono); }
+.v-topbar .crumbs strong {
+  color: var(--text-bright);
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.v-topbar .top-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+.v-topbar .clock {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2);
+  color: var(--text-dim);
+  padding: 0 var(--sp-1);
+  letter-spacing: 0.04em;
+}
+.v-topbar .clock b {
+  color: var(--text-bright);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Reuse dashboard .pill look */
+.v-topbar .pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: 2px var(--sp-2);
+  border-radius: var(--r-1);
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border: 1px solid var(--line);
+  background: var(--surf-raised);
+  color: var(--text-dim);
+  font-weight: 500;
+}
+.v-topbar .pill.ok {
+  color: var(--ok);
+  border-color: color-mix(in oklab, var(--ok) 40%, transparent);
+  background: color-mix(in oklab, var(--ok) 10%, transparent);
+}
+.v-topbar .pill .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 5px currentColor;
+}
+.v-topbar .pill .k { opacity: 0.75; }
+.v-topbar .pill .v { color: var(--text-bright); }
+
+/* Split-view toggle */
+.v-split-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: 4px var(--sp-2);
+  border-radius: var(--r-2);
+  border: 1px solid var(--line);
+  background: var(--surf-raised);
+  color: var(--text-dim);
+  cursor: pointer;
+  font-family: var(--font-display);
+  font-size: var(--fs-2);
+  letter-spacing: 0.06em;
+  transition: all 0.12s;
+  font-weight: 500;
+}
+.v-split-toggle:hover {
+  color: var(--accent-brass);
+  border-color: var(--line-accent);
+}
+.v-split-toggle.on {
+  color: var(--accent-brass);
+  background: color-mix(in oklab, var(--accent-brass) 14%, transparent);
+  border-color: var(--line-accent);
+}
+.v-split-toggle svg {
+  width: 13px; height: 13px;
+}

--- a/dashboard/src/styles/ds-viewer-kit/tweaks.css
+++ b/dashboard/src/styles/ds-viewer-kit/tweaks.css
@@ -1,0 +1,78 @@
+/* ─── Tweaks floating panel ─────────────────────────────── */
+
+.v-tweaks {
+  position: fixed;
+  right: var(--sp-4);
+  bottom: 80px;
+  width: 256px;
+  padding: var(--sp-3) var(--sp-3) var(--sp-3);
+  background: color-mix(in oklab, var(--surface-1) 96%, transparent);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-2);
+  box-shadow:
+    0 12px 32px rgba(0,0,0,0.5),
+    0 2px 6px rgba(0,0,0,0.3),
+    inset 0 0 0 1px color-mix(in oklab, var(--accent-brass) 10%, transparent);
+  color: var(--text-bright);
+  z-index: 50;
+  display: none;
+  backdrop-filter: blur(8px);
+}
+.v-tweaks.on { display: block; }
+.v-tweaks h5 {
+  margin: 0 0 var(--sp-3);
+  padding-bottom: var(--sp-2);
+  border-bottom: 1px solid var(--line);
+  font-family: var(--font-display);
+  font-size: var(--fs-2);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent-brass);
+  font-weight: 500;
+}
+.v-tweaks .row {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-1) 0;
+}
+.v-tweaks .row.col {
+  grid-template-columns: 1fr;
+  gap: var(--sp-1);
+  padding-top: var(--sp-2);
+}
+.v-tweaks .row .l {
+  font-family: var(--font-display);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: var(--fs-1);
+  font-weight: 500;
+}
+.v-tweaks .seg, .v-tweaks .filters {
+  display: flex;
+  gap: 2px;
+  flex-wrap: wrap;
+}
+.v-tweaks .seg button, .v-tweaks .filters button {
+  padding: 3px var(--sp-2);
+  border: 1px solid var(--line);
+  background: var(--surf-sink);
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  cursor: pointer;
+  border-radius: var(--r-1);
+  letter-spacing: 0.04em;
+  transition: all 0.1s;
+}
+.v-tweaks .seg button:hover, .v-tweaks .filters button:hover {
+  color: var(--text-bright);
+  border-color: var(--line-strong);
+}
+.v-tweaks .seg button.on, .v-tweaks .filters button.on {
+  color: var(--accent-brass);
+  border-color: var(--line-accent);
+  background: color-mix(in oklab, var(--accent-brass) 14%, transparent);
+}

--- a/dashboard/src/styles/ds-viewer-kit/waterfall.css
+++ b/dashboard/src/styles/ds-viewer-kit/waterfall.css
@@ -1,0 +1,138 @@
+/* ─── Waterfall view — tool-call Gantt ───────────────────── */
+
+.wf {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.wf-axis {
+  position: sticky;
+  top: 0;
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  background: color-mix(in oklab, var(--bg) 92%, transparent);
+  backdrop-filter: blur(4px);
+  border-bottom: 1px solid var(--line);
+  font-family: var(--font-display);
+  font-size: var(--fs-1);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 500;
+  padding: var(--sp-2) 0;
+  z-index: 2;
+}
+.wf-axis-name { padding: 0 var(--sp-3); }
+.wf-axis-ticks {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 var(--sp-2);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  text-transform: none;
+}
+.wf-axis-ticks::before {
+  content: "";
+  position: absolute;
+  left: var(--sp-2); right: var(--sp-2);
+  bottom: -1px;
+  height: 1px;
+  background: var(--line);
+}
+
+.wf-row {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  align-items: center;
+  height: 30px;
+  border-bottom: 1px solid color-mix(in oklab, var(--line) 60%, transparent);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.wf-row:hover {
+  background: var(--surf-hover);
+}
+.wf-row.selected {
+  background: var(--surf-selected);
+  box-shadow: inset 2px 0 0 var(--accent-brass);
+}
+
+.wf-name {
+  padding: 0 var(--sp-3);
+  font-family: var(--font-ui);
+  font-size: var(--fs-3);
+  color: var(--text-bright);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+}
+.wf-name .wf-status {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: var(--sp-2);
+  flex: 0 0 auto;
+  background: var(--ok);
+  box-shadow: 0 0 0 1px var(--bg);
+}
+.wf-row[data-status="ok"]      .wf-status { background: var(--ok); }
+.wf-row[data-status="warn"]    .wf-status { background: var(--warn); }
+.wf-row[data-status="err"]     .wf-status { background: var(--bad); }
+.wf-row[data-status="timeout"] .wf-status { background: var(--bad); opacity: 0.6; }
+.wf-row[data-status="hilt"]    .wf-status { background: var(--warn); animation: wf-pulse 1.4s ease-in-out infinite; }
+.wf-row[data-status="run"]     .wf-status { background: var(--accent-brass); animation: wf-pulse 1.4s ease-in-out infinite; }
+@keyframes wf-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(1.25); }
+}
+
+.wf-track {
+  position: relative;
+  height: 100%;
+  padding: 0 var(--sp-2);
+}
+.wf-bar {
+  position: absolute;
+  top: 7px;
+  bottom: 7px;
+  min-width: 3px;
+  border-radius: var(--r-1);
+  background: color-mix(in oklab, var(--accent-brass) 60%, var(--surface-2));
+  border: 1px solid var(--line-accent);
+}
+.wf-row[data-status="warn"] .wf-bar {
+  background: color-mix(in oklab, var(--warn) 55%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--warn) 60%, transparent);
+}
+.wf-row[data-status="err"] .wf-bar,
+.wf-row[data-status="timeout"] .wf-bar {
+  background: color-mix(in oklab, var(--bad) 50%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--bad) 60%, transparent);
+}
+.wf-row[data-status="hilt"] .wf-bar {
+  background: repeating-linear-gradient(45deg,
+    color-mix(in oklab, var(--warn) 50%, var(--surface-2)) 0 6px,
+    color-mix(in oklab, var(--warn) 25%, var(--surface-2)) 6px 12px);
+  border-color: color-mix(in oklab, var(--warn) 65%, transparent);
+}
+
+.wf-bar-label {
+  position: absolute;
+  left: var(--sp-2);
+  top: 50%;
+  transform: translateY(-50%);
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--text-bright);
+  white-space: nowrap;
+  pointer-events: none;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.7);
+}


### PR DESCRIPTION
## Summary
Adds the keeper-v2 design-system UI kit CSS as an experimental, opt-in layer.

## What changed
- **New directories**:
  - `dashboard/src/styles/ds-dashboard-kit/` — 24 files (base, shell, primitives, topbar, nav, hud, alert, main, goals, swim, pressure, a2a, aside, approvals, focus, systems, chronicle, drawer, palette, cmdk, tweaks, density, etc.)
  - `dashboard/src/styles/ds-cockpit-kit/` — 11 files
  - `dashboard/src/styles/ds-viewer-kit/` — 16 files
- **Aggregator** `dashboard/src/styles/ds-ui-kits.css` importing all three kit indices.
- **Experimental import** in `dashboard/src/main.ts` (commented out by default).
- **Test** `dashboard/src/styles/ds-ui-kits.test.ts` — 4 tests verifying kit files exist.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `ds-ui-kits.test.ts` ✅ 4/4

## Notes
- The import in `main.ts` is intentionally commented out; enabling it may conflict with existing `v2-*` styles. This PR delivers the kits so they can be adopted incrementally.
