### PR TITLE
fix(keeper): make librarian provider slot per-keeper (Lane Per Keeper)

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -39,28 +39,105 @@ let default_timeout_sec () =
 
 let provider_slot_busy = "librarian provider slot busy"
 
-(* Per-keeper librarian provider slot (Lane Per Keeper, RFC-0225).
-   A single global slot would let one keeper's librarian block every other
-   keeper's memory ingestion. Keeping the slot per-keeper still bounds each
-   keeper to one concurrent librarian call while removing cross-keeper
-   starvation.
+(* IMPORTANT: mutually exclusive with PR #21376.
 
-   The integer passed to [Hashtbl.create] is only the initial bucket count;
-   it is not a capacity limit. The registry grows as new keepers are seen. *)
-let provider_slot_registry : (string, Eio.Semaphore.t) Hashtbl.t =
-  Hashtbl.create 1
+   PR #21376 (per-keeper memory execution lane, RFC-0252) removes the
+   [provider_slot]/[with_provider_slot] mechanism entirely and moves
+   serialization into [Keeper_memory_lane.mem_mu]. This PR keeps and
+   per-keeper-izes the slot. The two changes edit the same lines in
+   [keeper_librarian_runtime.ml] and cannot both land.
+
+   Decision needed before merge: pick one.
+   - If #21376's lane already covers per-keeper librarian serialization,
+     close this PR (#21408) and let #21376 be the canonical fix.
+   - If the lane does NOT cover the shared provider pool, keep this PR
+     but make sure the fleet-total provider concurrency bound below is
+     explicit and preserved.
+
+   The current code adds a fleet-total semaphore on top of per-keeper
+   semaphores so that the shared flash/glm provider is not overwhelmed
+   when N keepers each hold their own slot (#21230 regression guard). *)
+
+(* Per-keeper slot registry entry. [last_used] is a monotonic stamp updated on
+   every access so that the registry can evict stale entries when it reaches
+   its configured capacity. *)
+type slot_entry =
+  { sem : Eio.Semaphore.t
+  ; mutable last_used : int
+  }
+
+let provider_slot_registry : (string, slot_entry) Hashtbl.t = Hashtbl.create 1
+let provider_slot_mutex = Eio.Mutex.create ()
+let provider_slot_access_counter = Atomic.make 0
+
+let provider_max_keepers () =
+  Keeper_memory_bank_env.memory_env_int_logged
+    "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_KEEPERS"
+    ~default:1024
+  |> max 1
 ;;
 
-let provider_slot_mutex = Eio.Mutex.create ()
+let provider_total_slots () =
+  Keeper_memory_bank_env.memory_env_int_logged
+    "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TOTAL_SLOTS"
+    ~default:1
+  |> max 1
+;;
+
+(* The total slot semaphore is created lazily so that tests that set the
+   env var before the first librarian call still take effect. The value is
+   read once, at first use. *)
+let provider_total_slot_sem =
+  lazy (Eio.Semaphore.make (provider_total_slots ()))
+;;
 
 let provider_slot_for keeper_id =
   Eio.Mutex.use_rw ~protect:true provider_slot_mutex (fun () ->
     match Hashtbl.find_opt provider_slot_registry keeper_id with
-    | Some sem -> sem
+    | Some entry ->
+      entry.last_used <- Atomic.fetch_and_add provider_slot_access_counter 1;
+      entry.sem
     | None ->
+      let cap = provider_max_keepers () in
+      (* Evict stale entries when at capacity. Only entries whose semaphore
+         is currently free ([get_value] == 1) are removed, so we never drop
+         a slot that a fiber is actively holding. *)
+      let rec evict () =
+        if Hashtbl.length provider_slot_registry < cap
+        then ()
+        else (
+          let victim =
+            Hashtbl.fold
+              (fun k entry acc ->
+                 let free = Eio.Semaphore.get_value entry.sem = 1 in
+                 match acc, free with
+                 | _, false -> acc
+                 | None, true -> Some (k, entry.last_used)
+                 | Some (_, acc_ts), true when entry.last_used < acc_ts ->
+                   Some (k, entry.last_used)
+                 | _ -> acc)
+              provider_slot_registry
+              None
+          in
+          match victim with
+          | Some (k, _) ->
+            Hashtbl.remove provider_slot_registry k;
+            evict ()
+          | None ->
+            (* All existing slots are in use; allow a temporary exceed
+               rather than block the current keeper or clear active slots. *)
+            ())
+      in
+      evict ();
       let sem = Eio.Semaphore.make 1 in
-      Hashtbl.replace provider_slot_registry keeper_id sem;
+      let ts = Atomic.fetch_and_add provider_slot_access_counter 1 in
+      Hashtbl.replace provider_slot_registry keeper_id { sem; last_used = ts };
       sem)
+;;
+
+let provider_slot_registry_length_for_testing () =
+  Eio.Mutex.use_rw ~protect:true provider_slot_mutex (fun () ->
+    Hashtbl.length provider_slot_registry)
 ;;
 
 let provider_slot_wait_sec () =
@@ -218,6 +295,11 @@ let with_timeout ?clock ~timeout_sec f =
 
 let with_provider_slot ~keeper_id ?clock f =
   let slot = provider_slot_for keeper_id in
+  let total_sem = Lazy.force provider_total_slot_sem in
+  (* Per-keeper slot first: this preserves the Lane Per Keeper invariant and
+     avoids holding the fleet-total slot while waiting for a single keeper's
+     slot. The global semaphore is acquired second; because it never waits on
+     a per-keeper semaphore there is no deadlock. *)
   match
     with_timeout ?clock ~timeout_sec:(provider_slot_wait_sec ()) (fun () ->
       Eio.Semaphore.acquire slot)
@@ -226,7 +308,18 @@ let with_provider_slot ~keeper_id ?clock f =
   | Some () ->
     (* fun-protect-finally-ok: [Eio.Semaphore.release] only returns the
        provider slot; it does not wait, acquire, or perform I/O. *)
-    Fun.protect ~finally:(fun () -> Eio.Semaphore.release slot) f
+    Fun.protect
+      ~finally:(fun () -> Eio.Semaphore.release slot)
+      (fun () ->
+         match
+           with_timeout ?clock ~timeout_sec:(provider_slot_wait_sec ()) (fun () ->
+             Eio.Semaphore.acquire total_sem)
+         with
+         | None -> Error provider_slot_busy
+         | Some () ->
+           Fun.protect
+             ~finally:(fun () -> Eio.Semaphore.release total_sem)
+             f)
 ;;
 
 let extract_with_provider

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -39,7 +39,29 @@ let default_timeout_sec () =
 
 let provider_slot_busy = "librarian provider slot busy"
 
-let provider_slot = Eio.Semaphore.make 1
+(* Per-keeper librarian provider slot (Lane Per Keeper, RFC-0225).
+   A single global slot would let one keeper's librarian block every other
+   keeper's memory ingestion. Keeping the slot per-keeper still bounds each
+   keeper to one concurrent librarian call while removing cross-keeper
+   starvation.
+
+   The integer passed to [Hashtbl.create] is only the initial bucket count;
+   it is not a capacity limit. The registry grows as new keepers are seen. *)
+let provider_slot_registry : (string, Eio.Semaphore.t) Hashtbl.t =
+  Hashtbl.create 1
+;;
+
+let provider_slot_mutex = Eio.Mutex.create ()
+
+let provider_slot_for keeper_id =
+  Eio.Mutex.use_rw ~protect:true provider_slot_mutex (fun () ->
+    match Hashtbl.find_opt provider_slot_registry keeper_id with
+    | Some sem -> sem
+    | None ->
+      let sem = Eio.Semaphore.make 1 in
+      Hashtbl.replace provider_slot_registry keeper_id sem;
+      sem)
+;;
 
 let provider_slot_wait_sec () =
   Keeper_memory_bank_env.memory_env_float_logged
@@ -194,16 +216,17 @@ let with_timeout ?clock ~timeout_sec f =
      | Eio.Time.Timeout -> None)
 ;;
 
-let with_provider_slot ?clock f =
+let with_provider_slot ~keeper_id ?clock f =
+  let slot = provider_slot_for keeper_id in
   match
     with_timeout ?clock ~timeout_sec:(provider_slot_wait_sec ()) (fun () ->
-      Eio.Semaphore.acquire provider_slot)
+      Eio.Semaphore.acquire slot)
   with
   | None -> Error provider_slot_busy
   | Some () ->
     (* fun-protect-finally-ok: [Eio.Semaphore.release] only returns the
        provider slot; it does not wait, acquire, or perform I/O. *)
-    Fun.protect ~finally:(fun () -> Eio.Semaphore.release provider_slot) f
+    Fun.protect ~finally:(fun () -> Eio.Semaphore.release slot) f
 ;;
 
 let extract_with_provider
@@ -212,6 +235,7 @@ let extract_with_provider
     ?(timeout_sec = Env_config_governance.Inference.timeout_seconds)
     ~sw
     ~net
+    ~keeper_id
     ~provider_cfg
     (inp : Keeper_librarian.input)
   =
@@ -219,7 +243,7 @@ let extract_with_provider
   | Error _ as e -> e
   | Ok messages ->
     let provider_cfg = provider_for_librarian provider_cfg in
-    with_provider_slot ?clock (fun () ->
+    with_provider_slot ~keeper_id ?clock (fun () ->
       let attempt messages =
         match
           with_timeout ?clock ~timeout_sec (fun () ->
@@ -252,7 +276,9 @@ let extract_and_append_with_provider
     ~provider_cfg
     inp
   =
-  match extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg inp with
+  match
+    extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~keeper_id ~provider_cfg inp
+  with
   | Error _ as e -> e
   | Ok episode ->
     let now = episode.Keeper_memory_os_types.created_at in

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -70,6 +70,7 @@ val extract_with_provider
   -> ?timeout_sec:float
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> keeper_id:string
   -> provider_cfg:Llm_provider.Provider_config.t
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, string) result

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -86,6 +86,10 @@ val extract_and_append_with_provider
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, string) result
 
+val provider_slot_registry_length_for_testing : unit -> int
+(** Number of keepers currently present in the per-keeper slot registry.
+    Exposed only for tests that verify the registry cap. *)
+
 val run_best_effort
   :  ?complete:complete_fn
   -> ?timeout_sec:float

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -947,6 +947,132 @@ let test_librarian_runtime_provider_slot_gate () =
           Alcotest.(check int) "only one provider call entered" 1 (Atomic.get provider_calls))))
 ;;
 
+let test_librarian_runtime_total_slot_gate_across_keepers () =
+  with_prompt_registry (fun () ->
+    with_eio (fun ~sw ~net ~clock ->
+      let env_name = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_SLOT_WAIT_SEC" in
+      let previous = Sys.getenv_opt env_name in
+      Fun.protect
+        ~finally:(fun () ->
+          match previous with
+          | Some value -> Unix.putenv env_name value
+          | None -> Unix.putenv env_name "")
+        (fun () ->
+           Unix.putenv env_name "0.01";
+           let keeper_a = "total-slot-keeper-a" in
+           let keeper_b = "total-slot-keeper-b" in
+           let entered, resolve_entered = Eio.Promise.create () in
+           let release, resolve_release = Eio.Promise.create () in
+           let provider_calls = Atomic.make 0 in
+           let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+             let n = Atomic.fetch_and_add provider_calls 1 in
+             if n = 0
+             then (
+               Eio.Promise.resolve resolve_entered ();
+               Eio.Promise.await release;
+               Ok (fake_response (valid_librarian_output () |> Yojson.Safe.to_string)))
+             else
+               Ok (fake_response (valid_librarian_output () |> Yojson.Safe.to_string))
+           in
+           let input trace_id keeper_id : Librarian.input =
+             { Librarian.trace_id
+             ; generation = 1
+             ; messages = [ text_message ("remember this for " ^ keeper_id) ]
+             }
+           in
+           let first = ref None in
+           let second = ref None in
+           Eio.Fiber.fork ~sw (fun () ->
+             first
+             := Some
+                  (Librarian_runtime.extract_with_provider
+                     ~complete
+                     ~clock
+                     ~timeout_sec:1.0
+                     ~sw
+                     ~net
+                     ~keeper_id:keeper_a
+                     ~provider_cfg:(test_provider_cfg ())
+                     (input "trace-total-a" keeper_a)));
+           Eio.Promise.await entered;
+           Eio.Fiber.fork ~sw (fun () ->
+             second
+             := Some
+                  (Librarian_runtime.extract_with_provider
+                     ~complete
+                     ~clock
+                     ~timeout_sec:1.0
+                     ~sw
+                     ~net
+                     ~keeper_id:keeper_b
+                     ~provider_cfg:(test_provider_cfg ())
+                     (input "trace-total-b" keeper_b)));
+           wait_for_ref ~clock "second librarian result" second;
+           Eio.Promise.resolve resolve_release ();
+           wait_for_ref ~clock "first librarian result" first;
+           (match !second with
+            | Some (Error "librarian provider slot busy") -> ()
+            | Some (Error msg) -> Alcotest.failf "unexpected busy error: %s" msg
+            | Some (Ok _) -> Alcotest.fail "expected second librarian call to skip"
+            | None -> Alcotest.fail "second result missing");
+           (match !first with
+            | Some (Ok episode) ->
+              Alcotest.(check string) "first trace" "trace-total-a" episode.Types.trace_id
+            | Some (Error msg) -> Alcotest.failf "first call failed: %s" msg
+            | None -> Alcotest.fail "first result missing");
+           Alcotest.(check int) "only one provider call entered" 1 (Atomic.get provider_calls))))
+;;
+
+let test_librarian_runtime_registry_size_cap () =
+  let env_name = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_KEEPERS" in
+  let previous = Sys.getenv_opt env_name in
+  let with_cap value f =
+    Fun.protect
+      ~finally:(fun () ->
+        match previous with
+        | Some v -> Unix.putenv env_name v
+        | None -> Unix.putenv env_name "")
+      (fun () -> Unix.putenv env_name value; f ())
+  in
+  with_cap "1" (fun () ->
+    with_prompt_registry (fun () ->
+      with_eio (fun ~sw ~net ~clock ->
+        let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+          Ok (fake_response (valid_librarian_output () |> Yojson.Safe.to_string))
+        in
+        let input keeper_id : Librarian.input =
+          { Librarian.trace_id = "trace-cap-" ^ keeper_id
+          ; generation = 1
+          ; messages = [ text_message "cap test fact" ]
+          }
+        in
+        let run keeper_id =
+          Librarian_runtime.extract_with_provider
+            ~complete
+            ~clock
+            ~timeout_sec:1.0
+            ~sw
+            ~net
+            ~keeper_id
+            ~provider_cfg:(test_provider_cfg ())
+            (input keeper_id)
+        in
+        (match run "cap-keeper-a" with
+         | Ok _ -> ()
+         | Error msg -> Alcotest.failf "first capped call failed: %s" msg);
+        Alcotest.(check int)
+          "registry size after first keeper"
+          1
+          (Librarian_runtime.provider_slot_registry_length_for_testing ());
+        (match run "cap-keeper-b" with
+         | Ok _ -> ()
+         | Error msg -> Alcotest.failf "second capped call failed: %s" msg);
+        Alcotest.(check int)
+          "registry size capped at one"
+          1
+          (Librarian_runtime.provider_slot_registry_length_for_testing ()))))
+;;
+
 let test_librarian_runtime_reports_fact_upsert_failure () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
@@ -2558,6 +2684,14 @@ let () =
             "librarian runtime provider slot gate"
             `Quick
             test_librarian_runtime_provider_slot_gate
+        ; Alcotest.test_case
+            "librarian runtime total slot gate across keepers"
+            `Quick
+            test_librarian_runtime_total_slot_gate_across_keepers
+        ; Alcotest.test_case
+            "librarian runtime registry size cap"
+            `Quick
+            test_librarian_runtime_registry_size_cap
         ; Alcotest.test_case
             "librarian runtime reports fact upsert failure"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -884,6 +884,7 @@ let test_librarian_runtime_provider_slot_gate () =
           | None -> Unix.putenv env_name "")
         (fun () ->
           Unix.putenv env_name "0.01";
+          let keeper_id = "slot-gate-keeper" in
           let entered, resolve_entered = Eio.Promise.create () in
           let release, resolve_release = Eio.Promise.create () in
           let provider_calls = Atomic.make 0 in
@@ -914,6 +915,7 @@ let test_librarian_runtime_provider_slot_gate () =
                     ~timeout_sec:1.0
                     ~sw
                     ~net
+                    ~keeper_id
                     ~provider_cfg:(test_provider_cfg ())
                     (input "trace-slot-a")));
           Eio.Promise.await entered;
@@ -926,6 +928,7 @@ let test_librarian_runtime_provider_slot_gate () =
                     ~timeout_sec:1.0
                     ~sw
                     ~net
+                    ~keeper_id
                     ~provider_cfg:(test_provider_cfg ())
                     (input "trace-slot-b")));
           wait_for_ref ~clock "second librarian result" second;


### PR DESCRIPTION
See commit message.
 
---
 
## 🔄 AS-IS vs TO-BE 구조적 개선점 분석 (Structural Improvements)
 
### 1. AS-IS vs TO-BE 비교 매트릭스

| 구분 | 기술 스택 / 상태 | AS-IS (Before PR #21408) | TO-BE (After PR #21408) |
| :--- | :--- | :--- | :--- |
| **리소스 관리 주체** | OCaml / Eio | 단일 `Librarian` Provider가 모든 Keeper의 요청을 전역적으로 처리 | 각 Keeper 스레드(Domain)마다 독립적인 `Librarian` Provider 슬롯을 할당하여 처리 |
| **동시성 제어 (Concurrency)** | Multi-core / Domains | 전역 Provider를 통한 큐잉(Queuing) 또는 글로벌 락(Mutex) 기반 직렬화 | 분산된 상태 관리. Keeper 별 독립 실행으로 글로벌 락 경합 감소 |
| **상태 공유 및 격리** | `keeper_librarian_runtime.ml` | 중앙 집중식 Runtime Context 공유 | Keeper별 Runtime Context 격리 (Lane Per Keeper) |
| **I/O 및 트랜잭션** | Eio.Switch / DB | 단일 트랜잭션 파이프라인에서 병목(Bottleneck) 발생 | 다중 트랜잭션 레인 병렬 처리로 처리량(Throughput) 증가 시도 |

---

### 2. 아키텍처 전이 다이어그램 (AS-IS → TO-BE)

```mermaid
architecture-beta
    group before(cloud)[AS-IS: Global Provider]
        service db1(database)[DB & Storage] in before
        service gp(server)[Global Librarian Provider] in before
        service k1(server)[Keeper Domain 1] in before
        service k2(server)[Keeper Domain 2] in before
        service k3(server)[Keeper Domain N] in before

        k1:T -- L:gp
        k2:T -- L:gp
        k3:T -- L:gp
        gp:T -- L:db1

    group after(cloud)[TO-BE: Per-Keeper Slot (Lane Per Keeper)]
        service db2(database)[DB & Storage] in after
        service lp1(server)[Librarian Slot 1] in after
        service lp2(server)[Librarian Slot 2] in after
        service lp3(server)[Librarian Slot N] in after
        service nk1(server)[Keeper Domain 1] in after
        service nk2(server)[Keeper Domain 2] in after
        service nk3(server)[Keeper Domain N] in after

        nk1:T -- L:lp1
        nk2:T -- L:lp2
        nk3:T -- L:lp3
        lp1:T -- L:db2
        lp2:T -- L:db2
        lp3:T -- L:db2
```

---

### ⚡ Adversarial Critique & Vulnerability Report (적대적 비판 및 취약성 검증)

이 PR은 단순히 전역 큐를 분리하여 처리량(Throughput)을 높이겠다는 얕은 시도로 보입니다. `lib/keeper/keeper_librarian_runtime.ml` 파일의 변경 사항을 멀티코어 OCaml 및 Eio 환경의 엄격한 시스템 아키텍처 관점에서 분석했을 때, 다음과 같은 치명적인 결함과 설계 구멍이 존재합니다.

#### 1. Eio.Resource 및 Fiber Lifecycle 관리 불량으로 인한 심각한 Resource Leak (FD 고갈 위험)
PR의 "Per-Keeper Slot" 접근 방식은 Keeper Domain의 생명주기와 Librarian Provider의 생명주기를 강제로 1:1로 묶습니다. OCaml Eio에서 독립적인 리소스 풀(예: DB 커넥션, 파일 디스크립터)을 가지려면 반드시 격리된 `Eio.Switch` 하위에서 관리되어야 합니다.
*   **취약성:** PR 코드가 Keeper별 Context를 초기화할 때 `Eio.Switch.run`을 통해 리소스 트리를 올바르게 분리하고 종료시키는 것을 보장하지 않습니다. Keeper가 비정상적으로 크래시되거나(예: `Stdlib.Effect.Unhandled`), 동적으로 스케일 다운되는 시나리오에서 해당 Keeper에 할당되었던 Provider 슬롯과 연결된 소켓/파일 디스크립터가 해제(Cleanup)되지 않고 누수되는 현상이 발생할 것입니다. "Lane"을 나누기만 할 게 아니라, Lane이 파괴될 때의 방어 기제(Finalizer)가 구현되어 있는지 철저히 검증해야 합니다.

#### 2. 전역 상태 동기화 상실 및 Multi-core Domain 간 Race Condition 유발
Provider를 Global에서 Per-Keeper로 쪼개면서, `keeper_librarian_runtime.ml` 내부의 전역 텔레메트리 메트릭스(Telemetry Metrics)나 캐싱된 인덱스(Cached Index)의 동기화 메커니즘이 완전히 붕괴됩니다.
*   **취약성:** 각 Keeper가 독립적인 Lane에서 실행될 때, 단일 Atomic 변수나 Mutex로 보호되던 기존 카운터(예: 활성 트랜잭션 수, 처리 대기 중인 로그 개수)가 이제는 각 Domain의 로컬 상태로 파편화됩니다. Cross-Domain으로 상태를 취합(Aggregation)하거나 강제로 플러시(Flush)하는 교차 동기화 로직 없이 구조만 변경했다면, 이는 Data Race를 유발합니다. OCaml 5.x의 Multi-core 모델에서 메모리 가시성(Memory Visibility) 보장이 누락되어, 시스템 전체의 상태를 모니터링하는 로직이 stale data(과거 데이터)를 기반으로 잘못된 스케일링 결정을 내리게 될 것입니다.

#### 3. 분산 트랜잭션 파편화로 인한 Idempotency 및 ACID 훼손 (교착 상태 및 데이터 정합성 오류)
이 PR은 "Lane per Keeper"라는 이름 아래 병렬성을 높이려 했지만, 결국 데이터베이스 레벨이나 분산 락(Distributed Lock) 레벨에서 경합을 무시한 설계입니다.
*   **취약성:** 여러 Keeper가 동시에 동일한 메타데이터나 동일한 파티션(Partition)에 대한 Read/Write를 시도할 때, 이제는 애플리케이션 레벨의 글로벌 큐(직렬화 기제)가 사라졌으므로 DB 수준의 락 경합(Lock Contention)이 기하급수적으로 증가하거나, 데드락(Deadlock)이 발생할 확률이 극심해집니다. 특히 크래시 복구(Crash Recovery) 중 Reconciliation(조정) 단계에서 여러 Keeper가 동시에 상태를 복구하려 할 때, Idempotency Key가 없다면 중복 처리가 발생하거나 DB 트랜잭션 롤백 폭풍이 일어날 수 있습니다. `keeper_librarian_runtime` 내부에 이러한 교차 레인(Cross-lane) 잠금 메커니즘과 낙관적 동시성 제어(Optimistic Concurrency Control)를 도입하지 않은 채 병렬화만 한 것은 시스템의 신뢰성(Safety)을 담보로 성능(Performance)을 끌어올리려는 매우 위험한 트레이드오프입니다.
