### PR TITLE
fix(dashboard): remove nested scroll container from keeper conversation thread

### DIFF
--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -177,7 +177,6 @@
  * Provide the spacious rhythm + centered max-width column here. */
 .kw-thread {
   flex: 1; min-height: 0; display: flex; flex-direction: column;
-  overflow-y: auto;
   padding: 0;
 }
 .kw-thread-inner {


### PR DESCRIPTION
## 문제
keeper detail 모드의 대화창에서 스크롤이 여전히 되지 않음.

## 원인
`.kw-thread`에 `overflow-y: auto`를 추가하면서, 날부 `ChatTranscript`와 중첩된 scroll container가 되었습니다. `ChatTranscript`는 이미 `size="primary"`일 때 `flex-1 min-h-0 overflow-y-auto`로 스크롤 컨테이너입니다. 바깥 `.kw-thread`까지 스크롤 컨테이너가 되면 wheel 이벤트가 가로채지고 날부 트랜스크립트가 제대로 size/scroll을 잡지 못합니다.

## 수정
`.kw-thread`의 `overflow-y: auto`를 제거하고 flex 높이 래퍼로만 남겨둡니다. 스크롤은 `ChatTranscript`가 담당합니다.

## 검증
- `npx tsc --noEmit --pretty` ✅
- `npm run build` ✅
- `npx vitest run src/app.test.ts` ✅ (15 tests)