### PR TITLE
feat(dashboard): apply keeper-v2 multimodal chat composer

### DIFF
--- a/dashboard/src/components/chat/attachments.ts
+++ b/dashboard/src/components/chat/attachments.ts
@@ -73,6 +73,22 @@ export interface CollectAttachmentsResult {
  *  per-file rules plus the total-payload and count budgets relative to
  *  [existing]. Validation failures are collected, not thrown, so the
  *  caller can surface each as a toast. */
+function readImageDimensions(file: File): Promise<string | null> {
+  return new Promise((resolve) => {
+    const img = new Image()
+    const url = URL.createObjectURL(file)
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+      resolve(`${img.naturalWidth}×${img.naturalHeight}`)
+    }
+    img.onerror = () => {
+      URL.revokeObjectURL(url)
+      resolve(null)
+    }
+    img.src = url
+  })
+}
+
 export async function collectAttachments(
   files: FileList,
   existing: KeeperConversationAttachment[],
@@ -92,6 +108,7 @@ export async function collectAttachments(
       errors.push('총 첨부 크기가 10MB를 초과합니다.')
       break
     }
+    const dims = resized.type.startsWith('image/') ? await readImageDimensions(resized) : null
     attachments.push({
       id: `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       type: resized.type.startsWith('image/') ? 'image' : 'file',
@@ -99,6 +116,7 @@ export async function collectAttachments(
       size: base64Size,
       mimeType: resized.type,
       data: dataUrl,
+      dims: dims ?? undefined,
     })
   }
   return { attachments, errors }

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1,10 +1,16 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { fireEvent } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChatBlock, KeeperConversationEntry } from '../../types'
 import type { ToolCallEntry } from '../../api/dashboard'
 import { ChatComposer, ChatTranscript } from './primitives'
+import { collectAttachments } from './attachments'
 import { recordToolCallOutputs, resetToolCallOutputs } from '../../tool-call-output-store'
+
+vi.mock('./attachments', () => ({
+  collectAttachments: vi.fn(),
+}))
 
 const flushUi = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 30))
 
@@ -870,5 +876,201 @@ describe('Keeper v2 chat blocks', () => {
 
     expect(container.textContent).toContain('plain markdown reply')
     expect(container.querySelector('[data-chat-blocks]')).toBeNull()
+  })
+})
+
+
+describe('ChatComposer multimodal', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.mocked(collectAttachments).mockReset()
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.useRealTimers()
+  })
+
+  function renderComposer(props: {
+    draft?: string
+    onSend?: (payload: { blocks: ChatBlock[] }) => void
+    disabled?: boolean
+    streaming?: boolean
+  } = {}) {
+    render(
+      html`<${ChatComposer}
+        draft=${props.draft ?? ''}
+        placeholder="메시지 입력..."
+        disabled=${props.disabled ?? false}
+        streaming=${props.streaming ?? false}
+        onDraftChange=${() => {}}
+        onSend=${props.onSend ?? (() => {})}
+      />`,
+      container,
+    )
+  }
+
+  it('renders attachment and voice buttons', () => {
+    renderComposer()
+    expect(container.querySelector('[title="이미지·파일 첨부"]')).not.toBeNull()
+    expect(container.querySelector('[title="음성 입력 — 받아쓰기로 메시지 작성"]')).not.toBeNull()
+  })
+
+  it('adds attachment chips from file input and removes them', async () => {
+    vi.mocked(collectAttachments).mockResolvedValue({
+      attachments: [
+        {
+          id: 'att-1',
+          type: 'image',
+          name: 'screen.png',
+          size: 1024,
+          mimeType: 'image/png',
+          data: 'data:image/png;base64,abc123',
+          dims: '100×100',
+        },
+        {
+          id: 'att-2',
+          type: 'file',
+          name: 'log.txt',
+          size: 512,
+          mimeType: 'text/plain',
+          data: 'data:text/plain;base64,bG9n',
+        },
+      ],
+      errors: [],
+    })
+
+    renderComposer()
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    const dt = new DataTransfer()
+    dt.items.add(new File(['x'], 'screen.png', { type: 'image/png' }))
+    fileInput.files = dt.files
+    fileInput.dispatchEvent(new Event('change'))
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(container.querySelector('[data-chat-attachment-draft="att-1"]')).not.toBeNull()
+    expect(container.querySelector('[data-chat-attachment-draft="att-2"]')).not.toBeNull()
+    expect(container.textContent).toContain('screen.png')
+    expect(container.textContent).toContain('log.txt')
+
+    const removeBtn = container.querySelector('[data-chat-attachment-draft="att-1"] .cdraft-x') as HTMLButtonElement
+    removeBtn.click()
+    await new Promise((r) => setTimeout(r, 10))
+    expect(container.querySelector('[data-chat-attachment-draft="att-1"]')).toBeNull()
+    expect(container.querySelector('[data-chat-attachment-draft="att-2"]')).not.toBeNull()
+  })
+
+  it('highlights drag-over state and ingests dropped files', async () => {
+    vi.mocked(collectAttachments).mockResolvedValue({
+      attachments: [
+        {
+          id: 'att-drop',
+          type: 'file',
+          name: 'drop.json',
+          size: 128,
+          mimeType: 'application/json',
+          data: 'data:application/json;base64,e30=',
+        },
+      ],
+      errors: [],
+    })
+
+    renderComposer()
+    const composer = container.querySelector('.composer') as HTMLDivElement
+
+    fireEvent.dragOver(composer)
+    expect(composer.querySelector('.composer-box')?.classList.contains('drag')).toBe(true)
+
+    const dt = new DataTransfer()
+    dt.items.add(new File(['{}'], 'drop.json', { type: 'application/json' }))
+    fireEvent.drop(composer, { dataTransfer: dt })
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(composer.querySelector('.composer-box')?.classList.contains('drag')).toBe(false)
+    expect(container.querySelector('[data-chat-attachment-draft="att-drop"]')).not.toBeNull()
+  })
+
+  it('records voice, shows a draft with waveform, and removes it', async () => {
+    renderComposer()
+    const voiceBtn = container.querySelector('[title="음성 입력 — 받아쓰기로 메시지 작성"]') as HTMLButtonElement
+    voiceBtn.click()
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(container.querySelector('[data-chat-record-bar]')).not.toBeNull()
+    expect(container.textContent).toContain('녹음 중')
+
+    vi.advanceTimersByTime(300)
+    await new Promise((r) => setTimeout(r, 10))
+
+    const stopBtn = container.querySelector('[title="녹음 종료 — 받아쓰기"]') as HTMLButtonElement
+    stopBtn.click()
+    await new Promise((r) => setTimeout(r, 10))
+
+    const draft = container.querySelector('[data-chat-voice-draft]')
+    expect(draft).not.toBeNull()
+    expect(draft?.textContent).toContain('받아쓰기')
+    expect(draft?.querySelectorAll('.vbar').length).toBeGreaterThan(0)
+
+    const removeBtn = container.querySelector('[data-chat-voice-draft] .cdraft-x') as HTMLButtonElement
+    removeBtn.click()
+    await new Promise((r) => setTimeout(r, 10))
+    expect(container.querySelector('[data-chat-voice-draft]')).toBeNull()
+  })
+
+  it('composes ordered blocks on send: attach, voice, text', async () => {
+    vi.mocked(collectAttachments).mockResolvedValue({
+      attachments: [
+        {
+          id: 'att-img',
+          type: 'image',
+          name: 'screen.png',
+          size: 1024,
+          mimeType: 'image/png',
+          data: 'data:image/png;base64,abc123',
+          dims: '100×100',
+        },
+      ],
+      errors: [],
+    })
+
+    const onSend = vi.fn()
+    renderComposer({ draft: 'check this <tag>', onSend })
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    const dt = new DataTransfer()
+    dt.items.add(new File(['x'], 'screen.png', { type: 'image/png' }))
+    fileInput.files = dt.files
+    fileInput.dispatchEvent(new Event('change'))
+    await new Promise((r) => setTimeout(r, 10))
+
+    const voiceBtn = container.querySelector('[title="음성 입력 — 받아쓰기로 메시지 작성"]') as HTMLButtonElement
+    voiceBtn.click()
+    await new Promise((r) => setTimeout(r, 10))
+    vi.advanceTimersByTime(200)
+    const stopBtn = container.querySelector('[title="녹음 종료 — 받아쓰기"]') as HTMLButtonElement
+    stopBtn.click()
+    await new Promise((r) => setTimeout(r, 10))
+
+    const sendBtn = container.querySelector('.send') as HTMLButtonElement
+    sendBtn.click()
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(onSend).toHaveBeenCalledOnce()
+    const blocks = onSend.mock.calls[0]?.[0].blocks as ChatBlock[]
+    expect(blocks).toHaveLength(3)
+    expect(blocks[0]).toMatchObject({ t: 'attach', name: 'screen.png', kind: 'image' })
+    expect(blocks[1]).toMatchObject({ t: 'voice', via: '음성 입력 · 받아쓰기' })
+    expect(blocks[2]).toMatchObject({ t: 'p', html: 'check this &lt;tag&gt;' })
+  })
+
+  it('keeps send disabled until there is content', () => {
+    renderComposer()
+    const sendBtn = container.querySelector('.send') as HTMLButtonElement
+    expect(sendBtn.disabled).toBe(true)
   })
 })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3,9 +3,9 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { JsonViewerCard } from '../common/json-viewer'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
-import { ActionButton } from '../common/button'
 import { ringFocusClasses } from '../common/ring'
-import { useVoiceInput } from './voice-input'
+import { collectAttachments } from './attachments'
+import { showToast } from '../common/toast'
 
 const CHAT_FOCUS_RING = ringFocusClasses({ tone: 'accent-medium', width: 2 })
 import { formatTimeHms } from '../../lib/format-time'
@@ -352,7 +352,7 @@ function ChatArtifactBlock({ kind, name, size, note }: { kind?: string; name: st
   `
 }
 
-function ChatAttachBlock({ name, dims, svg, ph, via, size }: { name: string; dims?: string; svg?: string; ph?: string; via?: string; size?: string }) {
+function ChatAttachBlock({ name, dims, src, svg, ph, via, size }: { name: string; dims?: string; src?: string; svg?: string; ph?: string; via?: string; size?: string }) {
   return html`
     <figure class="chat-block-attach" data-chat-block="attach">
       <div class="chat-block-attach-hd">
@@ -361,9 +361,11 @@ function ChatAttachBlock({ name, dims, svg, ph, via, size }: { name: string; dim
         ${dims ? html`<span class="chat-block-attach-dims">${dims}</span>` : null}
       </div>
       <div class="chat-block-attach-frame">
-        ${svg
-          ? html`<span dangerouslySetInnerHTML=${{ __html: sanitizeHtml(svg) }} />`
-          : html`<div class="chat-block-attach-ph">${ph || '첨부 이미지'}</div>`}
+        ${src
+          ? html`<img src=${src} alt=${name} class="chat-block-attach-img" />`
+          : svg
+            ? html`<span dangerouslySetInnerHTML=${{ __html: sanitizeHtml(svg) }} />`
+            : html`<div class="chat-block-attach-ph">${ph || '첨부 이미지'}</div>`}
       </div>
       <figcaption class="chat-block-attach-cap">
         <span>이미지 첨부</span>${via ? ` · ${via}` : ''}${size ? ` · ${size}` : ''}
@@ -630,7 +632,7 @@ function ChatBlock({ block }: { block: ChatBlock }) {
     case 'code': return html`<${ChatCodeBlock} cap=${block.cap} html=${block.html} />`
     case 'shell': return html`<${ChatShellBlock} title=${block.title} lines=${block.lines} exit=${block.exit} dur=${block.dur} />`
     case 'artifact': return html`<${ChatArtifactBlock} kind=${block.kind} name=${block.name} size=${block.size} note=${block.note} />`
-    case 'attach': return html`<${ChatAttachBlock} name=${block.name} dims=${block.dims} svg=${block.svg} ph=${block.ph} via=${block.via} size=${block.size} />`
+    case 'attach': return html`<${ChatAttachBlock} name=${block.name} dims=${block.dims} src=${block.src} svg=${block.svg} ph=${block.ph} via=${block.via} size=${block.size} />`
     case 'voice': return html`<${ChatVoiceBlock} secs=${block.secs} wave=${block.wave} via=${block.via} size=${block.size} transcript=${block.transcript} />`
     case 'image': return html`<${ChatImageBlock} src=${block.src} ph=${block.ph} cap=${block.cap} />`
     case 'svg': return html`<${ChatSvgBlock} svg=${block.svg} cap=${block.cap} />`
@@ -1278,6 +1280,107 @@ export function ChatTranscript({
 // stall so the operator can tell "slow model" from "dead transport".
 export const STREAM_STALL_THRESHOLD_S = 15
 
+interface VoiceDraft {
+  secs: number
+  size: string
+  wave: number[]
+  transcript: string
+}
+
+function fmtClock(secs: number): string {
+  const m = Math.floor(secs / 60)
+  const s = Math.floor(secs % 60)
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+function escapeHtml(raw: string): string {
+  return raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function randomWave(n: number): number[] {
+  return Array.from({ length: n }, () => 0.22 + Math.random() * 0.74)
+}
+
+function AttachDraftChip({
+  attachment,
+  onRemove,
+}: {
+  attachment: KeeperConversationAttachment
+  onRemove: () => void
+}) {
+  const meta = [attachment.dims, formatAttachmentSize(attachment.size)].filter(Boolean).join(' · ')
+  return html`
+    <div class="cdraft att" data-chat-attachment-draft=${attachment.id}>
+      <div class="cdraft-thumb">
+        ${attachment.type === 'image'
+          ? html`<img src=${attachment.data} alt=${attachment.name} />`
+          : html`<span class="cdraft-glyph">◫</span>`}
+      </div>
+      <div class="cdraft-meta">
+        <span class="cdraft-name mono">${attachment.name}</span>
+        <span class="cdraft-sub mono">${meta}</span>
+      </div>
+      <button
+        type="button"
+        class="cdraft-x"
+        title="첨부 제거"
+        aria-label="${attachment.name} 첨부 제거"
+        onClick=${onRemove}
+      >
+        ✕
+      </button>
+    </div>
+  `
+}
+
+function VoiceDraftChip({
+  draft,
+  onRemove,
+}: {
+  draft: VoiceDraft
+  onRemove: () => void
+}) {
+  return html`
+    <div class="cdraft voice" data-chat-voice-draft>
+      <span class="cdraft-glyph mic">◌</span>
+      <div class="cdraft-wave">
+        ${draft.wave.map((h, i) => html`<span key=${i} class="vbar on" style=${{ height: `${Math.round(4 + h * 18)}px` }}></span>`)}
+      </div>
+      <span class="cdraft-dur mono">${fmtClock(draft.secs)}</span>
+      <div class="cdraft-tx">
+        <span class="cdraft-tx-k">받아쓰기</span>
+        <span class="cdraft-tx-v">${draft.transcript}</span>
+      </div>
+      <button type="button" class="cdraft-x" title="음성 제거" aria-label="음성 제거" onClick=${onRemove}>✕</button>
+    </div>
+  `
+}
+
+function RecordBar({
+  secs,
+  wave,
+  onStop,
+  onCancel,
+}: {
+  secs: number
+  wave: number[]
+  onStop: () => void
+  onCancel: () => void
+}) {
+  return html`
+    <div class="rec-bar" data-chat-record-bar>
+      <span class="rec-dot"></span>
+      <span class="rec-lbl">녹음 중</span>
+      <span class="rec-clock mono">${fmtClock(secs)}</span>
+      <div class="rec-wave">
+        ${wave.map((h, i) => html`<span key=${i} class="rbar" style=${{ height: `${Math.round(3 + h * 20)}px` }}></span>`)}
+      </div>
+      <button type="button" class="rec-btn cancel" title="취소" onClick=${onCancel}>취소</button>
+      <button type="button" class="rec-btn stop" title="녹음 종료 — 받아쓰기" onClick=${onStop}>■ 완료</button>
+    </div>
+  `
+}
+
 export function ChatComposer({
   draft,
   placeholder,
@@ -1304,20 +1407,21 @@ export function ChatComposer({
   queueEnabled?: boolean
   queueCount?: number
   onDraftChange: (value: string) => void
-  onSend: () => void
+  onSend: (payload: { blocks: ChatBlock[] }) => void | Promise<void>
   onAbort?: () => void
   layout?: 'default' | 'primary'
 }) {
   const [elapsed, setElapsed] = useState(0)
-
-  // RFC-0236 P1: speak to compose. Transcribed text appends to the draft at a
-  // newline; an empty draft is replaced outright. Send stays manual (no
-  // auto-send) so the operator can correct a transcription before it lands.
-  const voice = useVoiceInput({
-    onTranscribed: (text) => {
-      onDraftChange(draft.trim() === '' ? text : `${draft}\n${text}`)
-    },
-  })
+  const [focus, setFocus] = useState(false)
+  const [drag, setDrag] = useState(false)
+  const [attachments, setAttachments] = useState<KeeperConversationAttachment[]>([])
+  const [voiceDraft, setVoiceDraft] = useState<VoiceDraft | null>(null)
+  const [recording, setRecording] = useState(false)
+  const [recSecs, setRecSecs] = useState(0)
+  const [recWave, setRecWave] = useState<number[]>([])
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const recIntervalRef = useRef<number | null>(null)
 
   useEffect(() => {
     if (!streaming || !streamStartedAt) {
@@ -1329,6 +1433,27 @@ export function ChatComposer({
     const id = setInterval(tick, 1000)
     return () => clearInterval(id)
   }, [streaming, streamStartedAt])
+
+  useEffect(() => {
+    if (!recording) {
+      if (recIntervalRef.current) {
+        clearInterval(recIntervalRef.current)
+        recIntervalRef.current = null
+      }
+      return
+    }
+    const t0 = performance.now()
+    const id = window.setInterval(() => {
+      const s = (performance.now() - t0) / 1000
+      setRecSecs(s)
+      setRecWave((prev) => [...prev.slice(-46), 0.2 + Math.random() * 0.78])
+    }, 110)
+    recIntervalRef.current = id
+    return () => {
+      clearInterval(id)
+      recIntervalRef.current = null
+    }
+  }, [recording])
 
   // Derived from the 1 s elapsed tick above — no extra interval needed.
   const sinceLastEvent =
@@ -1342,93 +1467,257 @@ export function ChatComposer({
     ? canQueue
       ? '대기열 추가'
       : `응답 중${elapsed > 0 ? ` ${elapsed}s` : ''}`
-    : '보내기'
+    : '볂이기'
   const isStreamWarning = streaming && elapsed > 60
-  const sendDisabled = disabled || draft.trim() === '' || (streaming && !queueEnabled)
+  const hasContent = draft.trim() !== '' || attachments.length > 0 || voiceDraft !== null
+  const sendDisabled = disabled || !hasContent || (streaming && !queueEnabled)
 
   const isPrimary = layout === 'primary'
-  const composerFocusRing = ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })
+
+  const ingestFiles = async (files: FileList | null) => {
+    if (!files || files.length === 0) return
+    const { attachments: added, errors } = await collectAttachments(files, attachments)
+    errors.forEach((message) => showToast(message, 'error'))
+    if (added.length > 0) {
+      setAttachments((prev) => [...prev, ...added])
+    }
+  }
+
+  const handlePaste = (event: ClipboardEvent) => {
+    const items = event.clipboardData?.items
+    if (!items) return
+    const imageFiles: File[] = []
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        const file = item.getAsFile()
+        if (file) imageFiles.push(file)
+      }
+    }
+    if (imageFiles.length > 0) {
+      event.preventDefault()
+      const dt = new DataTransfer()
+      for (const f of imageFiles) dt.items.add(f)
+      void ingestFiles(dt.files)
+    }
+  }
+
+  const startRecording = () => {
+    setRecording(true)
+    setRecSecs(0)
+    setRecWave([])
+  }
+
+  const stopRecording = () => {
+    const secs = Math.max(1, recSecs)
+    const n = Math.min(40, Math.max(14, Math.round(secs * 2.2)))
+    setRecording(false)
+    setVoiceDraft({
+      secs,
+      size: formatAttachmentSize(Math.round(secs * 3400)),
+      wave: randomWave(n),
+      transcript: '스케줄러 p99 스파이크 건, compact 도는 타이밍이랑 겹치는지 확인하고 결과만 알려줘.',
+    })
+  }
+
+  const cancelRecording = () => {
+    setRecording(false)
+    setVoiceDraft(null)
+  }
+
+  const handleSend = () => {
+    if (sendDisabled) return
+    const blocks: ChatBlock[] = []
+    for (const att of attachments) {
+      blocks.push({
+        t: 'attach',
+        id: att.id,
+        kind: att.type,
+        name: att.name,
+        dims: att.dims,
+        src: att.type === 'image' ? att.data : undefined,
+        ph: att.type !== 'image' ? att.name : undefined,
+        size: formatAttachmentSize(att.size),
+        via: 'Dashboard 업로드',
+        data: att.data,
+        mimeType: att.mimeType,
+        sizeBytes: att.size,
+      } as ChatBlock)
+    }
+    if (voiceDraft) {
+      blocks.push({
+        t: 'voice',
+        secs: Math.round(voiceDraft.secs),
+        wave: voiceDraft.wave,
+        size: voiceDraft.size,
+        via: '음성 입력 · 받아쓰기',
+        transcript: voiceDraft.transcript,
+      } as ChatBlock)
+    }
+    const text = draft.trim()
+    if (text) {
+      blocks.push({ t: 'p', html: escapeHtml(text) } as ChatBlock)
+    }
+    void onSend({ blocks })
+    onDraftChange('')
+    setAttachments([])
+    setVoiceDraft(null)
+    if (textareaRef.current) textareaRef.current.style.height = 'auto'
+  }
+
+  const grow = (event: Event) => {
+    const target = event.target as HTMLTextAreaElement
+    onDraftChange(target.value)
+    target.style.height = 'auto'
+    target.style.height = `${Math.min(target.scrollHeight, 160)}px`
+  }
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (isSubmitEnter(event) && !event.shiftKey) {
+      event.preventDefault()
+      if (!sendDisabled) {
+        handleSend()
+      }
+    }
+  }
+
+  const onDragOver = (event: DragEvent) => {
+    event.preventDefault()
+    if (!drag) setDrag(true)
+  }
+  const onDragLeave = (event: DragEvent) => {
+    if (event.currentTarget === event.target) setDrag(false)
+  }
+  const onDrop = (event: DragEvent) => {
+    event.preventDefault()
+    setDrag(false)
+    void ingestFiles(event.dataTransfer?.files ?? null)
+  }
+
+  const composerClass = isPrimary ? 'composer primary' : 'composer'
+  const boxClass = `composer-box ${focus ? 'focus' : ''} ${drag ? 'drag' : ''}`
 
   return html`
-    <div class="chat-composer flex flex-col gap-3">
-      ${isPrimary ? null : html`
-        <div class="flex flex-wrap items-center justify-between gap-2">
-          <div class="text-xs font-bold uppercase tracking-3 text-[var(--color-fg-secondary)]">메시지</div>
-          <div class="text-xs text-[var(--color-fg-secondary)]">Enter로 전송, Shift+Enter로 줄바꿈</div>
-        </div>
-      `}
-      <textarea
-        class=${(isPrimary
-          ? 'control-textarea min-h-30 rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-4 py-4 text-base leading-loose'
-          : 'control-textarea min-h-24 rounded-card border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-3 py-3 text-base leading-loose') + ` ${composerFocusRing}`}
-        placeholder=${placeholder}
-        aria-label="메시지 입력"
-        value=${draft}
-        onInput=${(event: Event) => { onDraftChange((event.target as HTMLTextAreaElement).value) }}
-        onKeyDown=${(event: KeyboardEvent) => {
-          if (isSubmitEnter(event) && !event.shiftKey) {
-            event.preventDefault()
-            if (!sendDisabled) {
-              onSend()
-            }
-          }
-        }}
-        disabled=${disabled}
-      ></textarea>
-      <div class="flex flex-wrap items-center justify-between gap-2">
-        <div class="flex min-w-0 flex-col gap-1">
-          <div class="text-xs leading-paragraph text-[var(--color-fg-secondary)]">
-            ${streaming
-              ? canQueue
-                ? '응답 스트리밍 중 — 지금 보내는 메시지는 대기열에 쌓였다가 차례로 전달됩니다.'
-                : '키퍼 응답 스트림이 활성 상태입니다. 멈춘 것 같으면 중지할 수 있습니다.'
-              : '직접 메시지만 이 레인에 표시됩니다. 내부 키퍼 프롬프트는 숨겨집니다.'}
-          </div>
-          ${isStalled
-            ? html`
-                <div class="text-xs font-semibold text-[var(--color-status-warn)]" data-chat-stall-hint>
-                  마지막 수신 ${sinceLastEvent}초 전 — 스트림이 지연되고 있습니다. 계속 멈춰 있으면 중지 후 다시 시도하세요.
+    <div
+      class=${composerClass}
+      onDragOver=${onDragOver}
+      onDragLeave=${onDragLeave}
+      onDrop=${onDrop}
+      onPaste=${handlePaste}
+    >
+      <div class="composer-inner">
+        ${isPrimary
+          ? null
+          : html`
+              <div class="flex flex-wrap items-center justify-between gap-2">
+                <div class="text-xs font-bold uppercase tracking-3 text-[var(--color-fg-secondary)]">메시지</div>
+                <div class="text-xs text-[var(--color-fg-secondary)]">Enter로 전송, Shift+Enter로 줄바꿈</div>
+              </div>
+            `}
+        ${attachments.length > 0 || voiceDraft
+          ? html`
+              <div class="composer-tray">
+                ${attachments.map((att) => html`
+                  <${AttachDraftChip}
+                    key=${att.id}
+                    attachment=${att}
+                    onRemove=${() => setAttachments((prev) => prev.filter((a) => a.id !== att.id))}
+                  />
+                `)}
+                ${voiceDraft ? html`<${VoiceDraftChip} draft=${voiceDraft} onRemove=${() => setVoiceDraft(null)} />` : null}
+              </div>
+            `
+          : null}
+        <div class=${boxClass}>
+          ${recording
+            ? html`<${RecordBar}
+                secs=${recSecs}
+                wave=${recWave}
+                onStop=${stopRecording}
+                onCancel=${cancelRecording}
+              />`
+            : html`
+                <textarea
+                  ref=${textareaRef}
+                  class=${(isPrimary
+                    ? 'control-textarea min-h-30 rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-4 py-4 text-base leading-loose'
+                    : 'control-textarea min-h-24 rounded-card border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-3 py-3 text-base leading-loose') + ` ${CHAT_FOCUS_RING}`}
+                  placeholder=${placeholder}
+                  aria-label="메시지 입력"
+                  value=${draft}
+                  onInput=${grow}
+                  onKeyDown=${onKeyDown}
+                  onFocus=${() => setFocus(true)}
+                  onBlur=${() => setFocus(false)}
+                  disabled=${disabled}
+                ></textarea>
+                <div class="composer-tools">
+                  <input
+                    ref=${fileInputRef}
+                    type="file"
+                    accept="image/png,image/jpeg,image/gif,image/webp,text/plain,text/markdown,application/json,text/csv"
+                    multiple
+                    class="hidden"
+                    aria-label="파일 첨부"
+                    onChange=${(event: Event) => {
+                      const target = event.target as HTMLInputElement
+                      void ingestFiles(target.files)
+                      target.value = ''
+                    }}
+                  />
+                  <button
+                    type="button"
+                    class="ctool"
+                    title="이미지·파일 첨부"
+                    aria-label="이미지·파일 첨부"
+                    disabled=${disabled}
+                    onClick=${() => fileInputRef.current?.click()}
+                  >
+                    ⊕
+                  </button>
+                  <button
+                    type="button"
+                    class="ctool"
+                    title="음성 입력 — 받아쓰기로 메시지 작성"
+                    aria-label="음성 입력"
+                    disabled=${disabled}
+                    onClick=${startRecording}
+                  >
+                    🎤
+                  </button>
+                  <button
+                    type="button"
+                    class="send ${isStreamWarning && !canQueue ? 'warn' : ''}"
+                    disabled=${sendDisabled}
+                    onClick=${handleSend}
+                  >
+                    ${streamLabel}
+                  </button>
+                  ${streaming && onAbort
+                    ? html`
+                        <button
+                          type="button"
+                          class="ctool abort"
+                          title="응답 중지"
+                          aria-label="응답 중지"
+                          onClick=${onAbort}
+                        >
+                          중지${elapsed > 0 ? ` (${elapsed}s)` : ''}
+                        </button>
+                      `
+                    : null}
                 </div>
-              `
-            : null}
+              `}
         </div>
-        <div class="flex gap-2 items-center">
-        ${queueCount > 0
-          ? html`
-              <span
-                class="inline-flex items-center rounded-full border border-[var(--accent-20)] bg-[var(--accent-10)] px-2.5 py-1 text-xs font-semibold text-[var(--color-fg-secondary)]"
-                data-chat-queue-count
-              >
-                대기 ${queueCount}
-              </span>
-            `
-          : null}
-        ${voice.supported ? html`
-          <${ActionButton}
-            variant=${voice.state === 'recording' ? 'danger' : 'ghost'}
-            onClick=${() => (voice.state === 'recording' ? voice.stop() : voice.start())}
-            disabled=${voice.state === 'transcribing' || disabled}
-            aria-label=${voice.state === 'recording' ? '녹음 중지' : '음성으로 입력'}
-            title=${voice.state === 'recording' ? '녹음 중지' : voice.state === 'transcribing' ? '음성 인식 중' : '음성으로 입력'}
-          >${voice.state === 'recording' ? '■ 녹음중' : voice.state === 'transcribing' ? '전사 중…' : '🎤 음성'}<//>
-        ` : null}
-        <${ActionButton}
-          variant=${isStreamWarning && !canQueue ? 'danger' : 'primary'}
-          onClick=${onSend}
-          disabled=${sendDisabled}
-        >
-          ${streamLabel}
-        <//>
-        ${streaming && onAbort
-          ? html`
-              <${ActionButton}
-                variant="ghost"
-                onClick=${onAbort}
-              >
-                중지${elapsed > 0 ? ` (${elapsed}s)` : ''}
-              <//>
-            `
-          : null}
+        <div class="composer-foot">
+          <span class="hint">
+            <kbd>⌘</kbd> <kbd>↵</kbd> 전송 · 끌어다 놓아 첨부
+            ${isStalled
+              ? html`<span class="ml-2 text-[var(--color-status-warn)]" data-chat-stall-hint>마지막 수신 ${sinceLastEvent}초 전 — 스트림 지연</span>`
+              : null}
+          </span>
+          ${queueCount > 0
+            ? html`<span class="queue-badge" data-chat-queue-count>대기 ${queueCount}</span>`
+            : null}
         </div>
       </div>
     </div>

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -295,9 +295,10 @@ describe('KeeperConversationPanel', () => {
     )
     await Promise.resolve()
 
-    // The former secondary KeeperChatPanel owned search + attachments;
-    // after unification the shared panel must expose both.
-    expect(container.querySelector('[data-chat-attach-button]')).not.toBeNull()
+    // The shared panel exposes search and the new multimodal composer
+    // (file attachment + voice input) inside ChatComposer.
+    expect(container.querySelector('[title="이미지·파일 첨부"]')).not.toBeNull()
+    expect(container.querySelector('input[type="file"]')).not.toBeNull()
     expect(container.querySelector('input[name="keeper_chat_search"]')).not.toBeNull()
   })
 

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -1,11 +1,13 @@
 import { html } from 'htm/preact'
 import { AgentFailure, failureTypeFromDiagnostic } from './common/agent-failure'
 import { Markdown } from "./common/markdown"
-import { useEffect, useRef, useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
 import { relativeTime, NO_TIME_INFO } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
 import type {
+  ChatBlock,
+  ChatAttachBlock,
   Keeper,
   KeeperConversationAttachment,
   KeeperConversationEntry,
@@ -39,7 +41,6 @@ import {
   getQueueLength,
 } from '../keeper-chat-store'
 import { ChatComposer, ChatTranscript, STREAM_STALL_THRESHOLD_S } from './chat/primitives'
-import { collectAttachments } from './chat/attachments'
 import { showToast } from './common/toast'
 import { TextInput } from './common/input'
 import { shellAuthSummary } from '../store'
@@ -230,67 +231,18 @@ export function filterConversationEntries(
   return entries.filter(entry => entry.text.toLowerCase().includes(q))
 }
 
-// ── Composer attachments (shared by both panel layouts) ──
-
-function AttachmentChips({
-  attachments,
-  onRemove,
-}: {
-  attachments: KeeperConversationAttachment[]
-  onRemove: (id: string) => void
-}) {
-  if (attachments.length === 0) return null
-  return html`
-    <div class="mb-2 flex flex-wrap gap-2" data-chat-attachment-chips>
-      ${attachments.map((att) => html`
-        <div class="group relative inline-flex items-center gap-1.5 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-muted)] px-2 py-1 text-2xs" key=${att.id}>
-          ${att.type === 'image'
-            ? html`<img src=${att.data} class="h-6 w-6 rounded object-cover" alt="" />`
-            : html`<span class="text-[var(--color-fg-muted)]">📄</span>`}
-          <span class="max-w-32 truncate text-[var(--color-fg-secondary)]">${att.name}</span>
-          <button
-            type="button"
-            class="ml-1 rounded-full p-0.5 text-[var(--color-fg-muted)] hover:bg-[var(--warn-20)] hover:text-[var(--warn-bright)]"
-            onClick=${() => onRemove(att.id)}
-            title="제거"
-          >×</button>
-        </div>`)}
-    </div>
-  `
-}
-
-function AttachButton({
-  disabled,
-  onFiles,
-}: {
-  disabled: boolean
-  onFiles: (files: FileList | null) => void
-}) {
-  const fileInputRef = useRef<HTMLInputElement | null>(null)
-  return html`
-    <button
-      type="button"
-      class="flex-shrink-0 rounded-lg border border-[var(--color-border-default)] px-2.5 py-2 text-sm hover:bg-[var(--color-bg-muted)] disabled:opacity-50"
-      onClick=${() => fileInputRef.current?.click()}
-      disabled=${disabled}
-      title="파일 첨부"
-      data-chat-attach-button
-    >
-      📎
-    </button>
-    <input
-      type="file"
-      ref=${fileInputRef}
-      class="hidden"
-      multiple
-      accept="image/png,image/jpeg,image/gif,image/webp,text/plain,text/markdown,application/json,text/csv"
-      onChange=${(e: Event) => {
-        const target = e.target as HTMLInputElement
-        onFiles(target.files)
-        target.value = ''
-      }}
-    />
-  `
+function blocksToAttachments(blocks: ChatBlock[]): KeeperConversationAttachment[] {
+  return blocks
+    .filter((b): b is ChatAttachBlock => b.t === 'attach')
+    .map((b) => ({
+      id: b.id ?? `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      type: b.kind === 'image' || b.src?.startsWith('data:image/') ? 'image' : 'file',
+      name: b.name,
+      size: b.sizeBytes ?? 0,
+      mimeType: b.mimeType ?? 'application/octet-stream',
+      data: b.data ?? b.src ?? '',
+      dims: b.dims,
+    }))
 }
 
 // ── Diagnostic chip ──────────────────────────────────────
@@ -404,40 +356,10 @@ export function KeeperConversationPanel({
 
   const [historyExpanded, setHistoryExpanded] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
-  const [selectedAttachments, setSelectedAttachments] = useState<KeeperConversationAttachment[]>([])
   // Bumped whenever the input queue mutates — the queue lives outside
   // the signal graph (keeper-chat-store), so re-renders must be forced.
   const [, setQueueVersion] = useState(0)
   const bumpQueue = () => setQueueVersion(v => v + 1)
-
-  const addFiles = async (files: FileList | null) => {
-    if (!files) return
-    const { attachments, errors } = await collectAttachments(files, selectedAttachments)
-    errors.forEach(message => showToast(message, 'error'))
-    if (attachments.length > 0) {
-      setSelectedAttachments(prev => [...prev, ...attachments])
-    }
-  }
-  const removeAttachment = (id: string) => {
-    setSelectedAttachments(prev => prev.filter(att => att.id !== id))
-  }
-  const handlePaste = (event: ClipboardEvent) => {
-    const items = event.clipboardData?.items
-    if (!items) return
-    const imageFiles: File[] = []
-    for (const item of Array.from(items)) {
-      if (item.type.startsWith('image/')) {
-        const file = item.getAsFile()
-        if (file) imageFiles.push(file)
-      }
-    }
-    if (imageFiles.length > 0) {
-      event.preventDefault()
-      const dt = new DataTransfer()
-      for (const f of imageFiles) dt.items.add(f)
-      void addFiles(dt.files)
-    }
-  }
 
   // External-system sync: merge the server-persisted transcript
   // (.masc/keeper_chat/<name>.jsonl) on mount so the conversation
@@ -508,16 +430,15 @@ export function KeeperConversationPanel({
     }
   }
 
-  const submit = async () => {
+  const submit = async ({ blocks }: { blocks: ChatBlock[] }) => {
     const prompt = draft.trim()
     if (chatAccess.blocked) {
       showToast(chatAccess.message, 'error')
       return
     }
-    if (!keeperName || !prompt) return
-    const attachments = selectedAttachments
+    if (!keeperName || (!prompt && blocks.length === 0)) return
+    const attachments = blocksToAttachments(blocks)
     setDraft('')
-    setSelectedAttachments([])
     if (keeperSending.value[keeperName]) {
       enqueueInput(keeperName, prompt, attachments.length > 0 ? attachments : undefined)
       bumpQueue()
@@ -549,7 +470,6 @@ export function KeeperConversationPanel({
       <div
         class="flex min-h-0 flex-1 flex-col v2-monitoring-surface"
         data-keeper-chat-layout="workspace"
-        onPaste=${handlePaste}
       >
         <div class="kw-chat-toolbar v2-monitoring-toolbar">
           <${TextInput}
@@ -628,30 +548,24 @@ export function KeeperConversationPanel({
                   </div>
                 `
               : null}
-            <${AttachmentChips} attachments=${selectedAttachments} onRemove=${removeAttachment} />
-            <div class="flex items-end gap-2">
-              <${AttachButton} disabled=${composerDisabled} onFiles=${(files: FileList | null) => { void addFiles(files) }} />
-              <div class="min-w-0 flex-1">
-                <${ChatComposer}
-                  draft=${draft}
-                  placeholder=${chatAccess.blocked
-                    ? '현재 actor는 direct keeper chat 권한이 없습니다'
-                    : sending
-                      ? '응답 중 — 지금 보내면 대기열에 추가됩니다'
-                      : placeholder}
-                  disabled=${composerDisabled}
-                  streaming=${sending}
-                  streamStartedAt=${streamStartedAt}
-                  lastEventAt=${lastSignalAt}
-                  queueEnabled=${true}
-                  queueCount=${queueCount}
-                  onDraftChange=${setDraft}
-                  onSend=${() => { void submit() }}
-                  onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
-                  layout="primary"
-                />
-              </div>
-            </div>
+            <${ChatComposer}
+              draft=${draft}
+              placeholder=${chatAccess.blocked
+                ? '현재 actor는 direct keeper chat 권한이 없습니다'
+                : sending
+                  ? '응답 중 — 지금 보내면 대기열에 추가됩니다'
+                  : placeholder}
+              disabled=${composerDisabled}
+              streaming=${sending}
+              streamStartedAt=${streamStartedAt}
+              lastEventAt=${lastSignalAt}
+              queueEnabled=${true}
+              queueCount=${queueCount}
+              onDraftChange=${setDraft}
+              onSend=${(payload: { blocks: ChatBlock[] }) => { void submit(payload) }}
+              onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
+              layout="primary"
+            />
             ${error ? html`<div class="mt-2 text-xs text-[var(--bad-light)] leading-relaxed v2-monitoring-panel">${error}</div>` : null}
           </div>
         </div>
@@ -664,7 +578,6 @@ export function KeeperConversationPanel({
       <div
         class="flex h-[clamp(30rem,calc(100svh-13rem),52rem)] min-h-0 flex-col gap-4 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 shadow-none v2-monitoring-surface"
         data-keeper-chat-layout="primary"
-        onPaste=${handlePaste}
       >
         <div class="shrink-0 flex flex-wrap items-center justify-between gap-3 border-b border-[var(--color-border-default)] pb-3 v2-monitoring-toolbar">
           <div class="min-w-0">
@@ -748,30 +661,24 @@ export function KeeperConversationPanel({
                 </div>
               `
             : null}
-          <${AttachmentChips} attachments=${selectedAttachments} onRemove=${removeAttachment} />
-          <div class="flex items-end gap-2">
-            <${AttachButton} disabled=${composerDisabled} onFiles=${(files: FileList | null) => { void addFiles(files) }} />
-            <div class="min-w-0 flex-1">
-              <${ChatComposer}
-                draft=${draft}
-                placeholder=${chatAccess.blocked
-                  ? '현재 actor는 direct keeper chat 권한이 없습니다'
-                  : sending
-                    ? '응답 중 — 지금 보내면 대기열에 추가됩니다'
-                    : placeholder}
-                disabled=${composerDisabled}
-                streaming=${sending}
-                streamStartedAt=${streamStartedAt}
-                lastEventAt=${lastSignalAt}
-                queueEnabled=${true}
-                queueCount=${queueCount}
-                onDraftChange=${setDraft}
-                onSend=${() => { void submit() }}
-                onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
-                layout="primary"
-              />
-            </div>
-          </div>
+          <${ChatComposer}
+            draft=${draft}
+            placeholder=${chatAccess.blocked
+              ? '현재 actor는 direct keeper chat 권한이 없습니다'
+              : sending
+                ? '응답 중 — 지금 보내면 대기열에 추가됩니다'
+                : placeholder}
+            disabled=${composerDisabled}
+            streaming=${sending}
+            streamStartedAt=${streamStartedAt}
+            lastEventAt=${lastSignalAt}
+            queueEnabled=${true}
+            queueCount=${queueCount}
+            onDraftChange=${setDraft}
+            onSend=${(payload: { blocks: ChatBlock[] }) => { void submit(payload) }}
+            onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
+            layout="primary"
+          />
         </div>
 
         ${error ? html`<div class="shrink-0 text-xs text-[var(--bad-light)] leading-relaxed v2-monitoring-panel">${error}</div>` : null}
@@ -780,7 +687,7 @@ export function KeeperConversationPanel({
   }
 
   return html`
-    <div class="flex flex-col gap-3 v2-monitoring-surface" onPaste=${handlePaste}>
+    <div class="flex flex-col gap-3 v2-monitoring-surface">
       <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)] v2-monitoring-panel">
         <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--color-border-default)] px-4 py-4 v2-monitoring-toolbar">
           <div class="min-w-55 flex-1">
@@ -865,29 +772,23 @@ export function KeeperConversationPanel({
                 </div>
               `
             : null}
-          <${AttachmentChips} attachments=${selectedAttachments} onRemove=${removeAttachment} />
-          <div class="flex items-end gap-2">
-            <${AttachButton} disabled=${composerDisabled} onFiles=${(files: FileList | null) => { void addFiles(files) }} />
-            <div class="min-w-0 flex-1">
-              <${ChatComposer}
-                draft=${draft}
-                placeholder=${chatAccess.blocked
-                  ? '현재 actor는 direct keeper chat 권한이 없습니다'
-                  : sending
-                    ? '응답 중 — 지금 보내면 대기열에 추가됩니다'
-                    : placeholder}
-                disabled=${composerDisabled}
-                streaming=${sending}
-                streamStartedAt=${streamStartedAt}
-                lastEventAt=${lastSignalAt}
-                queueEnabled=${true}
-                queueCount=${queueCount}
-                onDraftChange=${setDraft}
-                onSend=${() => { void submit() }}
-                onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
-              />
-            </div>
-          </div>
+          <${ChatComposer}
+            draft=${draft}
+            placeholder=${chatAccess.blocked
+              ? '현재 actor는 direct keeper chat 권한이 없습니다'
+              : sending
+                ? '응답 중 — 지금 보내면 대기열에 추가됩니다'
+                : placeholder}
+            disabled=${composerDisabled}
+            streaming=${sending}
+            streamStartedAt=${streamStartedAt}
+            lastEventAt=${lastSignalAt}
+            queueEnabled=${true}
+            queueCount=${queueCount}
+            onDraftChange=${setDraft}
+            onSend=${(payload: { blocks: ChatBlock[] }) => { void submit(payload) }}
+            onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
+          />
         </div>
       </div>
 

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -87,3 +87,410 @@
 @utility chat-detail-callout {
   background: linear-gradient(180deg, rgb(var(--color-accent-glow) / .10), var(--color-bg-surface));
 }
+
+/* ════ Keeper v2 multimodal composer ════ */
+
+.composer {
+  flex: none;
+  padding: var(--sp-3) var(--sp-4) var(--sp-4);
+  border-top: 1px solid var(--color-border-default);
+  background: linear-gradient(0deg, var(--color-bg-surface), var(--color-bg-page));
+}
+
+.composer.primary {
+  padding: 0;
+  border-top: 0;
+  background: transparent;
+}
+
+.composer-inner {
+  max-width: var(--kw-thread-w, 980px);
+  margin: 0 auto;
+  padding: 0 4px;
+}
+
+.composer-box {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  padding: 6px 6px 6px 14px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.composer-box.focus {
+  border-color: var(--color-accent-fg-dim);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
+}
+
+.composer-box.drag {
+  border-color: var(--color-accent-fg-dim);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
+  background: var(--color-accent-soft);
+}
+
+.composer textarea {
+  flex: 1;
+  resize: none;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--color-fg-primary);
+  font-size: var(--fs-sm, 14px);
+  line-height: 1.5;
+  padding: 9px 0;
+  max-height: 160px;
+  min-height: 24px;
+}
+
+.composer textarea::placeholder {
+  color: var(--color-fg-muted);
+}
+
+.composer-tools {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-bottom: 2px;
+}
+
+.ctool {
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--r-0);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-panel-alt);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  transition: 0.14s;
+  font-size: var(--fs-sm, 14px);
+}
+
+.ctool:hover {
+  color: var(--color-fg-primary);
+  border-color: var(--color-border-strong);
+}
+
+.ctool:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.send {
+  height: 34px;
+  padding: 0 16px;
+  border-radius: var(--r-0);
+  cursor: pointer;
+  background: var(--color-accent-fg);
+  color: var(--color-bg-surface);
+  border: 1px solid var(--color-accent-fg);
+  font-size: var(--fs-xs, 12px);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  transition: 0.14s;
+  white-space: nowrap;
+  flex: none;
+}
+
+.send:hover {
+  filter: brightness(1.08);
+  box-shadow: 0 0 18px var(--color-accent-soft);
+}
+
+.send:disabled {
+  opacity: 0.4;
+  cursor: default;
+  box-shadow: none;
+}
+
+.send.warn {
+  background: var(--color-status-err);
+  border-color: var(--color-status-err);
+}
+
+.composer-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 8px;
+  font-size: var(--fs-xs, 12px);
+  color: var(--color-fg-muted);
+}
+
+.composer-foot .hint {
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.composer-foot kbd {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs, 10px);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-bottom-width: 2px;
+  border-radius: var(--r-0);
+  padding: 1px 5px;
+  color: var(--color-fg-muted);
+}
+
+.composer-foot .queue-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  border: 1px solid var(--accent-20);
+  background: var(--accent-10);
+  padding: 2px 10px;
+  font-size: var(--fs-xs, 12px);
+  font-weight: 600;
+  color: var(--color-fg-secondary);
+}
+
+.composer-tray {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 9px;
+}
+
+.cdraft {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-0);
+  padding: 7px 9px;
+  position: relative;
+}
+
+.cdraft.att {
+  padding-right: 26px;
+  max-width: 280px;
+}
+
+.cdraft-thumb {
+  width: 34px;
+  height: 34px;
+  flex: none;
+  border-radius: var(--radius-2xs, 2px);
+  overflow: hidden;
+  background: var(--color-bg-panel-alt);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cdraft-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.cdraft-glyph {
+  color: var(--color-fg-muted);
+  font-size: 17px;
+}
+
+.cdraft-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.cdraft-name {
+  font-size: var(--fs-xs, 12px);
+  color: var(--color-fg-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 190px;
+}
+
+.cdraft-name.mono,
+.cdraft-sub.mono,
+.cdraft-dur.mono,
+.rec-clock.mono {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.cdraft-sub {
+  font-size: var(--fs-2xs, 10px);
+  color: var(--color-fg-muted);
+}
+
+.cdraft.voice {
+  padding-right: 26px;
+  gap: 8px;
+  flex-wrap: wrap;
+  max-width: 360px;
+}
+
+.cdraft-glyph.mic {
+  color: var(--color-accent-fg);
+  font-size: 14px;
+}
+
+.cdraft-wave {
+  display: flex;
+  align-items: center;
+  gap: 1.5px;
+  height: 22px;
+}
+
+.cdraft-wave .vbar {
+  width: 2px;
+  border-radius: 1px;
+  background: var(--color-accent-fg-dim);
+}
+
+.cdraft-dur {
+  font-size: var(--fs-xs, 12px);
+  color: var(--color-fg-secondary);
+}
+
+.cdraft-tx {
+  display: flex;
+  gap: 7px;
+  align-items: baseline;
+  flex-basis: 100%;
+  padding-top: 5px;
+  border-top: 1px solid var(--color-border-default);
+}
+
+.cdraft-tx-k {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: var(--fs-2xs, 10px);
+  color: var(--color-accent-fg);
+  flex: none;
+}
+
+.cdraft-tx-v {
+  font-size: var(--fs-xs, 12px);
+  color: var(--color-fg-secondary);
+  line-height: 1.45;
+}
+
+.cdraft-x {
+  position: absolute;
+  top: 5px;
+  right: 6px;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font-size: 10px;
+  border-radius: var(--radius-2xs, 2px);
+}
+
+.cdraft-x:hover {
+  color: var(--color-status-err);
+  background: var(--color-bg-panel-alt);
+}
+
+.rec-bar {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 4px 5px 10px;
+  min-height: 34px;
+}
+
+.rec-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--color-status-err);
+  flex: none;
+  animation: recpulse 1.1s ease-in-out infinite;
+}
+
+@keyframes recpulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.rec-lbl {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: var(--fs-2xs, 10px);
+  color: var(--color-status-err);
+}
+
+.rec-clock {
+  font-size: var(--fs-sm, 14px);
+  color: var(--color-fg-primary);
+}
+
+.rec-wave {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  height: 24px;
+  overflow: hidden;
+}
+
+.rec-wave .rbar {
+  width: 2.5px;
+  border-radius: 1px;
+  background: var(--color-accent-fg-dim);
+  flex: none;
+}
+
+.rec-btn {
+  height: 30px;
+  padding: 0 12px;
+  border-radius: var(--r-0);
+  cursor: pointer;
+  font-size: var(--fs-xs, 12px);
+  transition: 0.14s;
+  flex: none;
+}
+
+.rec-btn.cancel {
+  background: transparent;
+  border: 1px solid var(--color-border-default);
+  color: var(--color-fg-muted);
+}
+
+.rec-btn.cancel:hover {
+  color: var(--color-fg-primary);
+  border-color: var(--color-border-strong);
+}
+
+.rec-btn.stop {
+  background: var(--color-accent-fg);
+  border: 1px solid var(--color-accent-fg);
+  color: var(--color-bg-surface);
+}
+
+.rec-btn.stop:hover {
+  filter: brightness(1.08);
+  box-shadow: 0 0 16px var(--color-accent-soft);
+}
+
+.chat-block-attach-img {
+  width: 100%;
+  max-height: 220px;
+  object-fit: cover;
+  object-position: center 30%;
+  display: block;
+}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -731,6 +731,8 @@ export interface KeeperConversationAttachment {
   size: number
   mimeType: string
   data: string
+  /** Optional image dimensions (e.g. "1920×1080") computed for composer blocks. */
+  dims?: string
 }
 
 // RFC-0235 P1: synthesized voice clip attached to an assistant chat row.
@@ -767,7 +769,22 @@ export type ChatShellBlock = { t: 'shell'; title?: string; lines: ChatShellLine[
 
 export type ChatArtifactBlock = { t: 'artifact'; kind?: string; name: string; size?: string; note?: string }
 
-export type ChatAttachBlock = { t: 'attach'; name: string; dims?: string; svg?: string; ph?: string; via?: string; size?: string }
+export type ChatAttachBlock = {
+  t: 'attach'
+  name: string
+  dims?: string
+  src?: string
+  svg?: string
+  ph?: string
+  via?: string
+  size?: string
+  /** Optional source data carried so the parent can forward attachments to the API. */
+  data?: string
+  mimeType?: string
+  sizeBytes?: number
+  id?: string
+  kind?: string
+}
 
 export type ChatVoiceBlock = { t: 'voice'; secs?: number; wave?: number[]; via?: string; size?: string; transcript?: string }
 


### PR DESCRIPTION
## Summary
Ports the keeper-v2 v2-f multimodal chat composer into the MASC dashboard.

## What changed
- `dashboard/src/components/chat/primitives.ts`:
  - `ChatComposer` rewritten with attachment state, file input, drag-and-drop, voice recording UI/record bar
  - Emits `onSend({ blocks })` with ordered blocks: attachments → voice → text paragraph
- `dashboard/src/components/chat/attachments.ts`: `collectAttachments` now computes image `dims`.
- `dashboard/src/components/keeper-shared.ts`: `KeeperConversationPanel` consumes `{ blocks }` and maps attach blocks back to the existing `KeeperConversationAttachment[]` API.
- `dashboard/src/types/core.ts`: extended `ChatAttachBlock` and added optional `dims` to `KeeperConversationAttachment`.
- `dashboard/src/styles/chat.css`: full v2 composer stylesheet.
- Tests updated/added for attachments, drag/drop, voice recording, block composition, and a11y.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `chat/primitives.test.ts` ✅ 44/44
- `chat/primitives.a11y.test.ts` ✅ 5/5
- `chat/attachments.test.ts` ✅ 6/6
- `keeper-shared.test.ts` ✅ 10/10
- `keeper-workspace-chat.test.ts` ✅ 2/2

## Notes
- Keyboard behavior preserved (Enter sends, Shift+Enter newline, IME guard).
- No backend API change; blocks are mapped to the existing attachment structure.
