### PR TITLE
fix(dashboard): keeper detail thread scroll height regression

### DIFF
--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -137,7 +137,7 @@
 @keyframes kw-dot-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
 
 /* ════ CONVERSATION (center) ════════════════════════════════════ */
-.kw-chat { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--color-bg-page); }
+.kw-chat { display: flex; flex-direction: column; min-width: 0; min-height: 0; height: 100%; background: var(--color-bg-page); }
 
 /* Single-row header (identity + status + actions). Slimmer than the old
  * two-row variant — the runtime/model/throughput sub-row moved to the rail —
@@ -177,11 +177,12 @@
  * Provide the spacious rhythm + centered max-width column here. */
 .kw-thread {
   flex: 1; min-height: 0; display: flex; flex-direction: column;
+  overflow: hidden;
   padding: 0;
 }
 .kw-thread-inner {
   width: 100%; max-width: var(--kw-thread-w, 980px); margin: 0 auto;
-  flex: 1; min-height: 0; display: flex; flex-direction: column;
+  height: 100%; min-height: 0; display: flex; flex-direction: column;
 }
 /* Overrides for the reused ChatTranscript (chat/primitives.ts).
  * Two-class specificity beats its single-class Tailwind gap/padding.

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -22,6 +22,15 @@
  */
 
 /* ── Shell grid: roster | conversation | context rail ───────────── */
+
+/* The workspace is rendered inside .v2-surface, which is otherwise
+ * height:auto. In keeper detail mode the outer scroll container is hidden,
+ * so .v2-surface must fill the stage for .kw-grid height:100% to resolve
+ * to the viewport and give the thread a constrained scroll box. */
+[data-keeper-detail-mode="true"] .v2-surface {
+  height: 100%;
+}
+
 .kw-grid {
   display: grid;
   grid-template-columns:


### PR DESCRIPTION
Follow-up to #21416.

The conversation thread in keeper detail mode still does not scroll because `.v2-surface` resolves to `height: auto`, so `.kw-grid`/`height: 100%` collapses to content height and `.kw-thread` never gets a constrained scrollport.

Changes:
- Give `.kw-chat`, `.kw-thread`, and `.kw-thread-inner` explicit `height: 100%`.
- Scope `.v2-surface { height: 100%; }` to `[data-keeper-detail-mode="true"]` so the grid has a real viewport height to fill.

Test plan:
- `cd dashboard && npx tsc --noEmit --pretty`
- `npm run build`
- `npx vitest run src/app.test.ts`,timeout:120}