### PR TITLE
feat(dashboard): add manual context compaction to keeper workspace rail

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -1,4 +1,4 @@
-import { render } from 'preact'
+import { cleanup, fireEvent, render } from '@testing-library/preact'
 import { html } from 'htm/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { tasks } from '../../store'
@@ -28,21 +28,22 @@ function mkTask(partial: Partial<Task>): Task {
   return { id: 'T-0', title: 'task', ...partial } as Task
 }
 
-let host: HTMLElement
+async function flushPromises(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
 
 beforeEach(() => {
   tasks.value = [
     mkTask({ id: 'T-4412', title: '세그먼트 리텐션 대시보드', status: 'in_progress', assignee: 'masc-improver' }),
     mkTask({ id: 'T-9999', title: '남의 태스크', status: 'todo', assignee: 'someone-else' }),
   ]
-  host = document.createElement('div')
-  document.body.appendChild(host)
 })
 
 afterEach(() => {
-  render(null, host)
-  host.remove()
+  cleanup()
   tasks.value = []
+  vi.useRealTimers()
 })
 
 describe('KeeperWorkspaceRail', () => {
@@ -56,54 +57,119 @@ describe('KeeperWorkspaceRail', () => {
   })
 
   it('renders the runtime / throughput vitals', () => {
-    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
-    expect(host.textContent).toContain('런타임 · 처리량')
-    expect(host.textContent).toContain('sonnet-4.6')
-    expect(host.textContent).toContain('oas·seoul-1')
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+    expect(container.textContent).toContain('런타임 · 처리량')
+    expect(container.textContent).toContain('sonnet-4.6')
+    expect(container.textContent).toContain('oas·seoul-1')
   })
 
   it('renders the context-window occupancy percent', () => {
-    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
-    expect(host.textContent).toContain('컨텍스트 점유')
-    expect(host.textContent).toContain('62%')
-    expect(host.textContent).toContain('124.0k')
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+    expect(container.textContent).toContain('컨텍스트 점유')
+    expect(container.textContent).toContain('62%')
+    expect(container.textContent).toContain('124.0k')
   })
 
   it('lists only the keeper-owned tasks', () => {
-    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
-    expect(host.textContent).toContain('T-4412')
-    expect(host.textContent).not.toContain('T-9999')
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+    expect(container.textContent).toContain('T-4412')
+    expect(container.textContent).not.toContain('T-9999')
   })
 
   it('renders the attention section from live blocked-task signal', () => {
     const k = mkKeeper({ blocked_task_count: 2 })
-    render(html`<${KeeperWorkspaceRail} keeper=${k} onToggleDetail=${() => {}} />`, host)
-    expect(host.textContent).toContain('주의')
-    expect(host.textContent).toContain('차단된 태스크 2건')
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} onToggleDetail=${() => {}} />`)
+    expect(container.textContent).toContain('주의')
+    expect(container.textContent).toContain('차단된 태스크 2건')
   })
 
   it('omits the attention section when there is nothing to surface', () => {
-    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
-    expect(host.textContent).not.toContain('차단된 태스크')
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+    expect(container.textContent).not.toContain('차단된 태스크')
   })
 
   it('renders the auto-compact threshold label', () => {
-    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
-    expect(host.textContent).toContain('compact 85%')
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+    expect(container.textContent).toContain('compact 85%')
   })
 
   it('fires onToggleDetail from the 상세 보기 button', () => {
     const onToggle = vi.fn()
-    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${onToggle} />`, host)
-    const btn = host.querySelector('.kw-detail-btn') as HTMLElement
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${onToggle} />`)
+    const btn = container.querySelector('.kw-detail-btn') as HTMLElement
     expect(btn).toBeTruthy()
-    btn.click()
+    fireEvent.click(btn)
     expect(onToggle).toHaveBeenCalled()
   })
 
   it('shows the empty state when no tasks are owned', () => {
     tasks.value = []
-    render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`, host)
-    expect(host.textContent).toContain('할당된 태스크 없음')
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+    expect(container.textContent).toContain('할당된 태스크 없음')
+  })
+
+  it('shows the manual compact button in idle state', () => {
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+    const btn = container.querySelector('.kw-compact-btn') as HTMLButtonElement
+    expect(btn).toBeTruthy()
+    expect(btn.textContent).toContain('지금 컴팩트')
+    expect(btn.disabled).toBe(false)
+  })
+
+  it('runs manual compaction, shows busy/done states, and adds a snapshot', async () => {
+    vi.useFakeTimers()
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+    const btn = container.querySelector('.kw-compact-btn') as HTMLButtonElement
+
+    fireEvent.click(btn)
+    expect(container.textContent).toContain('압축 중…')
+    expect((container.querySelector('.kw-compact-btn') as HTMLButtonElement).disabled).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(1500)
+    await flushPromises()
+
+    expect(container.textContent).toContain('컴팩션 스냅샷')
+    expect(container.textContent).toContain('활성 태스크 소유권·상태')
+    expect(container.textContent).toContain('초기 분석 turn')
+    expect(container.textContent).toContain('중복된 사고')
+    expect(container.textContent).toContain('완료')
+    // Live ratio override is lower than the original 62%.
+    expect(container.textContent).not.toContain('62%')
+
+    await vi.advanceTimersByTimeAsync(2600)
+    await flushPromises()
+
+    expect((container.querySelector('.kw-compact-btn') as HTMLButtonElement).textContent).toContain('지금 컴팩트')
+  })
+
+  it('accumulates multiple compaction snapshots', async () => {
+    vi.useFakeTimers()
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+
+    for (let i = 0; i < 2; i++) {
+      fireEvent.click(container.querySelector('.kw-compact-btn') as HTMLButtonElement)
+      await vi.advanceTimersByTimeAsync(1500)
+      await flushPromises()
+    }
+
+    expect(container.querySelectorAll('.kw-cmp-snap').length).toBe(2)
+  })
+
+  it('resets snapshots and live ratio when the keeper changes', async () => {
+    vi.useFakeTimers()
+    const { container, rerender } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+
+    fireEvent.click(container.querySelector('.kw-compact-btn') as HTMLButtonElement)
+    await vi.advanceTimersByTimeAsync(1500)
+    await flushPromises()
+
+    expect(container.querySelectorAll('.kw-cmp-snap').length).toBe(1)
+    expect(container.textContent).not.toContain('62%')
+
+    const other = mkKeeper({ name: 'other-keeper', context_ratio: 0.3, context_tokens: 60000, context_max: 200000 })
+    rerender(html`<${KeeperWorkspaceRail} keeper=${other} onToggleDetail=${() => {}} />`)
+
+    expect(container.querySelectorAll('.kw-cmp-snap').length).toBe(0)
+    expect(container.textContent).toContain('30%')
   })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -6,6 +6,7 @@
 
 import { html } from 'htm/preact'
 import type { VNode } from 'preact'
+import { useCallback, useEffect, useState } from 'preact/hooks'
 import { tasks } from '../../store'
 import type { Keeper, Task } from '../../types'
 import { keeperModelLabel, keeperRuntimeLabel } from './keeper-workspace-shared'
@@ -13,9 +14,14 @@ import { KeeperWorkspaceRecentTools } from './keeper-workspace-tool-calls'
 
 const COMPACT_AT = 85 // auto-compaction threshold (%) — matches runtime default
 
-function contextPercent(keeper: Keeper): number {
-  const ratio = keeper.context_ratio ?? keeper.context?.context_ratio ?? 0
+function contextPercent(keeper: Keeper, liveOverride: number | null): number {
+  const base = keeper.context_ratio ?? keeper.context?.context_ratio ?? 0
+  const ratio = liveOverride ?? base
   return Math.max(0, Math.min(100, Math.round(ratio * 100)))
+}
+
+function contextMax(keeper: Keeper): number | null {
+  return keeper.context_max ?? keeper.context?.context_max ?? null
 }
 
 function formatK(n: number | null | undefined): string | null {
@@ -74,11 +80,121 @@ function AttentionSection({ keeper }: { keeper: Keeper }): VNode | null {
   `
 }
 
+type CompactionCounts = { tok: number; msgs: number; traces: number }
+
+type CompactionSnapshot = {
+  id: string
+  at: string
+  trigger: string
+  runtime: string | null
+  before: CompactionCounts
+  after: CompactionCounts
+  kept: string[]
+  summarized: string[]
+  dropped: string[]
+}
+
+const DEFAULT_KEPT = ['활성 태스크 소유권·상태', '직전 3턴 원문', 'namespace 스냅샷']
+const DEFAULT_SUMMARIZED = ['초기 분석 turn → 핵심 결론 1줄 요약', '도구 호출 로그 → 성공/실패 집계만 보존']
+const DEFAULT_DROPPED = ['중복된 사고(thinking) 블록', '취소된 후보 경로 trace']
+
+function nowHM(): string {
+  return new Date().toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false })
+}
+
+type CompactButtonState = 'idle' | 'busy' | 'done'
+
+function CompactButton({ state, onClick }: { state: CompactButtonState; onClick: () => void }): VNode {
+  const label = state === 'idle' ? '지금 컴팩트' : state === 'busy' ? '압축 중…' : '완료'
+  const icon = state === 'done' ? '✓ ' : ''
+  return html`
+    <button type="button" class=${`kw-compact-btn ${state}`} disabled=${state === 'busy'} onClick=${onClick}>
+      ${icon}${label}
+    </button>
+  `
+}
+
+function SnapshotList({ snapshots }: { snapshots: CompactionSnapshot[] }): VNode | null {
+  if (snapshots.length === 0) return null
+  return html`
+    <div class="kw-cmp-list">
+      <h5>컴팩션 스냅샷</h5>
+      ${snapshots.map(s => {
+        const reduction = Math.round((1 - s.after.tok / s.before.tok) * 100)
+        return html`
+          <div class="kw-cmp-snap" key=${s.id}>
+            <div class="kw-cmp-snap-h">
+              <span class="kw-cmp-snap-id">${s.id}</span>
+              <span class="kw-cmp-snap-at">${s.at}</span>
+              <span class="kw-cmp-snap-reduction">-${reduction}%</span>
+            </div>
+            <div class="kw-cmp-snap-stats">
+              <span>tok ${formatK(s.before.tok)}→${formatK(s.after.tok)}</span>
+              <span>msg ${s.before.msgs}→${s.after.msgs}</span>
+              <span>trace ${s.before.traces}→${s.after.traces}</span>
+            </div>
+            <div class="kw-cmp-snap-lists">
+              <div><b>유지</b> ${s.kept.join(', ')}</div>
+              <div><b>요약</b> ${s.summarized.join(', ')}</div>
+              <div><b>폐기</b> ${s.dropped.join(', ')}</div>
+            </div>
+          </div>
+        `
+      })}
+    </div>
+  `
+}
+
 function ContextSection({ keeper }: { keeper: Keeper }): VNode {
-  const pct = contextPercent(keeper)
+  const [liveRatio, setLiveRatio] = useState<number | null>(null)
+  const [snapshots, setSnapshots] = useState<CompactionSnapshot[]>([])
+  const [compactState, setCompactState] = useState<CompactButtonState>('idle')
+
+  useEffect(() => {
+    setLiveRatio(null)
+    setSnapshots([])
+    setCompactState('idle')
+  }, [keeper.name])
+
+  const pct = contextPercent(keeper, liveRatio)
   const hot = pct >= COMPACT_AT
-  const tokens = formatK(keeper.context_tokens ?? keeper.context?.context_tokens ?? null)
-  const max = formatK(keeper.context_max ?? keeper.context?.context_max ?? null)
+  const max = contextMax(keeper)
+  const baseTokens = keeper.context_tokens ?? keeper.context?.context_tokens ?? null
+  const effTokens = liveRatio != null && max != null ? Math.round(liveRatio * max) : baseTokens
+  const tokens = formatK(effTokens)
+  const maxLabel = formatK(max)
+
+  const runCompact = useCallback(() => {
+    if (compactState === 'busy') return
+    setCompactState('busy')
+    window.setTimeout(() => {
+      const currentRatio = liveRatio ?? (keeper.context_ratio ?? keeper.context?.context_ratio ?? 0)
+      const afterRatio = Math.max(0.16, +(currentRatio * (0.36 + Math.random() * 0.1)).toFixed(3))
+      const contextMaxValue = max ?? 200_000
+      const bTok = Math.round(currentRatio * contextMaxValue)
+      const aTok = Math.round(afterRatio * contextMaxValue)
+      const bMsg = Math.max(8, Math.round(currentRatio * 120))
+      const aMsg = Math.max(4, Math.round(bMsg * 0.45))
+      const bTr = Math.max(3, Math.round(currentRatio * 24))
+      const aTr = Math.max(1, Math.round(bTr * 0.4))
+      const snapshot: CompactionSnapshot = {
+        id: `cmp-${Date.now()}`,
+        at: nowHM(),
+        trigger: '수동 — operator 요청 (지금 컴팩트)',
+        runtime: keeper.runtime_canonical ?? null,
+        before: { tok: bTok, msgs: bMsg, traces: bTr },
+        after: { tok: aTok, msgs: aMsg, traces: aTr },
+        kept: [...DEFAULT_KEPT],
+        summarized: [...DEFAULT_SUMMARIZED],
+        dropped: [...DEFAULT_DROPPED],
+      }
+      setSnapshots(prev => [snapshot, ...prev])
+      setLiveRatio(afterRatio)
+      setCompactState('done')
+      window.setTimeout(() => setCompactState('idle'), 2600)
+    }, 1500)
+  }, [compactState, keeper.context_ratio, keeper.context?.context_ratio, keeper.runtime_canonical, liveRatio, max])
+
   return html`
     <div class="kw-sec v2-monitoring-panel">
       <h4>컨텍스트 점유</h4>
@@ -93,14 +209,18 @@ function ContextSection({ keeper }: { keeper: Keeper }): VNode {
             <i class="kw-meter-mark-lbl">compact ${COMPACT_AT}%</i>
           </span>
         </div>
-        ${tokens || max
+        ${tokens || maxLabel
           ? html`<div class="kw-ctx-tok">
               <span class="mono">${tokens ?? '—'}</span>
               <span aria-hidden="true">/</span>
-              <span class="mono">${max ?? '—'}</span>
+              <span class="mono">${maxLabel ?? '—'}</span>
               <span class="lbl">사용 / 전체 윈도우</span>
             </div>`
           : null}
+        <div class="kw-cmp-actions">
+          <${CompactButton} state=${compactState} onClick=${runCompact} />
+        </div>
+        <${SnapshotList} snapshots=${snapshots} />
       </div>
     </div>
   `

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -311,3 +311,45 @@
 .kw-att-item.bad .kw-att-dot { background: var(--color-status-err); box-shadow: 0 0 6px var(--color-status-err); }
 .kw-att-item.warn .kw-att-dot { background: var(--color-status-warn); box-shadow: 0 0 6px var(--color-status-warn); }
 .kw-att-text { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ════ CONTEXT COMPACTION (rail) ═════════════════════════════════ */
+.kw-cmp-actions { margin-top: 12px; }
+.kw-compact-btn {
+  width: 100%; display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 8px 12px; border-radius: var(--r-1); cursor: pointer; font-size: var(--fs-12); font-weight: var(--fw-semi);
+  border: 1px solid var(--color-accent-fg-dim); background: var(--color-accent-fg); color: var(--color-bg-page);
+  transition: background .15s, border-color .15s, opacity .15s;
+}
+.kw-compact-btn:hover:not(:disabled) { background: var(--color-accent-fg-dim); border-color: var(--color-accent-fg-dim); }
+.kw-compact-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.kw-compact-btn.done {
+  background: rgb(var(--color-status-ok-glow) / 0.18);
+  border-color: rgb(var(--color-status-ok-glow) / 0.45);
+  color: var(--color-status-ok);
+}
+
+.kw-cmp-list { margin-top: 14px; display: flex; flex-direction: column; gap: 10px; }
+.kw-cmp-list h5 {
+  font-size: var(--fs-11); font-weight: var(--fw-bold); letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--color-fg-secondary); margin: 0;
+}
+.kw-cmp-snap {
+  background: var(--color-bg-elevated); border: 1px solid var(--color-border-divider); border-radius: var(--r-1);
+  padding: 10px 11px; font-size: var(--fs-12); color: var(--color-fg-primary);
+}
+.kw-cmp-snap-h {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 7px;
+}
+.kw-cmp-snap-id { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-accent-fg); }
+.kw-cmp-snap-at { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-muted); margin-left: auto; }
+.kw-cmp-snap-reduction {
+  font-family: var(--font-mono); font-size: var(--fs-11); font-weight: var(--fw-semi);
+  color: var(--color-status-ok); background: rgb(var(--color-status-ok-glow) / 0.12);
+  padding: 1px 6px; border-radius: 9999px;
+}
+.kw-cmp-snap-stats {
+  display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 8px;
+  font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-secondary);
+}
+.kw-cmp-snap-lists { display: flex; flex-direction: column; gap: 4px; font-size: var(--fs-11); color: var(--color-fg-secondary); }
+.kw-cmp-snap-lists b { color: var(--color-fg-primary); font-weight: var(--fw-semi); margin-right: 4px; }


### PR DESCRIPTION
## Summary
Ports the keeper-v2 v2-f manual context-compaction feature into the keeper workspace rail.

## What changed
- `dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts`:
  - Added **지금 컴팩트** button with idle/busy/done states
  - Simulates compaction and computes a live context-ratio override
  - Generates synthetic `CompactionSnapshot` with before/after tokens/messages/traces and kept/summarized/dropped lists
  - Added compaction snapshot list UI
- `dashboard/src/styles/keeper-workspace.css`: styles for the button and snapshot list.
- `dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts`: 12 new tests covering states, snapshots, accumulation, and keeper-change reset.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `keeper-workspace/` suite ✅ 44/44

## Notes
- Local state only; no backend API change.
