### PR TITLE
fix(dashboard): keeper chat UX follow-up

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3,7 +3,7 @@ import type { ComponentChildren, VNode } from 'preact'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { JsonViewerCard } from '../common/json-viewer'
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { ringFocusClasses } from '../common/ring'
 import { collectAttachments } from './attachments'
 import { showToast } from '../common/toast'
@@ -236,7 +236,7 @@ function overviewRows(details: KeeperConversationDetails): Array<{ label: string
   ].filter((row): row is { label: string; value: string } => Boolean(row))
 }
 
-function formatAttachmentSize(bytes: number): string {
+export function formatAttachmentSize(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
   if (bytes < 1024) return `${Math.round(bytes)} B`
   if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
@@ -834,7 +834,7 @@ function ChatMessageBubble({
 
   return html`
     <article
-      class=${`chat-bubble ${tone} flex w-full flex-col border backdrop-blur-sm ${
+      class=${`chat-bubble ${tone} flex w-full flex-col backdrop-blur-sm ${
         isMessenger
           ? 'max-w-[82%] gap-2.5 rounded-[var(--radius-xl)] px-4 py-3.5'
           : 'max-w-[90%] gap-3 rounded-[var(--r-5)] px-4 py-3'
@@ -844,7 +844,7 @@ function ChatMessageBubble({
       <div class=${`flex justify-between gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
         <div class=${`flex min-w-0 flex-1 gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
           <div
-            class=${`chat-avatar ${tone} flex shrink-0 items-center justify-center border text-xs font-bold uppercase tracking-[var(--track-caps)] ${
+            class=${`chat-avatar ${tone} flex shrink-0 items-center justify-center whitespace-nowrap text-xs font-bold uppercase tracking-[var(--track-caps)] ${
               isMessenger ? 'size-8 rounded-card' : 'size-10 rounded-[var(--r-1)]'
             }`}
           >
@@ -899,7 +899,7 @@ function ChatMessageBubble({
               : html`
                   <div class="flex flex-wrap items-center gap-1.5">
                     <span
-                      class=${`chat-role-chip ${tone} inline-flex items-center rounded-[var(--r-0)] border px-2.5 py-1 text-2xs font-bold uppercase tracking-2`}
+                      class=${`chat-role-chip ${tone} inline-flex items-center rounded-[var(--r-0)] px-2.5 py-1 text-2xs font-bold uppercase tracking-2`}
                     >
                       ${entry.label}
                     </span>
@@ -1268,11 +1268,13 @@ export function ChatTranscript({
     if (pinned) setUnread(false)
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = scrollerRef.current
     if (!el) return
     if (pinnedRef.current) {
-      el.scrollTop = el.scrollHeight
+      const snap = () => { el.scrollTop = el.scrollHeight }
+      snap()
+      requestAnimationFrame(snap)
     } else {
       setUnread(true)
     }
@@ -1351,7 +1353,7 @@ function randomWave(n: number): number[] {
   return Array.from({ length: n }, () => 0.22 + Math.random() * 0.74)
 }
 
-function AttachDraftChip({
+export function AttachDraftChip({
   attachment,
   onRemove,
 }: {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -39,8 +39,12 @@ import {
   markInputSent,
   clearInputQueue,
   getQueueLength,
+  getQueuedMessages,
+  updateQueuedMessage,
+  removeQueuedMessage,
+  type QueuedMessage,
 } from '../keeper-chat-store'
-import { ChatComposer, ChatTranscript, STREAM_STALL_THRESHOLD_S } from './chat/primitives'
+import { AttachDraftChip, ChatComposer, ChatTranscript, STREAM_STALL_THRESHOLD_S, formatAttachmentSize } from './chat/primitives'
 import { showToast } from './common/toast'
 import { TextInput } from './common/input'
 import { shellAuthSummary } from '../store'
@@ -324,6 +328,91 @@ export function KeeperDiagnosticSummary({
   `
 }
 
+// ── Queued message editor (rendered inside the conversation panel) ──
+
+interface QueueItemCardProps {
+  keeperName: string
+  msg: QueuedMessage
+  onMutate: () => void
+}
+
+function QueueItemCard({ keeperName, msg, onMutate }: QueueItemCardProps) {
+  const [editing, setEditing] = useState(false)
+  const [text, setText] = useState(msg.content)
+  const [attachments, setAttachments] = useState(msg.attachments ?? [])
+
+  const save = () => {
+    updateQueuedMessage(keeperName, msg.id, {
+      content: text.trim(),
+      attachments: attachments.length > 0 ? attachments : undefined,
+    })
+    setEditing(false)
+    onMutate()
+  }
+
+  const cancel = () => {
+    setText(msg.content)
+    setAttachments(msg.attachments ?? [])
+    setEditing(false)
+  }
+
+  const removeAttachment = (id: string) => {
+    setAttachments(prev => prev.filter(a => a.id !== id))
+  }
+
+  return html`
+    <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2.5" data-chat-queue-item=${msg.id}>
+      ${editing
+        ? html`
+            <textarea
+              class="w-full min-h-[3.5rem] rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2.5 py-2 text-sm leading-relaxed text-[var(--color-fg-primary)] outline-none focus:border-[var(--color-accent-fg-dim)]"
+              value=${text}
+              onInput=${(e: Event) => { setText((e.target as HTMLTextAreaElement).value) }}
+            />
+            ${attachments.length > 0
+              ? html`
+                  <div class="mt-2 flex flex-wrap gap-2">
+                    ${attachments.map(att => html`
+                      <${AttachDraftChip}
+                        key=${att.id}
+                        attachment=${att}
+                        onRemove=${() => { removeAttachment(att.id) }}
+                      />
+                    `)}
+                  </div>
+                `
+              : null}
+            <div class="mt-2 flex items-center justify-end gap-2">
+              <button type="button" class="text-2xs text-[var(--color-fg-secondary)] hover:text-[var(--color-fg-primary)]" onClick=${cancel}>취소</button>
+              <button type="button" class="rounded-[var(--r-0)] bg-[var(--color-accent-fg)] px-2.5 py-1 text-2xs font-semibold text-[var(--color-bg-page)]" onClick=${save}>저장</button>
+            </div>
+          `
+        : html`
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0 flex-1">
+                <div class="text-sm text-[var(--color-fg-primary)] whitespace-pre-wrap break-words">${msg.content}</div>
+                ${attachments.length > 0
+                  ? html`<div class="mt-1.5 flex flex-wrap gap-1.5">
+                      ${attachments.map(att => html`
+                        <span class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-1.5 py-0.5 text-2xs text-[var(--color-fg-secondary)]">
+                          <span>${att.type === 'image' ? '▣' : '◫'}</span>
+                          <span class="truncate max-w-[12rem]">${att.name}</span>
+                          <span class="tabular-nums">${formatAttachmentSize(att.size)}</span>
+                        </span>
+                      `)}
+                    </div>`
+                  : null}
+              </div>
+              <div class="flex items-center gap-1.5 flex-none">
+                <button type="button" class="text-2xs text-[var(--color-fg-secondary)] hover:text-[var(--color-fg-primary)]" onClick=${() => { setEditing(true) }}>수정</button>
+                <button type="button" class="text-2xs text-[var(--color-status-err)] hover:text-[var(--color-status-err)]" onClick=${() => { removeQueuedMessage(keeperName, msg.id); onMutate() }}>삭제</button>
+              </div>
+            </div>
+          `}
+    </div>
+  `
+}
+
 // ── Conversation Panel ───────────────────────────────────
 
 export function KeeperConversationPanel({
@@ -411,22 +500,23 @@ export function KeeperConversationPanel({
   }
 
   const drainQueue = async () => {
-    for (;;) {
-      const next = dequeueInput(keeperName)
-      if (!next) break
-      bumpQueue()
-      try {
-        await sendKeeperThreadMessage(keeperName, next.content, { attachments: next.attachments })
-      } catch (err) {
-        markInputSent(keeperName)
-        bumpQueue()
-        if (isAbortError(err)) return
-        const message = err instanceof Error ? err.message : `${keeperName} 메시지 전송 실패`
-        showToast(message, 'error')
-        return
-      }
-      markInputSent(keeperName)
-      bumpQueue()
+    const queued = getQueuedMessages(keeperName)
+    if (queued.length === 0) return
+    clearInputQueue(keeperName)
+    bumpQueue()
+
+    const batchedContent = queued.map(q => q.content.trim()).filter(Boolean).join('\n\n---\n\n')
+    const batchedAttachments = queued.flatMap(q => q.attachments ?? [])
+    if (!batchedContent && batchedAttachments.length === 0) return
+
+    try {
+      await sendKeeperThreadMessage(keeperName, batchedContent, {
+        attachments: batchedAttachments.length > 0 ? batchedAttachments : undefined,
+      })
+    } catch (err) {
+      if (isAbortError(err)) return
+      const message = err instanceof Error ? err.message : `${keeperName} 메시지 전송 실패`
+      showToast(message, 'error')
     }
   }
 
@@ -542,9 +632,19 @@ export function KeeperConversationPanel({
           <div class="kw-composer-inner v2-monitoring-panel">
             ${queueCount > 0
               ? html`
-                  <div class="mb-2 flex items-center gap-2 text-2xs text-[var(--color-fg-muted)] v2-monitoring-row" data-chat-queue-row>
-                    <span>${queueCount}개 메시지 대기 중</span>
-                    <button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>모두 취소</button>
+                  <div class="mb-3 flex flex-col gap-2" data-chat-queue-list>
+                    <div class="flex items-center justify-between gap-2 text-2xs text-[var(--color-fg-muted)] v2-monitoring-row" data-chat-queue-row>
+                      <span>${queueCount}개 메시지 대기 중</span>
+                      <button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>모두 취소</button>
+                    </div>
+                    ${getQueuedMessages(keeperName).map(msg => html`
+                      <${QueueItemCard}
+                        key=${msg.id}
+                        keeperName=${keeperName}
+                        msg=${msg}
+                        onMutate=${bumpQueue}
+                      />
+                    `)}
                   </div>
                 `
               : null}

--- a/dashboard/src/keeper-chat-store.ts
+++ b/dashboard/src/keeper-chat-store.ts
@@ -53,6 +53,36 @@ export function enqueueInput(
   return msg
 }
 
+/** Return all queued items for a keeper (newest last). */
+export function getQueuedMessages(keeperName: string): QueuedMessage[] {
+  const q = _queues.get(keeperName)
+  return q ? q.items.slice() : []
+}
+
+/** Update the content/attachments of a queued message. */
+export function updateQueuedMessage(
+  keeperName: string,
+  id: string,
+  updates: Partial<Pick<QueuedMessage, 'content' | 'attachments'>>,
+): QueuedMessage | null {
+  const q = _queues.get(keeperName)
+  if (!q) return null
+  const item = q.items.find(i => i.id === id)
+  if (!item) return null
+  if (typeof updates.content === 'string') item.content = updates.content
+  if (updates.attachments) item.attachments = updates.attachments
+  return item
+}
+
+/** Remove a specific queued message. */
+export function removeQueuedMessage(keeperName: string, id: string): boolean {
+  const q = _queues.get(keeperName)
+  if (!q) return false
+  const before = q.items.length
+  q.items = q.items.filter(i => i.id !== id)
+  return q.items.length < before
+}
+
 /** Pop the front queued message. Returns null if empty or already sending. */
 export function dequeueInput(keeperName: string): QueuedMessage | null {
   const q = _queues.get(keeperName)

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -13,20 +13,24 @@
 }
 
 @utility chat-bubble {
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--color-border-default);
   box-shadow: var(--elev-4-shadow);
   &.user {
     align-self: flex-end;
     background: linear-gradient(180deg, rgb(var(--color-accent-glow) / .12), var(--color-bg-elevated));
-    border-color: var(--color-border-strong);
+    border-color: var(--color-accent-fg-dim);
   }
   &.assistant {
     align-self: flex-start;
     background: linear-gradient(180deg, rgb(var(--color-accent-glow) / .08), var(--color-bg-panel-alt));
-    border-color: var(--color-status-info);
+    border-color: var(--color-accent-fg-dim);
   }
   &.system,
   &.error {
     align-self: flex-start;
+    border-color: var(--color-border-default);
   }
   &.error {
     border-color: var(--color-status-err);
@@ -35,13 +39,16 @@
 }
 
 @utility chat-avatar {
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--color-border-default);
   &.user {
     border-color: var(--color-accent-fg-dim);
     background: var(--color-accent-soft);
     color: var(--chat-user-avatar);
   }
   &.assistant {
-    border-color: var(--color-status-info);
+    border-color: var(--color-accent-fg-dim);
     background: rgb(var(--color-accent-glow) / .18);
     color: var(--chat-assistant-avatar);
   }
@@ -53,13 +60,16 @@
 }
 
 @utility chat-role-chip {
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--color-border-default);
   &.user {
     border-color: var(--color-accent-fg-dim);
     color: var(--chat-user-chip);
     background: rgb(var(--color-accent-glow) / .14);
   }
   &.assistant {
-    border-color: var(--color-status-info);
+    border-color: var(--color-accent-fg-dim);
     color: var(--chat-assistant-chip);
     background: rgb(var(--color-accent-glow) / .10);
   }


### PR DESCRIPTION
Follow-up to #21419.

Fixes several keeper chat UX issues reported after the scroll height regression was resolved:

1. **Auto-scroll on send** — `ChatTranscript` now uses `useLayoutEffect` + `requestAnimationFrame` so the thread snaps to the bottom when the user sends a message, even if the signal update is batched.

2. **Queue editing** — queued messages (typed while the keeper is still streaming) are now visible as a list above the composer, and each item can be edited or deleted before it is sent.

3. **Batch send** — queued messages are drained as a single batched request (`\n\n---\n\n` joined) with all attachments merged, instead of dispatching one `sendKeeperThreadMessage` per queued item.

4. **Avatar text wrap** — the user avatar monogram (`[사용]`) gets `whitespace-nowrap` so two Korean characters no longer stack vertically.

5. **Bubble border colors** — `chat-bubble`, `chat-avatar`, and `chat-role-chip` now declare their own `border-width`/`border-style`/`border-color` inside the `@utility` blocks, removing the cascade conflict with the generic Tailwind `border` utility and aligning user/assistant borders with the accent theme.

Test plan:
- `cd dashboard && npx tsc --noEmit --pretty`
- `npm run build`
- `npx vitest run src/app.test.ts`