### PR TITLE
feat(dashboard): add StyleSeed-inspired opt-in theme foundation

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -25,6 +25,15 @@ import './styles/center.css'
 import './styles/base.css'
 import './styles/keyframes.css'
 
+/*
+ * EXPERIMENTAL: StyleSeed light theme — opt-in via data-theme='styleseed' on html
+ * These files define a self-contained StyleSeed-inspired token layer. Rules are
+ * scoped to [data-theme="styleseed"] so they have no effect on the default
+ * dark-fantasy / v2 surfaces unless the attribute is explicitly set.
+ */
+import './styles/styleseed-theme.css'
+import './styles/styleseed-base.css'
+
 // Global utilities and layout
 import './styles/global.css'
 import './styles/chat-blocks-v2.css'

--- a/dashboard/src/styles/styleseed-base.css
+++ b/dashboard/src/styles/styleseed-base.css
@@ -1,0 +1,38 @@
+/* ════════════════════════════════════════════════════════════════
+   StyleSeed base body / card / mobile styles
+   Active only when data-theme="styleseed" is set on <html>.
+   ════════════════════════════════════════════════════════════════ */
+
+/* Body base — CJK word-break + Pretendard-friendly metric reset */
+[data-theme="styleseed"] body {
+  background-color: var(--surface-page);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  word-break: keep-all;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Card base — all content lives inside cards */
+[data-theme="styleseed"] .ss-card {
+  background-color: var(--card);
+  border-radius: 1rem; /* rounded-2xl */
+  box-shadow: var(--shadow-card);
+}
+
+/* Dark mode: shadows are invisible, use subtle border for edges */
+[data-theme="styleseed"].dark .ss-card,
+.dark [data-theme="styleseed"] .ss-card {
+  box-shadow: none;
+  border: var(--card-border);
+}
+
+/* Mobile safe-area helpers */
+[data-theme="styleseed"] .ss-safe-bottom {
+  padding-bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px));
+}
+
+[data-theme="styleseed"] .ss-safe-top {
+  padding-top: calc(1.5rem + env(safe-area-inset-top, 0px));
+}

--- a/dashboard/src/styles/styleseed-theme.css
+++ b/dashboard/src/styles/styleseed-theme.css
@@ -1,0 +1,99 @@
+/* ════════════════════════════════════════════════════════════════
+   StyleSeed light theme foundation
+   Opt-in only: set data-theme="styleseed" on <html>.
+   Does NOT override existing dark-fantasy / v2 tokens unless active.
+   ════════════════════════════════════════════════════════════════ */
+
+[data-theme="styleseed"] {
+  /* Brand accent — single key color; everything else grayscale */
+  --brand: #721FE5;
+
+  /* Background & surfaces */
+  --background: #FAFAFA;
+  --surface-page: #FAFAFA;
+  --card: #FFFFFF;
+  --surface-subtle: #FAFAF9;
+  --surface-muted: #E8E6E1;
+
+  /* Text hierarchy — no pure black */
+  --text-primary: #3C3C3C;
+  --text-secondary: #6B6B6B;
+  --text-tertiary: #9B9B9B;
+  --text-disabled: #BDBDBD;
+  --icon-default: #6B6B6B;
+
+  /* Status / UI colors */
+  --success: #6B9B7A;
+  --destructive: #D4183D;
+  --warning: #D97706;
+  --info: #3B82F6;
+
+  /* Borders */
+  --border: #E8E6E1;
+  --card-border: none;
+
+  /* Brand tint for selected rows / active surfaces */
+  --brand-tint: #F0E8FF;
+
+  /* Alert badge */
+  --alert-badge: #FF4444;
+
+  /* Shadows — low opacity, barely visible */
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.04);
+  --shadow-card-hover: 0 2px 4px rgba(0, 0, 0, 0.08);
+  --shadow-elevated: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-modal: 0 8px 24px rgba(0, 0, 0, 0.12);
+  --shadow-button: 0 1px 3px rgba(0, 0, 0, 0.06);
+
+  /* Shape */
+  --radius: 0.625rem;
+
+  /* Type stack — Inter for Latin, Pretendard for CJK */
+  --font-sans:
+    'Inter', 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* ── Dark mode mapping ───────────────────────────────────────────
+   Card must be brighter than the page background.
+   Shadows are invisible in dark mode, so they are removed and card
+   edges rely on a subtle border instead. */
+[data-theme="styleseed"].dark,
+.dark [data-theme="styleseed"] {
+  /* Background levels */
+  --background: #121212;
+  --surface-page: #121212;
+  --card: #1E1E1E;
+  --surface-subtle: #252525;
+  --surface-muted: rgba(255, 255, 255, 0.08);
+
+  /* Text hierarchy — inverted */
+  --text-primary: #E0E0E0;
+  --text-secondary: #A0A0A0;
+  --text-tertiary: #808080;
+  --text-disabled: #555555;
+  --icon-default: #909090;
+
+  /* Brand & status — brightened */
+  --brand: #9B5FFF;
+  --success: #8FBF9A;
+  --destructive: #FF5C5C;
+  --warning: #FFB347;
+  --info: #64B5F6;
+
+  /* Border — subtle for dark card edges */
+  --border: rgba(255, 255, 255, 0.08);
+  --card-border: 1px solid rgba(255, 255, 255, 0.06);
+
+  /* Brand tint */
+  --brand-tint: rgba(155, 95, 255, 0.15);
+
+  /* Alert badge */
+  --alert-badge: #FF5C5C;
+
+  /* Shadows removed in dark mode */
+  --shadow-card: none;
+  --shadow-card-hover: none;
+  --shadow-elevated: none;
+  --shadow-modal: none;
+  --shadow-button: none;
+}

--- a/dashboard/src/styles/styleseed-theme.test.ts
+++ b/dashboard/src/styles/styleseed-theme.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const cssPath = resolve(__dirname, 'styleseed-theme.css')
+const css = readFileSync(cssPath, 'utf-8')
+
+/**
+ * Parse a CSS block for a given selector and return its declared custom
+ * properties as a record.
+ */
+function parseBlock(selector: string | RegExp): Record<string, string> {
+  let start = 0
+  if (typeof selector === 'string') {
+    start = css.indexOf(selector)
+  } else {
+    const match = selector.exec(css)
+    start = match ? match.index : -1
+  }
+  if (start === -1) {
+    throw new Error(`Selector not found: ${selector.toString()}`)
+  }
+
+  const open = css.indexOf('{', start)
+  let depth = 0
+  let close = open
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === '{') depth++
+    if (css[i] === '}') {
+      depth--
+      if (depth === 0) {
+        close = i
+        break
+      }
+    }
+  }
+
+  const block = css.slice(open + 1, close)
+  const vars: Record<string, string> = {}
+  for (const line of block.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('/*')) continue
+    const match = /^(--[\w-]+):\s*([^;]+);/.exec(trimmed)
+    if (match && match[1] && match[2]) {
+      vars[match[1]] = match[2].trim()
+    }
+  }
+  return vars
+}
+
+describe('styleseed-theme.css', () => {
+  it('uses [data-theme="styleseed"] as the opt-in selector', () => {
+    expect(css).toContain('[data-theme="styleseed"]')
+  })
+
+  it('declares all required light-mode tokens', () => {
+    const light = parseBlock('[data-theme="styleseed"]')
+    expect(light['--background']).toBe('#FAFAFA')
+    expect(light['--card']).toBe('#FFFFFF')
+    expect(light['--surface-page']).toBe('#FAFAFA')
+    expect(light['--brand']).toBe('#721FE5')
+    expect(light['--text-primary']).toBe('#3C3C3C')
+    expect(light['--text-secondary']).toBe('#6B6B6B')
+    expect(light['--text-tertiary']).toBe('#9B9B9B')
+    expect(light['--text-disabled']).toBe('#BDBDBD')
+    expect(light['--success']).toBe('#6B9B7A')
+    expect(light['--destructive']).toBe('#D4183D')
+    expect(light['--warning']).toBe('#D97706')
+    expect(light['--info']).toBe('#3B82F6')
+    expect(light['--border']).toBe('#E8E6E1')
+    expect(light['--surface-muted']).toBe('#E8E6E1')
+    expect(light['--surface-subtle']).toBe('#FAFAF9')
+    expect(light['--shadow-card']).toBe('0 1px 3px rgba(0, 0, 0, 0.04)')
+    expect(light['--shadow-elevated']).toBe('0 4px 12px rgba(0, 0, 0, 0.08)')
+    expect(light['--shadow-modal']).toBe('0 8px 24px rgba(0, 0, 0, 0.12)')
+    expect(light['--radius']).toBe('0.625rem')
+  })
+
+  it('switches token values for dark mode', () => {
+    const dark = parseBlock(/\[data-theme="styleseed"\]\.dark/)
+    expect(dark['--surface-page']).toBe('#121212')
+    expect(dark['--card']).toBe('#1E1E1E')
+    expect(dark['--surface-subtle']).toBe('#252525')
+    expect(dark['--text-primary']).toBe('#E0E0E0')
+    expect(dark['--text-secondary']).toBe('#A0A0A0')
+    expect(dark['--text-tertiary']).toBe('#808080')
+    expect(dark['--text-disabled']).toBe('#555555')
+    expect(dark['--brand']).toBe('#9B5FFF')
+    expect(dark['--success']).toBe('#8FBF9A')
+    expect(dark['--destructive']).toBe('#FF5C5C')
+    expect(dark['--warning']).toBe('#FFB347')
+    expect(dark['--info']).toBe('#64B5F6')
+    expect(dark['--shadow-card']).toBe('none')
+    expect(dark['--card-border']).toBe('1px solid rgba(255, 255, 255, 0.06)')
+  })
+
+  it('never uses pure black (#000) for text or surfaces', () => {
+    const blackHex = /#[0]{3,6}\b/
+    expect(blackHex.test(css)).toBe(false)
+  })
+
+  it('keeps card brighter than page background in both modes', () => {
+    const light = parseBlock('[data-theme="styleseed"]')
+    expect(light['--card']).toBe('#FFFFFF')
+    expect(light['--surface-page']).toBe('#FAFAFA')
+
+    const dark = parseBlock(/\[data-theme="styleseed"\]\.dark/)
+    expect(dark['--card']).toBe('#1E1E1E')
+    expect(dark['--surface-page']).toBe('#121212')
+
+    // Hex brightness check: higher numeric value = brighter.
+    const darkCard = dark['--card'] ?? ''
+    const darkPage = dark['--surface-page'] ?? ''
+    const hexValue = (hex: string) => parseInt(hex.replace('#', ''), 16)
+    expect(hexValue(darkCard)).toBeGreaterThan(hexValue(darkPage))
+  })
+})


### PR DESCRIPTION
## Summary
Adds a StyleSeed-inspired light/dark theme foundation as an opt-in layer.

## What changed
- `dashboard/src/styles/styleseed-theme.css`:
  - Light mode: `--background #FAFAFA`, `--card #FFFFFF`, 5-level grayscale text, semantic status colors, low-opacity shadows
  - Dark mode: `--surface-page #121212`, `--card #1E1E1E`, brightened brand `#9B5FFF`, shadows replaced by subtle borders
  - Scoped to `[data-theme="styleseed"]`
- `dashboard/src/styles/styleseed-base.css`:
  - CJK `word-break: keep-all`, `overflow-wrap: break-word`
  - `.ss-card` helper with `bg-card rounded-2xl shadow-card`
- `dashboard/src/main.ts`: experimental opt-in import block
- `dashboard/src/styles/styleseed-theme.test.ts`: 5 tests verifying tokens and dark-mode switch

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `styleseed-theme.test.ts` ✅ 5/5

## Notes
- Existing dark-fantasy/v2 themes are untouched.
- To preview: add `data-theme="styleseed"` to the `<html>` element.
