### PR TITLE
fix(redact): anchor secret-prefix regexes at word boundary (task-id false-positive)

### DIFF
--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -39,15 +39,27 @@ let url_credential_re =
 
 (** Common secret-bearing value patterns. Specific prefixes are listed before
     the generic high-entropy matcher so short, well-known tokens are not missed
-    when they are embedded inside larger strings. *)
+    when they are embedded inside larger strings.
+
+    Each prefix literal is anchored at a word boundary ([Re.bow]) so a
+    word-internal substring is not mistaken for a key. Without the anchor, the
+    [sk-] pattern matched the substring [sk-1234] inside the task id
+    [task-1234] and redacted it to [ta\[REDACTED\]], destroying diagnostic
+    identifiers in error previews (and any other observability field carrying a
+    [task-XXXX] reference). [bow] rejects that match because [sk-] is preceded
+    by the identifier char 'a'. [Re.bow]/[eow] are zero-width assertions, so
+    [Re.replace_string] preserves the boundary character (=, space, quote)
+    automatically. The [sk-] body allows [-] so modern [sk-proj-...] keys are
+    matched in one shot instead of leaving a [-abc...] tail. [AKIA] is anchored
+    at both ends so a 17-char run is not truncated to its first 16 chars. *)
 let secret_res ?(min_len = default_min_secret_len) () =
   let open Re in
   [ url_credential_re
   ; compile (seq [str "Bearer "; rep1 (compl [set " \t\r\n"])])
-  ; compile (seq [str "ghp_"; rep1 alnum])
-  ; compile (seq [str "github_pat_"; rep1 (alt [alnum; char '_'])])
-  ; compile (seq [str "sk-"; rep1 alnum])
-  ; compile (seq [str "AKIA"; repn alnum 16 (Some 16)])
+  ; compile (seq [bow; str "ghp_"; rep1 alnum])
+  ; compile (seq [bow; str "github_pat_"; rep1 (alt [alnum; char '_'])])
+  ; compile (seq [bow; str "sk-"; rep1 (alt [alnum; char '-'])])
+  ; compile (seq [bow; str "AKIA"; repn alnum 16 (Some 16); eow])
   ; generic_secret_re min_len
   ]
 

--- a/test/test_observability_redact.ml
+++ b/test/test_observability_redact.ml
@@ -147,6 +147,47 @@ let test_preview_json_strings_preserves_embedded_marker () =
        | _ -> Alcotest.fail "content field missing or not a string")
   | _ -> Alcotest.fail "expected Assoc root"
 
+(* Regression: prefix-based secret regexes used to match substrings of ordinary
+   identifiers. Without a word-boundary anchor, the sk- pattern matched the
+   substring "sk-1234" inside the task id "task-1234" and redacted it to
+   "ta[REDACTED]", corrupting error-preview diagnostics (and any observability
+   field carrying a task-XXXX reference). Same root cause affected ghp_ (inside
+   e.g. "baghp_12"). bow rejects these because the prefix is preceded by an
+   identifier char. *)
+let test_no_false_positive_on_task_ids () =
+  let inputs =
+    [ "task-1234"; "desk-1234"; "mask-abc"; "disk-99"
+    ; "flask-test"; "risk-5"; "bask-5"; "xsk-5" ]
+  in
+  List.iter
+    (fun input ->
+      let r = Observability_redact.redact_text input in
+      Alcotest.(check string)
+        (input ^ " not corrupted by sk-/ghp_ false positive") input r)
+    inputs
+
+let test_no_false_positive_on_keeper_identities () =
+  let inputs =
+    [ "task-claim-bot"; "heartbeat-keeper"; "baghp_12"; "diagnostic-judge" ]
+  in
+  List.iter
+    (fun input ->
+      let r = Observability_redact.redact_text input in
+      Alcotest.(check string)
+        (input ^ " keeper identity preserved") input r)
+    inputs
+
+(* Regression: the sk- body used to stop at the first '-', so modern keys with a
+   "-proj-" segment leaked the tail and were only caught by the generic 20+
+   fallback by luck. The body now allows '-' so the whole key matches in one
+   shot. Token literal is split so it is not mistaken for a real credential by
+   tooling; it is a synthetic test value, not a live secret. *)
+let test_sk_modern_key_fully_redacted () =
+  let input = "sk-" ^ "proj-" ^ "0123456789abcdefghijklmnopqrstuv" in
+  let r = Observability_redact.redact_text input in
+  Alcotest.(check bool) "no partial sk- tail leak" true
+    (not (String_util.contains_substring r "0123456789abcdef"))
+
 let () =
   Alcotest.run "observability_redact"
     [
@@ -168,6 +209,12 @@ let () =
             test_blob_marker_redacts_preview_body;
           Alcotest.test_case "preview_json_strings preserves embedded marker"
             `Quick test_preview_json_strings_preserves_embedded_marker;
+          Alcotest.test_case "no false positive on task ids" `Quick
+            test_no_false_positive_on_task_ids;
+          Alcotest.test_case "no false positive on keeper identities" `Quick
+            test_no_false_positive_on_keeper_identities;
+          Alcotest.test_case "modern sk- key fully redacted" `Quick
+            test_sk_modern_key_fully_redacted;
         ] );
       ( "deny_list",
         [


### PR DESCRIPTION
## Summary

Keeper tool_call 로그의 error preview에서 diagnostic 식별자(task_id, assignee)가 `[REDACTED]`로 잘려 디버깅이 불가능했던 버그를 고칩니다.

**증상** (실제 로그):
```
error_preview=...preview="{\"error\":\"[TaskError] Invalid task state: task ta[REDACTED] is already done by [REDACTED]; inspect tas..."
```

## Root cause (재현으로 패명)

`lib/observability_redact.ml`의 OpenAI key 정규식 `sk-[0-9A-Za-z]+`가 word boundary 없이 `task-1234` 안의 부분문자열 `sk-1234`(`task`의 `s`부터)를 매칭해 `ta` + `[REDACTED]`로 치환. `input_shape=[task_id=string:9]`(=`task-1234`, 9자)과 정확히 일치.

전수: `task-`, `desk-`, `mask-`, `disk-`, `flask-`, `risk-` 등 하이픈 앞에 `sk`가 오는 모든 단어가 false positive. **모든 `task-XXXX` 참조**가 관측 로그 전 영역(tool I/O preview, MCP log, keeper tool call log, eval gate, JSON value)에서 조용히 오염되고 있었다.

## Fix

`ghp_`/`github_pat_`/`sk-`/`AKIA` 정규식 앞에 `Re.bow`(AKIA는 뒤에도 `eow`) 추가:
- `sk-` 앞이 식별자 문자(`t`**`a`**`sk` 의 `a`)면 매칭 거부 → `task-1234` 보존.
- `Re.bow`/`eow`는 zero-width라 기존 `Re.replace_string`이 boundary(`=`, 공백, 따옴표) 자동 보존. group capture 불필요.
- `sk-` body에 `-` 허용 → modern `sk-proj-...` key 한 번에 매칭 (latent bug: 기존엔 `sk-proj`까지만 매칭, generic 20+ fallback이 우연히 뒤 처리).

`generic_secret_re`는 변경 없음 — keeper-ID false-positive(`task-claim-bot-9a8b7c6d` 23+자)는 별도 길이 임계값 이슈로 분리 추적.

## This is a classification bug fix, not a workaround

시그니처 "String/Substring 분류기 보강"(새 prefix/substring **추가**)이 아님 — 반대로 boundary anchor로 매칭을 **줄여** 정확도 향상. 새 secret 패턴 추가 없음.

WORKAROUND-WAIVED: word-boundary anchor로 false-positive 매칭을 줄이는 classification bug fix. 새 substring 분류기 추가 아님. RFC 불필요 (observability_redact는 credential/identity/repo/operator mandatory-RFC subsystem 아님).

## Verification

- `dune build test/test_observability_redact.exe` — green (worktree local, `--root`로 nested worktree 빌드).
- `dune exec test/test_observability_redact.exe` — **17/17 tests pass** (기존 14 + 신규 회귀 3):
  - `no false positive on task ids` — `task-1234`, `desk-1234`, `mask-abc`, `disk-99`, `flask-test`, `risk-5`, `bask-5`, `xsk-5` 보존
  - `no false positive on keeper identities` — `task-claim-bot`, `heartbeat-keeper`, `baghp_12`, `diagnostic-judge` 보존
  - `modern sk- key fully redacted` — latent `sk-proj` 누출 회귀
- 기존 real-secret 테스트(API key, URL credential, Bearer ghp_, blob marker 3종) 전부 green 유지.

## Out of scope

`generic_secret_re`(20+ alnum)의 keeper-ID false-positive는 별도 이슈로 추적 (단일 길이 임계값으로 SHA(64) vs keeper ID(20-35) 분리 불가 → keeper allowlist 또는 typed secret-source 마스킹 확대 필요).

Co-Authored-By: Claude <noreply@anthropic.com>
