### PR TITLE
feat(dashboard): dark-fantasy foundation — palette + Cinzel + scroll

### DIFF
--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -40,25 +40,28 @@ import {
 // Mermaid classDef requires literal hex values — CSS vars are not resolved.
 // These constants map to design system token values for single-source truth.
 
-const M_SOURCE_FILL = '#0f172a'     // --color-bg-3 (navy approx)
-const M_SOURCE_STROKE = '#475569'   // --color-line-2
-const M_SOURCE_TEXT = '#cbd5e1'     // --color-frost-100
-const M_HUB_FILL = '#111827'        // --color-bg-surface
-const M_HUB_STROKE = '#38bdf8'      // --color-cyan
-const M_HUB_TEXT = '#e0f2fe'        // --color-frost-100
-const M_HEALTHY_FILL = '#082f1d'
-const M_HEALTHY_STROKE = '#4ade80'
-const M_HEALTHY_TEXT = '#dcfce7'
-const M_WARN_FILL = '#3b2a07'
-const M_WARN_STROKE = '#fbbf24'
-const M_WARN_TEXT = '#fde68a'
-const M_STALE_FILL = '#1f2937'
-const M_STALE_STROKE = '#94a3b8'    // --color-fg-4
-const M_STALE_TEXT = '#e2e8f0'      // --color-frost-100
-const M_IDLE_FILL = '#111827'       // --color-bg-surface
-const M_IDLE_STROKE = '#475569'     // --color-line-2
-const M_IDLE_TEXT = '#94a3b8'       // --color-fg-4
-const M_ACTIVE_STROKE = '#7dd3fc'
+/* Mermaid classDef colors cannot reference CSS vars, so the dark-fantasy
+   palette is mirrored here as literals (dashboard is dark-only). Keep these
+   in sync with the _ds Dark-Fantasy tokens noted per line. */
+const M_SOURCE_FILL = '#221815'     // --color-bg-3 (bruised meat)
+const M_SOURCE_STROKE = '#5a3028'   // --color-line-2 (scab)
+const M_SOURCE_TEXT = '#b8a488'     // --color-fg-2 (bandage)
+const M_HUB_FILL = '#14100d'        // --color-bg-surface (rotted wood)
+const M_HUB_STROKE = '#c4a265'      // brass accent (central hub)
+const M_HUB_TEXT = '#e8d8b8'        // --color-fg-1 (bone)
+const M_HEALTHY_FILL = '#16210f'    // bile-green bg
+const M_HEALTHY_STROKE = '#5a7a3a'  // --status-ok (bile)
+const M_HEALTHY_TEXT = '#9abc7a'    // --ok-fg
+const M_WARN_FILL = '#2a1d08'       // ember bg
+const M_WARN_STROKE = '#a06a1a'     // --status-warn (ember)
+const M_WARN_TEXT = '#d49a3a'       // --warn-fg
+const M_STALE_FILL = '#1b1612'      // --color-bg-2
+const M_STALE_STROKE = '#6a5848'    // --color-fg-3 (mold dust)
+const M_STALE_TEXT = '#b8a488'      // --color-fg-2
+const M_IDLE_FILL = '#14100d'       // --color-bg-surface
+const M_IDLE_STROKE = '#5a3028'     // --color-line-2
+const M_IDLE_TEXT = '#6a5848'       // --color-fg-3
+const M_ACTIVE_STROKE = '#c4a265'   // brass accent (active highlight)
 
 type HarnessRailKey = 'evaluator' | 'pre_compact' | 'handoff'
 

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -76,9 +76,11 @@ export const ARCHITECTURE_FLOW = `graph LR
     G1 --> D1
     D1 --> UI[기억 서브시스템 패널]
 
-    classDef store fill:#1e293b,stroke:#334155,color:#e2e8f0
-    classDef action fill:#0f766e,stroke:#14b8a6,color:#e2e8f0
-    classDef ui fill:#7c2d12,stroke:#f97316,color:#e2e8f0
+    %% dark-fantasy palette (mermaid can't use CSS vars): store=bg/mold,
+    %% action=bile, ui=ember. Mirrors _ds Dark-Fantasy tokens.
+    classDef store fill:#221815,stroke:#5a3028,color:#e8d8b8
+    classDef action fill:#16210f,stroke:#5a7a3a,color:#e8d8b8
+    classDef ui fill:#2a1d08,stroke:#c4461a,color:#e8d8b8
     class F1,G1 store
     class M1,M3,H1,H2,T2 action
     class UI ui`

--- a/dashboard/src/styles/base.css
+++ b/dashboard/src/styles/base.css
@@ -11,11 +11,40 @@ body {
 html {
   overflow-y: scroll;
   scrollbar-gutter: stable;
+  /* Foundation scrollbar (Firefox/standards). Webkit equivalent below.
+     Consumes the dark-fantasy scrollbar tokens so every scroll container
+     inherits one canonical thumb instead of re-declaring it per surface. */
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb, var(--line-2)) transparent;
   /* iOS Safari auto-inflates font sizes in landscape / narrow columns;
      pinning to 100% keeps the responsive --font-size-* scale honest on
      mobile so "state at a glance" isn't distorted by the browser. */
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
+}
+
+/* Canonical webkit scrollbar — foundation default for all scroll
+   containers. Per-surface overrides may still tune width, but the thumb
+   color is token-driven here so the palette stays consistent. */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb, var(--line-2));
+  border-radius: var(--radius-pill, 999px);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover, var(--line-3));
+  background-clip: padding-box;
+}
+::-webkit-scrollbar-corner {
+  background: transparent;
 }
 
 /* Kill the 300ms double-tap zoom delay on touch targets so taps feel
@@ -34,7 +63,10 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: var(--color-bg-page);
+  /* Dark-fantasy ambient: a faint blood bloom top-left and a tarnished
+     brass bloom top-right over the near-black ground. Subtle, not a hero. */
   background-image:
+    radial-gradient(ellipse at 12% 8%, rgb(var(--err-glow) / .05), transparent 42%),
     radial-gradient(circle at 88% 14%, rgb(var(--brass-glow) / .05), transparent 20%);
   background-attachment: fixed;
   position: relative;
@@ -44,6 +76,14 @@ body {
   position: relative;
   min-height: 100vh;
   z-index: 1;
+}
+
+/* Headings carry the engraved display voice (Cinzel). Uppercase/tracking is
+   left to component opt-in so Korean labels are not force-cased. */
+h1, h2, h3, h4, .display {
+  font-family: var(--font-display);
+  color: var(--color-fg-1);
+  letter-spacing: var(--track-caps, 0.08em);
 }
 
 a {

--- a/dashboard/src/styles/ide-v2.css
+++ b/dashboard/src/styles/ide-v2.css
@@ -403,7 +403,7 @@
 .ide-v2-drawer {
   flex: none;
   border-top: 1px solid var(--border-main);
-  background: #06070a;
+  background: var(--color-bg-page);
   display: flex;
   flex-direction: column;
   max-height: 200px;

--- a/dashboard/src/styles/memory-v2.css
+++ b/dashboard/src/styles/memory-v2.css
@@ -140,7 +140,7 @@
   flex: none;
   font-family: var(--font-mono);
   font-weight: 700;
-  color: #0b0c10;
+  color: var(--color-bg-page);
   background: var(--kc);
   border-radius: var(--radius-xs);
 }

--- a/dashboard/src/styles/v2-shell.css
+++ b/dashboard/src/styles/v2-shell.css
@@ -10,25 +10,26 @@
 .v2-status-tray,
 .v2-shell-header,
 .v2-health-strip {
-  /* v5 Observatory dark-fantasy palette, calibrated against the v2
-     colors_and_type.css "Dark Fantasy" theme. */
-  --v2-ink:         #0a0e18;
-  --v2-velvet:      #0f1524;
-  --v2-card:        #131a2a;
-  --v2-card-soft:   #161d30;
-  --v2-raised:      #1a2238;
-  --v2-border-soft: rgba(120, 140, 180, 0.09);
-  --v2-border:      rgba(120, 140, 180, 0.13);
-  --v2-border-strong: rgba(140, 160, 200, 0.18);
-  --v2-text:        #b8c4dc;
-  --v2-text-bright: #e8eef8;
-  --v2-text-dim:    #5a6a88;
-  --v2-text-faint:  #4a5a78;
-  --v2-accent-brass: #8a6a28;
-  --v2-accent-brass-dim: #5a4618;
-  --v2-ok:          #5a7a3a;
-  --v2-warn:        #a06a1a;
-  --v2-bad:         #a01818;
+  /* Shell palette — aliased to the global dark-fantasy tokens (owned by
+     v2-theme.css) instead of a local literal copy, so the shell chrome
+     stays in lockstep with the rest of the dashboard. */
+  --v2-ink:         var(--color-bg-page);
+  --v2-velvet:      var(--color-bg-surface);
+  --v2-card:        var(--color-bg-panel-alt);
+  --v2-card-soft:   var(--color-bg-elevated);
+  --v2-raised:      var(--color-bg-hover);
+  --v2-border-soft: var(--color-border-divider);
+  --v2-border:      var(--color-border-default);
+  --v2-border-strong: var(--color-border-strong);
+  --v2-text:        var(--color-fg-secondary);
+  --v2-text-bright: var(--color-fg-primary);
+  --v2-text-dim:    var(--color-fg-muted);
+  --v2-text-faint:  var(--color-fg-disabled);
+  --v2-accent-brass: var(--accent-brass);
+  --v2-accent-brass-dim: var(--color-accent-fg-dim);
+  --v2-ok:          var(--ok);
+  --v2-warn:        var(--warn);
+  --v2-bad:         var(--err);
 
   /* Re-use the generated type stacks (Cinzel display, Noto Sans KR UI). */
   --v2-font-display: var(--font-display);

--- a/dashboard/src/styles/v2-theme.css
+++ b/dashboard/src/styles/v2-theme.css
@@ -1,30 +1,38 @@
 /* MASC Dashboard v2 — global theme bridge.
  *
- * Maps the legacy dashboard token ladder to the v5 Observatory dark-fantasy
- * palette so existing components pick up new colors without a full rewrite.
- * Paper theme remains opt-in via data-theme="paper".
+ * Maps the legacy dashboard token ladder to the _ds Dark-Fantasy palette so
+ * existing components pick up new colors without a full rewrite. This file is
+ * the LAST-loading theme layer (global.css), so its base values below are the
+ * effective surface/text/accent palette for the whole dashboard; everything
+ * else (--color-bg-page, --fg-*, soft/alpha slots, component tokens) derives
+ * from them via var(). Paper theme remains opt-in via data-theme="paper".
  *
- * Source: /Users/dancer/Downloads/v2/_ds/masc-design-system-a925c77f-042a-40f5-ac15-0675a4a58d3f/ui_kits/dashboard/styles/base.css
- *         /Users/dancer/Downloads/v2/_ds/masc-design-system-a925c77f-042a-40f5-ac15-0675a4a58d3f/colors_and_type.css
+ * Palette: _ds Dark Fantasy (visceral / decay-forward) — wet stone, blood-
+ * soaked wood, bone & bandage text. Status keeps the muted bile/ember/blood
+ * triad. Brass is the rare interactive/selection accent; blood (--accent-blood
+ * from ds-theme-tokens.css) carries emphasis/danger.
+ * Source: _ds .../colors_and_type.css + ui_kits/dashboard/styles/base.css
  */
 
 :root,
 [data-theme="dark-fantasy"] {
-  /* v5 dashboard surfaces */
-  --bg-ink:        #0a0e18;
-  --bg-velvet:     #0f1524;
-  --bg-card:       #131a2a;
-  --bg-card-soft:  #161d30;
-  --bg-raised:     #1a2238;
+  /* Dark-fantasy dashboard surfaces — 5-step warm-dark ramp */
+  --bg-ink:        #0a0706;   /* page — pitch with a red undertone */
+  --bg-velvet:     #14100d;   /* topbar / composer — rotted wood */
+  --bg-card:       #1b1612;   /* panel surface — card base */
+  --bg-card-soft:  #221815;   /* elevated card — bruised meat */
+  --bg-raised:     #2e211c;   /* hover / active row */
 
-  --border-soft:   rgba(120, 140, 180, 0.09);
-  --border:        rgba(120, 140, 180, 0.13);
-  --border-strong: rgba(140, 160, 200, 0.18);
+  /* Hairlines — scabbed, stitched leather (warm red-brown) */
+  --border-soft:   rgba(122, 70, 54, 0.14);
+  --border:        rgba(122, 70, 54, 0.24);
+  --border-strong: rgba(150, 90, 70, 0.36);
 
-  --text-bright:   #e8eef8;
-  --text-primary:  #b8c4dc;
-  --text-dim:      #5a6a88;
-  --text-faint:    #4a5a78;
+  /* Text — bone and bandage */
+  --text-bright:   #e8d8b8;   /* clean bone */
+  --text-primary:  #b8a488;   /* dirty bandage */
+  --text-dim:      #8a7560;   /* mold dust (lifted for WCAG on near-black) */
+  --text-faint:    #5a4a3c;
 
   --accent-brass:     #c4a265;
   --accent-brass-dim: #5a4618;

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -638,44 +638,17 @@ html:not([data-theme="paper"]) {
 }
 
 /* ══════════════════════════════════════════════════════════════
-   DARK FANTASY palette application (foundation sweep, 2026-06)
+   DARK FANTASY type restore (foundation sweep, 2026-06)
 
-   The raw token tier (tokens.generated.css @theme + tokens.css) and the
-   v5 "Pretendard neutral sans" decision stay in place as the brass canon.
-   This block is the active theme override: it re-points the surface
-   primitives to the _ds Dark-Fantasy palette and restores the engraved
-   display / warm body type stacks. It is the LAST :root in the foundation
-   load order (after tokens.generated.css, tokens.css), so it wins for
-   every var(--color-*) / var(--font-display|body) consumer — and the whole
-   chain (--color-bg-page 170×, --bg-deep 33×, --bg-0 27×, the color-mix
-   shells) bottoms out here.
-
-   WORKAROUND scope: an override layer is used (not a generated-file edit)
-   because tokens.generated.* is @generated and locked by the tokens-drift
-   CI gate (Gate 3), and its generator (design-system/tokens/build.ts) is
-   absent in-tree. The 8 baked Tailwind utilities (bg-bg-0 / bg-bg-1) keep
-   #0c0b08 / #141210 — within ~2 hex of the dark-fantasy bg, visually
-   identical. Root fix: restore build.ts and regenerate from source.ts.
+   The surface/text/accent palette is owned by v2-theme.css (the last-loading
+   theme bridge); this block only restores the engraved display / warm book
+   body type stacks that the v5 "Pretendard neutral sans" default (tokens.css)
+   and a keeper-v2 font bridge had erased. Chrome/UI stays sans (--font-sans,
+   --font-ui) for data density; headings/KPIs opt into --font-display (Cinzel),
+   narrative into --font-body (EB Garamond). Placed last so it wins over
+   tokens.css's --font-display: var(--font-sans).
    ══════════════════════════════════════════════════════════════ */
 :root {
-  /* Surfaces — wet stone / blood-soaked wood (source: _ds colors_and_type.css) */
-  --color-bg-0: #0a0706;   /* page bg — pitch with a red undertone */
-  --color-bg-1: #14100d;   /* topbar / composer — rotted wood */
-  --color-bg-2: #1b1612;   /* panel surface — card base */
-  --color-bg-3: #221815;   /* elevated card — bruised meat */
-  --color-bg-4: #2e211c;   /* hover / active row */
-  /* Hairlines — scabbed, stitched leather */
-  --color-line-1: #2a1a14; /* default border */
-  --color-line-2: #5a3028; /* emphasized border — scab / raw wound */
-  --color-line-3: #3a2419; /* divider between zones */
-  /* Text — bone and bandage, never pure white */
-  --color-fg-1: #e8d8b8;   /* primary — clean bone */
-  --color-fg-2: #b8a488;   /* secondary — dirty bandage */
-  --color-fg-3: #6a5848;   /* tertiary / labels — mold dust */
-  --color-fg-4: #4a3a30;   /* disabled / placeholder */
-
-  /* Engraved display + warm book body restored over the v5 sans default.
-     Chrome/UI stays sans (--font-sans, --font-ui) for data density. */
   --font-display: "Cinzel", "Noto Sans KR", "EB Garamond", serif;
   --font-body: "EB Garamond", "Noto Sans KR", Georgia, serif;
 }

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -578,9 +578,10 @@ html:not([data-theme="paper"]) {
   --text-primary: var(--fg-2);
   --text-mid: var(--fg-3);
 
-  --font-display: var(--font-sans);
-  --font-ui: var(--font-sans);
-  --font-body: var(--font-sans);
+  /* Font bridge removed (dark-fantasy migration): these previously forced
+     --font-display/ui/body to plain --font-sans, erasing the brand voice.
+     The real stacks now resolve from ds-theme-tokens.css / tokens.generated.css:
+     display = Cinzel, body = EB Garamond, ui = Noto Sans KR. */
 
   --pad-surface: 22px 26px 40px;
   --pad-card: 12px 14px;
@@ -634,4 +635,47 @@ html:not([data-theme="paper"]) {
   --text-mid: var(--color-fg-secondary);
   --text-dim: var(--color-fg-muted);
   --text-bright: var(--color-fg-primary);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   DARK FANTASY palette application (foundation sweep, 2026-06)
+
+   The raw token tier (tokens.generated.css @theme + tokens.css) and the
+   v5 "Pretendard neutral sans" decision stay in place as the brass canon.
+   This block is the active theme override: it re-points the surface
+   primitives to the _ds Dark-Fantasy palette and restores the engraved
+   display / warm body type stacks. It is the LAST :root in the foundation
+   load order (after tokens.generated.css, tokens.css), so it wins for
+   every var(--color-*) / var(--font-display|body) consumer — and the whole
+   chain (--color-bg-page 170×, --bg-deep 33×, --bg-0 27×, the color-mix
+   shells) bottoms out here.
+
+   WORKAROUND scope: an override layer is used (not a generated-file edit)
+   because tokens.generated.* is @generated and locked by the tokens-drift
+   CI gate (Gate 3), and its generator (design-system/tokens/build.ts) is
+   absent in-tree. The 8 baked Tailwind utilities (bg-bg-0 / bg-bg-1) keep
+   #0c0b08 / #141210 — within ~2 hex of the dark-fantasy bg, visually
+   identical. Root fix: restore build.ts and regenerate from source.ts.
+   ══════════════════════════════════════════════════════════════ */
+:root {
+  /* Surfaces — wet stone / blood-soaked wood (source: _ds colors_and_type.css) */
+  --color-bg-0: #0a0706;   /* page bg — pitch with a red undertone */
+  --color-bg-1: #14100d;   /* topbar / composer — rotted wood */
+  --color-bg-2: #1b1612;   /* panel surface — card base */
+  --color-bg-3: #221815;   /* elevated card — bruised meat */
+  --color-bg-4: #2e211c;   /* hover / active row */
+  /* Hairlines — scabbed, stitched leather */
+  --color-line-1: #2a1a14; /* default border */
+  --color-line-2: #5a3028; /* emphasized border — scab / raw wound */
+  --color-line-3: #3a2419; /* divider between zones */
+  /* Text — bone and bandage, never pure white */
+  --color-fg-1: #e8d8b8;   /* primary — clean bone */
+  --color-fg-2: #b8a488;   /* secondary — dirty bandage */
+  --color-fg-3: #6a5848;   /* tertiary / labels — mold dust */
+  --color-fg-4: #4a3a30;   /* disabled / placeholder */
+
+  /* Engraved display + warm book body restored over the v5 sans default.
+     Chrome/UI stays sans (--font-sans, --font-ui) for data density. */
+  --font-display: "Cinzel", "Noto Sans KR", "EB Garamond", serif;
+  --font-body: "EB Garamond", "Noto Sans KR", Georgia, serif;
 }


### PR DESCRIPTION
## 목적

대시보드 디자인 파운데이션(배경/색/폰트/스크롤)을 `_ds` **Dark-Fantasy** 팔레트로 일관되게 적용한다. 토큰은 있었지만 다수 표면이 일관 소비하지 않아 색이 혼재(BLUE/navy + brass)했고, Cinzel 디스플레이 폰트는 죽어 있었다.

## 근본 원인

대시보드에 **3개의 다크 팔레트가 경쟁**하고 있었다:
1. brass 캐논 — `tokens.generated.css` `@theme` + `tokens.css`
2. `ds-theme-tokens.css` — _ds Dark-Fantasy RED (가장 먼저 로드 → 그림자 처리)
3. `v2-theme.css` — BLUE "v5 Observatory" (가장 늦게 로드 → **실제 컨트롤러**였음)

Cinzel은 `tokens.css`의 v5 "Pretendard neutral sans" 결정 + keeper-v2 폰트 브릿지가 `--font-display: var(--font-sans)`로 덮어써 무력화돼 있었다.

## 변경 (foundation only, 9 files)

- **색**: `v2-theme.css`의 surfaces/text를 BLUE→Dark-Fantasy RED(`#0a0706` 5단계 + bone/bandage). `v2-shell.css`의 로컬 `--v2-*` blue 팔레트를 글로벌 토큰으로 alias(중복 제거). `ide-v2`/`memory-v2` spot fix. mermaid 그래프 색(`harness-health`, `memory-subsystems`) navy/cyan→dark-fantasy.
- **폰트**: Cinzel 디스플레이(제목/KPI/섹션헤드) + EB Garamond body 복구.
- **스크롤**: `base.css`에 토큰 기반 단일 스크롤바 규칙(webkit + Firefox).
- **배경**: body blood/brass ambient radial.

## 설계 결정

- `tokens.generated.*`는 **편집하지 않음**. `tokens-drift.yml` Gate 3(generated 변경 시 source.ts 동반 강제) + `tokens:check`(status canon + keeper OkLCH 핀)가 잠그고 있고, 생성기 `design-system/tokens/build.ts`가 부재라 정공법 재생성이 불가. 따라서 non-generated 레이어(`v2-theme.css` / `variables.css`)에서 적용했다. status canon·keeper 팔레트는 불변 유지.
- 8개 베이크된 Tailwind 유틸(`bg-bg-0/1`)은 generated brass 값 유지(#0c0b08 vs #0a0706, ~2 hex 차, 불가시).

## 의도적 미변경 (근거 있음)

- `cytoscape-fsm.ts`: 런타임에 `getComputedStyle`로 CSS var를 읽음 → 이미 라이브 테마 추종.
- `ide-memory-panel.ts`: `var(--tone-*, fallback)` → var-기반.
- `composite-fsm-flowchart` classDef: 이미 warm + "tokens 1:1" 주석.
- 키퍼 아바타 identity 색: 의도적 per-keeper 색.
- **Spacing 일괄 px→토큰**: `8px`→`var(--space-2)`는 렌더 동일(시각 변화 0) + off-grid 값 다수 → churn/회귀 위험이라 제외(스케일은 이미 존재·사용 중).

## 검증

- `pnpm build` green.
- 토큰/테마 테스트 10/10, `harness-health.test` + `memory-subsystems.test` 18/18 통과.
- Overview / Memory Explore / shell 3개 뷰 스크린샷으로 일관성 확인 (blue cast 제거, Cinzel 적용, 레이아웃 정상).

## 후속 (별도)

- 인프라 갭: `design-system/tokens/build.ts` 부재로 토큰 codegen 파이프라인이 끊겨 `tokens:build`가 no-op. 복원 시 generated가 다시 진짜 SSOT가 됨.
- 컴포넌트 그래프 색을 `TOKENS` const/computed CSS var로 소싱하는 리팩터.

RFC-WAIVED: dashboard 디자인 파운데이션(CSS 토큰/테마/폰트)만 변경. credential/identity/operator/sandbox/hooks/workflow subsystem 미접촉이라 RFC 대상 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
