### PR TITLE
test(dashboard): lock dark-fantasy mermaid colors (follow-up to #21430)

### DIFF
--- a/dashboard/src/components/harness-health.test.ts
+++ b/dashboard/src/components/harness-health.test.ts
@@ -201,6 +201,15 @@ describe('HarnessHealth', () => {
     expect(mermaidSource(container)).toContain('판정 기록')
     expect(mermaidSource(container)).toContain('debounced reload')
 
+    // Dark-fantasy palette regression: mermaid classDefs (which cannot use
+    // CSS vars) carry the _ds Dark-Fantasy literals, not the retired
+    // navy/cyan/green set.
+    expect(mermaidSource(container)).toContain('#5a7a3a') // healthy stroke — status-ok (bile)
+    expect(mermaidSource(container)).toContain('#c4a265') // hub / active — brass accent
+    expect(mermaidSource(container)).not.toContain('#38bdf8') // retired cyan
+    expect(mermaidSource(container)).not.toContain('#0f172a') // retired navy
+    expect(mermaidSource(container)).not.toContain('#4ade80') // retired bright green
+
     const markup = container.innerHTML
     // Shared theme tokens reach the markup. KpiCell (post-StatCard swap)
     // emits `--color-fg-primary` via inline style; the rest of the


### PR DESCRIPTION
#21430 (dark-fantasy foundation) was admin-merged before its test-coverage gate fix landed. This adds the orphaned regression test: asserts the harness-health flow diagram emits the _ds Dark-Fantasy classDef colors (status-ok `#5a7a3a`, brass `#c4a265`) and not the retired navy/cyan/green. Test-only.

Follow-up to #21430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
