### PR TITLE
fix(keeper): WebSearch/WebFetch descriptor examples and Exclusive_external concurrency

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -89,8 +89,12 @@ Decide what to do based on the current world state below.
 ### Research evidence
 - Ground novel technical, policy, library, model, pricing, API, or industry-pattern claims with evidence before presenting them as fact.
 - Use code evidence for repo-local claims: search/read the relevant files and cite stable `path:line` references in the post or reply.
-- Use web evidence for external or current claims: call `WebSearch` with `includeContent: true` to get current sources plus keeper-readable `content_text` and raw per-result `page_content`; call `WebFetch` for a selected URL when you need deeper reading or a citation-ready page. These MASC-owned names are intentionally distinct from generic snake_case web tool names and from MASC backend ids.
+- Use web evidence for external or current claims: call `WebSearch` with `includeContent: true` to get current sources plus keeper-readable `content_text` and raw per-result `page_content`; call `WebFetch` for a selected URL when you need deeper reading or a citation-ready page. These MASC-owned names (`WebSearch`, `WebFetch`) are the exact tool names to use; do not use snake_case variants such as `web_search` or `masc_web_search`.
 - If no source is found or the available tools cannot verify the claim, mark the claim with `[uncited]` instead of presenting it as verified.
+
+#### WebSearch / WebFetch concrete usage
+- `WebSearch` input: `{ "query": "OCaml 5.2 release date", "limit": 5, "includeContent": true }`. Only `query` is required; `limit` defaults to 5. With `includeContent: true`, the result includes a human-readable `content_text` summary and per-result `page_content` fields. Prefer reading `content_text` first; fetch individual URLs only when you need a citation or deeper read.
+- `WebFetch` input: `{ "url": "https://ocaml.org/news", "extractMode": "markdown", "maxChars": 5000 }`. Only `url` is required; `extractMode` defaults to `markdown`; `maxChars` defaults to 50000. The result contains `text`, `title`, `final_url`, `http_status`, and `truncated`.
 - When posting research-backed findings to the board, include a `sources` array on `keeper_board_post`/`masc_board_post` with `{url, quote}` entries. The board will persist those sources in metadata and append a Sources footer.
 
 ### Continuity across turns

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -86,7 +86,7 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | Workflow | Primary tools |
 |----------|---------------|
 | 의견 내기 / 토론 참여 | `keeper_board_post`, `keeper_board_comment` |
-| 최신 정보 / 외부 자료 확인 | `WebSearch` with `includeContent: true` for current results plus keeper-readable `content_text` and raw `page_content`; `WebFetch` for one selected URL when deeper reading is needed |
+| 최신 정보 / 외부 자료 확인 | `WebSearch { "query": "...", "includeContent": true }` for current results plus keeper-readable `content_text` and raw `page_content`; `WebFetch { "url": "..." }` for one selected URL when deeper reading or a citation is needed. See `config/prompts/keeper.unified.system.md` for exact input/output shape. |
 | 찬성 / 반대 신호 | `keeper_board_vote` |
 | 거버넌스 의견 제출 | retired as keeper tools; use board discussion/vote paths and governance dashboard read models |
 | 목표 / 계획 lifecycle | `masc_goal_list`, `masc_goal_upsert`, `masc_goal_transition`, `masc_goal_verify` |

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -262,12 +262,12 @@ let search_files_schema =
 let search_web_schema =
   object_schema
     ~required:[ "query" ]
-    [ property "query" "string" "Search query text for current public web information."
-    ; property "limit" "integer" "Maximum number of results to return."
+    [ property "query" "string" "Plain-text search query. Example: \"OCaml 5.2 release date\"."
+    ; property "limit" "integer" "Maximum number of results to return (1-10, default 5)."
     ; property
         "includeContent"
         "boolean"
-        "When true, best-effort fetch raw page_content for each result and add a keeper-readable content_text summary."
+        "When true, also fetch each result page and add raw page_content plus a human-readable content_text summary. Recommended for research."
     ; ( "contentMaxChars",
         `Assoc
           [ "type", `String "integer"
@@ -293,7 +293,7 @@ let fetch_web_schema =
     [ "type", `String "object"
     ; ( "properties",
         `Assoc
-          [ property "url" "string" "URL to fetch."
+          [ property "url" "string" "Full URL to fetch. Example: \"https://ocaml.org/news\"."
           ; ( "timeout",
               `Assoc
                 [ "type", `String "integer"
@@ -308,7 +308,7 @@ let fetch_web_schema =
                 ; "enum", `List [ `String "markdown"; `String "text" ]
                 ; "description",
                   `String
-                    "Output extraction mode. markdown preserves headings/lists/links; \
+                    "Output extraction mode. markdown (default) preserves headings/lists/links; \
                      text returns flattened plain text."
                 ; "default", `String "markdown"
                 ] )
@@ -593,8 +593,11 @@ let public_descriptors =
       ~public_name:"WebSearch"
       ~internal_name:"masc_web_search"
       ~description:
-        "Search the public web for current information using the MASC-owned \
-         tool-list alias, not a generic snake_case web tool id."
+        "Search the public web. Use exact tool name WebSearch. Example input: \
+         {\"query\":\"OCaml 5.2 release date\",\"limit\":5,\"includeContent\":true}. \
+         Returns result.results with title, url, snippet. With includeContent:true \
+         each result also has page_content and the response has a human-readable \
+         content_text summary. Do not use snake_case names like web_search."
       ~input_schema:search_web_schema
       ~policy:
         (policy
@@ -613,8 +616,11 @@ let public_descriptors =
       ~public_name:"WebFetch"
       ~internal_name:"masc_web_fetch"
       ~description:
-        "Fetch a selected web page for source-backed reading using the \
-         MASC-owned tool-list alias, not a generic snake_case web tool id."
+        "Fetch one web page for deeper reading. Use exact tool name WebFetch. \
+         Example input: {\"url\":\"https://ocaml.org/news\",\"extractMode\":\"markdown\",\"maxChars\":5000}. \
+         Returns text, title, final_url, http_status, truncated. Use after WebSearch \
+         when you need a citation or full article text. Do not use snake_case names \
+         like web_fetch."
       ~input_schema:fetch_web_schema
       ~policy:
         (policy

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -181,7 +181,12 @@ let make_tool_bundle
                  ~failure_counts
                  ()
              in
+             (* Public aliases (e.g. WebSearch) are not present in
+                [Tool_catalog] metadata, so derive the descriptor from the
+                internal name and pass it explicitly. *)
+             let oas_descriptor = Tool_bridge.oas_descriptor_of_masc_tool internal in
              Tool_bridge.oas_tool_of_masc
+               ?descriptor:oas_descriptor
                ~name:public_name
                ~description:descriptor.description
                ~input_schema:descriptor.input_schema

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -226,29 +226,57 @@ let oas_permission_of_masc_tool name =
     Some Agent_sdk.Tool.ReadOnly
   | _ -> None
 
+(** Tools that perform real external network I/O (not local file reads) should
+    never be marked [Parallel_read], even when read-only. Running multiple web
+    searches or fetches concurrently would violate provider rate limits and
+    abuse external services. Keep this list in sync with
+    [Keeper_tool_descriptor.public_descriptors] web aliases and their internal
+    names. *)
+let is_external_network_tool name =
+  List.mem name [ "masc_web_search"; "masc_web_fetch"; "WebSearch"; "WebFetch" ]
+;;
+
 let oas_descriptor_of_masc_tool name =
-  let descriptor_of_permission permission =
+  let permission =
+    match oas_permission_of_masc_tool name with
+    | Some _ as p -> p
+    | None ->
+      (* Public aliases such as WebSearch/WebFetch do not appear in
+         [Tool_catalog] metadata, but they still need a descriptor so the
+         OAS runtime does not default them to Sequential_workspace and so
+         they are never classified as Parallel_read. *)
+      if is_external_network_tool name
+      then Some Agent_sdk.Tool.ReadOnly
+      else None
+  in
+  let descriptor_of_permission perm =
     let mutation_class, concurrency_class =
-      match permission with
+      match perm with
+      | Agent_sdk.Tool.ReadOnly when is_external_network_tool name ->
+        (* External read-only tools are not workspace-parallel: they hit
+           rate-limited remote APIs. Use [Exclusive_external] so the OAS
+           runtime runs them in isolation and flushes any parallel-read batch
+           before and after. *)
+        Some "external_effect", Some Agent_sdk.Tool.Exclusive_external
       | Agent_sdk.Tool.ReadOnly ->
-          Some "read_only", Some Agent_sdk.Tool.Parallel_read
+        Some "read_only", Some Agent_sdk.Tool.Parallel_read
       | Agent_sdk.Tool.Write ->
-          Some "workspace_mutating", Some Agent_sdk.Tool.Sequential_workspace
+        Some "workspace_mutating", Some Agent_sdk.Tool.Sequential_workspace
       | Agent_sdk.Tool.Destructive ->
-          Some "external_effect", Some Agent_sdk.Tool.Exclusive_external
+        Some "external_effect", Some Agent_sdk.Tool.Exclusive_external
     in
     {
       Agent_sdk.Tool.kind = Some "masc";
       mutation_class;
       concurrency_class;
-      permission = Some permission;
+      permission = Some perm;
       evidence_role = None;
       shell = None;
       notes = [];
       examples = [];
     }
   in
-  Option.map descriptor_of_permission (oas_permission_of_masc_tool name)
+  Option.map descriptor_of_permission permission
 
 let to_oas_typed_result (tr : Tool_result.result) : Agent_sdk.Types.tool_result =
   if Tool_result.is_success tr
@@ -281,14 +309,19 @@ let to_oas_typed_result (tr : Tool_result.result) : Agent_sdk.Types.tool_result 
         ~input_schema:schema_json
         (fun args -> handle_board_post ctx args)
     ]} *)
-let oas_tool_of_masc ~name ~description ~input_schema
+let oas_tool_of_masc ?descriptor ~name ~description ~input_schema
     handler : Agent_sdk.Tool.t =
   let parameters = params_of_json_schema input_schema in
-  let descriptor = oas_descriptor_of_masc_tool name in
+  let descriptor =
+    match descriptor with
+    | Some _ -> descriptor
+    | None -> oas_descriptor_of_masc_tool name
+  in
   let oas_handler json_args =
     to_oas_typed_result (handler json_args)
   in
   Agent_sdk.Tool.create ?descriptor ~name ~description ~parameters oas_handler
 
 let () =
-  Runtime_agent.set_oas_tool_of_masc_hook oas_tool_of_masc
+  Runtime_agent.set_oas_tool_of_masc_hook (fun ~name ~description ~input_schema handler ->
+    oas_tool_of_masc ~name ~description ~input_schema handler)

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -50,7 +50,16 @@ val params_of_json_schema : Yojson.Safe.t -> Agent_sdk.Types.tool_param list
 
 (** {1 OAS Tool.t Creation} *)
 
+val oas_descriptor_of_masc_tool : string -> Agent_sdk.Tool.descriptor option
+(** Derive an OAS [Tool.descriptor] from MASC [Tool_catalog] metadata.
+
+    Read-only tools that perform external network I/O (e.g. [masc_web_search],
+    [masc_web_fetch] and their public aliases) are mapped to
+    [Exclusive_external] rather than [Parallel_read] so the OAS runtime does
+    not fire concurrent requests against rate-limited remote APIs. *)
+
 val oas_tool_of_masc :
+  ?descriptor:Agent_sdk.Tool.descriptor ->
   name:string ->
   description:string ->
   input_schema:Yojson.Safe.t ->
@@ -60,4 +69,10 @@ val oas_tool_of_masc :
     JSON input schema, and typed handler function.
 
     The handler receives raw JSON args and returns a {!Tool_result.result}.
-    Conversion to OAS [tool_result] is applied automatically. *)
+    Conversion to OAS [tool_result] is applied automatically.
+
+    Pass an explicit [descriptor] to override the default derived from
+    [Tool_catalog] metadata. This is needed for public aliases whose
+    LLM-visible name (e.g. ["WebSearch"]) is not present in the metadata
+    table; the caller can compute the descriptor from the internal name
+    and supply it here. *)

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -1125,6 +1125,195 @@ let test_registered_dispatch_preserves_workflow_failure_class () =
              Yojson.Safe.Util.(member "error" json |> to_string)
              "Self-approval"))
 
+(* ── OAS descriptor concurrency class ────────────────────────
+
+   WebSearch/WebFetch hit external rate-limited APIs. They must not be
+   classified as [Parallel_read] even though they are read-only. *)
+
+let make_dummy_oas_tool name =
+  Masc.Tool_bridge.oas_tool_of_masc
+    ~name
+    ~description:"descriptor probe"
+    ~input_schema:
+      (`Assoc
+         [ "type", `String "object"
+         ; "properties", `Assoc []
+         ; "required", `List []
+         ])
+    (fun _ -> Tool_result.make_ok ~tool_name:name ~start_time:0.0 ~data:(`String "") ())
+;;
+
+let string_of_concurrency_class = function
+  | Agent_sdk.Tool.Parallel_read -> "parallel_read"
+  | Agent_sdk.Tool.Sequential_workspace -> "sequential_workspace"
+  | Agent_sdk.Tool.Exclusive_external -> "exclusive_external"
+;;
+
+let string_of_permission = function
+  | Agent_sdk.Tool.ReadOnly -> "read_only"
+  | Agent_sdk.Tool.Write -> "write"
+  | Agent_sdk.Tool.Destructive -> "destructive"
+;;
+
+let check_descriptor ~msg name expected_cc expected_perm =
+  let tool = make_dummy_oas_tool name in
+  match Agent_sdk.Tool.descriptor tool with
+  | None -> fail (Printf.sprintf "%s: descriptor missing for %s" msg name)
+  | Some d ->
+    let actual_cc =
+      match d.Agent_sdk.Tool.concurrency_class with
+      | Some cc -> string_of_concurrency_class cc
+      | None -> "none"
+    in
+    check string (msg ^ " concurrency_class") expected_cc actual_cc;
+    let actual_perm =
+      match d.Agent_sdk.Tool.permission with
+      | Some p -> string_of_permission p
+      | None -> "none"
+    in
+    check string (msg ^ " permission") expected_perm actual_perm
+;;
+
+let test_web_search_oas_descriptor_is_exclusive_external () =
+  check_descriptor ~msg:"masc_web_search" "masc_web_search" "exclusive_external" "read_only"
+;;
+
+let test_web_fetch_oas_descriptor_is_exclusive_external () =
+  check_descriptor ~msg:"masc_web_fetch" "masc_web_fetch" "exclusive_external" "read_only"
+;;
+
+let test_read_oas_descriptor_is_parallel_read () =
+  check_descriptor ~msg:"tool_read_file" "tool_read_file" "parallel_read" "read_only"
+;;
+
+let find_tool_by_name tools name =
+  List.find_opt
+    (fun (t : Agent_sdk.Tool.t) -> String.equal t.Agent_sdk.Tool.schema.Agent_sdk.Types.name name)
+    tools
+;;
+
+let check_bundle_concurrency ~msg tools name expected_cc =
+  match find_tool_by_name tools name with
+  | None -> fail (Printf.sprintf "%s: %s not in bundle" msg name)
+  | Some t ->
+    (match Agent_sdk.Tool.descriptor t with
+     | None -> fail (Printf.sprintf "%s: %s has no descriptor" msg name)
+     | Some d ->
+       let actual =
+         Option.fold
+           ~none:"none"
+           ~some:string_of_concurrency_class
+           d.Agent_sdk.Tool.concurrency_class
+       in
+       check string (msg ^ " concurrency_class") expected_cc actual)
+;;
+
+let test_public_alias_oas_descriptors () =
+  with_exec_fixture
+    "public_alias_oas_descriptors"
+    (fun ~config ~meta ~ctx_work:_ ->
+       let tools =
+         Masc.Keeper_tools_oas_bundle.make_tools
+           ~config
+           ~meta
+           ~ctx_snapshot:(make_ctx ())
+           ()
+       in
+       check_bundle_concurrency ~msg:"WebSearch" tools "WebSearch" "exclusive_external";
+       check_bundle_concurrency ~msg:"WebFetch" tools "WebFetch" "exclusive_external";
+       (* Read is a direct internal tool and is correctly classified as
+          [Parallel_read] by [Tool_bridge.oas_descriptor_of_masc_tool].
+          Grep is currently not marked read-only in [Tool_catalog], so it
+          carries no descriptor and defaults to sequential execution. *)
+       check_bundle_concurrency ~msg:"Read" tools "Read" "parallel_read")
+;;
+
+(* ── Parallel read execution ─────────────────────────────────
+
+   Confirm that two [Parallel_read] tools run concurrently and that
+   [Agent_tools.execute_tools] returns results in input order even when the
+   second tool finishes before the first. *)
+
+let make_delayed_read_tool clock name delay_ms =
+  let descriptor =
+    { Agent_sdk.Tool.kind = Some "test"
+    ; mutation_class = Some "read_only"
+    ; concurrency_class = Some Agent_sdk.Tool.Parallel_read
+    ; permission = Some Agent_sdk.Tool.ReadOnly
+    ; evidence_role = None
+    ; shell = None
+    ; notes = []
+    ; examples = []
+    }
+  in
+  Agent_sdk.Tool.create
+    ~descriptor
+    ~name
+    ~description:"Delayed read-only probe"
+    ~parameters:[]
+    (fun _args ->
+       Eio.Time.sleep clock (Float.of_int delay_ms /. 1000.0);
+       Ok { Agent_sdk.Types.content = name })
+;;
+
+let execute_tools_in_env env ~tools tool_uses =
+  let net = Eio.Stdenv.net env in
+  let config =
+    { Agent_sdk.Types.default_config with
+      Agent_sdk.Types.name = "parallel-read-test"
+    ; system_prompt = Some "test"
+    ; max_turns = 1
+    }
+  in
+  let agent = Agent_sdk.Agent.create ~net ~config ~tools () in
+  let opts = Agent_sdk.Agent.options agent in
+  let state = Agent_sdk.Agent.state agent in
+  Agent_sdk.Agent_tools.execute_tools
+    ~context:(Agent_sdk.Agent.context agent)
+    ~tools
+    ~hooks:opts.Agent_sdk.Agent.hooks
+    ~event_bus:opts.Agent_sdk.Agent.event_bus
+    ~tracer:opts.Agent_sdk.Agent.tracer
+    ~agent_name:state.Agent_sdk.Types.config.Agent_sdk.Types.name
+    ~turn_count:state.Agent_sdk.Types.turn_count
+    ~usage:state.Agent_sdk.Types.usage
+    ~approval:opts.Agent_sdk.Agent.approval
+    ~missing_approval_callback_policy:opts.Agent_sdk.Agent.missing_approval_callback_policy
+    tool_uses
+;;
+
+let test_parallel_read_tools_reorder_results () =
+  let tool_uses =
+    [ Agent_sdk.Types.ToolUse { id = "u-1"; name = "slow_read"; input = `Assoc [] }
+    ; Agent_sdk.Types.ToolUse { id = "u-2"; name = "fast_read"; input = `Assoc [] }
+    ]
+  in
+  let elapsed_ms, results =
+    Eio_main.run
+    @@ fun env ->
+    let clock = Eio.Stdenv.clock env in
+    let tools =
+      [ make_delayed_read_tool clock "slow_read" 150
+      ; make_delayed_read_tool clock "fast_read" 30
+      ]
+    in
+    let t0 = Unix.gettimeofday () in
+    let results = execute_tools_in_env env ~tools tool_uses in
+    let elapsed_ms = int_of_float ((Unix.gettimeofday () -. t0) *. 1000.0) in
+    (elapsed_ms, results)
+  in
+  match elapsed_ms, results with
+  | _, [ r1; r2 ] ->
+    check string "first result id" "u-1" r1.Agent_sdk.Agent_tools.tool_use_id;
+    check string "first result content" "slow_read" r1.Agent_sdk.Agent_tools.content;
+    check string "second result id" "u-2" r2.Agent_sdk.Agent_tools.tool_use_id;
+    check string "second result content" "fast_read" r2.Agent_sdk.Agent_tools.content;
+    (* If they ran sequentially the elapsed time would be at least 180 ms.
+       Allow generous slack for scheduler jitter on shared CI runners. *)
+    check bool "parallel read ran concurrently" true (elapsed_ms < 250)
+  | _ -> fail "expected exactly two tool execution results"
+;;
+
 (* ── Exec cache data structure tests ───────────────────────── *)
 
 let test_exec_cache_stats_json () =
@@ -1215,6 +1404,18 @@ let () =
     ("keeper_tools_list_json", [
       test_case "uses typed groups" `Quick
         test_keeper_tools_list_json_uses_typed_groups;
+    ]);
+    ("oas_descriptor", [
+      test_case "masc_web_search is Exclusive_external" `Quick
+        test_web_search_oas_descriptor_is_exclusive_external;
+      test_case "masc_web_fetch is Exclusive_external" `Quick
+        test_web_fetch_oas_descriptor_is_exclusive_external;
+      test_case "tool_read_file is Parallel_read" `Quick
+        test_read_oas_descriptor_is_parallel_read;
+      test_case "public aliases carry correct concurrency class" `Quick
+        test_public_alias_oas_descriptors;
+      test_case "parallel read tools reorder results" `Quick
+        test_parallel_read_tools_reorder_results;
     ]);
     ("exec_cache", [
       test_case "stats json" `Quick test_exec_cache_stats_json;


### PR DESCRIPTION
## Summary
- Ensure Keeper sees concrete JSON input/output examples for WebSearch/WebFetch in tool descriptors and system prompt.
- Enforce Exclusive_external concurrency for WebSearch/WebFetch (external API rate-limit safety).
- Forward OAS descriptors when registering public aliases so concurrency classification is preserved.
- Add dispatch-runtime tests covering descriptor classification, alias descriptors, and Parallel_read result ordering.

## Verification
- \+ Alcote.st test_keeper_tool_dispatch_runtime: 5 new descriptor tests pass.
- Full suite: 35 tests run, 2 pre-existing failures in tool_not_allowed_counter (unrelated).

## Related
- OAS companion PR: jeong-sik/oas#<number> (tool concurrency docs/examples).