### PR TITLE
fix(dashboard): prefer lifecycle phase over status so running keepers do not show Idle

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -73,6 +73,7 @@ const PHASE_LABEL_KO: Record<string, string> = {
   crashed: '비정상 종료',
   dead: '종료됨',
   zombie: '응답 없음',
+  idle: '유휴',
   unknown: '알 수 없음',
 }
 

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -172,7 +172,9 @@ export function keeperActivityDisplay(
 export function keeperDisplayStatus(keeper: Keeper | null | undefined, fallbackStatus?: string | null): string {
   if (keeper && isKeeperPaused(keeper)) return 'paused'
   const lifecycleStatus = keeperLifecycleStatus(keeper?.lifecycle_phase)
-  if (lifecycleStatus && lifecycleStatus !== 'running') return lifecycleStatus
+  // Honor the FSM phase first: a Running keeper whose status field says
+  // 'idle' should still read as running, not collapse to idle.
+  if (lifecycleStatus) return lifecycleStatus
   const status = keeper?.status ?? fallbackStatus
   const normalized = (status ?? '').trim().toLowerCase()
 


### PR DESCRIPTION
Fixes the issue where every keeper appeared as "Idle" in the workspace roster and chat header.

Root cause: `keeperDisplayStatus` in `lib/keeper-runtime-display.ts` mapped a `Running` lifecycle phase to `running`, but then intentionally fell through to the generic `status` field. When the backend populated `status: "idle"` even for running keepers, the display layer returned `idle` and the roster/chat header rendered it literally.

Changes:
- `lib/keeper-runtime-display.ts`: honor `lifecycle_phase` first; a `Running` phase now always returns `running`.
- `components/keeper-workspace/keeper-workspace-shared.ts`: add Korean label for `idle` (`유휴`) so any genuine idle state still reads nicely.

Test plan:
- `cd dashboard && npx tsc --noEmit --pretty`
- `npx vitest run src/lib/keeper-runtime-display.test.ts`
- `npx vitest run src/components/keeper-workspace/keeper-workspace-shared.test.ts`,timeout:120}