### PR TITLE
feat(dashboard): activate StyleSeed as default theme

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -34,6 +34,12 @@ describe('App v2 header chrome', () => {
     expect(app?.hasAttribute('data-surface')).toBe(true)
   })
 
+  it('sets the default StyleSeed theme on the dashboard root', () => {
+    renderApp()
+    const app = container.querySelector('.v2-app')
+    expect(app?.getAttribute('data-theme')).toBe('styleseed')
+  })
+
   it('renders v2 shell header and health strip scopes', () => {
     renderApp()
     expect(container.querySelector('header.v2-shell-header')).not.toBeNull()

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -267,6 +267,7 @@ export function App() {
   return html`
     <div
       class="v2-app flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--color-bg-page)] text-[var(--color-fg-primary)]"
+      data-theme="styleseed"
       data-widget-solo=${widgetSoloMode ? 'true' : 'false'}
       data-focus-mode=${focusMode ? 'true' : 'false'}
       data-keeper-detail-mode=${keeperDetailMode ? 'true' : 'false'}

--- a/dashboard/src/components/theme-switch.test.ts
+++ b/dashboard/src/components/theme-switch.test.ts
@@ -11,41 +11,57 @@ describe('ThemeSwitch', () => {
     window.history.replaceState(null, '', '/')
   })
 
-  it('renders DARK label by default', () => {
+  it('renders DARK label when no theme attribute is set', () => {
     const container = document.createElement('div')
     render(h(ThemeSwitch), container)
     expect(container.textContent).toContain('DARK')
   })
 
-  it('toggles to paper on click from default', () => {
+  it('renders SEED label when StyleSeed theme is active', () => {
+    document.documentElement.dataset.theme = 'styleseed'
+    const container = document.createElement('div')
+    render(h(ThemeSwitch), container)
+    expect(container.textContent).toContain('SEED')
+  })
+
+  it('toggles from styleseed to dark on click', () => {
+    document.documentElement.dataset.theme = 'styleseed'
+    window.history.replaceState(null, '', '/?theme=styleseed')
     const container = document.createElement('div')
     render(h(ThemeSwitch), container)
     const btn = container.querySelector('button')
     expect(btn).not.toBeNull()
     btn!.click()
-    expect(document.documentElement.dataset.theme).toBe('paper')
-    expect(localStorage.getItem('dashboardTheme')).toBe('paper')
-    expect(window.location.search).toContain('theme=paper')
+    expect(document.documentElement.dataset.theme).toBeUndefined()
+    expect(localStorage.getItem('dashboardTheme')).toBeNull()
+    expect(window.location.search).not.toContain('theme=')
   })
 
-  it('toggles back to dark on second click', () => {
-    document.documentElement.dataset.theme = 'paper'
-    window.history.replaceState(null, '', '/?theme=paper')
+  it('toggles from dark to styleseed on click', () => {
     const container = document.createElement('div')
     render(h(ThemeSwitch), container)
     const btn = container.querySelector('button')
     btn!.click()
-    expect(document.documentElement.dataset.theme).toBeUndefined()
-    expect(localStorage.getItem('dashboardTheme')).toBeNull()
-    expect(window.location.search).not.toContain('theme=paper')
+    expect(document.documentElement.dataset.theme).toBe('styleseed')
+    expect(localStorage.getItem('dashboardTheme')).toBe('styleseed')
+    expect(window.location.search).toContain('theme=styleseed')
+  })
+
+  it('has correct aria-label for styleseed', () => {
+    document.documentElement.dataset.theme = 'styleseed'
+    const container = document.createElement('div')
+    render(h(ThemeSwitch), container)
+    const btn = container.querySelector('button')
+    expect(btn!.getAttribute('aria-label')).toContain('StyleSeed')
+    expect(btn!.getAttribute('title')).toContain('StyleSeed')
   })
 
   it('has correct aria-label for default', () => {
     const container = document.createElement('div')
     render(h(ThemeSwitch), container)
     const btn = container.querySelector('button')
-    expect(btn!.getAttribute('aria-label')).toContain('Dark')
-    expect(btn!.getAttribute('title')).toContain('Dark')
+    expect(btn!.getAttribute('aria-label')).toContain('StyleSeed')
+    expect(btn!.getAttribute('title')).toContain('StyleSeed')
   })
 
   it('carries the v2 shell action marker', () => {
@@ -55,12 +71,16 @@ describe('ThemeSwitch', () => {
     expect(btn!.classList.contains('v2-shell-action')).toBe(true)
   })
 
-  it('has correct aria-label after toggling to paper', () => {
+  it('migrates paper to styleseed on click', () => {
+    document.documentElement.dataset.theme = 'paper'
+    window.history.replaceState(null, '', '/?theme=paper')
     const container = document.createElement('div')
     render(h(ThemeSwitch), container)
     const btn = container.querySelector('button')
     btn!.click()
-    expect(btn!.getAttribute('aria-label')).toContain('Paper')
-    expect(btn!.getAttribute('title')).toContain('Paper')
+    expect(document.documentElement.dataset.theme).toBe('styleseed')
+    expect(localStorage.getItem('dashboardTheme')).toBe('styleseed')
+    expect(window.location.search).toContain('theme=styleseed')
+    expect(window.location.search).not.toContain('theme=paper')
   })
 })

--- a/dashboard/src/components/theme-switch.ts
+++ b/dashboard/src/components/theme-switch.ts
@@ -1,9 +1,10 @@
-// ThemeSwitch — compact header toggle for opt-in paper theme (#8177).
+// ThemeSwitch — compact header theme toggle.
 //
-// Cycles between the default dark palette and the "paper" palette.
-// The actual token swap lives in styles/paper-theme.css; this component
-// only flips document.documentElement.dataset.theme and persists the
-// choice to localStorage so reloads are stable.
+// Cycles between the default StyleSeed palette and the legacy dark palette.
+// The actual token swaps live in styles/styleseed-theme.css and
+// styles/paper-theme.css; this component only flips
+// document.documentElement.dataset.theme and persists the choice to
+// localStorage so reloads are stable.
 //
 // The switch is intentionally unobtrusive — a 2-letter mono label in
 // the same visual register as BuildIdentityBadge and ConnectionStatus.
@@ -17,7 +18,9 @@ import { THEME_STORAGE_KEYS, THEME_SEARCH_PARAM, type ThemeId } from '../lib/the
 
 function readDomTheme(): ThemeId {
   const attr = document.documentElement.dataset.theme
-  return attr === 'paper' ? 'paper' : null
+  if (attr === 'styleseed') return 'styleseed'
+  if (attr === 'paper') return 'paper'
+  return null
 }
 
 // Single source of truth: mirrors the DOM attribute so Preact renders
@@ -48,7 +51,7 @@ function applyTheme(next: ThemeId): void {
 
 function syncThemeSearchParam(next: ThemeId): void {
   const url = new URL(window.location.href)
-  if (next === 'paper') {
+  if (next === 'styleseed' || next === 'paper') {
     url.searchParams.set(THEME_SEARCH_PARAM, next)
   } else {
     url.searchParams.delete(THEME_SEARCH_PARAM)
@@ -57,21 +60,30 @@ function syncThemeSearchParam(next: ThemeId): void {
 }
 
 function toggleTheme(): void {
-  applyTheme(currentTheme.value === 'paper' ? null : 'paper')
+  applyTheme(currentTheme.value === 'styleseed' ? null : 'styleseed')
 }
 
-const LABEL: Record<'default' | 'paper', string> = {
+const LABEL: Record<'default' | 'styleseed' | 'paper', string> = {
   default: 'DARK',
+  styleseed: 'SEED',
   paper: 'PAPER',
 }
 
-const TITLE: Record<'default' | 'paper', string> = {
-  default: '현재 테마: Dark · 클릭하여 Paper 테마로 전환',
-  paper: '현재 테마: Paper · 클릭하여 Dark 테마로 전환',
+const TITLE: Record<'default' | 'styleseed' | 'paper', string> = {
+  default: '현재 테마: Dark · 클릭하여 StyleSeed 테마로 전환',
+  styleseed: '현재 테마: StyleSeed · 클릭하여 Dark 테마로 전환',
+  paper: '현재 테마: Paper · 클릭하여 StyleSeed 테마로 전환',
 }
 
 export function ThemeSwitch() {
-  const key = currentTheme.value === 'paper' ? 'paper' : 'default'
+  // Re-sync with the DOM on every render so external bootstrapping (main.ts)
+  // and tests that set dataset.theme after module load see the correct label.
+  const domTheme = readDomTheme()
+  if (currentTheme.value !== domTheme) {
+    currentTheme.value = domTheme
+  }
+
+  const key = currentTheme.value === 'styleseed' ? 'styleseed' : currentTheme.value === 'paper' ? 'paper' : 'default'
   return html`
     <button
       type="button"

--- a/dashboard/src/lib/theme.ts
+++ b/dashboard/src/lib/theme.ts
@@ -16,4 +16,4 @@ export const THEME_STORAGE_KEYS = ['dashboardTheme', 'masc-theme-v2'] as const
 
 export const THEME_SEARCH_PARAM = 'theme'
 
-export type ThemeId = 'paper' | null
+export type ThemeId = 'styleseed' | 'paper' | null

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -51,6 +51,10 @@ import './styles/ops.css'
 import './styles/tools.css'
 import './styles/provider-matrix.css'
 import './styles/paper-theme.css'
+
+// StyleSeed design-system theme — default light palette.
+import './styles/styleseed-theme.css'
+
 import './styles/keeper-workspace.css'
 import './styles/copilot-dock.css'
 import './styles/keeper-turn-inspector.css'
@@ -87,13 +91,15 @@ import { startNavTelemetry } from './lib/nav-telemetry'
 import { THEME_STORAGE_KEYS, THEME_SEARCH_PARAM, type ThemeId } from './lib/theme'
 
 function normalizeTheme(raw: string | null): ThemeId {
-  if (raw === 'paper' || raw === 'light') {
+  if (raw === 'styleseed' || raw === 'light') {
+    return 'styleseed'
+  }
+  if (raw === 'paper') {
     return 'paper'
   }
   // Preserve compatibility with existing callers that may send dark-themed values
-  // while keeping the default dashboard branch at the non-paper
-  // baseline (`dark-fantasy` in the generated token stack).
-  if (raw === 'dark' || raw === 'dark-fantasy' || raw === null || raw === '') {
+  // while treating explicit dark values as an opt-out to the legacy palette.
+  if (raw === 'dark' || raw === 'dark-fantasy') {
     return null
   }
   return null
@@ -101,7 +107,7 @@ function normalizeTheme(raw: string | null): ThemeId {
 
 function persistTheme(theme: ThemeId): void {
   try {
-    if (theme === 'paper') {
+    if (theme === 'styleseed' || theme === 'paper') {
       THEME_STORAGE_KEYS.forEach((key) => localStorage.setItem(key, theme))
     } else {
       THEME_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key))
@@ -122,11 +128,13 @@ function resolveTheme(): ThemeId {
       if (stored) return normalizeTheme(stored)
     }
   } catch { /* access denied */ }
-  return null
+  return 'styleseed'
 }
 
 function applyTheme(theme: ThemeId): void {
-  if (theme === 'paper') {
+  if (theme === 'styleseed') {
+    document.documentElement.dataset.theme = 'styleseed'
+  } else if (theme === 'paper') {
     document.documentElement.dataset.theme = 'paper'
   } else {
     delete document.documentElement.dataset.theme

--- a/dashboard/src/styles/styleseed-theme.css
+++ b/dashboard/src/styles/styleseed-theme.css
@@ -4,9 +4,15 @@
    Does NOT override existing dark-fantasy / v2 tokens unless active.
    ════════════════════════════════════════════════════════════════ */
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
+
 [data-theme="styleseed"] {
+  color-scheme: light;
+
   /* Brand accent — single key color; everything else grayscale */
   --brand: #721FE5;
+  --brand-dim: #5543C7;
+  --brand-wash: rgba(107, 92, 231, 0.10);
 
   /* Background & surfaces */
   --background: #FAFAFA;
@@ -15,6 +21,14 @@
   --surface-subtle: #FAFAF9;
   --surface-muted: #E8E6E1;
 
+  /* StyleSeed palette aliases */
+  --ss-page: #FAFAFA;
+  --ss-card: #FFFFFF;
+  --ss-card-raised: #FFFFFF;
+  --ss-card-hover: #F5F5F5;
+  --ss-surface: #F5F5F5;
+  --ss-sunken: #EFEFEF;
+
   /* Text hierarchy — no pure black */
   --text-primary: #3C3C3C;
   --text-secondary: #6B6B6B;
@@ -22,15 +36,19 @@
   --text-disabled: #BDBDBD;
   --icon-default: #6B6B6B;
 
-  /* Status / UI colors */
-  --success: #6B9B7A;
-  --destructive: #D4183D;
-  --warning: #D97706;
-  --info: #3B82F6;
+  --ss-text-strong: #2A2A2A;
+  --ss-text-primary: #3C3C3C;
+  --ss-text-secondary: #6A6A6A;
+  --ss-text-tertiary: #7A7A7A;
+  --ss-text-disabled: #9B9B9B;
 
   /* Borders */
   --border: #E8E6E1;
   --card-border: none;
+
+  --ss-border-1: rgba(0, 0, 0, 0.06);
+  --ss-border-2: rgba(0, 0, 0, 0.08);
+  --ss-border-3: rgba(0, 0, 0, 0.12);
 
   /* Brand tint for selected rows / active surfaces */
   --brand-tint: #F0E8FF;
@@ -38,12 +56,21 @@
   /* Alert badge */
   --alert-badge: #FF4444;
 
+  /* Status / UI colors */
+  --success: #6B9B7A;
+  --destructive: #D4183D;
+  --warning: #D97706;
+  --info: #3B82F6;
+
   /* Shadows — low opacity, barely visible */
   --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.04);
   --shadow-card-hover: 0 2px 4px rgba(0, 0, 0, 0.08);
   --shadow-elevated: 0 4px 12px rgba(0, 0, 0, 0.08);
   --shadow-modal: 0 8px 24px rgba(0, 0, 0, 0.12);
   --shadow-button: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --shadow-panel: 0 1px 3px rgba(0, 0, 0, 0.04);
+  --shadow-raised: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-glow: none;
 
   /* Shape */
   --radius: 0.625rem;
@@ -51,6 +78,96 @@
   /* Type stack — Inter for Latin, Pretendard for CJK */
   --font-sans:
     'Inter', 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
+
+  /* v2 token ladder aliases */
+  --color-bg-0: var(--ss-page);
+  --color-bg-1: var(--ss-surface);
+  --color-bg-2: var(--ss-card);
+  --color-bg-3: var(--ss-card-raised);
+  --color-bg-4: var(--ss-card-hover);
+
+  --color-bg-page: var(--ss-page);
+  --color-bg-surface: var(--ss-surface);
+  --color-bg-panel-alt: var(--ss-card);
+  --color-bg-elevated: var(--ss-card-raised);
+  --color-bg-hover: var(--ss-card-hover);
+
+  --color-fg-1: var(--ss-text-strong);
+  --color-fg-2: var(--ss-text-primary);
+  --color-fg-3: var(--ss-text-secondary);
+  --color-fg-4: var(--ss-text-disabled);
+
+  --color-fg-primary: var(--ss-text-strong);
+  --color-fg-secondary: var(--ss-text-primary);
+  --color-fg-muted: var(--ss-text-secondary);
+  --color-fg-disabled: var(--ss-text-disabled);
+
+  --color-line-1: var(--ss-border-2);
+  --color-line-2: var(--ss-border-3);
+  --color-line-3: var(--ss-border-1);
+
+  --color-border-default: var(--ss-border-2);
+  --color-border-strong: var(--ss-border-3);
+  --color-border-divider: var(--ss-border-1);
+
+  /* Brass aliases → brand accent */
+  --color-brass-1: var(--brand);
+  --color-brass-2: color-mix(in srgb, var(--brand) 80%, black);
+  --color-brass-3: var(--brand-dim);
+  --color-brass-soft: var(--brand-wash);
+  --color-brass-glow: 107 92 231;
+  --color-brass-fg: var(--brand);
+
+  --color-accent: var(--brand);
+  --color-accent-soft: var(--brand-wash);
+  --color-accent-fg: var(--brand);
+  --color-accent-fg-dim: var(--brand-dim);
+  --color-accent-glow: 107 92 231;
+
+  /* Status ladder */
+  --color-ok: var(--success);
+  --color-warn: var(--warning);
+  --color-err: var(--destructive);
+  --color-info: var(--info);
+
+  --color-status-ok: var(--success);
+  --color-status-warn: var(--warning);
+  --color-status-err: var(--destructive);
+  --color-status-info: var(--info);
+
+  --color-ok-glow: 107 155 122;
+  --color-warn-glow: 217 119 6;
+  --color-err-glow: 212 24 61;
+  --color-info-glow: 59 130 246;
+
+  --color-ok-soft: rgba(107, 155, 122, 0.10);
+  --color-warn-soft: rgba(217, 119, 6, 0.12);
+  --color-err-soft: rgba(212, 24, 61, 0.12);
+  --color-info-soft: rgba(59, 130, 246, 0.12);
+
+  /* Legacy aliases */
+  --ok: var(--success);
+  --warn: var(--warning);
+  --bad: var(--destructive);
+  --err: var(--destructive);
+
+  --ok-10: rgba(107, 155, 122, 0.10);
+  --ok-20: rgba(107, 155, 122, 0.20);
+  --warn-10: rgba(217, 119, 6, 0.10);
+  --warn-20: rgba(217, 119, 6, 0.20);
+  --bad-10: rgba(212, 24, 61, 0.10);
+  --bad-20: rgba(212, 24, 61, 0.20);
+  --bad-soft: rgba(212, 24, 61, 0.12);
+
+  --accent: var(--brand);
+  --accent-10: var(--brand-wash);
+  --accent-15: rgba(114, 31, 229, 0.15);
+  --accent-20: rgba(107, 92, 231, 0.20);
+  --accent-soft: var(--brand-wash);
+
+  --color-card: var(--ss-card);
+  --color-card-border: var(--ss-border-2);
 }
 
 /* ── Dark mode mapping ───────────────────────────────────────────
@@ -96,4 +213,30 @@
   --shadow-elevated: none;
   --shadow-modal: none;
   --shadow-button: none;
+}
+
+/* v2 shell chrome overrides — v2-shell.css pins hardcoded dark-fantasy
+   tokens on these selectors, so we re-map them to the StyleSeed light
+   palette when the theme is active. */
+[data-theme="styleseed"] .v2-shell-rail,
+[data-theme="styleseed"] .v2-status-tray,
+[data-theme="styleseed"] .v2-shell-header,
+[data-theme="styleseed"] .v2-health-strip {
+  --v2-ink:         var(--ss-page);
+  --v2-velvet:      var(--ss-surface);
+  --v2-card:        var(--ss-card);
+  --v2-card-soft:   var(--ss-card-raised);
+  --v2-raised:      var(--ss-card-hover);
+  --v2-border-soft: var(--ss-border-1);
+  --v2-border:      var(--ss-border-2);
+  --v2-border-strong:var(--ss-border-3);
+  --v2-text:        var(--ss-text-secondary);
+  --v2-text-bright: var(--ss-text-primary);
+  --v2-text-dim:    var(--ss-text-tertiary);
+  --v2-text-faint:  var(--ss-text-disabled);
+  --v2-accent-brass:var(--brand);
+  --v2-accent-brass-dim: var(--brand-dim);
+  --v2-ok:          var(--success);
+  --v2-warn:        var(--warning);
+  --v2-bad:         var(--destructive);
 }


### PR DESCRIPTION
## Summary
Activates StyleSeed as the default dashboard theme.

## What changed
- `dashboard/src/styles/styleseed-theme.css`: StyleSeed token ladder that overrides dark-fantasy under `[data-theme="styleseed"]`.
- `dashboard/src/main.ts`: imports StyleSeed theme; `resolveTheme()` defaults to `'styleseed'`.
- `dashboard/src/lib/theme.ts`: `ThemeId` expanded to include `'styleseed'`.
- `dashboard/src/components/theme-switch.ts`: recognizes StyleSeed and toggles between StyleSeed and legacy dark.
- `dashboard/src/app.ts`: adds `data-theme="styleseed"` to the dashboard root.
- Tests updated for the new default.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `app.test.ts` + `theme-switch.test.ts` ✅ 24/24
- Related theme tests ✅ 116/116

## Notes
- Legacy dark and paper themes remain available.
