### PR TITLE
fix(dashboard): wire real compaction API and surface context fields in rail

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -21,6 +21,20 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
   }
 })
 
+vi.mock('../../api/mcp', () => ({
+  callMcpTool: vi.fn().mockResolvedValue(JSON.stringify({
+    before_tokens: 124000,
+    after_tokens: 62000,
+    saved_tokens: 62000,
+    phase: 'Running',
+    trigger: 'manual_operator_compact',
+  })),
+}))
+
+vi.mock('../common/toast', () => ({
+  showToast: vi.fn(),
+}))
+
 function mkKeeper(partial: Partial<Keeper>): Keeper {
   return { name: 'masc-improver', status: 'running', ...partial } as Keeper
 }
@@ -125,16 +139,13 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('압축 중…')
     expect((container.querySelector('.kw-compact-btn') as HTMLButtonElement).disabled).toBe(true)
 
-    await vi.advanceTimersByTimeAsync(1500)
     await flushPromises()
 
     expect(container.textContent).toContain('컴팩션 스냅샷')
-    expect(container.textContent).toContain('활성 태스크 소유권·상태')
-    expect(container.textContent).toContain('초기 분석 turn')
-    expect(container.textContent).toContain('중복된 사고')
+    expect(container.textContent).toContain('124.0k → 62.0k tok')
+    expect(container.textContent).toContain('절약 62.0k tok')
+    expect(container.textContent).toContain('manual_operator_compact')
     expect(container.textContent).toContain('완료')
-    // Live ratio override is lower than the original 62%.
-    expect(container.textContent).not.toContain('62%')
 
     await vi.advanceTimersByTimeAsync(2600)
     await flushPromises()
@@ -143,28 +154,23 @@ describe('KeeperWorkspaceRail', () => {
   })
 
   it('accumulates multiple compaction snapshots', async () => {
-    vi.useFakeTimers()
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
 
     for (let i = 0; i < 2; i++) {
       fireEvent.click(container.querySelector('.kw-compact-btn') as HTMLButtonElement)
-      await vi.advanceTimersByTimeAsync(1500)
       await flushPromises()
     }
 
     expect(container.querySelectorAll('.kw-cmp-snap').length).toBe(2)
   })
 
-  it('resets snapshots and live ratio when the keeper changes', async () => {
-    vi.useFakeTimers()
+  it('resets snapshots when the keeper changes', async () => {
     const { container, rerender } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
 
     fireEvent.click(container.querySelector('.kw-compact-btn') as HTMLButtonElement)
-    await vi.advanceTimersByTimeAsync(1500)
     await flushPromises()
 
     expect(container.querySelectorAll('.kw-cmp-snap').length).toBe(1)
-    expect(container.textContent).not.toContain('62%')
 
     const other = mkKeeper({ name: 'other-keeper', context_ratio: 0.3, context_tokens: 60000, context_max: 200000 })
     rerender(html`<${KeeperWorkspaceRail} keeper=${other} onToggleDetail=${() => {}} />`)

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -11,12 +11,15 @@ import { tasks } from '../../store'
 import type { Keeper, Task } from '../../types'
 import { keeperModelLabel, keeperRuntimeLabel } from './keeper-workspace-shared'
 import { KeeperWorkspaceRecentTools } from './keeper-workspace-tool-calls'
+import { callMcpTool } from '../../api/mcp'
+import { showToast } from '../common/toast'
+import { asNumber, asString, isRecord } from '../common/normalize'
+import { formatDuration } from '../../lib/format-time'
 
 const COMPACT_AT = 85 // auto-compaction threshold (%) — matches runtime default
 
-function contextPercent(keeper: Keeper, liveOverride: number | null): number {
-  const base = keeper.context_ratio ?? keeper.context?.context_ratio ?? 0
-  const ratio = liveOverride ?? base
+function contextPercent(keeper: Keeper): number {
+  const ratio = keeper.context_ratio ?? keeper.context?.context_ratio ?? 0
   return Math.max(0, Math.min(100, Math.round(ratio * 100)))
 }
 
@@ -80,26 +83,23 @@ function AttentionSection({ keeper }: { keeper: Keeper }): VNode | null {
   `
 }
 
-type CompactionCounts = { tok: number; msgs: number; traces: number }
-
 type CompactionSnapshot = {
   id: string
   at: string
   trigger: string
-  runtime: string | null
-  before: CompactionCounts
-  after: CompactionCounts
-  kept: string[]
-  summarized: string[]
-  dropped: string[]
+  phase: string | null
+  beforeTokens: number
+  afterTokens: number
+  savedTokens: number
 }
-
-const DEFAULT_KEPT = ['활성 태스크 소유권·상태', '직전 3턴 원문', 'namespace 스냅샷']
-const DEFAULT_SUMMARIZED = ['초기 분석 turn → 핵심 결론 1줄 요약', '도구 호출 로그 → 성공/실패 집계만 보존']
-const DEFAULT_DROPPED = ['중복된 사고(thinking) 블록', '취소된 후보 경로 trace']
 
 function nowHM(): string {
   return new Date().toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false })
+}
+
+function formatAgo(seconds: number | null | undefined): string | null {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) return null
+  return `${formatDuration(seconds)} 전`
 }
 
 type CompactButtonState = 'idle' | 'busy' | 'done'
@@ -120,24 +120,21 @@ function SnapshotList({ snapshots }: { snapshots: CompactionSnapshot[] }): VNode
     <div class="kw-cmp-list">
       <h5>컴팩션 스냅샷</h5>
       ${snapshots.map(s => {
-        const reduction = Math.round((1 - s.after.tok / s.before.tok) * 100)
+        const reduction = s.beforeTokens > 0
+          ? Math.round((1 - s.afterTokens / s.beforeTokens) * 100)
+          : 0
         return html`
           <div class="kw-cmp-snap" key=${s.id}>
             <div class="kw-cmp-snap-h">
-              <span class="kw-cmp-snap-id">${s.id}</span>
-              <span class="kw-cmp-snap-at">${s.at}</span>
+              <span class="kw-cmp-snap-id">${s.at}</span>
+              ${s.phase ? html`<span class="kw-cmp-snap-phase">${s.phase}</span>` : null}
               <span class="kw-cmp-snap-reduction">-${reduction}%</span>
             </div>
             <div class="kw-cmp-snap-stats">
-              <span>tok ${formatK(s.before.tok)}→${formatK(s.after.tok)}</span>
-              <span>msg ${s.before.msgs}→${s.after.msgs}</span>
-              <span>trace ${s.before.traces}→${s.after.traces}</span>
+              <span>${formatK(s.beforeTokens) ?? '—'} → ${formatK(s.afterTokens) ?? '—'} tok</span>
+              <span>절약 ${formatK(s.savedTokens) ?? '—'} tok</span>
             </div>
-            <div class="kw-cmp-snap-lists">
-              <div><b>유지</b> ${s.kept.join(', ')}</div>
-              <div><b>요약</b> ${s.summarized.join(', ')}</div>
-              <div><b>폐기</b> ${s.dropped.join(', ')}</div>
-            </div>
+            <div class="kw-cmp-snap-trigger text-2xs text-[var(--color-fg-muted)]">${s.trigger}</div>
           </div>
         `
       })}
@@ -146,54 +143,60 @@ function SnapshotList({ snapshots }: { snapshots: CompactionSnapshot[] }): VNode
 }
 
 function ContextSection({ keeper }: { keeper: Keeper }): VNode {
-  const [liveRatio, setLiveRatio] = useState<number | null>(null)
   const [snapshots, setSnapshots] = useState<CompactionSnapshot[]>([])
   const [compactState, setCompactState] = useState<CompactButtonState>('idle')
 
   useEffect(() => {
-    setLiveRatio(null)
     setSnapshots([])
     setCompactState('idle')
   }, [keeper.name])
 
-  const pct = contextPercent(keeper, liveRatio)
+  const pct = contextPercent(keeper)
   const hot = pct >= COMPACT_AT
   const max = contextMax(keeper)
   const baseTokens = keeper.context_tokens ?? keeper.context?.context_tokens ?? null
-  const effTokens = liveRatio != null && max != null ? Math.round(liveRatio * max) : baseTokens
-  const tokens = formatK(effTokens)
+  const tokens = formatK(baseTokens)
   const maxLabel = formatK(max)
+  const msgCount = keeper.context?.message_count ?? null
+  const hasCheckpoint = keeper.context?.has_checkpoint ?? null
+  const contextSource = keeper.context_source ?? keeper.context?.source ?? null
+  const compactionCount = keeper.compaction_count ?? null
+  const lastCompactionAgo = formatAgo(keeper.last_compaction_ago_s)
+  const lastCompactionSaved = formatK(keeper.last_compaction_saved_tokens)
 
-  const runCompact = useCallback(() => {
+  const runCompact = useCallback(async () => {
     if (compactState === 'busy') return
     setCompactState('busy')
-    window.setTimeout(() => {
-      const currentRatio = liveRatio ?? (keeper.context_ratio ?? keeper.context?.context_ratio ?? 0)
-      const afterRatio = Math.max(0.16, +(currentRatio * (0.36 + Math.random() * 0.1)).toFixed(3))
-      const contextMaxValue = max ?? 200_000
-      const bTok = Math.round(currentRatio * contextMaxValue)
-      const aTok = Math.round(afterRatio * contextMaxValue)
-      const bMsg = Math.max(8, Math.round(currentRatio * 120))
-      const aMsg = Math.max(4, Math.round(bMsg * 0.45))
-      const bTr = Math.max(3, Math.round(currentRatio * 24))
-      const aTr = Math.max(1, Math.round(bTr * 0.4))
+    try {
+      const text = await callMcpTool('masc_keeper_compact', { name: keeper.name })
+      let parsed: unknown = null
+      try {
+        parsed = JSON.parse(text)
+      } catch {
+        parsed = null
+      }
+      const record = isRecord(parsed) ? parsed : null
+      const beforeTokens = asNumber(record?.before_tokens) ?? 0
+      const afterTokens = asNumber(record?.after_tokens) ?? 0
+      const savedTokens = asNumber(record?.saved_tokens) ?? Math.max(0, beforeTokens - afterTokens)
       const snapshot: CompactionSnapshot = {
         id: `cmp-${Date.now()}`,
         at: nowHM(),
-        trigger: '수동 — operator 요청 (지금 컴팩트)',
-        runtime: keeper.runtime_canonical ?? null,
-        before: { tok: bTok, msgs: bMsg, traces: bTr },
-        after: { tok: aTok, msgs: aMsg, traces: aTr },
-        kept: [...DEFAULT_KEPT],
-        summarized: [...DEFAULT_SUMMARIZED],
-        dropped: [...DEFAULT_DROPPED],
+        trigger: asString(record?.trigger) ?? '수동 컴팩트',
+        phase: asString(record?.phase) ?? null,
+        beforeTokens,
+        afterTokens,
+        savedTokens,
       }
       setSnapshots(prev => [snapshot, ...prev])
-      setLiveRatio(afterRatio)
       setCompactState('done')
       window.setTimeout(() => setCompactState('idle'), 2600)
-    }, 1500)
-  }, [compactState, keeper.context_ratio, keeper.context?.context_ratio, keeper.runtime_canonical, liveRatio, max])
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '컴팩트 요청 실패'
+      showToast(message, 'error')
+      setCompactState('idle')
+    }
+  }, [compactState, keeper.name])
 
   return html`
     <div class="kw-sec v2-monitoring-panel">
@@ -217,8 +220,16 @@ function ContextSection({ keeper }: { keeper: Keeper }): VNode {
               <span class="lbl">사용 / 전체 윈도우</span>
             </div>`
           : null}
+        <div class="mt-2 grid grid-cols-2 gap-2 text-2xs text-[var(--color-fg-secondary)]">
+          ${msgCount !== null ? html`<span>메시지 ${msgCount}개</span>` : null}
+          ${hasCheckpoint === true ? html`<span>체크포인트 보유</span>` : null}
+          ${contextSource ? html`<span>출처 ${contextSource}</span>` : null}
+          ${compactionCount !== null ? html`<span>누적 컴팩트 ${compactionCount}회</span>` : null}
+          ${lastCompactionAgo ? html`<span>마지막 컴팩트 ${lastCompactionAgo}</span>` : null}
+          ${lastCompactionSaved ? html`<span>절약 ${lastCompactionSaved} tok</span>` : null}
+        </div>
         <div class="kw-cmp-actions">
-          <${CompactButton} state=${compactState} onClick=${runCompact} />
+          <${CompactButton} state=${compactState} onClick=${() => { void runCompact() }} />
         </div>
         <${SnapshotList} snapshots=${snapshots} />
       </div>


### PR DESCRIPTION
Part of the dashboard wiring audit.

Fixes the context/compaction rail so it no longer shows fabricated data:

- Replaces the mocked `runCompact` (which used `Math.random()` and hard-coded kept/summarized/dropped arrays) with a real `callMcpTool("masc_keeper_compact", { name: keeper.name })` call.
- Snapshot data shape now matches the backend response: `before_tokens`, `after_tokens`, `saved_tokens`, `phase`, `trigger`.
- Removes the local `liveRatio` override that was hiding the real backend context ratio.
- Surfaces real context/compaction metadata: message count, checkpoint status, context source, compaction count, last compaction age, and saved tokens.
- Guards snapshot reduction math against division by zero.
- Updates tests to mock the MCP tool and assert real response values.

Test plan:
- `cd dashboard && npx tsc --noEmit --pretty`
- `npm run build`
- `npx vitest run src/components/keeper-workspace/keeper-workspace-rail.test.ts`
- `npx vitest run src/app.test.ts`,timeout:120}
 
---
 
## 🔄 AS-IS vs TO-BE 구조적 개선점 분석 (Structural Improvements)
 
| 비교 항목 | AS-IS (변경 전) | TO-BE (변경 후) |
| :--- | :--- | :--- |
| **컴팩션 트리거** | 클라이언트 내부 `Math.random()` 및 하드코딩된 배열 반환 (순수 무상태 모킹) | `callMcpTool("masc_keeper_compact", { name })` 호출을 통한 실제 백엔드 IPC 통신 |
| **컨텍스트 메타데이터** | 로컬 `liveRatio` 오버라이드로 백엔드 상태 은폐 | 백엔드 응답 구조(`before_tokens`, `after_tokens`, `saved_tokens`, `phase`, `trigger`) 직접 매핑 |
| **상태 동기화 모델** | UI 컴포넌트 내부 스코프에 국한된 가상 상태 (동시성 이슈 불가) | OCaml/Eio 백엔드의 실제 힙 상태와 MCP 프로토콜을 통한 비동기 양방향 동기화 |
| **에러 처리** | `Math.random()` 호출이므로 실패 불가 (예외 경로 없음) | 네트워크/IPC 파이프 폭발, Eio 스위치 취소, 백엔드 프로세스 크래시 등에 대한 예외 경로 노출 |
| **테스트 검증** | 하드코딩된 가짜 값 주입 및 스냅샷 검증 | `callMcpTool` 모킹을 통한 응답 파싱 및 0으로 나누기 방어 로직 검증 |

```mermaid
sequenceDiagram
    participant UI as Dashboard (TypeScript)
    participant MCP as MCP Protocol Layer
    participant BE as Backend (OCaml/Eio)

    rect rgb(255, 230, 230)
        Note over UI: AS-IS: Fabricated State
        UI->>UI: Math.random() 실행
        UI->>UI: 하드코딩된 kept/summarized 배열 생성
        UI->>UI: 로컬 liveRatio 강제 오버라이드
        Note over UI: 백엔드 상태와 완전히 동기화 안 됨
    end

    rect rgb(230, 255, 230)
        Note over UI,BE: TO-BE: Real IPC Wiring
        UI->>MCP: callMcpTool("masc_keeper_compact", { name })
        MCP->>BE: Eio 스위치 경로로 컴팩션 요청 전달
        BE->>BE: 멀티코어 환경에서 힙 락 획득 및 컨텍스트 압축 수행
        BE-->>MCP: { before_tokens, after_tokens, saved_tokens, phase, trigger }
        MCP-->>UI: JSON 페이로드 반환
        UI->>UI: 0으로 나누기 가드 처리 후 상태 업데이트
    end
```

## ⚡ Adversarial Critique & Vulnerability Report (적대적 비판 및 취약성 검증)

이 PR은 단순히 "목(Mock)을 실제 API로 교체"했다는 치명적인 착각에 빠져 있습니다. 클라이언트 상태를 순수 함수적 환경에서 OCaml/Eio가 지배하는 비동기 멀티코어 환경으로 강제 전환하면서, 동시성 제어, 자원 수명 주기, 멱등성 보장이라는 핵심적인 비기능 요구사항이 완전히 무시되었습니다. 아래 3가지 치명적 결함을 명확히 지적합니다.

### 1. 치명적인 Race Condition 및 Eio 스위치 취소 무시 (동시성 경쟁 상태)
`keeper-workspace-rail.ts`에서 `callMcpTool("masc_keeper_compact", ...)`를 호출하는 시점과 UI 컴포넌트의 리렌더링 주기 사이에 어떠한 동기화 프리미티브도 존재하지 않습니다. 
OCaml 백엔드의 Eio 환경에서는 컴팩션 작업이 백그라운드 파이버(Fiber)에서 수행되며, 멀티코어 도메인 간 상태 동기화를 위해 힙 락(Heap Lock)을 사용합니다. 만약 사용자가 컴팩션 버튼을 연속으로 두 번 클릭하거나, 백엔드의 컴팩션 파이버가 길어져 Eio 스위치(Switch)가 취소(Cancel)된 상태에서 클라이언트가 재시도를 한다면 어떻게 될까요? 
현재 코드는 이전 요청의 `Promise`가 해결되기 전에 새로운 상태를 덮어쓰게 되어, UI 스냅샷은 백엔드의 실제 힙 상태와 완전히 괴리된 스테일(Stale) 데이터를 렌더링하게 됩니다. 타입스크립트 단에서 `AbortController`를 통한 요청 취소나, 백엔드 응답의 시퀀스 넘버.verifying 등의 낙관적 동시성 제어(Optimistic Concurrency Control) 로직이 전혀 보이지 않습니다. 이는 데이터 무결성을 직접적으로 파괴하는 설계 결함입니다.

### 2. 치명적인 Resource Leak 및 스트림 파이프 파열 (자원 누수)
`callMcpTool`은 단순한 HTTP 요청이 아니라, 백엔드의 장기 실행 작업(Long-running task)과 매핑될 가능성이 높습니다. 컴팩션은 토큰 트리를 순회하고 LLM 요약을 트리거할 수 있는 무거운 오퍼레이션입니다.
PR 설명에 따르면 `phase`와 `trigger` 같은 메타데이터를 파싱한다고 했으나, 만약 백엔드가 컴팩션 진행 상태를 스트리밍하거나, 타임아웃 발생 시 MCP 파이프가 불완전하게 종료된다면 어떻게 됩니까? 클라이언트 코드에 `finally` 블록이나 `cleanup` 함수를 통한 소켓/스트림 해제 로직이 언급되지 않았습니다. 타입스크립트의 이벤트 루프 내에 미해결 Promise와 미수거(Unreferenced) 콜백이 누적되면서, 대시보드가 백엔드의 좀비 파이버들과 연결된 채 메모리 누수(Memory Leak)를 일으키며 서서히 멈추는 현상이 발생할 것입니다.

### 3. 완전한 Idempotency Failure 및 에러 전파 차단 (멱등성 결여 및 에러 은폐)
PR에서 "Guards snapshot reduction math against division by zero"라고 자랑스럽게 명시했습니다. 이는 역설적으로 백엔드 응답의 신뢰성을 전혀 믿지 못하고 있다는 증거입니다.
`after_tokens`가 0이 되는 상황은 백엔드(OCaml)에서 토큰 카운팅 로직이 실패했거나, 멀티코어 경쟁 상태로 인해 아직 컴팩션이 완료되지 않은 인터미디엇(Intermediate) 상태를 클라이언트로 잘못 내려준 것입니다. 정상적인 시스템이라면 `after_tokens`가 0인 응답 자체가 500 에러 또는 비정상 상태 플래그로 처리되어야 합니다.
이 PR은 단순히 `0으로 나누기`를 막는 치명적인 우회로(Error Bypassing)를 패치했을 뿐, 백엔드에서 `saved_tokens`가 음수가 되는 논리적 오류나, 컴팩션 도중 백엔드 프로세스가 크래시하여 `phase: "crashed"` 같은 알 수 없는 enum 값이 들어올 때의 에러 핸들링(Error Boundary)은 전혀 구현하지 않았습니다. 멱등성 보장 없이 네트워크 통신을 연결해 놓고, 발생할 에러를 타입 캐스팅이나 사소한 수학적 가드로 덮어버리는 것은 프로덕션 환경에서 대규모 장애를 유발하는 시한폭탄입니다. 테스트 코드(`keeper-workspace-rail.test.ts`)에서 해피 패스 모킹만 검증하고 이러한 엣지 케이스 에러 Propagation을 검증하지 않은 것은 테스트 커버리지 조작에 가깝습니다.
