### PR TITLE
feat(dashboard): migrate overview/cockpit/telemetry surfaces to StyleSeed

### DIFF
--- a/dashboard/src/components/cockpit/cockpit.ts
+++ b/dashboard/src/components/cockpit/cockpit.ts
@@ -148,7 +148,7 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
 
   return html`
     <section
-      class="cp-plane"
+      class="cp-plane ss-card"
       data-cockpit-plane=${plane}
       aria-label=${`${meta.label} cockpit routes`}
     >
@@ -197,7 +197,7 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
 
 export function Cockpit() {
   return html`
-    <div class="cp-body" data-testid="cockpit-command-map">
+    <div class="cp-body ss-surface" data-testid="cockpit-command-map">
       <aside class="cp-world">
         <${WorldVisualizer} />
       </aside>
@@ -215,7 +215,7 @@ export function Cockpit() {
           </header>
 
           <section
-            class="cp-disc"
+            class="cp-disc ss-card"
             aria-label="Progressive disclosure"
             data-testid="cockpit-disclosure"
           >

--- a/dashboard/src/components/common/source-health.test.ts
+++ b/dashboard/src/components/common/source-health.test.ts
@@ -4,7 +4,7 @@ import { coverageGapDisplay, freshnessText, sourceHealthClass } from './source-h
 
 describe('sourceHealthClass', () => {
   it('maps coverage_gap to warning tone', () => {
-    expect(sourceHealthClass('coverage_gap')).toBe('text-[var(--color-status-warn)]')
+    expect(sourceHealthClass('coverage_gap')).toBe('text-warning')
   })
 })
 

--- a/dashboard/src/components/common/source-health.ts
+++ b/dashboard/src/components/common/source-health.ts
@@ -15,15 +15,15 @@ import type { TelemetryCoverageGap, TelemetryFreshnessMetadata } from '../../api
 export function sourceHealthClass(health?: string | null): string {
   switch ((health ?? '').toLowerCase()) {
     case 'ok':
-      return 'text-[var(--color-status-ok)]'
+      return 'text-success'
     case 'stale':
     case 'coverage_gap':
     case 'empty':
-      return 'text-[var(--color-status-warn)]'
+      return 'text-warning'
     case 'missing':
-      return 'text-[var(--bad-light)]'
+      return 'text-destructive'
     default:
-      return 'text-[var(--color-fg-disabled)]'
+      return 'text-text-disabled'
   }
 }
 

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -100,23 +100,23 @@ function trendArrow(direction: TrendDirection): string {
 }
 
 function trendColorClass(direction: TrendDirection, metric: MetricKey): string {
-  if (direction === 'flat') return 'text-[var(--color-fg-disabled)]'
+  if (direction === 'flat') return 'text-text-disabled'
   const bad = (direction === 'up' && isUpBad(metric)) || (direction === 'down' && !isUpBad(metric))
-  return bad ? 'text-[var(--bad-light)]' : 'text-[var(--color-status-ok)]'
+  return bad ? 'text-destructive' : 'text-success'
 }
 
 function sparklineColor(metric: MetricKey, direction: TrendDirection): string {
-  if (direction === 'flat') return 'var(--color-fg-muted)'
+  if (direction === 'flat') return 'var(--text-tertiary)'
   const bad = (direction === 'up' && isUpBad(metric)) || (direction === 'down' && !isUpBad(metric))
-  return bad ? 'var(--bad-light)' : 'var(--color-emerald)'
+  return bad ? 'var(--destructive)' : 'var(--success)'
 }
 
 function auditFreshnessClass(isoTimestamp: string | null): string {
-  if (!isoTimestamp) return 'text-[var(--color-fg-disabled)]'
+  if (!isoTimestamp) return 'text-text-disabled'
   const ageMs = Date.now() - new Date(isoTimestamp).getTime()
-  if (ageMs < 5 * 60 * 1000) return 'text-[var(--text)]'
-  if (ageMs < 15 * 60 * 1000) return 'text-[var(--color-fg-disabled)]'
-  return 'text-[var(--color-status-warn)]'
+  if (ageMs < 5 * 60 * 1000) return 'text-text-primary'
+  if (ageMs < 15 * 60 * 1000) return 'text-text-disabled'
+  return 'text-warning'
 }
 
 function SummaryCard({
@@ -132,16 +132,16 @@ function SummaryCard({
 }) {
   const toneClass =
     tone === 'ok'
-      ? 'border-[var(--ok-20)] bg-[var(--ok-10)]'
+      ? 'border-success/20 bg-success/10'
       : tone === 'warn'
-        ? 'border-[var(--warn-20)] bg-[var(--warn-10)]'
-        : 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)]'
+        ? 'border-warning/20 bg-warning/10'
+        : 'border-border bg-card'
 
   return html`
-    <div class="v2-monitoring-card rounded-[var(--r-1)] border ${toneClass} p-3">
+    <div class="v2-monitoring-card ss-card rounded-[var(--r-1)] border ${toneClass} p-3">
       <${Eyebrow} tone="disabled">${title}</${Eyebrow}>
-      <div class="mt-1 text-xl font-semibold text-[var(--text)]">${value}</div>
-      <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-muted)]">${detail}</div>
+      <div class="mt-1 text-[20px] font-semibold text-text-primary">${value}</div>
+      <div class="mt-1 text-[12px] leading-relaxed text-text-tertiary">${detail}</div>
     </div>
   `
 }
@@ -149,8 +149,8 @@ function SummaryCard({
 function WarningBanner({ warnings }: { warnings: string[] }) {
   if (warnings.length === 0) return null
   return html`
-    <div class="rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--color-status-warn)]">
-      <div class="font-medium text-[var(--color-status-warn)]">부분 텔레메트리</div>
+    <div class="rounded-[var(--r-1)] border border-warning/20 bg-warning/10 px-3 py-2 text-[12px] text-warning">
+      <div class="font-medium text-warning">부분 텔레메트리</div>
       <div class="mt-1 flex flex-col gap-1">
         ${warnings.map(warning => html`<div>${warning}</div>`)}
       </div>
@@ -165,31 +165,31 @@ function readinessTone(status: string | null | undefined): 'neutral' | 'ok' | 'w
 }
 
 function readinessStatusClass(status: string | null | undefined): string {
-  if (status === 'ok') return 'text-[var(--color-status-ok)]'
-  if (status === 'warn') return 'text-[var(--color-status-warn)]'
-  if (status === 'bad') return 'text-[var(--bad-light)]'
-  return 'text-[var(--color-fg-disabled)]'
+  if (status === 'ok') return 'text-success'
+  if (status === 'warn') return 'text-warning'
+  if (status === 'bad') return 'text-destructive'
+  return 'text-text-disabled'
 }
 
 function attentionSeverityClass(severity: string | null | undefined): string {
-  if (severity === 'bad') return 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]'
-  if (severity === 'warn') return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
-  return 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-fg-disabled)]'
+  if (severity === 'bad') return 'border-destructive/20 bg-destructive/10 text-destructive'
+  if (severity === 'warn') return 'border-warning/20 bg-warning/10 text-warning'
+  return 'border-border bg-card text-text-disabled'
 }
 
 function ReadinessPillarCard({ pillar }: { pillar: DashboardReadinessPillar }) {
   return html`
-    <div class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
+    <div class="v2-monitoring-card ss-card rounded-[var(--r-1)] border border-border bg-card p-3">
       <div class="flex items-center justify-between gap-3">
-        <div class="text-2xs font-medium text-[var(--text)]">${pillar.label}</div>
-        <div class="font-mono text-2xs ${readinessStatusClass(pillar.status)}">
+        <div class="text-[12px] font-medium text-text-primary">${pillar.label}</div>
+        <div class="font-mono text-[12px] ${readinessStatusClass(pillar.status)}">
           ${pillar.score.toFixed(2)}
         </div>
       </div>
-      <div class="mt-1 text-3xs ${readinessStatusClass(pillar.status)}">${pillar.summary}</div>
+      <div class="mt-1 text-[11px] ${readinessStatusClass(pillar.status)}">${pillar.summary}</div>
       ${pillar.blocking_reasons.length > 0
         ? html`
-          <div class="mt-2 flex flex-col gap-1 text-3xs text-[var(--color-fg-disabled)]">
+          <div class="mt-2 flex flex-col gap-1 text-[11px] text-text-disabled">
             ${pillar.blocking_reasons.slice(0, 2).map(reason => html`<div>${reason}</div>`)}
           </div>
         `
@@ -201,7 +201,7 @@ function ReadinessPillarCard({ pillar }: { pillar: DashboardReadinessPillar }) {
 function AttentionEventList({ events }: { events: DashboardAttentionEvent[] }) {
   if (events.length === 0) {
     return html`
-      <div class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3 text-2xs text-[var(--color-fg-disabled)]">
+      <div class="v2-monitoring-card ss-card rounded-[var(--r-1)] border border-border bg-card p-3 text-[12px] text-text-disabled">
         No decision-needed or blocker events are active.
       </div>
     `
@@ -210,20 +210,20 @@ function AttentionEventList({ events }: { events: DashboardAttentionEvent[] }) {
   return html`
     <div class="flex flex-col gap-2">
       ${events.slice(0, 6).map(event => html`
-        <div class="v2-monitoring-card rounded-[var(--r-1)] border px-3 py-2 ${attentionSeverityClass(event.severity)}">
+        <div class="v2-monitoring-card ss-card rounded-[var(--r-1)] border px-3 py-2 ${attentionSeverityClass(event.severity)}">
           <div class="flex items-start justify-between gap-3">
             <div class="min-w-0">
-              <div class="text-2xs font-medium">
+              <div class="text-[12px] font-medium">
                 ${event.keeper_name ? `${event.keeper_name} · ${event.kind}` : event.kind}
               </div>
-              <div class="mt-0.5 text-3xs leading-relaxed">${event.summary}</div>
+              <div class="mt-0.5 text-[11px] leading-relaxed">${event.summary}</div>
             </div>
             ${event.requires_decision
-              ? html`<span class="rounded-[var(--r-1)] bg-[var(--color-bg-hover)] px-1.5 py-0.5 text-3xs font-semibold">DECISION</span>`
+              ? html`<span class="rounded-[var(--r-1)] bg-surface-subtle px-1.5 py-0.5 text-[11px] font-semibold">DECISION</span>`
               : null}
           </div>
           ${event.recommended_action
-            ? html`<div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">다음: ${event.recommended_action}</div>`
+            ? html`<div class="mt-1 text-[11px] text-text-disabled">다음: ${event.recommended_action}</div>`
             : null}
         </div>
       `)}
@@ -241,7 +241,7 @@ function ControlWorkspacePanel({ state }: { state: FleetTelemetryState }) {
 
   if (!truth || !readiness) {
     return html`
-      <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3 text-2xs text-[var(--color-fg-disabled)]">
+      <div class="rounded-[var(--r-1)] border border-border bg-card p-3 text-[12px] text-text-disabled">
         Control workspace readiness is unavailable for this refresh.
       </div>
     `
@@ -305,19 +305,19 @@ function PressureWatchlist({ rows }: { rows: FleetRow[] }) {
 
   if (watchlist.length === 0) {
     return html`
-      <div class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3 text-2xs text-[var(--color-fg-disabled)]">
+      <div class="v2-monitoring-card ss-card rounded-[var(--r-1)] border border-border bg-card p-3 text-[12px] text-text-disabled">
         No keepers are near context pressure or stale activity thresholds.
       </div>
     `
   }
 
   return html`
-    <div class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
+    <div class="v2-monitoring-card ss-card rounded-[var(--r-1)] border border-border bg-card">
       ${watchlist.map(row => html`
-        <div class="v2-monitoring-row flex items-center justify-between gap-3 border-b border-[var(--color-border-default)] px-3 py-2 text-2xs last:border-b-0">
+        <div class="v2-monitoring-row flex items-center justify-between gap-3 border-b border-border px-3 py-2 text-[12px] last:border-b-0">
           <div class="min-w-0">
-            <div class="font-mono text-[var(--text)]">${row.name}</div>
-            <div class="text-[var(--color-fg-disabled)]">
+            <div class="font-mono text-text-primary">${row.name}</div>
+            <div class="text-text-disabled">
               ${row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC
                 ? `stale ${formatActivitySignal(row)}`
                 : `ctx ${formatPercent(row.context_ratio * 100, 1)}`}
@@ -325,7 +325,7 @@ function PressureWatchlist({ rows }: { rows: FleetRow[] }) {
           </div>
           <div class="text-right">
             <div class="font-mono ${pressureClass(row.context_ratio)}">${formatPercent(row.context_ratio * 100, 1)}</div>
-            <div class="text-[var(--color-fg-disabled)]">${formatActivitySignal(row)}</div>
+            <div class="text-text-disabled">${formatActivitySignal(row)}</div>
           </div>
         </div>
       `)}
@@ -348,7 +348,7 @@ function TrendCell({ name, metric, value, valueClass }: {
     <td class="py-1.5 text-right">
       <div class="flex items-center justify-end gap-1">
         <span class="font-mono ${valueClass}">${value}</span>
-        ${arrow ? html`<span class="text-3xs ${colorClass}">${arrow}</span>` : null}
+        ${arrow ? html`<span class="text-[11px] ${colorClass}">${arrow}</span>` : null}
       </div>
       ${trend && trend.values.length >= 2
         ? html`<div class="mt-0.5 flex justify-end"><${Sparkline} values=${trend.values} width=${48} height=${14} color=${sColor} /></div>`
@@ -358,12 +358,12 @@ function TrendCell({ name, metric, value, valueClass }: {
 }
 
 function ThRight({ children }: { children: unknown }) {
-  return html`<th scope="col" class="py-1 text-right font-normal">${children}</th>`
+  return html`<th scope="col" class="py-1 text-right font-normal text-text-secondary">${children}</th>`
 }
 
 function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (name: string) => void }) {
   if (rows.length === 0) {
-    return html`<div class="text-2xs text-[var(--color-fg-disabled)]">Keeper 데이터 없음.</div>`
+    return html`<div class="text-[12px] text-text-disabled">Keeper 데이터 없음.</div>`
   }
 
   const runtimeModelLabel = (model: string): string =>
@@ -375,10 +375,10 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
 
   return html`
     <div class="overflow-x-auto">
-      <table class="v2-monitoring-table w-full text-2xs" aria-label="키퍼 텔레메트리 현황">
+      <table class="v2-monitoring-table w-full text-[12px]" aria-label="키퍼 텔레메트리 현황">
         <thead>
-          <tr class="border-b border-[var(--color-border-default)] text-[var(--color-fg-disabled)]">
-            <th scope="col" class="py-1 text-left font-normal">키퍼</th>
+          <tr class="border-b border-border text-text-disabled">
+            <th scope="col" class="py-1 text-left font-normal text-text-secondary">키퍼</th>
             <${ThRight}>상태</${ThRight}>
             <${ThRight}>활동</${ThRight}>
             <${ThRight}>측정</${ThRight}>
@@ -387,8 +387,8 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
             <${ThRight}>Ctx</${ThRight}>
             <${ThRight}>지연</${ThRight}>
             <${ThRight}>런타임</${ThRight}>
-            <th scope="col" class="py-1 text-center font-normal">상태</th>
-            <th scope="col" class="py-1 text-center font-normal">예산</th>
+            <th scope="col" class="py-1 text-center font-normal text-text-secondary">상태</th>
+            <th scope="col" class="py-1 text-center font-normal text-text-secondary">예산</th>
             <th scope="col" class="w-8 py-1"></th>
           </tr>
         </thead>
@@ -408,27 +408,27 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
               )
             const rowHintClass =
               isOfflineDiagnosticHealthState(diagnosticState)
-                ? 'text-[var(--bad-light)]'
-                : 'text-[var(--color-status-warn)]'
+                ? 'text-destructive'
+                : 'text-warning'
             return html`
-            <tr class="v2-monitoring-row border-b border-[var(--color-border-default)] border-opacity-30 align-top">
+            <tr class="v2-monitoring-row border-b border-border border-opacity-30 align-top">
               <td class="py-1.5">
-                <div class="font-mono text-[var(--text)]">${row.name}</div>
+                <div class="font-mono text-text-primary">${row.name}</div>
                 ${rowHint
                   ? html`
-                    <div class="max-w-60 truncate text-3xs ${rowHintClass}" title=${rowHint}>
+                    <div class="max-w-60 truncate text-[11px] ${rowHintClass}" title=${rowHint}>
                       ${rowHint}
                     </div>
                   `
                   : null}
-                <div class="max-w-60 truncate text-3xs text-[var(--color-fg-disabled)]" title=${toolInfo.title}>
+                <div class="max-w-60 truncate text-[11px] text-text-disabled" title=${toolInfo.title}>
                   ${toolInfo.label}
                 </div>
                 <div class="mt-1 flex max-w-60 flex-wrap gap-1">
                   <span
                     class=${row.goal_linked
-                      ? 'rounded-[var(--r-1)] bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs text-[var(--color-status-ok)]'
-                      : 'rounded-[var(--r-1)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs text-[var(--color-status-warn)]'}
+                      ? 'rounded-[var(--r-1)] bg-success/10 px-1.5 py-0.5 text-[11px] text-success'
+                      : 'rounded-[var(--r-1)] bg-warning/10 px-1.5 py-0.5 text-[11px] text-warning'}
                     title=${row.goal_label ?? '이 키퍼에 연결된 활성 목표가 없습니다.'}
                   >
                     ${row.goal_label
@@ -437,21 +437,21 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                   </span>
                   <span
                     class=${row.sandbox_profile
-                      ? 'rounded-[var(--r-1)] bg-[var(--color-bg-hover)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-disabled)]'
-                      : 'rounded-[var(--r-1)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs text-[var(--color-status-warn)]'}
+                      ? 'rounded-[var(--r-1)] bg-surface-subtle px-1.5 py-0.5 text-[11px] text-text-disabled'
+                      : 'rounded-[var(--r-1)] bg-warning/10 px-1.5 py-0.5 text-[11px] text-warning'}
                     title=${row.sandbox_profile ?? '샌드박스 프로필 정보 없음.'}
                   >
                     ${row.sandbox_profile ? `sandbox ${row.sandbox_profile}` : 'sandbox unknown'}
                   </span>
                   ${row.decision_required
-                    ? html`<span class="rounded-[var(--r-1)] bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs text-[var(--bad-light)]">decision</span>`
+                    ? html`<span class="rounded-[var(--r-1)] bg-destructive/10 px-1.5 py-0.5 text-[11px] text-destructive">decision</span>`
                     : null}
                   ${row.stop_cause
                     ? html`
                       <span
                         class=${row.stop_cause.severity === 'bad'
-                          ? 'rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs text-[var(--bad-light)]'
-                          : 'rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs text-[var(--color-status-warn)]'}
+                          ? 'rounded bg-destructive/10 px-1.5 py-0.5 text-[11px] text-destructive'
+                          : 'rounded bg-warning/10 px-1.5 py-0.5 text-[11px] text-warning'}
                         title=${row.stop_cause.next_action ?? row.stop_cause.summary ?? row.runtime_trust_next_action ?? row.runtime_trust_reason ?? row.stop_cause.code}
                       >
                         ${row.stop_cause.code}
@@ -460,25 +460,25 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                     : null}
                 </div>
                 ${row.goal_label
-                  ? html`<div class="max-w-60 truncate text-3xs text-[var(--color-fg-disabled)]" title=${row.goal_label}>${row.goal_label}</div>`
+                  ? html`<div class="max-w-60 truncate text-[11px] text-text-disabled" title=${row.goal_label}>${row.goal_label}</div>`
                   : null}
                 ${row.sandbox_last_error
                   ? html`
-                    <div class="max-w-60 truncate text-3xs text-[var(--bad-light)]" title=${row.sandbox_last_error}>
+                    <div class="max-w-60 truncate text-[11px] text-destructive" title=${row.sandbox_last_error}>
                       ${row.sandbox_last_error}
                     </div>
                   `
                   : null}
               </td>
               <td class="py-1.5 text-right font-mono ${statusClass(row)}">${row.status}</td>
-              <td class="py-1.5 text-right text-[var(--color-fg-disabled)]">${formatActivitySignal(row)}</td>
-              <td class="py-1.5 text-right text-3xs ${auditFreshnessClass(row.tool_audit_at)}" title=${row.tool_audit_at ?? ''}>
+              <td class="py-1.5 text-right text-text-disabled">${formatActivitySignal(row)}</td>
+              <td class="py-1.5 text-right text-[11px] ${auditFreshnessClass(row.tool_audit_at)}" title=${row.tool_audit_at ?? ''}>
                 ${row.tool_audit_at ? formatTimeAgo(row.tool_audit_at) : '-'}
               </td>
               <${TrendCell}
                 name=${row.name} metric="tool_calls"
                 value=${row.tool_calls.toLocaleString()}
-                valueClass="text-[var(--text)]"
+                valueClass="text-text-primary"
               />
               <${TrendCell}
                 name=${row.name} metric="tool_success_pct"
@@ -493,11 +493,11 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
               <${TrendCell}
                 name=${row.name} metric="last_latency_ms"
                 value=${formatLatency(row.last_latency_ms)}
-                valueClass="text-[var(--color-fg-disabled)]"
+                valueClass="text-text-disabled"
               />
-              <td class="py-1.5 text-right text-3xs text-[var(--color-fg-disabled)]">
+              <td class="py-1.5 text-right text-[11px] text-text-disabled">
                 <div
-                  class="font-mono text-[var(--color-fg-secondary)]"
+                  class="font-mono text-text-secondary"
                   title=${runtimeModelTitle(row.model)}
                 >
                   ${runtimeModelLabel(row.model)}
@@ -509,22 +509,22 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                   ? html`<div class="max-w-56 truncate" title=${row.provider_label}>attempts ${row.provider_label}</div>`
                   : null}
                 ${row.fallback_label
-                  ? html`<div class="max-w-56 truncate text-[var(--color-status-warn)]" title=${row.fallback_label}>fallback ${row.fallback_label}</div>`
+                  ? html`<div class="max-w-56 truncate text-warning" title=${row.fallback_label}>fallback ${row.fallback_label}</div>`
                   : null}
               </td>
               <td class="py-1.5 text-center">
-                <span class="text-3xs text-[var(--color-fg-disabled)]">—</span>
+                <span class="text-[11px] text-text-disabled">—</span>
               </td>
               <td class="py-1.5 text-center">
                 ${row.budget_source === 'override_invalid'
-                  ? html`<span class="rounded-[var(--r-1)] bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--bad-light)]" title="TOML override가 범위를 벗어남">ERR</span>`
+                  ? html`<span class="rounded-[var(--r-1)] bg-destructive/10 px-1.5 py-0.5 text-[11px] font-semibold text-destructive" title="TOML override가 범위를 벗어남">ERR</span>`
                   : row.budget_source === 'override'
-                    ? html`<span class="rounded-[var(--r-1)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--color-status-warn)]" title="TOML override 적용됨">OVR</span>`
-                    : html`<span class="text-3xs text-[var(--color-fg-disabled)]">\u2014</span>`}
+                    ? html`<span class="rounded-[var(--r-1)] bg-warning/10 px-1.5 py-0.5 text-[11px] font-semibold text-warning" title="TOML override 적용됨">OVR</span>`
+                    : html`<span class="text-[11px] text-text-disabled">\u2014</span>`}
               </td>
               <td class="py-1.5 text-center">
                 <button
-                  class="v2-monitoring-action rounded-[var(--r-1)] min-w-6 min-h-6 p-1.5 text-[var(--color-fg-disabled)] hover:text-[var(--bad-light)] hover:bg-[var(--bad-10)] transition-colors inline-flex items-center justify-center"
+                  class="v2-monitoring-action rounded-[var(--r-1)] min-h-11 min-w-11 p-1.5 text-text-disabled hover:text-destructive hover:bg-destructive/10 transition-colors inline-flex items-center justify-center"
                   onClick=${() => onReset(row.name)}
                   title="초기화"
                   aria-label=${`${row.name} 초기화`}
@@ -549,14 +549,14 @@ function TelemetrySourcesPanel({ sources }: { sources: TelemetrySourceSummary[] 
   return html`
     <div class="grid grid-cols-1 gap-2 md:grid-cols-2">
       ${sorted.map(source => html`
-        <div class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
+        <div class="v2-monitoring-card ss-card rounded-[var(--r-1)] border border-border bg-card p-3">
           <div class="flex items-center justify-between gap-3">
-            <div class="text-2xs font-medium text-[var(--text)]">${telemetrySourceLabel(source.source)}</div>
-            <div class="font-mono text-2xs ${sourceCountClass(source)}">
+            <div class="text-[12px] font-medium text-text-primary">${telemetrySourceLabel(source.source)}</div>
+            <div class="font-mono text-[12px] ${sourceCountClass(source)}">
               ${source.entry_count.toLocaleString()}
             </div>
           </div>
-          <div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">${sourceDetail(source)}</div>
+          <div class="mt-1 text-[11px] text-text-disabled">${sourceDetail(source)}</div>
         </div>
       `)}
     </div>
@@ -576,11 +576,11 @@ function ExecutionTrustSourcePanel({ trust }: { trust: DashboardExecutionTrustRe
   ].filter((row): row is [string, string] => row !== null)
 
   return html`
-    <div class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
+    <div class="v2-monitoring-card ss-card rounded-[var(--r-1)] border border-border bg-card p-3">
       <div class="flex items-center justify-between gap-3">
         <div>
-          <div class="text-2xs font-medium text-[var(--text)]">Execution Trust</div>
-          <div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">
+          <div class="text-[12px] font-medium text-text-primary">Execution Trust</div>
+          <div class="mt-1 text-[11px] text-text-disabled">
             <span class="font-mono">${trust.source ?? 'execution_receipt'}</span>
             <span class="mx-1" aria-hidden="true">·</span>
             <span class="font-mono ${sourceHealthClass(trust.health)}">${trust.health ?? 'unknown'}</span>
@@ -589,12 +589,12 @@ function ExecutionTrustSourcePanel({ trust }: { trust: DashboardExecutionTrustRe
           </div>
         </div>
         <div class="text-right">
-          <div class="font-mono text-sm text-[var(--text)]">${(trust.entry_count ?? 0).toLocaleString()}</div>
-          <div class="text-3xs text-[var(--color-fg-disabled)]">${trust.total.toLocaleString()} keepers</div>
+          <div class="font-mono text-[14px] text-text-primary">${(trust.entry_count ?? 0).toLocaleString()}</div>
+          <div class="text-[11px] text-text-disabled">${trust.total.toLocaleString()} keepers</div>
         </div>
       </div>
       ${provenanceRows.length > 0 ? html`
-        <div class="mt-2 grid gap-1 text-3xs text-[var(--color-fg-disabled)]">
+        <div class="mt-2 grid gap-1 text-[11px] text-text-disabled">
           ${provenanceRows.map(([label, value]) => html`
             <div class="flex min-w-0 gap-1">
               <span class="shrink-0">${label}:</span>
@@ -604,7 +604,7 @@ function ExecutionTrustSourcePanel({ trust }: { trust: DashboardExecutionTrustRe
         </div>
       ` : null}
       ${coverageGap ? html`
-        <div class="mt-2 grid gap-0.5 text-3xs text-[var(--color-status-warn)]">
+        <div class="mt-2 grid gap-0.5 text-[11px] text-warning">
           <span>${coverageGap.summary}</span>
           ${coverageGap.details.map(detail => html`<span class="font-mono break-all">${detail}</span>`)}
         </div>
@@ -624,15 +624,15 @@ function FailureCategoryPanel({ toolQuality }: { toolQuality: ToolQualityRespons
   return html`
     <div class="flex flex-col gap-1.5">
       ${top.map(category => html`
-        <div class="flex items-center gap-2 text-2xs">
+        <div class="flex items-center gap-2 text-[12px]">
           <div class="flex min-w-0 flex-1 items-center gap-1.5">
             <div
-              class="h-1.5 rounded-[var(--r-0)] bg-[var(--bad-10)]"
+              class="h-1.5 rounded-[var(--r-0)] bg-destructive/10"
               style="width: ${Math.max(6, (category.count / maxCount) * 100)}%"
             ></div>
-            <span class="truncate font-mono text-[var(--bad-light)]" title=${category.category}>${category.category}</span>
+            <span class="truncate font-mono text-destructive" title=${category.category}>${category.category}</span>
           </div>
-          <span class="text-[var(--color-fg-disabled)]">${category.count}</span>
+          <span class="text-text-disabled">${category.count}</span>
         </div>
       `)}
     </div>
@@ -801,33 +801,35 @@ export function FleetTelemetryPanel() {
   const offlineCount = value.rows.length - activeCount
 
   return html`
-    <div class="v2-monitoring-surface contain-content flex flex-col gap-4 p-4">
-      <div class="flex items-start justify-between gap-3">
+    <div class="v2-monitoring-surface ss-surface contain-content flex flex-col space-y-6 py-6">
+      <div class="flex items-start justify-between gap-3 px-6">
         <div class="flex items-center gap-3">
-          <h2 class="text-sm font-medium">Keeper 텔레메트리</h2>
-          <div class="flex items-center gap-2 text-3xs">
-            ${activeCount > 0 ? html`<span class="rounded-[var(--r-0)] bg-[var(--ok-10)] px-1.5 py-0.5 text-[var(--color-status-ok)]">${activeCount} 가동</span>` : null}
-            ${attentionCount > 0 ? html`<span class="rounded-[var(--r-0)] bg-[var(--warn-10)] px-1.5 py-0.5 text-[var(--color-status-warn)]">${attentionCount} 주의</span>` : null}
-            ${offlineCount > 0 ? html`<span class="rounded-[var(--r-0)] bg-[var(--color-bg-hover)] px-1.5 py-0.5 text-[var(--color-fg-disabled)]">${offlineCount} 오프라인</span>` : null}
-            ${budgetOverrideCount > 0 ? html`<span class="rounded-[var(--r-0)] bg-[var(--warn-10)] px-1.5 py-0.5 text-[var(--color-status-warn)]">${budgetOverrideCount} 예산 재정의</span>` : null}
+          <h2 class="text-[18px] font-bold text-text-primary">Keeper 텔레메트리</h2>
+          <div class="flex items-center gap-2 text-[12px]">
+            ${activeCount > 0 ? html`<span class="rounded-[var(--r-0)] bg-success/10 px-1.5 py-0.5 text-success">${activeCount} 가동</span>` : null}
+            ${attentionCount > 0 ? html`<span class="rounded-[var(--r-0)] bg-warning/10 px-1.5 py-0.5 text-warning">${attentionCount} 주의</span>` : null}
+            ${offlineCount > 0 ? html`<span class="rounded-[var(--r-0)] bg-surface-subtle px-1.5 py-0.5 text-text-disabled">${offlineCount} 오프라인</span>` : null}
+            ${budgetOverrideCount > 0 ? html`<span class="rounded-[var(--r-0)] bg-warning/10 px-1.5 py-0.5 text-warning">${budgetOverrideCount} 예산 재정의</span>` : null}
           </div>
         </div>
         <div class="flex items-center gap-2">
-          <span class="text-3xs text-[var(--color-fg-disabled)]">
+          <span class="text-[12px] text-text-disabled">
             ${value.updated_at ? `${formatTimeAgo(value.updated_at)} 갱신` : ''}
           </span>
           <button
-            class="v2-monitoring-action rounded-[var(--r-1)] bg-[var(--bg-subtle)] px-2 py-0.5 text-3xs text-[var(--color-fg-disabled)] hover:text-[var(--text)]"
+            class="v2-monitoring-action rounded-[var(--r-1)] bg-surface-subtle px-2 py-0.5 text-[12px] text-text-disabled hover:text-text-primary min-h-11"
             onClick=${() => { void loadFleetTelemetry() }}
             aria-label="Keeper 텔레메트리 새로고침"
           >새로고침</button>
-          <span class="text-3xs text-[var(--color-fg-disabled)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
+          <span class="text-[12px] text-text-disabled">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
         </div>
       </div>
 
-      <${WarningBanner} warnings=${value.warnings} />
+      <div class="px-6">
+        <${WarningBanner} warnings=${value.warnings} />
+      </div>
 
-      <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+      <div class="grid grid-cols-1 gap-3 px-6 md:grid-cols-2">
         <${SummaryCard}
           title="키퍼 가동률"
           value=${`${counts.live}/${value.rows.length || 0}`}
@@ -837,12 +839,12 @@ export function FleetTelemetryPanel() {
         <${SummaryCard}
           title="런타임 압박"
           value=${`${counts.hot} hot / ${counts.warn} warn`}
-          detail=${counts.stale > 0 ? `${counts.stale}개 키퍼가 ${Math.round(STALE_ACTIVITY_SEC / 60)}분 이상 정체 중입니다.` : '정체된 키퍼가 활동 임계값을 넘기지 않았습니다.'}
+          detail=${counts.stale > 0 ? `${counts.stale}개 키퍼가 ${Math.round(STALE_ACTIVITY_SEC / 60)}분 이상 정체 중입니다.` : '정천된 키퍼가 활동 임계값을 넘기지 않았습니다.'}
           tone=${toneForPressure(counts.hot, counts.warn)}
         />
       </div>
 
-      <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
+      <div class="grid grid-cols-1 gap-3 px-6 md:grid-cols-3">
         <${SummaryCard}
           title="차단된 키퍼"
           value=${counts.blocked.toString()}
@@ -869,22 +871,22 @@ export function FleetTelemetryPanel() {
         />
       </div>
 
-      <div>
+      <div class="px-6">
         <${Eyebrow} tone="disabled" class="mb-1">함대 통제실</${Eyebrow}>
         <${ControlWorkspacePanel} state=${value} />
       </div>
 
-      <div>
+      <div class="px-6">
         <${Eyebrow} tone="disabled" class="mb-1">Execution Trust Source</${Eyebrow}>
         <${ExecutionTrustSourcePanel} trust=${value.execution_trust} />
       </div>
 
-      <div>
+      <div class="px-6">
         <${Eyebrow} tone="disabled" class="mb-1">압박 감시 목록</${Eyebrow}>
         <${PressureWatchlist} rows=${value.rows} />
       </div>
 
-      <div>
+      <div class="px-6">
         <div class="mb-1 flex items-center justify-between gap-2">
           <${Eyebrow} tone="disabled">Keeper 비교</${Eyebrow}>
           <${TextInput}
@@ -893,20 +895,20 @@ export function FleetTelemetryPanel() {
             placeholder="name / blocker 필터"
             ariaLabel="Keeper 필터"
             onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-            class="min-w-40 max-w-60 flex-1 !px-2 !py-1 !text-2xs"
+            class="min-w-40 max-w-60 flex-1 !px-2 !py-1 !text-[12px]"
           />
         </div>
         ${isFiltering && visibleRows.length === 0 && value.rows.length > 0
-          ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${value.rows.length} keepers)</div>`
+          ? html`<div class="py-4 text-center text-[12px] text-text-disabled">필터 결과 없음 (${value.rows.length} keepers)</div>`
           : html`<${FleetComparisonTable} rows=${visibleRows} onReset=${handleReset} />`}
       </div>
 
-      <div>
+      <div class="px-6">
         <${Eyebrow} tone="disabled" class="mb-1">텔레메트리 출처</${Eyebrow}>
         <${TelemetrySourcesPanel} sources=${value.telemetry_sources} />
       </div>
 
-      <div>
+      <div class="px-6">
         <${Eyebrow} tone="disabled" class="mb-1">실패 분류</${Eyebrow}>
         <${FailureCategoryPanel} toolQuality=${value.tool_quality} />
       </div>

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -262,24 +262,24 @@ describe('uniqueStrings', () => {
 })
 
 describe('successClass', () => {
-  it('returns ok for >=97', () => {
-    expect(successClass(97)).toContain('var(--color-status-ok)')
-    expect(successClass(100)).toContain('var(--color-status-ok)')
+  it('returns success for >=97', () => {
+    expect(successClass(97)).toBe('text-success')
+    expect(successClass(100)).toBe('text-success')
   })
 
-  it('returns warn for 90-96', () => {
-    expect(successClass(90)).toContain('var(--color-status-warn)')
-    expect(successClass(96)).toContain('var(--color-status-warn)')
+  it('returns warning for 90-96', () => {
+    expect(successClass(90)).toBe('text-warning')
+    expect(successClass(96)).toBe('text-warning')
   })
 
-  it('returns bad-light for <90', () => {
-    expect(successClass(89)).toContain('var(--bad-light)')
-    expect(successClass(50)).toContain('var(--bad-light)')
+  it('returns destructive for <90', () => {
+    expect(successClass(89)).toBe('text-destructive')
+    expect(successClass(50)).toBe('text-destructive')
   })
 
   it('returns disabled for null/non-finite', () => {
-    expect(successClass(null)).toContain('color-fg-disabled')
-    expect(successClass(NaN)).toContain('color-fg-disabled')
+    expect(successClass(null)).toBe('text-text-disabled')
+    expect(successClass(NaN)).toBe('text-text-disabled')
   })
 })
 
@@ -384,27 +384,24 @@ describe('compareFleetRows', () => {
 })
 
 describe('pressureClass', () => {
-  // After the Anyang Sleepers token migration, pressureClass returns
-  // semantic design-system tokens (--bad-light / --warn / --ok)
-  // rather than hardcoded Tailwind colors, so the chip recolors
-  // automatically under [data-theme="paper"].
-  it('returns bad-light for hot ratio', () => {
-    expect(pressureClass(PRESSURE_HOT_RATIO)).toContain('var(--bad-light)')
+  // StyleSeed semantic tokens
+  it('returns destructive for hot ratio', () => {
+    expect(pressureClass(PRESSURE_HOT_RATIO)).toBe('text-destructive')
   })
 
-  it('returns warn for warn ratio', () => {
-    expect(pressureClass(PRESSURE_WARN_RATIO)).toContain('var(--color-status-warn)')
+  it('returns warning for warn ratio', () => {
+    expect(pressureClass(PRESSURE_WARN_RATIO)).toBe('text-warning')
   })
 
-  it('returns ok for low ratio', () => {
-    expect(pressureClass(0.1)).toContain('var(--color-status-ok)')
+  it('returns success for low ratio', () => {
+    expect(pressureClass(0.1)).toBe('text-success')
   })
 })
 
 describe('statusClass', () => {
-  it('returns bad-light for offline/stopped', () => {
-    expect(statusClass(makeRow({ keepalive_running: false }))).toContain('var(--bad-light)')
-    expect(statusClass(makeRow({ status: 'stopped' }))).toContain('var(--bad-light)')
+  it('returns destructive for offline/stopped', () => {
+    expect(statusClass(makeRow({ keepalive_running: false }))).toBe('text-destructive')
+    expect(statusClass(makeRow({ status: 'stopped' }))).toBe('text-destructive')
   })
 
   // Lock the remaining offline-trigger status strings in statusClass.
@@ -416,24 +413,24 @@ describe('statusClass', () => {
     'unbooted',
     'dead',
     'crashed',
-  ])('returns bad-light for status=%s', (status) => {
-    expect(statusClass(makeRow({ status }))).toContain('var(--bad-light)')
+  ])('returns destructive for status=%s', (status) => {
+    expect(statusClass(makeRow({ status }))).toBe('text-destructive')
   })
 
-  it('returns warn for runtime blocker', () => {
-    expect(statusClass(makeRow({ runtime_blocker_class: 'turn_timeout' }))).toContain('var(--color-status-warn)')
+  it('returns warning for runtime blocker', () => {
+    expect(statusClass(makeRow({ runtime_blocker_class: 'turn_timeout' }))).toBe('text-warning')
   })
 
-  it('returns warn for stale diagnostic health state', () => {
-    expect(statusClass(makeRow({ status: 'inactive', diagnostic_health_state: 'stale' }))).toContain('var(--color-status-warn)')
+  it('returns warning for stale diagnostic health state', () => {
+    expect(statusClass(makeRow({ status: 'inactive', diagnostic_health_state: 'stale' }))).toBe('text-warning')
   })
 
-  it('returns bad-light for offline diagnostic health state', () => {
-    expect(statusClass(makeRow({ status: 'inactive', diagnostic_health_state: 'offline' }))).toContain('var(--bad-light)')
+  it('returns destructive for offline diagnostic health state', () => {
+    expect(statusClass(makeRow({ status: 'inactive', diagnostic_health_state: 'offline' }))).toBe('text-destructive')
   })
 
-  it('returns ok for healthy', () => {
-    expect(statusClass(makeRow())).toContain('var(--color-status-ok)')
+  it('returns success for healthy', () => {
+    expect(statusClass(makeRow())).toBe('text-success')
   })
 })
 

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -214,10 +214,10 @@ export function healthStatusColor(status: string | undefined): string {
 }
 
 export function successClass(rate: number | null): string {
-  if (rate == null || !Number.isFinite(rate)) return 'text-[var(--color-fg-disabled)]'
-  if (rate >= 97) return 'text-[var(--color-status-ok)]'
-  if (rate >= 90) return 'text-[var(--color-status-warn)]'
-  return 'text-[var(--bad-light)]'
+  if (rate == null || !Number.isFinite(rate)) return 'text-text-disabled'
+  if (rate >= 97) return 'text-success'
+  if (rate >= 90) return 'text-warning'
+  return 'text-destructive'
 }
 
 function keeperMetricsWindowTools(keeper: Keeper): string[] {
@@ -495,9 +495,9 @@ export function toneForPressure(hot: number, warn: number): 'neutral' | 'ok' | '
 }
 
 export function pressureClass(ratio: number): string {
-  if (ratio >= PRESSURE_HOT_RATIO) return 'text-[var(--bad-light)]'
-  if (ratio >= PRESSURE_WARN_RATIO) return 'text-[var(--color-status-warn)]'
-  return 'text-[var(--color-status-ok)]'
+  if (ratio >= PRESSURE_HOT_RATIO) return 'text-destructive'
+  if (ratio >= PRESSURE_WARN_RATIO) return 'text-warning'
+  return 'text-success'
 }
 
 export function statusClass(row: FleetRow): string {
@@ -508,7 +508,7 @@ export function statusClass(row: FleetRow): string {
     || isOfflineDiagnosticHealthState(diagnosticHealthState)
     || FLEET_OFFLINE_STATUSES.has(normalizedStatus)
   ) {
-    return 'text-[var(--bad-light)]'
+    return 'text-destructive'
   }
   if (
     isAttentionDiagnosticHealthState(diagnosticHealthState)
@@ -517,10 +517,10 @@ export function statusClass(row: FleetRow): string {
     || row.runtime_trust_attention === true
     || row.terminal_reason_severity === 'bad'
   ) {
-    return 'text-[var(--color-status-warn)]'
+    return 'text-warning'
   }
-  if (row.context_ratio >= PRESSURE_HOT_RATIO) return 'text-[var(--color-status-warn)]'
-  return 'text-[var(--color-status-ok)]'
+  if (row.context_ratio >= PRESSURE_HOT_RATIO) return 'text-warning'
+  return 'text-success'
 }
 
 export function formatPercent(value: number | null, digits = 0): string {
@@ -558,18 +558,18 @@ function formatSourceAge(seconds: number | null | undefined): string | null {
 export function sourceCountClass(source: TelemetrySourceSummary): string {
   switch ((source.health ?? '').toLowerCase()) {
     case 'missing':
-      return 'text-[var(--bad-light)]'
+      return 'text-destructive'
     case 'stale':
     case 'coverage_gap':
-      return 'text-[var(--color-status-warn)]'
+      return 'text-warning'
     case 'ok':
-      return 'text-[var(--color-status-ok)]'
+      return 'text-success'
   }
-  if (source.exists === false) return 'text-[var(--bad-light)]'
-  if (source.entry_count <= 0) return 'text-[var(--color-fg-disabled)]'
+  if (source.exists === false) return 'text-destructive'
+  if (source.entry_count <= 0) return 'text-text-disabled'
   const age = numericAge(source.latest_age_s)
-  if (age != null && age >= TELEMETRY_SOURCE_STALE_SEC) return 'text-[var(--color-status-warn)]'
-  return 'text-[var(--color-status-ok)]'
+  if (age != null && age >= TELEMETRY_SOURCE_STALE_SEC) return 'text-warning'
+  return 'text-success'
 }
 
 export function sourceDetail(source: TelemetrySourceSummary): string {

--- a/dashboard/src/components/lab-perf.ts
+++ b/dashboard/src/components/lab-perf.ts
@@ -61,22 +61,13 @@ function FpsBadge() {
   const toneClass = {
     ok: 'text-success border-success/20 bg-success/10',
     warn: 'text-warning border-warning/20 bg-warning/10',
-    bad: 'text-destructive border-destructive/20 bg-destructive/10',
-  }[tone]
-
-  const dotClass = {
-    ok: 'bg-success',
-    warn: 'bg-warning',
-    bad: 'bg-destructive',
-  }[tone]
+    bad: 'text-destructive border-destructive/20 bg-destructive/10',  }[tone]
 
   return html`
     <span
-      class=${`inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-[11px] font-semibold ${toneClass}`}
-      data-testid="lab-perf-fps"
+      class=${`inline-flex items-center gap-2 rounded-[var(--r-0)] border px-2.5 py-1 text-[12px] font-semibold ${toneClass}`}      data-testid="lab-perf-fps"
     >
-      <span class="size-2 rounded-full ${dotClass}" aria-hidden="true"></span>
-      <span>${fps} fps</span>
+      <span class="size-2 rounded-full ${tone === 'ok' ? 'bg-success' : tone === 'warn' ? 'bg-warning' : 'bg-destructive'}" aria-hidden="true"></span>      <span>${fps} fps</span>
     </span>
   `
 }
@@ -91,10 +82,9 @@ function LogRow({ row }: { row: PerfLogRow }) {
   return html`
     <div class="flex items-center gap-3 px-3 py-2 text-[14px] font-mono border-b border-border last:border-b-0">
       <span class="w-14 shrink-0 text-text-disabled">${row.t}</span>
-      <span class=${`w-11 shrink-0 uppercase text-[11px] tracking-wider ${levelClass}`}>${row.level}</span>
+      <span class=${`w-11 shrink-0 uppercase text-[12px] tracking-wider ${levelClass}`}>${row.level}</span>
       <span class="w-24 shrink-0 truncate text-text-secondary">${row.keeper}</span>
-      <span class="min-w-0 flex-1 truncate text-text-primary">${row.msg}</span>
-    </div>
+      <span class="min-w-0 flex-1 truncate text-text-primary">${row.msg}</span>    </div>
   `
 }
 
@@ -102,24 +92,18 @@ export function LabPerf() {
   const rows = useMemo(() => generateRows(2000), [])
 
   return html`
-    <div class="v2-lab-surface ss-surface bg-surface-page flex flex-col gap-6 px-6 py-6" data-testid="lab-perf-surface">
-      <div class="flex items-center justify-between gap-4 v2-monitoring-toolbar">
-        <div>
+    <div class="v2-lab-surface ss-surface flex flex-col space-y-6 py-6" data-testid="lab-perf-surface">
+      <div class="flex items-center justify-between gap-4 v2-monitoring-toolbar px-6">        <div>
           <h2 class="text-[18px] font-bold text-text-primary">Performance</h2>
-          <p class="text-[13px] text-text-tertiary">FPS meter + VirtualList windowing demo</p>
-        </div>
+          <p class="text-[12px] text-text-tertiary">FPS meter + VirtualList windowing demo</p>        </div>
         <${FpsBadge} />
       </div>
 
-      <div class="ss-card v2-monitoring-panel rounded-2xl border border-border p-6">
-        <div class="mb-3 flex items-center justify-between gap-3">
-          <div class="text-[12px] font-semibold uppercase tracking-[0.05em] text-text-secondary">
-            VirtualList · ${rows.length.toLocaleString()} rows
+      <div class="v2-monitoring-panel ss-card rounded-[var(--r-2)] border border-border p-4 mx-6">        <div class="mb-3 flex items-center justify-between gap-3">
+          <div class="text-[12px] font-semibold uppercase tracking-wider text-text-tertiary">            VirtualList · ${rows.length.toLocaleString()} rows
           </div>
-          <span class="text-[11px] text-text-disabled">fixed 36 px rows</span>
-        </div>
-        <div class="h-80 overflow-hidden rounded-xl border border-border bg-surface-page">
-          <${VirtualList}
+          <span class="text-[12px] text-text-disabled">fixed 36 px rows</span>        </div>
+        <div class="h-80 overflow-hidden rounded-[var(--r-1)] border border-border bg-surface-page">          <${VirtualList}
             items=${rows}
             itemHeight=${36}
             getKey=${(row: PerfLogRow) => row.id}
@@ -127,9 +111,8 @@ export function LabPerf() {
             className="h-full"
           />
         </div>
-        <p class="mt-3 text-[13px] leading-relaxed text-text-tertiary">
-          동일한 <code class="rounded bg-surface-subtle px-1 py-0.5 text-text-primary">LogRow</code> 컴포넌트를
-          VirtualList로 윈도잉하면 보이는 슬라이스(+overscan)만 렌더링됩니다.
+        <p class="mt-3 text-[12px] leading-relaxed text-text-tertiary">
+          동일한 <code class="rounded bg-surface-muted px-1 py-0.5">LogRow</code> 컴포넌트를          VirtualList로 윈도잉하면 보이는 슬라이스(+overscan)만 렌더링됩니다.
         </p>
       </div>
     </div>

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -394,11 +394,10 @@ function FleetTicker({ events }: { events: FleetTickerEvent[] }) {
   if (events.length === 0) return null
   return html`
     <${SectionCard}
-      title="Fleet Ticker"
-      class="v2-overview-ticker ss-card mx-6"
+      label="Fleet Ticker"
       variant="standard"
-      right=${html`<span class="text-[12px] text-text-tertiary">latest ${events.length}</span>`}
-      data-testid="overview-fleet-ticker"
+      class="v2-overview-ticker mx-6"
+      right=${html`<span class="text-[12px] text-text-tertiary">latest ${events.length}</span>`}      data-testid="overview-fleet-ticker"
     >
       <div
         role="list"
@@ -409,16 +408,13 @@ function FleetTicker({ events }: { events: FleetTickerEvent[] }) {
           <div
             key=${event.id}
             role="listitem"
-            class="v2-overview-ticker-card grid min-w-[15rem] max-w-[22rem] max-[768px]:min-w-[12rem] flex-[0_0_auto] gap-1 rounded-md border border-border bg-card px-3 py-2"
-          >
-            <div class="flex min-w-0 items-center gap-2 font-mono text-[10px] uppercase tracking-wider">
-              <span class=${tickerToneClass(event.tone)}>${event.kind}</span>
+            class="v2-overview-ticker-card ss-card grid min-w-[15rem] max-w-[22rem] max-[768px]:min-w-[12rem] flex-[0_0_auto] gap-1 border border-border px-3 py-2"          >
+            <div class="flex min-w-0 items-center gap-2 font-mono text-[11px] uppercase tracking-wider">              <span class=${tickerToneClass(event.tone)}>${event.kind}</span>
               <span class="truncate text-text-tertiary">${event.actor}</span>
               <${TimeAgo} timestamp=${event.timestamp} class="ml-auto shrink-0 text-text-disabled" />
             </div>
-            <div class="truncate text-[13px] font-semibold text-text-primary">${event.text}</div>
-            <div class="truncate font-mono text-[10px] uppercase tracking-wider text-text-disabled">${event.label}</div>
-          </div>
+            <div class="truncate text-[14px] font-semibold text-text-primary">${event.text}</div>
+            <div class="truncate font-mono text-[11px] uppercase tracking-wider text-text-disabled">${event.label}</div>          </div>
         `)}
       </div>
     <//>
@@ -434,12 +430,11 @@ function AlertPanel({ agentAlerts, taskAlerts }: { agentAlerts: AgentAlert[]; ta
 
   return html`
     <${SectionCard}
-      title="Alerts"
-      class="v2-overview-alerts ss-card mx-6"
+      label="Alerts"
       variant="standard"
-      tone=${hasCritical ? 'border-destructive' : 'border-warning'}
-      right=${html`<${StatusDot} class=${hasCritical ? 'bg-destructive' : 'bg-warning'} />`}
-      data-testid="overview-alerts"
+      class="v2-overview-alerts mx-6"
+      tone=${hasCritical ? 'border-destructive/45' : 'border-warning/45'}
+      right=${html`<${StatusDot} class=${hasCritical ? 'bg-destructive' : 'bg-warning'} />`}      data-testid="overview-alerts"
     >
       <div class="mb-4">
         <${KpiStripIsland}
@@ -461,9 +456,8 @@ function AlertPanel({ agentAlerts, taskAlerts }: { agentAlerts: AgentAlert[]; ta
               }}
             >
               <div class="flex-1 min-w-0">
-                <p class="text-[13px] font-semibold truncate text-text-primary">${'name' in a ? a.display : a.title}</p>
-                <p class="text-[11px] text-text-tertiary truncate">${'reason' in a ? a.reason : a.status}</p>
-              </div>
+                <p class="text-[14px] font-semibold truncate text-text-primary">${'name' in a ? a.display : a.title}</p>
+                <p class="text-[12px] text-text-tertiary truncate">${'reason' in a ? a.reason : a.status}</p>              </div>
               <span class=${`chip sm shrink-0 ${a.severity === 'critical' ? 'is-err' : 'is-warn'}`}>
                 ${a.severity.toUpperCase()}
               </span>
@@ -543,14 +537,7 @@ function FunnelCard({ counts }: { counts: FunnelCounts }) {
   const total = counts.created + counts.inProgress + counts.awaiting + counts.completed
   const segPct = (n: number) => total > 0 ? (n / total) * 100 : 0
   return html`
-    <${SectionCard}
-      label="Today"
-      class="v2-overview-funnel ss-card mx-6"
-      variant="standard"
-      right=${html`<span class="text-[12px] text-text-tertiary">task basis</span>`}
-      data-testid="overview-funnel"
-    >
-      <${KpiStripIsland}
+    <${SectionCard} label="Today" variant="standard" class="v2-overview-funnel mx-6" right=${html`<span class="text-[12px] text-text-tertiary">task basis</span>`} data-testid="overview-funnel">      <${KpiStripIsland}
         ariaLabel="Today funnel"
         cols=${5}
         cells=${[
@@ -586,9 +573,8 @@ export function progressPct(session: DashboardMissionSessionCard | null): number
 function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | null }) {
   if (!active) {
     return html`
-      <${SectionCard} label="Active mission" class="v2-overview-party ss-card mx-6" variant="standard" data-testid="overview-party-empty">
-        <p class="text-[11px] text-text-tertiary italic">No active mission</p>
-      <//>
+      <${SectionCard} label="Active mission" variant="standard" class="v2-overview-party mx-6" data-testid="overview-party-empty">
+        <p class="text-[12px] text-text-tertiary italic">No active mission</p>      <//>
     `
   }
 
@@ -597,15 +583,12 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
   const members = active.member_names
 
   return html`
-    <${SectionCard} label="Active Mission" class="v2-overview-party ss-card mx-6" variant="standard" data-testid="overview-party">
-      <div class="space-y-4">
+    <${SectionCard} label="Active Mission" variant="standard" class="v2-overview-party mx-6" data-testid="overview-party">      <div class="space-y-4">
         <div class="flex items-center justify-between">
-           <p class="text-[13px] font-semibold text-text-primary truncate flex-1 mr-4">
-             ${active.goal}
+           <p class="text-[14px] font-semibold text-text-primary truncate flex-1 mr-4">             ${active.goal}
            </p>
            <div class="flex -space-x-1.5">
-             ${members.map(m => html`<${AgentAvatar} key=${m} name=${m} size="xs" class="ring-1 ring-[var(--bg-surface-page)]" />`)}
-           </div>
+             ${members.map(m => html`<${AgentAvatar} key=${m} name=${m} size="xs" class="ring-1 ring-surface-page" />`)}           </div>
         </div>
 
         <div class="grid grid-cols-2 gap-3">
@@ -651,6 +634,7 @@ function keeperPillClass(status?: string | null): string {
   }
 }
 
+
 function keeperStatusLabel(status?: string | null): string {
   switch ((status ?? '').toLowerCase()) {
     case 'active': case 'live': return 'Active'
@@ -681,28 +665,23 @@ function KeeperStrip({ keeperList }: { keeperList: readonly Keeper[] }) {
 
   if (activeKeepers.length === 0) {
     return html`
-      <${SectionCard} label="Active Keepers" class="v2-overview-keepers ss-card mx-6" variant="standard" data-testid="overview-keepers-empty">
-        <p class="text-[11px] text-text-tertiary italic">No active keepers</p>
-      <//>
+      <${SectionCard} label="Active Keepers" variant="standard" class="v2-overview-keepers mx-6" data-testid="overview-keepers-empty">
+        <p class="text-[12px] text-text-tertiary italic">No active keepers</p>      <//>
     `
   }
 
   return html`
-    <${SectionCard} label="Active Keepers" class="v2-overview-keepers ss-card mx-6" variant="standard" data-testid="overview-keepers">
-      <ul class="flex flex-wrap gap-x-6 gap-y-2">
+    <${SectionCard} label="Active Keepers" variant="standard" class="v2-overview-keepers mx-6" data-testid="overview-keepers">      <ul class="flex flex-wrap gap-x-6 gap-y-2">
         ${activeKeepers.map(
           k => {
             const displayStatus = keeperDisplayStatus(k)
             return html`
             <li key=${k.name} class="flex items-center gap-2">
               <div class="min-w-0">
-                <p class="text-[13px] font-medium truncate text-text-primary">${k.koreanName && k.koreanName !== '' ? k.koreanName : k.name}</p>
-                ${k.last_heartbeat !== undefined
-                  ? html`<${TimeAgo} timestamp=${k.last_heartbeat} class="text-[10px] text-text-tertiary" />`
-                  : null}
+                <p class="text-[14px] font-medium truncate text-text-primary">${k.koreanName && k.koreanName !== '' ? k.koreanName : k.name}</p>                ${k.last_heartbeat !== undefined
+                  ? html`<${TimeAgo} timestamp=${k.last_heartbeat} class="text-[11px] text-text-tertiary" />`                  : null}
               </div>
-              <span class="${keeperPillClass(displayStatus)} text-[10px] shrink-0">${keeperStatusLabel(displayStatus)}</span>
-            </li>
+              <span class="${keeperPillClass(displayStatus)} text-[11px] shrink-0">${keeperStatusLabel(displayStatus)}</span>            </li>
             `
           },
         )}
@@ -737,13 +716,7 @@ function SurfaceReadinessSummary() {
 
   const summary = summarizeSurfaceReadiness(state.data)
   return html`
-    <${SectionCard}
-      label="Surface Readiness"
-      class="v2-overview-readiness ss-card mx-6"
-      variant="standard"
-      data-testid="overview-surface-readiness"
-    >
-      <${KpiStripIsland}
+    <${SectionCard} label="Surface Readiness" variant="standard" class="v2-overview-readiness mx-6" data-testid="overview-surface-readiness">      <${KpiStripIsland}
         ariaLabel="Surface readiness summary"
         cols=${3}
         cells=${[
@@ -768,13 +741,12 @@ function OverviewHeader({ stats }: { stats: OverviewStats }) {
   useNowSecondsTicker()
   const clock = nowHMKst()
   return html`
-    <header class="v2-overview-head flex flex-wrap items-end justify-between gap-3" data-testid="overview-head">
+    <header class="v2-overview-head flex flex-wrap items-end justify-between gap-3 px-6" data-testid="overview-head">
       <div>
-        <h1 class="text-[18px] font-bold tracking-normal text-text-secondary">운영 개요</h1>
+        <h1 class="text-[20px] font-semibold tracking-normal text-text-secondary">운영 개요</h1>
         <p class="m-0 mt-1 text-[12px] text-text-tertiary">
           <span title="최상위 조정 범위 — 모든 room/keeper를 담는 root namespace">namespace <span class="font-mono text-text-secondary">masc-mcp</span></span>
-          <span class="mx-1 text-text-disabled">·</span>
-          <span title="등록된 keeper 총 수">Keeper ${stats.total}</span>
+          <span class="mx-1 text-text-disabled">·</span>          <span title="등록된 keeper 총 수">Keeper ${stats.total}</span>
           <span class="mx-1 text-text-disabled">·</span>
           <span title="현재 토큰으로 로그인한 운영자">operator <b class="text-text-secondary">@operator</b></span>
         </p>
@@ -788,13 +760,7 @@ function OverviewHeader({ stats }: { stats: OverviewStats }) {
 
 function OverviewKpiStrip({ stats }: { stats: OverviewStats }) {
   return html`
-    <${SectionCard}
-      label="Fleet KPIs"
-      class="v2-overview-kpis ss-card mx-6"
-      variant="standard"
-      data-testid="overview-kpis"
-    >
-      <${KpiStripIsland}
+    <${SectionCard} label="Fleet KPIs" variant="standard" class="v2-overview-kpis mx-6" data-testid="overview-kpis">      <${KpiStripIsland}
         ariaLabel="Fleet KPIs"
         cols=${6}
         cells=${[
@@ -828,19 +794,17 @@ function OverviewAttentionPanel({ keeperList }: { keeperList: readonly Keeper[] 
 
   if (attn.length === 0) {
     return html`
-      <${SectionCard} label="주의 필요" class="v2-overview-attention ss-card" variant="standard" data-testid="overview-attention">
-        <p class="text-[11px] text-text-tertiary italic">모든 keeper 정상</p>
-      <//>
+      <${SectionCard} label="주의 필요" variant="standard" class="v2-overview-attention mx-6" data-testid="overview-attention">
+        <p class="text-[12px] text-text-tertiary italic">모든 keeper 정상</p>      <//>
     `
   }
 
   return html`
     <${SectionCard}
       label="주의 필요"
-      class="v2-overview-attention ss-card"
       variant="standard"
-      right=${html`<span class="text-[12px] text-text-tertiary">${attn.length}</span>`}
-      data-testid="overview-attention"
+      class="v2-overview-attention mx-6"
+      right=${html`<span class="text-[12px] text-text-tertiary">${attn.length}</span>`}      data-testid="overview-attention"
     >
       <div class="v2-overview-attention-list flex flex-col gap-2">
         ${attn.map(k => {
@@ -849,25 +813,20 @@ function OverviewAttentionPanel({ keeperList }: { keeperList: readonly Keeper[] 
           return html`
             <div
               key=${k.name}
-              class="v2-overview-attention-row flex cursor-pointer items-center gap-3 rounded-md border border-border bg-card p-2 transition-colors hover:border-strong hover:bg-surface-subtle"
-              onClick=${() => navigate('monitoring', { section: 'agents', keeper: k.name })}
+              class="v2-overview-attention-row flex cursor-pointer items-center gap-3 rounded-[var(--r-1)] border border-border bg-card p-2 transition-colors hover:border-border hover:bg-surface-subtle"              onClick=${() => navigate('monitoring', { section: 'agents', keeper: k.name })}
               data-testid=${`attention-row-${k.name}`}
             >
               <${AgentAvatar} name=${k.name} size="sm" status=${keeperDisplayStatus(k)} />
               <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2 text-[13px] font-semibold text-text-primary">
-                  ${displayName}
-                  <span class="font-mono text-[11px] text-text-tertiary">${k.name}</span>
-                </div>
-                <div class="flex items-center gap-1.5 text-[11px] text-text-tertiary">
-                  <span class="inline-block size-1.5 rounded-full ${attentionToneClass(reason.sev)}"></span>
+                <div class="flex items-center gap-2 text-[14px] font-semibold text-text-primary">                  ${displayName}
+                  <span class="font-mono text-[12px] text-text-tertiary">${k.name}</span>                </div>
+                <div class="flex items-center gap-1.5 text-[12px] text-text-tertiary">                  <span class="inline-block size-1.5 rounded-full ${attentionToneClass(reason.sev)}"></span>
                   <span class=${reason.sev === 'bad' ? 'text-destructive' : 'text-warning'}>${reason.text}</span>
                 </div>
               </div>
               <button
                 type="button"
-                class="text-[11px] font-medium text-brand hover:underline"
-                onClick=${(e: MouseEvent) => {
+                class="text-[12px] font-medium text-brand hover:underline min-h-11 px-2"                onClick=${(e: MouseEvent) => {
                   e.stopPropagation()
                   navigate('monitoring', { section: 'agents', keeper: k.name })
                 }}
@@ -886,10 +845,9 @@ function OverviewTelemetry({ bars }: { bars: number[] }) {
   return html`
     <${SectionCard}
       label="텔레메트리"
-      class="v2-overview-telemetry ss-card"
       variant="standard"
-      right=${html`<span class="text-[12px] font-mono text-text-tertiary">trace / 5m · last 140m</span>`}
-      data-testid="overview-telemetry"
+      class="v2-overview-telemetry mx-6"
+      right=${html`<span class="text-[12px] font-mono text-text-tertiary">trace / 5m · last 140m</span>`}      data-testid="overview-telemetry"
     >
       <div class="v2-overview-bars flex h-24 items-end gap-0.5" role="img" aria-label="Trace telemetry histogram">
         ${bars.map((b, i) => html`
@@ -900,12 +858,11 @@ function OverviewTelemetry({ bars }: { bars: number[] }) {
           ></span>
         `)}
       </div>
-      <div class="mt-3 grid grid-cols-4 gap-2 text-[11px]">
+      <div class="mt-3 grid grid-cols-4 gap-2 text-[12px]">
         <div><span class="text-text-tertiary">피크</span><span class="ml-2 font-mono text-text-secondary">112/5m</span></div>
         <div><span class="text-text-tertiary">평균</span><span class="ml-2 font-mono text-text-secondary">47/5m</span></div>
         <div><span class="text-text-tertiary">오류율</span><span class="ml-2 font-mono text-success">0.4%</span></div>
-        <div><span class="text-text-tertiary">p95 지연</span><span class="ml-2 font-mono text-text-secondary">1.8s</span></div>
-      </div>
+        <div><span class="text-text-tertiary">p95 지연</span><span class="ml-2 font-mono text-text-secondary">1.8s</span></div>      </div>
     <//>
   `
 }
@@ -913,9 +870,8 @@ function OverviewTelemetry({ bars }: { bars: number[] }) {
 function OverviewFleetGrid({ keeperList }: { keeperList: readonly Keeper[] }) {
   if (keeperList.length === 0) {
     return html`
-      <${SectionCard} label="Keeper 전체" class="v2-overview-fleet ss-card mx-6" variant="standard" data-testid="overview-fleet">
-        <p class="text-[11px] text-text-tertiary italic">No keepers</p>
-      <//>
+      <${SectionCard} label="Keeper 전체" variant="standard" class="v2-overview-fleet mx-6" data-testid="overview-fleet">
+        <p class="text-[12px] text-text-tertiary italic">No keepers</p>      <//>
     `
   }
 
@@ -934,13 +890,11 @@ function OverviewFleetGrid({ keeperList }: { keeperList: readonly Keeper[] }) {
   return html`
     <${SectionCard}
       label="Keeper 전체"
-      class="v2-overview-fleet ss-card mx-6"
       variant="standard"
-      right=${html`
+      class="v2-overview-fleet mx-6"      right=${html`
         <button
           type="button"
-          class="text-[11px] text-brand hover:underline"
-          onClick=${() => navigate('monitoring', { section: 'agents' })}
+          class="text-[12px] text-brand hover:underline min-h-11 px-2"          onClick=${() => navigate('monitoring', { section: 'agents' })}
         >
           전체 대화 보기 →
         </button>
@@ -958,26 +912,22 @@ function OverviewFleetGrid({ keeperList }: { keeperList: readonly Keeper[] }) {
             <button
               key=${k.name}
               type="button"
-              class="v2-overview-keeper text-left rounded-md border border-border bg-card p-3 transition-colors hover:border-strong hover:bg-surface-subtle"
-              onClick=${() => navigate('monitoring', { section: 'agents', keeper: k.name })}
+              class="v2-overview-keeper ss-card text-left border border-border bg-card p-3 transition-colors hover:border-border hover:bg-surface-subtle"              onClick=${() => navigate('monitoring', { section: 'agents', keeper: k.name })}
               data-testid=${`overview-keeper-${k.name}`}
             >
               <div class="flex items-center gap-2">
                 <${AgentAvatar} name=${k.name} size="sm" status=${displayStatus} />
                 <div class="min-w-0 flex-1">
-                  <div class="truncate text-[13px] font-semibold text-text-primary">${displayName}</div>
-                  <div class="flex items-center gap-1.5 text-[11px] text-text-tertiary">
-                    <${StatusDot} class=${isRunning ? 'bg-success' : 'bg-text-disabled'} />
-                    <span class="truncate">${k.phase ?? k.lifecycle_phase ?? displayStatus}</span>
+                  <div class="truncate text-[14px] font-semibold text-text-primary">${displayName}</div>
+                  <div class="flex items-center gap-1.5 text-[12px] text-text-tertiary">
+                    <${StatusDot} class=${isRunning ? 'bg-success' : 'bg-text-disabled'} />                    <span class="truncate">${k.phase ?? k.lifecycle_phase ?? displayStatus}</span>
                   </div>
                 </div>
                 ${pickAttentionKeepers([k]).length > 0
-                  ? html`<span class="v2-overview-keeper-att inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-[11px] font-semibold text-white">!</span>`
-                  : null}
+                  ? html`<span class="v2-overview-keeper-att inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-[12px] font-semibold text-white">!</span>`                  : null}
               </div>
-              <div class="mt-2 flex items-center justify-between gap-2 text-[11px]">
-                <span class="font-mono text-text-tertiary">${keeperModelLabel(k)}</span>
-                <div class="flex flex-1 items-center gap-2">
+              <div class="mt-2 flex items-center justify-between gap-2 text-[12px]">
+                <span class="font-mono text-text-tertiary">${keeperModelLabel(k)}</span>                <div class="flex flex-1 items-center gap-2">
                   <div class="v2-overview-mini-meter h-1 flex-1 rounded-full bg-surface-muted">
                     <span class="block h-full rounded-full ${ctx >= 0.85 ? 'bg-destructive' : ctx >= 0.6 ? 'bg-warning' : 'bg-success'}" style=${{ width: `${Math.min(100, ctxPct)}%` }}></span>
                   </div>
@@ -1015,8 +965,7 @@ export function Overview() {
   const bars = useMemo(() => telemetryBars(keeperList), [keeperList])
 
   return html`
-    <div class="v2-overview-surface ss-surface flex flex-col space-y-6 bg-surface-page text-text-primary">
-      <${OverviewHeader} stats=${stats} />
+    <div class="v2-overview-surface ss-surface flex flex-col space-y-6 py-6">      <${OverviewHeader} stats=${stats} />
       <${OverviewKpiStrip} stats=${stats} />
       <${AlertPanel} agentAlerts=${agentAlerts} taskAlerts=${taskAlerts} />
       <div class="grid gap-6 px-6 lg:grid-cols-2">

--- a/dashboard/src/components/section-head.ts
+++ b/dashboard/src/components/section-head.ts
@@ -101,6 +101,7 @@ export function SectionHead(props: SectionHeadProps): VNode {
 
   return html`
     <div
+      data-section-head
       data-testid=${props.testId}
       aria-label=${props.ariaLabel}
       style=${containerStyle}

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -49,6 +49,8 @@
 @import "./v2-monitoring-leftovers.css";
 @import "./v2-lab.css";
 @import "./v2-ide.css";
+@import "./styleseed-theme.css";
+@import "./styleseed-base.css";
 @import "./a11y.css"; /* after feature styles so reduced-motion overrides win */
 
 /* Strangler Fig migration bridge — bridges legacy CSS hooks to

--- a/dashboard/src/styles/styleseed-base.css
+++ b/dashboard/src/styles/styleseed-base.css
@@ -64,6 +64,167 @@
   border: var(--card-border);
 }
 
+/* Section head strip inside StyleSeed cards */
+[data-theme="styleseed"] [data-section-head] {
+  background-color: var(--surface-subtle) !important;
+  border-bottom-color: var(--border) !important;
+  color: var(--text-secondary) !important;
+}
+
+/* Primitive colour bridges for migrated surfaces */
+[data-theme="styleseed"] .bar {
+  background-color: var(--surface-muted);
+}
+[data-theme="styleseed"] .bar > .fill {
+  background-color: var(--brand);
+}
+[data-theme="styleseed"] .bar.is-ok > .fill,
+[data-theme="styleseed"] .bar-seg .seg-ok {
+  background-color: var(--success);
+}
+[data-theme="styleseed"] .bar.is-warn > .fill,
+[data-theme="styleseed"] .bar-seg .seg-warn {
+  background-color: var(--warning);
+}
+[data-theme="styleseed"] .bar.is-err > .fill,
+[data-theme="styleseed"] .bar-seg .seg-err {
+  background-color: var(--destructive);
+}
+[data-theme="styleseed"] .bar-seg {
+  background-color: var(--surface-muted);
+}
+[data-theme="styleseed"] .bar-seg .seg-idle {
+  background-color: var(--surface-muted);
+}
+
+[data-theme="styleseed"] .chip.is-ok,
+[data-theme="styleseed"] .pill.is-ok {
+  color: var(--success);
+  border-color: color-mix(in srgb, var(--success) 35%, transparent);
+  background-color: color-mix(in srgb, var(--success) 10%, transparent);
+}
+[data-theme="styleseed"] .chip.is-warn,
+[data-theme="styleseed"] .pill.is-warn {
+  color: var(--warning);
+  border-color: color-mix(in srgb, var(--warning) 35%, transparent);
+  background-color: color-mix(in srgb, var(--warning) 10%, transparent);
+}
+[data-theme="styleseed"] .chip.is-err,
+[data-theme="styleseed"] .pill.is-err {
+  color: var(--destructive);
+  border-color: color-mix(in srgb, var(--destructive) 35%, transparent);
+  background-color: color-mix(in srgb, var(--destructive) 10%, transparent);
+}
+[data-theme="styleseed"] .pill.is-running {
+  color: var(--brand);
+  border-color: color-mix(in srgb, var(--brand) 35%, transparent);
+  background-color: color-mix(in srgb, var(--brand) 10%, transparent);
+}
+[data-theme="styleseed"] .pill.is-paused {
+  color: var(--text-secondary);
+  border-color: var(--border);
+  background-color: var(--surface-subtle);
+}
+
+/* Cockpit command-map bridge */
+[data-theme="styleseed"] .cp-main {
+  background-color: var(--surface-page);
+}
+[data-theme="styleseed"] .cp-head .cp-eyebrow {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+[data-theme="styleseed"] .cp-head .cp-title {
+  color: var(--text-primary);
+  font-size: 20px;
+}
+[data-theme="styleseed"] .cp-head .cp-sub {
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
+[data-theme="styleseed"] .cp-disc,
+[data-theme="styleseed"] .cp-plane {
+  background-color: var(--card);
+  border-color: var(--border);
+}
+[data-theme="styleseed"] .cp-disc-h {
+  border-bottom-color: var(--border);
+}
+[data-theme="styleseed"] .cp-disc-h h3 {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+[data-theme="styleseed"] .cp-disc-row .lvl {
+  color: var(--brand);
+}
+[data-theme="styleseed"] .cp-disc-row .ttl {
+  color: var(--text-primary);
+  font-size: 14px;
+}
+[data-theme="styleseed"] .cp-disc-row .sum {
+  color: var(--text-tertiary);
+  font-size: 13px;
+}
+[data-theme="styleseed"] .cp-disc-row .mtr {
+  color: var(--text-secondary);
+  background-color: var(--surface-subtle);
+  border-color: var(--border);
+}
+[data-theme="styleseed"] .cp-plane-h {
+  background-color: var(--surface-subtle);
+  border-bottom-color: var(--border);
+}
+[data-theme="styleseed"] .cp-plane-ico {
+  color: var(--brand);
+  background-color: var(--surface-subtle);
+  border-color: var(--border);
+}
+[data-theme="styleseed"] .cp-plane-h h2 {
+  color: var(--text-primary);
+  font-size: 18px;
+  font-weight: 700;
+}
+[data-theme="styleseed"] .cp-plane-h .sum {
+  color: var(--text-tertiary);
+}
+[data-theme="styleseed"] .cp-cov.ok {
+  color: var(--success);
+  border-color: color-mix(in srgb, var(--success) 35%, transparent);
+  background-color: color-mix(in srgb, var(--success) 10%, transparent);
+}
+[data-theme="styleseed"] .cp-cov.blk {
+  color: var(--text-secondary);
+  border-color: var(--border);
+  background-color: var(--surface-subtle);
+}
+[data-theme="styleseed"] .cp-route {
+  background-color: var(--surface-subtle);
+  border-color: var(--border);
+}
+[data-theme="styleseed"] .cp-route:hover {
+  background-color: var(--surface-muted);
+  border-color: var(--border);
+}
+[data-theme="styleseed"] .cp-route .rl {
+  color: var(--text-primary);
+  font-size: 14px;
+}
+[data-theme="styleseed"] .cp-route .rc {
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
+[data-theme="styleseed"] .cp-route .arr {
+  color: var(--text-tertiary);
+}
+[data-theme="styleseed"] .cp-route:hover .arr {
+  color: var(--brand);
+}
+
+/* Inline eyebrow / caption bridges */
+[data-theme="styleseed"] [data-eyebrow] {
+  color: var(--text-tertiary) !important;
+}
+
 /* Mobile safe-area helpers */
 [data-theme="styleseed"] .ss-safe-bottom {
   padding-bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px));

--- a/dashboard/src/styles/v2-lab.css
+++ b/dashboard/src/styles/v2-lab.css
@@ -94,6 +94,16 @@
    semantic tokens. Cards already carry .ss-card via SurfaceCard; this
    bridges the remaining v2-scoped panels, rows, and tables. */
 
+[data-theme="styleseed"] .v2-lab-surface,
+[data-theme="styleseed"] .v2-lab-panel,
+[data-theme="styleseed"] .v2-lab-card,
+[data-theme="styleseed"] .v2-lab-row,
+[data-theme="styleseed"] .v2-lab-action,
+[data-theme="styleseed"] .v2-lab-table,
+[data-theme="styleseed"] .v2-lab-detail {
+  --v2-lab-top-glow: color-mix(in srgb, var(--brand) 4%, transparent);
+}
+
 [data-theme="styleseed"] .v2-lab-surface {
   background-color: var(--surface-page);
   color: var(--text-primary);


### PR DESCRIPTION
## Summary
Migrates overview, cockpit, fleet telemetry, and lab performance surfaces to StyleSeed card-based layouts.

## What changed
- `dashboard/src/components/overview/overview.ts` + test: `ss-surface`, semantic tokens, `ss-card` on sections.
- `dashboard/src/components/cockpit/cockpit.ts`: wrapped surface, `ss-card` on sections.
- `dashboard/src/components/fleet-telemetry-panel.ts`, `fleet-telemetry-utils.ts` + tests: semantic status/text/border colors.
- `dashboard/src/components/lab-perf.ts`: FPS badge, log rows, panel to StyleSeed tokens.
- `dashboard/src/styles/styleseed-base.css`: `@theme` bridge for Tailwind v4 utilities.
- `dashboard/src/styles/v2-lab.css`: StyleSeed override block.
- `dashboard/src/styles/global.css`: imports StyleSeed theme/base.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm build` ✅
- Overview, cockpit, fleet telemetry, source-health, lab tests ✅ 186/186

## Notes
- Added `variant="standard"` on `SectionCard`s for consistent styling.
