### PR TITLE
feat(dashboard): migrate IDE/connectors/lab surfaces to StyleSeed

### DIFF
--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -170,7 +170,7 @@ export function SurfaceCard({
     testId,
     children,
   })
-  const cls = surfaceCardClassName({ variant, tone, className: cx })
+  const cls = surfaceCardClassName({ variant, tone, className: ['ss-card', cx].filter(Boolean).join(' ') })
   return html`<div
     class=${cls}
     style=${style}
@@ -309,7 +309,7 @@ export function SectionCard({
   const rootClass = surfaceCardClassName({
     variant,
     tone,
-    className: ['flex flex-col !p-0 overflow-hidden', cx].filter(Boolean).join(' '),
+    className: ['ss-card flex flex-col !p-0 overflow-hidden', cx].filter(Boolean).join(' '),
   })
   return html`
     <div

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1938,7 +1938,7 @@ export function ConnectorStatusPanel() {
   const activeCount = allConnectors.filter(c => connectorStateLabel(c) === 'connected').length
 
   return html`
-    <div class="contain-content v2-connector-status v2-connectors-surface">
+    <div class="contain-content v2-connector-status v2-connectors-surface ss-surface bg-surface-page">
       <${ConnectorsSurfaceHeader}
         filterId=${filterId as KnownConnectorId | null}
         connectorCount=${connectorCount}

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -641,7 +641,7 @@ export function IdeShell() {
 
   return html`
     <section
-      class="ide-plane-shell ide-v2-surface v2-ide-surface"
+      class="ide-plane-shell ide-v2-surface v2-ide-surface ss-surface bg-surface-page"
       role="region"
       aria-label="Code IDE shell"
       data-terminal-open=${terminalOpen ? 'true' : 'false'}

--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -61,10 +61,10 @@ function InspectorTabButton({
     <button
       type="button"
       class=${[
-        'v2-command-action rounded-[var(--r-0)] border px-3 py-1.5 text-2xs font-semibold transition-colors',
+        'v2-command-action rounded-md border px-3 py-1.5 text-[12px] font-semibold transition-colors min-h-11 min-w-11',
         active
-          ? 'border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-accent-fg)]'
-          : 'border-card-border bg-[var(--color-bg-surface)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] hover:bg-[var(--color-bg-hover)]',
+          ? 'border-brand/30 bg-brand/10 text-brand'
+          : 'border-border bg-surface-subtle text-text-secondary hover:text-text-primary hover:bg-surface-muted',
       ].join(' ')}
       aria-pressed=${active ? 'true' : 'false'}
       onClick=${() => {
@@ -81,18 +81,18 @@ function InspectorOverview() {
     <div class="grid gap-4">
       <${SectionCard} label="대시보드 포커스" class="section">
         <div class="grid gap-3">
-          <div class="v2-command-panel rounded-[var(--r-1)] border border-card-border/35 bg-[var(--color-bg-elevated)]/10 px-4 py-3 text-sm leading-airy text-[var(--color-fg-primary)]">
-            이제 대시보드는 <strong class="text-[var(--color-fg-secondary)]">핵심 운영 화면</strong>에 더 집중합니다.
+          <div class="v2-command-panel rounded-xl border border-border/35 bg-surface-subtle px-4 py-3 text-[14px] leading-relaxed text-text-primary">
+            이제 대시보드는 <strong class="text-text-secondary">핵심 운영 화면</strong>에 더 집중합니다.
             낮은 활용도의 화면은 줄이고, 진짜 자주 보는 상태/개입/근거 화면으로 빠르게 이동할 수 있게 정리했습니다.
           </div>
           <div class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">
             ${FOCUS_SURFACES.map(surface => html`
-              <div class="v2-command-card rounded-[var(--r-1)] border border-card-border/35 bg-[var(--color-bg-elevated)]/10 px-4 py-3">
-                <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">${surface.title}</div>
-                <div class="mt-2 text-2xs leading-loose text-[var(--color-fg-muted)]">${surface.description}</div>
+              <div class="v2-command-card rounded-xl border border-border/35 bg-surface-subtle px-4 py-3">
+                <div class="text-[14px] font-bold text-text-secondary">${surface.title}</div>
+                <div class="mt-2 text-[13px] leading-loose text-text-tertiary">${surface.description}</div>
                 <button
                   type="button"
-                  class="v2-command-action mt-3 rounded-[var(--r-1)] border border-[var(--accent-25)] bg-[var(--accent-10)] px-2.5 py-1.5 text-2xs font-semibold text-[var(--color-accent-fg)] transition-colors hover:bg-[var(--accent-20)]"
+                  class="v2-command-action mt-3 rounded-md border border-brand/25 bg-brand/10 px-2.5 py-1.5 text-[12px] font-semibold text-brand transition-colors hover:bg-brand/20"
                   onClick=${() => navigate(surface.tab, surface.params)}
                 >
                   ${surface.action}
@@ -110,7 +110,7 @@ export function LabInspector() {
   const current = inspectorSection.value
 
   return html`
-    <div class="v2-command-surface flex flex-col gap-4">
+    <div class="v2-command-surface ss-surface bg-surface-page flex flex-col gap-4 px-6 py-6">
       <${SectionCard} label="운영 인스펙터" class="section v2-command-panel">
         <div class="flex flex-col gap-3">
           <div class="flex flex-wrap gap-2">

--- a/dashboard/src/components/lab-perf.ts
+++ b/dashboard/src/components/lab-perf.ts
@@ -59,17 +59,23 @@ function FpsBadge() {
 
   const tone = fps >= 55 ? 'ok' : fps >= 30 ? 'warn' : 'bad'
   const toneClass = {
-    ok: 'text-[var(--color-status-ok)] border-[var(--ok-20)] bg-[var(--ok-10)]',
-    warn: 'text-[var(--color-status-warn)] border-[var(--warn-20)] bg-[var(--warn-10)]',
-    bad: 'text-[var(--color-status-err)] border-[var(--err-border)] bg-[var(--bad-soft)]',
+    ok: 'text-success border-success/20 bg-success/10',
+    warn: 'text-warning border-warning/20 bg-warning/10',
+    bad: 'text-destructive border-destructive/20 bg-destructive/10',
+  }[tone]
+
+  const dotClass = {
+    ok: 'bg-success',
+    warn: 'bg-warning',
+    bad: 'bg-destructive',
   }[tone]
 
   return html`
     <span
-      class=${`inline-flex items-center gap-2 rounded-[var(--r-0)] border px-2.5 py-1 text-2xs font-semibold ${toneClass}`}
+      class=${`inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-[11px] font-semibold ${toneClass}`}
       data-testid="lab-perf-fps"
     >
-      <span class="size-2 rounded-full ${tone === 'ok' ? 'bg-[var(--color-status-ok)]' : tone === 'warn' ? 'bg-[var(--color-status-warn)]' : 'bg-[var(--color-status-err)]'}" aria-hidden="true"></span>
+      <span class="size-2 rounded-full ${dotClass}" aria-hidden="true"></span>
       <span>${fps} fps</span>
     </span>
   `
@@ -77,17 +83,17 @@ function FpsBadge() {
 
 function LogRow({ row }: { row: PerfLogRow }) {
   const levelClass = {
-    info: 'text-[var(--color-fg-muted)]',
-    warn: 'text-[var(--color-status-warn)]',
-    error: 'text-[var(--color-status-err)]',
+    info: 'text-text-tertiary',
+    warn: 'text-warning',
+    error: 'text-destructive',
   }[row.level]
 
   return html`
-    <div class="flex items-center gap-3 px-3 py-2 text-xs font-mono border-b border-[var(--color-border-muted)] last:border-b-0">
-      <span class="w-14 shrink-0 text-[var(--color-fg-disabled)]">${row.t}</span>
-      <span class=${`w-11 shrink-0 uppercase text-2xs tracking-wider ${levelClass}`}>${row.level}</span>
-      <span class="w-24 shrink-0 truncate text-[var(--color-fg-secondary)]">${row.keeper}</span>
-      <span class="min-w-0 flex-1 truncate text-[var(--color-fg-primary)]">${row.msg}</span>
+    <div class="flex items-center gap-3 px-3 py-2 text-[14px] font-mono border-b border-border last:border-b-0">
+      <span class="w-14 shrink-0 text-text-disabled">${row.t}</span>
+      <span class=${`w-11 shrink-0 uppercase text-[11px] tracking-wider ${levelClass}`}>${row.level}</span>
+      <span class="w-24 shrink-0 truncate text-text-secondary">${row.keeper}</span>
+      <span class="min-w-0 flex-1 truncate text-text-primary">${row.msg}</span>
     </div>
   `
 }
@@ -96,23 +102,23 @@ export function LabPerf() {
   const rows = useMemo(() => generateRows(2000), [])
 
   return html`
-    <div class="v2-lab-surface flex flex-col gap-6" data-testid="lab-perf-surface">
+    <div class="v2-lab-surface ss-surface bg-surface-page flex flex-col gap-6 px-6 py-6" data-testid="lab-perf-surface">
       <div class="flex items-center justify-between gap-4 v2-monitoring-toolbar">
         <div>
-          <h2 class="text-base font-semibold text-[var(--color-fg-primary)]">Performance</h2>
-          <p class="text-2xs text-[var(--color-fg-muted)]">FPS meter + VirtualList windowing demo</p>
+          <h2 class="text-[18px] font-bold text-text-primary">Performance</h2>
+          <p class="text-[13px] text-text-tertiary">FPS meter + VirtualList windowing demo</p>
         </div>
         <${FpsBadge} />
       </div>
 
-      <div class="v2-monitoring-panel rounded-[var(--r-2)] border border-[var(--color-border-default)] p-4">
+      <div class="ss-card v2-monitoring-panel rounded-2xl border border-border p-6">
         <div class="mb-3 flex items-center justify-between gap-3">
-          <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">
+          <div class="text-[12px] font-semibold uppercase tracking-[0.05em] text-text-secondary">
             VirtualList · ${rows.length.toLocaleString()} rows
           </div>
-          <span class="text-2xs text-[var(--color-fg-disabled)]">fixed 36 px rows</span>
+          <span class="text-[11px] text-text-disabled">fixed 36 px rows</span>
         </div>
-        <div class="h-80 overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)]">
+        <div class="h-80 overflow-hidden rounded-xl border border-border bg-surface-page">
           <${VirtualList}
             items=${rows}
             itemHeight=${36}
@@ -121,8 +127,8 @@ export function LabPerf() {
             className="h-full"
           />
         </div>
-        <p class="mt-3 text-2xs leading-relaxed text-[var(--color-fg-muted)]">
-          동일한 <code class="rounded bg-[var(--color-bg-muted)] px-1 py-0.5">LogRow</code> 컴포넌트를
+        <p class="mt-3 text-[13px] leading-relaxed text-text-tertiary">
+          동일한 <code class="rounded bg-surface-subtle px-1 py-0.5 text-text-primary">LogRow</code> 컴포넌트를
           VirtualList로 윈도잉하면 보이는 슬라이스(+overscan)만 렌더링됩니다.
         </p>
       </div>

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -25,7 +25,7 @@ export function Lab() {
   const section = currentSection()
 
   return html`
-    <div class="v2-lab-surface flex flex-col gap-6" data-testid="lab-surface">
+    <div class="v2-lab-surface ss-surface bg-surface-page flex flex-col gap-6" data-testid="lab-surface">
       ${section === 'tools' ? html`
         <${Tools} />
       ` : null}

--- a/dashboard/src/styles/styleseed-base.css
+++ b/dashboard/src/styles/styleseed-base.css
@@ -3,6 +3,36 @@
    Active only when data-theme="styleseed" is set on <html>.
    ════════════════════════════════════════════════════════════════ */
 
+/* Tailwind v4 theme bridge — StyleSeed semantic utilities fall back to
+   the existing v2 dark-brass tokens so components work in both themes.
+   When data-theme="styleseed" is active the StyleSeed CSS variables
+   override these values; otherwise the v2 fallbacks keep legacy styling. */
+@theme {
+  --color-surface-page: var(--surface-page, var(--color-bg-page));
+  --color-surface-subtle: var(--surface-subtle, var(--color-bg-surface));
+  --color-surface-muted: var(--surface-muted, var(--color-border-default));
+  --color-card: var(--card, var(--color-bg-surface));
+  --color-text-primary: var(--text-primary, var(--color-fg-primary));
+  --color-text-secondary: var(--text-secondary, var(--color-fg-secondary));
+  --color-text-tertiary: var(--text-tertiary, var(--color-fg-muted));
+  --color-text-disabled: var(--text-disabled, var(--color-fg-disabled));
+  --color-icon-default: var(--icon-default, var(--color-fg-muted));
+  --color-border: var(--border, var(--color-border-default));
+  --color-card-border: var(--card-border, var(--color-border-default));
+  --color-brand: var(--brand, var(--color-accent-fg));
+  --color-brand-tint: var(--brand-tint, var(--color-brass-soft));
+  --color-success: var(--success, var(--color-status-ok));
+  --color-destructive: var(--destructive, var(--color-status-err));
+  --color-warning: var(--warning, var(--color-status-warn));
+  --color-info: var(--info, var(--color-status-info));
+  --color-alert-badge: var(--alert-badge, var(--color-status-err));
+  --shadow-card: var(--shadow-card, 0 1px 3px rgba(0, 0, 0, 0.04));
+  --shadow-card-hover: var(--shadow-card-hover, 0 2px 4px rgba(0, 0, 0, 0.08));
+  --shadow-elevated: var(--shadow-elevated, 0 4px 12px rgba(0, 0, 0, 0.08));
+  --shadow-modal: var(--shadow-modal, 0 8px 24px rgba(0, 0, 0, 0.12));
+  --shadow-button: var(--shadow-button, 0 1px 3px rgba(0, 0, 0, 0.06));
+}
+
 /* Body base — CJK word-break + Pretendard-friendly metric reset */
 [data-theme="styleseed"] body {
   background-color: var(--surface-page);
@@ -12,6 +42,12 @@
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Surface wrapper — page background + primary text color */
+[data-theme="styleseed"] .ss-surface {
+  background-color: var(--surface-page);
+  color: var(--text-primary);
 }
 
 /* Card base — all content lives inside cards */

--- a/dashboard/src/styles/v2-command.css
+++ b/dashboard/src/styles/v2-command.css
@@ -105,3 +105,108 @@
 .v2-command-surface .v2-command-composer:hover {
   border-color: var(--color-border-strong);
 }
+
+/* ── StyleSeed theme overrides ───────────────────────────────────────────────
+   When data-theme="styleseed" is active, map v2 command chrome to
+   StyleSeed semantic tokens. Lab inspector reuses .v2-command-* classes. */
+
+[data-theme="styleseed"] .v2-command-surface {
+  background-color: var(--surface-page);
+  color: var(--text-primary);
+  /* Bridge v2 token ladder to StyleSeed values inside this surface. */
+  --color-fg-primary: var(--text-primary);
+  --color-fg-secondary: var(--text-secondary);
+  --color-fg-muted: var(--text-tertiary);
+  --color-fg-disabled: var(--text-disabled);
+  --color-border-default: var(--border);
+  --color-border-strong: var(--border);
+  --color-bg-page: var(--surface-page);
+  --color-bg-surface: var(--card);
+  --color-bg-elevated: var(--surface-subtle);
+  --color-bg-hover: var(--surface-muted);
+  --color-accent-fg: var(--brand);
+}
+
+[data-theme="styleseed"] .v2-command-panel,
+[data-theme="styleseed"] .v2-command-card,
+[data-theme="styleseed"] .v2-command-surface [data-surface-card] {
+  background-color: var(--card);
+  border-color: var(--border);
+  box-shadow: var(--shadow-card);
+}
+
+[data-theme="styleseed"] .v2-command-panel:hover,
+[data-theme="styleseed"] .v2-command-card:hover,
+[data-theme="styleseed"] .v2-command-surface [data-surface-card]:hover {
+  border-color: var(--border);
+  background-color: var(--surface-subtle);
+}
+
+[data-theme="styleseed"] .v2-command-row,
+[data-theme="styleseed"] .v2-command-table tbody tr,
+[data-theme="styleseed"] .v2-command-panel table tbody tr,
+[data-theme="styleseed"] .v2-command-detail table tbody tr {
+  color: var(--text-primary);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-command-row:hover,
+[data-theme="styleseed"] .v2-command-table tbody tr:hover,
+[data-theme="styleseed"] .v2-command-panel table tbody tr:hover,
+[data-theme="styleseed"] .v2-command-detail table tbody tr:hover {
+  background-color: var(--surface-subtle);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-command-action:not(:disabled),
+[data-theme="styleseed"] .v2-command-panel .v2-command-action:not(:disabled),
+[data-theme="styleseed"] .v2-command-surface [data-action-button]:not(:disabled) {
+  border-color: var(--border);
+  color: var(--text-secondary);
+}
+
+[data-theme="styleseed"] .v2-command-action:not(:disabled):hover,
+[data-theme="styleseed"] .v2-command-surface [data-action-button]:not(:disabled):hover {
+  border-color: var(--brand);
+  background-color: var(--brand-tint);
+  color: var(--brand);
+}
+
+[data-theme="styleseed"] .v2-command-table,
+[data-theme="styleseed"] .v2-command-panel table,
+[data-theme="styleseed"] .v2-command-detail table,
+[data-theme="styleseed"] .v2-command-table thead,
+[data-theme="styleseed"] .v2-command-panel table thead,
+[data-theme="styleseed"] .v2-command-detail table thead {
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-command-table th,
+[data-theme="styleseed"] .v2-command-panel table th,
+[data-theme="styleseed"] .v2-command-detail table th {
+  color: var(--text-secondary);
+}
+
+[data-theme="styleseed"] .v2-command-table td,
+[data-theme="styleseed"] .v2-command-panel table td,
+[data-theme="styleseed"] .v2-command-detail table td {
+  color: var(--text-primary);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-command-detail {
+  background-color: var(--card);
+  border-color: var(--border);
+  box-shadow: var(--shadow-card);
+}
+
+[data-theme="styleseed"] .v2-command-surface .v2-command-composer {
+  background-color: var(--card);
+  border-color: var(--border);
+  box-shadow: var(--shadow-card);
+}
+
+[data-theme="styleseed"] .v2-command-surface .v2-command-composer:hover {
+  border-color: var(--border);
+  background-color: var(--surface-subtle);
+}

--- a/dashboard/src/styles/v2-connectors.css
+++ b/dashboard/src/styles/v2-connectors.css
@@ -116,3 +116,105 @@
 .v2-sidecar-startup-watch [data-action-button]:not(:disabled) {
   transition: border-color 120ms ease, background 120ms ease, color 120ms ease, box-shadow 120ms ease;
 }
+
+/* ── StyleSeed theme overrides ───────────────────────────────────────────────
+   When data-theme="styleseed" is active, map v2 connector chrome to
+   StyleSeed semantic tokens. SurfaceCard already carries .ss-card, so
+   this file only needs to bridge the v2-scoped panels and strips. */
+
+[data-theme="styleseed"] .v2-connector-status,
+[data-theme="styleseed"] .v2-connectors-surface {
+  background-color: var(--surface-page);
+  color: var(--text-primary);
+  /* Bridge v2 token ladder to StyleSeed values inside this surface. */
+  --color-fg-primary: var(--text-primary);
+  --color-fg-secondary: var(--text-secondary);
+  --color-fg-muted: var(--text-tertiary);
+  --color-fg-disabled: var(--text-disabled);
+  --color-border-default: var(--border);
+  --color-border-strong: var(--border);
+  --color-bg-page: var(--surface-page);
+  --color-bg-surface: var(--card);
+  --color-bg-elevated: var(--surface-subtle);
+  --color-bg-hover: var(--surface-muted);
+  --color-status-ok: var(--success);
+  --color-status-warn: var(--warning);
+  --color-status-err: var(--destructive);
+  --color-accent-fg: var(--brand);
+  --ok-10: color-mix(in srgb, var(--success) 10%, transparent);
+  --ok-20: color-mix(in srgb, var(--success) 20%, transparent);
+  --ok-border: color-mix(in srgb, var(--success) 35%, transparent);
+  --warn-10: color-mix(in srgb, var(--warning) 10%, transparent);
+  --warn-20: color-mix(in srgb, var(--warning) 20%, transparent);
+  --bad-10: color-mix(in srgb, var(--destructive) 10%, transparent);
+  --bad-soft: color-mix(in srgb, var(--destructive) 12%, transparent);
+  --err-border: color-mix(in srgb, var(--destructive) 40%, transparent);
+  --bad-light: var(--destructive);
+}
+
+[data-theme="styleseed"] .v2-connector-status [data-surface-card],
+[data-theme="styleseed"] .v2-connector-overview-strip [data-surface-card],
+[data-theme="styleseed"] .v2-connector-onboarding [data-surface-card],
+[data-theme="styleseed"] .v2-connector-keeper-matrix [data-surface-card],
+[data-theme="styleseed"] .v2-connector-paths-strip [data-surface-card],
+[data-theme="styleseed"] .v2-connector-quick-bind [data-surface-card],
+[data-theme="styleseed"] .v2-connector-flow [data-surface-card],
+[data-theme="styleseed"] .v2-connector-config-form [data-surface-card],
+[data-theme="styleseed"] .v2-sidecar-startup-watch [data-surface-card] {
+  background-color: var(--card);
+  border-color: var(--border);
+  box-shadow: var(--shadow-card);
+}
+
+[data-theme="styleseed"] .v2-connector-overview-strip {
+  background-color: var(--surface-page);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-connector-overview-strip [data-overview-tile] [data-surface-card] {
+  background-color: var(--card);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-connector-overview-strip [data-overview-tile] [data-surface-card]:hover {
+  border-color: var(--border);
+  background-color: var(--surface-subtle);
+}
+
+[data-theme="styleseed"] .v2-connector-readiness-rail [data-rail-pill]:not(:disabled):hover {
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-connector-quick-bind [data-surface-card] {
+  background-color: var(--card);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-connector-config-form [data-surface-card] {
+  background-color: var(--card);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-connector-flow [data-surface-card] {
+  background-color: var(--surface-subtle);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-sidecar-startup-watch [data-surface-card] {
+  background-color: var(--warning);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-connector-status [data-action-button]:not(:disabled):hover,
+[data-theme="styleseed"] .v2-connector-overview-strip [data-action-button]:not(:disabled):hover,
+[data-theme="styleseed"] .v2-connector-onboarding [data-action-button]:not(:disabled):hover,
+[data-theme="styleseed"] .v2-connector-keeper-matrix [data-action-button]:not(:disabled):hover,
+[data-theme="styleseed"] .v2-connector-paths-strip [data-action-button]:not(:disabled):hover,
+[data-theme="styleseed"] .v2-connector-quick-bind [data-action-button]:not(:disabled):hover,
+[data-theme="styleseed"] .v2-connector-flow [data-action-button]:not(:disabled):hover,
+[data-theme="styleseed"] .v2-connector-config-form [data-action-button]:not(:disabled):hover,
+[data-theme="styleseed"] .v2-sidecar-startup-watch [data-action-button]:not(:disabled):hover {
+  border-color: var(--brand);
+  background-color: var(--brand-tint);
+  color: var(--brand);
+}

--- a/dashboard/src/styles/v2-ide.css
+++ b/dashboard/src/styles/v2-ide.css
@@ -107,3 +107,83 @@
   color: var(--color-fg-secondary);
   border-bottom: 1px solid var(--color-border-default);
 }
+
+/* ── StyleSeed theme overrides ───────────────────────────────────────────────
+   When data-theme="styleseed" is active, map v2 chrome to StyleSeed
+   semantic tokens so the IDE shell stays coherent with the rest of the
+   migrated surfaces. */
+
+[data-theme="styleseed"] .v2-ide-surface,
+[data-theme="styleseed"] .v2-ide-panel,
+[data-theme="styleseed"] .v2-ide-card {
+  background-color: var(--card);
+  border-color: var(--border);
+  color: var(--text-primary);
+}
+
+[data-theme="styleseed"] .v2-ide-surface {
+  background-color: var(--surface-page);
+  /* Bridge v2 token ladder to StyleSeed values inside this surface. */
+  --color-fg-primary: var(--text-primary);
+  --color-fg-secondary: var(--text-secondary);
+  --color-fg-muted: var(--text-tertiary);
+  --color-fg-disabled: var(--text-disabled);
+  --color-border-default: var(--border);
+  --color-border-strong: var(--border);
+  --color-bg-page: var(--surface-page);
+  --color-bg-surface: var(--card);
+  --color-bg-elevated: var(--surface-subtle);
+  --color-bg-hover: var(--surface-muted);
+  --color-accent-fg: var(--brand);
+}
+
+[data-theme="styleseed"] .v2-ide-toolbar,
+[data-theme="styleseed"] .v2-ide-action {
+  border-color: var(--border);
+  color: var(--text-secondary);
+}
+
+[data-theme="styleseed"] .v2-ide-action:not(:disabled):hover,
+[data-theme="styleseed"] .v2-ide-toolbar .v2-ide-action:not(:disabled):hover {
+  border-color: var(--brand);
+  background-color: var(--brand-tint);
+  color: var(--brand);
+}
+
+[data-theme="styleseed"] .v2-ide-row,
+[data-theme="styleseed"] .v2-ide-table tbody tr,
+[data-theme="styleseed"] .v2-ide-panel table tbody tr,
+[data-theme="styleseed"] .v2-ide-detail table tbody tr {
+  color: var(--text-primary);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-ide-row:hover,
+[data-theme="styleseed"] .v2-ide-table tbody tr:hover,
+[data-theme="styleseed"] .v2-ide-panel table tbody tr:hover,
+[data-theme="styleseed"] .v2-ide-detail table tbody tr:hover {
+  background-color: var(--surface-subtle);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-ide-table,
+[data-theme="styleseed"] .v2-ide-panel table,
+[data-theme="styleseed"] .v2-ide-detail table,
+[data-theme="styleseed"] .v2-ide-table thead,
+[data-theme="styleseed"] .v2-ide-panel table thead,
+[data-theme="styleseed"] .v2-ide-detail table thead {
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-ide-table th,
+[data-theme="styleseed"] .v2-ide-panel table th,
+[data-theme="styleseed"] .v2-ide-detail table th {
+  color: var(--text-secondary);
+}
+
+[data-theme="styleseed"] .v2-ide-table td,
+[data-theme="styleseed"] .v2-ide-panel table td,
+[data-theme="styleseed"] .v2-ide-detail table td {
+  color: var(--text-primary);
+  border-color: var(--border);
+}

--- a/dashboard/src/styles/v2-lab.css
+++ b/dashboard/src/styles/v2-lab.css
@@ -88,3 +88,93 @@
   color: var(--color-fg-secondary);
   border-bottom: 1px solid var(--color-border-default);
 }
+
+/* ── StyleSeed theme overrides ───────────────────────────────────────────────
+   When data-theme="styleseed" is active, map v2 lab chrome to StyleSeed
+   semantic tokens. Cards already carry .ss-card via SurfaceCard; this
+   bridges the remaining v2-scoped panels, rows, and tables. */
+
+[data-theme="styleseed"] .v2-lab-surface {
+  background-color: var(--surface-page);
+  color: var(--text-primary);
+  /* Bridge v2 token ladder to StyleSeed values inside this surface. */
+  --color-fg-primary: var(--text-primary);
+  --color-fg-secondary: var(--text-secondary);
+  --color-fg-muted: var(--text-tertiary);
+  --color-fg-disabled: var(--text-disabled);
+  --color-border-default: var(--border);
+  --color-border-strong: var(--border);
+  --color-bg-page: var(--surface-page);
+  --color-bg-surface: var(--card);
+  --color-bg-elevated: var(--surface-subtle);
+  --color-bg-hover: var(--surface-muted);
+  --color-bg-muted: var(--surface-muted);
+  --color-accent-fg: var(--brand);
+}
+
+[data-theme="styleseed"] .v2-lab-panel,
+[data-theme="styleseed"] .v2-lab-card,
+[data-theme="styleseed"] .v2-lab-surface [data-surface-card] {
+  background-color: var(--card);
+  border-color: var(--border);
+  box-shadow: var(--shadow-card);
+}
+
+[data-theme="styleseed"] .v2-lab-panel:hover,
+[data-theme="styleseed"] .v2-lab-card:hover,
+[data-theme="styleseed"] .v2-lab-surface [data-surface-card]:hover {
+  border-color: var(--border);
+  background-color: var(--surface-subtle);
+}
+
+[data-theme="styleseed"] .v2-lab-row,
+[data-theme="styleseed"] .v2-lab-table tbody tr,
+[data-theme="styleseed"] .v2-lab-panel table tbody tr,
+[data-theme="styleseed"] .v2-lab-detail table tbody tr {
+  color: var(--text-primary);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-lab-row:hover,
+[data-theme="styleseed"] .v2-lab-table tbody tr:hover,
+[data-theme="styleseed"] .v2-lab-panel table tbody tr:hover,
+[data-theme="styleseed"] .v2-lab-detail table tbody tr:hover {
+  background-color: var(--surface-subtle);
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-lab-action:not(:disabled),
+[data-theme="styleseed"] .v2-lab-panel .v2-lab-action:not(:disabled),
+[data-theme="styleseed"] .v2-lab-surface [data-action-button]:not(:disabled) {
+  border-color: var(--border);
+  color: var(--text-secondary);
+}
+
+[data-theme="styleseed"] .v2-lab-action:not(:disabled):hover,
+[data-theme="styleseed"] .v2-lab-surface [data-action-button]:not(:disabled):hover {
+  border-color: var(--brand);
+  background-color: var(--brand-tint);
+  color: var(--brand);
+}
+
+[data-theme="styleseed"] .v2-lab-table,
+[data-theme="styleseed"] .v2-lab-panel table,
+[data-theme="styleseed"] .v2-lab-detail table,
+[data-theme="styleseed"] .v2-lab-table thead,
+[data-theme="styleseed"] .v2-lab-panel table thead,
+[data-theme="styleseed"] .v2-lab-detail table thead {
+  border-color: var(--border);
+}
+
+[data-theme="styleseed"] .v2-lab-table th,
+[data-theme="styleseed"] .v2-lab-panel table th,
+[data-theme="styleseed"] .v2-lab-detail table th {
+  color: var(--text-secondary);
+}
+
+[data-theme="styleseed"] .v2-lab-table td,
+[data-theme="styleseed"] .v2-lab-panel table td,
+[data-theme="styleseed"] .v2-lab-detail table td {
+  color: var(--text-primary);
+  border-color: var(--border);
+}


### PR DESCRIPTION
## Summary
Migrates IDE, connector, and lab surfaces to StyleSeed card-based layouts.

## What changed
- `dashboard/src/components/ide/ide-shell.ts`: `ss-surface bg-surface-page` wrapper.
- `dashboard/src/components/connector-status.ts`: `ss-surface bg-surface-page` wrapper.
- `dashboard/src/components/lab.ts`, `lab-perf.ts`, `lab-inspector.ts`: full StyleSeed pass with `ss-card`, semantic colors, explicit px font sizes, 44×44 touch targets.
- `dashboard/src/components/common/card.ts`: `ss-card` added to `SurfaceCard`/`SectionCard`.
- `dashboard/src/styles/styleseed-base.css`: Tailwind v4 `@theme` bridge + `.ss-surface` helper.
- `dashboard/src/styles/v2-ide.css`, `v2-connectors.css`, `v2-lab.css`, `v2-command.css`: StyleSeed token bridges for legacy surfaces.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm build` ✅
- IDE, connector, lab, card, StyleSeed theme tests ✅ 134/134

## Notes
- The originally named `ide-surface.ts` / `connector-surface.ts` files don't exist; mapped to the actual `ide-shell.ts`, `connector-status.ts`, and lab surfaces.
