### PR TITLE
feat(dashboard): migrate design canvas and memory surfaces to StyleSeed

### DIFF
--- a/dashboard/src/components/design-canvas.test.ts
+++ b/dashboard/src/components/design-canvas.test.ts
@@ -24,7 +24,10 @@ describe('DesignCanvas', () => {
       render(html`<${DesignCanvas} />`, container)
     })
 
-    expect(container.querySelector('[data-design-canvas]')).not.toBeNull()
+    const root = container.querySelector('[data-design-canvas]')
+    expect(root).not.toBeNull()
+    expect(root!.classList.contains('ss-surface')).toBe(true)
+    expect(root!.classList.contains('bg-surface-page')).toBe(true)
     expect(container.querySelector('[data-testid="design-canvas-tab-primitives"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="design-canvas-tab-molecules"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="design-canvas-tab-organisms"]')).not.toBeNull()
@@ -42,7 +45,9 @@ describe('DesignCanvas', () => {
 
     const stage = container.querySelector('[data-testid="design-canvas-stage"]')
     expect(stage).not.toBeNull()
-    expect(stage!.querySelectorAll('[data-design-canvas-artboard]').length).toBeGreaterThanOrEqual(6)
+    const artboards = stage!.querySelectorAll('[data-design-canvas-artboard]')
+    expect(artboards.length).toBeGreaterThanOrEqual(6)
+    expect(artboards[0]!.querySelector('.ss-card')).not.toBeNull()
     expect(stage!.querySelectorAll('[role="progressbar"]').length).toBeGreaterThan(0)
   })
 

--- a/dashboard/src/components/design-canvas.ts
+++ b/dashboard/src/components/design-canvas.ts
@@ -94,7 +94,7 @@ function Artboard({ title, h, children }: { title: string; h?: number; children:
   return html`
     <div class="dc-artboard" data-design-canvas-artboard>
       <div class="dc-artboard-label">${title}</div>
-      <div class="dc-artboard-well" style=${h !== undefined ? { height: `${h}px` } : undefined}>${children}</div>
+      <div class="dc-artboard-well ss-card" style=${h !== undefined ? { height: `${h}px` } : undefined}>${children}</div>
     </div>
   `
 }
@@ -258,7 +258,7 @@ function KeeperCard({ name, state, qps, latency }: {
   latency: string
 }) {
   return html`
-    <div class="dc-organism-card" data-design-canvas-organism="keeper-card">
+    <div class="dc-organism-card ss-card" data-design-canvas-organism="keeper-card">
       <div class="dc-organism-header">
         <span class="dc-mono">${name}</span>
         <${StatusChip} tone=${state === 'active' ? 'ok' : state === 'warn' ? 'warn' : 'paused'}>${state}<//>
@@ -359,8 +359,8 @@ function SurfacesGallery() {
   return html`
     <${Section} title="Surfaces">
       <${Artboard} title="Lab surface sample">
-        <div class="dc-surface-sample v2-lab-surface">
-          <div class="v2-lab-panel dc-surface-panel">
+        <div class="dc-surface-sample">
+          <div class="v2-lab-panel dc-surface-panel ss-card">
             <div class="section-head">Panel</div>
             <div class="p-3">
               <${Vitals}
@@ -371,8 +371,8 @@ function SurfacesGallery() {
               />
             </div>
           </div>
-          <div class="v2-lab-card dc-surface-card">
-            <p class="m-0 text-xs text-[var(--color-fg-muted)]">Card content area</p>
+          <div class="v2-lab-card dc-surface-card ss-card">
+            <p class="m-0 text-[13px] text-text-tertiary">Card content area</p>
             <${ActionButton} variant="primary" size="sm" class="mt-2">Action<//>
           </div>
         </div>
@@ -412,9 +412,9 @@ function MotionGallery() {
 
       <${Artboard} title="Enter animation">
         <div class="dc-motion-stack">
-          <div class="dc-motion-card anim-slide-up">slide-up</div>
-          <div class="dc-motion-card anim-fade-in">fade-in</div>
-          <div class="dc-motion-card anim-pop">pop</div>
+          <div class="dc-motion-card ss-card anim-slide-up">slide-up</div>
+          <div class="dc-motion-card ss-card anim-fade-in">fade-in</div>
+          <div class="dc-motion-card ss-card anim-pop">pop</div>
         </div>
       <//>
     <//>
@@ -731,7 +731,7 @@ export function DesignCanvas() {
   const { theme, toggle } = useDesignCanvasTheme()
 
   return html`
-    <div class="dc-root" data-design-canvas>
+    <div class="dc-root ss-surface bg-surface-page" data-design-canvas>
       <div class="dc-header">
         <div>
           <h2 class="dc-title">Design Canvas</h2>

--- a/dashboard/src/components/memory/goal-dossier.test.ts
+++ b/dashboard/src/components/memory/goal-dossier.test.ts
@@ -58,6 +58,8 @@ describe('GoalDossier', () => {
       testId="dossier"
     />`)
     const dossier = screen.getByTestId('dossier')
+    expect(dossier.classList.contains('ss-card')).toBe(true)
+    expect(dossier.querySelectorAll('.gd-crow.ss-card').length).toBeGreaterThan(0)
     expect(dossier.textContent).toContain('scheduler p95 round-jitter < 50ms')
     expect(dossier.textContent).toContain('47%')
     expect(dossier.textContent).toContain('D-3 마감')

--- a/dashboard/src/components/memory/goal-dossier.ts
+++ b/dashboard/src/components/memory/goal-dossier.ts
@@ -68,7 +68,7 @@ export function GoalDossier({
   const snapshotType = nodeTypes.snapshot ?? { kr: '스냅샷', g: '◷', c: 'var(--accent-ice)' }
 
   return html`
-    <div class="mg-board gd-board" data-testid=${testId} aria-label=${ariaLabel}>
+    <div class="mg-board gd-board ss-card" data-testid=${testId} aria-label=${ariaLabel}>
       <${MgEntry} extra="목표 중심 · 얼만큼 일했나" />
       <div class="gd-head">
         <div class="gd-head-l">
@@ -138,7 +138,7 @@ export function GoalDossier({
                 <span class="cnt mono">${items.length}</span>
               </div>
               ${items.map((it, j) => html`
-                <div key=${j} class=${cx('gd-crow', `st-${it.state}`)}>
+                <div key=${j} class=${cx('gd-crow ss-card', `st-${it.state}`)}>
                   <div class="gd-cmain">
                     <div class="gd-ctitle">${it.title}</div>
                     <div class="gd-cmeta">

--- a/dashboard/src/components/memory/memory-explore.test.ts
+++ b/dashboard/src/components/memory/memory-explore.test.ts
@@ -11,7 +11,10 @@ describe('MemoryExplore', () => {
 
   it('renders the surface header', () => {
     render(html`<${MemoryExplore} />`)
-    expect(screen.getByTestId('memory-explore-surface')).not.toBeNull()
+    const surface = screen.getByTestId('memory-explore-surface')
+    expect(surface).not.toBeNull()
+    expect(surface.classList.contains('ss-surface')).toBe(true)
+    expect(surface.classList.contains('bg-surface-page')).toBe(true)
     expect(screen.getByText('Memory Linkage Explore')).not.toBeNull()
   })
 
@@ -19,6 +22,7 @@ describe('MemoryExplore', () => {
     render(html`<${MemoryExplore} />`)
     const lens = screen.getByTestId('memory-explore-lens')
     expect(lens).not.toBeNull()
+    expect(lens.closest('.ss-card')).not.toBeNull()
     expect(lens.textContent).toContain('compact()가 라운드 락 보유 중 호출돼 round-jitter 발생')
   })
 
@@ -26,6 +30,7 @@ describe('MemoryExplore', () => {
     render(html`<${MemoryExplore} />`)
     const lineage = screen.getByTestId('memory-explore-lineage')
     expect(lineage).not.toBeNull()
+    expect(lineage.closest('.ss-card')).not.toBeNull()
     expect(lineage.textContent).toContain('13:49')
     expect(lineage.textContent).toContain('통찰 기록')
   })
@@ -34,6 +39,7 @@ describe('MemoryExplore', () => {
     render(html`<${MemoryExplore} />`)
     const dossier = screen.getByTestId('memory-explore-dossier')
     expect(dossier).not.toBeNull()
+    expect(dossier.closest('.ss-card')).not.toBeNull()
     expect(dossier.textContent).toContain('scheduler p95 round-jitter < 50ms')
     expect(dossier.textContent).toContain('47%')
   })

--- a/dashboard/src/components/memory/memory-explore.ts
+++ b/dashboard/src/components/memory/memory-explore.ts
@@ -130,16 +130,16 @@ const LEDGER = [
 
 export function MemoryExplore() {
   return html`
-    <div class="v2-lab-surface flex flex-col gap-6" data-testid="memory-explore-surface">
-      <div class="flex items-center justify-between gap-4 v2-monitoring-toolbar">
+    <div class="ss-surface bg-surface-page flex flex-col gap-6 px-6 py-6" data-testid="memory-explore-surface">
+      <div class="flex items-center justify-between gap-4">
         <div>
-          <h2 class="text-base font-semibold text-[var(--color-fg-primary)]">Memory Linkage Explore</h2>
-          <p class="text-2xs text-[var(--color-fg-muted)]">메모리 체크포인트 → 골 → 태스크 → 보드 연결망</p>
+          <h2 class="text-[18px] font-bold text-text-primary">Memory Linkage Explore</h2>
+          <p class="text-[13px] text-text-tertiary">메모리 체크포인트 → 골 → 태스크 → 보드 연결망</p>
         </div>
       </div>
 
       <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
-        <div class="v2-monitoring-panel rounded-[var(--r-2)] border border-[var(--color-border-default)] overflow-hidden">
+        <div class="ss-card overflow-hidden">
           <${MemoryLens}
             nodes=${NODES}
             edges=${EDGES}
@@ -150,7 +150,7 @@ export function MemoryExplore() {
           />
         </div>
 
-        <div class="v2-monitoring-panel rounded-[var(--r-2)] border border-[var(--color-border-default)] overflow-hidden">
+        <div class="ss-card overflow-hidden">
           <${MemoryLineageRail}
             steps=${LINEAGE_STEPS}
             nodes=${NODES}
@@ -161,7 +161,7 @@ export function MemoryExplore() {
         </div>
       </div>
 
-      <div class="v2-monitoring-panel rounded-[var(--r-2)] border border-[var(--color-border-default)] overflow-hidden">
+      <div class="ss-card overflow-hidden">
         <${GoalDossier}
           goal=${GOAL}
           nodeTypes=${NODE_TYPES}

--- a/dashboard/src/components/memory/memory-lens.test.ts
+++ b/dashboard/src/components/memory/memory-lens.test.ts
@@ -35,6 +35,8 @@ describe('MemoryLens', () => {
   it('renders the anchor node and satellite nodes from props', () => {
     render(html`<${MemoryLens} nodes=${nodes} edges=${edges} nodeTypes=${nodeTypes} start="mem" testId="lens" />`)
     const board = screen.getByTestId('lens')
+    expect(board.classList.contains('ss-card')).toBe(true)
+    expect(board.querySelectorAll('.mg-node.ss-card').length).toBeGreaterThan(0)
     expect(board.textContent).toContain('insight checkpoint')
     expect(board.textContent).toContain('isolate compact() call')
     expect(board.textContent).toContain('add regression test')

--- a/dashboard/src/components/memory/memory-lens.ts
+++ b/dashboard/src/components/memory/memory-lens.ts
@@ -62,12 +62,12 @@ export function MemoryLens({
   if (nodeIds.length === 0 || !nodes[anchor]) {
     return html`
       <div
-        class="mg-board"
+        class="mg-board ss-card"
         data-testid=${testId}
         aria-label=${ariaLabel}
       >
         <${MgEntry} extra="1-hop 렌즈 · 노드 클릭 = 재중심" />
-        <div class="flex items-center justify-center text-xs text-[var(--color-fg-muted)]" style=${{ height: `${H}px` }}>
+        <div class="flex items-center justify-center text-[12px] text-text-tertiary" style=${{ height: `${H}px` }}>
           연결할 메모리 노드가 없습니다.
         </div>
       </div>
@@ -101,7 +101,7 @@ export function MemoryLens({
   }
 
   return html`
-    <div class="mg-board" data-testid=${testId} aria-label=${ariaLabel}>
+    <div class="mg-board ss-card" data-testid=${testId} aria-label=${ariaLabel}>
       <${MgEntry} extra="1-hop 렌즈 · 노드 클릭 = 재중심" />
       <div class="mg-lens" style=${{ width: W, height: H }}>
         <svg

--- a/dashboard/src/components/memory/memory-lineage-rail.test.ts
+++ b/dashboard/src/components/memory/memory-lineage-rail.test.ts
@@ -32,6 +32,8 @@ describe('MemoryLineageRail', () => {
   it('renders step times, relations, and node titles', () => {
     render(html`<${MemoryLineageRail} steps=${steps} nodes=${nodes} nodeTypes=${nodeTypes} testId="rail" />`)
     const rail = screen.getByTestId('rail')
+    expect(rail.classList.contains('ss-card')).toBe(true)
+    expect(rail.querySelectorAll('.mg-step-card.ss-card').length).toBeGreaterThan(0)
     expect(rail.textContent).toContain('13:18')
     expect(rail.textContent).toContain('13:49')
     expect(rail.textContent).toContain('13:50')

--- a/dashboard/src/components/memory/memory-lineage-rail.ts
+++ b/dashboard/src/components/memory/memory-lineage-rail.ts
@@ -35,9 +35,9 @@ export function MemoryLineageRail({
 }: MemoryLineageRailProps) {
   if (steps.length === 0) {
     return html`
-      <div class="mg-board" data-testid=${testId} aria-label=${ariaLabel}>
+      <div class="mg-board ss-card" data-testid=${testId} aria-label=${ariaLabel}>
         <${MgEntry} extra="lineage · 위→아래 인과 흐름" />
-        <div class="flex items-center justify-center text-xs text-[var(--color-fg-muted)]" style=${{ minHeight: '160px' }}>
+        <div class="flex items-center justify-center text-[12px] text-text-tertiary" style=${{ minHeight: '160px' }}>
           인과 단계가 없습니다.
         </div>
       </div>
@@ -45,7 +45,7 @@ export function MemoryLineageRail({
   }
 
   return html`
-    <div class="mg-board" data-testid=${testId} aria-label=${ariaLabel}>
+    <div class="mg-board ss-card" data-testid=${testId} aria-label=${ariaLabel}>
       <${MgEntry} extra="lineage · 위→아래 인과 흐름" />
       <div class="mg-rail" role="list" aria-label=${ariaLabel}>
         ${steps.map((step, i) => {
@@ -66,7 +66,7 @@ export function MemoryLineageRail({
               </div>
               <div class="mg-step-body">
                 <div class="mg-rel mono">${step.rel}</div>
-                <div class="mg-step-card">
+                <div class="mg-step-card ss-card">
                   <div class="mg-node-top">
                     <span class="mg-type"><span class="g">${t.g}</span>${t.kr}</span>
                     ${step.anchor ? html`<span class="mg-anchor-tag mono">진입 지점</span>` : null}

--- a/dashboard/src/components/memory/memory-primitives.ts
+++ b/dashboard/src/components/memory/memory-primitives.ts
@@ -98,7 +98,7 @@ export function MgNodeCard({
 }: NodeCardProps) {
   return html`
     <div
-      class=${cx('mg-node', anchor && 'is-anchor', satellite && 'is-sat')}
+      class=${cx('mg-node ss-card', anchor && 'is-anchor', satellite && 'is-sat')}
       style=${{ '--nc': type.c }}
       onClick=${onClick}
       title=${node.title}

--- a/dashboard/src/styles/design-canvas.css
+++ b/dashboard/src/styles/design-canvas.css
@@ -1,67 +1,71 @@
-/* DesignCanvas — keeper-v2 design-system preview surface styles.
+/* DesignCanvas — StyleSeed design-system preview surface styles.
    Scoped to .dc-* so the preview surface doesn't leak into the rest
-   of the dashboard. Uses dashboard semantic tokens for dark/paper. */
+   of the dashboard. Uses StyleSeed semantic tokens; active when
+   [data-theme="styleseed"] is set on <html>. */
 
 .dc-root {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
-  color: var(--color-fg-primary);
+  gap: 24px;
+  padding: 24px;
+  color: var(--text-primary);
 }
 
 .dc-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: var(--space-3);
+  gap: 12px;
 }
 
 .dc-title {
   margin: 0;
-  font-size: var(--fs-lg);
-  font-weight: var(--fw-semibold);
-  color: var(--color-fg-secondary);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary);
 }
 
 .dc-subtitle {
-  margin: var(--space-1) 0 0;
-  font-size: var(--fs-sm);
-  color: var(--color-fg-muted);
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--text-tertiary);
 }
 
 .dc-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-1);
-  padding: var(--space-1);
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--r-1);
+  gap: 6px;
+  padding: 6px;
+  background: var(--surface-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
 }
 
 .dc-tab {
   appearance: none;
   border: 1px solid transparent;
   background: transparent;
-  color: var(--color-fg-muted);
-  font-size: var(--fs-xs);
-  font-weight: var(--fw-medium);
-  padding: var(--space-1) var(--space-2);
-  border-radius: var(--r-0);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: var(--radius);
   cursor: pointer;
-  transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast);
+  min-height: 44px;
+  min-width: 44px;
+  transition: background 120ms, color 120ms, border-color 120ms;
 }
 
 .dc-tab:hover {
-  background: var(--color-bg-hover);
-  color: var(--color-fg-secondary);
+  background: var(--surface-muted);
+  color: var(--text-primary);
 }
 
 .dc-tab.active {
-  background: var(--color-bg-surface);
-  border-color: var(--color-border-strong);
-  color: var(--color-fg-primary);
-  box-shadow: var(--shadow-sm);
+  background: var(--card);
+  border-color: var(--border);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-card);
 }
 
 .dc-stage {
@@ -71,65 +75,61 @@
 .dc-section {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: 24px;
 }
 
 .dc-section-title {
   margin: 0;
-  font-size: var(--fs-sm);
-  font-weight: var(--fw-semibold);
+  font-size: 12px;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: var(--track-caps);
-  color: var(--color-fg-muted);
+  letter-spacing: 0.05em;
+  color: var(--text-tertiary);
 }
 
 .dc-section-body {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: var(--space-4);
+  gap: 16px;
 }
 
 .dc-artboard {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: 8px;
 }
 
 .dc-artboard-label {
-  font-size: var(--fs-xs);
-  font-weight: var(--fw-medium);
-  color: var(--color-fg-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
 }
 
 .dc-artboard-well {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: 12px;
   min-height: 80px;
-  padding: var(--space-3);
-  background: var(--color-bg-surface);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--r-1);
-  box-shadow: var(--shadow-sm);
+  padding: 16px;
 }
 
 .dc-stack-v {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: 8px;
 }
 
 .dc-row {
   display: flex;
   align-items: center;
-  gap: var(--space-2);
+  gap: 8px;
 }
 
 .dc-row-wrap {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-2);
+  gap: 8px;
 }
 
 .dc-vitals-narrow {
@@ -139,55 +139,52 @@
 .dc-stat-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
-  gap: var(--space-2);
+  gap: 8px;
 }
 
 .dc-molecule-row {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: var(--space-2);
+  gap: 8px;
 }
 
 .dc-button-group {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-2);
+  gap: 8px;
 }
 
 .dc-organism-row {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-3);
+  gap: 12px;
 }
 
 .dc-organism-card {
   width: 220px;
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
-  padding: var(--space-3);
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--r-1);
+  gap: 12px;
+  padding: 16px;
 }
 
 .dc-organism-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-2);
+  gap: 8px;
 }
 
 .dc-mono {
   font-family: var(--font-mono);
-  font-size: var(--fs-xs);
-  color: var(--color-fg-secondary);
+  font-size: 12px;
+  color: var(--text-secondary);
 }
 
 .dc-telemetry-layout {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--space-2);
+  gap: 8px;
 }
 
 .dc-spark-box {
@@ -201,28 +198,25 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: var(--space-3);
+  margin-bottom: 12px;
 }
 
 .dc-surface-sample {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--space-3);
+  gap: 12px;
 }
 
 .dc-surface-panel,
 .dc-surface-card {
   min-height: 120px;
-  padding: var(--space-2);
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--r-1);
+  padding: 12px;
 }
 
 .dc-surface-rail {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: 12px;
   align-items: center;
   justify-content: center;
   min-height: 120px;
@@ -231,13 +225,13 @@
 .dc-fixtures-stack {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: 24px;
 }
 
 .dc-fixtures-row {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-3);
+  gap: 12px;
 }
 
 .dc-fixtures-table-wrap {
@@ -247,38 +241,28 @@
 .dc-rail-dot {
   width: 10px;
   height: 10px;
-  border-radius: var(--radius-pill);
+  border-radius: 999px;
 }
 
-.dc-rail-dot.ok { background: var(--color-status-ok); box-shadow: var(--ok-ring); }
-.dc-rail-dot.warn { background: var(--color-status-warn); box-shadow: var(--warn-ring); }
-.dc-rail-dot.bad { background: var(--color-status-err); box-shadow: var(--err-ring); }
-.dc-rail-dot.info { background: var(--color-status-info); box-shadow: var(--info-ring); }
+.dc-rail-dot.ok { background: var(--success); }
+.dc-rail-dot.warn { background: var(--warning); }
+.dc-rail-dot.bad { background: var(--destructive); }
+.dc-rail-dot.info { background: var(--info); }
 
 .dc-pulse-dot {
   width: 12px;
   height: 12px;
-  border-radius: var(--radius-pill);
+  border-radius: 999px;
 }
 
 .dc-motion-stack {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-2);
+  gap: 8px;
 }
 
 .dc-motion-card {
-  padding: var(--space-2) var(--space-3);
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--r-1);
-  font-size: var(--fs-xs);
-  color: var(--color-fg-secondary);
-}
-
-/* Paper theme adjustments for the preview surface.
-   The dashboard paper theme already remaps the semantic tokens,
-   so we only tweak surface-specific accents here. */
-html[data-theme="paper"] .dc-tab.active {
-  border-color: var(--color-border-strong);
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
 }

--- a/dashboard/src/styles/memory-v2.css
+++ b/dashboard/src/styles/memory-v2.css
@@ -1,6 +1,6 @@
-/* MASC Dashboard — keeper-v2 memory visualization surfaces (Memory Lens,
-   Lineage Rail, Goal Dossier). Imported after variables.css so the keeper
-   token bridge aliases are available. */
+/* MASC Dashboard — StyleSeed memory visualization surfaces
+   (Memory Lens, Lineage Rail, Goal Dossier). Active when
+   [data-theme="styleseed"] is set on <html>. */
 
 /* ── shared primitives ── */
 .memory-v2 .mono,
@@ -9,16 +9,14 @@
   font-family: var(--font-mono);
 }
 
-.mg-board {
+.mg-board,
+.gd-board {
   box-sizing: border-box;
   height: 100%;
-  padding: 14px 16px 16px;
+  padding: 16px;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  background:
-    radial-gradient(ellipse at 30% 0%, rgba(224, 176, 87, 0.05), transparent 60%),
-    var(--bg-deep);
   color: var(--text-primary);
 }
 
@@ -29,32 +27,32 @@
   gap: 9px;
   flex-wrap: wrap;
   font-size: 11px;
-  color: var(--text-mid);
+  color: var(--text-secondary);
   padding: 7px 11px;
-  border: 1px solid var(--border-main);
-  border-radius: var(--radius-sm);
-  background: var(--bg-panel-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-subtle);
 }
 
 .mg-entry-g {
-  color: var(--volt);
+  color: var(--brand);
   font-size: 12px;
 }
 
 .mg-entry .dim {
-  color: var(--text-dim);
-  font-size: 10.5px;
+  color: var(--text-tertiary);
+  font-size: 10px;
 }
 
 .mg-entry-x {
   margin-left: auto;
   font-size: 10px;
   letter-spacing: 0.04em;
-  color: var(--volt-strong);
-  background: var(--volt-wash);
-  border: 1px solid color-mix(in oklab, var(--volt) 32%, transparent);
+  color: var(--brand);
+  background: var(--brand-tint);
+  border: 1px solid var(--border);
   padding: 2px 8px;
-  border-radius: var(--radius-pill);
+  border-radius: 999px;
   white-space: nowrap;
 }
 
@@ -62,12 +60,9 @@
 .mg-node {
   box-sizing: border-box;
   width: 152px;
-  background: var(--bg-card);
-  border: 1px solid var(--border-main);
+  border: 1px solid var(--border);
   border-left: 2.5px solid var(--nc);
-  border-radius: var(--radius-md);
   padding: 8px 10px 9px;
-  box-shadow: var(--shadow-card);
   transition: 0.16s;
 }
 
@@ -85,7 +80,7 @@
   gap: 4px;
   flex: none;
   white-space: nowrap;
-  font-size: 9.5px;
+  font-size: 10px;
   letter-spacing: 0.06em;
   color: var(--nc);
   font-weight: 600;
@@ -97,7 +92,7 @@
 
 .mg-meta {
   font-size: 9px;
-  color: var(--text-dim);
+  color: var(--text-tertiary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -105,11 +100,10 @@
 }
 
 .mg-title {
-  font-family: var(--font-display);
   font-weight: 500;
   font-size: 12px;
   line-height: 1.32;
-  color: var(--text-bright);
+  color: var(--text-primary);
   text-wrap: pretty;
   margin-bottom: 7px;
 }
@@ -121,14 +115,14 @@
 }
 
 .mg-node-foot .ns {
-  font-size: 9.5px;
-  color: var(--text-dim);
+  font-size: 10px;
+  color: var(--text-tertiary);
   white-space: nowrap;
 }
 
 .mg-node-foot .meta2 {
   font-size: 9px;
-  color: var(--text-mid);
+  color: var(--text-secondary);
   margin-left: auto;
   white-space: nowrap;
 }
@@ -140,9 +134,9 @@
   flex: none;
   font-family: var(--font-mono);
   font-weight: 700;
-  color: var(--color-bg-page);
+  color: var(--card);
   background: var(--kc);
-  border-radius: var(--radius-xs);
+  border-radius: 4px;
 }
 
 /* ── A · Memory Lens ── */
@@ -169,23 +163,23 @@
   transform: translate(-50%, -50%);
   font-size: 9px;
   letter-spacing: 0.04em;
-  color: var(--text-mid);
-  background: var(--bg-deep);
-  border: 1px solid var(--border-soft);
+  color: var(--text-secondary);
+  background: var(--surface-page);
+  border: 1px solid var(--border);
   padding: 1px 6px;
-  border-radius: var(--radius-pill);
+  border-radius: 999px;
   white-space: nowrap;
   pointer-events: none;
 }
 
 .mg-node.is-anchor {
   width: 180px;
-  border-color: color-mix(in oklab, var(--nc) 55%, var(--border-main));
+  border-color: color-mix(in oklab, var(--nc) 55%, var(--border));
   border-left-width: 3px;
   box-shadow:
     0 0 0 1px color-mix(in oklab, var(--nc) 30%, transparent),
     0 0 26px color-mix(in oklab, var(--nc) 16%, transparent);
-  background: var(--bg-card-hover);
+  background: var(--surface-subtle);
 }
 
 .mg-node.is-anchor .mg-title {
@@ -198,8 +192,8 @@
 
 .mg-node.is-sat:hover {
   transform: translateY(-2px);
-  border-color: color-mix(in oklab, var(--nc) 50%, var(--border-main));
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.5);
+  border-color: color-mix(in oklab, var(--nc) 50%, var(--border));
+  box-shadow: var(--shadow-elevated);
 }
 
 /* ── B · Lineage Rail ── */
@@ -224,8 +218,8 @@
 }
 
 .mg-time {
-  font-size: 9.5px;
-  color: var(--text-dim);
+  font-size: 10px;
+  color: var(--text-tertiary);
   margin-bottom: 4px;
 }
 
@@ -238,7 +232,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--bg-card);
+  background: var(--card);
   border: 1.5px solid var(--nc);
   color: var(--nc);
 }
@@ -251,7 +245,7 @@
 .mg-wire {
   flex: 1;
   width: 1.5px;
-  background: linear-gradient(var(--nc), var(--border-main));
+  background: linear-gradient(var(--nc), var(--border));
   margin: 2px 0 -2px;
   opacity: 0.5;
   min-height: 16px;
@@ -264,35 +258,33 @@
 
 .mg-rel {
   font-size: 10px;
-  color: var(--text-mid);
+  color: var(--text-secondary);
   margin: 1px 0 6px;
 }
 
 .mg-step-card {
-  background: var(--bg-card);
-  border: 1px solid var(--border-main);
+  border: 1px solid var(--border);
   border-left: 2.5px solid var(--nc);
-  border-radius: var(--radius-md);
   padding: 9px 11px;
 }
 
 .mg-step.is-anchor .mg-step-card {
-  background: var(--bg-card-hover);
+  background: var(--surface-subtle);
   box-shadow: 0 0 0 1px color-mix(in oklab, var(--nc) 30%, transparent);
 }
 
 .mg-step-card .mg-title {
-  font-size: 12.5px;
+  font-size: 12px;
   margin-bottom: 7px;
 }
 
 .mg-anchor-tag {
   font-size: 9px;
-  color: var(--volt-strong);
-  background: var(--volt-wash);
-  border: 1px solid color-mix(in oklab, var(--volt) 32%, transparent);
+  color: var(--brand);
+  background: var(--brand-tint);
+  border: 1px solid var(--border);
   padding: 1px 7px;
-  border-radius: var(--radius-pill);
+  border-radius: 999px;
 }
 
 /* legend */
@@ -302,9 +294,9 @@
   gap: 12px;
   flex-wrap: wrap;
   padding-top: 10px;
-  border-top: 1px solid var(--border-soft);
-  font-size: 10.5px;
-  color: var(--text-mid);
+  border-top: 1px solid var(--border);
+  font-size: 10px;
+  color: var(--text-secondary);
 }
 
 .mg-leg {
@@ -321,12 +313,12 @@
 }
 
 .mg-leg-sep {
-  color: var(--text-dim);
+  color: var(--text-tertiary);
 }
 
 .mg-leg-note {
-  font-size: 9.5px;
-  color: var(--text-dim);
+  font-size: 9px;
+  color: var(--text-tertiary);
 }
 
 /* ── C · Goal Dossier ── */
@@ -346,27 +338,25 @@
 
 .gd-glyph {
   font-size: 22px;
-  color: var(--accent-ice);
+  color: var(--brand);
   line-height: 1;
   margin-top: 2px;
   flex: none;
-  text-shadow: 0 0 16px color-mix(in oklab, var(--accent-ice) 30%, transparent);
 }
 
 .gd-ey {
-  font-size: 9.5px;
+  font-size: 10px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--text-dim);
+  color: var(--text-tertiary);
   margin-bottom: 3px;
 }
 
 .gd-title {
-  font-family: var(--font-display);
-  font-weight: 600;
+  font-weight: 700;
   font-size: 17px;
   line-height: 1.25;
-  color: var(--text-bright);
+  color: var(--text-primary);
   text-wrap: pretty;
 }
 
@@ -375,12 +365,12 @@
   align-items: center;
   gap: 8px;
   margin-top: 6px;
-  font-size: 10.5px;
-  color: var(--text-mid);
+  font-size: 10px;
+  color: var(--text-secondary);
 }
 
 .gd-sub .dimd {
-  color: var(--text-dim);
+  color: var(--text-tertiary);
 }
 
 .gd-ring {
@@ -397,7 +387,7 @@
   width: 56px;
   height: 56px;
   border-radius: 50%;
-  background: var(--bg-panel);
+  background: var(--surface-subtle);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -408,7 +398,7 @@
 .gd-ring-in b {
   font-family: var(--font-mono);
   font-size: 16px;
-  color: var(--volt-strong);
+  color: var(--brand);
   font-weight: 700;
 }
 
@@ -416,7 +406,7 @@
   font-size: 8px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--text-dim);
+  color: var(--text-tertiary);
 }
 
 /* snapshot trend */
@@ -428,16 +418,16 @@
 
 .gd-prog {
   height: 8px;
-  border-radius: var(--radius-pill);
-  background: var(--bg-sunken);
-  border: 1px solid var(--border-main);
+  border-radius: 999px;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
   overflow: hidden;
 }
 
 .gd-prog-fill {
   display: block;
   height: 100%;
-  background: linear-gradient(90deg, color-mix(in oklab, var(--accent-ice) 60%, transparent), var(--volt));
+  background: linear-gradient(90deg, color-mix(in oklab, var(--brand) 60%, transparent), var(--brand));
 }
 
 .gd-snaps {
@@ -451,14 +441,14 @@
   font-size: 10px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--text-dim);
+  color: var(--text-tertiary);
   display: inline-flex;
   align-items: center;
   gap: 5px;
 }
 
 .gd-snaparr {
-  color: var(--text-dim);
+  color: var(--text-tertiary);
   font-size: 11px;
 }
 
@@ -467,62 +457,62 @@
   align-items: baseline;
   gap: 6px;
   padding: 4px 10px;
-  border-radius: var(--radius-sm);
-  background: var(--bg-card);
-  border: 1px solid var(--border-main);
+  border-radius: var(--radius);
+  background: var(--card);
+  border: 1px solid var(--border);
 }
 
 .gd-snap.now {
-  border-color: color-mix(in oklab, var(--accent-ice) 45%, var(--border-main));
-  background: var(--bg-card-hover);
+  border-color: color-mix(in oklab, var(--brand) 45%, var(--border));
+  background: var(--brand-tint);
 }
 
 .gd-snap b {
-  font-size: 12.5px;
-  color: var(--text-bright);
+  font-size: 12px;
+  color: var(--text-primary);
 }
 
 .gd-snap.now b {
-  color: var(--accent-ice);
+  color: var(--brand);
 }
 
 .gd-snap .dt {
   font-size: 9px;
-  color: var(--text-dim);
+  color: var(--text-tertiary);
 }
 
 .gd-snap .nt {
-  font-size: 9.5px;
-  color: var(--text-mid);
+  font-size: 10px;
+  color: var(--text-secondary);
 }
 
 .gd-ledger {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
   gap: 1px;
-  background: var(--border-soft);
-  border: 1px solid var(--border-main);
-  border-radius: var(--radius-sm);
+  background: var(--border);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   overflow: hidden;
 }
 
 .gd-cell {
-  background: var(--bg-panel-alt);
+  background: var(--surface-subtle);
   padding: 9px 8px;
   text-align: center;
 }
 
 .gd-cv {
   font-size: 14px;
-  color: var(--text-bright);
+  color: var(--text-primary);
   font-weight: 600;
 }
 
 .gd-ck {
-  font-size: 8.5px;
+  font-size: 8px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--text-dim);
+  color: var(--text-tertiary);
   margin-top: 3px;
 }
 
@@ -554,22 +544,20 @@
 
 .gd-group-h .cnt {
   margin-left: 2px;
-  font-size: 9.5px;
-  color: var(--text-dim);
-  background: var(--bg-card);
-  border: 1px solid var(--border-main);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  background: var(--card);
+  border: 1px solid var(--border);
   padding: 0 6px;
-  border-radius: var(--radius-pill);
+  border-radius: 999px;
 }
 
 .gd-crow {
   display: flex;
   align-items: center;
   gap: 10px;
-  background: var(--bg-card);
-  border: 1px solid var(--border-main);
+  border: 1px solid var(--border);
   border-left: 2.5px solid var(--nc);
-  border-radius: var(--radius-sm);
   padding: 8px 11px;
 }
 
@@ -583,10 +571,9 @@
 }
 
 .gd-ctitle {
-  font-family: var(--font-display);
   font-weight: 500;
-  font-size: 12.5px;
-  color: var(--text-bright);
+  font-size: 12px;
+  color: var(--text-primary);
   line-height: 1.3;
 }
 
@@ -596,7 +583,7 @@
   gap: 7px;
   margin-top: 4px;
   font-size: 10px;
-  color: var(--text-mid);
+  color: var(--text-secondary);
 }
 
 .gd-state {
@@ -604,29 +591,29 @@
   letter-spacing: 0.08em;
   flex: none;
   padding: 2px 8px;
-  border-radius: var(--radius-pill);
+  border-radius: 999px;
   border: 1px solid transparent;
 }
 
 .gd-state.st-done {
-  color: var(--status-ok);
-  background: color-mix(in oklab, var(--status-ok) 14%, transparent);
-  border-color: color-mix(in oklab, var(--status-ok) 34%, transparent);
+  color: var(--success);
+  background: color-mix(in oklab, var(--success) 14%, transparent);
+  border-color: color-mix(in oklab, var(--success) 34%, transparent);
 }
 
 .gd-state.st-open {
-  color: var(--volt-strong);
-  background: var(--volt-wash);
-  border-color: color-mix(in oklab, var(--volt) 32%, transparent);
+  color: var(--brand);
+  background: var(--brand-tint);
+  border-color: color-mix(in oklab, var(--brand) 32%, transparent);
 }
 
 .gd-state.st-block {
-  color: var(--status-bad);
-  background: color-mix(in oklab, var(--status-bad) 14%, transparent);
-  border-color: color-mix(in oklab, var(--status-bad) 34%, transparent);
+  color: var(--destructive);
+  background: color-mix(in oklab, var(--destructive) 14%, transparent);
+  border-color: color-mix(in oklab, var(--destructive) 34%, transparent);
 }
 
 .gd-state.st-ctx {
-  color: var(--text-dim);
-  border-color: var(--border-main);
+  color: var(--text-tertiary);
+  border-color: var(--border);
 }

--- a/dashboard/src/styles/styleseed-base.test.ts
+++ b/dashboard/src/styles/styleseed-base.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const cssPath = resolve(__dirname, 'styleseed-base.css')
+const css = readFileSync(cssPath, 'utf-8')
+
+describe('styleseed-base.css', () => {
+  it('registers StyleSeed semantic tokens in @theme', () => {
+    expect(css).toContain('@theme {')
+    expect(css).toMatch(/--color-surface-page:\s*var\(--surface-page\b/)
+    expect(css).toMatch(/--color-card:\s*var\(--card\b/)
+    expect(css).toMatch(/--color-text-primary:\s*var\(--text-primary\b/)
+    expect(css).toMatch(/--color-text-secondary:\s*var\(--text-secondary\b/)
+    expect(css).toMatch(/--color-text-tertiary:\s*var\(--text-tertiary\b/)
+    expect(css).toMatch(/--color-border:\s*var\(--border\b/)
+    expect(css).toMatch(/--shadow-card:\s*var\(--shadow-card\b/)
+    expect(css).not.toContain('--radius: var(--radius)')
+  })
+
+  it('declares an .ss-surface page wrapper', () => {
+    expect(css).toContain('.ss-surface')
+    expect(css).toContain('background-color: var(--surface-page)')
+    expect(css).toContain('color: var(--text-primary)')
+  })
+
+  it('declares an .ss-card component class scoped to StyleSeed theme', () => {
+    expect(css).toContain('[data-theme="styleseed"] .ss-card')
+    expect(css).toContain('background-color: var(--card)')
+    expect(css).toContain('border-radius: 1rem')
+    expect(css).toContain('box-shadow: var(--shadow-card)')
+  })
+})


### PR DESCRIPTION
## Summary
Migrates Design Canvas and memory surfaces to StyleSeed card-based layouts.

## What changed
- `dashboard/src/components/design-canvas.ts` + test: `ss-surface`, `ss-card` on artboards/cards.
- `dashboard/src/components/memory/memory-primitives.ts`, `memory-lens.ts`, `memory-lineage-rail.ts`, `goal-dossier.ts`, `memory-explore.ts` + tests: `ss-card`, semantic empty-state colors, explicit px font sizes.
- `dashboard/src/styles/design-canvas.css`, `memory-v2.css`: StyleSeed tokens.
- `dashboard/src/styles/styleseed-base.css`: `@theme` registration for StyleSeed semantic tokens and `.ss-surface`.
- `dashboard/src/styles/styleseed-base.test.ts`: new test verifying `@theme` block and utilities.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm build` ✅
- Design canvas, memory, StyleSeed base tests ✅ 45/45

## Notes
- Preserved existing testids/class names for downstream consumers.
