### PR TITLE
feat(dashboard): migrate chat/agents surfaces to StyleSeed

### DIFF
--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -151,7 +151,7 @@ export function AgentLiveTimeline({ name }: { name: string }) {
   }, [filtered.length])
 
   return html`
-    <div class="v2-monitoring-detail flex flex-col gap-2">
+    <div class="ss-card bg-card rounded-2xl shadow-card styleseed-scope v2-monitoring-detail flex flex-col gap-2">
       <div class="flex items-center justify-between gap-2 flex-wrap">
         <${FilterChips} chips=${FILTER_CHIPS} active=${activeFilter} />
         <div class="flex items-center gap-2 text-2xs">

--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -31,7 +31,7 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
   const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
 
   return html`
-    <div class="v2-monitoring-detail agent-runtime-strip">
+    <div class="ss-card bg-card rounded-2xl shadow-card styleseed-scope v2-monitoring-detail agent-runtime-strip">
       <div class="flex items-center gap-1.5 text-sm">
         <${PipelineStageBadge} stage=${stage} />
       </div>

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -983,8 +983,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     : null
 
   return html`
-    <div class="v2-monitoring-surface agent-page flex w-full flex-col gap-5 px-0 py-1">
-      <section class="monitor-surface-card monitor-surface-card-strong v2-monitoring-card p-5" aria-label="에이전트 디렉터리">
+    <div class="ss-surface bg-surface-page styleseed-scope v2-monitoring-surface agent-page flex w-full flex-col gap-5 px-0 py-1">
+      <section class="ss-card bg-card rounded-2xl shadow-card monitor-surface-card monitor-surface-card-strong v2-monitoring-card p-5" aria-label="에이전트 디렉터리">
         <div class="flex flex-col gap-5">
           <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
             <div class="flex min-w-0 flex-col gap-2">
@@ -1040,7 +1040,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       </section>
 
       <div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
-        <section class="monitor-surface-card monitor-surface-card-medium v2-monitoring-panel overflow-hidden" aria-label="Keeper operations list">
+        <section class="ss-card bg-card rounded-2xl shadow-card monitor-surface-card monitor-surface-card-medium v2-monitoring-panel overflow-hidden" aria-label="Keeper operations list">
           <!--
             2026-05-27 KEEPER OPERATIONS row redesign:
             - 현재 단계 column was almost always "-" for stuck keepers (the
@@ -1167,7 +1167,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           </div>
         </section>
 
-        <aside class="monitor-surface-card monitor-surface-card-medium v2-monitoring-panel p-4" aria-label="Selected keeper detail">
+        <aside class="ss-card bg-card rounded-2xl shadow-card monitor-surface-card monitor-surface-card-medium v2-monitoring-panel p-4" aria-label="Selected keeper detail">
           ${selectedRow ? html`
             <div class="flex h-full flex-col gap-4">
               <div class="flex items-start justify-between gap-3">

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -83,7 +83,7 @@ export function AgentsUnified() {
   }))
 
   return html`
-    <div class="v2-monitoring-surface flex flex-col gap-4">
+    <div class="ss-surface bg-surface-page styleseed-scope v2-monitoring-surface flex flex-col gap-4">
       <${FilterChips}
         chips=${viewChips}
         value=${currentView}
@@ -126,7 +126,7 @@ export function AgentsUnified() {
 function FleetAndFsmHubPanel() {
   const [pinned, setPinned] = useState<string | null>(null)
   return html`
-    <div class="v2-monitoring-panel flex flex-col gap-4">
+    <div class="ss-card bg-card rounded-2xl shadow-card styleseed-scope v2-monitoring-panel flex flex-col gap-4">
       <${FleetFsmMatrix} onSelectKeeper=${(name: string) => setPinned(name)} />
       <${CompositeFsmFlowchart} />
       <${FsmHub} selectedName=${pinned} />

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -384,8 +384,18 @@ function linkifyHtml(raw: string): string {
   )
 }
 
-function sanitizeHtml(raw: string): string {
-  return DOMPurify.sanitize(raw)
+const SVG_TAGS = ['svg', 'path', 'rect', 'circle', 'g', 'line', 'polyline', 'polygon', 'ellipse', 'defs', 'use', 'text', 'tspan']
+const SVG_ATTRS = ['viewBox', 'width', 'height', 'fill', 'stroke', 'cx', 'cy', 'r', 'x', 'y', 'x1', 'y1', 'x2', 'y2', 'points', 'd']
+
+function sanitizeHtml(raw: string, options?: { svg?: boolean }): string {
+  if (!options?.svg) return DOMPurify.sanitize(raw)
+  // DOMPurify strips the root <svg> when sanitizing a fragment directly.
+  // Wrapping it in a disposable <div> preserves the svg element, then we
+  // remove the wrapper so callers get clean SVG markup.
+  const wrapped = DOMPurify.sanitize(`<div>${raw}</div>`, { ADD_TAGS: SVG_TAGS, ADD_ATTR: SVG_ATTRS })
+  const tmp = document.createElement('div')
+  tmp.innerHTML = wrapped
+  return tmp.innerHTML.replace(/^<div[^>]*>|<\/div>$/g, '')
 }
 
 function sanitizeSvg(raw: string): string {
@@ -681,7 +691,7 @@ function ChatAttachBlock({ name, dims, src, svg, ph, via, size }: { name: string
         ${src
           ? html`<img src=${src} alt=${name} class="chat-block-attach-img" />`
           : svg
-            ? html`<span dangerouslySetInnerHTML=${{ __html: sanitizeHtml(svg) }} />`
+            ? html`<span dangerouslySetInnerHTML=${{ __html: sanitizeHtml(svg, { svg: true }) }} />`
             : html`<div class="chat-block-attach-ph">${ph || '첨부 이미지'}</div>`}
       </div>
       <figcaption class="chat-block-attach-cap">
@@ -786,7 +796,7 @@ function ChatImageBlock({ src, ph, cap }: { src?: string; ph?: string; cap?: str
 
 function ChatSvgBlock({ svg, cap }: { svg: string; cap?: string }) {
   const [open, setOpen] = useState(false)
-  const clean = useMemo(() => sanitizeSvg(svg), [svg])
+  const clean = useMemo(() => sanitizeHtml(svg, { svg: true }), [svg])
   return html`
     <figure class="chat-block-media" data-chat-block="svg">
       <div
@@ -1671,7 +1681,7 @@ export function ChatTranscript({
     : 'min-h-75 max-h-130'
 
   return html`
-    <div class=${`relative flex min-h-0 flex-col ${isPrimary ? 'flex-1' : ''}`}>
+    <div class=${`ss-surface bg-surface-page styleseed-scope relative flex min-h-0 flex-col ${isPrimary ? 'flex-1' : ''}`}>
       <div
         class=${`chat-transcript ${isPrimary ? 'chat-transcript-airy' : ''} flex ${heightClass} flex-col overflow-y-auto ${
           isPrimary
@@ -2030,7 +2040,7 @@ export function ChatComposer({
     void ingestFiles(event.dataTransfer?.files ?? null)
   }
 
-  const composerClass = isPrimary ? 'composer primary' : 'composer'
+  const composerClass = (isPrimary ? 'composer primary' : 'composer') + ' ss-card styleseed-scope'
   const boxClass = `composer-box ${focus ? 'focus' : ''} ${drag ? 'drag' : ''}`
 
   return html`

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -147,7 +147,7 @@ export function KeeperWorkspaceChat({
   const entries = keeperThreads.value[keeper.name] ?? []
 
   return html`
-    <section class="kw-chat v2-monitoring-surface" role="region" aria-label=${`${keeper.name} 대화`}>
+    <section class="ss-surface bg-surface-page styleseed-scope kw-chat v2-monitoring-surface" role="region" aria-label=${`${keeper.name} 대화`}>
       <${ChatHeader}
         keeper=${keeper}
         detailOpen=${detailOpen}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -69,7 +69,7 @@ function AttentionSection({ keeper }: { keeper: Keeper }): VNode | null {
   const items = attentionItems(keeper)
   if (items.length === 0) return null
   return html`
-    <div class="kw-sec v2-monitoring-panel">
+    <div class="ss-card bg-card rounded-2xl shadow-card kw-sec v2-monitoring-panel">
       <h4>주의 <span class="kw-kp-att">${items.length}</span></h4>
       <div class="kw-att-list v2-monitoring-row">
         ${items.map((it, i) => html`
@@ -199,7 +199,7 @@ function ContextSection({ keeper }: { keeper: Keeper }): VNode {
   }, [compactState, keeper.name])
 
   return html`
-    <div class="kw-sec v2-monitoring-panel">
+    <div class="ss-card bg-card rounded-2xl shadow-card kw-sec v2-monitoring-panel">
       <h4>컨텍스트 점유</h4>
       <div class="kw-card v2-monitoring-card">
         <div class="flex items-baseline justify-between">
@@ -247,7 +247,7 @@ function ThroughputSection({ keeper }: { keeper: Keeper }): VNode {
   const peak = Math.max(1, ...series)
   const latest = series.length ? series[series.length - 1] : 0
   return html`
-    <div class="kw-sec v2-monitoring-panel">
+    <div class="ss-card bg-card rounded-2xl shadow-card kw-sec v2-monitoring-panel">
       <h4>런타임 · 처리량</h4>
       <div class="kw-vitals v2-monitoring-row">
         <div class="kw-vital"><div class="vk">모델</div><div class="vv" title=${model ?? ''}>${model ?? '—'}</div></div>
@@ -272,7 +272,7 @@ function ThroughputSection({ keeper }: { keeper: Keeper }): VNode {
 function OwnedTasksSection({ keeper }: { keeper: Keeper }): VNode {
   const owned = ownedTasks(keeper)
   return html`
-    <div class="kw-sec v2-monitoring-panel">
+    <div class="ss-card bg-card rounded-2xl shadow-card kw-sec v2-monitoring-panel">
       <h4>소유 태스크</h4>
       <div class="kw-list v2-monitoring-row">
         ${owned.length
@@ -297,7 +297,7 @@ export function KeeperWorkspaceRail({
   onToggleDetail: () => void
 }): VNode {
   return html`
-    <aside class="kw-rail v2-monitoring-surface" aria-label="키퍼 컨텍스트">
+    <aside class="ss-surface bg-surface-page styleseed-scope kw-rail v2-monitoring-surface" aria-label="키퍼 컨텍스트">
       <div class="kw-rail-scroll v2-monitoring-panel">
         <${AttentionSection} keeper=${keeper} />
         <${ThroughputSection} keeper=${keeper} />

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -163,7 +163,7 @@ export function KeeperWorkspaceRoster({
   }
 
   return html`
-    <aside class="kw-roster v2-monitoring-surface" aria-label="키퍼 로스터">
+    <aside class="ss-surface bg-surface-page styleseed-scope kw-roster v2-monitoring-surface" aria-label="키퍼 로스터">
       <div class="kw-roster-head v2-monitoring-toolbar">
         <input
           class="kw-roster-search"

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-tool-calls.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-tool-calls.ts
@@ -121,7 +121,7 @@ export function KeeperWorkspaceRecentTools({ keeperName }: { keeperName: string 
   if (entries.length === 0) return null
 
   return html`
-    <div class="kw-sec v2-monitoring-panel">
+    <div class="ss-card bg-card rounded-2xl shadow-card kw-sec v2-monitoring-panel">
       <h4>최근 도구 호출</h4>
       <${RecentToolList}
         entries=${entries}

--- a/dashboard/src/styles/styleseed-base.css
+++ b/dashboard/src/styles/styleseed-base.css
@@ -44,17 +44,20 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Surface wrapper — page background + primary text color */
-[data-theme="styleseed"] .ss-surface {
-  background-color: var(--surface-page);
-  color: var(--text-primary);
+/* Surface + card shells — fallbacks preserve the legacy dark theme when
+   StyleSeed is not active, so migrated components remain safe to render
+   in either mode. */
+.ss-surface {
+  background-color: var(--surface-page, var(--color-bg-page));
+  color: var(--text-primary, var(--color-fg-primary));
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
-/* Card base — all content lives inside cards */
-[data-theme="styleseed"] .ss-card {
-  background-color: var(--card);
+.ss-card {
+  background-color: var(--card, var(--color-bg-surface));
   border-radius: 1rem; /* rounded-2xl */
-  box-shadow: var(--shadow-card);
+  box-shadow: var(--shadow-card, 0 1px 4px rgba(0, 0, 0, 0.5));
 }
 
 /* Dark mode: shadows are invisible, use subtle border for edges */
@@ -62,6 +65,94 @@
 .dark [data-theme="styleseed"] .ss-card {
   box-shadow: none;
   border: var(--card-border);
+}
+
+/* Scope bridge — when StyleSeed is active, every surface marked with
+   .styleseed-scope rewrites the legacy v2 semantic variables its children
+   already consume into StyleSeed tokens. This lets existing components
+   migrate without replacing every inline var() reference. */
+[data-theme="styleseed"] .styleseed-scope {
+  /* Text hierarchy */
+  --color-fg-primary: var(--text-primary);
+  --color-fg-secondary: var(--text-secondary);
+  --color-fg-muted: var(--text-tertiary);
+  --color-fg-disabled: var(--text-disabled);
+
+  /* Surfaces */
+  --color-bg-page: var(--surface-page);
+  --color-bg-surface: var(--card);
+  --color-bg-panel-alt: var(--surface-subtle);
+  --color-bg-elevated: var(--surface-subtle);
+  --color-bg-hover: var(--surface-muted);
+
+  /* Borders */
+  --color-border-default: var(--border);
+  --color-border-divider: var(--border);
+  --color-border-strong: var(--border);
+
+  /* Brand / accent */
+  --color-accent-fg: var(--brand);
+  --color-accent-fg-dim: var(--brand);
+  --color-accent-soft: var(--brand-tint);
+  --color-accent-glow: 155 95 255;
+  --brass-glow: 155 95 255;
+  --brass-soft: var(--brand-tint);
+  --brass-fg: var(--brand);
+  --brass-border: color-mix(in srgb, var(--brand) 35%, transparent);
+
+  /* Status */
+  --color-status-ok: var(--success);
+  --color-status-warn: var(--warning);
+  --color-status-err: var(--destructive);
+  --color-status-info: var(--info);
+  --ok-glow: 107 155 122;
+  --warn-glow: 217 119 6;
+  --err-glow: 212 24 61;
+  --info-glow: 59 130 246;
+  --ok-border: color-mix(in srgb, var(--success) 35%, transparent);
+  --warn-border: color-mix(in srgb, var(--warning) 35%, transparent);
+  --err-border: color-mix(in srgb, var(--destructive) 40%, transparent);
+  --info-border: color-mix(in srgb, var(--info) 35%, transparent);
+
+  /* Legacy status helpers used by chat blocks and roster chips */
+  --color-warn-soft: color-mix(in srgb, var(--warning) 12%, transparent);
+  --color-warn-fg: var(--warning);
+  --color-info-soft: color-mix(in srgb, var(--info) 12%, transparent);
+  --color-info-fg: var(--info);
+  --bad-soft: color-mix(in srgb, var(--destructive) 15%, transparent);
+
+  /* Misc v2 tokens consumed inside the migration scope */
+  --purple: var(--info);
+  --stalled-fg: var(--info);
+  --purple-12: var(--brand-tint);
+  --purple-24: color-mix(in srgb, var(--brand) 24%, transparent);
+  --accent-10: var(--brand-tint);
+  --accent-20: color-mix(in srgb, var(--brand) 20%, transparent);
+  --warn-10: color-mix(in srgb, var(--warning) 10%, transparent);
+  --warn-20: color-mix(in srgb, var(--warning) 20%, transparent);
+  --shadow-panel: var(--shadow-card);
+  --shadow-raised: var(--shadow-elevated);
+  --shadow-inset: none;
+  --elev-4-shadow: var(--shadow-card);
+
+  /* Code syntax */
+  --syn-key: var(--info);
+  --syn-str: var(--success);
+}
+
+/* Coerce migrated card/panel shells to the StyleSeed card radius and shadow
+   when the theme is active. The legacy .v2-monitoring-* / .monitor-surface-*
+   classes still provide structure and borders; this only updates the shape. */
+[data-theme="styleseed"] .v2-monitoring-card,
+[data-theme="styleseed"] .v2-monitoring-panel,
+[data-theme="styleseed"] .v2-monitoring-detail,
+[data-theme="styleseed"] .monitor-surface-card,
+[data-theme="styleseed"] .monitor-surface-card-strong,
+[data-theme="styleseed"] .monitor-surface-card-medium,
+[data-theme="styleseed"] .kw-card,
+[data-theme="styleseed"] .kw-sec.v2-monitoring-panel {
+  border-radius: 1rem;
+  box-shadow: var(--shadow-card);
 }
 
 /* Mobile safe-area helpers */

--- a/dashboard/src/styles/styleseed-theme.css
+++ b/dashboard/src/styles/styleseed-theme.css
@@ -6,6 +6,38 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
 
+/* Tailwind v4 theme bridge — exposes StyleSeed tokens as utilities.
+   Fallbacks point at the legacy v2 semantic variables so components that
+   add bg-surface-page / text-text-primary / shadow-card keep working when
+   the StyleSeed attribute is not active. */
+@theme inline {
+  --color-surface-page: var(--surface-page, var(--color-bg-page));
+  --color-card: var(--card, var(--color-bg-surface));
+  --color-surface-subtle: var(--surface-subtle, var(--color-bg-panel-alt));
+  --color-surface-muted: var(--surface-muted, var(--color-bg-hover));
+
+  --color-text-primary: var(--text-primary, var(--color-fg-primary));
+  --color-text-secondary: var(--text-secondary, var(--color-fg-secondary));
+  --color-text-tertiary: var(--text-tertiary, var(--color-fg-muted));
+  --color-text-disabled: var(--text-disabled, var(--color-fg-disabled));
+  --color-icon-default: var(--icon-default, var(--color-fg-secondary));
+
+  --color-brand: var(--brand, var(--color-accent-fg));
+  --color-brand-tint: var(--brand-tint, var(--color-accent-soft));
+  --color-success: var(--success, var(--color-status-ok));
+  --color-destructive: var(--destructive, var(--color-status-err));
+  --color-warning: var(--warning, var(--color-status-warn));
+  --color-info: var(--info, var(--color-status-info));
+  --color-border: var(--border, var(--color-border-default));
+  --color-alert-badge: var(--alert-badge, var(--color-status-err));
+
+  --shadow-card: var(--shadow-card, 0 1px 4px rgba(0, 0, 0, 0.5));
+  --shadow-card-hover: var(--shadow-card-hover, 0 2px 8px rgba(0, 0, 0, 0.55));
+  --shadow-elevated: var(--shadow-elevated, 0 8px 24px rgba(0, 0, 0, 0.55));
+  --shadow-modal: var(--shadow-modal, 0 8px 24px rgba(0, 0, 0, 0.55));
+  --shadow-button: var(--shadow-button, 0 1px 3px rgba(0, 0, 0, 0.5));
+}
+
 [data-theme="styleseed"] {
   color-scheme: light;
 


### PR DESCRIPTION
## Summary
Migrates chat and agent surfaces to StyleSeed card-based layouts.

## What changed
- `dashboard/src/components/chat/primitives.ts`: transcript + composer wrapped, inline SVG sanitization fixed.
- `dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts`, `keeper-workspace-roster.ts`, `keeper-workspace-rail.ts`, `keeper-workspace-tool-calls.ts`: wrapped cards/panels.
- `dashboard/src/components/agent-roster.ts`, `agents-unified.ts`, `agent-monitor/runtime-strip.ts`, `agent-monitor/live-timeline.ts`: wrapped surfaces/cards.
- `dashboard/src/styles/styleseed-theme.css`: `@theme inline` bridge for Tailwind utilities.
- `dashboard/src/styles/styleseed-base.css`: `.ss-surface`, `.ss-card`, `.styleseed-scope` variable bridge to rewrite v2 semantic vars under StyleSeed.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm build` ✅
- Chat, keeper-workspace, agent roster, agents-unified, runtime-strip tests ✅ 163/163

## Notes
- Legacy `v2-monitoring-*` / `kw-*` / `chat-*` classes are preserved so existing tests still pass.
