### PR TITLE
feat(dashboard): rich 1:1 chat with markdown blocks, Shiki, Mermaid, and artifact panel

### DIFF
--- a/dashboard/src/components/chat/artifact-panel.test.ts
+++ b/dashboard/src/components/chat/artifact-panel.test.ts
@@ -1,0 +1,235 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { act } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KeeperConversationEntry } from '../../types'
+import { ChatArtifactPanel, extractArtifactGroups } from './artifact-panel'
+
+function entry(
+  overrides: Partial<KeeperConversationEntry> & Pick<KeeperConversationEntry, 'id' | 'text'>,
+): KeeperConversationEntry {
+  return {
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    delivery: 'delivered',
+    streamState: null,
+    details: null,
+    error: null,
+    attachments: [],
+    blocks: [],
+    ...overrides,
+    id: overrides.id,
+    text: overrides.text,
+  }
+}
+
+describe('extractArtifactGroups', () => {
+  it('returns an empty array when there are no artifacts', () => {
+    const groups = extractArtifactGroups([
+      entry({ id: 'e1', text: 'hello', blocks: [], attachments: [] }),
+    ])
+    expect(groups).toHaveLength(0)
+  })
+
+  it('collects attachments, code, mermaid, images, svgs, artifacts, tool outputs, and links', () => {
+    const groups = extractArtifactGroups([
+      entry({
+        id: 'e1',
+        text: 'reply',
+        role: 'assistant',
+        label: 'sangsu',
+        attachments: [
+          { id: 'att-1', type: 'image', name: 'screen.png', size: 1024, mimeType: 'image/png', data: 'data:image/png;base64,abc' },
+        ],
+        blocks: [
+          { t: 'code', cap: 'config.ml', html: 'let x = 1' },
+          { t: 'mermaid', source: 'graph TD; A-->B', caption: 'flow' },
+          { t: 'image', src: '/img/screen.png', cap: '실행 화면' },
+          { t: 'svg', svg: '<svg viewBox="0 0 10 10"><circle cx="5" cy="5" r="5"/></svg>', cap: 'diagram' },
+          { t: 'artifact', kind: 'json', name: 'report.json', size: '12 KB', note: '3 items' },
+          {
+            t: 'trace',
+            trace: [
+              { kind: 'think', text: 'plan' },
+              { kind: 'tool', name: 'keeper_context_status', status: 'ok', dur: '0.2s', args: { path: 'a' }, result: '{"ok":true}' },
+            ],
+          },
+          { t: 'link', url: 'https://example.com', title: 'Example', meta: 'example.com' },
+        ],
+      }),
+      entry({ id: 'e2', text: 'user msg', role: 'user', label: '사용자', blocks: [{ t: 'attach', name: 'shape.svg', svg: '<svg/>', size: '1 KB' }] }),
+    ])
+
+    expect(groups).toHaveLength(2)
+    expect(groups[0]!.turnIndex).toBe(0)
+    expect(groups[0]!.items).toHaveLength(8)
+    expect(groups[1]!.turnIndex).toBe(1)
+    expect(groups[1]!.items).toHaveLength(1)
+
+    const kinds = groups[0]!.items.map((i) => i.kind)
+    expect(kinds).toEqual(['attachment', 'code', 'mermaid', 'image', 'svg', 'artifact', 'tool', 'link'])
+  })
+
+  it('groups items by entry id', () => {
+    const groups = extractArtifactGroups([
+      entry({ id: 'e1', text: 'a', blocks: [{ t: 'code', html: 'a' }] }),
+      entry({ id: 'e2', text: 'b', blocks: [{ t: 'code', html: 'b' }] }),
+    ])
+    expect(groups).toHaveLength(2)
+    expect(groups[0]!.entryId).toBe('e1')
+    expect(groups[1]!.entryId).toBe('e2')
+  })
+})
+
+describe('ChatArtifactPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    vi.stubGlobal('open', vi.fn())
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders the total artifact count', () => {
+    render(
+      html`<${ChatArtifactPanel}
+        entries=${[
+          entry({
+            id: 'e1',
+            text: 'reply',
+            blocks: [
+              { t: 'code', cap: 'a.ml', html: 'let x = 1' },
+              { t: 'image', src: '/img/screen.png' },
+            ],
+          }),
+        ]}
+      />`,
+      container,
+    )
+
+    expect(container.textContent).toContain('아티팩트')
+    expect(container.querySelector('.chat-artifact-panel-count')?.textContent).toBe('2')
+  })
+
+  it('shows an empty message when there are no artifacts', () => {
+    render(html`<${ChatArtifactPanel} entries=${[]} />`, container)
+    expect(container.textContent).toContain('아티팩트가 없습니다')
+  })
+
+  it('groups artifacts under turn headers', () => {
+    render(
+      html`<${ChatArtifactPanel}
+        entries=${[
+          entry({ id: 'e1', text: 'a', role: 'assistant', label: 'sangsu', blocks: [{ t: 'code', html: 'a' }] }),
+          entry({ id: 'e2', text: 'b', role: 'user', label: '사용자', blocks: [{ t: 'image', src: '/b.png' }] }),
+        ]}
+      />`,
+      container,
+    )
+
+    expect(container.textContent).toContain('#1')
+    expect(container.textContent).toContain('sangsu')
+    expect(container.textContent).toContain('#2')
+    expect(container.textContent).toContain('사용자')
+  })
+
+  it('renders compact cards with open and download buttons', () => {
+    render(
+      html`<${ChatArtifactPanel}
+        entries=${[
+          entry({
+            id: 'e1',
+            text: 'reply',
+            blocks: [{ t: 'artifact', kind: 'json', name: 'report.json', size: '12 KB', note: '3 items' }],
+          }),
+        ]}
+      />`,
+      container,
+    )
+
+    const card = container.querySelector('[data-artifact-kind="artifact"]')
+    expect(card).not.toBeNull()
+    expect(card?.textContent).toContain('report.json')
+    expect(card?.textContent).toContain('JSON')
+    expect(card?.textContent).toContain('12 KB')
+    const buttons = [...(card?.querySelectorAll('button') ?? [])].map((b) => b.textContent?.trim())
+    expect(buttons).toContain('열기')
+    expect(buttons).toContain('다운로드')
+  })
+
+  it('disables download for artifact blocks that carry no payload', () => {
+    render(
+      html`<${ChatArtifactPanel}
+        entries=${[
+          entry({
+            id: 'e1',
+            text: 'reply',
+            blocks: [{ t: 'artifact', kind: 'json', name: 'report.json' }],
+          }),
+        ]}
+      />`,
+      container,
+    )
+
+    const card = container.querySelector('[data-artifact-kind="artifact"]')
+    const downloadBtn = card?.querySelector('button[aria-label="다운로드"]') as HTMLButtonElement | null
+    expect(downloadBtn?.disabled).toBe(true)
+  })
+
+  it('expands a code preview when open is clicked', async () => {
+    render(
+      html`<${ChatArtifactPanel}
+        entries=${[
+          entry({
+            id: 'e1',
+            text: 'reply',
+            blocks: [{ t: 'code', cap: 'a.ml', html: 'let x = 1' }],
+          }),
+        ]}
+      />`,
+      container,
+    )
+
+    const card = container.querySelector('[data-artifact-kind="code"]')
+    expect(card?.querySelector('[data-artifact-preview="code"]')).toBeNull()
+
+    const openBtn = card?.querySelector('button[aria-label="미리보기"]') as HTMLButtonElement | null
+    await act(async () => {
+      openBtn?.click()
+    })
+
+    expect(card?.querySelector('[data-artifact-preview="code"]')).not.toBeNull()
+    expect(card?.textContent).toContain('let x = 1')
+  })
+
+  it('opens a link in a new tab when open is clicked', async () => {
+    render(
+      html`<${ChatArtifactPanel}
+        entries=${[
+          entry({
+            id: 'e1',
+            text: 'reply',
+            blocks: [{ t: 'link', url: 'https://example.com', title: 'Example' }],
+          }),
+        ]}
+      />`,
+      container,
+    )
+
+    const card = container.querySelector('[data-artifact-kind="link"]')
+    const openBtn = card?.querySelector('button[aria-label="링크 열기"]') as HTMLButtonElement | null
+    await act(async () => {
+      openBtn?.click()
+    })
+
+    expect(window.open).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer')
+  })
+})

--- a/dashboard/src/components/chat/artifact-panel.ts
+++ b/dashboard/src/components/chat/artifact-panel.ts
@@ -1,0 +1,377 @@
+// Conversation artifact/output panel — right-side inventory of every rich
+// output in a keeper transcript (attachments, code, diagrams, images, SVGs,
+// artifacts, tool outputs, links). Grouped by the message/turn they belong to.
+
+import { html } from 'htm/preact'
+import { useMemo, useState } from 'preact/hooks'
+import type { VNode } from 'preact'
+import DOMPurify from 'dompurify'
+import type { ChatBlock, KeeperConversationEntry, KeeperConversationAttachment } from '../../types'
+import { copyToClipboard } from '../common/copyable-code'
+import { showToast } from '../common/toast'
+
+export type ArtifactKind = 'attachment' | 'code' | 'mermaid' | 'image' | 'svg' | 'artifact' | 'tool' | 'link'
+
+export interface ArtifactItem {
+  id: string
+  entryId: string
+  turnIndex: number
+  kind: ArtifactKind
+  name: string
+  typeLabel: string
+  size?: string
+  src?: string
+  data?: string
+  mimeType?: string
+  source?: string
+  url?: string
+  note?: string
+}
+
+export interface ArtifactGroup {
+  entryId: string
+  turnIndex: number
+  label: string
+  role: string
+  items: ArtifactItem[]
+}
+
+function formatAttachmentSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+  if (bytes < 1024) return `${Math.round(bytes)} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function artifactIcon(kind: ArtifactKind): string {
+  switch (kind) {
+    case 'attachment': return '◫'
+    case 'code': return '</>'
+    case 'mermaid': return '~>'
+    case 'image': return '▣'
+    case 'svg': return '◫'
+    case 'artifact': return '⎙'
+    case 'tool': return 'T'
+    case 'link': return '↗'
+  }
+}
+
+function attachmentToArtifact(att: KeeperConversationAttachment, entryId: string, turnIndex: number, index: number): ArtifactItem {
+  return {
+    id: `${entryId}-att-${index}`,
+    entryId,
+    turnIndex,
+    kind: 'attachment',
+    name: att.name,
+    typeLabel: att.mimeType,
+    size: formatAttachmentSize(att.size),
+    src: att.data,
+    data: att.data,
+    mimeType: att.mimeType,
+  }
+}
+
+function blockToArtifacts(block: ChatBlock, entryId: string, turnIndex: number, blockIndex: number): ArtifactItem[] {
+  switch (block.t) {
+    case 'attach':
+      return [{
+        id: `${entryId}-block-attach-${blockIndex}`,
+        entryId,
+        turnIndex,
+        kind: 'attachment',
+        name: block.name,
+        typeLabel: block.mimeType || 'file',
+        size: block.size,
+        src: block.src || block.data,
+        data: block.data,
+        mimeType: block.mimeType,
+      }]
+    case 'code':
+      return [{
+        id: `${entryId}-block-code-${blockIndex}`,
+        entryId,
+        turnIndex,
+        kind: 'code',
+        name: block.cap || `snippet-${blockIndex}`,
+        typeLabel: block.cap || 'code',
+        source: block.html,
+      }]
+    case 'mermaid':
+      return [{
+        id: `${entryId}-block-mermaid-${blockIndex}`,
+        entryId,
+        turnIndex,
+        kind: 'mermaid',
+        name: block.caption || 'diagram',
+        typeLabel: 'mermaid',
+        source: block.source,
+      }]
+    case 'image':
+      return [{
+        id: `${entryId}-block-image-${blockIndex}`,
+        entryId,
+        turnIndex,
+        kind: 'image',
+        name: block.cap || 'image',
+        typeLabel: 'image',
+        src: block.src,
+      }]
+    case 'svg':
+      return [{
+        id: `${entryId}-block-svg-${blockIndex}`,
+        entryId,
+        turnIndex,
+        kind: 'svg',
+        name: block.cap || 'svg',
+        typeLabel: 'svg',
+        source: block.svg,
+      }]
+    case 'artifact':
+      return [{
+        id: `${entryId}-block-artifact-${blockIndex}`,
+        entryId,
+        turnIndex,
+        kind: 'artifact',
+        name: block.name,
+        typeLabel: block.kind || 'file',
+        size: block.size,
+        note: block.note,
+      }]
+    case 'trace':
+      return block.trace.flatMap((step, stepIndex) => {
+        if (step.kind !== 'tool') return []
+        return [{
+          id: `${entryId}-block-trace-${blockIndex}-${stepIndex}`,
+          entryId,
+          turnIndex,
+          kind: 'tool',
+          name: step.name,
+          typeLabel: 'tool',
+          source: step.result ?? JSON.stringify(step.args),
+        }]
+      })
+    case 'link':
+      return [{
+        id: `${entryId}-block-link-${blockIndex}`,
+        entryId,
+        turnIndex,
+        kind: 'link',
+        name: block.title,
+        typeLabel: block.meta || 'link',
+        url: block.url,
+      }]
+    default:
+      return []
+  }
+}
+
+/** Scan conversation entries and group every artifact/output by its turn. */
+export function extractArtifactGroups(entries: KeeperConversationEntry[]): ArtifactGroup[] {
+  const groups: ArtifactGroup[] = []
+  entries.forEach((entry, turnIndex) => {
+    const items: ArtifactItem[] = []
+    entry.attachments?.forEach((att, i) => { items.push(attachmentToArtifact(att, entry.id, turnIndex, i)) })
+    entry.blocks?.forEach((block, i) => { items.push(...blockToArtifacts(block, entry.id, turnIndex, i)) })
+    if (items.length === 0) return
+    groups.push({
+      entryId: entry.id,
+      turnIndex,
+      label: entry.label || entry.role,
+      role: entry.role,
+      items,
+    })
+  })
+  return groups
+}
+
+function hasDownloadPayload(item: ArtifactItem): boolean {
+  if (item.kind === 'link') return false
+  return !!(item.data || item.src || item.source)
+}
+
+function downloadPayload(item: ArtifactItem): void {
+  if (item.kind === 'link') return
+  const content = item.data || item.src || item.source || ''
+  const mime = item.mimeType || 'text/plain'
+  const filename = item.name
+  let url: string
+  if (content.startsWith('data:')) {
+    url = content
+  } else {
+    const blob = new Blob([content], { type: mime })
+    url = URL.createObjectURL(blob)
+  }
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  if (!content.startsWith('data:')) URL.revokeObjectURL(url)
+}
+
+function sanitizeHtml(raw: string): string {
+  return DOMPurify.sanitize(raw)
+}
+
+function ArtifactPreview({ item }: { item: ArtifactItem }): VNode {
+  switch (item.kind) {
+    case 'image':
+      return html`
+        <div class="chat-artifact-preview" data-artifact-preview="image">
+          ${item.src
+            ? html`<img src=${item.src} alt=${item.name} class="chat-artifact-preview-img" />`
+            : html`<div class="chat-artifact-preview-ph">이미지 없음</div>`}
+        </div>
+      `
+    case 'svg':
+      return html`
+        <div
+          class="chat-artifact-preview"
+          data-artifact-preview="svg"
+          dangerouslySetInnerHTML=${{ __html: item.source ? sanitizeHtml(item.source) : '' }}
+        />
+      `
+    case 'link':
+      return html`
+        <div class="chat-artifact-preview" data-artifact-preview="link">
+          <a
+            class="chat-artifact-preview-link"
+            href=${item.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span>${item.name}</span>
+            <span class="chat-artifact-preview-link-meta">${item.url}</span>
+          </a>
+        </div>
+      `
+    case 'attachment':
+      if (item.mimeType?.startsWith('image/') && item.src) {
+        return html`
+          <div class="chat-artifact-preview" data-artifact-preview="attachment-image">
+            <img src=${item.src} alt=${item.name} class="chat-artifact-preview-img" />
+          </div>
+        `
+      }
+      return html`
+        <div class="chat-artifact-preview" data-artifact-preview="attachment">
+          <pre class="chat-artifact-preview-text">${item.name}</pre>
+        </div>
+      `
+    default:
+      return html`
+        <div class="chat-artifact-preview" data-artifact-preview="code">
+          <pre class="chat-artifact-preview-text"><code dangerouslySetInnerHTML=${{ __html: item.source ? sanitizeHtml(item.source) : '' }} /></pre>
+        </div>
+      `
+  }
+}
+
+function ArtifactCard({ item }: { item: ArtifactItem }): VNode {
+  const [open, setOpen] = useState(false)
+  const [copying, setCopying] = useState(false)
+  const canDownload = hasDownloadPayload(item)
+  const canOpen = item.kind === 'link' ? !!item.url : true
+
+  const handleOpen = () => {
+    if (item.kind === 'link' && item.url) {
+      window.open(item.url, '_blank', 'noopener,noreferrer')
+      return
+    }
+    setOpen((o) => !o)
+  }
+
+  const handleDownload = () => {
+    if (!canDownload) return
+    downloadPayload(item)
+  }
+
+  const handleCopy = async () => {
+    const text = item.data || item.src || item.source || item.url || ''
+    if (!text) return
+    const ok = await copyToClipboard(text)
+    if (ok) {
+      setCopying(true)
+      showToast('클립보드에 복사됨', 'success', 1400)
+      setTimeout(() => setCopying(false), 1200)
+    } else {
+      showToast('복사 실패', 'error')
+    }
+  }
+
+  const meta = [item.typeLabel.toUpperCase(), item.size, item.note].filter(Boolean).join(' · ')
+
+  return html`
+    <div class="chat-artifact-card" data-artifact-kind=${item.kind} data-artifact-id=${item.id}>
+      <div class="chat-artifact-card-hd">
+        <span class="chat-artifact-card-icon">${artifactIcon(item.kind)}</span>
+        <div class="chat-artifact-card-info">
+          <div class="chat-artifact-card-name" title=${item.name}>${item.name}</div>
+          <div class="chat-artifact-card-meta">${meta}</div>
+        </div>
+      </div>
+      <div class="chat-artifact-card-actions">
+        <button
+          type="button"
+          class="chat-artifact-card-btn"
+          disabled=${!canOpen}
+          onClick=${handleOpen}
+          aria-label=${item.kind === 'link' ? '링크 열기' : '미리보기'}
+        >
+          ${item.kind === 'link' ? '열기' : open ? '닫기' : '열기'}
+        </button>
+        <button
+          type="button"
+          class="chat-artifact-card-btn"
+          disabled=${!canDownload}
+          onClick=${handleDownload}
+          aria-label="다운로드"
+        >
+          다운로드
+        </button>
+        <button
+          type="button"
+          class="chat-artifact-card-btn ${copying ? 'copied' : ''}"
+          onClick=${handleCopy}
+          aria-label="복사"
+        >
+          ${copying ? '✓' : '복사'}
+        </button>
+      </div>
+      ${open ? html`<${ArtifactPreview} item=${item} />` : null}
+    </div>
+  `
+}
+
+/** Right-side panel that inventories every artifact/output in the transcript. */
+export function ChatArtifactPanel({ entries }: { entries: KeeperConversationEntry[] }): VNode {
+  const groups = useMemo(() => extractArtifactGroups(entries), [entries])
+  const total = useMemo(() => groups.reduce((sum, g) => sum + g.items.length, 0), [groups])
+
+  return html`
+    <aside class="chat-artifact-panel" role="complementary" aria-label="대화 아티팩트">
+      <div class="chat-artifact-panel-head">
+        <span class="chat-artifact-panel-title">⚡ 아티팩트</span>
+        <span class="chat-artifact-panel-count">${total}</span>
+      </div>
+      ${groups.length === 0
+        ? html`<div class="chat-artifact-panel-empty">이 대화에는 아티팩트가 없습니다.</div>`
+        : html`
+            <div class="chat-artifact-panel-body">
+              ${groups.map((group) => html`
+                <div key=${group.entryId} class="chat-artifact-group" data-artifact-group=${group.entryId}>
+                  <div class="chat-artifact-group-hd">
+                    <span class="chat-artifact-group-turn">#${group.turnIndex + 1}</span>
+                    <span class="chat-artifact-group-role ${group.role}">${group.label}</span>
+                  </div>
+                  <div class="chat-artifact-group-items">
+                    ${group.items.map((item) => html`<${ArtifactCard} key=${item.id} item=${item} />`)}
+                  </div>
+                </div>
+              `)}
+            </div>
+          `}
+    </aside>
+  `
+}

--- a/dashboard/src/components/chat/code-blocks.test.ts
+++ b/dashboard/src/components/chat/code-blocks.test.ts
@@ -1,0 +1,143 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ChatBlock, KeeperConversationEntry } from '../../types'
+import { ChatTranscript } from './primitives'
+
+const flushUi = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 40))
+
+function entry(
+  overrides: Partial<KeeperConversationEntry> & Pick<KeeperConversationEntry, 'id' | 'text'>,
+): KeeperConversationEntry {
+  const { id, text, ...rest } = overrides
+  return {
+    id,
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    text,
+    rawText: rest.rawText ?? text,
+    timestamp: '2026-03-24T00:00:00.000Z',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+    ...rest,
+  }
+}
+
+function renderBlocks(blocks: ChatBlock[]) {
+  return html`<${ChatTranscript}
+    entries=${[entry({ id: 'b1', text: '', blocks })]}
+    emptyText="empty"
+  />`
+}
+
+describe('ChatCodeBlock Shiki highlighting', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders a highlighted code block with a copy button', async () => {
+    render(renderBlocks([{ t: 'code', cap: 'config.ml', html: 'let x = 1', source: 'let x = 1' }]), container)
+
+    const code = container.querySelector('[data-chat-block="code"]')
+    expect(code).not.toBeNull()
+    expect(code?.textContent).toContain('config.ml')
+
+    await flushUi()
+    expect(code?.querySelector('pre.shiki')).not.toBeNull()
+    expect(code?.textContent).toContain('let x = 1')
+
+    const copy = code?.querySelector('button[aria-label="코드 복사"]')
+    expect(copy).not.toBeNull()
+    expect(copy?.textContent?.trim()).toBe('복사')
+  })
+
+  it('copies the plain source text, not escaped HTML', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    const originalClipboard = navigator.clipboard
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    render(
+      renderBlocks([
+        { t: 'code', cap: 'example', html: '&lt;script&gt;alert(1)&lt;/script&gt;', source: '<script>alert(1)</script>' },
+      ]),
+      container,
+    )
+
+    await flushUi()
+    const copy = container.querySelector('[data-chat-block="code"] button[aria-label="코드 복사"]') as HTMLButtonElement
+    copy.click()
+    await flushUi()
+
+    expect(writeText).toHaveBeenCalledWith('<script>alert(1)</script>')
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard,
+    })
+  })
+
+  it('falls back to the escaped HTML when Shiki fails', async () => {
+    const { codeToHtml } = await import('shiki')
+    vi.mocked(codeToHtml).mockRejectedValueOnce(new Error('unsupported language'))
+
+    render(renderBlocks([{ t: 'code', cap: 'weirdlang', html: 'a &lt; b', source: 'a < b' }]), container)
+
+    await flushUi()
+    const code = container.querySelector('[data-chat-block="code"]')
+    expect(code?.classList.contains('chat-block-code-fallback')).toBe(true)
+    expect(code?.textContent).toContain('a < b')
+  })
+})
+
+describe('ChatMermaidBlock diagram rendering', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders a mermaid block as SVG', async () => {
+    render(renderBlocks([{ t: 'mermaid', source: 'graph TD; A-->B;', caption: 'flow' }]), container)
+
+    const block = container.querySelector('[data-chat-block="mermaid"]')
+    expect(block).not.toBeNull()
+    expect(block?.textContent).toContain('flow')
+
+    await flushUi()
+    expect(block?.querySelector('svg')).not.toBeNull()
+  })
+
+  it('falls back to a code block when mermaid rendering errors', async () => {
+    const { default: mermaid } = await import('mermaid')
+    vi.mocked(mermaid.render).mockRejectedValueOnce(new Error('parse error'))
+
+    render(renderBlocks([{ t: 'mermaid', source: 'invalid diagram', caption: 'broken' }]), container)
+
+    await flushUi()
+    expect(container.querySelector('[data-chat-block="mermaid"]')).toBeNull()
+    const code = container.querySelector('[data-chat-block="code"]')
+    expect(code).not.toBeNull()
+    expect(code?.textContent).toContain('invalid diagram')
+    expect(code?.textContent).toContain('mermaid')
+  })
+})

--- a/dashboard/src/components/chat/markdown-blocks.test.ts
+++ b/dashboard/src/components/chat/markdown-blocks.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import { parseMarkdownToBlocks } from './markdown-blocks'
+import type { ChatBlock } from '../../types'
+
+describe('parseMarkdownToBlocks', () => {
+  it('returns an empty array for empty/whitespace input', () => {
+    expect(parseMarkdownToBlocks('')).toEqual([])
+    expect(parseMarkdownToBlocks('   \n  ')).toEqual([])
+  })
+
+  it('parses paragraphs with inline formatting and links', () => {
+    const blocks = parseMarkdownToBlocks('Hello **world**. Visit http://example.com')
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toMatchObject({ t: 'p' })
+    const html = (blocks[0] as Extract<ChatBlock, { t: 'p' }>).html
+    expect(html).toContain('Hello')
+    expect(html).toContain('<strong>world</strong>')
+    expect(html).toContain('<a')
+    expect(html).toContain('http://example.com')
+  })
+
+  it('parses headings as h4 blocks', () => {
+    const blocks = parseMarkdownToBlocks('# Title\n\n## Subtitle')
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0]).toMatchObject({ t: 'h4' })
+    expect(blocks[1]).toMatchObject({ t: 'h4' })
+    expect((blocks[0] as Extract<ChatBlock, { t: 'h4' }>).html).toContain('Title')
+  })
+
+  it('parses unordered lists', () => {
+    const blocks = parseMarkdownToBlocks('- first\n- **second**\n- [third](http://x.com)')
+    expect(blocks).toHaveLength(1)
+    const list = blocks[0] as Extract<ChatBlock, { t: 'ul' }>
+    expect(list.t).toBe('ul')
+    expect(list.items).toHaveLength(3)
+    expect(list.items[0]).toContain('first')
+    expect(list.items[1]).toContain('<strong>second</strong>')
+    expect(list.items[2]).toContain('<a')
+  })
+
+  it('parses ordered lists', () => {
+    const blocks = parseMarkdownToBlocks('1. first\n2. second')
+    const list = blocks[0] as Extract<ChatBlock, { t: 'ul' }>
+    expect(list.t).toBe('ul')
+    expect(list.items).toHaveLength(2)
+  })
+
+  it('parses code fences with language caption', () => {
+    const blocks = parseMarkdownToBlocks('```typescript\nconst x = 1 < 2\n```')
+    expect(blocks).toHaveLength(1)
+    const code = blocks[0] as Extract<ChatBlock, { t: 'code' }>
+    expect(code.t).toBe('code')
+    expect(code.cap).toBe('typescript')
+    expect(code.html).toContain('const x = 1')
+    expect(code.html).toContain('&lt;') // escaped, not raw
+  })
+
+  it('parses mermaid fences into mermaid blocks', () => {
+    const blocks = parseMarkdownToBlocks('```mermaid\ngraph TD\n  A --> B\n```')
+    expect(blocks).toHaveLength(1)
+    const mermaid = blocks[0] as Extract<ChatBlock, { t: 'mermaid' }>
+    expect(mermaid.t).toBe('mermaid')
+    expect(mermaid.source).toContain('graph TD')
+  })
+
+  it('parses GitHub-style callouts', () => {
+    const cases: Array<{ input: string; severity: string; label: string }> = [
+      { input: '> [!NOTE]\n> note body', severity: 'info', label: 'NOTE' },
+      { input: '> [!TIP]\n> tip body', severity: 'info', label: 'TIP' },
+      { input: '> [!WARNING]\n> warning body', severity: 'warn', label: 'WARNING' },
+      { input: '> [!CAUTION]\n> caution body', severity: 'bad', label: 'CAUTION' },
+      { input: '> [!DANGER]\n> danger body', severity: 'bad', label: 'DANGER' },
+    ]
+
+    for (const { input, severity, label } of cases) {
+      const blocks = parseMarkdownToBlocks(input)
+      expect(blocks).toHaveLength(1)
+      const callout = blocks[0] as Extract<ChatBlock, { t: 'callout' }>
+      expect(callout.t).toBe('callout')
+      expect(callout.severity).toBe(severity)
+      expect(callout.html).toContain(`${label.toLowerCase()} body`)
+      expect(callout.html).not.toContain('[!')
+    }
+  })
+
+  it('turns plain blockquotes into info callouts', () => {
+    const blocks = parseMarkdownToBlocks('> plain quote')
+    const callout = blocks[0] as Extract<ChatBlock, { t: 'callout' }>
+    expect(callout.t).toBe('callout')
+    expect(callout.severity).toBe('info')
+    expect(callout.html).toContain('plain quote')
+  })
+
+  it('parses tables and detects numeric/muted cells', () => {
+    const blocks = parseMarkdownToBlocks('|name|count|\n|---|---|\n|a|42|\n|b|n/a|\n')
+    expect(blocks).toHaveLength(1)
+    const table = blocks[0] as Extract<ChatBlock, { t: 'table' }>
+    expect(table.t).toBe('table')
+    expect(table.head).toHaveLength(2)
+    expect(table.rows).toHaveLength(2)
+    expect(table.rows[0]![1]).toMatchObject({ v: '42', num: true })
+    expect(table.rows[1]![1]).toMatchObject({ v: 'n/a', muted: true })
+  })
+
+  it('promotes image-only paragraphs to image blocks', () => {
+    const blocks = parseMarkdownToBlocks('![alt text](http://x.com/img.png)')
+    expect(blocks).toHaveLength(1)
+    const image = blocks[0] as Extract<ChatBlock, { t: 'image' }>
+    expect(image.t).toBe('image')
+    expect(image.src).toBe('http://x.com/img.png')
+    expect(image.cap).toBe('alt text')
+  })
+
+  it('keeps inline images inside paragraphs', () => {
+    const blocks = parseMarkdownToBlocks('See ![icon](http://x.com/icon.png) here')
+    expect(blocks).toHaveLength(1)
+    const p = blocks[0] as Extract<ChatBlock, { t: 'p' }>
+    expect(p.html).toContain('<img')
+    expect(p.html).toContain('icon')
+  })
+
+  it('parses top-level SVG html into svg blocks', () => {
+    const blocks = parseMarkdownToBlocks('<svg viewBox="0 0 10 10"><circle cx="5" cy="5" r="5"/></svg>')
+    expect(blocks).toHaveLength(1)
+    const svg = blocks[0] as Extract<ChatBlock, { t: 'svg' }>
+    expect(svg.t).toBe('svg')
+    expect(svg.svg).toContain('<svg')
+  })
+
+  it('ignores horizontal rules', () => {
+    const blocks = parseMarkdownToBlocks('before\n\n---\n\nafter')
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0]).toMatchObject({ t: 'p' })
+    expect(blocks[1]).toMatchObject({ t: 'p' })
+  })
+
+  it('does not throw on malformed input so callers can fall back', () => {
+    // Passing an extremely malformed string should not throw.
+    expect(() => parseMarkdownToBlocks('\0')).not.toThrow()
+    expect(Array.isArray(parseMarkdownToBlocks('\0'))).toBe(true)
+  })
+
+  it('preserves HTML escaping in inline code', () => {
+    const blocks = parseMarkdownToBlocks('Use `<script>`')
+    const p = blocks[0] as Extract<ChatBlock, { t: 'p' }>
+    expect(p.html).toContain('<code>')
+    expect(p.html).not.toContain('<script>')
+  })
+})

--- a/dashboard/src/components/chat/markdown-blocks.ts
+++ b/dashboard/src/components/chat/markdown-blocks.ts
@@ -1,0 +1,152 @@
+import { marked, type Token, type Tokens } from 'marked'
+import DOMPurify from 'dompurify'
+import type { ChatBlock, ChatCalloutSeverity, ChatTableCellValue } from '../../types'
+
+function escapeHtml(raw: string): string {
+  return raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/** Linkify plain URLs without touching existing HTML tags. */
+function linkifyHtml(raw: string): string {
+  if (!raw || raw.indexOf('http') === -1) return raw
+  const linkRe = /(^|[\s(>])(https?:\/\/[^\s<)]+[^\s<).,!?:;])/g
+  return raw
+    .split(/(<[^>]+>)/g)
+    .map((part, i) =>
+      i % 2 === 1
+        ? part
+        : part.replace(linkRe, '$1<a class="inline-link" href="$2" target="_blank" rel="noopener noreferrer">$2</a>'),
+    )
+    .join('')
+}
+
+function sanitizeHtml(raw: string): string {
+  return DOMPurify.sanitize(raw)
+}
+
+function inlineHtml(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+  const parsed = marked.parseInline(trimmed) as string
+  return sanitizeHtml(linkifyHtml(parsed))
+}
+
+function cellValue(raw: string): ChatTableCellValue {
+  const text = inlineHtml(raw)
+  const plain = text.replace(/<[^>]+>/g, '').trim()
+  const num = /^-?\d+(\.\d+)?%?$/.test(plain)
+  const muted = plain === '' || /^(n\/a|n\.a\.|—|-)$/i.test(plain)
+  return num || muted ? { v: text, num, muted } : text
+}
+
+const CALLOUT_TAG_RE = /\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION|DANGER|WARN|ERROR)\]\s*/i
+
+function detectCalloutSeverity(html: string): ChatCalloutSeverity {
+  const match = html.match(CALLOUT_TAG_RE)
+  if (!match) return 'info'
+  const kind = (match[1] ?? '').toUpperCase()
+  if (['NOTE', 'TIP', 'IMPORTANT'].includes(kind)) return 'info'
+  if (['WARNING', 'WARN'].includes(kind)) return 'warn'
+  return 'bad'
+}
+
+function parseBlockquote(token: Tokens.Blockquote): ChatBlock {
+  const inner = marked.parser(token.tokens).trim()
+  const severity = detectCalloutSeverity(inner)
+  const body = inner
+    .replace(CALLOUT_TAG_RE, '')
+    .replace(/^<blockquote>\s*/i, '')
+    .replace(/<\/blockquote>\s*$/i, '')
+    .trim()
+  return { t: 'callout', severity, html: sanitizeHtml(linkifyHtml(body)) }
+}
+
+function parseList(token: Tokens.List): ChatBlock {
+  const items = token.items.map((item) => sanitizeHtml(linkifyHtml(marked.parseInline(item.text) as string)))
+  return { t: 'ul', items }
+}
+
+function parseParagraph(token: Tokens.Paragraph): ChatBlock | null {
+  if (token.tokens.length === 1 && token.tokens[0]?.type === 'image') {
+    const img = token.tokens[0] as Tokens.Image
+    return { t: 'image', src: img.href, cap: img.text || img.title || undefined }
+  }
+  const trimmed = token.text.trim()
+  if (/^<svg\b[\s\S]*<\/svg>$/i.test(trimmed)) {
+    return { t: 'svg', svg: trimmed, cap: undefined }
+  }
+  const html = inlineHtml(token.text).trim()
+  return html ? { t: 'p', html } : null
+}
+
+function parseCode(token: Tokens.Code): ChatBlock {
+  const lang = token.lang?.trim().toLowerCase() || undefined
+  if (lang?.startsWith('mermaid')) {
+    return { t: 'mermaid', source: token.text }
+  }
+  return { t: 'code', cap: lang, html: escapeHtml(token.text) }
+}
+
+function parseHeading(token: Tokens.Heading): ChatBlock {
+  return { t: 'h4', html: inlineHtml(token.text) }
+}
+
+function parseTable(token: Tokens.Table): ChatBlock {
+  return {
+    t: 'table',
+    head: token.header.map((cell) => cellValue(cell.text)),
+    rows: token.rows.map((row) => row.map((cell) => cellValue(cell.text))),
+  }
+}
+
+function parseHtml(token: Tokens.HTML): ChatBlock | null {
+  const trimmed = token.text.trim()
+  if (/^<svg\b[\s\S]*<\/svg>$/i.test(trimmed)) {
+    return { t: 'svg', svg: trimmed, cap: undefined }
+  }
+  // Treat other top-level HTML as a paragraph after sanitization.
+  const html = sanitizeHtml(linkifyHtml(trimmed)).trim()
+  return html ? { t: 'p', html } : null
+}
+
+function tokenToBlock(token: Token): ChatBlock | ChatBlock[] | null {
+  switch (token.type) {
+    case 'paragraph':
+      return parseParagraph(token as Tokens.Paragraph)
+    case 'code':
+      return parseCode(token as Tokens.Code)
+    case 'heading':
+      return parseHeading(token as Tokens.Heading)
+    case 'list':
+      return parseList(token as Tokens.List)
+    case 'blockquote':
+      return parseBlockquote(token as Tokens.Blockquote)
+    case 'table':
+      return parseTable(token as Tokens.Table)
+    case 'html':
+      return parseHtml(token as Tokens.HTML)
+    case 'hr':
+    case 'space':
+      return null
+    default:
+      return null
+  }
+}
+
+/** Convert assistant/system markdown text into the dashboard's ChatBlock[] format. */
+export function parseMarkdownToBlocks(markdown: string): ChatBlock[] {
+  if (!markdown || !markdown.trim()) return []
+  try {
+    const tokens = marked.lexer(markdown)
+    const blocks: ChatBlock[] = []
+    for (const token of tokens) {
+      const block = tokenToBlock(token)
+      if (!block) continue
+      if (Array.isArray(block)) blocks.push(...block)
+      else blocks.push(block)
+    }
+    return blocks
+  } catch {
+    return []
+  }
+}

--- a/dashboard/src/components/chat/media-artifact-ux.test.ts
+++ b/dashboard/src/components/chat/media-artifact-ux.test.ts
@@ -1,0 +1,209 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ChatBlock, KeeperConversationAttachment, KeeperConversationEntry } from '../../types'
+import { ChatTranscript } from './primitives'
+
+const flushUi = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 30))
+
+function entry(
+  overrides: Partial<KeeperConversationEntry> & Pick<KeeperConversationEntry, 'id' | 'text'>,
+): KeeperConversationEntry {
+  return {
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    rawText: overrides.rawText ?? overrides.text,
+    timestamp: '2026-03-24T00:00:00.000Z',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+    ...overrides,
+  }
+}
+
+function renderBlocks(blocks: ChatBlock[]) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  render(
+    html`<${ChatTranscript}
+      entries=${[entry({ id: 'b1', text: '', blocks })]}
+      emptyText="empty"
+    />`,
+    container,
+  )
+  return container
+}
+
+describe('media and artifact UX', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('opens an artifact preview modal and closes it', async () => {
+    const container = renderBlocks([
+      {
+        t: 'artifact',
+        kind: 'md',
+        name: 'note.md',
+        data: 'data:text/markdown;base64,SGVsbG8gV29ybGQ=',
+        mimeType: 'text/markdown',
+      },
+    ])
+
+    const artifact = container.querySelector('[data-chat-block="artifact"]')
+    expect(artifact).not.toBeNull()
+
+    const [openBtn, downloadBtn] = artifact!.querySelectorAll('button')
+    expect(openBtn!.hasAttribute('disabled')).toBe(false)
+    expect(downloadBtn!.hasAttribute('disabled')).toBe(false)
+
+    ;(openBtn as HTMLElement).click()
+    await flushUi()
+
+    const modal = document.querySelector('[role="dialog"]')
+    expect(modal).not.toBeNull()
+    expect(modal!.textContent).toContain('note.md')
+
+    const closeBtn = modal!.querySelector('button[aria-label="닫기"]')
+    ;(closeBtn as HTMLElement).click()
+    await flushUi()
+
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('disables open/download when artifact has no data', () => {
+    const container = renderBlocks([{ t: 'artifact', kind: 'json', name: 'report.json' }])
+
+    const artifact = container.querySelector('[data-chat-block="artifact"]')
+    const [openBtn, downloadBtn] = artifact!.querySelectorAll('button')
+    expect(openBtn!.hasAttribute('disabled')).toBe(true)
+    expect(downloadBtn!.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('downloads artifact data via a temporary anchor', async () => {
+    const createEl = document.createElement
+    const clickSpy = vi.fn()
+    document.createElement = vi.fn((tag: string) => {
+      const el = createEl.call(document, tag as keyof HTMLElementTagNameMap)
+      if (tag === 'a') {
+        ;(el as HTMLAnchorElement).click = clickSpy
+      }
+      return el
+    }) as typeof document.createElement
+
+    const container = renderBlocks([
+      {
+        t: 'artifact',
+        kind: 'json',
+        name: 'report.json',
+        data: '{"ok":true}',
+        mimeType: 'application/json',
+      },
+    ])
+
+    const artifact = container.querySelector('[data-chat-block="artifact"]')
+    const downloadBtn = artifact!.querySelector('button[aria-label="다운로드"]')
+    ;(downloadBtn as HTMLElement).click()
+    await flushUi()
+
+    expect(clickSpy).toHaveBeenCalled()
+    document.createElement = createEl
+  })
+
+  it('opens a lightbox when clicking an image block', async () => {
+    const container = renderBlocks([{ t: 'image', src: '/img/screen.png', cap: '실행 화면' }])
+
+    const frame = container.querySelector('[data-chat-block="image"] .chat-block-media-frame')
+    ;(frame as HTMLElement).click()
+    await flushUi()
+
+    const modal = document.querySelector('[role="dialog"]')
+    expect(modal).not.toBeNull()
+    expect(modal!.querySelector('img')?.getAttribute('src')).toBe('/img/screen.png')
+
+    ;(modal!.querySelector('button[aria-label="닫기"]') as HTMLElement).click()
+    await flushUi()
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('opens a lightbox when clicking an svg block', async () => {
+    const container = renderBlocks([
+      { t: 'svg', svg: '<svg viewBox="0 0 10 10"><circle cx="5" cy="5" r="5"/></svg>', cap: 'diagram' },
+    ])
+
+    ;(container.querySelector('[data-chat-block="svg"] .chat-block-media-frame') as HTMLElement).click()
+    await flushUi()
+
+    const modal = document.querySelector('[role="dialog"]')
+    expect(modal).not.toBeNull()
+    expect(modal!.querySelector('svg')).not.toBeNull()
+
+    ;(modal!.querySelector('button[aria-label="닫기"]') as HTMLElement).click()
+    await flushUi()
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('opens a lightbox when clicking an image attachment', async () => {
+    const attachment: KeeperConversationAttachment = {
+      id: 'att-1',
+      type: 'image',
+      name: 'screenshot.png',
+      size: 1024,
+      mimeType: 'image/png',
+      data: 'data:image/png;base64,abc123',
+    }
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    render(
+      html`<${ChatTranscript}
+        entries=${[entry({ id: 'u1', text: '첨부 확인', attachments: [attachment] })]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+
+    const card = container.querySelector('[data-chat-attachment-card="att-1"]')
+    ;(card!.querySelector('button') as HTMLElement).click()
+    await flushUi()
+
+    const modal = document.querySelector('[role="dialog"]')
+    expect(modal).not.toBeNull()
+    expect(modal!.textContent).toContain('screenshot.png')
+
+    ;(modal!.querySelector('button[aria-label="닫기"]') as HTMLElement).click()
+    await flushUi()
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('renders the audio player with desktop-style chrome and duration', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'a1',
+            text: 'hello',
+            audio: {
+              token: 'clip-1',
+              audioUrl: '/api/v1/voice/audio/clip-1',
+              mime: 'audio/mpeg',
+              durationSec: 5,
+              messageText: 'hello',
+            },
+          }),
+        ]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+
+    const player = container.querySelector('[data-chat-audio-clip]')
+    expect(player).not.toBeNull()
+    expect(player!.classList.contains('chat-audio-clip')).toBe(true)
+    expect(player!.querySelector('audio')).not.toBeNull()
+    expect(player!.textContent).toContain('0:05')
+  })
+})

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3,16 +3,17 @@ import type { ComponentChildren, VNode } from 'preact'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { JsonViewerCard } from '../common/json-viewer'
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { ringFocusClasses } from '../common/ring'
 import { collectAttachments } from './attachments'
+import { parseMarkdownToBlocks } from './markdown-blocks'
 import { showToast } from '../common/toast'
 
 const CHAT_FOCUS_RING = ringFocusClasses({ tone: 'accent-medium', width: 2 })
 import { formatTimeHms } from '../../lib/format-time'
 import { formatCost } from '../../lib/format-number'
 import { isSubmitEnter } from '../../lib/keyboard'
-import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatLinkBlock, ChatShellBlock, ChatTableBlock, ChatTraceStep, ChatVoiceBlock } from '../../types'
+import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatLinkBlock, ChatMermaidBlock, ChatShellBlock, ChatTableBlock, ChatTraceStep, ChatVoiceBlock } from '../../types'
 import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, SurfaceRef } from '../../types'
 import type { ToolCallOutputBlob } from '../../api/dashboard'
 import { lookupToolCallOutput } from '../../tool-call-output-store'
@@ -259,6 +260,119 @@ function attachmentMeta(attachment: KeeperConversationAttachment): string {
   return [attachment.mimeType, formatAttachmentSize(attachment.size)].filter(Boolean).join(' · ')
 }
 
+function dataUriToText(data: string): string | null {
+  const comma = data.indexOf(',')
+  if (comma === -1 || !data.startsWith('data:')) return null
+  const header = data.slice(0, comma)
+  const body = data.slice(comma + 1)
+  if (header.includes(';base64')) {
+    try {
+      return atob(body)
+    } catch {
+      return null
+    }
+  }
+  try {
+    return decodeURIComponent(body)
+  } catch {
+    return null
+  }
+}
+
+function downloadArtifact(data: string, filename: string, mimeType?: string): void {
+  const href = data.startsWith('data:')
+    ? data
+    : URL.createObjectURL(new Blob([data], { type: mimeType ?? 'application/octet-stream' }))
+  const a = document.createElement('a')
+  a.href = href
+  a.download = filename
+  a.style.display = 'none'
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  if (!data.startsWith('data:')) {
+    setTimeout(() => URL.revokeObjectURL(href), 1000)
+  }
+}
+
+function artifactPreviewType(kind?: string, data?: string, mimeType?: string): 'image' | 'svg' | 'md' | 'code' | 'unknown' {
+  const k = (kind ?? '').toLowerCase()
+  const mt = (mimeType ?? '').toLowerCase()
+  if (k === 'image' || mt.startsWith('image/') || data?.startsWith('data:image/')) return 'image'
+  if (k === 'svg' || mt === 'image/svg+xml' || data?.startsWith('data:image/svg')) return 'svg'
+  if (k === 'md' || k === 'markdown' || mt.includes('markdown')) return 'md'
+  if (
+    k === 'code'
+    || k === 'json'
+    || mt.startsWith('text/')
+    || mt === 'application/json'
+    || data?.startsWith('data:text/')
+    || data?.startsWith('data:application/json')
+  ) {
+    return 'code'
+  }
+  return 'unknown'
+}
+
+function isPreviewableArtifact(kind?: string, data?: string, mimeType?: string): boolean {
+  return !!data && artifactPreviewType(kind, data, mimeType) !== 'unknown'
+}
+
+function ChatArtifactPreview({
+  kind,
+  name,
+  data,
+  mimeType,
+  onClose,
+}: {
+  kind?: string
+  name: string
+  data: string
+  mimeType?: string
+  onClose: () => void
+}) {
+  const type = artifactPreviewType(kind, data, mimeType)
+  if (type === 'image') {
+    return html`
+      <${ChatPreviewModal} title=${name} onClose=${onClose}>
+        <img
+          src=${data}
+          alt=${name}
+          class="max-h-[80vh] max-w-full rounded-[var(--r-1)] object-contain"
+        />
+      <//>
+    `
+  }
+  if (type === 'svg') {
+    return html`
+      <${ChatPreviewModal} title=${name} onClose=${onClose}>
+        <div
+          class="chat-lightbox-svg"
+          dangerouslySetInnerHTML=${{ __html: sanitizeHtml(data) }}
+        />
+      <//>
+    `
+  }
+  const text = dataUriToText(data) ?? data
+  if (type === 'md') {
+    return html`
+      <${ChatPreviewModal} title=${name} onClose=${onClose}>
+        <div
+          class="chat-lightbox-md markdown-body"
+          dangerouslySetInnerHTML=${{
+            __html: DOMPurify.sanitize(marked.parse(text) as string),
+          }}
+        />
+      <//>
+    `
+  }
+  return html`
+    <${ChatPreviewModal} title=${name} onClose=${onClose}>
+      <pre class="chat-lightbox-code"><code>${escapeHtml(text)}</code></pre>
+    <//>
+  `
+}
+
 // --- Keeper v2 rich block helpers -------------------------------------------------
 
 function linkifyHtml(raw: string): string {
@@ -334,7 +448,7 @@ function ChatTableBlock({ head, rows }: ChatTableBlock) {
         <tr>
           ${head.map((h, i) => {
             const c = cell(h)
-            return html`<th key=${i} class=${c.num ? 'chat-block-cell-num' : ''}>${c.v}</th>`
+            return html`<th key=${i} class=${c.num ? 'chat-block-cell-num' : ''} dangerouslySetInnerHTML=${renderInlineHtml(String(c.v))} />`
           })}
         </tr>
       </thead>
@@ -343,7 +457,7 @@ function ChatTableBlock({ head, rows }: ChatTableBlock) {
           <tr key=${ri}>
             ${row.map((c0, ci) => {
               const c = cell(c0)
-              return html`<td key=${ci} class="${c.num ? 'chat-block-cell-num' : ''} ${c.muted ? 'chat-block-cell-muted' : ''}">${c.v}</td>`
+              return html`<td key=${ci} class="${c.num ? 'chat-block-cell-num' : ''} ${c.muted ? 'chat-block-cell-muted' : ''}" dangerouslySetInnerHTML=${renderInlineHtml(String(c.v))} />`
             })}
           </tr>
         `)}
@@ -352,11 +466,114 @@ function ChatTableBlock({ head, rows }: ChatTableBlock) {
   `
 }
 
-function ChatCodeBlock({ cap, html: htmlContent }: { cap?: string; html: string }) {
+function ChatPreviewModal({
+  title,
+  onClose,
+  children,
+}: {
+  title: string
+  onClose: () => void
+  children: ComponentChildren
+}) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onClose])
+
   return html`
-    <div class="chat-block-code" data-chat-block="code">
-      ${cap ? html`<div class="chat-block-code-cap">${cap}</div>` : null}
-      <pre class="m-0 overflow-x-auto p-3 text-2xs leading-relaxed"><code dangerouslySetInnerHTML=${{ __html: sanitizeHtml(htmlContent) }} /></pre>
+    <div
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+      onClick=${onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label=${title}
+    >
+      <div
+        class="relative max-h-[90vh] max-w-[90vw] overflow-auto rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 shadow-[var(--shadow-raised)]"
+        onClick=${(e: Event) => e.stopPropagation()}
+      >
+        <div class="mb-3 flex items-center justify-between gap-4">
+          <span class="truncate text-sm font-semibold text-[var(--color-fg-primary)]">${title}</span>
+          <button
+            type="button"
+            class="rounded-[var(--r-0)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]"
+            onClick=${onClose}
+            aria-label="닫기"
+          >
+            ✕
+          </button>
+        </div>
+        <div class="chat-preview-modal-body">${children}</div>
+      </div>
+    </div>
+  `
+}
+
+function codeBlockText(htmlContent: string, source?: string): string {
+  if (source !== undefined) return source
+  if (typeof document !== 'undefined') {
+    const el = document.createElement('div')
+    el.innerHTML = htmlContent
+    return el.textContent ?? htmlContent
+  }
+  return htmlContent
+}
+
+async function copyCodeToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text)
+    showToast('코드를 복사했습니다', 'success')
+  } catch {
+    showToast('복사하지 못했습니다', 'error')
+  }
+}
+
+function ChatCodeBlock({ cap, html: htmlContent, source }: { cap?: string; html: string; source?: string }) {
+  const [highlighted, setHighlighted] = useState<string | null>(null)
+  const [failed, setFailed] = useState(false)
+  const codeId = useId()
+
+  useEffect(() => {
+    let cancelled = false
+    const run = async () => {
+      try {
+        const shiki = await import('shiki')
+        const text = codeBlockText(htmlContent, source)
+        const next = await shiki.codeToHtml(text, {
+          lang: cap && cap.trim() ? cap.trim() : 'text',
+          theme: 'github-dark',
+        })
+        if (!cancelled) setHighlighted(next)
+      } catch {
+        if (!cancelled) setFailed(true)
+      }
+    }
+    void run()
+    return () => { cancelled = true }
+  }, [htmlContent, cap, source])
+
+  const plain = codeBlockText(htmlContent, source)
+
+  return html`
+    <div class="chat-block-code ${failed ? 'chat-block-code-fallback' : ''}" data-chat-block="code">
+      <div class="chat-block-code-hd">
+        ${cap ? html`<span class="chat-block-code-cap">${cap}</span>` : html`<span class="chat-block-code-cap" />`}
+        <button
+          type="button"
+          class="chat-block-code-copy"
+          aria-label="코드 복사"
+          title="복사"
+          onClick=${() => { void copyCodeToClipboard(plain) }}
+        >
+          복사
+        </button>
+      </div>
+      ${highlighted
+        ? html`<div class="m-0 overflow-x-auto p-0 text-2xs leading-relaxed" id=${codeId} dangerouslySetInnerHTML=${{ __html: highlighted }} />`
+        : html`<pre class="m-0 overflow-x-auto p-3 text-2xs leading-relaxed" id=${codeId}><code dangerouslySetInnerHTML=${{ __html: htmlContent }} /></pre>`}
     </div>
   `
 }
@@ -385,8 +602,30 @@ function ChatShellBlock({ title, lines, exit, dur }: ChatShellBlock) {
   `
 }
 
-function ChatArtifactBlock({ kind, name, size, note }: { kind?: string; name: string; size?: string; note?: string }) {
+function ChatArtifactBlock({
+  kind,
+  name,
+  size,
+  note,
+  data,
+  mimeType,
+}: {
+  kind?: string
+  name: string
+  size?: string
+  note?: string
+  data?: string
+  mimeType?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const hasData = !!data
+  const previewable = isPreviewableArtifact(kind, data, mimeType)
   const icon = kind === 'md' ? '⌹' : kind === 'svg' ? '◫' : kind === 'json' ? '{ }' : '⎙'
+
+  const handleDownload = () => {
+    if (data) downloadArtifact(data, name, mimeType)
+  }
+
   return html`
     <div class="chat-block-artifact" data-chat-block="artifact">
       <span class="chat-block-artifact-icon">${icon}</span>
@@ -396,8 +635,35 @@ function ChatArtifactBlock({ kind, name, size, note }: { kind?: string; name: st
           ${(kind || 'file').toUpperCase()}${size ? ` · ${size}` : ''}${note ? ` · ${note}` : ''}
         </div>
       </div>
-      <button type="button" class="chat-block-artifact-btn" aria-label="열기">열기</button>
-      <button type="button" class="chat-block-artifact-btn" aria-label="다운로드">다운로드</button>
+      <button
+        type="button"
+        class="chat-block-artifact-btn"
+        disabled=${!previewable}
+        onClick=${() => previewable && setOpen(true)}
+        aria-label="열기"
+      >
+        열기
+      </button>
+      <button
+        type="button"
+        class="chat-block-artifact-btn"
+        disabled=${!hasData}
+        onClick=${handleDownload}
+        aria-label="다운로드"
+      >
+        다운로드
+      </button>
+      ${open && previewable
+        ? html`
+            <${ChatArtifactPreview}
+              kind=${kind}
+              name=${name}
+              data=${data}
+              mimeType=${mimeType}
+              onClose=${() => setOpen(false)}
+            />
+          `
+        : null}
     </div>
   `
 }
@@ -493,23 +759,88 @@ function ChatVoiceBlock(b: ChatVoiceBlock) {
 }
 
 function ChatImageBlock({ src, ph, cap }: { src?: string; ph?: string; cap?: string }) {
+  const [open, setOpen] = useState(false)
   return html`
     <figure class="chat-block-media" data-chat-block="image">
-      <div class="chat-block-media-frame">
+      <div class="chat-block-media-frame ${src ? 'cursor-zoom-in' : ''}" onClick=${() => src && setOpen(true)}>
         ${src
           ? html`<img src=${src} alt=${cap || ''} class="max-h-52 w-full rounded-[var(--r-1)] object-contain" />`
           : html`<div class="chat-block-media-ph">${ph || '실행 화면'}</div>`}
       </div>
       ${cap ? html`<figcaption class="chat-block-media-cap">${cap}</figcaption>` : null}
+      ${open && src
+        ? html`
+            <${ChatPreviewModal} title=${cap || '이미지'} onClose=${() => setOpen(false)}>
+              <img
+                src=${src}
+                alt=${cap || ''}
+                class="max-h-[80vh] max-w-full rounded-[var(--r-1)] object-contain"
+              />
+            <//>
+          `
+        : null}
     </figure>
   `
 }
 
 function ChatSvgBlock({ svg, cap }: { svg: string; cap?: string }) {
+  const [open, setOpen] = useState(false)
+  const clean = useMemo(() => sanitizeHtml(svg), [svg])
   return html`
     <figure class="chat-block-media" data-chat-block="svg">
-      <div class="chat-block-media-frame" dangerouslySetInnerHTML=${{ __html: sanitizeHtml(svg) }} />
+      <div
+        class="chat-block-media-frame cursor-zoom-in"
+        onClick=${() => setOpen(true)}
+        dangerouslySetInnerHTML=${{ __html: clean }}
+      />
       ${cap ? html`<figcaption class="chat-block-media-cap">${cap}</figcaption>` : null}
+      ${open
+        ? html`
+            <${ChatPreviewModal} title=${cap || 'SVG'} onClose=${() => setOpen(false)}>
+              <div class="chat-preview-modal-body-svg" dangerouslySetInnerHTML=${{ __html: clean }} />
+            <//>
+          `
+        : null}
+    </figure>
+  `
+}
+
+function ChatMermaidBlock({ source, caption }: ChatMermaidBlock) {
+  const id = useId()
+  const [svg, setSvg] = useState<string | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    const run = async () => {
+      try {
+        const mod = await import('mermaid')
+        const mermaid = mod.default
+        if (typeof mermaid.initialize === 'function') {
+          mermaid.initialize({ startOnLoad: false, securityLevel: 'strict', theme: 'dark' })
+        }
+        const { svg: rendered } = await mermaid.render(`mermaid-${id}`, source)
+        if (active) setSvg(rendered)
+      } catch {
+        if (active) setError(true)
+      }
+    }
+    void run()
+    return () => { active = false }
+  }, [source, id])
+
+  if (error) {
+    return html`<${ChatCodeBlock} cap="mermaid" html=${escapeHtml(source)} source=${source} />`
+  }
+
+  return html`
+    <figure class="chat-block-media" data-chat-block="mermaid">
+      <div class="chat-block-mermaid">
+        ${svg
+          ? html`<div dangerouslySetInnerHTML=${{ __html: sanitizeHtml(svg) }} />`
+          : html`<div class="chat-block-media-ph">다이어그램 렌더링 중…</div>`}
+      </div>
+      ${caption ? html`<figcaption class="chat-block-media-cap">${caption}</figcaption>` : null}
     </figure>
   `
 }
@@ -679,13 +1010,14 @@ function ChatBlock({ block }: { block: ChatBlock }) {
     case 'ul': return html`<${ChatListBlock} items=${block.items} />`
     case 'callout': return html`<${ChatCalloutBlock} severity=${block.severity} html=${block.html} />`
     case 'table': return html`<${ChatTableBlock} head=${block.head} rows=${block.rows} />`
-    case 'code': return html`<${ChatCodeBlock} cap=${block.cap} html=${block.html} />`
+    case 'code': return html`<${ChatCodeBlock} cap=${block.cap} html=${block.html} source=${block.source} />`
     case 'shell': return html`<${ChatShellBlock} title=${block.title} lines=${block.lines} exit=${block.exit} dur=${block.dur} />`
-    case 'artifact': return html`<${ChatArtifactBlock} kind=${block.kind} name=${block.name} size=${block.size} note=${block.note} />`
+    case 'artifact': return html`<${ChatArtifactBlock} kind=${block.kind} name=${block.name} size=${block.size} note=${block.note} data=${block.data} mimeType=${block.mimeType} />`
     case 'attach': return html`<${ChatAttachBlock} name=${block.name} dims=${block.dims} src=${block.src} svg=${block.svg} ph=${block.ph} via=${block.via} size=${block.size} />`
     case 'voice': return html`<${ChatVoiceBlock} secs=${block.secs} wave=${block.wave} via=${block.via} size=${block.size} transcript=${block.transcript} />`
     case 'image': return html`<${ChatImageBlock} src=${block.src} ph=${block.ph} cap=${block.cap} />`
     case 'svg': return html`<${ChatSvgBlock} svg=${block.svg} cap=${block.cap} />`
+    case 'mermaid': return html`<${ChatMermaidBlock} source=${block.source} caption=${block.caption} />`
     case 'trace': return html`<${ChatTraceBlock} trace=${block.trace} />`
     case 'link': return html`<${ChatLinkBlock} url=${block.url} title=${block.title} desc=${block.desc} meta=${block.meta} fav=${block.fav} kind=${block.kind} />`
     case 'broadcast': return html`<${ChatBroadcastBlock} scope=${block.scope} via=${block.via} note=${block.note} recipients=${block.recipients} />`
@@ -717,50 +1049,90 @@ function LiveMessagePlaceholder({ label }: { label: string }) {
   `
 }
 
-function renderAttachmentCard(attachment: KeeperConversationAttachment) {
-  const canLink = isSafeAttachmentHref(attachment)
+function AttachmentCard({ attachment }: { attachment: KeeperConversationAttachment }) {
+  const [open, setOpen] = useState(false)
+  const canDownload = isSafeAttachmentHref(attachment)
   const meta = attachmentMeta(attachment)
-  const content = isRenderableImageAttachment(attachment)
-    ? html`
-        <img
-          src=${attachment.data}
-          alt=${attachment.name}
-          class="max-h-52 w-full rounded-[var(--r-1)] object-contain"
-          loading="lazy"
-        />
-      `
-    : html`
-        <div class="flex min-h-18 items-center gap-3 px-3 py-3">
-          <span class="inline-flex h-9 w-11 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] text-2xs font-bold uppercase tracking-2 text-[var(--color-fg-secondary)]">
-            FILE
-          </span>
-          <div class="min-w-0">
-            <div class="truncate text-sm font-bold text-[var(--color-fg-primary)]">${attachment.name}</div>
-            <div class="mt-1 text-xs text-[var(--color-fg-secondary)]">${meta}</div>
-          </div>
-        </div>
-      `
+  const isImage = isRenderableImageAttachment(attachment)
 
   return html`
-    <div class="overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
-      ${canLink
+    <div
+      class="overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
+      data-chat-attachment-card=${attachment.id}
+    >
+      ${isImage
         ? html`
-            <a
-              href=${attachment.data}
-              download=${attachment.name}
-              class="block hover:bg-[var(--color-bg-hover)]"
-              aria-label=${`${attachment.name} 내려받기`}
+            <button
+              type="button"
+              class="block w-full text-left hover:bg-[var(--color-bg-hover)]"
+              onClick=${() => setOpen(true)}
+              aria-label=${`${attachment.name} 미리보기`}
             >
-              ${content}
-            </a>
+              <img
+                src=${attachment.data}
+                alt=${attachment.name}
+                class="max-h-52 w-full rounded-[var(--r-1)] object-contain"
+                loading="lazy"
+              />
+            </button>
           `
-        : content}
-      ${isRenderableImageAttachment(attachment)
+        : canDownload
+          ? html`
+              <a
+                href=${attachment.data}
+                download=${attachment.name}
+                class="block hover:bg-[var(--color-bg-hover)]"
+                aria-label=${`${attachment.name} 날려받기`}
+              >
+                <div class="flex min-h-18 items-center gap-3 px-3 py-3">
+                  <span class="inline-flex h-9 w-11 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] text-2xs font-bold uppercase tracking-2 text-[var(--color-fg-secondary)]">
+                    FILE
+                  </span>
+                  <div class="min-w-0">
+                    <div class="truncate text-sm font-bold text-[var(--color-fg-primary)]">${attachment.name}</div>
+                    <div class="mt-1 text-xs text-[var(--color-fg-secondary)]">${meta}</div>
+                  </div>
+                </div>
+              </a>
+            `
+          : html`
+              <div class="flex min-h-18 items-center gap-3 px-3 py-3">
+                <span class="inline-flex h-9 w-11 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] text-2xs font-bold uppercase tracking-2 text-[var(--color-fg-secondary)]">
+                  FILE
+                </span>
+                <div class="min-w-0">
+                  <div class="truncate text-sm font-bold text-[var(--color-fg-primary)]">${attachment.name}</div>
+                  <div class="mt-1 text-xs text-[var(--color-fg-secondary)]">${meta}</div>
+                </div>
+              </div>
+            `}
+      <div class="flex items-center justify-between gap-2 border-t border-[var(--color-border-default)] px-3 py-2">
+        <div class="min-w-0">
+          <div class="truncate text-sm font-bold text-[var(--color-fg-primary)]">${attachment.name}</div>
+          <div class="mt-1 text-xs text-[var(--color-fg-secondary)]">${meta}</div>
+        </div>
+        ${canDownload
+          ? html`
+              <a
+                href=${attachment.data}
+                download=${attachment.name}
+                class="chat-block-artifact-btn shrink-0"
+                aria-label=${`${attachment.name} 날려받기`}
+              >
+                ↓
+              </a>
+            `
+          : null}
+      </div>
+      ${open && isImage
         ? html`
-            <div class="border-t border-[var(--color-border-default)] px-3 py-2">
-              <div class="truncate text-sm font-bold text-[var(--color-fg-primary)]">${attachment.name}</div>
-              <div class="mt-1 text-xs text-[var(--color-fg-secondary)]">${meta}</div>
-            </div>
+            <${ChatPreviewModal} title=${attachment.name} onClose=${() => setOpen(false)}>
+              <img
+                src=${attachment.data}
+                alt=${attachment.name}
+                class="max-h-[80vh] max-w-full rounded-[var(--r-1)] object-contain"
+              />
+            <//>
           `
         : null}
     </div>
@@ -780,22 +1152,27 @@ function formatAudioDuration(seconds?: number | null): string {
 function AudioPlayer({ clip }: { clip: KeeperConversationAudioClip }) {
   const duration = formatAudioDuration(clip.durationSec)
   return html`
-    <div
-      class="flex items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1.5"
-      data-chat-audio-clip
-    >
+    <div class="chat-audio-clip" data-chat-audio-clip>
+      <div class="chat-audio-wave" aria-hidden="true">
+        ${Array.from({ length: 24 }, (_, i) => html`
+          <span
+            key=${i}
+            class="chat-audio-bar"
+            style=${{ height: `${6 + (i % 7) * 3}px` }}
+          />
+        `)}
+      </div>
       <audio
         controls
         preload="none"
         src=${clip.audioUrl ?? `/api/v1/voice/audio/${encodeURIComponent(clip.token)}`}
-        class="h-8 max-w-[16rem]"
         aria-label=${clip.messageText || '음성 메시지'}
       />
       ${duration
-        ? html`<span class="text-xs tabular-nums text-[var(--color-fg-secondary)]">${duration}</span>`
+        ? html`<span class="chat-audio-dur">${duration}</span>`
         : null}
       ${clip.deviceId
-        ? html`<span class="text-xs text-[var(--color-fg-secondary)]" title=${`device: ${clip.deviceId}`}>🔊</span>`
+        ? html`<span class="chat-audio-device" title=${`device: ${clip.deviceId}`}>🔊</span>`
         : null}
     </div>
   `
@@ -819,8 +1196,15 @@ function ChatMessageBubble({
   const liveLabel = liveMessageLabel(entry)
   const messageText = liveLabel ? '' : entry.text || '(empty reply)'
   const messageLength = messageText.length
+  const parsedBlocks = useMemo(() => {
+    if (hasBlocks) return null
+    if (entry.role !== 'assistant' && entry.role !== 'system') return null
+    return parseMarkdownToBlocks(messageText)
+  }, [hasBlocks, entry.role, messageText])
+  const effectiveBlocks = entry.blocks && entry.blocks.length > 0 ? entry.blocks : (parsedBlocks ?? [])
+  const hasEffectiveBlocks = effectiveBlocks.length > 0
   const collapseThreshold = 1200
-  const isCollapsible = !hasBlocks && messageLength > collapseThreshold
+  const isCollapsible = !hasEffectiveBlocks && messageLength > collapseThreshold
   const tone = bubbleTone(entry)
   const isMessenger = variant === 'messenger'
   const detailItems = detailSummary(entry.details)
@@ -980,8 +1364,8 @@ function ChatMessageBubble({
       ${liveLabel
         ? html`<${LiveMessagePlaceholder} label=${liveLabel} />`
         : html`
-            ${hasBlocks
-              ? html`<${ChatBlocks} blocks=${entry.blocks!} />`
+            ${hasEffectiveBlocks
+              ? html`<${ChatBlocks} blocks=${effectiveBlocks} />`
               : html`
                   <div
                     class=${`markdown-body whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)] ${isCollapsible && messageCollapsed ? 'max-h-96 overflow-hidden' : ''}`}
@@ -1011,7 +1395,7 @@ function ChatMessageBubble({
       ${attachments.length > 0
         ? html`
             <div class="grid grid-cols-[repeat(auto-fit,minmax(11rem,1fr))] gap-2">
-              ${attachments.map(attachment => renderAttachmentCard(attachment))}
+              ${attachments.map(attachment => html`<${AttachmentCard} key=${attachment.id} attachment=${attachment} />`)}
             </div>
           `
         : null}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -34,6 +34,10 @@ async function loadChat() {
   vi.doMock('../../lib/keeper-runtime-display', () => ({
     keeperDisplayStatus: () => 'running',
   }))
+  vi.doMock('../chat/artifact-panel', () => ({
+    ChatArtifactPanel: ({ entries }: { entries: unknown[] }) =>
+      html`<div data-testid="kw-artifact-panel" data-artifact-count=${entries.length}>Artifacts</div>`,
+  }))
   return import('./keeper-workspace-chat')
 }
 
@@ -56,6 +60,7 @@ describe('KeeperWorkspaceChat', () => {
     vi.doUnmock('../keeper-shared')
     vi.doUnmock('../keeper-turn-inspector')
     vi.doUnmock('../../lib/keeper-runtime-display')
+    vi.doUnmock('../chat/artifact-panel')
   })
 
   it('renders the chat header and conversation panel', async () => {
@@ -108,5 +113,39 @@ describe('KeeperWorkspaceChat', () => {
     })
 
     expect(container.querySelector('[data-testid="kw-chat-turn-inspector-drawer"]')).toBeNull()
+  })
+
+  it('toggles the artifact panel when the artifacts button is clicked', async () => {
+    const { KeeperWorkspaceChat } = await loadChat()
+
+    await act(async () => {
+      render(html`
+        <${KeeperWorkspaceChat}
+          keeper=${mockKeeper}
+          detailOpen=${false}
+          onToggleDetail=${vi.fn()}
+          onClear=${vi.fn()}
+        />
+      `, container)
+    })
+
+    expect(container.querySelector('[data-testid="kw-artifact-panel"]')).toBeNull()
+
+    const btn = container.querySelector('[data-testid="kw-chat-artifacts-toggle"]') as HTMLButtonElement
+    expect(btn?.textContent?.trim()).toBe('아티팩트')
+
+    await act(async () => {
+      btn.click()
+    })
+
+    const panel = container.querySelector('[data-testid="kw-artifact-panel"]')
+    expect(panel).not.toBeNull()
+    expect(btn?.textContent?.trim()).toBe('아티팩트 숨김')
+
+    await act(async () => {
+      btn.click()
+    })
+
+    expect(container.querySelector('[data-testid="kw-artifact-panel"]')).toBeNull()
   })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -10,6 +10,8 @@ import type { Keeper } from '../../types'
 import { KeeperConversationPanel } from '../keeper-shared'
 import { KeeperLifecycleButtons } from '../keeper-detail-lifecycle'
 import { KeeperTurnInspector } from '../keeper-turn-inspector'
+import { ChatArtifactPanel } from '../chat/artifact-panel'
+import { keeperThreads } from '../../keeper-state'
 import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
 import {
   WorkspaceSigil,
@@ -26,12 +28,16 @@ function ChatHeader({
   onToggleDetail,
   onClear,
   onOpenTurnInspector,
+  artifactsOpen,
+  onToggleArtifacts,
 }: {
   keeper: Keeper
   detailOpen: boolean
   onToggleDetail: () => void
   onClear: () => void
   onOpenTurnInspector: () => void
+  artifactsOpen: boolean
+  onToggleArtifacts: () => void
 }): VNode {
   const bucket = keeperBucket(keeper)
   const tone = keeperStatusTone(keeper)
@@ -63,6 +69,14 @@ function ChatHeader({
           data-testid="kw-chat-turn-inspector-btn"
         >턴 검사</button>
         <button type="button" class="kw-act danger v2-monitoring-action" title="컨텍스트 비우기" onClick=${onClear}>비우기</button>
+        <button
+          type="button"
+          class="kw-act v2-monitoring-action"
+          aria-pressed=${artifactsOpen ? 'true' : 'false'}
+          title="대화 아티팩트"
+          onClick=${onToggleArtifacts}
+          data-testid="kw-chat-artifacts-toggle"
+        >${artifactsOpen ? '아티팩트 숨김' : '아티팩트'}</button>
         <button
           type="button"
           class="kw-act v2-monitoring-action"
@@ -129,6 +143,8 @@ export function KeeperWorkspaceChat({
   onClear: () => void
 }): VNode {
   const [turnInspectorOpen, setTurnInspectorOpen] = useState(false)
+  const [artifactsOpen, setArtifactsOpen] = useState(false)
+  const entries = keeperThreads.value[keeper.name] ?? []
 
   return html`
     <section class="kw-chat v2-monitoring-surface" role="region" aria-label=${`${keeper.name} 대화`}>
@@ -138,12 +154,19 @@ export function KeeperWorkspaceChat({
         onToggleDetail=${onToggleDetail}
         onClear=${onClear}
         onOpenTurnInspector=${() => setTurnInspectorOpen(true)}
+        artifactsOpen=${artifactsOpen}
+        onToggleArtifacts=${() => setArtifactsOpen((o) => !o)}
       />
-      <${KeeperConversationPanel}
-        keeperName=${keeper.name}
-        placeholder=${`${keeper.name} 에게 메시지…  (⌘+Enter 전송)`}
-        layout="workspace"
-      />
+      <div class="kw-chat-body">
+        <${KeeperConversationPanel}
+          keeperName=${keeper.name}
+          placeholder=${`${keeper.name} 에게 메시지…  (⌘+Enter 전송)`}
+          layout="workspace"
+        />
+        ${artifactsOpen
+          ? html`<${ChatArtifactPanel} entries=${entries} />`
+          : null}
+      </div>
       <${TurnInspectorDrawer}
         keeperName=${keeper.name}
         open=${turnInspectorOpen}

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -704,3 +704,58 @@
   color: var(--color-fg-muted);
   margin-left: auto;
 }
+
+/* ── Rich code block header / copy button ────────────────────── */
+.chat-block-code-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+}
+
+.chat-block-code-hd .chat-block-code-cap {
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+.chat-block-code-copy {
+  padding: 3px 8px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-0);
+  background: var(--color-bg-panel-alt);
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-semi);
+  cursor: pointer;
+  transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast);
+}
+
+.chat-block-code-copy:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-fg-primary);
+  border-color: var(--color-border-strong);
+}
+
+.chat-block-code-fallback pre {
+  color: var(--color-fg-secondary);
+}
+
+/* ── Mermaid diagram container ───────────────────────────────── */
+.chat-block-mermaid {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  padding: 12px;
+  background: var(--color-bg-panel-alt);
+  overflow-x: auto;
+}
+
+.chat-block-mermaid svg {
+  max-width: 100%;
+  height: auto;
+}

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -504,3 +504,388 @@
   object-position: center 30%;
   display: block;
 }
+
+/* ════ Conversation artifact panel ════════════════════════════════ */
+
+.chat-artifact-panel {
+  display: flex;
+  flex-direction: column;
+  width: 320px;
+  flex: none;
+  min-height: 0;
+  border-left: 1px solid var(--color-border-default);
+  background: var(--color-bg-panel-alt);
+}
+
+.chat-artifact-panel-head {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+}
+
+.chat-artifact-panel-title {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-bold);
+  color: var(--color-fg-primary);
+}
+
+.chat-artifact-panel-count {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--color-fg-secondary);
+  background: var(--color-bg-panel-alt);
+  border: 1px solid var(--color-border-default);
+  border-radius: 9999px;
+  padding: 2px 8px;
+}
+
+.chat-artifact-panel-empty {
+  padding: 24px 16px;
+  text-align: center;
+  font-size: var(--fs-xs);
+  color: var(--color-fg-secondary);
+}
+
+.chat-artifact-panel-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.chat-artifact-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-artifact-group-hd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 4px;
+}
+
+.chat-artifact-group-turn {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+}
+
+.chat-artifact-group-role {
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semi);
+  color: var(--color-fg-secondary);
+}
+
+.chat-artifact-group-role.user {
+  color: var(--color-accent-fg);
+}
+
+.chat-artifact-group-role.assistant {
+  color: var(--color-status-ok);
+}
+
+.chat-artifact-group-items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-artifact-card {
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-artifact-card-hd {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.chat-artifact-card-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex: none;
+  border-radius: var(--r-0);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-panel-alt);
+  color: var(--color-fg-muted);
+  font-size: var(--fs-xs);
+  font-family: var(--font-mono);
+}
+
+.chat-artifact-card-info {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.chat-artifact-card-name {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--color-fg-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-artifact-card-meta {
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+}
+
+.chat-artifact-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.chat-artifact-card-btn {
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-med);
+  padding: 4px 9px;
+  border-radius: var(--r-0);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-panel-alt);
+  color: var(--color-fg-secondary);
+  cursor: pointer;
+  transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast);
+}
+
+.chat-artifact-card-btn:hover:not(:disabled) {
+  background: var(--color-bg-hover);
+  color: var(--color-fg-primary);
+  border-color: var(--color-border-strong);
+}
+
+.chat-artifact-card-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.chat-artifact-card-btn.copied {
+  color: var(--color-status-ok);
+  border-color: rgb(var(--color-status-ok-glow) / 0.45);
+  background: rgb(var(--color-status-ok-glow) / 0.12);
+}
+
+.chat-artifact-preview {
+  border-top: 1px solid var(--color-border-default);
+  padding-top: 10px;
+}
+
+.chat-artifact-preview-img {
+  max-width: 100%;
+  max-height: 220px;
+  object-fit: contain;
+  border-radius: var(--r-0);
+  display: block;
+  margin: 0 auto;
+}
+
+.chat-artifact-preview-ph {
+  text-align: center;
+  color: var(--color-fg-muted);
+  font-size: var(--fs-xs);
+  padding: 16px;
+}
+
+.chat-artifact-preview-text {
+  margin: 0;
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  line-height: 1.5;
+  color: var(--color-fg-secondary);
+  background: var(--color-bg-panel-alt);
+  border-radius: var(--r-0);
+  padding: 8px;
+}
+
+.chat-artifact-preview-link {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  border-radius: var(--r-0);
+  background: var(--color-bg-panel-alt);
+  color: var(--color-accent-fg);
+  font-size: var(--fs-xs);
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.chat-artifact-preview-link:hover {
+  text-decoration: underline;
+}
+
+.chat-artifact-preview-link-meta {
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+}
+
+/* ════ Rich media / artifact UX ════ */
+
+.chat-block-code-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--color-border-default);
+  background: var(--color-bg-panel-alt);
+  border-radius: var(--r-1) var(--r-1) 0 0;
+}
+
+.chat-block-code-hd .chat-block-code-cap {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs, 10px);
+  color: var(--color-fg-secondary);
+}
+
+.chat-block-code-copy {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-0);
+  background: var(--color-bg-surface);
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-2xs, 10px);
+  cursor: pointer;
+  transition: 0.14s;
+}
+
+.chat-block-code-copy:hover {
+  border-color: var(--color-border-strong);
+  color: var(--color-fg-primary);
+  background: var(--color-bg-hover);
+}
+
+.chat-block-artifact-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.chat-block-media-frame.cursor-zoom-in,
+.chat-block-attach-frame {
+  cursor: zoom-in;
+}
+
+/* Lightbox / preview modal content */
+
+.chat-preview-modal-body-svg {
+  max-height: 80vh;
+}
+
+.chat-preview-modal-body-svg svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.chat-lightbox-svg {
+  max-height: 80vh;
+}
+
+.chat-lightbox-svg svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.chat-lightbox-md {
+  min-width: min(700px, 80vw);
+  max-width: min(900px, 90vw);
+  font-size: var(--fs-sm, 14px);
+  line-height: 1.6;
+  color: var(--color-fg-primary);
+}
+
+.chat-lightbox-code {
+  margin: 0;
+  padding: 12px 16px;
+  background: var(--color-bg-page);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs, 12px);
+  line-height: 1.55;
+  color: var(--color-fg-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-width: min(560px, 80vw);
+  max-height: 80vh;
+  overflow: auto;
+}
+
+/* Audio player */
+
+.chat-audio-clip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: var(--r-1);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+}
+
+.chat-audio-clip audio {
+  flex: 1;
+  min-width: 0;
+  height: 36px;
+}
+
+.chat-audio-wave {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  height: 22px;
+}
+
+.chat-audio-bar {
+  width: 2.5px;
+  border-radius: 1px;
+  background: var(--color-accent-fg-dim);
+}
+
+.chat-audio-dur {
+  flex: none;
+  font-size: var(--fs-xs, 12px);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-fg-secondary);
+}
+
+.chat-audio-device {
+  flex: none;
+  font-size: var(--fs-xs, 12px);
+  color: var(--color-fg-secondary);
+}

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -147,6 +147,8 @@
 
 /* ════ CONVERSATION (center) ════════════════════════════════════ */
 .kw-chat { display: flex; flex-direction: column; min-width: 0; min-height: 0; height: 100%; background: var(--color-bg-page); }
+.kw-chat-body { display: flex; flex: 1; min-height: 0; min-width: 0; }
+.kw-chat-body > *:first-child { flex: 1; min-width: 0; }
 
 /* Single-row header (identity + status + actions). Slimmer than the old
  * two-row variant — the runtime/model/throughput sub-row moved to the rail —

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -762,12 +762,12 @@ export type ChatCalloutBlock = { t: 'callout'; severity?: ChatCalloutSeverity; h
 export type ChatTableCellValue = string | { v: string; num?: boolean; muted?: boolean }
 export type ChatTableBlock = { t: 'table'; head: ChatTableCellValue[]; rows: ChatTableCellValue[][] }
 
-export type ChatCodeBlock = { t: 'code'; cap?: string; html: string }
+export type ChatCodeBlock = { t: 'code'; cap?: string; html: string; source?: string }
 
 export type ChatShellLine = { t?: 'cmd' | 'out' | 'err'; v: string }
 export type ChatShellBlock = { t: 'shell'; title?: string; lines: ChatShellLine[]; exit?: number; dur?: string }
 
-export type ChatArtifactBlock = { t: 'artifact'; kind?: string; name: string; size?: string; note?: string }
+export type ChatArtifactBlock = { t: 'artifact'; kind?: string; name: string; size?: string; note?: string; data?: string; mimeType?: string }
 
 export type ChatAttachBlock = {
   t: 'attach'
@@ -790,6 +790,7 @@ export type ChatVoiceBlock = { t: 'voice'; secs?: number; wave?: number[]; via?:
 
 export type ChatImageBlock = { t: 'image'; src?: string; ph?: string; cap?: string }
 export type ChatSvgBlock = { t: 'svg'; svg: string; cap?: string }
+export type ChatMermaidBlock = { t: 'mermaid'; source: string; caption?: string }
 
 export type ChatTraceThinkStep = { kind: 'think'; text: string }
 export type ChatTraceReasonStep = { kind: 'reason'; text: string; detail?: string }
@@ -816,6 +817,7 @@ export type ChatBlock =
   | ChatVoiceBlock
   | ChatImageBlock
   | ChatSvgBlock
+  | ChatMermaidBlock
   | ChatTraceBlock
   | ChatLinkBlock
   | ChatBroadcastBlock

--- a/dashboard/vitest-setup.ts
+++ b/dashboard/vitest-setup.ts
@@ -93,23 +93,27 @@ vi.mock('shiki', () => {
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
   }
+  const codeToHtml = vi.fn((code: string) => `<pre class="shiki"><code>${escapeHtml(code)}</code></pre>`)
   return {
     createHighlighter: vi.fn().mockResolvedValue({
       getLoadedLanguages: vi.fn().mockReturnValue([]),
       loadLanguage: vi.fn().mockResolvedValue(undefined),
-      codeToHtml: vi.fn((code: string) => `<pre class="shiki"><code>${escapeHtml(code)}</code></pre>`)
-    })
+      codeToHtml,
+    }),
+    codeToHtml,
   }
 })
 
 // Mock Mermaid to avoid heavyweight parsing/rendering during happy-dom tests.
+const mermaidMock = {
+  initialize: vi.fn(),
+  render: vi.fn(async (_id: string, source: string) => ({
+    svg: `<svg><text>${source}</text></svg>`,
+  })),
+}
 vi.mock('mermaid', () => ({
-  default: {
-    initialize: vi.fn(),
-    render: vi.fn(async (_id: string, source: string) => ({
-      svg: `<svg><text>${source}</text></svg>`,
-    })),
-  },
+  default: mermaidMock,
+  ...mermaidMock,
 }))
 
 // Block real network requests in tests. Tests that intentionally need


### PR DESCRIPTION
## Summary

Closes the gap between the dashboard 1:1 chat and desktop clients (Claude/Codex) by adding rich content rendering and an artifact/output inventory panel.

## Changes

- **Markdown → ChatBlock parser** (`dashboard/src/components/chat/markdown-blocks.ts`)
  - Assistant/system markdown is now parsed into rich blocks: paragraphs, headings, lists, tables, GitHub-style callouts, code fences, Mermaid diagrams, images, and SVG.

- **Code blocks & Mermaid**
  - `ChatCodeBlock` now uses the shared `highlightCodeHtml` helper for Shiki syntax highlighting, with a language header and copy-to-clipboard button.
  - New `ChatMermaidBlock` renders Mermaid diagrams; falls back to a plain code block on parse errors.

- **Media & artifact UX**
  - Artifact cards now have working **열기**, **다운로드**, and **복사** actions.
  - Images and SVGs open in a lightbox modal.
  - Audio player restyled with a desktop chat look.

- **Conversation artifact panel**
  - New right-side panel in `KeeperWorkspaceChat` lists every artifact/output per turn: attachments, code snippets, diagrams, images, SVGs, tool outputs, and links.

- **Dependencies**
  - Pinned `dompurify` to `3.4.2` because 3.4.9 strips `<pre>`/`<svg>` tags in the happy-dom test environment, breaking existing dashboard tests. This restores the dependency state already present in the local `node_modules` tree.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm build` ✅
- Chat + workspace tests: 162 passed ✅

## Notes

- New `ChatMermaidBlock` type added to `ChatBlock` union in `types/core.ts`.
- Shiki and Mermaid are loaded lazily so initial bundle is not blocked.
