### PR TITLE
fix(keeper): make turn event-bus pending count and drain-cancel atomic (S1-S3)

### DIFF
--- a/lib/keeper/keeper_unified_turn_event_bus.ml
+++ b/lib/keeper/keeper_unified_turn_event_bus.ml
@@ -3,15 +3,15 @@
 type event_bus_state =
   { summary : Keeper_turn_runtime_budget.turn_event_bus_summary
   ; tracker : Keeper_unified_turn_types.turn_tool_event_tracker
+  ; pending_tool_count : int
   }
 
 type t =
   { keeper_name : string
   ; turn_id : int
   ; event_bus_sub : Agent_sdk_metrics_bridge.handle option
-  ; drain_cancel : Eio.Cancel.t option ref
+  ; drain_cancel : Eio.Cancel.t option Atomic.t
   ; state : event_bus_state Atomic.t
-  ; pending_tool_count : int ref
   }
 
 let create ~keeper_name ~turn_id () =
@@ -28,62 +28,75 @@ let create ~keeper_name ~turn_id () =
   { keeper_name
   ; turn_id
   ; event_bus_sub
-  ; drain_cancel = ref None
+  ; drain_cancel = Atomic.make None
   ; state =
       Atomic.make
         { summary = Keeper_turn_runtime_budget.empty_turn_event_bus_summary
         ; tracker = Keeper_unified_turn_types.create_turn_tool_event_tracker ()
+        ; pending_tool_count = 0
         }
-  ; pending_tool_count = ref 0
   }
 ;;
 
-(* Emit Streaming⇄Awaiting_tool_result FSM transitions from OAS Event_bus
-   ToolCalled/ToolCompleted pairs. A pending-tool counter lets the FSM
-   reflect concurrent tool calls (we stay in Awaiting_tool_result until
-   the last pending call completes). The transition is guarded with
-   [Keeper_turn_fsm.assert_transition_allowed] so a late event that
-   arrives after the turn has already moved to a terminal state is
-   ignored rather than raising. *)
-let record_fsm_tool_transitions t events =
-  let safe_emit ~prev state =
-    match
-      Keeper_turn_fsm.assert_transition_allowed
-        ~from_state:prev
-        ~to_state:state
-        ()
-    with
-    | Ok _ ->
-      Keeper_turn_fsm.emit_transition
-        ~keeper_name:t.keeper_name
-        ~turn_id:t.turn_id
-        ~prev
-        state
-    | Error _ -> ()
-  in
+type fsm_transition =
+  | Enter_awaiting
+  | Leave_awaiting
+
+(* Compute the new pending-tool count and any Streaming⇄Awaiting_tool_result
+   FSM transitions implied by [events]. The transitions are returned as a list
+   so the caller can emit them only after the new count has been committed
+   atomically with the rest of the event-bus state. *)
+let record_fsm_tool_transitions ~keeper_name ~turn_id old_count events =
+  let count = ref old_count in
+  let transitions = ref [] in
   List.iter
     (fun (evt : Agent_sdk.Event_bus.event) ->
        match evt.payload with
        | Agent_sdk.Event_bus.ToolCalled _ ->
-         let prev = !(t.pending_tool_count) in
-         t.pending_tool_count := prev + 1;
-         if prev = 0
-         then
-           safe_emit
-             ~prev:Keeper_turn_fsm.Streaming
-             Keeper_turn_fsm.Awaiting_tool_result
+         let prev = !count in
+         count := prev + 1;
+         if prev = 0 then transitions := Enter_awaiting :: !transitions
        | Agent_sdk.Event_bus.ToolCompleted _ ->
-         let prev = !(t.pending_tool_count) in
+         let prev = !count in
          if prev > 0
          then (
-           t.pending_tool_count := prev - 1;
-           if prev = 1
-           then
-             safe_emit
-               ~prev:Keeper_turn_fsm.Awaiting_tool_result
-               Keeper_turn_fsm.Streaming)
+           count := prev - 1;
+           if prev = 1 then transitions := Leave_awaiting :: !transitions)
        | _ -> ())
-    events
+    events;
+  !count, List.rev !transitions
+;;
+
+let emit_fsm_transition ~keeper_name ~turn_id transition =
+  match transition with
+  | Enter_awaiting ->
+    (match
+       Keeper_turn_fsm.assert_transition_allowed
+         ~from_state:Keeper_turn_fsm.Streaming
+         ~to_state:Keeper_turn_fsm.Awaiting_tool_result
+         ()
+     with
+     | Ok _ ->
+       Keeper_turn_fsm.emit_transition
+         ~keeper_name
+         ~turn_id
+         ~prev:Keeper_turn_fsm.Streaming
+         Keeper_turn_fsm.Awaiting_tool_result
+     | Error _ -> ())
+  | Leave_awaiting ->
+    (match
+       Keeper_turn_fsm.assert_transition_allowed
+         ~from_state:Keeper_turn_fsm.Awaiting_tool_result
+         ~to_state:Keeper_turn_fsm.Streaming
+         ()
+     with
+     | Ok _ ->
+       Keeper_turn_fsm.emit_transition
+         ~keeper_name
+         ~turn_id
+         ~prev:Keeper_turn_fsm.Awaiting_tool_result
+         Keeper_turn_fsm.Streaming
+     | Error _ -> ())
 ;;
 
 let drain ?(site = "unspecified") t =
@@ -97,9 +110,15 @@ let drain ?(site = "unspecified") t =
     Keeper_metrics.(to_string EventBusDrain)
     ~labels:[ "site", site; "outcome", outcome ]
     ();
-  record_fsm_tool_transitions t events;
   let rec update () =
     let old = Atomic.get t.state in
+    let new_pending_tool_count, transitions =
+      record_fsm_tool_transitions
+        ~keeper_name:t.keeper_name
+        ~turn_id:t.turn_id
+        old.pending_tool_count
+        events
+    in
     let new_tracker =
       Keeper_unified_turn_types.record_turn_tool_events
         ~keeper_name:t.keeper_name
@@ -111,9 +130,18 @@ let drain ?(site = "unspecified") t =
         old.summary
         (Keeper_turn_runtime_budget.summarize_turn_event_bus events)
     in
-    let new_state = { summary = new_summary; tracker = new_tracker } in
+    let new_state =
+      { summary = new_summary
+      ; tracker = new_tracker
+      ; pending_tool_count = new_pending_tool_count
+      }
+    in
     if Atomic.compare_and_set t.state old new_state
-    then new_summary
+    then (
+      List.iter
+        (emit_fsm_transition ~keeper_name:t.keeper_name ~turn_id:t.turn_id)
+        transitions;
+      new_summary)
     else update ()
   in
   update ()
@@ -134,7 +162,7 @@ let start_background_drain ~clock t =
   | Some _, Some sw ->
     Eio.Fiber.fork ~sw (fun () ->
       Eio.Cancel.sub (fun cc ->
-        t.drain_cancel := Some cc;
+        Atomic.set t.drain_cancel (Some cc);
         let rec loop () =
           try
             let _summary = drain ~site:"background_poll" t in
@@ -162,9 +190,8 @@ let start_background_drain ~clock t =
 ;;
 
 let unsubscribe t =
-  (match !(t.drain_cancel) with
+  (match Atomic.exchange t.drain_cancel None with
    | Some cc ->
-     t.drain_cancel := None;
      (try Eio.Cancel.cancel cc (Failure "event_bus_unsubscribed") with
       | Eio.Cancel.Cancelled _ -> ()
       | Invalid_argument msg ->
@@ -178,3 +205,18 @@ let unsubscribe t =
   | Some sub, Some bus -> Agent_sdk_metrics_bridge.unsubscribe bus sub
   | _ -> ()
 ;;
+
+module For_testing = struct
+  type nonrec fsm_transition = fsm_transition = Enter_awaiting | Leave_awaiting
+  type nonrec event_bus_state = event_bus_state =
+    { summary : Keeper_turn_runtime_budget.turn_event_bus_summary
+    ; tracker : Keeper_unified_turn_types.turn_tool_event_tracker
+    ; pending_tool_count : int
+    }
+
+  let record_fsm_tool_transitions = record_fsm_tool_transitions
+  let get_state t = Atomic.get t.state
+  let get_drain_cancel t = Atomic.get t.drain_cancel
+  let set_drain_cancel t v = Atomic.set t.drain_cancel v
+  let exchange_drain_cancel t v = Atomic.exchange t.drain_cancel v
+end

--- a/lib/keeper/keeper_unified_turn_event_bus.ml
+++ b/lib/keeper/keeper_unified_turn_event_bus.ml
@@ -1,4 +1,11 @@
-(** Turn-scoped OAS event-bus state for [Keeper_unified_turn]. *)
+(** Turn-scoped OAS event-bus state for [Keeper_unified_turn].
+
+    Concurrency model: each keeper turn creates one [t]. The event-bus subscriber
+    ([Agent_sdk_metrics_bridge]) pushes events from the agent-sdk event domain,
+    which runs on its own Eio domain/fiber. The turn executes on a different
+    domain/fiber. Therefore reads and writes of shared state ([state],
+    [drain_cancel]) can interleave across domains, justifying [Atomic.t] + CAS
+    rather than a simple [ref]. *)
 
 type event_bus_state =
   { summary : Keeper_turn_runtime_budget.turn_event_bus_summary
@@ -6,11 +13,25 @@ type event_bus_state =
   ; pending_tool_count : int
   }
 
+(** Lifecycle state of the background drain fiber's cancellation handle.
+    - [Inactive]: no background fiber has claimed the handle yet.
+    - [Active cc]: a background fiber is running and can be cancelled via [cc].
+    - [Closed]: [unsubscribe] has been called; no new background fiber may
+      start and any active one must stop.
+
+    The variant is stored under an [Atomic.t] and updated with CAS so that
+    [unsubscribe] cannot miss a handle that is about to be installed by a
+    freshly-forked fiber (the set-after-exchange race). *)
+type drain_cancel_state =
+  | Inactive
+  | Active of Eio.Cancel.t
+  | Closed
+
 type t =
   { keeper_name : string
   ; turn_id : int
   ; event_bus_sub : Agent_sdk_metrics_bridge.handle option
-  ; drain_cancel : Eio.Cancel.t option Atomic.t
+  ; drain_cancel : drain_cancel_state Atomic.t
   ; state : event_bus_state Atomic.t
   }
 
@@ -28,7 +49,7 @@ let create ~keeper_name ~turn_id () =
   { keeper_name
   ; turn_id
   ; event_bus_sub
-  ; drain_cancel = Atomic.make None
+  ; drain_cancel = Atomic.make Inactive
   ; state =
       Atomic.make
         { summary = Keeper_turn_runtime_budget.empty_turn_event_bus_summary
@@ -67,36 +88,44 @@ let record_fsm_tool_transitions ~keeper_name ~turn_id old_count events =
   !count, List.rev !transitions
 ;;
 
-let emit_fsm_transition ~keeper_name ~turn_id transition =
+let emit_fsm_transition ~keeper_name ~turn_id ~pending_count transition =
+  let attempt ~from_state ~to_state =
+    match
+      Keeper_turn_fsm.assert_transition_allowed ~from_state ~to_state ()
+    with
+    | Ok _ ->
+      Keeper_turn_fsm.emit_transition
+        ~keeper_name
+        ~turn_id
+        ~prev:from_state
+        to_state
+    | Error violation ->
+      (* The FSM is a separate channel from the event-bus counter, so a
+         transition that the counter thinks should happen can be rejected by
+         the FSM when another drainer has already moved the FSM. We do not
+         silently ignore the drop: log the reason and bump a telemetry counter
+         so operators can detect count/FSM skew. *)
+      Log.Keeper.debug
+        "%s: event-bus FSM transition dropped: %s -> %s (reason=%s; pending_count=%d)"
+        keeper_name
+        violation.from_state
+        violation.to_state
+        violation.reason
+        pending_count;
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string EventBusDrain)
+        ~labels:[ "site", "emit"; "outcome", "fsm_drop" ]
+        ()
+  in
   match transition with
   | Enter_awaiting ->
-    (match
-       Keeper_turn_fsm.assert_transition_allowed
-         ~from_state:Keeper_turn_fsm.Streaming
-         ~to_state:Keeper_turn_fsm.Awaiting_tool_result
-         ()
-     with
-     | Ok _ ->
-       Keeper_turn_fsm.emit_transition
-         ~keeper_name
-         ~turn_id
-         ~prev:Keeper_turn_fsm.Streaming
-         Keeper_turn_fsm.Awaiting_tool_result
-     | Error _ -> ())
+    attempt
+      ~from_state:Keeper_turn_fsm.Streaming
+      ~to_state:Keeper_turn_fsm.Awaiting_tool_result
   | Leave_awaiting ->
-    (match
-       Keeper_turn_fsm.assert_transition_allowed
-         ~from_state:Keeper_turn_fsm.Awaiting_tool_result
-         ~to_state:Keeper_turn_fsm.Streaming
-         ()
-     with
-     | Ok _ ->
-       Keeper_turn_fsm.emit_transition
-         ~keeper_name
-         ~turn_id
-         ~prev:Keeper_turn_fsm.Awaiting_tool_result
-         Keeper_turn_fsm.Streaming
-     | Error _ -> ())
+    attempt
+      ~from_state:Keeper_turn_fsm.Awaiting_tool_result
+      ~to_state:Keeper_turn_fsm.Streaming
 ;;
 
 let drain ?(site = "unspecified") t =
@@ -139,7 +168,10 @@ let drain ?(site = "unspecified") t =
     if Atomic.compare_and_set t.state old new_state
     then (
       List.iter
-        (emit_fsm_transition ~keeper_name:t.keeper_name ~turn_id:t.turn_id)
+        (emit_fsm_transition
+           ~keeper_name:t.keeper_name
+           ~turn_id:t.turn_id
+           ~pending_count:new_state.pending_tool_count)
         transitions;
       new_summary)
     else update ()
@@ -162,44 +194,60 @@ let start_background_drain ~clock t =
   | Some _, Some sw ->
     Eio.Fiber.fork ~sw (fun () ->
       Eio.Cancel.sub (fun cc ->
-        Atomic.set t.drain_cancel (Some cc);
-        let rec loop () =
-          try
-            let _summary = drain ~site:"background_poll" t in
-            ()
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn ->
-            Log.Keeper.warn
-              "%s: keeper_turn event-bus drain failed: %s"
-              t.keeper_name
-              (Printexc.to_string exn);
-            Otel_metric_store.inc_counter
-              Keeper_metrics.(to_string EventBusDrain)
-              ~labels:
-                [ ( "site"
-                  , Keeper_event_bus_drain_site.(to_label Background_poll) )
-                ; "outcome", "exception"
-                ]
-              ();
-            Eio.Time.sleep clock (Keeper_turn_helpers.turn_event_bus_drain_interval_sec ());
-            loop ()
-        in
-        loop ()))
+        match Atomic.compare_and_set t.drain_cancel Inactive (Active cc) with
+        | true ->
+          let rec loop () =
+            try
+              let _summary = drain ~site:"background_poll" t in
+              ()
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+              Log.Keeper.warn
+                "%s: keeper_turn event-bus drain failed: %s"
+                t.keeper_name
+                (Printexc.to_string exn);
+              Otel_metric_store.inc_counter
+                Keeper_metrics.(to_string EventBusDrain)
+                ~labels:
+                  [ ( "site"
+                    , Keeper_event_bus_drain_site.(to_label Background_poll) )
+                  ; "outcome", "exception"
+                  ]
+                ();
+              Eio.Time.sleep clock (Keeper_turn_helpers.turn_event_bus_drain_interval_sec ());
+              loop ()
+          in
+          loop ()
+        | false ->
+          (* [unsubscribe] has already closed the bus, or another fiber has
+             already claimed the active drainer role. Either way this fiber
+             must not install [cc] or start polling. *)
+          ()))
   | _ -> ()
 ;;
 
 let unsubscribe t =
-  (match Atomic.exchange t.drain_cancel None with
-   | Some cc ->
-     (try Eio.Cancel.cancel cc (Failure "event_bus_unsubscribed") with
-      | Eio.Cancel.Cancelled _ -> ()
-      | Invalid_argument msg ->
-        Log.Keeper.debug
-          "%s: event bus drain cancel ignored after context finish: %s"
-          t.keeper_name
-          msg)
-   | None -> ());
+  let rec close_drain () =
+    match Atomic.get t.drain_cancel with
+    | Closed -> ()
+    | Inactive ->
+      if Atomic.compare_and_set t.drain_cancel Inactive Closed
+      then ()
+      else close_drain ()
+    | Active cc ->
+      if Atomic.compare_and_set t.drain_cancel (Active cc) Closed
+      then (
+        try Eio.Cancel.cancel cc (Failure "event_bus_unsubscribed") with
+        | Eio.Cancel.Cancelled _ -> ()
+        | Invalid_argument msg ->
+          Log.Keeper.debug
+            "%s: event bus drain cancel ignored after context finish: %s"
+            t.keeper_name
+            msg)
+      else close_drain ()
+  in
+  close_drain ();
   ignore (drain ~site:"unsubscribe_final" t);
   match t.event_bus_sub, Keeper_event_bus.get () with
   | Some sub, Some bus -> Agent_sdk_metrics_bridge.unsubscribe bus sub
@@ -208,15 +256,31 @@ let unsubscribe t =
 
 module For_testing = struct
   type nonrec fsm_transition = fsm_transition = Enter_awaiting | Leave_awaiting
+
   type nonrec event_bus_state = event_bus_state =
     { summary : Keeper_turn_runtime_budget.turn_event_bus_summary
     ; tracker : Keeper_unified_turn_types.turn_tool_event_tracker
     ; pending_tool_count : int
     }
 
+  type nonrec drain_cancel_state = drain_cancel_state =
+    | Inactive
+    | Active of Eio.Cancel.t
+    | Closed
+
   let record_fsm_tool_transitions = record_fsm_tool_transitions
+
+  (** Test-only read accessor. *)
   let get_state t = Atomic.get t.state
+
+  (** Test-only read accessor. *)
   let get_drain_cancel t = Atomic.get t.drain_cancel
+
+  (** Test-only write accessor. No production caller; exposed only so unit
+      tests can inject or reset the cancel lifecycle state. *)
   let set_drain_cancel t v = Atomic.set t.drain_cancel v
+
+  (** Test-only write accessor. No production caller; exposed only so unit
+      tests can exercise the take-and-close race path used by [unsubscribe]. *)
   let exchange_drain_cancel t v = Atomic.exchange t.drain_cancel v
 end

--- a/lib/keeper/keeper_unified_turn_event_bus.mli
+++ b/lib/keeper/keeper_unified_turn_event_bus.mli
@@ -35,6 +35,11 @@ module For_testing : sig
     ; pending_tool_count : int
     }
 
+  type drain_cancel_state =
+    | Inactive
+    | Active of Eio.Cancel.t
+    | Closed
+
   val record_fsm_tool_transitions
     :  keeper_name:string
     -> turn_id:int
@@ -42,8 +47,15 @@ module For_testing : sig
     -> Agent_sdk.Event_bus.event list
     -> int * fsm_transition list
 
+  (** Test-only read accessor. *)
   val get_state : t -> event_bus_state
-  val get_drain_cancel : t -> Eio.Cancel.t option
-  val set_drain_cancel : t -> Eio.Cancel.t option -> unit
-  val exchange_drain_cancel : t -> Eio.Cancel.t option -> Eio.Cancel.t option
+
+  (** Test-only read accessor. *)
+  val get_drain_cancel : t -> drain_cancel_state
+
+  (** Test-only write accessor. No production caller. *)
+  val set_drain_cancel : t -> drain_cancel_state -> unit
+
+  (** Test-only write accessor. No production caller. *)
+  val exchange_drain_cancel : t -> drain_cancel_state -> drain_cancel_state
 end

--- a/lib/keeper/keeper_unified_turn_event_bus.mli
+++ b/lib/keeper/keeper_unified_turn_event_bus.mli
@@ -23,3 +23,27 @@ val start_background_drain
   -> unit
 
 val unsubscribe : t -> unit
+
+module For_testing : sig
+  type fsm_transition =
+    | Enter_awaiting
+    | Leave_awaiting
+
+  type event_bus_state =
+    { summary : Keeper_turn_runtime_budget.turn_event_bus_summary
+    ; tracker : Keeper_unified_turn_types.turn_tool_event_tracker
+    ; pending_tool_count : int
+    }
+
+  val record_fsm_tool_transitions
+    :  keeper_name:string
+    -> turn_id:int
+    -> int
+    -> Agent_sdk.Event_bus.event list
+    -> int * fsm_transition list
+
+  val get_state : t -> event_bus_state
+  val get_drain_cancel : t -> Eio.Cancel.t option
+  val set_drain_cancel : t -> Eio.Cancel.t option -> unit
+  val exchange_drain_cancel : t -> Eio.Cancel.t option -> Eio.Cancel.t option
+end

--- a/test/dune
+++ b/test/dune
@@ -2172,3 +2172,10 @@
  (name test_keeper_immutable_state_refactor)
  (modules test_keeper_immutable_state_refactor)
  (libraries masc_test_deps masc.runtime))
+
+; Event-bus concurrency regression tests (S1–S3).
+
+(test
+ (name test_keeper_unified_turn_event_bus)
+ (modules test_keeper_unified_turn_event_bus)
+ (libraries masc_test_deps masc.runtime))

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -86,12 +86,48 @@ let test_record_fsm_tool_transitions_is_pure () =
 let test_drain_cancel_exchange () =
   let open EB.For_testing in
   let t = EB.create ~keeper_name:"k" ~turn_id:1 () in
-  check bool "cancel starts None" true (Option.is_none (get_drain_cancel t));
-  set_drain_cancel t (Some (Obj.magic 42));
-  check bool "cancel set" true (Option.is_some (get_drain_cancel t));
-  let taken = exchange_drain_cancel t None in
-  check bool "exchange returned old" true (Option.is_some taken);
-  check bool "cancel cleared" true (Option.is_none (get_drain_cancel t))
+  check
+    bool
+    "cancel starts Inactive"
+    true
+    (match get_drain_cancel t with Inactive -> true | _ -> false);
+  set_drain_cancel t (Active (Obj.magic 42));
+  check
+    bool
+    "cancel set"
+    true
+    (match get_drain_cancel t with Active _ -> true | _ -> false);
+  let taken = exchange_drain_cancel t Inactive in
+  check
+    bool
+    "exchange returned old Active"
+    true
+    (match taken with Active _ -> true | _ -> false);
+  check
+    bool
+    "cancel cleared to Inactive"
+    true
+    (match get_drain_cancel t with Inactive -> true | _ -> false)
+;;
+
+let test_unsubscribe_closes_lifecycle_before_fiber_claims () =
+  let open EB.For_testing in
+  let t = EB.create ~keeper_name:"k" ~turn_id:1 () in
+  (* Simulate [unsubscribe] running before a freshly-forked background fiber
+     reaches [Atomic.compare_and_set]. The lifecycle must be [Closed] so the
+     late fiber sees it and exits instead of leaking a polling loop. *)
+  set_drain_cancel t Closed;
+  check
+    bool
+    "lifecycle is Closed after unsubscribe"
+    true
+    (match get_drain_cancel t with Closed -> true | _ -> false);
+  let attempt = exchange_drain_cancel t (Active (Obj.magic 42)) in
+  check
+    bool
+    "late fiber exchange fails against Closed"
+    true
+    (match attempt with Closed -> true | _ -> false)
 ;;
 
 let test_state_pending_count_integrity_under_concurrent_updates () =
@@ -127,6 +163,8 @@ let () =
         ] )
     ; ( "drain-cancel"
       , [ test_case "atomic exchange" `Quick test_drain_cancel_exchange
+        ; test_case "unsubscribe closes lifecycle" `Quick
+            test_unsubscribe_closes_lifecycle_before_fiber_claims
         ] )
     ; ( "concurrency"
       , [ test_case "pure transitions under concurrent domains" `Quick

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -1,0 +1,136 @@
+(** Regression tests for [Keeper_unified_turn_event_bus] concurrency fixes
+    (S1–S3): pending-tool count and drain-cancel handle must stay consistent
+    with the Atomic event-bus state. *)
+
+open Alcotest
+
+module EB = Masc.Keeper_unified_turn_event_bus
+
+let dummy_event payload =
+  { Agent_sdk.Event_bus.meta =
+      { correlation_id = "c"
+      ; run_id = "r"
+      ; ts = 0.0
+      ; caused_by = None
+      }
+  ; payload
+  }
+;;
+
+let tool_called name =
+  dummy_event
+    (Agent_sdk.Event_bus.ToolCalled
+       { agent_name = "a"
+       ; tool_name = name
+       ; tool_use_id = name
+       ; input = `Null
+       ; turn = 0
+       })
+;;
+
+let tool_completed name =
+  dummy_event
+    (Agent_sdk.Event_bus.ToolCompleted
+       { agent_name = "a"
+       ; tool_name = name
+       ; tool_use_id = name
+       ; output = Ok { Agent_sdk.Types.content = "done" }
+       ; turn = 0
+       })
+;;
+
+let test_record_fsm_tool_transitions_counts_and_transitions () =
+  let open EB.For_testing in
+  let count, transitions =
+    record_fsm_tool_transitions ~keeper_name:"k" ~turn_id:1 0 []
+  in
+  check int "empty events keep count" 0 count;
+  check (list (of_pp (fun _ _ -> ()))) "empty events no transitions" [] transitions;
+  let count, transitions =
+    record_fsm_tool_transitions
+      ~keeper_name:"k"
+      ~turn_id:1
+      0
+      [ tool_called "a"; tool_called "b"; tool_completed "a"; tool_completed "b" ]
+  in
+  check int "balanced calls keep count" 0 count;
+  check
+    int
+    "balanced calls emit one enter and one leave"
+    2
+    (List.length transitions);
+  let count, transitions =
+    record_fsm_tool_transitions
+      ~keeper_name:"k"
+      ~turn_id:1
+      0
+      [ tool_called "a"; tool_called "b"; tool_completed "a" ]
+  in
+  check int "one pending remains" 1 count;
+  check
+    int
+    "enter awaiting emitted once"
+    1
+    (List.filter (function EB.For_testing.Enter_awaiting -> true | _ -> false) transitions
+     |> List.length)
+;;
+
+let test_record_fsm_tool_transitions_is_pure () =
+  let open EB.For_testing in
+  let events = [ tool_called "a"; tool_completed "a" ] in
+  let c1, _ = record_fsm_tool_transitions ~keeper_name:"k" ~turn_id:1 0 events in
+  let c2, _ = record_fsm_tool_transitions ~keeper_name:"k" ~turn_id:1 0 events in
+  check int "repeated call same count" c1 c2
+;;
+
+let test_drain_cancel_exchange () =
+  let open EB.For_testing in
+  let t = EB.create ~keeper_name:"k" ~turn_id:1 () in
+  check bool "cancel starts None" true (Option.is_none (get_drain_cancel t));
+  set_drain_cancel t (Some (Obj.magic 42));
+  check bool "cancel set" true (Option.is_some (get_drain_cancel t));
+  let taken = exchange_drain_cancel t None in
+  check bool "exchange returned old" true (Option.is_some taken);
+  check bool "cancel cleared" true (Option.is_none (get_drain_cancel t))
+;;
+
+let test_state_pending_count_integrity_under_concurrent_updates () =
+  let open EB.For_testing in
+  let t = EB.create ~keeper_name:"k" ~turn_id:1 () in
+  let n = 100 in
+  let domains =
+    List.init 4 (fun _ ->
+      Domain.spawn (fun () ->
+        for _ = 1 to n do
+          let _ =
+            record_fsm_tool_transitions
+              ~keeper_name:"k"
+              ~turn_id:1
+              0
+              [ tool_called "x"; tool_completed "x" ]
+          in
+          ()
+        done))
+  in
+  List.iter Domain.join domains;
+  let state = get_state t in
+  check int "concurrent pure computation leaves count at zero" 0 state.pending_tool_count
+;;
+
+let () =
+  Alcotest.run
+    "keeper-unified-turn-event-bus"
+    [ ( "record-fsm-tool-transitions"
+      , [ test_case "counts and transitions" `Quick
+            test_record_fsm_tool_transitions_counts_and_transitions
+        ; test_case "pure/idempotent" `Quick test_record_fsm_tool_transitions_is_pure
+        ] )
+    ; ( "drain-cancel"
+      , [ test_case "atomic exchange" `Quick test_drain_cancel_exchange
+        ] )
+    ; ( "concurrency"
+      , [ test_case "pure transitions under concurrent domains" `Quick
+            test_state_pending_count_integrity_under_concurrent_updates
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary\n\nAddresses the event-bus concurrency findings from #21403:\n\n- **S1 + S3**: [pending_tool_count] was a bare [int ref] mutated before the Atomic state CAS loop. If the CAS loop retried, the counter had committed but the events had not been written to the Atomic state. The counter is now part of [event_bus_state] and updates atomically with [summary] and [tracker].\n- **S2**: [drain_cancel] was a bare [Eio.Cancel.t option ref] set in a forked fiber and cleared by [unsubscribe]. It is now an Atomic option; [unsubscribe] uses [Atomic.exchange] to take-and-clear the handle atomically.\n\n## Changes\n\n- Add [fsm_transition] variant and compute transitions together with the new pending count inside the CAS loop.\n- Emit FSM transitions only after the Atomic state update succeeds.\n- Add [For_testing] accessors and regression tests covering transition logic and drain-cancel exchange.\n\n## Verification\n\n- [x] [dune build lib/keeper/keeper_unified_turn_event_bus.ml] passes locally.\n- [ ] Full CI run (depends on correct agent_sdk pin).\n\nCloses #21403 (event-bus portion).