### PR TITLE
fix(dashboard): sync nav-event allowlist with navigation.ts (RFC-0049 parity)

### DIFF
--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -17,6 +17,7 @@ let valid_surfaces =
   ; "lab"
   ; "code"
   ; "logs"
+  ; "settings"
   ]
 ;;
 
@@ -37,8 +38,9 @@ let valid_sections =
       ] )
   ; "command", [ "operations" ]
   ; "connectors", [ "connector-status" ]
-  ; "workspace", [ "board"; "sub-boards"; "moderation"; "planning"; "repositories"; "verification" ]
-  ; "lab", [ "tools"; "harness" ]
+  ; ( "workspace"
+    , [ "board"; "sub-boards"; "moderation"; "planning"; "repositories"; "verification"; "work" ] )
+  ; "lab", [ "tools"; "harness"; "design-canvas"; "memory-explore"; "performance" ]
   ; "code", [ "ide-shell" ]
   ]
 ;;


### PR DESCRIPTION
## 문제

`scripts/check-dashboard-nav-event-parity.sh` (RFC-0049) 게이트가 main에서 실패합니다. dashboard 파일을 건드리는 모든 PR(예: #21320)이 이 게이트를 트리거하면서 대신 실패를 떠안습니다.

```
dashboard nav-event allowlist parity: DRIFT
  - surfaces in navigation.ts but not in dashboard_nav_event.ml: ['settings']
  - surface 'lab': sections not in dashboard_nav_event.ml: ['design-canvas', 'memory-explore', 'performance']
  - surface 'workspace': sections not in dashboard_nav_event.ml: ['work']
```

## 원인

최근 main 커밋들("migrate IDE/connectors/lab surfaces …")이 `dashboard/src/config/navigation.ts`의 `DASHBOARD_SECTION_ITEMS`에 surface/section을 추가했으나, 그 SSOT를 미러링하는 OCaml validator allowlist(`lib/dashboard/dashboard_nav_event.ml`)를 동기화하지 않았습니다.

런타임 영향: 서버가 알 수 없는 `(surface, section)` 쌍에 400 반환 → 클라이언트 `catch()`에서 이벤트 드롭 → 해당 counter 미증가 → Grafana에 조용한 공백 (원인 불명).

## 변경

게이트가 직접 지시하는 root fix — `valid_surfaces` / `valid_sections`를 `DASHBOARD_SECTION_ITEMS`에 일치:

- `valid_surfaces`: `settings` 추가
- `lab`: `design-canvas`, `memory-explore`, `performance` 추가
- `workspace`: `work` 추가

`settings`는 section 없는 surface(cockpit/overview/logs와 동일)라 `valid_sections`엔 불포함.

## 검증

```
$ bash scripts/check-dashboard-nav-event-parity.sh --check
dashboard nav-event allowlist parity: OK
```

변경은 기존 `string list` 두 바인딩에 string literal 추가뿐 — 타입 변화 없음. 빌드는 CI에 위임(로컬은 agent_sdk pin으로 차단).

RFC-WAIVED: RFC-0049가 이미 정의한 allowlist를 SSOT(navigation.ts)에 동기화하는 순수 데이터 수정. credential/identity/operator/sandbox/hooks/workflow 미해당.
