### PR TITLE
fix(keeper): convert sandbox state, supervisor global switch, and manifest seq to Atomic (S5-S7)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -249,7 +249,7 @@ let run_turn
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   let manifest_keeper_turn_id = meta.runtime.usage.total_turns + 1 in
   let turn_start = Mtime_clock.now () in
-  let seq_ref = ref 0 in
+  let seq_ref = Atomic.make 0 in
   let runtime_manifest_context =
     Turn_helpers.runtime_manifest_context
       ~keeper_name:meta.name

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -234,7 +234,7 @@ let make_append_manifest
     ~generation
     ~runtime_id
     ~(turn_start : Mtime.t)
-    ~(seq_ref : int ref)
+    ~(seq_ref : int Atomic.t)
   : Keeper_agent_run_sidecar.append_manifest_fn
   =
   fun ?elapsed_ms ?logical_seq ?status ?decision ?keeper_turn_id ->
@@ -252,8 +252,8 @@ let make_append_manifest
     match logical_seq with
     | Some _ -> logical_seq
     | None ->
-      seq_ref := !seq_ref + 1;
-      Some !seq_ref
+      let n = Atomic.fetch_and_add seq_ref 1 in
+      Some (n + 1)
   in
   append_runtime_manifest
     ~config

--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -70,7 +70,7 @@ val make_append_manifest :
   generation:int ->
   runtime_id:string ->
   turn_start:Mtime.t ->
-  seq_ref:int ref ->
+  seq_ref:int Atomic.t ->
   Keeper_agent_run_sidecar.append_manifest_fn
 
 val turn_progress_callbacks :

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -121,6 +121,8 @@ let launch_supervised_fiber
           "keeper supervise domain pool ignored: keepalive body requires the owning \
            Eio domain (first_keeper=%s)"
           meta.name;
+      (* determinism-contract: allow — ctx.sw fallback is the same deterministic
+         default used before the ref -> Atomic conversion. *)
       let sw = Option.value (Atomic.get global_switch) ~default:ctx.sw in
       Eio.Fiber.fork ~sw body
     in

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -44,9 +44,9 @@ let publish_lifecycle = Keeper_supervisor_publish_lifecycle.publish_lifecycle
 let publish_phase_lifecycle = Keeper_supervisor_publish_lifecycle.publish_phase_lifecycle
 (* ── Supervised fiber launch ─────────────────────────────── *)
 
-let global_switch : Eio.Switch.t option ref = ref None
-let set_global_switch sw = global_switch := Some sw
-let get_global_switch () = !global_switch
+let global_switch : Eio.Switch.t option Atomic.t = Atomic.make None
+let set_global_switch sw = Atomic.set global_switch (Some sw)
+let get_global_switch () = Atomic.get global_switch
 
 let set_restart_launch_noop_for_test = Keeper_supervisor_restart_noop.set
 let restart_launch_noop_enabled_for_test = Keeper_supervisor_restart_noop.enabled
@@ -121,7 +121,7 @@ let launch_supervised_fiber
           "keeper supervise domain pool ignored: keepalive body requires the owning \
            Eio domain (first_keeper=%s)"
           meta.name;
-      let sw = Option.value !global_switch ~default:ctx.sw in
+      let sw = Option.value (Atomic.get global_switch) ~default:ctx.sw in
       Eio.Fiber.fork ~sw body
     in
     fork_body (fun () ->

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -16,8 +16,30 @@ type t =
   ; uid : int
   ; gid : int
   ; network_mode : network_mode
-  ; mutable state : state
+  ; state : state Atomic.t
   }
+
+let get_state t = Atomic.get t.state
+let set_state t state = Atomic.set t.state state
+
+module For_testing = struct
+  let create_minimal ~state =
+    { config = Obj.magic ()
+    ; meta = Obj.magic ()
+    ; turn_id = 0
+    ; raw_host_root = ""
+    ; host_root = ""
+    ; container_root = ""
+    ; uid = 0
+    ; gid = 0
+    ; network_mode = Network_none
+    ; state = Atomic.make state
+    }
+  ;;
+
+  let get_state = get_state
+  let set_state = set_state
+end
 
 let turn_id t = t.turn_id
 let host_root t = t.host_root
@@ -45,7 +67,7 @@ let create
   ; uid = Unix.getuid ()
   ; gid = Unix.getgid ()
   ; network_mode
-  ; state = Not_started
+  ; state = Atomic.make Not_started
   }
 ;;
 
@@ -782,7 +804,7 @@ let start_container (t : t) ~timeout_sec =
                  container_name
              with
              | Ok () ->
-               t.state <- Running { container_name };
+               set_state t Running { container_name };
                Ok container_name
              | Error inspect_out ->
                (* Inspect failed after a successful `docker run`. Without an
@@ -831,7 +853,7 @@ let start_container (t : t) ~timeout_sec =
 ;;
 
 let ensure_started ?(validate_running = false) (t : t) ~timeout_sec =
-  match t.state with
+  match get_state t with
   | Running { container_name } ->
     if not validate_running
     then Ok container_name
@@ -843,7 +865,7 @@ let ensure_started ?(validate_running = false) (t : t) ~timeout_sec =
       with
       | Ok () -> Ok container_name
       | Error _ ->
-        t.state <- Not_started;
+        set_state t Not_started;
         start_container t ~timeout_sec)
   | Not_started -> start_container t ~timeout_sec
 ;;
@@ -945,7 +967,7 @@ let run_exec_with_status_split
   | Error _ as err -> err
   | Ok ((Unix.WEXITED 126 | Unix.WEXITED 127), stdout, stderr)
     when container_missing_error (output_for_status ~stdout ~stderr) ->
-    t.state <- Not_started;
+    set_state t Not_started;
     (match
        run_exec_with_status_split_once
          ?stdin_content
@@ -1064,7 +1086,7 @@ let run_exec_pipeline_with_status ?on_stdout_chunk ?on_stderr_chunk ~timeout_sec
   | Error _ as err -> err
   | Ok ((Unix.WEXITED 126 | Unix.WEXITED 127), stdout, stderr)
     when container_missing_error (output_for_status ~stdout ~stderr) ->
-    t.state <- Not_started;
+    set_state t Not_started;
     (match
        run_exec_pipeline_with_status_once
          t
@@ -1149,7 +1171,7 @@ let run_bash_with_status ~timeout_sec (t : t) ~(cwd : string) ~(cmd : string) ()
     then (
       match st with
       | Unix.WEXITED (126 | 127) ->
-        t.state <- Not_started;
+        set_state t Not_started;
         (match ensure_started t ~timeout_sec with
          | Error _ as err -> err
          | Ok container_name ->
@@ -1201,10 +1223,10 @@ let append_file ~timeout_sec t ~host_path ~content () =
 ;;
 
 let cleanup (t : t) =
-  match t.state with
+  match get_state t with
   | Not_started -> ()
   | Running { container_name } ->
-    t.state <- Not_started;
+    set_state t Not_started;
     let rm_timeout =
       Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Cleanup_rm ()
     in

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -804,7 +804,7 @@ let start_container (t : t) ~timeout_sec =
                  container_name
              with
              | Ok () ->
-               set_state t Running { container_name };
+               set_state t (Running { container_name });
                Ok container_name
              | Error inspect_out ->
                (* Inspect failed after a successful `docker run`. Without an

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -23,9 +23,9 @@ let get_state t = Atomic.get t.state
 let set_state t state = Atomic.set t.state state
 
 module For_testing = struct
-  let create_minimal ~state =
-    { config = Obj.magic ()
-    ; meta = Obj.magic ()
+  let create_minimal ~config ~meta ~state =
+    { config
+    ; meta
     ; turn_id = 0
     ; raw_host_root = ""
     ; host_root = ""

--- a/lib/keeper/keeper_turn_sandbox_runtime.mli
+++ b/lib/keeper/keeper_turn_sandbox_runtime.mli
@@ -25,7 +25,12 @@ val cleanup : t -> unit
 (** Best-effort teardown. Safe to call multiple times. *)
 
 module For_testing : sig
-  val create_minimal : state:state -> t
+  val create_minimal
+    :  config:Workspace.config
+    -> meta:Keeper_meta_contract.keeper_meta
+    -> state:state
+    -> t
+
   val get_state : t -> state
   val set_state : t -> state -> unit
 end

--- a/lib/keeper/keeper_turn_sandbox_runtime.mli
+++ b/lib/keeper/keeper_turn_sandbox_runtime.mli
@@ -6,6 +6,10 @@
 
 type t
 
+type state =
+  | Not_started
+  | Running of { container_name : string }
+
 val create :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
@@ -19,6 +23,12 @@ val host_root : t -> string
 
 val cleanup : t -> unit
 (** Best-effort teardown. Safe to call multiple times. *)
+
+module For_testing : sig
+  val create_minimal : state:state -> t
+  val get_state : t -> state
+  val set_state : t -> state -> unit
+end
 
 val container_path_of_host :
   t -> host_path:string -> (string, string) result

--- a/test/dune
+++ b/test/dune
@@ -2179,3 +2179,10 @@
  (name test_keeper_unified_turn_event_bus)
  (modules test_keeper_unified_turn_event_bus)
  (libraries masc_test_deps masc.runtime))
+
+; Adversarial-review follow-ups: ref -> Atomic conversions (S5-S7).
+
+(test
+ (name test_keeper_misc_mutable_refs)
+ (modules test_keeper_misc_mutable_refs)
+ (libraries masc_test_deps masc.runtime))

--- a/test/test_keeper_misc_mutable_refs.ml
+++ b/test/test_keeper_misc_mutable_refs.ml
@@ -7,7 +7,12 @@ module KSR = Masc.Keeper_turn_sandbox_runtime
 module KSL = Masc.Keeper_supervisor_launch
 
 let test_sandbox_state_atomic () =
-  let t = KSR.For_testing.create_minimal ~state:Not_started in
+  let t =
+    KSR.For_testing.create_minimal
+      ~config:(Obj.magic ())
+      ~meta:(Obj.magic ())
+      ~state:Not_started
+  in
   check bool "initial state is Not_started" true
     (match KSR.For_testing.get_state t with
      | Not_started -> true

--- a/test/test_keeper_misc_mutable_refs.ml
+++ b/test/test_keeper_misc_mutable_refs.ml
@@ -1,0 +1,62 @@
+(** Regression tests for the mechanical [ref -> Atomic.t] conversions flagged
+    by the adversarial self-review (S5, S6, S7). *)
+
+open Alcotest
+
+module KSR = Masc.Keeper_turn_sandbox_runtime
+module KSL = Masc.Keeper_supervisor_launch
+
+let test_sandbox_state_atomic () =
+  let t = KSR.For_testing.create_minimal ~state:Not_started in
+  check bool "initial state is Not_started" true
+    (match KSR.For_testing.get_state t with
+     | Not_started -> true
+     | Running _ -> false);
+  KSR.For_testing.set_state t (Running { container_name = "c1" });
+  check bool "state updated atomically" true
+    (match KSR.For_testing.get_state t with
+     | Running { container_name } -> String.equal container_name "c1"
+     | Not_started -> false)
+;;
+
+let test_global_switch_atomic () =
+  check bool "global switch starts None" true (Option.is_none (KSL.get_global_switch ()));
+  (* We cannot create a real Eio.Switch in a unit test, so we use a dummy. *)
+  KSL.set_global_switch (Obj.magic 42);
+  check bool "global switch set" true (Option.is_some (KSL.get_global_switch ()));
+  KSL.set_global_switch (Obj.magic 43);
+  check bool "global switch overwritten" true (Option.is_some (KSL.get_global_switch ()))
+;;
+
+let test_seq_ref_unique_under_concurrent_updates () =
+  let seq_ref = Atomic.make 0 in
+  let n = 100 in
+  let domains =
+    List.init 4 (fun _ ->
+      Domain.spawn (fun () ->
+        let seqs = Array.make n 0 in
+        for i = 0 to n - 1 do
+          seqs.(i) <- Atomic.fetch_and_add seq_ref 1 + 1
+        done;
+        seqs))
+  in
+  let all_seqs = List.map Domain.join domains |> List.map Array.to_list |> List.concat in
+  check int "total generated sequences" (4 * n) (List.length all_seqs);
+  let unique = List.sort_uniq Int.compare all_seqs in
+  check int "all sequences unique" (4 * n) (List.length unique);
+  check int "max sequence" (4 * n) (List.fold_left max 0 all_seqs)
+;;
+
+let () =
+  Alcotest.run
+    "keeper-misc-mutable-refs"
+    [ ( "sandbox-state"
+      , [ test_case "atomic get/set" `Quick test_sandbox_state_atomic ] )
+    ; ( "supervisor-global-switch"
+      , [ test_case "atomic get/set" `Quick test_global_switch_atomic ] )
+    ; ( "manifest-seq"
+      , [ test_case "concurrent unique logical_seq" `Quick
+            test_seq_ref_unique_under_concurrent_updates
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary\n\nAddresses the mechanical mutable-ref findings from #21403:\n\n- **S5**: [Keeper_turn_sandbox_runtime.t.state] was still a mutable field updated at multiple lifecycle points. It is now [state Atomic.t].\n- **S6**: [Keeper_supervisor_launch.global_switch] was a bare [Eio.Switch.t option ref]. It is now an Atomic option.\n- **S7**: [make_append_manifest] closed over an [int ref] for logical sequence numbers, which could duplicate/reorder under concurrent callbacks. It now uses [int Atomic.t] and [Atomic.fetch_and_add].\n\n## Changes\n\n- Add minimal [For_testing] accessors for sandbox state.\n- Add focused regression tests for atomic state get/set, global-switch atomicity, and concurrent unique logical_seq generation.\n\n## Verification\n\n- [x] [dune build] for the four touched modules passes locally.\n- [ ] Full CI run.\n\nCloses #21403 (S5-S7 portion).