### PR TITLE
fix(dashboard): align stale tests with current shell/button output

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -28,7 +28,7 @@ describe('App v2 header chrome', () => {
     renderApp()
     const app = container.querySelector('.v2-app')
     expect(app).not.toBeNull()
-    expect(app?.getAttribute('data-shell-theme')).toBe('styleseed')
+    expect(app?.getAttribute('data-theme')).toBe('styleseed')
     expect(app?.getAttribute('data-density')).toBe('regular')
     expect(app?.getAttribute('data-motion')).toBe('subtle')
     expect(app?.getAttribute('data-bubble')).toBe('card')

--- a/dashboard/src/components/common/feedback-state.test.ts
+++ b/dashboard/src/components/common/feedback-state.test.ts
@@ -214,16 +214,15 @@ describe('ErrorFatal', () => {
     expect(container.querySelector('button')!.textContent).toContain('새로고침')
   })
 
-  it('uses the danger variant button (background tint)', () => {
+  it('uses the danger variant button (destructive outline)', () => {
     render(html`<${ErrorFatal} title="t" onReload=${() => {}} />`, container)
     const btn = container.querySelector('button')!
-    // ActionButton danger variant uses the component-level alias
-    // --button-danger-bg, which tokens.generated.ts resolves to
-    // var(--bad-10). Asserting on the literal classname keeps the
-    // test honest about what the component actually outputs (was
-    // missed in the cycle-34 migration to component-level aliases,
-    // commit c8011e3).
-    expect(btn.className).toContain('bg-[var(--button-danger-bg)]')
+    // ActionButton variant=danger now renders as a destructive outline
+    // (border-destructive/40, text-destructive, transparent bg with
+    // hover tint) rather than a filled background.
+    expect(btn.className).toContain('border-destructive/40')
+    expect(btn.className).toContain('text-destructive')
+    expect(btn.className).toContain('bg-transparent')
   })
 })
 


### PR DESCRIPTION
Two dashboard unit tests were asserting outdated implementation details that are already red on main after recent design-system migrations:

- `app.test.ts` looked for `data-shell-theme`, but `App` now renders `data-theme`.
- `feedback-state.test.ts` expected the old filled danger background (`--button-danger-bg`), but `ActionButton variant=danger` now outputs a destructive outline style.

This PR updates both assertions to match the current component output so the Dashboard CI job can pass again.

/cc @jeong-sik