### PR TITLE
feat(dashboard): add v2 high-contrast skin

### DIFF
--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -39,6 +39,8 @@
 @import "./v2-shell.css";
 @import "./app-shell-v2.css";
 @import "./v2-theme.css";
+@import "./v2-skin-tokens.css";
+@import "./v2-keeper-chat.css";
 @import "./keeper-turn-inspector.css";
 @import "./v2-logs.css";
 @import "./v2-overview.css";

--- a/dashboard/src/styles/v2-keeper-chat.css
+++ b/dashboard/src/styles/v2-keeper-chat.css
@@ -1,0 +1,1096 @@
+/* ── Reset for the keeper-chat shell ─────────────────────── */
+.v2-keeper-chat *{ box-sizing: border-box; }
+.v2-keeper-chat{
+  position: fixed; inset: 0;
+  display: flex; flex-direction: column;
+  background:
+    radial-gradient(1200px 600px at 80% -10%, rgba(224,176,87,0.04), transparent 60%),
+    radial-gradient(900px 500px at -5% 110%, rgba(232,71,47,0.05), transparent 60%),
+    var(--bg-deep);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  overflow: hidden;
+}
+.v2-keeper-chat .mono{ font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+
+/* ════ TOP BAR ════ */
+.v2-keeper-chat .v2-top{
+  display: flex; align-items: center; gap: 18px;
+  height: 50px; flex: none;
+  padding: 0 16px;
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+  border-bottom: 1px solid var(--border-main);
+  z-index: 20;
+}
+.v2-keeper-chat .v2-wordmark{ display: flex; align-items: baseline; gap: 9px; }
+.v2-keeper-chat .v2-wordmark b{
+  font-family: var(--font-display); font-weight: 400;
+  letter-spacing: 0.26em; font-size: 16px; color: var(--text-bright);
+}
+.v2-keeper-chat .v2-wordmark .ver{
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em;
+  color: var(--volt-ink); background: var(--volt); padding: 2px 6px; border-radius: var(--radius-sm);
+  font-weight: 600;
+}
+.v2-keeper-chat .v2-top .crumb{
+  font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--text-dim); display: flex; gap: 8px; align-items: center;
+}
+.v2-keeper-chat .v2-top .crumb .on{ color: var(--text-mid); }
+.v2-keeper-chat .v2-top-spacer{ flex: 1; }
+.v2-keeper-chat .v2-statchip{
+  display: inline-flex; align-items: center; gap: 7px;
+  font-size: 11px; letter-spacing: 0.04em;
+  padding: 5px 10px; border: 1px solid var(--border-main);
+  border-radius: var(--radius-pill); color: var(--text-mid);
+  background: var(--bg-panel-alt); white-space: nowrap;
+}
+.v2-keeper-chat .v2-statchip b{ color: var(--text-bright); font-weight: 600; }
+.v2-keeper-chat .v2-statchip.live{ color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 40%, transparent); }
+.v2-keeper-chat .v2-statchip.warn{ color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); }
+
+/* ════ BODY GRID ════ */
+.v2-keeper-chat .v2-body{
+  flex: 1; min-height: 0;
+  display: grid;
+  grid-template-columns: var(--nav-w, 58px) var(--roster-w, 286px) 1fr var(--ctx-w, 312px);
+}
+.v2-keeper-chat .v2-body.no-ctx{ grid-template-columns: var(--nav-w, 58px) var(--roster-w, 286px) 1fr 0; }
+
+/* ════ APP NAV RAIL (main menu) ════ */
+.v2-keeper-chat .v2-nav{
+  display: flex; flex-direction: column; align-items: center; gap: 3px;
+  padding: 10px 0 12px; border-right: 1px solid var(--border-main);
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+}
+.v2-keeper-chat .nav-home{
+  width: 38px; height: 38px; border-radius: var(--radius-sm); margin-bottom: 9px;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-display); font-weight: 700; font-size: 16px;
+  color: var(--volt-ink); background: var(--volt); cursor: default;
+  box-shadow: 0 0 14px var(--volt-glow); transition: 0.14s;
+}
+.v2-keeper-chat .nav-home:hover{ filter: none; }
+.v2-keeper-chat .nav-brand{ display: flex; flex-direction: column; align-items: center; gap: 3px; margin-bottom: 8px; }
+.v2-keeper-chat .nav-brand .nav-home{ margin-bottom: 0; }
+.v2-keeper-chat .nav-brand .nlbl{ font-size: 8.5px; letter-spacing: 0.06em; color: var(--text-dim); }
+.v2-keeper-chat .nav-item{
+  width: 46px; height: 48px; border-radius: var(--radius-sm); cursor: pointer;
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px;
+  color: var(--text-dim); border: 1px solid transparent; background: transparent;
+  transition: 0.14s; position: relative;
+}
+.v2-keeper-chat .nav-item svg{ width: 19px; height: 19px; }
+.v2-keeper-chat .nav-item .nlbl{ font-size: 8.5px; letter-spacing: 0.02em; }
+.v2-keeper-chat .nav-item:hover{ color: var(--text-bright); background: var(--bg-card); }
+.v2-keeper-chat .nav-item.on{ color: var(--volt-strong); background: var(--bg-card); }
+.v2-keeper-chat .nav-item.on::before{ content: ""; position: absolute; left: -10px; top: 10px; bottom: 10px; width: 3px; background: var(--volt); border-radius: 0 3px 3px 0; box-shadow: 0 0 10px var(--volt-glow); }
+.v2-keeper-chat .nav-spacer{ flex: 1; }
+
+/* avatar fallback (keeper without a portrait) */
+.v2-keeper-chat .is-fallback{
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono); font-weight: 600; letter-spacing: 0.02em;
+  color: hsl(var(--ah, 40) 62% 80%);
+  background: linear-gradient(135deg, hsl(var(--ah,40) 34% 18%), hsl(var(--ah,40) 30% 10%));
+  border: 1px solid hsl(var(--ah,40) 40% 33%);
+}
+.v2-keeper-chat .kp-av.is-fallback{ font-size: 13px; }
+.v2-keeper-chat .chat-av.is-fallback{ font-size: 17px; }
+.v2-keeper-chat .msg-av.is-fallback{ font-size: 12px; }
+
+/* ════ KEEPER SIGIL BADGE (canonical identity: slot color + 2-letter monogram) ════ */
+.v2-keeper-chat{
+  --kp1:#e0b057; --kp2:#d9743f; --kp3:#e0a82e; --kp4:#c64f6d;
+  --kp5:#8a6cf0; --kp6:#46c66a; --kp7:#5fb0c4; --kp8:#9aa83f;
+  --kp9:#5b9cf0; --kp10:#c569d4; --kp11:#8a7bf0; --kp12:#d98a4f;
+}
+.v2-keeper-chat .sigil{
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono); font-weight: 700; letter-spacing: 0; flex: none;
+  color: #0b0c10; background: var(--kc, var(--kp1));
+  border-radius: var(--radius-sm);
+}
+.v2-keeper-chat .sigil.heartbeat{ box-shadow: 0 0 8px color-mix(in oklab, var(--kc, var(--kp1)) 70%, transparent); animation: sg-beat 1.5s ease-in-out infinite; }
+@keyframes sg-beat { 0%,100% { box-shadow: 0 0 6px color-mix(in oklab, var(--kc) 55%, transparent); } 50% { box-shadow: 0 0 13px color-mix(in oklab, var(--kc) 85%, transparent); } }
+.v2-keeper-chat .sigil-chip{
+  display: inline-flex; align-items: center; gap: 6px; flex: none; white-space: nowrap;
+  font-family: var(--font-mono); font-size: 11px; color: var(--kc, var(--kp1));
+  padding: 2px 8px 2px 3px; border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in oklab, var(--kc, var(--kp1)) 40%, var(--border-main));
+  background: color-mix(in oklab, var(--kc, var(--kp1)) 9%, transparent);
+}
+.v2-keeper-chat .sigil-chip .sigil{ width: 17px; height: 17px; font-size: 9px; }
+
+/* ════ ROSTER RAIL ════ */
+.v2-keeper-chat .roster{
+  border-right: 1px solid var(--border-main);
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 60%);
+  display: flex; flex-direction: column; min-height: 0;
+}
+.v2-keeper-chat .roster-head{ padding: 11px 12px 11px; border-bottom: 1px solid var(--border-soft); }
+.v2-keeper-chat .roster-title{ display: flex; align-items: center; justify-content: space-between; margin-bottom: 11px; }
+.v2-keeper-chat .roster-title h3{
+  font-family: var(--font-display); font-weight: 400; text-transform: uppercase;
+  letter-spacing: 0.2em; font-size: 13px; color: var(--text-bright); margin: 0;
+}
+.v2-keeper-chat .roster-title .count{
+  font-family: var(--font-mono); font-size: 11px; color: var(--text-dim);
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  padding: 2px 7px; border-radius: var(--radius-pill);
+}
+.v2-keeper-chat .roster-search{
+  width: 100%; font-family: var(--font-ui); font-size: 12.5px;
+  padding: 8px 11px; background: var(--bg-sunken); color: var(--text-primary);
+  border: 1px solid var(--border-main); border-radius: var(--radius-sm);
+  outline: none;
+}
+.v2-keeper-chat .roster-search:focus{ border-color: var(--volt-dim); box-shadow: 0 0 0 2px var(--volt-wash); }
+.v2-keeper-chat .roster-search::placeholder{ color: var(--text-dim); }
+
+.v2-keeper-chat .roster-filters{ display: flex; gap: 5px; padding: 10px 12px; flex-wrap: wrap; border-bottom: 1px solid var(--border-soft); }
+.v2-keeper-chat .rfilter{
+  font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 4px 9px; border-radius: var(--radius-pill); cursor: pointer;
+  border: 1px solid var(--border-main); background: transparent; color: var(--text-dim);
+  font-family: var(--font-ui); transition: 0.15s; display: inline-flex; gap: 5px; align-items: center;
+}
+.v2-keeper-chat .rfilter:hover{ color: var(--text-mid); border-color: var(--border-highlight); }
+.v2-keeper-chat .rfilter.on{ color: var(--volt-ink); background: var(--volt); border-color: var(--volt); font-weight: 600; }
+.v2-keeper-chat .rfilter .n{ opacity: 0.7; }
+
+.v2-keeper-chat .roster-list{ flex: 1; overflow-y: auto; padding: 6px; }
+.v2-keeper-chat .roster-group{
+  font-size: 9.5px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--text-dim);
+  padding: 12px 8px 5px;
+}
+.v2-keeper-chat .kp-row{
+  display: grid; grid-template-columns: 38px 1fr auto; gap: 10px; align-items: center;
+  padding: 8px 9px; border-radius: var(--radius-sm); cursor: pointer;
+  border: 1px solid transparent; transition: background 0.14s, border-color 0.14s;
+  position: relative;
+}
+.v2-keeper-chat .kp-row:hover{ background: var(--bg-card); }
+.v2-keeper-chat .kp-row.sel{ background: var(--bg-card); border-color: var(--volt-dim); box-shadow: inset 0 0 0 1px var(--volt-wash); }
+.v2-keeper-chat .kp-row.sel::before{
+  content: ""; position: absolute; left: -6px; top: 8px; bottom: 8px; width: 3px;
+  background: var(--volt); border-radius: 0 3px 3px 0; box-shadow: 0 0 10px var(--volt-glow);
+}
+.v2-keeper-chat .kp-av{
+  width: 38px; height: 38px; border-radius: var(--radius-sm); object-fit: cover;
+  border: 1px solid var(--border-highlight); filter: saturate(0.92) contrast(1.04);
+  background: var(--bg-sunken); font-size: 14px;
+}
+.v2-keeper-chat .kp-meta{ min-width: 0; }
+.v2-keeper-chat .kp-name{ font-family: var(--font-display); font-weight: 600; font-size: 13.5px; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.v2-keeper-chat .kp-handle{ font-family: var(--font-mono); font-size: 10.5px; color: var(--text-mid); }
+.v2-keeper-chat .kp-sub{ display: flex; align-items: center; gap: 6px; font-size: 10.5px; color: var(--text-dim); margin-top: 2px; }
+.v2-keeper-chat .kp-state{ display: inline-flex; align-items: center; gap: 5px; }
+.v2-keeper-chat .kp-right{ display: flex; flex-direction: column; align-items: flex-end; gap: 4px; }
+.v2-keeper-chat .kp-time{ font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+.v2-keeper-chat .kp-att{
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 600;
+  min-width: 16px; text-align: center; padding: 1px 5px; border-radius: var(--radius-pill);
+  color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 16%, transparent);
+  border: 1px solid color-mix(in oklab, var(--status-bad) 35%, transparent);
+}
+
+/* status dot */
+.v2-keeper-chat .dot2{ width: 7px; height: 7px; border-radius: 50%; display: inline-block; flex: none; background: var(--status-idle); }
+.v2-keeper-chat .dot2.ok{ background: var(--status-ok);   box-shadow: 0 0 7px var(--status-ok); }
+.v2-keeper-chat .dot2.warn{ background: var(--status-warn); box-shadow: 0 0 7px var(--status-warn); }
+.v2-keeper-chat .dot2.bad{ background: var(--status-bad);  box-shadow: 0 0 7px var(--status-bad); }
+.v2-keeper-chat .dot2.busy{ background: var(--status-busy); box-shadow: 0 0 7px var(--status-busy); }
+.v2-keeper-chat .dot2.pulse{ animation: dot-pulse 1.8s ease-in-out infinite; }
+@keyframes dot-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+/* ════ CHAT MAIN ════ */
+.v2-keeper-chat .chat{ display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--bg-deep); }
+
+.v2-keeper-chat .chat-head{
+  flex: none; padding: 13px 20px 12px;
+  border-bottom: 1px solid var(--border-main);
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+  display: flex; align-items: center; gap: 14px;
+}
+.v2-keeper-chat .chat-av{
+  width: 46px; height: 46px; border-radius: var(--radius-md); object-fit: cover;
+  border: 1px solid var(--border-highlight); flex: none;
+  box-shadow: 0 0 0 1px var(--bg-deep), 0 0 18px rgba(0,0,0,0.5);
+  filter: saturate(0.95) contrast(1.05);
+}
+.v2-keeper-chat .chat-av[data-sigil]{ display: flex; align-items: center; justify-content: center; padding: 0; border: 0; box-shadow: none; filter: none; background: transparent; }
+.v2-keeper-chat .chat-av[data-sigil] .sigil{ width: 46px; height: 46px; border-radius: var(--radius-md); font-size: 18px; }
+.v2-keeper-chat .chat-id{ min-width: 0; flex: 1; }
+.v2-keeper-chat .chat-id .name-row{ display: flex; align-items: center; gap: 11px; flex-wrap: wrap; }
+.v2-keeper-chat .chat-id h2{
+  font-family: var(--font-display); font-weight: 400; text-transform: none;
+  letter-spacing: 0.02em; font-size: 20px; color: var(--text-bright); margin: 0; white-space: nowrap;
+}
+.v2-keeper-chat .chat-id .slug{ font-family: var(--font-mono); font-size: 12px; color: var(--text-dim); }
+.v2-keeper-chat .chat-id .sub{ display: flex; align-items: center; gap: 10px; margin-top: 5px; font-size: 11px; color: var(--text-dim); flex-wrap: wrap; }
+.v2-keeper-chat .chat-id .sub > span{ white-space: nowrap; }
+
+.v2-keeper-chat .state-pill{
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11px; letter-spacing: 0.04em; padding: 4px 10px; border-radius: var(--radius-pill);
+  background: var(--bg-card); border: 1px solid var(--border-main); color: var(--text-mid);
+}
+.v2-keeper-chat .state-pill.run{ color: var(--status-ok);  border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); background: color-mix(in oklab, var(--status-ok) 10%, var(--bg-card)); }
+.v2-keeper-chat .state-pill.pause{ color: var(--status-warn);border-color: color-mix(in oklab, var(--status-warn) 45%, transparent); }
+.v2-keeper-chat .state-pill.off{ color: var(--text-dim); }
+.v2-keeper-chat .fsm-chip{
+  font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.04em;
+  padding: 3px 8px; border-radius: var(--radius-sm); color: var(--text-mid);
+  background: var(--bg-card); border: 1px solid var(--border-main);
+}
+
+.v2-keeper-chat .chat-actions{ display: flex; gap: 7px; align-items: center; flex: none; }
+.v2-keeper-chat .act{
+  font-family: var(--font-ui); font-size: 11px; letter-spacing: 0.05em;
+  padding: 7px 12px; border-radius: var(--radius-sm); cursor: pointer;
+  border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-mid);
+  transition: 0.15s; white-space: nowrap;
+}
+.v2-keeper-chat .act:hover{ color: var(--text-bright); border-color: var(--border-highlight); background: var(--bg-card-hover); }
+.v2-keeper-chat .act.danger:hover{ color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 50%, transparent); }
+.v2-keeper-chat .act.icon{ padding: 7px 9px; }
+
+/* meta strip */
+.v2-keeper-chat .chat-meta{
+  flex: none; display: flex; align-items: center; gap: 0;
+  padding: 0 20px; height: 34px;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--bg-sunken);
+  overflow-x: auto;
+}
+.v2-keeper-chat .meta-cell{ display: flex; align-items: center; gap: 7px; padding-right: 18px; margin-right: 18px; border-right: 1px solid var(--border-soft); white-space: nowrap; }
+.v2-keeper-chat .meta-cell:last-child{ border-right: 0; }
+.v2-keeper-chat .meta-cell .k{ font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-dim); }
+.v2-keeper-chat .meta-cell .v{ font-family: var(--font-mono); font-size: 11px; color: var(--text-mid); }
+.v2-keeper-chat .meta-cell .v.volt{ color: var(--volt-strong); }
+
+/* thread */
+.v2-keeper-chat .thread{ flex: 1; overflow-y: auto; padding: 22px 0 8px; }
+.v2-keeper-chat .thread-inner{ max-width: var(--thread-w, 980px); margin: 0 auto; padding: 0 28px; display: flex; flex-direction: column; gap: 22px; }
+
+.v2-keeper-chat .daydiv{ display: flex; align-items: center; gap: 12px; color: var(--text-dim); font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; }
+.v2-keeper-chat .daydiv::before, .v2-keeper-chat .daydiv::after{ content: ""; height: 1px; flex: 1; background: var(--border-soft); }
+
+/* message */
+.v2-keeper-chat .msg{ display: grid; grid-template-columns: 34px 1fr; gap: 13px; }
+.v2-keeper-chat .msg-av{ width: 34px; height: 34px; border-radius: var(--radius-sm); object-fit: cover; border: 1px solid var(--border-highlight); filter: saturate(0.95) contrast(1.05); }
+.v2-keeper-chat .msg-av.op{ display: flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 11px; color: var(--volt-ink); background: var(--volt); border-color: var(--volt); }
+.v2-keeper-chat .msg-col{ min-width: 0; }
+.v2-keeper-chat .msg-hd{ display: flex; align-items: center; gap: 9px; margin-bottom: 6px; }
+.v2-keeper-chat .msg-hd .who{ font-family: var(--font-display); font-weight: 600; font-size: 13px; color: var(--text-bright); white-space: nowrap; }
+.v2-keeper-chat .msg-hd .whoh{ font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.v2-keeper-chat .msg-hd .ts{ font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.v2-keeper-chat .src-badge{
+  font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 2px 6px; border-radius: var(--radius-xs); color: var(--text-mid);
+  background: var(--bg-card); border: 1px solid var(--border-main);
+}
+.v2-keeper-chat .src-badge.dashboard{ color: var(--volt-strong); border-color: var(--volt-dim); }
+.v2-keeper-chat .src-badge.discord{ color: #8a9bf0; border-color: #3a3d6a; }
+.v2-keeper-chat .src-badge.slack{ color: #5fc7b0; border-color: #2c5a52; }
+.v2-keeper-chat .src-badge.imessage{ color: #6aa6ef; border-color: #2c4a6a; }
+
+/* assistant bubble */
+.v2-keeper-chat .bubble{
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  border-radius: 4px 12px 12px 12px; padding: 14px 16px;
+  color: var(--text-primary); line-height: 1.62; font-family: var(--font-body); font-size: 15px;
+}
+.v2-keeper-chat .bubble.user{
+  background: var(--volt-wash); border-color: var(--volt-dim);
+  border-radius: 12px 4px 12px 12px; color: var(--text-bright);
+}
+.v2-keeper-chat .msg.from-user{ grid-template-columns: 1fr 34px; }
+.v2-keeper-chat .msg.from-user .msg-col{ order: 0; }
+.v2-keeper-chat .msg.from-user .msg-av{ order: 1; }
+.v2-keeper-chat .msg.from-user .msg-hd{ justify-content: flex-end; }
+
+.v2-keeper-chat .bubble p{ margin: 0 0 10px; color: var(--text-primary); }
+.v2-keeper-chat .bubble p:last-child{ margin-bottom: 0; }
+.v2-keeper-chat .bubble strong{ color: var(--text-bright); font-weight: 600; }
+.v2-keeper-chat .bubble h4{ font-family: var(--font-ui); text-transform: none; letter-spacing: 0; font-size: 14px; color: var(--text-bright); margin: 4px 0 9px; }
+.v2-keeper-chat .bubble ul{ margin: 0 0 10px; padding-left: 18px; }
+.v2-keeper-chat .bubble li{ margin: 3px 0; color: var(--text-primary); }
+.v2-keeper-chat .bubble li::marker{ color: var(--volt); }
+.v2-keeper-chat .bubble code{ font-family: var(--font-mono); font-size: 12.5px; background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 1px 5px; border-radius: var(--radius-sm); color: var(--volt-strong); }
+.v2-keeper-chat .bubble hr{ border: 0; border-top: 1px solid var(--border-soft); margin: 13px 0; }
+
+.v2-keeper-chat .callout{
+  display: flex; gap: 9px; padding: 10px 12px; margin: 10px 0;
+  border-radius: var(--radius-sm); font-size: 13.5px; line-height: 1.5;
+  background: color-mix(in oklab, var(--status-warn) 9%, var(--bg-sunken));
+  border: 1px solid color-mix(in oklab, var(--status-warn) 36%, transparent);
+  color: var(--text-primary);
+}
+.v2-keeper-chat .callout .ico{ color: var(--status-warn); flex: none; }
+
+/* markdown table */
+.v2-keeper-chat .md-table{ width: 100%; border-collapse: collapse; margin: 8px 0 10px; font-family: var(--font-ui); font-size: 13px; }
+.v2-keeper-chat .md-table th, .v2-keeper-chat .md-table td{ text-align: left; padding: 8px 12px; border-bottom: 1px solid var(--border-soft); }
+.v2-keeper-chat .md-table thead th{ font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); font-weight: 600; border-bottom: 1px solid var(--border-main); }
+.v2-keeper-chat .md-table tbody tr:hover{ background: var(--bg-panel-alt); }
+.v2-keeper-chat .md-table td.num, .v2-keeper-chat .md-table th.num{ font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.v2-keeper-chat .md-table .muted{ color: var(--text-dim); }
+
+/* feedback row */
+.v2-keeper-chat .fbk{ display: flex; align-items: center; gap: 4px; margin-top: 9px; }
+.v2-keeper-chat .fbk-btn{
+  display: inline-flex; align-items: center; gap: 5px; cursor: pointer;
+  padding: 5px 8px; border-radius: var(--radius-xs); border: 1px solid transparent;
+  background: transparent; color: var(--text-dim); font-family: var(--font-ui); font-size: 11px; transition: 0.14s;
+  white-space: nowrap;
+}
+.v2-keeper-chat .fbk-btn:hover{ color: var(--text-mid); background: var(--bg-card); }
+.v2-keeper-chat .fbk-btn.on{ color: var(--volt-strong); }
+.v2-keeper-chat .fbk-verify{ margin-left: auto; display: inline-flex; align-items: center; gap: 6px; font-size: 11px; color: var(--status-ok); }
+
+/* tool trace */
+.v2-keeper-chat .tool{
+  border: 1px solid var(--border-main); border-radius: var(--radius-sm);
+  background: var(--bg-sunken); overflow: hidden; margin-top: 2px;
+}
+.v2-keeper-chat .tool-hd{
+  display: flex; align-items: center; gap: 10px; padding: 9px 12px; cursor: pointer;
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-mid); transition: 0.14s;
+}
+.v2-keeper-chat .tool-hd:hover{ background: var(--bg-panel-alt); }
+.v2-keeper-chat .tool-hd .chev{ transition: transform 0.18s; color: var(--text-dim); }
+.v2-keeper-chat .tool.open .tool-hd .chev{ transform: rotate(90deg); }
+.v2-keeper-chat .tool-hd .tname{ color: var(--text-bright); }
+.v2-keeper-chat .tool-hd .tdot{ margin-left: auto; }
+.v2-keeper-chat .tool-hd .tdur{ color: var(--text-dim); font-size: 11px; }
+.v2-keeper-chat .tool-body{ padding: 0 12px 12px; display: none; }
+.v2-keeper-chat .tool.open .tool-body{ display: block; }
+.v2-keeper-chat .tool-kv{ display: grid; grid-template-columns: 70px 1fr; gap: 4px 12px; font-family: var(--font-mono); font-size: 11.5px; padding: 9px 0 0; }
+.v2-keeper-chat .tool-kv .tk{ color: var(--text-dim); }
+.v2-keeper-chat .tool-kv .tv{ color: var(--text-mid); word-break: break-word; }
+.v2-keeper-chat .tool pre{
+  margin: 9px 0 0; padding: 10px; background: #06070a; border: 1px solid var(--border-soft);
+  border-radius: var(--radius-xs); font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid);
+  overflow-x: auto; line-height: 1.55;
+}
+.v2-keeper-chat .tool pre .jk{ color: var(--volt-strong); }
+.v2-keeper-chat .tool pre .js{ color: var(--status-ok); }
+
+/* agent trace group — bundles thinking / reasoning / tool steps into one block */
+.v2-keeper-chat .trace{ border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-sunken); overflow: hidden; }
+.v2-keeper-chat .trace-hd{
+  display: flex; align-items: center; gap: 9px; padding: 9px 12px; cursor: pointer;
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-mid); transition: background 0.14s;
+}
+.v2-keeper-chat .trace-hd:hover{ background: var(--bg-panel-alt); }
+.v2-keeper-chat .trace-hd .chev{ color: var(--text-dim); transition: transform 0.18s; font-size: 9px; }
+.v2-keeper-chat .trace.open > .trace-hd .chev{ transform: rotate(90deg); }
+.v2-keeper-chat .trace-hd .glyph{ color: var(--volt); font-size: 11px; }
+.v2-keeper-chat .trace-hd .tlabel{ color: var(--text-bright); font-family: var(--font-ui); letter-spacing: 0.13em; text-transform: uppercase; font-size: 11px; }
+.v2-keeper-chat .trace-hd .tcount{ color: var(--text-dim); }
+.v2-keeper-chat .trace-hd .tmeta{ margin-left: auto; display: flex; align-items: center; gap: 12px; color: var(--text-dim); font-size: 11px; }
+.v2-keeper-chat .trace-hd .tmeta .mono{ color: var(--text-mid); }
+
+.v2-keeper-chat .trace-steps{ display: none; position: relative; padding: 8px 12px 12px 14px; }
+.v2-keeper-chat .trace.open > .trace-steps{ display: block; }
+.v2-keeper-chat .trace-rail{ position: absolute; left: 19px; top: 14px; bottom: 18px; width: 1px; background: var(--border-main); }
+
+.v2-keeper-chat .tstep{ position: relative; padding-left: 18px; }
+.v2-keeper-chat .tstep + .tstep{ margin-top: 10px; }
+.v2-keeper-chat .tnode{
+  position: absolute; left: 0; top: 4px; width: 11px; height: 11px; border-radius: 50%;
+  background: var(--bg-sunken); border: 1.5px solid var(--text-dim); box-sizing: border-box; z-index: 1;
+}
+.v2-keeper-chat .tstep.think .tnode{ border-style: dotted; }
+.v2-keeper-chat .tstep.reason .tnode{ border-color: var(--info); }
+.v2-keeper-chat .tstep.tool .tnode{ border-color: var(--volt); background: var(--volt); box-shadow: 0 0 0 2px var(--bg-sunken); }
+
+.v2-keeper-chat .tstep-main{ min-width: 0; flex: 1; }
+.v2-keeper-chat .tstep-row{ display: flex; align-items: center; gap: 8px; }
+.v2-keeper-chat .tstep-row.click{ cursor: pointer; }
+.v2-keeper-chat .tstep-kind{
+  font-family: var(--font-ui); text-transform: uppercase; letter-spacing: 0.1em;
+  font-size: 9.5px; line-height: 1.5; flex: none;
+}
+.v2-keeper-chat .tstep.think .tstep-kind{ color: var(--text-dim); }
+.v2-keeper-chat .tstep.reason .tstep-kind{ color: var(--info); }
+.v2-keeper-chat .tstep.tool .tstep-kind{ color: var(--volt); }
+.v2-keeper-chat .tstep-text{ font-family: var(--font-body); font-size: 12.5px; color: var(--text-primary); line-height: 1.5; min-width: 0; }
+.v2-keeper-chat .tstep.think .tstep-text{ color: var(--text-mid); font-style: italic; }
+.v2-keeper-chat .tstep .tname{ color: var(--text-bright); font-size: 12px; }
+.v2-keeper-chat .tstep .tdur{ color: var(--text-dim); font-size: 11px; }
+.v2-keeper-chat .tstep-row .chev.sm{ margin-left: auto; color: var(--text-dim); font-size: 8px; transition: transform 0.18s; flex: none; }
+.v2-keeper-chat .tstep.exp .tstep-row .chev.sm{ transform: rotate(90deg); }
+.v2-keeper-chat .tstep .dot2{ flex: none; }
+
+.v2-keeper-chat .reason-detail{
+  margin-top: 7px; padding: 9px 12px; border-left: 2px solid var(--info-dim);
+  background: color-mix(in oklab, var(--info) 7%, transparent);
+  font-family: var(--font-body); font-size: 12.5px; line-height: 1.62; color: var(--text-mid);
+  border-radius: 0 var(--radius-xs) var(--radius-xs) 0;
+}
+.v2-keeper-chat .reason-detail code{ font-family: var(--font-mono); font-size: 11.5px; color: var(--info); }
+.v2-keeper-chat .reason-detail strong{ color: var(--text-bright); }
+
+.v2-keeper-chat .tool-body2{ margin-top: 8px; }
+.v2-keeper-chat .tool-body2 .tk{ font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.1em; margin-top: 9px; }
+.v2-keeper-chat .tool-body2 .tk:first-child{ margin-top: 0; }
+.v2-keeper-chat .tool-body2 pre{
+  margin: 4px 0 0; padding: 10px; background: #06070a; border: 1px solid var(--border-soft);
+  border-radius: var(--radius-xs); font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid);
+  overflow-x: auto; line-height: 1.55;
+}
+.v2-keeper-chat .tool-body2 pre .jk{ color: var(--volt-strong); }
+.v2-keeper-chat .tool-body2 pre .js{ color: var(--status-ok); }
+
+/* attention section (ctx rail) — what needs the operator's attention, and where */
+.v2-keeper-chat .att-count{
+  font-family: var(--font-mono); font-size: 10px; color: var(--status-bad);
+  border: 1px solid color-mix(in oklab, var(--status-bad) 40%, transparent);
+  background: color-mix(in oklab, var(--status-bad) 12%, transparent);
+  padding: 0 6px; border-radius: var(--radius-pill); margin-left: 7px; vertical-align: middle;
+}
+.v2-keeper-chat .att-list{ display: flex; flex-direction: column; gap: 6px; }
+.v2-keeper-chat .att-item{
+  display: flex; align-items: flex-start; gap: 8px; padding: 8px 10px;
+  background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm);
+  font-size: 12px; line-height: 1.45; color: var(--text-primary);
+}
+.v2-keeper-chat .att-item .att-dot{ width: 6px; height: 6px; border-radius: 50%; margin-top: 5px; flex: none; }
+.v2-keeper-chat .att-item.warn{ border-left: 2px solid var(--status-warn); }
+.v2-keeper-chat .att-item.warn .att-dot{ background: var(--status-warn); box-shadow: 0 0 6px var(--status-warn); }
+.v2-keeper-chat .att-item.bad{ border-left: 2px solid var(--status-bad); }
+.v2-keeper-chat .att-item.bad .att-dot{ background: var(--status-bad); box-shadow: 0 0 6px var(--status-bad); }
+
+/* turn inspector drawer — full injected prompt + context for one turn */
+.v2-keeper-chat .fbk-btn.inspect{ margin-left: 4px; color: var(--info); border-color: color-mix(in oklab, var(--info) 30%, transparent); }
+.v2-keeper-chat .fbk-btn.inspect:hover{ color: var(--info); border-color: var(--info); }
+.v2-keeper-chat .turn-overlay{ position: fixed; inset: 0; background: rgba(4,5,8,0.55); z-index: 90; display: flex; justify-content: flex-end; }
+.v2-keeper-chat .turn-drawer{
+  width: min(560px, 94vw); height: 100%; background: var(--bg-panel);
+  border-left: 1px solid var(--border-main); box-shadow: -8px 0 30px rgba(0,0,0,0.5);
+  display: flex; flex-direction: column; animation: turn-in 0.18s ease;
+}
+@keyframes turn-in { from { transform: translateX(24px); opacity: 0; } to { transform: none; opacity: 1; } }
+.v2-keeper-chat .turn-hd{ display: flex; align-items: center; gap: 10px; padding: 14px 16px; border-bottom: 1px solid var(--border-main); }
+.v2-keeper-chat .turn-hd h3{ font-family: var(--font-display); text-transform: uppercase; letter-spacing: 0.14em; font-size: 13px; color: var(--text-bright); margin: 0; }
+.v2-keeper-chat .turn-hd .tid{ font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
+.v2-keeper-chat .turn-close{ margin-left: auto; background: none; border: 1px solid var(--border-main); color: var(--text-mid); width: 26px; height: 26px; border-radius: var(--radius-sm); cursor: pointer; font-size: 12px; transition: 0.14s; }
+.v2-keeper-chat .turn-close:hover{ border-color: var(--volt-dim); color: var(--volt); }
+.v2-keeper-chat .turn-tabs{ display: flex; gap: 5px; padding: 9px 14px; border-bottom: 1px solid var(--border-soft); }
+.v2-keeper-chat .turn-tab{ font-family: var(--font-ui); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; padding: 6px 12px; border: 1px solid transparent; border-radius: var(--radius-sm); color: var(--text-dim); background: none; cursor: pointer; transition: 0.14s; }
+.v2-keeper-chat .turn-tab:hover{ color: var(--text-mid); }
+.v2-keeper-chat .turn-tab.on{ color: var(--volt); border-color: var(--volt-dim); background: var(--volt-wash); }
+.v2-keeper-chat .turn-body{ flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 16px; }
+.v2-keeper-chat .turn-sec h4{ font-family: var(--font-ui); text-transform: uppercase; letter-spacing: 0.1em; font-size: 10px; color: var(--text-dim); margin: 0 0 8px; }
+.v2-keeper-chat .turn-pre{ margin: 0; padding: 12px 13px; background: var(--bg-sunken); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: 11.5px; line-height: 1.62; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+.v2-keeper-chat .turn-thread{ display: flex; flex-direction: column; gap: 9px; }
+.v2-keeper-chat .turn-msg{ border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
+.v2-keeper-chat .turn-msg .role{ font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.1em; padding: 5px 10px; background: var(--bg-panel-alt); color: var(--text-dim); border-bottom: 1px solid var(--border-soft); }
+.v2-keeper-chat .turn-msg .role.system{ color: var(--info); }
+.v2-keeper-chat .turn-msg .role.user{ color: var(--volt); }
+.v2-keeper-chat .turn-msg .role.tool{ color: var(--status-ok); }
+.v2-keeper-chat .turn-msg .role.assistant{ color: var(--text-bright); }
+.v2-keeper-chat .turn-msg .body{ padding: 9px 11px; font-family: var(--font-mono); font-size: 11.5px; line-height: 1.55; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+.v2-keeper-chat .turn-kv{ display: grid; grid-template-columns: 130px 1fr; gap: 8px 12px; font-family: var(--font-mono); font-size: 12px; }
+.v2-keeper-chat .turn-kv .k{ color: var(--text-dim); }
+.v2-keeper-chat .turn-kv .v{ color: var(--text-bright); }
+
+/* keeper config drawer */
+.v2-keeper-chat .kc-text{ width: 100%; font-family: var(--font-body); font-size: 13px; line-height: 1.55; padding: 10px 12px; background: var(--bg-sunken); color: var(--text-primary); border: 1px solid var(--border-main); border-radius: var(--radius-sm); outline: none; resize: vertical; }
+.v2-keeper-chat .kc-text:focus{ border-color: var(--volt-dim); box-shadow: 0 0 0 2px var(--volt-wash); }
+.v2-keeper-chat .kc-traits{ display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.v2-keeper-chat .kc-trait{ font-family: var(--font-ui); font-size: 10.5px; color: var(--volt-strong); border: 1px solid var(--volt-dim); background: var(--volt-wash); padding: 2px 9px; border-radius: var(--radius-pill); }
+.v2-keeper-chat .kc-save{ width: 100%; margin-top: 4px; padding: 11px; background: var(--volt); color: var(--volt-ink); border: 0; border-radius: var(--radius-sm); font-family: var(--font-ui); font-weight: 600; font-size: 13px; cursor: pointer; transition: 0.14s; }
+.v2-keeper-chat .kc-save:hover{ filter: brightness(1.06); }
+.v2-keeper-chat .turn-sec .set-row{ padding: 8px 0; }
+.v2-keeper-chat .kc-codectx{ display: flex; flex-direction: column; gap: 8px; }
+.v2-keeper-chat .kc-cc-row{ display: flex; align-items: center; gap: 10px; }
+.v2-keeper-chat .kc-cc-row .sub-k{ min-width: 92px; }
+.v2-keeper-chat .kc-cc-row .mono{ font-size: 12px; color: var(--text-bright); }
+.v2-keeper-chat .kc-cc-row .set-input{ flex: 1; }
+.v2-keeper-chat .kc-fact-note{ font-size: 11px; color: var(--text-dim); margin: -2px 0 9px; }
+.v2-keeper-chat .kc-inherit{ display: flex; flex-direction: column; gap: 7px; padding: 10px 11px; background: var(--bg-sunken); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); }
+.v2-keeper-chat .kc-inh-row{ display: flex; align-items: baseline; gap: 9px; min-width: 0; }
+.v2-keeper-chat .kc-inh-tag{ flex: none; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.04em; color: var(--text-mid); min-width: 64px; }
+.v2-keeper-chat .kc-inh-txt{ flex: 1; min-width: 0; font-size: 11.5px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.v2-keeper-chat .kc-inh-note{ margin-top: 2px; padding-top: 8px; border-top: 1px solid var(--border-soft); font-size: 10.5px; color: var(--text-dim); }
+
+/* web link unfurl card (chat) */
+.v2-keeper-chat .linkcard{ display: flex; align-items: flex-start; gap: 11px; margin-top: 10px; padding: 11px 13px; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); text-decoration: none; transition: border-color 0.18s ease, background 0.18s ease; max-width: 520px; }
+.v2-keeper-chat .linkcard:hover{ border-color: var(--volt-dim); background: color-mix(in oklab, var(--volt) 5%, var(--bg-card)); }
+.v2-keeper-chat .linkcard-fav{ flex: none; width: 30px; height: 30px; display: grid; place-items: center; border-radius: var(--radius-xs); background: var(--bg-sunken); border: 1px solid var(--border-soft); color: var(--volt-strong); font-family: var(--font-mono); font-size: 14px; }
+.v2-keeper-chat .linkcard.git .linkcard-fav{ color: var(--text-bright); }
+.v2-keeper-chat .linkcard-body{ display: flex; flex-direction: column; gap: 3px; min-width: 0; flex: 1; }
+.v2-keeper-chat .linkcard-title{ font-family: var(--font-ui); font-size: 13px; font-weight: 600; color: var(--text-bright); line-height: 1.3; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.v2-keeper-chat .linkcard-desc{ font-size: 12px; color: var(--text-mid); line-height: 1.45; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.v2-keeper-chat .linkcard-meta{ font-size: 10.5px; color: var(--text-dim); margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.v2-keeper-chat .linkcard-go{ flex: none; color: var(--text-dim); font-size: 13px; transition: color 0.18s ease; }
+.v2-keeper-chat .linkcard:hover .linkcard-go{ color: var(--volt-strong); }
+/* inline links inside message bubbles */
+.v2-keeper-chat .bubble a, .v2-keeper-chat .inline-link{ color: var(--volt-strong); text-decoration: underline; text-underline-offset: 2px; text-decoration-color: color-mix(in oklab, var(--volt-strong) 45%, transparent); transition: color 0.15s ease; }
+.v2-keeper-chat .bubble a:hover, .v2-keeper-chat .inline-link:hover{ color: var(--volt); text-decoration-color: var(--volt); }
+
+/* work / goal surface */
+.v2-keeper-chat .wk-list{ display: flex; flex-direction: column; gap: 12px; margin-top: 4px; }
+.v2-keeper-chat .wk-goal{ background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.v2-keeper-chat .wk-goal.has-block{ border-color: color-mix(in oklab, var(--status-bad) 32%, var(--border-main)); }
+.v2-keeper-chat .wk-goal-h{ display: flex; align-items: center; gap: 10px; width: 100%; padding: 13px 15px 11px; background: none; border: 0; cursor: pointer; text-align: left; color: inherit; }
+.v2-keeper-chat .wk-goal-h:hover{ background: color-mix(in oklab, var(--volt) 3%, transparent); }
+.v2-keeper-chat .wk-caret{ flex: none; color: var(--text-dim); font-size: 11px; width: 12px; }
+.v2-keeper-chat .wk-pri{ flex: none; font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-soft); color: var(--text-dim); }
+.v2-keeper-chat .wk-pri.high{ color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 40%, transparent); background: color-mix(in oklab, var(--status-bad) 10%, transparent); }
+.v2-keeper-chat .wk-pri.normal{ color: var(--volt-strong); border-color: color-mix(in oklab, var(--volt) 32%, transparent); }
+.v2-keeper-chat .wk-pri.low{ color: var(--text-dim); }
+.v2-keeper-chat .wk-goal-id{ flex: none; font-size: 11.5px; color: var(--text-dim); }
+.v2-keeper-chat .wk-goal-title{ font-family: var(--font-ui); font-size: 14.5px; font-weight: 600; color: var(--text-bright); }
+.v2-keeper-chat .wk-goal-ns{ flex: none; font-size: 11px; color: var(--text-mid); background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 1px 7px; border-radius: var(--radius-pill); }
+.v2-keeper-chat .wk-spacer{ flex: 1; }
+.v2-keeper-chat .wk-due{ flex: none; font-size: 11px; color: var(--text-dim); }
+.v2-keeper-chat .wk-lead{ flex: none; display: inline-flex; }
+.v2-keeper-chat .wk-goal-sub{ display: flex; align-items: center; gap: 11px; padding: 0 15px 13px 37px; }
+.v2-keeper-chat .wk-prog{ flex: none; width: 300px; max-width: 42%; height: 6px; display: flex; gap: 1.5px; background: var(--bg-sunken); border-radius: var(--radius-pill); overflow: hidden; }
+.v2-keeper-chat .wk-seg{ height: 100%; }
+.v2-keeper-chat .wk-seg.done{ background: var(--status-ok); }
+.v2-keeper-chat .wk-seg.wip{ background: var(--volt); }
+.v2-keeper-chat .wk-seg.blocked{ background: var(--status-bad); }
+.v2-keeper-chat .wk-prog-lbl{ flex: none; font-size: 11px; color: var(--text-mid); }
+.v2-keeper-chat .wk-metric{ margin-left: auto; flex: none; font-size: 11px; color: var(--text-dim); }
+.v2-keeper-chat .wk-jobs{ border-top: 1px solid var(--border-soft); padding: 10px 15px 13px; display: flex; flex-direction: column; gap: 2px; }
+.v2-keeper-chat .wk-note{ font-size: 12px; color: var(--text-mid); line-height: 1.5; padding: 2px 0 9px; border-bottom: 1px dashed var(--border-soft); margin-bottom: 7px; }
+.v2-keeper-chat .wk-job{ display: flex; align-items: center; gap: 10px; padding: 7px 8px; border-radius: var(--radius-xs); }
+.v2-keeper-chat .wk-job:hover{ background: var(--bg-sunken); }
+.v2-keeper-chat .wk-job-dot{ flex: none; width: 7px; height: 7px; border-radius: 50%; background: var(--text-dim); }
+.v2-keeper-chat .wk-job-dot.done{ background: var(--status-ok); }
+.v2-keeper-chat .wk-job-dot.wip{ background: var(--volt); }
+.v2-keeper-chat .wk-job-dot.review{ background: var(--status-warn); }
+.v2-keeper-chat .wk-job-dot.blocked{ background: var(--status-bad); }
+.v2-keeper-chat .wk-job-id{ flex: none; font-size: 11px; color: var(--text-dim); min-width: 52px; }
+.v2-keeper-chat .wk-job-title{ font-size: 13px; color: var(--text-primary); display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.v2-keeper-chat .wk-job.done .wk-job-title{ color: var(--text-mid); }
+.v2-keeper-chat .wk-job-block{ font-size: 11px; color: var(--status-bad); }
+.v2-keeper-chat .wk-job-state{ flex: none; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.04em; color: var(--text-dim); }
+.v2-keeper-chat .wk-job-state.done{ color: var(--status-ok); }
+.v2-keeper-chat .wk-job-state.wip{ color: var(--volt-strong); }
+.v2-keeper-chat .wk-job-state.review{ color: var(--status-warn); }
+.v2-keeper-chat .wk-job-state.blocked{ color: var(--status-bad); }
+.v2-keeper-chat .wk-job-kp{ flex: none; display: inline-flex; align-items: center; justify-content: flex-end; gap: 6px; min-width: 130px; padding: 3px 6px; border-radius: var(--radius-pill); border: 1px solid transparent; background: none; cursor: pointer; color: var(--text-mid); font-size: 11.5px; white-space: nowrap; transition: border-color 0.15s ease, color 0.15s ease; }
+.v2-keeper-chat .wk-job-kp:hover{ border-color: var(--border-highlight); color: var(--text-bright); }
+.v2-keeper-chat .wk-job-kp.none{ color: var(--text-dim); cursor: default; }
+.v2-keeper-chat .set-add.wk-newgoal{ width: auto; margin: 0; flex: none; align-self: center; white-space: nowrap; }
+.v2-keeper-chat .wk-blk-n{ color: var(--status-bad); }
+.v2-keeper-chat .wk-foot{ margin: 16px 2px 4px; font-size: 11px; color: var(--text-dim); }
+
+/* small inline label for jargon keys (room / 세션 / …) */
+.v2-keeper-chat .sub-k{ font-family: var(--font-ui); font-size: 9px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-dim); margin-right: 4px; }
+
+/* suggested chips */
+.v2-keeper-chat .suggest{ display: flex; flex-direction: column; gap: 7px; margin-top: 4px; }
+.v2-keeper-chat .suggest .lbl{ font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); }
+.v2-keeper-chat .suggest-row{ display: flex; flex-wrap: wrap; gap: 8px; }
+.v2-keeper-chat .chip{
+  font-family: var(--font-ui); font-size: 13px; cursor: pointer; text-align: left;
+  padding: 8px 13px; border-radius: var(--radius-pill); border: 1px solid var(--border-main);
+  background: var(--bg-card); color: var(--text-primary); transition: 0.15s; line-height: 1.3;
+}
+.v2-keeper-chat .chip:hover{ border-color: var(--volt); color: var(--text-bright); background: var(--bg-card-hover); box-shadow: 0 0 0 2px var(--volt-wash); }
+.v2-keeper-chat .chip .pre{ color: var(--volt); margin-right: 7px; }
+
+/* typing */
+.v2-keeper-chat .typing{ display: inline-flex; gap: 4px; align-items: center; padding: 4px 0; }
+.v2-keeper-chat .typing i{ width: 6px; height: 6px; border-radius: 50%; background: var(--volt); display: inline-block; animation: tdot 1.2s infinite ease-in-out; }
+.v2-keeper-chat .typing i:nth-child(2){ animation-delay: 0.18s; } .v2-keeper-chat .typing i:nth-child(3){ animation-delay: 0.36s; }
+@keyframes tdot { 0%,60%,100% { opacity: 0.25; transform: translateY(0); } 30% { opacity: 1; transform: translateY(-3px); } }
+
+/* composer */
+.v2-keeper-chat .composer{ flex: none; padding: 12px 24px 16px; border-top: 1px solid var(--border-main); background: linear-gradient(0deg, var(--bg-panel), var(--bg-deep)); }
+.v2-keeper-chat .composer-inner{ max-width: var(--thread-w, 980px); margin: 0 auto; padding: 0 4px; }
+.v2-keeper-chat .composer-box{
+  background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-md);
+  padding: 6px 6px 6px 14px; display: flex; align-items: flex-end; gap: 10px; transition: border-color 0.15s, box-shadow 0.15s;
+}
+.v2-keeper-chat .composer-box.focus{ border-color: var(--volt-dim); box-shadow: 0 0 0 3px var(--volt-wash); }
+.v2-keeper-chat .composer textarea{
+  flex: 1; resize: none; border: 0; outline: 0; background: transparent;
+  color: var(--text-bright); font-family: var(--font-ui); font-size: 14.5px; line-height: 1.5;
+  padding: 9px 0; max-height: 160px; min-height: 24px;
+}
+.v2-keeper-chat .composer textarea::placeholder{ color: var(--text-dim); }
+.v2-keeper-chat .composer-tools{ display: flex; align-items: center; gap: 6px; padding-bottom: 2px; }
+.v2-keeper-chat .ctool{
+  width: 34px; height: 34px; display: flex; align-items: center; justify-content: center;
+  border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-panel-alt);
+  color: var(--text-mid); cursor: pointer; transition: 0.14s;
+}
+.v2-keeper-chat .ctool:hover{ color: var(--text-bright); border-color: var(--border-highlight); }
+.v2-keeper-chat .send{
+  height: 34px; padding: 0 16px; border-radius: var(--radius-sm); cursor: pointer;
+  background: var(--volt); color: var(--volt-ink); border: 1px solid var(--volt);
+  font-family: var(--font-ui); font-size: 12.5px; font-weight: 600; letter-spacing: 0.04em;
+  display: inline-flex; align-items: center; gap: 7px; transition: 0.14s;
+  white-space: nowrap; flex: none;
+}
+.v2-keeper-chat .send:hover{ background: var(--volt-strong); box-shadow: 0 0 18px var(--volt-glow); }
+.v2-keeper-chat .send:disabled{ opacity: 0.4; cursor: default; box-shadow: none; }
+.v2-keeper-chat .composer-foot{ display: flex; align-items: center; justify-content: space-between; margin-top: 8px; font-size: 11px; color: var(--text-dim); }
+.v2-keeper-chat .composer-foot .as{ display: inline-flex; align-items: center; gap: 7px; }
+.v2-keeper-chat .composer-foot .as b{ color: var(--volt-strong); font-family: var(--font-mono); }
+.v2-keeper-chat .composer-foot .hint{ font-family: var(--font-mono); white-space: nowrap; }
+.v2-keeper-chat .composer-foot .as{ white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.v2-keeper-chat .composer-foot kbd{ font-family: var(--font-mono); font-size: 10px; background: var(--bg-card); border: 1px solid var(--border-main); border-bottom-width: 2px; border-radius: var(--radius-xs); padding: 1px 5px; color: var(--text-mid); }
+
+/* composer — drag-over affordance */
+.v2-keeper-chat .composer-box.drag{ border-color: var(--volt-dim); box-shadow: 0 0 0 3px var(--volt-wash); background: var(--volt-wash); }
+
+/* composer — pending attachment / voice tray */
+.v2-keeper-chat .composer-tray{ display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 9px; }
+.v2-keeper-chat .cdraft{ display: flex; align-items: center; gap: 9px; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 7px 9px; position: relative; }
+.v2-keeper-chat .cdraft.att{ padding-right: 26px; max-width: 280px; }
+.v2-keeper-chat .cdraft-thumb{ width: 34px; height: 34px; flex: none; border-radius: var(--radius-xs); overflow: hidden; background: var(--bg-panel-alt); display: flex; align-items: center; justify-content: center; }
+.v2-keeper-chat .cdraft-thumb img{ width: 100%; height: 100%; object-fit: cover; display: block; }
+.v2-keeper-chat .cdraft-glyph{ color: var(--text-dim); font-size: 17px; }
+.v2-keeper-chat .cdraft-meta{ display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.v2-keeper-chat .cdraft-name{ font-size: 11.5px; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 190px; }
+.v2-keeper-chat .cdraft-sub{ font-size: 10px; color: var(--text-dim); }
+.v2-keeper-chat .cdraft.voice{ padding-right: 26px; gap: 8px; flex-wrap: wrap; max-width: 360px; }
+.v2-keeper-chat .cdraft-glyph.mic{ color: var(--volt); font-size: 14px; }
+.v2-keeper-chat .cdraft-wave{ display: flex; align-items: center; gap: 1.5px; height: 22px; }
+.v2-keeper-chat .cdraft-wave .vbar{ width: 2px; border-radius: 1px; background: var(--volt-dim); }
+.v2-keeper-chat .cdraft-dur{ font-size: 11px; color: var(--text-mid); }
+.v2-keeper-chat .cdraft-tx{ display: flex; gap: 7px; align-items: baseline; flex-basis: 100%; padding-top: 5px; border-top: 1px solid var(--border-main); }
+.v2-keeper-chat .cdraft-tx-k{ font-family: var(--font-display); text-transform: uppercase; letter-spacing: 0.14em; font-size: 9px; color: var(--volt); flex: none; }
+.v2-keeper-chat .cdraft-tx-v{ font-size: 11.5px; color: var(--text-mid); line-height: 1.45; }
+.v2-keeper-chat .cdraft-x{ position: absolute; top: 5px; right: 6px; width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; border: 0; background: transparent; color: var(--text-dim); cursor: pointer; font-size: 10px; border-radius: var(--radius-xs); }
+.v2-keeper-chat .cdraft-x:hover{ color: var(--status-bad); background: var(--bg-panel-alt); }
+
+/* composer — live recording bar */
+.v2-keeper-chat .rec-bar{ flex: 1; display: flex; align-items: center; gap: 10px; padding: 5px 4px 5px 10px; min-height: 34px; }
+.v2-keeper-chat .rec-dot{ width: 9px; height: 9px; border-radius: 50%; background: var(--status-bad); flex: none; animation: recpulse 1.1s ease-in-out infinite; }
+@keyframes recpulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+.v2-keeper-chat .rec-lbl{ font-family: var(--font-display); text-transform: uppercase; letter-spacing: 0.16em; font-size: 10px; color: var(--status-bad); }
+.v2-keeper-chat .rec-clock{ font-size: 13px; color: var(--text-bright); }
+.v2-keeper-chat .rec-wave{ flex: 1; display: flex; align-items: center; gap: 2px; height: 24px; overflow: hidden; }
+.v2-keeper-chat .rec-wave .rbar{ width: 2.5px; border-radius: 1px; background: var(--volt-dim); flex: none; }
+.v2-keeper-chat .rec-btn{ height: 30px; padding: 0 12px; border-radius: var(--radius-sm); cursor: pointer; font-family: var(--font-ui); font-size: 12px; transition: 0.14s; flex: none; }
+.v2-keeper-chat .rec-btn.cancel{ background: transparent; border: 1px solid var(--border-main); color: var(--text-mid); }
+.v2-keeper-chat .rec-btn.cancel:hover{ color: var(--text-bright); border-color: var(--border-highlight); }
+.v2-keeper-chat .rec-btn.stop{ background: var(--volt); border: 1px solid var(--volt); color: var(--volt-ink); }
+.v2-keeper-chat .rec-btn.stop:hover{ background: var(--volt-strong); box-shadow: 0 0 16px var(--volt-glow); }
+
+/* ════ CONTEXT RAIL ════ */
+.v2-keeper-chat .ctx{ border-left: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+.v2-keeper-chat .ctx-scroll{ overflow-y: auto; padding: 14px; display: flex; flex-direction: column; gap: 16px; }
+.v2-keeper-chat .ctx-sec h4{ font-family: var(--font-display); font-weight: 400; text-transform: uppercase; letter-spacing: 0.18em; font-size: 11px; color: var(--text-mid); margin: 0 0 9px; }
+.v2-keeper-chat .ctx-card{ background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 11px 12px; }
+
+.v2-keeper-chat .vitals{ display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--border-soft); border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.v2-keeper-chat .vital{ background: var(--bg-card); padding: 9px 11px; }
+.v2-keeper-chat .vital .vk{ font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-mid); font-weight: 600; }
+.v2-keeper-chat .vital .vv{ font-family: var(--font-mono); font-size: 15px; color: var(--text-bright); margin-top: 3px; }
+.v2-keeper-chat .vital .vv.volt{ color: var(--volt-strong); }
+.v2-keeper-chat .vital .vv small{ font-size: 10px; color: var(--text-dim); }
+
+/* context meter */
+.v2-keeper-chat .meter{ height: 7px; border-radius: var(--radius-pill); background: var(--bg-sunken); border: 1px solid var(--border-soft); overflow: hidden; margin-top: 7px; }
+.v2-keeper-chat .meter > span{ display: block; height: 100%; background: linear-gradient(90deg, var(--volt-dim), var(--volt)); }
+.v2-keeper-chat .meter.hot > span{ background: linear-gradient(90deg, var(--status-warn), var(--status-bad)); }
+.v2-keeper-chat .meter-wrap{ position: relative; margin-top: 7px; }
+.v2-keeper-chat .meter-wrap .meter{ margin-top: 0; }
+.v2-keeper-chat .meter-mark{ position: absolute; top: -2px; width: 1px; height: 11px; background: color-mix(in oklab, var(--status-warn) 75%, transparent); transform: translateX(-50%); pointer-events: none; }
+.v2-keeper-chat .meter-mark.hot{ background: var(--status-bad); }
+.v2-keeper-chat .meter-mark-lbl{ position: absolute; bottom: 100%; right: 1px; margin-bottom: 3px; font-size: 8.5px; font-style: normal; letter-spacing: 0.04em; text-transform: uppercase; white-space: nowrap; color: color-mix(in oklab, var(--status-warn) 80%, var(--text-dim)); }
+.v2-keeper-chat .meter-mark.hot .meter-mark-lbl{ color: var(--status-bad); }
+
+/* fsm list */
+.v2-keeper-chat .fsm{ display: flex; flex-direction: column; gap: 0; }
+.v2-keeper-chat .fsm-step{ display: flex; align-items: center; gap: 9px; padding: 5px 4px; font-family: var(--font-mono); font-size: 11.5px; color: var(--text-dim); position: relative; }
+.v2-keeper-chat .fsm-step .pip{ width: 9px; height: 9px; border-radius: 50%; border: 1px solid var(--border-highlight); background: var(--bg-sunken); flex: none; z-index: 1; }
+.v2-keeper-chat .fsm-step.done{ color: var(--text-mid); }
+.v2-keeper-chat .fsm-step.done .pip{ background: var(--text-dim); border-color: var(--text-dim); }
+.v2-keeper-chat .fsm-step.cur{ color: var(--volt-strong); }
+.v2-keeper-chat .fsm-step.cur .pip{ background: var(--volt); border-color: var(--volt); box-shadow: 0 0 10px var(--volt-glow); }
+.v2-keeper-chat .fsm-step:not(:last-child)::after{ content: ""; position: absolute; left: 8.5px; top: 16px; bottom: -5px; width: 1px; background: var(--border-soft); }
+.v2-keeper-chat .fsm-step.done:not(:last-child)::after{ background: var(--text-dim); }
+
+.v2-keeper-chat .ctx-list{ display: flex; flex-direction: column; gap: 7px; }
+.v2-keeper-chat .ctx-item{ display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text-mid); }
+.v2-keeper-chat .ctx-item .ci-name{ font-family: var(--font-mono); font-size: 11.5px; color: var(--text-primary); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v2-keeper-chat .ctx-item .ci-meta{ font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); white-space: nowrap; flex: none; }
+
+.v2-keeper-chat .tasktag{ display: flex; align-items: center; gap: 6px; padding: 6px 9px; border-radius: var(--radius-xs); background: var(--bg-sunken); border: 1px solid var(--border-soft); font-size: 12px; color: var(--text-primary); }
+.v2-keeper-chat .tasktag .ttl{ overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.v2-keeper-chat .tasktag .tid{ font-family: var(--font-mono); font-size: 10.5px; color: var(--volt-strong); flex: none; }
+
+/* empty state */
+.v2-keeper-chat .empty2{ flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; color: var(--text-dim); text-align: center; padding: 40px; }
+.v2-keeper-chat .empty2 .ico{ font-size: 30px; opacity: 0.5; }
+.v2-keeper-chat .empty2 h3{ font-family: var(--font-display); letter-spacing: 0.14em; color: var(--text-mid); font-size: 15px; }
+
+/* density compact */
+.v2-keeper-chat[data-density="compact"] .thread-inner{ gap: 14px; }
+.v2-keeper-chat[data-density="compact"] .bubble{ padding: 11px 13px; font-size: 14px; }
+.v2-keeper-chat[data-density="compact"] .kp-row{ padding: 6px 9px; }
+
+/* ════ TOK/S THROUGHPUT ════ */
+/* header live readout */
+.v2-keeper-chat .chat-id .sub .tps-live{ display: inline-flex; align-items: center; gap: 5px; color: var(--status-ok); }
+.v2-keeper-chat .tps-dot{ width: 6px; height: 6px; border-radius: 50%; background: var(--status-ok); box-shadow: 0 0 6px var(--status-ok); animation: tps-pulse 1.1s ease-in-out infinite; }
+@keyframes tps-pulse { 0%,100% { opacity: 0.45; } 50% { opacity: 1; } }
+.v2-keeper-chat .chat-id .sub .tps-live .mono{ color: var(--status-ok); }
+
+/* context-rail throughput card */
+.v2-keeper-chat .tps-card{ background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 11px 12px; }
+.v2-keeper-chat .tps-now{ display: flex; align-items: baseline; gap: 6px; }
+.v2-keeper-chat .tps-val{ font-family: var(--font-mono); font-size: 26px; line-height: 1; color: var(--status-ok); font-variant-numeric: tabular-nums; }
+.v2-keeper-chat .tps-val.idle{ color: var(--text-dim); }
+.v2-keeper-chat .tps-unit{ font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
+.v2-keeper-chat .tps-flag{ margin-left: auto; display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--status-ok); }
+.v2-keeper-chat .tps-spark{ position: relative; display: flex; align-items: flex-end; gap: 2px; height: 30px; margin-top: 8px; }
+.v2-keeper-chat .tps-spark > span:not(.tps-spark-rt){ flex: 1; background: var(--status-ok); border-radius: 1px; min-height: 2px; transition: height 0.5s ease; }
+.v2-keeper-chat .tps-spark-rt{ position: absolute; top: -2px; right: 0; font-size: 10px; color: var(--text-mid); background: color-mix(in oklab, var(--bg-card) 80%, transparent); padding: 1.5px 6px; border-radius: var(--radius-pill); border: 1px solid var(--border-soft); pointer-events: none; opacity: 0.72; transition: opacity 0.14s ease, color 0.14s ease, border-color 0.14s ease; }
+.v2-keeper-chat .tps-spark:hover .tps-spark-rt{ opacity: 1; color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 38%, transparent); }
+.v2-keeper-chat .tps-ranges{ display: flex; align-items: center; gap: 4px; margin-top: 9px; }
+.v2-keeper-chat .tps-range{ font-family: var(--font-mono); font-size: 10.5px; padding: 3px 9px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: transparent; color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.v2-keeper-chat .tps-range:hover{ color: var(--text-mid); border-color: var(--border-highlight); }
+.v2-keeper-chat .tps-range.on{ color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); background: color-mix(in oklab, var(--status-ok) 10%, transparent); }
+.v2-keeper-chat .tps-avg{ margin-left: auto; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+
+/* compaction full-context before/after toggle */
+.v2-keeper-chat .cmp-side-toggle{ display: flex; gap: 5px; margin-bottom: 9px; }
+.v2-keeper-chat .cmp-side{ flex: 1; font-family: var(--font-ui); font-size: 11px; padding: 7px 9px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-sunken); color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.v2-keeper-chat .cmp-side:hover{ color: var(--text-mid); }
+.v2-keeper-chat .cmp-side.on{ color: var(--text-bright); border-color: var(--volt-dim); background: var(--volt-wash); }
+.v2-keeper-chat .cmp-ctx-pre{ max-height: 280px; overflow-y: auto; }
+
+/* ════ MOBILE-ONLY HEADER CONTROLS (rendered only ≤900px via JS) ════ */
+/* feedback voted state + regen tag */
+.v2-keeper-chat .fbk-btn.on.up{ color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); }
+.v2-keeper-chat .fbk-btn.on.down{ color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); }
+.v2-keeper-chat .fbk-noted{ font-family: var(--font-ui); font-size: 11px; color: var(--status-ok); margin-left: 4px; animation: turn-in 0.18s ease; }
+.v2-keeper-chat .regen-tag{ font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.04em; color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-pill); padding: 1px 7px; }
+
+/* external-source context provenance (Discord/Slack pulled-in context range) */
+.v2-keeper-chat .ctx-from{
+  display: flex; align-items: center; gap: 8px; margin-bottom: 8px; padding: 7px 11px;
+  background: color-mix(in oklab, var(--info) 8%, transparent);
+  border: 1px solid color-mix(in oklab, var(--info) 28%, transparent);
+  border-radius: var(--radius-sm); font-size: 11.5px; color: var(--text-mid);
+}
+.v2-keeper-chat .ctx-from .cf-ico{ color: var(--info); font-family: var(--font-mono); }
+.v2-keeper-chat .ctx-from b{ color: var(--text-bright); font-weight: 600; }
+.v2-keeper-chat .ctx-from .cf-view{ margin-left: auto; flex: none; background: none; border: 1px solid var(--info-dim); color: var(--info); border-radius: var(--radius-pill); font-size: 10.5px; padding: 2px 9px; cursor: pointer; transition: 0.14s; }
+.v2-keeper-chat .ctx-from .cf-view:hover{ background: color-mix(in oklab, var(--info) 14%, transparent); }
+.v2-keeper-chat .cf-detail{ margin: -2px 0 8px; padding: 10px 12px; border: 1px solid color-mix(in oklab, var(--info) 24%, transparent); border-top: 0; border-radius: 0 0 var(--radius-sm) var(--radius-sm); background: color-mix(in oklab, var(--info) 5%, transparent); }
+.v2-keeper-chat .cf-detail-h{ font-size: 10.5px; color: var(--text-dim); margin-bottom: 8px; }
+.v2-keeper-chat .cf-msg{ display: grid; grid-template-columns: 44px 70px 1fr; gap: 8px; align-items: baseline; padding: 4px 0; font-size: 12px; line-height: 1.45; border-top: 1px solid color-mix(in oklab, var(--info) 12%, transparent); }
+.v2-keeper-chat .cf-msg:first-of-type{ border-top: 0; }
+.v2-keeper-chat .cf-msg .cf-ts{ color: var(--text-dim); font-size: 10.5px; }
+.v2-keeper-chat .cf-msg .cf-who{ color: var(--info); font-weight: 600; }
+.v2-keeper-chat .cf-msg .cf-text{ color: var(--text-mid); }
+
+/* code block in messages */
+.v2-keeper-chat .code-block{ margin: 10px 0; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: #06070a; }
+.v2-keeper-chat .code-cap{ padding: 6px 12px; font-size: 10.5px; color: var(--text-dim); background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.v2-keeper-chat .code-block pre{ margin: 0; padding: 12px 14px; overflow-x: auto; }
+.v2-keeper-chat .code-block code{ font-family: var(--font-mono); font-size: 12.5px; line-height: 1.6; color: var(--text-primary); white-space: pre; }
+.v2-keeper-chat .code-block .kw{ color: var(--volt-strong); opacity: 0.85; }
+.v2-keeper-chat .code-block .fn{ color: var(--text-bright); }
+.v2-keeper-chat .code-block .str{ color: color-mix(in oklab, var(--status-ok) 70%, var(--text-mid)); }
+.v2-keeper-chat .code-block .cm{ color: var(--text-dim); font-style: italic; }
+.v2-keeper-chat .code-block .del{ color: var(--status-bad); }
+.v2-keeper-chat .code-block .add{ color: var(--status-ok); }
+
+/* shell / exec output */
+.v2-keeper-chat .shell-block{ margin: 10px 0; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: #06070a; }
+.v2-keeper-chat .shell-bar{ display: flex; align-items: center; gap: 6px; padding: 7px 11px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.v2-keeper-chat .shell-bar .dot{ width: 9px; height: 9px; border-radius: 50%; }
+.v2-keeper-chat .shell-bar .dot.r{ background: #e0625b; } .v2-keeper-chat .shell-bar .dot.y{ background: #e0b257; } .v2-keeper-chat .shell-bar .dot.g{ background: #5ea66a; }
+.v2-keeper-chat .shell-bar .shell-title{ margin-left: 8px; font-size: 10.5px; color: var(--text-dim); }
+.v2-keeper-chat .shell-block pre{ margin: 0; padding: 11px 13px; overflow-x: auto; }
+.v2-keeper-chat .sh-ln{ font-family: var(--font-mono); font-size: 12px; line-height: 1.6; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+.v2-keeper-chat .sh-ln.cmd{ color: var(--text-bright); }
+.v2-keeper-chat .sh-ln .sh-prompt{ color: var(--volt-strong); }
+.v2-keeper-chat .sh-ln.ok{ color: var(--status-ok); }
+.v2-keeper-chat .sh-ln.err{ color: var(--status-bad); }
+.v2-keeper-chat .sh-ln.dim{ color: var(--text-dim); }
+.v2-keeper-chat .shell-exit{ padding: 6px 13px; font-family: var(--font-mono); font-size: 11px; border-top: 1px solid var(--border-soft); }
+.v2-keeper-chat .shell-exit.ok{ color: var(--status-ok); }
+.v2-keeper-chat .shell-exit.fail{ color: var(--status-bad); }
+
+/* artifact file card */
+.v2-keeper-chat .artifact{ display: flex; align-items: center; gap: 11px; margin: 10px 0; padding: 11px 13px; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); }
+.v2-keeper-chat .af-ico{ width: 34px; height: 34px; flex: none; display: flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 15px; color: var(--volt-strong); background: var(--volt-wash); border: 1px solid var(--volt-dim); border-radius: var(--radius-sm); }
+.v2-keeper-chat .af-meta{ flex: 1; min-width: 0; }
+.v2-keeper-chat .af-name{ font-size: 13px; color: var(--text-bright); }
+.v2-keeper-chat .af-sub{ font-size: 10.5px; color: var(--text-dim); margin-top: 2px; text-transform: uppercase; letter-spacing: 0.06em; }
+.v2-keeper-chat .af-btn{ flex: none; font-family: var(--font-ui); font-size: 11px; padding: 5px 11px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: transparent; color: var(--text-mid); cursor: pointer; transition: 0.14s; }
+.v2-keeper-chat .af-btn:hover{ border-color: var(--volt-dim); color: var(--volt); }
+
+/* image / svg output */
+.v2-keeper-chat .img-out, .v2-keeper-chat .svg-out{ margin: 10px 0; }
+.v2-keeper-chat .img-frame, .v2-keeper-chat .svg-frame{ border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-sunken); display: flex; align-items: center; justify-content: center; }
+.v2-keeper-chat .img-frame img{ max-width: 100%; display: block; }
+.v2-keeper-chat .img-ph{ padding: 40px; color: var(--text-dim); font-size: 12px; font-family: var(--font-ui); }
+.v2-keeper-chat .svg-frame{ padding: 16px; }
+.v2-keeper-chat .svg-frame svg{ max-width: 100%; height: auto; display: block; }
+.v2-keeper-chat .img-out figcaption, .v2-keeper-chat .svg-out figcaption{ margin-top: 6px; font-size: 11px; color: var(--text-dim); }
+
+/* ── multimodal: image attachment (vision-modal user input) ── */
+.v2-keeper-chat .attach{ margin: 10px 0; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: #06070a; }
+.v2-keeper-chat .attach-hd{ display: flex; align-items: center; gap: 8px; padding: 7px 11px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.v2-keeper-chat .attach-clip{ color: var(--volt-strong); font-size: 12px; flex: none; }
+.v2-keeper-chat .attach-name{ font-size: 11px; color: var(--text-mid); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v2-keeper-chat .attach-dims{ font-size: 10px; color: var(--text-dim); flex: none; }
+.v2-keeper-chat .attach-frame{ display: flex; align-items: center; justify-content: center; background: var(--bg-sunken); padding: 0; }
+.v2-keeper-chat .attach-frame svg{ max-width: 100%; height: auto; display: block; }
+.v2-keeper-chat .attach-frame img{ width: 100%; max-height: 220px; object-fit: cover; object-position: center 30%; display: block; }
+.v2-keeper-chat .attach-cap{ display: flex; align-items: center; gap: 8px; padding: 7px 11px; font-size: 10.5px; color: var(--text-dim); border-top: 1px solid var(--border-soft); }
+.v2-keeper-chat .attach-tag{ font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-pill); padding: 1px 7px; }
+
+/* ── multimodal: voice memo (audio-modal user input) ── */
+.v2-keeper-chat .voice{ margin: 10px 0; padding: 11px 13px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: #06070a; }
+.v2-keeper-chat .voice-row{ display: flex; align-items: center; gap: 12px; }
+.v2-keeper-chat .voice-play{ flex: none; width: 32px; height: 32px; border-radius: 50%; border: 1px solid var(--volt-dim); background: var(--volt-wash); color: var(--volt-strong); cursor: pointer; font-size: 11px; line-height: 1; display: flex; align-items: center; justify-content: center; padding-left: 2px; transition: 0.14s; }
+.v2-keeper-chat .voice-play:hover{ border-color: var(--volt); color: var(--volt); }
+.v2-keeper-chat .voice-play.on{ background: var(--volt); color: var(--volt-ink); border-color: var(--volt); padding-left: 0; }
+.v2-keeper-chat .voice-wave{ flex: 1; display: flex; align-items: center; gap: 2px; height: 30px; min-width: 0; overflow: hidden; }
+.v2-keeper-chat .voice-wave .vbar{ flex: 1; min-width: 1px; border-radius: 1px; background: var(--border-highlight); transition: background 0.1s; }
+.v2-keeper-chat .voice-wave .vbar.on{ background: var(--volt); }
+.v2-keeper-chat .voice-dur{ flex: none; font-size: 11px; color: var(--text-mid); font-variant-numeric: tabular-nums; }
+.v2-keeper-chat .voice-meta{ display: flex; align-items: center; gap: 8px; margin-top: 8px; font-size: 10px; color: var(--text-dim); }
+.v2-keeper-chat .voice-meta .voice-via{ flex: 1; }
+.v2-keeper-chat .voice-meta .mono{ flex: none; }
+.v2-keeper-chat .voice-tx{ margin-top: 9px; padding-top: 9px; border-top: 1px dashed var(--border-soft); display: flex; gap: 9px; }
+.v2-keeper-chat .voice-tx-k{ flex: none; font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); padding-top: 2px; }
+.v2-keeper-chat .voice-tx-v{ font-size: 12.5px; color: var(--text-primary); line-height: 1.55; }
+
+/* ── keeper-to-keeper broadcast ── */
+.v2-keeper-chat .bcast{ margin: 10px 0; border: 1px solid var(--volt-dim); border-radius: var(--radius-sm); background: linear-gradient(180deg, var(--volt-wash), #06070a 80%); overflow: hidden; }
+.v2-keeper-chat .bcast-hd{ display: flex; align-items: center; gap: 9px; flex-wrap: wrap; padding: 8px 12px; border-bottom: 1px solid var(--border-soft); background: color-mix(in oklab, var(--volt) 6%, transparent); }
+.v2-keeper-chat .bcast-tag{ font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--volt-strong); font-weight: 600; }
+.v2-keeper-chat .bcast-scope{ font-size: 11px; color: var(--text-bright); }
+.v2-keeper-chat .bcast-via{ font-size: 10px; color: var(--text-dim); }
+.v2-keeper-chat .bcast-count{ margin-left: auto; flex: none; font-size: 10px; color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-pill); padding: 1px 8px; }
+.v2-keeper-chat .bcast-note{ padding: 11px 12px; font-size: 13px; color: var(--text-primary); line-height: 1.6; }
+.v2-keeper-chat .bcast-note code{ font-family: var(--font-mono); font-size: 12px; background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 0 4px; border-radius: var(--radius-xs); color: var(--volt-strong); }
+.v2-keeper-chat .bcast-rcpts{ display: flex; flex-direction: column; gap: 1px; background: var(--border-soft); border-top: 1px solid var(--border-soft); }
+.v2-keeper-chat .bcast-rcpt{ display: flex; align-items: center; gap: 9px; padding: 8px 12px; background: #06070a; }
+.v2-keeper-chat .bcast-rcpt-id{ font-family: var(--font-mono); font-size: 12px; color: var(--text-bright); flex: 1; min-width: 0; }
+.v2-keeper-chat .bcast-ack{ flex: none; font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+.v2-keeper-chat .bcast-rcpt.acked .bcast-ack{ color: var(--status-ok); }
+.v2-keeper-chat .bcast-rcpt.read .bcast-ack{ color: var(--info); }
+.v2-keeper-chat .bcast-rcpt::before{ content: ""; flex: none; width: 6px; height: 6px; border-radius: 50%; background: var(--text-dim); order: 3; }
+.v2-keeper-chat .bcast-rcpt.acked::before{ background: var(--status-ok); box-shadow: 0 0 6px color-mix(in oklab, var(--status-ok) 60%, transparent); }
+.v2-keeper-chat .bcast-rcpt.read::before{ background: var(--info); }
+
+/* compaction inspector trigger (ctx rail) */
+.v2-keeper-chat .cmp-open{
+  width: 100%; margin-top: 10px; display: flex; align-items: center; gap: 7px;
+  font-family: var(--font-ui); font-size: 11.5px; color: var(--text-mid);
+  padding: 8px 10px; background: var(--bg-sunken); border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm); cursor: pointer; transition: 0.14s;
+}
+.v2-keeper-chat .cmp-open:hover{ border-color: var(--volt-dim); color: var(--volt); }
+.v2-keeper-chat .cmp-open-sub{ margin-left: auto; font-size: 10px; color: var(--text-dim); }
+
+/* manual compaction trigger (ctx rail) — operator-run compact */
+.v2-keeper-chat .cmp-actions{ margin-top: 10px; }
+.v2-keeper-chat .cmp-run{
+  width: 100%; display: flex; align-items: center; justify-content: center; gap: 7px;
+  font-family: var(--font-ui); font-size: 12px; color: var(--volt-ink);
+  background: var(--volt); border: 1px solid var(--volt); padding: 7px 10px;
+  border-radius: var(--radius-sm); cursor: pointer; transition: 0.14s;
+}
+.v2-keeper-chat .cmp-run:hover:not(:disabled){ background: var(--volt-strong); box-shadow: 0 0 16px var(--volt-glow); }
+.v2-keeper-chat .cmp-run:disabled{ cursor: default; opacity: 0.92; }
+.v2-keeper-chat .cmp-run.busy{ background: var(--bg-panel-alt); color: var(--text-mid); border-color: var(--border-main); }
+.v2-keeper-chat .cmp-spin{ width: 11px; height: 11px; border-radius: 50%; border: 2px solid var(--border-highlight); border-top-color: var(--volt); animation: spin 0.7s linear infinite; flex: none; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* roster row command menu */
+.v2-keeper-chat .kp-row{ position: relative; }
+.v2-keeper-chat .kp-more{
+  position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
+  width: 24px; height: 24px; border-radius: var(--radius-sm); border: 1px solid var(--border-main);
+  background: var(--bg-panel); color: var(--text-mid); cursor: pointer; font-size: 14px; line-height: 1;
+  opacity: 0; transition: 0.14s; z-index: 2;
+}
+.v2-keeper-chat .kp-row:hover .kp-more{ opacity: 1; }
+.v2-keeper-chat .kp-more:hover{ border-color: var(--volt-dim); color: var(--volt); }
+.v2-keeper-chat .kp-menu{
+  position: fixed; z-index: 80; min-width: 186px; padding: 5px;
+  background: var(--bg-panel); border: 1px solid var(--border-highlight);
+  border-radius: var(--radius-sm); box-shadow: 0 8px 24px rgba(0,0,0,0.55);
+  animation: turn-in 0.13s ease;
+}
+.v2-keeper-chat .kp-menu-h{ display: flex; align-items: center; gap: 7px; padding: 7px 9px 8px; border-bottom: 1px solid var(--border-soft); margin-bottom: 4px; font-size: 12px; color: var(--text-bright); }
+.v2-keeper-chat .kp-menu-i{ display: flex; align-items: center; gap: 9px; width: 100%; padding: 8px 9px; background: none; border: 0; border-radius: var(--radius-xs); color: var(--text-mid); font-family: var(--font-ui); font-size: 12.5px; text-align: left; cursor: pointer; transition: 0.12s; }
+.v2-keeper-chat .kp-menu-i:hover{ background: var(--bg-card); color: var(--text-bright); }
+.v2-keeper-chat .kp-menu-i.danger{ color: var(--status-bad); }
+.v2-keeper-chat .kp-menu-i.danger:hover{ background: color-mix(in oklab, var(--status-bad) 14%, transparent); }
+.v2-keeper-chat .kp-menu-sep{ height: 1px; background: var(--border-soft); margin: 4px 0; }
+.v2-keeper-chat .kp-menu-note{ padding: 8px 10px; font-size: 11px; color: var(--text-dim); line-height: 1.4; }
+
+/* header lifecycle: quiet label when no action is legal (transient/Dead) */
+.v2-keeper-chat .act-quiet{ font-family: var(--font-ui); font-size: 11px; color: var(--text-dim); padding: 0 6px; white-space: nowrap; }
+
+/* mobile chat-header overflow (lifecycle actions live here when chat-actions are hidden) */
+.v2-keeper-chat .chat-head-mob{ margin-left: auto; display: flex; align-items: center; gap: 8px; position: relative; flex: none; }
+.v2-keeper-chat .chat-head-mob .chat-ctx-btn{ margin-left: 0; }
+.v2-keeper-chat .chat-ovf{
+  flex: none; width: 34px; height: 34px; border-radius: var(--radius-sm);
+  display: flex; align-items: center; justify-content: center;
+  border: 1px solid var(--border-main); background: var(--bg-panel-alt);
+  color: var(--text-mid); font-size: 18px; cursor: pointer; transition: 0.14s;
+}
+.v2-keeper-chat .chat-ovf:hover{ border-color: var(--volt-dim); color: var(--volt); }
+.v2-keeper-chat .chat-ovf:active{ transform: translateY(1px); }
+.v2-keeper-chat .chat-ovf-menu{
+  position: absolute; top: 42px; right: 0; z-index: 80; min-width: 188px; padding: 5px;
+  background: var(--bg-panel); border: 1px solid var(--border-highlight);
+  border-radius: var(--radius-md); box-shadow: var(--shadow-pop);
+  display: flex; flex-direction: column;
+}
+
+/* compaction inspector body */
+.v2-keeper-chat .cmp-empty{ font-size: 12.5px; line-height: 1.7; color: var(--text-dim); text-align: center; padding: 30px 12px; }
+.v2-keeper-chat .cmp-trigger{ font-size: 12px; color: var(--text-mid); margin-bottom: 4px; }
+.v2-keeper-chat .cmp-trigger .sub-k{ margin-right: 6px; }
+.v2-keeper-chat .cmp-headline{ display: flex; align-items: center; gap: 10px; font-size: 20px; margin-bottom: 12px; }
+.v2-keeper-chat .cmp-arrow{ color: var(--text-dim); }
+.v2-keeper-chat .cmp-reduce{ margin-left: auto; font-family: var(--font-mono); font-size: 13px; color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 40%, transparent); background: color-mix(in oklab, var(--status-ok) 10%, transparent); padding: 2px 9px; border-radius: var(--radius-pill); }
+.v2-keeper-chat .cmp-stat{ display: grid; grid-template-columns: 54px 1fr; gap: 10px; align-items: start; margin-top: 12px; }
+.v2-keeper-chat .cmp-stat-k{ font-family: var(--font-ui); font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-dim); padding-top: 2px; }
+.v2-keeper-chat .cmp-bars{ display: flex; flex-direction: column; gap: 3px; }
+.v2-keeper-chat .cmp-line{ display: flex; align-items: baseline; justify-content: space-between; }
+.v2-keeper-chat .cmp-line .t{ font-family: var(--font-ui); font-size: 10px; color: var(--text-dim); }
+.v2-keeper-chat .cmp-line .v{ font-family: var(--font-mono); font-weight: 500; font-size: 12px; color: var(--text-bright); }
+.v2-keeper-chat .cmp-line .v.ok{ color: var(--status-ok); }
+.v2-keeper-chat .cmp-line:nth-of-type(3){ margin-top: 5px; }
+.v2-keeper-chat .cmp-bar{ position: relative; height: 7px; background: var(--bg-sunken); border-radius: 3px; overflow: hidden; }
+.v2-keeper-chat .cmp-bar span{ position: absolute; left: 0; top: 0; bottom: 0; border-radius: 3px; }
+.v2-keeper-chat .cmp-bar.before span{ background: color-mix(in oklab, var(--text-dim) 55%, transparent); }
+.v2-keeper-chat .cmp-bar.after span{ background: var(--status-ok); }
+
+/* context absolute-token line */
+.v2-keeper-chat .ctx-tok{ display: flex; align-items: baseline; gap: 5px; margin-top: 8px; }
+.v2-keeper-chat .ctx-tok .mono{ font-size: 13px; color: var(--text-bright); }
+.v2-keeper-chat .ctx-tok-sep{ color: var(--text-dim); }
+.v2-keeper-chat .ctx-tok-full{ color: var(--text-dim) !important; }
+.v2-keeper-chat .ctx-tok-lbl{ margin-left: auto; font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
+
+/* recent tool — expandable detail */
+.v2-keeper-chat .ctx-item.click{ cursor: pointer; }
+.v2-keeper-chat .ctx-item.click:hover{ color: var(--text-bright); }
+.v2-keeper-chat .ctx-item .ci-chev{ margin-left: 6px; flex: none; font-size: 8px; color: var(--text-dim); transition: transform 0.18s; }
+.v2-keeper-chat .ctx-item-wrap.open .ci-chev{ transform: rotate(90deg); }
+.v2-keeper-chat .ci-detail{ margin: 4px 0 8px; padding: 8px 10px; background: #06070a; border: 1px solid var(--border-soft); border-radius: var(--radius-xs); }
+.v2-keeper-chat .ci-detail .tk{ font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.1em; margin-top: 8px; }
+.v2-keeper-chat .ci-detail .tk:first-child{ margin-top: 0; }
+.v2-keeper-chat .ci-detail pre{ margin: 3px 0 0; font-family: var(--font-mono); font-size: 11px; color: var(--text-mid); line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
+.v2-keeper-chat .cmp-diff{ display: grid; grid-template-columns: 1fr; gap: 10px; }
+.v2-keeper-chat .cmp-col{ border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 9px 11px; }
+.v2-keeper-chat .cmp-col-h{ font-family: var(--font-ui); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 7px; }
+.v2-keeper-chat .cmp-col.kept{ border-left: 2px solid var(--status-ok); }
+.v2-keeper-chat .cmp-col.kept .cmp-col-h{ color: var(--status-ok); }
+.v2-keeper-chat .cmp-col.summ{ border-left: 2px solid var(--info); }
+.v2-keeper-chat .cmp-col.summ .cmp-col-h{ color: var(--info); }
+.v2-keeper-chat .cmp-col.drop{ border-left: 2px solid var(--text-dim); }
+.v2-keeper-chat .cmp-col.drop .cmp-col-h{ color: var(--text-dim); }
+.v2-keeper-chat .cmp-li{ font-size: 12px; line-height: 1.5; color: var(--text-mid); padding: 3px 0; border-top: 1px solid var(--border-soft); }
+.v2-keeper-chat .cmp-li:first-of-type{ border-top: 0; }
+
+.v2-keeper-chat .chat-back, .v2-keeper-chat .chat-ctx-btn{
+  flex: none; width: 34px; height: 34px; border-radius: var(--radius-sm);
+  display: flex; align-items: center; justify-content: center;
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  color: var(--text-mid); font-size: 16px; cursor: pointer; transition: 0.14s;
+}
+.v2-keeper-chat .chat-back:active, .v2-keeper-chat .chat-ctx-btn:active{ transform: translateY(1px); }
+.v2-keeper-chat .chat-ctx-btn{ margin-left: auto; }
+.v2-keeper-chat .chat-back:hover, .v2-keeper-chat .chat-ctx-btn:hover{ border-color: var(--volt-dim); color: var(--volt); }
+
+/* context drawer (mobile) */
+.v2-keeper-chat .ctx-overlay{ position: fixed; inset: 0; background: rgba(4,5,8,0.6); z-index: 60; display: flex; justify-content: flex-end; }
+.v2-keeper-chat .ctx-drawer{ position: relative; width: min(330px, 88vw); height: 100%; animation: turn-in 0.18s ease; box-shadow: -8px 0 30px rgba(0,0,0,0.5); }
+.v2-keeper-chat .ctx-drawer .ctx{ height: 100%; }
+.v2-keeper-chat .ctx-drawer-close{
+  position: absolute; top: 11px; right: 11px; z-index: 3; width: 28px; height: 28px;
+  border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-main);
+  color: var(--text-mid); cursor: pointer; font-size: 12px;
+}
+
+/* scrollbars */
+.v2-keeper-chat .roster-list::-webkit-scrollbar, .v2-keeper-chat .thread::-webkit-scrollbar, .v2-keeper-chat .ctx-scroll::-webkit-scrollbar, .v2-keeper-chat .chat-meta::-webkit-scrollbar{ width: 9px; height: 7px; }
+.v2-keeper-chat .thread::-webkit-scrollbar-thumb, .v2-keeper-chat .roster-list::-webkit-scrollbar-thumb, .v2-keeper-chat .ctx-scroll::-webkit-scrollbar-thumb{ background: var(--border-main); border-radius: var(--radius-md); border: 2px solid transparent; background-clip: padding-box; }
+.v2-keeper-chat .thread::-webkit-scrollbar-thumb:hover{ background: var(--border-highlight); background-clip: padding-box; }
+
+/* ════ RESPONSIVE ════ */
+/* tablet-ish: drop the context rail so chat keeps breathing room (desktop ≥901) */
+@media (min-width: 901px) and (max-width: 1120px) {
+  .v2-keeper-chat .v2-body{ --shrink-ctx: 1; }
+}
+
+/* phones + portrait tablets: single-column master-detail */
+@media (max-width: 900px) {
+  /* top bar trims to crumb + copilot */
+  .v2-keeper-chat .v2-top{ gap: 10px; padding: 0 12px; height: 46px; }
+  .v2-keeper-chat .v2-statchip{ display: none; }
+  .v2-keeper-chat .v2-top .crumb{ font-size: 10px; letter-spacing: 0.08em; }
+  .v2-keeper-chat .topbar-copilot kbd{ display: none; }
+
+  /* nav rail → fixed bottom tab bar */
+  .v2-keeper-chat .v2-nav{
+    position: fixed; left: 0; right: 0; bottom: 0; top: auto;
+    flex-direction: row; height: 56px; gap: 0; padding: 0 4px;
+    border-right: none; border-top: 1px solid var(--border-main);
+    justify-content: space-around; z-index: 50;
+  }
+  .v2-keeper-chat .nav-brand, .v2-keeper-chat .nav-spacer{ display: none; }
+  .v2-keeper-chat .nav-item{ flex: 1 1 0; width: auto; height: 52px; border-radius: 0; }
+  .v2-keeper-chat .nav-item:hover, .v2-keeper-chat .nav-item.on{ background: transparent; }
+  .v2-keeper-chat .nav-item.on::before{ left: 24%; right: 24%; top: 0; bottom: auto; width: auto; height: 3px; border-radius: 0 0 3px 3px; }
+
+  /* hide the bottom bar while reading a thread (full-screen chat) */
+  .v2-keeper-chat .v2-body[data-mpane="chat"] .v2-nav{ display: none; }
+
+  /* in a 1:1 keeper thread the co-view dock is redundant — hide its
+     topbar trigger and floating FAB while reading a thread on mobile */
+  .v2-keeper-chat .v2-body[data-mpane="chat"] .topbar-copilot, .v2-keeper-chat .v2-body[data-mpane="chat"] ~ .dock-fab, .v2-keeper-chat .v2-body[data-mpane="chat"] .dock-fab{ display: none; }
+
+  /* single column; JS already sets gridTemplateColumns:1fr, this is the guard */
+  .v2-keeper-chat .v2-body{ grid-template-columns: 1fr !important; }
+
+  /* master-detail: show one pane at a time */
+  .v2-keeper-chat .v2-body[data-mpane="chat"] .roster{ display: none; }
+  .v2-keeper-chat .v2-body[data-mpane="roster"] .chat-wrap{ display: none; }
+
+  .v2-keeper-chat .roster{ border-right: none; }
+  .v2-keeper-chat .roster-list{ padding-bottom: 76px; }
+
+  .v2-keeper-chat .rail-toggle{ display: none; }
+  .v2-keeper-chat .chat-wrap{ min-width: 0; }
+
+  /* chat header compact + mobile controls */
+  .v2-keeper-chat .chat-head{ padding: 9px 12px; gap: 10px; }
+  .v2-keeper-chat .chat-head .chat-actions{ display: none; }
+  .v2-keeper-chat .chat-id h2{ font-size: 17px; }
+  .v2-keeper-chat .chat-id .name-row{ gap: 8px; }
+  .v2-keeper-chat .chat-id .sub{ gap: 8px; margin-top: 4px; }
+
+  .v2-keeper-chat .thread{ padding-top: 16px; }
+  .v2-keeper-chat .thread-inner{ padding: 0 14px; gap: 18px; }
+  .v2-keeper-chat .composer{ padding: 10px 12px 14px; }
+  .v2-keeper-chat .composer-inner{ padding: 0; }
+
+  /* turn inspector full-width on phones */
+  .v2-keeper-chat .turn-drawer{ width: 100vw; }
+}
+
+@media (max-width: 420px) {
+  .v2-keeper-chat .chat-id .sub > span:nth-child(2){ display: none; } /* drop model on very narrow, keep room + tok/s */
+  .v2-keeper-chat .topbar-copilot span:not(.spark){ display: none; }
+}

--- a/dashboard/src/styles/v2-skin-tokens.css
+++ b/dashboard/src/styles/v2-skin-tokens.css
@@ -1,0 +1,113 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — High-contrast skin tokens
+   Loaded AFTER colors_and_type.css / global.css.
+   ══════════════════════════════════════════════════════════════ */
+[data-skin="v2"] {
+  /* Surfaces — cool neutral charcoal, clean elevation steps */
+  --bg-deep:        #08090d;
+  --bg-panel:       #0f1015;
+  --bg-panel-alt:   #15161d;
+  --bg-card:        #1b1c25;
+  --bg-card-hover:  #23242f;
+  --bg-sunken:      #0a0b0f;
+
+  /* Borders — crisper, cooler */
+  --border-main:      #282a36;
+  --border-soft:      #1e1f29;
+  --border-highlight: #3b3d4e;
+
+  /* Text — bone, pushed bright for reading (raised contrast on mid/dim
+     so 9–11px labels, eyebrows and captions stay legible on dark ground) */
+  --text-bright:  #f7f1e6;
+  --text-primary: #e3dacb;
+  --text-mid:     #c0b7a6;
+  --text-dim:     #968fa1;
+
+  /* Accents — vivid */
+  --accent-blood:     #e8472f;
+  --accent-blood-dim: #7a1a12;
+  --accent-viscera:   #ff6a4d;
+  --accent-brass:     #e0b057;
+  --accent-brass-dim: #8a6a28;
+  --accent-bone:      #e6d8b6;
+  --accent-ice:       #46c6f0;
+  --accent-ice-dim:   #1c6b86;
+  --accent-bile:      #8aa83f;
+
+  /* Information / reference accent — distinct from volt (primary action).
+     Used for mentions, state badges, syntax fns, tool events. Volt-aware:
+     under volt=ice it shifts off-cyan so it never collides with primary. */
+  --info:     var(--accent-ice);
+  --info-dim: var(--accent-ice-dim);
+
+  /* Status — saturated but composed */
+  --status-ok:    #46c66a;
+  --status-warn:  #e0a02a;
+  --status-bad:   #e8472f;
+  --status-idle:  #6b6478;
+  --status-busy:  #46c6f0;
+
+  /* Voltage — the single primary accent (default brass/gold) */
+  --volt:        var(--accent-brass);
+  --volt-strong: #f0c373;
+  --volt-dim:    var(--accent-brass-dim);
+  --volt-ink:    #1a1405;
+  --volt-glow:   rgba(224,176,87,0.22);
+  --volt-wash:   rgba(224,176,87,0.10);
+
+  /* Radius scale — engraved, tiny corners (brand: 2/4/6/…). One ladder;
+     literals below recovered into these tokens. */
+  --radius-2xs: 2px;
+  --radius-xs:  3px;
+  --radius-sm:  4px;   /* chips · tabs · inputs · small controls */
+  --radius-md:  6px;   /* cards · panels · composer */
+  --radius-lg:  10px;  /* large panels */
+
+  /* Spacing scale (2px base) + semantic aliases. Surface padding, card
+     padding and inter-card gaps were drifting (12·13·14 / 22·20…) — these
+     give every surface one rhythm. */
+  --sp-1: 4px;  --sp-2: 6px;  --sp-3: 8px;  --sp-4: 10px; --sp-5: 12px;
+  --sp-6: 14px; --sp-7: 16px; --sp-8: 20px; --sp-9: 24px; --sp-10: 32px;
+  --pad-surface: 22px 26px 40px;  /* surface scroll outer padding */
+  --pad-card:    12px 14px;       /* card / panel body padding */
+  --gap-card:    14px;            /* between sibling cards / panels */
+  --gap-row:     8px;             /* between list rows */
+
+  --shadow-card:   0 1px 3px rgba(0,0,0,0.5);
+  --shadow-panel:  0 4px 22px rgba(0,0,0,0.55);
+  --shadow-pop:    0 12px 40px rgba(0,0,0,0.6), 0 0 0 1px var(--border-main);
+  /* Override the base (dark-fantasy) blood-tinted glow so it tracks volt
+     instead — keeps title/primary glow coherent in every voltage. */
+  --accent-glow:   var(--volt-glow);
+  --shadow-glow:   0 0 20px var(--volt-glow);
+
+  /* v2 type — sharp grotesque replaces the gothic Cinzel */
+  --font-display: 'Space Grotesk', 'Noto Sans KR', system-ui, sans-serif;
+  --font-body:    'Noto Sans KR', 'Space Grotesk', system-ui, sans-serif;
+
+  /* ── TYPE LADDER — one heading system across every surface ──
+     T1 surface/subject title · T2 region/panel title ·
+     T3 card/section header (UPPER) · T4 micro label (UPPER).
+     All display = Space Grotesk, all weight 600. The authoritative
+     selector block lives at the end of surfaces.css. */
+  --fs-t1: 22px; --fw-t1: 600; --tr-t1: -0.005em;  /* bright · sentence */
+  --fs-t2: 16px; --fw-t2: 600; --tr-t2: 0;         /* bright · sentence */
+  --fs-t3: 11px; --fw-t3: 600; --tr-t3: 0.14em;    /* mid · UPPER */
+  --fs-t4: 9px;  --fw-t4: 600; --tr-t4: 0.2em;     /* dim · UPPER */
+}
+
+[data-skin="v2"][data-volt="blood"] {
+  --volt: var(--accent-blood); --volt-strong: #ff6a4d; --volt-dim: var(--accent-blood-dim);
+  --volt-ink: #ffffff; --volt-glow: rgba(232,71,47,0.26); --volt-wash: rgba(232,71,47,0.10);
+}
+[data-skin="v2"][data-volt="ice"] {
+  --volt: var(--accent-ice); --volt-strong: #7ad8f6; --volt-dim: var(--accent-ice-dim);
+  --volt-ink: #04121a; --volt-glow: rgba(70,198,240,0.24); --volt-wash: rgba(70,198,240,0.09);
+  /* primary is now cyan → shift the info accent to violet to stay distinct */
+  --info: #8a6cf0; --info-dim: #4a3aa0;
+}
+
+/* Ensure the skinned root/html/body fill the viewport. */
+[data-skin="v2"],
+[data-skin="v2"] body { height: 100%; }
+


### PR DESCRIPTION
Adds an optional `[data-skin="v2"]` high-contrast skin file and imports it from `global.css` after `v2-theme.css`. This is an additive layer only; it does not overwrite existing chat/theme styles.

### What changed
- New `dashboard/src/styles/v2-high-contrast-skin.css`
- One new import in `dashboard/src/styles/global.css`

### Validation
- `npx tsc --noEmit --pretty` passes in `dashboard/`.