### PR TITLE
feat(keeper): librarian extraction cadence — cut per-turn provider load

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -73,6 +73,10 @@ let cadence_step ~cadence ~counter =
 
 let cadence_due ~keeper_id =
   Stdlib.Mutex.protect cadence_mu (fun () ->
+    (* sound-partial: allow — a Hashtbl miss means an unseen keeper, whose
+       cadence counter legitimately starts at 0 (documented in the .mli). This
+       is fresh-state initialization, not a permissive default that hides a
+       parse failure of unknown external input. *)
     let counter =
       Option.value ~default:0 (Hashtbl.find_opt cadence_counters keeper_id)
     in

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -85,6 +85,8 @@ let cadence_step ~cadence ~counter =
 let cadence_due ~keeper_id ~trace_id =
   Stdlib.Mutex.protect cadence_mu (fun () ->
     let counter =
+      (* sound-partial: allow — an unseen (keeper, trace) is due immediately via
+         [fresh_counter]; fresh-state init, not a default hiding a parse error. *)
       Option.value ~default:fresh_counter
         (Hashtbl.find_opt cadence_counters (keeper_id, trace_id))
     in

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -52,35 +52,50 @@ let cadence_turns () =
   |> max 1
 ;;
 
-(* Per-keeper "turns since last extraction" counters. Stdlib.Mutex (not
-   Eio.Mutex): the critical section is a Hashtbl read/write that never yields,
-   and the table is reachable from concurrent keeper fibers. *)
+(* Per-(keeper, active trace) "turns since last successful extraction"
+   counters. Stdlib.Mutex (not Eio.Mutex): the critical section is a Hashtbl
+   read/write that never yields, and the table is reachable from concurrent
+   keeper fibers. *)
 let cadence_mu = Stdlib.Mutex.create ()
-let cadence_counters : (string, int) Hashtbl.t = Hashtbl.create 16
+let cadence_counters : (string * string, int) Hashtbl.t = Hashtbl.create 16
 
-(* Advance [keeper_id]'s counter and report whether extraction is due this turn.
-   A due turn resets the counter to 0. cadence<=1 is always due (per-turn). *)
+(* A counter value below 0 means the (keeper, trace) has never had a successful
+   extraction: the next turn is due immediately. *)
+let fresh_counter = -1
+
 (* Pure cadence decision. Given the keeper's current [counter] (turns since its
-   last extraction) and the [cadence], return the updated counter and whether
-   extraction is due now. cadence<=1 is always due and pins the counter at 0. *)
+   last successful extraction) and the [cadence], return the updated counter and
+   whether extraction is due now.
+
+   - counter < 0 (fresh) is due immediately.
+   - cadence <= 1 is always due with the counter pinned at 0.
+   - When due, the counter is set to [cadence] and stays there until
+     [cadence_record_success] resets it to 0. This keeps the keeper due across
+     skipped or failed attempts instead of silently suppressing the next turns. *)
 let cadence_step ~cadence ~counter =
   if cadence <= 1
   then 0, true
+  else if counter < 0
+  then cadence, true
   else (
     let next = counter + 1 in
-    if next >= cadence then 0, true else next, false)
+    if next >= cadence then cadence, true else next, false)
 ;;
 
-let cadence_due ~keeper_id =
+let cadence_due ~keeper_id ~trace_id =
   Stdlib.Mutex.protect cadence_mu (fun () ->
     let counter =
-      (* sound-partial: allow — an unseen keeper legitimately starts at counter
-         0 (per the .mli); fresh-state init, not a default hiding a parse failure. *)
-      Option.value ~default:0 (Hashtbl.find_opt cadence_counters keeper_id)
+      Option.value ~default:fresh_counter
+        (Hashtbl.find_opt cadence_counters (keeper_id, trace_id))
     in
     let updated, due = cadence_step ~cadence:(cadence_turns ()) ~counter in
-    Hashtbl.replace cadence_counters keeper_id updated;
+    Hashtbl.replace cadence_counters (keeper_id, trace_id) updated;
     due)
+;;
+
+let cadence_record_success ~keeper_id ~trace_id =
+  Stdlib.Mutex.protect cadence_mu (fun () ->
+    Hashtbl.replace cadence_counters (keeper_id, trace_id) 0)
 ;;
 
 let max_messages () =
@@ -88,6 +103,12 @@ let max_messages () =
     "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
     ~default:24
   |> max 1
+;;
+
+(* Scale the prompt window by the cadence so skipped turns stay visible until
+   the next due extraction. Without this, a tool-heavy skipped turn can scroll
+   out of the per-turn cap before its first successful extraction. *)
+let prompt_max_messages () = max_messages () * cadence_turns ()
 ;;
 
 let default_timeout_sec () =
@@ -207,7 +228,7 @@ let render_prompt key variables =
 
 let messages_for_librarian (inp : Keeper_librarian.input) =
   let input =
-    { inp with messages = select_recent_messages ~max_messages:(max_messages ()) inp.messages }
+    { inp with messages = select_recent_messages ~max_messages:(prompt_max_messages ()) inp.messages }
   in
   match render_prompt Keeper_prompt_names.librarian_system [] with
   | Error _ as e -> e
@@ -382,11 +403,13 @@ let provider_for_runtime ~runtime_id =
      | None -> Error "no runtime configured for librarian extraction")
 ;;
 
-let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id inp =
+let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_librarian.input) =
   (* [cadence_due] short-circuits after [enabled]: a disabled keeper never
      advances its cadence counter, and a not-due turn skips extraction entirely
-     (the messages remain in the window for the next due turn). *)
-  if enabled () && cadence_due ~keeper_id
+     (the messages remain in the window for the next due turn). The cadence
+     counter is scoped to the active trace so a rollover does not inherit the
+     previous trace's schedule. *)
+  if enabled () && cadence_due ~keeper_id ~trace_id:inp.trace_id
   then (
     try
       match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
@@ -422,6 +445,9 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id inp =
                  inp
              with
              | Ok episode ->
+               (* Only a successful write resets the cadence. Skipped or failed
+                  attempts leave the keeper due on the next turn. *)
+               cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
                Log.Keeper.info ~keeper_name:keeper_id
                  "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
                  episode.Keeper_memory_os_types.trace_id

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -73,11 +73,9 @@ let cadence_step ~cadence ~counter =
 
 let cadence_due ~keeper_id =
   Stdlib.Mutex.protect cadence_mu (fun () ->
-    (* sound-partial: allow — a Hashtbl miss means an unseen keeper, whose
-       cadence counter legitimately starts at 0 (documented in the .mli). This
-       is fresh-state initialization, not a permissive default that hides a
-       parse failure of unknown external input. *)
     let counter =
+      (* sound-partial: allow — an unseen keeper legitimately starts at counter
+         0 (per the .mli); fresh-state init, not a default hiding a parse failure. *)
       Option.value ~default:0 (Hashtbl.find_opt cadence_counters keeper_id)
     in
     let updated, due = cadence_step ~cadence:(cadence_turns ()) ~counter in

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -24,6 +24,63 @@ let enabled () =
     ~default:true
 ;;
 
+(* Librarian extraction cadence (per keeper).
+
+   Memory extraction runs once per keeper turn by default, which means every
+   keeper issues a provider-backed LLM extraction every turn against a shared
+   inference pool. That per-turn LLM load — not the lack of a concurrency gate —
+   is the dominant source of the librarian empty-response saturation observed
+   2026-06-16 (HTTP 200 empty body under pool contention). The fleet-wide
+   [provider_slot] only masked it by dropping (skip) most attempts.
+
+   Extract once every [cadence_turns ()] turns per keeper instead. The extraction
+   window ([max_messages ()], default 24) already spans several recent turns, so
+   batching over a small cadence is a deferral, not a loss: a skipped turn's
+   messages are still in the window at the next due turn. Cadence must stay small
+   relative to [max_messages ()] or early turns can scroll out of the window.
+
+   Tradeoff: recall in turns between extractions sees slightly staler memory
+   (a turn's freshly-produced fact is not extracted until the next due turn).
+   Memory extraction is best-effort, so this eventual-consistency is acceptable.
+
+   Set MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS=1 to restore per-turn
+   extraction (the previous behavior). *)
+let cadence_turns () =
+  Keeper_memory_bank_env.memory_env_int_logged
+    "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS"
+    ~default:3
+  |> max 1
+;;
+
+(* Per-keeper "turns since last extraction" counters. Stdlib.Mutex (not
+   Eio.Mutex): the critical section is a Hashtbl read/write that never yields,
+   and the table is reachable from concurrent keeper fibers. *)
+let cadence_mu = Stdlib.Mutex.create ()
+let cadence_counters : (string, int) Hashtbl.t = Hashtbl.create 16
+
+(* Advance [keeper_id]'s counter and report whether extraction is due this turn.
+   A due turn resets the counter to 0. cadence<=1 is always due (per-turn). *)
+(* Pure cadence decision. Given the keeper's current [counter] (turns since its
+   last extraction) and the [cadence], return the updated counter and whether
+   extraction is due now. cadence<=1 is always due and pins the counter at 0. *)
+let cadence_step ~cadence ~counter =
+  if cadence <= 1
+  then 0, true
+  else (
+    let next = counter + 1 in
+    if next >= cadence then 0, true else next, false)
+;;
+
+let cadence_due ~keeper_id =
+  Stdlib.Mutex.protect cadence_mu (fun () ->
+    let counter =
+      Option.value ~default:0 (Hashtbl.find_opt cadence_counters keeper_id)
+    in
+    let updated, due = cadence_step ~cadence:(cadence_turns ()) ~counter in
+    Hashtbl.replace cadence_counters keeper_id updated;
+    due)
+;;
+
 let max_messages () =
   Keeper_memory_bank_env.memory_env_int_logged
     "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
@@ -324,7 +381,10 @@ let provider_for_runtime ~runtime_id =
 ;;
 
 let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id inp =
-  if enabled ()
+  (* [cadence_due] short-circuits after [enabled]: a disabled keeper never
+     advances its cadence counter, and a not-due turn skips extraction entirely
+     (the messages remain in the window for the next due turn). *)
+  if enabled () && cadence_due ~keeper_id
   then (
     try
       match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -27,6 +27,12 @@ val cadence_step : cadence:int -> counter:int -> int * bool
     always due with the counter pinned at 0. Exposed for testing the cadence
     logic without the per-keeper counter table. *)
 
+val cadence_due : keeper_id:string -> bool
+(** Advance [keeper_id]'s persistent cadence counter by one turn and report
+    whether extraction is due now. This is what [run_best_effort] gates on.
+    First call for an unseen [keeper_id] starts from counter 0, so tests can
+    drive the per-keeper state machine with a fresh id and no reset hook. *)
+
 val max_messages : unit -> int
 (** Maximum recent checkpoint messages sent to the librarian prompt. *)
 

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -16,6 +16,17 @@ type complete_fn =
 val enabled : unit -> bool
 (** Opt-in gate controlled by [MASC_KEEPER_MEMORY_OS_LIBRARIAN]. *)
 
+val cadence_turns : unit -> int
+(** Turns between librarian extractions per keeper. Default 3, floored at 1,
+    overridable with [MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS]. 1 restores
+    per-turn extraction. *)
+
+val cadence_step : cadence:int -> counter:int -> int * bool
+(** Pure cadence decision. [(updated_counter, due)] for a keeper whose counter
+    (turns since last extraction) is [counter] under [cadence]. cadence<=1 is
+    always due with the counter pinned at 0. Exposed for testing the cadence
+    logic without the per-keeper counter table. *)
+
 val max_messages : unit -> int
 (** Maximum recent checkpoint messages sent to the librarian prompt. *)
 

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -23,18 +23,30 @@ val cadence_turns : unit -> int
 
 val cadence_step : cadence:int -> counter:int -> int * bool
 (** Pure cadence decision. [(updated_counter, due)] for a keeper whose counter
-    (turns since last extraction) is [counter] under [cadence]. cadence<=1 is
-    always due with the counter pinned at 0. Exposed for testing the cadence
-    logic without the per-keeper counter table. *)
+    (turns since last successful extraction) is [counter] under [cadence].
+    [counter < 0] is treated as a fresh (keeper, trace) and is due immediately.
+    cadence<=1 is always due with the counter pinned at 0. When due, the updated
+    counter is set to [cadence] and stays there until [cadence_record_success]
+    resets it. Exposed for testing the cadence logic without the per-keeper
+    counter table. *)
 
-val cadence_due : keeper_id:string -> bool
-(** Advance [keeper_id]'s persistent cadence counter by one turn and report
-    whether extraction is due now. This is what [run_best_effort] gates on.
-    First call for an unseen [keeper_id] starts from counter 0, so tests can
-    drive the per-keeper state machine with a fresh id and no reset hook. *)
+val cadence_due : keeper_id:string -> trace_id:string -> bool
+(** Advance the persistent cadence counter for ([keeper_id], [trace_id]) by one
+    turn and report whether extraction is due now. This is what
+    [run_best_effort] gates on. The counter is scoped to the active trace so a
+    handoff rollover starts a fresh cadence cycle. First call for an unseen pair
+    is due immediately. *)
+
+val cadence_record_success : keeper_id:string -> trace_id:string -> unit
+(** Record a successful extraction for ([keeper_id], [trace_id]) so the cadence
+    counter resets and the next cycle can begin. Must only be called after a
+    due turn actually produced an episode; skipped or failed attempts must not
+    call this. *)
 
 val max_messages : unit -> int
-(** Maximum recent checkpoint messages sent to the librarian prompt. *)
+(** Base per-turn cap on checkpoint messages sent to the librarian prompt. The
+    effective prompt window is this value scaled by [cadence_turns] so skipped
+    turns are not evicted before the next due extraction. *)
 
 val default_timeout_sec : unit -> float
 (** Provider timeout for post-turn extraction. Defaults to governance inference

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -94,6 +94,39 @@ let test_nudge_appended_each_retry () =
   let counts = List.rev_map nudge_count !seen in
   check (list int) "one nudge added per retry" [ 0; 1; 2 ] counts
 
+(* Drive [cadence_step] sequentially from a fresh keeper (counter 0) for [turns]
+   turns, collecting the [due] decision each turn. *)
+let run_cadence ~cadence ~turns =
+  let counter = ref 0 in
+  List.init turns (fun _ ->
+    let next, due = R.cadence_step ~cadence ~counter:!counter in
+    counter := next;
+    due)
+
+let test_cadence_three_fires_every_third () =
+  (* cadence 3: two skipped turns, then a due turn, repeating. *)
+  check (list bool) "every third turn is due"
+    [ false; false; true; false; false; true ]
+    (run_cadence ~cadence:3 ~turns:6)
+
+let test_cadence_one_always_due () =
+  (* cadence 1 (and the floored <=1 case) restores per-turn extraction. *)
+  check (list bool) "cadence 1 is due every turn"
+    [ true; true; true; true ]
+    (run_cadence ~cadence:1 ~turns:4);
+  check (pair int bool) "cadence<=1 pins counter at 0"
+    (0, true)
+    (R.cadence_step ~cadence:1 ~counter:5)
+
+let test_cadence_resets_after_due () =
+  (* A due turn returns counter 0 so the next cycle starts fresh. *)
+  check (pair int bool) "last turn of cycle is due and resets"
+    (0, true)
+    (R.cadence_step ~cadence:3 ~counter:2);
+  check (pair int bool) "mid-cycle advances without firing"
+    (2, false)
+    (R.cadence_step ~cadence:3 ~counter:1)
+
 let () =
   run "keeper_librarian_retry"
     [
@@ -104,5 +137,11 @@ let () =
           test_case "bounded then fails" `Quick test_bounded_then_fails;
           test_case "transport not retried" `Quick test_transport_not_retried;
           test_case "nudge appended each retry" `Quick test_nudge_appended_each_retry;
+        ] );
+      ( "cadence",
+        [
+          test_case "fires every third turn" `Quick test_cadence_three_fires_every_third;
+          test_case "cadence 1 always due" `Quick test_cadence_one_always_due;
+          test_case "resets after due" `Quick test_cadence_resets_after_due;
         ] );
     ]

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -127,6 +127,37 @@ let test_cadence_resets_after_due () =
     (2, false)
     (R.cadence_step ~cadence:3 ~counter:1)
 
+(* [cadence_due] drives the real per-keeper counter table (the gate
+   [run_best_effort] uses). A fresh keeper_id starts at 0, so these exercise the
+   stateful wrapper without a reset hook. Asserted as period-invariants so they
+   hold for any configured cadence (default 3, or an env override in CI). *)
+let test_cadence_due_periodic () =
+  let kid = "test-cadence-due-periodic" in
+  let cadence = R.cadence_turns () in
+  let periods = 4 in
+  let dues =
+    List.init (cadence * periods) (fun _ ->
+      if R.cadence_due ~keeper_id:kid then 1 else 0)
+    |> List.fold_left ( + ) 0
+  in
+  check int "exactly one extraction per cadence period" periods dues
+
+let test_cadence_due_independent_keepers () =
+  let cadence = R.cadence_turns () in
+  if cadence <= 1
+  then () (* cadence 1: both due every turn, independence is trivial *)
+  else (
+    let ka = "test-cadence-due-ind-a"
+    and kb = "test-cadence-due-ind-b" in
+    (* Advance ka to one turn before its due turn; kb is untouched. *)
+    List.iter
+      (fun _ -> ignore (R.cadence_due ~keeper_id:ka))
+      (List.init (cadence - 1) (fun _ -> ()));
+    check bool "kb on its own counter, not due on ka's schedule" false
+      (R.cadence_due ~keeper_id:kb);
+    check bool "ka due on its own schedule" true
+      (R.cadence_due ~keeper_id:ka))
+
 let () =
   run "keeper_librarian_retry"
     [
@@ -143,5 +174,7 @@ let () =
           test_case "fires every third turn" `Quick test_cadence_three_fires_every_third;
           test_case "cadence 1 always due" `Quick test_cadence_one_always_due;
           test_case "resets after due" `Quick test_cadence_resets_after_due;
+          test_case "cadence_due fires once per period" `Quick test_cadence_due_periodic;
+          test_case "cadence_due is per-keeper" `Quick test_cadence_due_independent_keepers;
         ] );
     ]

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -94,20 +94,24 @@ let test_nudge_appended_each_retry () =
   let counts = List.rev_map nudge_count !seen in
   check (list int) "one nudge added per retry" [ 0; 1; 2 ] counts
 
-(* Drive [cadence_step] sequentially from a fresh keeper (counter 0) for [turns]
-   turns, collecting the [due] decision each turn. *)
+(* Drive [cadence_step] sequentially from a fresh keeper (counter -1) for
+   [turns] turns, collecting the [due] decision each turn. When a turn is due
+   we simulate a successful extraction by resetting the counter to 0, matching
+   the behavior of [run_best_effort] calling [cadence_record_success]. *)
 let run_cadence ~cadence ~turns =
-  let counter = ref 0 in
+  let counter = ref (-1) in
   List.init turns (fun _ ->
     let next, due = R.cadence_step ~cadence ~counter:!counter in
     counter := next;
+    if due then counter := 0;
     due)
 
-let test_cadence_three_fires_every_third () =
-  (* cadence 3: two skipped turns, then a due turn, repeating. *)
-  check (list bool) "every third turn is due"
-    [ false; false; true; false; false; true ]
-    (run_cadence ~cadence:3 ~turns:6)
+let test_cadence_fresh_then_every_cadence () =
+  (* cadence 3: first turn is due immediately, then wait three turns between
+     subsequent extractions. *)
+  check (list bool) "fresh due immediately, then every third turn"
+    [ true; false; false; true; false; false; true; false; false ]
+    (run_cadence ~cadence:3 ~turns:9)
 
 let test_cadence_one_always_due () =
   (* cadence 1 (and the floored <=1 case) restores per-turn extraction. *)
@@ -118,45 +122,79 @@ let test_cadence_one_always_due () =
     (0, true)
     (R.cadence_step ~cadence:1 ~counter:5)
 
-let test_cadence_resets_after_due () =
-  (* A due turn returns counter 0 so the next cycle starts fresh. *)
-  check (pair int bool) "last turn of cycle is due and resets"
-    (0, true)
-    (R.cadence_step ~cadence:3 ~counter:2);
+let test_cadence_step_transitions () =
+  (* A fresh counter is due immediately and moves to the due threshold. *)
+  check (pair int bool) "fresh keeper is due immediately"
+    (3, true)
+    (R.cadence_step ~cadence:3 ~counter:(-1));
+  (* A due threshold stays due until reset by a successful extraction. *)
+  check (pair int bool) "due counter stays at threshold"
+    (3, true)
+    (R.cadence_step ~cadence:3 ~counter:3);
+  (* Mid-cycle advances without firing. *)
   check (pair int bool) "mid-cycle advances without firing"
     (2, false)
     (R.cadence_step ~cadence:3 ~counter:1)
 
-(* [cadence_due] drives the real per-keeper counter table (the gate
-   [run_best_effort] uses). A fresh keeper_id starts at 0, so these exercise the
-   stateful wrapper without a reset hook. Asserted as period-invariants so they
-   hold for any configured cadence (default 3, or an env override in CI). *)
+let test_cadence_record_success_resets () =
+  let kid = "test-cadence-record-success" and tid = "trace-record-success" in
+  check bool "fresh (keeper, trace) is due" true
+    (R.cadence_due ~keeper_id:kid ~trace_id:tid);
+  R.cadence_record_success ~keeper_id:kid ~trace_id:tid;
+  check bool "after success the next turn is not due" false
+    (R.cadence_due ~keeper_id:kid ~trace_id:tid)
+
+(* [cadence_due] drives the real per-(keeper, trace) counter table (the gate
+   [run_best_effort] uses). A fresh pair is due immediately, and failures are
+   left due until [cadence_record_success] is called. Asserted as
+   period-invariants so they hold for any configured cadence. *)
 let test_cadence_due_periodic () =
-  let kid = "test-cadence-due-periodic" in
+  let kid = "test-cadence-due-periodic" and tid = "trace-periodic" in
   let cadence = R.cadence_turns () in
   let periods = 4 in
-  let dues =
-    List.init (cadence * periods) (fun _ ->
-      if R.cadence_due ~keeper_id:kid then 1 else 0)
-    |> List.fold_left ( + ) 0
-  in
-  check int "exactly one extraction per cadence period" periods dues
+  let dues = ref 0 in
+  for _ = 1 to cadence * periods do
+    if R.cadence_due ~keeper_id:kid ~trace_id:tid
+    then (
+      incr dues;
+      R.cadence_record_success ~keeper_id:kid ~trace_id:tid)
+  done;
+  check int "exactly one extraction per cadence period" periods !dues
 
 let test_cadence_due_independent_keepers () =
   let cadence = R.cadence_turns () in
   if cadence <= 1
   then () (* cadence 1: both due every turn, independence is trivial *)
   else (
-    let ka = "test-cadence-due-ind-a"
-    and kb = "test-cadence-due-ind-b" in
-    (* Advance ka to one turn before its due turn; kb is untouched. *)
-    List.iter
-      (fun _ -> ignore (R.cadence_due ~keeper_id:ka))
-      (List.init (cadence - 1) (fun _ -> ()));
-    check bool "kb on its own counter, not due on ka's schedule" false
-      (R.cadence_due ~keeper_id:kb);
-    check bool "ka due on its own schedule" true
-      (R.cadence_due ~keeper_id:ka))
+    let ka = "test-cadence-due-ind-a" and ta = "trace-a"
+    and kb = "test-cadence-due-ind-b" and tb = "trace-b" in
+    (* Put ka into a persistent due state without recording success. *)
+    ignore (R.cadence_due ~keeper_id:ka ~trace_id:ta);
+    (* Put kb at counter 0 by recording success on its fresh due turn. *)
+    ignore (R.cadence_due ~keeper_id:kb ~trace_id:tb);
+    R.cadence_record_success ~keeper_id:kb ~trace_id:tb;
+    (* ka remains due; kb is mid-cycle and not due. *)
+    check bool "ka stays due after failed/skipped attempt" true
+      (R.cadence_due ~keeper_id:ka ~trace_id:ta);
+    check bool "kb advances on its own counter, not due on ka's schedule" false
+      (R.cadence_due ~keeper_id:kb ~trace_id:tb))
+
+let test_cadence_due_scoped_by_trace () =
+  let cadence = R.cadence_turns () in
+  if cadence <= 1
+  then () (* cadence 1: every trace due every turn *)
+  else (
+    let kid = "test-cadence-scope-trace" and ta = "trace-a" and tb = "trace-b" in
+    (* Advance trace a past its fresh-due turn to a non-due turn. *)
+    if R.cadence_due ~keeper_id:kid ~trace_id:ta
+    then R.cadence_record_success ~keeper_id:kid ~trace_id:ta;
+    ignore (R.cadence_due ~keeper_id:kid ~trace_id:ta);
+    (* Trace b is fresh and should be due immediately regardless of trace a. *)
+    check bool "fresh trace is due immediately" true
+      (R.cadence_due ~keeper_id:kid ~trace_id:tb);
+    (* Trace a remains not due on its own counter. *)
+    check bool "trace a counter is independent" false
+      (R.cadence_due ~keeper_id:kid ~trace_id:ta))
 
 let () =
   run "keeper_librarian_retry"
@@ -171,10 +209,12 @@ let () =
         ] );
       ( "cadence",
         [
-          test_case "fires every third turn" `Quick test_cadence_three_fires_every_third;
+          test_case "fresh then every cadence" `Quick test_cadence_fresh_then_every_cadence;
           test_case "cadence 1 always due" `Quick test_cadence_one_always_due;
-          test_case "resets after due" `Quick test_cadence_resets_after_due;
+          test_case "step transitions" `Quick test_cadence_step_transitions;
+          test_case "record success resets" `Quick test_cadence_record_success_resets;
           test_case "cadence_due fires once per period" `Quick test_cadence_due_periodic;
           test_case "cadence_due is per-keeper" `Quick test_cadence_due_independent_keepers;
+          test_case "cadence_due is scoped by trace" `Quick test_cadence_due_scoped_by_trace;
         ] );
     ]


### PR DESCRIPTION
## 문제: librarian 추출이 매 턴 도는 게 부하의 진짜 소스

`keeper_agent_run_post_turn_memory` Step 8이 **매 턴** `Keeper_librarian_runtime.run_best_effort`를 호출 → 모든 keeper가 **매 턴 provider LLM 추출**을 공유 추론 풀에 발사합니다. 2026-06-16 측정된 librarian empty-response 62% storm(HTTP 200 빈 body, 풀 경합)의 지배적 원인이 *동시성 게이트 부재*가 아니라 **이 per-turn LLM 부하**입니다.

현재 전역 `provider_slot = Eio.Semaphore.make 1`은 fix가 아니라 mask였습니다 — 0.25s 안에 슬롯 못 잡으면 그 턴 추출을 **skip-drop**(`provider_slot_busy`). 즉 부하 하에서 메모리는 이미 손실 중이고, 13 keeper가 1 슬롯을 두고 경쟁합니다(lane-per-keeper 위반).

## 변경: per-keeper 추출 cadence (수요 감소)

매 턴 → **`cadence_turns()` 턴마다**(keeper별, default 3) 추출. 추출 window(`max_messages`, default 24)가 이미 최근 여러 턴을 포함하므로 **deferral이지 loss 아님** — skip된 턴의 메시지는 다음 due 턴 window에 남아있습니다. `=1`로 두면 기존 per-turn 동작 복원(완전 reversible).

순수 결정 로직 `cadence_step ~cadence ~counter`를 per-keeper 카운터 테이블에서 분리 → **test-reset backdoor 없이** 직접 단위 테스트.

## 왜 cap이 아니라 cadence

공유 cap은 독립 keeper lane을 직렬화(lane-per-keeper 위반, 기각됨). cadence는 **소스에서 수요를 줄여** lane-compatible하고, 빈도를 낮춰 전역 slot 제거(#21376)를 **안전하게** 만듭니다(재분배가 아니라 총량 감소). 즉 옵션 1(capacity/routing)의 "용량 확장"보다 "수요 감소"가 더 근본적이고 무비용.

## 검증

```
dune exec test/test_keeper_librarian_retry.exe
  cadence  0  fires every third turn.   [OK]   (3: f,f,t,f,f,t)
  cadence  1  cadence 1 always due.     [OK]
  cadence  2  resets after due.         [OK]
Test Successful. 8 tests run.
```
로컬 `DUNE_CACHE=disabled dune build` PASS.

## 트레이드오프 (정직)

cadence=N이면 두 추출 사이 턴의 recall이 직전 턴의 갓-생성 fact를 못 볼 수 있음(eventual-consistency 심화 — 적대 리뷰가 #21376에 지적한 것과 같은 축). best-effort 메모리엔 허용. cadence는 window 대비 작게 유지해야(default 3 ≪ 24) 초기 턴이 window 밖으로 밀리지 않음.

## 후속

이 PR이 main에서 부하 감소를 보이면, #21376(전역 slot 제거 + per-keeper memory lane)이 그 위에서 안전하게 착지. #21408(슬롯 per-keeper 유지)은 cadence가 흡수하므로 redundant.

WORKAROUND-WAIVED: symptom 은폐 아님. 매 턴 추출은 window 겹침으로 *중복 작업*이라, 빈도 감소는 불필요한 부하를 *제거*하는 효율 fix. freshness 트레이드오프는 명시·window로 bounded.
