### PR TITLE
fix(fusion): pattern-match create_post result against Board.post, not unit

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -171,7 +171,7 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judge_usage :
          ~post_kind:Board.System_post ?meta_json ~visibility:Board.Internal
          ~ttl_hours:board_post_ttl_hours ()
      with
-     | Ok () -> Ok ()
+     | Ok _post -> Ok ()
      | Error e -> Error (Board.show_board_error e))
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn


### PR DESCRIPTION
Quick compile fix for the regression introduced by #21425.

`Board_dispatch.create_post` returns `(Board.post, _) Result.t`, but `fusion_sink.ml` was matching `Ok ()`. This breaks `dune build @install` on current `main` and blocks any rebased PR from passing Lint.

Fixes #21459