### PR TITLE
chore(fusion): enable masc_fusion by default (personal canary)

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -180,14 +180,15 @@ nick0cave = "ollama.gemma4-26b-a4b-qat"
 trigger_policy = "mention_or_thread"
 
 # ── Fusion 패널+심판 심의 (RFC-0252) ─────────────────────────────────
-# masc_fusion 도구의 out-of-band 심의 루프 설정. 기본 OFF (opt-in).
+# masc_fusion 도구의 out-of-band 심의 루프 설정. 개인 dev 카나리로 기본 ON.
+# harness(RFC-0252 §11) 미검증 — 카나리 출력(panel 답 + judge 종합)으로 사후 판단.
 # [fusion] 섹션이 없거나 enabled=false면 masc_fusion 호출은 게이트에서
 # Deny로 즉시 반환되고 모델을 호출하지 않는다.
 #
 # 패널/심판 모델 문자열은 위의 <provider>.<model> 런타임 id를 그대로 쓴다.
 # 패널은 1..8개. 심판은 패널 답변을 종합한다.
 [fusion]
-enabled = false
+enabled = true
 default_preset = "trio"
 # 동시에 띄울 수 있는 패널 수 (Async_agent.all max_fibers 상한).
 max_concurrent_panels = 2


### PR DESCRIPTION
## 변경
`config/runtime.toml [fusion] enabled = false → true`. masc_fusion out-of-band 심의를 기본 ON.

## 맥락 — 개인 dev 카나리
masc는 single-user(개인 멀티에이전트 시스템)라 팀 영향 없는 개인 카나리입니다. 키퍼가 고위험/저확신 결정에서 `masc_fusion`을 자율 호출하면 panel N + judge 종합이 out-of-band로 돌고, 결론이 키퍼 chat lane에 도착합니다.

- preset `trio`: panel[`deepseek-v4-pro`, `glm-5-turbo`, `deepseek-v4-flash`] + judge[`deepseek-v4-pro`]
- 안전망: `per_hour_budget=20`(시간당 cap) + out-of-band(턴 비차단)

## 미검증 (정직)
- **harness(RFC-0252 §11) 미측정**: fusion이 single/self-consistency보다 나은지 delta가 0입니다. 카나리 출력으로 사후 판단합니다.
- **panel 모델 provider 미확인**: 4개 runtime_id가 배포 환경에 등록됐는지 확인 필요(없으면 호출 시 `Failed(build failed)`).

## 검증 계획 (카나리)
1. 배포 후 키퍼가 `masc_fusion` 호출.
2. board(panel 답 N + judge 종합 + observed_usage) + 키퍼 chat lane 결론 확인.
3. "single 한 번보다 쓸만한가" 사람 판단 → OK면 default ON 유지, 아니면 revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
