### PR TITLE
fix(exec_policy): exempt gh REST endpoints from shell-IR path jail

### DIFF
--- a/lib/exec_policy/exec_policy.ml
+++ b/lib/exec_policy/exec_policy.ml
@@ -362,6 +362,29 @@ let git_revisionish_token ?workdir token =
   not (Sys.file_exists resolved)
 ;;
 
+(* [gh] positional args are issue/PR numbers, refs, repo specs, and REST or
+   GraphQL API endpoints (e.g. [gh api /repos/owner/repo/check-runs]) — not
+   filesystem paths.  The descriptor intentionally excludes [gh] from
+   [command_materializes_path_arg], but the [looks_like_path_token] fallback
+   still flagged a leading-[/] endpoint as an absolute path and jailed it,
+   blocking legitimate [gh api /repos/...] calls.
+
+   A token is endpoint-ish when it contains [/], has no [..] traversal
+   segment, and does NOT resolve to an existing file.  This mirrors
+   [git_revisionish_token] but permits the explicit leading-[/] form that gh
+   api endpoints use.  The not-existing-file clause keeps real file arguments
+   jailed: [gh release upload v1 /etc/passwd] resolves to an existing file, so
+   it stays subject to the whitelist, and any [..] traversal is rejected. *)
+let gh_endpointish_token ?workdir token =
+  let token = String.trim token in
+  token <> ""
+  && String.contains token '/'
+  && not (token_has_parent_dir_segment token)
+  &&
+  let resolved = resolve_path ?base_dir:workdir token in
+  not (Sys.file_exists resolved)
+;;
+
 let token_value_is_redirect_to_dev_null value =
   String.equal value ">/dev/null"
   || String.equal value "2>/dev/null"
@@ -658,6 +681,10 @@ let validate_shell_ir_paths ?keeper_id ?base_path ?workdir shell_ir =
             | None
               when String.equal command_name "git"
                    && git_revisionish_token ?workdir value ->
+              validate_path_values ~command_name false rest
+            | None
+              when String.equal command_name "gh"
+                   && gh_endpointish_token ?workdir value ->
               validate_path_values ~command_name false rest
             | None when looks_like_path_token value ->
               (match validate_path_value ~requires_existing_dir:false value with

--- a/test/dune
+++ b/test/dune
@@ -1432,6 +1432,8 @@
 
 (include stanzas/test_exec_policy_path_arg_descriptor.inc)
 
+(include stanzas/test_exec_policy_gh_endpoint_jail.inc)
+
 (include stanzas/test_export_symbol_graph.inc)
 
 (include stanzas/test_feature_flag_registry.inc)

--- a/test/stanzas/test_exec_policy_gh_endpoint_jail.inc
+++ b/test/stanzas/test_exec_policy_gh_endpoint_jail.inc
@@ -1,0 +1,8 @@
+; RFC-0254 follow-up — end-to-end coverage that gh REST/GraphQL endpoints
+; are exempt from the Exec_policy path jail while real file args and [..]
+; traversals stay jailed.
+
+(test
+ (name test_exec_policy_gh_endpoint_jail)
+ (modules test_exec_policy_gh_endpoint_jail)
+ (libraries masc.exec_policy masc.masc_exec))

--- a/test/test_exec_policy_gh_endpoint_jail.ml
+++ b/test/test_exec_policy_gh_endpoint_jail.ml
@@ -1,0 +1,65 @@
+(** RFC-0254 follow-up — gh REST/GraphQL endpoint path-jail false positive.
+
+    [Exec_policy.validate_shell_ir_paths] jailed [gh api /repos/...] because
+    the [looks_like_path_token] fallback treated the leading-[/] REST endpoint
+    as an absolute filesystem path. The descriptor intentionally excludes [gh]
+    from path-materializing commands (its positional args are issue numbers,
+    refs, repo specs, and API endpoints), so these tests pin that a gh endpoint
+    is exempt from the jail while a real file argument and any [..] traversal
+    stay jailed. End-to-end against [Exec_policy.validate_shell_ir_paths]. *)
+
+module Shell_ir = Masc_exec.Shell_ir
+module Exec_program = Masc_exec.Exec_program
+module Sandbox_target = Masc_exec.Sandbox_target
+
+let lit s = Shell_ir.Lit (s, Shell_ir.default_meta)
+
+let bin name =
+  match Exec_program.of_string name with
+  | Ok b -> b
+  (* bin must classify *)
+  | Error _ -> assert false
+
+let ir name args : Shell_ir.t =
+  Shell_ir.Simple
+    {
+      bin = bin name;
+      args = List.map lit args;
+      env = [];
+      cwd = None;
+      redirects = [];
+      sandbox = Sandbox_target.host ();
+    }
+
+let workdir = "/tmp"
+let is_ok = function Ok () -> true | Error _ -> false
+let is_err = function Error _ -> true | Ok () -> false
+
+(* The reported false positive: a gh api REST endpoint with a leading slash
+   must not be jailed as an absolute filesystem path. *)
+let test_gh_api_endpoint_allowed () =
+  let shell_ir = ir "gh" [ "api"; "/repos/jeong-sik/masc/check-runs?head_sha=abc" ] in
+  assert (is_ok (Exec_policy.validate_shell_ir_paths ~workdir shell_ir))
+
+(* Repo-spec / no-leading-slash endpoint form is exempt too. *)
+let test_gh_api_repo_spec_allowed () =
+  let shell_ir = ir "gh" [ "api"; "repos/jeong-sik/masc/pulls/21434" ] in
+  assert (is_ok (Exec_policy.validate_shell_ir_paths ~workdir shell_ir))
+
+(* Safety: a [..] traversal under gh is still jailed. *)
+let test_gh_parent_traversal_blocked () =
+  let shell_ir = ir "gh" [ "api"; "../../../etc/passwd" ] in
+  assert (is_err (Exec_policy.validate_shell_ir_paths ~workdir shell_ir))
+
+(* Safety: the exemption is gh-specific. A path-materializing command (cat)
+   with the same look-alike token stays jailed. *)
+let test_non_gh_endpointlike_token_blocked () =
+  let shell_ir = ir "cat" [ "/repos/jeong-sik/masc/secret" ] in
+  assert (is_err (Exec_policy.validate_shell_ir_paths ~workdir shell_ir))
+
+let () =
+  test_gh_api_endpoint_allowed ();
+  test_gh_api_repo_spec_allowed ();
+  test_gh_parent_traversal_blocked ();
+  test_non_gh_endpointlike_token_blocked ();
+  print_endline "[test_exec_policy_gh_endpoint_jail] all tests passed"


### PR DESCRIPTION
## 문제

라이브 keeper 로그에서 `gh api /repos/jeong-sik/masc/check-runs?head_sha=...` 호출이 `shell_ir path_reject`로 차단됨 ("Path blocked: /repos/... outside allowed directories"). `Exec_policy.validate_shell_ir_paths`의 `looks_like_path_token` fallback이 gh REST 엔드포인트(`/`로 시작)를 절대 파일시스템 경로로 오인한 false-positive.

## 근본 원인

`exec_policy_path_arg_descriptor.ml`은 의도적으로 `git`/`gh`를 `command_materializes_path_arg`에서 제외하고("positional args are revisions/refs/issue-numbers, not paths") 있으나, `validate_path_values`의 fallback이 descriptor 미매치 토큰에 여전히 발화한다. `git`은 `git_revisionish_token` 예외가 있지만 `gh`는 없어 엔드포인트가 path-jail에 걸렸다.

## 수정

`git_revisionish_token`과 동일 패턴의 `gh_endpointish_token` 추가 + `validate_path_values`에 gh arm(git arm 바로 뒤, fallback 앞). 토큰이 `/` 포함 + `..` traversal 없음 + resolve 시 실재 파일 아님 → REST 엔드포인트/repo-spec로 보고 면제.

defense-in-depth 보존: 실재 파일 인자(`gh release upload v1 /etc/passwd`)는 계속 whitelist 적용, `..` traversal도 계속 차단. 면제는 gh 전용(`cat /repos/...`는 여전히 jailed).

## 검증

end-to-end 테스트 `test/test_exec_policy_gh_endpoint_jail.ml` (4 케이스: 엔드포인트 허용 ×2, traversal 차단, 비-gh 차단) — `dune exec` green. `lib/exec_policy` 단독 빌드 green. ocamlformat green.

## RFC

RFC-0254 §5.4/§6이 명시하는 "catastrophic/path는 approval gate 하류의 `Exec_policy.validate_shell_ir_paths`가 jail한다"는 전제의 그 path-jail에서 발생한 false-positive 수정. RFC-0254 후속 (gate 자체는 무변경, downstream jail 정합만 교정).
