### PR TITLE
feat(dashboard): keeper-v2 Dark Fantasy default over StyleSeed token layer + readable type

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="ko" data-skin="v2" data-volt="ice">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -24,21 +24,24 @@ describe('App v2 header chrome', () => {
     render(h(App, {}), container)
   }
 
-  it('renders v2 app shell wrapper with StyleSeed theme and tweak attributes', () => {
+  it('renders v2 app shell wrapper with tweak attributes (v2 dark default, no data-theme)', () => {
     renderApp()
     const app = container.querySelector('.v2-app')
     expect(app).not.toBeNull()
-    expect(app?.getAttribute('data-theme')).toBe('styleseed')
+    expect(app?.hasAttribute('data-theme')).toBe(false)
     expect(app?.getAttribute('data-density')).toBe('regular')
     expect(app?.getAttribute('data-motion')).toBe('subtle')
     expect(app?.getAttribute('data-bubble')).toBe('card')
     expect(app?.hasAttribute('data-surface')).toBe(true)
   })
 
-  it('sets the default StyleSeed theme on the dashboard root', () => {
+  it('defaults to the v2 dark skin (no data-theme on the dashboard root)', () => {
+    // Theme ownership lives on <html> (bootstrapped by main.ts, toggled by
+    // ThemeSwitch). The app root no longer hard-codes a theme, so the default
+    // is the keeper-v2 dark skin; paper / styleseed are opt-in light themes.
     renderApp()
     const app = container.querySelector('.v2-app')
-    expect(app?.getAttribute('data-theme')).toBe('styleseed')
+    expect(app?.hasAttribute('data-theme')).toBe(false)
   })
 
   it('renders v2 shell header and health strip scopes', () => {

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -267,7 +267,6 @@ export function App() {
   return html`
     <div
       class="v2-app flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--color-bg-page)] text-[var(--color-fg-primary)]"
-      data-theme="styleseed"
       data-widget-solo=${widgetSoloMode ? 'true' : 'false'}
       data-focus-mode=${focusMode ? 'true' : 'false'}
       data-keeper-detail-mode=${keeperDetailMode ? 'true' : 'false'}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -67,6 +67,16 @@ import './styles/telemetry-v2.css'
 import './styles/craft-v2.css'
 import './styles/states.css'
 
+// v2 skin — cool-charcoal palette + voltage accent (brass/blood/ice) +
+// Space Grotesk display, for the --color-* surfaces. Activated by
+// data-skin="v2" on <html> (index.html), scoped to yield to paper/styleseed.
+import './styles/skin-v2.css'
+// StyleSeed → keeper-v2 Dark Fantasy bridge. Re-points the StyleSeed token
+// VALUES (--ss-* / --background / --card / --brand, defined LIGHT by
+// app-shell-v2.css) at the Dark Fantasy spine, so the migrated surfaces render
+// dark under the default theme while StyleSeed's readable sizing is kept.
+import './styles/ss-keeper-v2-bridge.css'
+
 /*
  * EXPERIMENTAL: keeper-v2 DS UI kits — may conflict with existing v2-* styles; enable after review
  * import './styles/ds-ui-kits.css'
@@ -128,7 +138,9 @@ function resolveTheme(): ThemeId {
       if (stored) return normalizeTheme(stored)
     }
   } catch { /* access denied */ }
-  return 'styleseed'
+  // Default: keeper-v2 Dark Fantasy (null = no data-theme). StyleSeed / paper
+  // are opt-in via ThemeSwitch or ?theme= and persist in localStorage.
+  return null
 }
 
 function applyTheme(theme: ThemeId): void {

--- a/dashboard/src/styles/skin-v2.css
+++ b/dashboard/src/styles/skin-v2.css
@@ -1,0 +1,220 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — High-contrast skin + Keeper Agent Chat layout
+   A chromatic re-skin over the MASC semantic spine: cooler neutral
+   near-black ground so a single warm voltage (brass / blood / ice)
+   reads vivid and sharp. Body text pushed brighter for readability.
+   Loaded AFTER colors_and_type.css.
+   ══════════════════════════════════════════════════════════════ */
+
+/* Fonts the v2 skin needs (Space Grotesk display + Noto Sans KR). The
+   canonical source assumes these are already loaded; the dashboard ships
+   them via this @import. Self-host later for offline fidelity. */
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Noto+Sans+KR:wght@300;400;500;600;700;900&display=swap');
+
+/* NOTE: only the data-skin="v2" token block (palette + voltage + type +
+   spacing) is brought in from the canonical source
+   (~/Downloads/v2/keeper-v2/styles/v2.css lines 1-112). The .v2-app chat
+   layout (lines 114+) is intentionally NOT copied — the dashboard ports
+   its own shell in app-shell-v2.css. The bridge at the bottom re-points
+   the dashboard's --color-* / --volt tokens at this spine. */
+
+html[data-skin="v2"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
+  /* Surfaces — cool neutral charcoal, clean elevation steps */
+  --bg-deep:        #08090d;
+  --bg-panel:       #0f1015;
+  --bg-panel-alt:   #15161d;
+  --bg-card:        #1b1c25;
+  --bg-card-hover:  #23242f;
+  --bg-sunken:      #0a0b0f;
+
+  /* Borders — crisper, cooler */
+  --border-main:      #282a36;
+  --border-soft:      #1e1f29;
+  --border-highlight: #3b3d4e;
+
+  /* Text — bone, pushed bright for reading */
+  --text-bright:  #f7f1e6;
+  --text-primary: #e3dacb;
+  --text-mid:     #c0b7a6;
+  --text-dim:     #968fa1;
+
+  /* Accents — vivid */
+  --accent-blood:     #e8472f;
+  --accent-blood-dim: #7a1a12;
+  --accent-viscera:   #ff6a4d;
+  --accent-brass:     #e0b057;
+  --accent-brass-dim: #8a6a28;
+  --accent-bone:      #e6d8b6;
+  --accent-ice:       #46c6f0;
+  --accent-ice-dim:   #1c6b86;
+  --accent-bile:      #8aa83f;
+
+  /* Information / reference accent — distinct from volt (primary action).
+     Used for mentions, state badges, syntax fns, tool events. Volt-aware:
+     under volt=ice it shifts off-cyan so it never collides with primary. */
+  --info:     var(--accent-ice);
+  --info-dim: var(--accent-ice-dim);
+
+  /* Status — saturated but composed */
+  --status-ok:    #46c66a;
+  --status-warn:  #e0a02a;
+  --status-bad:   #e8472f;
+  --status-idle:  #6b6478;
+  --status-busy:  #46c6f0;
+
+  /* Voltage — the single primary accent (default brass/gold) */
+  --volt:        var(--accent-brass);
+  --volt-strong: #f0c373;
+  --volt-dim:    var(--accent-brass-dim);
+  --volt-ink:    #1a1405;
+  --volt-glow:   rgba(224,176,87,0.22);
+  --volt-wash:   rgba(224,176,87,0.10);
+
+  /* Radius scale — engraved, tiny corners (brand: 2/4/6/…). One ladder;
+     literals below recovered into these tokens. */
+  --radius-2xs: 2px;
+  --radius-xs:  3px;
+  --radius-sm:  4px;   /* chips · tabs · inputs · small controls */
+  --radius-md:  6px;   /* cards · panels · composer */
+  --radius-lg:  10px;  /* large panels */
+
+  /* Spacing scale (2px base) + semantic aliases. Surface padding, card
+     padding and inter-card gaps were drifting (12·13·14 / 22·20…) — these
+     give every surface one rhythm. */
+  --sp-1: 4px;  --sp-2: 6px;  --sp-3: 8px;  --sp-4: 10px; --sp-5: 12px;
+  --sp-6: 14px; --sp-7: 16px; --sp-8: 20px; --sp-9: 24px; --sp-10: 32px;
+  --pad-surface: 22px 26px 40px;  /* surface scroll outer padding */
+  --pad-card:    12px 14px;       /* card / panel body padding */
+  --gap-card:    14px;            /* between sibling cards / panels */
+  --gap-row:     8px;             /* between list rows */
+
+  --shadow-card:   0 1px 3px rgba(0,0,0,0.5);
+  --shadow-panel:  0 4px 22px rgba(0,0,0,0.55);
+  --shadow-pop:    0 12px 40px rgba(0,0,0,0.6), 0 0 0 1px var(--border-main);
+  /* Override the base (dark-fantasy) blood-tinted glow so it tracks volt
+     instead — keeps title/primary glow coherent in every voltage. */
+  --accent-glow:   var(--volt-glow);
+  --shadow-glow:   0 0 20px var(--volt-glow);
+
+  /* v2 type — sharp grotesque replaces the gothic Cinzel */
+  --font-display: 'Space Grotesk', 'Noto Sans KR', system-ui, sans-serif;
+  --font-body:    'Noto Sans KR', 'Space Grotesk', system-ui, sans-serif;
+
+  /* ── TYPE LADDER — one heading system across every surface ──
+     T1 surface/subject title · T2 region/panel title ·
+     T3 card/section header (UPPER) · T4 micro label (UPPER).
+     All display = Space Grotesk, all weight 600. The authoritative
+     selector block lives at the end of surfaces.css. */
+  --fs-t1: 22px; --fw-t1: 600; --tr-t1: -0.005em;  /* bright · sentence */
+  --fs-t2: 16px; --fw-t2: 600; --tr-t2: 0;         /* bright · sentence */
+  --fs-t3: 11px; --fw-t3: 600; --tr-t3: 0.14em;    /* mid · UPPER */
+  --fs-t4: 9px;  --fw-t4: 600; --tr-t4: 0.2em;     /* dim · UPPER */
+}
+
+html[data-skin="v2"][data-volt="blood"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
+  --volt: var(--accent-blood); --volt-strong: #ff6a4d; --volt-dim: var(--accent-blood-dim);
+  --volt-ink: #ffffff; --volt-glow: rgba(232,71,47,0.26); --volt-wash: rgba(232,71,47,0.10);
+}
+html[data-skin="v2"][data-volt="ice"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
+  --volt: var(--accent-ice); --volt-strong: #7ad8f6; --volt-dim: var(--accent-ice-dim);
+  --volt-ink: #04121a; --volt-glow: rgba(70,198,240,0.24); --volt-wash: rgba(70,198,240,0.09);
+  /* primary is now cyan → shift the info accent to violet to stay distinct */
+  --info: #8a6cf0; --info-dim: #4a3aa0;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   BRIDGE — re-point the dashboard's consumed tokens at the v2 spine
+   so existing components (which read --color-* / --bg-* / --fg-* /
+   --brass-* / --ok.. / --volt) adopt the skin without a rewrite. The
+   :not([data-theme=paper/styleseed]) guard makes the skin yield to the
+   opt-in light themes; under the default (no data-theme) it loads last and
+   outranks :root, so it wins. The 8 baked Tailwind utilities (bg-bg-0/1)
+   keep their generated value (negligible).
+   ══════════════════════════════════════════════════════════════ */
+html[data-skin="v2"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
+  /* Surfaces */
+  --color-bg-0: var(--bg-deep);   --bg-0: var(--bg-deep);
+  --color-bg-1: var(--bg-panel);  --bg-1: var(--bg-panel);
+  --color-bg-2: var(--bg-panel-alt); --bg-2: var(--bg-panel-alt);
+  --color-bg-3: var(--bg-card);   --bg-3: var(--bg-card);
+  --color-bg-4: var(--bg-card-hover); --bg-4: var(--bg-card-hover);
+  --color-bg-page: var(--bg-deep);
+  --color-bg-surface: var(--bg-panel);
+  --color-bg-panel-alt: var(--bg-panel-alt);
+  --color-bg-elevated: var(--bg-card);
+  --color-bg-hover: var(--bg-card-hover);
+  --bg-root: var(--bg-deep);
+  --bg-deepest: var(--bg-sunken);
+  --panel-dark: var(--bg-panel-alt);
+  --bg-panel-hover: var(--bg-card-hover);
+  --shell-header-bg: var(--bg-panel);
+  --shell-rail-bg: var(--bg-panel);
+  --shell-main-bg: var(--bg-deep);
+  --card: var(--bg-card);
+  --color-card: var(--bg-card);
+  --surface-inset: var(--bg-sunken);
+  --bg-subtle: var(--bg-card);
+  --input-bg: var(--bg-sunken);
+
+  /* Borders (dashboard: line-1 default, line-2 emphasized, line-3 divider) */
+  --color-line-1: var(--border-main);   --line-1: var(--border-main);
+  --color-line-2: var(--border-highlight); --line-2: var(--border-highlight);
+  --color-line-3: var(--border-soft);   --line-3: var(--border-soft);
+  --color-border-default: var(--border-main);
+  --color-border-strong: var(--border-highlight);
+  --color-border-divider: var(--border-soft);
+  --color-border-subtle: var(--border-soft);
+  --border-base: var(--border-main);
+  --border-subtle: var(--border-soft);
+  --border-strong: var(--border-highlight);
+  --card-border: var(--border-main);
+  --input-border: var(--border-highlight);
+
+  /* Text */
+  --color-fg-1: var(--text-bright);  --fg-1: var(--text-bright);
+  --color-fg-2: var(--text-primary); --fg-2: var(--text-primary);
+  --color-fg-3: var(--text-mid);     --fg-3: var(--text-mid);
+  --color-fg-4: var(--text-dim);     --fg-4: var(--text-dim);
+  --color-fg-primary: var(--text-bright);
+  --color-fg-secondary: var(--text-primary);
+  --color-fg-muted: var(--text-mid);
+  --color-fg-disabled: var(--text-dim);
+  --text-strong: var(--text-bright);
+  --text-body: var(--text-primary);
+  --text-muted: var(--text-mid);
+  --text: var(--text-primary);
+
+  /* Accent = voltage (default brass; data-volt swaps to blood/ice) */
+  --color-accent-fg: var(--volt);
+  --color-accent-fg-dim: var(--volt-dim);
+  --color-accent: var(--volt);
+  --color-accent-soft: var(--volt-wash);
+  --color-accent-glow: var(--volt-rgb);
+  --accent: var(--volt);
+  --accent-soft: var(--volt-wash);
+  --accent-glow: var(--volt-glow);
+  --brass-1: var(--volt);  --color-brass-1: var(--volt);
+  --brass-2: var(--volt-strong); --color-brass-2: var(--volt-strong);
+  --brass-3: var(--volt-dim);    --color-brass-3: var(--volt-dim);
+  --brass-fg: var(--volt); --color-brass-fg: var(--volt);
+  --brass-soft: var(--volt-wash); --color-brass-soft: var(--volt-wash);
+  --brass-glow: var(--volt-rgb);  --color-brass-glow: var(--volt-rgb);
+  --select: var(--volt);
+  --select-10: var(--volt-wash);
+  --select-20: var(--volt-glow);
+
+  /* Status */
+  --ok: var(--status-ok);   --color-ok: var(--status-ok);   --color-status-ok: var(--status-ok);
+  --warn: var(--status-warn); --color-warn: var(--status-warn); --color-status-warn: var(--status-warn);
+  --err: var(--status-bad); --bad: var(--status-bad); --color-err: var(--status-bad); --color-status-err: var(--status-bad);
+  --color-info: var(--info); --color-status-info: var(--info);
+  --idle: var(--status-idle); --color-idle: var(--status-idle); --color-status-idle: var(--status-idle);
+  --ok-glow: 70 198 106;   --color-ok-glow: 70 198 106;
+  --warn-glow: 224 160 42; --color-warn-glow: 224 160 42;
+  --err-glow: 232 71 47;   --color-err-glow: 232 71 47;
+  --info-glow: 70 198 240; --color-info-glow: 70 198 240;
+
+  /* Fonts — clean grotesque, no Cinzel */
+  --font-sans: var(--font-ui);
+}
+

--- a/dashboard/src/styles/ss-keeper-v2-bridge.css
+++ b/dashboard/src/styles/ss-keeper-v2-bridge.css
@@ -1,0 +1,95 @@
+/* ════════════════════════════════════════════════════════════════
+   StyleSeed → keeper-v2 Dark Fantasy bridge
+   ----------------------------------------------------------------
+   The keeper-v2 surfaces were migrated onto StyleSeed's token layer
+   (app-shell-v2.css defines the full --ss-* set at :root with LIGHT
+   values; styleseed-theme.css adds the --background/--card/--text-*
+   semantic mirror). The dashboard's canonical design system is
+   keeper-v2 Dark Fantasy (RFC-0253), not StyleSeed light, so this file
+   re-points the token VALUES at the Dark Fantasy spine: every migrated
+   surface renders charcoal + ice voltage + bone without touching
+   component code.
+
+   Borrowed from StyleSeed (reference, not migration): the readable
+   sizing/spacing AND the rounded cards (--ss-radius-* left untouched) —
+   the "큼지막 / readable" look the rest of the system keeps.
+
+   Scoped to the DEFAULT case (html with no opt-in light theme): the
+   migrated surfaces read --ss-* unconditionally, so this must outrank the
+   app-shell-v2.css :root defaults — html:not(...) is (0,2,1) > :root
+   (0,1,0). The :not() guards let the styleseed / paper light themes still
+   win when explicitly selected. Voltage = ice (matches data-volt).
+   ════════════════════════════════════════════════════════════════ */
+html:not([data-theme="styleseed"]):not([data-theme="paper"]) {
+  color-scheme: dark;
+
+  /* ── StyleSeed --ss-* token layer → Dark Fantasy (full set) ── */
+  /* Surfaces — cool charcoal ramp */
+  --ss-page:           #08090d;
+  --ss-card:           #15161d;
+  --ss-card-raised:    #1b1c25;
+  --ss-card-hover:     #23242f;
+  --ss-surface:        #0f1015;
+  --ss-surface-subtle: #1b1c25;
+  --ss-surface-muted:  #23242f;
+  --ss-sunken:         #0a0b0f;
+
+  /* Text — bone, pushed bright for reading on near-black */
+  --ss-text-strong:    #f7f1e6;
+  --ss-text-primary:   #e3dacb;
+  --ss-text-secondary: #c0b7a6;
+  --ss-text-tertiary:  #968fa1;
+  --ss-text-disabled:  #6b6478;
+
+  /* Borders — cool hairlines (the light rgba(0,0,0,…) edges vanish on dark) */
+  --ss-border:        #282a36;
+  --ss-border-subtle: #1e1f29;
+  --ss-border-strong: #3b3d4e;
+  --ss-border-1:      #1e1f29;
+  --ss-border-2:      #282a36;
+  --ss-border-3:      #3b3d4e;
+
+  /* Accent — ice voltage */
+  --ss-brand:      #46c6f0;
+  --ss-brand-tint: rgba(70, 198, 240, 0.14);
+  --ss-brand-dim:  rgba(70, 198, 240, 0.08);
+  --ss-brand-glow: 70 198 240;
+
+  /* Status — keeper-v2 triad */
+  --ss-success:     #46c66a;
+  --ss-warning:     #e0a02a;
+  --ss-destructive: #e8472f;
+
+  /* Shadows — off in dark (edges rely on borders); keep modal depth only */
+  --ss-shadow-card:       none;
+  --ss-shadow-card-hover: none;
+  --ss-shadow-elevated:   none;
+  --ss-shadow-modal:      0 8px 24px rgba(0, 0, 0, 0.6);
+  /* --ss-radius-card / --ss-radius-input intentionally NOT overridden:
+     the rounded cards are part of the readable look we keep. */
+
+  /* ── Non-ss semantic mirror (styleseed-theme.css maps these only under
+        [data-theme=styleseed]; supply Dark Fantasy for the default case) ── */
+  --background:     #08090d;
+  --surface-page:   #08090d;
+  --card:           #15161d;
+  --surface-subtle: #1b1c25;
+  --surface-muted:  #23242f;
+  --text-primary:   #e3dacb;
+  --text-secondary: #c0b7a6;
+  --text-tertiary:  #968fa1;
+  --text-disabled:  #6b6478;
+  --icon-default:   #c0b7a6;
+  --border:         #282a36;
+  --brand:          #46c6f0;
+  --brand-dim:      #1c6b86;
+  --brand-wash:     rgba(70, 198, 240, 0.10);
+  --brand-tint:     rgba(70, 198, 240, 0.14);
+  --success:        #46c66a;
+  --warning:        #e0a02a;
+  --destructive:    #e8472f;
+  --info:           #46c6f0;
+
+  /* Type → keeper-v2 grotesque (fonts @imported by skin-v2.css) */
+  --font-sans: 'Space Grotesk', 'Noto Sans KR', system-ui, sans-serif;
+}

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -696,3 +696,32 @@ html:not([data-theme="paper"]) {
   --font-display: "Cinzel", "Noto Sans KR", "EB Garamond", serif;
   --font-body: "EB Garamond", "Noto Sans KR", Georgia, serif;
 }
+
+/* ══════════════════════════════════════════════════════════════
+   Desktop type-scale bump (approved 2026-06-17)
+
+   The canonical @theme scale (tokens.generated.css) tops out at base 14px /
+   sm 13px, which reads too small on the keeper-v2 surfaces. The token
+   generator (design-system/tokens/build.ts) is absent, so the generated file
+   can't be regenerated — bump the scale here at :root instead (variables.css
+   loads after tokens.generated.css). Scoped to desktop so the mobile
+   scale-down in responsive.css stays authoritative on small screens. The
+   --fs-* aliases above follow --font-size-* via var(); --type-* composites
+   use the numeric --fs-9..56 ladder, bumped in parallel. Aligns with RFC-0253
+   (dashboard keeper-v2 token scale).
+   ══════════════════════════════════════════════════════════════ */
+@media (min-width: 769px) {
+  :root {
+    --font-size-3xs: 12px;
+    --font-size-2xs: 13px;
+    --font-size-xs:  14px;
+    --font-size-sm:  15px;
+    --font-size-base: 16px;
+    --font-size-md:  17px;
+    --font-size-lg:  18px;
+
+    --fs-9:  11px; --fs-10: 12px; --fs-11: 13px; --fs-12: 14px;
+    --fs-13: 15px; --fs-14: 16px; --fs-16: 18px; --fs-20: 22px;
+    --fs-28: 30px; --fs-36: 38px; --fs-56: 58px;
+  }
+}


### PR DESCRIPTION
## 목표
대시보드 정본 디자인 시스템을 **keeper-v2 Dark Fantasy**(RFC-0253)로 복원합니다. 그 사이 함대가 진행한 StyleSeed 라이트 마이그레이션은 *통째 이주*가 아니라 토큰/spacing/일관성 **규칙 참고**가 본래 의도였습니다(사용자 확인). StyleSeed의 읽기 좋은 사이징·둥근 카드는 유지하고 색/폰트만 우리 것으로 가져옵니다.

## 접근 — forward-fix (revert 아님)
StyleSeed 마이그레이션은 surface를 `--ss-*` 토큰 한 층으로 중앙화했습니다(`app-shell-v2.css`가 `:root`에 라이트 값으로 정의). 그래서 7개 머지 PR을 되돌리지 않고 **토큰 *값*을 Dark Fantasy로 재정의**합니다 → 마이그레이션된 모든 surface가 컴포넌트 수정 없이 차콜 + ice + bone으로 렌더됩니다.

## 변경 파일 (7)
- `styles/ss-keeper-v2-bridge.css` (신규): 전체 `--ss-*` + `--background/--card/--text-*/--brand` → Dark Fantasy. `html:not([data-theme="styleseed"]):not([data-theme="paper"])` 스코프(app-shell `:root` 라이트 기본을 이기고, 라이트 opt-in엔 양보). `--ss-radius-*`는 미변경(둥근 카드 = 읽기 좋은 룩 유지).
- `styles/skin-v2.css` (신규): `--color-*` surface용 keeper-v2 spine + voltage + Space Grotesk. `data-skin="v2"`.
- `main.ts`: 기본 테마 다크 복원(`resolveTheme` → `null`) + 두 스킨 import.
- `app.ts`: `.v2-app`의 하드코딩 `data-theme="styleseed"` 제거(테마는 `<html>`이 소유). styleseed/paper opt-in 유지.
- `app.test.ts`: 다크 기본(`.v2-app`에 `data-theme` 없음) 단언으로 수정.
- `index.html`: `data-skin="v2" data-volt="ice"`.
- `styles/variables.css`: 데스크톱 타입 스케일 +2px(base 14→16, sm 13→15). `@theme` 스케일이 작았고 생성기(`build.ts`) 부재라 `:root` override, `@media(min-width:769px)`로 모바일은 `responsive.css`에 위임.

## 로컬 검증
- `tsc --noEmit` clean
- `vite build` ok
- vitest: `app.test.ts` + `theme-switch.test.ts` 26 통과 / 전체 메인 스위트 실행 중 (CI + 로컬 배경 잡에서 확인 중)
- 시각 확인: overview + monitor/keeper-fleet 모두 Dark Fantasy + 큰 폰트, 라이트 누수 없음

## 관련 정리
- StyleSeed 마이그레이션 draft 4개(#21441 / #21443 / #21444 / #21450) close.
- 머지된 StyleSeed PR 7개는 유지(bridge가 색 재정의).

## 미검증 / 후속
- 라이트 opt-in(styleseed/paper) 시 `v2-shell` rail accent는 별도 점검 필요.
- 레이아웃 각짐(rounded-2xl → keeper-v2 2/4/6 engraved)은 RFC-0253 후속 과제.
- ⚠️ 함대 StyleSeed task가 라이브면 추가 StyleSeed PR이 나올 수 있음.

RFC: RFC-0253 (dashboard keeper-v2 spacing/radius token scale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
