### PR TITLE
feat(copilot): wire dashboard Copilot Dock to keeper chat stream

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -168,6 +168,50 @@ describe('streamKeeperMessage', () => {
     expect(events).toEqual(['RUN_FINISHED'])
   })
 
+  it('forwards copilot context fields to the stream endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('data: {"type":"RUN_FINISHED"}\n\n', {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const events: string[] = []
+    await streamKeeperMessage('sangsu', 'ping', {
+      onEvent: event => {
+        events.push(event.type)
+      },
+      channel: 'copilot',
+      channelWorkspaceId: 'session-7',
+      turnInstructions: 'focus on overview',
+      surfaceContext: {
+        label: 'Overview',
+        route: '/overview',
+        scene: 'fleet view',
+        fields: [{ k: 'run', v: '2/5' }],
+      },
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
+      name: 'sangsu',
+      message: 'ping',
+      direct_reply: true,
+      channel: 'copilot',
+      channel_workspace_id: 'session-7',
+      turn_instructions: 'focus on overview',
+      surface_context: {
+        label: 'Overview',
+        route: '/overview',
+        scene: 'fleet view',
+        fields: [{ k: 'run', v: '2/5' }],
+      },
+    })
+    expect(events).toEqual(['RUN_FINISHED'])
+  })
+
   const stubStaleToken = () => {
     window.sessionStorage.setItem('masc_bearer_token', 'stale-token')
     window.sessionStorage.setItem(

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -371,6 +371,14 @@ export interface StreamAttachment {
   data: string
 }
 
+/** Co-view context sent from dashboard surfaces such as the Copilot Dock. */
+export interface KeeperStreamSurfaceContext {
+  label: string
+  route: string
+  scene: string
+  fields: unknown
+}
+
 /** Outcome of a keeper chat stream read loop.
  *  `terminal: false` means the connection closed without a
  *  RUN_FINISHED / RUN_ERROR event — the response was cut mid-stream
@@ -444,6 +452,16 @@ async function refreshLoopbackDevTokenAfterMismatch(): Promise<boolean> {
   return getStoredToken() !== null
 }
 
+export interface StreamKeeperMessageOptions {
+  signal?: AbortSignal
+  onEvent: (event: KeeperChatStreamEvent) => void
+  attachments?: StreamAttachment[]
+  channel?: string
+  channelWorkspaceId?: string
+  turnInstructions?: string
+  surfaceContext?: KeeperStreamSurfaceContext
+}
+
 export async function streamKeeperMessage(
   name: string,
   message: string,
@@ -451,16 +469,28 @@ export async function streamKeeperMessage(
     signal,
     onEvent,
     attachments,
-  }: {
-    signal?: AbortSignal
-    onEvent: (event: KeeperChatStreamEvent) => void
-    attachments?: StreamAttachment[]
-  },
+    channel,
+    channelWorkspaceId,
+    turnInstructions,
+    surfaceContext,
+  }: StreamKeeperMessageOptions,
 ): Promise<KeeperStreamOutcome> {
   const body: Record<string, unknown> = {
     name,
     message,
     direct_reply: true,
+  }
+  if (channel && channel.trim() !== '') {
+    body.channel = channel.trim()
+  }
+  if (channelWorkspaceId && channelWorkspaceId.trim() !== '') {
+    body.channel_workspace_id = channelWorkspaceId.trim()
+  }
+  if (turnInstructions && turnInstructions.trim() !== '') {
+    body.turn_instructions = turnInstructions.trim()
+  }
+  if (surfaceContext && Object.keys(surfaceContext).length > 0) {
+    body.surface_context = surfaceContext
   }
   if (attachments && attachments.length > 0) {
     body.attachments = attachments.map(att => ({

--- a/dashboard/src/components/copilot-dock.test.ts
+++ b/dashboard/src/components/copilot-dock.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor, fireEvent } from '@testing-library/preact'
 import {
@@ -34,6 +34,8 @@ describe('CopilotDock', () => {
     container.remove()
     globalShortcutManager.unregisterAll('copilot-dock.')
     try { window.localStorage.removeItem('dashboard:copilot-dock') } catch { /* noop */ }
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
   })
 
   function DockHarness({ dock }: { dock: ReturnType<typeof useCopilotDock> }) {
@@ -142,7 +144,36 @@ describe('CopilotDock', () => {
     expect(coview?.textContent).toContain('/connectors/connector-status')
   })
 
+  function sseResponse(events: unknown[]) {
+    const encoder = new TextEncoder()
+    const payload = events
+      .map(e => `data: ${JSON.stringify(e)}\n\n`)
+      .join('')
+    return new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(payload))
+          controller.close()
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      },
+    )
+  }
+
   it('sends a message and shows a streaming reply', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      sseResponse([
+        { type: 'TEXT_MESSAGE_START', role: 'Assistant', messageId: 'm1' },
+        { type: 'TEXT_MESSAGE_CONTENT', delta: '안녕하세요' },
+        { type: 'TEXT_MESSAGE_END' },
+        { type: 'RUN_FINISHED' },
+      ]),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
     const dock = renderDock()
     dock.open()
     await waitFor(() => expect(container.querySelector('[data-testid="copilot-dock-textarea"]')).not.toBeNull())
@@ -155,6 +186,39 @@ describe('CopilotDock', () => {
 
     await waitFor(() => expect(container.querySelectorAll('[data-dock-message="user"]').length).toBe(1))
     await waitFor(() => expect(container.querySelectorAll('[data-dock-message="assistant"]').length).toBe(1), { timeout: 3000 })
+
+    const assistant = container.querySelector('[data-dock-message="assistant"]')
+    expect(assistant?.textContent).toContain('안녕하세요')
+  })
+
+  it('posts copilot channel and surface context to the keeper stream', async () => {
+    window.history.replaceState({}, '', '/?agent=dashboard-eager-manta')
+    const fetchMock = vi.fn().mockResolvedValue(
+      sseResponse([{ type: 'RUN_FINISHED' }]),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const dock = renderDock()
+    dock.open()
+    await waitFor(() => expect(container.querySelector('[data-testid="copilot-dock-textarea"]')).not.toBeNull())
+
+    const textarea = container.querySelector('[data-testid="copilot-dock-textarea"]') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: '요약해줘' } })
+
+    const sendBtn = container.querySelector('.dock-send') as HTMLButtonElement
+    sendBtn.click()
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(String(init.body))
+    expect(body.channel).toBe('copilot')
+    expect(body.channel_workspace_id).toBe('dashboard-eager-manta')
+    expect(body.surface_context).toMatchObject({
+      label: expect.any(String),
+      route: '/overview',
+      scene: expect.any(String),
+      fields: expect.any(Array),
+    })
   })
 
   it('switches keeper via picker', async () => {

--- a/dashboard/src/components/copilot-dock.ts
+++ b/dashboard/src/components/copilot-dock.ts
@@ -6,6 +6,8 @@ import { globalShortcutManager } from '../lib/global-shortcut-manager'
 import { route } from '../router'
 import { keepers } from '../store'
 import { isSubmitEnter } from '../lib/keyboard'
+import { streamKeeperMessage } from '../api/keeper'
+import { currentDashboardActor } from '../api/core'
 import type { Keeper } from '../types'
 
 interface DockState {
@@ -84,37 +86,6 @@ function keeperGlow(name: string): string {
     rama: 'var(--k-rama-glow)',
   }
   return map[name] ?? 'var(--brass-glow)'
-}
-
-function buildReply(keeper: DockKeeper, ctx: SurfaceContext): { body: string; sug: string[] } {
-  if (ctx.route === '/overview') {
-    return {
-      body: `지금 **${ctx.label}**를 같이 보고 있네요. 실행 중 keeper와 주의 큐를 훑었어요.\n\n가장 급한 건 \`drifter\` — 컨텍스트가 **오버플로우**라 재시작이 필요합니다. \`nick0cave\`도 91%라 곧 compact가 걸릴 거예요.\n\n제가 ${keeper.kr}로서 주의 4건을 우선순위대로 정리핼까요?`,
-      sug: ['drifter 재시작 절차 보기', '주의 4건 한 번에 트리아지', 'nick0cave compact 미리 돌리기'],
-    }
-  }
-  if (ctx.route === '/code') {
-    return {
-      body: `\`round.ml\`의 lock 재진입 경로를 같이 보고 있어요. \`compact()\`가 라운드 락을 잡은 채 호출되는 **L93**이 의심됩니다.\n\nPR **#7741**은 테스트 84/84 통과지만 아직 리뷰 대기예요.`,
-      sug: ['L93 FIXME 같이 보기', 'PR #7741 리뷰 코멘트 요약', 'sangsu에게 핸드오프'],
-    }
-  }
-  if (ctx.route === '/workspace') {
-    return {
-      body: `**전체 피드**를 같이 보고 있어요. \`@operator\` 멘션 3건 중 \`drifter\`의 restart 승인 대기가 가장 급합니다.`,
-      sug: ['멘션 인박스 정리', 'drifter 상태 블록 열기', 'scheduler 공지 스레드로'],
-    }
-  }
-  if (ctx.route === '/connectors') {
-    return {
-      body: `**Gate** 상태를 같이 보고 있어요. iMessage 게이트가 **stale** — heartbeat 120s 초과로 응답이 지연되고 있어요.`,
-      sug: ['stale 게이트 재연결', '바인딩 현황 요약', '최근 감사 로그 보기'],
-    }
-  }
-  return {
-    body: `\`${ctx.label}\` 화면을 같이 보고 있어요. \`${keeper.ns}\` 기준으로 관련 trace와 태스크를 모아둘게요. 무엇부터 볼까요?`,
-    sug: ['이 화면 요약', '관련 태스크 보기', '다음 액션 추천'],
-  }
 }
 
 function mdInline(s: string): string {
@@ -268,30 +239,40 @@ export function useCopilotDock() {
         ...dockThreads.value,
         [kid]: [...(dockThreads.value[kid] ?? []), { role: 'user', ts: nowHM(), text: text.trim() }],
       }
-      const { body, sug } = buildReply(keeper, ctx)
-      window.setTimeout(() => {
-        dockStreaming.value = { keeperId: kid, shown: '', full: body, sug }
-        const start = typeof performance !== 'undefined' ? performance.now() : Date.now()
-        const DUR = 900
-        const timer = window.setInterval(() => {
-          const now = typeof performance !== 'undefined' ? performance.now() : Date.now()
-          const p = Math.min(1, (now - start) / DUR)
-          if (p >= 1) {
-            window.clearInterval(timer)
-            dockStreaming.value = null
-            dockThreads.value = {
-              ...dockThreads.value,
-              [kid]: [...(dockThreads.value[kid] ?? []), { role: 'assistant', ts: nowHM(), text: body, sug }],
-            }
-          } else {
-            const n = Math.max(1, Math.floor(body.length * p))
+      const abortController = new AbortController()
+      dockStreaming.value = { keeperId: kid, shown: '', full: '', sug: [] }
+      let replyText = ''
+      streamKeeperMessage(kid, text.trim(), {
+        signal: abortController.signal,
+        channel: 'copilot',
+        channelWorkspaceId: currentDashboardActor(),
+        surfaceContext: ctx,
+        onEvent: (event) => {
+          if (event.type === 'TEXT_MESSAGE_CONTENT' && typeof event.delta === 'string') {
+            replyText += event.delta
             const current = dockStreaming.value
             if (current && current.keeperId === kid) {
-              dockStreaming.value = { ...current, shown: body.slice(0, n) }
+              dockStreaming.value = { ...current, shown: replyText }
             }
           }
-        }, 40)
-      }, 220)
+        },
+      })
+        .then((outcome) => {
+          dockStreaming.value = null
+          const finalText = replyText.trim() || (outcome.terminal ? '(empty reply)' : '(stream ended unexpectedly)')
+          dockThreads.value = {
+            ...dockThreads.value,
+            [kid]: [...(dockThreads.value[kid] ?? []), { role: 'assistant', ts: nowHM(), text: finalText }],
+          }
+        })
+        .catch((err) => {
+          dockStreaming.value = null
+          const message = err instanceof Error ? err.message : 'Keeper stream failed'
+          dockThreads.value = {
+            ...dockThreads.value,
+            [kid]: [...(dockThreads.value[kid] ?? []), { role: 'assistant', ts: nowHM(), text: `Error: ${message}` }],
+          }
+        })
     },
   }
 }

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -331,6 +331,10 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "number");
           ("description", `String "Optional: overall timeout (sec) for this async keeper message request and its runtime turn");
         ]);
+        ("direct_reply", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Optional: run the turn synchronously and return the reply directly instead of queueing");
+        ]);
         ("no_skill_route", `Assoc [
           ("type", `String "boolean");
           ("description", `String "Optional: do not emit SKILL/SKILL_REASON headers in reply");
@@ -338,6 +342,30 @@ let keeper_schemas : tool_schema list = [
         ("no_state_block", `Assoc [
           ("type", `String "boolean");
           ("description", `String "Optional: do not emit [STATE]...[/STATE] block in reply");
+        ]);
+        ("turn_instructions", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: free-form instructions to prepend to the keeper prompt for this turn");
+        ]);
+        ("surface_context", `Assoc [
+          ("type", `String "object");
+          ("description", `String "Optional: co-view context from the dashboard ({ label, route, scene, fields }); formatted into turn instructions when turn_instructions is omitted");
+        ]);
+        ("channel", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: channel label (e.g. copilot) for the chat lane");
+        ]);
+        ("channel_user_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: external user id on the channel");
+        ]);
+        ("channel_user_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: external user name on the channel");
+        ]);
+        ("channel_workspace_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: operator session or workspace id for the channel");
         ]);
       ]);
       ("required", `List [`String "name"; `String "message"]);

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -105,8 +105,47 @@ let direct_owner_conversation_context
       ~limit:8 ~config ~meta ()
     |> Keeper_world_observation_message_scope.render_recent_direct_conversation_context
 
+let surface_context_to_instructions (ctx : Yojson.Safe.t) : string option =
+  match ctx with
+  | `Assoc fields ->
+      let string_field key =
+        match List.assoc_opt key fields with
+        | Some (`String s) ->
+            let s = String.trim s in
+            if s = "" then None else Some s
+        | _ -> None
+      in
+      let json_field key = List.assoc_opt key fields in
+      let parts =
+        (match string_field "label" with
+         | Some s -> [ Printf.sprintf "Surface label: %s" s ]
+         | None -> [])
+        @
+        (match string_field "route" with
+         | Some s -> [ Printf.sprintf "Route: %s" s ]
+         | None -> [])
+        @
+        (match string_field "scene" with
+         | Some s -> [ Printf.sprintf "Scene: %s" s ]
+         | None -> [])
+        @
+        (match json_field "fields" with
+         | Some (`Assoc fs) when fs <> [] ->
+             [ "Fields:\n"
+               ^ String.concat "\n"
+                   (List.map
+                      (fun (k, v) ->
+                        Printf.sprintf "- %s: %s" k (Yojson.Safe.to_string v))
+                      fs) ]
+         | Some _ | None -> [])
+      in
+      if parts = [] then None
+      else Some (String.concat "\n\n" parts)
+  | _ -> None
+
 module For_testing = struct
   let direct_owner_conversation_context = direct_owner_conversation_context
+  let surface_context_to_instructions = surface_context_to_instructions
 end
 
 let resolve_turn_runtime_id (meta : keeper_meta) =
@@ -297,7 +336,17 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
   else if message = "" then
     tool_result_error "message is required"
   else
-    let turn_instructions = get_string_opt args "turn_instructions" in
+    let turn_instructions =
+      match get_string_opt args "turn_instructions" with
+      | Some _ as ti -> ti
+      | None -> (
+          match args with
+          | `Assoc fields -> (
+              match List.assoc_opt "surface_context" fields with
+              | Some ctx -> surface_context_to_instructions ctx
+              | None -> None)
+          | _ -> None)
+    in
     let no_skill_route = get_bool args "no_skill_route" false in
     let no_state_block = get_bool args "no_state_block" false in
     let direct_reply = get_bool args "direct_reply" false in

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -38,6 +38,10 @@ module For_testing : sig
     channel_session_key:string option ->
     channel:string ->
     string
+
+  val surface_context_to_instructions : Yojson.Safe.t -> string option
+  (** Format a dashboard co-view context object ({ label, route, scene, fields })
+      into turn instructions when no explicit [turn_instructions] is supplied. *)
 end
 
 val handle_keeper_msg :

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -925,6 +925,8 @@ let start_keeper_loops
                  name = keeper_name;
                  message = queued_message.content;
                  timeout_sec = None;
+                 turn_instructions = None;
+                 surface_context = None;
                  channel = projection.payload_channel;
                  channel_user_id = projection.payload_channel_user_id;
                  channel_user_name = projection.payload_channel_user_name;

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -8,6 +8,8 @@ type keeper_chat_stream_request = {
   name : string;
   message : string;
   timeout_sec : int option;
+  turn_instructions : string option;
+  surface_context : Yojson.Safe.t option;
   channel : string;
   channel_user_id : string;
   channel_user_name : string;
@@ -21,6 +23,179 @@ let keeper_chat_stream_error_json message =
       ( "error",
         `Assoc [ ("message", `String message) ] );
     ]
+
+let normalized_context_value value =
+  value
+  |> String.to_seq
+  |> Seq.map (function
+       | '\n' | '\r' | '\t' -> ' '
+       | ch -> ch)
+  |> String.of_seq
+  |> String.trim
+
+let format_surface_context_field_value = function
+  | `String s -> normalized_context_value s
+  | json -> Yojson.Safe.to_string json
+
+let format_surface_context_fields fields_json =
+  let lines =
+    match fields_json with
+    | `List items ->
+        List.filter_map
+          (function
+            | `Assoc fields -> (
+                match
+                  ( List.assoc_opt "k" fields,
+                    List.assoc_opt "v" fields )
+                with
+                | Some (`String k), Some v ->
+                    let k = normalized_context_value k in
+                    if k = "" then None
+                    else Some (Printf.sprintf "  - %s: %s" k (format_surface_context_field_value v))
+                | _ -> None)
+            | _ -> None)
+          items
+    | `Assoc pairs ->
+        List.filter_map
+          (fun (k, v) ->
+            let k = normalized_context_value k in
+            if k = "" then None
+            else Some (Printf.sprintf "  - %s: %s" k (format_surface_context_field_value v)))
+          pairs
+    | _ -> []
+  in
+  if lines = [] then None else Some (String.concat "\n" lines)
+
+let format_surface_context = function
+  | `Assoc fields ->
+      let get_string key =
+        match List.assoc_opt key fields with
+        | Some (`String s) ->
+            let s = normalized_context_value s in
+            if s = "" then None else Some s
+        | _ -> None
+      in
+      let label = get_string "label" in
+      let route = get_string "route" in
+      let scene = get_string "scene" in
+      let fields_block =
+        match List.assoc_opt "fields" fields with
+        | Some fields_json -> format_surface_context_fields fields_json
+        | None -> None
+      in
+      let lines =
+        List.filter_map
+          (fun (name, value_opt) ->
+            Option.map (fun v -> Printf.sprintf "%s: %s" name v) value_opt)
+          [
+            ("Surface label", label);
+            ("Route", route);
+            ("Scene", scene);
+          ]
+      in
+      let lines =
+        match fields_block with
+        | Some block -> lines @ [ "Fields:"; block ]
+        | None -> lines
+      in
+      if lines = [] then "" else String.concat "\n" ("[Co-view context]" :: lines)
+  | json ->
+      Printf.sprintf "[Co-view context]\n%s" (Yojson.Safe.pretty_to_string json)
+
+let surface_context_to_instructions ctx =
+  let s = format_surface_context ctx in
+  if s = "" then None else Some s
+
+let has_connector_context (payload : keeper_chat_stream_request) =
+  payload.channel <> "" && payload.channel_workspace_id <> ""
+
+let has_external_speaker (payload : keeper_chat_stream_request) =
+  has_connector_context payload && payload.channel_user_id <> ""
+
+let message_for_request payload =
+  if has_external_speaker payload then
+    Gate_keeper_backend.contextualize_message
+      ~channel:payload.channel
+      ~channel_user_id:payload.channel_user_id
+      ~channel_user_name:payload.channel_user_name
+      ~channel_workspace_id:payload.channel_workspace_id
+      ~metadata:[]
+      ~content:payload.message
+  else
+    payload.message
+
+let chat_surface_of_request payload =
+  if has_connector_context payload then
+    Surface_ref.Gate { label = payload.channel; address = [] }
+  else Surface_ref.Dashboard { session_id = None }
+
+let chat_speaker_of_request payload =
+  if has_external_speaker payload then
+    { Keeper_chat_store.speaker_id = Some payload.channel_user_id;
+      speaker_name =
+        (let name = String.trim payload.channel_user_name in
+         if name = "" then None else Some name);
+      speaker_authority = Keeper_chat_store.External }
+  else
+    { Keeper_chat_store.speaker_id = None;
+      speaker_name = None;
+      speaker_authority = Keeper_chat_store.Owner }
+
+let turn_instructions_for_request payload =
+  let ctx_text =
+    match payload.surface_context with
+    | Some ctx -> format_surface_context ctx
+    | None -> ""
+  in
+  match payload.turn_instructions with
+  | None -> if ctx_text = "" then None else Some ctx_text
+  | Some ti ->
+      if ctx_text = "" then Some ti
+      else Some (ti ^ "\n\n" ^ ctx_text)
+
+let attachment_json (att : Keeper_chat_store.attachment) =
+  `Assoc
+    [ ("id", `String att.Keeper_chat_store.id);
+      ("type", `String att.att_type);
+      ("name", `String att.name);
+      ("size", `Int att.size);
+      ("mime_type", `String att.mime_type);
+      ("data", `String att.data) ]
+
+let args_of_request payload : Yojson.Safe.t =
+  let message = message_for_request payload in
+  let base_fields =
+    [ ("name", `String payload.name);
+      ("message", `String message);
+      ("direct_reply", `Bool true) ]
+    @
+    (match payload.timeout_sec with
+     | Some timeout_sec -> [ ("timeout_sec", `Int timeout_sec) ]
+     | None -> [])
+    @
+    (match turn_instructions_for_request payload with
+     | Some instructions when String.trim instructions <> "" ->
+         [ ("turn_instructions", `String instructions) ]
+     | _ -> [])
+  in
+  let connector_fields =
+    (if has_connector_context payload then
+       [ ("channel", `String payload.channel);
+         ("channel_workspace_id", `String payload.channel_workspace_id) ]
+     else [])
+    @
+    (if payload.channel_user_id <> "" then
+       [ ("channel_user_id", `String payload.channel_user_id) ]
+     else [])
+    @
+    (if payload.channel_user_name <> "" then
+       [ ("channel_user_name", `String payload.channel_user_name) ]
+     else [])
+  in
+  let fields = base_fields @ connector_fields in
+  `Assoc
+    (if payload.attachments = [] then fields
+     else ("attachments", `List (List.map attachment_json payload.attachments)) :: fields)
 
 let keeper_chat_request_prefixes =
   [
@@ -215,6 +390,19 @@ let parse_keeper_chat_stream_request body_str =
         |> Option.value ~default:""
         |> String.trim
       in
+      let turn_instructions =
+        match Json_util.get_string json "turn_instructions" with
+        | None -> None
+        | Some s ->
+            let s = String.trim s in
+            if s = "" then None else Some s
+      in
+      let surface_context : Yojson.Safe.t option =
+        match Json_util.assoc_member_opt "surface_context" json with
+        | Some (`Assoc _ as obj) -> Some obj
+        | Some `Null | None -> None
+        | Some _ -> None
+      in
       let has_connector_context =
         channel <> "" || channel_user_id <> ""
         || channel_user_name <> "" || channel_workspace_id <> ""
@@ -268,10 +456,10 @@ let parse_keeper_chat_stream_request body_str =
       else if message = "" then
         Error "message is required"
       else if has_connector_context
-              && (channel = "" || channel_user_id = "" || channel_workspace_id = "")
+              && (channel = "" || channel_workspace_id = "")
       then
         Error
-          "channel, channel_user_id, and channel_workspace_id are required when connector context is supplied"
+          "channel and channel_workspace_id are required when connector context is supplied"
       else
         match
           Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg" json
@@ -285,6 +473,8 @@ let parse_keeper_chat_stream_request body_str =
                   name;
                   message;
                   timeout_sec;
+                  turn_instructions;
+                  surface_context;
                   channel;
                   channel_user_id;
                   channel_user_name;
@@ -525,54 +715,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
     (Run_started { run_id; thread_id });
   Keeper_chat_events.publish events
     (Text_message_start { message_id; role = Assistant });
-  let has_connector_context =
-    payload.channel <> "" && payload.channel_user_id <> ""
-  in
-  let message =
-    if has_connector_context then
-      Gate_keeper_backend.contextualize_message
-         ~channel:payload.channel
-         ~channel_user_id:payload.channel_user_id
-         ~channel_user_name:payload.channel_user_name
-         ~channel_workspace_id:payload.channel_workspace_id
-         ~metadata:[]
-         ~content:payload.message
-    else
-      payload.message
-  in
-  let attachment_json (att : Keeper_chat_store.attachment) =
-    `Assoc
-      [ ("id", `String att.Keeper_chat_store.id);
-        ("type", `String att.att_type);
-        ("name", `String att.name);
-        ("size", `Int att.size);
-        ("mime_type", `String att.mime_type);
-        ("data", `String att.data) ]
-  in
-  let args =
-    let base_fields =
-      [ ("name", `String payload.name);
-        ("message", `String message);
-        ("direct_reply", `Bool true) ]
-      @
-      (match payload.timeout_sec with
-       | Some timeout_sec -> [ ("timeout_sec", `Int timeout_sec) ]
-       | None -> [])
-    in
-    let connector_fields =
-      if has_connector_context then
-        [ ("channel", `String payload.channel);
-          ("channel_user_id", `String payload.channel_user_id);
-          ("channel_user_name", `String payload.channel_user_name);
-          ("channel_workspace_id", `String payload.channel_workspace_id) ]
-      else
-        []
-    in
-    let fields = base_fields @ connector_fields in
-    `Assoc
-      (if payload.attachments = [] then fields
-       else ("attachments", `List (List.map attachment_json payload.attachments)) :: fields)
-  in
+  let args = args_of_request payload in
   (* Stream model text deltas live with per-delta redaction — the same
      treatment ThinkingDelta and Tool_call_args already get in
      [consume_worker_events]. The once-only invariant (live emit + terminal
@@ -620,28 +763,14 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
   in
   (* RFC-0232 P5: the typed surface is the write-side truth; the label
      [chat_source] is its derivation, used for broadcast metadata. *)
-  let chat_surface =
-    if has_connector_context then
-      Surface_ref.Gate { label = payload.channel; address = [] }
-    else Surface_ref.Dashboard { session_id = None }
-  in
+  let chat_surface = chat_surface_of_request payload in
   let chat_source = Surface_ref.lane_label chat_surface in
-  (* RFC-0223 P1: authority derives from the arrival route. Connector
-     context means an arbitrary external person on that channel; its
-     absence means the authenticated dashboard operator (the route is
-     bearer-gated, and the dashboard supplies no per-user identity). *)
-  let chat_speaker : Keeper_chat_store.speaker =
-    if has_connector_context then
-      { speaker_id = Some payload.channel_user_id;
-        speaker_name =
-          (let name = String.trim payload.channel_user_name in
-           if name = "" then None else Some name);
-        speaker_authority = Keeper_chat_store.External }
-    else
-      { speaker_id = None;
-        speaker_name = None;
-        speaker_authority = Keeper_chat_store.Owner }
-  in
+  (* RFC-0223 P1: authority derives from the arrival route. A non-empty
+     [channel_user_id] means an arbitrary external person on that channel;
+     a channel label without a user id (e.g. dashboard Copilot Dock) is
+     still an authenticated dashboard operator, so it keeps Owner authority
+     while recording the Gate surface label. *)
+  let chat_speaker : Keeper_chat_store.speaker = chat_speaker_of_request payload in
   let on_event evt =
     record_tool_event evt;
     push_worker_event (Stream_event evt)
@@ -730,7 +859,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
   Log.Keeper.info
     "keeper_stream: queued request keeper=%s request_id=%s surface=%s"
     payload.name request_id
-    (if has_connector_context then payload.channel else "dashboard");
+    (if has_connector_context payload then payload.channel else "dashboard");
   Keeper_chat_events.publish events
     (Custom
        { name = "KEEPER_QUEUE_REQUEST";
@@ -740,7 +869,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
                destination_type = "keeper";
                destination_id = payload.name;
                channel =
-                 (if has_connector_context then payload.channel
+                 (if has_connector_context payload then payload.channel
                   else "dashboard");
                actor_id = Some agent_name;
                status = Gate_protocol.Queued;
@@ -1009,11 +1138,9 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
       ignore
         (Eio.Switch.run @@ fun stream_sw ->
            Eio.Switch.on_release stream_sw close_stream;
-           let has_connector_context =
-             payload.channel <> "" && payload.channel_user_id <> ""
-           in
+           let has_external_actor = has_external_speaker payload in
            let agent_name =
-             if has_connector_context then
+             if has_external_actor then
                Gate_keeper_backend.agent_name_for_channel_actor
                  ~channel:payload.channel
                  ~channel_workspace_id:payload.channel_workspace_id
@@ -1039,3 +1166,16 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
            ))
 
 (** Build routes for MCP server *)
+
+module For_testing = struct
+  let parse_request = parse_keeper_chat_stream_request
+  let has_connector_context = has_connector_context
+  let has_external_speaker = has_external_speaker
+  let message_for_request = message_for_request
+  let chat_surface_of_request = chat_surface_of_request
+  let chat_speaker_of_request = chat_speaker_of_request
+  let turn_instructions_for_request = turn_instructions_for_request
+  let args_of_request = args_of_request
+  let format_surface_context = format_surface_context
+  let surface_context_to_instructions = surface_context_to_instructions
+end

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -44,6 +44,8 @@ type keeper_chat_stream_request = {
   name : string;
   message : string;
   timeout_sec : int option;
+  turn_instructions : string option;
+  surface_context : Yojson.Safe.t option;
   channel : string;
   channel_user_id : string;
   channel_user_name : string;
@@ -52,10 +54,14 @@ type keeper_chat_stream_request = {
 }
 (** Parsed payload of a keeper chat-stream HTTP request.
     [timeout_sec] is clamped to [\[5, 300\]] when
-    present.  [channel] / [channel_user_id] /
-    [channel_user_name] / [channel_workspace_id] are all
-    required together when any connector context is
-    supplied; otherwise they are accepted as empty. *)
+    present.  [turn_instructions] and [surface_context]
+    are optional copilot context fields; when
+    [turn_instructions] is absent but [surface_context]
+    is present, the surface context is formatted and
+    injected as turn instructions.  [channel] and
+    [channel_workspace_id] are required together when any
+    connector context is supplied; [channel_user_id] and
+    [channel_user_name] are optional. *)
 
 (** {1 Parsing} *)
 
@@ -127,3 +133,18 @@ val process_single_turn :
     event pushes when set to [true] (used by the SSE adapter when the
     HTTP stream is closed).  [auth_token] is [None] for queue-consumer
     turns where no HTTP request is available. *)
+
+(** {1 Testing helpers} *)
+
+module For_testing : sig
+  val parse_request : string -> (keeper_chat_stream_request, string) result
+  val has_connector_context : keeper_chat_stream_request -> bool
+  val has_external_speaker : keeper_chat_stream_request -> bool
+  val message_for_request : keeper_chat_stream_request -> string
+  val chat_surface_of_request : keeper_chat_stream_request -> Surface_ref.t
+  val chat_speaker_of_request : keeper_chat_stream_request -> Keeper_chat_store.speaker
+  val turn_instructions_for_request : keeper_chat_stream_request -> string option
+  val args_of_request : keeper_chat_stream_request -> Yojson.Safe.t
+  val format_surface_context : Yojson.Safe.t -> string
+  val surface_context_to_instructions : Yojson.Safe.t -> string option
+end

--- a/test/dune
+++ b/test/dune
@@ -109,6 +109,7 @@
   test_tool_assignment_telemetry
   test_dashboard_link_preview
   test_gate_keeper_backend
+  test_copilot_dock_channel_wiring
   test_transport_read_model
   test_multi_workspace
   test_worktree_detection
@@ -398,6 +399,7 @@
   test_tool_assignment_telemetry
   test_dashboard_link_preview
   test_gate_keeper_backend
+  test_copilot_dock_channel_wiring
   test_transport_read_model
   test_multi_workspace
   test_worktree_detection

--- a/test/test_copilot_dock_channel_wiring.ml
+++ b/test/test_copilot_dock_channel_wiring.ml
@@ -1,0 +1,195 @@
+(* Tests for dashboard Copilot Dock -> keeper chat stream wiring.
+
+   Verifies the shared contract from the HTTP parser down to the
+   [masc_keeper_msg] args that [Keeper_tool_surface.dispatch_stream]
+   receives:
+   - copilot channel label + operator workspace id parse without requiring
+     an external user id;
+   - [turn_instructions] and [surface_context] are forwarded as turn
+     instructions;
+   - the chat history surface is recorded as [Surface_ref.Gate];
+   - external connector traffic still gets contextualized messages and
+     External speaker authority. *)
+
+open Alcotest
+open Masc
+
+module Stream = Server_routes_http_keeper_stream
+
+let surface : Masc.Surface_ref.t testable =
+  testable
+    (fun fmt t -> Format.pp_print_string fmt (Masc.Surface_ref.lane_label t))
+    Masc.Surface_ref.equal
+
+let parse_ok body =
+  match Stream.For_testing.parse_request body with
+  | Ok payload -> payload
+  | Error err -> fail ("expected parse to succeed: " ^ err)
+
+let args_assoc args =
+  match args with
+  | `Assoc fields -> fields
+  | _ -> fail "expected args to be a JSON object"
+
+let get_string_field key args =
+  match List.assoc_opt key (args_assoc args) with
+  | Some (`String s) -> s
+  | _ -> ""
+
+let get_bool_field key args =
+  match List.assoc_opt key (args_assoc args) with
+  | Some (`Bool b) -> b
+  | _ -> false
+
+let has_field key args = Option.is_some (List.assoc_opt key (args_assoc args))
+
+let contains needle haystack = Astring.String.is_infix ~affix:needle haystack
+
+let test_copilot_parse_accepts_operator_workspace () =
+  let body =
+    {|{"name":"luna","message":"hello","channel":"copilot","channel_workspace_id":"session-7","turn_instructions":"focus on overview"}|}
+  in
+  let payload = parse_ok body in
+  check string "channel" "copilot" payload.channel;
+  check string "workspace id" "session-7" payload.channel_workspace_id;
+  check string "user id optional" "" payload.channel_user_id;
+  check (option string) "turn instructions" (Some "focus on overview")
+    payload.turn_instructions;
+  check bool "connector context" true
+    (Stream.For_testing.has_connector_context payload);
+  check bool "external speaker" false
+    (Stream.For_testing.has_external_speaker payload)
+
+let test_copilot_surface_is_gate_label () =
+  let payload =
+    parse_ok
+      {|{"name":"luna","message":"hello","channel":"copilot","channel_workspace_id":"session-7"}|}
+  in
+  let chat_surface = Stream.For_testing.chat_surface_of_request payload in
+  check surface "chat surface"
+    (Masc.Surface_ref.Gate { label = "copilot"; address = [] })
+    chat_surface;
+  let speaker = Stream.For_testing.chat_speaker_of_request payload in
+  check string "authority label" "owner"
+    (Keeper_chat_store.authority_label speaker.speaker_authority);
+  check (option string) "speaker id" None speaker.speaker_id
+
+let test_copilot_message_is_not_contextualized () =
+  let payload =
+    parse_ok
+      {|{"name":"luna","message":"hello","channel":"copilot","channel_workspace_id":"session-7"}|}
+  in
+  let message = Stream.For_testing.message_for_request payload in
+  check bool "no external channel envelope" false
+    (contains "[External channel context]" message);
+  check string "message verbatim" "hello" message
+
+let test_copilot_args_carry_turn_instructions () =
+  let payload =
+    parse_ok
+      {|{"name":"luna","message":"hello","channel":"copilot","channel_workspace_id":"session-7","turn_instructions":"focus on overview"}|}
+  in
+  let args = Stream.For_testing.args_of_request payload in
+  check string "name" "luna" (get_string_field "name" args);
+  check string "message" "hello" (get_string_field "message" args);
+  check bool "direct_reply" true (get_bool_field "direct_reply" args);
+  check string "turn_instructions" "focus on overview"
+    (get_string_field "turn_instructions" args);
+  check string "channel" "copilot" (get_string_field "channel" args);
+  check string "channel_workspace_id" "session-7"
+    (get_string_field "channel_workspace_id" args);
+  check bool "no channel_user_id" false (has_field "channel_user_id" args);
+  check bool "no channel_user_name" false (has_field "channel_user_name" args)
+
+let test_surface_context_is_formatted_as_turn_instructions () =
+  let payload =
+    parse_ok
+      {|{"name":"luna","message":"hello","channel":"copilot","channel_workspace_id":"session-7","surface_context":{"label":"Overview","route":"/overview","scene":"fleet view","fields":[{"k":"run","v":"2/5"},{"k":"alert","v":"1"}]}}|}
+  in
+  let instructions = Stream.For_testing.turn_instructions_for_request payload in
+  check bool "instructions produced" true (Option.is_some instructions);
+  let text = Option.value ~default:"" instructions in
+  check bool "contains label" true (contains "Surface label: Overview" text);
+  check bool "contains route" true (contains "Route: /overview" text);
+  check bool "contains scene" true (contains "Scene: fleet view" text);
+  check bool "contains field" true (contains "run: 2/5" text);
+  let args = Stream.For_testing.args_of_request payload in
+  check bool "turn_instructions in args" true (has_field "turn_instructions" args)
+
+let test_turn_instructions_and_surface_context_combine () =
+  let payload =
+    parse_ok
+      {|{"name":"luna","message":"hello","channel":"copilot","channel_workspace_id":"session-7","turn_instructions":"focus","surface_context":{"label":"Overview","route":"/overview","scene":"fleet view","fields":[]}}|}
+  in
+  let instructions = Stream.For_testing.turn_instructions_for_request payload in
+  let text = Option.value ~default:"" instructions in
+  check bool "starts with explicit instructions" true
+    (Astring.String.is_prefix ~affix:"focus" text);
+  check bool "includes formatted surface context" true
+    (contains "[Co-view context]" text)
+
+let test_external_connector_still_contextualized () =
+  let payload =
+    parse_ok
+      {|{"name":"luna","message":"hello","channel":"discord","channel_user_id":"user-42","channel_user_name":"Alice","channel_workspace_id":"workspace-9"}|}
+  in
+  check bool "has external speaker" true
+    (Stream.For_testing.has_external_speaker payload);
+  let chat_surface = Stream.For_testing.chat_surface_of_request payload in
+  check surface "surface"
+    (Masc.Surface_ref.Gate { label = "discord"; address = [] })
+    chat_surface;
+  let speaker = Stream.For_testing.chat_speaker_of_request payload in
+  check string "authority" "external"
+    (Keeper_chat_store.authority_label speaker.speaker_authority);
+  check (option string) "speaker id" (Some "user-42") speaker.speaker_id;
+  let message = Stream.For_testing.message_for_request payload in
+  check bool "context envelope present" true
+    (contains "[External channel context]" message);
+  let args = Stream.For_testing.args_of_request payload in
+  check string "channel_user_id" "user-42"
+    (get_string_field "channel_user_id" args);
+  check string "channel_user_name" "Alice"
+    (get_string_field "channel_user_name" args)
+
+let test_dashboard_without_channel_is_owner () =
+  let payload = parse_ok {|{"name":"luna","message":"hello"}|} in
+  check bool "no connector context" false
+    (Stream.For_testing.has_connector_context payload);
+  let chat_surface = Stream.For_testing.chat_surface_of_request payload in
+  check surface "surface" (Masc.Surface_ref.Dashboard { session_id = None }) chat_surface;
+  let speaker = Stream.For_testing.chat_speaker_of_request payload in
+  check string "authority" "owner"
+    (Keeper_chat_store.authority_label speaker.speaker_authority);
+  let args = Stream.For_testing.args_of_request payload in
+  check bool "no channel in args" false (has_field "channel" args)
+
+let () =
+  run "copilot_dock_channel_wiring"
+    [
+      ( "parse",
+        [
+          test_case "copilot context parses without user id" `Quick
+            test_copilot_parse_accepts_operator_workspace;
+        ] );
+      ( "surface",
+        [
+          test_case "copilot records Gate surface and Owner speaker" `Quick
+            test_copilot_surface_is_gate_label;
+          test_case "external connector keeps External speaker" `Quick
+            test_external_connector_still_contextualized;
+          test_case "dashboard without channel records Dashboard surface" `Quick
+            test_dashboard_without_channel_is_owner;
+        ] );
+      ( "prompt",
+        [
+          test_case "copilot message is not contextualized" `Quick
+            test_copilot_message_is_not_contextualized;
+          test_case "turn_instructions forwarded to args" `Quick
+            test_copilot_args_carry_turn_instructions;
+          test_case "surface_context formatted as turn instructions" `Quick
+            test_surface_context_is_formatted_as_turn_instructions;
+          test_case "turn_instructions and surface_context combine" `Quick
+            test_turn_instructions_and_surface_context_combine;
+        ] );
+    ]

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -2,6 +2,7 @@ open Alcotest
 open Masc
 
 module K = Keeper_chat_store
+module KT = Keeper_turn
 
 let rec remove_tree path =
   if Sys.file_exists path then
@@ -168,8 +169,108 @@ let test_parse_keeper_chat_stream_request_rejects_partial_connector_context () =
   | Ok _ -> fail "expected partial connector context to be rejected"
   | Error err ->
       check string "validation message"
-        "channel, channel_user_id, and channel_workspace_id are required when connector context is supplied"
+        "channel and channel_workspace_id are required when connector context is supplied"
         err
+
+let test_parse_keeper_chat_stream_request_accepts_copilot_context () =
+  let body =
+    {|{"name":"luna","message":"hello","channel":"copilot","channel_workspace_id":"session-7","turn_instructions":"focus on overview"}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok payload ->
+      check string "channel" "copilot" payload.channel;
+      check string "workspace id" "session-7" payload.channel_workspace_id;
+      check string "user id optional" "" payload.channel_user_id;
+      check (option string) "turn instructions" (Some "focus on overview") payload.turn_instructions;
+      check bool "surface context absent" true (Option.is_none payload.surface_context)
+  | Error err -> fail ("expected copilot context to parse: " ^ err)
+
+let test_parse_keeper_chat_stream_request_formats_surface_context () =
+  let body =
+    {|{"name":"luna","message":"hello","channel":"copilot","channel_workspace_id":"session-7","surface_context":{"label":"Overview","route":"/overview","scene":"fleet view","fields":[{"k":"run","v":"2/5"},{"k":"alert","v":"1"}]}}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok payload ->
+      check string "channel" "copilot" payload.channel;
+      check (option string) "turn instructions" None payload.turn_instructions;
+      check bool "surface context present" true (Option.is_some payload.surface_context)
+  | Error err -> fail ("expected surface context to parse: " ^ err)
+
+let test_surface_context_to_instructions_formats_copilot_context () =
+  let ctx =
+    Yojson.Safe.from_string
+      {|{"label":"Overview","route":"/overview","scene":"fleet view","fields":{"run":"2/5","alert":"1"}}|}
+  in
+  match Server_routes_http_keeper_stream.For_testing.surface_context_to_instructions ctx with
+  | Some instructions ->
+      check bool "includes label" true
+        (String_util.string_contains_substring ~needle:"Surface label: Overview" instructions);
+      check bool "includes route" true
+        (String_util.string_contains_substring ~needle:"Route: /overview" instructions);
+      check bool "includes scene" true
+        (String_util.string_contains_substring ~needle:"Scene: fleet view" instructions);
+      check bool "includes fields" true
+        (String_util.string_contains_substring ~needle:"Fields:" instructions)
+  | None -> fail "expected surface_context to format into instructions"
+
+let test_surface_context_to_instructions_ignores_empty () =
+  let ctx = `Assoc [ ("label", `String "  "); ("fields", `Assoc []) ] in
+  check (option string) "empty surface_context" None
+    (Server_routes_http_keeper_stream.For_testing.surface_context_to_instructions ctx)
+
+let test_chat_surface_of_request_labels_copilot_gate () =
+  let payload =
+    { Server_routes_http_keeper_stream.name = "luna";
+      message = "hello";
+      timeout_sec = None;
+      turn_instructions = None;
+      surface_context = None;
+      channel = "copilot";
+      channel_user_id = "";
+      channel_user_name = "";
+      channel_workspace_id = "session-7";
+      attachments = [] }
+  in
+  let surface = Server_routes_http_keeper_stream.For_testing.chat_surface_of_request payload in
+  check string "copilot surface label" "copilot" (Surface_ref.lane_label surface)
+
+let test_chat_speaker_of_request_copilot_is_owner () =
+  let payload =
+    { Server_routes_http_keeper_stream.name = "luna";
+      message = "hello";
+      timeout_sec = None;
+      turn_instructions = None;
+      surface_context = None;
+      channel = "copilot";
+      channel_user_id = "";
+      channel_user_name = "";
+      channel_workspace_id = "session-7";
+      attachments = [] }
+  in
+  let speaker = Server_routes_http_keeper_stream.For_testing.chat_speaker_of_request payload in
+  check (option string) "copilot speaker id" None speaker.speaker_id;
+  check (option string) "copilot speaker name" None speaker.speaker_name;
+  check bool "copilot speaker authority is owner" true
+    (speaker.speaker_authority = Keeper_chat_store.Owner)
+
+let test_chat_speaker_of_request_connector_is_external () =
+  let payload =
+    { Server_routes_http_keeper_stream.name = "luna";
+      message = "hello";
+      timeout_sec = None;
+      turn_instructions = None;
+      surface_context = None;
+      channel = "discord";
+      channel_user_id = "user-42";
+      channel_user_name = "Alice";
+      channel_workspace_id = "workspace-9";
+      attachments = [] }
+  in
+  let speaker = Server_routes_http_keeper_stream.For_testing.chat_speaker_of_request payload in
+  check (option string) "connector speaker id" (Some "user-42") speaker.speaker_id;
+  check (option string) "connector speaker name" (Some "Alice") speaker.speaker_name;
+  check bool "connector speaker authority is external" true
+    (speaker.speaker_authority = Keeper_chat_store.External)
 
 let test_parse_keeper_chat_stream_request_rejects_legacy_model_args () =
   let cases =
@@ -329,6 +430,20 @@ let () =
             test_parse_keeper_chat_stream_request_accepts_connector_context;
           test_case "stream request rejects partial connector context" `Quick
             test_parse_keeper_chat_stream_request_rejects_partial_connector_context;
+          test_case "stream request accepts copilot context" `Quick
+            test_parse_keeper_chat_stream_request_accepts_copilot_context;
+          test_case "stream request formats surface context" `Quick
+            test_parse_keeper_chat_stream_request_formats_surface_context;
+          test_case "surface context formats into instructions" `Quick
+            test_surface_context_to_instructions_formats_copilot_context;
+          test_case "surface context ignores empty fields" `Quick
+            test_surface_context_to_instructions_ignores_empty;
+          test_case "copilot request labels gate surface" `Quick
+            test_chat_surface_of_request_labels_copilot_gate;
+          test_case "copilot request speaker is owner" `Quick
+            test_chat_speaker_of_request_copilot_is_owner;
+          test_case "connector request speaker is external" `Quick
+            test_chat_speaker_of_request_connector_is_external;
           test_case "stream request rejects legacy model args" `Quick
             test_parse_keeper_chat_stream_request_rejects_legacy_model_args;
         ] );


### PR DESCRIPTION
## Summary
Wires the dashboard Copilot Dock into MASC's existing keeper chat stream system so that Copilot turns run through the real multi-channel turn lifecycle and are recorded as a distinct channel.

## Changes
- **Frontend**: Removed the mock reply/setTimeout streaming in `copilot-dock.ts` and switched to `streamKeeperMessage`.
  - Sends `channel: "copilot"`, `channel_workspace_id: currentDashboardActor()`, and `surface_context` with every Copilot turn.
  - Extended `streamKeeperMessage` options to accept `channel`, `channelWorkspaceId`, `turnInstructions`, and `surfaceContext`.
- **Backend**: Extended `/api/v1/keepers/chat/stream` request parsing to accept `turn_instructions`, `surface_context`, `channel`, and `channel_workspace_id`.
  - `surface_context` is formatted into turn instructions when no explicit `turn_instructions` are provided.
  - Copilot turns are recorded as `Surface_ref.Gate { label = "copilot" }` with `Owner` speaker authority (dashboard operator).
  - External connectors (Discord/Slack) keep their existing contextualized messages and `External` speaker authority.
- **Schema**: Added missing `direct_reply`, `turn_instructions`, `surface_context`, and channel fields to the `masc_keeper_msg` JSON schema.
- **Tests**: Added `test/test_copilot_dock_channel_wiring.ml` and expanded dashboard/backend tests.

## Verification
- `npx tsc --noEmit` in `dashboard/` passes.
- Dashboard tests for `copilot-dock.test.ts` and `keeper.test.ts` pass (34 tests).
- `test/test_gate_keeper_backend.exe` passes (36 tests).
- `test/test_copilot_dock_channel_wiring.exe` passes (8 tests).
- `bin/main_eio.exe` builds successfully.
