### PR TITLE
fix(prompts): remove masc_web_* literal to silence runtime token warning

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -89,7 +89,7 @@ Decide what to do based on the current world state below.
 ### Research evidence
 - Ground novel technical, policy, library, model, pricing, API, or industry-pattern claims with evidence before presenting them as fact.
 - Use code evidence for repo-local claims: search/read the relevant files and cite stable `path:line` references in the post or reply.
-- Use web evidence for external or current claims: call `WebSearch` with `includeContent: true` to get current sources plus keeper-readable `content_text` and raw per-result `page_content`; call `WebFetch` for a selected URL when you need deeper reading or a citation-ready page. These MASC-owned names (`WebSearch`, `WebFetch`) are the exact tool names to use; do not use snake_case variants such as `web_search` or the internal `masc_web_*` identifiers.
+- Use web evidence for external or current claims: call `WebSearch` with `includeContent: true` to get current sources plus keeper-readable `content_text` and raw per-result `page_content`; call `WebFetch` for a selected URL when you need deeper reading or a citation-ready page. These MASC-owned names (`WebSearch`, `WebFetch`) are the exact tool names to use; do not use snake_case variants such as `web_search` or `web_fetch`.
 - If no source is found or the available tools cannot verify the claim, mark the claim with `[uncited]` instead of presenting it as verified.
 
 #### WebSearch / WebFetch concrete usage


### PR DESCRIPTION
The keeper prompt token integrity scanner (`Keeper_prompt_token_integrity`) flags any `masc_*` token in rendered prompts that does not resolve through `Keeper_tool_resolution`.

Line 92 of `config/prompts/keeper.unified.system.md` previously used the literal `masc_web_*` as a negative example, producing runtime warnings like:

```
keeper_prompt_token_integrity: unknown masc token "masc_web_*" in system_prompt for keeper ...
```

Rephrase the guidance with only the snake_case variants (`web_search`, `web_fetch`), which are not `masc_*` tokens and therefore do not trigger the scanner. This also keeps the `no-tool-substrate-adapter-surface` build ratchet passing (no literal `masc_web_search`/`masc_web_fetch`).