### PR TITLE
feat(bin): masc_shell_ir_probe — offline Shell IR pipeline probe

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -264,6 +264,14 @@
  (name poc_shell_ir_gen)
  (modules poc_shell_ir_gen))
 
+;; Offline Shell IR pipeline probe — read-only. Feeds a command string through
+;; parse / command-gate / capabilities / approval verdict / path-jail and prints
+;; each layer's outcome. Dev/test tool: run via `dune exec bin/masc_shell_ir_probe.exe`.
+(executable
+ (name masc_shell_ir_probe)
+ (modules masc_shell_ir_probe)
+ (libraries masc.masc_exec masc.exec_policy))
+
 ; RFC-0054 PR-3 — production codegen for lib/exec/shell_ir_typed.ml.
 ; Hardcoded 9-constructor spec mirrors shell_ir_typed.{ml,mli} order.
 ; Stdlib-only — no ppxlib, no AST manipulation. Output goes through

--- a/bin/masc_shell_ir_probe.ml
+++ b/bin/masc_shell_ir_probe.ml
@@ -1,0 +1,120 @@
+(** masc_shell_ir_probe — offline Shell IR pipeline probe (read-only).
+
+    Feeds a shell command string through the same decision layers the keeper
+    Execute path uses, WITHOUT running it:
+
+      1. Exec_policy.parse_string_to_ir ~mode:Tool_execute      (parse)
+      2. Exec_policy.validate_command_tool_execute              (command gate)
+      3. Capability_check.of_ir                                 (capabilities)
+      4. Approval_policy.decide ~overlay:autonomous             (four-way verdict)
+      5. Exec_policy.validate_shell_ir_paths ~workdir           (downstream path jail)
+
+    Every layer's outcome is printed independently so a probe shows exactly
+    which layer would block a command. Parse failures, gate rejections, and
+    exceptions are reported, never raised past the per-command loop — this is
+    a stability probe, so a crash on any single command is a finding, not an
+    abort.
+
+    Usage:
+      masc_shell_ir_probe "gh api /repos/jeong-sik/masc/check-runs"
+      masc_shell_ir_probe --workdir /repo "rm -rf /" "git reset --hard"
+      masc_shell_ir_probe --stdin < commands.txt    (one command per line) *)
+
+module Shell_ir = Masc_exec.Shell_ir
+module Exec_program = Masc_exec.Exec_program
+module Capability = Masc_exec.Capability
+module Capability_check = Masc_exec.Capability_check
+module Approval_policy = Masc_exec.Approval_policy
+module Approval_config = Masc_exec.Approval_config
+module Verdict = Masc_exec.Verdict
+
+let probe_policy : Approval_policy.t = { raw_source = "(probe)"; summary = "(probe)" }
+
+let last_simple_of_ir = function
+  | Shell_ir.Simple s -> Some s
+  | Shell_ir.Pipeline stages -> (
+    match List.rev stages with Shell_ir.Simple s :: _ -> Some s | _ -> None)
+
+let ir_shape = function
+  | Shell_ir.Simple _ -> "Simple"
+  | Shell_ir.Pipeline stages -> Printf.sprintf "Pipeline(%d stages)" (List.length stages)
+
+let render_caps = function
+  | [] -> "(none)"
+  | caps ->
+    caps
+    |> List.map (fun c -> Format.asprintf "%a" Capability.pp c)
+    |> String.concat "; "
+
+let render_verdict = function
+  | Verdict.Allow t ->
+    Printf.sprintf "Allow (bin=%s)" (Exec_program.to_string (Verdict.Trusted_argv.bin t))
+  | Verdict.Suggest_confirm (t, _) ->
+    Printf.sprintf "Suggest_confirm (bin=%s)"
+      (Exec_program.to_string (Verdict.Trusted_argv.bin t))
+  | Verdict.Ask req ->
+    Printf.sprintf "Ask (bin=%s) — %s" (Exec_program.to_string req.Verdict.bin)
+      req.Verdict.summary
+  | Verdict.Deny { reason; _ } -> Printf.sprintf "Deny — %s" (Verdict.deny_reason_to_string reason)
+
+let probe ~workdir command =
+  Printf.printf "cmd:          %s\n" command;
+  (match Exec_policy.parse_string_to_ir ~mode:Tool_execute command with
+   | Error reason ->
+     Printf.printf "parse:        BLOCKED — %s\n" (Exec_policy.block_reason_to_string reason)
+   | Ok ir ->
+     Printf.printf "parse:        ok (%s)\n" (ir_shape ir);
+     (match Exec_policy.validate_command_tool_execute ~allow_pipes:true ir with
+      | Ok () -> Printf.printf "command-gate: ok\n"
+      | Error reason ->
+        Printf.printf "command-gate: BLOCKED — %s\n" (Exec_policy.block_reason_to_string reason));
+     Printf.printf "caps:         %s\n" (render_caps (Capability_check.of_ir ir));
+     (match last_simple_of_ir ir with
+      | None -> Printf.printf "verdict:      (no simple stage)\n"
+      | Some simple ->
+        let caps = Capability_check.of_simple simple in
+        let verdict =
+          Approval_policy.decide probe_policy ~overlay:Approval_config.autonomous ~caps ~simple
+        in
+        Printf.printf "verdict:      %s\n" (render_verdict verdict));
+     match Exec_policy.validate_shell_ir_paths ~workdir ir with
+     | Ok () -> Printf.printf "path-jail:    OK\n"
+     | Error e -> Printf.printf "path-jail:    BLOCKED — %s\n" e);
+  print_newline ()
+
+let probe_safe ~workdir command =
+  try probe ~workdir command
+  with exn ->
+    Printf.printf "cmd:          %s\nEXCEPTION:    %s\n\n" command (Printexc.to_string exn)
+
+let () =
+  let workdir = ref "/tmp" in
+  let from_stdin = ref false in
+  let commands = ref [] in
+  let rec parse = function
+    | [] -> ()
+    | "--workdir" :: dir :: rest ->
+      workdir := dir;
+      parse rest
+    | "--stdin" :: rest ->
+      from_stdin := true;
+      parse rest
+    | c :: rest ->
+      commands := c :: !commands;
+      parse rest
+  in
+  parse (List.tl (Array.to_list Sys.argv));
+  let commands =
+    if !from_stdin then (
+      let acc = ref [] in
+      (try
+         while true do
+           acc := input_line stdin :: !acc
+         done
+       with End_of_file -> ());
+      List.rev !acc)
+    else List.rev !commands
+  in
+  Printf.printf "# masc_shell_ir_probe  workdir=%s overlay=autonomous mode=Tool_execute\n\n"
+    !workdir;
+  List.iter (fun c -> if String.trim c <> "" then probe_safe ~workdir:!workdir c) commands


### PR DESCRIPTION
## 목적

Shell IR 결정 파이프라인을 명령 단위로 오프라인 검증하는 read-only 하네스. keeper Execute 경로의 결정 층을 실행 없이 재현:

1. `Exec_policy.parse_string_to_ir ~mode:Tool_execute` (parse)
2. `Exec_policy.validate_command_tool_execute` (command gate)
3. `Capability_check.of_ir` (capabilities)
4. `Approval_policy.decide ~overlay:autonomous` (4-way verdict)
5. `Exec_policy.validate_shell_ir_paths ~workdir` (path jail)

각 층의 결과를 독립 출력 → 어느 층이 명령을 막는지 정확히 보임. parse 실패/gate 거부/예외를 보고하되 per-command loop 밖으로 raise하지 않음(stability probe).

## 사용

```
dune exec bin/masc_shell_ir_probe.exe -- "gh api /repos/owner/repo/check-runs"
dune exec bin/masc_shell_ir_probe.exe -- --workdir /repo "git status" "git reset --hard"
dune exec bin/masc_shell_ir_probe.exe -- --stdin < commands.txt
```

## 검증

66개 변종 명령(gh/git/filesystem/redirect/traversal/network/pipeline/edge)을 통과시켜 **예외 0건, exit 0** — 파이프라인 crash-stability 확인. 분류 정확성 검증 중 catastrophic floor의 변종 누락 등 후속 findings를 발견(별도 추적).

read-only 도구로 production 경로 무변경. exec_policy/exec를 *읽기만* 함.
