### PR TITLE
fix(exec): complete catastrophic floor — fs-format family + bundled git force flags

### DIFF
--- a/lib/exec/exec_program.ml
+++ b/lib/exec/exec_program.ml
@@ -352,6 +352,14 @@ let of_string raw =
     match known_of_string name with
     | Some k ->
       Ok { name; risk = risk_of_known k; kind = kind_of_known k; known = Some k }
+    | None when String.starts_with ~prefix:"mkfs." name ->
+      (* The [mkfs.<fstype>] family (mkfs.ext4, mkfs.xfs, mkfs.vfat, ...) is the
+         util-linux / fs-tools naming convention for filesystem-format helpers.
+         Every member is catastrophic-by-identity like bare [mkfs] (RFC-0254
+         §5.3 floor), so recognize the family structurally: an enumerated set
+         would let a new fstype helper silently bypass the floor. The recorded
+         [name] stays the real binary so the deny diagnostic is accurate. *)
+      Ok { name; risk = risk_of_known Mkfs; kind = kind_of_known Mkfs; known = Some Mkfs }
     | None ->
       (* Unknown binary -> Privileged per RFC v5 fail-closed rule. *)
       Ok { name; risk = `Privileged; kind = `Privileged_program; known = None })

--- a/lib/exec/git_op.ml
+++ b/lib/exec/git_op.ml
@@ -11,6 +11,18 @@ type t =
 
 let has_flag args flag = List.mem flag args
 
+(* git short flags bundle: [git clean -fd] carries [-f] inside the [-fd]
+   cluster, and [git push -fv] carries [-f] inside [-fv]. [has_short_flag]
+   matches a single-letter flag whether standalone ([-f]) or bundled with
+   other short flags ([-fd], [-df], [-xfd]), but never inside a long flag
+   ([--force-with-lease] stays unmatched). Without this, [git clean -fd] —
+   the common force form — bypasses the destructive classifier. *)
+let has_short_flag args ch =
+  List.exists
+    (fun arg ->
+      String.length arg >= 2 && arg.[0] = '-' && arg.[1] <> '-' && String.contains arg ch)
+    args
+
 let rec strip_global_options = function
   | "-C" :: _path :: rest -> strip_global_options rest
   | "-c" :: _binding :: rest -> strip_global_options rest
@@ -52,12 +64,12 @@ let of_argv = function
             | "drop" :: _ -> Ok (Destructive `Stash_drop)
             | _ -> Ok (Mutating `Stash_push))
        | "push" ->
-           if has_flag rest "--force" || has_flag rest "-f" then
+           if has_flag rest "--force" || has_short_flag rest 'f' then
              Ok (Destructive `Push_force)
            else Ok (Mutating `Push)
        | "reset" when has_flag rest "--hard" ->
            Ok (Destructive `Reset_hard)
-       | "clean" when has_flag rest "-f" || has_flag rest "--force" ->
+       | "clean" when has_short_flag rest 'f' || has_flag rest "--force" ->
            Ok (Destructive `Clean_force)
        | "worktree" ->
            (match rest with

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -263,6 +263,29 @@ let test_autonomous_allows_toolchain () =
     assert (Exec_program.to_string (Verdict.Trusted_argv.bin t) = "git")
   | _ -> assert false
 
+(* Floor completeness — the [mkfs.<fstype>] family (mkfs.ext4, mkfs.xfs, ...)
+   is catastrophic-by-identity exactly like bare [mkfs], so it hits the floor
+   regardless of overlay. Probe finding 2026-06-18: the family bypassed the
+   floor when only bare [mkfs] was a recognized program. *)
+let test_mkfs_family_denied_under_autonomous () =
+  let s = simple (bin_ok "mkfs.ext4") ~args:[ lit "/dev/sdb1" ] in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps ~simple:s with
+  | Verdict.Deny { reason = Catastrophic_program bin; _ } ->
+    assert (Exec_program.to_string bin = "mkfs.ext4")
+  | _ -> assert false
+
+(* Floor completeness — [git clean] with a bundled force flag ([-fd], the
+   common force-delete-untracked form) is destructive and hits the floor.
+   Probe finding 2026-06-18: [git clean -fd] was graded as plain audited git
+   because the classifier matched only the standalone [-f] token. *)
+let test_git_clean_bundled_force_denied () =
+  let s = simple (bin_ok "git") ~args:[ lit "clean"; lit "-fd" ] in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps ~simple:s with
+  | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Clean_force); _ } -> ()
+  | _ -> assert false
+
 let () =
   test_safe_bin_strict_asks ();
   test_safe_bin_allowed_with_overlay ();
@@ -284,6 +307,8 @@ let () =
   (* RFC-0254 catastrophic floor *)
   test_destructive_git_floor_independent_of_trust ();
   test_mkfs_denied_under_autonomous ();
+  test_mkfs_family_denied_under_autonomous ();
+  test_git_clean_bundled_force_denied ();
   test_rm_root_allowed_at_policy_layer_jailed_downstream ();
   test_autonomous_allows_toolchain ();
   print_endline "[test_approval_policy] all tests passed"


### PR DESCRIPTION
## 배경

오프라인 Shell IR probe(`bin/masc_shell_ir_probe`, PR #21467)로 갈래별 분류를 검증하다 RFC-0254 §5.3 trust-independent catastrophic floor의 **열거 누락 2건**을 발견.

## 수정

### ① 파일시스템-포맷 패밀리 floor 누락
- bare `mkfs`만 known program이라, 실제 명령인 `mkfs.ext4`/`mkfs.xfs`/`mkfs.vfat`는 privileged-unknown으로 분류되어 floor를 우회. workspace 내 경로면 **전 층 통과**.
- `Exec_program.of_string`이 `mkfs.<fstype>` 패밀리를 **구조적으로** 인식(util-linux 안정 명명 규약) → `Mkfs`로 매핑 → overlay 무관 deny. 기록 name은 실제 바이너리 유지(정확한 deny 진단).
- enumerate(닫힌 집합)이 아니라 구조 인식인 이유: 새 fstype 헬퍼가 집합 누락으로 조용히 floor를 우회하는 걸 막기 위함.

### ② 결합 git force 플래그 누락
- destructive 분류기가 standalone `-f` 토큰만 매칭 → `git clean -fd`(흔한 force-delete-untracked 형태)가 plain audited git으로 격하.
- `has_short_flag` 추가(단일 문자 플래그를 standalone/결합 `-fd`·`-df` 모두 인식, long flag `--force-with-lease`는 미매칭) → 같은 root의 두 사이트(`push`, `clean`)에 적용(N-of-M 회피).

## 검증

- `test_approval_policy`: `test_mkfs_family_denied_under_autonomous`, `test_git_clean_bundled_force_denied` 추가.
- 전체 `lib/exec` 테스트 스위트 green (회귀 0).
- probe end-to-end: fs-format 패밀리 + `git clean -fd` → Deny, `git clean -n`(dry-run) → Allow 유지.

## RFC

RFC-0254 §5.3 catastrophic floor의 완성도 보강(floor 의미는 무변경, 누락 사이트만 닫음). 게이트/overlay 동작 불변.
