### PR TITLE
fix(build): expose keeper_unified_turn_event_bus so its test compiles

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -107,7 +107,6 @@
   keeper_turn_driver_wrappers
   keeper_unified_metrics_json_support
   keeper_unified_metrics_support
-  keeper_unified_turn_event_bus
   keeper_unified_turn_no_progress
   keeper_unified_turn_success
   keeper_unified_turn_failure


### PR DESCRIPTION
test/test_keeper_unified_turn_event_bus.ml uses `Masc.Keeper_unified_turn_event_bus.For_testing`, but the module was listed in `lib/dune` `private_modules`. Remove it from `private_modules` so the regression test added in #21447 compiles against the public library surface.

- `dune build test/test_keeper_unified_turn_event_bus.exe` now succeeds.
- `dune exec test/test_keeper_unified_turn_event_bus.exe` passes (5/5 tests).