### PR TITLE
fix(fusion): expose masc_fusion to keepers (visibility Hidden->Default)

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -792,10 +792,10 @@ let read_only_in_process_policy ?(inline_safe = false) ?(maintenance_only = fals
 ;;
 
 let write_in_process_policy ?(retryable = false) ?(inline_safe = false)
-      ?(maintenance_only = false) ()
+      ?(maintenance_only = false) ?(visibility = Tool_catalog.Hidden) ()
   =
   policy
-    ~visibility:Tool_catalog.Hidden
+    ~visibility
     ~readonly:false
     ~effect_domain:Tool_catalog.Playground_write
     ~approval:No_approval
@@ -1176,7 +1176,12 @@ let internal_descriptors : t list =
          chat lane (also visible in the dashboard). Returns a status with a \
          run_id. Gated by runtime.toml [fusion] (disabled by default)."
       ~input_schema:masc_fusion_schema
-      ~policy:(write_in_process_policy ())
+      (* RFC-0252 §159/§177: 심의 가치는 키퍼(이미 LLM)가 스스로 판단해
+         masc_fusion 을 직접 호출하는 것으로 표현된다. 따라서 키퍼가 LLM 도구
+         목록에서 이 도구를 볼 수 있어야 한다 → visibility=Default. 다른
+         in-process write 도구의 기본값(Hidden, playground_write 공통)을 그대로
+         쓰면 키퍼가 도구를 못 봐 자율 호출이 불가능해 RFC 의도와 모순된다. *)
+      ~policy:(write_in_process_policy ~visibility:Tool_catalog.Default ())
       ~handler:Tool_masc_fusion_dispatch
     (* ── voice cluster (RFC-0179 PR-3, 6 tools) ───────────────── *)
   ; voice_descriptor


### PR DESCRIPTION
## 변경
`masc_fusion` 도구를 키퍼 LLM 도구 목록에 노출한다 (visibility `Hidden`→`Default`).

- `write_in_process_policy`에 optional `~visibility` 인자 추가 (기본값 `Hidden` 유지 → 다른 in-process write 도구 영향 0).
- `masc_fusion` descriptor만 `~visibility:Tool_catalog.Default` 로 노출.

## 근거 — RFC-0252 의도와의 모순 (버그)
RFC-0252 §159/§177: "심의 가치는 키퍼(이미 LLM)가 스스로 판단해 `masc_fusion`을 직접 호출하는 것으로 표현된다." 즉 키퍼가 LLM 도구 목록에서 이 도구를 **봐야** 자율 호출이 가능하다.

그런데 `masc_fusion`은 `write_in_process_policy ()`(playground_write 공통, `visibility=Hidden`)를 그대로 써서 키퍼 LLM 도구 목록에 노출되지 않았다. 키퍼가 호출을 시도하면 SDK가 `Tool not found: masc_fusion`을 반환한다.

라이브 재현 (2026-06-17, base-path=/Users/dancer/me):
```
15:09:48 idealist :: on_error: Tool not found: masc_fusion. Available tools: Edit,Execute,Grep,Read,...
15:10:28 rondo    :: tool_error: masc_tool_help — {"error":"unknown tool: masc_fusion"}
```

descriptor 등록 / dispatch (`Tool_masc_fusion_dispatch`) / handler (`handle_masc_fusion`) / config gate (`[fusion]`)는 모두 완성돼 있었고, **키퍼 노출 wiring만 빠진 미완성**이었다.

## 검증
- `ocamlformat --check lib/keeper/keeper_tool_descriptor.ml`: PASS
- `dune build --root . lib/keeper`: PASS (exit 0, 격리 worktree 빌드)
- 라이브 재현 후속: `keeper_tool_search` 우회도 실패 — Hidden 도구는 검색 결과로도 키퍼가 호출 불가 (issue_king turn 4918, 2026-06-17T15:37).
- `write_in_process_policy`는 `.mli` 미노출 internal helper → optional 인자 추가는 시그니처 하위호환.

## 영향
- 다른 in-process write 도구(`keeper_ide_annotate` 등): 영향 0 (default `Hidden` 유지).
- `masc_fusion`: 키퍼 LLM 도구 목록에 노출 → RFC-0252 §159/§177 의도대로 자율 호출 가능.
- 라이브 반영: 머지 + `dune build` + 서버 재시작 필요 (visibility는 코드 상수, config 아님).

## RFC
RFC-0252-fusion-panel-judge-deliberation.md §159/§177 (키퍼 자율 직접 호출 설계).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
