### PR TITLE
feat(comm): backend blocks, Slack rich posts, Voice MCP browser audio, expired audio UI

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -18,6 +18,7 @@
 
 import {
   array,
+  boolean,
   number,
   object,
   optional,
@@ -72,6 +73,7 @@ export const KeeperChatHistoryAudioClipSchema = object({
   messageText: optional(string()),
   device_id: optional(string()),
   deviceId: optional(string()),
+  expired: optional(boolean()),
 })
 
 export type KeeperChatHistoryAudioClip = InferOutput<typeof KeeperChatHistoryAudioClipSchema>

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -514,6 +514,39 @@ describe('ChatTranscript', () => {
     expect(container.textContent).toContain('음성을 불러올 수 없습니다')
   })
 
+  it('shows an expired placeholder instead of the native player', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'a1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: 'hello operator',
+            audio: {
+              token: 'clip-expired',
+              audioUrl: '/api/v1/voice/audio/clip-expired',
+              mime: 'audio/mpeg',
+              durationSec: 5,
+              messageText: 'hello operator',
+              deviceId: null,
+              expired: true,
+            },
+          }),
+        ]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+
+    const player = container.querySelector('[data-chat-audio-clip]')
+    expect(player).not.toBeNull()
+    expect(container.querySelector('audio')).toBeNull()
+    expect(container.textContent).toContain('음성이 만료되었습니다.')
+    expect(container.textContent).toContain('hello operator')
+  })
+
   it('renders a real audio element inside a voice block when src is provided', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1178,6 +1178,25 @@ function formatAudioDuration(seconds?: number | null): string {
 // voice clips. Uses the native `<audio controls>` element (no autoplay).
 function AudioPlayer({ clip }: { clip: KeeperConversationAudioClip }) {
   const [loadError, setLoadError] = useState(false)
+  if (clip.expired) {
+    return html`
+      <div class="chat-audio-clip" data-chat-audio-clip>
+        <div class="chat-audio-wave" aria-hidden="true">
+          ${Array.from({ length: 24 }, (_, i) => html`
+            <span
+              key=${i}
+              class="chat-audio-bar"
+              style=${{ height: `${6 + (i % 7) * 3}px` }}
+            />
+          `)}
+        </div>
+        <span class="chat-audio-error">음성이 만료되었습니다.</span>
+        ${clip.messageText
+          ? html`<span class="chat-audio-caption">${clip.messageText}</span>`
+          : null}
+      </div>
+    `
+  }
   const fallbackPath = `/api/v1/voice/audio/${encodeURIComponent(clip.token)}`
   const fallbackSrc = typeof window !== 'undefined'
     ? new URL(fallbackPath, window.location.href).href

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -421,8 +421,13 @@ export async function resumePendingKeeperChatRequests(name: string): Promise<voi
  *  If the event carries an RFC-0235 audio clip, we first try to attach
  *  it to the matching assistant bubble that is already streaming. A
  *  failed match still falls back to the history re-merge (the clip is
- *  persisted server-side too). */
-export function noteKeeperChatAppended(name: string, audio?: unknown): void {
+ *  persisted server-side too).
+ *
+ *  [blocks] is accepted so the live SSE path can carry server-parsed
+ *  rich blocks; the current implementation refreshes history (which now
+ *  persists blocks) so the dashboard's normalizeHistoryEntry path prefers
+ *  them automatically. */
+export function noteKeeperChatAppended(name: string, audio?: unknown, _blocks?: unknown): void {
   const keeperName = name.trim()
   if (!keeperName) return
   if (!hydratedChatKeepers.has(keeperName)) return

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -224,6 +224,38 @@ describe('thread history merge & persistence', () => {
     expect(ok[0]?.delivery).toBe('history')
   })
 
+  it('prefers server-provided rich blocks for assistant rows', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      { role: 'assistant', content: 'hello', ts: 1_780_000_000, blocks: [{ t: 'image', src: 'https://x.com/a.png' }] },
+    ])
+    expect(entries[0]?.blocks).toEqual([{ t: 'image', src: 'https://x.com/a.png' }])
+  })
+
+  it('falls back to the local parser when server blocks are missing or empty', () => {
+    const withMissing = chatHistoryEntriesFromRest('echo', [
+      { role: 'assistant', content: 'https://x.com/post', ts: 1_780_000_000 },
+    ])
+    expect(withMissing[0]?.blocks).toEqual([{ t: 'link', url: 'https://x.com/post', title: 'x.com', meta: 'x.com' }])
+    const withEmpty = chatHistoryEntriesFromRest('echo', [
+      { role: 'assistant', content: 'https://x.com/post', ts: 1_780_000_000, blocks: [] },
+    ])
+    expect(withEmpty[0]?.blocks).toEqual([{ t: 'link', url: 'https://x.com/post', title: 'x.com', meta: 'x.com' }])
+  })
+
+  it('drops malformed server blocks and falls back to the local parser', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      { role: 'assistant', content: 'hello', ts: 1_780_000_000, blocks: [{ t: 'unknown' }] as any },
+    ])
+    expect(entries[0]?.blocks).toEqual([{ t: 'p', html: 'hello' }])
+  })
+
+  it('does not attach blocks to non-assistant rows', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'https://x.com/post', ts: 1_780_000_000, blocks: [{ t: 'image', src: 'https://x.com/a.png' }] },
+    ])
+    expect(entries[0]?.blocks).toBeUndefined()
+  })
+
   it('drops tool rows that lack id or name and keeps the rest of the turn', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       { role: 'user', content: 'hi', ts: 1_780_000_000 },
@@ -375,6 +407,25 @@ describe('RFC-0235 audio clip normalization', () => {
       durationSec: 7.5,
       messageText: 'hello',
       deviceId: 'living-room',
+      expired: null,
+    })
+  })
+
+  it('carries the expired flag from the backend', () => {
+    const clip = normalizeAudioClip({
+      token: 'clip-expired',
+      mime: 'audio/mpeg',
+      message_text: 'hello',
+      expired: true,
+    })
+    expect(clip).toEqual({
+      token: 'clip-expired',
+      audioUrl: '/api/v1/voice/audio/clip-expired',
+      mime: 'audio/mpeg',
+      durationSec: null,
+      messageText: 'hello',
+      deviceId: null,
+      expired: true,
     })
   })
 

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -15,6 +15,7 @@ import type {
   KeeperRecoverResult,
   KeeperStatusDetail,
   SurfaceRef,
+  ChatBlock,
 } from './types'
 
 // --- Signals ---
@@ -133,6 +134,7 @@ export function normalizeAudioClip(raw: unknown): KeeperConversationAudioClip | 
   const duration = asNumber(raw.duration_sec) ?? asNumber(raw.durationSec)
   const messageText = asString(raw.message_text) ?? asString(raw.messageText) ?? ''
   const deviceId = asString(raw.device_id) ?? asString(raw.deviceId)
+  const expired = asBoolean(raw.expired) ?? null
   return {
     token,
     audioUrl,
@@ -140,6 +142,7 @@ export function normalizeAudioClip(raw: unknown): KeeperConversationAudioClip | 
     durationSec: duration ?? null,
     messageText,
     deviceId: deviceId ?? null,
+    expired,
   }
 }
 
@@ -168,6 +171,42 @@ function normalizeAttachments(raw: unknown): KeeperConversationAttachment[] | un
     .map(normalizeAttachment)
     .filter((a): a is KeeperConversationAttachment => a !== null)
   return atts.length > 0 ? atts : undefined
+}
+
+/** Normalize server-provided rich chat blocks. Only the block types the
+ *  backend currently emits (text, image, link) are accepted; unknown
+ *  shapes are dropped so the caller can fall back to the local parser. */
+function normalizeBlocks(raw: unknown): ChatBlock[] | undefined {
+  if (!Array.isArray(raw)) return undefined
+  const blocks = raw
+    .map((item): ChatBlock | null => {
+      if (!isRecord(item)) return null
+      const t = asString(item.t)
+      if (t === 'p') {
+        const html = asString(item.html)
+        return html ? { t: 'p', html } : null
+      }
+      if (t === 'image') {
+        const src = asString(item.src)
+        return src ? { t: 'image', src, cap: asString(item.cap) ?? undefined } : null
+      }
+      if (t === 'link') {
+        const url = asString(item.url)
+        const title = asString(item.title)
+        return url && title
+          ? {
+              t: 'link',
+              url,
+              title,
+              desc: asString(item.desc) ?? undefined,
+              meta: asString(item.meta) ?? undefined,
+            }
+          : null
+      }
+      return null
+    })
+    .filter((b): b is ChatBlock => b !== null)
+  return blocks.length > 0 ? blocks : undefined
 }
 
 /** Try to attach an audio clip to the most recent assistant entry whose
@@ -343,7 +382,10 @@ function normalizeHistoryEntry(
   // the bubble renders the error label/styling instead of a saved reply.
   const delivery: KeeperConversationDelivery =
     asString(raw.kind) === 'transport_failure' ? 'error' : 'history'
-  const blocks = role === 'assistant' ? parseTextToChatBlocks(text) : undefined
+  const blocks =
+    role === 'assistant'
+      ? (normalizeBlocks(raw.blocks) ?? parseTextToChatBlocks(text))
+      : undefined
   return {
     // R3: key off the producer-assigned server id when present so the
     // render key is stable across history-page merges (the former
@@ -554,6 +596,9 @@ interface RestChatHistoryMessage {
   }>
   // Row kind; 'transport_failure' distinguishes a persisted failed request.
   kind?: string
+  // RFC-0235 P3: backend-parsed rich chat blocks. When present the dashboard
+  // prefers them over its local parser.
+  blocks?: ChatBlock[]
 }
 
 /** Convert a persisted tool-call row into the same entry shape the live
@@ -605,6 +650,7 @@ export function chatHistoryEntriesFromRest(
         audio: message.audio,
         attachments: message.attachments,
         kind: message.kind,
+        blocks: message.blocks,
       },
       keeperName,
       previousSource,

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -42,7 +42,7 @@ const replayOasRuntimeTelemetry = vi.fn<() => Promise<void>>(async () => {})
 const compositeTick = signal({ name: '', ts_unix: 0 })
 const hydrateFleetCompositeSnapshot = vi.fn<(payload: unknown) => void>()
 const hydrateGoalTreeSnapshot = vi.fn<(payload: unknown) => boolean>(() => true)
-const noteKeeperChatAppended = vi.fn<(name: string, audio?: unknown) => void>()
+const noteKeeperChatAppended = vi.fn<(name: string, audio?: unknown, blocks?: unknown) => void>()
 
 async function flushAsyncWork(): Promise<void> {
   await vi.dynamicImportSettled()
@@ -336,7 +336,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     })
     await flushAsyncWork()
 
-    expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo', undefined)
+    expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo', undefined, undefined)
   })
 
   it('forwards RFC-0235 audio clips on keeper_chat_appended to the chat handler', async () => {
@@ -356,7 +356,22 @@ describe('setupSSEReaction reconnect hydration', () => {
     })
     await flushAsyncWork()
 
-    expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo', audio)
+    expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo', audio, undefined)
+  })
+
+  it('forwards rich blocks on keeper_chat_appended to the chat handler', async () => {
+    const { sseStore } = await loadSseStore()
+    const blocks = [{ t: 'p', html: 'hello' }]
+
+    sseStore.routeServerPushEvent({
+      type: 'keeper_chat_appended',
+      name: 'echo',
+      connector: 'dashboard',
+      blocks,
+    } as any)
+    await flushAsyncWork()
+
+    expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo', undefined, blocks)
   })
 
   it('treats keeper_composite_changed as a signal-only tick and does not hydrate from the event payload', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -550,13 +550,13 @@ export function hydrateServerPushEvent(event: SSEEvent): boolean {
   }
 
   if (event.type === 'keeper_chat_appended') {
-    const payload = event as unknown as { name?: string; audio?: unknown }
+    const payload = event as unknown as { name?: string; audio?: unknown; blocks?: unknown }
     const name = typeof payload.name === 'string' ? payload.name : ''
     if (name) {
       // Dynamic import keeps sse-store decoupled from the keeper action
       // layer (same pattern as the agent-failed notification above).
       void import('./keeper-runtime')
-        .then(mod => { mod.noteKeeperChatAppended(name, payload.audio) })
+        .then(mod => { mod.noteKeeperChatAppended(name, payload.audio, payload.blocks) })
         .catch(err => {
           console.debug('[SSE] keeper chat refresh unavailable', err instanceof Error ? err.message : '')
         })

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -746,6 +746,7 @@ export interface KeeperConversationAudioClip {
   durationSec?: number | null
   messageText: string
   deviceId?: string | null
+  expired?: boolean | null
 }
 
 // --- Keeper v2 rich chat blocks (optional; when present the bubble renderer

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -122,12 +122,16 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judge_usage :
        오염시키지 않으려 결론을 남기지 않는다(board에는 실패도 증거로 남는다). *)
     (match judge with
      | Ok j ->
+       let content =
+         Printf.sprintf "Fusion deliberation (run %s) — %s\n\n%s" run_id
+           (render_decision j.Fusion_types.decision) j.Fusion_types.resolved_answer
+       in
        Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper
-         ~content:
-           (Printf.sprintf "Fusion deliberation (run %s) — %s\n\n%s" run_id
-              (render_decision j.Fusion_types.decision) j.Fusion_types.resolved_answer)
+         ~content
          ();
        Keeper_chat_broadcast.chat_appended ~keeper_name:keeper ~source:"fusion"
+         ~content
+         ()
      | Error _ -> ());
     (* 비용 관측(제약 아님) — 패널 N + 심판 1 실측 토큰 합산 (RFC §10). board 증거에만
        남긴다 (cost cap은 v1 제외, 측정값만 — 괴상한 제약 제거 원칙). 실패한 패널/심판은
@@ -171,7 +175,7 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judge_usage :
          ~post_kind:Board.System_post ?meta_json ~visibility:Board.Internal
          ~ttl_hours:board_post_ttl_hours ()
      with
-     | Ok () -> Ok ()
+     | Ok _post -> Ok ()
      | Error e -> Error (Board.show_board_error e))
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -22,6 +22,8 @@ let append_chat_failure ~base_dir ~keeper ~run_id content =
   try
     Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper ~content ();
     Keeper_chat_broadcast.chat_appended ~keeper_name:keeper ~source:"fusion"
+      ~content
+      ()
   with
   | Eio.Cancel.Cancelled _ as exn ->
     (* 구조적 취소는 재전파. *)

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -123,7 +123,7 @@ let persist_connector_assistant_reply ~base_dir ~keeper_name ~source
     let surface = Surface_ref.Gate { label = source; address = [] } in
     Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name
       ~content ~surface ?conversation_id ();
-    Keeper_chat_broadcast.chat_appended ~keeper_name ~source
+    Keeper_chat_broadcast.chat_appended ~keeper_name ~source ~content ()
   end
 
 let dispatch ~sw ~clock ~proc_mgr ~net ~config
@@ -187,7 +187,7 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
     ~extra_mentions
     ();
   Keeper_chat_broadcast.chat_appended
-    ~keeper_name ~source:lane;
+    ~keeper_name ~source:lane ();
   let args =
     `Assoc [
       ("name", `String keeper_name);

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -1,0 +1,175 @@
+(** Backend mirror of dashboard/src/lib/chat-blocks.ts:parseTextToChatBlocks.
+
+    The output JSON is intentionally identical to the dashboard's block
+    shape so the dashboard can prefer server-provided blocks and skip its
+    local parser. *)
+
+type image_block = {
+  src : string;
+  cap : string option;
+}
+
+type link_block = {
+  url : string;
+  title : string;
+  meta : string;
+}
+
+type text_block = { html : string }
+
+type chat_block =
+  | Text of text_block
+  | Image of image_block
+  | Link of link_block
+
+let escape_html raw =
+  raw
+  |> String.split_on_char '&'
+  |> String.concat "&amp;"
+  |> String.split_on_char '<'
+  |> String.concat "&lt;"
+  |> String.split_on_char '>'
+  |> String.concat "&gt;"
+  |> String.split_on_char '"'
+  |> String.concat "&quot;"
+  |> String.split_on_char '\''
+  |> String.concat "&#39;"
+;;
+
+let image_extensions = [ "png"; "jpg"; "jpeg"; "gif"; "webp"; "svg" ];;
+
+let path_extension pathname =
+  match String.rindex_opt pathname '.' with
+  | None -> ""
+  | Some i ->
+    let ext = String.sub pathname (i + 1) (String.length pathname - i - 1) in
+    String.lowercase_ascii ext
+;;
+
+let is_image_url url =
+  try
+    let uri = Uri.of_string url in
+    let path = Uri.path uri in
+    List.mem (path_extension path) image_extensions
+  with
+  | _ -> false
+;;
+
+let hostname_title url =
+  try
+    let uri = Uri.of_string url in
+    let host = Option.value (Uri.host uri) ~default:url in
+    let host =
+      if String.length host > 4 && String.sub host 0 4 = "www."
+      then String.sub host 4 (String.length host - 4)
+      else host
+    in
+    if host = "" then url else host
+  with
+  | _ -> url
+;;
+
+let standalone_url_re =
+  Re.Pcre.re "^https?://\\S+$" |> Re.compile |> Re.execp
+;;
+
+let line_to_block line : chat_block option =
+  let trimmed = String.trim line in
+  if trimmed = ""
+  then None
+  else if standalone_url_re trimmed
+  then (
+    if is_image_url trimmed
+    then Some (Image { src = trimmed; cap = None })
+    else
+      Some
+        (Link
+           { url = trimmed
+           ; title = hostname_title trimmed
+           ; meta = hostname_title trimmed
+           }))
+  else Some (Text { html = escape_html line })
+;;
+
+let push_text_fragment acc fragment =
+  fragment
+  |> String.split_on_char '\n'
+  |> List.fold_left
+       (fun acc line ->
+          match line_to_block line with
+          | None -> acc
+          | Some block -> block :: acc)
+       acc
+;;
+
+let md_image_re = Re.Pcre.re "!\\[([^\\]]*)\\]\\(([^)]+)\\)" |> Re.compile
+
+let parse_text_to_blocks text : chat_block list =
+  let rec scan acc last_index =
+    match Re.exec_opt ~pos:last_index md_image_re text with
+    | None -> push_text_fragment acc (String.sub text last_index (String.length text - last_index))
+    | Some group ->
+      let start = Re.Group.start group 0 in
+      let stop = Re.Group.stop group 0 in
+      let before = String.sub text last_index (start - last_index) in
+      let alt = Re.Group.get group 1 in
+      let url = Re.Group.get group 2 in
+      let acc = push_text_fragment acc before in
+      let cap = if String.trim alt = "" then None else Some alt in
+      let acc = Image { src = url; cap } :: acc in
+      scan acc stop
+  in
+  List.rev (scan [] 0)
+;;
+
+let block_to_yojson = function
+  | Text { html } ->
+    `Assoc [ ("t", `String "p"); ("html", `String html) ]
+  | Image { src; cap } ->
+    let fields = [ ("t", `String "image"); ("src", `String src) ] in
+    let fields =
+      match cap with
+      | None -> fields
+      | Some c -> fields @ [ ("cap", `String c) ]
+    in
+    `Assoc fields
+  | Link { url; title; meta } ->
+    `Assoc
+      [ ("t", `String "link")
+      ; ("url", `String url)
+      ; ("title", `String title)
+      ; ("meta", `String meta)
+      ]
+;;
+
+let blocks_to_yojson blocks = `List (List.map block_to_yojson blocks)
+
+let block_of_yojson json : chat_block option =
+  match json with
+  | `Assoc fields ->
+    let get_string key =
+      match List.assoc_opt key fields with
+      | Some (`String s) -> Some s
+      | _ -> None
+    in
+    (match get_string "t" with
+     | Some "p" ->
+       Option.map (fun html -> Text { html }) (get_string "html")
+     | Some "image" ->
+       Option.bind (get_string "src") (fun src ->
+         let cap = get_string "cap" in
+         Some (Image { src; cap }))
+     | Some "link" ->
+       Option.bind (get_string "url") (fun url ->
+         Option.bind (get_string "title") (fun title ->
+           let meta = Option.value (get_string "meta") ~default:title in
+           Some (Link { url; title; meta })))
+     | _ -> None)
+  | _ -> None
+;;
+
+let blocks_of_yojson = function
+  | `List items ->
+    let blocks = List.filter_map block_of_yojson items in
+    if blocks = [] then None else Some blocks
+  | _ -> None

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -1,0 +1,34 @@
+(** Backend mirror of the dashboard's [parseTextToChatBlocks].
+
+    Turns assistant reply text into a list of rich chat blocks so the
+    server can own the parsing and the dashboard can render server-provided
+    blocks verbatim.
+
+    Supported shapes:
+    - Markdown images [![alt](url)] become image blocks.
+    - Bare image URLs (png/jpg/gif/webp/svg) on their own line become image blocks.
+    - Other standalone URLs become link blocks with a hostname-derived title.
+    - Remaining text becomes escaped HTML text blocks. *)
+
+type image_block = {
+  src : string;
+  cap : string option;
+}
+
+type link_block = {
+  url : string;
+  title : string;
+  meta : string;
+}
+
+type text_block = { html : string }
+
+type chat_block =
+  | Text of text_block
+  | Image of image_block
+  | Link of link_block
+
+val parse_text_to_blocks : string -> chat_block list
+val block_to_yojson : chat_block -> Yojson.Safe.t
+val blocks_to_yojson : chat_block list -> Yojson.Safe.t
+val blocks_of_yojson : Yojson.Safe.t -> chat_block list option

--- a/lib/keeper/keeper_chat_broadcast.ml
+++ b/lib/keeper/keeper_chat_broadcast.ml
@@ -15,6 +15,7 @@ type audio_clip = {
   duration_sec : float option;
   message_text : string;
   device_id : string option;
+  expired : bool;
 }
 
 let audio_clip_to_json (clip : audio_clip) =
@@ -35,20 +36,24 @@ let audio_clip_to_json (clip : audio_clip) =
      | None -> fs
      | Some d -> fs @ [ ("duration_sec", `Float d) ])
     |> fun fs ->
-    match clip.device_id with
-    | None -> fs
-    | Some id -> fs @ [ ("device_id", `String id) ]
+    (match clip.device_id with
+     | None -> fs
+     | Some id -> fs @ [ ("device_id", `String id) ])
+    |> fun fs ->
+    if clip.expired then fs @ [ ("expired", `Bool true) ] else fs
   in
   with_optional base
 
-let do_broadcast ~keeper_name ~source ~audio =
+let do_broadcast ~keeper_name ~source ~audio ?content () =
   try
     (* Field is named [connector], not [source]: the dashboard SSE
        vocabulary already reserves [source] for the journal origin
        (JournalSource), and the chat JSONL's own [source] column is a
        different boundary. [audio] is a separate boundary (RFC-0235): only
        present when this turn synthesized a clip, and the dashboard decodes
-       it into a typed record at the SSE edge. *)
+       it into a typed record at the SSE edge. [blocks] mirrors the
+       backend parser output so the dashboard can prefer server-provided
+       rich blocks over its local parser. *)
     let base_fields =
       [ ("type", `String "keeper_chat_appended");
         ("name", `String keeper_name);
@@ -60,6 +65,18 @@ let do_broadcast ~keeper_name ~source ~audio =
       match audio with
       | None -> base_fields
       | Some clip -> base_fields @ [ ("audio", `Assoc (audio_clip_to_json clip)) ]
+    in
+    let blocks =
+      match content with
+      | None -> None
+      | Some text ->
+        let parsed = Keeper_chat_blocks.parse_text_to_blocks text in
+        if parsed = [] then None else Some parsed
+    in
+    let fields =
+      match blocks with
+      | None -> fields
+      | Some bs -> fields @ [ ("blocks", Keeper_chat_blocks.blocks_to_yojson bs) ]
     in
     Sse.broadcast (`Assoc fields)
   with
@@ -74,15 +91,17 @@ let do_broadcast ~keeper_name ~source ~audio =
       keeper_name
       (Printexc.to_string exn)
 
-(** Broadcast with no audio clip — the existing surface, unchanged signature
-    so all current callers stay as-is. *)
-let chat_appended ~keeper_name ~source = do_broadcast ~keeper_name ~source ~audio:None
+(** Broadcast with no audio clip. [content] is optional; when supplied the
+    backend parser turns it into rich chat blocks included in the SSE
+    payload so the dashboard can render server-provided blocks. *)
+let chat_appended ~keeper_name ~source ?content () =
+  do_broadcast ~keeper_name ~source ~audio:None ?content ()
 
 (** Broadcast with a synthesized audio clip attached (RFC-0235 P1). Used by
     a turn that owns a voice clip ([Voice_bridge_transport.make_audio_file]
     token); the dashboard decodes the [audio] field into a typed record and
-    renders a play button. Separate from {!chat_appended} so the rare
-    audio-bearing case does not force every caller to thread an option. *)
-let chat_appended_with_audio ~keeper_name ~source ~audio =
-  do_broadcast ~keeper_name ~source ~audio:(Some audio)
+    renders a play button. [content] is used to derive rich blocks for the
+    event, mirroring {!chat_appended}. *)
+let chat_appended_with_audio ~keeper_name ~source ~audio ?content () =
+  do_broadcast ~keeper_name ~source ~audio:(Some audio) ?content ()
 

--- a/lib/keeper/keeper_chat_broadcast.mli
+++ b/lib/keeper/keeper_chat_broadcast.mli
@@ -13,6 +13,7 @@ type audio_clip = {
   duration_sec : float option;
   message_text : string;
   device_id : string option;
+  expired : bool;
 }
 
 (** Broadcast a [keeper_chat_appended] SSE event after a completed turn
@@ -29,7 +30,8 @@ type audio_clip = {
     Exceptions from [Sse.broadcast] are counted on the
     [keeper_sse_broadcast_failures] counter (site [chat_appended]) and
     logged at WARN. {!Eio.Cancel.Cancelled} propagates. *)
-val chat_appended : keeper_name:string -> source:string -> unit
+val chat_appended :
+  keeper_name:string -> source:string -> ?content:string -> unit -> unit
 
 (** Like {!chat_appended} but attaches a synthesized audio clip
     (RFC-0235 P1) so the dashboard can render a play button instead of
@@ -37,6 +39,6 @@ val chat_appended : keeper_name:string -> source:string -> unit
     ([Voice_bridge_transport.make_audio_file] token) calls this; every
     other caller keeps using {!chat_appended}. The [audio] field is
     decoded into a typed record at the SSE edge, never string-sniffed
-    downstream. *)
+    downstream. [content] is used to derive rich blocks for the event. *)
 val chat_appended_with_audio :
-  keeper_name:string -> source:string -> audio:audio_clip -> unit
+  keeper_name:string -> source:string -> audio:audio_clip -> ?content:string -> unit -> unit

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -89,6 +89,86 @@ let tool_context_block_json ~name ~args_summary ~result_summary =
     ; ("text", `Assoc [ ("type", `String "mrkdwn"); ("text", `String text) ])
     ]
 
+(* ── Content → Slack blocks ──────────────────────────────────────── *)
+
+let image_extensions = [ ".png"; ".jpg"; ".jpeg"; ".gif"; ".webp"; ".svg" ]
+
+let is_image_url url =
+  try
+    let ext = String.lowercase_ascii (Filename.extension (Uri.of_string url |> Uri.path)) in
+    List.mem ext image_extensions
+  with _ -> false
+
+let hostname_of_url url =
+  try
+    match Uri.of_string url |> Uri.host with
+    | Some "" | None -> url
+    | Some host ->
+        let len = String.length host in
+        if len > 4 && String.sub host 0 4 = "www." then
+          String.sub host 4 (len - 4)
+        else host
+  with _ -> url
+
+let standalone_url_re = Str.regexp "^https?://[^ \t\r\n]+$"
+let markdown_image_re = Str.regexp "!\\[\\([^]]*\\)\\](\\([^)]+\\))"
+
+let is_standalone_url line =
+  try Str.string_match standalone_url_re (String.trim line) 0
+  with _ -> false
+
+let line_to_block line =
+  let trimmed = String.trim line in
+  if trimmed = "" then None
+  else if is_standalone_url trimmed then
+    if is_image_url trimmed then
+      Some (image_block_json ~url:trimmed ~caption:None)
+    else
+      let title = hostname_of_url trimmed in
+      Some (link_block_json ~url:trimmed ~title ~description:None)
+  else None
+
+let content_blocks_of_text text =
+  let rec scan_images acc pos =
+    if pos >= String.length text then List.rev acc
+    else
+      try
+        let _ = Str.search_forward markdown_image_re text pos in
+        let before = String.sub text pos (Str.match_beginning () - pos) in
+        let alt = Str.matched_group 1 text in
+        let url = Str.matched_group 2 text in
+        let next = Str.match_end () in
+        scan_images ((before, Some url, Some alt) :: acc) next
+      with Not_found ->
+        let rest = String.sub text pos (String.length text - pos) in
+        List.rev ((rest, None, None) :: acc)
+  in
+  let fragments = scan_images [] 0 in
+  List.fold_left
+    (fun blocks (fragment, image_url, image_alt) ->
+      let blocks =
+        match image_url with
+        | Some url ->
+            let caption =
+              match image_alt with
+              | Some "" | None -> None
+              | Some alt -> Some alt
+            in
+            image_block_json ~url ~caption :: blocks
+        | None -> blocks
+      in
+      let lines = String.split_on_char '\n' fragment in
+      List.fold_left
+        (fun blocks line ->
+          match line_to_block line with
+          | Some block -> block :: blocks
+          | None -> blocks)
+        blocks
+        lines)
+    []
+    fragments
+  |> List.rev
+
 (* ── HTTP delivery ───────────────────────────────────────────────── *)
 
 let send_message_with_blocks ~token ~channel ~content ~blocks =
@@ -187,4 +267,5 @@ module For_testing = struct
   let image_block_json = image_block_json
   let audio_block_json = audio_block_json
   let tool_context_block_json = tool_context_block_json
+  let content_blocks_of_text = content_blocks_of_text
 end

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -19,6 +19,19 @@ val send_message :
 (** [send_message ~token ~channel ~content] posts to
     [chat.postMessage]. Logs errors via [Log.Keeper.warn]. *)
 
+val send_message_with_blocks :
+  token:string -> channel:string -> content:string -> blocks:Yojson.Safe.t list -> unit
+(** [send_message_with_blocks ~token ~channel ~content ~blocks] posts to
+    [chat.postMessage] with the given Block Kit [blocks]. Logs errors via
+    [Log.Keeper.warn]. *)
+
+val content_blocks_of_text : string -> Yojson.Safe.t list
+(** [content_blocks_of_text text] extracts rich Slack blocks from plain text:
+    - Markdown images [![alt](url)] become image blocks.
+    - Standalone image URLs (png/jpg/gif/webp/svg) become image blocks.
+    - Other standalone URLs become link blocks with a hostname-derived title.
+    Non-URL text is omitted because it is delivered via the [content] field. *)
+
 val adapter_loop :
   token:string ->
   channel:string ->
@@ -55,4 +68,7 @@ module For_testing : sig
 
   val tool_context_block_json :
     name:string -> args_summary:string -> result_summary:string option -> Yojson.Safe.t
+
+  val content_blocks_of_text : string -> Yojson.Safe.t list
+  (** Same as {!content_blocks_of_text}; exposed for unit testing. *)
 end

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -129,6 +129,8 @@ let authority_of_label = function
   | "external" -> Some External
   | _ -> None
 
+type chat_block = Keeper_chat_blocks.chat_block
+
 type audio_clip = {
   token : string;
   audio_url : string option;
@@ -136,6 +138,7 @@ type audio_clip = {
   duration_sec : float option;
   message_text : string;
   device_id : string option;
+  expired : bool;
 }
 
 type speaker = {
@@ -169,6 +172,11 @@ type chat_message = {
   external_message_id : string option;
   speaker : speaker option;
   audio : audio_clip option;
+  blocks : Keeper_chat_blocks.chat_block list option;
+      (* RFC-0235 P3: rich chat blocks parsed from assistant reply text.
+         Persisted server-side so the dashboard can prefer backend blocks
+         over its local parser. [None] on rows written before this field
+         and on non-assistant rows. *)
   mentions : Keeper_identity.Keeper_id.t list;
       (* RFC-0232 §3.3: parsed once at append from the persisted content
          (plus connector-provided explicit mentions); [] = none.  Rows
@@ -213,7 +221,10 @@ let speaker_fields = function
 
 (* RFC-0235 P1: nested ["audio"] assoc so the clip stays one unit on the
    JSONL row. Absent on rows written before voice transport; reads as
-   [None] (the dashboard renders text-only, matching any non-voice turn). *)
+   [None] (the dashboard renders text-only, matching any non-voice turn).
+   [expired] is written only when true so fresh clips stay byte-identical
+   to rows written before this field existed; the history endpoint stamps
+   it when the underlying MP3 has been reaped. *)
 let audio_to_json a =
   let base =
     [ ("token", `String a.token)
@@ -221,13 +232,21 @@ let audio_to_json a =
     ; ("message_text", `String a.message_text)
     ]
   in
-  match a.duration_sec with
-  | None -> base
-  | Some d -> base @ [ ("duration_sec", `Float d) ]
+  let with_duration =
+    match a.duration_sec with
+    | None -> base
+    | Some d -> base @ [ ("duration_sec", `Float d) ]
+  in
+  if a.expired then with_duration @ [ ("expired", `Bool true) ] else with_duration
 
 let audio_fields = function
   | None -> []
   | Some a -> [ ("audio", `Assoc (audio_to_json a)) ]
+
+let blocks_fields = function
+  | None | Some [] -> []
+  | Some blocks -> [ ("blocks", Keeper_chat_blocks.blocks_to_yojson blocks) ]
+;;
 
 (* R3: producer-assigned message id.  [encode_line] is the sole writer, so
    minting here makes it impossible to persist a row without an id.  The
@@ -258,7 +277,7 @@ let legacy_message_id ~ts ~content =
 
 let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     ?tool_call_name ?surface ?conversation_id ?external_message_id ?speaker
-    ?audio ?(mentions = []) ?(kind = Row_kind.Utterance) ()
+    ?audio ?blocks ?(mentions = []) ?(kind = Row_kind.Utterance) ()
     : string =
   (* RFC-0232 P5: the label is a derivation of the typed surface — the
      single site that turns a [Surface_ref.t] into the legacy [source]
@@ -275,6 +294,17 @@ let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     ("content", `String content);
     ("ts", `Float ts);
   ] in
+  (* Backend-driven chat blocks: assistant rows get a default parse unless
+     the caller already supplied blocks (e.g., a future rich-content path).
+     Tool and user rows carry no blocks. *)
+  let blocks =
+    match blocks with
+    | Some _ -> blocks
+    | None ->
+      if Role.equal role Role.Assistant && String.trim content <> ""
+      then Some (Keeper_chat_blocks.parse_text_to_blocks content)
+      else None
+  in
   let mention_fields =
     match mentions with
     | [] -> []
@@ -324,6 +354,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     @ opt_string_field "external_message_id" external_message_id
     @ speaker_fields speaker
     @ audio_fields audio
+    @ blocks_fields blocks
   in
   Yojson.Safe.to_string (`Assoc all_fields)
 
@@ -348,6 +379,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     ~(user_attachments : attachment list) ?(tool_calls = []) ?surface
     ?conversation_id ?external_message_id ?speaker ?(extra_mentions = [])
     ?(assistant_kind = Row_kind.Utterance)
+    ?blocks
     ~(assistant_content : string)
     () =
   try
@@ -386,7 +418,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     in
     let asst_line =
       encode_line ~role:Role.Assistant ~content:assistant_content ~ts ?surface
-        ?conversation_id ~kind:assistant_kind ()
+        ?conversation_id ~kind:assistant_kind ?blocks ()
     in
     let payload =
       String.concat "\n" ((user_line :: tool_lines) @ [ asst_line ]) ^ "\n"
@@ -405,7 +437,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
 (* RFC-0223 P4: keeper-initiated message on one lane. A single
    assistant line — there is no user turn to pair it with. *)
 let append_assistant_message ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio () =
+    ?surface ?conversation_id ?audio ?blocks () =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
@@ -413,7 +445,7 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line =
-      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id ?audio ()
+      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id ?audio ?blocks ()
     in
     Fs_compat.append_file path (line ^ "\n")
   with
@@ -536,7 +568,12 @@ let parse_line ~file_path (line : string) : chat_message option =
                let message_text = Option.value (get "message_text") ~default:"" in
                let audio_url = get "audio_url" in
                let device_id = get "device_id" in
-               Some { token; audio_url; mime; duration_sec; message_text; device_id }
+               let expired =
+                 match List.assoc_opt "expired" fields with
+                 | Some (`Bool b) -> b
+                 | _ -> false
+               in
+               Some { token; audio_url; mime; duration_sec; message_text; device_id; expired }
            | _ ->
                (* audio without token+mime is malformed; drop the field but
                   keep the row (text-only render). *)
@@ -606,6 +643,19 @@ let parse_line ~file_path (line : string) : chat_message option =
             ~detail:"mentions field is not a list";
           []
     in
+    let blocks =
+      match Json_util.assoc_member_opt "blocks" json with
+      | None -> None
+      | Some blocks_json -> (
+          match Keeper_chat_blocks.blocks_of_yojson blocks_json with
+          | Some _ as blocks -> blocks
+          | None ->
+              report_persistence_read_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                ~path:file_path
+                ~detail:"invalid blocks field";
+              None)
+    in
     let kind =
       (* Absent field = every row written before [kind] existed; all of
          those are utterances. Unknown labels are surfaced and read as
@@ -656,7 +706,7 @@ let parse_line ~file_path (line : string) : chat_message option =
           Some
             { id; role; content; ts; attachments; tool_call_id; tool_call_name;
               source; surface; conversation_id; external_message_id; speaker;
-              audio; mentions; kind }
+              audio; blocks; mentions; kind }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -821,7 +871,28 @@ let load_page ~base_dir ~keeper_name ?before () : page =
 let load ~base_dir ~keeper_name : chat_message list =
   (load_page ~base_dir ~keeper_name ()).messages
 
-let to_json_array (messages : chat_message list) : Yojson.Safe.t =
+(* RFC-0235 P3: the history endpoint can tell the dashboard that a clip
+   has been reaped by checking the same audio directory the synthesis side
+   writes to. This keeps the TTL reaper simple while avoiding a broken
+   native player on reload. *)
+let audio_clip_file_path ~base_dir token =
+  Filename.concat
+    (Filename.concat (Common.masc_dir_from_base_path ~base_path:base_dir) "audio")
+    (token ^ ".mp3")
+
+let audio_fields_with_expired ~base_dir audio =
+  match audio with
+  | None -> []
+  | Some a ->
+      let expired =
+        match base_dir with
+        | None -> a.expired
+        | Some base_dir ->
+            a.expired || not (Sys.file_exists (audio_clip_file_path ~base_dir a.token))
+      in
+      [ ("audio", `Assoc (audio_to_json { a with expired })) ]
+
+let to_json_array ?base_dir (messages : chat_message list) : Yojson.Safe.t =
   `List
     (List.map
        (fun m ->
@@ -859,5 +930,6 @@ let to_json_array (messages : chat_message list) : Yojson.Safe.t =
                        ]
                      ) atts in
                      [("attachments", `List att_json)])
-              @ audio_fields m.audio))
+              @ audio_fields_with_expired ~base_dir m.audio
+              @ blocks_fields m.blocks))
        messages)

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -83,6 +83,11 @@ type speaker_authority =
 val authority_label : speaker_authority -> string
 val authority_of_label : string -> speaker_authority option
 
+(** Rich chat block produced by the backend parser. Mirrors the dashboard's
+    [ChatBlock] union so the server can own parsing and the dashboard can
+    render server-provided blocks verbatim. *)
+type chat_block = Keeper_chat_blocks.chat_block
+
 (** Identity of the user-line author. [speaker_id] / [speaker_name] are
     absent when the route supplies none (the dashboard is a single
     authenticated operator and carries no per-user identity). *)
@@ -93,12 +98,15 @@ type audio_clip = {
   duration_sec : float option;
   message_text : string;
   device_id : string option;
+  expired : bool;
 }
 (** Persistable audio clip (RFC-0235 P1). Written on an assistant line
     when the keeper synthesized a voice utterance; [token] is the
     [/api/v1/voice/audio/:token] capability, [message_text] doubles as
     the caption. [audio_url] and [device_id] carry transport routing hints
-    so the dashboard can fetch and route the clip. Same shape as
+    so the dashboard can fetch and route the clip. [expired] is true when
+    the underlying MP3 has been reaped; the history endpoint stamps it by
+    checking the audio directory. Same shape as
     {!Keeper_chat_broadcast}'s SSE payload so the two never drift. *)
 
 type speaker = {
@@ -141,6 +149,11 @@ type chat_message = {
           voice utterance (keeper_voice_speak). [None] on every other
           line and on rows written before voice transport; the dashboard
           renders a play button when present. *)
+  blocks : chat_block list option;
+      (** RFC-0235 P3: rich chat blocks parsed from assistant reply text.
+          Persisted server-side so the dashboard can prefer backend blocks
+          over its local parser. [None] on rows written before this field
+          and on non-assistant rows. *)
   mentions : Keeper_identity.Keeper_id.t list;
       (** RFC-0232 §3.3: mention ids parsed once at append from the
           persisted user content (plus connector-supplied explicit
@@ -182,6 +195,7 @@ val append_turn :
   ?speaker:speaker ->
   ?extra_mentions:Keeper_identity.Keeper_id.t list ->
   ?assistant_kind:Row_kind.t ->
+  ?blocks:chat_block list ->
   assistant_content:string ->
   unit ->
   unit
@@ -198,6 +212,7 @@ val append_assistant_message :
   ?surface:Surface_ref.t ->
   ?conversation_id:string ->
   ?audio:audio_clip ->
+  ?blocks:chat_block list ->
   unit ->
   unit
 
@@ -246,5 +261,6 @@ val load_page :
     [ts] field; [tool_call_id] / [tool_call_name] / [source] /
     [conversation_id] / [external_message_id] /
     [speaker_id] / [speaker_name] / [speaker_authority] appear only
-    when present. *)
-val to_json_array : chat_message list -> Yojson.Safe.t
+    when present. When [base_dir] is supplied, the history endpoint marks
+    audio clips as [expired] when the underlying MP3 file is gone. *)
+val to_json_array : ?base_dir:string -> chat_message list -> Yojson.Safe.t

--- a/lib/keeper/keeper_surface_post.ml
+++ b/lib/keeper/keeper_surface_post.ml
@@ -1,7 +1,9 @@
+type rich_block = Yojson.Safe.t
+
 type post_target =
   | To_dashboard
   | To_discord of { channel_id : string }
-  | To_slack of { channel_id : string }
+  | To_slack of { channel_id : string; blocks : rich_block list option }
 
 let dashboard_label = "dashboard"
 let discord_label = "discord"
@@ -42,7 +44,7 @@ let resolve_target ~surface ~channel_id ?(bound_discord_channels = [])
         Error
           "this keeper has no Slack channel binding; bind a channel first \
            (posting to an unbound surface is an error, not a no-op)"
-    | None, [ only ] -> Ok (To_slack { channel_id = only })
+    | None, [ only ] -> Ok (To_slack { channel_id = only; blocks = None })
     | None, _ :: _ :: _ ->
         Error
           (Printf.sprintf
@@ -52,7 +54,7 @@ let resolve_target ~surface ~channel_id ?(bound_discord_channels = [])
     | Some requested, bound ->
         let requested = String.trim requested in
         if List.exists (String.equal requested) bound then
-          Ok (To_slack { channel_id = requested })
+          Ok (To_slack { channel_id = requested; blocks = None })
         else
           Error
             (Printf.sprintf
@@ -65,6 +67,11 @@ let resolve_target ~surface ~channel_id ?(bound_discord_channels = [])
          "posting to %S is not supported: discord, dashboard, and slack only \
           in this phase (generic gate connectors have no send surface yet)"
          surface)
+
+let set_blocks target blocks_opt =
+  match target with
+  | To_slack s -> To_slack { s with blocks = blocks_opt }
+  | other -> other
 
 let ok_json ~surface ?message_id () =
   let fields =

--- a/lib/keeper/keeper_surface_post.mli
+++ b/lib/keeper/keeper_surface_post.mli
@@ -7,12 +7,17 @@
     no-op (RFC-0223 §4 P4). All transport I/O stays in the runtime
     handler. *)
 
+type rich_block = Yojson.Safe.t
+(** Slack Block Kit block rendered as a JSON value. *)
+
 type post_target =
   | To_dashboard
       (** Persist an assistant line + broadcast [keeper_chat_appended];
           the dashboard is always present. *)
   | To_discord of { channel_id : string }
-  | To_slack of { channel_id : string }
+  | To_slack of { channel_id : string; blocks : rich_block list option }
+      (** Post to a bound Slack channel. [blocks] may carry Slack Block Kit
+          rich blocks to render alongside the plain-text fallback. *)
 
 val resolve_target :
   surface:string ->
@@ -32,6 +37,10 @@ val resolve_target :
     - ["slack"] → same semantics against [bound_slack_channels].
     - any other label → error: P4 ships discord + dashboard + slack
       (generic gate connectors have no send surface yet). *)
+
+val set_blocks : post_target -> rich_block list option -> post_target
+(** [set_blocks target blocks] attaches [blocks] to a [To_slack] target and
+    returns any other target unchanged. *)
 
 val ok_json : surface:string -> ?message_id:string -> unit -> string
 val error_json : string -> string

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -182,7 +182,9 @@ let handle_surface_post ~config ~(meta : keeper_meta) ~args =
           ~surface:(Surface_ref.Dashboard { session_id = None })
           ();
         Keeper_chat_broadcast.chat_appended ~keeper_name:meta.name
-          ~source:"dashboard";
+          ~source:"dashboard"
+          ~content:safe_content
+          ();
         Keeper_surface_post.ok_json ~surface ()
     | Ok (Keeper_surface_post.To_discord { channel_id }) -> (
         match Channel_gate_discord_state.send_message ~channel_id ~content:safe_content () with
@@ -205,16 +207,26 @@ let handle_surface_post ~config ~(meta : keeper_meta) ~args =
                    })
               ();
             Keeper_chat_broadcast.chat_appended ~keeper_name:meta.name
-              ~source:"discord";
+              ~source:"discord"
+              ~content:safe_content
+              ();
             Keeper_surface_post.ok_json ~surface ~message_id ())
-    | Ok (Keeper_surface_post.To_slack { channel_id }) -> (
+    | Ok (Keeper_surface_post.To_slack { channel_id; blocks = _ }) -> (
+        let slack_blocks =
+          Keeper_chat_slack.content_blocks_of_text safe_content
+        in
+        let (_ : Keeper_surface_post.post_target) =
+          Keeper_surface_post.set_blocks
+            (Keeper_surface_post.To_slack { channel_id; blocks = None })
+            (Some slack_blocks)
+        in
         match slack_token_opt () with
         | None ->
             Keeper_surface_post.error_json
               "MASC_SLACK_BOT_TOKEN is unset or empty"
         | Some token ->
-            Keeper_chat_slack.send_message ~token ~channel:channel_id
-              ~content:safe_content;
+            Keeper_chat_slack.send_message_with_blocks ~token
+              ~channel:channel_id ~content:safe_content ~blocks:slack_blocks;
             Keeper_chat_store.append_assistant_message
               ~base_dir:config.Workspace.base_path
               ~keeper_name:meta.name
@@ -224,7 +236,9 @@ let handle_surface_post ~config ~(meta : keeper_meta) ~args =
                    { team_id = None; channel_id; thread_ts = None })
               ();
             Keeper_chat_broadcast.chat_appended ~keeper_name:meta.name
-              ~source:"slack";
+              ~source:"slack"
+              ~content:safe_content
+              ();
             Keeper_surface_post.ok_json ~surface ())
 ;;
 

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -573,6 +573,8 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
             ~assistant_content
             ();
           Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source:"agent"
+            ~content:assistant_content
+            ()
         end
         else begin
           Keeper_chat_store.append_assistant_message
@@ -582,6 +584,8 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
             ~surface:(Surface_ref.Gate { label = channel; address = [] })
             ();
           Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source:channel
+            ~content:assistant_content
+            ()
         end)
 ;;
 

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -168,6 +168,7 @@ let handle_speak
                  ; duration_sec
                  ; message_text = message
                  ; device_id = audio_device
+                 ; expired = false
                  }
              | None -> None
            in
@@ -185,10 +186,15 @@ let handle_speak
                   ; duration_sec = c.duration_sec
                   ; message_text = c.message_text
                   ; device_id = c.device_id
+                  ; expired = c.expired
                   }
+                ~content:message
+                ()
             | None ->
               Keeper_chat_broadcast.chat_appended
-                ~keeper_name:meta.name ~source:"agent");
+                ~keeper_name:meta.name ~source:"agent"
+                ~content:message
+                ());
            let memory_status =
              record_voice_output
                ~config

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -148,7 +148,7 @@ let handle_keeper_get_subroutes state req request reqd =
         Keeper_chat_store.load ~base_dir ~keeper_name:name
       in
       Server_auth.respond_json_value_with_cors ~status:`OK request reqd
-        (Keeper_chat_store.to_json_array messages)
+        (Keeper_chat_store.to_json_array ~base_dir messages)
   else if ends_with "/person-notes" then
     (* RFC-0229 P2: keeper-authored person notes for the roster pane.
        Read-only fold over the notes store; same shape as the tool

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -484,7 +484,7 @@ let handle_ambient ~base_dir
           ; speaker_authority = Keeper_chat_store.External
           }
         ();
-      Keeper_chat_broadcast.chat_appended ~keeper_name ~source:State.channel;
+      Keeper_chat_broadcast.chat_appended ~keeper_name ~source:State.channel ();
       Discord_observability.record_ambient
         Discord_observability.Ambient_recorded
     end

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -668,6 +668,8 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
       ();
     Keeper_chat_broadcast.chat_appended
       ~keeper_name:payload.name ~source:chat_source
+      ~content:(persisted_error_reply err)
+      ()
   in
   let timeout_sec = Option.map float_of_int payload.timeout_sec in
   let request_id =
@@ -714,7 +716,9 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
                 ~assistant_content:visible_reply
                 ();
               Keeper_chat_broadcast.chat_appended
-                ~keeper_name:payload.name ~source:chat_source);
+                ~keeper_name:payload.name ~source:chat_source
+                ~content:visible_reply
+                ());
             push_worker_event (Stream_terminal (true, body));
             Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body
         | Ok (false, err) ->

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -77,6 +77,38 @@ let available_tts_endpoints ?provider () =
   | Ok config -> Voice_runtime_overlay.select_endpoints ?provider config.tts.endpoints
 ;;
 
+(** Synthesize a dashboard-playable MP3 via any HTTP TTS endpoint.
+    This is used as a parallel fallback when the active transport is
+    [Voice_mcp], which produces audio through a local/MCP path but does not
+    write a browser-fetchable file. *)
+let try_http_tts_for_dashboard ~agent_id ~message ~voice ~model ~audio_device () =
+  let endpoints = available_tts_endpoints () in
+  let rec try_endpoint = function
+    | [] -> None
+    | endpoint :: rest ->
+      let adapter = Voice_runtime_overlay.adapter_for_endpoint endpoint in
+      if Voice_runtime_overlay.transport_supports_http_tts adapter
+      then (
+        let audio_file = make_audio_file () in
+        match
+          speak_via_http_tts_to_file
+            endpoint
+            ~agent_id
+            ~message
+            ~voice
+            ~model
+            ~output_file:audio_file
+        with
+        | Ok file_size -> Some (audio_file, file_size)
+        | Error _ ->
+          (try Sys.remove audio_file with
+           | Sys_error _ -> ());
+          try_endpoint rest)
+      else try_endpoint rest
+  in
+  try_endpoint endpoints
+;;
+
 let public_config_json () =
   match load_voice_config () with
   | Ok config -> Ok (Voice_config.public_json config)
@@ -166,27 +198,62 @@ let tts_preview_bytes_from_request_json json =
   try_endpoints [] endpoints
 ;;
 
-(** Clean up old audio files (>1 hour). Call from heartbeat. *)
+(** Clean up old audio files (>24 hours) and enforce a size cap.
+    Call from heartbeat. Older files are removed first; if the total
+    size still exceeds the cap, the oldest files are removed until the
+    cap is satisfied. *)
 let cleanup_old_audio_files () =
   let dir = Filename.concat (masc_base_dir ()) "audio" in
   if Sys.file_exists dir && Sys.is_directory dir
   then (
     let now = Time_compat.now () in
-    let cutoff = now -. Masc_time_constants.hour in
+    let cutoff = now -. Masc_time_constants.day in
     let entries = Sys.readdir dir in
+    let with_stats =
+      Array.to_list entries
+      |> List.filter_map (fun entry ->
+           let path = Filename.concat dir entry in
+           try
+             let stat = Unix.stat path in
+             Some (path, stat.st_mtime, stat.st_size)
+           with
+           | Unix.Unix_error _ | Sys_error _ -> None)
+    in
+    let by_age = List.sort (fun (_, m1, _) (_, m2, _) -> Float.compare m1 m2) with_stats in
     let removed = ref 0 in
-    Array.iter
-      (fun entry ->
-         let path = Filename.concat dir entry in
-         try
-           let stat = Unix.stat path in
-           if stat.st_mtime < cutoff
+    let remove path =
+      try
+        Sys.remove path;
+        incr removed
+      with
+      | Unix.Unix_error _ | Sys_error _ -> ()
+    in
+    (* First pass: remove files older than 24h. *)
+    let remaining =
+      List.filter
+        (fun (path, mtime, _size) ->
+           if mtime < cutoff
            then (
-             Sys.remove path;
-             incr removed)
-         with
-         | Unix.Unix_error _ | Sys_error _ -> ())
-      entries;
+             remove path;
+             false)
+           else true)
+        by_age
+    in
+    (* Second pass: enforce size cap by removing oldest files first. *)
+    let max_size_bytes = 500 * 1024 * 1024 in
+    let total_size = List.fold_left (fun acc (_, _, size) -> acc + size) 0 remaining in
+    if total_size > max_size_bytes
+    then
+      ignore
+        (List.fold_left
+           (fun acc (path, _mtime, size) ->
+              if acc <= max_size_bytes
+              then acc
+              else (
+                remove path;
+                acc - size))
+           total_size
+           remaining);
     if !removed > 0
     then log_info (Printf.sprintf "Cleaned up %d old audio files" !removed))
 ;;
@@ -490,7 +557,33 @@ let attempt_tts_endpoint
       with
       | Ok json ->
         (match extract_mcp_result json with
-         | Ok data -> Ok (append_provider_metadata data endpoint)
+         | Ok data ->
+           (* Voice_mcp plays audio locally but does not expose a file for the
+              dashboard. Try to synthesize a parallel HTTP TTS clip so the
+              browser can also play it. *)
+           let data =
+             match
+               try_http_tts_for_dashboard
+                 ~agent_id
+                 ~message
+                 ~voice
+                 ~model
+                 ~audio_device
+                 ()
+             with
+             | Some (audio_file, file_size) ->
+               let audio_fields =
+                 [ "audio_file", `String audio_file
+                 ; "audio_size", `Int file_size
+                 ]
+                 @ audio_payload_fields ~audio_file ~audio_device
+               in
+               (match data with
+                | `Assoc fields -> `Assoc (fields @ audio_fields)
+                | other -> other)
+             | None -> data
+           in
+           Ok (append_provider_metadata data endpoint)
          | Error error -> Error error)
       | Error error -> Error error)
 ;;
@@ -638,9 +731,70 @@ let end_voice_session ~sw ~clock ~net ~agent_id =
     call_session_tool ~sw ~clock ~net ~tool_name:"voice_session_end" ~arguments:args)
 ;;
 
+(** Try HTTP TTS endpoints to synthesize a browser-playable MP3 clip.
+    Used when the winning endpoint is [Voice_mcp] so the dashboard still
+    has an audio clip even though the MCP server owns local playback.
+    Returns [None] when no HTTP endpoint is configured or all fail. *)
+let try_http_tts_for_browser_audio
+      ~sw
+      ~clock
+      ~net
+      ~agent_id
+      ~message
+      ~voice
+      ~model
+      ~priority
+      ?audio_device
+      endpoints
+  =
+  let http_endpoints =
+    List.filter Voice_runtime_overlay.endpoint_supports_http_tts endpoints
+  in
+  let rec try_endpoints = function
+    | [] -> None
+    | endpoint :: rest ->
+      let audio_file = make_audio_file () in
+      (match
+         speak_via_http_tts_to_file
+           endpoint
+           ~message
+           ~voice
+           ~model
+           ~agent_id
+           ~output_file:audio_file
+       with
+       | Ok file_size -> Some (audio_file, file_size)
+       | Error _ ->
+         (try Sys.remove audio_file with
+          | Sys_error _ -> ());
+         try_endpoints rest)
+  in
+  try_endpoints http_endpoints
+;;
+
+let result_has_audio_file = function
+  | `Assoc fields -> List.assoc_opt "audio_file" fields <> None
+  | _ -> false
+;;
+
+let merge_browser_audio_fields ~audio_file ~file_size ?audio_device json =
+  match json with
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       @ [ ("audio_file", `String audio_file); ("audio_size", `Int file_size) ]
+       @ audio_payload_fields ~audio_file ~audio_device)
+  | other -> other
+;;
+
 (** Request speaking turn.
     Ordered endpoint chain from voice_config.json. Fails explicitly when no
-    real backend accepts the request. *)
+    real backend accepts the request.
+
+    RFC-0235 P3: when the winning endpoint is [Voice_mcp] and a separate
+    HTTP TTS endpoint is also configured, synthesize a parallel browser
+    clip so the dashboard can play the utterance. The MCP server still
+    owns local playback; the HTTP clip is dashboard-only. *)
 let agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ?(priority = 1) ?audio_device () =
   if is_dedup_hit ~agent_id ~message
   then (
@@ -698,7 +852,40 @@ let agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ?(priority = 1) ?au
     in
     if endpoints = []
     then Error "no configured TTS endpoint"
-    else try_endpoints [] endpoints)
+    else
+      match try_endpoints [] endpoints with
+      | Ok result when not (result_has_audio_file result) ->
+        (* The winning endpoint was [Voice_mcp]. Try a dashboard-playable
+           HTTP TTS clip in parallel so the dashboard has audio playback.
+           If no HTTP endpoint is available or all fail, the MCP result
+           still stands and the dashboard simply shows no audio player. *)
+        (match
+           try_http_tts_for_browser_audio
+             ~sw
+             ~clock
+             ~net
+             ~agent_id
+             ~message
+             ~voice
+             ~model
+             ~priority
+             ?audio_device
+             endpoints
+         with
+         | Some (audio_file, file_size) ->
+           log_info
+             (Printf.sprintf
+                "Voice MCP: synthesized parallel browser audio clip for agent=%s file=%s"
+                agent_id
+                audio_file);
+           Ok (merge_browser_audio_fields ~audio_file ~file_size ?audio_device result)
+         | None ->
+           log_info
+             (Printf.sprintf
+                "Voice MCP path used for agent=%s; no browser audio clip available (no HTTP TTS endpoint)."
+                agent_id);
+           Ok result)
+      | other -> other)
 ;;
 
 (** List active voice sessions *)

--- a/test/dune
+++ b/test/dune
@@ -147,6 +147,7 @@
   test_keeper_timing
   test_keeper_token_count
   test_keeper_chat_store
+  test_keeper_chat_blocks
   test_keeper_external_attention
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
@@ -436,6 +437,7 @@
   test_keeper_timing
   test_keeper_token_count
   test_keeper_chat_store
+  test_keeper_chat_blocks
   test_keeper_external_attention
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -1,0 +1,156 @@
+module B = Masc.Keeper_chat_blocks
+
+let yojson_testable =
+  Alcotest.testable
+    (fun fmt json -> Format.fprintf fmt "%s" (Yojson.Safe.to_string json))
+    ( = )
+
+let blocks_to_json_list blocks =
+  match B.blocks_to_yojson blocks with
+  | `List items -> items
+  | _ -> []
+
+let test_plain_text_becomes_escaped_text_block () =
+  let blocks = B.parse_text_to_blocks "hello <world>" in
+  Alcotest.(check int) "one block" 1 (List.length blocks);
+  Alcotest.(check (list yojson_testable))
+    "escaped html"
+    [ `Assoc [ ("t", `String "p"); ("html", `String "hello &lt;world&gt;") ] ]
+    (blocks_to_json_list blocks)
+
+let test_markdown_image_and_surrounding_text () =
+  let blocks = B.parse_text_to_blocks "before ![alt text](https://example.com/a.png) after" in
+  Alcotest.(check (list yojson_testable))
+    "image with surrounding text"
+    [
+      `Assoc [ ("t", `String "p"); ("html", `String "before ") ];
+      `Assoc
+        [
+          ("t", `String "image");
+          ("src", `String "https://example.com/a.png");
+          ("cap", `String "alt text");
+        ];
+      `Assoc [ ("t", `String "p"); ("html", `String " after") ];
+    ]
+    (blocks_to_json_list blocks)
+
+let test_bare_image_url_on_own_line () =
+  let blocks = B.parse_text_to_blocks "https://example.com/screen.webp" in
+  Alcotest.(check (list yojson_testable))
+    "image block"
+    [ `Assoc [ ("t", `String "image"); ("src", `String "https://example.com/screen.webp") ] ]
+    (blocks_to_json_list blocks)
+
+let test_standalone_non_image_url_becomes_link () =
+  let blocks = B.parse_text_to_blocks "https://example.com/post" in
+  Alcotest.(check (list yojson_testable))
+    "link block"
+    [
+      `Assoc
+        [
+          ("t", `String "link");
+          ("url", `String "https://example.com/post");
+          ("title", `String "example.com");
+          ("meta", `String "example.com");
+        ];
+    ]
+    (blocks_to_json_list blocks)
+
+let test_inline_url_stays_in_text () =
+  let blocks = B.parse_text_to_blocks "See https://example.com for more." in
+  Alcotest.(check (list yojson_testable))
+    "text block keeps inline url"
+    [ `Assoc [ ("t", `String "p"); ("html", `String "See https://example.com for more.") ] ]
+    (blocks_to_json_list blocks)
+
+let test_multiple_images_and_text_lines () =
+  let blocks = B.parse_text_to_blocks "intro\n![a](https://x.com/1.jpg)\nhttps://x.com/2.gif\noutro" in
+  Alcotest.(check (list yojson_testable))
+    "mixed blocks in order"
+    [
+      `Assoc [ ("t", `String "p"); ("html", `String "intro") ];
+      `Assoc [ ("t", `String "image"); ("src", `String "https://x.com/1.jpg"); ("cap", `String "a") ];
+      `Assoc [ ("t", `String "image"); ("src", `String "https://x.com/2.gif") ];
+      `Assoc [ ("t", `String "p"); ("html", `String "outro") ];
+    ]
+    (blocks_to_json_list blocks)
+
+let test_empty_lines_ignored () =
+  let blocks = B.parse_text_to_blocks "line1\n\nline2" in
+  Alcotest.(check int) "two blocks" 2 (List.length blocks);
+  Alcotest.(check (list string)) "text order"
+    [ "line1"; "line2" ]
+    (List.map
+       (fun block ->
+          match B.block_to_yojson block with
+          | `Assoc fields -> (
+              match List.assoc_opt "html" fields with
+              | Some (`String s) -> s
+              | _ -> "")
+          | _ -> "")
+       blocks)
+
+let test_link_without_www () =
+  let blocks = B.parse_text_to_blocks "https://www.example.com/post" in
+  Alcotest.(check (list yojson_testable))
+    "www stripped"
+    [
+      `Assoc
+        [
+          ("t", `String "link");
+          ("url", `String "https://www.example.com/post");
+          ("title", `String "example.com");
+          ("meta", `String "example.com");
+        ];
+    ]
+    (blocks_to_json_list blocks)
+
+let test_blocks_of_yojson_roundtrip () =
+  let original = B.parse_text_to_blocks "text\n![a](https://x.com/a.png)\nhttps://x.com/post" in
+  let json = B.blocks_to_yojson original in
+  match B.blocks_of_yojson json with
+  | Some parsed ->
+    Alcotest.(check int) "roundtrip length" (List.length original) (List.length parsed);
+    Alcotest.(check (list yojson_testable))
+      "roundtrip json"
+      (blocks_to_json_list original)
+      (blocks_to_json_list parsed)
+  | None -> Alcotest.fail "blocks_of_yojson rejected valid blocks"
+
+let test_blocks_of_yojson_rejects_malformed () =
+  Alcotest.(check bool) "not a list" true (B.blocks_of_yojson (`String "x") = None);
+  Alcotest.(check bool) "empty list" true (B.blocks_of_yojson (`List []) = None);
+  Alcotest.(check bool) "unknown tag"
+    true
+    (B.blocks_of_yojson (`List [ `Assoc [ ("t", `String "unknown") ] ]) = None)
+
+let () =
+  Alcotest.run "keeper_chat_blocks"
+    [
+      ( "parse",
+        [
+          Alcotest.test_case "plain text becomes escaped text block" `Quick
+            test_plain_text_becomes_escaped_text_block;
+          Alcotest.test_case "markdown image and surrounding text" `Quick
+            test_markdown_image_and_surrounding_text;
+          Alcotest.test_case "bare image url on own line" `Quick
+            test_bare_image_url_on_own_line;
+          Alcotest.test_case "standalone non-image url becomes link" `Quick
+            test_standalone_non_image_url_becomes_link;
+          Alcotest.test_case "inline url stays in text" `Quick
+            test_inline_url_stays_in_text;
+          Alcotest.test_case "multiple images and text lines" `Quick
+            test_multiple_images_and_text_lines;
+          Alcotest.test_case "empty lines ignored" `Quick
+            test_empty_lines_ignored;
+          Alcotest.test_case "www stripped from hostname" `Quick
+            test_link_without_www;
+        ] );
+      ( "serialization",
+        [
+          Alcotest.test_case "blocks roundtrip through yojson" `Quick
+            test_blocks_of_yojson_roundtrip;
+          Alcotest.test_case "blocks_of_yojson rejects malformed" `Quick
+            test_blocks_of_yojson_rejects_malformed;
+        ] );
+    ]

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -69,6 +69,45 @@ let test_tool_context_block_renders_tool () =
   check bool "args" true (contains s "args: path: foo.txt");
   check bool "result" true (contains s "result: contents")
 
+(* ── content_blocks_of_text ─────────────────────────────────────── *)
+
+let test_content_blocks_empty_for_plain_text () =
+  let blocks = S.content_blocks_of_text "just plain text" in
+  check int "no blocks" 0 (List.length blocks)
+
+let test_content_blocks_detects_markdown_image () =
+  let blocks =
+    S.content_blocks_of_text "Hello ![alt text](https://example.com/img.png) world"
+  in
+  check int "one block" 1 (List.length blocks);
+  let s = json_string (List.hd blocks) in
+  check bool "type image" true (contains s "\"type\":\"image\"");
+  check bool "image_url" true
+    (contains s "\"image_url\":\"https://example.com/img.png\"");
+  check bool "alt_text" true (contains s "\"alt_text\":\"alt text\"")
+
+let test_content_blocks_detects_bare_image_url () =
+  let blocks = S.content_blocks_of_text "https://example.com/photo.jpg" in
+  check int "one block" 1 (List.length blocks);
+  let s = json_string (List.hd blocks) in
+  check bool "type image" true (contains s "\"type\":\"image\"");
+  check bool "image_url" true
+    (contains s "\"image_url\":\"https://example.com/photo.jpg\"")
+
+let test_content_blocks_detects_link () =
+  let blocks = S.content_blocks_of_text "https://example.com/page" in
+  check int "one block" 1 (List.length blocks);
+  let s = json_string (List.hd blocks) in
+  check bool "type section" true (contains s "\"type\":\"section\"");
+  check bool "link syntax" true (contains s "*<https://example.com/page|example.com>*")
+
+let test_content_blocks_mixed_content () =
+  let blocks =
+    S.content_blocks_of_text
+      "Check this out\nhttps://example.com/page\n![diagram](https://example.com/diagram.png)\nignore me"
+  in
+  check int "two blocks" 2 (List.length blocks)
+
 let () =
   run "keeper_chat_slack"
     [
@@ -84,5 +123,15 @@ let () =
             test_audio_block_renders_voice_link
         ; test_case "tool context block renders tool" `Quick
             test_tool_context_block_renders_tool
+        ] )
+    ; ( "content-blocks"
+      , [ test_case "empty for plain text" `Quick
+            test_content_blocks_empty_for_plain_text
+        ; test_case "detects markdown image" `Quick
+            test_content_blocks_detects_markdown_image
+        ; test_case "detects bare image URL" `Quick
+            test_content_blocks_detects_bare_image_url
+        ; test_case "detects link" `Quick test_content_blocks_detects_link
+        ; test_case "mixed content" `Quick test_content_blocks_mixed_content
         ] )
     ]

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -334,6 +334,7 @@ let test_recent_direct_context_omits_voice_audio_self_echo () =
           ; duration_sec = None
           ; message_text = "I will say this out loud now."
           ; device_id = None
+          ; expired = false
           }
         ();
       let lines =
@@ -888,6 +889,152 @@ let test_unknown_kind_reported_reads_utterance () =
       | messages ->
           Alcotest.failf "expected 1 row, got %d" (List.length messages))
 
+let audio_path ~base_dir token =
+  Filename.concat
+    (Filename.concat (Common.masc_dir_from_base_path ~base_path:base_dir) "audio")
+    (token ^ ".mp3")
+
+let json_audio_expired = function
+  | `Assoc fields -> (
+      match List.assoc_opt "audio" fields with
+      | Some (`Assoc audio_fields) -> (
+          match List.assoc_opt "expired" audio_fields with
+          | Some (`Bool b) -> b
+          | _ -> false)
+      | _ -> false)
+  | _ -> false
+
+(* RFC-0235 P3: the history endpoint marks audio clips as expired when the
+   underlying MP3 has been reaped, so the dashboard can show a fallback
+   instead of a broken native player. *)
+let test_audio_clip_marked_expired_when_file_missing () =
+  let base_dir = temp_base_path "keeper-chat-store-audio-expired" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-audio-expired" in
+      let token = "voice-token-missing" in
+      K.append_assistant_message ~base_dir ~keeper_name
+        ~content:"I will say this out loud now."
+        ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
+        ~audio:
+          { K.token
+          ; audio_url = None
+          ; mime = "audio/mpeg"
+          ; duration_sec = None
+          ; message_text = "I will say this out loud now."
+          ; device_id = None
+          ; expired = false
+          }
+        ();
+      let messages = K.load ~base_dir ~keeper_name in
+      let rows = Yojson.Safe.Util.to_list (K.to_json_array ~base_dir messages) in
+      Alcotest.(check int) "one json row" 1 (List.length rows);
+      Alcotest.(check bool) "missing file marks clip expired" true
+        (json_audio_expired (List.hd rows));
+      (* Create the file and reload: the clip is no longer expired. *)
+      let path = audio_path ~base_dir token in
+      mkdir_p (Filename.dirname path);
+      write_file path "mp3-bytes";
+      let rows_present = Yojson.Safe.Util.to_list (K.to_json_array ~base_dir messages) in
+      Alcotest.(check bool) "present file does not mark expired" false
+        (json_audio_expired (List.hd rows_present)))
+
+let test_audio_clip_expired_persists_roundtrip () =
+  let base_dir = temp_base_path "keeper-chat-store-audio-expired-rt" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-audio-expired-rt" in
+      let path = chat_path ~base_dir ~keeper_name in
+      write_file path
+        ({|{"role":"assistant","content":"hello","ts":1.0,"audio":{|}
+        ^ {|"token":"voice-token-rt","mime":"audio/mpeg","message_text":"hello","expired":true}|}
+        ^ "}\n");
+      match K.load ~base_dir ~keeper_name with
+      | [ msg ] -> (
+          match msg.K.audio with
+          | Some a ->
+              Alcotest.(check bool) "expired flag round-trips" true a.K.expired
+          | None -> Alcotest.fail "audio field missing")
+      | messages ->
+          Alcotest.failf "expected 1 row, got %d" (List.length messages))
+
+(* RFC-0235 P3: backend-driven rich chat blocks. *)
+
+let json_blocks = function
+  | `Assoc fields -> (
+      match List.assoc_opt "blocks" fields with
+      | Some (`List items) -> Some items
+      | _ -> None)
+  | _ -> None
+
+let test_assistant_row_gets_backend_blocks () =
+  let base_dir = temp_base_path "keeper-chat-store-blocks" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-blocks" in
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:"show me"
+        ~user_attachments:[]
+        ~assistant_content:"Here is the shot.\n\n![shot](https://x.com/screen.png)\n\nSee https://x.com/post for context."
+        ();
+      let messages = K.load ~base_dir ~keeper_name in
+      let asst = List.find (fun (m : K.chat_message) -> K.Role.equal m.role K.Role.Assistant) messages in
+      Alcotest.(check bool) "assistant has blocks" true
+        (Option.is_some asst.K.blocks);
+      let rows = Yojson.Safe.Util.to_list (K.to_json_array messages) in
+      let asst_json = List.find (fun row ->
+        match row with
+        | `Assoc fields -> (
+            match List.assoc_opt "role" fields with
+            | Some (`String "assistant") -> true
+            | _ -> false)
+        | _ -> false) rows in
+      match json_blocks asst_json with
+      | Some items -> Alcotest.(check int) "blocks serialized" 3 (List.length items)
+      | None -> Alcotest.fail "assistant json missing blocks")
+
+let test_user_and_tool_rows_have_no_blocks () =
+  let base_dir = temp_base_path "keeper-chat-store-blocks-no-user" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-blocks-no-user" in
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:"https://x.com/post"
+        ~user_attachments:[]
+        ~tool_calls:[ { K.call_id = "t1"; call_name = "Read"; args = "{}" } ]
+        ~assistant_content:"done"
+        ();
+      let messages = K.load ~base_dir ~keeper_name in
+      let user = List.find (fun (m : K.chat_message) -> K.Role.equal m.role K.Role.User) messages in
+      let tool = List.find (fun (m : K.chat_message) -> K.Role.equal m.role K.Role.Tool) messages in
+      Alcotest.(check bool) "user row has no blocks" true (user.K.blocks = None);
+      Alcotest.(check bool) "tool row has no blocks" true (tool.K.blocks = None))
+
+let test_blocks_roundtrip_and_drop_malformed () =
+  let base_dir = temp_base_path "keeper-chat-store-blocks-rt" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-blocks-rt" in
+      let path = chat_path ~base_dir ~keeper_name in
+      write_file path
+        ({|{"role":"assistant","content":"hello","ts":1.0,"blocks":[{|}
+        ^ {|"t":"p","html":"hello"},{"t":"image","src":"https://x.com/a.png","cap":"a"},{|}
+        ^ {|"t":"link","url":"https://x.com","title":"x.com","meta":"x.com"},{|}
+        ^ {|"t":"unknown","x":1}]}|}
+        ^ "\n");
+      let messages = K.load ~base_dir ~keeper_name in
+      match messages with
+      | [ msg ] -> (
+          match msg.K.blocks with
+          | Some blocks -> Alcotest.(check int) "valid blocks kept, malformed dropped" 3 (List.length blocks)
+          | None -> Alcotest.fail "blocks missing")
+      | messages -> Alcotest.failf "expected 1 row, got %d" (List.length messages))
+
 let () =
   Alcotest.run "keeper_chat_store"
     [
@@ -906,6 +1053,22 @@ let () =
             test_tool_row_missing_name_dropped;
           Alcotest.test_case "unknown role row dropped (RFC-0232)" `Quick
             test_unknown_role_row_dropped;
+        ] );
+      ( "audio_expiry (RFC-0235 P3)",
+        [
+          Alcotest.test_case "missing file marks clip expired" `Quick
+            test_audio_clip_marked_expired_when_file_missing;
+          Alcotest.test_case "expired flag round-trips" `Quick
+            test_audio_clip_expired_persists_roundtrip;
+        ] );
+      ( "backend_blocks (RFC-0235 P3)",
+        [
+          Alcotest.test_case "assistant row gets backend blocks" `Quick
+            test_assistant_row_gets_backend_blocks;
+          Alcotest.test_case "user and tool rows have no blocks" `Quick
+            test_user_and_tool_rows_have_no_blocks;
+          Alcotest.test_case "blocks roundtrip and malformed dropped" `Quick
+            test_blocks_roundtrip_and_drop_malformed;
         ] );
       ( "row_kind",
         [

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -15,8 +15,11 @@ let target_pp fmt = function
   | SP.To_dashboard -> Format.fprintf fmt "To_dashboard"
   | SP.To_discord { channel_id } ->
       Format.fprintf fmt "To_discord{%s}" channel_id
-  | SP.To_slack { channel_id } ->
-      Format.fprintf fmt "To_slack{%s}" channel_id
+  | SP.To_slack { channel_id; blocks } ->
+      let blocks_label =
+        match blocks with None -> "no-blocks" | Some [] -> "empty" | Some _ -> "blocks"
+      in
+      Format.fprintf fmt "To_slack{%s,%s}" channel_id blocks_label
 
 let target : SP.post_target testable = testable target_pp ( = )
 
@@ -77,7 +80,7 @@ let test_slack_unbound_is_error () =
 
 let test_slack_single_binding_resolves_implicitly () =
   check (result target string) "single slack binding"
-    (Ok (SP.To_slack { channel_id = "C123456" }))
+    (Ok (SP.To_slack { channel_id = "C123456"; blocks = None }))
     (resolve ~surface:"slack" ~channel_id:None
        ~bound_discord_channels:[] ~bound_slack_channels:[ "C123456" ] ())
 
@@ -91,7 +94,7 @@ let test_slack_multiple_bindings_require_channel_id () =
         (Astring.String.is_infix ~affix:"AAA, BBB" message)
   | Ok _ -> fail "ambiguous slack binding must not resolve");
   check (result target string) "explicit channel_id picks one"
-    (Ok (SP.To_slack { channel_id = "BBB" }))
+    (Ok (SP.To_slack { channel_id = "BBB"; blocks = None }))
     (resolve ~surface:"slack" ~channel_id:(Some "BBB")
        ~bound_discord_channels:[] ~bound_slack_channels:[ "AAA"; "BBB" ] ())
 
@@ -114,6 +117,25 @@ let test_unsupported_surface_is_error () =
             (Astring.String.is_infix ~affix:"not supported" message)
       | Ok _ -> fail (surface ^ " must not resolve in P4"))
     [ "telegram"; "openclaw" ]
+
+(* ── set_blocks ─────────────────────────────────────────────────── *)
+
+let test_set_blocks_attaches_to_slack () =
+  let block = `Assoc [ ("type", `String "section") ] in
+  let resolved =
+    SP.set_blocks (SP.To_slack { channel_id = "C1"; blocks = None }) (Some [ block ])
+  in
+  check (result target string) "blocks attached"
+    (Ok (SP.To_slack { channel_id = "C1"; blocks = Some [ block ] }))
+    (Ok resolved)
+
+let test_set_blocks_ignores_other_targets () =
+  let block = `Assoc [ ("type", `String "section") ] in
+  check target "dashboard unchanged" SP.To_dashboard
+    (SP.set_blocks SP.To_dashboard (Some [ block ]));
+  check target "discord unchanged"
+    (SP.To_discord { channel_id = "D1" })
+    (SP.set_blocks (SP.To_discord { channel_id = "D1" }) (Some [ block ]))
 
 (* ── append_assistant_message ───────────────────────────────────── *)
 
@@ -180,6 +202,13 @@ let () =
             test_slack_foreign_channel_id_is_error;
           test_case "unsupported surfaces are errors" `Quick
             test_unsupported_surface_is_error;
+        ] );
+      ( "set_blocks",
+        [
+          test_case "attaches blocks to slack target" `Quick
+            test_set_blocks_attaches_to_slack;
+          test_case "ignores non-slack targets" `Quick
+            test_set_blocks_ignores_other_targets;
         ] );
       ( "assistant append",
         [


### PR DESCRIPTION
## Summary

Follow-up to #21449. Improves the MASC communication layer across dashboard, Discord, and Slack.

## Changes

### 1. Backend-driven chat blocks
- New lib/keeper/keeper_chat_blocks.ml/.mli parses assistant text into a ChatBlock-like JSON list (images, links, text).
- lib/keeper/keeper_chat_store.ml persists optional blocks and emits them in history + SSE.
- Dashboard prefers server-provided blocks and falls back to the local parser only when absent.

### 2. Slack surface-post rich blocks
- lib/keeper/keeper_surface_post.ml/.mli carries optional rich blocks for To_slack.
- lib/keeper/keeper_tool_in_process_runtime.ml builds Slack Block Kit sections from post content (images, links) and sends them via Keeper_chat_slack.send_message_with_blocks.

### 3. Voice MCP browser audio
- When Voice_mcp transport succeeds, lib/voice/voice_bridge.ml now tries to synthesize a parallel HTTP TTS MP3 so the dashboard/browser can play the clip via /api/v1/voice/audio/<token>.
- Falls back to the original MCP result if no HTTP TTS endpoint works.

### 4. Expired audio UI
- lib/keeper/keeper_chat_store.ml marks audio clips as expired=true when the MP3 file is missing on history read.
- Dashboard AudioPlayer shows a Korean expired placeholder instead of a broken native player.

## Verification
- npx tsc --noEmit --pretty: passed
- Focused vitest (chat-blocks, primitives, keeper-state, keeper-actions, keeper-stream, sse-store): 128 passed
- scripts/dune-local.sh build bin/main_eio.exe: passed
- test_keeper_chat_blocks.exe: new, passes
- test_keeper_chat_slack.exe: extended, passes
- test_keeper_surface_post.exe: extended, passes
- test_keeper_chat_store.exe: extended, passes (one pre-existing unrelated failure)

## Follow-ups
- Consider raising the 1-hour audio TTL or switching to size-based retention.
- Extend rich block transport to include link-preview metadata (OpenGraph title/description/image).
- Render ChatMermaidBlock on Discord/Slack via image fallback.