### PR TITLE
fix(probe): mirror keeper command gate (gate_typed) not the exec_policy wrapper

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -270,7 +270,7 @@
 (executable
  (name masc_shell_ir_probe)
  (modules masc_shell_ir_probe)
- (libraries masc.masc_exec masc.exec_policy))
+ (libraries masc.masc_exec masc.exec_policy masc.masc_exec_command_gate))
 
 ; RFC-0054 PR-3 — production codegen for lib/exec/shell_ir_typed.ml.
 ; Hardcoded 9-constructor spec mirrors shell_ir_typed.{ml,mli} order.

--- a/bin/masc_shell_ir_probe.ml
+++ b/bin/masc_shell_ir_probe.ml
@@ -4,10 +4,18 @@
     Execute path uses, WITHOUT running it:
 
       1. Exec_policy.parse_string_to_ir ~mode:Tool_execute      (parse)
-      2. Exec_policy.validate_command_tool_execute              (command gate)
+      2. Shell_command_gate.gate_typed                          (command gate)
       3. Capability_check.of_ir                                 (capabilities)
       4. Approval_policy.decide ~overlay:autonomous             (four-way verdict)
       5. Exec_policy.validate_shell_ir_paths ~workdir           (downstream path jail)
+
+    Layers 2 and 5 mirror keeper_tool_execute_shell_ir.dispatch_classified,
+    which calls Shell_command_gate.gate_typed then validate_shell_ir_paths.
+    Layer 2 deliberately does NOT use Exec_policy.validate_command_tool_execute:
+    that wraps gate_typed with an extra validate_no_unquoted_glob check no live
+    keeper path applies, so it over-reports blocks on unquoted-glob commands
+    (e.g. [gh api /r/check-runs?sha=x], [ls *.ml]) keepers actually run.
+    (baseline.jsonl pins this: [ls *.txt] -> ir_verdict=allow, worker=injection.)
 
     Every layer's outcome is printed independently so a probe shows exactly
     which layer would block a command. Parse failures, gate rejections, and
@@ -27,6 +35,7 @@ module Capability_check = Masc_exec.Capability_check
 module Approval_policy = Masc_exec.Approval_policy
 module Approval_config = Masc_exec.Approval_config
 module Verdict = Masc_exec.Verdict
+module Shell_gate = Masc_exec_command_gate.Shell_command_gate
 
 let probe_policy : Approval_policy.t = { raw_source = "(probe)"; summary = "(probe)" }
 
@@ -64,10 +73,18 @@ let probe ~workdir command =
      Printf.printf "parse:        BLOCKED — %s\n" (Exec_policy.block_reason_to_string reason)
    | Ok ir ->
      Printf.printf "parse:        ok (%s)\n" (ir_shape ir);
-     (match Exec_policy.validate_command_tool_execute ~allow_pipes:true ir with
-      | Ok () -> Printf.printf "command-gate: ok\n"
-      | Error reason ->
-        Printf.printf "command-gate: BLOCKED — %s\n" (Exec_policy.block_reason_to_string reason));
+     (match
+        Shell_gate.gate_typed ~ir
+          ~syntax_policy:{ Shell_gate.redirect_allowed = true; allow_pipes = true }
+          ~path_policy:Shell_gate.allow_all_paths ~sandbox:Shell_gate.host_sandbox ()
+      with
+      | Shell_gate.Allow _ -> Printf.printf "command-gate: ok\n"
+      | Shell_gate.Reject { diagnostic; _ } ->
+        Printf.printf "command-gate: BLOCKED — %s\n" diagnostic
+      | Shell_gate.Cannot_parse _ ->
+        Printf.printf "command-gate: BLOCKED — cannot parse (chain/redirect/injection)\n"
+      | Shell_gate.Too_complex _ ->
+        Printf.printf "command-gate: BLOCKED — unsupported construct (too complex)\n");
      Printf.printf "caps:         %s\n" (render_caps (Capability_check.of_ir ir));
      (match last_simple_of_ir ir with
       | None -> Printf.printf "verdict:      (no simple stage)\n"


### PR DESCRIPTION
## 배경

오프라인 Shell IR probe(`bin/masc_shell_ir_probe`, #21467)로 갈래별 분류를 검증하던 중, probe의 command-gate 레이어가 **keeper가 실제로 안 쓰는 함수**를 호출하는 fidelity gap을 발견.

probe layer 2는 `Exec_policy.validate_command_tool_execute`를 호출했는데, 이건 `Shell_command_gate.gate_typed`를 감싸면서 **추가로 `validate_no_unquoted_glob` 검사**를 붙인 래퍼다. 코드 트레이스 결과:

- keeper live path: `keeper_tool_execute_runtime.ml` → `dispatch_classified_with_approval` → `dispatch_classified`가 `Shell_command_gate.gate_typed`를 **직접** 호출 (+ `validate_shell_ir_paths`). glob 검사 없음.
- `validate_command_tool_execute`(및 그 glob 검사)는 `lib/` 어디에서도 호출되지 않음 (호출자 0, test/probe/RFC 문서만 참조).
- `gate_typed` 본문은 `arg_meta.glob` 비트를 **아예 읽지 않음** (`shell_command_gate.ml` 전체에 `.glob`/`meta` 접근 0건).

## 드리프트의 영향

probe가 keeper가 일상적으로 실행하는 unquoted-glob 명령에 대해 `command-gate: BLOCKED` 헛경보를 냈다 — `gh api .../check-runs?head_sha=abc`(쿼리스트링의 `?`), `ls *.ml` 등. probe docstring은 "keeper Execute path가 쓰는 동일한 결정 레이어"라고 명시하는데 layer 2가 이를 위반한 상태였다.

실제로는 keeper가 `gh api /r/check-runs?sha=x`를 실행하면 **정상 통과**한다: gate_typed=Allow, path-jail=OK, verdict=Allow.

이건 게이트 버그가 아니라 **probe 자체의 결함**이다 (#21462의 gh path-jail FP는 진짜 게이트 버그였고, 이건 다름).

## 수정

- layer 2를 `Shell_command_gate.gate_typed`로 교체. `dispatch_classified`와 동일한 정책 사용: `{redirect_allowed=true; allow_pipes=true}`, `allow_all_paths`, `host_sandbox`.
- `bin/dune`에 `masc.masc_exec_command_gate` 의존 추가.
- docstring에 선택 근거 주석 추가 (왜 wrapper가 아니라 gate_typed인가).

게이트/overlay 동작 변경 없음 — read-only 진단 도구의 fidelity 교정.

## 검증

- 로컬 빌드 `DUNE_CACHE=disabled dune build bin/masc_shell_ir_probe.exe --root .` exit 0.
- probe 실측 (before → after):
  - `gh api .../check-runs?head_sha=abc` → command-gate **BLOCKED → ok**
  - `gh api .../pulls?state=open` → **BLOCKED → ok**
  - `ls *.ml` → ok (glob을 gate_typed가 Allow)
  - `git status && git log` (chain) → parse에서 BLOCKED 유지 (layer 1, 미변경)
  - `cat $(echo foo)` (cmd_subst) → parse에서 BLOCKED 유지
  - `git clean -fd` → command-gate ok, verdict Deny 유지 (#21468 floor fix)
- 음성 검증: chain/cmd_subst 등 위험 구문은 여전히 차단됨 (parse 레이어). glob 헛경보만 제거.

## 회귀 가드

keeper-facing 불변식("command gate가 unquoted glob을 Allow")은 이미 `test/fixtures/shell_gate/baseline.jsonl`에 핀되어 있음:

```
{"raw_cmd":"ls *.txt","category":"glob","expected_worker_verdict":"injection","expected_ir_verdict":"allow",...}
```

→ gate_typed=allow, exec_policy worker wrapper=injection을 명시적으로 핀. 미래에 누가 command-gate에 glob 거부를 넣으면 corpus diff로 드러남. 중복 행은 추가하지 않음.

## RFC

RFC-0254 (Shell IR capability-based approval gate) — read-only 진단 도구의 keeper-path 미러링 정확도 교정. 게이트 동작 불변.
