### PR TITLE
fix(keeper): event-bus unsubscribe busy-spins at 100% CPU (drain-cancel CAS)

### DIFF
--- a/lib/keeper/keeper_unified_turn_event_bus.ml
+++ b/lib/keeper/keeper_unified_turn_event_bus.ml
@@ -227,27 +227,33 @@ let start_background_drain ~clock t =
   | _ -> ()
 ;;
 
+(* Atomically claim the [Closed] state and hand back any background drain
+   handle the caller must cancel. [Atomic.exchange] takes no [seen] argument,
+   so unlike a [compare_and_set] retry loop it cannot spin: the previous value
+   is taken in a single step. The earlier loop compared against a freshly
+   reconstructed [Active cc], which is never PHYSICALLY equal to the stored box
+   (OCaml [Atomic.compare_and_set] uses [==]), so on [Active] the CAS failed
+   forever and the loop busy-spun at 100% CPU, starving the Eio scheduler
+   (server-wide hang — regression from #21447). Cancellation is left to the
+   caller, keeping this a pure state transition (testable without a live
+   cancel context). *)
+let take_drain_cancel t : Eio.Cancel.t option =
+  match Atomic.exchange t.drain_cancel Closed with
+  | Closed | Inactive -> None
+  | Active cc -> Some cc
+;;
+
 let unsubscribe t =
-  let rec close_drain () =
-    match Atomic.get t.drain_cancel with
-    | Closed -> ()
-    | Inactive ->
-      if Atomic.compare_and_set t.drain_cancel Inactive Closed
-      then ()
-      else close_drain ()
-    | Active cc ->
-      if Atomic.compare_and_set t.drain_cancel (Active cc) Closed
-      then (
-        try Eio.Cancel.cancel cc (Failure "event_bus_unsubscribed") with
-        | Eio.Cancel.Cancelled _ -> ()
-        | Invalid_argument msg ->
-          Log.Keeper.debug
-            "%s: event bus drain cancel ignored after context finish: %s"
-            t.keeper_name
-            msg)
-      else close_drain ()
-  in
-  close_drain ();
+  (match take_drain_cancel t with
+   | None -> ()
+   | Some cc -> (
+     try Eio.Cancel.cancel cc (Failure "event_bus_unsubscribed") with
+     | Eio.Cancel.Cancelled _ -> ()
+     | Invalid_argument msg ->
+       Log.Keeper.debug
+         "%s: event bus drain cancel ignored after context finish: %s"
+         t.keeper_name
+         msg));
   ignore (drain ~site:"unsubscribe_final" t);
   match t.event_bus_sub, Keeper_event_bus.get () with
   | Some sub, Some bus -> Agent_sdk_metrics_bridge.unsubscribe bus sub
@@ -283,4 +289,9 @@ module For_testing = struct
   (** Test-only write accessor. No production caller; exposed only so unit
       tests can exercise the take-and-close race path used by [unsubscribe]. *)
   let exchange_drain_cancel t v = Atomic.exchange t.drain_cancel v
+
+  (** The exact take-and-close step [unsubscribe] runs: claims [Closed] and
+      returns the displaced background drain handle (if any). Exposed so a
+      unit test can assert it terminates and is idempotent on [Active]. *)
+  let take_drain_cancel = take_drain_cancel
 end

--- a/lib/keeper/keeper_unified_turn_event_bus.mli
+++ b/lib/keeper/keeper_unified_turn_event_bus.mli
@@ -58,4 +58,8 @@ module For_testing : sig
 
   (** Test-only write accessor. No production caller. *)
   val exchange_drain_cancel : t -> drain_cancel_state -> drain_cancel_state
+
+  (** The take-and-close step [unsubscribe] runs: atomically claims [Closed]
+      and returns the displaced background drain handle (if any). *)
+  val take_drain_cancel : t -> Eio.Cancel.t option
 end

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -153,6 +153,26 @@ let test_state_pending_count_integrity_under_concurrent_updates () =
   check int "concurrent pure computation leaves count at zero" 0 state.pending_tool_count
 ;;
 
+let test_take_drain_cancel_clears_active_without_spin () =
+  let open EB.For_testing in
+  let t = EB.create ~keeper_name:"k" ~turn_id:1 () in
+  set_drain_cancel t (Active (Obj.magic 42));
+  (* The previous [unsubscribe] reconstructed [Active cc] as the CAS [seen]
+     value; physical inequality made the CAS fail forever and the close loop
+     busy-spun at 100% CPU (server-wide hang, regression from #21447).
+     [take_drain_cancel] uses [Atomic.exchange] — it takes the handle and
+     closes the lifecycle in one step that cannot spin. *)
+  check bool "take returns the displaced active handle" true
+    (match take_drain_cancel t with Some _ -> true | None -> false);
+  check bool "lifecycle is Closed after take" true
+    (match get_drain_cancel t with Closed -> true | _ -> false);
+  (* idempotent: a second take observes [Closed] and yields nothing. *)
+  check bool "second take returns None" true
+    (match take_drain_cancel t with None -> true | Some _ -> false);
+  check bool "lifecycle stays Closed" true
+    (match get_drain_cancel t with Closed -> true | _ -> false)
+;;
+
 let () =
   Alcotest.run
     "keeper-unified-turn-event-bus"
@@ -165,6 +185,8 @@ let () =
       , [ test_case "atomic exchange" `Quick test_drain_cancel_exchange
         ; test_case "unsubscribe closes lifecycle" `Quick
             test_unsubscribe_closes_lifecycle_before_fiber_claims
+        ; test_case "take_drain_cancel clears active without spin" `Quick
+            test_take_drain_cancel_clears_active_without_spin
         ] )
     ; ( "concurrency"
       , [ test_case "pure transitions under concurrent domains" `Quick


### PR DESCRIPTION
## 증상

`./start-masc.sh --base-path ~/me`로 기동 후 수 분 내 서버가 멈춤(stuck). 프로세스는 살아있으나 한 코어 100% CPU, HTTP `/health` 무응답. 키퍼/대시보드/gRPC 전부 정지.

## 진단 (live, 실측)

- `ps`: PID `R+`, `%CPU=100`, RSS 1.15GB.
- `curl --max-time 5 /health`: 타임아웃(무응답).
- `sample <pid>`: top-of-stack = `camlMasc__Keeper_unified_turn_event_bus$close_drain` + `caml_atomic_cas_field` → CAS 스핀.

## 근본 원인

`Keeper_unified_turn_event_bus.unsubscribe`의 `close_drain` 루프가 `Active cc` 브랜치에서:

```ocaml
| Active cc ->
  if Atomic.compare_and_set t.drain_cancel (Active cc) Closed   (* ← bug *)
```

OCaml `Atomic.compare_and_set`은 `seen`을 **물리적 동등성(`==`)** 으로 비교한다. 패턴에서 꺼낸 `cc`를 `(Active cc)`로 **재구성하면 새 box**라 저장된 box와 절대 `==`가 아님 → CAS 영구 실패 → `else close_drain ()` 무한 스핀 → Eio 단일 도메인 스케줄러 starvation → 서버 전체 hang.

`Inactive`/`Closed`는 payload 없는 immediate라 비교가 통과 → background drain이 `Active`인 turn이 종료(unsubscribe)될 때만 발현. "기동 후 금세 멈춤"과 일치.

**회귀 출처: #21447** ("make turn event-bus pending count and drain-cancel atomic") — drain-cancel을 Atomic+CAS로 전환하며 이 boxed-CAS 실수가 유입.

## 수정

CAS 재시도 루프를 `take_drain_cancel`(`Atomic.exchange t.drain_cancel Closed`)로 교체:

```ocaml
let take_drain_cancel t : Eio.Cancel.t option =
  match Atomic.exchange t.drain_cancel Closed with
  | Closed | Inactive -> None
  | Active cc -> Some cc
```

`Atomic.exchange`는 `seen` 인자가 없어 **스핀이 구조적으로 불가능**(한 스텝에 직전 값을 take). 반환된 drain handle은 `unsubscribe`가 cancel — 부작용을 caller로 분리해 take를 순수·동기 테스트 가능하게 함. `For_testing.exchange_drain_cancel` 훅 주석이 명시한 "take-and-close ... used by unsubscribe" 설계 복원.

## 검증

- 로컬: `DUNE_CACHE=disabled dune build test/test_keeper_unified_turn_event_bus.exe --root .` exit 0.
- 테스트 6/6 green, 신규 `take_drain_cancel clears active without spin`(Active→`Some`+`Closed` 1스텝 + idempotent) 포함, 기존 회귀 0.
- `Inactive`/`Closed` CAS는 immediate라 동작 무변경.

## RFC

keeper turn lifecycle 회귀 hotfix (서버 hang). 새 동작/추상화 추가 없음 — #21447 회귀를 의도된 take-and-close(`Atomic.exchange`) 설계로 복원.
RFC-WAIVED: SEV regression hotfix restoring the intended exchange-based take-and-close already documented in For_testing.exchange_drain_cancel; no new behavior or design.
