### PR TITLE
Aggressively merge keeper-v2 paper/dark design-system deltas into dashboard

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ko" data-skin="v2" data-volt="ice">
+<html lang="ko" data-skin="v2" data-volt="brass">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -52,9 +52,6 @@ import './styles/tools.css'
 import './styles/provider-matrix.css'
 import './styles/paper-theme.css'
 
-// StyleSeed design-system theme — default light palette.
-import './styles/styleseed-theme.css'
-
 import './styles/keeper-workspace.css'
 import './styles/copilot-dock.css'
 import './styles/keeper-turn-inspector.css'
@@ -65,7 +62,6 @@ import './styles/states.css'
 import './styles/connectors-v2.css'
 import './styles/telemetry-v2.css'
 import './styles/craft-v2.css'
-import './styles/states.css'
 
 // v2 skin — cool-charcoal palette + voltage accent (brass/blood/ice) +
 // Space Grotesk display, for the --color-* surfaces. Activated by
@@ -155,6 +151,13 @@ function applyTheme(theme: ThemeId): void {
 
 const theme = resolveTheme()
 applyTheme(theme)
+
+// Ensure the v2 voltage accent attribute is present so skin-v2.css voltage
+// variants (brass/blood/ice) resolve. The source default is brass; an explicit
+// attribute in index.html wins and is preserved.
+if (!document.documentElement.dataset.volt) {
+  document.documentElement.dataset.volt = 'brass'
+}
 
 const root = document.getElementById('app')
 if (root) {

--- a/dashboard/src/styles/cockpit-v2.css
+++ b/dashboard/src/styles/cockpit-v2.css
@@ -18,7 +18,7 @@
 
 .cp-world {
   border-right: 1px solid var(--border-main);
-  background: var(--bg-deepest);
+  background: var(--bg-well); /* v2 source override */
   position: relative;
   overflow: hidden;
   display: flex;
@@ -74,7 +74,7 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  background: color-mix(in srgb, var(--bg-deepest) 70%, transparent);
+  background: rgba(8, 9, 13, 0.7); /* v2 source override */
 }
 
 .cp-world-foot .row {

--- a/dashboard/src/styles/connectors-v2.css
+++ b/dashboard/src/styles/connectors-v2.css
@@ -190,7 +190,7 @@
 
 .cn-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(var(--cn-card-min), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(330px, 1fr)); /* v2 source override */
   gap: var(--gap-card);
   margin-bottom: 16px;
 }
@@ -201,8 +201,7 @@
   border-radius: var(--radius-md);
   overflow: hidden;
   display: flex;
-  flex-direction: column;
-  transition: border-color 0.14s ease, background 0.14s ease;
+  flex-direction: column; /* v2 source override */
 }
 
 .cn-card:hover {
@@ -318,7 +317,7 @@
 
 .cn-config:hover {
   border-color: var(--volt-dim);
-  color: var(--volt-strong);
+  color: var(--volt); /* v2 source override */
 }
 
 .cn-kv {
@@ -422,6 +421,174 @@
   padding: 4px 0;
 }
 
+/* ── Binding editor (v2 source) ─────────────────────────────────────────── */
+.cn-be {
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  padding: 9px 11px;
+  margin-bottom: 8px;
+  background: var(--bg-card);
+  transition: opacity 0.14s;
+}
+
+.cn-be.off {
+  opacity: 0.5;
+}
+
+.cn-be-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cn-be-chn {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  padding: 5px 8px;
+  background: var(--bg-sunken);
+  color: var(--text-bright);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-xs);
+  outline: none;
+}
+
+.cn-be-chn:focus {
+  border-color: var(--volt-dim);
+}
+
+.cn-be-arr {
+  color: var(--text-dim);
+  flex: none;
+}
+
+.cn-be-kp {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+}
+
+.cn-be-sel {
+  font-size: 12px;
+  padding: 5px 8px;
+  background: var(--bg-sunken);
+  color: var(--text-bright);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-xs);
+  outline: none;
+  cursor: pointer;
+}
+
+.cn-be-sel:focus {
+  border-color: var(--volt-dim);
+}
+
+.cn-be-del {
+  flex: none;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-xs);
+  border: 1px solid var(--border-main);
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 11px;
+  transition: 0.14s;
+}
+
+.cn-be-del:hover {
+  border-color: color-mix(in oklab, var(--status-bad) 45%, transparent);
+  color: var(--status-bad);
+}
+
+.cn-be-opts {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.cn-be-dir {
+  display: inline-flex;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-xs);
+  overflow: hidden;
+}
+
+.cn-dir-b {
+  font-family: var(--font-ui);
+  font-size: 10.5px;
+  padding: 4px 10px;
+  background: transparent;
+  border: 0;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: 0.14s;
+}
+
+.cn-dir-b:not(:last-child) {
+  border-right: 1px solid var(--border-main);
+}
+
+.cn-dir-b:hover {
+  color: var(--text-mid);
+}
+
+.cn-dir-b.on {
+  background: var(--volt-wash);
+  color: var(--volt);
+}
+
+/* Toggle used by the binding editor direction control. */
+.set-toggle {
+  width: 38px;
+  height: 22px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-main);
+  background: var(--bg-sunken);
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+  transition: 0.16s;
+}
+
+.set-toggle .knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  transition: 0.16s;
+}
+
+.set-toggle.on {
+  background: var(--volt-wash);
+  border-color: var(--volt-dim);
+}
+
+.set-toggle.on .knob {
+  left: 18px;
+  background: var(--volt);
+}
+
+.set-toggle.sm {
+  width: 32px;
+  height: 18px;
+}
+
+.set-toggle.sm .knob {
+  width: 13px;
+  height: 13px;
+}
+
+.set-toggle.sm.on .knob {
+  left: 16px;
+}
+
 /* ── Audit log section ──────────────────────────────────────────────────── */
 
 .cn-audit {
@@ -489,6 +656,36 @@
 
 .cn-audit tr:last-child td {
   border-bottom: 0;
+}
+
+/* ── Gate status strip (v2 source) ──────────────────────────────────────── */
+.gate-strip {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 16px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  background: var(--bg-panel);
+  margin-bottom: 16px;
+  font-size: 12px;
+  color: var(--text-mid);
+  flex-wrap: wrap;
+}
+
+.gate-strip .sep {
+  width: 1px;
+  height: 16px;
+  background: var(--border-soft);
+}
+
+.gate-strip b {
+  color: var(--text-bright);
+  font-weight: 600;
+}
+
+.gate-strip .mono {
+  font-size: 11px;
 }
 
 /* ── Detail drawer (config / test / events) ─────────────────────────────── */

--- a/dashboard/src/styles/copilot-dock.css
+++ b/dashboard/src/styles/copilot-dock.css
@@ -185,7 +185,7 @@
 .topbar-copilot:hover { border-color: var(--volt-dim); color: var(--volt-strong); }
 .topbar-copilot.on { border-color: var(--volt); color: var(--volt-strong); background: var(--volt-wash); }
 .topbar-copilot .spark { width: 14px; height: 14px; }
-.topbar-copilot kbd { font-family: var(--font-mono); font-size: 9px; padding: 1px 4px; border-radius: var(--radius-xs); background: var(--bg-card); border: 1px solid var(--border-main); color: var(--text-mid); }
+.topbar-copilot kbd { font-family: var(--font-mono); font-size: 9px; padding: 1px 4px; border-radius: var(--radius-xs); background: var(--bg-card); border: 1px solid var(--border-main); color: var(--text-dim); /* v2 source override */ }
 
 @media (max-width: 1180px) {
   .dock.docked { width: 320px; }

--- a/dashboard/src/styles/craft-v2.css
+++ b/dashboard/src/styles/craft-v2.css
@@ -65,6 +65,45 @@
   margin-top: var(--twk-gap-card);
 }
 
+/* ── Component-level density tweaks from v2 source ────────────── */
+/* Chat console */
+.v2-app[data-density="spacious"] .chat-head    { padding: 18px 28px 16px; gap: 16px; }
+.v2-app[data-density="spacious"] .thread       { padding: 34px 0 14px; }
+.v2-app[data-density="spacious"] .thread-inner { gap: 30px; padding: 0 40px; }
+.v2-app[data-density="spacious"] .msg          { gap: 15px; }
+.v2-app[data-density="spacious"] .bubble       { padding: 17px 21px; line-height: 1.7; }
+.v2-app[data-density="spacious"] .composer     { padding: 16px 30px 22px; }
+.v2-app[data-density="spacious"] .ctx-scroll   { padding: 20px; gap: 22px; }
+.v2-app[data-density="spacious"] .ctx-card,
+.v2-app[data-density="spacious"] .tps-card      { padding: 14px 15px; }
+.v2-app[data-density="spacious"] .roster-head  { padding: 15px 14px; }
+.v2-app[data-density="spacious"] .roster-list  { padding: 9px 8px; }
+.v2-app[data-density="spacious"] .kp-row       { padding: 11px 11px; }
+.v2-app[data-density="spacious"] .roster-filters { padding: 12px 14px; }
+
+/* Board */
+.v2-app[data-density="spacious"] .bd-feed-head     { padding: 15px 24px; }
+.v2-app[data-density="spacious"] .bd-list          { padding: 20px 24px; gap: 14px; }
+.v2-app[data-density="spacious"] .bd-rail          { padding: 18px 12px; }
+.v2-app[data-density="spacious"] .bd-composer      { padding: 14px 24px 18px; }
+.v2-app[data-density="spacious"] .bd-detail-h      { padding: 16px 18px; }
+.v2-app[data-density="spacious"] .bd-detail-scroll { padding: 18px; gap: 14px; }
+
+/* Settings */
+.v2-app[data-density="spacious"] .settings-surf .set-card-b { padding: 12px 40px 56px; }
+.v2-app[data-density="spacious"] .set-content-h { padding: 26px 40px 18px; }
+.v2-app[data-density="spacious"] .set-row       { padding: 16px 0; }
+.v2-app[data-density="spacious"] .set-nav-item  { padding: 11px 13px; }
+
+/* Compact overrides */
+.v2-app[data-density="compact"] .thread        { padding: 14px 0 6px; }
+.v2-app[data-density="compact"] .thread-inner  { gap: 14px; padding: 0 22px; }
+.v2-app[data-density="compact"] .chat-head     { padding: 10px 16px 9px; }
+.v2-app[data-density="compact"] .composer      { padding: 9px 18px 12px; }
+.v2-app[data-density="compact"] .ctx-scroll    { padding: 11px; gap: 12px; }
+.v2-app[data-density="compact"] .bd-list       { padding: 11px 14px; gap: 8px; }
+.v2-app[data-density="compact"] .set-row       { padding: 10px 0; }
+
 /* ── Motion ───────────────────────────────────────────────────── */
 .v2-app[data-motion]:not([data-motion="off"]) button,
 .v2-app[data-motion]:not([data-motion="off"]) [role="button"],
@@ -79,11 +118,73 @@
               transform var(--dur-fast) var(--ease-out);
 }
 
+/* Specific v2 controls that need the same transition package. */
+.v2-app .act, .v2-app .send, .v2-app .rfilter, .v2-app .bd-filter,
+.v2-app .bd-sub, .v2-app .log-f, .v2-app .set-verify, .v2-app .set-seg-b,
+.v2-app .cp-mode, .v2-app .fbk-btn, .v2-app .chip, .v2-app .tps-range,
+.v2-app .set-add, .v2-app .ctool, .v2-app .nav-item, .v2-app .turn-tab,
+.v2-app .bd-react, .v2-app .bd-comp-tab, .v2-app .cn-config,
+.v2-app .set-stepper button, .v2-app .turn-close, .v2-app .rail-toggle,
+.v2-app .topbar-copilot, .v2-app .dock-fab {
+  transition: background var(--dur) var(--ease-out),
+              border-color var(--dur) var(--ease-out),
+              color var(--dur) var(--ease-out),
+              box-shadow var(--dur) var(--ease-out),
+              transform var(--dur-fast) var(--ease-out);
+}
+
 /* Press sink on active controls. */
 .v2-app[data-motion]:not([data-motion="off"]) button:active,
 .v2-app[data-motion]:not([data-motion="off"]) [role="button"]:active {
   transform: translateY(var(--press));
 }
+
+/* Specific v2 controls — press sink (v2 source). */
+.v2-app[data-motion]:not([data-motion="off"]) .act:active,
+.v2-app[data-motion]:not([data-motion="off"]) .send:not(:disabled):active,
+.v2-app[data-motion]:not([data-motion="off"]) .rfilter:active,
+.v2-app[data-motion]:not([data-motion="off"]) .bd-filter:active,
+.v2-app[data-motion]:not([data-motion="off"]) .bd-sub:active,
+.v2-app[data-motion]:not([data-motion="off"]) .log-f:active,
+.v2-app[data-motion]:not([data-motion="off"]) .set-verify:active,
+.v2-app[data-motion]:not([data-motion="off"]) .set-seg-b:active,
+.v2-app[data-motion]:not([data-motion="off"]) .cp-mode:active,
+.v2-app[data-motion]:not([data-motion="off"]) .fbk-btn:active,
+.v2-app[data-motion]:not([data-motion="off"]) .chip:active,
+.v2-app[data-motion]:not([data-motion="off"]) .tps-range:active,
+.v2-app[data-motion]:not([data-motion="off"]) .set-add:active,
+.v2-app[data-motion]:not([data-motion="off"]) .ctool:active,
+.v2-app[data-motion]:not([data-motion="off"]) .bd-react:active,
+.v2-app[data-motion]:not([data-motion="off"]) .turn-tab:active,
+.v2-app[data-motion]:not([data-motion="off"]) .cn-config:active,
+.v2-app[data-motion]:not([data-motion="off"]) .topbar-copilot:active,
+.v2-app[data-motion]:not([data-motion="off"]) .set-nav-item:active {
+  transform: translateY(var(--press));
+}
+
+/* Hover lift on genuine cards. */
+.v2-app .ov-keeper, .v2-app .cp-route, .v2-app .cp-mode,
+.v2-app .cn-card, .v2-app .bd-post {
+  transition: background var(--dur) var(--ease-out),
+              border-color var(--dur) var(--ease-out),
+              box-shadow var(--dur) var(--ease-out),
+              transform var(--dur) var(--ease-out);
+}
+.v2-app[data-motion]:not([data-motion="off"]) .ov-keeper:hover,
+.v2-app[data-motion]:not([data-motion="off"]) .cp-route:hover,
+.v2-app[data-motion]:not([data-motion="off"]) .cn-card:hover {
+  transform: translateY(var(--lift));
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--volt-wash);
+}
+.v2-app[data-motion]:not([data-motion="off"]) .bd-post:hover {
+  transform: translateY(var(--lift));
+  box-shadow: 0 5px 16px rgba(0, 0, 0, 0.38);
+}
+
+/* Avatar / sigil micro-zoom. */
+.v2-app .kp-av, .v2-app .roster .sigil { transition: transform var(--dur) var(--ease-out); }
+.v2-app[data-motion="lively"] .kp-row:hover .kp-av,
+.v2-app[data-motion="lively"] .kp-row:hover .sigil { transform: scale(1.06); }
 
 /* Lively tier. */
 .v2-app[data-motion="lively"] {
@@ -91,11 +192,26 @@
 }
 
 .v2-app[data-motion="lively"] .card:hover,
-.v2-app[data-motion="lively"] [class*="-card"]:not(.twk-panel):not(.twk-panel *):hover {
+.v2-app[data-motion="lively"] [class*="-card"]:not(.twk-panel):not(.twk-panel *):hover,
+.v2-app[data-motion="lively"] .ov-keeper:hover,
+.v2-app[data-motion="lively"] .cp-route:hover,
+.v2-app[data-motion="lively"] .cn-card:hover,
+.v2-app[data-motion="lively"] .bd-post:hover {
   transition-timing-function: var(--ease-spring);
 }
+.v2-app[data-motion="lively"] .send:not(:disabled):hover {
+  box-shadow: 0 0 22px var(--volt-glow), 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+.v2-app[data-motion="lively"] .nav-item:hover { transform: translateY(-1px); }
+.v2-app[data-motion="lively"] .chip:hover { transform: translateY(-2px); }
 
-/* Off tier — kill motion (also reduced-motion is respected via base). */
+/* Trace / tool body reveal. */
+.v2-app .reason-detail, .v2-app .tool-body2 {
+  animation: fade-soft var(--dur) var(--ease-out);
+}
+@keyframes fade-soft { from { opacity: 0; } to { opacity: 1; } }
+
+/* Off tier — kill motion. */
 .v2-app[data-motion="off"] *,
 .v2-app[data-motion="off"] *::before,
 .v2-app[data-motion="off"] *::after {
@@ -103,14 +219,24 @@
   animation: none !important;
 }
 
-/* Keyboard focus ring consistency. */
+@media (prefers-reduced-motion: reduce) {
+  .v2-app *, .v2-app *::before, .v2-app *::after {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+  }
+}
+
+/* Keyboard focus ring consistency — v2 source override. */
 .v2-app a:focus-visible,
 .v2-app button:focus-visible,
 .v2-app [role="button"]:focus-visible,
-.v2-app [tabindex]:not([tabindex="-1"]):focus-visible {
+.v2-app [tabindex]:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px var(--color-bg-page), 0 0 0 4px var(--color-accent-fg-dim, var(--accent-15));
+  box-shadow: 0 0 0 2px var(--bg-deep), 0 0 0 4px var(--volt-dim);
+  border-radius: var(--radius-sm);
 }
+.v2-app textarea:focus-visible,
+.v2-app input:focus-visible { outline: none; }
 
 /* ── Bubble style ─────────────────────────────────────────────── */
 .v2-app[data-bubble="flat"] .bubble {
@@ -127,18 +253,60 @@
   border-radius: 0;
   padding: 2px 0 2px 16px;
 }
+.v2-app[data-bubble="flat"] .bubble code,
+.v2-app[data-bubble="flat"] .bubble .md-table,
+.v2-app[data-bubble="flat"] .bubble .callout {
+  /* nested chrome stays — only the outer shell flattens */
+}
+.v2-app[data-bubble="flat"] .msg.from-user .bubble.user {
+  border-left: 0;
+  border-right: 2px solid var(--color-accent-fg-dim, var(--accent-15));
+  padding: 2px 16px 2px 0;
+  text-align: left;
+}
 
 /* ── Scrollbar treatment ──────────────────────────────────────── */
 .v2-app .dashboard-main-scroll::-webkit-scrollbar,
-.v2-app .v2-shell-rail::-webkit-scrollbar {
+.v2-app .v2-shell-rail::-webkit-scrollbar,
+.v2-app .thread::-webkit-scrollbar,
+.v2-app .ctx-scroll::-webkit-scrollbar,
+.v2-app .roster-list::-webkit-scrollbar,
+.v2-app .set-content::-webkit-scrollbar,
+.v2-app .set-nav::-webkit-scrollbar,
+.v2-app .bd-list::-webkit-scrollbar,
+.v2-app .bd-detail-scroll::-webkit-scrollbar,
+.v2-app .bd-rail::-webkit-scrollbar,
+.v2-app .log-stream::-webkit-scrollbar,
+.v2-app .turn-body::-webkit-scrollbar {
   width: 10px;
 }
 
 .v2-app .dashboard-main-scroll::-webkit-scrollbar-thumb,
-.v2-app .v2-shell-rail::-webkit-scrollbar-thumb {
+.v2-app .v2-shell-rail::-webkit-scrollbar-thumb,
+.v2-app .thread::-webkit-scrollbar-thumb,
+.v2-app .ctx-scroll::-webkit-scrollbar-thumb,
+.v2-app .roster-list::-webkit-scrollbar-thumb,
+.v2-app .set-content::-webkit-scrollbar-thumb,
+.v2-app .set-nav::-webkit-scrollbar-thumb,
+.v2-app .bd-list::-webkit-scrollbar-thumb,
+.v2-app .bd-detail-scroll::-webkit-scrollbar-thumb,
+.v2-app .bd-rail::-webkit-scrollbar-thumb,
+.v2-app .log-stream::-webkit-scrollbar-thumb,
+.v2-app .turn-body::-webkit-scrollbar-thumb {
   background: var(--color-border-default);
   border-radius: var(--r-2, 6px);
   border: 2px solid transparent;
+  background-clip: padding-box;
+  transition: background var(--dur);
+}
+
+.v2-app .thread::-webkit-scrollbar-thumb:hover,
+.v2-app .ctx-scroll::-webkit-scrollbar-thumb:hover,
+.v2-app .roster-list::-webkit-scrollbar-thumb:hover,
+.v2-app .set-content::-webkit-scrollbar-thumb:hover,
+.v2-app .bd-list::-webkit-scrollbar-thumb:hover,
+.v2-app .bd-detail-scroll::-webkit-scrollbar-thumb:hover {
+  background: var(--color-border-strong, var(--color-border-default));
   background-clip: padding-box;
 }
 
@@ -146,6 +314,31 @@
   scrollbar-width: thin;
   scrollbar-color: var(--color-border-default) transparent;
 }
+
+/* ── Consistency polish from v2 source ────────────────────────── */
+/* Composer hairline lifts to accent on focus. */
+.v2-app .composer-box.focus { box-shadow: 0 0 0 3px var(--volt-wash); }
+
+/* Shared focus halo for text inputs. */
+.v2-app .set-input:focus,
+.v2-app .roster-search:focus,
+.v2-app .cn-be-chn:focus,
+.v2-app .kc-text:focus {
+  box-shadow: 0 0 0 2px var(--volt-wash);
+}
+
+/* Section headers keep an even baseline rhythm in the context rail. */
+.v2-app .ctx-sec + .ctx-sec { margin-top: 2px; }
+
+/* Top-bar stat chips: quiet hover. */
+.v2-app .v2-statchip { transition: border-color var(--dur), color var(--dur); }
+
+/* Disabled send reads clearly inert. */
+.v2-app .send:disabled { transform: none; }
+
+/* Compaction-snapshot trigger sub-label alignment. */
+.v2-app .cmp-open { flex-wrap: wrap; align-items: baseline; row-gap: 3px; }
+.v2-app .cmp-open-sub { margin-left: auto; }
 
 /* ═══════════════════════════════════════════════════════════════
    Tweaks panel chrome — self-contained, does not depend on the

--- a/dashboard/src/styles/keeper-turn-inspector.css
+++ b/dashboard/src/styles/keeper-turn-inspector.css
@@ -371,6 +371,7 @@
   height: 12px;
   border-radius: 3px;
   min-width: 4px;
+  transition: none; /* v2 source: waterfall bars are not animated */
 }
 
 .kti-wf-dur {
@@ -769,4 +770,11 @@
     grid-template-columns: 110px 1fr 48px;
     gap: 8px;
   }
+}
+
+/* Drawer entrance from v2 source — transform-only so a backgrounded tab
+   never holds the drawer invisible. */
+@keyframes turn-in {
+  from { transform: translateX(18px); }
+  to   { transform: none; }
 }

--- a/dashboard/src/styles/memory-v2.css
+++ b/dashboard/src/styles/memory-v2.css
@@ -10,6 +10,9 @@
 }
 
 .mg-board {
+  --kp1: #e0b057;
+  --kp3: #e0a82e;
+  --kp9: #5b9cf0;
   box-sizing: border-box;
   height: 100%;
   padding: 14px 16px 16px;
@@ -140,7 +143,7 @@
   flex: none;
   font-family: var(--font-mono);
   font-weight: 700;
-  color: var(--color-bg-page);
+  color: #0b0c10; /* v2 source override */
   background: var(--kc);
   border-radius: var(--radius-xs);
 }

--- a/dashboard/src/styles/skin-v2.css
+++ b/dashboard/src/styles/skin-v2.css
@@ -26,6 +26,7 @@ html[data-skin="v2"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
   --bg-card:        #1b1c25;
   --bg-card-hover:  #23242f;
   --bg-sunken:      #0a0b0f;
+  --bg-well:        #06070a;   /* deepest: code/shell/tool wells inside cards */
 
   /* Borders — crisper, cooler */
   --border-main:      #282a36;
@@ -69,6 +70,7 @@ html[data-skin="v2"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
   --volt-ink:    #1a1405;
   --volt-glow:   rgba(224,176,87,0.22);
   --volt-wash:   rgba(224,176,87,0.10);
+  --volt-rgb:    224 176 87;
 
   /* Radius scale — engraved, tiny corners (brand: 2/4/6/…). One ladder;
      literals below recovered into these tokens. */
@@ -114,12 +116,78 @@ html[data-skin="v2"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
 html[data-skin="v2"][data-volt="blood"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
   --volt: var(--accent-blood); --volt-strong: #ff6a4d; --volt-dim: var(--accent-blood-dim);
   --volt-ink: #ffffff; --volt-glow: rgba(232,71,47,0.26); --volt-wash: rgba(232,71,47,0.10);
+  --volt-rgb: 232 71 47;
 }
 html[data-skin="v2"][data-volt="ice"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
   --volt: var(--accent-ice); --volt-strong: #7ad8f6; --volt-dim: var(--accent-ice-dim);
   --volt-ink: #04121a; --volt-glow: rgba(70,198,240,0.24); --volt-wash: rgba(70,198,240,0.09);
+  --volt-rgb: 70 198 240;
   /* primary is now cyan → shift the info accent to violet to stay distinct */
   --info: #8a6cf0; --info-dim: #4a3aa0;
+}
+
+/* ════════════════════════════════════════════════════════════
+   PAPER — light reading theme. The same v2 semantic spine and
+   voltage system, surfaces flipped to warm paper-white so long
+   conversations read like a printed document (high contrast,
+   airy). Toggled via html[data-theme="paper"].
+   Source: keeper-v2/styles/v2.css lines 121-173.
+   ════════════════════════════════════════════════════════════ */
+html[data-skin="v2"][data-theme="paper"] {
+  color-scheme: light;
+  --bg-deep:        #f1f2f5;
+  --bg-panel:       #fafbfc;
+  --bg-panel-alt:   #ffffff;
+  --bg-card:        #ffffff;
+  --bg-card-hover:  #eef0f3;
+  --bg-sunken:      #f3f4f7;
+  --bg-well:        #eef0f3;
+
+  --border-main:      rgba(22,24,29,0.12);
+  --border-soft:      rgba(22,24,29,0.07);
+  --border-highlight: rgba(22,24,29,0.22);
+
+  --text-bright:  #16181d;
+  --text-primary: #2f3137;
+  --text-mid:     #565962;
+  --text-dim:     #797d86;
+
+  /* status — darkened for legibility on white */
+  --status-ok:    #17803d;
+  --status-warn:  #b45309;
+  --status-bad:   #b42318;
+  --status-idle:  #9298a2;
+  --status-busy:  #1e6fa8;
+
+  --info:     #2d6cdf;
+  --info-dim: #1e54bc;
+
+  /* soft ink shadows instead of black drop shadows */
+  --shadow-card:   0 1px 2px rgba(22,24,29,0.07);
+  --shadow-panel:  0 4px 18px rgba(22,24,29,0.10);
+  --shadow-pop:    0 12px 32px rgba(22,24,29,0.16), 0 0 0 1px var(--border-main);
+  --shadow-glow:   0 0 0 1px var(--volt-dim);
+
+  /* default voltage (brass) deepened so gold reads on white */
+  --volt:        #b07d1a;
+  --volt-strong: #8c5e0f;
+  --volt-dim:    #e2c987;
+  --volt-ink:    #ffffff;
+  --volt-glow:   rgba(176,125,26,0.16);
+  --volt-wash:   rgba(176,125,26,0.10);
+  --volt-rgb:    176 125 26;
+  --accent-glow: var(--volt-glow);
+}
+html[data-skin="v2"][data-theme="paper"][data-volt="blood"] {
+  --volt: #b42318; --volt-strong: #8f1b12; --volt-dim: #f0b4ad;
+  --volt-ink: #ffffff; --volt-glow: rgba(180,35,24,0.16); --volt-wash: rgba(180,35,24,0.09);
+  --volt-rgb: 180 35 24;
+}
+html[data-skin="v2"][data-theme="paper"][data-volt="ice"] {
+  --volt: #1e6fa8; --volt-strong: #155888; --volt-dim: #a8d4ea;
+  --volt-ink: #ffffff; --volt-glow: rgba(30,111,168,0.16); --volt-wash: rgba(30,111,168,0.09);
+  --volt-rgb: 30 111 168;
+  --info: #7a4fd0; --info-dim: #5a37a0;
 }
 
 /* ══════════════════════════════════════════════════════════════
@@ -215,6 +283,100 @@ html[data-skin="v2"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
   --info-glow: 70 198 240; --color-info-glow: 70 198 240;
 
   /* Fonts — clean grotesque, no Cinzel */
+  --font-sans: var(--font-ui);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   BRIDGE — PAPER variant
+   Re-point the dashboard's consumed tokens at the v2 paper spine
+   so existing components render correctly under data-theme="paper"
+   when data-skin="v2". Loaded after paper-theme.css, so it wins for
+   v2-branded paper surfaces.
+   ══════════════════════════════════════════════════════════════ */
+html[data-skin="v2"][data-theme="paper"] {
+  /* Surfaces */
+  --color-bg-0: var(--bg-deep);   --bg-0: var(--bg-deep);
+  --color-bg-1: var(--bg-panel);  --bg-1: var(--bg-panel);
+  --color-bg-2: var(--bg-panel-alt); --bg-2: var(--bg-panel-alt);
+  --color-bg-3: var(--bg-card);   --bg-3: var(--bg-card);
+  --color-bg-4: var(--bg-card-hover); --bg-4: var(--bg-card-hover);
+  --color-bg-page: var(--bg-deep);
+  --color-bg-surface: var(--bg-panel);
+  --color-bg-panel-alt: var(--bg-panel-alt);
+  --color-bg-elevated: var(--bg-card);
+  --color-bg-hover: var(--bg-card-hover);
+  --bg-root: var(--bg-deep);
+  --bg-deepest: var(--bg-sunken);
+  --panel-dark: var(--bg-panel-alt);
+  --bg-panel-hover: var(--bg-card-hover);
+  --shell-header-bg: var(--bg-panel);
+  --shell-rail-bg: var(--bg-panel);
+  --shell-main-bg: var(--bg-deep);
+  --card: var(--bg-card);
+  --color-card: var(--bg-card);
+  --surface-inset: var(--bg-sunken);
+  --bg-subtle: var(--bg-card);
+  --input-bg: var(--bg-sunken);
+
+  /* Borders */
+  --color-line-1: var(--border-main);   --line-1: var(--border-main);
+  --color-line-2: var(--border-highlight); --line-2: var(--border-highlight);
+  --color-line-3: var(--border-soft);   --line-3: var(--border-soft);
+  --color-border-default: var(--border-main);
+  --color-border-strong: var(--border-highlight);
+  --color-border-divider: var(--border-soft);
+  --color-border-subtle: var(--border-soft);
+  --border-base: var(--border-main);
+  --border-subtle: var(--border-soft);
+  --border-strong: var(--border-highlight);
+  --card-border: var(--border-main);
+  --input-border: var(--border-highlight);
+
+  /* Text */
+  --color-fg-1: var(--text-bright);  --fg-1: var(--text-bright);
+  --color-fg-2: var(--text-primary); --fg-2: var(--text-primary);
+  --color-fg-3: var(--text-mid);     --fg-3: var(--text-mid);
+  --color-fg-4: var(--text-dim);     --fg-4: var(--text-dim);
+  --color-fg-primary: var(--text-bright);
+  --color-fg-secondary: var(--text-primary);
+  --color-fg-muted: var(--text-mid);
+  --color-fg-disabled: var(--text-dim);
+  --text-strong: var(--text-bright);
+  --text-body: var(--text-primary);
+  --text-muted: var(--text-mid);
+  --text: var(--text-primary);
+
+  /* Accent = voltage */
+  --color-accent-fg: var(--volt);
+  --color-accent-fg-dim: var(--volt-dim);
+  --color-accent: var(--volt);
+  --color-accent-soft: var(--volt-wash);
+  --color-accent-glow: var(--volt-rgb);
+  --accent: var(--volt);
+  --accent-soft: var(--volt-wash);
+  --accent-glow: var(--volt-glow);
+  --brass-1: var(--volt);  --color-brass-1: var(--volt);
+  --brass-2: var(--volt-strong); --color-brass-2: var(--volt-strong);
+  --brass-3: var(--volt-dim);    --color-brass-3: var(--volt-dim);
+  --brass-fg: var(--volt); --color-brass-fg: var(--volt);
+  --brass-soft: var(--volt-wash); --color-brass-soft: var(--volt-wash);
+  --brass-glow: var(--volt-rgb);  --color-brass-glow: var(--volt-rgb);
+  --select: var(--volt);
+  --select-10: var(--volt-wash);
+  --select-20: var(--volt-glow);
+
+  /* Status */
+  --ok: var(--status-ok);   --color-ok: var(--status-ok);   --color-status-ok: var(--status-ok);
+  --warn: var(--status-warn); --color-warn: var(--status-warn); --color-status-warn: var(--status-warn);
+  --err: var(--status-bad); --bad: var(--status-bad); --color-err: var(--status-bad); --color-status-err: var(--status-bad);
+  --color-info: var(--info); --color-status-info: var(--info);
+  --idle: var(--status-idle); --color-idle: var(--status-idle); --color-status-idle: var(--status-idle);
+  --ok-glow: 23 128 61;    --color-ok-glow: 23 128 61;
+  --warn-glow: 180 83 9;   --color-warn-glow: 180 83 9;
+  --err-glow: 180 35 24;   --color-err-glow: 180 35 24;
+  --info-glow: 45 109 223; --color-info-glow: 45 109 223;
+
+  /* Fonts */
   --font-sans: var(--font-ui);
 }
 

--- a/dashboard/src/styles/states.css
+++ b/dashboard/src/styles/states.css
@@ -63,6 +63,12 @@
   margin-top: 4px;
 }
 
+/* v2 source keeps the action margin on any button inside the state surface. */
+.kv-state .act,
+.kv-state button {
+  margin-top: 4px;
+}
+
 /* Loading skeleton */
 .kv-state.loading {
   align-items: stretch;

--- a/dashboard/src/styles/telemetry-v2.css
+++ b/dashboard/src/styles/telemetry-v2.css
@@ -293,3 +293,57 @@
     animation: none;
   }
 }
+
+/* ───────────────────────────────────────────────────────────────
+   PERFORMANCE LAYER (keeper-v2 perf.css port)
+   VirtualList / CVList scrollers, native <dialog> chrome, and the
+   demo FPS meter. v2 source is SSOT for behavior.
+   ─────────────────────────────────────────────────────────────── */
+
+/* ── VirtualList / CVList scrollers ── */
+.vl-scroller { scrollbar-width: thin; }
+.vl-scroller::-webkit-scrollbar { width: 10px; }
+.vl-scroller::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: 6px; border: 2px solid transparent; background-clip: padding-box; }
+.vl-row { box-sizing: border-box; }
+.cv-list { display: flex; flex-direction: column; }
+.cv-row { box-sizing: border-box; }
+
+/* ── native <dialog> ── */
+.v2-dialog {
+  border: 1px solid var(--border-main);
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  border-radius: var(--radius-lg, 12px);
+  padding: 0;
+  box-shadow: 0 24px 64px -12px rgba(0,0,0,0.7), 0 0 0 1px var(--border-soft);
+  max-width: min(92vw, 560px);
+  width: 100%;
+}
+.v2-dialog::backdrop {
+  background: color-mix(in oklab, var(--bg-deep) 64%, transparent);
+  backdrop-filter: blur(3px);
+  animation: v2dlg-bd 0.18s ease;
+}
+.v2-dialog[open] { animation: v2dlg-in 0.2s cubic-bezier(0.2, 0.8, 0.2, 1); }
+@keyframes v2dlg-in { from { opacity: 0; transform: translateY(8px) scale(0.98); } }
+@keyframes v2dlg-bd { from { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  .v2-dialog[open], .v2-dialog::backdrop { animation: none; }
+}
+
+/* ── FPS meter (demo) ── */
+.fps-meter {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 11.5px; letter-spacing: 0.02em;
+  padding: 4px 10px; border-radius: 999px;
+  border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-mid);
+}
+.fps-meter b { color: var(--text-bright); font-weight: 600; }
+.fps-meter .fps-label { color: var(--text-dim); margin-right: 2px; }
+.fps-meter .fps-low { color: var(--text-dim); }
+.fps-meter .fps-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--text-dim); }
+.fps-meter.ok .fps-dot { background: var(--status-ok); box-shadow: 0 0 7px var(--status-ok); }
+.fps-meter.warn .fps-dot { background: var(--status-warn, #e0a82e); box-shadow: 0 0 7px var(--status-warn, #e0a82e); }
+.fps-meter.bad .fps-dot { background: var(--status-bad, #e8472f); box-shadow: 0 0 7px var(--status-bad, #e8472f); }
+.fps-meter.ok b { color: var(--status-ok); }
+.fps-meter.bad b { color: var(--status-bad, #e8472f); }


### PR DESCRIPTION
This PR treats `/Users/dancer/Downloads/v2 (11)/keeper-v2/` as the single source of truth and merges missing paper/dark design-system deltas into `dashboard/`.

## What changed
- `skin-v2.css`: added the v2 paper theme block, voltage variants for paper, and a paper-specific bridge so existing dashboard tokens resolve correctly in light mode.
- Fixed missing `--volt-rgb` (used by `--color-accent-glow`).
- `index.html` + `main.ts`: default `data-volt` is now `brass` (matching the v2 source) with a runtime guarantee.
- `main.ts`: removed duplicate `styleseed-theme.css` and `states.css` imports.
- Merged deltas from keeper-v2 styles into dashboard v2 files:
  - `craft.css` → `craft-v2.css`
  - `surfaces.css` → `connectors-v2.css`, `cockpit-v2.css`
  - `dock.css` → `copilot-dock.css`
  - `memory.css` → `memory-v2.css`
  - `inspector.css` → `keeper-turn-inspector.css`
  - `states.css` → `states.css`
  - `perf.css` / `indicators.css` → `telemetry-v2.css`

## Verification
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm build` ✅