### PR TITLE
fix(dashboard): restore missing chat.css import

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -36,6 +36,7 @@ import './styles/styleseed-base.css'
 
 // Global utilities and layout
 import './styles/global.css'
+import './styles/chat.css'
 import './styles/chat-blocks-v2.css'
 import './styles/surfaces-v2.css'
 import './styles/cockpit-v2.css'
@@ -43,7 +44,6 @@ import './styles/cockpit-v2.css'
 // Component-specific styles
 import './styles/ui.css'
 import './styles/board.css'
-/* chat.css: styles merged into global.css @utility blocks (#3915) */
 import './styles/dashboard.css'
 import './styles/governance.css'
 import './styles/governance-agent.css'


### PR DESCRIPTION
dashboard/src/styles/chat.css defines the chat-bubble/chat-avatar/chat-role-chip utilities, artifact/lightbox preview styles, and audio-clip styles used by the chat primitives. It has not been imported since main.ts was introduced (#21109); the comment saying it was merged into global.css was incorrect, and global.css does not contain those rules. As a result, chat bubbles, rich artifact previews, and lightbox markdown/code viewers were unstyled or appeared broken.

Changes:
- Import `./styles/chat.css` in `dashboard/src/main.ts`, placed before `chat-blocks-v2.css` so v2 block styles still win on overlapping selectors.
- Remove the misleading comment.

Verification:
- `pnpm build` succeeds.
- `pnpm typecheck` passes.
- `pnpm vitest run src/components/chat/primitives.test.ts src/components/chat/markdown-blocks.test.ts src/components/chat/primitives.a11y.test.ts` → 73/73 pass.