### PR TITLE
refactor(mutex): Phase 1 cluster — 15 general-domain files to Mutex.protect (RFC-0255)

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -139,31 +139,23 @@ module FileSystem = struct
       the shared hashtable.  Uses [Stdlib.Mutex] + [Fun.protect]. *)
 
   let ki_replace t k v =
-    Mutex.lock t.key_index_mu;
-    Fun.protect ~finally:(fun () -> Mutex.unlock t.key_index_mu)
-      (fun () -> Hashtbl.replace t.key_index k v)
+    Mutex.protect t.key_index_mu (fun () -> Hashtbl.replace t.key_index k v)
 
   let ki_remove t k =
-    Mutex.lock t.key_index_mu;
-    Fun.protect ~finally:(fun () -> Mutex.unlock t.key_index_mu)
-      (fun () -> Hashtbl.remove t.key_index k)
+    Mutex.protect t.key_index_mu (fun () -> Hashtbl.remove t.key_index k)
 
   let ki_length t =
-    Mutex.lock t.key_index_mu;
-    Fun.protect ~finally:(fun () -> Mutex.unlock t.key_index_mu)
-      (fun () -> Hashtbl.length t.key_index)
+    Mutex.protect t.key_index_mu (fun () -> Hashtbl.length t.key_index)
 
   let ki_iter t f =
     let entries =
-      Mutex.lock t.key_index_mu;
-      Fun.protect ~finally:(fun () -> Mutex.unlock t.key_index_mu) (fun () ->
+      Mutex.protect t.key_index_mu (fun () ->
         Hashtbl.fold (fun k v acc -> (k, v) :: acc) t.key_index [])
     in
     List.iter (fun (k, v) -> f k v) entries
 
   let ki_replace_bulk t entries =
-    Mutex.lock t.key_index_mu;
-    Fun.protect ~finally:(fun () -> Mutex.unlock t.key_index_mu) (fun () ->
+    Mutex.protect t.key_index_mu (fun () ->
       List.iter (fun (k, v) -> Hashtbl.replace t.key_index k v) entries)
 
   (** {2 Key Validation} *)
@@ -458,8 +450,7 @@ module FileSystem = struct
        The mutex is released BEFORE Eio.Promise.await (which needs Eio
        fiber context and would deadlock under a held Stdlib.Mutex). *)
     let action =
-      Mutex.lock t.key_index_mu;
-      Fun.protect ~finally:(fun () -> Mutex.unlock t.key_index_mu) (fun () ->
+      Mutex.protect t.key_index_mu (fun () ->
         (* Direct Hashtbl access — already inside key_index_mu lock.
            ki_length would deadlock (non-reentrant mutex). *)
         if Hashtbl.length t.key_index > 0 then `Done
@@ -509,8 +500,7 @@ module FileSystem = struct
          Eio.Promise.resolve_ok r ();
          `Ready
        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-         Mutex.lock t.key_index_mu;
-         Fun.protect ~finally:(fun () -> Mutex.unlock t.key_index_mu) (fun () ->
+         Mutex.protect t.key_index_mu (fun () ->
            t.key_index_promise <- None);
          Eio.Promise.resolve_error r exn;
          match exn with

--- a/lib/context_overflow_action_tracker.ml
+++ b/lib/context_overflow_action_tracker.ml
@@ -25,9 +25,7 @@ type keeper_state = {
 let state : (string, keeper_state) Hashtbl.t = Hashtbl.create 16
 let mu = Stdlib.Mutex.create ()
 
-let with_lock f =
-  Stdlib.Mutex.lock mu;
-  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock mu) f
+let with_lock f = Stdlib.Mutex.protect mu f
 
 let get_or_create keeper_name =
   match Hashtbl.find_opt state keeper_name with

--- a/lib/dashboard/dashboard_execute_output.ml
+++ b/lib/dashboard/dashboard_execute_output.ml
@@ -82,9 +82,7 @@ let now_unix () =
   (* NDT-OK: runtime freshness timestamp only; not a deterministic input. *)
   Unix.gettimeofday ()
 
-let with_lock f =
-  Mutex.lock mu;
-  Fun.protect ~finally:(fun () -> Mutex.unlock mu) f
+let with_lock f = Mutex.protect mu f
 
 let queue_to_list q =
   Queue.fold (fun acc value -> value :: acc) [] q |> List.rev

--- a/lib/dashboard_attribution.ml
+++ b/lib/dashboard_attribution.ml
@@ -11,9 +11,7 @@ let mu = Mutex.create ()
 let table : (string, (Attribution.t * float) Queue.t) Hashtbl.t =
   Hashtbl.create 8
 
-let with_lock f =
-  Mutex.lock mu;
-  Fun.protect ~finally:(fun () -> Mutex.unlock mu) f
+let with_lock f = Mutex.protect mu f
 
 let record_with_time ~now (attr : Attribution.t) =
   with_lock (fun () ->

--- a/lib/jsonl_atomic/jsonl_atomic.ml
+++ b/lib/jsonl_atomic/jsonl_atomic.ml
@@ -45,9 +45,7 @@ let canonicalize_path path =
   if joined = "" then "/" else joined
 
 let get_or_create_mutex key =
-  Stdlib.Mutex.lock mutex_registry_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock mutex_registry_mu)
+  Stdlib.Mutex.protect mutex_registry_mu
     (fun () ->
       match Hashtbl.find_opt mutex_registry key with
       | Some m -> m

--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -6,9 +6,7 @@ let fallback_triggered_metric = Otel_metric_store.metric_fallback_triggered
 let provider_cache : (string, string) Hashtbl.t = Hashtbl.create 64
 let provider_cache_mu = Stdlib.Mutex.create ()
 
-let with_provider_cache_lock f =
-  Stdlib.Mutex.lock provider_cache_mu;
-  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock provider_cache_mu) f
+let with_provider_cache_lock f = Stdlib.Mutex.protect provider_cache_mu f
 ;;
 
 let contains_substring haystack needle =

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -387,9 +387,7 @@ module Ring = struct
 
   let write_to_sink entry_json =
     rotate_if_needed ();
-    Stdlib.Mutex.lock sink_mutex;
-    Fun.protect
-      ~finally:(fun () -> Stdlib.Mutex.unlock sink_mutex)
+    Stdlib.Mutex.protect sink_mutex
       (fun () ->
         (* Self-heal: if a prior rotate left [file_channel = None]
            (open failure) but the base dir is still configured, try

--- a/lib/runtime/dashboard_oas_bridge.ml
+++ b/lib/runtime/dashboard_oas_bridge.ml
@@ -39,9 +39,7 @@ let mu = Mutex.create ()
 let table : (string, (sample * float) Queue.t) Hashtbl.t =
   Hashtbl.create 8
 
-let with_lock f =
-  Mutex.lock mu;
-  Fun.protect ~finally:(fun () -> Mutex.unlock mu) f
+let with_lock f = Mutex.protect mu f
 
 let status_to_yojson = function
   | Success -> `Assoc [ ("kind", `String "success") ]

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -618,10 +618,7 @@ let full_health_snapshot_ttl_sec =
 ;;
 
 let with_full_health_snapshot_lock f =
-  Stdlib.Mutex.lock full_health_snapshot_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock full_health_snapshot_mu)
-    f
+  Stdlib.Mutex.protect full_health_snapshot_mu f
 
 let full_health_cached_field_names =
   [

--- a/lib/subsystem_health.ml
+++ b/lib/subsystem_health.ml
@@ -13,11 +13,7 @@
 let registry : (string, bool * float option) Hashtbl.t = Hashtbl.create 8
 let registry_mu = Stdlib.Mutex.create ()
 
-let with_lock f =
-  Stdlib.Mutex.lock registry_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock registry_mu)
-    f
+let with_lock f = Stdlib.Mutex.protect registry_mu f
 
 let register name =
   with_lock (fun () ->

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -76,9 +76,7 @@ let dropped_full_queue = Atomic.make 0
 
 let store_ref : (string * Dated_jsonl.t) option ref = ref None
 
-let with_write_queue_lock f =
-  Mutex.lock write_queue_mu;
-  Fun.protect ~finally:(fun () -> Mutex.unlock write_queue_mu) f
+let with_write_queue_lock f = Mutex.protect write_queue_mu f
 
 let take_queued_record () =
   with_write_queue_lock (fun () ->

--- a/lib/tool_surface/tool_metrics.ml
+++ b/lib/tool_surface/tool_metrics.ml
@@ -47,11 +47,7 @@ type accumulator = {
 let metrics : accumulator StringMap.t ref = ref StringMap.empty
 let metrics_mu = Stdlib.Mutex.create ()
 
-let with_lock f =
-  Stdlib.Mutex.lock metrics_mu;
-  Stdlib.Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock metrics_mu)
-    f
+let with_lock f = Stdlib.Mutex.protect metrics_mu f
 
 let record (result : Tool_result.result) =
   let tool_name, duration_ms, is_success =

--- a/lib/workspace/mention.ml
+++ b/lib/workspace/mention.ml
@@ -155,9 +155,7 @@ let compile_target_pattern target =
   ]))
 
 let target_re target =
-  Stdlib.Mutex.lock is_mentioned_cache_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock is_mentioned_cache_mu)
+  Stdlib.Mutex.protect is_mentioned_cache_mu
     (fun () ->
       match Hashtbl.find_opt is_mentioned_cache target with
       | Some re -> re

--- a/lib/workspace/playground_repo_cache.ml
+++ b/lib/workspace/playground_repo_cache.ml
@@ -25,10 +25,7 @@ let cache_update_std_mu = Stdlib.Mutex.create ()
    Eio mutex in fibers so same-domain concurrent updates queue cooperatively;
    keep a Stdlib fallback for direct non-Eio test/helper calls. *)
 let with_cache_update_lock f =
-  let with_stdlib_lock () =
-    Stdlib.Mutex.lock cache_update_std_mu;
-    Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock cache_update_std_mu) f
-  in
+  let with_stdlib_lock () = Stdlib.Mutex.protect cache_update_std_mu f in
   let inside_eio =
     try
       Eio.Fiber.check ();

--- a/lib/workspace/workspace_task_cache_invariant.ml
+++ b/lib/workspace/workspace_task_cache_invariant.ml
@@ -112,9 +112,7 @@ let backlog_unavailable_message ~from_agent task_ids =
 let remember_invalidation ~module_name ~task_id ~status =
   let key = String.concat "\x00" [ module_name; task_id; status ] in
   let now = Time_compat.now () in
-  Mutex.lock invalidation_memory_lock;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock invalidation_memory_lock)
+  Mutex.protect invalidation_memory_lock
     (fun () ->
        Hashtbl.filter_map_inplace
          (fun _ ts ->


### PR DESCRIPTION
## What

Phase 1 cluster of RFC-0255 (Mutex.protect migration): migrate **15 general-domain files** with the canonical hand-rolled `Mutex.lock m; Fun.protect ~finally:(unlock m) f` pattern to OCaml 5.1 `Mutex.protect m f`. RFC-0255 is at #21471 (Draft).

This is **group A only** (canonical wrappers + inline single lock/protect/unlock pairs). The inline-multi-site group B (`console_sink`, `mention_dedup`, `masc_http_client`, `server_routes_http_routes_provider_runs`, `server_dashboard_http_link_preview`) is deferred to a follow-up PR — those sites have branches between lock and unlock that each need a closer rewrite.

## Why

`Fun.protect ~finally` runs its `finally` only for synchronous exceptions. An asynchronous exception (`Eio.Cancel.Cancelled`) bypasses the finally and leaves the mutex permanently locked — a deadlock vector. `Mutex.protect` (stdlib >= 5.1) guarantees unlock under async exceptions. All 15 files run under Eio fibers / keeper turns / HTTP handlers where cancellation is reachable.

## Behavior preservation

Every site is a single lock/protect/unlock pair with no early/conditional unlock and no re-entrant lock of the same mutex (RFC-0255 §7 proof method):

1. **Identical lock sequence** — `Mutex.protect m f` and hand-rolled `lock m; f (); unlock m` are the same lock/unlock order on OCaml's non-recursive Mutex.
2. The wrapper helpers (`with_lock`, `with_provider_cache_lock`, `with_write_queue_lock`, `with_full_health_snapshot_lock`, `with_cache_update_lock`'s stdlib branch) collapse to one line.
3. The inline sites (`write_to_sink`, `get_or_create_mutex`, `target_re`, `remember_invalidation`, `backend.ml` 7 key_index sites) wrap a body lambda with no early unlock.

Notable: `backend.ml:461` carries the comment *"mutex released BEFORE Eio.Promise.await"* — `Mutex.protect` preserves this invariant (it unlocks before returning the `Wait p` value, exactly as the hand-rolled `Fun.protect` finally did).

## Verification

- `ocamlformat --check` passes on all 15 files (parsing/format).
- `rg "Mutex\.lock|Fun\.protect.*Mutex|Mutex\.unlock"` over the changed files returns **zero residual hand-rolled sites**.
- Type-checking is delegated to CI (local `dune build` is blocked by the `agent_sdk` opam pin).

## Non-goals (this PR)

- Eio.Mutex primitives (`playground_repo_cache`'s `Eio.Mutex.use_rw ~protect:true` branch) are left unchanged (RFC-0255 Non-goals — already cancellation-safe).
- Group B inline-multi-region sites — separate PR.

## Files (15)

dashboard_attribution, dashboard/dashboard_execute_output, context_overflow_action_tracker, llm_metric_bridge, subsystem_health, server/server_routes_http_runtime, runtime/dashboard_oas_bridge, masc_log/log, jsonl_atomic/jsonl_atomic, tool_metrics_persist, workspace/playground_repo_cache (stdlib branch), workspace/mention, tool_surface/tool_metrics, workspace/workspace_task_cache_invariant, backend/backend (7 sites).

# ci:skip-test-coverage

Co-Authored-By: Claude <noreply@anthropic.com>
