### PR TITLE
fix(dashboard): address review follow-ups from #21480

### DIFF
--- a/dashboard/src/styles/cockpit-v2.css
+++ b/dashboard/src/styles/cockpit-v2.css
@@ -74,7 +74,7 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  background: rgba(8, 9, 13, 0.7); /* v2 source override */
+  background: var(--bg-sunken); /* theme-aware footer surface */
 }
 
 .cp-world-foot .row {

--- a/dashboard/src/styles/craft-v2.css
+++ b/dashboard/src/styles/craft-v2.css
@@ -67,19 +67,19 @@
 
 /* ── Component-level density tweaks from v2 source ────────────── */
 /* Chat console */
-.v2-app[data-density="spacious"] .chat-head    { padding: 18px 28px 16px; gap: 16px; }
-.v2-app[data-density="spacious"] .thread       { padding: 34px 0 14px; }
-.v2-app[data-density="spacious"] .thread-inner { gap: 30px; padding: 0 40px; }
-.v2-app[data-density="spacious"] .msg          { gap: 15px; }
-.v2-app[data-density="spacious"] .bubble       { padding: 17px 21px; line-height: 1.7; }
-.v2-app[data-density="spacious"] .composer     { padding: 16px 30px 22px; }
-.v2-app[data-density="spacious"] .ctx-scroll   { padding: 20px; gap: 22px; }
-.v2-app[data-density="spacious"] .ctx-card,
-.v2-app[data-density="spacious"] .tps-card      { padding: 14px 15px; }
-.v2-app[data-density="spacious"] .roster-head  { padding: 15px 14px; }
-.v2-app[data-density="spacious"] .roster-list  { padding: 9px 8px; }
-.v2-app[data-density="spacious"] .kp-row       { padding: 11px 11px; }
-.v2-app[data-density="spacious"] .roster-filters { padding: 12px 14px; }
+.v2-app[data-density="spacious"] .v2-keeper-chat .chat-head    { padding: 18px 28px 16px; gap: 16px; }
+.v2-app[data-density="spacious"] .v2-keeper-chat .thread       { padding: 34px 0 14px; }
+.v2-app[data-density="spacious"] .v2-keeper-chat .thread-inner { gap: 30px; padding: 0 40px; }
+.v2-app[data-density="spacious"] .v2-keeper-chat .msg          { gap: 15px; }
+.v2-app[data-density="spacious"] .v2-keeper-chat .bubble       { padding: 17px 21px; line-height: 1.7; }
+.v2-app[data-density="spacious"] .v2-keeper-chat .composer     { padding: 16px 30px 22px; }
+.v2-app[data-density="spacious"] .v2-keeper-chat .ctx-scroll   { padding: 20px; gap: 22px; }
+.v2-app[data-density="spacious"] .v2-keeper-chat .ctx-card,
+.v2-app[data-density="spacious"] .v2-keeper-chat .tps-card      { padding: 14px 15px; }
+.v2-app[data-density="spacious"] .v2-keeper-chat .roster-head  { padding: 15px 14px; }
+.v2-app[data-density="spacious"] .v2-keeper-chat .roster-list  { padding: 9px 8px; }
+.v2-app[data-density="spacious"] .v2-keeper-chat .kp-row       { padding: 11px 11px; }
+.v2-app[data-density="spacious"] .v2-keeper-chat .roster-filters { padding: 12px 14px; }
 
 /* Board */
 .v2-app[data-density="spacious"] .bd-feed-head     { padding: 15px 24px; }
@@ -96,11 +96,11 @@
 .v2-app[data-density="spacious"] .set-nav-item  { padding: 11px 13px; }
 
 /* Compact overrides */
-.v2-app[data-density="compact"] .thread        { padding: 14px 0 6px; }
-.v2-app[data-density="compact"] .thread-inner  { gap: 14px; padding: 0 22px; }
-.v2-app[data-density="compact"] .chat-head     { padding: 10px 16px 9px; }
-.v2-app[data-density="compact"] .composer      { padding: 9px 18px 12px; }
-.v2-app[data-density="compact"] .ctx-scroll    { padding: 11px; gap: 12px; }
+.v2-app[data-density="compact"] .v2-keeper-chat .thread        { padding: 14px 0 6px; }
+.v2-app[data-density="compact"] .v2-keeper-chat .thread-inner  { gap: 14px; padding: 0 22px; }
+.v2-app[data-density="compact"] .v2-keeper-chat .chat-head     { padding: 10px 16px 9px; }
+.v2-app[data-density="compact"] .v2-keeper-chat .composer      { padding: 9px 18px 12px; }
+.v2-app[data-density="compact"] .v2-keeper-chat .ctx-scroll    { padding: 11px; gap: 12px; }
 .v2-app[data-density="compact"] .bd-list       { padding: 11px 14px; gap: 8px; }
 .v2-app[data-density="compact"] .set-row       { padding: 10px 0; }
 
@@ -222,7 +222,7 @@
 @media (prefers-reduced-motion: reduce) {
   .v2-app *, .v2-app *::before, .v2-app *::after {
     transition-duration: 0.001ms !important;
-    animation-duration: 0.001ms !important;
+    animation: none !important;
   }
 }
 
@@ -236,7 +236,11 @@
   border-radius: var(--radius-sm);
 }
 .v2-app textarea:focus-visible,
-.v2-app input:focus-visible { outline: none; }
+.v2-app input:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-deep), 0 0 0 4px var(--volt-dim);
+  border-radius: var(--radius-sm);
+}
 
 /* ── Bubble style ─────────────────────────────────────────────── */
 .v2-app[data-bubble="flat"] .bubble {

--- a/dashboard/src/styles/skin-v2.css
+++ b/dashboard/src/styles/skin-v2.css
@@ -307,7 +307,6 @@ html[data-skin="v2"][data-theme="paper"] {
   --color-bg-hover: var(--bg-card-hover);
   --bg-root: var(--bg-deep);
   --bg-deepest: var(--bg-sunken);
-  --panel-dark: var(--bg-panel-alt);
   --bg-panel-hover: var(--bg-card-hover);
   --shell-header-bg: var(--bg-panel);
   --shell-rail-bg: var(--bg-panel);


### PR DESCRIPTION
Addresses the 5 unresolved review threads from `chatgpt-codex-connector` on PR #21480.

# ci:skip-test-coverage (CSS-only changes; no runtime test paths affected)

## Changes

1. **`dashboard/src/styles/skin-v2.css`** — Removed the paper-bridge override that mapped `--panel-dark` to `--bg-panel-alt` (white in paper mode). The memory/synapse matrix uses `stroke="var(--panel-dark)"`; keeping paper-theme.css' `--ink` mapping restores grid boundaries.

2. **`dashboard/src/styles/cockpit-v2.css`** — Replaced the hard-coded near-black `rgba(8, 9, 13, 0.7)` footer background with `var(--bg-sunken)` so the command-map footer follows the active theme instead of inverting in paper mode.

3. **`dashboard/src/styles/craft-v2.css`** — Changed the `prefers-reduced-motion` media query from `animation-duration: 0.001ms` to `animation: none`, actually disabling infinite animations (copilot caret, live dots, skeleton shimmers) for users who prefer reduced motion.

4. **`dashboard/src/styles/craft-v2.css`** — Added the same v2 focus-ring box-shadow used for buttons/links to `input:focus-visible` and `textarea:focus-visible` instead of suppressing the native outline without a replacement.

5. **`dashboard/src/styles/craft-v2.css`** — Scoped the chat density padding rules under `.v2-keeper-chat` so `data-density="spacious"` / `"compact"` no longer leaks onto code-review `.thread` items in `code.css`.

## Verification

- `pnpm lint` ✅
- `pnpm build` ✅

## Related

- Closes the review threads from #21480