### PR TITLE
fix(dashboard): address review follow-ups from #21478

### DIFF
--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -368,17 +368,18 @@ function normalizeHistoryEntry(
   const role = normalizeRole(raw.role)
   const rawText = asString(raw.content) ?? asString(raw.preview) ?? ''
   const attachments = normalizeAttachments(raw.attachments)
-  // Accept attachment-only rows: a user may send a file/image with no text.
-  // Without this guard the entry is dropped on reload even though it is
-  // persisted server-side.
-  if (!rawText && !attachments?.length) return null
+  const audio = normalizeAudioClip(raw.audio) ?? null
+  // Accept attachment-only or audio-only rows: a user may send a file/image
+  // with no text, or the assistant may emit a synthesized voice clip with no
+  // generated text. Without this guard those persisted rows are dropped on
+  // reload even though they are renderable server-side.
+  if (!rawText && !attachments?.length && !audio) return null
   const source = normalizeConversationSource(raw.source, role, rawText, previousSource)
   const text = formatKeeperVisibleReply(rawText)
-  if (!text && !attachments?.length) return null
+  if (!text && !attachments?.length && !audio) return null
   const timestamp = toIsoTimestamp(raw.ts_unix) ?? toIsoTimestamp(raw.timestamp)
   const label = role === 'assistant' && keeperName ? keeperName : roleLabel(role)
   const surface = isRecord(raw.surface) ? (raw.surface as unknown as SurfaceRef) : null
-  const audio = normalizeAudioClip(raw.audio) ?? null
   // keeper_chat_store mints kind=transport_failure (row content is the
   // "Keeper request failed: ..." text) so a reload can tell a failed request
   // apart from a real reply. Map it to the existing error delivery state so
@@ -574,7 +575,11 @@ function replaceThread(name: string, entries: KeeperConversationEntry[]): void {
     const locals = merged.filter(isLocalEntry)
     const history = merged.filter(entry => !isLocalEntry(entry))
     const historyCap = Math.max(0, THREAD_ENTRY_CAP - locals.length)
-    kept = [...history.slice(-historyCap), ...locals]
+    // history.slice(-0) is equivalent to history.slice(0), so an explicit
+    // empty prefix is needed when the local tail already fills the cap.
+    kept = historyCap === 0
+      ? locals
+      : [...history.slice(-historyCap), ...locals]
   }
   keeperThreads.value = {
     ...keeperThreads.value,

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -458,7 +458,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     expect(refreshHearths).toHaveBeenCalledTimes(1)
   })
 
-  it('does not mutate boardOffset when optimistically prepending a post', async () => {
+  it('advances boardOffset when a real server post is prepended', async () => {
     const { sseStore } = await loadSseStore()
     route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
     boardExcludeSystem.value = false
@@ -477,7 +477,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     await flushAsyncWork()
 
     expect(boardPosts.value[0]?.id).toBe('post-1')
-    expect(boardOffset.value).toBe(10)
+    expect(boardOffset.value).toBe(11)
   })
 
   it('falls back to board refresh when post_kind is missing under kind exclusions', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -40,6 +40,7 @@ import {
   boardExcludeAutomation,
   boardAuthorFilter,
   boardHearthFilter,
+  boardOffset,
 } from './store'
 import {
   requestNamespaceTruth,
@@ -413,9 +414,10 @@ function handleBoardPostCreated(event: SSEEvent): boolean {
     hearth: eventHearth || undefined,
   }
   boardPosts.value = [post, ...boardPosts.value]
-  // Do not bump boardOffset for an optimistic prepend: the offset tracks the
-  // server-side pagination cursor, and mutating it here would skip the newly
-  // created post on the next real pagination fetch.
+  // The server-side offset-based list has shifted by one because of this real
+  // persisted post, so advance the pagination cursor to avoid requesting the
+  // same posts again on the next load-more fetch.
+  boardOffset.value += 1
   return true
 }
 


### PR DESCRIPTION
Resolves the three outstanding review threads from chatgpt-codex-connector on #21478.

- `dashboard/src/keeper-state.ts:577` — when local/optimistic entries already fill `THREAD_ENTRY_CAP`, the history budget becomes 0. Use an explicit empty history prefix instead of `history.slice(-0)`, which would keep the whole server history and blow past the cap.
- `dashboard/src/sse-store.ts:418` — a `post_created` SSE represents a real persisted post, so the server-side offset list shifts by one. Advance `boardOffset` so the next `loadMoreBoardPosts` does not overlap already-loaded posts.
- `dashboard/src/keeper-state.ts:374` — treat a normalized audio clip as renderable content when deciding whether to drop an empty persisted row, so synthesized audio events with no generated text still appear after a history refresh.