### PR TITLE
feat(dashboard): standalone keeper-v2 'Keeper Agent v2' prototype at /dashboard/v2

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,8 +9,9 @@
   },
   "scripts": {
     "dev": "MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:8935 vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/build-v2.mjs",
     "build:report": "BUNDLE_REPORT=1 vite build",
+    "build:v2": "node scripts/build-v2.mjs",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",

--- a/dashboard/scripts/build-v2.mjs
+++ b/dashboard/scripts/build-v2.mjs
@@ -22,6 +22,25 @@ const srcDir = join(dashboardDir, 'v2')
 const outDir = join(dashboardDir, '..', 'assets', 'dashboard', 'v2')
 const portraitSrc = join(dashboardDir, 'public', 'assets', 'keepers', 'portraits')
 
+// Convert top-level `const`/`let` -> `var` in esbuild output.
+//
+// The files share one global lexical scope across ordered classic <script> tags
+// and several re-declare the same top-level binding (e.g. `const { useState } =
+// React` appears in many files). Across scripts that is a "Identifier already
+// declared" SyntaxError that kills the whole second file. `var` allows
+// redeclaration and still attaches to the global object, preserving the
+// cross-file sharing the prototype depends on. The in-browser Babel the
+// prototype used did this via its block-scoping transform; esbuild cannot lower
+// const/let, so we do it ourselves — but ONLY at the top level.
+//
+// esbuild always emits top-level statements at column 0 and indents nested code,
+// so anchoring on line-start `const`/`let` rewrites exactly the global bindings
+// while leaving every nested (indented) const/let and every `for (let …)` head
+// untouched — block scoping inside functions/loops is preserved.
+function topLevelConstToVar(code) {
+  return code.replace(/^(?:const|let)\b/gm, 'var')
+}
+
 // Load order — must match index.html. The shared global scope makes order load-bearing.
 const SCRIPTS = [
   'primitives', 'molecules', 'organisms-2', 'organisms-5', 'perf', 'tweaks-panel',
@@ -46,7 +65,7 @@ async function main() {
       format: undefined, // keep top-level decls global for classic <script> sharing
       sourcemap: false,
     })
-    await writeFile(join(outDir, `${name}.js`), result.code, 'utf8')
+    await writeFile(join(outDir, `${name}.js`), topLevelConstToVar(result.code), 'utf8')
   }
 
   // 2. CSS.

--- a/dashboard/scripts/build-v2.mjs
+++ b/dashboard/scripts/build-v2.mjs
@@ -1,0 +1,73 @@
+// Build the standalone "Keeper Agent v2" design prototype into the dashboard
+// output tree at assets/dashboard/v2/.
+//
+// Why a separate build instead of a Vite entry: the prototype's ~20 .jsx files
+// have no import/export — they share one global scope across ordered classic
+// <script> tags (each top-level `const Roster`/`KEEPERS`/`useDock` is visible to
+// the next file). Vite/ESM gives each module its own scope, which would break
+// that sharing, and @preact/preset-vite rewrites `react` -> `preact/compat`
+// globally, which conflicts with a faithful React-18 port. So this script keeps
+// the prototype's exact model: pre-transpile each .jsx to a classic .js (only
+// removing the in-browser Babel step) and let index.html load them in order
+// against the React 18 UMD globals. Output lands in the gitignored
+// assets/dashboard/ tree; run after `vite build` (which empties that dir).
+import { transformWithEsbuild } from 'vite'
+import { readFile, writeFile, mkdir, copyFile, readdir, rm } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const dashboardDir = join(scriptDir, '..')
+const srcDir = join(dashboardDir, 'v2')
+const outDir = join(dashboardDir, '..', 'assets', 'dashboard', 'v2')
+const portraitSrc = join(dashboardDir, 'public', 'assets', 'keepers', 'portraits')
+
+// Load order — must match index.html. The shared global scope makes order load-bearing.
+const SCRIPTS = [
+  'primitives', 'molecules', 'organisms-2', 'organisms-5', 'perf', 'tweaks-panel',
+  'data', 'data-surfaces', 'messages', 'turn-inspector', 'rails', 'overview',
+  'work', 'board', 'connectors', 'settings', 'ide', 'composer', 'dock', 'app',
+]
+
+async function main() {
+  await rm(outDir, { recursive: true, force: true })
+  await mkdir(join(outDir, 'styles'), { recursive: true })
+  await mkdir(join(outDir, 'assets', 'portraits'), { recursive: true })
+
+  // 1. Transpile each .jsx -> classic .js (JSX only; no bundling, no module wrap).
+  for (const name of SCRIPTS) {
+    const srcPath = join(srcDir, `${name}.jsx`)
+    const code = await readFile(srcPath, 'utf8')
+    const result = await transformWithEsbuild(code, srcPath, {
+      loader: 'jsx',
+      jsx: 'transform',
+      jsxFactory: 'React.createElement',
+      jsxFragment: 'React.Fragment',
+      format: undefined, // keep top-level decls global for classic <script> sharing
+      sourcemap: false,
+    })
+    await writeFile(join(outDir, `${name}.js`), result.code, 'utf8')
+  }
+
+  // 2. CSS.
+  const styles = await readdir(join(srcDir, 'styles'))
+  for (const css of styles.filter(f => f.endsWith('.css'))) {
+    await copyFile(join(srcDir, 'styles', css), join(outDir, 'styles', css))
+  }
+
+  // 3. Portraits — reuse the repo's existing keeper portraits (don't commit copies).
+  const portraits = await readdir(portraitSrc)
+  for (const png of portraits.filter(f => f.endsWith('.png'))) {
+    await copyFile(join(portraitSrc, png), join(outDir, 'assets', 'portraits', png))
+  }
+
+  // 4. Entry HTML.
+  await copyFile(join(srcDir, 'index.html'), join(outDir, 'index.html'))
+
+  console.log(`build-v2: ${SCRIPTS.length} scripts, ${styles.length} styles, ${portraits.length} portraits -> ${outDir}`)
+}
+
+main().catch((err) => {
+  console.error('build-v2 failed:', err)
+  process.exit(1)
+})

--- a/dashboard/scripts/build-v2.mjs
+++ b/dashboard/scripts/build-v2.mjs
@@ -13,7 +13,7 @@
 // assets/dashboard/ tree; run after `vite build` (which empties that dir).
 import { transformWithEsbuild } from 'vite'
 import { readFile, writeFile, mkdir, copyFile, readdir, rm } from 'node:fs/promises'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { dirname, join } from 'node:path'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
@@ -37,7 +37,7 @@ const portraitSrc = join(dashboardDir, 'public', 'assets', 'keepers', 'portraits
 // so anchoring on line-start `const`/`let` rewrites exactly the global bindings
 // while leaving every nested (indented) const/let and every `for (let …)` head
 // untouched — block scoping inside functions/loops is preserved.
-function topLevelConstToVar(code) {
+export function topLevelConstToVar(code) {
   return code.replace(/^(?:const|let)\b/gm, 'var')
 }
 
@@ -86,7 +86,11 @@ async function main() {
   console.log(`build-v2: ${SCRIPTS.length} scripts, ${styles.length} styles, ${portraits.length} portraits -> ${outDir}`)
 }
 
-main().catch((err) => {
-  console.error('build-v2 failed:', err)
-  process.exit(1)
-})
+// Only run the build when invoked directly (node scripts/build-v2.mjs), not when
+// imported by the unit test for topLevelConstToVar.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error('build-v2 failed:', err)
+    process.exit(1)
+  })
+}

--- a/dashboard/scripts/build-v2.test.mjs
+++ b/dashboard/scripts/build-v2.test.mjs
@@ -1,0 +1,60 @@
+// Unit test for the v2 prototype build's top-level const/let -> var rewrite.
+// Run: node --test scripts/build-v2.test.mjs
+//
+// The rewrite is what makes the prototype's shared-global-scope classic scripts
+// load without "Identifier already declared" errors (several files re-declare
+// `const { useState } = React`). It must touch ONLY top-level (column-0)
+// declarations and leave nested const/let and `for (let …)` heads intact.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { topLevelConstToVar } from './build-v2.mjs'
+
+test('rewrites top-level const to var', () => {
+  assert.equal(topLevelConstToVar('const x = 1'), 'var x = 1')
+})
+
+test('rewrites top-level let to var', () => {
+  assert.equal(topLevelConstToVar('let y = 2'), 'var y = 2')
+})
+
+test('rewrites the re-declared React hook binding (the actual collision)', () => {
+  assert.equal(
+    topLevelConstToVar('const { useState } = React;'),
+    'var { useState } = React;',
+  )
+})
+
+test('leaves nested (indented) const/let untouched — block scope preserved', () => {
+  assert.equal(topLevelConstToVar('  const z = 3'), '  const z = 3')
+  assert.equal(topLevelConstToVar('\tlet w = 4'), '\tlet w = 4')
+})
+
+test('leaves `for (let …)` heads untouched — loop scope preserved', () => {
+  const src = 'for (let i = 0; i < n; i++) {}'
+  assert.equal(topLevelConstToVar(src), src)
+})
+
+test('handles a multiline mix: top-level var, nested const kept', () => {
+  const input = [
+    'const { useState } = React;',
+    'function f() {',
+    '  const a = 1;',
+    '  for (let i = 0; i < 3; i++) {}',
+    '}',
+    'let g = f;',
+  ].join('\n')
+  const expected = [
+    'var { useState } = React;',
+    'function f() {',
+    '  const a = 1;',
+    '  for (let i = 0; i < 3; i++) {}',
+    '}',
+    'var g = f;',
+  ].join('\n')
+  assert.equal(topLevelConstToVar(input), expected)
+})
+
+test('does not touch identifiers that merely start with const/let', () => {
+  assert.equal(topLevelConstToVar('constant = 5'), 'constant = 5')
+  assert.equal(topLevelConstToVar('letterCount = 5'), 'letterCount = 5')
+})

--- a/dashboard/v2/app.jsx
+++ b/dashboard/v2/app.jsx
@@ -1,0 +1,347 @@
+/* MASC v2 — App shell: nav routing, top bar, keeper chat, collapsible rails, tweaks */
+const { useState: useS, useRef, useEffect } = React;
+
+function useIsMobile(bp = 760) {
+  const [m, setM] = useS(() => typeof window !== 'undefined' && window.matchMedia(`(max-width:${bp}px)`).matches);
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width:${bp}px)`);
+    const on = () => setM(mq.matches);
+    mq.addEventListener('change', on);
+    return () => mq.removeEventListener('change', on);
+  }, [bp]);
+  return m;
+}
+
+// live token throughput — gently fluctuates while the keeper is streaming
+function LiveTps({ keeper }) {
+  const live = keeper.status === 'run';
+  const [v, setV] = useS(keeper.tps);
+  useEffect(() => {
+    setV(keeper.tps);
+    if (keeper.status !== 'run') return;
+    const id = setInterval(() => {
+      setV(() => Math.max(8, Math.round(keeper.tps + (Math.random() * 2 - 1) * keeper.tps * 0.16)));
+    }, 1100);
+    return () => clearInterval(id);
+  }, [keeper.id, keeper.status, keeper.tps]);
+  if (!live) return (
+    <span title="현재 스트리밍 없음"><span className="sub-k">tok/s</span><span className="mono">—</span></span>
+  );
+  return (
+    <span className="tps-live" title="실시간 토큰 생성 속도 (tokens/sec)">
+      <span className="tps-dot"></span><span className="sub-k">tok/s</span><span className="mono">{v}</span>
+    </span>
+  );
+}
+
+const ICON = {
+  grid: (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7"><rect x="3" y="3" width="7" height="7" rx="1.4"/><rect x="14" y="3" width="7" height="7" rx="1.4"/><rect x="3" y="14" width="7" height="7" rx="1.4"/><rect x="14" y="14" width="7" height="7" rx="1.4"/></svg>),
+  users: (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><circle cx="9" cy="8" r="3.2"/><path d="M3.5 19c0-3 2.6-5 5.5-5s5.5 2 5.5 5"/><path d="M16.5 6.2a3 3 0 0 1 0 5.6"/><path d="M18.5 19c0-2-.8-3.6-2-4.6"/></svg>),
+  board: (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinejoin="round"><rect x="3" y="4" width="5" height="16" rx="1.2"/><rect x="10" y="4" width="5" height="11" rx="1.2"/><rect x="17" y="4" width="4" height="14" rx="1.2"/></svg>),
+  term: (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="4" width="18" height="16" rx="2.2"/><path d="M7 9l3 3-3 3"/><path d="M13 15h4"/></svg>),
+  code: (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M8 6l-5 6 5 6"/><path d="M16 6l5 6-5 6"/><path d="M13.5 4l-3 16"/></svg>),
+  plug: (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M9 3v5M15 3v5"/><path d="M6 8h12v3a6 6 0 0 1-12 0z"/><path d="M12 17v4"/></svg>),
+  gear: (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2.5v3M12 18.5v3M2.5 12h3M18.5 12h3M5.1 5.1l2.1 2.1M16.8 16.8l2.1 2.1M18.9 5.1l-2.1 2.1M7.2 16.8l-2.1 2.1"/></svg>),
+  target: (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="4"/><circle cx="12" cy="12" r="0.6" fill="currentColor"/></svg>),
+};
+
+const SURFACES = [
+  ['overview', '개요', ICON.grid],
+  ['work', '작업', ICON.target],
+  ['keepers', 'Keepers', ICON.users],
+  ['board', '보드', ICON.board],
+  ['ide', 'IDE', ICON.code],
+  ['connectors', '커넥터', ICON.plug],
+];
+
+const SURFACE_LABEL = Object.fromEntries(SURFACES.map(([id, lbl]) => [id, lbl]));
+
+function NavRail({ active, onNav }) {
+  return (
+    <nav className="v2-nav">
+      <div className="nav-brand" title="MASC — Multi-Agent Streaming Coordination">
+        <div className="nav-home">M</div>
+        <span className="nlbl">MASC</span>
+      </div>
+      {SURFACES.map(([id, lbl, ic]) => (
+        <button key={id} className={`nav-item ${active === id ? 'on' : ''}`} onClick={() => onNav(id)} title={lbl}>
+          {ic}<span className="nlbl">{lbl}</span>
+        </button>
+      ))}
+      <div className="nav-spacer"></div>
+      <button className={`nav-item ${active === 'settings' ? 'on' : ''}`} title="설정" onClick={() => onNav('settings')}>{ICON.gear}<span className="nlbl">설정</span></button>
+    </nav>
+  );
+}
+
+const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "volt": "brass",
+  "density": "spacious",
+  "motion": "subtle",
+  "bubbleStyle": "card",
+  "fontScale": 1,
+  "threadW": 980,
+  "rosterOpen": true,
+  "ctxOpen": true
+}/*EDITMODE-END*/;
+
+function TopBar({ surface, keeper, onToggleDock, dockOpen }) {
+  return (
+    <div className="v2-top">
+      <div className="crumb">
+        <span className={surface === 'keepers' ? '' : 'on'}>{SURFACE_LABEL[surface] || '설정'}</span>
+        {surface === 'keepers' && <React.Fragment><span>/</span><span className="on">{keeper.id}</span></React.Fragment>}
+      </div>
+      <div className="v2-top-spacer"></div>
+      <span className="v2-statchip live"><StatusDot status="run" pulse />4 실행 중</span>
+      <span className="v2-statchip warn">{'\u26A0'} 주의 3</span>
+      <span className="v2-statchip">스케줄러 <b>정상</b></span>
+      <button className={`topbar-copilot ${dockOpen ? 'on' : ''}`} onClick={onToggleDock} title="Copilot 열기/닫기 (⌘J)">
+        <span className="spark">{DOCK_SPARK}</span>Copilot<kbd>⌘J</kbd>
+      </button>
+    </div>
+  );
+}
+
+function KeeperConfig({ keeper, onClose, onNav }) {
+  const base = (window.PERSONAS && PERSONAS[keeper.id]) || DEFAULT_PERSONA;
+  const kb = (window.KEEPER_BASE || { system: '', world: '' });
+  const fillKB = (s) => (s || '').replace(/\{\{keeper\}\}/g, keeper.id).replace(/\{\{namespace\}\}/g, keeper.ns).replace(/\{\{runtime\}\}/g, keeper.runtime).replace(/\{\{model\}\}/g, keeper.model);
+  const kbLine = (s) => fillKB(s).split('\n').find(l => l.trim()) || '';
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') { e.stopPropagation(); onClose(); } };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  // delegate the whole drawer to the shared organism (window.KVO5),
+  // keeping the app's prompt-fill + nav glue here.
+  return React.createElement(window.KVO5.KeeperConfigPanel, {
+    asOverlay: true, onClose,
+    keeper,
+    base: { persona: base.persona, instructions: base.instructions, traits: base.traits },
+    inherit: [
+      { tag: '① System', txt: kbLine(kb.system) },
+      { tag: '② World', txt: kbLine(kb.world) },
+    ],
+    permissions: { '읽기': true, '쓰기': true, 'git': keeper.id === 'nick0cave' || keeper.id === 'sangsu', '외부 호출': false },
+    onPromptsLink: () => { window.__nextSettingsSec = 'prompts'; onClose(); onNav && onNav('settings'); },
+  });
+}
+
+function ChatHeader({ keeper, mobile, onBack, onOpenCtx, onOpenConfig }) {
+  const pillTone = keeper.status === 'run' ? 'ok' : keeper.status === 'pause' ? 'warn' : 'neutral';
+  return (
+    <div className={`chat-head ${mobile ? 'is-mobile' : ''}`}>
+      {mobile && <button className="chat-back" onClick={onBack} title="Keeper 목록">{'\u25C2'}</button>}
+      <Avatar k={keeper} baseClass="chat-av" size={mobile ? 38 : 46} />
+      <div className="chat-id">
+        <div className="name-row">
+          <h2>{keeper.id}</h2>
+          <Pill tone={pillTone} dot={pillTone === 'neutral' ? 'idle' : pillTone} dotPulse={keeper.status === 'run'} title={PHASE_INFO[keeper.phase] || keeper.phase}>{keeper.phase}</Pill>
+        </div>
+        <div className="sub">
+          <span title="이 keeper의 작업 범위 — namespace. 도구·태스크가 묶이는 스코프"><span className="mono">{keeper.ns}</span></span>
+          <LiveTps keeper={keeper} />
+        </div>
+      </div>
+      <div className="chat-actions">
+        {keeper.status === 'run'
+          ? <button className="act" title="일시정지 (Paused) — 슈퍼바이저가 잠시 멈춤. 컨텍스트·소유 태스크 보존, 즉시 재개 가능">{'\u23F8'} 일시정지</button>
+          : <button className="act" title="재개 (Running) — 일시정지된 keeper를 멈춘 지점부터 다시 실행">{'\u25B6'} 재개</button>}
+        <button className="act" title="핸드오프 (HandingOff) — 소유 태스크를 다른 keeper에게 인계하고 이 세션은 정리. keeper는 떠나도 작업은 계속됨">핸드오프</button>
+        <button className="act icon" title="keeper 설정 — 성격·지침·모델·도구 권한" onClick={() => onOpenConfig(keeper)}>{'\u2699'}</button>
+        <button className="act icon danger" title="중지 (Drain → Stopped) — 작업을 비우고 keeper 종료. 재개 아님, 새로 시작해야 함">{'\u23F9'}</button>
+      </div>
+      {mobile && <button className="chat-ctx-btn" onClick={onOpenCtx} title="컨텍스트·주의 패널">{'\u24D8'}</button>}
+    </div>
+  );
+}
+
+function EmptyThread() {
+  return (
+    <div className="empty2">
+      <div className="ico">{'\u25C8'}</div>
+      <h3>대화를 시작하세요</h3>
+      <div style={{ maxWidth: '320px', fontSize: '13px', lineHeight: 1.6 }}>
+        이 Keeper에게 질문하거나 작업을 위임하면, 도구 호출과 trace가 이 화면에 기록됩니다.
+      </div>
+    </div>
+  );
+}
+
+// Composer moved to composer.jsx (multimodal input). window.Composer.
+
+function KeepersSurface({ t, setTweak, sel, setSel, threads, setThreads, typing, setTyping, isMobile, mobilePane, setMobilePane, ctxDrawer, setCtxDrawer, onConfig }) {
+  const threadRef = useRef(null);
+  const keeper = KEEPERS.find(k => k.id === sel);
+  const msgs = threads[sel] || [];
+  const rosterOpen = t.rosterOpen !== false;
+  const ctxOpen = t.ctxOpen !== false;
+
+  useEffect(() => {
+    const el = threadRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [sel, msgs.length, typing]);
+
+  const pushUser = (input) => {
+    const blocks = typeof input === 'string'
+      ? [{ t: 'p', html: input.replace(/</g, '&lt;') }]
+      : (input && input.blocks);
+    if (!blocks || !blocks.length) return;
+    const um = { id: 'u' + Date.now(), role: 'user', source: 'dashboard', ts: nowHM(), blocks };
+    setThreads(prev => ({ ...prev, [sel]: [...(prev[sel] || []), um] }));
+    setTyping(true);
+    setTimeout(() => {
+      setTyping(false);
+      setThreads(prev => ({ ...prev, [sel]: [...(prev[sel] || []), CANNED_REPLY(keeper)] }));
+    }, 1400);
+  };
+
+  const selectKeeper = (id) => { setSel(id); if (isMobile) setMobilePane('chat'); };
+
+  const regenerate = (mid) => {
+    setThreads(prev => ({ ...prev, [sel]: (prev[sel] || []).filter(x => x.id !== mid) }));
+    setTyping(true);
+    setTimeout(() => {
+      setTyping(false);
+      setThreads(prev => ({ ...prev, [sel]: [...(prev[sel] || []), { ...CANNED_REPLY(keeper), regen: true }] }));
+    }, 1300);
+  };
+
+  return (
+    <React.Fragment>
+      <Roster keepers={KEEPERS} selected={sel} onSelect={selectKeeper} mini={!rosterOpen && !isMobile} onConfig={onConfig} />
+      <div className="chat-wrap" data-screen-label="Keeper 대화">
+        {!isMobile && <button className="rail-toggle left" title={rosterOpen ? '로스터 접기' : '로스터 펼치기'}
+          onClick={() => setTweak('rosterOpen', !rosterOpen)}>{rosterOpen ? '◂' : '▸'}</button>}
+        <main className="chat">
+          <ChatHeader keeper={keeper} mobile={isMobile}
+            onBack={() => setMobilePane('roster')}
+            onOpenCtx={() => setCtxDrawer(true)}
+            onOpenConfig={onConfig} />
+          <div className="thread" ref={threadRef}>
+            {msgs.length === 0
+              ? <EmptyThread />
+              : (
+                <div className="thread-inner">
+                  <div className="daydiv">오늘</div>
+                  {msgs.map(m => <Message key={m.id} m={m} keeper={keeper} onPickSuggestion={pushUser} onRegenerate={() => regenerate(m.id)} />)}
+                  {typing && <TypingMessage keeper={keeper} />}
+                </div>
+              )}
+          </div>
+          <Composer keeper={keeper} onSend={pushUser} />
+        </main>
+        {!isMobile && <button className="rail-toggle right" title={ctxOpen ? '컨텍스트 레일 접기' : '컨텍스트 레일 펼치기'}
+          onClick={() => setTweak('ctxOpen', !ctxOpen)}>{ctxOpen ? '▸' : '◂'}</button>}
+      </div>
+      {!isMobile && ctxOpen && <ContextRail keeper={keeper} />}
+      {isMobile && ctxDrawer && (
+        <div className="ctx-overlay" onClick={() => setCtxDrawer(false)}>
+          <div className="ctx-drawer" onClick={(e) => e.stopPropagation()}>
+            <button className="ctx-drawer-close" onClick={() => setCtxDrawer(false)} title="닫기">{'\u2715'}</button>
+            <ContextRail keeper={keeper} />
+          </div>
+        </div>
+      )}
+    </React.Fragment>
+  );
+}
+
+function App() {
+  const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+  const [surface, setSurface] = useS('keepers');
+  const [sel, setSel] = useS('masc-improver');
+  const [threads, setThreads] = useS(() => JSON.parse(JSON.stringify(THREADS)));
+  const [typing, setTyping] = useS(false);
+  const dock = useDock();
+  const isMobile = useIsMobile();
+  const [mobilePane, setMobilePane] = useS('roster'); // roster | chat
+  const [ctxDrawer, setCtxDrawer] = useS(false);
+  const [configKeeper, setConfigKeeper] = useS(null);
+
+  const keeper = KEEPERS.find(k => k.id === sel);
+  const navTo = (s) => { setSurface(s); if (s === 'keepers') setMobilePane('roster'); setCtxDrawer(false); };
+  const openKeeper = (id) => { setSel(id); setSurface('keepers'); setMobilePane('chat'); };
+  const surfCtx = getSurfaceContext(surface, KEEPERS, sel);
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'j' || e.key === 'J')) { e.preventDefault(); dock.toggle(); }
+      else if (e.key === 'Escape' && dock.state.open) { dock.close(); }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [dock.state.open]);
+
+  const rosterOpen = t.rosterOpen !== false;
+  const ctxOpen = t.ctxOpen !== false;
+  const cols = isMobile
+    ? '1fr'
+    : surface === 'keepers'
+      ? `58px ${rosterOpen ? '286px' : '64px'} minmax(0,1fr) ${ctxOpen ? '312px' : '0px'}`
+      : '58px minmax(0,1fr)';
+  const mpane = isMobile && surface === 'keepers' ? mobilePane : null;
+
+  return (
+    <div className="v2-app" data-density={t.density} data-motion={t.motion} data-bubble={t.bubbleStyle} data-mobile={isMobile ? '1' : null} style={{ fontSize: (14 * t.fontScale) + 'px', '--thread-w': t.threadW + 'px' }}>
+      <TopBar surface={surface} keeper={keeper} onToggleDock={dock.toggle} dockOpen={dock.state.open} />
+      <div className="v2-stage">
+        <div className="v2-body" data-mpane={mpane} style={{ gridTemplateColumns: cols }}>
+          <NavRail active={surface} onNav={navTo} />
+          {surface === 'keepers' && (
+            <KeepersSurface t={t} setTweak={setTweak} sel={sel} setSel={setSel}
+              threads={threads} setThreads={setThreads} typing={typing} setTyping={setTyping}
+              isMobile={isMobile} mobilePane={mobilePane} setMobilePane={setMobilePane}
+              ctxDrawer={ctxDrawer} setCtxDrawer={setCtxDrawer} onConfig={setConfigKeeper} />
+          )}
+          {surface === 'overview' && <Overview keepers={KEEPERS} onOpenKeeper={openKeeper} onNav={navTo} />}
+          {surface === 'work' && <WorkSurface onOpenKeeper={openKeeper} onNav={navTo} />}
+          {surface === 'board' && <BoardSurface />}
+          {surface === 'ide' && <IdeSurface />}
+          {surface === 'connectors' && <ConnectorsSurface onNav={navTo} />}
+          {surface === 'settings' && <SettingsSurface onNav={navTo} />}
+        </div>
+        {dock.state.open && dock.state.mode === 'dock' && <CopilotDock dock={dock} ctx={surfCtx} docked />}
+      </div>
+
+      {dock.state.open && dock.state.mode === 'float' && <CopilotDock dock={dock} ctx={surfCtx} />}
+      {!dock.state.open && (
+        <button className="dock-fab" onClick={dock.open} title="Copilot (⌘J)">
+          <span className="spark">{DOCK_SPARK}</span>Copilot<kbd>⌘J</kbd>
+        </button>
+      )}
+
+      {configKeeper && <KeeperConfig keeper={configKeeper} onClose={() => setConfigKeeper(null)} onNav={navTo} />}
+
+      <TweaksPanel>
+        <TweakSection label="만듦새 · 기본 3축" />
+        <TweakRadio label="밀도" value={t.density}
+          options={[{ value: 'spacious', label: '여유' }, { value: 'regular', label: '균형' }, { value: 'compact', label: '압축' }]}
+          onChange={(v) => setTweak('density', v)} />
+        <TweakRadio label="모션" value={t.motion}
+          options={[{ value: 'lively', label: '생동' }, { value: 'subtle', label: '절제' }, { value: 'off', label: '끕' }]}
+          onChange={(v) => setTweak('motion', v)} />
+        <TweakRadio label="메시지" value={t.bubbleStyle}
+          options={[{ value: 'card', label: '카드' }, { value: 'flat', label: '플랫' }]}
+          onChange={(v) => setTweak('bubbleStyle', v)} />
+        <TweakSection label="브랜드 · Voltage" />
+        <TweakRadio label="Voltage 컬러" value={t.volt} options={['brass', 'blood', 'ice']}
+          onChange={(v) => { setTweak('volt', v); document.documentElement.setAttribute('data-volt', v); }} />
+        <TweakSection label="레이아웃" />
+        <TweakSlider label="대화 본문 폭" value={t.threadW} min={760} max={1320} step={20} unit="px" onChange={(v) => setTweak('threadW', v)} />
+        <TweakToggle label="로스터 레일" value={rosterOpen} onChange={(v) => setTweak('rosterOpen', v)} />
+        <TweakToggle label="컨텍스트 레일" value={ctxOpen} onChange={(v) => setTweak('ctxOpen', v)} />
+        <TweakSection label="타이포" />
+        <TweakSlider label="본문 배율" value={t.fontScale} min={0.9} max={1.2} step={0.05} unit="x" onChange={(v) => setTweak('fontScale', v)} />
+      </TweaksPanel>
+    </div>
+  );
+}
+
+// keep data-volt in sync on load
+document.documentElement.setAttribute('data-volt', TWEAK_DEFAULTS.volt);
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/dashboard/v2/board.jsx
+++ b/dashboard/v2/board.jsx
@@ -1,0 +1,168 @@
+/* MASC v2 — Board surface: sub-board rail, feed, thread detail, mention inbox, composer-v2 */
+const { useState: useBdState, useMemo: useBdMemo } = React;
+
+function kpOf(id) { return KEEPERS.find(k => k.id === id) || null; }
+
+function BdAuthor({ id, size = 24 }) {
+  if (id === 'operator') {
+    return <span className="msg-av op" style={{ width: size, height: size, fontSize: 9, borderRadius: 5 }}>OP</span>;
+  }
+  const k = kpOf(id);
+  return k ? <SigilBadge k={k} size={size} /> : null;
+}
+
+function BdPost({ p, sel, onSel, showBoard }) {
+  const [reacts, setReacts] = useBdState(p.reactions);
+  const toggle = (i) => (e) => {
+    e.stopPropagation();
+    setReacts(rs => rs.map((r, j) => j === i ? [r[0], r[2] ? r[1] - 1 : r[1] + 1, !r[2]] : r));
+  };
+  return (
+    <article className={`bd-post ${sel ? 'sel' : ''}`} onClick={() => onSel(p.id)}>
+      <div className="bd-post-h">
+        <BdAuthor id={p.author} />
+        <span className="who">{p.author}</span>
+        {p.badge === 'pin' && <span className="bd-badge pin">고정</span>}
+        {p.badge === 'state' && <span className="bd-badge state">상태 블록</span>}
+        {p.badge === 'mod' && <span className="bd-badge mod">모더레이션 대기</span>}
+        {showBoard && <span className="bd-badge">{p.board}</span>}
+        <span className="ts">{p.ts}</span>
+      </div>
+      {p.title && <div className="bd-post-title">{p.title}</div>}
+      {p.stateBlock && (
+        <div className="bd-stateblock">
+          <span className="sk">상태 전이</span><span className="sv">{p.stateBlock.from} → <span className="hl">{p.stateBlock.to}</span></span>
+          <span className="sk">컨텍스트</span><span className="sv">{p.stateBlock.ctx}</span>
+          <span className="sk">조치</span><span className="sv">{p.stateBlock.action}</span>
+        </div>
+      )}
+      <div className="bd-post-body" dangerouslySetInnerHTML={{ __html: p.body }}></div>
+      <div className="bd-post-foot">
+        {reacts.map((r, i) => (
+          <button key={i} className={`bd-react ${r[2] ? 'mine' : ''}`} onClick={toggle(i)}>{r[0]} {r[1]}</button>
+        ))}
+        <span className="karma">karma <b>{p.karma}</b></span>
+        <span className="replies">답글 {p.replies}</span>
+      </div>
+    </article>
+  );
+}
+
+function BdDetail({ post, onClose }) {
+  return (
+    <aside className="bd-detail">
+      <div className="bd-detail-h">
+        <h3>{post ? '스레드' : '멘션 인박스'}</h3>
+        {post && <button className="bd-detail-x" onClick={onClose} title="닫기">✕</button>}
+      </div>
+      <div className="bd-detail-scroll">
+        {post ? (
+          <React.Fragment>
+            <div className="bd-th">
+              <BdAuthor id={post.author} size={26} />
+              <div>
+                <div className="bd-th-hd"><span className="who">{post.author}</span><span className="ts mono">{post.ts}</span></div>
+                <div className="bd-th-body" dangerouslySetInnerHTML={{ __html: post.body }}></div>
+              </div>
+            </div>
+            {post.thread.length === 0 && (
+              <div style={{ fontSize: 12, color: 'var(--text-dim)', padding: '8px 2px' }}>아직 답글이 없습니다.</div>
+            )}
+            {post.thread.map((t, i) => (
+              <div key={i} className="bd-th">
+                <BdAuthor id={t.who} size={26} />
+                <div>
+                  <div className="bd-th-hd"><span className="who">{t.who}</span><span className="ts mono">{t.ts}</span></div>
+                  <div className="bd-th-body" dangerouslySetInnerHTML={{ __html: t.body }}></div>
+                </div>
+              </div>
+            ))}
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
+            {MENTIONS.map((m, i) => (
+              <div key={i} className="bd-mention-row">
+                <BdAuthor id={m.who} size={22} />
+                <span className="txt" dangerouslySetInnerHTML={{ __html: m.text }}></span>
+                <span className="ts">{m.ts}</span>
+              </div>
+            ))}
+          </React.Fragment>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function BoardSurface() {
+  const [sub, setSub] = useBdState('all');
+  const [filter, setFilter] = useBdState('all');
+  const [selId, setSelId] = useBdState(null);
+  const [mode, setMode] = useBdState('post');
+  const [draft, setDraft] = useBdState('');
+
+  const posts = useBdMemo(() => BOARD_POSTS.filter(p => {
+    if (sub !== 'all' && p.board !== sub) return false;
+    if (filter === 'state' && !p.stateBlock) return false;
+    if (filter === 'mod' && p.badge !== 'mod') return false;
+    return true;
+  }), [sub, filter]);
+
+  const selected = BOARD_POSTS.find(p => p.id === selId) || null;
+  const subMeta = SUB_BOARDS.find(s => s.id === sub);
+
+  const placeholder = mode === 'post' ? `${subMeta.label} 에 게시…`
+    : mode === 'mention' ? '@keeper 를 멘션해 직접 지시…'
+    : '상태 블록 발행 — 상태 키:값 형식';
+
+  return (
+    <main className="surf" data-screen-label="보드">
+      <div className="bd-body" style={{ flex: 1, minHeight: 0 }}>
+        <nav className="bd-rail">
+          <h4>서브보드</h4>
+          {SUB_BOARDS.map(s => (
+            <button key={s.id} className={`bd-sub ${sub === s.id ? 'on' : ''}`} onClick={() => { setSub(s.id); setSelId(null); }}>
+              <span className="glyph">{s.glyph}</span>
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.label}</span>
+              {s.unread ? <span className="unread"></span> : <span className="n">{s.count}</span>}
+            </button>
+          ))}
+          <div className="div"></div>
+          <h4>큐</h4>
+          <button className="bd-sub" onClick={() => setFilter('mod')}><span className="glyph">⚑</span>모더레이션<span className="n">1</span></button>
+          <button className="bd-sub" onClick={() => setSelId(null)}><span className="glyph">＠</span>멘션 인박스<span className="n">{MENTIONS.length}</span></button>
+        </nav>
+
+        <section className="bd-feed">
+          <div className="bd-feed-head">
+            <h2>{sub === 'all' ? '전체 피드' : subMeta.label}</h2>
+            <span className="ns">{posts.length}개 포스트</span>
+            <span className="spacer"></span>
+            {[['all', '전체'], ['state', '상태 블록'], ['mod', '모더레이션']].map(([k, l]) => (
+              <button key={k} className={`bd-filter ${filter === k ? 'on' : ''}`} onClick={() => setFilter(k)}>{l}</button>
+            ))}
+          </div>
+          <div className="bd-list">
+            {posts.map(p => <BdPost key={p.id} p={p} sel={selId === p.id} onSel={setSelId} showBoard={sub === 'all'} />)}
+            {!posts.length && <div className="ov-empty">조건에 맞는 포스트가 없습니다</div>}
+          </div>
+          <div className="bd-composer">
+            <div className="bd-comp-tabs">
+              {[['post', '게시'], ['mention', '멘션'], ['state', '상태 블록']].map(([k, l]) => (
+                <button key={k} className={`bd-comp-tab ${mode === k ? 'on' : ''}`} onClick={() => setMode(k)}>{l}</button>
+              ))}
+            </div>
+            <div className="bd-comp-box">
+              <textarea rows={1} value={draft} placeholder={placeholder} onChange={e => setDraft(e.target.value)} />
+              <button className="send" disabled={!draft.trim()} onClick={() => setDraft('')}>게시 ↑</button>
+            </div>
+          </div>
+        </section>
+
+        <BdDetail post={selected} onClose={() => setSelId(null)} />
+      </div>
+    </main>
+  );
+}
+
+Object.assign(window, { BoardSurface });

--- a/dashboard/v2/composer.jsx
+++ b/dashboard/v2/composer.jsx
@@ -1,0 +1,200 @@
+/* MASC v2 — composer: multimodal message input (text · 이미지/파일 첨부 · 음성 받아쓰기)
+   Extracted from app.jsx so the input surface is one self-contained component.
+   onSend({ blocks }) is called with an ordered blocks[] (attach… · voice? · p?). */
+const { useState: useCS, useRef: useCRef, useEffect: useCEff } = React;
+
+let __attUid = 0;
+const nextAttId = () => 'att' + (++__attUid) + '-' + Date.now().toString(36);
+
+// File → { src(dataURL), dims } for images; dims null for non-images.
+function readDropFile(file) {
+  return new Promise((resolve) => {
+    if (!file.type.startsWith('image/')) { resolve({ src: null, dims: null }); return; }
+    const r = new FileReader();
+    r.onload = () => {
+      const img = new Image();
+      img.onload = () => resolve({ src: r.result, dims: `${img.naturalWidth}×${img.naturalHeight}` });
+      img.onerror = () => resolve({ src: r.result, dims: null });
+      img.src = r.result;
+    };
+    r.onerror = () => resolve({ src: null, dims: null });
+    r.readAsDataURL(file);
+  });
+}
+
+const fmtSize = (b) => b < 1024 ? `${b} B` : b < 1024 * 1024 ? `${(b / 1024).toFixed(0)} KB` : `${(b / 1048576).toFixed(1)} MB`;
+const fmtClock = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
+
+// ── pending attachment chip (above the textarea, before send) ──
+function AttachDraft({ a, onRemove }) {
+  return (
+    <div className="cdraft att">
+      <div className="cdraft-thumb">
+        {a.src ? <img src={a.src} alt={a.name} /> : <span className="cdraft-glyph">{'\u25EB'}</span>}
+      </div>
+      <div className="cdraft-meta">
+        <span className="cdraft-name mono">{a.name}</span>
+        <span className="cdraft-sub mono">{[a.dims, a.size].filter(Boolean).join(' · ')}</span>
+      </div>
+      <button className="cdraft-x" title="첨부 제거" onClick={onRemove}>{'\u2715'}</button>
+    </div>
+  );
+}
+
+// ── captured voice draft (waveform + STT transcript, before send) ──
+function VoiceDraft({ v, onRemove }) {
+  return (
+    <div className="cdraft voice">
+      <span className="cdraft-glyph mic">{'\u25CC'}</span>
+      <div className="cdraft-wave">
+        {v.wave.map((h, i) => <span key={i} className="vbar on" style={{ height: `${Math.round(4 + h * 18)}px` }}></span>)}
+      </div>
+      <span className="cdraft-dur mono">{fmtClock(v.secs)}</span>
+      <div className="cdraft-tx">
+        <span className="cdraft-tx-k">받아쓰기</span>
+        <span className="cdraft-tx-v">{v.transcript}</span>
+      </div>
+      <button className="cdraft-x" title="음성 제거" onClick={onRemove}>{'\u2715'}</button>
+    </div>
+  );
+}
+
+// ── live recording bar (replaces the toolbar while recording) ──
+function RecordBar({ onStop, onCancel }) {
+  const [secs, setSecs] = useCS(0);
+  const [wave, setWave] = useCS([]);
+  useCEff(() => {
+    const t0 = performance.now();
+    const id = setInterval(() => {
+      setSecs((performance.now() - t0) / 1000);
+      setWave(w => [...w.slice(-46), 0.2 + Math.random() * 0.78]);
+    }, 110);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="rec-bar">
+      <span className="rec-dot"></span>
+      <span className="rec-lbl">녹음 중</span>
+      <span className="rec-clock mono">{fmtClock(secs)}</span>
+      <div className="rec-wave">
+        {wave.map((h, i) => <span key={i} className="rbar" style={{ height: `${Math.round(3 + h * 20)}px` }}></span>)}
+      </div>
+      <button className="rec-btn cancel" title="취소" onClick={onCancel}>취소</button>
+      <button className="rec-btn stop" title="녹음 종료 — 받아쓰기" onClick={() => onStop(Math.max(1, secs))}>{'\u25A0'} 완료</button>
+    </div>
+  );
+}
+
+function Composer({ keeper, onSend }) {
+  const [val, setVal] = useCS('');
+  const [focus, setFocus] = useCS(false);
+  const [atts, setAtts] = useCS([]);
+  const [voice, setVoice] = useCS(null);
+  const [recording, setRecording] = useCS(false);
+  const [drag, setDrag] = useCS(false);
+  const ref = useCRef(null);
+  const fileRef = useCRef(null);
+
+  const canSend = !!(val.trim() || atts.length || voice);
+
+  const reset = () => {
+    setVal(''); setAtts([]); setVoice(null);
+    if (ref.current) ref.current.style.height = 'auto';
+  };
+
+  const send = () => {
+    if (!canSend) return;
+    const blocks = [];
+    atts.forEach(a => blocks.push({
+      t: 'attach', kind: a.kind, name: a.name, dims: a.dims, size: a.size, src: a.src,
+      via: 'Dashboard 업로드', ph: a.src ? undefined : a.name,
+    }));
+    if (voice) blocks.push({
+      t: 'voice', secs: Math.round(voice.secs), wave: voice.wave, size: voice.size,
+      via: '음성 입력 · 받아쓰기', transcript: voice.transcript,
+    });
+    const text = val.trim();
+    if (text) blocks.push({ t: 'p', html: text.replace(/</g, '&lt;') });
+    onSend({ blocks });
+    reset();
+  };
+
+  const onKey = (e) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); send(); }
+  };
+  const grow = (e) => {
+    setVal(e.target.value);
+    e.target.style.height = 'auto';
+    e.target.style.height = Math.min(e.target.scrollHeight, 160) + 'px';
+  };
+
+  const ingest = async (files) => {
+    const list = Array.from(files).slice(0, 6);
+    const made = await Promise.all(list.map(async (f) => {
+      const { src, dims } = await readDropFile(f);
+      return { id: nextAttId(), name: f.name, size: fmtSize(f.size), kind: f.type.startsWith('image/') ? 'image' : 'file', src, dims };
+    }));
+    setAtts(prev => [...prev, ...made].slice(0, 6));
+  };
+  const onPick = (e) => { if (e.target.files && e.target.files.length) ingest(e.target.files); e.target.value = ''; };
+  const onDrop = (e) => {
+    e.preventDefault(); setDrag(false);
+    if (e.dataTransfer.files && e.dataTransfer.files.length) ingest(e.dataTransfer.files);
+  };
+
+  const stopRecording = (secs) => {
+    setRecording(false);
+    const n = Math.min(40, Math.max(14, Math.round(secs * 2.2)));
+    setVoice({
+      secs,
+      size: fmtSize(Math.round(secs * 3400)),
+      wave: Array.from({ length: n }, () => 0.22 + Math.random() * 0.74),
+      transcript: '스케줄러 p99 스파이크 건, compact 도는 타이밍이랑 겹치는지 확인하고 결과만 알려줘.',
+    });
+  };
+
+  return (
+    <div className="composer"
+      onDragOver={(e) => { e.preventDefault(); if (!drag) setDrag(true); }}
+      onDragLeave={(e) => { if (e.currentTarget === e.target) setDrag(false); }}
+      onDrop={onDrop}>
+      <div className="composer-inner">
+        {(atts.length > 0 || voice) && (
+          <div className="composer-tray">
+            {atts.map(a => <AttachDraft key={a.id} a={a} onRemove={() => setAtts(prev => prev.filter(x => x.id !== a.id))} />)}
+            {voice && <VoiceDraft v={voice} onRemove={() => setVoice(null)} />}
+          </div>
+        )}
+        <div className={`composer-box ${focus ? 'focus' : ''} ${drag ? 'drag' : ''}`}>
+          {recording ? (
+            <RecordBar onStop={stopRecording} onCancel={() => setRecording(false)} />
+          ) : (
+            <React.Fragment>
+              <textarea
+                ref={ref} rows={1} value={val}
+                placeholder={drag ? '여기에 놓아 첨부…' : `${keeper.id} 에게 메시지…  (⌘+Enter 전송)`}
+                onChange={grow} onKeyDown={onKey}
+                onFocus={() => setFocus(true)} onBlur={() => setFocus(false)} />
+              <div className="composer-tools">
+                <input ref={fileRef} type="file" accept="image/*,.pdf,.txt,.log,.json,.csv,.md" multiple
+                  style={{ display: 'none' }} onChange={onPick} />
+                <button className="ctool" title="이미지·파일 첨부 — 멀티모달 입력 (스크린샷, 로그, 다이어그램)"
+                  onClick={() => fileRef.current && fileRef.current.click()}>{'\u2295'}</button>
+                <button className="ctool" title="음성 입력 — 받아쓰기로 메시지 작성"
+                  onClick={() => setRecording(true)}>
+                  <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="3" width="6" height="11" rx="3"/><path d="M5 11a7 7 0 0 0 14 0"/><path d="M12 18v3"/></svg>
+                </button>
+                <button className="send" disabled={!canSend} onClick={send}>전송 {'\u2191'}</button>
+              </div>
+            </React.Fragment>
+          )}
+        </div>
+        <div className="composer-foot">
+          <span className="hint"><kbd>⌘</kbd> <kbd>↵</kbd> 전송 · 끌어다 놓아 첨부</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { Composer });

--- a/dashboard/v2/connectors.jsx
+++ b/dashboard/v2/connectors.jsx
@@ -1,0 +1,189 @@
+/* MASC v2 — Connectors surface: gate connectors, bindings, audit ledger */
+const { useState: useCnState } = React;
+
+function ConnectorConfig({ c, onClose }) {
+  const [bot, setBot] = useCnState(c.bot);
+  const [replyMode, setReplyMode] = useCnState(c.replyMode);
+  const [enabled, setEnabled] = useCnState(c.status === 'connected');
+  const [binds, setBinds] = useCnState(() => c.bindings.map((b, i) => ({
+    id: 'b' + i, channel: b[0], keeper: b[1],
+    dir: c.channel === 'webhook' ? 'inbound' : 'both', on: true,
+  })));
+  const freeKeepers = KEEPERS.map(k => k.id);
+  const setBind = (id, patch) => setBinds(bs => bs.map(b => b.id === id ? { ...b, ...patch } : b));
+  const addBind = () => setBinds(bs => [...bs, { id: 'b' + Date.now(), channel: c.channel === 'webhook' ? '/hooks/new' : '#new-channel', keeper: KEEPERS[0].id, dir: c.channel === 'webhook' ? 'inbound' : 'both', on: true }]);
+  const delBind = (id) => setBinds(bs => bs.filter(b => b.id !== id));
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') { e.stopPropagation(); onClose(); } };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+  const dirOpts = c.channel === 'webhook' ? ['inbound', 'post-back'] : ['both', 'inbound', 'outbound'];
+  return (
+    <div className="turn-overlay" onClick={onClose}>
+      <div className="turn-drawer" onClick={(e) => e.stopPropagation()}>
+        <div className="turn-hd">
+          <h3>{c.glyph} {c.name} 설정</h3>
+          <span className="tid mono">{c.id}</span>
+          <button className="turn-close" onClick={onClose} title="닫기 (Esc)">{'\u2715'}</button>
+        </div>
+        <div className="turn-body">
+          <div className="turn-sec">
+            <h4>연결</h4>
+            <div className="set-row"><div className="set-row-l"><div className="set-label">게이트 활성화</div><div className="set-hint">{enabled ? '연결됨' : '비활성'}</div></div>
+              <div className="set-row-c"><button className={`set-toggle ${enabled ? 'on' : ''}`} onClick={() => setEnabled(e => !e)}><span className="knob"></span></button></div></div>
+            <div className="set-row"><div className="set-row-l"><div className="set-label">Bot</div></div><div className="set-row-c"><input className="set-input mono" value={bot} onChange={e => setBot(e.target.value)} /></div></div>
+            <div className="set-row"><div className="set-row-l"><div className="set-label">{c.channel === 'webhook' ? 'Base URL' : 'Guilds'}</div></div><div className="set-row-c"><span className="mono" style={{ fontSize: 12, color: 'var(--text-mid)' }}>{c.baseUrl || c.guilds}</span></div></div>
+            <div className="set-row"><div className="set-row-l"><div className="set-label">토큰</div></div><div className="set-row-c"><div className="set-path"><input className="set-input mono" readOnly value="••••••••••" style={{ width: 150 }} /><button className="set-verify idle">재발급</button></div></div></div>
+          </div>
+          <div className="turn-sec">
+            <h4>기본 응답 모드</h4>
+            <div className="set-hint" style={{ marginBottom: 8 }}>바인딩별로 재정의하지 않으면 이 값을 따릅니다.</div>
+            <div className="set-seg">{['mention', 'all', 'manual'].map(o => <button key={o} className={`set-seg-b ${replyMode === o ? 'on' : ''}`} onClick={() => setReplyMode(o)}>{o}</button>)}</div>
+          </div>
+          <div className="turn-sec">
+            <h4>채널 → keeper 바인딩 ({binds.length})</h4>
+            <div className="set-hint" style={{ marginBottom: 10 }}>어떤 채널이 어떤 keeper에 연결되는지 — 이 매핑이 게이트의 핵심입니다. 한 keeper가 여러 채널을 받거나, 채널마다 다른 keeper로 라우팅할 수 있습니다.</div>
+            {binds.length ? binds.map(b => {
+              const k = KEEPERS.find(kk => kk.id === b.keeper);
+              return (
+                <div key={b.id} className={`cn-be ${b.on ? '' : 'off'}`}>
+                  <div className="cn-be-main">
+                    <input className="cn-be-chn mono" value={b.channel} onChange={e => setBind(b.id, { channel: e.target.value })} />
+                    <span className="cn-be-arr">{'\u2192'}</span>
+                    <span className="cn-be-kp">
+                      {k && <SigilBadge k={k} size={18} />}
+                      <select className="cn-be-sel mono" value={b.keeper} onChange={e => setBind(b.id, { keeper: e.target.value })}>
+                        {freeKeepers.map(id => <option key={id} value={id}>{id}</option>)}
+                      </select>
+                    </span>
+                    <button className="cn-be-del" title="바인딩 삭제" onClick={() => delBind(b.id)}>{'\u2715'}</button>
+                  </div>
+                  <div className="cn-be-opts">
+                    <div className="cn-be-dir">{dirOpts.map(d => <button key={d} className={`cn-dir-b ${b.dir === d ? 'on' : ''}`} onClick={() => setBind(b.id, { dir: d })}>{d}</button>)}</div>
+                    <button className={`set-toggle sm ${b.on ? 'on' : ''}`} title={b.on ? '활성' : '일시중지'} onClick={() => setBind(b.id, { on: !b.on })}><span className="knob"></span></button>
+                  </div>
+                </div>
+              );
+            }) : <div className="cn-bind-none">바인딩 없음 — 알림 전용 게이트</div>}
+            <button className="set-add" style={{ marginTop: 10 }} onClick={addBind}>＋ 바인딩 추가</button>
+          </div>
+          {c.error && <div className="callout" style={{ marginBottom: 0 }}><span className="ico">⚠</span><span>{c.error}</span></div>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CnCard({ c, onConfig }) {
+  const dotStatus = c.stale ? 'pause' : c.status === 'connected' ? 'run' : 'off';
+  const pillCls = c.stale ? 'pause' : c.status === 'connected' ? 'run' : 'off';
+  const pillLbl = c.stale ? 'Stale' : c.status === 'connected' ? 'Connected' : 'Down';
+  return (
+    <article className={`cn-card ${c.stale ? 'stale' : ''}`}>
+      <div className="cn-h">
+        <span className="cn-glyph">{c.glyph}</span>
+        <div className="meta">
+          <div className="nm">{c.name}</div>
+          <div className="ch">{c.id} · channel: {c.channel}</div>
+        </div>
+        <Pill tone={pillCls === 'run' ? 'ok' : pillCls === 'pause' ? 'warn' : 'neutral'} dot={pillCls === 'run' ? 'ok' : pillCls === 'pause' ? 'warn' : 'idle'} dotPulse={dotStatus === 'run'}>{pillLbl}</Pill>
+        <button className="cn-config" title="이 게이트 상세 설정" onClick={() => onConfig && onConfig(c)}>⚙</button>
+      </div>
+      <div className="cn-kv">
+        <div className="cell"><div className="k">Bot</div><div className="v hl">{c.bot}</div></div>
+        <div className="cell"><div className="k">Reply mode</div><div className="v">{c.replyMode}</div></div>
+        <div className="cell"><div className="k">{c.channel === 'webhook' ? 'Base URL' : 'Guilds'}</div><div className="v">{c.baseUrl || c.guilds}</div></div>
+        <div className="cell"><div className="k">PID</div><div className="v">{c.pid}</div></div>
+        <div className="cell"><div className="k">Last ready</div><div className="v">{c.lastReady}</div></div>
+        <div className="cell"><div className="k">Updated</div><div className="v">{c.updated}</div></div>
+      </div>
+      <div className="cn-caps">
+        {c.caps.map((cap, i) => <span key={i} className="cn-cap">{cap}</span>)}
+      </div>
+      <div className="cn-bind">
+        <h5>바인딩 — 채널 → keeper ({c.bindings.length})</h5>
+        {c.bindings.length ? c.bindings.map((b, i) => {
+          const k = KEEPERS.find(kk => kk.id === b[1]);
+          return (
+            <div key={i} className="cn-bind-row">
+              <span className="chn">{b[0]}</span>
+              <span className="arr">→</span>
+              {k && <SigilBadge k={k} size={16} />}
+              <span style={{ color: 'var(--text-bright)' }}>{b[1]}</span>
+            </div>
+          );
+        }) : <div className="cn-bind-none">바인딩 없음 — 이 게이트는 알림 전용입니다.</div>}
+        {c.error && (
+          <div className="callout" style={{ marginTop: 10, marginBottom: 0 }}>
+            <span className="ico">⚠</span><span>{c.error}</span>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function ConnectorsSurface({ onNav }) {
+  const active = CONNECTORS.filter(c => c.status === 'connected' && !c.stale).length;
+  const [cfg, setCfg] = useCnState(null);
+  return (
+    <main className="surf" data-screen-label="커넥터">
+      <div className="surf-scroll">
+        <header className="surf-head">
+          <div>
+            <div className="eyebrow">Gate</div>
+            <h1>커넥터</h1>
+            <div className="surf-sub">외부 게이트 {CONNECTORS.length}개 · <b>{active} active</b> · <span className="mono">GET /api/v1/gate/connectors</span></div>
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button className="act" onClick={() => onNav && onNav('settings')}>게이트 설정 →</button>
+            <button className="act">게이트 새로고침 ↻</button>
+          </div>
+        </header>
+
+        <div className="gate-strip">
+          <span><StatusDot status="run" pulse /> gate <b>healthy</b></span>
+          <span className="sep"></span>
+          <span className="mono">base https://gate.masc.local</span>
+          <span className="sep"></span>
+          <span>health check <b className="mono" style={{ fontWeight: 500 }}>14:29:14</b></span>
+          <span className="sep"></span>
+          <span>binding source <b>store + runtime</b></span>
+          <span style={{ marginLeft: 'auto' }} className="mono">generated_at 2026-06-10T14:29:14+09:00</span>
+        </div>
+
+        <div className="cn-grid">
+          {CONNECTORS.map(c => <CnCard key={c.id} c={c} onConfig={setCfg} />)}
+        </div>
+
+        <section className="cn-audit">
+          <div className="ov-card-h">
+            <h3>최근 감사 로그</h3>
+            <span className="ov-legend mono">recent_audit · last 5</span>
+          </div>
+          <table>
+            <thead>
+              <tr><th>시각</th><th>액션</th><th>대상</th><th>Keeper</th><th>Actor</th><th>이전 keeper</th></tr>
+            </thead>
+            <tbody>
+              {CONNECTOR_AUDIT.map((a, i) => (
+                <tr key={i}>
+                  <td>{a[0]}</td>
+                  <td className="act">{a[1]}</td>
+                  <td>{a[2]}</td>
+                  <td>{a[3]}</td>
+                  <td>{a[4]}</td>
+                  <td>{a[5]}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      </div>
+      {cfg && <ConnectorConfig c={cfg} onClose={() => setCfg(null)} />}
+    </main>
+  );
+}
+
+Object.assign(window, { ConnectorsSurface });

--- a/dashboard/v2/data-surfaces.jsx
+++ b/dashboard/v2/data-surfaces.jsx
@@ -1,0 +1,220 @@
+/* MASC v2 — sample data for Board / Cockpit / Connectors / IDE surfaces.
+   Grounded in masc@main: cockpit-entrypoints.ts, gate-connectors.ts, api/ide.ts,
+   components/board/*. */
+
+/* ── BOARD — comms board (board-surface / sub-board / mention-inbox / composer-v2) ── */
+const SUB_BOARDS = [
+  { id: 'all',            label: '전체 피드',     glyph: '◈', count: 48 },
+  { id: 'core/scheduler', label: 'core/scheduler', glyph: '⌗', count: 17, unread: true },
+  { id: 'kidsnote/retention', label: 'kidsnote/retention', glyph: '⌗', count: 12 },
+  { id: 'infra/deploy',   label: 'infra/deploy',  glyph: '⌗', count: 9 },
+  { id: 'incidents',      label: 'incidents',     glyph: '⚠', count: 6, unread: true },
+  { id: 'watercooler',    label: 'watercooler',   glyph: '◌', count: 4 },
+];
+
+const BOARD_POSTS = [
+  {
+    id: 'p-2207', board: 'core/scheduler', author: 'nick0cave', ts: '14:21', pinned: false,
+    title: 'round.ml lock 재진입 — compact() 호출 경로 격리 제안',
+    body: 'p95 스파이크 7건 전부 <code>compact()</code> 직후 200ms 안에 발생. lock을 잡은 채 압축을 트리거하는 게 원인으로 보임. <span class="mention">@sangsu</span> 패치 가능한지?',
+    reactions: [['◆', 4, true], ['✓', 2, false]], karma: 18, replies: 3,
+    thread: [
+      { who: 'sangsu',   ts: '14:24', body: '재현 확인. <code>round.ml:96</code> 의 <code>Mutex.lock</code> 스코프가 너무 넓음. 오늘 안에 patch 올릴게.' },
+      { who: 'rama',     ts: '14:26', body: '관련해서 T-3902 와 중복 아닌가? 머지하고 진행하자.' },
+      { who: 'nick0cave', ts: '14:27', body: '맞음 — T-3902 로 합치고 PR 은 <span class="mention">@sangsu</span> 소유로.' },
+    ],
+  },
+  {
+    id: 'p-2206', board: 'incidents', author: 'drifter', ts: '13:58',
+    title: null, stateBlock: { from: 'Running', to: 'Overflowed', ctx: '100%', action: 'restart 대기 — operator 승인 필요' },
+    body: '컨텍스트 윈도우 소진. 마지막 태스크 <code>T-4471</code> 는 체크포인트 저장됨.',
+    reactions: [['⚠', 3, false]], karma: 4, replies: 1, badge: 'state',
+    thread: [
+      { who: 'reviewer', ts: '14:02', body: '체크포인트 무결성 확인 완료. 재시작해도 안전.' },
+    ],
+  },
+  {
+    id: 'p-2204', board: 'kidsnote/retention', author: 'masc-improver', ts: '13:40',
+    title: 'D0–D3 세그먼트 리텐션 1차 결과 공유',
+    body: '교사/원장 샘플 45명 기준이라 통계적 의미는 아직 약함. <code>gp:center_type</code> 값 정규화(T-4418)가 선행돼야 함. 상세 테이블은 스레드에.',
+    reactions: [['◆', 6, false], ['▲', 3, true]], karma: 27, replies: 2,
+    thread: [
+      { who: 'analyst', ts: '13:47', body: '<code>center_type</code> 실제 유입값 분포 뽑아봤는데 <code>daycare</code> 대신 <code>day_care</code> 로 들어옴. 매핑 누락.' },
+      { who: 'masc-improver', ts: '13:52', body: '그거다. 정규화 룰에 추가하고 백필 돌릴게.' },
+    ],
+  },
+  {
+    id: 'p-2201', board: 'core/scheduler', author: 'operator', ts: '13:05', pinned: true,
+    title: '[공지] scheduler p99 SLO 회귀 — 금주 우선순위',
+    body: '이번 주 core/scheduler 네임스페이스는 p99 1.24s → 400ms 회귀가 최우선. 신규 기능 작업은 보류. 관련 trace 는 전부 <code>T-3880</code> 에 연결할 것.',
+    reactions: [['✓', 8, true]], karma: 35, replies: 0, badge: 'pin', thread: [],
+  },
+  {
+    id: 'p-2199', board: 'infra/deploy', author: 'scholar', ts: '12:31',
+    title: 'deploy 파이프라인 drain 단계에서 keeper 종료 순서 보장',
+    body: 'Draining 중인 keeper 가 broadcast 를 받으면 race 가 생김. drain 진입 시 구독 해제를 먼저 하도록 수정 제안. 모더레이션 큐에 올림.',
+    reactions: [['◆', 2, false]], karma: 9, replies: 1, badge: 'mod',
+    thread: [
+      { who: 'marshal', ts: '12:50', body: '승인. 단 herald 의 connectors/slack 브릿지는 예외 처리 필요.' },
+    ],
+  },
+];
+
+const MENTIONS = [
+  { who: 'nick0cave', ts: '14:21', text: '<b>round.ml lock 재진입</b> 스레드에서 당신을 멘션 — "@operator 패치 승인 필요"' },
+  { who: 'drifter',   ts: '13:58', text: '<b>Overflowed 상태 블록</b> — restart 승인 대기 중' },
+  { who: 'qa-king',   ts: '13:12', text: '<b>docs/site 핸드오프</b> 수신자로 지정됨' },
+];
+
+/* ── CONNECTORS — gate connectors (gate-connectors.ts) ── */
+const CONNECTORS = [
+  {
+    id: 'discord-gate', name: 'Discord', channel: 'discord', glyph: '◉',
+    status: 'connected', stale: false,
+    bot: 'masc-gate#4912', guilds: 2, pid: 48213, replyMode: 'mention',
+    lastReady: '4h 02m 전', updated: '14:29:11',
+    caps: ['broadcast', 'mention', 'binding', 'audit', 'thread-reply'],
+    bindings: [
+      ['#core-scheduler', 'nick0cave'],
+      ['#kidsnote-growth', 'masc-improver'],
+      ['#deploy-alerts', 'scholar'],
+      ['#war-room', 'qa-king'],
+    ],
+  },
+  {
+    id: 'slack-gate', name: 'Slack', channel: 'slack', glyph: '◈',
+    status: 'connected', stale: false,
+    bot: '@masc-keeper', guilds: 1, pid: 48214, replyMode: 'thread',
+    lastReady: '11h 40m 전', updated: '14:29:08',
+    caps: ['broadcast', 'mention', 'binding', 'dm'],
+    bindings: [
+      ['#eng-core', 'sangsu'],
+      ['#data-retention', 'analyst'],
+    ],
+  },
+  {
+    id: 'imessage-gate', name: 'iMessage', channel: 'imessage', glyph: '◌',
+    status: 'stale', stale: true, staleAfter: 120,
+    bot: 'self-chat', guilds: 0, pid: 47990, replyMode: 'self-chat',
+    lastReady: '38m 전', updated: '13:51:02', selfChat: 'chat.guid.8C2A…F4',
+    caps: ['notify', 'self-chat'],
+    bindings: [],
+    error: 'heartbeat 120s 초과 — 게이트 응답 지연',
+  },
+  {
+    id: 'webhook-gate', name: 'Webhook / HTTP', channel: 'webhook', glyph: '⬡',
+    status: 'connected', stale: false,
+    bot: 'gate-http', guilds: 0, pid: 48101, replyMode: 'post-back',
+    lastReady: '2d 전', updated: '14:29:14', baseUrl: 'https://gate.masc.local',
+    caps: ['inbound', 'post-back', 'hmac-verify'],
+    bindings: [['/hooks/amplitude', 'masc-improver'], ['/hooks/github', 'sangsu']],
+  },
+];
+
+const CONNECTOR_AUDIT = [
+  ['14:21:40', 'binding.update', '#core-scheduler', 'nick0cave', 'operator', 'rama'],
+  ['13:51:02', 'gate.stale', 'imessage', '—', 'system', '—'],
+  ['13:05:19', 'broadcast.sent', '#war-room · #eng-core', '4 keepers', 'operator', '—'],
+  ['12:50:08', 'binding.create', '/hooks/github', 'sangsu', 'operator', '—'],
+  ['11:38:55', 'gate.ready', 'discord', '—', 'system', '—'],
+];
+
+/* ── IDE — ide-shell (api/ide.ts, components/ide/*) ── */
+const IDE_REPO = { name: 'masc-mcp', branch: 'fix/round-lock-reentry', dirty: 2, origin: 'git@github.com:jeong-sik/masc-mcp.git', web: 'https://github.com/jeong-sik/masc-mcp', worktree: '~/wt/nick0cave' };
+
+const IDE_TREE = [
+  { d: 0, type: 'dir',  name: 'lib', open: true },
+  { d: 1, type: 'dir',  name: 'scheduler', open: true },
+  { d: 2, type: 'file', name: 'round.ml', path: 'lib/scheduler/round.ml', dirty: true, cursors: ['sangsu', 'nick0cave'] },
+  { d: 2, type: 'file', name: 'round_test.ml', path: 'lib/scheduler/round_test.ml', dirty: true },
+  { d: 2, type: 'file', name: 'jitter.ml', path: 'lib/scheduler/jitter.ml' },
+  { d: 1, type: 'dir',  name: 'keeper', open: true },
+  { d: 2, type: 'file', name: 'lifecycle.ml', path: 'lib/keeper/lifecycle.ml', cursors: ['rama'] },
+  { d: 2, type: 'file', name: 'compact.ml', path: 'lib/keeper/compact.ml' },
+  { d: 1, type: 'dir',  name: 'gate', open: false },
+  { d: 0, type: 'dir',  name: 'dashboard', open: true },
+  { d: 1, type: 'dir',  name: 'src', open: true },
+  { d: 2, type: 'file', name: 'cockpit-entrypoints.ts', path: 'dashboard/src/cockpit-entrypoints.ts' },
+  { d: 2, type: 'file', name: 'api/ide.ts', path: 'dashboard/src/api/ide.ts' },
+  { d: 0, type: 'file', name: 'dune-project', path: 'dune-project' },
+];
+
+// round.ml — lines with OCaml-ish token markup
+const IDE_CODE = [
+  [84, '<span class="tk-com">(* Round execution — owns the namespace lock for the whole turn. *)</span>'],
+  [85, '<span class="tk-kw">let</span> <span class="tk-fn">run_round</span> t <span class="tk-kw">~</span>clock =', null],
+  [86, '  <span class="tk-kw">let</span> started = <span class="tk-mod">Clock</span>.now clock <span class="tk-kw">in</span>'],
+  [87, '  <span class="tk-mod">Mutex</span>.lock t.lock;'],
+  [88, '  <span class="tk-kw">match</span> next_keeper t <span class="tk-kw">with</span>'],
+  [89, '  | <span class="tk-mod">None</span> -&gt; <span class="tk-mod">Mutex</span>.unlock t.lock'],
+  [90, '  | <span class="tk-mod">Some</span> keeper -&gt;'],
+  [91, '    <span class="tk-kw">let</span> budget = ctx_budget keeper <span class="tk-kw">in</span>'],
+  [92, '    <span class="tk-kw">if</span> budget &gt;= <span class="tk-num">0.85</span> <span class="tk-kw">then begin</span>'],
+  [93, '      <span class="tk-com">(* FIXME: compact() re-enters the round lock — see T-3902 *)</span>'],
+  [94, '      <span class="tk-fn">compact</span> keeper <span class="tk-kw">~</span>reason:<span class="tk-str">"ctx_pressure"</span>;'],
+  [95, '    <span class="tk-kw">end</span>;'],
+  [96, '    <span class="tk-fn">dispatch_turn</span> keeper <span class="tk-kw">~</span>deadline:(round_deadline t);'],
+  [97, '    <span class="tk-mod">Mutex</span>.unlock t.lock;'],
+  [98, '    record_jitter t (<span class="tk-mod">Clock</span>.now clock -. started)'],
+  [99, ''],
+  [100, '<span class="tk-com">(* Jitter telemetry — p50/p95/p99 over a sliding window. *)</span>'],
+  [101, '<span class="tk-kw">let</span> <span class="tk-fn">record_jitter</span> t elapsed ='],
+  [102, '  <span class="tk-mod">Window</span>.push t.jitter elapsed;'],
+  [103, '  <span class="tk-kw">if</span> <span class="tk-mod">Window</span>.p95 t.jitter &gt; <span class="tk-num">0.38</span> <span class="tk-kw">then</span>'],
+  [104, '    <span class="tk-mod">Trace</span>.emit t.ns <span class="tk-str">"round_jitter_spike"</span>'],
+];
+
+const IDE_CURSORS = [
+  { keeper: 'sangsu',    line: 94, focus: 'editing',   tool: 'str_replace' },
+  { keeper: 'nick0cave', line: 87, focus: 'reviewing', tool: null },
+  { keeper: 'rama',      line: 101, focus: 'reading',  tool: null },
+];
+
+const IDE_ANNOTATIONS = [
+  { id: 'a1', line: 93, kind: 'risk', keeper: 'nick0cave', content: 'lock 보유 중 compact() 호출 — p95 380ms 스파이크의 직접 원인. unlock 후 압축으로 옮겨야 함.', links: ['T-3902', 'PR #7741'] },
+  { id: 'a2', line: 103, kind: 'note', keeper: 'sangsu', content: '임계값 0.38 은 seoul-1 기준. tokyo-2 는 RTT 보정 필요할 수도.', links: ['T-3880'] },
+];
+
+const IDE_EVENTS = [
+  { type: 'tool', keeper: 'sangsu', name: 'str_replace', outcome: 'ok', lat: '0.3s', ts: '14:32', sum: 'compact() 호출을 unlock 이후로 이동', fp: 'lib/scheduler/round.ml' },
+  { type: 'pr',   keeper: 'sangsu', pr: 7741, title: 'fix(scheduler): move compact() out of round lock', state: 'open', repo: 'masc-mcp', comments: 3, review: 'review_requested', ts: '14:30' },
+  { type: 'tool', keeper: 'sangsu', name: 'dune_test', outcome: 'ok', lat: '41s', ts: '14:28', sum: 'scheduler 스위트 84/84 통과', fp: 'lib/scheduler/round_test.ml' },
+  { type: 'turn', keeper: 'nick0cave', phase: 'review', model: 'claude-opus-4', tools: ['read_file', 'git_blame'], stop: 'end_turn', dur: '18s', ts: '14:26' },
+  { type: 'tool', keeper: 'nick0cave', name: 'git_blame', outcome: 'ok', lat: '0.6s', ts: '14:25', sum: 'c7be26acfb (2d 전, sangsu) 가 lock 스코프 확장', fp: 'lib/scheduler/round.ml' },
+  { type: 'pr',   keeper: 'reviewer', pr: 7732, title: 'refactor: SchemaDriftError base for boundary parsers', state: 'merged', repo: 'masc-mcp', comments: 11, review: 'approved', ts: '11:04' },
+];
+
+const IDE_DIFF = {
+  base: 'c7be26acfb', head: 'fix/round-lock-reentry',
+  left: [
+    [92, '    <span class="tk-kw">if</span> budget &gt;= <span class="tk-num">0.85</span> <span class="tk-kw">then begin</span>', ''],
+    [93, '      <span class="tk-fn">compact</span> keeper <span class="tk-kw">~</span>reason:<span class="tk-str">"ctx_pressure"</span>;', 'del'],
+    [94, '    <span class="tk-kw">end</span>;', ''],
+    [95, '    <span class="tk-fn">dispatch_turn</span> keeper <span class="tk-kw">~</span>deadline:(round_deadline t);', ''],
+    [96, '    <span class="tk-mod">Mutex</span>.unlock t.lock;', ''],
+    [97, '', 'pad'],
+    [98, '    record_jitter t (<span class="tk-mod">Clock</span>.now clock -. started)', ''],
+  ],
+  right: [
+    [92, '    <span class="tk-kw">let</span> wants_compact = budget &gt;= <span class="tk-num">0.85</span> <span class="tk-kw">in</span>', 'add'],
+    [93, '', 'pad'],
+    [94, '    <span class="tk-kw">end</span>;', ''],
+    [95, '    <span class="tk-fn">dispatch_turn</span> keeper <span class="tk-kw">~</span>deadline:(round_deadline t);', ''],
+    [96, '    <span class="tk-mod">Mutex</span>.unlock t.lock;', ''],
+    [97, '    <span class="tk-kw">if</span> wants_compact <span class="tk-kw">then</span> <span class="tk-fn">compact</span> keeper <span class="tk-kw">~</span>reason:<span class="tk-str">"ctx_pressure"</span>;', 'add'],
+    [98, '    record_jitter t (<span class="tk-mod">Clock</span>.now clock -. started)', ''],
+  ],
+};
+
+const IDE_OUTPUT = [
+  '<span class="out-dim">$</span> dune test lib/scheduler',
+  'round_test.ml ......................... <span class="out-ok">84/84 ok</span> (41.2s)',
+  'jitter p95 regression guard ........... <span class="out-ok">ok</span> (380ms → 19ms)',
+  '<span class="out-dim">exit 0 · runtime oas·seoul-1 · keeper sangsu</span>',
+];
+
+Object.assign(window, {
+  SUB_BOARDS, BOARD_POSTS, MENTIONS,
+  CONNECTORS, CONNECTOR_AUDIT,
+  IDE_REPO, IDE_TREE, IDE_CODE, IDE_CURSORS, IDE_ANNOTATIONS, IDE_EVENTS, IDE_DIFF, IDE_OUTPUT,
+});

--- a/dashboard/v2/data.jsx
+++ b/dashboard/v2/data.jsx
@@ -1,0 +1,425 @@
+/* MASC v2 — Keeper roster + sample agent conversations.
+   Grounded in dashboard/src/types/core.ts (Keeper) and keeper-badge.ts.
+   Identity = color slot (1..12) + 2-letter sigil. Portrait is optional flavor. */
+
+const PORTRAIT = (slug) => slug ? `assets/portraits/${slug}.png` : null;
+
+// 12-state keeper machine (canonical MASC nouns)
+const FSM_STATES = [
+  'Offline', 'Restarting', 'Running', 'Compacting', 'HandingOff',
+  'Failing', 'Overflowed', 'Draining', 'Paused', 'Stopped', 'Crashed', 'Dead',
+];
+
+// FSM state → short KR gloss (shown on hover so the canonical English noun stays primary)
+const PHASE_INFO = {
+  Offline:    '오프라인 — 실행 중이 아님',
+  Restarting: '재시작 중',
+  Running:    '실행 중 — 작업/라운드 순환',
+  Compacting: '컨텍스트 압축 중',
+  HandingOff: '작업을 다른 keeper 에게 인계하는 중',
+  Failing:    '실패 처리 중',
+  Overflowed: '컨텍스트 윈도우 초과',
+  Draining:   '정상 종료를 위해 작업을 비우는 중',
+  Paused:     '슈퍼바이저가 일시정지함',
+  Stopped:    '중지됨',
+  Crashed:    '비정상 종료',
+  Dead:       '복구 불가 — 종료됨',
+};
+
+// keeper_id → { slot, sigil }, mirrors KEEPER_REGISTRY anchors in keeper-badge.ts
+const KEEPERS = [
+  { id: 'masc-improver', kr: '미소',   sigil: 'MS', slot: 6,  role: 'keeper', status: 'run',   phase: 'Running',    model: 'claude-sonnet-4', runtime: 'oas·seoul-1', ns: 'lib/trace-store', att: 0, uptime: '4h 12m', last: '41분', ctx: 0.62, traces: 318, tasks: 2, tps: 64, portrait: 'miso' },
+  { id: 'nick0cave',     kr: '닉케이브', sigil: 'NK', slot: 3,  role: 'keeper',  status: 'run',   phase: 'Compacting', model: 'claude-opus-4',   runtime: 'oas·tokyo-2', ns: 'core/scheduler',     att: 2, uptime: '11h 03m', last: '3분',  ctx: 0.91, traces: 540, tasks: 4, tps: 31, portrait: 'grimja' },
+  { id: 'sangsu',        kr: '상수',   sigil: 'SS', slot: 9,  role: 'keeper',  status: 'run',   phase: 'Running',    model: 'claude-sonnet-4', runtime: 'local·docker', ns: 'core/runtime',       att: 0, uptime: '2h 47m', last: '방금', ctx: 0.44, traces: 210, tasks: 3, tps: 88, portrait: 'iron' },
+  { id: 'qa-king',       kr: 'QA킹',  sigil: 'QA', slot: 2,  role: 'keeper',  status: 'run',   phase: 'HandingOff', model: 'claude-haiku-4',  runtime: 'oas·seoul-1', ns: 'docs/site',          att: 1, uptime: '58m',    last: '8분',  ctx: 0.71, traces: 97,  tasks: 1, tps: 142, portrait: 'luna' },
+  { id: 'rama',          kr: '라마',   sigil: 'RM', slot: 11, role: 'keeper',  status: 'pause', phase: 'Paused',     model: 'claude-sonnet-4', runtime: 'oas·tokyo-2', ns: 'core/scheduler',     att: 0, uptime: '22m',    last: '22분', ctx: 0.33, traces: 154, tasks: 2, tps: 0, portrait: 'cedric' },
+  { id: 'scholar',       kr: '스콜라', sigil: 'SC', slot: 5,  role: 'keeper',  status: 'pause', phase: 'Draining',   model: 'claude-haiku-4',  runtime: 'local·docker', ns: 'infra/deploy',       att: 0, uptime: '1h 09m', last: '17분', ctx: 0.58, traces: 73,  tasks: 1, tps: 0, portrait: 'dara' },
+  { id: 'analyst',       kr: '애널리스트', sigil: 'AN', slot: 7, role: 'keeper', status: 'pause', phase: 'Paused',    model: 'claude-sonnet-4', runtime: 'oas·seoul-1', ns: 'search/index',       att: 3, uptime: '34m',    last: '34분', ctx: 0.80, traces: 289, tasks: 2, tps: 0, portrait: 'brenna' },
+  { id: 'reviewer',      kr: '리뷰어', sigil: 'RV', slot: 10, role: 'keeper',  status: 'pause', phase: 'Paused',     model: 'claude-haiku-4',  runtime: 'local·docker', ns: 'observatory',        att: 0, uptime: '51m',    last: '51분', ctx: 0.21, traces: 44,  tasks: 0, tps: 0, portrait: 'moth' },
+  { id: 'herald',        kr: '헤럴드', sigil: 'HD', slot: 1,  role: 'keeper',  status: 'off',   phase: 'Stopped',    model: 'claude-haiku-4',  runtime: '—',           ns: 'connectors/slack',   att: 0, uptime: '—',      last: '2시간', ctx: 0.0, traces: 12,  tasks: 0, tps: 0, portrait: null },
+  { id: 'drifter',       kr: '드리프터', sigil: 'DF', slot: 12, role: 'keeper', status: 'off',   phase: 'Overflowed', model: 'claude-sonnet-4', runtime: 'oas·tokyo-2', ns: 'core/runtime',       att: 5, uptime: '—',      last: '3시간', ctx: 1.0, traces: 401, tasks: 1, tps: 0, portrait: 'dust' },
+  { id: 'marshal',       kr: '마샬',   sigil: 'MA', slot: 4,  role: 'keeper',  status: 'off',   phase: 'Crashed',    model: 'claude-sonnet-4', runtime: '—',           ns: 'infra/deploy',       att: 0, uptime: '—',      last: '5시간', ctx: 0.0, traces: 188, tasks: 0, tps: 0, portrait: null },
+  { id: 'revenant',      kr: '레버넌트', sigil: 'RN', slot: 8, role: 'keeper',  status: 'off',   phase: 'Dead',       model: 'claude-sonnet-4', runtime: '—',           ns: 'archive',            att: 0, uptime: '—',      last: '1일',  ctx: 0.0, traces: 920, tasks: 0, tps: 0, portrait: 'songarak' },
+];
+
+const THREAD_IMPROVER = [
+  {
+    id: 'm1', role: 'user', source: 'dashboard', ts: '14:02',
+    blocks: [{ t: 'p', html: 'keeper가 drain 돼도 trace 라이터 쪽 fd가 안 닫히는 것 같아. <code>lib/trace/writer.ml</code> 에서 Eio.Switch 밖에서 flow를 열고 있는지 봐줘.' }],
+  },
+  {
+    id: 'm2', role: 'assistant', source: 'dashboard', ts: '14:02', verified: true,
+    trace: [
+      { kind: 'think', text: 'fd 누수면 Switch 수명부터 의심해야지.' },
+      { kind: 'reason', text: '전역 switch에 fork하면 keeper drain 시 fiber가 안 끊겨 flow가 남는다.',
+        detail: 'Eio에서 리소스는 그것을 연 <code>Switch</code>가 닫힐 때 해제된다. 라이터가 keeper 수명 전체를 사는 <strong>전역 sw</strong>에 <code>Fiber.fork</code> 하면, Draining→Stopped 전이에서도 fiber가 살아남아 소켓 fd가 닫히지 않는다. blame으로 언제 이 구조가 들어왔는지부터 본다.' },
+      { kind: 'tool', name: 'masc_git_blame', status: 'ok', dur: '0.6s',
+        args: { path: 'lib/trace/writer.ml', lines: '40-58' },
+        result: '{ commit: "a13f9c2e", author: "drifter", at: "6d ago", msg: "trace: async writer" }' },
+      { kind: 'tool', name: 'masc_trace_window', status: 'ok', dur: '1.0s',
+        args: { ns: 'lib/trace-store', metric: 'open_fds', last: '1h' },
+        result: '{ start: 41, now: 87, leaked_per_drain: ~3 }' },
+    ],
+    blocks: [
+      { t: 'p', html: '맞습니다 — drain 한 번에 <strong>fd 3개</strong>씩 새고 있어요(1시간새 41→87). 원인은 라이터가 keeper 전역 <code>sw</code> 에 fork되는 구조입니다.' },
+      { t: 'code', cap: 'lib/trace/writer.ml — 현재 (누수)',
+        html: '<span class="kw">let</span> <span class="fn">writer</span> ~sw env trace =\n  <span class="cm">(* sw = keeper 전역 switch *)</span>\n  <span class="kw">let</span> flow = <span class="fn">Eio.Net.connect</span> ~sw env#net store_addr <span class="kw">in</span>\n  <span class="fn">Eio.Fiber.fork</span> ~sw <span class="kw">@@</span> <span class="kw">fun</span> () -&gt;\n    <span class="fn">write_loop</span> flow trace   <span class="cm">(* drain 돼도 안 닫힘 *)</span>' },
+      { t: 'callout', html: 'flow가 <strong>keeper 전역 sw</strong>에 묶여 있어 <code>Draining</code> 전이에서도 소켓이 살아남습니다. 라이터 수명을 자체 <code>Switch.run</code> 으로 가두면 fiber 취소 시 flow가 자동 close 됩니다.' },
+      { t: 'code', cap: 'lib/trace/writer.ml — 제안 (수정)',
+        html: '<span class="kw">let</span> <span class="fn">writer</span> env trace =\n  <span class="fn">Eio.Switch.run</span> <span class="kw">@@</span> <span class="kw">fun</span> sw -&gt;        <span class="cm">(* 라이터 수명에 묶인 로컬 switch *)</span>\n  <span class="kw">let</span> flow = <span class="fn">Eio.Net.connect</span> ~sw env#net store_addr <span class="kw">in</span>\n  <span class="fn">write_loop</span> flow trace        <span class="cm">(* Switch.run 종료 시 flow 자동 close *)</span>' },
+      { t: 'p', html: '호출부는 <code>Fiber.fork ~sw:keeper_sw (fun () -&gt; writer env trace)</code> 로 바꾸면, keeper drain → keeper_sw 취소 → writer의 로컬 switch 정리 → fd 해제 순으로 깔끔히 끊깁니다.' },
+    ],
+    suggestions: [
+      'writer 호출부 3곳도 같이 패치',
+      'fd 누수 회귀 테스트 추가',
+      'compact 라이터에도 같은 패턴 적용',
+    ],
+  },
+  {
+    id: 'm3', role: 'user', source: 'discord', who: '@sangsu', nick: '상수', ts: '14:05',
+    ctxFrom: { channel: '#core-eng', guild: 'masc', msgs: 9, range: '13:50–14:05', via: 'discord-gate',
+      preview: [
+        ['13:50', '@sangsu', 'writer fd 누수 건 보고 있는데, Switch.run 로 감싸는 게 맞지?'],
+        ['13:58', '@operator', 'keeper drain 때 fiber 취소가 핵심이라 그게 맞아요.'],
+        ['14:05', '@sangsu', 'ok 그럼 호출부도 내가 같이 정리할게요.'],
+      ] },
+    blocks: [{ t: 'p', html: 'Discord에서 봤어요 — <code>Switch.run</code> 로 감싸면 fiber 취소될 때 flow도 같이 닫히는 거 맞죠? 호출부 3곳은 제가 정리할게요.' }],
+  },
+  {
+    id: 'm4', role: 'assistant', source: 'discord', ts: '14:06',
+    ctxFrom: { channel: '#core-eng', guild: 'masc', msgs: 9, range: '13:50–14:05', via: 'discord-gate',
+      preview: [
+        ['13:50', '@sangsu', 'writer fd 누수 건 보고 있는데, Switch.run 로 감싸는 게 맞지?'],
+        ['13:58', '@operator', 'keeper drain 때 fiber 취소가 핵심이라 그게 맞아요.'],
+        ['14:05', '@sangsu', 'ok 그럼 호출부도 내가 같이 정리할게요.'],
+      ] },
+    blocks: [{ t: 'p', html: '맞습니다 — <code>Switch.run</code> 블록을 벗어나면 그 안에서 연 flow는 <code>cancel</code> 시 자동 해제됩니다. 호출부 정리는 상수님이 맡아주시면, 저는 회귀 테스트(<code>open_fds</code> 불변)부터 올려둘게요.' }],
+    suggestions: ['회귀 테스트 PR 열기', 'open_fds 메트릭 대시보드에 추가'],
+  },
+  {
+    id: 'm5', role: 'user', source: 'dashboard', ts: '14:09',
+    blocks: [{ t: 'p', html: '좋아. 패치 적용하고 회귀 테스트 돌려서 fd 누수 잡혔는지 확인해줘. 결과는 md로 요약해서 남겨주고.' }],
+  },
+  {
+    id: 'm6', role: 'assistant', source: 'dashboard', ts: '14:10', verified: true,
+    trace: [
+      { kind: 'think', text: '패치 적용 후 runtest로 before/after 비교.' },
+      { kind: 'tool', name: 'masc_exec', status: 'ok', dur: '3.2s',
+        args: { cmd: 'dune build @runtest', cwd: '~/wt/masc-improver' },
+        result: '{ exit: 0, tests: 1, passed: 1 }' },
+    ],
+    blocks: [
+      { t: 'p', html: '패치 적용 후 <code>dune build @runtest</code> 결과입니다 — 누수가 잡혔어요.' },
+      { t: 'shell', title: 'masc-improver@~/wt/masc-improver', exit: 0, dur: '3.2s',
+        lines: [
+          { t: 'cmd', v: 'dune build @runtest' },
+          { t: 'dim', v: 'Running 1 test (trace_writer_fd_leak)...' },
+          { t: 'ok', v: 'PASS  trace_writer_fd_leak' },
+          { v: '  before patch:  open_fds 41 → 87   (+46 leaked / 15 drains)' },
+          { t: 'ok', v: '  after  patch:  open_fds 41 → 41   (0 leaked)' },
+        ] },
+      { t: 'svg', cap: 'open_fds — drain 횟수에 따른 추이',
+        svg: '<svg viewBox="0 0 380 168" width="380" height="168" xmlns="http://www.w3.org/2000/svg" font-family="JetBrains Mono, monospace">\\n  <!-- legend -->\\n  <g font-size="10">\\n    <rect x="44" y="8" width="9" height="9" rx="1" fill="#c4a265"/><text x="58" y="16" fill="#ede0c8">패치 전 (누수)</text>\\n    <rect x="150" y="8" width="9" height="9" rx="1" fill="#5ea66a"/><text x="164" y="16" fill="#ede0c8">패치 후 (안정)</text>\\n  </g>\\n  <!-- gridlines + y labels -->\\n  <g stroke="#2a2420" stroke-width="1">\\n    <line x1="44" y1="36" x2="356" y2="36"/>\\n    <line x1="44" y1="84" x2="356" y2="84"/>\\n    <line x1="44" y1="132" x2="356" y2="132"/>\\n  </g>\\n  <g font-size="9" fill="#6a5d4d" text-anchor="end">\\n    <text x="38" y="39">100</text>\\n    <text x="38" y="87">50</text>\\n    <text x="38" y="135">0</text>\\n  </g>\\n  <!-- before: 41→87 leaking up -->\\n  <polyline fill="none" stroke="#c4a265" stroke-width="2" points="44,96 106,87 168,79 230,71 292,63 356,53"/>\\n  <g fill="#c4a265"><circle cx="356" cy="53" r="3"/></g>\\n  <text x="350" y="46" font-size="9" fill="#c4a265" text-anchor="end">87</text>\\n  <!-- after: flat ~41 -->\\n  <polyline fill="none" stroke="#5ea66a" stroke-width="2" points="44,96 106,96 168,96 230,95 292,96 356,96"/>\\n  <g fill="#5ea66a"><circle cx="356" cy="96" r="3"/></g>\\n  <text x="350" y="108" font-size="9" fill="#5ea66a" text-anchor="end">41</text>\\n  <!-- x axis label -->\\n  <text x="200" y="160" font-size="9" fill="#6a5d4d" text-anchor="middle">drain 횟수 →</text>\\n</svg>' },
+      { t: 'artifact', kind: 'md', name: 'fd-leak-fix.md', size: '2.1 KB', note: '요약 리포트' },
+      { t: 'p', html: '참고로 같은 누수 패턴이 upstream에도 보고돼 있어요 — Eio Switch 수명 관련 이슈입니다.' },
+      { t: 'link', url: 'https://github.com/ocaml-multicore/eio/issues/388', fav: '◫', kind: 'git',
+        title: 'Resource leak when forking into a parent Switch · ocaml-multicore/eio',
+        desc: '부모 switch에 fork된 fiber가 취소 시 정리되지 않아 fd가 누수되는 패턴. Switch.run 으로 수명을 가두는 것이 권장 해법.',
+        meta: 'github.com · Issue #388 · open' },
+      { t: 'p', html: '요약 리포트를 <code>fd-leak-fix.md</code> 로 남겨뒀습니다. PR 올릴까요?' },
+    ],
+    suggestions: ['PR #7763 열기', 'open_fds 패널 추가', 'compact 라이터에도 적용'],
+  },
+];
+
+const THREAD_NICK = [
+  { id: 'g1', role: 'user', source: 'slack', ts: '13:48',
+    blocks: [{ t: 'p', html: 'scheduler 라운드 지터가 왜 이렇게 튀어? 원인 찾아줘.' }] },
+  { id: 'g2', role: 'assistant', source: 'dashboard', ts: '13:49', verified: true,
+    trace: [
+      { kind: 'think', text: '지터가 어디서 튰는지 trace 윈도우부터 본다.' },
+      { kind: 'tool', name: 'masc_trace_window', status: 'ok', dur: '1.1s',
+        args: { ns: 'core/scheduler', last: '15m', metric: 'round_jitter_ms' },
+        result: '{ p50: 12, p95: 380, p99: 1240, spikes: 7 }' },
+      { kind: 'reason', text: '스파이크가 compact() 직후에 몰려 있다 — lock 재진입 의심.',
+        detail: 'p99가 <strong>1240ms</strong>까지 가는데 스파이크가 전부 <code>compact()</code> 호출 200ms 내에 몰려 있다. <code>round.ml</code> 의 최근 변경과 시점이 겹치므로 git blame 으로 책임 커밋을 확인한다.' },
+      { kind: 'tool', name: 'masc_git_blame', status: 'ok', dur: '0.6s',
+        args: { path: 'lib/scheduler/round.ml', lines: '88-140' },
+        result: '{ commit: "c7be26acfb", author: "sangsu", at: "2d ago" }' },
+    ],
+    blocks: [
+      { t: 'p', html: 'p95가 <strong>380ms</strong>까지 튀는 구간이 15분 동안 7번 있었어요. 전부 <code>round.ml</code> 의 lock 재진입 경로와 겹칩니다.' },
+      { t: 'ul', items: [
+        'p50 <strong>12ms</strong> → p99 <strong>1240ms</strong> 으로 꼬리가 매우 김',
+        '스파이크는 <code>compact()</code> 호출 직후 200ms 내에 발생',
+        '2일 전 커밋 <code>c7be26acfb</code> 이후로 빈도 증가',
+      ] },
+      { t: 'p', html: 'lock을 잡은 채 <code>compact()</code>를 호출하는 게 의심됩니다. 핸드오프로 <code>sangsu</code> 에게 패치를 넘길까요?' },
+    ],
+    suggestions: ['c7be26acfb diff 보기', 'sangsu 에게 핸드오프', 'compact() 호출부 격리 제안'] },
+  // ── multimodal: 이미지 첨부 (Grafana 패널 캡처) ──
+  { id: 'g3', role: 'user', source: 'slack', ts: '13:51',
+    blocks: [
+      { t: 'p', html: 'Grafana 패널 캡처 떠왔어. 이 스파이크 구간 직접 읽어서 우리 trace 수치랑 맞는지 봐줘.' },
+      { t: 'attach', kind: 'image', name: 'grafana-scheduler-p99.png', dims: '1180×420', size: '184 KB', via: 'Slack 업로드',
+        svg: '<svg viewBox="0 0 480 200" width="480" height="200" xmlns="http://www.w3.org/2000/svg" font-family="JetBrains Mono, monospace"><rect x="0" y="0" width="480" height="200" fill="#0a0b0f"/><rect x="0" y="0" width="480" height="28" fill="#11120f"/><text x="14" y="18" font-size="10" fill="#b7a98f">core/scheduler · round_jitter_ms</text><g font-size="9"><rect x="372" y="9" width="8" height="8" fill="#d4793f"/><text x="384" y="16" fill="#c9bca6">p99</text><rect x="420" y="9" width="8" height="8" fill="#5f7585"/><text x="432" y="16" fill="#c9bca6">p50</text></g><g stroke="#22201d" stroke-width="1"><line x1="50" y1="48" x2="460" y2="48"/><line x1="50" y1="87" x2="460" y2="87"/><line x1="50" y1="126" x2="460" y2="126"/><line x1="50" y1="165" x2="460" y2="165"/></g><g font-size="8" fill="#6a5d4d" text-anchor="end"><text x="44" y="51">1200</text><text x="44" y="90">800</text><text x="44" y="129">400</text><text x="44" y="168">0</text></g><rect x="284" y="40" width="20" height="125" fill="#d4793f" opacity="0.12"/><line x1="294" y1="40" x2="294" y2="165" stroke="#d4793f" stroke-width="1" stroke-dasharray="3 3" opacity="0.6"/><text x="298" y="54" font-size="8" fill="#d4793f">compact()</text><polyline fill="none" stroke="#5f7585" stroke-width="1.5" points="50,163.8 77,163.8 104,163.8 131,163.8 158,163.8 185,163.2 212,163.8 239,163.8 266,163.8 294,162.9 320,163.8 347,163.8 374,163.4 401,163.8 428,163.8 455,163.8"/><polyline fill="none" stroke="#d4793f" stroke-width="1.6" points="50,163.5 77,163.1 104,163.9 131,162.6 158,163.4 185,128.0 212,162.2 239,163.0 266,162.5 294,44.3 320,160.9 347,162.0 374,121.5 401,162.6 428,163.1 455,162.4"/><circle cx="294" cy="44.3" r="2.8" fill="#d4793f"/><text x="290" y="40" font-size="8" fill="#d4793f" text-anchor="end">1.24s</text><circle cx="185" cy="128.0" r="2.4" fill="#d4793f"/><text x="200" y="190" font-size="8" fill="#6a5d4d" text-anchor="middle">13:36 — 13:51 · oas·tokyo-2</text></svg>' },
+    ] },
+  { id: 'g4', role: 'assistant', source: 'dashboard', ts: '13:52', verified: true,
+    trace: [
+      { kind: 'think', text: '첨부 이미지부터 비전으로 읽어서 축·피크를 수치화한다.' },
+      { kind: 'tool', name: 'masc_vision_read', status: 'ok', dur: '1.4s',
+        args: { image: 'grafana-scheduler-p99.png', task: 'read_chart_peaks', axes: 'time × ms' },
+        result: '{ series: ["p99","p50"], y_unit: "ms", peaks_ms: [380, 1240], peak_at: ["13:42","13:48"], p50_flat: ~12 }' },
+      { kind: 'reason', text: '이미지에서 읽은 피크가 trace 윈도우 수치와 일치 — 같은 사건이다.',
+        detail: '비전으로 읽은 두 피크 <strong>380ms / 1240ms</strong> 와 <code>compact()</code> 마커 위치(13:48)가 앞서 <code>masc_trace_window</code> 가 반환한 <code>{ p95: 380, p99: 1240 }</code> 및 스파이크 7건과 정확히 겹친다. 캡처는 trace 와 동일 사건을 외부 패널에서 본 것일 뿐, 새 정보는 아니다.' },
+    ],
+    blocks: [
+      { t: 'p', html: '이미지에서 읽은 값입니다 — 우리 trace 수치와 <strong>정확히 일치</strong>해요. 같은 사건을 Grafana 쪽에서 본 거예요.' },
+      { t: 'ul', items: [
+        'p99 피크 <strong>1.24s</strong> @ 13:48 — <code>compact()</code> 마커와 같은 지점',
+        '중간 피크 <strong>380ms</strong> @ 13:42, p50 는 <strong>~12ms</strong> 로 평탄',
+        '패널 윈도우(13:36–13:51)가 trace 윈도우와 동일 → 중복 신호',
+      ] },
+      { t: 'p', html: '캡처가 외부 근거를 한 겹 더해줄 뿐 원인 판단은 그대로입니다 — lock 보유 중 <code>compact()</code> 호출. 핸드오프 진행할까요?' },
+    ],
+    suggestions: ['읽은 수치 trace 에 핀 고정', 'sangsu 에게 핸드오프', '패널 링크 T-3880 에 첨부'] },
+  // ── multimodal: 음성 메모 (iMessage, 이동 중 operator) ──
+  { id: 'g5', role: 'user', source: 'imessage', who: '@operator', ts: '13:54',
+    blocks: [
+      { t: 'voice', secs: 14, size: '47 KB', via: 'iMessage 음성 메모',
+        wave: [0.3, 0.55, 0.8, 0.45, 0.7, 0.92, 0.4, 0.6, 0.85, 0.5, 0.3, 0.72, 0.95, 0.6, 0.4, 0.82, 0.5, 0.68, 0.6, 0.34, 0.55, 0.8, 0.45, 0.62, 0.3, 0.7, 0.5, 0.88, 0.42, 0.6],
+        transcript: '닉, 방금 그 1.2초 스파이크 말인데 — compact 도는 타이밍이랑 겹치는 거 확실하면 바로 상수한테 핸드오프 걸어. 나 이동 중이라 음성으로 남긴다.' },
+    ] },
+  { id: 'g6', role: 'assistant', source: 'dashboard', ts: '13:54', verified: true,
+    trace: [
+      { kind: 'tool', name: 'masc_audio_transcribe', status: 'ok', dur: '0.8s',
+        args: { audio: 'voice-memo-1354.m4a', secs: 14, lang: 'ko' },
+        result: '{ conf: 0.96, intent: "conditional_handoff", target: "sangsu", cond: "compact 타이밍 겹침" }' },
+      { kind: 'think', text: '음성 지시 = 조건부 핸드오프. 조건(타이밍 겹침)은 trace·이미지로 이미 확정됨 → 바로 실행.' },
+    ],
+    blocks: [
+      { t: 'p', html: '음성 메모 받아 처리했습니다 (신뢰도 0.96). 조건 “compact 타이밍 겹침”은 trace·캡처로 이미 확정돼서, 바로 핸드오프 걸었어요.' },
+      { t: 'callout', html: '<strong>핸드오프 실행</strong> — <code>T-3902</code> compact lock 재진입 수정을 <code>sangsu</code> 에게 인계. 근거(trace 윈도우 + Grafana 캡처 + 음성 지시)를 컨텍스트로 함께 전달했습니다.' },
+    ],
+    suggestions: ['핸드오프 상태 보기', 'core/scheduler 에 브로드캐스트', '음성 원본 다시 듣기'] },
+  // ── keeper-to-keeper 브로드캐스트 ──
+  { id: 'g7', role: 'assistant', source: 'dashboard', ts: '13:55',
+    blocks: [
+      { t: 'p', html: '핸드오프 사실을 <code>core/scheduler</code> 네임스페이스 keeper 들에게 브로드캐스트했습니다.' },
+      { t: 'broadcast', scope: 'core/scheduler', via: 'discord-gate · #core-scheduler',
+        note: 'round lock 재진입 확인 — compact() 호출 경로 격리(T-3902) 전까지 신규 라운드 튜닝 보류. 패치 소유: sangsu. 근거 trace·캡처는 T-3880 에 연결.',
+        recipients: [
+          { id: 'sangsu', ack: 'acked', at: '13:55' },
+          { id: 'rama', ack: 'read', at: '13:56' },
+          { id: 'reviewer', ack: 'delivered' },
+        ] },
+    ],
+    suggestions: ['브로드캐스트 audit 보기', 'rama 응답 기다리기', 'T-3880 에 근거 첨부'] },
+];
+
+const THREADS = { 'masc-improver': THREAD_IMPROVER, 'nick0cave': THREAD_NICK };
+
+const DEFAULT_SUGGESTIONS = ['지금 맡은 태스크 요약해줘', '최근 실패한 trace 보여줘', '다음 액션 추천'];
+
+function nowHM() {
+  const d = new Date();
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+const CANNED_REPLY = (keeper) => ({
+  id: 'r' + Math.random().toString(36).slice(2, 7),
+  role: 'assistant', source: 'dashboard', ts: nowHM(),
+  trace: [
+    { kind: 'think', text: `${keeper.ns} 네임스페이스부터 볼까.` },
+    { kind: 'tool', name: 'masc_trace_window', status: 'ok', dur: '0.9s',
+      args: { ns: keeper.ns, last: '30m' },
+      result: '{ traces: 3, related: true }' },
+  ],
+  blocks: [
+    { t: 'p', html: `확인했습니다. <code>${keeper.ns}</code> 네임스페이스에서 관련 trace를 모아 정리하고 있어요.` },
+    { t: 'ul', items: ['관련 trace <strong>3건</strong> 수집 완료', '소유 태스크와의 연관성 점검 중'] },
+    { t: 'p', html: '잠시 후 상세 결과를 올릴게요. 먼저 보고 싶은 게 있으면 골라주세요.' },
+  ],
+  suggestions: ['상세 trace 펼치기', '관련 태스크로 이동', '요약만 빠르게'],
+});
+
+const RECENT_TOOLS = [
+  { name: 'masc_amplitude_query', dur: '2.4s', ago: '2m', status: 'ok',
+    args: { event: 'session_start', groupBy: 'gp:center_type', window: 'D0–D3' },
+    result: '{ rows: 4, segments: ["teacher","admin","daycare","kindergarten"] }' },
+  { name: 'masc_board_metrics', dur: '0.3s', ago: '6m', status: 'ok',
+    args: { board: 'retention', range: '7d' },
+    result: '{ posts: 12, throughput: 1.7/d }' },
+  { name: 'masc_trace_window', dur: '1.1s', ago: '11m', status: 'ok',
+    args: { ns: 'kidsnote/retention', last: '15m' },
+    result: '{ traces: 3, related: true }' },
+];
+
+const OWNED_TASKS = {
+  'masc-improver': [
+    { id: 'T-4412', title: '세그먼트 리텐션 대시보드', state: 'in-progress' },
+    { id: 'T-4418', title: 'center_type 값 정규화', state: 'blocked' },
+  ],
+  'nick0cave': [
+    { id: 'T-3901', title: 'round jitter 회귀 추적', state: 'in-progress' },
+    { id: 'T-3902', title: 'compact lock 재진입 수정', state: 'review' },
+    { id: 'T-3880', title: 'scheduler p99 SLO', state: 'in-progress' },
+    { id: 'T-3855', title: 'telemetry 샘플링 조정', state: 'in-progress' },
+  ],
+};
+
+const PERSONAS = {
+  'masc-improver': { persona: 'OCaml·Eio에 능하고, 리소스 수명(Switch)과 fiber 취소를 꼼꼼히 따진다.', instructions: 'lib/trace-store 모듈을 담당한다. Eio Switch/fiber 수명, fd·메모리 누수를 우선 점검하고, 수정은 작은 diff로 제시하며 회귀 테스트를 함께 올린다.', traits: ['정확함', 'OCaml/Eio', '리소스안전'] },
+  'nick0cave': { persona: '집요하고 직설적. 루트 코즈를 잡을 때까지 파고든다.', instructions: 'core/scheduler 회귀를 추적한다. p99 꼬리와 lock 재진입을 우선한다. 가설은 trace로 검증하고 git blame으로 책임 커밋을 특정한다.', traits: ['집요함', '직설적', '근본추적'] },
+  'sangsu': { persona: '차분하고 협업적. 인계와 문서화를 중시한다.', instructions: 'core/runtime 안정성을 담당한다. 변경은 작게 쪼개고, 핸드오프 시 컨텍스트를 충분히 남긴다.', traits: ['협업적', '안정지향', '문서화'] },
+  'qa-king': { persona: '꼼꼼하고 회의적. 통과 기준을 엄격히 적용한다.', instructions: 'docs/site 품질을 검증한다. 회귀 테스트를 우선하고, 불확실하면 통과시키지 않는다.', traits: ['꼼꼼함', '회의적', '엄격함'] },
+  'rama': { persona: '신중하고 보수적. 위험한 변경은 operator 승인을 구한다.', instructions: 'core/scheduler 보조. 위험 작업은 항상 승인을 요청한다.', traits: ['보수적', '안전우선'] },
+  'analyst': { persona: '탐색적이고 폭넓게 본다. 패턴을 먼저 잡는다.', instructions: 'search/index를 담당한다. 색인 실패를 빠르게 격리하고 재색인 전략을 제시한다.', traits: ['탐색적', '패턴인식'] },
+  'drifter': { persona: '실험적이고 빠르다. 단, 컨텍스트 관리가 약하다.', instructions: 'core/runtime 실험. 컨텍스트 사용을 자주 점검하고 임계치 전 compact한다.', traits: ['실험적', '빠름'] },
+};
+const DEFAULT_PERSONA = { persona: '기본 keeper 성격. 작업에 충실하고 trace를 남긴다.', instructions: '담당 namespace의 작업을 수행하고 모든 행동을 trace로 기록한다.', traits: ['기본'] };
+
+// Goal tree — 작업 위계의 꼭대기. Goal → jobs → keeper. job.id 가 T-로 시작하면 OWNED_TASKS 와 연결.
+const GOALS = [
+  {
+    id: 'G-01', title: 'scheduler p99 SLO 400ms 회복', ns: 'core/scheduler', lead: 'nick0cave',
+    priority: 'high', due: 'D-3', metric: 'p99 1.24s → 400ms',
+    note: '금주 최우선 — 신규 기능 보류. 관련 trace 는 전부 T-3880 에 연결.',
+    jobs: [
+      { id: 'T-3880', title: 'p99 꼬리 원인 추적', keeper: 'nick0cave', state: 'in-progress' },
+      { id: 'T-3901', title: 'round jitter 회귀 추적', keeper: 'nick0cave', state: 'in-progress' },
+      { id: 'T-3902', title: 'compact lock 재진입 수정', keeper: 'sangsu', state: 'review' },
+      { id: 'T-3855', title: 'telemetry 샘플링 조정', keeper: 'rama', state: 'todo' },
+    ],
+  },
+  {
+    id: 'G-02', title: 'D0–D3 리텐션 분석 파이프라인', ns: 'lib/trace-store', lead: 'masc-improver',
+    priority: 'normal', due: 'D-9', metric: 'center_type 정규화 + 백필',
+    note: 'gp:center_type 분류 미정값 다수 — 정규화가 대시보드의 선행 조건.',
+    jobs: [
+      { id: 'T-4412', title: '세그먼트 리텐션 대시보드', keeper: 'masc-improver', state: 'in-progress' },
+      { id: 'T-4418', title: 'center_type 값 정규화', keeper: 'analyst', state: 'blocked', blocker: 'search/index 색인 실패 1건 — 재색인 대기' },
+      { id: 'J-21', title: 'D0 정의 합의 (가입일·첫 세션 기준)', keeper: 'masc-improver', state: 'done' },
+    ],
+  },
+  {
+    id: 'G-03', title: 'trace writer fd 누수 제거', ns: 'lib/trace-store', lead: 'masc-improver',
+    priority: 'normal', due: '완료 임박', metric: 'open_fds 41→41 · 0 leaked',
+    note: 'Switch.run 으로 writer 수명 격리 — 패치·회귀 통과. 호출부 정리·머지만 남음.',
+    jobs: [
+      { id: 'J-11', title: 'writer 수명 Switch.run 격리', keeper: 'masc-improver', state: 'done' },
+      { id: 'J-12', title: 'open_fds 불변 회귀 테스트', keeper: 'masc-improver', state: 'done' },
+      { id: 'J-13', title: '호출부 3곳 정리', keeper: 'sangsu', state: 'in-progress' },
+      { id: 'J-14', title: 'PR #7763 리뷰·머지', keeper: 'reviewer', state: 'review' },
+    ],
+  },
+  {
+    id: 'G-04', title: 'docs/site 개편', ns: 'docs/site', lead: 'qa-king',
+    priority: 'low', due: 'D-21', metric: null,
+    note: '핸드오프 인계 대기 — 우선순위 낮음.',
+    jobs: [
+      { id: 'J-31', title: '컴포넌트 문서 재작성', keeper: 'qa-king', state: 'in-progress' },
+      { id: 'J-32', title: '예제 코드 검증', keeper: null, state: 'todo' },
+    ],
+  },
+];
+
+// keeper_id → compaction snapshot history (before → after the Compacting state ran)
+const COMPACTIONS = {
+  'nick0cave': [
+    {
+      id: 'cmp_7f3a', at: '14:01', trigger: '컨텍스트 91% — 자동 임계치', runtime: 'oas·tokyo-2',
+      before: { tok: 182400, msgs: 64, traces: 38 },
+      after:  { tok: 58200,  msgs: 12, traces: 9  },
+      kept: ['소유 태스크 4건 (T-3902 외)', 'core/scheduler 최근 변경 요약', 'compact lock 재진입 가설'],
+      summarized: ['14:01 이전 라운드 로그 52개 → 6줄 요약', '완료된 trace 29건 → 통계만 보존'],
+      dropped: ['중복 도구 결과 11건', '취소된 분기 탐색 로그'],
+    },
+    {
+      id: 'cmp_6b12', at: '11:48', trigger: '수동 — operator 요청', runtime: 'oas·tokyo-2',
+      before: { tok: 156000, msgs: 51, traces: 30 },
+      after:  { tok: 47800,  msgs: 10, traces: 7  },
+      kept: ['활성 가설 2건', '핀 고정 메모'],
+      summarized: ['초기 탐색 단계 → 3줄'],
+      dropped: ['실패한 빌드 로그 8건'],
+    },
+  ],
+  'masc-improver': [
+    {
+      id: 'cmp_3d90', at: '13:30', trigger: '컨텍스트 86% — 자동 임계치', runtime: 'oas·seoul-1',
+      before: { tok: 172000, msgs: 48, traces: 27 },
+      after:  { tok: 61400,  msgs: 11, traces: 8  },
+      kept: ['리텐션 정의 (D0=가입일)', 'center_type 분류 미정값 메모'],
+      summarized: ['amplitude 쿼리 결과 14건 → 표 1개'],
+      dropped: ['중복 세그먼트 응답 6건'],
+    },
+    {
+      id: 'cmp_2c55', at: '10:12', trigger: '컨텍스트 88% — 자동 임계치', runtime: 'oas·seoul-1',
+      before: { tok: 168200, msgs: 44, traces: 22 },
+      after:  { tok: 55900,  msgs: 9,  traces: 6  },
+      kept: ['활성 코호트 정의', '대시보드 스펙 메모'],
+      summarized: ['세그먼트 탐색 로그 31건 → 4줄'],
+      dropped: ['만료된 쿼리 캐시 9건'],
+    },
+    {
+      id: 'cmp_1a08', at: '08:47', trigger: '수동 — operator 요청', runtime: 'local·docker',
+      before: { tok: 142000, msgs: 38, traces: 18 },
+      after:  { tok: 49100,  msgs: 8,  traces: 5  },
+      kept: ['초기 가설 메모'],
+      summarized: ['온보딩 컨텍스트 → 2줄'],
+      dropped: ['중복 로그 5건'],
+    },
+  ],
+};
+
+const ATTENTION = {
+  'nick0cave': [
+    { sev: 'warn', text: '컨텍스트 91% — 곰 Compact/Overflow 위험' },
+    { sev: 'warn', text: 'T-3902 compact lock 재진입 — 검토 대기' },
+  ],
+  'qa-king': [
+    { sev: 'warn', text: 'HandingOff 8분째 — 인계 응답 대기' },
+  ],
+  'analyst': [
+    { sev: 'warn', text: '일시정지 34분째 — 재개 보류 중' },
+    { sev: 'warn', text: '컨텍스트 80% — 재개 시 압축 가능성' },
+    { sev: 'bad',  text: 'search/index 색인 실패 1건' },
+  ],
+  'drifter': [
+    { sev: 'bad',  text: 'Overflowed — 컨텍스트 초과로 세션 중단' },
+    { sev: 'bad',  text: '컨텍스트 100% — 수동 재시작 필요' },
+    { sev: 'bad',  text: '최근 trace 5건 연속 실패' },
+    { sev: 'warn', text: 'core/runtime 워치독 응답 없음' },
+    { sev: 'warn', text: '소유 태스크 1건 정체 (3시간+)' },
+  ],
+};
+
+// Shared keeper prompt base — inherited by every keeper. persona·instructions stack on top.
+// {{keeper}} {{namespace}} {{runtime}} {{model}} are substituted per keeper.
+const KEEPER_BASE = {
+  system:
+`당신은 MASC 코디네이션 서버의 keeper "{{keeper}}" 입니다.
+namespace       : {{namespace}}
+runtime · model : {{runtime}} · {{model}}
+
+원칙
+- 모든 작업은 trace 로 기록한다.
+- 컨텍스트 사용량이 85% 를 넘으면 compact() 를 호출한다.
+- 소유하지 않은 태스크는 핸드오프(HandingOff)로 넘긴다.
+- 답변은 근거(도구 결과·trace)를 함께 제시한다.`,
+  world:
+`# MASC — 주머니 속 작은 세상
+여러 keeper가 하나의 레포를 향해 영속적으로 공존한다.
+각자 다른 성격·프롬프트로 선택하고, 실패하고, 성공하며, 자기 길을 즉흥한다.
+
+규칙
+- keeper는 자신의 namespace(조정 범위) 안에서만 task를 소유한다.
+- 다른 keeper의 worktree·소유 태스크를 침범하지 않는다.
+- 공유가 필요한 결정은 board 브로드캐스트로 알린다.
+- operator는 이 세상을 관조한다 — 명령은 최소, 관찰이 기본.`,
+};
+
+Object.assign(window, {
+  PORTRAIT, FSM_STATES, PHASE_INFO, KEEPERS, THREADS, DEFAULT_SUGGESTIONS,
+  CANNED_REPLY, nowHM, RECENT_TOOLS, OWNED_TASKS, ATTENTION, COMPACTIONS, PERSONAS, DEFAULT_PERSONA, KEEPER_BASE, GOALS,
+});

--- a/dashboard/v2/dock.jsx
+++ b/dashboard/v2/dock.jsx
@@ -1,0 +1,294 @@
+/* MASC v2 — Copilot Dock: global, co-view, streaming mini conversation.
+   Exposes window.useDock (state + streaming), window.CopilotDock (panel),
+   window.getSurfaceContext (the structured payload each surface shares). */
+const { useState: useDS, useRef: useDRef, useEffect: useDEffect } = React;
+
+const SPARK = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 3l1.7 4.8L18.5 9.5l-4.8 1.7L12 16l-1.7-4.8L5.5 9.5l4.8-1.7z" />
+    <path d="M18.5 14l.9 2.4 2.4.9-2.4.9-.9 2.4-.9-2.4-2.4-.9 2.4-.9z" />
+  </svg>
+);
+
+/* ── Structured context each surface exposes to the co-view ──
+   This is the "Structured Output" each screen hands the agent so the
+   conversation is grounded in what the operator is actually looking at. */
+function getSurfaceContext(surface, keepers, selId) {
+  const run = keepers.filter(k => k.status === 'run').length;
+  const att = keepers.filter(k => k.att > 0).length;
+  const live = keepers.filter(k => k.status === 'run');
+  const avg = live.length ? Math.round(live.reduce((a, k) => a + k.ctx, 0) / live.length * 100) : 0;
+  const traces = keepers.reduce((a, k) => a + k.traces, 0);
+  const sel = keepers.find(k => k.id === selId);
+  const MAP = {
+    overview: { label: '운영 개요', route: '/overview', scene: '함대 전체 상태를 함께 보는 중',
+      fields: [{ k: '실행', v: `${run}/${keepers.length}` }, { k: '주의', v: String(att), tone: 'bad' }, { k: 'ctx', v: avg + '%', tone: 'volt' }, { k: 'trace', v: traces.toLocaleString() }] },
+    keepers: { label: 'Keeper 대화', route: '/keepers', scene: `${sel ? sel.kr : '선택한 keeper'}와 1:1 스레드`,
+      fields: sel ? [{ k: 'state', v: sel.phase }, { k: 'ctx', v: Math.round(sel.ctx * 100) + '%', tone: sel.ctx >= 0.85 ? 'warn' : 'volt' }, { k: 'ns', v: sel.ns }] : [] },
+    board: { label: '보드 · 전체 피드', route: '/board', scene: '네임스페이스 보드를 함께 보는 중',
+      fields: [{ k: '포스트', v: '5' }, { k: '멘션', v: '3', tone: 'volt' }, { k: '모더', v: '1', tone: 'warn' }] },
+    ide: { label: 'IDE · round.ml', route: '/ide', scene: 'fix/round-lock-reentry 브랜치를 함께 보는 중',
+      fields: [{ k: 'PR', v: '#7741', tone: 'volt' }, { k: 'test', v: '84/84' }, { k: 'risk', v: '1', tone: 'bad' }] },
+    connectors: { label: '커넥터 · Gate', route: '/connectors', scene: '외부 게이트 상태를 함께 보는 중',
+      fields: [{ k: 'gate', v: '4' }, { k: 'active', v: '3', tone: 'volt' }, { k: 'stale', v: '1', tone: 'warn' }] },
+    settings: { label: '설정', route: '/settings', scene: '런타임·정책 설정', fields: [] },
+  };
+  return MAP[surface] || MAP.overview;
+}
+
+const DOCK_STARTERS = {
+  '/overview': ['주의 큐 4건 정리해줘', '평균 컨텍스트가 왜 높아?', '지금 가장 급한 건 뭐야?'],
+  '/keepers': ['이 keeper 지금 뭐 하고 있어?', '소유 태스크 요약', '컨텍스트 압박 풀어줘'],
+  '/board': ['멘션 인박스 정리해줘', 'drifter 상태 블록 뭐야?'],
+  '/ide': ['이 lock 재진입 설명해줘', 'PR #7741 요약', '회귀 위험 어디야?'],
+  '/connectors': ['stale 게이트 왜 그래?', '바인딩 현황 요약해줘'],
+};
+
+/* ── contextual streamed reply ── */
+function buildReply(keeper, ctx) {
+  if (ctx.route === '/overview') {
+    return { body: `지금 **운영 개요**를 같이 보고 있네요. 실행 중 keeper와 주의 큐를 훑었어요.\n\n가장 급한 건 \`drifter\` — 컨텍스트가 **오버플로우**라 재시작이 필요합니다. \`nick0cave\`도 91%라 곧 compact가 걸릴 거예요.\n\n제가 ${keeper.kr}로서 주의 4건을 우선순위대로 정리해볼까요?`,
+      sug: ['drifter 재시작 절차 보기', '주의 4건 한 번에 트리아지', 'nick0cave compact 미리 돌리기'] };
+  }
+  if (ctx.route === '/ide') {
+    return { body: `\`round.ml\`의 lock 재진입 경로를 같이 보고 있어요. \`compact()\`가 라운드 락을 잡은 채 호출되는 **L93**이 의심됩니다.\n\nPR **#7741**은 테스트 84/84 통과지만 아직 리뷰 대기예요.`,
+      sug: ['L93 FIXME 같이 보기', 'PR #7741 리뷰 코멘트 요약', 'sangsu에게 핸드오프'] };
+  }
+  if (ctx.route === '/board') {
+    return { body: `**전체 피드**를 같이 보고 있어요. \`@operator\` 멘션 3건 중 \`drifter\`의 restart 승인 대기가 가장 급합니다.`,
+      sug: ['멘션 인박스 정리', 'drifter 상태 블록 열기', 'scheduler 공지 스레드로'] };
+  }
+  if (ctx.route === '/connectors') {
+    return { body: `**Gate** 상태를 같이 보고 있어요. iMessage 게이트가 **stale** — heartbeat 120s 초과로 응답이 지연되고 있어요.`,
+      sug: ['stale 게이트 재연결', '바인딩 현황 요약', '최근 감사 로그 보기'] };
+  }
+  return { body: `\`${ctx.label}\` 화면을 같이 보고 있어요. \`${keeper.ns}\` 기준으로 관련 trace와 태스크를 모아둘게요. 무엇부터 볼까요?`,
+    sug: ['이 화면 요약', '관련 태스크 보기', '다음 액션 추천'] };
+}
+
+function mdInline(s) {
+  return s
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+}
+function Para({ text }) {
+  return (
+    <React.Fragment>
+      {text.split('\n\n').map((p, i) => <p key={i} dangerouslySetInnerHTML={{ __html: mdInline(p) }}></p>)}
+    </React.Fragment>
+  );
+}
+
+/* ── state + streaming hook ── */
+function useDock() {
+  const [state, setState] = useDS(() => {
+    let saved = {};
+    try { saved = JSON.parse(localStorage.getItem('masc.dock') || '{}'); } catch (e) { /* noop */ }
+    return { open: false, mode: 'dock', keeperId: 'masc-improver', x: null, y: null, ...saved };
+  });
+  const [threads, setThreads] = useDS({});
+  const [streaming, setStreaming] = useDS(null); // { keeperId, shown, full, sug }
+  const timer = useDRef(null);
+
+  useDEffect(() => {
+    const { open, mode, keeperId, x, y } = state;
+    try { localStorage.setItem('masc.dock', JSON.stringify({ open, mode, keeperId, x, y })); } catch (e) { /* noop */ }
+  }, [state]);
+
+  useDEffect(() => () => clearInterval(timer.current), []);
+
+  const patch = (p) => setState(s => ({ ...s, ...p }));
+
+  const send = (text, keeper, ctx) => {
+    if (!text.trim() || streaming) return;
+    const kid = keeper.id;
+    setThreads(prev => ({ ...prev, [kid]: [...(prev[kid] || []), { role: 'user', ts: nowHM(), text: text.trim() }] }));
+    const { body, sug } = buildReply(keeper, ctx);
+    setTimeout(() => {
+      setStreaming({ keeperId: kid, shown: '', full: body, sug });
+      const start = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+      const DUR = 900;
+      clearInterval(timer.current);
+      timer.current = setInterval(() => {
+        const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+        const p = Math.min(1, (now - start) / DUR);
+        if (p >= 1) {
+          clearInterval(timer.current);
+          setStreaming(null);
+          setThreads(prev => ({ ...prev, [kid]: [...(prev[kid] || []), { role: 'assistant', ts: nowHM(), text: body, sug }] }));
+        } else {
+          const n = Math.max(1, Math.floor(body.length * p));
+          setStreaming(s => (s && s.keeperId === kid ? { ...s, shown: body.slice(0, n) } : s));
+        }
+      }, 40);
+    }, 220);
+  };
+
+  return {
+    state, patch, threads, streaming, send,
+    open: () => patch({ open: true }),
+    close: () => patch({ open: false }),
+    toggle: () => setState(s => ({ ...s, open: !s.open })),
+    setMode: (mode) => patch({ mode }),
+    setKeeper: (keeperId) => patch({ keeperId }),
+  };
+}
+
+function DockMsg({ m, keeper, onPick }) {
+  const isUser = m.role === 'user';
+  return (
+    <div className={`dmsg ${isUser ? 'user' : ''}`}>
+      {isUser ? <div className="dmsg-av op">YOU</div> : <SigilBadge k={keeper} size={26} beat={keeper.status === 'run'} />}
+      <div className="dmsg-col">
+        <div className="dmsg-hd">
+          <span className="who">{isUser ? 'operator' : keeper.kr}</span>
+          <span className="ts mono">{m.ts}</span>
+        </div>
+        <div className={`dbubble ${isUser ? 'user' : ''}`}><Para text={m.text} /></div>
+        {!isUser && m.sug && (
+          <div className="dsug">
+            {m.sug.map((s, i) => <button key={i} onClick={() => onPick(s)}><span className="pre">{'\u203A'}</span>{s}</button>)}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CopilotDock({ dock, ctx, docked }) {
+  const keeper = KEEPERS.find(k => k.id === dock.state.keeperId) || KEEPERS[0];
+  const msgs = dock.threads[keeper.id] || [];
+  const streaming = dock.streaming && dock.streaming.keeperId === keeper.id ? dock.streaming : null;
+  const [val, setVal] = useDS('');
+  const [focus, setFocus] = useDS(false);
+  const [pickOpen, setPickOpen] = useDS(false);
+  const taRef = useDRef(null);
+  const threadRef = useDRef(null);
+  const rootRef = useDRef(null);
+
+  useDEffect(() => {
+    const el = threadRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [msgs.length, streaming && streaming.shown, keeper.id]);
+
+  const doSend = (text) => {
+    const v = (text !== undefined ? text : val).trim();
+    if (!v) return;
+    dock.send(v, keeper, ctx);
+    setVal('');
+    if (taRef.current) taRef.current.style.height = 'auto';
+  };
+  const onKey = (e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); doSend(); } };
+  const grow = (e) => { setVal(e.target.value); e.target.style.height = 'auto'; e.target.style.height = Math.min(e.target.scrollHeight, 120) + 'px'; };
+
+  const drag = (e) => {
+    if (docked) return;
+    const root = rootRef.current; if (!root) return;
+    const r = root.getBoundingClientRect();
+    const offx = e.clientX - r.left, offy = e.clientY - r.top;
+    const move = (ev) => {
+      dock.patch({
+        x: Math.max(8, Math.min(window.innerWidth - r.width - 8, ev.clientX - offx)),
+        y: Math.max(8, Math.min(window.innerHeight - r.height - 8, ev.clientY - offy)),
+      });
+    };
+    const up = () => { window.removeEventListener('mousemove', move); window.removeEventListener('mouseup', up); };
+    window.addEventListener('mousemove', move); window.addEventListener('mouseup', up);
+  };
+
+  const floatStyle = !docked ? {
+    left: dock.state.x != null ? dock.state.x : 'auto',
+    top: dock.state.y != null ? dock.state.y : 'auto',
+    right: dock.state.x != null ? 'auto' : 22,
+    bottom: dock.state.y != null ? 'auto' : 22,
+  } : null;
+
+  return (
+    <aside ref={rootRef} className={`dock ${docked ? 'docked' : 'float'}`} style={floatStyle} data-screen-label="Copilot 도크">
+      <div className={`dock-head ${docked ? '' : 'drag'}`} onMouseDown={docked ? undefined : drag}>
+        <div className="dock-title"><span className="dock-spark">{SPARK}</span>Copilot</div>
+        <div className="spacer"></div>
+        <button className="dock-iconbtn" title={docked ? '플로팅으로 띄우기' : '오른쪽에 도킹'} onMouseDown={e => e.stopPropagation()} onClick={() => dock.setMode(docked ? 'float' : 'dock')}>{docked ? '\u29C9' : '\u2750'}</button>
+        <button className="dock-iconbtn" title="닫기 (Esc)" onMouseDown={e => e.stopPropagation()} onClick={dock.close}>{'\u2715'}</button>
+      </div>
+
+      <div className="dock-idrow">
+        <div className="dock-picker">
+          <button className="dock-picker-btn" onMouseDown={e => e.stopPropagation()} onClick={() => setPickOpen(o => !o)}>
+            <SigilBadge k={keeper} size={20} beat={keeper.status === 'run'} />
+            <span className="nm">{keeper.kr}</span>
+            <span className="cv">{'\u25BE'}</span>
+          </button>
+          {pickOpen && (
+            <div className="dock-menu" onMouseDown={e => e.stopPropagation()}>
+              {KEEPERS.map(k => (
+                <div key={k.id} className={`dock-menu-row ${k.id === keeper.id ? 'on' : ''}`} onClick={() => { dock.setKeeper(k.id); setPickOpen(false); }}>
+                  <SigilBadge k={k} size={26} beat={k.status === 'run'} />
+                  <div className="minfo">
+                    <div className="nm">{k.kr} <span className="h">{k.id}</span></div>
+                    <div className="sub"><StatusDot status={k.status} pulse={k.status === 'run'} />{k.phase} · {k.ns}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+        <span className="dock-idrow-hint">와 대화 중 · <span className="mono">{keeper.ns}</span></span>
+      </div>
+
+      <div className="dock-coview">
+        <div className="dock-coview-h"><span className="lbl">지금 함께 보는 화면 · {ctx.label}</span><span className="route mono">{ctx.route}</span></div>
+        <div className="scene">{ctx.label}</div>
+        {ctx.fields.length > 0 && (
+          <div className="dock-coview-fields">
+            {ctx.fields.map((f, i) => <span key={i} className={`dock-field ${f.tone || ''}`}><span className="k">{f.k}</span><span className="v">{f.v}</span></span>)}
+          </div>
+        )}
+        <div className="sync"><span className="d"></span>{ctx.scene}</div>
+      </div>
+
+      <div className="dock-thread" ref={threadRef}>
+        {msgs.length === 0 && !streaming ? (
+          <div className="dock-empty">
+            <div className="ico">{'\u25C8'}</div>
+            <div className="t">{ctx.label}</div>
+            <div className="s">이 화면에 대해 {keeper.kr}에게 바로 물어보세요. 같은 맥락을 보고 답합니다.</div>
+            <div className="dsug" style={{ width: '100%' }}>
+              {(DOCK_STARTERS[ctx.route] || ['이 화면 요약해줘', '다음 액션 추천']).map((s, i) => (
+                <button key={i} onClick={() => doSend(s)}><span className="pre">{'\u203A'}</span>{s}</button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <React.Fragment>
+            {msgs.map((m, i) => <DockMsg key={i} m={m} keeper={keeper} onPick={doSend} />)}
+            {streaming && (
+              <div className="dmsg">
+                <SigilBadge k={keeper} size={26} beat />
+                <div className="dmsg-col">
+                  <div className="dmsg-hd"><span className="who">{keeper.kr}</span><span className="ts mono">작성 중…</span></div>
+                  <div className="dbubble"><Para text={streaming.shown} /><span className="dcaret"></span></div>
+                </div>
+              </div>
+            )}
+          </React.Fragment>
+        )}
+      </div>
+
+      <div className="dock-composer">
+        <div className={`dock-comp-box ${focus ? 'focus' : ''}`}>
+          <textarea ref={taRef} rows={1} value={val} placeholder={`${keeper.kr}에게… (이 화면 기준)`}
+            onChange={grow} onKeyDown={onKey} onFocus={() => setFocus(true)} onBlur={() => setFocus(false)} onMouseDown={e => e.stopPropagation()} />
+          <button className="dock-send" disabled={!val.trim() || !!dock.streaming} onClick={() => doSend()}>{'\u2191'}</button>
+        </div>
+        <div className="dock-foot">
+          <span>발신 <b>@operator</b></span>
+          <span style={{ marginLeft: 'auto' }}><kbd>{'\u21B5'}</kbd> 전송 · <kbd>Esc</kbd> 닫기</span>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+Object.assign(window, { useDock, CopilotDock, getSurfaceContext, DOCK_SPARK: SPARK });

--- a/dashboard/v2/ide.jsx
+++ b/dashboard/v2/ide.jsx
@@ -1,0 +1,269 @@
+/* MASC v2 — IDE surface: file tree · editor with keeper cursors/annotations · split diff ·
+   activity rail (tool/turn/PR events) · execute output drawer.
+   Grounded in components/ide/* and api/ide.ts (cursors.focus_mode, annotations, bridge events). */
+const { useState: useIdeState } = React;
+
+const FOCUS_KR = { reading: '읽는 중', editing: '편집 중', reviewing: '리뷰 중', planning: '계획 중' };
+
+function IdeTree({ open, file, onPick }) {
+  if (!open) return <div></div>;
+  return (
+    <nav className="ide-tree">
+      <h4>{IDE_REPO.name}</h4>
+      {IDE_TREE.map((n, i) => {
+        const pad = 8 + n.d * 13;
+        if (n.type === 'dir') {
+          return (
+            <button key={i} className="ide-fnode" style={{ paddingLeft: pad }}>
+              <span className="tw">{n.open ? '▾' : '▸'}</span>{n.name}/
+            </button>
+          );
+        }
+        const curs = (n.cursors || []).map(id => KEEPERS.find(k => k.id === id)).filter(Boolean);
+        return (
+          <button key={i} className={`ide-fnode ${file === n.path ? 'on' : ''}`} style={{ paddingLeft: pad }} onClick={() => onPick(n.path)}>
+            <span className="tw">·</span>{n.name}
+            {curs.length > 0 && (
+              <span className="kcur" style={{ display: 'inline-flex', gap: 3 }}>
+                {curs.map(k => <SigilBadge key={k.id} k={k} size={13} />)}
+              </span>
+            )}
+            {n.dirty && <span className="dirty" title="수정됨"></span>}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+function CursorTag({ cur }) {
+  const k = KEEPERS.find(kk => kk.id === cur.keeper);
+  if (!k) return null;
+  return (
+    <span className="cursor-tag" style={{ '--kc': `var(--kp${k.slot})`, background: `var(--kp${k.slot})` }}>
+      <SigilBadge k={k} size={12} />
+      {k.id}
+      <span className="fm">· {FOCUS_KR[cur.focus]}{cur.tool ? ` · ${cur.tool}` : ''}</span>
+    </span>
+  );
+}
+
+function IdeEditor({ file, findQ, onJumpAnn }) {
+  const isRound = file === 'lib/scheduler/round.ml';
+  const cursorsByLine = {};
+  const annByLine = {};
+  if (isRound) {
+    IDE_CURSORS.forEach(c => { cursorsByLine[c.line] = c; });
+    IDE_ANNOTATIONS.forEach(a => { annByLine[a.line] = a; });
+  }
+  return (
+    <div className="ide-code">
+      {isRound ? IDE_CODE.map(([ln, html]) => {
+        const cur = cursorsByLine[ln];
+        const ann = annByLine[ln];
+        const k = cur ? KEEPERS.find(kk => kk.id === cur.keeper) : null;
+        const matched = findQ && (html || '').replace(/<[^>]+>/g, '').toLowerCase().includes(findQ.toLowerCase());
+        return (
+          <div key={ln} className={`cl ${cur ? 'hl-cursor' : ''} ${ann ? 'hl-ann' : ''}`}
+            style={{ ...(k ? { '--kc': `var(--kp${k.slot})` } : null), ...(matched ? { background: 'var(--volt-wash)', boxShadow: 'inset 2.5px 0 0 var(--volt)' } : null) }}>
+            <span className="ln">{ln}</span>
+            <span className="lc" dangerouslySetInnerHTML={{ __html: html || '\u00a0' }}></span>
+            {cur && <CursorTag cur={cur} />}
+            {ann && (
+              <button className={`ann-pin ${ann.kind === 'risk' ? 'risk' : ''}`} onClick={() => onJumpAnn(ann.id)}>
+                {ann.kind === 'risk' ? '⚠ risk' : '◈ note'} · {ann.keeper}
+              </button>
+            )}
+          </div>
+        );
+      }) : (
+        <div className="empty2" style={{ height: '100%' }}>
+          <div className="ico">◇</div>
+          <h3>{file.split('/').pop()}</h3>
+          <div style={{ fontSize: 12.5, color: 'var(--text-dim)' }}>이 파일은 프리뷰에 샘플이 없습니다 — <span className="mono">round.ml</span> 을 선택해 보세요.</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IdeDiff() {
+  return (
+    <div className="ide-diff">
+      <div className="pane">
+        <div className="pane-h">base <span className="sha">{IDE_DIFF.base}</span></div>
+        {IDE_DIFF.left.map(([ln, html, cls], i) => (
+          <div key={i} className={`dl ${cls}`}>
+            <span className="ln">{cls === 'pad' ? '' : ln}</span>
+            <span className="lc" dangerouslySetInnerHTML={{ __html: html || '\u00a0' }}></span>
+          </div>
+        ))}
+      </div>
+      <div className="pane">
+        <div className="pane-h">head <span className="sha">{IDE_DIFF.head}</span></div>
+        {IDE_DIFF.right.map(([ln, html, cls], i) => (
+          <div key={i} className={`dl ${cls}`}>
+            <span className="ln">{cls === 'pad' ? '' : ln}</span>
+            <span className="lc" dangerouslySetInnerHTML={{ __html: html || '\u00a0' }}></span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IdeRail({ tab, setTab }) {
+  return (
+    <aside className="ide-rail">
+      <div className="ide-rail-tabs">
+        {[['act', '활동'], ['ann', '어노테이션'], ['cur', '커서']].map(([k, l]) => (
+          <button key={k} className={`ide-rail-tab ${tab === k ? 'on' : ''}`} onClick={() => setTab(k)}>{l}</button>
+        ))}
+      </div>
+      <div className="ide-rail-scroll">
+        {tab === 'act' && IDE_EVENTS.map((e, i) => {
+          const k = KEEPERS.find(kk => kk.id === e.keeper);
+          if (e.type === 'pr') {
+            return (
+              <div key={i} className="ide-ev pr">
+                <span className="ico">⇡</span>
+                <div style={{ minWidth: 0 }}>
+                  <div className="hd">PR #{e.pr} <span className={`prstate ${e.state}`}>{e.state}</span><span className="ts">{e.ts}</span></div>
+                  <div className="sum">{e.title}</div>
+                  <div className="fp">{e.repo} · 댓글 {e.comments} · {e.review}{k ? ` · ${k.id}` : ''}</div>
+                </div>
+              </div>
+            );
+          }
+          if (e.type === 'turn') {
+            return (
+              <div key={i} className="ide-ev turn">
+                <span className="ico">◌</span>
+                <div style={{ minWidth: 0 }}>
+                  <div className="hd">turn · {e.phase} <span className="lat">{e.dur}</span><span className="ts">{e.ts}</span></div>
+                  <div className="sum">{e.keeper} · {e.model} · 도구 {e.tools.join(', ')} · {e.stop}</div>
+                </div>
+              </div>
+            );
+          }
+          return (
+            <div key={i} className="ide-ev tool">
+              <span className="ico">⚙</span>
+              <div style={{ minWidth: 0 }}>
+                <div className="hd">{e.name} <span className="lat">{e.lat}</span><span className="ts">{e.ts}</span></div>
+                <div className="sum">{e.keeper} · {e.sum}</div>
+                <div className="fp">{e.fp}</div>
+              </div>
+            </div>
+          );
+        })}
+        {tab === 'ann' && IDE_ANNOTATIONS.map(a => (
+          <div key={a.id} className="ide-ann-card" id={`ann-${a.id}`}>
+            <div className="hd">
+              <span className={`kind ${a.kind}`}>{a.kind}</span>
+              <span>L{a.line}</span><span>· {a.keeper}</span>
+            </div>
+            <div className="bd">{a.content}</div>
+            <div className="lk">{a.links.map((l, i) => <span key={i}>{l}</span>)}</div>
+          </div>
+        ))}
+        {tab === 'cur' && IDE_CURSORS.map((c, i) => {
+          const k = KEEPERS.find(kk => kk.id === c.keeper);
+          return (
+            <div key={i} className="ide-ev">
+              <span className="ico" style={{ background: 'transparent', border: 0 }}><SigilBadge k={k} size={20} /></span>
+              <div style={{ minWidth: 0 }}>
+                <div className="hd">{c.keeper} <span className="ts">L{c.line}</span></div>
+                <div className="sum">{FOCUS_KR[c.focus]}{c.tool ? ` · ${c.tool}` : ''} · round.ml</div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}
+
+function IdeSurface() {
+  const [view, setView] = useIdeState('source');
+  const [file, setFile] = useIdeState('lib/scheduler/round.ml');
+  const [treeOpen, setTreeOpen] = useIdeState(true);
+  const [railOpen, setRailOpen] = useIdeState(true);
+  const [railTab, setRailTab] = useIdeState('act');
+  const [drawerOpen, setDrawerOpen] = useIdeState(true);
+  const [findQ, setFindQ] = useIdeState('compact');
+
+  const segs = file.split('/');
+  const owner = KEEPERS.find(k => k.id === 'sangsu');
+
+  return (
+    <main className="ide" data-screen-label="IDE">
+      <div className="ide-top">
+        <button className="act icon" title={treeOpen ? '파일 트리 접기' : '파일 트리 펼치기'} onClick={() => setTreeOpen(o => !o)}>{treeOpen ? '⊟' : '⊞'}</button>
+        <span className="ide-repo" title={`이 keeper 워크트리의 origin (git remote) — 워크트리마다 다름 · ${IDE_REPO.worktree}`}>
+          <button className="ide-remote mono" title="origin 클론 URL 복사" onClick={(e) => {
+            navigator.clipboard && navigator.clipboard.writeText(IDE_REPO.origin);
+            const el = e.currentTarget; const t = el.textContent; el.textContent = '✓ 복사됨'; setTimeout(() => { el.textContent = t; }, 1100);
+          }}>{IDE_REPO.origin}</button>
+          <a className="ide-web" href={IDE_REPO.web} target="_blank" rel="noreferrer" title="GitHub에서 보기 ↗">↗</a>
+          <span className="br">{IDE_REPO.branch}</span> · 변경 {IDE_REPO.dirty}건
+        </span>
+        <div className="ide-views">
+          {[['source', 'Source'], ['split', 'Split Diff'], ['find', '검색']].map(([k, l]) => (
+            <button key={k} className={`ide-view ${view === k ? 'on' : ''}`} onClick={() => setView(k)}>{l}</button>
+          ))}
+        </div>
+        <span className="spacer"></span>
+        <div className="ide-presence">
+          <span className="lbl">Presence</span>
+          {IDE_CURSORS.map((c, i) => {
+            const k = KEEPERS.find(kk => kk.id === c.keeper);
+            return <SigilBadge key={i} k={k} size={20} beat={c.focus === 'editing'} />;
+          })}
+        </div>
+        <button className="act icon" title={railOpen ? '활동 레일 접기' : '활동 레일 펼치기'} onClick={() => setRailOpen(o => !o)}>{railOpen ? '⊣' : '⊢'}</button>
+      </div>
+
+      <div className={`ide-body ${treeOpen ? '' : 'no-tree'} ${railOpen ? '' : 'no-rail'}`}>
+        <IdeTree open={treeOpen} file={file} onPick={setFile} />
+        <section className="ide-ed">
+          <div className="ide-crumb">
+            {segs.map((s, i) => (
+              <React.Fragment key={i}>
+                <span className={`seg ${i === segs.length - 1 ? 'last' : ''}`}>{s}</span>
+                {i < segs.length - 1 && <span>/</span>}
+              </React.Fragment>
+            ))}
+            <span className="own">
+              소유 {owner && <SigilBadge k={owner} size={14} />} sangsu · blame <span style={{ color: 'var(--volt-strong)' }}>c7be26acfb</span>
+            </span>
+          </div>
+          {view === 'find' && (
+            <div style={{ flex: 'none', display: 'flex', alignItems: 'center', gap: 9, padding: '7px 14px', borderBottom: '1px solid var(--border-soft)', background: 'var(--bg-panel-alt)' }}>
+              <span style={{ fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--text-dim)' }}>찾기</span>
+              <input className="roster-search" style={{ width: 240 }} value={findQ} onChange={e => setFindQ(e.target.value)} placeholder="패턴…" />
+              <span className="mono" style={{ fontSize: 10.5, color: 'var(--text-dim)' }}>
+                {findQ ? `${IDE_CODE.filter(([, h]) => (h || '').replace(/<[^>]+>/g, '').toLowerCase().includes(findQ.toLowerCase())).length}개 라인 일치 · round.ml` : '패턴을 입력하세요'}
+              </span>
+            </div>
+          )}
+          {view === 'split' ? <IdeDiff /> : <IdeEditor file={file} findQ={view === 'find' ? findQ : ''} onJumpAnn={() => { setRailOpen(true); setRailTab('ann'); }} />}
+          <div className={`ide-drawer ${drawerOpen ? '' : 'closed'}`}>
+            <div className="ide-drawer-h" onClick={() => setDrawerOpen(o => !o)}>
+              <span className="chev">▾</span>
+              <span>실행 출력 — dune test</span>
+              <span className="ok">84/84 ok</span>
+              <span style={{ marginLeft: 'auto' }}>oas·seoul-1 · sangsu</span>
+            </div>
+            <div className="ide-drawer-body">
+              {IDE_OUTPUT.map((l, i) => <div key={i} dangerouslySetInnerHTML={{ __html: l }}></div>)}
+            </div>
+          </div>
+        </section>
+        {railOpen ? <IdeRail tab={railTab} setTab={setRailTab} /> : <div></div>}
+      </div>
+    </main>
+  );
+}
+
+Object.assign(window, { IdeSurface });

--- a/dashboard/v2/index.html
+++ b/dashboard/v2/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>MASC v2 — Keeper Agent</title>
+<link rel="stylesheet" href="styles/colors_and_type.css" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" />
+<link rel="stylesheet" href="styles/v2.css" />
+<link rel="stylesheet" href="styles/surfaces.css" />
+<link rel="stylesheet" href="styles/dock.css" />
+<link rel="stylesheet" href="styles/craft.css" />
+<link rel="stylesheet" href="styles/inspector.css" />
+<link rel="stylesheet" href="styles/perf.css" />
+<link rel="stylesheet" href="styles/states.css" />
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; background: #08090d; }
+  #root { height: 100%; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<!-- React 18.3.1 UMD (same build + integrity as the prototype). In-browser
+     Babel was removed: each .jsx is pre-transpiled to a classic .js by
+     scripts/build-v2.mjs and loaded in the original order so the prototype's
+     shared global scope is preserved bit-for-bit. -->
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+
+<script src="primitives.js"></script>
+<script src="molecules.js"></script>
+<script src="organisms-2.js"></script>
+<script src="organisms-5.js"></script>
+<script src="perf.js"></script>
+<script src="tweaks-panel.js"></script>
+<script src="data.js"></script>
+<script src="data-surfaces.js"></script>
+<script src="messages.js"></script>
+<script src="turn-inspector.js"></script>
+<script src="rails.js"></script>
+<script src="overview.js"></script>
+<script src="work.js"></script>
+<script src="board.js"></script>
+<script src="connectors.js"></script>
+<script src="settings.js"></script>
+<script src="ide.js"></script>
+<script src="composer.js"></script>
+<script src="dock.js"></script>
+<script src="app.js"></script>
+</body>
+</html>

--- a/dashboard/v2/messages.jsx
+++ b/dashboard/v2/messages.jsx
@@ -1,0 +1,295 @@
+/* MASC v2 — message rendering: blocks, tool traces, feedback, suggestions */
+const { useState } = React;
+
+// Identity + status leaves now DELEGATE to the shared library (window.KV)
+// so the live app and the component catalog render from one source.
+// Signatures are kept (k-object in, status-string in) so call-sites are
+// untouched; the library atoms do the actual drawing.
+function StatusDot({ status, pulse }) {
+  const state = status === 'run' ? 'ok' : status === 'pause' ? 'warn' : status === 'off' ? 'idle' : status;
+  return React.createElement(window.KV.Dot, { state, pulse });
+}
+
+// Canonical keeper identity: color slot + 2-letter sigil (keeper-badge.ts).
+function SigilBadge({ k, size = 18, beat }) {
+  return React.createElement(window.KV.Sigil,
+    { slot: k.slot, size, heartbeat: beat, title: k.id, fontScale: 0.46 }, k.sigil);
+}
+
+function SigilChip({ k }) {
+  return (
+    <span className="sigil-chip" style={{ '--kc': `var(--kp${k.slot})` }}>
+      <SigilBadge k={k} size={17} /><span>{k.id}</span>
+    </span>
+  );
+}
+
+// Portrait when present, else the sigil badge. Used for the large chat hero.
+function Avatar({ k, baseClass, size }) {
+  const [err, setErr] = useState(false);
+  const src = PORTRAIT(k.portrait);
+  if (!src || err) {
+    return <span className={baseClass} style={{ '--kc': `var(--kp${k.slot})` }} data-sigil><SigilBadge k={k} size={size} /></span>;
+  }
+  return <img className={baseClass} src={src} onError={() => setErr(true)} alt={k.id} />;
+}
+
+function jsonHl(obj) {
+  const s = JSON.stringify(obj, null, 2);
+  return s
+    .replace(/("[^"]+"):/g, '<span class="jk">$1</span>:')
+    .replace(/: ("[^"]*")/g, ': <span class="js">$1</span>');
+}
+
+// total tool duration across the trace → "X.Xs"
+function traceDur(trace) {
+  let sum = 0, has = false;
+  trace.forEach(st => {
+    const m = st.kind === 'tool' && st.dur && st.dur.match(/([\d.]+)s/);
+    if (m) { sum += parseFloat(m[1]); has = true; }
+  });
+  return has ? (Math.round(sum * 10) / 10) + 's' : null;
+}
+
+function TraceStep({ step }) {
+  const [open, setOpen] = useState(false);
+
+  if (step.kind === 'think') {
+    return (
+      <div className="tstep think">
+        <span className="tnode"></span>
+        <div className="tstep-main">
+          <div className="tstep-row">
+            <span className="tstep-kind">Thinking</span>
+            <span className="tstep-text">{step.text}</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (step.kind === 'reason') {
+    const exp = !!step.detail;
+    return (
+      <div className={`tstep reason ${open ? 'exp' : ''}`}>
+        <span className="tnode"></span>
+        <div className="tstep-main">
+          <div className={`tstep-row ${exp ? 'click' : ''}`} onClick={() => exp && setOpen(o => !o)}>
+            <span className="tstep-kind">Reasoning</span>
+            <span className="tstep-text" dangerouslySetInnerHTML={{ __html: step.text }}></span>
+            {exp && <span className="chev sm">▶</span>}
+          </div>
+          {exp && open && <div className="reason-detail" dangerouslySetInnerHTML={{ __html: step.detail }}></div>}
+        </div>
+      </div>
+    );
+  }
+
+  // tool
+  return (
+    <div className={`tstep tool ${open ? 'exp' : ''}`}>
+      <span className="tnode"></span>
+      <div className="tstep-main">
+        <div className="tstep-row click" onClick={() => setOpen(o => !o)}>
+          <span className="tstep-kind">Tool</span>
+          <span className="tname mono">{step.name}</span>
+          <StatusDot status={step.status === 'ok' ? 'run' : 'bad'} />
+          <span className="tdur mono">{step.dur}</span>
+          <span className="chev sm">▶</span>
+        </div>
+        {open && (
+          <div className="tool-body2">
+            <div className="tk">args</div>
+            <pre dangerouslySetInnerHTML={{ __html: jsonHl(step.args) }}></pre>
+            <div className="tk">result</div>
+            <pre dangerouslySetInnerHTML={{ __html: step.result.replace(/("[^"]+")/g, '<span class="js">$1</span>') }}></pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TraceGroup({ trace }) {
+  const [open, setOpen] = useState(true);
+  const toolN = trace.filter(s => s.kind === 'tool').length;
+  const dur = traceDur(trace);
+  return (
+    <div className={`trace ${open ? 'open' : ''}`}>
+      <div className="trace-hd" onClick={() => setOpen(o => !o)}>
+        <span className="chev">▶</span>
+        <span className="glyph">◈</span>
+        <span className="tlabel">작업 과정</span>
+        <span className="tcount">{trace.length}단계</span>
+        <span className="tmeta">
+          {toolN > 0 && <span>도구 {toolN}</span>}
+          {dur && <span className="mono">{dur}</span>}
+        </span>
+      </div>
+      <div className="trace-steps">
+        <span className="trace-rail"></span>
+        {trace.map((s, i) => <TraceStep key={i} step={s} />)}
+      </div>
+    </div>
+  );
+}
+
+// VoiceMemo / AttachCard / Broadcast moved into the shared library (window.KVM
+// .Voice / .Attach / .Broadcast). Block() below maps the `b` block → those.
+
+function linkifyHtml(html) {
+  if (!html || html.indexOf('http') === -1 || html.indexOf('<a ') !== -1) return html;
+  return html.replace(/(^|[\s(>])(https?:\/\/[^\s<)]+[^\s<).,!?:;])/g, '$1<a class="inline-link" href="$2" target="_blank" rel="noopener noreferrer">$2</a>');
+}
+
+// Web link unfurl — compact preview card (favicon · title · desc · source)
+function LinkCard({ b }) {
+  let host = b.meta;
+  try { host = new URL(b.url).hostname.replace(/^www\./, ''); } catch (e) {}
+  return (
+    <a className={`linkcard ${b.kind || ''}`} href={b.url} target="_blank" rel="noopener noreferrer">
+      <span className="linkcard-fav">{b.fav || (host ? host[0].toUpperCase() : '\u2197')}</span>
+      <span className="linkcard-body">
+        <span className="linkcard-title">{b.title}</span>
+        {b.desc && <span className="linkcard-desc">{b.desc}</span>}
+        <span className="linkcard-meta mono">{b.meta || host}</span>
+      </span>
+      <span className="linkcard-go">{'\u2197'}</span>
+    </a>
+  );
+}
+
+function Block({ b }) {
+  const KVM = window.KVM;
+  if (b.t === 'broadcast') return <KVM.Broadcast tag="⊚ 브로드캐스트" scope={b.scope} via={b.via} note={b.note} recipients={b.recipients} />;
+  if (b.t === 'link') return <LinkCard b={b} />;
+  if (b.t === 'p') return <p dangerouslySetInnerHTML={{ __html: linkifyHtml(b.html) }}></p>;
+  if (b.t === 'h4') return <h4 dangerouslySetInnerHTML={{ __html: b.html }}></h4>;
+  if (b.t === 'ul') return <ul>{b.items.map((it, i) => <li key={i} dangerouslySetInnerHTML={{ __html: linkifyHtml(it) }}></li>)}</ul>;
+  if (b.t === 'callout') return <KVM.Callout html={b.html} />;
+  if (b.t === 'table') return <KVM.MdTable head={b.head} rows={b.rows} />;
+  if (b.t === 'code') return <KVM.CodeBlock caption={b.cap} html={b.html} />;
+  if (b.t === 'shell') return <KVM.ShellBlock title={b.title} lines={b.lines} exit={b.exit} dur={b.dur} />;
+  if (b.t === 'artifact') {
+    const icon = b.kind === 'md' ? '⌹' : b.kind === 'svg' ? '◫' : b.kind === 'json' ? '{ }' : '⎙';
+    const sub = `${(b.kind || 'file').toUpperCase()}${b.size ? ` · ${b.size}` : ''}${b.note ? ` · ${b.note}` : ''}`;
+    return <KVM.Artifact icon={icon} name={b.name} sub={sub} actions={[{ label: '열기' }, { label: '다운로드' }]} />;
+  }
+  if (b.t === 'attach') return <KVM.Attach clip="◫" name={b.name} dims={b.dims} svg={b.svg} src={b.src} ph={b.ph} tag="이미지 첨부" via={b.via} size={b.size} />;
+  if (b.t === 'voice') return <KVM.Voice secs={b.secs} wave={b.wave} via={b.via} size={b.size} transcript={b.transcript} sttLabel="받아쓰기" />;
+  if (b.t === 'image') return (
+    <figure className="img-out">
+      <div className="img-frame">{b.src ? <img src={b.src} alt={b.cap || ''} /> : <div className="img-ph">{b.ph || '실행 화면'}</div>}</div>
+      {b.cap && <figcaption>{b.cap}</figcaption>}
+    </figure>
+  );
+  if (b.t === 'svg') return (
+    <figure className="svg-out">
+      <div className="svg-frame" dangerouslySetInnerHTML={{ __html: b.svg }}></div>
+      {b.cap && <figcaption>{b.cap}</figcaption>}
+    </figure>
+  );
+  return null;
+}
+
+// Thin adapter → shared FeedbackRow (self-managed, KO, with copy + regenerate).
+function Feedback({ verified, onInspect, onRegenerate }) {
+  return <window.KVM.FeedbackRow verified={verified} onInspect={onInspect} onRegenerate={onRegenerate} showCopy showRegen ko />;
+}
+
+function Suggestions({ items, onPick }) {
+  if (!items || !items.length) return null;
+  return (
+    <div className="suggest">
+      <span className="lbl">추천 후속 질문</span>
+      <div className="suggest-row">
+        {items.map((s, i) => (
+          <SuggestionChip key={i} pre={'\u203A'} onClick={() => onPick && onPick(s)}>{s}</SuggestionChip>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SourceBadge({ source }) {
+  const label = { dashboard: 'Dashboard', discord: 'Discord', slack: 'Slack', imessage: 'iMessage' }[source] || source;
+  return <span className={`src-badge ${source}`}>{label}</span>;
+}
+
+// Thin adapter → shared Provenance with an expandable scope preview.
+function CtxFrom({ cf }) {
+  const detail = cf.preview ? (
+    <div className="cf-detail">
+      <div className="cf-detail-h">{cf.guild} · {cf.channel} · {cf.via} 가 가져온 {cf.msgs}개 중 일부</div>
+      {cf.preview.map((m, i) => (
+        <div key={i} className="cf-msg">
+          <span className="cf-ts mono">{m[0]}</span>
+          <span className="cf-who">{m[1]}</span>
+          <span className="cf-text">{m[2]}</span>
+        </div>
+      ))}
+    </div>
+  ) : null;
+  return (
+    <window.KVM.Provenance icon={'\u2318'} action="범위 보기" detail={detail}>
+      <span><b>{cf.channel}</b> 맥락 포함 · 메시지 {cf.msgs}개 · {cf.range}</span>
+    </window.KVM.Provenance>
+  );
+}
+
+const Message = React.memo(function Message({ m, keeper, onPickSuggestion, onRegenerate }) {
+  const isUser = m.role === 'user';
+  const [inspect, setInspect] = useState(false);
+  const trace = m.trace || (m.tools ? m.tools.map(t => ({ kind: 'tool', ...t })) : null);
+  const senderName = isUser ? (m.nick || m.who || 'operator') : keeper.id;
+  const handle = isUser && m.nick && m.who ? m.who : null;
+  const avLabel = (m.nick || m.who) ? (m.nick || m.who).replace(/^@/, '').slice(0, 2).toUpperCase() : 'YOU';
+  return (
+    <div className={`msg ${isUser ? 'from-user' : ''}`} style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 120px' }}>
+      {isUser
+        ? <div className="msg-av op" title={senderName}>{avLabel}</div>
+        : <SigilBadge k={keeper} size={34} beat={keeper.status === 'run'} />}
+      <div className="msg-col">
+        <div className="msg-hd">
+          <span className="who">{senderName}</span>
+          {handle && <span className="whoh">{handle}</span>}
+          <SourceBadge source={m.source} />
+          {m.regen && <span className="regen-tag" title="이 응답은 재생성되었습니다">↻ 재생성됨</span>}
+          <span className="ts mono">{m.ts}</span>
+        </div>
+        {m.ctxFrom && <CtxFrom cf={m.ctxFrom} />}
+        {trace && <TraceGroup trace={trace} />}
+        <div className={`bubble ${isUser ? 'user' : ''}`} style={trace ? { marginTop: '10px' } : null}>
+          {m.blocks.map((b, i) => <Block key={i} b={b} />)}
+        </div>
+        {!isUser && <Feedback verified={m.verified} onInspect={() => setInspect(true)} onRegenerate={onRegenerate} />}
+        {!isUser && <Suggestions items={m.suggestions} onPick={onPickSuggestion} />}
+      </div>
+      {inspect && <TurnInspector keeper={keeper} m={m} onClose={() => setInspect(false)} />}
+    </div>
+  );
+}, (a, b) => (
+  // the message object is immutable once pushed; skip re-render on parent
+  // churn (typing indicator, sibling appends) when this turn is unchanged
+  a.m === b.m && a.m.regen === b.m.regen &&
+  a.keeper.id === b.keeper.id && a.keeper.status === b.keeper.status
+));
+
+function TypingMessage({ keeper }) {
+  return (
+    <div className="msg">
+      <SigilBadge k={keeper} size={34} beat={keeper.status === 'run'} />
+      <div className="msg-col">
+        <div className="msg-hd">
+          <span className="who">{keeper.id}</span>
+          <span className="ts mono">작성 중…</span>
+        </div>
+        <div className="bubble">
+          <span className="typing"><i></i><i></i><i></i></span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { StatusDot, SigilBadge, SigilChip, Avatar, TraceGroup, TraceStep, Block, Feedback, Suggestions, SourceBadge, Message, TypingMessage });

--- a/dashboard/v2/molecules.jsx
+++ b/dashboard/v2/molecules.jsx
@@ -1,0 +1,599 @@
+// @ds-adherence-ignore -- v2 skin molecule library (composes primitives.jsx + the established v2.css/surfaces.css classes by design)
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Molecule component library
+   The catalog's "molecules" — shell chrome, the chat scaffold,
+   the content blocks a keeper embeds in a reply, the turn-inspector
+   viz, and the feedback/attention surfaces — were still raw class
+   strings. This turns the rest of the catalog into named, reusable
+   React molecules built FROM the atoms in primitives.jsx (KV).
+
+   Same contract as primitives.jsx:
+     React + ReactDOM (UMD)  →  babel  →  primitives.jsx  →  this file
+   Everything is exported onto window + window.KVM at the bottom.
+   ══════════════════════════════════════════════════════════════ */
+
+const { useState, useMemo } = React;
+const {
+  Dot, Pill, StatePill, Sigil, Button, Spinner,
+} = window.KV;
+
+const cx = (...a) => a.filter(Boolean).join(' ');
+
+/* ════════════════════════════════════════════════════════════════
+   SHELL & CHROME — the app frame
+   ════════════════════════════════════════════════════════════════ */
+function Wordmark({ ver = 'v2' }) {
+  return (
+    <div className="v2-wordmark"><b>MASC</b><span className="ver">{ver}</span></div>
+  );
+}
+function StatChip({ tone = 'live', dot = 'ok', count, children }) {
+  return (
+    <span className={cx('v2-statchip', tone)}>
+      {dot ? <span className={cx('dot2', dot)} /> : null}
+      {count != null ? <b>{count}</b> : null} {children}
+    </span>
+  );
+}
+function Crumb({ trail = [] }) {
+  // trail: ['Keepers', {label:'iron-claw', on:true}]
+  return (
+    <span className="crumb">
+      {trail.map((t, i) => {
+        const label = typeof t === 'object' ? t.label : t;
+        const on = typeof t === 'object' && t.on;
+        return <span key={i} className={on ? 'on' : undefined}>{i ? '/ ' : ''}{label}</span>;
+      })}
+    </span>
+  );
+}
+function TopBar({ ver, crumb, chips, style, children }) {
+  return (
+    <div className="v2-top" style={style}>
+      <Wordmark ver={ver} />
+      {crumb ? <Crumb trail={crumb} /> : null}
+      <div className="v2-top-spacer" />
+      {chips}
+      {children}
+    </div>
+  );
+}
+
+const NAV_ICONS = {
+  fleet: <><rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" /><rect x="3" y="14" width="7" height="7" /><rect x="14" y="14" width="7" height="7" /></>,
+  chat: <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />,
+  work: <><path d="M9 11l3 3L22 4" /><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" /></>,
+  set: <><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-2.82 1.17V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15H4.5a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 6 9.4l.33-.59z" /></>,
+};
+function NavItem({ icon, label, active = false, onClick }) {
+  const glyph = typeof icon === 'string' ? NAV_ICONS[icon] : icon;
+  return (
+    <button className={cx('nav-item', active && 'on')} onClick={onClick}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">{glyph}</svg>
+      <span className="nlbl">{label}</span>
+    </button>
+  );
+}
+function NavRail({ home = 'M', items = [], value, onChange, style }) {
+  // items: [{ id, icon, label, foot }]
+  const top = items.filter(i => !i.foot);
+  const foot = items.filter(i => i.foot);
+  return (
+    <div className="v2-nav" style={style}>
+      <div className="nav-home">{home}</div>
+      {top.map(it => <NavItem key={it.id} icon={it.icon} label={it.label} active={value === it.id} onClick={() => onChange && onChange(it.id)} />)}
+      <div className="nav-spacer" />
+      {foot.map(it => <NavItem key={it.id} icon={it.icon} label={it.label} active={value === it.id} onClick={() => onChange && onChange(it.id)} />)}
+    </div>
+  );
+}
+function RailToggle({ side = 'left', children, ...rest }) {
+  return <button className={cx('rail-toggle', side)} {...rest}>{children || (side === 'left' ? '‹' : '›')}</button>;
+}
+function SurfaceHead({ eyebrow, title, sub, action, style }) {
+  return (
+    <div className="surf-head" style={style}>
+      <div>
+        {eyebrow ? <div className="eyebrow">{eyebrow}</div> : null}
+        <h1>{title}</h1>
+        {sub ? <div className="surf-sub">{sub}</div> : null}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   FSM LIFELINE — the 12-state keeper machine as a vertical lifeline
+   ════════════════════════════════════════════════════════════════ */
+function FsmLifeline({ steps = [], style }) {
+  // steps: [{ label, state: 'done'|'cur'|'' }]
+  return (
+    <div className="fsm" style={style}>
+      {steps.map((s, i) => (
+        <div key={i} className={cx('fsm-step', s.state)}><span className="pip" />{s.label}</div>
+      ))}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   STREAMING & LIVE — typing, caret, throughput, progress
+   ════════════════════════════════════════════════════════════════ */
+function Typing() {
+  return <div className="typing"><i /><i /><i /></div>;
+}
+function StreamingCaret() {
+  return <span className="dcaret" />;
+}
+function TpsLive({ rate = 41 }) {
+  return (
+    <span className="tps-live"><span className="tps-dot" /><span className="mono">{rate} tok/s</span></span>
+  );
+}
+function SegmentedProgress({ done = 0, wip = 0, blocked = 0, total = 100, style }) {
+  const rest = Math.max(0, total - done - wip - blocked);
+  return (
+    <div className="wk-prog" style={{ maxWidth: 'none', ...style }}>
+      {done ? <span className="wk-seg done" style={{ flex: done }} /> : null}
+      {wip ? <span className="wk-seg wip" style={{ flex: wip }} /> : null}
+      {blocked ? <span className="wk-seg blocked" style={{ flex: blocked }} /> : null}
+      {rest ? <span style={{ flex: rest }} /> : null}
+    </div>
+  );
+}
+function Sparkline({ values, count = 28, label, style }) {
+  const heights = useMemo(
+    () => values || Array.from({ length: count }, () => 20 + Math.random() * 78),
+    [values, count]
+  );
+  return (
+    <div className="tps-spark" style={style}>
+      {heights.map((h, i) => <span key={i} style={{ height: h + '%' }} />)}
+      {label ? <span className="tps-spark-rt">{label}</span> : null}
+    </div>
+  );
+}
+function TelemetryBars({ values, count = 24, hotRate = 0.78, style }) {
+  const bars = useMemo(
+    () => values || Array.from({ length: count }, () => ({ h: 18 + Math.random() * 80, hot: Math.random() > hotRate })),
+    [values, count, hotRate]
+  );
+  return (
+    <div className="ov-bars" style={style}>
+      {bars.map((b, i) => <div key={i} className={cx('ov-bar', b.hot && 'hot')} style={{ height: b.h + '%' }} />)}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   IDENTITY — the roster row (Sigil + Dot + Pill composed)
+   ════════════════════════════════════════════════════════════════ */
+const RosterRow = React.memo(function RosterRow({ slot = 1, mono, name, state = 'running', dot = 'ok', time, count, selected = false, onClick, style }) {
+  return (
+    <div className={cx('kp-row', selected && 'sel')} onClick={onClick} style={style}>
+      <Sigil slot={slot} size={38}>{mono}</Sigil>
+      <div className="kp-meta">
+        <div className="kp-name">{name}</div>
+        <div className="kp-sub"><span className="kp-state"><Dot state={dot} />{state}</span></div>
+      </div>
+      <div className="kp-right">
+        {count != null ? <span className="kp-att">{count}</span> : time != null ? <span className="kp-time">{time}</span> : null}
+      </div>
+    </div>
+  );
+});
+
+/* ════════════════════════════════════════════════════════════════
+   CHAT SCAFFOLD — bubble, day divider, message row, header, meta
+   ════════════════════════════════════════════════════════════════ */
+function Bubble({ user = false, style, children }) {
+  return <div className={cx('bubble', user && 'user')} style={style}>{children}</div>;
+}
+function DayDivider({ children = 'Today' }) {
+  return <div className="daydiv">{children}</div>;
+}
+function MessageRow({ slot = 1, mono, op = false, who, handle, ts, source, fromUser = false, children }) {
+  return (
+    <div className={cx('msg', fromUser && 'from-user')}>
+      {op
+        ? <div className="msg-av op">{mono || 'OP'}</div>
+        : <div className="msg-av sigil" style={{ '--kc': `var(--kp${slot})` }}>{mono}</div>}
+      <div className="msg-col">
+        <div className="msg-hd">
+          {fromUser ? <span className="ts">{ts}</span> : null}
+          {who ? <span className="who">{who}</span> : null}
+          {handle ? <span className="whoh">{handle}</span> : null}
+          {!fromUser ? <span className="ts">{ts}</span> : null}
+          {source ? <span className={cx('src-badge', source)}>{source}</span> : null}
+        </div>
+        <Bubble user={fromUser}>{children}</Bubble>
+      </div>
+    </div>
+  );
+}
+function ChatMeta({ cells = [] }) {
+  // cells: [{ k, v, tone }]
+  return (
+    <div className="chat-meta">
+      {cells.map((c, i) => (
+        <div key={i} className="meta-cell">
+          <span className="k">{c.k}</span>
+          <span className={cx('v', c.tone)}>{c.v}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+function ChatHead({ slot = 1, mono, name, slug, state = 'running', model, tps, turn, actions, style }) {
+  return (
+    <div className="chat-head" style={style}>
+      <div className="chat-av" data-sigil><Sigil slot={slot}>{mono}</Sigil></div>
+      <div className="chat-id">
+        <div className="name-row">
+          <h2>{name}</h2>
+          {slug ? <span className="slug">{slug}</span> : null}
+          <StatePill state={state}>{state[0].toUpperCase() + state.slice(1)}</StatePill>
+        </div>
+        <div className="sub">
+          {model ? <span>{model}</span> : null}
+          {tps != null ? <TpsLive rate={tps} /> : null}
+          {turn ? <span>turn {turn}</span> : null}
+        </div>
+      </div>
+      <div className="chat-actions">{actions}</div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   MESSAGING — broadcast
+   ════════════════════════════════════════════════════════════════ */
+const BCAST_ACK = { acked: '확인함', read: '읽음', delivered: '전달됨' };
+function Broadcast({ scope, via, count, note, recipients = [], tag = 'Broadcast' }) {
+  // recipients: [{ id, ack: 'acked'|'read'|'delivered', at }]
+  const findK = (id) => (window.KEEPERS || []).find(k => k.id === id);
+  const ackN = recipients.filter(r => r.ack === 'acked').length;
+  const countNode = count != null ? count : (recipients.length ? `${ackN}/${recipients.length} 확인` : null);
+  return (
+    <div className="bcast">
+      <div className="bcast-hd">
+        <span className="bcast-tag">{tag}</span>
+        {scope ? <span className="bcast-scope mono">{scope}</span> : null}
+        {via ? <span className="bcast-via mono">{via}</span> : null}
+        {countNode != null ? <span className="bcast-count mono">{countNode}</span> : null}
+      </div>
+      {note ? <div className="bcast-note">{note}</div> : null}
+      {recipients.length ? (
+        <div className="bcast-rcpts">
+          {recipients.map((r, i) => {
+            const k = findK(r.id);
+            return (
+              <div key={i} className={cx('bcast-rcpt', r.ack)}>
+                {k ? <Sigil slot={k.slot} size={16} title={k.id} fontScale={0.46}>{k.sigil}</Sigil> : null}
+                <span className="bcast-rcpt-id">{r.id}</span>
+                <span className="bcast-ack">{(BCAST_ACK[r.ack] || r.ack)}{r.at ? ` · ${r.at}` : ''}</span>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   CONTENT BLOCKS — what a keeper embeds inside a reply
+   ════════════════════════════════════════════════════════════════ */
+function Callout({ icon = '⚠', html, children }) {
+  return (
+    <div className="callout">
+      <span className="ico">{icon}</span>
+      {html != null ? <span dangerouslySetInnerHTML={{ __html: html }}></span> : <div>{children}</div>}
+    </div>
+  );
+}
+function Trace({ label = 'Reasoning', glyph = '◆', count, meta, defaultOpen = true, steps = [] }) {
+  // steps: [{ kind:'think'|'reason'|'tool', text, name, dur, ok }]
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className={cx('trace', open && 'open')}>
+      <div className="trace-hd" onClick={() => setOpen(o => !o)}>
+        <span className="chev">▸</span>
+        <span className="glyph">{glyph}</span>
+        <span className="tlabel">{label}</span>
+        {count ? <span className="tcount">{count}</span> : null}
+        {meta ? <span className="tmeta"><span className="mono">{meta}</span></span> : null}
+      </div>
+      <div className="trace-steps">
+        <div className="trace-rail" />
+        {steps.map((s, i) => (
+          <div key={i} className={cx('tstep', s.kind)}>
+            <span className="tnode" />
+            <div className="tstep-main">
+              <div className="tstep-row">
+                <span className="tstep-kind">{s.kind}</span>
+                {s.name ? <span className="tname">{s.name}</span> : null}
+                {s.dur ? <span className="tdur">{s.dur}</span> : null}
+                {s.ok != null ? <Dot state={s.ok ? 'ok' : 'bad'} /> : null}
+              </div>
+              {s.text ? <div className="tstep-text">{s.text}</div> : null}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+function CodeBlock({ caption, html, children }) {
+  return (
+    <div className="code-block">
+      {caption ? <div className="code-cap mono">{caption}</div> : null}
+      <pre className="mono">{html != null ? <code dangerouslySetInnerHTML={{ __html: html }}></code> : <code>{children}</code>}</pre>
+    </div>
+  );
+}
+function ShellBlock({ title = 'keeper@worktree', lines = [], exit, dur }) {
+  // lines: [{ kind|t:'cmd'|'ok'|'err'|'dim', text | v(html) }]
+  return (
+    <div className="shell-block">
+      <div className="shell-bar">
+        <span className="dot r" /><span className="dot y" /><span className="dot g" />
+        {title ? <span className="shell-title mono">{title}</span> : null}
+      </div>
+      <pre className="mono">
+        {lines.map((l, i) => {
+          const kind = l.kind || l.t;
+          return (
+            <div key={i} className={cx('sh-ln', kind)}>
+              {kind === 'cmd' ? <span className="sh-prompt">$ </span> : null}
+              {l.v != null ? <span dangerouslySetInnerHTML={{ __html: l.v }}></span> : l.text}
+            </div>
+          );
+        })}
+      </pre>
+      {exit != null ? <div className={cx('shell-exit', exit === 0 ? 'ok' : 'fail')}>exit {exit}{dur ? ` · ${dur}` : ''}</div> : null}
+    </div>
+  );
+}
+function MdTable({ head = [], rows = [] }) {
+  // head: ['Keeper', {label:'Turns', num:true}]  rows: [['iron-claw', {v:88,num:true}, {v:'running',muted:true}]]
+  const cell = c => (typeof c === 'object' ? c : { v: c });
+  return (
+    <table className="md-table">
+      <thead><tr>{head.map((h, i) => { const c = cell(h); return <th key={i} className={c.num ? 'num' : undefined}>{c.v ?? c.label}</th>; })}</tr></thead>
+      <tbody>
+        {rows.map((r, i) => (
+          <tr key={i}>{r.map((c2, j) => { const c = cell(c2); return <td key={j} className={cx(c.num && 'num', c.muted && 'muted')}>{c.v}</td>; })}</tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+function Artifact({ icon = '⌬', name, sub, action = 'Open', onAction, actions }) {
+  return (
+    <div className="artifact">
+      <div className="af-ico">{icon}</div>
+      <div className="af-meta"><div className="af-name mono">{name}</div><div className="af-sub">{sub}</div></div>
+      {actions
+        ? actions.map((a, i) => <button key={i} className="af-btn" onClick={a.onClick}>{a.label}</button>)
+        : <button className="af-btn" onClick={onAction}>{action}</button>}
+    </div>
+  );
+}
+function Attach({ name, dims, src, svg, ph, alt, clip = '◫', tag = 'vision', caption, via, size, imgStyle, mono = true }) {
+  const capText = caption != null ? caption : [via, size].filter(Boolean).join(' · ');
+  return (
+    <div className="attach">
+      <div className="attach-hd">
+        <span className="attach-clip">{clip}</span>
+        <span className={cx('attach-name', mono && 'mono')}>{name}</span>
+        {dims ? <span className={cx('attach-dims', mono && 'mono')}>{dims}</span> : null}
+      </div>
+      <div className="attach-frame">
+        {svg ? <span dangerouslySetInnerHTML={{ __html: svg }}></span>
+          : src ? <img src={src} alt={alt || name} style={imgStyle} />
+          : <div className="img-ph">{ph || '첨부 이미지'}</div>}
+      </div>
+      {(capText || tag) ? <div className="attach-cap">{tag ? <span className="attach-tag">{tag}</span> : null}{capText}</div> : null}
+    </div>
+  );
+}
+// Voice memo — static (catalog: dur/bars/played/stt) OR interactive playback
+// (live: pass `secs` + `wave[]` 0..1 and it scrubs a playhead). One source.
+function Voice({ dur, secs, wave, bars = 42, played = 17, stt, transcript, sttLabel = 'STT', via, size }) {
+  const txt = transcript != null ? transcript : stt;
+  const interactive = secs != null;
+  const [playing, setPlaying] = useState(false);
+  const [prog, setProg] = useState(0);
+  React.useEffect(() => {
+    if (!interactive || !playing) return;
+    const start = performance.now() - prog * secs * 1000;
+    let raf;
+    const tick = (now) => {
+      const p = Math.min(1, (now - start) / (secs * 1000));
+      setProg(p);
+      if (p >= 1) { setPlaying(false); return; }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [playing]);
+  const heights = useMemo(() => Array.from({ length: bars }, () => 22 + Math.random() * 74), [bars]);
+  const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.round(s) % 60).padStart(2, '0')}`;
+  const toggle = () => { if (prog >= 1) setProg(0); setPlaying(p => !p); };
+  const barNodes = wave
+    ? wave.map((h, i) => <span key={i} className={cx('vbar', (i + 0.5) / wave.length <= prog && 'on')} style={{ height: `${Math.round(5 + h * 21)}px` }} />)
+    : heights.map((h, i) => <span key={i} className={cx('vbar', i < played && 'on')} style={{ height: h + '%' }} />);
+  const durLabel = interactive ? fmt((playing || prog > 0) ? prog * secs : secs) : (dur || '0:12');
+  return (
+    <div className="voice">
+      <div className="voice-row">
+        <button className={cx('voice-play', playing && 'on')} onClick={interactive ? toggle : undefined} aria-label={playing ? '일시정지' : '재생'}>{playing ? '❙❙' : '▶'}</button>
+        <div className="voice-wave">{barNodes}</div>
+        <span className="voice-dur mono">{durLabel}</span>
+      </div>
+      {via ? <div className="voice-meta"><span className="voice-via">{'◌'} {via}</span>{size ? <span className="mono">{size}</span> : null}</div> : null}
+      {txt ? <div className="voice-tx"><span className="voice-tx-k">{sttLabel}</span><span className="voice-tx-v">{txt}</span></div> : null}
+    </div>
+  );
+}
+function ContextMenu({ slot = 1, mono, name, items = [], style }) {
+  // items: [{ label, danger }, 'sep']
+  return (
+    <div className="kp-menu" style={{ position: 'static', animation: 'none', width: 186, ...style }}>
+      {name ? <div className="kp-menu-h"><Sigil slot={slot} size={17}>{mono}</Sigil>{name}</div> : null}
+      {items.map((it, i) =>
+        it === 'sep'
+          ? <div key={i} className="kp-menu-sep" />
+          : <button key={i} className={cx('kp-menu-i', it.danger && 'danger')} onClick={it.onClick}>{it.label}</button>
+      )}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   INSPECTOR VIZ — turn-level data viz
+   ════════════════════════════════════════════════════════════════ */
+function StatSummary({ stats = [], cols, style }) {
+  // stats: [{ k, v, sub, tone }]
+  return (
+    <div className="ti-summary" style={{ gridTemplateColumns: cols || `repeat(${stats.length || 1},1fr)`, ...style }}>
+      {stats.map((s, i) => (
+        <div key={i} className="ti-stat">
+          <div className="k">{s.k}</div>
+          <div className={cx('v', s.tone)}>{s.v}{s.sub ? <small>{s.sub}</small> : null}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+function TokenEconomics({ ctxLabel, inPct = 72, outPct = 28, inVal, outVal, style }) {
+  return (
+    <div className="ti-tok" style={{ padding: 0, ...style }}>
+      <div className="ti-tok-top"><span className="lbl">Token mix</span>{ctxLabel ? <span className="ctxpct">{ctxLabel}</span> : null}</div>
+      <div className="ti-tok-bar"><span className="seg-in" style={{ width: inPct + '%' }} /><span className="seg-out" style={{ width: outPct + '%' }} /></div>
+      <div className="ti-tok-legend"><span className="in">input <b>{inVal}</b></span><span className="out">output <b>{outVal}</b></span></div>
+    </div>
+  );
+}
+function Waterfall({ rows = [], total, style }) {
+  // rows: [{ kind:'ctx'|'reason'|'tool'|'gen', label, mono, left, width, dur }]
+  return (
+    <div className="ti-wf" style={style}>
+      {rows.map((r, i) => (
+        <div key={i} className="ti-wf-row">
+          <div className="ti-wf-lbl"><span className={cx('ti-wf-ico', 'ti-k-' + r.kind)} /><span className={cx('nm', r.mono && 'mono')}>{r.label}</span></div>
+          <div className="ti-wf-track"><div className={cx('ti-wf-bar', 'ti-k-' + r.kind)} style={{ left: r.left + '%', width: r.width + '%' }} /></div>
+          <div className="ti-wf-dur">{r.dur}</div>
+        </div>
+      ))}
+      <div className="ti-wf-foot">
+        <span>total <b>{total}</b></span>
+        <div className="ti-wf-legend">
+          <span><i className="ti-k-ctx" />ctx</span><span><i className="ti-k-reason" />reason</span>
+          <span><i className="ti-k-tool" />tool</span><span><i className="ti-k-gen" />gen</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+function InspectorChip({ sub, tone, children }) {
+  return <span className={cx('ti-chip', tone)}><span className="sub-k">{sub}</span>{children}</span>;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   FEEDBACK & ATTENTION
+   ════════════════════════════════════════════════════════════════ */
+// Response feedback row. Controlled (catalog: value/onChange) OR self-managed
+// (live: omit onChange). Optional copy / regenerate buttons + transient "noted".
+function FeedbackRow({ value, onChange, onInspect, onRegenerate, onCopy, verified = false, showCopy = false, showRegen = false, ko = false }) {
+  const controlled = onChange != null;
+  const [internal, setInternal] = useState(null);
+  const v = controlled ? value : internal;
+  const [copied, setCopied] = useState(false);
+  const [noted, setNoted] = useState(false);
+  const set = (nv) => {
+    const next = v === nv ? null : nv;
+    if (controlled) onChange(next); else setInternal(next);
+    if (next) { setNoted(true); setTimeout(() => setNoted(false), 2200); }
+  };
+  const L = ko
+    ? { good: '좋음', poor: '밄로', inspect: '턴 상세', copy: '복사', copied: '복사됨', verify: '검증 통과', regen: '재생성', noted: '피드백 기록됨', up: '△', down: '▽', vk: '◈' }
+    : { good: 'Good', poor: 'Poor', inspect: 'Inspect turn', copy: 'Copy', copied: 'Copied', verify: 'verified', regen: 'Regenerate', noted: 'Noted', up: '▲', down: '▼', vk: '✓' };
+  return (
+    <div className="fbk">
+      {showCopy ? <button className="fbk-btn" onClick={() => { setCopied(true); setTimeout(() => setCopied(false), 1200); onCopy && onCopy(); }}>{copied ? `✓ ${L.copied}` : `⎘ ${L.copy}`}</button> : null}
+      <button className={cx('fbk-btn', 'up', v === 'up' && 'on')} onClick={() => set('up')}>{L.up} {L.good}</button>
+      <button className={cx('fbk-btn', 'down', v === 'down' && 'on')} onClick={() => set('down')}>{L.down} {L.poor}</button>
+      {showRegen ? <button className="fbk-btn" onClick={onRegenerate}>{'↻'} {L.regen}</button> : null}
+      <button className="fbk-btn inspect" onClick={onInspect}>{ko ? '⊙ ' : ''}{L.inspect}</button>
+      {verified ? <span className="fbk-verify">{L.vk} {L.verify}</span> : null}
+      {noted ? <span className="fbk-noted">{'✓'} {L.noted}</span> : null}
+    </div>
+  );
+}
+function AttentionItem({ severity = 'warn', children }) {
+  return <div className={cx('att-item', severity)}><span className="att-dot" /><div>{children}</div></div>;
+}
+// External-context provenance. Pass `detail` (a node) to make `action` a
+// fold toggle that reveals it (live CtxFrom); otherwise `action`/`onAction`.
+function Provenance({ icon = '#', children, action, onAction, detail }) {
+  const [open, setOpen] = useState(false);
+  const toggles = detail != null && onAction == null;
+  const head = (
+    <div className="ctx-from">
+      <span className="cf-ico">{icon}</span>
+      <div>{children}</div>
+      {action ? <button className="cf-view" onClick={toggles ? () => setOpen(o => !o) : onAction}>{toggles && open ? '접기' : action}</button> : null}
+    </div>
+  );
+  if (detail == null) return head;
+  return <div className="ctx-from-wrap">{head}{open ? detail : null}</div>;
+}
+function RegenTag({ children = '재생성됨' }) {
+  return <span className="regen-tag">{children}</span>;
+}
+function Noted({ children = '기록됨 ✓' }) {
+  return <span className="fbk-noted">{children}</span>;
+}
+// Manual context-compaction trigger. state: 'idle' | 'busy' | 'done'.
+// Shared by the live ContextRail and the catalog so both render one button.
+function CompactButton({ state = 'idle', onClick, labels, title }) {
+  const L = labels || { idle: '지금 컴팩트', busy: '컴팩트 실행 중…', done: '컴팩트 완료' };
+  return (
+    <button className={cx('cmp-run', state === 'busy' && 'busy')} onClick={onClick} disabled={state === 'busy'}
+      title={title || '컨텍스트를 지금 즉시 압축 — 임계치 도달을 기다리지 않고 operator가 수동 실행'}>
+      {state === 'busy'
+        ? <React.Fragment><span className="cmp-spin"></span> {L.busy}</React.Fragment>
+        : state === 'done'
+          ? <React.Fragment>{'\u2713'} {L.done}</React.Fragment>
+          : <React.Fragment>{'\u25C9'} {L.idle}</React.Fragment>}
+    </button>
+  );
+}
+
+/* ── export every molecule to window so the demo babel script can
+   use these as JSX globals ── */
+const KVM = {
+  // shell
+  Wordmark, StatChip, Crumb, TopBar, NavItem, NavRail, RailToggle, SurfaceHead, NAV_ICONS,
+  // fsm
+  FsmLifeline,
+  // streaming
+  Typing, StreamingCaret, TpsLive, SegmentedProgress, Sparkline, TelemetryBars,
+  // identity
+  RosterRow,
+  // chat
+  Bubble, DayDivider, MessageRow, ChatMeta, ChatHead,
+  // messaging
+  Broadcast,
+  // content blocks
+  Callout, Trace, CodeBlock, ShellBlock, MdTable, Artifact, Attach, Voice, ContextMenu,
+  // inspector viz
+  StatSummary, TokenEconomics, Waterfall, InspectorChip,
+  // feedback
+  FeedbackRow, AttentionItem, Provenance, RegenTag, Noted, CompactButton,
+};
+Object.assign(window, KVM);
+window.KVM = KVM;

--- a/dashboard/v2/organisms-2.jsx
+++ b/dashboard/v2/organisms-2.jsx
@@ -1,0 +1,275 @@
+// @ds-adherence-ignore -- v2 skin organisms (batch 2): inspector drawer, settings, logs, connectors — composed from molecules.jsx/primitives.jsx
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Organisms, batch 2
+   Turn Inspector · Settings · Logs · Connectors — the remaining
+   page-level surfaces, each built from the atoms + molecules.
+   Exported onto window + window.KVO2.
+   ══════════════════════════════════════════════════════════════ */
+
+const { useState: use2 } = React;
+const K2 = window.KV, KM2 = window.KVM;
+const {
+  Dot, Pill, Sigil, Button, FilterChip, LogFilter, Toggle, Segmented, Stepper, StatCell,
+} = K2;
+const {
+  SurfaceHead, StatSummary, TokenEconomics, Waterfall, InspectorChip,
+  TpsLive, Callout,
+} = KM2;
+
+const o2 = (...a) => a.filter(Boolean).join(' ');
+
+/* ════════════════════════════════════════════════════════════════
+   TABS — tiny shared tab shell (turn-tabs)
+   ════════════════════════════════════════════════════════════════ */
+function Tabs({ tabs = [], value, onChange }) {
+  return (
+    <div className="turn-tabs">
+      {tabs.map(t => (
+        <button key={t.id} className={o2('turn-tab', value === t.id && 'on')} onClick={() => onChange(t.id)}>{t.label}</button>
+      ))}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   TURN INSPECTOR — the per-turn detail drawer (rendered inline here)
+   ════════════════════════════════════════════════════════════════ */
+function TurnInspectorPanel({ traceId = 'trc_iron_0142', model = 'sonnet-4.5', runtime = 'oas·seoul-1',
+  summary, tokIn = 168000, tokOut = 980, ctxPct = 68, waterfall = [], total = '2.4s', meta = [], asOverlay = false, onClose, style }) {
+  const [tab, setTab] = use2('timeline');
+  const inner = (
+    <div className={o2('turn-drawer', 'ti-drawer')} onClick={e => e.stopPropagation()} style={{ ...(asOverlay ? {} : { position: 'static', width: '100%', height: '100%', boxShadow: 'none', borderRadius: 0 }), ...style }}>
+      <div className="turn-hd">
+        <h3>턴 상세</h3>
+        <span className="tid mono">{traceId}</span>
+        {onClose ? <button className="turn-close" onClick={onClose} title="닫기 (Esc)" style={{ marginLeft: 8 }}>✕</button> : null}
+      </div>
+      <div className="ti-sub">
+        <InspectorChip sub="model">{model}</InspectorChip>
+        <InspectorChip sub="finish" tone="ok">stop</InspectorChip>
+        <InspectorChip sub="runtime">{runtime}</InspectorChip>
+      </div>
+      <StatSummary stats={summary} cols="repeat(5,1fr)" />
+      <TokenEconomics ctxLabel={`컨텍스트 ${ctxPct}% / 200K`}
+        inPct={tokIn / (tokIn + tokOut) * 100} outPct={tokOut / (tokIn + tokOut) * 100}
+        inVal={tokIn.toLocaleString()} outVal={tokOut.toLocaleString()} />
+      <Tabs value={tab} onChange={setTab} tabs={[
+        { id: 'timeline', label: '타임라인' }, { id: 'context', label: '컨텍스트' }, { id: 'meta', label: '메타' },
+      ]} />
+      <div className="turn-body">
+        {tab === 'timeline' ? (
+          <div className="turn-sec">
+            <div className="ti-sec-h"><h4>턴 워터폴</h4><span className="n">{waterfall.length} 단계 · {total}</span></div>
+            <Waterfall rows={waterfall} total={total} />
+          </div>
+        ) : null}
+        {tab === 'context' ? (
+          <div className="turn-sec">
+            <div className="ti-ctx-card">
+              <div className="ti-ctx-h"><span className="t">주입 컨텍스트 · namespace · tasks · traces</span><span className="tok">~{Math.round(tokIn / 3.6 / 1000)}k tok</span></div>
+              <pre>{`# namespace snapshot
+namespace   = ns:masc-core
+fsm.state   = Compacting
+ctx.window  = ${ctxPct}%   (${tokIn.toLocaleString()} / 200,000 tok)
+owned.tasks = 3
+
+# recent traces (last 30m)
+  - edit_file        0.3s  (2m ago)
+  - masc_git_blame   0.4s  (8m ago)`}</pre>
+            </div>
+          </div>
+        ) : null}
+        {tab === 'meta' ? (
+          <div className="turn-sec">
+            <div className="ti-sec-h"><h4>실행 메타데이터</h4></div>
+            <div className="turn-kv">
+              {meta.map((m, i) => <React.Fragment key={i}><span className="k">{m.k}</span><span className="v">{m.v}</span></React.Fragment>)}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+  if (asOverlay) return <div className="turn-overlay" onClick={onClose}>{inner}</div>;
+  return inner;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   SETTINGS — category rail + sectioned rows
+   ════════════════════════════════════════════════════════════════ */
+function SetRow({ label, hint, children }) {
+  return (
+    <div className="set-row">
+      <div className="set-row-l"><div className="set-label">{label}</div>{hint ? <div className="set-hint">{hint}</div> : null}</div>
+      <div className="set-row-c">{children}</div>
+    </div>
+  );
+}
+function SetNav({ groups = [], value, onChange }) {
+  return (
+    <nav className="set-nav" style={{ width: 210, flex: 'none', borderRight: '1px solid var(--border-main)', padding: '14px 10px', overflowY: 'auto' }}>
+      {groups.map((g, gi) => (
+        <div key={gi} style={{ marginBottom: 14 }}>
+          <div style={{ fontSize: 9, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--text-dim)', padding: '0 8px 6px' }}>{g.label}</div>
+          {g.items.map(it => (
+            <button key={it.id} className={o2('set-nav-i', value === it.id && 'on')} onClick={() => onChange(it.id)}
+              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '6px 9px', borderRadius: 'var(--radius-sm)', border: 0, background: value === it.id ? 'var(--bg-card)' : 'transparent', color: value === it.id ? 'var(--volt-strong)' : 'var(--text-mid)', fontSize: 12.5, cursor: 'pointer', borderLeft: '2px solid ' + (value === it.id ? 'var(--volt)' : 'transparent') }}>
+              {it.label}
+            </button>
+          ))}
+        </div>
+      ))}
+    </nav>
+  );
+}
+function SettingsSurface({ style }) {
+  const [sec, setSec] = use2('runtime');
+  const [autoCompact, setAuto] = use2(true);
+  const [compactAt, setCompactAt] = use2(85);
+  const [maxPar, setMaxPar] = use2(6);
+  const [model, setModel] = use2('claude-sonnet-4');
+  const [reply, setReply] = use2('mention');
+  const [followIde, setFollowIde] = use2(true);
+  const groups = [
+    { label: '계정', items: [{ id: 'account', label: 'Account' }] },
+    { label: 'Keeper 운영', items: [{ id: 'runtime', label: 'Runtime 기본값' }, { id: 'routing', label: '모델 라우팅' }, { id: 'policy', label: '승인 정책' }] },
+    { label: '연결 · 통합', items: [{ id: 'mcp', label: 'MCP 서버' }, { id: 'gate', label: '커넥터 게이트' }] },
+    { label: '관측 · 표시', items: [{ id: 'display', label: '표시' }] },
+  ];
+  return (
+    <div className="set" style={{ display: 'flex', height: '100%', minHeight: 0, ...style }}>
+      <SetNav groups={groups} value={sec} onChange={setSec} />
+      <div className="set-body surf-scroll" style={{ flex: 1, padding: 22, overflowY: 'auto' }}>
+        <SurfaceHead eyebrow="Operator" title="런타임 기본값"
+          sub={<>새 keeper 생성 시 적용되는 기본값 · <span className="mono">12-FSM</span></>} />
+        <div className="set-card" style={{ background: 'var(--bg-panel)', border: '1px solid var(--border-main)', borderRadius: 'var(--radius-md)', padding: '4px 16px', marginBottom: 16 }}>
+          <SetRow label="자동 컴팩션" hint="컨텍스트 임계치 초과 시 compact() 자동 호출">
+            <Toggle on={autoCompact} onChange={setAuto} />
+          </SetRow>
+          <SetRow label="컴팩션 임계치" hint={`${compactAt}% 도달 시`}>
+            <div className="set-slider"><input type="range" min="50" max="95" value={compactAt} onChange={e => setCompactAt(+e.target.value)} /><span className="mono">{compactAt}%</span></div>
+          </SetRow>
+          <SetRow label="최대 동시 실행" hint="namespace당 running keeper 상한">
+            <Stepper value={maxPar} min={1} max={16} onChange={setMaxPar} />
+          </SetRow>
+          <SetRow label="기본 모델" hint="라우팅 미지정 시">
+            <Segmented options={[{ value: 'claude-haiku-4', label: 'haiku' }, { value: 'claude-sonnet-4', label: 'sonnet' }, { value: 'claude-opus-4', label: 'opus' }]} value={model} onChange={setModel} />
+          </SetRow>
+          <SetRow label="기본 응답 모드" hint="커넥터 바인딩 미재정의 시">
+            <Segmented options={['mention', 'all', 'manual']} value={reply} onChange={setReply} />
+          </SetRow>
+          <SetRow label="IDE 커서 따라가기" hint="co-view 패널이 keeper 포커스를 추적">
+            <Toggle on={followIde} onChange={setFollowIde} />
+          </SetRow>
+        </div>
+        <Callout icon="ℹ">로컬 상태입니다 — 실제 저장·정책 집행은 백엔드 연동이 필요합니다.</Callout>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   LOGS — level filters + live stream
+   ════════════════════════════════════════════════════════════════ */
+const LOG_SEV = { ok: '✓', fail: '✕', warn: '⚠', run: '·', info: '·' };
+function LogViewer({ rows = [], filters = ['전체', '도구', '성공', '실패'], live = 'tail -f', style }) {
+  const [f, setF] = use2(filters[0]);
+  const shown = rows.filter(r =>
+    f === '전체' || (f === '도구' && /masc_|edit_|file/.test(r.msg)) ||
+    (f === '성공' && r.sev === 'ok') || (f === '실패' && r.sev === 'fail'));
+  return (
+    <div className="log-view" style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0, ...style }}>
+      <div className="log-filters" style={{ display: 'flex', gap: 6, alignItems: 'center', padding: 12, borderBottom: '1px solid var(--border-main)' }}>
+        {filters.map(x => <LogFilter key={x} active={f === x} onClick={() => setF(x)}>{x}</LogFilter>)}
+        <span className="log-live" style={{ marginLeft: 'auto' }}><span className="tps-dot" />{live}</span>
+      </div>
+      <div className="log-stream mono" style={{ flex: 1, overflowY: 'auto', padding: '8px 12px' }}>
+        {shown.map((r, i) => (
+          <div key={i} className={o2('log-line', r.level)} style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 22px' }}>
+            <span className="lt">{r.t}</span>
+            <span className={o2('ll', r.level)}>{r.level}</span>
+            <span className="lk">{r.keeper}</span>
+            <span className="lm">{r.msg}</span>
+            <span className={o2('ls', r.sev)}>{LOG_SEV[r.sev] || '·'}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   CONNECTORS — gate strip + connector cards + audit
+   ════════════════════════════════════════════════════════════════ */
+function GateStrip({ healthy = true, base = 'https://gate.masc.local', checked = '14:29:14', source = 'store + runtime', generated }) {
+  return (
+    <div className="gate-strip">
+      <span><Dot state={healthy ? 'ok' : 'bad'} pulse /> gate <b>{healthy ? 'healthy' : 'down'}</b></span>
+      <span className="sep" />
+      <span className="mono">base {base}</span>
+      <span className="sep" />
+      <span>health check <b className="mono" style={{ fontWeight: 500 }}>{checked}</b></span>
+      <span className="sep" />
+      <span>binding source <b>{source}</b></span>
+      {generated ? <span style={{ marginLeft: 'auto' }} className="mono">generated_at {generated}</span> : null}
+    </div>
+  );
+}
+function CnCard({ c }) {
+  const tone = c.stale ? 'warn' : c.status === 'connected' ? 'ok' : 'neutral';
+  const label = c.stale ? 'Stale' : c.status === 'connected' ? 'Connected' : 'Down';
+  return (
+    <article className={o2('cn-card', c.stale && 'stale')}>
+      <div className="cn-h">
+        <span className="cn-glyph">{c.glyph}</span>
+        <div className="meta"><div className="nm">{c.name}</div><div className="ch">{c.id} · channel: {c.channel}</div></div>
+        <Pill tone={tone} dot={tone === 'neutral' ? 'idle' : tone} dotPulse={tone === 'ok'}>{label}</Pill>
+        <button className="cn-config" title="설정">⚙</button>
+      </div>
+      <div className="cn-kv">
+        {c.kv.map((cell, i) => <div key={i} className="cell"><div className="k">{cell.k}</div><div className={o2('v', cell.hl && 'hl')}>{cell.v}</div></div>)}
+      </div>
+      <div className="cn-caps">{c.caps.map((cap, i) => <span key={i} className="cn-cap">{cap}</span>)}</div>
+      <div className="cn-bind">
+        <h5>바인딩 — 채널 → keeper ({c.bindings.length})</h5>
+        {c.bindings.length ? c.bindings.map((b, i) => (
+          <div key={i} className="cn-bind-row">
+            <span className="chn">{b.channel}</span><span className="arr">→</span>
+            <Sigil slot={b.slot} size={16}>{b.mono}</Sigil>
+            <span style={{ color: 'var(--text-bright)' }}>{b.keeper}</span>
+          </div>
+        )) : <div className="cn-bind-none">바인딩 없음 — 알림 전용 게이트</div>}
+        {c.error ? <Callout icon="⚠">{c.error}</Callout> : null}
+      </div>
+    </article>
+  );
+}
+function ConnectorsSurface({ connectors = [], audit = [], gate = {} }) {
+  const active = connectors.filter(c => c.status === 'connected' && !c.stale).length;
+  return (
+    <div className="surf-scroll" style={{ padding: 22, height: '100%', overflowY: 'auto' }}>
+      <SurfaceHead eyebrow="Gate" title="커넥터"
+        sub={<>외부 게이트 {connectors.length}개 · <b>{active} active</b> · <span className="mono">GET /api/v1/gate/connectors</span></>}
+        action={<Button>게이트 새로고침 ↻</Button>} />
+      <GateStrip {...gate} />
+      <div className="cn-grid">{connectors.map((c, i) => <CnCard key={i} c={c} />)}</div>
+      {audit.length ? (
+        <section className="cn-audit">
+          <div className="ov-card-h"><h3>최근 감사 로그</h3><span className="ov-legend mono">recent_audit · last {audit.length}</span></div>
+          <table>
+            <thead><tr><th>시각</th><th>액션</th><th>대상</th><th>Keeper</th><th>Actor</th></tr></thead>
+            <tbody>{audit.map((a, i) => <tr key={i}><td>{a[0]}</td><td className="act">{a[1]}</td><td>{a[2]}</td><td>{a[3]}</td><td>{a[4]}</td></tr>)}</tbody>
+          </table>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+/* ── export ── */
+const KVO2 = {
+  Tabs, TurnInspectorPanel, SetRow, SetNav, SettingsSurface, LogViewer,
+  GateStrip, CnCard, ConnectorsSurface,
+};
+Object.assign(window, KVO2);
+window.KVO2 = KVO2;

--- a/dashboard/v2/organisms-5.jsx
+++ b/dashboard/v2/organisms-5.jsx
@@ -1,0 +1,144 @@
+// @ds-adherence-ignore -- v2 skin organism (batch 5): Keeper Config drawer + shared empty/error/loading state surfaces — composed from primitives/molecules
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Organisms, batch 5
+   · KeeperConfigPanel — the per-keeper config drawer (identity facts,
+     inherited base prompts, persona + instruction editors, model /
+     runtime segmented controls, tool-permission toggles). Data-driven
+     re-expression of app.jsx's KeeperConfig, built from KV atoms +
+     the SetRow molecule.
+   · State surfaces — EmptyState / ErrorState / LoadingState: the
+     empty/error/loading variants every surface needs but the catalog
+     never componentized. Reusable across Fleet, Board, Logs, etc.
+   Exported onto window + window.KVO5.
+   ══════════════════════════════════════════════════════════════ */
+
+const { useState: use5 } = React;
+const K5 = window.KV;
+const { Sigil, Button, TraitPill, Toggle, Segmented } = K5;
+const { SetRow } = window.KVO2;
+const o5 = (...a) => a.filter(Boolean).join(' ');
+
+/* ── small shared bits ── */
+function TurnSec({ title, children }) {
+  return <div className="turn-sec"><h4>{title}</h4>{children}</div>;
+}
+function KvRows({ rows = [] }) {
+  return (
+    <div className="kc-codectx">
+      {rows.map((r, i) => <div key={i} className="kc-cc-row"><span className="sub-k">{r.k}</span><span className="mono">{r.v}</span></div>)}
+    </div>
+  );
+}
+function InheritRows({ rows = [], note }) {
+  return (
+    <div className="kc-inherit">
+      {rows.map((r, i) => <div key={i} className="kc-inh-row"><span className="kc-inh-tag">{r.tag}</span><span className="kc-inh-txt mono">{r.txt}</span></div>)}
+      {note ? <div className="kc-inh-note">{note}</div> : null}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   KEEPER CONFIG — drawer (renders inline here; asOverlay for the app)
+   ════════════════════════════════════════════════════════════════ */
+function KeeperConfigPanel({
+  keeper = {}, base = {}, inherit = [],
+  models = ['claude-haiku-4', 'claude-sonnet-4', 'claude-opus-4'],
+  runtimes = ['oas·seoul-1', 'oas·tokyo-2', 'local·docker'],
+  permissions = { '읽기': true, '쓰기': true, 'git': false, '외부 호출': false },
+  asOverlay = false, onClose, onPromptsLink, style,
+}) {
+  const [persona, setPersona] = use5(base.persona || '');
+  const [instr, setInstr] = use5(base.instructions || '');
+  const [model, setModel] = use5(keeper.model || models[1]);
+  const [rt, setRt] = use5((keeper.runtime || runtimes[0]).split('·')[0] === 'oas' ? (keeper.runtime || runtimes[0]) : runtimes[0]);
+  const [perm, setPerm] = use5(permissions);
+
+  const inner = (
+    <div className="turn-drawer" onClick={e => e.stopPropagation()}
+      style={asOverlay ? style : { position: 'static', width: '100%', height: '100%', boxShadow: 'none', borderRadius: 0, ...style }}>
+      <div className="turn-hd">
+        <h3>keeper 설정</h3>
+        <span className="tid">{keeper.id}</span>
+        {onClose ? <button className="turn-close" onClick={onClose} title="닫기 (Esc)">{'\u2715'}</button> : null}
+      </div>
+      <div className="turn-body">
+        <TurnSec title="정체성 · 배정">
+          <div className="kc-fact-note">아래는 배정·파생된 사실 — 여기서 바꾸지 않습니다. worktree는 keeper가 basepath 아래에 자동 생성·관리합니다.</div>
+          <KvRows rows={[
+            { k: 'namespace', v: keeper.ns },
+            { k: 'repo · branch', v: `masc-mcp · keeper/${keeper.id}` },
+          ]} />
+        </TurnSec>
+        <TurnSec title="상속 — 공유 베이스 (read-only)">
+          <InheritRows rows={inherit}
+            note={<>전 keeper 공유 · <button className="set-link" onClick={onPromptsLink}>operator 설정 · Keeper 기본 · 프롬프트 →</button></>} />
+        </TurnSec>
+        <TurnSec title="③ 성격 (persona) — 이 keeper">
+          <textarea className="kc-text" rows={2} value={persona} onChange={e => setPersona(e.target.value)} />
+          <div className="kc-traits">{(base.traits || []).map((t, i) => <TraitPill key={i}>{t}</TraitPill>)}</div>
+        </TurnSec>
+        <TurnSec title="④ 지침 (instructions) — 이 keeper">
+          <textarea className="kc-text" rows={5} value={instr} onChange={e => setInstr(e.target.value)} />
+        </TurnSec>
+        <TurnSec title="모델">
+          <Segmented options={models} value={model} onChange={setModel} />
+        </TurnSec>
+        <TurnSec title="기본 런타임">
+          <Segmented options={runtimes} value={rt} onChange={setRt} />
+        </TurnSec>
+        <TurnSec title="도구 권한">
+          {Object.keys(perm).map(k => (
+            <SetRow key={k} label={k}>
+              <Toggle on={perm[k]} onChange={v => setPerm(p => ({ ...p, [k]: v }))} />
+            </SetRow>
+          ))}
+        </TurnSec>
+        <button className="kc-save">저장 · 재시작 없이 적용</button>
+      </div>
+    </div>
+  );
+  if (asOverlay) return <div className="turn-overlay" onClick={onClose}>{inner}</div>;
+  return inner;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   STATE SURFACES — empty / error / loading (the missing variants)
+   ════════════════════════════════════════════════════════════════ */
+function EmptyState({ glyph = '◌', title, hint, action, onAction, style }) {
+  return (
+    <div className="kv-state empty" style={style}>
+      <div className="kv-state-g">{glyph}</div>
+      <div className="kv-state-t">{title}</div>
+      {hint ? <div className="kv-state-h">{hint}</div> : null}
+      {action ? <Button variant="primary" onClick={onAction}>{action}</Button> : null}
+    </div>
+  );
+}
+function ErrorState({ glyph = '⚠', title, detail, action = '다시 시도', onAction, style }) {
+  return (
+    <div className="kv-state error" style={style}>
+      <div className="kv-state-g">{glyph}</div>
+      <div className="kv-state-t">{title}</div>
+      {detail ? <div className="kv-state-h mono">{detail}</div> : null}
+      {action ? <Button onClick={onAction}>{action}</Button> : null}
+    </div>
+  );
+}
+function LoadingState({ title = '불러오는 중…', rows = 3, style }) {
+  return (
+    <div className="kv-state loading" style={style}>
+      <window.KV.LoadingBar />
+      <div className="kv-skel-list">
+        {Array.from({ length: rows }).map((_, i) => (
+          <div key={i} className="kv-skel-row"><span className="kv-skel-av" /><span className="kv-skel-lines"><span className="kv-skel-line" /><span className="kv-skel-line short" /></span></div>
+        ))}
+      </div>
+      <div className="kv-state-h">{title}</div>
+    </div>
+  );
+}
+
+const KVO5 = { TurnSec, KvRows, InheritRows, KeeperConfigPanel, EmptyState, ErrorState, LoadingState };
+Object.assign(window, KVO5);
+window.KVO5 = KVO5;

--- a/dashboard/v2/overview.jsx
+++ b/dashboard/v2/overview.jsx
@@ -1,0 +1,159 @@
+/* MASC v2 — Overview surface (operator console landing / "main menu").
+   Fleet KPIs, attention queue, keeper fleet grid, telemetry strip. */
+const { useMemo: useMemoOv } = React;
+
+// derived attention reasons for keepers with att > 0
+const ATTN_REASON = {
+  'drifter':   { sev: 'bad',  text: '컨텍스트 오버플로우 — 재시작 필요', act: '재시작' },
+  'analyst':   { sev: 'warn', text: '승인 대기 3건 (도구 권한)', act: '승인 검토' },
+  'nick0cave': { sev: 'warn', text: '컨텍스트 91% · 압축 진행 중', act: '대화 열기' },
+  'qa-king':   { sev: 'warn', text: '핸드오프 승인 대기', act: '대화 열기' },
+};
+
+function Kpi({ k, v, sub, tone }) {
+  return (
+    <div className="ov-kpi">
+      <div className="ov-kpi-k">{k}</div>
+      <div className={`ov-kpi-v ${tone || ''}`}>{v}{sub && <small>{sub}</small>}</div>
+    </div>
+  );
+}
+
+// deterministic 28-bar telemetry histogram
+function telemetryBars(keepers) {
+  const seed = keepers.reduce((a, k) => a + k.traces, 0);
+  const bars = [];
+  let s = seed;
+  for (let i = 0; i < 28; i++) {
+    s = (s * 1103515245 + 12345) & 0x7fffffff;
+    const base = 0.25 + ((s >> 8) % 1000) / 1000 * 0.7;
+    const spike = (i === 9 || i === 22) ? 1 : base;
+    bars.push(Math.min(1, spike));
+  }
+  return bars;
+}
+
+function Overview({ keepers, onOpenKeeper, onNav }) {
+  const stats = useMemoOv(() => {
+    const run = keepers.filter(k => k.status === 'run').length;
+    const att = keepers.filter(k => k.att > 0);
+    const hot = keepers.filter(k => k.ctx >= 0.85).length;
+    const traces = keepers.reduce((a, k) => a + k.traces, 0);
+    const tasks = keepers.reduce((a, k) => a + k.tasks, 0);
+    const liveCtx = keepers.filter(k => k.status === 'run');
+    const avgCtx = liveCtx.length ? Math.round(liveCtx.reduce((a, k) => a + k.ctx, 0) / liveCtx.length * 100) : 0;
+    return { run, att, hot, traces, tasks, avgCtx, total: keepers.length };
+  }, [keepers]);
+
+  const attn = stats.att.slice().sort((a, b) => b.att - a.att);
+  const bars = useMemoOv(() => telemetryBars(keepers), [keepers]);
+
+  return (
+    <main className="ov">
+      <div className="ov-scroll">
+        <header className="ov-head">
+          <div>
+            <h1>운영 개요</h1>
+            <p className="ov-sub"><span title="최상위 조정 범위 — 모든 room/keeper를 담는 root namespace">namespace <span className="mono">masc-mcp</span></span> · <span title="등록된 keeper 총 수">Keeper {stats.total}</span> · <span title="현재 토큰으로 로그인한 운영자 — 당신">operator <b>@operator</b></span></p>
+          </div>
+          <div className="ov-clock mono">{nowHM()} <span>KST</span></div>
+        </header>
+
+        <section className="ov-kpis">
+          <Kpi k="실행 중" v={stats.run} sub={` / ${stats.total}`} tone="ok" />
+          <Kpi k="주의 필요" v={stats.att.length} tone={stats.att.length ? 'bad' : ''} />
+          <Kpi k="컨텍스트 압박" v={stats.hot} sub=" ≥85%" tone={stats.hot ? 'warn' : ''} />
+          <Kpi k="평균 컨텍스트" v={stats.avgCtx + '%'} tone="volt" />
+          <Kpi k="소유 태스크" v={stats.tasks} />
+          <Kpi k="누적 trace" v={stats.traces.toLocaleString()} />
+        </section>
+
+        <div className="ov-grid">
+          <section className="ov-card ov-attn">
+            <div className="ov-card-h">
+              <h3>주의 필요</h3>
+              <span className="ov-count">{attn.length}</span>
+            </div>
+            <div className="ov-attn-list">
+              {attn.map(k => {
+                const r = ATTN_REASON[k.id] || { sev: 'warn', text: '점검 필요', act: '대화 열기' };
+                return (
+                  <div key={k.id} className="ov-attn-row" onClick={() => onOpenKeeper(k.id)}>
+                    <SigilBadge k={k} size={32} />
+                    <div className="ov-attn-meta">
+                      <div className="ov-attn-name">{k.id}<span className="ov-attn-ns mono">{k.ns}</span></div>
+                      <div className={`ov-attn-reason sev-${r.sev}`}><span className={`dot2 ${r.sev}`}></span>{r.text}</div>
+                    </div>
+                    <button className="ov-attn-act" onClick={(e) => { e.stopPropagation(); onOpenKeeper(k.id); }}>{r.act} →</button>
+                  </div>
+                );
+              })}
+              {!attn.length && <div className="ov-empty">모든 keeper 정상</div>}
+            </div>
+          </section>
+
+          <section className="ov-card ov-telemetry">
+            <div className="ov-card-h">
+              <h3>텔레메트리</h3>
+              <span className="ov-legend mono">trace / 5m · last 140m</span>
+            </div>
+            <div className="ov-bars">
+              {bars.map((b, i) => (
+                <span key={i} className={`ov-bar ${b >= 0.95 ? 'hot' : ''}`} style={{ height: (10 + b * 90) + '%' }}></span>
+              ))}
+            </div>
+            <div className="ov-tel-foot">
+              <div className="ov-tel-stat"><span className="k">피크</span><span className="v mono">112/5m</span></div>
+              <div className="ov-tel-stat"><span className="k">평균</span><span className="v mono">47/5m</span></div>
+              <div className="ov-tel-stat"><span className="k">오류율</span><span className="v mono" style={{ color: 'var(--status-ok)' }}>0.4%</span></div>
+              <div className="ov-tel-stat"><span className="k">p95 지연</span><span className="v mono">1.8s</span></div>
+            </div>
+          </section>
+        </div>
+
+        <section className="ov-card ov-fleet">
+          <div className="ov-card-h">
+            <h3>Keeper 전체</h3>
+            <button className="ov-link" onClick={() => onNav('keepers')}>전체 대화 보기 →</button>
+          </div>
+          <div className="ov-fleet-grid">
+            {keepers.map(k => (
+              <button key={k.id} className="ov-keeper" onClick={() => onOpenKeeper(k.id)}>
+                <div className="ov-keeper-top">
+                  <SigilBadge k={k} size={30} beat={k.status === 'run'} />
+                  <div className="ov-keeper-id">
+                    <div className="ov-keeper-name">{k.id}</div>
+                    <div className="ov-keeper-state"><StatusDot status={k.status} pulse={k.status === 'run'} />{k.phase}</div>
+                  </div>
+                  {k.att > 0 && <span className="ov-keeper-att">{k.att}</span>}
+                </div>
+                <div className="ov-keeper-ns mono">{k.ns}</div>
+                <div className="ov-keeper-foot">
+                  <span className="mono">{k.model.replace('claude-', '')}</span>
+                  <div className="ov-mini-meter"><span className={k.ctx >= 0.85 ? 'hot' : ''} style={{ width: Math.round(k.ctx * 100) + '%' }}></span></div>
+                  <span className="mono ov-keeper-ctx">{Math.round(k.ctx * 100)}%</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function PlaceholderSurface({ surface }) {
+  const map = { board: ['보드', '태스크 칸반 · 골 정렬 · 의존성'], connectors: ['커넥터', 'Slack · Discord · Amplitude · GitHub'], settings: ['설정', '런타임 · 승인 정책 · 모델 라우팅'] };
+  const [title, desc] = map[surface] || [surface, ''];
+  return (
+    <main className="ov">
+      <div className="empty2" style={{ height: '100%' }}>
+        <div className="ico">◈</div>
+        <h3>{title}</h3>
+        <div style={{ maxWidth: 320, fontSize: 13, lineHeight: 1.6, color: 'var(--text-dim)' }}>{desc}<br />다음 단계에서 설계합니다.</div>
+      </div>
+    </main>
+  );
+}
+
+Object.assign(window, { Overview, PlaceholderSurface });

--- a/dashboard/v2/perf.jsx
+++ b/dashboard/v2/perf.jsx
@@ -1,0 +1,233 @@
+// @ds-adherence-ignore -- v2 skin performance layer: windowing, content-visibility, modern Web API hooks
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Performance & platform layer (perf.jsx)
+
+   The component library is composable but, by default, eager: every
+   list renders every row. This layer adds the production-grade
+   primitives the surfaces compose WITH — windowing, content-
+   visibility, and thin wrappers over modern Web APIs — so the same
+   atoms/molecules scale to tens of thousands of rows.
+
+   Load AFTER React + babel, BEFORE the demo/app scripts.
+   Exports onto window + window.KVP.
+
+   Contents
+     · useRaf / useThrottledRef       frame-budget helpers
+     · useInView(opts)                IntersectionObserver hook
+     · useSize()                      ResizeObserver hook
+     · useViewTransition()            View Transitions API (graceful)
+     · VirtualList                    fixed-row windowing (the real one)
+     · CVList                         content-visibility cheap virtualization
+     · Dialog                         native <dialog> modal w/ focus + Esc
+     · FpsMeter                       live scroll FPS probe (for demos)
+   ══════════════════════════════════════════════════════════════ */
+
+const { useState: useP, useRef: useR, useEffect: useE, useCallback: useC, useMemo: useM, useLayoutEffect: useL } = React;
+
+/* ── frame-budget: a ref that only updates on rAF, never faster ── */
+function useRaf(callback) {
+  const cb = useR(callback); cb.current = callback;
+  const raf = useR(0);
+  return useC((...args) => {
+    if (raf.current) return;
+    raf.current = requestAnimationFrame(() => { raf.current = 0; cb.current(...args); });
+  }, []);
+}
+
+/* ── IntersectionObserver — lazy mount / infinite scroll sentinels ── */
+function useInView({ rootMargin = '200px', threshold = 0, once = false } = {}) {
+  const ref = useR(null);
+  const [inView, setInView] = useP(false);
+  useE(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') { setInView(true); return; }
+    const io = new IntersectionObserver(([e]) => {
+      setInView(e.isIntersecting);
+      if (e.isIntersecting && once) io.disconnect();
+    }, { rootMargin, threshold });
+    io.observe(el);
+    return () => io.disconnect();
+  }, [rootMargin, threshold, once]);
+  return [ref, inView];
+}
+
+/* ── ResizeObserver — measure a node so windowing math is exact ── */
+function useSize() {
+  const ref = useR(null);
+  const [size, setSize] = useP({ width: 0, height: 0 });
+  useL(() => {
+    const el = ref.current;
+    if (!el) return;
+    // synchronous first measurement — don't wait for RO's async first callback
+    setSize({ width: Math.round(el.clientWidth), height: Math.round(el.clientHeight) });
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(entries => {
+      const cr = entries[0].contentRect;
+      setSize({ width: Math.round(cr.width), height: Math.round(cr.height) });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  return [ref, size];
+}
+
+/* ── View Transitions API — animate DOM swaps where supported ── */
+function useViewTransition() {
+  return useC((mutate) => {
+    if (document.startViewTransition) {
+      try { return document.startViewTransition(() => mutate()); } catch (_) { mutate(); }
+    } else { mutate(); }
+  }, []);
+}
+
+/* ════════════════════════════════════════════════════════════════
+   VirtualList — true windowing. Renders only the visible slice
+   (+overscan); total height is faked with a spacer so the scrollbar
+   stays honest. Uses ResizeObserver for the viewport height and an
+   rAF-throttled scroll handler.
+
+   rowHeight may be:
+     · a Number              — uniform fixed-height rows (fast path)
+     · a fn(item,index)→px   — VARIABLE heights; offsets are memoised
+                                as a prefix-sum and the first visible
+                                row is found by binary search.
+     props: items[], rowHeight, renderRow(item,index), overscan,
+            height (optional fixed; else fills parent), className,
+            onEndReached, getKey(item,index)
+   ════════════════════════════════════════════════════════════════ */
+function VirtualList({ items = [], rowHeight = 40, renderRow, overscan = 6, height, className, style, onEndReached, getKey }) {
+  const [measureRef, size] = useSize();
+  const scrollerRef = useR(null);
+  const [scrollTop, setScrollTop] = useP(0);
+  const viewportH = height || size.height || 360;
+  const total = items.length;
+  const variable = typeof rowHeight === 'function';
+
+  // prefix-sum offsets for variable rows (offsets[i] = top of row i; last = totalH)
+  const offsets = useM(() => {
+    if (!variable) return null;
+    const o = new Array(total + 1); o[0] = 0;
+    for (let i = 0; i < total; i++) o[i + 1] = o[i] + (rowHeight(items[i], i) || 0);
+    return o;
+  }, [variable, total, items, rowHeight]);
+
+  const totalH = variable ? offsets[total] : total * rowHeight;
+
+  // first visible index
+  let first, last;
+  if (variable) {
+    // binary search for the last offset <= scrollTop
+    let lo = 0, hi = total;
+    while (lo < hi) { const mid = (lo + hi) >> 1; if (offsets[mid + 1] <= scrollTop) lo = mid + 1; else hi = mid; }
+    first = Math.max(0, lo - overscan);
+    last = first;
+    const bottom = scrollTop + viewportH;
+    while (last < total && offsets[last] < bottom) last++;
+    last = Math.min(total, last + overscan);
+  } else {
+    first = Math.max(0, Math.floor(scrollTop / rowHeight) - overscan);
+    last = Math.min(total, first + Math.ceil(viewportH / rowHeight) + overscan * 2);
+  }
+
+  const onScroll = useRaf(() => {
+    const el = scrollerRef.current; if (!el) return;
+    setScrollTop(el.scrollTop);
+    if (onEndReached && el.scrollHeight - el.scrollTop - el.clientHeight < (variable ? 200 : rowHeight * 4)) onEndReached();
+  });
+
+  const slice = [];
+  for (let i = first; i < last; i++) {
+    const item = items[i];
+    const top = variable ? offsets[i] : i * rowHeight;
+    const h = variable ? offsets[i + 1] - offsets[i] : rowHeight;
+    slice.push(
+      React.createElement('div', {
+        key: getKey ? getKey(item, i) : i,
+        className: 'vl-row',
+        style: { position: 'absolute', top, left: 0, right: 0, height: h },
+      }, renderRow(item, i))
+    );
+  }
+
+  const setRefs = (el) => { scrollerRef.current = el; measureRef.current = el; };
+  return React.createElement('div', {
+    ref: setRefs, onScroll, className: 'vl-scroller ' + (className || ''),
+    style: { position: 'relative', overflowY: 'auto', height: height || '100%', ...style },
+    'data-vl': '', 'data-vl-rendered': slice.length, 'data-vl-total': total,
+  }, React.createElement('div', { className: 'vl-sizer', style: { height: totalH, position: 'relative' } }, slice));
+}
+
+/* ════════════════════════════════════════════════════════════════
+   CVList — cheap "virtualization" via CSS content-visibility.
+   The browser skips layout+paint for off-screen rows while keeping
+   them in the DOM (so Ctrl-F, a11y tree, and variable heights still
+   work). Zero JS scroll math. Great default for medium lists and
+   variable row heights where true windowing is overkill.
+     props: items[], estRow (intrinsic size hint), renderRow, getKey
+   ════════════════════════════════════════════════════════════════ */
+function CVList({ items = [], estRow = 40, renderRow, getKey, className, style }) {
+  return React.createElement('div', { className: 'cv-list ' + (className || ''), style, 'data-cv': '', 'data-cv-total': items.length },
+    items.map((item, i) => React.createElement('div', {
+      key: getKey ? getKey(item, i) : i,
+      className: 'cv-row',
+      style: { contentVisibility: 'auto', containIntrinsicSize: `auto ${estRow}px` },
+    }, renderRow(item, i))));
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Dialog — native <dialog> element. Real top-layer, ::backdrop,
+   focus-trap and Esc-to-close come free from the platform; we just
+   sync the open prop and forward the close event.
+   ════════════════════════════════════════════════════════════════ */
+function Dialog({ open, onClose, labelledBy, className, style, children }) {
+  const ref = useR(null);
+  useE(() => {
+    const d = ref.current; if (!d) return;
+    if (open && !d.open) { try { d.showModal(); } catch (_) {} }
+    else if (!open && d.open) { d.close(); }
+  }, [open]);
+  useE(() => {
+    const d = ref.current; if (!d) return;
+    const onCancel = (e) => { e.preventDefault(); onClose && onClose(); };
+    const onClick = (e) => { if (e.target === d) onClose && onClose(); }; // backdrop click
+    d.addEventListener('cancel', onCancel);
+    d.addEventListener('click', onClick);
+    return () => { d.removeEventListener('cancel', onCancel); d.removeEventListener('click', onClick); };
+  }, [onClose]);
+  return React.createElement('dialog', { ref, className: 'v2-dialog ' + (className || ''), 'aria-labelledby': labelledBy, style }, children);
+}
+
+/* ════════════════════════════════════════════════════════════════
+   FpsMeter — samples rAF deltas, shows a live FPS + min over a window.
+   For demos only: pass `running` to gate sampling.
+   ════════════════════════════════════════════════════════════════ */
+function FpsMeter({ running = true, label }) {
+  const [fps, setFps] = useP(60);
+  const [low, setLow] = useP(60);
+  useE(() => {
+    if (!running) return;
+    let raf, last = performance.now(), acc = 0, n = 0, minF = 999;
+    const tick = (t) => {
+      const dt = t - last; last = t;
+      const f = 1000 / dt; acc += f; n++;
+      if (f < minF) minF = f;
+      if (n >= 20) { setFps(Math.round(acc / n)); setLow(Math.round(minF)); acc = 0; n = 0; minF = 999; }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [running]);
+  const tone = fps >= 55 ? 'ok' : fps >= 30 ? 'warn' : 'bad';
+  return React.createElement('span', { className: 'fps-meter ' + tone },
+    React.createElement('span', { className: 'fps-dot' }),
+    label ? React.createElement('span', { className: 'fps-label' }, label) : null,
+    React.createElement('b', null, fps), ' fps',
+    React.createElement('span', { className: 'fps-low' }, ' · min ', low));
+}
+
+const KVP = {
+  useRaf, useInView, useSize, useViewTransition,
+  VirtualList, CVList, Dialog, FpsMeter,
+};
+Object.assign(window, KVP);
+window.KVP = KVP;

--- a/dashboard/v2/primitives.jsx
+++ b/dashboard/v2/primitives.jsx
@@ -1,0 +1,234 @@
+// @ds-adherence-ignore -- v2 skin primitive library (wraps the established v2.css classes by design)
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Primitive component library
+   Turns the raw v2.css class strings into named, reusable React
+   primitives. The big win: the SEVEN forked badge classes
+   (.state-pill / .fsm-chip / .wk-pri / .src-badge / .kc-trait /
+   .att-count / .set-rolepill) converge into ONE <Pill> component
+   with a `tone` prop. Visual identity is preserved 1:1 — tone tints
+   are driven by the same design tokens the classes used.
+
+   Load order (in the host HTML):
+     React + ReactDOM (UMD)  →  babel  →  this file (text/babel)
+   Everything is exported onto window + window.KV at the bottom.
+   ══════════════════════════════════════════════════════════════ */
+
+const { useState } = React;
+
+/* ── token-driven tone table (the converged badge palette) ───────── */
+const PILL_TONES = {
+  neutral: { color: 'var(--text-mid)',     border: 'var(--border-main)',                                   bg: 'var(--bg-card)' },
+  ok:      { color: 'var(--status-ok)',    border: 'color-mix(in oklab, var(--status-ok) 45%, transparent)',   bg: 'color-mix(in oklab, var(--status-ok) 10%, var(--bg-card))' },
+  warn:    { color: 'var(--status-warn)',  border: 'color-mix(in oklab, var(--status-warn) 45%, transparent)', bg: 'color-mix(in oklab, var(--status-warn) 9%, var(--bg-card))' },
+  bad:     { color: 'var(--status-bad)',   border: 'color-mix(in oklab, var(--status-bad) 42%, transparent)',  bg: 'color-mix(in oklab, var(--status-bad) 10%, var(--bg-card))' },
+  volt:    { color: 'var(--volt-strong)',  border: 'var(--volt-dim)',                                      bg: 'var(--volt-wash)' },
+  info:    { color: 'var(--info)',         border: 'color-mix(in oklab, var(--info) 38%, transparent)',        bg: 'color-mix(in oklab, var(--info) 9%, var(--bg-card))' },
+};
+
+/* ════════════════════════════════════════════════════════════════
+   Dot — the status pip (.dot2)
+   ════════════════════════════════════════════════════════════════ */
+function Dot({ state = 'idle', pulse = false }) {
+  const cls = ['dot2'];
+  if (state && state !== 'idle') cls.push(state); // ok | warn | bad | busy
+  if (pulse) cls.push('pulse');
+  return React.createElement('span', { className: cls.join(' ') });
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Pill — the CONVERGED badge. One component, seven former classes.
+     tone : neutral | ok | warn | bad | volt | info
+     mono : monospace face (former .fsm-chip)
+     dot  : true → neutral pip, or a state string ('ok'|'warn'|…)
+     soft : transparent ground, hairline (former .kc-trait)
+     count: numeric tally styling (former .att-count / .kp-att)
+   ════════════════════════════════════════════════════════════════ */
+function Pill({ tone = 'neutral', mono = false, dot = false, dotPulse = false, soft = false, count = false, children, style, ...rest }) {
+  const t = PILL_TONES[tone] || PILL_TONES.neutral;
+  const base = {
+    display: 'inline-flex', alignItems: 'center', gap: 6,
+    fontFamily: mono ? 'var(--font-mono)' : 'var(--font-ui)',
+    fontSize: count ? 10 : 11,
+    fontWeight: count ? 600 : 400,
+    letterSpacing: mono ? '0.04em' : '0.05em',
+    lineHeight: 1.2,
+    padding: count ? '1px 7px' : '4px 10px',
+    borderRadius: 'var(--radius-pill)',
+    border: '1px solid ' + t.border,
+    color: t.color,
+    background: soft ? 'transparent' : t.bg,
+    whiteSpace: 'nowrap',
+    ...style,
+  };
+  const dotState = dot === true ? (tone === 'neutral' ? 'idle' : tone) : dot;
+  // belt-and-braces: keep component props off the DOM node (the in-browser
+  // babel rest-spread can let named props slip through into `rest`)
+  const SKIP = { tone: 1, mono: 1, dot: 1, dotPulse: 1, soft: 1, count: 1 };
+  const domRest = {};
+  for (const k in rest) if (!SKIP[k]) domRest[k] = rest[k];
+  return React.createElement(
+    'span',
+    { style: base, ...domRest },
+    dot ? React.createElement(Dot, { state: dotState, pulse: dotPulse }) : null,
+    children
+  );
+}
+
+/* ── thin presets that PROVE the convergence: every former badge is
+   now one <Pill> call. Kept as named exports so call-sites read
+   semantically, but they all funnel through the single component. ── */
+const STATE_TONE = { running: 'ok', paused: 'warn', offline: 'neutral', blocked: 'bad', compacting: 'warn' };
+function StatePill({ state = 'running', children }) {
+  return React.createElement(Pill, { tone: STATE_TONE[state] || 'neutral', dot: true }, children || state);
+}
+function FsmChip({ children }) {
+  return React.createElement(Pill, { tone: 'neutral', mono: true }, children);
+}
+const PRI_TONE = { high: 'bad', normal: 'volt', low: 'neutral' };
+function PriorityPill({ level = 'normal', children }) {
+  return React.createElement(Pill, { tone: PRI_TONE[level] || 'neutral', soft: level === 'low',
+    style: { fontSize: 9.5, letterSpacing: '0.08em', textTransform: 'uppercase', padding: '2px 7px' } }, children || level);
+}
+const SOURCE_TONE = { dashboard: 'volt', discord: 'info', slack: 'ok', imessage: 'info' };
+function SourceBadge({ source = 'dashboard' }) {
+  return React.createElement(Pill, { tone: SOURCE_TONE[source] || 'neutral',
+    style: { fontSize: 9, letterSpacing: '0.1em', textTransform: 'uppercase', padding: '2px 6px', borderRadius: 'var(--radius-xs)' } }, source);
+}
+function TraitPill({ children, ...rest }) {
+  return React.createElement(Pill, { tone: 'volt',
+    style: { fontSize: 10.5, padding: '2px 9px' }, ...rest }, children);
+}
+function CountBadge({ tone = 'bad', children, ...rest }) {
+  return React.createElement(Pill, { tone, count: true, mono: true, ...rest }, children);
+}
+function RolePill({ children, ...rest }) {
+  return React.createElement(Pill, { tone: 'volt', mono: true, style: { fontSize: 11, padding: '3px 10px' }, ...rest }, children);
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Sigil — slot-colored monogram identity (.sigil)
+   ════════════════════════════════════════════════════════════════ */
+function Sigil({ slot = 1, size = 32, heartbeat = false, title, fontScale = 0.4, style, children }) {
+  const kc = typeof slot === 'number' ? `var(--kp${slot})` : slot;
+  return React.createElement('span', {
+    className: 'sigil' + (heartbeat ? ' heartbeat' : ''),
+    title, 'aria-label': title,
+    style: { '--kc': kc, width: size, height: size, fontSize: Math.round(size * fontScale), ...style },
+  }, children);
+}
+function SigilChip({ slot = 1, mono, children }) {
+  const kc = typeof slot === 'number' ? `var(--kp${slot})` : slot;
+  return React.createElement('span', { className: 'sigil-chip', style: { '--kc': kc } },
+    React.createElement(Sigil, { slot, size: 17 }, mono),
+    children);
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Buttons — .act / .send / .ctool / .rfilter
+   ════════════════════════════════════════════════════════════════ */
+function Button({ variant = 'action', danger = false, icon = false, children, ...rest }) {
+  if (variant === 'primary') return React.createElement('button', { className: 'send', ...rest }, children);
+  if (variant === 'tool')    return React.createElement('button', { className: 'ctool', ...rest }, children);
+  const cls = ['act']; if (danger) cls.push('danger'); if (icon) cls.push('icon');
+  return React.createElement('button', { className: cls.join(' '), ...rest }, children);
+}
+function FilterChip({ active = false, count, children, ...rest }) {
+  return React.createElement('button', { className: 'rfilter' + (active ? ' on' : ''), ...rest },
+    children, count != null ? React.createElement('span', { className: 'n' }, count) : null);
+}
+// LogFilter — the flatter, label-only filter used in the log/level strips
+// (.log-f). Distinct from FilterChip (.rfilter, pill + count) by design.
+function LogFilter({ active = false, children, ...rest }) {
+  return React.createElement('button', { className: 'log-f' + (active ? ' on' : ''), ...rest }, children);
+}
+// SuggestionChip — a keeper's proposed next action (.chip), with a leading
+// arrow affordance (.pre). Used under streamed replies and in the dock.
+function SuggestionChip({ pre = '\u2192', children, ...rest }) {
+  return React.createElement('button', { className: 'chip', ...rest },
+    pre ? React.createElement('span', { className: 'pre' }, pre) : null, children);
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Form controls — toggle / segmented / stepper / slider
+   ════════════════════════════════════════════════════════════════ */
+function Toggle({ on = false, onChange, size }) {
+  const cls = 'set-toggle' + (on ? ' on' : '') + (size === 'sm' ? ' sm' : '');
+  return React.createElement('button', {
+    className: cls, role: 'switch', 'aria-checked': on,
+    onClick: () => onChange && onChange(!on),
+  }, React.createElement('span', { className: 'knob' }));
+}
+function Segmented({ options = [], value, onChange }) {
+  return React.createElement('div', { className: 'set-seg' },
+    options.map(opt => {
+      const v = typeof opt === 'object' ? opt.value : opt;
+      const label = typeof opt === 'object' ? opt.label : opt;
+      return React.createElement('button', {
+        key: v, className: 'set-seg-b' + (v === value ? ' on' : ''),
+        onClick: () => onChange && onChange(v),
+      }, label);
+    }));
+}
+function Stepper({ value = 0, min = -Infinity, max = Infinity, onChange }) {
+  return React.createElement('div', { className: 'set-stepper' },
+    React.createElement('button', { onClick: () => onChange && onChange(Math.max(min, value - 1)) }, '−'),
+    React.createElement('span', { className: 'mono' }, value),
+    React.createElement('button', { onClick: () => onChange && onChange(Math.min(max, value + 1)) }, '+'));
+}
+function Slider({ value = 0, min = 0, max = 100, step = 1, onChange, format }) {
+  return React.createElement('div', { className: 'set-slider' },
+    React.createElement('input', {
+      type: 'range', min, max, step, value,
+      onChange: e => onChange && onChange(Number(e.target.value)),
+    }),
+    React.createElement('span', { className: 'mono' }, format ? format(value) : value));
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Data viz — meter / spinner / stat cell / vital
+   ════════════════════════════════════════════════════════════════ */
+function Meter({ pct = 0, hot = false }) {
+  return React.createElement('div', { className: 'meter' + (hot ? ' hot' : '') },
+    React.createElement('span', { style: { width: Math.max(0, Math.min(100, pct)) + '%' } }));
+}
+function Spinner({ size }) {
+  const cls = 'spinner' + (size === 'sm' ? ' sm' : size === 'lg' ? ' lg' : '');
+  return React.createElement('span', { className: cls });
+}
+function LoadingRow({ children }) {
+  return React.createElement('div', { className: 'loading-row' },
+    React.createElement(Spinner, { size: 'sm' }), children);
+}
+// LoadingBar — indeterminate sweeping bar (.loading-bar) for waits with no
+// known duration. The horizontal companion to Spinner/LoadingRow.
+function LoadingBar(props) {
+  return React.createElement('div', { className: 'loading-bar', ...props });
+}
+const STAT_TONE = { ok: 'ok', bad: 'bad', warn: 'warn', volt: 'volt' };
+function StatCell({ label, value, sub, tone }) {
+  return React.createElement('div', { className: 'ov-kpi' },
+    React.createElement('div', { className: 'ov-kpi-k' }, label),
+    React.createElement('div', { className: 'ov-kpi-v' + (STAT_TONE[tone] ? ' ' + STAT_TONE[tone] : '') },
+      value, sub ? React.createElement('small', null, ' ' + sub) : null));
+}
+function Vital({ k, v, tone }) {
+  return React.createElement('div', { className: 'vital' },
+    React.createElement('div', { className: 'vk' }, k),
+    React.createElement('div', { className: 'vv' + (tone === 'volt' ? ' volt' : '') }, v));
+}
+function Vitals({ items = [] }) {
+  return React.createElement('div', { className: 'vitals' },
+    items.map((it, i) => React.createElement(Vital, { key: i, ...it })));
+}
+
+/* ── export everything to window so the (separate) app babel script
+   can use these as JSX globals ── */
+const KV = {
+  Dot, Pill, StatePill, FsmChip, PriorityPill, SourceBadge, TraitPill, CountBadge, RolePill,
+  Sigil, SigilChip, Button, FilterChip, LogFilter, SuggestionChip,
+  Toggle, Segmented, Stepper, Slider,
+  Meter, Spinner, LoadingRow, LoadingBar, StatCell, Vital, Vitals,
+  PILL_TONES,
+};
+Object.assign(window, KV);
+window.KV = KV;

--- a/dashboard/v2/rails.jsx
+++ b/dashboard/v2/rails.jsx
@@ -1,0 +1,438 @@
+/* MASC v2 — Roster rail (left) and Context rail (right) */
+const { useState: useStateP, useEffect: useEffectP, useRef: useRefP } = React;
+
+// live tok/s throughput card with selectable time range + rolling sparkline
+function makeTpsSeries(base, n, variance) {
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const wob = Math.sin(i * 0.6) * 0.4 + (Math.random() - 0.5);
+    out.push(Math.max(6, Math.round(base + wob * base * variance)));
+  }
+  return out;
+}
+
+const TPS_RANGES = [['15m', 30, 0.16], ['1h', 30, 0.10], ['6h', 30, 0.06]];
+
+function RailTps({ keeper }) {
+  const live = keeper.status === 'run';
+  const base = keeper.tps;
+  const [range, setRange] = useStateP('15m');
+  const [v, setV] = useStateP(base);
+  const [hist, setHist] = useStateP(() => makeTpsSeries(base || 0, 30, 0.16));
+
+  useEffectP(() => {
+    const cfg = TPS_RANGES.find(r => r[0] === range);
+    setHist(live ? makeTpsSeries(base, cfg[1], cfg[2]) : Array(cfg[1]).fill(0));
+    setV(live ? base : 0);
+    if (!live || range !== '15m') return;
+    const id = setInterval(() => {
+      const next = Math.max(8, Math.round(base + (Math.random() * 2 - 1) * base * 0.16));
+      setV(next);
+      setHist(h => [...h.slice(1), next]);
+    }, 1100);
+    return () => clearInterval(id);
+  }, [keeper.id, keeper.status, base, range]);
+
+  const peak = Math.max(1, ...hist);
+  const avg = live ? Math.round(hist.reduce((a, b) => a + b, 0) / hist.length) : 0;
+
+  return (
+    <div className="tps-card">
+      <div className="tps-now">
+        <span className={`tps-val ${live ? '' : 'idle'}`}>{live ? v : '—'}</span>
+        <span className="tps-unit">tok/s</span>
+        {live && <span className="tps-flag"><span className="tps-dot"></span>live</span>}
+      </div>
+      <div className="tps-ranges">
+        {TPS_RANGES.map(([r]) => (
+          <button key={r} className={`tps-range ${range === r ? 'on' : ''}`} onClick={() => setRange(r)}>{r}</button>
+        ))}
+        <span className="tps-avg">{live ? `평균 ${avg}` : '유휴'}</span>
+      </div>
+      <div className="tps-spark" title={`런타임 ${keeper.runtime}`}>
+        {hist.map((h, i) => <span key={i} style={{ height: (8 + (h / peak) * 92) + '%', opacity: live ? (0.3 + 0.7 * (i / hist.length)) : 0.15 }}></span>)}
+        <span className="tps-spark-rt mono">{keeper.runtime}</span>
+      </div>
+    </div>
+  );
+}
+
+function fsmGroupOf(k) {
+  if (k.status === 'run') return '실행 중';
+  if (k.status === 'pause') return '대기 · 일시정지';
+  return '중지 · 종료됨';
+}
+
+function Roster({ keepers, selected, onSelect, mini, onConfig }) {
+  const [q, setQ] = useStateP('');
+  const [filter, setFilter] = useStateP('all');
+  const [menu, setMenu] = useStateP(null); // { keeper, x, y }
+
+  useEffectP(() => {
+    if (!menu) return;
+    const close = () => setMenu(null);
+    const esc = (e) => { if (e.key === 'Escape') setMenu(null); };
+    window.addEventListener('click', close);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('keydown', esc);
+    return () => { window.removeEventListener('click', close); window.removeEventListener('scroll', close, true); window.removeEventListener('keydown', esc); };
+  }, [menu]);
+
+  const openMenu = (e, k) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const x = Math.min(e.clientX, window.innerWidth - 196);
+    const y = Math.min(e.clientY, window.innerHeight - 230);
+    setMenu({ keeper: k, x, y });
+  };
+
+  const counts = {
+    all: keepers.length,
+    run: keepers.filter(k => k.status === 'run').length,
+    att: keepers.filter(k => k.att > 0).length,
+  };
+
+  let list = keepers.filter(k => {
+    if (filter === 'run' && k.status !== 'run') return false;
+    if (filter === 'att' && k.att === 0) return false;
+    if (q && !(`${k.id} ${k.kr} ${k.ns} ${k.model}`.toLowerCase().includes(q.toLowerCase()))) return false;
+    return true;
+  });
+
+  // group by status
+  const order = ['실행 중', '대기 · 일시정지', '중지 · 종료됨'];
+  const groups = {};
+  list.forEach(k => { (groups[fsmGroupOf(k)] = groups[fsmGroupOf(k)] || []).push(k); });
+
+  // one keeper row — shared by the normal and windowed render paths
+  const renderKeeper = (k) => (
+    <div key={k.id} className={`kp-row ${selected === k.id ? 'sel' : ''}`} onClick={() => onSelect(k.id)} onContextMenu={(e) => openMenu(e, k)} style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 58px' }}>
+      <SigilBadge k={k} size={38} beat={k.status === 'run'} />
+      <div className="kp-meta">
+        <div className="kp-name">{k.id}</div>
+        <div className="kp-sub">
+          <span className="kp-state"><StatusDot status={k.status} pulse={k.status === 'run'} />{k.phase}</span>
+          <span>·</span>
+          <span className="kp-handle">{k.ns}</span>
+        </div>
+      </div>
+      <div className="kp-right">
+        <span className="kp-time">{k.last}</span>
+        {k.att > 0 && <span className="kp-att" title={`주의 ${k.att}건 — 컨텍스트 레일에서 확인`}>{k.att}</span>}
+      </div>
+      <button className="kp-more" title="명령 메뉴" onClick={(e) => openMenu(e, k)}>⋯</button>
+    </div>
+  );
+
+  // flatten groups → [{t:'h'|'r', ...}] for windowing
+  const flat = [];
+  order.filter(g => groups[g]).forEach(g => {
+    flat.push({ t: 'h', g });
+    groups[g].forEach(k => flat.push({ t: 'r', k }));
+  });
+  // window only when the roster is long enough to matter (keeps DOM
+  // structure identical for the common small case → zero regression)
+  const WINDOW_AT = 60;
+  const windowed = flat.length > WINDOW_AT && window.KVP && window.KVP.VirtualList;
+  const ROW_H = 58, HEAD_H = 30;
+
+  return (
+    <aside className={`roster ${mini ? 'mini' : ''}`}>
+      <div className="roster-head">
+        <input className="roster-search" placeholder="이름·네임스페이스 검색…" value={q} onChange={e => setQ(e.target.value)} />
+      </div>
+      <div className="roster-filters">
+        {[['all', '전체'], ['run', '실행중'], ['att', '주의']].map(([key, lbl]) => (
+          <button key={key} className={`rfilter ${filter === key ? 'on' : ''}`} onClick={() => setFilter(key)}>
+            {lbl}<span className="n">{counts[key]}</span>
+          </button>
+        ))}
+      </div>
+      {windowed ? (
+        <window.KVP.VirtualList
+          className="roster-list"
+          items={flat}
+          rowHeight={(it) => (it.t === 'h' ? HEAD_H : ROW_H)}
+          getKey={(it) => (it.t === 'h' ? 'h:' + it.g : it.k.id)}
+          renderRow={(it) => (it.t === 'h' ? <div className="roster-group">{it.g}</div> : renderKeeper(it.k))}
+        />
+      ) : (
+        <div className="roster-list">
+          {order.filter(g => groups[g]).map(g => (
+            <div key={g}>
+              <div className="roster-group">{g}</div>
+              {groups[g].map(renderKeeper)}
+            </div>
+          ))}
+          {!list.length && <div style={{ padding: '30px 12px', textAlign: 'center', color: 'var(--text-dim)', fontSize: '12px' }}>일치하는 Keeper가 없습니다</div>}
+        </div>
+      )}
+      {menu && (
+        <div className="kp-menu" style={{ left: menu.x, top: menu.y }} onClick={(e) => e.stopPropagation()}>
+          <div className="kp-menu-h"><SigilBadge k={menu.keeper} size={20} /><span className="mono">{menu.keeper.id}</span></div>
+          <button className="kp-menu-i" onClick={() => { onSelect(menu.keeper.id); setMenu(null); }}>{'\u25C8'} 대화 열기</button>
+          {menu.keeper.status === 'run'
+            ? <button className="kp-menu-i" onClick={() => setMenu(null)}>{'\u23F8'} 일시정지</button>
+            : <button className="kp-menu-i" onClick={() => setMenu(null)}>{'\u25B6'} 재개</button>}
+          <button className="kp-menu-i" onClick={() => setMenu(null)}>{'\u21C4'} 핸드오프…</button>
+          <button className="kp-menu-i" onClick={() => setMenu(null)}>{'\u25C9'} 컴팩션 실행</button>
+          <div className="kp-menu-sep"></div>
+          <button className="kp-menu-i" onClick={() => { onConfig && onConfig(menu.keeper); setMenu(null); }}>{'\u2699'} keeper 설정</button>
+          <button className="kp-menu-i danger" onClick={() => setMenu(null)}>{'\u23F9'} 중지</button>
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function CmpStat({ label, a, b, unit, max }) {
+  const pa = Math.min(100, (a / max) * 100);
+  const pb = Math.min(100, (b / max) * 100);
+  const fmt = (n) => unit === 'k' ? (n >= 1000 ? (n / 1000).toFixed(1) + 'k' : n) : n;
+  return (
+    <div className="cmp-stat">
+      <div className="cmp-stat-k">{label}</div>
+      <div className="cmp-bars">
+        <div className="cmp-line"><span className="t">이전</span><b className="v">{fmt(a)}</b></div>
+        <div className="cmp-bar before"><span style={{ width: pa + '%' }}></span></div>
+        <div className="cmp-line"><span className="t">이후</span><b className="v ok">{fmt(b)}</b></div>
+        <div className="cmp-bar after"><span style={{ width: pb + '%' }}></span></div>
+      </div>
+    </div>
+  );
+}
+
+function cmpFullCtx(ev, side) {
+  const m = side === 'before' ? ev.before : ev.after;
+  const head = `# 주입 컨텍스트 — ${side === 'before' ? '압축 전' : '압축 후'}\n# ${m.msgs} messages · ${m.traces} traces · ${(m.tok / 1000).toFixed(1)}k tokens\n# runtime ${ev.runtime}\n`;
+  const kept = '\n## 유지 (그대로 보존)\n' + ev.kept.map(x => '  • ' + x).join('\n');
+  if (side === 'before') {
+    return head + kept
+      + '\n\n## 원본 — 요약 전 전체 로그\n' + ev.summarized.map(x => '  • ' + x.split('→')[0].trim() + ' — [원본 전체 보존]').join('\n')
+      + '\n' + ev.dropped.map(x => '  • ' + x + ' — [전체 보존]').join('\n');
+  }
+  return head + kept
+    + '\n\n## 요약본 (모델 생성)\n' + ev.summarized.map(x => '  • ' + x).join('\n')
+    + '\n\n## 폐기됨 (컨텍스트에서 제거)\n' + ev.dropped.map(x => '  • ' + x).join('\n');
+}
+
+function CompactionInspector({ keeper, onClose }) {
+  const events = (window.COMPACTIONS && COMPACTIONS[keeper.id]) || [];
+  const [idx, setIdx] = useStateP(0);
+  const [side, setSide] = useStateP('after');
+  useEffectP(() => {
+    const onKey = (e) => { if (e.key === 'Escape') { e.stopPropagation(); onClose(); } };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+  const ev = events[idx];
+  const reduction = ev ? Math.round((1 - ev.after.tok / ev.before.tok) * 100) : 0;
+
+  return (
+    <div className="turn-overlay" onClick={onClose}>
+      <div className="turn-drawer" onClick={(e) => e.stopPropagation()}>
+        <div className="turn-hd">
+          <h3>컴팩션 스냅샷</h3>
+          <span className="tid">{keeper.id}</span>
+          <button className="turn-close" onClick={onClose} title="닫기 (Esc)">{'\u2715'}</button>
+        </div>
+
+        {events.length === 0 ? (
+          <div className="turn-body"><div className="cmp-empty">아직 이 keeper에서 실행된 컴팩션이 없습니다.<br />컨텍스트가 임계치(85%)를 넘으면 자동으로 기록됩니다.</div></div>
+        ) : (
+          <React.Fragment>
+            <div className="turn-tabs">
+              {events.map((e, i) => (
+                <button key={e.id} className={`turn-tab ${idx === i ? 'on' : ''}`} onClick={() => setIdx(i)}>
+                  {e.at} <span className="mono" style={{ opacity: 0.6 }}>{e.id}</span>
+                </button>
+              ))}
+            </div>
+            <div className="turn-body">
+              <div className="cmp-trigger"><span className="sub-k">트리거</span>{ev.trigger}</div>
+              <div className="cmp-trigger"><span className="sub-k">수행 런타임</span><span className="mono">{ev.runtime}</span></div>
+
+              <div className="turn-sec">
+                <h4>Before → After</h4>
+                <div className="cmp-headline">
+                  <span className="mono">{(ev.before.tok / 1000).toFixed(1)}k</span>
+                  <span className="cmp-arrow">{'\u2192'}</span>
+                  <span className="mono" style={{ color: 'var(--status-ok)' }}>{(ev.after.tok / 1000).toFixed(1)}k</span>
+                  <span className="cmp-reduce">{'\u2212'}{reduction}%</span>
+                </div>
+                <CmpStat label="토큰" a={ev.before.tok} b={ev.after.tok} unit="k" max={200000} />
+                <CmpStat label="메시지" a={ev.before.msgs} b={ev.after.msgs} max={Math.max(ev.before.msgs, 1)} />
+                <CmpStat label="trace" a={ev.before.traces} b={ev.after.traces} max={Math.max(ev.before.traces, 1)} />
+              </div>
+
+              <div className="turn-sec">
+                <h4>유지 · 요약 · 폐기</h4>
+                <div className="cmp-diff">
+                  <div className="cmp-col kept">
+                    <div className="cmp-col-h">{'\u25C8'} 유지</div>
+                    {ev.kept.map((x, i) => <div key={i} className="cmp-li">{x}</div>)}
+                  </div>
+                  <div className="cmp-col summ">
+                    <div className="cmp-col-h">{'\u25C9'} 요약</div>
+                    {ev.summarized.map((x, i) => <div key={i} className="cmp-li">{x}</div>)}
+                  </div>
+                  <div className="cmp-col drop">
+                    <div className="cmp-col-h">{'\u25CC'} 폐기</div>
+                    {ev.dropped.map((x, i) => <div key={i} className="cmp-li">{x}</div>)}
+                  </div>
+                </div>
+              </div>
+              <div className="turn-sec">
+                <h4>전체 컨텍스트 (실제 프롬프트)</h4>
+                <div className="cmp-side-toggle">
+                  <button className={`cmp-side ${side === 'before' ? 'on' : ''}`} onClick={() => setSide('before')}>압축 전 · {(ev.before.tok / 1000).toFixed(1)}k</button>
+                  <button className={`cmp-side ${side === 'after' ? 'on' : ''}`} onClick={() => setSide('after')}>압축 후 · {(ev.after.tok / 1000).toFixed(1)}k</button>
+                </div>
+                <pre className="turn-pre cmp-ctx-pre">{cmpFullCtx(ev, side)}</pre>
+              </div>
+            </div>
+          </React.Fragment>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RecentTool({ t }) {
+  const [open, setOpen] = useStateP(false);
+  const hasDetail = t.args || t.result;
+  return (
+    <div className={`ctx-item-wrap ${open ? 'open' : ''}`}>
+      <div className={`ctx-item ${hasDetail ? 'click' : ''}`} onClick={() => hasDetail && setOpen(o => !o)}>
+        <StatusDot status={t.status === 'ok' ? 'run' : t.status === 'bad' ? 'bad' : 'run'} />
+        <span className="ci-name">{t.name}</span>
+        <span className="ci-meta">{t.dur} · {t.ago}</span>
+        {hasDetail && <span className="ci-chev">{'\u25B8'}</span>}
+      </div>
+      {open && hasDetail && (
+        <div className="ci-detail">
+          {t.args && <React.Fragment><div className="tk">args</div><pre>{JSON.stringify(t.args, null, 2)}</pre></React.Fragment>}
+          {t.result && <React.Fragment><div className="tk">result</div><pre>{t.result}</pre></React.Fragment>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ContextRail({ keeper }) {
+  const tasks = OWNED_TASKS[keeper.id] || [];
+  const COMPACT_AT = 85;
+  const att = ATTENTION[keeper.id] || [];
+  const cmps = (window.COMPACTIONS && COMPACTIONS[keeper.id]) || [];
+  const [cmpOpen, setCmpOpen] = useStateP(false);
+  const [ctxLive, setCtxLive] = useStateP(null);   // post-manual-compact override (0..1)
+  const [compacting, setCompacting] = useStateP(false);
+  const [justRan, setJustRan] = useStateP(false);
+  useEffectP(() => { setCmpOpen(false); setCtxLive(null); setCompacting(false); setJustRan(false); }, [keeper.id]);
+
+  const effCtx = ctxLive != null ? ctxLive : keeper.ctx;
+  const ctxPct = Math.round(effCtx * 100);
+  const hot = effCtx >= 0.85;
+
+  const runCompact = () => {
+    if (compacting) return;
+    setCompacting(true);
+    setTimeout(() => {
+      const before = effCtx;
+      const after = Math.max(0.16, +(before * (0.36 + Math.random() * 0.1)).toFixed(3));
+      const bTok = Math.round(before * 200000), aTok = Math.round(after * 200000);
+      const bMsg = Math.max(8, Math.round(before * 120)), aMsg = Math.max(4, Math.round(bMsg * 0.45));
+      const bTr = Math.max(3, Math.round(before * 24)), aTr = Math.max(1, Math.round(bTr * 0.4));
+      const list = (window.COMPACTIONS[keeper.id] = (window.COMPACTIONS[keeper.id] || []).slice());
+      list.unshift({
+        id: 'cmp-m' + (list.length + 1), at: nowHM(), trigger: '수동 — operator 요청 (지금 컴팩트)', runtime: keeper.runtime,
+        before: { tok: bTok, msgs: bMsg, traces: bTr },
+        after: { tok: aTok, msgs: aMsg, traces: aTr },
+        kept: ['활성 태스크 소유권·상태', '직전 3턴 원문', 'namespace 스냅샷'],
+        summarized: ['초기 분석 turn → 핵심 결론 1줄 요약', '도구 호출 로그 → 성공/실패 집계만 보존'],
+        dropped: ['중복된 사고(thinking) 블록', '취소된 후보 경로 trace'],
+      });
+      setCtxLive(after);
+      setCompacting(false);
+      setJustRan(true);
+      setTimeout(() => setJustRan(false), 2600);
+    }, 1500);
+  };
+
+  return (
+    <aside className="ctx">
+      <div className="ctx-scroll">
+        {att.length > 0 && (
+          <div className="ctx-sec">
+            <h4>주의 <CountBadge style={{ marginLeft: 7, verticalAlign: 'middle' }}>{att.length}</CountBadge></h4>
+            <div className="att-list">
+              {att.map((a, i) => (
+                <div key={i} className={`att-item ${a.sev}`}>
+                  <span className="att-dot"></span>
+                  <span className="att-text">{a.text}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        <div className="ctx-sec">
+          <h4>런타임 · 처리량</h4>
+          <div className="vitals">
+            <div className="vital"><div className="vk">모델</div><div className="vv" style={{ fontSize: '11.5px' }}>{keeper.model}</div></div>
+            <div className="vital"><div className="vk">런타임</div><div className="vv" style={{ fontSize: '11.5px' }}>{keeper.runtime.split('·')[0]}</div></div>
+          </div>
+          <div style={{ marginTop: '8px' }}><RailTps keeper={keeper} /></div>
+        </div>
+
+        <div className="ctx-sec">
+          <h4>컨텍스트</h4>
+          <div className="ctx-card">
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+              <span style={{ fontSize: '12px', color: 'var(--text-mid)' }}>윈도우 사용량</span>
+              <span className="mono" style={{ fontSize: '14px', color: hot ? 'var(--status-bad)' : 'var(--volt-strong)' }}>{ctxPct}%</span>
+            </div>
+            <div className="meter-wrap">
+              <div className={`meter ${hot ? 'hot' : ''}`}><span style={{ width: ctxPct + '%' }}></span></div>
+              <span className={`meter-mark ${hot ? 'hot' : ''}`} style={{ left: COMPACT_AT + '%' }} title={`자동 compact 임계치 ${COMPACT_AT}%`}><i className="meter-mark-lbl">compact {COMPACT_AT}%</i></span>
+            </div>
+            <div className="ctx-tok">
+              <span className="mono">{(effCtx * 200).toFixed(1)}k</span>
+              <span className="ctx-tok-sep">/</span>
+              <span className="mono ctx-tok-full">200k</span>
+              <span className="ctx-tok-lbl">사용 / 전체 윈도우</span>
+            </div>
+            <div className="cmp-actions">
+              <window.KVM.CompactButton state={compacting ? 'busy' : justRan ? 'done' : 'idle'} onClick={runCompact} />
+            </div>
+            <button className="cmp-open" onClick={() => setCmpOpen(true)}>
+              {'\u25C9'} 컴팩션 스냅샷{cmps.length ? ` · ${cmps.length}` : ''} <span className="cmp-open-sub">before/after 보기</span>
+            </button>
+          </div>
+        </div>
+
+        <div className="ctx-sec">
+          <h4>소유 태스크</h4>
+          <div className="ctx-list">
+            {tasks.length ? tasks.map(t => (
+              <div key={t.id} className="tasktag">
+                <span className="tid">{t.id}</span>
+                <span className="ttl">{t.title}</span>
+                <span style={{ marginLeft: 'auto', flex: 'none', fontSize: '10px', color: t.state === 'blocked' ? 'var(--status-bad)' : t.state === 'review' ? 'var(--status-warn)' : 'var(--text-dim)' }}>{t.state}</span>
+              </div>
+            )) : <div style={{ fontSize: '12px', color: 'var(--text-dim)' }}>할당된 태스크 없음</div>}
+          </div>
+        </div>
+
+        <div className="ctx-sec">
+          <h4>최근 도구 호출</h4>
+          <div className="ctx-list">
+            {RECENT_TOOLS.map((t, i) => <RecentTool key={i} t={t} />)}
+          </div>
+        </div>
+      </div>
+      {cmpOpen && <CompactionInspector keeper={keeper} onClose={() => setCmpOpen(false)} />}
+    </aside>
+  );
+}
+
+Object.assign(window, { Roster, ContextRail });

--- a/dashboard/v2/settings.jsx
+++ b/dashboard/v2/settings.jsx
@@ -1,0 +1,410 @@
+/* MASC v2 — Settings surface: sectioned operator console.
+   Grounded in real MASC concepts (README): /mcp endpoint, operator role, masc_* tools,
+   /api/v1/gate, 12-state FSM, namespace. Controls hold local state — persistence is mock. */
+const { useState: useSet } = React;
+
+function SetToggle({ on, onChange }) {
+  return <button className={`set-toggle ${on ? 'on' : ''}`} onClick={() => onChange(!on)} role="switch" aria-checked={on}><span className="knob"></span></button>;
+}
+function SetSeg({ value, options, onChange }) {
+  return <div className="set-seg">{options.map(o => <button key={o} className={`set-seg-b ${value === o ? 'on' : ''}`} onClick={() => onChange(o)}>{o}</button>)}</div>;
+}
+function SetRow({ label, hint, children }) {
+  return (
+    <div className="set-row">
+      <div className="set-row-l"><div className="set-label">{label}</div>{hint && <div className="set-hint">{hint}</div>}</div>
+      <div className="set-row-c">{children}</div>
+    </div>
+  );
+}
+function SetStepper({ v, set, min, max }) {
+  return <div className="set-stepper"><button onClick={() => set(Math.max(min, v - 1))}>−</button><span className="mono">{v}</span><button onClick={() => set(Math.min(max, v + 1))}>+</button></div>;
+}
+function VerifyBtn({ label }) {
+  const [st, setSt] = useSet('idle');
+  return <button className={`set-verify ${st}`} onClick={(e) => { e.stopPropagation(); setSt('checking'); setTimeout(() => setSt('ok'), 700); }}>{st === 'idle' ? (label || '확인') : st === 'checking' ? '확인 중…' : '✓ 정상'}</button>;
+}
+
+const SET_SECTIONS = [
+  ['account', 'Account', '계정'],
+  ['mcp', 'MCP', 'MCP 서버'],
+  ['runtime', 'Runtime', '런타임 기본값'],
+  ['runtimes', 'Runtimes', '런타임 관리'],
+  ['routing', 'Routing', '모델 라우팅'],
+  ['prompts', 'Prompts', '기본 프롬프트'],
+  ['policy', 'Policy', '승인 정책'],
+  ['lifecycle', 'Lifecycle', 'keeper 수명'],
+  ['sandbox', 'Sandbox', '샌드박스'],
+  ['ide', 'IDE', 'IDE · 편집기'],
+  ['gate', 'Gate', '커넥터 게이트'],
+  ['paths', 'Paths', '경로 · Basepath'],
+  ['logs', 'Logs', '관측 · 시스템 로그'],
+  ['notify', 'Notify', '알림'],
+  ['display', 'Display', '표시'],
+];
+
+const SET_GROUPS = [
+  ['계정', ['account']],
+  ['Keeper 운영', ['runtime', 'routing', 'prompts', 'lifecycle', 'policy']],
+  ['인프라 · 실행', ['runtimes', 'sandbox', 'paths']],
+  ['연결 · 통합', ['mcp', 'gate', 'ide']],
+  ['관측 · 표시', ['logs', 'notify', 'display']],
+];
+
+const MCP_TOOLS = ['masc_start', 'masc_handoff', 'masc_compact', 'masc_amplitude_query', 'masc_trace_window', 'masc_board_metrics', 'masc_git_blame'];
+const RUNTIMES = [
+  { name: 'oas·seoul-1', endpoint: 'oas://seoul-1.masc.run', region: 'ap-northeast-2', kind: 'OAS', keepers: 3 },
+  { name: 'oas·tokyo-2', endpoint: 'oas://tokyo-2.masc.run', region: 'ap-northeast-1', kind: 'OAS', keepers: 2 },
+  { name: 'local·docker', endpoint: 'unix:///var/run/masc.sock', region: 'local', kind: 'Docker', keepers: 1 },
+];
+const APPROVAL_ACTIONS = [
+  ['git push / merge', 'always', '원격 브랜치에 쓰기'],
+  ['배포 (infra/deploy)', 'always', 'deploy 트리거'],
+  ['외부 호출 (Slack·Discord 발신)', 'risky', '외부로 메시지 전송'],
+  ['파일 쓰기 (worktree)', 'auto', 'keeper 워크트리 내 편집'],
+  ['읽기 전용 도구', 'auto', 'query·trace·blame 등'],
+];
+const SYS_LOG = [
+  ['16:24:51', 'info', 'masc-improver', 'masc_amplitude_query 완료', 'ok'],
+  ['16:24:48', 'info', 'masc-improver', 'masc_amplitude_query 호출 (D0–D3)', 'run'],
+  ['16:23:10', 'warn', 'nick0cave', '컨텍스트 91% — compact 예약', 'warn'],
+  ['16:22:55', 'info', 'sangsu', 'masc_git_blame 완료', 'ok'],
+  ['16:21:02', 'error', 'drifter', 'masc_trace_window 실패 — context overflow', 'fail'],
+  ['16:20:40', 'info', 'qa-king', 'HandingOff → sangsu 인계 시작', 'run'],
+  ['16:19:33', 'info', 'nick0cave', 'masc_compact 완료 (−64%)', 'ok'],
+  ['16:18:12', 'error', 'drifter', 'masc_start 재시작 실패 (3/3)', 'fail'],
+  ['16:17:50', 'info', 'scholar', 'masc_board_metrics 완료', 'ok'],
+  ['16:16:04', 'warn', 'analyst', 'search/index 색인 실패 1건', 'warn'],
+];
+
+function LogViewer() {
+  const [f, setF] = useSet('전체');
+  const rows = SYS_LOG.filter(r => f === '전체' || (f === '도구' && /masc_/.test(r[3])) || (f === '성공' && r[4] === 'ok') || (f === '실패' && r[4] === 'fail'));
+  return (
+    <div className="log-view">
+      <div className="log-filters">
+        {['전체', '도구', '성공', '실패'].map(x => <LogFilter key={x} active={f === x} onClick={() => setF(x)}>{x}</LogFilter>)}
+        <span className="log-live"><span className="tps-dot"></span>tail -f</span>
+      </div>
+      <div className="log-stream mono">
+        {rows.map((r, i) => (
+          <div key={i} className={`log-line ${r[1]}`}>
+            <span className="lt">{r[0]}</span>
+            <span className={`ll ${r[1]}`}>{r[1]}</span>
+            <span className="lk">{r[2]}</span>
+            <span className="lm">{r[3]}</span>
+            <span className={`ls ${r[4]}`}>{r[4] === 'ok' ? '✓' : r[4] === 'fail' ? '✕' : r[4] === 'warn' ? '⚠' : '·'}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SettingsSurface({ onNav }) {
+  const [sec, setSec] = useSet(() => { const s = window.__nextSettingsSec; window.__nextSettingsSec = null; return s || 'account'; });
+  // account
+  const [tokenShown, setTokenShown] = useSet(false);
+  // mcp
+  const [mcpUrl, setMcpUrl] = useSet('https://masc.local/mcp');
+  const [transport, setTransport] = useSet('http');
+  const [tools, setTools] = useSet(Object.fromEntries(MCP_TOOLS.map(t => [t, true])));
+  // runtime defaults
+  const [defRuntime, setDefRuntime] = useSet('oas·seoul-1');
+  const [defModel, setDefModel] = useSet('claude-sonnet-4');
+  const [maxPar, setMaxPar] = useSet(6);
+  const [compactAt, setCompactAt] = useSet(85);
+  const [autoCompact, setAutoCompact] = useSet(true);
+  // routing / policy
+  const [routing, setRouting] = useSet({ analysis: 'claude-sonnet-4', heavy: 'claude-opus-4', cheap: 'claude-haiku-4' });
+  const [approve, setApprove] = useSet(Object.fromEntries(APPROVAL_ACTIONS.map(a => [a[0], a[1]])));
+  // lifecycle
+  const [idleDrain, setIdleDrain] = useSet(30);
+  const [autoRestart, setAutoRestart] = useSet(true);
+  const [restartMax, setRestartMax] = useSet(3);
+  const [onOverflow, setOnOverflow] = useSet('자동 compact');
+  // gate / paths
+  const [gateBase, setGateBase] = useSet('https://gate.masc.local');
+  const [gateOn, setGateOn] = useSet({ Slack: true, Discord: true, Amplitude: true, GitHub: false });
+  const [wtBase, setWtBase] = useSet('~/wt');
+  const [storeUrl, setStoreUrl] = useSet('postgres://masc.local:5432/masc');
+  // sandbox
+  const [isolation, setIsolation] = useSet('container');
+  const [egress, setEgress] = useSet('허용목록');
+  const [allowlist, setAllowlist] = useSet('github.com, opam.ocaml.org, *.masc.local');
+  const [fsScope, setFsScope] = useSet('worktree');
+  const [shellOn, setShellOn] = useSet(true);
+  const [blockRisky, setBlockRisky] = useSet(true);
+  const [memLimit, setMemLimit] = useSet('2GB');
+  const [cpuLimit, setCpuLimit] = useSet(2);
+  const [execTimeout, setExecTimeout] = useSet(120);
+  // ide
+  const [ideView, setIdeView] = useSet('split-diff');
+  const [diffStyle, setDiffStyle] = useSet('side-by-side');
+  const [tabWidth, setTabWidth] = useSet(2);
+  const [formatOnSave, setFormatOnSave] = useSet(true);
+  const [wrapLines, setWrapLines] = useSet(false);
+  const [liveCursors, setLiveCursors] = useSet(true);
+  const [ideOwnership, setIdeOwnership] = useSet(true);
+  const [convRail, setConvRail] = useSet(true);
+  const [contextLens, setContextLens] = useSet(true);
+  const [blameGutter, setBlameGutter] = useSet(true);
+  const [ideAnnos, setIdeAnnos] = useSet(true);
+  const [annoAutoLink, setAnnoAutoLink] = useSet(true);
+  const [embedTerminal, setEmbedTerminal] = useSet(true);
+  const [searchIndex, setSearchIndex] = useSet(true);
+  const [ideRepo, setIdeRepo] = useSet('masc/masc-mcp');
+  // prompts (shared keeper base)
+  const _kb = (window.KEEPER_BASE || { system: '', world: '' });
+  const [sysPrompt, setSysPrompt] = useSet(_kb.system);
+  const [worldPrompt, setWorldPrompt] = useSet(_kb.world);
+  // logs
+  const [traceKeep, setTraceKeep] = useSet('30일');
+  const [logLevel, setLogLevel] = useSet('info');
+  const [sampling, setSampling] = useSet(100);
+  // notify / display
+  const [notifyCtx, setNotifyCtx] = useSet(85);
+  const [notifyFails, setNotifyFails] = useSet(3);
+  const [notifyCh, setNotifyCh] = useSet('Slack');
+  const [notifyOn, setNotifyOn] = useSet({ '컨텍스트 임계치 초과': true, '연속 실패': true, 'keeper crash/dead': true, '핸드오프 완료': false, '승인 요청': true });
+  const [density, setDensity] = useSet('regular');
+  const [tz, setTz] = useSet('Asia/Seoul');
+  const [locale, setLocale] = useSet('KO');
+  const [clock24, setClock24] = useSet(true);
+
+  const cur = SET_SECTIONS.find(s => s[0] === sec);
+
+  return (
+    <main className="surf settings-surf" data-screen-label="설정">
+      <div className="set-shell">
+        <nav className="set-nav">
+          <div className="set-nav-h">
+            <div className="eyebrow">Operator</div>
+            <div className="set-nav-title">설정</div>
+            <div className="set-nav-sub mono">@operator · masc-mcp</div>
+          </div>
+          {SET_GROUPS.map(([glabel, ids]) => (
+            <div key={glabel} className="set-nav-group">
+              <div className="set-nav-glabel">{glabel}</div>
+              {ids.map(id => {
+                const s = SET_SECTIONS.find(x => x[0] === id);
+                if (!s) return null;
+                return (
+                  <button key={id} className={`set-nav-item ${sec === id ? 'on' : ''}`} onClick={() => setSec(id)}>
+                    <span className="ko">{s[2]}</span><span className="en mono">{s[1]}</span>
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+          <div className="set-nav-note">프로토타입 — 변경은 로컬에만 적용됩니다.</div>
+        </nav>
+
+        <div className="set-content">
+          <header className="set-content-h">
+            <h1>{cur[2]}</h1>
+            <button className="act">변경사항 저장</button>
+          </header>
+
+          <div className="set-card-b">
+            {sec === 'account' && (
+              <React.Fragment>
+                <SetRow label="운영자" hint="현재 로그인한 operator"><span className="mono" style={{ color: 'var(--text-bright)' }}>@operator</span></SetRow>
+                <SetRow label="역할" hint="MASC 역할 — DM / player / keeper / operator"><RolePill>operator</RolePill></SetRow>
+                <SetRow label="API 토큰" hint="MCP·게이트 인증에 사용">
+                  <div className="set-path">
+                    <input className="set-input mono" readOnly value={tokenShown ? 'msc_live_8a4f2c71e0' : '••••••••••••••'} />
+                    <button className="set-verify idle" onClick={() => setTokenShown(s => !s)}>{tokenShown ? '숨기기' : '표시'}</button>
+                    <button className="set-verify idle">재발급</button>
+                  </div>
+                </SetRow>
+                <SetRow label="세션 만료" hint="자동 로그아웃까지"><SetSeg value="8시간" options={['1시간', '8시간', '안 함']} onChange={() => {}} /></SetRow>
+                <button className="set-add" style={{ borderColor: 'color-mix(in oklab, var(--status-bad) 40%, transparent)', color: 'var(--status-bad)' }}>로그아웃</button>
+              </React.Fragment>
+            )}
+
+            {sec === 'mcp' && (
+              <React.Fragment>
+                <div className="set-hint" style={{ marginBottom: 12 }}>이 namespace를 외부 에이전트/클라이언트에 노출하는 MCP 서버 설정.</div>
+                <SetRow label="MCP 엔드포인트" hint="GET/POST /mcp"><div className="set-path"><input className="set-input mono" value={mcpUrl} onChange={e => setMcpUrl(e.target.value)} /><VerifyBtn /></div></SetRow>
+                <SetRow label="전송 방식" hint="transport"><SetSeg value={transport} options={['http', 'stdio', 'sse']} onChange={setTransport} /></SetRow>
+                <div className="set-mcp-detail mono">
+                  {transport === 'http' && <span>POST {mcpUrl}  ·  Content-Type: application/json  ·  Authorization: Bearer ••••</span>}
+                  {transport === 'stdio' && <span>spawn: masc-mcp serve --stdio  ·  framing: ndjson  ·  pid 8421</span>}
+                  {transport === 'sse' && <span>GET {mcpUrl}/sse  ·  keep-alive 15s  ·  event: message</span>}
+                </div>
+                <div className="set-sub-h">노출 도구 ({Object.values(tools).filter(Boolean).length}/{MCP_TOOLS.length})</div>
+                {MCP_TOOLS.map(t => (
+                  <SetRow key={t} label={<span className="mono" style={{ fontSize: 12.5 }}>{t}</span>}><SetToggle on={tools[t]} onChange={(v) => setTools(p => ({ ...p, [t]: v }))} /></SetRow>
+                ))}
+              </React.Fragment>
+            )}
+
+            {sec === 'runtime' && (
+              <React.Fragment>
+                <SetRow label="기본 런타임" hint="새 keeper가 시작될 위치"><SetSeg value={defRuntime} options={['oas·seoul-1', 'oas·tokyo-2', 'local·docker']} onChange={setDefRuntime} /></SetRow>
+                <SetRow label="기본 모델" hint="라우팅 규칙이 없을 때"><SetSeg value={defModel} options={['claude-haiku-4', 'claude-sonnet-4', 'claude-opus-4']} onChange={setDefModel} /></SetRow>
+                <SetRow label="최대 동시 keeper" hint="이 namespace에서 동시에 실행"><SetStepper v={maxPar} set={setMaxPar} min={1} max={12} /></SetRow>
+                <SetRow label="자동 컴팩션" hint={`컨텍스트 ${compactAt}% 도달 시 compact() 자동 실행`}><SetToggle on={autoCompact} onChange={setAutoCompact} /></SetRow>
+                {autoCompact && <SetRow label="컴팩션 임계치" hint="윈도우 사용량 기준"><div className="set-slider"><input type="range" min="60" max="95" value={compactAt} onChange={e => setCompactAt(+e.target.value)} /><span className="mono">{compactAt}%</span></div></SetRow>}
+              </React.Fragment>
+            )}
+
+            {sec === 'runtimes' && (
+              <React.Fragment>
+                <div className="set-hint" style={{ marginBottom: 12 }}>등록된 런타임 타깃. keeper는 이 중 하나에서 구동됩니다.</div>
+                {RUNTIMES.map(rt => (
+                  <div key={rt.name} className="set-rt">
+                    <div className="set-rt-top">
+                      <span className="set-rt-name mono">{rt.name}</span>
+                      <span className="set-rt-kind">{rt.kind}</span>
+                      <span className="set-rt-keepers">keeper {rt.keepers}</span>
+                      <VerifyBtn label="연결 확인" />
+                    </div>
+                    <div className="set-rt-row"><span className="sub-k">endpoint</span><input className="set-input mono" defaultValue={rt.endpoint} /></div>
+                    <div className="set-rt-row"><span className="sub-k">region</span><span className="mono" style={{ fontSize: 12, color: 'var(--text-mid)' }}>{rt.region}</span></div>
+                  </div>
+                ))}
+                <button className="set-add">＋ 런타임 추가</button>
+              </React.Fragment>
+            )}
+
+            {sec === 'routing' && (
+              <React.Fragment>
+                <div className="set-hint" style={{ marginBottom: 12 }}>작업 유형(task.kind)에 따라 keeper가 사용할 모델을 자동 선택합니다.</div>
+                {[['analysis', '분석 · 리서치'], ['heavy', '복잡한 추론 · 대규모 리팩터'], ['cheap', '단순 작업 · 분류']].map(([k, lbl]) => (
+                  <SetRow key={k} label={lbl} hint={`task.kind = ${k}`}><SetSeg value={routing[k]} options={['claude-haiku-4', 'claude-sonnet-4', 'claude-opus-4']} onChange={(v) => setRouting(p => ({ ...p, [k]: v }))} /></SetRow>
+                ))}
+              </React.Fragment>
+            )}
+
+            {sec === 'prompts' && (
+              <React.Fragment>
+                <div className="set-hint" style={{ marginBottom: 12 }}>모든 keeper가 상속하는 공유 프롬프트 베이스. keeper 설정의 persona·instructions는 이 위에 얹힙니다. <span className="mono">{'{{keeper}}'} · {'{{namespace}}'} · {'{{runtime}}'} · {'{{model}}'}</span> 는 keeper별로 치환됩니다.</div>
+                <div className="set-sub-h">① System (base) — keeper란 무엇인가</div>
+                <textarea className="set-input mono" style={{ width: '100%', minHeight: 150, resize: 'vertical', lineHeight: 1.6, padding: '10px 12px', whiteSpace: 'pre' }} value={sysPrompt} onChange={e => setSysPrompt(e.target.value)} />
+                <div className="set-sub-h" style={{ marginTop: 14 }}>② World 프롬프트 — 공유 세계·규칙</div>
+                <textarea className="set-input mono" style={{ width: '100%', minHeight: 150, resize: 'vertical', lineHeight: 1.6, padding: '10px 12px', whiteSpace: 'pre' }} value={worldPrompt} onChange={e => setWorldPrompt(e.target.value)} />
+                <div className="set-mcp-detail mono" style={{ marginTop: 12 }}>유효 프롬프트 = ① System + ② World + ③ persona + ④ instructions · 합성 결과는 턴 인스펙터에서 확인</div>
+              </React.Fragment>
+            )}
+
+            {sec === 'policy' && (
+              <React.Fragment>
+                <div className="set-policy-legend"><span><b className="mono">always</b> 항상 승인 필요</span><span><b className="mono">risky</b> 위험 시에만</span><span><b className="mono">auto</b> 자동 허용</span></div>
+                {APPROVAL_ACTIONS.map(([action, , hint]) => (
+                  <SetRow key={action} label={action} hint={hint}><SetSeg value={approve[action]} options={['always', 'risky', 'auto']} onChange={(v) => setApprove(p => ({ ...p, [action]: v }))} /></SetRow>
+                ))}
+              </React.Fragment>
+            )}
+
+            {sec === 'lifecycle' && (
+              <React.Fragment>
+                <SetRow label="유휴 자동 drain" hint="활동 없을 때 정상 종료까지 (분)"><div className="set-slider"><input type="range" min="0" max="120" step="5" value={idleDrain} onChange={e => setIdleDrain(+e.target.value)} /><span className="mono">{idleDrain ? idleDrain + '분' : '안 함'}</span></div></SetRow>
+                <SetRow label="crash 자동 재시작" hint="Crashed → Restarting 시도"><SetToggle on={autoRestart} onChange={setAutoRestart} /></SetRow>
+                {autoRestart && <SetRow label="최대 재시작 횟수" hint="초과 시 Dead 로 전이"><SetStepper v={restartMax} set={setRestartMax} min={1} max={10} /></SetRow>}
+                <SetRow label="Overflowed 시 동작" hint="컨텍스트 윈도우 초과했을 때"><SetSeg value={onOverflow} options={['자동 compact', '자동 종료', 'operator 대기']} onChange={setOnOverflow} /></SetRow>
+              </React.Fragment>
+            )}
+
+            {sec === 'sandbox' && (
+              <React.Fragment>
+                <div className="set-hint" style={{ marginBottom: 12 }}>keeper가 코드를 실행하는 격리 환경. 도구 권한(승인 정책)보다 낮은 계층의 OS·네트워크 경계입니다.</div>
+                <SetRow label="격리 수준" hint="keeper 실행 격리 방식"><SetSeg value={isolation} options={['worktree', 'container', 'microVM']} onChange={setIsolation} /></SetRow>
+                <SetRow label="파일시스템 범위" hint="keeper가 접근 가능한 경로"><SetSeg value={fsScope} options={['worktree', 'namespace', '전체']} onChange={setFsScope} /></SetRow>
+                <SetRow label="네트워크 송신 (egress)" hint="외부 네트워크 접근"><SetSeg value={egress} options={['차단', '허용목록', '전체']} onChange={setEgress} /></SetRow>
+                {egress === '허용목록' && <SetRow label="허용 도메인" hint="쉼표로 구분"><input className="set-input mono" style={{ width: 260 }} value={allowlist} onChange={e => setAllowlist(e.target.value)} /></SetRow>}
+                <SetRow label="셸 명령 허용" hint="keeper가 셸 명령 실행"><SetToggle on={shellOn} onChange={setShellOn} /></SetRow>
+                {shellOn && <SetRow label="위험 명령 차단" hint="rm -rf, curl | sh 등 차단"><SetToggle on={blockRisky} onChange={setBlockRisky} /></SetRow>}
+                <div className="set-sub-h">리소스 한도</div>
+                <SetRow label="메모리" hint="keeper당 최대"><SetSeg value={memLimit} options={['1GB', '2GB', '4GB', '8GB']} onChange={setMemLimit} /></SetRow>
+                <SetRow label="CPU" hint="vCPU 코어"><SetStepper v={cpuLimit} set={setCpuLimit} min={1} max={16} /></SetRow>
+                <SetRow label="실행 타임아웃" hint="단일 명령 최대 실행 시간 (초)"><div className="set-slider"><input type="range" min="10" max="600" step="10" value={execTimeout} onChange={e => setExecTimeout(+e.target.value)} /><span className="mono">{execTimeout}s</span></div></SetRow>
+              </React.Fragment>
+            )}
+
+            {sec === 'ide' && (
+              <React.Fragment>
+                <div className="set-hint" style={{ marginBottom: 12 }}>모든 keeper가 공유하는 IDE 화면의 동작. 편집기·협업·코드 인사이트·버전 관리 기본값입니다.</div>
+
+                <div className="set-sub-h">편집기</div>
+                <SetRow label="기본 보기" hint="파일 열 때 시작 뷰"><SetSeg value={ideView} options={['source', 'unified', 'split-diff']} onChange={setIdeView} /></SetRow>
+                <SetRow label="diff 스타일" hint="변경 비교 방식"><SetSeg value={diffStyle} options={['inline', 'side-by-side']} onChange={setDiffStyle} /></SetRow>
+                <SetRow label="탭 폭" hint="들여쓰기 칸 수"><SetStepper v={tabWidth} set={setTabWidth} min={2} max={8} /></SetRow>
+                <SetRow label="저장 시 포맷" hint="format-on-save"><SetToggle on={formatOnSave} onChange={setFormatOnSave} /></SetRow>
+                <SetRow label="긴 줄 줄바꿈" hint="wrap long lines"><SetToggle on={wrapLines} onChange={setWrapLines} /></SetRow>
+
+                <div className="set-sub-h">협업 (presence)</div>
+                <SetRow label="다른 keeper 커서" hint="실시간 커서·선택 영역·focus_mode 표시"><SetToggle on={liveCursors} onChange={setLiveCursors} /></SetRow>
+                <SetRow label="소유권 색상" hint="파일·영역별 담당 keeper 색상 표시"><SetToggle on={ideOwnership} onChange={setIdeOwnership} /></SetRow>
+                <SetRow label="컨버세이션 레일" hint="편집 옆 대화 맥락 패널"><SetToggle on={convRail} onChange={setConvRail} /></SetRow>
+                <SetRow label="컨텍스트 렌즈" hint="해당 코드의 turn·tool 이벤트 오버레이"><SetToggle on={contextLens} onChange={setContextLens} /></SetRow>
+
+                <div className="set-sub-h">코드 인사이트</div>
+                <SetRow label="blame 거터" hint="줄별 마지막 변경 keeper·turn"><SetToggle on={blameGutter} onChange={setBlameGutter} /></SetRow>
+                <SetRow label="인라인 주석" hint="goal·task·PR에 연결된 주석 표시"><SetToggle on={ideAnnos} onChange={setIdeAnnos} /></SetRow>
+                {ideAnnos && <SetRow label="주석 자동 링크" hint="새 주석을 활성 goal/task/PR에 자동 연결"><SetToggle on={annoAutoLink} onChange={setAnnoAutoLink} /></SetRow>}
+
+                <div className="set-sub-h">실행 · 버전 관리</div>
+                <SetRow label="임베디드 터미널" hint="IDE 안에서 셸 실행 — 샌드박스 정책 적용"><SetToggle on={embedTerminal} onChange={setEmbedTerminal} /></SetRow>
+                <SetRow label="검색 색인" hint="심볼·전문 검색 인덱스 유지"><SetToggle on={searchIndex} onChange={setSearchIndex} /></SetRow>
+                <SetRow label="연동 레포" hint="diff·PR·blame 소스 — 예: #7732"><div className="set-path"><input className="set-input mono" value={ideRepo} onChange={e => setIdeRepo(e.target.value)} /><VerifyBtn label="레포 확인" /></div></SetRow>
+              </React.Fragment>
+            )}
+
+            {sec === 'gate' && (
+              <React.Fragment>
+                <div className="set-hint" style={{ marginBottom: 12 }}>외부 게이트 연결의 기본 설정. 개별 채널→keeper 바인딩은 <button className="set-link" onClick={() => onNav && onNav('connectors')}>커넥터 화면 →</button> 에서 관리합니다.</div>
+                <SetRow label="게이트 base URL" hint="GET /api/v1/gate/connectors"><div className="set-path"><input className="set-input mono" value={gateBase} onChange={e => setGateBase(e.target.value)} /><VerifyBtn /></div></SetRow>
+                {['Slack', 'Discord', 'Amplitude', 'GitHub'].map(g => (
+                  <SetRow key={g} label={g} hint={gateOn[g] ? '연결됨' : '비활성'}><SetToggle on={gateOn[g]} onChange={(v) => setGateOn(p => ({ ...p, [g]: v }))} /></SetRow>
+                ))}
+                <button className="set-add">＋ 게이트 추가</button>
+              </React.Fragment>
+            )}
+
+            {sec === 'paths' && (
+              <React.Fragment>
+                <div className="set-hint" style={{ marginBottom: 12 }}>서버·스토어의 base 경로(basepath)와 keeper 워크트리 루트. 각 항목은 연결 확인이 가능합니다.</div>
+                <SetRow label="MCP 엔드포인트" hint="/mcp HTTP 진입점"><div className="set-path"><input className="set-input mono" value={mcpUrl} onChange={e => setMcpUrl(e.target.value)} /><VerifyBtn /></div></SetRow>
+                <SetRow label="스토어 (DB)" hint="trace·감사 영속 저장소"><div className="set-path"><input className="set-input mono" value={storeUrl} onChange={e => setStoreUrl(e.target.value)} /><VerifyBtn /></div></SetRow>
+                <SetRow label="기본 worktree basepath" hint="keeper worktree 루트 — 예: ~/wt/<keeper>"><div className="set-path"><input className="set-input mono" value={wtBase} onChange={e => setWtBase(e.target.value)} /><VerifyBtn label="경로 확인" /></div></SetRow>
+              </React.Fragment>
+            )}
+
+            {sec === 'logs' && (
+              <React.Fragment>
+                <SetRow label="trace 보존 기간" hint="이후 자동 아카이브"><SetSeg value={traceKeep} options={['7일', '30일', '90일']} onChange={setTraceKeep} /></SetRow>
+                <SetRow label="로그 레벨" hint="keeper 런타임 로그"><SetSeg value={logLevel} options={['error', 'warn', 'info', 'debug']} onChange={setLogLevel} /></SetRow>
+                <SetRow label="telemetry 샘플링" hint="trace 수집 비율"><div className="set-slider"><input type="range" min="1" max="100" value={sampling} onChange={e => setSampling(+e.target.value)} /><span className="mono">{sampling}%</span></div></SetRow>
+                <div className="set-sub-h">시스템 로그 (전체 keeper · 실시간)</div>
+                <LogViewer />
+              </React.Fragment>
+            )}
+
+            {sec === 'notify' && (
+              <React.Fragment>
+                <SetRow label="컨텍스트 임계치 알림" hint="이 % 초과 시 주의로 올림"><div className="set-slider"><input type="range" min="70" max="98" value={notifyCtx} onChange={e => setNotifyCtx(+e.target.value)} /><span className="mono">{notifyCtx}%</span></div></SetRow>
+                <SetRow label="연속 실패 알림" hint="이 횟수 연속 실패 시 알림"><SetStepper v={notifyFails} set={setNotifyFails} min={1} max={10} /></SetRow>
+                <SetRow label="알림 채널" hint="어디로 보낼지"><SetSeg value={notifyCh} options={['Slack', 'Discord', '없음']} onChange={setNotifyCh} /></SetRow>
+                <div className="set-sub-h">알림 이벤트</div>
+                {Object.keys(notifyOn).map(k => <SetRow key={k} label={k}><SetToggle on={notifyOn[k]} onChange={(v) => setNotifyOn(p => ({ ...p, [k]: v }))} /></SetRow>)}
+              </React.Fragment>
+            )}
+
+            {sec === 'display' && (
+              <React.Fragment>
+                <SetRow label="밀도" hint="목록·카드 간격"><SetSeg value={density} options={['compact', 'regular']} onChange={setDensity} /></SetRow>
+                <SetRow label="언어" hint="UI 표기"><SetSeg value={locale} options={['KO', 'EN']} onChange={setLocale} /></SetRow>
+                <SetRow label="타임존" hint="타임스탬프 표시 기준"><SetSeg value={tz} options={['Asia/Seoul', 'Asia/Tokyo', 'UTC']} onChange={setTz} /></SetRow>
+                <SetRow label="24시간제" hint="시각 표기"><SetToggle on={clock24} onChange={setClock24} /></SetRow>
+              </React.Fragment>
+            )}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+Object.assign(window, { SettingsSurface });

--- a/dashboard/v2/styles/colors_and_type.css
+++ b/dashboard/v2/styles/colors_and_type.css
@@ -1,0 +1,447 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC — Colors & Type
+   The brand runs across 4 themes (Dark Fantasy / Cyberpunk /
+   Terminal / Parchment) but Dark Fantasy is the canonical voice.
+   This file defines the Dark Fantasy tokens as :root defaults and
+   offers the other three as [data-theme] overrides, plus the
+   Paper/Ink dashboard inversion (used as the docs/light surface).
+   ══════════════════════════════════════════════════════════════ */
+
+/* Fonts — all four families via Google Fonts CDN.
+   The prototype shipped Cinzel + Noto Sans KR as local TTFs, but Noto Sans KR
+   Regular is 9.9MB; committing it would permanently bloat the repo. Cinzel and
+   Noto Sans KR are identical on Google Fonts, so this standalone port loads the
+   whole set from the CDN. Substitution is sanctioned by the design-system
+   README font-substitution note. Trade-off: the /v2 page needs network access
+   for fonts (no offline fidelity); falls back to the stack in --font-* tokens. */
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=EB+Garamond:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&family=Noto+Sans+KR:wght@300;400;500;700&family=Share+Tech+Mono&display=swap');
+
+/* ── Dark Fantasy (default) — Visceral · decay-forward ── */
+:root,
+[data-theme="dark-fantasy"] {
+  /* Base surfaces — wet stone, blood-soaked wood */
+  --bg-deep:        #0a0706;     /* pitch with a red undertone */
+  --bg-panel:       #14100d;     /* rotted wood */
+  --bg-panel-alt:   #1b1612;     /* card base */
+  --bg-card:        #221815;     /* bruised meat */
+  --bg-card-hover:  #2e211c;
+
+  /* Borders — scabbed, stitched leather */
+  --border-main:      #2a1a14;
+  --border-highlight: #5a3028;   /* scab / raw wound */
+
+  /* Text — bone and bandage */
+  --text-bright:  #e8d8b8;       /* clean bone */
+  --text-primary: #b8a488;       /* dirty bandage */
+  --text-dim:     #6a5848;       /* mold dust */
+
+  /* Accents — blood is primary now; brass demoted to warning */
+  --accent-blood:    #a01818;    /* fresh arterial */
+  --accent-blood-dim:#5a0f0f;    /* dried clot */
+  --accent-viscera:  #c94a3a;    /* raw flesh / inflamed */
+  --accent-bile:     #6a7a3a;    /* sickly yellow-green */
+  --accent-mold:     #3a5a48;    /* cold mold */
+  --accent-brass:    #8a6a28;    /* tarnished gold, rare */
+  --accent-brass-dim:#5a4618;
+  --accent-bone:     #d8c8a0;
+  --accent-ink:      #3a2a5a;    /* arcane violet, rarer */
+  --accent-ember:    #c4461a;    /* dying ember */
+  --accent-glow:     rgba(160, 24, 24, 0.28);
+  --accent-blood-glow: rgba(201, 74, 58, 0.32);
+
+  /* Status — blood, bile, mold */
+  --status-ok:    #5a7a3a;       /* bile / queasy green */
+  --status-warn:  #a06a1a;       /* burnt ember */
+  --status-bad:   #a01818;       /* blood */
+  --status-idle:  #4a3a32;       /* dried mold */
+
+  /* Type stacks */
+  --font-display: 'Cinzel', 'Noto Sans KR', 'EB Garamond', serif;
+  --font-body:    'EB Garamond', 'Noto Sans KR', Georgia, serif;
+  --font-ui:      'Noto Sans KR', 'IBM Plex Sans KR', -apple-system, sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
+
+  /* Shape */
+  --radius-xs:   2px;
+  --radius-sm:   4px;
+  --radius-md:   6px;
+  --radius-lg:   12px;
+  --radius-pill: 999px;
+
+  /* Shadows */
+  --shadow-panel:  0 2px 12px rgba(0, 0, 0, 0.6);
+  --shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
+  --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
+  --shadow-glow:   0 0 20px var(--accent-glow);
+  --shadow-inset:  inset 0 0 0 1px rgba(196, 162, 101, 0.25);
+
+  /* Spacing (4px grid) */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  24px;
+  --space-6:  32px;
+  --space-7:  48px;
+  --space-8:  64px;
+
+  /* Scrollbar */
+  --scrollbar-thumb:       #2a1f1a;
+  --scrollbar-thumb-hover: #3d2e22;
+}
+
+/* ── Cyberpunk ─────────────────────────────────────────── */
+[data-theme="cyberpunk"] {
+  --bg-deep:      #05000f;
+  --bg-panel:     #0d0821;
+  --bg-panel-alt: #130e2a;
+  --bg-card:      #1a1235;
+  --bg-card-hover:#221a42;
+  --border-main:      #2a1a4a;
+  --border-highlight: #6a2fd6;
+  --text-bright:  #f5f0ff;
+  --text-primary: #e0d4ff;
+  --text-dim:     #6a5d8d;
+  --accent-brass: #00ffcc;
+  --accent-brass-dim: #008866;
+  --accent-blood: #ff2266;
+  --accent-ink:   #6a2fd6;
+  --accent-glow:  rgba(0, 255, 204, 0.12);
+  --status-ok:   #00ffcc;
+  --status-warn: #ffaa00;
+  --status-bad:  #ff2266;
+  --font-display: 'Share Tech Mono', 'Noto Sans KR', monospace;
+  --font-body:    'Noto Sans KR', sans-serif;
+  --font-ui:      'Share Tech Mono', 'Noto Sans KR', monospace;
+  --radius-xs: 0; --radius-sm: 0; --radius-md: 0;
+  --shadow-panel: 0 0 16px rgba(106, 47, 214, 0.3);
+  --shadow-glow:  0 0 24px rgba(0, 255, 204, 0.2), 0 0 48px rgba(0, 255, 204, 0.05);
+}
+
+/* ── Terminal ──────────────────────────────────────────── */
+[data-theme="terminal"] {
+  --bg-deep:      #000800;
+  --bg-panel:     #001200;
+  --bg-panel-alt: #001a00;
+  --bg-card:      #002200;
+  --bg-card-hover:#003000;
+  --border-main:      #0a3a0a;
+  --border-highlight: #00aa00;
+  --text-bright:  #00ff00;
+  --text-primary: #00cc00;
+  --text-dim:     #006600;
+  --accent-brass: #00ff00;
+  --accent-brass-dim: #009900;
+  --accent-blood: #ffcc00;
+  --accent-ink:   #00aaaa;
+  --accent-glow:  rgba(0, 255, 0, 0.08);
+  --status-ok:   #00ff00;
+  --status-warn: #ffcc00;
+  --status-bad:  #ff4400;
+  --font-display: 'JetBrains Mono', 'Noto Sans KR', monospace;
+  --font-body:    'JetBrains Mono', 'Noto Sans KR', monospace;
+  --font-ui:      'JetBrains Mono', 'Noto Sans KR', monospace;
+  --radius-xs: 0; --radius-sm: 0; --radius-md: 0;
+  --shadow-panel: 0 0 8px rgba(0, 255, 0, 0.1);
+  --shadow-glow:  0 0 16px rgba(0, 255, 0, 0.15);
+}
+
+/* ── Parchment (in-app warm theme) ─────────────────────── */
+[data-theme="parchment"] {
+  --bg-deep:      #1a1610;
+  --bg-panel:     #241f18;
+  --bg-panel-alt: #2e2820;
+  --bg-card:      #332d24;
+  --bg-card-hover:#3d362c;
+  --border-main:      #4a3f30;
+  --border-highlight: #6a5d48;
+  --text-bright:  #f0e4cc;
+  --text-primary: #d4c4a0;
+  --text-dim:     #8a7d68;
+  --accent-brass: #c4a050;
+  --accent-brass-dim: #8a7035;
+  --accent-blood: #8b4513;
+  --accent-ink:   #556b2f;
+  --accent-glow:  rgba(196, 160, 80, 0.1);
+}
+
+/* ── Paper / Ink (docs + light-surface inversion) ──────── */
+[data-theme="paper"] {
+  color-scheme: light;
+  --paper:   #F5F2EA;
+  --paper-2: #EFEBE0;
+  --paper-3: #E5E0D1;
+  --paper-4: #D8D2BF;
+  --ink:     #151515;
+  --ink-2:   #2E2E2C;
+  --ink-3:   #515049;
+  --ink-4:   #74726A;
+  --ink-5:   #9A978D;
+  --ink-6:   #BCB8AC;
+
+  --forest:  #2D5F4E;  --forest-fill:#CFDFD7;
+  --brass:   #8C6A1E;  --brass-fill: #E9DDB8;
+  --brick:   #8B3A3A;  --brick-fill: #E8CFCB;
+  --ember:   #B35A1F;  --ember-fill: #ECD5BD;
+  --slate:   #3E4A5C;  --slate-fill: #D6DBE2;
+  --plum:    #5C3E56;  --plum-fill:  #E0D4DE;
+  --teal:    #236874;  --teal-fill:  #CEDEE2;
+
+  --bg-deep:      var(--paper);
+  --bg-panel:     var(--paper-2);
+  --bg-panel-alt: var(--paper-3);
+  --bg-card:      var(--paper-2);
+  --bg-card-hover:var(--paper-3);
+  --border-main:      rgba(21,21,21,0.22);
+  --border-highlight: rgba(21,21,21,0.48);
+  --text-bright:  var(--ink);
+  --text-primary: var(--ink-2);
+  --text-dim:     var(--ink-4);
+  --accent-brass: var(--brass);
+  --accent-brass-dim: var(--brass-fill);
+  --accent-blood: var(--brick);
+  --accent-ink:   var(--slate);
+  --accent-glow:  rgba(140,106,30,0.12);
+  --status-ok:   var(--forest);
+  --status-warn: var(--ember);
+  --status-bad:  var(--brick);
+  --status-idle: var(--ink-5);
+  --shadow-panel: 0 1px 2px rgba(0,0,0,0.06), 0 0 0 1px rgba(0,0,0,0.06);
+  --shadow-card:  0 1px 0 rgba(0,0,0,0.04);
+  --shadow-glow:  none;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SEMANTIC ELEMENT DEFAULTS
+   Opinionated tags so a bare HTML file looks like MASC.
+   ══════════════════════════════════════════════════════════════ */
+
+html, body {
+  background: var(--bg-deep);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3, h4, .display {
+  font-family: var(--font-display);
+  color: var(--text-bright);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 400;
+  margin: 0;
+}
+
+h1 { font-size: 42px; letter-spacing: 0.2em; text-shadow: 0 0 40px var(--accent-glow); }
+h2 { font-size: 24px; letter-spacing: 0.14em; color: var(--accent-brass); }
+h3 { font-size: 16px; letter-spacing: 0.12em; color: var(--accent-brass); }
+h4 { font-size: 13px; letter-spacing: 0.1em;  color: var(--text-primary); }
+
+p, li { font-family: var(--font-body); color: var(--text-primary); }
+
+.overline, .eyebrow {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+code, pre, .mono, .tabular-nums {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}
+
+a { color: var(--accent-brass); text-decoration: none; border-bottom: 1px dotted var(--accent-brass-dim); }
+a:hover { color: var(--text-bright); border-bottom-color: var(--text-bright); }
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--border-main);
+  margin: var(--space-5) 0;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   UTILITY PRIMITIVES
+   Minimal set used by preview cards & UI kit. Components live in
+   ui_kits/, not here.
+   ══════════════════════════════════════════════════════════════ */
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-card);
+}
+
+.panel {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-xs);
+  box-shadow: var(--shadow-panel);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-pill);
+  background: var(--bg-panel-alt);
+  color: var(--text-dim);
+}
+.pill.ok    { color: var(--status-ok);   border-color: color-mix(in oklab, var(--status-ok)   40%, transparent); }
+.pill.warn  { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); }
+.pill.bad   { color: var(--status-bad);  border-color: color-mix(in oklab, var(--status-bad)  40%, transparent); }
+.pill.brass { color: var(--accent-brass);border-color: color-mix(in oklab, var(--accent-brass)40%, transparent); }
+
+.btn {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: 6px 14px;
+  border: 1px solid var(--border-main);
+  background: var(--bg-panel-alt);
+  color: var(--text-primary);
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  transition: border-color 0.18s, color 0.18s, background 0.18s, transform 0.08s;
+}
+.btn:hover { border-color: var(--accent-brass-dim); color: var(--accent-brass); }
+.btn:active { transform: translateY(1px); }
+.btn.primary {
+  border-color: var(--accent-brass);
+  color: var(--accent-brass);
+  box-shadow: var(--shadow-inset);
+}
+.btn.primary:hover { background: var(--accent-glow); color: var(--text-bright); }
+.btn.ghost { background: transparent; }
+
+.input {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  padding: 6px 10px;
+  background: var(--bg-panel-alt);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-xs);
+  color: var(--text-primary);
+}
+.input:focus { outline: none; border-color: var(--accent-brass-dim); }
+
+.dot { width: 6px; height: 6px; border-radius: 50%; display: inline-block; background: var(--text-dim); }
+.dot.ok   { background: var(--status-ok);   box-shadow: 0 0 6px var(--status-ok); }
+.dot.warn { background: var(--status-warn); box-shadow: 0 0 6px var(--status-warn); }
+.dot.bad  { background: var(--status-bad);  box-shadow: 0 0 6px var(--status-bad); }
+
+/* ══════════════════════════════════════════════════════════════
+   TEXTURES — parchment grain, blood, wax, scratches
+   Apply via `.tex-parchment`, `.tex-blood`, `.tex-wax`, `.tex-scratch`.
+   They're SVG-data-URI backgrounds that layer on top of any surface.
+   ══════════════════════════════════════════════════════════════ */
+.tex-parchment {
+  background-image:
+    radial-gradient(ellipse at 20% 15%, rgba(255,230,180,0.04), transparent 50%),
+    radial-gradient(ellipse at 80% 85%, rgba(90,40,10,0.08), transparent 55%),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='7'/><feColorMatrix values='0 0 0 0 0.1  0 0 0 0 0.08  0 0 0 0 0.06  0 0 0 0.55 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.35'/></svg>");
+  background-blend-mode: multiply, multiply, normal;
+}
+.tex-blood {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='360' height='360' viewBox='0 0 360 360'><g fill='%23a01818' opacity='0.55'><ellipse cx='48' cy='36' rx='14' ry='5' transform='rotate(-12 48 36)'/><path d='M52 40c2 8-1 18-6 22-4-6-3-16 6-22Z'/><ellipse cx='230' cy='180' rx='22' ry='8'/><path d='M240 188c3 12-1 30-10 34-6-10-5-24 10-34Z'/><circle cx='300' cy='80' r='3'/><circle cx='310' cy='90' r='2'/><circle cx='120' cy='300' r='4'/><circle cx='130' cy='310' r='2'/><ellipse cx='150' cy='260' rx='10' ry='4' transform='rotate(25 150 260)'/></g></svg>");
+  background-size: 360px 360px;
+}
+.tex-wax {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='300' height='300'><g fill='%23e8d8b0' opacity='0.35'><path d='M40 20c6 18-4 30-12 30 4-12 0-22 12-30Z'/><circle cx='28' cy='52' r='4'/><circle cx='36' cy='58' r='3'/><path d='M220 160c8 22-6 40-14 38 2-14 0-28 14-38Z'/><circle cx='208' cy='200' r='5'/></g></svg>");
+  background-size: 300px 300px;
+}
+.tex-scratch {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><g stroke='%23e8d8b0' stroke-opacity='0.07' stroke-width='0.6' fill='none'><path d='M0 80 L400 60'/><path d='M40 0 L80 400'/><path d='M0 240 L400 260'/><path d='M200 0 L240 400'/><path d='M0 340 L400 320'/><path d='M320 0 L340 400'/></g></svg>");
+}
+.tex-mold {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='340' height='340'><g opacity='0.55'><circle cx='40' cy='60' r='18' fill='%233a5a48' opacity='0.4'/><circle cx='50' cy='70' r='10' fill='%236a7a3a' opacity='0.35'/><circle cx='260' cy='120' r='24' fill='%233a5a48' opacity='0.35'/><circle cx='270' cy='130' r='12' fill='%236a7a3a' opacity='0.3'/><circle cx='150' cy='280' r='20' fill='%233a5a48' opacity='0.3'/><circle cx='80' cy='220' r='14' fill='%236a7a3a' opacity='0.3'/><circle cx='310' cy='260' r='16' fill='%233a5a48' opacity='0.35'/></g></svg>");
+  background-size: 340px 340px;
+  filter: blur(1.5px);
+}
+.tex-viscera {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><g fill='none' stroke='%23a01818' stroke-opacity='0.4' stroke-width='1.4'><path d='M40 60c20 0 20 20 10 30s-30 10-20 30 40 5 40 25 -30 15 -40 30'/><path d='M260 140c20 0 25 25 10 35s-40 10-30 35 45 10 45 30'/><path d='M120 300c25-5 40 10 30 25s-30 10-40 30'/></g></svg>");
+  background-size: 400px 400px;
+  opacity: 0.85;
+}
+.tex-noise {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='2' seed='3'/><feColorMatrix values='0 0 0 0 0.9  0 0 0 0 0.85  0 0 0 0 0.7  0 0 0 0.05 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+}
+
+/* ══════════════════════════════════════════════════════════════
+   GOTHIC FRAMES — corner tabs, arch, sarcophagus
+   Wrap any element with .frame-gothic to get corner carvings.
+   ══════════════════════════════════════════════════════════════ */
+.frame-gothic {
+  position: relative;
+  border: 1px solid var(--border-highlight);
+  box-shadow: var(--shadow-inset), var(--shadow-panel);
+}
+.frame-gothic::before,
+.frame-gothic::after {
+  content: ""; position: absolute; width: 14px; height: 14px;
+  border: 1px solid var(--accent-brass); pointer-events: none;
+}
+.frame-gothic::before { top: -1px; left: -1px; border-right: 0; border-bottom: 0; }
+.frame-gothic::after  { bottom: -1px; right: -1px; border-left: 0; border-top: 0; }
+
+.frame-arch {
+  position: relative;
+  border: 1px solid var(--accent-brass-dim);
+  border-radius: 120px 120px 2px 2px / 60px 60px 2px 2px;
+  padding: 28px 20px 16px;
+  background: var(--bg-card);
+}
+.frame-arch::before {
+  content: ""; position: absolute; inset: 6px; border: 1px solid var(--border-highlight);
+  border-radius: inherit; pointer-events: none;
+}
+
+.frame-sarc {
+  position: relative;
+  border: 1px solid var(--border-highlight);
+  clip-path: polygon(
+    12px 0, calc(100% - 12px) 0, 100% 12px,
+    100% calc(100% - 12px), calc(100% - 12px) 100%,
+    12px 100%, 0 calc(100% - 12px), 0 12px
+  );
+  background: var(--bg-card);
+}
+
+/* Glyph usage: <svg class="gl"><use href=".../atlas.svg#skull"/></svg> */
+.gl { width: 16px; height: 16px; display: inline-block; vertical-align: -3px; color: currentColor; }
+.gl-lg { width: 24px; height: 24px; vertical-align: -6px; }
+.gl-xl { width: 40px; height: 40px; }
+.gl-brass { color: var(--accent-brass); }
+.gl-blood { color: var(--accent-blood); }
+.gl-bone  { color: var(--accent-bone); }
+
+/* Drop cap for gothic body text */
+.dropcap::first-letter {
+  font-family: var(--font-display);
+  float: left; font-size: 54px; line-height: 0.9;
+  padding: 6px 10px 0 0; color: var(--accent-blood);
+  text-shadow: 0 0 24px var(--accent-blood-glow);
+}
+
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb, var(--border-main)); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover, var(--border-highlight)); }

--- a/dashboard/v2/styles/craft.css
+++ b/dashboard/v2/styles/craft.css
@@ -1,0 +1,306 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Craft layer
+   Loaded LAST. A polish pass over the existing skin: one breathing
+   rhythm (density), one motion system (press / lift / focus / entrance),
+   and consistency fixes across every surface. Purely additive —
+   nothing here invents new color or type, it only refines spacing,
+   interaction and finish on top of v2.css / surfaces.css.
+
+   Three taste axes are exposed as Tweaks and driven by attributes on
+   .v2-app:  data-density (spacious|regular|compact),
+             data-motion  (lively|subtle|off),
+             data-bubble  (card|flat).
+   ══════════════════════════════════════════════════════════════ */
+
+/* ── Motion + lift tokens ─────────────────────────────────────── */
+[data-skin="v2"] {
+  --ease-out:    cubic-bezier(0.22, 0.61, 0.36, 1);
+  --ease-spring: cubic-bezier(0.34, 1.32, 0.5, 1);
+  --dur-fast: 110ms;
+  --dur:      170ms;
+  --dur-slow: 260ms;
+  --lift:  -2px;   /* card hover rise */
+  --press:  1px;   /* button press sink */
+}
+
+/* ══════════════════════════════════════════════════════════════
+   1 · DENSITY — one breathing rhythm, three steps
+   The semantic spacing tokens already feed most surfaces; override
+   them per density, then top up the spots that still carry literals.
+   ══════════════════════════════════════════════════════════════ */
+.v2-app[data-density="spacious"] {
+  --pad-surface: 32px 42px 60px;
+  --pad-card:    16px 18px;
+  --gap-card:    18px;
+  --gap-row:     11px;
+}
+.v2-app[data-density="regular"] {
+  --pad-surface: 22px 26px 40px;
+  --pad-card:    12px 14px;
+  --gap-card:    14px;
+  --gap-row:     8px;
+}
+.v2-app[data-density="compact"] {
+  --pad-surface: 15px 18px 30px;
+  --pad-card:    9px 11px;
+  --gap-card:    10px;
+  --gap-row:     6px;
+}
+
+/* ── Chat console — spacious (the headline surface) ── */
+.v2-app[data-density="spacious"] .chat-head   { padding: 18px 28px 16px; gap: 16px; }
+.v2-app[data-density="spacious"] .thread      { padding: 34px 0 14px; }
+.v2-app[data-density="spacious"] .thread-inner{ gap: 30px; padding: 0 40px; }
+.v2-app[data-density="spacious"] .msg         { gap: 15px; }
+.v2-app[data-density="spacious"] .bubble      { padding: 17px 21px; line-height: 1.7; }
+.v2-app[data-density="spacious"] .composer    { padding: 16px 30px 22px; }
+.v2-app[data-density="spacious"] .ctx-scroll  { padding: 20px; gap: 22px; }
+.v2-app[data-density="spacious"] .ctx-card,
+.v2-app[data-density="spacious"] .tps-card    { padding: 14px 15px; }
+.v2-app[data-density="spacious"] .roster-head { padding: 15px 14px; }
+.v2-app[data-density="spacious"] .roster-list { padding: 9px 8px; }
+.v2-app[data-density="spacious"] .kp-row      { padding: 11px 11px; }
+.v2-app[data-density="spacious"] .roster-filters { padding: 12px 14px; }
+
+/* ── Board — spacious ── */
+.v2-app[data-density="spacious"] .bd-feed-head    { padding: 15px 24px; }
+.v2-app[data-density="spacious"] .bd-list         { padding: 20px 24px; gap: 14px; }
+.v2-app[data-density="spacious"] .bd-rail         { padding: 18px 12px; }
+.v2-app[data-density="spacious"] .bd-composer     { padding: 14px 24px 18px; }
+.v2-app[data-density="spacious"] .bd-detail-h     { padding: 16px 18px; }
+.v2-app[data-density="spacious"] .bd-detail-scroll{ padding: 18px; gap: 14px; }
+
+/* ── Settings — spacious ── */
+.v2-app[data-density="spacious"] .settings-surf .set-card-b { padding: 12px 40px 56px; }
+.v2-app[data-density="spacious"] .set-content-h { padding: 26px 40px 18px; }
+.v2-app[data-density="spacious"] .set-row       { padding: 16px 0; }
+.v2-app[data-density="spacious"] .set-nav-item  { padding: 11px 13px; }
+
+/* ── Chat console — compact (tighten what regular leaves) ── */
+.v2-app[data-density="compact"] .thread        { padding: 14px 0 6px; }
+.v2-app[data-density="compact"] .thread-inner  { gap: 14px; padding: 0 22px; }
+.v2-app[data-density="compact"] .chat-head     { padding: 10px 16px 9px; }
+.v2-app[data-density="compact"] .composer      { padding: 9px 18px 12px; }
+.v2-app[data-density="compact"] .ctx-scroll    { padding: 11px; gap: 12px; }
+.v2-app[data-density="compact"] .bd-list       { padding: 11px 14px; gap: 8px; }
+.v2-app[data-density="compact"] .set-row       { padding: 10px 0; }
+
+/* ══════════════════════════════════════════════════════════════
+   2 · MOTION — press, hover lift, focus ring, entrance
+   Base rules below are the "subtle" tier. [data-motion="lively"]
+   amplifies; [data-motion="off"] removes all of it (and is implied
+   for reduced-motion users).
+   ══════════════════════════════════════════════════════════════ */
+
+/* Consistent transitions on every interactive control. */
+.v2-app .act, .v2-app .send, .v2-app .rfilter, .v2-app .bd-filter,
+.v2-app .bd-sub, .v2-app .log-f, .v2-app .set-verify, .v2-app .set-seg-b,
+.v2-app .cp-mode, .v2-app .fbk-btn, .v2-app .chip, .v2-app .tps-range,
+.v2-app .set-add, .v2-app .ctool, .v2-app .nav-item, .v2-app .turn-tab,
+.v2-app .bd-react, .v2-app .bd-comp-tab, .v2-app .cn-config,
+.v2-app .set-stepper button, .v2-app .turn-close, .v2-app .rail-toggle,
+.v2-app .topbar-copilot, .v2-app .dock-fab {
+  transition: background var(--dur) var(--ease-out),
+              border-color var(--dur) var(--ease-out),
+              color var(--dur) var(--ease-out),
+              box-shadow var(--dur) var(--ease-out),
+              transform var(--dur-fast) var(--ease-out);
+}
+
+/* Press — every button sinks 1px on active (brand: translateY press). */
+.v2-app[data-motion]:not([data-motion="off"]) .act:active,
+.v2-app[data-motion]:not([data-motion="off"]) .send:not(:disabled):active,
+.v2-app[data-motion]:not([data-motion="off"]) .rfilter:active,
+.v2-app[data-motion]:not([data-motion="off"]) .bd-filter:active,
+.v2-app[data-motion]:not([data-motion="off"]) .bd-sub:active,
+.v2-app[data-motion]:not([data-motion="off"]) .log-f:active,
+.v2-app[data-motion]:not([data-motion="off"]) .set-verify:active,
+.v2-app[data-motion]:not([data-motion="off"]) .set-seg-b:active,
+.v2-app[data-motion]:not([data-motion="off"]) .cp-mode:active,
+.v2-app[data-motion]:not([data-motion="off"]) .fbk-btn:active,
+.v2-app[data-motion]:not([data-motion="off"]) .chip:active,
+.v2-app[data-motion]:not([data-motion="off"]) .tps-range:active,
+.v2-app[data-motion]:not([data-motion="off"]) .set-add:active,
+.v2-app[data-motion]:not([data-motion="off"]) .ctool:active,
+.v2-app[data-motion]:not([data-motion="off"]) .bd-react:active,
+.v2-app[data-motion]:not([data-motion="off"]) .turn-tab:active,
+.v2-app[data-motion]:not([data-motion="off"]) .cn-config:active,
+.v2-app[data-motion]:not([data-motion="off"]) .topbar-copilot:active,
+.v2-app[data-motion]:not([data-motion="off"]) .set-nav-item:active {
+  transform: translateY(var(--press));
+}
+
+/* Hover lift on genuine cards (not list rows). */
+.v2-app .ov-keeper, .v2-app .cp-route, .v2-app .cp-mode,
+.v2-app .cn-card, .v2-app .bd-post {
+  transition: background var(--dur) var(--ease-out),
+              border-color var(--dur) var(--ease-out),
+              box-shadow var(--dur) var(--ease-out),
+              transform var(--dur) var(--ease-out);
+}
+.v2-app[data-motion]:not([data-motion="off"]) .ov-keeper:hover,
+.v2-app[data-motion]:not([data-motion="off"]) .cp-route:hover,
+.v2-app[data-motion]:not([data-motion="off"]) .cn-card:hover {
+  transform: translateY(var(--lift));
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--volt-wash);
+}
+.v2-app[data-motion]:not([data-motion="off"]) .bd-post:hover {
+  transform: translateY(var(--lift));
+  box-shadow: 0 5px 16px rgba(0, 0, 0, 0.38);
+}
+
+/* Avatar / sigil micro-zoom on the keeper rows + board authors. */
+.v2-app .kp-av, .v2-app .roster .sigil { transition: transform var(--dur) var(--ease-out); }
+.v2-app[data-motion="lively"] .kp-row:hover .kp-av,
+.v2-app[data-motion="lively"] .kp-row:hover .sigil { transform: scale(1.06); }
+
+/* Keyboard focus ring — one brass halo everywhere, mouse clicks stay clean. */
+.v2-app a:focus-visible,
+.v2-app button:focus-visible,
+.v2-app [role="button"]:focus-visible,
+.v2-app [tabindex]:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-deep), 0 0 0 4px var(--volt-dim);
+  border-radius: var(--radius-sm);
+}
+.v2-app textarea:focus-visible,
+.v2-app input:focus-visible { outline: none; }
+
+/* Message entrance is intentionally omitted: a backgrounded iframe freezes
+   the animation clock on frame 0, so any keyframe that starts at opacity:0
+   would hold content hidden. Content visibility must never depend on an
+   animation running — the press/hover/focus polish below carries the craft. */
+
+/* Trace / tool body reveal a touch smoother (render on click → foreground). */
+.v2-app .reason-detail, .v2-app .tool-body2 {
+  animation: fade-soft var(--dur) var(--ease-out);
+}
+@keyframes fade-soft { from { opacity: 0; } to { opacity: 1; } }
+
+/* ── LIVELY tier — bolder lifts, glow on the primary action, sheen ── */
+.v2-app[data-motion="lively"] { --lift: -3px; }
+.v2-app[data-motion="lively"] .ov-keeper:hover,
+.v2-app[data-motion="lively"] .cp-route:hover,
+.v2-app[data-motion="lively"] .cn-card:hover,
+.v2-app[data-motion="lively"] .bd-post:hover {
+  transition-timing-function: var(--ease-spring);
+}
+.v2-app[data-motion="lively"] .send:not(:disabled):hover {
+  box-shadow: 0 0 22px var(--volt-glow), 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+.v2-app[data-motion="lively"] .nav-item:hover { transform: translateY(-1px); }
+.v2-app[data-motion="lively"] .chip:hover { transform: translateY(-2px); }
+
+/* ── OFF tier — kill every transition & animation (also reduced-motion) ── */
+.v2-app[data-motion="off"] *,
+.v2-app[data-motion="off"] *::before,
+.v2-app[data-motion="off"] *::after {
+  transition: none !important;
+  animation: none !important;
+}
+@media (prefers-reduced-motion: reduce) {
+  .v2-app *, .v2-app *::before, .v2-app *::after {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   3 · MESSAGE STYLE — card (default) vs flat (document-like)
+   Flat strips the assistant bubble chrome so long answers read as
+   a clean document; the user message keeps a quiet brass spine so
+   the conversation still has two clear voices.
+   ══════════════════════════════════════════════════════════════ */
+.v2-app[data-bubble="flat"] .bubble {
+  background: transparent;
+  border-color: transparent;
+  border-radius: 0;
+  padding: 2px 0 0;
+}
+.v2-app[data-bubble="flat"] .bubble.user {
+  background: transparent;
+  border: 0;
+  border-left: 2px solid var(--volt-dim);
+  border-radius: 0;
+  padding: 2px 0 2px 16px;
+}
+.v2-app[data-bubble="flat"] .bubble code,
+.v2-app[data-bubble="flat"] .bubble .md-table,
+.v2-app[data-bubble="flat"] .bubble .callout {
+  /* nested chrome stays — only the outer shell flattens */
+}
+.v2-app[data-bubble="flat"] .msg.from-user .bubble.user {
+  border-left: 0;
+  border-right: 2px solid var(--volt-dim);
+  padding: 2px 16px 2px 0;
+  text-align: left;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   4 · CONSISTENCY — scrollbars, hairlines, small finish fixes
+   ══════════════════════════════════════════════════════════════ */
+
+/* One scrollbar treatment across every scroll region. */
+.v2-app .thread::-webkit-scrollbar,
+.v2-app .ctx-scroll::-webkit-scrollbar,
+.v2-app .roster-list::-webkit-scrollbar,
+.v2-app .set-content::-webkit-scrollbar,
+.v2-app .set-nav::-webkit-scrollbar,
+.v2-app .bd-list::-webkit-scrollbar,
+.v2-app .bd-detail-scroll::-webkit-scrollbar,
+.v2-app .bd-rail::-webkit-scrollbar,
+.v2-app .log-stream::-webkit-scrollbar,
+.v2-app .turn-body::-webkit-scrollbar {
+  width: 10px;
+}
+.v2-app .thread::-webkit-scrollbar-thumb,
+.v2-app .ctx-scroll::-webkit-scrollbar-thumb,
+.v2-app .roster-list::-webkit-scrollbar-thumb,
+.v2-app .set-content::-webkit-scrollbar-thumb,
+.v2-app .set-nav::-webkit-scrollbar-thumb,
+.v2-app .bd-list::-webkit-scrollbar-thumb,
+.v2-app .bd-detail-scroll::-webkit-scrollbar-thumb,
+.v2-app .bd-rail::-webkit-scrollbar-thumb,
+.v2-app .log-stream::-webkit-scrollbar-thumb,
+.v2-app .turn-body::-webkit-scrollbar-thumb {
+  background: var(--border-main);
+  border-radius: var(--radius-md);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  transition: background var(--dur);
+}
+.v2-app .thread::-webkit-scrollbar-thumb:hover,
+.v2-app .ctx-scroll::-webkit-scrollbar-thumb:hover,
+.v2-app .roster-list::-webkit-scrollbar-thumb:hover,
+.v2-app .set-content::-webkit-scrollbar-thumb:hover,
+.v2-app .bd-list::-webkit-scrollbar-thumb:hover,
+.v2-app .bd-detail-scroll::-webkit-scrollbar-thumb:hover {
+  background: var(--border-highlight);
+  background-clip: padding-box;
+}
+.v2-app * { scrollbar-width: thin; scrollbar-color: var(--border-main) transparent; }
+
+/* Composer hairline lifts to brass on focus (matches board composer). */
+.v2-app .composer-box.focus { box-shadow: 0 0 0 3px var(--volt-wash); }
+
+/* Roster search + every text input share the same focus halo. */
+.v2-app .set-input:focus,
+.v2-app .roster-search:focus,
+.v2-app .cn-be-chn:focus,
+.v2-app .kc-text:focus {
+  box-shadow: 0 0 0 2px var(--volt-wash);
+}
+
+/* Section headers keep an even baseline rhythm in the context rail. */
+.v2-app .ctx-sec + .ctx-sec { margin-top: 2px; }
+
+/* Top-bar stat chips: quiet hover so they don't look dead next to live data. */
+.v2-app .v2-statchip { transition: border-color var(--dur), color var(--dur); }
+
+/* Disabled send reads clearly inert. */
+.v2-app .send:disabled { transform: none; }
+
+/* Compaction-snapshot trigger: let the "before/after 보기" sub-label drop to
+   its own right-aligned line instead of crushing the label into a wrap. */
+.v2-app .cmp-open { flex-wrap: wrap; align-items: baseline; row-gap: 3px; }
+.v2-app .cmp-open-sub { margin-left: auto; }

--- a/dashboard/v2/styles/dock.css
+++ b/dashboard/v2/styles/dock.css
@@ -1,0 +1,194 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Copilot Dock
+   A global, co-view conversation panel. Toggleable from anywhere
+   (top-bar button · FAB · ⌘J), dockable to the right OR floating,
+   keeper-pickable, streaming, and bound to each surface's structured
+   context ("we're both looking at this screen"). Uses the v2 token
+   system + type ladder — no new colors.
+   ══════════════════════════════════════════════════════════════ */
+
+/* stage wrapper: lets the docked panel push the body */
+.v2-stage { flex: 1; min-height: 0; display: flex; }
+.v2-stage > .v2-body { flex: 1; min-width: 0; }
+
+/* ── shell ── */
+.dock {
+  display: flex; flex-direction: column; min-height: 0;
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 72%);
+  color: var(--text-primary);
+}
+.dock.docked {
+  width: var(--dock-w, 372px); flex: none;
+  border-left: 1px solid var(--border-main);
+}
+.dock.float {
+  position: fixed; z-index: 60;
+  width: 384px; height: min(78vh, 600px);
+  border: 1px solid var(--border-highlight);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-pop);
+  overflow: hidden;
+}
+
+/* ── header ── */
+.dock-head {
+  flex: none; display: flex; align-items: center; gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--border-main); background: var(--bg-panel);
+}
+.dock-head.drag { cursor: grab; user-select: none; }
+.dock-head.drag:active { cursor: grabbing; }
+.dock-title {
+  display: flex; align-items: center; gap: var(--sp-2);
+  font-family: var(--font-display); font-weight: 600; font-size: 13px;
+  letter-spacing: 0.02em; color: var(--text-bright);
+}
+.dock-spark { width: 16px; height: 16px; color: var(--volt-strong); }
+.dock-head .spacer { flex: 1; }
+.dock-iconbtn {
+  width: 28px; height: 28px; display: flex; align-items: center; justify-content: center;
+  border-radius: var(--radius-sm); border: 1px solid transparent; background: transparent;
+  color: var(--text-dim); cursor: pointer; transition: 0.14s; font-size: 13px;
+}
+.dock-iconbtn:hover { color: var(--text-bright); background: var(--bg-card); }
+
+/* ── identity row (keeper picker) ── */
+.dock-idrow { flex: none; display: flex; align-items: center; gap: var(--sp-3); padding: var(--sp-3) var(--sp-4) 0; }
+.dock-picker { position: relative; flex: none; }
+.dock-picker-btn {
+  display: flex; align-items: center; gap: var(--sp-2);
+  padding: 3px 9px 3px 3px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border-main); background: var(--bg-card); cursor: pointer; transition: 0.14s;
+}
+.dock-picker-btn:hover { border-color: var(--border-highlight); }
+.dock-picker-btn .nm { font-size: 11.5px; color: var(--text-bright); font-weight: 600; white-space: nowrap; }
+.dock-picker-btn .cv { color: var(--text-dim); font-size: 9px; }
+.dock-idrow-hint { font-size: 10.5px; color: var(--text-dim); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dock-idrow-hint .mono { font-family: var(--font-mono); color: var(--text-mid); }
+
+.dock-menu {
+  position: absolute; top: calc(100% + 6px); left: 0; width: 256px; max-height: 318px; overflow-y: auto;
+  background: var(--bg-panel); border: 1px solid var(--border-highlight);
+  border-radius: var(--radius-md); box-shadow: var(--shadow-pop); z-index: 8; padding: 5px;
+}
+.dock-menu-row { display: flex; align-items: center; gap: var(--sp-3); padding: 7px 8px; border-radius: var(--radius-sm); cursor: pointer; transition: 0.12s; }
+.dock-menu-row:hover { background: var(--bg-card); }
+.dock-menu-row.on { background: var(--bg-card); box-shadow: inset 0 0 0 1px var(--volt-wash); }
+.dock-menu-row .minfo { min-width: 0; flex: 1; }
+.dock-menu-row .nm { font-size: 12px; color: var(--text-bright); font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dock-menu-row .nm .h { color: var(--text-dim); font-weight: 400; font-size: 10px; }
+.dock-menu-row .sub { display: flex; align-items: center; gap: 5px; font-size: 10px; color: var(--text-dim); font-family: var(--font-mono); margin-top: 2px; }
+
+/* ── co-view context card ── */
+.dock-coview {
+  flex: none; margin: var(--sp-4) var(--sp-4) 0; padding: var(--sp-3) var(--sp-4);
+  border: 1px solid var(--border-soft); border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--info) 6%, var(--bg-sunken));
+}
+.dock-coview-h { display: flex; align-items: center; gap: var(--sp-2); margin-bottom: var(--sp-2); }
+.dock-coview-h .lbl { font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--info); font-weight: 600; }
+.dock-coview-h .route { margin-left: auto; font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
+.dock-coview .scene { font-size: 12.5px; color: var(--text-bright); font-weight: 600; margin-bottom: var(--sp-2); }
+.dock-coview-fields { display: flex; flex-wrap: wrap; gap: 5px; }
+.dock-field {
+  display: inline-flex; align-items: center; gap: 5px; white-space: nowrap;
+  font-family: var(--font-mono); font-size: 10px; padding: 2px 7px;
+  border-radius: var(--radius-pill); border: 1px solid var(--border-main);
+  background: var(--bg-deep); color: var(--text-mid);
+}
+.dock-field .k { color: var(--text-dim); }
+.dock-field.bad .v  { color: var(--status-bad); }
+.dock-field.warn .v { color: var(--status-warn); }
+.dock-field.volt .v { color: var(--volt-strong); }
+.dock-coview .sync { display: flex; align-items: center; gap: 5px; margin-top: var(--sp-2); font-size: 9.5px; color: var(--text-dim); }
+.dock-coview .sync .d { width: 5px; height: 5px; border-radius: 50%; background: var(--status-ok); box-shadow: 0 0 6px var(--status-ok); animation: dot-pulse 2s ease-in-out infinite; }
+
+/* ── thread ── */
+.dock-thread { flex: 1; overflow-y: auto; padding: var(--sp-4); display: flex; flex-direction: column; gap: var(--sp-4); }
+.dock-thread::-webkit-scrollbar { width: 8px; }
+.dock-thread::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); border: 2px solid transparent; background-clip: padding-box; }
+.dock-empty { margin: auto; text-align: center; color: var(--text-dim); padding: var(--sp-5) var(--sp-3); display: flex; flex-direction: column; gap: var(--sp-3); align-items: center; }
+.dock-empty .ico { font-size: 24px; opacity: 0.5; color: var(--info); }
+.dock-empty .t { font-family: var(--font-display); font-size: 12.5px; color: var(--text-mid); letter-spacing: 0.03em; }
+.dock-empty .s { font-size: 11.5px; line-height: 1.6; max-width: 250px; }
+
+.dmsg { display: grid; grid-template-columns: 26px 1fr; gap: var(--sp-3); }
+.dmsg.user { grid-template-columns: 1fr 26px; }
+.dmsg.user .dmsg-col { order: 0; }
+.dmsg.user .dmsg-av { order: 1; }
+.dmsg-av.op { width: 26px; height: 26px; display: flex; align-items: center; justify-content: center; border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: 9px; color: var(--volt-ink); background: var(--volt); }
+.dmsg-col { min-width: 0; }
+.dmsg.user .dmsg-hd { justify-content: flex-end; }
+.dmsg-hd { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; }
+.dmsg-hd .who { font-family: var(--font-display); font-weight: 600; font-size: 11px; color: var(--text-bright); }
+.dmsg-hd .ts { font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); }
+.dbubble {
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  border-radius: 3px var(--radius-md) var(--radius-md) var(--radius-md);
+  padding: var(--sp-3) var(--sp-4); font-size: 12.5px; line-height: 1.6; color: var(--text-primary);
+}
+.dmsg.user .dbubble { background: var(--volt-wash); border-color: var(--volt-dim); border-radius: var(--radius-md) 3px var(--radius-md) var(--radius-md); color: var(--text-bright); }
+.dbubble p { margin: 0 0 7px; }
+.dbubble p:last-child { margin-bottom: 0; }
+.dbubble code { font-family: var(--font-mono); font-size: 11px; background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 0 4px; border-radius: var(--radius-xs); color: var(--volt-strong); }
+.dbubble strong { color: var(--text-bright); font-weight: 600; }
+.dcaret { display: inline-block; width: 7px; height: 13px; background: var(--volt); margin-left: 2px; vertical-align: -2px; animation: dcaret 1s steps(2) infinite; }
+@keyframes dcaret { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+
+/* ── suggestions (mini) ── */
+.dsug { display: flex; flex-direction: column; gap: 5px; margin-top: var(--sp-3); }
+.dsug button {
+  text-align: left; font-family: var(--font-ui); font-size: 11.5px; line-height: 1.3;
+  padding: 6px 10px; border-radius: var(--radius-sm); border: 1px solid var(--border-main);
+  background: var(--bg-card); color: var(--text-primary); cursor: pointer; transition: 0.14s;
+}
+.dsug button:hover { border-color: var(--volt); color: var(--text-bright); background: var(--bg-card-hover); }
+.dsug button .pre { color: var(--volt); margin-right: 6px; }
+
+/* ── composer ── */
+.dock-composer { flex: none; padding: var(--sp-3) var(--sp-4) var(--sp-4); border-top: 1px solid var(--border-main); background: var(--bg-panel); }
+.dock-comp-box {
+  display: flex; align-items: flex-end; gap: var(--sp-2);
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  border-radius: var(--radius-md); padding: 5px 5px 5px var(--sp-4); transition: 0.15s;
+}
+.dock-comp-box.focus { border-color: var(--volt-dim); box-shadow: 0 0 0 3px var(--volt-wash); }
+.dock-comp-box textarea { flex: 1; resize: none; border: 0; outline: 0; background: transparent; color: var(--text-bright); font-family: var(--font-ui); font-size: 12.5px; line-height: 1.5; padding: 7px 0; max-height: 120px; min-height: 20px; }
+.dock-comp-box textarea::placeholder { color: var(--text-dim); }
+.dock-send { width: 30px; height: 30px; flex: none; border-radius: var(--radius-sm); border: 1px solid var(--volt); background: var(--volt); color: var(--volt-ink); cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 14px; transition: 0.14s; }
+.dock-send:hover:not(:disabled) { background: var(--volt-strong); box-shadow: 0 0 14px var(--volt-glow); }
+.dock-send:disabled { opacity: 0.4; cursor: default; }
+.dock-foot { display: flex; align-items: center; gap: var(--sp-3); margin-top: 7px; font-size: 10px; color: var(--text-dim); }
+.dock-foot b { color: var(--volt-strong); font-family: var(--font-mono); font-weight: 600; }
+.dock-foot kbd { font-family: var(--font-mono); font-size: 9px; background: var(--bg-card); border: 1px solid var(--border-main); border-bottom-width: 2px; border-radius: var(--radius-xs); padding: 1px 4px; color: var(--text-mid); }
+
+/* ── triggers: FAB + top-bar button ── */
+.dock-fab {
+  position: fixed; right: 22px; bottom: 22px; z-index: 55;
+  height: 44px; padding: 0 16px; display: flex; align-items: center; gap: var(--sp-2);
+  border-radius: var(--radius-pill); border: 1px solid var(--volt);
+  background: var(--volt); color: var(--volt-ink);
+  font-family: var(--font-ui); font-weight: 600; font-size: 12.5px; cursor: pointer;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4), 0 0 18px var(--volt-glow); transition: 0.16s;
+}
+.dock-fab:hover { background: var(--volt-strong); transform: translateY(-1px); }
+.dock-fab .spark { width: 17px; height: 17px; }
+.dock-fab kbd { font-family: var(--font-mono); font-size: 9px; padding: 1px 5px; border-radius: var(--radius-xs); background: color-mix(in oklab, var(--volt-ink) 16%, transparent); }
+
+.topbar-copilot {
+  display: flex; align-items: center; gap: 7px; height: 30px; padding: 0 10px;
+  border-radius: var(--radius-pill); border: 1px solid var(--border-main);
+  background: var(--bg-panel-alt); color: var(--text-mid); cursor: pointer;
+  font-family: var(--font-ui); font-size: 11px; transition: 0.14s; white-space: nowrap;
+}
+.topbar-copilot:hover { border-color: var(--volt-dim); color: var(--volt-strong); }
+.topbar-copilot.on { border-color: var(--volt); color: var(--volt-strong); background: var(--volt-wash); }
+.topbar-copilot .spark { width: 14px; height: 14px; }
+.topbar-copilot kbd { font-family: var(--font-mono); font-size: 9px; padding: 1px 4px; border-radius: var(--radius-xs); background: var(--bg-card); border: 1px solid var(--border-main); color: var(--text-dim); }
+
+@media (max-width: 1180px) {
+  .dock.docked { width: 320px; }
+}
+@media (max-width: 860px) {
+  .dock.docked { position: fixed; right: 0; top: 50px; bottom: 0; width: 320px; z-index: 60; box-shadow: var(--shadow-pop); }
+}

--- a/dashboard/v2/styles/inspector.css
+++ b/dashboard/v2/styles/inspector.css
@@ -1,0 +1,127 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Turn Inspector
+   A real agent-trace detail surface: summary stats, token economics,
+   a turn waterfall, a structured transcript with tool cards, and
+   copyable context blocks. Reuses the .turn-overlay / .turn-drawer
+   shell; everything new is namespaced .ti-*.
+   ══════════════════════════════════════════════════════════════ */
+
+.v2-app .ti-drawer { width: min(720px, 96vw); }
+.v2-app .ti-drawer .turn-hd h3 { white-space: nowrap; flex: none; }
+.v2-app .ti-drawer .turn-hd .tid { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* ── Header subline: model · finish ── */
+.ti-sub { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 0 16px 12px; border-bottom: 1px solid var(--border-soft); }
+.ti-chip { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-mid); border: 1px solid var(--border-main); background: var(--bg-card); padding: 3px 9px; border-radius: var(--radius-pill); white-space: nowrap; }
+.ti-chip .sub-k { margin: 0; }
+.ti-chip.ok { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 35%, transparent); }
+
+/* ── Summary stat strip ── */
+.ti-summary { display: grid; grid-template-columns: repeat(5, 1fr); gap: 1px; background: var(--border-soft); border-bottom: 1px solid var(--border-main); }
+.ti-stat { background: var(--bg-panel); padding: 11px 14px; min-width: 0; }
+.ti-stat .k { font-size: 8.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); }
+.ti-stat .v { font-family: var(--font-mono); font-size: 16px; color: var(--text-bright); margin-top: 5px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.ti-stat .v small { font-size: 10px; color: var(--text-dim); }
+.ti-stat .v.ok { color: var(--status-ok); }
+.ti-stat .v.volt { color: var(--volt-strong); }
+
+/* ── Token economics bar ── */
+.ti-tok { padding: 13px 16px; }
+.ti-tok-top { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
+.ti-tok-top .lbl { font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); }
+.ti-tok-top .ctxpct { font-family: var(--font-mono); font-size: 11px; color: var(--text-mid); }
+.ti-tok-bar { display: flex; height: 10px; border-radius: var(--radius-pill); overflow: hidden; background: var(--bg-sunken); border: 1px solid var(--border-soft); }
+.ti-tok-bar > span { display: block; height: 100%; min-width: 2px; }
+.ti-tok-bar .seg-in { background: var(--info-dim); }
+.ti-tok-bar .seg-out { background: var(--volt); }
+.ti-tok-legend { display: flex; gap: 18px; margin-top: 9px; font-size: 11.5px; color: var(--text-mid); }
+.ti-tok-legend span { display: inline-flex; align-items: center; gap: 6px; }
+.ti-tok-legend i { width: 9px; height: 9px; border-radius: 2px; flex: none; }
+.ti-tok-legend .in i { background: var(--info-dim); }
+.ti-tok-legend .out i { background: var(--volt); }
+.ti-tok-legend b { font-family: var(--font-mono); color: var(--text-bright); font-weight: 600; }
+
+/* ── Waterfall timeline ── */
+.ti-wf { display: flex; flex-direction: column; }
+.ti-wf-row { display: grid; grid-template-columns: 158px 1fr 56px; gap: 12px; align-items: center; padding: 6px 0; border-top: 1px solid var(--border-soft); }
+.ti-wf-row:first-child { border-top: 0; }
+.ti-wf-lbl { display: flex; align-items: center; gap: 8px; min-width: 0; font-size: 12.5px; color: var(--text-primary); }
+.ti-wf-lbl .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ti-wf-lbl .nm.mono { font-family: var(--font-mono); font-size: 11.5px; }
+.ti-wf-ico { width: 8px; height: 8px; border-radius: 2px; flex: none; }
+.ti-wf-track { position: relative; height: 18px; background: var(--bg-sunken); border-radius: var(--radius-xs); overflow: hidden; }
+.ti-wf-bar { position: absolute; top: 3px; height: 12px; border-radius: 3px; min-width: 4px; transition: none; }
+.ti-wf-dur { font-family: var(--font-mono); font-size: 11px; color: var(--text-mid); text-align: right; font-variant-numeric: tabular-nums; }
+.ti-k-ctx { background: var(--text-dim); }
+.ti-k-reason { background: var(--info); }
+.ti-k-tool { background: var(--volt); }
+.ti-k-gen { background: var(--status-ok); }
+.ti-wf-foot { display: flex; align-items: center; justify-content: space-between; margin-top: 12px; padding-top: 11px; border-top: 1px solid var(--border-main); font-size: 11.5px; color: var(--text-dim); }
+.ti-wf-foot b { font-family: var(--font-mono); color: var(--text-bright); font-weight: 600; }
+.ti-wf-legend { display: flex; gap: 14px; }
+.ti-wf-legend span { display: inline-flex; align-items: center; gap: 5px; font-size: 10.5px; color: var(--text-dim); }
+.ti-wf-legend i { width: 8px; height: 8px; border-radius: 2px; }
+
+/* ── Copyable code card ── */
+.ti-code { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; background: #06070a; margin-top: 6px; }
+.ti-code-h { display: flex; align-items: center; gap: 8px; padding: 6px 10px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.ti-code-h .cap { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); }
+.ti-code-h .sz { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
+.ti-code pre { margin: 0; padding: 10px 12px; overflow-x: auto; font-family: var(--font-mono); font-size: 11.5px; line-height: 1.62; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+.ti-code pre .jk { color: var(--volt-strong); }
+.ti-code pre .js { color: var(--status-ok); }
+.ti-copy { margin-left: auto; display: inline-flex; align-items: center; gap: 5px; background: none; border: 1px solid var(--border-main); color: var(--text-dim); border-radius: var(--radius-xs); font-family: var(--font-ui); font-size: 10px; padding: 3px 9px; cursor: pointer; transition: 0.14s; white-space: nowrap; }
+.ti-copy:hover { color: var(--volt); border-color: var(--volt-dim); }
+.ti-copy.done { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 40%, transparent); }
+
+/* ── Structured tool card (transcript) ── */
+.ti-tool { border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.ti-tool-h { display: flex; align-items: center; gap: 9px; padding: 9px 12px; background: var(--bg-panel-alt); }
+.ti-tool-h .seq { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
+.ti-tool-h .tnm { font-family: var(--font-mono); font-size: 12.5px; color: var(--text-bright); }
+.ti-tool-h .pill { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 7px; border-radius: var(--radius-pill); }
+.ti-tool-h .pill.ok { color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 40%, transparent); }
+.ti-tool-h .pill.bad { color: var(--status-bad); border: 1px solid color-mix(in oklab, var(--status-bad) 40%, transparent); }
+.ti-tool-h .lat { margin-left: auto; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
+.ti-tool-b { padding: 10px 12px; }
+
+/* ── Role-tinted transcript message ── */
+.ti-msg { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
+.ti-msg-h { display: flex; align-items: center; gap: 8px; padding: 7px 11px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.ti-msg-role { font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.1em; padding: 1px 8px; border-radius: var(--radius-xs); }
+.ti-msg-role.system { color: var(--info); border: 1px solid color-mix(in oklab, var(--info) 35%, transparent); }
+.ti-msg-role.user { color: var(--volt-strong); border: 1px solid var(--volt-dim); }
+.ti-msg-role.assistant { color: var(--text-bright); border: 1px solid var(--border-highlight); }
+.ti-msg-h .who { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.ti-msg-h .seq { margin-left: auto; font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
+.ti-msg-b { padding: 10px 12px; font-family: var(--font-body); font-size: 12.5px; line-height: 1.62; color: var(--text-primary); white-space: pre-wrap; word-break: break-word; }
+.ti-msg-b.mono { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid); }
+
+.ti-seq-rail { display: flex; flex-direction: column; gap: 10px; }
+
+/* ── Meta: parameter chips + kv ── */
+.ti-params { display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 4px; }
+.ti-param { font-family: var(--font-mono); font-size: 11px; padding: 4px 11px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-dim); }
+.ti-param b { color: var(--text-bright); font-weight: 600; margin-left: 6px; }
+
+/* ── Context section card ── */
+.ti-ctx-card { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
+.ti-ctx-h { display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.ti-ctx-h .t { font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-mid); }
+.ti-ctx-h .tok { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+.ti-ctx-card pre { margin: 0; padding: 11px 13px; max-height: 340px; overflow: auto; font-family: var(--font-mono); font-size: 11.5px; line-height: 1.62; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+
+/* section title gets a count chip on the right */
+.ti-sec-h { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin: 0 0 9px; }
+.ti-sec-h h4 { margin: 0; }
+.ti-sec-h .n { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+
+/* Drawer entrance: transform-only (no opacity fade). A backgrounded tab
+   freezes the animation clock on frame 0 — fading opacity there would hold
+   the whole drawer invisible. Sliding without fading keeps the resting/paused
+   state fully visible (just 18px offset) while still animating in foreground.
+   Redefines the global @keyframes turn-in used by every .turn-drawer. */
+@keyframes turn-in {
+  from { transform: translateX(18px); }
+  to   { transform: none; }
+}

--- a/dashboard/v2/styles/perf.css
+++ b/dashboard/v2/styles/perf.css
@@ -1,0 +1,51 @@
+/* MASC v2 — performance layer styles (perf.jsx).
+   Windowing scrollers, content-visibility rows, native dialog chrome,
+   and the demo FPS meter. Tokens from colors_and_type.css + v2.css. */
+
+/* ── VirtualList / CVList scrollers ── */
+.vl-scroller { scrollbar-width: thin; }
+.vl-scroller::-webkit-scrollbar { width: 10px; }
+.vl-scroller::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: 6px; border: 2px solid transparent; background-clip: padding-box; }
+.vl-row { box-sizing: border-box; }
+.cv-list { display: flex; flex-direction: column; }
+.cv-row { box-sizing: border-box; }
+
+/* ── native <dialog> ── */
+.v2-dialog {
+  border: 1px solid var(--border-main);
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  border-radius: var(--radius-lg, 12px);
+  padding: 0;
+  box-shadow: 0 24px 64px -12px rgba(0,0,0,0.7), 0 0 0 1px var(--border-soft);
+  max-width: min(92vw, 560px);
+  width: 100%;
+}
+.v2-dialog::backdrop {
+  background: color-mix(in oklab, var(--bg-deep) 64%, transparent);
+  backdrop-filter: blur(3px);
+  animation: v2dlg-bd 0.18s ease;
+}
+.v2-dialog[open] { animation: v2dlg-in 0.2s cubic-bezier(0.2, 0.8, 0.2, 1); }
+@keyframes v2dlg-in { from { opacity: 0; transform: translateY(8px) scale(0.98); } }
+@keyframes v2dlg-bd { from { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  .v2-dialog[open], .v2-dialog::backdrop { animation: none; }
+}
+
+/* ── FPS meter (demo) ── */
+.fps-meter {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 11.5px; letter-spacing: 0.02em;
+  padding: 4px 10px; border-radius: 999px;
+  border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-mid);
+}
+.fps-meter b { color: var(--text-bright); font-weight: 600; }
+.fps-meter .fps-label { color: var(--text-dim); margin-right: 2px; }
+.fps-meter .fps-low { color: var(--text-dim); }
+.fps-meter .fps-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--text-dim); }
+.fps-meter.ok .fps-dot { background: var(--status-ok); box-shadow: 0 0 7px var(--status-ok); }
+.fps-meter.warn .fps-dot { background: var(--status-warn, #e0a82e); box-shadow: 0 0 7px var(--status-warn, #e0a82e); }
+.fps-meter.bad .fps-dot { background: var(--status-bad, #e8472f); box-shadow: 0 0 7px var(--status-bad, #e8472f); }
+.fps-meter.ok b { color: var(--status-ok); }
+.fps-meter.bad b { color: var(--status-bad, #e8472f); }

--- a/dashboard/v2/styles/states.css
+++ b/dashboard/v2/styles/states.css
@@ -1,0 +1,33 @@
+/* MASC v2 — empty / error / loading state surfaces (kv-state, kv-skel).
+   Used by organisms-5 EmptyState / ErrorState / LoadingState across
+   Fleet, Board, Logs, etc. Tokens from colors_and_type.css + v2.css. */
+
+.kv-state {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 12px; padding: 40px 28px; text-align: center; min-height: 200px;
+}
+.kv-state-g {
+  width: 52px; height: 52px; display: grid; place-items: center;
+  font-size: 24px; border-radius: 50%;
+  color: var(--text-dim); background: var(--bg-card); border: 1px solid var(--border-main);
+}
+.kv-state.error .kv-state-g { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 45%, var(--border-main)); background: color-mix(in oklab, var(--status-bad) 9%, var(--bg-card)); }
+.kv-state-t { font-family: var(--font-display); font-weight: 600; font-size: 15px; color: var(--text-bright); letter-spacing: -0.01em; }
+.kv-state-h { font-size: 12.5px; line-height: 1.55; color: var(--text-mid); max-width: 320px; }
+.kv-state.error .kv-state-h { color: var(--status-bad); background: var(--bg-sunken); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 7px 11px; }
+.kv-state .act, .kv-state button { margin-top: 4px; }
+
+/* loading skeleton */
+.kv-state.loading { align-items: stretch; justify-content: flex-start; gap: 14px; min-height: 0; }
+.kv-skel-list { display: flex; flex-direction: column; gap: 12px; width: 100%; }
+.kv-skel-row { display: flex; align-items: center; gap: 11px; }
+.kv-skel-av { width: 38px; height: 38px; border-radius: 8px; flex: none; }
+.kv-skel-lines { display: flex; flex-direction: column; gap: 6px; flex: 1; }
+.kv-skel-line { height: 10px; border-radius: 4px; width: 70%; }
+.kv-skel-line.short { width: 40%; }
+.kv-skel-av, .kv-skel-line {
+  background: linear-gradient(100deg, var(--bg-card) 30%, color-mix(in oklab, var(--text-dim) 18%, var(--bg-card)) 50%, var(--bg-card) 70%);
+  background-size: 220% 100%; animation: kv-skel-sweep 1.3s ease-in-out infinite;
+}
+@keyframes kv-skel-sweep { from { background-position: 180% 0; } to { background-position: -40% 0; } }
+@media (prefers-reduced-motion: reduce) { .kv-skel-av, .kv-skel-line { animation: none; } }

--- a/dashboard/v2/styles/surfaces.css
+++ b/dashboard/v2/styles/surfaces.css
@@ -1,0 +1,613 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Surface styles: Overview · Board · Cockpit ·
+   Connectors · IDE, plus collapsible rails. Loads after v2.css.
+   ══════════════════════════════════════════════════════════════ */
+
+/* ════ SHARED SURFACE SHELL ════ */
+.surf { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--bg-deep); }
+.surf-scroll { flex: 1; overflow-y: auto; padding: var(--pad-surface); }
+.surf-scroll::-webkit-scrollbar { width: 9px; }
+.surf-scroll::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); border: 2px solid transparent; background-clip: padding-box; }
+
+.surf-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+.surf-head h1 { font-family: var(--font-display); font-weight: 500; font-size: 22px; letter-spacing: 0.02em; color: var(--text-bright); margin: 0; }
+.surf-head .eyebrow { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 5px; }
+.surf-sub { margin-top: 5px; font-size: 12px; color: var(--text-dim); }
+.surf-sub b { color: var(--volt-strong); font-weight: 600; }
+.surf-sub .mono { color: var(--text-mid); }
+
+/* ════ COLLAPSIBLE RAILS ════ */
+.v2-body { transition: grid-template-columns 0.22s ease; }
+
+/* roster mini mode: sigils only */
+.roster.mini .roster-head, .roster.mini .roster-filters { display: none; }
+.roster.mini .roster-group { padding: 10px 0 4px; text-align: center; letter-spacing: 0; font-size: 8px; overflow: hidden; white-space: nowrap; }
+.roster.mini .kp-row { grid-template-columns: 38px; justify-content: center; padding: 6px 0; justify-items: center; }
+.roster.mini .kp-meta, .roster.mini .kp-right { display: none; }
+.roster.mini .kp-row.sel::before { left: -4px; }
+.roster.mini .roster-list { padding: 6px 4px; }
+
+.rail-toggle {
+  position: absolute; top: 50%; transform: translateY(-50%);
+  width: 17px; height: 52px; z-index: 30; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  color: var(--text-dim); font-size: 10px; padding: 0;
+  transition: 0.15s;
+}
+.rail-toggle:hover { color: var(--volt-strong); border-color: var(--volt-dim); background: var(--bg-card-hover); }
+.rail-toggle.left { left: 0; border-left: 0; border-radius: 0 6px 6px 0; }
+.rail-toggle.right { right: 0; border-right: 0; border-radius: 6px 0 0 6px; }
+.chat-wrap { position: relative; display: flex; min-width: 0; min-height: 0; }
+.chat-wrap .chat { flex: 1; }
+
+/* ════ OVERVIEW ════ */
+.ov { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--bg-deep); }
+.ov-scroll { flex: 1; overflow-y: auto; padding: var(--pad-surface); max-width: 1280px; width: 100%; margin: 0 auto; }
+.ov-head { display: flex; align-items: flex-end; justify-content: space-between; margin-bottom: 18px; }
+.ov-head h1 { font-family: var(--font-display); font-weight: 500; font-size: 22px; color: var(--text-bright); margin: 0; }
+.ov-sub { margin-top: 5px; font-size: 12px; color: var(--text-dim); }
+.ov-sub b { color: var(--volt-strong); }
+.ov-sub .mono { color: var(--text-mid); }
+.ov-clock { font-size: 18px; color: var(--text-mid); }
+.ov-clock span { font-size: 10px; color: var(--text-dim); letter-spacing: 0.14em; }
+
+.ov-kpis { display: grid; grid-template-columns: repeat(6, 1fr); gap: 1px; background: var(--border-soft); border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: hidden; margin-bottom: 16px; }
+.ov-kpi { background: var(--bg-panel); padding: 13px 15px; }
+.ov-kpi-k { font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); }
+.ov-kpi-v { font-family: var(--font-mono); font-variant-numeric: tabular-nums; font-size: 23px; color: var(--text-bright); margin-top: 5px; }
+.ov-kpi-v small { font-size: 11px; color: var(--text-dim); }
+.ov-kpi-v.ok { color: var(--status-ok); } .ov-kpi-v.bad { color: var(--status-bad); }
+.ov-kpi-v.warn { color: var(--status-warn); } .ov-kpi-v.volt { color: var(--volt-strong); }
+
+.ov-grid { display: grid; grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr); gap: var(--gap-card); margin-bottom: 16px; }
+.ov-card { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: var(--pad-card); min-width: 0; }
+.ov-card-h { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+.ov-card-h h3 { font-family: var(--font-display); font-weight: 500; font-size: 12px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-mid); margin: 0; white-space: nowrap; }
+.ov-count { font-family: var(--font-mono); font-size: 11px; color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 14%, transparent); border: 1px solid color-mix(in oklab, var(--status-bad) 35%, transparent); padding: 1px 8px; border-radius: var(--radius-pill); }
+.ov-legend { font-size: 10px; color: var(--text-dim); }
+.ov-link { font-family: var(--font-ui); font-size: 11px; color: var(--volt-strong); background: none; border: 0; cursor: pointer; padding: 2px 0; }
+.ov-link:hover { text-decoration: underline; }
+
+.ov-attn-list { display: flex; flex-direction: column; gap: 7px; }
+.ov-attn-row { display: flex; align-items: center; gap: 11px; padding: 9px 10px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); cursor: pointer; transition: 0.14s; }
+.ov-attn-row:hover { border-color: var(--border-highlight); background: var(--bg-card-hover); }
+.ov-attn-meta { min-width: 0; flex: 1; }
+.ov-attn-name { font-family: var(--font-display); font-weight: 600; font-size: 13px; color: var(--text-bright); display: flex; gap: 9px; align-items: baseline; }
+.ov-attn-ns { font-size: 10px; color: var(--text-dim); font-weight: 400; }
+.ov-attn-reason { display: flex; align-items: center; gap: 6px; font-size: 11.5px; margin-top: 3px; color: var(--text-mid); }
+.ov-attn-reason.sev-bad { color: var(--status-bad); }
+.ov-attn-reason.sev-warn { color: var(--status-warn); }
+.ov-attn-act { flex: none; font-family: var(--font-ui); font-size: 11px; padding: 6px 11px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-panel-alt); color: var(--text-mid); cursor: pointer; transition: 0.14s; white-space: nowrap; }
+.ov-attn-act:hover { color: var(--volt-strong); border-color: var(--volt-dim); }
+.ov-empty { padding: 26px 0; text-align: center; color: var(--text-dim); font-size: 12px; }
+
+.ov-bars { display: flex; align-items: flex-end; gap: 4px; height: 92px; padding: 4px 2px 0; }
+.ov-bar { flex: 1; min-width: 0; background: linear-gradient(180deg, var(--volt-dim), color-mix(in oklab, var(--volt-dim) 50%, var(--bg-card))); border-radius: 2px 2px 0 0; }
+.ov-bar.hot { background: linear-gradient(180deg, var(--volt), var(--volt-dim)); box-shadow: 0 0 9px var(--volt-glow); }
+.ov-tel-foot { display: flex; gap: 22px; margin-top: 12px; padding-top: 11px; border-top: 1px solid var(--border-soft); }
+.ov-tel-stat .k { font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); display: block; }
+.ov-tel-stat .v { font-size: 13px; color: var(--text-mid); margin-top: 3px; display: block; }
+
+.ov-fleet-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(215px, 1fr)); gap: 9px; }
+.ov-keeper { text-align: left; background: var(--bg-card); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 11px 12px; cursor: pointer; transition: 0.14s; min-width: 0; font-family: var(--font-ui); }
+.ov-keeper:hover { border-color: var(--volt-dim); background: var(--bg-card-hover); box-shadow: 0 0 0 2px var(--volt-wash); }
+.ov-keeper-top { display: flex; align-items: center; gap: 9px; }
+.ov-keeper-id { min-width: 0; flex: 1; }
+.ov-keeper-name { font-family: var(--font-display); font-weight: 600; font-size: 12.5px; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ov-keeper-state { display: flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); margin-top: 2px; }
+.ov-keeper-att { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; min-width: 16px; text-align: center; padding: 1px 5px; border-radius: var(--radius-pill); color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 16%, transparent); border: 1px solid color-mix(in oklab, var(--status-bad) 35%, transparent); flex: none; }
+.ov-keeper-ns { font-size: 10px; color: var(--text-dim); margin-top: 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ov-keeper-foot { display: flex; align-items: center; gap: 8px; margin-top: 7px; font-size: 10px; color: var(--text-dim); }
+.ov-mini-meter { flex: 1; height: 4px; border-radius: var(--radius-pill); background: var(--bg-sunken); border: 1px solid var(--border-soft); overflow: hidden; }
+.ov-mini-meter span { display: block; height: 100%; background: var(--volt-dim); }
+.ov-mini-meter span.hot { background: var(--status-bad); }
+.ov-keeper-ctx { flex: none; }
+
+/* ════ COCKPIT — Command Map ════ */
+.cp-body { flex: 1; min-height: 0; display: grid; grid-template-columns: minmax(280px, 360px) minmax(0, 1fr); }
+.cp-world { border-right: 1px solid var(--border-main); background: #050608; position: relative; overflow: hidden; display: flex; flex-direction: column; }
+.cp-world-cv { position: relative; flex: 1; min-height: 300px; }
+.cp-ring { position: absolute; border: 1px solid rgba(224,176,87,0.10); border-radius: 50%; left: 50%; top: 50%; transform: translate(-50%, -50%); }
+.cp-node { position: absolute; transform: translate(-50%, -50%); display: flex; flex-direction: column; align-items: center; gap: 4px; cursor: pointer; transition: 0.15s; z-index: 2; }
+.cp-node:hover { transform: translate(-50%, -50%) scale(1.12); }
+.cp-node .nm { font-family: var(--font-mono); font-size: 8.5px; color: var(--text-dim); white-space: nowrap; }
+.cp-node.off { opacity: 0.4; }
+.cp-world-foot { flex: none; padding: 12px 14px; border-top: 1px solid var(--border-soft); display: flex; flex-direction: column; gap: 6px; background: rgba(8,9,13,0.7); }
+.cp-world-foot .row { display: flex; justify-content: space-between; font-size: 10.5px; color: var(--text-dim); }
+.cp-world-foot .row b { font-family: var(--font-mono); color: var(--text-mid); font-weight: 500; }
+.cp-world-title { position: absolute; top: 14px; left: 16px; z-index: 3; }
+.cp-world-title .t { font-family: var(--font-display); font-size: 11px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--text-mid); }
+.cp-world-title .s { font-size: 10px; color: var(--text-dim); margin-top: 3px; }
+
+.cp-main { min-height: 0; overflow-y: auto; padding: var(--pad-surface); }
+.cp-main::-webkit-scrollbar { width: 9px; }
+.cp-main::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); }
+.cp-inner { max-width: 1080px; margin: 0 auto; display: flex; flex-direction: column; gap: var(--gap-card); }
+
+.cp-modebar { display: flex; align-items: center; gap: 8px; }
+.cp-mode { display: flex; flex-direction: column; gap: 2px; align-items: flex-start; padding: 8px 14px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-panel); color: var(--text-mid); cursor: pointer; font-family: var(--font-ui); transition: 0.15s; }
+.cp-mode .ml { font-size: 12px; font-weight: 600; color: var(--text-mid); }
+.cp-mode .ms { font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); }
+.cp-mode:hover { border-color: var(--border-highlight); }
+.cp-mode.on { border-color: var(--volt); background: var(--volt-wash); box-shadow: 0 0 0 2px var(--volt-wash); }
+.cp-mode.on .ml { color: var(--volt-strong); }
+
+.cp-disc { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: hidden; }
+.cp-disc-h { display: flex; align-items: center; gap: 10px; padding: 10px 14px; border-bottom: 1px solid var(--border-soft); }
+.cp-disc-h h3 { font-family: var(--font-display); font-weight: 500; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-mid); margin: 0; white-space: nowrap; }
+.cp-disc-rows { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; background: var(--border-soft); }
+.cp-disc-row { background: var(--bg-panel); padding: 11px 14px; }
+.cp-disc-row .lvl { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--volt-strong); }
+.cp-disc-row .ttl { font-size: 12.5px; font-weight: 600; color: var(--text-bright); margin-top: 4px; }
+.cp-disc-row .sum { font-size: 11px; color: var(--text-dim); margin-top: 3px; line-height: 1.5; }
+.cp-disc-row .mtr { display: inline-block; font-family: var(--font-mono); font-size: 10px; color: var(--text-mid); background: var(--bg-card); border: 1px solid var(--border-main); padding: 1px 7px; border-radius: var(--radius-pill); margin-top: 7px; }
+
+.cp-plane { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: hidden; }
+.cp-plane-h { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 12px 14px; border-bottom: 1px solid var(--border-soft); background: var(--bg-panel-alt); }
+.cp-plane-h .lft { display: flex; gap: 10px; min-width: 0; }
+.cp-plane-ico { width: 30px; height: 30px; flex: none; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-deep); display: flex; align-items: center; justify-content: center; color: var(--volt-strong); }
+.cp-plane-ico svg { width: 15px; height: 15px; }
+.cp-plane-h h2 { font-family: var(--font-display); font-weight: 600; font-size: 14px; color: var(--text-bright); margin: 0; }
+.cp-plane-h .sum { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+.cp-plane-h .chips { display: flex; gap: 6px; flex: none; }
+.cp-cov { font-family: var(--font-mono); font-size: 9.5px; padding: 2px 8px; border-radius: var(--radius-xs); border: 1px solid; white-space: nowrap; }
+.cp-cov.ok { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 35%, transparent); background: color-mix(in oklab, var(--status-ok) 9%, transparent); }
+.cp-cov.blk { color: var(--text-dim); border-color: var(--border-main); background: var(--bg-deep); }
+
+.cp-routes { display: grid; grid-template-columns: repeat(auto-fill, minmax(225px, 1fr)); gap: 8px; padding: 12px 14px; }
+.cp-route { display: flex; flex-direction: column; justify-content: space-between; gap: 12px; min-height: 86px; text-align: left; padding: 10px 12px; border-radius: var(--radius-sm); border: 1px solid var(--border-soft); background: var(--bg-deep); cursor: pointer; font-family: var(--font-ui); transition: 0.15s; min-width: 0; }
+.cp-route:hover { border-color: var(--border-highlight); background: var(--bg-card); }
+.cp-route:hover .arr { color: var(--volt-strong); }
+.cp-route-top { display: flex; justify-content: space-between; gap: 8px; min-width: 0; }
+.cp-route .rl { font-size: 12.5px; font-weight: 600; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cp-route .rc { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); margin-top: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cp-route .arr { color: var(--text-dim); flex: none; transition: 0.15s; font-size: 12px; }
+.cp-route .cp-cov { align-self: flex-start; }
+
+/* ════ BOARD ════ */
+.bd-body { flex: 1; min-height: 0; display: grid; grid-template-columns: 200px minmax(0, 1fr) minmax(290px, 360px); }
+.bd-body.no-detail { grid-template-columns: 200px minmax(0, 1fr); }
+
+.bd-rail { border-right: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); padding: 14px 9px; overflow-y: auto; }
+.bd-rail h4 { font-size: 9.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--text-dim); margin: 0 0 8px 7px; font-weight: 500; }
+.bd-sub { display: flex; align-items: center; gap: 8px; width: 100%; text-align: left; padding: 7px 9px; border-radius: var(--radius-sm); border: 1px solid transparent; background: none; color: var(--text-mid); font-family: var(--font-ui); font-size: 12.5px; cursor: pointer; transition: 0.13s; white-space: nowrap; overflow: hidden; }
+.bd-sub:hover { background: var(--bg-card); color: var(--text-bright); }
+.bd-sub.on { background: var(--bg-card); color: var(--volt-strong); border-color: var(--volt-dim); }
+.bd-sub .glyph { font-size: 11px; color: var(--text-dim); width: 13px; text-align: center; }
+.bd-sub.on .glyph { color: var(--volt-strong); }
+.bd-sub .n { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+.bd-sub .unread { margin-left: auto; width: 7px; height: 7px; border-radius: 50%; background: var(--volt); box-shadow: 0 0 7px var(--volt-glow); }
+.bd-rail .div { height: 1px; background: var(--border-soft); margin: 12px 4px; }
+
+.bd-feed { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
+.bd-feed-head { flex: none; display: flex; align-items: center; gap: 10px; padding: 11px 18px; border-bottom: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep)); }
+.bd-feed-head h2 { font-family: var(--font-display); font-weight: 600; font-size: 15px; color: var(--text-bright); margin: 0; white-space: nowrap; }
+.bd-feed-head .ns { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.bd-feed-head .spacer { flex: 1; }
+.bd-filter { font-family: var(--font-ui); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 10px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: transparent; color: var(--text-dim); cursor: pointer; transition: 0.14s; white-space: nowrap; }
+.bd-filter.on { color: var(--volt-ink); background: var(--volt); border-color: var(--volt); font-weight: 600; }
+.bd-filter:not(.on):hover { color: var(--text-mid); border-color: var(--border-highlight); }
+
+.bd-list { flex: 1; overflow-y: auto; padding: 14px 18px; display: flex; flex-direction: column; gap: 10px; }
+.bd-list::-webkit-scrollbar { width: 9px; }
+.bd-list::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); }
+
+.bd-post { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: var(--pad-card); cursor: pointer; transition: 0.14s; }
+.bd-post:hover { border-color: var(--border-highlight); background: var(--bg-card); }
+.bd-post.sel { border-color: var(--volt-dim); box-shadow: inset 0 0 0 1px var(--volt-wash); background: var(--bg-card); }
+.bd-post-h { display: flex; align-items: center; gap: 9px; }
+.bd-post-h .who { font-family: var(--font-display); font-weight: 600; font-size: 12.5px; color: var(--text-bright); }
+.bd-post-h .ts { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); margin-left: auto; flex: none; }
+.bd-badge { font-size: 8.5px; letter-spacing: 0.1em; text-transform: uppercase; padding: 2px 6px; border-radius: var(--radius-xs); border: 1px solid var(--border-main); color: var(--text-dim); background: var(--bg-deep); white-space: nowrap; }
+.bd-badge.state { color: var(--info); border-color: color-mix(in oklab, var(--info) 35%, transparent); }
+.bd-badge.pin { color: var(--volt-strong); border-color: var(--volt-dim); }
+.bd-badge.mod { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); }
+.bd-post-title { font-size: 13.5px; font-weight: 600; color: var(--text-bright); margin-top: 8px; line-height: 1.4; }
+.bd-post-body { font-size: 12.5px; color: var(--text-mid); line-height: 1.55; margin-top: 5px; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.bd-post-body code, .bd-th-body code { font-family: var(--font-mono); font-size: 11px; background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 0 4px; border-radius: var(--radius-xs); color: var(--volt-strong); }
+.bd-post-body .mention, .bd-th-body .mention { color: var(--info); font-family: var(--font-mono); font-size: 11.5px; }
+.bd-post-foot { display: flex; align-items: center; gap: 7px; margin-top: 10px; }
+.bd-react { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 10.5px; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-soft); background: var(--bg-deep); color: var(--text-mid); cursor: pointer; transition: 0.13s; }
+.bd-react:hover { border-color: var(--volt-dim); color: var(--volt-strong); }
+.bd-react.mine { border-color: var(--volt-dim); background: var(--volt-wash); color: var(--volt-strong); }
+.bd-post-foot .replies { margin-left: auto; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.bd-post-foot .karma { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); white-space: nowrap; }
+.bd-post-foot .karma b { color: var(--volt-strong); font-weight: 600; }
+
+/* state-block post */
+.bd-stateblock { display: grid; grid-template-columns: auto 1fr; gap: 4px 14px; margin-top: 9px; padding: 9px 12px; border-radius: var(--radius-sm); background: var(--bg-sunken); border: 1px dashed var(--border-main); font-family: var(--font-mono); font-size: 11px; }
+.bd-stateblock .sk { color: var(--text-dim); }
+.bd-stateblock .sv { color: var(--text-mid); }
+.bd-stateblock .sv.hl { color: var(--info); }
+
+/* board composer */
+.bd-composer { flex: none; border-top: 1px solid var(--border-main); background: linear-gradient(0deg, var(--bg-panel), var(--bg-deep)); padding: 10px 18px 14px; }
+.bd-comp-tabs { display: flex; gap: 4px; margin-bottom: 8px; }
+.bd-comp-tab { font-family: var(--font-ui); font-size: 11px; padding: 4px 11px; border-radius: 4px 4px 0 0; border: 1px solid transparent; background: none; color: var(--text-dim); cursor: pointer; white-space: nowrap; }
+.bd-comp-tab.on { color: var(--volt-strong); border-color: var(--border-main); border-bottom-color: var(--bg-deep); background: var(--bg-card); }
+.bd-comp-box { display: flex; gap: 10px; align-items: flex-end; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: 5px 5px 5px 13px; }
+.bd-comp-box:focus-within { border-color: var(--volt-dim); box-shadow: 0 0 0 3px var(--volt-wash); }
+.bd-comp-box textarea { flex: 1; resize: none; border: 0; outline: 0; background: transparent; color: var(--text-bright); font-family: var(--font-ui); font-size: 13px; line-height: 1.5; padding: 8px 0; min-height: 21px; max-height: 120px; }
+.bd-comp-box textarea::placeholder { color: var(--text-dim); }
+
+/* board detail rail (thread) */
+.bd-detail { border-left: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); display: flex; flex-direction: column; min-height: 0; }
+.bd-detail-h { flex: none; display: flex; align-items: center; gap: 9px; padding: 12px 14px; border-bottom: 1px solid var(--border-soft); }
+.bd-detail-h h3 { font-family: var(--font-display); font-weight: 500; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-mid); margin: 0; flex: 1; }
+.bd-detail-x { background: none; border: 0; color: var(--text-dim); cursor: pointer; font-size: 13px; padding: 3px 6px; border-radius: var(--radius-sm); }
+.bd-detail-x:hover { color: var(--text-bright); background: var(--bg-card); }
+.bd-detail-scroll { flex: 1; overflow-y: auto; padding: 14px; display: flex; flex-direction: column; gap: 11px; }
+.bd-th { display: grid; grid-template-columns: 26px 1fr; gap: 9px; }
+.bd-th-hd { display: flex; align-items: baseline; gap: 7px; }
+.bd-th-hd .who { font-family: var(--font-display); font-weight: 600; font-size: 12px; color: var(--text-bright); }
+.bd-th-hd .ts { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
+.bd-th-body { font-size: 12.5px; color: var(--text-primary); line-height: 1.6; margin-top: 3px; }
+.bd-mention-row { display: flex; align-items: flex-start; gap: 9px; padding: 9px 10px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); cursor: pointer; transition: 0.13s; }
+.bd-mention-row:hover { border-color: var(--border-highlight); }
+.bd-mention-row .txt { font-size: 11.5px; color: var(--text-mid); line-height: 1.5; min-width: 0; }
+.bd-mention-row .txt b { color: var(--text-bright); font-weight: 600; }
+.bd-mention-row .ts { margin-left: auto; flex: none; font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
+
+/* ════ CONNECTORS ════ */
+.cn-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(330px, 1fr)); gap: var(--gap-card); margin-bottom: 16px; }
+.cn-card { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: hidden; display: flex; flex-direction: column; }
+.cn-card.stale { border-color: color-mix(in oklab, var(--status-warn) 35%, var(--border-main)); }
+.cn-card.down { border-color: color-mix(in oklab, var(--status-bad) 30%, var(--border-main)); }
+.cn-h { display: flex; align-items: center; gap: 11px; padding: 13px 15px; border-bottom: 1px solid var(--border-soft); background: var(--bg-panel-alt); }
+.cn-glyph { width: 34px; height: 34px; flex: none; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-deep); display: flex; align-items: center; justify-content: center; font-size: 15px; color: var(--volt-strong); }
+.cn-h .meta { min-width: 0; flex: 1; }
+.cn-h .nm { font-family: var(--font-display); font-weight: 600; font-size: 14px; color: var(--text-bright); }
+.cn-h .ch { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); margin-top: 3px; }
+.cn-kv { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--border-soft); border-bottom: 1px solid var(--border-soft); }
+.cn-kv .cell { background: var(--bg-panel); padding: 8px 15px; }
+.cn-kv .k { font-size: 8.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); }
+.cn-kv .v { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid); margin-top: 3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cn-kv .v.hl { color: var(--volt-strong); }
+.cn-caps { display: flex; flex-wrap: wrap; gap: 5px; padding: 10px 15px; border-bottom: 1px solid var(--border-soft); }
+.cn-cap { font-family: var(--font-mono); font-size: 9.5px; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); background: var(--bg-deep); white-space: nowrap; }
+.cn-bind { padding: 10px 15px 13px; flex: 1; }
+.cn-bind h5 { font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); margin: 0 0 9px; font-weight: 600; }
+.cn-bind-row { display: flex; align-items: center; gap: 9px; padding: 7px 0; font-family: var(--font-mono); font-size: 12.5px; border-bottom: 1px dashed var(--border-soft); }
+.cn-bind-row:last-child { border-bottom: 0; }
+.cn-bind-row .chn { color: var(--text-mid); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cn-bind-row .arr { color: var(--text-dim); flex: none; }
+.cn-bind-none { font-size: 11px; color: var(--text-dim); padding: 4px 0; }
+
+/* binding editor (connector config drawer) */
+.cn-be { border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 9px 11px; margin-bottom: 8px; background: var(--bg-card); transition: opacity 0.14s; }
+.cn-be.off { opacity: 0.5; }
+.cn-be-main { display: flex; align-items: center; gap: 8px; }
+.cn-be-chn { flex: 1; min-width: 0; font-size: 12px; padding: 5px 8px; background: var(--bg-sunken); color: var(--text-bright); border: 1px solid var(--border-main); border-radius: var(--radius-xs); outline: none; }
+.cn-be-chn:focus { border-color: var(--volt-dim); }
+.cn-be-arr { color: var(--text-dim); flex: none; }
+.cn-be-kp { display: flex; align-items: center; gap: 6px; flex: none; }
+.cn-be-sel { font-size: 12px; padding: 5px 8px; background: var(--bg-sunken); color: var(--text-bright); border: 1px solid var(--border-main); border-radius: var(--radius-xs); outline: none; cursor: pointer; }
+.cn-be-sel:focus { border-color: var(--volt-dim); }
+.cn-be-del { flex: none; width: 24px; height: 24px; border-radius: var(--radius-xs); border: 1px solid var(--border-main); background: transparent; color: var(--text-dim); cursor: pointer; font-size: 11px; transition: 0.14s; }
+.cn-be-del:hover { border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); color: var(--status-bad); }
+.cn-be-opts { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 8px; }
+.cn-be-dir { display: inline-flex; border: 1px solid var(--border-main); border-radius: var(--radius-xs); overflow: hidden; }
+.cn-dir-b { font-family: var(--font-ui); font-size: 10.5px; padding: 4px 10px; background: transparent; border: 0; color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.cn-dir-b:not(:last-child) { border-right: 1px solid var(--border-main); }
+.cn-dir-b:hover { color: var(--text-mid); }
+.cn-dir-b.on { background: var(--volt-wash); color: var(--volt); }
+.set-toggle.sm { width: 32px; height: 18px; }
+.set-toggle.sm .knob { width: 13px; height: 13px; }
+.set-toggle.sm.on .knob { left: 16px; }
+
+.cn-audit { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: 14px 16px; }
+.cn-audit table { width: 100%; border-collapse: collapse; font-size: 11.5px; }
+.cn-audit th { text-align: left; font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); font-weight: 500; padding: 4px 10px 8px 0; border-bottom: 1px solid var(--border-main); }
+.cn-audit td { padding: 7px 10px 7px 0; border-bottom: 1px solid var(--border-soft); color: var(--text-mid); font-family: var(--font-mono); font-size: 10.5px; white-space: nowrap; }
+.cn-audit td.act { color: var(--text-bright); font-family: var(--font-ui); font-size: 11.5px; white-space: normal; }
+.cn-audit tr:last-child td { border-bottom: 0; }
+
+.gate-strip { display: flex; align-items: center; gap: 14px; padding: 10px 16px; border: 1px solid var(--border-main); border-radius: var(--radius-md); background: var(--bg-panel); margin-bottom: 16px; font-size: 12px; color: var(--text-mid); flex-wrap: wrap; }
+.gate-strip .sep { width: 1px; height: 16px; background: var(--border-soft); }
+.gate-strip b { color: var(--text-bright); font-weight: 600; }
+.gate-strip .mono { font-size: 11px; }
+
+/* ════ IDE ════ */
+.ide { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--bg-deep); }
+.ide-top { flex: none; display: flex; align-items: center; gap: 12px; height: 42px; padding: 0 14px; border-bottom: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep)); }
+.ide-repo { display: flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid); }
+.ide-repo .br { color: var(--volt-strong); }
+.ide-remote { color: var(--text-bright); cursor: pointer; transition: color 0.14s; background: none; border: 0; padding: 0; font: inherit; }
+.ide-remote:hover { color: var(--volt); text-decoration: underline; text-underline-offset: 2px; }
+.ide-remote::before { content: "⎇ "; color: var(--text-dim); }
+.ide-web { color: var(--text-dim); text-decoration: none; margin: 0 6px 0 5px; font-size: 11px; transition: color 0.14s; }
+.ide-web:hover { color: var(--volt); }
+
+/* ════ SETTINGS SURFACE ════ */
+.settings-surf { display: flex; min-width: 0; min-height: 0; }
+.set-shell { display: flex; flex: 1; min-width: 0; min-height: 0; }
+.set-nav { width: 218px; flex: none; border-right: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); display: flex; flex-direction: column; overflow-y: auto; padding-bottom: 10px; }
+.set-nav-h { padding: 18px 18px 14px; border-bottom: 1px solid var(--border-soft); margin-bottom: 8px; }
+.set-nav-h .eyebrow { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--volt-strong); }
+.set-nav-title { font-family: var(--font-display); font-weight: 400; text-transform: uppercase; letter-spacing: 0.14em; font-size: 19px; color: var(--text-bright); margin: 4px 0 5px; }
+.set-nav-sub { font-size: 10.5px; color: var(--text-dim); }
+.set-nav-item { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin: 1px 8px; padding: 9px 11px; border-radius: var(--radius-sm); background: none; border: 1px solid transparent; cursor: pointer; transition: 0.14s; text-align: left; outline: none; }
+.set-nav-item .ko { font-size: 13px; color: var(--text-mid); }
+.set-nav-item .en { font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); }
+.set-nav-item:hover { background: var(--bg-card); }
+.set-nav-item:hover .ko { color: var(--text-bright); }
+.set-nav-item.on { background: var(--volt-wash); border-color: var(--volt-dim); }
+.set-nav-item.on .ko { color: var(--volt-strong); }
+.set-nav-item.on .en { color: var(--volt); }
+.set-nav-group { display: flex; flex-direction: column; margin-bottom: 5px; }
+.set-nav-glabel { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); padding: 13px 19px 4px; }
+@media (max-width: 900px) {
+  .set-nav-group { display: contents; }
+  .set-nav-glabel { display: none; }
+}
+
+.set-content { flex: 1; min-width: 0; overflow-y: auto; }
+.set-content-h { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 22px 28px 16px; border-bottom: 1px solid var(--border-soft); position: sticky; top: 0; background: var(--bg-deep); z-index: 2; }
+.set-content-h h1 { font-family: var(--font-display); font-weight: 400; text-transform: uppercase; letter-spacing: 0.1em; font-size: 22px; color: var(--text-bright); margin: 0; white-space: nowrap; }
+.settings-surf .set-card-b { padding: 8px 28px 40px; max-width: 760px; }
+
+.set-row { display: flex; align-items: center; gap: 14px; padding: 13px 0; border-top: 1px solid var(--border-soft); }
+.set-row:first-child { border-top: 0; }
+.set-row-l { flex: 1; min-width: 0; }
+.set-label { font-size: 13px; color: var(--text-primary); }
+.set-hint { font-size: 11px; color: var(--text-dim); margin-top: 3px; }
+.set-row-c { flex: none; }
+.set-sub-h { font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); margin: 18px 0 2px; }
+.set-link { background: none; border: 0; color: var(--volt); cursor: pointer; font: inherit; padding: 0; text-decoration: underline; text-underline-offset: 2px; }
+.set-mcp-detail { margin: -4px 0 4px; padding: 8px 11px; background: #06070a; border: 1px solid var(--border-soft); border-radius: var(--radius-xs); font-size: 11px; color: var(--text-dim); overflow-x: auto; white-space: nowrap; }
+.set-nav-note { margin: auto 12px 12px; font-size: 10px; line-height: 1.5; color: var(--text-dim); padding-top: 12px; border-top: 1px solid var(--border-soft); }
+
+.set-verify { font-family: var(--font-ui); font-size: 11px; padding: 6px 11px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-mid); cursor: pointer; white-space: nowrap; transition: 0.14s; }
+.set-verify:hover { border-color: var(--volt-dim); color: var(--volt); }
+.set-verify.ok { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); }
+.set-verify.checking { color: var(--text-dim); }
+.set-path { display: flex; align-items: center; gap: 7px; }
+.set-path .set-input { width: 260px; }
+
+.set-rolepill { font-family: var(--font-mono); font-size: 11px; color: var(--volt-strong); border: 1px solid var(--volt-dim); background: var(--volt-wash); padding: 3px 10px; border-radius: var(--radius-pill); }
+
+.set-rt { border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 11px 13px; margin-top: 10px; background: var(--bg-card); }
+.set-rt-top { display: flex; align-items: center; gap: 10px; margin-bottom: 9px; }
+.set-rt-name { font-size: 13px; color: var(--text-bright); }
+.set-rt-kind { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); border: 1px solid var(--border-main); padding: 1px 7px; border-radius: var(--radius-pill); }
+.set-rt-keepers { font-size: 11px; color: var(--text-dim); }
+.set-rt-top .set-verify { margin-left: auto; }
+.set-rt-row { display: flex; align-items: center; gap: 9px; margin-top: 6px; }
+.set-rt-row .sub-k { min-width: 62px; }
+.set-rt-row .set-input { flex: 1; }
+
+/* system log viewer */
+.log-view { border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: #06070a; }
+.log-filters { display: flex; align-items: center; gap: 5px; padding: 8px 10px; border-bottom: 1px solid var(--border-soft); background: var(--bg-panel); }
+.log-f { font-family: var(--font-ui); font-size: 11px; padding: 4px 11px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: transparent; color: var(--text-dim); cursor: pointer; transition: 0.14s; white-space: nowrap; }
+.log-f:hover { color: var(--text-mid); }
+.log-f.on { color: var(--volt-ink); background: var(--volt); border-color: var(--volt); }
+.log-live { margin-left: auto; display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 10.5px; color: var(--status-ok); }
+.log-stream { max-height: 320px; overflow-y: auto; padding: 6px 0; }
+.log-line { display: grid; grid-template-columns: 64px 44px 96px 1fr 16px; gap: 8px; align-items: baseline; padding: 4px 12px; font-size: 11.5px; line-height: 1.4; }
+.log-line:hover { background: var(--bg-panel-alt); }
+.log-line .lt { color: var(--text-dim); }
+.log-line .ll { text-transform: uppercase; font-size: 9px; letter-spacing: 0.06em; }
+.log-line .ll.info { color: var(--text-dim); }
+.log-line .ll.warn { color: var(--status-warn); }
+.log-line .ll.error { color: var(--status-bad); }
+.log-line .lk { color: var(--volt-strong); }
+.log-line .lm { color: var(--text-mid); }
+.log-line .ls.ok { color: var(--status-ok); }
+.log-line .ls.fail { color: var(--status-bad); }
+.log-line .ls.warn { color: var(--status-warn); }
+
+.set-toggle { width: 38px; height: 22px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: var(--bg-sunken); cursor: pointer; padding: 0; position: relative; transition: 0.16s; }
+.set-toggle .knob { position: absolute; top: 2px; left: 2px; width: 16px; height: 16px; border-radius: 50%; background: var(--text-dim); transition: 0.16s; }
+.set-toggle.on { background: var(--volt-wash); border-color: var(--volt-dim); }
+.set-toggle.on .knob { left: 18px; background: var(--volt); }
+
+.set-seg { display: inline-flex; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.set-seg-b { font-family: var(--font-mono); font-size: 11px; padding: 5px 11px; background: transparent; color: var(--text-dim); border: 0; border-left: 1px solid var(--border-main); cursor: pointer; transition: 0.14s; white-space: nowrap; }
+.set-seg-b:first-child { border-left: 0; }
+.set-seg-b:hover { color: var(--text-mid); background: var(--bg-card); }
+.set-seg-b.on { color: var(--volt-ink); background: var(--volt); }
+
+.set-stepper { display: inline-flex; align-items: center; gap: 10px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 3px 8px; }
+.set-stepper button { width: 22px; height: 22px; border: 0; background: var(--bg-card); color: var(--text-mid); border-radius: var(--radius-xs); cursor: pointer; font-size: 14px; }
+.set-stepper button:hover { color: var(--volt); }
+.set-stepper .mono { min-width: 18px; text-align: center; color: var(--text-bright); }
+
+.set-slider { display: inline-flex; align-items: center; gap: 10px; }
+.set-slider input[type=range] { width: 130px; accent-color: var(--volt); }
+.set-slider .mono { color: var(--text-bright); min-width: 36px; }
+
+.set-input { font-family: var(--font-mono); font-size: 12px; padding: 7px 10px; background: var(--bg-sunken); color: var(--text-primary); border: 1px solid var(--border-main); border-radius: var(--radius-sm); outline: none; width: 230px; }
+.set-input:focus { border-color: var(--volt-dim); box-shadow: 0 0 0 2px var(--volt-wash); }
+
+.set-policy-legend { display: flex; flex-wrap: wrap; gap: 14px; padding: 4px 0 10px; font-size: 11px; color: var(--text-dim); }
+.set-policy-legend b { color: var(--text-mid); }
+.set-add { margin-top: 12px; width: 100%; padding: 9px; background: var(--bg-sunken); border: 1px dashed var(--border-highlight); border-radius: var(--radius-sm); color: var(--text-mid); cursor: pointer; font-family: var(--font-ui); font-size: 12px; transition: 0.14s; }
+.set-add:hover { border-color: var(--volt-dim); color: var(--volt); }
+
+.cn-config { margin-left: 8px; width: 26px; height: 26px; flex: none; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-main); color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.cn-config:hover { border-color: var(--volt-dim); color: var(--volt); }
+
+@media (max-width: 900px) {
+  .set-shell { flex-direction: column; }
+  .set-nav { width: auto; flex-direction: row; overflow-x: auto; border-right: 0; border-bottom: 1px solid var(--border-main); padding: 0; }
+  .set-nav-h { display: none; }
+  .set-nav-item { flex: none; margin: 6px 2px; }
+  .set-nav-item .en { display: none; }
+  .settings-surf .set-card-b { padding: 8px 16px 80px; max-width: 100%; }
+  .set-content-h { padding: 16px; }
+  .set-input { width: 100%; }
+}
+.ide-views { display: flex; gap: 3px; margin-left: 8px; }
+.ide-view { font-family: var(--font-ui); font-size: 11px; padding: 5px 12px; border-radius: var(--radius-sm); border: 1px solid transparent; background: none; color: var(--text-dim); cursor: pointer; transition: 0.13s; }
+.ide-view:hover { color: var(--text-mid); background: var(--bg-card); }
+.ide-view.on { color: var(--volt-strong); background: var(--bg-card); border-color: var(--border-main); }
+.ide-top .spacer { flex: 1; }
+.ide-presence { display: flex; align-items: center; gap: 5px; }
+.ide-presence .lbl { font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); margin-right: 4px; }
+
+.ide-body { flex: 1; min-height: 0; display: grid; grid-template-columns: 230px minmax(0, 1fr) minmax(270px, 320px); }
+.ide-body.no-tree { grid-template-columns: 0 minmax(0, 1fr) minmax(270px, 320px); }
+.ide-body.no-rail { grid-template-columns: 230px minmax(0, 1fr) 0; }
+.ide-body.no-tree.no-rail { grid-template-columns: 0 minmax(0, 1fr) 0; }
+
+/* file tree */
+.ide-tree { border-right: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); overflow-y: auto; padding: 10px 7px; min-width: 0; }
+.ide-tree h4 { font-size: 9px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--text-dim); margin: 2px 0 8px 8px; font-weight: 500; }
+.ide-fnode { display: flex; align-items: center; gap: 7px; width: 100%; text-align: left; padding: 4px 8px; border-radius: var(--radius-sm); border: 0; background: none; color: var(--text-mid); font-family: var(--font-mono); font-size: 11.5px; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; transition: 0.12s; }
+.ide-fnode:hover { background: var(--bg-card); color: var(--text-bright); }
+.ide-fnode.on { background: var(--bg-card); color: var(--volt-strong); }
+.ide-fnode .tw { color: var(--text-dim); font-size: 9px; width: 10px; flex: none; }
+.ide-fnode .dirty { width: 6px; height: 6px; border-radius: 50%; background: var(--status-warn); margin-left: auto; flex: none; }
+.ide-fnode .kcur { margin-left: auto; flex: none; }
+.ide-fnode .kcur + .dirty { margin-left: 4px; }
+
+/* editor */
+.ide-ed { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
+.ide-crumb { flex: none; display: flex; align-items: center; gap: 7px; padding: 7px 14px; border-bottom: 1px solid var(--border-soft); background: var(--bg-sunken); font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); overflow-x: auto; white-space: nowrap; }
+.ide-crumb .seg { color: var(--text-dim); } .ide-crumb .seg.last { color: var(--text-mid); }
+.ide-crumb .own { margin-left: auto; display: inline-flex; align-items: center; gap: 6px; color: var(--text-dim); flex: none; }
+.ide-code { flex: 1; overflow: auto; font-family: var(--font-mono); font-size: 12px; line-height: 1.75; padding: 10px 0 28px; position: relative; }
+.ide-code::-webkit-scrollbar { width: 9px; height: 9px; }
+.ide-code::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); }
+.cl { display: flex; min-width: max-content; position: relative; padding: 0 18px 0 0; }
+.cl .ln { width: 52px; flex: none; text-align: right; padding-right: 14px; color: #3d3f4e; user-select: none; }
+.cl .lc { white-space: pre; color: var(--text-primary); }
+.cl:hover { background: rgba(255,255,255,0.018); }
+.cl.hl-cursor { background: color-mix(in oklab, var(--kc, var(--kp1)) 7%, transparent); box-shadow: inset 2.5px 0 0 var(--kc, var(--kp1)); }
+.cl.hl-ann { background: color-mix(in oklab, var(--status-warn) 5%, transparent); }
+.cl .ann-pin { position: sticky; right: 10px; margin-left: 18px; align-self: center; }
+/* syntax tints (OCaml-ish) */
+.tk-kw { color: #c792ea; } .tk-fn { color: var(--info); } .tk-str { color: var(--status-ok); }
+.tk-com { color: #586073; font-style: italic; } .tk-num { color: var(--volt-strong); } .tk-mod { color: var(--accent-bone); }
+
+.cursor-tag { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 8.5px; padding: 1px 7px 1px 2px; border-radius: var(--radius-pill); color: #0b0c10; background: var(--kc, var(--kp1)); margin-left: 16px; vertical-align: middle; white-space: nowrap; }
+.cursor-tag .fm { opacity: 0.75; }
+
+.ann-pin { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-ui); font-size: 9.5px; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid color-mix(in oklab, var(--status-warn) 45%, transparent); background: color-mix(in oklab, var(--status-warn) 12%, var(--bg-deep)); color: var(--status-warn); cursor: pointer; white-space: nowrap; }
+.ann-pin.risk { border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); background: color-mix(in oklab, var(--status-bad) 10%, var(--bg-deep)); color: var(--status-bad); }
+
+/* diff view */
+.ide-diff { flex: 1; overflow: auto; display: grid; grid-template-columns: 1fr 1fr; font-family: var(--font-mono); font-size: 11.5px; line-height: 1.7; }
+.ide-diff .pane { min-width: 0; border-right: 1px solid var(--border-soft); padding: 8px 0 24px; }
+.ide-diff .pane:last-child { border-right: 0; }
+.ide-diff .pane-h { position: sticky; top: 0; padding: 4px 14px 6px; font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); background: var(--bg-deep); border-bottom: 1px solid var(--border-soft); margin-bottom: 6px; z-index: 2; display: flex; gap: 8px; align-items: center; }
+.ide-diff .pane-h .sha { color: var(--volt-strong); text-transform: none; letter-spacing: 0; }
+.dl { display: flex; padding-right: 14px; }
+.dl .ln { width: 44px; flex: none; text-align: right; padding-right: 12px; color: #3d3f4e; user-select: none; }
+.dl .lc { white-space: pre; color: var(--text-primary); min-width: 0; }
+.dl.add { background: color-mix(in oklab, var(--status-ok) 8%, transparent); box-shadow: inset 2px 0 0 var(--status-ok); }
+.dl.del { background: color-mix(in oklab, var(--status-bad) 8%, transparent); box-shadow: inset 2px 0 0 var(--status-bad); }
+.dl.pad { opacity: 0.35; }
+
+/* activity rail */
+.ide-rail { border-left: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); display: flex; flex-direction: column; min-height: 0; min-width: 0; }
+.ide-rail-tabs { flex: none; display: flex; gap: 2px; padding: 9px 10px 0; border-bottom: 1px solid var(--border-soft); }
+.ide-rail-tab { font-family: var(--font-ui); font-size: 11px; padding: 6px 11px; border: 0; background: none; color: var(--text-dim); cursor: pointer; border-bottom: 2px solid transparent; }
+.ide-rail-tab.on { color: var(--volt-strong); border-bottom-color: var(--volt); }
+.ide-rail-scroll { flex: 1; overflow-y: auto; padding: 11px 12px; display: flex; flex-direction: column; gap: 9px; }
+.ide-ev { display: grid; grid-template-columns: 24px 1fr; gap: 8px; padding: 8px 9px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); }
+.ide-ev .ico { width: 22px; height: 22px; border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; font-size: 10px; background: var(--bg-deep); border: 1px solid var(--border-main); color: var(--text-dim); }
+.ide-ev.tool .ico { color: var(--info); } .ide-ev.pr .ico { color: var(--volt-strong); } .ide-ev.turn .ico { color: var(--text-mid); }
+.ide-ev .hd { display: flex; align-items: baseline; gap: 7px; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-bright); flex-wrap: wrap; }
+.ide-ev .hd .lat { color: var(--text-dim); font-size: 9.5px; }
+.ide-ev .hd .ts { margin-left: auto; color: var(--text-dim); font-size: 9px; }
+.ide-ev .sum { font-size: 11px; color: var(--text-mid); margin-top: 3px; line-height: 1.5; font-family: var(--font-ui); }
+.ide-ev .fp { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); margin-top: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ide-ev .prstate { font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; padding: 1px 6px; border-radius: var(--radius-xs); border: 1px solid; }
+.ide-ev .prstate.open { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 40%, transparent); }
+.ide-ev .prstate.merged { color: #b48af0; border-color: #4a3f8a; }
+
+.ide-ann-card { padding: 9px 11px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); }
+.ide-ann-card .hd { display: flex; align-items: center; gap: 7px; font-size: 10.5px; color: var(--text-dim); font-family: var(--font-mono); }
+.ide-ann-card .hd .kind { font-size: 8.5px; letter-spacing: 0.1em; text-transform: uppercase; padding: 1px 6px; border-radius: var(--radius-xs); border: 1px solid color-mix(in oklab, var(--status-warn) 40%, transparent); color: var(--status-warn); }
+.ide-ann-card .hd .kind.risk { border-color: color-mix(in oklab, var(--status-bad) 40%, transparent); color: var(--status-bad); }
+.ide-ann-card .bd { font-size: 11.5px; color: var(--text-primary); line-height: 1.55; margin-top: 6px; }
+.ide-ann-card .lk { display: flex; gap: 6px; margin-top: 7px; }
+.ide-ann-card .lk span { font-family: var(--font-mono); font-size: 9.5px; color: var(--volt-strong); background: var(--volt-wash); border: 1px solid var(--volt-dim); padding: 1px 7px; border-radius: var(--radius-pill); }
+
+/* execute output drawer */
+.ide-drawer { flex: none; border-top: 1px solid var(--border-main); background: #06070a; display: flex; flex-direction: column; max-height: 200px; }
+.ide-drawer.closed { max-height: 30px; }
+.ide-drawer-h { flex: none; display: flex; align-items: center; gap: 10px; padding: 5px 14px; cursor: pointer; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); user-select: none; }
+.ide-drawer-h:hover { color: var(--text-mid); }
+.ide-drawer-h .chev { transition: transform 0.18s; font-size: 9px; }
+.ide-drawer.closed .ide-drawer-h .chev { transform: rotate(-90deg); }
+.ide-drawer-h .ok { color: var(--status-ok); }
+.ide-drawer-body { overflow-y: auto; padding: 2px 14px 12px; font-family: var(--font-mono); font-size: 11px; line-height: 1.7; color: var(--text-mid); }
+.ide-drawer.closed .ide-drawer-body { display: none; }
+.ide-drawer-body .out-ok { color: var(--status-ok); }
+.ide-drawer-body .out-dim { color: #586073; }
+
+/* responsive */
+@media (max-width: 1280px) {
+  .ov-kpis { grid-template-columns: repeat(3, 1fr); }
+  .ov-grid { grid-template-columns: 1fr; }
+  .bd-body { grid-template-columns: 170px minmax(0, 1fr); }
+  .bd-detail { display: none; }
+  .cp-body { grid-template-columns: minmax(0, 1fr); }
+  .cp-world { display: none; }
+  .ide-body { grid-template-columns: 200px minmax(0, 1fr); }
+  .ide-rail { display: none; }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   TYPE LADDER — authoritative heading normalization
+   One ladder for every surface. Loads last so it wins source order;
+   values come from --fs/--fw/--tr tokens in v2.css. Editing a tier
+   here changes every title of that level at once.
+   ══════════════════════════════════════════════════════════════ */
+
+/* T1 — surface / subject title (개요 · 커넥터 · Command Map · keeper 이름) */
+.ov-head h1,
+.surf-head h1,
+.chat-id h2 {
+  font-family: var(--font-display);
+  font-weight: var(--fw-t1);
+  font-size: var(--fs-t1);
+  letter-spacing: var(--tr-t1);
+  text-transform: none;
+  color: var(--text-bright);
+  margin: 0;
+}
+
+/* T2 — region / panel title (Work·Comms 플레인 · 전체 피드) */
+.cp-plane-h h2,
+.bd-feed-head h2 {
+  font-family: var(--font-display);
+  font-weight: var(--fw-t2);
+  font-size: var(--fs-t2);
+  letter-spacing: var(--tr-t2);
+  text-transform: none;
+  color: var(--text-bright);
+  margin: 0;
+}
+
+/* T3 — card / section header (주의 필요 · 텔레메트리 · Progressive Disclosure
+   · Keepers · 활력 지표 · 최근 감사 로그) */
+.ov-card-h h3,
+.cp-disc-h h3,
+.roster-title h3,
+.ctx-sec h4 {
+  font-family: var(--font-display);
+  font-weight: var(--fw-t3);
+  font-size: var(--fs-t3);
+  letter-spacing: var(--tr-t3);
+  text-transform: uppercase;
+  color: var(--text-mid);
+  margin: 0;
+  white-space: nowrap;
+}
+
+/* T4 — micro label (서브보드 · 바인딩 · 파일트리) */
+.bd-rail h4,
+.cn-bind h5,
+.ide-tree h4 {
+  font-family: var(--font-ui);
+  font-weight: var(--fw-t4);
+  font-size: var(--fs-t4);
+  letter-spacing: var(--tr-t4);
+  text-transform: uppercase;
+  color: var(--text-dim);
+}

--- a/dashboard/v2/styles/v2.css
+++ b/dashboard/v2/styles/v2.css
@@ -1,0 +1,1184 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — High-contrast skin + Keeper Agent Chat layout
+   A chromatic re-skin over the MASC semantic spine: cooler neutral
+   near-black ground so a single warm voltage (brass / blood / ice)
+   reads vivid and sharp. Body text pushed brighter for readability.
+   Loaded AFTER colors_and_type.css.
+   ══════════════════════════════════════════════════════════════ */
+
+[data-skin="v2"] {
+  /* Surfaces — cool neutral charcoal, clean elevation steps */
+  --bg-deep:        #08090d;
+  --bg-panel:       #0f1015;
+  --bg-panel-alt:   #15161d;
+  --bg-card:        #1b1c25;
+  --bg-card-hover:  #23242f;
+  --bg-sunken:      #0a0b0f;
+
+  /* Borders — crisper, cooler */
+  --border-main:      #282a36;
+  --border-soft:      #1e1f29;
+  --border-highlight: #3b3d4e;
+
+  /* Text — bone, pushed bright for reading (raised contrast on mid/dim
+     so 9–11px labels, eyebrows and captions stay legible on dark ground) */
+  --text-bright:  #f7f1e6;
+  --text-primary: #e3dacb;
+  --text-mid:     #c0b7a6;
+  --text-dim:     #968fa1;
+
+  /* Accents — vivid */
+  --accent-blood:     #e8472f;
+  --accent-blood-dim: #7a1a12;
+  --accent-viscera:   #ff6a4d;
+  --accent-brass:     #e0b057;
+  --accent-brass-dim: #8a6a28;
+  --accent-bone:      #e6d8b6;
+  --accent-ice:       #46c6f0;
+  --accent-ice-dim:   #1c6b86;
+  --accent-bile:      #8aa83f;
+
+  /* Information / reference accent — distinct from volt (primary action).
+     Used for mentions, state badges, syntax fns, tool events. Volt-aware:
+     under volt=ice it shifts off-cyan so it never collides with primary. */
+  --info:     var(--accent-ice);
+  --info-dim: var(--accent-ice-dim);
+
+  /* Status — saturated but composed */
+  --status-ok:    #46c66a;
+  --status-warn:  #e0a02a;
+  --status-bad:   #e8472f;
+  --status-idle:  #6b6478;
+  --status-busy:  #46c6f0;
+
+  /* Voltage — the single primary accent (default brass/gold) */
+  --volt:        var(--accent-brass);
+  --volt-strong: #f0c373;
+  --volt-dim:    var(--accent-brass-dim);
+  --volt-ink:    #1a1405;
+  --volt-glow:   rgba(224,176,87,0.22);
+  --volt-wash:   rgba(224,176,87,0.10);
+
+  /* Radius scale — engraved, tiny corners (brand: 2/4/6/…). One ladder;
+     literals below recovered into these tokens. */
+  --radius-2xs: 2px;
+  --radius-xs:  3px;
+  --radius-sm:  4px;   /* chips · tabs · inputs · small controls */
+  --radius-md:  6px;   /* cards · panels · composer */
+  --radius-lg:  10px;  /* large panels */
+
+  /* Spacing scale (2px base) + semantic aliases. Surface padding, card
+     padding and inter-card gaps were drifting (12·13·14 / 22·20…) — these
+     give every surface one rhythm. */
+  --sp-1: 4px;  --sp-2: 6px;  --sp-3: 8px;  --sp-4: 10px; --sp-5: 12px;
+  --sp-6: 14px; --sp-7: 16px; --sp-8: 20px; --sp-9: 24px; --sp-10: 32px;
+  --pad-surface: 22px 26px 40px;  /* surface scroll outer padding */
+  --pad-card:    12px 14px;       /* card / panel body padding */
+  --gap-card:    14px;            /* between sibling cards / panels */
+  --gap-row:     8px;             /* between list rows */
+
+  --shadow-card:   0 1px 3px rgba(0,0,0,0.5);
+  --shadow-panel:  0 4px 22px rgba(0,0,0,0.55);
+  --shadow-pop:    0 12px 40px rgba(0,0,0,0.6), 0 0 0 1px var(--border-main);
+  /* Override the base (dark-fantasy) blood-tinted glow so it tracks volt
+     instead — keeps title/primary glow coherent in every voltage. */
+  --accent-glow:   var(--volt-glow);
+  --shadow-glow:   0 0 20px var(--volt-glow);
+
+  /* v2 type — sharp grotesque replaces the gothic Cinzel */
+  --font-display: 'Space Grotesk', 'Noto Sans KR', system-ui, sans-serif;
+  --font-body:    'Noto Sans KR', 'Space Grotesk', system-ui, sans-serif;
+
+  /* ── TYPE LADDER — one heading system across every surface ──
+     T1 surface/subject title · T2 region/panel title ·
+     T3 card/section header (UPPER) · T4 micro label (UPPER).
+     All display = Space Grotesk, all weight 600. The authoritative
+     selector block lives at the end of surfaces.css. */
+  --fs-t1: 22px; --fw-t1: 600; --tr-t1: -0.005em;  /* bright · sentence */
+  --fs-t2: 16px; --fw-t2: 600; --tr-t2: 0;         /* bright · sentence */
+  --fs-t3: 11px; --fw-t3: 600; --tr-t3: 0.14em;    /* mid · UPPER */
+  --fs-t4: 9px;  --fw-t4: 600; --tr-t4: 0.2em;     /* dim · UPPER */
+}
+
+[data-skin="v2"][data-volt="blood"] {
+  --volt: var(--accent-blood); --volt-strong: #ff6a4d; --volt-dim: var(--accent-blood-dim);
+  --volt-ink: #ffffff; --volt-glow: rgba(232,71,47,0.26); --volt-wash: rgba(232,71,47,0.10);
+}
+[data-skin="v2"][data-volt="ice"] {
+  --volt: var(--accent-ice); --volt-strong: #7ad8f6; --volt-dim: var(--accent-ice-dim);
+  --volt-ink: #04121a; --volt-glow: rgba(70,198,240,0.24); --volt-wash: rgba(70,198,240,0.09);
+  /* primary is now cyan → shift the info accent to violet to stay distinct */
+  --info: #8a6cf0; --info-dim: #4a3aa0;
+}
+
+/* ── Reset for the app shell ─────────────────────────────── */
+[data-skin="v2"], [data-skin="v2"] body { height: 100%; }
+.v2-app * { box-sizing: border-box; }
+.v2-app {
+  position: fixed; inset: 0;
+  display: flex; flex-direction: column;
+  background:
+    radial-gradient(1200px 600px at 80% -10%, rgba(224,176,87,0.04), transparent 60%),
+    radial-gradient(900px 500px at -5% 110%, rgba(232,71,47,0.05), transparent 60%),
+    var(--bg-deep);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  overflow: hidden;
+}
+.v2-app .mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+
+/* ════ TOP BAR ════ */
+.v2-top {
+  display: flex; align-items: center; gap: 18px;
+  height: 50px; flex: none;
+  padding: 0 16px;
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+  border-bottom: 1px solid var(--border-main);
+  z-index: 20;
+}
+.v2-wordmark { display: flex; align-items: baseline; gap: 9px; }
+.v2-wordmark b {
+  font-family: var(--font-display); font-weight: 400;
+  letter-spacing: 0.26em; font-size: 16px; color: var(--text-bright);
+}
+.v2-wordmark .ver {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em;
+  color: var(--volt-ink); background: var(--volt); padding: 2px 6px; border-radius: var(--radius-sm);
+  font-weight: 600;
+}
+.v2-top .crumb {
+  font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--text-dim); display: flex; gap: 8px; align-items: center;
+}
+.v2-top .crumb .on { color: var(--text-mid); }
+.v2-top-spacer { flex: 1; }
+.v2-statchip {
+  display: inline-flex; align-items: center; gap: 7px;
+  font-size: 11px; letter-spacing: 0.04em;
+  padding: 5px 10px; border: 1px solid var(--border-main);
+  border-radius: var(--radius-pill); color: var(--text-mid);
+  background: var(--bg-panel-alt); white-space: nowrap;
+}
+.v2-statchip b { color: var(--text-bright); font-weight: 600; }
+.v2-statchip.live { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 40%, transparent); }
+.v2-statchip.warn { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); }
+
+/* ════ BODY GRID ════ */
+.v2-body {
+  flex: 1; min-height: 0;
+  display: grid;
+  grid-template-columns: var(--nav-w, 58px) var(--roster-w, 286px) 1fr var(--ctx-w, 312px);
+}
+.v2-body.no-ctx { grid-template-columns: var(--nav-w, 58px) var(--roster-w, 286px) 1fr 0; }
+
+/* ════ APP NAV RAIL (main menu) ════ */
+.v2-nav {
+  display: flex; flex-direction: column; align-items: center; gap: 3px;
+  padding: 10px 0 12px; border-right: 1px solid var(--border-main);
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+}
+.nav-home {
+  width: 38px; height: 38px; border-radius: var(--radius-sm); margin-bottom: 9px;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-display); font-weight: 700; font-size: 16px;
+  color: var(--volt-ink); background: var(--volt); cursor: default;
+  box-shadow: 0 0 14px var(--volt-glow); transition: 0.14s;
+}
+.nav-home:hover { filter: none; }
+.nav-brand { display: flex; flex-direction: column; align-items: center; gap: 3px; margin-bottom: 8px; }
+.nav-brand .nav-home { margin-bottom: 0; }
+.nav-brand .nlbl { font-size: 8.5px; letter-spacing: 0.06em; color: var(--text-dim); }
+.nav-item {
+  width: 46px; height: 48px; border-radius: var(--radius-sm); cursor: pointer;
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px;
+  color: var(--text-dim); border: 1px solid transparent; background: transparent;
+  transition: 0.14s; position: relative;
+}
+.nav-item svg { width: 19px; height: 19px; }
+.nav-item .nlbl { font-size: 8.5px; letter-spacing: 0.02em; }
+.nav-item:hover { color: var(--text-bright); background: var(--bg-card); }
+.nav-item.on { color: var(--volt-strong); background: var(--bg-card); }
+.nav-item.on::before { content: ""; position: absolute; left: -10px; top: 10px; bottom: 10px; width: 3px; background: var(--volt); border-radius: 0 3px 3px 0; box-shadow: 0 0 10px var(--volt-glow); }
+.nav-spacer { flex: 1; }
+
+/* avatar fallback (keeper without a portrait) */
+.is-fallback {
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono); font-weight: 600; letter-spacing: 0.02em;
+  color: hsl(var(--ah, 40) 62% 80%);
+  background: linear-gradient(135deg, hsl(var(--ah,40) 34% 18%), hsl(var(--ah,40) 30% 10%));
+  border: 1px solid hsl(var(--ah,40) 40% 33%);
+}
+.kp-av.is-fallback { font-size: 13px; }
+.chat-av.is-fallback { font-size: 17px; }
+.msg-av.is-fallback { font-size: 12px; }
+
+/* ════ KEEPER SIGIL BADGE (canonical identity: slot color + 2-letter monogram) ════ */
+.v2-app {
+  --kp1:#e0b057; --kp2:#d9743f; --kp3:#e0a82e; --kp4:#c64f6d;
+  --kp5:#8a6cf0; --kp6:#46c66a; --kp7:#5fb0c4; --kp8:#9aa83f;
+  --kp9:#5b9cf0; --kp10:#c569d4; --kp11:#8a7bf0; --kp12:#d98a4f;
+}
+.sigil {
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono); font-weight: 700; letter-spacing: 0; flex: none;
+  color: #0b0c10; background: var(--kc, var(--kp1));
+  border-radius: var(--radius-sm);
+}
+.sigil.heartbeat { box-shadow: 0 0 8px color-mix(in oklab, var(--kc, var(--kp1)) 70%, transparent); animation: sg-beat 1.5s ease-in-out infinite; }
+@keyframes sg-beat { 0%,100% { box-shadow: 0 0 6px color-mix(in oklab, var(--kc) 55%, transparent); } 50% { box-shadow: 0 0 13px color-mix(in oklab, var(--kc) 85%, transparent); } }
+.sigil-chip {
+  display: inline-flex; align-items: center; gap: 6px; flex: none; white-space: nowrap;
+  font-family: var(--font-mono); font-size: 11px; color: var(--kc, var(--kp1));
+  padding: 2px 8px 2px 3px; border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in oklab, var(--kc, var(--kp1)) 40%, var(--border-main));
+  background: color-mix(in oklab, var(--kc, var(--kp1)) 9%, transparent);
+}
+.sigil-chip .sigil { width: 17px; height: 17px; font-size: 9px; }
+
+/* ════ ROSTER RAIL ════ */
+.roster {
+  border-right: 1px solid var(--border-main);
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 60%);
+  display: flex; flex-direction: column; min-height: 0;
+}
+.roster-head { padding: 11px 12px 11px; border-bottom: 1px solid var(--border-soft); }
+.roster-title { display: flex; align-items: center; justify-content: space-between; margin-bottom: 11px; }
+.roster-title h3 {
+  font-family: var(--font-display); font-weight: 400; text-transform: uppercase;
+  letter-spacing: 0.2em; font-size: 13px; color: var(--text-bright); margin: 0;
+}
+.roster-title .count {
+  font-family: var(--font-mono); font-size: 11px; color: var(--text-dim);
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  padding: 2px 7px; border-radius: var(--radius-pill);
+}
+.roster-search {
+  width: 100%; font-family: var(--font-ui); font-size: 12.5px;
+  padding: 8px 11px; background: var(--bg-sunken); color: var(--text-primary);
+  border: 1px solid var(--border-main); border-radius: var(--radius-sm);
+  outline: none;
+}
+.roster-search:focus { border-color: var(--volt-dim); box-shadow: 0 0 0 2px var(--volt-wash); }
+.roster-search::placeholder { color: var(--text-dim); }
+
+.roster-filters { display: flex; gap: 5px; padding: 10px 12px; flex-wrap: wrap; border-bottom: 1px solid var(--border-soft); }
+.rfilter {
+  font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 4px 9px; border-radius: var(--radius-pill); cursor: pointer;
+  border: 1px solid var(--border-main); background: transparent; color: var(--text-dim);
+  font-family: var(--font-ui); transition: 0.15s; display: inline-flex; gap: 5px; align-items: center;
+}
+.rfilter:hover { color: var(--text-mid); border-color: var(--border-highlight); }
+.rfilter.on { color: var(--volt-ink); background: var(--volt); border-color: var(--volt); font-weight: 600; }
+.rfilter .n { opacity: 0.7; }
+
+.roster-list { flex: 1; overflow-y: auto; padding: 6px; }
+.roster-group {
+  font-size: 9.5px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--text-dim);
+  padding: 12px 8px 5px;
+}
+.kp-row {
+  display: grid; grid-template-columns: 38px 1fr auto; gap: 10px; align-items: center;
+  padding: 8px 9px; border-radius: var(--radius-sm); cursor: pointer;
+  border: 1px solid transparent; transition: background 0.14s, border-color 0.14s;
+  position: relative;
+}
+.kp-row:hover { background: var(--bg-card); }
+.kp-row.sel { background: var(--bg-card); border-color: var(--volt-dim); box-shadow: inset 0 0 0 1px var(--volt-wash); }
+.kp-row.sel::before {
+  content: ""; position: absolute; left: -6px; top: 8px; bottom: 8px; width: 3px;
+  background: var(--volt); border-radius: 0 3px 3px 0; box-shadow: 0 0 10px var(--volt-glow);
+}
+.kp-av {
+  width: 38px; height: 38px; border-radius: var(--radius-sm); object-fit: cover;
+  border: 1px solid var(--border-highlight); filter: saturate(0.92) contrast(1.04);
+  background: var(--bg-sunken); font-size: 14px;
+}
+.kp-meta { min-width: 0; }
+.kp-name { font-family: var(--font-display); font-weight: 600; font-size: 13.5px; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kp-handle { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-mid); }
+.kp-sub { display: flex; align-items: center; gap: 6px; font-size: 10.5px; color: var(--text-dim); margin-top: 2px; }
+.kp-state { display: inline-flex; align-items: center; gap: 5px; }
+.kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; }
+.kp-time { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+.kp-att {
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 600;
+  min-width: 16px; text-align: center; padding: 1px 5px; border-radius: var(--radius-pill);
+  color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 16%, transparent);
+  border: 1px solid color-mix(in oklab, var(--status-bad) 35%, transparent);
+}
+
+/* status dot */
+.dot2 { width: 7px; height: 7px; border-radius: 50%; display: inline-block; flex: none; background: var(--status-idle); }
+.dot2.ok   { background: var(--status-ok);   box-shadow: 0 0 7px var(--status-ok); }
+.dot2.warn { background: var(--status-warn); box-shadow: 0 0 7px var(--status-warn); }
+.dot2.bad  { background: var(--status-bad);  box-shadow: 0 0 7px var(--status-bad); }
+.dot2.busy { background: var(--status-busy); box-shadow: 0 0 7px var(--status-busy); }
+.dot2.pulse { animation: dot-pulse 1.8s ease-in-out infinite; }
+@keyframes dot-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+/* ════ CHAT MAIN ════ */
+.chat { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--bg-deep); }
+
+.chat-head {
+  flex: none; padding: 13px 20px 12px;
+  border-bottom: 1px solid var(--border-main);
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+  display: flex; align-items: center; gap: 14px;
+}
+.chat-av {
+  width: 46px; height: 46px; border-radius: var(--radius-md); object-fit: cover;
+  border: 1px solid var(--border-highlight); flex: none;
+  box-shadow: 0 0 0 1px var(--bg-deep), 0 0 18px rgba(0,0,0,0.5);
+  filter: saturate(0.95) contrast(1.05);
+}
+.chat-av[data-sigil] { display: flex; align-items: center; justify-content: center; padding: 0; border: 0; box-shadow: none; filter: none; background: transparent; }
+.chat-av[data-sigil] .sigil { width: 46px; height: 46px; border-radius: var(--radius-md); font-size: 18px; }
+.chat-id { min-width: 0; flex: 1; }
+.chat-id .name-row { display: flex; align-items: center; gap: 11px; flex-wrap: wrap; }
+.chat-id h2 {
+  font-family: var(--font-display); font-weight: 400; text-transform: none;
+  letter-spacing: 0.02em; font-size: 20px; color: var(--text-bright); margin: 0; white-space: nowrap;
+}
+.chat-id .slug { font-family: var(--font-mono); font-size: 12px; color: var(--text-dim); }
+.chat-id .sub { display: flex; align-items: center; gap: 10px; margin-top: 5px; font-size: 11px; color: var(--text-dim); flex-wrap: wrap; }
+.chat-id .sub > span { white-space: nowrap; }
+
+.state-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11px; letter-spacing: 0.04em; padding: 4px 10px; border-radius: var(--radius-pill);
+  background: var(--bg-card); border: 1px solid var(--border-main); color: var(--text-mid);
+}
+.state-pill.run  { color: var(--status-ok);  border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); background: color-mix(in oklab, var(--status-ok) 10%, var(--bg-card)); }
+.state-pill.pause{ color: var(--status-warn);border-color: color-mix(in oklab, var(--status-warn) 45%, transparent); }
+.state-pill.off  { color: var(--text-dim); }
+.fsm-chip {
+  font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.04em;
+  padding: 3px 8px; border-radius: var(--radius-sm); color: var(--text-mid);
+  background: var(--bg-card); border: 1px solid var(--border-main);
+}
+
+.chat-actions { display: flex; gap: 7px; align-items: center; flex: none; }
+.act {
+  font-family: var(--font-ui); font-size: 11px; letter-spacing: 0.05em;
+  padding: 7px 12px; border-radius: var(--radius-sm); cursor: pointer;
+  border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-mid);
+  transition: 0.15s; white-space: nowrap;
+}
+.act:hover { color: var(--text-bright); border-color: var(--border-highlight); background: var(--bg-card-hover); }
+.act.danger:hover { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 50%, transparent); }
+.act.icon { padding: 7px 9px; }
+
+/* meta strip */
+.chat-meta {
+  flex: none; display: flex; align-items: center; gap: 0;
+  padding: 0 20px; height: 34px;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--bg-sunken);
+  overflow-x: auto;
+}
+.meta-cell { display: flex; align-items: center; gap: 7px; padding-right: 18px; margin-right: 18px; border-right: 1px solid var(--border-soft); white-space: nowrap; }
+.meta-cell:last-child { border-right: 0; }
+.meta-cell .k { font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-dim); }
+.meta-cell .v { font-family: var(--font-mono); font-size: 11px; color: var(--text-mid); }
+.meta-cell .v.volt { color: var(--volt-strong); }
+
+/* thread */
+.thread { flex: 1; overflow-y: auto; padding: 22px 0 8px; }
+.thread-inner { max-width: var(--thread-w, 980px); margin: 0 auto; padding: 0 28px; display: flex; flex-direction: column; gap: 22px; }
+
+.daydiv { display: flex; align-items: center; gap: 12px; color: var(--text-dim); font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; }
+.daydiv::before, .daydiv::after { content: ""; height: 1px; flex: 1; background: var(--border-soft); }
+
+/* message */
+.msg { display: grid; grid-template-columns: 34px 1fr; gap: 13px; }
+.msg-av { width: 34px; height: 34px; border-radius: var(--radius-sm); object-fit: cover; border: 1px solid var(--border-highlight); filter: saturate(0.95) contrast(1.05); }
+.msg-av.op { display: flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 11px; color: var(--volt-ink); background: var(--volt); border-color: var(--volt); }
+.msg-col { min-width: 0; }
+.msg-hd { display: flex; align-items: center; gap: 9px; margin-bottom: 6px; }
+.msg-hd .who { font-family: var(--font-display); font-weight: 600; font-size: 13px; color: var(--text-bright); white-space: nowrap; }
+.msg-hd .whoh { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.msg-hd .ts { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.src-badge {
+  font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 2px 6px; border-radius: var(--radius-xs); color: var(--text-mid);
+  background: var(--bg-card); border: 1px solid var(--border-main);
+}
+.src-badge.dashboard { color: var(--volt-strong); border-color: var(--volt-dim); }
+.src-badge.discord { color: #8a9bf0; border-color: #3a3d6a; }
+.src-badge.slack { color: #5fc7b0; border-color: #2c5a52; }
+.src-badge.imessage { color: #6aa6ef; border-color: #2c4a6a; }
+
+/* assistant bubble */
+.bubble {
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  border-radius: 4px 12px 12px 12px; padding: 14px 16px;
+  color: var(--text-primary); line-height: 1.62; font-family: var(--font-body); font-size: 15px;
+}
+.bubble.user {
+  background: var(--volt-wash); border-color: var(--volt-dim);
+  border-radius: 12px 4px 12px 12px; color: var(--text-bright);
+}
+.msg.from-user { grid-template-columns: 1fr 34px; }
+.msg.from-user .msg-col { order: 0; }
+.msg.from-user .msg-av { order: 1; }
+.msg.from-user .msg-hd { justify-content: flex-end; }
+
+.bubble p { margin: 0 0 10px; color: var(--text-primary); }
+.bubble p:last-child { margin-bottom: 0; }
+.bubble strong { color: var(--text-bright); font-weight: 600; }
+.bubble h4 { font-family: var(--font-ui); text-transform: none; letter-spacing: 0; font-size: 14px; color: var(--text-bright); margin: 4px 0 9px; }
+.bubble ul { margin: 0 0 10px; padding-left: 18px; }
+.bubble li { margin: 3px 0; color: var(--text-primary); }
+.bubble li::marker { color: var(--volt); }
+.bubble code { font-family: var(--font-mono); font-size: 12.5px; background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 1px 5px; border-radius: var(--radius-sm); color: var(--volt-strong); }
+.bubble hr { border: 0; border-top: 1px solid var(--border-soft); margin: 13px 0; }
+
+.callout {
+  display: flex; gap: 9px; padding: 10px 12px; margin: 10px 0;
+  border-radius: var(--radius-sm); font-size: 13.5px; line-height: 1.5;
+  background: color-mix(in oklab, var(--status-warn) 9%, var(--bg-sunken));
+  border: 1px solid color-mix(in oklab, var(--status-warn) 36%, transparent);
+  color: var(--text-primary);
+}
+.callout .ico { color: var(--status-warn); flex: none; }
+
+/* markdown table */
+.md-table { width: 100%; border-collapse: collapse; margin: 8px 0 10px; font-family: var(--font-ui); font-size: 13px; }
+.md-table th, .md-table td { text-align: left; padding: 8px 12px; border-bottom: 1px solid var(--border-soft); }
+.md-table thead th { font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); font-weight: 600; border-bottom: 1px solid var(--border-main); }
+.md-table tbody tr:hover { background: var(--bg-panel-alt); }
+.md-table td.num, .md-table th.num { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.md-table .muted { color: var(--text-dim); }
+
+/* feedback row */
+.fbk { display: flex; align-items: center; gap: 4px; margin-top: 9px; }
+.fbk-btn {
+  display: inline-flex; align-items: center; gap: 5px; cursor: pointer;
+  padding: 5px 8px; border-radius: var(--radius-xs); border: 1px solid transparent;
+  background: transparent; color: var(--text-dim); font-family: var(--font-ui); font-size: 11px; transition: 0.14s;
+  white-space: nowrap;
+}
+.fbk-btn:hover { color: var(--text-mid); background: var(--bg-card); }
+.fbk-btn.on { color: var(--volt-strong); }
+.fbk-verify { margin-left: auto; display: inline-flex; align-items: center; gap: 6px; font-size: 11px; color: var(--status-ok); }
+
+/* tool trace */
+.tool {
+  border: 1px solid var(--border-main); border-radius: var(--radius-sm);
+  background: var(--bg-sunken); overflow: hidden; margin-top: 2px;
+}
+.tool-hd {
+  display: flex; align-items: center; gap: 10px; padding: 9px 12px; cursor: pointer;
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-mid); transition: 0.14s;
+}
+.tool-hd:hover { background: var(--bg-panel-alt); }
+.tool-hd .chev { transition: transform 0.18s; color: var(--text-dim); }
+.tool.open .tool-hd .chev { transform: rotate(90deg); }
+.tool-hd .tname { color: var(--text-bright); }
+.tool-hd .tdot { margin-left: auto; }
+.tool-hd .tdur { color: var(--text-dim); font-size: 11px; }
+.tool-body { padding: 0 12px 12px; display: none; }
+.tool.open .tool-body { display: block; }
+.tool-kv { display: grid; grid-template-columns: 70px 1fr; gap: 4px 12px; font-family: var(--font-mono); font-size: 11.5px; padding: 9px 0 0; }
+.tool-kv .tk { color: var(--text-dim); }
+.tool-kv .tv { color: var(--text-mid); word-break: break-word; }
+.tool pre {
+  margin: 9px 0 0; padding: 10px; background: #06070a; border: 1px solid var(--border-soft);
+  border-radius: var(--radius-xs); font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid);
+  overflow-x: auto; line-height: 1.55;
+}
+.tool pre .jk { color: var(--volt-strong); }
+.tool pre .js { color: var(--status-ok); }
+
+/* agent trace group — bundles thinking / reasoning / tool steps into one block */
+.trace { border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-sunken); overflow: hidden; }
+.trace-hd {
+  display: flex; align-items: center; gap: 9px; padding: 9px 12px; cursor: pointer;
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-mid); transition: background 0.14s;
+}
+.trace-hd:hover { background: var(--bg-panel-alt); }
+.trace-hd .chev { color: var(--text-dim); transition: transform 0.18s; font-size: 9px; }
+.trace.open > .trace-hd .chev { transform: rotate(90deg); }
+.trace-hd .glyph { color: var(--volt); font-size: 11px; }
+.trace-hd .tlabel { color: var(--text-bright); font-family: var(--font-ui); letter-spacing: 0.13em; text-transform: uppercase; font-size: 11px; }
+.trace-hd .tcount { color: var(--text-dim); }
+.trace-hd .tmeta { margin-left: auto; display: flex; align-items: center; gap: 12px; color: var(--text-dim); font-size: 11px; }
+.trace-hd .tmeta .mono { color: var(--text-mid); }
+
+.trace-steps { display: none; position: relative; padding: 8px 12px 12px 14px; }
+.trace.open > .trace-steps { display: block; }
+.trace-rail { position: absolute; left: 19px; top: 14px; bottom: 18px; width: 1px; background: var(--border-main); }
+
+.tstep { position: relative; padding-left: 18px; }
+.tstep + .tstep { margin-top: 10px; }
+.tnode {
+  position: absolute; left: 0; top: 4px; width: 11px; height: 11px; border-radius: 50%;
+  background: var(--bg-sunken); border: 1.5px solid var(--text-dim); box-sizing: border-box; z-index: 1;
+}
+.tstep.think .tnode { border-style: dotted; }
+.tstep.reason .tnode { border-color: var(--info); }
+.tstep.tool .tnode { border-color: var(--volt); background: var(--volt); box-shadow: 0 0 0 2px var(--bg-sunken); }
+
+.tstep-main { min-width: 0; flex: 1; }
+.tstep-row { display: flex; align-items: center; gap: 8px; }
+.tstep-row.click { cursor: pointer; }
+.tstep-kind {
+  font-family: var(--font-ui); text-transform: uppercase; letter-spacing: 0.1em;
+  font-size: 9.5px; line-height: 1.5; flex: none;
+}
+.tstep.think .tstep-kind { color: var(--text-dim); }
+.tstep.reason .tstep-kind { color: var(--info); }
+.tstep.tool .tstep-kind { color: var(--volt); }
+.tstep-text { font-family: var(--font-body); font-size: 12.5px; color: var(--text-primary); line-height: 1.5; min-width: 0; }
+.tstep.think .tstep-text { color: var(--text-mid); font-style: italic; }
+.tstep .tname { color: var(--text-bright); font-size: 12px; }
+.tstep .tdur { color: var(--text-dim); font-size: 11px; }
+.tstep-row .chev.sm { margin-left: auto; color: var(--text-dim); font-size: 8px; transition: transform 0.18s; flex: none; }
+.tstep.exp .tstep-row .chev.sm { transform: rotate(90deg); }
+.tstep .dot2 { flex: none; }
+
+.reason-detail {
+  margin-top: 7px; padding: 9px 12px; border-left: 2px solid var(--info-dim);
+  background: color-mix(in oklab, var(--info) 7%, transparent);
+  font-family: var(--font-body); font-size: 12.5px; line-height: 1.62; color: var(--text-mid);
+  border-radius: 0 var(--radius-xs) var(--radius-xs) 0;
+}
+.reason-detail code { font-family: var(--font-mono); font-size: 11.5px; color: var(--info); }
+.reason-detail strong { color: var(--text-bright); }
+
+.tool-body2 { margin-top: 8px; }
+.tool-body2 .tk { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.1em; margin-top: 9px; }
+.tool-body2 .tk:first-child { margin-top: 0; }
+.tool-body2 pre {
+  margin: 4px 0 0; padding: 10px; background: #06070a; border: 1px solid var(--border-soft);
+  border-radius: var(--radius-xs); font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid);
+  overflow-x: auto; line-height: 1.55;
+}
+.tool-body2 pre .jk { color: var(--volt-strong); }
+.tool-body2 pre .js { color: var(--status-ok); }
+
+/* attention section (ctx rail) — what needs the operator's attention, and where */
+.att-count {
+  font-family: var(--font-mono); font-size: 10px; color: var(--status-bad);
+  border: 1px solid color-mix(in oklab, var(--status-bad) 40%, transparent);
+  background: color-mix(in oklab, var(--status-bad) 12%, transparent);
+  padding: 0 6px; border-radius: var(--radius-pill); margin-left: 7px; vertical-align: middle;
+}
+.att-list { display: flex; flex-direction: column; gap: 6px; }
+.att-item {
+  display: flex; align-items: flex-start; gap: 8px; padding: 8px 10px;
+  background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm);
+  font-size: 12px; line-height: 1.45; color: var(--text-primary);
+}
+.att-item .att-dot { width: 6px; height: 6px; border-radius: 50%; margin-top: 5px; flex: none; }
+.att-item.warn { border-left: 2px solid var(--status-warn); }
+.att-item.warn .att-dot { background: var(--status-warn); box-shadow: 0 0 6px var(--status-warn); }
+.att-item.bad { border-left: 2px solid var(--status-bad); }
+.att-item.bad .att-dot { background: var(--status-bad); box-shadow: 0 0 6px var(--status-bad); }
+
+/* turn inspector drawer — full injected prompt + context for one turn */
+.fbk-btn.inspect { margin-left: 4px; color: var(--info); border-color: color-mix(in oklab, var(--info) 30%, transparent); }
+.fbk-btn.inspect:hover { color: var(--info); border-color: var(--info); }
+.turn-overlay { position: fixed; inset: 0; background: rgba(4,5,8,0.55); z-index: 90; display: flex; justify-content: flex-end; }
+.turn-drawer {
+  width: min(560px, 94vw); height: 100%; background: var(--bg-panel);
+  border-left: 1px solid var(--border-main); box-shadow: -8px 0 30px rgba(0,0,0,0.5);
+  display: flex; flex-direction: column; animation: turn-in 0.18s ease;
+}
+@keyframes turn-in { from { transform: translateX(24px); opacity: 0; } to { transform: none; opacity: 1; } }
+.turn-hd { display: flex; align-items: center; gap: 10px; padding: 14px 16px; border-bottom: 1px solid var(--border-main); }
+.turn-hd h3 { font-family: var(--font-display); text-transform: uppercase; letter-spacing: 0.14em; font-size: 13px; color: var(--text-bright); margin: 0; }
+.turn-hd .tid { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
+.turn-close { margin-left: auto; background: none; border: 1px solid var(--border-main); color: var(--text-mid); width: 26px; height: 26px; border-radius: var(--radius-sm); cursor: pointer; font-size: 12px; transition: 0.14s; }
+.turn-close:hover { border-color: var(--volt-dim); color: var(--volt); }
+.turn-tabs { display: flex; gap: 5px; padding: 9px 14px; border-bottom: 1px solid var(--border-soft); }
+.turn-tab { font-family: var(--font-ui); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; padding: 6px 12px; border: 1px solid transparent; border-radius: var(--radius-sm); color: var(--text-dim); background: none; cursor: pointer; transition: 0.14s; }
+.turn-tab:hover { color: var(--text-mid); }
+.turn-tab.on { color: var(--volt); border-color: var(--volt-dim); background: var(--volt-wash); }
+.turn-body { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 16px; }
+.turn-sec h4 { font-family: var(--font-ui); text-transform: uppercase; letter-spacing: 0.1em; font-size: 10px; color: var(--text-dim); margin: 0 0 8px; }
+.turn-pre { margin: 0; padding: 12px 13px; background: var(--bg-sunken); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: 11.5px; line-height: 1.62; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+.turn-thread { display: flex; flex-direction: column; gap: 9px; }
+.turn-msg { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
+.turn-msg .role { font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.1em; padding: 5px 10px; background: var(--bg-panel-alt); color: var(--text-dim); border-bottom: 1px solid var(--border-soft); }
+.turn-msg .role.system { color: var(--info); }
+.turn-msg .role.user { color: var(--volt); }
+.turn-msg .role.tool { color: var(--status-ok); }
+.turn-msg .role.assistant { color: var(--text-bright); }
+.turn-msg .body { padding: 9px 11px; font-family: var(--font-mono); font-size: 11.5px; line-height: 1.55; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+.turn-kv { display: grid; grid-template-columns: 130px 1fr; gap: 8px 12px; font-family: var(--font-mono); font-size: 12px; }
+.turn-kv .k { color: var(--text-dim); }
+.turn-kv .v { color: var(--text-bright); }
+
+/* keeper config drawer */
+.kc-text { width: 100%; font-family: var(--font-body); font-size: 13px; line-height: 1.55; padding: 10px 12px; background: var(--bg-sunken); color: var(--text-primary); border: 1px solid var(--border-main); border-radius: var(--radius-sm); outline: none; resize: vertical; }
+.kc-text:focus { border-color: var(--volt-dim); box-shadow: 0 0 0 2px var(--volt-wash); }
+.kc-traits { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.kc-trait { font-family: var(--font-ui); font-size: 10.5px; color: var(--volt-strong); border: 1px solid var(--volt-dim); background: var(--volt-wash); padding: 2px 9px; border-radius: var(--radius-pill); }
+.kc-save { width: 100%; margin-top: 4px; padding: 11px; background: var(--volt); color: var(--volt-ink); border: 0; border-radius: var(--radius-sm); font-family: var(--font-ui); font-weight: 600; font-size: 13px; cursor: pointer; transition: 0.14s; }
+.kc-save:hover { filter: brightness(1.06); }
+.turn-sec .set-row { padding: 8px 0; }
+.kc-codectx { display: flex; flex-direction: column; gap: 8px; }
+.kc-cc-row { display: flex; align-items: center; gap: 10px; }
+.kc-cc-row .sub-k { min-width: 92px; }
+.kc-cc-row .mono { font-size: 12px; color: var(--text-bright); }
+.kc-cc-row .set-input { flex: 1; }
+.kc-fact-note { font-size: 11px; color: var(--text-dim); margin: -2px 0 9px; }
+.kc-inherit { display: flex; flex-direction: column; gap: 7px; padding: 10px 11px; background: var(--bg-sunken); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); }
+.kc-inh-row { display: flex; align-items: baseline; gap: 9px; min-width: 0; }
+.kc-inh-tag { flex: none; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.04em; color: var(--text-mid); min-width: 64px; }
+.kc-inh-txt { flex: 1; min-width: 0; font-size: 11.5px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kc-inh-note { margin-top: 2px; padding-top: 8px; border-top: 1px solid var(--border-soft); font-size: 10.5px; color: var(--text-dim); }
+
+/* web link unfurl card (chat) */
+.linkcard { display: flex; align-items: flex-start; gap: 11px; margin-top: 10px; padding: 11px 13px; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); text-decoration: none; transition: border-color 0.18s ease, background 0.18s ease; max-width: 520px; }
+.linkcard:hover { border-color: var(--volt-dim); background: color-mix(in oklab, var(--volt) 5%, var(--bg-card)); }
+.linkcard-fav { flex: none; width: 30px; height: 30px; display: grid; place-items: center; border-radius: var(--radius-xs); background: var(--bg-sunken); border: 1px solid var(--border-soft); color: var(--volt-strong); font-family: var(--font-mono); font-size: 14px; }
+.linkcard.git .linkcard-fav { color: var(--text-bright); }
+.linkcard-body { display: flex; flex-direction: column; gap: 3px; min-width: 0; flex: 1; }
+.linkcard-title { font-family: var(--font-ui); font-size: 13px; font-weight: 600; color: var(--text-bright); line-height: 1.3; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.linkcard-desc { font-size: 12px; color: var(--text-mid); line-height: 1.45; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.linkcard-meta { font-size: 10.5px; color: var(--text-dim); margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.linkcard-go { flex: none; color: var(--text-dim); font-size: 13px; transition: color 0.18s ease; }
+.linkcard:hover .linkcard-go { color: var(--volt-strong); }
+/* inline links inside message bubbles */
+.bubble a, .inline-link { color: var(--volt-strong); text-decoration: underline; text-underline-offset: 2px; text-decoration-color: color-mix(in oklab, var(--volt-strong) 45%, transparent); transition: color 0.15s ease; }
+.bubble a:hover, .inline-link:hover { color: var(--volt); text-decoration-color: var(--volt); }
+
+/* work / goal surface */
+.wk-list { display: flex; flex-direction: column; gap: 12px; margin-top: 4px; }
+.wk-goal { background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.wk-goal.has-block { border-color: color-mix(in oklab, var(--status-bad) 32%, var(--border-main)); }
+.wk-goal-h { display: flex; align-items: center; gap: 10px; width: 100%; padding: 13px 15px 11px; background: none; border: 0; cursor: pointer; text-align: left; color: inherit; }
+.wk-goal-h:hover { background: color-mix(in oklab, var(--volt) 3%, transparent); }
+.wk-caret { flex: none; color: var(--text-dim); font-size: 11px; width: 12px; }
+.wk-pri { flex: none; font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-soft); color: var(--text-dim); }
+.wk-pri.high { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 40%, transparent); background: color-mix(in oklab, var(--status-bad) 10%, transparent); }
+.wk-pri.normal { color: var(--volt-strong); border-color: color-mix(in oklab, var(--volt) 32%, transparent); }
+.wk-pri.low { color: var(--text-dim); }
+.wk-goal-id { flex: none; font-size: 11.5px; color: var(--text-dim); }
+.wk-goal-title { font-family: var(--font-ui); font-size: 14.5px; font-weight: 600; color: var(--text-bright); }
+.wk-goal-ns { flex: none; font-size: 11px; color: var(--text-mid); background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 1px 7px; border-radius: var(--radius-pill); }
+.wk-spacer { flex: 1; }
+.wk-due { flex: none; font-size: 11px; color: var(--text-dim); }
+.wk-lead { flex: none; display: inline-flex; }
+.wk-goal-sub { display: flex; align-items: center; gap: 11px; padding: 0 15px 13px 37px; }
+.wk-prog { flex: none; width: 300px; max-width: 42%; height: 6px; display: flex; gap: 1.5px; background: var(--bg-sunken); border-radius: var(--radius-pill); overflow: hidden; }
+.wk-seg { height: 100%; }
+.wk-seg.done { background: var(--status-ok); }
+.wk-seg.wip { background: var(--volt); }
+.wk-seg.blocked { background: var(--status-bad); }
+.wk-prog-lbl { flex: none; font-size: 11px; color: var(--text-mid); }
+.wk-metric { margin-left: auto; flex: none; font-size: 11px; color: var(--text-dim); }
+.wk-jobs { border-top: 1px solid var(--border-soft); padding: 10px 15px 13px; display: flex; flex-direction: column; gap: 2px; }
+.wk-note { font-size: 12px; color: var(--text-mid); line-height: 1.5; padding: 2px 0 9px; border-bottom: 1px dashed var(--border-soft); margin-bottom: 7px; }
+.wk-job { display: flex; align-items: center; gap: 10px; padding: 7px 8px; border-radius: var(--radius-xs); }
+.wk-job:hover { background: var(--bg-sunken); }
+.wk-job-dot { flex: none; width: 7px; height: 7px; border-radius: 50%; background: var(--text-dim); }
+.wk-job-dot.done { background: var(--status-ok); }
+.wk-job-dot.wip { background: var(--volt); }
+.wk-job-dot.review { background: var(--status-warn); }
+.wk-job-dot.blocked { background: var(--status-bad); }
+.wk-job-id { flex: none; font-size: 11px; color: var(--text-dim); min-width: 52px; }
+.wk-job-title { font-size: 13px; color: var(--text-primary); display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.wk-job.done .wk-job-title { color: var(--text-mid); }
+.wk-job-block { font-size: 11px; color: var(--status-bad); }
+.wk-job-state { flex: none; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.04em; color: var(--text-dim); }
+.wk-job-state.done { color: var(--status-ok); }
+.wk-job-state.wip { color: var(--volt-strong); }
+.wk-job-state.review { color: var(--status-warn); }
+.wk-job-state.blocked { color: var(--status-bad); }
+.wk-job-kp { flex: none; display: inline-flex; align-items: center; justify-content: flex-end; gap: 6px; min-width: 130px; padding: 3px 6px; border-radius: var(--radius-pill); border: 1px solid transparent; background: none; cursor: pointer; color: var(--text-mid); font-size: 11.5px; white-space: nowrap; transition: border-color 0.15s ease, color 0.15s ease; }
+.wk-job-kp:hover { border-color: var(--border-highlight); color: var(--text-bright); }
+.wk-job-kp.none { color: var(--text-dim); cursor: default; }
+.set-add.wk-newgoal { width: auto; margin: 0; flex: none; align-self: center; white-space: nowrap; }
+.wk-blk-n { color: var(--status-bad); }
+.wk-foot { margin: 16px 2px 4px; font-size: 11px; color: var(--text-dim); }
+
+/* small inline label for jargon keys (room / 세션 / …) */
+.sub-k { font-family: var(--font-ui); font-size: 9px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-dim); margin-right: 4px; }
+
+/* suggested chips */
+.suggest { display: flex; flex-direction: column; gap: 7px; margin-top: 4px; }
+.suggest .lbl { font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); }
+.suggest-row { display: flex; flex-wrap: wrap; gap: 8px; }
+.chip {
+  font-family: var(--font-ui); font-size: 13px; cursor: pointer; text-align: left;
+  padding: 8px 13px; border-radius: var(--radius-pill); border: 1px solid var(--border-main);
+  background: var(--bg-card); color: var(--text-primary); transition: 0.15s; line-height: 1.3;
+}
+.chip:hover { border-color: var(--volt); color: var(--text-bright); background: var(--bg-card-hover); box-shadow: 0 0 0 2px var(--volt-wash); }
+.chip .pre { color: var(--volt); margin-right: 7px; }
+
+/* typing */
+.typing { display: inline-flex; gap: 4px; align-items: center; padding: 4px 0; }
+.typing i { width: 6px; height: 6px; border-radius: 50%; background: var(--volt); display: inline-block; animation: tdot 1.2s infinite ease-in-out; }
+.typing i:nth-child(2) { animation-delay: 0.18s; } .typing i:nth-child(3) { animation-delay: 0.36s; }
+@keyframes tdot { 0%,60%,100% { opacity: 0.25; transform: translateY(0); } 30% { opacity: 1; transform: translateY(-3px); } }
+
+/* composer */
+.composer { flex: none; padding: 12px 24px 16px; border-top: 1px solid var(--border-main); background: linear-gradient(0deg, var(--bg-panel), var(--bg-deep)); }
+.composer-inner { max-width: var(--thread-w, 980px); margin: 0 auto; padding: 0 4px; }
+.composer-box {
+  background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-md);
+  padding: 6px 6px 6px 14px; display: flex; align-items: flex-end; gap: 10px; transition: border-color 0.15s, box-shadow 0.15s;
+}
+.composer-box.focus { border-color: var(--volt-dim); box-shadow: 0 0 0 3px var(--volt-wash); }
+.composer textarea {
+  flex: 1; resize: none; border: 0; outline: 0; background: transparent;
+  color: var(--text-bright); font-family: var(--font-ui); font-size: 14.5px; line-height: 1.5;
+  padding: 9px 0; max-height: 160px; min-height: 24px;
+}
+.composer textarea::placeholder { color: var(--text-dim); }
+.composer-tools { display: flex; align-items: center; gap: 6px; padding-bottom: 2px; }
+.ctool {
+  width: 34px; height: 34px; display: flex; align-items: center; justify-content: center;
+  border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-panel-alt);
+  color: var(--text-mid); cursor: pointer; transition: 0.14s;
+}
+.ctool:hover { color: var(--text-bright); border-color: var(--border-highlight); }
+.send {
+  height: 34px; padding: 0 16px; border-radius: var(--radius-sm); cursor: pointer;
+  background: var(--volt); color: var(--volt-ink); border: 1px solid var(--volt);
+  font-family: var(--font-ui); font-size: 12.5px; font-weight: 600; letter-spacing: 0.04em;
+  display: inline-flex; align-items: center; gap: 7px; transition: 0.14s;
+  white-space: nowrap; flex: none;
+}
+.send:hover { background: var(--volt-strong); box-shadow: 0 0 18px var(--volt-glow); }
+.send:disabled { opacity: 0.4; cursor: default; box-shadow: none; }
+.composer-foot { display: flex; align-items: center; justify-content: space-between; margin-top: 8px; font-size: 11px; color: var(--text-dim); }
+.composer-foot .as { display: inline-flex; align-items: center; gap: 7px; }
+.composer-foot .as b { color: var(--volt-strong); font-family: var(--font-mono); }
+.composer-foot .hint { font-family: var(--font-mono); white-space: nowrap; }
+.composer-foot .as { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.composer-foot kbd { font-family: var(--font-mono); font-size: 10px; background: var(--bg-card); border: 1px solid var(--border-main); border-bottom-width: 2px; border-radius: var(--radius-xs); padding: 1px 5px; color: var(--text-mid); }
+
+/* composer — drag-over affordance */
+.composer-box.drag { border-color: var(--volt-dim); box-shadow: 0 0 0 3px var(--volt-wash); background: var(--volt-wash); }
+
+/* composer — pending attachment / voice tray */
+.composer-tray { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 9px; }
+.cdraft { display: flex; align-items: center; gap: 9px; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 7px 9px; position: relative; }
+.cdraft.att { padding-right: 26px; max-width: 280px; }
+.cdraft-thumb { width: 34px; height: 34px; flex: none; border-radius: var(--radius-xs); overflow: hidden; background: var(--bg-panel-alt); display: flex; align-items: center; justify-content: center; }
+.cdraft-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.cdraft-glyph { color: var(--text-dim); font-size: 17px; }
+.cdraft-meta { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.cdraft-name { font-size: 11.5px; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 190px; }
+.cdraft-sub { font-size: 10px; color: var(--text-dim); }
+.cdraft.voice { padding-right: 26px; gap: 8px; flex-wrap: wrap; max-width: 360px; }
+.cdraft-glyph.mic { color: var(--volt); font-size: 14px; }
+.cdraft-wave { display: flex; align-items: center; gap: 1.5px; height: 22px; }
+.cdraft-wave .vbar { width: 2px; border-radius: 1px; background: var(--volt-dim); }
+.cdraft-dur { font-size: 11px; color: var(--text-mid); }
+.cdraft-tx { display: flex; gap: 7px; align-items: baseline; flex-basis: 100%; padding-top: 5px; border-top: 1px solid var(--border-main); }
+.cdraft-tx-k { font-family: var(--font-display); text-transform: uppercase; letter-spacing: 0.14em; font-size: 9px; color: var(--volt); flex: none; }
+.cdraft-tx-v { font-size: 11.5px; color: var(--text-mid); line-height: 1.45; }
+.cdraft-x { position: absolute; top: 5px; right: 6px; width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; border: 0; background: transparent; color: var(--text-dim); cursor: pointer; font-size: 10px; border-radius: var(--radius-xs); }
+.cdraft-x:hover { color: var(--status-bad); background: var(--bg-panel-alt); }
+
+/* composer — live recording bar */
+.rec-bar { flex: 1; display: flex; align-items: center; gap: 10px; padding: 5px 4px 5px 10px; min-height: 34px; }
+.rec-dot { width: 9px; height: 9px; border-radius: 50%; background: var(--status-bad); flex: none; animation: recpulse 1.1s ease-in-out infinite; }
+@keyframes recpulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+.rec-lbl { font-family: var(--font-display); text-transform: uppercase; letter-spacing: 0.16em; font-size: 10px; color: var(--status-bad); }
+.rec-clock { font-size: 13px; color: var(--text-bright); }
+.rec-wave { flex: 1; display: flex; align-items: center; gap: 2px; height: 24px; overflow: hidden; }
+.rec-wave .rbar { width: 2.5px; border-radius: 1px; background: var(--volt-dim); flex: none; }
+.rec-btn { height: 30px; padding: 0 12px; border-radius: var(--radius-sm); cursor: pointer; font-family: var(--font-ui); font-size: 12px; transition: 0.14s; flex: none; }
+.rec-btn.cancel { background: transparent; border: 1px solid var(--border-main); color: var(--text-mid); }
+.rec-btn.cancel:hover { color: var(--text-bright); border-color: var(--border-highlight); }
+.rec-btn.stop { background: var(--volt); border: 1px solid var(--volt); color: var(--volt-ink); }
+.rec-btn.stop:hover { background: var(--volt-strong); box-shadow: 0 0 16px var(--volt-glow); }
+
+/* ════ CONTEXT RAIL ════ */
+.ctx { border-left: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+.ctx-scroll { overflow-y: auto; padding: 14px; display: flex; flex-direction: column; gap: 16px; }
+.ctx-sec h4 { font-family: var(--font-display); font-weight: 400; text-transform: uppercase; letter-spacing: 0.18em; font-size: 11px; color: var(--text-mid); margin: 0 0 9px; }
+.ctx-card { background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 11px 12px; }
+
+.vitals { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--border-soft); border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.vital { background: var(--bg-card); padding: 9px 11px; }
+.vital .vk { font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-mid); font-weight: 600; }
+.vital .vv { font-family: var(--font-mono); font-size: 15px; color: var(--text-bright); margin-top: 3px; }
+.vital .vv.volt { color: var(--volt-strong); }
+.vital .vv small { font-size: 10px; color: var(--text-dim); }
+
+/* context meter */
+.meter { height: 7px; border-radius: var(--radius-pill); background: var(--bg-sunken); border: 1px solid var(--border-soft); overflow: hidden; margin-top: 7px; }
+.meter > span { display: block; height: 100%; background: linear-gradient(90deg, var(--volt-dim), var(--volt)); }
+.meter.hot > span { background: linear-gradient(90deg, var(--status-warn), var(--status-bad)); }
+.meter-wrap { position: relative; margin-top: 7px; }
+.meter-wrap .meter { margin-top: 0; }
+.meter-mark { position: absolute; top: -2px; width: 1px; height: 11px; background: color-mix(in oklab, var(--status-warn) 75%, transparent); transform: translateX(-50%); pointer-events: none; }
+.meter-mark.hot { background: var(--status-bad); }
+.meter-mark-lbl { position: absolute; bottom: 100%; right: 1px; margin-bottom: 3px; font-size: 8.5px; font-style: normal; letter-spacing: 0.04em; text-transform: uppercase; white-space: nowrap; color: color-mix(in oklab, var(--status-warn) 80%, var(--text-dim)); }
+.meter-mark.hot .meter-mark-lbl { color: var(--status-bad); }
+
+/* fsm list */
+.fsm { display: flex; flex-direction: column; gap: 0; }
+.fsm-step { display: flex; align-items: center; gap: 9px; padding: 5px 4px; font-family: var(--font-mono); font-size: 11.5px; color: var(--text-dim); position: relative; }
+.fsm-step .pip { width: 9px; height: 9px; border-radius: 50%; border: 1px solid var(--border-highlight); background: var(--bg-sunken); flex: none; z-index: 1; }
+.fsm-step.done { color: var(--text-mid); }
+.fsm-step.done .pip { background: var(--text-dim); border-color: var(--text-dim); }
+.fsm-step.cur { color: var(--volt-strong); }
+.fsm-step.cur .pip { background: var(--volt); border-color: var(--volt); box-shadow: 0 0 10px var(--volt-glow); }
+.fsm-step:not(:last-child)::after { content: ""; position: absolute; left: 8.5px; top: 16px; bottom: -5px; width: 1px; background: var(--border-soft); }
+.fsm-step.done:not(:last-child)::after { background: var(--text-dim); }
+
+.ctx-list { display: flex; flex-direction: column; gap: 7px; }
+.ctx-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text-mid); }
+.ctx-item .ci-name { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-primary); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ctx-item .ci-meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); white-space: nowrap; flex: none; }
+
+.tasktag { display: flex; align-items: center; gap: 6px; padding: 6px 9px; border-radius: var(--radius-xs); background: var(--bg-sunken); border: 1px solid var(--border-soft); font-size: 12px; color: var(--text-primary); }
+.tasktag .ttl { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.tasktag .tid { font-family: var(--font-mono); font-size: 10.5px; color: var(--volt-strong); flex: none; }
+
+/* empty state */
+.empty2 { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; color: var(--text-dim); text-align: center; padding: 40px; }
+.empty2 .ico { font-size: 30px; opacity: 0.5; }
+.empty2 h3 { font-family: var(--font-display); letter-spacing: 0.14em; color: var(--text-mid); font-size: 15px; }
+
+/* density compact */
+.v2-app[data-density="compact"] .thread-inner { gap: 14px; }
+.v2-app[data-density="compact"] .bubble { padding: 11px 13px; font-size: 14px; }
+.v2-app[data-density="compact"] .kp-row { padding: 6px 9px; }
+
+/* ════ TOK/S THROUGHPUT ════ */
+/* header live readout */
+.chat-id .sub .tps-live { display: inline-flex; align-items: center; gap: 5px; color: var(--status-ok); }
+.tps-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--status-ok); box-shadow: 0 0 6px var(--status-ok); animation: tps-pulse 1.1s ease-in-out infinite; }
+@keyframes tps-pulse { 0%,100% { opacity: 0.45; } 50% { opacity: 1; } }
+.chat-id .sub .tps-live .mono { color: var(--status-ok); }
+
+/* context-rail throughput card */
+.tps-card { background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 11px 12px; }
+.tps-now { display: flex; align-items: baseline; gap: 6px; }
+.tps-val { font-family: var(--font-mono); font-size: 26px; line-height: 1; color: var(--status-ok); font-variant-numeric: tabular-nums; }
+.tps-val.idle { color: var(--text-dim); }
+.tps-unit { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
+.tps-flag { margin-left: auto; display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--status-ok); }
+.tps-spark { position: relative; display: flex; align-items: flex-end; gap: 2px; height: 30px; margin-top: 8px; }
+.tps-spark > span:not(.tps-spark-rt) { flex: 1; background: var(--status-ok); border-radius: 1px; min-height: 2px; transition: height 0.5s ease; }
+.tps-spark-rt { position: absolute; top: -2px; right: 0; font-size: 10px; color: var(--text-mid); background: color-mix(in oklab, var(--bg-card) 80%, transparent); padding: 1.5px 6px; border-radius: var(--radius-pill); border: 1px solid var(--border-soft); pointer-events: none; opacity: 0.72; transition: opacity 0.14s ease, color 0.14s ease, border-color 0.14s ease; }
+.tps-spark:hover .tps-spark-rt { opacity: 1; color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 38%, transparent); }
+.tps-ranges { display: flex; align-items: center; gap: 4px; margin-top: 9px; }
+.tps-range { font-family: var(--font-mono); font-size: 10.5px; padding: 3px 9px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: transparent; color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.tps-range:hover { color: var(--text-mid); border-color: var(--border-highlight); }
+.tps-range.on { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); background: color-mix(in oklab, var(--status-ok) 10%, transparent); }
+.tps-avg { margin-left: auto; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+
+/* compaction full-context before/after toggle */
+.cmp-side-toggle { display: flex; gap: 5px; margin-bottom: 9px; }
+.cmp-side { flex: 1; font-family: var(--font-ui); font-size: 11px; padding: 7px 9px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-sunken); color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.cmp-side:hover { color: var(--text-mid); }
+.cmp-side.on { color: var(--text-bright); border-color: var(--volt-dim); background: var(--volt-wash); }
+.cmp-ctx-pre { max-height: 280px; overflow-y: auto; }
+
+/* ════ MOBILE-ONLY HEADER CONTROLS (rendered only ≤900px via JS) ════ */
+/* feedback voted state + regen tag */
+.fbk-btn.on.up { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); }
+.fbk-btn.on.down { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); }
+.fbk-noted { font-family: var(--font-ui); font-size: 11px; color: var(--status-ok); margin-left: 4px; animation: turn-in 0.18s ease; }
+.regen-tag { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.04em; color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-pill); padding: 1px 7px; }
+
+/* external-source context provenance (Discord/Slack pulled-in context range) */
+.ctx-from {
+  display: flex; align-items: center; gap: 8px; margin-bottom: 8px; padding: 7px 11px;
+  background: color-mix(in oklab, var(--info) 8%, transparent);
+  border: 1px solid color-mix(in oklab, var(--info) 28%, transparent);
+  border-radius: var(--radius-sm); font-size: 11.5px; color: var(--text-mid);
+}
+.ctx-from .cf-ico { color: var(--info); font-family: var(--font-mono); }
+.ctx-from b { color: var(--text-bright); font-weight: 600; }
+.ctx-from .cf-view { margin-left: auto; flex: none; background: none; border: 1px solid var(--info-dim); color: var(--info); border-radius: var(--radius-pill); font-size: 10.5px; padding: 2px 9px; cursor: pointer; transition: 0.14s; }
+.ctx-from .cf-view:hover { background: color-mix(in oklab, var(--info) 14%, transparent); }
+.cf-detail { margin: -2px 0 8px; padding: 10px 12px; border: 1px solid color-mix(in oklab, var(--info) 24%, transparent); border-top: 0; border-radius: 0 0 var(--radius-sm) var(--radius-sm); background: color-mix(in oklab, var(--info) 5%, transparent); }
+.cf-detail-h { font-size: 10.5px; color: var(--text-dim); margin-bottom: 8px; }
+.cf-msg { display: grid; grid-template-columns: 44px 70px 1fr; gap: 8px; align-items: baseline; padding: 4px 0; font-size: 12px; line-height: 1.45; border-top: 1px solid color-mix(in oklab, var(--info) 12%, transparent); }
+.cf-msg:first-of-type { border-top: 0; }
+.cf-msg .cf-ts { color: var(--text-dim); font-size: 10.5px; }
+.cf-msg .cf-who { color: var(--info); font-weight: 600; }
+.cf-msg .cf-text { color: var(--text-mid); }
+
+/* code block in messages */
+.code-block { margin: 10px 0; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: #06070a; }
+.code-cap { padding: 6px 12px; font-size: 10.5px; color: var(--text-dim); background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.code-block pre { margin: 0; padding: 12px 14px; overflow-x: auto; }
+.code-block code { font-family: var(--font-mono); font-size: 12.5px; line-height: 1.6; color: var(--text-primary); white-space: pre; }
+.code-block .kw { color: var(--volt-strong); opacity: 0.85; }
+.code-block .fn { color: var(--text-bright); }
+.code-block .str { color: color-mix(in oklab, var(--status-ok) 70%, var(--text-mid)); }
+.code-block .cm { color: var(--text-dim); font-style: italic; }
+.code-block .del { color: var(--status-bad); }
+.code-block .add { color: var(--status-ok); }
+
+/* shell / exec output */
+.shell-block { margin: 10px 0; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: #06070a; }
+.shell-bar { display: flex; align-items: center; gap: 6px; padding: 7px 11px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.shell-bar .dot { width: 9px; height: 9px; border-radius: 50%; }
+.shell-bar .dot.r { background: #e0625b; } .shell-bar .dot.y { background: #e0b257; } .shell-bar .dot.g { background: #5ea66a; }
+.shell-bar .shell-title { margin-left: 8px; font-size: 10.5px; color: var(--text-dim); }
+.shell-block pre { margin: 0; padding: 11px 13px; overflow-x: auto; }
+.sh-ln { font-family: var(--font-mono); font-size: 12px; line-height: 1.6; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+.sh-ln.cmd { color: var(--text-bright); }
+.sh-ln .sh-prompt { color: var(--volt-strong); }
+.sh-ln.ok { color: var(--status-ok); }
+.sh-ln.err { color: var(--status-bad); }
+.sh-ln.dim { color: var(--text-dim); }
+.shell-exit { padding: 6px 13px; font-family: var(--font-mono); font-size: 11px; border-top: 1px solid var(--border-soft); }
+.shell-exit.ok { color: var(--status-ok); }
+.shell-exit.fail { color: var(--status-bad); }
+
+/* artifact file card */
+.artifact { display: flex; align-items: center; gap: 11px; margin: 10px 0; padding: 11px 13px; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); }
+.af-ico { width: 34px; height: 34px; flex: none; display: flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 15px; color: var(--volt-strong); background: var(--volt-wash); border: 1px solid var(--volt-dim); border-radius: var(--radius-sm); }
+.af-meta { flex: 1; min-width: 0; }
+.af-name { font-size: 13px; color: var(--text-bright); }
+.af-sub { font-size: 10.5px; color: var(--text-dim); margin-top: 2px; text-transform: uppercase; letter-spacing: 0.06em; }
+.af-btn { flex: none; font-family: var(--font-ui); font-size: 11px; padding: 5px 11px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: transparent; color: var(--text-mid); cursor: pointer; transition: 0.14s; }
+.af-btn:hover { border-color: var(--volt-dim); color: var(--volt); }
+
+/* image / svg output */
+.img-out, .svg-out { margin: 10px 0; }
+.img-frame, .svg-frame { border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-sunken); display: flex; align-items: center; justify-content: center; }
+.img-frame img { max-width: 100%; display: block; }
+.img-ph { padding: 40px; color: var(--text-dim); font-size: 12px; font-family: var(--font-ui); }
+.svg-frame { padding: 16px; }
+.svg-frame svg { max-width: 100%; height: auto; display: block; }
+.img-out figcaption, .svg-out figcaption { margin-top: 6px; font-size: 11px; color: var(--text-dim); }
+
+/* ── multimodal: image attachment (vision-modal user input) ── */
+.attach { margin: 10px 0; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: #06070a; }
+.attach-hd { display: flex; align-items: center; gap: 8px; padding: 7px 11px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.attach-clip { color: var(--volt-strong); font-size: 12px; flex: none; }
+.attach-name { font-size: 11px; color: var(--text-mid); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.attach-dims { font-size: 10px; color: var(--text-dim); flex: none; }
+.attach-frame { display: flex; align-items: center; justify-content: center; background: var(--bg-sunken); padding: 0; }
+.attach-frame svg { max-width: 100%; height: auto; display: block; }
+.attach-frame img { width: 100%; max-height: 220px; object-fit: cover; object-position: center 30%; display: block; }
+.attach-cap { display: flex; align-items: center; gap: 8px; padding: 7px 11px; font-size: 10.5px; color: var(--text-dim); border-top: 1px solid var(--border-soft); }
+.attach-tag { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-pill); padding: 1px 7px; }
+
+/* ── multimodal: voice memo (audio-modal user input) ── */
+.voice { margin: 10px 0; padding: 11px 13px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: #06070a; }
+.voice-row { display: flex; align-items: center; gap: 12px; }
+.voice-play { flex: none; width: 32px; height: 32px; border-radius: 50%; border: 1px solid var(--volt-dim); background: var(--volt-wash); color: var(--volt-strong); cursor: pointer; font-size: 11px; line-height: 1; display: flex; align-items: center; justify-content: center; padding-left: 2px; transition: 0.14s; }
+.voice-play:hover { border-color: var(--volt); color: var(--volt); }
+.voice-play.on { background: var(--volt); color: var(--volt-ink); border-color: var(--volt); padding-left: 0; }
+.voice-wave { flex: 1; display: flex; align-items: center; gap: 2px; height: 30px; min-width: 0; overflow: hidden; }
+.voice-wave .vbar { flex: 1; min-width: 1px; border-radius: 1px; background: var(--border-highlight); transition: background 0.1s; }
+.voice-wave .vbar.on { background: var(--volt); }
+.voice-dur { flex: none; font-size: 11px; color: var(--text-mid); font-variant-numeric: tabular-nums; }
+.voice-meta { display: flex; align-items: center; gap: 8px; margin-top: 8px; font-size: 10px; color: var(--text-dim); }
+.voice-meta .voice-via { flex: 1; }
+.voice-meta .mono { flex: none; }
+.voice-tx { margin-top: 9px; padding-top: 9px; border-top: 1px dashed var(--border-soft); display: flex; gap: 9px; }
+.voice-tx-k { flex: none; font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); padding-top: 2px; }
+.voice-tx-v { font-size: 12.5px; color: var(--text-primary); line-height: 1.55; }
+
+/* ── keeper-to-keeper broadcast ── */
+.bcast { margin: 10px 0; border: 1px solid var(--volt-dim); border-radius: var(--radius-sm); background: linear-gradient(180deg, var(--volt-wash), #06070a 80%); overflow: hidden; }
+.bcast-hd { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; padding: 8px 12px; border-bottom: 1px solid var(--border-soft); background: color-mix(in oklab, var(--volt) 6%, transparent); }
+.bcast-tag { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--volt-strong); font-weight: 600; }
+.bcast-scope { font-size: 11px; color: var(--text-bright); }
+.bcast-via { font-size: 10px; color: var(--text-dim); }
+.bcast-count { margin-left: auto; flex: none; font-size: 10px; color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-pill); padding: 1px 8px; }
+.bcast-note { padding: 11px 12px; font-size: 13px; color: var(--text-primary); line-height: 1.6; }
+.bcast-note code { font-family: var(--font-mono); font-size: 12px; background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 0 4px; border-radius: var(--radius-xs); color: var(--volt-strong); }
+.bcast-rcpts { display: flex; flex-direction: column; gap: 1px; background: var(--border-soft); border-top: 1px solid var(--border-soft); }
+.bcast-rcpt { display: flex; align-items: center; gap: 9px; padding: 8px 12px; background: #06070a; }
+.bcast-rcpt-id { font-family: var(--font-mono); font-size: 12px; color: var(--text-bright); flex: 1; min-width: 0; }
+.bcast-ack { flex: none; font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+.bcast-rcpt.acked .bcast-ack { color: var(--status-ok); }
+.bcast-rcpt.read .bcast-ack { color: var(--info); }
+.bcast-rcpt::before { content: ""; flex: none; width: 6px; height: 6px; border-radius: 50%; background: var(--text-dim); order: 3; }
+.bcast-rcpt.acked::before { background: var(--status-ok); box-shadow: 0 0 6px color-mix(in oklab, var(--status-ok) 60%, transparent); }
+.bcast-rcpt.read::before { background: var(--info); }
+
+/* compaction inspector trigger (ctx rail) */
+.cmp-open {
+  width: 100%; margin-top: 10px; display: flex; align-items: center; gap: 7px;
+  font-family: var(--font-ui); font-size: 11.5px; color: var(--text-mid);
+  padding: 8px 10px; background: var(--bg-sunken); border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm); cursor: pointer; transition: 0.14s;
+}
+.cmp-open:hover { border-color: var(--volt-dim); color: var(--volt); }
+.cmp-open-sub { margin-left: auto; font-size: 10px; color: var(--text-dim); }
+
+/* manual compaction trigger (ctx rail) — operator-run compact */
+.cmp-actions { margin-top: 10px; }
+.cmp-run {
+  width: 100%; display: flex; align-items: center; justify-content: center; gap: 7px;
+  font-family: var(--font-ui); font-size: 12px; color: var(--volt-ink);
+  background: var(--volt); border: 1px solid var(--volt); padding: 7px 10px;
+  border-radius: var(--radius-sm); cursor: pointer; transition: 0.14s;
+}
+.cmp-run:hover:not(:disabled) { background: var(--volt-strong); box-shadow: 0 0 16px var(--volt-glow); }
+.cmp-run:disabled { cursor: default; opacity: 0.92; }
+.cmp-run.busy { background: var(--bg-panel-alt); color: var(--text-mid); border-color: var(--border-main); }
+.cmp-spin { width: 11px; height: 11px; border-radius: 50%; border: 2px solid var(--border-highlight); border-top-color: var(--volt); animation: spin 0.7s linear infinite; flex: none; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* roster row command menu */
+.kp-row { position: relative; }
+.kp-more {
+  position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
+  width: 24px; height: 24px; border-radius: var(--radius-sm); border: 1px solid var(--border-main);
+  background: var(--bg-panel); color: var(--text-mid); cursor: pointer; font-size: 14px; line-height: 1;
+  opacity: 0; transition: 0.14s; z-index: 2;
+}
+.kp-row:hover .kp-more { opacity: 1; }
+.kp-more:hover { border-color: var(--volt-dim); color: var(--volt); }
+.kp-menu {
+  position: fixed; z-index: 80; min-width: 186px; padding: 5px;
+  background: var(--bg-panel); border: 1px solid var(--border-highlight);
+  border-radius: var(--radius-sm); box-shadow: 0 8px 24px rgba(0,0,0,0.55);
+  animation: turn-in 0.13s ease;
+}
+.kp-menu-h { display: flex; align-items: center; gap: 7px; padding: 7px 9px 8px; border-bottom: 1px solid var(--border-soft); margin-bottom: 4px; font-size: 12px; color: var(--text-bright); }
+.kp-menu-i { display: flex; align-items: center; gap: 9px; width: 100%; padding: 8px 9px; background: none; border: 0; border-radius: var(--radius-xs); color: var(--text-mid); font-family: var(--font-ui); font-size: 12.5px; text-align: left; cursor: pointer; transition: 0.12s; }
+.kp-menu-i:hover { background: var(--bg-card); color: var(--text-bright); }
+.kp-menu-i.danger { color: var(--status-bad); }
+.kp-menu-i.danger:hover { background: color-mix(in oklab, var(--status-bad) 14%, transparent); }
+.kp-menu-sep { height: 1px; background: var(--border-soft); margin: 4px 0; }
+
+/* compaction inspector body */
+.cmp-empty { font-size: 12.5px; line-height: 1.7; color: var(--text-dim); text-align: center; padding: 30px 12px; }
+.cmp-trigger { font-size: 12px; color: var(--text-mid); margin-bottom: 4px; }
+.cmp-trigger .sub-k { margin-right: 6px; }
+.cmp-headline { display: flex; align-items: center; gap: 10px; font-size: 20px; margin-bottom: 12px; }
+.cmp-arrow { color: var(--text-dim); }
+.cmp-reduce { margin-left: auto; font-family: var(--font-mono); font-size: 13px; color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 40%, transparent); background: color-mix(in oklab, var(--status-ok) 10%, transparent); padding: 2px 9px; border-radius: var(--radius-pill); }
+.cmp-stat { display: grid; grid-template-columns: 54px 1fr; gap: 10px; align-items: start; margin-top: 12px; }
+.cmp-stat-k { font-family: var(--font-ui); font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-dim); padding-top: 2px; }
+.cmp-bars { display: flex; flex-direction: column; gap: 3px; }
+.cmp-line { display: flex; align-items: baseline; justify-content: space-between; }
+.cmp-line .t { font-family: var(--font-ui); font-size: 10px; color: var(--text-dim); }
+.cmp-line .v { font-family: var(--font-mono); font-weight: 500; font-size: 12px; color: var(--text-bright); }
+.cmp-line .v.ok { color: var(--status-ok); }
+.cmp-line:nth-of-type(3) { margin-top: 5px; }
+.cmp-bar { position: relative; height: 7px; background: var(--bg-sunken); border-radius: 3px; overflow: hidden; }
+.cmp-bar span { position: absolute; left: 0; top: 0; bottom: 0; border-radius: 3px; }
+.cmp-bar.before span { background: color-mix(in oklab, var(--text-dim) 55%, transparent); }
+.cmp-bar.after span { background: var(--status-ok); }
+
+/* context absolute-token line */
+.ctx-tok { display: flex; align-items: baseline; gap: 5px; margin-top: 8px; }
+.ctx-tok .mono { font-size: 13px; color: var(--text-bright); }
+.ctx-tok-sep { color: var(--text-dim); }
+.ctx-tok-full { color: var(--text-dim) !important; }
+.ctx-tok-lbl { margin-left: auto; font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
+
+/* recent tool — expandable detail */
+.ctx-item.click { cursor: pointer; }
+.ctx-item.click:hover { color: var(--text-bright); }
+.ctx-item .ci-chev { margin-left: 6px; flex: none; font-size: 8px; color: var(--text-dim); transition: transform 0.18s; }
+.ctx-item-wrap.open .ci-chev { transform: rotate(90deg); }
+.ci-detail { margin: 4px 0 8px; padding: 8px 10px; background: #06070a; border: 1px solid var(--border-soft); border-radius: var(--radius-xs); }
+.ci-detail .tk { font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.1em; margin-top: 8px; }
+.ci-detail .tk:first-child { margin-top: 0; }
+.ci-detail pre { margin: 3px 0 0; font-family: var(--font-mono); font-size: 11px; color: var(--text-mid); line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
+.cmp-diff { display: grid; grid-template-columns: 1fr; gap: 10px; }
+.cmp-col { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 9px 11px; }
+.cmp-col-h { font-family: var(--font-ui); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 7px; }
+.cmp-col.kept { border-left: 2px solid var(--status-ok); }
+.cmp-col.kept .cmp-col-h { color: var(--status-ok); }
+.cmp-col.summ { border-left: 2px solid var(--info); }
+.cmp-col.summ .cmp-col-h { color: var(--info); }
+.cmp-col.drop { border-left: 2px solid var(--text-dim); }
+.cmp-col.drop .cmp-col-h { color: var(--text-dim); }
+.cmp-li { font-size: 12px; line-height: 1.5; color: var(--text-mid); padding: 3px 0; border-top: 1px solid var(--border-soft); }
+.cmp-li:first-of-type { border-top: 0; }
+
+.chat-back, .chat-ctx-btn {
+  flex: none; width: 34px; height: 34px; border-radius: var(--radius-sm);
+  display: flex; align-items: center; justify-content: center;
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  color: var(--text-mid); font-size: 16px; cursor: pointer; transition: 0.14s;
+}
+.chat-back:active, .chat-ctx-btn:active { transform: translateY(1px); }
+.chat-ctx-btn { margin-left: auto; }
+.chat-back:hover, .chat-ctx-btn:hover { border-color: var(--volt-dim); color: var(--volt); }
+
+/* context drawer (mobile) */
+.ctx-overlay { position: fixed; inset: 0; background: rgba(4,5,8,0.6); z-index: 60; display: flex; justify-content: flex-end; }
+.ctx-drawer { position: relative; width: min(330px, 88vw); height: 100%; animation: turn-in 0.18s ease; box-shadow: -8px 0 30px rgba(0,0,0,0.5); }
+.ctx-drawer .ctx { height: 100%; }
+.ctx-drawer-close {
+  position: absolute; top: 11px; right: 11px; z-index: 3; width: 28px; height: 28px;
+  border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-main);
+  color: var(--text-mid); cursor: pointer; font-size: 12px;
+}
+
+/* scrollbars */
+.roster-list::-webkit-scrollbar, .thread::-webkit-scrollbar, .ctx-scroll::-webkit-scrollbar, .chat-meta::-webkit-scrollbar { width: 9px; height: 7px; }
+.thread::-webkit-scrollbar-thumb, .roster-list::-webkit-scrollbar-thumb, .ctx-scroll::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); border: 2px solid transparent; background-clip: padding-box; }
+.thread::-webkit-scrollbar-thumb:hover { background: var(--border-highlight); background-clip: padding-box; }
+
+/* ════ RESPONSIVE ════ */
+/* tablet-ish: drop the context rail so chat keeps breathing room (desktop ≥901) */
+@media (min-width: 901px) and (max-width: 1120px) {
+  .v2-body { --shrink-ctx: 1; }
+}
+
+/* phones + portrait tablets: single-column master-detail */
+@media (max-width: 900px) {
+  /* top bar trims to crumb + copilot */
+  .v2-top { gap: 10px; padding: 0 12px; height: 46px; }
+  .v2-statchip { display: none; }
+  .v2-top .crumb { font-size: 10px; letter-spacing: 0.08em; }
+  .topbar-copilot kbd { display: none; }
+
+  /* nav rail → fixed bottom tab bar */
+  .v2-nav {
+    position: fixed; left: 0; right: 0; bottom: 0; top: auto;
+    flex-direction: row; height: 56px; gap: 0; padding: 0 4px;
+    border-right: none; border-top: 1px solid var(--border-main);
+    justify-content: space-around; z-index: 50;
+  }
+  .nav-brand, .nav-spacer { display: none; }
+  .nav-item { flex: 1 1 0; width: auto; height: 52px; border-radius: 0; }
+  .nav-item:hover, .nav-item.on { background: transparent; }
+  .nav-item.on::before { left: 24%; right: 24%; top: 0; bottom: auto; width: auto; height: 3px; border-radius: 0 0 3px 3px; }
+
+  /* hide the bottom bar while reading a thread (full-screen chat) */
+  .v2-body[data-mpane="chat"] .v2-nav { display: none; }
+
+  /* single column; JS already sets gridTemplateColumns:1fr, this is the guard */
+  .v2-body { grid-template-columns: 1fr !important; }
+
+  /* master-detail: show one pane at a time */
+  .v2-body[data-mpane="chat"] .roster { display: none; }
+  .v2-body[data-mpane="roster"] .chat-wrap { display: none; }
+
+  .roster { border-right: none; }
+  .roster-list { padding-bottom: 76px; }
+
+  .rail-toggle { display: none; }
+  .chat-wrap { min-width: 0; }
+
+  /* chat header compact + mobile controls */
+  .chat-head { padding: 9px 12px; gap: 10px; }
+  .chat-head .chat-actions { display: none; }
+  .chat-id h2 { font-size: 17px; }
+  .chat-id .name-row { gap: 8px; }
+  .chat-id .sub { gap: 8px; margin-top: 4px; }
+
+  .thread { padding-top: 16px; }
+  .thread-inner { padding: 0 14px; gap: 18px; }
+  .composer { padding: 10px 12px 14px; }
+  .composer-inner { padding: 0; }
+
+  /* turn inspector full-width on phones */
+  .turn-drawer { width: 100vw; }
+}
+
+@media (max-width: 420px) {
+  .chat-id .sub > span:nth-child(2) { display: none; } /* drop model on very narrow, keep room + tok/s */
+  .topbar-copilot span:not(.spark) { display: none; }
+}

--- a/dashboard/v2/turn-inspector.jsx
+++ b/dashboard/v2/turn-inspector.jsx
@@ -1,0 +1,322 @@
+/* MASC v2 — Turn Inspector: the full detail surface for one keeper turn.
+   Summary stats · token economics · turn waterfall · structured transcript
+   with tool cards · copyable injected context. Opened from a message's
+   "턴 상세" action. Reads globals: OWNED_TASKS, RECENT_TOOLS. */
+const { useState: useTurnState, useEffect: useTurnEffect } = React;
+
+/* ── helpers ──────────────────────────────────────────────────── */
+function blocksToText(blocks) {
+  if (!blocks) return '';
+  return blocks.map(b => {
+    if (b.t === 'p' || b.t === 'h4' || b.t === 'callout') return stripTags(b.html);
+    if (b.t === 'ul') return b.items.map(it => '· ' + stripTags(it)).join('\n');
+    if (b.t === 'table') {
+      const head = b.head.map(h => (typeof h === 'object' ? h.v : h)).join('\t');
+      const rows = b.rows.map(r => r.map(c => (typeof c === 'object' ? c.v : c)).join('\t')).join('\n');
+      return head + '\n' + rows;
+    }
+    if (b.t === 'code') return stripTags(b.html);
+    return '';
+  }).filter(Boolean).join('\n\n');
+}
+function stripTags(html) {
+  return String(html).replace(/<[^>]+>/g, '').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+}
+function tiJsonHl(obj) {
+  return JSON.stringify(obj, null, 2)
+    .replace(/("[^"]+"):/g, '<span class="jk">$1</span>:')
+    .replace(/: ("[^"]*")/g, ': <span class="js">$1</span>');
+}
+function approxTokens(str) { return Math.max(1, Math.round(String(str).length / 3.6)); }
+function secOf(dur) { const m = String(dur || '').match(/([\d.]+)/); return m ? parseFloat(m[1]) : 0.5; }
+
+function CopyBtn({ text, label = '복사' }) {
+  const [done, setDone] = useTurnState(false);
+  const onClick = (e) => {
+    e.stopPropagation();
+    try { navigator.clipboard && navigator.clipboard.writeText(text); } catch (_) {}
+    setDone(true); setTimeout(() => setDone(false), 1200);
+  };
+  return (
+    <button className={`ti-copy ${done ? 'done' : ''}`} onClick={onClick}>
+      {done ? '\u2713 복사됨' : '\u2398 ' + label}
+    </button>
+  );
+}
+
+function CodeCard({ cap, text, html, tokens }) {
+  return (
+    <div className="ti-code">
+      <div className="ti-code-h">
+        <span className="cap">{cap}</span>
+        {tokens != null && <span className="sz">~{tokens} tok</span>}
+        <CopyBtn text={text} />
+      </div>
+      {html
+        ? <pre dangerouslySetInnerHTML={{ __html: html }}></pre>
+        : <pre>{text}</pre>}
+    </div>
+  );
+}
+
+/* ── turn model ───────────────────────────────────────────────── */
+function buildTurn(keeper, m) {
+  const traceId = 'trc_' + keeper.id.replace(/[^a-z0-9]/gi, '').slice(0, 5) + '_' + String(m.id).slice(-4);
+  const tasks = (window.OWNED_TASKS && OWNED_TASKS[keeper.id]) || [];
+  const trace = m.trace || (m.tools || []).map(t => ({ kind: 'tool', ...t }));
+  const tools = trace.filter(s => s.kind === 'tool');
+  const ctxPct = Math.round(keeper.ctx * 100);
+  const tokIn = Math.round(2400 + keeper.ctx * 172000);
+  const tokOut = 280 + (m.blocks ? m.blocks.length * 90 : 120);
+  const cost = (tokIn * 3 + tokOut * 15) / 1e6;
+
+  // waterfall phases — what actually ran in this turn, in order, with timings
+  const phases = [{ label: '컨텍스트 조립', kind: 'ctx', dur: 0.16 }];
+  const reasonN = trace.filter(s => s.kind === 'reason' || s.kind === 'think').length;
+  if (reasonN) phases.push({ label: '추론 · 계획', kind: 'reason', dur: Math.round((0.6 + reasonN * 0.35) * 100) / 100 });
+  tools.forEach(t => phases.push({ label: t.name, kind: 'tool', mono: true, status: t.status, dur: secOf(t.dur) }));
+  const genSec = Math.max(0.4, Math.round((tokOut / 52) * 100) / 100);
+  phases.push({ label: '응답 생성', kind: 'gen', dur: genSec });
+  let acc = 0; const total = phases.reduce((s, p) => s + p.dur, 0);
+  phases.forEach(p => { p.offset = acc; acc += p.dur; });
+
+  const systemPrompt =
+`당신은 MASC 코디네이션 서버의 keeper "${keeper.id}" 입니다.
+namespace       : ${keeper.ns}
+runtime · model : ${keeper.runtime} · ${keeper.model}
+state(12-FSM)   : ${keeper.phase}
+
+원칙
+- 모든 작업은 trace 로 기록한다.
+- 컨텍스트 사용량이 85% 를 넘으면 compact() 를 호출한다.
+- 소유하지 않은 태스크는 핸드오프(HandingOff)로 넘긴다.
+- 답변은 근거(도구 결과·trace)를 함께 제시한다.
+
+available tools
+  masc_amplitude_query · masc_trace_window · masc_board_metrics
+  masc_git_blame · masc_handoff · masc_compact`;
+
+  const injectedCtx =
+`# namespace snapshot
+namespace      = ${keeper.ns}
+fsm.state      = ${keeper.phase}
+ctx.window     = ${ctxPct}%   (${tokIn.toLocaleString()} / 200,000 tok)
+owned.tasks    = ${tasks.length}
+
+# owned tasks
+${tasks.length ? tasks.map(t => `  - ${t.id}  ${t.title}  [${t.state}]`).join('\n') : '  (none)'}
+
+# recent traces (last 30m)
+${(window.RECENT_TOOLS || []).map(t => `  - ${t.name}  ${t.dur}  (${t.ago} ago)`).join('\n')}
+
+# memory / pinned notes
+  - retention 정의: D0 = 가입일, 첫 세션 기준
+  - gp:center_type 분류 미정값 다수 (확인 필요)`;
+
+  return { traceId, tasks, tools, ctxPct, tokIn, tokOut, cost, phases, total, systemPrompt, injectedCtx };
+}
+
+/* ── tabs ─────────────────────────────────────────────────────── */
+function TimelineTab({ t }) {
+  return (
+    <div className="turn-sec">
+      <div className="ti-sec-h">
+        <h4>턴 워터폴</h4>
+        <span className="n">{t.phases.length} 단계 · {t.total.toFixed(2)}s</span>
+      </div>
+      <div className="ti-wf">
+        {t.phases.map((p, i) => (
+          <div key={i} className="ti-wf-row">
+            <div className="ti-wf-lbl">
+              <span className={`ti-wf-ico ti-k-${p.kind}`}></span>
+              <span className={`nm ${p.mono ? 'mono' : ''}`}>{p.label}</span>
+            </div>
+            <div className="ti-wf-track">
+              <div className={`ti-wf-bar ti-k-${p.kind}`}
+                style={{ left: (p.offset / t.total * 100) + '%', width: Math.max(0.6, p.dur / t.total * 100) + '%' }}></div>
+            </div>
+            <span className="ti-wf-dur">{p.dur.toFixed(2)}s</span>
+          </div>
+        ))}
+      </div>
+      <div className="ti-wf-foot">
+        <div className="ti-wf-legend">
+          <span><i className="ti-k-reason"></i>추론</span>
+          <span><i className="ti-k-tool"></i>도구</span>
+          <span><i className="ti-k-gen"></i>생성</span>
+        </div>
+        <span>총 소요 <b>{t.total.toFixed(2)}s</b></span>
+      </div>
+    </div>
+  );
+}
+
+function MessagesTab({ keeper, m, t }) {
+  let seq = 0;
+  return (
+    <div className="turn-sec">
+      <div className="ti-sec-h">
+        <h4>모델에 전달된 시퀀스</h4>
+        <span className="n">{3 + t.tools.length + 1} 메시지</span>
+      </div>
+      <div className="ti-seq-rail">
+        <div className="ti-msg">
+          <div className="ti-msg-h"><span className="ti-msg-role system">system</span><span className="who">시스템 프롬프트</span><span className="seq">#{++seq}</span></div>
+          <div className="ti-msg-b mono">{t.systemPrompt}</div>
+        </div>
+        <div className="ti-msg">
+          <div className="ti-msg-h"><span className="ti-msg-role system">context</span><span className="who">주입 컨텍스트</span><span className="seq">#{++seq}</span></div>
+          <div className="ti-msg-b mono">{t.injectedCtx}</div>
+        </div>
+        <div className="ti-msg">
+          <div className="ti-msg-h"><span className="ti-msg-role user">user</span><span className="who">operator</span><span className="seq">#{++seq}</span></div>
+          <div className="ti-msg-b">{m.promptEcho || '[직전 operator 요청 — 본 대화의 사용자 메시지]'}</div>
+        </div>
+        {t.tools.map((tool, i) => (
+          <div key={i} className="ti-tool">
+            <div className="ti-tool-h">
+              <span className="seq">#{++seq}</span>
+              <span className="tnm">{tool.name}</span>
+              <span className={`pill ${tool.status === 'ok' ? 'ok' : 'bad'}`}>{tool.status === 'ok' ? 'success' : 'error'}</span>
+              <span className="lat">{tool.dur}</span>
+            </div>
+            <div className="ti-tool-b">
+              <CodeCard cap="요청 · args" text={JSON.stringify(tool.args, null, 2)} html={tiJsonHl(tool.args)} tokens={approxTokens(JSON.stringify(tool.args))} />
+              <CodeCard cap="응답 · result" text={tool.result} html={String(tool.result).replace(/("[^"]+")/g, '<span class="js">$1</span>')} tokens={approxTokens(tool.result)} />
+            </div>
+          </div>
+        ))}
+        <div className="ti-msg">
+          <div className="ti-msg-h"><span className="ti-msg-role assistant">assistant</span><span className="who">{keeper.id}</span><span className="seq">#{++seq}</span></div>
+          <div className="ti-msg-b">{blocksToText(m.blocks)}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ContextTab({ t }) {
+  return (
+    <React.Fragment>
+      <div className="turn-sec">
+        <div className="ti-ctx-card">
+          <div className="ti-ctx-h">
+            <span className="t">시스템 프롬프트</span>
+            <span className="tok">~{approxTokens(t.systemPrompt)} tok</span>
+            <CopyBtn text={t.systemPrompt} />
+          </div>
+          <pre>{t.systemPrompt}</pre>
+        </div>
+      </div>
+      <div className="turn-sec">
+        <div className="ti-ctx-card">
+          <div className="ti-ctx-h">
+            <span className="t">주입 컨텍스트 · namespace · tasks · traces · memory</span>
+            <span className="tok">~{approxTokens(t.injectedCtx)} tok</span>
+            <CopyBtn text={t.injectedCtx} />
+          </div>
+          <pre>{t.injectedCtx}</pre>
+        </div>
+      </div>
+    </React.Fragment>
+  );
+}
+
+function MetaTab({ keeper, m, t }) {
+  return (
+    <div className="turn-sec">
+      <div className="ti-sec-h"><h4>샘플링 파라미터</h4></div>
+      <div className="ti-params">
+        <span className="ti-param">temperature<b>0.3</b></span>
+        <span className="ti-param">top_p<b>0.95</b></span>
+        <span className="ti-param">max_tokens<b>4,096</b></span>
+        <span className="ti-param">stop<b>—</b></span>
+      </div>
+      <div className="ti-sec-h" style={{ marginTop: '16px' }}><h4>실행 메타데이터</h4></div>
+      <div className="turn-kv">
+        <span className="k">model</span><span className="v">{keeper.model}</span>
+        <span className="k">runtime</span><span className="v">{keeper.runtime}</span>
+        <span className="k">namespace</span><span className="v">{keeper.ns}</span>
+        <span className="k">fsm.state</span><span className="v">{keeper.phase}</span>
+        <span className="k">input tokens</span><span className="v">{t.tokIn.toLocaleString()}</span>
+        <span className="k">output tokens</span><span className="v">{t.tokOut.toLocaleString()}</span>
+        <span className="k">ctx window</span><span className="v">{t.ctxPct}% / 200K</span>
+        <span className="k">tool calls</span><span className="v">{t.tools.length}</span>
+        <span className="k">duration</span><span className="v">{t.total.toFixed(2)}s</span>
+        <span className="k">est. cost</span><span className="v">${t.cost.toFixed(3)}</span>
+        <span className="k">finish_reason</span><span className="v">stop</span>
+        <span className="k">verified</span><span className="v">{m.verified ? 'pass \u2713' : '—'}</span>
+        <span className="k">source</span><span className="v">{m.source}</span>
+      </div>
+    </div>
+  );
+}
+
+/* ── shell ────────────────────────────────────────────────────── */
+function TurnInspector({ keeper, m, onClose }) {
+  const [tab, setTab] = useTurnState('timeline');
+  const t = buildTurn(keeper, m);
+
+  useTurnEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') { e.stopPropagation(); onClose(); } };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  return (
+    <div className="turn-overlay" onClick={onClose}>
+      <div className="turn-drawer ti-drawer" onClick={(e) => e.stopPropagation()}>
+        <div className="turn-hd">
+          <h3>턴 상세</h3>
+          <span className="tid mono">{t.traceId}</span>
+          <CopyBtn text={t.traceId} label="ID" />
+          <button className="turn-close" onClick={onClose} title="닫기 (Esc)" style={{ marginLeft: '8px' }}>{'\u2715'}</button>
+        </div>
+
+        <div className="ti-sub">
+          <span className="ti-chip"><span className="sub-k">model</span>{keeper.model}</span>
+          <span className="ti-chip ok"><StatusDot status="run" />stop</span>
+          <span className="ti-chip"><span className="sub-k">runtime</span>{keeper.runtime.split('·')[0]}</span>
+        </div>
+
+        <div className="ti-summary">
+          <div className="ti-stat"><div className="k">소요</div><div className="v">{t.total.toFixed(1)}<small>s</small></div></div>
+          <div className="ti-stat"><div className="k">입력</div><div className="v">{(t.tokIn / 1000).toFixed(1)}<small>k</small></div></div>
+          <div className="ti-stat"><div className="k">출력</div><div className="v volt">{t.tokOut.toLocaleString()}</div></div>
+          <div className="ti-stat"><div className="k">도구</div><div className="v">{t.tools.length}</div></div>
+          <div className="ti-stat"><div className="k">추정비용</div><div className="v ok">${t.cost.toFixed(2)}</div></div>
+        </div>
+
+        <div className="ti-tok">
+          <div className="ti-tok-top">
+            <span className="lbl">토큰 경제</span>
+            <span className="ctxpct">컨텍스트 {t.ctxPct}% / 200K</span>
+          </div>
+          <div className="ti-tok-bar">
+            <span className="seg-in" style={{ width: (t.tokIn / (t.tokIn + t.tokOut) * 100) + '%' }}></span>
+            <span className="seg-out" style={{ width: (t.tokOut / (t.tokIn + t.tokOut) * 100) + '%' }}></span>
+          </div>
+          <div className="ti-tok-legend">
+            <span className="in"><i></i>입력 <b>{t.tokIn.toLocaleString()}</b></span>
+            <span className="out"><i></i>출력 <b>{t.tokOut.toLocaleString()}</b></span>
+          </div>
+        </div>
+
+        <div className="turn-tabs">
+          {[['timeline', '타임라인'], ['messages', '메시지'], ['context', '컨텍스트'], ['meta', '메타']].map(([id, lbl]) => (
+            <button key={id} className={`turn-tab ${tab === id ? 'on' : ''}`} onClick={() => setTab(id)}>{lbl}</button>
+          ))}
+        </div>
+
+        <div className="turn-body">
+          {tab === 'timeline' && <TimelineTab t={t} />}
+          {tab === 'messages' && <MessagesTab keeper={keeper} m={m} t={t} />}
+          {tab === 'context' && <ContextTab t={t} />}
+          {tab === 'meta' && <MetaTab keeper={keeper} m={m} t={t} />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { TurnInspector });

--- a/dashboard/v2/tweaks-panel.jsx
+++ b/dashboard/v2/tweaks-panel.jsx
@@ -1,0 +1,541 @@
+// @ds-adherence-ignore -- omelette starter scaffold (raw elements/hex/px by design)
+
+/* BEGIN USAGE */
+// tweaks-panel.jsx
+// Reusable Tweaks shell + form-control helpers.
+// Exports (to window): useTweaks, TweaksPanel, TweakSection, TweakRow, TweakSlider,
+//   TweakToggle, TweakRadio, TweakSelect, TweakText, TweakNumber, TweakColor, TweakButton.
+//
+// Owns the host protocol (listens for __activate_edit_mode / __deactivate_edit_mode,
+// posts __edit_mode_available / __edit_mode_set_keys / __edit_mode_dismissed) so
+// individual prototypes don't re-roll it. Ships a consistent set of controls so you
+// don't hand-draw <input type="range">, segmented radios, steppers, etc.
+//
+// Usage (in an HTML file that loads React + Babel):
+//
+//   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+//     "primaryColor": "#D97757",
+//     "palette": ["#D97757", "#29261b", "#f6f4ef"],
+//     "fontSize": 16,
+//     "density": "regular",
+//     "dark": false
+//   }/*EDITMODE-END*/;
+//
+//   function App() {
+//     const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+//     return (
+//       <div style={{ fontSize: t.fontSize, color: t.primaryColor }}>
+//         Hello
+//         <TweaksPanel>
+//           <TweakSection label="Typography" />
+//           <TweakSlider label="Font size" value={t.fontSize} min={10} max={32} unit="px"
+//                        onChange={(v) => setTweak('fontSize', v)} />
+//           <TweakRadio  label="Density" value={t.density}
+//                        options={['compact', 'regular', 'comfy']}
+//                        onChange={(v) => setTweak('density', v)} />
+//           <TweakSection label="Theme" />
+//           <TweakColor  label="Primary" value={t.primaryColor}
+//                        options={['#D97757', '#2A6FDB', '#1F8A5B', '#7A5AE0']}
+//                        onChange={(v) => setTweak('primaryColor', v)} />
+//           <TweakColor  label="Palette" value={t.palette}
+//                        options={[['#D97757', '#29261b', '#f6f4ef'],
+//                                  ['#475569', '#0f172a', '#f1f5f9']]}
+//                        onChange={(v) => setTweak('palette', v)} />
+//           <TweakToggle label="Dark mode" value={t.dark}
+//                        onChange={(v) => setTweak('dark', v)} />
+//         </TweaksPanel>
+//       </div>
+//     );
+//   }
+//
+// TweakRadio is the segmented control for 2–3 short options (auto-falls-back to
+// TweakSelect past ~16/~10 chars per label); reach for TweakSelect directly when
+// options are many or long. For color tweaks always curate 3-4 options rather than
+// a free picker; an option can also be a whole 2–5 color palette (the stored value
+// is the array). The Tweak* controls are a floor, not a ceiling — build custom
+// controls inside the panel if a tweak calls for UI they don't cover.
+/* END USAGE */
+// ─────────────────────────────────────────────────────────────────────────────
+
+const __TWEAKS_STYLE = `
+  .twk-panel{position:fixed;right:16px;bottom:16px;z-index:2147483646;width:280px;
+    max-height:calc(100vh - 32px);display:flex;flex-direction:column;
+    transform:scale(var(--dc-inv-zoom,1));transform-origin:bottom right;
+    background:rgba(250,249,247,.78);color:#29261b;
+    -webkit-backdrop-filter:blur(24px) saturate(160%);backdrop-filter:blur(24px) saturate(160%);
+    border:.5px solid rgba(255,255,255,.6);border-radius:14px;
+    box-shadow:0 1px 0 rgba(255,255,255,.5) inset,0 12px 40px rgba(0,0,0,.18);
+    font:11.5px/1.4 ui-sans-serif,system-ui,-apple-system,sans-serif;overflow:hidden}
+  .twk-hd{display:flex;align-items:center;justify-content:space-between;
+    padding:10px 8px 10px 14px;cursor:move;user-select:none}
+  .twk-hd b{font-size:12px;font-weight:600;letter-spacing:.01em}
+  .twk-x{appearance:none;border:0;background:transparent;color:rgba(41,38,27,.55);
+    width:22px;height:22px;border-radius:6px;cursor:default;font-size:13px;line-height:1}
+  .twk-x:hover{background:rgba(0,0,0,.06);color:#29261b}
+  .twk-body{padding:2px 14px 14px;display:flex;flex-direction:column;gap:10px;
+    overflow-y:auto;overflow-x:hidden;min-height:0;
+    scrollbar-width:thin;scrollbar-color:rgba(0,0,0,.15) transparent}
+  .twk-body::-webkit-scrollbar{width:8px}
+  .twk-body::-webkit-scrollbar-track{background:transparent;margin:2px}
+  .twk-body::-webkit-scrollbar-thumb{background:rgba(0,0,0,.15);border-radius:4px;
+    border:2px solid transparent;background-clip:content-box}
+  .twk-body::-webkit-scrollbar-thumb:hover{background:rgba(0,0,0,.25);
+    border:2px solid transparent;background-clip:content-box}
+  .twk-row{display:flex;flex-direction:column;gap:5px}
+  .twk-row-h{flex-direction:row;align-items:center;justify-content:space-between;gap:10px}
+  .twk-lbl{display:flex;justify-content:space-between;align-items:baseline;
+    color:rgba(41,38,27,.72)}
+  .twk-lbl>span:first-child{font-weight:500}
+  .twk-val{color:rgba(41,38,27,.5);font-variant-numeric:tabular-nums}
+
+  .twk-sect{font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;
+    color:rgba(41,38,27,.45);padding:10px 0 0}
+  .twk-sect:first-child{padding-top:0}
+
+  .twk-field{appearance:none;box-sizing:border-box;width:100%;min-width:0;height:26px;padding:0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;
+    background:rgba(255,255,255,.6);color:inherit;font:inherit;outline:none}
+  .twk-field:focus{border-color:rgba(0,0,0,.25);background:rgba(255,255,255,.85)}
+  select.twk-field{padding-right:22px;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='rgba(0,0,0,.5)' d='M0 0h10L5 6z'/></svg>");
+    background-repeat:no-repeat;background-position:right 8px center}
+
+  .twk-slider{appearance:none;-webkit-appearance:none;width:100%;height:4px;margin:6px 0;
+    border-radius:999px;background:rgba(0,0,0,.12);outline:none}
+  .twk-slider::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;
+    width:14px;height:14px;border-radius:50%;background:#fff;
+    border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+  .twk-slider::-moz-range-thumb{width:14px;height:14px;border-radius:50%;
+    background:#fff;border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+
+  .twk-seg{position:relative;display:flex;padding:2px;border-radius:8px;
+    background:rgba(0,0,0,.06);user-select:none}
+  .twk-seg-thumb{position:absolute;top:2px;bottom:2px;border-radius:6px;
+    background:rgba(255,255,255,.9);box-shadow:0 1px 2px rgba(0,0,0,.12);
+    transition:left .15s cubic-bezier(.3,.7,.4,1),width .15s}
+  .twk-seg.dragging .twk-seg-thumb{transition:none}
+  .twk-seg button{appearance:none;position:relative;z-index:1;flex:1;border:0;
+    background:transparent;color:inherit;font:inherit;font-weight:500;min-height:22px;
+    border-radius:6px;cursor:default;padding:4px 6px;line-height:1.2;
+    overflow-wrap:anywhere}
+
+  .twk-toggle{position:relative;width:32px;height:18px;border:0;border-radius:999px;
+    background:rgba(0,0,0,.15);transition:background .15s;cursor:default;padding:0}
+  .twk-toggle[data-on="1"]{background:#34c759}
+  .twk-toggle i{position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;
+    background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.25);transition:transform .15s}
+  .twk-toggle[data-on="1"] i{transform:translateX(14px)}
+
+  .twk-num{display:flex;align-items:center;box-sizing:border-box;min-width:0;height:26px;padding:0 0 0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;background:rgba(255,255,255,.6)}
+  .twk-num-lbl{font-weight:500;color:rgba(41,38,27,.6);cursor:ew-resize;
+    user-select:none;padding-right:8px}
+  .twk-num input{flex:1;min-width:0;height:100%;border:0;background:transparent;
+    font:inherit;font-variant-numeric:tabular-nums;text-align:right;padding:0 8px 0 0;
+    outline:none;color:inherit;-moz-appearance:textfield}
+  .twk-num input::-webkit-inner-spin-button,.twk-num input::-webkit-outer-spin-button{
+    -webkit-appearance:none;margin:0}
+  .twk-num-unit{padding-right:8px;color:rgba(41,38,27,.45)}
+
+  .twk-btn{appearance:none;height:26px;padding:0 12px;border:0;border-radius:7px;
+    background:rgba(0,0,0,.78);color:#fff;font:inherit;font-weight:500;cursor:default}
+  .twk-btn:hover{background:rgba(0,0,0,.88)}
+  .twk-btn.secondary{background:rgba(0,0,0,.06);color:inherit}
+  .twk-btn.secondary:hover{background:rgba(0,0,0,.1)}
+
+  .twk-swatch{appearance:none;-webkit-appearance:none;width:56px;height:22px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:6px;padding:0;cursor:default;
+    background:transparent;flex-shrink:0}
+  .twk-swatch::-webkit-color-swatch-wrapper{padding:0}
+  .twk-swatch::-webkit-color-swatch{border:0;border-radius:5.5px}
+  .twk-swatch::-moz-color-swatch{border:0;border-radius:5.5px}
+
+  .twk-chips{display:flex;gap:6px}
+  .twk-chip{position:relative;appearance:none;flex:1;min-width:0;height:46px;
+    padding:0;border:0;border-radius:6px;overflow:hidden;cursor:default;
+    box-shadow:0 0 0 .5px rgba(0,0,0,.12),0 1px 2px rgba(0,0,0,.06);
+    transition:transform .12s cubic-bezier(.3,.7,.4,1),box-shadow .12s}
+  .twk-chip:hover{transform:translateY(-1px);
+    box-shadow:0 0 0 .5px rgba(0,0,0,.18),0 4px 10px rgba(0,0,0,.12)}
+  .twk-chip[data-on="1"]{box-shadow:0 0 0 1.5px rgba(0,0,0,.85),
+    0 2px 6px rgba(0,0,0,.15)}
+  .twk-chip>span{position:absolute;top:0;bottom:0;right:0;width:34%;
+    display:flex;flex-direction:column;box-shadow:-1px 0 0 rgba(0,0,0,.1)}
+  .twk-chip>span>i{flex:1;box-shadow:0 -1px 0 rgba(0,0,0,.1)}
+  .twk-chip>span>i:first-child{box-shadow:none}
+  .twk-chip svg{position:absolute;top:6px;left:6px;width:13px;height:13px;
+    filter:drop-shadow(0 1px 1px rgba(0,0,0,.3))}
+`;
+
+// ── useTweaks ───────────────────────────────────────────────────────────────
+// Single source of truth for tweak values. setTweak persists via the host
+// (__edit_mode_set_keys → host rewrites the EDITMODE block on disk).
+function useTweaks(defaults) {
+  const [values, setValues] = React.useState(defaults);
+  // Accepts either setTweak('key', value) or setTweak({ key: value, ... }) so a
+  // useState-style call doesn't write a "[object Object]" key into the persisted
+  // JSON block.
+  const setTweak = React.useCallback((keyOrEdits, val) => {
+    const edits = typeof keyOrEdits === 'object' && keyOrEdits !== null
+      ? keyOrEdits : { [keyOrEdits]: val };
+    setValues((prev) => ({ ...prev, ...edits }));
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits }, '*');
+    // Same-window signal so in-page listeners (deck-stage rail thumbnails)
+    // can react — the parent message only reaches the host, not peers.
+    window.dispatchEvent(new CustomEvent('tweakchange', { detail: edits }));
+  }, []);
+  return [values, setTweak];
+}
+
+// ── TweaksPanel ─────────────────────────────────────────────────────────────
+// Floating shell. Registers the protocol listener BEFORE announcing
+// availability — if the announce ran first, the host's activate could land
+// before our handler exists and the toolbar toggle would silently no-op.
+// The close button posts __edit_mode_dismissed so the host's toolbar toggle
+// flips off in lockstep; the host echoes __deactivate_edit_mode back which
+// is what actually hides the panel.
+function TweaksPanel({ title = 'Tweaks', children }) {
+  const [open, setOpen] = React.useState(false);
+  const dragRef = React.useRef(null);
+  const offsetRef = React.useRef({ x: 16, y: 16 });
+  const PAD = 16;
+
+  const clampToViewport = React.useCallback(() => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const w = panel.offsetWidth, h = panel.offsetHeight;
+    const maxRight = Math.max(PAD, window.innerWidth - w - PAD);
+    const maxBottom = Math.max(PAD, window.innerHeight - h - PAD);
+    offsetRef.current = {
+      x: Math.min(maxRight, Math.max(PAD, offsetRef.current.x)),
+      y: Math.min(maxBottom, Math.max(PAD, offsetRef.current.y)),
+    };
+    panel.style.right = offsetRef.current.x + 'px';
+    panel.style.bottom = offsetRef.current.y + 'px';
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) return;
+    clampToViewport();
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', clampToViewport);
+      return () => window.removeEventListener('resize', clampToViewport);
+    }
+    const ro = new ResizeObserver(clampToViewport);
+    ro.observe(document.documentElement);
+    return () => ro.disconnect();
+  }, [open, clampToViewport]);
+
+  React.useEffect(() => {
+    const onMsg = (e) => {
+      const t = e?.data?.type;
+      if (t === '__activate_edit_mode') setOpen(true);
+      else if (t === '__deactivate_edit_mode') setOpen(false);
+    };
+    window.addEventListener('message', onMsg);
+    window.parent.postMessage({ type: '__edit_mode_available' }, '*');
+    return () => window.removeEventListener('message', onMsg);
+  }, []);
+
+  const dismiss = () => {
+    setOpen(false);
+    window.parent.postMessage({ type: '__edit_mode_dismissed' }, '*');
+  };
+
+  const onDragStart = (e) => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const r = panel.getBoundingClientRect();
+    const sx = e.clientX, sy = e.clientY;
+    const startRight = window.innerWidth - r.right;
+    const startBottom = window.innerHeight - r.bottom;
+    const move = (ev) => {
+      offsetRef.current = {
+        x: startRight - (ev.clientX - sx),
+        y: startBottom - (ev.clientY - sy),
+      };
+      clampToViewport();
+    };
+    const up = () => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+
+  if (!open) return null;
+  return (
+    <>
+      <style>{__TWEAKS_STYLE}</style>
+      <div ref={dragRef} className="twk-panel" data-omelette-chrome=""
+           style={{ right: offsetRef.current.x, bottom: offsetRef.current.y }}>
+        <div className="twk-hd" onMouseDown={onDragStart}>
+          <b>{title}</b>
+          <button className="twk-x" aria-label="Close tweaks"
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={dismiss}>✕</button>
+        </div>
+        <div className="twk-body">
+          {children}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Layout helpers ──────────────────────────────────────────────────────────
+
+function TweakSection({ label, children }) {
+  return (
+    <>
+      <div className="twk-sect">{label}</div>
+      {children}
+    </>
+  );
+}
+
+function TweakRow({ label, value, children, inline = false }) {
+  return (
+    <div className={inline ? 'twk-row twk-row-h' : 'twk-row'}>
+      <div className="twk-lbl">
+        <span>{label}</span>
+        {value != null && <span className="twk-val">{value}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Controls ────────────────────────────────────────────────────────────────
+
+function TweakSlider({ label, value, min = 0, max = 100, step = 1, unit = '', onChange }) {
+  return (
+    <TweakRow label={label} value={`${value}${unit}`}>
+      <input type="range" className="twk-slider" min={min} max={max} step={step}
+             value={value} onChange={(e) => onChange(Number(e.target.value))} />
+    </TweakRow>
+  );
+}
+
+function TweakToggle({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <button type="button" className="twk-toggle" data-on={value ? '1' : '0'}
+              role="switch" aria-checked={!!value}
+              onClick={() => onChange(!value)}><i /></button>
+    </div>
+  );
+}
+
+function TweakRadio({ label, value, options, onChange }) {
+  const trackRef = React.useRef(null);
+  const [dragging, setDragging] = React.useState(false);
+  // The active value is read by pointer-move handlers attached for the lifetime
+  // of a drag — ref it so a stale closure doesn't fire onChange for every move.
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+
+  // Segments wrap mid-word once per-segment width runs out. The track is
+  // ~248px (280 panel − 28 body pad − 4 seg pad), each button loses 12px
+  // to its own padding, and 11.5px system-ui averages ~6.3px/char — so 2
+  // options fit ~16 chars each, 3 fit ~10. Past that (or >3 options), fall
+  // back to a dropdown rather than wrap.
+  const labelLen = (o) => String(typeof o === 'object' ? o.label : o).length;
+  const maxLen = options.reduce((m, o) => Math.max(m, labelLen(o)), 0);
+  const fitsAsSegments = maxLen <= ({ 2: 16, 3: 10 }[options.length] ?? 0);
+  if (!fitsAsSegments) {
+    // <select> emits strings — map back to the original option value so the
+    // fallback stays type-preserving (numbers, booleans) like the segment path.
+    const resolve = (s) => {
+      const m = options.find((o) => String(typeof o === 'object' ? o.value : o) === s);
+      return m === undefined ? s : typeof m === 'object' ? m.value : m;
+    };
+    return <TweakSelect label={label} value={value} options={options}
+                        onChange={(s) => onChange(resolve(s))} />;
+  }
+  const opts = options.map((o) => (typeof o === 'object' ? o : { value: o, label: o }));
+  const idx = Math.max(0, opts.findIndex((o) => o.value === value));
+  const n = opts.length;
+
+  const segAt = (clientX) => {
+    const r = trackRef.current.getBoundingClientRect();
+    const inner = r.width - 4;
+    const i = Math.floor(((clientX - r.left - 2) / inner) * n);
+    return opts[Math.max(0, Math.min(n - 1, i))].value;
+  };
+
+  const onPointerDown = (e) => {
+    setDragging(true);
+    const v0 = segAt(e.clientX);
+    if (v0 !== valueRef.current) onChange(v0);
+    const move = (ev) => {
+      if (!trackRef.current) return;
+      const v = segAt(ev.clientX);
+      if (v !== valueRef.current) onChange(v);
+    };
+    const up = () => {
+      setDragging(false);
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  return (
+    <TweakRow label={label}>
+      <div ref={trackRef} role="radiogroup" onPointerDown={onPointerDown}
+           className={dragging ? 'twk-seg dragging' : 'twk-seg'}>
+        <div className="twk-seg-thumb"
+             style={{ left: `calc(2px + ${idx} * (100% - 4px) / ${n})`,
+                      width: `calc((100% - 4px) / ${n})` }} />
+        {opts.map((o) => (
+          <button key={o.value} type="button" role="radio" aria-checked={o.value === value}>
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakSelect({ label, value, options, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <select className="twk-field" value={value} onChange={(e) => onChange(e.target.value)}>
+        {options.map((o) => {
+          const v = typeof o === 'object' ? o.value : o;
+          const l = typeof o === 'object' ? o.label : o;
+          return <option key={v} value={v}>{l}</option>;
+        })}
+      </select>
+    </TweakRow>
+  );
+}
+
+function TweakText({ label, value, placeholder, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <input className="twk-field" type="text" value={value} placeholder={placeholder}
+             onChange={(e) => onChange(e.target.value)} />
+    </TweakRow>
+  );
+}
+
+function TweakNumber({ label, value, min, max, step = 1, unit = '', onChange }) {
+  const clamp = (n) => {
+    if (min != null && n < min) return min;
+    if (max != null && n > max) return max;
+    return n;
+  };
+  const startRef = React.useRef({ x: 0, val: 0 });
+  const onScrubStart = (e) => {
+    e.preventDefault();
+    startRef.current = { x: e.clientX, val: value };
+    const decimals = (String(step).split('.')[1] || '').length;
+    const move = (ev) => {
+      const dx = ev.clientX - startRef.current.x;
+      const raw = startRef.current.val + dx * step;
+      const snapped = Math.round(raw / step) * step;
+      onChange(clamp(Number(snapped.toFixed(decimals))));
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+  return (
+    <div className="twk-num">
+      <span className="twk-num-lbl" onPointerDown={onScrubStart}>{label}</span>
+      <input type="number" value={value} min={min} max={max} step={step}
+             onChange={(e) => onChange(clamp(Number(e.target.value)))} />
+      {unit && <span className="twk-num-unit">{unit}</span>}
+    </div>
+  );
+}
+
+// Relative-luminance contrast pick — checkmarks drawn over a swatch need to
+// read on both #111 and #fafafa without per-option configuration. Hex input
+// only (#rgb / #rrggbb); named or rgb()/hsl() colors fall through to "light".
+function __twkIsLight(hex) {
+  const h = String(hex).replace('#', '');
+  const x = h.length === 3 ? h.replace(/./g, (c) => c + c) : h.padEnd(6, '0');
+  const n = parseInt(x.slice(0, 6), 16);
+  if (Number.isNaN(n)) return true;
+  const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255;
+  return r * 299 + g * 587 + b * 114 > 148000;
+}
+
+const __TwkCheck = ({ light }) => (
+  <svg viewBox="0 0 14 14" aria-hidden="true">
+    <path d="M3 7.2 5.8 10 11 4.2" fill="none" strokeWidth="2.2"
+          strokeLinecap="round" strokeLinejoin="round"
+          stroke={light ? 'rgba(0,0,0,.78)' : '#fff'} />
+  </svg>
+);
+
+// TweakColor — curated color/palette picker. Each option is either a single
+// hex string or an array of 1-5 hex strings; the card adapts — a lone color
+// renders solid, a palette renders colors[0] as the hero (left ~2/3) with the
+// rest stacked in a sharp column on the right. onChange emits the
+// option in the shape it was passed (string stays string, array stays array).
+// Without options it falls back to the native color input for back-compat.
+function TweakColor({ label, value, options, onChange }) {
+  if (!options || !options.length) {
+    return (
+      <div className="twk-row twk-row-h">
+        <div className="twk-lbl"><span>{label}</span></div>
+        <input type="color" className="twk-swatch" value={value}
+               onChange={(e) => onChange(e.target.value)} />
+      </div>
+    );
+  }
+  // Native <input type=color> emits lowercase hex per the HTML spec, so
+  // compare case-insensitively. String() guards JSON.stringify(undefined),
+  // which returns the primitive undefined (no .toLowerCase).
+  const key = (o) => String(JSON.stringify(o)).toLowerCase();
+  const cur = key(value);
+  return (
+    <TweakRow label={label}>
+      <div className="twk-chips" role="radiogroup">
+        {options.map((o, i) => {
+          const colors = Array.isArray(o) ? o : [o];
+          const [hero, ...rest] = colors;
+          const sup = rest.slice(0, 4);
+          const on = key(o) === cur;
+          return (
+            <button key={i} type="button" className="twk-chip" role="radio"
+                    aria-checked={on} data-on={on ? '1' : '0'}
+                    aria-label={colors.join(', ')} title={colors.join(' · ')}
+                    style={{ background: hero }}
+                    onClick={() => onChange(o)}>
+              {sup.length > 0 && (
+                <span>
+                  {sup.map((c, j) => <i key={j} style={{ background: c }} />)}
+                </span>
+              )}
+              {on && <__TwkCheck light={__twkIsLight(hero)} />}
+            </button>
+          );
+        })}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakButton({ label, onClick, secondary = false }) {
+  return (
+    <button type="button" className={secondary ? 'twk-btn secondary' : 'twk-btn'}
+            onClick={onClick}>{label}</button>
+  );
+}
+
+Object.assign(window, {
+  useTweaks, TweaksPanel, TweakSection, TweakRow,
+  TweakSlider, TweakToggle, TweakRadio, TweakSelect,
+  TweakText, TweakNumber, TweakColor, TweakButton,
+});

--- a/dashboard/v2/work.jsx
+++ b/dashboard/v2/work.jsx
@@ -1,0 +1,124 @@
+/* MASC v2 — Work surface: goal tree → jobs → keeper.
+   Goal 은 작업 위계의 꼭대기. 하나의 goal 이 여러 job 으로 쪼개지고, 각 job 을 keeper 가 소유한다. */
+const { useState: useWkState } = React;
+
+const JOB_STATE = {
+  done:          { lbl: '완료',   cls: 'done' },
+  'in-progress': { lbl: '진행 중', cls: 'wip' },
+  review:        { lbl: '리뷰',   cls: 'review' },
+  blocked:       { lbl: '막힘',   cls: 'blocked' },
+  todo:          { lbl: '대기',   cls: 'todo' },
+};
+const WK_PRIORITY = {
+  high:   { lbl: '높음', cls: 'high' },
+  normal: { lbl: '보통', cls: 'normal' },
+  low:    { lbl: '낮음', cls: 'low' },
+};
+
+function wkKeeper(id) { return (window.KEEPERS || []).find(k => k.id === id); }
+
+function GoalProgress({ jobs }) {
+  const n = jobs.length || 1;
+  let done = 0, wip = 0, blocked = 0;
+  jobs.forEach(j => {
+    if (j.state === 'done') done++;
+    else if (j.state === 'blocked') blocked++;
+    else if (j.state === 'in-progress' || j.state === 'review') wip++;
+  });
+  const pct = (x) => (x / n) * 100;
+  return (
+    <div className="wk-prog">
+      <span className="wk-seg done" style={{ width: pct(done) + '%' }}></span>
+      <span className="wk-seg wip" style={{ width: pct(wip) + '%' }}></span>
+      <span className="wk-seg blocked" style={{ width: pct(blocked) + '%' }}></span>
+    </div>
+  );
+}
+
+function GoalCard({ g, open, onToggle, onOpenKeeper }) {
+  const lead = wkKeeper(g.lead);
+  const done = g.jobs.filter(j => j.state === 'done').length;
+  const blocked = g.jobs.filter(j => j.state === 'blocked').length;
+  const pr = WK_PRIORITY[g.priority] || WK_PRIORITY.normal;
+  return (
+    <div className={`wk-goal ${open ? 'open' : ''} ${blocked ? 'has-block' : ''}`}>
+      <button className="wk-goal-h" onClick={onToggle}>
+        <span className="wk-caret">{open ? '\u25BE' : '\u25B8'}</span>
+        <span className={`wk-pri ${pr.cls}`}>{pr.lbl}</span>
+        <span className="wk-goal-id mono">{g.id}</span>
+        <span className="wk-goal-title">{g.title}</span>
+        <span className="wk-goal-ns mono">{g.ns}</span>
+        <span className="wk-spacer"></span>
+        {g.due && <span className="wk-due mono">{g.due}</span>}
+        {lead && <span className="wk-lead" title={`리드 · ${lead.id}`}><SigilBadge k={lead} size={22} /></span>}
+      </button>
+      <div className="wk-goal-sub">
+        <GoalProgress jobs={g.jobs} />
+        <span className="wk-prog-lbl mono">{done}/{g.jobs.length}{blocked ? ` · 막힘 ${blocked}` : ''}</span>
+        {g.metric && <span className="wk-metric mono" title="목표 지표">{g.metric}</span>}
+      </div>
+      {open && (
+        <div className="wk-jobs">
+          {g.note && <div className="wk-note">{g.note}</div>}
+          {g.jobs.map(j => {
+            const k = wkKeeper(j.keeper);
+            const st = JOB_STATE[j.state] || JOB_STATE.todo;
+            return (
+              <div key={j.id} className={`wk-job ${st.cls}`}>
+                <span className={`wk-job-dot ${st.cls}`}></span>
+                <span className="wk-job-id mono">{j.id}</span>
+                <span className="wk-job-title">{j.title}{j.blocker && <span className="wk-job-block">{'\u26A0'} {j.blocker}</span>}</span>
+                <span className="wk-spacer"></span>
+                <span className={`wk-job-state ${st.cls}`}>{st.lbl}</span>
+                {k
+                  ? <button className="wk-job-kp" onClick={() => onOpenKeeper(k.id)} title={`${k.id} 대화 열기`}><SigilBadge k={k} size={18} /><span className="mono">{k.id}</span></button>
+                  : <span className="wk-job-kp none mono">미배정</span>}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WorkSurface({ onOpenKeeper, onNav }) {
+  const goals = window.GOALS || [];
+  const [open, setOpen] = useWkState(() => new Set(goals.filter(g => g.priority === 'high' || g.jobs.some(j => j.state === 'blocked')).map(g => g.id)));
+  const toggle = (id) => setOpen(prev => { const n = new Set(prev); if (n.has(id)) n.delete(id); else n.add(id); return n; });
+
+  const jobs = goals.reduce((a, g) => a + g.jobs.length, 0);
+  const done = goals.reduce((a, g) => a + g.jobs.filter(j => j.state === 'done').length, 0);
+  const blocked = goals.reduce((a, g) => a + g.jobs.filter(j => j.state === 'blocked').length, 0);
+
+  return (
+    <main className="ov">
+      <div className="ov-scroll">
+        <header className="ov-head">
+          <div>
+            <h1>작업 · 목표</h1>
+            <p className="ov-sub"><span title="최상위 조정 범위">namespace <span className="mono">masc-mcp</span></span> · <span>목표 {goals.length}</span> · <span>job {jobs}</span> · <span>완료 {done}</span>{blocked ? <span> · <span className="wk-blk-n">막힘 {blocked}</span></span> : null}</p>
+          </div>
+          <button className="set-add wk-newgoal" title="새 목표 생성 — 다음 단계에서 설계">{'\uFF0B'} 새 목표</button>
+        </header>
+
+        <section className="ov-kpis" style={{ gridTemplateColumns: 'repeat(4, 1fr)' }}>
+          <div className="ov-kpi"><div className="ov-kpi-k">활성 목표</div><div className="ov-kpi-v volt">{goals.length}</div></div>
+          <div className="ov-kpi"><div className="ov-kpi-k">전체 job</div><div className="ov-kpi-v">{jobs}</div></div>
+          <div className="ov-kpi"><div className="ov-kpi-k">완료</div><div className="ov-kpi-v ok">{done}</div></div>
+          <div className="ov-kpi"><div className="ov-kpi-k">막힘</div><div className={`ov-kpi-v ${blocked ? 'bad' : ''}`}>{blocked}</div></div>
+        </section>
+
+        <div className="wk-list">
+          {goals.map(g => (
+            <GoalCard key={g.id} g={g} open={open.has(g.id)} onToggle={() => toggle(g.id)} onOpenKeeper={onOpenKeeper} />
+          ))}
+        </div>
+
+        <div className="wk-foot mono">Goal → job → keeper · job 의 keeper 를 누르면 해당 keeper 대화로 이동</div>
+      </div>
+    </main>
+  );
+}
+
+Object.assign(window, { WorkSurface });


### PR DESCRIPTION
## 목표
claude.ai/design **MASC Design System**의 `keeper-v2 / Keeper Agent v2.html` 디자인 프로토타입을 레포에 **충실히(faithful)** 옮겨, 라이브 대시보드를 건드리지 않고 별도 라우트 `/dashboard/v2`에서 서빙합니다. 사용자 선택: "통째 standalone 포팅".

## 접근 — standalone, 격리, 충실
프로토타입은 import/export가 없는 ~20개 `.jsx`가 **순서대로 로드되는 classic `<script>` 전역 스코프를 공유**하고, React 18 UMD + in-browser Babel로 동작합니다. 이를 실제 빌드(브라우저 Babel 제거)로 바꾸되 메인 앱 파이프라인(Preact/Tailwind/`@preact/preset-vite`의 `react`→`preact/compat` alias)과 **0 간섭**하도록:

- `scripts/build-v2.mjs`가 각 `.jsx`를 Vite의 esbuild로 classic `.js`로 1:1 트랜스파일(번들링/모듈화 없음)해 로드 순서대로 gitignore 출력 트리 `assets/dashboard/v2/`에 배치.
- `index.html`은 그 `.js`들을 React 18 UMD 전역에 대해 로드 — 프로토타입과 동일 모델.

## 핵심 빌드 디테일 (const/let → var)
프로토타입 파일 다수가 top-level에 같은 바인딩(`const { useState } = React` 등)을 **재선언**합니다. classic script들은 전역 lexical 스코프를 공유하므로 `const`/`let`이면 "already declared" SyntaxError로 두 번째 파일이 통째로 죽습니다(초기 증상: `StatusDot`/`Avatar` undefined, 앱 미마운트). esbuild는 const/let 하향을 지원하지 않아, 빌드가 **줄 시작 const/let만 var로** 치환합니다. 중첩(들여쓰기) const/let과 `for (let …)` 헤드는 그대로 → 블록 스코프 보존. 이는 프로토타입의 in-browser Babel이 하던 block-scoping을 top-level로 한정한 것으로, 런타임 분류기나 증상 억제가 아닌 **결정론적 컴파일 단계**입니다.

## 변경 파일
- `dashboard/v2/`: 프로토타입 소스 (20 jsx + 8 css + index.html). `colors_and_type.css`의 폰트만 Google Fonts CDN으로 전환(로컬 Noto Sans KR TTF가 9.9MB라 커밋 회피; 디자인 시스템 README가 폰트 substitution 허용).
- `dashboard/scripts/build-v2.mjs`: 트랜스파일 + CSS 복사 + 레포의 기존 keeper portraits 재사용(이미지 신규 커밋 0) + index.html 복사.
- `dashboard/package.json`: `build`가 `vite build` 후 `build:v2` 실행, `build:v2` 추가.

## 바이너리/에셋 정책
- 폰트: 전부 CDN (Cinzel/EB Garamond/JetBrains Mono/Noto Sans KR/Share Tech Mono). 신규 폰트 커밋 0.
- portraits: 레포가 이미 `dashboard/public/assets/keepers/portraits/`에 보유 → 빌드 시 gitignore 출력으로 복사. 신규 PNG 커밋 0.
- 출력 `assets/dashboard/`는 기존 `.gitignore`(line 72)로 제외.

## 검증
- `build:v2` 단독 빌드 성공 (20 scripts / 8 styles / 12 portraits), 산출 .js 전부 `node --check` 통과.
- 로컬 static 서버로 7개 서피스 전부 시각 확인 + **콘솔 에러 0건**(fresh load): keepers(대화 thread/composer/context rail) · overview(KPI/텔레메트리) · work(목표/태스크) · board(피드/karma) · ide(OCaml 신택스/멀티플레이어 커서/터미널) · connectors(게이트 카드/감사로그) · settings(카테고리/계정).
- `tsc --noEmit`/`eslint src` 범위 밖(`v2/`는 tsconfig include/lint 대상 아님, allowJs off).

## 트레이드오프 / 한계
- `/dashboard/v2`는 React UMD + Google Fonts를 CDN에서 받습니다 → **오프라인 미보장**(폰트는 `--font-*` 스택으로 폴백). 필요 시 vendor로 전환 가능.
- 이 프로토타입은 **mock 데이터**(`data.jsx`)로 구동되는 디자인 레퍼런스 surface입니다(라이브 API 미연결).
- 라이브 `/dashboard`는 무변경.

## 빌드/배포
`pnpm build`(= `vite build && build:v2`) 또는 `pnpm build:v2` 단독. 출력은 `assets/dashboard/v2/`, masc 서버가 `/dashboard/v2/`로 서빙.

RFC-WAIVED: dashboard 전용 신규 격리 surface (credential/identity/operator/hooks/workflow subsystem 미접촉; 라이브 대시보드·기존 컴포넌트 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
