### PR TITLE
fix(keeper): convert unprotected global shared refs/caches to Atomic

### DIFF
--- a/lib/keeper/keeper_agent_run_phase0_telemetry.ml
+++ b/lib/keeper/keeper_agent_run_phase0_telemetry.ml
@@ -26,7 +26,7 @@ let record_if_enabled
         | [] -> "auto"
       in
       let () =
-        !Keeper_keepalive_signal.record_wake_payload_callback
+        Keeper_keepalive_signal.record_wake_payload
           ~keeper_name:meta.name
           ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
           ~turn_index:start_turn_count

--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -65,16 +65,21 @@ type pair_result =
 let store_base_dir base_path =
   Filename.concat base_path "data/harness-compact"
 
-(* One store per process. Keeps Dated_jsonl's mutex alive for append safety. *)
-let store_ref : Dated_jsonl.t option ref = ref None
+(* One store per process. Keeps Dated_jsonl's mutex alive for append safety.
+   Stored under Atomic.t so concurrent fibers/domains do not race on the lazy
+   initialisation of the store handle. *)
+let store_ref : Dated_jsonl.t option Atomic.t = Atomic.make None
 
 let get_store base_path =
-  match !store_ref with
-  | Some s when String.equal (Dated_jsonl.base_dir s) (store_base_dir base_path) -> s
-  | _ ->
-    let s = Dated_jsonl.create ~base_dir:(store_base_dir base_path) () in
-    store_ref := Some s;
-    s
+  let expected_dir = store_base_dir base_path in
+  let rec ensure () =
+    match Atomic.get store_ref with
+    | Some s when String.equal (Dated_jsonl.base_dir s) expected_dir -> s
+    | old ->
+      let s = Dated_jsonl.create ~base_dir:expected_dir () in
+      if Atomic.compare_and_set store_ref old (Some s) then s else ensure ()
+  in
+  ensure ()
 
 (* ── ID synthesis ──────────────────────────────────────────────── *)
 

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -30,7 +30,25 @@ let record_pre_compact_callback_atomic
     (fun ~keeper_name:_ ~context_ratio:_ ~message_count:_ ~token_count:_ ~strategies:_ ~context_window:_ ~is_local_model:_ ~trigger:_ -> None)
 ;;
 
-let record_pre_compact_callback = Atomic.get record_pre_compact_callback_atomic
+let record_pre_compact_callback
+    ~keeper_name
+    ~context_ratio
+    ~message_count
+    ~token_count
+    ~strategies
+    ~context_window
+    ~is_local_model
+    ~trigger
+  =
+  Atomic.get record_pre_compact_callback_atomic
+    ~keeper_name
+    ~context_ratio
+    ~message_count
+    ~token_count
+    ~strategies
+    ~context_window
+    ~is_local_model
+    ~trigger
 
 let register_record_pre_compact
     (f :

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -22,11 +22,29 @@ type pre_compact_event = {
   trigger : Compaction_trigger.t;
 }
 
-let record_pre_compact_callback : (keeper_name:string -> context_ratio:float -> message_count:int -> token_count:int -> strategies:string list -> context_window:int -> is_local_model:bool -> trigger:Compaction_trigger.t -> pre_compact_event option) ref =
-  ref (fun ~keeper_name:_ ~context_ratio:_ ~message_count:_ ~token_count:_ ~strategies:_ ~context_window:_ ~is_local_model:_ ~trigger:_ -> None)
+let record_pre_compact_callback_atomic
+    : (keeper_name:string -> context_ratio:float -> message_count:int -> token_count:int -> strategies:string list -> context_window:int -> is_local_model:bool -> trigger:Compaction_trigger.t -> pre_compact_event option)
+      Atomic.t
+  =
+  Atomic.make
+    (fun ~keeper_name:_ ~context_ratio:_ ~message_count:_ ~token_count:_ ~strategies:_ ~context_window:_ ~is_local_model:_ ~trigger:_ -> None)
+;;
 
-let register_record_pre_compact (f : (keeper_name:string -> context_ratio:float -> message_count:int -> token_count:int -> strategies:string list -> context_window:int -> is_local_model:bool -> trigger:Compaction_trigger.t -> pre_compact_event option)) =
-  record_pre_compact_callback := f
+let record_pre_compact_callback = Atomic.get record_pre_compact_callback_atomic
+
+let register_record_pre_compact
+    (f :
+       keeper_name:string
+       -> context_ratio:float
+       -> message_count:int
+       -> token_count:int
+       -> strategies:string list
+       -> context_window:int
+       -> is_local_model:bool
+       -> trigger:Compaction_trigger.t
+       -> pre_compact_event option)
+  =
+  Atomic.set record_pre_compact_callback_atomic f
 ;;
 
 (** Fraction of context window at which compaction is treated as an
@@ -260,7 +278,7 @@ let compact_if_needed_typed
        future revision adds throwing observability calls here, wrap them. *)
     let pre_compact_event =
       try
-        !record_pre_compact_callback
+        Atomic.get record_pre_compact_callback_atomic
           ~keeper_name:meta.name
           ~context_ratio:ratio
           ~message_count:msg_count

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -92,16 +92,17 @@ type pre_compact_event = {
 }
 
 val record_pre_compact_callback :
-  (keeper_name:string ->
-   context_ratio:float ->
-   message_count:int ->
-   token_count:int ->
-   strategies:string list ->
-   context_window:int ->
-   is_local_model:bool ->
-   trigger:Compaction_trigger.t ->
-   pre_compact_event option) ref
+  keeper_name:string ->
+  context_ratio:float ->
+  message_count:int ->
+  token_count:int ->
+  strategies:string list ->
+  context_window:int ->
+  is_local_model:bool ->
+  trigger:Compaction_trigger.t ->
+  pre_compact_event option
 
+(** Replace [record_pre_compact_callback] with [f]. *)
 val register_record_pre_compact :
   (keeper_name:string ->
    context_ratio:float ->

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -131,7 +131,7 @@ let render_inline_skip_reason_with_source
 (** Broadcast a tool skip event via SSE for dashboard visibility.
     Also records in [Dashboard_governance_metrics] for aggregation. *)
 let broadcast_tool_skipped ~keeper_name ~tool_name ~reason_code =
-  !Keeper_keepalive_signal.record_tool_skipped_callback
+  Keeper_keepalive_signal.record_tool_skipped
     ~keeper_name ~tool_name ~reason_code;
   (try
     Sse.broadcast

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -17,81 +17,151 @@ type grpc_heartbeat_starter_fn = {
   f : 'a. ctx:'a context -> m:keeper_meta -> stop:bool Atomic.t -> (unit -> unit) option;
 }
 
-let grpc_heartbeat_starter_fn : grpc_heartbeat_starter_fn ref =
-  ref { f = (fun ~ctx:_ ~m:_ ~stop:_ -> None) }
+let grpc_heartbeat_starter_fn : grpc_heartbeat_starter_fn Atomic.t =
+  Atomic.make { f = (fun ~ctx:_ ~m:_ ~stop:_ -> None) }
 
 let register_grpc_heartbeat_starter (f : grpc_heartbeat_starter_fn) =
-  grpc_heartbeat_starter_fn := f
+  Atomic.set grpc_heartbeat_starter_fn f
 ;;
 
 let grpc_heartbeat_starter ~ctx ~m ~stop =
-  (!grpc_heartbeat_starter_fn).f ~ctx ~m ~stop
+  (Atomic.get grpc_heartbeat_starter_fn).f ~ctx ~m ~stop
 
-let record_wake_payload_callback : (keeper_name:string -> trace_id:string -> turn_index:int -> model_id:string -> context_window:int -> approx_body_bytes:int -> system_prompt_bytes:int -> tool_defs_bytes:int -> messages_bytes:int -> message_count:int -> role_counts:(string * int) list -> tool_count:int -> has_compact_happened:bool -> unit) ref =
-  ref (fun ~keeper_name:_ ~trace_id:_ ~turn_index:_ ~model_id:_ ~context_window:_ ~approx_body_bytes:_ ~system_prompt_bytes:_ ~tool_defs_bytes:_ ~messages_bytes:_ ~message_count:_ ~role_counts:_ ~tool_count:_ ~has_compact_happened:_ -> ())
+let record_wake_payload_callback
+    : (keeper_name:string ->
+       trace_id:string ->
+       turn_index:int ->
+       model_id:string ->
+       context_window:int ->
+       approx_body_bytes:int ->
+       system_prompt_bytes:int ->
+       tool_defs_bytes:int ->
+       messages_bytes:int ->
+       message_count:int ->
+       role_counts:(string * int) list ->
+       tool_count:int ->
+       has_compact_happened:bool ->
+       unit)
+      Atomic.t
+  =
+  Atomic.make
+    (fun ~keeper_name:_
+      ~trace_id:_
+      ~turn_index:_
+      ~model_id:_
+      ~context_window:_
+      ~approx_body_bytes:_
+      ~system_prompt_bytes:_
+      ~tool_defs_bytes:_
+      ~messages_bytes:_
+      ~message_count:_
+      ~role_counts:_
+      ~tool_count:_
+      ~has_compact_happened:_ -> ())
 
-let register_record_wake_payload (f : (keeper_name:string -> trace_id:string -> turn_index:int -> model_id:string -> context_window:int -> approx_body_bytes:int -> system_prompt_bytes:int -> tool_defs_bytes:int -> messages_bytes:int -> message_count:int -> role_counts:(string * int) list -> tool_count:int -> has_compact_happened:bool -> unit)) =
-  record_wake_payload_callback := f
+let record_wake_payload
+    ~keeper_name
+    ~trace_id
+    ~turn_index
+    ~model_id
+    ~context_window
+    ~approx_body_bytes
+    ~system_prompt_bytes
+    ~tool_defs_bytes
+    ~messages_bytes
+    ~message_count
+    ~role_counts
+    ~tool_count
+    ~has_compact_happened
+  =
+  (Atomic.get record_wake_payload_callback)
+    ~keeper_name
+    ~trace_id
+    ~turn_index
+    ~model_id
+    ~context_window
+    ~approx_body_bytes
+    ~system_prompt_bytes
+    ~tool_defs_bytes
+    ~messages_bytes
+    ~message_count
+    ~role_counts
+    ~tool_count
+    ~has_compact_happened
 ;;
 
-let record_tool_skipped_callback : (keeper_name:string -> tool_name:string -> reason_code:string -> unit) ref =
-  ref (fun ~keeper_name:_ ~tool_name:_ ~reason_code:_ -> ())
+let register_record_wake_payload f = Atomic.set record_wake_payload_callback f
 
-let register_record_tool_skipped (f : (keeper_name:string -> tool_name:string -> reason_code:string -> unit)) =
-  record_tool_skipped_callback := f
+let record_tool_skipped_callback
+    : (keeper_name:string -> tool_name:string -> reason_code:string -> unit) Atomic.t
+  =
+  Atomic.make (fun ~keeper_name:_ ~tool_name:_ ~reason_code:_ -> ())
+
+let record_tool_skipped ~keeper_name ~tool_name ~reason_code =
+  (Atomic.get record_tool_skipped_callback) ~keeper_name ~tool_name ~reason_code
 ;;
+
+let register_record_tool_skipped f = Atomic.set record_tool_skipped_callback f
 
 let record_execute_output_callback
-  : (keeper_name:string ->
-     task_id:string option ->
-     stdout:string ->
-     stderr:string ->
-     status:Yojson.Safe.t ->
-     streamed:bool ->
-     unit)
-      ref
+    : (keeper_name:string ->
+       task_id:string option ->
+       stdout:string ->
+       stderr:string ->
+       status:Yojson.Safe.t ->
+       streamed:bool ->
+       unit)
+      Atomic.t
   =
-  ref
+  Atomic.make
     (fun ~keeper_name:_ ~task_id:_ ~stdout:_ ~stderr:_ ~status:_ ~streamed:_ -> ())
 
-let register_record_execute_output f =
-  record_execute_output_callback := f
+let record_execute_output ~keeper_name ~task_id ~stdout ~stderr ~status ~streamed =
+  (Atomic.get record_execute_output_callback)
+    ~keeper_name
+    ~task_id
+    ~stdout
+    ~stderr
+    ~status
+    ~streamed
 ;;
+
+let register_record_execute_output f = Atomic.set record_execute_output_callback f
 
 let record_execute_stream_chunk_callback
-  : (keeper_name:string ->
-     stream:[ `Stdout | `Stderr ] ->
-     string ->
-     unit)
-      ref
+    : (keeper_name:string -> stream:[ `Stdout | `Stderr ] -> string -> unit) Atomic.t
   =
-  ref (fun ~keeper_name:_ ~stream:_ _chunk -> ())
+  Atomic.make (fun ~keeper_name:_ ~stream:_ _chunk -> ())
+
+let record_execute_stream_chunk ~keeper_name ~stream chunk =
+  (Atomic.get record_execute_stream_chunk_callback) ~keeper_name ~stream chunk
+;;
 
 let register_record_execute_stream_chunk f =
-  record_execute_stream_chunk_callback := f
-;;
+  Atomic.set record_execute_stream_chunk_callback f
 
 let record_execute_stream_start_callback
-  : (keeper_name:string -> task_id:string option -> unit) ref
+    : (keeper_name:string -> task_id:string option -> unit) Atomic.t
   =
-  ref (fun ~keeper_name:_ ~task_id:_ -> ())
+  Atomic.make (fun ~keeper_name:_ ~task_id:_ -> ())
+
+let record_execute_stream_start ~keeper_name ~task_id =
+  (Atomic.get record_execute_stream_start_callback) ~keeper_name ~task_id
+;;
 
 let register_record_execute_stream_start f =
-  record_execute_stream_start_callback := f
-;;
+  Atomic.set record_execute_stream_start_callback f
 
 let record_execute_stream_end_callback
-  : (keeper_name:string ->
-     task_id:string option ->
-     status:Yojson.Safe.t ->
-     unit)
-      ref
+    : (keeper_name:string -> task_id:string option -> status:Yojson.Safe.t -> unit) Atomic.t
   =
-  ref (fun ~keeper_name:_ ~task_id:_ ~status:_ -> ())
+  Atomic.make (fun ~keeper_name:_ ~task_id:_ ~status:_ -> ())
 
-let register_record_execute_stream_end f =
-  record_execute_stream_end_callback := f
+let record_execute_stream_end ~keeper_name ~task_id ~status =
+  (Atomic.get record_execute_stream_end_callback) ~keeper_name ~task_id ~status
 ;;
+
+let register_record_execute_stream_end f = Atomic.set record_execute_stream_end_callback f
 
 (* Skip log throttle removed with manual_reconcile blocker — no more
    sticky reconcile state means no flood of "reconcile pending" skip logs. *)

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -10,21 +10,21 @@ val grpc_heartbeat_starter : ctx:'a context -> m:keeper_meta -> stop:bool Atomic
 
 val register_grpc_heartbeat_starter : grpc_heartbeat_starter_fn -> unit
 
-val record_wake_payload_callback :
-  (keeper_name:string ->
-   trace_id:string ->
-   turn_index:int ->
-   model_id:string ->
-   context_window:int ->
-   approx_body_bytes:int ->
-   system_prompt_bytes:int ->
-   tool_defs_bytes:int ->
-   messages_bytes:int ->
-   message_count:int ->
-   role_counts:(string * int) list ->
-   tool_count:int ->
-   has_compact_happened:bool ->
-   unit) ref
+val record_wake_payload :
+  keeper_name:string ->
+  trace_id:string ->
+  turn_index:int ->
+  model_id:string ->
+  context_window:int ->
+  approx_body_bytes:int ->
+  system_prompt_bytes:int ->
+  tool_defs_bytes:int ->
+  messages_bytes:int ->
+  message_count:int ->
+  role_counts:(string * int) list ->
+  tool_count:int ->
+  has_compact_happened:bool ->
+  unit
 
 val register_record_wake_payload :
   (keeper_name:string ->
@@ -43,22 +43,21 @@ val register_record_wake_payload :
    unit) ->
   unit
 
-val record_tool_skipped_callback :
-  (keeper_name:string -> tool_name:string -> reason_code:string -> unit) ref
+val record_tool_skipped :
+  keeper_name:string -> tool_name:string -> reason_code:string -> unit
 
 val register_record_tool_skipped :
   (keeper_name:string -> tool_name:string -> reason_code:string -> unit) ->
   unit
 
-val record_execute_output_callback :
-  (keeper_name:string ->
-   task_id:string option ->
-   stdout:string ->
-   stderr:string ->
-   status:Yojson.Safe.t ->
-   streamed:bool ->
-   unit)
-    ref
+val record_execute_output :
+  keeper_name:string ->
+  task_id:string option ->
+  stdout:string ->
+  stderr:string ->
+  status:Yojson.Safe.t ->
+  streamed:bool ->
+  unit
 
 val register_record_execute_output :
   (keeper_name:string ->
@@ -70,39 +69,25 @@ val register_record_execute_output :
    unit) ->
   unit
 
-val record_execute_stream_chunk_callback :
-  (keeper_name:string ->
-   stream:[ `Stdout | `Stderr ] ->
-   string ->
-   unit)
-    ref
+val record_execute_stream_chunk :
+  keeper_name:string -> stream:[ `Stdout | `Stderr ] -> string -> unit
 
 val register_record_execute_stream_chunk :
-  (keeper_name:string ->
-   stream:[ `Stdout | `Stderr ] ->
-   string ->
-   unit) ->
+  (keeper_name:string -> stream:[ `Stdout | `Stderr ] -> string -> unit) ->
   unit
 
-val record_execute_stream_start_callback :
-  (keeper_name:string -> task_id:string option -> unit) ref
+val record_execute_stream_start :
+  keeper_name:string -> task_id:string option -> unit
 
 val register_record_execute_stream_start :
   (keeper_name:string -> task_id:string option -> unit) ->
   unit
 
-val record_execute_stream_end_callback :
-  (keeper_name:string ->
-   task_id:string option ->
-   status:Yojson.Safe.t ->
-   unit)
-    ref
+val record_execute_stream_end :
+  keeper_name:string -> task_id:string option -> status:Yojson.Safe.t -> unit
 
 val register_record_execute_stream_end :
-  (keeper_name:string ->
-   task_id:string option ->
-   status:Yojson.Safe.t ->
-   unit) ->
+  (keeper_name:string -> task_id:string option -> status:Yojson.Safe.t -> unit) ->
   unit
 
 (** FSM guard identity helpers (Cycle 43).

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -9,11 +9,16 @@ open Keeper_types_profile
 open Keeper_meta_contract
 open Keeper_meta_json
 
-let runtime_meta_write_sync_hook : (Workspace.config -> Keeper_meta_contract.keeper_meta -> unit) ref =
-  ref (fun _ _ -> ())
+let runtime_meta_write_sync_hook_atomic
+    : (Workspace.config -> Keeper_meta_contract.keeper_meta -> unit) Atomic.t
+  =
+  Atomic.make (fun _ _ -> ())
 ;;
 
-let register_runtime_meta_write_sync f = runtime_meta_write_sync_hook := f
+let runtime_meta_write_sync_hook = Atomic.get runtime_meta_write_sync_hook_atomic
+
+let register_runtime_meta_write_sync f =
+  Atomic.set runtime_meta_write_sync_hook_atomic f
 
 let version_conflict_re = Re.Pcre.re "meta version conflict" |> Re.compile
 
@@ -281,7 +286,7 @@ let persist_meta config path persisted =
   let json = meta_to_json persisted in
   match Keeper_fs.save_json_atomic path json with
   | Ok () ->
-    !runtime_meta_write_sync_hook config persisted;
+    Atomic.get runtime_meta_write_sync_hook_atomic config persisted;
     refresh_progress_updated_line config persisted.name;
     Ok ()
   | Error msg -> Error (Printf.sprintf "failed to write meta %s: %s" path msg)

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -15,7 +15,8 @@ let runtime_meta_write_sync_hook_atomic
   Atomic.make (fun _ _ -> ())
 ;;
 
-let runtime_meta_write_sync_hook = Atomic.get runtime_meta_write_sync_hook_atomic
+let runtime_meta_write_sync_hook config meta =
+  Atomic.get runtime_meta_write_sync_hook_atomic config meta
 
 let register_runtime_meta_write_sync f =
   Atomic.set runtime_meta_write_sync_hook_atomic f

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -9,7 +9,7 @@
     [write_meta_with_merge]. Reset by the runtime to keep
     [Workspace_state] caches in sync. *)
 val runtime_meta_write_sync_hook :
-  (Workspace.config -> Keeper_meta_contract.keeper_meta -> unit) ref
+  Workspace.config -> Keeper_meta_contract.keeper_meta -> unit
 
 (** Replace [runtime_meta_write_sync_hook] with [f]. *)
 val register_runtime_meta_write_sync :

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -738,3 +738,10 @@ let execute_keeper_tool_call
   in
   result.raw_output
 ;;
+
+module For_testing = struct
+  let set_on_keeper_tool_call = set_on_keeper_tool_call
+  let record_keeper_tool_call = record_keeper_tool_call
+  let set_tool_search_fn = set_tool_search_fn
+  let search_tools = search_tools
+end

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -23,20 +23,15 @@ type keeper_tool_call_recorder =
   tool_name:string -> success:bool -> duration_ms:int -> unit
 
 let default_keeper_tool_call_recorder ~tool_name:_ ~success:_ ~duration_ms:_ = ()
-let keeper_tool_call_recorder_mutex = Stdlib.Mutex.create ()
-let keeper_tool_call_recorder = ref default_keeper_tool_call_recorder
+let keeper_tool_call_recorder : keeper_tool_call_recorder Atomic.t =
+  Atomic.make default_keeper_tool_call_recorder
 
 let set_on_keeper_tool_call (f : keeper_tool_call_recorder) =
-  Stdlib.Mutex.protect keeper_tool_call_recorder_mutex (fun () ->
-    keeper_tool_call_recorder := f)
+  Atomic.set keeper_tool_call_recorder f
 ;;
 
 let record_keeper_tool_call ~tool_name ~success ~duration_ms =
-  let f =
-    Stdlib.Mutex.protect keeper_tool_call_recorder_mutex (fun () ->
-      !keeper_tool_call_recorder)
-  in
-  f ~tool_name ~success ~duration_ms
+  Atomic.get keeper_tool_call_recorder ~tool_name ~success ~duration_ms
 ;;
 
 let search_char c =
@@ -159,17 +154,11 @@ let default_tool_search_fn ~query ~max_results =
 type tool_searcher = query:string -> max_results:int -> Yojson.Safe.t
 
 let default_tool_searcher = default_tool_search_fn
-let tool_searcher_mutex = Stdlib.Mutex.create ()
-let tool_searcher = ref default_tool_searcher
+let tool_searcher : tool_searcher Atomic.t = Atomic.make default_tool_searcher
 
-let set_tool_search_fn (f : tool_searcher) =
-  Stdlib.Mutex.protect tool_searcher_mutex (fun () -> tool_searcher := f)
-;;
+let set_tool_search_fn (f : tool_searcher) = Atomic.set tool_searcher f
 
-let search_tools ~query ~max_results =
-  let f = Stdlib.Mutex.protect tool_searcher_mutex (fun () -> !tool_searcher) in
-  f ~query ~max_results
-;;
+let search_tools ~query ~max_results = Atomic.get tool_searcher ~query ~max_results
 
 type tool_result_payload =
   | Structured_success

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -79,6 +79,20 @@ val is_core_always_tool : string -> bool
 (** Deduplicate tool names, preserving order. *)
 val dedupe_tool_names : string list -> string list
 
+(** Test-only hooks for the global recorder/searcher refs converted to Atomic.t. *)
+module For_testing : sig
+  val set_on_keeper_tool_call
+    : (tool_name:string -> success:bool -> duration_ms:int -> unit) -> unit
+
+  val record_keeper_tool_call
+    : tool_name:string -> success:bool -> duration_ms:int -> unit
+
+  val set_tool_search_fn
+    : (query:string -> max_results:int -> Yojson.Safe.t) -> unit
+
+  val search_tools : query:string -> max_results:int -> Yojson.Safe.t
+end
+
 (** Inject all masc_* schemas for keeper descriptor/registry surface filtering.
     Must be called once during server initialization. *)
 val inject_masc_schemas : Masc_domain.tool_schema list -> unit

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -371,7 +371,7 @@ let handle_tool_execute_typed
           if stream_dispatch
           then (
             try
-              !Keeper_keepalive_signal.record_execute_stream_start_callback
+              Keeper_keepalive_signal.record_execute_stream_start
                 ~keeper_name:meta.name
                 ~task_id
             with
@@ -390,7 +390,7 @@ let handle_tool_execute_typed
                 | `Stderr s -> `Stderr, s
               in
               try
-                !Keeper_keepalive_signal.record_execute_stream_chunk_callback
+                Keeper_keepalive_signal.record_execute_stream_chunk
                   ~keeper_name:meta.name
                   ~stream
                   data
@@ -532,7 +532,7 @@ let handle_tool_execute_typed
             if stream_dispatch
             then (
               try
-                !Keeper_keepalive_signal.record_execute_stream_end_callback
+                Keeper_keepalive_signal.record_execute_stream_end
                   ~keeper_name:meta.name
                   ~task_id
                   ~status:status_json
@@ -544,7 +544,7 @@ let handle_tool_execute_typed
                   meta.name
                   (Printexc.to_string exn));
             (try
-               !Keeper_keepalive_signal.record_execute_output_callback
+               Keeper_keepalive_signal.record_execute_output
                  ~keeper_name:meta.name
                  ~task_id
                  ~stdout:result.stdout

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -415,8 +415,12 @@ let handle_masc_fusion ~(config : Workspace.config) ~(meta : keeper_meta) ~args 
 
    TEL-OK: descriptor projection — telemetry lives in [Tool_shard.execute]
    and the upstream [Keeper_tool_dispatch_runtime] dispatch wrapper. *)
-let dashboard_surface_readiness_callback = ref (fun ?surface_id:_ () -> `Assoc [])
-let register_dashboard_surface_readiness fn = dashboard_surface_readiness_callback := fn
+let dashboard_surface_readiness_callback
+    : (?surface_id:string -> unit -> Yojson.Safe.t) Atomic.t
+  =
+  Atomic.make (fun ?surface_id:_ () -> `Assoc [])
+
+let register_dashboard_surface_readiness fn = Atomic.set dashboard_surface_readiness_callback fn
 
 (* RFC-0182 §3.1 — masc_surface_audit singleton.  Body is pure
    ([Dashboard_surface_readiness.json ?surface_id ()]) with no ctx
@@ -426,7 +430,7 @@ let register_dashboard_surface_readiness fn = dashboard_surface_readiness_callba
    [Dashboard_surface_readiness]. *)
 let handle_masc_surface_audit ~args =
   let surface_id = Safe_ops.json_string_opt "surface_id" args in
-  Yojson.Safe.to_string (!dashboard_surface_readiness_callback ?surface_id ())
+  Yojson.Safe.to_string (Atomic.get dashboard_surface_readiness_callback ?surface_id ())
 ;;
 
 (* RFC-0182 §3.1 — masc_keeper cluster.  [Keeper_tool_surface] lives in lib/

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -11,11 +11,13 @@ open Keeper_keepalive
 
 type tool_result = Keeper_types_profile.tool_result
 
-let remove_pending_confirms_by_target_callback =
-  ref (fun _config ~target_type:_ ~target_id:_ -> 0)
+let remove_pending_confirms_by_target_callback
+    : (Workspace.config -> target_type:string -> target_id:string option -> int) Atomic.t
+  =
+  Atomic.make (fun _config ~target_type:_ ~target_id:_ -> 0)
 
 let register_remove_pending_confirms_by_target fn =
-  remove_pending_confirms_by_target_callback := fn
+  Atomic.set remove_pending_confirms_by_target_callback fn
 
 let handle_keeper_down_config ~(config : Workspace.config) args : tool_result =
   let requested_name = String.trim (get_string args "name" "") in
@@ -34,7 +36,7 @@ let handle_keeper_down_config ~(config : Workspace.config) args : tool_result =
     | Ok None -> tool_result_ok (Printf.sprintf "keeper already absent: %s" requested_name)
     | Ok (Some (name, m)) ->
       let pending_confirms_removed =
-        (!remove_pending_confirms_by_target_callback) config
+        Atomic.get remove_pending_confirms_by_target_callback config
           ~target_type:"keeper" ~target_id:(Some name)
       in
       Log.Misc.info

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -113,3 +113,11 @@ let handle_keeper_down_config ~(config : Workspace.config) args : tool_result =
       tool_result_ok (Yojson.Safe.to_string json)
 
 let handle_keeper_down (ctx : _ context) args = handle_keeper_down_config ~config:ctx.config args
+
+module For_testing = struct
+  let remove_pending_confirms_by_target ~config ~target_type ~target_id =
+    Atomic.get remove_pending_confirms_by_target_callback config ~target_type ~target_id
+
+  let reset_remove_pending_confirms_by_target () =
+    Atomic.set remove_pending_confirms_by_target_callback (fun _config ~target_type:_ ~target_id:_ -> 0)
+end

--- a/lib/keeper/keeper_turn_lifecycle.mli
+++ b/lib/keeper/keeper_turn_lifecycle.mli
@@ -17,3 +17,11 @@ val handle_keeper_down_config :
 val register_remove_pending_confirms_by_target :
   (Workspace.config -> target_type:string -> target_id:string option -> int) ->
   unit
+
+(** Test-only hooks for the Atomic-backed callback. *)
+module For_testing : sig
+  val remove_pending_confirms_by_target
+    : config:Workspace.config -> target_type:string -> target_id:string option -> int
+
+  val reset_remove_pending_confirms_by_target : unit -> unit
+end

--- a/test/dune
+++ b/test/dune
@@ -2190,3 +2190,10 @@
  (name test_keeper_misc_mutable_refs)
  (modules test_keeper_misc_mutable_refs)
  (libraries masc_test_deps masc.runtime))
+
+; Remaining unprotected keeper-wide shared callback refs and caches (PR #21487).
+
+(test
+ (name test_keeper_global_shared_refs_atomic)
+ (modules test_keeper_global_shared_refs_atomic)
+ (libraries alcotest masc masc.compaction_trigger))

--- a/test/test_keeper_global_shared_refs_atomic.ml
+++ b/test/test_keeper_global_shared_refs_atomic.ml
@@ -1,0 +1,211 @@
+(** Regression tests for the ref -> Atomic conversions of keeper-wide shared
+    callback refs and caches (PR #21487). Each test registers a callback,
+    invokes it through the public API, and restores the default no-op so the
+    tests remain order-independent. *)
+
+open Alcotest
+
+let tmp_base_path suffix =
+  Filename.concat (Filename.get_temp_dir_name ()) ("masc-test-" ^ suffix)
+;;
+
+let test_compact_audit_store_cache () =
+  let open Masc in
+  let base1 = tmp_base_path "compact-audit-1" in
+  let start =
+    { Keeper_compact_audit.compaction_id = "id-1"
+    ; ts_unix = 0.0
+    ; keeper_name = "k"
+    ; trigger = Keeper_compact_audit.Proactive
+    ; correlation_id = "c"
+    ; run_id = "r"
+    }
+  in
+  let r1 = Keeper_compact_audit.persist_start ~base_path:base1 ~retention_days:14 start in
+  check (result unit (of_pp (fun _ _ -> ()))) "persist_start base1 succeeds" (Ok ()) r1;
+  let r1' = Keeper_compact_audit.persist_start ~base_path:base1 ~retention_days:14 start in
+  check (result unit (of_pp (fun _ _ -> ()))) "persist_start base1 again succeeds" (Ok ()) r1';
+  let base2 = tmp_base_path "compact-audit-2" in
+  let r2 = Keeper_compact_audit.persist_start ~base_path:base2 ~retention_days:14 start in
+  check (result unit (of_pp (fun _ _ -> ()))) "persist_start base2 succeeds" (Ok ()) r2;
+  (* Switching back to base1 still works after base2 store was created. *)
+  let r1'' = Keeper_compact_audit.persist_start ~base_path:base1 ~retention_days:14 start in
+  check (result unit (of_pp (fun _ _ -> ()))) "persist_start base1 after base2 succeeds" (Ok ()) r1''
+;;
+
+let test_compact_policy_callback () =
+  let open Masc in
+  let called = ref false in
+  let ts = 1234567890.0 in
+  Keeper_compact_policy.register_record_pre_compact (fun ~keeper_name ~context_ratio:_ ~message_count:_ ~token_count:_ ~strategies:_ ~context_window:_ ~is_local_model:_ ~trigger:_ ->
+    called := true;
+    Some
+      { Keeper_compact_policy.timestamp = ts
+      ; keeper_name
+      ; context_ratio = 0.5
+      ; message_count = 1
+      ; token_count = 1
+      ; strategies = []
+      ; context_window = 4096
+      ; is_local_model = false
+      ; trigger = Compaction_trigger.Manual
+      });
+  let result =
+    Keeper_compact_policy.record_pre_compact_callback
+      ~keeper_name:"k"
+      ~context_ratio:0.5
+      ~message_count:1
+      ~token_count:1
+      ~strategies:[]
+      ~context_window:4096
+      ~is_local_model:false
+      ~trigger:Compaction_trigger.Manual
+  in
+  check bool "callback was invoked" true !called;
+  check bool "returns registered event" true (Option.is_some result);
+  (* Restore default. *)
+  Keeper_compact_policy.register_record_pre_compact (fun ~keeper_name:_ ~context_ratio:_ ~message_count:_ ~token_count:_ ~strategies:_ ~context_window:_ ~is_local_model:_ ~trigger:_ -> None)
+;;
+
+let test_meta_store_hook () =
+  let open Masc in
+  let called = ref false in
+  Keeper_meta_store.register_runtime_meta_write_sync (fun _config _meta -> called := true);
+  Keeper_meta_store.runtime_meta_write_sync_hook (Obj.magic ()) (Obj.magic ());
+  check bool "sync hook was invoked" true !called;
+  Keeper_meta_store.register_runtime_meta_write_sync (fun _config _meta -> ())
+;;
+
+let test_tool_dispatch_runtime () =
+  let open Masc in
+  let recorded = ref None in
+  Keeper_tool_dispatch_runtime.For_testing.set_on_keeper_tool_call (fun ~tool_name ~success ~duration_ms ->
+    recorded := Some (tool_name, success, duration_ms));
+  Keeper_tool_dispatch_runtime.For_testing.record_keeper_tool_call ~tool_name:"t" ~success:true ~duration_ms:42;
+  check (option (triple string bool int)) "recorder received call" (Some ("t", true, 42)) !recorded;
+  (* Search path. *)
+  let searched = ref None in
+  Keeper_tool_dispatch_runtime.For_testing.set_tool_search_fn (fun ~query ~max_results ->
+    searched := Some (query, max_results);
+    `Assoc [ "query", `String query; "max_results", `Int max_results ]);
+  let _ = Keeper_tool_dispatch_runtime.For_testing.search_tools ~query:"foo" ~max_results:3 in
+  check (option (pair string int)) "searcher received call" (Some ("foo", 3)) !searched;
+  (* Restore defaults. *)
+  Keeper_tool_dispatch_runtime.For_testing.set_on_keeper_tool_call (fun ~tool_name:_ ~success:_ ~duration_ms:_ -> ());
+  Keeper_tool_dispatch_runtime.For_testing.set_tool_search_fn (fun ~query ~max_results:_ -> `Assoc [ "query", `String query ])
+;;
+
+let test_tool_in_process_runtime () =
+  let open Masc in
+  let called = ref false in
+  Keeper_tool_in_process_runtime.register_dashboard_surface_readiness (fun ?surface_id:_ () ->
+    called := true;
+    `Bool true);
+  let json = Keeper_tool_in_process_runtime.handle_masc_surface_audit ~args:(`Assoc []) in
+  check bool "surface readiness callback was invoked" true !called;
+  check string "surface readiness JSON returned" "true" json;
+  (* Restore default. *)
+  Keeper_tool_in_process_runtime.register_dashboard_surface_readiness (fun ?surface_id:_ () -> `Assoc [])
+;;
+
+let test_keepalive_signal_callbacks () =
+  let open Masc in
+  (* gRPC heartbeat starter. *)
+  let started = ref false in
+  Keeper_keepalive_signal.register_grpc_heartbeat_starter
+    { Keeper_keepalive_signal.f =
+        (fun ~ctx:_ ~m:_ ~stop:_ ->
+           started := true;
+           Some (fun () -> ()))
+    };
+  let _ = Keeper_keepalive_signal.grpc_heartbeat_starter ~ctx:(Obj.magic ()) ~m:(Obj.magic ()) ~stop:(Atomic.make false) in
+  check bool "grpc starter invoked" true !started;
+  Keeper_keepalive_signal.register_grpc_heartbeat_starter
+    { Keeper_keepalive_signal.f = (fun ~ctx:_ ~m:_ ~stop:_ -> None) };
+  (* Wake payload. *)
+  let wake_called = ref false in
+  Keeper_keepalive_signal.register_record_wake_payload (fun ~keeper_name:_ ~trace_id:_ ~turn_index:_ ~model_id:_ ~context_window:_ ~approx_body_bytes:_ ~system_prompt_bytes:_ ~tool_defs_bytes:_ ~messages_bytes:_ ~message_count:_ ~role_counts:_ ~tool_count:_ ~has_compact_happened:_ ->
+    wake_called := true);
+  Keeper_keepalive_signal.record_wake_payload
+    ~keeper_name:"k"
+    ~trace_id:"t"
+    ~turn_index:0
+    ~model_id:"m"
+    ~context_window:4096
+    ~approx_body_bytes:0
+    ~system_prompt_bytes:0
+    ~tool_defs_bytes:0
+    ~messages_bytes:0
+    ~message_count:0
+    ~role_counts:[]
+    ~tool_count:0
+    ~has_compact_happened:false;
+  check bool "wake payload callback invoked" true !wake_called;
+  Keeper_keepalive_signal.register_record_wake_payload (fun ~keeper_name:_ ~trace_id:_ ~turn_index:_ ~model_id:_ ~context_window:_ ~approx_body_bytes:_ ~system_prompt_bytes:_ ~tool_defs_bytes:_ ~messages_bytes:_ ~message_count:_ ~role_counts:_ ~tool_count:_ ~has_compact_happened:_ -> ());
+  (* Tool skipped. *)
+  let skipped = ref false in
+  Keeper_keepalive_signal.register_record_tool_skipped (fun ~keeper_name:_ ~tool_name:_ ~reason_code:_ -> skipped := true);
+  Keeper_keepalive_signal.record_tool_skipped ~keeper_name:"k" ~tool_name:"t" ~reason_code:"r";
+  check bool "tool skipped callback invoked" true !skipped;
+  Keeper_keepalive_signal.register_record_tool_skipped (fun ~keeper_name:_ ~tool_name:_ ~reason_code:_ -> ());
+  (* Execute output. *)
+  let output = ref false in
+  Keeper_keepalive_signal.register_record_execute_output (fun ~keeper_name:_ ~task_id:_ ~stdout:_ ~stderr:_ ~status:_ ~streamed:_ -> output := true);
+  Keeper_keepalive_signal.record_execute_output
+    ~keeper_name:"k"
+    ~task_id:None
+    ~stdout:""
+    ~stderr:""
+    ~status:(`Assoc [])
+    ~streamed:false;
+  check bool "execute output callback invoked" true !output;
+  Keeper_keepalive_signal.register_record_execute_output (fun ~keeper_name:_ ~task_id:_ ~stdout:_ ~stderr:_ ~status:_ ~streamed:_ -> ());
+  (* Stream start/chunk/end. *)
+  let stream_start = ref false in
+  let stream_chunk = ref false in
+  let stream_end = ref false in
+  Keeper_keepalive_signal.register_record_execute_stream_start (fun ~keeper_name:_ ~task_id:_ -> stream_start := true);
+  Keeper_keepalive_signal.register_record_execute_stream_chunk (fun ~keeper_name:_ ~stream:_ _chunk -> stream_chunk := true);
+  Keeper_keepalive_signal.register_record_execute_stream_end (fun ~keeper_name:_ ~task_id:_ ~status:_ -> stream_end := true);
+  Keeper_keepalive_signal.record_execute_stream_start ~keeper_name:"k" ~task_id:None;
+  Keeper_keepalive_signal.record_execute_stream_chunk ~keeper_name:"k" ~stream:`Stdout "x";
+  Keeper_keepalive_signal.record_execute_stream_end ~keeper_name:"k" ~task_id:None ~status:(`Assoc []);
+  check bool "stream start callback invoked" true !stream_start;
+  check bool "stream chunk callback invoked" true !stream_chunk;
+  check bool "stream end callback invoked" true !stream_end;
+  Keeper_keepalive_signal.register_record_execute_stream_start (fun ~keeper_name:_ ~task_id:_ -> ());
+  Keeper_keepalive_signal.register_record_execute_stream_chunk (fun ~keeper_name:_ ~stream:_ _chunk -> ());
+  Keeper_keepalive_signal.register_record_execute_stream_end (fun ~keeper_name:_ ~task_id:_ ~status:_ -> ())
+;;
+
+let test_turn_lifecycle_callback () =
+  let open Masc in
+  let called = ref false in
+  Keeper_turn_lifecycle.register_remove_pending_confirms_by_target (fun _config ~target_type:_ ~target_id:_ ->
+    called := true;
+    7);
+  let n = Keeper_turn_lifecycle.For_testing.remove_pending_confirms_by_target ~config:(Obj.magic ()) ~target_type:"keeper" ~target_id:(Some "k") in
+  check bool "remove pending confirms callback invoked" true !called;
+  check int "remove pending confirms returned value" 7 n;
+  Keeper_turn_lifecycle.For_testing.reset_remove_pending_confirms_by_target ()
+;;
+
+let () =
+  Alcotest.run
+    "keeper-global-shared-refs-atomic"
+    [ ( "compact-audit"
+      , [ test_case "store cache is shared per base_path" `Quick test_compact_audit_store_cache ] )
+    ; ( "compact-policy"
+      , [ test_case "record_pre_compact callback registration" `Quick test_compact_policy_callback ] )
+    ; ( "meta-store"
+      , [ test_case "runtime_meta_write_sync_hook registration" `Quick test_meta_store_hook ] )
+    ; ( "tool-dispatch-runtime"
+      , [ test_case "recorder and searcher registration" `Quick test_tool_dispatch_runtime ] )
+    ; ( "tool-in-process-runtime"
+      , [ test_case "dashboard surface readiness callback" `Quick test_tool_in_process_runtime ] )
+    ; ( "keepalive-signal"
+      , [ test_case "all global callback registrations" `Quick test_keepalive_signal_callbacks ] )
+    ; ( "turn-lifecycle"
+      , [ test_case "remove_pending_confirms_by_target callback" `Quick test_turn_lifecycle_callback ] )
+    ]
+;;


### PR DESCRIPTION
Follow-up to the ref -> Atomic / immutable-state refactor (PRs #21402, #21447, #21454).

This converts the remaining unprotected top-level shared callback refs and lazy caches that are read/written across Eio fibers/domains to Atomic.t:

- keeper_compact_audit: lazy Dated_jsonl store cache
- keeper_compact_policy: record_pre_compact_callback
- keeper_keepalive_signal: all global callbacks (grpc starter, wake payload, tool skipped, execute output/stream callbacks)
- keeper_meta_store: runtime_meta_write_sync_hook
- keeper_tool_dispatch_runtime: keeper_tool_call_recorder, tool_searcher (removes Stdlib.Mutex)
- keeper_tool_in_process_runtime: dashboard_surface_readiness_callback
- keeper_turn_lifecycle: remove_pending_confirms_by_target_callback

For keepalive callbacks the public mli values are changed from refs to functions; internal callers updated.

Refs #21403