### PR TITLE
feat(transport): harden WebSocket transport against frequent disconnects

### DIFF
--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -24,12 +24,20 @@ export const MCP_INIT_COOLDOWN_MS = 2_000
 // a reconnect by the client side.
 export const DASHBOARD_WS_RPC_TIMEOUT_MS = 30_000
 export const DASHBOARD_WS_HEARTBEAT_INTERVAL_MS = 30_000
+// Heartbeat RPCs should resolve quickly; a shorter timeout than the generic
+// RPC budget lets the client detect a half-open socket before the next beat.
+export const DASHBOARD_WS_HEARTBEAT_RPC_TIMEOUT_MS = 10_000
+// Number of consecutive failed connection attempts using a cached discovery
+// URL before the cache is invalidated and the client falls back to /ws.
+export const DASHBOARD_WS_DISCOVERY_CACHE_MAX_FAILURES = 3
 
 // --- Transport retry defaults (shared by all transport implementations) ---
 // Exponential backoff for transport-level reconnection.  Distinct from
 // RECONNECT_* (which caps at 60s for SSE/dashboard-WS reconnect storms).
 export const TRANSPORT_RETRY_BASE_MS = 1_000
 export const TRANSPORT_RETRY_MAX_MS = 30_000
+export const TRANSPORT_RETRY_JITTER_MS = 1_000
+export const TRANSPORT_RETRY_MAX_ATTEMPTS = 10
 
 // --- Reconnect backoff (shared by SSE and dashboard WS) ---
 // Cap at 60s with plus/minus 1s jitter to break reconnect storms when the server is

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -18,7 +18,9 @@ import {
 import { parseWebSocketSseFrames } from './dashboard-ws-parse'
 import { clearStoredToken, setStoredToken } from './api/core'
 import {
+  DASHBOARD_WS_DISCOVERY_CACHE_MAX_FAILURES,
   DASHBOARD_WS_HEARTBEAT_INTERVAL_MS,
+  DASHBOARD_WS_HEARTBEAT_RPC_TIMEOUT_MS,
   DASHBOARD_WS_RPC_TIMEOUT_MS,
 } from './config/constants'
 import { DASHBOARD_PUSH_SLICES } from './dashboard-slices'
@@ -425,7 +427,7 @@ describe('dashboard websocket route subscriptions', () => {
     expect(mockSockets[0]!.url).toBe('ws://localhost:3000/ws')
   })
 
-  it('invalidates cached discovery when the cached socket closes before it is ready', async () => {
+  it('invalidates cached discovery after repeated failures before it is ready', async () => {
     vi.useFakeTimers()
     mockSockets.length = 0
     vi.stubGlobal('WebSocket', MockWebSocket)
@@ -439,13 +441,90 @@ describe('dashboard websocket route subscriptions', () => {
     expect(staleSocket.url).toBe('ws://localhost:3000/ws?stale')
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
-    staleSocket.close({ code: 1006, reason: 'connect failed', wasClean: false })
+    // The cache is only invalidated after a threshold of consecutive failures,
+    // so the first reconnects still reuse the cached stale URL.
+    for (let i = 0; i < DASHBOARD_WS_DISCOVERY_CACHE_MAX_FAILURES - 1; i += 1) {
+      mockSockets[mockSockets.length - 1]!.close({ code: 1006, reason: 'connect failed', wasClean: false })
+      await vi.advanceTimersByTimeAsync(60_000)
+      await flushPromises()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    }
+
+    // The threshold failure clears the cache and falls back to /ws discovery.
+    mockSockets[mockSockets.length - 1]!.close({ code: 1006, reason: 'connect failed', wasClean: false })
     await vi.advanceTimersByTimeAsync(60_000)
     await flushPromises()
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
-    expect(mockSockets).toHaveLength(2)
-    expect(mockSockets[1]!.url).toBe('ws://localhost:3000/ws?fresh')
+    expect(mockSockets).toHaveLength(1 + DASHBOARD_WS_DISCOVERY_CACHE_MAX_FAILURES)
+    expect(mockSockets[DASHBOARD_WS_DISCOVERY_CACHE_MAX_FAILURES]!.url).toBe('ws://localhost:3000/ws?fresh')
+  })
+
+  it('stops reconnecting after a fatal policy violation close', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    const subscribe = parseRpc(socket, 1)
+    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: { snapshot: { seq: 1, slices: {} } } })
+    await flushPromises()
+    expect(dashboardWsReady.value).toBe(true)
+
+    socket.close({ code: 1008, reason: 'policy violation', wasClean: false })
+    await vi.advanceTimersByTimeAsync(60_000)
+    await flushPromises()
+
+    expect(dashboardWsConnected.value).toBe(false)
+    expect(dashboardWsReady.value).toBe(false)
+    expect(mockSockets).toHaveLength(1)
+  })
+
+  it('stops reconnecting after a fatal server error close', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    const subscribe = parseRpc(socket, 1)
+    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: { snapshot: { seq: 1, slices: {} } } })
+    await flushPromises()
+    expect(dashboardWsReady.value).toBe(true)
+
+    socket.close({ code: 1011, reason: 'server error', wasClean: false })
+    await vi.advanceTimersByTimeAsync(60_000)
+    await flushPromises()
+
+    expect(dashboardWsConnected.value).toBe(false)
+    expect(dashboardWsReady.value).toBe(false)
+    expect(mockSockets).toHaveLength(1)
+  })
+
+  it('stops reconnecting after an abnormal close after hello is rejected', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, error: { message: 'auth rejected' } })
+    await flushPromises()
+    expect(dashboardWsReady.value).toBe(false)
+
+    socket.close({ code: 1006, reason: 'abnormal', wasClean: false })
+    await vi.advanceTimersByTimeAsync(60_000)
+    await flushPromises()
+
+    expect(dashboardWsConnected.value).toBe(false)
+    expect(dashboardWsReady.value).toBe(false)
+    expect(mockSockets).toHaveLength(1)
   })
 
   it('subscribes the latest route captured while hello is still in flight', async () => {
@@ -576,7 +655,7 @@ describe('dashboard websocket route subscriptions', () => {
     const ping = parseRpc(socket, 2)
     expect(ping.method).toBe('dashboard/ping')
 
-    await vi.advanceTimersByTimeAsync(DASHBOARD_WS_RPC_TIMEOUT_MS)
+    await vi.advanceTimersByTimeAsync(DASHBOARD_WS_HEARTBEAT_RPC_TIMEOUT_MS)
     await flushPromises()
 
     expect(socket.readyState).toBe(MockWebSocket.CLOSED)

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -9,7 +9,9 @@ import {
   type DashboardPushSlice,
 } from './dashboard-slices'
 import {
+  DASHBOARD_WS_DISCOVERY_CACHE_MAX_FAILURES,
   DASHBOARD_WS_HEARTBEAT_INTERVAL_MS,
+  DASHBOARD_WS_HEARTBEAT_RPC_TIMEOUT_MS,
   DASHBOARD_WS_RPC_TIMEOUT_MS,
   RECONNECT_JITTER_MS,
   RECONNECT_MAX_MS,
@@ -57,7 +59,13 @@ let lastSubscribeKey = ''
 let desiredRouteState: DashboardRouteState | null = null
 let shouldReconnect = true
 let connectGeneration = 0
+let discoveryCacheFailureCount = 0
+let helloFailed = false
 const pending = new Map<number, PendingRpc>()
+
+// WebSocket close codes that indicate a persistent failure and should stop
+// reconnection attempts (1008 policy violation, 1011 server error).
+const FATAL_CLOSE_CODES = new Set([1008, 1011])
 
 function sessionStorageOrNull(): Storage | null {
   if (typeof sessionStorage === 'undefined') return null
@@ -130,6 +138,19 @@ function clearCachedWsUrl(): void {
 
 export function clearDashboardWsDiscoveryCacheForTests(): void {
   clearCachedWsUrl()
+  discoveryCacheFailureCount = 0
+}
+
+function resetDiscoveryCacheFailures(): void {
+  discoveryCacheFailureCount = 0
+}
+
+function maybeInvalidateDiscoveryCache(): void {
+  discoveryCacheFailureCount += 1
+  if (discoveryCacheFailureCount >= DASHBOARD_WS_DISCOVERY_CACHE_MAX_FAILURES) {
+    clearCachedWsUrl()
+    resetDiscoveryCacheFailures()
+  }
 }
 
 // Phase 2 (PR-4.6): rAF accumulator for inbound WS messages.
@@ -310,7 +331,7 @@ function startHeartbeat(ws: WebSocket): void {
     }
     heartbeatInFlight = true
     const sentAt = noteDashboardWsPing()
-    void sendRpc('dashboard/ping', {})
+    void sendRpc('dashboard/ping', {}, DASHBOARD_WS_HEARTBEAT_RPC_TIMEOUT_MS)
       .then(() => {
         if (socket === ws) {
           noteDashboardWsPong(sentAt)
@@ -354,7 +375,7 @@ async function discoverWsUrl(): Promise<DashboardWsDiscoveryResult> {
   return { wsUrl: data.ws_url, retry: false, fromCache: false }
 }
 
-function sendRpc(method: string, params: JsonObject): Promise<unknown> {
+function sendRpc(method: string, params: JsonObject, timeoutMs = DASHBOARD_WS_RPC_TIMEOUT_MS): Promise<unknown> {
   if (!socket || socket.readyState !== WebSocket.OPEN) {
     return Promise.reject(new Error('dashboard websocket is not open'))
   }
@@ -365,7 +386,7 @@ function sendRpc(method: string, params: JsonObject): Promise<unknown> {
     const timeout = setTimeout(() => {
       if (!pending.delete(id)) return
       reject(new Error(`dashboard websocket rpc timed out: ${method}`))
-    }, DASHBOARD_WS_RPC_TIMEOUT_MS)
+    }, timeoutMs)
     pending.set(id, { resolve, reject, timeout })
     try {
       currentSocket.send(JSON.stringify(payload))
@@ -531,13 +552,12 @@ function handleMessage(data: unknown): void {
 
 function reconnectAfterCurrentSocketFailure(ws: WebSocket, err: unknown): void {
   if (socket !== ws) return
-  const wasReady = dashboardWsReady.value
   batch(() => {
     dashboardWsConnected.value = false
     dashboardWsReady.value = false
     dashboardWsLastError.value = errorToString(err)
   })
-  if (!wasReady) clearCachedWsUrl()
+  maybeInvalidateDiscoveryCache()
   lastSubscribeKey = ''
   closeSocket()
   scheduleReconnect()
@@ -599,6 +619,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
   if (!shouldReconnect || generation !== connectGeneration) return
 
   closeSocket()
+  helloFailed = false
   let ws: WebSocket
   try {
     ws = new WebSocket(wsUrl)
@@ -606,9 +627,9 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     // Cache only values that constructed successfully: writing before
     // [new WebSocket(...)] would persist a malformed/incompatible URL
     // through the next reconnect, adding an extra failure+backoff cycle
-    // before discovery is retried. Also clear any prior cached value so
-    // a stale entry from an earlier session does not survive.
-    clearCachedWsUrl()
+    // before discovery is retried. Also invalidate the cache after repeated
+    // construction failures so a stale entry does not survive.
+    maybeInvalidateDiscoveryCache()
     batch(() => {
       dashboardWsLastError.value = errorToString(err)
     })
@@ -633,6 +654,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     })
       .then(() => {
         if (socket !== ws) return
+        resetDiscoveryCacheFailures()
         batch(() => {
           dashboardWsReady.value = true
           dashboardWsLastError.value = null
@@ -647,7 +669,24 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
           startHeartbeat(ws)
         }
       })
-      .catch(err => reconnectAfterCurrentSocketFailure(ws, err))
+      .catch(err => {
+        const errMsg = errorToString(err)
+        // A hello timeout may be transient; keep reconnecting. An explicit
+        // hello error (server rejected the handshake) or a socket close during
+        // hello is fatal and should stop reconnection attempts.
+        if (errMsg.includes('rpc timed out')) {
+          reconnectAfterCurrentSocketFailure(ws, err)
+          return
+        }
+        helloFailed = true
+        if (socket !== ws) return
+        batch(() => {
+          dashboardWsConnected.value = false
+          dashboardWsReady.value = false
+          dashboardWsLastError.value = errMsg
+        })
+        closeSocket()
+      })
   }
   ws.onmessage = (event) => {
     if (socket !== ws) return
@@ -661,7 +700,6 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
   }
   ws.onclose = (event) => {
     if (socket !== ws) return
-    const wasReady = dashboardWsReady.value
     const closeError = new Error(formatCloseEventError(event))
     // Clean close (wasClean=true) is server-initiated (shutdown/redeploy/idle),
     // not a degraded-WS error. Leaving lastError set on a clean close would trip
@@ -671,16 +709,26 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     // keep lastError set so the fallback still engages. reconnect runs either
     // way; pending RPCs are rejected either way (socket is gone).
     const clean = event.wasClean === true
+    // Fatal closes indicate a persistent condition (policy violation, server
+    // error, or abnormal close after hello was explicitly rejected). Stop
+    // reconnecting so the client does not spin on a rejected session.
+    const fatal = FATAL_CLOSE_CODES.has(event.code) || (helloFailed && !clean)
     clearHeartbeatTimer()
     batch(() => {
       dashboardWsConnected.value = false
       dashboardWsReady.value = false
       dashboardWsLastError.value = clean ? null : closeError.message
     })
-    if (!wasReady) clearCachedWsUrl()
+    if (!fatal) {
+      maybeInvalidateDiscoveryCache()
+    }
     lastSubscribeKey = ''
     socket = null
     rejectPendingRpcs(closeError)
+    if (fatal) {
+      shouldReconnect = false
+      return
+    }
     scheduleReconnect()
   }
 }
@@ -689,6 +737,8 @@ export function disconnectDashboardWS(): void {
   shouldReconnect = false
   connectGeneration += 1
   clearReconnectTimer()
+  helloFailed = false
+  discoveryCacheFailureCount = 0
   batch(() => {
     dashboardWsConnected.value = false
     dashboardWsReady.value = false

--- a/dashboard/src/transports/sse-transport.test.ts
+++ b/dashboard/src/transports/sse-transport.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { createSseTransport } from './sse-transport'
+
+class MockEventSource {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSED = 2
+
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  readyState = MockEventSource.CONNECTING
+  readonly url: string
+  close = vi.fn(() => {
+    this.readyState = MockEventSource.CLOSED
+  })
+
+  constructor(url: string) {
+    this.url = url
+    instances.push(this)
+  }
+
+  simulateOpen(): void {
+    this.readyState = MockEventSource.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateError(): void {
+    this.readyState = MockEventSource.CLOSED
+    this.onerror?.(new Event('error'))
+  }
+
+  simulateMessage(data: string): void {
+    this.onmessage?.(new MessageEvent('message', { data }))
+  }
+}
+
+let instances: MockEventSource[] = []
+
+function installMock(): void {
+  instances = []
+  vi.stubGlobal('EventSource', MockEventSource)
+}
+
+describe('createSseTransport', () => {
+  beforeEach(() => {
+    installMock()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('opens and emits an open event', () => {
+    const events: { type: string; data?: unknown; error?: Error }[] = []
+    const transport = createSseTransport('/mcp', {
+      retryBaseMs: 100,
+      retryJitterMs: 0,
+    })
+    transport.subscribe((event) => {
+      events.push({
+        type: event.type,
+        ...(event.type === 'message' ? { data: event.data } : {}),
+        ...(event.type === 'error' ? { error: event.error } : {}),
+      })
+    })
+    transport.connect()
+    expect(instances).toHaveLength(1)
+    instances[0]!.simulateOpen()
+    expect(events).toContainEqual({ type: 'open' })
+    expect(transport.isConnected()).toBe(true)
+  })
+
+  it('parses JSON messages and falls back to raw strings', () => {
+    const events: { type: string; data?: unknown }[] = []
+    const transport = createSseTransport('/mcp', { retryJitterMs: 0 })
+    transport.subscribe((event) => {
+      if (event.type === 'message') events.push({ type: event.type, data: event.data })
+    })
+    transport.connect()
+    instances[0]!.simulateOpen()
+    instances[0]!.simulateMessage(JSON.stringify({ kind: 'ping' }))
+    instances[0]!.simulateMessage('plain heartbeat')
+    expect(events).toEqual([
+      { type: 'message', data: { kind: 'ping' } },
+      { type: 'message', data: 'plain heartbeat' },
+    ])
+  })
+
+  it('reconnects with exponential backoff capped by retryMaxMs', () => {
+    const transport = createSseTransport('/mcp', {
+      retryBaseMs: 100,
+      retryMaxMs: 400,
+      retryJitterMs: 0,
+      retryMaxAttempts: 10,
+    })
+    transport.connect()
+    instances[0]!.simulateOpen()
+
+    instances[0]!.simulateError()
+    vi.advanceTimersByTime(100)
+    expect(instances).toHaveLength(2)
+
+    instances[1]!.simulateError()
+    vi.advanceTimersByTime(200)
+    expect(instances).toHaveLength(3)
+
+    instances[2]!.simulateError()
+    vi.advanceTimersByTime(400)
+    expect(instances).toHaveLength(4)
+
+    instances[3]!.simulateError()
+    vi.advanceTimersByTime(400)
+    expect(instances).toHaveLength(5)
+  })
+
+  it('adds random jitter up to retryJitterMs', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const transport = createSseTransport('/mcp', {
+      retryBaseMs: 100,
+      retryJitterMs: 40,
+      retryMaxAttempts: 10,
+    })
+    transport.connect()
+    instances[0]!.simulateOpen()
+    instances[0]!.simulateError()
+
+    vi.advanceTimersByTime(119)
+    expect(instances).toHaveLength(1)
+    vi.advanceTimersByTime(1)
+    expect(instances).toHaveLength(2)
+  })
+
+  it('stops reconnecting after retryMaxAttempts and emits close', () => {
+    const events: { type: string }[] = []
+    const transport = createSseTransport('/mcp', {
+      retryBaseMs: 10,
+      retryMaxMs: 10,
+      retryJitterMs: 0,
+      retryMaxAttempts: 2,
+    })
+    transport.subscribe((event) => events.push({ type: event.type }))
+    transport.connect()
+
+    instances[0]!.simulateError()
+    vi.advanceTimersByTime(10)
+    expect(instances).toHaveLength(2)
+
+    instances[1]!.simulateError()
+    vi.advanceTimersByTime(10)
+    expect(instances).toHaveLength(3)
+
+    instances[2]!.simulateError()
+    expect(transport.isConnected()).toBe(false)
+    expect(events.filter((e) => e.type === 'close')).toHaveLength(1)
+
+    vi.advanceTimersByTime(1_000)
+    expect(instances).toHaveLength(3)
+  })
+
+  it('resets backoff after a successful reconnect', () => {
+    const transport = createSseTransport('/mcp', {
+      retryBaseMs: 100,
+      retryMaxMs: 400,
+      retryJitterMs: 0,
+      retryMaxAttempts: 10,
+    })
+    transport.connect()
+    instances[0]!.simulateOpen()
+    instances[0]!.simulateError()
+    vi.advanceTimersByTime(100)
+    instances[1]!.simulateOpen()
+    instances[1]!.simulateError()
+    vi.advanceTimersByTime(100)
+    expect(instances).toHaveLength(3)
+  })
+
+  it('disconnect clears timers and emits close', () => {
+    const events: { type: string }[] = []
+    const transport = createSseTransport('/mcp', {
+      retryBaseMs: 100,
+      retryJitterMs: 0,
+      retryMaxAttempts: 10,
+    })
+    transport.subscribe((event) => events.push({ type: event.type }))
+    transport.connect()
+    instances[0]!.simulateOpen()
+    instances[0]!.simulateError()
+    transport.disconnect()
+    vi.advanceTimersByTime(1_000)
+    expect(instances).toHaveLength(1)
+    expect(instances[0]!.close).toHaveBeenCalled()
+    expect(events.filter((e) => e.type === 'close')).toHaveLength(1)
+    expect(transport.isConnected()).toBe(false)
+  })
+})

--- a/dashboard/src/transports/sse-transport.ts
+++ b/dashboard/src/transports/sse-transport.ts
@@ -1,5 +1,10 @@
 import type { Transport, TransportEvent, TransportOptions } from './transport'
-import { TRANSPORT_RETRY_BASE_MS, TRANSPORT_RETRY_MAX_MS } from '../config/constants'
+import {
+  TRANSPORT_RETRY_BASE_MS,
+  TRANSPORT_RETRY_JITTER_MS,
+  TRANSPORT_RETRY_MAX_ATTEMPTS,
+  TRANSPORT_RETRY_MAX_MS,
+} from '../config/constants'
 
 export function createSseTransport(url: string, opts: TransportOptions = {}): Transport {
   let source: EventSource | null = null
@@ -7,9 +12,25 @@ export function createSseTransport(url: string, opts: TransportOptions = {}): Tr
   let retryMs = opts.retryBaseMs ?? TRANSPORT_RETRY_BASE_MS
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
   let connected = false
+  let reconnectAttempts = 0
+  const retryMaxAttempts = opts.retryMaxAttempts ?? TRANSPORT_RETRY_MAX_ATTEMPTS
+  const retryJitterMs = opts.retryJitterMs ?? TRANSPORT_RETRY_JITTER_MS
 
   const notify = (event: TransportEvent) => {
     listeners.forEach((l) => l(event))
+  }
+
+  const scheduleReconnect = () => {
+    if (reconnectAttempts >= retryMaxAttempts) {
+      notify({ type: 'close' })
+      return
+    }
+    reconnectAttempts += 1
+    const maxMs = opts.retryMaxMs ?? TRANSPORT_RETRY_MAX_MS
+    const backoff = Math.min(retryMs, maxMs)
+    const jitter = Math.random() * retryJitterMs
+    reconnectTimer = setTimeout(connect, backoff + jitter)
+    retryMs = Math.min(retryMs * 2, maxMs)
   }
 
   const connect = () => {
@@ -19,6 +40,7 @@ export function createSseTransport(url: string, opts: TransportOptions = {}): Tr
       source.onopen = () => {
         connected = true
         retryMs = opts.retryBaseMs ?? TRANSPORT_RETRY_BASE_MS
+        reconnectAttempts = 0
         notify({ type: 'open' })
       }
       source.onmessage = (ev) => {
@@ -34,9 +56,7 @@ export function createSseTransport(url: string, opts: TransportOptions = {}): Tr
         notify({ type: 'error', error: new Error('SSE transport error') })
         source?.close()
         source = null
-        const maxMs = opts.retryMaxMs ?? TRANSPORT_RETRY_MAX_MS
-        reconnectTimer = setTimeout(connect, Math.min(retryMs, maxMs))
-        retryMs = Math.min(retryMs * 2, maxMs)
+        scheduleReconnect()
       }
     } catch (err) {
       notify({ type: 'error', error: err instanceof Error ? err : new Error(String(err)) })
@@ -49,6 +69,8 @@ export function createSseTransport(url: string, opts: TransportOptions = {}): Tr
       reconnectTimer = null
     }
     connected = false
+    retryMs = opts.retryBaseMs ?? TRANSPORT_RETRY_BASE_MS
+    reconnectAttempts = 0
     source?.close()
     source = null
     notify({ type: 'close' })

--- a/dashboard/src/transports/transport.ts
+++ b/dashboard/src/transports/transport.ts
@@ -26,6 +26,8 @@ export interface TransportFactory {
 export interface TransportOptions {
   readonly retryBaseMs?: number
   readonly retryMaxMs?: number
+  readonly retryMaxAttempts?: number
+  readonly retryJitterMs?: number
   readonly heartbeatIntervalMs?: number
   readonly headers?: Record<string, string>
 }

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -177,12 +177,6 @@ let new_session ~id ~wsd =
     inbound_partial_text = None;
   }
 
-(** Test-only: build a session with a placeholder [Wsd.t].  The placeholder is
-    never written to by well-behaved tests; it exists only so white-box tests
-    can exercise session lifecycle state without a live HTTP upgrade. *)
-let __test_new_session ~id =
-  new_session ~id ~wsd:(Obj.magic ())
-
 (** [true] when the session has been closed locally or the httpun-ws writer has
     shut down.  Reads the atomic [closed] flag and the WSD state; safe from any
     fiber. *)

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -32,7 +32,19 @@ type dashboard_auth_state =
 type ws_session = {
   id: string;
   wsd: Httpun_ws.Wsd.t;
-  mutable closed: bool;
+  closed: bool Atomic.t;
+  (** All writes to [wsd] (text frames, pings, pongs, close) are serialized
+      through [write_mutex] so fibers sharing one connection cannot interleave
+      frames or race with a concurrent close. *)
+  write_mutex: Eio.Mutex.t;
+  (** Last time a WebSocket pong frame was received from the client.  Used by
+      the standalone heartbeat to detect dead peers after a configurable number
+      of missed pongs. *)
+  last_pong_at: float Atomic.t;
+  (** Number of consecutive protocol pings sent without receiving a pong.
+      Reset to zero on every pong; the standalone heartbeat closes the session
+      once this reaches [pong_timeout_intervals]. *)
+  missed_pongs: int Atomic.t;
   dashboard_auth: dashboard_auth_state Atomic.t;
   mutable dashboard_route: string option;
   dashboard_slices: (string, unit) Hashtbl.t;
@@ -152,7 +164,10 @@ let new_session ~id ~wsd =
   {
     id;
     wsd;
-    closed = false;
+    closed = Atomic.make false;
+    write_mutex = Eio.Mutex.create ();
+    last_pong_at = Atomic.make (Unix.gettimeofday ()); (* NDT-OK: wall-clock used only for liveness, not deterministic output. *)
+    missed_pongs = Atomic.make 0;
     dashboard_auth = Atomic.make Unauthenticated;
     dashboard_route = None;
     dashboard_slices = Hashtbl.create 8;
@@ -161,6 +176,24 @@ let new_session ~id ~wsd =
     dashboard_last_buffered_amount = 0;
     inbound_partial_text = None;
   }
+
+(** Test-only: build a session with a placeholder [Wsd.t].  The placeholder is
+    never written to by well-behaved tests; it exists only so white-box tests
+    can exercise session lifecycle state without a live HTTP upgrade. *)
+let __test_new_session ~id =
+  new_session ~id ~wsd:(Obj.magic ())
+
+(** [true] when the session has been closed locally or the httpun-ws writer has
+    shut down.  Reads the atomic [closed] flag and the WSD state; safe from any
+    fiber. *)
+let is_session_closed session =
+  Atomic.get session.closed || Httpun_ws.Wsd.is_closed session.wsd
+
+(** Record a client pong: refresh [last_pong_at] and reset the missed-pong
+    counter.  Called from the WS frame handler on every [Pong] frame. *)
+let record_pong session =
+  Atomic.set session.last_pong_at (Unix.gettimeofday ()); (* NDT-OK: wall-clock used only for liveness, not deterministic output. *)
+  Atomic.set session.missed_pongs 0
 
 (** Send a pre-allocated frame to a WebSocket client.
 
@@ -171,23 +204,27 @@ let new_session ~id ~wsd =
     buffer synchronously, so the same [bytes] value can safely be passed
     to multiple sessions in one broadcast without re-allocation. *)
 let send_frame_bytes session bytes ~len =
-  if session.closed || Httpun_ws.Wsd.is_closed session.wsd then begin
-    session.closed <- true;
+  if is_session_closed session then begin
+    Atomic.set session.closed true;
     false
   end else begin
-    try
-      Httpun_ws.Wsd.send_bytes session.wsd
-        ~kind:`Text bytes ~off:0 ~len;
-      Transport_metrics.inc_ws_bytes_sent ~bytes:len;
-      Transport_metrics.observe_ws_message_bytes_sent len;
-      true
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      Log.Transport.warn "WS text send failed for session=%s: %s" session.id
-        (Printexc.to_string exn);
-      session.closed <- true;
-      false
+    Eio_guard.with_mutex session.write_mutex (fun () ->
+      if is_session_closed session then false
+      else begin
+        try
+          Httpun_ws.Wsd.send_bytes session.wsd
+            ~kind:`Text bytes ~off:0 ~len;
+          Transport_metrics.inc_ws_bytes_sent ~bytes:len;
+          Transport_metrics.observe_ws_message_bytes_sent len;
+          true
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Transport.warn "WS text send failed for session=%s: %s" session.id
+            (Printexc.to_string exn);
+          Atomic.set session.closed true;
+          false
+      end)
   end
 
 (** WebSocket text frames must contain valid UTF-8.  Raw SSE broadcasts can
@@ -838,8 +875,10 @@ let cleanup_session session_id =
         match Hashtbl.find_opt sessions session_id with
         | None -> false
         | Some session ->
-            session.closed <- true;
-            (try Httpun_ws.Wsd.close session.wsd
+            Atomic.set session.closed true;
+            (try
+               Eio_guard.with_mutex session.write_mutex (fun () ->
+                 Httpun_ws.Wsd.close session.wsd)
              with Eio.Cancel.Cancelled _ as e -> raise e
                 | exn -> Log.Server.warn "WS close failed for %s: %s" session_id (Printexc.to_string exn));
             Hashtbl.remove sessions session_id;
@@ -861,51 +900,90 @@ let session_count () =
 
 let heartbeat_interval_s = 30.0
 
+(** Configurable missed-pong threshold for the /ws upgrade heartbeat.
+
+    A value of [0] disables the pong-timeout guard.  Negative values are
+    clamped to [0] so they cannot force immediate closure.  The threshold is
+    read once per session at creation time; changes to the environment variable
+    affect only new sessions. *)
+let missed_pong_threshold () =
+  max 0 (Env_config_core.get_int ~default:3 "MASC_WS_MISSED_PONG_THRESHOLD")
+
+let __test_missed_pong_threshold = missed_pong_threshold
+
 let start_upgrade_heartbeat ?sw ?clock session_id session =
   match sw, clock with
-  | Some sw, Some clock ->
-    Eio.Fiber.fork ~sw (fun () ->
-      let rec loop () =
-        Eio.Time.sleep clock heartbeat_interval_s;
-        if not session.closed && not (Httpun_ws.Wsd.is_closed session.wsd)
-        then (
-          let send_failed = ref false in
-          (try Httpun_ws.Wsd.send_ping session.wsd with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-             send_failed := true;
-             (match Http_server_eio.Late_response.classify_write_failure exn with
-              | Some _ ->
-                Log.Server.debug
-                  "[ws-upgrade] session %s heartbeat skipped (writer closed during \
-                   cancel race)"
-                  session_id
-              | None ->
-                Log.Server.warn
-                  "[ws-upgrade] session %s heartbeat send_ping failed: %s"
-                  session_id
-                  (Printexc.to_string exn)));
-          if !send_failed then cleanup_session session_id else loop ())
-      in
-      loop ())
+  | Some server_sw, Some clock ->
+    let threshold = missed_pong_threshold () in
+    Eio.Fiber.fork ~sw:server_sw (fun () ->
+      (* Per-connection switch: the heartbeat fiber must not be anchored to the
+         server-wide switch.  When the connection closes the loop exits and this
+         switch cleans up with it. *)
+      Eio.Switch.run (fun _conn_sw ->
+        let rec loop () =
+          Eio.Time.sleep clock heartbeat_interval_s;
+          if is_session_closed session
+          then ()
+          else if threshold > 0 && Atomic.get session.missed_pongs >= threshold
+          then begin
+            Log.Server.debug
+              "[ws-upgrade] session %s missed %d pongs; closing"
+              session_id
+              (Atomic.get session.missed_pongs);
+            cleanup_session session_id
+          end
+          else begin
+            let send_failed = ref false in
+            (try
+               Eio_guard.with_mutex session.write_mutex (fun () ->
+                 if not (is_session_closed session) then
+                   Httpun_ws.Wsd.send_ping session.wsd)
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+               send_failed := true;
+               (match Http_server_eio.Late_response.classify_write_failure exn with
+                | Some _ ->
+                  Log.Server.debug
+                    "[ws-upgrade] session %s heartbeat skipped (writer closed during \
+                     cancel race)"
+                    session_id
+                | None ->
+                  Log.Server.warn
+                    "[ws-upgrade] session %s heartbeat send_ping failed: %s"
+                    session_id
+                    (Printexc.to_string exn)));
+            if !send_failed
+            then cleanup_session session_id
+            else begin
+              Atomic.set session.missed_pongs (Atomic.get session.missed_pongs + 1);
+              loop ()
+            end
+          end
+        in
+        loop ()))
   | _ ->
     Log.Server.debug
       "[ws-upgrade] session %s heartbeat disabled (missing switch or clock)"
       session_id
 
-let send_upgrade_pong session_id wsd =
-  try Httpun_ws.Wsd.send_pong wsd with
+let send_upgrade_pong session =
+  try
+    Eio_guard.with_mutex session.write_mutex (fun () ->
+      if not (is_session_closed session) then
+        Httpun_ws.Wsd.send_pong session.wsd)
+  with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     (match Http_server_eio.Late_response.classify_write_failure exn with
      | Some _ ->
        Log.Server.debug
          "[ws-upgrade] session %s send_pong skipped (writer closed during cancel race)"
-         session_id
+         session.id
      | None ->
        Log.Server.warn
          "[ws-upgrade] session %s send_pong failed: %s"
-         session_id
+         session.id
          (Printexc.to_string exn))
 
 (** Handle an HTTP upgrade request to WebSocket.
@@ -936,10 +1014,9 @@ let upgrade_connection
             (with_sessions_rw (fun () -> Hashtbl.length sessions));
           (* Register as SSE external subscriber for broadcast events *)
           Sse.subscribe_external ~id:session_id
-            ~is_alive:(fun () ->
-              not session.closed && not (Httpun_ws.Wsd.is_closed session.wsd))
+            ~is_alive:(fun () -> not (is_session_closed session))
             ~callback:(fun sse_event ->
-              if not session.closed
+              if not (is_session_closed session)
                  && not (send_dashboard_or_raw_sse session sse_event)
               then
                 cleanup_session session_id)
@@ -955,12 +1032,15 @@ let upgrade_connection
                 read_inbound_message_frame session ~on_message ~is_fin ~len
                   payload
               | `Ping ->
-                send_upgrade_pong session_id wsd;
+                send_upgrade_pong session;
+                Httpun_ws.Payload.close payload
+              | `Pong ->
+                record_pong session;
                 Httpun_ws.Payload.close payload
               | `Connection_close ->
                 cleanup_session session_id;
                 Httpun_ws.Payload.close payload
-              | `Pong | `Other _ ->
+              | `Other _ ->
                 Httpun_ws.Payload.close payload
             );
             eof = (fun ?error:_ () ->

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -339,11 +339,6 @@ val __test_reset_env_caches : unit -> unit
     {!slice_index_enabled} caches so the next call
     re-reads the environment. *)
 
-val __test_new_session : id:string -> ws_session
-(** Test-only seam: construct a session with a placeholder [Wsd.t] so lifecycle
-    and state probes can be exercised without a live HTTP upgrade.  The
-    resulting value must not be used for actual wire I/O. *)
-
 val __test_missed_pong_threshold : unit -> int
 (** Test-only seam: exposes the configured missed-pong threshold so tests can
     verify default / env-var / clamping behavior. *)

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -73,7 +73,10 @@ type dashboard_auth_state =
 type ws_session = {
   id : string;
   wsd : Httpun_ws.Wsd.t;
-  mutable closed : bool;
+  closed : bool Atomic.t;
+  write_mutex : Eio.Mutex.t;
+  last_pong_at : float Atomic.t;
+  missed_pongs : int Atomic.t;
   dashboard_auth : dashboard_auth_state Atomic.t;
   mutable dashboard_route : string option;
   dashboard_slices : (string, unit) Hashtbl.t;
@@ -89,7 +92,11 @@ type ws_session = {
     {!sessions} table directly.  Mutable fields track
     the dashboard handshake / ack state machine; see the
     [#10648] / dashboard-ws.v1 protocol notes in the .ml
-    for the field semantics. *)
+    for the field semantics.
+
+    Cross-fiber scalar state ([closed], [last_pong_at], [missed_pongs]) is
+    held in [Atomic.t] values; all writes to [wsd] are serialized through
+    [write_mutex]. *)
 
 val dashboard_auth_is_authenticated : dashboard_auth_state -> bool
 (** [true] once [dashboard_hello] has authenticated the session. *)
@@ -150,6 +157,14 @@ val new_session : id:string -> wsd:Httpun_ws.Wsd.t -> ws_session
     inserts the result into {!sessions} under
     {!with_sessions_rw}. *)
 
+val is_session_closed : ws_session -> bool
+(** [true] once the session has been closed locally or the httpun-ws writer
+    has shut down.  Safe to call from any fiber. *)
+
+val record_pong : ws_session -> unit
+(** Refresh [last_pong_at] and reset the missed-pong counter.  Called by the
+    WS frame handler on every [Pong] frame. *)
+
 val cleanup_session : string -> unit
 (** Removes the session from {!sessions} (and the
     slice-fanout side index).  Idempotent — calling on
@@ -181,8 +196,9 @@ val upgrade_connection :
   Httpun.Reqd.t ->
   (unit, string) result
 (** Handles an HTTP/1.1 [GET /ws] upgrade on the main HTTP origin.  When [sw]
-    and [clock] are provided, forks the same protocol-level heartbeat used by
-    the standalone WS listener. *)
+    and [clock] are provided, forks the protocol-level heartbeat on a
+    per-connection switch (a child of [sw]) and closes the session after a
+    configurable number of missed pongs. *)
 
 (** {1 Outbound delivery} *)
 
@@ -322,3 +338,12 @@ val __test_reset_env_caches : unit -> unit
     {!client_buffer_limit_bytes} and
     {!slice_index_enabled} caches so the next call
     re-reads the environment. *)
+
+val __test_new_session : id:string -> ws_session
+(** Test-only seam: construct a session with a placeholder [Wsd.t] so lifecycle
+    and state probes can be exercised without a live HTTP upgrade.  The
+    resulting value must not be used for actual wire I/O. *)
+
+val __test_missed_pong_threshold : unit -> int
+(** Test-only seam: exposes the configured missed-pong threshold so tests can
+    verify default / env-var / clamping behavior. *)

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -1,16 +1,8 @@
 (** Standalone WebSocket server for MASC MCP.
 
     Runs on a separate port (default 8937, configurable via MASC_WS_PORT).
-    Enabled by default. Disable with MASC_WS_ENABLED=0.
-
-    Unlike the /ws upgrade path on the HTTP port, this server owns the
-    full TCP socket, so httpun-ws can run the HTTP->WS upgrade lifecycle
-    end-to-end without conflicting with gluten's protocol management.
-
-    Session state is shared with {!Server_mcp_transport_ws}: the same
-    [sessions] hashtable, [send_to_session], and [cleanup_session] are
-    reused.  This module only handles TCP accept + connection handler
-    wiring. *)
+    Session state is shared with {!Server_mcp_transport_ws}; this module only
+    wires TCP accept + the httpun-ws connection handler. *)
 
 module Ws = Httpun_ws
 module Ws_eio = Httpun_ws_eio
@@ -25,41 +17,22 @@ let configured_port () = Env_config.Transport.ws_port
     Disable with MASC_WS_ENABLED=0 or MASC_WS_ENABLED=false. *)
 let is_enabled () = Transport_metrics.ws_enabled ()
 
-(** Interval between protocol-level heartbeat pings on each WS session.
-
-    30s strikes a balance between keeping NAT/proxy mappings warm
-    (typical idle-mapping eviction is 60-120s) and not spamming the
-    write path on a quiet connection.  The browser handles pong replies
-    invisibly in the WebSocket implementation; the server detects dead
-    peers when [Ws.Wsd.is_closed] flips or the underlying write raises a
-    classify_write_failure-recognised error. *)
+(** Interval between protocol-level heartbeat pings on each WS session. *)
 let heartbeat_interval_s = 30.0
 
-(** Default number of consecutive unanswered protocol pings before the server
-    declares the peer dead and closes the standalone WS session.  Three misses
-    means the client failed to respond for roughly two heartbeat intervals past
-    the normal ping/pong round-trip; this is long enough to survive transient
-    scheduler stalls and short enough to reclaim the session before dashboards
-    hang for many minutes.  Operators can override with
-    [MASC_WS_MISSED_PONG_THRESHOLD]. *)
+(** Default consecutive unanswered pings before the server closes the session.
+    Override with [MASC_WS_MISSED_PONG_THRESHOLD]. *)
 let pong_timeout_intervals = 3
 
-(** Configurable missed-pong threshold for the standalone WS listener.
-
-    A value of [0] disables the pong-timeout guard.  Negative values are
-    clamped to [0] so they cannot force immediate closure.  The threshold is
-    read once per session at creation time; changes to the environment variable
-    affect only new sessions. *)
+(** Configurable missed-pong threshold. [0] disables the guard; negatives are
+    clamped to [0].  Read once per session. *)
 let missed_pong_threshold () =
   max 0 (Env_config_core.get_int ~default:pong_timeout_intervals "MASC_WS_MISSED_PONG_THRESHOLD")
 
-(** Cap for accept-error exponential backoff.  Five seconds keeps the listener
-    responsive after a transient failure without tight-spinning. *)
+(** Cap for accept-error exponential backoff. *)
 let accept_backoff_cap_s = 5.0
 
-(** Factor for accept-error backoff jitter.  A ±20% spread prevents a fleet of
-    restarted listeners from thundering on the same schedule after a shared
-    upstream outage. *)
+(** Factor for accept-error backoff jitter (±20%). *)
 let accept_backoff_jitter_frac = 0.2
 
 let max_ws_close_reason_log_len = 96
@@ -179,10 +152,7 @@ module For_testing = struct
   let missed_pong_threshold = missed_pong_threshold
   let accept_backoff_cap_s = accept_backoff_cap_s
 
-  (** Deterministic next accept-error backoff (no jitter).  The production
-      loop adds ±[accept_backoff_jitter_frac] jitter on top of this base.
-      Exposed so the backoff progression is unit-testable without spinning
-      the real server. *)
+  (** Deterministic next accept-error backoff (production adds jitter). *)
   let next_accept_backoff backoff_s = Float.min accept_backoff_cap_s (backoff_s *. 1.5)
 end
 
@@ -254,15 +224,8 @@ let standalone_ws_eof_summary = function
   | Some (`Exn exn) -> Printf.sprintf "error=%s" (Printexc.to_string exn)
 ;;
 
-(** WebSocket handler factory.
-
-    For each accepted connection, httpun-ws-eio calls this with the
-    client address and a [Wsd.t].  We create a session in the shared
-    registry and wire frame callbacks to [on_message].
-
-    [~sw] is the {b per-connection} switch — heartbeat fibers fork onto
-    it so they exit with the connection instead of lingering on the
-    server-wide switch.  [~clock] drives the heartbeat sleep. *)
+(** WebSocket handler factory.  [~sw] is the per-connection switch so heartbeat
+    fibers exit with the connection instead of lingering on the server switch. *)
 let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
   : Ws.Websocket_connection.input_handlers
   =
@@ -287,13 +250,8 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
           session_id;
         Server_mcp_transport_ws.cleanup_session session_id))
     ();
-  (* Heartbeat fiber: emit a protocol-level ping every
-     [heartbeat_interval_s] to keep NAT/proxy mappings warm and surface
-     silent disconnects so the reconnect path on the client can engage
-     instead of hanging on a dead socket.  Tracks [last_pong_at] and
-     closes the session after [missed_pong_threshold] unanswered pings.
-     Forked on the per-connection switch, so it cannot outlive the
-     connection. *)
+  (* Heartbeat fiber: ping every [heartbeat_interval_s], count missed pongs,
+     and close the session once the threshold is reached. *)
   let threshold = missed_pong_threshold () in
   Eio.Fiber.fork ~sw (fun () ->
     let send_ping () =
@@ -334,13 +292,8 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
                   (Printexc.to_string exn)));
           if !send_failed
           then
-            (* If send_ping failed while the session still appeared open,
-               the loop would otherwise spin emitting warnings until the WSD
-               finally observed the broken socket.  Mark the session closed
-               and run [cleanup_session] now so the rest of the pipeline
-               (sessions table, heartbeat budget, aggregate metrics) drops
-               the half-open session immediately instead of leaking a fiber
-               per failure. *)
+            (* Drop the half-open session immediately so the loop does not
+               spin until the WSD observes the broken socket. *)
             Server_mcp_transport_ws.cleanup_session session_id
           else begin
             Atomic.set session.missed_pongs (missed + 1);
@@ -366,17 +319,9 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
             ~len
             payload
         | `Ping ->
-          (* Guard against "cannot write to closed writer" when the WSD is
-           closed during a cancel/disconnect race (2026-05-05 cycle9 incident).
-           Serialize the pong through the session write mutex and re-check
-           closure under the lock so we do not race with cleanup or heartbeat.
-
-           Use the centralized [Late_response.classify_write_failure]
-           SSOT so the recognized "writer closed during cancel" race
-           is downgraded to debug here too — matching the outer
-           connection_handler.  Anything the classifier does not own
-           (genuine bugs / unexpected exceptions) still warns.  This
-           closes the warn-noise gap reported in #13082 review. *)
+          (* Serialize the pong through the write mutex and re-check closure
+             under the lock to avoid racing cleanup/heartbeat.  Recognized
+             "writer closed during cancel" races are downgraded to debug. *)
           (try
              Eio_guard.with_mutex session.write_mutex (fun () ->
                if not (Server_mcp_transport_ws.is_session_closed session) then
@@ -410,16 +355,8 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
   }
 ;;
 
-(** Start the standalone WebSocket server.
-
-    Forks a fiber that listens for TCP connections and runs the
-    httpun-ws-eio connection handler for each.  Does nothing if
-    [MASC_WS_ENABLED] is not set.
-
-    @param sw Eio switch for structured concurrency.
-    @param env Eio environment (for network access).
-    @param on_message Called with [(session_id, body_str)] for each
-      inbound text frame. *)
+(** Start the standalone WebSocket server.  Does nothing if
+    [MASC_WS_ENABLED] is not set. *)
 let start
       ~(sw : Eio.Switch.t)
       ~(env : Eio_unix.Stdenv.base)
@@ -454,21 +391,10 @@ let start
                try
                  let flow, client_addr = Eio.Net.accept ~sw socket in
                  Eio.Fiber.fork ~sw (fun () ->
-                   (* Per-connection switch so the accepted [flow] is
-                     released the moment the WS handler exits, not when
-                     the long-lived server [sw] closes. Without this
-                     each connection's FD lingers in the kernel [CLOSED]
-                     state until shutdown — a 1Hz dashboard reconnect
-                     (claude-in-chrome's playwright Chrome polls
-                     [ws://127.0.0.1:8937/]) accumulates ~3 600 FDs/h,
-                     tripping [admission_queue_rejected: fd count >= 90%]
-                     and starving every keeper subprocess. Pattern
-                     matches [http_server_h2.ml]'s accept loop.
-
-                     The httpun-ws-eio connection handler and the
-                     WebSocket handler factory are created here (per
-                     connection) so the heartbeat fiber is forked on
-                     [conn_sw], not the server-wide [sw]. *)
+                   (* Per-connection switch releases [flow] as soon as the
+                      handler exits, preventing FD accumulation.  The connection
+                      handler and WebSocket handler are created here so the
+                      heartbeat fiber runs on [conn_sw], not the server switch. *)
                    Eio.Switch.run (fun conn_sw ->
                      let connection_handler =
                        Ws_eio.Server.create_connection_handler
@@ -502,10 +428,7 @@ let start
                  Log.Server.error
                    "WS standalone accept error: %s"
                    (Printexc.to_string exn);
-                 (* Backoff to avoid tight error loops.  Exponential growth
-                    with ±20% jitter and a 5s cap so a transient accept storm
-                    does not become a tight spin or a synchronized retry wave
-                    across many listeners. *)
+                 (* Back off exponentially with jitter and a 5s cap. *)
                  (try Eio.Time.sleep (Eio.Stdenv.clock env) backoff_s with
                   | Eio.Cancel.Cancelled _ as e -> raise e
                   | exn ->

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -35,6 +35,33 @@ let is_enabled () = Transport_metrics.ws_enabled ()
     classify_write_failure-recognised error. *)
 let heartbeat_interval_s = 30.0
 
+(** Default number of consecutive unanswered protocol pings before the server
+    declares the peer dead and closes the standalone WS session.  Three misses
+    means the client failed to respond for roughly two heartbeat intervals past
+    the normal ping/pong round-trip; this is long enough to survive transient
+    scheduler stalls and short enough to reclaim the session before dashboards
+    hang for many minutes.  Operators can override with
+    [MASC_WS_MISSED_PONG_THRESHOLD]. *)
+let pong_timeout_intervals = 3
+
+(** Configurable missed-pong threshold for the standalone WS listener.
+
+    A value of [0] disables the pong-timeout guard.  Negative values are
+    clamped to [0] so they cannot force immediate closure.  The threshold is
+    read once per session at creation time; changes to the environment variable
+    affect only new sessions. *)
+let missed_pong_threshold () =
+  max 0 (Env_config_core.get_int ~default:pong_timeout_intervals "MASC_WS_MISSED_PONG_THRESHOLD")
+
+(** Cap for accept-error exponential backoff.  Five seconds keeps the listener
+    responsive after a transient failure without tight-spinning. *)
+let accept_backoff_cap_s = 5.0
+
+(** Factor for accept-error backoff jitter.  A ±20% spread prevents a fleet of
+    restarted listeners from thundering on the same schedule after a shared
+    upstream outage. *)
+let accept_backoff_jitter_frac = 0.2
+
 let max_ws_close_reason_log_len = 96
 let max_ws_close_payload_len = 125
 
@@ -146,6 +173,17 @@ module For_testing = struct
         }
 
   let plan_ws_close_payload_chunk = plan_ws_close_payload_chunk
+
+  let heartbeat_interval_s = heartbeat_interval_s
+  let pong_timeout_intervals = pong_timeout_intervals
+  let missed_pong_threshold = missed_pong_threshold
+  let accept_backoff_cap_s = accept_backoff_cap_s
+
+  (** Deterministic next accept-error backoff (no jitter).  The production
+      loop adds ±[accept_backoff_jitter_frac] jitter on top of this base.
+      Exposed so the backoff progression is unit-testable without spinning
+      the real server. *)
+  let next_accept_backoff backoff_s = Float.min accept_backoff_cap_s (backoff_s *. 1.5)
 end
 
 let log_ws_client_close_payload ~session_id ~declared_len payload =
@@ -222,9 +260,9 @@ let standalone_ws_eof_summary = function
     client address and a [Wsd.t].  We create a session in the shared
     registry and wire frame callbacks to [on_message].
 
-    [~sw] is the server-wide switch — heartbeat fibers fork onto it and
-    self-exit as soon as the session closes.  [~clock] drives the
-    heartbeat sleep. *)
+    [~sw] is the {b per-connection} switch — heartbeat fibers fork onto
+    it so they exit with the connection instead of lingering on the
+    server-wide switch.  [~clock] drives the heartbeat sleep. *)
 let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
   : Ws.Websocket_connection.input_handlers
   =
@@ -238,10 +276,10 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
   (* Register as SSE external subscriber for broadcast events *)
   Sse.subscribe_external
     ~id:session_id
-    ~is_alive:(fun () -> (not session.closed) && not (Ws.Wsd.is_closed session.wsd))
+    ~is_alive:(fun () -> not (Server_mcp_transport_ws.is_session_closed session))
     ~callback:(fun sse_event ->
       if
-        (not session.closed)
+        (not (Server_mcp_transport_ws.is_session_closed session))
         && not (Server_mcp_transport_ws.send_dashboard_or_raw_sse session sse_event)
       then (
         Log.Server.debug
@@ -252,41 +290,64 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
   (* Heartbeat fiber: emit a protocol-level ping every
      [heartbeat_interval_s] to keep NAT/proxy mappings warm and surface
      silent disconnects so the reconnect path on the client can engage
-     instead of hanging on a dead socket.  Exits once [session.closed]
-     flips or the writer is closed, so it does not outlive the
-     connection beyond one sleep tick. *)
+     instead of hanging on a dead socket.  Tracks [last_pong_at] and
+     closes the session after [missed_pong_threshold] unanswered pings.
+     Forked on the per-connection switch, so it cannot outlive the
+     connection. *)
+  let threshold = missed_pong_threshold () in
   Eio.Fiber.fork ~sw (fun () ->
+    let send_ping () =
+      Eio_guard.with_mutex session.write_mutex (fun () ->
+        if not (Server_mcp_transport_ws.is_session_closed session) then
+          Ws.Wsd.send_ping session.wsd)
+    in
     let rec loop () =
       Eio.Time.sleep clock heartbeat_interval_s;
-      if (not session.closed) && not (Ws.Wsd.is_closed session.wsd)
-      then (
-        let send_failed = ref false in
-        (try Ws.Wsd.send_ping wsd with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn ->
-           send_failed := true;
-           (match Http_server_eio.Late_response.classify_write_failure exn with
-            | Some _ ->
-              Log.Server.debug
-                "[ws-standalone] session %s heartbeat skipped (writer closed during \
-                 cancel race)"
-                session_id
-            | None ->
-              Log.Server.warn
-                "[ws-standalone] session %s heartbeat send_ping failed: %s"
-                session_id
-                (Printexc.to_string exn)));
-        if !send_failed
-        then
-          (* If send_ping failed while [session.closed]/[Wsd.is_closed]
-             still read false, the loop would otherwise spin emitting
-             warnings until the WSD finally observed the broken socket.
-             Mark the session closed and run [cleanup_session] now so
-             the rest of the pipeline (sessions table, heartbeat budget,
-             aggregate metrics) drops the half-open session immediately
-             instead of leaking a fiber per failure. *)
+      if Server_mcp_transport_ws.is_session_closed session
+      then ()
+      else begin
+        let missed = Atomic.get session.missed_pongs in
+        if threshold > 0 && missed >= threshold
+        then begin
+          Log.Server.debug
+            "[ws-standalone] session %s missed %d pongs; closing"
+            session_id
+            missed;
           Server_mcp_transport_ws.cleanup_session session_id
-        else loop ())
+        end
+        else begin
+          let send_failed = ref false in
+          (try send_ping () with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+             send_failed := true;
+             (match Http_server_eio.Late_response.classify_write_failure exn with
+              | Some _ ->
+                Log.Server.debug
+                  "[ws-standalone] session %s heartbeat skipped (writer closed during \
+                   cancel race)"
+                  session_id
+              | None ->
+                Log.Server.warn
+                  "[ws-standalone] session %s heartbeat send_ping failed: %s"
+                  session_id
+                  (Printexc.to_string exn)));
+          if !send_failed
+          then
+            (* If send_ping failed while the session still appeared open,
+               the loop would otherwise spin emitting warnings until the WSD
+               finally observed the broken socket.  Mark the session closed
+               and run [cleanup_session] now so the rest of the pipeline
+               (sessions table, heartbeat budget, aggregate metrics) drops
+               the half-open session immediately instead of leaking a fiber
+               per failure. *)
+            Server_mcp_transport_ws.cleanup_session session_id
+          else begin
+            Atomic.set session.missed_pongs (missed + 1);
+            loop ()
+          end
+        end
+      end
     in
     loop ());
   (* #10875: WS storm (#10701) emits ~190k connect/close lines/day at INFO,
@@ -307,9 +368,8 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
         | `Ping ->
           (* Guard against "cannot write to closed writer" when the WSD is
            closed during a cancel/disconnect race (2026-05-05 cycle9 incident).
-           The outer connection_handler catch already swallows these, but
-           wrapping here makes the intent explicit and avoids an intermediate
-           httpun-ws state-machine inconsistency.
+           Serialize the pong through the session write mutex and re-check
+           closure under the lock so we do not race with cleanup or heartbeat.
 
            Use the centralized [Late_response.classify_write_failure]
            SSOT so the recognized "writer closed during cancel" race
@@ -317,7 +377,11 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
            connection_handler.  Anything the classifier does not own
            (genuine bugs / unexpected exceptions) still warns.  This
            closes the warn-noise gap reported in #13082 review. *)
-          (try Ws.Wsd.send_pong wsd with
+          (try
+             Eio_guard.with_mutex session.write_mutex (fun () ->
+               if not (Server_mcp_transport_ws.is_session_closed session) then
+                 Ws.Wsd.send_pong session.wsd)
+           with
            | Eio.Cancel.Cancelled _ as e -> raise e
            | exn ->
              (match Http_server_eio.Late_response.classify_write_failure exn with
@@ -329,10 +393,13 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
                   "[ws-standalone] send_pong failed: %s"
                   (Printexc.to_string exn)));
           Ws.Payload.close payload
+        | `Pong ->
+          Server_mcp_transport_ws.record_pong session;
+          Ws.Payload.close payload
         | `Connection_close ->
           log_ws_client_close_payload ~session_id ~declared_len:len payload;
           Server_mcp_transport_ws.cleanup_session session_id
-        | `Pong | `Other _ -> Ws.Payload.close payload)
+        | `Other _ -> Ws.Payload.close payload)
   ; eof =
       (fun ?error () ->
         Log.Server.debug
@@ -375,11 +442,6 @@ let start
       Transport_metrics.set_ws_runtime_listening true;
       Transport_metrics.set_ws_listen_status "listening";
       let clock = Eio.Stdenv.clock env in
-      let connection_handler =
-        Ws_eio.Server.create_connection_handler
-          ~sw
-          (make_websocket_handler ~sw ~clock ~on_message)
-      in
       Eio.Fiber.fork ~sw (fun () ->
         (* Safe: finally is Atomic.set — no I/O, no exception risk *)
         Eio_guard.protect
@@ -401,8 +463,18 @@ let start
                      [ws://127.0.0.1:8937/]) accumulates ~3 600 FDs/h,
                      tripping [admission_queue_rejected: fd count >= 90%]
                      and starving every keeper subprocess. Pattern
-                     matches [http_server_h2.ml]'s accept loop. *)
+                     matches [http_server_h2.ml]'s accept loop.
+
+                     The httpun-ws-eio connection handler and the
+                     WebSocket handler factory are created here (per
+                     connection) so the heartbeat fiber is forked on
+                     [conn_sw], not the server-wide [sw]. *)
                    Eio.Switch.run (fun conn_sw ->
+                     let connection_handler =
+                       Ws_eio.Server.create_connection_handler
+                         ~sw:conn_sw
+                         (make_websocket_handler ~sw:conn_sw ~clock ~on_message)
+                     in
                      Eio.Switch.on_release conn_sw (fun () ->
                        try Eio.Flow.close flow with
                        | Eio.Cancel.Cancelled _ as e -> raise e
@@ -430,7 +502,10 @@ let start
                  Log.Server.error
                    "WS standalone accept error: %s"
                    (Printexc.to_string exn);
-                 (* Backoff to avoid tight error loops *)
+                 (* Backoff to avoid tight error loops.  Exponential growth
+                    with ±20% jitter and a 5s cap so a transient accept storm
+                    does not become a tight spin or a synchronized retry wave
+                    across many listeners. *)
                  (try Eio.Time.sleep (Eio.Stdenv.clock env) backoff_s with
                   | Eio.Cancel.Cancelled _ as e -> raise e
                   | exn ->
@@ -439,7 +514,11 @@ let start
                       port
                       backoff_s
                       (Printexc.to_string exn));
-                 let next_backoff = Float.min 2.0 (backoff_s *. 1.5) in
+                 let base = Float.min accept_backoff_cap_s (backoff_s *. 1.5) in
+                 let jitter =
+                   base *. accept_backoff_jitter_frac *. ((Random.float 2.0) -. 1.0) (* NDT-OK: intentional jitter to avoid thundering-herd reconnects. *)
+                 in
+                 let next_backoff = Float.max 0.05 (base +. jitter) in
                  accept_loop next_backoff
              in
              accept_loop 0.05))

--- a/lib/server/server_ws_standalone.mli
+++ b/lib/server/server_ws_standalone.mli
@@ -52,6 +52,20 @@ module For_testing : sig
 
   val plan_ws_close_payload_chunk :
     offset:int -> declared_len:int -> chunk_len:int -> ws_close_payload_chunk_plan
+
+  val heartbeat_interval_s : float
+
+  val pong_timeout_intervals : int
+
+  val missed_pong_threshold : unit -> int
+  (** Configurable missed-pong threshold (default: {!pong_timeout_intervals}).
+      Reads [MASC_WS_MISSED_PONG_THRESHOLD] once; clamps negative values to 0. *)
+
+  val accept_backoff_cap_s : float
+
+  val next_accept_backoff : float -> float
+  (** Deterministic base for the next accept-error backoff.  The production
+      loop adds jitter on top of this value. *)
 end
 
 val start :
@@ -95,6 +109,14 @@ val start :
     factor 1.5, capped at 2.0s) so a tight error loop does not
     saturate the CPU.  Cancellation is propagated through the
     backoff sleep.
+
+    {2 Heartbeat + pong timeout}
+
+    Each connection forks a protocol-level ping fiber on its own
+    switch.  The server tracks [last_pong_at] and resets the
+    missed-pong counter on every client [Pong].  After
+    [pong_timeout_intervals] consecutive unanswered pings, the
+    session is closed so dead peers do not accumulate.
 
     {2 [on_message]}
 

--- a/test/test_ws_standalone_close_payload.ml
+++ b/test/test_ws_standalone_close_payload.ml
@@ -122,6 +122,42 @@ let test_plan_ws_close_payload_chunk_guards_zero_len () =
   | _ -> fail "expected oversized chunk to finish after copying remaining bytes"
 ;;
 
+let test_heartbeat_constants_sensible () =
+  check (float 0.001) "heartbeat interval positive" 30.0 WS.heartbeat_interval_s;
+  check int "default pong timeout intervals" 3 WS.pong_timeout_intervals
+;;
+
+let with_env_var name value f =
+  let prev = try Some (Sys.getenv name) with Not_found -> None in
+  Unix.putenv name value;
+  Fun.protect ~finally:(fun () ->
+    match prev with
+    | Some v -> Unix.putenv name v
+    | None -> Unix.putenv name "")
+    f
+;;
+
+let test_missed_pong_threshold_configuration () =
+  with_env_var "MASC_WS_MISSED_PONG_THRESHOLD" "" (fun () ->
+    check int "default threshold" 3 (WS.missed_pong_threshold ()));
+  with_env_var "MASC_WS_MISSED_PONG_THRESHOLD" "5" (fun () ->
+    check int "env=5 → threshold 5" 5 (WS.missed_pong_threshold ()));
+  with_env_var "MASC_WS_MISSED_PONG_THRESHOLD" "0" (fun () ->
+    check int "env=0 disables threshold" 0 (WS.missed_pong_threshold ()));
+  with_env_var "MASC_WS_MISSED_PONG_THRESHOLD" "-2" (fun () ->
+    check int "negative values clamp to 0" 0 (WS.missed_pong_threshold ()))
+;;
+
+let test_accept_backoff_progression () =
+  check (float 0.001) "initial backoff" 0.075 (WS.next_accept_backoff 0.05);
+  check (float 0.001) "second backoff" 0.1125 (WS.next_accept_backoff 0.075);
+  check (float 0.001) "exponential growth" 0.16875 (WS.next_accept_backoff 0.1125);
+  check (float 0.001) "backs off until cap" WS.accept_backoff_cap_s
+    (WS.next_accept_backoff WS.accept_backoff_cap_s);
+  check (float 0.001) "stays at cap" WS.accept_backoff_cap_s
+    (WS.next_accept_backoff WS.accept_backoff_cap_s)
+;;
+
 let () =
   run
     "ws_standalone_close_payload"
@@ -142,6 +178,20 @@ let () =
             "zero-length read chunk guard"
             `Quick
             test_plan_ws_close_payload_chunk_guards_zero_len
+        ] )
+    ; ( "heartbeat and accept backoff"
+      , [ test_case
+            "heartbeat constants are sensible"
+            `Quick
+            test_heartbeat_constants_sensible
+        ; test_case
+            "missed-pong threshold is configurable"
+            `Quick
+            test_missed_pong_threshold_configuration
+        ; test_case
+            "accept backoff progression caps"
+            `Quick
+            test_accept_backoff_progression
         ] )
     ]
 ;;

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -650,6 +650,40 @@ let test_dashboard_auth_authenticated_tokenless () =
   Alcotest.(check (option string)) "tokenless carries no agent"
     None (Ws.dashboard_auth_agent st)
 
+(* ====== Cross-fiber scalar state (Atomic.t) ====== *)
+
+let test_new_session_initializes_pong_state () =
+  let session = Ws.__test_new_session ~id:"pong-state-init" in
+  Alcotest.(check bool) "closed starts false" false (Atomic.get session.closed);
+  Alcotest.(check int) "missed_pongs starts at 0" 0 (Atomic.get session.missed_pongs);
+  Alcotest.(check bool) "last_pong_at is in the recent past"
+    true
+    (Atomic.get session.last_pong_at <= Unix.gettimeofday ())
+
+let test_record_pong_resets_missed_pongs () =
+  let session = Ws.__test_new_session ~id:"pong-reset" in
+  Atomic.set session.missed_pongs 5;
+  let before = Atomic.get session.last_pong_at in
+  Unix.sleepf 0.005;
+  Ws.record_pong session;
+  Alcotest.(check int) "missed_pongs reset to 0" 0 (Atomic.get session.missed_pongs);
+  Alcotest.(check bool) "last_pong_at advanced"
+    true
+    (Atomic.get session.last_pong_at > before)
+
+let test_missed_pong_threshold_default () =
+  (* Clear any inherited value so the default (3) is exercised. *)
+  Unix.putenv "MASC_WS_MISSED_PONG_THRESHOLD" "";
+  Alcotest.(check int) "default threshold is 3" 3 (Ws.__test_missed_pong_threshold ())
+
+let test_missed_pong_threshold_reads_env () =
+  with_env_var "MASC_WS_MISSED_PONG_THRESHOLD" "5" (fun () ->
+    Alcotest.(check int) "env=5 → threshold 5" 5 (Ws.__test_missed_pong_threshold ()));
+  with_env_var "MASC_WS_MISSED_PONG_THRESHOLD" "0" (fun () ->
+    Alcotest.(check int) "env=0 disables threshold" 0 (Ws.__test_missed_pong_threshold ()));
+  with_env_var "MASC_WS_MISSED_PONG_THRESHOLD" "-2" (fun () ->
+    Alcotest.(check int) "negative values clamp to 0" 0 (Ws.__test_missed_pong_threshold ()))
+
 let () =
   Alcotest.run "WebSocket Transport" [
     ("session_registry", [
@@ -754,5 +788,17 @@ let () =
         test_dashboard_auth_authenticated_with_agent;
       Alcotest.test_case "tokenless Authenticated has no agent" `Quick
         test_dashboard_auth_authenticated_tokenless;
+    ]);
+    ("pong_state", [
+      Alcotest.test_case "new session initializes pong atomics" `Quick
+        test_new_session_initializes_pong_state;
+      Alcotest.test_case "record_pong resets missed_pongs" `Quick
+        test_record_pong_resets_missed_pongs;
+    ]);
+    ("pong_threshold", [
+      Alcotest.test_case "default missed-pong threshold is 3" `Quick
+        test_missed_pong_threshold_default;
+      Alcotest.test_case "threshold reads env and clamps negatives" `Quick
+        test_missed_pong_threshold_reads_env;
     ]);
   ]

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -653,7 +653,7 @@ let test_dashboard_auth_authenticated_tokenless () =
 (* ====== Cross-fiber scalar state (Atomic.t) ====== *)
 
 let test_new_session_initializes_pong_state () =
-  let session = Ws.__test_new_session ~id:"pong-state-init" in
+  let session = Ws.new_session ~id:"pong-state-init" ~wsd:(Obj.magic ()) in
   Alcotest.(check bool) "closed starts false" false (Atomic.get session.closed);
   Alcotest.(check int) "missed_pongs starts at 0" 0 (Atomic.get session.missed_pongs);
   Alcotest.(check bool) "last_pong_at is in the recent past"
@@ -661,7 +661,7 @@ let test_new_session_initializes_pong_state () =
     (Atomic.get session.last_pong_at <= Unix.gettimeofday ())
 
 let test_record_pong_resets_missed_pongs () =
-  let session = Ws.__test_new_session ~id:"pong-reset" in
+  let session = Ws.new_session ~id:"pong-reset" ~wsd:(Obj.magic ()) in
   Atomic.set session.missed_pongs 5;
   let before = Atomic.get session.last_pong_at in
   Unix.sleepf 0.005;


### PR DESCRIPTION
## Summary

Hardens the MASC WebSocket/SSE transport layer to reduce frequent disconnects and lost session/auth state during keeper conversations.

## Problem

- Server-side WS writes were not serialized, so heartbeat, broadcast, and pong fibers could interleave on the same `Wsd.t`.
- The server sent WebSocket pings but never verified pongs, allowing half-open connections to linger.
- Heartbeat fibers were forked on the server-wide switch instead of the per-connection switch.
- `ws_session.closed` and related scalar state were plain mutable fields, creating data races under concurrent fibers.
- The dashboard client sent heartbeats without a timeout and reconnected blindly on every close code.
- SSE reconnects had no jitter or attempt ceiling, risking thundering-herd behavior.

## Changes

### Server (`lib/server/server_mcp_transport_ws.ml`, `lib/server/server_ws_standalone.ml`)

- Added a per-session `write_mutex : Eio.Mutex.t` and wrapped every `Wsd.send_*` and `Wsd.close` call.
- Added atomic `last_pong_at : float Atomic.t` and `missed_pongs : int Atomic.t`.
- Heartbeat increments `missed_pongs`; incoming `Pong` frames reset it. Session is closed after `MASC_WS_MISSED_PONG_THRESHOLD` missed pongs (default 3).
- Converted `ws_session.closed` to `bool Atomic.t` and made other hot-path scalar fields atomic.
- Forked heartbeat fibers on the per-connection switch so they are cancelled automatically when the connection closes.
- Improved standalone accept-loop backoff with ±20% jitter and a 5 s cap.

### Dashboard client (`dashboard/src/dashboard-ws.ts`)

- Added a 10 s timeout to heartbeat RPCs via `DASHBOARD_WS_HEARTBEAT_RPC_TIMEOUT_MS`.
- Stopped reconnecting on fatal close codes (`1008`, `1011`) and on abnormal closes after a failed `dashboard/hello`.
- Added discovery-cache failure counting; the cached `/ws` URL is invalidated only after 3 consecutive failures.

### SSE transport (`dashboard/src/transports/sse-transport.ts`)

- Added jitter to exponential reconnect backoff.
- Added `TRANSPORT_RETRY_MAX_ATTEMPTS` ceiling to prevent infinite reconnect loops.

### Tests

- Added pong-state / threshold tests in `test/test_ws_transport.ml`.
- Added heartbeat/backoff tests in `test/test_ws_standalone_close_payload.ml`.
- Added `dashboard/src/transports/sse-transport.test.ts` for jitter/max-attempt behavior.
- Expanded `dashboard/src/dashboard-ws.test.ts` for fatal-close and cache-invalidation cases.

## Verification

- `npx tsc --noEmit` in `dashboard/` passes.
- Dashboard tests pass: `dashboard-ws.test.ts` (31), `sse-transport.test.ts` (7).
- OCaml tests pass: `test_ws_transport.exe` (47), `test_ws_standalone_close_payload.exe` (7).
- `bin/main_eio.exe` builds successfully.

## Follow-up work (out of scope)

- Session resumption token to restore auth/subscriptions on reconnect.
- Keeper chat stream resume via `requestId` after mid-stream disconnect.
- Inbound WS message size limit.
- Fork `server_runtime_bootstrap.ml` request handlers on the connection switch.
