### PR TITLE
fix(dashboard): keep queued keeper chat entries across history merges

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -399,6 +399,125 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(keeperActionErrors.value.echo).toContain('서버 재시작')
     expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1)
   })
+
+  it('keeps the queued assistant after page reload while history has only the user message', async () => {
+    vi.useFakeTimers()
+    try {
+      _resetChatHydrationForTests()
+      _clearPendingKeeperChatRequestsForTests()
+      upsertPendingKeeperChatRequest({
+        requestId: 'kmsg_echo_1',
+        keeperName: 'echo',
+        message: '진행 상황?',
+        submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
+      })
+
+      // Server already persisted the user turn, but the assistant reply is
+      // still queued and has not been written yet.
+      fetchKeeperChatHistory.mockResolvedValue([
+        { role: 'user', content: '진행 상황?', ts: 1_780_000_000 },
+      ])
+
+      // First poll says queued; second poll completes so the test can finish.
+      let pollCount = 0
+      fetchQueuedKeeperMessageResult.mockImplementation(() => {
+        pollCount += 1
+        if (pollCount === 1) {
+          return Promise.resolve({ status: 'queued' })
+        }
+        return Promise.resolve({ status: 'done', ok: true, result: { reply: '완료' } })
+      })
+
+      // Simulate the post-reload mount: hydrate history and resume pending
+      // requests are kicked off concurrently by the panel effect.
+      await hydrateKeeperChatHistory('echo')
+      const resumePromise = resumePendingKeeperChatRequests('echo')
+
+      // During the first sleep the assistant should still be queued.
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect((keeperThreads.value.echo ?? []).some(entry => entry.role === 'assistant' && entry.delivery === 'queued')).toBe(true)
+
+      // Let the resume loop finish.
+      await vi.advanceTimersByTimeAsync(2_000)
+      await resumePromise
+
+      const thread = keeperThreads.value.echo ?? []
+      expect(thread.filter(entry => entry.role === 'user')).toHaveLength(1)
+      expect(thread.some(entry => entry.role === 'assistant' && entry.delivery === 'delivered')).toBe(true)
+      expect(keeperActionErrors.value.echo).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not replace a queued assistant with an older empty-text history error', async () => {
+    vi.useFakeTimers()
+    try {
+      _resetChatHydrationForTests()
+      _clearPendingKeeperChatRequestsForTests()
+      upsertPendingKeeperChatRequest({
+        requestId: 'kmsg_echo_2',
+        keeperName: 'echo',
+        message: '진행 상황?',
+        submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
+      })
+
+      // History resolves after the resume loop has created pending entries,
+      // so the merge races against the in-flight queued assistant. The older
+      // history error has empty visible text (kept only because of its audio
+      // clip), which would collide with the pending assistant under a naive
+      // role+text dedup and cause the queued state to appear as an error.
+      fetchKeeperChatHistory.mockImplementation(() => new Promise(resolve => {
+        setTimeout(() => {
+          resolve([
+            { role: 'user', content: 'old question', ts: 1_700_000_000 },
+            {
+              role: 'assistant',
+              content: '',
+              ts: 1_700_000_001,
+              kind: 'transport_failure',
+              audio: {
+                token: 'old-failure-clip',
+                mime: 'audio/mpeg',
+                duration_sec: 1,
+                message_text: '',
+              },
+            },
+          ])
+        }, 100)
+      }))
+
+      // Keep queued for the race window, then complete so the test can end.
+      let pollCount = 0
+      fetchQueuedKeeperMessageResult.mockImplementation(() => {
+        pollCount += 1
+        if (pollCount === 1) {
+          return Promise.resolve({ status: 'queued' })
+        }
+        return Promise.resolve({ status: 'done', ok: true, result: { reply: '완료' } })
+      })
+
+      const hydratePromise = hydrateKeeperChatHistory('echo')
+      const resumePromise = resumePendingKeeperChatRequests('echo')
+
+      // Let history resolve and merge while the assistant is still queued.
+      await vi.advanceTimersByTimeAsync(200)
+      await hydratePromise
+
+      const thread = keeperThreads.value.echo ?? []
+      const assistants = thread.filter(entry => entry.role === 'assistant')
+      expect(assistants).toHaveLength(2)
+      expect(assistants.some(entry => entry.delivery === 'queued')).toBe(true)
+      expect(assistants.some(entry => entry.delivery === 'error')).toBe(true)
+      expect(keeperActionErrors.value.echo).toBeNull()
+
+      // Let the resume loop finish.
+      await vi.advanceTimersByTimeAsync(2_000)
+      await resumePromise
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 // ─── Status / runtime actions (exports untested before this block) ──

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -548,6 +548,10 @@ function sameConversationEntry(
   return left.role === right.role && left.text === right.text
 }
 
+function isInFlightDelivery(delivery: KeeperConversationDelivery): boolean {
+  return delivery === 'sending' || delivery === 'streaming' || delivery === 'queued'
+}
+
 function replaceThread(name: string, entries: KeeperConversationEntry[]): void {
   // An empty history payload means the caller did not request history
   // (e.g. hydrateKeeperStatus fast path with tail_messages: 0), not
@@ -559,7 +563,12 @@ function replaceThread(name: string, entries: KeeperConversationEntry[]): void {
   const localEntries = existing.filter(
     entry =>
       entry.delivery !== 'history'
-      && !entries.some(historyEntry => sameConversationEntry(entry, historyEntry)),
+      // In-flight (sending/streaming/queued) entries represent live state and
+      // must survive history merges until they finalize. Otherwise a queued
+      // assistant with empty text can be mistaken for an older empty-text
+      // history row and dropped, making the queued reply look like an error.
+      && (isInFlightDelivery(entry.delivery)
+        || !entries.some(historyEntry => sameConversationEntry(entry, historyEntry))),
   )
   // When the merged list exceeds the cap, prefer to keep locally-created
   // entries (optimistic/pending/live) at the end rather than trimming the


### PR DESCRIPTION
대시보드에서 키퍼에게 메시지를 별내 응답이 queued 상태일 때, 대화를 나갔다 들어오면 hydrate/resume 병합 과정에서 빈 텍스트를 가진 queued assistant entry가 과거 빈 텍스트 history row와 중복으로 처리되어 사라지거나 에러로 보이는 문제를 수정합니다.

- In-flight(sending/streaming/queued) 로컬 entry들은 history merge 시 finalized 될 때까지 보존
- 재현/회귀 테스트 2건 추가

검증:
- npx vitest run --config vitest.config.ts src/keeper-actions.test.ts src/keeper-state.test.ts src/keeper-stream.test.ts: 84 pass
- npx tsc --noEmit: clean