### PR TITLE
feat(fusion): standalone keeper-independent fusion harness (RFC-0252)

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -310,7 +310,6 @@
   unix
   yojson
   fmt
-  str
   eio
   eio_main
   time_compat

--- a/bin/dune
+++ b/bin/dune
@@ -291,4 +291,37 @@
  (modules gen_tool_descriptors)
  (libraries tool_schemas_specs yojson))
 
+;; RFC-0252 standalone fusion harness: on-demand panel+judge deliberation vs
+;; single-model baseline, side by side. Makes live LLM calls (NOT a test —
+;; CI determinism rules forbid network calls in test/). Calls Fusion_panel.run
+;; + Fusion_judge.run directly (bypasses the orchestrator's gate/budget/sink).
+
+(executable
+ (name fusion_run)
+ (modules fusion_run)
+ (public_name masc-fusion-run)
+ (package masc)
+ (libraries
+  masc
+  masc.fusion_core
+  masc.runtime
+  masc.config_dir_resolver
+  masc_core
+  unix
+  yojson
+  fmt
+  str
+  eio
+  eio_main
+  time_compat
+  masc_eio_context
+  mirage-crypto-rng.unix
+  httpun
+  cohttp
+  cohttp-eio
+  masc.prompt_registry
+  masc.mcp_transport_protocol
+  agent_sdk
+  agent_sdk.llm_provider))
+
 ; Executable for MASC MCP

--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -1,8 +1,23 @@
 (* RFC-0252 standalone fusion harness.
 
-   Runs an on-demand panel+judge deliberation and a single-model baseline on
-   the same prompt and prints both side by side, so a human can judge whether
-   the panel+judge deliberation produces a better answer than one model.
+   Runs three arms on the same prompt and prints them side by side so a human
+   can judge whether panel+judge deliberation beats the alternatives:
+
+   [1] BASELINE          single model, one call.
+   [2] SELF-CONSISTENCY  the same judge model sampled N times + the same judge
+                         synthesis. Cost-matched to fusion (same panelist count,
+                         same judge call) but homogeneous.
+   [3] FUSION            N diverse models + judge synthesis. Heterogeneous.
+
+   Why the self-consistency arm exists: comparing fusion only against a single
+   call conflates two effects — spending more compute and using diverse models.
+   Self-consistency holds compute fixed and varies only diversity, so [2] vs [3]
+   isolates the panel-diversity effect. If fusion only matches self-consistency,
+   the apparent win was compute, not heterogeneity (Self-MoA, arXiv:2502.00674).
+   The harness cannot force a sampling temperature (fusion exposes none), so the
+   N self-consistency samples diverge only if the provider samples stochastically;
+   each sample is printed verbatim so a deterministic provider is visible rather
+   than silently collapsing [2] into [1].
 
    It is keeper-independent: it bypasses [Fusion_orchestrator.run] (gate +
    hourly budget + keeper chat-lane sink) and calls [Fusion_panel.run] and
@@ -11,18 +26,17 @@
    synthetic keeper, can return [Sink_failed] and discard the computed panel
    and judge results) and the shared hourly budget counter.
 
-   The baseline reuses [Fusion_panel.run] with a single model so the call path
-   is identical to a panel member: the comparison differs only in
-   N-models + judge, not in plumbing.
+   The baseline and the self-consistency arm reuse [Fusion_panel.run] so the
+   call path is identical to a panel member: the arms differ only in model set
+   and judge, not in plumbing.
 
    Provider bindings (model routing + API keys from env vars named in
    runtime.toml) are materialised once via [Runtime.init_default]; without it
    every panel comes back [Failed (Provider_error ...)].
 
    Usage: dune exec bin/fusion_run.exe -- [--base PATH] [--preset NAME] <prompt...>
-   Defaults: --base /Users/dancer/me, --preset = policy.default_preset. *)
-
-let default_base = "/Users/dancer/me"
+   Base path: --base wins; else MASC_BASE_PATH (via Config_dir_resolver); else
+   the run fails. --preset defaults to policy.default_preset. *)
 
 (* runtime.toml absolute path, mirroring Fusion_config_loader.runtime_toml_path
    so the harness resolves the same file the server and the fusion loader do
@@ -96,9 +110,53 @@ let first_some (f : 'a -> 'b option) (xs : 'a list) : 'b option =
     None
     xs
 
+(* Run the judge over a panel; returns the synthesis and the judge's own usage. *)
+let synthesize ~sw ~net ~(preset : Fusion_policy.preset) ~(prompt : string)
+    ~(panel : Fusion_types.panel_outcome list)
+  : (Fusion_types.judge_synthesis * Fusion_types.usage, string) result =
+  Masc.Fusion_judge.run
+    ~sw
+    ~net
+    ~timeout_s:preset.Fusion_policy.judge_timeout_s
+    ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+    ~judge_model:preset.Fusion_policy.judge
+    ~question:prompt
+    ~panel
+    ~web_tools:preset.Fusion_policy.web_tools
+    ~max_tool_calls:preset.Fusion_policy.max_tool_calls_per_panel
+    ()
+
+(* Print a judge arm and return (resolved_answer, judge_in_tokens, judge_out_tokens). *)
+let print_judge_arm ~(tag : string)
+    (r : (Fusion_types.judge_synthesis * Fusion_types.usage, string) result)
+  : string * int * int =
+  match r with
+  | Error msg ->
+    Printf.printf "  [%s] judge failed: %s\n\n" tag msg;
+    (Printf.sprintf "(judge failed: %s)" msg, 0, 0)
+  | Ok (synthesis, u) ->
+    Printf.printf
+      "  [%s] decision: %s\n\n  RESOLVED ANSWER:\n%s\n\n"
+      tag
+      (string_of_decision synthesis.Fusion_types.decision)
+      synthesis.Fusion_types.resolved_answer;
+    Printf.printf
+      "  [%s] full synthesis (consensus / contradictions / unique_insights / blind_spots):\n%s\n\n"
+      tag
+      (Yojson.Safe.pretty_to_string
+         (Fusion_types.judge_synthesis_to_yojson synthesis));
+    ( synthesis.Fusion_types.resolved_answer
+    , u.Fusion_types.input_tokens
+    , u.Fusion_types.output_tokens )
+
 let run_harness ~sw ~net ~(policy : Fusion_policy.t) ~(preset : Fusion_policy.preset)
     ~(prompt : string) ~(config_path : string) : unit =
-  Printf.printf "%s\nFUSION HARNESS (RFC-0252) — panel+judge vs single model\n%s\n" bar bar;
+  let n = List.length preset.Fusion_policy.panel in
+  let max_fibers = max 1 policy.Fusion_policy.max_concurrent_panels in
+  Printf.printf
+    "%s\nFUSION HARNESS (RFC-0252) — single vs self-consistency vs fusion\n%s\n"
+    bar
+    bar;
   Printf.printf
     "config: %s\npreset: %s\npanel:  %s\njudge:  %s\nprompt: %s\n\n"
     config_path
@@ -107,25 +165,27 @@ let run_harness ~sw ~net ~(policy : Fusion_policy.t) ~(preset : Fusion_policy.pr
     preset.Fusion_policy.judge
     prompt;
 
-  (* ── [1] BASELINE: judge model alone, via the same panel call path ── *)
-  Printf.printf
-    "%s\n[1] BASELINE — single model (%s) answering alone\n%s\n"
-    rule
-    preset.Fusion_policy.judge
-    rule;
-  let baseline =
+  let run_panel ~max_fibers ~models =
     Masc.Fusion_panel.run
       ~sw
       ~net
-      ~max_fibers:1
+      ~max_fibers
       ~timeout_s:preset.Fusion_policy.panel_timeout_s
-      ~models:[ preset.Fusion_policy.judge ]
+      ~models
       ~system_prompt:preset.Fusion_policy.panel_system_prompt
       ~prompt
       ~web_tools:preset.Fusion_policy.web_tools
       ~max_tool_calls_per_panel:preset.Fusion_policy.max_tool_calls_per_panel
       ()
   in
+
+  (* ── [1] BASELINE: judge model alone, one call ── *)
+  Printf.printf
+    "%s\n[1] BASELINE — single model (%s), 1 call\n%s\n"
+    rule
+    preset.Fusion_policy.judge
+    rule;
+  let baseline = run_panel ~max_fibers:1 ~models:[ preset.Fusion_policy.judge ] in
   List.iter (print_outcome ~tag:"baseline") baseline;
   let baseline_answer =
     match first_some answer_of_outcome baseline with
@@ -136,90 +196,83 @@ let run_harness ~sw ~net ~(policy : Fusion_policy.t) ~(preset : Fusion_policy.pr
     sum_usage (List.filter_map usage_of_outcome baseline)
   in
 
-  (* ── [2] FUSION PANEL: full model list, run independently ── *)
+  (* ── [2] SELF-CONSISTENCY: same judge model x n + judge (cost-matched) ── *)
   Printf.printf
-    "%s\n[2] FUSION PANEL — %d models (independent answers)\n%s\n"
-    rule
-    (List.length preset.Fusion_policy.panel)
-    rule;
-  let panel =
-    Masc.Fusion_panel.run
-      ~sw
-      ~net
-      ~max_fibers:(max 1 policy.Fusion_policy.max_concurrent_panels)
-      ~timeout_s:preset.Fusion_policy.panel_timeout_s
-      ~models:preset.Fusion_policy.panel
-      ~system_prompt:preset.Fusion_policy.panel_system_prompt
-      ~prompt
-      ~web_tools:preset.Fusion_policy.web_tools
-      ~max_tool_calls_per_panel:preset.Fusion_policy.max_tool_calls_per_panel
-      ()
-  in
-  List.iter (print_outcome ~tag:"panel") panel;
-  let panel_in, panel_out = sum_usage (List.filter_map usage_of_outcome panel) in
-
-  (* ── [3] FUSION JUDGE: synthesise the panel ── *)
-  Printf.printf
-    "%s\n[3] FUSION JUDGE — %s synthesises the panel\n%s\n"
+    "%s\n[2] SELF-CONSISTENCY — %s x %d samples + judge (cost-matched, homogeneous)\n%s\n"
     rule
     preset.Fusion_policy.judge
+    n
     rule;
-  match
-    Masc.Fusion_judge.run
-      ~sw
-      ~net
-      ~timeout_s:preset.Fusion_policy.judge_timeout_s
-      ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-      ~judge_model:preset.Fusion_policy.judge
-      ~question:prompt
-      ~panel
-      ~web_tools:preset.Fusion_policy.web_tools
-      ~max_tool_calls:preset.Fusion_policy.max_tool_calls_per_panel
-      ()
-  with
-  | Error msg -> Printf.printf "  judge failed: %s\n\n" msg
-  | Ok (synthesis, judge_usage) ->
-    Printf.printf
-      "  decision: %s\n\n  RESOLVED ANSWER:\n%s\n\n"
-      (string_of_decision synthesis.Fusion_types.decision)
-      synthesis.Fusion_types.resolved_answer;
-    Printf.printf
-      "  full synthesis (consensus / contradictions / unique_insights / blind_spots):\n%s\n\n"
-      (Yojson.Safe.pretty_to_string
-         (Fusion_types.judge_synthesis_to_yojson synthesis));
+  let sc_models = List.init n (fun _ -> preset.Fusion_policy.judge) in
+  let sc_panel = run_panel ~max_fibers ~models:sc_models in
+  List.iter (print_outcome ~tag:"self-consistency") sc_panel;
+  let sc_answer, sc_judge_in, sc_judge_out =
+    print_judge_arm ~tag:"self-consistency" (synthesize ~sw ~net ~preset ~prompt ~panel:sc_panel)
+  in
+  let sc_panel_in, sc_panel_out =
+    sum_usage (List.filter_map usage_of_outcome sc_panel)
+  in
 
-    (* ── SIDE-BY-SIDE SUMMARY ── *)
-    let fusion_in = panel_in + judge_usage.Fusion_types.input_tokens in
-    let fusion_out = panel_out + judge_usage.Fusion_types.output_tokens in
-    Printf.printf "%s\nSUMMARY — single model vs fusion\n%s\n" bar bar;
-    Printf.printf
-      "BASELINE (%s):\n%s\n\n"
-      preset.Fusion_policy.judge
-      baseline_answer;
-    Printf.printf
-      "FUSION (%d-model panel + judge):\n%s\n\n"
-      (List.length preset.Fusion_policy.panel)
-      synthesis.Fusion_types.resolved_answer;
-    Printf.printf
-      "COST (tokens in/out) — baseline: %d/%d | fusion: %d/%d (panel %d/%d + judge %d/%d)\n"
-      baseline_in
-      baseline_out
-      fusion_in
-      fusion_out
-      panel_in
-      panel_out
-      judge_usage.Fusion_types.input_tokens
-      judge_usage.Fusion_types.output_tokens
+  (* ── [3] FUSION: n diverse models + judge (heterogeneous) ── *)
+  Printf.printf
+    "%s\n[3] FUSION — %d diverse models + judge (heterogeneous)\n%s\n"
+    rule
+    n
+    rule;
+  let fusion_panel = run_panel ~max_fibers ~models:preset.Fusion_policy.panel in
+  List.iter (print_outcome ~tag:"fusion") fusion_panel;
+  let fusion_answer, fusion_judge_in, fusion_judge_out =
+    print_judge_arm ~tag:"fusion" (synthesize ~sw ~net ~preset ~prompt ~panel:fusion_panel)
+  in
+  let fusion_panel_in, fusion_panel_out =
+    sum_usage (List.filter_map usage_of_outcome fusion_panel)
+  in
+
+  (* ── SIDE-BY-SIDE SUMMARY (3-way) ── *)
+  let sc_in = sc_panel_in + sc_judge_in in
+  let sc_out = sc_panel_out + sc_judge_out in
+  let fusion_in = fusion_panel_in + fusion_judge_in in
+  let fusion_out = fusion_panel_out + fusion_judge_out in
+  Printf.printf
+    "%s\nSUMMARY — single vs self-consistency vs fusion\n%s\n"
+    bar
+    bar;
+  Printf.printf "BASELINE (%s, 1 call):\n%s\n\n" preset.Fusion_policy.judge baseline_answer;
+  Printf.printf
+    "SELF-CONSISTENCY (%s x %d + judge):\n%s\n\n"
+    preset.Fusion_policy.judge
+    n
+    sc_answer;
+  Printf.printf "FUSION (%d diverse + judge):\n%s\n\n" n fusion_answer;
+  Printf.printf
+    "COST (tokens in/out):\n\
+    \  baseline:         %d/%d\n\
+    \  self-consistency: %d/%d  (panel %d/%d + judge %d/%d)\n\
+    \  fusion:           %d/%d  (panel %d/%d + judge %d/%d)\n"
+    baseline_in
+    baseline_out
+    sc_in
+    sc_out
+    sc_panel_in
+    sc_panel_out
+    sc_judge_in
+    sc_judge_out
+    fusion_in
+    fusion_out
+    fusion_panel_in
+    fusion_panel_out
+    fusion_judge_in
+    fusion_judge_out
 
 (* ── entry point ── *)
 let () =
-  let base = ref default_base in
+  let base = ref None in
   let preset_override = ref None in
   let prompt_parts = ref [] in
   let rec parse = function
     | [] -> ()
     | "--base" :: v :: rest ->
-      base := v;
+      base := Some v;
       parse rest
     | "--preset" :: v :: rest ->
       preset_override := Some v;
@@ -231,10 +284,23 @@ let () =
   parse (match Array.to_list Sys.argv with _ :: tl -> tl | [] -> []);
   let prompt = String.concat " " (List.rev !prompt_parts) in
   if String.trim prompt = "" then (
-    prerr_endline
-      "usage: fusion_run [--base PATH] [--preset NAME] <prompt...>";
+    prerr_endline "usage: fusion_run [--base PATH] [--preset NAME] <prompt...>";
     exit 2);
-  let base_path = !base in
+  (* Base path: explicit --base wins; else the workspace base the server uses
+     (MASC_BASE_PATH via Host_config, surfaced by Config_dir_resolver). We do
+     not invent a default path — an unknown base is an error, not a silent
+     fallback to one operator's home directory. *)
+  let base_path =
+    match !base with
+    | Some p -> p
+    | None ->
+      (match Config_dir_resolver.current_env_base_path_opt () with
+       | Some p -> p
+       | None ->
+         prerr_endline
+           "no workspace base path: set MASC_BASE_PATH or pass --base PATH";
+         exit 2)
+  in
   Eio_main.run @@ fun env ->
   Mirage_crypto_rng_unix.use_default ();
   Time_compat.set_clock (Eio.Stdenv.clock env);

--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -240,6 +240,10 @@ let () =
   Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let net = Eio.Stdenv.net env in
+  (* Capture the Eio handles the OAS/fusion call path reads via
+     [Masc_eio_env.get_opt]. Without this, [Masc_oas_bridge.run_safe] finds no
+     clock and runs the panel/judge calls without timeout enforcement. *)
+  Masc.Masc_eio_env.init ~sw ~net ~clock:(Eio.Stdenv.clock env) ();
   let config_path = runtime_toml_path ~base_path in
   (match Runtime.init_default ~config_path with
    | Error msg ->

--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -1,0 +1,268 @@
+(* RFC-0252 standalone fusion harness.
+
+   Runs an on-demand panel+judge deliberation and a single-model baseline on
+   the same prompt and prints both side by side, so a human can judge whether
+   the panel+judge deliberation produces a better answer than one model.
+
+   It is keeper-independent: it bypasses [Fusion_orchestrator.run] (gate +
+   hourly budget + keeper chat-lane sink) and calls [Fusion_panel.run] and
+   [Fusion_judge.run] directly. Bypassing the orchestrator avoids the sink
+   side effect (which writes a transcript to a keeper chat lane and, for a
+   synthetic keeper, can return [Sink_failed] and discard the computed panel
+   and judge results) and the shared hourly budget counter.
+
+   The baseline reuses [Fusion_panel.run] with a single model so the call path
+   is identical to a panel member: the comparison differs only in
+   N-models + judge, not in plumbing.
+
+   Provider bindings (model routing + API keys from env vars named in
+   runtime.toml) are materialised once via [Runtime.init_default]; without it
+   every panel comes back [Failed (Provider_error ...)].
+
+   Usage: dune exec bin/fusion_run.exe -- [--base PATH] [--preset NAME] <prompt...>
+   Defaults: --base /Users/dancer/me, --preset = policy.default_preset. *)
+
+let default_base = "/Users/dancer/me"
+
+(* runtime.toml absolute path, mirroring Fusion_config_loader.runtime_toml_path
+   so the harness resolves the same file the server and the fusion loader do
+   (honours MASC_CONFIG_DIR override + <base>/.masc/config/ fallback). *)
+let runtime_toml_path ~base_path : string =
+  let inputs = Config_dir_resolver.inputs_from_env () in
+  let resolution =
+    Config_dir_resolver.resolve_with
+      { inputs with Config_dir_resolver.env_base_path = Some base_path }
+  in
+  Filename.concat
+    resolution.Config_dir_resolver.config_root.Config_dir_resolver.path
+    Config_dir_resolver.runtime_toml_filename
+
+(* ── pretty printers (exhaustive: fusion_types are closed sums by design) ── *)
+
+let rule = String.make 72 '-'
+let bar = String.make 72 '='
+
+let string_of_failure (f : Fusion_types.panel_failure) : string =
+  match f with
+  | Fusion_types.Timeout -> "timeout"
+  | Fusion_types.Provider_error msg -> "provider_error: " ^ msg
+  | Fusion_types.Empty_response -> "empty_response"
+
+let string_of_decision (d : Fusion_types.judge_decision) : string =
+  match d with
+  | Fusion_types.Answer _ -> "Answer"
+  | Fusion_types.Recommend _ -> "Recommend"
+  | Fusion_types.Insufficient _ -> "Insufficient"
+
+let print_outcome ~(tag : string) (o : Fusion_types.panel_outcome) : unit =
+  match o with
+  | Fusion_types.Answered a ->
+    let u = a.Fusion_types.usage in
+    Printf.printf
+      "  [%s] %s  (tokens in/out: %d/%d)\n%s\n\n"
+      tag
+      a.Fusion_types.model
+      u.Fusion_types.input_tokens
+      u.Fusion_types.output_tokens
+      a.Fusion_types.answer
+  | Fusion_types.Failed e ->
+    Printf.printf
+      "  [%s] %s  FAILED: %s\n\n"
+      tag
+      e.Fusion_types.failed_model
+      (string_of_failure e.Fusion_types.reason)
+
+let usage_of_outcome (o : Fusion_types.panel_outcome) : Fusion_types.usage option =
+  match o with
+  | Fusion_types.Answered a -> Some a.Fusion_types.usage
+  | Fusion_types.Failed _ -> None
+
+let answer_of_outcome (o : Fusion_types.panel_outcome) : string option =
+  match o with
+  | Fusion_types.Answered a -> Some a.Fusion_types.answer
+  | Fusion_types.Failed _ -> None
+
+let sum_usage (us : Fusion_types.usage list) : int * int =
+  List.fold_left
+    (fun (i, o) (u : Fusion_types.usage) ->
+      (i + u.Fusion_types.input_tokens, o + u.Fusion_types.output_tokens))
+    (0, 0)
+    us
+
+(* first non-None over a list *)
+let first_some (f : 'a -> 'b option) (xs : 'a list) : 'b option =
+  List.fold_left
+    (fun acc x -> match acc with Some _ -> acc | None -> f x)
+    None
+    xs
+
+let run_harness ~sw ~net ~(policy : Fusion_policy.t) ~(preset : Fusion_policy.preset)
+    ~(prompt : string) ~(config_path : string) : unit =
+  Printf.printf "%s\nFUSION HARNESS (RFC-0252) — panel+judge vs single model\n%s\n" bar bar;
+  Printf.printf
+    "config: %s\npreset: %s\npanel:  %s\njudge:  %s\nprompt: %s\n\n"
+    config_path
+    preset.Fusion_policy.name
+    (String.concat ", " preset.Fusion_policy.panel)
+    preset.Fusion_policy.judge
+    prompt;
+
+  (* ── [1] BASELINE: judge model alone, via the same panel call path ── *)
+  Printf.printf
+    "%s\n[1] BASELINE — single model (%s) answering alone\n%s\n"
+    rule
+    preset.Fusion_policy.judge
+    rule;
+  let baseline =
+    Masc.Fusion_panel.run
+      ~sw
+      ~net
+      ~max_fibers:1
+      ~timeout_s:preset.Fusion_policy.panel_timeout_s
+      ~models:[ preset.Fusion_policy.judge ]
+      ~system_prompt:preset.Fusion_policy.panel_system_prompt
+      ~prompt
+      ~web_tools:preset.Fusion_policy.web_tools
+      ~max_tool_calls_per_panel:preset.Fusion_policy.max_tool_calls_per_panel
+      ()
+  in
+  List.iter (print_outcome ~tag:"baseline") baseline;
+  let baseline_answer =
+    match first_some answer_of_outcome baseline with
+    | Some a -> a
+    | None -> "(baseline produced no answer)"
+  in
+  let baseline_in, baseline_out =
+    sum_usage (List.filter_map usage_of_outcome baseline)
+  in
+
+  (* ── [2] FUSION PANEL: full model list, run independently ── *)
+  Printf.printf
+    "%s\n[2] FUSION PANEL — %d models (independent answers)\n%s\n"
+    rule
+    (List.length preset.Fusion_policy.panel)
+    rule;
+  let panel =
+    Masc.Fusion_panel.run
+      ~sw
+      ~net
+      ~max_fibers:(max 1 policy.Fusion_policy.max_concurrent_panels)
+      ~timeout_s:preset.Fusion_policy.panel_timeout_s
+      ~models:preset.Fusion_policy.panel
+      ~system_prompt:preset.Fusion_policy.panel_system_prompt
+      ~prompt
+      ~web_tools:preset.Fusion_policy.web_tools
+      ~max_tool_calls_per_panel:preset.Fusion_policy.max_tool_calls_per_panel
+      ()
+  in
+  List.iter (print_outcome ~tag:"panel") panel;
+  let panel_in, panel_out = sum_usage (List.filter_map usage_of_outcome panel) in
+
+  (* ── [3] FUSION JUDGE: synthesise the panel ── *)
+  Printf.printf
+    "%s\n[3] FUSION JUDGE — %s synthesises the panel\n%s\n"
+    rule
+    preset.Fusion_policy.judge
+    rule;
+  match
+    Masc.Fusion_judge.run
+      ~sw
+      ~net
+      ~timeout_s:preset.Fusion_policy.judge_timeout_s
+      ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+      ~judge_model:preset.Fusion_policy.judge
+      ~question:prompt
+      ~panel
+      ~web_tools:preset.Fusion_policy.web_tools
+      ~max_tool_calls:preset.Fusion_policy.max_tool_calls_per_panel
+      ()
+  with
+  | Error msg -> Printf.printf "  judge failed: %s\n\n" msg
+  | Ok (synthesis, judge_usage) ->
+    Printf.printf
+      "  decision: %s\n\n  RESOLVED ANSWER:\n%s\n\n"
+      (string_of_decision synthesis.Fusion_types.decision)
+      synthesis.Fusion_types.resolved_answer;
+    Printf.printf
+      "  full synthesis (consensus / contradictions / unique_insights / blind_spots):\n%s\n\n"
+      (Yojson.Safe.pretty_to_string
+         (Fusion_types.judge_synthesis_to_yojson synthesis));
+
+    (* ── SIDE-BY-SIDE SUMMARY ── *)
+    let fusion_in = panel_in + judge_usage.Fusion_types.input_tokens in
+    let fusion_out = panel_out + judge_usage.Fusion_types.output_tokens in
+    Printf.printf "%s\nSUMMARY — single model vs fusion\n%s\n" bar bar;
+    Printf.printf
+      "BASELINE (%s):\n%s\n\n"
+      preset.Fusion_policy.judge
+      baseline_answer;
+    Printf.printf
+      "FUSION (%d-model panel + judge):\n%s\n\n"
+      (List.length preset.Fusion_policy.panel)
+      synthesis.Fusion_types.resolved_answer;
+    Printf.printf
+      "COST (tokens in/out) — baseline: %d/%d | fusion: %d/%d (panel %d/%d + judge %d/%d)\n"
+      baseline_in
+      baseline_out
+      fusion_in
+      fusion_out
+      panel_in
+      panel_out
+      judge_usage.Fusion_types.input_tokens
+      judge_usage.Fusion_types.output_tokens
+
+(* ── entry point ── *)
+let () =
+  let base = ref default_base in
+  let preset_override = ref None in
+  let prompt_parts = ref [] in
+  let rec parse = function
+    | [] -> ()
+    | "--base" :: v :: rest ->
+      base := v;
+      parse rest
+    | "--preset" :: v :: rest ->
+      preset_override := Some v;
+      parse rest
+    | x :: rest ->
+      prompt_parts := x :: !prompt_parts;
+      parse rest
+  in
+  parse (match Array.to_list Sys.argv with _ :: tl -> tl | [] -> []);
+  let prompt = String.concat " " (List.rev !prompt_parts) in
+  if String.trim prompt = "" then (
+    prerr_endline
+      "usage: fusion_run [--base PATH] [--preset NAME] <prompt...>";
+    exit 2);
+  let base_path = !base in
+  Eio_main.run @@ fun env ->
+  Mirage_crypto_rng_unix.use_default ();
+  Time_compat.set_clock (Eio.Stdenv.clock env);
+  Eio.Switch.run @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let config_path = runtime_toml_path ~base_path in
+  (match Runtime.init_default ~config_path with
+   | Error msg ->
+     Printf.eprintf "runtime init failed (%s): %s\n" config_path msg;
+     exit 1
+   | Ok () -> ());
+  match Masc.Fusion_config_loader.load ~base_path with
+  | Error msg ->
+    Printf.eprintf "fusion config error: %s\n" msg;
+    exit 1
+  | Ok policy ->
+    if not policy.Fusion_policy.enabled then (
+      Printf.eprintf
+        "fusion disabled in %s ([fusion].enabled=false or no [fusion] section)\n"
+        config_path;
+      exit 1);
+    let preset_name =
+      match !preset_override with
+      | Some p -> p
+      | None -> policy.Fusion_policy.default_preset
+    in
+    (match Fusion_policy.find_preset policy preset_name with
+     | None ->
+       Printf.eprintf "preset not found: %s\n" preset_name;
+       exit 1
+     | Some preset -> run_harness ~sw ~net ~policy ~preset ~prompt ~config_path)

--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -1,19 +1,21 @@
 (* RFC-0252 standalone fusion harness.
 
-   Runs three arms on the same prompt and prints them side by side so a human
+   Runs four arms on the same prompt and prints them side by side so a human
    can judge whether panel+judge deliberation beats the alternatives:
 
    [1] BASELINE          single model, one call.
-   [2] SELF-CONSISTENCY  the same judge model sampled N times + the same judge
+   [2] SELF-CONSISTENCY  the same judge model sampled N times + majority
+                         aggregate. Homogeneous, no judge synthesis.
+   [3] SELF-MOA          the same judge model sampled N times + judge
                          synthesis. Cost-matched to fusion (same panelist count,
                          same judge call) but homogeneous.
-   [3] FUSION            N diverse models + judge synthesis. Heterogeneous.
+   [4] FUSION            N diverse models + judge synthesis. Heterogeneous.
 
    Why the self-consistency arm exists: comparing fusion only against a single
    call conflates two effects — spending more compute and using diverse models.
-   Self-consistency holds compute fixed and varies only diversity, so [2] vs [3]
-   isolates the panel-diversity effect. If fusion only matches self-consistency,
-   the apparent win was compute, not heterogeneity (Self-MoA, arXiv:2502.00674).
+   Self-MoA holds compute fixed and varies only diversity, so [3] vs [4]
+   isolates the panel-diversity effect. If fusion only matches Self-MoA, the
+   apparent win was compute, not heterogeneity (Self-MoA, arXiv:2502.00674).
    The harness cannot force a sampling temperature (fusion exposes none), so the
    N self-consistency samples diverge only if the provider samples stochastically;
    each sample is printed verbatim so a deterministic provider is visible rather
@@ -129,11 +131,11 @@ let synthesize ~sw ~net ~(preset : Fusion_policy.preset) ~(prompt : string)
 (* Print a judge arm and return (resolved_answer, judge_in_tokens, judge_out_tokens). *)
 let print_judge_arm ~(tag : string)
     (r : (Fusion_types.judge_synthesis * Fusion_types.usage, string) result)
-  : string * int * int =
+  : (string * int * int, string) result =
   match r with
   | Error msg ->
     Printf.printf "  [%s] judge failed: %s\n\n" tag msg;
-    (Printf.sprintf "(judge failed: %s)" msg, 0, 0)
+    Error msg
   | Ok (synthesis, u) ->
     Printf.printf
       "  [%s] decision: %s\n\n  RESOLVED ANSWER:\n%s\n\n"
@@ -145,18 +147,20 @@ let print_judge_arm ~(tag : string)
       tag
       (Yojson.Safe.pretty_to_string
          (Fusion_types.judge_synthesis_to_yojson synthesis));
-    ( synthesis.Fusion_types.resolved_answer
-    , u.Fusion_types.input_tokens
-    , u.Fusion_types.output_tokens )
+    Ok
+      ( synthesis.Fusion_types.resolved_answer
+      , u.Fusion_types.input_tokens
+      , u.Fusion_types.output_tokens )
 
 let run_harness ~sw ~net ~(policy : Fusion_policy.t) ~(preset : Fusion_policy.preset)
     ~(prompt : string) ~(config_path : string) : unit =
   let n = List.length preset.Fusion_policy.panel in
   let max_fibers = max 1 policy.Fusion_policy.max_concurrent_panels in
+  let incomplete = ref [] in
+  let mark_incomplete msg = incomplete := msg :: !incomplete in
   Printf.printf
-    "%s\nFUSION HARNESS (RFC-0252) — single vs self-consistency vs fusion\n%s\n"
-    bar
-    bar;
+    "%s\nFUSION HARNESS (RFC-0252) — single vs self-consistency vs Self-MoA vs fusion\n%s\n"
+    bar bar;
   Printf.printf
     "config: %s\npreset: %s\npanel:  %s\njudge:  %s\nprompt: %s\n\n"
     config_path
@@ -196,9 +200,9 @@ let run_harness ~sw ~net ~(policy : Fusion_policy.t) ~(preset : Fusion_policy.pr
     sum_usage (List.filter_map usage_of_outcome baseline)
   in
 
-  (* ── [2] SELF-CONSISTENCY: same judge model x n + judge (cost-matched) ── *)
+  (* ── [2] SELF-CONSISTENCY: same judge model x n + majority aggregate ── *)
   Printf.printf
-    "%s\n[2] SELF-CONSISTENCY — %s x %d samples + judge (cost-matched, homogeneous)\n%s\n"
+    "%s\n[2] SELF-CONSISTENCY — %s x %d samples + majority aggregate\n%s\n"
     rule
     preset.Fusion_policy.judge
     n
@@ -206,63 +210,118 @@ let run_harness ~sw ~net ~(policy : Fusion_policy.t) ~(preset : Fusion_policy.pr
   let sc_models = List.init n (fun _ -> preset.Fusion_policy.judge) in
   let sc_panel = run_panel ~max_fibers ~models:sc_models in
   List.iter (print_outcome ~tag:"self-consistency") sc_panel;
-  let sc_answer, sc_judge_in, sc_judge_out =
-    print_judge_arm ~tag:"self-consistency" (synthesize ~sw ~net ~preset ~prompt ~panel:sc_panel)
+  let sc_answers = List.filter_map answer_of_outcome sc_panel in
+  let sc_answer =
+    match sc_answers with
+    | [] ->
+      let msg = "self-consistency majority has no answered samples" in
+      Printf.printf "  [self-consistency] majority failed: %s\n\n" msg;
+      mark_incomplete msg;
+      "(self-consistency majority unavailable)"
+    | answers ->
+      let answer = Fusion_harness_core.majority_vote answers in
+      Printf.printf
+        "  [self-consistency] MAJORITY ANSWER (%d samples):\n%s\n\n"
+        (List.length answers)
+        answer;
+      answer
   in
   let sc_panel_in, sc_panel_out =
     sum_usage (List.filter_map usage_of_outcome sc_panel)
   in
 
-  (* ── [3] FUSION: n diverse models + judge (heterogeneous) ── *)
+  (* ── [3] SELF-MOA: same judge model x n + judge synthesis ── *)
   Printf.printf
-    "%s\n[3] FUSION — %d diverse models + judge (heterogeneous)\n%s\n"
+    "%s\n[3] SELF-MOA — %s x %d samples + judge synthesis (cost-matched, homogeneous)\n%s\n"
+    rule
+    preset.Fusion_policy.judge
+    n
+    rule;
+  let self_moa_answer, self_moa_judge_in, self_moa_judge_out =
+    match
+      print_judge_arm ~tag:"self-moa"
+        (synthesize ~sw ~net ~preset ~prompt ~panel:sc_panel)
+    with
+    | Ok values -> values
+    | Error msg ->
+      mark_incomplete ("self-moa judge failed: " ^ msg);
+      (Printf.sprintf "(self-moa judge failed: %s)" msg, 0, 0)
+  in
+
+  (* ── [4] FUSION: n diverse models + judge (heterogeneous) ── *)
+  Printf.printf
+    "%s\n[4] FUSION — %d diverse models + judge synthesis (heterogeneous)\n%s\n"
     rule
     n
     rule;
   let fusion_panel = run_panel ~max_fibers ~models:preset.Fusion_policy.panel in
   List.iter (print_outcome ~tag:"fusion") fusion_panel;
   let fusion_answer, fusion_judge_in, fusion_judge_out =
-    print_judge_arm ~tag:"fusion" (synthesize ~sw ~net ~preset ~prompt ~panel:fusion_panel)
+    match
+      print_judge_arm ~tag:"fusion"
+        (synthesize ~sw ~net ~preset ~prompt ~panel:fusion_panel)
+    with
+    | Ok values -> values
+    | Error msg ->
+      mark_incomplete ("fusion judge failed: " ^ msg);
+      (Printf.sprintf "(fusion judge failed: %s)" msg, 0, 0)
   in
   let fusion_panel_in, fusion_panel_out =
     sum_usage (List.filter_map usage_of_outcome fusion_panel)
   in
 
-  (* ── SIDE-BY-SIDE SUMMARY (3-way) ── *)
-  let sc_in = sc_panel_in + sc_judge_in in
-  let sc_out = sc_panel_out + sc_judge_out in
+  (* ── SIDE-BY-SIDE SUMMARY (4-way) ── *)
+  let self_moa_in = sc_panel_in + self_moa_judge_in in
+  let self_moa_out = sc_panel_out + self_moa_judge_out in
   let fusion_in = fusion_panel_in + fusion_judge_in in
   let fusion_out = fusion_panel_out + fusion_judge_out in
+  let incomplete = List.rev !incomplete in
+  let status = if incomplete = [] then "complete" else "INCOMPLETE" in
   Printf.printf
-    "%s\nSUMMARY — single vs self-consistency vs fusion\n%s\n"
+    "%s\nSUMMARY (%s) — single vs self-consistency vs Self-MoA vs fusion\n%s\n"
     bar
+    status
     bar;
   Printf.printf "BASELINE (%s, 1 call):\n%s\n\n" preset.Fusion_policy.judge baseline_answer;
   Printf.printf
-    "SELF-CONSISTENCY (%s x %d + judge):\n%s\n\n"
+    "SELF-CONSISTENCY (%s x %d + majority):\n%s\n\n"
     preset.Fusion_policy.judge
     n
     sc_answer;
+  Printf.printf
+    "SELF-MOA (%s x %d + judge):\n%s\n\n"
+    preset.Fusion_policy.judge
+    n
+    self_moa_answer;
   Printf.printf "FUSION (%d diverse + judge):\n%s\n\n" n fusion_answer;
   Printf.printf
     "COST (tokens in/out):\n\
     \  baseline:         %d/%d\n\
-    \  self-consistency: %d/%d  (panel %d/%d + judge %d/%d)\n\
+    \  self-consistency: %d/%d  (panel only; majority aggregate)\n\
+    \  self-moa:         %d/%d  (panel %d/%d + judge %d/%d)\n\
     \  fusion:           %d/%d  (panel %d/%d + judge %d/%d)\n"
     baseline_in
     baseline_out
-    sc_in
-    sc_out
     sc_panel_in
     sc_panel_out
-    sc_judge_in
-    sc_judge_out
+    self_moa_in
+    self_moa_out
+    sc_panel_in
+    sc_panel_out
+    self_moa_judge_in
+    self_moa_judge_out
     fusion_in
     fusion_out
     fusion_panel_in
     fusion_panel_out
     fusion_judge_in
-    fusion_judge_out
+    fusion_judge_out;
+  if incomplete <> [] then (
+    Printf.eprintf "\nINCOMPLETE fusion harness run:\n";
+    List.iter (Printf.eprintf "  - %s\n") incomplete;
+    flush stdout;
+    flush stderr;
+    exit 1)
 
 (* ── entry point ── *)
 let () =
@@ -270,21 +329,33 @@ let () =
   let preset_override = ref None in
   let prompt_parts = ref [] in
   let rec parse = function
-    | [] -> ()
+    | [] -> Ok ()
     | "--base" :: v :: rest ->
       base := Some v;
       parse rest
+    | [ "--base" ] -> Error "missing value for --base"
     | "--preset" :: v :: rest ->
       preset_override := Some v;
       parse rest
+    | [ "--preset" ] -> Error "missing value for --preset"
+    | "--" :: rest ->
+      prompt_parts := List.rev_append rest !prompt_parts;
+      Ok ()
+    | x :: _ when String.length x > 0 && x.[0] = '-' ->
+      Error ("unknown option: " ^ x)
     | x :: rest ->
       prompt_parts := x :: !prompt_parts;
       parse rest
   in
-  parse (match Array.to_list Sys.argv with _ :: tl -> tl | [] -> []);
+  (match parse (match Array.to_list Sys.argv with _ :: tl -> tl | [] -> []) with
+   | Ok () -> ()
+   | Error msg ->
+     Printf.eprintf "fusion_run: %s\n" msg;
+     prerr_endline "usage: fusion_run [--base PATH] [--preset NAME] [--] <prompt...>";
+     exit 2);
   let prompt = String.concat " " (List.rev !prompt_parts) in
   if String.trim prompt = "" then (
-    prerr_endline "usage: fusion_run [--base PATH] [--preset NAME] <prompt...>";
+    prerr_endline "usage: fusion_run [--base PATH] [--preset NAME] [--] <prompt...>";
     exit 2);
   (* Base path: explicit --base wins; else the workspace base the server uses
      (MASC_BASE_PATH via Host_config, surfaced by Config_dir_resolver). We do

--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -40,19 +40,6 @@
    Base path: --base wins; else MASC_BASE_PATH (via Config_dir_resolver); else
    the run fails. --preset defaults to policy.default_preset. *)
 
-(* runtime.toml absolute path, mirroring Fusion_config_loader.runtime_toml_path
-   so the harness resolves the same file the server and the fusion loader do
-   (honours MASC_CONFIG_DIR override + <base>/.masc/config/ fallback). *)
-let runtime_toml_path ~base_path : string =
-  let inputs = Config_dir_resolver.inputs_from_env () in
-  let resolution =
-    Config_dir_resolver.resolve_with
-      { inputs with Config_dir_resolver.env_base_path = Some base_path }
-  in
-  Filename.concat
-    resolution.Config_dir_resolver.config_root.Config_dir_resolver.path
-    Config_dir_resolver.runtime_toml_filename
-
 (* ── pretty printers (exhaustive: fusion_types are closed sums by design) ── *)
 
 let rule = String.make 72 '-'
@@ -194,7 +181,11 @@ let run_harness ~sw ~net ~(policy : Fusion_policy.t) ~(preset : Fusion_policy.pr
   let baseline_answer =
     match first_some answer_of_outcome baseline with
     | Some a -> a
-    | None -> "(baseline produced no answer)"
+    | None ->
+      let msg = "baseline produced no answer" in
+      Printf.printf "  [baseline] failed: %s\n\n" msg;
+      mark_incomplete msg;
+      "(baseline produced no answer)"
   in
   let baseline_in, baseline_out =
     sum_usage (List.filter_map usage_of_outcome baseline)
@@ -381,7 +372,7 @@ let () =
      [Masc_eio_env.get_opt]. Without this, [Masc_oas_bridge.run_safe] finds no
      clock and runs the panel/judge calls without timeout enforcement. *)
   Masc.Masc_eio_env.init ~sw ~net ~clock:(Eio.Stdenv.clock env) ();
-  let config_path = runtime_toml_path ~base_path in
+  let config_path = Masc.Fusion_config_loader.runtime_toml_path ~base_path in
   (match Runtime.init_default ~config_path with
    | Error msg ->
      Printf.eprintf "runtime init failed (%s): %s\n" config_path msg;

--- a/lib/fusion/fusion_config_loader.mli
+++ b/lib/fusion/fusion_config_loader.mli
@@ -11,6 +11,10 @@
 
     설계 SSOT: docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §9 *)
 
+(** [runtime_toml_path ~base_path] returns the runtime.toml path resolved with
+    the same Config_dir_resolver recipe used by [load]. *)
+val runtime_toml_path : base_path:string -> string
+
 (** [load ~base_path]: workspace base path 기준으로 runtime.toml의 [fusion]을 로드.
 
     - runtime.toml 부재 → [Ok Fusion_config.disabled] (opt-in OFF 기본).


### PR DESCRIPTION
## 목적
RFC-0252 fusion(panel+judge 심의)의 가치를 키퍼 배선 *전에* 측정하기 위한 standalone 평가 하네스. 한 프롬프트에 대해 세 arm을 나란히 실행한다:

1. **BASELINE** — 단일 모델, 1콜.
2. **SELF-CONSISTENCY** — 같은 judge 모델을 N번(패널 크기와 동일) 샘플 + 동일 judge 합성. fusion과 **cost-matched**(패널 수·judge 콜 동일)이되 동질(homogeneous).
3. **FUSION** — N개 이종(heterogeneous) 모델 + judge 합성.

`Harness First` 원칙(측정 가능한 평가 없이 AI subsystem 진행 금지)의 직접 구현이다.

## 왜 self-consistency arm이 필요한가 (핵심 설계)
fusion을 단일 콜하고만 비교하면 두 효과가 **conflate**된다 — (a) compute를 더 쓰는 효과와 (b) 모델 다양성의 효과. self-consistency는 compute를 고정하고 다양성만 변화시키므로 **[2] vs [3]가 다양성 효과를 격리**한다. fusion이 self-consistency를 *못 이기면*, baseline 대비 lift는 다양성이 아니라 compute였다는 뜻이다 (Self-MoA, arXiv:2502.00674). 하네스는 sampling temperature를 강제할 수단이 없으므로(fusion이 노출 안 함) N개 self-consistency 샘플은 provider가 stochastic할 때만 갈린다 — 각 샘플을 그대로 출력해, 결정적 provider면 [2]가 [1]로 붕괴하는 게 숨겨지지 않고 보인다.

## 변경
- `bin/fusion_run.ml` (신규): 키퍼 독립 3-arm 하네스.
  - `Fusion_orchestrator.run`(gate / hourly budget / keeper chat-lane sink)을 우회하고 `Fusion_panel.run` + `Fusion_judge.run`를 직접 호출.
  - baseline·self-consistency·fusion 모두 동일한 `run_panel` 헬퍼를 공유 → 차이는 **모델 집합뿐**, plumbing 동일.
  - base path는 `--base` 우선, 없으면 `MASC_BASE_PATH`(`Config_dir_resolver.current_env_base_path_opt`, 서버 `Workspace.base_path`와 동일 소스), 둘 다 없으면 **에러**. 하드코딩 기본 경로를 두지 않는다(unknown→permissive default 금지).
  - provider 바인딩은 `Runtime.init_default`로 1회 초기화, `Masc_eio_env.init`로 panel/judge 120s 타임아웃 강제.
  - 출력: arm별 답 + judge synthesis(consensus / contradictions / unique_insights / blind_spots) JSON + 3-way 나란히 비교 + arm별 토큰 비용.
- `bin/dune`: `fusion_run` executable 스탠자. live LLM 호출이라 `test/`가 아닌 `bin/`에 배치(`test/`는 네트워크 호출 금지).

## 설계 결정 (트레이드오프)
- **orchestrator 우회**: orchestrator 마지막 단계 `Fusion_sink.emit`가 합성 keeper에 chat lane이 없으면 `Sink_failed`를 반환하고 계산된 panel/judge 결과를 버린다. 직접 호출은 sink/budget 부작용이 없다.
- **하네스에 자동 테스트 없음**: live LLM 호출이라 결정적 테스트 불가(의도적). fusion_core 순수 로직은 기존 `test/fusion_core/`가 커버.

## 로컬 검증
- `dune build --root . bin/fusion_run.exe`: PASS (exit 0, 격리 worktree)
- `ocamlformat --check bin/fusion_run.ml`: PASS (0.29.0, repo pin과 일치)
- release-train 가드: PASS(warn) — base에 rebase해 head==base==0.19.46(version-neutral)
- 라이브 3-arm 실행 (base=/Users/dancer/me, trio preset = kimi-k2-6 + minimax-m3 + deepseek-v4-pro 패널, deepseek-v4-pro judge):

## 측정된 결론 (3-arm, 논쟁형 프롬프트 1회 — n=1)
프롬프트: "10+ 동시 AI 에이전트가 공유 상태를 변경할 때 optimistic concurrency(lock-free CAS+retry) vs pessimistic locking(single-writer) 중 하나를 단정 추천하라."

| Arm | 결정 | contradictions | cost in/out |
|---|---|---|---|
| BASELINE (deepseek 1콜) | **Optimistic** | — | 86 / 1095 |
| SELF-CONSISTENCY (deepseek ×3 + judge) | **Pessimistic** | 있음(샘플 2:1 분열) | 1365 / 8076 |
| FUSION (이종 3 + judge) | **Pessimistic** | **없음([], 합의)** | 1827 / 6653 |

- 단일 baseline은 Optimistic이었으나 **self-consistency(같은 모델 ×3)도 fusion(이종 ×3)도 똑같이 Pessimistic으로 교정**. baseline→교정의 원동력은 **재샘플링/aggregation이지 모델 다양성이 아니다** — diversity 없는 self-consistency가 같은 결정에 도달.
- 이 프롬프트에서 **fusion은 cost-matched self-consistency를 결정 수준에서 이기지 못했다**(둘 다 Pessimistic, 비용도 동급). 두 arm은 다른 정보를 노출한다 — SC는 모델 내부 불안정(2:1 분열)을, fusion은 이종 모델 합의(robustness)를 — 그러나 헤드라인 결정은 수렴.
- 이는 self-consistency arm을 추가한 정확한 이유다: 이전 2-arm 측정의 "fusion이 단일 모델을 이김" 결론은 **compute와 diversity를 conflate한 교란**이었고, cost-matched arm이 그것을 드러냈다.
- **함의**: fusion 다양성의 *marginal* 가치는 cost-matched self-consistency 대비 미입증(이 1회 관측에선 0). 따라서 (1) 키퍼 노출은 `core_always`가 아니라 `keeper_tool_search` 발견이어야 하고, (2) 이종 패널 비용을 self-consistency 대비 정당화하려면 이 하네스로 **다수 프롬프트 eval**이 선행되어야 한다. 하네스는 이제 그 eval을 가능하게 한다.

## RFC
RFC-0252-fusion-panel-judge-deliberation §11(평가 하네스 비협상), §4(orchestrator 동기 호출), §7(OAS 글루).

WORKAROUND-WAIVED: 본 PR은 RFC-0252 §11이 요구하는 평가 하네스다. 증상 억제/telemetry-as-fix가 아니라 measurement infrastructure 신설.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
