### PR TITLE
chore(release): sync ROADMAP and lockfile versions after v0.19.45/v0.19.46

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Current package version: v0.19.46
 > Latest changelog entry: v0.19.46 (2026-06-18)
-> Latest published GitHub release: v0.19.41 (2026-06-12)
+> Latest published GitHub release: v0.19.45 (2026-06-17)
 > Updated: 2026-06-18
 
 This roadmap is the 6-8 week operating view for `masc`.

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -11,7 +11,7 @@ code_refs:
 
 > Current package version: v0.19.46
 > Latest changelog entry: v0.19.46 (2026-06-18)
-> Latest published GitHub release: v0.19.41 (2026-06-12)
+> Latest published GitHub release: v0.19.45 (2026-06-17)
 > Updated: 2026-06-18
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history
 

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "masc"
-version: "0.19.42"
+version: "0.19.46"
 synopsis: "Multi-Agent Shared Context MCP Server in OCaml"
 description:
   "MASC Protocol: File-based workspace collaboration for Claude, Gemini, and Codex agents"


### PR DESCRIPTION
Follow-up to #21491.\n\n- ROADMAP.md: update published release marker from v0.19.41 to v0.19.45.\n- masc.opam.locked: update package version from 0.19.42 to 0.19.46.\n\nLocal check: scripts/check-version-truth.sh passes.