### PR TITLE
fix(exec): enforce catastrophic floor on the always-run dispatch path (flag-independent)

### DIFF
--- a/docs/rfc/RFC-0254-shell-ir-approval-autonomous-policy.md
+++ b/docs/rfc/RFC-0254-shell-ir-approval-autonomous-policy.md
@@ -111,6 +111,36 @@ let decide policy ~overlay ~caps ~simple : Verdict.t =
 
 `find_destructive_git` no longer reads `privileged_trust` — destructive git is in the floor. This fixes defect §2.2(4): loosening trust never re-enables force-push.
 
+### 5.3.1 Floor independence from the kill-switch (amendment, 2026-06-18)
+
+§5.3 decoupled the floor from *trust* (a loosened overlay can no longer
+re-enable force-push). It did **not** decouple it from the *flag*.
+`catastrophic_floor` runs only inside `dispatch_classified_with_approval`, which
+`keeper_tool_execute_runtime.ml` invokes only when
+`MASC_SHELL_IR_APPROVAL_GATE_ENABLED` is true. With the flag off, the keeper
+path falls to bare `dispatch_classified`, which skips the floor entirely — so
+the kill-switch silently removes it. For destructive git that means **zero**
+enforcement when off, because §5.4 establishes the floor is its only enforcer
+(force-push has no path argument for `validate_paths` to jail). This contradicts
+§4 lesson (c): "a catastrophic floor is unconditional, independent of
+mode/allowlist." (The flag was `default=false, Experimental` at the time of
+§5.3; it is now `default=true, Active`, so the gap bites only when the
+kill-switch is set explicitly — but a one-line env override dropping irreversible
+protection is precisely the hazard the floor exists to remove.)
+
+**Amendment.** The floor moves into the always-run chokepoint
+`dispatch_classified` — the single function every executed command passes
+through (the flag-off keeper path, `keeper_workspace_read_ops`, and
+`keeper_deterministic_evidence_probe` all reach it directly, and
+`dispatch_classified_with_approval` delegates its allow path to it). The pure
+`catastrophic_floor` is exposed from `Approval_policy` and called there; `decide`
+keeps calling the same function (single source of truth), so the `_with_approval`
+allow-path re-scan is a `None` no-op, not a double-deny. The kill-switch now
+disables only the trust-overlay grading (stage 2 / the `Ask` approval path); the
+catastrophic floor is unconditional — both trust-independent (§5.3) and
+flag-independent (this amendment). A floor hit on the bare path surfaces as the
+same `Policy_denied` typed error the `_with_approval` path already returns.
+
 ### 5.4 Catastrophic floor membership — typed, no string match
 
 > **Premise correction (code-verified 2026-06-17, supersedes the original

--- a/lib/exec/approval_policy.mli
+++ b/lib/exec/approval_policy.mli
@@ -42,3 +42,18 @@ val decide :
     [git push --force].  Path-bearing destructive programs ([rm], [dd], …)
     are graded in stage 2; their target paths are jailed to the workspace by
     [Exec_policy.validate_shell_ir_paths] downstream of this decision. *)
+
+val catastrophic_floor : Capability.t list -> Verdict.deny_reason option
+(** Stage 1 of [decide] on its own: [Some reason] for a [Destructive] git op, a
+    redirect [Write_path] escaping the workspace, or a catastrophic-by-identity
+    binary ([mkfs]); [None] otherwise.
+
+    Exposed so the always-run dispatch core
+    ([Keeper_tool_execute_shell_ir.dispatch_classified]) can enforce the floor
+    on every executed command, independent of the
+    [MASC_SHELL_IR_APPROVAL_GATE_ENABLED] flag.  The flag gates only the
+    trust-overlay grading (stage 2 / the [Ask] approval path); the floor must
+    not be flag-gated — RFC-0254 §4 lesson (c) "a catastrophic floor is
+    unconditional, independent of mode/allowlist".  For destructive git this
+    floor is the {i only} enforcer: force-push has no path argument, so
+    [validate_shell_ir_paths] cannot catch it (RFC-0254 §5.4). *)

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -104,23 +104,41 @@ let dispatch_classified
       envelope
   =
   let ir = envelope.Masc_exec.Shell_ir_risk.ir in
-  let gate_verdict =
-    Shell_gate.gate_typed
-      ~ir
-      ~syntax_policy:{ allow_pipes; redirect_allowed }
-      ~path_policy:Shell_gate.forbid_masc_internal_state_paths
-      ~sandbox:{ target = sandbox }
-      ()
-  in
-  gate_verdict_map
-    gate_verdict
-    ~f_reject:(fun diagnostic -> Error (Gate_reject diagnostic))
-    ~f_cannot_parse:(Error Cannot_parse)
-    ~f_too_complex:(Error Too_complex)
-    ~f_allow:(fun _context ->
-      match validate_paths ?keeper_id ?base_path ~workdir ir with
-      | Error e -> Error (Path_reject e)
-      | Ok () -> Ok (Masc_exec.Exec_dispatch.dispatch_decided ?base_host_env ?on_output_chunk envelope))
+  (* Trust- AND flag-independent catastrophic floor (RFC-0254 §4 lesson (c),
+     §5.4).  [dispatch_classified] is the single chokepoint every executed
+     command passes through — the [MASC_SHELL_IR_APPROVAL_GATE_ENABLED]=off
+     keeper path (keeper_tool_execute_runtime.ml) and the read-ops/evidence
+     paths reach it directly — so enforcing the floor here makes it
+     unconditional: destructive git, redirect write-escape, and [mkfs] are
+     denied even with the approval flag off.  The [_with_approval] wrapper runs
+     the same [catastrophic_floor] first via [Approval_policy.decide] (single
+     source of truth); on its allow path this re-scan returns [None], so there
+     is no double-deny, only one cheap pure scan.  Destructive git has no path
+     argument for [validate_paths] to jail, so this floor is its only enforcer
+     (RFC-0254 §5.4). *)
+  match
+    Masc_exec.Approval_policy.catastrophic_floor (Masc_exec.Capability_check.of_ir ir)
+  with
+  | Some reason ->
+    Error (Policy_denied { reason = Masc_exec.Verdict.deny_reason_to_string reason })
+  | None ->
+    let gate_verdict =
+      Shell_gate.gate_typed
+        ~ir
+        ~syntax_policy:{ allow_pipes; redirect_allowed }
+        ~path_policy:Shell_gate.forbid_masc_internal_state_paths
+        ~sandbox:{ target = sandbox }
+        ()
+    in
+    gate_verdict_map
+      gate_verdict
+      ~f_reject:(fun diagnostic -> Error (Gate_reject diagnostic))
+      ~f_cannot_parse:(Error Cannot_parse)
+      ~f_too_complex:(Error Too_complex)
+      ~f_allow:(fun _context ->
+        match validate_paths ?keeper_id ?base_path ~workdir ir with
+        | Error e -> Error (Path_reject e)
+        | Ok () -> Ok (Masc_exec.Exec_dispatch.dispatch_decided ?base_host_env ?on_output_chunk envelope))
 ;;
 
 (* TEL-OK: wrapper only classifies before delegating to dispatch_classified. *)

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -1046,4 +1046,38 @@ let () =
   | Error _ -> assert false
 
 let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Exec_program.of_string "mkfs" |> Result.get_ok in
+  let ir =
+    { bin
+    ; args = [ Lit ("/dev/sdb1", default_meta) ]
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Masc_exec.Sandbox_target.host ()
+    }
+  in
+  let envelope =
+    Masc_exec.Shell_ir_risk.classify (Masc_exec.Shell_ir_risk.undecided (Masc_exec.Shell_ir.Simple ir))
+  in
+  (* A second, distinct floor member (Catastrophic_program) on the bare path.
+     The destructive-git case alone could pass even if a regression narrowed the
+     bare-path capability derivation; denying a catastrophic-by-identity binary
+     too proves the bare [dispatch_classified] runs the whole
+     [catastrophic_floor], not just one arm.  (The third member, redirect
+     write-escape, is covered at the policy layer in test_approval_policy; all
+     three route through the same single [catastrophic_floor] function, so two
+     distinct members exercising the bare path guard the wiring.) *)
+  match
+    Keeper_tool_execute_shell_ir.dispatch_classified
+      ~workdir:"/tmp"
+      ~sandbox:(Masc_exec.Sandbox_target.host ())
+      envelope
+  with
+  | Ok _ -> assert false
+  | Error (Keeper_tool_execute_shell_ir.Policy_denied _) -> ()
+  | Error _ -> assert false
+
+let () =
   Printf.printf "p7_exec_dispatch: all tests passed.\n"

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -1007,5 +1007,43 @@ let () =
   | Error (Keeper_tool_execute_shell_ir.Approval_required _) -> ()
   | Error _ -> assert false
 
+(* --- Keeper_tool_execute_shell_ir.dispatch_classified: catastrophic floor is
+   flag-independent (RFC-0254 §5.3.1) --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Exec_program.of_string "git" |> Result.get_ok in
+  let ir =
+    { bin
+    ; args = [ Lit ("push", default_meta); Lit ("--force", default_meta) ]
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Masc_exec.Sandbox_target.host ()
+    }
+  in
+  let envelope =
+    Masc_exec.Shell_ir_risk.classify (Masc_exec.Shell_ir_risk.undecided (Masc_exec.Shell_ir.Simple ir))
+  in
+  (* The bare [dispatch_classified] path takes no approval_config/agent_id — it is
+     the [MASC_SHELL_IR_APPROVAL_GATE_ENABLED]=off route that
+     [keeper_tool_execute_runtime.ml] falls to when the kill-switch is set.
+     Before §5.3.1 it skipped the catastrophic floor, so [git push --force]
+     (no path argument, so [validate_paths] cannot jail it — §5.4) executed.
+     The floor must now deny it here as [Policy_denied], identically to the
+     _with_approval path, proving the floor is flag-independent.  ([Ok _] would
+     mean the floor was skipped — a regression; [git push --force] in /tmp is a
+     non-repo no-op even if it ran, so no filesystem effect.) *)
+  match
+    Keeper_tool_execute_shell_ir.dispatch_classified
+      ~workdir:"/tmp"
+      ~sandbox:(Masc_exec.Sandbox_target.host ())
+      envelope
+  with
+  | Ok _ -> assert false
+  | Error (Keeper_tool_execute_shell_ir.Policy_denied _) -> ()
+  | Error _ -> assert false
+
 let () =
   Printf.printf "p7_exec_dispatch: all tests passed.\n"


### PR DESCRIPTION
## Summary

The Shell IR catastrophic floor (destructive git, redirect write-escape, `mkfs`) was flag-gated: it ran only inside `dispatch_classified_with_approval`, which `keeper_tool_execute_runtime.ml` invokes only when `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` is true. With the flag off (the kill-switch), the keeper path falls to bare `dispatch_classified`, which skipped the floor — so a single env override silently removed irreversible-action protection. For destructive git that meant **zero** enforcement when off: the floor is its only enforcer, because force-push has no path argument for `validate_shell_ir_paths` to jail (RFC-0254 §5.4).

This realizes RFC-0254 §4 lesson (c) — "a catastrophic floor is unconditional, independent of mode/allowlist" — which §5.3 satisfied for *trust* (a loosened overlay can no longer re-enable force-push) but not for the *flag*.

## Change

- Move the floor into `dispatch_classified`, the single chokepoint every executed command passes through: the flag-off keeper path, `keeper_workspace_read_ops`, and `keeper_deterministic_evidence_probe` all reach it directly, and `dispatch_classified_with_approval` delegates its allow path to it.
- Expose `Approval_policy.catastrophic_floor` (the existing pure function) and call it there. `decide` keeps calling the same function — single source of truth, no duplicated membership list — so the `_with_approval` allow-path re-scan returns `None` (a no-op, not a double-deny).
- The kill-switch now disables only the trust-overlay grading (stage 2 / the `Ask` approval path). The floor is unconditional: trust-independent (§5.3) and flag-independent (new §5.3.1).

## Not changed

`Approval_policy.decide` logic, `gate_typed`, the path jail, the flag default (`true`), log levels, and the runtime's error match (already handles `Policy_denied`, so a bare-path floor hit needs no runtime change).

## Verification

- New `test_exec_dispatch` case: bare `dispatch_classified` (no approval config) denies `git push --force` with `Policy_denied`, proving flag-independence.
- `lib/exec` suite + shell-gate baseline (19/19) green:
  `DUNE_CACHE=disabled dune build --root . @lib/exec/test/runtest` and `test/test_exec_dispatch.exe`, `test/test_exec_shell_command_gate.exe`.

## RFC

RFC-0254 §5.3.1 (amendment, this PR) — Floor independence from the kill-switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
