### PR TITLE
fix(keeper): orphan audit keeper-aware staleness (root fix for #21418)

### DIFF
--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -69,7 +69,6 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
       (* "Failed" here means still-auditable active work. Terminal Cancelled
          tasks are historical evidence, not a reason to wake every keeper. *)
       Workspace.audit_orphan_tasks config
-      |> List.filter (fun (_, assignee) -> assignee <> meta.agent_name)
       |> List.map fst
       |> List.filter claim_scope_filter
       |> List.length

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -114,7 +114,16 @@ let get_all_agents config =
 
 (** Audit tasks: find claimed/in_progress tasks whose assignees are not active agents.
     Matches assignees by exact name or agent-type prefix (e.g. "<prefix>" matches "<prefix>-xxx").
-    Agents with Inactive status are excluded from the active set. *)
+    Agents with Inactive status are excluded from the active set.
+
+    Staleness uses the canonical keeper-aware predicate
+    {!Workspace_resilience.Zombie.is_zombie_for_agent}: keeper agents get the
+    longer keeper grace ([MASC_KEEPER_ZOMBIE_THRESHOLD_SEC], default 3600s) and
+    ordinary agents the default ([MASC_ZOMBIE_THRESHOLD_SEC], default 300s) —
+    the same policy as [cleanup_zombies]/[status]. A live keeper that has gone
+    quiet between heartbeats (but within its grace) is therefore not classified
+    as inactive, so its own claimed/in-progress task is not mis-reported as an
+    orphan at the source. *)
 let audit_orphan_tasks config : (Masc_domain.task * string) list =
   if not (is_initialized config) then []
   else
@@ -123,7 +132,11 @@ let audit_orphan_tasks config : (Masc_domain.task * string) list =
     let active_names =
       load_agents_from_dir config agents_path ~include_inactive:false
       |> List.filter (fun (agent : Masc_domain.agent) ->
-          not (Workspace_resilience.Time.is_stale agent.last_seen))
+          not
+            (Workspace_resilience.Zombie.is_zombie_for_agent
+               ~agent_name:agent.name
+               ~agent_type:agent.agent_type
+               agent.last_seen))
       |> List.map (fun (agent : Masc_domain.agent) -> agent.name)
     in
     let is_active_agent assignee =

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -921,6 +921,21 @@ let make_stale_agent ?(agent_type = "test") config ~name ~age_seconds =
   in
   Workspace.write_json config path (Yojson.Safe.from_string agent_json)
 
+(* Age a bound agent's last_seen while keeping status:active — simulates a live
+   agent that has gone quiet between heartbeats. Unlike make_stale_agent (which
+   marks the agent inactive, so the include_inactive:false load drops it before
+   any threshold check), this exercises the staleness threshold path in
+   audit_orphan_tasks. *)
+let age_active_agent ?(agent_type = "test") config ~name ~age_seconds =
+  let agents_path = Filename.concat (Workspace.masc_dir config) "agents" in
+  let path = Filename.concat agents_path (Workspace.safe_filename name ^ ".json") in
+  let stale_ts = iso_ago age_seconds in
+  let agent_json = Printf.sprintf
+    {|{"name":"%s","agent_type":"%s","status":"active","capabilities":[],"joined_at":"%s","last_seen":"%s"}|}
+    name agent_type stale_ts stale_ts
+  in
+  Workspace.write_json config path (Yojson.Safe.from_string agent_json)
+
 let test_cleanup_zombies_detects_regular () =
   with_test_env (fun config ->
     (* Create a regular agent idle for 10 minutes (> 300s threshold) *)
@@ -1336,6 +1351,55 @@ let test_audit_orphan_awaiting_verification_tasks () =
               assignee;
             Alcotest.(check string) "verification orphan task id" "task-001"
               task.id))
+
+(* Regression for #21418: a live keeper that has gone quiet between heartbeats
+   (last_seen past the 300s default, but within the 3600s keeper grace) must NOT
+   have its own claimed task classified as an orphan. With the pre-fix
+   [Time.is_stale] (300s flat) predicate this returned 1 orphan, which drove the
+   keeper self-wake loop that #21418 papered over by filtering self from the
+   count. The root fix routes keepers through [Zombie.is_zombie_for_agent]. *)
+let test_audit_orphan_spares_live_keeper_within_grace () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Keeper Task" ~priority:1 ~description:"" in
+    let keeper = "keeper-grace-agent" in
+    let _ = Workspace.bind_session config ~agent_name:keeper ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:keeper ~task_id:"task-001" in
+    age_active_agent config ~agent_type:"keeper" ~name:keeper ~age_seconds:600.0;
+    let orphans = Workspace.audit_orphan_tasks config in
+    Alcotest.(check int) "live keeper within grace is not an orphan" 0
+      (List.length orphans)
+  )
+
+(* A keeper quiet beyond the 3600s keeper grace IS still an orphan, so its task
+   remains reclaimable — the fix extends the grace window, it does not exempt
+   keepers permanently. *)
+let test_audit_orphan_detects_dead_keeper_beyond_grace () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Keeper Task" ~priority:1 ~description:"" in
+    let keeper = "keeper-dead-agent" in
+    let _ = Workspace.bind_session config ~agent_name:keeper ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:keeper ~task_id:"task-001" in
+    age_active_agent config ~agent_type:"keeper" ~name:keeper ~age_seconds:4000.0;
+    let orphans = Workspace.audit_orphan_tasks config in
+    Alcotest.(check int) "dead keeper beyond grace is an orphan" 1
+      (List.length orphans);
+    let (_, assignee) = List.hd orphans in
+    Alcotest.(check string) "orphan assignee is the dead keeper" keeper assignee
+  )
+
+(* Non-keeper agents keep the 300s default threshold — 10 minutes quiet orphans
+   the task, confirming the keeper grace is scoped to keepers only. *)
+let test_audit_orphan_nonkeeper_uses_default_threshold () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Regular Task" ~priority:1 ~description:"" in
+    let agent = "claude-worker-agent" in
+    let _ = Workspace.bind_session config ~agent_name:agent ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:agent ~task_id:"task-001" in
+    age_active_agent config ~agent_type:"claude" ~name:agent ~age_seconds:600.0;
+    let orphans = Workspace.audit_orphan_tasks config in
+    Alcotest.(check int) "non-keeper past default threshold is an orphan" 1
+      (List.length orphans)
+  )
 
 let test_cleanup_zombies_releases_tasks () =
   with_test_env (fun config ->
@@ -1817,6 +1881,12 @@ let () =
         "audit orphan awaiting verification tasks"
         `Quick
         test_audit_orphan_awaiting_verification_tasks;
+      Alcotest.test_case "audit orphan spares live keeper within grace" `Quick
+        test_audit_orphan_spares_live_keeper_within_grace;
+      Alcotest.test_case "audit orphan detects dead keeper beyond grace" `Quick
+        test_audit_orphan_detects_dead_keeper_beyond_grace;
+      Alcotest.test_case "audit orphan non-keeper uses default threshold" `Quick
+        test_audit_orphan_nonkeeper_uses_default_threshold;
       Alcotest.test_case "cleanup zombies runtime" `Quick test_cleanup_zombies_releases_tasks;
     ];
 


### PR DESCRIPTION
## 목적
머지된 PR #21418("exclude self-assigned tasks from stale failed_task_count")이 남긴 **라이브 HIGH 회귀**의 근본 수정. 적대 리뷰(#21418 코멘트)에서 symptom-suppression으로 식별된 건을 root fix로 대체.

## 근본 원인
`audit_orphan_tasks`(lib/workspace/workspace_query.ml)가 staleness를 flat 300s `Time.is_stale`로 판정 → heartbeat 사이 조용해진 *살아있는* keeper의 last_seen이 300s를 넘으면 그 keeper의 claimed/in-progress task가 orphan으로 오분류 → `failed_task_count>0` → keeper self-wake/self-audit 루프. #21418은 카운트에서 자기만 빼서(`assignee <> meta.agent_name`) 증상을 가렸지만:
- 다른 consumer(`keeper_tool_task_runtime` Tasks_audit, 자기 task에 force-release 힌트 발행)는 여전히 깨짐
- 근본 오분류는 그대로

## 수정
- **lib/workspace/workspace_query.ml**: staleness를 canonical keeper-aware predicate `Workspace_resilience.Zombie.is_zombie_for_agent ~agent_name ~agent_type`로 교체. keeper는 3600s grace(`MASC_KEEPER_ZOMBIE_THRESHOLD_SEC`), 일반 에이전트는 300s 기본 — `cleanup_zombies`/`status`가 이미 쓰는 SSOT 정책. 시그니처 불변 → caller 무영향(2 caller + .mli).
- **lib/keeper/keeper_world_observation_inputs.ml**: self-filter 워크어라운드 1줄 제거 (root fix가 source에서 처리하므로 불필요).

## 검증
로컬 `DUNE_CACHE=disabled dune build --root .` green + `test/test_workspace.exe`:
- ✅ `audit orphan spares live keeper within grace` (600s, keeper) → 0 orphans (**pre-fix면 1 = 회귀 재현**)
- ✅ `audit orphan detects dead keeper beyond grace` (4000s) → 1 orphan (dead keeper는 여전히 회수 가능)
- ✅ `audit orphan non-keeper uses default threshold` (claude, 600s) → 1 orphan (300s 유지)
- ✅ 기존 `audit orphan tasks` / `awaiting verification` 회귀 없음

⚠️ pre-existing 실패 3건(`lifecycle messages typed`, `multiple tasks independent`, `BUG-1 rejoin event log`)은 **내 변경을 stash한 clean origin/main에서도 동일하게 실패**(81 vs 84 tests = 내 신규 3개 차이만) → 본 PR과 무관.

## 안 건드린 것
소스 시그니처(audit_orphan_tasks .mli) 불변. credential/operator/sandbox/dashboard-credential/hooks/workflow 게이트 미해당.

RFC-WAIVED: 동작 버그 수정(staleness 정책 정합)이며 RFC-게이트 subsystem 미해당. 본 PR은 워크어라운드를 *추가가 아니라 제거*하므로 Workaround Signature Gate도 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
