### PR TITLE
fix(transport): address review follow-ups from #21489

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -483,7 +483,7 @@ describe('dashboard websocket route subscriptions', () => {
     expect(mockSockets).toHaveLength(1)
   })
 
-  it('stops reconnecting after a fatal server error close', async () => {
+  it('reconnects after a transient 1011 server error close', async () => {
     vi.useFakeTimers()
     installWebSocketMocks()
 
@@ -503,7 +503,8 @@ describe('dashboard websocket route subscriptions', () => {
 
     expect(dashboardWsConnected.value).toBe(false)
     expect(dashboardWsReady.value).toBe(false)
-    expect(mockSockets).toHaveLength(1)
+    expect(mockSockets).toHaveLength(2)
+    expect(mockSockets[1]!.readyState).toBe(MockWebSocket.CONNECTING)
   })
 
   it('stops reconnecting after an abnormal close after hello is rejected', async () => {

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -64,8 +64,9 @@ let helloFailed = false
 const pending = new Map<number, PendingRpc>()
 
 // WebSocket close codes that indicate a persistent failure and should stop
-// reconnection attempts (1008 policy violation, 1011 server error).
-const FATAL_CLOSE_CODES = new Set([1008, 1011])
+// reconnection attempts (1008 policy violation). 1011 (server error) is left
+// to the normal reconnect backoff because it is often transient.
+const FATAL_CLOSE_CODES = new Set([1008])
 
 function sessionStorageOrNull(): Storage | null {
   if (typeof sessionStorage === 'undefined') return null

--- a/dashboard/src/transports/sse-transport.test.ts
+++ b/dashboard/src/transports/sse-transport.test.ts
@@ -133,7 +133,7 @@ describe('createSseTransport', () => {
     expect(instances).toHaveLength(2)
   })
 
-  it('stops reconnecting after retryMaxAttempts and emits close', () => {
+  it('keeps reconnecting after retryMaxAttempts and emits close once', () => {
     const events: { type: string }[] = []
     const transport = createSseTransport('/mcp', {
       retryBaseMs: 10,
@@ -156,8 +156,8 @@ describe('createSseTransport', () => {
     expect(transport.isConnected()).toBe(false)
     expect(events.filter((e) => e.type === 'close')).toHaveLength(1)
 
-    vi.advanceTimersByTime(1_000)
-    expect(instances).toHaveLength(3)
+    vi.advanceTimersByTime(10)
+    expect(instances).toHaveLength(4)
   })
 
   it('resets backoff after a successful reconnect', () => {

--- a/dashboard/src/transports/sse-transport.ts
+++ b/dashboard/src/transports/sse-transport.ts
@@ -13,6 +13,7 @@ export function createSseTransport(url: string, opts: TransportOptions = {}): Tr
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
   let connected = false
   let reconnectAttempts = 0
+  let closeNotified = false
   const retryMaxAttempts = opts.retryMaxAttempts ?? TRANSPORT_RETRY_MAX_ATTEMPTS
   const retryJitterMs = opts.retryJitterMs ?? TRANSPORT_RETRY_JITTER_MS
 
@@ -21,9 +22,9 @@ export function createSseTransport(url: string, opts: TransportOptions = {}): Tr
   }
 
   const scheduleReconnect = () => {
-    if (reconnectAttempts >= retryMaxAttempts) {
+    if (reconnectAttempts >= retryMaxAttempts && !closeNotified) {
+      closeNotified = true
       notify({ type: 'close' })
-      return
     }
     reconnectAttempts += 1
     const maxMs = opts.retryMaxMs ?? TRANSPORT_RETRY_MAX_MS
@@ -41,6 +42,7 @@ export function createSseTransport(url: string, opts: TransportOptions = {}): Tr
         connected = true
         retryMs = opts.retryBaseMs ?? TRANSPORT_RETRY_BASE_MS
         reconnectAttempts = 0
+        closeNotified = false
         notify({ type: 'open' })
       }
       source.onmessage = (ev) => {
@@ -71,6 +73,7 @@ export function createSseTransport(url: string, opts: TransportOptions = {}): Tr
     connected = false
     retryMs = opts.retryBaseMs ?? TRANSPORT_RETRY_BASE_MS
     reconnectAttempts = 0
+    closeNotified = false
     source?.close()
     source = null
     notify({ type: 'close' })

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -950,7 +950,7 @@ let start_upgrade_heartbeat ?sw ?clock session_id session =
             if !send_failed
             then cleanup_session session_id
             else begin
-              Atomic.set session.missed_pongs (Atomic.get session.missed_pongs + 1);
+              Atomic.incr session.missed_pongs;
               loop ()
             end
           end

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -296,7 +296,7 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
                spin until the WSD observes the broken socket. *)
             Server_mcp_transport_ws.cleanup_session session_id
           else begin
-            Atomic.set session.missed_pongs (missed + 1);
+            Atomic.incr session.missed_pongs;
             loop ()
           end
         end


### PR DESCRIPTION
Addresses the three unresolved review threads from chatgpt-codex-connector on #21489.

- P1: dashboard/src/transports/sse-transport.ts — keep SSE reconnecting after transient outages instead of giving up at retryMaxAttempts.
- P2: lib/server/server_ws_standalone.ml / lib/server/server_mcp_transport_ws.ml — use atomic increment for the missed-pong counter so a pong reset is not overwritten by the heartbeat.
- P2: dashboard/src/dashboard-ws.ts — do not treat 1011 (server error) as fatal; let the normal reconnect backoff handle it.