### PR TITLE
fix(keeper): unify surface_context formatter as SSOT across HTTP and MCP paths (#21465)

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -105,43 +105,95 @@ let direct_owner_conversation_context
       ~limit:8 ~config ~meta ()
     |> Keeper_world_observation_message_scope.render_recent_direct_conversation_context
 
+(* Flatten newlines/tabs to spaces and trim, so a co-view value never breaks
+   the line-oriented instruction block. *)
+let normalized_surface_context_value value =
+  value
+  |> String.to_seq
+  |> Seq.map (function '\n' | '\r' | '\t' -> ' ' | ch -> ch)
+  |> String.of_seq
+  |> String.trim
+
+let surface_context_field_value = function
+  | `String s -> normalized_surface_context_value s
+  | json -> Yojson.Safe.to_string json
+
+(* Accept fields as BOTH the dashboard wire shape [`List of {k,v} objects] and a
+   plain [`Assoc] map. The earlier keeper_turn copy matched only `Assoc and
+   silently dropped the dashboard's list shape on the MCP tool path. *)
+let surface_context_fields fields_json =
+  let lines =
+    match fields_json with
+    | `List items ->
+        List.filter_map
+          (function
+            | `Assoc fields -> (
+                match
+                  (List.assoc_opt "k" fields, List.assoc_opt "v" fields)
+                with
+                | Some (`String k), Some v ->
+                    let k = normalized_surface_context_value k in
+                    if k = "" then None
+                    else
+                      Some
+                        (Printf.sprintf "  - %s: %s" k
+                           (surface_context_field_value v))
+                | _ -> None)
+            | _ -> None)
+          items
+    | `Assoc pairs ->
+        List.filter_map
+          (fun (k, v) ->
+            let k = normalized_surface_context_value k in
+            if k = "" then None
+            else
+              Some
+                (Printf.sprintf "  - %s: %s" k (surface_context_field_value v)))
+          pairs
+    | _ -> []
+  in
+  if lines = [] then None else Some (String.concat "\n" lines)
+
+(* Single SSOT formatter for dashboard co-view context
+   ({label,route,scene,fields}). Shared by the HTTP copilot route
+   ([Server_routes_http_keeper_stream]) and the masc_keeper_msg MCP tool path,
+   so the two surfaces cannot drift. *)
 let surface_context_to_instructions (ctx : Yojson.Safe.t) : string option =
   match ctx with
   | `Assoc fields ->
-      let string_field key =
+      let get_string key =
         match List.assoc_opt key fields with
         | Some (`String s) ->
-            let s = String.trim s in
+            let s = normalized_surface_context_value s in
             if s = "" then None else Some s
         | _ -> None
       in
-      let json_field key = List.assoc_opt key fields in
-      let parts =
-        (match string_field "label" with
-         | Some s -> [ Printf.sprintf "Surface label: %s" s ]
-         | None -> [])
-        @
-        (match string_field "route" with
-         | Some s -> [ Printf.sprintf "Route: %s" s ]
-         | None -> [])
-        @
-        (match string_field "scene" with
-         | Some s -> [ Printf.sprintf "Scene: %s" s ]
-         | None -> [])
-        @
-        (match json_field "fields" with
-         | Some (`Assoc fs) when fs <> [] ->
-             [ "Fields:\n"
-               ^ String.concat "\n"
-                   (List.map
-                      (fun (k, v) ->
-                        Printf.sprintf "- %s: %s" k (Yojson.Safe.to_string v))
-                      fs) ]
-         | Some _ | None -> [])
+      let fields_block =
+        match List.assoc_opt "fields" fields with
+        | Some fields_json -> surface_context_fields fields_json
+        | None -> None
       in
-      if parts = [] then None
-      else Some (String.concat "\n\n" parts)
-  | _ -> None
+      let lines =
+        List.filter_map
+          (fun (name, value_opt) ->
+            Option.map (fun v -> Printf.sprintf "%s: %s" name v) value_opt)
+          [
+            ("Surface label", get_string "label");
+            ("Route", get_string "route");
+            ("Scene", get_string "scene");
+          ]
+      in
+      let lines =
+        match fields_block with
+        | Some block -> lines @ [ "Fields:"; block ]
+        | None -> lines
+      in
+      if lines = [] then None
+      else Some (String.concat "\n" ("[Co-view context]" :: lines))
+  | json ->
+      Some
+        (Printf.sprintf "[Co-view context]\n%s"
+           (Yojson.Safe.pretty_to_string json))
 
 module For_testing = struct
   let direct_owner_conversation_context = direct_owner_conversation_context

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -44,6 +44,15 @@ module For_testing : sig
       into turn instructions when no explicit [turn_instructions] is supplied. *)
 end
 
+(** Format a dashboard co-view context object ({ label, route, scene, fields })
+    into turn instructions. Accepts [fields] as both a [`List] of {k,v} objects
+    (dashboard wire shape) and a plain [`Assoc] map. This is the single SSOT
+    formatter shared by the HTTP copilot route
+    ([Server_routes_http_keeper_stream]) and the masc_keeper_msg MCP tool path,
+    so the two surfaces cannot drift. Returns [None] when there is nothing to
+    render. *)
+val surface_context_to_instructions : Yojson.Safe.t -> string option
+
 val handle_keeper_msg :
   ?on_text_delta:(string -> unit) ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -24,87 +24,16 @@ let keeper_chat_stream_error_json message =
         `Assoc [ ("message", `String message) ] );
     ]
 
-let normalized_context_value value =
-  value
-  |> String.to_seq
-  |> Seq.map (function
-       | '\n' | '\r' | '\t' -> ' '
-       | ch -> ch)
-  |> String.of_seq
-  |> String.trim
+(* Co-view context formatting is owned by the single SSOT
+   [Keeper_turn.surface_context_to_instructions], shared with the
+   masc_keeper_msg MCP tool path so the HTTP copilot route and the tool path
+   cannot drift (and so both accept the dashboard's `List of {k,v} fields
+   shape). [format_surface_context] keeps the string-returning shape that
+   [turn_instructions_for_request] consumes. *)
+let surface_context_to_instructions = Keeper_turn.surface_context_to_instructions
 
-let format_surface_context_field_value = function
-  | `String s -> normalized_context_value s
-  | json -> Yojson.Safe.to_string json
-
-let format_surface_context_fields fields_json =
-  let lines =
-    match fields_json with
-    | `List items ->
-        List.filter_map
-          (function
-            | `Assoc fields -> (
-                match
-                  ( List.assoc_opt "k" fields,
-                    List.assoc_opt "v" fields )
-                with
-                | Some (`String k), Some v ->
-                    let k = normalized_context_value k in
-                    if k = "" then None
-                    else Some (Printf.sprintf "  - %s: %s" k (format_surface_context_field_value v))
-                | _ -> None)
-            | _ -> None)
-          items
-    | `Assoc pairs ->
-        List.filter_map
-          (fun (k, v) ->
-            let k = normalized_context_value k in
-            if k = "" then None
-            else Some (Printf.sprintf "  - %s: %s" k (format_surface_context_field_value v)))
-          pairs
-    | _ -> []
-  in
-  if lines = [] then None else Some (String.concat "\n" lines)
-
-let format_surface_context = function
-  | `Assoc fields ->
-      let get_string key =
-        match List.assoc_opt key fields with
-        | Some (`String s) ->
-            let s = normalized_context_value s in
-            if s = "" then None else Some s
-        | _ -> None
-      in
-      let label = get_string "label" in
-      let route = get_string "route" in
-      let scene = get_string "scene" in
-      let fields_block =
-        match List.assoc_opt "fields" fields with
-        | Some fields_json -> format_surface_context_fields fields_json
-        | None -> None
-      in
-      let lines =
-        List.filter_map
-          (fun (name, value_opt) ->
-            Option.map (fun v -> Printf.sprintf "%s: %s" name v) value_opt)
-          [
-            ("Surface label", label);
-            ("Route", route);
-            ("Scene", scene);
-          ]
-      in
-      let lines =
-        match fields_block with
-        | Some block -> lines @ [ "Fields:"; block ]
-        | None -> lines
-      in
-      if lines = [] then "" else String.concat "\n" ("[Co-view context]" :: lines)
-  | json ->
-      Printf.sprintf "[Co-view context]\n%s" (Yojson.Safe.pretty_to_string json)
-
-let surface_context_to_instructions ctx =
-  let s = format_surface_context ctx in
-  if s = "" then None else Some s
+let format_surface_context ctx =
+  Option.value ~default:"" (surface_context_to_instructions ctx)
 
 let has_connector_context (payload : keeper_chat_stream_request) =
   payload.channel <> "" && payload.channel_workspace_id <> ""

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -218,6 +218,29 @@ let test_surface_context_to_instructions_ignores_empty () =
   check (option string) "empty surface_context" None
     (Server_routes_http_keeper_stream.For_testing.surface_context_to_instructions ctx)
 
+(* Regression for #21465: the keeper_turn (MCP tool path) formatter must render
+   the dashboard's `List of {k,v} fields shape rather than silently dropping it,
+   and must agree byte-for-byte with the HTTP copilot route now that both share
+   one SSOT formatter (Keeper_turn.surface_context_to_instructions). *)
+let test_surface_context_mcp_path_renders_list_fields () =
+  let ctx =
+    Yojson.Safe.from_string
+      {|{"label":"Overview","route":"/overview","scene":"fleet view","fields":[{"k":"run","v":"2/5"},{"k":"alert","v":"1"}]}|}
+  in
+  match KT.For_testing.surface_context_to_instructions ctx with
+  | Some instructions ->
+      check bool "renders list-shaped field key" true
+        (String_util.string_contains_substring ~needle:"run: 2/5" instructions);
+      check bool "renders second list-shaped field" true
+        (String_util.string_contains_substring ~needle:"alert: 1" instructions);
+      check bool "includes co-view header" true
+        (String_util.string_contains_substring ~needle:"[Co-view context]" instructions);
+      check (option string) "http route matches mcp formatter (single SSOT)"
+        (Some instructions)
+        (Server_routes_http_keeper_stream.For_testing.surface_context_to_instructions
+           ctx)
+  | None -> fail "expected list-shaped surface_context to format into instructions"
+
 let test_chat_surface_of_request_labels_copilot_gate () =
   let payload =
     { Server_routes_http_keeper_stream.name = "luna";
@@ -438,6 +461,8 @@ let () =
             test_surface_context_to_instructions_formats_copilot_context;
           test_case "surface context ignores empty fields" `Quick
             test_surface_context_to_instructions_ignores_empty;
+          test_case "surface context mcp path renders list fields" `Quick
+            test_surface_context_mcp_path_renders_list_fields;
           test_case "copilot request labels gate surface" `Quick
             test_chat_surface_of_request_labels_copilot_gate;
           test_case "copilot request speaker is owner" `Quick


### PR DESCRIPTION
## 문제 (#21465)

대시보드 co-view surface context가 **두 곳에서 서로 다르게** 포맷됐다:

- `Server_routes_http_keeper_stream.format_surface_context` (HTTP copilot route): `[Co-view context]` 헤더 + Surface/Route/Scene 라벨 + `List of {k,v}` wire shape에서 Fields 렌더링하는 rich 출력.
- `Keeper_turn.surface_context_to_instructions` (masc_keeper_msg MCP tool): `Assoc`만 처리, 헤더 없음, 대시보드가 실제로 보내는 `List` fields shape를 **조용히 drop**.

결과: MCP tool 경로에서 co-view context가 비거나 부분만 렌더링되고 두 surface가 drift.

## 수정

rich formatter를 `Keeper_turn`의 **단일 SSOT**(top-level `surface_context_to_instructions`)로 승격. `List of {k,v}`와 `Assoc` 두 shape를 모두 처리하고, HTTP route는 이 함수로 위임. server 파일에서 중복 포맷 로직 ~89줄 제거.

## 검증

- `DUNE_CACHE=disabled dune build` green
- `test_gate_keeper_backend` (37 tests) / `test_copilot_dock_channel_wiring` (8 tests) 통과
- 신규 `test_surface_context_mcp_path_renders_list_fields`: MCP 경로가 `List` fields를 렌더하고 HTTP/MCP 출력이 **byte-for-byte 동일**함을 assert → 두 surface가 다시 drift 불가
- `ocamlformat --check` 4파일 clean

RFC-WAIVED: keeper turn 핸들러 + stream route 포맷 통합. credential/identity/operator/sandbox/dashboard-credential/hooks 경계 미해당. 워크어라운드의 반대 — N-of-M 복붙 2곳을 SSOT 1곳으로 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
