### PR TITLE
perf(goal_verification): bound resolved requests (unbounded long-lived alloc)

### DIFF
--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -261,9 +261,10 @@ export function normalizeSSEDispatchType(rawType: string): string {
 
 
 // rAF-coalesced ingress: buffer SSE events and flush once per animation
-// frame inside batch(), collapsing a high-frequency burst (keeper streaming
-// emits per-token events) to <=1 signal notification / render per frame.
-// Mirrors dashboard-ws.ts's pendingInbound + scheduleFlush + batch() pattern;
+// frame. Each event is processed in its own batch() so signal writes inside
+// handleEvent stay coalesced per event, while lastEvent is updated per event
+// so subscribers receive every server push.
+// Mirrors dashboard-ws.ts's pendingInbound + scheduleFlush pattern;
 // the two flush bodies differ (WS: processInboundMessage, here: handleEvent),
 // so this is a local copy rather than a shared util — extract if a third
 // consumer appears.
@@ -288,15 +289,17 @@ function scheduleFlush(): void {
 function flushPending(): void {
   if (pendingEvents.length === 0) return
   const events = pendingEvents.splice(0, pendingEvents.length)
-  // Order preserved (splice + for-loop); batch() coalesces all signal writes
-  // across the whole burst into one notification.
-  batch(() => {
-    for (const ev of events) {
+  // Order preserved (splice + for-loop). Process each event in its own
+  // batch() so [handleEvent] signal writes are coalesced per event, while
+  // [lastEvent] is assigned outside the batch so subscribers are notified
+  // once per server push.
+  for (const ev of events) {
+    batch(() => {
       eventCount.value++
-      lastEvent.value = ev
       handleEvent(ev)
-    }
-  })
+    })
+    lastEvent.value = ev
+  }
 }
 
 /** Test-only: synchronously drain pending SSE events. Production code never
@@ -1041,6 +1044,12 @@ function handleEvent(event: SSEEvent): void {
 }
 
 export function disconnectSSE(): void {
+  if (flushHandle) {
+    if (typeof cancelAnimationFrame !== 'undefined') cancelAnimationFrame(flushHandle)
+    else clearTimeout(flushHandle)
+    flushHandle = 0
+  }
+  pendingEvents.length = 0
   unsubscribe?.()
   unsubscribe = null
   transport?.disconnect()

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,7 +14,7 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 350 unique knobs across 9 modules.
+**Total**: 351 unique knobs across 9 modules.
 
 **Typed getter classification**: 21/207 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 186).
 

--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -557,11 +557,50 @@ let emit_event config ~(goal_id : string) ~(event_type : string)
   in
   Fs_compat.append_jsonl path event
 
+let max_resolved_requests () =
+  (* Bounds how many resolved (Approved/Rejected/Cancelled) requests the
+     persistent [state.requests] list retains. The list is append-only
+     (create_request: requests @ [request]) with no prior pruning, so it
+     grew unbounded for the lifetime of the state file — a long-lived
+     allocation source (live_words growth after restart). Open requests
+     are always kept; only terminal resolved entries are capped. *)
+  match Sys.getenv_opt "MASC_GOAL_VERIFICATION_MAX_RESOLVED" with
+  | Some v -> (match int_of_string_opt (String.trim v) with Some n when n > 0 -> n | _ -> 500)
+  | None -> 500
+
+let prune_resolved_requests requests =
+  (* Keep every Open (active quorum) request plus the most recent
+     [max_resolved_requests] resolved entries. Resolved requests are
+     terminal: quorum evaluation only consults Open rows and vote dedup
+     short-circuits on non-Open status, so dropping old resolved entries
+     cannot regress correctness. Append order is chronological, so
+     dropping from the front of the resolved partition drops the oldest.
+     Order across the list is not load-bearing — list_requests_for_goal
+     filters by goal_id and find_request searches by id. *)
+  let opens, resolved = List.partition (fun (r : goal_verification_request) -> r.status = Open) requests in
+  let max_r = max_resolved_requests () in
+  let resolved_len = List.length resolved in
+  if resolved_len <= max_r then requests
+  else
+    (* Skip (resolved_len - max_r) oldest resolved, keep the rest. *)
+    let to_skip = resolved_len - max_r in
+    let rec keep_after_skip n = function
+      | _ :: rest when n > 0 -> keep_after_skip (n - 1) rest
+      | rest -> rest
+    in
+    opens @ keep_after_skip to_skip resolved
+
 let update_state config f =
   let lock_path = requests_path config in
   Workspace_utils.with_file_lock config lock_path (fun () ->
       let state = read_state config in
       let next_state = f state in
+      (* Bound long-lived growth: cap resolved requests on every write so
+         the persistent list cannot grow without limit. No-op once the
+         resolved count is within the cap. *)
+      let next_state =
+        { next_state with requests = prune_resolved_requests next_state.requests }
+      in
       write_state config next_state;
       next_state)
 

--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -456,7 +456,70 @@ let read_state config =
   else
     default_state ()
 
+let max_resolved_requests () =
+  (* Bounds how many resolved (Approved/Rejected/Cancelled) requests the
+     persistent [state.requests] list retains. The list is append-only
+     (create_request: requests @ [request]) with no prior pruning, so it
+     grew unbounded for the lifetime of the state file — a long-lived
+     allocation source (live_words growth after restart). Open requests
+     are always kept; only terminal resolved entries are capped. *)
+  match Sys.getenv_opt "MASC_GOAL_VERIFICATION_MAX_RESOLVED" with
+  | Some v ->
+      (match int_of_string_opt (String.trim v) with
+       | Some n when n > 0 -> n
+       | _ -> 500)
+  | None -> 500
+
+let prune_resolved_requests requests =
+  (* Keep every Open (active quorum) request plus the most recent
+     [max_resolved_requests] resolved entries. Resolved requests are
+     terminal: quorum evaluation only consults Open rows and vote dedup
+     short-circuits on non-Open status, so dropping old resolved entries cannot
+     regress correctness. Retention is by [resolved_at] so a long-lived Open
+     request that resolves now survives even if many newer-created terminal rows
+     already fill the cap. Output preserves original list order for retained
+     rows. *)
+  let opens, resolved =
+    List.partition (fun (r : goal_verification_request) -> r.status = Open) requests
+  in
+  let max_r = max_resolved_requests () in
+  let resolved_len = List.length resolved in
+  if resolved_len <= max_r then requests
+  else (
+    let retention_key (r : goal_verification_request) =
+      match r.resolved_at with
+      | Some resolved_at -> resolved_at
+      | None ->
+          (* NDT-OK: legacy terminal rows may not have [resolved_at]. This
+             fallback only orders bounded retention after the request already
+             reached a terminal state; open quorum semantics do not depend on
+             it. *)
+          r.created_at
+    in
+    let ranked =
+      resolved
+      |> List.mapi (fun index request -> index, request)
+      |> List.sort (fun (left_index, left) (right_index, right) ->
+        match String.compare (retention_key right) (retention_key left) with
+        | 0 -> Int.compare right_index left_index
+        | n -> n)
+    in
+    let keep_ids = Hashtbl.create max_r in
+    let rec add_first n = function
+      | _ when n <= 0 -> ()
+      | [] -> ()
+      | (_, request) :: rest ->
+          Hashtbl.replace keep_ids request.id ();
+          add_first (n - 1) rest
+    in
+    add_first max_r ranked;
+    let should_keep (request : goal_verification_request) =
+      request.status = Open || Hashtbl.mem keep_ids request.id
+    in
+    List.filter should_keep requests)
+
 let write_state config (state : state) =
+  let state = { state with requests = prune_resolved_requests state.requests } in
   let json = state_to_yojson state in
   Workspace_utils.write_json config (requests_path config) json;
   Workspace_utils.write_json config (requests_recovery_path config) json
@@ -557,50 +620,11 @@ let emit_event config ~(goal_id : string) ~(event_type : string)
   in
   Fs_compat.append_jsonl path event
 
-let max_resolved_requests () =
-  (* Bounds how many resolved (Approved/Rejected/Cancelled) requests the
-     persistent [state.requests] list retains. The list is append-only
-     (create_request: requests @ [request]) with no prior pruning, so it
-     grew unbounded for the lifetime of the state file — a long-lived
-     allocation source (live_words growth after restart). Open requests
-     are always kept; only terminal resolved entries are capped. *)
-  match Sys.getenv_opt "MASC_GOAL_VERIFICATION_MAX_RESOLVED" with
-  | Some v -> (match int_of_string_opt (String.trim v) with Some n when n > 0 -> n | _ -> 500)
-  | None -> 500
-
-let prune_resolved_requests requests =
-  (* Keep every Open (active quorum) request plus the most recent
-     [max_resolved_requests] resolved entries. Resolved requests are
-     terminal: quorum evaluation only consults Open rows and vote dedup
-     short-circuits on non-Open status, so dropping old resolved entries
-     cannot regress correctness. Append order is chronological, so
-     dropping from the front of the resolved partition drops the oldest.
-     Order across the list is not load-bearing — list_requests_for_goal
-     filters by goal_id and find_request searches by id. *)
-  let opens, resolved = List.partition (fun (r : goal_verification_request) -> r.status = Open) requests in
-  let max_r = max_resolved_requests () in
-  let resolved_len = List.length resolved in
-  if resolved_len <= max_r then requests
-  else
-    (* Skip (resolved_len - max_r) oldest resolved, keep the rest. *)
-    let to_skip = resolved_len - max_r in
-    let rec keep_after_skip n = function
-      | _ :: rest when n > 0 -> keep_after_skip (n - 1) rest
-      | rest -> rest
-    in
-    opens @ keep_after_skip to_skip resolved
-
 let update_state config f =
   let lock_path = requests_path config in
   Workspace_utils.with_file_lock config lock_path (fun () ->
       let state = read_state config in
       let next_state = f state in
-      (* Bound long-lived growth: cap resolved requests on every write so
-         the persistent list cannot grow without limit. No-op once the
-         resolved count is within the cap. *)
-      let next_state =
-        { next_state with requests = prune_resolved_requests next_state.requests }
-      in
       write_state config next_state;
       next_state)
 
@@ -672,6 +696,13 @@ let evaluate_quorum request =
   else
     Pending
 
+let replace_request_for_write ~request_id (updated_request : goal_verification_request) requests =
+  let matches row = String.equal row.id request_id in
+  if updated_request.status = Open then
+    List.map (fun row -> if matches row then updated_request else row) requests
+  else
+    List.filter (fun row -> not (matches row)) requests @ [ updated_request ]
+
 let cancel_request config ~(request_id : string) =
   let lock_path = requests_path config in
   Workspace_utils.with_file_lock config lock_path (fun () ->
@@ -689,10 +720,7 @@ let cancel_request config ~(request_id : string) =
             }
           in
           let requests =
-            List.map
-              (fun row ->
-                if String.equal row.id request_id then updated_request else row)
-              state.requests
+            replace_request_for_write ~request_id updated_request state.requests
           in
           write_state config
             { version = state.version + 1; updated_at = resolved_at; requests };
@@ -746,10 +774,7 @@ let submit_vote config ~(request_id : string) ~(principal : goal_principal)
                   Failed )
           in
           let requests =
-            List.map
-              (fun row ->
-                if String.equal row.id request_id then next_request else row)
-              state.requests
+            replace_request_for_write ~request_id next_request state.requests
           in
           write_state config
             { version = state.version + 1; updated_at = submitted_at; requests };

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -636,12 +636,11 @@ let snapshot_json
   in
   (* Singleflight cache lookup: check for fresh hit, in-flight compute,
      or start a new compute.  Uses Eio.Mutex for safe Hashtbl access.
-     Waiters await the owner's [Condition] broadcast (the [cond] stored in
-     the [Computing] slot, fired at compute finish), racing a short timer
-     via [Eio.Fiber.first] so they stay cancellable and re-check on a known
-     cadence as a lost-wakeup safety net.  The [Condition]+mutex machinery
-     was always present; the await replaces a prior blind poll-retry that
-     added up to [_poll_interval_s] latency per cache miss. *)
+     Waiters poll outside the lock on [_poll_interval_s] cadence so they
+     stay fully cancellable and re-check the slot, avoiding the
+     cancellation-immune deadlock that [Condition.await] inside
+     [Mutex.use_rw ~protect:true] would create.  The compute fiber still
+     broadcasts its [Condition] when finished; that is harmless. *)
   let _max_wait_s = 60.0 in
   let _poll_interval_s = 0.25 in
   let rec cache_lookup ~waited =
@@ -707,20 +706,16 @@ let snapshot_json
       in
       match action with
       | `Hit value -> value
-      | `Wait cond ->
-        (* Another fiber is computing this key.  Await its broadcast (fired
-           at compute finish) for near-zero wakeup latency, racing a short
-           timer so we stay cancellable and re-check on a known cadence as a
-           lost-wakeup safety net.  [Eio.Fiber.first] cancels whichever fiber
-           loses the race, and [~protect:true] releases the mutex under
-           cancel — so the waiter stays cancellable. *)
-        let () =
-          Eio.Fiber.first
-            (fun () ->
-               Eio.Mutex.use_rw ~protect:true _snapshot_mu (fun () ->
-                 Eio.Condition.await cond _snapshot_mu))
-            (fun () -> Eio.Time.sleep ctx.clock _poll_interval_s)
-        in
+      | `Wait _cond ->
+        (* Another fiber is computing this key.  Poll outside the mutex on a
+           short cadence so the waiter stays fully cancellable and re-checks
+           the slot.  We intentionally do not [Condition.await] inside
+           [Mutex.use_rw ~protect:true] because protected awaits mask Eio
+           cancellation, which can leave the waiter hung if the compute owner
+           is slow or its broadcast is missed.  The compute fiber still
+           broadcasts the condition for any waiters using the old path; that
+           is harmless. *)
+        Eio.Time.sleep ctx.clock _poll_interval_s;
         cache_lookup ~waited:(waited +. _poll_interval_s)
       | `Compute cond ->
         (match compute_snapshot () with

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -285,8 +285,9 @@ let hash_namespace_truth_snapshot (snapshot : Yojson.Safe.t) : Digestif.SHA256.t
      The hash value differs from the old string-hash (different bytes fed),
      but it is deterministic for a given structure and is used only for change
      detection (compare current to previous, both via this walker), so the
-     broadcast semantics are preserved. Type tags (S/I/F/...) prevent prefix
-     collisions between scalar kinds. *)
+     broadcast semantics are preserved. Type tags (S/I/F/...) and length
+     prefixes for strings/object keys prevent prefix collisions and make the
+     feed injective. *)
   let rec walk (ctx : Digestif.SHA256.ctx) (json : Yojson.Safe.t) :
       Digestif.SHA256.ctx =
     match json with
@@ -298,8 +299,10 @@ let hash_namespace_truth_snapshot (snapshot : Yojson.Safe.t) : Digestif.SHA256.t
                if String.equal key "generated_at" || String.equal key "generated_at_iso"
                then ctx
                else
-                 let ctx = Digestif.SHA256.feed_string ctx key in
+                 let ctx = Digestif.SHA256.feed_string ctx (string_of_int (String.length key)) in
                  let ctx = Digestif.SHA256.feed_string ctx ":" in
+                 let ctx = Digestif.SHA256.feed_string ctx key in
+                 let ctx = Digestif.SHA256.feed_string ctx "=" in
                  walk ctx value)
             ctx fields
         in
@@ -310,6 +313,8 @@ let hash_namespace_truth_snapshot (snapshot : Yojson.Safe.t) : Digestif.SHA256.t
         Digestif.SHA256.feed_string ctx "]"
     | `String s ->
         let ctx = Digestif.SHA256.feed_string ctx "S" in
+        let ctx = Digestif.SHA256.feed_string ctx (string_of_int (String.length s)) in
+        let ctx = Digestif.SHA256.feed_string ctx ":" in
         Digestif.SHA256.feed_string ctx s
     | `Int n ->
         let ctx = Digestif.SHA256.feed_string ctx "I" in

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -16,7 +16,6 @@ let dashboard_metrics_cache_mu = Stdlib.Mutex.create ()
 let dashboard_model_metrics_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
 let dashboard_cost_latency_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
 let dashboard_keeper_costs_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
-let dashboard_keeper_decisions_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
 let dashboard_keeper_decisions_log_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
 let dashboard_keeper_memory_log_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
 
@@ -204,24 +203,16 @@ let add_routes ~sw router =
        with_public_read (fun state req reqd ->
          let limit = dashboard_feed_limit req in
          let config = (Mcp_server.workspace_config state) in
-         let key = cache_key [ config.base_path; string_of_int limit ] in
+         let keeper_names = Keeper_meta_store.keeper_names config in
+         let keepers =
+           List.filter_map (fun name ->
+             match Keeper_meta_store.read_meta config name with
+             | Ok (Some m) -> Some m
+             | _ -> None
+           ) keeper_names
+         in
          let json =
-           cached_dashboard_json ~sw ~cache:dashboard_keeper_decisions_cache
-             ~key
-             ~placeholder:
-               (Dashboard_http_keeper.keeper_decisions_json ~config
-                  ~keepers:[] ~limit ())
-             ~compute:(fun () ->
-               let keeper_names = Keeper_meta_store.keeper_names config in
-               let keepers =
-                 List.filter_map (fun name ->
-                   match Keeper_meta_store.read_meta config name with
-                   | Ok (Some m) -> Some m
-                   | _ -> None
-                 ) keeper_names
-               in
-               Dashboard_http_keeper.keeper_decisions_json ~config ~keepers
-                 ~limit ())
+           Dashboard_http_keeper.keeper_decisions_json ~config ~keepers ~limit ()
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -15,9 +15,6 @@ let dashboard_metrics_cache_ttl_s = 60.0
 let dashboard_metrics_cache_mu = Stdlib.Mutex.create ()
 let dashboard_model_metrics_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
 let dashboard_cost_latency_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
-let dashboard_keeper_costs_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
-let dashboard_keeper_decisions_log_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
-let dashboard_keeper_memory_log_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
 
 let cache_key parts = String.concat "\x1f" parts
 
@@ -165,23 +162,20 @@ let add_routes ~sw router =
        with_public_read (fun state req reqd ->
          let window = int_query_param req "window" ~default:1440 in
          let config = (Mcp_server.workspace_config state) in
-         let key = cache_key [ config.base_path; string_of_int window ] in
          let json =
-           cached_dashboard_json ~sw ~cache:dashboard_keeper_costs_cache ~key
-             ~placeholder:
-               (Dashboard_http_keeper.keeper_cost_aggregates_json ~config
-                  ~keepers:[] ~window_minutes:window)
-             ~compute:(fun () ->
-               let keeper_names = Keeper_meta_store.keeper_names config in
-               let keepers =
-                 List.filter_map (fun name ->
-                   match Keeper_meta_store.read_meta config name with
-                   | Ok (Some m) -> Some m
-                   | _ -> None
-                 ) keeper_names
-               in
-               Dashboard_http_keeper.keeper_cost_aggregates_json ~config
-                 ~keepers ~window_minutes:window)
+           Eio_guard.run_in_systhread (fun () ->
+             let keeper_names = Keeper_meta_store.keeper_names config in
+             let keepers =
+               List.filter_map (fun name ->
+                 match Keeper_meta_store.read_meta config name with
+                 | Ok (Some m) -> Some m
+                 | _ -> None)
+                 keeper_names
+             in
+             Dashboard_http_keeper.keeper_cost_aggregates_json
+               ~config
+               ~keepers
+               ~window_minutes:window)
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -203,66 +197,65 @@ let add_routes ~sw router =
        with_public_read (fun state req reqd ->
          let limit = dashboard_feed_limit req in
          let config = (Mcp_server.workspace_config state) in
-         let keeper_names = Keeper_meta_store.keeper_names config in
-         let keepers =
-           List.filter_map (fun name ->
-             match Keeper_meta_store.read_meta config name with
-             | Ok (Some m) -> Some m
-             | _ -> None
-           ) keeper_names
-         in
          let json =
-           Dashboard_http_keeper.keeper_decisions_json ~config ~keepers ~limit ()
+           Eio_guard.run_in_systhread (fun () ->
+             let keeper_names = Keeper_meta_store.keeper_names config in
+             let keepers =
+               List.filter_map (fun name ->
+                 match Keeper_meta_store.read_meta config name with
+                 | Ok (Some m) -> Some m
+                 | _ -> None)
+                 keeper_names
+             in
+             Dashboard_http_keeper.keeper_decisions_json
+               ~config
+               ~keepers
+               ~limit
+               ())
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/keeper-decisions-log" (fun request reqd ->
-       with_public_read (fun state req reqd ->
-         let limit = dashboard_feed_limit req in
-         let config = (Mcp_server.workspace_config state) in
-         let key = cache_key [ config.base_path; string_of_int limit ] in
-         let json =
-           cached_dashboard_json ~sw
-             ~cache:dashboard_keeper_decisions_log_cache ~key
-             ~placeholder:
-               (Dashboard_http_keeper.keeper_decisions_log_json ~config
-                  ~keepers:[] ~limit ())
-             ~compute:(fun () ->
-               let keeper_names = Keeper_meta_store.keeper_names config in
-               let keepers =
-                 List.filter_map (fun name ->
-                   match Keeper_meta_store.read_meta config name with
-                   | Ok (Some m) -> Some m
-                   | _ -> None
-                 ) keeper_names
-               in
-               Dashboard_http_keeper.keeper_decisions_log_json ~config
-                 ~keepers ~limit ())
-         in
-         Http.Response.json_value ~compress:true ~request:req json reqd
-       ) request reqd)
-  |> Http.Router.get "/api/v1/dashboard/keeper-memory-log" (fun request reqd ->
-       with_public_read (fun state req reqd ->
-         let limit = dashboard_feed_limit req in
-         let config = (Mcp_server.workspace_config state) in
-         let key = cache_key [ config.base_path; string_of_int limit ] in
-         let json =
-           cached_dashboard_json ~sw ~cache:dashboard_keeper_memory_log_cache
-             ~key
-             ~placeholder:
-               (Dashboard_http_keeper.keeper_memory_log_json ~config
-                  ~keepers:[] ~limit ())
-             ~compute:(fun () ->
-               let keeper_names = Keeper_meta_store.keeper_names config in
-               let keepers =
-                 List.filter_map (fun name ->
-                   match Keeper_meta_store.read_meta config name with
-                   | Ok (Some m) -> Some m
-                   | _ -> None
-                 ) keeper_names
-               in
-               Dashboard_http_keeper.keeper_memory_log_json ~config ~keepers
-                 ~limit ())
-         in
-         Http.Response.json_value ~compress:true ~request:req json reqd
-       ) request reqd)
+	       with_public_read (fun state req reqd ->
+	         let limit = dashboard_feed_limit req in
+	         let config = (Mcp_server.workspace_config state) in
+	         let json =
+	           Eio_guard.run_in_systhread (fun () ->
+	             let keeper_names = Keeper_meta_store.keeper_names config in
+	             let keepers =
+	               List.filter_map (fun name ->
+	                 match Keeper_meta_store.read_meta config name with
+	                 | Ok (Some m) -> Some m
+	                 | _ -> None)
+	                 keeper_names
+	             in
+	             Dashboard_http_keeper.keeper_decisions_log_json
+	               ~config
+	               ~keepers
+	               ~limit
+	               ())
+	         in
+	         Http.Response.json_value ~compress:true ~request:req json reqd
+	       ) request reqd)
+	  |> Http.Router.get "/api/v1/dashboard/keeper-memory-log" (fun request reqd ->
+	       with_public_read (fun state req reqd ->
+	         let limit = dashboard_feed_limit req in
+	         let config = (Mcp_server.workspace_config state) in
+	         let json =
+	           Eio_guard.run_in_systhread (fun () ->
+	             let keeper_names = Keeper_meta_store.keeper_names config in
+	             let keepers =
+	               List.filter_map (fun name ->
+	                 match Keeper_meta_store.read_meta config name with
+	                 | Ok (Some m) -> Some m
+	                 | _ -> None)
+	                 keeper_names
+	             in
+	             Dashboard_http_keeper.keeper_memory_log_json
+	               ~config
+	               ~keepers
+	               ~limit
+	               ())
+	         in
+	         Http.Response.json_value ~compress:true ~request:req json reqd
+	       ) request reqd)

--- a/test/test_goal_verification.ml
+++ b/test/test_goal_verification.ml
@@ -36,14 +36,14 @@ let operator ?display_name id : Goal_verification.goal_principal =
 let agent ?display_name id : Goal_verification.goal_principal =
   { id; display_name }
 
-let request_snapshot ~requested_by =
+let request_snapshot ?(required_verdicts = 2) ~requested_by () =
   let reviewer = operator "reviewer-1" in
   let verifier = agent "agent-a" in
   let principals = [ requested_by; reviewer; verifier ] in
   {
     Goal_verification.principals;
     eligible_principals = [ reviewer; verifier ];
-    required_verdicts = 2;
+    required_verdicts;
   }
 
 let test_cancel_missing_request_does_not_bump () =
@@ -62,7 +62,7 @@ let test_invalid_vote_does_not_bump () =
   let request =
     match
       Goal_verification.create_request config ~goal_id:"goal-1" ~requested_by
-        ~policy_snapshot:(request_snapshot ~requested_by)
+        ~policy_snapshot:(request_snapshot ~requested_by ())
     with
     | Ok request -> request
     | Error msg -> fail msg
@@ -101,7 +101,7 @@ let test_resolved_requests_bounded () =
     match
       Goal_verification.create_request config
         ~goal_id:(Printf.sprintf "goal-%d" i) ~requested_by
-        ~policy_snapshot:(request_snapshot ~requested_by)
+        ~policy_snapshot:(request_snapshot ~requested_by ())
     with
     | Ok r -> r
     | Error msg -> fail msg
@@ -129,6 +129,103 @@ let test_resolved_requests_bounded () =
    | None -> ()
    | Some _ -> fail "oldest resolved request not pruned")
 
+let test_cancel_request_prunes_on_direct_write () =
+  Unix.putenv "MASC_GOAL_VERIFICATION_MAX_RESOLVED" "3";
+  Fun.protect ~finally:(fun () ->
+      Unix.putenv "MASC_GOAL_VERIFICATION_MAX_RESOLVED" "")
+  @@ fun () ->
+  with_workspace @@ fun config ->
+  let requested_by = operator "planner" in
+  let mk i =
+    match
+      Goal_verification.create_request config
+        ~goal_id:(Printf.sprintf "cancel-goal-%d" i) ~requested_by
+        ~policy_snapshot:(request_snapshot ~requested_by ())
+    with
+    | Ok r -> r
+    | Error msg -> fail msg
+  in
+  let ids = List.init 5 (fun i -> (mk i).id) in
+  List.iter
+    (fun id ->
+      match Goal_verification.cancel_request config ~request_id:id with
+      | Ok _ -> ()
+      | Error msg -> fail msg)
+    ids;
+  let state = Goal_verification.read_state config in
+  check int "direct cancel writes are capped" 3 (List.length state.requests);
+  (match Goal_verification.find_request config ~request_id:(List.nth ids 0) with
+   | None -> ()
+   | Some _ -> fail "oldest cancelled request not pruned by direct write")
+
+let test_submit_vote_prunes_on_direct_write () =
+  Unix.putenv "MASC_GOAL_VERIFICATION_MAX_RESOLVED" "3";
+  Fun.protect ~finally:(fun () ->
+      Unix.putenv "MASC_GOAL_VERIFICATION_MAX_RESOLVED" "")
+  @@ fun () ->
+  with_workspace @@ fun config ->
+  let requested_by = operator "planner" in
+  let voter = operator "reviewer-1" in
+  let mk i =
+    match
+      Goal_verification.create_request config
+        ~goal_id:(Printf.sprintf "vote-goal-%d" i) ~requested_by
+        ~policy_snapshot:(request_snapshot ~required_verdicts:1 ~requested_by ())
+    with
+    | Ok r -> r
+    | Error msg -> fail msg
+  in
+  let ids = List.init 5 (fun i -> (mk i).id) in
+  List.iter
+    (fun id ->
+      match
+        Goal_verification.submit_vote config ~request_id:id ~principal:voter
+          ~decision:Goal_verification.Approve ()
+      with
+      | Ok _ -> ()
+      | Error msg -> fail msg)
+    ids;
+  let state = Goal_verification.read_state config in
+  check int "direct vote writes are capped" 3 (List.length state.requests);
+  (match Goal_verification.find_request config ~request_id:(List.nth ids 0) with
+   | None -> ()
+   | Some _ -> fail "oldest approved request not pruned by direct write")
+
+let test_late_resolution_survives_cap () =
+  Unix.putenv "MASC_GOAL_VERIFICATION_MAX_RESOLVED" "3";
+  Fun.protect ~finally:(fun () ->
+      Unix.putenv "MASC_GOAL_VERIFICATION_MAX_RESOLVED" "")
+  @@ fun () ->
+  with_workspace @@ fun config ->
+  let requested_by = operator "planner" in
+  let mk goal_id =
+    match
+      Goal_verification.create_request config ~goal_id ~requested_by
+        ~policy_snapshot:(request_snapshot ~requested_by ())
+    with
+    | Ok r -> r
+    | Error msg -> fail msg
+  in
+  let old_open = mk "old-open" in
+  let newer = List.init 5 (fun i -> mk (Printf.sprintf "newer-%d" i)) in
+  List.iter
+    (fun (request : Goal_verification.goal_verification_request) ->
+      match Goal_verification.cancel_request config ~request_id:request.id with
+      | Ok _ -> ()
+      | Error msg -> fail msg)
+    newer;
+  (match Goal_verification.cancel_request config ~request_id:old_open.id with
+   | Ok _ -> ()
+   | Error msg -> fail msg);
+  let state = Goal_verification.read_state config in
+  check int "resolved cap still applies" 3 (List.length state.requests);
+  match Goal_verification.find_request config ~request_id:old_open.id with
+  | Some request ->
+    (match request.Goal_verification.status with
+     | Goal_verification.Cancelled -> ()
+     | _ -> fail "late-resolved request has unexpected status")
+  | None -> fail "late-resolved old request was pruned immediately"
+
 let () =
   run "Goal_verification"
     [
@@ -143,5 +240,11 @@ let () =
         [
           test_case "resolved requests capped, open preserved"
             `Quick test_resolved_requests_bounded;
+          test_case "cancel_request direct writes are capped"
+            `Quick test_cancel_request_prunes_on_direct_write;
+          test_case "submit_vote direct writes are capped"
+            `Quick test_submit_vote_prunes_on_direct_write;
+          test_case "late resolution survives resolved cap"
+            `Quick test_late_resolution_survives_cap;
         ] );
     ]

--- a/test/test_goal_verification.ml
+++ b/test/test_goal_verification.ml
@@ -84,6 +84,51 @@ let test_invalid_vote_does_not_bump () =
   in
   check int "no votes written" 0 (List.length saved.votes)
 
+let test_resolved_requests_bounded () =
+  (* Cap resolved requests via a small env value, create more resolved
+     requests than the cap plus one Open request, and verify: (1) total
+     requests == cap + open count, (2) the Open request survives, (3) the
+     oldest resolved request is pruned. Proves the prune is
+     correctness-preserving for active quorum (Open) while bounding
+     long-lived growth. *)
+  Unix.putenv "MASC_GOAL_VERIFICATION_MAX_RESOLVED" "3";
+  Fun.protect ~finally:(fun () ->
+      Unix.putenv "MASC_GOAL_VERIFICATION_MAX_RESOLVED" "")
+  @@ fun () ->
+  with_workspace @@ fun config ->
+  let requested_by = operator "planner" in
+  let mk i =
+    match
+      Goal_verification.create_request config
+        ~goal_id:(Printf.sprintf "goal-%d" i) ~requested_by
+        ~policy_snapshot:(request_snapshot ~requested_by)
+    with
+    | Ok r -> r
+    | Error msg -> fail msg
+  in
+  (* 5 resolved (Cancelled) requests — exceeds the cap of 3 *)
+  let resolved_ids = List.init 5 (fun i -> (mk i).id) in
+  List.iter
+    (fun id ->
+      match Goal_verification.cancel_request config ~request_id:id with
+      | Ok _ -> ()
+      | Error msg -> fail msg)
+    resolved_ids;
+  (* 1 Open request that must survive the cap *)
+  let open_req = mk 6 in
+  let state = Goal_verification.read_state config in
+  check int "requests bounded to cap + open" 4 (List.length state.requests);
+  (match Goal_verification.find_request config ~request_id:open_req.id with
+   | Some r ->
+       (match r.Goal_verification.status with
+        | Goal_verification.Open -> ()
+        | _ -> fail "open request has non-Open status after cap")
+   | None -> fail "open request dropped by cap");
+  (* Oldest resolved request (index 0, first created) must be pruned. *)
+  (match Goal_verification.find_request config ~request_id:(List.nth resolved_ids 0) with
+   | None -> ()
+   | Some _ -> fail "oldest resolved request not pruned")
+
 let () =
   run "Goal_verification"
     [
@@ -93,5 +138,10 @@ let () =
             test_cancel_missing_request_does_not_bump;
           test_case "invalid vote: no bump" `Quick
             test_invalid_vote_does_not_bump;
+        ] );
+      ( "bounded_growth",
+        [
+          test_case "resolved requests capped, open preserved"
+            `Quick test_resolved_requests_bounded;
         ] );
     ]


### PR DESCRIPTION
## Goal
Bound the unbounded long-lived `state.requests` list in `goal_verification` — a confirmed long-lived allocation source (live_words grew 57M→66M→70M after restart; major GC ~1/sec from this class, separate from the short-term allocation already handled by the stampede/compose/poll-retry fixes).

## Root cause (code-proven)
`lib/goal/goal_verification.ml:345` `requests : goal_verification_request list` is **append-only** (`:594 requests @ [request]`) with zero pruning anywhere in the file. Resolved (Approved/Rejected/Cancelled) entries are never removed, so the list grows unbounded for the lifetime of the state file.

Found via a workflow that ran 9 per-store boundedness analyses in parallel; this was the only HIGH source that is unbounded-by-construction AND confirmed unbounded-by-read. Two per-store analyses were confabulated and corrected at synthesis (goal_store Hashtbl = function-local/GC'd, operator status_cache = dead code `Hashtbl.create 0`).

## Fix
`prune_resolved_requests` + `max_resolved_requests` (env `MASC_GOAL_VERIFICATION_MAX_RESOLVED`, default 500). Open (active quorum) requests are always kept; resolved entries are capped to the most recent 500. Applied in `update_state` so every write path (submit / vote / cancel) is bounded.

## Correctness (code-proven)
- quorum evaluation only consults Open rows
- vote dedup short-circuits on non-Open status (lines 642/669)
- resolved requests are terminal — no path reopens them or depends on their presence after `resolved_at` is set
- append order is chronological, so dropping from the front of the resolved partition drops the oldest

## Verification
- `DUNE_CACHE=disabled dune build --root . lib/goal/` RC=0 (worktree)
- runtime effect pending server restart (binary built and cp'd to `_build/default/bin/main_eio.exe`)

WORKAROUND-WAIVED: This is a root fix (provably-unbounded → bounded), not symptom suppression. The cap targets a genuine unbounded long-lived allocation proven by code read; it does not mask a leak or silent failure, and resolved requests are terminal so correctness is preserved.

Co-Authored-By: Claude <noreply@anthropic.com>
