### PR TITLE
fix: address review follow-ups from #21495

### DIFF
--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -47,7 +47,11 @@ let find_destructive_git (caps : Capability.t list) : Git_op.t option =
 let find_write_escape (caps : Capability.t list) : Path_scope.t option =
   let escapes (ps : Path_scope.t) : bool =
     match Path_scope.scope ps with
-    | Outside_workspace _ | Absolute_unknown _ -> true
+    | Outside_workspace _ | Absolute_unknown _ ->
+      (* /dev/null is the canonical discard sink for typed stdout/stderr
+         redirection; it is already exempted in path validation and handled
+         as a drop target by the native dispatcher. *)
+      not (String.equal (Path_scope.raw ps) "/dev/null")
     | Inside_workspace _ | Inside_sandbox _ -> false
   in
   let rec scan = function

--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -51,7 +51,7 @@ let find_write_escape (caps : Capability.t list) : Path_scope.t option =
       (* /dev/null is the canonical discard sink for typed stdout/stderr
          redirection; it is already exempted in path validation and handled
          as a drop target by the native dispatcher. *)
-      not (String.equal (Path_scope.raw ps) "/dev/null")
+      not (Path_scope.is_discard_sink ps)
     | Inside_workspace _ | Inside_sandbox _ -> false
   in
   let rec scan = function

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -36,8 +36,6 @@ let set_redirect_target plan fd target =
   | 2 -> Ok { plan with stderr_target = target }
   | fd -> Error (Printf.sprintf "unsupported redirect fd: %d" fd)
 
-let is_dev_null target = String.equal (Path_scope.raw target) "/dev/null"
-
 let redirect_plan_of_redirects redirects =
   let step plan = function
     | Redirect_scope.Fd_to_fd { src; dst } ->
@@ -45,7 +43,7 @@ let redirect_plan_of_redirects redirects =
         set_redirect_target plan src target
     | Redirect_scope.File
         { fd; target; mode = (Redirect_scope.Write | Redirect_scope.Append) }
-      when is_dev_null target ->
+      when Path_scope.is_discard_sink target ->
         set_redirect_target plan fd Drop
     | Redirect_scope.File { fd; target; mode = Redirect_scope.Read } ->
         Error

--- a/lib/exec/path_scope.ml
+++ b/lib/exec/path_scope.ml
@@ -100,6 +100,7 @@ let classify ~raw ~cwd =
 
 let scope t = t.scope
 let raw t = t.raw
+let is_discard_sink t = String.equal t.raw "/dev/null"
 
 let pp fmt t =
   let tag =

--- a/lib/exec/path_scope.mli
+++ b/lib/exec/path_scope.mli
@@ -20,4 +20,8 @@ val classify : raw:string -> cwd:string -> t
 
 val scope : t -> scope
 val raw : t -> string
+val is_discard_sink : t -> bool
+(** [is_discard_sink t] is true for the canonical stdout/stderr discard
+    target.  Policy and dispatch consumers use this predicate instead of
+    matching the raw path themselves. *)
 val pp : Format.formatter -> t -> unit

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -1018,7 +1018,7 @@ let () =
     { bin
     ; args = [ Lit ("push", default_meta); Lit ("--force", default_meta) ]
     ; env = []
-    ; cwd = None
+    ; cwd = Some (Masc_exec.Path_scope.classify ~raw:"/tmp" ~cwd:"/tmp")
     ; redirects = []
     ; sandbox = Masc_exec.Sandbox_target.host ()
     }
@@ -1032,9 +1032,9 @@ let () =
      Before §5.3.1 it skipped the catastrophic floor, so [git push --force]
      (no path argument, so [validate_paths] cannot jail it — §5.4) executed.
      The floor must now deny it here as [Policy_denied], identically to the
-     _with_approval path, proving the floor is flag-independent.  ([Ok _] would
-     mean the floor was skipped — a regression; [git push --force] in /tmp is a
-     non-repo no-op even if it ran, so no filesystem effect.) *)
+     _with_approval path, proving the floor is flag-independent.  We set the
+     IR cwd to /tmp so that if the floor were ever skipped, [git push --force]
+     would run in a non-repo directory rather than the test checkout. *)
   match
     Keeper_tool_execute_shell_ir.dispatch_classified
       ~workdir:"/tmp"


### PR DESCRIPTION
This PR resolves the two unresolved review threads on #21495.

### Changes

1. **lib/exec/approval_policy.ml**
   - Exempt `/dev/null` from the catastrophic write-escape floor in `find_write_escape`. Typed `stdout`/`stderr` discard redirects lower to `/dev/null`, and without this exemption the bare (approval-gate-disabled) dispatch path was rejecting otherwise-valid commands with `Policy_denied`. This aligns the catastrophic floor with the existing `/dev/null` exception in `Exec_policy.validate_shell_ir_paths` and the `/dev/null` drop handling in `Exec_dispatch`.

2. **test/test_exec_dispatch.ml**
   - Set the Shell IR `cwd` to `/tmp` in the `git push --force` catastrophic-floor regression test. Previously `cwd = None` meant a skipped floor would run the command in the test process's current directory, which could attempt a real force-push in a developer or CI checkout. With `cwd = /tmp` the command runs in a non-repo directory and fails safely.

This branch was created from the current `main` in a worktree.
