### PR TITLE
feat(dashboard): apply keeper-v2 design system increments (tone-rail, roster sort, token/label cleanup)

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -698,6 +698,42 @@ describe('AgentRoster live-only cards', () => {
     expect(text).not.toContain('상세 상태 부분 동기화')
   })
 
+  it('paints a per-row tone rail keyed to runtime band (keeper-v2 Fleet)', async () => {
+    keepers.value = [
+      {
+        name: 'runner', agent_name: 'keeper-runner-agent', status: 'idle',
+        phase: 'Running', pipeline_stage: 'idle', keepalive_running: true,
+      } as Keeper,
+      {
+        name: 'rester', agent_name: 'keeper-rester-agent', status: 'paused',
+        phase: 'Paused', pipeline_stage: 'paused', paused: true, keepalive_running: false,
+      } as Keeper,
+      {
+        name: 'gone', agent_name: 'keeper-gone-agent', status: 'offline',
+        phase: 'Offline', pipeline_stage: 'offline', keepalive_running: false,
+      } as Keeper,
+    ]
+    agents.value = []
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const rows = Array.from(
+      container.querySelectorAll('[data-testid="keeper-operations-row"]'),
+    ) as HTMLElement[]
+    expect(rows.length).toBe(3)
+    // every row carries a tone the rail CSS can paint
+    const valid = new Set(['ok', 'warn', 'bad', 'idle'])
+    expect(rows.every(r => valid.has(r.getAttribute('data-tone') ?? ''))).toBe(true)
+    const toneByName = (name: string) =>
+      rows.find(r => r.textContent?.includes(name))?.getAttribute('data-tone')
+    // band → tone: paused=warn, offline=idle (the unambiguous bands)
+    expect(toneByName('rester')).toBe('warn')
+    expect(toneByName('gone')).toBe('idle')
+  })
+
   it('does not show keeper boot hints on offline non-keeper agent rows', async () => {
     agents.value = [
       makeAgent({

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -89,6 +89,17 @@ function rosterBandActionHint(band: RuntimeBand, isKeeper: boolean): string {
 }
 
 // PipelineStage SSOT: branches aligned to `types/core.ts#PipelineStage`.
+// Tone for the scannable per-row rail (keeper-v2 Fleet design: a left edge
+// keyed to runtime band so keeper state reads down a single column instead of
+// every row looking identical). Maps masc's RuntimeBand onto the v2 tone
+// vocabulary (ok/warn/bad/idle); the CSS in v2-monitoring.css paints the edge.
+const ROSTER_BAND_TONE: Record<RuntimeBand, 'ok' | 'warn' | 'bad' | 'idle'> = {
+  active: 'ok',
+  attention: 'bad',
+  paused: 'warn',
+  offline: 'idle',
+}
+
 // Legacy `tool_use` / `scheduled_autonomous` / `thinking` removed — the
 // backend never emits them as pipeline_stage.
 function stageBadgeClass(stageKey: string): string {
@@ -1098,6 +1109,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   tabIndex=${0}
                   key=${row.key}
                   data-testid="keeper-operations-row"
+                  data-tone=${ROSTER_BAND_TONE[row.band.key]}
                   aria-label=${`${row.displayName} 선택`}
                   aria-pressed=${selected}
                   onClick=${() => setSelectedKey(row.key)}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -145,4 +145,44 @@ describe('KeeperWorkspaceRoster', () => {
     expect(host.querySelector('.virtual-list-spacer')).not.toBeNull()
     expect(host.querySelector('.kw-roster-list')).not.toBeNull()
   })
+
+  it('renders the sort select defaulting to status order', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    const sortSel = host.querySelector('.kw-roster-sort') as HTMLSelectElement
+    expect(sortSel).not.toBeNull()
+    expect(sortSel.value).toBe('status')
+    expect(Array.from(sortSel.options).map(o => o.value)).toEqual(['status', 'name', 'att'])
+    // status mode keeps the bucket group headers
+    expect(host.querySelectorAll('.kw-roster-group').length).toBeGreaterThan(0)
+  })
+
+  it('sorts by name into a flat alphabetical list with no group headers', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    fireEvent.change(host.querySelector('.kw-roster-sort') as HTMLSelectElement, {
+      target: { value: 'name' },
+    })
+    // flat list → status group headers disappear
+    expect(host.querySelectorAll('.kw-roster-group').length).toBe(0)
+    const order = Array.from(host.querySelectorAll('.kw-kp-row')).map(r =>
+      r.textContent?.includes('masc-improver') ? 'masc-improver' : r.textContent?.includes('rama') ? 'rama' : 'sangsu',
+    )
+    expect(order).toEqual(['masc-improver', 'rama', 'sangsu'])
+  })
+
+  it('sorts by attention, ranking attention-needing keepers first', () => {
+    keepers.value = [
+      mk({ name: 'calm', status: 'running' }),
+      mk({ name: 'blocked-3', status: 'running', blocked_task_count: 3 }),
+      mk({ name: 'flagged', status: 'running', needs_attention: true }),
+    ]
+    render(html`<${KeeperWorkspaceRoster} activeName="calm" />`, host)
+    fireEvent.change(host.querySelector('.kw-roster-sort') as HTMLSelectElement, {
+      target: { value: 'att' },
+    })
+    const order = Array.from(host.querySelectorAll('.kw-kp-row')).map(r =>
+      r.textContent?.includes('blocked-3') ? 'blocked-3' : r.textContent?.includes('flagged') ? 'flagged' : 'calm',
+    )
+    // blocked-3 (score 3) > flagged (flag → score 1) > calm (score 0)
+    expect(order).toEqual(['blocked-3', 'flagged', 'calm'])
+  })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -23,6 +23,7 @@ import {
 } from './keeper-workspace-shared'
 
 type RosterFilter = 'all' | 'run' | 'att'
+type RosterSort = 'status' | 'name' | 'att'
 
 const GROUP_ORDER: { bucket: KeeperBucket; label: string }[] = [
   { bucket: 'running', label: '실행 중' },
@@ -46,6 +47,22 @@ function attentionCount(keeper: Keeper): number {
 }
 function needsAttention(keeper: Keeper): boolean {
   return keeper.needs_attention === true || attentionCount(keeper) > 0
+}
+
+/** Numeric attention weight for the 'att' sort: attention-needing keepers rank
+ *  above the rest, ordered by blocked-task count (min 1 when only the flag is
+ *  set, so a flagged-but-unblocked keeper still outranks a calm one). Mirrors
+ *  the v2 roster's numeric `k.att` sort key. */
+function attentionScore(keeper: Keeper): number {
+  return needsAttention(keeper) ? Math.max(1, attentionCount(keeper)) : 0
+}
+
+/** Comparator for the flat sort modes ('name'/'att'). 'status' keeps the bucket
+ *  grouping instead and never reaches here. Name ties break alphabetically so
+ *  the order is stable. */
+function compareKeepers(a: Keeper, b: Keeper, sort: Exclude<RosterSort, 'status'>): number {
+  if (sort === 'name') return a.name.localeCompare(b.name)
+  return attentionScore(b) - attentionScore(a) || a.name.localeCompare(b.name)
 }
 
 /** ns proxy: keepers have no namespace field; the skill path is the closest
@@ -111,6 +128,7 @@ export function KeeperWorkspaceRoster({
 }): VNode {
   const [query, setQuery] = useState('')
   const [filter, setFilter] = useState<RosterFilter>('all')
+  const [sort, setSort] = useState<RosterSort>('status')
 
   const all = keepers.value
   const counts = {
@@ -137,13 +155,21 @@ export function KeeperWorkspaceRoster({
     { id: 'att', label: '주의' },
   ]
 
-  // Flatten groups → [{ type: 'header'|'row', ... }] for windowing.
+  // Flatten to [{ type: 'header'|'row', ... }] for windowing. 'status' keeps the
+  // bucket grouping with headers; 'name'/'att' produce a flat sorted list with no
+  // headers, mirroring the v2 roster sort modes (rails.jsx Roster).
   const items: RosterItem[] = []
-  for (const group of GROUP_ORDER) {
-    const rows = visible.filter(k => keeperBucket(k) === group.bucket)
-    if (rows.length === 0) continue
-    items.push({ type: 'header', bucket: group.bucket, label: group.label })
-    for (const keeper of rows) {
+  if (sort === 'status') {
+    for (const group of GROUP_ORDER) {
+      const rows = visible.filter(k => keeperBucket(k) === group.bucket)
+      if (rows.length === 0) continue
+      items.push({ type: 'header', bucket: group.bucket, label: group.label })
+      for (const keeper of rows) {
+        items.push({ type: 'row', keeper })
+      }
+    }
+  } else {
+    for (const keeper of [...visible].sort((a, b) => compareKeepers(a, b, sort))) {
       items.push({ type: 'row', keeper })
     }
   }
@@ -185,6 +211,17 @@ export function KeeperWorkspaceRoster({
             ${chip.label}<span class="n">${counts[chip.id]}</span>
           </button>
         `)}
+        <select
+          class="kw-roster-sort"
+          aria-label="키퍼 정렬 기준"
+          title="정렬 기준"
+          value=${sort}
+          onChange=${(e: Event) => setSort((e.target as HTMLSelectElement).value as RosterSort)}
+        >
+          <option value="status">상태순</option>
+          <option value="name">이름순</option>
+          <option value="att">주의순</option>
+        </select>
       </div>
       ${visible.length === 0
         ? html`<div class="kw-roster-list"><div class="kw-roster-empty v2-monitoring-row">일치하는 키퍼가 없습니다</div></div>`
@@ -197,16 +234,11 @@ export function KeeperWorkspaceRoster({
               getKey=${getKey}
             />`
           : html`<div class="kw-roster-list">
-              ${GROUP_ORDER.map(group => {
-                const rows = visible.filter(k => keeperBucket(k) === group.bucket)
-                if (rows.length === 0) return null
-                return html`
-                  <div>
-                    <div class="kw-roster-group v2-monitoring-row">${group.label}</div>
-                    ${rows.map(k => html`<${RosterRow} key=${k.name} keeper=${k} active=${k.name === activeName} onSelect=${select} style=${rowStyle} />`)}
-                  </div>
-                `
-              })}
+              ${items.map(item =>
+                item.type === 'header'
+                  ? html`<div class="kw-roster-group v2-monitoring-row">${item.label}</div>`
+                  : html`<${RosterRow} key=${item.keeper.name} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} style=${rowStyle} />`,
+              )}
             </div>`}
     </aside>
   `

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -45,11 +45,13 @@ const SET_SECTIONS: [SectionId, string, string][] = [
 ]
 
 const SET_GROUPS: [string, SectionId[]][] = [
-  ['Account', ['account']],
-  ['Keeper runtime', ['runtime', 'routing', 'prompts', 'lifecycle', 'policy']],
-  ['Infrastructure / Execution', ['runtimes', 'sandbox', 'paths']],
-  ['Connections / Integration', ['mcp', 'gate', 'ide']],
-  ['Observation / Display', ['logs', 'notify', 'display']],
+  // KO group labels per keeper-v2 settings.jsx SET_GROUPS — matches the
+  // Korean section names below (avoids EN-header / KO-item bilingual mismatch).
+  ['계정', ['account']],
+  ['Keeper 운영', ['runtime', 'routing', 'prompts', 'lifecycle', 'policy']],
+  ['인프라 · 실행', ['runtimes', 'sandbox', 'paths']],
+  ['연결 · 통합', ['mcp', 'gate', 'ide']],
+  ['관측 · 표시', ['logs', 'notify', 'display']],
 ]
 
 const MCP_TOOLS = [

--- a/dashboard/src/styles/app-shell-v2.css
+++ b/dashboard/src/styles/app-shell-v2.css
@@ -165,7 +165,7 @@
   gap: 7px;
   padding: 4px 10px;
   border: 1px solid var(--ss-border);
-  border-radius: 9999px;
+  border-radius: var(--radius-pill);
   background: var(--ss-surface-subtle);
   color: var(--ss-text-secondary);
   font-size: 11px;

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -91,6 +91,19 @@
 .kw-rfilter:hover { color: var(--color-fg-primary); border-color: var(--color-border-strong); }
 .kw-rfilter[aria-pressed="true"] { color: var(--color-bg-page); background: var(--color-accent-fg); border-color: var(--color-accent-fg); font-weight: var(--fw-semi); }
 .kw-rfilter .n { opacity: 0.8; }
+/* Roster sort <select> — ported from keeper-v2 v2.css .roster-sort. Pushed to
+   the right of the filter chips; pill control with the same resting/hover/focus
+   treatment as the search field and filter chips. */
+.kw-roster-sort {
+  margin-left: auto;
+  font-size: var(--fs-11); letter-spacing: 0.04em;
+  padding: 4px 7px; border-radius: var(--radius-pill); cursor: pointer;
+  border: 1px solid var(--color-border-default); background: transparent; color: var(--color-fg-secondary);
+  transition: color .15s, border-color .15s, background .15s; outline: none;
+}
+.kw-roster-sort:hover { color: var(--color-fg-primary); border-color: var(--color-border-strong); }
+.kw-roster-sort:focus { border-color: var(--color-accent-fg-dim); }
+.kw-roster-sort option { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
 
 .kw-roster-list { flex: 1; overflow-y: auto; padding: 9px 8px; }
 .kw-roster-group {

--- a/dashboard/src/styles/primitives-v2.css
+++ b/dashboard/src/styles/primitives-v2.css
@@ -57,7 +57,7 @@
   letter-spacing: 0.05em;
   text-transform: uppercase;
   padding: 4px 10px;
-  border-radius: 9999px;
+  border-radius: var(--radius-pill);
   cursor: pointer;
   border: 1px solid var(--color-border);
   background: transparent;
@@ -131,7 +131,7 @@
   line-height: 1.3;
   text-align: left;
   padding: 7px 13px;
-  border-radius: 9999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--color-border);
   background: var(--color-card);
   color: var(--color-text-primary);

--- a/dashboard/src/styles/primitives-v2.css
+++ b/dashboard/src/styles/primitives-v2.css
@@ -72,7 +72,9 @@
 }
 
 .rfilter.on {
-  color: #ffffff;
+  /* ink-on-accent token (theme-adaptive) per keeper-v2 v2.css .rfilter.on;
+     hardcoded #ffffff was illegible on the ice-cyan brand in the default theme */
+  color: var(--volt-ink);
   background: var(--color-brand);
   border-color: var(--color-brand);
   font-weight: 600;

--- a/dashboard/src/styles/v2-monitoring.css
+++ b/dashboard/src/styles/v2-monitoring.css
@@ -113,8 +113,24 @@
 /* ── Agent roster rows ────────────────────────────────────────────────────── */
 
 .v2-monitoring-roster-row {
+  position: relative;
   transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
 }
+
+/* Scannable per-row tone rail (keeper-v2 Fleet design) — a 3px left edge keyed
+   to the runtime band (data-tone) so keeper state reads down a single column
+   instead of every row looking identical. */
+.v2-monitoring-roster-row::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--roster-rail, transparent);
+}
+.v2-monitoring-roster-row[data-tone="ok"] { --roster-rail: var(--color-status-ok); }
+.v2-monitoring-roster-row[data-tone="warn"] { --roster-rail: var(--color-status-warn); }
+.v2-monitoring-roster-row[data-tone="bad"] { --roster-rail: var(--color-status-err); }
+.v2-monitoring-roster-row[data-tone="idle"] { --roster-rail: color-mix(in oklab, var(--color-fg-muted) 50%, transparent); }
 
 .v2-monitoring-roster-row:hover {
   border-color: var(--color-border-strong);


### PR DESCRIPTION
## 목표

keeper-v2 Dark Fantasy 디자인 시스템을 masc 대시보드에 적용하는 증분 5건. 각 커밋은 동작을 바꾸지 않거나(토큰화·라벨), 기존 데이터에 기반한 표면 개선(tone-rail·sort)이다.

## 변경 내용 (5 commits)

1. **fix: `.rfilter.on` 텍스트를 `--volt-ink`로 토큰화** — 하드코딩 `#ffffff`가 default(ice-cyan) 테마에서 가독성 낮음. theme-adaptive 토큰으로 교체.
2. **fix: pill radius 토큰화** — `border-radius: 9999px` 3곳(app-shell-v2.css, primitives-v2.css)을 정의된 `--radius-pill`로 교체.
3. **fix: 설정 그룹 라벨 KO 통일** — `SET_GROUPS` EN 헤더(Account/Keeper runtime/…)를 하위 KO 섹션명과 맞춰 KO로 통일(EN헤더/KO항목 bilingual 불일치 해소). 출처: keeper-v2 settings.jsx SET_GROUPS.
4. **feat: keeper roster 정렬 컨트롤** — `keeper-workspace-roster`에 상태순/이름순/주의순 select 추가. 기본값 상태순(기존 버킷 그룹핑 유지).
5. **feat: keeper fleet roster per-row tone-rail** — `agent-roster` 행 좌측 3px 레일을 RuntimeBand(active/attention/paused/offline)에 매핑(`--color-status-*`). 키퍼 상태를 한 컬럼 엣지로 스캔 가능하게(keeper-v2 Fleet 디자인 의도). 타입드 `Record<RuntimeBand, tone>`로 exhaustive.

## 변경 파일 (9, dashboard only)

- components: agent-roster.ts(+test), keeper-workspace-roster.ts(+test), settings-surface.ts
- styles: app-shell-v2.css, primitives-v2.css, keeper-workspace.css, v2-monitoring.css

## 로컬 검증

- `vitest run` (agent-roster + keeper-workspace-roster): **48 passed**
- `tsc --noEmit`: **exit 0** (clean)
- 참조 토큰(`--radius-pill`, `--volt-ink`, `--color-status-ok/warn/err`) 모두 정의 확인 — 미정의 var 참조 없음
- token-drift 센티넬: literal-vs-token 드리프트 = 0

## 미검증 / 범위 밖

- 원격 Claude Design SoT의 공유 스타일 파일(v2.css 등)이 로컬 baseline 너머 진화했는지 — DesignSync 커넥터 일시 장애로 보류(코드 정합성과 무관, 디자인 baseline 검증 사안).
- fleet vitals grid / `.dirty` 등 mock-data UI는 의도적으로 미구현(backing data 없음 = 기능 발명).

RFC-WAIVED: dashboard presentational 변경(roster 표시·설정 라벨·CSS 토큰화)으로 credential/identity/operator/sandbox/hooks/workflow 서브시스템 무관.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
