### PR TITLE
fix: address review follow-ups from #21488

### DIFF
--- a/lib/exec/git_op.ml
+++ b/lib/exec/git_op.ml
@@ -9,8 +9,8 @@ type t =
       (* Trust-independent catastrophic floor (RFC-0255 §4.5).  This includes
          irreversible operations plus raw commands whose recovery preconditions
          are stateful and unproven at the syntax classifier. *)
-      [ `Push_force | `Clean_force | `Stash_drop | `Worktree_remove
-      | `Reset_hard | `Branch_delete ]
+      [ `Push_force | `Push_delete | `Clean_force | `Stash_drop
+      | `Worktree_remove | `Reset_hard | `Branch_delete ]
 
 let has_flag args flag = List.mem flag args
 
@@ -69,6 +69,8 @@ let of_argv = function
        | "push" ->
            if has_flag rest "--force" || has_short_flag rest 'f' then
              Ok (Destructive `Push_force)
+           else if has_flag rest "--delete" || has_short_flag rest 'd' then
+             Ok (Destructive `Push_delete)
            else Ok (Mutating `Push)
        | "reset" when has_flag rest "--hard" ->
            Ok (Destructive `Reset_hard)

--- a/lib/exec/git_op.ml
+++ b/lib/exec/git_op.ml
@@ -9,17 +9,23 @@ type t =
       (* Trust-independent catastrophic floor (RFC-0255 §4.5).  This includes
          irreversible operations plus raw commands whose recovery preconditions
          are stateful and unproven at the syntax classifier. *)
-      [ `Push_force | `Push_delete | `Clean_force | `Stash_drop
-      | `Worktree_remove | `Reset_hard | `Branch_delete ]
+      [ `Push_force | `Push_delete | `Push_mirror | `Clean_force
+      | `Stash_drop | `Worktree_remove | `Reset_hard | `Branch_delete ]
 
 let has_flag args flag = List.mem flag args
+
+let has_long_flag args flag =
+  List.exists
+    (fun arg -> String.equal arg flag || String.starts_with ~prefix:(flag ^ "=") arg)
+    args
 
 (* git short flags bundle: [git clean -fd] carries [-f] inside the [-fd]
    cluster, and [git push -fv] carries [-f] inside [-fv]. [has_short_flag]
    matches a single-letter flag whether standalone ([-f]) or bundled with
    other short flags ([-fd], [-df], [-xfd]), but never inside a long flag
-   ([--force-with-lease] stays unmatched). Without this, [git clean -fd] —
-   the common force form — bypasses the destructive classifier. *)
+   ([--force-with-lease] is matched explicitly as a long force flag). Without
+   this, [git clean -fd] — the common force form — bypasses the destructive
+   classifier. *)
 let has_short_flag args ch =
   List.exists
     (fun arg ->
@@ -67,8 +73,13 @@ let of_argv = function
             | "drop" :: _ -> Ok (Destructive `Stash_drop)
             | _ -> Ok (Mutating `Stash_push))
        | "push" ->
-           if has_flag rest "--force" || has_short_flag rest 'f' then
+           if has_flag rest "--force"
+              || has_long_flag rest "--force-with-lease"
+              || has_short_flag rest 'f'
+           then
              Ok (Destructive `Push_force)
+           else if has_flag rest "--mirror" then
+             Ok (Destructive `Push_mirror)
            else if has_flag rest "--delete" || has_short_flag rest 'd' then
              Ok (Destructive `Push_delete)
            else Ok (Mutating `Push)

--- a/lib/exec/git_op.mli
+++ b/lib/exec/git_op.mli
@@ -13,8 +13,8 @@ type t =
       | `Push | `Tag | `Stash_push | `Checkout_branch ]
   | Destructive of
       (* Trust-independent catastrophic floor — RFC-0255 §4.5. *)
-      [ `Push_force | `Clean_force | `Stash_drop | `Worktree_remove
-      | `Reset_hard | `Branch_delete ]
+      [ `Push_force | `Push_delete | `Clean_force | `Stash_drop
+      | `Worktree_remove | `Reset_hard | `Branch_delete ]
 
 val of_argv : string list -> (t, [ `Unknown_subcmd of string ]) result
 (** [of_argv argv] expects [argv] to start with the [git] token.  The

--- a/lib/exec/git_op.mli
+++ b/lib/exec/git_op.mli
@@ -13,8 +13,8 @@ type t =
       | `Push | `Tag | `Stash_push | `Checkout_branch ]
   | Destructive of
       (* Trust-independent catastrophic floor — RFC-0255 §4.5. *)
-      [ `Push_force | `Push_delete | `Clean_force | `Stash_drop
-      | `Worktree_remove | `Reset_hard | `Branch_delete ]
+      [ `Push_force | `Push_delete | `Push_mirror | `Clean_force
+      | `Stash_drop | `Worktree_remove | `Reset_hard | `Branch_delete ]
 
 val of_argv : string list -> (t, [ `Unknown_subcmd of string ]) result
 (** [of_argv argv] expects [argv] to start with the [git] token.  The

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -328,6 +328,23 @@ let test_push_delete_short_flag_floored_under_autonomous () =
   | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Push_delete); _ } -> ()
   | _ -> assert false
 
+let test_push_force_with_lease_floored_under_autonomous () =
+  let s =
+    simple (bin_ok "git")
+      ~args:[ lit "push"; lit "--force-with-lease=main"; lit "origin"; lit "main" ]
+  in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps ~simple:s with
+  | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Push_force); _ } -> ()
+  | _ -> assert false
+
+let test_push_mirror_floored_under_autonomous () =
+  let s = simple (bin_ok "git") ~args:[ lit "push"; lit "--mirror"; lit "origin" ] in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps ~simple:s with
+  | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Push_mirror); _ } -> ()
+  | _ -> assert false
+
 (* RFC-0255 §4.5: [worktree remove] is NOT recoverable (discards uncommitted
    worktree state and races concurrent keepers/the conveyor) — it STAYS in the
    floor and is [Deny] under every overlay including autonomous. *)
@@ -366,6 +383,8 @@ let () =
   test_branch_delete_floored_under_autonomous ();
   test_push_delete_floored_under_autonomous ();
   test_push_delete_short_flag_floored_under_autonomous ();
+  test_push_force_with_lease_floored_under_autonomous ();
+  test_push_mirror_floored_under_autonomous ();
   test_worktree_remove_floored_under_autonomous ();
   test_rm_root_allowed_at_policy_layer_jailed_downstream ();
   test_autonomous_allows_toolchain ();

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -307,6 +307,27 @@ let test_branch_delete_floored_under_autonomous () =
   | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Branch_delete); _ } -> ()
   | _ -> assert false
 
+(* RFC-0255 P1 review response: [git push --delete] and [git push -d] delete
+   remote refs and are irreversible at the syntax classifier, so they must be
+   in the trust-independent destructive floor. *)
+let test_push_delete_floored_under_autonomous () =
+  let s =
+    simple (bin_ok "git")
+      ~args:[ lit "push"; lit "--delete"; lit "origin"; lit "feature-x" ]
+  in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps ~simple:s with
+  | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Push_delete); _ } -> ()
+  | _ -> assert false
+
+let test_push_delete_short_flag_floored_under_autonomous () =
+  let s =
+    simple (bin_ok "git") ~args:[ lit "push"; lit "-d"; lit "origin"; lit "feature-x" ] in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps ~simple:s with
+  | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Push_delete); _ } -> ()
+  | _ -> assert false
+
 (* RFC-0255 §4.5: [worktree remove] is NOT recoverable (discards uncommitted
    worktree state and races concurrent keepers/the conveyor) — it STAYS in the
    floor and is [Deny] under every overlay including autonomous. *)
@@ -343,6 +364,8 @@ let () =
   (* RFC-0255 §4.5 review response: no raw destructive-git demotion. *)
   test_reset_hard_floored_under_autonomous ();
   test_branch_delete_floored_under_autonomous ();
+  test_push_delete_floored_under_autonomous ();
+  test_push_delete_short_flag_floored_under_autonomous ();
   test_worktree_remove_floored_under_autonomous ();
   test_rm_root_allowed_at_policy_layer_jailed_downstream ();
   test_autonomous_allows_toolchain ();

--- a/lib/exec/test/test_capability_check.ml
+++ b/lib/exec/test/test_capability_check.ml
@@ -53,6 +53,28 @@ let test_git_push_force_destructive () =
   | [ Capability.Git (Git_op.Destructive `Push_force) ] -> ()
   | _ -> assert false
 
+let test_git_push_delete_destructive () =
+  let ir =
+    Shell_ir.Simple
+      (simple
+         ~args:[ lit "push"; lit "--delete"; lit "origin"; lit "feature-x" ]
+         (bin_ok "git"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Git (Git_op.Destructive `Push_delete) ] -> ()
+  | _ -> assert false
+
+let test_git_push_delete_short_flag_destructive () =
+  let ir =
+    Shell_ir.Simple
+      (simple
+         ~args:[ lit "push"; lit "-d"; lit "origin"; lit "feature-x" ]
+         (bin_ok "git"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Git (Git_op.Destructive `Push_delete) ] -> ()
+  | _ -> assert false
+
 let test_git_with_var_falls_back_to_exec_bin () =
   (* git ${REMOTE} push — can't classify statically, falls back. *)
   let ir =
@@ -129,6 +151,8 @@ let () =
   test_git_status_classified_as_git_read ();
   test_git_status_with_cwd_flag_classified_as_git_read ();
   test_git_push_force_destructive ();
+  test_git_push_delete_destructive ();
+  test_git_push_delete_short_flag_destructive ();
   test_git_with_var_falls_back_to_exec_bin ();
   test_env_set_prefix_emitted_first ();
   test_redirect_write_becomes_write_path ();

--- a/lib/exec/test/test_capability_check.ml
+++ b/lib/exec/test/test_capability_check.ml
@@ -75,6 +75,26 @@ let test_git_push_delete_short_flag_destructive () =
   | [ Capability.Git (Git_op.Destructive `Push_delete) ] -> ()
   | _ -> assert false
 
+let test_git_push_force_with_lease_destructive () =
+  let ir =
+    Shell_ir.Simple
+      (simple
+         ~args:[ lit "push"; lit "--force-with-lease=main"; lit "origin"; lit "main" ]
+         (bin_ok "git"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Git (Git_op.Destructive `Push_force) ] -> ()
+  | _ -> assert false
+
+let test_git_push_mirror_destructive () =
+  let ir =
+    Shell_ir.Simple
+      (simple ~args:[ lit "push"; lit "--mirror"; lit "origin" ] (bin_ok "git"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Git (Git_op.Destructive `Push_mirror) ] -> ()
+  | _ -> assert false
+
 let test_git_with_var_falls_back_to_exec_bin () =
   (* git ${REMOTE} push — can't classify statically, falls back. *)
   let ir =
@@ -153,6 +173,8 @@ let () =
   test_git_push_force_destructive ();
   test_git_push_delete_destructive ();
   test_git_push_delete_short_flag_destructive ();
+  test_git_push_force_with_lease_destructive ();
+  test_git_push_mirror_destructive ();
   test_git_with_var_falls_back_to_exec_bin ();
   test_env_set_prefix_emitted_first ();
   test_redirect_write_becomes_write_path ();


### PR DESCRIPTION
This PR resolves the unresolved P1 review thread on #21488.

## Change

RFC-0255 §4.5 already documents ``git push --delete`` and ``git push -d`` as remote-irreversible operations that must stay in the trust-independent catastrophic floor. However, the syntax classifier in ``Git_op.of_argv`` only detected ``--force``/``-f``, so push-delete was falling through to ``Mutating `Push`` and bypassing ``find_destructive_git`` under autonomous overlays.

- Added ``Push_delete`` to the ``Git_op.Destructive`` variant (both ``.ml`` and ``.mli``).
- Updated the ``push`` arm to detect ``--delete`` and the bundled short flag ``-d`` before falling back to ``Mutating `Push``.
- Added tests in ``test_capability_check.ml`` and ``test_approval_policy.ml`` covering both long and short flag forms, asserting they hit the destructive floor (Deny under autonomous overlay).

## Verification

- ``ocamlformat --check`` passed on all touched files.
- ``scripts/dune-local.sh runtest lib/exec/test`` passed (all 30+ test binaries).

## Scope

Minimal/surgical change scoped to ``lib/exec`` only; no unrelated refactoring.

Closes the review thread on #21488.
