### PR TITLE
fix(keeper): annotate surface context boundary

### DIFF
--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -33,6 +33,9 @@ let keeper_chat_stream_error_json message =
 let surface_context_to_instructions = Keeper_turn.surface_context_to_instructions
 
 let format_surface_context ctx =
+  (* NDT-OK: sound-partial; the shared formatter returns [None] for absent
+     co-view instructions, while this HTTP helper preserves its legacy
+     string-returning boundary for [turn_instructions_for_request]. *)
   Option.value ~default:"" (surface_context_to_instructions ctx)
 
 let has_connector_context (payload : keeper_chat_stream_request) =


### PR DESCRIPTION
## Summary

Follow-up to #21498 after post-merge review found the required `Meta Guards` DET/NDT ratchet was red at merge time.

This adds the local `NDT-OK: sound-partial` rationale next to the HTTP string-boundary wrapper around `Keeper_turn.surface_context_to_instructions`.

## Validation

- `bash scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`
- `ocamlformat --check lib/server/server_routes_http_keeper_stream.ml`
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_gate_keeper_backend.exe`
- `_build/default/test/test_gate_keeper_backend.exe` (37 tests)

## Review context

- #21498 was merged before the failing Meta Guards review finding was addressed.
- The earlier stale streaming-redaction concern is not present on current `origin/main`: the SSE adapter still forwards already-redacted `Text_delta` and `Tool_call_args` without re-redacting.
