### PR TITLE
fix: address review follow-ups from #21481

### DIFF
--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -44,26 +44,32 @@ const CHIPS: { id: AgentsView; label: string; description: string }[] = [
 
 export function AgentsUnified() {
   const keeperParam = route.value.params.keeper as string | undefined
-  if (keeperParam) {
-    return html`<${KeeperDetailPage} />`
-  }
-
-  // If an agent name is in the route params, show the profile page
   const agentParam = route.value.params.agent as string | undefined
-  if (agentParam) {
-    return html`<${AgentProfile} name=${agentParam} />`
-  }
-
   const currentView = activeView.value
 
   // countRuntimeKinds is an O(N) scan over agents+keepers. Memoized so an
   // execution_snapshot that only touches unrelated signals (or a re-render from
   // activeView/namespaceTruth/shellCounts) skips the rescan when agents/keepers
   // themselves are unchanged.
+  //
+  // Must run before any conditional return: when the route has a keeper/agent
+  // param this component renders a detail page, but navigating back to the
+  // fleet view re-enters this branch. Keeping the hook sequence stable prevents
+  // Preact hook-order failures during detail-to-list navigation.
   const liveRuntimeCounts = useMemo(
     () => countRuntimeKinds(agents.value, keepers.value),
     [agents.value, keepers.value],
   )
+
+  if (keeperParam) {
+    return html`<${KeeperDetailPage} />`
+  }
+
+  // If an agent name is in the route params, show the profile page
+  if (agentParam) {
+    return html`<${AgentProfile} name=${agentParam} />`
+  }
+
   const runtimeCounts = resolveRuntimeCounts({
     executionLoaded: executionLoaded.value,
     agentsCount: liveRuntimeCounts.agents,

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -288,12 +288,18 @@ function scheduleFlush(): void {
 function flushPending(): void {
   if (pendingEvents.length === 0) return
   const events = pendingEvents.splice(0, pendingEvents.length)
-  // Order preserved (splice + for-loop); batch() coalesces all signal writes
-  // across the whole burst into one notification.
+  // lastEvent is used as an event bus by several consumers
+  // (setupSSEReaction, reaction bars, connector/status panels, tool telemetry).
+  // Emit every event so intermediate messages are not dropped when multiple
+  // SSE messages arrive in one animation frame.
+  for (const ev of events) {
+    lastEvent.value = ev
+  }
+  // Order preserved (splice + for-loop); batch() coalesces the remaining
+  // signal writes across the whole burst into one notification.
   batch(() => {
     for (const ev of events) {
       eventCount.value++
-      lastEvent.value = ev
       handleEvent(ev)
     }
   })

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -707,20 +707,15 @@ let snapshot_json
       in
       match action with
       | `Hit value -> value
-      | `Wait cond ->
-        (* Another fiber is computing this key.  Await its broadcast (fired
-           at compute finish) for near-zero wakeup latency, racing a short
-           timer so we stay cancellable and re-check on a known cadence as a
-           lost-wakeup safety net.  [Eio.Fiber.first] cancels whichever fiber
-           loses the race, and [~protect:true] releases the mutex under
-           cancel — so the waiter stays cancellable. *)
-        let () =
-          Eio.Fiber.first
-            (fun () ->
-               Eio.Mutex.use_rw ~protect:true _snapshot_mu (fun () ->
-                 Eio.Condition.await cond _snapshot_mu))
-            (fun () -> Eio.Time.sleep ctx.clock _poll_interval_s)
-        in
+      | `Wait _cond ->
+        (* Another fiber is computing this key.  We intentionally do NOT
+           [Eio.Condition.await] inside [Eio.Mutex.use_rw ~protect:true]:
+           [Condition.await] masks cancellation while blocked, so if the
+           short timer wins a [Fiber.first] race the waiter can remain stuck
+           until the original compute broadcasts.  A bounded poll-retry loop
+           keeps the waiter cancellable and preserves the retry cadence.
+           See [dashboard_cache.ml] and docs/spec/10-dashboard.md. *)
+        Eio.Time.sleep ctx.clock _poll_interval_s;
         cache_lookup ~waited:(waited +. _poll_interval_s)
       | `Compute cond ->
         (match compute_snapshot () with

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -309,7 +309,10 @@ let hash_namespace_truth_snapshot (snapshot : Yojson.Safe.t) : Digestif.SHA256.t
         let ctx = List.fold_left walk ctx values in
         Digestif.SHA256.feed_string ctx "]"
     | `String s ->
-        let ctx = Digestif.SHA256.feed_string ctx "S" in
+        (* Length-prefix variable-length string fields so distinct JSON
+           payloads cannot collide in the hash stream (e.g. ["aS","b"] vs
+           ["a","Sb"]). The exact separator format is internal to this hash. *)
+        let ctx = Digestif.SHA256.feed_string ctx (Printf.sprintf "S%d:" (String.length s)) in
         Digestif.SHA256.feed_string ctx s
     | `Int n ->
         let ctx = Digestif.SHA256.feed_string ctx "I" in

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -113,6 +113,7 @@ let cached_dashboard_json ~sync_first ~sw ~cache ~key ~placeholder ~compute =
         | Error _, _ -> response
       else (
         Eio.Fiber.fork ~sw (fun () ->
+          (* fire-and-forget: stale-while-revalidate background refresh. *)
           ignore (run_compute_and_store entry : (Yojson.Safe.t, string) result * float));
         response)
     else

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -44,9 +44,28 @@ let json_with_cache_metadata json metadata =
   | `Assoc fields -> `Assoc (fields @ [ "cache", metadata ])
   | other -> `Assoc [ "payload", other; "cache", metadata ]
 
-let cached_dashboard_json ~sw ~cache ~key ~placeholder ~compute =
+let cached_dashboard_json ~sync_first ~sw ~cache ~key ~placeholder ~compute =
   let now = Unix.gettimeofday () in
-  let entry, response, should_refresh =
+  let run_compute_and_store entry =
+    let result =
+      try Ok (Eio_guard.run_in_systhread compute) with
+      | exn -> Error (Printexc.to_string exn)
+    in
+    let refreshed_at = Unix.gettimeofday () in
+    Stdlib.Mutex.lock dashboard_metrics_cache_mu;
+    (match result with
+     | Ok json ->
+         entry.value <- Some json;
+         entry.updated_at <- refreshed_at;
+         entry.last_error <- None
+     | Error message ->
+         Log.Misc.warn "dashboard metrics cache refresh failed: %s" message;
+         entry.last_error <- Some message);
+    entry.in_flight <- false;
+    Stdlib.Mutex.unlock dashboard_metrics_cache_mu;
+    result, refreshed_at
+  in
+  let entry, response, should_refresh, was_cold =
     Stdlib.Mutex.lock dashboard_metrics_cache_mu;
     let entry =
       match Hashtbl.find_opt cache key with
@@ -57,11 +76,12 @@ let cached_dashboard_json ~sw ~cache ~key ~placeholder ~compute =
           entry
     in
     let age_s = now -. entry.updated_at in
-    let response, should_refresh =
+    let response, should_refresh, was_cold =
       match entry.value with
       | Some json when age_s <= dashboard_metrics_cache_ttl_s ->
           ( json_with_cache_metadata json
               (cache_metadata ~state:"fresh" ~generated_at:now ~age_s ()),
+            false,
             false )
       | Some json ->
           let start_refresh = not entry.in_flight in
@@ -69,37 +89,35 @@ let cached_dashboard_json ~sw ~cache ~key ~placeholder ~compute =
           ( json_with_cache_metadata json
               (cache_metadata ~state:"stale_refreshing" ~generated_at:now
                  ~age_s ?error:entry.last_error ()),
-            start_refresh )
+            start_refresh,
+            false )
       | None ->
           let start_refresh = not entry.in_flight in
           if start_refresh then entry.in_flight <- true;
           ( json_with_cache_metadata placeholder
               (cache_metadata ~state:"warming" ~generated_at:now
                  ?error:entry.last_error ()),
-            start_refresh )
+            start_refresh,
+            true )
     in
     Stdlib.Mutex.unlock dashboard_metrics_cache_mu;
-    entry, response, should_refresh
+    entry, response, should_refresh, was_cold
   in
-  if should_refresh then
-    Eio.Fiber.fork ~sw (fun () ->
-      let result =
-        try Ok (Eio_guard.run_in_systhread compute) with
-        | exn ->
-            Error (Printexc.to_string exn)
-      in
-      let refreshed_at = Unix.gettimeofday () in
-      Stdlib.Mutex.lock dashboard_metrics_cache_mu;
-      (match result with
-       | Ok json ->
-           entry.value <- Some json;
-           entry.updated_at <- refreshed_at;
-           entry.last_error <- None
-       | Error message ->
-           Log.Misc.warn "dashboard metrics cache refresh failed: %s" message;
-           entry.last_error <- Some message);
-      entry.in_flight <- false;
-      Stdlib.Mutex.unlock dashboard_metrics_cache_mu);
+  let response =
+    if should_refresh then
+      if sync_first && was_cold then
+        match run_compute_and_store entry with
+        | Ok json, refreshed_at ->
+            json_with_cache_metadata json
+              (cache_metadata ~state:"fresh" ~generated_at:refreshed_at ())
+        | Error _, _ -> response
+      else (
+        Eio.Fiber.fork ~sw (fun () ->
+          ignore (run_compute_and_store entry : (Yojson.Safe.t, string) result * float));
+        response)
+    else
+      response
+  in
   response
 
 let empty_model_metrics_json ~window ~bucket_min =
@@ -147,7 +165,8 @@ let add_routes ~sw router =
              [ base_path; string_of_int window; string_of_int bucket_min ]
          in
          let json =
-           cached_dashboard_json ~sw ~cache:dashboard_model_metrics_cache ~key
+           cached_dashboard_json ~sw ~sync_first:false
+             ~cache:dashboard_model_metrics_cache ~key
              ~placeholder:(empty_model_metrics_json ~window ~bucket_min)
              ~compute:(fun () ->
                let agg =
@@ -168,7 +187,8 @@ let add_routes ~sw router =
          let config = (Mcp_server.workspace_config state) in
          let key = cache_key [ config.base_path; string_of_int window ] in
          let json =
-           cached_dashboard_json ~sw ~cache:dashboard_keeper_costs_cache ~key
+           cached_dashboard_json ~sw ~sync_first:false
+             ~cache:dashboard_keeper_costs_cache ~key
              ~placeholder:
                (Dashboard_http_keeper.keeper_cost_aggregates_json ~config
                   ~keepers:[] ~window_minutes:window)
@@ -191,7 +211,8 @@ let add_routes ~sw router =
          let window = int_query_param req "window" ~default:1440 in
          let base_path = (Mcp_server.workspace_config state).base_path in
          let json =
-           cached_dashboard_json ~sw ~cache:dashboard_cost_latency_cache
+           cached_dashboard_json ~sw ~sync_first:false
+             ~cache:dashboard_cost_latency_cache
              ~key:(cache_key [ base_path; string_of_int window ])
              ~placeholder:(empty_cost_latency_json ~window)
              ~compute:(fun () ->
@@ -206,8 +227,8 @@ let add_routes ~sw router =
          let config = (Mcp_server.workspace_config state) in
          let key = cache_key [ config.base_path; string_of_int limit ] in
          let json =
-           cached_dashboard_json ~sw ~cache:dashboard_keeper_decisions_cache
-             ~key
+           cached_dashboard_json ~sw ~sync_first:true
+             ~cache:dashboard_keeper_decisions_cache ~key
              ~placeholder:
                (Dashboard_http_keeper.keeper_decisions_json ~config
                   ~keepers:[] ~limit ())
@@ -231,7 +252,7 @@ let add_routes ~sw router =
          let config = (Mcp_server.workspace_config state) in
          let key = cache_key [ config.base_path; string_of_int limit ] in
          let json =
-           cached_dashboard_json ~sw
+           cached_dashboard_json ~sw ~sync_first:false
              ~cache:dashboard_keeper_decisions_log_cache ~key
              ~placeholder:
                (Dashboard_http_keeper.keeper_decisions_log_json ~config
@@ -256,8 +277,8 @@ let add_routes ~sw router =
          let config = (Mcp_server.workspace_config state) in
          let key = cache_key [ config.base_path; string_of_int limit ] in
          let json =
-           cached_dashboard_json ~sw ~cache:dashboard_keeper_memory_log_cache
-             ~key
+           cached_dashboard_json ~sw ~sync_first:false
+             ~cache:dashboard_keeper_memory_log_cache ~key
              ~placeholder:
                (Dashboard_http_keeper.keeper_memory_log_json ~config
                   ~keepers:[] ~limit ())

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -51,6 +51,7 @@ let cached_dashboard_json ~sync_first ~sw ~cache ~key ~placeholder ~compute =
       try Ok (Eio_guard.run_in_systhread compute) with
       | exn -> Error (Printexc.to_string exn)
     in
+    (* NDT-OK: moved cache freshness timestamp; wall-clock metadata is boundary output. *)
     let refreshed_at = Unix.gettimeofday () in
     Stdlib.Mutex.lock dashboard_metrics_cache_mu;
     (match result with

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -723,6 +723,23 @@ let test_namespace_truth_snapshot_hash_ignores_generated_at () =
         (Server_dashboard_http.should_broadcast_namespace_truth_snapshot
            (snapshot ~generated_at:"2026-04-09T00:00:10Z" ~active_sessions:2)))
 
+let test_namespace_truth_snapshot_hash_avoids_string_collision () =
+  (* Length-prefixing string fields must keep distinct payloads distinct.
+     The pre-fix hash would collide on these two list-of-string shapes. *)
+  Fun.protect
+    ~finally:(fun () ->
+      Server_dashboard_http.last_namespace_truth_snapshot_hash := None)
+    (fun () ->
+      Server_dashboard_http.last_namespace_truth_snapshot_hash := None;
+      Eio_main.run @@ fun _env ->
+      let payload fields = `Assoc [("items", `List fields)] in
+      let a = payload [ `String "aS"; `String "b" ] in
+      let b = payload [ `String "a"; `String "Sb" ] in
+      check bool "first payload broadcasts" true
+        (Server_dashboard_http.should_broadcast_namespace_truth_snapshot a);
+      check bool "different string concatenation still broadcasts" true
+        (Server_dashboard_http.should_broadcast_namespace_truth_snapshot b))
+
 let () =
   Alcotest.run "Dashboard Namespace Truth"
     [
@@ -750,5 +767,7 @@ let () =
             test_last_good_shell_fallback_preserves_counts;
           test_case "snapshot hash ignores generated_at churn" `Quick
             test_namespace_truth_snapshot_hash_ignores_generated_at;
+          test_case "snapshot hash avoids string concatenation collisions" `Quick
+            test_namespace_truth_snapshot_hash_avoids_string_collision;
         ] );
     ]


### PR DESCRIPTION
This PR addresses the five unresolved review threads on merged PR #21481.

## Changes

1. **Synchronous first load for keeper decisions** (lib/server/server_routes_http_routes_provider_runs.ml)
   - Adds a ~sync_first flag to cached_dashboard_json. When true and the cache is cold, the first request computes inline instead of returning an empty warming placeholder.
   - Enabled for /api/v1/dashboard/keeper-decisions so dashboard consumers (decisions stream, cost dashboard, IDE rail) do not decode events: [] as loaded data.
   - Other dashboard feeds keep the existing async stale-while-revalidate behavior.

2. **Stable hook order in AgentsUnified** (dashboard/src/components/agents-unified.ts)
   - Moves useMemo and other hook-derived values before the conditional early returns for keeper/agent route params.
   - Prevents Preact hook-order failures when navigating from detail pages back to the fleet view.

3. **Preserve every lastEvent notification** (dashboard/src/sse.ts)
   - Assigns lastEvent.value for each buffered event outside batch() so event-bus consumers see all intermediate messages, not just the final one per animation frame.

4. **Avoid Condition.await under protected mutex** (lib/operator/operator_control_snapshot.ml)
   - Replaces the Fiber.first [Condition.await; sleep] wait path with a cancellable poll-retry loop (Eio.Time.sleep + recheck).
   - Prevents cancellation-masked waiters from getting stuck when the timer branch wins, matching the established pattern in lib/dashboard/dashboard_cache.ml.

5. **Length-prefix snapshot hash fields** (lib/server/server_dashboard_http_namespace_truth.ml)
   - Prefixes variable-length string fields with their length when feeding the incremental SHA-256 hash, preventing collisions like ["aS","b"] vs ["a","Sb"].

## Test additions

- Added a regression test in test/test_dashboard_namespace_truth.ml proving that distinct list-of-string payloads produce different namespace-truth snapshot hashes.

## Local verification

- MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/masc.a lib/server/masc_server.a lib/operator/masc_operator.a: passed
- test/test_operator_control_snapshot_state.exe: passed
- test/test_dashboard_namespace_truth.exe: passed (14 tests)
- pnpm typecheck: passed
- npx eslint src/components/agents-unified.ts src/sse.ts: passed
- npx vitest run src/components/agents-unified.test.ts src/sse-store.test.ts: passed
- ocamlformat --check on touched OCaml files: passed
- scripts/ci/check-ignore-without-comment-diff.sh --base e58b5706445cb6fb04c392596d54cea2c1c0be66 --head HEAD: passed
- python3 scripts/check_test_coverage.py: passed

## Notes

- Does not merge the follow-up PR; leaves that for human review.
- Changes are surgical and limited to the files/lines called out in the review threads.
