### PR TITLE
fix(docs): regenerate env knob catalog total (350->351) — clears main Build and Test drift gate

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,7 +14,7 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 350 unique knobs across 9 modules.
+**Total**: 351 unique knobs across 9 modules.
 
 **Typed getter classification**: 21/207 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 186).
 


### PR DESCRIPTION
## 문제 (main-broken)

CI `Build and Test`의 **Env knob catalog drift gate**가 main에서 fail 중:

```
**Total**: 350 unique knobs across 9 modules.   # committed (stale)
**Total**: 351 unique knobs across 9 modules.   # bin/env_knob_catalog.exe 재생성 결과
```

게이트는 `docs/runtime-tunables.md`가 `lib/config/env_config_*.ml`에서 재생성한 결과와 byte 일치하는지 검사한다. 현재 불일치로 fail → 그 뒤 13개 step skip.

## 원인

#21488 (`d2cfa01646`, shell-ir path-jail)이 `env_config_runtime.ml`에 knob을 추가(350→351)하면서 `runtime-tunables.md`를 부분만 편집하고 **Total 카운트 줄을 안 올렸다**. 카탈로그는 typed getter에서 *파생*되는 산출물이라 손으로 고치지 않고 재생성해야 한다.

## 수정

게이트가 지시하는 정규 명령 그대로:
```
dune exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md
```
결과는 Total 줄 1줄 변경.

## 검증

- main HEAD `e58b570644`에서 게이트 로컬 재현(`DUNE_CACHE=disabled` env_knob_catalog.exe 빌드)
- 재생성 후 `git diff --exit-code docs/runtime-tunables.md` clean
- keeper fix #21465/#21418이 원인 아님 — 그 커밋들은 env_config 파일 0개 변경

RFC-WAIVED: 파생 카탈로그 문서 재생성(`docs/runtime-tunables.md`). credential/identity/operator/sandbox/hooks/workflow 경계 미해당. 코드 변경 0, 생성물 동기화만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
