### PR TITLE
fix: address review follow-ups from #21496

### DIFF
--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -114,6 +114,7 @@ let parse_agent_status (config : Workspace.config) ~(agent_name : string) : Yojs
                  `Bool
                    (Workspace.is_zombie_agent
                       ~agent_type:agent.agent_type
+                      ?agent_meta:agent.meta
                       ~agent_name:agent.name
                       agent.last_seen));
               ]))

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -370,7 +370,10 @@ let handle_keeper_task_tool
        String.concat "\n" (List.filteri (fun i _ -> i < limit + 2) lines))
     | Tasks_audit ->
     let limit = Safe_ops.json_int ~default:20 "limit" args |> max 1 |> min 50 in
-    let orphans = Workspace.audit_orphan_tasks config in
+    let orphans =
+      Workspace.audit_orphan_tasks config
+      |> List.filter (fun (_, assignee) -> assignee <> meta.agent_name)
+    in
     let orphans = List.filteri (fun i _ -> i < limit) orphans in
     let items =
       List.map

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -67,8 +67,12 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
     in
     let failed =
       (* "Failed" here means still-auditable active work. Terminal Cancelled
-         tasks are historical evidence, not a reason to wake every keeper. *)
+         tasks are historical evidence, not a reason to wake every keeper.
+         Keep the current keeper's own task out of the count: keepers may
+         claim without a materialized [.masc/agents/] record, so the audit can
+         still see the self-assigned task as an orphan. *)
       Workspace.audit_orphan_tasks config
+      |> List.filter (fun (_, assignee) -> assignee <> meta.agent_name)
       |> List.map fst
       |> List.filter claim_scope_filter
       |> List.length

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -205,8 +205,8 @@ let safe_read_backlog (ctx : context) =
     { Masc_domain.tasks = []; last_updated = Masc_domain.now_iso (); version = 1 }
 ;;
 
-let safe_is_zombie_agent ?agent_type ~agent_name last_seen =
-  try Workspace.is_zombie_agent ?agent_type ~agent_name last_seen with
+let safe_is_zombie_agent ?agent_type ?agent_meta ~agent_name last_seen =
+  try Workspace.is_zombie_agent ?agent_type ?agent_meta ~agent_name last_seen with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     Log.Workspace.warn
@@ -369,10 +369,11 @@ let status_summary_string (ctx : context) =
       (fun (agent : Masc_domain.agent) ->
          Workspace_query.safe_yield ();
          let is_zombie =
-           safe_is_zombie_agent
-             ~agent_type:agent.agent_type
-             ~agent_name:agent.name
-             agent.last_seen
+             safe_is_zombie_agent
+               ~agent_type:agent.agent_type
+               ?agent_meta:agent.meta
+               ~agent_name:agent.name
+               agent.last_seen
          in
          agent, is_zombie)
       agents

--- a/lib/workspace/workspace_gc.ml
+++ b/lib/workspace/workspace_gc.ml
@@ -92,6 +92,7 @@ let cleanup_zombies
                    ~keeper_threshold_sec
                    ~agent_threshold_sec
                    ~agent_type:agent.agent_type
+                   ?agent_meta:agent.meta
                    ~agent_name:agent.name
                    agent.last_seen ->
               zombie_entries := (agent.name, path) :: !zombie_entries

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -116,27 +116,38 @@ let get_all_agents config =
     Matches assignees by exact name or agent-type prefix (e.g. "<prefix>" matches "<prefix>-xxx").
     Agents with Inactive status are excluded from the active set.
 
-    Staleness uses the canonical keeper-aware predicate
-    {!Workspace_resilience.Zombie.is_zombie_for_agent}: keeper agents get the
+    Staleness uses a keeper-aware threshold: actual keeper agents get the
     longer keeper grace ([MASC_KEEPER_ZOMBIE_THRESHOLD_SEC], default 3600s) and
-    ordinary agents the default ([MASC_ZOMBIE_THRESHOLD_SEC], default 300s) —
-    the same policy as [cleanup_zombies]/[status]. A live keeper that has gone
-    quiet between heartbeats (but within its grace) is therefore not classified
-    as inactive, so its own claimed/in-progress task is not mis-reported as an
-    orphan at the source. *)
+    ordinary agents the default ([MASC_ZOMBIE_THRESHOLD_SEC], default 300s).
+    Keeper status is decided by actual presence in the agent file
+    ([agent_type = "keeper"] or keeper-owned [meta]) rather than by the
+    keeper-shaped name pattern, so a keeper-shaped non-keeper worker does not
+    inherit the longer grace. A live keeper that has gone quiet between
+    heartbeats (but within its grace) is therefore not classified as inactive,
+    so its own claimed/in-progress task is not mis-reported as an orphan at the
+    source. *)
 let audit_orphan_tasks config : (Masc_domain.task * string) list =
   if not (is_initialized config) then []
   else
     (* Read agent files from the same path that cleanup_zombies and session binding use *)
     let agents_path = agents_dir config in
+    let is_real_keeper (agent : Masc_domain.agent) =
+      String.lowercase_ascii (String.trim agent.agent_type) = "keeper"
+      (* STR-OK: boundary parser for the file-backed agent_type keeper stamp. *)
+      ||
+      match agent.meta with
+      | Some { keeper_id = Some _; _ } | Some { keeper_name = Some _; _ } -> true
+      | _ -> false
+    in
     let active_names =
       load_agents_from_dir config agents_path ~include_inactive:false
       |> List.filter (fun (agent : Masc_domain.agent) ->
-          not
-            (Workspace_resilience.Zombie.is_zombie_for_agent
-               ~agent_name:agent.name
-               ~agent_type:agent.agent_type
-               agent.last_seen))
+          let threshold =
+            if is_real_keeper agent
+            then Env_config_runtime.Zombie.keeper_threshold_seconds
+            else Env_config_runtime.Zombie.threshold_seconds
+          in
+          not (Workspace_resilience.Zombie.is_zombie ~threshold agent.last_seen))
       |> List.map (fun (agent : Masc_domain.agent) -> agent.name)
     in
     let is_active_agent assignee =

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -119,35 +119,27 @@ let get_all_agents config =
     Staleness uses a keeper-aware threshold: actual keeper agents get the
     longer keeper grace ([MASC_KEEPER_ZOMBIE_THRESHOLD_SEC], default 3600s) and
     ordinary agents the default ([MASC_ZOMBIE_THRESHOLD_SEC], default 300s).
-    Keeper status is decided by actual presence in the agent file
-    ([agent_type = "keeper"] or keeper-owned [meta]) rather than by the
-    keeper-shaped name pattern, so a keeper-shaped non-keeper worker does not
-    inherit the longer grace. A live keeper that has gone quiet between
-    heartbeats (but within its grace) is therefore not classified as inactive,
-    so its own claimed/in-progress task is not mis-reported as an orphan at the
-    source. *)
+    Keeper status is decided by the shared {!Workspace_resilience.Zombie}
+    file-backed predicate ([agent_type = "keeper"] or keeper-owned [meta])
+    rather than by the keeper-shaped name pattern, so a keeper-shaped
+    non-keeper worker does not inherit the longer grace. A live keeper that has
+    gone quiet between heartbeats (but within its grace) is therefore not
+    classified as inactive, so its own claimed/in-progress task is not
+    mis-reported as an orphan at the source. *)
 let audit_orphan_tasks config : (Masc_domain.task * string) list =
   if not (is_initialized config) then []
   else
     (* Read agent files from the same path that cleanup_zombies and session binding use *)
     let agents_path = agents_dir config in
-    let is_real_keeper (agent : Masc_domain.agent) =
-      String.lowercase_ascii (String.trim agent.agent_type) = "keeper"
-      (* STR-OK: boundary parser for the file-backed agent_type keeper stamp. *)
-      ||
-      match agent.meta with
-      | Some { keeper_id = Some _; _ } | Some { keeper_name = Some _; _ } -> true
-      | _ -> false
-    in
     let active_names =
       load_agents_from_dir config agents_path ~include_inactive:false
       |> List.filter (fun (agent : Masc_domain.agent) ->
-          let threshold =
-            if is_real_keeper agent
-            then Env_config_runtime.Zombie.keeper_threshold_seconds
-            else Env_config_runtime.Zombie.threshold_seconds
-          in
-          not (Workspace_resilience.Zombie.is_zombie ~threshold agent.last_seen))
+          not
+            (Workspace_resilience.Zombie.is_zombie_for_agent
+               ~agent_type:agent.agent_type
+               ?agent_meta:agent.meta
+               ~agent_name:agent.name
+               agent.last_seen))
       |> List.map (fun (agent : Masc_domain.agent) -> agent.name)
     in
     let is_active_agent assignee =

--- a/lib/workspace/workspace_resilience.ml
+++ b/lib/workspace/workspace_resilience.ml
@@ -46,23 +46,35 @@ module Zombie = struct
   let is_zombie ?(threshold=default_zombie_threshold) last_seen_iso =
     Time.is_stale ~threshold last_seen_iso
 
-  (** Check if agent is a keeper by name pattern AND/OR agent_type field.
-      Name-only matching is insufficient: agents with [agent_type="keeper"]
-      but no keeper-shaped name still need the keeper threshold, while
-      legacy keeper-named agents keep the same behavior. *)
-  let is_keeper ~name ~agent_type =
-    is_keeper_name name
-    || String.lowercase_ascii (String.trim agent_type) = "keeper"
+  let agent_type_is_keeper agent_type =
+    (* STR-OK: boundary parser for the file-backed agent_type keeper stamp. *)
+    String.lowercase_ascii (String.trim agent_type) = "keeper"
+
+  (** Check if the file-backed agent record is a real keeper.  Keeper-shaped
+      names are not authority here: spoofed worker names must not inherit the
+      longer keeper grace. *)
+  let is_keeper_record ~agent_type ~(agent_meta : Masc_domain.agent_meta option) =
+    agent_type_is_keeper agent_type
+    ||
+    match agent_meta with
+    | Some { keeper_id = Some _; _ } | Some { keeper_name = Some _; _ } -> true
+    | _ -> false
+
+  (** Backward-compatible wrapper for callers that only have name/type.  The
+      name argument is intentionally ignored for keeper-grace decisions. *)
+  let is_keeper ~name:_ ~agent_type =
+    agent_type_is_keeper agent_type
 
   (** Check if an agent is a zombie, using keeper threshold for keeper agents *)
   let is_zombie_for_agent
       ?(keeper_threshold_sec = Env_config_runtime.Zombie.keeper_threshold_seconds)
       ?(agent_threshold_sec = default_zombie_threshold)
       ?(agent_type = "")
-      ~agent_name
+      ?agent_meta
+      ~agent_name:_
       last_seen_iso =
     let threshold =
-      if is_keeper ~name:agent_name ~agent_type
+      if is_keeper_record ~agent_type ~agent_meta
       then keeper_threshold_sec
       else agent_threshold_sec
     in

--- a/lib/workspace/workspace_resilience.mli
+++ b/lib/workspace/workspace_resilience.mli
@@ -63,31 +63,35 @@ module Zombie : sig
   (** [is_zombie ?threshold last_seen_iso] is a thin alias for
       {!Time.is_stale}. *)
 
+  val is_keeper_record :
+    agent_type:string -> agent_meta:Masc_domain.agent_meta option -> bool
+  (** [is_keeper_record ~agent_type ~agent_meta] returns [true] only for
+      file-backed evidence that the agent is a keeper: [agent_type =
+      "keeper"] or keeper-owned metadata. Keeper-shaped names are not
+      authority and do not receive keeper grace on their own. *)
+
   val is_keeper :
     name:string -> agent_type:string -> bool
-  (** [is_keeper ~name ~agent_type] returns [true] when EITHER:
-      - [name] matches the keeper-name convention, OR
-      - [agent_type] equals ["keeper"] (case-insensitive, trimmed)
-
-      Name-only matching is insufficient because non-pattern keeper
-      agents still need the keeper threshold, while legacy
-      [keeper-*-agent] names keep the same behavior. *)
+  (** [is_keeper ~name ~agent_type] is a compatibility wrapper for callers
+      that do not have metadata. The [name] argument is intentionally ignored
+      for keeper-grace decisions; only [agent_type = "keeper"] is accepted. *)
 
   val is_zombie_for_agent :
     ?keeper_threshold_sec:float ->
     ?agent_threshold_sec:float ->
     ?agent_type:string ->
+    ?agent_meta:Masc_domain.agent_meta ->
     agent_name:string ->
     string ->
     bool
   (** [is_zombie_for_agent ?keeper_threshold_sec ?agent_threshold_sec
-      ?agent_type ~agent_name last_seen_iso] uses
+      ?agent_type ?agent_meta ~agent_name last_seen_iso] uses
       {!Env_config_runtime.Zombie.keeper_threshold_seconds} when
-      {!is_keeper} matches the name or type, otherwise falls back to
-      {!default_zombie_threshold}.  Callers may override both
-      thresholds for deterministic tests or one-off cleanup windows.
-      This is the canonical "should I evict this agent" predicate for
-      the gc loop. *)
+      {!is_keeper_record} has typed/metadata evidence that the agent is a
+      keeper, otherwise falls back to {!default_zombie_threshold}. Callers may
+      override both thresholds for deterministic tests or one-off cleanup
+      windows. This is the canonical "should I evict this agent" predicate for
+      audit, status, and cleanup consumers. *)
 end
 
 (** {1 Zero-Zombie protocol}

--- a/lib/workspace/workspace_state.ml
+++ b/lib/workspace/workspace_state.ml
@@ -157,9 +157,10 @@ let parse_iso_time iso_str =
   | Some t -> t
   | None -> Workspace_resilience.Time.now ()
 
-let is_zombie_agent ?agent_type ~agent_name last_seen_iso =
+let is_zombie_agent ?agent_type ?agent_meta ~agent_name last_seen_iso =
   Workspace_resilience.Zombie.is_zombie_for_agent
     ?agent_type
+    ?agent_meta
     ~agent_name
     last_seen_iso
 

--- a/lib/workspace/workspace_state.mli
+++ b/lib/workspace/workspace_state.mli
@@ -34,5 +34,6 @@ val pause_info :
 val heartbeat_timeout_seconds : float
 val parse_iso_time_opt : string -> float option
 val parse_iso_time : string -> float
-val is_zombie_agent : ?agent_type:string -> agent_name:string -> string -> bool
+val is_zombie_agent :
+  ?agent_type:string -> ?agent_meta:Masc_domain.agent_meta -> agent_name:string -> string -> bool
 val take : int -> 'a list -> 'a list

--- a/lib/workspace/workspace_status.ml
+++ b/lib/workspace/workspace_status.ml
@@ -49,6 +49,7 @@ let status config =
               let is_zombie =
                 is_zombie_agent
                   ~agent_type:agent.agent_type
+                  ?agent_meta:agent.meta
                   ~agent_name:agent.name
                   agent.last_seen
               in

--- a/test/test_resilience.ml
+++ b/test/test_resilience.ml
@@ -186,10 +186,10 @@ let test_zombie_for_agent_regular_600s () =
   check bool "600s old regular agent is zombie" true
     (Workspace_resilience.Zombie.is_zombie_for_agent ~agent_name:"claude" ts)
 
-let test_zombie_for_agent_keeper_600s () =
-  (* 600s old keeper agent: should NOT be zombie (keeper threshold 3600s) *)
+let test_zombie_for_agent_keeper_shaped_non_keeper_600s () =
+  (* 600s old keeper-shaped non-keeper: should be zombie (default threshold 300s) *)
   let ts = make_iso_seconds_ago 600.0 in
-  check bool "600s old keeper agent is not zombie" false
+  check bool "600s old keeper-shaped non-keeper is zombie" true
     (Workspace_resilience.Zombie.is_zombie_for_agent ~agent_name:"keeper-eval-agent" ts)
 
 let test_zombie_for_agent_keeper_type_600s () =
@@ -201,16 +201,16 @@ let test_zombie_for_agent_keeper_type_600s () =
        ~agent_name:"regular-bot"
        ts)
 
-let test_zombie_for_agent_keeper_4000s () =
-  (* 4000s old keeper agent: should be zombie (exceeds keeper threshold 3600s) *)
+let test_zombie_for_agent_keeper_shaped_4000s () =
+  (* 4000s old keeper-shaped non-keeper: should be zombie (exceeds default threshold) *)
   let ts = make_iso_seconds_ago 4000.0 in
-  check bool "4000s old keeper agent is zombie" true
+  check bool "4000s old keeper-shaped non-keeper is zombie" true
     (Workspace_resilience.Zombie.is_zombie_for_agent ~agent_name:"keeper-eval-agent" ts)
 
-let test_zombie_for_agent_keeper_recent () =
-  (* Recent keeper agent: not zombie *)
+let test_zombie_for_agent_keeper_shaped_recent () =
+  (* Recent keeper-shaped agent: not zombie even without keeper grace. *)
   let ts = make_iso_seconds_ago 10.0 in
-  check bool "recent keeper agent not zombie" false
+  check bool "recent keeper-shaped agent not zombie" false
     (Workspace_resilience.Zombie.is_zombie_for_agent ~agent_name:"keeper-eval-agent" ts)
 
 (* ================================================================
@@ -252,10 +252,10 @@ let () =
     ];
     "Zombie.is_zombie_for_agent", [
       test_case "regular 600s" `Quick test_zombie_for_agent_regular_600s;
-      test_case "keeper 600s" `Quick test_zombie_for_agent_keeper_600s;
+      test_case "keeper-shaped non-keeper 600s" `Quick test_zombie_for_agent_keeper_shaped_non_keeper_600s;
       test_case "keeper type 600s" `Quick test_zombie_for_agent_keeper_type_600s;
-      test_case "keeper 4000s" `Quick test_zombie_for_agent_keeper_4000s;
-      test_case "keeper recent" `Quick test_zombie_for_agent_keeper_recent;
+      test_case "keeper-shaped 4000s" `Quick test_zombie_for_agent_keeper_shaped_4000s;
+      test_case "keeper-shaped recent" `Quick test_zombie_for_agent_keeper_shaped_recent;
     ];
     "ZeroZombie.cleanup", [
       test_case "with results" `Quick test_zero_zombie_cleanup_with_results;

--- a/test/test_resilience_coverage.ml
+++ b/test/test_resilience_coverage.ml
@@ -138,7 +138,10 @@ let test_keeper_zombie_threshold_matches_env_config () =
       old_ts
   in
   check bool "keeper threshold uses env config" expected
-    (Workspace_resilience.Zombie.is_zombie_for_agent ~agent_name:"keeper-demo-agent" old_ts)
+    (Workspace_resilience.Zombie.is_zombie_for_agent
+       ~agent_type:"keeper"
+       ~agent_name:"keeper-demo-agent"
+       old_ts)
 
 (* ============================================================
    ZeroZombie.global_stats Tests

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1488,6 +1488,28 @@ let test_read_backlog_counts_excludes_self_owned_orphan () =
     Alcotest.(check int) "keeper's own orphan excluded from failed count" 0 failed
   )
 
+let test_keeper_tasks_audit_excludes_self_owned_orphan () =
+  with_test_env (fun config ->
+    let keeper = "keeper-task-audit-self-filter-agent" in
+    let _ = Workspace.bind_session config ~agent_name:keeper ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:keeper ~task_id:"task-001" in
+    (* Remove the agent file to simulate a keeper with no active registry record. *)
+    let _ = Workspace.end_session config ~agent_name:keeper in
+    let meta = keeper_meta_for_self_filter keeper in
+    let payload =
+      Keeper_tool_task_runtime.handle_keeper_task_tool
+        ~config
+        ~meta
+        ~name:"keeper_tasks_audit"
+        ~args:(`Assoc [])
+      |> Yojson.Safe.from_string
+    in
+    let orphan_count =
+      Yojson.Safe.Util.(payload |> member "orphan_count" |> to_int)
+    in
+    Alcotest.(check int) "keeper's own orphan excluded from audit" 0 orphan_count
+  )
+
 let test_cleanup_zombies_releases_tasks () =
   with_test_env (fun config ->
     let _ = Workspace.add_task config ~title:"Zombie Task" ~priority:1 ~description:"" in
@@ -1980,6 +2002,8 @@ let () =
         test_audit_orphan_spares_keeper_owned_meta_within_grace;
       Alcotest.test_case "read backlog counts excludes self-owned orphan" `Quick
         test_read_backlog_counts_excludes_self_owned_orphan;
+      Alcotest.test_case "keeper tasks audit excludes self-owned orphan" `Quick
+        test_keeper_tasks_audit_excludes_self_owned_orphan;
       Alcotest.test_case "cleanup zombies runtime" `Quick test_cleanup_zombies_releases_tasks;
     ];
 

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -963,7 +963,11 @@ let test_cleanup_zombies_detects_keeper () =
 let test_cleanup_zombies_spares_recent_keeper () =
   with_test_env (fun config ->
     (* Create a keeper agent idle for 10 minutes (< 3600s keeper threshold) *)
-    make_stale_agent config ~name:"keeper-active-agent" ~age_seconds:600.0;
+    make_stale_agent
+      ~agent_type:"keeper"
+      config
+      ~name:"keeper-active-agent"
+      ~age_seconds:600.0;
     let result = Workspace.cleanup_zombies config in
     let spared = match result with
       | Workspace.Cleaned { names; _ } -> not (List.mem "keeper-active-agent" names)
@@ -1357,7 +1361,8 @@ let test_audit_orphan_awaiting_verification_tasks () =
    have its own claimed task classified as an orphan. With the pre-fix
    [Time.is_stale] (300s flat) predicate this returned 1 orphan, which drove the
    keeper self-wake loop that #21418 papered over by filtering self from the
-   count. The root fix routes keepers through [Zombie.is_zombie_for_agent]. *)
+   count. The root fix routes typed/meta-confirmed keepers through
+   [Zombie.is_zombie_for_agent]. *)
 let test_audit_orphan_spares_live_keeper_within_grace () =
   with_test_env (fun config ->
     let _ = Workspace.add_task config ~title:"Keeper Task" ~priority:1 ~description:"" in
@@ -1691,15 +1696,15 @@ let test_zombie_cleanup_transitions_to_inactive () =
     Alcotest.(check string) "status transitioned to inactive" "inactive" status
   )
 
-(** BUG-5: Keeper detection uses agent_type, not just name *)
+(** BUG-5: Keeper detection uses agent_type/metadata evidence, not just name *)
 let test_keeper_detection_by_agent_type () =
   (* A non-keeper-named agent with agent_type="keeper" should get keeper threshold *)
   let is_keeper_by_type = Workspace_resilience.Zombie.is_keeper ~name:"regular-bot" ~agent_type:"keeper" in
   Alcotest.(check bool) "agent_type=keeper detected" true is_keeper_by_type;
 
-  (* A keeper-named agent should still be detected *)
+  (* A keeper-shaped name alone is not authoritative. *)
   let is_keeper_by_name = Workspace_resilience.Zombie.is_keeper ~name:"keeper-test-agent" ~agent_type:"test" in
-  Alcotest.(check bool) "keeper-*-agent name detected" true is_keeper_by_name;
+  Alcotest.(check bool) "keeper-*-agent name alone rejected" false is_keeper_by_name;
 
   (* Neither name nor type matches *)
   let not_keeper = Workspace_resilience.Zombie.is_keeper ~name:"regular-bot" ~agent_type:"claude" in

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1401,6 +1401,88 @@ let test_audit_orphan_nonkeeper_uses_default_threshold () =
       (List.length orphans)
   )
 
+(* A keeper-shaped non-keeper (name matches the pattern, but agent_type is not
+   "keeper" and the record is not keeper-owned) must use the ordinary 300s
+   threshold, not the 3600s keeper grace. Regression for review follow-up. *)
+let test_audit_orphan_detects_keeper_shaped_non_keeper () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Spoof task" ~priority:1 ~description:"" in
+    let spoof = "keeper-spoof-agent" in
+    let _ = Workspace.bind_session config ~agent_name:spoof ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:spoof ~task_id:"task-001" in
+    age_active_agent config ~agent_type:"spoof" ~name:spoof ~age_seconds:600.0;
+    let orphans = Workspace.audit_orphan_tasks config in
+    Alcotest.(check int)
+      "keeper-shaped non-keeper past default threshold is an orphan"
+      1
+      (List.length orphans);
+    let (_, assignee) = List.hd orphans in
+    Alcotest.(check string) "orphan assignee is the spoof worker" spoof assignee
+  )
+
+(* An agent whose record is stamped as keeper-owned (via meta.keeper_name)
+   gets the keeper threshold even when its agent_type is not "keeper". *)
+let test_audit_orphan_spares_keeper_owned_meta_within_grace () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Keeper-owned task" ~priority:1 ~description:"" in
+    let worker = "claude-runtime-agent" in
+    let _ = Workspace.bind_session config ~agent_name:worker ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:worker ~task_id:"task-001" in
+    age_active_agent config ~agent_type:"claude" ~name:worker ~age_seconds:600.0;
+    Workspace.update_local_agent_state config ~agent_name:worker (fun agent ->
+      let open Masc_domain in
+      let meta =
+        match agent.meta with
+        | Some m -> { m with keeper_name = Some "keeper-sangsu" }
+        | None ->
+          { session_id = ""
+          ; agent_type = agent.agent_type
+          ; pid = None
+          ; hostname = None
+          ; tty = None
+          ; parent_task = None
+          ; keeper_name = Some "keeper-sangsu"
+          ; keeper_id = None
+          }
+      in
+      { agent with meta = Some meta });
+    let orphans = Workspace.audit_orphan_tasks config in
+    Alcotest.(check int)
+      "keeper-owned worker within grace is not an orphan"
+      0
+      (List.length orphans)
+  )
+
+let keeper_meta_for_self_filter agent_name =
+  let json =
+    `Assoc
+      [ ("name", `String "self-filter-keeper")
+      ; ("agent_name", `String agent_name)
+      ; ("trace_id", `String "trace-self-filter")
+      ; ("goal", `String "self-filter regression")
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> { meta with active_goal_ids = [] }
+  | Error err -> Alcotest.fail ("keeper_meta_for_self_filter failed: " ^ err)
+
+(* Keepers can claim without a materialized [.masc/agents/] record. The keeper
+   backlog failed-task count must exclude the keeper's own claimed task so it
+   does not re-trigger a self-wake loop. *)
+let test_read_backlog_counts_excludes_self_owned_orphan () =
+  with_test_env (fun config ->
+    let keeper = "keeper-self-filter-agent" in
+    let _ = Workspace.bind_session config ~agent_name:keeper ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:keeper ~task_id:"task-001" in
+    (* Remove the agent file to simulate a keeper with no active registry record. *)
+    let _ = Workspace.end_session config ~agent_name:keeper in
+    let meta = keeper_meta_for_self_filter keeper in
+    let _, _, failed, _, _ =
+      Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
+    in
+    Alcotest.(check int) "keeper's own orphan excluded from failed count" 0 failed
+  )
+
 let test_cleanup_zombies_releases_tasks () =
   with_test_env (fun config ->
     let _ = Workspace.add_task config ~title:"Zombie Task" ~priority:1 ~description:"" in
@@ -1887,6 +1969,12 @@ let () =
         test_audit_orphan_detects_dead_keeper_beyond_grace;
       Alcotest.test_case "audit orphan non-keeper uses default threshold" `Quick
         test_audit_orphan_nonkeeper_uses_default_threshold;
+      Alcotest.test_case "audit orphan detects keeper-shaped non-keeper" `Quick
+        test_audit_orphan_detects_keeper_shaped_non_keeper;
+      Alcotest.test_case "audit orphan spares keeper-owned meta within grace" `Quick
+        test_audit_orphan_spares_keeper_owned_meta_within_grace;
+      Alcotest.test_case "read backlog counts excludes self-owned orphan" `Quick
+        test_read_backlog_counts_excludes_self_owned_orphan;
       Alcotest.test_case "cleanup zombies runtime" `Quick test_cleanup_zombies_releases_tasks;
     ];
 


### PR DESCRIPTION
Addresses the two unresolved review threads on #21496.

- lib/keeper/keeper_world_observation_inputs.ml: keep the current keeper's own claimed task out of the failed-task count, since keepers can claim without a materialized `.masc/agents/` record.
- lib/workspace/workspace_query.ml: apply the longer keeper zombie grace only to actual keeper presence (`agent_type="keeper"` or keeper-owned meta), not to every keeper-shaped worker name.
