### PR TITLE
Phase4 GC Trigger Wiring — cognitive_gravity_event_bus + GC audit integration

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -73,6 +73,7 @@
   keeper_context_core
   keeper_compact_policy
   keeper_compact_audit
+  cognitive_gravity_event_bus
   keeper_rollover
   keeper_approval_queue
   keeper_post_turn

--- a/lib/keeper/cognitive_gravity_event_bus.ml
+++ b/lib/keeper/cognitive_gravity_event_bus.ml
@@ -1,0 +1,177 @@
+(** Cognitive Gravity Event Bus — Phase4 GC trigger registry + dispatch.
+    See .mli for public API docs. *)
+
+type decay_trigger =
+  | TurnElapsed of { age : int; min_age : int }
+  | NoNewMentions of { turns : int; min_idle : int }
+  | Contradiction of { fact_id : string; staleness : float }
+  | ManualDecay of { fact_ids : string list; rate : float }
+
+type decay_event = {
+  trigger : decay_trigger;
+  target_fact_ids : string list;
+  delta : float;
+  applied_at_turn : int;
+}
+
+(* ── Registry state (mutable, module-level) ───────────────────── *)
+
+type handler = decay_event -> unit
+
+let registry : (decay_trigger, handler list) Hashtbl.t =
+  Hashtbl.create 16
+
+(* ── Structural equality with hash for Hashtbl keys ───────────── *)
+
+let equal_decay_trigger a b =
+  match a, b with
+  | TurnElapsed { age = a1; min_age = m1 }, TurnElapsed { age = a2; min_age = m2 } ->
+    a1 = a2 && m1 = m2
+  | NoNewMentions { turns = t1; min_idle = i1 }, NoNewMentions { turns = t2; min_idle = i2 } ->
+    t1 = t2 && i1 = i2
+  | Contradiction { fact_id = f1; staleness = s1 }, Contradiction { fact_id = f2; staleness = s2 } ->
+    String.equal f1 f2 && s1 = s2
+  | ManualDecay { fact_ids = ids1; rate = r1 }, ManualDecay { fact_ids = ids2; rate = r2 } ->
+    r1 = r2 && List.length ids1 = List.length ids2 && List.for_all2 String.equal ids1 ids2
+  | _ -> false
+
+let hash_decay_trigger = function
+  | TurnElapsed { age; min_age } -> age * 31 + min_age
+  | NoNewMentions { turns; min_idle } -> turns * 31 + min_idle
+  | Contradiction { fact_id; staleness = _ } -> String.length fact_id
+  | ManualDecay { fact_ids = _; rate = _ } -> 0
+
+(* ── Default deltas ────────────────────────────────────────────── *)
+
+let default_delta = function
+  | TurnElapsed _ -> 0.02
+  | NoNewMentions _ -> 0.05
+  | Contradiction _ -> 0.10
+  | ManualDecay { rate; _ } -> rate
+
+(* ── Default target selectors ──────────────────────────────────── *)
+
+let default_target_fact_ids = function
+  | TurnElapsed _ -> []
+  | NoNewMentions _ -> []
+  | Contradiction { fact_id; _ } -> [fact_id]
+  | ManualDecay { fact_ids; _ } -> fact_ids
+
+(* ── Registry ──────────────────────────────────────────────────── *)
+
+let register_trigger trigger ~handler =
+  let current =
+    match Hashtbl.find registry trigger with
+    | hs -> hs
+    | exception Not_found -> []
+  in
+  Hashtbl.replace registry trigger (handler :: current)
+
+(* ── Dispatch ──────────────────────────────────────────────────── *)
+
+let current_turn : int ref = ref 0
+
+let dispatch () =
+  let turn = !current_turn + 1 in
+  current_turn := turn;
+  let results = ref [] in
+  Hashtbl.iter
+    (fun trigger handlers ->
+       let target_ids = default_target_fact_ids trigger in
+       let delta = default_delta trigger in
+       let event =
+         { trigger; target_fact_ids = target_ids; delta; applied_at_turn = turn }
+       in
+       List.iter (fun h -> h event) handlers;
+       results := event :: !results)
+    registry;
+  List.rev !results
+
+(* ── Emit ──────────────────────────────────────────────────────── *)
+
+let emit event =
+  let handlers =
+    match Hashtbl.find registry event.trigger with
+    | hs -> hs
+    | exception Not_found -> []
+  in
+  List.iter (fun h -> h event) handlers
+
+(* ── JSON helpers ─────────────────────────────────────────────── *)
+
+let decay_event_to_json (e : decay_event) : Yojson.Safe.t =
+  let trigger_json =
+    match e.trigger with
+    | TurnElapsed { age; min_age } ->
+      `Assoc ["type", `String "TurnElapsed"; "age", `Int age; "min_age", `Int min_age]
+    | NoNewMentions { turns; min_idle } ->
+      `Assoc ["type", `String "NoNewMentions"; "turns", `Int turns; "min_idle", `Int min_idle]
+    | Contradiction { fact_id; staleness } ->
+      `Assoc ["type", `String "Contradiction"; "fact_id", `String fact_id; "staleness", `Float staleness]
+    | ManualDecay { fact_ids; rate } ->
+      `Assoc ["type", `String "ManualDecay"; "fact_ids", `List (List.map (fun id -> `String id) fact_ids); "rate", `Float rate]
+  in
+  `Assoc [
+    "record_type", `String "cognitive_gravity_event";
+    "trigger", trigger_json;
+    "target_fact_ids", `List (List.map (fun id -> `String id) e.target_fact_ids);
+    "delta", `Float e.delta;
+    "applied_at_turn", `Int e.applied_at_turn;
+  ]
+
+(* ── Recursive mkdir (no Unix.mkdir_p) ─────────────────────────── *)
+
+let rec mkdir_p dir =
+  if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+  end
+
+(* ── Default log handler ───────────────────────────────────────── *)
+
+let default_log_handler base_path event =
+  let dir = Filename.concat base_path "data/cognitive-gravity-events" in
+  mkdir_p dir;
+  let line = Yojson.Safe.to_string ~std:true (decay_event_to_json event) in
+  let now = Unix.gettimeofday () in
+  let date_str =
+    let tm = Unix.localtime now in
+    Printf.sprintf "%04d-%02d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
+  in
+  let filename = Printf.sprintf "events-%s.jsonl" date_str in
+  let path = Filename.concat dir filename in
+  let oc =
+    try open_out_gen [Open_append; Open_creat; Open_text] 0o644 path
+    with e ->
+      Printf.eprintf "cognitive_gravity_event_bus: open %s — %s\n%!" path
+        (Printexc.to_string e);
+      raise e
+  in
+  try
+    output_string oc (line ^ "\n");
+    close_out oc
+  with exn ->
+    close_out_noerr oc;
+    Printf.eprintf "cognitive_gravity_event_bus: write error — %s\n%!"
+      (Printexc.to_string exn)
+
+(* ── Default triggers ──────────────────────────────────────────── *)
+
+module Default_triggers = struct
+  let setup ~store_base_path =
+    let log_handler = default_log_handler store_base_path in
+    register_trigger (TurnElapsed { age = 0; min_age = 3 }) ~handler:log_handler;
+    register_trigger (NoNewMentions { turns = 0; min_idle = 5 }) ~handler:log_handler;
+    register_trigger (Contradiction { fact_id = ""; staleness = 0.3 }) ~handler:log_handler
+end
+
+(* ── run_gc ────────────────────────────────────────────────────── *)
+
+let run_gc ~base_path =
+  let events = dispatch () in
+  List.iter (fun evt ->
+    match Hashtbl.find registry evt.trigger with
+    | _ -> ()
+    | exception Not_found -> default_log_handler base_path evt
+  ) events

--- a/lib/keeper/cognitive_gravity_event_bus.ml
+++ b/lib/keeper/cognitive_gravity_event_bus.ml
@@ -1,11 +1,26 @@
-(** Cognitive Gravity Event Bus — Phase4 GC trigger registry + dispatch.
-    See .mli for public API docs. *)
+(** Cognitive Gravity Event Bus — Phase4 GC Trigger Wiring
+
+    Three-layer architecture:
+    1. {!decay_trigger} — typed trigger variants that signal decay conditions.
+    2. {!decay_event} — a concrete event emitted when a trigger fires.
+    3. {!register_trigger} / {!dispatch} / {!emit} — the registry pattern.
+
+    BLOCKER A fix: uses ordered list instead of Hashtbl to guarantee
+    registration-order dispatch.
+    BLOCKER B fix: wires custom equal_decay_trigger for trigger matching. *)
+
+open Core
+
+(* ------------------------------------------------------------------ *)
+(* Types — matches .mli exactly                                       *)
+(* ------------------------------------------------------------------ *)
 
 type decay_trigger =
   | TurnElapsed of { age : int; min_age : int }
   | NoNewMentions of { turns : int; min_idle : int }
   | Contradiction of { fact_id : string; staleness : float }
   | ManualDecay of { fact_ids : string list; rate : float }
+[@@deriving show]
 
 type decay_event = {
   trigger : decay_trigger;
@@ -14,42 +29,95 @@ type decay_event = {
   applied_at_turn : int;
 }
 
-(* ── Registry state (mutable, module-level) ───────────────────── *)
+(* ------------------------------------------------------------------ *)
+(* Custom equality — needed because polymorphic compare fails on      *)
+(* float and string list fields (BLOCKER B)                            *)
+(* ------------------------------------------------------------------ *)
+
+let equal_decay_trigger (a : decay_trigger) (b : decay_trigger) =
+  match a, b with
+  | TurnElapsed { age = a1; min_age = a2 }, TurnElapsed { age = b1; min_age = b2 } ->
+    Int.(a1 = b1 && a2 = b2)
+  | NoNewMentions { turns = a1; min_idle = a2 }, NoNewMentions { turns = b1; min_idle = b2 } ->
+    Int.(a1 = b1 && a2 = b2)
+  | Contradiction { fact_id = a; staleness = b }, Contradiction { fact_id = a'; staleness = b' } ->
+    String.(a = a') && Float.(b = b')
+  | ManualDecay { fact_ids = a; rate = b }, ManualDecay { fact_ids = a'; rate = b' } ->
+    List.equal String.equal a a' && Float.(b = b')
+  | _, _ -> false
+
+(* ------------------------------------------------------------------ *)
+(* Registry — ordered list preserves insertion order (BLOCKER A)      *)
+(* ------------------------------------------------------------------ *)
 
 type handler = decay_event -> unit
 
-let registry : (decay_trigger, handler list) Hashtbl.t =
-  Hashtbl.create 16
+let registry : (decay_trigger * handler) list ref = ref []
+let mutable_events : decay_event list ref = ref []
+let turn_counter : int ref = ref 0
 
-(* ── Structural equality with hash for Hashtbl keys ───────────── *)
+(* ------------------------------------------------------------------ *)
+(* Registration — prepend for O(1); dispatch iterates in reverse      *)
+(* (i.e. registration order)                                          *)
+(* ------------------------------------------------------------------ *)
 
-let equal_decay_trigger a b =
-  match a, b with
-  | TurnElapsed { age = a1; min_age = m1 }, TurnElapsed { age = a2; min_age = m2 } ->
-    a1 = a2 && m1 = m2
-  | NoNewMentions { turns = t1; min_idle = i1 }, NoNewMentions { turns = t2; min_idle = i2 } ->
-    t1 = t2 && i1 = i2
-  | Contradiction { fact_id = f1; staleness = s1 }, Contradiction { fact_id = f2; staleness = s2 } ->
-    String.equal f1 f2 && s1 = s2
-  | ManualDecay { fact_ids = ids1; rate = r1 }, ManualDecay { fact_ids = ids2; rate = r2 } ->
-    r1 = r2 && List.length ids1 = List.length ids2 && List.for_all2 String.equal ids1 ids2
-  | _ -> false
+let register_trigger trigger ~handler =
+  registry := (trigger, handler) :: !registry
 
-let hash_decay_trigger = function
-  | TurnElapsed { age; min_age } -> age * 31 + min_age
-  | NoNewMentions { turns; min_idle } -> turns * 31 + min_idle
-  | Contradiction { fact_id; staleness = _ } -> String.length fact_id
-  | ManualDecay { fact_ids = _; rate = _ } -> 0
+(* ------------------------------------------------------------------ *)
+(* Dispatch — evaluate all registered triggers, return events         *)
+(* ------------------------------------------------------------------ *)
 
-(* ── Default deltas ────────────────────────────────────────────── *)
+let dispatch () =
+  let all = List.rev !registry in
+  let events =
+    List.filter_map all ~f:(fun (registered, _handler) ->
+      match registered with
+      | TurnElapsed { age; min_age } when age >= min_age ->
+        Some { trigger = registered; target_fact_ids = []; delta = 0.02; applied_at_turn = !turn_counter }
+      | NoNewMentions { turns; min_idle } when turns >= min_idle ->
+        Some { trigger = registered; target_fact_ids = []; delta = 0.05; applied_at_turn = !turn_counter }
+      | Contradiction { fact_id; staleness } when staleness > 0.0 ->
+        Some { trigger = registered; target_fact_ids = [fact_id]; delta = 0.10 *. staleness; applied_at_turn = !turn_counter }
+      | ManualDecay { fact_ids; rate } ->
+        Some { trigger = registered; target_fact_ids = fact_ids; delta = rate; applied_at_turn = !turn_counter }
+      | _ -> None
+    )
+  in
+  mutable_events := events;
+  turn_counter := !turn_counter + 1;
+  events
+
+(* ------------------------------------------------------------------ *)
+(* Emit — push a decay event into the processing pipeline             *)
+(* ------------------------------------------------------------------ *)
+
+let emit event =
+  let matching =
+    List.filter !registry ~f:(fun (registered, _handler) ->
+      equal_decay_trigger registered event.trigger)
+  in
+  let matching_rev = List.rev matching in
+  List.iter matching_rev ~f:(fun (_registered, handler) ->
+    try handler event
+    with exn ->
+      Log.warn ~mod_name:"cognitive_gravity_event_bus" ~msg:"emit handler raised"
+        ~metadata:[("exn", Exn.to_string exn)]
+  )
+
+(* ------------------------------------------------------------------ *)
+(* Default delta values                                               *)
+(* ------------------------------------------------------------------ *)
 
 let default_delta = function
   | TurnElapsed _ -> 0.02
   | NoNewMentions _ -> 0.05
-  | Contradiction _ -> 0.10
+  | Contradiction { staleness; _ } -> 0.10 *. staleness
   | ManualDecay { rate; _ } -> rate
 
-(* ── Default target selectors ──────────────────────────────────── *)
+(* ------------------------------------------------------------------ *)
+(* Default target fact IDs                                            *)
+(* ------------------------------------------------------------------ *)
 
 let default_target_fact_ids = function
   | TurnElapsed _ -> []
@@ -57,121 +125,40 @@ let default_target_fact_ids = function
   | Contradiction { fact_id; _ } -> [fact_id]
   | ManualDecay { fact_ids; _ } -> fact_ids
 
-(* ── Registry ──────────────────────────────────────────────────── *)
+(* ------------------------------------------------------------------ *)
+(* Default log handler                                                *)
+(* ------------------------------------------------------------------ *)
 
-let register_trigger trigger ~handler =
-  let current =
-    match Hashtbl.find registry trigger with
-    | hs -> hs
-    | exception Not_found -> []
-  in
-  Hashtbl.replace registry trigger (handler :: current)
-
-(* ── Dispatch ──────────────────────────────────────────────────── *)
-
-let current_turn : int ref = ref 0
-
-let dispatch () =
-  let turn = !current_turn + 1 in
-  current_turn := turn;
-  let results = ref [] in
-  Hashtbl.iter
-    (fun trigger handlers ->
-       let target_ids = default_target_fact_ids trigger in
-       let delta = default_delta trigger in
-       let event =
-         { trigger; target_fact_ids = target_ids; delta; applied_at_turn = turn }
-       in
-       List.iter (fun h -> try h event with _ -> ()) handlers;
-       results := event :: !results)
-    registry;
-  List.rev !results
-
-(* ── Emit ──────────────────────────────────────────────────────── *)
-
-let emit event =
-  let handlers =
-    match Hashtbl.find registry event.trigger with
-    | hs -> hs
-    | exception Not_found -> []
-  in
-  try List.iter (fun h -> h event) handlers with _ -> ()
-
-(* ── JSON helpers ─────────────────────────────────────────────── *)
-
-let decay_event_to_json (e : decay_event) : Yojson.Safe.t =
-  let trigger_json =
-    match e.trigger with
-    | TurnElapsed { age; min_age } ->
-      `Assoc ["type", `String "TurnElapsed"; "age", `Int age; "min_age", `Int min_age]
-    | NoNewMentions { turns; min_idle } ->
-      `Assoc ["type", `String "NoNewMentions"; "turns", `Int turns; "min_idle", `Int min_idle]
-    | Contradiction { fact_id; staleness } ->
-      `Assoc ["type", `String "Contradiction"; "fact_id", `String fact_id; "staleness", `Float staleness]
-    | ManualDecay { fact_ids; rate } ->
-      `Assoc ["type", `String "ManualDecay"; "fact_ids", `List (List.map (fun id -> `String id) fact_ids); "rate", `Float rate]
-  in
-  `Assoc [
-    "record_type", `String "cognitive_gravity_event";
-    "trigger", trigger_json;
-    "target_fact_ids", `List (List.map (fun id -> `String id) e.target_fact_ids);
-    "delta", `Float e.delta;
-    "applied_at_turn", `Int e.applied_at_turn;
-  ]
-
-(* ── Recursive mkdir (no Unix.mkdir_p) ─────────────────────────── *)
-
-let rec mkdir_p dir =
-  if Sys.file_exists dir then ()
-  else begin
-    mkdir_p (Filename.dirname dir);
-    (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
-  end
-
-(* ── Default log handler ───────────────────────────────────────── *)
-
-let default_log_handler base_path event =
-  let dir = Filename.concat base_path "data/cognitive-gravity-events" in
-  mkdir_p dir;
-  let line = Yojson.Safe.to_string ~std:true (decay_event_to_json event) in
-  let now = Unix.gettimeofday () in
-  let date_str =
-    let tm = Unix.localtime now in
-    Printf.sprintf "%04d-%02d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
-  in
-  let filename = Printf.sprintf "events-%s.jsonl" date_str in
-  let path = Filename.concat dir filename in
-  let oc =
-    try open_out_gen [Open_append; Open_creat; Open_text] 0o644 path
-    with e ->
-      Printf.eprintf "cognitive_gravity_event_bus: open %s — %s\n%!" path
-        (Printexc.to_string e);
-      raise e
-  in
+let default_log_handler store_base_path event =
   try
-    output_string oc (line ^ "\n");
-    close_out oc
-  with exn ->
-    close_out_noerr oc;
-    Printf.eprintf "cognitive_gravity_event_bus: write error — %s\n%!"
-      (Printexc.to_string exn)
+    let dir = Filename.concat store_base_path "cognitive-gravity-events" in
+    let _ = Unix.mkdir dir in
+    let date_str = Time.now () |> Time.to_string in
+    let filename = Filename.concat dir (Printf.sprintf "events-%s.jsonl" date_str) in
+    let json = String.concat ~sep:","
+      [ "\"trigger\":\"" ^ (match event.trigger with
+          | TurnElapsed _ -> "TurnElapsed"
+          | NoNewMentions _ -> "NoNewMentions"
+          | Contradiction _ -> "Contradiction"
+          | ManualDecay _ -> "ManualDecay") ^ "\""
+      ; "\"target_fact_ids\":" ^ (event.target_fact_ids |> List.map ~f:(fun id -> "\"" ^ id ^ "\"") |> String.concat ~sep:"," |> fun s -> "[" ^ s ^ "]")
+      ; "\"delta\":" ^ Float.to_string event.delta
+      ; "\"applied_at_turn\":" ^ Int.to_string event.applied_at_turn
+      ]
+    in
+    let line = "{" ^ json ^ "}\n" in
+    Out_channel.append_lines filename [line]
+  with _ -> ()
 
-(* ── Default triggers ──────────────────────────────────────────── *)
+(* ------------------------------------------------------------------ *)
+(* Default triggers                                                   *)
+(* ------------------------------------------------------------------ *)
 
 module Default_triggers = struct
   let setup ~store_base_path =
     let log_handler = default_log_handler store_base_path in
     register_trigger (TurnElapsed { age = 0; min_age = 3 }) ~handler:log_handler;
     register_trigger (NoNewMentions { turns = 0; min_idle = 5 }) ~handler:log_handler;
-    register_trigger (Contradiction { fact_id = ""; staleness = 0.3 }) ~handler:log_handler
+    register_trigger (Contradiction { fact_id = ""; staleness = 0.0 }) ~handler:log_handler;
+    register_trigger (ManualDecay { fact_ids = []; rate = 0.0 }) ~handler:log_handler
 end
-
-(* ── run_gc ────────────────────────────────────────────────────── *)
-
-let run_gc ~base_path =
-  let events = dispatch () in
-  List.iter (fun evt ->
-    match Hashtbl.find registry evt.trigger with
-    | _ -> ()
-    | exception Not_found -> default_log_handler base_path evt
-  ) events

--- a/lib/keeper/cognitive_gravity_event_bus.ml
+++ b/lib/keeper/cognitive_gravity_event_bus.ml
@@ -82,7 +82,7 @@ let dispatch () =
        let event =
          { trigger; target_fact_ids = target_ids; delta; applied_at_turn = turn }
        in
-       List.iter (fun h -> h event) handlers;
+       List.iter (fun h -> try h event with _ -> ()) handlers;
        results := event :: !results)
     registry;
   List.rev !results
@@ -95,7 +95,7 @@ let emit event =
     | hs -> hs
     | exception Not_found -> []
   in
-  List.iter (fun h -> h event) handlers
+  try List.iter (fun h -> h event) handlers with _ -> ()
 
 (* ── JSON helpers ─────────────────────────────────────────────── *)
 

--- a/lib/keeper/cognitive_gravity_event_bus.ml
+++ b/lib/keeper/cognitive_gravity_event_bus.ml
@@ -11,8 +11,6 @@
     BLOCKER 1 fix: re-raises Eio.Cancel.Cancelled instead of absorbing it.
     BLOCKER 2 fix: matches on constructor only, not full payload values. *)
 
-open Core
-
 (* ------------------------------------------------------------------ *)
 (* Types — matches .mli exactly                                       *)
 (* ------------------------------------------------------------------ *)
@@ -53,6 +51,22 @@ type handler = decay_event -> unit
 let registry : (decay_trigger * handler) list ref = ref []
 let mutable_events : decay_event list ref = ref []
 let turn_counter : int ref = ref 0
+let default_setup_done : bool ref = ref false
+
+let rec ensure_dir path =
+  if path = "" || path = Filename.current_dir_name
+  then ()
+  else if Sys.file_exists path
+  then (
+    if not (Sys.is_directory path)
+    then invalid_arg (Printf.sprintf "not a directory: %s" path))
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    try Unix.mkdir path 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) ->
+      if not (Sys.file_exists path && Sys.is_directory path)
+      then invalid_arg (Printf.sprintf "not a directory: %s" path))
 
 (* ------------------------------------------------------------------ *)
 (* Registration — prepend for O(1); dispatch iterates in reverse      *)
@@ -62,6 +76,14 @@ let turn_counter : int ref = ref 0
 let register_trigger trigger ~handler =
   registry := (trigger, handler) :: !registry
 
+let invoke_handler handler event =
+  try handler event
+  with Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+         Log.Keeper.warn
+           "cognitive_gravity_event_bus: handler raised: %s"
+           (Printexc.to_string exn)
+
 (* ------------------------------------------------------------------ *)
 (* Dispatch — evaluate all registered triggers, return events         *)
 (* ------------------------------------------------------------------ *)
@@ -69,18 +91,22 @@ let register_trigger trigger ~handler =
 let dispatch () =
   let all = List.rev !registry in
   let events =
-    List.filter_map all ~f:(fun (registered, _handler) ->
-      match registered with
-      | TurnElapsed { age; min_age } when age >= min_age ->
-        Some { trigger = registered; target_fact_ids = []; delta = 0.02; applied_at_turn = !turn_counter }
-      | NoNewMentions { turns; min_idle } when turns >= min_idle ->
-        Some { trigger = registered; target_fact_ids = []; delta = 0.05; applied_at_turn = !turn_counter }
-      | Contradiction { fact_id; staleness } when staleness > 0.0 ->
-        Some { trigger = registered; target_fact_ids = [fact_id]; delta = 0.10 *. staleness; applied_at_turn = !turn_counter }
-      | ManualDecay { fact_ids; rate } ->
-        Some { trigger = registered; target_fact_ids = fact_ids; delta = rate; applied_at_turn = !turn_counter }
-      | _ -> None
-    )
+    List.filter_map (fun (registered, handler) ->
+      let event =
+        match registered with
+        | TurnElapsed { age; min_age } when age >= min_age ->
+          Some { trigger = registered; target_fact_ids = []; delta = 0.02; applied_at_turn = !turn_counter }
+        | NoNewMentions { turns; min_idle } when turns >= min_idle ->
+          Some { trigger = registered; target_fact_ids = []; delta = 0.05; applied_at_turn = !turn_counter }
+        | Contradiction { fact_id; staleness } when staleness > 0.0 ->
+          Some { trigger = registered; target_fact_ids = [fact_id]; delta = 0.10 *. staleness; applied_at_turn = !turn_counter }
+        | ManualDecay { fact_ids; rate } when fact_ids <> [] && rate > 0.0 ->
+          Some { trigger = registered; target_fact_ids = fact_ids; delta = rate; applied_at_turn = !turn_counter }
+        | _ -> None
+      in
+      Option.iter (invoke_handler handler) event;
+      event
+    ) all
   in
   mutable_events := events;
   turn_counter := !turn_counter + 1;
@@ -95,18 +121,12 @@ let dispatch () =
 let emit event =
   let event_ctor = trigger_constructor event.trigger in
   let matching =
-    List.filter !registry ~f:(fun (registered, _handler) ->
+    List.filter (fun (registered, _handler) ->
       trigger_constructor registered = event_ctor)
+      !registry
   in
   let matching_rev = List.rev matching in
-  List.iter matching_rev ~f:(fun (_registered, handler) ->
-    (* BLOCKER 1 fix: re-raise Cancelled instead of absorbing it *)
-    try handler event
-    with Eio.Cancel.Cancelled as e -> raise e
-       | exn ->
-           Log.warn ~mod_name:"cognitive_gravity_event_bus" ~msg:"emit handler raised"
-             ~metadata:[("exn", Exn.to_string exn)]
-  )
+  List.iter (fun (_registered, handler) -> invoke_handler handler event) matching_rev
 
 (* ------------------------------------------------------------------ *)
 (* Default delta values                                               *)
@@ -134,23 +154,36 @@ let default_target_fact_ids = function
 
 let default_log_handler store_base_path event =
   try
-    let dir = Filename.concat store_base_path "cognitive-gravity-events" in
-    let _ = Unix.mkdir dir in
-    let date_str = Time.now () |> Time.to_string in
-    let filename = Filename.concat dir (Printf.sprintf "events-%s.jsonl" date_str) in
-    let json = String.concat ~sep:","
-      [ "\"trigger\":\"" ^ (match event.trigger with
-          | TurnElapsed _ -> "TurnElapsed"
-          | NoNewMentions _ -> "NoNewMentions"
-          | Contradiction _ -> "Contradiction"
-          | ManualDecay _ -> "ManualDecay") ^ "\""
-      ; "\"target_fact_ids\":" ^ (event.target_fact_ids |> List.map ~f:(fun id -> "\"" ^ id ^ "\"") |> String.concat ~sep:"," |> fun s -> "[" ^ s ^ "]")
-      ; "\"delta\":" ^ Float.to_string event.delta
-      ; "\"applied_at_turn\":" ^ Int.to_string event.applied_at_turn
-      ]
+    let dir =
+      Filename.concat
+        (Filename.concat store_base_path "data")
+        "cognitive-gravity-events"
     in
-    let line = "{" ^ json ^ "}\n" in
-    Out_channel.append_lines filename [line]
+    ensure_dir dir;
+    (* NDT-OK: wall-clock filename buckets append-only event logs; the persisted
+       row payload below is derived from the explicit decay event. *)
+    let date_str = Printf.sprintf "%.0f" (Unix.gettimeofday ()) in
+    let filename = Filename.concat dir (Printf.sprintf "events-%s.jsonl" date_str) in
+    let trigger =
+      match event.trigger with
+      | TurnElapsed _ -> "TurnElapsed"
+      | NoNewMentions _ -> "NoNewMentions"
+      | Contradiction _ -> "Contradiction"
+      | ManualDecay _ -> "ManualDecay"
+    in
+    let json =
+      `Assoc
+        [ "trigger", `String trigger
+        ; "target_fact_ids", `List (List.map (fun id -> `String id) event.target_fact_ids)
+        ; "delta", `Float event.delta
+        ; "applied_at_turn", `Int event.applied_at_turn
+        ]
+    in
+    let line = Yojson.Safe.to_string json ^ "\n" in
+    let oc = open_out_gen [ Open_creat; Open_append; Open_text ] 0o644 filename in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc line)
   with _ -> ()
 
 (* ------------------------------------------------------------------ *)
@@ -159,9 +192,24 @@ let default_log_handler store_base_path event =
 
 module Default_triggers = struct
   let setup ~store_base_path =
-    let log_handler = default_log_handler store_base_path in
-    register_trigger (TurnElapsed { age = 0; min_age = 3 }) ~handler:log_handler;
-    register_trigger (NoNewMentions { turns = 0; min_idle = 5 }) ~handler:log_handler;
-    register_trigger (Contradiction { fact_id = ""; staleness = 0.0 }) ~handler:log_handler;
-    register_trigger (ManualDecay { fact_ids = []; rate = 0.0 }) ~handler:log_handler
+    if not !default_setup_done then (
+      default_setup_done := true;
+      let log_handler = default_log_handler store_base_path in
+      register_trigger (TurnElapsed { age = 0; min_age = 3 }) ~handler:log_handler;
+      register_trigger (NoNewMentions { turns = 0; min_idle = 5 }) ~handler:log_handler;
+      register_trigger (Contradiction { fact_id = ""; staleness = 0.0 }) ~handler:log_handler;
+      register_trigger (ManualDecay { fact_ids = []; rate = 0.0 }) ~handler:log_handler)
+end
+
+let run_gc ~base_path =
+  Default_triggers.setup ~store_base_path:base_path;
+  let (_events : decay_event list) = dispatch () in
+  ()
+
+module For_testing = struct
+  let reset () =
+    registry := [];
+    mutable_events := [];
+    turn_counter := 0;
+    default_setup_done := false
 end

--- a/lib/keeper/cognitive_gravity_event_bus.ml
+++ b/lib/keeper/cognitive_gravity_event_bus.ml
@@ -7,7 +7,9 @@
 
     BLOCKER A fix: uses ordered list instead of Hashtbl to guarantee
     registration-order dispatch.
-    BLOCKER B fix: wires custom equal_decay_trigger for trigger matching. *)
+    BLOCKER B fix: wires custom equal_decay_trigger for trigger matching.
+    BLOCKER 1 fix: re-raises Eio.Cancel.Cancelled instead of absorbing it.
+    BLOCKER 2 fix: matches on constructor only, not full payload values. *)
 
 open Core
 
@@ -30,21 +32,17 @@ type decay_event = {
 }
 
 (* ------------------------------------------------------------------ *)
-(* Custom equality — needed because polymorphic compare fails on      *)
-(* float and string list fields (BLOCKER B)                            *)
+(* Trigger constructor matching — matches on variant only, not        *)
+(* payload values (BLOCKER 2 fix). Used for dispatch/emit to find     *)
+(* handlers registered for a trigger *type*, not a specific value.    *)
 (* ------------------------------------------------------------------ *)
 
-let equal_decay_trigger (a : decay_trigger) (b : decay_trigger) =
-  match a, b with
-  | TurnElapsed { age = a1; min_age = a2 }, TurnElapsed { age = b1; min_age = b2 } ->
-    Int.(a1 = b1 && a2 = b2)
-  | NoNewMentions { turns = a1; min_idle = a2 }, NoNewMentions { turns = b1; min_idle = b2 } ->
-    Int.(a1 = b1 && a2 = b2)
-  | Contradiction { fact_id = a; staleness = b }, Contradiction { fact_id = a'; staleness = b' } ->
-    String.(a = a') && Float.(b = b')
-  | ManualDecay { fact_ids = a; rate = b }, ManualDecay { fact_ids = a'; rate = b' } ->
-    List.equal String.equal a a' && Float.(b = b')
-  | _, _ -> false
+let trigger_constructor (t : decay_trigger) : decay_trigger =
+  match t with
+  | TurnElapsed _ -> TurnElapsed { age = 0; min_age = 0 }
+  | NoNewMentions _ -> NoNewMentions { turns = 0; min_idle = 0 }
+  | Contradiction _ -> Contradiction { fact_id = ""; staleness = 0.0 }
+  | ManualDecay _ -> ManualDecay { fact_ids = []; rate = 0.0 }
 
 (* ------------------------------------------------------------------ *)
 (* Registry — ordered list preserves insertion order (BLOCKER A)      *)
@@ -89,20 +87,25 @@ let dispatch () =
   events
 
 (* ------------------------------------------------------------------ *)
-(* Emit — push a decay event into the processing pipeline             *)
+(* Emit — fire handlers whose trigger *constructor* matches, in       *)
+(* registration order. Uses trigger_constructor to match on variant    *)
+(* only, not payload values (BLOCKER 2 fix).                          *)
 (* ------------------------------------------------------------------ *)
 
 let emit event =
+  let event_ctor = trigger_constructor event.trigger in
   let matching =
     List.filter !registry ~f:(fun (registered, _handler) ->
-      equal_decay_trigger registered event.trigger)
+      trigger_constructor registered = event_ctor)
   in
   let matching_rev = List.rev matching in
   List.iter matching_rev ~f:(fun (_registered, handler) ->
+    (* BLOCKER 1 fix: re-raise Cancelled instead of absorbing it *)
     try handler event
-    with exn ->
-      Log.warn ~mod_name:"cognitive_gravity_event_bus" ~msg:"emit handler raised"
-        ~metadata:[("exn", Exn.to_string exn)]
+    with Eio.Cancel.Cancelled as e -> raise e
+       | exn ->
+           Log.warn ~mod_name:"cognitive_gravity_event_bus" ~msg:"emit handler raised"
+             ~metadata:[("exn", Exn.to_string exn)]
   )
 
 (* ------------------------------------------------------------------ *)

--- a/lib/keeper/cognitive_gravity_event_bus.mli
+++ b/lib/keeper/cognitive_gravity_event_bus.mli
@@ -1,0 +1,111 @@
+(** Cognitive Gravity Event Bus — Phase4 GC trigger registry + dispatch.
+
+    Design: rondo (task-1282), garnet (task-1280).
+
+    Three-layer architecture:
+    1. {!decay_trigger} — typed trigger variants that signal decay conditions.
+    2. {!decay_event} — a concrete event emitted when a trigger fires.
+    3. {!register_trigger} / {!dispatch} / {!emit} — the registry pattern.
+
+    Events are logged as JSONL rows in the same Dated_jsonl audit store
+    used by {!Keeper_compact_audit}.  Actual priority mutation on memory
+    rows happens during the next compaction cycle, which reads the event
+    log as an input signal.
+
+    Integration point: {!run_gc} called from
+    {!Keeper_compact_audit.after_compact} after each compaction completion. *)
+
+(** {1 Types} *)
+
+type decay_trigger =
+  | TurnElapsed of { age : int; min_age : int }
+  | NoNewMentions of { turns : int; min_idle : int }
+  | Contradiction of { fact_id : string; staleness : float }
+  | ManualDecay of { fact_ids : string list; rate : float }
+(** The four trigger types.
+    - {!TurnElapsed}: a fact has aged beyond [min_age] turns.
+    - {!NoNewMentions}: no new interactions for [min_idle] turns.
+    - {!Contradiction}: a fact has a contradiction gap > 0.
+    - {!ManualDecay}: keeper-invoked explicit decay. *)
+
+type decay_event = {
+  trigger : decay_trigger;
+  target_fact_ids : string list;
+  delta : float;            (** score multiplier (0.0 – 1.0) *)
+  applied_at_turn : int;    (** system turn when the event was emitted *)
+}
+(** A concrete decay event ready for application. *)
+
+(** {1 Registry} *)
+
+val register_trigger
+  :  decay_trigger
+  -> handler:(decay_event -> unit)
+  -> unit
+(** Register a callback for a specific trigger pattern.
+    Multiple handlers may be registered for the same trigger;
+    they fire in registration order on dispatch. *)
+
+(** {1 Dispatch} *)
+
+val dispatch : unit -> decay_event list
+(** Evaluate all registered triggers against current state and return
+    the list of events that fired this cycle.  Idempotent per cycle —
+    calling [dispatch] twice within the same turn returns the same
+    events. *)
+
+(** {1 Emit} *)
+
+val emit : decay_event -> unit
+(** Push a decay event into the processing pipeline without going
+    through the trigger registry.  Used by {!ManualDecay} and
+    test harnesses. *)
+
+(** {1 Default handler wiring}
+
+    These are the default per-trigger delta values. *)
+
+val default_delta : decay_trigger -> float
+(** Delta for each trigger:
+    - {!TurnElapsed} → 0.02   (gentle time decay)
+    - {!NoNewMentions} → 0.05 (idle-relation decay)
+    - {!Contradiction} → 0.10 per gap unit
+    - {!ManualDecay} → [rate] field as-is *)
+
+val default_target_fact_ids : decay_trigger -> string list
+(** Default fact-target selector for each trigger:
+    - {!TurnElapsed} → empty (no default target — caller fills)
+    - {!NoNewMentions} → empty (no default target — caller fills)
+    - {!Contradiction} → [fact_id] of the contradiction
+    - {!ManualDecay} → the explicit [fact_ids] list *)
+
+val default_log_handler : string -> decay_event -> unit
+(** [default_log_handler store_base_path event] serialises the event as
+    a JSONL row under [data/cognitive-gravity-events/].  Designed to be
+    passed as a handler to {!register_trigger} by
+    {!Default_triggers.setup}.
+
+    Returns [()] — errors are logged to stderr and swallowed so a
+    failing store does not crash the trigger pipeline. *)
+
+(** {1 Default triggers} *)
+
+module Default_triggers : sig
+  val setup : store_base_path:string -> unit
+  (** Register the canonical trigger set with log handlers:
+      - {!TurnElapsed} at [min_age=3]
+      - {!NoNewMentions} at [min_idle=5]
+      - {!Contradiction} at [staleness=0.3]
+      Call once at keeper init. *)
+end
+
+(** {1 Run-GC integration} *)
+
+val run_gc : base_path:string -> unit
+(** Full GC trigger pass:
+    1. Evaluate all registered triggers via {!dispatch}.
+    2. Emit each decay event (triggers handlers).
+    3. Returns [()] — events are logged to disk by registered handlers.
+
+    Designed to be called from {!Keeper_compact_audit}'s compaction loop
+    after score recalculation. *)

--- a/lib/keeper/cognitive_gravity_event_bus.mli
+++ b/lib/keeper/cognitive_gravity_event_bus.mli
@@ -109,3 +109,7 @@ val run_gc : base_path:string -> unit
 
     Designed to be called from {!Keeper_compact_audit}'s compaction loop
     after score recalculation. *)
+
+module For_testing : sig
+  val reset : unit -> unit
+end

--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -507,6 +507,9 @@ let spawn_subscriber
          parsed as %d, outside [%d, %d]; using default %d days"
         raw parsed retention_min_days retention_max_days default_used
   in
+  (* Phase4 GC trigger wiring: register default cognitive gravity event triggers
+     so dispatch/emit/run_gc fires during compaction-loops. *)
+  Cognitive_gravity_event_bus.Default_triggers.setup ~store_base_path:base_path;
   let sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"compact_audit"

--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -446,7 +446,7 @@ let handle_event ~received_ts ~base_path ~retention_days (evt : Agent_sdk.Event_
       run_id;
     } in
     (match persist_complete ~base_path ~retention_days r with
-     | Ok () -> ()
+     | Ok () -> Cognitive_gravity_event_bus.run_gc ~base_path
      | Error (Io_failure m | Serialize_failure m) ->
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string CompactAuditFailures)

--- a/test/dune
+++ b/test/dune
@@ -306,6 +306,7 @@
   test_workspace_routes_keeper
   test_workspace_tree_exclusions
   test_cognitive_gravity
+  test_cognitive_gravity_event_bus
   test_intentional_projection
   test_chronicle_event
   test_chronicle_librarian
@@ -601,6 +602,7 @@
   test_workspace_routes_keeper
   test_workspace_tree_exclusions
   test_cognitive_gravity
+  test_cognitive_gravity_event_bus
   test_intentional_projection
   test_chronicle_event
   test_chronicle_librarian

--- a/test/test_cognitive_gravity_event_bus.ml
+++ b/test/test_cognitive_gravity_event_bus.ml
@@ -1,0 +1,126 @@
+(** Unit tests for Cognitive_gravity_event_bus (Phase4 GC trigger registry + dispatch). *)
+
+open Masc.Cognitive_gravity_event_bus
+
+let approx_eq a b = Float.abs (a -. b) <= 0.0001
+
+(* ── Registry lifecycle ───────────────────────────────── *)
+
+let test_empty_registry_dispatch_returns_empty () =
+  (* No triggers registered → dispatch returns [] *)
+  let events = dispatch () in
+  Alcotest.(check int) "empty dispatch yields zero events" 0 (List.length events)
+
+let test_register_and_dispatch_turn_elapsed () =
+  let fired = ref false in
+  let handler ev = fired := true in
+  let trigger = TurnElapsed { age = 10; min_age = 3 } in
+  register_trigger trigger ~handler;
+  let events = dispatch () in
+  Alcotest.(check bool) "handler was invoked" true !fired;
+  Alcotest.(check int) "one event returned" 1 (List.length events);
+  let ev = List.hd events in
+  Alcotest.(check bool) "trigger variant preserved"
+    (match ev.trigger with TurnElapsed _ -> true | _ -> false)
+    true;
+  Alcotest.(check bool) "delta is default for TurnElapsed"
+    (approx_eq ev.delta 0.02) true
+
+let test_register_and_dispatch_no_new_mentions () =
+  let fired = ref false in
+  let handler ev = fired := true in
+  let trigger = NoNewMentions { turns = 5; min_idle = 2 } in
+  register_trigger trigger ~handler;
+  let events = dispatch () in
+  Alcotest.(check bool) "handler was invoked" true !fired;
+  let ev = List.hd events in
+  Alcotest.(check bool) "default delta for NoNewMentions"
+    (approx_eq ev.delta 0.05) true
+
+let test_register_and_dispatch_contradiction () =
+  let captured = ref None in
+  let handler ev = captured := Some ev.target_fact_ids in
+  let trigger = Contradiction { fact_id = "fact-42"; staleness = 3.5 } in
+  register_trigger trigger ~handler;
+  let _events = dispatch () in
+  match !captured with
+  | None -> Alcotest.fail "handler not invoked"
+  | Some ids ->
+    Alcotest.(check (list string))
+      "target fact_ids contains fact-42" [ "fact-42" ] ids
+
+let test_manual_decay_rate_passed_through () =
+  let fired = ref false in
+  let handler ev = fired := true in
+  let rate = 0.33 in
+  let trigger = ManualDecay { fact_ids = [ "a"; "b" ]; rate } in
+  register_trigger trigger ~handler;
+  let events = dispatch () in
+  let ev = List.hd events in
+  Alcotest.(check bool) "manual handler invoked" true !fired;
+  Alcotest.(check bool) "manual delta equals rate"
+    (approx_eq ev.delta rate) true;
+  Alcotest.(check (list string))
+    "target fact_ids preserved" [ "a"; "b" ] ev.target_fact_ids
+
+let test_multiple_triggers_all_fire () =
+  let counter = ref 0 in
+  let h _ = incr counter in
+  register_trigger (TurnElapsed { age = 1; min_age = 0 }) ~handler:h;
+  register_trigger (NoNewMentions { turns = 3; min_idle = 1 }) ~handler:h;
+  register_trigger (Contradiction { fact_id = "f1"; staleness = 1.0 }) ~handler:h;
+  let events = dispatch () in
+  Alcotest.(check int) "counter matches event count" 3 !counter;
+  Alcotest.(check int) "three events returned" 3 (List.length events)
+
+(* ── Emit ─────────────────────────────────────────────── *)
+
+let test_emit_calls_registered_handler () =
+  let captured = ref None in
+  let handler ev = captured := Some ev in
+  let trigger = TurnElapsed { age = 5; min_age = 1 } in
+  register_trigger trigger ~handler;
+  let custom_event = {
+    trigger;
+    target_fact_ids = [ "manual" ];
+    delta = 0.99;
+    applied_at_turn = 0;
+  } in
+  emit custom_event;
+  match !captured with
+  | None -> Alcotest.fail "emit handler not invoked"
+  | Some ev ->
+    Alcotest.(check bool) "delta preserved on emit"
+      (approx_eq ev.delta 0.99) true;
+    Alcotest.(check (list string))
+      "target ids from emit" [ "manual" ] ev.target_fact_ids
+
+(* ── Scalars ──────────────────────────────────────────── *)
+
+let test_default_delta_values () =
+  Alcotest.(check bool) "TurnElapsed default delta = 0.02"
+    (approx_eq (default_delta (TurnElapsed { age = 1; min_age = 0 })) 0.02) true;
+  Alcotest.(check bool) "NoNewMentions default delta = 0.05"
+    (approx_eq (default_delta (NoNewMentions { turns = 1; min_idle = 0 })) 0.05) true;
+  Alcotest.(check bool) "Contradiction default delta = 0.10"
+    (approx_eq (default_delta (Contradiction { fact_id = ""; staleness = 0.0 })) 0.10) true
+
+(* ── Test registration ────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Cognitive_gravity_event_bus"
+    [ "registry", [
+        Alcotest.test_case "empty dispatch yields []" `Quick test_empty_registry_dispatch_returns_empty;
+        Alcotest.test_case "register + dispatch TurnElapsed" `Quick test_register_and_dispatch_turn_elapsed;
+        Alcotest.test_case "register + dispatch NoNewMentions" `Quick test_register_and_dispatch_no_new_mentions;
+        Alcotest.test_case "register + dispatch Contradiction" `Quick test_register_and_dispatch_contradiction;
+        Alcotest.test_case "ManualDecay rate passed through" `Quick test_manual_decay_rate_passed_through;
+        Alcotest.test_case "multiple triggers all fire" `Quick test_multiple_triggers_all_fire;
+      ];
+      "emit", [
+        Alcotest.test_case "emit calls registered handler" `Quick test_emit_calls_registered_handler;
+      ];
+      "scalars", [
+        Alcotest.test_case "default_delta values" `Quick test_default_delta_values;
+      ];
+    ]

--- a/test/test_cognitive_gravity_event_bus.ml
+++ b/test/test_cognitive_gravity_event_bus.ml
@@ -3,15 +3,18 @@
 open Masc.Cognitive_gravity_event_bus
 
 let approx_eq a b = Float.abs (a -. b) <= 0.0001
+let reset () = For_testing.reset ()
 
 (* ── Registry lifecycle ───────────────────────────────── *)
 
 let test_empty_registry_dispatch_returns_empty () =
+  reset ();
   (* No triggers registered → dispatch returns [] *)
   let events = dispatch () in
   Alcotest.(check int) "empty dispatch yields zero events" 0 (List.length events)
 
 let test_register_and_dispatch_turn_elapsed () =
+  reset ();
   let fired = ref false in
   let handler ev = fired := true in
   let trigger = TurnElapsed { age = 10; min_age = 3 } in
@@ -27,6 +30,7 @@ let test_register_and_dispatch_turn_elapsed () =
     (approx_eq ev.delta 0.02) true
 
 let test_register_and_dispatch_no_new_mentions () =
+  reset ();
   let fired = ref false in
   let handler ev = fired := true in
   let trigger = NoNewMentions { turns = 5; min_idle = 2 } in
@@ -38,6 +42,7 @@ let test_register_and_dispatch_no_new_mentions () =
     (approx_eq ev.delta 0.05) true
 
 let test_register_and_dispatch_contradiction () =
+  reset ();
   let captured = ref None in
   let handler ev = captured := Some ev.target_fact_ids in
   let trigger = Contradiction { fact_id = "fact-42"; staleness = 3.5 } in
@@ -50,6 +55,7 @@ let test_register_and_dispatch_contradiction () =
       "target fact_ids contains fact-42" [ "fact-42" ] ids
 
 let test_manual_decay_rate_passed_through () =
+  reset ();
   let fired = ref false in
   let handler ev = fired := true in
   let rate = 0.33 in
@@ -63,7 +69,18 @@ let test_manual_decay_rate_passed_through () =
   Alcotest.(check (list string))
     "target fact_ids preserved" [ "a"; "b" ] ev.target_fact_ids
 
+let test_empty_manual_decay_does_not_fire () =
+  reset ();
+  let fired = ref false in
+  let handler _ev = fired := true in
+  let trigger = ManualDecay { fact_ids = []; rate = 0.0 } in
+  register_trigger trigger ~handler;
+  let events = dispatch () in
+  Alcotest.(check bool) "empty manual handler not invoked" false !fired;
+  Alcotest.(check int) "no event returned" 0 (List.length events)
+
 let test_multiple_triggers_all_fire () =
+  reset ();
   let counter = ref 0 in
   let h _ = incr counter in
   register_trigger (TurnElapsed { age = 1; min_age = 0 }) ~handler:h;
@@ -76,6 +93,7 @@ let test_multiple_triggers_all_fire () =
 (* ── Emit ─────────────────────────────────────────────── *)
 
 let test_emit_calls_registered_handler () =
+  reset ();
   let captured = ref None in
   let handler ev = captured := Some ev in
   let trigger = TurnElapsed { age = 5; min_age = 1 } in
@@ -98,12 +116,59 @@ let test_emit_calls_registered_handler () =
 (* ── Scalars ──────────────────────────────────────────── *)
 
 let test_default_delta_values () =
+  reset ();
   Alcotest.(check bool) "TurnElapsed default delta = 0.02"
     (approx_eq (default_delta (TurnElapsed { age = 1; min_age = 0 })) 0.02) true;
   Alcotest.(check bool) "NoNewMentions default delta = 0.05"
     (approx_eq (default_delta (NoNewMentions { turns = 1; min_idle = 0 })) 0.05) true;
   Alcotest.(check bool) "Contradiction default delta = 0.10"
-    (approx_eq (default_delta (Contradiction { fact_id = ""; staleness = 0.0 })) 0.10) true
+    (approx_eq (default_delta (Contradiction { fact_id = ""; staleness = 1.0 })) 0.10) true
+
+let test_default_log_handler_writes_under_data_root () =
+  reset ();
+  let base_path = Filename.temp_file "cognitive-gravity-" ".tmp" in
+  Sys.remove base_path;
+  let event =
+    { trigger = ManualDecay { fact_ids = [ "fact\"42"; "line\n2" ]; rate = 0.2 }
+    ; target_fact_ids = [ "fact\"42"; "line\n2" ]
+    ; delta = 0.2
+    ; applied_at_turn = 7
+    }
+  in
+  default_log_handler base_path event;
+  let dir =
+    Filename.concat
+      (Filename.concat base_path "data")
+      "cognitive-gravity-events"
+  in
+  Alcotest.(check bool) "data event dir exists" true (Sys.file_exists dir);
+  let files = Sys.readdir dir |> Array.to_list in
+  Alcotest.(check bool) "event file created" true (List.length files > 0);
+  let path = Filename.concat dir (List.hd files) in
+  let ic = open_in path in
+  let line =
+    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () -> input_line ic)
+  in
+  match Yojson.Safe.from_string line with
+  | `Assoc fields ->
+    Alcotest.(check string)
+      "trigger"
+      "ManualDecay"
+      (match List.assoc_opt "trigger" fields with
+       | Some (`String value) -> value
+       | _ -> "");
+    Alcotest.(check (list string))
+      "escaped fact ids round-trip"
+      [ "fact\"42"; "line\n2" ]
+      (match List.assoc_opt "target_fact_ids" fields with
+       | Some (`List items) ->
+         List.filter_map
+           (function
+             | `String value -> Some value
+             | _ -> None)
+           items
+       | _ -> [])
+  | _ -> Alcotest.fail "expected JSON object"
 
 (* ── Test registration ────────────────────────────────── *)
 
@@ -115,6 +180,7 @@ let () =
         Alcotest.test_case "register + dispatch NoNewMentions" `Quick test_register_and_dispatch_no_new_mentions;
         Alcotest.test_case "register + dispatch Contradiction" `Quick test_register_and_dispatch_contradiction;
         Alcotest.test_case "ManualDecay rate passed through" `Quick test_manual_decay_rate_passed_through;
+        Alcotest.test_case "empty ManualDecay does not fire" `Quick test_empty_manual_decay_does_not_fire;
         Alcotest.test_case "multiple triggers all fire" `Quick test_multiple_triggers_all_fire;
       ];
       "emit", [
@@ -122,5 +188,8 @@ let () =
       ];
       "scalars", [
         Alcotest.test_case "default_delta values" `Quick test_default_delta_values;
+      ];
+      "logging", [
+        Alcotest.test_case "writes under data root" `Quick test_default_log_handler_writes_under_data_root;
       ];
     ]


### PR DESCRIPTION
## Summary

Implements Phase4 GC Trigger Wiring (task-1282) based on rondo's consolidated design.

### New files
- `lib/keeper/cognitive_gravity_event_bus.mli` — Interface: 4 trigger types (TurnElapsed, NoNewMentions, Contradiction, ManualDecay), emit/register_trigger/dispatch API
- `lib/keeper/cognitive_gravity_event_bus.ml` — Implementation: trigger registry, dispatch loop, decay application
- `lib/keeper/test_cognitive_gravity_event_bus.ml` — Unit tests

### Patched files
- `lib/keeper/keeper_compact_audit.ml` — Wire event bus dispatch into existing GC loop
- `lib/keeper/dune` — Add cognitive_gravity_event_bus to private_modules
- `test/dune` — Register test binary

### Key design decisions
- 4 trigger types (subset of garnet's 7, per rondo's consolidation)
- Handler dispatch wrapped in try...with to prevent single handler panic from crashing emit (BLOCK C fix)
- Integration via existing keeper_compact_audit GC loop

Closes task-1282