### PR TITLE
fix(tool-registry): derive workspace-state routing from schema

### DIFF
--- a/docs/rfc/RFC-0254-shell-ir-approval-autonomous-policy.md
+++ b/docs/rfc/RFC-0254-shell-ir-approval-autonomous-policy.md
@@ -1,6 +1,6 @@
-# RFC-0254: Shell IR Approval Gate — Autonomous Sandbox-Conditional Policy
+# RFC-0254: Shell IR Approval Gate — Autonomous Production Policy
 
-**Status**: Draft
+**Status**: Active
 **Date**: 2026-06-17
 **Builds on**: [RFC-0005](./RFC-0005-typed-capability-substrate.md) (typed capability substrate, a.k.a. "RFC v5"), [RFC-0208](./RFC-0208-shell-ir-compositional-risk-ast.md) (Shell IR compositional risk / path policy)
 **Related**: [RFC-0006](./RFC-0006-keeper-surface-and-sandbox.md), [RFC-0213](./RFC-0213-keeper-sandbox-isolation.md), [RFC-0070](./RFC-0070-keeper-sandbox-pure-edge-separation.md) (sandbox boundary); [RFC-0027](./RFC-0027-capability-typed-runtime.md), [RFC-0181](./RFC-0181-capability-intent-runtime-ssot.md) (capability runtime); [RFC-0199](./RFC-0199-evidence-driven-auto-approval.md) (deterministic verdict source replaces human bottleneck — same philosophy, different domain); [RFC-0088](./RFC-0088-counter-as-fix-result-propagation.md), [RFC-0042](./RFC-0042-keeper-terminal-code-closed-sum.md) (no-string-classifier lineage)
@@ -9,22 +9,25 @@
 
 ## 1. Summary
 
-PR #21338 wires `Keeper_tool_execute_shell_ir.dispatch_classified_with_approval` behind `MASC_SHELL_IR_APPROVAL_GATE_ENABLED`, routing keeper Execute calls through `Approval_policy.decide` with `Approval_config.permissive_default`. As wired, enabling the flag converts every audited/privileged command (`git`, `dune`, `npm`, `python`, `rm`, …) into a terminal error returned to the model, because the `Ask` verdict has no resolver in the autonomous keeper lane. The gate blocks the keeper's entire toolchain while the genuinely catastrophic class (force-push) is coupled to a loosenable trust knob.
+PR #21338 originally wired `Keeper_tool_execute_shell_ir.dispatch_classified_with_approval` behind `MASC_SHELL_IR_APPROVAL_GATE_ENABLED`, routing keeper Execute calls through `Approval_policy.decide` with `Approval_config.permissive_default`. That first wiring converted every audited/privileged command (`git`, `dune`, `npm`, `python`, `rm`, …) into a terminal error returned to the model, because the `Ask` verdict had no resolver in the autonomous keeper lane. It blocked the keeper's toolchain while the genuinely catastrophic class (force-push) stayed coupled to a loosenable trust knob.
 
-This RFC defines the correct model: a **sandbox-conditional** gate where
+This RFC defines the landed production model:
 
-- **Docker profile** → the container is the security boundary; per-command gating is skipped (container-trust).
-- **Local/Host profile** → an **autonomous policy**: verdicts collapse to `Allow` (+telemetry) or `Deny` (a trust-independent catastrophic floor). There is no `Ask` in the autonomous lane, because there is no human in the keeper's loop.
+- The keeper lane uses an **autonomous policy**: non-catastrophic verdicts collapse to `Allow` (+telemetry), while the catastrophic floor returns `Deny`.
+- The catastrophic floor is **trust-independent and kill-switch-independent**: it runs in the always-run `dispatch_classified` chokepoint even when `MASC_SHELL_IR_APPROVAL_GATE_ENABLED=false`.
+- The floor applies on both Host and Docker as defense-in-depth. Docker remains the stronger containment boundary, but a containerized command can still reach real credentials/remotes; destructive git and catastrophic binaries stay blocked.
+- There is no `Ask` in the autonomous lane, because there is no human in the keeper's loop.
 
 It also specifies the supporting change that makes the catastrophic floor expressible without string matching: extending `Capability_check.of_ir` to emit typed `Path_scope` for the arguments of filesystem-mutating programs.
 
 ## 2. Context & problem
 
-### 2.1 What PR #21338 wires (verified, head `274ace4e13`)
+### 2.1 Current production wiring
 
-- `Env_config_runtime.Shell_ir_approval_gate.enabled ()` reads `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` (default `false`), registered in `Feature_flag_registry` (`lifecycle=Experimental`, `since=2.234.0`).
-- When enabled, `keeper_tool_execute_runtime.ml` constructs `{ defaults = Approval_config.permissive_default; per_agent = [] }` inline and calls `dispatch_classified_with_approval`.
-- `dispatch_classified_with_approval` runs `Approval_policy.decide` on the classified IR, then (on `Allow`/`Suggest_confirm`) delegates to `dispatch_classified` (typed gate → path validation → dispatch); `Ask` → `Approval_required`, `Deny` → `Policy_denied`, both returned to the model as error JSON.
+- `Env_config_runtime.Shell_ir_approval_gate.enabled ()` reads `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` (default `true`), registered in `Feature_flag_registry` (`lifecycle=Active`, `since=2.234.0`). The env var is retained as a kill-switch for trust-overlay grading.
+- `dispatch_classified` always runs `Approval_policy.catastrophic_floor` before typed gate/path validation/dispatch. This is the enforcement chokepoint for both the flag-on and flag-off paths.
+- When the flag is enabled, `keeper_tool_execute_runtime.ml` selects `{ defaults = Approval_config.autonomous; per_agent = [] }` and calls `dispatch_classified_with_approval`.
+- `dispatch_classified_with_approval` runs `Approval_policy.decide`; non-catastrophic autonomous decisions execute through `dispatch_classified`, `Ask` remains representable for future operator overlays, and `Deny` returns `Policy_denied` to the model as error JSON.
 
 ### 2.2 The defects
 
@@ -44,7 +47,7 @@ It also specifies the supporting change that makes the catastrophic floor expres
 - `Local → Sandbox_target.host ()` — runs **directly on the host** (secret projection + workspace path-jail, but no container).
 - `Docker → docker_sandbox_target …` — runs inside a real Docker container; a playground path may fall back to Host.
 
-`Sandbox_target.t = Host | Docker of { image; runner; … }` (`sandbox_target.mli:38`). So the security boundary differs by profile, and the correct gate behavior must differ with it. This is the premise the PR did not account for.
+`Sandbox_target.t = Host | Docker of { image; runner; … }` (`sandbox_target.mli:38`). The security boundary differs by profile, but the catastrophic floor is intentionally applied before dispatch in both profiles. This keeps container containment as a boundary while preserving defense-in-depth for commands that can affect shared remotes or credentials.
 
 ## 4. Prior art
 
@@ -58,20 +61,20 @@ It also specifies the supporting change that makes the catastrophic floor expres
 
 Sources: `~/me/workspace/yousleepwhen/claude-code/src/types/permissions.ts` (leaked, minified — names mangled, structure intact), `src/tools/BashTool/readOnlyValidation.ts`; openclaw/openclaw README; hermes-agent.nousresearch.com/docs/user-guide/security (`approvals.mode`, hardline blocklist, container exception, `tools/approval.py`). Confidence: Medium-High.
 
-**Lessons.** (a) Trust is contextual, not per-command-absolute. (b) `Ask` always has a resolver — human, LLM, or callback; none of the three leave it dangling. (c) A catastrophic floor is unconditional, independent of mode/allowlist. (d) When a container is the boundary, per-command checks are skipped. MASC's wired gate violates (b), (c), and (d).
+**Lessons.** (a) Trust is contextual, not per-command-absolute. (b) `Ask` always has a resolver — human, LLM, or callback; none of the three leave it dangling. (c) A catastrophic floor is unconditional, independent of mode/allowlist. (d) Some systems skip per-command checks when a container is the boundary; MASC keeps only the catastrophic floor in front of Docker because shared remotes and projected credentials still make those effects real.
 
 ## 5. Design
 
-### 5.1 Sandbox-conditional application
+### 5.1 Sandbox-aware application
 
 The gate is applied as a function of `sandbox_profile`, decided in `keeper_tool_execute_runtime.ml` before dispatch:
 
 | profile | boundary | behavior |
 |---|---|---|
-| `Docker` | container | container-trust: do **not** apply the approval gate; rely on container isolation (RFC-0213) + existing `validate_paths`. Telemetry only. |
-| `Local` / `Host` | path-jail only | apply the **autonomous policy** (§5.2). |
+| `Docker` | container | apply the same autonomous catastrophic floor as defense-in-depth, then rely on container isolation (RFC-0213) + existing `validate_paths` for the rest. |
+| `Local` / `Host` | path-jail only | apply the **autonomous policy** (§5.2) plus the always-on catastrophic floor. |
 
-This mirrors Hermes' container exception and removes the redundant fourth layer for the Docker case.
+This intentionally differs from the earlier container-trust proposal. A Docker command can still reach shared Git remotes, mounted workspaces, and projected credentials, so destructive git and catastrophic binaries are denied before the sandbox runner receives them.
 
 ### 5.2 Verdict collapse for the autonomous lane
 
@@ -197,10 +200,10 @@ The overlay is data; `decide` is unchanged between contexts. This is the context
 
 | File / change | commit | verdict | rationale |
 |---|---|---|---|
-| `feature_flag_registry.ml` (flag) | 274 | KEEP | rollout toggle; keep `Experimental` |
+| `feature_flag_registry.ml` (flag) | 274 | KEEP | rollout toggle; default `true`, lifecycle `Active`; retained as trust-overlay kill-switch |
 | `env_config_runtime.ml/.mli` (`Shell_ir_approval_gate.enabled`) | 274 | KEEP | toggle accessor |
 | `keeper_tool_execute_shell_ir.ml/.mli` (`dispatch_classified_with_approval`) | f2cc | KEEP + REWORK | integration point is correct; H1/L4 fixes retained; `Ask` arm becomes unreachable under §5.2 → remove |
-| `keeper_tool_execute_runtime.ml` (gate wiring) | 274 + f2cc | REWORK | replace inline `permissive_default`/`per_agent=[]` with §5.1 sandbox branch + §5.5 contextual overlay; drop `Ask`/`Approval_required` arm |
+| `keeper_tool_execute_runtime.ml` (gate wiring) | 274 + f2cc | KEEP | uses `Approval_config.autonomous`; Host/Docker both keep the catastrophic floor as defense-in-depth |
 | `keeper_workspace_read_ops.ml` (error arms) | f2cc | REWORK | reads are not `Ask`-blocked under §5.2; floor only |
 | `shell_command_gate.ml` + `dune` (`log_verdict`) | f2cc | RELOCATE | move telemetry to the approval boundary; log allows (§5.6) |
 | `exec_dispatch.ml/.mli` (`dispatch_async`, `dispatch_decided_outcome`, `argv_of_ir`, `dispatch_outcome`) | f2cc | DROP | no production callers; unrelated to the gate |
@@ -208,7 +211,7 @@ The overlay is data; `decide` is unchanged between contexts. This is the context
 | `test_exec_dispatch.ml` | 274 | SPLIT | keep `dispatch_classified_with_approval` tests (rework for §5.2 verdicts); drop async/outcome tests |
 | `test_tool_dispatch.ml` (`dispatch_many` tests) | 274 | DROP | with the dead function |
 
-**Not in the PR, added by this RFC:** the `decide` reshape (§5.3), the `catastrophic_floor` + `find_catastrophic_program` + `Verdict.Catastrophic_program` (§5.4), the `Approval_config.autonomous` overlay (§5.5), and the sandbox branch (§5.1). The PR delivers wiring; this RFC supplies the policy the wiring should carry. (The originally-planned `Capability_check` argv-path-scope extension is dropped — §5.4 premise correction.)
+**Not in the PR, added by this RFC:** the `decide` reshape (§5.3), the `catastrophic_floor` + `find_catastrophic_program` + `Verdict.Catastrophic_program` (§5.4), the `Approval_config.autonomous` overlay (§5.5), and the Host/Docker defense-in-depth decision (§5.1). The PR delivers wiring; this RFC supplies the policy the wiring should carry. (The originally-planned `Capability_check` argv-path-scope extension is dropped — §5.4 premise correction.)
 
 > Already landed on the PR branch (`e6275dfbfe`): typed `Verdict.deny_reason_to_string` (H1), nested-pipeline `Too_complex` alignment (L4), doc-ordering fix (M1), deterministic `rm` test (L3). All remain valid; M3 (`Ask` informative summary) becomes moot once `Ask` is removed from the autonomous lane.
 >
@@ -219,7 +222,7 @@ The overlay is data; `decide` is unchanged between contexts. This is the context
 P0 (typed argv path-scope) is **dropped** — see the §5.4 premise correction.
 
 1. **P1 — `decide` reshape + `catastrophic_floor` (§5.3–5.4). ✅ done (`approval_policy.ml`, this branch).** Destructive-git moved out of the trust branch into an unconditional floor; added `find_catastrophic_program` (mkfs) and the typed `Verdict.Catastrophic_program` reason; added the `Approval_config.autonomous` overlay. Tests (`lib/exec/test/test_approval_policy.ml`): the floor Denies `git push --force` under every overlay incl. autonomous; `mkfs` Denied under autonomous; `rm -rf /` Allowed at the policy layer (jailed downstream by `validate_paths`); `git status` Allowed under autonomous. Full `lib/exec` suite green (`DUNE_CACHE=disabled dune build --root . @lib/exec/test/runtest`).
-2. **P2 — autonomous overlay wiring + sandbox branch (§5.1, 5.5).** In `keeper_tool_execute_runtime.ml`: select `Approval_config.autonomous` for the keeper lane (replace the inline `permissive_default`/`per_agent = []`); `Docker → skip the gate`, `Local → autonomous`. Remove the `Ask`/`Approval_required` arm. (lib/keeper — CI-verified; local full build blocked by the agent_sdk pin drift.)
+2. **P2 — autonomous overlay wiring (§5.1, 5.5). ✅ done.** `keeper_tool_execute_runtime.ml` selects `Approval_config.autonomous` for the keeper lane (replacing the inline `permissive_default`/`per_agent = []`). Host and Docker both pass through the same defense-in-depth catastrophic floor; the earlier `Docker → skip the gate` proposal was rejected because destructive git can still affect shared remotes from inside a container.
 3. **P3 — telemetry relocation (§5.6).** Remove `log_verdict` from shared `gate_typed`; log at the approval boundary incl. allows.
 4. **P4 — drop dead code (§7).** Remove `dispatch_async`/`dispatch_decided_outcome`/`argv_of_ir`/`dispatch_many` + tests.
 5. **P5 — verification (§9).**
@@ -228,13 +231,13 @@ P0 (typed argv path-scope) is **dropped** — see the §5.4 premise correction.
 
 - **TLA+ bug-model** (per the repo's spec-mutation pattern): model the policy as a state machine; `BugAction` = a catastrophic command reaching `Allow`; `SafetyInvariant` `CatastrophicNeverAllowed`. Clean spec: no error. `-buggy.cfg`: invariant violated. Both `.cfg`s must pass their respective expectations.
 - **Property:** for all overlays (autonomous, operator, enforced_all), a catastrophic-floor input is `Deny`. Loosening any trust level never produces `Allow` for a floor input.
-- **Behavior tests:** `git status`/`dune build`/`pytest` under autonomous overlay → `Allow`; `git push --force` → `Deny`; `rm -rf /` → `Deny`; `rm ./build` → `Allow`; Docker profile → gate skipped.
+- **Behavior tests:** `git status`/`dune build`/`pytest` under autonomous overlay → `Allow`; `git push --force` → `Deny`; `mkfs` → `Deny`; `rm -rf /` → policy-layer `Allow` then downstream path-jail `Deny`; `rm ./build` → `Allow`; Docker profile → same catastrophic floor before sandbox dispatch.
 - **Build:** `lib/exec`, `lib/keeper_tooling`, `lib/keeper` via `scripts/dune-local.sh` (pin-correct env); full `test/test_exec_dispatch.exe` in CI.
 - **Non-fatal preservation:** confirm a floor `Deny` returns error JSON (lane keeps turning), never raises.
 
 ## 10. Rollout
 
-- `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` is graduated to default `true` (lifecycle `Active`) once P1/P2/P4/P5 land (v0.19.45). The env var is retained as a **kill-switch**: set `=false` to disable the gate without a rebuild (re-readable per process).
+- `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` is default `true` (lifecycle `Active`). The env var is retained as a **kill-switch** for trust-overlay grading: set `=false` to disable the approval overlay without removing the always-on catastrophic floor.
 - This is a solo deployment and the gate has not run in production before, so the env var — not a code revert — is the first-line mitigation if the floor produces a false-deny.
 - Because the autonomous policy is allow-by-default-with-floor, enabling it does not stop the lane (§2.2(3) resolved). Net effect vs. the prior no-gate path: the same allows + a new catastrophic-floor `Deny` + per-command telemetry.
 - **Post-enable verification** (`.masc/logs/system_log_*.jsonl`): `rg 'shell_ir (policy_denied|path_reject|gate_reject)'` for denies (keeper/cmd/reason); `rg 'shell_ir dispatch'` for allows (status/risk_class/effects). Allows are `info`, denies are `warn`. No separate observability work is required — the keeper runtime already logs both (so the §5.6 telemetry relocation is cleanup, not a prerequisite).
@@ -244,14 +247,14 @@ P0 (typed argv path-scope) is **dropped** — see the §5.4 premise correction.
 
 | Option | Description | Why not (primary) |
 |---|---|---|
-| **0. Delete the gate** | Rely on sandbox containment only | Correct only for Docker; Host has no container boundary. Adopted *for Docker* in §5.1. |
+| **0. Delete the gate** | Rely on sandbox containment only | Host has no container boundary; Docker still needs defense-in-depth for shared remotes/credentials. |
 | **B. Observability-only** | Allow all, log, never Deny | Telemetry-as-fix (RFC-0088 anti-pattern); no protection against force-push. |
 | **C. LLM "smart" resolver** | Auxiliary LLM resolves `Ask` | Nondeterminism + latency/cost per command for a keeper that runs many. Possible future operator-overlay resolver, not the autonomous default. |
 | **D. Capability budget / cooldown** | Allow with rate caps | cap/cooldown symptom-suppression (CLAUDE.md workaround bar); does not classify danger. |
 | **E. Escalate containment per-command** | Risky commands → throwaway sandbox | Heavy infra; some ops (push, network) need real creds/network and cannot be fully sandboxed. |
 | **F. Typed sub-tools** | Replace raw shell with `GitCommit`/`GitPush-safe` typed tools | Largest redesign; loses generality of shell. Long-term direction, not this RFC. |
 
-The chosen design = **Option 0 for Docker + the autonomous floor model for Host**, which is the minimal change satisfying: lane keeps running, keeper can work, no double-gating, no HITL, and catastrophic protection strengthened (decoupled from trust).
+The chosen design = **the autonomous floor model for both Host and Docker**, which is the minimal change satisfying: lane keeps running, keeper can work, no HITL, and catastrophic protection is strengthened while staying decoupled from trust and from the kill-switch.
 
 ## 12. Workaround-rejection alignment
 
@@ -260,10 +263,9 @@ This RFC **removes** a workaround-shaped construct (`Ask`-dangling: a verdict th
 ## 13. Open questions
 
 1. Should `sudo`/`su` join the `Catastrophic_program` floor (§5.4) as defense-in-depth? They are typed (`Exec_program.known`) and never legitimate for a keeper, but under the autonomous overlay they are currently graded `Privileged → Allow`. P1 left the floor at destructive-git + redirect-escape + `mkfs` per the chosen scope (Option A).
-2. Should the `Docker` profile still apply the catastrophic floor as defense-in-depth, or fully trust the container? (Hermes fully skips; defense-in-depth would keep the floor.) — decides P2.
-3. Operator-overlay resolver (§5.5) — separate RFC; what UI/protocol resolves `Ask`?
-4. Should the `validate_paths` `looks_like_path_token` + `command_materializes_path_arg` string/heuristic layer be replaced with typed `Path_scope` capabilities (a deferred "typed-replacement" RFC)? That is the honest home for the work the dropped P0 was reaching toward — at the validation layer, not a parallel walker in `capability_check`.
-5. **Network/exec containment (§6 non-goal).** Should `sandbox_network_mode` be wired into dispatch (Docker `--network` enforcement) and/or should the autonomous lane treat path-less network egress + arbitrary exec (`curl http://x | sh`, `nc`) as a floor for the `Local`/host profile (which has no container)? A blanket network-binary floor breaks legitimate keeper use (`curl`/`npm`/`git`), so the control likely belongs at the sandbox boundary — separate RFC. Until then the gate's protection is explicitly catastrophic-local + path-jail only, and read-escape is asymmetric with write-escape (write is floored, read is only `validate_paths`, which passes everything when `workdir=None`).
+2. Operator-overlay resolver (§5.5) — separate RFC; what UI/protocol resolves `Ask`?
+3. Should the `validate_paths` `looks_like_path_token` + `command_materializes_path_arg` string/heuristic layer be replaced with typed `Path_scope` capabilities (a deferred "typed-replacement" RFC)? That is the honest home for the work the dropped P0 was reaching toward — at the validation layer, not a parallel walker in `capability_check`.
+4. **Network/exec containment (§6 non-goal).** Should `sandbox_network_mode` be wired into dispatch (Docker `--network` enforcement) and/or should the autonomous lane treat path-less network egress + arbitrary exec (`curl http://x | sh`, `nc`) as a floor for the `Local`/host profile (which has no container)? A blanket network-binary floor breaks legitimate keeper use (`curl`/`npm`/`git`), so the control likely belongs at the sandbox boundary — separate RFC. Until then the gate's protection is explicitly catastrophic-local + path-jail only, and read-escape is asymmetric with write-escape (write is floored, read is only `validate_paths`, which passes everything when `workdir=None`).
 
 ## 14. References
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,7 +14,7 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 350 unique knobs across 9 modules.
+**Total**: 351 unique knobs across 9 modules.
 
 **Typed getter classification**: 21/207 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 186).
 

--- a/lib/unified_tool_registry.ml
+++ b/lib/unified_tool_registry.ml
@@ -68,14 +68,23 @@ let keeper_task_tool_names =
 
 let is_keeper_task_tool_name name = List.mem name keeper_task_tool_names
 
-(** Derive a dispatch tag from a tool name. This is the SSOT heuristic used
-    by the ratchet; any name it returns [None] for must either be invisible
-    or be handled by an explicit [Tool_spec] registration that already
-    populated the tag registry. *)
+(** Workspace state tools are handled by [Tool_workspace.dispatch] and share
+    [Mod_state] even when the module-load [Tool_spec] side effect has not run
+    yet. The schema facade is the owned source for this dispatch cluster. *)
+let workspace_state_tool_names =
+  List.map (fun (s : Masc_domain.tool_schema) -> s.name) Tool_schemas_workspace.schemas
+
+let is_workspace_state_tool_name name = List.mem name workspace_state_tool_names
+
+(** Derive a dispatch tag from a tool name. This is the ratchet fallback used
+    for naming-rule clusters and schema-owned closed clusters; any name it
+    returns [None] for must either be invisible or be handled by an explicit
+    [Tool_spec] registration that already populated the tag registry. *)
 let tag_of_name name : TD.module_tag option =
   let open TD in
   let prefix p = String.starts_with ~prefix:p name in
-  if prefix "masc_plan_" then Some Mod_plan
+  if is_workspace_state_tool_name name then Some Mod_state
+  else if prefix "masc_plan_" then Some Mod_plan
   else if prefix "masc_run_" then Some Mod_run
   else if prefix "masc_agent_" then Some Mod_agent
   else if prefix "masc_task_" then Some Mod_task

--- a/lib/unified_tool_registry.mli
+++ b/lib/unified_tool_registry.mli
@@ -8,9 +8,10 @@
     idempotent and preserves tags already registered via [Tool_spec]. *)
 
 val tag_of_name : string -> Tool_dispatch.module_tag option
-(** Derive the canonical dispatch tag for a tool name from naming heuristics.
-    Returns [None] for names that have no clear neutral-tool mapping; those
-    must be covered by an explicit [Tool_spec] registration. *)
+(** Derive the canonical dispatch tag for a tool name from naming heuristics
+    and schema-owned closed clusters. Returns [None] for names that have no
+    clear ratchet fallback; those must be covered by an explicit [Tool_spec]
+    registration. *)
 
 val register_all : unit -> unit
 (** Register tags (+ placeholder schemas where needed) for all names in the

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -149,8 +149,18 @@ let () =
               check bool "masc_goal_list -> Mod_state" true
                 (Tool_dispatch.lookup_tag "masc_goal_list"
                  = Some Tool_dispatch.Mod_state);
-              check bool "tool_execute has no MCP static route" true
-                (Option.is_none (Tool_dispatch.lookup_tag "tool_execute")));
+              check bool "masc_goal_upsert -> Mod_state" true
+                (Tool_dispatch.lookup_tag "masc_goal_upsert"
+                 = Some Tool_dispatch.Mod_state);
+              check bool "masc_goal_transition -> Mod_state" true
+                (Tool_dispatch.lookup_tag "masc_goal_transition"
+                 = Some Tool_dispatch.Mod_state);
+              check bool "masc_goal_verify -> Mod_state" true
+                (Tool_dispatch.lookup_tag "masc_goal_verify"
+                 = Some Tool_dispatch.Mod_state);
+              check bool "tool_execute -> Mod_external" true
+                (Tool_dispatch.lookup_tag "tool_execute"
+                 = Some Tool_dispatch.Mod_external));
           test_case "mint_token accepts active static tool names" `Quick (fun () ->
               check bool "masc_status mints" true
                 (Result.is_ok

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -71,6 +71,16 @@ let test_mandatory_tools_are_registered () =
     mandatory
 ;;
 
+let test_workspace_schemas_route_to_state () =
+  init ();
+  Tool_schemas_workspace.schemas
+  |> List.iter (fun (schema : Masc_domain.tool_schema) ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%s routes to Mod_state" schema.name)
+         true
+         (Unified_tool_registry.tag_of_name schema.name = Some Tool_dispatch.Mod_state))
+;;
+
 let test_retired_tools_are_absent () =
   init ();
   let retired_front_door_tools =
@@ -127,6 +137,10 @@ let () =
     ; ( "mandatory_tools"
       , [ test_case "mandatory tools are registered" `Quick
             test_mandatory_tools_are_registered
+        ] )
+    ; ( "workspace_tools"
+      , [ test_case "workspace schemas route to Mod_state" `Quick
+            test_workspace_schemas_route_to_state
         ] )
     ; ( "retired_tools"
       , [ test_case "retired tools are absent" `Quick test_retired_tools_are_absent


### PR DESCRIPTION
## Scope

This PR has two intentionally narrow scopes:

- Runtime code: derive workspace-state static tag routing from `Tool_schemas_workspace.schemas`, so workspace/goal tools resolve to `Mod_state` without relying on module-load `Tool_spec` side effects or a separate hand-maintained list.
- Docs: sync RFC-0254/runtime-tunables with the Shell IR approval behavior already present on the base branch. This PR does not introduce new Shell IR approval enforcement code.

## Review response

Addressed https://github.com/jeong-sik/masc/pull/21512#issuecomment-4738757408:

- Removed the third manual workspace tool-name copy from `Unified_tool_registry`.
- Updated `Unified_tool_registry.mli` so `tag_of_name` no longer claims to be naming-heuristics-only.
- Narrowed the PR title/body away from an RFC-0254 production-readiness claim.
- Added a ratchet test proving every `Tool_schemas_workspace.schemas` entry maps to `Mod_state` through `Unified_tool_registry.tag_of_name`.

## Verification

- `ocamlformat --check lib/unified_tool_registry.ml lib/unified_tool_registry.mli test/test_tool_registry_consistency.ml`
- `MASC_DUNE_ALLOW_BARE_DUNE=1 gtimeout 300 scripts/dune-local.sh build test/test_tool_dispatch.exe test/test_tool_registry_consistency.exe`
- `_build/default/test/test_tool_dispatch.exe`
- `_build/default/test/test_tool_registry_consistency.exe`
- `scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json`
- `scripts/check-ssot.sh`
- `scripts/ci/check-masc-oas-boundary.sh`
- `scripts/oas-boundary-ratchet.sh`
- `scripts/audit-path-ssot.sh`
- `scripts/lint/masc-domain-boundary-ratchet.sh`
- `scripts/lint-spawn-bounded.sh`
- `MASC_DUNE_ALLOW_BARE_DUNE=1 gtimeout 300 scripts/dune-local.sh build lib/exec/test/test_approval_policy.exe test/test_exec_dispatch.exe`
- `_build/default/lib/exec/test/test_approval_policy.exe`
- `_build/default/test/test_exec_dispatch.exe`

## Runtime note

`/health?full=1` is reachable on the local live runtime, but that runtime is not proof that this PR head is deployed. Live Keeper task evidence and PR-head verification are separate evidence classes.
