### PR TITLE
fix(dashboard): 모바일 keeper 채팅 단일 pane 레이아웃 + 헤더 overflow/nav 드로어 수정

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -168,8 +168,15 @@ describe('App v2 header chrome', () => {
     expect(menuButton).not.toBeNull()
     menuButton!.click()
 
+    // When open, the rail must both drop max-[768px]:hidden AND add
+    // max-[768px]:block. The rail also carries the static max-[1100px]:hidden,
+    // so removing :hidden alone leaves it display:none at <=768px — the
+    // pre-fix '' open-state class regressed exactly here. Assert both tokens in
+    // the same waitFor so they are checked at the open moment.
     await waitFor(() => {
+      expect(rail?.classList.contains('max-[1100px]:hidden')).toBe(true)
       expect(rail?.classList.contains('max-[768px]:hidden')).toBe(false)
+      expect(rail?.classList.contains('max-[768px]:block')).toBe(true)
     })
   })
 

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -327,7 +327,7 @@ export function App() {
                 scheduler <b>${serverStatus.value ? 'healthy' : '—'}</b>
               </span>
             </div>
-            <${EmergencyStopControl} />
+            <span class="contents" data-mobile-detail-keep><${EmergencyStopControl} /></span>
             <${CopilotDockTopBarButton} dock=${dock} />
             <${Suspense} fallback=${authStatusFallback()}>
               <${LazyAuthStatus} />

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -371,7 +371,7 @@ export function App() {
             ${mobileMenuOpen.value ? html`
               <button type="button" aria-label="Close navigation" tabindex=${-1} class="hidden max-[768px]:block fixed inset-0 z-40 cursor-pointer bg-black/50" onClick=${() => { mobileMenuOpen.value = false }}></button>
             ` : null}
-            <aside id="dashboard-side-rail" aria-label="Sidebar navigation" class="v2-shell-rail ${sidebarCollapsed.value ? 'w-14' : 'w-55'} shrink-0 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] max-[1100px]:hidden max-[768px]:fixed max-[768px]:inset-y-0 max-[768px]:left-0 max-[768px]:z-50 max-[768px]:m-0 max-[768px]:w-72 max-[768px]:max-h-none max-[768px]:rounded-none max-[768px]:border-r ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
+            <aside id="dashboard-side-rail" aria-label="Sidebar navigation" class="v2-shell-rail ${sidebarCollapsed.value ? 'w-14' : 'w-55'} shrink-0 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] max-[1100px]:hidden max-[768px]:fixed max-[768px]:inset-y-0 max-[768px]:left-0 max-[768px]:z-50 max-[768px]:m-0 max-[768px]:w-72 max-[768px]:max-h-none max-[768px]:rounded-none max-[768px]:border-r ${mobileMenuOpen.value ? 'max-[768px]:block' : 'max-[768px]:hidden'}">
               <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
             </aside>
           `}

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -17,6 +17,7 @@ import {
   selectedKeeper,
   clearKeeperDetailSelection,
   closeKeeperDetail,
+  keeperMobilePane,
 } from './keeper-detail-state'
 import {
   refreshAfterRuntimeAction,
@@ -288,7 +289,7 @@ const KeeperDetailContent = memo(function KeeperDetailContent({ keeper }: { keep
   `
 
   return html`
-    <div class="kw-grid v2-monitoring-surface" data-detail=${detailOpen ? 'open' : 'closed'} data-route-focused-keeper=${keeper.name}>
+    <div class="kw-grid v2-monitoring-surface" data-detail=${detailOpen ? 'open' : 'closed'} data-mobile-pane=${keeperMobilePane.value} data-route-focused-keeper=${keeper.name}>
       <${KeeperWorkspaceRoster} activeName=${keeper.name} />
       ${detailOpen
         ? html`

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -137,6 +137,13 @@ const KeeperDetailContent = memo(function KeeperDetailContent({ keeper }: { keep
     selectedKeeper.value = keeper
     selectKeeper(keeper.name)
     void loadKeeperConfig(keeper.name)
+    // Entering a keeper (mount or keeper change) always lands on the chat pane
+    // on mobile. keeperMobilePane is a module-global signal; the back button
+    // sets it to 'roster', but many entry points (command palette, overview
+    // cards, reactivity monitor, …) route straight to a keeper via navigate()
+    // without going through openKeeperDetail/roster-select, so without this
+    // reset a stale 'roster' would hide the chat of the keeper just selected.
+    keeperMobilePane.value = 'chat'
     return () => {
       clearKeeperDetailSelection(keeper.name)
     }

--- a/dashboard/src/components/keeper-detail-state.ts
+++ b/dashboard/src/components/keeper-detail-state.ts
@@ -8,6 +8,15 @@ import { loadKeeperConfig, resetKeeperConfig } from './keeper-config-panel'
 
 export const selectedKeeper = signal<Keeper | null>(null)
 
+/** Mobile (≤860px) single-pane switch for the keeper workspace grid.
+ * Desktop shows roster | conversation | rail side by side; below 860px only
+ * one pane fits at a time, so this selects the visible one. Defaults to 'chat'
+ * because entering keeper detail means a keeper is focused. Roster row select
+ * and `openKeeperDetail` set 'chat'; the chat header back button sets 'roster'.
+ * Read by `.kw-grid[data-mobile-pane]` in keeper-workspace.css. */
+export type KeeperMobilePane = 'roster' | 'chat'
+export const keeperMobilePane = signal<KeeperMobilePane>('chat')
+
 registerKeeperTurnRefresh((keeperName: string) => {
   if (keeperName !== activeKeeperName.value) return
   void hydrateKeeperStatus(keeperName, true)
@@ -42,6 +51,7 @@ function baseAgentDirectoryRouteParams(): Record<string, string> {
 
 export function openKeeperDetail(k: Keeper) {
   selectedKeeper.value = k
+  keeperMobilePane.value = 'chat'
   selectKeeper(k.name)
   void loadKeeperConfig(k.name)
   navigate('monitoring', { ...baseAgentDirectoryRouteParams(), keeper: k.name })

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -142,6 +142,7 @@ import {
   clearKeeperDetailSelection,
   closeKeeperDetail,
   filterCheckpointHistory,
+  keeperMobilePane,
   lineageTransitionLabel,
   lineageVerdictMeta,
   openKeeperDetail,
@@ -335,6 +336,13 @@ describe('KeeperDetailPage', () => {
     expect(container.querySelector('.kw-grid')).toBeTruthy()
     expect(container.querySelector('.kw-roster')).toBeTruthy()
     expect(container.querySelector('.kw-rail')).toBeTruthy()
+    // The grid binds data-mobile-pane to the keeperMobilePane signal — the
+    // load-bearing hook the <=860px CSS pane-switch depends on. Entering a
+    // keeper resets the signal to 'chat', so the attribute must reflect that
+    // (guards against a silent attribute-name regression on the binding).
+    const grid = container.querySelector('.kw-grid')
+    expect(grid?.getAttribute('data-mobile-pane')).toBe('chat')
+    expect(grid?.getAttribute('data-mobile-pane')).toBe(keeperMobilePane.value)
     // The keeper name appears in the roster row and the chat header.
     expect(screen.getAllByText('analyst').length).toBeGreaterThanOrEqual(1)
     // The reused chat engine is mounted in the conversation pane.

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -5,6 +5,7 @@ export {
   openKeeperDetail,
   clearKeeperDetailSelection,
   closeKeeperDetail,
+  keeperMobilePane,
 } from './keeper-detail-state'
 export {
   filterCheckpointHistory,

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { html } from 'htm/preact'
 import { render } from 'preact'
+import { signal } from '@preact/signals'
 import { act } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Keeper } from '../../types'
@@ -38,6 +39,9 @@ async function loadChat() {
     ChatArtifactPanel: ({ entries }: { entries: unknown[] }) =>
       html`<div data-testid="kw-artifact-panel" data-artifact-count=${entries.length}>Artifacts</div>`,
   }))
+  vi.doMock('../keeper-detail-state', () => ({
+    keeperMobilePane: signal<'roster' | 'chat'>('chat'),
+  }))
   return import('./keeper-workspace-chat')
 }
 
@@ -61,6 +65,7 @@ describe('KeeperWorkspaceChat', () => {
     vi.doUnmock('../keeper-turn-inspector')
     vi.doUnmock('../../lib/keeper-runtime-display')
     vi.doUnmock('../chat/artifact-panel')
+    vi.doUnmock('../keeper-detail-state')
   })
 
   it('renders the chat header and conversation panel', async () => {
@@ -113,6 +118,32 @@ describe('KeeperWorkspaceChat', () => {
     })
 
     expect(container.querySelector('[data-testid="kw-chat-turn-inspector-drawer"]')).toBeNull()
+  })
+
+  it('switches the mobile pane to roster when the back button is clicked', async () => {
+    const { KeeperWorkspaceChat } = await loadChat()
+    const { keeperMobilePane } = await import('../keeper-detail-state')
+    keeperMobilePane.value = 'chat'
+
+    await act(async () => {
+      render(html`
+        <${KeeperWorkspaceChat}
+          keeper=${mockKeeper}
+          detailOpen=${false}
+          onToggleDetail=${vi.fn()}
+          onClear=${vi.fn()}
+        />
+      `, container)
+    })
+
+    const back = container.querySelector('[data-testid="kw-chat-back-to-roster"]') as HTMLButtonElement
+    expect(back).not.toBeNull()
+
+    await act(async () => {
+      back.click()
+    })
+
+    expect(keeperMobilePane.value).toBe('roster')
   })
 
   it('toggles the artifact panel when the artifacts button is clicked', async () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -9,6 +9,7 @@ import type { VNode } from 'preact'
 import type { Keeper } from '../../types'
 import { KeeperConversationPanel } from '../keeper-shared'
 import { KeeperLifecycleButtons } from '../keeper-detail-lifecycle'
+import { keeperMobilePane } from '../keeper-detail-state'
 import { KeeperTurnInspector } from '../keeper-turn-inspector'
 import { ChatArtifactPanel } from '../chat/artifact-panel'
 import { keeperThreads } from '../../keeper-state'
@@ -50,6 +51,14 @@ function ChatHeader({
   // vertical space instead of a redundant metadata sub-row.
   return html`
     <div class="kw-chat-head v2-monitoring-toolbar">
+      <button
+        type="button"
+        class="kw-chat-back kw-act v2-monitoring-action"
+        title="키퍼 목록으로"
+        aria-label="키퍼 목록으로"
+        onClick=${() => { keeperMobilePane.value = 'roster' }}
+        data-testid="kw-chat-back-to-roster"
+      >← 키퍼</button>
       <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${live} />
       <div class="kw-chat-id">
         <div class="kw-chat-name-row">

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../router', async (orig) => ({
 
 import { navigate } from '../../router'
 import { keepers } from '../../store'
+import { keeperMobilePane } from '../keeper-detail-state'
 import { KeeperWorkspaceRoster } from './keeper-workspace-roster'
 import type { Keeper } from '../../types'
 
@@ -63,14 +64,18 @@ describe('KeeperWorkspaceRoster', () => {
     expect(chips.some(c => c?.includes('주의') && c?.includes('1'))).toBe(true)
   })
 
-  it('navigates to the keeper route on row click', () => {
+  it('navigates to the keeper route and reveals the chat pane on row click', () => {
     const onSelect = vi.fn()
+    // Simulate the mobile roster pane being open; selecting a keeper must
+    // switch the single-pane mobile layout over to that keeper's chat.
+    keeperMobilePane.value = 'roster'
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" onSelect=${onSelect} />`, host)
     const rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
     const sangsuRow = rows.find(r => r.textContent?.includes('sangsu'))
     sangsuRow?.click()
     expect(navigate).toHaveBeenCalledWith('monitoring', { section: 'agents', keeper: 'sangsu' })
     expect(onSelect).toHaveBeenCalledWith('sangsu')
+    expect(keeperMobilePane.value).toBe('chat')
   })
 
   it('filters by search query', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -10,6 +10,7 @@ import type { VNode } from 'preact'
 import { keepers } from '../../store'
 import { navigate } from '../../router'
 import { selectKeeper } from '../../keeper-runtime'
+import { keeperMobilePane } from '../keeper-detail-state'
 import { keeperActivityDisplay, keeperWorkPreview } from '../../lib/keeper-runtime-display'
 import type { Keeper } from '../../types'
 import { VirtualList } from '../common/virtual-list'
@@ -145,6 +146,9 @@ export function KeeperWorkspaceRoster({
 
   const select = (name: string) => {
     selectKeeper(name)
+    // On mobile the roster and conversation share one column; picking a keeper
+    // should reveal that keeper's chat (the roster is the "back" target).
+    keeperMobilePane.value = 'chat'
     navigate('monitoring', { section: 'agents', keeper: name })
     onSelect?.(name)
   }

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -51,11 +51,18 @@
   .kw-grid { grid-template-columns: var(--kw-roster-w, 248px) minmax(0, 1fr); }
   .kw-grid .kw-rail { display: none; }
 }
-/* Below 860px the rail is already gone; roster + conversation stack in one
- * column. A dedicated mobile pane-switcher is deferred (no JS sets it yet),
- * so we do not ship the unreachable data-mobile-pane hide rules. */
+/* Below 860px the rail is already gone and roster + conversation can no longer
+ * sit side by side. Rather than stacking both in one column (which halves the
+ * grid height — the conversation collapses to ~half a screen behind the full
+ * roster), switch to a single visible pane driven by `data-mobile-pane`
+ * (keeperMobilePane signal). The hidden pane is removed from the grid so the
+ * visible one stretches to the full grid height. Roster row select → 'chat';
+ * the chat header "← 키퍼" back button → 'roster'. */
 @media (max-width: 860px) {
   .kw-grid { grid-template-columns: minmax(0, 1fr); }
+  .kw-grid[data-mobile-pane="chat"] > .kw-roster { display: none; }
+  .kw-grid[data-mobile-pane="roster"] > .kw-chat,
+  .kw-grid[data-mobile-pane="roster"] > .kw-detail { display: none; }
 }
 
 /* ════ ROSTER (left) ════════════════════════════════════════════ */
@@ -170,10 +177,23 @@
   flex: none; padding: 12px 28px;
   border-bottom: 1px solid var(--color-border-default);
   background: var(--color-bg-panel-alt);
-  display: flex; align-items: center; gap: 14px;
+  display: flex; align-items: center; gap: 10px 14px;
+  /* Wrap when the chat pane is narrow (3-pane laptop widths, ≤860px mobile).
+   * Without this the flex:none actions squeeze the flex:1 identity to width:0
+   * and its name + state pill overflow on top of the buttons. With wrap +
+   * .kw-chat-id min-width, the actions drop to their own row instead. */
+  flex-wrap: wrap;
 }
-.kw-chat-id { min-width: 0; flex: 1; }
+/* min-width (not 0) is load-bearing: it stops the flex algorithm from
+ * collapsing the identity to zero to fit the actions on one row — which is
+ * what made the name + pill overflow onto the buttons. Below this width the
+ * actions wrap to their own row instead (see .kw-chat-head flex-wrap). */
+.kw-chat-id { min-width: 9rem; flex: 1; }
 .kw-chat-name-row { display: flex; align-items: center; gap: 11px; flex-wrap: wrap; }
+/* Back-to-roster affordance: only meaningful on the single-pane mobile layout
+ * (shown at ≤860px in the conversation media block). On desktop the roster is
+ * always visible, so the button is hidden. */
+.kw-chat-back { display: none; flex: none; }
 .kw-chat-name { font-size: var(--fs-20); font-weight: var(--fw-bold); letter-spacing: -0.01em; color: var(--color-fg-primary); margin: 0; white-space: nowrap; }
 
 .kw-state-pill {
@@ -196,6 +216,33 @@
 .kw-act:hover { color: var(--color-fg-primary); border-color: var(--color-border-strong); background: var(--color-bg-hover); }
 .kw-act:disabled { opacity: 0.5; cursor: not-allowed; }
 .kw-act.danger:hover { color: var(--color-status-err); border-color: rgb(var(--color-status-err-glow) / 0.5); }
+
+/* Mobile conversation header (≤860px). The desktop header is a single flex row
+ * [sigil | identity (flex:1) | actions (flex:none)]. At phone widths the five
+ * action buttons consume the row and squeeze the flex:1 identity to width:0,
+ * whose overflowing name + state pill then paint on top of the buttons. Fix:
+ * let the header wrap, force the actions onto their own full-width row (so the
+ * identity keeps real width and cannot collapse), and make that row a
+ * horizontal scroll strip instead of overflowing. The "← 키퍼" back button
+ * appears here as the pane-switch affordance. */
+@media (max-width: 860px) {
+  .kw-chat-head { flex-wrap: wrap; padding: 9px 14px; gap: 8px 10px; }
+  .kw-chat-back { display: inline-flex; align-items: center; }
+  .kw-chat-id { flex: 1 1 auto; }
+  .kw-chat-actions {
+    flex: 1 1 100%;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  .kw-chat-actions::-webkit-scrollbar { display: none; }
+  .kw-chat-actions > * { flex: none; }
+  /* Reclaim vertical space for the transcript: tighter composer + insets. */
+  .kw-composer-inner { padding: 0 14px; }
+  .kw-composer-inner .control-textarea { min-height: 56px; }
+  .kw-thread-inner .chat-transcript { padding-left: 16px; padding-right: 16px; padding-top: 12px; }
+}
 
 /* thread: the conversation panel renders ChatTranscript + composer inside.
  * Provide the spacious rhythm + centered max-width column here. */

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -31,6 +31,17 @@
   height: 100%;
 }
 
+/* Keeper detail is a focused single-keeper view. On mobile the global header's
+ * action chips (Emergency / Copilot / auth / connection / error) wrap onto two
+ * extra rows (~76px) that crowd out the conversation. Hide them and tighten the
+ * header padding here. The brand block + hamburger stay — the hamburger is the
+ * only global-nav escape on mobile in this mode (the bottom bar is hidden), and
+ * the chips remain reachable from the nav drawer and other surfaces. */
+@media (max-width: 768px) {
+  [data-keeper-detail-mode="true"] .v2-shell-header { padding-top: 4px; padding-bottom: 4px; }
+  [data-keeper-detail-mode="true"] .v2-header-actions { display: none; }
+}
+
 .kw-grid {
   display: grid;
   grid-template-columns:

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -32,14 +32,16 @@
 }
 
 /* Keeper detail is a focused single-keeper view. On mobile the global header's
- * action chips (Emergency / Copilot / auth / connection / error) wrap onto two
- * extra rows (~76px) that crowd out the conversation. Hide them and tighten the
- * header padding here. The brand block + hamburger stay — the hamburger is the
- * only global-nav escape on mobile in this mode (the bottom bar is hidden), and
- * the chips remain reachable from the nav drawer and other surfaces. */
+ * action chips (Copilot / auth / connection / error) wrap onto two extra rows
+ * (~76px) that crowd out the conversation. Hide them and tighten the header
+ * padding here. Kept: the brand block + hamburger (the only global-nav escape
+ * on mobile in this mode, since the bottom bar is hidden), and the global
+ * Emergency Stop (namespace pause) — a safety control with no other on-surface
+ * affordance here (marked [data-mobile-detail-keep] in app.ts). The remaining
+ * chips stay reachable from the nav drawer / other surfaces. */
 @media (max-width: 768px) {
   [data-keeper-detail-mode="true"] .v2-shell-header { padding-top: 4px; padding-bottom: 4px; }
-  [data-keeper-detail-mode="true"] .v2-header-actions { display: none; }
+  [data-keeper-detail-mode="true"] .v2-header-actions > *:not([data-mobile-detail-keep]) { display: none; }
 }
 
 .kw-grid {


### PR DESCRIPTION
## 무엇을 / 왜

모바일(≤860px)에서 keeper 채팅(`#monitoring?section=agents&keeper=<name>`)의 레이아웃이 깨져 있었다. 브라우저로 측정해 3가지 근본 원인을 확인했다.

1. **모바일 pane 스위처 미구현** — `.kw-grid`(roster | conversation | rail, 3컬럼)가 ≤860px에서 단일 컬럼이 되는데, roster와 conversation이 한 컬럼에 세로로 쌓여 각자 그리드 높이의 절반만 차지했다. 대화 transcript가 ~30px로 눌려 메시지가 보이지 않고 composer는 화면 밖으로 잘렸다. CSS 주석이 "a dedicated mobile pane-switcher is deferred (no JS sets it yet)"라고 명시하고 있었다.
2. **헤더 flex 붕괴 → overflow 겹침** — `.kw-chat-head`(단일 flex 행)에서 액션 버튼 5개가 폭을 다 먹어 `flex:1`인 `.kw-chat-id`(이름 + 상태 pill)가 width 0으로 붕괴, 그 내용이 버튼 위로 overflow돼 그려졌다("실행 중" pill이 종료하기 버튼 위 녹색 원으로 보임). 모바일뿐 아니라 3-pane 노트북 폭(chat ~510px)에서도 재현.
3. **글로벌 헤더가 채팅 세로 공간 잠식** — keeper-detail 모바일에서 상단 글로벌 헤더의 액션 칩이 2행 추가로 wrap돼(~76px) 채팅을 밀어냄.

## 변경

- **모바일 단일 pane 스위처**: `keeperMobilePane` 시그널 → `.kw-grid[data-mobile-pane]`. ≤860px에서 한 pane만 표시(숨은 pane은 grid에서 빠져 보이는 pane이 전체 높이 확보). roster 행 선택 / `openKeeperDetail` → `chat`, 채팅 헤더의 신규 `← 키퍼` 버튼 → `roster`.
- **헤더 overflow 수정(전 폭 적용)**: `.kw-chat-head`에 `flex-wrap`, `.kw-chat-id`에 `min-width`를 둬 identity가 0으로 붕괴하지 않고 액션이 자체 행으로 내려가게 함. 넓은 화면은 단일 행 유지(불변).
- **모바일 여백 축소**: 액션 가로 스크롤 스트립, composer/transcript inset 축소.
- **글로벌 헤더 슬림화**: keeper-detail 모바일에서 `.v2-header-actions` 숨김 + 헤더 패딩 축소(브랜드 + 햄버거 유지).
- **모바일 nav 드로어 수정**: aside `#dashboard-side-rail`이 `max-[1100px]:hidden`만 있고 ≤768px에서 display를 되살리는 규칙이 없어, 햄버거가 backdrop만 띄우고 rail은 숨긴 채였다(빈 화면). open 상태에 `max-[768px]:block`을 추가해 오버라이드. **기존 버그(origin/main에서도 재현)**이지만, keeper-detail 모바일에선 bottom bar도 숨겨져 햄버거가 유일한 글로벌 nav 탈출구라 헤더 슬림화와 함께 고쳐야 했다.

## 측정 (모바일 500px, before → after)

| 지표 | before | after |
|------|--------|-------|
| transcript 높이 | 30px | ~200px |
| 채팅 영역 높이 | 208px | 548px |
| 헤더 identity 폭 | 0px (붕괴) | 정상 |
| 글로벌 헤더 | 145px(3행) | 57px(1행) |
| 햄버거 nav | 빈 화면 | 정상 작동 |

## 검증

- ESLint(변경 파일) 클린, `tsc --noEmit` 0 에러, Vitest 36 통과(신규 pane 전환 테스트 2건 포함).
- Chrome 시각 검증: 모바일 500px(roster⇄chat 양방향, 겹침 0, 햄버거 작동) + 데스크톱 1400px(3-pane 유지, 겹침 제거).
- pre-existing lint 에러 2건(`connector-status.ts`, `logs.ts`)은 이 PR과 무관(미수정).

RFC-WAIVED: dashboard 채팅 UI(keeper-workspace / keeper-detail / app shell CSS)만 변경. credential/identity/operator/sandbox/hooks 등 RFC 게이트 대상 subsystem 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## 적대적 self-review (grounded)

머지 전 3-렌즈(반응형 CSS / TS·상태 / 회귀·shell·a11y) grounded 적대적 리뷰 + skeptic 검증 수행. confirmed 결함 4건 모두 이 브랜치에서 수정:
- [high] `keeperMobilePane` stale-'roster' → route 진입 effect에서 'chat' 리셋 (12개 우회 진입점 커버)
- [medium] 글로벌 Emergency Stop 소실 → `[data-mobile-detail-keep]` 마커로 유지
- [medium] 드로어 테스트가 buggy 코드도 통과 → `max-[768px]:block` 토큰 검증 추가
- [low] `data-mobile-pane` 바인딩 미검증 → 속성 reflect 테스트 추가

dismissed(검증 후 비결함): `min-width:9rem` overflow(flex-wrap이 처리), detail→roster 2탭(서브뷰 계층 의도).
