### PR TITLE
fix: assign incrementing generation numbers to episodes

### DIFF
--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -201,7 +201,7 @@ let source_turn_range claims =
     Some (lo, hi)
 ;;
 
-let episode_of_output ?now (inp : input) (raw : string) : episode option =
+let episode_of_output ?now ?generation (inp : input) (raw : string) : episode option =
   let now =
     match now with
     | Some now -> now
@@ -230,7 +230,7 @@ let episode_of_output ?now (inp : input) (raw : string) : episode option =
           | Some claims ->
             Some
               { trace_id = inp.trace_id
-              ; generation = inp.generation
+              ; generation = Option.value generation ~default:inp.generation
               ; episode_summary
               ; claims
               ; open_items

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -295,6 +295,7 @@ let extract_with_provider
     ~sw
     ~net
     ~provider_cfg
+    ?generation
     (inp : Keeper_librarian.input)
   =
   match messages_for_librarian inp with
@@ -314,7 +315,7 @@ let extract_with_provider
           if String.equal raw ""
           then Unparseable "librarian provider returned empty response"
           else (
-            match Keeper_librarian.episode_of_output inp raw with
+            match Keeper_librarian.episode_of_output ?generation inp raw with
             | Some episode -> Parsed episode
             | None -> Unparseable "librarian provider returned invalid episode JSON")
       in
@@ -334,7 +335,10 @@ let extract_and_append_with_provider
     ~provider_cfg
     inp
   =
-  match extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg inp with
+  let generation =
+    Keeper_memory_os_io.next_generation ~keeper_id ~trace_id:inp.Keeper_librarian.trace_id
+  in
+  match extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~generation inp with
   | Error _ as e -> e
   | Ok episode ->
     let now = episode.Keeper_memory_os_types.created_at in

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -91,6 +91,22 @@ let episode_path ~keeper_id ~trace_id ~generation =
     (Printf.sprintf "%s-g%04d.json" trace_id generation)
 ;;
 
+let next_generation ~keeper_id ~trace_id =
+  let dir = episodes_dir ~keeper_id in
+  let prefix = Printf.sprintf "%s-g" trace_id in
+  let max_gen =
+    Sys.readdir dir
+    |> Array.to_list
+    |> List.filter_map (fun name ->
+      if String.starts_with ~prefix name then
+        let rest = String.drop_prefix name (String.length prefix) in
+        try Some (int_of_string (String.sub rest 0 4)) with _ -> None
+      else None)
+    |> List.fold_left max (-1)
+  in
+  max_gen + 1
+;;
+
 let unique_episode_path ~keeper_id episode =
   let created_ms =
     episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float


### PR DESCRIPTION
## Problem

Every episode extracted by the librarian was assigned `generation = 0` (from `inp.generation`), so all episodes for a given trace_id had the same `g0000` suffix. The consolidator could only see one episode per trace, making multi-turn memory evolution impossible.

## Root cause

`Keeper_librarian.episode_of_output` always set `episode.generation = inp.generation`, which is always 0. No code path ever incremented it.

## Fix

1. **`keeper_memory_os_io.ml`**: Added `next_generation ~keeper_id ~trace_id` — scans the episodes directory for existing files matching `{trace_id}-gNNNN.json`, returns `max_generation + 1`.
2. **`keeper_librarian.ml`**: Added optional `?generation` parameter to `episode_of_output`. When provided, it overrides `inp.generation`.
3. **`keeper_librarian_runtime.ml`**: `extract_and_append_with_provider` now calls `next_generation` before extraction and passes the result through `extract_with_provider` to `episode_of_output`.

## Verification

- `git diff --stat`: 3 files changed, 24 insertions(+), 4 deletions(-)
- The `next_generation` function handles empty directories (returns 0), missing files (returns 0), and non-matching files (ignores them).
- The `?generation` parameter is optional — all existing callers continue to work unchanged.