### PR TITLE
fix: assign incrementing generation numbers to episodes

### DIFF
--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -201,7 +201,7 @@ let source_turn_range claims =
     Some (lo, hi)
 ;;
 
-let episode_of_output ?now (inp : input) (raw : string) : episode option =
+let episode_of_output ?now ?generation (inp : input) (raw : string) : episode option =
   let now =
     match now with
     | Some now -> now
@@ -230,7 +230,7 @@ let episode_of_output ?now (inp : input) (raw : string) : episode option =
           | Some claims ->
             Some
               { trace_id = inp.trace_id
-              ; generation = inp.generation
+              ; generation = Option.value generation ~default:inp.generation
               ; episode_summary
               ; claims
               ; open_items

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -230,6 +230,7 @@ let episode_of_output ?now ?generation (inp : input) (raw : string) : episode op
           | Some claims ->
             Some
               { trace_id = inp.trace_id
+              (* sound-partial: allow: callers without a fresh generation keep inp.generation. *)
               ; generation = Option.value generation ~default:inp.generation
               ; episode_summary
               ; claims

--- a/lib/keeper/keeper_librarian.mli
+++ b/lib/keeper/keeper_librarian.mli
@@ -21,6 +21,7 @@ val prompt_variables : input -> (string * string) list
     [now] is optional so tests can keep timestamps deterministic. *)
 val episode_of_output
   :  ?now:float
+  -> ?generation:int
   -> input
   -> string
   -> Keeper_memory_os_types.episode option

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -362,7 +362,7 @@ let extract_with_provider
         if String.equal raw ""
         then Unparseable "librarian provider returned empty response"
         else (
-          match Keeper_librarian.episode_of_output ?generation inp raw with
+          match Keeper_librarian.episode_of_output ~generation inp raw with
           | Some episode -> Parsed episode
           | None -> Unparseable "librarian provider returned invalid episode JSON")
     in

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -343,13 +343,14 @@ let extract_with_provider
     ~sw
     ~net
     ~provider_cfg
+    ?generation
     (inp : Keeper_librarian.input)
   =
   match messages_for_librarian inp with
   | Error _ as e -> e
   | Ok messages ->
     let provider_cfg = provider_for_librarian provider_cfg in
-    let attempt messages =
+let attempt messages =
       match
         with_timeout ?clock ~timeout_sec (fun () ->
           complete ~sw ~net ?clock ~config:provider_cfg ~messages ())
@@ -361,7 +362,7 @@ let extract_with_provider
         if String.equal raw ""
         then Unparseable "librarian provider returned empty response"
         else (
-          match Keeper_librarian.episode_of_output inp raw with
+          match Keeper_librarian.episode_of_output ?generation inp raw with
           | Some episode -> Parsed episode
           | None -> Unparseable "librarian provider returned invalid episode JSON")
     in
@@ -381,7 +382,10 @@ let extract_and_append_with_provider
     ~provider_cfg
     inp
   =
-  match extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg inp with
+  let generation =
+    Keeper_memory_os_io.next_generation ~keeper_id ~trace_id:inp.Keeper_librarian.trace_id
+  in
+  match extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~generation inp with
   | Error _ as e -> e
   | Ok episode ->
     let now = episode.Keeper_memory_os_types.created_at in

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -350,7 +350,7 @@ let extract_with_provider
   | Error _ as e -> e
   | Ok messages ->
     let provider_cfg = provider_for_librarian provider_cfg in
-let attempt messages =
+    let attempt messages =
       match
         with_timeout ?clock ~timeout_sec (fun () ->
           complete ~sw ~net ?clock ~config:provider_cfg ~messages ())

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -343,7 +343,7 @@ let extract_with_provider
     ~sw
     ~net
     ~provider_cfg
-    ?generation
+    ~generation
     (inp : Keeper_librarian.input)
   =
   match messages_for_librarian inp with

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -116,6 +116,7 @@ val extract_with_provider
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> provider_cfg:Llm_provider.Provider_config.t
+  -> generation:int
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, string) result
 

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -110,7 +110,7 @@ let next_generation ~keeper_id ~trace_id =
       if String.starts_with ~prefix name then
         let plen = String.length prefix in
         let rest = String.sub name plen (String.length name - plen) in
-        try Some (int_of_string (String.sub rest 0 4)) with _ -> None
+        if String.length rest >= 4 then int_of_string_opt (String.sub rest 0 4) else None
       else None)
     |> List.fold_left max (-1)
   in

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -108,7 +108,8 @@ let next_generation ~keeper_id ~trace_id =
     |> Array.to_list
     |> List.filter_map (fun name ->
       if String.starts_with ~prefix name then
-        let rest = String.drop_prefix name (String.length prefix) in
+        let plen = String.length prefix in
+        let rest = String.sub name plen (String.length name - plen) in
         try Some (int_of_string (String.sub rest 0 4)) with _ -> None
       else None)
     |> List.fold_left max (-1)

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -91,6 +91,15 @@ let episode_path ~keeper_id ~trace_id ~generation =
     (Printf.sprintf "%s-g%04d.json" trace_id generation)
 ;;
 
+(** Compute the next generation number for a trace's episode files.
+
+    Scans the episodes directory for files matching [trace_id-gNNNN.json]
+    and returns [max_gen + 1].  This is a **single-writer** operation:
+    concurrent callers for the same [trace_id] will race on the directory
+    scan and may produce duplicate generation numbers.  The caller must
+    ensure at most one fiber calls [next_generation] for a given
+    [trace_id] at a time (e.g. via a per-trace sequencer or by running
+    all extractions for one trace on a single fiber). *)
 let next_generation ~keeper_id ~trace_id =
   let dir = episodes_dir ~keeper_id in
   let prefix = Printf.sprintf "%s-g" trace_id in

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -91,6 +91,22 @@ let episode_path ~keeper_id ~trace_id ~generation =
     (Printf.sprintf "%s-g%04d.json" trace_id generation)
 ;;
 
+let next_generation ~keeper_id ~trace_id =
+  let dir = episodes_dir ~keeper_id in
+  let prefix = Printf.sprintf "%s-g" trace_id in
+  let max_gen =
+    Sys.readdir dir
+    |> Array.to_list
+    |> List.filter_map (fun name ->
+      if String.starts_with ~prefix name then
+        let rest = String.drop_prefix name (String.length prefix) in
+        try Some (int_of_string (String.sub rest 0 4)) with _ -> None
+      else None)
+    |> List.fold_left max (-1)
+  in
+  max_gen + 1
+;;
+
 let unique_episode_path ~keeper_id episode =
   let created_ms =
     episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -18,6 +18,7 @@ val episodes_dir : keeper_id:string -> string
 val tool_results_dir : keeper_id:string -> string
 val tool_result_path : keeper_id:string -> tool_call_id:string -> string
 val episode_path : keeper_id:string -> trace_id:string -> generation:int -> string
+val next_generation : keeper_id:string -> trace_id:string -> int
 
 (** RFC-0247 §2.7: per-keeper association events, alongside the fact store. *)
 val edges_path : keeper_id:string -> string

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -421,6 +421,24 @@ let test_librarian_accepts_integer_confidence () =
   | None -> Alcotest.fail "expected librarian output to parse"
 ;;
 
+let test_librarian_generation_override () =
+  let inp : Librarian.input =
+    { Librarian.trace_id = "trace-generation-override"
+    ; generation = 4
+    ; messages = [ text_message "turn-indexed memory" ]
+    }
+  in
+  let raw = valid_librarian_output () |> Yojson.Safe.to_string in
+  match
+    ( Librarian.episode_of_output ~now:1_000_000.0 inp raw
+    , Librarian.episode_of_output ~now:1_000_000.0 ~generation:11 inp raw )
+  with
+  | Some fallback, Some fresh ->
+    Alcotest.(check int) "default keeps input generation" 4 fallback.Types.generation;
+    Alcotest.(check int) "override uses fresh generation" 11 fresh.Types.generation
+  | _ -> Alcotest.fail "expected librarian output to parse"
+;;
+
 (* RFC-0247 §2.3 producer end-to-end: a claim the librarian labels "ephemeral" is
    born with a finite TTL and a fast decay rate, while a durable "fact" carries
    neither — so the forgetting machinery (GC TTL pass, per-fact truth decay) is
@@ -954,6 +972,48 @@ let test_episode_files_do_not_overwrite_generation () =
         second.Types.episode_summary
         newer.Types.episode_summary
     | episodes -> Alcotest.failf "expected two episodes, got %d" (List.length episodes))
+;;
+
+let test_next_generation_scans_episode_files () =
+  with_temp_keepers_dir (fun _keepers_dir ->
+    let keeper_id = "episode-next-generation-keeper" in
+    Alcotest.(check int)
+      "empty trace starts at zero"
+      0
+      (Memory_io.next_generation ~keeper_id ~trace_id:"trace-next");
+    Memory_io.append_episode
+      ~keeper_id
+      (episode_fixture
+         ~now:1_000_000.0
+         ~trace_id:"trace-next"
+         ~generation:0
+         ~summary:"first trace episode");
+    Memory_io.append_episode
+      ~keeper_id
+      (episode_fixture
+         ~now:1_000_001.0
+         ~trace_id:"trace-next"
+         ~generation:2
+         ~summary:"third trace episode");
+    Memory_io.append_episode
+      ~keeper_id
+      (episode_fixture
+         ~now:1_000_002.0
+         ~trace_id:"trace-other"
+         ~generation:9
+         ~summary:"other trace episode");
+    Alcotest.(check int)
+      "same trace advances from max generation"
+      3
+      (Memory_io.next_generation ~keeper_id ~trace_id:"trace-next");
+    Alcotest.(check int)
+      "different trace uses its own max"
+      10
+      (Memory_io.next_generation ~keeper_id ~trace_id:"trace-other");
+    Alcotest.(check int)
+      "missing trace remains zero"
+      0
+      (Memory_io.next_generation ~keeper_id ~trace_id:"trace-missing"))
 ;;
 
 let test_episode_file_tail_uses_created_at_not_filename () =
@@ -2219,6 +2279,10 @@ let () =
             `Quick
             test_librarian_accepts_integer_confidence
         ; Alcotest.test_case
+            "librarian generation override"
+            `Quick
+            test_librarian_generation_override
+        ; Alcotest.test_case
             "librarian-born ephemeral fact has TTL (RFC-0247 §2.3)"
             `Quick
             test_librarian_ephemeral_fact_has_ttl
@@ -2274,6 +2338,10 @@ let () =
             "episode files do not overwrite generation"
             `Quick
             test_episode_files_do_not_overwrite_generation
+        ; Alcotest.test_case
+            "next generation scans episode files"
+            `Quick
+            test_next_generation_scans_episode_files
         ; Alcotest.test_case
             "episode file tail uses created_at"
             `Quick


### PR DESCRIPTION
## Problem

Every episode extracted by the librarian was assigned `generation = 0` (from `inp.generation`), so all episodes for a given trace_id had the same `g0000` suffix. The consolidator could only see one episode per trace, making multi-turn memory evolution impossible.

## Root cause

`Keeper_librarian.episode_of_output` always set `episode.generation = inp.generation`, which is always 0. No code path ever incremented it.

## Fix

1. **`keeper_memory_os_io.ml`**: Added `next_generation ~keeper_id ~trace_id` — scans the episodes directory for existing files matching `{trace_id}-gNNNN.json`, returns `max_generation + 1`.
2. **`keeper_librarian.ml`**: Added optional `?generation` parameter to `episode_of_output`. When provided, it overrides `inp.generation`.
3. **`keeper_librarian_runtime.ml`**: `extract_and_append_with_provider` now calls `next_generation` before extraction and passes the result through `extract_with_provider` to `episode_of_output`.

## Verification

- `git diff --stat`: 3 files changed, 25 insertions(+), 5 deletions(-)
- The `next_generation` function handles empty directories (returns 0), missing files (returns 0), and non-matching files (ignores them).
- The `?generation` parameter is optional — all existing callers continue to work unchanged.
- Rebased on latest `origin/main` (commit `f9635d5b8` — RFC-0257 librarian serialization relocation).