### PR TITLE
memory-os: add cap_edges for edges store retention (RFC-0239 Q4)

### DIFF
--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -344,6 +344,29 @@ let read_edges_all ~keeper_id =
 let read_associations ~keeper_id =
   read_edges_all ~keeper_id |> Keeper_memory_os_edges.aggregate
 ;;
+(* RFC-0239 Q4: cap the edges store to [keep] highest-ranked edges when total exceeds [trigger]. Returns the number of edges dropped. *)
+let cap_edges ~keeper_id ~keep ~trigger ~rank =
+  let path = edges_path ~keeper_id in
+  let all = read_edges_all ~keeper_id in
+  let total = List.length all in
+  if total <= trigger
+  then 0
+  else (
+    let kept =
+      all
+      |> List.stable_sort (fun a b -> Float.compare (rank b) (rank a))
+      |> take_first keep
+    in
+    let content =
+      match kept with
+      | [] -> ""
+      | _ ->
+        (kept |> List.map (fun e -> Yojson.Safe.to_string (Keeper_memory_os_edges.edge_to_json e)) |> String.concat "\n")
+        ^ "\n"
+    in
+    write_file_atomically path content;
+    total - List.length kept)
+;;
 
 let read_facts_all_strict ~keeper_id =
   let path = facts_path ~keeper_id in

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -52,6 +52,8 @@ val read_edges_all : keeper_id:string -> Keeper_memory_os_edges.edge list
 (** The aggregated read view: per-(src,dst,relation) associations with Hebbian
     weight, the surface a spreading-activation recall consumes. *)
 val read_associations : keeper_id:string -> Keeper_memory_os_edges.association list
+val cap_edges :
+  keeper_id:string -> keep:int -> trigger:int -> rank:(Keeper_memory_os_edges.edge -> float) -> int
 val read_events_tail : keeper_id:string -> n:int -> episode list
 val read_episodes_tail : keeper_id:string -> n:int -> episode list
 


### PR DESCRIPTION
Implements `cap_edges` following the same pattern as `cap_facts`: reads all edges, sorts by rank descending, keeps the top [keep] when total exceeds [trigger], rewrites the edges file atomically. Returns count of dropped edges.

Changes:
- `lib/keeper/keeper_memory_os_io.ml`: new `cap_edges` function
- `lib/keeper/keeper_memory_os_io.mli`: `cap_edges` signature

Closes task-1398.