### PR TITLE
[codex] guard workspace tool registry drift

### DIFF
--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -693,40 +693,38 @@ let handle_heartbeat ~tool_name ~start_time ctx _args =
       ~tool_name ~start_time message
 ;;
 
+type dispatch_handler =
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+
+let handle_check ~tool_name ~start_time ctx args =
+  let inspect ctx =
+    let s = inspect_state ctx in
+    { Workspace_assertions.task_claimed = s.task_claimed
+    ; current_task_set = s.current_task_set
+    }
+  in
+  Workspace_assertions.handle_check ~inspect_state:inspect ~tool_name ~start_time ctx args
+;;
+
+let dispatch_bindings : (string * dispatch_handler) list =
+  [ "masc_status", handle_status
+  ; "masc_heartbeat", handle_heartbeat
+  ; "masc_goal_list", Workspace_goals.handle_goal_list
+  ; "masc_goal_upsert", Workspace_goals.handle_goal_upsert
+  ; "masc_goal_transition", Workspace_goals.handle_goal_transition
+  ; "masc_goal_verify", Workspace_goals.handle_goal_verify
+  ; "masc_reset", handle_reset
+  ; "masc_check", handle_check
+  ]
+;;
+
+let dispatchable_names = List.map fst dispatch_bindings
+
 let dispatch ctx ~name ~args : Tool_result.result option =
   let start_time = Time_compat.now () in
-  match name with
-  | "masc_status" -> Some (handle_status ~tool_name:name ~start_time ctx args)
-  | "masc_heartbeat" -> Some (handle_heartbeat ~tool_name:name ~start_time ctx args)
-  | "masc_goal_list" ->
-    Some (Workspace_goals.handle_goal_list ~tool_name:name ~start_time ctx args)
-  | "masc_goal_upsert" ->
-    Some (Workspace_goals.handle_goal_upsert ~tool_name:name ~start_time ctx args)
-  | "masc_goal_transition" ->
-    Some
-      (Workspace_goals.handle_goal_transition
-         ~tool_name:name
-         ~start_time
-         ctx
-         args)
-  | "masc_goal_verify" ->
-    Some (Workspace_goals.handle_goal_verify ~tool_name:name ~start_time ctx args)
-  | "masc_reset" -> Some (handle_reset ~tool_name:name ~start_time ctx args)
-  | "masc_check" ->
-    let inspect ctx =
-      let s = inspect_state ctx in
-      { Workspace_assertions.task_claimed = s.task_claimed
-      ; current_task_set = s.current_task_set
-      }
-    in
-    Some
-      (Workspace_assertions.handle_check
-         ~inspect_state:inspect
-         ~tool_name:name
-         ~start_time
-         ctx
-         args)
-  | _ -> None
+  match List.assoc_opt name dispatch_bindings with
+  | Some handle -> Some (handle ~tool_name:name ~start_time ctx args)
+  | None -> None
 ;;
 
 let schemas = Tool_schemas_workspace.schemas
@@ -735,7 +733,7 @@ let schemas = Tool_schemas_workspace.schemas
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let tool_spec_read_only = [ "masc_status"; "masc_goal_list" ];;
+let tool_spec_read_only = [ "masc_status"; "masc_check"; "masc_goal_list" ];;
 
 let tool_spec_system_internal = [ "masc_reset" ]
 

--- a/lib/tool_workspace.mli
+++ b/lib/tool_workspace.mli
@@ -74,6 +74,12 @@ val assertion_kind_of_string_lenient : string -> assertion_kind option
 
 (** {1 Dispatch} *)
 
+(** Tool names routed by {!dispatch}.  This list is derived from the
+    same binding table used by runtime dispatch, so schema/registry
+    tests can fail when a workspace schema is exposed without a handler
+    route or a handler route is added without a schema. *)
+val dispatchable_names : string list
+
 (** [dispatch ctx ~name ~args] routes [name] to the appropriate
     private handler ([handle_status], [handle_reset],
     [handle_init], [handle_check],

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -37,6 +37,21 @@ let schema_inventory_names () =
   List.map (fun (s : Masc_domain.tool_schema) -> s.name) Config.raw_all_tool_schemas
 ;;
 
+let workspace_schema_names () =
+  List.map (fun (s : Masc_domain.tool_schema) -> s.name) Tool_schemas_workspace.schemas
+;;
+
+let expected_workspace_read_only_names =
+  [ "masc_check"; "masc_goal_list"; "masc_status" ]
+;;
+
+let expected_workspace_hidden_names = [ "masc_reset" ]
+
+let expect_some ~label = function
+  | Some value -> value
+  | None -> Alcotest.fail (label ^ " missing")
+;;
+
 let test_schema_set_equals_tag_registry_set () =
   init ();
   let tags = tag_registry_names () in
@@ -77,8 +92,73 @@ let test_workspace_schemas_route_to_state () =
   |> List.iter (fun (schema : Masc_domain.tool_schema) ->
        Alcotest.(check bool)
          (Printf.sprintf "%s routes to Mod_state" schema.name)
-         true
-         (Unified_tool_registry.tag_of_name schema.name = Some Tool_dispatch.Mod_state))
+       true
+       (Unified_tool_registry.tag_of_name schema.name = Some Tool_dispatch.Mod_state))
+;;
+
+let test_workspace_schemas_match_dispatch_bindings () =
+  init ();
+  assert_same_set
+    ~label:"workspace schema names vs dispatchable names"
+    ~expected:(workspace_schema_names ())
+    ~actual:Tool_workspace.dispatchable_names
+;;
+
+let test_workspace_schemas_have_tool_spec_metadata () =
+  init ();
+  let workspace_names = workspace_schema_names () in
+  let missing_tool_specs =
+    List.filter
+      (fun name -> not (List.mem name (Tool_spec.all_registered_names ())))
+      workspace_names
+  in
+  Alcotest.(check (list string))
+    "workspace schemas registered via Tool_spec"
+    []
+    missing_tool_specs;
+  let unexpected_read_only_contract =
+    List.filter
+      (fun name -> not (List.mem name workspace_names))
+      expected_workspace_read_only_names
+  in
+  Alcotest.(check (list string))
+    "expected read-only workspace tools exist"
+    []
+    unexpected_read_only_contract;
+  let unexpected_hidden_contract =
+    List.filter
+      (fun name -> not (List.mem name workspace_names))
+      expected_workspace_hidden_names
+  in
+  Alcotest.(check (list string))
+    "expected hidden workspace tools exist"
+    []
+    unexpected_hidden_contract;
+  List.iter
+    (fun name ->
+       let meta =
+         Tool_catalog.registered_metadata name
+         |> expect_some ~label:(Printf.sprintf "%s Tool_catalog metadata" name)
+       in
+       let expected_read_only = List.mem name expected_workspace_read_only_names in
+       let expected_hidden = List.mem name expected_workspace_hidden_names in
+       Alcotest.(check (option bool))
+         (Printf.sprintf "%s readonly metadata" name)
+         (Some expected_read_only)
+         meta.Tool_catalog.readonly;
+       Alcotest.(check (option bool))
+         (Printf.sprintf "%s idempotent metadata" name)
+         (Some expected_read_only)
+         meta.Tool_catalog.idempotent;
+       Alcotest.(check bool)
+         (Printf.sprintf "%s hidden visibility" name)
+         expected_hidden
+         (meta.Tool_catalog.visibility = Tool_catalog.Hidden);
+       Alcotest.(check bool)
+         (Printf.sprintf "%s direct hidden call allowance" name)
+         expected_hidden
+         meta.Tool_catalog.allow_direct_call_when_hidden)
+    workspace_names
 ;;
 
 let test_retired_tools_are_absent () =
@@ -141,6 +221,10 @@ let () =
     ; ( "workspace_tools"
       , [ test_case "workspace schemas route to Mod_state" `Quick
             test_workspace_schemas_route_to_state
+        ; test_case "workspace schemas match dispatch bindings" `Quick
+            test_workspace_schemas_match_dispatch_bindings
+        ; test_case "workspace schemas have ToolSpec metadata" `Quick
+            test_workspace_schemas_have_tool_spec_metadata
         ] )
     ; ( "retired_tools"
       , [ test_case "retired tools are absent" `Quick test_retired_tools_are_absent


### PR DESCRIPTION
## Summary

- Refactor `Tool_workspace.dispatch` to use a single dispatch binding table and expose `dispatchable_names` for registry consistency checks.
- Add workspace tool drift guards that compare workspace schemas, dispatch bindings, ToolSpec registration, and catalog metadata.
- Mark `masc_check` as read-only/idempotent ToolSpec metadata, matching its assertion-read behavior.

## Why

The Tool Orchestration Lane design starts with a hard invariant: a workspace tool must not be exposed in schema/catalog surfaces unless the runtime dispatch path and metadata agree. This closes the first P0 guard from the design doc and prevents schema/dispatch/ToolSpec drift from becoming a hidden runtime failure.

Closes #21517.

## Validation

- `ocamlformat --inplace lib/tool_workspace.ml lib/tool_workspace.mli test/test_tool_registry_consistency.ml`
- `scripts/dune-local.sh build test/test_tool_registry_consistency.exe`
- `./_build/default/test/test_tool_registry_consistency.exe`
