### PR TITLE
config(runtime): add minimax-m3 for memory-os librarian (fix ~74% empty-response producer)

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -151,6 +151,34 @@ supports-structured-output = false
 
 [glm-coding.glm-5-turbo]
 
+# MiniMax M3 (Ollama Cloud) — runtime for the memory-os librarian (post-turn
+# episode extraction). The librarian requests JsonMode
+# (keeper_librarian_runtime.ml:228); a runtime whose model omits
+# supports-response-format-json produces unconstrained output, which on the
+# fleet default (deepseek-v4-flash, no JSON capability declared) measured ~74%
+# empty / invalid-JSON. minimax-m3 declares json + structured output and is the
+# memory_os judge runtime. Activate for the librarian only via
+# MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID=ollama_cloud.minimax-m3 (keeper
+# chat stays on [runtime].default). api-name verified 2026-06-18 against
+# https://ollama.com/v1/chat/completions: HTTP 200 with response_format
+# json_object honored (clean JSON body), model "minimax-m3".
+[models.minimax-m3]
+api-name = "minimax-m3"
+max-context = 1000000
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.minimax-m3.capabilities]
+max-output-tokens = 131072
+supports-tool-choice = true
+supports-extended-thinking = true
+supports-native-streaming = true
+supports-response-format-json = true
+supports-structured-output = true
+
+[ollama_cloud.minimax-m3]
+
 [ollama.gemma4-26b-a4b-qat]
 max-concurrent = 1
 


### PR DESCRIPTION
## 목표
memory-os librarian(post-turn episode 추출) producer가 라이브에서 ~74% 실패(empty/invalid-JSON)하는 P0를 모델/capability 레벨에서 해소.

## 근본 원인 (file:line + 라이브 로그)
- librarian은 `response_format = JsonMode`를 요청한다 (`lib/keeper/keeper_librarian_runtime.ml:228`).
- 별도 라우팅이 없어 플릿 기본 `[runtime].default = ollama_cloud.deepseek-v4-flash`를 상속한다 (`config/runtime.toml:13`).
- `[models.deepseek-v4-flash]`에는 `.capabilities`가 없어 `supports-response-format-json` 미선언 → OAS가 `format=json`을 enforce하지 못해 unconstrained 출력 → empty/invalid.
- 라이브 측정(2026-06-18, exact event key): empty 245 + invalid-JSON 64 + timeout 23 vs wrote ~119 = **success ~26%**. 모든 실패가 단일 runtime, 하루 균일 분포(burst 아님). provider gate(#21376)+cadence(#21458) 머지 후에도 불변 → 부하 아닌 모델/capability.

## 변경
- `config/runtime.toml`(seed): `[models.minimax-m3]` + `.capabilities`(`supports-response-format-json=true`, `supports-structured-output=true`) + `[ollama_cloud.minimax-m3]` 바인딩 (+27, 로직 0줄).
- minimax-m3 근거: 이 시스템 memory_os judge로 gold 9/9 검증, 1M ctx. Ollama Cloud 카탈로그 존재.

## 검증 (완료)
- `tomllib` 파싱 OK, minimax 엔트리/바인딩 확인.
- **api-name `minimax-m3` 라이브 검증**: `curl https://ollama.com/v1/chat/completions ... response_format=json_object` → **HTTP 200 + clean JSON body**. ollama cloud가 JSON 모드를 honor함을 실측(flash가 empty 내던 자리).
- coverage gate: data-only 카탈로그 엔트리(로직 0줄, seed 파일은 in-harness 테스트 seam 없음)라 설계된 opt-out `# ci:skip-test-coverage`를 근거와 함께 사용(commit message).

## 활성화 (운영자, 라이브 — seed는 라이브 미반영)
1. live `.masc/config/runtime.toml`에 동일 블록 추가 (runtime config path).
2. `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID=ollama_cloud.minimax-m3` 후 재시작. keeper chat은 default(flash) 유지.
3. empty-rate 강하 측정 — 미개선 시 `deepseek.deepseek-v4-pro` 폴백(이미 capability 선언). root가 (a)capability drop이든 (b)flash 품질이든 둘 다 robust.

## 범위 밖 (follow-up)
- OAS fail-loud capability gate: librarian이 JSON 미지원 runtime을 만나면 silent empty 대신 skip/warn. capability가 OAS(`Llm_provider.Provider_config`)에 있어 masc 단독 불가 → OAS 이슈.

RFC-WAIVED: runtime 모델 카탈로그 추가, gated subsystem 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
