### PR TITLE
feat(runtime): [runtime].librarian config-driven memory-os librarian routing

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -11,6 +11,13 @@
 
 [runtime]
 default = "ollama_cloud.deepseek-v4-flash"
+# memory-os librarian (post-turn episode extraction) runs JSON mode, so it is
+# routed independently of keeper chat to a JSON-capable runtime. minimax-m3
+# declares supports-response-format-json (deepseek-v4-flash does not — it
+# measured ~74% empty/invalid-JSON on the librarian, 2026-06-18). Override per
+# process with MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID. Unset = inherit each
+# keeper's runtime (legacy).
+librarian = "ollama_cloud.minimax-m3"
 
 [providers.ollama_cloud]
 display-name = "Ollama Cloud"

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -195,7 +195,14 @@ let runtime_id_for_librarian ~runtime_id =
     Keeper_memory_bank_env.memory_env_opt "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
   with
   | Some value -> value
-  | None -> runtime_id
+  | None ->
+    (* [runtime].librarian (runtime.toml) routes the librarian independently of
+       keeper chat — the librarian runs JSON mode and needs a JSON-capable model,
+       which the cheap chat runtimes may not be. Env var above takes precedence;
+       [None] here falls back to inheriting the keeper's own runtime. *)
+    (match Runtime.librarian_runtime_id () with
+     | Some id -> id
+     | None -> runtime_id)
 ;;
 
 let select_recent_messages ~max_messages messages =

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -69,8 +69,28 @@ let validate_keeper_assignments ~(config_path : string) (runtimes : t list)
          (List.length runtimes))
 ;;
 
+(* [runtime].librarian must resolve to a configured runtime when set, mirroring
+   [runtime].default / [runtime.assignments] validation: an unknown id is an
+   operator typo rejected at load, not a silent fallback (Unknown→Permissive
+   anti-pattern). [None] is the designed "inherit the keeper's runtime" case. *)
+let validate_librarian_runtime ~(config_path : string) (runtimes : t list)
+    (librarian_id : string option) : (unit, string) result =
+  match librarian_id with
+  | None -> Ok ()
+  | Some id ->
+    if List.exists (fun (r : t) -> String.equal r.id id) runtimes
+    then Ok ()
+    else
+      Error
+        (Printf.sprintf
+           "%s: [runtime].librarian = %S not found among %d runtimes"
+           config_path
+           id
+           (List.length runtimes))
+;;
+
 let materialize_config ~(config_path : string) (cfg : config)
-  : (t list * t * (string * string) list, string) result
+  : (t list * t * (string * string) list * string option, string) result
   =
   let runtimes = List.filter_map (of_binding cfg) cfg.bindings in
   let assignments = cfg.keeper_assignments in
@@ -93,11 +113,18 @@ let materialize_config ~(config_path : string) (cfg : config)
      | Some rt ->
        (match validate_keeper_assignments ~config_path runtimes assignments with
         | Error _ as e -> e
-        | Ok () -> Ok (runtimes, rt, assignments)))
+        | Ok () ->
+          (match
+             validate_librarian_runtime ~config_path runtimes
+               cfg.librarian_runtime_id
+           with
+           | Error _ as e -> e
+           | Ok () ->
+             Ok (runtimes, rt, assignments, cfg.librarian_runtime_id))))
 ;;
 
 let load_list ~(config_path : string)
-  : (t list * t * (string * string) list, string) result
+  : (t list * t * (string * string) list * string option, string) result
   =
   match Runtime_toml.parse_file config_path with
   | Error errs ->
@@ -124,14 +151,20 @@ let runtimes_ref : t list Atomic.t = Atomic.make []
    configured runtime. *)
 let keeper_assignments_ref : (string * string) list Atomic.t = Atomic.make []
 
+(* [runtime].librarian — runtime id for the memory-os librarian, or [None] to
+   inherit the keeper's own runtime. Populated by [init_default], read by
+   [librarian_runtime_id]; validated at load so a [Some] always resolves. *)
+let librarian_runtime_id_ref : string option Atomic.t = Atomic.make None
+
 let runtime_ids runtimes = List.map (fun (rt : t) -> rt.id) runtimes
 
 let init_default ~config_path =
   match load_list ~config_path with
-  | Ok (runtimes, rt, assignments) ->
+  | Ok (runtimes, rt, assignments, librarian_id) ->
     Atomic.set runtimes_ref runtimes;
     Atomic.set default_runtime_ref (Some rt);
     Atomic.set keeper_assignments_ref assignments;
+    Atomic.set librarian_runtime_id_ref librarian_id;
     Ok ()
   | Error _ as e -> e
 
@@ -148,6 +181,11 @@ let get_runtime_ids () = runtime_ids (Atomic.get runtimes_ref)
 let runtime_id_for_keeper (keeper_name : string) : string option =
   List.assoc_opt keeper_name (Atomic.get keeper_assignments_ref)
 ;;
+
+(* [runtime].librarian routing for the memory-os librarian. [None] = the
+   librarian inherits each keeper's runtime (legacy). Reads the Atomic ref set by
+   [init_default]; the env override lives in keeper_librarian_runtime. *)
+let librarian_runtime_id () = Atomic.get librarian_runtime_id_ref
 
 (* RFC-0207: resolve a runtime by its binding-key id ["provider.model"].  The
    keeper turn driver dispatches to the *requested* runtime (a keeper's persona

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -19,12 +19,16 @@ val id_of_binding : binding -> string
 val of_binding : config -> binding -> t option
 
 val load_list :
-  config_path:string -> (t list * t * (string * string) list, string) result
+  config_path:string
+  -> (t list * t * (string * string) list * string option, string) result
 (** [load_list ~config_path] parses runtime.toml into [(runtimes, default,
-    keeper_assignments)]. Fails ([Error]) if [\[runtime\].default] is missing /
-    unresolved, or if any [\[runtime.assignments\]] target does not resolve to a
-    configured runtime (mirrors default validation — no silent fallback for a
-    typo'd assignment). [keeper_assignments] is the keeper→runtime-id list. *)
+    keeper_assignments, librarian_runtime_id)]. Fails ([Error]) if
+    [\[runtime\].default] is missing / unresolved, if any
+    [\[runtime.assignments\]] target does not resolve to a configured runtime, or
+    if [\[runtime\].librarian] is set to an unresolved id (mirrors default
+    validation — no silent fallback for a typo'd id). [keeper_assignments] is the
+    keeper→runtime-id list; [librarian_runtime_id] is the optional memory-os
+    librarian runtime. *)
 
 val runtime_ids : t list -> string list
 
@@ -46,6 +50,13 @@ val runtime_id_for_keeper : string -> string option
     {!get_default_runtime_id}). The id is opaque (only the OAS adapter parses
     it). persona⊥{model,runtime}: keeper→runtime assignment is NOT sourced from
     persona JSON or keeper TOML. *)
+
+val librarian_runtime_id : unit -> string option
+(** [\[runtime\].librarian] runtime id for the memory-os librarian, or [None]
+    when unset (the librarian inherits each keeper's runtime). Validated at load
+    so a [Some] always resolves to a configured runtime.
+    [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID] overrides this at the librarian
+    call site. *)
 
 val get_runtime_by_id : string -> t option
 (** [get_runtime_by_id id] is the materialized runtime whose binding-key id

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -184,6 +184,14 @@ type config =
   ; models : model_spec list
   ; bindings : binding list
   ; default_runtime_id : string option
+  ; librarian_runtime_id : string option
+    (** [\[runtime\].librarian] — runtime id ["provider.model"] for the memory-os
+        librarian (post-turn episode extraction). The librarian requests JSON
+        mode, so it must run on a model that declares
+        [supports-response-format-json]; the keeper chat runtimes need not.
+        [None] = the librarian inherits each keeper's runtime (legacy). An
+        unknown id is rejected at load like [\[runtime\].default]. The
+        [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID] env var overrides this. *)
   ; keeper_assignments : (string * string) list
     (** [\[runtime.assignments\]] — keeper name → runtime id ["provider.model"].
         runtime.toml is the sole SSOT for keeper→runtime assignment (persona⊥

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -131,6 +131,13 @@ type config =
   ; models : model_spec list
   ; bindings : binding list
   ; default_runtime_id : string option
+  ; librarian_runtime_id : string option
+    (** [\[runtime\].librarian] — runtime id for the memory-os librarian
+        (post-turn episode extraction). The librarian requests JSON mode, so it
+        must run on a model declaring [supports-response-format-json]. [None] =
+        inherit each keeper's runtime. Unknown id rejected at load like
+        [\[runtime\].default]; [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID]
+        overrides. *)
   ; keeper_assignments : (string * string) list
     (** [\[runtime.assignments\]] — keeper name → runtime id ["provider.model"].
         Sole SSOT for keeper→runtime assignment (persona⊥{model,runtime}). A

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -656,6 +656,9 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
   let default_runtime_id =
     Otoml.find_opt toml Otoml.get_string [ "runtime"; "default" ]
   in
+  let librarian_runtime_id =
+    Otoml.find_opt toml Otoml.get_string [ "runtime"; "librarian" ]
+  in
   if all_errors <> []
   then Error all_errors
   else (
@@ -674,6 +677,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
       ; models
       ; bindings
       ; default_runtime_id
+      ; librarian_runtime_id
       ; keeper_assignments
       })
 ;;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -28,7 +28,7 @@ let test_repo_runtime_toml_loads () =
   check bool "repo runtime.toml present" true (Sys.file_exists path);
   match Runtime.load_list ~config_path:path with
   | Error msg -> failf "repo runtime.toml should load: %s" msg
-  | Ok (runtimes, default, assignments) ->
+  | Ok (runtimes, default, assignments, _librarian) ->
     check bool "at least one runtime" true (List.length runtimes > 0);
     check string "default runtime" "ollama_cloud.deepseek-v4-flash"
       default.Runtime.id;
@@ -316,7 +316,7 @@ let test_runtime_toml_max_concurrent_flows_to_candidate () =
   with_temp_runtime_toml content (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "runtime TOML should materialize: %s" msg
-    | Ok (runtimes, _default, _assignments) ->
+    | Ok (runtimes, _default, _assignments, _librarian) ->
       let expect id expected =
         match
           List.find_opt (fun (rt : Runtime.t) -> String.equal rt.id id) runtimes
@@ -342,6 +342,46 @@ let test_runtime_toml_max_concurrent_flows_to_candidate () =
       expect "local.no-cap" None;
       expect "local.capped" (Some 5))
 
+(* [runtime].librarian (RFC: memory-os librarian routing): resolves to a
+   configured runtime and is returned by load_list; absent = None (inherit
+   keeper runtime); an unknown id is rejected at load like [runtime].default. *)
+let test_librarian_runtime_routing () =
+  let base =
+    "[providers.local]\n\
+     display-name = \"Local\"\n\
+     protocol = \"ollama-http\"\n\
+     endpoint = \"http://localhost:11434\"\n\
+     \n\
+     [models.chat]\n\
+     api-name = \"chat\"\n\
+     max-context = 1024\n\
+     \n\
+     [models.libr]\n\
+     api-name = \"libr\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.chat]\n\
+     \n\
+     [local.libr]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.chat\"\n"
+  in
+  with_temp_runtime_toml (base ^ "librarian = \"local.libr\"\n") (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error msg -> failf "librarian routing should load: %s" msg
+    | Ok (_runtimes, _default, _assignments, librarian) ->
+      check (option string) "librarian runtime id" (Some "local.libr") librarian);
+  with_temp_runtime_toml base (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error msg -> failf "absent librarian should load: %s" msg
+    | Ok (_, _, _, librarian) ->
+      check (option string) "librarian unset is None" None librarian);
+  with_temp_runtime_toml (base ^ "librarian = \"local.nope\"\n") (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Ok _ -> failf "unknown [runtime].librarian id must be rejected at load"
+    | Error _ -> ())
+
 let () =
   run "runtime_config_validity"
     [ ( "runtime TOML gate",
@@ -349,6 +389,9 @@ let () =
             test_runtime_json_not_in_repo_config;
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
+          test_case
+            "[runtime].librarian resolves, defaults to None, rejects unknown"
+            `Quick test_librarian_runtime_routing;
           test_case
             "lifecycle TOML keys resolve through the declarative catalog"
             `Quick test_toml_catalog_resolves_lifecycle_keys;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -455,6 +455,7 @@ let test_runtime_adapter_keeps_auth_out_of_headers () =
     ; models = [ qwen_model ]
     ; bindings = [ runpod_binding ]
     ; default_runtime_id = Some "runpod_mtp.qwen"
+    ; librarian_runtime_id = None
     ; keeper_assignments = []
     }
   in
@@ -484,6 +485,7 @@ let test_runtime_adapter_filters_toml_auth_headers () =
     ; models = [ qwen_model ]
     ; bindings = [ runpod_binding ]
     ; default_runtime_id = Some "runpod_mtp.qwen"
+    ; librarian_runtime_id = None
     ; keeper_assignments = []
     }
   in
@@ -514,6 +516,7 @@ let provider_cfg () =
     ; models = [ qwen_model ]
     ; bindings = [ runpod_binding ]
     ; default_runtime_id = Some "runpod_mtp.qwen"
+    ; librarian_runtime_id = None
     ; keeper_assignments = []
     }
   in
@@ -589,6 +592,7 @@ let runtime_or_fail ?(provider = runpod_provider) () =
     ; models = [ qwen_model ]
     ; bindings = [ runpod_binding ]
     ; default_runtime_id = Some "runpod_mtp.qwen"
+    ; librarian_runtime_id = None
     ; keeper_assignments = []
     }
   in


### PR DESCRIPTION
## 목표
memory-os librarian(post-turn 추출)을 **runtime.toml로 제대로 라우팅** — 기존엔 env(`MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID`)만 가능했음. librarian은 JSON mode를 요구하는데 chat 모델(deepseek-v4-flash/qwen36)이 `supports-response-format-json` 미선언이라 라이브 ~74% empty/invalid (2026-06-18). minimax-m3(JSON-capable, curl 검증)로 보내야 하나 discoverable한 config seam이 없었음.

## 변경 — `[runtime].librarian` 추가
- **schema** (`runtime_schema.ml/.mli`): `config.librarian_runtime_id : string option`.
- **parser** (`runtime_toml.ml`): `[runtime].librarian` 파싱 → config.
- **load/validate** (`runtime.ml/.mli`): `validate_librarian_runtime` — Some면 binding에 resolve돼야 하고 unknown id는 load에서 **reject**(default와 동일, silent fallback 없음). 전역 Atomic + accessor `Runtime.librarian_runtime_id ()`. `load_list`/`materialize_config`는 4-tuple(+ librarian id)로 확장.
- **librarian** (`keeper_librarian_runtime.ml`): `runtime_id_for_librarian` = env override > `Runtime.librarian_runtime_id ()` > 키퍼 runtime 상속. (lib/keeper→Runtime 의존은 기존 존재, hook 불필요.)
- **seed** (`config/runtime.toml`): `librarian = "ollama_cloud.minimax-m3"`.

경계 설계: librarian은 chat과 **다른 모델 요구**(JSON mode)를 가지므로 독립 라우팅 필드. chat 비용에 영향 없이 librarian만 JSON-capable 모델로.

## 검증
- `DUNE_CACHE=disabled dune build lib/runtime lib/keeper test/...` exit 0 (.mli 변경 → 풀빌드).
- `test_runtime_config_validity`: **10 tests green** — 신규 케이스 `[runtime].librarian resolves, defaults to None, rejects unknown`(resolve / 미지정=None / unknown reject 3-경로). 기존 `test_repo_runtime_toml_loads`도 seed(librarian=minimax 포함) 로드/검증 통과.
- ocamlformat --check: 변경 7개 OCaml 파일 전부 OK.
- minimax-m3 api-name 라이브 검증: `curl ollama.com/v1 response_format=json_object` → HTTP 200 clean JSON (별도, #21519).

## 라이브 적용 (운영자)
seed는 신규 워크스페이스용. 라이브(`~/me/.masc/config/runtime.toml`)에 ① minimax-m3 블록에 `[models.minimax-m3.capabilities] supports-response-format-json=true` 추가 ② `[runtime] librarian = "ollama_cloud.minimax-m3"` 추가 후 **재빌드+재시작**(코드 변경이므로 env-only보다 재빌드 필요). 적용 후 empty→wrote 측정.

## 범위 밖 (follow-up)
- OAS fail-loud capability gate: librarian이 JSON 미지원 runtime을 만나면 silent empty 대신 skip/warn (capability가 OAS `Llm_provider.Provider_config`에 있어 masc 단독 불가).

RFC-WAIVED: runtime 설정 라우팅 필드 추가, gated subsystem(credential/repo/operator/dashboard-credential/hooks/workflow) 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
