### PR TITLE
feat(verifier): add grounded verdict evidence parser

### DIFF
--- a/lib/verifier_core.ml
+++ b/lib/verifier_core.ml
@@ -25,6 +25,17 @@ type verdict =
   | Warn of string
   | Fail of string
 
+type grounded_ref = {
+  path : string;
+  line : int option;
+  quote : string;
+}
+
+type grounded_verdict = {
+  verdict : verdict;
+  evidence : grounded_ref list;
+}
+
 (* ================================================================ *)
 (* Read-Only Detection                                              *)
 (* ================================================================ *)
@@ -120,6 +131,38 @@ let parse_verdict (text : string) : (verdict, string) result =
        String_util.utf8_safe ~max_bytes:83 ~suffix:"..." trimmed
        |> String_util.to_string))
 
+let validate_grounded_ref idx (ref_ : grounded_ref) =
+  let path = String.trim ref_.path in
+  let quote = String.trim ref_.quote in
+  if path = "" then Error (sprintf "evidence[%d].path is required" idx)
+  else if quote = "" then Error (sprintf "evidence[%d].quote is required" idx)
+  else
+    match ref_.line with
+    | Some line when line <= 0 ->
+      Error (sprintf "evidence[%d].line must be >= 1" idx)
+    | Some _ | None -> Ok ()
+
+let validate_grounded_refs refs =
+  let rec loop idx = function
+    | [] -> Ok ()
+    | ref_ :: rest -> (
+      match validate_grounded_ref idx ref_ with
+      | Error _ as e -> e
+      | Ok () -> loop (idx + 1) rest)
+  in
+  loop 0 refs
+
+let grounded_of verdict evidence =
+  match verdict with
+  | Pass -> Ok { verdict; evidence = [] }
+  | Warn _ | Fail _ ->
+    if evidence = [] then
+      Error "WARN/FAIL verdicts require at least one evidence item"
+    else
+      match validate_grounded_refs evidence with
+      | Error _ as e -> e
+      | Ok () -> Ok { verdict; evidence }
+
 (* ================================================================ *)
 (* Structured Verdict: Tool Schema + JSON Parsing (ADR D3)          *)
 (* ================================================================ *)
@@ -142,6 +185,29 @@ let report_verdict_schema : Masc_domain.tool_schema =
         "reason", `Assoc [
           "type", `String "string";
           "description", `String "Brief explanation for the verdict (required for WARN and FAIL)";
+        ];
+        "evidence", `Assoc [
+          "type", `String "array";
+          "description", `String "Optional grounding references: each item cites a repo-relative path, optional 1-based line, and verbatim quote";
+          "items", `Assoc [
+            "type", `String "object";
+            "properties", `Assoc [
+              "path", `Assoc [
+                "type", `String "string";
+                "description", `String "Repo-relative file path inspected by the reviewer";
+              ];
+              "line", `Assoc [
+                "type", `String "integer";
+                "minimum", `Int 1;
+                "description", `String "Optional 1-based line number";
+              ];
+              "quote", `Assoc [
+                "type", `String "string";
+                "description", `String "Verbatim excerpt from the cited file";
+              ];
+            ];
+            "required", `List [ `String "path"; `String "quote" ];
+          ];
         ];
       ];
       "required", `List [`String "verdict"];
@@ -174,3 +240,61 @@ let parse_verdict_from_json (args : Yojson.Safe.t) : (verdict, string) result =
     Error (sprintf "verdict JSON type error: %s" msg)
   | exn ->
     Error (sprintf "verdict JSON parse error: %s" (Printexc.to_string exn))
+
+let parse_evidence_line ~idx json =
+  match Json_util.assoc_member_opt "line" json with
+  | None | Some `Null -> Ok None
+  | Some (`Int line) when line > 0 -> Ok (Some line)
+  | Some (`Intlit raw) -> (
+    match int_of_string_opt raw with
+    | Some line when line > 0 -> Ok (Some line)
+    | _ -> Error (sprintf "evidence[%d].line must be >= 1" idx))
+  | Some (`Int _) -> Error (sprintf "evidence[%d].line must be >= 1" idx)
+  | Some other ->
+    Error
+      (sprintf "evidence[%d].line must be an integer, got %s" idx
+         (Json_util.kind_name other))
+
+let parse_evidence_item idx = function
+  | `Assoc _ as json -> (
+    match Json_util.require_string json "path" with
+    | Error msg -> Error (sprintf "evidence[%d]: %s" idx msg)
+    | Ok path -> (
+      match Json_util.require_string json "quote" with
+      | Error msg -> Error (sprintf "evidence[%d]: %s" idx msg)
+      | Ok quote -> (
+        match parse_evidence_line ~idx json with
+        | Error _ as e -> e
+        | Ok line ->
+          let ref_ = { path; line; quote } in
+          match validate_grounded_ref idx ref_ with
+          | Error _ as e -> e
+          | Ok () -> Ok ref_)))
+  | other ->
+    Error
+      (sprintf "evidence[%d] must be an object, got %s" idx
+         (Json_util.kind_name other))
+
+let parse_evidence_from_json args =
+  match Json_util.assoc_member_opt "evidence" args with
+  | None | Some `Null -> Ok []
+  | Some (`List items) ->
+    let rec loop idx acc = function
+      | [] -> Ok (List.rev acc)
+      | item :: rest -> (
+        match parse_evidence_item idx item with
+        | Error _ as e -> e
+        | Ok ref_ -> loop (idx + 1) (ref_ :: acc) rest)
+    in
+    loop 0 [] items
+  | Some other ->
+    Error (sprintf "evidence must be an array, got %s" (Json_util.kind_name other))
+
+let parse_grounded_verdict_from_json args =
+  match parse_verdict_from_json args with
+  | Error _ as e -> e
+  | Ok Pass -> grounded_of Pass []
+  | Ok verdict -> (
+    match parse_evidence_from_json args with
+    | Error _ as e -> e
+    | Ok evidence -> grounded_of verdict evidence)

--- a/lib/verifier_core.mli
+++ b/lib/verifier_core.mli
@@ -23,6 +23,17 @@ type verdict =
   | Warn of string
   | Fail of string
 
+type grounded_ref = {
+  path : string;
+  line : int option;
+  quote : string;
+}
+
+type grounded_verdict = private {
+  verdict : verdict;
+  evidence : grounded_ref list;
+}
+
 (** {1 Read-Only Detection} *)
 
 (** [should_skip ~action_description] returns [true] when the
@@ -52,14 +63,29 @@ val valid_verdict_strings : string list
     [Fail] fill in a default reason. *)
 val parse_verdict : string -> (verdict, string) result
 
+(** [grounded_of verdict evidence] builds a grounded verdict. [Pass]
+    does not require evidence. [Warn]/[Fail] require at least one
+    evidence item with a non-empty [path] and [quote], and [line] must
+    be 1-based when present. *)
+val grounded_of :
+  verdict -> grounded_ref list -> (grounded_verdict, string) result
+
 (** {1 Structured Verdict — report_verdict tool} *)
 
 (** MCP tool schema for [report_verdict]: [verdict] (enum of
-    {!valid_verdict_strings}) + optional [reason]. *)
+    {!valid_verdict_strings}) + optional [reason] and optional
+    [evidence]. *)
 val report_verdict_schema : Masc_domain.tool_schema
 
 (** Parse a [report_verdict] JSON arg payload. Empty/missing [reason]
     on [Warn]/[Fail] fills in a default reason (same as
     {!parse_verdict}). Errors on type mismatch or unknown [verdict]
-    values. *)
+    values. Optional [evidence] is accepted but ignored by this
+    compatibility parser. *)
 val parse_verdict_from_json : Yojson.Safe.t -> (verdict, string) result
+
+(** Parse a [report_verdict] JSON arg payload and enforce grounding.
+    This is the opt-in parser for reviewers that need blocking/wake
+    semantics: [Warn]/[Fail] without valid [evidence] return [Error]. *)
+val parse_grounded_verdict_from_json :
+  Yojson.Safe.t -> (grounded_verdict, string) result

--- a/test/dune
+++ b/test/dune
@@ -1225,6 +1225,13 @@
 
 ; test_failover_leader removed (CP purge)
 
+; RFC-0258 P1: grounded verifier verdict parsing.
+
+(test
+ (name test_verifier_core_grounding)
+ (modules test_verifier_core_grounding)
+ (libraries masc_test_deps))
+
 ; Keeper Tool Matrix — shared case modules as a library
 
 (library

--- a/test/test_verifier_core_grounding.ml
+++ b/test/test_verifier_core_grounding.ml
@@ -1,0 +1,152 @@
+(** test_verifier_core_grounding — RFC-0258 P1 additive grounding.
+
+    These tests pin the narrow contract: the public [verdict] variant stays
+    unchanged, legacy JSON verdict parsing stays compatible, and the opt-in
+    grounded parser refuses ungrounded blocking verdicts. *)
+
+module VC = Masc.Verifier_core
+
+let evidence ?line ?(path = "lib/foo.ml") ?(quote = "let x = 1") () :
+    VC.grounded_ref =
+  { path; line; quote }
+
+let json ?reason ?evidence_items verdict =
+  let fields =
+    [ ("verdict", `String verdict) ]
+    @ (match reason with None -> [] | Some s -> [ ("reason", `String s) ])
+    @
+    match evidence_items with
+    | None -> []
+    | Some items -> [ ("evidence", `List items) ]
+  in
+  `Assoc fields
+
+let evidence_json ?line ?(path = "lib/foo.ml") ?(quote = "let x = 1") () =
+  let fields =
+    [ ("path", `String path); ("quote", `String quote) ]
+    @ (match line with None -> [] | Some n -> [ ("line", `Int n) ])
+  in
+  `Assoc fields
+
+let test_grounded_of_pass_allows_no_evidence () =
+  match VC.grounded_of VC.Pass [] with
+  | Ok grounded ->
+    Alcotest.(check bool) "pass verdict" true (grounded.verdict = VC.Pass);
+    Alcotest.(check int) "pass evidence ignored" 0 (List.length grounded.evidence)
+  | Error msg -> Alcotest.fail msg
+
+let test_grounded_of_fail_requires_evidence () =
+  match VC.grounded_of (VC.Fail "bad") [] with
+  | Error msg ->
+    Alcotest.(check bool) "mentions evidence" true (String.length msg > 0)
+  | Ok _ -> Alcotest.fail "expected ungrounded FAIL to be refused"
+
+let test_grounded_of_warn_requires_evidence () =
+  match VC.grounded_of (VC.Warn "concern") [] with
+  | Error msg ->
+    Alcotest.(check bool) "mentions evidence" true (String.length msg > 0)
+  | Ok _ -> Alcotest.fail "expected ungrounded WARN to be refused"
+
+let test_grounded_of_fail_accepts_valid_evidence () =
+  match VC.grounded_of (VC.Fail "bad") [ evidence ~line:7 () ] with
+  | Ok grounded ->
+    Alcotest.(check int) "one evidence" 1 (List.length grounded.evidence);
+    let first = List.hd grounded.evidence in
+    Alcotest.(check (option int)) "line preserved" (Some 7) first.line
+  | Error msg -> Alcotest.fail msg
+
+let test_legacy_parser_accepts_optional_evidence () =
+  let payload =
+    json ~reason:"bad" ~evidence_items:[ evidence_json ~line:3 () ] "FAIL"
+  in
+  match VC.parse_verdict_from_json payload with
+  | Ok (VC.Fail reason) -> Alcotest.(check string) "reason" "bad" reason
+  | Ok other ->
+    Alcotest.failf "expected Fail, got %s" (VC.verdict_to_string other)
+  | Error msg -> Alcotest.fail msg
+
+let test_grounded_parser_round_trips_evidence () =
+  let payload =
+    json ~reason:"bad"
+      ~evidence_items:[ evidence_json ~line:3 ~path:"lib/foo.ml" ~quote:"let x = 1" () ]
+      "FAIL"
+  in
+  match VC.parse_grounded_verdict_from_json payload with
+  | Ok grounded ->
+    Alcotest.(check int) "one evidence" 1 (List.length grounded.evidence);
+    let first = List.hd grounded.evidence in
+    Alcotest.(check string) "path" "lib/foo.ml" first.path;
+    Alcotest.(check (option int)) "line" (Some 3) first.line;
+    Alcotest.(check string) "quote" "let x = 1" first.quote
+  | Error msg -> Alcotest.fail msg
+
+let test_grounded_parser_ignores_pass_evidence () =
+  let payload =
+    json ~evidence_items:[ `String "not an evidence object" ] "PASS"
+  in
+  match VC.parse_grounded_verdict_from_json payload with
+  | Ok grounded ->
+    Alcotest.(check bool) "pass verdict" true (grounded.verdict = VC.Pass);
+    Alcotest.(check int) "pass evidence ignored" 0 (List.length grounded.evidence)
+  | Error msg -> Alcotest.fail msg
+
+let test_grounded_parser_refuses_empty_fail () =
+  match VC.parse_grounded_verdict_from_json (json ~reason:"bad" "FAIL") with
+  | Error msg ->
+    Alcotest.(check bool) "mentions evidence" true (String.length msg > 0)
+  | Ok _ -> Alcotest.fail "expected ungrounded FAIL to be refused"
+
+let test_grounded_parser_rejects_bad_line () =
+  let payload =
+    json ~reason:"bad" ~evidence_items:[ evidence_json ~line:0 () ] "FAIL"
+  in
+  match VC.parse_grounded_verdict_from_json payload with
+  | Error msg ->
+    Alcotest.(check bool) "mentions line" true
+      (String.contains msg 'l')
+  | Ok _ -> Alcotest.fail "expected line 0 to be rejected"
+
+let test_report_schema_keeps_verdict_enum_and_adds_evidence () =
+  let schema = VC.report_verdict_schema.input_schema in
+  let open Yojson.Safe.Util in
+  let props = schema |> member "properties" in
+  let enum =
+    props |> member "verdict" |> member "enum" |> to_list
+    |> List.map to_string
+  in
+  Alcotest.(check (list string)) "verdict enum unchanged"
+    [ "PASS"; "WARN"; "FAIL" ] enum;
+  Alcotest.(check string) "evidence is array"
+    "array"
+    (props |> member "evidence" |> member "type" |> to_string)
+
+let () =
+  Alcotest.run "verifier_core_grounding"
+    [
+      ( "grounded_of",
+        [
+          Alcotest.test_case "Pass allows no evidence" `Quick
+            test_grounded_of_pass_allows_no_evidence;
+          Alcotest.test_case "Fail requires evidence" `Quick
+            test_grounded_of_fail_requires_evidence;
+          Alcotest.test_case "Warn requires evidence" `Quick
+            test_grounded_of_warn_requires_evidence;
+          Alcotest.test_case "Fail accepts evidence" `Quick
+            test_grounded_of_fail_accepts_valid_evidence;
+        ] );
+      ( "json",
+        [
+          Alcotest.test_case "legacy parser accepts evidence" `Quick
+            test_legacy_parser_accepts_optional_evidence;
+          Alcotest.test_case "grounded parser round trips evidence" `Quick
+            test_grounded_parser_round_trips_evidence;
+          Alcotest.test_case "grounded parser ignores Pass evidence" `Quick
+            test_grounded_parser_ignores_pass_evidence;
+          Alcotest.test_case "grounded parser refuses empty Fail" `Quick
+            test_grounded_parser_refuses_empty_fail;
+          Alcotest.test_case "grounded parser rejects bad line" `Quick
+            test_grounded_parser_rejects_bad_line;
+          Alcotest.test_case "schema keeps enum and adds evidence" `Quick
+            test_report_schema_keeps_verdict_enum_and_adds_evidence;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add `Verifier_core.grounded_ref` and private `grounded_verdict` without changing the existing `verdict` variant shape
- extend `report_verdict_schema` with optional `evidence` while keeping the `PASS`/`WARN`/`FAIL` enum unchanged
- add opt-in `parse_grounded_verdict_from_json`; legacy `parse_verdict_from_json` remains compatible and ignores evidence
- add focused RFC-0258 P1 tests for grounding, parser compatibility, and schema shape

## Validation
- `scripts/dune-local.sh build @runtest-test_verifier_core_grounding`
- `scripts/dune-local.sh build @runtest-test_verifier_oas_bridge @runtest-test_keeper_adversarial_review`
- `git diff --check`

## Notes
This is P1 only. It does not route live verifier/wake behavior through grounded verdicts yet; P2/P3 should add `Verdict_router` and migrate callers intentionally.