### PR TITLE
[codex] soften keeper runtime network errors

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -12,6 +12,63 @@ let sdk_error_kind = function
   | Agent_sdk.Error.Internal _ -> "internal"
 ;;
 
+let network_error_kind_user_label = function
+  | Llm_provider.Http_client.Connection_refused -> "connection refused"
+  | Llm_provider.Http_client.Dns_failure -> "DNS lookup failed"
+  | Llm_provider.Http_client.Tls_error -> "TLS handshake failed"
+  | Llm_provider.Http_client.Timeout -> "network timeout"
+  | Llm_provider.Http_client.Local_resource_exhaustion ->
+    "local network resources exhausted"
+  | Llm_provider.Http_client.End_of_file -> "connection closed"
+  | Llm_provider.Http_client.Unknown -> "network error"
+;;
+
+let network_error_kind_user_action = function
+  | Llm_provider.Http_client.Dns_failure ->
+    "Check network/DNS or select another runtime."
+  | Llm_provider.Http_client.Connection_refused ->
+    "Check that the runtime endpoint is running or select another runtime."
+  | Llm_provider.Http_client.Tls_error ->
+    "Check the provider TLS endpoint or select another runtime."
+  | Llm_provider.Http_client.Timeout ->
+    "Check provider health or select another runtime."
+  | Llm_provider.Http_client.Local_resource_exhaustion ->
+    "Reduce concurrent requests or select another runtime."
+  | Llm_provider.Http_client.End_of_file
+  | Llm_provider.Http_client.Unknown ->
+    "Check provider health or select another runtime."
+;;
+
+let runtime_provider_label provider =
+  match Option.map String.trim provider with
+  | Some provider when provider <> "" -> Printf.sprintf "Runtime provider '%s'" provider
+  | _ -> "Runtime provider"
+;;
+
+let detail_suffix detail =
+  match String.trim detail with
+  | "" -> ""
+  | detail -> " Detail: " ^ detail
+;;
+
+let provider_network_user_message ?provider ~kind ~detail () =
+  Printf.sprintf
+    "%s unavailable: %s. %s%s"
+    (runtime_provider_label provider)
+    (network_error_kind_user_label kind)
+    (network_error_kind_user_action kind)
+    (detail_suffix detail)
+;;
+
+let user_message_of_sdk_error = function
+  | Agent_sdk.Error.Api (Agent_sdk.Retry.NetworkError { message; kind }) ->
+    provider_network_user_message ~kind ~detail:message ()
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.NetworkError { provider; kind; detail; _ }) ->
+    provider_network_user_message ~provider ~kind ~detail ()
+  | err -> Agent_sdk.Error.to_string err
+;;
+
 type sdk_termination_semantics =
   | Provider_wall_clock_timeout
   | Oas_agent_execution_timeout

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -3,6 +3,11 @@
 (** Coarse categorisation of [Agent_sdk.Error.sdk_error] (for dashboards). *)
 val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
 
+(** User-facing SDK error message for keeper chat/tool surfaces.
+    Keeps low-level SDK prefixes out of persisted keeper replies while
+    telemetry and terminal reason codes continue to use structured errors. *)
+val user_message_of_sdk_error : Agent_sdk.Error.sdk_error -> string
+
 (** Layer-aware termination semantics for SDK errors crossing the OAS ->
     keeper boundary.
 

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -732,6 +732,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
             match run_result with
             | Error err ->
               let e_str = Agent_sdk.Error.to_string err in
+              let user_message = Keeper_agent_error.user_message_of_sdk_error err in
               (try
                  let _ = Trajectory.finalize trajectory_acc
                    (Trajectory.Failed e_str) in
@@ -740,7 +741,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
                  ~label:"trajectory finalize (agent_run error)" exn);
               start_keepalive ctx meta;
               Progress.stop_tracking turn_task_id;
-              tool_result_error (Printf.sprintf "Agent.run failed: %s" e_str)
+              tool_result_error user_message
             | Ok result ->
               let explicit_accountability_claim =
                 Keeper_social_model.extract_accountability_claim result

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -146,6 +146,47 @@ let test_server_parse_rejection_split () =
     ~server:false
 ;;
 
+let test_user_message_of_network_errors () =
+  let api_dns =
+    SdkE.Api
+      (Retry.NetworkError
+         { message = "failed to resolve hostname: ollama.com"
+         ; kind = Http.Dns_failure
+         })
+  in
+  Alcotest.(check string)
+    "api dns user message"
+    "Runtime provider unavailable: DNS lookup failed. Check network/DNS or select another runtime. Detail: failed to resolve hostname: ollama.com"
+    (AE.user_message_of_sdk_error api_dns);
+  Alcotest.(check bool)
+    "api dns hides Agent.run prefix"
+    false
+    (String_util.contains_substring_ci
+       (AE.user_message_of_sdk_error api_dns)
+       "Agent.run failed");
+  let provider_dns =
+    SdkE.Provider
+      (Llm_provider.Error.NetworkError
+         { provider = "ollama_cloud"
+         ; kind = Http.Dns_failure
+         ; timeout_phase = None
+         ; detail = "failed to resolve hostname: ollama.com"
+         })
+  in
+  Alcotest.(check string)
+    "provider dns user message"
+    "Runtime provider 'ollama_cloud' unavailable: DNS lookup failed. Check network/DNS or select another runtime. Detail: failed to resolve hostname: ollama.com"
+    (AE.user_message_of_sdk_error provider_dns);
+  let guardrail =
+    SdkE.Agent
+      (SdkE.GuardrailViolation { validator = "policy"; reason = "blocked" })
+  in
+  Alcotest.(check string)
+    "non-network errors preserve SDK message"
+    (Agent_sdk.Error.to_string guardrail)
+    (AE.user_message_of_sdk_error guardrail)
+;;
+
 let () =
   Alcotest.run
     "keeper_sdk_error_typed_bridge"
@@ -166,6 +207,12 @@ let () =
             "provider and model parse rejections remain distinguishable"
             `Quick
             test_server_parse_rejection_split
+        ] )
+    ; ( "user-facing error message"
+      , [ Alcotest.test_case
+            "network errors are presented as runtime availability failures"
+            `Quick
+            test_user_message_of_network_errors
         ] )
     ]
 ;;


### PR DESCRIPTION
## What changed

- Added a keeper-facing SDK error formatter for runtime network failures.
- Routed `masc_keeper_msg` Agent.run failures through that formatter before returning/persisting the chat error.
- Added regression coverage for API-level and provider-level DNS failures like `failed to resolve hostname: ollama.com`.

## Why

Keeper chat was surfacing raw low-level text such as `Agent.run failed: Network error (dns_failure): failed to resolve hostname: ollama.com`. That is useful diagnostic detail, but it is not the right product-level message for the operator-facing chat surface.

The raw SDK string is still preserved for trajectory/debug evidence. The user-facing path now presents the failure as runtime provider unavailability with a concrete next action.

## Validation

- `scripts/dune-local.sh build test/test_keeper_sdk_error_typed_bridge.exe`
- `_build/default/test/test_keeper_sdk_error_typed_bridge.exe`
- `ocamlformat --check lib/keeper/keeper_agent_error.ml lib/keeper/keeper_agent_error.mli lib/keeper/keeper_turn.ml test/test_keeper_sdk_error_typed_bridge.ml`
- `git diff --check`

## Notes

Live `/Users/dancer/me/.masc/config/runtime.toml` still assigns several keepers directly to `ollama_cloud.deepseek-v4-flash`; this PR does not change model routing or live runtime config.