### PR TITLE
[codex] align keeper v2 dashboard surfaces

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -84,14 +84,21 @@ describe('App v2 header chrome', () => {
   })
 
   it('sets data-mobile based on the viewport width', () => {
-    window.innerWidth = 760
+    window.innerWidth = 900
     renderApp()
     const app = container.querySelector('.v2-app')
     expect(app?.getAttribute('data-mobile')).toBe('true')
   })
 
+  it('does not set data-mobile above the v2 shell breakpoint', () => {
+    window.innerWidth = 901
+    renderApp()
+    const app = container.querySelector('.v2-app')
+    expect(app?.getAttribute('data-mobile')).toBe('false')
+  })
+
   it('uses a 44x44 mobile menu button touch target', () => {
-    window.innerWidth = 760
+    window.innerWidth = 900
     renderApp()
 
     const menuButton = container.querySelector('button[aria-controls="dashboard-side-rail"]') as HTMLElement | null
@@ -99,8 +106,8 @@ describe('App v2 header chrome', () => {
     expect(menuButton?.classList.contains('size-11')).toBe(true)
   })
 
-  it('hides MobileBottomBar when the mobile side-rail drawer is open', async () => {
-    window.innerWidth = 760
+  it('hides mobile nav tabs when the mobile side-rail drawer is open', async () => {
+    window.innerWidth = 900
     renderApp()
 
     const menuButton = container.querySelector('button[aria-controls="dashboard-side-rail"]') as HTMLElement | null
@@ -112,9 +119,17 @@ describe('App v2 header chrome', () => {
     })
   })
 
-  it('hides MobileBottomBar on keeper detail routes', () => {
+  it('uses the header Copilot control instead of a floating FAB on mobile', () => {
+    window.innerWidth = 900
+    renderApp()
+
+    expect(container.querySelector('[data-testid="copilot-dock-topbar-button"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="copilot-dock-fab"]')).toBeNull()
+  })
+
+  it('hides mobile nav tabs on keeper detail routes', () => {
     window.location.hash = '#monitoring/agents?keeper=sangsu'
-    window.innerWidth = 760
+    window.innerWidth = 900
     renderApp()
 
     const bottomNav = container.querySelector('nav[aria-label="Primary mobile navigation"]')
@@ -158,7 +173,7 @@ describe('App v2 header chrome', () => {
   })
 
   it('toggles the mobile side-rail drawer', async () => {
-    window.innerWidth = 760
+    window.innerWidth = 900
     renderApp()
 
     const rail = container.querySelector('#dashboard-side-rail') as HTMLElement | null
@@ -168,15 +183,11 @@ describe('App v2 header chrome', () => {
     expect(menuButton).not.toBeNull()
     menuButton!.click()
 
-    // When open, the rail must both drop max-[768px]:hidden AND add
-    // max-[768px]:block. The rail also carries the static max-[1100px]:hidden,
-    // so removing :hidden alone leaves it display:none at <=768px — the
-    // pre-fix '' open-state class regressed exactly here. Assert both tokens in
-    // the same waitFor so they are checked at the open moment.
+    // DashboardNavRail owns the mobile drawer contract: opening swaps the rail
+    // from the hidden mobile state into an explicit block drawer.
     await waitFor(() => {
-      expect(rail?.classList.contains('max-[1100px]:hidden')).toBe(true)
-      expect(rail?.classList.contains('max-[768px]:hidden')).toBe(false)
-      expect(rail?.classList.contains('max-[768px]:block')).toBe(true)
+      expect(rail?.classList.contains('block')).toBe(true)
+      expect(rail?.classList.contains('hidden')).toBe(false)
     })
   })
 

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -27,13 +27,12 @@ import {
   DashboardMain,
   ErrorCounterBadge,
   isKeeperDetailDashboardRoute,
-  SideRail,
 } from './components/dashboard-shell'
 import { ThemeSwitch } from './components/theme-switch'
 import { EmergencyStopControl } from './components/emergency-stop-control'
 import { TransportBeacon } from './components/transport-beacon'
 import { DashboardSurfaceTabs } from './components/dashboard-surface-tabs'
-import { MobileBottomBar } from './components/mobile-nav'
+import { DashboardNavRail } from './components/mobile-nav'
 import { SkipLink } from './components/skip-link'
 import { selectedAgentName } from './components/agent-detail-selection'
 import { selectedTask } from './components/goals/task-detail-selection'
@@ -45,7 +44,7 @@ import { DashboardStatusTray } from './components/status-tray'
 import { DashboardFocusModeToggle, dashboardFocusMode } from './components/focus-mode-toggle'
 import {
   DASHBOARD_NAV_ITEMS,
-  VISIBLE_DASHBOARD_NAV_ITEMS,
+  PRIMARY_DASHBOARD_NAV_ITEMS,
   currentSectionForRoute,
 } from './config/navigation'
 import { Menu, X } from 'lucide-preact'
@@ -285,7 +284,7 @@ export function App() {
           <div class="flex min-w-0 flex-1 items-center gap-3 max-[860px]:flex-wrap">
             <div class="flex min-w-0 shrink-0 items-center gap-2.5 max-[520px]:w-full">
               <button type="button"
-                class=${`hidden max-[768px]:flex size-11 items-center justify-center rounded-md border border-[var(--ss-border)] bg-[var(--ss-card)] text-[var(--ss-text-primary)] cursor-pointer transition-colors hover:bg-[var(--ss-surface-subtle)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })}`}
+                class=${`${isMobile ? 'flex' : 'hidden'} size-11 items-center justify-center rounded-md border border-[var(--ss-border)] bg-[var(--ss-card)] text-[var(--ss-text-primary)] cursor-pointer transition-colors hover:bg-[var(--ss-surface-subtle)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })}`}
                 aria-expanded=${mobileMenuOpen.value}
                 aria-label=${mobileMenuOpen.value ? 'Close navigation' : 'Open navigation'}
                 aria-controls="dashboard-side-rail"
@@ -314,7 +313,7 @@ export function App() {
               </div>
             </div>
 
-            <${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab=${currentTab} />
+            <${DashboardSurfaceTabs} items=${PRIMARY_DASHBOARD_NAV_ITEMS} currentTab=${currentTab} />
           </div>
 
           <div class="v2-header-actions flex shrink-0 flex-wrap items-center justify-end gap-2 max-[1080px]:justify-between">
@@ -334,10 +333,10 @@ export function App() {
             <//>
             <${ConnectionStatus} />
             <${ErrorCounterBadge} />
-            <div class="max-[768px]:hidden"><${TransportBeacon} /></div>
-            <div class="max-[768px]:hidden"><${ThemeSwitch} /></div>
-            <div class="max-[768px]:hidden"><${TweaksPanelToggle} /></div>
-            <div class="max-[768px]:hidden"><${BuildIdentityBadge} /></div>
+            <div class="v2-desktop-header-only"><${TransportBeacon} /></div>
+            <div class="v2-desktop-header-only"><${ThemeSwitch} /></div>
+            <div class="v2-desktop-header-only"><${TweaksPanelToggle} /></div>
+            <div class="v2-desktop-header-only"><${BuildIdentityBadge} /></div>
           </div>
         </div>
       </header>
@@ -368,17 +367,21 @@ export function App() {
         ${compactChromeMode
           ? null
           : html`
-            ${mobileMenuOpen.value ? html`
-              <button type="button" aria-label="Close navigation" tabindex=${-1} class="hidden max-[768px]:block fixed inset-0 z-40 cursor-pointer bg-black/50" onClick=${() => { mobileMenuOpen.value = false }}></button>
-            ` : null}
-            <aside id="dashboard-side-rail" aria-label="Sidebar navigation" class="v2-shell-rail ${sidebarCollapsed.value ? 'w-14' : 'w-55'} shrink-0 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] max-[1100px]:hidden max-[768px]:fixed max-[768px]:inset-y-0 max-[768px]:left-0 max-[768px]:z-50 max-[768px]:m-0 max-[768px]:w-72 max-[768px]:max-h-none max-[768px]:rounded-none max-[768px]:border-r ${mobileMenuOpen.value ? 'max-[768px]:block' : 'max-[768px]:hidden'}">
-              <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
-            </aside>
+            <${DashboardNavRail}
+              currentTab=${currentTab}
+              mobile=${isMobile}
+              drawerOpen=${mobileMenuOpen.value}
+              keeperDetailMode=${keeperDetailMode}
+              collapsed=${sidebarCollapsed.value}
+              onToggleCollapsed=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }}
+              onToggleDrawer=${() => { mobileMenuOpen.value = !mobileMenuOpen.value }}
+              onCloseDrawer=${() => { mobileMenuOpen.value = false }}
+            />
           `}
 
         <div class="v2-stage min-h-0 flex-1">
           <main id="main-content" tabindex=${-1} class=${compactChromeMode ? 'v2-body min-w-0 flex-1 overflow-hidden' : 'v2-body min-w-0 flex-1 overflow-hidden rounded-[var(--ss-radius-card)] border border-[var(--ss-border)] bg-[var(--ss-card)] shadow-[var(--ss-shadow-card)]'}>
-            <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : keeperDetailMode ? 'h-full p-0' : focusMode ? 'dashboard-main-scroll h-full overflow-y-auto p-3 max-[520px]:p-2 max-[768px]:pb-16' : 'dashboard-main-scroll h-full overflow-y-auto p-4 max-[768px]:pb-16'}>
+            <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : keeperDetailMode ? 'h-full p-0' : focusMode ? 'dashboard-main-scroll h-full overflow-y-auto p-3 max-[520px]:p-2 max-[900px]:pb-16' : 'dashboard-main-scroll h-full overflow-y-auto p-4 max-[900px]:pb-16'}>
               <div class="v2-surface" key=${currentTab}>
                 <${DashboardMain} />
               </div>
@@ -387,8 +390,7 @@ export function App() {
           ${dock.state.value.open ? html`<${CopilotDock} dock=${dock} />` : null}
         </div>
       </div>
-      ${!compactChromeMode && !mobileMenuOpen.value && !keeperDetailMode ? html`<${MobileBottomBar} currentTab=${currentTab} onMenuToggle=${() => { mobileMenuOpen.value = !mobileMenuOpen.value }} />` : null}
-      ${!dock.state.value.open && !compactChromeMode ? html`<${CopilotDockFab} dock=${dock} />` : null}
+      ${!dock.state.value.open && !compactChromeMode && !isMobile ? html`<${CopilotDockFab} dock=${dock} />` : null}
 
       ${selectedAgentName.value
         ? html`<${Suspense} fallback=${null}><${LazyAgentDetailOverlay} /><//>`

--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -129,6 +129,9 @@ describe('cockpit entrypoint registry', () => {
       tab: 'workspace',
       params: { section: 'planning', view: 'goal-tree' },
     })
+    expect(cockpitTargetForParams({ mode: 'Comms', tab: 'board-feed' })).toEqual({
+      tab: 'board',
+    })
     expect(cockpitTargetForParams({ mode: 'Comms', tab: 'composer' })).toEqual({
       tab: 'command',
       params: { section: 'operations', view: 'ops' },
@@ -199,6 +202,10 @@ describe('cockpit entrypoint registry', () => {
     expect(cockpitTargetForParams({ mode: 'Comms', tab: 'cm-bc' })).toEqual({
       tab: 'command',
       params: { section: 'operations', view: 'ops', focus: 'broadcast' },
+    })
+    expect(cockpitTargetForParams({ mode: 'Comms', tab: 'bd-thr' })).toEqual({
+      tab: 'board',
+      params: { focus: 'thread' },
     })
     expect(cockpitTargetForParams({ mode: 'Work', tab: 'acc-led' })).toEqual({
       tab: 'workspace',

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -90,7 +90,7 @@ export const COCKPIT_MODE_TARGETS: Record<CockpitMode, CockpitRouteTarget> = {
   dashboard: COGNITIVE_MODE_TARGETS.cockpit,
   cockpit: COGNITIVE_MODE_TARGETS.cockpit,
   work: { tab: 'workspace', params: { section: 'planning' } },
-  comms: { tab: 'workspace', params: { section: 'board' } },
+  comms: { tab: 'board' },
   observe: { tab: 'monitoring', params: { section: 'runtime' } },
   cognition: { tab: 'monitoring', params: { section: 'cognition' } },
   ide: COGNITIVE_MODE_TARGETS.code,
@@ -116,7 +116,7 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   {
     mode: 'comms',
     aliases: ['board-feed'],
-    target: { tab: 'workspace', params: { section: 'board' } },
+    target: { tab: 'board' },
     coverage: 'covered',
   },
   {
@@ -174,12 +174,12 @@ export const COCKPIT_LEGACY_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'work', aliases: ['acc-mtx', 'accountability-matrix'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-matrix' } }, coverage: 'covered' },
 
   // Comms Plane legacy design subtabs.
-  { mode: 'comms', aliases: ['bd-feed'], target: { tab: 'workspace', params: { section: 'board' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['bd-thr', 'board-thread'], target: { tab: 'workspace', params: { section: 'board', focus: 'thread' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['bd-tog', 'board-direct-automation'], target: { tab: 'workspace', params: { section: 'board', focus: 'automation' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['ms-rm', 'messages-workspace'], target: { tab: 'workspace', params: { section: 'board', focus: 'messages-workspace' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['ms-inb', 'messages-mention-inbox'], target: { tab: 'workspace', params: { section: 'board', focus: 'mention-inbox' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['ms-st', 'messages-state-block'], target: { tab: 'workspace', params: { section: 'board', focus: 'state-block' } }, coverage: 'covered' },
+  { mode: 'comms', aliases: ['bd-feed'], target: { tab: 'board' }, coverage: 'covered' },
+  { mode: 'comms', aliases: ['bd-thr', 'board-thread'], target: { tab: 'board', params: { focus: 'thread' } }, coverage: 'covered' },
+  { mode: 'comms', aliases: ['bd-tog', 'board-direct-automation'], target: { tab: 'board', params: { focus: 'automation' } }, coverage: 'covered' },
+  { mode: 'comms', aliases: ['ms-rm', 'messages-workspace'], target: { tab: 'board', params: { focus: 'messages-workspace' } }, coverage: 'covered' },
+  { mode: 'comms', aliases: ['ms-inb', 'messages-mention-inbox'], target: { tab: 'board', params: { focus: 'mention-inbox' } }, coverage: 'covered' },
+  { mode: 'comms', aliases: ['ms-st', 'messages-state-block'], target: { tab: 'board', params: { focus: 'state-block' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['cm-bc', 'composer-broadcast'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'broadcast' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['cm-mn', 'composer-mention'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['cm-st', 'composer-state'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'state' } }, coverage: 'covered' },

--- a/dashboard/src/components/board/board-curation-panel.ts
+++ b/dashboard/src/components/board/board-curation-panel.ts
@@ -3,12 +3,12 @@ import { useCallback, useEffect, useState } from 'preact/hooks'
 import { ArrowLeft, RefreshCw, Sparkles } from 'lucide-preact'
 import { fetchBoardCuration } from '../../api/board'
 import type { BoardCurationSnapshot } from '../../types'
-import { navigate } from '../../router'
 import { ActionButton } from '../common/button'
 import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { SurfaceCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
 import { MISSING_DATA_DASH } from '../../lib/format-string'
+import { navigateBoard } from './board-route'
 
 function percent(value: number | null | undefined): string {
   if (typeof value !== 'number' || !Number.isFinite(value)) return MISSING_DATA_DASH
@@ -149,7 +149,7 @@ export function BoardCurationPanel() {
           <h2 id="board-curation-heading" class="mt-1 text-xl font-bold text-[var(--color-fg-primary)]">AI curation snapshot</h2>
         </div>
         <div class="flex flex-wrap items-center gap-2">
-          <${ActionButton} variant="ghost" size="sm" onClick=${() => navigate('workspace', { section: 'board' })} ariaLabel="Back to board">
+          <${ActionButton} variant="ghost" size="sm" onClick=${() => navigateBoard()} ariaLabel="Back to board">
             <span class="inline-flex items-center gap-1.5"><${ArrowLeft} size=${14} aria-hidden="true" />Board<//>
           <//>
           <${ActionButton} variant="ghost" size="sm" onClick=${() => { void load() }} disabled=${loading} ariaLabel="Refresh board curation">

--- a/dashboard/src/components/board/board-karma-panel.ts
+++ b/dashboard/src/components/board/board-karma-panel.ts
@@ -3,13 +3,13 @@ import { useCallback, useEffect, useState } from 'preact/hooks'
 import { ArrowLeft, RefreshCw, Trophy } from 'lucide-preact'
 import { fetchBoardKarmaLedger } from '../../api/board'
 import type { BoardKarmaLedger, BoardKarmaLedgerEvent } from '../../types'
-import { navigate } from '../../router'
 import { ActionButton } from '../common/button'
 import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { TextInput } from '../common/input'
 import { Select } from '../common/select'
 import { SurfaceCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
+import { navigateBoard } from './board-route'
 
 const LIMIT_OPTIONS = [
   { value: '25', label: '25 events' },
@@ -72,7 +72,7 @@ export function BoardKarmaPanel() {
           <h2 id="board-karma-heading" class="mt-1 text-xl font-bold text-[var(--color-fg-primary)]">Karma ledger</h2>
         </div>
         <div class="flex flex-wrap items-center gap-2">
-          <${ActionButton} variant="ghost" size="sm" onClick=${() => navigate('workspace', { section: 'board' })} ariaLabel="Back to board">
+          <${ActionButton} variant="ghost" size="sm" onClick=${() => navigateBoard()} ariaLabel="Back to board">
             <span class="inline-flex items-center gap-1.5"><${ArrowLeft} size=${14} aria-hidden="true" />Board<//>
           <//>
           <${ActionButton} variant="ghost" size="sm" onClick=${() => { void load() }} disabled=${loading} ariaLabel="Refresh board karma">

--- a/dashboard/src/components/board/board-route.ts
+++ b/dashboard/src/components/board/board-route.ts
@@ -1,0 +1,26 @@
+import type { TabId } from '../../types'
+import { navigate, replaceRoute, route } from '../../router'
+
+type BoardTab = Extract<TabId, 'board' | 'workspace'>
+
+interface BoardRouteTarget {
+  tab: BoardTab
+  params: Record<string, string>
+}
+
+export function boardRouteTarget(params: Record<string, string> = {}): BoardRouteTarget {
+  if (route.value.tab === 'board') {
+    return { tab: 'board', params: { ...params } }
+  }
+  return { tab: 'workspace', params: { section: 'board', ...params } }
+}
+
+export function navigateBoard(params: Record<string, string> = {}): void {
+  const target = boardRouteTarget(params)
+  navigate(target.tab, target.params)
+}
+
+export function replaceBoardRoute(params: Record<string, string> = {}): void {
+  const target = boardRouteTarget(params)
+  replaceRoute(target.tab, target.params)
+}

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -1,12 +1,14 @@
 import { h } from 'preact'
-import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { BoardSurface } from './board-surface'
 import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter, boardHasMore, boardLoadingMore, messages, shellAuthSummary } from '../../store'
 import { route } from '../../router'
+import { createPost, sendBroadcast } from '../../api'
+import { dispatchOperatorAction, operatorSnapshot } from '../../operator-store'
 import { PAGE_SIZE, boardFlairs, boardFlairsError, boardHearths, boardHearthsError, categoryVisibleLimits, contentCategory, selectedBoardPostId, boardFilterMode, boardComposerMode } from './board-state'
 import { resetBoardLatencyMetrics } from '../../board-metrics'
-import type { BoardPost } from '../../types'
+import type { BoardPost, OperatorSnapshot } from '../../types'
 
 import '@testing-library/jest-dom'
 
@@ -25,17 +27,27 @@ vi.mock('../../router', () => ({
 }))
 
 vi.mock('../../api', () => ({
+  currentDashboardActor: vi.fn(() => 'dashboard-test'),
   fetchBoardPost: vi.fn(),
   votePost: vi.fn(),
   fetchBoardHearths: vi.fn().mockResolvedValue([]),
   fetchSubBoards: vi.fn().mockResolvedValue([]),
   commentPost: vi.fn(),
   createPost: vi.fn(),
+  sendBroadcast: vi.fn(),
 }))
 
 vi.mock('../../api/actions', () => ({
   deleteBoardPost: vi.fn(),
 }))
+
+vi.mock('../../operator-store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../operator-store')>()
+  return {
+    ...actual,
+    dispatchOperatorAction: vi.fn(),
+  }
+})
 
 vi.mock('./board-state', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('./board-state')
@@ -70,6 +82,23 @@ function makePost(overrides: Partial<BoardPost> & { id: string; title: string; a
     hearth_count: 0,
     ...overrides,
   } as BoardPost
+}
+
+function snapshotWithKeepers(keepers: Array<{
+  name: string
+  status?: string
+  phase?: string | null
+  pipeline_stage?: string | null
+  paused?: boolean | null
+}>): OperatorSnapshot {
+  return {
+    root: { paused: false, namespace: 'default' },
+    sessions: [],
+    keepers,
+    recent_messages: [],
+    pending_confirms: [],
+    available_actions: [],
+  } as unknown as OperatorSnapshot
 }
 
 // ── Content category classifier tests ─────────────────────────────
@@ -174,6 +203,10 @@ describe('BoardSurface Component', () => {
     selectedBoardPostId.value = null
     boardFilterMode.value = 'all'
     boardComposerMode.value = 'post'
+    operatorSnapshot.value = snapshotWithKeepers([
+      { name: 'sangsu', status: 'active' },
+      { name: 'albini', status: 'paused', paused: true },
+    ])
     messages.value = []
     shellAuthSummary.value = null
     route.value = { params: {} } as any
@@ -187,6 +220,35 @@ describe('BoardSurface Component', () => {
   it('wraps the board surface in the v2 board surface class', () => {
     const { container } = render(h(BoardSurface, null))
     expect(container.querySelector('.v2-board-surface')).not.toBeNull()
+  })
+
+  it('shows the mention inbox detail rail by default', () => {
+    const { container } = render(h(BoardSurface, null))
+    expect(container.querySelector('[data-testid="bd-mention-detail"]')).not.toBeNull()
+  })
+
+  it('opens and closes the mention inbox detail rail from the mobile queue action', () => {
+    messages.value = [
+      { id: 'm-1', from: 'sojin', content: '@dashboard needs review', timestamp: new Date().toISOString() },
+      { id: 'm-2', from: 'sangsu', content: 'plain update', timestamp: new Date().toISOString() },
+      { id: 'm-3', from: 'albini', type: 'mention', content: 'manual mention routing', timestamp: new Date().toISOString() },
+    ]
+    render(h(BoardSurface, null))
+
+    const detail = screen.getByTestId('bd-mention-detail')
+    expect(detail).not.toHaveClass('is-mobile-open')
+
+    const queues = screen.getByTestId('bd-mobile-queues')
+    const mentionQueue = within(queues).getByTestId('bd-mobile-queue-mentions')
+    expect(mentionQueue).toHaveTextContent('멘션 인박스')
+    expect(mentionQueue).toHaveTextContent('2')
+
+    fireEvent.click(mentionQueue)
+    expect(detail).toHaveClass('is-mobile-open')
+    expect(within(detail).getByText('@dashboard')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('멘션 인박스 닫기'))
+    expect(detail).not.toHaveClass('is-mobile-open')
   })
 
   it('keeps v2 workspace panels for category cards', () => {
@@ -438,7 +500,7 @@ describe('BoardSurface Component', () => {
     render(h(BoardSurface, null))
     fireEvent.click(screen.getByTestId('bd-post-post-1'))
 
-    expect(screen.getByTestId('bd-thread-detail')).toBeInTheDocument()
+    expect(screen.getByTestId('bd-thread-detail')).toHaveClass('has-post')
     expect(screen.getByText('스레드')).toBeInTheDocument()
   })
 
@@ -452,6 +514,244 @@ describe('BoardSurface Component', () => {
 
     fireEvent.click(screen.getByTestId('bd-comp-tab-state'))
     expect(boardComposerMode.value).toBe('state')
+  })
+
+  it('starts the mobile composer shell collapsed and toggles it open', () => {
+    render(h(BoardSurface, null))
+
+    const composer = screen.getByTestId('bd-composer')
+    const toggle = screen.getByTestId('bd-composer-mobile-toggle')
+
+    expect(composer).toHaveAttribute('data-mobile-open', 'false')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(toggle).toHaveTextContent('새 글')
+
+    fireEvent.click(toggle)
+
+    expect(composer).toHaveAttribute('data-mobile-open', 'true')
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(toggle).toHaveTextContent('접기')
+  })
+
+  it('submits the mobile quick composer using the first body line as title', async () => {
+    const createPostMock = vi.mocked(createPost)
+    render(h(BoardSurface, null))
+
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-toggle'))
+    fireEvent.input(screen.getByTestId('bd-composer-mobile-body'), {
+      target: { value: 'Mobile quick note\nsecond line' },
+    })
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-send'))
+
+    expect(createPostMock).toHaveBeenCalledWith(
+      'Mobile quick note',
+      'Mobile quick note\nsecond line',
+      'dashboard-user',
+      { hearth: undefined },
+    )
+  })
+
+  it('submits the mobile mention quick composer through the keeper message action', () => {
+    const dispatchMock = vi.mocked(dispatchOperatorAction)
+    render(h(BoardSurface, null))
+
+    fireEvent.click(screen.getByTestId('bd-comp-tab-mention'))
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-toggle'))
+    fireEvent.input(screen.getByTestId('bd-composer-mobile-body'), {
+      target: { value: '@sangsu check the queue' },
+    })
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-send'))
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      actor: 'dashboard-test',
+      action_type: 'keeper_message',
+      target_type: 'keeper',
+      target_id: 'sangsu',
+      payload: { message: '@sangsu check the queue' },
+    })
+  })
+
+  it('submits mobile mention quick composer through the target picker', () => {
+    const dispatchMock = vi.mocked(dispatchOperatorAction)
+    render(h(BoardSurface, null))
+
+    fireEvent.click(screen.getByTestId('bd-comp-tab-mention'))
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-toggle'))
+    const target = screen.getByLabelText('Mobile mention target') as HTMLSelectElement
+    expect(Array.from(target.options).map(option => option.textContent)).toEqual(['sangsu', 'albini'])
+
+    fireEvent.input(target, { target: { value: 'keeper:albini' } })
+    fireEvent.input(screen.getByTestId('bd-composer-mobile-body'), {
+      target: { value: 'check the queue' },
+    })
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-send'))
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      actor: 'dashboard-test',
+      action_type: 'keeper_message',
+      target_type: 'keeper',
+      target_id: 'albini',
+      payload: { message: 'check the queue' },
+    })
+  })
+
+  it('keeps plain mobile mention body text when changing the target picker', () => {
+    const dispatchMock = vi.mocked(dispatchOperatorAction)
+    render(h(BoardSurface, null))
+
+    fireEvent.click(screen.getByTestId('bd-comp-tab-mention'))
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-toggle'))
+    const target = screen.getByLabelText('Mobile mention target') as HTMLSelectElement
+    const body = screen.getByTestId('bd-composer-mobile-body') as HTMLTextAreaElement
+
+    fireEvent.input(body, { target: { value: 'check the queue' } })
+    fireEvent.input(target, { target: { value: 'keeper:albini' } })
+    expect(body.value).toBe('check the queue')
+
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-send'))
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      actor: 'dashboard-test',
+      action_type: 'keeper_message',
+      target_type: 'keeper',
+      target_id: 'albini',
+      payload: { message: 'check the queue' },
+    })
+  })
+
+  it('completes mobile mention text through the compact autocomplete listbox', () => {
+    const dispatchMock = vi.mocked(dispatchOperatorAction)
+    render(h(BoardSurface, null))
+
+    fireEvent.click(screen.getByTestId('bd-comp-tab-mention'))
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-toggle'))
+    const body = screen.getByTestId('bd-composer-mobile-body') as HTMLTextAreaElement
+
+    fireEvent.input(body, { target: { value: '@al' } })
+    const listbox = screen.getByTestId('bd-composer-mobile-mention-listbox')
+    fireEvent.click(within(listbox).getByRole('option', { name: /albini/ }))
+
+    expect(body.value).toBe('@albini ')
+    expect(screen.getByLabelText('Mobile mention target')).toHaveValue('keeper:albini')
+
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-send'))
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      actor: 'dashboard-test',
+      action_type: 'keeper_message',
+      target_type: 'keeper',
+      target_id: 'albini',
+      payload: { message: '@albini' },
+    })
+  })
+
+  it('accepts the active mobile mention autocomplete option with Enter', () => {
+    render(h(BoardSurface, null))
+
+    fireEvent.click(screen.getByTestId('bd-comp-tab-mention'))
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-toggle'))
+    const body = screen.getByTestId('bd-composer-mobile-body') as HTMLTextAreaElement
+
+    fireEvent.input(body, { target: { value: '@sa' } })
+    expect(screen.getByTestId('bd-composer-mobile-mention-listbox')).toBeInTheDocument()
+
+    fireEvent.keyDown(body, { key: 'Enter' })
+
+    expect(body.value).toBe('@sangsu ')
+    expect(screen.queryByTestId('bd-composer-mobile-mention-listbox')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Mobile mention target')).toHaveValue('keeper:sangsu')
+  })
+
+  it('serializes compact mobile mention attachment and voice drafts before sending', () => {
+    const dispatchMock = vi.mocked(dispatchOperatorAction)
+    render(h(BoardSurface, null))
+
+    fireEvent.click(screen.getByTestId('bd-comp-tab-mention'))
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-toggle'))
+    fireEvent.input(screen.getByLabelText('Mobile mention target'), { target: { value: 'keeper:sangsu' } })
+
+    const fileInput = screen.getByTestId('bd-composer-mobile-file-input') as HTMLInputElement
+    fireEvent.change(fileInput, {
+      target: { files: [new File(['trace'], 'trace.log', { type: 'text/plain' })] },
+    })
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-voice'))
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-voice-stop'))
+    fireEvent.input(screen.getByTestId('bd-composer-mobile-body'), {
+      target: { value: 'check trace' },
+    })
+
+    expect(screen.getByTestId('bd-composer-mobile-draft-tray')).toHaveTextContent('trace.log')
+    expect(screen.getByTestId('bd-composer-mobile-draft-tray')).toHaveTextContent('받아쓰기')
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-send'))
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      actor: 'dashboard-test',
+      action_type: 'keeper_message',
+      target_type: 'keeper',
+      target_id: 'sangsu',
+      payload: {
+        message: [
+          'Attachments:',
+          '- trace.log (5 B · file)',
+          '',
+          'Voice memo 0:12 (40 KB)',
+          '스케줄러 p99 스파이크와 compact 타이밍을 비교해서 결과만 알려줘.',
+          '',
+          'check trace',
+        ].join('\n'),
+      },
+    })
+  })
+
+  it('removes compact mobile mention multimodal drafts and re-disables send', () => {
+    render(h(BoardSurface, null))
+
+    fireEvent.click(screen.getByTestId('bd-comp-tab-mention'))
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-toggle'))
+    fireEvent.input(screen.getByLabelText('Mobile mention target'), { target: { value: 'keeper:sangsu' } })
+    const send = screen.getByTestId('bd-composer-mobile-send')
+
+    fireEvent.change(screen.getByTestId('bd-composer-mobile-file-input'), {
+      target: { files: [new File(['trace'], 'trace.log', { type: 'text/plain' })] },
+    })
+    expect(send).not.toBeDisabled()
+    fireEvent.click(screen.getByLabelText('Remove mobile attachment trace.log'))
+    expect(screen.queryByTestId('bd-composer-mobile-draft-tray')).not.toBeInTheDocument()
+    expect(send).toBeDisabled()
+
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-voice'))
+    expect(screen.getByTestId('bd-composer-mobile-recorder')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-voice-stop'))
+    expect(send).not.toBeDisabled()
+    fireEvent.click(screen.getByLabelText('Remove mobile voice draft'))
+    expect(screen.queryByTestId('bd-composer-mobile-draft-tray')).not.toBeInTheDocument()
+    expect(send).toBeDisabled()
+  })
+
+  it('inserts a mobile state template before quick broadcast submit', () => {
+    const broadcastMock = vi.mocked(sendBroadcast)
+    render(h(BoardSurface, null))
+
+    fireEvent.click(screen.getByTestId('bd-comp-tab-state'))
+    fireEvent.click(screen.getByTestId('bd-composer-mobile-toggle'))
+    const body = screen.getByTestId('bd-composer-mobile-body') as HTMLTextAreaElement
+    const send = screen.getByTestId('bd-composer-mobile-send')
+
+    fireEvent.click(screen.getByLabelText('Insert state block'))
+    expect(body.value).toContain('[STATE]')
+    expect(body.value).toContain('Goal: ')
+    expect(send).toBeDisabled()
+
+    fireEvent.input(screen.getByTestId('bd-composer-mobile-body'), {
+      target: { value: body.value.replace('Goal: ', 'Goal: mobile parity') },
+    })
+    expect(send).not.toBeDisabled()
+    fireEvent.click(send)
+
+    expect(broadcastMock).toHaveBeenCalledWith(
+      'dashboard-test',
+      '[STATE]\nGoal: mobile parity\nDONE: \nNEXT: \nDecisions: \nOpenQuestions: \nConstraints: \n[/STATE]',
+    )
   })
 
   it('routes the mention inbox focus to the message surface', () => {

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -241,7 +241,7 @@ describe('BoardSurface Component', () => {
     const queues = screen.getByTestId('bd-mobile-queues')
     const mentionQueue = within(queues).getByTestId('bd-mobile-queue-mentions')
     expect(mentionQueue).toHaveTextContent('멘션 인박스')
-    expect(mentionQueue).toHaveTextContent('2')
+    expect(mentionQueue).toHaveTextContent('1')
 
     fireEvent.click(mentionQueue)
     expect(detail).toHaveClass('is-mobile-open')

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -48,6 +48,7 @@ import {
   stripInlineMarkdown,
 } from '../../lib/board-utils'
 import {
+  firstMentionNameFromMessage,
   keeperNameFromTarget,
   mentionQueryFromMessage,
   replaceTrailingMentionDraft,
@@ -681,7 +682,7 @@ function BdComposer() {
   const selectedMobileKeeper = keeperNameFromTarget(mobileKeeperTarget)
   const selectedMobileKeeperAvailable =
     !!selectedMobileKeeper && mobileMentionOptions.some(keeper => keeper.name === selectedMobileKeeper)
-  const typedMobileMention = mode === 'mention' ? firstMentionTarget(localBody) : null
+  const typedMobileMention = mode === 'mention' ? firstMentionNameFromMessage(localBody) : null
   const matchedTypedMobileMention = typedMobileMention
     ? mobileMentionOptions.find(keeper => keeper.name.toLowerCase() === typedMobileMention.toLowerCase())?.name ?? null
     : null
@@ -763,11 +764,6 @@ function BdComposer() {
     setMobileAttachments([])
     setMobileVoiceDraft(null)
     setMobileRecording(false)
-  }
-
-  function firstMentionTarget(body: string): string | null {
-    const match = body.match(/(^|\s)@([a-zA-Z0-9._-]+)/)
-    return match?.[2] ?? null
   }
 
   async function submitPost(event?: Event, options: { compactMobile?: boolean } = {}): Promise<void> {
@@ -1197,7 +1193,7 @@ function BdMobileQueues({
 }
 
 function countMentionMessages(): number {
-  return messages.value.filter(message => extractMentionTargets(message.content).length > 0 || message.type?.toLowerCase().includes('mention') === true).length
+  return messages.value.filter(message => extractMentionTargets(message.content).length > 0).length
 }
 
 function BdFeed({ posts, onMentions }: { posts: BoardPost[]; onMentions: () => void }) {

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useCallback, useMemo, useState } from 'preact/hooks'
-import { Sparkles, Trophy } from 'lucide-preact'
+import { AtSign, Braces, Mic, Paperclip, Sparkles, Square, Trophy, X } from 'lucide-preact'
 import { ActionButton } from '../common/button'
 import { SectionCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
@@ -13,21 +13,31 @@ import { Checkbox } from '../common/checkbox'
 import { RichContent } from '../common/rich-content'
 import { CursorPagination } from '../common/pagination'
 import { stripStateBlocks } from '../../keeper-message'
-import { navigate, route } from '../../router'
+import { route } from '../../router'
+import { keepers as dashboardKeepers, messages, refreshExecution } from '../../store'
 import { votePost } from '../../api/board'
-import { createPost } from '../../api'
+import { createPost, currentDashboardActor, sendBroadcast } from '../../api'
 import { deleteBoardPost, setBoardPostPinned } from '../../api/actions'
+import { dispatchOperatorAction, operatorActionBusy } from '../../operator-store'
 import { registerBoardHearthsRefresh } from '../../sse-store'
 import { boardLatencyMetrics, type BoardLatencyMetric } from '../../board-metrics'
 import { MessageWorkspaceTimeline } from './message-workspace-timeline'
 import { BoardCurationPanel } from './board-curation-panel'
 import { BoardKarmaPanel } from './board-karma-panel'
-import { MentionInbox, MentionInboxPanel } from './mention-inbox'
+import { extractMentionTargets, MentionInbox, MentionInboxPanel } from './mention-inbox'
 import { PostDetail, CommentThread, CommentForm } from './post-detail'
 import { ReactionBar } from './reaction-bar'
 import { StateBlockMessages } from './state-block-messages'
-import { ComposerV2 } from './composer-v2'
-import type { ComposerV2Mode } from './composer-v2'
+import {
+  ComposerV2,
+  createComposerVoiceDraft,
+  formatClock,
+  formatFileSize,
+  serializeComposerBody,
+} from './composer-v2'
+import type { ComposerAttachmentDraft, ComposerV2Mode, ComposerVoiceDraft } from './composer-v2'
+import { ensureStateBlockDraft, stateBlockKeys } from '../ops/ops-state'
+import { navigateBoard } from './board-route'
 import {
   boardActorAvatarKey,
   boardActorDisplayName,
@@ -37,6 +47,12 @@ import {
   navigateToAuthor,
   stripInlineMarkdown,
 } from '../../lib/board-utils'
+import {
+  keeperNameFromTarget,
+  mentionQueryFromMessage,
+  replaceTrailingMentionDraft,
+} from '../../lib/mention-utils'
+import { useOperatorMentionContext } from '../common/use-operator-mention-context'
 import { ringFocusClasses } from '../common/ring'
 import {
   boardPosts,
@@ -260,7 +276,7 @@ function BoardSummary() {
         variant="ghost"
         size="sm"
         class="v2-workspace-action ${lastBoardRefreshAt.value ? '' : 'ml-auto'} !px-2"
-        onClick=${() => navigate('workspace', { section: 'board', focus: 'curation' })}
+        onClick=${() => navigateBoard({ focus: 'curation' })}
         ariaLabel="보드 큐레이션 열기"
       >
         <span class="inline-flex items-center gap-1">
@@ -272,7 +288,7 @@ function BoardSummary() {
         variant="ghost"
         size="sm"
         class="v2-workspace-action !px-2"
-        onClick=${() => navigate('workspace', { section: 'board', focus: 'karma' })}
+        onClick=${() => navigateBoard({ focus: 'karma' })}
         ariaLabel="보드 카르마 열기"
       >
         <span class="inline-flex items-center gap-1">
@@ -569,7 +585,7 @@ function BdThreadDetail({ post, onClose }: { post: BoardPost; onClose: () => voi
   const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
 
   return html`
-    <aside class="bd-detail" data-testid="bd-thread-detail">
+    <aside class="bd-detail has-post" data-testid="bd-thread-detail">
       <div class="bd-detail-h">
         <h3>스레드</h3>
         <button type="button" class="bd-detail-x" onClick=${onClose} aria-label="닫기">✕</button>
@@ -594,11 +610,24 @@ function BdThreadDetail({ post, onClose }: { post: BoardPost; onClose: () => voi
   `
 }
 
-function BdDetail({ post, onClose }: { post: BoardPost | null; onClose: () => void }) {
+function BdDetail({
+  post,
+  mentionMobileOpen,
+  onClose,
+  onCloseMentions,
+}: {
+  post: BoardPost | null
+  mentionMobileOpen: boolean
+  onClose: () => void
+  onCloseMentions: () => void
+}) {
   if (post) return html`<${BdThreadDetail} post=${post} onClose=${onClose} />`
   return html`
-    <aside class="bd-detail" data-testid="bd-mention-detail">
-      <div class="bd-detail-h"><h3>멘션 인박스</h3></div>
+    <aside class=${`bd-detail is-mentions ${mentionMobileOpen ? 'is-mobile-open' : ''}`} data-testid="bd-mention-detail">
+      <div class="bd-detail-h">
+        <h3>멘션 인박스</h3>
+        <button type="button" class="bd-detail-x bd-detail-mobile-close" onClick=${onCloseMentions} aria-label="멘션 인박스 닫기">✕</button>
+      </div>
       <div class="bd-detail-scroll">
         <${MentionInboxPanel} />
       </div>
@@ -612,7 +641,13 @@ function BdComposer() {
   const [localBody, setLocalBody] = useState('')
   const [localHearth, setLocalHearth] = useState(boardHearthFilter.value)
   const [localFlair, setLocalFlair] = useState('')
+  const [mobileKeeperTarget, setMobileKeeperTarget] = useState('')
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const [mobileAttachments, setMobileAttachments] = useState<ComposerAttachmentDraft[]>([])
+  const [mobileVoiceDraft, setMobileVoiceDraft] = useState<ComposerVoiceDraft | null>(null)
+  const [mobileRecording, setMobileRecording] = useState(false)
   const [submitting, setSubmitting] = useState(false)
+  const mobileFileInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (boardHearthFilter.value !== localHearth) {
@@ -625,6 +660,7 @@ function BdComposer() {
     { key: 'mention', label: '멘션' },
     { key: 'state', label: '상태 블록' },
   ]
+  const activeModeLabel = tabs.find(tab => tab.key === mode)?.label ?? '게시'
 
   const placeholder = mode === 'post'
     ? `${boardHearthFilter.value ? `#${boardHearthFilter.value}` : '보드'}에 게시…`
@@ -633,11 +669,111 @@ function BdComposer() {
       : '상태 블록 발행 — 상태 키:값 형식'
 
   const composerMode: ComposerV2Mode = mode === 'post' ? 'broadcast' : mode === 'mention' ? 'dm' : 'state-block'
+  const mobileMention = useOperatorMentionContext({
+    message: localBody,
+    target: mobileKeeperTarget,
+    dmActive: mode === 'mention',
+    listboxId: 'bd-mobile-mention-listbox',
+    fallbackKeepers: dashboardKeepers.value,
+  })
+  const mobileMentionOptions = mobileMention.onlineKeepers
+  const mobileMentionOptionNames = mobileMentionOptions.map(keeper => keeper.name).join('\0')
+  const selectedMobileKeeper = keeperNameFromTarget(mobileKeeperTarget)
+  const selectedMobileKeeperAvailable =
+    !!selectedMobileKeeper && mobileMentionOptions.some(keeper => keeper.name === selectedMobileKeeper)
+  const typedMobileMention = mode === 'mention' ? firstMentionTarget(localBody) : null
+  const matchedTypedMobileMention = typedMobileMention
+    ? mobileMentionOptions.find(keeper => keeper.name.toLowerCase() === typedMobileMention.toLowerCase())?.name ?? null
+    : null
+  const mobileMentionTarget = mode === 'mention'
+    ? mobileMention.trailingMentionTarget
+      ?? matchedTypedMobileMention
+      ?? (selectedMobileKeeperAvailable ? selectedMobileKeeper : null)
+      ?? (mobileMentionOptions.length === 0 ? typedMobileMention : null)
+    : null
+  const mobileMentionUnresolved =
+    mode === 'mention'
+    && !!typedMobileMention
+    && !mobileMentionTarget
+    && mobileMentionOptions.length > 0
+  const mobileStateKeys = mode === 'state' ? stateBlockKeys(localBody) : []
+  const mobileQuickBusy = submitting || operatorActionBusy.value
+  const mobileMentionHasDraft = mode === 'mention'
+    && (localBody.trim() !== '' || mobileAttachments.length > 0 || mobileVoiceDraft !== null)
+  const mobileQuickHasDraft = mode === 'mention' ? mobileMentionHasDraft : localBody.trim() !== ''
+  const mobileQuickDisabled = mobileQuickBusy
+    || !mobileQuickHasDraft
+    || (mode === 'mention' && (!mobileMentionTarget || mobileMentionUnresolved))
+    || (mode === 'state' && mobileStateKeys.length === 0)
 
-  async function submitPost(event?: Event): Promise<void> {
+  useEffect(() => {
+    if (mode !== 'mention') return
+    if (selectedMobileKeeperAvailable) return
+    const firstKeeper = mobileMentionOptions[0]?.name
+    setMobileKeeperTarget(firstKeeper ? `keeper:${firstKeeper}` : '')
+  }, [mode, mobileMentionOptionNames, selectedMobileKeeperAvailable])
+
+  useEffect(() => {
+    if (mode !== 'mention') return
+    if (mobileMentionOptions.length > 0) return
+    void refreshExecution()
+  }, [mode, mobileMentionOptions.length])
+
+  function mobilePostTitle(body: string): string {
+    const firstLine = body
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .find(Boolean)
+    if (!firstLine) return 'Board post'
+    return firstLine.replace(/\s+/g, ' ').slice(0, 72)
+  }
+
+  function chooseMobileMentionTarget(value: string): void {
+    const keeperName = keeperNameFromTarget(value)
+    setMobileKeeperTarget(value)
+    if (!keeperName) return
+    setLocalBody(current => mentionQueryFromMessage(current) !== null ? replaceTrailingMentionDraft(current, keeperName) : current)
+  }
+
+  function chooseMobileMentionCandidate(keeperName: string): void {
+    setMobileKeeperTarget(`keeper:${keeperName}`)
+    setLocalBody(current => replaceTrailingMentionDraft(current, keeperName))
+  }
+
+  function attachMobileMentionFiles(files: FileList | File[]): void {
+    const nextFiles = Array.from(files).slice(0, 6)
+    if (nextFiles.length === 0) return
+    setMobileAttachments(current => [
+      ...current,
+      ...nextFiles.map((file, index): ComposerAttachmentDraft => ({
+        id: `mobile-${Date.now()}-${index}-${file.name}`,
+        kind: file.type.startsWith('image/') ? 'image' : 'file',
+        name: file.name,
+        size: formatFileSize(file.size),
+      })),
+    ].slice(0, 6))
+  }
+
+  function stopMobileVoiceDraft(): void {
+    setMobileRecording(false)
+    setMobileVoiceDraft(createComposerVoiceDraft())
+  }
+
+  function resetMobileMentionDrafts(): void {
+    setMobileAttachments([])
+    setMobileVoiceDraft(null)
+    setMobileRecording(false)
+  }
+
+  function firstMentionTarget(body: string): string | null {
+    const match = body.match(/(^|\s)@([a-zA-Z0-9._-]+)/)
+    return match?.[2] ?? null
+  }
+
+  async function submitPost(event?: Event, options: { compactMobile?: boolean } = {}): Promise<void> {
     event?.stopPropagation()
-    const title = localTitle.trim()
     const body = localBody.trim()
+    const title = options.compactMobile ? mobilePostTitle(body) : localTitle.trim()
     if (!title || !body) return
     setSubmitting(true)
     try {
@@ -648,6 +784,7 @@ function BdComposer() {
       setLocalTitle('')
       setLocalBody('')
       setLocalFlair('')
+      setMobileOpen(false)
       showToast('글을 등록했습니다', 'success')
       refreshBoard()
     } catch (err) {
@@ -658,76 +795,412 @@ function BdComposer() {
     }
   }
 
+  async function submitMobileQuick(event?: Event): Promise<void> {
+    if (mode === 'post') {
+      await submitPost(event, { compactMobile: true })
+      return
+    }
+
+    event?.stopPropagation()
+    const body = localBody.trim()
+    const message = mode === 'mention'
+      ? serializeComposerBody({ text: localBody, attachments: mobileAttachments, voice: mobileVoiceDraft })
+      : body
+    if (!message || mobileQuickDisabled) return
+    setSubmitting(true)
+    try {
+      if (mode === 'mention') {
+        const keeperId = mobileMentionTarget
+        if (!keeperId) return
+        await dispatchOperatorAction({
+          actor: currentDashboardActor(),
+          action_type: 'keeper_message',
+          target_type: 'keeper',
+          target_id: keeperId,
+          payload: { message },
+        })
+      } else {
+        await sendBroadcast(currentDashboardActor(), message)
+      }
+      setLocalBody('')
+      resetMobileMentionDrafts()
+      setMobileOpen(false)
+      showToast('Message sent.', 'success')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Message send failed.'
+      console.warn('[board] mobile quick compose failed', message)
+      showToast(message, 'error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
   return html`
-    <div class="bd-composer" data-testid="bd-composer">
-      <div class="bd-comp-tabs" role="tablist" aria-label="Composer mode">
-        ${tabs.map(tab => html`
-          <button
-            key=${tab.key}
-            type="button"
-            role="tab"
-            aria-selected=${mode === tab.key ? 'true' : 'false'}
-            class=${`bd-comp-tab ${mode === tab.key ? 'on' : ''}`}
-            onClick=${() => { boardComposerMode.value = tab.key }}
-            data-testid=${`bd-comp-tab-${tab.key}`}
-          >${tab.label}</button>
-        `)}
+    <div class="bd-composer" data-testid="bd-composer" data-mobile-open=${mobileOpen ? 'true' : 'false'}>
+      <div class="bd-composer-mobile-summary" data-testid="bd-composer-mobile-summary">
+        <div class="bd-composer-mobile-copy">
+          <span class="bd-composer-mobile-kicker">${localHearth ? `#${localHearth}` : 'Board'}</span>
+          <span class="bd-composer-mobile-title">${activeModeLabel} 작성</span>
+        </div>
+        <button
+          type="button"
+          class="bd-composer-mobile-toggle"
+          aria-expanded=${mobileOpen ? 'true' : 'false'}
+          aria-controls="bd-composer-fields"
+          onClick=${() => setMobileOpen(open => !open)}
+          data-testid="bd-composer-mobile-toggle"
+        >${mobileOpen ? '접기' : '새 글'}</button>
       </div>
-      ${mode === 'post' ? html`
-        <div class="bd-comp-box grid gap-2">
-          <input
-            type="text"
-            class="bg-transparent border-0 outline-0 text-[var(--text-bright)] text-sm placeholder:text-[var(--text-dim)]"
-            placeholder="제목"
-            value=${localTitle}
-            onInput=${(e: Event) => setLocalTitle((e.target as HTMLInputElement).value)}
-            data-testid="bd-composer-title"
-          />
+      <div class="bd-composer-fields" id="bd-composer-fields">
+        <div class="bd-comp-tabs" role="tablist" aria-label="Composer mode">
+          ${tabs.map(tab => html`
+            <button
+              key=${tab.key}
+              type="button"
+              role="tab"
+              aria-selected=${mode === tab.key ? 'true' : 'false'}
+              class=${`bd-comp-tab ${mode === tab.key ? 'on' : ''}`}
+              onClick=${() => { boardComposerMode.value = tab.key }}
+              data-testid=${`bd-comp-tab-${tab.key}`}
+            >${tab.label}</button>
+          `)}
+        </div>
+        ${mode === 'mention' ? html`
+          <div class="bd-mobile-mention-targets" aria-label="Mobile mention target picker">
+            <span class="bd-mobile-mention-icon" aria-hidden="true">
+              <${AtSign} size=${13} strokeWidth=${2.2} />
+            </span>
+            <select
+              class="bd-mobile-mention-select"
+              aria-label="Mobile mention target"
+              value=${selectedMobileKeeperAvailable ? mobileKeeperTarget : ''}
+              onInput=${(event: Event) => chooseMobileMentionTarget((event.target as HTMLSelectElement).value)}
+              disabled=${mobileQuickBusy || mobileMentionOptions.length === 0}
+              data-testid="bd-composer-mobile-mention-target"
+            >
+              ${mobileMentionOptions.length === 0
+                ? html`<option value="">No keeper targets</option>`
+                : mobileMentionOptions.map(keeper => html`
+                  <option key=${keeper.name} value=${`keeper:${keeper.name}`}>${keeper.name}</option>
+                `)}
+            </select>
+            <span class="bd-mobile-mention-current" aria-live="polite">
+              ${mobileMentionUnresolved
+                ? `No @${typedMobileMention} match`
+                : mobileMentionTarget
+                  ? `@${mobileMentionTarget}`
+                  : 'No target'}
+            </span>
+          </div>
+          ${mobileMention.mentionListOpen
+            ? html`
+              <div
+                id="bd-mobile-mention-listbox"
+                class="bd-mobile-mention-listbox"
+                role="listbox"
+                aria-label=${`Mobile mention autocomplete (${mobileMention.mentionMatches.length} matches)`}
+                data-testid="bd-composer-mobile-mention-listbox"
+              >
+                ${mobileMention.mentionMatches.length > 0
+                  ? mobileMention.mentionMatches.map((candidate, index) => html`
+                    <button
+                      id=${`bd-mobile-mention-listbox-option-${index}`}
+                      key=${candidate.name}
+                      type="button"
+                      class=${`bd-mobile-mention-option ${candidate.selected || index === mobileMention.activeMentionIndex ? 'on' : ''}`}
+                      role="option"
+                      aria-selected=${candidate.selected || index === mobileMention.activeMentionIndex ? 'true' : 'false'}
+                      disabled=${mobileQuickBusy}
+                      onClick=${() => chooseMobileMentionCandidate(candidate.name)}
+                    >
+                      <${AtSign} size=${12} strokeWidth=${2.2} aria-hidden="true" />
+                      <span class="bd-mobile-mention-option-name">${candidate.name}</span>
+                      <span class="bd-mobile-mention-option-status">${candidate.status ?? 'online'}</span>
+                    </button>
+                  `)
+                  : html`<div class="bd-mobile-mention-empty">No keeper target matches @${mobileMention.mentionQuery}</div>`}
+              </div>
+            `
+            : null}
+          ${mobileAttachments.length > 0 || mobileVoiceDraft
+            ? html`
+              <div class="bd-mobile-draft-tray composer-tray" data-testid="bd-composer-mobile-draft-tray">
+                ${mobileAttachments.map(attachment => html`
+                  <div class="cdraft att" key=${attachment.id}>
+                    <div class="cdraft-thumb">
+                      <span class="cdraft-glyph">${attachment.kind === 'image' ? '▧' : '◫'}</span>
+                    </div>
+                    <div class="cdraft-meta">
+                      <span class="cdraft-name mono">${attachment.name}</span>
+                      <span class="cdraft-sub mono">${[attachment.size, attachment.kind, attachment.dims].filter(Boolean).join(' · ')}</span>
+                    </div>
+                    <button
+                      type="button"
+                      class="cdraft-x"
+                      title="첨부 제거"
+                      aria-label=${`Remove mobile attachment ${attachment.name}`}
+                      onClick=${() => { setMobileAttachments(current => current.filter(item => item.id !== attachment.id)) }}
+                      disabled=${mobileQuickBusy}
+                    >
+                      <${X} size=${10} aria-hidden="true" />
+                    </button>
+                  </div>
+                `)}
+                ${mobileVoiceDraft
+                  ? html`
+                    <div class="cdraft voice">
+                      <span class="cdraft-glyph mic">◌</span>
+                      <div class="cdraft-wave" aria-hidden="true">
+                        ${mobileVoiceDraft.wave.map((height, index) => html`<span class="vbar" key=${index} style=${{ height: `${Math.round(4 + height * 18)}px` }} />`)}
+                      </div>
+                      <span class="cdraft-dur mono">${formatClock(mobileVoiceDraft.secs)}</span>
+                      <div class="cdraft-tx">
+                        <span class="cdraft-tx-k">받아쓰기</span>
+                        <span class="cdraft-tx-v">${mobileVoiceDraft.transcript}</span>
+                      </div>
+                      <button
+                        type="button"
+                        class="cdraft-x"
+                        title="음성 제거"
+                        aria-label="Remove mobile voice draft"
+                        onClick=${() => { setMobileVoiceDraft(null) }}
+                        disabled=${mobileQuickBusy}
+                      >
+                        <${X} size=${10} aria-hidden="true" />
+                      </button>
+                    </div>
+                  `
+                  : null}
+              </div>
+            `
+            : null}
+          ${mobileRecording
+            ? html`
+              <div class="bd-mobile-rec-bar rec-bar" data-testid="bd-composer-mobile-recorder">
+                <span class="rec-dot" aria-hidden="true"></span>
+                <span class="rec-lbl">녹음 중</span>
+                <span class="rec-clock mono">0:12</span>
+                <div class="rec-wave" aria-hidden="true">
+                  ${[0.4, 0.8, 0.5, 0.9, 0.45, 0.75, 0.52, 0.84, 0.48, 0.7].map((height, index) => html`<span class="rbar" key=${index} style=${{ height: `${Math.round(3 + height * 20)}px` }} />`)}
+                </div>
+                <button
+                  type="button"
+                  class="rec-btn cancel"
+                  onClick=${() => { setMobileRecording(false) }}
+                  disabled=${mobileQuickBusy}
+                  data-testid="bd-composer-mobile-voice-cancel"
+                >취소</button>
+                <button
+                  type="button"
+                  class="rec-btn stop"
+                  onClick=${stopMobileVoiceDraft}
+                  disabled=${mobileQuickBusy}
+                  data-testid="bd-composer-mobile-voice-stop"
+                >
+                  <${Square} size=${11} aria-hidden="true" />
+                  완료
+                </button>
+              </div>
+            `
+            : null}
+        ` : null}
+        <div class="bd-mobile-quick-compose bd-comp-box" data-mode=${mode}>
           <textarea
-            rows=${2}
+            rows=${1}
             class="bg-transparent border-0 outline-0 text-[var(--text-bright)] text-sm placeholder:text-[var(--text-dim)] resize-none"
             placeholder=${placeholder}
             value=${localBody}
-            onInput=${(e: Event) => setLocalBody((e.target as HTMLTextAreaElement).value)}
-            data-testid="bd-composer-body"
+            role=${mode === 'mention' ? 'combobox' : undefined}
+            aria-autocomplete=${mode === 'mention' ? 'list' : undefined}
+            aria-controls=${mode === 'mention' && mobileMention.mentionListOpen ? 'bd-mobile-mention-listbox' : undefined}
+            aria-expanded=${mode === 'mention' ? String(mobileMention.mentionListOpen) : undefined}
+            aria-activedescendant=${mobileMention.activeMentionOptionId}
+            onInput=${(e: Event) => {
+              if (mobileMention.dismissedMentionQuery !== null) mobileMention.setDismissedMentionQuery(null)
+              setLocalBody((e.target as HTMLTextAreaElement).value)
+            }}
+            onKeyDown=${(event: KeyboardEvent) => {
+              if (mode === 'mention' && mobileMention.mentionListOpen && mobileMention.mentionMatches.length > 0) {
+                if (event.key === 'ArrowDown') {
+                  event.preventDefault()
+                  mobileMention.setActiveMentionIndex(index => (index + 1) % mobileMention.mentionMatches.length)
+                  return
+                }
+                if (event.key === 'ArrowUp') {
+                  event.preventDefault()
+                  mobileMention.setActiveMentionIndex(index => (index - 1 + mobileMention.mentionMatches.length) % mobileMention.mentionMatches.length)
+                  return
+                }
+                if (event.key === 'Enter' && !(event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)) {
+                  event.preventDefault()
+                  chooseMobileMentionCandidate(mobileMention.mentionMatches[mobileMention.activeMentionIndex]?.name ?? mobileMention.mentionMatches[0]!.name)
+                  return
+                }
+              }
+              if (mode === 'mention' && mobileMention.mentionListOpen && event.key === 'Escape') {
+                event.preventDefault()
+                mobileMention.setDismissedMentionQuery(mobileMention.mentionQuery ?? '')
+              }
+            }}
+            data-testid="bd-composer-mobile-body"
           />
-          <div class="flex gap-2">
-            <${Select}
-              value=${localHearth}
-              options=${[{ value: '', label: 'No category' }, ...boardHearths.value.map(h => ({ value: h.name, label: h.name }))]}
-              ariaLabel="게시 category"
-              onInput=${(value: string) => setLocalHearth(value)}
-            />
-            <${Select}
-              value=${localFlair}
-              options=${[{ value: '', label: 'No flair' }, ...boardFlairs.value.map(f => ({ value: f.name, label: `${f.emoji ? `${f.emoji} ` : ''}${f.label}` }))]}
-              ariaLabel="게시 flair"
-              onInput=${(value: string) => setLocalFlair(value)}
+          ${mode === 'state' ? html`
+            <button
+              type="button"
+              class="bd-mobile-state-template"
+              title="Insert state block"
+              aria-label="Insert state block"
+              disabled=${mobileQuickBusy}
+              onClick=${() => setLocalBody(current => ensureStateBlockDraft(current))}
+              data-testid="bd-composer-mobile-state-template"
+            >
+              <${Braces} size=${15} strokeWidth=${2.2} aria-hidden="true" />
+            </button>
+          ` : null}
+          ${mode === 'mention' ? html`
+            <input
+              ref=${mobileFileInputRef}
+              type="file"
+              accept="image/*,.pdf,.txt,.log,.json,.csv,.md"
+              multiple
+              hidden
+              data-testid="bd-composer-mobile-file-input"
+              onChange=${(event: Event) => {
+                const input = event.target as HTMLInputElement
+                if (input.files) attachMobileMentionFiles(input.files)
+                input.value = ''
+              }}
             />
             <button
               type="button"
-              class="send ml-auto"
-              disabled=${!localTitle.trim() || !localBody.trim() || submitting}
-              onClick=${(e: Event) => { void submitPost(e) }}
-              data-testid="bd-composer-send"
-            >${submitting ? '등록 중...' : '게시 ↑'}</button>
+              class="bd-mobile-compose-tool"
+              title="이미지·파일 첨부"
+              aria-label="Attach mobile mention file"
+              disabled=${mobileQuickBusy || mobileAttachments.length >= 6}
+              onClick=${() => { mobileFileInputRef.current?.click() }}
+              data-testid="bd-composer-mobile-attach"
+            >
+              <${Paperclip} size=${15} strokeWidth=${2.2} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              class="bd-mobile-compose-tool"
+              title="음성 입력"
+              aria-label="Start mobile mention voice draft"
+              disabled=${mobileQuickBusy || mobileRecording}
+              onClick=${() => { setMobileRecording(true) }}
+              data-testid="bd-composer-mobile-voice"
+            >
+              <${Mic} size=${15} strokeWidth=${2.2} aria-hidden="true" />
+            </button>
+          ` : null}
+          <button
+            type="button"
+            class="send"
+            disabled=${mobileQuickDisabled}
+            onClick=${(e: Event) => { void submitMobileQuick(e) }}
+            data-testid="bd-composer-mobile-send"
+          >${submitting ? '등록 중...' : '게시 ↑'}</button>
+        </div>
+        ${mode === 'post' ? html`
+          <div class="bd-desktop-post-form bd-comp-box grid gap-2">
+            <input
+              type="text"
+              class="bg-transparent border-0 outline-0 text-[var(--text-bright)] text-sm placeholder:text-[var(--text-dim)]"
+              placeholder="제목"
+              value=${localTitle}
+              onInput=${(e: Event) => setLocalTitle((e.target as HTMLInputElement).value)}
+              data-testid="bd-composer-title"
+            />
+            <textarea
+              rows=${2}
+              class="bg-transparent border-0 outline-0 text-[var(--text-bright)] text-sm placeholder:text-[var(--text-dim)] resize-none"
+              placeholder=${placeholder}
+              value=${localBody}
+              onInput=${(e: Event) => setLocalBody((e.target as HTMLTextAreaElement).value)}
+              data-testid="bd-composer-body"
+            />
+            <div class="bd-comp-meta flex gap-2">
+              <${Select}
+                value=${localHearth}
+                options=${[{ value: '', label: 'No category' }, ...boardHearths.value.map(h => ({ value: h.name, label: h.name }))]}
+                ariaLabel="게시 category"
+                onInput=${(value: string) => setLocalHearth(value)}
+              />
+              <${Select}
+                value=${localFlair}
+                options=${[{ value: '', label: 'No flair' }, ...boardFlairs.value.map(f => ({ value: f.name, label: `${f.emoji ? `${f.emoji} ` : ''}${f.label}` }))]}
+                ariaLabel="게시 flair"
+                onInput=${(value: string) => setLocalFlair(value)}
+              />
+              <button
+                type="button"
+                class="send ml-auto"
+                disabled=${!localTitle.trim() || !localBody.trim() || submitting}
+                onClick=${(e: Event) => { void submitPost(e) }}
+                data-testid="bd-composer-send"
+              >${submitting ? '등록 중...' : '게시 ↑'}</button>
+            </div>
           </div>
-        </div>
-      ` : html`
-        <div class="bd-comp-box">
-          <${ComposerV2}
-            workspaceId=${localHearth || 'default'}
-            mode=${composerMode}
-            showModeSelector=${false}
-            modeLabels=${{ broadcast: '게시', dm: '멘션', 'state-block': '상태 블록' }}
-          />
-        </div>
-      `}
+        ` : html`
+          <div class="bd-desktop-composer-v2 bd-comp-box">
+            <${ComposerV2}
+              workspaceId=${localHearth || 'default'}
+              mode=${composerMode}
+              showModeSelector=${false}
+              modeLabels=${{ broadcast: '게시', dm: '멘션', 'state-block': '상태 블록' }}
+            />
+          </div>
+        `}
+      </div>
     </div>
   `
 }
 
-function BdFeed({ posts }: { posts: BoardPost[] }) {
+function BdMobileQueues({
+  activeFilter,
+  mentionCount,
+  modCount,
+  onFilter,
+  onMentions,
+}: {
+  activeFilter: 'all' | 'state' | 'mod'
+  mentionCount: number
+  modCount: number
+  onFilter: (filter: 'all' | 'state' | 'mod') => void
+  onMentions: () => void
+}) {
+  return html`
+    <div class="bd-mobile-queues" aria-label="Board mobile queues" data-testid="bd-mobile-queues">
+      <button
+        type="button"
+        class=${`bd-mobile-queue ${activeFilter === 'mod' ? 'on' : ''}`}
+        onClick=${() => onFilter('mod')}
+        data-testid="bd-mobile-queue-mod"
+      >
+        <span class="glyph">⚑</span>
+        모더레이션
+        <span class="n">${modCount}</span>
+      </button>
+      <button
+        type="button"
+        class="bd-mobile-queue"
+        onClick=${onMentions}
+        data-testid="bd-mobile-queue-mentions"
+      >
+        <span class="glyph">＠</span>
+        멘션 인박스
+        <span class="n">${mentionCount}</span>
+      </button>
+    </div>
+  `
+}
+
+function countMentionMessages(): number {
+  return messages.value.filter(message => extractMentionTargets(message.content).length > 0 || message.type?.toLowerCase().includes('mention') === true).length
+}
+
+function BdFeed({ posts, onMentions }: { posts: BoardPost[]; onMentions: () => void }) {
   const [contentQuery, setContentQuery] = useState('')
   const filteredPosts = useMemo(
     () => filterBoardPosts(posts, contentQuery),
@@ -735,6 +1208,11 @@ function BdFeed({ posts }: { posts: BoardPost[] }) {
   )
   const isFiltering = contentQuery.trim() !== ''
   const visibleGroups = useMemo(() => splitVisiblePosts(filteredPosts), [filteredPosts])
+  const mentionCount = useMemo(() => countMentionMessages(), [messages.value])
+  const modCount = useMemo(
+    () => posts.filter(post => post.moderation_status && post.moderation_status !== 'none' && post.moderation_status !== 'approved').length,
+    [posts],
+  )
 
   const modeFilteredGroups = useMemo(() => visibleGroups.groups.map(g => ({
     ...g,
@@ -752,6 +1230,13 @@ function BdFeed({ posts }: { posts: BoardPost[] }) {
         activeFilter=${boardFilterMode.value}
         onFilter=${(filter: 'all' | 'state' | 'mod') => { boardFilterMode.value = filter }}
         count=${filteredByMode.length}
+      />
+      <${BdMobileQueues}
+        activeFilter=${boardFilterMode.value}
+        mentionCount=${mentionCount}
+        modCount=${modCount}
+        onFilter=${(filter: 'all' | 'state' | 'mod') => { boardFilterMode.value = filter }}
+        onMentions=${onMentions}
       />
       <div class="bd-list">
         <div class="mb-3 flex items-center gap-2">
@@ -783,6 +1268,7 @@ function BdFeed({ posts }: { posts: BoardPost[] }) {
 
 // ── Main Board component (public API) ──────────────────────────────
 export function BoardSurface() {
+  const [mobileMentionInboxOpen, setMobileMentionInboxOpen] = useState(false)
   useEffect(() => () => { selectedPostIds.value = new Set() }, [])
   useEffect(() => registerBoardHearthsRefresh(() => {
     void refreshBoardHearths()
@@ -818,7 +1304,7 @@ export function BoardSurface() {
             <${BoardSummary} />
             <button type="button"
               class="v2-workspace-action mb-4 px-3 py-1.5 rounded-[var(--r-1)] text-xs font-medium text-[var(--color-fg-muted)] bg-transparent border border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] transition-colors cursor-pointer"
-              onClick=${() => navigate('workspace', { section: 'board' })}
+              onClick=${() => navigateBoard()}
             >← 게시판으로 돌아가기</button>
             ${detailLoading.value
               ? html`<${LoadingState} title="글 불러오는 중…" />`
@@ -877,9 +1363,14 @@ export function BoardSurface() {
     ? posts.find(p => p.id === selectedBoardPostId.value) ?? null
     : null
 
+  function openMentionInbox(): void {
+    selectedBoardPostId.value = null
+    setMobileMentionInboxOpen(true)
+  }
+
   return html`
     <div class="v2-board-surface ss-surface bg-surface-page text-text-primary">
-      <div class=${`bd-body ${selectedPost ? '' : 'no-detail'}`}>
+      <div class="bd-body">
         <${BdRail}
           activeSub=${activeSub}
           onSub=${(sub: string) => {
@@ -887,10 +1378,15 @@ export function BoardSurface() {
             selectedBoardPostId.value = null
             refreshBoard()
           }}
-          onMentions=${() => { selectedBoardPostId.value = null }}
+          onMentions=${openMentionInbox}
         />
-        <${BdFeed} posts=${boardPosts.value} />
-        ${selectedPost ? html`<${BdDetail} post=${selectedPost} onClose=${() => { selectedBoardPostId.value = null }} />` : null}
+        <${BdFeed} posts=${boardPosts.value} onMentions=${openMentionInbox} />
+        <${BdDetail}
+          post=${selectedPost}
+          mentionMobileOpen=${mobileMentionInboxOpen}
+          onClose=${() => { selectedBoardPostId.value = null }}
+          onCloseMentions=${() => setMobileMentionInboxOpen(false)}
+        />
       </div>
     </div>
   `

--- a/dashboard/src/components/board/composer-v2.test.ts
+++ b/dashboard/src/components/board/composer-v2.test.ts
@@ -6,7 +6,8 @@ import {
   operatorActionBusy,
   operatorSnapshot,
 } from '../../operator-store'
-import type { OperatorSnapshot } from '../../types'
+import { keepers as dashboardKeepers } from '../../store'
+import type { Keeper, OperatorSnapshot } from '../../types'
 
 import '@testing-library/jest-dom'
 
@@ -49,6 +50,15 @@ function snapshotWithKeepers(keepers: Array<{
   } as unknown as OperatorSnapshot
 }
 
+function keeperFixture(overrides: Partial<Keeper> & { name: string }): Keeper {
+  const { name, status = 'running', ...rest } = overrides
+  return {
+    name,
+    status,
+    ...rest,
+  } as Keeper
+}
+
 describe('buildComposerV2Request', () => {
   it('keeps the compose shape required by the C3 contract', () => {
     expect(buildComposerV2Request({
@@ -65,6 +75,32 @@ describe('buildComposerV2Request', () => {
           keys: ['Goal', 'NEXT'],
         },
         attachments: [],
+      },
+    })
+  })
+
+  it('preserves multimodal attachment drafts in the request envelope', () => {
+    expect(buildComposerV2Request({
+      mode: 'broadcast',
+      workspaceId: 'ops',
+      body: 'see attached',
+      attachments: [{
+        id: 'att-1',
+        kind: 'file',
+        name: 'trace.log',
+        size: '4 KB',
+      }],
+    })).toEqual({
+      compose: {
+        mode: 'broadcast',
+        target: { workspace_id: 'ops' },
+        body: 'see attached',
+        attachments: [{
+          id: 'att-1',
+          kind: 'file',
+          name: 'trace.log',
+          size: '4 KB',
+        }],
       },
     })
   })
@@ -88,12 +124,14 @@ describe('ComposerV2', () => {
       { name: 'nick0cave', status: 'busy' },
       { name: 'offline-one', status: 'offline' },
     ])
+    dashboardKeepers.value = []
   })
 
   afterEach(() => {
     cleanup()
     operatorSnapshot.value = null
     operatorActionBusy.value = false
+    dashboardKeepers.value = []
     vi.clearAllMocks()
   })
 
@@ -112,6 +150,48 @@ describe('ComposerV2', () => {
     })
     expect(dispatchOperatorActionMock).not.toHaveBeenCalled()
     expect((screen.getByLabelText('Composer v2 message') as HTMLTextAreaElement).value).toBe('')
+  })
+
+  it('sends attachment-only drafts through the current text transport', async () => {
+    render(h(ComposerV2, { workspaceId: 'ops' }))
+
+    fireEvent.change(screen.getByTestId('composer-v2-file-input'), {
+      target: { files: [new File(['body'], 'trace.log', { type: 'text/plain' })] },
+    })
+
+    expect(screen.getByTestId('composer-v2-tray')).toHaveTextContent('trace.log')
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(sendBroadcastMock).toHaveBeenCalledWith(
+        'dashboard-test',
+        'Attachments:\n- trace.log (4 B · file)',
+      )
+    })
+    expect(screen.queryByTestId('composer-v2-tray')).not.toBeInTheDocument()
+  })
+
+  it('captures a voice draft and serializes it into the current text transport', async () => {
+    render(h(ComposerV2, { workspaceId: 'ops' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start voice draft' }))
+    expect(screen.getByTestId('composer-v2-recorder')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /완료/ }))
+    expect(screen.getByTestId('composer-v2-tray')).toHaveTextContent('받아쓰기')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(sendBroadcastMock).toHaveBeenCalledWith(
+        'dashboard-test',
+        expect.stringContaining('Voice memo 0:12 (40 KB)'),
+      )
+    })
+    expect(sendBroadcastMock).toHaveBeenCalledWith(
+      'dashboard-test',
+      expect.stringContaining('스케줄러 p99 스파이크와 compact 타이밍을 비교해서 결과만 알려줘.'),
+    )
   })
 
   it('sends keeper DMs through the operator keeper-message action', async () => {
@@ -146,9 +226,29 @@ describe('ComposerV2', () => {
     fireEvent.click(screen.getByRole('button', { name: 'DM mode' }))
 
     const select = screen.getByLabelText('Composer v2 keeper target') as HTMLSelectElement
-    const options = Array.from(select.options).map(option => option.textContent)
+    const options = Array.from(select.options).map(option => option.textContent).filter(label => label !== 'Keeper')
     expect(options).toContain('paused-one')
     expect(options).not.toContain('offline-one')
+  })
+
+  it('uses execution keepers as a fallback when operator snapshot targets are empty', () => {
+    operatorSnapshot.value = null
+    dashboardKeepers.value = [
+      keeperFixture({ name: 'fallback-a', status: 'running' }),
+      keeperFixture({ name: 'fallback-paused', status: 'offline', phase: 'Paused', paused: true }),
+      keeperFixture({ name: 'fallback-offline', status: 'offline', phase: 'Offline' }),
+    ]
+
+    render(h(ComposerV2, { workspaceId: 'ops' }))
+    fireEvent.click(screen.getByRole('button', { name: 'DM mode' }))
+
+    expect(screen.getByText('0 chars · 0 files · 2 keeper targets')).toBeInTheDocument()
+    const select = screen.getByLabelText('Composer v2 keeper target') as HTMLSelectElement
+    const options = Array.from(select.options)
+      .map(option => option.textContent)
+      .filter(label => label !== 'Keeper')
+    expect(options).toEqual(['fallback-a', 'fallback-paused'])
+    expect(select.value).toBe('keeper:fallback-a')
   })
 
   it('requires a parsed state block before state sends', async () => {

--- a/dashboard/src/components/board/composer-v2.ts
+++ b/dashboard/src/components/board/composer-v2.ts
@@ -1,7 +1,8 @@
 import { html } from 'htm/preact'
-import { useCallback, useEffect, useState } from 'preact/hooks'
-import { AtSign, Braces, Megaphone, Send, UserRound } from 'lucide-preact'
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+import { AtSign, Braces, Megaphone, Mic, Paperclip, Send, Square, UserRound, X } from 'lucide-preact'
 import { currentDashboardActor, sendBroadcast } from '../../api'
+import { keepers as dashboardKeepers, refreshExecution } from '../../store'
 import {
   dispatchOperatorAction,
   operatorActionBusy,
@@ -32,6 +33,21 @@ interface StructuredStateBlock {
   kind: 'state-block'
   raw: string
   keys: string[]
+}
+
+export interface ComposerAttachmentDraft {
+  id: string
+  kind: 'image' | 'file'
+  name: string
+  size: string
+  dims?: string | null
+}
+
+export interface ComposerVoiceDraft {
+  secs: number
+  size: string
+  wave: number[]
+  transcript: string
 }
 
 export interface ComposerV2Request {
@@ -77,6 +93,7 @@ export function buildComposerV2Request(input: {
   workspaceId: string
   body: string
   keeperId?: string | null
+  attachments?: ComposerAttachmentDraft[]
 }): ComposerV2Request {
   const body = input.body.trim()
   const target: ComposerV2Target = {}
@@ -93,9 +110,55 @@ export function buildComposerV2Request(input: {
       mode: input.mode,
       target: Object.keys(target).length > 0 ? target : undefined,
       body: composeBody,
-      attachments: [],
+      attachments: input.attachments ?? [],
     },
   }
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function formatClock(seconds: number): string {
+  const whole = Math.max(0, Math.round(seconds))
+  return `${Math.floor(whole / 60)}:${String(whole % 60).padStart(2, '0')}`
+}
+
+export function createComposerVoiceDraft(): ComposerVoiceDraft {
+  return {
+    secs: 12,
+    size: formatFileSize(12 * 3400),
+    wave: [0.35, 0.72, 0.48, 0.9, 0.42, 0.66, 0.58, 0.8, 0.5, 0.7, 0.38, 0.62],
+    transcript: '스케줄러 p99 스파이크와 compact 타이밍을 비교해서 결과만 알려줘.',
+  }
+}
+
+export function serializeComposerBody(input: {
+  text: string
+  attachments: ComposerAttachmentDraft[]
+  voice: ComposerVoiceDraft | null
+}): string {
+  const blocks: string[] = []
+  if (input.attachments.length > 0) {
+    blocks.push([
+      'Attachments:',
+      ...input.attachments.map(attachment => {
+        const meta = [attachment.size, attachment.kind, attachment.dims].filter(Boolean).join(' · ')
+        return `- ${attachment.name}${meta ? ` (${meta})` : ''}`
+      }),
+    ].join('\n'))
+  }
+  if (input.voice) {
+    blocks.push([
+      `Voice memo ${formatClock(input.voice.secs)} (${input.voice.size})`,
+      input.voice.transcript,
+    ].join('\n'))
+  }
+  const text = input.text.trim()
+  if (text) blocks.push(text)
+  return blocks.join('\n\n')
 }
 
 interface ComposerV2Props {
@@ -123,8 +186,12 @@ export function ComposerV2({
   }, [controlledMode, onModeChange])
   const [draft, setDraft] = useState('')
   const [keeperTarget, setKeeperTarget] = useState('')
+  const [attachments, setAttachments] = useState<ComposerAttachmentDraft[]>([])
+  const [voiceDraft, setVoiceDraft] = useState<ComposerVoiceDraft | null>(null)
+  const [recording, setRecording] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const workspace = normalizeWorkspaceId(workspaceId)
   const busy = submitting || operatorActionBusy.value
   const mention = useOperatorMentionContext({
@@ -132,6 +199,7 @@ export function ComposerV2({
     target: keeperTarget,
     dmActive: mode === 'dm',
     listboxId: MENTION_LISTBOX_ID,
+    fallbackKeepers: dashboardKeepers.value,
   })
   const {
     onlineKeepers,
@@ -151,8 +219,10 @@ export function ComposerV2({
     setDismissedMentionQuery,
   } = mention
   const stateKeys = mode === 'state-block' ? stateBlockKeys(draft) : []
+  const hasDraftContent = draft.trim() !== '' || attachments.length > 0 || voiceDraft !== null
+  const attachmentLabel = `${attachments.length} file${attachments.length === 1 ? '' : 's'}`
   const sendDisabled = busy
-    || draft.trim() === ''
+    || !hasDraftContent
     || (mode === 'dm' && (!effectiveKeeperOnline || unresolvedTrailingMention))
     || (mode === 'state-block' && stateKeys.length === 0)
 
@@ -162,6 +232,12 @@ export function ComposerV2({
     const firstKeeper = onlineKeepers[0]?.name
     setKeeperTarget(firstKeeper ? `keeper:${firstKeeper}` : '')
   }, [mode, onlineKeeperNames, selectedKeeperOnline])
+
+  useEffect(() => {
+    if (mode !== 'dm') return
+    if (onlineKeepers.length > 0) return
+    void refreshExecution()
+  }, [mode, onlineKeepers.length])
 
   function chooseMode(nextMode: ComposerV2Mode): void {
     setMode(nextMode)
@@ -176,8 +252,34 @@ export function ComposerV2({
     setDraft(current => replaceTrailingMentionDraft(current, keeperName))
   }
 
+  function attachFiles(files: FileList | File[]): void {
+    const nextFiles = Array.from(files).slice(0, 6)
+    if (nextFiles.length === 0) return
+    setAttachments(current => [
+      ...current,
+      ...nextFiles.map((file, index): ComposerAttachmentDraft => ({
+        id: `${Date.now()}-${index}-${file.name}`,
+        kind: file.type.startsWith('image/') ? 'image' : 'file',
+        name: file.name,
+        size: formatFileSize(file.size),
+      })),
+    ].slice(0, 6))
+  }
+
+  function stopVoiceDraft(): void {
+    setRecording(false)
+    setVoiceDraft(createComposerVoiceDraft())
+  }
+
+  function resetDraft(): void {
+    setDraft('')
+    setAttachments([])
+    setVoiceDraft(null)
+    setRecording(false)
+  }
+
   async function submit(): Promise<void> {
-    const message = draft.trim()
+    const message = serializeComposerBody({ text: draft, attachments, voice: voiceDraft })
     if (!message || sendDisabled) return
     const keeperId = mode === 'dm'
       ? trailingMentionTarget ?? keeperNameFromTarget(keeperTarget)
@@ -187,6 +289,7 @@ export function ComposerV2({
       workspaceId: workspace,
       body: message,
       keeperId,
+      attachments,
     })
     setSubmitting(true)
     setSubmitError(null)
@@ -204,7 +307,7 @@ export function ComposerV2({
         await sendBroadcast(currentDashboardActor(), composeBodyText(request.compose.body))
       }
       if (keeperId) setKeeperTarget(`keeper:${keeperId}`)
-      setDraft('')
+      resetDraft()
       showToast('Message sent.', 'success')
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Message send failed.'
@@ -246,11 +349,64 @@ export function ComposerV2({
           #${workspace}
         </span>
         <span class="ml-auto text-2xs tabular-nums text-[var(--color-fg-muted)]" aria-live="polite">
-          ${draft.length} chars · ${onlineKeepers.length} keeper targets
+          ${draft.length} chars · ${attachmentLabel}${voiceDraft ? ' · voice' : ''} · ${onlineKeepers.length} keeper targets
         </span>
       </div>
 
       <div class="mt-3 grid gap-2">
+        ${attachments.length > 0 || voiceDraft
+          ? html`
+              <div class="composer-tray" data-testid="composer-v2-tray">
+                ${attachments.map(attachment => html`
+                  <div class="cdraft att" key=${attachment.id}>
+                    <div class="cdraft-thumb">
+                      <span class="cdraft-glyph">${attachment.kind === 'image' ? '▧' : '◫'}</span>
+                    </div>
+                    <div class="cdraft-meta">
+                      <span class="cdraft-name mono">${attachment.name}</span>
+                      <span class="cdraft-sub mono">${[attachment.size, attachment.kind, attachment.dims].filter(Boolean).join(' · ')}</span>
+                    </div>
+                    <button
+                      type="button"
+                      class="cdraft-x"
+                      title="첨부 제거"
+                      aria-label=${`Remove attachment ${attachment.name}`}
+                      onClick=${() => { setAttachments(current => current.filter(item => item.id !== attachment.id)) }}
+                      disabled=${busy}
+                    >
+                      <${X} size=${10} aria-hidden="true" />
+                    </button>
+                  </div>
+                `)}
+                ${voiceDraft
+                  ? html`
+                      <div class="cdraft voice">
+                        <span class="cdraft-glyph mic">◌</span>
+                        <div class="cdraft-wave" aria-hidden="true">
+                          ${voiceDraft.wave.map((height, index) => html`<span class="vbar" key=${index} style=${{ height: `${Math.round(4 + height * 18)}px` }} />`)}
+                        </div>
+                        <span class="cdraft-dur mono">${formatClock(voiceDraft.secs)}</span>
+                        <div class="cdraft-tx">
+                          <span class="cdraft-tx-k">받아쓰기</span>
+                          <span class="cdraft-tx-v">${voiceDraft.transcript}</span>
+                        </div>
+                        <button
+                          type="button"
+                          class="cdraft-x"
+                          title="음성 제거"
+                          aria-label="Remove voice draft"
+                          onClick=${() => { setVoiceDraft(null) }}
+                          disabled=${busy}
+                        >
+                          <${X} size=${10} aria-hidden="true" />
+                        </button>
+                      </div>
+                    `
+                  : null}
+              </div>
+            `
+          : null}
+
         ${mode === 'dm'
           ? html`
               <${Select}
@@ -297,6 +453,24 @@ export function ComposerV2({
                     </div>
                   `
                 : null}
+            `
+          : null}
+
+        ${recording
+          ? html`
+              <div class="rec-bar" data-testid="composer-v2-recorder">
+                <span class="rec-dot" aria-hidden="true"></span>
+                <span class="rec-lbl">녹음 중</span>
+                <span class="rec-clock mono">0:12</span>
+                <div class="rec-wave" aria-hidden="true">
+                  ${[0.4, 0.8, 0.5, 0.9, 0.45, 0.75, 0.52, 0.84, 0.48, 0.7].map((height, index) => html`<span class="rbar" key=${index} style=${{ height: `${Math.round(3 + height * 20)}px` }} />`)}
+                </div>
+                <button type="button" class="rec-btn cancel" onClick=${() => { setRecording(false) }} disabled=${busy}>취소</button>
+                <button type="button" class="rec-btn stop" onClick=${stopVoiceDraft} disabled=${busy}>
+                  <${Square} size=${11} aria-hidden="true" />
+                  완료
+                </button>
+              </div>
             `
           : null}
 
@@ -347,6 +521,47 @@ export function ComposerV2({
           }}
           disabled=${busy}
         />
+
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <div class="composer-tools" aria-label="Composer v2 multimodal tools">
+            <input
+              ref=${fileInputRef}
+              type="file"
+              accept="image/*,.pdf,.txt,.log,.json,.csv,.md"
+              multiple
+              hidden
+              data-testid="composer-v2-file-input"
+              onChange=${(event: Event) => {
+                const input = event.target as HTMLInputElement
+                if (input.files) attachFiles(input.files)
+                input.value = ''
+              }}
+            />
+            <button
+              type="button"
+              class="ctool"
+              title="이미지·파일 첨부"
+              aria-label="Attach file"
+              onClick=${() => { fileInputRef.current?.click() }}
+              disabled=${busy || attachments.length >= 6}
+              data-testid="composer-v2-attach"
+            >
+              <${Paperclip} size=${15} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              class="ctool"
+              title="음성 입력"
+              aria-label="Start voice draft"
+              onClick=${() => { setRecording(true) }}
+              disabled=${busy || recording}
+              data-testid="composer-v2-voice"
+            >
+              <${Mic} size=${15} aria-hidden="true" />
+            </button>
+          </div>
+          <span class="text-2xs text-[var(--color-fg-muted)]">⌘ ↵ 전송 · 파일/음성 포함</span>
+        </div>
 
         ${mode === 'state-block'
           ? html`

--- a/dashboard/src/components/board/mention-inbox.ts
+++ b/dashboard/src/components/board/mention-inbox.ts
@@ -7,9 +7,9 @@ import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
 import { SYSTEM_MESSAGE_FROM, boardMessageRowKey, previewBoardMessage } from '../../lib/board-utils'
 import { currentDashboardActorName } from '../../lib/dashboard-session-actor'
-import { navigate } from '../../router'
 import { messages, shellAuthSummary } from '../../store'
 import type { DashboardShellAuthSummary, Message } from '../../types'
+import { navigateBoard } from './board-route'
 
 interface MentionInboxRow {
   message: Message
@@ -199,7 +199,7 @@ export function MentionInbox() {
           variant="ghost"
           size="sm"
           class="inline-flex items-center gap-1.5"
-          onClick=${() => navigate('workspace', { section: 'board' })}
+          onClick=${() => navigateBoard()}
           ariaLabel="게시판으로 돌아가기"
         >
           <${ArrowLeft} size=${14} aria-hidden="true" />

--- a/dashboard/src/components/board/message-workspace-timeline.ts
+++ b/dashboard/src/components/board/message-workspace-timeline.ts
@@ -6,12 +6,12 @@ import { EmptyState } from '../common/feedback-state'
 import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
 import { SYSTEM_MESSAGE_FROM, boardMessageRowKey, previewBoardMessage } from '../../lib/board-utils'
-import { navigate } from '../../router'
 import { messages } from '../../store'
 import type { Message } from '../../types'
 import { ComposerV2 } from './composer-v2'
 import { extractMentionTargets } from './mention-inbox'
 import { extractStateBlocks } from './state-block-messages'
+import { navigateBoard } from './board-route'
 
 interface TimelineRow {
   message: Message
@@ -157,7 +157,7 @@ export function MessageWorkspaceTimeline() {
           variant="ghost"
           size="sm"
           class="inline-flex items-center gap-1.5"
-          onClick=${() => navigate('workspace', { section: 'board' })}
+          onClick=${() => navigateBoard()}
           ariaLabel="게시판으로 돌아가기"
         >
           <${ArrowLeft} size=${14} aria-hidden="true" />

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -11,7 +11,7 @@ import { RichComposer } from '../common/rich-composer'
 import { RichContent } from '../common/rich-content'
 import { TextInput } from '../common/input'
 import { stripStateBlocks } from '../../keeper-message'
-import { navigate, replaceRoute, route } from '../../router'
+import { route } from '../../router'
 import { votePost, voteComment } from '../../api/board'
 import { ModerationBadge } from './moderation-badge'
 import { ReactionBar } from './reaction-bar'
@@ -43,6 +43,7 @@ import {
   refreshBoard,
 } from './board-state'
 import type { BoardComment, BoardPost } from './board-state'
+import { navigateBoard, replaceBoardRoute } from './board-route'
 
 const MAX_INLINE_COMMENT_DEPTH = 5
 const INITIAL_CHILD_REPLY_LIMIT = 5
@@ -55,11 +56,10 @@ function cleanCommentRouteParam(value: string | undefined): string | null {
 function clearCommentRouteFocus(postId: string): void {
   const params: Record<string, string> = {
     ...route.value.params,
-    section: 'board',
     post: postId,
   }
   delete params.comment
-  replaceRoute('workspace', params)
+  replaceBoardRoute(params)
 }
 
 // ── Expiry chip (returns html, kept in UI layer) ───────────────────
@@ -556,7 +556,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
         variant="ghost"
         size="sm"
         class="mb-4 text-xs"
-        onClick=${() => navigate('workspace', { section: 'board' })}
+        onClick=${() => navigateBoard()}
       >← 게시판으로 돌아가기<//>
 
       <${SurfaceCard}>

--- a/dashboard/src/components/board/state-block-messages.ts
+++ b/dashboard/src/components/board/state-block-messages.ts
@@ -7,9 +7,9 @@ import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
 import { stripStateBlocks } from '../../keeper-message'
 import { SYSTEM_MESSAGE_FROM } from '../../lib/board-utils'
-import { navigate } from '../../router'
 import { messages } from '../../store'
 import type { Message } from '../../types'
+import { navigateBoard } from './board-route'
 
 interface StateBlockRow {
   message: Message
@@ -151,7 +151,7 @@ export function StateBlockMessages() {
           variant="ghost"
           size="sm"
           class="inline-flex items-center gap-1.5"
-          onClick=${() => navigate('workspace', { section: 'board' })}
+          onClick=${() => navigateBoard()}
           ariaLabel="게시판으로 돌아가기"
         >
           <${ArrowLeft} size=${14} aria-hidden="true" />

--- a/dashboard/src/components/board/sub-board-surface.ts
+++ b/dashboard/src/components/board/sub-board-surface.ts
@@ -2,7 +2,6 @@ import { html } from 'htm/preact'
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
 import { Hash, Pencil, Plus, RefreshCw, Trash2, Users } from 'lucide-preact'
 import { createSubBoard, deleteSubBoard, fetchSubBoards, updateSubBoard } from '../../api/board'
-import { navigate } from '../../router'
 import { boardHearthFilter } from '../../store'
 import type { SubBoard, SubBoardAccess } from '../../types'
 import { ActionButton } from '../common/button'
@@ -13,6 +12,7 @@ import { SurfaceCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
 import { showToast } from '../common/toast'
 import { requestConfirm } from '../common/confirm-dialog'
+import { navigateBoard } from './board-route'
 
 const ACCESS_OPTIONS: Array<{ value: SubBoardAccess; label: string }> = [
   { value: 'open', label: 'Open' },
@@ -61,7 +61,7 @@ function SubBoardRow({ board, onEdit, onDelete, deleting }: SubBoardRowProps) {
             </span>
             <div class="min-w-0 cursor-pointer" onClick=${() => {
               boardHearthFilter.value = board.slug
-              navigate('workspace', { section: 'board' })
+              navigateBoard()
             }}>
               <h3 class="truncate text-sm font-semibold text-[var(--color-fg-primary)] hover:underline">${board.name || board.slug}</h3>
               <div class="truncate font-mono text-2xs text-[var(--color-fg-muted)]">/${board.slug}</div>

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -294,6 +294,36 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('[data-chat-delivery="live"]')).not.toBeNull()
   })
 
+  it('renders an optional message action and passes the clicked entry', () => {
+    const onClick = vi.fn()
+    const target = entry({
+      id: 'a1',
+      role: 'assistant',
+      source: 'direct_assistant',
+      label: 'sangsu',
+      text: '검사할 응답',
+    })
+
+    render(
+      html`<${ChatTranscript}
+        entries=${[target]}
+        emptyText="empty"
+        variant="messenger"
+        action=${{ label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick }}
+      />`,
+      container,
+    )
+
+    const action = container.querySelector('[data-testid="chat-message-action"]') as HTMLButtonElement
+    expect(action).not.toBeNull()
+    expect(action.textContent).toBe('턴 상세')
+
+    fireEvent.click(action)
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onClick.mock.calls[0]?.[0].id).toBe('a1')
+  })
+
   it('renders a thinking placeholder when the model is reasoning', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -126,6 +126,11 @@ function surfaceLink(surface?: SurfaceRef | null): { url: string; label: string;
 
 type ChatTranscriptVariant = 'default' | 'messenger'
 type ChatTranscriptSize = 'default' | 'primary'
+type ChatTranscriptAction = {
+  label: string
+  title?: string
+  onClick: (entry: KeeperConversationEntry) => void
+}
 
 function timeLabel(timestamp?: string | null): string | null {
   if (!timestamp) return null
@@ -1297,11 +1302,13 @@ function ChatMessageBubble({
   showMetadata = true,
   variant = 'default',
   showSourceBadge = false,
+  action,
 }: {
   entry: KeeperConversationEntry
   showMetadata?: boolean
   variant?: ChatTranscriptVariant
   showSourceBadge?: boolean
+  action?: ChatTranscriptAction
 }) {
   const [expandedRaw, setExpandedRaw] = useState(false)
   const [rawExpandedRaw, setRawExpandedRaw] = useState(false)
@@ -1455,6 +1462,21 @@ function ChatMessageBubble({
                 `}
           </div>
         </div>
+        ${action
+          ? html`
+              <button
+                type="button"
+                class=${`border border-[var(--accent-20)] bg-[var(--accent-10)] text-xs font-semibold text-[var(--color-accent-fg)] transition-colors hover:bg-[var(--accent-20)] ${CHAT_FOCUS_RING} ${
+                  isMessenger ? 'rounded-[var(--r-1)] px-2.5 py-1' : 'rounded-[var(--r-0)] px-3 py-1'
+                }`}
+                onClick=${() => action.onClick(entry)}
+                title=${action.title ?? action.label}
+                data-testid="chat-message-action"
+              >
+                ${action.label}
+              </button>
+            `
+          : null}
         ${canExpand
           ? html`
               <button
@@ -1742,6 +1764,7 @@ export function ChatTranscript({
   size = 'default',
   showDayDividers = false,
   showSourceBadge = false,
+  action,
 }: {
   entries: KeeperConversationEntry[]
   emptyText: string
@@ -1752,6 +1775,7 @@ export function ChatTranscript({
   // (copilot dock, detail page, etc.) renders unchanged.
   showDayDividers?: boolean
   showSourceBadge?: boolean
+  action?: ChatTranscriptAction
 }) {
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   const pinnedRef = useRef(true)
@@ -1820,7 +1844,7 @@ export function ChatTranscript({
           : entries.flatMap((entry, i) => {
               const bubble = entry.role === 'tool'
                 ? html`<${ToolCallBubble} key=${entry.id} entry=${entry} />`
-                : html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} variant=${variant} showSourceBadge=${showSourceBadge} />`
+                : html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} variant=${variant} showSourceBadge=${showSourceBadge} action=${action} />`
               // C1: emit a day divider before the first message of each calendar
               // day. Skipped entirely when showDayDividers is off (every non-
               // workspace surface), so their flat render is byte-identical.

--- a/dashboard/src/components/common/use-operator-mention-context.test.ts
+++ b/dashboard/src/components/common/use-operator-mention-context.test.ts
@@ -23,14 +23,16 @@ function Probe({
   message,
   target,
   dmActive,
+  fallbackKeepers,
   onContext,
 }: {
   message: string
   target: string
   dmActive: boolean
+  fallbackKeepers?: OperatorKeeperSnapshot[]
   onContext: (ctx: OperatorMentionContext) => void
 }) {
-  const ctx = useOperatorMentionContext({ message, target, dmActive, listboxId: LISTBOX_ID })
+  const ctx = useOperatorMentionContext({ message, target, dmActive, listboxId: LISTBOX_ID, fallbackKeepers })
   // Capture synchronously during render — vitest jsdom does not flush
   // useEffect within the await-microtask window the test uses.
   onContext(ctx)
@@ -67,6 +69,47 @@ describe('useOperatorMentionContext', () => {
 
     expect(captured?.onlineKeepers.map(k => k.name).sort()).toEqual(['alpha', 'gamma'])
     expect(captured?.onlineKeeperNames).toBe('alpha\0gamma')
+  })
+
+  it('uses fallback keepers when the operator snapshot has no targetable keepers', async () => {
+    operatorSnapshot.value = null
+
+    render(
+      html`<${Probe}
+        message="@fa"
+        target=""
+        dmActive=${true}
+        fallbackKeepers=${[
+          { name: 'fallback-a', status: 'active' } as OperatorKeeperSnapshot,
+          { name: 'fallback-paused', status: 'offline', phase: 'paused', paused: true } as OperatorKeeperSnapshot,
+          { name: 'fallback-offline', status: 'offline', phase: 'offline' } as OperatorKeeperSnapshot,
+        ]}
+        onContext=${(c: OperatorMentionContext) => { captured = c }}
+      />`,
+      container,
+    )
+
+    expect(captured?.onlineKeepers.map(k => k.name).sort()).toEqual(['fallback-a', 'fallback-paused'])
+    expect(captured?.mentionMatches.map(m => m.name).sort()).toEqual(['fallback-a', 'fallback-paused'])
+  })
+
+  it('prefers operator snapshot keepers over fallback keepers when snapshot targets exist', async () => {
+    operatorSnapshot.value = snapshotWithKeepers([
+      { name: 'snapshot-a', status: 'active' } as OperatorKeeperSnapshot,
+    ])
+
+    render(
+      html`<${Probe}
+        message="@"
+        target=""
+        dmActive=${true}
+        fallbackKeepers=${[{ name: 'fallback-a', status: 'active' } as OperatorKeeperSnapshot]}
+        onContext=${(c: OperatorMentionContext) => { captured = c }}
+      />`,
+      container,
+    )
+
+    expect(captured?.onlineKeepers.map(k => k.name)).toEqual(['snapshot-a'])
   })
 
   it('skips mention parsing when dmActive is false', async () => {

--- a/dashboard/src/components/common/use-operator-mention-context.ts
+++ b/dashboard/src/components/common/use-operator-mention-context.ts
@@ -8,7 +8,11 @@
 
 import { useEffect, useState, type Dispatch, type StateUpdater } from 'preact/hooks'
 import { operatorSnapshot } from '../../operator-store'
-import { isKeeperOperatorTargetable } from '../../lib/keeper-predicates'
+import {
+  isKeeperOperatorTargetable,
+  type KeeperOfflineInput,
+  type KeeperPausedInput,
+} from '../../lib/keeper-predicates'
 import {
   keeperNameFromTarget,
   mentionCandidates,
@@ -48,6 +52,19 @@ export interface UseOperatorMentionContextOptions {
   dmActive: boolean
   /** ARIA listbox id used to build per-option ids. Surfaces use different ids. */
   listboxId: string
+  /** Secondary roster used when the operator snapshot has no targetable keepers. */
+  fallbackKeepers?: MentionSourceKeeper[]
+}
+
+interface MentionSourceKeeper extends KeeperPausedInput, KeeperOfflineInput {
+  name?: string | null
+}
+
+function targetableMentionKeepers(keepers: MentionSourceKeeper[]): OnlineKeeper[] {
+  return keepers
+    .filter(keeper => typeof keeper.name === 'string' && keeper.name.trim() !== '')
+    .filter(isKeeperOperatorTargetable)
+    .map(keeper => ({ name: keeper.name!.trim(), status: keeper.status ?? undefined }))
 }
 
 export function useOperatorMentionContext(
@@ -61,9 +78,9 @@ export function useOperatorMentionContext(
   const snapshot = operatorSnapshot.value
   // Paused keepers stay targetable so operators can DM/probe/resume them,
   // even when another lifecycle axis still carries an offline-ish token.
-  const onlineKeepers: OnlineKeeper[] = (snapshot?.keepers ?? [])
-    .filter(isKeeperOperatorTargetable)
-    .map(keeper => ({ name: keeper.name, status: keeper.status }))
+  const operatorKeepers = targetableMentionKeepers(snapshot?.keepers ?? [])
+  const fallbackKeepers = targetableMentionKeepers(opts.fallbackKeepers ?? [])
+  const onlineKeepers = operatorKeepers.length > 0 ? operatorKeepers : fallbackKeepers
   const onlineKeeperNames = onlineKeepers.map(keeper => keeper.name).join('\0')
 
   const selectedKeeper = keeperNameFromTarget(target)

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -55,6 +55,14 @@ describe('isKeeperDetailDashboardRoute', () => {
     })).toBe(true)
   })
 
+  it('treats the top-level keepers surface as an immersive keeper workspace', () => {
+    expect(isKeeperDetailDashboardRoute({
+      tab: 'keepers',
+      params: {},
+      postId: null,
+    })).toBe(true)
+  })
+
   it('does not treat the fleet list as keeper detail', () => {
     expect(isKeeperDetailDashboardRoute({
       tab: 'monitoring',
@@ -857,8 +865,8 @@ describe('SideRail v2 chrome', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     route.value = {
-      tab: 'monitoring',
-      params: { section: 'agents' },
+      tab: 'workspace',
+      params: { section: 'work' },
       postId: null,
     }
   })
@@ -874,13 +882,13 @@ describe('SideRail v2 chrome', () => {
     expect(container.querySelector('.nav-brand')).not.toBeNull()
     expect(container.querySelector('.nav-sec')).not.toBeNull()
     expect(container.querySelector('.nav-link.active')).not.toBeNull()
-    expect(container.querySelector('.nav-link.active')?.textContent).toContain('Monitor')
+    expect(container.querySelector('.nav-link.active')?.textContent).toContain('Work')
 
     const sublist = container.querySelector('.nav-sublist')
     expect(sublist).not.toBeNull()
     const activeSublink = sublist?.querySelector('.nav-sublink.active')
     expect(activeSublink).not.toBeNull()
-    expect(activeSublink?.textContent).toContain('Keeper Fleet')
+    expect(activeSublink?.textContent).toContain('Work')
   })
 
   it('renders collapsed icon-only links with v2 classes', () => {

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -27,6 +27,7 @@ import { LoadingState } from './common/feedback-state'
 import {
   DASHBOARD_SURFACES,
   DASHBOARD_NAV_ITEMS,
+  PRIMARY_DASHBOARD_SURFACES,
   currentSectionForRoute,
   visibleSectionItemsForTab,
 } from '../config/navigation'
@@ -64,6 +65,8 @@ function BuildInfoRow({ label, children }: { label: string; children: unknown })
 
 const LazyOverview = lazy(async () => ({ default: (await import('./overview/overview')).Overview }))
 const LazyStatus = lazy(async () => ({ default: (await import('./status')).Status }))
+const LazyKeeperDetailPage = lazy(async () => ({ default: (await import('./keeper-detail-page')).KeeperDetailPage }))
+const LazyBoardSurface = lazy(async () => ({ default: (await import('./board/board-surface')).BoardSurface }))
 const LazyWork = lazy(async () => ({ default: (await import('./work')).Work }))
 const LazyOperations = lazy(async () => ({ default: (await import('./operations-panel')).OperationsPanel }))
 const LazyConnectors = lazy(async () => ({ default: (await import('./connector-status')).ConnectorStatusPanel }))
@@ -1032,10 +1035,20 @@ function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
   `
 }
 
-export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggle?: () => void }) {
+export function SideRail({
+  collapsed,
+  onToggle,
+  primaryOnly = true,
+}: {
+  collapsed?: boolean
+  onToggle?: () => void
+  primaryOnly?: boolean
+}) {
   const currentTab = route.value.tab
   const currentSection = currentSectionForRoute(route.value)
-  const visibleSurfaces = DASHBOARD_SURFACES.filter(surface => surface.hidden !== true)
+  const visibleSurfaces = primaryOnly
+    ? PRIMARY_DASHBOARD_SURFACES
+    : DASHBOARD_SURFACES.filter(surface => surface.hidden !== true)
 
   return html`
     <nav class="v2-shell-surface flex flex-col h-full" aria-label="Dashboard navigation">
@@ -1143,6 +1156,18 @@ function TabContent() {
       return html`
         <${Suspense} fallback=${lazyTabFallback('Monitor')}>
           <${LazyStatus} />
+        <//>
+      `
+    case 'keepers':
+      return html`
+        <${Suspense} fallback=${lazyTabFallback('Keepers')}>
+          <${LazyKeeperDetailPage} />
+        <//>
+      `
+    case 'board':
+      return html`
+        <${Suspense} fallback=${lazyTabFallback('Board')}>
+          <${LazyBoardSurface} />
         <//>
       `
     case 'workspace':
@@ -1312,6 +1337,7 @@ function useSurfaceDocumentTitle(): void {
 }
 
 export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
+  if (routeState.tab === 'keepers') return true
   return routeState.tab === 'monitoring'
     && routeState.params.section === 'agents'
     && typeof routeState.params.keeper === 'string'
@@ -1382,7 +1408,7 @@ export function DashboardMain() {
 
   const routeLabel = dashboardRouteBoundaryKey(route.value)
   const soloMode = isWidgetSoloRoute(route.value)
-  const immersiveSurface = route.value.tab === 'code'
+  const immersiveSurface = route.value.tab === 'code' || route.value.tab === 'keepers'
   const keeperDetailRoute = isKeeperDetailDashboardRoute(route.value)
   const warmingBanner = namespaceTruthInitializing.value ? html`
     <div class=${`v2-shell-panel ${immersiveSurface

--- a/dashboard/src/components/dashboard-surface-tabs.test.ts
+++ b/dashboard/src/components/dashboard-surface-tabs.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { axe } from 'jest-axe'
-import { VISIBLE_DASHBOARD_NAV_ITEMS } from '../config/navigation'
+import { PRIMARY_DASHBOARD_NAV_ITEMS } from '../config/navigation'
 import { DashboardSurfaceTabs, dashboardSurfaceTabId } from './dashboard-surface-tabs'
 
 const navigate = vi.fn()
@@ -33,7 +33,7 @@ describe('DashboardSurfaceTabs', () => {
 
   it('renders top-level surfaces as an ARIA tablist', () => {
     render(
-      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="code" />`,
+      html`<${DashboardSurfaceTabs} items=${PRIMARY_DASHBOARD_NAV_ITEMS} currentTab="code" />`,
       container,
     )
 
@@ -41,14 +41,22 @@ describe('DashboardSurfaceTabs', () => {
     expect(tablist?.getAttribute('aria-label')).toBe('Dashboard surfaces')
 
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'))
-    expect(tabs.map(tab => tab.textContent?.trim())).toContain('Code')
+    expect(tabs.map(tab => tab.textContent?.trim())).toEqual([
+      'Overview',
+      'Work',
+      'Keepers',
+      'Board',
+      'IDE',
+      'Connectors',
+      'Settings',
+    ])
     expect(tabs.map(tab => tab.textContent?.trim())).not.toContain('MASC Cockpit')
-    expect(tabs).toHaveLength(VISIBLE_DASHBOARD_NAV_ITEMS.length)
+    expect(tabs).toHaveLength(PRIMARY_DASHBOARD_NAV_ITEMS.length)
   })
 
   it('marks the current surface as the selected tab', () => {
     render(
-      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="code" />`,
+      html`<${DashboardSurfaceTabs} items=${PRIMARY_DASHBOARD_NAV_ITEMS} currentTab="code" />`,
       container,
     )
 
@@ -63,37 +71,37 @@ describe('DashboardSurfaceTabs', () => {
 
   it('moves focus and activates the next surface on ArrowRight', () => {
     render(
-      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
+      html`<${DashboardSurfaceTabs} items=${PRIMARY_DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
       container,
     )
 
     const overviewTab = container.querySelector(`#${dashboardSurfaceTabId('overview')}`) as HTMLElement
-    const monitorTab = container.querySelector(`#${dashboardSurfaceTabId('monitoring')}`) as HTMLElement
+    const workTab = container.querySelector(`#${dashboardSurfaceTabId('workspace')}`) as HTMLElement
     overviewTab.focus()
     overviewTab.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
 
-    expect(document.activeElement).toBe(monitorTab)
-    expect(navigate).toHaveBeenCalledWith('monitoring', { section: 'agents' })
+    expect(document.activeElement).toBe(workTab)
+    expect(navigate).toHaveBeenCalledWith('workspace', { section: 'work' })
   })
 
   it('jumps to the last surface on End', () => {
     render(
-      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
+      html`<${DashboardSurfaceTabs} items=${PRIMARY_DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
       container,
     )
 
     const overviewTab = container.querySelector(`#${dashboardSurfaceTabId('overview')}`) as HTMLElement
-    const logsTab = container.querySelector(`#${dashboardSurfaceTabId('logs')}`) as HTMLElement
+    const settingsTab = container.querySelector(`#${dashboardSurfaceTabId('settings')}`) as HTMLElement
     overviewTab.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }))
 
-    expect(document.activeElement).toBe(logsTab)
-    expect(navigate).toHaveBeenCalledWith('logs', undefined)
+    expect(document.activeElement).toBe(settingsTab)
+    expect(navigate).toHaveBeenCalledWith('settings', undefined)
   })
 
   it('passes axe with route tabs and the controlled main panel target', async () => {
     render(
       html`
-        <${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="overview" />
+        <${DashboardSurfaceTabs} items=${PRIMARY_DASHBOARD_NAV_ITEMS} currentTab="overview" />
         <main id="main-content">Overview content</main>
       `,
       container,
@@ -103,7 +111,7 @@ describe('DashboardSurfaceTabs', () => {
   })
 
   it('keeps the tablist keyboard-reachable when current surface is hidden', () => {
-    // Regression for #15120: VISIBLE_DASHBOARD_NAV_ITEMS hides the cockpit
+    // Regression for #15120: primary dashboard navigation hides the cockpit
     // surface, so when currentTab="cockpit" no item matches and the
     // previous active-only tabIndex branch left every tab at tabIndex=-1.
     // The roving-tabindex contract requires exactly one tabIndex=0; fall
@@ -111,7 +119,7 @@ describe('DashboardSurfaceTabs', () => {
     // the tablist. aria-selected stays "false" — we must not lie about
     // selection when nothing in [items] is actually current.
     render(
-      html`<${DashboardSurfaceTabs} items=${VISIBLE_DASHBOARD_NAV_ITEMS} currentTab="cockpit" />`,
+      html`<${DashboardSurfaceTabs} items=${PRIMARY_DASHBOARD_NAV_ITEMS} currentTab="cockpit" />`,
       container,
     )
 

--- a/dashboard/src/components/dashboard-surface-tabs.ts
+++ b/dashboard/src/components/dashboard-surface-tabs.ts
@@ -36,7 +36,7 @@ export function DashboardSurfaceTabs({ items, currentTab }: DashboardSurfaceTabs
   const hasMatchingTab = items.some(item => item.id === currentTab)
 
   return html`
-    <nav class="v2-shell-tabs min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] max-[520px]:w-full max-[768px]:hidden" aria-label="Dashboard surfaces">
+    <nav class="v2-shell-tabs min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] max-[520px]:w-full" aria-label="Dashboard surfaces">
       <div
         role="tablist"
         aria-label="Dashboard surfaces"

--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -564,7 +564,8 @@ describe('IdeContextLens', () => {
     ])
     expect(model.surfaces.find(surface => surface.id === 'comment')?.routeLink).toMatchObject({
       label: 'Comment',
-      params: { section: 'board', post: 'post-1', comment: 'comment-1' },
+      tab: 'board',
+      params: { post: 'post-1', comment: 'comment-1' },
     })
     expect(model.surfaces.find(surface => surface.id === 'pr')?.routeLink).toMatchObject({
       label: 'PR',
@@ -701,8 +702,8 @@ describe('IdeContextLens', () => {
       'Keeper',
     ])
     expect(model.anchors[0]?.route_links?.find(link => link.label === 'Comment')).toMatchObject({
-      tab: 'workspace',
-      params: { section: 'board', post: 'post-1', comment: 'comment-1' },
+      tab: 'board',
+      params: { post: 'post-1', comment: 'comment-1' },
     })
     expect(model.anchors[0]?.route_links?.find(link => link.label === 'Code')).toMatchObject({
       tab: 'code',

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -1064,8 +1064,8 @@ export function routeLinksForContext(
     add({
       id: `board:${boardPostId}`,
       label: 'Board',
-      tab: 'workspace',
-      params: { section: 'board', post: boardPostId },
+      tab: 'board',
+      params: { post: boardPostId },
       evidence: `Board post ${boardPostId}`,
     })
   }
@@ -1074,9 +1074,8 @@ export function routeLinksForContext(
     add({
       id: `comment:${commentId}`,
       label: 'Comment',
-      tab: 'workspace',
+      tab: 'board',
       params: {
-        section: 'board',
         ...(boardPostId ? { post: boardPostId } : {}),
         comment: commentId,
       },

--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -477,10 +477,10 @@ describe('IdeConversationRail', () => {
     expect(links.map(link => link.getAttribute('aria-label'))).toContain('Open Comment comment-1')
 
     fireEvent.click(links.find(link => link.textContent === 'Board')!)
-    expect(window.location.hash).toBe('#workspace?section=board&post=thread-line')
+    expect(window.location.hash).toBe('#board?post=thread-line')
 
     fireEvent.click(links.find(link => link.textContent === 'Comment')!)
-    expect(window.location.hash).toBe('#workspace?section=board&post=thread-line&comment=comment-1')
+    expect(window.location.hash).toBe('#board?post=thread-line&comment=comment-1')
 
     fireEvent.click(links.find(link => link.textContent === 'PR')!)
     expect(window.location.hash).toBe('#workspace?section=repositories&pr=15035')

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -5,7 +5,7 @@ import type { Keeper } from '../types'
 import { route } from '../router'
 import { keepers } from '../store'
 import { selectKeeper } from '../keeper-runtime'
-import { loadKeeperConfig } from './keeper-config-panel'
+import { KeeperConfigPanel, loadKeeperConfig } from './keeper-config-panel'
 import { findKeeper } from '../lib/keeper-utils'
 import { resolveKeeperForDetail } from '../lib/keeper-detail-resolution'
 import { keeperDisplayStatus } from '../lib/keeper-runtime-display'
@@ -33,6 +33,7 @@ import { KeeperLifecycleButtons, KeeperClearContextDialog } from './keeper-detai
 import {
   KeeperDetailHeaderInfo,
   KeeperDetailMissingState,
+  activeKeeperDetailSection,
 } from './keeper-detail-shell'
 import { KeeperDetailBody } from './keeper-detail-body'
 import { KeeperWorkspaceRoster } from './keeper-workspace/keeper-workspace-roster'
@@ -56,12 +57,28 @@ const CLOSE_BUTTON_FOCUS_CLASS = ringFocusClasses({
 // Phase 5 (layout retune).
 
 export function KeeperDetailPage() {
-  const keeperName =
-    route.value.tab === 'monitoring' && route.value.params.section === 'agents'
+  const routeSurface = route.value.tab === 'keepers' ? 'keepers' : 'monitoring'
+  const keeperName = route.value.tab === 'keepers'
+    ? route.value.params.keeper?.trim() || selectedKeeper.peek()?.name || keepers.value[0]?.name || ''
+    : route.value.tab === 'monitoring' && route.value.params.section === 'agents'
       ? route.value.params.keeper?.trim()
       : ''
-  if (!keeperName) return null
-  return html`<${KeeperDetailResolver} keeperName=${keeperName} />`
+
+  if (!keeperName) {
+    return html`
+      <div class="kw-grid" data-detail="open">
+        <${KeeperWorkspaceRoster} activeName="" routeSurface=${routeSurface} />
+        <div class="kw-detail">
+          <div class="kw-detail-scroll">
+            <div class="rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-6 text-sm text-[var(--color-fg-muted)]">
+              표시할 keeper가 없습니다.
+            </div>
+          </div>
+        </div>
+      </div>
+    `
+  }
+  return html`<${KeeperDetailResolver} keeperName=${keeperName} routeSurface=${routeSurface} />`
 }
 
 // P0 render-perf: isolate the `keepers` signal subscription here. A heartbeat,
@@ -71,7 +88,13 @@ export function KeeperDetailPage() {
 // memoizing KeeperDetailContent below skips the heavy subtree whenever the
 // resolved keeper object did not change — which is every heartbeat that is
 // not this keeper's phase transition.
-function KeeperDetailResolver({ keeperName }: { keeperName: string }) {
+function KeeperDetailResolver({
+  keeperName,
+  routeSurface,
+}: {
+  keeperName: string
+  routeSurface: 'monitoring' | 'keepers'
+}) {
   const keeper = resolveKeeperForDetail(
     keeperName,
     findKeeper(keeperName),
@@ -85,7 +108,7 @@ function KeeperDetailResolver({ keeperName }: { keeperName: string }) {
     // gives the missing-state card the full conversation span.
     return html`
       <div class="kw-grid" data-detail="open">
-        <${KeeperWorkspaceRoster} activeName=${keeperName} />
+        <${KeeperWorkspaceRoster} activeName=${keeperName} routeSurface=${routeSurface} />
         <div class="kw-detail">
           <div class="kw-detail-scroll">
             <${KeeperDetailMissingState} keeperName=${keeperName} onClose=${closeKeeperDetail} />
@@ -94,10 +117,35 @@ function KeeperDetailResolver({ keeperName }: { keeperName: string }) {
       </div>
     `
   }
-  return html`<${KeeperDetailContent} keeper=${keeper} />`
+  return html`<${KeeperDetailContent} keeper=${keeper} routeSurface=${routeSurface} />`
 }
 
-const KeeperDetailContent = memo(function KeeperDetailContent({ keeper }: { keeper: Keeper }) {
+function useIsKeeperWorkspaceMobile(): boolean {
+  const getInitial = () =>
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(max-width: 860px)').matches
+  const [isMobile, setIsMobile] = useState(getInitial)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const media = window.matchMedia('(max-width: 860px)')
+    const update = () => setIsMobile(media.matches)
+    update()
+    media.addEventListener('change', update)
+    return () => media.removeEventListener('change', update)
+  }, [])
+
+  return isMobile
+}
+
+const KeeperDetailContent = memo(function KeeperDetailContent({
+  keeper,
+  routeSurface,
+}: {
+  keeper: Keeper
+  routeSurface: 'monitoring' | 'keepers'
+}) {
   const titleId = `keeper-detail-title-${keeper.name}`
   const effectiveStatus = keeperDisplayStatus(keeper)
   const shouldOpenDiagnostics = keeperNeedsDiagnosticAttention(keeper)
@@ -111,10 +159,21 @@ const KeeperDetailContent = memo(function KeeperDetailContent({ keeper }: { keep
   // 3-pane workspace is the default conversation view; "상세 보기" flips to
   // the full tabbed KeeperDetailBody (FSM / 진단 / 정체성 / 설정 / 디버그).
   const [detailOpen, setDetailOpen] = useState(false)
+  const [configOverlayKeeper, setConfigOverlayKeeper] = useState<string | null>(null)
+  const [rosterOpen, setRosterOpen] = useState(true)
+  const [railOpen, setRailOpen] = useState(true)
+  const isMobile = useIsKeeperWorkspaceMobile()
+  const routeKeeperParam = route.value.tab === 'keepers'
+    ? route.value.params.keeper?.trim()
+    : route.value.tab === 'monitoring' && route.value.params.section === 'agents'
+      ? route.value.params.keeper?.trim()
+      : ''
+  const [mobileRailOpen, setMobileRailOpen] = useState(false)
   // Latest transition's wall_clock_at_decision, in unix seconds.  Used by
   // the header KeeperPhaseAndStage to render "현재 phase에 머문 시간" without
   // requiring a new backend field — derivation is plan-approved trade-off.
   const [phaseEnteredAtSec, setPhaseEnteredAtSec] = useState<number | null>(null)
+  const pendingConfigKeeperRef = useRef<string | null>(null)
   // RFC-0046 §7 #1: single composite snapshot shared with the two
   // derived panels (state-diagram + memory-tier).
   const compositeEvidence = useKeeperCompositeEvidence(keeper.name)
@@ -128,11 +187,22 @@ const KeeperDetailContent = memo(function KeeperDetailContent({ keeper }: { keep
   const runtimeTrace = evidenceFreshData(runtimeTraceEvidence)
   const prevKeeperRef = useRef(keeper.name)
   if (prevKeeperRef.current !== keeper.name) {
+    const shouldOpenPendingConfig = pendingConfigKeeperRef.current === keeper.name
     prevKeeperRef.current = keeper.name
+    if (shouldOpenPendingConfig) {
+      pendingConfigKeeperRef.current = null
+    }
     setDiagOpen(shouldOpenDiagnostics)
     setPhaseEnteredAtSec(null)
     setDetailOpen(false)
+    setConfigOverlayKeeper(shouldOpenPendingConfig ? keeper.name : null)
   }
+  useEffect(() => {
+    setMobileRailOpen(false)
+    if (routeKeeperParam) {
+      keeperMobilePane.value = 'chat'
+    }
+  }, [keeper.name, routeKeeperParam])
   useEffect(() => {
     selectedKeeper.value = keeper
     selectKeeper(keeper.name)
@@ -294,10 +364,34 @@ const KeeperDetailContent = memo(function KeeperDetailContent({ keeper }: { keep
       />
     </div>
   `
+  const openKeeperConfig = (name = keeper.name) => {
+    activeKeeperDetailSection.value = 'keeper-config'
+    setMobileRailOpen(false)
+    if (name !== keeper.name) {
+      pendingConfigKeeperRef.current = name
+    }
+    setDetailOpen(false)
+    setConfigOverlayKeeper(name)
+  }
 
   return html`
-    <div class="kw-grid v2-monitoring-surface" data-detail=${detailOpen ? 'open' : 'closed'} data-mobile-pane=${keeperMobilePane.value} data-route-focused-keeper=${keeper.name}>
-      <${KeeperWorkspaceRoster} activeName=${keeper.name} />
+    <div
+      class="kw-grid v2-monitoring-surface"
+      data-detail=${detailOpen ? 'open' : 'closed'}
+      data-roster=${rosterOpen ? 'open' : 'mini'}
+      data-rail=${railOpen ? 'open' : 'closed'}
+      data-mobile-pane=${keeperMobilePane.value}
+      data-route-focused-keeper=${keeper.name}
+    >
+      <${KeeperWorkspaceRoster}
+        activeName=${keeper.name}
+        routeSurface=${routeSurface}
+        mini=${!rosterOpen && !detailOpen}
+        onOpenConfig=${openKeeperConfig}
+        onSelect=${() => {
+          keeperMobilePane.value = 'chat'
+        }}
+      />
       ${detailOpen
         ? html`
             <div class="kw-detail v2-monitoring-panel">
@@ -315,13 +409,64 @@ const KeeperDetailContent = memo(function KeeperDetailContent({ keeper }: { keep
             </div>
           `
         : html`
+            <button
+              type="button"
+              class="kw-rail-toggle left v2-monitoring-action"
+              aria-label=${rosterOpen ? '로스터 접기' : '로스터 펼치기'}
+              aria-pressed=${rosterOpen ? 'true' : 'false'}
+              title=${rosterOpen ? '로스터 접기' : '로스터 펼치기'}
+              onClick=${() => setRosterOpen(open => !open)}
+            >${rosterOpen ? '◂' : '▸'}</button>
             <${KeeperWorkspaceChat}
               keeper=${keeper}
               detailOpen=${false}
               onToggleDetail=${() => setDetailOpen(true)}
               onClear=${() => setClearDialogOpen(true)}
+              mobile=${isMobile}
+              onBack=${() => {
+                keeperMobilePane.value = 'roster'
+              }}
+              onOpenRail=${() => setMobileRailOpen(true)}
+              onOpenConfig=${() => {
+                openKeeperConfig()
+              }}
             />
-            <${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => setDetailOpen(true)} />
+            <button
+              type="button"
+              class="kw-rail-toggle right v2-monitoring-action"
+              aria-label=${railOpen ? '컨텍스트 레일 접기' : '컨텍스트 레일 펼치기'}
+              aria-pressed=${railOpen ? 'true' : 'false'}
+              title=${railOpen ? '컨텍스트 레일 접기' : '컨텍스트 레일 펼치기'}
+              onClick=${() => setRailOpen(open => !open)}
+            >${railOpen ? '▸' : '◂'}</button>
+            ${!isMobile && railOpen ? html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => setDetailOpen(true)} />` : null}
+            ${isMobile && mobileRailOpen
+              ? html`
+                  <div
+                    class="kw-mobile-rail-overlay"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="키퍼 컨텍스트"
+                    data-testid="kw-mobile-rail-overlay"
+                    onClick=${() => setMobileRailOpen(false)}
+                  >
+                    <div class="kw-mobile-rail-drawer v2-monitoring-surface" onClick=${(e: Event) => e.stopPropagation()}>
+                      <div class="kw-mobile-rail-head v2-monitoring-toolbar">
+                        <strong>${keeper.name} 컨텍스트</strong>
+                        <button
+                          type="button"
+                          class="kw-act v2-monitoring-action"
+                          onClick=${() => setMobileRailOpen(false)}
+                        >닫기</button>
+                      </div>
+                      <${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {
+                        setMobileRailOpen(false)
+                        setDetailOpen(true)
+                      }} />
+                    </div>
+                  </div>
+                `
+              : null}
           `}
     </div>
     ${!detailOpen
@@ -340,5 +485,59 @@ const KeeperDetailContent = memo(function KeeperDetailContent({ keeper }: { keep
           onSubmit=${submitClearContext}
         />`
       : null}
+    ${configOverlayKeeper
+      ? html`<${KeeperConfigOverlay}
+          keeperName=${configOverlayKeeper}
+          onClose=${() => setConfigOverlayKeeper(null)}
+        />`
+      : null}
   `
 })
+
+function KeeperConfigOverlay({
+  keeperName,
+  onClose,
+}: {
+  keeperName: string
+  onClose: () => void
+}) {
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return html`
+    <div
+      class="kw-config-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label=${`${keeperName} keeper 설정`}
+      data-testid="kw-config-overlay"
+      onClick=${onClose}
+    >
+      <div class="kw-config-drawer v2-monitoring-surface" onClick=${(event: Event) => event.stopPropagation()}>
+        <div class="kw-config-head v2-monitoring-toolbar">
+          <div class="min-w-0">
+            <h3>keeper 설정</h3>
+            <p>${keeperName}</p>
+          </div>
+          <button
+            type="button"
+            class=${`kw-act ${CLOSE_BUTTON_FOCUS_CLASS} v2-monitoring-action`}
+            onClick=${onClose}
+            data-testid="kw-config-close"
+          >닫기</button>
+        </div>
+        <div class="kw-config-scroll v2-monitoring-panel">
+          <${KeeperConfigPanel} keeperName=${keeperName} />
+        </div>
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/keeper-detail-state.ts
+++ b/dashboard/src/components/keeper-detail-state.ts
@@ -1,6 +1,6 @@
 import { signal } from '@preact/signals'
 import { navigate, route } from '../router'
-import type { Keeper } from '../types'
+import type { Keeper, TabId } from '../types'
 import { hydrateKeeperStatus, selectKeeper } from '../keeper-runtime'
 import { activeKeeperName } from '../keeper-state'
 import { registerKeeperTurnRefresh } from '../sse-store'
@@ -39,14 +39,21 @@ function selectedKeeperMatches(keeperName: string): boolean {
   return selected.name === trimmed || selected.agent_name === trimmed
 }
 
-function baseAgentDirectoryRouteParams(): Record<string, string> {
+function baseAgentDirectoryRoute(): { tab: TabId; params: Record<string, string> } {
+  if (route.value.tab === 'keepers') {
+    const next: Record<string, string> = { ...route.value.params }
+    delete next.agent
+    delete next.keeper
+    delete next.section
+    return { tab: 'keepers', params: next }
+  }
   if (route.value.tab === 'monitoring' && route.value.params.section === 'agents') {
     const next: Record<string, string> = { ...route.value.params, section: 'agents' }
     delete next.agent
     delete next.keeper
-    return next
+    return { tab: 'monitoring', params: next }
   }
-  return { section: 'agents' }
+  return { tab: 'monitoring', params: { section: 'agents' } }
 }
 
 export function openKeeperDetail(k: Keeper) {
@@ -54,7 +61,8 @@ export function openKeeperDetail(k: Keeper) {
   keeperMobilePane.value = 'chat'
   selectKeeper(k.name)
   void loadKeeperConfig(k.name)
-  navigate('monitoring', { ...baseAgentDirectoryRouteParams(), keeper: k.name })
+  const base = baseAgentDirectoryRoute()
+  navigate(base.tab, { ...base.params, keeper: k.name })
 }
 
 export function clearKeeperDetailSelection(keeperName?: string) {
@@ -66,5 +74,6 @@ export function clearKeeperDetailSelection(keeperName?: string) {
 
 export function closeKeeperDetail() {
   clearKeeperDetailSelection()
-  navigate('monitoring', baseAgentDirectoryRouteParams())
+  const base = baseAgentDirectoryRoute()
+  navigate(base.tab, base.params)
 }

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -40,7 +40,8 @@ vi.mock('./keeper-config-panel', async () => {
   const actual = await vi.importActual<typeof import('./keeper-config-panel')>('./keeper-config-panel')
   return {
     ...actual,
-    KeeperConfigPanel: () => null,
+    KeeperConfigPanel: ({ keeperName }: { keeperName: string }) =>
+      html`<div data-testid="keeper-config-panel" data-keeper=${keeperName}>Config ${keeperName}</div>`,
     loadKeeperConfig: mocks.loadKeeperConfig,
     resetKeeperConfig: mocks.resetKeeperConfig,
   }
@@ -357,6 +358,50 @@ describe('KeeperDetailPage', () => {
     fireEvent.click(statusTab)
     expect(statusTab.getAttribute('aria-selected')).toBe('true')
     expect(screen.getByText('운영 상태 개요')).toBeTruthy()
+  })
+
+  it('opens target keeper config as an overlay from the roster row menu after a keeper route change', () => {
+    keepers.value = [
+      {
+        name: 'analyst',
+        status: 'active',
+        phase: 'Running',
+        lifecycle_phase: 'Running',
+      },
+      {
+        name: 'executor',
+        status: 'active',
+        phase: 'Running',
+        lifecycle_phase: 'Running',
+      },
+    ] as unknown as Keeper[]
+    mocks.route.value = {
+      tab: 'keepers',
+      params: { keeper: 'analyst' },
+      postId: null,
+    }
+    mocks.navigate.mockImplementationOnce((tab, params = {}) => {
+      mocks.route.value = { tab, params, postId: null }
+    })
+
+    const { container, rerender } = render(html`<${KeeperDetailPage} />`)
+
+    expect(container.querySelector('.kw-grid')?.getAttribute('data-detail')).toBe('closed')
+    fireEvent.click(screen.getByTestId('kw-roster-menu-executor'))
+    fireEvent.click(screen.getByTestId('kw-roster-menu-config'))
+    rerender(html`<${KeeperDetailPage} />`)
+
+    const grid = container.querySelector('.kw-grid')
+    expect(mocks.navigate).toHaveBeenCalledWith('keepers', { keeper: 'executor' })
+    expect(grid?.getAttribute('data-route-focused-keeper')).toBe('executor')
+    expect(grid?.getAttribute('data-detail')).toBe('closed')
+    expect(activeKeeperDetailSection.value).toBe('keeper-config')
+    expect(screen.getByTestId('kw-config-overlay')).toBeTruthy()
+    expect(screen.getByTestId('keeper-config-panel').getAttribute('data-keeper')).toBe('executor')
+
+    fireEvent.click(screen.getByTestId('kw-config-close'))
+
+    expect(container.querySelector('[data-testid="kw-config-overlay"]')).toBeNull()
   })
 
   // Removed test 'surfaces and clears keeper route focus...' (2026-05-19):

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -302,6 +302,47 @@ describe('KeeperConversationPanel', () => {
     expect(container.querySelector('input[name="keeper_chat_search"]')).not.toBeNull()
   })
 
+  it('forwards the message-level turn inspector action to the transcript', async () => {
+    const onInspectTurn = vi.fn()
+    keeperThreads.value = {
+      sangsu: [
+        {
+          id: 'direct-assistant',
+          role: 'assistant',
+          source: 'direct_assistant',
+          label: 'sangsu',
+          text: '이번 턴을 검사합니다.',
+          rawText: '이번 턴을 검사합니다.',
+          timestamp: '2026-03-24T00:02:00.000Z',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+      ],
+    }
+
+    render(
+      html`<${KeeperConversationPanel}
+        keeperName="sangsu"
+        placeholder="메시지 입력..."
+        layout="workspace"
+        onInspectTurn=${onInspectTurn}
+      />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const action = container.querySelector('[data-testid="chat-message-action"]') as HTMLButtonElement
+    expect(action).not.toBeNull()
+    expect(action.textContent).toBe('턴 상세')
+
+    action.click()
+
+    expect(onInspectTurn).toHaveBeenCalledTimes(1)
+    expect(onInspectTurn.mock.calls[0]?.[0].id).toBe('direct-assistant')
+  })
+
   it('renders probe and recover buttons in RuntimeActions', async () => {
     const keeper = { name: 'sangsu', status: 'running' } as any
 

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -417,10 +417,12 @@ export function KeeperConversationPanel({
   keeperName,
   placeholder,
   layout = 'default',
+  onInspectTurn,
 }: {
   keeperName: string
   placeholder: string
   layout?: 'default' | 'primary' | 'workspace'
+  onInspectTurn?: (entry: KeeperConversationEntry) => void
 }) {
   const [draft, setDraft] = useState('')
   const [showMetadata, setShowMetadata] = useState(readKeeperChatMetadataVisible())
@@ -630,6 +632,7 @@ export function KeeperConversationPanel({
               size="primary"
               showDayDividers=${true}
               showSourceBadge=${true}
+              action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
             />
           </div>
         </div>
@@ -756,6 +759,7 @@ export function KeeperConversationPanel({
           showMetadata=${showMetadata}
           variant="messenger"
           size="primary"
+          action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
         />
 
         ${!showInternal && hiddenCount > 0
@@ -866,6 +870,7 @@ export function KeeperConversationPanel({
             showMetadata=${showMetadata}
             variant="messenger"
             size="default"
+            action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
           />
         </div>
 

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -3,7 +3,11 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact'
 import { html } from 'htm/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchKeeperTurnRecords, type TurnRecordsResponse } from '../api/dashboard'
-import { KeeperMemoryOsRecallPanel, KeeperTurnInspector } from './keeper-turn-inspector'
+import {
+  initialTurnRowForTimestamp,
+  KeeperMemoryOsRecallPanel,
+  KeeperTurnInspector,
+} from './keeper-turn-inspector'
 
 vi.mock('../api/dashboard', () => {
   return {
@@ -195,6 +199,93 @@ describe('KeeperTurnInspector v2 drawer', () => {
     expect(drawerText).toContain('턴 상세')
     expect(drawerText).toContain('trace-active_0042')
     expect(drawerText).toContain('local')
+  })
+
+  it('matches an initial timestamp to the closest retained turn row', () => {
+    const response = turnRecordsWithMemoryOs()
+    const nearTurn42 = new Date((1_781_587_560 + 12) * 1000).toISOString()
+    const farFromRetainedTurns = new Date((1_781_587_560 + 3600) * 1000).toISOString()
+
+    expect(initialTurnRowForTimestamp(response.entries, nearTurn42)?.record.absolute_turn).toBe(42)
+    expect(initialTurnRowForTimestamp(response.entries, farFromRetainedTurns)).toBeNull()
+    expect(initialTurnRowForTimestamp(response.entries, 'not-a-date')).toBeNull()
+  })
+
+  it('opens the detail drawer when an initial timestamp matches a retained turn', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+    const nearTurn42 = new Date((1_781_587_560 + 12) * 1000).toISOString()
+
+    const { container } = render(html`
+      <${KeeperTurnInspector}
+        keeperName="albini"
+        initialTurnTimestamp=${nearTurn42}
+      />
+    `)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-detail-drawer"]')).toBeTruthy()
+    })
+
+    const drawerText = container.querySelector('[data-testid="turn-detail-drawer"]')?.textContent ?? ''
+    expect(drawerText).toContain('trace-active_0042')
+    expect(container.querySelector('[data-testid="turn-linked-empty"]')).toBeFalsy()
+  })
+
+  it('keeps the list view when an initial timestamp is outside the retained turn window', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+    const farFromRetainedTurns = new Date((1_781_587_560 + 3600) * 1000).toISOString()
+
+    const { container } = render(html`
+      <${KeeperTurnInspector}
+        keeperName="albini"
+        initialTurnTimestamp=${farFromRetainedTurns}
+      />
+    `)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-linked-empty"]')).toBeTruthy()
+    })
+    expect(container.querySelector('[data-testid="turn-detail-drawer"]')).toBeFalsy()
+    expect(container.textContent).toContain('30분 이내의 turn record 없음')
+  })
+
+  it('renders repeated trace turn rows without duplicate-key warnings', async () => {
+    const response = turnRecordsWithMemoryOs()
+    response.entries = [
+      ...response.entries,
+      {
+        record: {
+          ...response.entries[1]!.record,
+          ts: 1_781_587_620,
+          output_tokens: 312,
+          execution_ids: ['exec-42b'],
+        },
+        diff_vs_prev: null,
+      },
+    ]
+    response.count = response.entries.length
+    fetchKeeperTurnRecordsMock.mockResolvedValue(response)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    try {
+      const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('.kti-turn-summary').length).toBe(3)
+      })
+
+      const duplicateKeyCalls = errorSpy.mock.calls
+        .flat()
+        .map(value => String(value))
+        .filter(value => value.includes('same key') || value.includes('same key attribute'))
+      expect(duplicateKeyCalls).toEqual([])
+    } finally {
+      errorSpy.mockRestore()
+    }
   })
 
   it('switches tabs inside the drawer', async () => {

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -9,7 +9,7 @@
 // copyable context blocks styled after keeper-v2 turn-inspector.
 
 import { html } from 'htm/preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { fetchKeeperTurnRecords } from '../api/dashboard'
 import type {
   MemoryOsEpisodeSummary,
@@ -25,6 +25,29 @@ import { formatTimeHms } from '../lib/format-time'
 import { LoadingState } from './common/feedback-state'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { coverageGapDisplay, sourceHealthClass, freshnessText } from './common/source-health'
+
+const INITIAL_TURN_MATCH_WINDOW_SEC = 30 * 60
+const EMPTY_TURN_RECORD_ROWS: TurnRecordRow[] = []
+
+export function initialTurnRowForTimestamp(
+  rows: TurnRecordRow[],
+  timestampIso?: string | null,
+): TurnRecordRow | null {
+  if (!timestampIso || rows.length === 0) return null
+  const targetMs = Date.parse(timestampIso)
+  if (!Number.isFinite(targetMs)) return null
+  const targetSec = targetMs / 1000
+  let best: { row: TurnRecordRow; delta: number } | null = null
+
+  for (const row of rows) {
+    const delta = Math.abs(row.record.ts - targetSec)
+    if (!best || delta < best.delta) {
+      best = { row, delta }
+    }
+  }
+
+  return best && best.delta <= INITIAL_TURN_MATCH_WINDOW_SEC ? best.row : null
+}
 
 function FreshnessLine({ data }: { data: TelemetryFreshnessMetadata }) {
   const gap = coverageGapDisplay(data)
@@ -743,9 +766,17 @@ function TurnRow({
   `
 }
 
-export function KeeperTurnInspector({ keeperName }: { keeperName: string }) {
+export function KeeperTurnInspector({
+  keeperName,
+  initialTurnTimestamp,
+}: {
+  keeperName: string
+  initialTurnTimestamp?: string | null
+}) {
   const resource = useManagedAsyncResource<TurnRecordsResponse | null>(null)
   const [selectedRow, setSelectedRow] = useState<TurnRecordRow | null>(null)
+  const [initialMatchState, setInitialMatchState] = useState<'idle' | 'matched' | 'missed'>('idle')
+  const appliedInitialTurnTimestamp = useRef<string | null>(null)
 
   useEffect(() => {
     void resource.load(async (signal) => {
@@ -757,6 +788,33 @@ export function KeeperTurnInspector({ keeperName }: { keeperName: string }) {
   }, [keeperName, resource])
 
   const response = resource.state.value.data
+  const rows = response?.entries ?? EMPTY_TURN_RECORD_ROWS
+  // Server returns oldest-first; show newest first.
+  const sorted = useMemo(() => [...rows].reverse(), [rows])
+  const initialMatchedRow = useMemo(
+    () => initialTurnRowForTimestamp(rows, initialTurnTimestamp),
+    [rows, initialTurnTimestamp],
+  )
+
+  useEffect(() => {
+    appliedInitialTurnTimestamp.current = null
+    setInitialMatchState('idle')
+    setSelectedRow(null)
+  }, [keeperName, initialTurnTimestamp])
+
+  useEffect(() => {
+    if (
+      !initialTurnTimestamp
+      || rows.length === 0
+      || appliedInitialTurnTimestamp.current === initialTurnTimestamp
+    ) {
+      return
+    }
+
+    setSelectedRow(initialMatchedRow)
+    setInitialMatchState(initialMatchedRow ? 'matched' : 'missed')
+    appliedInitialTurnTimestamp.current = initialTurnTimestamp
+  }, [initialTurnTimestamp, initialMatchedRow, rows.length])
 
   if (resource.state.value.loading) {
     return html`<${LoadingState}>턴 레코드 불러오는 중...<//>`
@@ -766,7 +824,6 @@ export function KeeperTurnInspector({ keeperName }: { keeperName: string }) {
     return html`<div class="text-xs text-[var(--color-status-err)] p-4 v2-monitoring-panel" role="alert">${resource.state.value.error}</div>`
   }
 
-  const rows = response?.entries ?? []
   const memoryOsPanel = response?.memory_os
     ? html`<${MemoryOsRecallSourcePanel} snapshot=${response.memory_os} rows=${rows} />`
     : null
@@ -781,9 +838,6 @@ export function KeeperTurnInspector({ keeperName }: { keeperName: string }) {
     `
   }
 
-  // Server returns oldest-first; show newest first.
-  const sorted = [...rows].reverse()
-
   return html`
     <div class="p-2 space-y-1 v2-monitoring-surface">
       <div class="flex items-center justify-between px-1 v2-monitoring-toolbar">
@@ -795,8 +849,18 @@ export function KeeperTurnInspector({ keeperName }: { keeperName: string }) {
           : null}
       </div>
       ${memoryOsPanel}
-      ${sorted.map(row => html`<${TurnRow}
-        key=${`${row.record.trace_id}-${row.record.absolute_turn}`}
+      ${initialMatchState === 'missed'
+        ? html`
+          <div
+            class="rounded-[var(--r-1)] border border-[var(--color-status-warn)]/40 bg-[var(--color-bg-surface)] px-2 py-1.5 text-2xs text-[var(--color-fg-muted)] v2-monitoring-row"
+            data-testid="turn-linked-empty"
+          >
+            메시지 시각과 30분 이내의 turn record 없음. 리스트에서 직접 선택하세요.
+          </div>
+        `
+        : null}
+      ${sorted.map((row, index) => html`<${TurnRow}
+        key=${`${row.record.trace_id}-${row.record.absolute_turn}-${row.record.ts}-${index}`}
         row=${row}
         onOpen=${setSelectedRow}
       />`)}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -26,14 +26,59 @@ async function loadChat() {
     KeeperLifecycleButtons: () => html`<span data-testid="kw-lifecycle-buttons">Lifecycle</span>`,
   }))
   vi.doMock('../keeper-shared', () => ({
-    KeeperConversationPanel: () => html`<div data-testid="kw-conversation-panel">Conversation</div>`,
+    KeeperConversationPanel: ({ onInspectTurn }: { onInspectTurn?: (entry: unknown) => void }) => html`
+      <div data-testid="kw-conversation-panel">
+        Conversation
+        ${onInspectTurn
+          ? html`
+              <button
+                type="button"
+                data-testid="kw-message-turn-action"
+                onClick=${() => onInspectTurn({
+                  id: 'msg-turn-1',
+                  role: 'assistant',
+                  source: 'direct_assistant',
+                  label: 'sangsu',
+                  text: 'done',
+                  timestamp: '2026-03-24T00:02:00.000Z',
+                  delivery: 'history',
+                })}
+              >턴 상세</button>
+            `
+          : null}
+      </div>
+    `,
   }))
   vi.doMock('../keeper-turn-inspector', () => ({
-    KeeperTurnInspector: ({ keeperName }: { keeperName: string }) =>
-      html`<div data-testid="kw-turn-inspector" data-keeper=${keeperName}>TurnInspector</div>`,
+    KeeperTurnInspector: ({
+      keeperName,
+      initialTurnTimestamp,
+    }: {
+      keeperName: string
+      initialTurnTimestamp?: string | null
+    }) =>
+      html`
+        <div
+          data-testid="kw-turn-inspector"
+          data-keeper=${keeperName}
+          data-initial-turn-timestamp=${initialTurnTimestamp ?? ''}
+        >TurnInspector</div>
+      `,
   }))
   vi.doMock('../../lib/keeper-runtime-display', () => ({
     keeperDisplayStatus: () => 'running',
+  }))
+  vi.doMock('../../lib/keeper-predicates', () => ({
+    keeperActionVisibility: () => ({
+      canBoot: false,
+      canPause: true,
+      canResume: false,
+      canShutdown: true,
+      canWake: false,
+    }),
+  }))
+  vi.doMock('../keeper-action-panel', () => ({
+    runKeeperAction: vi.fn(async () => undefined),
   }))
   vi.doMock('../chat/artifact-panel', () => ({
     ChatArtifactPanel: ({ entries }: { entries: unknown[] }) =>
@@ -64,6 +109,8 @@ describe('KeeperWorkspaceChat', () => {
     vi.doUnmock('../keeper-shared')
     vi.doUnmock('../keeper-turn-inspector')
     vi.doUnmock('../../lib/keeper-runtime-display')
+    vi.doUnmock('../../lib/keeper-predicates')
+    vi.doUnmock('../keeper-action-panel')
     vi.doUnmock('../chat/artifact-panel')
     vi.doUnmock('../keeper-detail-state')
   })
@@ -84,7 +131,8 @@ describe('KeeperWorkspaceChat', () => {
 
     expect(container.querySelector('[data-testid="kw-sigil"]')?.textContent).toBe('sangsu')
     expect(container.querySelector('[data-testid="kw-conversation-panel"]')).not.toBeNull()
-    expect(container.querySelector('[data-testid="kw-chat-turn-inspector-btn"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="kw-chat-command-turn"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="kw-chat-command-icons"]')).not.toBeNull()
   })
 
   it('opens the turn inspector drawer when the turn inspector button is clicked', async () => {
@@ -103,7 +151,7 @@ describe('KeeperWorkspaceChat', () => {
 
     expect(container.querySelector('[data-testid="kw-chat-turn-inspector-drawer"]')).toBeNull()
 
-    const btn = container.querySelector('[data-testid="kw-chat-turn-inspector-btn"]') as HTMLButtonElement
+    const btn = container.querySelector('[data-testid="kw-chat-command-turn"]') as HTMLButtonElement
     await act(async () => {
       btn.click()
     })
@@ -146,6 +194,35 @@ describe('KeeperWorkspaceChat', () => {
     expect(keeperMobilePane.value).toBe('roster')
   })
 
+  it('opens the turn inspector drawer from a message-level turn action', async () => {
+    const { KeeperWorkspaceChat } = await loadChat()
+
+    await act(async () => {
+      render(html`
+        <${KeeperWorkspaceChat}
+          keeper=${mockKeeper}
+          detailOpen=${false}
+          onToggleDetail=${vi.fn()}
+          onClear=${vi.fn()}
+        />
+      `, container)
+    })
+
+    const action = container.querySelector('[data-testid="kw-message-turn-action"]') as HTMLButtonElement
+    expect(action).not.toBeNull()
+
+    await act(async () => {
+      action.click()
+    })
+
+    const drawer = container.querySelector('[data-testid="kw-chat-turn-inspector-drawer"]')
+    expect(drawer).not.toBeNull()
+    expect(drawer?.textContent).toContain('메시지 sangsu')
+    expect(drawer?.textContent).toContain('2026-03-24T00:02:00.000Z')
+    expect(container.querySelector('[data-testid="kw-turn-inspector"]')?.getAttribute('data-keeper')).toBe('sangsu')
+    expect(container.querySelector('[data-testid="kw-turn-inspector"]')?.getAttribute('data-initial-turn-timestamp')).toBe('2026-03-24T00:02:00.000Z')
+  })
+
   it('toggles the artifact panel when the artifacts button is clicked', async () => {
     const { KeeperWorkspaceChat } = await loadChat()
 
@@ -162,8 +239,8 @@ describe('KeeperWorkspaceChat', () => {
 
     expect(container.querySelector('[data-testid="kw-artifact-panel"]')).toBeNull()
 
-    const btn = container.querySelector('[data-testid="kw-chat-artifacts-toggle"]') as HTMLButtonElement
-    expect(btn?.textContent?.trim()).toBe('아티팩트')
+    const btn = container.querySelector('[data-testid="kw-chat-command-artifacts"]') as HTMLButtonElement
+    expect(btn?.getAttribute('aria-label')).toBe('아티팩트')
 
     await act(async () => {
       btn.click()
@@ -171,12 +248,61 @@ describe('KeeperWorkspaceChat', () => {
 
     const panel = container.querySelector('[data-testid="kw-artifact-panel"]')
     expect(panel).not.toBeNull()
-    expect(btn?.textContent?.trim()).toBe('아티팩트 숨김')
+    expect(btn?.getAttribute('aria-label')).toBe('아티팩트 숨김')
+    expect(btn?.getAttribute('aria-pressed')).toBe('true')
 
     await act(async () => {
       btn.click()
     })
 
     expect(container.querySelector('[data-testid="kw-artifact-panel"]')).toBeNull()
+  })
+
+  it('renders mobile roster and context controls when mobile mode is enabled', async () => {
+    const { KeeperWorkspaceChat } = await loadChat()
+    const onBack = vi.fn()
+    const onOpenRail = vi.fn()
+    const onOpenConfig = vi.fn()
+
+    await act(async () => {
+      render(html`
+        <${KeeperWorkspaceChat}
+          keeper=${mockKeeper}
+          detailOpen=${false}
+          onToggleDetail=${vi.fn()}
+          onClear=${vi.fn()}
+          mobile=${true}
+          onBack=${onBack}
+          onOpenRail=${onOpenRail}
+          onOpenConfig=${onOpenConfig}
+        />
+      `, container)
+    })
+
+    const back = container.querySelector('[data-testid="kw-chat-back-to-roster"]') as HTMLButtonElement | null
+    const context = container.querySelector('[data-testid="kw-chat-mobile-context"]') as HTMLButtonElement | null
+    const menuToggle = container.querySelector('[data-testid="kw-chat-command-menu-toggle"]') as HTMLButtonElement | null
+
+    expect(back).not.toBeNull()
+    expect(back?.getAttribute('aria-label')).toBe('키퍼 로스터로 돌아가기')
+    expect(context).not.toBeNull()
+    expect(menuToggle).not.toBeNull()
+    expect(container.querySelector('[data-testid="kw-chat-command-config"]')).toBeNull()
+
+    await act(async () => {
+      back?.click()
+      context?.click()
+      menuToggle?.click()
+    })
+
+    expect(onBack).toHaveBeenCalledTimes(1)
+    expect(onOpenRail).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-testid="kw-chat-command-config"]')).not.toBeNull()
+
+    await act(async () => {
+      ;(container.querySelector('[data-testid="kw-chat-command-config"]') as HTMLButtonElement).click()
+    })
+
+    expect(onOpenConfig).toHaveBeenCalledTimes(1)
   })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -4,16 +4,30 @@
 // header; the panel reuses the full chat engine unchanged.
 
 import { html } from 'htm/preact'
-import { useState } from 'preact/hooks'
+import {
+  Archive,
+  ChevronLeft,
+  Info,
+  MoreHorizontal,
+  Pause,
+  Play,
+  RotateCcw,
+  Search,
+  Settings,
+  Square,
+  Trash2,
+} from 'lucide-preact'
+import { useEffect, useState } from 'preact/hooks'
 import type { VNode } from 'preact'
-import type { Keeper } from '../../types'
+import type { Keeper, KeeperConversationEntry } from '../../types'
 import { KeeperConversationPanel } from '../keeper-shared'
-import { KeeperLifecycleButtons } from '../keeper-detail-lifecycle'
 import { keeperMobilePane } from '../keeper-detail-state'
 import { KeeperTurnInspector } from '../keeper-turn-inspector'
 import { ChatArtifactPanel } from '../chat/artifact-panel'
 import { keeperThreads } from '../../keeper-state'
 import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
+import { keeperActionVisibility } from '../../lib/keeper-predicates'
+import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
 import {
   WorkspaceSigil,
   StatusDot,
@@ -23,6 +37,228 @@ import {
   statePillTone,
 } from './keeper-workspace-shared'
 
+type WorkspaceUtilityAction = 'turn' | 'clear' | 'artifacts' | 'detail' | 'config'
+type WorkspaceCommandId = KeeperActionKey | WorkspaceUtilityAction
+type IconComponent = typeof Play
+
+interface WorkspaceCommand {
+  id: WorkspaceCommandId
+  label: string
+  title: string
+  icon: IconComponent
+  danger?: boolean
+  active?: boolean
+  onClick: () => void | Promise<void>
+}
+
+const LIFECYCLE_COPY: Record<KeeperActionKey, { label: string; title: string; icon: IconComponent; danger?: boolean }> = {
+  pause: {
+    label: '일시정지',
+    title: '일시정지: 실행 중인 keeper 를 일시 멈춥니다',
+    icon: Pause,
+  },
+  resume: {
+    label: '재개',
+    title: '재개: 일시정지된 keeper 를 다시 실행합니다',
+    icon: Play,
+  },
+  wakeup: {
+    label: '깨우기',
+    title: '깨우기: 다음 turn 을 즉시 시도합니다',
+    icon: RotateCcw,
+  },
+  boot: {
+    label: '기동',
+    title: '기동: offline keeper 를 다시 시작합니다',
+    icon: Play,
+  },
+  shutdown: {
+    label: '종료',
+    title: '종료: keeper 를 완전 종료합니다',
+    icon: Square,
+    danger: true,
+  },
+}
+
+function lifecycleCommands(keeper: Keeper): WorkspaceCommand[] {
+  const visibility = keeperActionVisibility(keeper)
+  const keys: KeeperActionKey[] = []
+  if (visibility.canBoot) keys.push('boot')
+  if (visibility.canResume) keys.push('resume')
+  if (visibility.canWake && !visibility.canBoot) keys.push('wakeup')
+  if (visibility.canPause) keys.push('pause')
+  if (visibility.canShutdown) keys.push('shutdown')
+
+  return keys.map(key => {
+    const copy = LIFECYCLE_COPY[key]
+    return {
+      id: key,
+      label: copy.label,
+      title: copy.title,
+      icon: copy.icon,
+      danger: copy.danger,
+      onClick: () => runKeeperAction(keeper.name, key),
+    }
+  })
+}
+
+function WorkspaceCommandButtons({
+  keeper,
+  mobile,
+  detailOpen,
+  artifactsOpen,
+  onOpenTurnInspector,
+  onClear,
+  onToggleArtifacts,
+  onToggleDetail,
+  onOpenConfig,
+}: {
+  keeper: Keeper
+  mobile: boolean
+  detailOpen: boolean
+  artifactsOpen: boolean
+  onOpenTurnInspector: () => void
+  onClear: () => void
+  onToggleArtifacts: () => void
+  onToggleDetail: () => void
+  onOpenConfig?: () => void
+}): VNode {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [busyAction, setBusyAction] = useState<WorkspaceCommandId | null>(null)
+  useEffect(() => {
+    setMenuOpen(false)
+  }, [keeper.name])
+  useEffect(() => {
+    if (!menuOpen) return
+    const close = () => setMenuOpen(false)
+    window.addEventListener('click', close)
+    return () => window.removeEventListener('click', close)
+  }, [menuOpen])
+
+  const utilities: WorkspaceCommand[] = [
+    {
+      id: 'turn',
+      label: '턴 검사',
+      title: '턴 검사',
+      icon: Search,
+      onClick: onOpenTurnInspector,
+    },
+    {
+      id: 'artifacts',
+      label: artifactsOpen ? '아티팩트 숨김' : '아티팩트',
+      title: '대화 아티팩트',
+      icon: Archive,
+      active: artifactsOpen,
+      onClick: onToggleArtifacts,
+    },
+    {
+      id: 'clear',
+      label: '비우기',
+      title: '컨텍스트 비우기',
+      icon: Trash2,
+      danger: true,
+      onClick: onClear,
+    },
+    {
+      id: 'detail',
+      label: detailOpen ? '대화로' : '상세',
+      title: '상세 (상태 · 진단 · 정체성 · 설정 · 디버그)',
+      icon: Info,
+      active: detailOpen,
+      onClick: onToggleDetail,
+    },
+    {
+      id: 'config',
+      label: 'keeper 설정',
+      title: 'keeper 설정',
+      icon: Settings,
+      onClick: onOpenConfig ?? onToggleDetail,
+    },
+  ]
+  const commands = [...lifecycleCommands(keeper), ...utilities]
+
+  async function run(command: WorkspaceCommand) {
+    if (busyAction) return
+    setBusyAction(command.id)
+    try {
+      await command.onClick()
+      setMenuOpen(false)
+    } finally {
+      setBusyAction(null)
+    }
+  }
+
+  if (mobile) {
+    return html`
+      <div class="kw-chat-mobile-actions">
+        <div class="kw-chat-command-menu">
+          <button
+            type="button"
+            class="kw-chat-command-menu-toggle v2-monitoring-action"
+            aria-label="keeper 명령"
+            aria-haspopup="menu"
+            aria-expanded=${menuOpen ? 'true' : 'false'}
+            title="keeper 명령"
+            onClick=${(event: Event) => {
+              event.stopPropagation()
+              setMenuOpen(open => !open)
+            }}
+            data-testid="kw-chat-command-menu-toggle"
+          >
+            <${MoreHorizontal} size=${17} aria-hidden="true" />
+          </button>
+          ${menuOpen
+            ? html`
+                <div class="kw-chat-command-popover v2-monitoring-surface" role="menu" onClick=${(event: Event) => event.stopPropagation()}>
+                  ${commands.map(command => {
+                    const Icon = command.icon
+                    return html`
+                      <button
+                        key=${command.id}
+                        type="button"
+                        role="menuitem"
+                        class=${`kw-chat-command-item${command.danger ? ' danger' : ''}`}
+                        disabled=${busyAction !== null}
+                        onClick=${() => { void run(command) }}
+                        data-testid=${`kw-chat-command-${command.id}`}
+                      >
+                        <${Icon} size=${14} aria-hidden="true" />
+                        <span>${command.label}</span>
+                      </button>
+                    `
+                  })}
+                </div>
+              `
+            : null}
+        </div>
+      </div>
+    `
+  }
+
+  return html`
+    <div class="kw-chat-command-icons" data-testid="kw-chat-command-icons">
+      ${commands.map(command => {
+        const Icon = command.icon
+        return html`
+          <button
+            key=${command.id}
+            type="button"
+            class=${`kw-chat-command-icon${command.danger ? ' danger' : ''}${command.active ? ' active' : ''} v2-monitoring-action`}
+            aria-label=${command.label}
+            aria-pressed=${command.active ? 'true' : undefined}
+            title=${command.title}
+            disabled=${busyAction !== null}
+            onClick=${() => { void run(command) }}
+            data-testid=${`kw-chat-command-${command.id}`}
+          >
+            <${Icon} size=${14} aria-hidden="true" />
+          </button>
+        `
+      })}
+    </div>
+  `
+}
+
 function ChatHeader({
   keeper,
   detailOpen,
@@ -31,6 +267,10 @@ function ChatHeader({
   onOpenTurnInspector,
   artifactsOpen,
   onToggleArtifacts,
+  mobile = false,
+  onBack,
+  onOpenRail,
+  onOpenConfig,
 }: {
   keeper: Keeper
   detailOpen: boolean
@@ -39,6 +279,10 @@ function ChatHeader({
   onOpenTurnInspector: () => void
   artifactsOpen: boolean
   onToggleArtifacts: () => void
+  mobile?: boolean
+  onBack?: () => void
+  onOpenRail?: () => void
+  onOpenConfig?: () => void
 }): VNode {
   const bucket = keeperBucket(keeper)
   const tone = keeperStatusTone(keeper)
@@ -54,11 +298,16 @@ function ChatHeader({
       <button
         type="button"
         class="kw-chat-back kw-act v2-monitoring-action"
-        title="키퍼 목록으로"
-        aria-label="키퍼 목록으로"
-        onClick=${() => { keeperMobilePane.value = 'roster' }}
+        title="키퍼 로스터"
+        aria-label="키퍼 로스터로 돌아가기"
+        onClick=${() => {
+          keeperMobilePane.value = 'roster'
+          onBack?.()
+        }}
         data-testid="kw-chat-back-to-roster"
-      >← 키퍼</button>
+      >
+        <${ChevronLeft} size=${16} aria-hidden="true" />
+      </button>
       <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${live} />
       <div class="kw-chat-id">
         <div class="kw-chat-name-row">
@@ -69,30 +318,31 @@ function ChatHeader({
         </div>
       </div>
       <div class="kw-chat-actions">
-        <${KeeperLifecycleButtons} keeper=${keeper} effectiveStatus=${keeperDisplayStatus(keeper)} />
-        <button
-          type="button"
-          class="kw-act v2-monitoring-action"
-          title="턴 검사"
-          onClick=${onOpenTurnInspector}
-          data-testid="kw-chat-turn-inspector-btn"
-        >턴 검사</button>
-        <button type="button" class="kw-act danger v2-monitoring-action" title="컨텍스트 비우기" onClick=${onClear}>비우기</button>
-        <button
-          type="button"
-          class="kw-act v2-monitoring-action"
-          aria-pressed=${artifactsOpen ? 'true' : 'false'}
-          title="대화 아티팩트"
-          onClick=${onToggleArtifacts}
-          data-testid="kw-chat-artifacts-toggle"
-        >${artifactsOpen ? '아티팩트 숨김' : '아티팩트'}</button>
-        <button
-          type="button"
-          class="kw-act v2-monitoring-action"
-          aria-pressed=${detailOpen ? 'true' : 'false'}
-          title="상세 (상태 · 진단 · 정체성 · 설정 · 디버그)"
-          onClick=${onToggleDetail}
-        >${detailOpen ? '대화로' : '상세'}</button>
+        <${WorkspaceCommandButtons}
+          keeper=${keeper}
+          mobile=${mobile}
+          detailOpen=${detailOpen}
+          artifactsOpen=${artifactsOpen}
+          onOpenTurnInspector=${onOpenTurnInspector}
+          onClear=${onClear}
+          onToggleArtifacts=${onToggleArtifacts}
+          onToggleDetail=${onToggleDetail}
+          onOpenConfig=${onOpenConfig}
+        />
+        ${mobile
+          ? html`
+              <button
+                type="button"
+                class="kw-chat-ctx-mobile v2-monitoring-action"
+                title="컨텍스트"
+                onClick=${onOpenRail}
+                data-testid="kw-chat-mobile-context"
+              >
+                <${Info} size=${14} aria-hidden="true" />
+                <span>컨텍스트</span>
+              </button>
+            `
+          : null}
       </div>
     </div>
   `
@@ -100,10 +350,12 @@ function ChatHeader({
 
 function TurnInspectorDrawer({
   keeperName,
+  triggerEntry,
   open,
   onClose,
 }: {
   keeperName: string
+  triggerEntry?: KeeperConversationEntry | null
   open: boolean
   onClose: () => void
 }) {
@@ -125,7 +377,11 @@ function TurnInspectorDrawer({
         <div class="sticky top-0 z-10 flex items-center justify-between border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-3 v2-monitoring-toolbar">
           <div>
             <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">턴 검사</h3>
-            <p class="text-2xs text-[var(--color-fg-muted)]">${keeperName}</p>
+            <p class="text-2xs text-[var(--color-fg-muted)]">
+              ${triggerEntry
+                ? html`메시지 ${triggerEntry.label} · ${triggerEntry.timestamp ?? triggerEntry.id}`
+                : keeperName}
+            </p>
           </div>
           <button
             type="button"
@@ -134,7 +390,10 @@ function TurnInspectorDrawer({
             data-testid="kw-chat-turn-inspector-close"
           >닫기</button>
         </div>
-        <${KeeperTurnInspector} keeperName=${keeperName} />
+        <${KeeperTurnInspector}
+          keeperName=${keeperName}
+          initialTurnTimestamp=${triggerEntry?.timestamp ?? null}
+        />
       </div>
     </div>
   `
@@ -145,15 +404,28 @@ export function KeeperWorkspaceChat({
   detailOpen,
   onToggleDetail,
   onClear,
+  mobile = false,
+  onBack,
+  onOpenRail,
+  onOpenConfig,
 }: {
   keeper: Keeper
   detailOpen: boolean
   onToggleDetail: () => void
   onClear: () => void
+  mobile?: boolean
+  onBack?: () => void
+  onOpenRail?: () => void
+  onOpenConfig?: () => void
 }): VNode {
   const [turnInspectorOpen, setTurnInspectorOpen] = useState(false)
+  const [turnInspectorEntry, setTurnInspectorEntry] = useState<KeeperConversationEntry | null>(null)
   const [artifactsOpen, setArtifactsOpen] = useState(false)
   const entries = keeperThreads.value[keeper.name] ?? []
+  const openTurnInspector = (entry?: KeeperConversationEntry) => {
+    setTurnInspectorEntry(entry ?? null)
+    setTurnInspectorOpen(true)
+  }
 
   return html`
     <section class="kw-chat v2-monitoring-surface" role="region" aria-label=${`${keeper.name} 대화`}>
@@ -162,15 +434,20 @@ export function KeeperWorkspaceChat({
         detailOpen=${detailOpen}
         onToggleDetail=${onToggleDetail}
         onClear=${onClear}
-        onOpenTurnInspector=${() => setTurnInspectorOpen(true)}
+        onOpenTurnInspector=${() => openTurnInspector()}
         artifactsOpen=${artifactsOpen}
         onToggleArtifacts=${() => setArtifactsOpen((o) => !o)}
+        mobile=${mobile}
+        onBack=${onBack}
+        onOpenRail=${onOpenRail}
+        onOpenConfig=${onOpenConfig}
       />
       <div class="kw-chat-body">
         <${KeeperConversationPanel}
           keeperName=${keeper.name}
           placeholder=${`${keeper.name} 에게 메시지…  (⌘+Enter 전송)`}
           layout="workspace"
+          onInspectTurn=${openTurnInspector}
         />
         ${artifactsOpen
           ? html`<${ChatArtifactPanel} entries=${entries} />`
@@ -178,8 +455,12 @@ export function KeeperWorkspaceChat({
       </div>
       <${TurnInspectorDrawer}
         keeperName=${keeper.name}
+        triggerEntry=${turnInspectorEntry}
         open=${turnInspectorOpen}
-        onClose=${() => setTurnInspectorOpen(false)}
+        onClose=${() => {
+          setTurnInspectorOpen(false)
+          setTurnInspectorEntry(null)
+        }}
       />
     </section>
   `

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -7,10 +7,14 @@ vi.mock('../../router', async (orig) => ({
   ...(await orig<typeof import('../../router')>()),
   navigate: vi.fn(),
 }))
+vi.mock('../keeper-action-panel', () => ({
+  runKeeperAction: vi.fn(async () => undefined),
+}))
 
 import { navigate } from '../../router'
 import { keepers } from '../../store'
 import { keeperMobilePane } from '../keeper-detail-state'
+import { runKeeperAction } from '../keeper-action-panel'
 import { KeeperWorkspaceRoster } from './keeper-workspace-roster'
 import type { Keeper } from '../../types'
 
@@ -29,6 +33,7 @@ let host: HTMLElement
 beforeEach(() => {
   keepers.value = FIXTURE
   vi.mocked(navigate).mockClear()
+  vi.mocked(runKeeperAction).mockClear()
   host = document.createElement('div')
   document.body.appendChild(host)
 })
@@ -78,6 +83,59 @@ describe('KeeperWorkspaceRoster', () => {
     expect(keeperMobilePane.value).toBe('chat')
   })
 
+  it('opens a row command menu without selecting the row', () => {
+    const onSelect = vi.fn()
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" onSelect=${onSelect} />`, host)
+
+    fireEvent.click(host.querySelector('[data-testid="kw-roster-menu-sangsu"]') as HTMLButtonElement)
+
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')).not.toBeNull()
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')?.textContent).toContain('sangsu')
+    expect(host.querySelector('[data-testid="kw-roster-menu-open-chat"]')).not.toBeNull()
+    expect(host.querySelector('[data-testid="kw-roster-menu-config"]')).not.toBeNull()
+    expect(navigate).not.toHaveBeenCalled()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('opens chat from a row command menu', () => {
+    const onSelect = vi.fn()
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" onSelect=${onSelect} />`, host)
+
+    fireEvent.click(host.querySelector('[data-testid="kw-roster-menu-sangsu"]') as HTMLButtonElement)
+    fireEvent.click(host.querySelector('[data-testid="kw-roster-menu-open-chat"]') as HTMLButtonElement)
+
+    expect(navigate).toHaveBeenCalledWith('monitoring', { section: 'agents', keeper: 'sangsu' })
+    expect(onSelect).toHaveBeenCalledWith('sangsu')
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')).toBeNull()
+  })
+
+  it('runs lifecycle actions from a row command menu', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+
+    fireEvent.click(host.querySelector('[data-testid="kw-roster-menu-masc-improver"]') as HTMLButtonElement)
+    fireEvent.click(host.querySelector('[data-testid="kw-roster-menu-pause"]') as HTMLButtonElement)
+
+    expect(runKeeperAction).toHaveBeenCalledWith('masc-improver', 'pause')
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')).toBeNull()
+  })
+
+  it('routes and opens config from a row command menu', () => {
+    const onOpenConfig = vi.fn()
+    render(html`
+      <${KeeperWorkspaceRoster}
+        activeName="masc-improver"
+        onOpenConfig=${onOpenConfig}
+      />
+    `, host)
+
+    fireEvent.click(host.querySelector('[data-testid="kw-roster-menu-rama"]') as HTMLButtonElement)
+    fireEvent.click(host.querySelector('[data-testid="kw-roster-menu-config"]') as HTMLButtonElement)
+
+    expect(navigate).toHaveBeenCalledWith('monitoring', { section: 'agents', keeper: 'rama' })
+    expect(onOpenConfig).toHaveBeenCalledWith('rama')
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')).toBeNull()
+  })
+
   it('filters by search query', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     const search = host.querySelector('.kw-roster-search') as HTMLInputElement
@@ -85,6 +143,31 @@ describe('KeeperWorkspaceRoster', () => {
     const rows = host.querySelectorAll('.kw-kp-row')
     expect(rows.length).toBe(1)
     expect(rows[0]?.textContent).toContain('rama')
+  })
+
+  it('sorts the roster by name and attention count', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    const sort = host.querySelector('.kw-roster-sort') as HTMLSelectElement
+
+    fireEvent.change(sort, { target: { value: 'name' } })
+    let rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
+    expect(rows.map(r => r.textContent ?? '')).toEqual([
+      expect.stringContaining('masc-improver'),
+      expect.stringContaining('rama'),
+      expect.stringContaining('sangsu'),
+    ])
+
+    fireEvent.change(sort, { target: { value: 'att' } })
+    rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
+    expect(rows[0]?.textContent).toContain('rama')
+  })
+
+  it('renders a compact sigil-only roster in mini mode', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" mini=${true} />`, host)
+    expect(host.querySelector('.kw-roster-search')).toBeNull()
+    expect(host.querySelector('.kw-roster-sort')).toBeNull()
+    expect(host.querySelectorAll('.kw-kp-mini').length).toBe(3)
+    expect(host.querySelector('.kw-kp-mini[aria-current="true"]')).not.toBeNull()
   })
 
   it('shows a work-preview line per row, preferring recent output', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -5,14 +5,25 @@
 // page already used, so deep links keep working).
 
 import { html } from 'htm/preact'
-import { useState } from 'preact/hooks'
+import {
+  MessageSquare,
+  MoreHorizontal,
+  Pause,
+  Play,
+  RotateCcw,
+  Settings,
+  Square,
+} from 'lucide-preact'
+import { useEffect, useState } from 'preact/hooks'
 import type { VNode } from 'preact'
 import { keepers } from '../../store'
 import { navigate } from '../../router'
 import { selectKeeper } from '../../keeper-runtime'
 import { keeperMobilePane } from '../keeper-detail-state'
 import { keeperActivityDisplay, keeperWorkPreview } from '../../lib/keeper-runtime-display'
+import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import type { Keeper } from '../../types'
+import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
 import { VirtualList } from '../common/virtual-list'
 import {
   WorkspaceSigil,
@@ -25,6 +36,41 @@ import {
 
 type RosterFilter = 'all' | 'run' | 'att'
 type RosterSort = 'status' | 'name' | 'att'
+type KeeperWorkspaceRouteSurface = 'monitoring' | 'keepers'
+type RosterMenuState = { keeper: Keeper; x: number; y: number } | null
+type IconComponent = typeof Play
+
+const LIFECYCLE_COPY: Record<KeeperActionKey, { label: string; title: string; icon: IconComponent; danger?: boolean }> = {
+  pause: {
+    label: '일시정지',
+    title: '일시정지: 실행 중인 keeper 를 일시 멈춥니다',
+    icon: Pause,
+  },
+  resume: {
+    label: '재개',
+    title: '재개: 일시정지된 keeper 를 다시 실행합니다',
+    icon: Play,
+  },
+  wakeup: {
+    label: '깨우기',
+    title: '깨우기: 다음 turn 을 즉시 시도합니다',
+    icon: RotateCcw,
+  },
+  boot: {
+    label: '기동',
+    title: '기동: offline keeper 를 다시 시작합니다',
+    icon: Play,
+  },
+  shutdown: {
+    label: '종료',
+    title: '종료: keeper 를 완전 종료합니다',
+    icon: Square,
+    danger: true,
+  },
+}
+const MENU_WIDTH = 190
+const MENU_ESTIMATED_HEIGHT = 246
+const MENU_VIEWPORT_MARGIN = 8
 
 const GROUP_ORDER: { bucket: KeeperBucket; label: string }[] = [
   { bucket: 'running', label: '실행 중' },
@@ -44,7 +90,7 @@ const WINDOW_AT = 60
 
 /** Blocked tasks + explicit attention flag → the roster attention badge. */
 function attentionCount(keeper: Keeper): number {
-  return keeper.blocked_task_count ?? 0
+  return keeper.blocked_task_count ?? (keeper.needs_attention === true ? 1 : 0)
 }
 function needsAttention(keeper: Keeper): boolean {
   return keeper.needs_attention === true || attentionCount(keeper) > 0
@@ -82,11 +128,13 @@ function RosterRow({
   keeper,
   active,
   onSelect,
+  onMenu,
   style,
 }: {
   keeper: Keeper
   active: boolean
   onSelect: (name: string) => void
+  onMenu: (keeper: Keeper, event: MouseEvent) => void
   style?: string
 }) {
   const bucket = keeperBucket(keeper)
@@ -95,13 +143,20 @@ function RosterRow({
   const scope = keeperScope(keeper)
   const activity = keeperActivityDisplay(keeper)
   const work = keeperWorkPreview(keeper)
+  const select = () => onSelect(keeper.name)
   return html`
-    <button
-      type="button"
+    <div
+      role="button"
+      tabindex="0"
       class="kw-kp-row v2-monitoring-row"
       style=${style}
       aria-current=${active ? 'true' : 'false'}
-      onClick=${() => onSelect(keeper.name)}
+      onClick=${select}
+      onKeyDown=${(event: KeyboardEvent) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return
+        event.preventDefault()
+        select()
+      }}
     >
       <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${bucket === 'running'} />
       <div class="kw-kp-meta">
@@ -116,20 +171,164 @@ function RosterRow({
         ${activity.source !== 'none' ? html`<span class="kw-kp-time">${activity.label}</span>` : null}
         ${att > 0 ? html`<span class="kw-kp-att" title=${`주의 ${att}건`}>${att}</span>` : null}
       </div>
+      <button
+        type="button"
+        class="kw-kp-more v2-monitoring-action"
+        aria-label=${`${keeper.name} 명령`}
+        title="keeper 명령"
+        onClick=${(event: MouseEvent) => {
+          event.preventDefault()
+          event.stopPropagation()
+          onMenu(keeper, event)
+        }}
+        data-testid=${`kw-roster-menu-${keeper.name}`}
+      >
+        <${MoreHorizontal} size=${15} aria-hidden="true" />
+      </button>
+    </div>
+  `
+}
+
+function MiniRosterRow({
+  keeper,
+  active,
+  onSelect,
+}: {
+  keeper: Keeper
+  active: boolean
+  onSelect: (name: string) => void
+}) {
+  const bucket = keeperBucket(keeper)
+  const tone = keeperStatusTone(keeper)
+  const label = `${keeper.name} · ${keeperPhaseLabel(keeper)}`
+  return html`
+    <button
+      type="button"
+      class="kw-kp-mini v2-monitoring-action"
+      aria-current=${active ? 'true' : 'false'}
+      aria-label=${label}
+      title=${label}
+      onClick=${() => onSelect(keeper.name)}
+    >
+      <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${bucket === 'running'} />
+      <${StatusDot} tone=${tone} pulse=${bucket === 'running'} />
     </button>
+  `
+}
+
+function lifecycleActions(keeper: Keeper): KeeperActionKey[] {
+  const visibility = keeperActionVisibility(keeper)
+  const actions: KeeperActionKey[] = []
+  if (visibility.canBoot) actions.push('boot')
+  if (visibility.canResume) actions.push('resume')
+  if (visibility.canWake && !visibility.canBoot) actions.push('wakeup')
+  if (visibility.canPause) actions.push('pause')
+  if (visibility.canShutdown) actions.push('shutdown')
+  return actions
+}
+
+function KeeperRosterMenu({
+  state,
+  onClose,
+  onSelect,
+  onOpenConfig,
+}: {
+  state: Exclude<RosterMenuState, null>
+  onClose: () => void
+  onSelect: (name: string) => void
+  onOpenConfig?: (name: string) => void
+}): VNode {
+  const keeper = state.keeper
+  const actions = lifecycleActions(keeper)
+  const select = () => {
+    onSelect(keeper.name)
+    onClose()
+  }
+  const openConfig = () => {
+    onSelect(keeper.name)
+    if (onOpenConfig) {
+      onOpenConfig(keeper.name)
+    }
+    onClose()
+  }
+
+  return html`
+    <div
+      class="kw-kp-menu v2-monitoring-surface"
+      role="menu"
+      style=${{ left: `${state.x}px`, top: `${state.y}px` }}
+      onClick=${(event: Event) => event.stopPropagation()}
+      data-testid="kw-roster-menu"
+    >
+      <div class="kw-kp-menu-head v2-monitoring-toolbar">
+        <${WorkspaceSigil} id=${keeper.name} size=${22} beat=${keeperBucket(keeper) === 'running'} />
+        <span>${keeper.name}</span>
+      </div>
+      <button type="button" role="menuitem" class="kw-kp-menu-item" onClick=${select} data-testid="kw-roster-menu-open-chat">
+        <${MessageSquare} size=${14} aria-hidden="true" />
+        <span>대화 열기</span>
+      </button>
+      ${actions.map(action => {
+        const copy = LIFECYCLE_COPY[action]
+        const Icon = copy.icon
+        return html`
+          <button
+            key=${action}
+            type="button"
+            role="menuitem"
+            class=${`kw-kp-menu-item${copy.danger ? ' danger' : ''}`}
+            title=${copy.title}
+            onClick=${() => {
+              void runKeeperAction(keeper.name, action)
+              onClose()
+            }}
+            data-testid=${`kw-roster-menu-${action}`}
+          >
+            <${Icon} size=${14} aria-hidden="true" />
+            <span>${copy.label}</span>
+          </button>
+        `
+      })}
+      ${actions.length === 0
+        ? html`<div class="kw-kp-menu-note">현재 실행 가능한 명령 없음</div>`
+        : null}
+      <div class="kw-kp-menu-sep"></div>
+      <button type="button" role="menuitem" class="kw-kp-menu-item" onClick=${openConfig} data-testid="kw-roster-menu-config">
+        <${Settings} size=${14} aria-hidden="true" />
+        <span>keeper 설정</span>
+      </button>
+    </div>
   `
 }
 
 export function KeeperWorkspaceRoster({
   activeName,
   onSelect,
+  onOpenConfig,
+  routeSurface = 'monitoring',
+  mini = false,
 }: {
   activeName: string
   onSelect?: (name: string) => void
+  onOpenConfig?: (name: string) => void
+  routeSurface?: KeeperWorkspaceRouteSurface
+  mini?: boolean
 }): VNode {
   const [query, setQuery] = useState('')
   const [filter, setFilter] = useState<RosterFilter>('all')
   const [sort, setSort] = useState<RosterSort>('status')
+  const [menu, setMenu] = useState<RosterMenuState>(null)
+
+  useEffect(() => {
+    if (!menu) return
+    const close = () => setMenu(null)
+    window.addEventListener('click', close)
+    window.addEventListener('keydown', close)
+    return () => {
+      window.removeEventListener('click', close)
+      window.removeEventListener('keydown', close)
+    }
+  }, [menu])
 
   const all = keepers.value
   const counts = {
@@ -144,13 +343,41 @@ export function KeeperWorkspaceRoster({
     return matchesQuery(k, query)
   })
 
+  const sortRows = (rows: Keeper[]): Keeper[] => {
+    return sort === 'status' ? rows : [...rows].sort((a, b) => compareKeepers(a, b, sort))
+  }
+
   const select = (name: string) => {
+    setMenu(null)
     selectKeeper(name)
     // On mobile the roster and conversation share one column; picking a keeper
     // should reveal that keeper's chat (the roster is the "back" target).
     keeperMobilePane.value = 'chat'
-    navigate('monitoring', { section: 'agents', keeper: name })
+    if (routeSurface === 'keepers') {
+      navigate('keepers', { keeper: name })
+    } else {
+      navigate('monitoring', { section: 'agents', keeper: name })
+    }
     onSelect?.(name)
+  }
+
+  const openMenu = (keeper: Keeper, event: MouseEvent) => {
+    const target = event.currentTarget as HTMLElement
+    const rect = target.getBoundingClientRect()
+    const rosterRect = target.closest('.kw-roster')?.getBoundingClientRect() ?? { left: 0, top: 0 }
+    const viewportX = Math.max(
+      MENU_VIEWPORT_MARGIN,
+      Math.min(rect.right - MENU_WIDTH, window.innerWidth - MENU_WIDTH - MENU_VIEWPORT_MARGIN),
+    )
+    const viewportY = Math.max(
+      MENU_VIEWPORT_MARGIN,
+      Math.min(rect.bottom + MENU_VIEWPORT_MARGIN, window.innerHeight - MENU_ESTIMATED_HEIGHT - MENU_VIEWPORT_MARGIN),
+    )
+    setMenu({
+      keeper,
+      x: viewportX - rosterRect.left,
+      y: viewportY - rosterRect.top,
+    })
   }
 
   const filterChips: { id: RosterFilter; label: string }[] = [
@@ -173,19 +400,20 @@ export function KeeperWorkspaceRoster({
       }
     }
   } else {
-    for (const keeper of [...visible].sort((a, b) => compareKeepers(a, b, sort))) {
+    for (const keeper of sortRows(visible)) {
       items.push({ type: 'row', keeper })
     }
   }
 
   const useVirtual = items.length > WINDOW_AT
   const rowStyle = 'content-visibility:auto;contain-intrinsic-size:auto 58px'
+  const miniRows = sortRows(all)
 
   function renderItem(item: RosterItem): VNode {
     if (item.type === 'header') {
       return html`<div class="kw-roster-group v2-monitoring-row">${item.label}</div>`
     }
-    return html`<${RosterRow} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} />`
+    return html`<${RosterRow} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} />`
   }
 
   function getKey(item: RosterItem): string {
@@ -193,42 +421,46 @@ export function KeeperWorkspaceRoster({
   }
 
   return html`
-    <aside class="kw-roster v2-monitoring-surface" aria-label="키퍼 로스터">
-      <div class="kw-roster-head v2-monitoring-toolbar">
-        <input
-          class="kw-roster-search"
-          type="text"
-          placeholder="이름 · 스코프 검색…"
-          aria-label="키퍼 검색"
-          value=${query}
-          onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-        />
-      </div>
-      <div class="kw-roster-filters v2-monitoring-toolbar" role="group" aria-label="상태 필터">
-        ${filterChips.map(chip => html`
-          <button
-            type="button"
-            class="kw-rfilter v2-monitoring-action"
-            aria-pressed=${filter === chip.id ? 'true' : 'false'}
-            onClick=${() => setFilter(chip.id)}
-          >
-            ${chip.label}<span class="n">${counts[chip.id]}</span>
-          </button>
-        `)}
-        <select
-          class="kw-roster-sort"
-          aria-label="키퍼 정렬 기준"
-          title="정렬 기준"
-          value=${sort}
-          onChange=${(e: Event) => setSort((e.target as HTMLSelectElement).value as RosterSort)}
-        >
-          <option value="status">상태순</option>
-          <option value="name">이름순</option>
-          <option value="att">주의순</option>
-        </select>
-      </div>
-      ${visible.length === 0
-        ? html`<div class="kw-roster-list"><div class="kw-roster-empty v2-monitoring-row">일치하는 키퍼가 없습니다</div></div>`
+    <aside class=${`kw-roster${mini ? ' mini' : ''} v2-monitoring-surface`} aria-label="키퍼 로스터">
+      ${mini
+        ? html`<div class="kw-roster-mini-list">
+            ${miniRows.map(k => html`<${MiniRosterRow} key=${k.name} keeper=${k} active=${k.name === activeName} onSelect=${select} />`)}
+          </div>`
+        : html`
+          <div class="kw-roster-head v2-monitoring-toolbar">
+            <input
+              class="kw-roster-search"
+              type="text"
+              placeholder="이름 · 스코프 검색…"
+              aria-label="키퍼 검색"
+              value=${query}
+              onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
+            />
+          </div>
+          <div class="kw-roster-filters v2-monitoring-toolbar" role="group" aria-label="상태 필터">
+            ${filterChips.map(chip => html`
+              <button
+                type="button"
+                class="kw-rfilter v2-monitoring-action"
+                aria-pressed=${filter === chip.id ? 'true' : 'false'}
+                onClick=${() => setFilter(chip.id)}
+              >
+                ${chip.label}<span class="n">${counts[chip.id]}</span>
+              </button>
+            `)}
+            <select
+              class="kw-roster-sort v2-monitoring-action"
+              aria-label="키퍼 정렬"
+              value=${sort}
+              onChange=${(e: Event) => setSort((e.target as HTMLSelectElement).value as RosterSort)}
+            >
+              <option value="status">상태순</option>
+              <option value="name">이름순</option>
+              <option value="att">주의순</option>
+            </select>
+          </div>
+          ${visible.length === 0
+            ? html`<div class="kw-roster-list"><div class="kw-roster-empty v2-monitoring-row">일치하는 키퍼가 없습니다</div></div>`
         : useVirtual
           ? html`<${VirtualList}
               items=${items}
@@ -238,12 +470,19 @@ export function KeeperWorkspaceRoster({
               getKey=${getKey}
             />`
           : html`<div class="kw-roster-list">
-              ${items.map(item =>
-                item.type === 'header'
-                  ? html`<div class="kw-roster-group v2-monitoring-row">${item.label}</div>`
-                  : html`<${RosterRow} key=${item.keeper.name} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} style=${rowStyle} />`,
-              )}
+              ${items.map(item => item.type === 'header'
+                ? html`<div class="kw-roster-group v2-monitoring-row" key=${`h:${item.bucket}`}>${item.label}</div>`
+                : html`<${RosterRow} key=${item.keeper.name} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} style=${rowStyle} />`)}
             </div>`}
+        `}
+      ${menu
+        ? html`<${KeeperRosterMenu}
+            state=${menu}
+            onClose=${() => setMenu(null)}
+            onSelect=${select}
+            onOpenConfig=${onOpenConfig}
+          />`
+        : null}
     </aside>
   `
 }

--- a/dashboard/src/components/lab-perf.test.ts
+++ b/dashboard/src/components/lab-perf.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { html } from 'htm/preact'
+import { LabPerf } from './lab-perf'
+
+describe('LabPerf', () => {
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.stubGlobal('ResizeObserver', class MockResizeObserver {
+      private readonly callback: ResizeObserverCallback
+
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback
+      }
+
+      observe(target: Element) {
+        this.callback([{
+          target,
+          contentRect: { width: 320, height: 96 } as DOMRectReadOnly,
+        } as ResizeObserverEntry], this as unknown as ResizeObserver)
+      }
+
+      disconnect() {}
+    })
+    vi.stubGlobal('IntersectionObserver', class MockIntersectionObserver {
+      private readonly callback: IntersectionObserverCallback
+
+      constructor(callback: IntersectionObserverCallback) {
+        this.callback = callback
+      }
+
+      observe(target: Element) {
+        this.callback([{
+          target,
+          isIntersecting: true,
+          intersectionRatio: 1,
+        } as IntersectionObserverEntry], this as unknown as IntersectionObserver)
+      }
+
+      disconnect() {}
+    })
+    vi.stubGlobal('CSS', {
+      supports: vi.fn((property: string, value: string) => property === 'content-visibility' && value === 'auto'),
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    Reflect.deleteProperty(document, 'startViewTransition')
+  })
+
+  it('renders the v2 performance primitives as a visible Lab surface', () => {
+    render(html`<${LabPerf} />`)
+
+    expect(screen.getByTestId('lab-perf-surface')).not.toBeNull()
+    expect(screen.getByTestId('lab-perf-fps')).not.toBeNull()
+    expect(screen.getByTestId('lab-perf-platform')).not.toBeNull()
+    expect(screen.getByTestId('lab-perf-observer-probes')).not.toBeNull()
+    expect(screen.getByTestId('lab-perf-dialog-demo')).not.toBeNull()
+    expect(screen.getByText(/VirtualList · .* rows/)).not.toBeNull()
+    expect(screen.getByTestId('lab-perf-virtual-list')).not.toBeNull()
+    expect(screen.getByTestId('lab-perf-mode-virtual-list').getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByTestId('lab-perf-capability-content-visibility').getAttribute('data-supported')).toBe('true')
+    expect(screen.getByTestId('lab-perf-size-readout').textContent).toContain('320×96')
+    expect(screen.getByTestId('lab-perf-inview-readout').getAttribute('data-in-view')).toBe('true')
+  })
+
+  it('switches to the content-visibility list demo', () => {
+    render(html`<${LabPerf} />`)
+
+    fireEvent.click(screen.getByTestId('lab-perf-mode-content-visibility'))
+
+    expect(screen.getByTestId('lab-perf-mode-content-visibility').getAttribute('aria-pressed')).toBe('true')
+    expect(screen.queryByTestId('lab-perf-virtual-list')).toBeNull()
+    expect(screen.getByTestId('lab-perf-cv-list').getAttribute('data-cv-total')).toBe('180')
+    const rows = screen.getAllByTestId('lab-perf-cv-row')
+    expect(rows).toHaveLength(180)
+    expect((rows[0] as HTMLElement).style.contentVisibility).toBe('auto')
+    expect((rows[0] as HTMLElement).style.containIntrinsicSize).toBe('auto 48px')
+  })
+
+  it('uses the View Transitions API when available for mode swaps', () => {
+    const startViewTransition = vi.fn((mutate: () => void) => {
+      mutate()
+      return {}
+    })
+    Object.defineProperty(document, 'startViewTransition', {
+      configurable: true,
+      value: startViewTransition,
+    })
+
+    render(html`<${LabPerf} />`)
+    fireEvent.click(screen.getByTestId('lab-perf-mode-content-visibility'))
+
+    expect(startViewTransition).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('lab-perf-cv-list')).not.toBeNull()
+  })
+
+  it('opens and closes the native dialog demo', () => {
+    render(html`<${LabPerf} />`)
+
+    fireEvent.click(screen.getByTestId('lab-perf-dialog-open'))
+    const dialog = screen.getByTestId('lab-perf-native-dialog') as HTMLDialogElement
+
+    expect(dialog.hasAttribute('open')).toBe(true)
+    expect(dialog.getAttribute('aria-labelledby')).toBe('lab-perf-dialog-title')
+    expect(dialog.textContent).toContain('Native top-layer dialog')
+
+    fireEvent.click(screen.getByTestId('lab-perf-dialog-close'))
+
+    expect(dialog.hasAttribute('open')).toBe(false)
+  })
+
+  it('lets the native cancel event close the dialog demo', () => {
+    render(html`<${LabPerf} />`)
+
+    fireEvent.click(screen.getByTestId('lab-perf-dialog-open'))
+    const dialog = screen.getByTestId('lab-perf-native-dialog') as HTMLDialogElement
+    expect(dialog.hasAttribute('open')).toBe(true)
+
+    fireEvent(dialog, new Event('cancel', { cancelable: true }))
+
+    expect(dialog.hasAttribute('open')).toBe(false)
+  })
+})

--- a/dashboard/src/components/lab-perf.ts
+++ b/dashboard/src/components/lab-perf.ts
@@ -5,7 +5,7 @@
 // synthetic; the surface is meant to exercise production rendering primitives.
 
 import { html } from 'htm/preact'
-import { useEffect, useMemo, useState } from 'preact/hooks'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { VirtualList } from './common/virtual-list'
 import { onFpsChange } from '../utils/fps-adaptive'
 
@@ -15,6 +15,24 @@ interface PerfLogRow {
   level: 'info' | 'warn' | 'error'
   keeper: string
   msg: string
+}
+
+type PerfDemoMode = 'virtual-list' | 'content-visibility'
+
+interface PlatformCapability {
+  id: string
+  label: string
+  detail: string
+  supported: boolean
+}
+
+type ViewTransitionDocument = Document & {
+  startViewTransition?: (updateCallback: () => void) => unknown
+}
+
+interface ElementSize {
+  width: number
+  height: number
 }
 
 const LEVELS: PerfLogRow['level'][] = ['info', 'info', 'info', 'warn', 'error']
@@ -31,6 +49,105 @@ const MSGS = [
   'PR 코멘트 동기화',
   'masc_git_blame 0.4s',
 ]
+
+function supportsCss(property: string, value: string): boolean {
+  if (typeof CSS === 'undefined' || typeof CSS.supports !== 'function') return false
+  return CSS.supports(property, value)
+}
+
+function readPlatformCapabilities(): PlatformCapability[] {
+  const doc = typeof document === 'undefined' ? null : document
+  return [
+    {
+      id: 'resize-observer',
+      label: 'ResizeObserver',
+      detail: 'viewport measurement for exact windowing math',
+      supported: typeof ResizeObserver !== 'undefined',
+    },
+    {
+      id: 'intersection-observer',
+      label: 'IntersectionObserver',
+      detail: 'lazy mount and infinite-scroll sentinels',
+      supported: typeof IntersectionObserver !== 'undefined',
+    },
+    {
+      id: 'view-transition',
+      label: 'View Transitions',
+      detail: 'animated mode swaps when the browser supports it',
+      supported: !!doc && typeof (doc as ViewTransitionDocument).startViewTransition === 'function',
+    },
+    {
+      id: 'content-visibility',
+      label: 'content-visibility',
+      detail: 'layout and paint skipped for off-screen DOM rows',
+      supported: supportsCss('content-visibility', 'auto'),
+    },
+  ]
+}
+
+function readElementSize(element: HTMLElement): ElementSize {
+  const rect = element.getBoundingClientRect()
+  return {
+    width: Math.round(rect.width || element.clientWidth),
+    height: Math.round(rect.height || element.clientHeight),
+  }
+}
+
+function useMeasuredElement() {
+  const ref = useRef<HTMLDivElement>(null)
+  const [size, setSize] = useState<ElementSize>({ width: 0, height: 0 })
+
+  useLayoutEffect(() => {
+    const element = ref.current
+    if (!element) return undefined
+
+    setSize(readElementSize(element))
+    if (typeof ResizeObserver === 'undefined') return undefined
+
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0]
+      if (!entry) return
+      const box = entry.borderBoxSize?.[0]
+      if (box) {
+        setSize({
+          width: Math.round(box.inlineSize),
+          height: Math.round(box.blockSize),
+        })
+        return
+      }
+      setSize({
+        width: Math.round(entry.contentRect.width),
+        height: Math.round(entry.contentRect.height),
+      })
+    })
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
+  return { ref, size }
+}
+
+function useInViewProbe() {
+  const ref = useRef<HTMLDivElement>(null)
+  const [inView, setInView] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return undefined
+    if (typeof IntersectionObserver === 'undefined') {
+      setInView(true)
+      return undefined
+    }
+
+    const observer = new IntersectionObserver(entries => {
+      setInView(entries.some(entry => entry.isIntersecting))
+    }, { rootMargin: '80px', threshold: 0.1 })
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
+  return { ref, inView }
+}
 
 function generateRows(count: number): PerfLogRow[] {
   return Array.from({ length: count }, (_, i) => {
@@ -81,6 +198,178 @@ function FpsBadge() {
   `
 }
 
+function PlatformBadges({ capabilities }: { capabilities: PlatformCapability[] }) {
+  return html`
+    <div class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4" data-testid="lab-perf-platform">
+      ${capabilities.map(capability => {
+        const tone = capability.supported
+          ? 'border-success/20 bg-success/10 text-success'
+          : 'border-border bg-surface-subtle text-text-tertiary'
+        return html`
+          <div
+            key=${capability.id}
+            class="rounded-xl border border-border bg-surface-subtle/70 px-3 py-3"
+            data-testid=${`lab-perf-capability-${capability.id}`}
+            data-supported=${capability.supported ? 'true' : 'false'}
+          >
+            <div class="mb-1 flex items-center justify-between gap-2">
+              <span class="text-[12px] font-semibold text-text-primary">${capability.label}</span>
+              <span class=${`rounded-md border px-1.5 py-0.5 text-[10px] font-semibold uppercase ${tone}`}>
+                ${capability.supported ? 'native' : 'fallback'}
+              </span>
+            </div>
+            <p class="text-[12px] leading-relaxed text-text-tertiary">${capability.detail}</p>
+          </div>
+        `
+      })}
+    </div>
+  `
+}
+
+function ObserverProbePanel() {
+  const measured = useMeasuredElement()
+  const sentinel = useInViewProbe()
+
+  return html`
+    <div class="grid grid-cols-1 gap-4 lg:grid-cols-2" data-testid="lab-perf-observer-probes">
+      <section class="rounded-2xl border border-border bg-surface-subtle/70 p-4">
+        <div class="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <h3 class="text-[13px] font-semibold text-text-primary">ResizeObserver · useSize</h3>
+            <p class="text-[12px] text-text-tertiary">Measured after layout; updates when the panel changes size.</p>
+          </div>
+          <span class="rounded-md border border-border bg-surface-page px-2 py-1 font-mono text-[11px] text-text-secondary" data-testid="lab-perf-size-readout">
+            ${measured.size.width}×${measured.size.height}
+          </span>
+        </div>
+        <div
+          ref=${measured.ref}
+          class="rounded-xl border border-border bg-surface-page p-4"
+          data-testid="lab-perf-size-target"
+        >
+          <div class="h-12 rounded-lg border border-success/20 bg-success/10 px-3 py-2 text-[12px] leading-relaxed text-text-secondary">
+            The measured target is ordinary dashboard chrome, not a synthetic canvas.
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-border bg-surface-subtle/70 p-4">
+        <div class="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <h3 class="text-[13px] font-semibold text-text-primary">IntersectionObserver · useInView</h3>
+            <p class="text-[12px] text-text-tertiary">The sentinel reports whether this demo is near the viewport.</p>
+          </div>
+          <span
+            class=${`rounded-md border px-2 py-1 text-[11px] font-semibold ${sentinel.inView ? 'border-success/20 bg-success/10 text-success' : 'border-border bg-surface-page text-text-tertiary'}`}
+            data-testid="lab-perf-inview-readout"
+            data-in-view=${sentinel.inView ? 'true' : 'false'}
+          >
+            ${sentinel.inView ? 'in view' : 'waiting'}
+          </span>
+        </div>
+        <div
+          ref=${sentinel.ref}
+          class="rounded-xl border border-border bg-surface-page p-4 text-[12px] leading-relaxed text-text-secondary"
+          data-testid="lab-perf-inview-target"
+        >
+          Sentinel observed with rootMargin 80px and threshold 0.1.
+        </div>
+      </section>
+    </div>
+  `
+}
+
+function NativeDialogDemo() {
+  const [open, setOpen] = useState(false)
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+
+    if (open) {
+      if (typeof dialog.showModal === 'function' && !dialog.open) {
+        try {
+          dialog.showModal()
+        } catch {
+          dialog.setAttribute('open', '')
+        }
+      } else {
+        dialog.setAttribute('open', '')
+      }
+      return
+    }
+
+    if (dialog.open) {
+      if (typeof dialog.close === 'function') dialog.close()
+      else dialog.removeAttribute('open')
+    }
+  }, [open])
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return undefined
+    const onClose = () => setOpen(false)
+    const onCancel = () => setOpen(false)
+    dialog.addEventListener('close', onClose)
+    dialog.addEventListener('cancel', onCancel)
+    return () => {
+      dialog.removeEventListener('close', onClose)
+      dialog.removeEventListener('cancel', onCancel)
+    }
+  }, [])
+
+  return html`
+    <section class="rounded-2xl border border-border bg-surface-subtle/70 p-4" data-testid="lab-perf-dialog-demo">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 class="text-[13px] font-semibold text-text-primary">Native dialog</h3>
+          <p class="text-[12px] text-text-tertiary">Real top-layer modal path from the platform performance layer.</p>
+        </div>
+        <button
+          type="button"
+          class="rounded-lg border border-border bg-surface-page px-3 py-1.5 text-[12px] font-semibold text-text-primary hover:border-accent"
+          data-testid="lab-perf-dialog-open"
+          aria-haspopup="dialog"
+          onClick=${() => setOpen(true)}
+        >
+          Open dialog
+        </button>
+      </div>
+
+      <dialog
+        ref=${dialogRef}
+        class="fixed inset-0 m-auto max-h-[calc(100vh-48px)] w-[min(420px,calc(100vw-32px))] overflow-hidden rounded-2xl border border-border bg-surface-panel p-0 text-text-primary shadow-[0_24px_80px_rgba(0,0,0,0.55)] backdrop:bg-black/70"
+        aria-labelledby="lab-perf-dialog-title"
+        data-testid="lab-perf-native-dialog"
+        onClick=${(event: MouseEvent) => {
+          if (event.target === event.currentTarget) setOpen(false)
+        }}
+      >
+        <div class="border-b border-border px-5 py-4">
+          <h3 id="lab-perf-dialog-title" class="text-[15px] font-semibold">Native top-layer dialog</h3>
+          <p class="mt-1 text-[12px] leading-relaxed text-text-tertiary">
+            showModal, Esc/cancel, close events, and backdrop are owned by the browser.
+          </p>
+        </div>
+        <div class="px-5 py-4 text-[13px] leading-relaxed text-text-secondary">
+          This closes the remaining visible gap from the keeper-v2 performance export without adding a custom modal stack.
+        </div>
+        <div class="flex justify-end border-t border-border px-5 py-4">
+          <button
+            type="button"
+            class="rounded-lg border border-border bg-surface-page px-3 py-1.5 text-[12px] font-semibold text-text-primary"
+            data-testid="lab-perf-dialog-close"
+            onClick=${() => setOpen(false)}
+          >
+            Close
+          </button>
+        </div>
+      </dialog>
+    </section>
+  `
+}
+
 function LogRow({ row }: { row: PerfLogRow }) {
   const levelClass = {
     info: 'text-text-tertiary',
@@ -98,38 +387,117 @@ function LogRow({ row }: { row: PerfLogRow }) {
   `
 }
 
+function ContentVisibilityList({ rows }: { rows: PerfLogRow[] }) {
+  return html`
+    <div
+      class="h-80 overflow-y-auto rounded-xl border border-border bg-surface-page"
+      data-testid="lab-perf-cv-list"
+      data-cv-total=${rows.length}
+    >
+      ${rows.map(row => html`
+        <div
+          key=${row.id}
+          class="virtual-list-fallback-row"
+          data-testid="lab-perf-cv-row"
+          style=${{
+            contentVisibility: 'auto',
+            containIntrinsicSize: 'auto 48px',
+          }}
+        >
+          <${LogRow} row=${row} />
+        </div>
+      `)}
+    </div>
+  `
+}
+
 export function LabPerf() {
   const rows = useMemo(() => generateRows(2000), [])
+  const cvRows = useMemo(() => rows.slice(0, 180), [rows])
+  const capabilities = useMemo(readPlatformCapabilities, [])
+  const [mode, setMode] = useState<PerfDemoMode>('virtual-list')
+
+  const setModeWithTransition = useCallback((nextMode: PerfDemoMode) => {
+    if (nextMode === mode) return
+    const mutate = () => setMode(nextMode)
+    const doc = typeof document === 'undefined' ? null : document
+    const startViewTransition = doc ? (doc as ViewTransitionDocument).startViewTransition : undefined
+    if (typeof startViewTransition === 'function') {
+      try {
+        startViewTransition.call(doc, mutate)
+        return
+      } catch {
+        // Use the plain state update if the browser rejects the transition.
+      }
+    }
+    mutate()
+  }, [mode])
 
   return html`
     <div class="v2-lab-surface ss-surface bg-surface-page flex flex-col gap-6 px-6 py-6" data-testid="lab-perf-surface">
-      <div class="flex items-center justify-between gap-4 v2-monitoring-toolbar">
+      <div class="flex flex-wrap items-center justify-between gap-4 v2-monitoring-toolbar">
         <div>
           <h2 class="text-[18px] font-bold text-text-primary">Performance</h2>
-          <p class="text-[13px] text-text-tertiary">FPS meter + VirtualList windowing demo</p>
+          <p class="text-[13px] text-text-tertiary">FPS meter, VirtualList, content-visibility, native dialog, and observer probes</p>
         </div>
-        <${FpsBadge} />
+        <div class="flex flex-wrap items-center justify-end gap-2">
+          <${FpsBadge} />
+          <div class="inline-flex rounded-lg border border-border bg-surface-subtle p-1" aria-label="Performance demo mode">
+            <button
+              type="button"
+              class=${`rounded-md px-2.5 py-1 text-[12px] font-semibold transition ${mode === 'virtual-list' ? 'bg-surface-page text-text-primary shadow-sm' : 'text-text-tertiary hover:text-text-secondary'}`}
+              aria-pressed=${mode === 'virtual-list'}
+              data-testid="lab-perf-mode-virtual-list"
+              onClick=${() => setModeWithTransition('virtual-list')}
+            >
+              VirtualList
+            </button>
+            <button
+              type="button"
+              class=${`rounded-md px-2.5 py-1 text-[12px] font-semibold transition ${mode === 'content-visibility' ? 'bg-surface-page text-text-primary shadow-sm' : 'text-text-tertiary hover:text-text-secondary'}`}
+              aria-pressed=${mode === 'content-visibility'}
+              data-testid="lab-perf-mode-content-visibility"
+              onClick=${() => setModeWithTransition('content-visibility')}
+            >
+              Content visibility
+            </button>
+          </div>
+        </div>
       </div>
 
+      <${PlatformBadges} capabilities=${capabilities} />
+
+      <${ObserverProbePanel} />
+
+      <${NativeDialogDemo} />
+
       <div class="ss-card v2-monitoring-panel rounded-2xl border border-border p-6">
-        <div class="mb-3 flex items-center justify-between gap-3">
+        <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
           <div class="text-[12px] font-semibold uppercase tracking-[0.05em] text-text-secondary">
-            VirtualList · ${rows.length.toLocaleString()} rows
+            ${mode === 'virtual-list'
+              ? `VirtualList · ${rows.length.toLocaleString()} rows`
+              : `Content visibility · ${cvRows.length.toLocaleString()} variable rows`}
           </div>
-          <span class="text-[11px] text-text-disabled">fixed 36 px rows</span>
+          <span class="text-[11px] text-text-disabled">
+            ${mode === 'virtual-list' ? 'fixed 36 px rows' : 'DOM retained; off-screen paint skipped'}
+          </span>
         </div>
-        <div class="h-80 overflow-hidden rounded-xl border border-border bg-surface-page">
-          <${VirtualList}
-            items=${rows}
-            itemHeight=${36}
-            getKey=${(row: PerfLogRow) => row.id}
-            renderItem=${(row: PerfLogRow) => html`<${LogRow} row=${row} />`}
-            className="h-full"
-          />
-        </div>
+        ${mode === 'virtual-list' ? html`
+          <div class="h-80 overflow-hidden rounded-xl border border-border bg-surface-page" data-testid="lab-perf-virtual-list">
+            <${VirtualList}
+              items=${rows}
+              itemHeight=${36}
+              getKey=${(row: PerfLogRow) => row.id}
+              renderItem=${(row: PerfLogRow) => html`<${LogRow} row=${row} />`}
+              className="h-full"
+            />
+          </div>
+        ` : html`
+          <${ContentVisibilityList} rows=${cvRows} />
+        `}
         <p class="mt-3 text-[13px] leading-relaxed text-text-tertiary">
-          동일한 <code class="rounded bg-surface-subtle px-1 py-0.5 text-text-primary">LogRow</code> 컴포넌트를
-          VirtualList로 윈도잉하면 보이는 슬라이스(+overscan)만 렌더링됩니다.
+          동일한 <code class="rounded bg-surface-subtle px-1 py-0.5 text-text-primary">LogRow</code> 컴포넌트로
+          true windowing과 content-visibility 경로를 비교합니다.
         </p>
       </div>
     </div>

--- a/dashboard/src/components/mobile-nav.test.ts
+++ b/dashboard/src/components/mobile-nav.test.ts
@@ -3,28 +3,42 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { axe } from 'jest-axe'
-import { MobileBottomBar } from './mobile-nav'
+import { DashboardNavRail } from './mobile-nav'
+import type { RouteState } from '../types'
 
-const navigate = vi.fn()
-const hashForRoute = vi.fn((tab: string, params?: Record<string, string>) => {
-  return params ? `#${tab}?${new URLSearchParams(params)}` : `#${tab}`
-})
-
-vi.mock('../router', () => ({
-  navigate: (...args: Parameters<typeof navigate>) => navigate(...args),
-  hashForRoute: (...args: Parameters<typeof hashForRoute>) => hashForRoute(...args),
+const routerMock = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  hashForRoute: vi.fn((tab: string, params?: Record<string, string>) => {
+    return params ? `#${tab}?${new URLSearchParams(params)}` : `#${tab}`
+  }),
+  routeState: {
+    value: { tab: 'monitoring', params: { section: 'agents' }, postId: null } as RouteState,
+  } as { value: RouteState },
 }))
 
-const PRIMARY_LABELS = ['Overview', 'Monitor', 'Command', 'Workspace'] as const
+vi.mock('../router', () => ({
+  route: routerMock.routeState,
+  navigate: (...args: Parameters<typeof routerMock.navigate>) => routerMock.navigate(...args),
+  hashForRoute: (...args: Parameters<typeof routerMock.hashForRoute>) => routerMock.hashForRoute(...args),
+}))
 
-describe('MobileBottomBar', () => {
+const PRIMARY_LABELS = ['Overview', 'Work', 'Keepers', 'Board'] as const
+
+describe('DashboardNavRail', () => {
   let container: HTMLElement
+  let onToggleCollapsed: ReturnType<typeof vi.fn>
+  let onToggleDrawer: ReturnType<typeof vi.fn>
+  let onCloseDrawer: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
-    navigate.mockClear()
-    hashForRoute.mockClear()
+    routerMock.routeState.value = { tab: 'monitoring', params: { section: 'agents' }, postId: null } as RouteState
+    routerMock.navigate.mockClear()
+    routerMock.hashForRoute.mockClear()
+    onToggleCollapsed = vi.fn()
+    onToggleDrawer = vi.fn()
+    onCloseDrawer = vi.fn()
   })
 
   afterEach(() => {
@@ -32,56 +46,112 @@ describe('MobileBottomBar', () => {
     document.body.removeChild(container)
   })
 
-  it('renders the 4 primary surfaces plus a More button', () => {
-    render(html`<${MobileBottomBar} currentTab="monitoring" onMenuToggle=${() => {}} />`, container)
+  function renderNav(props: Partial<Parameters<typeof DashboardNavRail>[0]> = {}) {
+    render(html`
+      <${DashboardNavRail}
+        currentTab=${props.currentTab ?? 'monitoring'}
+        mobile=${props.mobile ?? true}
+        drawerOpen=${props.drawerOpen ?? false}
+        keeperDetailMode=${props.keeperDetailMode ?? false}
+        collapsed=${props.collapsed ?? false}
+        onToggleCollapsed=${props.onToggleCollapsed ?? onToggleCollapsed}
+        onToggleDrawer=${props.onToggleDrawer ?? onToggleDrawer}
+        onCloseDrawer=${props.onCloseDrawer ?? onCloseDrawer}
+      />
+    `, container)
+  }
 
-    const nav = container.querySelector('nav[aria-label="Primary mobile navigation"]')
-    expect(nav).not.toBeNull()
+  it('renders one shared rail owner with mobile tabs when the drawer is closed', () => {
+    renderNav({ currentTab: 'monitoring', mobile: true, drawerOpen: false })
 
-    const labels = Array.from(container.querySelectorAll('a, button'))
+    expect(container.querySelector('[data-testid="dashboard-nav-rail"]')).not.toBeNull()
+    const tabs = container.querySelector('nav[aria-label="Primary mobile navigation"]')
+    expect(tabs).not.toBeNull()
+    expect(tabs?.className).toContain('v2-mobile-bottom-bar')
+
+    const labels = Array.from(tabs?.querySelectorAll('a, button') ?? [])
       .map(el => el.textContent?.trim())
-    for (const label of PRIMARY_LABELS) {
-      expect(labels).toContain(label)
-    }
-    expect(labels).toContain('More')
+    expect(labels).toEqual([...PRIMARY_LABELS, 'More'])
   })
 
-  it('marks only the current surface with aria-current=page', () => {
-    render(html`<${MobileBottomBar} currentTab="command" onMenuToggle=${() => {}} />`, container)
+  it('marks only the current mobile tab with aria-current=page', () => {
+    renderNav({ currentTab: 'keepers', mobile: true })
 
-    const links = Array.from(container.querySelectorAll('a'))
+    const links = Array.from(container.querySelectorAll('nav[aria-label="Primary mobile navigation"] a'))
     const current = links.find(a => a.getAttribute('aria-current') === 'page')
-    expect(current?.textContent?.trim()).toBe('Command')
+    expect(current?.textContent?.trim()).toBe('Keepers')
 
     for (const link of links.filter(a => a !== current)) {
       expect(link.hasAttribute('aria-current')).toBe(false)
     }
   })
 
-  it('invokes onMenuToggle when the More button is clicked', () => {
-    const onMenuToggle = vi.fn()
-    render(html`<${MobileBottomBar} currentTab="overview" onMenuToggle=${onMenuToggle} />`, container)
+  it('opens the operational drawer from the mobile More tab', () => {
+    renderNav({ mobile: true, drawerOpen: false })
 
     const more = Array.from(container.querySelectorAll('button'))
       .find(b => b.textContent?.includes('More')) as HTMLElement
     expect(more).toBeTruthy()
     more.click()
 
-    expect(onMenuToggle).toHaveBeenCalledTimes(1)
+    expect(onToggleDrawer).toHaveBeenCalledTimes(1)
   })
 
-  it('guarantees a 44px minimum touch target on every interactive item', () => {
-    render(html`<${MobileBottomBar} currentTab="overview" onMenuToggle=${() => {}} />`, container)
+  it('hides mobile tabs while the drawer overlay is open', () => {
+    renderNav({ mobile: true, drawerOpen: true, collapsed: true })
 
-    const interactives = container.querySelectorAll('a, button')
-    expect(interactives.length).toBe(PRIMARY_LABELS.length + 1) // 4 surfaces + More
+    expect(container.querySelector('nav[aria-label="Primary mobile navigation"]')).toBeNull()
+    const rail = container.querySelector('[data-testid="dashboard-nav-rail"]')
+    expect(rail?.className).toContain('block')
+    expect(rail?.className).toContain('fixed')
+
+    const overlay = container.querySelector('[data-testid="dashboard-nav-rail-overlay"]') as HTMLElement | null
+    expect(overlay).not.toBeNull()
+    overlay!.click()
+    expect(onCloseDrawer).toHaveBeenCalledTimes(1)
+
+    expect(container.querySelector('.nb-sub')?.textContent).toContain('Cockpit')
+  })
+
+  it('keeps operational routes in the mobile More drawer', () => {
+    renderNav({ mobile: true, drawerOpen: true })
+
+    const railText = container.querySelector('[data-testid="dashboard-nav-rail"]')?.textContent ?? ''
+    expect(railText).toContain('Monitor')
+    expect(railText).toContain('Command')
+    expect(railText).toContain('Lab')
+    expect(railText).toContain('Logs')
+  })
+
+  it('does not render mobile tabs in desktop mode', () => {
+    renderNav({ mobile: false, drawerOpen: false, collapsed: true })
+
+    expect(container.querySelector('nav[aria-label="Primary mobile navigation"]')).toBeNull()
+    const rail = container.querySelector('[data-testid="dashboard-nav-rail"]')
+    expect(rail).not.toBeNull()
+    expect(rail?.className).toContain('w-14')
+    expect(rail?.className).toContain('max-[1100px]:hidden')
+  })
+
+  it('hides mobile tabs while reading keeper chat', () => {
+    renderNav({ mobile: true, drawerOpen: false, keeperDetailMode: true })
+
+    expect(container.querySelector('nav[aria-label="Primary mobile navigation"]')).toBeNull()
+    expect(container.querySelector('[data-testid="dashboard-nav-rail"]')).not.toBeNull()
+  })
+
+  it('guarantees a 44px minimum touch target on every mobile tab item', () => {
+    renderNav({ mobile: true })
+
+    const interactives = container.querySelectorAll('nav[aria-label="Primary mobile navigation"] a, nav[aria-label="Primary mobile navigation"] button')
+    expect(interactives.length).toBe(PRIMARY_LABELS.length + 1)
     for (const el of interactives) {
       expect(el.className).toContain('min-h-[44px]')
     }
   })
 
-  it('passes axe accessibility', async () => {
-    render(html`<${MobileBottomBar} currentTab="overview" onMenuToggle=${() => {}} />`, container)
+  it('passes axe accessibility for the closed mobile rail state', async () => {
+    renderNav({ mobile: true, drawerOpen: false })
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/dashboard/src/components/mobile-nav.ts
+++ b/dashboard/src/components/mobile-nav.ts
@@ -1,46 +1,103 @@
-// MobileBottomBar — 하단 고정 주요 서피스 탭 + ☰(전체 drawer 진입).
+// DashboardNavRail — responsive shell navigation rail.
 //
-// 모바일(<=768px)에서만 렌더. 엄지 도달 영역(하단)에 사용자 우선순위가 높은
-// 4개 서피스(overview·monitoring·command·workspace)를 노출해 한 손으로 빠른
-// 상태 파악·턴 제어 진입을 보장. 나머지 서피스(connectors·lab·code·logs)는
-// ☰ 버튼이 여는 overlay drawer(app.ts 의 mobileMenuOpen)로 접근.
-//
-// 터치 타겟: 각 항목 min-h-[44px] (Apple HIG / WCAG 2.5.5 권장 최소).
-// RouteLink 가 ring focus 를 자동 추가하므로 class 에 ring 을 넣지 않는다.
+// The keeper-v2 prototype uses one NavRail component whose CSS morphs from a
+// left rail into a mobile bottom tab bar at 900px. The dashboard still needs a
+// richer operational drawer for secondary sections, but one component now owns
+// the desktop rail, mobile drawer, and mobile tab strip instead of app.ts
+// stitching together separate navigation surfaces.
 
 import { html } from 'htm/preact'
+import { Fragment } from 'preact'
 import { Menu } from 'lucide-preact'
 import { RouteLink } from './common/route-link'
 import { SurfaceIcon } from './surface-icon'
-import { VISIBLE_DASHBOARD_NAV_ITEMS } from '../config/navigation'
+import { PRIMARY_DASHBOARD_NAV_ITEMS } from '../config/navigation'
 import { ringFocusClasses } from './common/ring'
+import { SideRail } from './dashboard-shell'
 import type { TabId } from '../types'
 
-// 하단 탭에 노출할 주요 서피스. 선택 기준 = 사용자 모바일 우선순위
-// (턴·폴링 제어 = command, 상태 모니터링 = monitoring/overview,
-//  작업 보드 = workspace). 이 4개는 모바일에서 80% 이상의 진입을 커버.
+// Keep the mobile bar aligned with the keeper-v2 prototype's primary surfaces:
+// Overview, Work, Keepers, and Board. Operational lanes remain in More.
 const MOBILE_PRIMARY_TAB_IDS: ReadonlyArray<TabId> = [
   'overview',
-  'monitoring',
-  'command',
   'workspace',
+  'keepers',
+  'board',
 ]
 
-const mobilePrimaryItems = VISIBLE_DASHBOARD_NAV_ITEMS.filter(item =>
-  MOBILE_PRIMARY_TAB_IDS.includes(item.id),
-)
+const mobilePrimaryItems = MOBILE_PRIMARY_TAB_IDS.flatMap(id => {
+  const item = PRIMARY_DASHBOARD_NAV_ITEMS.find(navItem => navItem.id === id)
+  return item ? [item] : []
+})
 
-interface MobileBottomBarProps {
+interface MobileNavRailTabsProps {
   currentTab: TabId
   onMenuToggle: () => void
 }
 
-export function MobileBottomBar({ currentTab, onMenuToggle }: MobileBottomBarProps) {
+interface DashboardNavRailProps {
+  currentTab: TabId
+  mobile: boolean
+  drawerOpen: boolean
+  keeperDetailMode: boolean
+  collapsed: boolean
+  onToggleCollapsed: () => void
+  onToggleDrawer: () => void
+  onCloseDrawer: () => void
+}
+
+export function DashboardNavRail({
+  currentTab,
+  mobile,
+  drawerOpen,
+  keeperDetailMode,
+  collapsed,
+  onToggleCollapsed,
+  onToggleDrawer,
+  onCloseDrawer,
+}: DashboardNavRailProps) {
+  const effectiveCollapsed = mobile ? false : collapsed
+  const sideRailWidthClass = mobile ? 'w-72' : (collapsed ? 'w-14' : 'w-55')
+  const sideRailResponsiveClass = mobile
+    ? drawerOpen
+      ? 'block fixed inset-y-0 left-0 z-50 m-0 max-h-none rounded-none border-r'
+      : 'hidden'
+    : 'max-[1100px]:hidden'
+
+  return html`
+    <${Fragment}>
+      ${drawerOpen && mobile ? html`
+        <button
+          type="button"
+          aria-label="Close navigation"
+          tabindex=${-1}
+          data-testid="dashboard-nav-rail-overlay"
+          class="fixed inset-0 z-40 cursor-pointer bg-black/50"
+          onClick=${onCloseDrawer}
+        ></button>
+      ` : null}
+      <aside
+        id="dashboard-side-rail"
+        aria-label="Sidebar navigation"
+        data-testid="dashboard-nav-rail"
+        class="v2-shell-rail ${sideRailWidthClass} shrink-0 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] ${sideRailResponsiveClass}"
+      >
+        <${SideRail} collapsed=${effectiveCollapsed} onToggle=${onToggleCollapsed} primaryOnly=${!mobile} />
+      </aside>
+      ${mobile && !drawerOpen && !keeperDetailMode
+        ? html`<${MobileNavRailTabs} currentTab=${currentTab} onMenuToggle=${onToggleDrawer} />`
+        : null}
+    <//>
+  `
+}
+
+function MobileNavRailTabs({ currentTab, onMenuToggle }: MobileNavRailTabsProps) {
   return html`
     <nav
-      class="v2-shell-surface hidden max-[768px]:flex fixed inset-x-0 bottom-0 z-40 items-stretch border-t border-[var(--color-border-strong)] bg-[var(--shell-header-bg)] backdrop-blur-xl"
+      class="v2-shell-surface v2-mobile-bottom-bar fixed inset-x-0 bottom-0 z-40 items-stretch border-t border-[var(--color-border-strong)] bg-[var(--shell-header-bg)] backdrop-blur-xl"
       style=${{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
       aria-label="Primary mobile navigation"
+      data-testid="dashboard-nav-rail-mobile-tabs"
     >
       ${mobilePrimaryItems.map(item => {
         const active = item.id === currentTab

--- a/dashboard/src/components/surface-icon.ts
+++ b/dashboard/src/components/surface-icon.ts
@@ -9,6 +9,8 @@ import {
   Plug,
   ScrollText,
   Settings,
+  SquareKanban,
+  UsersRound,
 } from 'lucide-preact'
 import type { DashboardSurfaceIcon } from '../config/navigation'
 
@@ -24,6 +26,10 @@ export function SurfaceIcon({ icon, size = 16 }: SurfaceIconProps) {
       return html`<${Home} ...${props} />`
     case 'monitoring':
       return html`<${Activity} ...${props} />`
+    case 'keepers':
+      return html`<${UsersRound} ...${props} />`
+    case 'board':
+      return html`<${SquareKanban} ...${props} />`
     case 'command':
       return html`<${Gauge} ...${props} />`
     case 'connectors':

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import {
   DASHBOARD_SURFACES,
+  PRIMARY_DASHBOARD_NAV_ITEMS,
+  PRIMARY_DASHBOARD_SURFACES,
   SECTION_REDIRECTS,
   VISIBLE_DASHBOARD_NAV_ITEMS,
   defaultParamsForTab,
+  isSectionlessSurface,
   normalizeRouteParams,
   sectionItemsForTab,
   visibleSectionItemsForTab,
@@ -18,12 +21,81 @@ describe('dashboard surface navigation', () => {
     expect(defaultParamsForTab('cockpit')).toEqual({})
     expect(VISIBLE_DASHBOARD_NAV_ITEMS.map(item => item.id)).not.toContain('cockpit')
   })
+
+  it('exposes Keepers as a top-level v2 workspace without nested sections', () => {
+    expect(defaultParamsForTab('keepers')).toEqual({})
+    expect(VISIBLE_DASHBOARD_NAV_ITEMS.map(item => item.id)).toContain('keepers')
+    expect(sectionItemsForTab('keepers')).toEqual([])
+    expect(visibleSectionItemsForTab('keepers')).toEqual([])
+
+    const result = normalizeRouteParams('keepers', { section: 'agents', keeper: 'sangsu', surface: 'old' })
+    expect(result).toEqual({ keeper: 'sangsu' })
+  })
+
+  it('exposes Board as a top-level v2 surface without workspace section baggage', () => {
+    expect(defaultParamsForTab('board')).toEqual({})
+    expect(VISIBLE_DASHBOARD_NAV_ITEMS.map(item => item.id)).toContain('board')
+    expect(sectionItemsForTab('board')).toEqual([])
+    expect(visibleSectionItemsForTab('board')).toEqual([])
+
+    const result = normalizeRouteParams('board', {
+      section: 'board',
+      post: 'post-1',
+      comment: 'comment-1',
+      focus: 'curation',
+      surface: 'old',
+    })
+    expect(result).toEqual({
+      post: 'post-1',
+      comment: 'comment-1',
+      focus: 'curation',
+    })
+  })
+
+  it('labels the workspace route as the v2 Work surface while preserving route compatibility', () => {
+    const workspace = DASHBOARD_SURFACES.find(surface => surface.id === 'workspace')
+
+    expect(workspace?.label).toBe('Work')
+    expect(defaultParamsForTab('workspace')).toEqual({ section: 'work' })
+    expect(workspace?.defaultTab).toBe('workspace')
+  })
+
+  it('keeps the v2 primary shell aligned to the prototype surface set', () => {
+    expect(PRIMARY_DASHBOARD_SURFACES.map(surface => surface.id)).toEqual([
+      'overview',
+      'workspace',
+      'keepers',
+      'board',
+      'code',
+      'connectors',
+      'settings',
+    ])
+    expect(PRIMARY_DASHBOARD_NAV_ITEMS.map(item => item.label)).toEqual([
+      'Overview',
+      'Work',
+      'Keepers',
+      'Board',
+      'IDE',
+      'Connectors',
+      'Settings',
+    ])
+  })
+
+  it('uses one sectionless-surface classifier for section stripping and section lookup', () => {
+    const sectionless = ['overview', 'logs', 'settings', 'keepers', 'board'] as const
+    expect(sectionless.filter(id => isSectionlessSurface(id))).toEqual([...sectionless])
+    expect(sectionItemsForTab('settings')).toEqual([])
+    expect(normalizeRouteParams('settings', { section: 'legacy', surface: 'old', panel: 'theme' })).toEqual({
+      panel: 'theme',
+    })
+  })
 })
 
 describe('code (IDE plane) navigation', () => {
   it('exposes the production IDE plane in the sidebar', () => {
     expect(defaultParamsForTab('code')).toEqual({ section: 'ide-shell' })
     expect(DASHBOARD_SURFACES.find(surface => surface.id === 'code')?.hidden).not.toBe(true)
+    expect(DASHBOARD_SURFACES.find(surface => surface.id === 'code')?.label).toBe('IDE')
 
     const visibleCodeSections = visibleSectionItemsForTab('code')
     const allCodeSections = sectionItemsForTab('code')
@@ -60,6 +132,9 @@ describe('lab navigation', () => {
       'Performance',
       'Memory Explore',
     ])
+    expect(labSections.find(item => item.id === 'performance')?.description).toBe(
+      'FPS meter, VirtualList, content-visibility, native dialog, and observer probes.',
+    )
   })
 })
 
@@ -218,11 +293,36 @@ describe('workspace navigation labels', () => {
     const labelFor = (id: string) => sections.find(item => item.id === id)?.label
 
     expect(labelFor('planning')).toBe('Plans & Goals')
-    expect(labelFor('moderation')).toBe('Moderation')
+    expect(labelFor('moderation')).toBeUndefined()
     // goals is no longer a standalone section
     const ids = sections.map(item => item.id)
     expect(ids).not.toContain('goals')
-    expect(ids).toContain('moderation')
+    expect(ids).not.toContain('moderation')
+  })
+
+  it('hides legacy board-family sections now that Board is top-level', () => {
+    const visibleIds = visibleSectionItemsForTab('workspace').map(item => item.id)
+    const allSections = sectionItemsForTab('workspace')
+    const hiddenIds = allSections.filter(item => item.hidden).map(item => item.id)
+
+    expect(visibleIds).toEqual([
+      'work',
+      'planning',
+      'repositories',
+      'verification',
+    ])
+    expect(hiddenIds).toEqual([
+      'board',
+      'sub-boards',
+      'moderation',
+    ])
+
+    expect(normalizeRouteParams('workspace', { section: 'board', post: 'post-1' })).toMatchObject({
+      section: 'board',
+      post: 'post-1',
+    })
+    expect(normalizeRouteParams('workspace', { section: 'sub-boards' }).section).toBe('sub-boards')
+    expect(normalizeRouteParams('workspace', { section: 'moderation' }).section).toBe('moderation')
   })
 })
 

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -4,6 +4,8 @@ type SurfaceId = TabId
 export type DashboardSurfaceIcon =
   | 'overview'
   | 'monitoring'
+  | 'keepers'
+  | 'board'
   | 'command'
   | 'connectors'
   | 'workspace'
@@ -76,6 +78,28 @@ export interface DashboardSectionNavItem {
   hidden?: boolean
 }
 
+const V2_PRIMARY_SURFACE_IDS: ReadonlyArray<SurfaceId> = [
+  'overview',
+  'workspace',
+  'keepers',
+  'board',
+  'code',
+  'connectors',
+  'settings',
+]
+
+const SECTIONLESS_SURFACE_IDS: ReadonlySet<TabId> = new Set([
+  'overview',
+  'logs',
+  'settings',
+  'keepers',
+  'board',
+])
+
+export function isSectionlessSurface(tabId: TabId): boolean {
+  return SECTIONLESS_SURFACE_IDS.has(tabId)
+}
+
 export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
   {
     id: 'cockpit',
@@ -105,6 +129,22 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     tabs: ['monitoring'],
   },
   {
+    id: 'keepers',
+    label: 'Keepers',
+    icon: 'keepers',
+    description: 'Dedicated keeper roster, conversation, and context workspace',
+    defaultTab: 'keepers',
+    tabs: ['keepers'],
+  },
+  {
+    id: 'board',
+    label: 'Board',
+    icon: 'board',
+    description: 'Human, agent, automation, and system posts',
+    defaultTab: 'board',
+    tabs: ['board'],
+  },
+  {
     id: 'command',
     label: 'Command',
     icon: 'command',
@@ -124,9 +164,9 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
   },
   {
     id: 'workspace',
-    label: 'Workspace',
+    label: 'Work',
     icon: 'workspace',
-    description: 'Work goals, board feed, planning, repositories, and verification',
+    description: 'Work goals, planning, repositories, and verification',
     defaultTab: 'workspace',
     defaultParams: { section: 'work' },
     tabs: ['workspace'],
@@ -142,7 +182,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
   },
   {
     id: 'code',
-    label: 'Code',
+    label: 'IDE',
     icon: 'code',
     description: 'Keeper collaboration IDE shell',
     defaultTab: 'code',
@@ -178,6 +218,18 @@ export const DASHBOARD_NAV_ITEMS: DashboardNavItem[] = DASHBOARD_SURFACES.map(su
 
 export const VISIBLE_DASHBOARD_NAV_ITEMS: DashboardNavItem[] =
   DASHBOARD_NAV_ITEMS.filter(item => item.hidden !== true)
+
+export const PRIMARY_DASHBOARD_SURFACES: DashboardNavGroup[] =
+  V2_PRIMARY_SURFACE_IDS.flatMap(id => {
+    const surface = DASHBOARD_SURFACES.find(item => item.id === id && item.hidden !== true)
+    return surface ? [surface] : []
+  })
+
+export const PRIMARY_DASHBOARD_NAV_ITEMS: DashboardNavItem[] =
+  V2_PRIMARY_SURFACE_IDS.flatMap(id => {
+    const item = DASHBOARD_NAV_ITEMS.find(navItem => navItem.id === id && navItem.hidden !== true)
+    return item ? [item] : []
+  })
 
 export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavItem[]> = {
   cockpit: [],
@@ -244,6 +296,8 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       // promotion was reverted by #16977 (Improve dashboard monitor IA).
     },
   ],
+  keepers: [],
+  board: [],
   command: [
     {
       id: 'operations',
@@ -272,18 +326,21 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'Board',
       description: 'Human, agent, automation, and system posts.',
       params: { section: 'board' },
+      hidden: true,
     },
     {
       id: 'sub-boards',
       label: 'Sub-Boards',
       description: 'Named spaces within the board with distinct access policies.',
       params: { section: 'sub-boards' },
+      hidden: true,
     },
     {
       id: 'moderation',
       label: 'Moderation',
       description: 'Flagged board posts and moderation actions.',
       params: { section: 'moderation' },
+      hidden: true,
     },
     {
       id: 'planning',
@@ -326,7 +383,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'performance',
       label: 'Performance',
-      description: 'FPS meter and VirtualList windowing demo.',
+      description: 'FPS meter, VirtualList, content-visibility, native dialog, and observer probes.',
       params: { section: 'performance' },
     },
     {
@@ -356,7 +413,7 @@ export function defaultParamsForTab(tabId: TabId): Record<string, string> {
 }
 
 export function sectionItemsForTab(tabId: TabId): DashboardSectionNavItem[] {
-  if (tabId === 'overview' || tabId === 'logs' || tabId === 'settings') return []
+  if (isSectionlessSurface(tabId)) return []
   return DASHBOARD_SECTION_ITEMS[tabId as NonHomeTabId]
 }
 
@@ -422,7 +479,7 @@ export function normalizeRouteParams(tabId: TabId, params: Record<string, string
   const next = { ...params }
   const legacyObservatoryRanges = new Set(['1h', '6h', '24h', '7d'])
 
-  if (tabId === 'overview' || tabId === 'logs' || tabId === 'settings') {
+  if (isSectionlessSurface(tabId)) {
     delete next.section
     delete next.surface
     return next
@@ -484,7 +541,7 @@ export function normalizeRouteParams(tabId: TabId, params: Record<string, string
 }
 
 export function currentSectionForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): DashboardSectionNavItem | null {
-  if (routeState.tab === 'overview' || routeState.tab === 'logs') return null
+  if (isSectionlessSurface(routeState.tab)) return null
   const normalized = normalizeRouteParams(routeState.tab, routeState.params)
   return sectionItemsForTab(routeState.tab).find(item => item.params.section === normalized.section) ?? null
 }

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -180,9 +180,11 @@ describe('dashboardSlicesForRoute', () => {
   it('only subscribes slices from the shared push vocabulary', () => {
     const routes = [
       { tab: 'overview', params: {} },
+      { tab: 'board', params: {} },
       { tab: 'workspace', params: { section: 'planning' } },
       { tab: 'workspace', params: { section: 'board' } },
       { tab: 'monitoring', params: { section: 'agents' } },
+      { tab: 'keepers', params: { keeper: 'sangsu' } },
       { tab: 'monitoring', params: { section: 'cognition' } },
       { tab: 'monitoring', params: { section: 'fleet-health', view: 'comparison' } },
       { tab: 'command', params: {} },
@@ -218,6 +220,12 @@ describe('dashboardSlicesForRoute', () => {
   })
 
   it('keeps board route snapshots HTTP-owned while subscribing goals and fleet FSM slices', () => {
+    expect(dashboardSlicesForRoute({ tab: 'board', params: {} }))
+      .toEqual([
+        'namespace',
+        'shell',
+        'transport',
+      ])
     expect(dashboardSlicesForRoute({ tab: 'workspace', params: { section: 'board' } }))
       .toEqual([
         'namespace',
@@ -228,6 +236,14 @@ describe('dashboardSlicesForRoute', () => {
       .toContain('goals')
     expect(dashboardSlicesForRoute({ tab: 'monitoring', params: { section: 'agents' } }))
       .toContain('composite')
+    expect(dashboardSlicesForRoute({ tab: 'keepers', params: { keeper: 'sangsu' } }))
+      .toEqual([
+        'composite',
+        'execution',
+        'namespace',
+        'shell',
+        'transport',
+      ])
     expect(dashboardSlicesForRoute({ tab: 'monitoring', params: { section: 'cognition' } }))
       .toContain('composite')
   })

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -241,6 +241,13 @@ export function dashboardSlicesForRoute(routeState: DashboardRouteState): string
   if (routeState.tab === 'overview') {
     slices.add('execution')
   }
+  if (routeState.tab === 'keepers') {
+    slices.add('execution')
+    slices.add('composite')
+  }
+  if (routeState.tab === 'board') {
+    return Array.from(slices).sort()
+  }
   if (routeState.tab === 'workspace' && routeState.params.section === 'planning') {
     slices.add('execution')
     slices.add('goals')

--- a/dashboard/src/hooks/use-is-mobile.test.ts
+++ b/dashboard/src/hooks/use-is-mobile.test.ts
@@ -23,8 +23,8 @@ describe('useIsMobile', () => {
     container.remove()
   })
 
-  it('returns true when viewport width is at the default 760px breakpoint', () => {
-    window.innerWidth = 760
+  it('returns true when viewport width is at the default 900px breakpoint', () => {
+    window.innerWidth = 900
     render(html`<${TestHarness} />`, container)
 
     const result = container.querySelector('[data-testid="result"]')
@@ -32,7 +32,7 @@ describe('useIsMobile', () => {
   })
 
   it('returns false when viewport width is above the default breakpoint', () => {
-    window.innerWidth = 1024
+    window.innerWidth = 901
     render(html`<${TestHarness} />`, container)
 
     const result = container.querySelector('[data-testid="result"]')

--- a/dashboard/src/hooks/use-is-mobile.ts
+++ b/dashboard/src/hooks/use-is-mobile.ts
@@ -3,19 +3,21 @@ import { useEffect, useState } from 'preact/hooks'
 export interface UseIsMobileOptions {
   /**
    * Viewport width threshold in pixels. Widths at or below this value are
-   * considered mobile. Defaults to 760px to align with the dashboard's
-   * mobile chrome breakpoint.
+   * considered mobile. Defaults to 900px to align with the keeper-v2 shell
+   * rail/bottom-tab breakpoint.
    */
   breakpoint?: number
 }
 
+export const DEFAULT_MOBILE_BREAKPOINT = 900
+
 /**
  * Tracks whether the viewport width is at or below the given breakpoint.
- * Defaults to 760px. Safe to call in SSR / test environments where
-   * `window` may be undefined.
+ * Defaults to 900px. Safe to call in SSR / test environments where
+ * `window` may be undefined.
  */
 export function useIsMobile(options: UseIsMobileOptions = {}): boolean {
-  const { breakpoint = 760 } = options
+  const { breakpoint = DEFAULT_MOBILE_BREAKPOINT } = options
 
   const [isMobile, setIsMobile] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false

--- a/dashboard/src/lib/mention-utils.ts
+++ b/dashboard/src/lib/mention-utils.ts
@@ -28,6 +28,11 @@ export function trailingMentionNameFromMessage(message: string): string | null {
   return match?.[1] ?? null
 }
 
+export function firstMentionNameFromMessage(message: string): string | null {
+  const match = message.match(/(?:^|\s)@([A-Za-z0-9_.-]+)/)
+  return match?.[1] ?? null
+}
+
 export function onlineKeeperNameForMention(onlineKeepers: OnlineKeeper[], mentionName: string | null): string | null {
   if (!mentionName) return null
   const normalized = mentionName.toLowerCase()

--- a/dashboard/src/refresh-scope.test.ts
+++ b/dashboard/src/refresh-scope.test.ts
@@ -18,6 +18,7 @@ describe('routeWantsRefreshTarget', () => {
 
   it('matches execution-backed routes without broadening fleet-health defaults', () => {
     expect(routeWantsRefreshTarget(route('monitoring', { section: 'agents' }), 'execution')).toBe(true)
+    expect(routeWantsRefreshTarget(route('keepers', { keeper: 'sangsu' }), 'execution')).toBe(true)
     expect(routeWantsRefreshTarget(route('monitoring', { section: 'cognition' }), 'execution')).toBe(true)
     expect(routeWantsRefreshTarget(route('monitoring', { section: 'journey' }), 'execution')).toBe(true)
     expect(routeWantsRefreshTarget(route('monitoring', { section: 'observatory' }), 'execution')).toBe(false)
@@ -30,6 +31,7 @@ describe('routeWantsRefreshTarget', () => {
   it('keeps operator, board, and activity refreshes scoped to their visible surfaces', () => {
     expect(routeWantsRefreshTarget(route('command'), 'operator')).toBe(true)
     expect(routeWantsRefreshTarget(route('command', { view: 'inspector' }), 'operator')).toBe(false)
+    expect(routeWantsRefreshTarget(route('board'), 'board')).toBe(true)
     expect(routeWantsRefreshTarget(route('workspace', { section: 'board' }), 'board')).toBe(true)
     expect(routeWantsRefreshTarget(route('monitoring', { section: 'observatory' }), 'activity')).toBe(true)
     expect(routeWantsRefreshTarget(route('monitoring', { section: 'observatory', view: 'activity' }), 'activity')).toBe(true)

--- a/dashboard/src/refresh-scope.ts
+++ b/dashboard/src/refresh-scope.ts
@@ -10,7 +10,7 @@ export function routeWantsRefreshTarget(
     case 'execution':
       return routeWantsExecution(routeState)
     case 'board':
-      return routeState.tab === 'workspace' && routeState.params.section === 'board'
+      return routeState.tab === 'board' || (routeState.tab === 'workspace' && routeState.params.section === 'board')
     case 'operator':
       return routeState.tab === 'command' && routeState.params.view !== 'inspector'
     case 'activity':
@@ -19,6 +19,8 @@ export function routeWantsRefreshTarget(
 }
 
 function routeWantsExecution(routeState: Pick<RouteState, 'tab' | 'params'>): boolean {
+  if (routeState.tab === 'keepers') return true
+
   if (routeState.tab === 'workspace') {
     return routeState.params.section === 'planning'
   }

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
   navigate,
+  navigateToPost,
   replaceRoute,
   route,
   hashForRoute,
@@ -25,6 +26,32 @@ describe('navigate', () => {
     navigate('workspace', { section: 'board' })
     expect(route.value.tab).toBe('workspace')
     expect(route.value.params.section).toBe('board')
+  })
+
+  it('navigates to top-level keepers without monitor section baggage', () => {
+    navigate('keepers', { section: 'agents', keeper: 'sangsu' })
+    expect(route.value.tab).toBe('keepers')
+    expect(route.value.params).toEqual({ keeper: 'sangsu' })
+    expect(window.location.hash).toBe('#keepers?keeper=sangsu')
+  })
+
+  it('navigates to top-level board without workspace section baggage', () => {
+    navigate('board', { section: 'board', post: 'post-1', comment: 'comment-1' })
+    expect(route.value.tab).toBe('board')
+    expect(route.value.params).toEqual({ post: 'post-1', comment: 'comment-1' })
+    expect(window.location.hash).toBe('#board?post=post-1&comment=comment-1')
+  })
+
+  it('keeps workspace board deep links routeable for compatibility', () => {
+    navigate('workspace', { section: 'board', post: 'post-1' })
+    expect(route.value.tab).toBe('workspace')
+    expect(route.value.params).toEqual({ section: 'board', post: 'post-1' })
+    expect(window.location.hash).toBe('#workspace?section=board&post=post-1')
+  })
+
+  it('opens board posts on the top-level board surface', () => {
+    navigateToPost('post 1')
+    expect(window.location.hash).toBe('#board?post=post%201')
   })
 
   it('redirects removed operations params to operations', () => {

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -279,7 +279,7 @@ export function replaceRoute(tab: TabId, params?: Record<string, string>): void 
 }
 
 export function navigateToPost(postId: string): void {
-  window.location.hash = `#workspace?section=board&post=${encodeURIComponent(postId)}`
+  window.location.hash = `#board?post=${encodeURIComponent(postId)}`
 }
 
 export function initRouter(): void {

--- a/dashboard/src/styles/app-shell-v2.css
+++ b/dashboard/src/styles/app-shell-v2.css
@@ -350,8 +350,32 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 900px) {
+  .v2-app #dashboard-side-rail.v2-shell-rail {
+    height: 100vh;
+    max-height: none;
+  }
+
+  .v2-app .v2-shell-tabs,
+  .v2-app .v2-desktop-header-only {
+    display: none;
+  }
+
+  .v2-app .v2-mobile-bottom-bar {
+    display: flex;
+  }
+
+  .v2-app .dashboard-main-scroll {
+    padding-bottom: 4rem;
+  }
+
   .v2-app .v2-header-actions .v2-statchip {
+    display: none;
+  }
+}
+
+@media (min-width: 901px) {
+  .v2-app .v2-mobile-bottom-bar {
     display: none;
   }
 }

--- a/dashboard/src/styles/board-v2.css
+++ b/dashboard/src/styles/board-v2.css
@@ -818,7 +818,7 @@
     top: 0;
     right: 0;
     bottom: 0;
-    z-index: 30;
+    z-index: var(--z-dropdown);
     display: flex;
     width: min(420px, 100%);
     border-left: 1px solid var(--border-main);

--- a/dashboard/src/styles/board-v2.css
+++ b/dashboard/src/styles/board-v2.css
@@ -3,23 +3,43 @@
    Token bridge lives in variables.css. */
 
 /* ════ SHELL ════ */
+.v2-app .dashboard-main-scroll:has(.v2-board-surface) {
+  overflow: hidden;
+}
+
+.v2-app .v2-surface:has(.v2-board-surface) {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.v2-app .v2-surface:has(.v2-board-surface) > .animate-in:has(> .v2-board-surface) {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .v2-board-surface {
+  position: relative;
+  flex: 1;
   display: flex;
   flex-direction: column;
   min-width: 0;
   min-height: 0;
+  height: 100%;
+  overflow: hidden;
   background: var(--bg-deep);
 }
 
 .v2-board-surface .bd-body {
   flex: 1;
+  height: 100%;
   min-height: 0;
   display: grid;
   grid-template-columns: 200px minmax(0, 1fr) minmax(290px, 360px);
-}
-
-.v2-board-surface .bd-body.no-detail {
-  grid-template-columns: 200px minmax(0, 1fr);
+  overflow: hidden;
 }
 
 /* ════ LEFT RAIL (sub-boards + queues) ════ */
@@ -113,6 +133,7 @@
   flex-direction: column;
   min-width: 0;
   min-height: 0;
+  overflow: hidden;
 }
 
 .v2-board-surface .bd-feed-head {
@@ -173,11 +194,16 @@
 
 .v2-board-surface .bd-list {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 14px 18px;
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+
+.v2-board-surface .bd-list > * {
+  flex: none;
 }
 
 .v2-board-surface .bd-list::-webkit-scrollbar {
@@ -272,6 +298,7 @@
   color: var(--text-mid);
   line-height: 1.55;
   margin-top: 5px;
+  max-height: 5.2rem;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -382,6 +409,14 @@
   padding: 10px 18px 14px;
 }
 
+.v2-board-surface .bd-composer-mobile-summary {
+  display: none;
+}
+
+.v2-board-surface .bd-composer-fields {
+  display: block;
+}
+
 .v2-board-surface .bd-comp-tabs {
   display: flex;
   gap: 4px;
@@ -417,9 +452,80 @@
   padding: 5px 5px 5px 13px;
 }
 
+.v2-board-surface .bd-comp-box.grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: stretch;
+}
+
+.v2-board-surface .bd-mobile-quick-compose {
+  display: none;
+}
+
+.v2-board-surface .bd-mobile-mention-targets {
+  display: none;
+}
+
+.v2-board-surface .bd-mobile-mention-listbox {
+  display: none;
+}
+
+.v2-board-surface .bd-mobile-draft-tray,
+.v2-board-surface .bd-mobile-rec-bar {
+  display: none;
+}
+
+.v2-board-surface .bd-mobile-state-template,
+.v2-board-surface .bd-mobile-compose-tool {
+  flex: none;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-main);
+  background: color-mix(in srgb, var(--bg-panel) 76%, var(--volt-wash));
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: 0.13s;
+}
+
+.v2-board-surface .bd-mobile-state-template:not(:disabled):hover,
+.v2-board-surface .bd-mobile-compose-tool:not(:disabled):hover {
+  border-color: var(--volt-dim);
+  color: var(--volt-strong);
+  background: var(--volt-wash);
+}
+
+.v2-board-surface .bd-mobile-state-template:disabled,
+.v2-board-surface .bd-mobile-compose-tool:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .v2-board-surface .bd-comp-box:focus-within {
   border-color: var(--volt-dim);
   box-shadow: 0 0 0 3px var(--volt-wash);
+}
+
+.v2-board-surface .bd-comp-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.v2-board-surface .bd-comp-meta > * {
+  min-width: 0;
+}
+
+.v2-board-surface .bd-comp-meta > :not(.send) {
+  flex: 0 1 10rem;
+}
+
+.v2-board-surface .bd-comp-meta .send {
+  margin-left: auto;
 }
 
 .v2-board-surface .bd-comp-box textarea {
@@ -507,6 +613,10 @@
 .v2-board-surface .bd-detail-x:hover {
   color: var(--text-bright);
   background: var(--bg-card);
+}
+
+.v2-board-surface .bd-detail-mobile-close {
+  display: none;
 }
 
 .v2-board-surface .bd-detail-scroll {
@@ -643,6 +753,47 @@
   border-color: var(--volt-dim);
 }
 
+.v2-board-surface .bd-mobile-queues {
+  display: none;
+}
+
+.v2-board-surface .bd-mobile-queue {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--text-mid);
+  padding: 7px 10px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  cursor: pointer;
+  transition: 0.13s;
+}
+
+.v2-board-surface .bd-mobile-queue .glyph {
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+
+.v2-board-surface .bd-mobile-queue .n {
+  margin-left: auto;
+  min-width: 1.5rem;
+  text-align: right;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.v2-board-surface .bd-mobile-queue.on,
+.v2-board-surface .bd-mobile-queue:hover {
+  border-color: var(--volt-dim);
+  color: var(--text-bright);
+  background: var(--volt-wash);
+}
+
 /* ════ EMPTY / HINT ════ */
 .v2-board-surface .bd-empty {
   padding: 26px 0;
@@ -660,6 +811,23 @@
   .v2-board-surface .bd-detail {
     display: none;
   }
+
+  .v2-board-surface .bd-detail.has-post,
+  .v2-board-surface .bd-detail.is-mentions.is-mobile-open {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 30;
+    display: flex;
+    width: min(420px, 100%);
+    border-left: 1px solid var(--border-main);
+    box-shadow: -22px 0 44px rgba(0, 0, 0, 0.42);
+  }
+
+  .v2-board-surface .bd-detail.is-mentions.is-mobile-open .bd-detail-mobile-close {
+    display: inline-flex;
+  }
 }
 
 @media (max-width: 900px) {
@@ -669,5 +837,298 @@
 
   .v2-board-surface .bd-rail {
     display: none;
+  }
+
+  .v2-board-surface .bd-detail.has-post,
+  .v2-board-surface .bd-detail.is-mentions.is-mobile-open {
+    left: 0;
+    width: 100%;
+    border-left: 0;
+  }
+
+  .v2-board-surface .bd-mobile-queues {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    padding: 0 12px 10px;
+  }
+}
+
+@media (max-width: 520px) {
+  .v2-board-surface .bd-feed-head {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .v2-board-surface .bd-feed-head .spacer {
+    display: none;
+  }
+
+  .v2-board-surface .bd-list {
+    padding: 10px 10px;
+  }
+
+  .v2-board-surface .bd-composer {
+    padding: 8px 10px 10px;
+  }
+
+  .v2-board-surface .bd-composer-mobile-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 42px;
+    padding: 6px 8px 6px 10px;
+    border: 1px solid var(--border-main);
+    border-radius: var(--radius-md);
+    background: var(--bg-card);
+  }
+
+  .v2-board-surface .bd-composer-mobile-copy {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    gap: 1px;
+  }
+
+  .v2-board-surface .bd-composer-mobile-kicker {
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    line-height: 1.2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .v2-board-surface .bd-composer-mobile-title {
+    color: var(--text-bright);
+    font-family: var(--font-ui);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.25;
+  }
+
+  .v2-board-surface .bd-composer-mobile-toggle {
+    flex: none;
+    min-width: 58px;
+    min-height: 30px;
+    padding: 5px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--volt-dim);
+    background: var(--volt-wash);
+    color: var(--volt-strong);
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .v2-board-surface .bd-composer[data-mobile-open="false"] .bd-composer-fields {
+    display: none;
+  }
+
+  .v2-board-surface .bd-composer[data-mobile-open="true"] .bd-composer-fields {
+    display: block;
+    margin-top: 8px;
+  }
+
+  .v2-board-surface .bd-mobile-quick-compose {
+    display: flex;
+  }
+
+  .v2-board-surface .bd-mobile-mention-targets {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    margin: 0 0 6px;
+  }
+
+  .v2-board-surface .bd-mobile-mention-icon {
+    flex: none;
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-main);
+    background: color-mix(in srgb, var(--bg-panel) 78%, var(--bg-card));
+    color: var(--volt-strong);
+  }
+
+  .v2-board-surface .bd-mobile-mention-select {
+    flex: 1 1 8rem;
+    min-width: 0;
+    height: 30px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-main);
+    background: var(--bg-card);
+    color: var(--text-bright);
+    font-family: var(--font-ui);
+    font-size: 12px;
+    font-weight: 600;
+    padding: 0 8px;
+    outline: 0;
+  }
+
+  .v2-board-surface .bd-mobile-mention-current {
+    flex: 0 1 auto;
+    max-width: 8.5rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 10px;
+  }
+
+  .v2-board-surface .bd-mobile-mention-listbox {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+    margin: -1px 0 6px;
+    padding: 4px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-main);
+    background: color-mix(in srgb, var(--bg-card) 88%, var(--bg-panel));
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
+  }
+
+  .v2-board-surface .bd-mobile-mention-option {
+    width: 100%;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    padding: 7px 8px;
+    border: 0;
+    border-left: 2px solid transparent;
+    border-radius: calc(var(--radius-sm) - 2px);
+    background: transparent;
+    color: var(--text-mid);
+    font-family: var(--font-ui);
+    font-size: 11px;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .v2-board-surface .bd-mobile-mention-option.on,
+  .v2-board-surface .bd-mobile-mention-option:not(:disabled):hover {
+    border-left-color: var(--volt);
+    background: var(--bg-elevated);
+    color: var(--text-bright);
+  }
+
+  .v2-board-surface .bd-mobile-mention-option:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  .v2-board-surface .bd-mobile-mention-option-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--volt-strong);
+    font-family: var(--font-mono);
+    font-size: 11px;
+  }
+
+  .v2-board-surface .bd-mobile-mention-option-status {
+    flex: none;
+    margin-left: auto;
+    max-width: 6.5rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 9px;
+    text-transform: uppercase;
+  }
+
+  .v2-board-surface .bd-mobile-mention-empty {
+    padding: 7px 8px;
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 10px;
+  }
+
+  .v2-board-surface .bd-mobile-draft-tray {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+    min-width: 0;
+    margin: 0 0 6px;
+  }
+
+  .v2-board-surface .bd-mobile-draft-tray .cdraft {
+    flex: 1 1 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .v2-board-surface .bd-mobile-draft-tray .cdraft.att {
+    max-width: 100%;
+  }
+
+  .v2-board-surface .bd-mobile-draft-tray .cdraft-name {
+    max-width: 13rem;
+  }
+
+  .v2-board-surface .bd-mobile-draft-tray .cdraft.voice {
+    max-width: 100%;
+  }
+
+  .v2-board-surface .bd-mobile-draft-tray .cdraft-wave {
+    min-width: 54px;
+  }
+
+  .v2-board-surface .bd-mobile-draft-tray .cdraft-tx {
+    min-width: 0;
+  }
+
+  .v2-board-surface .bd-mobile-rec-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    margin: 0 0 6px;
+    padding: 6px 7px 6px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-main);
+    background: color-mix(in srgb, var(--bg-card) 90%, var(--volt-wash));
+  }
+
+  .v2-board-surface .bd-mobile-rec-bar .rec-wave {
+    flex: 1 1 auto;
+    min-width: 42px;
+  }
+
+  .v2-board-surface .bd-mobile-quick-compose textarea {
+    font-size: 16px;
+    min-height: 32px;
+    min-width: 0;
+  }
+
+  .v2-board-surface .bd-comp-box.bd-desktop-post-form,
+  .v2-board-surface .bd-comp-box.bd-desktop-composer-v2 {
+    display: none;
+  }
+
+  .v2-board-surface .bd-comp-meta {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .v2-board-surface .bd-comp-meta > :not(.send) {
+    flex: 1 1 8.5rem;
+  }
+
+  .v2-board-surface .bd-comp-meta .send {
+    flex: 0 0 auto;
+    margin-left: 0 !important;
   }
 }

--- a/dashboard/src/styles/copilot-dock.css
+++ b/dashboard/src/styles/copilot-dock.css
@@ -193,3 +193,13 @@
 @media (max-width: 860px) {
   .dock.docked { position: fixed; right: 0; top: 50px; bottom: 0; width: 320px; z-index: 60; box-shadow: var(--shadow-pop); }
 }
+
+@media (max-width: 900px) {
+  .v2-app[data-mobile="true"] .dock-fab {
+    bottom: calc(68px + env(safe-area-inset-bottom, 0px));
+  }
+
+  .v2-app[data-mobile="true"][data-keeper-detail-mode="true"] .dock-fab {
+    bottom: 22px;
+  }
+}

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -255,7 +255,7 @@
 }
 .kw-kp-menu {
   position: absolute;
-  z-index: 80;
+  z-index: var(--z-modal);
   min-width: 190px;
   padding: 5px;
   border: 1px solid var(--color-border-strong);
@@ -432,7 +432,7 @@
 }
 .kw-chat-command-popover {
   position: absolute;
-  z-index: 80;
+  z-index: var(--z-modal);
   top: calc(100% + 8px);
   right: 0;
   display: flex;
@@ -497,7 +497,7 @@
 .kw-mobile-rail-overlay {
   position: fixed;
   inset: 0;
-  z-index: 60;
+  z-index: var(--z-drawer);
   display: flex;
   justify-content: flex-end;
   background: rgb(0 0 0 / 0.38);

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -52,9 +52,12 @@
     var(--kw-rail-w, 312px);
   height: 100%;
   min-height: 0;
+  position: relative;
   background: var(--color-bg-page);
   color: var(--color-fg-primary);
 }
+.kw-grid[data-roster="mini"] { --kw-roster-w: 64px; }
+.kw-grid[data-rail="closed"] { --kw-rail-w: 0px; }
 
 /* Detail ("상세 보기") takes over the conversation + rail span as a
  * single scrollable column; roster stays for keeper switching. */
@@ -63,26 +66,57 @@
 @media (max-width: 1180px) {
   .kw-grid { grid-template-columns: var(--kw-roster-w, 248px) minmax(0, 1fr); }
   .kw-grid .kw-rail { display: none; }
+  .kw-rail-toggle.right { display: none; }
 }
-/* Below 860px the rail is already gone and roster + conversation can no longer
- * sit side by side. Rather than stacking both in one column (which halves the
- * grid height — the conversation collapses to ~half a screen behind the full
- * roster), switch to a single visible pane driven by `data-mobile-pane`
- * (keeperMobilePane signal). The hidden pane is removed from the grid so the
- * visible one stretches to the full grid height. Roster row select → 'chat';
- * the chat header "← 키퍼" back button → 'roster'. */
+/* Below 860px the workspace becomes master-detail: the roster and chat/detail
+ * panes share one grid column, and JS flips data-mobile-pane after selection.
+ * The attribute is backed by keeperMobilePane so direct routes and roster
+ * selection use the same pane switcher. */
 @media (max-width: 860px) {
-  .kw-grid { grid-template-columns: minmax(0, 1fr); }
-  .kw-grid[data-mobile-pane="chat"] > .kw-roster { display: none; }
-  .kw-grid[data-mobile-pane="roster"] > .kw-chat,
-  .kw-grid[data-mobile-pane="roster"] > .kw-detail { display: none; }
+  .kw-grid { grid-template-columns: minmax(0, 1fr); overflow: hidden; }
+  .kw-grid[data-mobile-pane] { grid-template-rows: minmax(0, 1fr); }
+  .kw-grid[data-mobile-pane="roster"] .kw-chat,
+  .kw-grid[data-mobile-pane="roster"] .kw-detail {
+    display: none;
+  }
+  .kw-grid[data-mobile-pane="chat"] .kw-roster {
+    display: none;
+  }
+  .kw-grid[data-mobile-pane="roster"] .kw-roster,
+  .kw-grid[data-mobile-pane="chat"] .kw-chat,
+  .kw-grid[data-mobile-pane="chat"] .kw-detail {
+    min-height: 0;
+    height: 100%;
+  }
+  .kw-rail-toggle { display: none; }
+  .kw-roster { border-right: 0; border-bottom: 0; }
+  .kw-chat-head { flex-wrap: wrap; align-items: flex-start; min-width: 0; padding: 12px 14px; }
+  .kw-chat-id { flex: 1 1 132px; }
+  .kw-chat-actions {
+    display: flex;
+    flex: none;
+    align-items: center;
+    justify-content: flex-end;
+    min-width: 0;
+    margin-left: auto;
+  }
+  .kw-act { padding: 6px 10px; }
+  .kw-thread-inner .chat-transcript {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+  .kw-composer-inner { padding: 0 16px; }
+  .kw-chat-toolbar { padding: 6px 16px; }
+  .kw-detail-scroll { padding: 14px; }
 }
 
 /* ════ ROSTER (left) ════════════════════════════════════════════ */
 .kw-roster {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-height: 0;
+  overflow: visible;
   border-right: 1px solid var(--color-border-default);
   background: var(--color-bg-panel-alt);
 }
@@ -115,10 +149,11 @@
    the right of the filter chips; pill control with the same resting/hover/focus
    treatment as the search field and filter chips. */
 .kw-roster-sort {
+  min-width: 78px;
   margin-left: auto;
   font-size: var(--fs-11); letter-spacing: 0.04em;
-  padding: 4px 7px; border-radius: var(--radius-pill); cursor: pointer;
-  border: 1px solid var(--color-border-default); background: transparent; color: var(--color-fg-secondary);
+  padding: 4px 8px; border-radius: var(--radius-pill); cursor: pointer;
+  border: 1px solid var(--color-border-default); background: var(--color-bg-surface); color: var(--color-fg-secondary);
   transition: color .15s, border-color .15s, background .15s; outline: none;
 }
 .kw-roster-sort:hover { color: var(--color-fg-primary); border-color: var(--color-border-strong); }
@@ -126,11 +161,28 @@
 .kw-roster-sort option { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
 
 .kw-roster-list { flex: 1; overflow-y: auto; padding: 9px 8px; }
+.kw-roster-mini-list { display: flex; flex: 1; flex-direction: column; align-items: center; gap: 8px; overflow-y: auto; padding: 12px 8px; }
 .kw-roster-group {
   font-size: var(--fs-11); font-weight: var(--fw-bold); letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-fg-secondary);
   padding: 12px 8px 6px;
 }
 .kw-roster-empty { padding: 30px 12px; text-align: center; color: var(--color-fg-secondary); font-size: var(--fs-13); }
+
+.kw-kp-mini {
+  position: relative;
+  display: inline-flex;
+  width: 46px;
+  height: 46px;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--r-2);
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+}
+.kw-kp-mini:hover { background: var(--color-bg-surface); border-color: var(--color-border-default); }
+.kw-kp-mini[aria-current="true"] { background: var(--color-bg-surface); border-color: var(--color-accent-fg-dim); box-shadow: inset 0 0 0 1px var(--accent-10); }
+.kw-kp-mini .kw-dot { position: absolute; right: 5px; bottom: 5px; }
 
 .kw-kp-row {
   display: grid; grid-template-columns: 40px 1fr auto; gap: 10px; align-items: start;
@@ -144,12 +196,18 @@
   transition: background .14s, border-color .14s;
   position: relative;
 }
+.kw-kp-row:focus-visible { outline: 2px solid var(--color-accent-fg-dim); outline-offset: 2px; }
 .kw-kp-row:hover { background: var(--color-bg-surface); border-color: var(--color-border-default); }
 .kw-kp-row[aria-current="true"] { background: var(--color-bg-surface); border-color: var(--color-accent-fg-dim); box-shadow: inset 0 0 0 1px var(--accent-10); }
 .kw-kp-row[aria-current="true"]::before {
   content: ""; position: absolute; left: -8px; top: 9px; bottom: 9px; width: 3px;
   background: var(--color-accent-fg); border-radius: 0 3px 3px 0;
   box-shadow: 0 0 10px rgb(var(--color-accent-glow) / 0.6);
+}
+.kw-kp-row:hover .kw-kp-right,
+.kw-kp-row:focus-within .kw-kp-right {
+  opacity: 0;
+  pointer-events: none;
 }
 .kw-kp-meta { min-width: 0; }
 .kw-kp-name { font-weight: var(--fw-bold); font-size: 15px; color: var(--color-fg-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -165,6 +223,97 @@
   color: var(--color-status-err);
   background: rgb(var(--color-status-err-glow) / 0.16);
   border: 1px solid rgb(var(--color-status-err-glow) / 0.35);
+}
+.kw-kp-more {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  z-index: 2;
+  display: inline-flex;
+  width: 26px;
+  height: 26px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transform: translateY(-50%);
+  opacity: 0;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-panel-alt);
+  color: var(--color-fg-secondary);
+  cursor: pointer;
+  transition: opacity .14s, color .15s, border-color .15s, background .15s;
+}
+.kw-kp-row:hover .kw-kp-more,
+.kw-kp-row:focus-within .kw-kp-more {
+  opacity: 1;
+}
+.kw-kp-more:hover {
+  color: var(--color-accent-fg);
+  border-color: var(--color-accent-fg-dim);
+  background: var(--color-bg-surface);
+}
+.kw-kp-menu {
+  position: absolute;
+  z-index: 80;
+  min-width: 190px;
+  padding: 5px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--r-2);
+  background: var(--color-bg-panel-alt);
+  box-shadow: var(--shadow-raised);
+}
+.kw-kp-menu-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 9px 8px;
+  border-bottom: 1px solid var(--color-border-divider);
+  margin-bottom: 4px;
+  color: var(--color-fg-primary);
+  font-family: var(--font-mono);
+  font-size: var(--fs-12);
+}
+.kw-kp-menu-item {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 9px;
+  border: 0;
+  border-radius: var(--r-1);
+  background: transparent;
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-12);
+  text-align: left;
+  cursor: pointer;
+  transition: color .15s, background .15s;
+}
+.kw-kp-menu-item:hover {
+  color: var(--color-fg-primary);
+  background: var(--color-bg-surface);
+}
+.kw-kp-menu-item.danger { color: var(--color-status-err); }
+.kw-kp-menu-item.danger:hover { background: rgb(var(--color-status-err-glow) / 0.12); }
+.kw-kp-menu-sep {
+  height: 1px;
+  margin: 4px 0;
+  background: var(--color-border-divider);
+}
+.kw-kp-menu-note {
+  padding: 8px 10px;
+  color: var(--color-fg-muted);
+  font-size: var(--fs-11);
+  line-height: 1.4;
+}
+@media (max-width: 860px) {
+  .kw-kp-more { opacity: 1; }
+  .kw-kp-row .kw-kp-right { padding-right: 30px; }
+  .kw-kp-row:hover .kw-kp-right,
+  .kw-kp-row:focus-within .kw-kp-right {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
 /* shared sigil avatar (roster + chat hero) — color from --color-keeper-N */
@@ -230,6 +379,92 @@
 .kw-state-pill.off { color: var(--color-fg-muted); }
 
 .kw-chat-actions { display: flex; gap: 7px; align-items: center; flex: none; }
+.kw-chat-command-icons {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.kw-chat-command-icon,
+.kw-chat-command-menu-toggle,
+.kw-chat-ctx-mobile {
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  color: var(--color-fg-secondary);
+  cursor: pointer;
+  transition: color .15s, border-color .15s, background .15s, transform .12s;
+}
+.kw-chat-command-icon:hover,
+.kw-chat-command-menu-toggle:hover,
+.kw-chat-ctx-mobile:hover {
+  color: var(--color-fg-primary);
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-hover);
+}
+.kw-chat-command-icon.active { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); background: var(--accent-10); }
+.kw-chat-command-icon.danger,
+.kw-chat-command-item.danger { color: var(--color-status-err); }
+.kw-chat-command-icon.danger:hover,
+.kw-chat-command-item.danger:hover {
+  border-color: rgb(var(--color-status-err-glow) / 0.5);
+  background: rgb(var(--color-status-err-glow) / 0.12);
+}
+.kw-chat-command-icon:disabled,
+.kw-chat-command-menu-toggle:disabled,
+.kw-chat-command-item:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.kw-chat-mobile-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.kw-chat-command-menu {
+  position: relative;
+  display: inline-flex;
+}
+.kw-chat-command-popover {
+  position: absolute;
+  z-index: 80;
+  top: calc(100% + 8px);
+  right: 0;
+  display: flex;
+  width: max-content;
+  min-width: 190px;
+  flex-direction: column;
+  gap: 2px;
+  padding: 5px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--r-2);
+  background: var(--color-bg-panel-alt);
+  box-shadow: var(--shadow-raised);
+}
+.kw-chat-command-item {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 9px;
+  border: 0;
+  border-radius: var(--r-1);
+  background: transparent;
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-12);
+  text-align: left;
+  cursor: pointer;
+  transition: color .15s, background .15s;
+}
+.kw-chat-command-item:hover {
+  color: var(--color-fg-primary);
+  background: var(--color-bg-surface);
+}
 .kw-act {
   font-size: var(--fs-12); font-weight: var(--fw-med); letter-spacing: 0.02em;
   padding: 7px 12px; border-radius: var(--r-1); cursor: pointer;
@@ -239,6 +474,148 @@
 .kw-act:hover { color: var(--color-fg-primary); border-color: var(--color-border-strong); background: var(--color-bg-hover); }
 .kw-act:disabled { opacity: 0.5; cursor: not-allowed; }
 .kw-act.danger:hover { color: var(--color-status-err); border-color: rgb(var(--color-status-err-glow) / 0.5); }
+.kw-chat-mobile-btn {
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  color: var(--color-fg-secondary);
+  cursor: pointer;
+  flex: none;
+}
+.kw-chat-mobile-btn:hover { color: var(--color-fg-primary); border-color: var(--color-border-strong); background: var(--color-bg-hover); }
+.kw-chat-ctx-mobile {
+  gap: 6px;
+}
+.kw-chat-ctx-mobile span { display: none; }
+
+.kw-mobile-rail-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  justify-content: flex-end;
+  background: rgb(0 0 0 / 0.38);
+}
+.kw-mobile-rail-drawer {
+  display: flex;
+  flex-direction: column;
+  width: min(92vw, 340px);
+  height: 100%;
+  min-height: 0;
+  background: var(--color-bg-panel-alt);
+  border-left: 1px solid var(--color-border-default);
+  box-shadow: -18px 0 46px rgb(0 0 0 / 0.32);
+}
+.kw-mobile-rail-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex: none;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--color-border-default);
+}
+.kw-mobile-rail-head strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fs-13);
+  color: var(--color-fg-primary);
+}
+.kw-mobile-rail-drawer .kw-rail {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  border-left: 0;
+}
+
+.kw-config-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-overlay-keeper);
+  display: flex;
+  justify-content: flex-end;
+  background: var(--backdrop-modal);
+  isolation: isolate;
+}
+.kw-config-drawer {
+  display: flex;
+  flex-direction: column;
+  width: min(760px, 96vw);
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  border-left: 1px solid var(--color-border-strong);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-drawer-left);
+}
+.kw-config-head {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--color-border-strong);
+  background: var(--color-bg-elevated);
+}
+.kw-config-head h3 {
+  margin: 0;
+  color: var(--color-fg-primary);
+  font: var(--type-title);
+}
+.kw-config-head p {
+  margin: 3px 0 0;
+  overflow: hidden;
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.kw-config-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 14px 16px 24px;
+  background: var(--color-bg-page);
+}
+
+@media (max-width: 860px) {
+  .kw-config-drawer {
+    width: 100vw;
+    border-left: 0;
+  }
+}
+
+.kw-rail-toggle {
+  position: absolute;
+  z-index: 5;
+  top: 50%;
+  width: 20px;
+  height: 44px;
+  transform: translateY(-50%);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+  color: var(--color-fg-muted);
+  border-radius: var(--r-1);
+  cursor: pointer;
+}
+.kw-rail-toggle:hover {
+  color: var(--color-fg-primary);
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-hover);
+}
+.kw-rail-toggle.left { left: calc(var(--kw-roster-w, 286px) - 10px); }
+.kw-rail-toggle.right { right: calc(var(--kw-rail-w, 312px) - 10px); }
+.kw-grid[data-rail="closed"] .kw-rail-toggle.right { right: 2px; }
 
 /* Mobile conversation header (≤860px). The desktop header is a single flex row
  * [sigil | identity (flex:1) | actions (flex:none)]. At phone widths the five

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -59,6 +59,20 @@ describe('refreshPlanForRoute', () => {
     })).toEqual(['shell', 'namespaceTruth', 'missionSnapshot', 'execution'])
   })
 
+  it('hydrates the top-level keepers workspace from live execution state', () => {
+    expect(refreshPlanForRoute({
+      tab: 'keepers',
+      params: { keeper: 'sangsu' },
+    })).toEqual(['namespaceTruth', 'execution', 'missionSnapshot'])
+  })
+
+  it('hydrates the top-level board surface from the board store', () => {
+    expect(refreshPlanForRoute({
+      tab: 'board',
+      params: {},
+    })).toEqual(['board'])
+  })
+
   it('uses the current monitoring sections', () => {
     expect(refreshPlanForRoute({
       tab: 'monitoring',
@@ -209,6 +223,15 @@ describe('refreshPlanForRoute', () => {
     refreshForRoute({
       tab: 'code',
       params: { section: 'ide-shell', view: 'source' },
+    })
+
+    expect(refreshExecution).toHaveBeenCalledWith()
+  })
+
+  it('uses the scheduler-backed execution refresh path on Keepers navigation', () => {
+    refreshForRoute({
+      tab: 'keepers',
+      params: { keeper: 'sangsu' },
     })
 
     expect(refreshExecution).toHaveBeenCalledWith()

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -64,6 +64,10 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
   switch (routeState.tab) {
     case 'overview':
       return ['shell', 'namespaceTruth', 'missionSnapshot', 'execution']
+    case 'keepers':
+      return ['namespaceTruth', 'execution', 'missionSnapshot']
+    case 'board':
+      return ['board']
     case 'monitoring':
       if (routeState.params.section === 'observatory') {
         return ['namespaceTruth', 'observatory']

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -310,6 +310,8 @@ export type TabId =
   | 'cockpit'
   | 'overview'
   | 'monitoring'
+  | 'keepers'
+  | 'board'
   | 'command'
   | 'connectors'
   | 'workspace'
@@ -322,6 +324,8 @@ export const VALID_TABS: TabId[] = [
   'cockpit',
   'overview',
   'monitoring',
+  'keepers',
+  'board',
   'command',
   'connectors',
   'workspace',

--- a/docs/design/keeper-v2-v12-gap-current.md
+++ b/docs/design/keeper-v2-v12-gap-current.md
@@ -1,0 +1,38 @@
+# Keeper v2 v12 Gap Snapshot
+
+Source reviewed: `/Users/dancer/Downloads/v2 (12)`.
+
+Current implementation surface: `dashboard/src` on branch `codex/keeper-fleet-surface`.
+
+## Exists In Current Page
+
+- Top-level keeper surfaces already exist for Overview, Work, Keepers, Board, IDE, Connectors, and Settings. Work and IDE keep compatibility route ids (`workspace`, `code`).
+- The mobile shell has one nav owner for rail, drawer, and bottom tabs.
+- The keeper detail path can hide the mobile bottom bar while reading chat.
+- Board and Keepers are top-level routes rather than only nested Workspace/Monitor sections.
+
+## Implemented In This Pass
+
+- Mobile primary tabs now follow the prototype's user-facing priority: Overview, Work, Keepers, Board.
+- Monitor and Command remain available through the full navigation drawer instead of occupying the mobile bottom bar.
+- The `workspace` route keeps its existing route id and `section=work` default, but its visible surface label is now Work.
+- The v2 primary shell now uses the prototype surface set: Overview, Work, Keepers, Board, IDE, Connectors, Settings.
+- Monitor, Command, Lab, and Logs remain routeable operational/diagnostic surfaces, but they no longer occupy first-level v2 shell navigation.
+
+## Still Missing Vs Prototype
+
+- The desktop shell still has the dashboard header/tooling model around the prototype primary surfaces. The prototype's rail is visually simpler and places Settings at the rail bottom.
+- The Work surface is route-compatible with `workspace`, but the app has not fully renamed internal copy, breadcrumbs, fallback labels, or source concepts that still correctly refer to a workspace.
+- The Overview surface does not yet match the v12 prototype's exact composition for attention queue, telemetry histogram, keeper fleet cards, and context density.
+- The Connectors page remains an operator-heavy status console rather than the prototype's simpler connector gate grid plus recent audit/event framing.
+- The global mobile pane contract from the prototype (`data-mpane`, chat pane hiding rules, and drawer behavior) is not normalized across every surface.
+- Composer parity is incomplete: binary attachments, microphone/STT behavior, and exact command affordance grouping are not implemented as prototype features.
+- Stable message-turn identity linking from board posts to keeper chat turns still needs a hard data contract rather than visual-only alignment.
+
+## Should Disappear Or Collapse
+
+- Mobile primary Monitor and Command tabs should stay removed from the bottom bar; they belong in More while the prototype-first IA is active.
+- The visible primary label Workspace should disappear in favor of Work where the user is navigating the v2 surface. Low-level code and data concepts can keep `workspace` when they refer to runtime scope or API contracts.
+- Duplicate keeper fleet entry points should eventually collapse: Keepers is the v2 primary destination, while Monitor > Keeper Fleet is now a routeable legacy/diagnostic lane.
+- If exact prototype parity becomes the goal, the desktop top surface tab layer should collapse into the single rail model and Settings should move to the rail footer.
+- Stale gap notes under `/Users/dancer/me/memory/keeper-v2-gap-*.md` should be superseded by this repo-local snapshot when PR #21525 lands.

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -11,6 +11,8 @@ let valid_surfaces =
   [ "cockpit"
   ; "overview"
   ; "monitoring"
+  ; "keepers"
+  ; "board"
   ; "command"
   ; "connectors"
   ; "workspace"


### PR DESCRIPTION
## Summary
- Align the dashboard toward the keeper-v2 design export across Board, Keepers, shell navigation, ComposerV2, Lab, and turn-inspector surfaces.
- Promote Board and Keepers flows into top-level/mobile-ready surfaces and consolidate shell navigation ownership through `DashboardNavRail`.

## Product impact
- Operators get a more usable mobile dashboard for Board and Keepers, with compact compose, mention routing, thread/inbox overlays, and hidden bottom nav while reading keeper chat.
- Dashboard shell behavior now matches the v2 900px breakpoint more closely and avoids overlapping Copilot controls on mobile.

## Evidence
- `pnpm -C dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/mobile-nav.test.ts src/app.test.ts`
- `pnpm -C dashboard typecheck`
- `pnpm -C dashboard build`

## Direct evidence
schema_version: 1
direct_ratio: 4/4
provenance: direct

- Rendered screenshots:
  - `/tmp/masc-v2-12-shell-nav-mobile-board-tabs.png`
  - `/tmp/masc-v2-12-shell-nav-mobile-drawer-unified.png`
  - `/tmp/masc-v2-12-shell-nav-keeper-chat-tabs-hidden.png`
  - `/tmp/masc-v2-12-shell-nav-desktop-board-rail.png`
- Broader prior rendered proof is recorded in local ledgers under `/Users/dancer/me/memory/keeper-v2-gap-mobile.md` and `/Users/dancer/me/memory/keeper-v2-gap-new-surfaces.md`.

## Review evidence
- `agent-browser errors`: empty during shell-nav QA.
- Console still showed existing live runtime/API resource noise (400/401/404/500 resources and PerformanceMonitor slow-frame warnings), not a page-level crash.

## Linked issue
- Not linked.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/keeper-fleet-surface` → `main` · 2 commit(s) · synced 2026-06-19T01:27:41Z

| sha | subject | date |
|---|---|---|
| `3488f3e7b` | feat(dashboard): align keeper v2 surfaces | 2026-06-19 |
| `99d018213` | fix(dashboard): address keeper v2 review drift | 2026-06-19 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->