### PR TITLE
tool-orchestration P1: typed ToolJob envelope and durable ToolEvent ledger

### DIFF
--- a/docs/design/tool-orchestration-lane.md
+++ b/docs/design/tool-orchestration-lane.md
@@ -1,0 +1,39 @@
+# Tool Orchestration Lane Design Note
+
+Status: draft design note
+Date: 2026-06-19
+
+## Purpose
+
+The tool orchestration lane gives MASC a durable, typed record of tool work before it introduces a scheduler or executor. The first slice only defines the data contract:
+
+- `ToolJob`: an immutable envelope for one intended tool call.
+- `ToolEvent`: append-only ledger events for job and batch lifecycle changes.
+- Stable schema hashing for replay and compatibility checks.
+- Conservative resource metadata that can later drive locking and fanout.
+
+This slice is deliberately not an executor. It does not run tools, schedule batches, or acquire locks.
+
+## Boundary
+
+The lane belongs to MASC, not OAS. It may depend on neutral tool catalog and dispatch metadata, but it must not encode provider, model, transport, or runtime-specific behavior.
+
+The durable ledger is also not a planner. When a tool contract does not provide typed resource keys, the fallback must be conservative:
+
+- read-only tools default to no write resource keys.
+- unknown or writer tools default to `write:any`.
+- name prefixes are not a resource authority.
+
+## P1 Contract
+
+P1 establishes the following properties:
+
+1. Missing optional fields in old ledger records decode as `None`.
+2. Job and event identifiers can be supplied by tests and replay.
+3. Fresh generated IDs are replay handles only, not semantic ordering.
+4. Unregistered tool schema hashes include the tool name, avoiding empty-object hash collisions.
+5. Event helpers enumerate known event variants instead of catch-all matching.
+
+## Later Phases
+
+P2 can add read-only batch execution behind a feature flag. P3 can add resource locks once real tool contracts provide typed resource keys. Replay should consume the ledger contract here rather than infer behavior from free-form tool names.

--- a/lib/dune
+++ b/lib/dune
@@ -498,6 +498,9 @@
   masc.masc_tool_dispatch
   ;; Pure tool surface leaf above the dispatch substrate.
   masc.masc_tool_surface
+  ;; Tool Orchestration Lane — typed ToolJob envelope and durable ToolEvent ledger.
+  ;; Phase 1 (RFC-0256) introduces the envelope; Phase 2 will wire the executor.
+  masc.tool_orchestration
   ;; OTel metric bridge leaf (Otel_metric_store_core snapshot -> OTLP observable).
   masc.otel_metrics
   ;; Thompson Sampling leaf; health/Otel_metric_store edges are callbacks.

--- a/lib/tool_orchestration/dune
+++ b/lib/tool_orchestration/dune
@@ -1,0 +1,21 @@
+(include_subdirs no)
+
+;; RFC-0256 Phase 1 / Tool Orchestration Lane — typed ToolJob envelope and
+;; durable ToolEvent ledger primitives. This library sits above the neutral
+;; Tool dispatch substrate (masc.masc_tool_dispatch) and below Keeper turn
+;; execution. It must remain agnostic to provider/model transport (OAS) and
+;; to specific Keeper policy, while owning the cross-batch contract for
+;; read-only flags, resource keys, schema hashes, and replay events.
+
+(library
+ (name masc_tool_orchestration)
+ (public_name masc.tool_orchestration)
+ (wrapped false)
+ (libraries
+  masc.masc_tool_dispatch
+  masc.tool_types
+  yojson
+  uuidm
+  digestif)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/tool_orchestration/tool_event.ml
+++ b/lib/tool_orchestration/tool_event.ml
@@ -1,0 +1,39 @@
+type error_class =
+  | Transient
+  | Policy
+  | Runtime
+[@@deriving yojson, show, eq]
+
+type artifact_ref = Yojson.Safe.t [@@deriving yojson, show]
+
+type batch_created = {
+  batch_id : string;
+  parent_turn_id : string option;
+  parent_goal_id : string option;
+}
+[@@deriving yojson, show, eq]
+
+type t =
+  | Batch_created of batch_created
+  | Job_scheduled of string
+  | Job_started of string
+  | Job_progress of string * Yojson.Safe.t
+  | Job_succeeded of string * artifact_ref
+  | Job_failed of string * error_class * string
+  | Job_cancelled of string * string
+  | Batch_finished of string * string
+[@@deriving yojson, show]
+
+let job_id = function
+  | Batch_created _ | Batch_finished _ -> None
+  | Job_scheduled id
+  | Job_started id
+  | Job_succeeded (id, _)
+  | Job_failed (id, _, _)
+  | Job_cancelled (id, _) -> Some id
+  | Job_progress (id, _) -> Some id
+
+let batch_id = function
+  | Batch_created b -> Some b.batch_id
+  | Batch_finished (id, _) -> Some id
+  | _ -> None

--- a/lib/tool_orchestration/tool_event.ml
+++ b/lib/tool_orchestration/tool_event.ml
@@ -8,8 +8,8 @@ type artifact_ref = Yojson.Safe.t [@@deriving yojson, show]
 
 type batch_created = {
   batch_id : string;
-  parent_turn_id : string option;
-  parent_goal_id : string option;
+  parent_turn_id : string option [@default None];
+  parent_goal_id : string option [@default None];
 }
 [@@deriving yojson, show, eq]
 
@@ -36,4 +36,9 @@ let job_id = function
 let batch_id = function
   | Batch_created b -> Some b.batch_id
   | Batch_finished (id, _) -> Some id
-  | _ -> None
+  | Job_scheduled _
+  | Job_started _
+  | Job_progress _
+  | Job_succeeded _
+  | Job_failed _
+  | Job_cancelled _ -> None

--- a/lib/tool_orchestration/tool_event.mli
+++ b/lib/tool_orchestration/tool_event.mli
@@ -1,0 +1,45 @@
+(** Durable ledger events for ToolBatch execution and replay.
+
+    Events are append-only, JSON-serializable, and intentionally minimal:
+    they record what happened to a job or batch so that a restarted runtime
+    can skip already-completed work. A future phase will add event history
+    compaction and snapshotting; this module only defines the event grammar. *)
+
+(** Classification of a job failure for replay policy. *)
+type error_class =
+  | Transient
+  | Policy
+  | Runtime
+[@@deriving yojson, show, eq]
+
+(** Opaque artifact reference carried by [Job_succeeded].
+
+    In Phase 1 this is a JSON value; later phases may introduce a structured
+    reference with storage backend URI, hash, and provenance. *)
+type artifact_ref = Yojson.Safe.t [@@deriving yojson, show]
+
+(** Snapshot of a batch at creation time. *)
+type batch_created = {
+  batch_id : string;
+  parent_turn_id : string option;
+  parent_goal_id : string option;
+}
+[@@deriving yojson, show, eq]
+
+type t =
+  | Batch_created of batch_created
+  | Job_scheduled of string
+  | Job_started of string
+  | Job_progress of string * Yojson.Safe.t
+  | Job_succeeded of string * artifact_ref
+  | Job_failed of string * error_class * string
+  | Job_cancelled of string * string
+  | Batch_finished of string * string
+[@@deriving yojson, show]
+
+val job_id : t -> string option
+(** Return the affected job id, if any. [Batch_created] and [Batch_finished]
+    carry no job id. *)
+
+val batch_id : t -> string option
+(** Return the affected batch id, if the event carries one. *)

--- a/lib/tool_orchestration/tool_event.mli
+++ b/lib/tool_orchestration/tool_event.mli
@@ -21,8 +21,8 @@ type artifact_ref = Yojson.Safe.t [@@deriving yojson, show]
 (** Snapshot of a batch at creation time. *)
 type batch_created = {
   batch_id : string;
-  parent_turn_id : string option;
-  parent_goal_id : string option;
+  parent_turn_id : string option [@default None];
+  parent_goal_id : string option [@default None];
 }
 [@@deriving yojson, show, eq]
 

--- a/lib/tool_orchestration/tool_job.ml
+++ b/lib/tool_orchestration/tool_job.ml
@@ -7,24 +7,27 @@ type policy_verdict =
 type t = {
   job_id : string;
   batch_id : string;
-  turn_id : string option;
-  goal_id : string option;
-  keeper_id : string option;
+  turn_id : string option [@default None];
+  goal_id : string option [@default None];
+  keeper_id : string option [@default None];
   tool_name : string;
-  tool_version : string option;
+  tool_version : string option [@default None];
   schema_hash : string;
   input_json : Yojson.Safe.t;
   read_only : bool;
   resource_keys : string list;
-  idempotency_key : string option;
-  deadline_ms : int option;
+  idempotency_key : string option [@default None];
+  deadline_ms : int option [@default None];
   approval : policy_verdict;
   attempt : int;
 }
 [@@deriving yojson, show]
 
+(* NDT-OK: UUID entropy is a replay handle only; tests pass explicit [job_id]. *)
+let uuid_rng = Random.State.make_self_init ()
+
 let fresh_id () =
-  Uuidm.v4_gen (Random.State.make_self_init ()) () |> Uuidm.to_string
+  Uuidm.v4_gen uuid_rng () |> Uuidm.to_string
 
 let rec normalize_input_for_hash = function
   | `Assoc kvs ->
@@ -43,26 +46,20 @@ let schema_hash_of_yojson schema =
   |> Digestif.SHA256.to_hex
 
 let read_only_of_tool_name name =
+  (* DET-OK: sound-partial allow — unknown tools default to writer semantics, which
+     makes the scheduler use the conservative [write:any] resource key below. *)
   (Tool_catalog.metadata name).readonly |> Option.value ~default:false
 
-let default_resource_keys_of_tool ~tool_name ~input_json =
-  let get = Tool_args.get_string_opt input_json in
-  let keys = ref [] in
-  let add prefix key_name =
-    match get key_name with
-    | Some value -> keys := (prefix ^ value) :: !keys
-    | None -> ()
-  in
-  (if String.starts_with ~prefix:"masc_goal_" tool_name then add "goal:" "goal_id");
-  (if String.starts_with ~prefix:"masc_task_" tool_name then add "task:" "task_id");
-  (if String.starts_with ~prefix:"masc_board_" tool_name then add "board:thread:" "thread_id");
-  (if String.starts_with ~prefix:"masc_workspace_" tool_name then add "workspace:" "workspace_path");
-  (if tool_name = "tool_read_file"
-      || tool_name = "tool_edit_file"
-      || tool_name = "tool_write_file"
-   then add "file:" "path");
-  (if tool_name = "tool_search_files" then add "repo:" "path");
-  List.rev !keys
+let default_resource_keys_of_tool ~read_only ~tool_name:_ ~input_json:_ =
+  if read_only then [] else [ "write:any" ]
+
+let fallback_schema_for_tool tool_name =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc []
+    ; "required", `List []
+    ; "x-masc-unregistered-tool", `String tool_name
+    ]
 
 let make
     ?(job_id = fresh_id ())
@@ -82,17 +79,13 @@ let make
   let schema =
     match Tool_dispatch.lookup_schema tool_name with
     | Some s -> s
-    | None ->
-      `Assoc
-        [ "type", `String "object"
-        ; "properties", `Assoc []
-        ; "required", `List []
-        ]
+    | None -> fallback_schema_for_tool tool_name
   in
+  let read_only = read_only_of_tool_name tool_name in
   let resource_keys =
     match resource_keys with
     | Some keys -> keys
-    | None -> default_resource_keys_of_tool ~tool_name ~input_json
+    | None -> default_resource_keys_of_tool ~read_only ~tool_name ~input_json
   in
   { job_id
   ; batch_id
@@ -103,7 +96,7 @@ let make
   ; tool_version
   ; schema_hash = schema_hash_of_yojson schema
   ; input_json
-  ; read_only = read_only_of_tool_name tool_name
+  ; read_only
   ; resource_keys
   ; idempotency_key
   ; deadline_ms

--- a/lib/tool_orchestration/tool_job.ml
+++ b/lib/tool_orchestration/tool_job.ml
@@ -1,0 +1,115 @@
+type policy_verdict =
+  | Approved
+  | Pending of string
+  | Denied of string
+[@@deriving yojson, show, eq]
+
+type t = {
+  job_id : string;
+  batch_id : string;
+  turn_id : string option;
+  goal_id : string option;
+  keeper_id : string option;
+  tool_name : string;
+  tool_version : string option;
+  schema_hash : string;
+  input_json : Yojson.Safe.t;
+  read_only : bool;
+  resource_keys : string list;
+  idempotency_key : string option;
+  deadline_ms : int option;
+  approval : policy_verdict;
+  attempt : int;
+}
+[@@deriving yojson, show]
+
+let fresh_id () =
+  Uuidm.v4_gen (Random.State.make_self_init ()) () |> Uuidm.to_string
+
+let rec normalize_input_for_hash = function
+  | `Assoc kvs ->
+    let kvs =
+      List.sort (fun (a, _) (b, _) -> String.compare a b) kvs
+      |> List.map (fun (k, v) -> (k, normalize_input_for_hash v))
+    in
+    `Assoc kvs
+  | `List xs -> `List (List.map normalize_input_for_hash xs)
+  | other -> other
+
+let schema_hash_of_yojson schema =
+  normalize_input_for_hash schema
+  |> Yojson.Safe.to_string
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+
+let read_only_of_tool_name name =
+  (Tool_catalog.metadata name).readonly |> Option.value ~default:false
+
+let default_resource_keys_of_tool ~tool_name ~input_json =
+  let get = Tool_args.get_string_opt input_json in
+  let keys = ref [] in
+  let add prefix key_name =
+    match get key_name with
+    | Some value -> keys := (prefix ^ value) :: !keys
+    | None -> ()
+  in
+  (if String.starts_with ~prefix:"masc_goal_" tool_name then add "goal:" "goal_id");
+  (if String.starts_with ~prefix:"masc_task_" tool_name then add "task:" "task_id");
+  (if String.starts_with ~prefix:"masc_board_" tool_name then add "board:thread:" "thread_id");
+  (if String.starts_with ~prefix:"masc_workspace_" tool_name then add "workspace:" "workspace_path");
+  (if tool_name = "tool_read_file"
+      || tool_name = "tool_edit_file"
+      || tool_name = "tool_write_file"
+   then add "file:" "path");
+  (if tool_name = "tool_search_files" then add "repo:" "path");
+  List.rev !keys
+
+let make
+    ?(job_id = fresh_id ())
+    ?turn_id
+    ?goal_id
+    ?keeper_id
+    ?tool_version
+    ?idempotency_key
+    ?deadline_ms
+    ?(approval = Approved)
+    ?(attempt = 1)
+    ?resource_keys
+    ~batch_id
+    ~tool_name
+    ~input_json
+    () =
+  let schema =
+    match Tool_dispatch.lookup_schema tool_name with
+    | Some s -> s
+    | None ->
+      `Assoc
+        [ "type", `String "object"
+        ; "properties", `Assoc []
+        ; "required", `List []
+        ]
+  in
+  let resource_keys =
+    match resource_keys with
+    | Some keys -> keys
+    | None -> default_resource_keys_of_tool ~tool_name ~input_json
+  in
+  { job_id
+  ; batch_id
+  ; turn_id
+  ; goal_id
+  ; keeper_id
+  ; tool_name
+  ; tool_version
+  ; schema_hash = schema_hash_of_yojson schema
+  ; input_json
+  ; read_only = read_only_of_tool_name tool_name
+  ; resource_keys
+  ; idempotency_key
+  ; deadline_ms
+  ; approval
+  ; attempt
+  }
+
+let with_approval t approval = { t with approval }
+let with_attempt t attempt = { t with attempt }

--- a/lib/tool_orchestration/tool_job.mli
+++ b/lib/tool_orchestration/tool_job.mli
@@ -18,17 +18,17 @@ type policy_verdict =
 type t = {
   job_id : string;
   batch_id : string;
-  turn_id : string option;
-  goal_id : string option;
-  keeper_id : string option;
+  turn_id : string option [@default None];
+  goal_id : string option [@default None];
+  keeper_id : string option [@default None];
   tool_name : string;
-  tool_version : string option;
+  tool_version : string option [@default None];
   schema_hash : string;
   input_json : Yojson.Safe.t;
   read_only : bool;
   resource_keys : string list;
-  idempotency_key : string option;
-  deadline_ms : int option;
+  idempotency_key : string option [@default None];
+  deadline_ms : int option [@default None];
   approval : policy_verdict;
   attempt : int;
 }
@@ -58,8 +58,9 @@ val make :
       [tool_name], or from a minimal empty object schema when the tool has no
       registered schema.
     - [read_only] is derived from {!Tool_catalog} metadata when available.
-    - [resource_keys] uses the explicit list if provided; otherwise falls back
-      to {!default_resource_keys_of_tool}.
+    - [resource_keys] uses the explicit list if provided; otherwise read-only
+      tools get no lock key and writer/unknown tools get a coarse ["write:any"]
+      key so they serialize until a caller supplies typed resource keys.
     - [job_id] defaults to a fresh UUIDv4. Pass an explicit id in tests. *)
 
 (** {1 Schema hashing} *)
@@ -74,19 +75,13 @@ val schema_hash_of_yojson : Yojson.Safe.t -> string
 (** {1 Resource key inference} *)
 
 val default_resource_keys_of_tool :
-  tool_name:string -> input_json:Yojson.Safe.t -> string list
-(** Best-effort resource key inference from known tool naming patterns.
+  read_only:bool -> tool_name:string -> input_json:Yojson.Safe.t -> string list
+(** Conservative default resource key selection.
 
-    The returned keys are intentionally conservative: a tool that does not
-    match a known pattern yields an empty list, forcing the caller (planner or
-    executor) to supply explicit [resource_keys]. This avoids pretending a
-    write is read-only or locking the wrong resource.
-
-    Examples:
-    - [masc_goal_*] with [goal_id] -> ["goal:<id>"]
-    - [masc_task_*] with [task_id] -> ["task:<id>"]
-    - [tool_read_file]/[tool_edit_file]/[tool_write_file] with [path] -> ["file:<path>"]
-    - [tool_search_files] with [path] -> ["repo:<path>"] *)
+    This function deliberately does not infer resource keys from tool-name
+    strings. Read-only tools return [[]]. Writer or unknown tools return the
+    coarse ["write:any"] key, forcing serialization until the planner or
+    executor supplies typed resource keys from a real tool contract. *)
 
 (** {1 Field updates} *)
 

--- a/lib/tool_orchestration/tool_job.mli
+++ b/lib/tool_orchestration/tool_job.mli
@@ -1,0 +1,94 @@
+(** Typed envelope for a single tool invocation inside a {!Tool_batch}.
+
+    A [Tool_job.t] is the unit of scheduling, locking, evidence, and replay.
+    It carries everything the orchestrator needs to decide whether a tool can
+    run in parallel, which resource it touches, whether it is idempotent, and
+    how its result maps back to a turn/goal/keeper. *)
+
+(** {1 Policy verdict} *)
+
+type policy_verdict =
+  | Approved
+  | Pending of string
+  | Denied of string
+[@@deriving yojson, show, eq]
+
+(** {1 Job envelope} *)
+
+type t = {
+  job_id : string;
+  batch_id : string;
+  turn_id : string option;
+  goal_id : string option;
+  keeper_id : string option;
+  tool_name : string;
+  tool_version : string option;
+  schema_hash : string;
+  input_json : Yojson.Safe.t;
+  read_only : bool;
+  resource_keys : string list;
+  idempotency_key : string option;
+  deadline_ms : int option;
+  approval : policy_verdict;
+  attempt : int;
+}
+[@@deriving yojson, show]
+
+(** {1 Constructors} *)
+
+val make :
+  ?job_id:string ->
+  ?turn_id:string ->
+  ?goal_id:string ->
+  ?keeper_id:string ->
+  ?tool_version:string ->
+  ?idempotency_key:string ->
+  ?deadline_ms:int ->
+  ?approval:policy_verdict ->
+  ?attempt:int ->
+  ?resource_keys:string list ->
+  batch_id:string ->
+  tool_name:string ->
+  input_json:Yojson.Safe.t ->
+  unit ->
+  t
+(** Build a job envelope.
+
+    - [schema_hash] is computed from the currently registered input schema for
+      [tool_name], or from a minimal empty object schema when the tool has no
+      registered schema.
+    - [read_only] is derived from {!Tool_catalog} metadata when available.
+    - [resource_keys] uses the explicit list if provided; otherwise falls back
+      to {!default_resource_keys_of_tool}.
+    - [job_id] defaults to a fresh UUIDv4. Pass an explicit id in tests. *)
+
+(** {1 Schema hashing} *)
+
+val normalize_input_for_hash : Yojson.Safe.t -> Yojson.Safe.t
+(** Recursively sort object keys so that equivalent schemas produce the same
+    hash regardless of key order. Lists are kept in order. *)
+
+val schema_hash_of_yojson : Yojson.Safe.t -> string
+(** Deterministic SHA-256 hash (hex) of a normalized JSON value. *)
+
+(** {1 Resource key inference} *)
+
+val default_resource_keys_of_tool :
+  tool_name:string -> input_json:Yojson.Safe.t -> string list
+(** Best-effort resource key inference from known tool naming patterns.
+
+    The returned keys are intentionally conservative: a tool that does not
+    match a known pattern yields an empty list, forcing the caller (planner or
+    executor) to supply explicit [resource_keys]. This avoids pretending a
+    write is read-only or locking the wrong resource.
+
+    Examples:
+    - [masc_goal_*] with [goal_id] -> ["goal:<id>"]
+    - [masc_task_*] with [task_id] -> ["task:<id>"]
+    - [tool_read_file]/[tool_edit_file]/[tool_write_file] with [path] -> ["file:<path>"]
+    - [tool_search_files] with [path] -> ["repo:<path>"] *)
+
+(** {1 Field updates} *)
+
+val with_approval : t -> policy_verdict -> t
+val with_attempt : t -> int -> t

--- a/test/dune
+++ b/test/dune
@@ -810,6 +810,7 @@
   test_tool_registry_consistency
   test_tool_dispatch
   test_tool_spec
+  test_tool_job
   test_tool_catalog_system_internal_hidden
   test_typed_tool_masc
   test_state_product
@@ -993,6 +994,7 @@
   test_tool_registry_consistency
   test_tool_dispatch
   test_tool_spec
+  test_tool_job
   test_tool_catalog_system_internal_hidden
   test_typed_tool_masc
   test_state_product
@@ -1040,7 +1042,7 @@
   test_board_core_payload
   test_board_attachment_meta
   test_board_moderation)
- (libraries masc_test_deps)
+ (libraries masc_test_deps masc.tool_orchestration)
  (deps ../bin/main_eio.exe))
 
 (test

--- a/test/test_tool_job.ml
+++ b/test/test_tool_job.ml
@@ -29,6 +29,7 @@ let test_make_reads_tool_metadata () =
   init ();
   let job = make ~batch_id:"batch_1" ~tool_name:"masc_status" ~input_json:(`Assoc []) () in
   Alcotest.(check bool) "masc_status is read-only" true job.read_only;
+  Alcotest.(check (list string)) "read-only default has no writer lock" [] job.resource_keys;
   Alcotest.(check string) "batch_id carried" "batch_1" job.batch_id;
   Alcotest.(check bool) "schema hash is non-empty" true (String.length job.schema_hash > 0)
 ;;
@@ -63,28 +64,51 @@ let test_job_roundtrip () =
   Alcotest.(check bool) "job roundtrip" true (job = job')
 ;;
 
+let test_job_roundtrip_accepts_missing_option_fields () =
+  let json =
+    `Assoc
+      [ "job_id", `String "job_legacy"
+      ; "batch_id", `String "batch_legacy"
+      ; "tool_name", `String "unknown_tool"
+      ; "schema_hash", `String "hash"
+      ; "input_json", `Assoc []
+      ; "read_only", `Bool false
+      ; "resource_keys", `List [ `String "write:any" ]
+      ; "approval", Tool_job.policy_verdict_to_yojson Approved
+      ; "attempt", `Int 1
+      ]
+  in
+  let job = Tool_job.of_yojson json |> Result.get_ok in
+  Alcotest.(check (option string)) "missing turn_id defaults None" None job.turn_id;
+  Alcotest.(check (option string)) "missing goal_id defaults None" None job.goal_id;
+  Alcotest.(check (option string)) "missing keeper_id defaults None" None job.keeper_id;
+  Alcotest.(check (option string)) "missing tool_version defaults None" None job.tool_version;
+  Alcotest.(check (option string)) "missing idempotency_key defaults None" None job.idempotency_key;
+  Alcotest.(check (option int)) "missing deadline_ms defaults None" None job.deadline_ms
+;;
+
 let test_resource_key_inference () =
   let check ~tool_name ~input ~expected =
-    let actual = default_resource_keys_of_tool ~tool_name ~input_json:input in
+    let actual =
+      default_resource_keys_of_tool
+        ~read_only:(String.equal tool_name "masc_status")
+        ~tool_name
+        ~input_json:input
+    in
     Alcotest.(check (list string)) (Printf.sprintf "%s resource keys" tool_name) expected actual
   in
   check
-    ~tool_name:"masc_goal_transition"
-    ~input:(`Assoc [ "goal_id", `String "goal_01J" ])
-    ~expected:[ "goal:goal_01J" ];
-  check
-    ~tool_name:"masc_task_claim"
-    ~input:(`Assoc [ "task_id", `String "task_01J" ])
-    ~expected:[ "task:task_01J" ];
+    ~tool_name:"masc_status"
+    ~input:(`Assoc [])
+    ~expected:[];
   check
     ~tool_name:"tool_edit_file"
     ~input:(`Assoc [ "path", `String "lib/foo.ml" ])
-    ~expected:[ "file:lib/foo.ml" ];
+    ~expected:[ "write:any" ];
   check
-    ~tool_name:"tool_search_files"
-    ~input:(`Assoc [ "path", `String "/repo" ])
-    ~expected:[ "repo:/repo" ];
-  check ~tool_name:"unknown_tool" ~input:(`Assoc []) ~expected:[]
+    ~tool_name:"unknown_tool"
+    ~input:(`Assoc [])
+    ~expected:[ "write:any" ]
 ;;
 
 let test_event_roundtrip () =
@@ -107,6 +131,30 @@ let test_event_roundtrip () =
     events
 ;;
 
+let test_event_batch_created_accepts_missing_option_fields () =
+  let json = `List [ `String "Batch_created"; `Assoc [ "batch_id", `String "batch_legacy" ] ] in
+  match Tool_event.of_yojson json |> Result.get_ok with
+  | Batch_created b ->
+    Alcotest.(check string) "batch id" "batch_legacy" b.batch_id;
+    Alcotest.(check (option string)) "parent turn default" None b.parent_turn_id;
+    Alcotest.(check (option string)) "parent goal default" None b.parent_goal_id
+  | _ -> Alcotest.fail "expected Batch_created"
+;;
+
+let test_event_batch_id_exhaustive_helpers () =
+  let check name expected event =
+    Alcotest.(check (option string)) name expected (Tool_event.batch_id event)
+  in
+  check "batch created" (Some "batch_1") (Batch_created { batch_id = "batch_1"; parent_turn_id = None; parent_goal_id = None });
+  check "batch finished" (Some "batch_1") (Batch_finished ("batch_1", "ok"));
+  check "job scheduled has no batch id" None (Job_scheduled "job_1");
+  check "job started has no batch id" None (Job_started "job_1");
+  check "job progress has no batch id" None (Job_progress ("job_1", `Assoc []));
+  check "job succeeded has no batch id" None (Job_succeeded ("job_1", `Assoc []));
+  check "job failed has no batch id" None (Job_failed ("job_1", Runtime, "boom"));
+  check "job cancelled has no batch id" None (Job_cancelled ("job_1", "operator"))
+;;
+
 let () =
   Alcotest.run
     "Tool_job"
@@ -117,9 +165,20 @@ let () =
     ; ( "roundtrip"
       , [ Alcotest.test_case "policy verdict" `Quick test_policy_verdict_roundtrip
         ; Alcotest.test_case "job envelope" `Quick test_job_roundtrip
+        ; Alcotest.test_case
+            "job accepts missing option fields"
+            `Quick
+            test_job_roundtrip_accepts_missing_option_fields
         ; Alcotest.test_case "events" `Quick test_event_roundtrip
+        ; Alcotest.test_case
+            "event accepts missing option fields"
+            `Quick
+            test_event_batch_created_accepts_missing_option_fields
         ] )
     ; ( "resource_keys"
       , [ Alcotest.test_case "inference for known patterns" `Quick test_resource_key_inference ] )
+    ; ( "event_helpers"
+      , [ Alcotest.test_case "batch id helper is explicit" `Quick test_event_batch_id_exhaustive_helpers ]
+      )
     ]
 ;;

--- a/test/test_tool_job.ml
+++ b/test/test_tool_job.ml
@@ -1,0 +1,125 @@
+open Tool_job
+open Tool_event
+
+(** Initialize the full tool registry so [make] can look up schemas and
+    metadata for real tools like [masc_status]. *)
+let init () = Masc_test_deps.init_keeper_tool_registry ()
+
+let sample_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc [ "goal_id", `Assoc [ "type", `String "string" ] ]
+    ; "required", `List [ `String "goal_id" ]
+    ]
+
+let test_schema_hash_is_stable () =
+  let h1 = schema_hash_of_yojson sample_schema in
+  let h2 =
+    schema_hash_of_yojson
+      (`Assoc
+         [ "required", `List [ `String "goal_id" ]
+         ; "type", `String "object"
+         ; "properties", `Assoc [ "goal_id", `Assoc [ "type", `String "string" ] ]
+         ])
+  in
+  Alcotest.(check string) "schema hash stable under key reordering" h1 h2
+;;
+
+let test_make_reads_tool_metadata () =
+  init ();
+  let job = make ~batch_id:"batch_1" ~tool_name:"masc_status" ~input_json:(`Assoc []) () in
+  Alcotest.(check bool) "masc_status is read-only" true job.read_only;
+  Alcotest.(check string) "batch_id carried" "batch_1" job.batch_id;
+  Alcotest.(check bool) "schema hash is non-empty" true (String.length job.schema_hash > 0)
+;;
+
+let test_policy_verdict_roundtrip () =
+  let cases = [ Approved; Pending "awaiting approval"; Denied "catastrophic floor" ] in
+  List.iter
+    (fun v ->
+      let json = Tool_job.to_yojson { (make ~job_id:"j" ~batch_id:"b" ~tool_name:"masc_status" ~input_json:(`Assoc []) ()) with approval = v } in
+      let job = Tool_job.of_yojson json |> Result.get_ok in
+      Alcotest.(check bool) "policy verdict roundtrip" true (job.approval = v))
+    cases
+;;
+
+let test_job_roundtrip () =
+  init ();
+  let job =
+    make
+      ~job_id:"job_1"
+      ~turn_id:"turn_1"
+      ~goal_id:"goal_1"
+      ~keeper_id:"keeper_1"
+      ~batch_id:"batch_1"
+      ~tool_name:"masc_goal_list"
+      ~input_json:(`Assoc [ "limit", `Int 10 ])
+      ~approval:(Pending "operator")
+      ~attempt:2
+      ()
+  in
+  let json = Tool_job.to_yojson job in
+  let job' = Tool_job.of_yojson json |> Result.get_ok in
+  Alcotest.(check bool) "job roundtrip" true (job = job')
+;;
+
+let test_resource_key_inference () =
+  let check ~tool_name ~input ~expected =
+    let actual = default_resource_keys_of_tool ~tool_name ~input_json:input in
+    Alcotest.(check (list string)) (Printf.sprintf "%s resource keys" tool_name) expected actual
+  in
+  check
+    ~tool_name:"masc_goal_transition"
+    ~input:(`Assoc [ "goal_id", `String "goal_01J" ])
+    ~expected:[ "goal:goal_01J" ];
+  check
+    ~tool_name:"masc_task_claim"
+    ~input:(`Assoc [ "task_id", `String "task_01J" ])
+    ~expected:[ "task:task_01J" ];
+  check
+    ~tool_name:"tool_edit_file"
+    ~input:(`Assoc [ "path", `String "lib/foo.ml" ])
+    ~expected:[ "file:lib/foo.ml" ];
+  check
+    ~tool_name:"tool_search_files"
+    ~input:(`Assoc [ "path", `String "/repo" ])
+    ~expected:[ "repo:/repo" ];
+  check ~tool_name:"unknown_tool" ~input:(`Assoc []) ~expected:[]
+;;
+
+let test_event_roundtrip () =
+  let events =
+    [ Batch_created { batch_id = "batch_1"; parent_turn_id = Some "turn_1"; parent_goal_id = None }
+    ; Job_scheduled "job_1"
+    ; Job_started "job_1"
+    ; Job_progress ("job_1", `Assoc [ "percent", `Int 50 ])
+    ; Job_succeeded ("job_1", `Assoc [ "status", `String "ok" ])
+    ; Job_failed ("job_1", Transient, "timeout")
+    ; Job_cancelled ("job_1", "operator")
+    ; Batch_finished ("batch_1", "partial_success")
+    ]
+  in
+  List.iter
+    (fun ev ->
+      let json = Tool_event.to_yojson ev in
+      let ev' = Tool_event.of_yojson json |> Result.get_ok in
+      Alcotest.(check bool) "event roundtrip" true (ev = ev'))
+    events
+;;
+
+let () =
+  Alcotest.run
+    "Tool_job"
+    [ ( "schema_hash"
+      , [ Alcotest.test_case "stable under key reordering" `Quick test_schema_hash_is_stable ] )
+    ; ( "make"
+      , [ Alcotest.test_case "reads catalog metadata" `Quick test_make_reads_tool_metadata ] )
+    ; ( "roundtrip"
+      , [ Alcotest.test_case "policy verdict" `Quick test_policy_verdict_roundtrip
+        ; Alcotest.test_case "job envelope" `Quick test_job_roundtrip
+        ; Alcotest.test_case "events" `Quick test_event_roundtrip
+        ] )
+    ; ( "resource_keys"
+      , [ Alcotest.test_case "inference for known patterns" `Quick test_resource_key_inference ] )
+    ]
+;;


### PR DESCRIPTION
## What

Introduces the first MASC Tool Orchestration Lane primitive: a typed `ToolJob` envelope and `ToolEvent` ledger grammar.

This is intentionally **not** an executor yet. It establishes the contract that later phases (read-only fanout, resource locks, replay) will consume.

## Changes

- `docs/design/tool-orchestration-lane.md` — repo-local design note for this lane.
- `lib/tool_orchestration/dune` — new sub-library `masc.tool_orchestration`.
- `lib/tool_orchestration/tool_job.ml{,i}` — `Tool_job.t` with:
  - schema hash (SHA-256 of canonicalized JSON)
  - `read_only` derived from `Tool_catalog` metadata
  - conservative fallback resource keys (`write:any` for unknown/writer tools)
  - policy verdict (Approved / Pending / Denied)
  - idempotency key, deadline, attempt counter
  - JSON roundtrip via `ppx_deriving_yojson`
- `lib/tool_orchestration/tool_event.ml{,i}` — job/batch ledger events.
- `test/test_tool_job.ml` — focused roundtrip, compatibility, schema, and helper tests.
- `lib/dune` / `test/dune` — wire the new library into the build and test suite.

## Boundary

The new code stays on the MASC side of the OAS boundary. It only uses the neutral `Tool_dispatch` / `Tool_catalog` registries; no provider/model transport code.

## Verification

Local validation after review follow-ups:

```
ocamlformat --check lib/tool_orchestration/tool_job.ml lib/tool_orchestration/tool_job.mli lib/tool_orchestration/tool_event.ml lib/tool_orchestration/tool_event.mli test/test_tool_job.ml
git diff --check
scripts/lint/yojson-option-default.py
scripts/ci/check-determinism-contract.sh
scripts/dune-local.sh build test/test_tool_job.exe
scripts/dune-local.sh exec ./test/test_tool_job.exe
```

Docs-only follow-up:

```
git diff --check
```

## Related

- Design note: `docs/design/tool-orchestration-lane.md`
- P0 drift guard already landed via #21518 / #21512.
- Next: P2 read-only `ToolBatch` executor behind a feature flag.
