### PR TITLE
feat(keeper-workspace): adopt standalone v2 chat polish (B1-B5, C1, C2)

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1230,3 +1230,103 @@ describe('rich block URL safety', () => {
     expect(container.textContent).toContain('unsafe URL')
   })
 })
+
+describe('ChatTranscript — workspace day dividers (C1)', () => {
+  let container: HTMLDivElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('inserts one divider before the first message of each calendar day', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({ id: 'a', text: 'day one', timestamp: '2026-03-24T12:00:00.000Z' }),
+          entry({ id: 'b', text: 'same day', timestamp: '2026-03-24T13:00:00.000Z' }),
+          entry({ id: 'c', text: 'two days later', timestamp: '2026-03-26T12:00:00.000Z' }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+        showDayDividers=${true}
+      />`,
+      container,
+    )
+    // Two distinct days (a/b share one) → two dividers, not three.
+    const dividers = container.querySelectorAll('.kw-daydiv')
+    expect(dividers.length).toBe(2)
+    // Absolute "M월 D일" label (timezone-independent shape assertion).
+    expect(dividers[0]?.textContent ?? '').toMatch(/\d+월 \d+일/)
+  })
+
+  it('renders no dividers when the flag is off (every non-workspace surface)', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({ id: 'a', text: 'one', timestamp: '2026-03-24T12:00:00.000Z' }),
+          entry({ id: 'c', text: 'two', timestamp: '2026-03-26T12:00:00.000Z' }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+    expect(container.querySelectorAll('.kw-daydiv').length).toBe(0)
+  })
+})
+
+describe('ChatMessageBubble — workspace source badge (C2)', () => {
+  let container: HTMLDivElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('badges a non-obvious provenance (world-state) when enabled', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[entry({ id: 'w', text: 'injected context', role: 'system', source: 'world_state_prompt' })]}
+        emptyText="empty"
+        variant="messenger"
+        showSourceBadge=${true}
+      />`,
+      container,
+    )
+    const badge = container.querySelector('.kw-src-badge.world')
+    expect(badge).not.toBeNull()
+    expect(badge?.textContent).toContain('월드')
+  })
+
+  it('leaves an ordinary user turn unbadged', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[entry({ id: 'u', text: 'hi', role: 'user', source: 'direct_user' })]}
+        emptyText="empty"
+        variant="messenger"
+        showSourceBadge=${true}
+      />`,
+      container,
+    )
+    expect(container.querySelector('.kw-src-badge')).toBeNull()
+  })
+
+  it('renders no badge when the flag is off', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[entry({ id: 'w', text: 'injected', role: 'system', source: 'world_state_prompt' })]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+    expect(container.querySelector('.kw-src-badge')).toBeNull()
+  })
+})

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -15,7 +15,7 @@ import { formatTimeHms } from '../../lib/format-time'
 import { formatCost } from '../../lib/format-number'
 import { isSubmitEnter } from '../../lib/keyboard'
 import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatLinkBlock, ChatMermaidBlock, ChatShellBlock, ChatTableBlock, ChatTraceStep, ChatVoiceBlock } from '../../types'
-import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, SurfaceRef } from '../../types'
+import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, KeeperConversationSource, SurfaceRef } from '../../types'
 import type { ToolCallOutputBlob } from '../../api/dashboard'
 import { lookupToolCallOutput } from '../../tool-call-output-store'
 import { Sigil } from '../common/sigil-chip'
@@ -189,6 +189,38 @@ function avatarLabel(entry: KeeperConversationEntry): string {
 function avatarMonogram(entry: KeeperConversationEntry): string {
   const label = avatarLabel(entry)
   return label.slice(0, 2).toUpperCase()
+}
+
+// C2: badge non-obvious message provenance. The standalone's .src-badge marks
+// external CHANNELS (discord/slack/imessage) which the live keeper transport
+// does not have — its `source` is a *semantic* origin instead. So we badge the
+// origins that are easy to mistake for a plain user/assistant turn
+// (world-state injection, internal prompt, tool result, system) and leave the
+// two ordinary cases (direct_user / direct_assistant) unbadged.
+const SOURCE_BADGE: Partial<Record<KeeperConversationSource, { label: string; cls: string }>> = {
+  world_state_prompt: { label: '월드', cls: 'world' },
+  internal_assistant: { label: '내부', cls: 'internal' },
+  tool_result: { label: '도구', cls: 'tool' },
+  system: { label: '시스템', cls: 'system' },
+}
+function sourceBadgeInfo(entry: KeeperConversationEntry): { label: string; cls: string } | null {
+  return SOURCE_BADGE[entry.source] ?? null
+}
+
+// C1: group transcript messages by calendar day for the workspace day divider.
+// Absolute "M월 D일" labels (not relative 오늘/어제) so the output is a pure
+// function of the timestamp — deterministic and snapshot-test stable.
+function dayKey(timestamp?: string | null): string | null {
+  if (!timestamp) return null
+  const d = new Date(timestamp)
+  if (Number.isNaN(d.getTime())) return null
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
+}
+function dayDividerLabel(timestamp?: string | null): string | null {
+  if (!timestamp) return null
+  const d = new Date(timestamp)
+  if (Number.isNaN(d.getTime())) return null
+  return `${d.getMonth() + 1}월 ${d.getDate()}일`
 }
 
 function tokenSummary(details: KeeperConversationDetails | null | undefined): string | null {
@@ -1264,10 +1296,12 @@ function ChatMessageBubble({
   entry,
   showMetadata = true,
   variant = 'default',
+  showSourceBadge = false,
 }: {
   entry: KeeperConversationEntry
   showMetadata?: boolean
   variant?: ChatTranscriptVariant
+  showSourceBadge?: boolean
 }) {
   const [expandedRaw, setExpandedRaw] = useState(false)
   const [rawExpandedRaw, setRawExpandedRaw] = useState(false)
@@ -1295,6 +1329,7 @@ function ChatMessageBubble({
   const state = stateRows(entry.details?.stateBlock)
   const delivery = deliveryLabel(entry)
   const timestamp = timeLabel(entry.timestamp)
+  const sourceBadge = showSourceBadge ? sourceBadgeInfo(entry) : null
   const attachments = entry.attachments ?? []
   const surfaceInfo = surfaceLink(entry.surface)
 
@@ -1325,6 +1360,9 @@ function ChatMessageBubble({
                     </span>
                     ${timestamp
                       ? html`<span class="text-2xs font-medium tabular-nums text-[var(--color-fg-secondary)]">${timestamp}</span>`
+                      : null}
+                    ${sourceBadge
+                      ? html`<span class=${`kw-src-badge ${sourceBadge.cls}`}>${sourceBadge.label}</span>`
                       : null}
                     ${showDeliveryBadge(entry, variant)
                       ? html`
@@ -1702,12 +1740,18 @@ export function ChatTranscript({
   showMetadata,
   variant = 'default',
   size = 'default',
+  showDayDividers = false,
+  showSourceBadge = false,
 }: {
   entries: KeeperConversationEntry[]
   emptyText: string
   showMetadata?: boolean
   variant?: ChatTranscriptVariant
   size?: ChatTranscriptSize
+  // C1/C2: opt-in workspace polish. Default false so every other chat surface
+  // (copilot dock, detail page, etc.) renders unchanged.
+  showDayDividers?: boolean
+  showSourceBadge?: boolean
 }) {
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   const pinnedRef = useRef(true)
@@ -1773,10 +1817,24 @@ export function ChatTranscript({
                 <div class="mt-3 max-w-[34rem] text-base font-medium leading-airy text-[var(--color-fg-primary)]">${emptyText}</div>
               </div>
             `
-          : entries.map(entry => entry.role === 'tool'
-              ? html`<${ToolCallBubble} key=${entry.id} entry=${entry} />`
-              : html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} variant=${variant} />`
-          )}
+          : entries.flatMap((entry, i) => {
+              const bubble = entry.role === 'tool'
+                ? html`<${ToolCallBubble} key=${entry.id} entry=${entry} />`
+                : html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} variant=${variant} showSourceBadge=${showSourceBadge} />`
+              // C1: emit a day divider before the first message of each calendar
+              // day. Skipped entirely when showDayDividers is off (every non-
+              // workspace surface), so their flat render is byte-identical.
+              if (!showDayDividers) return [bubble]
+              const dk = dayKey(entry.timestamp)
+              const prevDk = i > 0 ? dayKey(entries[i - 1]?.timestamp) : null
+              if (dk && dk !== prevDk) {
+                return [
+                  html`<div class="kw-daydiv" key=${`day:${dk}`}>${dayDividerLabel(entry.timestamp)}</div>`,
+                  bubble,
+                ]
+              }
+              return [bubble]
+            })}
       </div>
       ${unread
         ? html`

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -628,6 +628,8 @@ export function KeeperConversationPanel({
               showMetadata=${showMetadata}
               variant="messenger"
               size="primary"
+              showDayDividers=${true}
+              showSourceBadge=${true}
             />
           </div>
         </div>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -45,14 +45,17 @@ export function WorkspaceSigil({
 }): VNode {
   const slot = kSlot(id)
   const sigil = kSigil(id)
+  // B4: expose the slot glow as --sigil-glow so the CSS kw-sigil-beat keyframe
+  // can pulse it (replacing the old static box-shadow). Always set so a
+  // non-beating sigil that later starts beating already has the color wired.
   const style = {
     width: `${size}px`,
     height: `${size}px`,
     fontSize: `${Math.round(size * 0.42)}px`,
     background: `var(--color-keeper-${slot})`,
-    boxShadow: beat ? `0 0 10px rgb(var(--color-keeper-${slot}-glow) / 0.6)` : undefined,
+    '--sigil-glow': `var(--color-keeper-${slot}-glow)`,
   }
-  return html`<span class="kw-sigil" style=${style} title=${id} aria-label=${id}>${sigil}</span>`
+  return html`<span class=${`kw-sigil${beat ? ' kw-sigil-beat' : ''}`} style=${style} title=${id} aria-label=${id}>${sigil}</span>`
 }
 
 /** Friendly (Korean) label per canonical status token. Keyed on the tokens

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -133,9 +133,13 @@
 .kw-roster-empty { padding: 30px 12px; text-align: center; color: var(--color-fg-secondary); font-size: var(--fs-13); }
 
 .kw-kp-row {
-  display: grid; grid-template-columns: 40px 1fr auto; gap: 11px; align-items: start;
+  display: grid; grid-template-columns: 40px 1fr auto; gap: 10px; align-items: start;
   width: 100%; text-align: left;
-  padding: 11px 10px; border-radius: var(--r-2); cursor: pointer;
+  /* B5: tighter vertical rhythm (standalone roster density) — row padding 11→8
+     so more keepers fit on screen. align-items stays `start` (not the
+     standalone's `center`) because the live row carries a 3rd work-preview
+     line the standalone's 2-line row does not. */
+  padding: 8px 9px; border-radius: var(--r-2); cursor: pointer;
   border: 1px solid transparent; background: transparent;
   transition: background .14s, border-color .14s;
   position: relative;
@@ -189,7 +193,9 @@
 .kw-chat-head {
   flex: none; padding: 12px 28px;
   border-bottom: 1px solid var(--color-border-default);
-  background: var(--color-bg-panel-alt);
+  /* B1: subtle panel→deep vertical gradient (standalone .chat-head voice)
+     instead of a flat fill — gives the header a faint lit-from-top depth. */
+  background: linear-gradient(180deg, var(--color-bg-panel-alt), var(--color-bg-page));
   display: flex; align-items: center; gap: 10px 14px;
   /* Wrap when the chat pane is narrow (3-pane laptop widths, ≤860px mobile).
    * Without this the flex:none actions squeeze the flex:1 identity to width:0
@@ -207,7 +213,11 @@
  * (shown at ≤860px in the conversation media block). On desktop the roster is
  * always visible, so the button is hidden. */
 .kw-chat-back { display: none; flex: none; }
-.kw-chat-name { font-size: var(--fs-20); font-weight: var(--fw-bold); letter-spacing: -0.01em; color: var(--color-fg-primary); margin: 0; white-space: nowrap; }
+/* B2: display-font name with positive tracking — the standalone's austere
+   "instrument panel" voice (Space Grotesk under [data-skin=v2], theme-aware via
+   --font-display). Weight eased to semi (was bold) so the wider tracking reads
+   engraved rather than heavy; tracking flipped negative→+0.02em. */
+.kw-chat-name { font-family: var(--font-display); font-size: var(--fs-20); font-weight: var(--fw-semi); letter-spacing: 0.02em; color: var(--color-fg-primary); margin: 0; white-space: nowrap; }
 
 .kw-state-pill {
   display: inline-flex; align-items: center; gap: 6px;
@@ -438,3 +448,33 @@
 }
 .kw-cmp-snap-lists { display: flex; flex-direction: column; gap: 4px; font-size: var(--fs-11); color: var(--color-fg-secondary); }
 .kw-cmp-snap-lists b { color: var(--color-fg-primary); font-weight: var(--fw-semi); margin-right: 4px; }
+
+/* ════ B3 — message bubbles: asymmetric "speech tail" + emboss ═══════
+ * Ported from the standalone v2 .bubble: a sharp corner on the speaker side
+ * (assistant top-left, user top-right) so each bubble points toward its author,
+ * plus a faint inner top-highlight emboss. Scoped to the workspace conversation
+ * (data-keeper-chat-layout="workspace") so the shared ChatTranscript used by
+ * every other surface keeps its symmetric rounded bubbles. The light-highlight
+ * emboss assumes the dark v2 skin; a paper/light theme would want an ink shadow
+ * instead (deferred — workspace is dark-skin today). */
+[data-keeper-chat-layout="workspace"] .chat-bubble {
+  border-radius: 4px 14px 14px 14px;
+  box-shadow: inset 0 1px 0 rgb(247 241 230 / 0.05), 0 2px 6px rgb(0 0 0 / 0.34);
+}
+[data-keeper-chat-layout="workspace"] .chat-bubble.user {
+  border-radius: 14px 4px 14px 14px;
+}
+
+/* ════ B4 — sigil heartbeat: a running keeper's avatar breathes ══════
+ * Replaces WorkspaceSigil's static glow (beat=true) with a 1.5s pulse, matching
+ * the standalone .sigil.heartbeat. --sigil-glow is set inline per keeper slot
+ * color by WorkspaceSigil; the fallback keeps the keyframe valid if it is unset.
+ * Honors prefers-reduced-motion by falling back to a steady glow. */
+@keyframes kw-sigil-beat {
+  0%, 100% { box-shadow: 0 0 6px rgb(var(--sigil-glow, 255 255 255) / 0.45); }
+  50%      { box-shadow: 0 0 14px rgb(var(--sigil-glow, 255 255 255) / 0.85); }
+}
+.kw-sigil-beat { animation: kw-sigil-beat 1.5s ease-in-out infinite; }
+@media (prefers-reduced-motion: reduce) {
+  .kw-sigil-beat { animation: none; box-shadow: 0 0 8px rgb(var(--sigil-glow, 255 255 255) / 0.5); }
+}

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -478,3 +478,34 @@
 @media (prefers-reduced-motion: reduce) {
   .kw-sigil-beat { animation: none; box-shadow: 0 0 8px rgb(var(--sigil-glow, 255 255 255) / 0.5); }
 }
+
+/* ════ C1 — day divider in the transcript ═══════════════════════════
+ * Standalone .daydiv: a centered uppercase date with a hairline rule on each
+ * side. Rendered by ChatTranscript only when showDayDividers (workspace). */
+.kw-daydiv {
+  display: flex; align-items: center; gap: 12px;
+  margin: 4px 0;
+  font-size: var(--fs-10); letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--color-fg-muted);
+}
+.kw-daydiv::before, .kw-daydiv::after {
+  content: ""; flex: 1; height: 1px; background: var(--color-border-divider);
+}
+
+/* ════ C2 — message source badge ════════════════════════════════════
+ * Distinguishes non-obvious message provenance (world-state / internal /
+ * tool / system) from a plain user/assistant turn. Mirrors the standalone
+ * .src-badge chip; colors are semantic and tied to the dashboard tokens
+ * (the standalone's channel colors don't map to the live transport). */
+.kw-src-badge {
+  display: inline-flex; align-items: center;
+  font-size: var(--fs-10); letter-spacing: 0.08em; text-transform: uppercase;
+  font-weight: var(--fw-semi);
+  padding: 1px 6px; border-radius: var(--r-1);
+  color: var(--color-fg-secondary);
+  background: var(--color-bg-surface); border: 1px solid var(--color-border-default);
+}
+.kw-src-badge.world    { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
+.kw-src-badge.internal { color: var(--color-fg-muted); }
+.kw-src-badge.tool     { color: var(--color-status-ok); border-color: rgb(var(--color-status-ok-glow) / 0.4); }
+.kw-src-badge.system   { color: var(--color-status-warn); border-color: rgb(var(--color-status-warn-glow) / 0.4); }


### PR DESCRIPTION
## 무엇을 / 왜

오늘 받은 standalone v2 목업(`MASC v2 — Keeper Agent`)을 기준으로 keeper 채팅 surface의 시각 완성도를 끌어올렸다. 핵심 발견은 **라이브 keeper workspace가 이미 같은 v2 디자인의 포팅 결과물**(`keeper-workspace.css` 헤더 주석 + 토큰 매핑 테이블)이라는 점 — 그래서 "통째 재포팅"(과거 #21486 → #21490 revert)이 아니라 목업이 가진 것 중 라이브에 빠졌거나 다르게 된 **델타만 선택 흡수**한다.

모든 변경은 `[data-keeper-chat-layout="workspace"]` 스코프 또는 opt-in prop(기본 false)으로 게이팅되어 **다른 chat surface(copilot dock, detail page 등) 렌더는 byte-identical**하다.

## 변경

**B — voice (keeper-workspace.css + WorkspaceSigil)**
- B1: 채팅 헤더 배경을 flat에서 panel→deep 세로 그라데이션으로.
- B2: 헤더 이름에 skin display 폰트(`--font-display`, v2에서 Space Grotesk) + 양수 트래킹. weight bold→semi(넓은 트래킹이 무겁지 않게).
- B3: 메시지 버블에 비대칭 speech-tail 모서리(assistant 좌상단·user 우상단 sharp) + 내부 top emboss.
- B4: 실행 중 키퍼 sigil이 1.5s 박동(정적 글로우 대체). `prefers-reduced-motion` 존중.
- B5: roster 행 패딩 11→8로 밀도 상향. `align-items`는 standalone의 center가 아니라 start 유지 — 라이브 행은 3번째 work-preview 줄을 갖기 때문.

**C — transcript (ChatTranscript opt-in props)**
- C1 (`showDayDividers`): 캘린더 일자별 첫 메시지 앞에 `.kw-daydiv` 삽입. 라벨은 `entry.timestamp`만의 함수인 절대 "M월 D일"(상대 오늘/어제 아님)이라 결정론적·스냅샷 안정.
- C2 (`showSourceBadge`): standalone의 `.src-badge`는 외부 채널(discord/slack/imessage)을 표시하지만 라이브 transport엔 그 데이터가 없다(`source`는 *의미론적* 출처). 그래서 헷갈리기 쉬운 출처(world_state_prompt/internal_assistant/tool_result/system)만 배지화하고 평범한 direct_user/direct_assistant는 미표시.

두 prop은 workspace의 `KeeperConversationPanel` 호출처에서만 켠다.

## 범위 밖 (D1 — 키퍼 초상)

목업은 일러스트 초상을 쓰지만, 디자인 원본이 초상을 명시적으로 "optional flavor"로 두고 sigil(슬롯색+모노그램)을 primary identity로 삼는다(일부 키퍼 `portrait: null`). 라이브 Keeper 타입엔 portrait 필드가 없고, 목업의 초상 10종은 라이브 키퍼와 매핑 0개(가상 키퍼 bespoke 아트). 따라서 sigil 기본선(B4 박동 추가)을 유지하고, 초상은 별도 아트-에셋 워크스트림으로 분리한다.

## 검증

- `tsc --noEmit`: 0 에러
- `eslint src/...`(변경 파일): 0
- `vitest`(chat primitives + keeper-workspace): 통과, C1/C2 동작 테스트 4개 신규 추가(divider 개수·라벨 형식, 배지 존재/부재/flag-off)
- `vite build`: 통과(19s)
- 시각 확인: 빌드 CSS + 실제 클래스 구조 기반 fixture 렌더 스크린샷

RFC-WAIVED: dashboard 채팅 UI(CSS + Preact 컴포넌트)만 변경. credential/identity/operator/sandbox/hooks 등 RFC 게이트 대상 subsystem 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
