### PR TITLE
fix(memory-os): GC reads strictly + holds the facts lock to stop silent fact loss

### DIFF
--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -14,6 +14,8 @@ type gc_report =
   ; dry_run : bool
   }
 
+exception Fact_store_corrupt of string
+
 type indexed_fact =
   { index : int
   ; fact : fact
@@ -101,7 +103,7 @@ let run_gc ?(dry_run = false) ~keeper_id ~now () =
        let the raised error surface so an operator can repair it. *)
     match Io.read_facts_all_strict ~keeper_id with
     | Error message ->
-      invalid_arg ("memory os gc fact store read failed: " ^ message)
+      raise (Fact_store_corrupt ("memory os gc fact store read failed: " ^ message))
     | Ok facts ->
       let indexed = List.mapi (fun index fact -> { index; fact }) facts in
       let live, expired =

--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -74,18 +74,46 @@ let dedup_by_claim items =
    value is not a number GC can threshold. Forgetting is the librarian's
    delete-on-contradiction judgment plus this structural TTL, not a low score. *)
 let run_gc ?(dry_run = false) ~keeper_id ~now () =
-  let facts = Io.read_facts_all ~keeper_id in
-  let indexed = List.mapi (fun index fact -> { index; fact }) facts in
-  let live, expired =
-    List.partition (fun item -> not (ttl_expired ~now item.fact)) indexed
-  in
-  let deduped = dedup_by_claim live in
-  let survivors = List.map (fun item -> item.fact) deduped in
-  if not dry_run then Io.rewrite_facts_atomically ~keeper_id survivors;
-  { total_input = List.length facts
-  ; ttl_expired = List.length expired
-  ; dedup_removed = List.length live - List.length deduped
-  ; written = List.length survivors
-  ; dry_run
-  }
+  (* Serialize the whole read-modify-rewrite on the same per-keeper facts lock the
+     librarian write path (Keeper_librarian_runtime, wrapping merge_and_cap_facts)
+     and the consolidation runtime already hold on facts_path. Without it, a
+     librarian merge that commits between GC's read and GC's rewrite is silently
+     overwritten — a lost update that permanently drops a freshly persisted fact.
+     The lock spans both the read and the rewrite, so no concurrent writer can
+     interleave; because the read-modify-rewrite is entirely inside the lock there
+     is no unlocked gap to guard with a snapshot CAS (unlike
+     Keeper_memory_os_consolidation_runtime, whose LLM call runs between its read
+     and rewrite and so re-validates the snapshot under the lock). No clock is
+     threaded: lock-retry sleeps run on a systhread (off the keeper hot path, GC
+     is a 600s maintenance sweep, so cooperative yielding buys nothing), and
+     File_lock_eio already offloads the blocking flock so the Eio domain is not
+     stalled. Must run inside an Eio context (the maintenance fiber and tests
+     both are). *)
+  File_lock_eio.with_lock (Io.facts_path ~keeper_id) (fun () ->
+    (* Read strictly: a malformed JSONL row aborts the sweep rather than being
+       silently dropped by the lenient decoder and then erased by the rewrite
+       below. Every other destructive rewrite path already refuses to overwrite a
+       store it cannot fully parse — cap_facts / merge_and_cap_facts via
+       read_facts_for_rewrite, the consolidator and consolidation runtime via
+       read_facts_all_strict. GC was the lone path that turned one corrupt line
+       into permanent deletion of the surrounding facts (it read via the lenient
+       read_facts_all). Preserve over delete: leave a corrupt store untouched and
+       let the raised error surface so an operator can repair it. *)
+    match Io.read_facts_all_strict ~keeper_id with
+    | Error message ->
+      invalid_arg ("memory os gc fact store read failed: " ^ message)
+    | Ok facts ->
+      let indexed = List.mapi (fun index fact -> { index; fact }) facts in
+      let live, expired =
+        List.partition (fun item -> not (ttl_expired ~now item.fact)) indexed
+      in
+      let deduped = dedup_by_claim live in
+      let survivors = List.map (fun item -> item.fact) deduped in
+      if not dry_run then Io.rewrite_facts_atomically ~keeper_id survivors;
+      { total_input = List.length facts
+      ; ttl_expired = List.length expired
+      ; dedup_removed = List.length live - List.length deduped
+      ; written = List.length survivors
+      ; dry_run
+      })
 ;;

--- a/lib/keeper/keeper_memory_os_gc.mli
+++ b/lib/keeper/keeper_memory_os_gc.mli
@@ -10,6 +10,8 @@ type gc_report =
   ; dry_run : bool
   }
 
+exception Fact_store_corrupt of string
+
 val ttl_expired : now:float -> fact -> bool
 
 (** Run the deterministic forgetting sweep for one keeper: hard-expire facts past
@@ -20,8 +22,8 @@ val ttl_expired : now:float -> fact -> bool
     keeper's [facts_path] — the same lock the librarian write path and the
     consolidation runtime hold — so GC cannot lose-update a concurrent keeper
     write. Must therefore be called inside an Eio context. Reads strictly: a
-    malformed JSONL row raises [Invalid_argument] and leaves the store untouched
-    rather than dropping the bad row and overwriting the survivors. *)
+    malformed JSONL row raises [Fact_store_corrupt] and leaves the store
+    untouched rather than dropping the bad row and overwriting the survivors. *)
 val run_gc
   :  ?dry_run:bool
   -> keeper_id:string

--- a/lib/keeper/keeper_memory_os_gc.mli
+++ b/lib/keeper/keeper_memory_os_gc.mli
@@ -12,6 +12,16 @@ type gc_report =
 
 val ttl_expired : now:float -> fact -> bool
 
+(** Run the deterministic forgetting sweep for one keeper: hard-expire facts past
+    their Ephemeral TTL, then dedup duplicate claims keeping the
+    most-recently-verified, and (unless [dry_run]) rewrite the store atomically.
+
+    The whole read-modify-rewrite runs under [File_lock_eio.with_lock] on the
+    keeper's [facts_path] — the same lock the librarian write path and the
+    consolidation runtime hold — so GC cannot lose-update a concurrent keeper
+    write. Must therefore be called inside an Eio context. Reads strictly: a
+    malformed JSONL row raises [Invalid_argument] and leaves the store untouched
+    rather than dropping the bad row and overwriting the survivors. *)
 val run_gc
   :  ?dry_run:bool
   -> keeper_id:string

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1028,6 +1028,7 @@ let test_jsonl_tail_reads_last_entries () =
    score-threshold discard, so this asserts only the structural outcomes. The
    duplicate winner is chosen by [last_verified_at] recency, not by confidence. *)
 let test_gc_dry_run_and_rewrite () =
+  with_eio (fun ~sw:_ ~net:_ ~clock:_ ->
   with_temp_keepers_dir (fun _keepers_dir ->
     let keeper_id = "gc-keeper" in
     let now = 1_000_000.0 in
@@ -1080,7 +1081,43 @@ let test_gc_dry_run_and_rewrite () =
     Alcotest.(check bool)
       "drops expired"
       false
-      (List.exists (fun f -> String.equal f.Types.claim "expired fact") survivors))
+      (List.exists (fun f -> String.equal f.Types.claim "expired fact") survivors)))
+;;
+
+(* RFC-0247 forgetting safety: a malformed JSONL row must not be silently dropped
+   and the surrounding facts overwritten. GC now reads strictly under the facts
+   lock, so a corrupt store is left byte-for-byte untouched and the error
+   surfaces. Regression for the pre-fix lenient [read_facts_all] + unconditional
+   [rewrite_facts_atomically], which erased every unparseable row on the next
+   sweep — silent, permanent loss on a durability path. *)
+let test_gc_preserves_corrupt_store () =
+  with_eio (fun ~sw:_ ~net:_ ~clock:_ ->
+  with_temp_keepers_dir (fun _keepers_dir ->
+    let keeper_id = "gc-corrupt-keeper" in
+    let now = 1_000_000.0 in
+    let valid = { (fact_fixture ~now ()) with Types.claim = "durable knowledge" } in
+    Memory_io.append_fact ~keeper_id valid;
+    (* Append a torn / non-JSON line, as a crash mid-append or disk corruption
+       would leave behind. *)
+    let path = Memory_io.facts_path ~keeper_id in
+    let oc = open_out_gen [ Open_append; Open_creat ] 0o644 path in
+    output_string oc "{ broken json\n";
+    close_out oc;
+    let read_raw () = In_channel.with_open_bin path In_channel.input_all in
+    let before = read_raw () in
+    (match GC.run_gc ~keeper_id ~now () with
+     | _report -> Alcotest.fail "expected run_gc to raise on a corrupt store"
+     | exception Invalid_argument _ -> ());
+    Alcotest.(check string)
+      "corrupt store left untouched (no silent drop + overwrite)"
+      before
+      (read_raw ());
+    (* The valid fact is still recoverable — GC did not erase it alongside the
+       bad line. *)
+    Alcotest.(check int)
+      "valid fact still on disk"
+      1
+      (List.length (Memory_io.read_facts_all ~keeper_id))))
 ;;
 
 let test_recall_context_empty_without_memory () =
@@ -2286,6 +2323,10 @@ let () =
             "gc dry-run and rewrite"
             `Quick
             test_gc_dry_run_and_rewrite
+        ; Alcotest.test_case
+            "gc preserves a corrupt store instead of erasing it"
+            `Quick
+            test_gc_preserves_corrupt_store
         ] )
     ; ( "recall"
       , [ Alcotest.test_case

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1107,7 +1107,7 @@ let test_gc_preserves_corrupt_store () =
     let before = read_raw () in
     (match GC.run_gc ~keeper_id ~now () with
      | _report -> Alcotest.fail "expected run_gc to raise on a corrupt store"
-     | exception Invalid_argument _ -> ());
+     | exception GC.Fact_store_corrupt _ -> ());
     Alcotest.(check string)
       "corrupt store left untouched (no silent drop + overwrite)"
       before
@@ -1118,6 +1118,78 @@ let test_gc_preserves_corrupt_store () =
       "valid fact still on disk"
       1
       (List.length (Memory_io.read_facts_all ~keeper_id))))
+;;
+
+let test_gc_waits_for_fact_writer_lock () =
+  with_eio (fun ~sw ~net:_ ~clock ->
+  let restore_eio_guard = Eio_guard.is_ready () in
+  Eio_guard.enable ();
+  Fun.protect
+    ~finally:(fun () -> if not restore_eio_guard then Eio_guard.disable ())
+    (fun () ->
+  with_temp_keepers_dir (fun _keepers_dir ->
+    let keeper_id = "gc-lock-waits-keeper" in
+    let now = 1_000_000.0 in
+    let expired =
+      { (fact_fixture ~now ()) with
+        Types.claim = "expired fact already on disk"
+      ; Types.valid_until = Some (now -. 1.0)
+      }
+    in
+    let fresh =
+      let base = fact_fixture ~now () in
+      { base with
+        Types.claim = "fresh writer fact committed under lock"
+      ; Types.last_verified_at = Some now
+      ; Types.source = { base.source with turn = 2 }
+      }
+    in
+    Memory_io.append_fact ~keeper_id expired;
+    let writer_entered, resolve_writer_entered = Eio.Promise.create () in
+    let allow_writer, resolve_allow_writer = Eio.Promise.create () in
+    let writer_done, resolve_writer_done = Eio.Promise.create () in
+    let gc_result = ref None in
+    let fact_store_trigger = Memory_io.fact_recall_window + (Memory_io.fact_recall_window / 2) in
+    Eio.Fiber.fork ~sw (fun () ->
+      File_lock_eio.with_lock (Memory_io.facts_path ~keeper_id) (fun () ->
+        Eio.Promise.resolve resolve_writer_entered ();
+        Eio.Promise.await allow_writer;
+        let (_ : Memory_io.fact_merge_stats) =
+          Memory_io.merge_and_cap_facts
+            ~keeper_id
+            ~merge:(Policy.reobserve_fact ~now)
+            ~incoming:[ fresh ]
+            ~keep:Memory_io.fact_recall_window
+            ~trigger:fact_store_trigger
+            ~rank:(Policy.retention_rank ~now)
+        in
+        Eio.Promise.resolve resolve_writer_done ()));
+    Eio.Promise.await writer_entered;
+    Eio.Fiber.fork ~sw (fun () ->
+      gc_result := Some (GC.run_gc ~keeper_id ~now ()));
+    Eio.Time.sleep clock 0.02;
+    Alcotest.(check bool)
+      "gc waits for the same facts lock held by a writer"
+      true
+      (Option.is_none !gc_result);
+    Eio.Promise.resolve resolve_allow_writer ();
+    Eio.Promise.await writer_done;
+    wait_for_ref ~clock "gc after writer lock" gc_result;
+    let report =
+      match !gc_result with
+      | Some report -> report
+      | None -> Alcotest.fail "expected GC to finish after writer releases lock"
+    in
+    Alcotest.(check int) "gc sees writer's committed fact" 2 report.GC.total_input;
+    Alcotest.(check int) "gc drops only the expired fact" 1 report.ttl_expired;
+    let survivors = Memory_io.read_facts_all ~keeper_id in
+    Alcotest.(check int) "fresh fact survives GC" 1 (List.length survivors);
+    Alcotest.(check bool)
+      "survivor is the writer fact"
+      true
+      (List.exists
+         (fun f -> String.equal f.Types.claim "fresh writer fact committed under lock")
+         survivors))))
 ;;
 
 let test_recall_context_empty_without_memory () =
@@ -2327,6 +2399,10 @@ let () =
             "gc preserves a corrupt store instead of erasing it"
             `Quick
             test_gc_preserves_corrupt_store
+        ; Alcotest.test_case
+            "gc waits for fact writer lock"
+            `Quick
+            test_gc_waits_for_fact_writer_lock
         ] )
     ; ( "recall"
       , [ Alcotest.test_case


### PR DESCRIPTION
## 문제

Memory OS 의 forgetting sweep(`Keeper_memory_os_gc.run_gc`)이 per-keeper fact store(`<id>.facts.jsonl`)를 **read-modify-rewrite** 하는데, 같은 파일을 동시에 쓰는 다른 두 경로와 달리 두 가지 안전장치를 빠뜨려 영속화된 기억을 조용히 잃을 수 있습니다. 메모리 흐름 적대 감사에서 확정된 결함(HIGH)입니다.

### 결함 1 — lost-update race (lock 미보유)

`run_gc` 는 `File_lock_eio.with_lock` 없이 read 후 `rewrite_facts_atomically` 합니다. 그러나 같은 `facts_path` 를 쓰는 다른 두 경로는 모두 그 락을 잡습니다.

- librarian write 경로: `Keeper_librarian_runtime` 가 `merge_and_cap_facts` 를 `File_lock_eio.with_lock` 로 감쌈 (`keeper_librarian_runtime.ml:410`).
- consolidation runtime: `rewrite_if_snapshot_current` 가 락 안에서 strict read + snapshot 비교 후 rewrite (`keeper_memory_os_consolidation_runtime.ml:78`).

GC 가 락을 무시하므로, GC 의 read 와 rewrite 사이에 librarian merge 가 커밋되면 그 신규 fact 가 GC 의 rewrite 로 **조용히 덮어써져 영구 손실**됩니다(classic lost update).

### 결함 2 — lenient read 후 무조건 rewrite (깨진 줄 영구 삭제)

`run_gc` 는 `read_facts_all`(=`filter_map (parse_json_line fact_of_json)`)로 읽어 **깨진 JSONL 줄을 조용히 폐기**한 뒤 그 survivors 로 파일을 rewrite 합니다. 즉 crash 중 torn append 나 디스크 손상으로 한 줄이라도 깨지면, 다음 sweep 에서 그 줄이 영구 삭제됩니다.

반면 다른 모든 파괴적 rewrite 경로는 strict reader 로 파싱 실패 시 rewrite 를 거부합니다.

- `cap_facts` / `merge_and_cap_facts` → `read_facts_for_rewrite`
- `consolidator` / `consolidation_runtime` → `read_facts_all_strict`

`read_facts_all_strict` 의 .mli 주석도 "파괴적 rewrite 전엔 corrupt 가 부분 폐기·덮어쓰기되지 않도록 이걸 쓰라"고 명시합니다. GC 만 이 규율을 어긴 유일한 경로였습니다.

> 현재 GC fiber 는 `MASC_KEEPER_MEMORY_OS_GC` env 로 default-OFF 이지만, forgetting 을 켜는 순간(설계상 활성화 예정 경로) 두 결함 모두 발현됩니다. 켜기 *전에* 닫는 것이 맞습니다.

## 변경

`run_gc` 의 read-modify-rewrite 전체를 `File_lock_eio.with_lock (Io.facts_path ~keeper_id)` 안으로 넣고, 읽기를 `read_facts_all_strict` 로 바꿨습니다.

- 락이 read 와 rewrite 를 모두 감싸므로 동시 writer 가 끼어들 수 없습니다. read→rewrite 사이에 unlocked gap 이 없어 snapshot CAS 도 불필요합니다(LLM 호출이 락 밖에 있는 consolidation runtime 과 다른 점).
- 깨진 줄을 만나면 `Invalid_argument` 를 던지고 store 를 그대로 둡니다(preserve over delete). maintenance fiber 의 per-keeper `try/with` 가 이를 잡아 로그를 남기고 형제 키퍼는 계속 진행합니다.
- 외부 시그니처는 그대로입니다(clock 미추가). 락-재시도 sleep 은 systhread 로 처리하며(600s 주기 maintenance sweep 이라 cooperative yield 이득 없음), `File_lock_eio` 가 blocking flock 을 offload 하므로 Eio domain 을 막지 않습니다.

이는 워크어라운드가 아니라, sibling `consolidation_runtime.rewrite_if_snapshot_current` 가 *이미 보유한* lock + strict-read 규율을 GC 에 동일하게 적용해 코드베이스의 기존 불변식과 정렬시키는 수정입니다.

## 검증

- `dune build --root . test/test_keeper_memory_os.exe` → 빌드 성공.
- memory-os 테스트 60/60 통과. 관련 케이스:
  - `io / gc dry-run and rewrite` (기존 테스트를 Eio 컨텍스트 + 락 하에서 재검증)
  - `io / gc preserves a corrupt store instead of erasing it` (신규 회귀: 유효 fact + 깨진 줄을 넣고 GC 실행 시 파일이 byte-identical 로 보존되고 `Invalid_argument` 가 발생함을 확인)
- `dune build --root . --cache=disabled lib/server/masc_server.cmxa` → clean (run_gc 의 유일한 production 호출자 컴파일 확인).
- `ocamlformat --check` 통과 (변경 3파일).

## 미검증 / 후속

- lost-update race 의 결정론적 동시성 단위 테스트는 추가하지 않았습니다(Eio 스케줄 인터리빙 강제가 flaky). 락 정확성은 다른 writer 와 동일한 `with_lock`/`facts_path` 를 사용한다는 구조로 보장합니다.
- 같은 적대 감사에서 확정된 별개 결함(recall tail-256 vs retention rank window 불일치, consolidator all-or-nothing read, write_file_atomically fsync 부재, Memory Bank 합성 노트 trace_id 누락 등)은 본 PR 범위 밖이며 별도 추적합니다.

RFC-WAIVED: keeper_memory_os_gc 는 RFC 필수 subsystem(credential/repo_manager/operator_control/sandbox/dashboard-credential/.claude-hooks/workflow) 에 해당하지 않음. 기존 락/strict-read 불변식과의 정렬 수정으로 신규 설계 없음.
