### PR TITLE
fix(dashboard): run metrics-cache compute in an Eio context, not a bare systhread

### DIFF
--- a/lib/core/executor_pool_ref.mli
+++ b/lib/core/executor_pool_ref.mli
@@ -11,3 +11,13 @@ val get : unit -> Eio.Executor_pool.t option
 val set : Eio.Executor_pool.t -> unit
 (** Install the pool reference. Idempotent overwrite. *)
 
+val submit_or_inline : ?weight:float -> (unit -> 'a) -> 'a
+(** Run [f] on an Executor_pool worker (a real Eio fiber under
+    [Eio.Switch.run], so effect-based ops keep their handlers), or inline
+    in the current fiber when no pool is installed (tests, pre-init).
+
+    Unlike [Eio_unix.run_in_systhread], the closure runs with a live
+    [Cancel.Get_context] handler, so code that takes an [Eio.Mutex]
+    (e.g. via [Keeper_fs.ensure_dir]) does not raise [Effect.Unhandled]
+    and cannot poison the mutex.  Re-raises [Eio.Cancel.Cancelled]. *)
+

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -48,7 +48,19 @@ let cached_dashboard_json ~sync_first ~sw ~cache ~key ~placeholder ~compute =
   let now = Unix.gettimeofday () in
   let run_compute_and_store entry =
     let result =
-      try Ok (Eio_guard.run_in_systhread compute) with
+      (* Offload via the Executor_pool, NOT [Eio_guard.run_in_systhread].
+         The keeper-* computes transitively reach [Keeper_fs.ensure_dir],
+         which takes the shared [dir_mu] through [Eio.Mutex.use_rw ~protect].
+         On a bare systhread there is no Eio effect handler, so [Cancel.protect]
+         performs [Get_context] with no handler -> [Effect.Unhandled], which
+         [use_rw] turns into a poison of [dir_mu] -> every file write in the
+         process then fails with [Eio.Mutex.Poisoned] (keeper persistence dies).
+         Executor_pool workers run [f] inside [Eio.Switch.run] (a real fiber
+         with a [Get_context] handler), so [use_rw] resolves normally; when no
+         pool is set [submit_or_inline] runs inline in the calling fiber, which
+         also carries an Eio context. *)
+      try Ok (Executor_pool_ref.submit_or_inline compute) with
+      | Eio.Cancel.Cancelled _ as e -> raise e
       | exn -> Error (Printexc.to_string exn)
     in
     (* NDT-OK: moved cache freshness timestamp; wall-clock metadata is boundary output. *)

--- a/test/dune
+++ b/test/dune
@@ -667,6 +667,11 @@
   test_board_metrics_labels)
  (libraries masc_test_deps))
 
+(tests
+ (names test_executor_pool_eio_mutex)
+ (modules test_executor_pool_eio_mutex)
+ (libraries masc_test_deps))
+
 ; Focused single-module tests
 
 ; Group 3: Eio-native tests (single-module, standard deps)

--- a/test/test_executor_pool_eio_mutex.ml
+++ b/test/test_executor_pool_eio_mutex.ml
@@ -1,0 +1,74 @@
+open Alcotest
+
+(** Regression for the 2026-06-19 keeper stall.
+
+    The dashboard metrics cache compute was offloaded via
+    [Eio_guard.run_in_systhread] — a bare OS thread with no Eio effect handler.
+    The compute reached [Keeper_fs.ensure_dir], which takes the process-shared
+    [dir_mu] through [Eio.Mutex.use_rw ~protect:true].  [Cancel.protect]
+    performs [Get_context] as its first action; with no handler on the systhread
+    that raises [Effect.Unhandled], which [use_rw] converts into a poison of
+    [dir_mu].  Every file write in the process then failed with
+    [Eio.Mutex.Poisoned], so no keeper could persist and the fleet stalled.
+
+    The fix routes such compute through [Executor_pool_ref.submit_or_inline],
+    which runs the closure as a real Eio fiber (under [Eio.Switch.run], on a
+    worker domain or inline), so [use_rw] keeps its [Get_context] handler and
+    the mutex is never poisoned.  These tests pin both directions. *)
+
+(* True iff taking [mu] raises [Eio.Mutex.Poisoned] (i.e. the mutex is dead). *)
+let poisons mu =
+  try
+    Eio.Mutex.use_rw ~protect:true mu (fun () -> ());
+    false
+  with
+  | Eio.Mutex.Poisoned _ -> true
+
+(* The bug: a bare systhread has no Eio handler, so [use_rw] inside it raises
+   [Effect.Unhandled(Get_context)] and poisons the mutex. This is exactly why
+   the dashboard cache compute must NOT use [Eio_guard.run_in_systhread]. *)
+let test_systhread_offload_poisons_mutex () =
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun _sw ->
+      Eio_guard.enable ();
+      Fun.protect ~finally:Eio_guard.disable (fun () ->
+        let mu = Eio.Mutex.create () in
+        let raised =
+          try
+            Eio_guard.run_in_systhread (fun () ->
+              Eio.Mutex.use_rw ~protect:true mu (fun () -> ()));
+            false
+          with
+          | _ -> true
+        in
+        check bool "use_rw inside a bare systhread raises" true raised;
+        check bool "and leaves the mutex poisoned" true (poisons mu))))
+
+(* The fix: [submit_or_inline] runs the closure with a live Eio context, so the
+   same [use_rw] resolves and the mutex stays usable afterwards. *)
+let test_submit_or_inline_preserves_mutex () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      Eio_guard.enable ();
+      Fun.protect ~finally:Eio_guard.disable (fun () ->
+        let dm = Eio.Stdenv.domain_mgr env in
+        let pool = Domain_pool.create ~sw ~domain_count:1 dm in
+        Executor_pool_ref.set (Domain_pool.executor_pool pool);
+        let mu = Eio.Mutex.create () in
+        let v =
+          Executor_pool_ref.submit_or_inline (fun () ->
+            Eio.Mutex.use_rw ~protect:true mu (fun () -> 7))
+        in
+        check int "use_rw inside offloaded closure returns its value" 7 v;
+        check bool "shared mutex is not poisoned after offload" false
+          (poisons mu))))
+
+let () =
+  Alcotest.run "Executor_pool_ref Eio mutex safety"
+    [ ( "offload"
+      , [ test_case "systhread offload poisons the mutex (bug)" `Quick
+            test_systhread_offload_poisons_mutex
+        ; test_case "submit_or_inline preserves the mutex (fix)" `Quick
+            test_submit_or_inline_preserves_mutex
+        ] )
+    ]


### PR DESCRIPTION
## 무엇을 / 왜

Dashboard 메트릭 캐시 refresh가 keeper 전체를 멈추게 하던 근본 원인을 고칩니다.

`cached_dashboard_json`의 compute는 `Eio_guard.run_in_systhread`로 offload됐습니다. 런타임에서는 이게 Eio effect 핸들러가 없는 **bare OS systhread**입니다. keeper-* 라우트(`/keeper-costs`, `/keeper-decisions`, `/keeper-memory-log`)의 compute는 `Keeper_meta_store.read_meta` → `keeper_dir` → `Keeper_fs.ensure_dir`를 거치며, 여기서 프로세스 공유 `dir_mu`를 `Eio.Mutex.use_rw ~protect:true`로 잡습니다.

`use_rw`의 `Cancel.protect`는 첫 동작으로 `Get_context` effect를 수행합니다. systhread에는 핸들러가 없어 `Effect.Unhandled(Cancel.Get_context)`가 발생하고, `use_rw`는 이를 받아 `dir_mu`를 **poison** 상태로 전환합니다. 그 뒤 프로세스의 모든 파일 쓰기(keeper chat append, save_atomic, decision-log, dashboard snapshot, supervisor sweep, TOML reconcile)가 `Eio.Mutex.Poisoned`로 실패하여 어떤 keeper도 상태를 저장하지 못하고 fleet이 멈췄습니다 (2026-06-19 관측).

## 변경

- `lib/server/server_routes_http_routes_provider_runs.ml`: compute offload를 `Eio_guard.run_in_systhread` → `Executor_pool_ref.submit_or_inline`로 교체. 후자는 closure를 `Eio.Switch.run` 아래 **실제 Eio fiber**(worker domain 또는 inline)로 실행하므로 `Get_context` 핸들러가 살아 있어 `use_rw`가 정상 resolve되고 mutex가 poison되지 않습니다. 구조적 동시성 보존을 위해 `Eio.Cancel.Cancelled`는 재전파합니다.
- `lib/core/executor_pool_ref.mli`: 이미 구현돼 있던 `submit_or_inline`을 인터페이스에 노출 (기존엔 `.ml`에만 존재).
- `test/test_executor_pool_eio_mutex.ml` (신규): 회귀 테스트 2종.

## 검증

- `dune build @check`: 0 errors.
- 회귀 테스트 양방향 통과:
  - `systhread offload poisons the mutex (bug)` — systhread + `use_rw`가 mutex를 poison시킴을 실증.
  - `submit_or_inline preserves the mutex (fix)` — 교체 후 동일 `use_rw`가 mutex를 정상 유지함을 확인.
- `ocamlformat --check`: 3개 변경 파일 모두 통과.

## 범위 밖 (후속)

근본 경계 불변식("offload 실행 컨텍스트는 Eio effect에 의존하는 코드를 호출하면 안 된다")을 `Eio_guard.run_in_systhread` 수준에서 강제하는 hardening은 핵심 primitive(호출처 6+)를 건드리므로 별도 변경으로 분리합니다. `keeper_fs.ml`의 deferred_exn 패턴(#8475)은 FS 실패 경로에 대해 이미 올바르게 동작하므로 유지합니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
