### PR TITLE
fix(dashboard): restore Logs to the primary desktop nav surface set

### DIFF
--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -60,7 +60,7 @@ describe('dashboard surface navigation', () => {
     expect(workspace?.defaultTab).toBe('workspace')
   })
 
-  it('keeps the v2 primary shell aligned to the prototype surface set', () => {
+  it('keeps the v2 primary shell aligned to the prototype surface set plus the operator-restored Logs surface', () => {
     expect(PRIMARY_DASHBOARD_SURFACES.map(surface => surface.id)).toEqual([
       'overview',
       'workspace',
@@ -69,6 +69,7 @@ describe('dashboard surface navigation', () => {
       'code',
       'connectors',
       'settings',
+      'logs',
     ])
     expect(PRIMARY_DASHBOARD_NAV_ITEMS.map(item => item.label)).toEqual([
       'Overview',
@@ -78,6 +79,7 @@ describe('dashboard surface navigation', () => {
       'IDE',
       'Connectors',
       'Settings',
+      'Logs',
     ])
   })
 

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -86,6 +86,12 @@ const V2_PRIMARY_SURFACE_IDS: ReadonlyArray<SurfaceId> = [
   'code',
   'connectors',
   'settings',
+  // 'logs' is kept in the primary surface set by operator request. #21525 dropped it
+  // from the desktop side rail (reachable only via Settings/command palette); operators
+  // still want the standalone Logs surface in the rail, so this deviates from the codex
+  // v2 prototype set on purpose. Settings is pinned in the rail footer, so logs renders
+  // as the last regular surface in the main list.
+  'logs',
 ]
 
 const SECTIONLESS_SURFACE_IDS: ReadonlySet<TabId> = new Set([


### PR DESCRIPTION
## 무엇을 / 왜

데스크톱 사이드바에서 **Logs 메뉴가 사라졌다**는 운영자 보고에 대응한다. 원인은 #21525 (`[codex] align keeper v2 dashboard surfaces`)가 v2 nav를 primary surface 집합으로 추리면서 `V2_PRIMARY_SURFACE_IDS`에서 `logs`를 제외한 것이다. 그 결과 standalone Logs surface는 Settings 하위 섹션 · 커맨드 팔레트 · 모바일 More 드로어로만 도달 가능했고, 데스크톱 `SideRail`에서는 보이지 않았다.

운영자 결정에 따라 `logs`를 primary surface 집합에 복원해 데스크톱 사이드바에 다시 노출한다.

## 변경

- `dashboard/src/config/navigation.ts`: `V2_PRIMARY_SURFACE_IDS`에 `'logs'`를 추가(맨 끝). Settings는 `SideRail`에서 footer로 고정 렌더되어 primary 목록에서 필터되므로(`dashboard-shell.ts`의 `PRIMARY_DASHBOARD_SURFACES.filter(id !== 'settings')`), Logs는 메인 목록의 마지막 일반 surface로 렌더된다. 모바일 하단바는 별도 curated 집합(`MOBILE_PRIMARY_TAB_IDS`)을 쓰므로 영향 없고, 모바일 More 드로어는 이미 `DASHBOARD_SURFACES` 전체를 써서 Logs를 표시하고 있었다. 코드 프로토타입 집합에서 의도적으로 벗어난 이유를 주석으로 남겼다(재강등 방지).
- `dashboard/src/config/navigation.test.ts`: primary surface 집합을 락하는 테스트(`PRIMARY_DASHBOARD_SURFACES` / `PRIMARY_DASHBOARD_NAV_ITEMS`)에 `logs` / `Logs`를 반영.

## 범위 밖 (의도적으로 안 건드림)

- Settings의 footer 고정, 모바일 하단바 curated 집합, 모바일 More 드로어 — 모두 그대로.
- Monitor · Command · Lab도 #21525에서 같이 강등됐지만, 이번 보고/결정은 Logs에 한정하므로 손대지 않는다.

## 검증

- `tsc --noEmit`: 0 에러
- `npm run lint` (eslint src): 0
- `npm test` (vitest.config.ts + vitest.solid.config.ts): 통과. 변경된 nav 락 테스트 포함, `dashboard-shell` SideRail · `mobile-nav` · `app` 테스트 green.
- `vite build`: 통과

RFC-WAIVED: dashboard 네비게이션 노출 설정(`navigation.ts`)만 변경. credential/identity/operator/sandbox/hooks 등 RFC 게이트 대상 subsystem 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
