### PR TITLE
fix(discord): reconnect with backoff on gateway connect failure instead of dying

### DIFF
--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -131,6 +131,8 @@ let set_presence (status : Discord_gateway_state.presence_status) =
 
 let reader_should_continue_after_input = function
   | Discord_gateway_state.Wss_closed _ -> false
+  (* The socket never came up; there is no reader to keep alive. *)
+  | Discord_gateway_state.Connect_failed _ -> false
   | Discord_gateway_state.Connect_requested
   | Discord_gateway_state.Frame_received _
   | Discord_gateway_state.Frame_parse_error _
@@ -250,6 +252,7 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
               | Discord_gateway_state.Connect_requested
               | Discord_gateway_state.Frame_parse_error _
               | Discord_gateway_state.Wss_closed _
+              | Discord_gateway_state.Connect_failed _
               | Discord_gateway_state.Heartbeat_tick
               | Discord_gateway_state.Heartbeat_ack_timeout
               | Discord_gateway_state.Backoff_elapsed
@@ -283,9 +286,22 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
          Discord_wss_connection.close old_conn;
          conn_ref := None
        | None -> ());
-      let conn = Discord_wss_connection.connect ~sw ~env ~url in
-      conn_ref := Some conn;
-      Eio.Fiber.fork ~sw (fun () -> reader_loop conn)
+      (match Discord_wss_connection.connect ~sw ~env ~url with
+       | conn ->
+         conn_ref := Some conn;
+         Eio.Fiber.fork ~sw (fun () -> reader_loop conn)
+       | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+       | exception exn ->
+         (* DNS / connect / TLS handshake failure: the socket never came up.
+            Feed Connect_failed so the FSM schedules a backoff reconnect
+            (reusing backoff_ms), instead of letting the exception unwind out
+            of the drive loop and kill the gateway with no restart. *)
+         let reason = Printexc.to_string exn in
+         log_effect `Warn
+           (Printf.sprintf "WSS connect failed: %s; scheduling reconnect"
+              reason);
+         Eio.Stream.add input_mailbox
+           (Discord_gateway_state.Connect_failed { reason }))
     | Close_wss { code; reason = _ } ->
       (* Phase 1.4b: explicit close. Discord_wss_connection.close
          resolves the inner session switch's close-signal promise,
@@ -393,6 +409,7 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
      | Discord_gateway_state.Frame_received _
      | Discord_gateway_state.Frame_parse_error _
      | Discord_gateway_state.Wss_closed _
+     | Discord_gateway_state.Connect_failed _
      | Discord_gateway_state.Heartbeat_tick
      | Discord_gateway_state.Heartbeat_ack_timeout
      | Discord_gateway_state.Status_change _ -> ());

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -911,6 +911,8 @@ let handle_wss_closed t ~now_mono ~code ~reason =
               }
           ] )
 
+(* TEL-OK: emits a typed Discord gateway [Log] effect on both handled and stale
+   connect-failure paths; the I/O layer owns transporting that effect. *)
 let handle_connect_failed t ~now_mono ~reason =
   match t.state with
   | Awaiting_hello | Identifying | Resuming ->

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -170,6 +170,10 @@ type input =
   | Frame_received of frame
   | Frame_parse_error of string
   | Wss_closed of { code : int; reason : string }
+  | Connect_failed of { reason : string }
+      (** The socket never came up (DNS / connect / TLS handshake failure),
+          as opposed to {!Wss_closed} where an established session ended.
+          Drives the same backoff reconnect path. *)
   | Heartbeat_tick
   | Heartbeat_ack_timeout
   | Backoff_elapsed
@@ -907,6 +911,35 @@ let handle_wss_closed t ~now_mono ~code ~reason =
               }
           ] )
 
+let handle_connect_failed t ~now_mono ~reason =
+  match t.state with
+  | Awaiting_hello | Identifying | Resuming ->
+      (* The socket never came up. Drive the same backoff reconnect as a
+         non-fatal Wss_closed, reusing [backoff_ms] / [make_reconnect_pending].
+         No Close_wss: there is no open connection to tear down (conn_ref was
+         never set by the I/O layer's Open_wss handler). *)
+      let resume_context = capture_resume_context t in
+      let resumable = Option.is_some resume_context in
+      let delay_ms = backoff_ms ~attempts:t.reconnect_attempts in
+      let t' =
+        make_reconnect_pending t ~now_mono ~delay_ms ~resumable ~resume_context
+      in
+      ( t'
+      , [ Schedule_backoff { delay_ms }
+        ; Log
+            { level = `Warn
+            ; message =
+                Printf.sprintf
+                  "WSS connect failed (%s); reconnect in %dms" reason delay_ms
+            }
+        ] )
+  | Disconnected | Reconnect_pending _ | Failed _ | Connected _ ->
+      (* No connection attempt is pending (already connected, idle, or
+         terminal): a late connect failure is stale; ignore it. *)
+      log_warn t
+        (Printf.sprintf
+           "Connect_failed (%s) outside a pending connection; ignoring" reason)
+
 let handle_heartbeat_ack_timeout t ~now_mono =
   match t.state with
   | Connected _ ->
@@ -1142,6 +1175,7 @@ let step t ~now_mono input =
       log_warn t (Printf.sprintf "frame parse error: %s" reason)
   | Wss_closed { code; reason } ->
       handle_wss_closed t ~now_mono ~code ~reason
+  | Connect_failed { reason } -> handle_connect_failed t ~now_mono ~reason
   | Heartbeat_tick -> handle_heartbeat_tick t ~now_mono
   | Heartbeat_ack_timeout -> handle_heartbeat_ack_timeout t ~now_mono
   | Backoff_elapsed -> handle_backoff_elapsed t ~now_mono

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -183,6 +183,10 @@ type input =
   | Frame_received of frame    (** Parsed inbound frame. *)
   | Frame_parse_error of string (** Decoded JSON, failed schema. *)
   | Wss_closed of { code : int; reason : string }
+  | Connect_failed of { reason : string }
+      (** Socket never came up (DNS / connect / TLS handshake failure), as
+          opposed to [Wss_closed] where an established session ended. Drives
+          the same backoff reconnect path. *)
   | Heartbeat_tick             (** Clock fired heartbeat interval. *)
   | Heartbeat_ack_timeout      (** No ack within 2x interval. *)
   | Backoff_elapsed            (** Reconnect timer fired. *)

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -301,6 +301,35 @@ let test_ready_transition () =
   check bool "Emit_event Ready sess-abc" true
     (has_emit_ready ~session_id:"sess-abc" effects)
 
+let test_connect_failed_schedules_backoff () =
+  let m = S.create ~config:(mk_config ()) in
+  let m, _ = S.step m ~now_mono:0.0 S.Connect_requested in
+  (* Awaiting_hello: a connection attempt is in flight. A DNS/connect failure
+     must reconnect with backoff, not unwind out of the drive loop. *)
+  let m', effects =
+    S.step m ~now_mono:1.0
+      (S.Connect_failed { reason = "getaddrinfo returned no result" })
+  in
+  (match S.state m' with
+   | S.Reconnect_pending _ -> ()
+   | _ -> fail "expected Reconnect_pending after Connect_failed");
+  check bool "Schedule_backoff effect emitted" true
+    (List.exists (function S.Schedule_backoff _ -> true | _ -> false) effects);
+  check bool "no Open_wss re-emitted synchronously" false (has_open_wss effects)
+
+let test_connect_failed_ignored_when_idle () =
+  let m = S.create ~config:(mk_config ()) in
+  (* Disconnected: no connection attempt pending, so a stale connect failure
+     is ignored (no state change, no backoff). *)
+  let m', effects =
+    S.step m ~now_mono:0.0 (S.Connect_failed { reason = "stale" })
+  in
+  (match S.state m' with
+   | S.Disconnected -> ()
+   | _ -> fail "expected Disconnected unchanged when idle");
+  check bool "no Schedule_backoff when idle" false
+    (List.exists (function S.Schedule_backoff _ -> true | _ -> false) effects)
+
 let test_heartbeat_tick_when_connected () =
   let m = S.create ~config:(mk_config ()) in
   let m, _ = S.step m ~now_mono:0.0 S.Connect_requested in
@@ -1958,6 +1987,11 @@ let () =
             test_ready_transition
         ; test_case "Heartbeat_tick (Connected) → Send_frame Op_heartbeat"
             `Quick test_heartbeat_tick_when_connected
+        ; test_case
+            "Connect_failed (Awaiting_hello) → Reconnect_pending + Schedule_backoff"
+            `Quick test_connect_failed_schedules_backoff
+        ; test_case "Connect_failed (idle) → ignored, no backoff" `Quick
+            test_connect_failed_ignored_when_idle
         ] )
     ; ( "presence"
       , [ test_case "Status_change (Connected) → opcode 3 STATUS_UPDATE"


### PR DESCRIPTION
## 무엇을 / 왜

In-process Discord gateway(RFC-0203)가 **DNS/connect 실패 시 영구히 죽던** 문제를 고칩니다.

`discord_wss_connection.build_session`은 `getaddrinfo`가 빈 결과를 주면 `failwith`로 예외를 던지고, `connect`가 이를 재전파합니다. 이 예외는 `Open_wss` effect 핸들러(try 없음)를 거쳐 drive loop 밖으로 빠져나가, gateway fiber를 **한 번 종료시키고 재시작하지 않습니다**(`server_discord_in_process_gateway`의 상위 핸들러는 로그만 남기고 fiber를 끝냄).

반면 세션이 성립한 뒤의 1011(No-route-to-host) close는 이미 FSM의 `Schedule_backoff`로 지수 backoff 재접속(최대 60s)을 잘 수행합니다. 즉 **연결 수립 실패만 재접속 경로에서 누락**돼 있었습니다 (2026-06-19 로그: `getaddrinfo returned no result for gateway-us-east1-c.discord.gg`).

## 변경

- `discord_gateway_state`: typed FSM 입력 `Connect_failed of { reason }` 추가 (`Wss_closed`와 의미 구분 — 소켓이 *애초에 안 올라온* 경우). `handle_connect_failed`는 기존 `backoff_ms` / `make_reconnect_pending` / `Schedule_backoff`를 **그대로 재사용**해 비-fatal `Wss_closed`와 동일한 backoff 재접속을 수행. **새 상수 0개** (backoff base=1_000ms / cap=60_000ms는 `backoff_ms`의 기존 SSOT, jitter는 I/O 레이어 ±25%).
- `discord_gateway_client`: `Open_wss` 핸들러가 `connect` 실패 시 예외를 drive loop로 흘리지 않고 `Connect_failed`를 input mailbox에 넣어 FSM이 backoff 재접속을 스케줄하게 함. `Eio.Cancel.Cancelled`는 재전파.
- exhaustive match 3곳(reader 사이드채널/`reader_should_continue_after_input`/reconnect 추적)에 `Connect_failed` 분기 추가 — OCaml 컴파일러가 누락을 강제 검출(`_ ->` catch-all 미사용).
- `test/test_discord_gateway_state.ml`: 회귀 테스트 2종 (Awaiting_hello→Reconnect_pending+Schedule_backoff / idle 상태 무시).

## 검증

- `dune build @check`: 0 errors.
- FSM 테스트 88건 통과(신규 2 포함), gateway_client 테스트 통과.
- `ocamlformat --check`: 변경 파일 전부 통과.

## 경계

연결 실패는 항상 transient(DNS/네트워크)로 간주해 backoff 재접속(fatal close code와 달리 `Failed` 전이 없음). 무한 재시도는 60s cap에서 멈추는 기존 비-fatal 동작과 동일합니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
