### PR TITLE
fix(memory-os): recall scans the whole bounded store via fact_store_max SSOT

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -417,7 +417,7 @@ let extract_and_append_with_provider
                ~merge:(Keeper_memory_os_policy.reobserve_fact ~now)
                ~incoming:episode.Keeper_memory_os_types.claims
                ~keep:window
-               ~trigger:(window + (window / 2))
+               ~trigger:Keeper_memory_os_io.fact_store_max
                ~rank:(Keeper_memory_os_policy.retention_rank ~now))
          in
          Ok ()

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -361,12 +361,23 @@ let read_facts_tail ~keeper_id ~n =
   |> take_last n
 ;;
 
-(* RFC-0239 Q4: the per-keeper fact recall window / retention target. The store
-   is bounded to this many facts by the retention sweep, and recall reads up to
-   this many candidates (no longer just the last 64), so score ranking selects
-   the globally best facts within the bounded store rather than the most recent
-   few. *)
+(* RFC-0239 Q4: the per-keeper fact recall *retention target* — the size the
+   store is trimmed back to when the cap fires. NOT the recall scan window: the
+   store legitimately holds up to [fact_store_max] facts between caps (see the
+   hysteresis note on [fact_store_max]), so a reader that scans only this many
+   tail rows can miss the highest-ranked rows the last cap wrote at the file head.
+   Recall scans [fact_store_max] for that reason. *)
 let fact_recall_window = 256
+
+(* The largest a bounded store can grow before the retention cap rewrites it: the
+   cap triggers when the store exceeds this and trims back to [fact_recall_window]
+   (hysteresis = [fact_recall_window]/2 keeps rewrites off the per-turn hot path).
+   SSOT for two callers that MUST agree: the librarian write path passes it as the
+   cap [trigger], and recall scans this many tail rows so it sees the entire
+   bounded store — including the high-rank durable rows a fresh cap places at the
+   file head, which a [fact_recall_window]-sized tail scan would exclude in the
+   [fact_recall_window]..[fact_store_max] band. *)
+let fact_store_max = fact_recall_window + (fact_recall_window / 2)
 
 let take_first n xs =
   let rec aux k = function

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -43,11 +43,18 @@ val read_episodes_tail : keeper_id:string -> n:int -> episode list
 
 (** {1 Retention (RFC-0239 Q4, supersedes RFC-0238 Capped_by_score)} *)
 
-(** Per-keeper fact recall window / retention target. The store is bounded to
-    this many facts; recall reads up to this many candidates (not just the last
-    few), so score ranking selects the globally best facts in the bounded
+(** Per-keeper fact retention target: the size the cap trims the store back to.
+    NOT the recall scan window — the store holds up to {!fact_store_max} between
+    caps, so recall scans {!fact_store_max} (not this) to see the whole bounded
     store. *)
 val fact_recall_window : int
+
+(** Upper bound on a bounded store between caps: the retention cap [trigger]
+    (= [fact_recall_window] + [fact_recall_window]/2). SSOT shared by the
+    librarian write path (cap trigger) and recall (tail scan window) so the read
+    side scans the entire bounded store — including the high-rank rows a fresh cap
+    writes at the file head, which a [fact_recall_window]-sized scan would miss. *)
+val fact_store_max : int
 
 (** Read and parse every fact in the store (unbounded; used by retention). *)
 val read_all_facts : keeper_id:string -> fact list

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -244,15 +244,16 @@ let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
   (* RFC-0244 Tier 2: append shared-semantic facts after the keeper's own, with
      private precedence — a claim already surfaced from this keeper's store is not
      repeated from the shared store. The shared store is read under the reserved
-     [shared_store_id]; reading it for the shared store itself is a no-op guard. *)
+     [shared_store_id]; reading it for the shared store itself is a no-op guard.
+     Unlike per-keeper stores, the consolidator rewrites the shared tier directly
+     and does not apply [fact_store_max], so recall must scan every shared fact
+     before ranking and taking the small communal slice. *)
   let private_keys = List.map (fun f -> normalize_claim f.claim) facts in
   let shared_facts =
     if String.equal keeper_id shared_store_id
     then []
     else
-      Keeper_memory_os_io.read_facts_tail
-        ~keeper_id:shared_store_id
-        ~n:Keeper_memory_os_io.fact_recall_window
+      Keeper_memory_os_io.read_facts_all ~keeper_id:shared_store_id
       |> facts_recency_ranked ~now
       |> List.filter (fun f -> not (List.mem (normalize_claim f.claim) private_keys))
       |> take default_max_shared_facts

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -9,7 +9,6 @@ let default_max_episodes = 2
    own (private-precedence) facts. Kept small so the communal tier informs
    without crowding out keeper-local memory. *)
 let default_max_shared_facts = 4
-let fact_tail_scan = 64
 let episode_tail_scan = 32
 let max_fact_text_len = 260
 let max_episode_text_len = 360
@@ -228,15 +227,17 @@ let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
   let max_facts = max 0 max_facts in
   let max_episodes = max 0 max_episodes in
   let facts =
-    (* RFC-0239 Q4: read up to the bounded recall window (the retention sweep
-       caps the store to this many facts), so recency ranking selects from the
-       whole store rather than only the most recent [fact_tail_scan].
-       RFC-0247: order by the structural truth anchor (most-recently-verified
+    (* RFC-0239 Q4: scan the whole bounded store, not a [fact_recall_window]-sized
+       tail. The store holds up to [fact_store_max] facts between caps, and a fresh
+       cap rewrites it in rank order — so the highest-ranked durable rows sit at
+       the file head while new appends land at the tail. Scanning only
+       [fact_recall_window] tail rows would exclude exactly those head rows in the
+       [fact_recall_window]..[fact_store_max] band; scanning [fact_store_max]
+       covers the entire bounded store so recency ranking selects the globally best
+       facts. RFC-0247: order by the structural truth anchor (most-recently-verified
        first); the composite score, lexical seed-rerank, and spreading-activation
        reranking were all removed in the purge. *)
-    Keeper_memory_os_io.read_facts_tail
-      ~keeper_id
-      ~n:(max fact_tail_scan Keeper_memory_os_io.fact_recall_window)
+    Keeper_memory_os_io.read_facts_tail ~keeper_id ~n:Keeper_memory_os_io.fact_store_max
     |> facts_recency_ranked ~now
     |> take max_facts
   in

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -72,7 +72,7 @@ let memory_os_episode_json ~now (episode : Keeper_memory_os_types.episode) =
 let memory_os_dashboard_json ~keeper_id =
   let now = Time_compat.now () in
   let recent_episode_limit = 12 in
-  let fact_tail_limit = Keeper_memory_os_io.fact_recall_window in
+  let fact_tail_limit = Keeper_memory_os_io.fact_store_max in
   let episodes, episode_error =
     memory_os_read_episodes ~keeper_id ~n:recent_episode_limit
   in

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1338,9 +1338,9 @@ let test_render_if_enabled_renders_persisted_memory () =
    (fact_recall_window, fact_store_max] band, a retention cap leaves the
    highest-ranked durable facts at the file head while newer appends land at the
    tail. Recall must scan fact_store_max (the whole bounded store), not a
-   fact_recall_window-sized tail, or it silently drops the best facts. Seed a head
-   fact verified now, then > fact_recall_window much-older fillers, and assert
-   recall still surfaces the head fact a tail-window scan would start past. *)
+   fact_recall_window-sized tail, or it silently drops the best facts. Drive the
+   real merge-and-cap rewrite first, append more tail rows, and assert recall
+   still surfaces the head fact a tail-window scan would start past. *)
 let test_recall_scans_whole_bounded_store () =
   with_recall_env "true" (fun () ->
     with_prompt_registry (fun () ->
@@ -1353,17 +1353,36 @@ let test_recall_scans_whole_bounded_store () =
           ; Types.last_verified_at = Some now
           }
         in
-        (* First append = file head (position 0). *)
-        Memory_io.append_fact ~keeper_id head;
-        let filler_count = Memory_io.fact_recall_window + 20 in
-        for i = 1 to filler_count do
-          let f =
+        let cap_fillers =
+          List.init Memory_io.fact_store_max (fun i ->
             { (fact_fixture ~now ()) with
-              Types.claim = Printf.sprintf "filler durable fact %d" i
+              Types.claim = Printf.sprintf "pre-cap filler durable fact %d" (i + 1)
             ; Types.last_verified_at = Some (now -. days 30 -. float_of_int i)
+            })
+        in
+        let cap_stats =
+          Memory_io.merge_and_cap_facts
+            ~keeper_id
+            ~merge:(Policy.reobserve_fact ~now)
+            ~incoming:(head :: cap_fillers)
+            ~keep:Memory_io.fact_recall_window
+            ~trigger:Memory_io.fact_store_max
+            ~rank:(Policy.retention_rank ~now)
+        in
+        Alcotest.(check bool) "cap rewrite dropped low-ranked rows" true (cap_stats.dropped > 0);
+        let capped = Memory_io.read_facts_all ~keeper_id in
+        Alcotest.(check int)
+          "cap rewrites to the recall window size"
+          Memory_io.fact_recall_window
+          (List.length capped);
+        for i = 1 to 20 do
+          let tail =
+            { (fact_fixture ~now ()) with
+              Types.claim = Printf.sprintf "post-cap tail durable fact %d" i
+            ; Types.last_verified_at = Some (now -. days 60 -. float_of_int i)
             }
           in
-          Memory_io.append_fact ~keeper_id f
+          Memory_io.append_fact ~keeper_id tail
         done;
         let total = List.length (Memory_io.read_facts_all ~keeper_id) in
         Alcotest.(check bool)
@@ -2111,6 +2130,40 @@ let test_recall_surfaces_shared_after_consolidation () =
            && not (contains "shared via" alpha_block)))))
 ;;
 
+let test_recall_scans_whole_shared_store () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun _keepers_dir ->
+        let now = 1_000_000.0 in
+        let shared_head =
+          { (mk_shared_fixture ~now "SHARED head fact verified most recently") with
+            Types.observed_by = [ "alpha"; "beta" ]
+          ; Types.last_verified_at = Some now
+          }
+        in
+        Memory_io.append_fact ~keeper_id:Types.shared_store_id shared_head;
+        for i = 1 to Memory_io.fact_recall_window + 10 do
+          let filler =
+            { (mk_shared_fixture ~now (Printf.sprintf "old shared filler fact %d" i)) with
+              Types.observed_by = [ "alpha"; "beta" ]
+            ; Types.last_verified_at = Some (now -. days 30 -. float_of_int i)
+            }
+          in
+          Memory_io.append_fact ~keeper_id:Types.shared_store_id filler
+        done;
+        let total = List.length (Memory_io.read_facts_all ~keeper_id:Types.shared_store_id) in
+        Alcotest.(check bool)
+          "shared store exceeds the private recall tail window"
+          true
+          (total > Memory_io.fact_recall_window);
+        let observer_block = Recall.render_context ~keeper_id:"observer" ~now () in
+        Alcotest.(check bool)
+          "shared recall surfaces a head fact beyond the tail window"
+          true
+          (contains "SHARED head fact verified most recently" observer_block
+           && contains "shared via alpha,beta" observer_block))))
+;;
+
 let with_env name value f =
   let old = Sys.getenv_opt name in
   Unix.putenv name value;
@@ -2424,6 +2477,10 @@ let () =
             "recall surfaces shared facts with provenance (private precedence)"
             `Quick
             test_recall_surfaces_shared_after_consolidation
+        ; Alcotest.test_case
+            "recall scans the whole shared fact store"
+            `Quick
+            test_recall_scans_whole_shared_store
         ; Alcotest.test_case
             "corrupt source store fails loud"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1334,6 +1334,51 @@ let test_render_if_enabled_renders_persisted_memory () =
             (contains "Gated recall should surface saved facts" block))))
 ;;
 
+(* RFC-0239 Q4 window invariant: when the store sits in the
+   (fact_recall_window, fact_store_max] band, a retention cap leaves the
+   highest-ranked durable facts at the file head while newer appends land at the
+   tail. Recall must scan fact_store_max (the whole bounded store), not a
+   fact_recall_window-sized tail, or it silently drops the best facts. Seed a head
+   fact verified now, then > fact_recall_window much-older fillers, and assert
+   recall still surfaces the head fact a tail-window scan would start past. *)
+let test_recall_scans_whole_bounded_store () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun _keepers_dir ->
+        let keeper_id = "window-band-keeper" in
+        let now = 1_000_000.0 in
+        let head =
+          { (fact_fixture ~now ()) with
+            Types.claim = "HEAD durable fact verified most recently"
+          ; Types.last_verified_at = Some now
+          }
+        in
+        (* First append = file head (position 0). *)
+        Memory_io.append_fact ~keeper_id head;
+        let filler_count = Memory_io.fact_recall_window + 20 in
+        for i = 1 to filler_count do
+          let f =
+            { (fact_fixture ~now ()) with
+              Types.claim = Printf.sprintf "filler durable fact %d" i
+            ; Types.last_verified_at = Some (now -. days 30 -. float_of_int i)
+            }
+          in
+          Memory_io.append_fact ~keeper_id f
+        done;
+        let total = List.length (Memory_io.read_facts_all ~keeper_id) in
+        Alcotest.(check bool)
+          "store sits in the (fact_recall_window, fact_store_max] band"
+          true
+          (total > Memory_io.fact_recall_window && total <= Memory_io.fact_store_max);
+        match Recall.render_if_enabled ~keeper_id ~now () with
+        | None -> Alcotest.fail "expected Some recall block for a seeded store"
+        | Some block ->
+          Alcotest.(check bool)
+            "recall surfaces the head fact a tail-window scan would miss"
+            true
+            (contains "HEAD durable fact verified most recently" block))))
+;;
+
 (* An old, never-verified fact is rendered with a worded staleness marker that
    names the age and asks for verification — the anti-confabulation cue. The
    prior [stale=%.2f] annotation was always 0.00 (no producer writes it), so this
@@ -2291,6 +2336,10 @@ let () =
             "render_if_enabled renders persisted memory"
             `Quick
             test_render_if_enabled_renders_persisted_memory
+        ; Alcotest.test_case
+            "recall scans the whole bounded store, not just the tail window"
+            `Quick
+            test_recall_scans_whole_bounded_store
         ; Alcotest.test_case
             "stale fact gets a worded staleness marker"
             `Quick


### PR DESCRIPTION
## 문제

Memory OS recall(`Keeper_memory_os_recall.render_context_exn`)이 후보 fact를 rank하기 전에 너무 좁은 tail window만 읽어, durable fact를 조용히 누락할 수 있었습니다.

- per-keeper store는 retention cap trigger(`fact_recall_window + fact_recall_window / 2`)까지 자라지만 recall은 `fact_recall_window` tail만 읽었습니다. cap rewrite는 high-rank rows를 file head에 두므로, store가 `(fact_recall_window, fact_store_max]` band에 있을 때 tail scan이 가장 좋은 fact를 놓칠 수 있었습니다.
- shared store는 consolidator가 직접 rewrite하고 per-keeper `fact_store_max` cap을 적용하지 않으므로, shared recall도 tail window로 읽으면 rank 전 후보집합이 truncated됩니다.

## 변경

- `Keeper_memory_os_io.fact_store_max`를 bounded fact store 상한 SSOT로 도입했습니다.
- librarian write path의 cap trigger와 per-keeper recall scan window를 `fact_store_max`로 정렬했습니다.
- shared recall은 store 특성상 `fact_store_max`가 아니라 `read_facts_all`로 전체 shared store를 읽은 뒤 rank/take하도록 수정했습니다.
- dashboard keeper memory fact display도 `fact_store_max`를 사용해 bounded per-keeper store 전체를 표시합니다.
- 기존 magic `fact_tail_scan`을 제거하고 io/recall 문서를 실제 retention invariant에 맞게 갱신했습니다.

## 검증

- `ocamlformat --check lib/keeper/keeper_librarian_runtime.ml lib/keeper/keeper_memory_os_io.ml lib/keeper/keeper_memory_os_io.mli lib/keeper/keeper_memory_os_recall.ml lib/server/server_dashboard_http_keeper_api.ml test/test_keeper_memory_os.ml`
- `scripts/dune-local.sh build test/test_keeper_memory_os.exe`
- `./_build/default/test/test_keeper_memory_os.exe test recall 7`
- `./_build/default/test/test_keeper_memory_os.exe test consolidator 12`

`recall / recall scans the whole bounded store, not just the tail window`는 실제 `merge_and_cap_facts` cap rewrite를 발생시킨 뒤 tail rows를 append해, head의 high-rank fact가 recall에 남는지 검증합니다.

`consolidator / recall scans the whole shared fact store`는 shared store가 private recall tail window를 초과해도 head shared fact가 recall에 surfacing되는지 검증합니다.

## 리뷰 대응 상태

- 1차 MEDIUM: shared facts reader가 tail-window 후보집합에서 rank하던 문제는 `read_facts_all`로 해결했습니다.
- 1차 LOW: dashboard under-display는 `fact_store_max`로 정렬했습니다.
- 1차 LOW: bounded-store test는 cap rewrite 경로를 직접 타도록 강화했습니다.
- 재리뷰 잔여: shared store cap 부재는 이 PR이 새로 만든 문제가 아니며, correctness fix로는 full scan이 맞습니다. 별도 RFC/consolidator cap 설계 영역으로 남깁니다.

RFC-WAIVED: keeper_memory_os_recall/io는 RFC 필수 subsystem이 아닙니다. 이 PR은 read/write window 정렬과 SSOT화 중심의 bug fix입니다.
