### PR TITLE
fix(core): surface an actionable error when Eio work runs on a bare systhread

### DIFF
--- a/lib/core/eio_guard.ml
+++ b/lib/core/eio_guard.ml
@@ -37,8 +37,37 @@ let with_mutex_ro mutex f =
 (** {1 Systhread Guard} *)
 
 (** Run [f] in a system thread when Eio is active, or directly when
-    no Eio runtime is available (e.g. unit tests). *)
-let run_in_systhread f = if Atomic.get ready then Eio_unix.run_in_systhread f else f ()
+    no Eio runtime is available (e.g. unit tests).
+
+    A pool system thread has no Eio effect handler.  [f] must therefore
+    perform only blocking C/Unix work, never an Eio operation: anything
+    that performs an effect (e.g. [Eio.Mutex.use_rw], whose [Cancel.protect]
+    performs [Get_context] first) raises [Effect.Unhandled] here, and an
+    enclosing [use_rw] then poisons its mutex.  That is the 2026-06-19 keeper
+    stall (a poisoned process-shared [dir_mu]); the structural cure is to
+    offload Eio-touching work via [Executor_pool] instead (PR #21530).
+
+    Defense-in-depth: this wrapper converts that cryptic [Effect.Unhandled]
+    into an actionable [Failure] naming the misuse and the alternative.  It
+    only improves the surfaced error — the poison still happens in the inner
+    [use_rw] frame before control returns here — so it diagnoses the bug
+    faster, it does not prevent it. *)
+let run_in_systhread f =
+  if Atomic.get ready
+  then
+    Eio_unix.run_in_systhread (fun () ->
+      try f () with
+      | Effect.Unhandled _ as exn ->
+        failwith
+          (Printf.sprintf
+             "Eio_guard.run_in_systhread: body performed an unhandled effect (%s) on a \
+              system thread, which has no Eio handler. Eio operations such as \
+              Eio.Mutex.use_rw must not run here (use_rw poisons its mutex on the \
+              resulting Effect.Unhandled). Offload Eio-touching work via Executor_pool \
+              (e.g. Executor_pool_ref.submit_or_inline), not run_in_systhread."
+             (Printexc.to_string exn)))
+  else f ()
+;;
 
 (** {1 Resource Cleanup}
 

--- a/test/test_executor_pool_eio_mutex.ml
+++ b/test/test_executor_pool_eio_mutex.ml
@@ -44,6 +44,30 @@ let test_systhread_offload_poisons_mutex () =
         check bool "use_rw inside a bare systhread raises" true raised;
         check bool "and leaves the mutex poisoned" true (poisons mu))))
 
+(* The diagnostic (defense-in-depth, Eio_guard.run_in_systhread): the bug still
+   poisons the mutex, but the exception surfaced out of [run_in_systhread] is now
+   an actionable [Failure] naming the misuse and the Executor_pool alternative,
+   instead of a bare [Effect.Unhandled]. This pins the conversion: on the
+   pre-hardening code the body raised [Effect.Unhandled] (caught here by [_ ->
+   false] -> test fails); after the hardening it is a [Failure] (-> test passes). *)
+let test_systhread_offload_raises_actionable_failure () =
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun _sw ->
+      Eio_guard.enable ();
+      Fun.protect ~finally:Eio_guard.disable (fun () ->
+        let mu = Eio.Mutex.create () in
+        let is_failure =
+          try
+            Eio_guard.run_in_systhread (fun () ->
+              Eio.Mutex.use_rw ~protect:true mu (fun () -> ()));
+            false
+          with
+          | Failure _ -> true
+          | _ -> false
+        in
+        check bool "run_in_systhread surfaces a Failure, not a bare Effect.Unhandled"
+          true is_failure)))
+
 (* The fix: [submit_or_inline] runs the closure with a live Eio context, so the
    same [use_rw] resolves and the mutex stays usable afterwards. *)
 let test_submit_or_inline_preserves_mutex () =
@@ -68,6 +92,8 @@ let () =
     [ ( "offload"
       , [ test_case "systhread offload poisons the mutex (bug)" `Quick
             test_systhread_offload_poisons_mutex
+        ; test_case "systhread offload raises an actionable Failure (diagnostic)" `Quick
+            test_systhread_offload_raises_actionable_failure
         ; test_case "submit_or_inline preserves the mutex (fix)" `Quick
             test_submit_or_inline_preserves_mutex
         ] )


### PR DESCRIPTION
## 무엇을 / 왜

`Eio_guard.run_in_systhread`는 클로저를 Eio 핸들러가 없는 풀 OS 스레드에서 실행하는 primitive입니다. 본문이 (보통 transitive하게) Eio 연산을 수행하면 — 예: `Eio.Mutex.use_rw`의 `Cancel.protect`가 `Get_context`를 먼저 수행 — `Effect.Unhandled`가 터지고, 이를 감싸던 `use_rw`가 자기 mutex를 poison시킵니다. 이게 2026-06-19 keeper stall(프로세스 공유 `dir_mu` poison → 모든 파일 쓰기 실패 → fleet 정지)의 메커니즘이었습니다.

근본 원인은 이미 #21530이 구조적으로 고쳤습니다(해당 compute를 systhread 대신 `Executor_pool` 경유로 offload — worker domain은 살아 있는 Eio 핸들러를 가짐). 이 PR은 그 위에 얇은 안전망을 둡니다: primitive 자체에서 같은 오용이 다시 생기면, cryptic한 `Effect.Unhandled` + 불투명한 poison 대신 **무엇을 어떻게 고치라는 `Failure`로 re-raise**합니다.

## 변경

- `lib/core/eio_guard.ml` `run_in_systhread` 한 함수: 본문을 `try … with Effect.Unhandled _ -> failwith <안내문>`로 감쌈. 안내문은 "systhread엔 Eio 핸들러가 없다 / use_rw 같은 Eio 연산을 쓰지 마라 / `Executor_pool` (`Executor_pool_ref.submit_or_inline`) 경유로 offload하라"를 명시. 원래 예외 문자열도 포함. doc comment로 메커니즘과 한계를 기술.
- `test/test_executor_pool_eio_mutex.ml`: 회귀 테스트 1건. systhread offload가 이제 `Effect.Unhandled`가 아니라 `Failure`를 surface하는지 고정(pre-hardening 코드에선 `Effect.Unhandled`라 `_ -> false`로 떨어져 fail, post에선 `Failure`라 pass).

## 경계 (정직한 한계)

이 변경은 **poison을 예방하지 않습니다.** poison은 더 안쪽 `use_rw` 프레임에서, 제어가 이 wrapper로 돌아오기 전에 이미 발생합니다. 따라서 이건 "버그를 더 빨리 진단"하게 만들 뿐(다음 오용 시 수 시간 디버깅 대신 에러 한 줄), 예방이 아닙니다. 예방은 #21530의 구조적 offload이며 이 PR은 그 대체재가 아니라 보완입니다.

이건 symptom 억제 워크어라운드가 아닙니다: counter/cap/cooldown/dedup/repair 없음, 예외를 삼키지 않고 더 명확하게 re-raise만 함(`Eio.Cancel.Cancelled`는 별개 예외라 안 잡힘), 그리고 메시지가 실제 fix 경로를 가리킴.

## 검증

- `dune build --root . lib/core/ test/test_executor_pool_eio_mutex.exe`: 0 errors.
- alcotest 3건 통과(기존 poison/fix 2건 + 신규 진단 1건).
- `ocamlformat --check`: 변경 2파일 통과.

## RFC

`lib/core/eio_guard.ml`은 RFC 게이트 대상 subsystem(credential / operator control / keeper sandbox / dashboard credential / hooks / workflow docs)에 해당하지 않습니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
