### PR TITLE
[codex] Wire grounded review evidence to dashboard attention

### DIFF
--- a/config/prompts/verification.adversarial_review.md
+++ b/config/prompts/verification.adversarial_review.md
@@ -37,3 +37,11 @@ Then call report_verdict exactly once:
 - WARN — acceptable, but with concerns the author should see.
 - FAIL — a blocker, or you could not verify the work. The reason must name the
   specific problems (with path:line) so the author can fix and resubmit.
+
+For WARN and FAIL, include an `evidence` array in the tool arguments. Each item
+must contain:
+- `path`: repo-relative file path you inspected.
+- `line`: optional 1-based line number.
+- `quote`: verbatim code or text excerpt that grounds the concern.
+
+PASS may omit evidence. WARN and FAIL without grounded evidence are invalid.

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, SideRail } from './dashboard-shell'
+import { DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, SideRail, summarizeAttentionPreview } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 import { dashboardLoading } from '../store'
@@ -69,6 +69,38 @@ describe('isKeeperDetailDashboardRoute', () => {
       params: { section: 'agents' },
       postId: null,
     })).toBe(false)
+  })
+})
+
+describe('summarizeAttentionPreview', () => {
+  it('includes grounded evidence in attention tooltip lines', () => {
+    expect(summarizeAttentionPreview([
+      {
+        summary: 'Adversarial review failed',
+        kind: 'review_rejected',
+        grounded_verdict: {
+          verdict: 'FAIL',
+          reason: 'bad branch',
+          evidence: [
+            { path: 'lib/foo.ml', line: 12, quote: 'let bad = true' },
+          ],
+        },
+      },
+    ])).toEqual([
+      'Adversarial review failed | lib/foo.ml:12 let bad = true',
+    ])
+  })
+
+  it('falls back to evidence_preview when no grounded verdict exists', () => {
+    expect(summarizeAttentionPreview([
+      {
+        summary: 'Needs inspection',
+        kind: 'runtime_blocked',
+        evidence_preview: ['runtime_blocker_state=blocked'],
+      },
+    ])).toEqual([
+      'Needs inspection | runtime_blocker_state=blocked',
+    ])
   })
 })
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
 import { useEffect, useMemo } from 'preact/hooks'
-import type { RouteState, TabId } from '../types'
+import type { GroundedVerdict, RouteState, TabId } from '../types'
 import type { DashboardCdalHealth, DashboardFleetSafetyHealth, DashboardKeeperReactionLedgerHealth, DashboardRuntimeResolution, Keeper } from '../types'
 import type { DashboardRuntimeProbePayload } from '../api/dashboard'
 import { fetchDashboardRuntimeProbe } from '../api/dashboard'
@@ -931,8 +931,26 @@ export function BuildIdentityBadge() {
     tooltip, Vercel deployment status footer, Gmail "2 unread" with
     sender preview — all reveal the contributing items on hover so the
     operator decides whether to navigate. Exposed for tests. */
-function summarizeAttentionPreview(
-  items: ReadonlyArray<{ summary?: string | null; kind?: string | null }>,
+type AttentionPreviewInput = {
+  summary?: string | null
+  kind?: string | null
+  evidence_preview?: readonly string[] | null
+  grounded_verdict?: GroundedVerdict | null
+}
+
+function clipAttentionLine(raw: string, max: number): string {
+  return raw.length > max ? `${raw.slice(0, Math.max(0, max - 3))}...` : raw
+}
+
+function firstGroundedEvidencePreview(verdict?: GroundedVerdict | null): string | null {
+  const ref = verdict?.evidence.find(item => item.path.trim() !== '' && item.quote.trim() !== '')
+  if (!ref) return null
+  const location = typeof ref.line === 'number' ? `${ref.path}:${ref.line}` : ref.path
+  return `${location} ${ref.quote.trim()}`
+}
+
+export function summarizeAttentionPreview(
+  items: ReadonlyArray<AttentionPreviewInput>,
   max = 3,
 ): string[] {
   // Two-pass: first filter to valid (non-empty summary or kind), then
@@ -944,9 +962,17 @@ function summarizeAttentionPreview(
     if (!item) continue
     const summary = item.summary?.trim()
     const kind = item.kind?.trim()
-    const raw = (summary && summary !== '') ? summary : (kind && kind !== '' ? kind : '')
-    if (raw === '') continue
-    valid.push(raw.length > 60 ? `${raw.slice(0, 57)}...` : raw)
+    const base = (summary && summary !== '') ? summary : (kind && kind !== '' ? kind : '')
+    if (base === '') continue
+    const groundedEvidence = firstGroundedEvidencePreview(item.grounded_verdict)
+    const previewEvidence =
+      groundedEvidence
+      ?? item.evidence_preview?.map(value => value.trim()).find(value => value !== '')
+      ?? null
+    const raw = previewEvidence
+      ? `${clipAttentionLine(base, 45)} | ${clipAttentionLine(previewEvidence, 60)}`
+      : base
+    valid.push(clipAttentionLine(raw, previewEvidence ? 110 : 60))
   }
   if (valid.length <= max) return valid
   return [...valid.slice(0, max), `... +${valid.length - max} more`]

--- a/dashboard/src/mission-normalizers-entities.ts
+++ b/dashboard/src/mission-normalizers-entities.ts
@@ -14,7 +14,53 @@ import type {
   DashboardMissionAgentBrief,
   DashboardMissionInternalSignal,
   DashboardMissionKeeperBrief,
+  GroundedVerdict,
+  GroundedVerdictEvidenceRef,
 } from './types'
+
+function parseJsonPayload(raw: unknown): unknown {
+  if (typeof raw !== 'string') return raw
+  try {
+    return JSON.parse(raw) as unknown
+  } catch {
+    return raw
+  }
+}
+
+function normalizeGroundedVerdictEvidenceRef(raw: unknown): GroundedVerdictEvidenceRef | null {
+  if (!isRecord(raw)) return null
+  const path = asString(raw.path)
+  const quote = asString(raw.quote)
+  if (!path || !quote) return null
+  const line = asNumber(raw.line)
+  return {
+    path,
+    line: typeof line === 'number' && Number.isInteger(line) && line > 0 ? line : null,
+    quote,
+  }
+}
+
+function normalizeGroundedVerdict(raw: unknown): GroundedVerdict | null {
+  const parsed = parseJsonPayload(raw)
+  if (!isRecord(parsed)) return null
+  const verdict = asString(parsed.verdict)
+  if (!verdict) return null
+  return {
+    verdict,
+    reason: asString(parsed.reason) ?? null,
+    evidence: extractArray(parsed.evidence)
+      .map(normalizeGroundedVerdictEvidenceRef)
+      .filter((item): item is GroundedVerdictEvidenceRef => item !== null),
+  }
+}
+
+function normalizeGroundedVerdictFromEvidence(evidence: unknown): GroundedVerdict | null {
+  const parsed = parseJsonPayload(evidence)
+  const direct = normalizeGroundedVerdict(parsed)
+  if (direct) return direct
+  if (!isRecord(parsed)) return null
+  return normalizeGroundedVerdict(parsed.grounded_verdict)
+}
 
 export function normalizeAttentionQueueItem(raw: unknown): DashboardMissionAttentionQueueItem | null {
   if (!isRecord(raw)) return null
@@ -23,6 +69,10 @@ export function normalizeAttentionQueueItem(raw: unknown): DashboardMissionAtten
   const summary = asString(raw.summary)
   const targetType = asString(raw.target_type)
   if (!id || !kind || !summary || !targetType) return null
+  const evidence = raw.evidence
+  const groundedVerdict =
+    normalizeGroundedVerdict(raw.grounded_verdict)
+    ?? normalizeGroundedVerdictFromEvidence(evidence)
   return {
     id,
     kind,
@@ -33,7 +83,9 @@ export function normalizeAttentionQueueItem(raw: unknown): DashboardMissionAtten
     top_action: normalizeRecommendedAction(raw.top_action),
     related_session_ids: asStringArray(raw.related_session_ids),
     related_agent_names: asStringArray(raw.related_agent_names),
+    evidence,
     evidence_preview: asStringArray(raw.evidence_preview),
+    grounded_verdict: groundedVerdict,
     last_seen_at: asString(raw.last_seen_at) ?? null,
   }
 }

--- a/dashboard/src/mission-normalizers.test.ts
+++ b/dashboard/src/mission-normalizers.test.ts
@@ -184,6 +184,38 @@ describe('normalizeMission', () => {
     expect(result.summary.workspace_health).toBe('healthy')
     expect(result.command_focus.health).toBe('ok')
   })
+
+  it('preserves attention queue evidence and parses grounded verdict metadata', () => {
+    const grounded = {
+      verdict: 'FAIL',
+      reason: 'bad branch',
+      evidence: [
+        { path: 'lib/foo.ml', line: 12, quote: 'let bad = true' },
+      ],
+    }
+    const result = normalizeMission({
+      attention_queue: [
+        {
+          id: 'review:keeper:task-42',
+          kind: 'review_rejected',
+          severity: 'bad',
+          summary: 'Adversarial review failed',
+          target_type: 'keeper',
+          target_id: 'builder-keeper',
+          evidence: {
+            grounded_verdict: JSON.stringify(grounded),
+          },
+          evidence_preview: ['legacy preview'],
+        },
+      ],
+    })
+
+    expect(result.attention_queue).toHaveLength(1)
+    expect(result.attention_queue[0]!.evidence).toEqual({
+      grounded_verdict: JSON.stringify(grounded),
+    })
+    expect(result.attention_queue[0]!.grounded_verdict).toEqual(grounded)
+  })
 })
 
 // ================================================================

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -41,8 +41,22 @@ export interface DashboardMissionAttentionQueueItem {
   top_action?: OperatorRecommendedAction | null
   related_session_ids: string[]
   related_agent_names: string[]
+  evidence?: unknown
   evidence_preview: string[]
+  grounded_verdict?: GroundedVerdict | null
   last_seen_at?: string | null
+}
+
+export interface GroundedVerdictEvidenceRef {
+  path: string
+  line?: number | null
+  quote: string
+}
+
+export interface GroundedVerdict {
+  verdict: string
+  reason?: string | null
+  evidence: GroundedVerdictEvidenceRef[]
 }
 
 export interface DashboardMissionSessionBrief {

--- a/lib/dashboard/dashboard_briefing.ml
+++ b/lib/dashboard/dashboard_briefing.ml
@@ -293,6 +293,7 @@ let build_attention_queue incidents actions sessions =
                      ("top_action", Json_util.option_to_yojson (fun value -> value) top_action);
                      ("related_session_ids", `List (List.map (fun value -> `String value) related_session_ids));
                      ("related_agent_names", `List (List.map (fun value -> `String value) related_agent_names));
+                     ("evidence", member_assoc "evidence" incident);
                      ("evidence_preview", `List (List.map (fun value -> `String value) (evidence_preview_strings (member_assoc "evidence" incident))));
                      ("last_seen_at", Json_util.string_opt_to_json last_seen_at);
                    ];

--- a/lib/keeper/keeper_adversarial_review.ml
+++ b/lib/keeper/keeper_adversarial_review.ml
@@ -56,12 +56,18 @@ let parse_verdict_from_text text =
     Error "model did not return a structured verdict (no JSON payload found)"
   | Some json -> Verifier_core.parse_verdict_from_json json
 
+let parse_grounded_verdict_from_text text =
+  match parse_json_payload text with
+  | None ->
+    Error "model did not return a structured verdict (no JSON payload found)"
+  | Some json -> Verifier_core.parse_grounded_verdict_from_json json
+
 (* Mirrors [Verifier_oas.verify]: structured verdict via the [report_verdict]
    tool, with a structured JSON fallback if the model answers in free text.
    The judgment itself is the model's; this only routes its structured output
    back as a typed [Verifier_core.verdict]. *)
-let run_review ~runtime_id (input : review_input) :
-    (Verifier_core.verdict, string) result =
+let run_grounded_review ~runtime_id (input : review_input) :
+    (Verifier_core.grounded_verdict, string) result =
   match build_prompt input with
   | Error msg ->
     Log.Keeper.warn "adversarial_review: prompt render/validation failed: %s" msg;
@@ -75,16 +81,17 @@ let run_review ~runtime_id (input : review_input) :
         let msg =
           Printf.sprintf
             "Verdict already recorded (%s); only one report_verdict call is allowed"
-            (Verifier_core.verdict_to_string v)
+            (Verifier_core.verdict_to_string v.Verifier_core.verdict)
         in
         Log.Keeper.warn "adversarial_review: %s" msg;
         Tool_result.error ~tool_name:name ~start_time msg
       | None -> (
-        match Verifier_core.parse_verdict_from_json args with
+        match Verifier_core.parse_grounded_verdict_from_json args with
         | Ok v ->
           verdict_ref := Some v;
           Tool_result.ok ~tool_name:name ~start_time
-            (Printf.sprintf "Verdict recorded: %s" (Verifier_core.verdict_to_string v))
+            (Printf.sprintf "Verdict recorded: %s"
+               (Verifier_core.verdict_to_string v.Verifier_core.verdict))
         | Error msg ->
           Log.Keeper.warn "adversarial_review: verdict parse failed: %s" msg;
           Tool_result.error ~tool_name:name ~start_time
@@ -104,17 +111,35 @@ let run_review ~runtime_id (input : review_input) :
       | None ->
         (* Model answered in text instead of calling report_verdict. *)
         let text = Agent_sdk_response.text_of_response result.response in
-        parse_verdict_from_text text)
+        parse_grounded_verdict_from_text text)
     | Error err -> Error (Agent_sdk.Error.to_string err)
+
+let run_review ~runtime_id (input : review_input) :
+    (Verifier_core.verdict, string) result =
+  match run_grounded_review ~runtime_id input with
+  | Ok grounded -> Ok grounded.Verifier_core.verdict
+  | Error msg -> Error msg
 
 (* Identity routing: the work's author is known, so waking them is structural,
    not a judgment. Dedup is keyed on the stable task-level FAIL outcome so
    reason wording drift cannot repeatedly wake the author for the same task. *)
-let wake_author ~base_path ~(input : review_input) ~reason :
+let wake_author ?grounded ~base_path ~(input : review_input) ~reason () :
     (unit, string) result =
   let dedupe_key = Printf.sprintf "adversarial_review:%s:fail" input.task_id in
   let event_id = Keeper_external_attention.event_id_of_dedupe_key dedupe_key in
   let conversation_id = Printf.sprintf "review:%s" input.task_id in
+  let grounded_metadata =
+    match grounded with
+    | None -> []
+    | Some grounded ->
+      [
+        ( "grounded_verdict",
+          Yojson.Safe.to_string
+            (Verifier_core.grounded_verdict_to_yojson grounded) );
+        ( "evidence_count",
+          string_of_int (List.length grounded.Verifier_core.evidence) );
+      ]
+  in
   let item : Keeper_external_attention.item =
     {
       event_id;
@@ -140,7 +165,8 @@ let wake_author ~base_path ~(input : review_input) ~reason :
           ("kind", "review_rejected");
           ("task_id", input.task_id);
           ("verdict", "FAIL");
-        ];
+        ]
+        @ grounded_metadata;
     }
   in
   match Keeper_external_attention.record ~base_path item with
@@ -156,12 +182,20 @@ let wake_author ~base_path ~(input : review_input) ~reason :
 let act_on_verdict ~base_path ~(input : review_input)
     (verdict : Verifier_core.verdict) : (unit, string) result =
   match verdict with
-  | Verifier_core.Fail reason -> wake_author ~base_path ~input ~reason
+  | Verifier_core.Fail reason -> wake_author ~base_path ~input ~reason ()
+  | Verifier_core.Pass | Verifier_core.Warn _ -> Ok ()
+
+let act_on_grounded_verdict ~base_path ~(input : review_input)
+    (grounded : Verifier_core.grounded_verdict) : (unit, string) result =
+  match grounded.Verifier_core.verdict with
+  | Verifier_core.Fail reason -> wake_author ~grounded ~base_path ~input ~reason ()
   | Verifier_core.Pass | Verifier_core.Warn _ -> Ok ()
 
 let review_and_wake_on_fail ~base_path ~runtime_id (input : review_input) :
     (Verifier_core.verdict, string) result =
-  match run_review ~runtime_id input with
-  | Error _ as e -> e
-  | Ok verdict ->
-    Result.map (fun () -> verdict) (act_on_verdict ~base_path ~input verdict)
+  match run_grounded_review ~runtime_id input with
+  | Error msg -> Error msg
+  | Ok grounded ->
+    Result.map
+      (fun () -> grounded.Verifier_core.verdict)
+      (act_on_grounded_verdict ~base_path ~input grounded)

--- a/lib/keeper/keeper_adversarial_review.mli
+++ b/lib/keeper/keeper_adversarial_review.mli
@@ -10,11 +10,11 @@
 
     The verdict is the LLM's judgment. On the structured [report_verdict] path
     there is no rule, heuristic, or string match deciding pass/fail. The
-    free-text fallback parses a JSON payload with
-    [Verifier_core.parse_verdict_from_json]; it does not use string matching to
-    decide pass/fail. The only deterministic parts are identity (which keeper
-    authored the work, hence who to wake) and event-id dedup (a given task-level
-    FAIL wakes the author at most once).
+    free-text fallback parses a JSON payload with [Verifier_core]; it does not
+    use string matching to decide pass/fail. The grounded entry point requires
+    evidence for WARN/FAIL before wake-on-fail routing. The only deterministic
+    parts are identity (which keeper authored the work, hence who to wake) and
+    event-id dedup (a given task-level FAIL wakes the author at most once).
 
     This module is a proof-of-concept. It is not yet wired to a keeper
     lifecycle trigger; integration with the tool registration in #21357 is the
@@ -36,11 +36,16 @@ val build_prompt : review_input -> (string, string) result
 
 val run_review :
   runtime_id:string -> review_input -> (Verifier_core.verdict, string) result
-(** Run the adversarial reviewer agent and read its structured verdict via the
-    [report_verdict] tool. If the model answers in free text, the fallback
-    attempts to parse a JSON payload and decode it with
-    [Verifier_core.parse_verdict_from_json]; it never uses string matching to
-    decide pass/fail. *)
+(** Compatibility wrapper around {!run_grounded_review}; returns only the
+    public verdict variant. *)
+
+val run_grounded_review :
+  runtime_id:string -> review_input -> (Verifier_core.grounded_verdict, string) result
+(** Run the adversarial reviewer agent and read its structured grounded verdict
+    via the [report_verdict] tool. If the model answers in free text, the
+    fallback attempts to parse a JSON payload and decode it with
+    [Verifier_core.parse_grounded_verdict_from_json]; it never uses string
+    matching to decide pass/fail. *)
 
 val act_on_verdict :
   base_path:string -> input:review_input -> Verifier_core.verdict -> (unit, string) result
@@ -51,9 +56,19 @@ val act_on_verdict :
     reason differently. Returns [Error] if recording the attention item fails,
     so the caller can decide whether to fail-closed. *)
 
+val act_on_grounded_verdict :
+  base_path:string ->
+  input:review_input ->
+  Verifier_core.grounded_verdict ->
+  (unit, string) result
+(** Like {!act_on_verdict}, but failed verdict wake metadata includes the
+    serialized grounded verdict so dashboard/turn surfaces can show the cited
+    code evidence. *)
+
 val review_and_wake_on_fail :
   base_path:string ->
   runtime_id:string ->
   review_input ->
   (Verifier_core.verdict, string) result
-(** [run_review] followed by [act_on_verdict] on the resulting verdict. *)
+(** [run_grounded_review] followed by [act_on_grounded_verdict] on the resulting
+    verdict, returning the compatibility [Verifier_core.verdict]. *)

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -126,6 +126,88 @@ let keeper_attention_summary ~(meta : Keeper_meta_contract.keeper_meta) ~reason
       Printf.sprintf "%s needs operator attention (%s)" meta.name summary
   | None, None -> Printf.sprintf "%s needs operator attention" meta.name
 
+let metadata_string key metadata =
+  match List.assoc_opt key metadata with
+  | Some value ->
+      let value = String.trim value in
+      if String.equal value "" then None else Some value
+  | None -> None
+
+let metadata_json metadata =
+  `Assoc (List.map (fun (key, value) -> (key, `String value)) metadata)
+
+let external_attention_kind (item : Keeper_external_attention.item) =
+  match metadata_string "kind" item.metadata with
+  | Some kind -> "keeper_" ^ kind
+  | None -> "keeper_external_attention"
+
+let external_attention_severity (item : Keeper_external_attention.item) =
+  match item.urgency with
+  | Keeper_external_attention.System -> Sev_bad
+  | Keeper_external_attention.Mention
+  | Keeper_external_attention.Direct_message
+  | Keeper_external_attention.Ambient -> Sev_warn
+
+let external_attention_summary (item : Keeper_external_attention.item) =
+  let preview = String.trim item.content_preview in
+  if String.equal preview "" then
+    Printf.sprintf "%s has external attention from %s" item.keeper_name
+      item.source_label
+  else
+    Printf.sprintf "%s has external attention from %s: %s" item.keeper_name
+      item.source_label preview
+
+let external_attention_evidence (item : Keeper_external_attention.item) =
+  let grounded_fields =
+    match metadata_string "grounded_verdict" item.metadata with
+    | Some value -> [ ("grounded_verdict", `String value) ]
+    | None -> []
+  in
+  `Assoc
+    ([
+       ("source", `String "keeper_external_attention");
+       ("event_id", `String item.event_id);
+       ("dedupe_key", `String item.dedupe_key);
+       ("keeper_name", `String item.keeper_name);
+       ("source_label", `String item.source_label);
+       ("urgency", `String (Keeper_external_attention.urgency_to_string item.urgency));
+       ("content_preview", `String item.content_preview);
+       ("metadata", metadata_json item.metadata);
+     ]
+     @ grounded_fields)
+
+let external_attention_projection item =
+  let severity = external_attention_severity item in
+  let attention_item =
+    {
+      kind = external_attention_kind item;
+      severity;
+      summary = external_attention_summary item;
+      target_type = "keeper";
+      target_id = Some item.keeper_name;
+      actor = Some item.keeper_name;
+      evidence = external_attention_evidence item;
+    }
+  in
+  let recommended_action =
+    {
+      action_type = "keeper_probe";
+      target_type = "keeper";
+      target_id = Some item.keeper_name;
+      severity;
+      reason = "Inspect pending external attention";
+      suggested_payload =
+        `Assoc
+          [
+            ("source", `String "operator_digest");
+            ("keeper", `String item.keeper_name);
+            ("event_id", `String item.event_id);
+            ("conversation_id", `String item.conversation.conversation_id);
+          ];
+    }
+  in
+  (attention_item, recommended_action)
+
 let keeper_attention_projection config (meta : Keeper_meta_contract.keeper_meta) =
   let attention_fields = Keeper_status_bridge.attention_fields_json config meta in
   if not (assoc_bool_field ~default:false "needs_attention" attention_fields)
@@ -191,11 +273,22 @@ let keeper_attention_projection config (meta : Keeper_meta_contract.keeper_meta)
     Some (attention_item, recommended_action)
 
 let keeper_attention_projection_items config =
-  Keeper_meta_store.keeper_names config
-  |> List.filter_map (fun name ->
-    match Keeper_meta_store.read_meta config name with
-    | Ok (Some meta) -> keeper_attention_projection config meta
-    | Ok None | Error _ -> None)
+  let keeper_names = Keeper_meta_store.keeper_names config in
+  let status_attention =
+    keeper_names
+    |> List.filter_map (fun name ->
+      match Keeper_meta_store.read_meta config name with
+      | Ok (Some meta) -> keeper_attention_projection config meta
+      | Ok None | Error _ -> None)
+  in
+  let external_attention =
+    keeper_names
+    |> List.concat_map (fun keeper_name ->
+      Keeper_external_attention.pending_for_keeper ~base_path:config.base_path
+        ~keeper_name ~limit:3 ()
+      |> List.map external_attention_projection)
+  in
+  status_attention @ external_attention
 
 let workspace_recommendations _config =
   dedup_recommendations []

--- a/lib/verifier_core.ml
+++ b/lib/verifier_core.ml
@@ -163,6 +163,30 @@ let grounded_of verdict evidence =
       | Error _ as e -> e
       | Ok () -> Ok { verdict; evidence }
 
+let reason_field = function
+  | Pass -> []
+  | Warn reason | Fail reason -> [ ("reason", `String reason) ]
+
+let grounded_ref_to_yojson ref_ =
+  `Assoc
+    [
+      ("path", `String ref_.path);
+      ( "line",
+        match ref_.line with
+        | Some line -> `Int line
+        | None -> `Null );
+      ("quote", `String ref_.quote);
+    ]
+
+let grounded_verdict_to_yojson grounded =
+  `Assoc
+    ([
+       ("verdict", `String (verdict_constructor_name grounded.verdict));
+       ( "evidence",
+         `List (List.map grounded_ref_to_yojson grounded.evidence) );
+     ]
+     @ reason_field grounded.verdict)
+
 (* ================================================================ *)
 (* Structured Verdict: Tool Schema + JSON Parsing (ADR D3)          *)
 (* ================================================================ *)

--- a/lib/verifier_core.mli
+++ b/lib/verifier_core.mli
@@ -70,6 +70,12 @@ val parse_verdict : string -> (verdict, string) result
 val grounded_of :
   verdict -> grounded_ref list -> (grounded_verdict, string) result
 
+(** JSON shape shared by review metadata and dashboard evidence. Emits
+    [verdict], optional [reason], and [evidence]. *)
+val grounded_ref_to_yojson : grounded_ref -> Yojson.Safe.t
+
+val grounded_verdict_to_yojson : grounded_verdict -> Yojson.Safe.t
+
 (** {1 Structured Verdict — report_verdict tool} *)
 
 (** MCP tool schema for [report_verdict]: [verdict] (enum of

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -26,6 +26,37 @@ let with_temp_base f =
   Sys.mkdir base 0o755;
   Fun.protect ~finally:(fun () -> rm_rf base) (fun () -> f base)
 
+let ensure_fs env =
+  Masc.Server_startup_state.mark_state_ready ~backend_mode:"test";
+  Masc_test_deps.init_eio_clock env;
+  if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env)
+
+let operator_ctx env sw config agent_name : _ Operator_control.context =
+  {
+    config;
+    agent_name;
+    sw;
+    clock = Eio.Stdenv.clock env;
+    proc_mgr = Some (Eio.Stdenv.process_mgr env);
+    net = Some (Eio.Stdenv.net env);
+    mcp_session_id = None;
+  }
+
+let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+          ("trace_id", `String ("trace-" ^ name));
+          ("goal", `String "test keeper");
+          ("autoboot_enabled", `Bool false);
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("meta_of_json failed: " ^ err)
+
 let write_prompt_file dir ~variables body =
   let path = Filename.concat dir "verification.adversarial_review.md" in
   let content =
@@ -111,6 +142,106 @@ let test_fail_dedup_different_reasons () =
       check int "dedup: still one pending for the task" 1
         (List.length (pending base ~keeper:author)))
 
+let test_grounded_fail_carries_evidence_metadata () =
+  with_temp_base (fun base ->
+      let author = "builder-keeper" in
+      let evidence : VC.grounded_ref =
+        { path = "lib/foo.ml"; line = Some 12; quote = "let bad = true" }
+      in
+      let grounded =
+        match VC.grounded_of (VC.Fail "bad branch") [ evidence ] with
+        | Ok value -> value
+        | Error msg -> fail msg
+      in
+      AR.act_on_grounded_verdict ~base_path:base ~input:(input ~author) grounded
+      |> check_ok;
+      let item =
+        match pending base ~keeper:author with
+        | [ item ] -> item
+        | items -> failf "expected one pending item, got %d" (List.length items)
+      in
+      check (option string) "evidence count metadata" (Some "1")
+        (List.assoc_opt "evidence_count" item.EA.metadata);
+      let grounded_json =
+        match List.assoc_opt "grounded_verdict" item.EA.metadata with
+        | Some raw -> Yojson.Safe.from_string raw
+        | None -> fail "missing grounded_verdict metadata"
+      in
+      let open Yojson.Safe.Util in
+      check string "grounded verdict" "FAIL"
+        (grounded_json |> member "verdict" |> to_string);
+      let first = grounded_json |> member "evidence" |> to_list |> List.hd in
+      check string "grounded path" "lib/foo.ml"
+        (first |> member "path" |> to_string);
+      check int "grounded line" 12 (first |> member "line" |> to_int);
+      check string "grounded quote" "let bad = true"
+        (first |> member "quote" |> to_string))
+
+let test_digest_projects_grounded_external_attention () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let author = "builder-keeper" in
+  with_temp_base (fun base ->
+      Fun.protect
+        ~finally:(fun () ->
+          Masc.Keeper_keepalive.stop_keepalive author;
+          Masc.Keeper_registry.clear ();
+          Masc.Keeper_runtime.reset_test_state base)
+        (fun () ->
+          let config = Masc.Workspace.default_config base in
+          ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+          (match Masc.Keeper_meta_store.write_meta config (make_meta author) with
+          | Ok () -> ()
+          | Error err -> fail ("write_meta failed: " ^ err));
+          let evidence : VC.grounded_ref =
+            { path = "lib/foo.ml"; line = Some 12; quote = "let bad = true" }
+          in
+          let grounded =
+            match VC.grounded_of (VC.Fail "bad branch") [ evidence ] with
+            | Ok value -> value
+            | Error msg -> fail msg
+          in
+          AR.act_on_grounded_verdict ~base_path:base ~input:(input ~author)
+            grounded
+          |> check_ok;
+          let digest =
+            match
+              Operator_control.digest_json ~actor:"dashboard"
+                (operator_ctx env sw config "dashboard")
+            with
+            | Ok json -> json
+            | Error err -> fail err
+          in
+          let open Yojson.Safe.Util in
+          let attention_items = digest |> member "attention_items" |> to_list in
+          let review_attention =
+            attention_items
+            |> List.find_opt (fun item ->
+                 let target_id_matches =
+                   match item |> member "target_id" with
+                   | `String value -> String.equal value author
+                   | _ -> false
+                 in
+                 (item |> member "kind" |> to_string)
+                 = "keeper_review_rejected"
+                 && target_id_matches)
+            |> Option.value ~default:`Null
+          in
+          check bool "review attention projected" true
+            (review_attention <> `Null);
+          check string "review attention severity" "bad"
+            (review_attention |> member "severity" |> to_string);
+          let grounded_json =
+            review_attention |> member "evidence" |> member "grounded_verdict"
+            |> to_string |> Yojson.Safe.from_string
+          in
+          let first = grounded_json |> member "evidence" |> to_list |> List.hd in
+          check string "projected grounded path" "lib/foo.ml"
+            (first |> member "path" |> to_string);
+          check int "projected grounded line" 12
+            (first |> member "line" |> to_int)))
+
 let test_build_prompt_replaces_variables () =
   with_prompt_dir
     ~variables:[ "task_title"; "task_description"; "evidence_refs" ]
@@ -170,6 +301,10 @@ let () =
           test_case "warn no wake" `Quick test_warn_does_not_wake;
           test_case "fail dedup different reasons" `Quick
             test_fail_dedup_different_reasons;
+          test_case "grounded fail carries evidence metadata" `Quick
+            test_grounded_fail_carries_evidence_metadata;
+          test_case "digest projects grounded external attention" `Quick
+            test_digest_projects_grounded_external_attention;
         ] );
       ( "render-fail-closed",
         [

--- a/test/test_verifier_core_grounding.ml
+++ b/test/test_verifier_core_grounding.ml
@@ -106,6 +106,19 @@ let test_grounded_parser_rejects_bad_line () =
       (String.contains msg 'l')
   | Ok _ -> Alcotest.fail "expected line 0 to be rejected"
 
+let test_grounded_verdict_serializes_evidence () =
+  match VC.grounded_of (VC.Fail "bad") [ evidence ~line:9 ~quote:"let bad = true" () ] with
+  | Error msg -> Alcotest.fail msg
+  | Ok grounded ->
+    let open Yojson.Safe.Util in
+    let json = VC.grounded_verdict_to_yojson grounded in
+    Alcotest.(check string) "verdict" "FAIL" (json |> member "verdict" |> to_string);
+    Alcotest.(check string) "reason" "bad" (json |> member "reason" |> to_string);
+    let first = json |> member "evidence" |> to_list |> List.hd in
+    Alcotest.(check string) "path" "lib/foo.ml" (first |> member "path" |> to_string);
+    Alcotest.(check int) "line" 9 (first |> member "line" |> to_int);
+    Alcotest.(check string) "quote" "let bad = true" (first |> member "quote" |> to_string)
+
 let test_report_schema_keeps_verdict_enum_and_adds_evidence () =
   let schema = VC.report_verdict_schema.input_schema in
   let open Yojson.Safe.Util in
@@ -146,6 +159,8 @@ let () =
             test_grounded_parser_refuses_empty_fail;
           Alcotest.test_case "grounded parser rejects bad line" `Quick
             test_grounded_parser_rejects_bad_line;
+          Alcotest.test_case "grounded verdict serializes evidence" `Quick
+            test_grounded_verdict_serializes_evidence;
           Alcotest.test_case "schema keeps enum and adds evidence" `Quick
             test_report_schema_keeps_verdict_enum_and_adds_evidence;
         ] );


### PR DESCRIPTION
## Summary
- Adds JSON serialization for grounded verifier verdicts so review evidence can be carried across metadata and dashboard payloads.
- Switches keeper adversarial review to the grounded parser for WARN/FAIL, stores grounded FAIL evidence in external-attention metadata, and projects pending external attention into operator digest items.
- Preserves mission attention queue evidence in the dashboard normalizer and includes grounded evidence in the health tooltip preview.

## Validation
- `env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 scripts/dune-local.sh build test/test_keeper_adversarial_review.exe test/test_verifier_core_grounding.exe test/test_dashboard_briefing.exe`
- `./_build/default/test/test_keeper_adversarial_review.exe`
- `./_build/default/test/test_verifier_core_grounding.exe`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard lint`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/mission-normalizers.test.ts src/components/dashboard-shell.test.ts --no-file-parallelism --maxWorkers=1`

## Known test gap
- `./_build/default/test/test_dashboard_briefing.exe` still fails in the pre-existing pending-confirm fixture assertion: `internal signal includes pending confirm`; this is separate from the new grounded evidence path, which is covered by `test_keeper_adversarial_review` digest projection.