### PR TITLE
[codex] Fix fusion active schema execution

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1457,6 +1457,17 @@ let internal_descriptors : t list =
 
 let all_descriptors () = public_descriptors @ internal_descriptors
 
+let model_visible_descriptors () =
+  let visible_internal_descriptors =
+    internal_descriptors
+    |> List.filter (fun descriptor ->
+      match descriptor.policy.visibility with
+      | Tool_catalog.Default -> true
+      | Tool_catalog.Hidden -> false)
+  in
+  public_descriptors @ visible_internal_descriptors
+;;
+
 let public_names_of_descriptor d = d.public_name :: d.public_aliases
 
 let public_names () = List.concat_map public_names_of_descriptor public_descriptors

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -117,6 +117,11 @@ val internal_descriptors : t list
     descriptor-backed tool, regardless of LLM-native vs workspace origin. *)
 val all_descriptors : unit -> t list
 
+(** [model_visible_descriptors ()] is [public_descriptors] plus internal
+    descriptors whose policy visibility is [Default]. Hidden internal
+    descriptors remain executable only through non-model dispatcher paths. *)
+val model_visible_descriptors : unit -> t list
+
 val public_names_of_descriptor : t -> string list
 val public_names : unit -> string list
 val internal_names : t -> string list

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -55,13 +55,14 @@ let make_tool_bundle
      names backing public aliases must NOT appear on
      the LLM-visible surface alongside their public alias.  Mirrors the
      pattern already established in [keeper_run_tools.ml] PRs #14574/#14596. *)
+  let model_visible_descriptors = Keeper_tool_descriptor.model_visible_descriptors () in
   let aliased_internal_names =
-    Keeper_tool_descriptor.public_descriptors
+    model_visible_descriptors
     |> List.map Keeper_tool_descriptor.internal_names
     |> List.concat
   in
   let alias_public_names_in_surface =
-    Keeper_tool_descriptor.public_descriptors
+    model_visible_descriptors
     |> List.concat_map (fun descriptor ->
       if
         List.exists
@@ -191,7 +192,7 @@ let make_tool_bundle
                ~description:descriptor.description
                ~input_schema:descriptor.input_schema
                (fun input -> h input))))
-      Keeper_tool_descriptor.public_descriptors
+      model_visible_descriptors
   in
   let bundle =
       { tools = internal_tools @ alias_tools

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -175,6 +175,35 @@ let test_web_alias_bundle_visible_without_injected_masc_schema () =
           check bool "WebFetch remains bundle-visible" true
             (List.mem "WebFetch" names)))
 
+let test_fusion_default_descriptor_is_bundle_visible () =
+  ignore (init_registry ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc_test_fusion_bundle_%d" (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () -> try Unix.rmdir dir with _ -> ())
+    (fun () ->
+      let config = Workspace.default_config dir in
+      let meta = make_meta ~name:"test-fusion-default-descriptor" () in
+      let ctx_snapshot =
+        Keeper_context_runtime.create ~system_prompt:"test" ~max_tokens:4000
+      in
+      let bundle =
+        Keeper_tools_oas_bundle.make_tool_bundle ~config ~meta ~ctx_snapshot ()
+      in
+      Fun.protect
+        ~finally:bundle.cleanup
+        (fun () ->
+          let names =
+            bundle.tools
+            |> List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name)
+          in
+          check bool "masc_fusion is in the executable OAS tool bundle" true
+            (List.mem "masc_fusion" names)))
+
 (* ── Test 2: Atomic agent JSON writes ─────────────────────────── *)
 
 let test_atomic_write_not_empty () =
@@ -295,6 +324,8 @@ let () =
             test_core_tools_hidden_by_denylist;
           test_case "web aliases survive missing injected masc schema" `Quick
             test_web_alias_bundle_visible_without_injected_masc_schema;
+          test_case "fusion default descriptor reaches OAS bundle" `Quick
+            test_fusion_default_descriptor_is_bundle_visible;
         ] );
       ( "atomic_agent_json",
         [


### PR DESCRIPTION
## Summary

Fixes the live `masc_fusion` mismatch where `keeper_tools_list` showed the tool in the active keeper surface, but the actual keeper tool call failed with `Tool not found: masc_fusion`.

## Root Cause

`keeper_tools_list` builds its candidate surface from `Keeper_tool_descriptor.all_descriptors ()`, which includes `internal_descriptors`.

The executable OAS tool bundle only projected `Keeper_tool_descriptor.public_descriptors`, so visible internal descriptors such as `masc_fusion` were listed for the keeper but never registered into the actual `Agent_sdk.Tool.t` bundle.

## Changes

- Add a model-visible descriptor projection that includes:
  - all existing public descriptors
  - internal descriptors explicitly marked `visibility=Default`
- Keep hidden internal descriptors out of the OAS bundle.
- Add regression coverage proving `masc_fusion` reaches the executable OAS tool bundle.

## Validation

- `ocamlformat --check lib/keeper/keeper_tools_oas_bundle.ml test/test_warn_root_causes.ml`
- `scripts/dune-local.sh build test/test_warn_root_causes.exe`
- `./_build/default/test/test_warn_root_causes.exe test 'allowlist_tool_access_filter' 5`

Note: full `./_build/default/test/test_warn_root_causes.exe` still has an unrelated existing failure in `mainline_failure_levels / keeper mainline failures log at error`, due to a string-pattern drift unrelated to this Fusion bundle fix. The new Fusion regression test passes.
