### PR TITLE
fix(memory-bank): persist trace_id on cross-trace recurrence promotion

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -318,6 +318,13 @@ let consolidate_memory_notes ?summarizer (rows : keeper_memory_row_raw list)
           ("schema_version", `Int keeper_memory_schema_version);
           ("priority", `Int consolidation_recurrence_priority);
           ("text", `String row.text);
+          (* Carry the representative source row's trace_id. [parse_memory_bank_row]
+             rejects rows with an empty trace_id, so omitting it here silently
+             purges this promoted long_term note on the next read/compaction.
+             [row] is one of the input rows (all passed that parse guard), so
+             [row_trace_id row] is non-empty. The note recurred across
+             [recurring_across] traces; this records the highest-priority origin. *)
+          ("trace_id", `String (row_trace_id row));
           ("generation", `Int row.generation);
           ("recurring_across", `Int (List.length tids));
         ] in

--- a/test/dune
+++ b/test/dune
@@ -1566,6 +1566,8 @@
 
 (include stanzas/test_keeper_memory_bank_consensus_re_10399.inc)
 
+(include stanzas/test_keeper_memory_bank_consolidation_provenance.inc)
+
 (include stanzas/test_keeper_meta_canonical_seed.inc)
 
 (include stanzas/test_keeper_meta_unknown_keys_warn.inc)

--- a/test/stanzas/test_keeper_memory_bank_consolidation_provenance.inc
+++ b/test/stanzas/test_keeper_memory_bank_consolidation_provenance.inc
@@ -1,0 +1,9 @@
+; Regression for [Keeper_memory_bank.consolidate_memory_notes]: the cross-trace
+; recurrence promotion must persist a trace_id, else [parse_memory_bank_row]
+; silently purges the promoted long_term row on the next read. Per-file stanza
+; per test/stanzas/README.md to avoid the legacy grouped-stanza conflict hotspot.
+
+(test
+ (name test_keeper_memory_bank_consolidation_provenance)
+ (modules test_keeper_memory_bank_consolidation_provenance)
+ (libraries masc_test_deps masc alcotest yojson))

--- a/test/test_keeper_memory_bank_consolidation_provenance.ml
+++ b/test/test_keeper_memory_bank_consolidation_provenance.ml
@@ -1,0 +1,84 @@
+(** Regression: cross-trace recurrence consolidation must persist a trace_id.
+
+    [Keeper_memory_bank.consolidate_memory_notes] promotes a text that recurs
+    across >= [consolidation_min_group_size] distinct traces to a [long_term]
+    row tagged [Cross_trace_recurrence].  The read guard
+    [parse_memory_bank_row] rejects any row with an empty [trace_id], so a
+    promoted row written without one is silently purged on the next
+    read/compaction — losing exactly the cross-trace knowledge consolidation
+    just decided was worth keeping.  The progress-cluster path already carries
+    a [trace_id]; this pins that the cross-trace path does too, via a
+    build -> serialize -> reparse round-trip on the promoted row. *)
+
+module Keeper_memory_bank = Masc.Keeper_memory_bank
+open Keeper_memory_bank
+
+(* schema_version and the kind -> horizon mapping are fixed by
+   keeper_memory_policy: schema 2, kind "progress" -> horizon "short_term". *)
+let progress_row ~trace_id ~text : string =
+  `Assoc
+    [ ("schema_version", `Int 2)
+    ; ("kind", `String "progress")
+    ; ("horizon", `String "short_term")
+    ; ("source", `String "tool_result")
+    ; ("trace_id", `String trace_id)
+    ; ("generation", `Int 1)
+    ; ("priority", `Int 50)
+    ; ("text", `String text)
+    ; ("ts_unix", `Float 1_700_000_000.0)
+    ]
+  |> Yojson.Safe.to_string
+
+let parse_or_fail line =
+  match parse_memory_bank_row line with
+  | Some r -> r
+  | None -> Alcotest.failf "fixture row should parse but did not: %s" line
+
+(* One text repeated across four distinct traces (>= the min group size of 3,
+   with margin).  Each trace contributes a single progress row, so the
+   same-trace progress consolidation path stays below its group threshold and
+   only the cross-trace recurrence path fires. *)
+let recurring_text =
+  "Database migration step 3 completed and verified against staging"
+
+let input_rows () =
+  [ "trace-a"; "trace-b"; "trace-c"; "trace-d" ]
+  |> List.map (fun trace_id ->
+         parse_or_fail (progress_row ~trace_id ~text:recurring_text))
+
+let test_cross_trace_row_survives_reparse () =
+  let consolidated, _dropped = consolidate_memory_notes (input_rows ()) in
+  let cross_trace_rows =
+    List.filter
+      (fun (r : keeper_memory_row_raw) -> r.source = Cross_trace_recurrence)
+      consolidated
+  in
+  (* Non-vacuous: consolidation actually produced a cross-trace promotion. *)
+  Alcotest.(check bool)
+    "cross-trace recurrence row was produced" true
+    (cross_trace_rows <> []);
+  List.iter
+    (fun (r : keeper_memory_row_raw) ->
+      (* The promoted row carries a non-empty trace_id ... *)
+      Alcotest.(check bool)
+        "promoted cross-trace row has non-empty trace_id" true
+        (row_trace_id r <> "");
+      (* ... so re-reading its serialized form survives the read guard
+         instead of being silently dropped. *)
+      let serialized = Yojson.Safe.to_string r.json in
+      match parse_memory_bank_row serialized with
+      | Some _ -> ()
+      | None ->
+          Alcotest.failf
+            "promoted cross-trace row was purged on reparse (empty trace_id?): \
+             %s"
+            serialized)
+    cross_trace_rows
+
+let () =
+  Alcotest.run "keeper_memory_bank_consolidation_provenance"
+    [ ( "cross_trace_recurrence"
+      , [ Alcotest.test_case "promoted row survives reparse" `Quick
+            test_cross_trace_row_survives_reparse
+        ] )
+    ]


### PR DESCRIPTION
## 무엇 / 왜

메모리 흐름 적대 감사(P2)에서 확인한 **silent memory-loss 버그**를 수정합니다.

`Keeper_memory_bank.consolidate_memory_notes`는 두 경로로 노트를 합성합니다:
1. **같은 trace의 progress 클러스터** → `long_term` 요약 (`Progress_consolidation`)
2. **여러 trace에 반복 등장하는 텍스트** → `long_term` 승격 (`Cross_trace_recurrence`)

경로 1의 JSON은 `("trace_id", ...)`를 포함하지만(`keeper_memory_bank.ml:268`), **경로 2의 `lt_json`은 trace_id 필드를 전혀 만들지 않았습니다**(`keeper_memory_bank.ml:312-323`).

read guard `parse_memory_bank_row`는 `trace_id <> ""`를 강제합니다(`keeper_memory_bank.ml:123`). 따라서 cross-trace로 승격된 `long_term` row는 디스크에 trace_id 없이 쓰이고 → **바로 다음 read/compaction에서 `trace_id=""`로 파싱되어 `None`으로 drop** → silent purge. 하필 "여러 trace에 반복돼 장기기억으로 올릴 만큼 가치있다"고 판정된 지식이 사라집니다.

## 수정

경로 2의 `lt_json`에 representative source row의 trace_id를 추가합니다(progress 경로와 동일한 패턴):

```ocaml
("trace_id", `String (row_trace_id row));
```

`row`는 입력 row 중 하나(전부 parse guard를 통과)이므로 `row_trace_id row`는 non-empty가 보장됩니다. 누락 사이트는 이 한 곳뿐(N-of-1).

왜 representative trace_id인가: 이 row는 `recurring_across` 개의 trace에 걸쳐 반복된 텍스트의 승격본이고, 단일 string 스키마 필드에는 대표값(highest-priority 출처)을 담는 것이 progress 경로(`tid` 단일값)와 일관되며 read guard를 통과시킵니다.

## 검증

`test/test_keeper_memory_bank_consolidation_provenance.ml` 추가 — **build → serialize → reparse round-trip** 회귀 테스트:
- 같은 텍스트를 4개 distinct trace로 입력 → cross-trace 승격 발화(non-vacuous 단언 포함)
- 승격 row를 `Yojson.Safe.to_string` 후 `parse_memory_bank_row`로 재파싱 → `Some` 생존 검증

mutation 확인(양쪽 검증):
- 수정 적용: `Test Successful` (1 test)
- 수정 제거: `[FAIL] promoted cross-trace row has non-empty trace_id — Expected: true, Received: false` (버그를 정확히 잡음, "row was produced" 단언은 통과해 vacuous 아님)

인접 테스트 무회귀: `test_keeper_memory_row_source`(4), `test_keeper_memory_bank_consensus_re_10399`(4) 모두 green. `ocamlformat --check` 통과.

## 범위 / 비고

- 4파일, +102 (lib +7, test/dune +2, 신규 테스트 .ml/.inc).
- `scripts/verify-test-registration.py`는 origin/main에서 이미 exit 1(기존 9 unregistered + 3 orphaned, 본 PR과 무관). 본 PR이 추가한 테스트는 정상 등록됨(unregistered 목록에 없음).
- 워크어라운드 시그니처 비해당: telemetry-as-fix 아님(실제 데이터 손실 차단), string 분류기 아님, N-of-1(유일 사이트), cap/cooldown/repair 아님.

RFC-WAIVED: lib/keeper/credential_*·repo_manager·operator_control·sandbox·hooks·workflow 등 RFC-게이트 subsystem 미해당(메모리 합성 직렬화 버그 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
