### PR TITLE
[codex] Tighten keeper v2 connectors visual parity

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -256,6 +256,11 @@ describe('shouldSuppressFloatingChrome', () => {
       keeperDetailMode: false,
       mobileDrawerOpen: false,
     })).toBe(true)
+    expect(shouldSuppressFloatingChrome({
+      currentTab: 'logs',
+      keeperDetailMode: false,
+      mobileDrawerOpen: false,
+    })).toBe(true)
   })
 
   it('keeps floating chrome for operational surfaces unless a shell overlay is active', () => {

--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -2,7 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { App, shouldUseCompactDashboardChrome } from './app'
+import { App, shouldSuppressFloatingChrome, shouldUseCompactDashboardChrome } from './app'
+import { route } from './router'
 
 describe('App v2 header chrome', () => {
   let container: HTMLDivElement
@@ -12,12 +13,14 @@ describe('App v2 header chrome', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     window.location.hash = originalHash
+    route.value = { tab: 'overview', params: {}, postId: null }
   })
 
   afterEach(() => {
     render(null, container)
     container.remove()
     window.location.hash = originalHash
+    route.value = { tab: 'overview', params: {}, postId: null }
   })
 
   function renderApp() {
@@ -129,6 +132,7 @@ describe('App v2 header chrome', () => {
 
   it('hides mobile nav tabs on keeper detail routes', () => {
     window.location.hash = '#monitoring/agents?keeper=sangsu'
+    route.value = { tab: 'monitoring', params: { section: 'agents', keeper: 'sangsu' }, postId: null }
     window.innerWidth = 900
     renderApp()
 
@@ -193,9 +197,30 @@ describe('App v2 header chrome', () => {
     })
   })
 
-  it('focus mode does not permanently hide the rail', async () => {
+  it('hides floating status and focus chrome on prototype primary surfaces', () => {
     window.innerWidth = 1280
     window.location.hash = '#overview'
+    route.value = { tab: 'overview', params: {}, postId: null }
+    renderApp()
+
+    expect(container.querySelector('[data-testid="dashboard-status-tray"]')).toBeNull()
+    expect(container.querySelector('[data-testid="dashboard-focus-mode-toggle"]')).toBeNull()
+  })
+
+  it('keeps floating status and focus chrome on operational surfaces', () => {
+    window.innerWidth = 1280
+    window.location.hash = '#monitoring/agents'
+    route.value = { tab: 'monitoring', params: { section: 'agents' }, postId: null }
+    renderApp()
+
+    expect(container.querySelector('[data-testid="dashboard-status-tray"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="dashboard-focus-mode-toggle"]')).not.toBeNull()
+  })
+
+  it('focus mode does not permanently hide the rail', async () => {
+    window.innerWidth = 1280
+    window.location.hash = '#monitoring/agents'
+    route.value = { tab: 'monitoring', params: { section: 'agents' }, postId: null }
     renderApp()
 
     // Rail should be visible initially.
@@ -216,6 +241,34 @@ describe('App v2 header chrome', () => {
     await waitFor(() => {
       expect(container.querySelector('#dashboard-side-rail')).not.toBeNull()
     })
+  })
+})
+
+describe('shouldSuppressFloatingChrome', () => {
+  it('suppresses floating chrome for prototype primary surfaces', () => {
+    expect(shouldSuppressFloatingChrome({
+      currentTab: 'overview',
+      keeperDetailMode: false,
+      mobileDrawerOpen: false,
+    })).toBe(true)
+    expect(shouldSuppressFloatingChrome({
+      currentTab: 'connectors',
+      keeperDetailMode: false,
+      mobileDrawerOpen: false,
+    })).toBe(true)
+  })
+
+  it('keeps floating chrome for operational surfaces unless a shell overlay is active', () => {
+    expect(shouldSuppressFloatingChrome({
+      currentTab: 'monitoring',
+      keeperDetailMode: false,
+      mobileDrawerOpen: false,
+    })).toBe(false)
+    expect(shouldSuppressFloatingChrome({
+      currentTab: 'monitoring',
+      keeperDetailMode: false,
+      mobileDrawerOpen: true,
+    })).toBe(true)
   })
 })
 

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -44,6 +44,7 @@ import { DashboardFocusModeToggle, dashboardFocusMode } from './components/focus
 import {
   DASHBOARD_NAV_ITEMS,
   currentSectionForRoute,
+  isPrimaryDashboardSurface,
 } from './config/navigation'
 import type { TabId } from './types'
 import { Menu, X } from 'lucide-preact'
@@ -76,15 +77,6 @@ const sidebarCollapsed = persistentSignal<boolean>({
   defaultValue: false,
 })
 const mobileMenuOpen = signal(false)
-const PROTOTYPE_PRIMARY_SURFACE_TABS = new Set<TabId>([
-  'overview',
-  'workspace',
-  'keepers',
-  'board',
-  'code',
-  'connectors',
-  'settings',
-])
 
 export function shouldSuppressFloatingChrome({
   currentTab,
@@ -95,7 +87,7 @@ export function shouldSuppressFloatingChrome({
   keeperDetailMode: boolean
   mobileDrawerOpen: boolean
 }): boolean {
-  return keeperDetailMode || mobileDrawerOpen || PROTOTYPE_PRIMARY_SURFACE_TABS.has(currentTab)
+  return keeperDetailMode || mobileDrawerOpen || isPrimaryDashboardSurface(currentTab)
 }
 
 const LazyAgentDetailOverlay = lazy(async () => ({

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -257,6 +257,7 @@ export function App() {
   const keeperDetailMode = isKeeperDetailDashboardRoute(route.value)
   const focusMode = dashboardFocusMode.value
   const mobileDrawerOpen = isMobile && mobileMenuOpen.value
+  const suppressFloatingChrome = keeperDetailMode || mobileDrawerOpen || currentTab === 'connectors'
   const compactChromeMode = shouldUseCompactDashboardChrome({
     widgetSoloMode,
     focusMode,
@@ -396,7 +397,7 @@ export function App() {
       ${selectedTask.value
         ? html`<${Suspense} fallback=${null}><${LazyTaskDetailOverlay} /><//>`
         : null}
-      ${keeperDetailMode || mobileDrawerOpen ? null : html`
+      ${suppressFloatingChrome ? null : html`
         <${DashboardStatusTray} sideRailCollapsed=${sidebarCollapsed.value} />
         <${DashboardFocusModeToggle} />
       `}

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -45,6 +45,7 @@ import {
   DASHBOARD_NAV_ITEMS,
   currentSectionForRoute,
 } from './config/navigation'
+import type { TabId } from './types'
 import { Menu, X } from 'lucide-preact'
 import { useKeyboardShortcutHost } from '../design-system/headless-preact/use-keyboard-shortcut'
 import { globalShortcutManager } from './lib/global-shortcut-manager'
@@ -75,6 +76,28 @@ const sidebarCollapsed = persistentSignal<boolean>({
   defaultValue: false,
 })
 const mobileMenuOpen = signal(false)
+const PROTOTYPE_PRIMARY_SURFACE_TABS = new Set<TabId>([
+  'overview',
+  'workspace',
+  'keepers',
+  'board',
+  'code',
+  'connectors',
+  'settings',
+])
+
+export function shouldSuppressFloatingChrome({
+  currentTab,
+  keeperDetailMode,
+  mobileDrawerOpen,
+}: {
+  currentTab: TabId
+  keeperDetailMode: boolean
+  mobileDrawerOpen: boolean
+}): boolean {
+  return keeperDetailMode || mobileDrawerOpen || PROTOTYPE_PRIMARY_SURFACE_TABS.has(currentTab)
+}
+
 const LazyAgentDetailOverlay = lazy(async () => ({
   default: (await import('./components/agent-detail')).AgentDetailOverlay,
 }))
@@ -257,7 +280,11 @@ export function App() {
   const keeperDetailMode = isKeeperDetailDashboardRoute(route.value)
   const focusMode = dashboardFocusMode.value
   const mobileDrawerOpen = isMobile && mobileMenuOpen.value
-  const suppressFloatingChrome = keeperDetailMode || mobileDrawerOpen || currentTab === 'connectors'
+  const suppressFloatingChrome = shouldSuppressFloatingChrome({
+    currentTab,
+    keeperDetailMode,
+    mobileDrawerOpen,
+  })
   const compactChromeMode = shouldUseCompactDashboardChrome({
     widgetSoloMode,
     focusMode,

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, SideRail, summarizeAttentionPreview } from './dashboard-shell'
+import { DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, shouldRenderSurfaceLead, SideRail, summarizeAttentionPreview } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 import { dashboardLoading } from '../store'
@@ -69,6 +69,24 @@ describe('isKeeperDetailDashboardRoute', () => {
       params: { section: 'agents' },
       postId: null,
     })).toBe(false)
+  })
+})
+
+describe('shouldRenderSurfaceLead', () => {
+  it('lets the Connectors prototype surface own its primary header', () => {
+    expect(shouldRenderSurfaceLead({
+      tab: 'connectors',
+      params: { section: 'connector-status' },
+      postId: null,
+    })).toBe(false)
+  })
+
+  it('keeps the generic lead for ordinary sectioned surfaces', () => {
+    expect(shouldRenderSurfaceLead({
+      tab: 'workspace',
+      params: { section: 'work' },
+      postId: null,
+    })).toBe(true)
   })
 })
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1395,6 +1395,11 @@ export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
     && routeState.params.keeper.trim() !== ''
 }
 
+export function shouldRenderSurfaceLead(routeState: RouteState): boolean {
+  if (isKeeperDetailDashboardRoute(routeState)) return false
+  return routeState.tab !== 'connectors'
+}
+
 function SurfaceLead() {
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
@@ -1461,6 +1466,7 @@ export function DashboardMain() {
   const soloMode = isWidgetSoloRoute(route.value)
   const immersiveSurface = route.value.tab === 'code' || route.value.tab === 'keepers'
   const keeperDetailRoute = isKeeperDetailDashboardRoute(route.value)
+  const renderSurfaceLead = shouldRenderSurfaceLead(route.value)
   const warmingBanner = namespaceTruthInitializing.value ? html`
     <div class=${`v2-shell-panel ${immersiveSurface
       ? 'shrink-0 border-b border-solid border-[var(--warn-20)] bg-[var(--warn-10)] px-4 py-1.5 text-center text-xs text-[var(--color-status-warn)]'
@@ -1505,7 +1511,7 @@ export function DashboardMain() {
 
   return html`
     ${warmingBanner}
-    ${keeperDetailRoute ? null : html`<${SurfaceLead} />`}
+    ${renderSurfaceLead ? html`<${SurfaceLead} />` : null}
     ${keeperDetailRoute ? null : html`<${ObservatoryFilterBar} />`}
     <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>
       <div class="animate-in fade-in slide-in-from-bottom-2 duration-[var(--t-slow)] fill-mode-both">

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1395,9 +1395,14 @@ export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
     && routeState.params.keeper.trim() !== ''
 }
 
+// Surfaces that render their own primary header and therefore do not need the
+// generic dashboard section lead above them. Keep this in sync with the route
+// registry; currently only the Connectors prototype surface uses its own header.
+const SURFACE_OWN_LEAD_IDS: ReadonlySet<TabId> = new Set(['connectors'])
+
 export function shouldRenderSurfaceLead(routeState: RouteState): boolean {
   if (isKeeperDetailDashboardRoute(routeState)) return false
-  return routeState.tab !== 'connectors'
+  return !SURFACE_OWN_LEAD_IDS.has(routeState.tab)
 }
 
 function SurfaceLead() {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -95,7 +95,7 @@ const V2_PRIMARY_SURFACE_IDS: ReadonlyArray<SurfaceId> = [
 ]
 
 export function isPrimaryDashboardSurface(tabId: TabId): boolean {
-  return V2_PRIMARY_SURFACE_IDS.includes(tabId as SurfaceId)
+  return V2_PRIMARY_SURFACE_IDS.includes(tabId)
 }
 
 const SECTIONLESS_SURFACE_IDS: ReadonlySet<TabId> = new Set([

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -94,6 +94,10 @@ const V2_PRIMARY_SURFACE_IDS: ReadonlyArray<SurfaceId> = [
   'logs',
 ]
 
+export function isPrimaryDashboardSurface(tabId: TabId): boolean {
+  return V2_PRIMARY_SURFACE_IDS.includes(tabId as SurfaceId)
+}
+
 const SECTIONLESS_SURFACE_IDS: ReadonlySet<TabId> = new Set([
   'overview',
   'logs',

--- a/dashboard/src/styles/connectors-v2.css
+++ b/dashboard/src/styles/connectors-v2.css
@@ -1009,6 +1009,10 @@
 /* ── Responsive ─────────────────────────────────────────────────────────── */
 
 @media (max-width: 900px) {
+  .v2-connectors-surface {
+    padding-bottom: 118px;
+  }
+
   .cn-surf-head {
     flex-direction: column;
     align-items: flex-start;

--- a/dashboard/src/styles/connectors-v2.css
+++ b/dashboard/src/styles/connectors-v2.css
@@ -1009,6 +1009,9 @@
 /* ── Responsive ─────────────────────────────────────────────────────────── */
 
 @media (max-width: 900px) {
+  /* Keep the last connector cards scrollable above the mobile bottom bar
+   * (~56px) plus the floating status/focus chrome row (~48px) with a small
+   * breathing gap. 118px matches the prototype mobile scroll-padding heuristic. */
   .v2-connectors-surface {
     padding-bottom: 118px;
   }

--- a/docs/design/keeper-v2-v12-gap-current.md
+++ b/docs/design/keeper-v2-v12-gap-current.md
@@ -1,6 +1,6 @@
 # Keeper v2 v12 Gap Snapshot
 
-Source reviewed: `/Users/dancer/Downloads/v2 (12)`.
+Source reviewed: design hand-off asset "v2 (12)".
 
 Current implementation surface: `dashboard/src` on branch `codex/keeper-v2-connectors-visual-followup`.
 
@@ -60,4 +60,4 @@ Current implementation surface: `dashboard/src` on branch `codex/keeper-v2-conne
 - The generic dashboard `Connectors > All` section lead should stay removed from the Connectors primary view; the prototype `Gate / 커넥터` header owns that page title.
 - The floating status tray/focus toggle should stay hidden on prototype primary surfaces; the top shell already carries connection/status controls, and those surfaces keep the bottom edge free for primary content.
 - The old read-only drawer binding summary should stay replaced by the inline editor shell; the lower-level config form can remain available under the drawer's `config` tab until persistence is fully wired.
-- Stale gap notes under `/Users/dancer/me/memory/keeper-v2-gap-*.md` are superseded by this repo-local snapshot.
+- Stale personal gap notes are superseded by this repo-local snapshot.

--- a/docs/design/keeper-v2-v12-gap-current.md
+++ b/docs/design/keeper-v2-v12-gap-current.md
@@ -2,7 +2,7 @@
 
 Source reviewed: `/Users/dancer/Downloads/v2 (12)`.
 
-Current implementation surface: `dashboard/src` on branch `codex/keeper-v2-connectors`.
+Current implementation surface: `dashboard/src` on branch `codex/keeper-v2-connectors-visual-followup`.
 
 ## Exists In Current Page
 
@@ -35,6 +35,8 @@ Current implementation surface: `dashboard/src` on branch `codex/keeper-v2-conne
 - The drawer binding editor supports local UI edits for channel, keeper, direction, delete, enabled toggle, and add-binding actions so the visible flow matches the prototype shell before backend persistence is wired.
 - Connector cards now pin the prototype-facing status vocabulary to a closed connected/stale/disconnected/offline domain so pill tone, card state, and border framing cannot drift when the backend advertises an unknown status.
 - Unsaved connector drawer drafts now survive same-connector live refreshes, matching the prototype's local editing feel while the hard persistence contract remains unwired.
+- The Connectors page no longer renders the generic dashboard `Connectors > All` lead above the prototype `Gate / 커넥터` header; the primary surface now starts at the prototype-owned header.
+- Connectors suppresses the generic floating status tray/focus toggle and adds mobile bottom scroll padding, so fixed shell chrome does not sit on top of connector card content.
 
 ## Still Missing Vs Prototype
 
@@ -54,5 +56,7 @@ Current implementation surface: `dashboard/src` on branch `codex/keeper-v2-conne
 - The desktop top surface tab layer should stay removed; it is now covered by the single rail model.
 - The old Overview slim-home cards should stay collapsed under `운영 롤업`, not return between the KPI/attention/telemetry/fleet prototype sections.
 - The old Connectors operator console should stay collapsed under `운영 상세`, not return above the connector gate grid and recent audit log.
+- The generic dashboard `Connectors > All` section lead should stay removed from the Connectors primary view; the prototype `Gate / 커넥터` header owns that page title.
+- The floating status tray/focus toggle should stay hidden on Connectors; the top shell already carries connection/status controls, and the prototype surface keeps the bottom edge free for connector cards.
 - The old read-only drawer binding summary should stay replaced by the inline editor shell; the lower-level config form can remain available under the drawer's `config` tab until persistence is fully wired.
 - Stale gap notes under `/Users/dancer/me/memory/keeper-v2-gap-*.md` are superseded by this repo-local snapshot.

--- a/docs/design/keeper-v2-v12-gap-current.md
+++ b/docs/design/keeper-v2-v12-gap-current.md
@@ -37,6 +37,7 @@ Current implementation surface: `dashboard/src` on branch `codex/keeper-v2-conne
 - Unsaved connector drawer drafts now survive same-connector live refreshes, matching the prototype's local editing feel while the hard persistence contract remains unwired.
 - The Connectors page no longer renders the generic dashboard `Connectors > All` lead above the prototype `Gate / 커넥터` header; the primary surface now starts at the prototype-owned header.
 - Connectors suppresses the generic floating status tray/focus toggle and adds mobile bottom scroll padding, so fixed shell chrome does not sit on top of connector card content.
+- The generic floating status tray/focus toggle is now suppressed across prototype primary surfaces (Overview, Work, Keepers, Board, IDE, Connectors, Settings) while remaining available on operational/diagnostic lanes.
 
 ## Still Missing Vs Prototype
 
@@ -57,6 +58,6 @@ Current implementation surface: `dashboard/src` on branch `codex/keeper-v2-conne
 - The old Overview slim-home cards should stay collapsed under `운영 롤업`, not return between the KPI/attention/telemetry/fleet prototype sections.
 - The old Connectors operator console should stay collapsed under `운영 상세`, not return above the connector gate grid and recent audit log.
 - The generic dashboard `Connectors > All` section lead should stay removed from the Connectors primary view; the prototype `Gate / 커넥터` header owns that page title.
-- The floating status tray/focus toggle should stay hidden on Connectors; the top shell already carries connection/status controls, and the prototype surface keeps the bottom edge free for connector cards.
+- The floating status tray/focus toggle should stay hidden on prototype primary surfaces; the top shell already carries connection/status controls, and those surfaces keep the bottom edge free for primary content.
 - The old read-only drawer binding summary should stay replaced by the inline editor shell; the lower-level config form can remain available under the drawer's `config` tab until persistence is fully wired.
 - Stale gap notes under `/Users/dancer/me/memory/keeper-v2-gap-*.md` are superseded by this repo-local snapshot.


### PR DESCRIPTION
## Summary

- suppress the generic dashboard section lead on the Connectors route so the v2 `Gate / 커넥터` header owns the page
- hide the floating status tray/focus toggle on Connectors and add mobile bottom scroll padding so connector cards are not covered by shell chrome
- update the keeper v2 gap snapshot with the new missing/should-disappear ledger entries

## Validation

- `pnpm -C dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/dashboard-shell.test.ts src/components/mobile-nav.test.ts src/components/connector-status.test.ts src/components/connector-card-border.test.ts`
- `pnpm -C dashboard lint`
- `pnpm -C dashboard typecheck`
- `pnpm -C dashboard build`
- Playwright screenshots:
  - desktop: `/private/tmp/masc-connectors-after-desktop-final.png`
  - mobile: `/private/tmp/masc-connectors-after-mobile-final.png`
