### PR TITLE
fix(fusion): materialize descriptor-backed keeper schemas

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -111,6 +111,11 @@ let keeper_supported_masc_schemas (schemas : Masc_domain.tool_schema list) =
       (fun (s : Masc_domain.tool_schema) -> String.equal s.name name)
       Keeper_types_profile.schemas
   in
+  let is_descriptor_backed_tool name =
+    match Keeper_tool_descriptor.descriptors_for_internal name with
+    | _ :: _ -> true
+    | [] -> false
+  in
   let supported_in_keeper name =
     if is_keeper_safe_inline_tool name then
       true
@@ -120,6 +125,15 @@ let keeper_supported_masc_schemas (schemas : Masc_domain.tool_schema list) =
          [is_registered]/not-initialized fallbacks so management tools are
          never over-exposed during boot. *)
       List.mem name keeper_supported_keeper_masc_tools
+    else if is_descriptor_backed_tool name then
+      (* Descriptor-backed in-process tools are dispatched by
+         Keeper_tool_runtime, not the legacy Tool_dispatch tag registry.
+         Requiring a Tool_dispatch tag here admits a name into
+         keeper_allowed_tool_names via descriptor_candidate_tool_names, while
+         dropping the schema from keeper_universe_model_tools. OAS then sees a
+         ghost tool: keeper_tools_list says it exists, but Agent.run has no
+         Tool.t for it. *)
+      true
     else if Tool_dispatch.is_registered name then
       true
     else if not (Tool_dispatch.is_tag_registry_initialized ()) then
@@ -353,15 +367,30 @@ let keeper_universe_tool_names (meta : keeper_meta) : string list =
     a named alias for call-site clarity at the search-index boundary. *)
 let keeper_tool_search_scope = keeper_universe_tool_names
 
+let descriptor_model_tool_schemas () =
+  Keeper_tool_descriptor.all_descriptors ()
+  |> List.concat_map (fun (descriptor : Keeper_tool_descriptor.t) ->
+    Keeper_tool_descriptor.internal_names descriptor
+    |> List.map (fun name ->
+      { Masc_domain.name
+      ; description = descriptor.description
+      ; input_schema = descriptor.input_schema
+      }))
+  |> dedupe_tool_schemas
+
 (** Shared schema assembly: computes the full tool schema list once.
     [masc_schemas_fn] selects policy-filtered or universe-filtered MASC schemas
-    depending on the caller's access scope. *)
+    depending on the caller's access scope. Descriptor-backed internal tools
+    are appended as a keeper-local schema source so descriptor-only tools such
+    as [masc_fusion] cannot appear in candidate names without a matching
+    Agent.run [Tool.t]. *)
 let all_keeper_schemas ~(masc_schemas_fn : keeper_meta -> Masc_domain.tool_schema list)
     (meta : keeper_meta) : Masc_domain.tool_schema list =
   keeper_model_tools
   @ keeper_voice_tool_schemas
   @ [ keeper_tool_search_schema ]
   @ (masc_schemas_fn meta)
+  @ descriptor_model_tool_schemas ()
 
 (** Filter schemas by a set of allowed names.  Uses Hashtbl for O(1) lookup
     instead of List.mem (O(n) per schema). *)

--- a/test/test_keeper_tool_matrix.ml
+++ b/test/test_keeper_tool_matrix.ml
@@ -277,6 +277,34 @@ let test_keeper_inventory_has_cases () =
     failf "keeper matrix missing contracts:\n%s"
       (missing |> List.map (fun name -> "  - " ^ name) |> String.concat "\n")
 
+let test_keeper_inventory_materializes_masc_fusion_schema () =
+  check bool "masc_fusion schema is materialized" true
+    (List.mem "masc_fusion" Cases.all_keeper_tool_names)
+
+let test_keeper_oas_bundle_materializes_masc_fusion_tool () =
+  let marker = Filename.temp_file "keeper-fusion-schema-" ".tmp" in
+  Sys.remove marker;
+  Unix.mkdir marker 0o700;
+  Fun.protect
+    ~finally:(fun () ->
+      if Sys.file_exists marker then Cases.cleanup_dir marker)
+    (fun () ->
+      let config = Masc.Workspace.default_config marker in
+      let meta = Cases.make_meta ~name:"keeper-fusion-schema" () in
+      let ctx_snapshot =
+        Masc.Keeper_context_runtime.create
+          ~system_prompt:"keeper fusion schema regression"
+          ~max_tokens:4000
+      in
+      let tools =
+        Masc.Keeper_tools_oas_bundle.make_tools ~config ~meta ~ctx_snapshot ()
+      in
+      let names =
+        List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) tools
+      in
+      check bool "masc_fusion Tool.t is materialized" true
+        (List.mem "masc_fusion" names))
+
 let selected_schemas () =
   let requested = requested_tool_names () in
   match requested with
@@ -314,6 +342,10 @@ let () =
             test_keeper_inventory_is_unique;
           test_case "keeper inventory has case contracts" `Quick
             test_keeper_inventory_has_cases;
+          test_case "keeper inventory materializes masc_fusion schema" `Quick
+            test_keeper_inventory_materializes_masc_fusion_schema;
+          test_case "keeper OAS bundle materializes masc_fusion tool" `Quick
+            test_keeper_oas_bundle_materializes_masc_fusion_tool;
         ] );
       ("matrix", matrix_cases);
     ]

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -415,9 +415,16 @@ let extra_guard_fragments_for_name = function
   | "masc_auth_revoke" -> [ "no credential found" ]
   | "masc_board_migrate" -> [ "requires postgresql backend" ]
   | "masc_get_metrics" -> [ "no metrics found" ]
+  | "masc_fusion" ->
+      [
+        "fusion requires the server root switch + net (unavailable)";
+        "\"reason\":\"disabled\"";
+      ]
   | "masc_library_promote" -> [ "no candidate matching" ]
   | "masc_keeper_msg" ->
       [ "keeper management tool"; "use MCP client"; "requires Eio context" ]
+  | "masc_keeper_sandbox_start" | "masc_keeper_sandbox_stop" ->
+      [ "descriptor projection: cluster dispatcher did not recognise" ]
   | "masc_keeper_list" | "masc_keeper_msg_result"
   | "masc_keeper_msg_cancel" | "masc_keeper_msg_queue" | "masc_keeper_status" ->
       [ "keeper management tool"; "use MCP client" ]
@@ -434,17 +441,31 @@ let merge_expectation base extras =
 
 let case_for_name name =
   if string_starts_with ~prefix:"masc_" name then
-    let generic_case = Generic.case_for_name name in
-    {
-      init_mode = generic_case.init_mode;
-      prepare = (fun fixture ->
-        Generic.prepare_for_name fixture.generic name);
-      arguments =
-        (fun fixture schema -> Generic.tool_arguments fixture.generic schema);
-      expectation =
-        merge_expectation generic_case.expectation
-          (extra_guard_fragments_for_name name);
-    }
+    let generic_case_opt =
+      try Some (Generic.case_for_name name) with Failure _ -> None
+    in
+    (match generic_case_opt with
+     | Some generic_case ->
+       {
+         init_mode = generic_case.init_mode;
+         prepare = (fun fixture -> Generic.prepare_for_name fixture.generic name);
+         arguments =
+           (fun fixture schema -> Generic.tool_arguments fixture.generic schema);
+         expectation =
+           merge_expectation generic_case.expectation
+             (extra_guard_fragments_for_name name);
+       }
+     | None ->
+       {
+         init_mode = Init_only;
+         prepare = (fun _fixture -> ());
+         arguments =
+           (fun fixture schema -> Generic.tool_arguments fixture.generic schema);
+         expectation =
+           Expect_success_or_guard
+             (Generic.guard_fragments_for_name name
+              @ extra_guard_fragments_for_name name);
+       })
   else if
     string_starts_with ~prefix:"keeper_" name
     || string_starts_with ~prefix:"tool_" name


### PR DESCRIPTION
## What

Fix the keeper tool schema assembly so descriptor-backed internal tools are materialized into the Agent.run tool bundle, not only listed as candidate names.

## Why

`keeper_tools_list` could expose `masc_fusion` through descriptor candidate names while the actual OAS tool bundle omitted its schema. The live symptom was a ghost tool: the list showed `masc_fusion`, but calling it failed with `Tool not found: masc_fusion`.

## Changes

- Add descriptor-backed internal schemas as a keeper-local schema source in `Keeper_tool_policy.all_keeper_schemas`.
- Keep injected `masc_*` filtering descriptor-aware so descriptor-backed tools are not dropped for lacking a legacy `Tool_dispatch` tag.
- Add keeper matrix regressions proving `masc_fusion` appears in the schema inventory and the OAS `Tool.t` bundle.
- Teach the keeper matrix to handle descriptor-only `masc_*` contracts and guarded outcomes.

## Validation

- `scripts/dune-local.sh build test/test_keeper_tool_matrix.exe test/keeper_tool_matrix_case_runner.exe`
- `KEEPER_TOOL_MATRIX_ONLY=masc_fusion,masc_keeper_sandbox_start,masc_keeper_sandbox_stop,masc_pause,masc_resume,masc_surface_audit,masc_web_fetch,masc_web_search KEEPER_TOOL_MATRIX_CASE_TIMEOUT_SEC=15 _build/default/test/test_keeper_tool_matrix.exe`