### PR TITLE
fix(dashboard): keeper-v2 design-system audit cleanup

### DIFF
--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -142,7 +142,7 @@ describe('cockpit entrypoint registry', () => {
     })
     expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'keeper-cognition' })).toEqual({
       tab: 'monitoring',
-      params: { section: 'cognition', view: 'keeper' },
+      params: { section: 'agents', view: 'keeper' },
     })
     expect(cockpitTargetForParams({ mode: 'IDE', tab: 'source' })).toEqual({
       tab: 'code',
@@ -165,19 +165,19 @@ describe('cockpit entrypoint registry', () => {
     })
     expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'dc-str' })).toEqual({
       tab: 'monitoring',
-      params: { section: 'cognition', view: 'decisions' },
+      params: { section: 'agents', view: 'decisions' },
     })
     expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'ki-bdi' })).toEqual({
       tab: 'monitoring',
-      params: { section: 'cognition', view: 'keeper', focus: 'bdi' },
+      params: { section: 'agents', view: 'keeper', focus: 'bdi' },
     })
     expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'keeper-tool-access' })).toEqual({
       tab: 'monitoring',
-      params: { section: 'cognition', view: 'keeper', focus: 'tool-access' },
+      params: { section: 'agents', view: 'keeper', focus: 'tool-access' },
     })
     expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'dc-mem' })).toEqual({
       tab: 'monitoring',
-      params: { section: 'cognition', view: 'memory', focus: 'entries' },
+      params: { section: 'agents', view: 'memory', focus: 'entries' },
     })
     expect(cockpitTargetForParams({ mode: 'Observe', tab: 'sa-dash' })).toEqual({
       tab: 'command',

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -92,7 +92,7 @@ export const COCKPIT_MODE_TARGETS: Record<CockpitMode, CockpitRouteTarget> = {
   work: { tab: 'workspace', params: { section: 'planning' } },
   comms: { tab: 'board' },
   observe: { tab: 'monitoring', params: { section: 'runtime' } },
-  cognition: { tab: 'monitoring', params: { section: 'cognition' } },
+  cognition: { tab: 'monitoring', params: { section: 'agents' } },
   ide: COGNITIVE_MODE_TARGETS.code,
   code: COGNITIVE_MODE_TARGETS.code,
   split: COGNITIVE_MODE_TARGETS.split,
@@ -152,7 +152,7 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   {
     mode: 'cognition',
     aliases: ['keeper-cognition'],
-    target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper' } },
+    target: { tab: 'monitoring', params: { section: 'agents', view: 'keeper' } },
     coverage: 'covered',
   },
   {
@@ -198,13 +198,13 @@ export const COCKPIT_LEGACY_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'observe', aliases: ['ct-lat', 'cost-latency'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'cost', focus: 'latency' } }, coverage: 'covered' },
 
   // Cognition Plane legacy design subtabs.
-  { mode: 'cognition', aliases: ['ki-bdi', 'keeper-bdi'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper', focus: 'bdi' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['ki-acc', 'keeper-tool-access'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper', focus: 'tool-access' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['ki-stat', 'keeper-token-stats'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'token-stats' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['dc-str', 'decisions-stream'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'decisions' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['dc-mem', 'memory-entries'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'memory', focus: 'entries' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['ep-card', 'episodes-cards'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'episodes' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['ep-lrn', 'episodes-learnings'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'episodes' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['ki-bdi', 'keeper-bdi'], target: { tab: 'monitoring', params: { section: 'agents', view: 'keeper', focus: 'bdi' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['ki-acc', 'keeper-tool-access'], target: { tab: 'monitoring', params: { section: 'agents', view: 'keeper', focus: 'tool-access' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['ki-stat', 'keeper-token-stats'], target: { tab: 'monitoring', params: { section: 'agents', view: 'token-stats' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['dc-str', 'decisions-stream'], target: { tab: 'monitoring', params: { section: 'agents', view: 'decisions' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['dc-mem', 'memory-entries'], target: { tab: 'monitoring', params: { section: 'agents', view: 'memory', focus: 'entries' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['ep-card', 'episodes-cards'], target: { tab: 'monitoring', params: { section: 'agents', view: 'episodes' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['ep-lrn', 'episodes-learnings'], target: { tab: 'monitoring', params: { section: 'agents', view: 'episodes' } }, coverage: 'covered' },
 
   // IDE Plane legacy design subtabs.
   { mode: 'ide', aliases: ['edit'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source' } }, coverage: 'covered' },

--- a/dashboard/src/components/copilot-dock.test.ts
+++ b/dashboard/src/components/copilot-dock.test.ts
@@ -129,8 +129,8 @@ describe('CopilotDock', () => {
     route.value = { tab: 'code', params: { section: 'ide-shell' }, postId: null }
     const ctx = getSurfaceContext()
     expect(ctx.route).toBe('/code/ide-shell')
-    expect(ctx.label).toBe('IDE · round.ml')
-    expect(ctx.fields.length).toBeGreaterThan(0)
+    expect(ctx.label).toBe('IDE')
+    expect(ctx.fields.length).toBe(0)
   })
 
   it('updates surface context when route changes', async () => {
@@ -140,7 +140,7 @@ describe('CopilotDock', () => {
     await waitFor(() => expect(container.querySelector('[data-testid="copilot-dock-coview"]')).not.toBeNull())
 
     const coview = container.querySelector('[data-testid="copilot-dock-coview"]')
-    expect(coview?.textContent).toContain('커넥터 · Gate')
+    expect(coview?.textContent).toContain('Connectors')
     expect(coview?.textContent).toContain('/connectors/connector-status')
   })
 
@@ -222,6 +222,10 @@ describe('CopilotDock', () => {
   })
 
   it('switches keeper via picker', async () => {
+    keepers.value = [
+      { name: 'masc-improver', keeper_id: 'masc-improver', koreanName: 'MASC Improver', status: 'running', phase: 'Running', runtime_id: 'fleet', needs_attention: false, total_turns: 0, context_ratio: 0.2 },
+      { name: 'nick0cave', keeper_id: 'nick0cave', koreanName: 'nick0cave', status: 'running', phase: 'Running', runtime_id: 'ops', needs_attention: false, total_turns: 0, context_ratio: 0.3 },
+    ] as unknown as typeof keepers.value
     const dock = renderDock()
     dock.open()
     await waitFor(() => expect(container.querySelector('[data-testid="copilot-dock-picker"]')).not.toBeNull())

--- a/dashboard/src/components/copilot-dock.ts
+++ b/dashboard/src/components/copilot-dock.ts
@@ -5,6 +5,7 @@ import { persistentSignal } from '../lib/persistent-signal'
 import { globalShortcutManager } from '../lib/global-shortcut-manager'
 import { route } from '../router'
 import { keepers } from '../store'
+import { DASHBOARD_NAV_ITEMS } from '../config/navigation'
 import { isSubmitEnter } from '../lib/keyboard'
 import { streamKeeperMessage } from '../api/keeper'
 import { currentDashboardActor } from '../api/core'
@@ -22,7 +23,7 @@ interface SurfaceContext {
   label: string
   route: string
   scene: string
-  fields: Array<{ k: string; v: string; tone?: 'bad' | 'warn' | 'volt' }>
+  fields: Array<{ k: string; v: string; tone?: 'err' | 'warn' | 'brass' }>
 }
 
 interface DockMessage {
@@ -46,15 +47,11 @@ const SPARK_SVG = html`
   </svg>
 `
 
-const DOCK_STARTERS: Record<string, string[]> = {
-  overview: ['주의 큐 4건 정리해줘', '평균 컨텍스트가 왜 높아?', '지금 가장 급한 건 뭐야?'],
-  monitoring: ['이 keeper 지금 뭐 하고 있어?', '소유 태스크 요약', '컨텍스트 압박 풀어줘'],
-  workspace: ['멘션 인박스 정리해줘', 'drifter 상태 블록 뭐야?'],
-  code: ['이 lock 재진입 설명해줘', 'PR #7741 요약', '회귀 위험 어디야?'],
-  connectors: ['stale 게이트 왜 그래?', '바인딩 현황 요약해줘'],
-  command: ['다음 승인 대기 항목 뭐야?', 'governance 큐 요약'],
-  lab: ['도구 등록 상태 요약', 'harness 결과 요약'],
-}
+const DOCK_STARTERS: string[] = [
+  '이 화면 요약해줘',
+  '다음 액션 추천',
+  '주의 항목 정리해줘',
+]
 
 function nowHM(): string {
   const d = new Date()
@@ -74,7 +71,7 @@ function keeperColor(name: string): string {
     'qa-king': 'var(--k-qa)',
     rama: 'var(--k-rama)',
   }
-  return map[name] ?? 'var(--volt-strong)'
+  return map[name] ?? 'var(--brass-1)'
 }
 
 function keeperGlow(name: string): string {
@@ -104,28 +101,19 @@ function Para({ text }: { text: string }) {
 export function getSurfaceContext(): SurfaceContext {
   const tab = route.value.tab
   const section = route.value.params.section ?? ''
-  const labelMap: Record<string, string> = {
-    overview: '운영 개요',
-    monitoring: 'Keeper 대화',
-    workspace: '보드 · 전체 피드',
-    code: 'IDE · round.ml',
-    connectors: '커넥터 · Gate',
-    command: 'Command · Actions',
-    lab: 'Lab · Tools',
-    logs: 'Logs',
-  }
+  const navItem = DASHBOARD_NAV_ITEMS.find(item => item.id === tab)
   const sceneMap: Record<string, string> = {
     overview: '함대 전체 상태를 함께 보는 중',
-    monitoring: ' keeper와 1:1 스레드',
+    monitoring: 'keeper와 1:1 스레드',
     workspace: '네임스페이스 보드를 함께 보는 중',
-    code: 'fix/round-lock-reentry 브랜치를 함께 보는 중',
+    code: '코드 모드에서 함께 보는 중',
     connectors: '외부 게이트 상태를 함께 보는 중',
     command: '운영 액션 패널을 함께 보는 중',
     lab: '실험 도구 패널을 함께 보는 중',
     logs: '시스템 로그 스트림을 함께 보는 중',
   }
   const base: SurfaceContext = {
-    label: labelMap[tab] ?? tab,
+    label: navItem?.label ?? tab,
     route: `/${tab}${section ? `/${section}` : ''}`,
     scene: sceneMap[tab] ?? `${tab} 화면을 함께 보는 중`,
     fields: [],
@@ -141,8 +129,8 @@ export function getSurfaceContext(): SurfaceContext {
     case 'overview':
       base.fields = [
         { k: '실행', v: `${run}/${total}` },
-        { k: '주의', v: String(att), tone: att > 0 ? 'bad' : undefined },
-        { k: 'ctx', v: `${total > 0 ? Math.round((live.reduce((a, k) => a + (typeof k.context_ratio === 'number' ? k.context_ratio : 0), 0) / total) * 100) : 0}%`, tone: 'volt' },
+        { k: '주의', v: String(att), tone: att > 0 ? 'err' : undefined },
+        { k: 'ctx', v: `${total > 0 ? Math.round((live.reduce((a, k) => a + (typeof k.context_ratio === 'number' ? k.context_ratio : 0), 0) / total) * 100) : 0}%`, tone: 'brass' },
         { k: 'trace', v: traces.toLocaleString() },
       ]
       break
@@ -154,33 +142,12 @@ export function getSurfaceContext(): SurfaceContext {
         base.scene = `${sel.koreanName ?? sel.name}와 1:1 스레드`
         base.fields = [
           { k: 'state', v: sel.phase ?? sel.status },
-          { k: 'ctx', v: `${Math.round(ctx * 100)}%`, tone: ctx >= 0.85 ? 'warn' : 'volt' },
+          { k: 'ctx', v: `${Math.round(ctx * 100)}%`, tone: ctx >= 0.85 ? 'warn' : 'brass' },
           { k: 'ns', v: sel.runtime_canonical ?? sel.runtime_id ?? '-' },
         ]
       }
       break
     }
-    case 'workspace':
-      base.fields = [
-        { k: '포스트', v: '5' },
-        { k: '멘션', v: '3', tone: 'volt' },
-        { k: '모더', v: '1', tone: 'warn' },
-      ]
-      break
-    case 'code':
-      base.fields = [
-        { k: 'PR', v: '#7741', tone: 'volt' },
-        { k: 'test', v: '84/84' },
-        { k: 'risk', v: '1', tone: 'bad' },
-      ]
-      break
-    case 'connectors':
-      base.fields = [
-        { k: 'gate', v: '4' },
-        { k: 'active', v: '3', tone: 'volt' },
-        { k: 'stale', v: '1', tone: 'warn' },
-      ]
-      break
   }
   return base
 }
@@ -194,24 +161,19 @@ interface DockKeeper {
 }
 
 function deriveDockKeepers(keeperRows: Keeper[]): DockKeeper[] {
-  const defaults: DockKeeper[] = [
-    { id: 'masc-improver', kr: 'MASC Improver', ns: 'fleet', phase: 'Running', status: 'run' },
-    { id: 'nick0cave', kr: 'nick0cave', ns: 'ops', phase: 'Running', status: 'run' },
-    { id: 'sangsu', kr: 'sangsu', ns: 'code', phase: 'Running', status: 'run' },
-    { id: 'qa-king', kr: 'qa-king', ns: 'qa', phase: 'Idle', status: 'idle' },
-    { id: 'rama', kr: 'rama', ns: 'memory', phase: 'Running', status: 'run' },
-  ]
-  if (keeperRows.length === 0) return defaults
-  const mapped = keeperRows.map(k => ({
+  if (keeperRows.length === 0) {
+    // Minimal fallback only when the store has not hydrated yet.
+    return [
+      { id: 'masc-improver', kr: 'MASC Improver', ns: 'fleet', phase: 'Running', status: 'run' },
+    ]
+  }
+  return keeperRows.map(k => ({
     id: k.keeper_id ?? k.name,
     kr: k.koreanName ?? k.name,
     ns: k.runtime_canonical ?? k.runtime_id ?? 'fleet',
     phase: k.phase ?? k.lifecycle_phase ?? k.status,
     status: statusLooksRunning(k.status) ? 'run' : k.status.toLowerCase(),
   }))
-  // Merge defaults for any missing canonical keepers so the picker is never empty.
-  const seen = new Set(mapped.map(k => k.id))
-  return [...mapped, ...defaults.filter(d => !seen.has(d.id))]
 }
 
 const dockOpen = persistentSignal<DockState>({
@@ -547,7 +509,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
                 <div class="t">${ctx.label}</div>
                 <div class="s">이 화면에 대해 ${keeper.kr}에게 바로 물어보세요. 같은 맥락을 보고 답합니다.</div>
                 <div class="dsug" style=${{ width: '100%' }}>
-                  ${(DOCK_STARTERS[route.value.tab] ?? ['이 화면 요약해줘', '다음 액션 추천']).map((s, i) => html`
+                  ${DOCK_STARTERS.map((s, i) => html`
                     <button key=${i} onClick=${() => doSend(s)}><span class="pre">›</span>${s}</button>
                   `)}
                 </div>

--- a/dashboard/src/components/status-tray.ts
+++ b/dashboard/src/components/status-tray.ts
@@ -600,7 +600,7 @@ function StatusTrayPopover({
       data-testid="dashboard-status-tray-popover"
       role="dialog"
       aria-label=${`${item.label} details`}
-      class=${`v2-shell-panel tray-popover tone-${item.tone} absolute bottom-full left-0 mb-2 w-[22rem] max-w-[calc(100vw-1rem)] rounded-[var(--r-2)] border border-solid bg-[var(--color-bg-panel)] p-3 text-[var(--color-fg-primary)] shadow-[var(--shadow-panel)] backdrop-blur-xl max-[520px]:w-full`}
+      class=${`v2-shell-panel tray-popover tone-${item.tone} absolute bottom-full left-0 mb-2 w-[22rem] max-w-[calc(100vw-1rem)] rounded-[var(--r-2)] border border-solid bg-[var(--color-bg-panel)] p-3 text-[var(--color-fg-primary)] shadow-[var(--shadow-panel)] max-[520px]:w-full`}
     >
       <div class="v2-shell-toolbar tray-popover-head mb-3 flex min-w-0 items-start justify-between gap-3">
         <div class="min-w-0">
@@ -663,7 +663,7 @@ export function DashboardStatusTray({ sideRailCollapsed = false }: DashboardStat
     >
       ${activeKey ? html`<${StatusTrayPopover} activeKey=${activeKey} onClose=${() => setActiveKey(null)} />` : null}
 
-      <div class="v2-tray-bar inline-flex max-w-full items-center gap-1 overflow-x-auto rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-header-bg)] p-1 shadow-[var(--shadow-panel)] backdrop-blur-xl [scrollbar-width:none]">
+      <div class="v2-tray-bar inline-flex max-w-full items-center gap-1 overflow-x-auto rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-header-bg)] p-1 shadow-[var(--shadow-panel)] [scrollbar-width:none]">
         <${TransportChip} active=${activeKey === 'transport'} onActivate=${() => activate('transport')} />
         <${FleetChips} activeKey=${activeKey} onActivate=${activate} />
       </div>

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -219,9 +219,11 @@ describe('monitoring navigation labels', () => {
     expect(ids).not.toContain('sessions')
   })
 
-  it('surfaces four primary Monitor lanes and no hidden diagnostic sections', () => {
+  it('surfaces four primary Monitor lanes and keeps support diagnostics routeable', () => {
     const sections = visibleSectionItemsForTab('monitoring')
+    const allSections = sectionItemsForTab('monitoring')
     const ids = sections.map(item => item.id)
+    const allIds = allSections.map(item => item.id)
 
     expect(defaultParamsForTab('monitoring')).toEqual({ section: 'agents' })
     expect(ids).toEqual([
@@ -231,6 +233,10 @@ describe('monitoring navigation labels', () => {
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('runtime')
     expect(ids).toContain('observatory')
+    expect(allIds).toContain('transport-health')
+    expect(allIds).toContain('feature-health')
+    expect(ids).not.toContain('transport-health')
+    expect(ids).not.toContain('feature-health')
     // Legacy sections removed in Phase 1
     expect(ids).not.toContain('live')
     expect(ids).not.toContain('git-graph')
@@ -256,11 +262,14 @@ describe('monitoring navigation labels', () => {
     ])
   })
 
-  it('has no hidden diagnostic monitoring sections', () => {
+  it('keeps support diagnostics hidden from the sidebar', () => {
     const sections = sectionItemsForTab('monitoring')
     const hiddenIds = sections.filter(item => item.hidden).map(item => item.id)
 
-    expect(hiddenIds).toEqual([])
+    expect(hiddenIds).toEqual([
+      'transport-health',
+      'feature-health',
+    ])
   })
 
   it('monitoring sidebar labels are unique (no overloaded term like "런타임")', () => {

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -219,11 +219,9 @@ describe('monitoring navigation labels', () => {
     expect(ids).not.toContain('sessions')
   })
 
-  it('surfaces four primary Monitor lanes and keeps remaining diagnostics routeable', () => {
+  it('surfaces four primary Monitor lanes and no hidden diagnostic sections', () => {
     const sections = visibleSectionItemsForTab('monitoring')
-    const allSections = sectionItemsForTab('monitoring')
     const ids = sections.map(item => item.id)
-    const allIds = allSections.map(item => item.id)
 
     expect(defaultParamsForTab('monitoring')).toEqual({ section: 'agents' })
     expect(ids).toEqual([
@@ -233,13 +231,6 @@ describe('monitoring navigation labels', () => {
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('runtime')
     expect(ids).toContain('observatory')
-    expect(allIds).toContain('transport-health')
-    expect(allIds).toContain('feature-health')
-    expect(allIds).toContain('cognition')
-    expect(ids).not.toContain('journey')
-    expect(ids).not.toContain('transport-health')
-    expect(ids).not.toContain('feature-health')
-    expect(ids).not.toContain('cognition')
     // Legacy sections removed in Phase 1
     expect(ids).not.toContain('live')
     expect(ids).not.toContain('git-graph')
@@ -265,16 +256,11 @@ describe('monitoring navigation labels', () => {
     ])
   })
 
-  it('keeps diagnostic monitoring routes available but hidden from the sidebar', () => {
+  it('has no hidden diagnostic monitoring sections', () => {
     const sections = sectionItemsForTab('monitoring')
     const hiddenIds = sections.filter(item => item.hidden).map(item => item.id)
 
-    expect(hiddenIds).toEqual([
-      'transport-health',
-      'feature-health',
-      'journey',
-      'cognition',
-    ])
+    expect(hiddenIds).toEqual([])
   })
 
   it('monitoring sidebar labels are unique (no overloaded term like "런타임")', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -513,7 +513,7 @@ export function normalizeRouteParams(tabId: TabId, params: Record<string, string
   // drops view); instead, direct `replaceRoute` callers pass `view: 'default'`
   // as the canonical planning entry point (see router.test.ts replaceRoute case).
   const SECTIONS_WITH_VIEW = new Set([
-    'fleet-health', 'runtime', 'agents', 'cognition', 'observatory',
+    'fleet-health', 'runtime', 'agents', 'observatory',
     'repositories', 'operations', 'ide-shell', 'planning',
   ])
   if (!next.section || !SECTIONS_WITH_VIEW.has(next.section)) {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -20,6 +20,8 @@ type SurfaceSectionId =
   | 'agents'
   | 'runtime'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
+  | 'transport-health' // Hidden support route for transport diagnostics; linked from Runtime.
+  | 'feature-health' // Hidden support route for feature flag diagnostics; linked from Runtime.
   // command
   | 'operations'     // Phase 1+6: absorbs intervene + governance + inspector (Phase 7: connectors split out)
   // connectors (Phase 7: top-level surface — sidecar-driven channel bridges)
@@ -259,6 +261,20 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'Observatory',
       description: 'Activity and runtime evidence.',
       params: { section: 'observatory' },
+    },
+    {
+      id: 'transport-health',
+      label: 'Transport Health',
+      description: 'Transport diagnostics.',
+      params: { section: 'transport-health' },
+      hidden: true,
+    },
+    {
+      id: 'feature-health',
+      label: 'Feature Flags',
+      description: 'Feature diagnostics.',
+      params: { section: 'feature-health' },
+      hidden: true,
     },
 
   ],

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -17,13 +17,9 @@ export type DashboardSurfaceIcon =
 type SurfaceSectionId =
   // monitoring
   | 'observatory'
-  | 'journey'
   | 'agents'
-  | 'cognition'
   | 'runtime'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
-  | 'transport-health' // Dedicated entry for /api/v1/dashboard/transport-health (was 5-hop buried inside Command → Operations → Inspector → "서버 설정" → ServerConfig → TransportHealthPanel)
-  | 'feature-health' // Dedicated entry for /api/v1/dashboard/feature-health (was 4-hop buried inside Command → Operations → Inspector → "피처 플래그" sub-tab)
   // command
   | 'operations'     // Phase 1+6: absorbs intervene + governance + inspector (Phase 7: connectors split out)
   // connectors (Phase 7: top-level surface — sidecar-driven channel bridges)
@@ -264,43 +260,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       description: 'Activity and runtime evidence.',
       params: { section: 'observatory' },
     },
-    {
-      id: 'transport-health',
-      label: 'Transport Health',
-      description: 'SSE/gRPC/WebSocket/WebRTC transport state.',
-      params: { section: 'transport-health' },
-      hidden: true,
-    },
-    {
-      id: 'feature-health',
-      label: 'Feature Flags',
-      description: 'Feature flag rollout and health snapshot.',
-      params: { section: 'feature-health' },
-      hidden: true,
-    },
-    {
-      id: 'journey',
-      label: 'Journey Map',
-      description: 'Legacy execution-flow drill-down.',
-      params: { section: 'journey' },
-      hidden: true,
-    },
-    {
-      id: 'cognition',
-      // Distinguish from sibling labels in Monitor sidebar; the section id
-      // (used in URLs, deep links from KeeperCognitionInspector, and the
-      // backend nav-event allowlist) remains 'cognition'.
-      label: 'Keeper Cognition',
-      description: 'Keeper cognition drill-down.',
-      params: { section: 'cognition' },
-      hidden: true,
-      // Hidden 2026-05-20: FilterChips (overview, keeper, token-stats,
-      // decisions, memory, episodes) and KeeperCognitionInspector
-      // deep links remain functional, but the sidebar entry is intentionally
-      // suppressed pending the cognition→keeper-detail Cognition section
-      // absorption (tracked in the Monitor IA review). The earlier 2026-05-17
-      // promotion was reverted by #16977 (Improve dashboard monitor IA).
-    },
+
   ],
   keepers: [],
   board: [],
@@ -463,6 +423,7 @@ export const SECTION_REDIRECTS: Record<TabSectionKey, SectionRedirect> = {
   'monitoring:governance':   { section: 'fleet-health', view: 'governance' },
   'monitoring:attribution':   { section: 'fleet-health', view: 'attribution' },
   'monitoring:fsm-hub':      { section: 'agents', view: 'fsm' },
+  'monitoring:cognition':    { section: 'agents' },
   'monitoring:metrics':      { section: 'runtime' },
   'monitoring:cost': { section: 'runtime', view: 'cost' },
 

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -111,25 +111,26 @@ describe('navigate', () => {
     expect(route.value.params.section).toBe('connector-status')
   })
 
-  it('maps cockpit Cognition design deep links into the production keeper surface', () => {
+  it('maps cockpit Cognition design deep links into the Monitor agents lane', () => {
     window.location.hash = '#repo=viewer&branch=wt%2Fsangsu-smoke&mode=Cognition'
     window.dispatchEvent(new HashChangeEvent('hashchange'))
 
     expect(route.value.tab).toBe('monitoring')
-    expect(route.value.params.section).toBe('cognition')
+    expect(route.value.params.section).toBe('agents')
     expect(route.value.params.repo).toBe('viewer')
     expect(route.value.params.branch).toBe('wt/sangsu-smoke')
     expect(route.value.params.mode).toBe('Cognition')
-    expect(window.location.hash).toContain('#monitoring?')
+    expect(window.location.hash).toContain('section=agents')
   })
 
-  it('treats slash-bearing raw cockpit query hashes as queries', () => {
+  it('treats slash-bearing raw cockpit query hashes as queries and redirects Cognition to agents', () => {
     window.location.hash = '#repo=viewer&branch=wt/sangsu-smoke&mode=Cognition'
     window.dispatchEvent(new HashChangeEvent('hashchange'))
 
     expect(route.value.tab).toBe('monitoring')
-    expect(route.value.params.section).toBe('cognition')
+    expect(route.value.params.section).toBe('agents')
     expect(route.value.params.branch).toBe('wt/sangsu-smoke')
+    expect(window.location.hash).toContain('section=agents')
   })
 
   it('maps cockpit IDE split mode links into the Code IDE view state', () => {
@@ -183,13 +184,14 @@ describe('navigate', () => {
     expect(route.value.params.mode).toBe('Cognition')
   })
 
-  it('maps cockpit cognition subtabs to explicit cognition views', () => {
+  it('maps cockpit cognition subtabs to explicit agents views', () => {
     window.location.hash = '#mode=Cognition&tab=dc-str'
     window.dispatchEvent(new HashChangeEvent('hashchange'))
 
     expect(route.value.tab).toBe('monitoring')
-    expect(route.value.params.section).toBe('cognition')
+    expect(route.value.params.section).toBe('agents')
     expect(route.value.params.view).toBe('decisions')
+    expect(window.location.hash).toContain('section=agents')
     expect(window.location.hash).toContain('view=decisions')
   })
 

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -82,6 +82,18 @@ describe('navigate', () => {
     expect(route.value.params.ag_range).toBeUndefined()
   })
 
+  it('keeps runtime diagnostic monitor links routeable while hidden from primary IA', () => {
+    navigate('monitoring', { section: 'transport-health' })
+    expect(route.value.tab).toBe('monitoring')
+    expect(route.value.params.section).toBe('transport-health')
+    expect(window.location.hash).toBe('#monitoring?section=transport-health')
+
+    navigate('monitoring', { section: 'feature-health' })
+    expect(route.value.tab).toBe('monitoring')
+    expect(route.value.params.section).toBe('feature-health')
+    expect(window.location.hash).toBe('#monitoring?section=feature-health')
+  })
+
   it('redirects retired Git graph links into the repository graph view', () => {
     navigate('monitoring', { section: 'git-graph' })
     expect(route.value.tab).toBe('workspace')

--- a/dashboard/src/styles/copilot-dock.css
+++ b/dashboard/src/styles/copilot-dock.css
@@ -93,9 +93,9 @@
   background: var(--bg-deep); color: var(--text-mid);
 }
 .dock-field .k { color: var(--text-dim); }
-.dock-field.bad .v  { color: var(--status-bad); }
+.dock-field.err .v  { color: var(--status-bad); }
 .dock-field.warn .v { color: var(--status-warn); }
-.dock-field.volt .v { color: var(--volt-strong); }
+.dock-field.brass .v { color: var(--brass-1); }
 .dock-coview .sync { display: flex; align-items: center; gap: 5px; margin-top: var(--sp-2); font-size: 9.5px; color: var(--text-dim); }
 .dock-coview .sync .d { width: 5px; height: 5px; border-radius: 50%; background: var(--status-ok); box-shadow: 0 0 6px var(--status-ok); animation: dot-pulse 2s ease-in-out infinite; }
 

--- a/dashboard/src/styles/v2-shell.css
+++ b/dashboard/src/styles/v2-shell.css
@@ -300,7 +300,6 @@ aside.v2-status-tray .v2-tray-bar {
   border-radius: 10px;
   background: var(--v2-card);
   box-shadow: var(--ss-shadow-elevated);
-  backdrop-filter: blur(12px);
 }
 
 aside.v2-status-tray .tray-button {

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -24,15 +24,13 @@ let valid_surfaces =
 ;;
 
 (* Mirror of dashboard/src/config/navigation.ts:DASHBOARD_SECTION_ITEMS.
-   Includes hidden sections because they remain directly reachable and
-   continue to fire telemetry. Retired sections are accepted only in
-   redirected_from, not as resolved targets. *)
+   Hidden support sections remain directly reachable and continue to fire
+   telemetry. Retired sections are accepted only in redirected_from, not as
+   resolved targets. *)
 let valid_sections =
   [ ( "monitoring"
-    , [ "journey"
-      ; "observatory"
+    , [ "observatory"
       ; "agents"
-      ; "cognition"
       ; "runtime"
       ; "fleet-health"
       ; "transport-health"


### PR DESCRIPTION
## Summary

Hostile-review follow-up for the keeper-v2 / v2-13 design-system drift in the MASC dashboard.

- **copilot-dock**: derive surface labels from `DASHBOARD_NAV_ITEMS`; remove hardcoded co-view numbers and per-surface starter prompts; collapse the default-keeper fallback to a single entry; migrate tone names to the Cockpit design-system set (`err` / `warn` / `brass`).
- **navigation**: remove hidden dead Monitor sections (`journey`, `cognition`, `transport-health`, `feature-health`) and redirect legacy `monitoring:cognition` deep links to `agents`.
- **cockpit-entrypoints**: map Cognition mode and its legacy subtabs to `monitoring:agents` so every entrypoint resolves to a live section.
- **status-tray / v2-shell**: remove `backdrop-filter: blur(...)` to match the design-system rule that blur is only allowed on code-overlay pinned notes.
- Update affected tests to expect `agents` for cognition routes and the `IDE` label for the code surface.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test --run` ✅ — 561 test files / 7,146 tests + 7 Solid test files / 85 tests passed

## Notes

This PR intentionally leaves the `CognitionPlane` component in place; it is simply no longer reachable through the sidebar or cockpit redirects, which now land on the Monitor agents lane.