### PR TITLE
fix(http-pool): release Piaf client on cancel during body read (#21547)

### DIFF
--- a/lib/masc_http_client/pool.ml
+++ b/lib/masc_http_client/pool.ml
@@ -333,34 +333,59 @@ let do_request t ?headers ?body ~method_ uri : (response, string) result =
   match acquired with
   | Error e -> Error e
   | Ok client ->
+    (* Mirror [do_request_with_idle_timeout]: guarantee the client is released
+       on EVERY exit. [Pool.request] wraps this call in [with_optional_timeout]'s
+       [Eio.Fiber.first]; when the timeout wins it cancels this fiber, and the
+       cancel can land inside [Piaf.Body.to_string] — past the explicit releases
+       below. Without the finally the Piaf client/socket is neither parked nor
+       closed and the FD leaks (#21547). [Eio.Cancel.protect] lets the blocking
+       shutdown complete under cancellation; exceptions are swallowed so the
+       finalizer cannot mask the original via [Fun.Finally_raised] (CLAUDE.md
+       OCaml cleanup rule). *)
+    let released = ref false in
+    let release_once ~close_only =
+      if not !released then begin
+        released := true;
+        release t key client ~close_only
+      end
+    in
     let path = path_and_query uri in
     let body_piaf = Option.map Piaf.Body.of_string body in
-    t.counters.inflight <- t.counters.inflight + 1;
-    let result =
-      try
-        Piaf.Client.request client ?headers ?body:body_piaf
-          ~meth:(method_to_piaf method_) path
-      with exn -> Error (`Msg (Printexc.to_string exn))
-    in
-    t.counters.inflight <- t.counters.inflight - 1;
-    match result with
-    | Error err ->
-      (* Connection is suspect; close, do not park. *)
-      release t key client ~close_only:true;
-      Error (Piaf.Error.to_string (err :> Piaf.Error.t))
-    | Ok resp ->
-      let status = Piaf.Status.to_code (Piaf.Response.status resp) in
-      let headers_list =
-        Piaf.Response.headers resp |> Piaf.Headers.to_list
-      in
-      let body_result = Piaf.Body.to_string (Piaf.Response.body resp) in
-      (match body_result with
-       | Error err ->
-         release t key client ~close_only:true;
-         Error (Piaf.Error.to_string (err :> Piaf.Error.t))
-       | Ok body_str ->
-         release t key client ~close_only:false;
-         Ok { status; headers = headers_list; body = body_str })
+    Fun.protect
+      ~finally:(fun () ->
+        Eio.Cancel.protect (fun () ->
+          if not !released then (try release_once ~close_only:true with _ -> ())))
+      (fun () ->
+        t.counters.inflight <- t.counters.inflight + 1;
+        let result =
+          Fun.protect
+            ~finally:(fun () -> t.counters.inflight <- t.counters.inflight - 1)
+            (fun () ->
+               try
+                 Piaf.Client.request client ?headers ?body:body_piaf
+                   ~meth:(method_to_piaf method_) path
+               with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn -> Error (`Msg (Printexc.to_string exn)))
+        in
+        match result with
+        | Error err ->
+          (* Connection is suspect; close, do not park. *)
+          release_once ~close_only:true;
+          Error (Piaf.Error.to_string (err :> Piaf.Error.t))
+        | Ok resp ->
+          let status = Piaf.Status.to_code (Piaf.Response.status resp) in
+          let headers_list =
+            Piaf.Response.headers resp |> Piaf.Headers.to_list
+          in
+          let body_result = Piaf.Body.to_string (Piaf.Response.body resp) in
+          (match body_result with
+           | Error err ->
+             release_once ~close_only:true;
+             Error (Piaf.Error.to_string (err :> Piaf.Error.t))
+           | Ok body_str ->
+             release_once ~close_only:false;
+             Ok { status; headers = headers_list; body = body_str }))
 
 (* Optional wall-clock timeout race; mirrors masc_http_client pattern. *)
 let with_optional_timeout
@@ -487,8 +512,13 @@ let do_request_with_idle_timeout t
     let start_sec = Eio.Time.now clock in
     Fun.protect
       ~finally:(fun () ->
-        if not !released then
-          release_once ~close_only:true)
+        (* Cancel-safe close. [request_with_idle_timeout]'s outer
+           [total_timeout_sec] [Eio.Fiber.first] can cancel this fiber mid-body;
+           without [Eio.Cancel.protect] the blocking Piaf shutdown would not
+           complete (socket FD leak) and a [Cancelled] raised here would mask the
+           original via [Fun.Finally_raised] (CLAUDE.md OCaml cleanup rule). *)
+        Eio.Cancel.protect (fun () ->
+          if not !released then (try release_once ~close_only:true with _ -> ())))
       (fun () ->
          t.counters.inflight <- t.counters.inflight + 1;
          let result =

--- a/lib/masc_http_client/pool.ml
+++ b/lib/masc_http_client/pool.ml
@@ -312,6 +312,10 @@ let method_to_piaf : http_method -> Piaf.Method.t = function
   | `HEAD   -> `HEAD
   | `PATCH  -> `Other "PATCH"
 
+let close_unreleased_client released release_once =
+  Eio.Cancel.protect (fun () ->
+    if not !released then (try release_once ~close_only:true with _ -> ()))
+
 let path_and_query uri =
   let p = Uri.path uri in
   let p = if p = "" then "/" else p in
@@ -353,8 +357,7 @@ let do_request t ?headers ?body ~method_ uri : (response, string) result =
     let body_piaf = Option.map Piaf.Body.of_string body in
     Fun.protect
       ~finally:(fun () ->
-        Eio.Cancel.protect (fun () ->
-          if not !released then (try release_once ~close_only:true with _ -> ())))
+        close_unreleased_client released release_once)
       (fun () ->
         t.counters.inflight <- t.counters.inflight + 1;
         let result =
@@ -517,8 +520,7 @@ let do_request_with_idle_timeout t
            without [Eio.Cancel.protect] the blocking Piaf shutdown would not
            complete (socket FD leak) and a [Cancelled] raised here would mask the
            original via [Fun.Finally_raised] (CLAUDE.md OCaml cleanup rule). *)
-        Eio.Cancel.protect (fun () ->
-          if not !released then (try release_once ~close_only:true with _ -> ())))
+        close_unreleased_client released release_once)
       (fun () ->
          t.counters.inflight <- t.counters.inflight + 1;
          let result =
@@ -618,5 +620,6 @@ let stats t : stats =
 
 module For_testing = struct
   module Host_key = Host_key
+  let close_unreleased_client = close_unreleased_client
   let read_body_with_idle = read_body_with_idle
 end

--- a/lib/masc_http_client/pool.mli
+++ b/lib/masc_http_client/pool.mli
@@ -196,6 +196,12 @@ module For_testing : sig
     val compare : t -> t -> int
   end
 
+  (** Exposed for cleanup contract tests: close an unreleased client exactly
+      once in a cancel-protected finalizer and swallow release exceptions so
+      [Fun.protect] does not mask the original request/body exception. *)
+  val close_unreleased_client :
+    bool ref -> (close_only:bool -> unit) -> unit
+
   (** Exposed so unit tests can drive idle-timeout logic against a
       mock [Piaf.Body.t] built from [Piaf_stream.create], without
       standing up a real HTTP server. *)

--- a/test/test_pool.ml
+++ b/test/test_pool.ml
@@ -272,6 +272,30 @@ let test_total_timeout_reports_progress_snapshot () =
   | Ok (_, _) ->
     Alcotest.fail "expected total timeout, got Ok"
 
+let test_close_unreleased_client_closes_once () =
+  Eio_main.run @@ fun _env ->
+  let released = ref false in
+  let calls = ref [] in
+  Masc_http_client.Pool.For_testing.close_unreleased_client released (fun ~close_only ->
+    calls := close_only :: !calls;
+    released := true);
+  Masc_http_client.Pool.For_testing.close_unreleased_client released (fun ~close_only ->
+    calls := close_only :: !calls;
+    released := true);
+  Alcotest.(check (list bool)) "close_only called once" [ true ] (List.rev !calls)
+
+let test_close_unreleased_client_swallows_release_error () =
+  Eio_main.run @@ fun _env ->
+  let released = ref false in
+  let calls = ref 0 in
+  Masc_http_client.Pool.For_testing.close_unreleased_client released (fun ~close_only ->
+    Alcotest.(check bool) "finalizer forces close_only" true close_only;
+    incr calls;
+    released := true;
+    failwith "synthetic release failure");
+  Alcotest.(check int) "release attempted once" 1 !calls;
+  Alcotest.(check bool) "marked released before failing" true !released
+
 (* ── Runner ──────────────────────────────────────────────────── *)
 
 let () =
@@ -327,9 +351,16 @@ let () =
             test_idle_steady_stream_completes;
           Alcotest.test_case "silent-from-start cancels" `Quick
             test_idle_silent_from_start_cancels;
-	          Alcotest.test_case "mid-stream silence cancels" `Quick
-	            test_idle_mid_stream_silence_cancels;
-	          Alcotest.test_case "total timeout reports progress snapshot" `Quick
-	            test_total_timeout_reports_progress_snapshot;
-	        ] );
-	    ]
+          Alcotest.test_case "mid-stream silence cancels" `Quick
+            test_idle_mid_stream_silence_cancels;
+          Alcotest.test_case "total timeout reports progress snapshot" `Quick
+            test_total_timeout_reports_progress_snapshot;
+        ] );
+      ( "cancel-safe release finalizer",
+        [
+          Alcotest.test_case "closes unreleased client once" `Quick
+            test_close_unreleased_client_closes_once;
+          Alcotest.test_case "swallows release failure" `Quick
+            test_close_unreleased_client_swallows_release_error;
+        ] );
+    ]


### PR DESCRIPTION
## 목표
Closes #21547. `masc_http_client` `Pool.do_request`가 timeout cancel이 body read 중 떨어질 때 Piaf client/socket을 누수하는 문제를 cancel-safe하게 수정한다.

## 문제
`Pool.request`는 `with_optional_timeout`(`pool.ml:366`)으로 감싸고, 이는 `Eio.Fiber.first`로 timeout 시 `do_request` fiber를 cancel한다. 그런데 `do_request`(325)의 `try/with`(340-343)는 `Piaf.Client.request`만 감싸고 `Piaf.Body.to_string`(356)은 무방호 → cancel이 body read 중 떨어지면 두 `release`(349/359/362)를 전부 건너뛴다. client/socket이 park도 close도 안 됨 → timeout마다 FD 누수. 사용처: `voice_bridge`(`post_sync`), dashboard link-preview/runtime-info.

추가로, finally에서 단순 `release`만으로는 부족하다 — 취소된 fiber의 finally에서 `Piaf.Client.shutdown`(blocking)이 다시 `Cancelled`를 받아 미완료되면 socket이 여전히 누수되고, finally의 예외가 원래 예외를 `Fun.Finally_raised`로 덮는다(CLAUDE.md OCaml cleanup 규칙).

## 변경 (`lib/masc_http_client/pool.ml`)
- `do_request`: acquire→release 전체를 `Fun.protect`로 감싼다(검증된 `do_request_with_idle_timeout` 구조 미러링: `released`/`release_once` + inflight 전용 nested `Fun.protect`). finally는 `Eio.Cancel.protect`로 감싸 blocking shutdown이 취소 컨텍스트에서도 완료되게 하고, 예외를 삼켜 `Fun.Finally_raised` 마스킹을 막는다. `Piaf.Client.request`의 `Cancelled`는 재전파(구조적 동시성).
- `do_request_with_idle_timeout`: 이미 `Fun.protect`는 있었으나 finally가 cancel-safe가 아니었다(`request_with_idle_timeout`의 `total_timeout_sec` `Fiber.first`가 cancel 가능). 동일하게 finally를 `Eio.Cancel.protect`로 감싼다. (N-of-M 회피: 같은 패턴의 두 사이트 모두 수정)

## 로컬 검증
- `dune build --root . @lib/masc_http_client/check` PASS.

## 남은 미검증
- cancel-during-body-read를 결정론적으로 유발하는 단위 테스트 미작성(가짜 stall 서버 필요). FD 카운트 before/after assert가 올바른 형태이나 fixture 부재. follow-up.
- full native build / CI 위임.

## 발견 경위
16-keeper FD 누수 적대 분석(#21546 gRPC LSP, #21548 SSE와 동반).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
