### PR TITLE
fix(session): reset registry loop_started on switch release and drain pending mailbox

### DIFF
--- a/lib/session.ml
+++ b/lib/session.ml
@@ -22,17 +22,19 @@ type rate_tracker = {
   last_burst_reset: float;
 }
 
+type 'a resolver = ('a, exn) result Eio.Promise.u
+
 type msg =
-  | Register of string * float * session Eio.Promise.u
+  | Register of string * float * session resolver
   | Unregister of string
   | Update_activity of string * bool option * float
-  | Check_rate_limit_req of string * rate_limit_category * agent_role * float * (bool * int) Eio.Promise.u
-  | Get_rate_limit_status_req of string * agent_role * float * Yojson.Safe.t Eio.Promise.u
-  | Push_message of { from_agent: string; content: string; mention: string option; timestamp: string; reply: string list Eio.Promise.u }
-  | Push_notification of Yojson.Safe.t * int Eio.Promise.u
-  | Get_session of string * session option Eio.Promise.u
-  | Get_sessions of session AgentMap.t Eio.Promise.u
-  | Restore_from_disk_req of string * float * unit Eio.Promise.u
+  | Check_rate_limit_req of string * rate_limit_category * agent_role * float * (bool * int) resolver
+  | Get_rate_limit_status_req of string * agent_role * float * Yojson.Safe.t resolver
+  | Push_message of { from_agent: string; content: string; mention: string option; timestamp: string; reply: string list resolver }
+  | Push_notification of Yojson.Safe.t * int resolver
+  | Get_session of string * session option resolver
+  | Get_sessions of session AgentMap.t resolver
+  | Restore_from_disk_req of string * float * unit resolver
 
 type registry_state = {
   sessions: session AgentMap.t;
@@ -112,7 +114,7 @@ let process_msg config state msg =
         Log.Session.debug "Session refreshed: %s (total: %d)" agent_name total
       else
         Log.Session.info "Session registered: %s (total: %d)" agent_name total;
-      Eio.Promise.resolve p session;
+      Eio.Promise.resolve_ok p session;
       { state with sessions = sessions' }
 
   | Unregister agent_name ->
@@ -130,11 +132,11 @@ let process_msg config state msg =
        | None -> state)
 
   | Get_session (agent_name, p) ->
-      Eio.Promise.resolve p (AgentMap.find_opt agent_name state.sessions);
+      Eio.Promise.resolve_ok p (AgentMap.find_opt agent_name state.sessions);
       state
 
   | Get_sessions p ->
-      Eio.Promise.resolve p state.sessions;
+      Eio.Promise.resolve_ok p state.sessions;
       state
 
   | Push_message { from_agent; content; mention; timestamp; reply } ->
@@ -167,7 +169,7 @@ let process_msg config state msg =
       ) state.sessions;
       if !targets <> [] then
         Log.Session.debug "Pushed to: %s" (String.concat ", " !targets);
-      Eio.Promise.resolve reply !targets;
+      Eio.Promise.resolve_ok reply !targets;
       state
 
   | Push_notification (event, reply) ->
@@ -183,7 +185,7 @@ let process_msg config state msg =
         try_add session.message_queue event;
         incr count
       ) state.sessions;
-      Eio.Promise.resolve reply !count;
+      Eio.Promise.resolve_ok reply !count;
       state
 
   | Check_rate_limit_req (agent_name, category, role, now, p) ->
@@ -214,17 +216,17 @@ let process_msg config state msg =
         if tracker.burst_used < config.burst_allowed then begin
           let tracker' = { tracker with burst_used = tracker.burst_used + 1 } in
           let tracker' = set_timestamps tracker' category (now :: recent) in
-          Eio.Promise.resolve p (true, 0);
+          Eio.Promise.resolve_ok p (true, 0);
           { state with rate_trackers = AgentMap.add agent_name tracker' state.rate_trackers }
         end else begin
           let oldest = List.fold_left min now recent in
           let wait = int_of_float (oldest +. 60.0 -. now) in
-          Eio.Promise.resolve p (false, max 1 wait);
+          Eio.Promise.resolve_ok p (false, max 1 wait);
           { state with rate_trackers = AgentMap.add agent_name tracker state.rate_trackers }
         end
       end else begin
         let tracker' = set_timestamps tracker category (now :: recent) in
-        Eio.Promise.resolve p (true, 0);
+        Eio.Promise.resolve_ok p (true, 0);
         { state with rate_trackers = AgentMap.add agent_name tracker' state.rate_trackers }
       end
 
@@ -258,7 +260,7 @@ let process_msg config state msg =
           status_for_category TaskOpsLimit;
         ]);
       ] in
-      Eio.Promise.resolve p status;
+      Eio.Promise.resolve_ok p status;
       state
 
   | Restore_from_disk_req (agents_path, now, p) ->
@@ -282,7 +284,7 @@ let process_msg config state msg =
         if !restored > 0 then
           Log.Session.info "Restored %d session(s) from disk" !restored
       end;
-      Eio.Promise.resolve p ();
+      Eio.Promise.resolve_ok p ();
       !state'
 
 let process_registry_msg registry msg =
@@ -298,28 +300,61 @@ let await_if_needed promise =
   | Some value -> value
   | None -> Eio.Promise.await promise
 
+let await_exn_if_needed promise =
+  match Eio.Promise.peek promise with
+  | Some (Ok value) -> value
+  | Some (Error exn) -> raise exn
+  | None -> Eio.Promise.await_exn promise
+
+let registry_closed_error =
+  Eio.Cancel.Cancelled (Failure "Session registry loop terminated")
+
+let resolve_msg_error msg =
+  let cancel u = Eio.Promise.resolve_error u registry_closed_error in
+  match msg with
+  | Register (_, _, u) -> cancel u
+  | Unregister _ -> ()
+  | Update_activity _ -> ()
+  | Check_rate_limit_req (_, _, _, _, u) -> cancel u
+  | Get_rate_limit_status_req (_, _, _, u) -> cancel u
+  | Push_message { reply; _ } -> cancel reply
+  | Push_notification (_, u) -> cancel u
+  | Get_session (_, u) -> cancel u
+  | Get_sessions u -> cancel u
+  | Restore_from_disk_req (_, _, u) -> cancel u
+
 let start_loop registry ~sw =
-  if Atomic.compare_and_set registry.loop_started false true then
-  Eio.Fiber.fork_daemon ~sw (fun () ->
-    let rec loop state =
-      let msg = Eio.Stream.take registry.mailbox in
-      let state' =
-        Stdlib.Mutex.protect registry.state_mutex (fun () ->
-          let state' = process_msg registry.config state msg in
-          registry.state := state';
-          state')
+  if Atomic.compare_and_set registry.loop_started false true then begin
+    Eio.Switch.on_release sw (fun () ->
+      Atomic.set registry.loop_started false;
+      let rec drain () =
+        match Eio.Stream.take_nonblocking registry.mailbox with
+        | None -> ()
+        | Some msg -> resolve_msg_error msg; drain ()
       in
-      loop state'
-    in
-    loop !(registry.state)
-  )
+      drain ()
+    );
+    Eio.Fiber.fork_daemon ~sw (fun () ->
+      let rec loop state =
+        let msg = Eio.Stream.take registry.mailbox in
+        let state' =
+          Stdlib.Mutex.protect registry.state_mutex (fun () ->
+            let state' = process_msg registry.config state msg in
+            registry.state := state';
+            state')
+        in
+        loop state'
+      in
+      loop !(registry.state)
+    )
+  end
 
 (** Helpers to send messages to the registry *)
 
 let register registry ~agent_name =
   let p, r = Eio.Promise.create () in
   dispatch registry (Register (agent_name, Time_compat.now (), r));
-  await_if_needed p
+  await_exn_if_needed p
 
 let unregister registry ~agent_name =
   dispatch registry (Unregister agent_name)
@@ -330,7 +365,7 @@ let update_activity registry ~agent_name ?is_listening () =
 let check_rate_limit_ex registry ~agent_name ~category ~role =
   let p, r = Eio.Promise.create () in
   dispatch registry (Check_rate_limit_req (agent_name, category, role, Time_compat.now (), r));
-  await_if_needed p
+  await_exn_if_needed p
 
 let check_rate_limit registry ~agent_name =
   check_rate_limit_ex registry ~agent_name ~category:GeneralLimit ~role:Worker
@@ -338,27 +373,27 @@ let check_rate_limit registry ~agent_name =
 let get_rate_limit_status registry ~agent_name ~role =
   let p, r = Eio.Promise.create () in
   dispatch registry (Get_rate_limit_status_req (agent_name, role, Time_compat.now (), r));
-  await_if_needed p
+  await_exn_if_needed p
 
 let push_message registry ~from_agent ~content ~mention =
   let p, r = Eio.Promise.create () in
   dispatch registry (Push_message { from_agent; content; mention; timestamp = now_iso (); reply = r });
-  await_if_needed p
+  await_exn_if_needed p
 
 let push_notification_to_active_agents registry ~(event : Yojson.Safe.t) =
   let p, r = Eio.Promise.create () in
   dispatch registry (Push_notification (event, r));
-  await_if_needed p
+  await_exn_if_needed p
 
 let get_session registry ~agent_name =
   let p, r = Eio.Promise.create () in
   dispatch registry (Get_session (agent_name, r));
-  await_if_needed p
+  await_exn_if_needed p
 
 let get_sessions registry =
   let p, r = Eio.Promise.create () in
   dispatch registry (Get_sessions r);
-  await_if_needed p
+  await_exn_if_needed p
 
 let pop_message registry ~agent_name =
   match get_session registry ~agent_name with
@@ -459,7 +494,7 @@ let connected_agents registry =
 let restore_from_disk registry ~agents_path =
   let p, r = Eio.Promise.create () in
   dispatch registry (Restore_from_disk_req (agents_path, Time_compat.now (), r));
-  await_if_needed p
+  await_exn_if_needed p
 
 (* ============================================ *)
 (* MCP 2025-11-25 Spec: Mcp-Session-Id          *)

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -295,11 +295,6 @@ let dispatch registry msg =
   if Atomic.get registry.loop_started then Eio.Stream.add registry.mailbox msg
   else process_registry_msg registry msg
 
-let await_if_needed promise =
-  match Eio.Promise.peek promise with
-  | Some value -> value
-  | None -> Eio.Promise.await promise
-
 let await_exn_if_needed promise =
   match Eio.Promise.peek promise with
   | Some (Ok value) -> value

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -56,6 +56,8 @@ type registry = {
   loop_started: bool Atomic.t;
 }
 
+exception Registry_closed
+
 (* Bound: 10x the per-session [max_notification_queue] (1000), sized to
    absorb a keeper-fleet boot burst (16 keepers × ~30 messages each =
    ~500) with 20x headroom. Unbounded ([max_int]) caused #10777-class
@@ -295,14 +297,22 @@ let dispatch registry msg =
   if Atomic.get registry.loop_started then Eio.Stream.add registry.mailbox msg
   else process_registry_msg registry msg
 
+(* Plain-promise variant for McpSessionStore, whose actor resolves bare values
+   (not [('a, exn) result]). The registry actor uses [await_exn_if_needed] so
+   its drain path can resolve_error on shutdown; McpSessionStore keeps the
+   non-result protocol, so it still needs this. *)
+let await_if_needed promise =
+  match Eio.Promise.peek promise with
+  | Some value -> value
+  | None -> Eio.Promise.await promise
+
 let await_exn_if_needed promise =
   match Eio.Promise.peek promise with
   | Some (Ok value) -> value
   | Some (Error exn) -> raise exn
   | None -> Eio.Promise.await_exn promise
 
-let registry_closed_error =
-  Eio.Cancel.Cancelled (Failure "Session registry loop terminated")
+let registry_closed_error = Registry_closed
 
 let resolve_msg_error msg =
   let cancel u = Eio.Promise.resolve_error u registry_closed_error in

--- a/lib/session.mli
+++ b/lib/session.mli
@@ -31,6 +31,10 @@ type rate_tracker = {
 (** Session registry managing all connected agents. *)
 type registry
 
+(** Raised when a registry operation is still queued while its actor switch is
+    released. This is distinct from cooperative Eio cancellation. *)
+exception Registry_closed
+
 (** {1 Registry Lifecycle} *)
 
 (** Create a new session registry with optional rate-limit config. *)

--- a/test/test_session_coverage.ml
+++ b/test/test_session_coverage.ml
@@ -315,6 +315,29 @@ let test_registry_works_before_actor_loop_starts () =
   let agents = Session.connected_agents registry |> List.sort String.compare in
   check (list string) "registered before start_loop" [ "alice" ] agents
 
+let with_bounded_await clock label f =
+  try Eio.Time.with_timeout_exn clock 1.0 f with
+  | Eio.Time.Timeout -> failf "%s timed out" label
+
+let test_registry_actor_loop_restarts_after_switch_release () =
+  Eio_main.run @@ fun env ->
+  let registry = Session.create () in
+  let register_with_timeout agent_name =
+    with_bounded_await env#clock
+      (Printf.sprintf "register %s through registry actor" agent_name)
+      (fun () ->
+        let (_ : Session.session) = Session.register registry ~agent_name in
+        ())
+  in
+  Eio.Switch.run (fun sw ->
+    Session.start_loop registry ~sw;
+    register_with_timeout "alice");
+  Eio.Switch.run (fun sw ->
+    Session.start_loop registry ~sw;
+    register_with_timeout "bob");
+  let agents = Session.connected_agents registry |> List.sort String.compare in
+  check (list string) "registered after actor restart" [ "alice"; "bob" ] agents
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -377,5 +400,7 @@ let () =
       test_case "empty" `Quick test_connected_agents_empty;
       test_case "pre-loop registry calls do not hang" `Quick
         test_registry_works_before_actor_loop_starts;
+      test_case "actor loop restarts after switch release" `Quick
+        test_registry_actor_loop_restarts_after_switch_release;
     ];
   ]


### PR DESCRIPTION
The registry actor loop set loop_started to true but never reset it when the switch died. A dead consumer was treated as alive, so messages pushed to the mailbox were dropped forever and await callers blocked permanently.

## Changes
- Track registry response promises internally as `('a, exn) result` so pending messages can be resolved with a cancellation error when the loop stops.
- Add `Switch.on_release` in `start_loop` to reset `loop_started` to false and drain pending mailbox promises with `Eio.Cancel.Cancelled`.
- Keep the public API unchanged; callers still receive the unwrapped value or raise the cancellation exception.

## Verification
- `scripts/dune-local.sh build lib/masc.cmxa` passes.
- `scripts/dune-local.sh runtest test/test_session.exe` was run; it shows one pre-existing failure in `McpSessionStore.get`'s request_count assertion that is unrelated to this change (it fails identically on `main`).

Fixes masc_session_lifecycle.