### PR TITLE
fix(keeper): skip board-event collection for paused keepers

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_board_events.ml
+++ b/lib/keeper/keeper_heartbeat_loop_board_events.ml
@@ -1,23 +1,48 @@
 (** Pending board-event collection for the keeper heartbeat loop.
     Extracted from [keeper_heartbeat_loop.ml] (godfile decomp).
 
-    Single helper that, once the proactive-warmup phase has elapsed,
-    queries [Keeper_world_observation.collect_board_events] for the
-    keeper's pending board events and returns them paired with the
+    Single helper that, once the proactive-warmup phase has elapsed and the
+    keeper is not paused, queries [Keeper_world_observation.collect_board_events]
+    for the keeper's pending board events and returns them paired with the
     current meta. Cancellation is re-raised; any other exception is
     logged + counted via the heartbeat-failure Otel_metric_store counter
-    (phase="board_count_query") and treated as zero pending events. *)
+    (phase="board_count_query") and treated as zero pending events.
+
+    Cursor-advance gating: [collect_board_events] advances and acks the
+    per-keeper board cursor as a side effect, so it must only run when the
+    keeper can actually act on the events this cycle. A paused keeper is not
+    scheduled to run a turn (see [keeper_heartbeat_loop] scheduling), so
+    collecting here would advance the cursor past posts the keeper never
+    processed — dropping them with no requeue and no log at the keeper level.
+    We therefore skip collection (returning no events and leaving the cursor
+    untouched) until the keeper is both warmed up and unpaused, so the posts
+    re-surface once the keeper resumes. This extends the existing warmup guard
+    to the paused state. Runtime-backpressure and approval-pending gating are a
+    follow-up: those verdicts are computed later in the scheduling stage, not at
+    this collection site. *)
 
 open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
+
+(* Pure gate: a keeper may consume board events — and thereby advance the
+   per-keeper cursor past them — only once it has warmed up AND is not paused.
+   [collect_board_events] advances + acks the cursor as a side effect, so
+   collecting for a keeper that cannot act this cycle would step the cursor
+   over posts it never processed, dropping them with no requeue. Backpressure
+   and approval-pending verdicts are decided later in scheduling, not here. *)
+let should_collect_board_events ~proactive_warmup_elapsed ~paused =
+  proactive_warmup_elapsed && not paused
+;;
 
 let collect_keepalive_board_events
       ~(ctx : _ context)
       ~(meta_current : keeper_meta)
       ~(proactive_warmup_elapsed : bool)
   =
-  if not proactive_warmup_elapsed
+  if not
+       (should_collect_board_events ~proactive_warmup_elapsed
+          ~paused:meta_current.paused)
   then [], meta_current
   else (
     let pending_board_events =

--- a/lib/keeper/keeper_heartbeat_loop_board_events.mli
+++ b/lib/keeper/keeper_heartbeat_loop_board_events.mli
@@ -1,5 +1,12 @@
 (** Pending board-event collection for the keeper heartbeat loop. *)
 
+val should_collect_board_events :
+  proactive_warmup_elapsed:bool -> paused:bool -> bool
+(** Pure gate deciding whether this cycle may collect board events (which
+    advances the per-keeper cursor as a side effect). True only when the keeper
+    has warmed up and is not paused; a paused keeper must not advance its cursor
+    past posts it cannot act on this cycle. *)
+
 val collect_keepalive_board_events :
   ctx:'a Keeper_types_profile.context ->
   meta_current:Keeper_meta_contract.keeper_meta ->

--- a/test/dune
+++ b/test/dune
@@ -38,6 +38,7 @@
   test_surface_ref
   test_keeper_turn_outcome
   test_keeper_cycle_channel
+  test_board_collect_pause_gate
   test_keeper_identity_id
   test_keeper_idle_threshold_contract
   test_keeper_context_layers
@@ -332,6 +333,7 @@
   test_surface_ref
   test_keeper_turn_outcome
   test_keeper_cycle_channel
+  test_board_collect_pause_gate
   test_keeper_identity_id
   test_keeper_idle_threshold_contract
   test_keeper_context_layers

--- a/test/test_board_collect_pause_gate.ml
+++ b/test/test_board_collect_pause_gate.ml
@@ -1,0 +1,44 @@
+(** Regression: a paused keeper must not collect board events.
+
+    [Keeper_heartbeat_loop_board_events.collect_keepalive_board_events] advances
+    and acks the per-keeper board cursor as a side effect of collection. A
+    paused keeper is not scheduled to run a turn, so collecting (and advancing
+    the cursor) for it would step the cursor past posts it never processed —
+    silently dropping them with no requeue. This pins the pure decision gate
+    [should_collect_board_events] that guards that side effect. *)
+
+open Alcotest
+module BE = Masc.Keeper_heartbeat_loop_board_events
+
+let gate ~warm ~paused =
+  BE.should_collect_board_events ~proactive_warmup_elapsed:warm ~paused
+
+let test_warm_unpaused_collects () =
+  check bool "warmed + unpaused keeper collects board events" true
+    (gate ~warm:true ~paused:false)
+
+(* The regression: before the fix, a warmed keeper collected (and advanced the
+   cursor) regardless of pause state, dropping board posts for paused keepers. *)
+let test_warm_paused_skips () =
+  check bool "warmed + PAUSED keeper must not collect (cursor stays put)" false
+    (gate ~warm:true ~paused:true)
+
+let test_cold_unpaused_skips () =
+  check bool "not-yet-warmed keeper does not collect" false
+    (gate ~warm:false ~paused:false)
+
+let test_cold_paused_skips () =
+  check bool "not-yet-warmed + paused keeper does not collect" false
+    (gate ~warm:false ~paused:true)
+
+let () =
+  run "board_collect_pause_gate"
+    [
+      ( "should_collect_board_events",
+        [
+          test_case "warm + unpaused -> collect" `Quick test_warm_unpaused_collects;
+          test_case "warm + paused -> skip" `Quick test_warm_paused_skips;
+          test_case "cold + unpaused -> skip" `Quick test_cold_unpaused_skips;
+          test_case "cold + paused -> skip" `Quick test_cold_paused_skips;
+        ] );
+    ]


### PR DESCRIPTION
## 목표

paused 키퍼가 board 이벤트를 조용히 유실하는 버그를 고칩니다.

`Keeper_heartbeat_loop_board_events.collect_keepalive_board_events`는 board 이벤트를 수집하면서 **부작용으로 per-keeper board cursor를 advance + ack** 합니다 (`Keeper_world_observation.collect_board_events ~advance_cursor:true`). 기존 가드는 proactive warmup 중에만 수집을 건너뛰었기 때문에, **paused 키퍼**(스케줄러가 턴을 돌리지 않음)도 커서를 전진시켜, 처리하지 않은 board 게시물을 cursor 너머로 넘겨 **requeue 없이 유실**했습니다. 키퍼 레벨 로그도 남지 않습니다.

코드 주석(`keeper_heartbeat_loop.ml`의 warmup 가드)이 이미 "키퍼가 act 못할 때 커서를 전진시키지 말 것"을 명시하지만, warmup 케이스만 구현돼 있었습니다. 이 PR은 그 의도를 **paused 상태로 확장**합니다.

## 접근 (근본 수정, 워크어라운드 아님)

- "이 사이클에 수집/커서 전진을 해도 되는가"라는 결정을 순수 함수 `should_collect_board_events ~proactive_warmup_elapsed ~paused`로 추출 (warmed-up AND not paused).
- side-effect(커서 advance)를 일으키는 I/O 함수에서 결정 로직을 분리 → 결정론적으로 단위 테스트 가능 (boundaries: 순수 결정 vs I/O).
- runtime-backpressure / approval-pending 게이팅은 **follow-up**입니다 — 그 verdict는 collect 이후 scheduling 단계에서 계산되므로, 이 site에서 가용한 `meta.paused`만 surgical하게 처리했습니다.

## 변경 파일

- `lib/keeper/keeper_heartbeat_loop_board_events.ml` — 순수 가드 추출 + 가드를 paused까지 확장 + 근본원인 주석.
- `lib/keeper/keeper_heartbeat_loop_board_events.mli` — `should_collect_board_events` 노출.
- `test/test_board_collect_pause_gate.ml` (신규) — 순수 가드 4케이스 회귀 테스트.
- `test/dune` — 신규 테스트 등록 (기존 중복 names 리스트 대칭 유지를 위해 두 곳 모두).

## 로컬 검증

- `dune build @check` → rc=0 (전체 타입체크).
- `test_board_collect_pause_gate` → 4/4 통과.
- 인접 테스트 무회귀: `test_smart_heartbeat_keepalive` 34/34, `test_board_dispatch` 60/60.
- ocamlformat: 변경한 `.ml/.mli` clean (기존 base-broken `dune` 파일 포맷은 미변경 — surgical 유지).

## 미검증 / 후속

- 전체 테스트 스위트는 CI에 위임.
- write-side board signal 경로(`wakeup_relevant_keeper_for_board_signal`)가 paused 키퍼에게 별도 전달을 보전하는지는 별도 추적 — 이 PR은 cursor-poll 경로의 silent loss만 닫습니다.
- backpressure/approval-pending 커서 게이팅은 scheduling 재배치가 필요한 후속 작업.

근거: 2026-06-19 MASC 턴 생명주기 적대 감사 (`board-reaction` 채널 confirmed-live finding).

RFC-WAIVED: `lib/keeper/keeper_heartbeat_loop_board_events`는 credential/identity/operator-control/sandbox/hooks/workflow RFC 게이트 대상 subsystem이 아님. 동작 보존형 가드 확장이며 워크어라운드 시그니처(telemetry-as-fix / string 분류기 / N-of-M / cap-cooldown-dedup-repair) 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
