### PR TITLE
fix(shutdown): make hook registry atomic to prevent registration races

### DIFF
--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -103,13 +103,19 @@ let is_shutting_down_global () = Atomic.get shutting_down_flag
    making the keeper supervisor's graceful-shutdown branch unreachable. *)
 let mark_shutting_down () = Atomic.set shutting_down_flag true
 
-let hooks : hook list ref = ref []
+let hooks : hook list Atomic.t = Atomic.make []
 
 let register ~name ?(priority = 50) action =
-  hooks := { name; priority; action } :: !hooks
+  let new_hook = { name; priority; action } in
+  let rec loop () =
+    let old = Atomic.get hooks in
+    if not (Atomic.compare_and_set hooks old (new_hook :: old)) then loop ()
+  in
+  loop ()
 
 let sorted_hooks () =
-  List.sort (fun a b -> compare a.priority b.priority) !hooks
+  let snapshot = Atomic.get hooks in
+  List.sort (fun a b -> compare a.priority b.priority) snapshot
 
 let run_registered_hooks () =
   let all_hooks = sorted_hooks () in


### PR DESCRIPTION
## Summary

Convert the global shutdown hook registry from a plain [hook list ref] to a [hook list Atomic.t] to eliminate a race condition in multi-fiber Eio environments.

## Problem

- [register] did [hooks := hook :: !hooks], which is read-modify-write on a non-atomic reference.
- [sorted_hooks] read [!hooks] while another fiber could be mutating the list.
- Concurrent registrations could lose hooks or observe inconsistent state.

## Fix

- [register] now atomically prepends via a CAS retry loop.
- [sorted_hooks] takes an atomic snapshot and sorts by priority as before.

## Verification

- Built: scripts/dune-local.sh build lib/masc.cmxa
- Tested: scripts/dune-local.sh runtest test/test_lifecycle.exe (4 passed, 0 failed)

Fixes: masc_shutdown_hooks_atomic