### PR TITLE
fix(pulse): make shutdown and nudge race-safe

### DIFF
--- a/lib/pulse/pulse.ml
+++ b/lib/pulse/pulse.ml
@@ -69,6 +69,7 @@ type t = {
   mutable consumers : (module Consumer) list;
   (* nudge signaling — Stream is cancellation-safe under Fiber.first *)
   nudge_stream : string Eio.Stream.t;
+  nudge_mutex  : Eio.Mutex.t;           (** protects is_empty + add atomically *)
   (* shutdown signaling — Promise is one-shot and non-blocking *)
   shutdown_p   : unit Eio.Promise.t;
   shutdown_r   : unit Eio.Promise.u;
@@ -207,7 +208,8 @@ let tick t trigger =
    | Bounded pred ->
      if pred beat && not (is_shutdown t) then begin
        Log.Pulse.info "bounded lifecycle condition met at beat #%d" beat.seq;
-       Eio.Promise.resolve t.shutdown_r ()
+       (* fire-and-forget: the bool only reports first-resolver status. *)
+       ignore (Eio.Promise.try_resolve t.shutdown_r () : bool)
      end);
   beat
 
@@ -264,6 +266,7 @@ let create ~clock ~rhythm ~lifecycle ~consumers =
     lifecycle;
     consumers;
     nudge_stream = Eio.Stream.create 1;
+    nudge_mutex  = Eio.Mutex.create ();
     shutdown_p;
     shutdown_r;
     seq         = 0;
@@ -296,15 +299,18 @@ let run ~sw t =
     )
 
 let nudge t ~reason =
-  if t.alive && Eio.Stream.is_empty t.nudge_stream then
-    (* Capacity-1 mailbox: buffer one nudge. If already pending, coalesce
-       (skip the new one — the loop will fire a Nudge beat soon anyway).
-       The is_empty guard avoids blocking on a full stream. *)
-    Eio.Stream.add t.nudge_stream reason
+  Eio.Mutex.use_rw ~protect:true t.nudge_mutex (fun () ->
+    if t.alive && Eio.Stream.is_empty t.nudge_stream then
+      (* Capacity-1 mailbox: buffer one nudge. If already pending, coalesce
+         (skip the new one — the loop will fire a Nudge beat soon anyway).
+         The is_empty guard avoids blocking on a full stream.
+         The mutex makes the empty-check + add atomic so concurrent nudges
+         cannot both see an empty stream and race to fill it. *)
+      Eio.Stream.add t.nudge_stream reason)
 
 let shutdown t =
-  if not (is_shutdown t) then
-    Eio.Promise.resolve t.shutdown_r ()
+  (* fire-and-forget: the bool only reports first-resolver status. *)
+  ignore (Eio.Promise.try_resolve t.shutdown_r () : bool)
 
 let set_rhythm t rhythm =
   t.rhythm <- rhythm;

--- a/test/test_pulse.ml
+++ b/test/test_pulse.ml
@@ -538,6 +538,52 @@ let () = test "get_rhythm returns current rhythm" (fun () ->
   assert (r2.quiet = (2, 5))
 )
 
+(* ── Test: concurrent shutdown does not raise ──────────────── *)
+
+let () = test "concurrent shutdown is safe" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let t = Pulse.create
+    ~clock
+    ~rhythm:{ Pulse.base_s = 10.0; min_s = 5.0; max_s = 20.0; quiet = (1, 6) }
+    ~lifecycle:Pulse.Always_on
+    ~consumers:[]
+  in
+  Eio.Switch.run @@ fun sw ->
+  Pulse.run ~sw t;
+  Eio.Time.sleep clock 0.05;
+  Eio.Fiber.both
+    (fun () -> Pulse.shutdown t)
+    (fun () -> Pulse.shutdown t);
+  Eio.Time.sleep clock 0.1;
+  assert (not (Pulse.is_alive t))
+)
+
+(* ── Test: concurrent nudges do not crash or block ──────────── *)
+
+let () = test "concurrent nudges are safe" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let t = Pulse.create
+    ~clock
+    ~rhythm:{ Pulse.base_s = 100.0; min_s = 50.0; max_s = 200.0; quiet = (1, 6) }
+    ~lifecycle:Pulse.Always_on
+    ~consumers:[]
+  in
+  Eio.Switch.run @@ fun sw ->
+  Pulse.run ~sw t;
+  Eio.Time.sleep clock 0.05;
+  Eio.Fiber.both
+    (fun () -> Pulse.nudge t ~reason:"a")
+    (fun () -> Pulse.nudge t ~reason:"b");
+  Eio.Time.sleep clock 0.15;
+  Pulse.shutdown t;
+  Eio.Time.sleep clock 0.1;
+  let s = Pulse.stats t in
+  if s.total_nudges < 1 then
+    failwith (Printf.sprintf "expected >=1 nudge, got %d" s.total_nudges)
+)
+
 (* ── Summary ───────────────────────────────────────────────── *)
 
 let () =


### PR DESCRIPTION
Fixes `masc_pulse_shutdown_race`.

Changes in `lib/pulse/pulse.ml`:
- Replace non-atomic `Eio.Promise.resolve` with `Eio.Promise.try_resolve` in `shutdown/1` and in the bounded-lifecycle resolution path, so concurrent shutdown calls cannot raise `Invalid_argument` from resolving an already-resolved promise.
- Add an `Eio.Mutex` around the nudge `is_empty` check + `Stream.add` so concurrent nudges do not both observe an empty capacity-1 stream and race to fill it.

Tests in `test/test_pulse.ml`:
- Add a concurrent-shutdown safety test.
- Add a concurrent-nudge safety test.

Verification:
- `scripts/dune-local.sh build lib/masc.cmxa` succeeds.
- `scripts/dune-local.sh runtest test/test_pulse.exe` passes (23/23).