### PR TITLE
fix(keeper): prevent evidence probe host fallback (#20756)

### DIFF
--- a/lib/keeper/keeper_deterministic_evidence_probe.ml
+++ b/lib/keeper/keeper_deterministic_evidence_probe.ml
@@ -1,10 +1,46 @@
 (* RFC-0199 Phase B — see .mli. Adapts the keeper sandbox file system into a
    Deterministic_evidence_evaluator.probe and reuses the (tested) pure
-   evaluator. Only file_bytes is backed by real I/O in v1; the other probe
-   functions return None (Indeterminate) so their claim kinds never
-   auto-complete until wired. *)
+   evaluator. File probes and Shell-IR command probes are backed by real I/O;
+   the forge/custom probe functions return None (Indeterminate) so their claim
+   kinds never auto-complete until wired. *)
 
-let make_probe ~(config : Workspace.config)
+type dispatch_target =
+  { sandbox : Masc_exec.Sandbox_target.t
+  ; base_host_env : string array option
+  }
+
+let local_dispatch_target ~(config : Workspace.config)
+    ~(meta : Keeper_meta_contract.keeper_meta) =
+  match
+    Keeper_secret_projection.local_env_for_keeper
+      ~base_path:config.base_path
+      ~keeper_name:meta.name
+      ()
+  with
+  | Error _ -> None
+  | Ok base_host_env ->
+    Some { sandbox = Masc_exec.Sandbox_target.host (); base_host_env }
+
+let command_dispatch_target
+    ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
+    ~(config : Workspace.config)
+    ~(meta : Keeper_meta_contract.keeper_meta)
+    ~(cwd : string) =
+  match Keeper_sandbox_runner.effective_sandbox_profile ~meta with
+  | Keeper_types_profile_sandbox.Local, _ -> local_dispatch_target ~config ~meta
+  | Keeper_types_profile_sandbox.Docker, _ -> (
+    match
+      Keeper_sandbox_shell_ir_target.docker_target
+        ~turn_sandbox_factory
+        ~meta
+        ~cwd
+    with
+    | Error _ -> None
+    | Ok sandbox -> Some { sandbox; base_host_env = None })
+
+let make_probe
+    ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
+    ~(config : Workspace.config)
     ~(meta : Keeper_meta_contract.keeper_meta) :
     Deterministic_evidence_evaluator.probe =
   let file_bytes raw_path =
@@ -28,20 +64,29 @@ let make_probe ~(config : Workspace.config)
       match Exec_policy.parse_string_to_ir ~mode:Tool_execute cmd with
       | Error _ -> None
       | Ok ir -> (
-        let sandbox = Masc_exec.Sandbox_target.host () in
         match
-          Keeper_tool_execute_shell_ir.dispatch
-            ~keeper_id:meta.name
-            ~base_path:config.base_path
-            ~workdir:cwd
-            ~sandbox
-            ir
+          command_dispatch_target
+            ~turn_sandbox_factory
+            ~config
+            ~meta
+            ~cwd
         with
-        | Error _ -> None
-        | Ok res -> (
-          match res.Masc_exec.Exec_dispatch.status with
-          | Unix.WEXITED code -> Some code
-          | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> None)))
+        | None -> None
+        | Some { sandbox; base_host_env } -> (
+          match
+            Keeper_tool_execute_shell_ir.dispatch
+              ~keeper_id:meta.name
+              ~base_path:config.base_path
+              ~workdir:cwd
+              ~sandbox
+              ?base_host_env
+              ir
+          with
+          | Error _ -> None
+          | Ok res -> (
+            match res.Masc_exec.Exec_dispatch.status with
+            | Unix.WEXITED code -> Some code
+            | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> None))))
   in
   { Deterministic_evidence_evaluator.file_bytes
   ; command_exit
@@ -51,9 +96,11 @@ let make_probe ~(config : Workspace.config)
   }
 
 
-let all_satisfied ~config ~meta claims =
+let all_satisfied ?turn_sandbox_factory ~config ~meta claims =
   match
-    Deterministic_evidence_evaluator.eval_all (make_probe ~config ~meta) claims
+    Deterministic_evidence_evaluator.eval_all
+      (make_probe ~turn_sandbox_factory ~config ~meta)
+      claims
   with
   | Deterministic_evidence_evaluator.Satisfied -> true
   | Deterministic_evidence_evaluator.Unsatisfied _

--- a/lib/keeper/keeper_deterministic_evidence_probe.ml
+++ b/lib/keeper/keeper_deterministic_evidence_probe.ml
@@ -9,6 +9,7 @@ type dispatch_target =
   ; base_host_env : string array option
   }
 
+(* TEL-OK: pure dispatch-target selector (no side-effecting action; probe execution + telemetry live in make_probe/the evaluator). *)
 let local_dispatch_target ~(config : Workspace.config)
     ~(meta : Keeper_meta_contract.keeper_meta) =
   match
@@ -21,6 +22,7 @@ let local_dispatch_target ~(config : Workspace.config)
   | Ok base_host_env ->
     Some { sandbox = Masc_exec.Sandbox_target.host (); base_host_env }
 
+(* TEL-OK: pure dispatch-target selector (no side-effecting action; probe execution + telemetry live in make_probe/the evaluator). *)
 let command_dispatch_target
     ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
     ~(config : Workspace.config)

--- a/lib/keeper/keeper_deterministic_evidence_probe.mli
+++ b/lib/keeper/keeper_deterministic_evidence_probe.mli
@@ -6,13 +6,16 @@
     non-zero fan-in (the Phase A [required_evidence_typed] field was removed
     for fan-in 0; this re-introduction ships with a real consumer).
 
-    v1 supports file-existence claims ([Artifact_exists] / [File_changed]);
-    other claim kinds ([Tests_pass], [PR_merged], [CI_pass], [Custom_check])
-    resolve to [None] -> [Indeterminate] (never auto-complete) until their
-    probes (Shell-IR command runner, forge queries) are wired. *)
+    v1 supports file-existence claims ([Artifact_exists] / [File_changed])
+    and Shell-IR command claims ([Tests_pass]). Docker command claims require
+    the caller's turn-scoped sandbox factory; without one they resolve to
+    [None] -> [Indeterminate] rather than silently falling back to the host.
+    Other claim kinds ([PR_merged], [CI_pass], [Custom_check]) still resolve to
+    [None] -> [Indeterminate] until their probes are wired. *)
 
 val all_satisfied :
-     config:Workspace.config
+     ?turn_sandbox_factory:Keeper_sandbox_factory.t
+  -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> Evidence_claim.t list
   -> bool

--- a/test/dune
+++ b/test/dune
@@ -853,6 +853,7 @@
   test_keeper_recurring
   test_evidence_claim_schema
   test_deterministic_evidence_evaluator
+  test_keeper_deterministic_evidence_probe
   test_verification_fsm
   test_governance_yojson_roundtrip
   test_eval_calibration
@@ -1037,6 +1038,7 @@
   test_keeper_recurring
   test_evidence_claim_schema
   test_deterministic_evidence_evaluator
+  test_keeper_deterministic_evidence_probe
   test_verification_fsm
   test_governance_yojson_roundtrip
   test_eval_calibration

--- a/test/test_keeper_deterministic_evidence_probe.ml
+++ b/test/test_keeper_deterministic_evidence_probe.ml
@@ -1,0 +1,95 @@
+open Alcotest
+
+module Probe = Masc.Keeper_deterministic_evidence_probe
+module Workspace = Masc.Workspace
+module Keeper_registry = Masc.Keeper_registry
+
+let temp_dir () =
+  let d = Filename.temp_file "keeper_evidence_probe_" "" in
+  Unix.unlink d;
+  Unix.mkdir d 0o755;
+  d
+
+let cleanup_dir dir =
+  let rec rm path =
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter (fun n -> rm (Filename.concat path n)) (Sys.readdir path);
+      Unix.rmdir path
+    | _ -> Unix.unlink path
+    | exception Unix.Unix_error _ -> ()
+  in
+  rm dir
+
+let make_meta ?(sandbox = Keeper_types_profile_sandbox.Local) name =
+  let json =
+    `Assoc
+      [ "name", `String name
+      ; "agent_name", `String ("agent-" ^ name)
+      ; "trace_id", `String ("trace-" ^ name)
+      ; "goal", `String "deterministic evidence probe"
+      ; "allowed_paths", `List [ `String "*" ]
+      ; ( "sandbox_profile"
+        , `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) )
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error err -> fail ("make_meta: " ^ err)
+
+let with_eio_runtime f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Process_eio.init
+    ~cwd_default:(Eio.Stdenv.cwd env)
+    ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    ~clock:(Eio.Stdenv.clock env);
+  f ()
+
+let with_fixture ?sandbox f =
+  with_eio_runtime @@ fun () ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+      Keeper_registry.clear ();
+      let config = Workspace.default_config base_path in
+      let meta = make_meta ?sandbox "probe-keeper" in
+      ignore (Keeper_registry.register ~base_path meta.name meta);
+      f ~config ~meta)
+
+let tests_pass command =
+  Evidence_claim.Tests_pass { command; expected_exit = 0 }
+
+let test_local_tests_pass_runs_in_local_target () =
+  with_fixture @@ fun ~config ~meta ->
+  check bool
+    "local command evidence satisfied"
+    true
+    (Probe.all_satisfied ~config ~meta [ tests_pass "true" ])
+
+let test_docker_without_factory_does_not_fall_back_to_host () =
+  with_fixture ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ->
+  check bool
+    "docker command evidence without factory stays indeterminate"
+    false
+    (Probe.all_satisfied ~config ~meta [ tests_pass "true" ])
+
+let () =
+  run
+    "keeper_deterministic_evidence_probe"
+    [ ( "command evidence sandbox"
+      , [ test_case
+            "local Tests_pass command runs"
+            `Quick
+            test_local_tests_pass_runs_in_local_target
+        ; test_case
+            "docker Tests_pass without factory does not host fallback"
+            `Quick
+            test_docker_without_factory_does_not_fall_back_to_host
+        ] )
+    ]


### PR DESCRIPTION
## Goal
Closes #20756.

Prevent the deterministic evidence `command_exit` probe from silently running Docker-profile keeper evidence commands on the host. That host fallback could mark a task Done from the wrong execution environment.

## Changes
- Route `Tests_pass` command evidence through the keeper's effective sandbox profile.
- Local profile: reuse the existing keeper secret/env projection and host target.
- Docker profile: use `Keeper_sandbox_shell_ir_target.docker_target`; if no turn sandbox factory/target is available, return `None` so the evaluator stays `Indeterminate` instead of host-running the command.
- Add regression coverage:
  - Local `Tests_pass { command = "true" }` can satisfy evidence.
  - Docker `Tests_pass { command = "true" }` without a factory does not fall back to host.

## Verification
- `ocamlformat --check ...` PASS.
- `git diff --check` PASS.
- Changed-code path/env audit PASS: no `/Users/dancer/me`, `default_base`, `MASC_BASE_PATH`, `Sys.getenv*`, `Unix.getenv`, or `docker_local_fallback_target` in the changed evidence probe/test files.

## Not Run
- Focused target compile: `scripts/dune-local.sh build test/test_keeper_deterministic_evidence_probe.exe` was blocked by an unrelated live bare Dune process:
  - `58378 dune build --root . @install`
- I did not bypass the local build guard or kill that process.

## Scope Note
This PR closes the unsafe false-Done path. It does not yet wire a production turn-scoped sandbox factory into task-claim deterministic evidence, so Docker command evidence without a factory remains `Indeterminate` rather than executing on host.
