### PR TITLE
fix(runtime_params): auto-persist and audit set/clear

### DIFF
--- a/lib/runtime_params.ml
+++ b/lib/runtime_params.ml
@@ -52,12 +52,21 @@ type 'a param = 'a param_entry
     Protected by [mu]. *)
 let registry_tbl : (string, erased) Hashtbl.t = Hashtbl.create 64
 
+(** Workspace base path used for automatic persistence and audit.
+    Set via [initialize]; optional [?base_path] overrides it per call. *)
+let global_base_path : string option ref = ref None
+
 (** Eio.Mutex for all mutable state.
     Falls back to lock-free when Eio scheduler is absent (tests, init). *)
 let mu = Eio.Mutex.create ()
 
 let with_rw f = Eio_guard.with_mutex mu f
 let with_ro f = Eio_guard.with_mutex_ro mu f
+
+let initialize ~base_path = global_base_path := Some base_path
+
+let effective_base_path ?base_path () =
+  match base_path with Some p -> Some p | None -> !global_base_path
 
 (* ── registration ────────────────────────────────────────────── *)
 
@@ -94,44 +103,6 @@ let register ~key ~default ~validate ~serialize ~deserialize ?meta () =
       invalid_arg (sprintf "Runtime_params: duplicate key %S" key);
     Hashtbl.replace registry_tbl key erased);
   entry
-
-(* ── read / write ────────────────────────────────────────────── *)
-
-let get (entry : 'a param) =
-  with_ro (fun () ->
-    match entry.override with Some v -> v | None -> entry.default ())
-
-let set (entry : 'a param) value =
-  with_rw (fun () ->
-    match entry.validate value with
-    | Error msg -> Error (sprintf "validation failed for %s: %s" entry.key msg)
-    | Ok () ->
-        entry.override <- Some value;
-        Ok ())
-
-let set_by_key key json =
-  with_rw (fun () ->
-    match Hashtbl.find_opt registry_tbl key with
-    | None -> Error (sprintf "unknown parameter: %s" key)
-    | Some erased -> erased.set_from_json json)
-
-let clear (entry : 'a param) =
-  with_rw (fun () -> entry.override <- None)
-
-let clear_by_key key =
-  with_rw (fun () ->
-    match Hashtbl.find_opt registry_tbl key with
-    | None -> Error (sprintf "unknown parameter: %s" key)
-    | Some erased -> erased.clear_override (); Ok ())
-
-let registry () =
-  with_ro (fun () ->
-    Hashtbl.fold
-      (fun _key (erased : erased) acc ->
-        (erased.key, erased.current_json (), erased.default_json (),
-         erased.has_override (), erased.meta) :: acc)
-      registry_tbl [])
-  |> List.sort (fun (a, _, _, _, _) (b, _, _, _, _) -> String.compare a b)
 
 (* ── persistence ─────────────────────────────────────────────── *)
 
@@ -219,3 +190,96 @@ let recent_audit ~base_path n =
   if len <= n then List.rev all
   else
     all |> List.to_seq |> Seq.drop (len - n) |> List.of_seq |> List.rev
+
+(* ── read / write ────────────────────────────────────────────── *)
+
+let get (entry : 'a param) =
+  with_ro (fun () ->
+    match entry.override with Some v -> v | None -> entry.default ())
+
+let set ?base_path ?(actor = "system") (entry : 'a param) value =
+  let result =
+    with_rw (fun () ->
+      match entry.validate value with
+      | Error msg -> Error (sprintf "validation failed for %s: %s" entry.key msg)
+      | Ok () ->
+          let old_value =
+            entry.serialize (match entry.override with Some v -> v | None -> entry.default ())
+          in
+          entry.override <- Some value;
+          Ok (entry.key, old_value, entry.serialize value))
+  in
+  match result with
+  | Error _ as e -> e
+  | Ok (key, old_value, new_value) ->
+      (match effective_base_path ?base_path () with
+      | None -> ()
+      | Some base_path ->
+          persist ~base_path;
+          record_audit ~base_path ~key ~old_value ~new_value ~actor ());
+      Ok ()
+
+let set_by_key ?base_path ?(actor = "system") key json =
+  let result =
+    with_rw (fun () ->
+      match Hashtbl.find_opt registry_tbl key with
+      | None -> Error (sprintf "unknown parameter: %s" key)
+      | Some erased ->
+          let old_value = erased.current_json () in
+          match erased.set_from_json json with
+          | Error _ as e -> e
+          | Ok () -> Ok (erased.current_json (), old_value))
+  in
+  match result with
+  | Error _ as e -> e
+  | Ok (new_value, old_value) ->
+      (match effective_base_path ?base_path () with
+      | None -> ()
+      | Some base_path ->
+          persist ~base_path;
+          record_audit ~base_path ~key ~old_value ~new_value ~actor ());
+      Ok ()
+
+let clear ?base_path ?(actor = "system") (entry : 'a param) =
+  let key, old_value, new_value =
+    with_rw (fun () ->
+      let old_value =
+        entry.serialize (match entry.override with Some v -> v | None -> entry.default ())
+      in
+      entry.override <- None;
+      (entry.key, old_value, entry.serialize (entry.default ())))
+  in
+  match effective_base_path ?base_path () with
+  | None -> ()
+  | Some base_path ->
+      persist ~base_path;
+      record_audit ~base_path ~key ~old_value ~new_value ~actor ()
+
+let clear_by_key ?base_path ?(actor = "system") key =
+  let result =
+    with_rw (fun () ->
+      match Hashtbl.find_opt registry_tbl key with
+      | None -> Error (sprintf "unknown parameter: %s" key)
+      | Some erased ->
+          let old_value = erased.current_json () in
+          erased.clear_override ();
+          Ok (erased.default_json (), old_value))
+  in
+  match result with
+  | Error _ as e -> e
+  | Ok (new_value, old_value) ->
+      (match effective_base_path ?base_path () with
+      | None -> ()
+      | Some base_path ->
+          persist ~base_path;
+          record_audit ~base_path ~key ~old_value ~new_value ~actor ());
+      Ok ()
+
+let registry () =
+  with_ro (fun () ->
+    Hashtbl.fold
+      (fun _key (erased : erased) acc ->
+        (erased.key, erased.current_json (), erased.default_json (),
+         erased.has_override (), erased.meta) :: acc)
+      registry_tbl [])
+  |> List.sort (fun (a, _, _, _, _) (b, _, _, _, _) -> String.compare a b)

--- a/lib/runtime_params.mli
+++ b/lib/runtime_params.mli
@@ -23,6 +23,13 @@ type param_meta = {
 (** Opaque typed parameter handle.  Obtained from {!register}. *)
 type 'a param
 
+(** {1 Initialization} *)
+
+(** Set the workspace base path used for automatic persistence and audit.
+    Call once during server bootstrap before the first [set]/[clear].
+    Per-call [?base_path] overrides this value. *)
+val initialize : base_path:string -> unit
+
 (** {1 Registration} *)
 
 (** Register a named parameter with default thunk, validation, and serialization.
@@ -44,17 +51,22 @@ val register :
 (** Get current value.  Returns the override if set, otherwise the default. *)
 val get : 'a param -> 'a
 
-(** Set override.  Runs validation; persists on success. *)
-val set : 'a param -> 'a -> (unit, string) result
+(** Set override.  Runs validation; persists and audits on success when a
+    base path is available via [initialize] or [?base_path]. *)
+val set : ?base_path:string -> ?actor:string -> 'a param -> 'a -> (unit, string) result
 
-(** Set override by string key and JSON value (for MCP / governance). *)
-val set_by_key : string -> Yojson.Safe.t -> (unit, string) result
+(** Set override by string key and JSON value (for MCP / governance).
+    Persists and audits on success when a base path is available. *)
+val set_by_key :
+  ?base_path:string -> ?actor:string -> string -> Yojson.Safe.t -> (unit, string) result
 
-(** Clear override; reverts to env default. *)
-val clear : 'a param -> unit
+(** Clear override; reverts to env default.  Persists and audits the
+    reversion when a base path is available. *)
+val clear : ?base_path:string -> ?actor:string -> 'a param -> unit
 
-(** Clear override by string key. Returns [Error] if key is unknown. *)
-val clear_by_key : string -> (unit, string) result
+(** Clear override by string key. Returns [Error] if key is unknown.
+    Persists and audits the reversion when a base path is available. *)
+val clear_by_key : ?base_path:string -> ?actor:string -> string -> (unit, string) result
 
 (** {1 Introspection} *)
 

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -785,7 +785,7 @@ let add_routes ~sw ~clock router =
                       | Some (_, current, _, _, _) -> current
                       | None -> `Null
                     in
-                    (match Runtime_params.set_by_key param_key value with
+                    (match Runtime_params.set_by_key param_key value ~actor with
                      | Error msg ->
                          respond_json_value_with_cors ~status:`Bad_request request reqd
                            (`Assoc
@@ -794,9 +794,6 @@ let add_routes ~sw ~clock router =
                                 ("error", `String msg);
                               ])
                      | Ok () ->
-                         Runtime_params.persist ~base_path;
-                         Runtime_params.record_audit ~base_path
-                           ~key:param_key ~old_value ~new_value:value ~actor ();
                          Sse.broadcast
                            (`Assoc
                               [
@@ -854,7 +851,7 @@ let add_routes ~sw ~clock router =
                      | Some (_, current, _, _, _) -> current
                      | None -> `Null
                    in
-                   match Runtime_params.clear_by_key param_key with
+                   match Runtime_params.clear_by_key param_key ~actor with
                    | Error msg ->
                        respond_json_value_with_cors ~status:`Bad_request request reqd
                          (`Assoc
@@ -869,9 +866,6 @@ let add_routes ~sw ~clock router =
                          | Some (_, _, default, _, _) -> default
                          | None -> `Null
                        in
-                       Runtime_params.persist ~base_path;
-                       Runtime_params.record_audit ~base_path
-                         ~key:param_key ~old_value ~new_value ~actor ();
                        Sse.broadcast
                          (`Assoc
                             [

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -138,6 +138,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
     | raw -> Some raw
   in
   let base_path = Env_config_core.normalize_masc_base_path_input base_path in
+  Runtime_params.initialize ~base_path;
   Fs_compat.set_fs fs;
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -189,6 +189,92 @@ let () =
      with Sys_error _ -> ())
   in
 
+  let test_set_persists_to_disk () =
+    let tmp_dir = Filename.temp_dir "masc_auto_persist_" "" in
+    let masc_dir = Filename.concat tmp_dir Common.masc_dirname in
+    (try Sys.mkdir masc_dir 0o755 with Sys_error _ -> ());
+    let p =
+      Runtime_params.register
+        ~key:"test.auto_persist_param"
+        ~default:(fun () -> 1)
+        ~validate:(fun _ -> Ok ())
+        ~serialize:(fun v -> `Int v)
+        ~deserialize:(fun json ->
+          match json with
+          | `Int i -> Ok i
+          | _ -> Error "expected int")
+        ()
+    in
+    (match Runtime_params.set p 42 ~base_path:tmp_dir with
+     | Ok () -> ()
+     | Error msg -> Alcotest.fail msg);
+    let path = Filename.concat masc_dir "runtime_params.json" in
+    Alcotest.(check bool) "runtime_params.json exists" true (Sys.file_exists path);
+    let content = Fs_compat.load_file path in
+    (match Yojson.Safe.from_string content with
+    | `Assoc pairs ->
+        (match List.assoc_opt "test.auto_persist_param" pairs with
+         | Some (`Int 42) -> ()
+         | Some other ->
+             Alcotest.fail
+               (Printf.sprintf "expected int 42, got %s" (Yojson.Safe.to_string other))
+         | None -> Alcotest.fail "param not found in persisted file")
+    | _ -> Alcotest.fail "expected JSON object");
+    (* Clear should remove the override from disk *)
+    Runtime_params.clear p ~base_path:tmp_dir;
+    let content_after_clear = Fs_compat.load_file path in
+    (match Yojson.Safe.from_string content_after_clear with
+    | `Assoc pairs ->
+        Alcotest.(check bool) "param removed from disk after clear"
+          true (List.assoc_opt "test.auto_persist_param" pairs = None)
+    | _ -> Alcotest.fail "expected JSON object after clear");
+    (try
+       Sys.remove path;
+       Sys.rmdir masc_dir;
+       Sys.rmdir tmp_dir
+     with Sys_error _ -> ())
+  in
+
+  let test_set_by_key_logs_audit () =
+    let tmp_dir = Filename.temp_dir "masc_auto_audit_" "" in
+    let masc_dir = Filename.concat tmp_dir Common.masc_dirname in
+    (try Sys.mkdir masc_dir 0o755 with Sys_error _ -> ());
+    let _p =
+      Runtime_params.register
+        ~key:"test.auto_audit_param"
+        ~default:(fun () -> "hello")
+        ~validate:(fun _ -> Ok ())
+        ~serialize:(fun v -> `String v)
+        ~deserialize:(fun json ->
+          match json with
+          | `String s -> Ok s
+          | _ -> Error "expected string")
+        ()
+    in
+    (match
+       Runtime_params.set_by_key "test.auto_audit_param" (`String "world")
+         ~base_path:tmp_dir ~actor:"test-actor"
+     with
+     | Ok () -> ()
+     | Error msg -> Alcotest.fail msg);
+    let audit_path = Filename.concat masc_dir "param_audit.jsonl" in
+    Alcotest.(check bool) "audit file exists" true (Sys.file_exists audit_path);
+    let entries = Runtime_params.recent_audit ~base_path:tmp_dir 10 in
+    Alcotest.(check int) "audit entry count" 1 (List.length entries);
+    let entry = List.hd entries in
+    let open Yojson.Safe.Util in
+    Alcotest.(check string) "audit key" "test.auto_audit_param"
+      (member "key" entry |> to_string);
+    Alcotest.(check string) "audit actor" "test-actor"
+      (member "actor" entry |> to_string);
+    (try
+       Sys.remove audit_path;
+       Sys.remove (Filename.concat masc_dir "runtime_params.json");
+       Sys.rmdir masc_dir;
+       Sys.rmdir tmp_dir
+     with Sys_error _ -> ())
+  in
+
   let test_governance_registry () =
     (* Verify that governance_registry registered params *)
     let entries = Runtime_params.registry () in
@@ -442,6 +528,9 @@ let () =
         [
           Alcotest.test_case "persist_restore" `Quick test_persist_restore;
           Alcotest.test_case "audit" `Quick test_audit;
+          Alcotest.test_case "set_persists_to_disk" `Quick test_set_persists_to_disk;
+          Alcotest.test_case "set_by_key_logs_audit" `Quick
+            test_set_by_key_logs_audit;
         ] );
       ( "governance_registry",
         [


### PR DESCRIPTION
## Problem

The [runtime_params.mli] documents that [set]/[set_by_key] persist to [.masc/runtime_params.json] and log to [.masc/param_audit.jsonl] after each successful call. The implementation did neither; [clear] also only cleared memory, so the next [restore] re-read stale overrides from disk.

## Fix

- Add [Runtime_params.initialize] to store the workspace [base_path].
- Make [set]/[set_by_key]/[clear]/[clear_by_key] persist and audit automatically when a base path is available via [initialize] or the optional [?base_path] argument.
- [clear]/[clear_by_key] now rewrite the persisted file so the override is removed from disk.
- Preserve backward-compatible public API via optional [?base_path]/[?actor] arguments.
- Call [Runtime_params.initialize] during server bootstrap and remove redundant explicit [persist]/[record_audit] calls from the governance HTTP routes.
- Add tests verifying automatic persistence on [set] and automatic audit on [set_by_key].

## Verification

- [x] [scripts/dune-local.sh build lib/masc.cmxa]
- [x] [scripts/dune-local.sh build bin/main_eio.exe]
- [x] [scripts/dune-local.sh runtest test/test_runtime_params.exe]
- [x] [scripts/dune-local.sh runtest test/test_dashboard_labels.exe]
- [x] [scripts/dune-local.sh runtest test/test_keeper_supervisor.exe]