### PR TITLE
fix(librarian): default memory-os librarian timeout to 600 seconds

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -2,6 +2,12 @@
 
 let librarian_max_tokens = 1024
 
+(* Memory extraction runs against a JSON-capable model with a long context
+   window and is not constrained by the generic inference API budget (30s).
+   600s aligns with the keeper turn budget so that provider cold starts or
+   model loading do not silently drop episodes. *)
+let librarian_default_timeout_sec = 600.0
+
 type complete_fn =
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
@@ -187,7 +193,7 @@ let prompt_max_messages () = max_messages () * cadence_turns ()
 let default_timeout_sec () =
   Keeper_memory_bank_env.memory_env_float_logged
     "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC"
-    ~default:600.0
+    ~default:librarian_default_timeout_sec
 ;;
 
 let runtime_id_for_librarian ~runtime_id =
@@ -346,7 +352,7 @@ let with_timeout ?clock ~timeout_sec f =
 let extract_with_provider
     ?(complete = default_complete)
     ?clock
-    ?(timeout_sec = Env_config_governance.Inference.timeout_seconds)
+    ?(timeout_sec = librarian_default_timeout_sec)
     ~sw
     ~net
     ~provider_cfg

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -187,7 +187,7 @@ let prompt_max_messages () = max_messages () * cadence_turns ()
 let default_timeout_sec () =
   Keeper_memory_bank_env.memory_env_float_logged
     "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC"
-    ~default:Env_config_governance.Inference.timeout_seconds
+    ~default:600.0
 ;;
 
 let runtime_id_for_librarian ~runtime_id =


### PR DESCRIPTION
Raises the default librarian extraction timeout from the generic inference fallback (30 s) to 600 s. The memory-os librarian is routed to `ollama_cloud.minimax-m3` for JSON-mode extraction; provider cold starts and model loading frequently exceed 30 s, causing repeated "librarian provider timed out" warnings.

- Env var `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` still overrides the default.
- Build verified: `scripts/dune-local.sh build lib/masc.cmxa`.

Closes the recurring timeout WARN reported in live logs.