### PR TITLE
feat(dashboard): surface runtime assignment governance

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1825,6 +1825,26 @@ describe('fetchRuntimeProviders', () => {
             },
           },
         ],
+        assignment_governance: {
+          schema: 'masc.runtime_assignment_governance.v1',
+          source: 'runtime.toml',
+          status: 'degraded',
+          degraded: true,
+          operator_action_required: true,
+          blast_radius: 'single_runtime_assignment_pin',
+          assignment_count: 2,
+          assigned_keeper_count: 2,
+          assigned_runtime_count: 1,
+          default_assignment_count: 0,
+          default_runtime_id: 'runpod_mtp.qwen',
+          librarian_runtime_id: 'ollama_cloud.minimax-m3',
+          warnings: ['explicit_assignments_present', 'single_runtime_assignment_pin'],
+          assigned_runtimes: ['openai.gpt'],
+          assignments: [
+            { keeper: 'budgettest', runtime_id: 'openai.gpt', matches_default: false },
+            { keeper: 'routingtest', runtime_id: 'openai.gpt', matches_default: false },
+          ],
+        },
         config_path: '/Users/dancer/me/.masc/runtime.toml',
       }), {
         status: 200,
@@ -1844,6 +1864,10 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.kind).toBe('cloud')
     expect(result.providers[0]?.runtime_kind).toBe('http')
     expect(result.providers[0]?.discovery?.ctx_size).toBe(200000)
+    expect(result.assignment_governance?.status).toBe('degraded')
+    expect(result.assignment_governance?.assignment_count).toBe(2)
+    expect(result.assignment_governance?.assigned_runtimes).toEqual(['openai.gpt'])
+    expect(result.assignment_governance?.assignments[0]?.keeper).toBe('budgettest')
   })
 })
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1833,7 +1833,6 @@ describe('fetchRuntimeProviders', () => {
           operator_action_required: true,
           blast_radius: 'single_runtime_assignment_pin',
           assignment_count: 2,
-          assigned_keeper_count: 2,
           assigned_runtime_count: 1,
           default_assignment_count: 0,
           default_runtime_id: 'runpod_mtp.qwen',
@@ -1845,7 +1844,7 @@ describe('fetchRuntimeProviders', () => {
             { keeper: 'routingtest', runtime_id: 'openai.gpt', matches_default: false },
           ],
         },
-        config_path: '/Users/dancer/me/.masc/runtime.toml',
+        config_path: '/tmp/masc-test/runtime.toml',
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1856,7 +1855,7 @@ describe('fetchRuntimeProviders', () => {
     const result = await fetchRuntimeProviders()
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/providers')
-    expect(result.config_path).toBe('/Users/dancer/me/.masc/runtime.toml')
+    expect(result.config_path).toBe('/tmp/masc-test/runtime.toml')
     expect(result.summary?.default_runtime_id).toBe('runpod_mtp.qwen')
     expect(result.providers[0]?.provider).toBe('runpod_mtp.qwen')
     expect(result.providers[0]?.provider_id).toBe('runpod_mtp')

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -598,7 +598,6 @@ export interface DashboardRuntimeAssignmentGovernance {
   operator_action_required: boolean
   blast_radius?: string | null
   assignment_count: number
-  assigned_keeper_count: number
   assigned_runtime_count: number
   default_assignment_count: number
   default_runtime_id?: string | null
@@ -797,7 +796,6 @@ function decodeRuntimeAssignmentGovernance(raw: unknown): DashboardRuntimeAssign
     operator_action_required: asBoolean(raw.operator_action_required) ?? false,
     blast_radius: asNullableString(raw.blast_radius),
     assignment_count: asNumber(raw.assignment_count) ?? 0,
-    assigned_keeper_count: asNumber(raw.assigned_keeper_count) ?? 0,
     assigned_runtime_count: asNumber(raw.assigned_runtime_count) ?? 0,
     default_assignment_count: asNumber(raw.default_assignment_count) ?? 0,
     default_runtime_id: asNullableString(raw.default_runtime_id),

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -584,6 +584,30 @@ export interface DashboardRuntimeProviderSnapshot {
   discovery?: DashboardRuntimeProviderDiscovery | null
 }
 
+export interface DashboardRuntimeAssignment {
+  keeper: string
+  runtime_id: string
+  matches_default?: boolean
+}
+
+export interface DashboardRuntimeAssignmentGovernance {
+  schema?: string | null
+  source?: string | null
+  status?: string | null
+  degraded: boolean
+  operator_action_required: boolean
+  blast_radius?: string | null
+  assignment_count: number
+  assigned_keeper_count: number
+  assigned_runtime_count: number
+  default_assignment_count: number
+  default_runtime_id?: string | null
+  librarian_runtime_id?: string | null
+  warnings: string[]
+  assigned_runtimes: string[]
+  assignments: DashboardRuntimeAssignment[]
+}
+
 export interface DashboardRuntimeProvidersResponse {
   updated_at?: string
   summary?: {
@@ -595,6 +619,7 @@ export interface DashboardRuntimeProvidersResponse {
     default_runtime_id?: string | null
   } | null
   providers: DashboardRuntimeProviderSnapshot[]
+  assignment_governance?: DashboardRuntimeAssignmentGovernance | null
   // Resolved filesystem path of the runtime.toml the server actually loaded
   // (Runtime.config_path); answers "which config is live" in the monitor.
   config_path?: string | null
@@ -750,6 +775,41 @@ function decodeRuntimeProviderSnapshot(raw: unknown): DashboardRuntimeProviderSn
   }
 }
 
+function decodeRuntimeAssignment(raw: unknown): DashboardRuntimeAssignment | null {
+  if (!isRecord(raw)) return null
+  const keeper = asString(raw.keeper)
+  const runtimeId = asString(raw.runtime_id)
+  if (!keeper || !runtimeId) return null
+  return {
+    keeper,
+    runtime_id: runtimeId,
+    matches_default: asBoolean(raw.matches_default),
+  }
+}
+
+function decodeRuntimeAssignmentGovernance(raw: unknown): DashboardRuntimeAssignmentGovernance | null {
+  if (!isRecord(raw)) return null
+  return {
+    schema: asNullableString(raw.schema),
+    source: asNullableString(raw.source),
+    status: asNullableString(raw.status),
+    degraded: asBoolean(raw.degraded) ?? false,
+    operator_action_required: asBoolean(raw.operator_action_required) ?? false,
+    blast_radius: asNullableString(raw.blast_radius),
+    assignment_count: asNumber(raw.assignment_count) ?? 0,
+    assigned_keeper_count: asNumber(raw.assigned_keeper_count) ?? 0,
+    assigned_runtime_count: asNumber(raw.assigned_runtime_count) ?? 0,
+    default_assignment_count: asNumber(raw.default_assignment_count) ?? 0,
+    default_runtime_id: asNullableString(raw.default_runtime_id),
+    librarian_runtime_id: asNullableString(raw.librarian_runtime_id),
+    warnings: asStringArray(raw.warnings),
+    assigned_runtimes: asStringArray(raw.assigned_runtimes),
+    assignments: asRecordArray(raw.assignments)
+      .map(decodeRuntimeAssignment)
+      .filter((item): item is DashboardRuntimeAssignment => item !== null),
+  }
+}
+
 function decodeRuntimeProvidersResponse(raw: unknown): DashboardRuntimeProvidersResponse | null {
   if (!isRecord(raw)) return null
   const summary = isRecord(raw.summary) ? raw.summary : null
@@ -768,6 +828,7 @@ function decodeRuntimeProvidersResponse(raw: unknown): DashboardRuntimeProviders
     providers: asRecordArray(raw.providers)
       .map(decodeRuntimeProviderSnapshot)
       .filter((provider): provider is DashboardRuntimeProviderSnapshot => provider !== null),
+    assignment_governance: decodeRuntimeAssignmentGovernance(raw.assignment_governance),
     config_path: asNullableString(raw.config_path),
   }
 }

--- a/dashboard/src/components/runtime-health-snapshot.test.ts
+++ b/dashboard/src/components/runtime-health-snapshot.test.ts
@@ -190,7 +190,6 @@ describe('RuntimeHealthSnapshot', () => {
         operator_action_required: true,
         blast_radius: 'single_runtime_assignment_pin',
         assignment_count: 2,
-        assigned_keeper_count: 2,
         assigned_runtime_count: 1,
         default_assignment_count: 0,
         default_runtime_id: 'runpod_mtp.qwen',

--- a/dashboard/src/components/runtime-health-snapshot.test.ts
+++ b/dashboard/src/components/runtime-health-snapshot.test.ts
@@ -179,6 +179,45 @@ describe('RuntimeHealthSnapshot', () => {
     expect(container.textContent).toContain('500 Internal Server Error: Eio mutex poisoned')
   })
 
+  it('surfaces runtime assignment governance warnings on the first screen', async () => {
+    apiMocks.fetchRuntimeProviders.mockResolvedValueOnce({
+      ...providerPayload(),
+      assignment_governance: {
+        schema: 'masc.runtime_assignment_governance.v1',
+        source: 'runtime.toml',
+        status: 'degraded',
+        degraded: true,
+        operator_action_required: true,
+        blast_radius: 'single_runtime_assignment_pin',
+        assignment_count: 2,
+        assigned_keeper_count: 2,
+        assigned_runtime_count: 1,
+        default_assignment_count: 0,
+        default_runtime_id: 'runpod_mtp.qwen',
+        librarian_runtime_id: null,
+        warnings: ['explicit_assignments_present', 'single_runtime_assignment_pin'],
+        assigned_runtimes: ['openai.gpt'],
+        assignments: [
+          { keeper: 'budgettest', runtime_id: 'openai.gpt', matches_default: false },
+          { keeper: 'routingtest', runtime_id: 'openai.gpt', matches_default: false },
+        ],
+      },
+    })
+    const { RuntimeHealthSnapshot } = await import('./runtime-health-snapshot')
+
+    render(h(RuntimeHealthSnapshot, {}), container)
+    await waitFor(
+      () => container.textContent?.includes('runtime assignment governance') ?? false,
+      'assignment governance warning',
+    )
+
+    expect(container.textContent).toContain('runtime assignment review')
+    expect(container.textContent).toContain('2 explicit')
+    expect(container.textContent).toContain('assigned runtimes: openai.gpt')
+    expect(container.textContent).toContain('single_runtime_assignment_pin')
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('runtime assignment governance')
+  })
+
   it('uses force=1 when the operator clicks Live probe', async () => {
     const { RuntimeHealthSnapshot } = await import('./runtime-health-snapshot')
 

--- a/dashboard/src/components/runtime-health-snapshot.ts
+++ b/dashboard/src/components/runtime-health-snapshot.ts
@@ -4,6 +4,7 @@ import {
   fetchDashboardRuntimeProbe,
   fetchRuntimeProviders,
   type DashboardRuntimeProbeResponse,
+  type DashboardRuntimeAssignmentGovernance,
   type DashboardRuntimeProviderProbe,
   type DashboardRuntimeProviderSnapshot,
   type DashboardRuntimeProvidersResponse,
@@ -90,14 +91,29 @@ function countProviderStatus(
   }
 }
 
-function snapshotStatus(counts: ReturnType<typeof countProviderStatus>, probeError: string | null): 'ok' | 'warn' | 'crit' {
+function governanceNeedsAttention(governance: DashboardRuntimeAssignmentGovernance | null | undefined): boolean {
+  return governance?.degraded === true || governance?.operator_action_required === true
+}
+
+function snapshotStatus(
+  counts: ReturnType<typeof countProviderStatus>,
+  probeError: string | null,
+  governance: DashboardRuntimeAssignmentGovernance | null | undefined,
+): 'ok' | 'warn' | 'crit' {
   if (probeError || counts.failed > 0 || counts.missingAuth > 0) return 'crit'
+  if (governanceNeedsAttention(governance)) return 'warn'
   if (counts.skipped > 0 || counts.reachable === 0) return 'warn'
   return 'ok'
 }
 
 function snapshotTone(status: 'ok' | 'warn' | 'crit'): 'ok' | 'warn' | 'bad' {
   return status === 'crit' ? 'bad' : status
+}
+
+function snapshotStatusText(status: 'ok' | 'warn' | 'crit', governanceAttention: boolean): string {
+  if (status === 'crit') return 'needs attention'
+  if (governanceAttention) return 'runtime assignment review'
+  return status === 'ok' ? 'runtime reachable' : 'probe incomplete'
 }
 
 function shortUrl(value: string | null | undefined): string {
@@ -146,6 +162,18 @@ function firstProblem(
   }
 }
 
+function assignmentGovernanceValue(governance: DashboardRuntimeAssignmentGovernance | null | undefined): string {
+  if (!governance) return MISSING_DATA_DASH
+  const count = governance.assignment_count
+  return count === 0 ? 'default only' : `${formatNumber(count)} explicit`
+}
+
+function assignmentGovernanceDetail(governance: DashboardRuntimeAssignmentGovernance | null | undefined): string {
+  if (!governance) return 'runtime.toml'
+  if (governance.warnings.length > 0) return governance.warnings.slice(0, 2).join(', ')
+  return governance.status ?? 'ok'
+}
+
 function endpointRows(probe: DashboardRuntimeProbeResponse | null): Array<{ label: string; value: string | null | undefined }> {
   return [
     { label: 'server', value: probe?.probe?.server_url },
@@ -173,8 +201,10 @@ export function RuntimeHealthSnapshot() {
   const providers = data?.providers ?? null
   const probe = data?.probe ?? null
   const probeError = data?.probeError ?? null
+  const governance = providers?.assignment_governance ?? null
   const counts = countProviderStatus(providers, probe)
-  const status = snapshotStatus(counts, probeError)
+  const status = snapshotStatus(counts, probeError, governance)
+  const governanceAttention = governanceNeedsAttention(governance)
   const problem = firstProblem(providers, probe)
   const providerProbes = providerProbeMap(probe)
   const defaultRuntime = configuredDefaultRuntime(providers) ?? probeDefaultRuntime(probe)
@@ -207,7 +237,7 @@ export function RuntimeHealthSnapshot() {
       ` : null}
       ${state.error ? html`<${ErrorState} message=${state.error} />` : null}
 
-      <div class="grid grid-cols-1 gap-3 md:grid-cols-4" data-testid="runtime-health-snapshot">
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-5" data-testid="runtime-health-snapshot">
         <${StatTile}
           label="live probe"
           value=${counts.failed > 0 ? `${counts.failed} failing` : `${counts.reachable} reachable`}
@@ -238,6 +268,15 @@ export function RuntimeHealthSnapshot() {
           status=${probeError ? 'crit' : probe ? 'ok' : 'warn'}
           delta=${{ direction: probeError ? 'down' : 'flat', text: probe?.cache_hit ? 'cache hit' : 'fresh probe' }}
         />
+        <${StatTile}
+          label="assignments"
+          value=${assignmentGovernanceValue(governance)}
+          status=${governanceAttention ? 'warn' : governance ? 'ok' : 'warn'}
+          delta=${{
+            direction: governanceAttention ? 'down' : 'flat',
+            text: assignmentGovernanceDetail(governance),
+          }}
+        />
       </div>
 
       ${probeError ? html`
@@ -252,6 +291,22 @@ export function RuntimeHealthSnapshot() {
           <span class="mx-1">·</span>
           <span>${problem.message}</span>
           ${problem.detail ? html`<div class="mt-1 truncate text-2xs" title=${problem.detail}>${problem.detail}</div>` : null}
+        </div>
+      ` : null}
+
+      ${governanceAttention ? html`
+        <div class="mt-3 rounded-[var(--r-1)] border border-[var(--status-warn)] bg-[var(--status-warn)]/5 px-3 py-2 text-xs text-[var(--status-warn)]" role="alert">
+          runtime assignment governance · ${governance?.status ?? 'watch'} · ${formatNumber(governance?.assignment_count ?? 0)} explicit assignments
+          ${governance?.assigned_runtimes.length ? html`
+            <div class="mt-1 truncate text-2xs" title=${governance.assigned_runtimes.join(', ')}>
+              assigned runtimes: ${governance.assigned_runtimes.join(', ')}
+            </div>
+          ` : null}
+          ${governance?.warnings.length ? html`
+            <div class="mt-1 truncate text-2xs" title=${governance.warnings.join(', ')}>
+              warnings: ${governance.warnings.join(', ')}
+            </div>
+          ` : null}
         </div>
       ` : null}
 
@@ -270,7 +325,7 @@ export function RuntimeHealthSnapshot() {
 
       <div class="mt-3 flex flex-wrap items-center gap-2 text-2xs">
         <${StatusChip} tone=${snapshotTone(status)} uppercase=${false}>
-          ${status === 'crit' ? 'needs attention' : status === 'ok' ? 'runtime reachable' : 'probe incomplete'}
+          ${snapshotStatusText(status, governanceAttention)}
         <//>
         <${RouteLink}
           tab="monitoring"

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -182,6 +182,8 @@ let runtime_id_for_keeper (keeper_name : string) : string option =
   List.assoc_opt keeper_name (Atomic.get keeper_assignments_ref)
 ;;
 
+let keeper_assignments () = Atomic.get keeper_assignments_ref
+
 (* [runtime].librarian routing for the memory-os librarian. [None] = the
    librarian inherits each keeper's runtime (legacy). Reads the Atomic ref set by
    [init_default]; the env override lives in keeper_librarian_runtime. *)

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -51,6 +51,13 @@ val runtime_id_for_keeper : string -> string option
     it). persona⊥{model,runtime}: keeper→runtime assignment is NOT sourced from
     persona JSON or keeper TOML. *)
 
+val keeper_assignments : unit -> (string * string) list
+(** Snapshot of explicit [keeper_name -> runtime_id] assignments loaded from
+    [\[runtime.assignments\]]. The list is validated during {!init_default};
+    every runtime id in the returned snapshot resolves to a configured runtime.
+    Dashboard/operator surfaces use this to expose assignment blast radius
+    without parsing TOML independently. *)
+
 val librarian_runtime_id : unit -> string option
 (** [\[runtime\].librarian] runtime id for the memory-os librarian, or [None]
     when unset (the librarian inherits each keeper's runtime). Validated at load

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1292,7 +1292,6 @@ let runtime_assignment_governance_json ~default_id =
          then "single_runtime_assignment_pin"
          else "mixed_runtime_assignments")
     ; "assignment_count", `Int assignment_count
-    ; "assigned_keeper_count", `Int assignment_count
     ; "assigned_runtime_count", `Int assigned_runtime_count
     ; "default_assignment_count", `Int default_assignment_count
     ; "default_runtime_id", Json_util.string_opt_to_json default_id

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1238,6 +1238,81 @@ let runtime_unique_count values =
   values |> List.sort_uniq String.compare |> List.length
 ;;
 
+let runtime_assignment_governance_json ~default_id =
+  let assignments =
+    Runtime.keeper_assignments ()
+    |> List.sort (fun (left, _) (right, _) -> String.compare left right)
+  in
+  let assignment_count = List.length assignments in
+  let assigned_runtime_ids = List.map snd assignments in
+  let assigned_runtimes = List.sort_uniq String.compare assigned_runtime_ids in
+  let assigned_runtime_count = List.length assigned_runtimes in
+  let default_assignment_count =
+    match default_id with
+    | None -> 0
+    | Some default_id ->
+      assignments
+      |> List.filter (fun (_, runtime_id) -> String.equal runtime_id default_id)
+      |> List.length
+  in
+  let librarian_runtime_id = Runtime.librarian_runtime_id () in
+  let single_runtime_pin = assignment_count > 1 && assigned_runtime_count = 1 in
+  let assignments_match_default =
+    assignment_count > 0 && default_assignment_count = assignment_count
+  in
+  let add_if condition warning warnings =
+    if condition then warning :: warnings else warnings
+  in
+  let warnings =
+    []
+    |> add_if (assignment_count > 0) "explicit_assignments_present"
+    |> add_if single_runtime_pin "single_runtime_assignment_pin"
+    |> add_if assignments_match_default "assignments_match_default_runtime"
+    |> add_if (Option.is_some librarian_runtime_id) "librarian_runtime_override"
+    |> List.rev
+  in
+  let status =
+    if warnings = []
+    then "ok"
+    else if single_runtime_pin || assignments_match_default || Option.is_some librarian_runtime_id
+    then "degraded"
+    else "watch"
+  in
+  `Assoc
+    [ "schema", `String "masc.runtime_assignment_governance.v1"
+    ; "source", `String runtime_inventory_source
+    ; "status", `String status
+    ; "degraded", `Bool (String.equal status "degraded")
+    ; "operator_action_required", `Bool (warnings <> [])
+    ; "blast_radius",
+      `String
+        (if assignment_count = 0
+         then "default_runtime_only"
+         else if single_runtime_pin
+         then "single_runtime_assignment_pin"
+         else "mixed_runtime_assignments")
+    ; "assignment_count", `Int assignment_count
+    ; "assigned_keeper_count", `Int assignment_count
+    ; "assigned_runtime_count", `Int assigned_runtime_count
+    ; "default_assignment_count", `Int default_assignment_count
+    ; "default_runtime_id", Json_util.string_opt_to_json default_id
+    ; "librarian_runtime_id", Json_util.string_opt_to_json librarian_runtime_id
+    ; "warnings", Json_util.json_string_list warnings
+    ; "assigned_runtimes", Json_util.json_string_list assigned_runtimes
+    ; ( "assignments"
+      , `List
+          (List.map
+             (fun (keeper_name, runtime_id) ->
+                `Assoc
+                  [ "keeper", `String keeper_name
+                  ; "runtime_id", `String runtime_id
+                  ; ( "matches_default"
+                    , `Bool (Option.equal String.equal default_id (Some runtime_id)) )
+                  ])
+             assignments) )
+    ]
+;;
+
 let runtime_inventory_json () =
   let runtimes = Runtime.get_runtimes () in
   let default_id = runtime_default_runtime_id () in
@@ -1264,6 +1339,7 @@ let runtime_inventory_json () =
           ; "cli_models", `Int (count_models "cli")
           ; "default_runtime_id", Json_util.string_opt_to_json default_id
           ] )
+    ; "assignment_governance", runtime_assignment_governance_json ~default_id
     ; "providers", `List (List.map (runtime_inventory_entry_json ~default_id) runtimes)
     ]
 ;;

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -86,7 +86,9 @@ val runtime_inventory_json : unit -> Yojson.Safe.t
 (** Returns the materialized runtime.toml inventory loaded by
     {!Runtime.init_default}. This is the dashboard-compatible projection for
     the legacy [/api/v1/providers] route; it does not execute providers or
-    infer defaults outside the Runtime SSOT. *)
+    infer defaults outside the Runtime SSOT. The envelope includes
+    [assignment_governance] so operators can see explicit keeper-runtime
+    assignment blast radius without the dashboard parsing TOML independently. *)
 
 val dashboard_perf_http_json : Workspace.config -> Yojson.Safe.t
 (** Renders the dashboard performance envelope (build

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -15,6 +15,7 @@
 
 open Alcotest
 open Masc
+module J = Yojson.Safe.Util
 module KMC = Keeper_meta_contract
 
 (* ---- temp config-dir + keeper TOML fixtures
@@ -222,6 +223,42 @@ let test_runtime_assignment_writer_updates_runtime_toml () =
       "meta runtime resolver sees updated assignment"
       "runpod_mtp.qwen"
       (KMC.runtime_id_of_meta (make_meta "routingtest")))
+;;
+
+let test_runtime_inventory_surfaces_assignment_governance () =
+  with_runtime_initialized (fun () ->
+    let json = Server_dashboard_http_runtime_info.runtime_inventory_json () in
+    let governance = J.member "assignment_governance" json in
+    Alcotest.(check string)
+      "schema"
+      "masc.runtime_assignment_governance.v1"
+      (governance |> J.member "schema" |> J.to_string);
+    Alcotest.(check string)
+      "status"
+      "degraded"
+      (governance |> J.member "status" |> J.to_string);
+    Alcotest.(check int)
+      "assignment count"
+      2
+      (governance |> J.member "assignment_count" |> J.to_int);
+    Alcotest.(check int)
+      "assigned runtime count"
+      1
+      (governance |> J.member "assigned_runtime_count" |> J.to_int);
+    Alcotest.(check int)
+      "default assignment count"
+      0
+      (governance |> J.member "default_assignment_count" |> J.to_int);
+    Alcotest.(check bool)
+      "operator action required"
+      true
+      (governance |> J.member "operator_action_required" |> J.to_bool);
+    Alcotest.(check bool)
+      "single runtime warning"
+      true
+      (string_contains
+         (Yojson.Safe.to_string governance)
+         "single_runtime_assignment_pin"))
 ;;
 
 let test_runtime_assignment_writer_rejects_unknown_runtime_without_write () =
@@ -565,6 +602,10 @@ let () =
             "dashboard runtime assignment writes runtime.toml and refreshes cache"
             `Quick
             test_runtime_assignment_writer_updates_runtime_toml
+        ; Alcotest.test_case
+            "dashboard runtime inventory exposes assignment governance"
+            `Quick
+            test_runtime_inventory_surfaces_assignment_governance
         ; Alcotest.test_case
             "unknown assignment is rejected before runtime.toml write"
             `Quick


### PR DESCRIPTION
## Summary
- expose runtime.toml keeper assignment governance on `/api/v1/providers`
- decode the new assignment governance envelope in dashboard API code
- show explicit assignment blast-radius warnings on the runtime health snapshot first screen

## Verification
- `opam exec -- ocamlformat --check lib/runtime/runtime.ml lib/runtime/runtime.mli lib/server/server_dashboard_http_runtime_info.ml lib/server/server_dashboard_http_runtime_info.mli test/test_runtime_per_keeper_routing.ml`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec eslint src/api/dashboard.ts src/components/runtime-health-snapshot.ts`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/dashboard.test.ts src/components/runtime-health-snapshot.test.ts --no-file-parallelism --maxWorkers=1`
- `python3 scripts/check_test_coverage.py`
- `git diff --check`

## Not run
- Dune build/runtest: intentionally not run per operator instruction; build will be handled separately.