### PR TITLE
fix(session): assert McpSessionStore.get return value (main red fix-forward, #21554)

### DIFF
--- a/test/test_session.ml
+++ b/test/test_session.ml
@@ -41,10 +41,16 @@ let test_mcp_session_get_updates_activity () =
 let test_mcp_session_get_increments_request () =
   let session = Session.McpSessionStore.create () in
   check int "initial count" 0 session.request_count;
-  let _ = Session.McpSessionStore.get session.id in
-  check int "count after first get" 1 session.request_count;
-  let _ = Session.McpSessionStore.get session.id in
-  check int "count after second get" 2 session.request_count
+  (* [get] returns a fresh immutable record carrying the incremented count
+     (with-copy, not in-place): the store advances but the original [session]
+     binding does not. Assert on the returned record — the real consumer
+     [get_or_create_mcp_session] likewise uses get's return value. *)
+  let count_of = function
+    | Some (s : Session.McpSessionStore.mcp_session) -> s.request_count
+    | None -> -1
+  in
+  check int "count after first get" 1 (count_of (Session.McpSessionStore.get session.id));
+  check int "count after second get" 2 (count_of (Session.McpSessionStore.get session.id))
 
 let test_mcp_session_remove () =
   let session = Session.McpSessionStore.create () in


### PR DESCRIPTION
## 목표

main을 red로 만드는 `test_session`의 `get increments request` 실패를 고친다. fix-forward (원인 PR #21554는 이미 머지됨).

## 원인

`mcp_session`은 immutable record다. `McpSessionStore.get`은 store를 전진시키고 **증가된 count를 담은 새 record를 반환**한다(with-copy, in-place 아님). 원래 binding은 0으로 남는다.

`test_mcp_session_get_increments_request`는 `create()`로 받은 `session`을 붙잡고 `get()` **후** `session.request_count`를 검사했다 — get의 반환값을 버렸으므로 stale 0에 대해 1을 단언해 실패한다. (`activity updated`는 `>=` 비교라 우연히 통과해 같은 결함이 가려져 있었다.)

실제 소비자 `get_or_create_mcp_session`은 get의 반환값을 사용한다(`Some session -> session`) — immutable API가 의도된 설계임을 확인. 즉 **코드가 아니라 test가 틀렸다**.

이 버그는 pre-existing이었으나, #21554의 컴파일 fix(`await_if_needed` 복원)가 그동안 빌드되지 못하던 `test_session`을 다시 활성화하면서 main에서 드러났다.

## 변경

- `test/test_session.ml` — `get`의 반환 record(`Some s -> s.request_count`)를 단언하도록 수정.

## 검증

- `dune-local.sh build test/test_session.exe` PASS
- `test_session` 실행: 14 tests PASS (이전 `get increments request` FAIL → PASS)
- `ocamlformat --check` PASS
- 증명: 머지된 main(원본 test)에서 동일 실행 시 `1 failure!` 재현 확인 후 본 수정으로 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
