### PR TITLE
[codex] add multimodal dashboard chat blocks

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -212,6 +212,67 @@ describe('streamKeeperMessage', () => {
     expect(events).toEqual(['RUN_FINISHED'])
   })
 
+  it('forwards semantic user blocks separately from attachment payloads', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('data: {"type":"RUN_FINISHED"}\n\n', {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await streamKeeperMessage('sangsu', 'describe this', {
+      onEvent: () => {},
+      attachments: [
+        {
+          id: 'att-img',
+          type: 'image',
+          name: 'screen.png',
+          size: 1024,
+          mimeType: 'image/png',
+          data: 'data:image/png;base64,abc123',
+        },
+      ],
+      userBlocks: [
+        {
+          type: 'image',
+          attachmentId: 'att-img',
+          name: 'screen.png',
+          mimeType: 'image/png',
+          size: 1024,
+        },
+        { type: 'text', text: 'describe this' },
+      ],
+    })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      name: 'sangsu',
+      message: 'describe this',
+      direct_reply: true,
+      attachments: [
+        {
+          id: 'att-img',
+          type: 'image',
+          name: 'screen.png',
+          size: 1024,
+          mime_type: 'image/png',
+          data: 'data:image/png;base64,abc123',
+        },
+      ],
+      user_blocks: [
+        {
+          type: 'image',
+          attachment_id: 'att-img',
+          name: 'screen.png',
+          mime_type: 'image/png',
+          size: 1024,
+        },
+        { type: 'text', text: 'describe this' },
+      ],
+    })
+  })
+
   const stubStaleToken = () => {
     window.sessionStorage.setItem('masc_bearer_token', 'stale-token')
     window.sessionStorage.setItem(

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -5,7 +5,7 @@ import {
   formatKeeperVisibleReply,
   normalizeKeeperConversationDetails,
 } from '../keeper-message'
-import type { KeeperConversationDetails } from '../types'
+import type { KeeperConversationDetails, KeeperUserInputBlock } from '../types'
 import type { DashboardAuthErrorCode } from '../types/dashboard-execution'
 import {
   currentDashboardActor,
@@ -456,10 +456,27 @@ export interface StreamKeeperMessageOptions {
   signal?: AbortSignal
   onEvent: (event: KeeperChatStreamEvent) => void
   attachments?: StreamAttachment[]
+  userBlocks?: KeeperUserInputBlock[]
   channel?: string
   channelWorkspaceId?: string
   turnInstructions?: string
   surfaceContext?: KeeperStreamSurfaceContext
+}
+
+function streamUserBlockToWire(block: KeeperUserInputBlock): Record<string, unknown> {
+  if (block.type === 'text') {
+    return {
+      type: 'text',
+      text: block.text,
+    }
+  }
+  return {
+    type: block.type,
+    attachment_id: block.attachmentId,
+    name: block.name,
+    mime_type: block.mimeType,
+    size: block.size,
+  }
 }
 
 export async function streamKeeperMessage(
@@ -469,6 +486,7 @@ export async function streamKeeperMessage(
     signal,
     onEvent,
     attachments,
+    userBlocks,
     channel,
     channelWorkspaceId,
     turnInstructions,
@@ -501,6 +519,9 @@ export async function streamKeeperMessage(
       mime_type: att.mimeType,
       data: att.data,
     }))
+  }
+  if (userBlocks && userBlocks.length > 0) {
+    body.user_blocks = userBlocks.map(streamUserBlockToWire)
   }
   const requestBody = JSON.stringify(body)
   const postStream = () => fetch('/api/v1/keepers/chat/stream', {

--- a/dashboard/src/components/chat/attachments.test.ts
+++ b/dashboard/src/components/chat/attachments.test.ts
@@ -30,6 +30,19 @@ describe('validateFile', () => {
     expect(validateFile(fileOfSize('a.json', 'application/json', 10))).toBeNull()
   })
 
+  it('accepts allowed audio files within the file size budget', () => {
+    expect(validateFile(fileOfSize('clip.webm', 'audio/webm', MAX_FILE_SIZE))).toBeNull()
+    expect(validateFile(fileOfSize('clip.wav', 'audio/wav', 10))).toBeNull()
+  })
+
+  it('rejects unsupported audio types', () => {
+    expect(validateFile(fileOfSize('clip.aiff', 'audio/aiff', 10))).toContain('지원하지 않는 오디오 형식')
+  })
+
+  it('rejects oversized audio files', () => {
+    expect(validateFile(fileOfSize('clip.webm', 'audio/webm', MAX_FILE_SIZE + 1))).toContain('오디오 크기 초과')
+  })
+
   it('rejects unsupported file types', () => {
     expect(validateFile(fileOfSize('a.bin', 'application/octet-stream', 10))).toContain('지원하지 않는 파일 형식')
   })

--- a/dashboard/src/components/chat/attachments.ts
+++ b/dashboard/src/components/chat/attachments.ts
@@ -11,6 +11,7 @@ import type { KeeperConversationAttachment } from '../../types'
 
 export const ALLOWED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
 export const ALLOWED_FILE_TYPES = ['text/plain', 'text/markdown', 'application/json', 'text/csv']
+export const ALLOWED_AUDIO_TYPES = ['audio/mpeg', 'audio/mp4', 'audio/wav', 'audio/webm', 'audio/ogg']
 export const MAX_IMAGE_SIZE = 5 * 1024 * 1024
 export const MAX_FILE_SIZE = 2 * 1024 * 1024
 export const MAX_TOTAL_PAYLOAD = 10 * 1024 * 1024
@@ -20,6 +21,9 @@ export function validateFile(file: File): string | null {
   if (file.type.startsWith('image/')) {
     if (!ALLOWED_IMAGE_TYPES.includes(file.type)) return `지원하지 않는 이미지 형식: ${file.type}`
     if (file.size > MAX_IMAGE_SIZE) return '이미지 크기 초과 (최대 5MB)'
+  } else if (file.type.startsWith('audio/')) {
+    if (!ALLOWED_AUDIO_TYPES.includes(file.type)) return `지원하지 않는 오디오 형식: ${file.type}`
+    if (file.size > MAX_FILE_SIZE) return '오디오 크기 초과 (최대 2MB)'
   } else {
     if (!ALLOWED_FILE_TYPES.includes(file.type)) return `지원하지 않는 파일 형식: ${file.type}`
     if (file.size > MAX_FILE_SIZE) return '파일 크기 초과 (최대 2MB)'

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -4,7 +4,7 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { fireEvent } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { ChatBlock, KeeperConversationEntry } from '../../types'
+import type { ChatBlock, KeeperConversationEntry, KeeperUserInputBlock } from '../../types'
 import type { ToolCallEntry } from '../../api/dashboard'
 import { ChatComposer, ChatTranscript } from './primitives'
 import { collectAttachments } from './attachments'
@@ -1077,7 +1077,7 @@ describe('ChatComposer multimodal', () => {
 
   function renderComposer(props: {
     draft?: string
-    onSend?: (payload: { blocks: ChatBlock[] }) => void
+    onSend?: (payload: { blocks: ChatBlock[]; userBlocks: KeeperUserInputBlock[] }) => void
     disabled?: boolean
     streaming?: boolean
   } = {}) {
@@ -1207,6 +1207,55 @@ describe('ChatComposer multimodal', () => {
     expect(blocks).toHaveLength(2)
     expect(blocks[0]).toMatchObject({ t: 'attach', name: 'screen.png', kind: 'image' })
     expect(blocks[1]).toMatchObject({ t: 'p', html: 'check this &lt;tag&gt;' })
+    expect(onSend.mock.calls[0]?.[0].userBlocks).toEqual([
+      {
+        type: 'image',
+        attachmentId: 'att-img',
+        name: 'screen.png',
+        mimeType: 'image/png',
+        size: 1024,
+      },
+      { type: 'text', text: 'check this <tag>' },
+    ])
+  })
+
+  it('preserves audio attachments as audio user blocks', async () => {
+    vi.mocked(collectAttachments).mockResolvedValue({
+      attachments: [
+        {
+          id: 'att-audio',
+          type: 'file',
+          name: 'voice.webm',
+          size: 2048,
+          mimeType: 'audio/webm',
+          data: 'data:audio/webm;base64,AAAA',
+        },
+      ],
+      errors: [],
+    })
+
+    const onSend = vi.fn()
+    renderComposer({ onSend })
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    setInputFiles(fileInput, [new File(['x'], 'voice.webm', { type: 'audio/webm' })])
+    fileInput.dispatchEvent(new Event('change'))
+    await new Promise((r) => setTimeout(r, 10))
+
+    const sendBtn = container.querySelector('.send') as HTMLButtonElement
+    sendBtn.click()
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(onSend).toHaveBeenCalledOnce()
+    expect(onSend.mock.calls[0]?.[0].userBlocks).toEqual([
+      {
+        type: 'audio',
+        attachmentId: 'att-audio',
+        name: 'voice.webm',
+        mimeType: 'audio/webm',
+        size: 2048,
+      },
+    ])
   })
 
   it('keeps send disabled until there is content', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -14,7 +14,7 @@ const CHAT_FOCUS_RING = ringFocusClasses({ tone: 'accent-medium', width: 2 })
 import { formatTimeHms } from '../../lib/format-time'
 import { formatCost } from '../../lib/format-number'
 import { isSubmitEnter } from '../../lib/keyboard'
-import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatLinkBlock, ChatMermaidBlock, ChatShellBlock, ChatTableBlock, ChatTraceStep, ChatVoiceBlock } from '../../types'
+import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatLinkBlock, ChatMermaidBlock, ChatShellBlock, ChatTableBlock, ChatTraceStep, ChatVoiceBlock, KeeperUserInputBlock } from '../../types'
 import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, KeeperConversationSource, SurfaceRef } from '../../types'
 import type { ToolCallOutputBlob } from '../../api/dashboard'
 import { lookupToolCallOutput } from '../../tool-call-output-store'
@@ -1230,6 +1230,14 @@ function AttachmentCard({ attachment }: { attachment: KeeperConversationAttachme
   `
 }
 
+function userInputMediaKindForAttachment(
+  attachment: KeeperConversationAttachment,
+): Exclude<KeeperUserInputBlock['type'], 'text'> {
+  if (attachment.type === 'image') return 'image'
+  if (attachment.mimeType.startsWith('audio/')) return 'audio'
+  return 'document'
+}
+
 function formatAudioDuration(seconds?: number | null): string {
   if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) return ''
   const totalSec = Math.round(seconds)
@@ -1946,7 +1954,7 @@ export function ChatComposer({
   queueEnabled?: boolean
   queueCount?: number
   onDraftChange: (value: string) => void
-  onSend: (payload: { blocks: ChatBlock[] }) => void | Promise<void>
+  onSend: (payload: { blocks: ChatBlock[]; userBlocks: KeeperUserInputBlock[] }) => void | Promise<void>
   onAbort?: () => void
   layout?: 'default' | 'primary'
 }) {
@@ -2026,6 +2034,7 @@ export function ChatComposer({
   const handleSend = () => {
     if (sendDisabled) return
     const blocks: ChatBlock[] = []
+    const userBlocks: KeeperUserInputBlock[] = []
     for (const att of attachments) {
       blocks.push({
         t: 'attach',
@@ -2041,12 +2050,20 @@ export function ChatComposer({
         mimeType: att.mimeType,
         sizeBytes: att.size,
       } as ChatBlock)
+      userBlocks.push({
+        type: userInputMediaKindForAttachment(att),
+        attachmentId: att.id,
+        name: att.name,
+        mimeType: att.mimeType,
+        size: att.size,
+      })
     }
     const text = draft.trim()
     if (text) {
       blocks.push({ t: 'p', html: escapeHtml(text) } as ChatBlock)
+      userBlocks.push({ type: 'text', text })
     }
-    void onSend({ blocks })
+    void onSend({ blocks, userBlocks })
     onDraftChange('')
     setAttachments([])
     if (textareaRef.current) textareaRef.current.style.height = 'auto'
@@ -2133,7 +2150,7 @@ export function ChatComposer({
             <input
               ref=${fileInputRef}
               type="file"
-              accept="image/png,image/jpeg,image/gif,image/webp,text/plain,text/markdown,application/json,text/csv"
+              accept="image/png,image/jpeg,image/gif,image/webp,audio/mpeg,audio/mp4,audio/wav,audio/webm,audio/ogg,text/plain,text/markdown,application/json,text/csv"
               multiple
               class="hidden"
               aria-label="파일 첨부"

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -12,6 +12,7 @@ import type {
   KeeperConversationAttachment,
   KeeperConversationEntry,
   KeeperDiagnostic,
+  KeeperUserInputBlock,
 } from '../types'
 import {
   abortKeeperThreadMessage,
@@ -534,7 +535,7 @@ export function KeeperConversationPanel({
     }
   }
 
-  const submit = async ({ blocks }: { blocks: ChatBlock[] }) => {
+  const submit = async ({ blocks, userBlocks }: { blocks: ChatBlock[]; userBlocks: KeeperUserInputBlock[] }) => {
     const prompt = draft.trim()
     if (chatAccess.blocked) {
       showToast(chatAccess.message, 'error')
@@ -549,7 +550,7 @@ export function KeeperConversationPanel({
       return
     }
     try {
-      await sendKeeperThreadMessage(keeperName, prompt, { attachments })
+      await sendKeeperThreadMessage(keeperName, prompt, { attachments, userBlocks })
     } catch (err) {
       if (isAbortError(err)) return
       const message = err instanceof Error ? err.message : `${keeperName} 메시지 전송 실패`
@@ -679,7 +680,7 @@ export function KeeperConversationPanel({
               queueEnabled=${true}
               queueCount=${queueCount}
               onDraftChange=${setDraft}
-              onSend=${(payload: { blocks: ChatBlock[] }) => { void submit(payload) }}
+              onSend=${(payload: { blocks: ChatBlock[]; userBlocks: KeeperUserInputBlock[] }) => { void submit(payload) }}
               onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
               layout="primary"
             />
@@ -793,7 +794,7 @@ export function KeeperConversationPanel({
             queueEnabled=${true}
             queueCount=${queueCount}
             onDraftChange=${setDraft}
-            onSend=${(payload: { blocks: ChatBlock[] }) => { void submit(payload) }}
+            onSend=${(payload: { blocks: ChatBlock[]; userBlocks: KeeperUserInputBlock[] }) => { void submit(payload) }}
             onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
             layout="primary"
           />
@@ -905,7 +906,7 @@ export function KeeperConversationPanel({
             queueEnabled=${true}
             queueCount=${queueCount}
             onDraftChange=${setDraft}
-            onSend=${(payload: { blocks: ChatBlock[] }) => { void submit(payload) }}
+            onSend=${(payload: { blocks: ChatBlock[]; userBlocks: KeeperUserInputBlock[] }) => { void submit(payload) }}
             onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
           />
         </div>

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -74,7 +74,7 @@ import {
 } from './keeper-chat-pending'
 import { KEEPER_HISTORY_TAIL_MESSAGES } from './config/constants'
 import type { KeeperChatStreamEvent } from './api'
-import type { KeeperStatusDetail } from './types'
+import type { KeeperConversationAttachment, KeeperStatusDetail } from './types'
 
 describe('noteKeeperChatAppended', () => {
   beforeEach(() => {
@@ -243,6 +243,81 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     // whole dashboard after every chat send (user-visible "refresh").
     expect(refreshDashboard).not.toHaveBeenCalled()
     expect(invalidateDashboardCache).not.toHaveBeenCalled()
+  })
+
+  it('derives text and media user blocks when only attachments are supplied', async () => {
+    streamKeeperMessage.mockImplementation(emitting([
+      { type: 'RUN_STARTED' },
+      { type: 'TEXT_MESSAGE_END' },
+      { type: 'RUN_FINISHED' },
+    ], true))
+    const attachments: KeeperConversationAttachment[] = [
+      {
+        id: 'att-img',
+        type: 'image',
+        name: 'screen.png',
+        size: 1024,
+        mimeType: 'image/png',
+        data: 'data:image/png;base64,abc123',
+      },
+    ]
+
+    await sendKeeperThreadMessage('echo', 'describe this', { attachments })
+
+    expect(streamKeeperMessage).toHaveBeenCalledWith(
+      'echo',
+      'describe this',
+      expect.objectContaining({
+        attachments,
+        userBlocks: [
+          {
+            type: 'image',
+            attachmentId: 'att-img',
+            name: 'screen.png',
+            mimeType: 'image/png',
+            size: 1024,
+          },
+          { type: 'text', text: 'describe this' },
+        ],
+      }),
+    )
+  })
+
+  it('derives audio user blocks from audio attachments', async () => {
+    streamKeeperMessage.mockImplementation(emitting([
+      { type: 'RUN_STARTED' },
+      { type: 'TEXT_MESSAGE_END' },
+      { type: 'RUN_FINISHED' },
+    ], true))
+    const attachments: KeeperConversationAttachment[] = [
+      {
+        id: 'att-audio',
+        type: 'file',
+        name: 'voice.webm',
+        size: 2048,
+        mimeType: 'audio/webm',
+        data: 'data:audio/webm;base64,AAAA',
+      },
+    ]
+
+    await sendKeeperThreadMessage('echo', '', { attachments })
+
+    expect(streamKeeperMessage).toHaveBeenCalledWith(
+      'echo',
+      '[첨부 1개: voice.webm]',
+      expect.objectContaining({
+        attachments,
+        userBlocks: [
+          {
+            type: 'audio',
+            attachmentId: 'att-audio',
+            name: 'voice.webm',
+            mimeType: 'audio/webm',
+            size: 2048,
+          },
+        ],
+      }),
+    )
   })
 
   it('mints deterministic non-colliding optimistic entry ids', async () => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -20,6 +20,7 @@ import type {
   KeeperConversationEntry,
   KeeperDiagnostic,
   KeeperStatusDetail,
+  KeeperUserInputBlock,
 } from './types'
 import {
   activeKeeperName,
@@ -488,16 +489,72 @@ export async function loadFullKeeperHistory(name: string): Promise<void> {
   }
 }
 
+function userInputMediaKindForAttachment(
+  attachment: KeeperConversationAttachment,
+): Exclude<KeeperUserInputBlock['type'], 'text'> {
+  if (attachment.type === 'image') return 'image'
+  if (attachment.mimeType.startsWith('audio/')) return 'audio'
+  return 'document'
+}
+
+function attachmentToUserInputBlock(attachment: KeeperConversationAttachment): KeeperUserInputBlock {
+  return {
+    type: userInputMediaKindForAttachment(attachment),
+    attachmentId: attachment.id,
+    name: attachment.name,
+    mimeType: attachment.mimeType,
+    size: attachment.size,
+  }
+}
+
+function deriveUserBlocks(
+  prompt: string,
+  attachments: KeeperConversationAttachment[] | undefined,
+): KeeperUserInputBlock[] | undefined {
+  const blocks = attachments?.map(attachmentToUserInputBlock) ?? []
+  const text = prompt.trim()
+  if (text) blocks.push({ type: 'text', text })
+  return blocks.length > 0 ? blocks : undefined
+}
+
+function fallbackMessageForUserBlocks(blocks: KeeperUserInputBlock[]): string {
+  const text = blocks
+    .filter((block): block is Extract<KeeperUserInputBlock, { type: 'text' }> => block.type === 'text')
+    .map(block => block.text.trim())
+    .filter(Boolean)
+    .join('\n\n')
+  if (text) return text
+
+  const media = blocks.filter(block => block.type !== 'text')
+  if (media.length === 0) return ''
+  const names = media
+    .slice(0, 3)
+    .map(block => block.name.trim())
+    .filter(Boolean)
+    .join(', ')
+  const suffix = media.length > 3 ? ` 외 ${media.length - 3}개` : ''
+  return names
+    ? `[첨부 ${media.length}개: ${names}${suffix}]`
+    : `[첨부 ${media.length}개]`
+}
+
 export async function sendKeeperThreadMessage(
   name: string,
   prompt: string,
-  options: { attachments?: KeeperConversationAttachment[] } = {},
+  options: {
+    attachments?: KeeperConversationAttachment[]
+    userBlocks?: KeeperUserInputBlock[]
+  } = {},
 ): Promise<void> {
   const keeperName = name.trim()
-  const message = prompt.trim()
-  if (!keeperName || !message) return
   const attachments =
     options.attachments && options.attachments.length > 0 ? options.attachments : undefined
+  const userBlocks =
+    options.userBlocks && options.userBlocks.length > 0
+      ? options.userBlocks
+      : deriveUserBlocks(prompt, attachments)
+  const message = prompt.trim() || fallbackMessageForUserBlocks(userBlocks ?? [])
+  if (!keeperName || !message) return
   abortKeeperThreadMessage(keeperName)
   const localId = `local-${++localIdCounter}-${Date.now()}`
   const assistantId = `reply-${++localIdCounter}-${Date.now()}`
@@ -538,6 +595,7 @@ export async function sendKeeperThreadMessage(
     const outcome = await streamKeeperMessage(keeperName, message, {
       signal: controller.signal,
       attachments,
+      userBlocks,
       onEvent: event => {
         setRecordValue(keeperStreamLastEventAt, keeperName, Date.now())
         if (event.type === 'CUSTOM' && event.name === 'KEEPER_QUEUE_REQUEST' && isRecord(event.value)) {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -735,6 +735,18 @@ export interface KeeperConversationAttachment {
   dims?: string
 }
 
+export type KeeperUserInputMediaKind = 'image' | 'document' | 'audio'
+
+export type KeeperUserInputBlock =
+  | { type: 'text'; text: string }
+  | {
+      type: KeeperUserInputMediaKind
+      attachmentId: string
+      name: string
+      mimeType: string
+      size: number
+    }
+
 // RFC-0235 P1: synthesized voice clip attached to an assistant chat row.
 // `audioUrl` is the absolute/relative URL the dashboard uses for playback;
 // `token` is the capability in `/api/v1/voice/audio/<token>` used as a

--- a/lib/dune
+++ b/lib/dune
@@ -66,7 +66,7 @@
   keeper_registry_orphan_drops
   keeper_registry_spawn_slots
   keeper_registry_error_tracking
-  keeper_text_processing
+  keeper_text_processing keeper_multimodal_input
   keeper_summarizer
   keeper_context_core_message_json
   keeper_context_core_history

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -84,6 +84,7 @@ let run_turn
       ~(build_turn_prompt :
          base_system_prompt:string -> messages:Agent_sdk.Types.message list -> turn_prompt)
       ~(user_message : string)
+      ?user_blocks
       ~(runtime_id : string)
       ?world_observation
       ?(turn_affordances = [])
@@ -485,6 +486,7 @@ let run_turn
                   ~runtime_id:runtime_id_string
                     ~keeper_name:meta.name
                     ~goal:user_message
+                    ?goal_blocks:user_blocks
                     ~priority
                     ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
                     ~system_prompt:turn_system_prompt

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -54,6 +54,9 @@ val per_provider_timeout_for_turn
      @param build_turn_prompt Callback: receives the base keeper system prompt
             and checkpoint message history, returns the final turn system prompt
      @param user_message The user's message to the keeper
+    @param user_blocks Optional structured user-authored OAS content blocks for
+           the current turn. [user_message] remains the display/history
+           fallback and must not contain raw media payloads.
     @param runtime_id Typed runtime profile name for model selection
      @param world_observation Structured keeper world snapshot used by
             advisory execution-progress checks. When omitted, the progress check
@@ -82,6 +85,7 @@ val run_turn
   -> build_turn_prompt:
        (base_system_prompt:string -> messages:Agent_sdk.Types.message list -> turn_prompt)
   -> user_message:string
+  -> ?user_blocks:Agent_sdk.Types.content_block list
   -> runtime_id:string
   -> ?world_observation:Keeper_world_observation.world_observation
   -> ?turn_affordances:string list

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -15,6 +15,7 @@ type message_source =
 
 type queued_message = {
   content : string;
+  user_blocks : Keeper_multimodal_input.user_input_block list;
   attachments : Keeper_chat_store.attachment list;
   timestamp : float;
   source : message_source;
@@ -94,6 +95,7 @@ let merge_batch batch =
       Some
         {
           content = String.concat "\n\n" (List.map (fun m -> m.content) batch);
+          user_blocks = List.concat_map (fun m -> m.user_blocks) batch;
           attachments = List.concat_map (fun m -> m.attachments) batch;
           timestamp = first.timestamp;
           source = first.source;

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -23,6 +23,7 @@ type message_source =
 
 type queued_message = {
   content : string;
+  user_blocks : Keeper_multimodal_input.user_input_block list;
   attachments : Keeper_chat_store.attachment list;
   timestamp : float;
   source : message_source;
@@ -52,10 +53,10 @@ val same_source : message_source -> message_source -> bool
 val dequeue_batch : keeper_name:string -> queued_message list
 
 (** [merge_batch batch] coalesces a same-source batch into one message:
-    contents joined in arrival order with a blank line, attachments
-    concatenated, the first message's timestamp (queueing latency stays
-    measurable), the shared source. [None] on [[]]; a singleton is
-    returned unchanged. *)
+    contents joined in arrival order with a blank line, semantic user blocks
+    and attachments concatenated, the first message's timestamp (queueing
+    latency stays measurable), the shared source. [None] on [[]]; a singleton
+    is returned unchanged. *)
 val merge_batch : queued_message list -> queued_message option
 
 (** [length keeper_name] returns the number of queued messages. *)

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -196,6 +196,13 @@ let redaction_for ~base_dir ~keeper_name =
 let redact_attachment redaction att =
   { att with data = Keeper_secret_redaction.redact_text redaction att.data }
 
+let persisted_attachment_ref (att : attachment) =
+  let digest = Digest.to_hex (Digest.string att.data) in
+  Printf.sprintf "masc://attachment/%s/%s" att.id digest
+
+let persisted_attachment (att : attachment) =
+  { att with data = persisted_attachment_ref att }
+
 let redact_tool_call redaction tc =
   { tc with args = Keeper_secret_redaction.redact_text redaction tc.args }
 
@@ -401,6 +408,9 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     let user_attachments =
       List.map (redact_attachment redaction) user_attachments
     in
+    let persisted_user_attachments =
+      List.map persisted_attachment user_attachments
+    in
     let tool_calls = List.map (redact_tool_call redaction) tool_calls in
     let assistant_content =
       Keeper_secret_redaction.redact_text redaction assistant_content
@@ -411,7 +421,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
        assistant lines are the keeper's own output. *)
     let user_line =
       encode_line ~role:Role.User ~content:user_content ~ts
-        ~attachments:user_attachments ?surface ?conversation_id
+        ~attachments:persisted_user_attachments ?surface ?conversation_id
         ?external_message_id ?speaker
         ~mentions:(user_line_mentions ~extra_mentions user_content) ()
     in

--- a/lib/keeper/keeper_multimodal_input.ml
+++ b/lib/keeper/keeper_multimodal_input.ml
@@ -1,0 +1,298 @@
+type user_media_block = {
+  attachment_id : string;
+  name : string;
+  mime_type : string;
+  size : int option;
+}
+
+type user_input_block =
+  | User_text of string
+  | User_image of user_media_block
+  | User_document of user_media_block
+  | User_audio of user_media_block
+
+let attachment_to_yojson (att : Keeper_chat_store.attachment) =
+  `Assoc
+    [ ("id", `String att.Keeper_chat_store.id);
+      ("type", `String att.att_type);
+      ("name", `String att.name);
+      ("size", `Int att.size);
+      ("mime_type", `String att.mime_type);
+      ("data", `String att.data) ]
+
+let attachments_to_yojson attachments =
+  `List (List.map attachment_to_yojson attachments)
+
+let parse_attachment json =
+  match json with
+  | `Assoc _ ->
+      let id =
+        Json_util.get_string_with_default json ~key:"id" ~default:""
+        |> String.trim
+      in
+      let att_type =
+        Json_util.get_string_with_default json ~key:"type" ~default:""
+        |> String.trim
+      in
+      let name =
+        Json_util.get_string_with_default json ~key:"name" ~default:""
+        |> String.trim
+      in
+      let size =
+        match Json_util.assoc_member_opt "size" json with
+        | Some (`Int n) when n >= 0 -> n
+        | _ -> 0
+      in
+      let mime_type =
+        Json_util.get_string_with_default json ~key:"mime_type" ~default:""
+        |> String.trim
+      in
+      let data =
+        Json_util.get_string_with_default json ~key:"data" ~default:""
+      in
+      if id = "" || data = "" then None
+      else
+        Some { Keeper_chat_store.id; att_type; name; size; mime_type; data }
+  | _ -> None
+
+let parse_attachments json =
+  match Json_util.assoc_member_opt "attachments" json with
+  | Some (`List attachments) -> List.filter_map parse_attachment attachments
+  | _ -> []
+
+let user_media_block_to_yojson kind (media : user_media_block) =
+  let fields =
+    [ ("type", `String kind);
+      ("attachment_id", `String media.attachment_id);
+      ("name", `String media.name);
+      ("mime_type", `String media.mime_type) ]
+  in
+  let fields =
+    match media.size with
+    | Some size -> ("size", `Int size) :: fields
+    | None -> fields
+  in
+  `Assoc (List.rev fields)
+
+let user_block_to_yojson = function
+  | User_text text -> `Assoc [ ("type", `String "text"); ("text", `String text) ]
+  | User_image media -> user_media_block_to_yojson "image" media
+  | User_document media -> user_media_block_to_yojson "document" media
+  | User_audio media -> user_media_block_to_yojson "audio" media
+
+let user_blocks_to_yojson blocks =
+  `List (List.map user_block_to_yojson blocks)
+
+let parse_user_media_block ~(kind : string) json =
+  let attachment_id =
+    Json_util.get_string_with_default json ~key:"attachment_id" ~default:""
+    |> String.trim
+  in
+  let name =
+    Json_util.get_string_with_default json ~key:"name" ~default:""
+    |> String.trim
+  in
+  let mime_type =
+    Json_util.get_string_with_default json ~key:"mime_type" ~default:""
+    |> String.trim
+  in
+  let size =
+    match Json_util.assoc_member_opt "size" json with
+    | None | Some `Null -> Ok None
+    | Some (`Int size) when size >= 0 -> Ok (Some size)
+    | Some (`Int _) -> Error "user_blocks media size must be non-negative"
+    | Some _ -> Error "user_blocks media size must be an integer"
+  in
+  if attachment_id = "" then
+    Error (Printf.sprintf "user_blocks %s block requires attachment_id" kind)
+  else
+    match size with
+    | Error err -> Error err
+    | Ok size -> Ok { attachment_id; name; mime_type; size }
+
+let parse_user_input_block json =
+  match json with
+  | `Assoc _ ->
+      let block_type =
+        Json_util.get_string_with_default json ~key:"type" ~default:""
+        |> String.trim
+        |> String.lowercase_ascii
+      in
+      (match block_type with
+       | "text" ->
+           let text =
+             Json_util.get_string_with_default json ~key:"text" ~default:""
+             |> String.trim
+           in
+           if text = "" then
+             Error "user_blocks text block requires non-empty text"
+           else Ok (User_text text)
+       | "image" ->
+           Result.map
+             (fun media -> User_image media)
+             (parse_user_media_block ~kind:"image" json)
+       | "document" ->
+           Result.map
+             (fun media -> User_document media)
+             (parse_user_media_block ~kind:"document" json)
+       | "audio" ->
+           Result.map
+             (fun media -> User_audio media)
+             (parse_user_media_block ~kind:"audio" json)
+       | "" -> Error "user_blocks block requires type"
+       | other ->
+           Error
+             (Printf.sprintf
+                "unsupported user_blocks type %S: expected text, image, document, or audio"
+                other))
+  | _ -> Error "user_blocks entries must be JSON objects"
+
+let parse_user_blocks json =
+  match Json_util.assoc_member_opt "user_blocks" json with
+  | None | Some `Null -> Ok []
+  | Some (`List blocks) ->
+      let rec loop acc = function
+        | [] -> Ok (List.rev acc)
+        | block :: rest -> (
+            match parse_user_input_block block with
+            | Ok parsed -> loop (parsed :: acc) rest
+            | Error err -> Error err)
+      in
+      loop [] blocks
+  | Some _ -> Error "user_blocks must be an array"
+
+let user_media_label (kind : string) (media : user_media_block) =
+  let label =
+    match String.trim media.name with
+    | "" -> media.attachment_id
+    | name -> name
+  in
+  Printf.sprintf "[%s attached: %s]" kind label
+
+let fallback_message_of_attachments attachments =
+  match attachments with
+  | [] -> ""
+  | _ ->
+      attachments
+      |> List.map (fun (att : Keeper_chat_store.attachment) ->
+        let kind =
+          match String.trim att.att_type with
+          | "" -> "file"
+          | att_type -> att_type
+        in
+        let label =
+          match String.trim att.name with
+          | "" -> att.id
+          | name -> name
+        in
+        Printf.sprintf "[%s attached: %s]" kind label)
+      |> String.concat "\n"
+      |> String.trim
+
+let fallback_message ~attachments blocks =
+  let text =
+    blocks
+    |> List.filter_map (function
+      | User_text text ->
+          let text = String.trim text in
+          if text = "" then None else Some text
+      | User_image _ | User_document _ | User_audio _ -> None)
+    |> String.concat "\n\n"
+    |> String.trim
+  in
+  if text <> "" then
+    text
+  else
+    let from_blocks =
+      blocks
+      |> List.filter_map (function
+        | User_text _ -> None
+        | User_image media -> Some (user_media_label "image" media)
+        | User_document media -> Some (user_media_label "document" media)
+        | User_audio media -> Some (user_media_label "audio" media))
+      |> String.concat "\n"
+      |> String.trim
+    in
+    if from_blocks <> "" then from_blocks else fallback_message_of_attachments attachments
+
+let add_unique label labels =
+  if List.exists (String.equal label) labels then labels else labels @ [ label ]
+
+let modalities blocks =
+  List.fold_left
+    (fun acc -> function
+       | User_text _ -> add_unique "text" acc
+       | User_image _ -> add_unique "image" acc
+       | User_document _ -> add_unique "document" acc
+       | User_audio _ -> add_unique "audio" acc)
+    [] blocks
+
+let find_attachment ~attachments attachment_id =
+  List.find_opt
+    (fun (att : Keeper_chat_store.attachment) ->
+       String.equal att.id attachment_id)
+    attachments
+
+let media_type_for media (att : Keeper_chat_store.attachment) =
+  match String.trim media.mime_type with
+  | "" -> (
+      match String.trim att.mime_type with
+      | "" -> "application/octet-stream"
+      | mime_type -> mime_type)
+  | mime_type -> mime_type
+
+let media_block_to_oas ~attachments kind make_block media =
+  match find_attachment ~attachments media.attachment_id with
+  | None ->
+      Error
+        (Printf.sprintf
+           "missing attachment payload for %s user block %S"
+           kind media.attachment_id)
+  | Some att ->
+      let data = String.trim att.data in
+      if data = "" then
+        Error
+          (Printf.sprintf
+             "empty attachment payload for %s user block %S"
+             kind media.attachment_id)
+      else
+        Ok (make_block ~media_type:(media_type_for media att) ~data ())
+
+let to_oas_blocks ~attachments blocks =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | User_text text :: rest ->
+        let text = String.trim text in
+        let acc =
+          if text = "" then acc else Agent_sdk.Types.Text text :: acc
+        in
+        loop acc rest
+    | User_image media :: rest -> (
+        match
+          media_block_to_oas ~attachments "image"
+            (fun ~media_type ~data () ->
+               Agent_sdk.Types.image_block ~media_type ~data ())
+            media
+        with
+        | Ok block -> loop (block :: acc) rest
+        | Error err -> Error err)
+    | User_document media :: rest -> (
+        match
+          media_block_to_oas ~attachments "document"
+            (fun ~media_type ~data () ->
+               Agent_sdk.Types.document_block ~media_type ~data ())
+            media
+        with
+        | Ok block -> loop (block :: acc) rest
+        | Error err -> Error err)
+    | User_audio media :: rest -> (
+        match
+          media_block_to_oas ~attachments "audio"
+            (fun ~media_type ~data () ->
+               Agent_sdk.Types.audio_block ~media_type ~data ())
+            media
+        with
+        | Ok block -> loop (block :: acc) rest
+        | Error err -> Error err)
+  in
+  loop [] blocks

--- a/lib/keeper/keeper_multimodal_input.mli
+++ b/lib/keeper/keeper_multimodal_input.mli
@@ -1,0 +1,48 @@
+(** Keeper_multimodal_input — MASC-side semantic user input blocks.
+
+    This module owns the dashboard/connector input contract before it crosses
+    into OAS.  It is intentionally distinct from dashboard rich-render blocks
+    and from OAS provider blocks. *)
+
+type user_media_block = {
+  attachment_id : string;
+  name : string;
+  mime_type : string;
+  size : int option;
+}
+
+type user_input_block =
+  | User_text of string
+  | User_image of user_media_block
+  | User_document of user_media_block
+  | User_audio of user_media_block
+
+val attachment_to_yojson : Keeper_chat_store.attachment -> Yojson.Safe.t
+
+val attachments_to_yojson : Keeper_chat_store.attachment list -> Yojson.Safe.t
+
+val parse_attachments : Yojson.Safe.t -> Keeper_chat_store.attachment list
+(** Parse optional [attachments] from a request/tool argument object.  Malformed
+    attachment entries are ignored, matching the historical chat stream
+    behavior; referenced-but-missing media is rejected later by {!to_oas_blocks}. *)
+
+val user_blocks_to_yojson : user_input_block list -> Yojson.Safe.t
+
+val parse_user_blocks : Yojson.Safe.t -> (user_input_block list, string) result
+(** Parse the optional [user_blocks] request field.  Unknown block types and
+    malformed media refs are request errors, not silently ignored. *)
+
+val fallback_message :
+  attachments:Keeper_chat_store.attachment list -> user_input_block list -> string
+(** Text fallback for the existing string-only keeper turn path.  Raw media data
+    is never included. *)
+
+val modalities : user_input_block list -> string list
+(** Stable, duplicate-free modality labels present in the input. *)
+
+val to_oas_blocks :
+  attachments:Keeper_chat_store.attachment list ->
+  user_input_block list ->
+  (Agent_sdk.Types.content_block list, string) result
+(** Convert semantic MASC input blocks to OAS provider input blocks.  Media
+    blocks resolve their raw payload through [attachments] by [attachment_id]. *)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -215,6 +215,17 @@ let keeper_msg_timeout_override args =
       Ok (Some timeout_sec)
   | Some _ -> Error "timeout_sec must be a positive finite number"
 
+let user_oas_blocks_of_args args =
+  match Keeper_multimodal_input.parse_user_blocks args with
+  | Error err -> Error err
+  | Ok [] -> Ok None
+  | Ok user_blocks ->
+      let attachments = Keeper_multimodal_input.parse_attachments args in
+      match Keeper_multimodal_input.to_oas_blocks ~attachments user_blocks with
+      | Error err -> Error err
+      | Ok [] -> Ok None
+      | Ok blocks -> Ok (Some blocks)
+
 let preflight_keeper_msg ctx args : (unit, string) result =
   let name = get_string args "name" "" in
   let message = get_string args "message" "" in
@@ -240,6 +251,9 @@ let preflight_keeper_msg ctx args : (unit, string) result =
     (match reject_removed_keeper_msg_input_keys ~tool_name:"masc_keeper_msg" args with
     | Error e -> Error e
     | Ok () ->
+    (match user_oas_blocks_of_args args with
+    | Error e -> Error e
+    | Ok _ ->
     match ensure_keeper_exists ~ctx ~name with
     | Error e -> Error e
     | Ok meta ->
@@ -256,7 +270,7 @@ let preflight_keeper_msg ctx args : (unit, string) result =
         match Keeper_types_support.ensure_api_keys_for_labels effective_models with
         | Error e -> Error e
         | Ok () ->
-          Keeper_turn_helpers.ensure_local_discovery_ready effective_models)))
+          Keeper_turn_helpers.ensure_local_discovery_ready effective_models))))
 
 (* -- Direct-message turn FSM wrapper ---------------------------------------- *)
 
@@ -416,6 +430,9 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
     (match reject_removed_keeper_msg_input_keys ~tool_name:"masc_keeper_msg" args with
     | Error e -> tool_result_error ("" ^ e)
     | Ok () ->
+    (match user_oas_blocks_of_args args with
+    | Error e -> tool_result_error ("" ^ e)
+    | Ok user_blocks ->
     match ensure_keeper_exists
       ~ctx ~name
     with
@@ -712,6 +729,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
                          ~max_context:max_runtime_context
                          ~build_turn_prompt
                          ~user_message:message
+                         ?user_blocks
                          ~runtime_id:
                            (                         (turn_runtime_id))
                          ~world_observation
@@ -946,7 +964,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
               in
               tool_result_ok (Yojson.Safe.to_string reply_json)
 
-)))))))
+))))))))
 
 let handle_keeper_msg ?on_text_delta ?on_event ctx args : tool_result =
   let name = get_string args "name" "" in

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -42,6 +42,7 @@ let run_named
     ~runtime_id
     ?(keeper_name = "")
     ~goal
+    ?goal_blocks
     ?priority
     ?session_id
     ?(system_prompt = "")
@@ -149,6 +150,7 @@ let run_named
     keeper_name;
     name;
     goal;
+    goal_blocks;
     priority;
     session_id;
     system_prompt;

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -93,6 +93,7 @@ val run_named :
   runtime_id:string ->
   ?keeper_name:string ->
   goal:string ->
+  ?goal_blocks:Agent_sdk.Types.content_block list ->
   ?priority:Llm_provider.Request_priority.t ->
   ?session_id:string ->
   ?system_prompt:string ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -23,6 +23,7 @@ type try_provider_ctx =
   ; name : string
   ; (* Agent config — fields passed through the runtime candidate boundary. *)
     goal : string
+  ; goal_blocks : Agent_sdk.Types.content_block list option
   ; priority : Llm_provider.Request_priority.t option
   ; session_id : string option
   ; system_prompt : string
@@ -410,16 +411,30 @@ let run_try_provider
         in
         let run_fn () =
           Eio_guard.check_if_ready ();
-          Runtime_agent.run
-            ~sw:attempt_sw
-            ~net:ctx.net
-            ~config
-            ?oas_checkpoint:effective_checkpoint
-            ?on_event:ctx.on_event
-            ?on_yield:ctx.on_yield
-            ?on_resume:ctx.on_resume
-            ~agent_ref:local_agent_ref
-            ctx.goal
+          match ctx.goal_blocks with
+          | Some blocks ->
+              Runtime_agent.run_blocks
+                ~sw:attempt_sw
+                ~net:ctx.net
+                ~config
+                ?oas_checkpoint:effective_checkpoint
+                ?on_event:ctx.on_event
+                ?on_yield:ctx.on_yield
+                ?on_resume:ctx.on_resume
+                ~agent_ref:local_agent_ref
+                ~goal_detail:ctx.goal
+                blocks
+          | None ->
+              Runtime_agent.run
+                ~sw:attempt_sw
+                ~net:ctx.net
+                ~config
+                ?oas_checkpoint:effective_checkpoint
+                ?on_event:ctx.on_event
+                ?on_yield:ctx.on_yield
+                ?on_resume:ctx.on_resume
+                ~agent_ref:local_agent_ref
+                ctx.goal
         in
         (* Do not wrap [Runtime_agent.run] in a MASC wall-clock timeout here.
            OAS provider stream/body timeouts and tool-local subprocess budgets

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -6,6 +6,7 @@ type try_provider_ctx =
   ; keeper_name : string
   ; name : string
   ; goal : string
+  ; goal_blocks : Agent_sdk.Types.content_block list option
   ; priority : Llm_provider.Request_priority.t option
   ; session_id : string option
   ; system_prompt : string

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -349,6 +349,139 @@ let resolve_clock_for_idle ~(stream_idle_timeout_s : float option) =
     ~ctx_clock:(Eio_context.get_clock_opt ())
 ;;
 
+let add_unique_string value values =
+  if List.exists (String.equal value) values then values else values @ [ value ]
+
+let rec required_modalities_of_content_blocks
+    (blocks : Agent_sdk.Types.content_block list) =
+  List.fold_left
+    (fun acc block ->
+       match block with
+       | Agent_sdk.Types.Text _
+       | Agent_sdk.Types.Thinking _
+       | Agent_sdk.Types.RedactedThinking _
+       | Agent_sdk.Types.ToolUse _ ->
+           acc
+       | Agent_sdk.Types.Image _ -> add_unique_string "image" acc
+       | Agent_sdk.Types.Document _ -> add_unique_string "document" acc
+       | Agent_sdk.Types.Audio _ -> add_unique_string "audio" acc
+       | Agent_sdk.Types.ToolResult { content_blocks = Some blocks; _ } ->
+           List.fold_left
+             (fun acc modality -> add_unique_string modality acc)
+             acc
+             (required_modalities_of_content_blocks blocks)
+       | Agent_sdk.Types.ToolResult { content_blocks = None; _ } -> acc)
+    [] blocks
+
+let supported_modalities_of_capabilities
+    (caps : Llm_provider.Capabilities.capabilities) =
+  [ "text" ]
+  @ (if caps.supports_image_input then [ "image" ] else [])
+  @ (if caps.supports_multimodal_inputs then [ "document" ] else [])
+  @ (if caps.supports_audio_input then [ "audio" ] else [])
+
+let supports_required_modality
+    (caps : Llm_provider.Capabilities.capabilities) = function
+  | "image" -> caps.supports_image_input
+  | "document" -> caps.supports_multimodal_inputs
+  | "audio" -> caps.supports_audio_input
+  | _ -> true
+
+let supported_non_text_capability_count
+    (caps : Llm_provider.Capabilities.capabilities) =
+  List.fold_left
+    (fun count supported -> if supported then count + 1 else count)
+    0
+    [ caps.supports_image_input
+    ; caps.supports_audio_input
+    ; caps.supports_video_input
+    ]
+
+let supports_multimodal_bundle
+    (caps : Llm_provider.Capabilities.capabilities) =
+  caps.supports_multimodal_inputs || supported_non_text_capability_count caps > 1
+
+let multimodal_capability_error ~provider_label ~required ~supported ~reason =
+  let render = function
+    | [] -> "none"
+    | values -> String.concat "," values
+  in
+  Agent_sdk.Error.Config
+    (Agent_sdk.Error.InvalidConfig
+       { field = "multimodal_input"
+       ; detail =
+           Printf.sprintf
+             "provider %s cannot accept requested multimodal input: %s \
+              (required=%s supported=%s)"
+             provider_label
+             reason
+             (render required)
+             (render supported)
+       })
+
+let validate_content_blocks_against_capabilities
+    ~(provider_label : string)
+    (caps : Llm_provider.Capabilities.capabilities)
+    (blocks : Agent_sdk.Types.content_block list) =
+  let required = required_modalities_of_content_blocks blocks in
+  let supported = supported_modalities_of_capabilities caps in
+  match
+    List.filter
+      (fun modality -> not (supports_required_modality caps modality))
+      required
+  with
+  | unsupported :: _ ->
+      Error
+        (multimodal_capability_error
+           ~provider_label
+           ~required
+           ~supported
+           ~reason:(Printf.sprintf "unsupported %s input" unsupported))
+  | [] ->
+      if List.length required <= 1 || supports_multimodal_bundle caps then
+        Ok ()
+      else
+        Error
+          (multimodal_capability_error
+             ~provider_label
+             ~required
+             ~supported
+             ~reason:"provider does not support combined non-text modalities")
+
+let apply_runtime_model_input_capabilities
+    (caps : Llm_provider.Capabilities.capabilities)
+    (model_caps : Runtime_schema.model_capabilities) =
+  (* Runtime model specs are the MASC SSOT for concrete media input support.
+     Provider-level caps may be broader than the selected model; media input
+     must fail closed before dispatch rather than letting a provider 400 leak
+     back as a late runtime error. *)
+  { caps with
+    supports_multimodal_inputs = model_caps.supports_multimodal_inputs;
+    supports_image_input = model_caps.supports_image_input;
+    supports_audio_input = model_caps.supports_audio_input;
+    supports_video_input = model_caps.supports_video_input;
+  }
+
+let input_capabilities_for_config (config : config) =
+  let caps = provider_caps_of_config config.provider_cfg in
+  match Runtime.get_runtime_by_id (runtime_id_of_config config) with
+  | None -> caps
+  | Some runtime ->
+      let model_caps =
+        Option.value
+          runtime.model.capabilities
+          ~default:Runtime_schema.model_capabilities_default
+      in
+      apply_runtime_model_input_capabilities caps model_caps
+
+let validate_content_blocks_for_config
+    ~(config : config)
+    (blocks : Agent_sdk.Types.content_block list) =
+  validate_content_blocks_against_capabilities
+    ~provider_label:(provider_label config.provider_cfg)
+    (input_capabilities_for_config config)
+    blocks
+
 module For_testing = struct
   let request_runtime_fields_on_base_config =
     request_runtime_fields_on_base_config
@@ -360,6 +493,11 @@ module For_testing = struct
   let runtime_observation_for_terminal_config =
     runtime_observation_for_terminal_config
   let decide_clock_for_idle = decide_clock_for_idle
+  let required_modalities_of_content_blocks = required_modalities_of_content_blocks
+  let validate_content_blocks_against_capabilities =
+    validate_content_blocks_against_capabilities
+  let apply_runtime_model_input_capabilities =
+    apply_runtime_model_input_capabilities
 end
 
 (* ================================================================ *)
@@ -551,7 +689,30 @@ let resume_from_checkpoint
 (* Run                                                               *)
 (* ================================================================ *)
 
-let run
+let content_block_detail (block : Agent_sdk.Types.content_block) =
+  match block with
+  | Agent_sdk.Types.Text text -> text
+  | Agent_sdk.Types.Thinking _ -> "[thinking block omitted]"
+  | Agent_sdk.Types.RedactedThinking _ -> "[redacted thinking block omitted]"
+  | Agent_sdk.Types.ToolUse { name; _ } ->
+      Printf.sprintf "[tool use block: %s]" name
+  | Agent_sdk.Types.ToolResult { is_error; _ } ->
+      if is_error then "[tool result block: error]"
+      else "[tool result block]"
+  | Agent_sdk.Types.Image { media_type; data; _ } ->
+      Printf.sprintf "[image:%s data_chars=%d]" media_type (String.length data)
+  | Agent_sdk.Types.Document { media_type; data; _ } ->
+      Printf.sprintf "[document:%s data_chars=%d]" media_type (String.length data)
+  | Agent_sdk.Types.Audio { media_type; data; _ } ->
+      Printf.sprintf "[audio:%s data_chars=%d]" media_type (String.length data)
+
+let content_blocks_detail (blocks : Agent_sdk.Types.content_block list) =
+  blocks
+  |> List.map content_block_detail
+  |> String.concat "\n"
+  |> String.trim
+
+let run_blocks
     ~(sw : Eio.Switch.t)
     ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(config : config)
@@ -560,8 +721,21 @@ let run
     ?(on_yield : (unit -> unit) option)
     ?(on_resume : (unit -> unit) option)
     ?(agent_ref : Agent_sdk.Agent.t option ref option)
-    (goal : string)
+    ?goal_detail
+    (goal_blocks : Agent_sdk.Types.content_block list)
   : (run_result, Agent_sdk.Error.sdk_error) result =
+  match
+    validate_content_blocks_for_config
+      ~config
+      goal_blocks
+  with
+  | Error _ as err -> err
+  | Ok () ->
+  let goal_detail =
+    match goal_detail with
+    | Some detail -> detail
+    | None -> content_blocks_detail goal_blocks
+  in
   let session_id = match config.session_id with
     | Some id -> id
     | None ->
@@ -576,7 +750,7 @@ let run
     Log.Misc.info "oas_worker %s: transport=%s"
       config.name (Masc_grpc_transport.to_string t));
   Option.iter (fun bus ->
-    publish_lifecycle bus ~name:config.name ~event:"build" ~detail:goal
+    publish_lifecycle bus ~name:config.name ~event:"build" ~detail:goal_detail
       ~attrs:(provider_lifecycle_attrs config)
       ()
   ) config.event_bus;
@@ -627,8 +801,12 @@ let run
         ]
         (fun _trace_id ->
           match on_event with
-          | Some cb -> Agent_sdk.Agent.run_stream ~sw ?clock ?on_yield ?on_resume ~on_event:cb agent goal
-          | None -> Agent_sdk.Agent.run ~sw ?clock ?on_yield ?on_resume agent goal)
+          | Some cb ->
+              Agent_sdk.Agent.run_stream_blocks ~sw ?clock ?on_yield ?on_resume
+                ~on_event:cb agent goal_blocks
+          | None ->
+              Agent_sdk.Agent.run_blocks ~sw ?clock ?on_yield ?on_resume agent
+                goal_blocks)
     in
     let run_total_duration_ms = run_duration_ms_since run_started_at in
     let checkpoint =
@@ -856,6 +1034,20 @@ let run
             ])
     in
     Error (Agent_sdk.Error.Internal typed_internal_error))
+
+let run
+    ~(sw : Eio.Switch.t)
+    ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
+    ~(config : config)
+    ?oas_checkpoint
+    ?on_event
+    ?on_yield
+    ?on_resume
+    ?agent_ref
+    (goal : string)
+  : (run_result, Agent_sdk.Error.sdk_error) result =
+  run_blocks ~sw ~net ~config ?oas_checkpoint ?on_event ?on_yield ?on_resume
+    ?agent_ref ~goal_detail:goal [Agent_sdk.Types.Text goal]
 
 (* ================================================================ *)
 (* Convenience: run_with_masc_tools                                  *)

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -209,6 +209,20 @@ module For_testing : sig
     ctx_clock:float Eio.Time.clock_ty Eio.Resource.t option ->
     float Eio.Time.clock_ty Eio.Resource.t option
 
+  val required_modalities_of_content_blocks :
+    Agent_sdk.Types.content_block list -> string list
+
+  val validate_content_blocks_against_capabilities :
+    provider_label:string ->
+    Llm_provider.Capabilities.capabilities ->
+    Agent_sdk.Types.content_block list ->
+    (unit, Agent_sdk.Error.sdk_error) result
+
+  val apply_runtime_model_input_capabilities :
+    Llm_provider.Capabilities.capabilities ->
+    Runtime_schema.model_capabilities ->
+    Llm_provider.Capabilities.capabilities
+
   val runtime_observation_for_completed_config :
     total_duration_ms:float -> config -> Runtime_observation.runtime_observation
 
@@ -272,6 +286,22 @@ val run :
     is used; otherwise {!build} produces a fresh agent.
     Returns the wrapped {!run_result}; errors propagate
     as [Agent_sdk.Error.sdk_error]. *)
+
+val run_blocks :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  config:config ->
+  ?oas_checkpoint:Agent_sdk.Checkpoint.t ->
+  ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
+  ?on_yield:(unit -> unit) ->
+  ?on_resume:(unit -> unit) ->
+  ?agent_ref:Agent_sdk.Agent.t option ref ->
+  ?goal_detail:string ->
+  Agent_sdk.Types.content_block list ->
+  (run_result, Agent_sdk.Error.sdk_error) result
+(** Runs an OAS agent against structured user-authored content blocks.  The
+    optional [goal_detail] is a display/log fallback only; media payloads stay
+    in typed OAS blocks and are not rendered into lifecycle strings. *)
 
 val run_with_masc_tools :
   sw:Eio.Switch.t ->

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -931,6 +931,7 @@ let start_keeper_loops
                  channel_user_id = projection.payload_channel_user_id;
                  channel_user_name = projection.payload_channel_user_name;
                  channel_workspace_id = projection.payload_channel_workspace_id;
+                 user_blocks = queued_message.user_blocks;
                  attachments = queued_message.attachments;
                }
              in
@@ -1000,7 +1001,7 @@ let start_keeper_loops
                           skipping Slack delivery for keeper=%s"
                          keeper_name));
              process_single_turn ~state ~clock ~sw ~auth_token:None
-               ~thread_id ~closed ~payload ~run_id ~message_id
+               ~thread_id ~closed ~client_disconnects:None ~payload ~run_id ~message_id
                ~agent_name ~events)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -4,9 +4,23 @@ open Server_auth
 module Http = Http_server_eio
 module Mcp_eio = Mcp_server_eio
 
+type user_media_block = Keeper_multimodal_input.user_media_block = {
+  attachment_id : string;
+  name : string;
+  mime_type : string;
+  size : int option;
+}
+
+type user_input_block = Keeper_multimodal_input.user_input_block =
+  | User_text of string
+  | User_image of user_media_block
+  | User_document of user_media_block
+  | User_audio of user_media_block
+
 type keeper_chat_stream_request = {
   name : string;
   message : string;
+  user_blocks : user_input_block list;
   timeout_sec : int option;
   turn_instructions : string option;
   surface_context : Yojson.Safe.t option;
@@ -85,15 +99,6 @@ let turn_instructions_for_request payload =
       if ctx_text = "" then Some ti
       else Some (ti ^ "\n\n" ^ ctx_text)
 
-let attachment_json (att : Keeper_chat_store.attachment) =
-  `Assoc
-    [ ("id", `String att.Keeper_chat_store.id);
-      ("type", `String att.att_type);
-      ("name", `String att.name);
-      ("size", `Int att.size);
-      ("mime_type", `String att.mime_type);
-      ("data", `String att.data) ]
-
 let args_of_request payload : Yojson.Safe.t =
   let message = message_for_request payload in
   let base_fields =
@@ -125,9 +130,22 @@ let args_of_request payload : Yojson.Safe.t =
      else [])
   in
   let fields = base_fields @ connector_fields in
+  let fields =
+    if payload.user_blocks = [] then fields
+    else
+      ("user_blocks", Keeper_multimodal_input.user_blocks_to_yojson payload.user_blocks)
+      :: fields
+  in
   `Assoc
     (if payload.attachments = [] then fields
-     else ("attachments", `List (List.map attachment_json payload.attachments)) :: fields)
+     else
+       ("attachments", Keeper_multimodal_input.attachments_to_yojson payload.attachments)
+       :: fields)
+
+let modalities_for_request payload =
+  match Keeper_multimodal_input.modalities payload.user_blocks with
+  | [] -> [ "text" ]
+  | labels -> labels
 
 let keeper_chat_request_prefixes =
   [
@@ -300,7 +318,7 @@ let parse_keeper_chat_stream_request body_str =
       Error "request body must be a JSON object"
     else
       let name = Json_util.get_string_with_default json ~key:"name" ~default:"" |> String.trim in
-      let message =
+      let raw_message =
         Json_util.get_string_with_default json ~key:"message" ~default:""
         |> String.trim
       in
@@ -348,45 +366,16 @@ let parse_keeper_chat_stream_request body_str =
         | Some (`Int _) | Some (`Float _) -> Ok None
         | Some _ -> Error "timeout_sec must be a positive number"
       in
-      let attachments : Keeper_chat_store.attachment list =
-        match Json_util.assoc_member_opt "attachments" json with
-        | Some (`List att_list) ->
-            List.filter_map
-              (fun att_json ->
-                match att_json with
-                | `Assoc _ -> (
-                    try
-                      let id =
-                        Json_util.get_string_with_default att_json ~key:"id" ~default:""
-                      in
-                      let att_type =
-                        Json_util.get_string_with_default att_json ~key:"type" ~default:""
-                      in
-                      let name =
-                        Json_util.get_string_with_default att_json ~key:"name" ~default:""
-                      in
-                      let size =
-                        match Json_util.assoc_member_opt "size" att_json with
-                        | Some (`Int i) -> i
-                        | _ -> 0
-                      in
-                      let mime_type =
-                        Json_util.get_string_with_default att_json ~key:"mime_type" ~default:""
-                      in
-                      let data =
-                        Json_util.get_string_with_default att_json ~key:"data" ~default:""
-                      in
-                      if id = "" || data = "" then None
-                      else Some { Keeper_chat_store.id; att_type; name; size; mime_type; data }
-                    with _ -> None)
-                | _ -> None)
-              att_list
-        | _ -> []
+      let attachments = Keeper_multimodal_input.parse_attachments json in
+      let user_blocks_result = Keeper_multimodal_input.parse_user_blocks json in
+      let message_of_blocks user_blocks =
+        match raw_message with
+        | "" ->
+            Keeper_multimodal_input.fallback_message ~attachments user_blocks
+        | message -> message
       in
       if name = "" then
         Error "name is required"
-      else if message = "" then
-        Error "message is required"
       else if has_connector_context
               && (channel = "" || channel_workspace_id = "")
       then
@@ -398,12 +387,19 @@ let parse_keeper_chat_stream_request body_str =
         with
         | Error err -> Error err
         | Ok () -> (
-          match timeout_sec with
-          | Ok timeout_sec ->
+          match user_blocks_result, timeout_sec with
+          | Error err, _ -> Error err
+          | Ok _, Error err -> Error err
+          | Ok user_blocks, Ok timeout_sec ->
+              let message = message_of_blocks user_blocks in
+              if message = "" then
+                Error "message is required"
+              else
               Ok
                 {
                   name;
                   message;
+                  user_blocks;
                   timeout_sec;
                   turn_instructions;
                   surface_context;
@@ -413,7 +409,7 @@ let parse_keeper_chat_stream_request body_str =
                   channel_workspace_id;
                   attachments;
                 }
-          | Error err -> Error err )
+          )
   with Yojson.Json_error e ->
     Error ("invalid json: " ^ e)
 
@@ -470,9 +466,20 @@ let split_keeper_reply_chunks (text : string) : string list =
       chunks := String.sub text !start (len - !start) :: !chunks;
     List.rev !chunks |> List.filter (fun chunk -> String.trim chunk <> "")
 
-let keeper_stream_send_raw writer mutex closed data =
-  if !closed || Httpun.Body.Writer.is_closed writer then begin
+let notify_closed on_closed =
+  match on_closed with
+  | None -> ()
+  | Some f -> f ()
+
+let mark_closed ?on_closed closed =
+  if not !closed then begin
     closed := true;
+    notify_closed on_closed
+  end
+
+let keeper_stream_send_raw ?on_closed writer mutex closed data =
+  if !closed || Httpun.Body.Writer.is_closed writer then begin
+    mark_closed ?on_closed closed;
     false
   end else
     try
@@ -484,11 +491,11 @@ let keeper_stream_send_raw writer mutex closed data =
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
       Log.Keeper.warn "keeper_stream_send_raw write failed: %s" (Printexc.to_string exn);
-      closed := true;
+      mark_closed ?on_closed closed;
       false
 
-let keeper_stream_send_event writer mutex closed event =
-  keeper_stream_send_raw writer mutex closed (Ag_ui.event_to_sse event)
+let keeper_stream_send_event ?on_closed writer mutex closed event =
+  keeper_stream_send_raw ?on_closed writer mutex closed (Ag_ui.event_to_sse event)
 
 (** Execute keeper dispatch with real-time streaming.
     Calls [dispatch_stream] which forwards MODEL text deltas to [on_text_delta].
@@ -569,9 +576,9 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ ?on_event stat
   (success, body)
 
 (** Send a Run_error AG-UI event with the given message. *)
-let send_keeper_error writer mutex closed ~thread_id ~run_id err =
+let send_keeper_error ?on_closed writer mutex closed ~thread_id ~run_id err =
   ignore
-    (keeper_stream_send_event writer mutex closed
+    (keeper_stream_send_event ?on_closed writer mutex closed
        Ag_ui.(
          make_event ~thread_id ~run_id:(Some run_id)
            ~custom_name:(Some "KEEPER_CHAT_ERROR")
@@ -635,6 +642,7 @@ type keeper_stream_worker_event =
   | Stream_terminal of bool * string
 
 let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
+    ~client_disconnects
     ~payload ~run_id ~message_id ~agent_name
     ~(events : Keeper_chat_events.keeper_chat_event Eio.Stream.t) =
   let base_path = (Mcp_server.workspace_config state).base_path in
@@ -656,15 +664,27 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
      #20869 history this guards against. *)
   let text_accum = Keeper_stream_text_accum.create () in
   let worker_events = Eio.Stream.create 512 in
+  let terminal_pushed = Atomic.make false in
   let push_worker_event event =
-    if not !closed then
-      try Eio.Stream.add worker_events event
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-          Log.Keeper.warn
-            "keeper_stream: worker event push failed: %s"
-            (Printexc.to_string exn)
+    match event with
+    | Stream_terminal _ ->
+        if Atomic.compare_and_set terminal_pushed false true then
+          (try Eio.Stream.add worker_events event
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+               Log.Keeper.warn
+                 "keeper_stream: worker terminal push failed: %s"
+                 (Printexc.to_string exn))
+    | Stream_event _ ->
+        if not !closed then
+          try Eio.Stream.add worker_events event
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+              Log.Keeper.warn
+                "keeper_stream: worker event push failed: %s"
+                (Printexc.to_string exn)
   in
   (* Mirror tool-call SDK events flowing through [on_event] so the
      completed turn persists tool lines alongside the user/assistant
@@ -792,6 +812,18 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
             Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err)
       ()
   in
+  (match client_disconnects with
+   | None -> ()
+   | Some disconnects ->
+       Eio.Fiber.fork ~sw (fun () ->
+         let _ = Eio.Stream.take disconnects in
+         if not (Atomic.get terminal_pushed) then begin
+           (* fire-and-forget: disconnect cleanup must not block terminal event emission. *)
+           ignore (Keeper_msg_async.cancel ~base_path request_id);
+           push_worker_event
+             (Stream_terminal
+                (false, "keeper chat stream closed by client"))
+         end));
   Log.Keeper.info
     "keeper_stream: queued request keeper=%s request_id=%s surface=%s"
     payload.name request_id
@@ -809,7 +841,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
                   else "dashboard");
                actor_id = Some agent_name;
                status = Gate_protocol.Queued;
-               modalities = [ "text" ];
+               modalities = modalities_for_request payload;
                transport = Some "sse";
                metadata =
                  [
@@ -949,6 +981,14 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let writer = Httpun.Reqd.respond_with_streaming reqd response in
   let mutex = Eio.Mutex.create () in
   let closed = ref false in
+  let client_disconnects = Eio.Stream.create 1 in
+  let disconnect_notified = ref false in
+  let notify_disconnect () =
+    if not !disconnect_notified then begin
+      disconnect_notified := true;
+      Eio.Stream.add client_disconnects ()
+    end
+  in
   let close_stream () =
     if not !closed then begin
       closed := true;
@@ -963,7 +1003,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let now_id () = int_of_float (Time_compat.now () *. 1000.0) in
   let thread_id = "keeper:" ^ payload.name in
 
-  let sse_adapter_loop ~events ~writer ~mutex ~closed =
+  let sse_adapter_loop ~events ~writer ~mutex ~closed ~on_closed =
     let current_thread_id = ref Ag_ui.default_thread_id in
     let current_run_id = ref None in
     let current_message_id = ref None in
@@ -976,11 +1016,11 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
       let message = redact_text message in
       match !current_run_id with
       | Some run_id ->
-          send_keeper_error writer mutex closed ~thread_id:!current_thread_id
-            ~run_id message
+          send_keeper_error ~on_closed writer mutex closed
+            ~thread_id:!current_thread_id ~run_id message
       | None ->
           ignore
-            (keeper_stream_send_event writer mutex closed
+            (keeper_stream_send_event ~on_closed writer mutex closed
                Ag_ui.(
                  make_event ~thread_id:!current_thread_id
                    ~custom_name:(Some "KEEPER_CHAT_ERROR")
@@ -994,13 +1034,13 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
             current_thread_id := thread_id;
             current_run_id := Some run_id;
             if
-              keeper_stream_send_event writer mutex closed
+              keeper_stream_send_event ~on_closed writer mutex closed
                 Ag_ui.(make_event ~thread_id ~run_id:(Some run_id) Run_started)
             then loop ()
         | Text_message_start { message_id; role } ->
             current_message_id := Some message_id;
             if
-              keeper_stream_send_event writer mutex closed
+              keeper_stream_send_event ~on_closed writer mutex closed
                 Ag_ui.(
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
                     ~message_id:(Some message_id) ~role:(Some (ag_role role))
@@ -1014,7 +1054,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                regex cost with no effect (redact is idempotent on already-
                redacted text).  Do not re-redact. *)
             if
-              keeper_stream_send_event writer mutex closed
+              keeper_stream_send_event ~on_closed writer mutex closed
                 Ag_ui.(
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
                     ~message_id:!current_message_id
@@ -1023,14 +1063,14 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
             then loop ()
         | Text_message_end ->
             if
-              keeper_stream_send_event writer mutex closed
+              keeper_stream_send_event ~on_closed writer mutex closed
                 Ag_ui.(
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
                     ~message_id:!current_message_id Text_message_end)
             then loop ()
         | Custom { name; value } ->
             if
-              keeper_stream_send_event writer mutex closed
+              keeper_stream_send_event ~on_closed writer mutex closed
                 Ag_ui.(
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
                     ~custom_name:(Some name)
@@ -1039,7 +1079,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
             then loop ()
         | Tool_call_start { tool_call_id; tool_call_name } ->
             if
-              keeper_stream_send_event writer mutex closed
+              keeper_stream_send_event ~on_closed writer mutex closed
                 Ag_ui.(
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
                     ~tool_call_id:(Some tool_call_id) ~tool_call_name:(Some tool_call_name)
@@ -1049,7 +1089,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
             (* [delta] is already redacted at publish
                ([Tool_call_args { delta = redact_text args; _ }]).  *)
             if
-              keeper_stream_send_event writer mutex closed
+              keeper_stream_send_event ~on_closed writer mutex closed
                 Ag_ui.(
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
                     ~tool_call_id:(Some tool_call_id)
@@ -1058,7 +1098,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
             then loop ()
         | Tool_call_end { tool_call_id } ->
             if
-              keeper_stream_send_event writer mutex closed
+              keeper_stream_send_event ~on_closed writer mutex closed
                 Ag_ui.(
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
                     ~tool_call_id:(Some tool_call_id)
@@ -1072,7 +1112,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
         | Run_finished { run_id } ->
             current_run_id := Some run_id;
             ignore
-              (keeper_stream_send_event writer mutex closed
+              (keeper_stream_send_event ~on_closed writer mutex closed
                  Ag_ui.(
                    make_event ~thread_id:!current_thread_id ~run_id:(Some run_id)
                      Run_finished))
@@ -1081,7 +1121,9 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   in
 
 
-  ignore (keeper_stream_send_raw writer mutex closed "retry: 1500\n\n");
+  ignore
+    (keeper_stream_send_raw ~on_closed:notify_disconnect writer mutex closed
+       "retry: 1500\n\n");
   Eio.Fiber.fork ~sw (fun () ->
       ignore
         (Eio.Switch.run @@ fun stream_sw ->
@@ -1104,10 +1146,12 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
            let message_id = Printf.sprintf "keeper-msg-%d" (now_id ()) in
            let events = Keeper_chat_events.create () in
            Eio.Fiber.fork ~sw:stream_sw (fun () ->
-             sse_adapter_loop ~events ~writer ~mutex ~closed);
-           process_single_turn ~state ~clock ~sw
+             sse_adapter_loop ~events ~writer ~mutex ~closed
+               ~on_closed:notify_disconnect);
+           process_single_turn ~state ~clock ~sw:stream_sw
              ~auth_token:(auth_token_from_request request)
              ~thread_id ~closed
+             ~client_disconnects:(Some client_disconnects)
              ~payload ~run_id ~message_id ~agent_name ~events;
            (* Queue drain is now handled by Keeper_chat_consumer
               (started in server_bootstrap_loops). *)
@@ -1124,6 +1168,7 @@ module For_testing = struct
   let chat_speaker_of_request = chat_speaker_of_request
   let turn_instructions_for_request = turn_instructions_for_request
   let args_of_request = args_of_request
+  let modalities_for_request = modalities_for_request
   let format_surface_context = format_surface_context
   let surface_context_to_instructions = surface_context_to_instructions
 end

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -40,9 +40,30 @@
 
 (** {1 Request record} *)
 
+type user_media_block = Keeper_multimodal_input.user_media_block = {
+  attachment_id : string;
+  name : string;
+  mime_type : string;
+  size : int option;
+}
+(** Media user input block carried by the dashboard stream request.
+    [attachment_id] points at an entry in [attachments]; raw media stays
+    in the attachment payload for the current dashboard contract and is
+    not mixed into the text [message]. *)
+
+type user_input_block = Keeper_multimodal_input.user_input_block =
+  | User_text of string
+  | User_image of user_media_block
+  | User_document of user_media_block
+  | User_audio of user_media_block
+(** Semantic user-input blocks accepted from the dashboard.  This is a
+    MASC request-boundary type, intentionally distinct from dashboard
+    rich-render [ChatBlock] values and from OAS provider blocks. *)
+
 type keeper_chat_stream_request = {
   name : string;
   message : string;
+  user_blocks : user_input_block list;
   timeout_sec : int option;
   turn_instructions : string option;
   surface_context : Yojson.Safe.t option;
@@ -53,7 +74,9 @@ type keeper_chat_stream_request = {
   attachments : Keeper_chat_store.attachment list;
 }
 (** Parsed payload of a keeper chat-stream HTTP request.
-    [timeout_sec] is clamped to [\[5, 300\]] when
+    [message] is the text fallback used by the existing direct keeper
+    path; [user_blocks] preserves semantic text/media input for the
+    block-aware runtime path.  [timeout_sec] is clamped to [\[5, 300\]] when
     present.  [turn_instructions] and [surface_context]
     are optional copilot context fields; when
     [turn_instructions] is absent but [surface_context]
@@ -70,7 +93,7 @@ val parse_keeper_chat_stream_request :
 (** Parses the HTTP body string into a
     {!keeper_chat_stream_request}.  Returns
     [Error reason] on JSON shape mismatches, missing
-    [name] / [message], partial connector context, or
+    [name] / content, malformed [user_blocks], partial connector context, or
     presence of legacy keeper model args removed by the
     runtime rewrite. *)
 
@@ -122,6 +145,7 @@ val process_single_turn :
   auth_token:string option ->
   thread_id:string ->
   closed:bool ref ->
+  client_disconnects:unit Eio.Stream.t option ->
   payload:keeper_chat_stream_request ->
   run_id:string ->
   message_id:string ->
@@ -145,6 +169,7 @@ module For_testing : sig
   val chat_speaker_of_request : keeper_chat_stream_request -> Keeper_chat_store.speaker
   val turn_instructions_for_request : keeper_chat_stream_request -> string option
   val args_of_request : keeper_chat_stream_request -> Yojson.Safe.t
+  val modalities_for_request : keeper_chat_stream_request -> string list
   val format_surface_context : Yojson.Safe.t -> string
   val surface_context_to_instructions : Yojson.Safe.t -> string option
 end

--- a/test/test_env_config_keeper_bootstrap_intervals.ml
+++ b/test/test_env_config_keeper_bootstrap_intervals.ml
@@ -166,6 +166,7 @@ let test_discord_queue_projection_matches_gateway_context () =
   let queued : Chat_queue.queued_message =
     {
       content = "hello";
+      user_blocks = [];
       attachments = [];
       timestamp = 0.0;
       source =

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -17,6 +17,22 @@ let temp_base_path prefix =
   Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
 
+let string_contains haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else if needle_len > haystack_len then false
+  else
+    let rec loop index =
+      if index + needle_len > haystack_len then false
+      else if String.sub haystack index needle_len = needle then true
+      else loop (index + 1)
+    in
+    loop 0
+
+let read_file path =
+  In_channel.with_open_bin path In_channel.input_all
+
 let test_agent_name_for_channel_actor () =
   let agent_name =
     Gate_keeper_backend.agent_name_for_channel_actor
@@ -196,6 +212,368 @@ let test_parse_keeper_chat_stream_request_formats_surface_context () =
       check bool "surface context present" true (Option.is_some payload.surface_context)
   | Error err -> fail ("expected surface context to parse: " ^ err)
 
+let test_parse_keeper_chat_stream_request_accepts_attachment_only_user_blocks () =
+  let body =
+    {|{"name":"luna","message":"","attachments":[{"id":"att-img","type":"image","name":"screen.png","size":1024,"mime_type":"image/png","data":"data:image/png;base64,abc123"}],"user_blocks":[{"type":"image","attachment_id":"att-img","name":"screen.png","mime_type":"image/png","size":1024}]}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok payload -> (
+      check string "fallback message" "[image attached: screen.png]" payload.message;
+      check int "attachment preserved" 1 (List.length payload.attachments);
+      match payload.user_blocks with
+      | [ Server_routes_http_keeper_stream.User_image media ] ->
+          check string "attachment id" "att-img" media.attachment_id;
+          check string "mime type" "image/png" media.mime_type;
+          check (option int) "size" (Some 1024) media.size
+      | _ -> fail "expected one image user block")
+  | Error err -> fail ("expected attachment-only user_blocks to parse: " ^ err)
+
+let test_parse_keeper_chat_stream_request_rejects_unknown_user_block_type () =
+  let body =
+    {|{"name":"luna","message":"hello","user_blocks":[{"type":"tool_result","text":"nope"}]}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok _ -> fail "expected unknown user block type to be rejected"
+  | Error err ->
+      check string "validation message"
+        {|unsupported user_blocks type "tool_result": expected text, image, document, or audio|}
+        err
+
+let test_keeper_multimodal_input_converts_user_blocks_to_oas_blocks () =
+  let attachments =
+    [
+      {
+        K.id = "att-img";
+        att_type = "image";
+        name = "screen.png";
+        size = 1024;
+        mime_type = "image/png";
+        data = "abc123";
+      };
+    ]
+  in
+  let media =
+    {
+      Keeper_multimodal_input.attachment_id = "att-img";
+      name = "screen.png";
+      mime_type = "image/png";
+      size = Some 1024;
+    }
+  in
+  match
+    Keeper_multimodal_input.to_oas_blocks ~attachments
+      [
+        Keeper_multimodal_input.User_image media;
+        Keeper_multimodal_input.User_text "describe this";
+      ]
+  with
+  | Ok
+      [
+        Agent_sdk.Types.Image { media_type; data; source_type };
+        Agent_sdk.Types.Text text;
+      ] ->
+      check string "media type" "image/png" media_type;
+      check string "data" "abc123" data;
+      check string "source type" "base64" source_type;
+      check string "text" "describe this" text
+  | Ok _ -> fail "expected image then text OAS blocks"
+  | Error err -> fail ("expected OAS block conversion: " ^ err)
+
+let test_keeper_stream_args_preserve_user_blocks () =
+  let media =
+    {
+      Keeper_multimodal_input.attachment_id = "att-img";
+      name = "screen.png";
+      mime_type = "image/png";
+      size = Some 1024;
+    }
+  in
+  let payload =
+    { Server_routes_http_keeper_stream.name = "luna";
+      message = "describe this";
+      user_blocks =
+        [
+          Keeper_multimodal_input.User_text "describe this";
+          Keeper_multimodal_input.User_image media;
+        ];
+      timeout_sec = None;
+      turn_instructions = None;
+      surface_context = None;
+      channel = "";
+      channel_user_id = "";
+      channel_user_name = "";
+      channel_workspace_id = "";
+      attachments =
+        [
+          {
+            K.id = "att-img";
+            att_type = "image";
+            name = "screen.png";
+            size = 1024;
+            mime_type = "image/png";
+            data = "abc123";
+          };
+        ];
+    }
+  in
+  match Server_routes_http_keeper_stream.For_testing.args_of_request payload with
+  | `Assoc fields -> (
+      match List.assoc_opt "user_blocks" fields, List.assoc_opt "attachments" fields with
+      | Some (`List [ `Assoc text_fields; `Assoc image_fields ]),
+        Some (`List [ `Assoc attachment_fields ]) ->
+          check (option string) "text block type" (Some "text")
+            (match List.assoc_opt "type" text_fields with
+             | Some (`String value) -> Some value
+             | _ -> None);
+          check (option string) "image block ref" (Some "att-img")
+            (match List.assoc_opt "attachment_id" image_fields with
+             | Some (`String value) -> Some value
+             | _ -> None);
+          check (option string) "attachment payload" (Some "abc123")
+            (match List.assoc_opt "data" attachment_fields with
+             | Some (`String value) -> Some value
+             | _ -> None)
+      | _ -> fail "expected user_blocks and attachment payload in keeper args")
+  | _ -> fail "expected keeper args object"
+
+let test_keeper_chat_history_persists_attachment_refs_not_raw_media () =
+  let base_dir = temp_base_path "gate-keeper-media-history" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "multimodal-history-keeper" in
+      let raw_media = "data:image/png;base64,SECRET_RAW_MEDIA" in
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:"describe this"
+        ~user_attachments:
+          [
+            {
+              K.id = "att-img";
+              att_type = "image";
+              name = "screen.png";
+              size = 1024;
+              mime_type = "image/png";
+              data = raw_media;
+            };
+          ]
+        ~assistant_content:"looks like a dashboard"
+        ();
+      let path =
+        Filename.concat
+          (Filename.concat
+             (Common.masc_dir_from_base_path ~base_path:base_dir)
+             "keeper_chat")
+          (keeper_name ^ ".jsonl")
+      in
+      let persisted = read_file path in
+      check bool "raw media omitted from jsonl" false
+        (string_contains persisted raw_media);
+      check bool "attachment ref persisted" true
+        (string_contains persisted "masc://attachment/att-img/");
+      match K.load ~base_dir ~keeper_name with
+      | user :: _ -> (
+          match user.K.attachments with
+          | Some [ att ] ->
+              check bool "loaded attachment omits raw media" false
+                (String.equal raw_media att.K.data);
+              check bool "loaded attachment has ref" true
+                (string_contains att.K.data "masc://attachment/att-img/")
+          | _ -> fail "expected one persisted attachment")
+      | [] -> fail "expected persisted chat messages")
+
+let vision_provider_cfg () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.Glm
+    ~model_id:"glm-5v-turbo"
+    ~base_url:"http://127.0.0.1.invalid"
+    ()
+
+let test_runtime_run_blocks_appends_multimodal_input_to_oas_agent () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config =
+    Runtime_agent.default_config
+      ~name:"multimodal-runtime-proof"
+      ~provider_cfg:(vision_provider_cfg ())
+      ~system_prompt:""
+      ~tools:[]
+  in
+  let config =
+    { config with
+      max_turns = 1;
+      session_id = Some "multimodal-runtime-proof-session";
+      exit_condition = Some (fun _turn -> true);
+      exit_condition_result =
+        Some (fun _turn -> Runtime_agent.Completed, Some "exit proof");
+    }
+  in
+  let agent_ref = ref None in
+  let blocks =
+    [
+      Agent_sdk.Types.Text "Inspect this";
+      Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"img" ();
+    ]
+  in
+  (match
+     Runtime_agent.run_blocks ~sw ~net:env#net ~config ~agent_ref blocks
+   with
+   | Ok result -> (
+       match result.Runtime_agent.stop_reason with
+       | Runtime_agent.Completed -> ()
+       | stop_reason ->
+           failf "unexpected stop reason after exit-condition proof: %s"
+             (Keeper_execution_receipt_types.stop_reason_to_string stop_reason))
+   | Error err ->
+       fail ("expected exit-condition checkpoint result: "
+             ^ Agent_sdk.Error.to_string err));
+  match !agent_ref with
+  | None -> fail "expected Runtime_agent.run_blocks to expose built OAS agent"
+  | Some agent -> (
+      match List.rev (Agent_sdk.Agent.state agent).messages with
+      | { Agent_sdk.Types.role = User; content; _ } :: _ -> (
+          check int "stored blocks" 2 (List.length content);
+          match content with
+          | [
+              Agent_sdk.Types.Text text;
+              Agent_sdk.Types.Image { media_type; data; source_type };
+            ] ->
+              check string "text preserved" "Inspect this" text;
+              check string "image media type" "image/png" media_type;
+              check string "image data" "img" data;
+              check string "source type" "base64" source_type
+          | _ -> fail "stored user input lost multimodal block shape")
+      | _ -> fail "missing appended OAS user message")
+
+let multimodal_caps ?(image = false) ?(audio = false) ?(multimodal = false) () =
+  { Llm_provider.Capabilities.default_capabilities with
+    supports_image_input = image;
+    supports_audio_input = audio;
+    supports_multimodal_inputs = multimodal;
+  }
+
+let test_runtime_multimodal_gate_model_caps_fail_closed () =
+  let provider_caps = multimodal_caps ~image:true ~multimodal:true () in
+  let model_caps =
+    { Runtime_schema.model_capabilities_default with
+      supports_image_input = false;
+      supports_multimodal_inputs = false;
+    }
+  in
+  let effective =
+    Runtime_agent.For_testing.apply_runtime_model_input_capabilities
+      provider_caps
+      model_caps
+  in
+  let blocks =
+    [ Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"abc" () ]
+  in
+  match
+    Runtime_agent.For_testing.validate_content_blocks_against_capabilities
+      ~provider_label:"runtime:deepseek"
+      effective
+      blocks
+  with
+  | Ok () -> fail "expected runtime model capability to veto image input"
+  | Error
+      (Agent_sdk.Error.Config
+         (Agent_sdk.Error.InvalidConfig { detail; _ })) ->
+      check bool "mentions unsupported image" true
+        (String_util.string_contains_substring
+           ~needle:"unsupported image input"
+           detail)
+  | Error err -> fail ("unexpected error shape: " ^ Agent_sdk.Error.to_string err)
+
+let test_runtime_multimodal_gate_lists_required_modalities () =
+  let blocks =
+    [
+      Agent_sdk.Types.Text "describe these";
+      Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"abc" ();
+      Agent_sdk.Types.audio_block ~media_type:"audio/wav" ~data:"def" ();
+    ]
+  in
+  check (list string) "required modalities" [ "image"; "audio" ]
+    (Runtime_agent.For_testing.required_modalities_of_content_blocks blocks)
+
+let test_runtime_multimodal_gate_rejects_unsupported_image () =
+  let blocks =
+    [ Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"abc" () ]
+  in
+  match
+    Runtime_agent.For_testing.validate_content_blocks_against_capabilities
+      ~provider_label:"test:text-only"
+      (multimodal_caps ())
+      blocks
+  with
+  | Ok () -> fail "expected image input to be rejected for text-only provider"
+  | Error
+      (Agent_sdk.Error.Config
+         (Agent_sdk.Error.InvalidConfig { field; detail })) ->
+      check string "field" "multimodal_input" field;
+      check bool "mentions image" true
+        (String_util.string_contains_substring
+           ~needle:"unsupported image input"
+           detail);
+      check bool "mentions provider" true
+        (String_util.string_contains_substring
+           ~needle:"test:text-only"
+           detail)
+  | Error err -> fail ("unexpected error shape: " ^ Agent_sdk.Error.to_string err)
+
+let test_runtime_multimodal_gate_allows_supported_image () =
+  let blocks =
+    [
+      Agent_sdk.Types.Text "describe this";
+      Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"abc" ();
+    ]
+  in
+  match
+    Runtime_agent.For_testing.validate_content_blocks_against_capabilities
+      ~provider_label:"test:image"
+      (multimodal_caps ~image:true ())
+      blocks
+  with
+  | Ok () -> ()
+  | Error err -> fail ("expected image-capable provider to pass: "
+                       ^ Agent_sdk.Error.to_string err)
+
+let test_runtime_multimodal_gate_requires_multimodal_for_document () =
+  let blocks =
+    [
+      Agent_sdk.Types.document_block
+        ~media_type:"application/pdf"
+        ~data:"abc"
+        ();
+    ]
+  in
+  let rejected =
+    Runtime_agent.For_testing.validate_content_blocks_against_capabilities
+      ~provider_label:"test:image-only"
+      (multimodal_caps ~image:true ())
+      blocks
+  in
+  let accepted =
+    Runtime_agent.For_testing.validate_content_blocks_against_capabilities
+      ~provider_label:"test:multimodal"
+      (multimodal_caps ~multimodal:true ())
+      blocks
+  in
+  (match rejected with
+   | Error
+       (Agent_sdk.Error.Config
+          (Agent_sdk.Error.InvalidConfig { detail; _ })) ->
+       check bool "mentions document" true
+         (String_util.string_contains_substring
+            ~needle:"unsupported document input"
+            detail)
+   | Ok () -> fail "expected document to require multimodal capability"
+   | Error err -> fail ("unexpected error shape: " ^ Agent_sdk.Error.to_string err));
+  match accepted with
+  | Ok () -> ()
+  | Error err -> fail ("expected multimodal provider to accept document: "
+                       ^ Agent_sdk.Error.to_string err)
+
 let test_surface_context_to_instructions_formats_copilot_context () =
   let ctx =
     Yojson.Safe.from_string
@@ -248,6 +626,7 @@ let test_chat_surface_of_request_labels_copilot_gate () =
       timeout_sec = None;
       turn_instructions = None;
       surface_context = None;
+      user_blocks = [];
       channel = "copilot";
       channel_user_id = "";
       channel_user_name = "";
@@ -264,6 +643,7 @@ let test_chat_speaker_of_request_copilot_is_owner () =
       timeout_sec = None;
       turn_instructions = None;
       surface_context = None;
+      user_blocks = [];
       channel = "copilot";
       channel_user_id = "";
       channel_user_name = "";
@@ -283,6 +663,7 @@ let test_chat_speaker_of_request_connector_is_external () =
       timeout_sec = None;
       turn_instructions = None;
       surface_context = None;
+      user_blocks = [];
       channel = "discord";
       channel_user_id = "user-42";
       channel_user_name = "Alice";
@@ -457,6 +838,28 @@ let () =
             test_parse_keeper_chat_stream_request_accepts_copilot_context;
           test_case "stream request formats surface context" `Quick
             test_parse_keeper_chat_stream_request_formats_surface_context;
+          test_case "stream request accepts attachment-only user blocks" `Quick
+            test_parse_keeper_chat_stream_request_accepts_attachment_only_user_blocks;
+          test_case "stream request rejects unknown user block type" `Quick
+            test_parse_keeper_chat_stream_request_rejects_unknown_user_block_type;
+          test_case "multimodal input converts user blocks to OAS blocks" `Quick
+            test_keeper_multimodal_input_converts_user_blocks_to_oas_blocks;
+          test_case "stream args preserve user blocks" `Quick
+            test_keeper_stream_args_preserve_user_blocks;
+          test_case "chat history persists attachment refs not raw media" `Quick
+            test_keeper_chat_history_persists_attachment_refs_not_raw_media;
+          test_case "runtime run_blocks appends multimodal input to OAS agent" `Quick
+            test_runtime_run_blocks_appends_multimodal_input_to_oas_agent;
+          test_case "runtime multimodal gate lists required modalities" `Quick
+            test_runtime_multimodal_gate_lists_required_modalities;
+          test_case "runtime multimodal gate model caps fail closed" `Quick
+            test_runtime_multimodal_gate_model_caps_fail_closed;
+          test_case "runtime multimodal gate rejects unsupported image" `Quick
+            test_runtime_multimodal_gate_rejects_unsupported_image;
+          test_case "runtime multimodal gate allows supported image" `Quick
+            test_runtime_multimodal_gate_allows_supported_image;
+          test_case "runtime multimodal gate requires multimodal for document" `Quick
+            test_runtime_multimodal_gate_requires_multimodal_for_document;
           test_case "surface context formats into instructions" `Quick
             test_surface_context_to_instructions_formats_copilot_context;
           test_case "surface context ignores empty fields" `Quick

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -19,7 +19,7 @@ let check name cond =
 ;;
 
 let msg ?(attachments = []) ~content ~ts source =
-  { Keeper_chat_queue.content; attachments; timestamp = ts; source }
+  { Keeper_chat_queue.content; user_blocks = []; attachments; timestamp = ts; source }
 ;;
 
 let attachment ~id =
@@ -30,6 +30,11 @@ let attachment ~id =
   ; mime_type = "text/plain"
   ; data = "d"
   }
+;;
+
+let image_block ~attachment_id =
+  Keeper_multimodal_input.User_image
+    { attachment_id; name = attachment_id ^ ".png"; mime_type = "image/png"; size = None }
 ;;
 
 let contents batch = List.map (fun m -> m.Keeper_chat_queue.content) batch
@@ -93,7 +98,8 @@ let test_merge_batch () =
   let batch =
     [ msg ~content:"first" ~ts:1.0 ~attachments:[ attachment ~id:"a" ]
         Keeper_chat_queue.Dashboard
-    ; msg ~content:"second" ~ts:2.0 Keeper_chat_queue.Dashboard
+    ; { (msg ~content:"second" ~ts:2.0 Keeper_chat_queue.Dashboard) with
+        Keeper_chat_queue.user_blocks = [ image_block ~attachment_id:"att-img" ] }
     ; msg ~content:"third" ~ts:3.0 ~attachments:[ attachment ~id:"b" ]
         Keeper_chat_queue.Dashboard
     ]
@@ -110,6 +116,10 @@ let test_merge_batch () =
          (fun (a : Keeper_chat_store.attachment) -> a.Keeper_chat_store.id)
          m.Keeper_chat_queue.attachments
        = [ "a"; "b" ]);
+    check
+      "semantic user blocks concatenate in order"
+      (Keeper_multimodal_input.modalities m.Keeper_chat_queue.user_blocks
+       = [ "image" ]);
     check "timestamp is the first message's" (m.Keeper_chat_queue.timestamp = 1.0);
     check
       "source is the shared route"


### PR DESCRIPTION
## Summary
- Add a MASC-side semantic user input block contract for dashboard/connector chat input.
- Wire dashboard attachments/text into `user_blocks`, preserve attachment manifests through the stream route and queue, and convert MASC input blocks to OAS `content_block` values at the runtime boundary.
- Add `Runtime_agent.run_blocks` plus capability gating so unsupported image/document/audio inputs fail closed before provider dispatch.
- Keep OAS unchanged: MASC adapts to the existing OAS block APIs rather than adding MASC-specific provider logic.

## Why
The dashboard could collect attachments, and OAS already supported provider content blocks, but the keeper turn path still collapsed chat input to a string goal. That meant attachments could survive as chat metadata without reaching the provider as image/document/audio input.

## Validation
- `bash scripts/ci/check-ignore-without-comment-diff.sh --base 5c4e87dd6cab74825b4cd972b72e4969fd1d68fb --head HEAD` - passed
- `scripts/ocaml-structure-ratchet.sh` - passed
- `ocamlformat --check lib/keeper/keeper_multimodal_input.ml lib/keeper/keeper_multimodal_input.mli lib/server/server_routes_http_keeper_stream.ml lib/dune` - passed
- `scripts/dune-local.sh build ./test/test_gate_keeper_backend.exe ./test/test_keeper_chat_coalescing.exe` - passed
- `./_build/default/test/test_gate_keeper_backend.exe` - 48 passed
- `./_build/default/test/test_keeper_chat_coalescing.exe` - passed
- `pnpm exec vitest run src/components/chat/attachments.test.ts src/components/chat/primitives.test.ts src/keeper-actions.test.ts src/api/keeper.test.ts` - 133 passed after rebase
- `pnpm exec tsc --noEmit --pretty false` - passed after rebase
- `git diff --check` - passed

## Notes
- `65378.events` is an untracked 65 MB binary event file in the worktree and was intentionally left out of the commit.
