### PR TITLE
fix(dashboard): keeper-chat 전송 라벨·음성 아이콘·도구 그룹핑·stale-error 정렬

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -717,6 +717,23 @@ describe('ChatComposer queue & stall', () => {
 
     expect(container.querySelector('[data-chat-stall-hint]')).toBeNull()
   })
+
+  it('labels the idle send button 전송 (regression: corrupted 볂이기 literal)', () => {
+    render(
+      html`<${ChatComposer}
+        draft="보낼 메시지"
+        placeholder="메시지 입력..."
+        disabled=${false}
+        streaming=${false}
+        onDraftChange=${() => {}}
+        onSend=${() => {}}
+      />`,
+      container,
+    )
+    const sendButton = [...container.querySelectorAll('button')].find((b) => b.classList.contains('send'))
+    expect(sendButton?.textContent?.trim()).toBe('전송')
+    expect(container.textContent).not.toContain('볂이기')
+  })
 })
 
 describe('ChatComposer IME composition guard', () => {
@@ -1324,6 +1341,119 @@ describe('ChatTranscript — workspace day dividers (C1)', () => {
       container,
     )
     expect(container.querySelectorAll('.kw-daydiv').length).toBe(0)
+  })
+
+  it('does not duplicate a day divider when a null-timestamp entry splits a day', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          // Both timestamps are midday UTC so they land on one calendar day in
+          // any plausible test TZ (the C1 baseline test uses the same window).
+          entry({ id: 'a', text: 'morning', timestamp: '2026-03-24T12:00:00.000Z' }),
+          // live placeholder with no timestamp, mid-day
+          entry({ id: 'live', text: '응답 연결 중', role: 'assistant', source: 'direct_assistant', timestamp: null, delivery: 'sending' }),
+          entry({ id: 'b', text: 'evening', timestamp: '2026-03-24T13:00:00.000Z' }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+        showDayDividers=${true}
+      />`,
+      container,
+    )
+    // One calendar day → exactly one divider. Adjacent-only comparison would
+    // let the null-ts entry reset the previous key and re-emit a second one.
+    expect(container.querySelectorAll('.kw-daydiv').length).toBe(1)
+  })
+})
+
+describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
+  let container: HTMLDivElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    resetToolCallOutputs()
+  })
+
+  it('folds consecutive tool calls into one 작업 과정 card when grouping is on', () => {
+    recordToolCallOutputs([
+      toolCallOutput({ tool_use_id: 't1', output: 'r1' }),
+      toolCallOutput({ tool_use_id: 't2', output: 'r2' }),
+    ])
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({ id: 'tool-t1', label: 'keeper_board_list' }),
+          toolEntry({ id: 'tool-t2', label: 'keeper_tasks_list' }),
+          entry({ id: 'a', text: '답변', role: 'assistant', source: 'direct_assistant' }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+      />`,
+      container,
+    )
+    const cards = container.querySelectorAll('[data-chat-tool-trace]')
+    expect(cards.length).toBe(1)
+    expect(cards[0]?.textContent).toContain('작업 과정')
+    expect(cards[0]?.textContent).toContain('2단계')
+    expect(cards[0]?.textContent).toContain('도구 2')
+    // Grouped surface keeps no standalone per-row tool bubbles.
+    expect(container.querySelectorAll('[data-chat-variant="tool-call"]').length).toBe(0)
+  })
+
+  it('keeps the flat per-row tool bubbles when grouping is off (default)', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({ id: 'tool-t1', label: 'keeper_board_list' }),
+          toolEntry({ id: 'tool-t2', label: 'keeper_tasks_list' }),
+        ]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+    expect(container.querySelectorAll('[data-chat-tool-trace]').length).toBe(0)
+    expect(container.querySelectorAll('[data-chat-variant="tool-call"]').length).toBe(2)
+  })
+
+  it('surfaces real failure status and result inside the card when expanded', async () => {
+    recordToolCallOutputs([
+      toolCallOutput({ tool_use_id: 't1', success: false, semantic_success: false, output: 'BOOM' }),
+    ])
+    render(
+      html`<${ChatTranscript}
+        entries=${[toolEntry({ id: 'tool-t1', label: 'keeper_board_post', text: '{"k":"v"}' })]}
+        emptyText="empty"
+        groupToolCalls=${true}
+      />`,
+      container,
+    )
+    expect(container.querySelector('[data-chat-tool-trace]')?.textContent).toContain('실패 1')
+    ;(container.querySelector('.chat-block-trace-hd') as HTMLButtonElement).click()
+    await flushUi()
+    const step = container.querySelector('[data-chat-trace-step="tool"]') as HTMLElement
+    expect(step.querySelector('.chat-block-tstep-status.bad')).not.toBeNull()
+    ;(step.querySelector('.chat-block-tstep-row') as HTMLElement).click()
+    await flushUi()
+    expect(step.textContent).toContain('BOOM')
+  })
+
+  it('marks a tool step pending until its output is joined', async () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[toolEntry({ id: 'tool-unjoined', label: 'keeper_context_status' })]}
+        emptyText="empty"
+        groupToolCalls=${true}
+      />`,
+      container,
+    )
+    ;(container.querySelector('.chat-block-trace-hd') as HTMLButtonElement).click()
+    await flushUi()
+    const step = container.querySelector('[data-chat-trace-step="tool"]')
+    expect(step?.querySelector('.chat-block-tstep-status.pending')).not.toBeNull()
   })
 })
 

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -9,14 +9,15 @@ import { collectAttachments } from './attachments'
 import { parseMarkdownToBlocks } from './markdown-blocks'
 import { showToast } from '../common/toast'
 import { useVoiceInput } from './voice-input'
+import { Mic, Square } from 'lucide-preact'
 
 const CHAT_FOCUS_RING = ringFocusClasses({ tone: 'accent-medium', width: 2 })
 import { formatTimeHms } from '../../lib/format-time'
-import { formatCost } from '../../lib/format-number'
+import { formatCost, formatMsCompact } from '../../lib/format-number'
 import { isSubmitEnter } from '../../lib/keyboard'
 import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatLinkBlock, ChatMermaidBlock, ChatShellBlock, ChatTableBlock, ChatTraceStep, ChatVoiceBlock } from '../../types'
 import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, KeeperConversationSource, SurfaceRef } from '../../types'
-import type { ToolCallOutputBlob } from '../../api/dashboard'
+import type { ToolCallEntry, ToolCallOutputBlob } from '../../api/dashboard'
 import { lookupToolCallOutput } from '../../tool-call-output-store'
 import { Sigil } from '../common/sigil-chip'
 import { SuggestionChip } from '../common/suggestion-chip'
@@ -1755,10 +1756,207 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
   `
 }
 
+const TOOL_STATUS_TITLE: Record<'pending' | 'ok' | 'bad', string> = {
+  pending: '출력 대기 중',
+  ok: '성공',
+  bad: '실패',
+}
+
+// One step of a grouped tool-trace card: a single tool call rendered from REAL
+// data only. Name + input args come from the chat entry; status, duration and
+// result are joined from the tool-call output store (null until hydration
+// lands, or forever for calls that carried no provider id — surfaced as a muted
+// "pending" dot rather than miscoloured as a failure).
+function ToolTraceStep({ entry, output }: { entry: KeeperConversationEntry; output: ToolCallEntry | null }) {
+  const [open, setOpen] = useState(false)
+  const name = entry.label || 'tool'
+  const displayArgs = prettyJsonish(entry.text || '')
+  const isEmptyArgs = EMPTY_ARG_TEXTS.has(displayArgs.trim())
+  const status: 'pending' | 'ok' | 'bad' =
+    output === null
+      ? 'pending'
+      : output.success === false || output.semantic_success === false
+        ? 'bad'
+        : 'ok'
+  const durLabel = output && output.duration_ms > 0 ? formatMsCompact(output.duration_ms) : ''
+  const resultView = output ? toolOutputDisplay(output.output) : null
+  const hasResult = resultView !== null && resultView.text.trim() !== ''
+  // Expandable when there is anything to show: args, a result, or a still-pending
+  // call (so the operator can open it and see "출력 대기 중…").
+  const hasBody = !isEmptyArgs || hasResult || output === null
+
+  return html`
+    <div class="chat-block-tstep tool ${open ? 'exp' : ''}" data-chat-trace-step="tool">
+      <span class="chat-block-tnode"></span>
+      <div class="min-w-0 flex-1">
+        <div
+          class="chat-block-tstep-row ${hasBody ? 'click' : ''}"
+          onClick=${() => { if (hasBody) setOpen((o) => !o) }}
+        >
+          <span class="chat-block-tstep-kind">Tool</span>
+          <span class="chat-block-tstep-name">${name}</span>
+          <span
+            class="chat-block-tstep-status ${status}"
+            title=${TOOL_STATUS_TITLE[status]}
+            aria-label=${TOOL_STATUS_TITLE[status]}
+          ></span>
+          <span class="chat-block-tstep-dur">${durLabel}</span>
+          ${hasBody ? html`<span class="chat-block-tstep-chev">▶</span>` : null}
+        </div>
+        ${open && hasBody
+          ? html`
+              <div class="chat-block-tool-body">
+                ${isEmptyArgs
+                  ? html`<div class="chat-block-tool-label">입력 없음</div>`
+                  : html`
+                      <div class="chat-block-tool-label">args</div>
+                      <pre class="m-0 max-h-48 overflow-y-auto whitespace-pre-wrap break-all text-2xs">${displayArgs}</pre>
+                    `}
+                ${hasResult
+                  ? html`
+                      <div class="chat-block-tool-label">result${resultView.truncated ? ' · 일부' : ''}</div>
+                      <pre class="m-0 max-h-64 overflow-y-auto whitespace-pre-wrap break-all text-2xs">${resultView.text}</pre>
+                    `
+                  : output === null
+                    ? html`<div class="chat-block-tool-label">출력 대기 중…</div>`
+                    : null}
+              </div>
+            `
+          : null}
+      </div>
+    </div>
+  `
+}
+
+// Groups a turn's consecutive tool-call entries into one folded "작업 과정"
+// trace card placed above the answer bubble — the v2 layout, built from live
+// data. Folded by default so a turn with many probes (a dozen keeper_board_list
+// / keeper_tasks_list calls) collapses to a single summary line instead of a
+// wall of raw-JSON rows. No think/reason steps are synthesised: the live
+// transcript has no reasoning channel, so the card omits them rather than
+// fabricate the v2 reference's mock reasoning.
+function ToolTraceCard({ tools }: { tools: KeeperConversationEntry[] }) {
+  const [open, setOpen] = useState(false)
+  const steps = tools.map((entry) => ({ entry, output: lookupToolCallOutput(entry.id) }))
+  const failN = steps.filter(
+    (s) => s.output !== null && (s.output.success === false || s.output.semantic_success === false),
+  ).length
+  const totalMs = steps.reduce((sum, s) => sum + (s.output?.duration_ms ?? 0), 0)
+  const durLabel = totalMs > 0 ? formatMsCompact(totalMs) : null
+
+  return html`
+    <div class="chat-block-trace ${open ? 'open' : ''}" data-chat-block="trace" data-chat-tool-trace>
+      <button
+        type="button"
+        class="chat-block-trace-hd"
+        onClick=${() => setOpen((o) => !o)}
+        aria-expanded=${open}
+      >
+        <span class="chat-block-trace-chev">${open ? '▾' : '▸'}</span>
+        <span>◈</span>
+        <span class="chat-block-trace-label">작업 과정</span>
+        <span class="chat-block-trace-count">${tools.length}단계</span>
+        <span class="chat-block-trace-meta">
+          <span>도구 ${tools.length}</span>
+          ${failN > 0 ? html`<span class="text-[var(--color-status-err)]">실패 ${failN}</span>` : null}
+          ${durLabel ? html`<span class="tnum">${durLabel}</span>` : null}
+        </span>
+      </button>
+      ${open
+        ? html`
+            <div class="chat-block-trace-steps">
+              <span class="chat-block-trace-rail"></span>
+              ${steps.map(({ entry, output }) => html`<${ToolTraceStep} key=${entry.id} entry=${entry} output=${output} />`)}
+            </div>
+          `
+        : null}
+    </div>
+  `
+}
+
 // A reader within this distance of the bottom is considered "pinned":
 // new content keeps auto-scrolling. Scrolling further up unpins so the
 // transcript stops yanking the viewport while old messages are read.
 const STICK_TO_BOTTOM_THRESHOLD_PX = 80
+
+type ChatRenderUnit =
+  | { kind: 'entry'; entry: KeeperConversationEntry }
+  | { kind: 'toolGroup'; id: string; entries: KeeperConversationEntry[] }
+
+// Fold maximal runs of consecutive tool-call entries into one group so they
+// render as a single "작업 과정" trace card. Adjacency is the only turn signal
+// on the transcript — chat entries carry no turn/trace id (that lives on the
+// separate ToolCallEntry) — and the live stream inserts a turn's tool rows
+// immediately before its assistant bubble (keeper-stream.ts), so a run of
+// role:'tool' entries is exactly that turn's tool set. With grouping off every
+// entry stays its own unit, leaving the flat render unchanged.
+function buildChatRenderUnits(
+  entries: KeeperConversationEntry[],
+  groupToolCalls: boolean,
+): ChatRenderUnit[] {
+  if (!groupToolCalls) return entries.map((entry) => ({ kind: 'entry', entry }))
+  const units: ChatRenderUnit[] = []
+  let run: KeeperConversationEntry[] = []
+  const flush = () => {
+    if (run.length === 0) return
+    units.push({ kind: 'toolGroup', id: `tracegroup-${run[0]!.id}`, entries: run })
+    run = []
+  }
+  for (const entry of entries) {
+    if (entry.role === 'tool') {
+      run.push(entry)
+    } else {
+      flush()
+      units.push({ kind: 'entry', entry })
+    }
+  }
+  flush()
+  return units
+}
+
+function renderChatTranscriptBody(opts: {
+  entries: KeeperConversationEntry[]
+  showDayDividers: boolean
+  groupToolCalls: boolean
+  showMetadata?: boolean
+  variant: ChatTranscriptVariant
+  showSourceBadge: boolean
+  action?: ChatTranscriptAction
+}): VNode[] {
+  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, action } = opts
+  const units = buildChatRenderUnits(entries, groupToolCalls)
+  const out: VNode[] = []
+  // Track the last NON-NULL calendar day rather than only the immediately
+  // previous entry, so a null-timestamp entry (live placeholder, checkpoint) in
+  // the middle of a day cannot poison the comparison and re-emit a spurious
+  // second divider for a day already shown above.
+  let lastDayKey: string | null = null
+  for (const unit of units) {
+    const ts = unit.kind === 'entry' ? unit.entry.timestamp : unit.entries[0]?.timestamp
+    if (showDayDividers) {
+      const dk = dayKey(ts)
+      if (dk && dk !== lastDayKey) {
+        out.push(html`<div class="kw-daydiv" key=${`day:${dk}`}>${dayDividerLabel(ts)}</div>`)
+        lastDayKey = dk
+      }
+    }
+    if (unit.kind === 'toolGroup') {
+      out.push(html`<${ToolTraceCard} key=${unit.id} tools=${unit.entries} />`)
+    } else if (unit.entry.role === 'tool') {
+      out.push(html`<${ToolCallBubble} key=${unit.entry.id} entry=${unit.entry} />`)
+    } else {
+      out.push(html`<${ChatMessageBubble}
+        key=${unit.entry.id}
+        entry=${unit.entry}
+        showMetadata=${showMetadata !== false}
+        variant=${variant}
+        showSourceBadge=${showSourceBadge}
+        action=${action}
+      />`)
+    }
+  }
+  return out
+}
 
 export function ChatTranscript({
   entries,
@@ -1767,6 +1965,7 @@ export function ChatTranscript({
   variant = 'default',
   size = 'default',
   showDayDividers = false,
+  groupToolCalls = false,
   showSourceBadge = false,
   action,
 }: {
@@ -1778,6 +1977,9 @@ export function ChatTranscript({
   // C1/C2: opt-in workspace polish. Default false so every other chat surface
   // (copilot dock, detail page, etc.) renders unchanged.
   showDayDividers?: boolean
+  // Opt-in: fold a turn's consecutive tool-call rows into one "작업 과정" card.
+  // Default false so non-workspace surfaces keep the flat per-row ToolCallBubble.
+  groupToolCalls?: boolean
   showSourceBadge?: boolean
   action?: ChatTranscriptAction
 }) {
@@ -1845,23 +2047,14 @@ export function ChatTranscript({
                 <div class="mt-3 max-w-[34rem] text-base font-medium leading-airy text-[var(--color-fg-primary)]">${emptyText}</div>
               </div>
             `
-          : entries.flatMap((entry, i) => {
-              const bubble = entry.role === 'tool'
-                ? html`<${ToolCallBubble} key=${entry.id} entry=${entry} />`
-                : html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} variant=${variant} showSourceBadge=${showSourceBadge} action=${action} />`
-              // C1: emit a day divider before the first message of each calendar
-              // day. Skipped entirely when showDayDividers is off (every non-
-              // workspace surface), so their flat render is byte-identical.
-              if (!showDayDividers) return [bubble]
-              const dk = dayKey(entry.timestamp)
-              const prevDk = i > 0 ? dayKey(entries[i - 1]?.timestamp) : null
-              if (dk && dk !== prevDk) {
-                return [
-                  html`<div class="kw-daydiv" key=${`day:${dk}`}>${dayDividerLabel(entry.timestamp)}</div>`,
-                  bubble,
-                ]
-              }
-              return [bubble]
+          : renderChatTranscriptBody({
+              entries,
+              showDayDividers,
+              groupToolCalls,
+              showMetadata,
+              variant,
+              showSourceBadge,
+              action,
             })}
       </div>
       ${unread
@@ -1989,7 +2182,7 @@ export function ChatComposer({
     ? canQueue
       ? '대기열 추가'
       : `응답 중${elapsed > 0 ? ` ${elapsed}s` : ''}`
-    : '볂이기'
+    : '전송'
   const isStreamWarning = streaming && elapsed > 60
   const hasContent = draft.trim() !== '' || attachments.length > 0
   const sendDisabled = disabled || !hasContent || (streaming && !queueEnabled)
@@ -2162,7 +2355,9 @@ export function ChatComposer({
                 disabled=${voice.state === 'transcribing' || disabled}
                 onClick=${() => (voice.state === 'recording' ? voice.stop() : voice.start())}
               >
-                ${voice.state === 'recording' ? '■ 녹음중' : voice.state === 'transcribing' ? '전사 중…' : '🎤 음성'}
+                ${voice.state === 'recording'
+                  ? html`<${Square} size=${15} aria-hidden="true" />`
+                  : html`<${Mic} size=${15} aria-hidden="true" />`}
               </button>
             ` : null}
             <button

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -631,6 +631,7 @@ export function KeeperConversationPanel({
               variant="messenger"
               size="primary"
               showDayDividers=${true}
+              groupToolCalls=${true}
               showSourceBadge=${true}
               action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
             />

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -335,6 +335,33 @@ describe('thread history merge & persistence', () => {
     expect(thread.at(-2)?.id).toBe('local-1')
   })
 
+  it('sorts a stale locally-appended error into chronological position, not the bottom', () => {
+    // A live turn failed days ago and appended an error entry, which stayed at
+    // the end of the thread. Newer server history must not leave that days-old
+    // dns_failure floating at the bottom where it reads as the newest message.
+    appendThreadEntry(
+      'echo',
+      entry({ id: 'err-old', text: 'dns_failure', delivery: 'error', timestamp: '2026-06-15T00:00:00.000Z' }),
+    )
+    mergeServerHistoryEntries('echo', [
+      entry({ id: 'h-16', text: 'day 16', delivery: 'history', timestamp: '2026-06-16T00:00:00.000Z' }),
+      entry({ id: 'h-19', text: 'day 19', delivery: 'history', timestamp: '2026-06-19T00:00:00.000Z' }),
+    ])
+    const ids = (keeperThreads.value.echo ?? []).map(e => e.id)
+    expect(ids).toEqual(['err-old', 'h-16', 'h-19'])
+  })
+
+  it('keeps no-timestamp live entries at the bottom of the sorted thread', () => {
+    // A still-streaming/optimistic entry with no timestamp must sort last so the
+    // in-flight tail stays at the bottom even as older history is merged.
+    appendThreadEntry('echo', entry({ id: 'live', text: '응답 연결 중', delivery: 'sending', timestamp: null }))
+    mergeServerHistoryEntries('echo', [
+      entry({ id: 'h-19', text: 'day 19', delivery: 'history', timestamp: '2026-06-19T00:00:00.000Z' }),
+    ])
+    const ids = (keeperThreads.value.echo ?? []).map(e => e.id)
+    expect(ids.at(-1)).toBe('live')
+  })
+
   it('accepts attachment-only history rows', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -552,6 +552,15 @@ function isInFlightDelivery(delivery: KeeperConversationDelivery): boolean {
   return delivery === 'sending' || delivery === 'streaming' || delivery === 'queued'
 }
 
+// Entries with no parseable timestamp (live placeholders, still-streaming
+// turns) sort to the very bottom so the in-flight tail stays put; everything
+// else sorts by wall-clock so history renders oldest→newest.
+const TIMESTAMP_SORT_FALLBACK = Number.MAX_SAFE_INTEGER
+function entryTimeMs(entry: KeeperConversationEntry): number {
+  const ms = entry.timestamp ? Date.parse(entry.timestamp) : NaN
+  return Number.isFinite(ms) ? ms : TIMESTAMP_SORT_FALLBACK
+}
+
 function replaceThread(name: string, entries: KeeperConversationEntry[]): void {
   // An empty history payload means the caller did not request history
   // (e.g. hydrateKeeperStatus fast path with tail_messages: 0), not
@@ -570,26 +579,21 @@ function replaceThread(name: string, entries: KeeperConversationEntry[]): void {
       && (isInFlightDelivery(entry.delivery)
         || !entries.some(historyEntry => sameConversationEntry(entry, historyEntry))),
   )
-  // When the merged list exceeds the cap, prefer to keep locally-created
-  // entries (optimistic/pending/live) at the end rather than trimming the
-  // newest messages. Server history beyond the cap is still available via
-  // the history endpoint.
-  const isLocalEntry = (entry: KeeperConversationEntry): boolean =>
-    entry.id.startsWith('local-')
-    || entry.id.startsWith('optimistic-')
-    || entry.delivery !== 'history'
+  // Render strictly oldest→newest by timestamp. Server /chat/history is
+  // chronological, but locally-appended entries (a live turn's transport error,
+  // optimistic rows) were concatenated AFTER it with no re-sort, which floated a
+  // days-old dns_failure to the very bottom of the transcript where it read as
+  // the newest message. Sorting by timestamp puts every entry in its real
+  // position; no-timestamp entries sort last (in-flight tail stays at the
+  // bottom) and the original array index breaks ties so same-second tool calls
+  // keep their issued order.
   const merged = [...entries, ...localEntries]
-  let kept = merged
-  if (merged.length > THREAD_ENTRY_CAP) {
-    const locals = merged.filter(isLocalEntry)
-    const history = merged.filter(entry => !isLocalEntry(entry))
-    const historyCap = Math.max(0, THREAD_ENTRY_CAP - locals.length)
-    // history.slice(-0) is equivalent to history.slice(0), so an explicit
-    // empty prefix is needed when the local tail already fills the cap.
-    kept = historyCap === 0
-      ? locals
-      : [...history.slice(-historyCap), ...locals]
-  }
+    .map((entry, index) => ({ entry, index }))
+    .sort((a, b) => entryTimeMs(a.entry) - entryTimeMs(b.entry) || a.index - b.index)
+    .map(({ entry }) => entry)
+  // Keep the newest THREAD_ENTRY_CAP entries. After the sort the in-flight tail
+  // is last, so the cap trims the oldest history rather than a live row.
+  const kept = merged.length > THREAD_ENTRY_CAP ? merged.slice(-THREAD_ENTRY_CAP) : merged
   keeperThreads.value = {
     ...keeperThreads.value,
     [name]: kept,

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -155,6 +155,14 @@
   background: var(--color-status-err);
 }
 
+/* Live tool calls have a third state the v2 mock lacks: the result has not yet
+   been joined from the tool-call output store (or the call carried no provider
+   id, so it never will). Render a muted dot rather than leave it invisible or
+   miscolour it as a failure. */
+.chat-block-tstep-status.pending {
+  background: var(--color-fg-disabled);
+}
+
 .chat-block-tstep-dur {
   font-family: var(--font-mono);
   font-size: var(--fs-2xs);


### PR DESCRIPTION
## 목표

operator가 keeper workspace 채팅에서 보고한 4가지 버그/UI 문제를 수정합니다.

| 증상 | 근본 원인 | 수정 |
|------|----------|------|
| 하단 전송 버튼이 깨진 글자 `볂이기` | `primitives.ts`에 깨진 Hangul 리터럴(U+BCC2) 하드코딩 | → `전송` |
| 음성 버튼 정렬 어긋남 | 음성 버튼만 `🎤 음성`(emoji+텍스트)이라 icon-only인 첨부/전송 버튼과 baseline 불일치 | → `Mic` 아이콘 (녹음 중엔 `Square` 중지 아이콘). 모든 composer-tools 버튼이 동일한 아이콘 정사각형이 됨 |
| 도구 사용 정보가 v2 디자인과 다름 + "오늘 날짜 대화가 잘못 표시" | 한 턴의 도구 호출이 각각 bare raw-JSON row로 떨어져 한 턴이 수십 줄의 노이즈가 됨 | 연속된 `role:'tool'` 엔트리를 하나의 접힌 **"작업 과정"** trace 카드로 그룹핑 (workspace surface opt-in) |
| 4일 전 오류가 계속 맨 아래(최신처럼) 떠 있음 | `replaceThread`가 **정렬 없이** local 엔트리를 서버 history 뒤에 concat → 오래된 transport_failure가 transcript 맨 아래에 고정 | 렌더 thread를 timestamp로 정렬 |

## 변경 내용

- **`primitives.ts`**
  - 전송 라벨 `볂이기` → `전송`
  - 음성 버튼을 `lucide-preact` 아이콘(`Mic`/`Square`)으로 교체. `title`/`aria-label`은 그대로 유지(테스트 호환)
  - `ToolTraceCard` + `ToolTraceStep` 추가: 기존 `chat-blocks-v2.css`의 `.chat-block-trace*` 마크업/CSS를 재사용. 라이브 데이터만 표시 — 도구명(`entry.label`), args(`entry.text`), 그리고 tool-call output store join으로 **실제** status/duration/result. **reasoning/think 스텝은 합성하지 않음**(라이브 transcript에 reasoning 채널이 없음 → v2 mock의 reasoning을 날조하지 않음). output join 전 도구는 빨강(실패)이 아니라 muted **pending** 닷으로 표시
  - `ChatTranscript`에 `groupToolCalls` opt-in prop 추가(기본 false → 다른 surface는 byte-identical). transcript flatMap을 `buildChatRenderUnits`(인접 도구 그룹핑) + `renderChatTranscriptBody`(날짜 divider)로 재구성
  - 날짜 divider 하드닝: 마지막 **non-null** day key를 추적 → null-timestamp 엔트리(라이브 placeholder 등)가 중간에 끼어도 중복 divider가 생기지 않음
- **`keeper-shared.ts`**: workspace 채팅 호출부에 `groupToolCalls=${true}` 배선 (day-divider opt-in과 동일 위치)
- **`keeper-state.ts`**: `replaceThread`에서 merge 후 timestamp 오름차순 정렬(no-timestamp 엔트리는 맨 아래로, 원본 index로 tie-break → 같은 초의 도구 호출 순서 보존). 버그가 있던 local-pinning partition(`isLocalEntry`: `delivery !== 'history'`로 terminal error까지 끝에 고정)을 **제거**하고 정렬 + 단순 `slice(-cap)`으로 대체
- **`chat-blocks-v2.css`**: `.chat-block-tstep-status.pending` 1개 추가(라이브에만 존재하는 "output 미join" 상태용 muted 닷)

## 로컬 검증

- `tsc --noEmit` clean
- `eslint src` clean
- vitest 18개 파일 240 테스트 통과 (신규 8개: 전송 라벨, icon-only 음성, 도구 그룹핑 card-vs-flat/실제 status·result/pending, 시간순 정렬, null-ts divider 하드닝)
- **브라우저 라이브 검증**(worktree vite dev server + 라이브 MASC 백엔드, keeper `albini`): 전송 라벨·음성 아이콘 확인, 도구 21개 카드로 그룹핑(flat row 0)·실제 duration(50ms/73ms/6ms) 표시, day divider `6/16→6/19` 시간순, 4일 전 dns_failure가 더 이상 맨 아래에 뜨지 않음

## 경계 / 안전

- 변경 영역은 dashboard UI + dashboard client store. credential/operator/sandbox/hooks/workflow subsystem 아님 → RFC 게이트 비해당
- 정렬 수정은 워크어라운드 추가가 아니라 버그있던 local-pinning을 **제거한 root fix**
- 다른 채팅 surface(copilot dock, detail page)는 `groupToolCalls` 기본 false라 렌더 변화 없음

## 남은 미검증

- 라이브 검증은 keeper `albini` 단건. 다른 keeper의 다양한 도구 패턴은 자동화 테스트로만 커버
