### PR TITLE
fix(ws): key heartbeat liveness on last_pong_at, not a tick counter (#21509)

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -37,14 +37,13 @@ type ws_session = {
       through [write_mutex] so fibers sharing one connection cannot interleave
       frames or race with a concurrent close. *)
   write_mutex: Eio.Mutex.t;
-  (** Last time a WebSocket pong frame was received from the client.  Used by
-      the standalone heartbeat to detect dead peers after a configurable number
-      of missed pongs. *)
+  (** Last time a WebSocket pong frame was received from the client (or the
+      time the connection opened, before any pong).  The heartbeat closes the
+      session once it has gone [threshold] whole intervals without a pong; a
+      client that keeps answering refreshes this and is never closed.  This is
+      the single liveness signal — there is no separate tick counter that a
+      responsive client could accumulate against (#21509). *)
   last_pong_at: float Atomic.t;
-  (** Number of consecutive protocol pings sent without receiving a pong.
-      Reset to zero on every pong; the standalone heartbeat closes the session
-      once this reaches [pong_timeout_intervals]. *)
-  missed_pongs: int Atomic.t;
   dashboard_auth: dashboard_auth_state Atomic.t;
   mutable dashboard_route: string option;
   dashboard_slices: (string, unit) Hashtbl.t;
@@ -167,7 +166,6 @@ let new_session ~id ~wsd =
     closed = Atomic.make false;
     write_mutex = Eio.Mutex.create ();
     last_pong_at = Atomic.make (Unix.gettimeofday ()); (* NDT-OK: wall-clock used only for liveness, not deterministic output. *)
-    missed_pongs = Atomic.make 0;
     dashboard_auth = Atomic.make Unauthenticated;
     dashboard_route = None;
     dashboard_slices = Hashtbl.create 8;
@@ -183,11 +181,12 @@ let new_session ~id ~wsd =
 let is_session_closed session =
   Atomic.get session.closed || Httpun_ws.Wsd.is_closed session.wsd
 
-(** Record a client pong: refresh [last_pong_at] and reset the missed-pong
-    counter.  Called from the WS frame handler on every [Pong] frame. *)
+(** Record a client pong: refresh [last_pong_at].  Called from the WS frame
+    handler on every [Pong] frame; this is the liveness signal the heartbeat
+    reads via {!heartbeat_should_close} (#21509). *)
 let record_pong session =
-  Atomic.set session.last_pong_at (Unix.gettimeofday ()); (* NDT-OK: wall-clock used only for liveness, not deterministic output. *)
-  Atomic.set session.missed_pongs 0
+  Atomic.set session.last_pong_at (Unix.gettimeofday ())
+(* NDT-OK: wall-clock used only for liveness, not deterministic output. *)
 
 (** Send a pre-allocated frame to a WebSocket client.
 
@@ -894,6 +893,17 @@ let session_count () =
 
 let heartbeat_interval_s = 30.0
 
+(** Whether the heartbeat should close a session for pong-timeout.  Liveness is
+    keyed on the last answered pong, not a per-tick counter: a client that keeps
+    answering refreshes [last_pong_at] via {!record_pong} and is therefore never
+    closed, fixing the conflation where a responsive client sat one tick from
+    closure every interval (#21509).  Closes only after [threshold] whole
+    [interval_s] periods with no pong.  [threshold = 0] (or negative) disables
+    the guard. *)
+let heartbeat_should_close ~now ~last_pong_at ~threshold ~interval_s =
+  threshold > 0 && now -. last_pong_at > float_of_int threshold *. interval_s
+;;
+
 (** Configurable missed-pong threshold for the /ws upgrade heartbeat.
 
     A value of [0] disables the pong-timeout guard.  Negative values are
@@ -918,12 +928,18 @@ let start_upgrade_heartbeat ?sw ?clock session_id session =
           Eio.Time.sleep clock heartbeat_interval_s;
           if is_session_closed session
           then ()
-          else if threshold > 0 && Atomic.get session.missed_pongs >= threshold
+          else if
+            (* NDT-OK: wall-clock compared for liveness only, not output *)
+            heartbeat_should_close
+              ~now:(Unix.gettimeofday ())
+              ~last_pong_at:(Atomic.get session.last_pong_at)
+              ~threshold
+              ~interval_s:heartbeat_interval_s
           then begin
             Log.Server.debug
-              "[ws-upgrade] session %s missed %d pongs; closing"
+              "[ws-upgrade] session %s pong timeout (no pong in %d intervals); closing"
               session_id
-              (Atomic.get session.missed_pongs);
+              threshold;
             cleanup_session session_id
           end
           else begin
@@ -949,10 +965,7 @@ let start_upgrade_heartbeat ?sw ?clock session_id session =
                     (Printexc.to_string exn)));
             if !send_failed
             then cleanup_session session_id
-            else begin
-              Atomic.incr session.missed_pongs;
-              loop ()
-            end
+            else loop ()
           end
         in
         loop ()))

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -76,7 +76,6 @@ type ws_session = {
   closed : bool Atomic.t;
   write_mutex : Eio.Mutex.t;
   last_pong_at : float Atomic.t;
-  missed_pongs : int Atomic.t;
   dashboard_auth : dashboard_auth_state Atomic.t;
   mutable dashboard_route : string option;
   dashboard_slices : (string, unit) Hashtbl.t;
@@ -94,7 +93,7 @@ type ws_session = {
     [#10648] / dashboard-ws.v1 protocol notes in the .ml
     for the field semantics.
 
-    Cross-fiber scalar state ([closed], [last_pong_at], [missed_pongs]) is
+    Cross-fiber scalar state ([closed], [last_pong_at]) is
     held in [Atomic.t] values; all writes to [wsd] are serialized through
     [write_mutex]. *)
 
@@ -162,6 +161,17 @@ val is_session_closed : ws_session -> bool
     has shut down.  Safe to call from any fiber. *)
 
 val record_pong : ws_session -> unit
+(** Refresh [last_pong_at] on a received pong; the single liveness signal read
+    by {!heartbeat_should_close} (#21509). *)
+
+val heartbeat_should_close :
+  now:float -> last_pong_at:float -> threshold:int -> interval_s:float -> bool
+(** [true] when a session should be closed for pong-timeout: it has gone
+    [threshold] whole [interval_s]-second intervals with no pong (i.e.
+    [now -. last_pong_at > threshold * interval_s]).  A client that keeps
+    answering refreshes [last_pong_at] and is never closed.  [threshold <= 0]
+    disables the guard.  Shared by the /ws upgrade heartbeat and the standalone
+    heartbeat so liveness is single-source (#21509). *)
 (** Refresh [last_pong_at] and reset the missed-pong counter.  Called by the
     WS frame handler on every [Pong] frame. *)
 

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -250,8 +250,9 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
           session_id;
         Server_mcp_transport_ws.cleanup_session session_id))
     ();
-  (* Heartbeat fiber: ping every [heartbeat_interval_s], count missed pongs,
-     and close the session once the threshold is reached. *)
+  (* Heartbeat fiber: ping every [heartbeat_interval_s] and close the session
+     once it has gone [threshold] whole intervals with no pong, via the shared
+     Server_mcp_transport_ws.heartbeat_should_close (#21509). *)
   let threshold = missed_pong_threshold () in
   Eio.Fiber.fork ~sw (fun () ->
     let send_ping () =
@@ -264,13 +265,18 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
       if Server_mcp_transport_ws.is_session_closed session
       then ()
       else begin
-        let missed = Atomic.get session.missed_pongs in
-        if threshold > 0 && missed >= threshold
+        if
+          (* NDT-OK: wall-clock compared for liveness only, not output *)
+          Server_mcp_transport_ws.heartbeat_should_close
+            ~now:(Unix.gettimeofday ())
+            ~last_pong_at:(Atomic.get session.last_pong_at)
+            ~threshold
+            ~interval_s:heartbeat_interval_s
         then begin
           Log.Server.debug
-            "[ws-standalone] session %s missed %d pongs; closing"
+            "[ws-standalone] session %s pong timeout (no pong in %d intervals); closing"
             session_id
-            missed;
+            threshold;
           Server_mcp_transport_ws.cleanup_session session_id
         end
         else begin
@@ -295,10 +301,7 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
             (* Drop the half-open session immediately so the loop does not
                spin until the WSD observes the broken socket. *)
             Server_mcp_transport_ws.cleanup_session session_id
-          else begin
-            Atomic.incr session.missed_pongs;
-            loop ()
-          end
+          else loop ()
         end
       end
     in

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -655,21 +655,46 @@ let test_dashboard_auth_authenticated_tokenless () =
 let test_new_session_initializes_pong_state () =
   let session = Ws.new_session ~id:"pong-state-init" ~wsd:(Obj.magic ()) in
   Alcotest.(check bool) "closed starts false" false (Atomic.get session.closed);
-  Alcotest.(check int) "missed_pongs starts at 0" 0 (Atomic.get session.missed_pongs);
   Alcotest.(check bool) "last_pong_at is in the recent past"
     true
     (Atomic.get session.last_pong_at <= Unix.gettimeofday ())
 
-let test_record_pong_resets_missed_pongs () =
-  let session = Ws.new_session ~id:"pong-reset" ~wsd:(Obj.magic ()) in
-  Atomic.set session.missed_pongs 5;
+let test_record_pong_refreshes_last_pong_at () =
+  let session = Ws.new_session ~id:"pong-refresh" ~wsd:(Obj.magic ()) in
   let before = Atomic.get session.last_pong_at in
   Unix.sleepf 0.005;
   Ws.record_pong session;
-  Alcotest.(check int) "missed_pongs reset to 0" 0 (Atomic.get session.missed_pongs);
-  Alcotest.(check bool) "last_pong_at advanced"
+  Alcotest.(check bool) "last_pong_at advanced on pong"
     true
     (Atomic.get session.last_pong_at > before)
+
+(* #21509 regression: liveness is keyed on the last answered pong, not a tick
+   counter, so a client that just answered must never be closed — even at the
+   most aggressive threshold=1.  Before the fix the per-tick missed counter sat
+   one short of the threshold every interval and closed responsive clients. *)
+let test_heartbeat_responsive_client_not_closed () =
+  let now = 1_000.0 in
+  Alcotest.(check bool) "answered 1s ago at threshold=1 stays open"
+    false
+    (Ws.heartbeat_should_close ~now ~last_pong_at:(now -. 1.0) ~threshold:1
+       ~interval_s:30.0)
+
+let test_heartbeat_silent_client_closed () =
+  let now = 1_000.0 in
+  Alcotest.(check bool) "no pong for >3 intervals closes"
+    true
+    (Ws.heartbeat_should_close ~now ~last_pong_at:(now -. 100.0) ~threshold:3
+       ~interval_s:30.0);
+  Alcotest.(check bool) "within 3 intervals stays open"
+    false
+    (Ws.heartbeat_should_close ~now ~last_pong_at:(now -. 80.0) ~threshold:3
+       ~interval_s:30.0)
+
+let test_heartbeat_threshold_zero_disables () =
+  Alcotest.(check bool) "threshold=0 never closes"
+    false
+    (Ws.heartbeat_should_close ~now:1e9 ~last_pong_at:0.0 ~threshold:0
+       ~interval_s:30.0)
 
 let test_missed_pong_threshold_default () =
   (* Clear any inherited value so the default (3) is exercised. *)
@@ -792,8 +817,16 @@ let () =
     ("pong_state", [
       Alcotest.test_case "new session initializes pong atomics" `Quick
         test_new_session_initializes_pong_state;
-      Alcotest.test_case "record_pong resets missed_pongs" `Quick
-        test_record_pong_resets_missed_pongs;
+      Alcotest.test_case "record_pong refreshes last_pong_at" `Quick
+        test_record_pong_refreshes_last_pong_at;
+    ]);
+    ("heartbeat_liveness", [
+      Alcotest.test_case "responsive client not closed (#21509)" `Quick
+        test_heartbeat_responsive_client_not_closed;
+      Alcotest.test_case "silent client closed past threshold" `Quick
+        test_heartbeat_silent_client_closed;
+      Alcotest.test_case "threshold=0 disables guard" `Quick
+        test_heartbeat_threshold_zero_disables;
     ]);
     ("pong_threshold", [
       Alcotest.test_case "default missed-pong threshold is 3" `Quick


### PR DESCRIPTION
## 목표

#21509: WS missed-pong 카운터가 answered-ping-aware가 아니라, `MASC_WS_MISSED_PONG_THRESHOLD=1`에서 **응답하는 클라이언트를 close**하는 버그를 고칩니다.

## root cause (grounded, `5c4e87dd6c`)

- `missed_pongs` 카운터가 'tick since reset'과 'consecutive unanswered ping'을 conflate. 두 heartbeat loop이 `send_ping` 후 **무조건** `Atomic.incr`, `record_pong`은 `missed_pongs:=0` + `last_pong_at` 기록하지만 **loop가 `last_pong_at`을 안 읽음**.
- responsive client도 매 interval `missed_pongs=1`로 진입 → `threshold=1`이면 start-of-tick `>=1` 발화 → live client close.
- PR #21497(`Atomic.incr`)은 ordering(send_ping→incr)을 안 고쳐 reset-after-pong이 여전히 덮임.

## 적대 검증 정정 (workflow `wgdppqj7p` verify)

- triage `live` → verify `partial`: 2개 loop 중 `server_ws_standalone.ml`만 live. `server_mcp_transport_ws.ml`의 `start_upgrade_heartbeat`은 **dead**(`upgrade_connection` 호출자 0, `main_eio` same-origin `/ws` upgrade disabled). 기본 `threshold=3`이라 default config severity는 낮음(threshold=1 config 또는 연속-tick race에서 발현).
- fix는 양쪽 loop를 **shared helper로 통일**(dead site여도 회귀 안전, single-source가 N-of-M보다 나음).

## fix (근본 해결)

- 결함 카운터 `missed_pongs`를 **제거**하고 `last_pong_at`을 단일 liveness 진실로.
- shared `heartbeat_should_close ~now ~last_pong_at ~threshold ~interval_s` (`now -. last_pong_at > threshold * interval`)를 `server_mcp_transport_ws.ml`에 두고 양쪽 loop가 호출 → single-source.
- `record_pong`이 `last_pong_at` 갱신 → **responsive client는 절대 close 안 됨**(answered-ping-aware).
- 의미 보존: `threshold * interval` 무응답 시 close ≈ 기존 N-tick.

## 변경 파일

- `lib/server/server_mcp_transport_ws.ml` (`.mli`): `missed_pongs` 제거, `heartbeat_should_close` helper 추가/노출, upgrade loop가 helper 사용.
- `lib/server/server_ws_standalone.ml`: standalone loop가 shared helper 호출.
- `test/test_ws_transport.ml`: `heartbeat_should_close` 순수 회귀(responsive-client-at-threshold-1 = #21509 포함) 추가, `missed_pongs` 참조 테스트 교체.

## 검증

- `dune build @check` rc=0 (전체 — record 필드 제거가 모든 consumer에서 컴파일러 검출, 0 에러).
- `test_ws_transport` 50 tests, **Test Successful**. `heartbeat_liveness` 3/3(responsive client not closed #21509 포함), `pong_state` 2/2, `pong_threshold` 2/2.
- ocamlformat: 변경한 `.ml/.mli/test` 4파일만(base-broken `dune` auto-promote는 revert — surgical 유지).

## 워크어라운드 self-check

결함 카운터를 **제거**(추가 아님), close 판정 single-source helper, telemetry-as-fix / string-classifier / N-of-M / cap-cooldown / catch-all 없음.

후속(scope 밖): dead `upgrade_connection`/`start_upgrade_heartbeat` 경로 삭제는 별도 cleanup PR.

RFC-WAIVED: `lib/server` WS transport로 credential/identity/operator-control/sandbox/hooks/workflow RFC 게이트 subsystem 아님. 동작 보존형 root fix이며 워크어라운드 시그니처 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
