### PR TITLE
fix(keeper): repair identity drift

### DIFF
--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -3,7 +3,65 @@ base = "base.toml"
 # autoboot_enabled = true because base.toml is now autoboot_enabled=false
 # (loader template, not bootable). See fix/base-toml-goal-required PR.
 autoboot_enabled = true
-persona_name = "analyst"
-will = "부드럽게 이해하되 결론은 분명하게 말하고, 확인되지 않은 정보는 끝까지 유보한다."
-needs = "원문 출처, 논문·연구·리포트 수준의 근거, 비교 가능한 수치, 질문의 실제 의사결정 맥락"
-desires = "사용자가 무엇을 믿어야 하고 무엇을 아직 의심해야 하는지, 그리고 어떤 구현이 베스트 프랙티스 대비 실제로 우위인지 분명히 이해하게 만든다."
+persona_name = "masc-improver"
+goal = "코드베이스의 구조적 품질을 개선한다. mutable -> immutable, god file 분할, dead code 제거, 타입 강화."
+active_goal_ids = ["goal-masc-improver", "goal-codex-cli-cascade-usability"]
+short_goal = "보드와 이슈에서 리팩토링 대상을 발견하고, 하나씩 worktree에서 수정한다."
+mid_goal = "반복되는 안티패턴을 근본 원인 수준에서 제거하여 같은 종류의 fix가 재발하지 않게 한다."
+long_goal = "코드베이스 전체에서 mutable 의존을 최소화하고, 모듈 경계를 명확하게 유지한다."
+
+will = "코드를 읽고, 문제를 찾고, 가장 작은 단위로 고친다. 큰 변경은 쪼갠다."
+needs = "파일 시스템 접근, gh CLI, shell, 코드 검색. 보드에서 다른 keeper의 발견을 수집."
+desires = "매 턴마다 하나의 구체적 개선을 PR로 만든다. 추상적 제안이 아니라 실행."
+
+instructions = """
+너는 리팩토링 엔지니어다. 코드 품질에 집착하고, 말보다 코드와 검증으로 증명한다.
+보드에는 발견한 문제, 접근법, 수정 결과, 검증 증거만 남긴다.
+
+행동 규칙:
+1. 매 턴 시작 시 보드와 task 목록에서 본인이 처리할 수 있는 구체적 개선을 찾는다.
+2. 할 일이 없으면 파일을 읽고 명령어로 코드를 탐색하여 개선점을 찾는다.
+3. 발견하면 보드에 문제와 접근법을 공유한 뒤 task를 claim한다.
+4. 수정은 항상 target repo의 worktree에서 진행한다.
+5. PR은 항상 draft로 열고, 하나의 PR에는 하나의 관심사만 담는다.
+6. PR 전에는 관련 검증을 직접 실행하고, 명령/결과/수치를 PR 본문에 남긴다.
+7. push를 한 번 더 했으면 이전 검증은 stale로 간주하고 다시 돌린다.
+8. 최근 self-authored open PR이 있으면 새 작업보다 먼저 다시 연다. CI, review comment, requested changes, 검증 섹션 최신성을 확인한다.
+9. 리뷰 코멘트에 답만 달지 않는다. 필요한 수정 후 어떤 검증을 다시 돌렸는지 남긴다.
+10. 추측으로 코드를 고치지 않는다. 먼저 읽고, caller를 확인하고, 영향 범위를 파악한 뒤 수정한다.
+"""
+
+mention_targets = ["masc-improver", "improver", "refactorer"]
+
+proactive_enabled = true
+proactive_idle_sec = 300
+proactive_cooldown_sec = 480
+sandbox_profile = "local"
+network_mode = "inherit"
+
+max_turns_per_call = 30
+max_turns_per_call_scheduled_autonomous = 10
+
+telemetry_feedback_enabled = true
+telemetry_feedback_window_hours = 24
+
+tool_access = [
+  "keeper_tool_search",
+  "keeper_tasks_list",
+  "keeper_task_claim",
+  "keeper_task_start",
+  "keeper_task_done",
+  "keeper_task_submit_for_verification",
+  "keeper_board_comment",
+  "keeper_board_curation_submit",
+  "tool_search_files",
+  "tool_read_file",
+  "tool_edit_file",
+  "tool_write_file",
+  "tool_execute",
+  "masc_tasks",
+  "masc_transition",
+  "masc_task_history",
+  "masc_plan_get",
+  "masc_plan_get_task"
+]

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -291,6 +291,62 @@ let resynced_tool_access
   | Some tools -> normalize_tool_names tools
   | None -> meta.tool_access
 
+let drift_if label changed =
+  if changed then Some label else None
+
+let goal_horizon_text_equal current target =
+  String.equal
+    (normalize_goal_horizon_text current)
+    (normalize_goal_horizon_text target)
+
+let keeper_meta_persistent_drift_categories
+    ~(defaults : Keeper_types_profile.keeper_profile_defaults)
+    ~(current : keeper_meta)
+    ~(target : keeper_meta) =
+  List.filter_map Fun.id
+    [
+      drift_if "persona" (current.persona <> target.persona);
+      drift_if "proactive" (current.proactive <> target.proactive);
+      drift_if "tool_access" (current.tool_access <> target.tool_access);
+      drift_if "tool_denylist" (current.tool_denylist <> target.tool_denylist);
+      drift_if "social_model" (current.social_model <> target.social_model);
+      drift_if "goal" (not (goal_horizon_text_equal current.goal target.goal));
+      drift_if "short_goal"
+        (not (goal_horizon_text_equal current.short_goal target.short_goal));
+      drift_if "mid_goal"
+        (not (goal_horizon_text_equal current.mid_goal target.mid_goal));
+      drift_if "long_goal"
+        (not (goal_horizon_text_equal current.long_goal target.long_goal));
+      drift_if "will" (not (personality_text_equal current.will target.will));
+      drift_if "needs" (not (personality_text_equal current.needs target.needs));
+      drift_if "desires"
+        (not (personality_text_equal current.desires target.desires));
+      drift_if "instructions"
+        (not (personality_text_equal current.instructions target.instructions));
+      drift_if "autoboot_enabled"
+        (current.autoboot_enabled <> target.autoboot_enabled);
+      drift_if "mention_targets"
+        (current.mention_targets <> target.mention_targets);
+      drift_if "active_goal_ids"
+        (Option.is_some defaults.active_goal_ids
+         && current.active_goal_ids <> target.active_goal_ids);
+      drift_if "sandbox_profile"
+        (current.sandbox_profile <> target.sandbox_profile);
+      drift_if "sandbox_image" (current.sandbox_image <> target.sandbox_image);
+      drift_if "network_mode" (current.network_mode <> target.network_mode);
+      drift_if "allowed_paths"
+        (Option.is_some defaults.allowed_paths
+         && current.allowed_paths <> target.allowed_paths);
+      drift_if "telemetry_feedback_enabled"
+        (current.telemetry_feedback_enabled <> target.telemetry_feedback_enabled);
+      drift_if "telemetry_feedback_window_hours"
+        (current.telemetry_feedback_window_hours
+         <> target.telemetry_feedback_window_hours);
+      drift_if "always_approve"
+        (current.always_approve <> target.always_approve);
+      drift_if "oas_env" (current.oas_env <> target.oas_env);
+    ]
+
 let ensure_keeper_meta_with_cause config name =
   match read_meta config name with
   | Ok (Some meta) ->
@@ -428,25 +484,20 @@ let ensure_keeper_meta_with_cause config name =
         oas_env = target_oas_env;
       }
     in
-    (* Runtime JSON intentionally omits TOML-owned config/personality
-       fields.  They must be overlaid into the returned meta for the
-       live registry, but comparing those omitted fields against TOML
-       would classify every reconcile tick as a write-worthy drift.
-       [active_goal_ids] can also be runtime-owned when set explicitly via
-       keeper_up, but when supplied by TOML it remains an overlay-only
-       declarative scope rather than being copied into runtime JSON. *)
-    let oas_env_changed = meta.oas_env <> target_oas_env in
-    let persistent_changed = oas_env_changed in
-    let overlay_without_persistent_changes =
-      { overlayed with
-        oas_env = meta.oas_env;
-      }
+    (* Keep the runtime snapshot honest as well as the live overlay.  The
+       previous overlay-only path made operators see stale JSON forever
+       (for example persona=analyst while TOML declared masc-improver),
+       which hid prompt/tool/autonomy drift from health and bootstrap
+       checks.  Runtime-owned list fields are only persisted when TOML
+       explicitly owns them, avoiding accidental allowed_paths or
+       active_goal_ids erasure. *)
+    let cats =
+      keeper_meta_persistent_drift_categories
+        ~defaults
+        ~current:meta
+        ~target:overlayed
     in
-
-    if persistent_changed then begin
-      let cats = List.filter_map Fun.id [
-        (if oas_env_changed then Some "oas_env" else None);
-      ] in
+    if cats <> [] then begin
       Log.Keeper.info
         "ensure_keeper_meta: re-syncing [%s] for %s"
         (String.concat "," cats)
@@ -460,7 +511,7 @@ let ensure_keeper_meta_with_cause config name =
           ~labels:[("keeper", updated.name); ("phase", "ensure_meta_resync")]
           ();
         Log.Keeper.warn "ensure_keeper_meta: write_meta re-sync failed: %s" e;
-        Ok overlay_without_persistent_changes
+        Ok overlayed
     end
     else Ok overlayed))
   | Ok None ->

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -459,6 +459,33 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
       Some (keeper_fleet_meta_scan (Mcp_server.workspace_config state))
     | None -> None
   in
+  let keeper_identity_drift_json =
+    compute_section ~name:"keeper_identity_drift" ?section_timings_ref
+      (fun () ->
+        match current_server_state_opt () with
+        | Some state ->
+          keeper_identity_drift_health_json (Mcp_server.workspace_config state)
+        | None ->
+          `Assoc
+            [
+              ("schema", `String "masc.keeper_identity_drift.v1");
+              ("status", `String "snapshot_not_ready");
+              ("blocking", `Bool false);
+              ("terminal_reason", `String "snapshot_not_ready");
+              ("operator_action_required", `Bool false);
+              ("configured_keeper_count", `Int 0);
+              ("configured_keeper_names", `List []);
+              ("materializable_configured_keeper_count", `Int 0);
+              ("materializable_configured_keeper_names", `List []);
+              ("persisted_meta_count", `Int 0);
+              ("persisted_meta_names", `List []);
+              ("configured_without_meta_count", `Int 0);
+              ("configured_without_meta_names", `List []);
+              ("meta_without_config_count", `Int 0);
+              ("meta_without_config_names", `List []);
+              ("next_action", `String "none");
+            ])
+  in
   let paused_keepers_json =
     compute_section ~name:"paused_keepers" ?section_timings_ref
       (fun () ->
@@ -531,6 +558,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
         ~starting_keepers:0 ~requested_keepers:24 () );
     ("fd_accountant", fd_accountant_json);
     ("keeper_fleet_safety", keeper_fleet_safety);
+    ("keeper_identity_drift", keeper_identity_drift_json);
     ("keeper_reaction_ledger", reaction_ledger_json);
     (* Paused-keeper visibility: a keeper with [meta.paused = true] does not
        run turns, and auto-paused keepers may no longer have a live registry
@@ -627,6 +655,7 @@ let full_health_cached_field_names =
     "keeper_fd_pressure";
     "fd_accountant";
     "keeper_fleet_safety";
+    "keeper_identity_drift";
     "keeper_reaction_ledger";
     "paused_keepers";
     "cdal";
@@ -660,6 +689,27 @@ let full_health_placeholder_fields ?error ?(component_timed_out = false)
     ( "keeper_fleet_safety",
       full_health_component_placeholder ?error ~component_timed_out ~status
         "keeper_fleet_safety" );
+    ( "keeper_identity_drift",
+      `Assoc
+        [
+          ("schema", `String "masc.keeper_identity_drift.v1");
+          ("status", `String status);
+          ("blocking", `Bool false);
+          ("terminal_reason", `String "snapshot_not_ready");
+          ("operator_action_required", `Bool false);
+          ("configured_keeper_count", `Int 0);
+          ("configured_keeper_names", `List []);
+          ("materializable_configured_keeper_count", `Int 0);
+          ("materializable_configured_keeper_names", `List []);
+          ("persisted_meta_count", `Int 0);
+          ("persisted_meta_names", `List []);
+          ("configured_without_meta_count", `Int 0);
+          ("configured_without_meta_names", `List []);
+          ("meta_without_config_count", `Int 0);
+          ("meta_without_config_names", `List []);
+          ("next_action", `String "none");
+          ("component_timed_out", `Bool component_timed_out);
+        ] );
     ( "keeper_reaction_ledger",
       full_health_component_placeholder ?error ~component_timed_out ~status
         "keeper_reaction_ledger" );

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -212,6 +212,14 @@ type keeper_fleet_meta_scan = {
   bootable_names : string list;
 }
 
+type keeper_identity_drift_scan = {
+  configured_names : string list;
+  persisted_meta_names : string list;
+  materializable_configured_names : string list;
+  configured_without_meta_names : string list;
+  meta_without_config_names : string list;
+}
+
 let sort_paused_keeper_details details =
   List.sort
     (fun left right ->
@@ -486,6 +494,97 @@ let keeper_phase_counts ?base_path () = (keeper_phase_snapshot ?base_path ()).co
 
 let string_set_of_list values =
   List.fold_left (fun acc value -> String_set.add value acc) String_set.empty values
+
+let json_string_list values = Json_util.json_string_list values
+
+let configured_keeper_is_materializable name =
+  try
+    let defaults = Keeper_types_profile.load_keeper_profile_defaults name in
+    (* Exclude loader-only TOMLs such as base.toml from identity drift. *)
+    Option.is_some defaults.persona_name
+    || Option.is_some defaults.goal
+    || defaults.mention_targets <> []
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | _ -> true
+
+let keeper_identity_drift_scan config =
+  let configured_names =
+    Keeper_meta_store.configured_keeper_names config |> sorted_unique_strings
+  in
+  let persisted_meta_names =
+    Keeper_meta_store.persisted_keeper_names config |> sorted_unique_strings
+  in
+  let materializable_configured_names =
+    configured_names
+    |> List.filter configured_keeper_is_materializable
+    |> sorted_unique_strings
+  in
+  let configured_set = string_set_of_list materializable_configured_names in
+  let persisted_set = string_set_of_list persisted_meta_names in
+  {
+    configured_names;
+    persisted_meta_names;
+    materializable_configured_names;
+    configured_without_meta_names =
+      materializable_configured_names
+      |> List.filter (fun name -> not (String_set.mem name persisted_set))
+      |> sorted_unique_strings;
+    meta_without_config_names =
+      persisted_meta_names
+      |> List.filter (fun name -> not (String_set.mem name configured_set))
+      |> sorted_unique_strings;
+  }
+
+let keeper_identity_drift_health_json_of_scan scan =
+  let configured_without_meta_count =
+    List.length scan.configured_without_meta_names
+  in
+  let meta_without_config_count = List.length scan.meta_without_config_names in
+  let blocking = meta_without_config_count > 0 in
+  let status =
+    if blocking then "blocked"
+    else if configured_without_meta_count > 0 then "degraded"
+    else "ok"
+  in
+  let terminal_reason =
+    if meta_without_config_count > 0 then "runtime_meta_without_keeper_toml"
+    else if configured_without_meta_count > 0 then "configured_keeper_without_runtime_meta"
+    else "none"
+  in
+  `Assoc
+    [
+      ("schema", `String "masc.keeper_identity_drift.v1");
+      ("status", `String status);
+      ("blocking", `Bool blocking);
+      ("terminal_reason", `String terminal_reason);
+      ("operator_action_required", `Bool (status <> "ok"));
+      ("configured_keeper_count", `Int (List.length scan.configured_names));
+      ( "configured_keeper_names",
+        json_string_list scan.configured_names );
+      ( "materializable_configured_keeper_count",
+        `Int (List.length scan.materializable_configured_names) );
+      ( "materializable_configured_keeper_names",
+        json_string_list scan.materializable_configured_names );
+      ("persisted_meta_count", `Int (List.length scan.persisted_meta_names));
+      ("persisted_meta_names", json_string_list scan.persisted_meta_names);
+      ("configured_without_meta_count", `Int configured_without_meta_count);
+      ( "configured_without_meta_names",
+        json_string_list scan.configured_without_meta_names );
+      ("meta_without_config_count", `Int meta_without_config_count);
+      ( "meta_without_config_names",
+        json_string_list scan.meta_without_config_names );
+      ( "next_action",
+        `String
+          (if meta_without_config_count > 0 then
+             "add_matching_keeper_toml_or_retire_stale_meta"
+           else if configured_without_meta_count > 0 then
+             "materialize_configured_keeper_or_disable_unused_toml"
+           else "none") );
+    ]
+
+let keeper_identity_drift_health_json config =
+  keeper_identity_drift_scan config |> keeper_identity_drift_health_json_of_scan
 
 let json_string_list_field field = function
   | `Assoc fields -> (

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -51,12 +51,24 @@ type keeper_fleet_meta_scan = {
   autoboot_scan : autoboot_keeper_scan;
   bootable_names : string list;
 }
+type keeper_identity_drift_scan = {
+  configured_names : string list;
+  persisted_meta_names : string list;
+  materializable_configured_names : string list;
+  configured_without_meta_names : string list;
+  meta_without_config_names : string list;
+}
 val sort_paused_keeper_details :
   ([> `Assoc of (string * [> `String of String.t ]) list ] as 'a) list ->
   'a list
 val keeper_fleet_meta_scan :
   ?include_paused_details:bool ->
   Workspace.config -> keeper_fleet_meta_scan
+val configured_keeper_is_materializable : string -> bool
+val keeper_identity_drift_scan : Workspace.config -> keeper_identity_drift_scan
+val keeper_identity_drift_health_json_of_scan :
+  keeper_identity_drift_scan -> Yojson.Safe.t
+val keeper_identity_drift_health_json : Workspace.config -> Yojson.Safe.t
 val autoboot_enabled_keeper_scan :
   Workspace.config -> autoboot_keeper_scan
 type keeper_phase_counts = {

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -7,6 +7,7 @@ module Turn = Masc.Keeper_turn
 module Keeper_tool_surface = Masc.Keeper_tool_surface
 module Keeper_tool_surface_ops = Masc.Keeper_tool_surface_ops
 module Heartbeat_presence = Masc.Keeper_heartbeat_loop_presence
+module Runtime = Masc.Keeper_runtime
 
 let temp_dir () =
   let path = Filename.temp_file "keeper-effective-meta-" "" in
@@ -323,6 +324,101 @@ tool_access = ["tool_execute"]
         (Some "profile instructions")
         (json_string_field "instructions" self_model)
 
+let test_ensure_keeper_meta_persists_toml_identity_snapshot () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "masc-improver" in
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+persona_name = "masc-improver"
+sandbox_profile = "docker"
+goal = "Improve MASC autonomously"
+short_goal = "Restore aggressive keeper autonomy"
+proactive_enabled = true
+proactive_idle_sec = 77
+proactive_cooldown_sec = 88
+tool_access = ["tool_execute", "tool_read_file"]
+allowed_paths = ["workspace/yousleepwhen/masc"]
+active_goal_ids = ["goal-masc-improver"]
+|};
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  let persisted =
+    match Store.read_meta config name with
+    | Ok (Some meta) -> meta
+    | Ok None -> Alcotest.fail "expected seeded keeper meta"
+    | Error err -> Alcotest.failf "read_meta failed: %s" err
+  in
+  let stale =
+    {
+      persisted with
+      persona = Some "analyst";
+      goal = "stale goal";
+      short_goal = "stale short goal";
+      proactive = { enabled = false; idle_sec = 1; cooldown_sec = 2 };
+      tool_access = [ "masc_status" ];
+      allowed_paths = [ "/tmp/stale-local-path" ];
+      active_goal_ids = [ "stale-goal" ];
+    }
+  in
+  (match Store.write_meta config stale with
+   | Ok () -> ()
+   | Error err -> Alcotest.failf "write stale meta failed: %s" err);
+  let returned =
+    match Runtime.ensure_keeper_meta config name with
+    | Ok meta -> meta
+    | Error err -> Alcotest.failf "ensure_keeper_meta failed: %s" err
+  in
+  let disk =
+    match Store.read_meta config name with
+    | Ok (Some meta) -> meta
+    | Ok None -> Alcotest.fail "expected re-synced keeper meta"
+    | Error err -> Alcotest.failf "read re-synced meta failed: %s" err
+  in
+  List.iter
+    (fun (label, meta) ->
+      Alcotest.(check (option string))
+        (label ^ " persona is TOML canonical")
+        (Some "masc-improver")
+        meta.persona;
+      Alcotest.(check string)
+        (label ^ " goal is TOML canonical")
+        "Improve MASC autonomously"
+        meta.goal;
+      Alcotest.(check string)
+        (label ^ " short_goal is TOML canonical")
+        "Restore aggressive keeper autonomy"
+        meta.short_goal;
+      Alcotest.(check bool)
+        (label ^ " proactive enabled is TOML canonical")
+        true
+        meta.proactive.enabled;
+      Alcotest.(check int)
+        (label ^ " proactive idle is TOML canonical")
+        77
+        meta.proactive.idle_sec;
+      Alcotest.(check int)
+        (label ^ " proactive cooldown is TOML canonical")
+        88
+        meta.proactive.cooldown_sec;
+      Alcotest.(check (list string))
+        (label ^ " tool_access is TOML canonical")
+        [ "tool_execute"; "tool_read_file" ]
+        meta.tool_access;
+      Alcotest.(check string)
+        (label ^ " sandbox_profile is TOML canonical")
+        "docker"
+        (Profile.sandbox_profile_to_string meta.sandbox_profile);
+      Alcotest.(check (list string))
+        (label ^ " allowed_paths is TOML canonical")
+        [ "workspace/yousleepwhen/masc" ]
+        meta.allowed_paths;
+      Alcotest.(check (list string))
+        (label ^ " active_goal_ids is TOML canonical")
+        [ "goal-masc-improver" ]
+        meta.active_goal_ids)
+    [ ("returned", returned); ("disk", disk) ]
+
 let test_turn_setup_uses_effective_meta () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
   let name = "turnsetup" in
@@ -616,6 +712,9 @@ let () =
           Alcotest.test_case
             "profile identity snapshot reaches meta JSON"
             `Quick test_profile_identity_snapshot_reaches_meta_json;
+          Alcotest.test_case
+            "ensure keeper meta persists TOML identity snapshot"
+            `Quick test_ensure_keeper_meta_persists_toml_identity_snapshot;
           Alcotest.test_case "status resolves keeper alias names" `Quick
             test_status_resolves_keeper_alias_names;
           Alcotest.test_case "keeper surface resolves alias names" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1183,6 +1183,61 @@ let test_health_json_surfaces_durable_paused_keepers () =
             true
             (reaction_ledger |> member "operator_action_required" |> to_bool)))
 
+let test_keeper_identity_drift_health_json_surfaces_config_meta_split () =
+  with_temp_dir "keeper-identity-drift" (fun dir ->
+    let config_root = make_config_root dir in
+    Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
+    write_config_root_keeper_toml config_root "mad-improver";
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = Mcp_server.workspace_config state in
+        write_keeper_meta_exn config
+          (make_keeper_meta ~name:"masc-improver" ~trace_id:"trace-masc-improver" ());
+        let json =
+          Server_routes_http_runtime_fleet_scan.keeper_identity_drift_health_json
+            config
+        in
+        let open Yojson.Safe.Util in
+        Alcotest.(check string) "drift schema" "masc.keeper_identity_drift.v1"
+          (json |> member "schema" |> to_string);
+        Alcotest.(check string) "drift status" "blocked"
+          (json |> member "status" |> to_string);
+        Alcotest.(check bool) "drift blocks on stale meta" true
+          (json |> member "blocking" |> to_bool);
+        Alcotest.(check string) "drift terminal reason"
+          "runtime_meta_without_keeper_toml"
+          (json |> member "terminal_reason" |> to_string);
+        Alcotest.(check bool) "drift asks operator action" true
+          (json |> member "operator_action_required" |> to_bool);
+        Alcotest.(check (list string)) "materializable configured names"
+          [ "mad-improver" ]
+          (json |> member "materializable_configured_keeper_names" |> to_list
+           |> List.map to_string);
+        Alcotest.(check (list string)) "configured without meta"
+          [ "mad-improver" ]
+          (json |> member "configured_without_meta_names" |> to_list
+           |> List.map to_string);
+        Alcotest.(check (list string)) "meta without config"
+          [ "masc-improver" ]
+          (json |> member "meta_without_config_names" |> to_list
+           |> List.map to_string);
+        Alcotest.(check string) "drift next action"
+          "add_matching_keeper_toml_or_retire_stale_meta"
+          (json |> member "next_action" |> to_string);
+        let request = Httpun.Request.create `GET "/health" in
+        let health = Server_routes_http_runtime.make_health_json request in
+        Alcotest.(check string) "health exposes drift status" "blocked"
+          (health |> member "keeper_identity_drift" |> member "status"
+           |> to_string)))
+
 let test_health_json_keeps_timeout_pause_without_policy_manual () =
   with_temp_dir "health-timeout-paused-without-policy" (fun dir ->
     let config_root = make_config_root dir in
@@ -3048,6 +3103,10 @@ let () =
           Alcotest.test_case
             "health json surfaces durable paused keepers"
             `Quick test_health_json_surfaces_durable_paused_keepers;
+          Alcotest.test_case
+            "health json surfaces keeper identity config/meta drift"
+            `Quick
+            test_keeper_identity_drift_health_json_surfaces_config_meta_split;
           Alcotest.test_case
             "health json keeps timeout pause without policy manual"
             `Quick test_health_json_keeps_timeout_pause_without_policy_manual;


### PR DESCRIPTION
## Summary

- make `masc-improver` keeper config self-describing instead of inheriting the `analyst` persona snapshot
- add `/health?full=1` visibility for keeper TOML/meta identity drift
- make `ensure_keeper_meta` persist TOML-owned identity/config fields back into runtime meta, not just overlay them in memory

## Root Cause

The runtime already overlaid keeper TOML defaults onto effective meta, but most TOML-owned fields were intentionally not written back to `.masc/keepers/*.json`. That made stale JSON such as `persona=analyst` survive indefinitely even when TOML declared a different keeper identity. Operators and health surfaces could then read stale runtime meta and misdiagnose prompt/tool/autonomy state.

## Behavior

- `keeper_identity_drift` health section now reports configured keepers, persisted meta names, config-without-meta, and meta-without-config.
- `meta_without_config` is blocking because a stale runtime JSON without matching keeper TOML can keep an obsolete identity alive.
- `ensure_keeper_meta` now re-syncs TOML-owned fields including persona, goals, proactive policy, tool access, sandbox/network config, explicit `allowed_paths`, explicit `active_goal_ids`, telemetry flags, approval policy, and OAS env.
- Runtime-owned list fields are only persisted when TOML explicitly owns them, avoiding accidental `allowed_paths` or `active_goal_ids` erasure.

## Validation

- `ocamlformat --check lib/keeper/keeper_runtime.ml test/test_keeper_effective_meta_overlay.ml lib/server/server_routes_http_runtime_fleet_scan.ml lib/server/server_routes_http_runtime_fleet_scan.mli lib/server/server_routes_http_runtime.ml test/test_server_runtime_bootstrap.ml`
- `git diff --check origin/main...HEAD`

Not run: full Dune build/test suite, per operator request.
