### PR TITLE
fix(server): terminate activity SSE keepalive loop on client disconnect (#21562)

### DIFF
--- a/lib/server/server_activity_http.ml
+++ b/lib/server/server_activity_http.ml
@@ -254,6 +254,30 @@ let close_stream info =
           Httpun.Body.Writer.close info.writer
       end)
 
+(* Keepalive loop for an activity SSE stream. Sleeps [interval_s] then calls
+   [send]; repeats until [stop] is set or [send] returns [false] (the client is
+   gone — writer closed / write failed). Setting [stop] on a [false] send makes
+   a disconnected client terminate the loop instead of spinning on the
+   server-lifetime switch until shutdown.
+
+   Root cause of #21562: the previous loop did [ignore (send_raw …)] and only
+   re-checked [info.stop], which nothing on the disconnect path ever set — so
+   one fiber leaked per disconnected SSE client. [Eio.Time.sleep] is a
+   cancellation point, so cancelling the owning switch still interrupts a
+   parked loop promptly and [Eio.Cancel.Cancelled] propagates to the caller for
+   fiber teardown. The blocking wait is injected as [sleep] so the loop's
+   control flow is deterministic and unit-testable in isolation from the clock.
+   Exposed for unit testing. *)
+let run_keepalive_loop ~sleep ~stop ~send =
+  let rec loop () =
+    if not !stop
+    then begin
+      sleep ();
+      if not !stop then if send () then loop () else stop := true
+    end
+  in
+  loop ()
+
 let handle_stream ~deps ~state request reqd =
   let origin = deps.get_origin request in
   let session_id =
@@ -307,22 +331,21 @@ let handle_stream ~deps ~state request reqd =
   (match (deps.get_switch (), deps.get_clock ()) with
   | Some sw, Some clock ->
       Eio.Fiber.fork ~sw (fun () ->
-          let is_cancelled = function
-            | Eio.Cancel.Cancelled _ -> true
-            | _ -> false
-          in
-          let rec loop () =
-            if not !(info.stop) then begin
-              (try Eio.Time.sleep clock keepalive_interval_s
-               with Eio.Cancel.Cancelled _ as e -> raise e | exn -> if is_cancelled exn then raise exn);
-              if not !(info.stop) then
-                ignore (send_raw info ": keepalive\n\n");
-              loop ()
-            end
-          in
-          try loop ()
-          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-            if not (is_cancelled exn) then close_stream info;
-            Activity_graph.unregister_if_current info.session_id info.client_id)
+          Fun.protect
+            ~finally:(fun () ->
+              Activity_graph.unregister_if_current info.session_id info.client_id)
+            (fun () ->
+              match
+                run_keepalive_loop
+                  ~sleep:(fun () -> Eio.Time.sleep clock keepalive_interval_s)
+                  ~stop:info.stop
+                  ~send:(fun () -> send_raw info ": keepalive\n\n")
+              with
+              | () -> close_stream info
+              | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+              | exception exn ->
+                  Log.Social.warn "activity keepalive fiber exception: %s"
+                    (Printexc.to_string exn);
+                  close_stream info))
   | None, _ | Some _, None -> ());
   ()

--- a/lib/server/server_activity_http.mli
+++ b/lib/server/server_activity_http.mli
@@ -53,6 +53,16 @@ val slice_default_events_to_limit :
     ["limit"], and ["next_after_seq"] accordingly.  Pure —
     exposed for unit testing ({!Test_server_activity_http}). *)
 
+val run_keepalive_loop :
+  sleep:(unit -> unit) -> stop:bool ref -> send:(unit -> bool) -> unit
+(** [run_keepalive_loop ~sleep ~stop ~send] runs the SSE keepalive loop:
+    [sleep ()] then [send ()], repeating until [stop] is set or [send] returns
+    [false] (the client disconnected), at which point [stop] is set so a
+    disconnected client terminates the loop instead of spinning on the
+    server-lifetime switch until shutdown (#21562).  The blocking wait is
+    injected as [sleep] so the control flow is deterministic — exposed for unit
+    testing ({!Test_server_activity_http}). *)
+
 (** {1 JSON dispatchers}
 
     All three take [~deps ~state request] and return a

--- a/test/test_server_activity_http.ml
+++ b/test/test_server_activity_http.ml
@@ -115,9 +115,44 @@ let test_count_and_limit_updated () =
   check (option int) "count updated" (Some 2) (get_int_field "count" got);
   check (option int) "limit updated" (Some 2) (get_int_field "limit" got)
 
+(* #21562 regression: the keepalive loop must terminate when the client is
+   gone ([send] returns [false]) instead of spinning on the server-lifetime
+   switch until shutdown.  [sleep] is injected as a no-op so the control flow
+   is exercised deterministically without a clock. *)
+let test_keepalive_loop_terminates_on_client_gone () =
+  let stop = ref false in
+  let sends = ref 0 in
+  let send () =
+    incr sends;
+    (* client alive for two keepalives, disconnected on the third *)
+    !sends < 3
+  in
+  Server_activity_http.run_keepalive_loop ~sleep:(fun () -> ()) ~stop ~send;
+  check bool "stop is set once the client is gone" true !stop;
+  check int "loop halts on the failing send (no further iterations)" 3 !sends
+
+(* The loop must also honour an externally-set [stop] (e.g. [close_stream]
+   from the disconnect path) at the top guard. *)
+let test_keepalive_loop_honours_external_stop () =
+  let stop = ref false in
+  let sends = ref 0 in
+  let send () =
+    incr sends;
+    stop := true;
+    true
+  in
+  Server_activity_http.run_keepalive_loop ~sleep:(fun () -> ()) ~stop ~send;
+  check int "loop halts at the top guard after external stop" 1 !sends
+
 let () =
   run "Server_activity_http"
-    [ ( "slice_default_events_to_limit"
+    [ ( "keepalive_loop"
+      , [ test_case "terminates when client is gone" `Quick
+            test_keepalive_loop_terminates_on_client_gone
+        ; test_case "honours external stop" `Quick
+            test_keepalive_loop_honours_external_stop
+        ] )
+    ; ( "slice_default_events_to_limit"
       , [ test_case "len < limit" `Quick test_len_lt_limit
         ; test_case "len == limit" `Quick test_len_eq_limit
         ; test_case "len > limit" `Quick test_len_gt_limit


### PR DESCRIPTION
## 증상

`server_activity_http.ml`의 activity-stream keepalive fiber가 클라이언트 disconnect 시 종료되지 않고, **server-lifetime switch 위에서 server shutdown까지 30초마다 no-op로 스핀**합니다. SSE 클라이언트가 연결/해제를 반복할 때마다 fiber + closure(`stream_info`/writer)가 누적됩니다. quiet period에는 `Activity_graph` registration도 함께 잔류합니다 (push-path unregister는 dead client에 이벤트가 push될 때만 동작).

근거/반경: #21562. 동일 누수 클래스의 sibling(drain fiber blocked in `Eio.Stream.take`)은 `server_mcp_transport_http_conn.ml`에서 #21558이 per-connection switch로 이미 수정 — main 전수 스캔 결과 keepalive가 마지막 단일 사이트.

## 근본 원인

기존 keepalive 루프:
```ocaml
if not !(info.stop) then
  ignore (send_raw info ": keepalive\n\n");   (* false(client gone)를 버림 *)
loop ()
```
- `send_raw`는 disconnect 시 `false`를 반환하나 `ignore`로 버려짐.
- 루프 종료 조건은 `!(info.stop)`뿐인데, disconnect 경로 어디에서도 `info.stop`을 set하지 않음 (`info.stop := true`는 `close_stream` 단일 출처, 그 호출자는 fiber 자신의 outer handler 하나뿐 — `loop()`가 비-Cancelled 예외를 propagate할 때만 실행되는데 `loop()`는 그러지 않음).
- 추가: inner `try Eio.Time.sleep … with Cancelled -> raise | exn -> if is_cancelled exn then raise` 에서 arm 2는 dead(arm 1이 이미 Cancelled 재-raise) → 비-Cancelled 예외 silent swallow.

## 수정

1. **`run_keepalive_loop ~sleep ~stop ~send` 추출** — `send`가 `false`(client gone) 반환 시 `stop := true`로 루프 종료. 블로킹 대기를 `sleep` thunk로 주입해 제어흐름(결정론)을 clock과 분리, 단위 테스트 가능. cancellation point(`Eio.Time.sleep`)는 `handle_stream`이 넘기는 thunk 안에 유지되어 switch cancel이 parked 루프를 즉시 끊고 `Cancelled`가 전파됨.
2. **`handle_stream` 재배선** — `Fun.protect ~finally`로 **모든 종료 경로(정상/disconnect/cancel/예외)에서 `unregister_if_current` 보장**. 정상 종료 → `close_stream`(writer 정리), `Cancelled` → 전파, 예기치 못한 예외 → **로그 후 `close_stream`** (기존 silent swallow 제거).
3. dead `is_cancelled` inner try 제거.

## 테스트

`test_server_activity_http.ml`에 회귀 테스트 2개 추가 (`sleep` no-op 주입이라 clock/Eio_main 불필요, 결정론적):
- `terminates when client is gone`: `send`가 3번째에 `false` → `stop` set + 루프가 그 시점에 정확히 종료(추가 반복 없음).
- `honours external stop`: `send`가 `stop:=true` 설정 → 다음 top guard에서 종료.

## 검증 (로컬)

- `dune build test/test_server_activity_http.exe` — **OK** (clean compile; `.mli` 시그니처 포함)
- `test_server_activity_http.exe` — **9 tests, Test Successful** (신규 keepalive_loop 2개 + 기존 slice 7개 회귀 없음)
- `ocamlformat 0.29.0 -i` (프로젝트 `.ocamlformat`와 일치) 적용
- `pr-rfc-check.sh --pr-body` — PASS (RFC-gated 아님, workaround 시그니처 없음)

## 경계 / 비-워크어라운드

- 루트 수정: silent failure 제거(send 실패가 루프 종료를 유도) + fiber 수명 = 논리 수명. telemetry-as-fix / string-classifier / N-of-M / cap-cooldown 시그니처 없음.
- `lib/server/server_activity_http.ml`은 RFC-gated subsystem(credential/repo/operator/sandbox/dashboard-credential/hooks/workflow) 아님.
- `run_keepalive_loop`의 `.mli` 노출은 `parse_since_ms`/`slice_default_events_to_limit` 선례를 따른 "exposed for unit testing"의 순수 DI 함수 — 상태 mutation/reset backdoor 아님.

Closes #21562.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
