### PR TITLE
fix(keeper): scope config discovery to workspace

### DIFF
--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -349,6 +349,21 @@ let prompts_dir () =
 let keepers_dir () =
   (resolve ()).keepers.path
 
+let inputs_for_base_path ~base_path =
+  {
+    cwd = base_path;
+    executable_name = Sys.executable_name;
+    env_base_path = Some base_path;
+    env_config_dir = current_env_config_dir_opt ();
+    env_personas_dir = current_env_personas_dir_opt ();
+  }
+
+let resolve_for_base_path ~base_path =
+  resolve_with (inputs_for_base_path ~base_path)
+
+let keepers_dir_for_base_path ~base_path =
+  (resolve_for_base_path ~base_path).keepers.path
+
 let personas_dir_opt () =
   let resolution = resolve () in
   match resolution.config_root.source with
@@ -399,6 +414,11 @@ let personas_dirs_with inputs resolution =
     in
     dedupe_paths primary
 
+let personas_dirs_for_base_path ~base_path =
+  let inputs = inputs_for_base_path ~base_path in
+  let resolution = resolve_with inputs in
+  personas_dirs_with inputs resolution
+
 let personas_dirs () =
   let resolution = resolve () in
   let inputs = inputs_from_env () in
@@ -406,6 +426,12 @@ let personas_dirs () =
 
 let keeper_toml_path_opt name =
   let path = Filename.concat (keepers_dir ()) (name ^ ".toml") in
+  if existing_file path then Some path else None
+
+let keeper_toml_path_opt_for_base_path ~base_path name =
+  let path =
+    Filename.concat (keepers_dir_for_base_path ~base_path) (name ^ ".toml")
+  in
   if existing_file path then Some path else None
 
 let warnings () =

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -78,6 +78,23 @@ val personas_dirs_with : inputs -> resolution -> string list
 val keeper_toml_path_opt : string -> string option
 (** [keeper_toml_path_opt name] checks for [keepers/<name>.toml]. *)
 
+val resolve_for_base_path : base_path:string -> resolution
+(** Resolve the config root for an explicit workspace [base_path]. Explicit
+    [MASC_CONFIG_DIR] and [MASC_PERSONAS_DIR] overrides are still honored, but
+    ambient [MASC_BASE_PATH] and process cwd do not replace the caller's
+    workspace. *)
+
+val keepers_dir_for_base_path : base_path:string -> string
+(** [keepers_dir_for_base_path ~base_path] returns the keepers directory for an
+    explicit workspace base path. *)
+
+val personas_dirs_for_base_path : base_path:string -> string list
+(** Base-path-scoped variant of {!personas_dirs}. *)
+
+val keeper_toml_path_opt_for_base_path :
+  base_path:string -> string -> string option
+(** Base-path-scoped variant of {!keeper_toml_path_opt}. *)
+
 (** {1 .masc/ root sub-directory accessors (RFC-0121)}
 
     All non-config artifacts under [<base>/.masc/<sub>/] route through these

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -81,9 +81,10 @@ let persisted_keeper_names config =
     |> List.sort String.compare
 ;;
 
-let configured_keeper_names _config =
-  Config_dir_resolver.log_warnings ~context:"KeeperTypes" ();
-  Keeper_types_profile.discover_keepers_toml (Config_dir_resolver.keepers_dir ())
+let configured_keeper_names config =
+  Keeper_types_profile.discover_keepers_toml
+    (Config_dir_resolver.keepers_dir_for_base_path
+       ~base_path:config.Workspace.base_path)
   |> List.map fst
   |> dedupe_keep_order
 ;;
@@ -97,14 +98,24 @@ let keeper_names config =
   persisted_keeper_names config
 ;;
 
-let declarative_autoboot_enabled_by_default name =
-  match (load_keeper_profile_defaults name).autoboot_enabled with
+let declarative_autoboot_enabled_by_default config name =
+  match
+    (load_keeper_profile_defaults_for_base_path
+       ~base_path:config.Workspace.base_path
+       name)
+      .autoboot_enabled
+  with
   | Some false -> false
   | Some true | None -> true
 ;;
 
-let effective_autoboot_enabled name meta =
-  match (load_keeper_profile_defaults name).autoboot_enabled with
+let effective_autoboot_enabled config name meta =
+  match
+    (load_keeper_profile_defaults_for_base_path
+       ~base_path:config.Workspace.base_path
+       name)
+      .autoboot_enabled
+  with
   | Some value -> value
   | None -> meta.autoboot_enabled
 ;;
@@ -114,10 +125,12 @@ let keepalive_keeper_names config =
   |> List.filter_map (fun name ->
     match read_meta_file_path (keeper_meta_path config name) with
     | Ok (Some meta)
-      when (not meta.paused) && effective_autoboot_enabled name meta ->
+      when (not meta.paused) && effective_autoboot_enabled config name meta ->
         Some meta.name
     | Ok (Some _) -> None
-    | Ok None -> if declarative_autoboot_enabled_by_default name then Some name else None
+    | Ok None ->
+      if declarative_autoboot_enabled_by_default config name then Some name
+      else None
     | Error msg ->
       (* Issue #8377: was [_ -> None] which collapsed read/parse
          failures silently into "name disappeared". Discovery would
@@ -147,7 +160,7 @@ let persistent_agent_names config =
   |> List.filter_map (fun name ->
     match read_meta_file_path (keeper_meta_path config name) with
     | Ok (Some meta)
-      when (not meta.paused) && effective_autoboot_enabled name meta ->
+      when (not meta.paused) && effective_autoboot_enabled config name meta ->
         Some meta.name
     | Ok (Some _) -> None
     | Ok None -> None

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -46,7 +46,7 @@ val keeper_names : Workspace.config -> string list
 
 (** Default autoboot policy when a keeper has TOML config but no
     persisted JSON yet. *)
-val declarative_autoboot_enabled_by_default : string -> bool
+val declarative_autoboot_enabled_by_default : Workspace.config -> string -> bool
 
 (** Names of keepers eligible for the keepalive fiber set —
     autoboot enabled, not paused. Logs and excludes on read failure

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -121,6 +121,21 @@ let boot_meta_failure_for ~base_path ~name =
       Hashtbl.find_opt boot_meta_failures
         (boot_meta_failure_key ~base_path ~name))
 
+let profile_defaults_for_config config name =
+  load_keeper_profile_defaults_for_base_path
+    ~base_path:config.Workspace.base_path
+    name
+
+let profile_defaults_result_for_config config name =
+  load_keeper_profile_defaults_result_for_base_path
+    ~base_path:config.Workspace.base_path
+    name
+
+let keeper_toml_path_opt_for_config config name =
+  keeper_toml_path_opt_for_base_path
+    ~base_path:config.Workspace.base_path
+    name
+
 let remember_boot_meta_result ctx name result =
   let base_path = ctx.config.base_path in
   match result with
@@ -141,13 +156,13 @@ let autoboot_exclusion_reason config name =
   | Ok (Some meta) ->
     if meta.paused then Some "paused"
     else
-      (match (load_keeper_profile_defaults name).autoboot_enabled with
+      (match (profile_defaults_for_config config name).autoboot_enabled with
        | Some true -> None
        | Some false -> Some "declarative_autoboot_disabled"
        | None ->
          if meta.autoboot_enabled then None else Some "autoboot_disabled")
   | Ok None ->
-    (match (load_keeper_profile_defaults name).autoboot_enabled with
+    (match (profile_defaults_for_config config name).autoboot_enabled with
      | Some false -> Some "declarative_autoboot_disabled"
      | Some true | None -> None)
   | Error _ ->
@@ -180,7 +195,7 @@ let auto_recoverable_paused_keeper_names ?now config =
        | Ok (Some meta)
          when meta.paused
               &&
-              (match (load_keeper_profile_defaults name).autoboot_enabled with
+              (match (profile_defaults_for_config config name).autoboot_enabled with
                | Some value -> value
                | None -> meta.autoboot_enabled)
               && Keeper_supervisor_types.paused_meta_auto_resume_due ~now meta ->
@@ -300,7 +315,7 @@ let ensure_keeper_meta_with_cause config name =
        persona config (TOML) plus explicit env overrides are the source of truth.
        Fields where TOML has [Some v] are overwritten; [None] keeps runtime value. *)
     let defaults_result =
-      Keeper_types_profile.load_keeper_profile_defaults_result meta.name
+      profile_defaults_result_for_config config meta.name
     in
     match defaults_result with
     | Error detail ->
@@ -491,8 +506,8 @@ let declarative_materialization_args name defaults =
   in
   `Assoc (List.rev fields)
 
-let declarative_materialization_defaults name =
-  match load_keeper_profile_defaults_result name with
+let declarative_materialization_defaults config name =
+  match profile_defaults_result_for_config config name with
   | Error detail -> Error (profile_defaults_boot_error ~keeper_name:name detail)
   | Ok defaults -> (
       match defaults.sandbox_profile with
@@ -527,13 +542,13 @@ let load_or_materialize_boot_meta (ctx : _ context) name
     match ensure_keeper_meta_with_cause ctx.config name with
     | Ok meta -> Ok { meta; materialized = false }
     | Error original_error -> (
-        match Config_dir_resolver.keeper_toml_path_opt name with
+        match keeper_toml_path_opt_for_config ctx.config name with
         | None -> Error original_error
         | Some toml_path -> (
             Log.Keeper.info
               "bootstrapping declarative keeper %s from %s"
               name toml_path;
-            match declarative_materialization_defaults name with
+            match declarative_materialization_defaults ctx.config name with
             | Error err -> Error err
             | Ok defaults -> (
                 match declarative_materialization_goal defaults with
@@ -733,7 +748,7 @@ let start_supervisor_sweep ctx =
                      reconcile and let any [Error] flow through the
                      standard back-off. *)
                   let toml_mtime =
-                    match Config_dir_resolver.keeper_toml_path_opt entry.name with
+                    match keeper_toml_path_opt_for_config ctx.config entry.name with
                     | None -> 0.0
                     | Some path ->
                         (try (Unix.stat path).Unix.st_mtime

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -150,9 +150,33 @@ let keeper_toml_path_opt name =
   Config_dir_resolver.log_warnings ~context:"KeeperTypesProfile" ();
   Config_dir_resolver.keeper_toml_path_opt name
 
+let keeper_toml_path_opt_for_base_path ~base_path name =
+  Config_dir_resolver.keeper_toml_path_opt_for_base_path ~base_path name
+
 let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
   Keeper_types_profile_persona_defaults.load ~name
 
+let load_keeper_profile_defaults_from_persona_dirs ~persona_dirs name
+    : keeper_profile_defaults =
+  Keeper_types_profile_persona_defaults.load_from_dirs ~persona_dirs ~name
+
+let safe_persona_dirs ?base_path () =
+  try
+    match base_path with
+    | Some base_path -> Config_dir_resolver.personas_dirs_for_base_path ~base_path
+    | None -> Config_dir_resolver.personas_dirs ()
+  with
+  | Sys_error _ -> []
+  | exn ->
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string ProfileLoadFailures)
+        ~labels:
+          [ "site", Keeper_profile_load_failure_site.(to_label Personas_dirs_resolve) ]
+        ();
+      Log.Keeper.warn
+        "profile defaults personas_dirs unexpected: %s"
+        (Printexc.to_string exn);
+      []
 
 let resolved_persona_name ~keeper_name
     (defaults : keeper_profile_defaults) : string =
@@ -160,20 +184,25 @@ let resolved_persona_name ~keeper_name
   | Some name when String.trim name <> "" -> name
   | _ -> keeper_name
 
-let load_keeper_profile_defaults_result_uncached name :
+let load_keeper_profile_defaults_result_uncached_with_paths
+    ~keeper_toml_path_opt
+    ~persona_dirs
+    name :
     (keeper_profile_defaults, string) result =
   (* Priority: TOML config/keepers/<name>.toml > persona profile.json.
      If TOML sets [persona_name], load that persona first and treat TOML as a
      thin overlay instead of duplicating the full keeper profile. *)
   let result =
-    match keeper_toml_path_opt name with
+    match keeper_toml_path_opt with
     | Some toml_path ->
       (match load_keeper_toml toml_path with
        | Ok (_name, defaults) -> (
            match defaults.persona_name with
            | Some persona_name ->
                let persona_defaults =
-                 load_keeper_profile_defaults_from_persona persona_name
+                 load_keeper_profile_defaults_from_persona_dirs
+                   ~persona_dirs
+                   persona_name
                in
                Ok
                  (merge_keeper_profile_defaults ~agent_name:name
@@ -181,9 +210,23 @@ let load_keeper_profile_defaults_result_uncached name :
            | None -> Ok defaults)
        | Error e -> Error e)
     | None ->
-      Ok (load_keeper_profile_defaults_from_persona name)
+      Ok (load_keeper_profile_defaults_from_persona_dirs ~persona_dirs name)
   in
   result
+
+let load_keeper_profile_defaults_result_uncached name :
+    (keeper_profile_defaults, string) result =
+  load_keeper_profile_defaults_result_uncached_with_paths
+    ~keeper_toml_path_opt:(keeper_toml_path_opt name)
+    ~persona_dirs:(safe_persona_dirs ())
+    name
+
+let load_keeper_profile_defaults_result_for_base_path ~base_path name :
+    (keeper_profile_defaults, string) result =
+  load_keeper_profile_defaults_result_uncached_with_paths
+    ~keeper_toml_path_opt:(keeper_toml_path_opt_for_base_path ~base_path name)
+    ~persona_dirs:(safe_persona_dirs ~base_path ())
+    name
 
 (* Classify a [load_keeper_toml] failure message into a low-cardinality
    label suitable for Otel_metric_store. The raw error string embeds user input
@@ -478,6 +521,22 @@ let load_keeper_profile_defaults name : keeper_profile_defaults =
          ()
      | None -> ());
     load_keeper_profile_defaults_from_persona name
+
+let load_keeper_profile_defaults_for_base_path ~base_path name
+    : keeper_profile_defaults =
+  match load_keeper_profile_defaults_result_for_base_path ~base_path name with
+  | Ok defaults -> defaults
+  | Error e ->
+    (match keeper_toml_path_opt_for_base_path ~base_path name with
+     | Some _ ->
+       Log.Keeper.warn "toml config for %s failed (%s), falling back to persona" name e;
+       Otel_metric_store.inc_counter Keeper_metrics.(to_string TomlInvalid)
+         ~labels:[ ("keeper", name); ("reason", classify_toml_failure_reason e) ]
+         ()
+     | None -> ());
+    load_keeper_profile_defaults_from_persona_dirs
+      ~persona_dirs:(safe_persona_dirs ~base_path ())
+      name
 
 (** Clamp a profile-provided max-turns override to [1, 100] — the same range
     enforced by [Keeper_runtime_resolved.reactive_max_turns_per_call].

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -115,7 +115,11 @@ val log_toml_skip_once : file:string -> error:string -> bool
 val reset_logged_toml_skip_for_test : unit -> unit
 val discover_keepers_toml : string -> (string * keeper_profile_defaults) list
 val keeper_toml_path_opt : string -> string option
+val keeper_toml_path_opt_for_base_path :
+  base_path:string -> string -> string option
 val load_keeper_profile_defaults_from_persona : string -> keeper_profile_defaults
+val load_keeper_profile_defaults_result_for_base_path :
+  base_path:string -> string -> (keeper_profile_defaults, string) result
 val resolved_persona_name : keeper_name:string -> keeper_profile_defaults -> string
 val load_keeper_profile_defaults_result : string -> (keeper_profile_defaults, string) result
 val invalidate_keeper_profile_defaults_cache : string -> unit
@@ -145,6 +149,8 @@ val keeper_toml_config_errors : unit -> keeper_toml_config_error list
 val keeper_toml_unknown_keys : unit -> keeper_toml_unknown_keys list
 val keeper_toml_config_errors_json : unit -> Yojson.Safe.t
 val keeper_toml_config_error_for_name : string -> keeper_toml_config_error option
+val load_keeper_profile_defaults_for_base_path :
+  base_path:string -> string -> keeper_profile_defaults
 val load_keeper_profile_defaults : string -> keeper_profile_defaults
 val clamp_max_turns_override : int option -> int option
 val effective_max_turns_per_call : keeper_profile_defaults -> int

--- a/lib/keeper/keeper_types_profile_persona.ml
+++ b/lib/keeper/keeper_types_profile_persona.ml
@@ -103,6 +103,16 @@ let personas_root_opt () =
     None
 ;;
 
+let persona_profile_path_opt_in_dirs dirs name =
+  (* Search the resolved persona roots only.
+     Config_dir_resolver.personas_dirs now returns a single source of truth:
+     explicit MASC_PERSONAS_DIR or resolved CONFIG_ROOT/personas. *)
+  dirs
+  |> List.find_map (fun root ->
+    let path = Filename.concat (Filename.concat root name) "profile.json" in
+    if Fs_compat.file_exists path then Some path else None)
+;;
+
 let persona_profile_path_opt name =
   let dirs =
     try
@@ -118,13 +128,7 @@ let persona_profile_path_opt name =
       Log.Keeper.warn "personas_dirs unexpected: %s" (Printexc.to_string exn);
       []
   in
-  (* Search the resolved persona roots only.
-     Config_dir_resolver.personas_dirs now returns a single source of truth:
-     explicit MASC_PERSONAS_DIR or resolved CONFIG_ROOT/personas. *)
-  dirs
-  |> List.find_map (fun root ->
-    let path = Filename.concat (Filename.concat root name) "profile.json" in
-    if Fs_compat.file_exists path then Some path else None)
+  persona_profile_path_opt_in_dirs dirs name
 ;;
 
 (** Load extended persona description from AGENT.md if present.

--- a/lib/keeper/keeper_types_profile_persona.mli
+++ b/lib/keeper/keeper_types_profile_persona.mli
@@ -15,6 +15,7 @@ val reject_placeholder_persona_profile :
   label:string -> path:string -> Yojson.Safe.t -> bool
 val operator_todo_placeholder_fields : (string * string option) list -> string list
 val personas_root_opt : unit -> string option
+val persona_profile_path_opt_in_dirs : string list -> string -> string option
 val persona_profile_path_opt : string -> string option
 val persona_description_max_chars : int
 val load_persona_extended : ?max_chars:int -> string -> string option

--- a/lib/keeper/keeper_types_profile_persona_defaults.ml
+++ b/lib/keeper/keeper_types_profile_persona_defaults.ml
@@ -1,104 +1,113 @@
 open Keeper_types_profile_defaults
 module Normalizers = Keeper_types_profile_toml_normalizers
 
+let load_from_path ~name path : keeper_profile_defaults =
+  match Safe_ops.read_json_file_logged ~label:"load_keeper_profile_defaults" path with
+  | None -> empty_keeper_profile_defaults
+  | Some json ->
+      if
+        Keeper_types_profile_persona.reject_placeholder_persona_profile
+          ~label:"load_keeper_profile_defaults" ~path json
+      then empty_keeper_profile_defaults
+      else
+        let keeper_json =
+          match Json_util.assoc_member_opt "keeper" json with
+          | Some v -> v
+          | None -> `Null
+        in
+        let per_provider_timeout_state, per_provider_timeout =
+          Normalizers.per_provider_timeout_of_json_field
+            ~source:(Printf.sprintf "persona profile %s" path)
+            ~field:"per_provider_timeout"
+            keeper_json
+        in
+        (* Persona profiles do not own a
+           runtime/model selection. Warn so stale manifests are visible. *)
+        (match Safe_ops.json_string_opt "model" keeper_json with
+         | Some raw ->
+             Log.Keeper.warn
+               "persona profile %s has a [model] key (%s); ignored - \
+                keeper->runtime assignment lives in runtime.toml \
+                [[runtime.assignments]]"
+               path raw
+         | None -> ());
+        match keeper_json with
+        | `Assoc _ ->
+            {
+              id = Some (Ids.Keeper_id.generate ~name ~path);
+              manifest_path = Some path;
+              persona_name = Some name;
+              goal = Safe_ops.json_string_opt "goal" keeper_json;
+              short_goal =
+                Normalizers.normalize_goal_horizon_opt
+                  (Safe_ops.json_string_opt "short_goal" keeper_json);
+              mid_goal =
+                Normalizers.normalize_goal_horizon_opt
+                  (Safe_ops.json_string_opt "mid_goal" keeper_json);
+              long_goal =
+                Normalizers.normalize_goal_horizon_opt
+                  (Safe_ops.json_string_opt "long_goal" keeper_json);
+              will = Safe_ops.json_string_opt "will" keeper_json;
+              needs = Safe_ops.json_string_opt "needs" keeper_json;
+              desires = Safe_ops.json_string_opt "desires" keeper_json;
+              instructions = Safe_ops.json_string_opt "instructions" keeper_json;
+              autoboot_enabled = None;
+              mention_targets = Safe_ops.json_string_list "mention_targets" keeper_json;
+              proactive_enabled = Safe_ops.json_bool_opt "proactive_enabled" keeper_json;
+              proactive_idle_sec = Safe_ops.json_int_opt "proactive_idle_sec" keeper_json;
+              proactive_cooldown_sec = Safe_ops.json_int_opt "proactive_cooldown_sec" keeper_json;
+              shards =
+                (match Safe_ops.json_string_list "shards" keeper_json with
+                 | [] -> None
+                 | xs -> Some xs);
+              allowed_paths = None;
+              sandbox_profile = None;
+              sandbox_image = None;
+              network_mode = None;
+              tool_access = None;
+              tool_denylist =
+                Normalizers.normalize_name_list_opt
+                  (Safe_ops.json_string_list "tool_denylist" keeper_json);
+              active_goal_ids = None;
+              telemetry_feedback_enabled =
+                Safe_ops.json_bool_opt "telemetry_feedback_enabled" keeper_json;
+              telemetry_feedback_window_hours =
+                Safe_ops.json_int_opt "telemetry_feedback_window_hours" keeper_json;
+              per_provider_timeout_state;
+              per_provider_timeout;
+              always_approve = Safe_ops.json_bool_opt "always_approve" keeper_json;
+              max_turns_per_call = Safe_ops.json_int_opt "max_turns_per_call" keeper_json;
+              max_turns_per_call_scheduled_autonomous =
+                Safe_ops.json_int_opt
+                  "max_turns_per_call_scheduled_autonomous"
+                  keeper_json;
+              social_model =
+                (match
+                   Normalizers.normalize_social_model_opt
+                     (Safe_ops.json_string_opt "social_model" keeper_json)
+                 with
+                 | Some _ as normalized -> normalized
+                 | None -> (
+                     match Safe_ops.json_string_opt "social_model" keeper_json with
+                     | Some raw ->
+                         Log.Keeper.warn
+                           "persona profile %s has invalid social_model '%s'; ignoring"
+                           path raw;
+                         None
+                     | None -> None));
+              oas_env = [];
+              unknown_toml_keys = [];
+            }
+        | _ -> { empty_keeper_profile_defaults with manifest_path = Some path }
+
+let load_from_dirs ~persona_dirs ~name : keeper_profile_defaults =
+  match
+    Keeper_types_profile_persona.persona_profile_path_opt_in_dirs persona_dirs name
+  with
+  | None -> empty_keeper_profile_defaults
+  | Some path -> load_from_path ~name path
+
 let load ~name : keeper_profile_defaults =
   match Keeper_types_profile_persona.persona_profile_path_opt name with
   | None -> empty_keeper_profile_defaults
-  | Some path -> (
-      match Safe_ops.read_json_file_logged ~label:"load_keeper_profile_defaults" path with
-      | None -> empty_keeper_profile_defaults
-      | Some json ->
-          if
-            Keeper_types_profile_persona.reject_placeholder_persona_profile
-              ~label:"load_keeper_profile_defaults" ~path json
-          then empty_keeper_profile_defaults
-          else
-            let keeper_json =
-              match Json_util.assoc_member_opt "keeper" json with
-              | Some v -> v
-              | None -> `Null
-            in
-            let per_provider_timeout_state, per_provider_timeout =
-              Normalizers.per_provider_timeout_of_json_field
-                ~source:(Printf.sprintf "persona profile %s" path)
-                ~field:"per_provider_timeout"
-                keeper_json
-            in
-            (* Persona profiles do not own a
-               runtime/model selection. Warn so stale manifests are visible. *)
-            (match Safe_ops.json_string_opt "model" keeper_json with
-             | Some raw ->
-                 Log.Keeper.warn
-                   "persona profile %s has a [model] key (%s); ignored - \
-                    keeper->runtime assignment lives in runtime.toml \
-                    [[runtime.assignments]]"
-                   path raw
-             | None -> ());
-            match keeper_json with
-            | `Assoc _ ->
-                {
-                  id = Some (Ids.Keeper_id.generate ~name ~path);
-                  manifest_path = Some path;
-                  persona_name = Some name;
-                  goal = Safe_ops.json_string_opt "goal" keeper_json;
-                  short_goal =
-                    Normalizers.normalize_goal_horizon_opt
-                      (Safe_ops.json_string_opt "short_goal" keeper_json);
-                  mid_goal =
-                    Normalizers.normalize_goal_horizon_opt
-                      (Safe_ops.json_string_opt "mid_goal" keeper_json);
-                  long_goal =
-                    Normalizers.normalize_goal_horizon_opt
-                      (Safe_ops.json_string_opt "long_goal" keeper_json);
-                  will = Safe_ops.json_string_opt "will" keeper_json;
-                  needs = Safe_ops.json_string_opt "needs" keeper_json;
-                  desires = Safe_ops.json_string_opt "desires" keeper_json;
-                  instructions = Safe_ops.json_string_opt "instructions" keeper_json;
-                  autoboot_enabled = None;
-                  mention_targets = Safe_ops.json_string_list "mention_targets" keeper_json;
-                  proactive_enabled = Safe_ops.json_bool_opt "proactive_enabled" keeper_json;
-                  proactive_idle_sec = Safe_ops.json_int_opt "proactive_idle_sec" keeper_json;
-                  proactive_cooldown_sec = Safe_ops.json_int_opt "proactive_cooldown_sec" keeper_json;
-                  shards =
-                    (match Safe_ops.json_string_list "shards" keeper_json with
-                     | [] -> None
-                     | xs -> Some xs);
-                  allowed_paths = None;
-                  sandbox_profile = None;
-                  sandbox_image = None;
-                  network_mode = None;
-                  tool_access = None;
-                  tool_denylist =
-                    Normalizers.normalize_name_list_opt
-                      (Safe_ops.json_string_list "tool_denylist" keeper_json);
-                  active_goal_ids = None;
-                  telemetry_feedback_enabled =
-                    Safe_ops.json_bool_opt "telemetry_feedback_enabled" keeper_json;
-                  telemetry_feedback_window_hours =
-                    Safe_ops.json_int_opt "telemetry_feedback_window_hours" keeper_json;
-                  per_provider_timeout_state;
-                  per_provider_timeout;
-                  always_approve = Safe_ops.json_bool_opt "always_approve" keeper_json;
-                  max_turns_per_call = Safe_ops.json_int_opt "max_turns_per_call" keeper_json;
-                  max_turns_per_call_scheduled_autonomous =
-                    Safe_ops.json_int_opt
-                      "max_turns_per_call_scheduled_autonomous"
-                      keeper_json;
-                  social_model =
-                    (match
-                       Normalizers.normalize_social_model_opt
-                         (Safe_ops.json_string_opt "social_model" keeper_json)
-                     with
-                     | Some _ as normalized -> normalized
-                     | None -> (
-                         match Safe_ops.json_string_opt "social_model" keeper_json with
-                         | Some raw ->
-                             Log.Keeper.warn
-                               "persona profile %s has invalid social_model '%s'; ignoring"
-                               path raw;
-                             None
-                         | None -> None));
-                  oas_env = [];
-                  unknown_toml_keys = [];
-                }
-            | _ -> { empty_keeper_profile_defaults with manifest_path = Some path })
+  | Some path -> load_from_path ~name path

--- a/lib/keeper/keeper_types_profile_persona_defaults.mli
+++ b/lib/keeper/keeper_types_profile_persona_defaults.mli
@@ -4,4 +4,9 @@
     remains outside persona profiles. Persona self-model fields are loaded as
     defaults and may be overridden by keeper TOML overlays. *)
 
+val load_from_dirs :
+  persona_dirs:string list ->
+  name:string ->
+  Keeper_types_profile_defaults.keeper_profile_defaults
+
 val load : name:string -> Keeper_types_profile_defaults.keeper_profile_defaults

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -21,8 +21,13 @@ let empty_paused_keeper_scan =
 
 let sorted_unique_strings values = List.sort_uniq String.compare values
 
-let effective_autoboot_enabled name (meta : Keeper_meta_contract.keeper_meta) =
-  match (Keeper_types_profile.load_keeper_profile_defaults name).autoboot_enabled with
+let effective_autoboot_enabled config name (meta : Keeper_meta_contract.keeper_meta) =
+  match
+    (Keeper_types_profile.load_keeper_profile_defaults_for_base_path
+       ~base_path:config.Workspace.base_path
+       name)
+      .autoboot_enabled
+  with
   | Some value -> value
   | None -> meta.autoboot_enabled
 
@@ -122,7 +127,7 @@ let durable_paused_keeper_scan ?(include_details = true) config =
        (fun acc name ->
          match Keeper_meta_store.read_meta config name with
          | Ok (Some meta) when meta.paused ->
-             let autoboot_enabled = effective_autoboot_enabled name meta in
+             let autoboot_enabled = effective_autoboot_enabled config name meta in
              {
                acc with
                names = meta.name :: acc.names;
@@ -257,7 +262,7 @@ let keeper_fleet_meta_scan ?(include_paused_details = true) config =
            in
            match Keeper_meta_store.read_meta config name with
            | Ok (Some meta) ->
-             let autoboot_enabled = effective_autoboot_enabled name meta in
+             let autoboot_enabled = effective_autoboot_enabled config name meta in
              let acc =
                if autoboot_enabled && should_count_autoboot_target meta.name
                then add_autoboot acc meta.name
@@ -296,7 +301,7 @@ let keeper_fleet_meta_scan ?(include_paused_details = true) config =
            | Ok None ->
              if
                should_count_autoboot_target name
-               && Keeper_meta_store.declarative_autoboot_enabled_by_default name
+               && Keeper_meta_store.declarative_autoboot_enabled_by_default config name
              then add_autoboot acc name |> fun acc -> add_bootable acc name
              else acc
            | Error err ->
@@ -363,11 +368,11 @@ let autoboot_enabled_keeper_scan config =
        (fun acc name ->
          match Keeper_meta_store.read_meta config name with
          | Ok (Some meta) ->
-             if effective_autoboot_enabled name meta then
+             if effective_autoboot_enabled config name meta then
                { acc with autoboot_names = meta.name :: acc.autoboot_names }
              else acc
          | Ok None ->
-             if Keeper_meta_store.declarative_autoboot_enabled_by_default name then
+             if Keeper_meta_store.declarative_autoboot_enabled_by_default config name then
                { acc with autoboot_names = name :: acc.autoboot_names }
              else acc
          | Error err ->

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -7,6 +7,7 @@ type paused_keeper_scan = {
 val empty_paused_keeper_scan : paused_keeper_scan
 val sorted_unique_strings : String.t list -> String.t list
 val effective_autoboot_enabled :
+  Workspace.config ->
   string ->
   Keeper_meta_contract.keeper_meta -> bool
 val pause_elapsed_sec :

--- a/test/test_supervisor_start_predicate.ml
+++ b/test/test_supervisor_start_predicate.ml
@@ -9,15 +9,10 @@
    independently force the supervisor up.  This is what protects
    us from a degenerate bootstrap.
 
-   Note on test isolation: [Keeper_runtime.has_boot_entries] reads
-   keeper TOML profiles via [Config_dir_resolver.keepers_dir ()],
-   which is the active resolved config root independent of the
-   [Workspace.config.base_path].  So in every test environment with an
-   active operator profile present,
-   [bootable_keeper_names] returns non-empty.  The tests below
-   exploit that — they verify the post-fix path
-   ([enabled = false] still triggers sweep) without trying to
-   construct an empty profile environment. *)
+   Note on test isolation: keeper TOML discovery must be scoped to the
+   supplied [Workspace.config.base_path].  The tests below pin that
+   path ownership so an ambient [MASC_BASE_PATH] from another runtime
+   cannot silently redirect supervisor boot decisions. *)
 
 open Alcotest
 
@@ -53,9 +48,14 @@ let restore_env name = function
   | Some value -> Unix.putenv name value
   | None -> Unix.putenv name ""
 
-let write_keeper_toml config_root ~name =
+let write_keeper_toml ?autoboot_enabled config_root ~name =
   let keepers_dir = Filename.concat config_root "keepers" in
   mkdir_p keepers_dir;
+  let autoboot_line =
+    match autoboot_enabled with
+    | None -> ""
+    | Some value -> Printf.sprintf "autoboot_enabled = %s\n" (string_of_bool value)
+  in
   write_file
     (Filename.concat keepers_dir (name ^ ".toml"))
     (Printf.sprintf
@@ -63,8 +63,10 @@ let write_keeper_toml config_root ~name =
 [keeper]
 name = "%s"
 goal = "test keeper"
+%s
 |}
-       name)
+       name
+       autoboot_line)
 
 let iso_of_unix ts =
   let t = Unix.gmtime ts in
@@ -102,15 +104,19 @@ let write_meta_exn config meta =
   | Ok () -> ()
   | Error err -> fail ("write_meta failed: " ^ err)
 
+let fresh_temp_dir prefix =
+  let path =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
+  in
+  Unix.mkdir path 0o755;
+  path
+
 let with_temp_masc_dir ?(keeper_names = [ "operator" ]) f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let base =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-10125-%d-%d" (Unix.getpid ())
-         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
-  in
-  Unix.mkdir base 0o755;
+  let base = fresh_temp_dir "masc-10125" in
   let config = Workspace.default_config base in
   let config_root = Filename.concat (Workspace.masc_root_dir config) "config" in
   let original_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR" in
@@ -128,6 +134,42 @@ let with_temp_masc_dir ?(keeper_names = [ "operator" ]) f =
       Config_dir_resolver.reset ();
       rm_rf base)
     (fun () -> f config)
+
+let test_configured_keeper_names_uses_workspace_base_path () =
+  let base_a = fresh_temp_dir "masc-config-a" in
+  let base_b = fresh_temp_dir "masc-config-b" in
+  let config_a = Workspace.default_config base_a in
+  let config_b = Workspace.default_config base_b in
+  let config_root_a = Filename.concat (Workspace.masc_root_dir config_a) "config" in
+  let config_root_b = Filename.concat (Workspace.masc_root_dir config_b) "config" in
+  let original_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  let original_base_path = Sys.getenv_opt "MASC_BASE_PATH" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "MASC_CONFIG_DIR" original_config_dir;
+      restore_env "MASC_BASE_PATH" original_base_path;
+      Config_dir_resolver.reset ();
+      rm_rf base_a;
+      rm_rf base_b)
+    (fun () ->
+      write_keeper_toml config_root_a ~name:"alpha";
+      write_keeper_toml config_root_b ~name:"bravo";
+      write_keeper_toml config_root_a ~name:"shared" ~autoboot_enabled:true;
+      write_keeper_toml config_root_b ~name:"shared" ~autoboot_enabled:false;
+      Unix.putenv "MASC_CONFIG_DIR" "";
+      Unix.putenv "MASC_BASE_PATH" base_b;
+      Config_dir_resolver.reset ();
+      check (list string) "global resolver sees ambient base path"
+        [ "bravo"; "shared" ]
+        (Masc.Keeper_types_profile.discover_keepers_toml
+           (Config_dir_resolver.keepers_dir ())
+         |> List.map fst);
+      check (list string) "configured keepers use Workspace.config base path"
+        [ "alpha"; "shared" ]
+        (Keeper_meta_store.configured_keeper_names config_a);
+      check (list string) "boot policy uses Workspace.config defaults"
+        [ "alpha"; "shared" ]
+        (KR.bootable_keeper_names config_a))
 
 (* The regression case the fix is for: bootstrap reported [enabled
    = false] AND [started = 0]. Pre-fix this killed the supervisor
@@ -243,6 +285,8 @@ let test_turn_timeout_pause_without_explicit_policy_starts_sweep () =
 let () =
   run "supervisor_start_predicate_10125" [
     "predicate", [
+      test_case "configured keeper names use workspace base path" `Quick
+        test_configured_keeper_names_uses_workspace_base_path;
       test_case "disabled bootstrap + disk keeper → true (regression fix)" `Quick
         test_disabled_bootstrap_with_disk_keepers_starts_sweep;
       test_case "stats.started > 0 even when enabled = false → true" `Quick


### PR DESCRIPTION
## Summary

- add basepath-scoped config resolver accessors for keepers/personas
- make keeper discovery, profile defaults, boot materialization, and fleet health use `Workspace.config.base_path`
- pin the regression where ambient `MASC_BASE_PATH` points at another workspace

## Root Cause

Several keeper paths accepted a `Workspace.config` but then discarded it by calling global `Config_dir_resolver.keepers_dir ()` or global profile-default loaders. In a long-running process, an ambient `MASC_BASE_PATH`/cwd from another workspace could redirect keeper TOML discovery or autoboot policy lookup away from the workspace being inspected.

That is especially dangerous for autonomous keepers: the name list can come from one base path while `autoboot_enabled`, persona defaults, or materialization TOML path are read from another base path.

## Behavior

- `Config_dir_resolver` now exposes explicit `*_for_base_path` helpers.
- `Keeper_meta_store.configured_keeper_names` reads the keepers directory for the supplied workspace base path.
- keeper profile defaults can be loaded with a base path, including matching persona roots.
- keeper bootstrap/materialization, supervisor mtime probes, persistent/keepalive name selection, and fleet health autoboot scans use the scoped defaults.
- explicit `MASC_CONFIG_DIR` / `MASC_PERSONAS_DIR` overrides are still honored; ambient `MASC_BASE_PATH` no longer replaces a caller-supplied workspace config.

## Validation

- `ocamlformat --check lib/config_dir_resolver/config_dir_resolver.ml lib/config_dir_resolver/config_dir_resolver.mli lib/keeper/keeper_meta_store.ml lib/keeper/keeper_meta_store.mli lib/keeper/keeper_runtime.ml lib/keeper/keeper_types_profile.ml lib/keeper/keeper_types_profile.mli lib/keeper/keeper_types_profile_persona.ml lib/keeper/keeper_types_profile_persona.mli lib/keeper/keeper_types_profile_persona_defaults.ml lib/keeper/keeper_types_profile_persona_defaults.mli lib/server/server_routes_http_runtime_fleet_scan.ml lib/server/server_routes_http_runtime_fleet_scan.mli test/test_supervisor_start_predicate.ml`
- `git diff --check origin/main...HEAD`

Not run: focused/full Dune build, per operator request to run builds later.
