### PR TITLE
refactor(keeper): purge keeper LLM force_done/force_release tools

### DIFF
--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -150,7 +150,7 @@ let risk_of_keeper (k : Keeper_tool_name.t) : risk_level =
   | Surface_post | Person_note_set
     -> Medium
   | Fs_edit | Fs_write | Fs_read | Ide_annotate -> High
-  | Board_sub_board_delete | Task_force_done | Task_force_release -> Critical
+  | Board_sub_board_delete -> Critical
 ;;
 
 (* Non-typed names keep explicit overrides when substring matching would

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -77,8 +77,7 @@ let tools_for_affordance = function
   | Task_claim ->
     [ "keeper_task_claim" ]
   | Task_audit ->
-    [ "keeper_tasks_audit"; "keeper_task_force_release"; "keeper_task_force_done";
-      "keeper_tasks_list"; "masc_tasks" ]
+    [ "keeper_tasks_audit"; "keeper_tasks_list"; "masc_tasks" ]
   | Task_verify ->
     [ "keeper_tasks_list"; "keeper_tasks_audit";
       "keeper_task_done"; "masc_transition" ]
@@ -115,8 +114,7 @@ let preferred_tool_names_for_turn_affordances turn_affordances =
        | Task_claim ->
          [ "keeper_task_claim" ]
        | Task_audit ->
-         [ "keeper_tasks_audit"; "keeper_task_force_release";
-           "keeper_task_force_done" ]
+         [ "keeper_tasks_audit" ]
        | Task_verify ->
          [ "keeper_task_done"; "masc_transition" ]
        )
@@ -208,8 +206,6 @@ let tool_search_alias_entries =
   ; "keeper_task_claim", "태스크 가져오기 할당"
   ; "keeper_task_create", "태스크 생성 만들기 일감"
   ; "keeper_task_done", "태스크 완료 마감"
-  ; "keeper_task_force_release", "태스크 강제해제 반환"
-  ; "keeper_task_force_done", "태스크 강제완료"
   ; "keeper_voice_speak", "음성 말하기 보이스"
   ; "keeper_voice_agent", "음성 설정 보이스"
   ; "keeper_voice_sessions", "음성 세션 목록"

--- a/lib/keeper/keeper_run_tools_task_scope.ml
+++ b/lib/keeper/keeper_run_tools_task_scope.ml
@@ -6,8 +6,6 @@
 let task_scope_tool_names =
   [ "masc_transition"
   ; "keeper_task_done"
-  ; "keeper_task_force_done"
-  ; "keeper_task_force_release"
   ]
 ;;
 

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1220,16 +1220,6 @@ let internal_descriptors : t list =
       "Audit MASC task state for stale claims and verification gaps."
       ~readonly:true
   ; task_descriptor
-      "force_release"
-      "keeper_task_force_release"
-      "Operator-only: release a stuck task claim."
-      ~readonly:false
-  ; task_descriptor
-      "force_done"
-      "keeper_task_force_done"
-      "Operator-only: mark a task done out-of-band."
-      ~readonly:false
-  ; task_descriptor
       "broadcast"
       "keeper_broadcast"
       "Broadcast a workspace message to the MASC workspace."

--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -60,7 +60,7 @@ let completion_tool_names : string list =
   "masc_deliver"
   :: List.map
        Keeper_tool_name.to_string
-       Keeper_tool_name.[ Task_done; Task_force_done; Task_force_release ]
+       Keeper_tool_name.[ Task_done ]
 ;;
 
 let is_claim_tool_name name =

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -321,8 +321,6 @@ let sync_keeper_meta_current_task
 type task_op =
   | Tasks_list
   | Tasks_audit
-  | Task_force_release
-  | Task_force_done
   | Broadcast
   | Task_create
   | Task_claim
@@ -331,8 +329,6 @@ type task_op =
 let task_op_of_keeper_tool = function
   | Keeper_tool_name.Tasks_list -> Some Tasks_list
   | Keeper_tool_name.Tasks_audit -> Some Tasks_audit
-  | Keeper_tool_name.Task_force_release -> Some Task_force_release
-  | Keeper_tool_name.Task_force_done -> Some Task_force_done
   | Keeper_tool_name.Broadcast -> Some Broadcast
   | Keeper_tool_name.Task_create -> Some Task_create
   | Keeper_tool_name.Task_claim -> Some Task_claim
@@ -391,7 +387,7 @@ let handle_keeper_task_tool
       if orphans = [] then
         "ACTION: STOP calling keeper_tasks_audit — no orphans found. Move on to other work or end your turn."
       else
-        Printf.sprintf "ACTION: %d orphan(s) found. Use keeper_task_force_release or keeper_task_force_done to resolve, then STOP re-auditing."
+        Printf.sprintf "ACTION: %d orphan(s) found. The workspace GC auto-releases zombie tasks — no keeper action required. STOP re-auditing."
           (List.length orphans)
     in
     Yojson.Safe.to_string
@@ -405,92 +401,6 @@ let handle_keeper_task_tool
                 then Keeper_tool_outcome.No_progress { reason = No_work_available }
                 else Keeper_tool_outcome.Progress) )
          ])
-    | Task_force_release ->
-    let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
-    let reason = Safe_ops.json_string ~default:"" "reason" args |> String.trim in
-    if task_id = ""
-    then error_json "task_id is required. Use the task_id from keeper_tasks_list or keeper_tasks_audit."
-    else if reason = ""
-    then
-      (* Schema (tool_shard_types.ml:1363) declares [reason] as a
-         required, minLength:1 field for audit-trail reasons: this is
-         an admin override of the normal release path and the operator
-         must record why. The previous implementation accepted an empty
-         reason and emitted "(reason: no reason given)" to the workspace,
-         which both contradicted the schema and left a silent audit
-         gap. Enforce the schema here. *)
-      error_json
-        "reason is required. Audit trail: record why this task is being \
-         force-released. Example: reason='assignee offline >10 min, no heartbeat'."
-    else (
-      let agent = keeper_agent_sender ~meta in
-      let outcome_result =
-        Workspace.force_release_task_outcome_r config ~agent_name:agent ~task_id ()
-      in
-      let result =
-        Result.map
-          (fun (o : Workspace.transition_outcome) -> o.message)
-          outcome_result
-      in
-      let is_noop =
-        match outcome_result with
-        | Ok outcome -> outcome.noop
-        | Error _ -> false
-      in
-      let () =
-        if not is_noop then
-          let _ =
-            Workspace.broadcast
-              config
-              ~from_agent:agent
-              ~content:
-                (Printf.sprintf
-                   "Force-releasing task %s (reason: %s)"
-                   task_id
-                   reason)
-          in
-          ()
-        else ()
-      in
-      let typed_outcome =
-        match result with
-        | Ok _ when is_noop ->
-          Keeper_tool_outcome.No_progress
-            { reason = Keeper_tool_outcome.No_work_available }
-        | Ok _ -> Keeper_tool_outcome.Progress
-        | Error e ->
-          Keeper_tool_outcome.Error
-            { reason = Masc_domain.masc_error_to_string e }
-      in
-      keeper_task_result_json
-        ~typed_outcome:(Some typed_outcome)
-        result)
-    | Task_force_done ->
-    let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
-    let notes = Safe_ops.json_string ~default:"" "notes" args |> String.trim in
-    if task_id = ""
-    then error_json "task_id is required. Use the task_id from keeper_tasks_list or keeper_tasks_audit."
-    else if notes = ""
-    then
-      (* Schema (tool_shard_types.ml:1391) declares [notes] as a
-         required, minLength:1 field — this is an admin override of
-         the normal done path and the operator must record completion
-         evidence. The previous implementation accepted an empty
-         [notes] and silently passed it through to Workspace, contradicting
-         the schema and leaving a silent audit gap. Enforce the
-         schema here. *)
-      error_json
-        "notes is required. Audit trail: record completion evidence. \
-         Example: notes='PR #12345 merged, all tests green'."
-    else
-      keeper_task_result_json
-        ~typed_outcome:(Some Keeper_tool_outcome.Progress)
-        (Workspace.force_done_task_r
-           config
-           ~agent_name:(keeper_agent_sender ~meta)
-           ~task_id
-           ~notes
-           ())
     | Broadcast ->
     let message = Safe_ops.json_string ~default:"" "message" args |> String.trim in
     if message = ""

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -42,8 +42,6 @@ type t =
   | Task_claim
   | Task_create
   | Task_done
-  | Task_force_done
-  | Task_force_release
   | Tasks_audit
   | Tasks_list
   | Time_now
@@ -91,8 +89,6 @@ let all : t list =
   ; Task_claim
   ; Task_create
   ; Task_done
-  ; Task_force_done
-  ; Task_force_release
   ; Tasks_audit
   ; Tasks_list
   ; Time_now
@@ -142,8 +138,6 @@ let to_string = function
   | Task_claim -> "keeper_task_claim"
   | Task_create -> "keeper_task_create"
   | Task_done -> "keeper_task_done"
-  | Task_force_done -> "keeper_task_force_done"
-  | Task_force_release -> "keeper_task_force_release"
   | Tasks_audit -> "keeper_tasks_audit"
   | Tasks_list -> "keeper_tasks_list"
   | Time_now -> "keeper_time_now"
@@ -192,8 +186,6 @@ let of_string = function
   | "keeper_task_claim" -> Some Task_claim
   | "keeper_task_create" -> Some Task_create
   | "keeper_task_done" -> Some Task_done
-  | "keeper_task_force_done" -> Some Task_force_done
-  | "keeper_task_force_release" -> Some Task_force_release
   | "keeper_tasks_audit" -> Some Tasks_audit
   | "keeper_tasks_list" -> Some Tasks_list
   | "keeper_time_now" -> Some Time_now
@@ -259,8 +251,6 @@ let is_keeper_board_tool = function
   | Task_claim
   | Task_create
   | Task_done
-  | Task_force_done
-  | Task_force_release
   | Tasks_audit
   | Tasks_list
   | Time_now

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -40,8 +40,6 @@ type t =
   | Task_claim
   | Task_create
   | Task_done
-  | Task_force_done
-  | Task_force_release
   | Tasks_audit
   | Tasks_list
   | Time_now

--- a/lib/tool_surface/tool_prefilter.ml
+++ b/lib/tool_surface/tool_prefilter.ml
@@ -178,16 +178,6 @@ let synonyms : (string * string list) list =
       ; "task finished"
       ; "done with task"
       ] )
-  ; ( "keeper_task_force_release"
-    , [ "release task"
-      ; "unassign task"
-      ; "free task"
-      ; "orphaned task"
-      ; "stuck task"
-      ; "unclaim task"
-      ] )
-  ; ( "keeper_task_force_done"
-    , [ "force complete"; "mark task done by force"; "force finish task" ] )
   ; ( "keeper_memory_search"
     , [ "remember"
       ; "recall"

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
@@ -47,7 +47,7 @@ let taskboard_tools : Masc_domain.tool_schema list =
     ; description =
         "Find orphaned tasks: claimed/in_progress tasks assigned to agents that are \
          offline (no heartbeat >10 min). Returns orphan list with assignee and \
-         last_seen. Use keeper_task_force_release to reassign orphaned tasks."
+         last_seen. The workspace GC auto-releases orphaned tasks; this audit is read-only."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -66,62 +66,6 @@ let taskboard_tools : Masc_domain.tool_schema list =
                       ; "default", `Int 20
                       ] )
                 ] )
-          ]
-    }
-  ; { name = "keeper_task_force_release"
-    ; description =
-        "Release a stuck task back to Todo status, removing the current assignee. \
-         Applies when the assignee is offline (no heartbeat >10 min). Broadcasts the \
-         release to the workspace."
-    ; input_schema =
-        `Assoc
-          [ "type", `String "object"
-          ; ( "properties"
-            , `Assoc
-                [ ( "task_id"
-                  , `Assoc
-                      [ "type", `String "string"
-                      ; ( "description"
-                        , `String "Task ID from keeper_tasks_list or keeper_tasks_audit" )
-                      ; "minLength", `Int 1
-                      ] )
-                ; ( "reason"
-                  , `Assoc
-                      [ "type", `String "string"
-                      ; ( "description"
-                        , `String "Why this task is being released (audit trail)" )
-                      ; "minLength", `Int 1
-                      ] )
-                ] )
-          ; "required", `List [ `String "task_id"; `String "reason" ]
-          ]
-    }
-  ; { name = "keeper_task_force_done"
-    ; description =
-        "Mark a task Done when the assignee completed the work but did not transition it \
-         (e.g. went offline after finishing). Broadcasts completion to workspace."
-    ; input_schema =
-        `Assoc
-          [ "type", `String "object"
-          ; ( "properties"
-            , `Assoc
-                [ ( "task_id"
-                  , `Assoc
-                      [ "type", `String "string"
-                      ; ( "description"
-                        , `String "Task ID from keeper_tasks_list or keeper_tasks_audit" )
-                      ; "minLength", `Int 1
-                      ] )
-                ; ( "notes"
-                  , `Assoc
-                      [ "type", `String "string"
-                      ; ( "description"
-                        , `String "Completion evidence: PR merged, test output, file diff"
-                        )
-                      ; "minLength", `Int 1
-                      ] )
-                ] )
-          ; "required", `List [ `String "task_id"; `String "notes" ]
           ]
     }
   ; { name = "keeper_broadcast"

--- a/lib/unified_tool_registry.ml
+++ b/lib/unified_tool_registry.ml
@@ -58,8 +58,6 @@ let keeper_task_tool_names =
     Keeper_tool_name.
       [ Tasks_list
       ; Tasks_audit
-      ; Task_force_release
-      ; Task_force_done
       ; Broadcast
       ; Task_create
       ; Task_claim

--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -40,7 +40,7 @@ let active_owned_task_ids_for_agent config ~agent_name (backlog : Masc_domain.ba
 let active_ownership_conflict_message ~agent_name ~requested_task_id task_ids =
   Printf.sprintf
     "Agent %s has task(s) in progress: %s. Use keeper_task_done (task_id + result) \
-     or keeper_task_force_release (task_id + reason) to finish them before claiming %s."
+     to finish them before claiming %s."
     agent_name
     (String.concat ", " task_ids)
     requested_task_id

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -659,38 +659,6 @@ let test_keeper_task_claim_accepts_specific_task_id () =
         check string "assignee" meta.agent_name assignee
       | _ -> fail "requested task should be claimed or auto-started")
 
-let test_keeper_task_force_release_noop_is_no_progress () =
-  with_exec_fixture "keeper_tool_dispatch_force_release_noop"
-    (fun ~config ~meta ~ctx_work ->
-      ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
-      ignore
-        (Workspace.add_task config ~title:"todo task" ~priority:1
-           ~description:"release is a no-op while todo");
-      let result =
-        KET.execute_keeper_tool_call_with_outcome
-          ~config
-          ~meta
-          ~ctx_work
-          ~exec_cache:None
-          ~name:"keeper_task_force_release"
-          ~input:
-            (`Assoc
-               [ "task_id", `String "task-001"
-               ; "reason", `String "already todo smoke"
-               ])
-          ()
-      in
-      check string "force release noop outcome" "success"
-        (outcome_label result.outcome);
-      let json = Yojson.Safe.from_string result.raw_output in
-      check bool "force release noop ok" true
-        (json_bool_field ~default:false "ok" json);
-      let typed = Yojson.Safe.Util.member "typed_outcome" json in
-      check string "typed outcome" "No_progress"
-        Yojson.Safe.Util.(member "kind" typed |> to_string);
-      check string "no-progress reason" "No_work_available"
-        Yojson.Safe.Util.(member "reason" typed |> member "kind" |> to_string))
-
 let test_glob_unknown_tool_returns_tutor_guidance () =
   with_exec_fixture "keeper_tool_dispatch_runtime_glob_tutor"
     (fun ~config ~meta ~ctx_work ->
@@ -1368,8 +1336,6 @@ let () =
         test_public_local_aliases_dispatch_to_runtime_handlers;
       test_case "keeper_task_claim accepts explicit task_id" `Quick
         test_keeper_task_claim_accepts_specific_task_id;
-      test_case "keeper_task_force_release todo no-op is no progress" `Quick
-        test_keeper_task_force_release_noop_is_no_progress;
       test_case "Glob returns tutor guidance instead of aliasing to rg" `Quick
         test_glob_unknown_tool_returns_tutor_guidance;
       test_case "public WebSearch alias reaches misc runtime" `Quick

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -233,14 +233,12 @@ let prepare_keeper_name fixture name =
   if
     List.mem name
       [ "keeper_task_claim"; "keeper_tasks_list"; "keeper_tasks_audit";
-        "keeper_task_force_release"; "keeper_task_force_done";
         "keeper_task_done" ]
   then
     ignore (Generic.ensure_task fixture.generic);
   if
     List.mem name
-      [ "keeper_task_force_release"; "keeper_task_force_done";
-        "keeper_task_done" ]
+      [ "keeper_task_done" ]
   then
     ensure_keeper_claim fixture;
   if name = "keeper_voice_session_end" then ensure_voice_session fixture;
@@ -344,18 +342,6 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
         [ ("speaker_id", `String "98791450001");
           ("note", `String "tool matrix person note") ]
   | "keeper_tasks_list" -> `Assoc [ ("include_done", `Bool true) ]
-  | "keeper_task_force_release" ->
-      `Assoc
-        [
-          ("task_id", `String (Generic.ensure_task fixture.generic));
-          ("reason", `String "tool matrix release");
-        ]
-  | "keeper_task_force_done" ->
-      `Assoc
-        [
-          ("task_id", `String (Generic.ensure_task fixture.generic));
-          ("notes", `String "tool matrix done");
-        ]
   | "keeper_broadcast" ->
       `Assoc [ ("message", `String "tool matrix broadcast") ]
   | "keeper_task_done" ->

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -189,7 +189,6 @@ let policy_tool_names =
       "keeper_task_claim";
       "keeper_task_create";
       "keeper_task_done";
-      "keeper_task_force_release";
       "keeper_tasks_audit";
       "keeper_tasks_list";
       "keeper_time_now";


### PR DESCRIPTION
## 목표

keeper LLM 전용 `keeper_task_force_done`/`keeper_task_force_release` 툴을 keeper surface에서 제거합니다. (#20925, #21074, board #21559 P0)

## 근본 문제 (grounded, `c5b7090494`)

- `keeper_task_force_done`: autonomous keeper가 LLM 재량으로 **임의 task를 완료처리** → ownership·evidence·anti-rationalization 게이트 전부 우회(`force_done`이 completion floor를 0으로). #20925/#21074의 근원.
- `keeper_task_force_release`: keeper LLM이 임의 task 강제해제 → 그런데 이건 **이미 workspace GC가 자동 수행**(`workspace_core.ml`의 `force_release_task_fn`을 `keeper-gc`로 호출).
- task 수 제약이 없음(코드엔 `max_active_tasks_display=30` 화면 상한, `MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS` keeper 상한만; task claim/active hard limit 부재) → orphan을 급히 강제정리할 동기 자체가 없음.

즉 두 LLM 툴은 정당한 system 자동화(GC=release, RFC-0199 probe=done)의 **수동 중복**이고, LLM 재량이라 거짓완료 위험을 낳습니다. `force_done`이 "모든 게이트 우회"라는 메커니즘 자체가 안티패턴입니다.

## 변경 (근본 해결)

- `Keeper_tool_name` closed sum에서 `Task_force_done`/`Task_force_release` variant 제거 → OCaml 컴파일러가 모든 consumer 누락을 강제 검출(string-classifier 아님).
- `task_op` 핸들러, schema, descriptor, prefilter 별칭, risk(`Critical`)/progress(`completion_tool_names`) 분류, `tasks_audit`의 "force_*로 정리하라" 안내문(GC 자동 release로 교체) 제거.
- **함수는 유지**: `force_done_task_r`(RFC-0199 probe가 사용), `force_release_task_r`(GC가 사용). 제거한 건 keeper LLM-facing surface뿐 — GC 자동 release / probe 자동 완료는 그대로 동작.
- `force_release_task_outcome_r`은 이 변경으로 production fan-in 0이 됨(제거한 release 핸들러가 유일 caller). 이 PR 범위(surface 숙청)를 좁게 유지하려 함수는 남기고 **후속 cleanup 후보**로 기록.

## 검증

- `dune build --root . @check` rc=0 (전체 — variant 제거가 모든 consumer를 컴파일러 검출, 0 에러).
- 영향 테스트(resolution/dispatch/workspace/matrix)의 실패는 **전부 origin/main 기존 broken**이며 force와 무관: baseline stash 비교로 resolution 4 / dispatch 2 동일 확인. matrix 8건은 `keeper_board_post`·`ide_annotate`·`tool_edit/read/write_file` 등 OAS middleware schema 불일치(force 무관, force 케이스는 매트릭스에서 사라짐). force 함수 동작 테스트(`force_done_bypasses_assignee` 등)는 통과.

## 워크어라운드 self-check

툴을 **제거**(추가 아님), telemetry-as-fix / string-classifier / N-of-M / cap-cooldown / catch-all 없음. orphan 정리 책임을 system 자동화(GC/probe)로 단일화.

RFC-WAIVED: keeper tool surface 제거로 credential/identity/operator-control/sandbox/hooks/workflow RFC 게이트 subsystem 아님. completion authority 정합은 RFC-0262와 연관(별도 추적).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
