### PR TITLE
refactor(workspace): remove dead force_release_task_outcome_r

### DIFF
--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -36,22 +36,6 @@ let force_release_task_r config ~agent_name ~task_id ?handoff_context ()
     ()
 ;;
 
-(** Force-release with the typed no-op flag (release on an already-Todo task).
-    Callers needing to distinguish a real release from the idempotent no-op
-    must use this instead of sniffing the message string. *)
-let force_release_task_outcome_r config ~agent_name ~task_id ?handoff_context ()
-  : transition_outcome Masc_domain.masc_result
-  =
-  transition_task_outcome_r
-    config
-    ~agent_name
-    ~task_id
-    ~action:Masc_domain.Release
-    ?handoff_context
-    ~force:true
-    ()
-;;
-
 (** Force-done a task regardless of assignee. Keeper privilege. *)
 let force_done_task_r config ~agent_name ~task_id ~notes ()
   : string Masc_domain.masc_result

--- a/lib/workspace/workspace_task.mli
+++ b/lib/workspace/workspace_task.mli
@@ -79,12 +79,6 @@ val force_release_task_r :
   config -> agent_name:string -> task_id:string ->
   ?handoff_context:Masc_domain.task_handoff_context -> unit -> string Masc_domain.masc_result
 
-(** [force_release_task_r] with the typed no-op flag; see {!transition_outcome}. *)
-val force_release_task_outcome_r :
-  config -> agent_name:string -> task_id:string ->
-  ?handoff_context:Masc_domain.task_handoff_context ->
-  unit -> transition_outcome Masc_domain.masc_result
-
 val force_done_task_r :
   config -> agent_name:string -> task_id:string ->
   notes:string -> unit -> string Masc_domain.masc_result

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -1089,45 +1089,6 @@ let test_transition_release_todo_noop () =
     | Error _ -> Alcotest.fail "Expected Ok no-op")
 ;;
 
-let test_transition_release_todo_typed_noop () =
-  with_test_env (fun config ->
-    let _ = Workspace.add_task config ~title:"Test" ~priority:1 ~description:"" in
-    match
-      Workspace.force_release_task_outcome_r
-        config
-        ~agent_name:"claude"
-        ~task_id:"task-001"
-        ()
-    with
-    | Ok outcome ->
-      Alcotest.(check bool) "typed release todo no-op" true outcome.noop;
-      Alcotest.(check bool)
-        "message remains human-readable"
-        true
-        (str_contains outcome.message "already todo")
-    | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e))
-;;
-
-let test_transition_force_release_claimed_typed_not_noop () =
-  with_test_env (fun config ->
-    let _ = Workspace.add_task config ~title:"Test" ~priority:1 ~description:"" in
-    let _ = Workspace.claim_task config ~agent_name:"claude" ~task_id:"task-001" in
-    match
-      Workspace.force_release_task_outcome_r
-        config
-        ~agent_name:"system"
-        ~task_id:"task-001"
-        ()
-    with
-    | Ok outcome ->
-      Alcotest.(check bool) "claimed force release mutates" false outcome.noop;
-      Alcotest.(check bool)
-        "release message"
-        true
-        (str_contains outcome.message "todo")
-    | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e))
-;;
-
 let test_transition_invalid () =
   with_test_env (fun config ->
     let _ = Workspace.add_task config ~title:"Test" ~priority:1 ~description:"" in
@@ -1982,14 +1943,6 @@ let () =
             `Quick
             test_transition_release_generated_nickname_alias
         ; Alcotest.test_case "release todo no-op" `Quick test_transition_release_todo_noop
-        ; Alcotest.test_case
-            "release todo typed no-op"
-            `Quick
-            test_transition_release_todo_typed_noop
-        ; Alcotest.test_case
-            "force release claimed typed not no-op"
-            `Quick
-            test_transition_force_release_claimed_typed_not_noop
         ; Alcotest.test_case "invalid" `Quick test_transition_invalid
         ; Alcotest.test_case "version mismatch" `Quick test_transition_version_mismatch
         ; Alcotest.test_case "done idempotent" `Quick test_transition_done_idempotent


### PR DESCRIPTION
## 목표

#21586(keeper LLM force 툴 숙청) 후속. `force_release_task_outcome_r`이 production fan-in 0이 된 dead 함수라 제거합니다.

## 근거 (grounded, `52482e2be4`)

- `force_release_task_outcome_r`의 유일한 production caller는 #21586에서 제거된 `keeper_task_force_release` 핸들러였습니다. 그 핸들러가 사라져 production caller 0 (`test_workspace_coverage` 2개 테스트만 참조).
- `transition_task_outcome_r`(이 함수가 wrap한 helper)은 다른 release 경로(`workspace_task_transitions.ml:651`)가 써서 **유지**.
- `force_release_task_r`(GC zombie cleanup용 string 반환 변종, `workspace_gc.ml:171`)은 **손대지 않음**.

## 변경

- `force_release_task_outcome_r` 함수 정의 + `.mli` val + 동작 테스트 2개(`test_transition_release_todo_typed_noop`, `test_transition_force_release_claimed_typed_not_noop`) 제거. (3파일, −69)

## 검증

- 함수 제거가 깬 consumer 0개 — `@check` 에러 중 `workspace_task`/`test_workspace_coverage`/`force_release` 관련 0건.
- 주의: origin/main(`52482e2be4`)이 **별건으로 baseline broken**입니다 — `test_keeper_effective_meta_overlay.ml:56` `Runtime.init_default` unbound. 내 변경을 stash하고 재빌드해도 동일 rc=1·동일 에러로 확인했습니다(내 PR과 무관). `check` CI가 이 baseline 탓에 실패할 수 있습니다.

## 워크어라운드 self-check

dead code 제거(추가 아님). telemetry-as-fix / string-classifier / N-of-M / cap-cooldown / catch-all 없음.

RFC-WAIVED: workspace dead-function cleanup으로 credential/identity/operator-control/sandbox/hooks/workflow RFC 게이트 subsystem 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
