### PR TITLE
feat(dashboard): keeper 설정 화면 분리 — 전역 hook 블록 접이식 + 파생 카운트 정리

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1465,7 +1465,6 @@ describe('fetchKeeperConfig', () => {
           },
         },
         deny_list: 'Execute',
-        deny_list_count: '1',
         destructive_check_tools: 'dynamic_boundary (Tool_dispatch.is_destructive)',
         cost_budget: {
           active: 'false',
@@ -1553,6 +1552,8 @@ describe('fetchKeeperConfig', () => {
     expect(result.execution.per_provider_timeout_mode).toBe('override')
     expect(result.hooks?.destructive_check_tools).toEqual(['dynamic_boundary (Tool_dispatch.is_destructive)'])
     expect(result.hooks?.slots.pre_tool_use?.gates).toEqual(['keeper_deny_list'])
+    // deny_list count is derived from the array (deny_list_count field dropped).
+    expect(result.hooks?.deny_list).toEqual(['Execute'])
     expect(result.sources.precedence).toEqual(['live_meta'])
     expect(result.metrics.total_cost_usd).toBe(0.12)
     expect(result.runtime.runtime_blocker_class).toBe('stale_fleet_batch')

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2197,7 +2197,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       ? {
           slots: normalizeKeeperHookSlots(hooks.slots),
           deny_list: normalizeStringList(hooks.deny_list),
-          deny_list_count: asInt(hooks.deny_list_count) ?? 0,
+          // deny_list_count is derived (deny_list.length); not stored.
           destructive_check_tools: normalizeStringList(hooks.destructive_check_tools),
           cost_budget: {
             max_cost_usd: asLooseNullableNumber(isRecord(hooks.cost_budget) ? hooks.cost_budget.max_cost_usd : undefined),

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -88,7 +88,6 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
     hooks: {
       slots: {},
       deny_list: [],
-      deny_list_count: 0,
       destructive_check_tools: ['dynamic_boundary (Tool_dispatch.is_destructive)'],
       cost_budget: {
         active: false,
@@ -576,6 +575,17 @@ describe('KeeperConfigPanel', () => {
     expect(container.textContent).toContain('활성 런타임')
     expect(container.textContent).toContain('레지스트리 상태')
     expect(container.textContent).toContain('running')
+
+    // The "전역 런타임 아키텍처" block is keeper-agnostic and collapsed by
+    // default; its content (deny list / destructive tools / cost budget) is
+    // hidden until the operator expands it.
+    expect(container.textContent).not.toContain('dynamic_boundary (Tool_dispatch.is_destructive)')
+    const archToggle = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('전역 런타임 아키텍처'),
+    )
+    expect(archToggle).toBeTruthy()
+    archToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
     expect(container.textContent).toContain('dynamic_boundary (Tool_dispatch.is_destructive)')
 
     const editButton = Array.from(container.querySelectorAll('button')).find(button =>

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -58,6 +58,12 @@ type EditDraft = {
 
 const editDraft = signal<EditDraft | null>(null)
 const hookFilterQuery = signal<string>('')
+// The hook-slot / deny-list / cost-budget block is keeper-AGNOSTIC — the
+// backend builds it from a global static introspection with no keeper name,
+// so it is identical for every keeper. It is grouped under a collapsible
+// "전역 런타임 아키텍처" section (collapsed by default) to keep the per-keeper
+// editable controls above as the focus, instead of reading as per-keeper state.
+const globalArchExpanded = signal<boolean>(false)
 const lastSavedAt = signal<string | null>(null)
 const promptPreviewTab = signal<'blocks' | 'system' | 'world'>('blocks')
 
@@ -327,6 +333,7 @@ export function resetKeeperConfig(): void {
   runtimeDraft.value = null
   runtimeSaving.value = false
   hookFilterQuery.value = ''
+  globalArchExpanded.value = false
 }
 
 /**
@@ -1137,44 +1144,62 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       ${c.hooks ? (() => {
         const allEntries: readonly HookSlotEntry[] = Object.entries(c.hooks.slots) as HookSlotEntry[]
+        const activeCount = allEntries.filter(([, slot]) => slot.active).length
         const visibleEntries = filterHookSlots(allEntries, hookFilterQuery.value)
         const isFiltering = hookFilterQuery.value.trim() !== ''
+        const expanded = globalArchExpanded.value
         return html`
-          <${SectionHeader} title="훅 슬롯" />
-          <div class="flex items-center justify-between gap-2 mb-2">
-            <span class="text-3xs text-text-muted">${allEntries.length} slots</span>
-            <input
-              type="search"
-              value=${hookFilterQuery.value}
-              placeholder="슬롯 이름 / source / gate 필터"
-              aria-label="훅 슬롯 필터"
-              onInput=${(e: Event) => { hookFilterQuery.value = (e.target as HTMLInputElement).value }}
-              class="min-w-40 max-w-65 flex-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs text-[var(--color-fg-secondary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
-            />
-          </div>
-          ${isFiltering && visibleEntries.length === 0 && allEntries.length > 0
-            ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${allEntries.length} slots)</div>`
-            : visibleEntries.map(([name, slot]) => html`
-                <div class="flex items-start gap-2 py-2 px-3 rounded-[var(--r-1)] border border-card-border/50 bg-card/20 mb-1.5">
-                  <span class="mt-1 w-2 h-2 rounded-full shrink-0 ${slot.active ? 'bg-[var(--color-status-ok)] shadow-[0_0_6px_var(--ok-48)]' : 'bg-[var(--color-fg-disabled)]'}" aria-hidden="true"></span>
-                  <div class="flex-1 min-w-0">
-                    <div class="flex justify-between">
-                      <span class="text-xs font-semibold text-text-strong">${name}</span>
-                      <span class="text-3xs text-text-muted">${slot.source}</span>
-                    </div>
-                    ${hookSlotDetails(slot).length > 0 ? html`
-                      <div class="flex flex-wrap gap-1 mt-1">
-                        ${hookSlotDetails(slot).map((d: string) => html`
-                          <span class="text-3xs px-1.5 py-0.5 rounded-[var(--r-1)] ${d.endsWith('_off') ? 'bg-[var(--color-bg-hover)] text-[var(--color-fg-disabled)]' : 'bg-[var(--accent-10)] text-[var(--color-accent-fg)] opacity-80'}">${d}</span>
-                        `)}
+          <button
+            type="button"
+            onClick=${() => { globalArchExpanded.value = !globalArchExpanded.value }}
+            aria-expanded=${expanded}
+            class="w-full text-left rounded-[var(--r-3)] border border-[var(--accent-20)] bg-[var(--accent-5)] px-4 py-3 mt-8 mb-4 flex items-center gap-2 shadow-[var(--shadow-1)] v2-monitoring-panel"
+          >
+            <span class="text-2xs text-accent-fg w-3 shrink-0" aria-hidden="true">${expanded ? '▾' : '▸'}</span>
+            <span class="text-xs font-bold uppercase tracking-[var(--track-caps)] text-accent-fg">전역 런타임 아키텍처</span>
+            <span class="text-3xs px-1.5 py-0.5 rounded-[var(--r-1)] bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]">전역 · 읽기 전용</span>
+            <div class="flex-1"></div>
+            <span class="text-3xs text-text-muted">${activeCount}/${allEntries.length} 슬롯 활성</span>
+          </button>
+          ${expanded ? html`
+            <p class="text-3xs text-text-muted mb-3 px-1 leading-relaxed">
+              모든 keeper에 공통인 런타임 hook 합성입니다. keeper별로 다르지 않으며 이 화면에서 편집할 수 없습니다.
+            </p>
+            <div class="flex items-center justify-between gap-2 mb-2">
+              <span class="text-3xs text-text-muted">${allEntries.length} slots</span>
+              <input
+                type="search"
+                value=${hookFilterQuery.value}
+                placeholder="슬롯 이름 / source / gate 필터"
+                aria-label="훅 슬롯 필터"
+                onInput=${(e: Event) => { hookFilterQuery.value = (e.target as HTMLInputElement).value }}
+                class="min-w-40 max-w-65 flex-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs text-[var(--color-fg-secondary)] placeholder:text-[var(--color-fg-disabled)] focus:outline-none focus:border-[var(--color-accent-fg)]"
+              />
+            </div>
+            ${isFiltering && visibleEntries.length === 0 && allEntries.length > 0
+              ? html`<div class="py-4 text-center text-2xs text-[var(--color-fg-disabled)]">필터 결과 없음 (${allEntries.length} slots)</div>`
+              : visibleEntries.map(([name, slot]) => html`
+                  <div class="flex items-start gap-2 py-2 px-3 rounded-[var(--r-1)] border border-card-border/50 bg-card/20 mb-1.5">
+                    <span class="mt-1 w-2 h-2 rounded-full shrink-0 ${slot.active ? 'bg-[var(--color-status-ok)] shadow-[0_0_6px_var(--ok-48)]' : 'bg-[var(--color-fg-disabled)]'}" aria-hidden="true"></span>
+                    <div class="flex-1 min-w-0">
+                      <div class="flex justify-between">
+                        <span class="text-xs font-semibold text-text-strong">${name}</span>
+                        <span class="text-3xs text-text-muted">${slot.source}</span>
                       </div>
-                    ` : null}
+                      ${hookSlotDetails(slot).length > 0 ? html`
+                        <div class="flex flex-wrap gap-1 mt-1">
+                          ${hookSlotDetails(slot).map((d: string) => html`
+                            <span class="text-3xs px-1.5 py-0.5 rounded-[var(--r-1)] ${d.endsWith('_off') ? 'bg-[var(--color-bg-hover)] text-[var(--color-fg-disabled)]' : 'bg-[var(--accent-10)] text-[var(--color-accent-fg)] opacity-80'}">${d}</span>
+                          `)}
+                        </div>
+                      ` : null}
+                    </div>
                   </div>
-                </div>
-              `)}
-          <${ConfigRow} label="거부 목록 수" value=${String(c.hooks.deny_list_count)} />
-          <${ConfigRow} label="파괴 검사 도구" value=${formatHookDestructiveTools(c.hooks.destructive_check_tools)} />
-          <${ConfigRow} label="비용 예산" value=${c.hooks.cost_budget.active ? formatCost(c.hooks.cost_budget.max_cost_usd ?? 0) : '비활성'} />
+                `)}
+            <${ConfigRow} label="거부 목록 수" value=${String(c.hooks.deny_list.length)} />
+            <${ConfigRow} label="파괴 검사 도구" value=${formatHookDestructiveTools(c.hooks.destructive_check_tools)} />
+            <${ConfigRow} label="비용 예산 (텔레메트리 · 미강제)" value=${c.hooks.cost_budget.active ? formatCost(c.hooks.cost_budget.max_cost_usd ?? 0) : '미설정'} />
+          ` : null}
         `
       })() : null}
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1482,7 +1482,8 @@ export interface KeeperHookSlot {
 interface KeeperHookIntrospection {
   slots: Record<string, KeeperHookSlot>
   deny_list: string[]
-  deny_list_count: number
+  // deny_list_count dropped: it is pure derived state (deny_list.length).
+  // Consumers compute the count from the array directly.
   destructive_check_tools: string[]
   cost_budget: { max_cost_usd?: number | null; active: boolean }
 }


### PR DESCRIPTION
slot 시스템 적대 감사 후속 (PR #21587에 이어). 레이아웃 결정 = "A. 인라인 전역 섹션(접이식)".

## 문제 (E1)
keeper 설정 화면이 훅 슬롯·거부목록·비용예산을 *이 keeper의 상태*처럼 렌더했지만, backend는 keeper 이름 없이 전역 정적 introspection(`hook_introspection_json ()`)으로 만들어 **모든 keeper에 동일**. per-keeper 화면에 인라인으로 섞여 오해를 유발.

## 변경 (프론트엔드)
- 훅 슬롯/거부목록/파괴검사/비용예산을 접이식 **"전역 런타임 아키텍처"** 섹션으로 이동. 기본 접힘 + `전역 · 읽기 전용` 배지 + 설명 문구. 위쪽 per-keeper 편집 컨트롤이 초점이 되도록.
- 비용 예산 라벨 → **"비용 예산 (텔레메트리 · 미강제)"**, 비활성 시 `미설정`. (`cost_guard`가 `ignore max_cost_usd` 후 항상 Continue = 강제 안 함. 기존 "비활성"/금액 표기는 강제 한도처럼 읽힘)
- 파생 `deny_list_count` 제거(타입+정규화기+픽스처) → `deny_list.length`로 렌더. slot_count/active/inactive/slot_names는 UI 미사용이었음.

## 변경 파일
- `keeper-config-panel.ts` (signal + 접이식 재배치 + reset)
- `keeper-config-panel.test.ts` (접이식 동작 테스트 + 픽스처)
- `api/dashboard.ts` (정규화기), `api/dashboard.test.ts` (픽스처+deny_list 단언), `types/core.ts` (타입)

## 로컬 검증
- `tsc --noEmit` exit 0
- `vitest` keeper-config-panel + dashboard — 83 passed (접이식 기본 접힘→토글→표시 검증 포함)
- `eslint` 0 errors

## 범위 밖(후속)
- **PR3b**: introspection backend가 파생 카운트(slot_count/active/inactive/slot_names/deny_list_count) emit 중단 + OCaml 상수 제거 (지금은 frontend가 무시만)
- **PR3c**: 숨은 편집 컨트롤(mention_targets/tool_denylist/compaction_token_gate) 노출 — backend PATCH 지원 확인 후

🤖 Generated with [Claude Code](https://claude.com/claude-code)