### PR TITLE
fix(dashboard): expose keeper runtime policy controls

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2275,6 +2275,7 @@ export type SharedMemoryScope = 'disabled' | 'workspace'
 export type KeeperConfigUpdatePayload = {
   runtime_id?: string
   active_goal_ids?: string[]
+  mention_targets?: string[]
   allowed_paths?: string[]
   // Sandbox
   sandbox_profile?: SandboxProfile
@@ -2301,6 +2302,8 @@ export type KeeperConfigUpdatePayload = {
   auto_handoff?: boolean
   handoff_threshold?: number
   handoff_cooldown_sec?: number
+  // Tool policy
+  tool_denylist?: string[]
 }
 
 export async function patchKeeperConfig(

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -311,7 +311,14 @@ function makeKeeperConfigForSandbox(overrides: Partial<KeeperConfig> = {}): Keep
       active_goal_count: 0,
       missing_active_goal_ids: [],
     },
-    tools: {} as KeeperConfig['tools'],
+    tools: {
+      tool_access: [],
+      resolved_allowlist: [],
+      tool_denylist: [],
+      active_masc_tool_count: 0,
+      active_keeper_tool_count: 0,
+      total_active: 0,
+    },
     sources: {} as KeeperConfig['sources'],
     metrics: {} as KeeperConfig['metrics'],
   }
@@ -448,6 +455,50 @@ describe('buildRuntimePayload — sandbox diffing', () => {
       active_goal_ids: ['goal-b', 'goal-c'],
     }), c)
     expect(payload.active_goal_ids).toEqual(['goal-b', 'goal-c'])
+  })
+
+  it('emits mention targets and tool denylist from line-based drafts', () => {
+    const c = makeKeeperConfigForSandbox({
+      workspace: {
+        mention_targets: ['sangsu'],
+        bound_workspace_ids: [],
+        active_goal_ids: [],
+        active_goals: [],
+        active_goal_count: 0,
+        missing_active_goal_ids: [],
+      },
+      tools: {
+        tool_access: [],
+        resolved_allowlist: [],
+        tool_denylist: ['Execute'],
+        active_masc_tool_count: 0,
+        active_keeper_tool_count: 0,
+        total_active: 0,
+      },
+    })
+    const payload = buildRuntimePayload(draftFrom(c, {
+      mention_targets_text: 'alpha\n beta \nalpha\n',
+      tool_denylist_text: 'Execute\nRead\nRead\n',
+    }), c)
+
+    expect(payload.mention_targets).toEqual(['alpha', 'beta'])
+    expect(payload.tool_denylist).toEqual(['Execute', 'Read'])
+  })
+
+  it('emits compaction_token_gate when the token gate changes', () => {
+    const c = makeKeeperConfigForSandbox({
+      compaction: {
+        profile: 'balanced',
+        ratio_gate: 0.8,
+        message_gate: 0,
+        token_gate: 24000,
+        cooldown_sec: 0,
+      },
+    })
+    const payload = buildRuntimePayload(draftFrom(c, {
+      compaction_token_gate: 32000,
+    }), c)
+    expect(payload.compaction_token_gate).toBe(32000)
   })
 })
 
@@ -742,6 +793,61 @@ describe('KeeperConfigPanel', () => {
       expect.objectContaining({
         sandbox_profile: 'docker',
         network_mode: 'none',
+      }),
+    )
+  })
+
+  it('patches mention targets, tool denylist, and compaction token gate from the dashboard panel', async () => {
+    const base = makeKeeperConfig()
+    mocks.patchKeeperConfig.mockResolvedValueOnce(
+      makeKeeperConfig({
+        workspace: {
+          ...base.workspace,
+          mention_targets: ['alpha', 'beta'],
+        },
+        tools: {
+          ...base.tools,
+          tool_denylist: ['Execute', 'Read'],
+        },
+        compaction: {
+          ...base.compaction,
+          token_gate: 32000,
+        },
+      }),
+    )
+
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    const mentionTargets = container.querySelector('textarea[aria-label="mention_targets"]') as HTMLTextAreaElement | null
+    const toolDenylist = container.querySelector('textarea[aria-label="tool_denylist"]') as HTMLTextAreaElement | null
+    const tokenGate = container.querySelector('input[aria-label="토큰 게이트"]') as HTMLInputElement | null
+    expect(mentionTargets).not.toBeNull()
+    expect(toolDenylist).not.toBeNull()
+    expect(tokenGate).not.toBeNull()
+
+    mentionTargets!.value = 'alpha\n beta \nalpha\n'
+    mentionTargets!.dispatchEvent(new Event('input', { bubbles: true }))
+    toolDenylist!.value = 'Execute\nRead\nRead\n'
+    toolDenylist!.dispatchEvent(new Event('input', { bubbles: true }))
+    tokenGate!.value = '32000'
+    tokenGate!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('런타임 설정 저장'),
+    )
+    saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    await flush()
+
+    expect(mocks.patchKeeperConfig).toHaveBeenCalledWith(
+      'keeper-sangsu',
+      expect.objectContaining({
+        mention_targets: ['alpha', 'beta'],
+        tool_denylist: ['Execute', 'Read'],
+        compaction_token_gate: 32000,
       }),
     )
   })

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -485,6 +485,24 @@ describe('buildRuntimePayload — sandbox diffing', () => {
     expect(payload.tool_denylist).toEqual(['Execute', 'Read'])
   })
 
+  it('emits explicit empty mention targets when the draft is cleared', () => {
+    const c = makeKeeperConfigForSandbox({
+      workspace: {
+        mention_targets: ['sangsu'],
+        bound_workspace_ids: [],
+        active_goal_ids: [],
+        active_goals: [],
+        active_goal_count: 0,
+        missing_active_goal_ids: [],
+      },
+    })
+    const payload = buildRuntimePayload(draftFrom(c, {
+      mention_targets_text: '',
+    }), c)
+
+    expect(payload.mention_targets).toEqual([])
+  })
+
   it('emits compaction_token_gate when the token gate changes', () => {
     const c = makeKeeperConfigForSandbox({
       compaction: {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -167,8 +167,10 @@ export type RuntimeDraft = {
   runtime_id: string
   sandbox_profile: SandboxProfile
   active_goal_ids: string[]
+  mention_targets_text: string
   network_mode: SandboxNetworkMode
   allowed_paths_text: string
+  tool_denylist_text: string
   proactive_enabled: boolean
   proactive_idle_sec: number
   proactive_cooldown_sec: number
@@ -208,8 +210,10 @@ export function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
     active_goal_ids: c.workspace.active_goal_ids.length > 0
       ? c.workspace.active_goal_ids
       : c.active_goal_ids,
+    mention_targets_text: c.workspace.mention_targets.join('\n'),
     network_mode: coerceNetworkMode(c.network_mode),
     allowed_paths_text: (c.allowed_paths ?? []).join('\n'),
+    tool_denylist_text: c.tools.tool_denylist.join('\n'),
     proactive_enabled: c.proactive.enabled,
     proactive_idle_sec: c.proactive.idle_sec,
     proactive_cooldown_sec: c.proactive.cooldown_sec,
@@ -226,13 +230,17 @@ export function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
 export function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): KeeperConfigUpdatePayload {
   const payload: KeeperConfigUpdatePayload = {}
   const newPaths = draft.allowed_paths_text.split('\n').map(s => s.trim()).filter(Boolean)
+  const newMentionTargets = listTextToStrings(draft.mention_targets_text)
+  const newToolDenylist = listTextToStrings(draft.tool_denylist_text)
   const origPaths = orig.allowed_paths ?? []
   const origActiveGoalIds = orig.workspace.active_goal_ids.length > 0
     ? orig.workspace.active_goal_ids
     : orig.active_goal_ids
   if (draft.runtime_id.trim() !== (orig.execution.selected_runtime_id ?? '').trim()) payload.runtime_id = draft.runtime_id.trim()
   if (!sameStringArray(draft.active_goal_ids, origActiveGoalIds)) payload.active_goal_ids = draft.active_goal_ids
+  if (!sameStringArray(newMentionTargets, orig.workspace.mention_targets)) payload.mention_targets = newMentionTargets
   if (JSON.stringify(newPaths) !== JSON.stringify(origPaths)) payload.allowed_paths = newPaths
+  if (!sameStringArray(newToolDenylist, orig.tools.tool_denylist)) payload.tool_denylist = newToolDenylist
   if (draft.sandbox_profile !== coerceSandboxProfile(orig.sandbox_profile)) payload.sandbox_profile = draft.sandbox_profile
   if (draft.network_mode !== coerceNetworkMode(orig.network_mode)) payload.network_mode = draft.network_mode
   if (draft.proactive_enabled !== orig.proactive.enabled) payload.proactive_enabled = draft.proactive_enabled
@@ -266,12 +274,18 @@ function sameStringArray(a: readonly string[], b: readonly string[]): boolean {
   return a.every((value, index) => value === b[index])
 }
 
+function listTextToStrings(text: string): string[] {
+  return dedupeStrings(text.split('\n'))
+}
+
 function computeRuntimeDirtyFlags(rd: RuntimeDraft, c: KeeperConfig): Record<string, boolean> {
   const payload = buildRuntimePayload(rd, c)
   return {
     runtime_id: 'runtime_id' in payload,
     active_goal_ids: 'active_goal_ids' in payload,
+    mention_targets: 'mention_targets' in payload,
     allowed_paths: 'allowed_paths' in payload,
+    tool_denylist: 'tool_denylist' in payload,
     sandbox_profile: 'sandbox_profile' in payload,
     network_mode: 'network_mode' in payload,
     proactive_enabled: 'proactive_enabled' in payload,
@@ -873,6 +887,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   const selectedActiveGoalIds = rd
     ? rd.active_goal_ids
     : (c.workspace.active_goal_ids.length > 0 ? c.workspace.active_goal_ids : c.active_goal_ids)
+  const currentMentionTargets = rd
+    ? listTextToStrings(rd.mention_targets_text)
+    : c.workspace.mention_targets
+  const currentToolDenylist = rd
+    ? listTextToStrings(rd.tool_denylist_text)
+    : c.tools.tool_denylist
   const knownGoalIds = new Set(goalOptions.map((goal) => goal.id))
   const unknownSelectedGoalIds = goalOptionsLoaded
     ? selectedActiveGoalIds.filter((goalId) => !knownGoalIds.has(goalId))
@@ -966,6 +986,24 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${SectionHeader} size="xs" class="mb-1">런타임 후보</${SectionHeader}>
         <${RuntimeList} runtimes=${c.execution.models} />
       </div>
+
+      <${SectionHeader} title="툴 정책" />
+      ${rd ? html`
+        <div class="py-2.5 px-4 rounded-[var(--r-1)] bg-[var(--color-bg-surface)] mb-2 ${dirtyFlags.tool_denylist ? 'border-l-4 border-l-[var(--color-accent-fg)]' : ''} v2-monitoring-panel">
+          <div class="flex items-center justify-between mb-2">
+            <span class="text-sm text-[var(--color-fg-secondary)]">tool_denylist</span>
+            <span class="text-xs text-[var(--color-fg-muted)]">${currentToolDenylist.length}개</span>
+          </div>
+          <textarea aria-label="tool_denylist" class="w-full text-sm font-mono bg-[var(--color-bg-hover)] border border-[var(--color-border-default)] rounded-[var(--r-1)] px-3 py-2 text-[var(--color-fg-secondary)] resize-y"
+            rows=${3}
+            value=${rd.tool_denylist_text}
+            placeholder="mcp__masc__dangerous_tool"
+            onInput=${(e: Event) => updateRuntimeDraft('tool_denylist_text', (e.target as HTMLTextAreaElement).value)}
+          ></textarea>
+        </div>
+      ` : html`
+        <${ConfigRow} label="tool_denylist" value=${currentToolDenylist.join(', ') || MISSING_DATA_DASH} />
+      `}
 
       <${SectionHeader} title="컴팩션" />
       <${ConfigRow} label="프로필" value=${c.compaction.profile || MISSING_DATA_DASH} />
@@ -1126,17 +1164,30 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           </div>
         ` : null}
       </div>
-      ${isVerifierRoleKeeper(c.workspace.mention_targets) ? html`
+      ${isVerifierRoleKeeper(currentMentionTargets) ? html`
       <div class="mb-2 flex items-center gap-2 rounded-[var(--r-1)] border border-[var(--accent-30)] bg-[var(--accent-10)] px-3 py-2">
         <span class="rounded-[var(--r-1)] border border-[var(--accent-40)] bg-[var(--accent-5)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-accent-fg">검증자</span>
         <span class="text-2xs text-text-body">이 keeper는 task completion_contract를 독립 실측하는 검증자 역할입니다.</span>
       </div>
       ` : null}
-      ${c.workspace.mention_targets.length > 0 ? html`
-      <div class="mt-1.5">
-        <${SectionHeader} size="xs" class="mb-1">멘션 대상</${SectionHeader}>
-        <${ModelList} models=${c.workspace.mention_targets} />
-      </div>
+      ${rd ? html`
+        <div class="py-2.5 px-4 rounded-[var(--r-1)] bg-[var(--color-bg-surface)] mb-2 ${dirtyFlags.mention_targets ? 'border-l-4 border-l-[var(--color-accent-fg)]' : ''} v2-monitoring-panel">
+          <div class="flex items-center justify-between mb-2">
+            <span class="text-sm text-[var(--color-fg-secondary)]">mention_targets</span>
+            <span class="text-xs text-[var(--color-fg-muted)]">${currentMentionTargets.length}개</span>
+          </div>
+          <textarea aria-label="mention_targets" class="w-full text-sm font-mono bg-[var(--color-bg-hover)] border border-[var(--color-border-default)] rounded-[var(--r-1)] px-3 py-2 text-[var(--color-fg-secondary)] resize-y"
+            rows=${3}
+            value=${rd.mention_targets_text}
+            placeholder="sangsu"
+            onInput=${(e: Event) => updateRuntimeDraft('mention_targets_text', (e.target as HTMLTextAreaElement).value)}
+          ></textarea>
+        </div>
+      ` : currentMentionTargets.length > 0 ? html`
+        <div class="mt-1.5">
+          <${SectionHeader} size="xs" class="mb-1">멘션 대상</${SectionHeader}>
+          <${ModelList} models=${currentMentionTargets} />
+        </div>
       ` : null}
       <div class="mt-1.5">
         <${SectionHeader} size="xs" class="mb-1">참여 네임스페이스</${SectionHeader}>

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -19,7 +19,7 @@ type parsed_args = {
   runtime_id_opt : string option;
   allowed_paths_opt : string list option;
   autoboot_enabled_opt : bool option;
-  mention_targets_in : string list;
+  mention_targets_opt : string list option;
   active_goal_ids_opt : string list option;
   max_context_override_opt : int option;
   proactive_enabled_opt : bool option;
@@ -148,27 +148,29 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let tool_access_input_res = parse_tool_access_input args in
     let allowed_paths_opt_res = parse_present_string_list_opt args "allowed_paths" in
     let active_goal_ids_opt_res = parse_present_string_list_opt args "active_goal_ids" in
+    let mention_targets_opt_res = parse_present_string_list_opt args "mention_targets" in
     let runtime_id_opt_res = parse_runtime_id_opt args in
     match
       compaction_profile_opt_res, tool_access_input_res, allowed_paths_opt_res,
-      active_goal_ids_opt_res, runtime_id_opt_res
+      active_goal_ids_opt_res, mention_targets_opt_res, runtime_id_opt_res
     with
-    | Error e, _, _, _, _
-    | _, Error e, _, _, _
-    | _, _, Error e, _, _
-    | _, _, _, Error e, _
-    | _, _, _, _, Error e -> Error (tool_result_error e)
+    | Error e, _, _, _, _, _
+    | _, Error e, _, _, _, _
+    | _, _, Error e, _, _, _
+    | _, _, _, Error e, _, _
+    | _, _, _, _, Error e, _
+    | _, _, _, _, _, Error e -> Error (tool_result_error e)
     | Ok compaction_profile_opt,
       Ok tool_access_opt,
       Ok allowed_paths_opt,
       Ok active_goal_ids_opt,
+      Ok mention_targets_opt,
       Ok runtime_id_opt ->
     let goal_opt = get_string_opt args "goal" in
     let short_goal_opt = parse_goal_horizon_opt args "short_goal" in
     let mid_goal_opt = parse_goal_horizon_opt args "mid_goal" in
     let long_goal_opt = parse_goal_horizon_opt args "long_goal" in
     let autoboot_enabled_opt = get_bool_opt args "autoboot_enabled" in
-    let mention_targets_in = get_string_list args "mention_targets" in
     let max_context_override_opt =
       let min_keeper_context = Keeper_config.min_keeper_context_tokens in
       let max_keeper_context = Keeper_config.max_keeper_context_tokens in
@@ -245,7 +247,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       allowed_paths_opt;
       active_goal_ids_opt;
       autoboot_enabled_opt;
-      mention_targets_in;
+      mention_targets_opt;
       max_context_override_opt;
       proactive_enabled_opt;
       proactive_idle_sec_opt;
@@ -270,11 +272,11 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     }
 
 (** Resolve mention targets with dedup and filtering. *)
-let resolve_mention_targets ~mention_targets_in ~fallback_targets ~name =
+let resolve_mention_targets ~mention_targets_opt ~fallback_targets ~name =
   let raw =
-    if mention_targets_in <> [] then mention_targets_in
-    else if fallback_targets <> [] then fallback_targets
-    else [ name ]
+    match mention_targets_opt with
+    | Some targets -> targets
+    | None -> if fallback_targets <> [] then fallback_targets else [ name ]
   in
   raw |> List.filter (fun s -> String.trim s <> "") |> dedupe_keep_order
 

--- a/lib/keeper/keeper_turn_up_args.mli
+++ b/lib/keeper/keeper_turn_up_args.mli
@@ -21,7 +21,7 @@ type parsed_args =
   ; runtime_id_opt : string option
   ; allowed_paths_opt : string list option
   ; autoboot_enabled_opt : bool option
-  ; mention_targets_in : string list
+  ; mention_targets_opt : string list option
   ; active_goal_ids_opt : string list option
   ; max_context_override_opt : int option
   ; proactive_enabled_opt : bool option
@@ -79,10 +79,10 @@ val parse_tool_access_input :
 val parse :
   _ context -> Yojson.Safe.t -> (parsed_args, tool_result) result
 
-(** Resolve mention targets with dedupe + blank filter, falling
-    through [mention_targets_in] → [fallback_targets] → [[name]]. *)
+(** Resolve mention targets with dedupe + blank filter. [None] falls through to
+    [fallback_targets] → [[name]]; [Some []] is an explicit clear. *)
 val resolve_mention_targets :
-  mention_targets_in:string list ->
+  mention_targets_opt:string list option ->
   fallback_targets:string list ->
   name:string ->
   string list

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -73,7 +73,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   in
   let mention_targets =
     resolve_mention_targets
-      ~mention_targets_in:p.mention_targets_in
+      ~mention_targets_opt:p.mention_targets_opt
       ~fallback_targets:p.profile_defaults.mention_targets
       ~name:p.name
   in

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -123,7 +123,7 @@ let update_keeper ?(preserve_prompt_defaults = false)
   in
   let mention_targets =
     resolve_mention_targets
-      ~mention_targets_in:p.mention_targets_in
+      ~mention_targets_opt:p.mention_targets_opt
       ~fallback_targets:
         (if old.mention_targets <> [] then old.mention_targets
          else p.profile_defaults.mention_targets)

--- a/test/dune
+++ b/test/dune
@@ -1543,6 +1543,8 @@
 
 (include stanzas/test_keeper_context_isolation.inc)
 
+(include stanzas/test_keeper_turn_up_args.inc)
+
 (include stanzas/test_keeper_cwd_response.inc)
 
 (include stanzas/test_keeper_disposition_budget.inc)

--- a/test/stanzas/test_keeper_turn_up_args.inc
+++ b/test/stanzas/test_keeper_turn_up_args.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_turn_up_args)
+ (modules test_keeper_turn_up_args)
+ (libraries masc_test_deps))

--- a/test/test_keeper_turn_up_args.ml
+++ b/test/test_keeper_turn_up_args.ml
@@ -1,0 +1,52 @@
+open Alcotest
+open Masc
+
+let test_resolve_mention_targets_uses_fallback_when_absent () =
+  check
+    (list string)
+    "fallback targets"
+    [ "existing" ]
+    (Keeper_turn_up_args.resolve_mention_targets
+       ~mention_targets_opt:None
+       ~fallback_targets:[ "existing" ]
+       ~name:"keeper-a")
+
+let test_resolve_mention_targets_preserves_explicit_clear () =
+  check
+    (list string)
+    "explicit clear"
+    []
+    (Keeper_turn_up_args.resolve_mention_targets
+       ~mention_targets_opt:(Some [])
+       ~fallback_targets:[ "existing" ]
+       ~name:"keeper-a")
+
+let test_resolve_mention_targets_normalizes_explicit_values () =
+  check
+    (list string)
+    "deduped explicit targets"
+    [ "alpha"; "beta" ]
+    (Keeper_turn_up_args.resolve_mention_targets
+       ~mention_targets_opt:(Some [ " alpha "; ""; "beta"; "alpha" ])
+       ~fallback_targets:[ "existing" ]
+       ~name:"keeper-a")
+
+let () =
+  run
+    "keeper_turn_up_args"
+    [ ( "mention_targets"
+      , [ test_case
+            "absent mention_targets uses fallback"
+            `Quick
+            test_resolve_mention_targets_uses_fallback_when_absent
+        ; test_case
+            "explicit empty mention_targets clears"
+            `Quick
+            test_resolve_mention_targets_preserves_explicit_clear
+        ; test_case
+            "explicit mention_targets normalize and dedupe"
+            `Quick
+            test_resolve_mention_targets_normalizes_explicit_values
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- expose hidden keeper runtime controls for mention_targets, tool_denylist, and compaction_token_gate
- send mention/tool policy diffs through KeeperConfigUpdatePayload with line-based trim/dedupe
- display hook deny count from the deny_list array length instead of trusting the derived count field

## Verification
- git diff --check
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/keeper-config-runtime-controls/dashboard/vitest.config.ts /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/keeper-config-runtime-controls/dashboard/src/components/keeper-config-panel.test.ts --no-file-parallelism --maxWorkers=1
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/eslint src/components/keeper-config-panel.ts src/api/dashboard.ts

Follow-up to #21587 F4/F5 remaining dashboard config gaps.