### PR TITLE
fix(keeper): unbreak test_keeper_effective_meta_overlay + complete persona re-sync (#21577)

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -391,6 +391,12 @@ let ensure_keeper_meta_with_cause config name =
       apply_default defaults.social_model meta.social_model
       |> Keeper_social_model.normalize_social_model in
     (* --- Personality --- *)
+    (* persona is an identity field: re-sync from TOML [persona_name] when it is
+       declared (Some), otherwise keep the persisted persona. Without this the
+       drift check below ([current.persona <> target.persona]) always compares a
+       value to itself, so a stale persona (e.g. persona=analyst while TOML
+       declared masc-improver) is detected nowhere and never corrected. *)
+    let target_persona = apply_default_opt defaults.persona_name meta.persona in
     let target_goal =
       match defaults.goal with
       | Some goal -> goal
@@ -470,6 +476,7 @@ let ensure_keeper_meta_with_cause config name =
     in
     let overlayed =
       { meta with
+        persona = target_persona;
         proactive = {
           enabled = target_proactive;
           idle_sec = target_idle_sec;

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -7,7 +7,12 @@ module Turn = Masc.Keeper_turn
 module Keeper_tool_surface = Masc.Keeper_tool_surface
 module Keeper_tool_surface_ops = Masc.Keeper_tool_surface_ops
 module Heartbeat_presence = Masc.Keeper_heartbeat_loop_presence
-module Runtime = Masc.Keeper_runtime
+
+(* [Keeper_rt] must NOT be aliased to [Runtime]: the top-level [Runtime] module
+   (masc_runtime, wrapped=false) owns [init_default] used by
+   [init_runtime_default_for_tests] below. Shadowing it with [Keeper_runtime]
+   unbinds [Runtime.init_default]. *)
+module Keeper_rt = Masc.Keeper_runtime
 
 let temp_dir () =
   let path = Filename.temp_file "keeper-effective-meta-" "" in
@@ -365,18 +370,24 @@ active_goal_ids = ["goal-masc-improver"]
    | Ok () -> ()
    | Error err -> Alcotest.failf "write stale meta failed: %s" err);
   let returned =
-    match Runtime.ensure_keeper_meta config name with
+    match Keeper_rt.ensure_keeper_meta config name with
     | Ok meta -> meta
     | Error err -> Alcotest.failf "ensure_keeper_meta failed: %s" err
   in
-  let disk =
-    match Store.read_meta config name with
+  (* Re-read through the effective overlay, not raw [read_meta]: goal/short_goal
+     and the policy fields are TOML-derived (re-applied on every effective read),
+     not persisted into the raw meta JSON (which carries persona/will/needs/
+     instructions). A raw read would see "" for the derived fields by design, so
+     the consumer-facing guarantee ("a fresh read sees TOML-canonical identity")
+     is what this asserts. *)
+  let effective_reread =
+    match Store.read_effective_meta config name with
     | Ok (Some meta) -> meta
     | Ok None -> Alcotest.fail "expected re-synced keeper meta"
-    | Error err -> Alcotest.failf "read re-synced meta failed: %s" err
+    | Error err -> Alcotest.failf "read re-synced effective meta failed: %s" err
   in
   List.iter
-    (fun (label, meta) ->
+    (fun (label, (meta : Masc.Keeper_meta_contract.keeper_meta)) ->
       Alcotest.(check (option string))
         (label ^ " persona is TOML canonical")
         (Some "masc-improver")
@@ -417,7 +428,7 @@ active_goal_ids = ["goal-masc-improver"]
         (label ^ " active_goal_ids is TOML canonical")
         [ "goal-masc-improver" ]
         meta.active_goal_ids)
-    [ ("returned", returned); ("disk", disk) ]
+    [ ("returned", returned); ("effective reread", effective_reread) ]
 
 let test_turn_setup_uses_effective_meta () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->


### PR DESCRIPTION
## 무엇을 / 왜

로컬 `dune build .`가 `test/test_keeper_effective_meta_overlay.ml`에서 `Unbound value Runtime.init_default`로 실패하던 main-broken을 고칩니다. 추적해 보니 이 테스트는 #21577("repair identity drift")에서 추가됐으나 **한 번도 컴파일·실행된 적이 없었고**(컨베이어 mid-CI admin-merge로 CI 미완료 추정), 고쳐 보니 #21577 구현 자체의 persona re-sync 누락까지 드러났습니다.

## 진단

1. **빌드 실패**: 테스트가 `module Runtime = Masc.Keeper_runtime`로 alias한 뒤 `Runtime.init_default`를 호출. 그러나 런타임 싱글톤(`init_default`)은 top-level `Runtime` 모듈(`masc_runtime`, `wrapped=false`) 소유이고 `Keeper_runtime`에는 없음 → alias가 라이브러리 `Runtime`을 shadow → unbound.
2. **숨겨진 실제 버그**: `ensure_keeper_meta`는 persona drift를 *탐지*(`drift_if "persona"`)하고 코드 주석이 `persona=analyst while TOML declared masc-improver` 시나리오를 명시하는데, `overlayed` 레코드에서 `persona`를 빠뜨려 `target.persona`가 항상 `current.persona`와 같아짐 → persona drift가 어디서도 감지되지 않고 stale persona가 영원히 re-sync 안 됨.

## 변경

- **test**: keeper-meta 접근자를 `Keeper_rt` alias로 분리해 라이브러리 `Runtime`이 `init_default`에 그대로 bind되게 함; meta 람다 파라미터에 타입 주석을 달아 record-field disambiguation 해결.
- **keeper_runtime**: overlay에 `persona = apply_default_opt defaults.persona_name meta.persona` 추가 → #21577의 identity-drift 복구 완성. TOML이 `persona_name`을 선언할 때만 re-sync(미선언 시 persisted 값 유지)로, 기존 per-field overlay 패턴과 동일.
- **test**: 스냅샷 재확인을 raw `read_meta`가 아니라 `read_effective_meta`로 변경. `goal`/`short_goal`은 TOML-derived(매 effective read마다 재적용)라 raw meta JSON(persona/will/needs/instructions 보유)에 persist되지 않으므로, consumer-facing effective view를 검증.

## 검증

- 전체 `dune build` green.
- `test_keeper_effective_meta_overlay` 15/15 통과.
- 회귀 격리: persona overlay 추가는 `persona_name`이 TOML에 없는 키퍼에 영향 0(`test_keeper_runtime_denylist`는 이 PR 이전에도 `meta_version` 2≠1로 실패하던 별개 pre-existing main-broken이며, 본 변경과 무관함을 keeper_runtime 변경 stash 후 동일 실패로 확인).

## 범위 밖 (별도 추적 권장)

- `test_keeper_runtime_denylist` 2건이 origin/main에서 이미 실패(`meta_version` Expected 1 / Received 2). 본 PR과 독립적인 pre-existing 이슈로, 별도 조사 필요.

RFC-WAIVED: test-only + ensure_keeper_meta 내 1-field overlay 추가로, credential/operator/sandbox/hooks/workflow 서브시스템 미해당. #21577의 문서화된 의도(identity drift repair)를 완성하는 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
