### PR TITLE
feat(runtime): anti-rationalization 평가기를 [runtime].cross_verifier로 독립 라우팅

### DIFF
--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -524,6 +524,9 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
         Board_metric_hooks_adapter.install ();
         Workspace_metric_hooks.install ();
         Atomic.set Workspace_hooks.get_default_runtime_id_fn Runtime.get_default_runtime_id;
+        Atomic.set
+          Workspace_hooks.get_cross_verifier_runtime_id_fn
+          Runtime.cross_verifier_runtime_id;
         Atomic.set Task.Handlers.record_verdict_fn (fun ~task_id ~req ~result () ->
           Eval_calibration.record_verdict ~task_id ~req ~result ());
         Atomic.set Task.Handlers.sse_broadcast_fn Sse.broadcast;

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -89,8 +89,30 @@ let validate_librarian_runtime ~(config_path : string) (runtimes : t list)
            (List.length runtimes))
 ;;
 
+(* [runtime].cross_verifier mirrors [runtime].librarian validation: an unknown
+   id is an operator typo rejected at load, not a silent fallback
+   (Unknown→Permissive anti-pattern). [None] is the designed "inherit
+   [runtime].default" case. *)
+let validate_cross_verifier_runtime ~(config_path : string) (runtimes : t list)
+    (cross_verifier_id : string option) : (unit, string) result =
+  match cross_verifier_id with
+  | None -> Ok ()
+  | Some id ->
+    if List.exists (fun (r : t) -> String.equal r.id id) runtimes
+    then Ok ()
+    else
+      Error
+        (Printf.sprintf
+           "%s: [runtime].cross_verifier = %S not found among %d runtimes"
+           config_path
+           id
+           (List.length runtimes))
+;;
+
 let materialize_config ~(config_path : string) (cfg : config)
-  : (t list * t * (string * string) list * string option, string) result
+  : ( t list * t * (string * string) list * string option * string option
+    , string )
+    result
   =
   let runtimes = List.filter_map (of_binding cfg) cfg.bindings in
   let assignments = cfg.keeper_assignments in
@@ -120,11 +142,24 @@ let materialize_config ~(config_path : string) (cfg : config)
            with
            | Error _ as e -> e
            | Ok () ->
-             Ok (runtimes, rt, assignments, cfg.librarian_runtime_id))))
+             (match
+                validate_cross_verifier_runtime ~config_path runtimes
+                  cfg.cross_verifier_runtime_id
+              with
+              | Error _ as e -> e
+              | Ok () ->
+                Ok
+                  ( runtimes
+                  , rt
+                  , assignments
+                  , cfg.librarian_runtime_id
+                  , cfg.cross_verifier_runtime_id )))))
 ;;
 
 let load_list ~(config_path : string)
-  : (t list * t * (string * string) list * string option, string) result
+  : ( t list * t * (string * string) list * string option * string option
+    , string )
+    result
   =
   match Runtime_toml.parse_file config_path with
   | Error errs ->
@@ -156,15 +191,21 @@ let keeper_assignments_ref : (string * string) list Atomic.t = Atomic.make []
    [librarian_runtime_id]; validated at load so a [Some] always resolves. *)
 let librarian_runtime_id_ref : string option Atomic.t = Atomic.make None
 
+(* [runtime].cross_verifier — runtime id for the anti-rationalization evaluator,
+   or [None] to inherit [runtime].default. Populated by [init_default], read by
+   [cross_verifier_runtime_id]; validated at load so a [Some] always resolves. *)
+let cross_verifier_runtime_id_ref : string option Atomic.t = Atomic.make None
+
 let runtime_ids runtimes = List.map (fun (rt : t) -> rt.id) runtimes
 
 let init_default ~config_path =
   match load_list ~config_path with
-  | Ok (runtimes, rt, assignments, librarian_id) ->
+  | Ok (runtimes, rt, assignments, librarian_id, cross_verifier_id) ->
     Atomic.set runtimes_ref runtimes;
     Atomic.set default_runtime_ref (Some rt);
     Atomic.set keeper_assignments_ref assignments;
     Atomic.set librarian_runtime_id_ref librarian_id;
+    Atomic.set cross_verifier_runtime_id_ref cross_verifier_id;
     Ok ()
   | Error _ as e -> e
 
@@ -188,6 +229,11 @@ let keeper_assignments () = Atomic.get keeper_assignments_ref
    librarian inherits each keeper's runtime (legacy). Reads the Atomic ref set by
    [init_default]; the env override lives in keeper_librarian_runtime. *)
 let librarian_runtime_id () = Atomic.get librarian_runtime_id_ref
+
+(* [runtime].cross_verifier routing for the anti-rationalization evaluator.
+   [None] = the evaluator inherits [runtime].default. Reads the Atomic ref set by
+   [init_default]. *)
+let cross_verifier_runtime_id () = Atomic.get cross_verifier_runtime_id_ref
 
 (* RFC-0207: resolve a runtime by its binding-key id ["provider.model"].  The
    keeper turn driver dispatches to the *requested* runtime (a keeper's persona

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -20,15 +20,18 @@ val of_binding : config -> binding -> t option
 
 val load_list :
   config_path:string
-  -> (t list * t * (string * string) list * string option, string) result
+  -> ( t list * t * (string * string) list * string option * string option
+     , string )
+     result
 (** [load_list ~config_path] parses runtime.toml into [(runtimes, default,
-    keeper_assignments, librarian_runtime_id)]. Fails ([Error]) if
-    [\[runtime\].default] is missing / unresolved, if any
+    keeper_assignments, librarian_runtime_id, cross_verifier_runtime_id)]. Fails
+    ([Error]) if [\[runtime\].default] is missing / unresolved, if any
     [\[runtime.assignments\]] target does not resolve to a configured runtime, or
-    if [\[runtime\].librarian] is set to an unresolved id (mirrors default
-    validation — no silent fallback for a typo'd id). [keeper_assignments] is the
-    keeper→runtime-id list; [librarian_runtime_id] is the optional memory-os
-    librarian runtime. *)
+    if [\[runtime\].librarian] / [\[runtime\].cross_verifier] is set to an
+    unresolved id (mirrors default validation — no silent fallback for a typo'd
+    id). [keeper_assignments] is the keeper→runtime-id list; the two trailing
+    options are the memory-os librarian and the anti-rationalization evaluator
+    runtimes. *)
 
 val runtime_ids : t list -> string list
 
@@ -57,6 +60,11 @@ val keeper_assignments : unit -> (string * string) list
     every runtime id in the returned snapshot resolves to a configured runtime.
     Dashboard/operator surfaces use this to expose assignment blast radius
     without parsing TOML independently. *)
+
+val cross_verifier_runtime_id : unit -> string option
+(** [\[runtime\].cross_verifier] runtime id for the anti-rationalization
+    evaluator, or [None] when unset (the evaluator uses [\[runtime\].default]).
+    Validated at load so a [Some] always resolves to a configured runtime. *)
 
 val librarian_runtime_id : unit -> string option
 (** [\[runtime\].librarian] runtime id for the memory-os librarian, or [None]

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -192,6 +192,11 @@ type config =
         [None] = the librarian inherits each keeper's runtime (legacy). An
         unknown id is rejected at load like [\[runtime\].default]. The
         [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID] env var overrides this. *)
+  ; cross_verifier_runtime_id : string option
+    (** [\[runtime\].cross_verifier] — runtime id for the anti-rationalization
+        evaluator. Like the librarian it requests JSON mode and must run on a
+        model declaring [supports-response-format-json]; [None] = inherit
+        [\[runtime\].default]. Unknown id rejected at load. *)
   ; keeper_assignments : (string * string) list
     (** [\[runtime.assignments\]] — keeper name → runtime id ["provider.model"].
         runtime.toml is the sole SSOT for keeper→runtime assignment (persona⊥

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -138,6 +138,14 @@ type config =
         inherit each keeper's runtime. Unknown id rejected at load like
         [\[runtime\].default]; [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID]
         overrides. *)
+  ; cross_verifier_runtime_id : string option
+    (** [\[runtime\].cross_verifier] — runtime id for the anti-rationalization
+        evaluator (cross-model task verification). The evaluator requests JSON
+        mode (a structured verdict tool call), so it must run on a model
+        declaring [supports-response-format-json]; otherwise it returns empty
+        output and the gate approves by liveness. [None] = inherit
+        [\[runtime\].default]. Unknown id rejected at load like
+        [\[runtime\].default]. *)
   ; keeper_assignments : (string * string) list
     (** [\[runtime.assignments\]] — keeper name → runtime id ["provider.model"].
         Sole SSOT for keeper→runtime assignment (persona⊥{model,runtime}). A

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -659,6 +659,9 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
   let librarian_runtime_id =
     Otoml.find_opt toml Otoml.get_string [ "runtime"; "librarian" ]
   in
+  let cross_verifier_runtime_id =
+    Otoml.find_opt toml Otoml.get_string [ "runtime"; "cross_verifier" ]
+  in
   if all_errors <> []
   then Error all_errors
   else (
@@ -678,6 +681,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
       ; bindings
       ; default_runtime_id
       ; librarian_runtime_id
+      ; cross_verifier_runtime_id
       ; keeper_assignments
       })
 ;;

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -565,9 +565,18 @@ let parse_verdict (text : string) : (verdict, string) result =
     See: Anthropic "Harness Design" blog analysis. *)
 (* Function, not a module-level value: [Runtime.get_default_runtime_id] fail-fasts
    until [Runtime.init_default] runs at startup (RFC-0206 §2.1). A module-level
-   binding evaluates at load time and crashes boot; defer to call time. *)
+   binding evaluates at load time and crashes boot; defer to call time.
+
+   Prefer [\[runtime\].cross_verifier] when set: the evaluator requests a JSON
+   structured verdict, so it must run on a JSON-capable model independent of the
+   fleet default. When the default runtime cannot emit JSON the evaluator returns
+   empty and the gate approves by liveness (#8688); routing it explicitly keeps
+   the gate live and restores cross-model separation. [None] = inherit the global
+   default (legacy). *)
 let default_evaluator_runtime () =
-  (Atomic.get Workspace_hooks.get_default_runtime_id_fn) ()
+  match (Atomic.get Workspace_hooks.get_cross_verifier_runtime_id_fn) () with
+  | Some id -> id
+  | None -> (Atomic.get Workspace_hooks.get_default_runtime_id_fn) ()
 ;;
 
 (* ================================================================ *)

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -286,6 +286,13 @@ let get_default_runtime_id_fn
   : (unit -> string) Atomic.t
   = Atomic.make (fun () -> failwith "Workspace_hooks: get_default_runtime_id_fn not connected")
 
+(* Optional: [None] means "use the global default runtime". Defaults to a
+   None-returning thunk (not a failwith) so unconnected test contexts fall back
+   to the default instead of crashing. *)
+let get_cross_verifier_runtime_id_fn
+  : (unit -> string option) Atomic.t
+  = Atomic.make (fun () -> None)
+
 let record_task_metric_fn
   : (Workspace_utils_backend_setup.config ->
      agent_id:string ->

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -89,6 +89,13 @@ val active_agents_change_fn : ([ `Inc | `Dec ] -> unit) Atomic.t
 val telemetry_observe_failure_fn : (string -> unit) Atomic.t
 val get_default_runtime_id_fn : (unit -> string) Atomic.t
 
+(** [\[runtime\].cross_verifier] runtime id for the anti-rationalization
+    evaluator, or [None] to use {!get_default_runtime_id_fn}. Wired to
+    [Runtime.cross_verifier_runtime_id] at startup; defaults to [fun () -> None]
+    (use the global default) when not connected, so callers in test contexts
+    fall back rather than crash. *)
+val get_cross_verifier_runtime_id_fn : (unit -> string option) Atomic.t
+
 val record_task_metric_fn :
   (Workspace_utils_backend_setup.config ->
    agent_id:string ->

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -28,7 +28,7 @@ let test_repo_runtime_toml_loads () =
   check bool "repo runtime.toml present" true (Sys.file_exists path);
   match Runtime.load_list ~config_path:path with
   | Error msg -> failf "repo runtime.toml should load: %s" msg
-  | Ok (runtimes, default, assignments, _librarian) ->
+  | Ok (runtimes, default, assignments, _librarian, _cross_verifier) ->
     check bool "at least one runtime" true (List.length runtimes > 0);
     check string "default runtime" "ollama_cloud.deepseek-v4-flash"
       default.Runtime.id;
@@ -316,7 +316,7 @@ let test_runtime_toml_max_concurrent_flows_to_candidate () =
   with_temp_runtime_toml content (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "runtime TOML should materialize: %s" msg
-    | Ok (runtimes, _default, _assignments, _librarian) ->
+    | Ok (runtimes, _default, _assignments, _librarian, _cross_verifier) ->
       let expect id expected =
         match
           List.find_opt (fun (rt : Runtime.t) -> String.equal rt.id id) runtimes
@@ -370,16 +370,31 @@ let test_librarian_runtime_routing () =
   with_temp_runtime_toml (base ^ "librarian = \"local.libr\"\n") (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "librarian routing should load: %s" msg
-    | Ok (_runtimes, _default, _assignments, librarian) ->
+    | Ok (_runtimes, _default, _assignments, librarian, _cross_verifier) ->
       check (option string) "librarian runtime id" (Some "local.libr") librarian);
   with_temp_runtime_toml base (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "absent librarian should load: %s" msg
-    | Ok (_, _, _, librarian) ->
+    | Ok (_, _, _, librarian, _cross_verifier) ->
       check (option string) "librarian unset is None" None librarian);
   with_temp_runtime_toml (base ^ "librarian = \"local.nope\"\n") (fun path ->
     match Runtime.load_list ~config_path:path with
     | Ok _ -> failf "unknown [runtime].librarian id must be rejected at load"
+    | Error _ -> ());
+  with_temp_runtime_toml (base ^ "cross_verifier = \"local.libr\"\n") (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error msg -> failf "cross_verifier routing should load: %s" msg
+    | Ok (_runtimes, _default, _assignments, _librarian, cross_verifier) ->
+      check (option string) "cross_verifier runtime id" (Some "local.libr")
+        cross_verifier);
+  with_temp_runtime_toml base (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error msg -> failf "absent cross_verifier should load: %s" msg
+    | Ok (_, _, _, _, cross_verifier) ->
+      check (option string) "cross_verifier unset is None" None cross_verifier);
+  with_temp_runtime_toml (base ^ "cross_verifier = \"local.nope\"\n") (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Ok _ -> failf "unknown [runtime].cross_verifier id must be rejected at load"
     | Error _ -> ())
 
 let () =
@@ -390,7 +405,8 @@ let () =
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
           test_case
-            "[runtime].librarian resolves, defaults to None, rejects unknown"
+            "[runtime].librarian and .cross_verifier resolve, default None, \
+             reject unknown"
             `Quick test_librarian_runtime_routing;
           test_case
             "lifecycle TOML keys resolve through the declarative catalog"

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -456,6 +456,7 @@ let test_runtime_adapter_keeps_auth_out_of_headers () =
     ; bindings = [ runpod_binding ]
     ; default_runtime_id = Some "runpod_mtp.qwen"
     ; librarian_runtime_id = None
+    ; cross_verifier_runtime_id = None
     ; keeper_assignments = []
     }
   in
@@ -486,6 +487,7 @@ let test_runtime_adapter_filters_toml_auth_headers () =
     ; bindings = [ runpod_binding ]
     ; default_runtime_id = Some "runpod_mtp.qwen"
     ; librarian_runtime_id = None
+    ; cross_verifier_runtime_id = None
     ; keeper_assignments = []
     }
   in
@@ -517,6 +519,7 @@ let provider_cfg () =
     ; bindings = [ runpod_binding ]
     ; default_runtime_id = Some "runpod_mtp.qwen"
     ; librarian_runtime_id = None
+    ; cross_verifier_runtime_id = None
     ; keeper_assignments = []
     }
   in
@@ -593,6 +596,7 @@ let runtime_or_fail ?(provider = runpod_provider) () =
     ; bindings = [ runpod_binding ]
     ; default_runtime_id = Some "runpod_mtp.qwen"
     ; librarian_runtime_id = None
+    ; cross_verifier_runtime_id = None
     ; keeper_assignments = []
     }
   in


### PR DESCRIPTION
## 문제

anti-rationalization 평가 게이트가 JSON을 못 내는 런타임에서 조용히 우회된다.

`Anti_rationalization.default_evaluator_runtime`가 `[runtime].default`(글로벌 기본 런타임)를 그대로 사용한다. 평가기는 구조화된 verdict(JSON tool call)를 요청하므로, 기본 런타임이 `supports-response-format-json`을 선언하지 않는 모델이면 빈 응답을 반환한다. 빈 응답은 의도적으로 "approve by liveness"로 처리된다(#8688 — 평가기 불가용 시 완료 agent를 부당하게 reject하지 않으려는 설계).

결과: 기본 런타임이 비-JSON 모델일 때 게이트가 사실상 무력화된다. 2026-06-19 RunPod 장애로 플릿이 `deepseek-v4-flash`(JSON 미선언)로 대피한 동안, 오늘 anti-rationalization 평가 20건 중 10건(50%)이 빈 응답으로 자동 승인됐다(structured verdict 0건).

librarian이 겪은 것과 같은 클래스의 문제다. librarian도 JSON이 필요해 `[runtime].librarian`(#21521)으로 기본 런타임과 독립 라우팅됐다.

## 변경

`[runtime].cross_verifier` 런타임 노브 추가 (`[runtime].librarian` 패턴 미러링):

- `Runtime_schema.config`에 `cross_verifier_runtime_id` 필드
- `runtime_toml.ml`: `[runtime].cross_verifier` 파싱
- `runtime.ml`: load-time 검증(unknown id는 typo로 reject) + Atomic ref + accessor
- `workspace_hooks` + `mcp_server.ml`: lib/task는 lib/runtime를 직접 의존하지 않으므로 hook 인다이렉션으로 wiring
- `anti_rationalization.ml`: `default_evaluator_runtime`가 cross_verifier를 우선 사용, 미설정 시 글로벌 default 상속

`None`(미설정)이면 기존 동작(글로벌 default 상속) 그대로이므로 회귀 없음. empty→approve 분기는 변경하지 않았다(불가용 평가기를 올바르게 처리하는 #8688 동작). 이 변경은 평가기가 빈 응답을 내는 원인을 제거한다(증상 억제가 아님).

운영: 노브 배포 후 `runtime.toml`에 `cross_verifier = "ollama_cloud.minimax-m3"`를 추가하면 플릿 default와 무관하게 평가기를 JSON-가능 모델에 고정하고 cross-model separation도 복원한다.

## 검증

- `test_runtime_config_validity`: 10/10 통과 (cross_verifier resolve / None-default / reject-unknown 신규 케이스 포함)
- `test_runtime_provider_auth_headers`: 23/23 통과 (config 리터럴에 새 필드 반영)
- `dune build` lib: clean
- 변경 파일 ocamlformat: 통과

## 알려진 무관 실패

`test/test_keeper_effective_meta_overlay.ml` 빌드 실패는 이 PR과 무관하다. 해당 테스트의 `module Runtime = Masc.Keeper_runtime`(lib/runtime의 `Runtime`이 아닌 별개 모듈)이 `Keeper_runtime.init_default`를 참조하는데 그 심볼이 없다. origin/main 선재 결함이며 본 변경이 닿는 `lib/runtime`과 다른 모듈이다.

RFC-WAIVED: lib/runtime / lib/task / lib/workspace 는 credential/identity/operator/sandbox/hooks/workflow 게이트 대상이 아님 (anti-rationalization 평가기 런타임 라우팅).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
