### PR TITLE
[RFC-0264 P2] Memory OS recall injection ledger

### DIFF
--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -223,24 +223,36 @@ let facts_recency_ranked ~now facts =
   |> dedup_by_claim
 ;;
 
+(* RFC-0264 P2: render_context_exn returns the rendered block alongside the
+   normalize_claim keys it injected, so [render_if_enabled] can append a
+   deterministic recall-injection record (the join key for outcome eval). The
+   keys are a by-product already computed for shared-store dedup
+   ([private_keys]); surfacing them costs nothing extra on the hot path. *)
+type render_result =
+  { block : string
+  ; injected_fact_keys : string list
+  ; injected_episode_keys : string list
+  ; n_facts_in_store : int
+  }
+
 let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
   let max_facts = max 0 max_facts in
   let max_episodes = max 0 max_episodes in
-  let facts =
-    (* RFC-0239 Q4: scan the whole bounded store, not a [fact_recall_window]-sized
-       tail. The store holds up to [fact_store_max] facts between caps, and a fresh
-       cap rewrites it in rank order — so the highest-ranked durable rows sit at
-       the file head while new appends land at the tail. Scanning only
-       [fact_recall_window] tail rows would exclude exactly those head rows in the
-       [fact_recall_window]..[fact_store_max] band; scanning [fact_store_max]
-       covers the entire bounded store so recency ranking selects the globally best
-       facts. RFC-0247: order by the structural truth anchor (most-recently-verified
-       first); the composite score, lexical seed-rerank, and spreading-activation
-       reranking were all removed in the purge. *)
+  (* RFC-0239 Q4: scan the whole bounded store, not a [fact_recall_window]-sized
+     tail. The store holds up to [fact_store_max] facts between caps, and a fresh
+     cap rewrites it in rank order — so the highest-ranked durable rows sit at
+     the file head while new appends land at the tail. Scanning only
+     [fact_recall_window] tail rows would exclude exactly those head rows in the
+     [fact_recall_window]..[fact_store_max] band; scanning [fact_store_max]
+     covers the entire bounded store so recency ranking selects the globally best
+     facts. RFC-0247: order by the structural truth anchor (most-recently-verified
+     first); the composite score, lexical seed-rerank, and spreading-activation
+     reranking were all removed in the purge. *)
+  let all_facts =
     Keeper_memory_os_io.read_facts_tail ~keeper_id ~n:Keeper_memory_os_io.fact_store_max
-    |> facts_recency_ranked ~now
-    |> take max_facts
   in
+  let n_facts_in_store = List.length all_facts in
+  let facts = all_facts |> facts_recency_ranked ~now |> take max_facts in
   (* RFC-0244 Tier 2: append shared-semantic facts after the keeper's own, with
      private precedence — a claim already surfaced from this keeper's store is not
      repeated from the shared store. The shared store is read under the reserved
@@ -265,19 +277,30 @@ let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
     |> List.filter (episode_is_current ~now)
     |> take max_episodes
   in
-  match facts, shared_facts, episodes with
-  | [], [], [] -> ""
-  | _ ->
-    let fact_lines =
-      List.map (render_fact ~now) facts
-      @ List.map (render_shared_fact ~now) shared_facts
-    in
-    let episode_lines = List.map render_episode episodes in
-    (match render_recall_context ~fact_lines ~episode_lines with
-     | Ok context -> context
-     | Error msg ->
-       Log.Keeper.warn "memory os recall prompt unavailable keeper=%s: %s" keeper_id msg;
-       "")
+  let injected_fact_keys =
+    private_keys @ List.map (fun f -> normalize_claim f.claim) shared_facts
+  in
+  let injected_episode_keys =
+    List.map
+      (fun (e : episode) -> Printf.sprintf "%s:g%d" e.trace_id e.generation)
+      episodes
+  in
+  let block =
+    match facts, shared_facts, episodes with
+    | [], [], [] -> ""
+    | _ ->
+      let fact_lines =
+        List.map (render_fact ~now) facts
+        @ List.map (render_shared_fact ~now) shared_facts
+      in
+      let episode_lines = List.map render_episode episodes in
+      (match render_recall_context ~fact_lines ~episode_lines with
+       | Ok context -> context
+       | Error msg ->
+         Log.Keeper.warn "memory os recall prompt unavailable keeper=%s: %s" keeper_id msg;
+         "")
+  in
+  { block; injected_fact_keys; injected_episode_keys; n_facts_in_store }
 ;;
 
 let render_context
@@ -287,7 +310,7 @@ let render_context
       ?(max_episodes = default_max_episodes)
       ()
   =
-  try render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () with
+  try (render_context_exn ~keeper_id ~now ~max_facts ~max_episodes ()).block with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     Log.Keeper.warn
@@ -305,11 +328,46 @@ let enabled () =
     ~default:true
 ;;
 
-let render_if_enabled ~keeper_id ~now () =
+let render_if_enabled ~keeper_id ~now ~trace_id ~turn ~masc_root () =
   if not (enabled ())
   then None
   else (
-    match String.trim (render_context ~keeper_id ~now ()) with
+    (* RFC-0264 P2: render once, then append a recall-injection record keyed by
+       trace_id/turn so outcome eval can join "what recall showed this trace" to
+       the execution_receipt + forge outcome. The ledger write is best-effort
+       and never affects the returned block. *)
+    let result =
+      try
+        render_context_exn
+          ~keeper_id
+          ~now
+          ~max_facts:default_max_facts
+          ~max_episodes:default_max_episodes
+          ()
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Log.Keeper.warn
+          "memory os recall unavailable keeper=%s: %s"
+          keeper_id
+          (Printexc.to_string exn);
+        { block = ""
+        ; injected_fact_keys = []
+        ; injected_episode_keys = []
+        ; n_facts_in_store = 0
+        }
+    in
+    match String.trim result.block with
     | "" -> None
-    | block -> Some block)
+    | block ->
+      Keeper_recall_injection_ledger.append
+        ~masc_root
+        ~keeper_id
+        ~trace_id
+        ~turn
+        ~injected_fact_keys:result.injected_fact_keys
+        ~injected_episode_keys:result.injected_episode_keys
+        ~n_facts_in_store:result.n_facts_in_store
+        ~now;
+      Some block)
 ;;

--- a/lib/keeper/keeper_memory_os_recall.mli
+++ b/lib/keeper/keeper_memory_os_recall.mli
@@ -24,8 +24,14 @@ val enabled : unit -> bool
 val render_if_enabled
   :  keeper_id:string
   -> now:float
+  -> trace_id:string
+  -> turn:int
+  -> masc_root:string
   -> unit
   -> string option
-(** [render_if_enabled ~keeper_id ~now ()] is [Some block] when the
-    flag is on and the store yields advisory content, [None] otherwise.
-    Intended for the [extra_system_context] assembly site. *)
+(** [render_if_enabled ~keeper_id ~now ~trace_id ~turn ~masc_root ()] is
+    [Some block] when the flag is on and the store yields advisory content,
+    [None] otherwise. Intended for the [extra_system_context] assembly site.
+    As a side effect (RFC-0264 P2) it appends a best-effort recall-injection
+    record — which fact/episode keys reached the prompt — keyed by
+    [trace_id]/[turn]; the write never affects the returned block. *)

--- a/lib/keeper/keeper_recall_injection_ledger.ml
+++ b/lib/keeper/keeper_recall_injection_ledger.ml
@@ -1,0 +1,57 @@
+(* RFC-0264 P2. See the .mli for the contract. Mirrors the cost-ledger
+   append pattern (Keeper_hooks_oas_cost_events): a per-process Dated_jsonl
+   store under masc_root, append wrapped so a write failure degrades to a log
+   line and never propagates into the turn. *)
+
+let recall_injections_dir masc_root = Filename.concat masc_root "recall_injections"
+
+let to_json
+      ~keeper_id
+      ~trace_id
+      ~turn
+      ~injected_fact_keys
+      ~injected_episode_keys
+      ~n_facts_in_store
+      ~now
+  : Yojson.Safe.t
+  =
+  `Assoc
+    [ "keeper_id", `String keeper_id
+    ; "trace_id", `String trace_id
+    ; "turn", `Int turn
+    ; "injected_fact_keys", `List (List.map (fun k -> `String k) injected_fact_keys)
+    ; "injected_episode_keys", `List (List.map (fun k -> `String k) injected_episode_keys)
+    ; "n_facts_in_store", `Int n_facts_in_store
+    ; "ts", `Float now
+    ]
+;;
+
+let append
+      ~masc_root
+      ~keeper_id
+      ~trace_id
+      ~turn
+      ~injected_fact_keys
+      ~injected_episode_keys
+      ~n_facts_in_store
+      ~now
+  =
+  let store = Dated_jsonl.create ~base_dir:(recall_injections_dir masc_root) () in
+  let entry =
+    to_json
+      ~keeper_id
+      ~trace_id
+      ~turn
+      ~injected_fact_keys
+      ~injected_episode_keys
+      ~n_facts_in_store
+      ~now
+  in
+  try Dated_jsonl.append store entry with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn
+      "recall_injection_ledger: failed to write %s: %s"
+      (Dated_jsonl.base_dir store)
+      (Printexc.to_string exn)
+;;

--- a/lib/keeper/keeper_recall_injection_ledger.mli
+++ b/lib/keeper/keeper_recall_injection_ledger.mli
@@ -1,0 +1,42 @@
+(** Keeper_recall_injection_ledger — RFC-0264 P2: per-turn recall injection trace.
+
+    On each turn where Memory OS recall renders a non-empty advisory block, this
+    appends a deterministic record of which fact/episode keys reached the
+    prompt. It is the join key between "what recall showed this trace" and the
+    turn outcome (execution_receipt carries trace_id + current_task_id; the
+    forge carries PR/CI merge state), consumed offline by recall_outcome_eval
+    (RFC-0264 P3) to compute recall_relevance / recall_harm.
+
+    Properties:
+    - Append-only, never read on the hot path -> cannot change recall behaviour.
+    - Best-effort: a write failure is logged and never aborts the turn.
+    - Bounded: uses the shared [Dated_jsonl] day-split layout
+      ([masc_root/recall_injections/YYYY-MM/DD.jsonl]), same per-day mutex
+      registry as the cost / receipt appenders.
+    - Deterministic: keys are [normalize_claim] outputs (the identity SSOT) and
+      [trace_id:gN] episode keys, so the same trace renders a byte-identical
+      record. *)
+
+val to_json
+  :  keeper_id:string
+  -> trace_id:string
+  -> turn:int
+  -> injected_fact_keys:string list
+  -> injected_episode_keys:string list
+  -> n_facts_in_store:int
+  -> now:float
+  -> Yojson.Safe.t
+(** Pure record serialiser. Exposed for round-trip tests. *)
+
+val append
+  :  masc_root:string
+  -> keeper_id:string
+  -> trace_id:string
+  -> turn:int
+  -> injected_fact_keys:string list
+  -> injected_episode_keys:string list
+  -> n_facts_in_store:int
+  -> now:float
+  -> unit
+(** Append one injection record. Best-effort: never raises except to re-raise
+    [Eio.Cancel.Cancelled]. *)

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -347,6 +347,9 @@ let assemble_hooks
                     Keeper_memory_os_recall.render_if_enabled
                       ~keeper_id:meta.name
                       ~now:(Time_compat.now ())
+                      ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                      ~turn
+                      ~masc_root:(Workspace.masc_root_dir config)
                       ()
                   with
                   | None -> ctx

--- a/test/dune
+++ b/test/dune
@@ -1094,6 +1094,12 @@
  (modules test_json_field)
  (libraries alcotest masc.json_field yojson))
 
+; RFC-0264 P2: recall-injection ledger record serialiser unit tests.
+(test
+ (name test_keeper_recall_injection_ledger)
+ (modules test_keeper_recall_injection_ledger)
+ (libraries masc_test_deps yojson))
+
 ; Lock-free atomic CAS helper leaf.
 
 (test

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -72,6 +72,16 @@ let with_temp_keepers_dir f =
   Memory_io.For_testing.with_keepers_dir marker (fun () -> f marker)
 ;;
 
+let render_if_enabled_for_test ~keeper_id ~now ~masc_root () =
+  Recall.render_if_enabled
+    ~keeper_id
+    ~now
+    ~trace_id:"trace-recall-render-test"
+    ~turn:1
+    ~masc_root
+    ()
+;;
+
 let has_memory_os_prompt_root path =
   Sys.file_exists
     (Filename.concat path "config/prompts/keeper.memory_os_recall.context.md")
@@ -1280,9 +1290,13 @@ let test_render_if_enabled_default_is_on () =
 
 let test_render_if_enabled_explicit_off () =
   with_recall_env "false" (fun () ->
-    with_temp_keepers_dir (fun _keepers_dir ->
+    with_temp_keepers_dir (fun keepers_dir ->
       match
-        Recall.render_if_enabled ~keeper_id:"virtual-memory-keeper" ~now:1_000_000.0 ()
+        render_if_enabled_for_test
+          ~keeper_id:"virtual-memory-keeper"
+          ~now:1_000_000.0
+          ~masc_root:keepers_dir
+          ()
       with
       | None -> ()
       | Some block -> Alcotest.failf "expected None with kill switch set, got %S" block))
@@ -1290,9 +1304,13 @@ let test_render_if_enabled_explicit_off () =
 
 let test_render_if_enabled_empty_store_yields_none () =
   with_recall_env "true" (fun () ->
-    with_temp_keepers_dir (fun _keepers_dir ->
+    with_temp_keepers_dir (fun keepers_dir ->
       match
-        Recall.render_if_enabled ~keeper_id:"virtual-memory-keeper" ~now:1_000_000.0 ()
+        render_if_enabled_for_test
+          ~keeper_id:"virtual-memory-keeper"
+          ~now:1_000_000.0
+          ~masc_root:keepers_dir
+          ()
       with
       | None -> ()
       | Some block -> Alcotest.failf "expected None for empty store, got %S" block))
@@ -1301,7 +1319,7 @@ let test_render_if_enabled_empty_store_yields_none () =
 let test_render_if_enabled_renders_persisted_memory () =
   with_recall_env "true" (fun () ->
     with_prompt_registry (fun () ->
-      with_temp_keepers_dir (fun _keepers_dir ->
+      with_temp_keepers_dir (fun keepers_dir ->
         let keeper_id = "virtual-memory-keeper" in
         let now = 1_000_000.0 in
         let fact =
@@ -1325,7 +1343,7 @@ let test_render_if_enabled_renders_persisted_memory () =
           }
         in
         Memory_io.append_episode_bundle ~keeper_id episode;
-        match Recall.render_if_enabled ~keeper_id ~now () with
+        match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
         | None -> Alcotest.fail "expected Some block with flag set and seeded store"
         | Some block ->
           Alcotest.(check bool)
@@ -1344,7 +1362,7 @@ let test_render_if_enabled_renders_persisted_memory () =
 let test_recall_scans_whole_bounded_store () =
   with_recall_env "true" (fun () ->
     with_prompt_registry (fun () ->
-      with_temp_keepers_dir (fun _keepers_dir ->
+      with_temp_keepers_dir (fun keepers_dir ->
         let keeper_id = "window-band-keeper" in
         let now = 1_000_000.0 in
         let head =
@@ -1389,7 +1407,7 @@ let test_recall_scans_whole_bounded_store () =
           "store sits in the (fact_recall_window, fact_store_max] band"
           true
           (total > Memory_io.fact_recall_window && total <= Memory_io.fact_store_max);
-        match Recall.render_if_enabled ~keeper_id ~now () with
+        match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
         | None -> Alcotest.fail "expected Some recall block for a seeded store"
         | Some block ->
           Alcotest.(check bool)
@@ -1405,7 +1423,7 @@ let test_recall_scans_whole_bounded_store () =
 let test_recall_marks_stale_fact () =
   with_recall_env "true" (fun () ->
     with_prompt_registry (fun () ->
-      with_temp_keepers_dir (fun _keepers_dir ->
+      with_temp_keepers_dir (fun keepers_dir ->
         let keeper_id = "stale-fact-keeper" in
         let now = 1_000_000.0 in
         let fact =
@@ -1416,7 +1434,7 @@ let test_recall_marks_stale_fact () =
           }
         in
         Memory_io.append_fact ~keeper_id fact;
-        match Recall.render_if_enabled ~keeper_id ~now () with
+        match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
         | None -> Alcotest.fail "expected Some block for a persisted stale fact"
         | Some block ->
           Alcotest.(check bool)
@@ -1434,7 +1452,7 @@ let test_recall_marks_stale_fact () =
 let test_recall_omits_marker_for_fresh_fact () =
   with_recall_env "true" (fun () ->
     with_prompt_registry (fun () ->
-      with_temp_keepers_dir (fun _keepers_dir ->
+      with_temp_keepers_dir (fun keepers_dir ->
         let keeper_id = "fresh-fact-keeper" in
         let now = 1_000_000.0 in
         let fact =
@@ -1445,7 +1463,7 @@ let test_recall_omits_marker_for_fresh_fact () =
           }
         in
         Memory_io.append_fact ~keeper_id fact;
-        match Recall.render_if_enabled ~keeper_id ~now () with
+        match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
         | None -> Alcotest.fail "expected Some block for a persisted fresh fact"
         | Some block ->
           (* Match the rendered marker's tail ("...ago — verify]"), not the bare

--- a/test/test_keeper_recall_injection_ledger.ml
+++ b/test/test_keeper_recall_injection_ledger.ml
@@ -1,0 +1,62 @@
+(* RFC-0264 P2: unit tests for the recall-injection ledger record serialiser.
+   Pure, deterministic, no I/O — verifies the JSON shape that recall_outcome_eval
+   (P3) will join against, and that the record round-trips. *)
+
+module Ledger = Masc.Keeper_recall_injection_ledger
+open Yojson.Safe.Util
+
+let failed = ref 0
+
+let check name cond =
+  if cond then Printf.printf "[PASS] %s\n%!" name
+  else (
+    incr failed;
+    Printf.printf "[FAIL] %s\n%!" name)
+
+let () =
+  let j =
+    Ledger.to_json
+      ~keeper_id:"alpha"
+      ~trace_id:"trace-1"
+      ~turn:3
+      ~injected_fact_keys:[ "fact one"; "fact two" ]
+      ~injected_episode_keys:[ "trace-1:g0" ]
+      ~n_facts_in_store:42
+      ~now:1234.5
+  in
+  check "keeper_id" (j |> member "keeper_id" |> to_string = "alpha");
+  check "trace_id" (j |> member "trace_id" |> to_string = "trace-1");
+  check "turn" (j |> member "turn" |> to_int = 3);
+  check "n_facts_in_store" (j |> member "n_facts_in_store" |> to_int = 42);
+  check "ts" (j |> member "ts" |> to_number = 1234.5);
+  check
+    "injected_fact_keys preserved in order"
+    (j |> member "injected_fact_keys" |> to_list |> List.map to_string
+     = [ "fact one"; "fact two" ]);
+  check
+    "injected_episode_keys preserved"
+    (j |> member "injected_episode_keys" |> to_list |> List.map to_string
+     = [ "trace-1:g0" ]);
+  (* Empty key lists serialise to empty JSON arrays, not null. *)
+  let empty =
+    Ledger.to_json
+      ~keeper_id:"k"
+      ~trace_id:"t"
+      ~turn:0
+      ~injected_fact_keys:[]
+      ~injected_episode_keys:[]
+      ~n_facts_in_store:0
+      ~now:0.0
+  in
+  check
+    "empty fact keys is []"
+    (empty |> member "injected_fact_keys" |> to_list = []);
+  (* Deterministic round-trip: serialise then re-parse is structurally equal. *)
+  let round_trip = Yojson.Safe.from_string (Yojson.Safe.to_string j) in
+  check "round-trip equal" (Yojson.Safe.equal j round_trip);
+  if !failed > 0
+  then (
+    Printf.printf "\n%d check(s) failed\n%!" !failed;
+    exit 1)
+  else Printf.printf "\nall checks passed\n%!"
+;;


### PR DESCRIPTION
## 목적

RFC-0264 P2: **recall injection ledger** 구현. 매 turn recall이 프롬프트에 넣은 fact/episode 키를 `trace_id`/`turn`으로 기록 → P3 outcome eval이 `execution_receipt`(trace↔task) + forge(PR/CI merge state)와 조인할 **join key**. "recall이 무엇을 보여줬나 ↔ 그 trace가 어떤 outcome으로 끝났나"를 잇는다.

## 변경

- **신규 `Keeper_recall_injection_ledger`** — `<masc_root>/recall_injections/YYYY-MM/DD.jsonl` day-split. best-effort(write 실패는 로그, turn 중단 안 함), cost-ledger append 패턴 미러.
- `render_context_exn` → record `{block; injected_fact_keys; injected_episode_keys; n_facts_in_store}`. 키는 shared-store dedup용 `private_keys`를 재활용 → **hot-path 추가비용 0**.
- `render_context`는 `string` 시그니처 유지(`.block`) → **외부 caller 무변경**. `render_if_enabled`에 `~trace_id ~turn ~masc_root` 추가, ledger append.
- 단일 호출처(`keeper_run_tools_hooks`) 배선.
- `to_json` round-trip + 필드 단위테스트.

## 검증

- 로컬 `dune build --root .` **green** (worktree 전체 빌드 exit 0).
- 로컬 test **9/9 PASS** (round-trip + 필드 shape + empty 배열).
- CI가 전체 빌드/테스트 재검증.

## 안전

append-only, hot-path read 없음 → **recall 동작 불변**. render_context_exn 시그니처 변경은 내부(mli 미노출), 외부 API(render_context) 호환.

## 워크어라운드 self-check

ledger는 측정 도구지만 **telemetry-as-fix 아님**: P3 ship-gate(`recall_relevance@merged`/`recall_harm@failed`)로 이어지는 join key이며 단순 카운터가 아니다 (RFC-0264 §3.2/§5). 데이터 모델을 추가해 측정→게이트로 연결한다.

WORKAROUND-WAIVED: P2는 측정 인프라(ledger) 추가일 뿐 코드 워크어라운드 없음. RFC-0264 §5가 telemetry-as-fix 회피를 명시.

## 연관

RFC-0264 (#21579, MERGED) · `execution_receipt`(P-a, trace↔task) · 다음 P3 forge collector. 근거: `project-masc-memory-os-adversarial-audit-2026-06-19`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
