### PR TITLE
[codex] tool orchestration read batch planning

### DIFF
--- a/lib/tool/tool_catalog_inference.ml
+++ b/lib/tool/tool_catalog_inference.ml
@@ -22,6 +22,7 @@ let effect_domain_to_string = function
 
 let inferred_effect_domain name =
   match name with
-  | "tool_read_file" -> Some Read_only
+  | "tool_read_file"
+  | "tool_search_files" -> Some Read_only
   | _ -> None
 ;;

--- a/lib/tool/tool_catalog_inference.mli
+++ b/lib/tool/tool_catalog_inference.mli
@@ -13,4 +13,6 @@ type effect_domain =
 val effect_domain_to_string : effect_domain -> string
 
 val inferred_effect_domain : string -> effect_domain option
-(** Always [None]. Effect metadata is descriptor/catalog-owned. *)
+(** Compatibility effect metadata for legacy internal tool names whose
+    descriptor-owned policy is not always visible at lower Tool/OAS bridge
+    layers. Prefer explicit descriptor/catalog metadata for new tools. *)

--- a/lib/tool_orchestration/tool_batch.ml
+++ b/lib/tool_orchestration/tool_batch.ml
@@ -1,0 +1,61 @@
+type execution_kind =
+  | Parallel_read
+  | Sequential_workspace
+  | Blocked
+
+type t = {
+  batch_id : string;
+  execution_kind : execution_kind;
+  jobs : Tool_job.t list;
+}
+
+let execution_kind_to_string = function
+  | Parallel_read -> "parallel_read"
+  | Sequential_workspace -> "sequential_workspace"
+  | Blocked -> "blocked"
+
+let is_parallel_read_candidate (job : Tool_job.t) =
+  match job.approval with
+  | Tool_job.Approved -> job.read_only && job.resource_keys = []
+  | Tool_job.Pending _
+  | Tool_job.Denied _ -> false
+
+let is_blocked (job : Tool_job.t) =
+  match job.approval with
+  | Tool_job.Pending _
+  | Tool_job.Denied _ -> true
+  | Tool_job.Approved -> false
+
+let make_batch execution_kind jobs =
+  match jobs with
+  | first :: _ -> { batch_id = first.Tool_job.batch_id; execution_kind; jobs }
+  | [] -> invalid_arg "Tool_batch.make_batch: empty jobs"
+
+let flush_parallel current acc =
+  match current with
+  | None -> acc
+  | Some (_batch_id, jobs_rev) ->
+    make_batch Parallel_read (List.rev jobs_rev) :: acc
+
+let plan jobs =
+  let rec loop current_parallel acc = function
+    | [] -> List.rev (flush_parallel current_parallel acc)
+    | job :: rest ->
+      if is_blocked job then
+        let acc = flush_parallel current_parallel acc in
+        loop None (make_batch Blocked [ job ] :: acc) rest
+      else if is_parallel_read_candidate job then
+        (match current_parallel with
+         | Some (batch_id, jobs_rev) ->
+           if String.equal batch_id job.batch_id
+           then loop (Some (batch_id, job :: jobs_rev)) acc rest
+           else
+             let acc = flush_parallel current_parallel acc in
+             loop (Some (job.batch_id, [ job ])) acc rest
+         | None -> loop (Some (job.batch_id, [ job ])) acc rest)
+      else
+        let acc = flush_parallel current_parallel acc in
+        loop None (make_batch Sequential_workspace [ job ] :: acc) rest
+  in
+  loop None [] jobs
+;;

--- a/lib/tool_orchestration/tool_batch.mli
+++ b/lib/tool_orchestration/tool_batch.mli
@@ -1,0 +1,29 @@
+(** Batch planning for ToolJob execution.
+
+    This module owns the scheduling contract only. It does not execute tools,
+    call providers, or know about Keeper runtime policy. Callers can use
+    {!plan} to split a turn's jobs into contiguous parallel-read batches,
+    sequential workspace jobs, and policy-blocked jobs before choosing an
+    executor such as OAS [Async_agent.all]. *)
+
+type execution_kind =
+  | Parallel_read
+  | Sequential_workspace
+  | Blocked
+
+type t = {
+  batch_id : string;
+  execution_kind : execution_kind;
+  jobs : Tool_job.t list;
+}
+
+val execution_kind_to_string : execution_kind -> string
+
+val plan : Tool_job.t list -> t list
+(** Plan jobs in input order.
+
+    Approved read-only jobs with no resource keys are grouped into contiguous
+    [Parallel_read] batches when they share the same [batch_id]. Approved jobs
+    that are mutating or require resource locks become singleton
+    [Sequential_workspace] batches. Pending or denied jobs become singleton
+    [Blocked] batches so policy evidence stays attached to the original job. *)

--- a/lib/tool_orchestration/tool_job.ml
+++ b/lib/tool_orchestration/tool_job.ml
@@ -48,7 +48,12 @@ let schema_hash_of_yojson schema =
 let read_only_of_tool_name name =
   (* DET-OK: sound-partial allow — unknown tools default to writer semantics, which
      makes the scheduler use the conservative [write:any] resource key below. *)
-  (Tool_catalog.metadata name).readonly |> Option.value ~default:false
+  let metadata = Tool_catalog.metadata name in
+  match metadata.readonly, metadata.effect_domain with
+  | Some true, _
+  | _, Some Tool_catalog.Read_only -> true
+  | Some false, _
+  | None, _ -> false
 
 let default_resource_keys_of_tool ~read_only ~tool_name:_ ~input_json:_ =
   if read_only then [] else [ "write:any" ]

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -1154,6 +1154,10 @@ let test_read_oas_descriptor_is_parallel_read () =
   check_descriptor ~msg:"tool_read_file" "tool_read_file" "parallel_read" "read_only"
 ;;
 
+let test_grep_oas_descriptor_is_parallel_read () =
+  check_descriptor ~msg:"tool_search_files" "tool_search_files" "parallel_read" "read_only"
+;;
+
 let find_tool_by_name tools name =
   List.find_opt
     (fun (t : Agent_sdk.Tool.t) -> String.equal t.Agent_sdk.Tool.schema.Agent_sdk.Types.name name)
@@ -1189,10 +1193,7 @@ let test_public_alias_oas_descriptors () =
        in
        check_bundle_concurrency ~msg:"WebSearch" tools "WebSearch" "exclusive_external";
        check_bundle_concurrency ~msg:"WebFetch" tools "WebFetch" "exclusive_external";
-       (* Read is a direct internal tool and is correctly classified as
-          [Parallel_read] by [Tool_bridge.oas_descriptor_of_masc_tool].
-          Grep is currently not marked read-only in [Tool_catalog], so it
-          carries no descriptor and defaults to sequential execution. *)
+       check_bundle_concurrency ~msg:"Grep" tools "Grep" "parallel_read";
        check_bundle_concurrency ~msg:"Read" tools "Read" "parallel_read")
 ;;
 
@@ -1378,6 +1379,8 @@ let () =
         test_web_fetch_oas_descriptor_is_exclusive_external;
       test_case "tool_read_file is Parallel_read" `Quick
         test_read_oas_descriptor_is_parallel_read;
+      test_case "tool_search_files is Parallel_read" `Quick
+        test_grep_oas_descriptor_is_parallel_read;
       test_case "public aliases carry correct concurrency class" `Quick
         test_public_alias_oas_descriptors;
       test_case "parallel read tools reorder results" `Quick

--- a/test/test_tool_capability_typed.ml
+++ b/test/test_tool_capability_typed.ml
@@ -69,6 +69,10 @@ let test_has_catalog_inferred_capabilities () =
     true
     (Tool_capability.has Read_only "tool_read_file");
   (check bool)
+    "tool_search_files grants Read_only"
+    true
+    (Tool_capability.has Read_only "tool_search_files");
+  (check bool)
     "static inline metadata grants Mcp_context_required"
     true
     (Tool_capability.has Mcp_context_required "masc_messages");

--- a/test/test_tool_job.ml
+++ b/test/test_tool_job.ml
@@ -31,7 +31,16 @@ let test_make_reads_tool_metadata () =
   Alcotest.(check bool) "masc_status is read-only" true job.read_only;
   Alcotest.(check (list string)) "read-only default has no writer lock" [] job.resource_keys;
   Alcotest.(check string) "batch_id carried" "batch_1" job.batch_id;
-  Alcotest.(check bool) "schema hash is non-empty" true (String.length job.schema_hash > 0)
+  Alcotest.(check bool) "schema hash is non-empty" true (String.length job.schema_hash > 0);
+  let grep_job =
+    make
+      ~batch_id:"batch_1"
+      ~tool_name:"tool_search_files"
+      ~input_json:(`Assoc [ "pattern", `String "Tool_batch"; "path", `String "lib" ])
+      ()
+  in
+  Alcotest.(check bool) "tool_search_files is read-only" true grep_job.read_only;
+  Alcotest.(check (list string)) "Grep has no writer lock by default" [] grep_job.resource_keys
 ;;
 
 let test_policy_verdict_roundtrip () =
@@ -111,6 +120,94 @@ let test_resource_key_inference () =
     ~expected:[ "write:any" ]
 ;;
 
+let job_ids jobs = List.map (fun (job : Tool_job.t) -> job.job_id) jobs
+
+let synthetic_job ?(batch_id = "batch_1") ?(read_only = true)
+      ?(resource_keys = []) ?(approval = Approved) job_id =
+  { (make ~job_id ~batch_id ~tool_name:"__synthetic_tool__" ~input_json:(`Assoc []) ())
+    with read_only = read_only
+       ; resource_keys = resource_keys
+       ; approval = approval
+  }
+;;
+
+let check_batch_kinds msg expected batches =
+  let actual =
+    List.map
+      (fun (batch : Tool_batch.t) ->
+         Tool_batch.execution_kind_to_string batch.execution_kind)
+      batches
+  in
+  Alcotest.(check (list string)) msg expected actual
+;;
+
+let test_tool_batch_groups_parallel_reads () =
+  let batches =
+    Tool_batch.plan
+      [ synthetic_job "read_1"; synthetic_job "read_2"; synthetic_job "read_3" ]
+  in
+  check_batch_kinds "one parallel batch" [ "parallel_read" ] batches;
+  match batches with
+  | [ batch ] ->
+    Alcotest.(check (list string))
+      "job order preserved"
+      [ "read_1"; "read_2"; "read_3" ]
+      (job_ids batch.jobs)
+  | _ -> Alcotest.fail "expected one batch"
+;;
+
+let test_tool_batch_serializes_writes_and_resumes_reads () =
+  let batches =
+    Tool_batch.plan
+      [ synthetic_job "read_1"
+      ; synthetic_job ~read_only:false ~resource_keys:[ "write:any" ] "write_1"
+      ; synthetic_job "read_2"
+      ]
+  in
+  check_batch_kinds
+    "write flushes parallel batch"
+    [ "parallel_read"; "sequential_workspace"; "parallel_read" ]
+    batches
+;;
+
+let test_tool_batch_blocks_policy_verdicts () =
+  let batches =
+    Tool_batch.plan
+      [ synthetic_job "read_1"
+      ; synthetic_job ~approval:(Pending "operator") "pending_1"
+      ; synthetic_job "read_2"
+      ; synthetic_job ~approval:(Denied "policy") "denied_1"
+      ]
+  in
+  check_batch_kinds
+    "blocked jobs are singleton boundaries"
+    [ "parallel_read"; "blocked"; "parallel_read"; "blocked" ]
+    batches;
+  match batches with
+  | _ :: pending :: _ :: denied :: [] ->
+    Alcotest.(check (list string)) "pending singleton" [ "pending_1" ] (job_ids pending.jobs);
+    Alcotest.(check (list string)) "denied singleton" [ "denied_1" ] (job_ids denied.jobs)
+  | _ -> Alcotest.fail "expected four batches"
+;;
+
+let test_tool_batch_does_not_cross_batch_id_boundary () =
+  let batches =
+    Tool_batch.plan
+      [ synthetic_job ~batch_id:"batch_1" "read_1"
+      ; synthetic_job ~batch_id:"batch_2" "read_2"
+      ]
+  in
+  check_batch_kinds
+    "batch ids stay isolated"
+    [ "parallel_read"; "parallel_read" ]
+    batches;
+  match batches with
+  | [ first; second ] ->
+    Alcotest.(check string) "first batch id" "batch_1" first.batch_id;
+    Alcotest.(check string) "second batch id" "batch_2" second.batch_id
+  | _ -> Alcotest.fail "expected two batches"
+;;
+
 let test_event_roundtrip () =
   let events =
     [ Batch_created { batch_id = "batch_1"; parent_turn_id = Some "turn_1"; parent_goal_id = None }
@@ -177,6 +274,21 @@ let () =
         ] )
     ; ( "resource_keys"
       , [ Alcotest.test_case "inference for known patterns" `Quick test_resource_key_inference ] )
+    ; ( "batch_plan"
+      , [ Alcotest.test_case "groups parallel reads" `Quick test_tool_batch_groups_parallel_reads
+        ; Alcotest.test_case
+            "serializes writes and resumes reads"
+            `Quick
+            test_tool_batch_serializes_writes_and_resumes_reads
+        ; Alcotest.test_case
+            "blocks policy verdicts"
+            `Quick
+            test_tool_batch_blocks_policy_verdicts
+        ; Alcotest.test_case
+            "does not cross batch_id boundary"
+            `Quick
+            test_tool_batch_does_not_cross_batch_id_boundary
+        ] )
     ; ( "event_helpers"
       , [ Alcotest.test_case "batch id helper is explicit" `Quick test_event_batch_id_exhaustive_helpers ]
       )


### PR DESCRIPTION
## Summary

- Project `tool_search_files` as a read-only effect for lower Tool/OAS bridge layers.
- Make `Tool_job` derive read-only semantics from `effect_domain=Read_only`, not only the explicit `readonly` flag.
- Add a small `Tool_batch.plan` contract that groups approved read-only/no-lock jobs into `Parallel_read`, keeps mutating jobs `Sequential_workspace`, and preserves pending/denied jobs as blocked singleton batches.
- Add focused regression coverage for `Grep`/`tool_search_files` OAS descriptors, Tool capability inference, ToolJob resource locks, and batch planning boundaries.

## Why

Keeper descriptors already declare `Grep` / `tool_search_files` as read-only, but lower catalog-driven paths could still miss that policy. That made the OAS tool descriptor and ToolJob defaults more conservative than the actual Keeper descriptor contract, causing read-only search to fall back toward sequential/write-like scheduling.

## Impact

This keeps OAS/model-provider boundaries intact: MASC only projects its tool policy and batch planning contract. Execution remains owned by existing OAS tool execution / async primitives and future Keeper/System Agent consumers can use the typed planner without adding provider-specific logic to OAS.

## Validation

- `git diff --check` passed.
- Local focused build was intentionally not completed; operator requested CI to run the build. Suggested CI/focused targets: `test/test_tool_job.exe`, `test/test_tool_capability_typed.exe`, `test/test_keeper_tool_dispatch_runtime.exe`.