### PR TITLE
feat(runtime): startup capability gate + consume OAS thinking-control guard (pin bump)

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -120,27 +120,21 @@ let validate_cross_verifier_runtime ~(config_path : string) (runtimes : t list)
    (Unknown->Permissive anti-pattern; mirrors [runtime].default validation,
    RFC-0206 §2.1 no-silent-fallback).
 
-   Catalog-presence guard: if EVERY model is unknown, the OAS catalog is almost
-   certainly not loaded in this environment (e.g. CI / a process without
-   ~/.config/oas/models.toml). Aborting the whole process over a missing catalog
-   would be worse than the gap, and the per-request OAS guard
-   ([Complete_common.validate_thinking_control_request]) still fails loud on the
-   actual unsatisfiable call. So abort only on a PARTIAL miss (some models resolved,
-   others did not) — the signature of a real catalog gap rather than an absent
-   catalog. *)
+   An empty runtime list is allowed for focused unit tests/config probes, but any
+   configured runtime whose model is absent from the catalog is rejected before it
+   can inherit guessed provider_default capabilities. *)
 let decide_capability_gate ~(config_path : string) (entries : (string * bool) list)
   : (unit, string) result
   =
   let unknown = List.filter (fun (_, known) -> not known) entries in
   match unknown with
   | [] -> Ok ()
-  | _ when List.for_all (fun (_, known) -> not known) entries -> Ok ()
   | _ ->
     Error
       (Printf.sprintf
-         "%s: %d runtime model(s) absent from the OAS capability catalog while \
-          others resolved — they would use provider_default and silently drop \
-          thinking/sampling control. Add them to models.toml (OAS catalog): %s"
+         "%s: %d runtime model(s) absent from the OAS capability catalog; they \
+          would use provider_default and silently drop thinking/sampling control. \
+          Add them to models.toml (OAS catalog): %s"
          config_path
          (List.length unknown)
          (String.concat ", " (List.map fst unknown)))

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -109,6 +109,58 @@ let validate_cross_verifier_runtime ~(config_path : string) (runtimes : t list)
            (List.length runtimes))
 ;;
 
+(* Pure decision for the capability gate, separated from the global OAS catalog
+   lookup so it is unit-testable. [entries] is [(label, known_to_oas)] per runtime.
+
+   An unknown model resolves to OAS [provider_default], whose guessed capabilities
+   (notably [thinking_control_format = No_thinking_control]) silently drop
+   thinking/sampling control a binding may require — that guess corrupted the
+   memory-os librarian for minimax-m3 (2026-06-19, before it was catalogued).
+   Reject such a binding at load instead of discovering corruption at runtime
+   (Unknown->Permissive anti-pattern; mirrors [runtime].default validation,
+   RFC-0206 §2.1 no-silent-fallback).
+
+   Catalog-presence guard: if EVERY model is unknown, the OAS catalog is almost
+   certainly not loaded in this environment (e.g. CI / a process without
+   ~/.config/oas/models.toml). Aborting the whole process over a missing catalog
+   would be worse than the gap, and the per-request OAS guard
+   ([Complete_common.validate_thinking_control_request]) still fails loud on the
+   actual unsatisfiable call. So abort only on a PARTIAL miss (some models resolved,
+   others did not) — the signature of a real catalog gap rather than an absent
+   catalog. *)
+let decide_capability_gate ~(config_path : string) (entries : (string * bool) list)
+  : (unit, string) result
+  =
+  let unknown = List.filter (fun (_, known) -> not known) entries in
+  match unknown with
+  | [] -> Ok ()
+  | _ when List.for_all (fun (_, known) -> not known) entries -> Ok ()
+  | _ ->
+    Error
+      (Printf.sprintf
+         "%s: %d runtime model(s) absent from the OAS capability catalog while \
+          others resolved — they would use provider_default and silently drop \
+          thinking/sampling control. Add them to models.toml (OAS catalog): %s"
+         config_path
+         (List.length unknown)
+         (String.concat ", " (List.map fst unknown)))
+;;
+
+(* Every runtime binding's model must be known to the OAS capability catalog
+   ({!Llm_provider.Capabilities.for_model_id}). *)
+let validate_runtime_model_capabilities ~(config_path : string) (runtimes : t list)
+  : (unit, string) result
+  =
+  decide_capability_gate
+    ~config_path
+    (List.map
+       (fun (r : t) ->
+          ( Printf.sprintf "%s (model=%s)" r.id r.provider_config.model_id
+          , Option.is_some
+              (Llm_provider.Capabilities.for_model_id r.provider_config.model_id) ))
+       runtimes)
+;;
+
 let materialize_config ~(config_path : string) (cfg : config)
   : ( t list * t * (string * string) list * string option * string option
     , string )
@@ -148,12 +200,15 @@ let materialize_config ~(config_path : string) (cfg : config)
               with
               | Error _ as e -> e
               | Ok () ->
-                Ok
-                  ( runtimes
-                  , rt
-                  , assignments
-                  , cfg.librarian_runtime_id
-                  , cfg.cross_verifier_runtime_id )))))
+                (match validate_runtime_model_capabilities ~config_path runtimes with
+                 | Error _ as e -> e
+                 | Ok () ->
+                   Ok
+                     ( runtimes
+                     , rt
+                     , assignments
+                     , cfg.librarian_runtime_id
+                     , cfg.cross_verifier_runtime_id ))))))
 ;;
 
 let load_list ~(config_path : string)

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -22,12 +22,10 @@ val decide_capability_gate :
   config_path:string -> (string * bool) list -> (unit, string) result
 (** Pure capability-gate decision used by [load_list]/[materialize_config],
     exposed for testing. [entries] is [(label, known_to_oas_catalog)] per runtime
-    binding. Returns [Error] when SOME (but not all) models are unknown to the OAS
+    binding. Returns [Error] when any configured model is unknown to the OAS
     capability catalog: an unknown model resolves to [provider_default] and
     silently drops thinking/sampling control (corrupted the memory-os librarian for
-    minimax-m3, 2026-06-19). An ALL-unknown result is treated as "OAS catalog not
-    loaded in this environment" and passes — the per-request OAS guard still fails
-    loud on the actual unsatisfiable call. *)
+    minimax-m3, 2026-06-19). Empty entries are allowed for focused config probes. *)
 
 val load_list :
   config_path:string

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -18,6 +18,17 @@ type t =
 val id_of_binding : binding -> string
 val of_binding : config -> binding -> t option
 
+val decide_capability_gate :
+  config_path:string -> (string * bool) list -> (unit, string) result
+(** Pure capability-gate decision used by [load_list]/[materialize_config],
+    exposed for testing. [entries] is [(label, known_to_oas_catalog)] per runtime
+    binding. Returns [Error] when SOME (but not all) models are unknown to the OAS
+    capability catalog: an unknown model resolves to [provider_default] and
+    silently drops thinking/sampling control (corrupted the memory-os librarian for
+    minimax-m3, 2026-06-19). An ALL-unknown result is treated as "OAS catalog not
+    loaded in this environment" and passes — the per-request OAS guard still fails
+    loud on the actual unsatisfiable call. *)
+
 val load_list :
   config_path:string
   -> ( t list * t * (string * string) list * string option * string option

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_VERSION="v0.207.5"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="6fe842bf2fdb869b2ed9004029f7cdfd7cd7ca5e"
+readonly OAS_AGENT_SDK_SHA="8a30a9a25b536216352f2ef5e858da52bdcb5e65"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.207.5"

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -933,9 +933,55 @@ let test_clock_failfast_opt_out_when_no_idle_no_clock () =
   in
   check bool "no idle + no clock -> None" true (Option.is_none clock)
 
+(* ── Runtime.decide_capability_gate (OAS catalog binding gate) ── *)
+
+let mentions ~sub s =
+  let ls = String.length sub and lc = String.length s in
+  let rec go i = i + ls <= lc && (String.sub s i ls = sub || go (i + 1)) in
+  ls = 0 || go 0
+
+let test_capability_gate_empty () =
+  match Runtime.decide_capability_gate ~config_path:"cfg" [] with
+  | Ok () -> ()
+  | Error msg -> failf "expected Ok for empty bindings, got: %s" msg
+
+let test_capability_gate_all_known () =
+  match Runtime.decide_capability_gate ~config_path:"cfg" [ "a", true; "b", true ] with
+  | Ok () -> ()
+  | Error msg -> failf "expected Ok when all models known, got: %s" msg
+
+let test_capability_gate_partial_unknown_aborts () =
+  match
+    Runtime.decide_capability_gate
+      ~config_path:"cfg"
+      [ "known", true; "missing-model", false ]
+  with
+  | Ok () -> fail "expected Error when a model is missing from a populated catalog"
+  | Error msg ->
+    check bool "error names the missing model" true (mentions ~sub:"missing-model" msg)
+
+let test_capability_gate_all_unknown_passes () =
+  (* all-unknown => OAS catalog not loaded in this env => pass (do not abort the
+     whole process; the per-request OAS guard still fails loud). *)
+  match Runtime.decide_capability_gate ~config_path:"cfg" [ "a", false; "b", false ] with
+  | Ok () -> ()
+  | Error msg -> failf "expected Ok for all-unknown (catalog absent), got: %s" msg
+
 let () =
   run "runtime_provider_auth_headers"
-    [ ( "provider_config"
+    [ ( "capability_gate"
+      , [ test_case "empty -> ok" `Quick test_capability_gate_empty
+        ; test_case "all known -> ok" `Quick test_capability_gate_all_known
+        ; test_case
+            "partial unknown -> abort"
+            `Quick
+            test_capability_gate_partial_unknown_aborts
+        ; test_case
+            "all unknown -> pass (catalog absent)"
+            `Quick
+            test_capability_gate_all_unknown_passes
+        ] )
+    ; ( "provider_config"
       , [ test_case
             "runtime adapter carries auth in api_key only"
             `Quick

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -960,12 +960,12 @@ let test_capability_gate_partial_unknown_aborts () =
   | Error msg ->
     check bool "error names the missing model" true (mentions ~sub:"missing-model" msg)
 
-let test_capability_gate_all_unknown_passes () =
-  (* all-unknown => OAS catalog not loaded in this env => pass (do not abort the
-     whole process; the per-request OAS guard still fails loud). *)
+let test_capability_gate_all_unknown_aborts () =
   match Runtime.decide_capability_gate ~config_path:"cfg" [ "a", false; "b", false ] with
-  | Ok () -> ()
-  | Error msg -> failf "expected Ok for all-unknown (catalog absent), got: %s" msg
+  | Ok () -> fail "expected Error when all configured models are missing"
+  | Error msg ->
+    check bool "error names first missing model" true (mentions ~sub:"a" msg);
+    check bool "error names second missing model" true (mentions ~sub:"b" msg)
 
 let () =
   run "runtime_provider_auth_headers"
@@ -977,9 +977,9 @@ let () =
             `Quick
             test_capability_gate_partial_unknown_aborts
         ; test_case
-            "all unknown -> pass (catalog absent)"
+            "all unknown -> abort"
             `Quick
-            test_capability_gate_all_unknown_passes
+            test_capability_gate_all_unknown_aborts
         ] )
     ; ( "provider_config"
       , [ test_case


### PR DESCRIPTION
masc 측에서 librarian thinking-control silent-failure를 닫는 묶음. 2 커밋.

## 1) feat(runtime): 부팅 capability 게이트 (layer 1)
runtime 바인딩 모델이 OAS catalog 미등록(`for_model_id -> None`)이면 `provider_default`(`No_thinking_control`)로 폴백 → thinking/sampling control silent drop → memory-os librarian 오염(minimax-m3, 2026-06-19). `materialize_config` fail-loud 체인에 `validate_runtime_model_capabilities` 추가(Unknown→Permissive 안티패턴, RFC-0206 §2.1). 순수 `decide_capability_gate`(runtime.mli 노출, 단위테스트).
- **Catalog-presence 가드**: partial-unknown→abort(진짜 gap), all-unknown→pass(catalog 부재=CI 안전).
- test: capability_gate 4/4 green.

## 2) chore(oas-pin): agent_sdk SHA bump (OAS 가드 소비)
`OAS_AGENT_SDK_SHA` `6fe842bf2`(release 0.207.5) → `8a30a9a25`(oas main, **oas#2156 포함**). 이게 없으면 OAS completion 가드(oas#2156 `validate_thinking_control_request → AcceptRejected`, layer 2)가 oas main에만 있고 masc는 영영 빌드 안 함.
- **버전 bump 불필요**: oas main은 아직 0.207.5(release-please 소관), MIN_VERSION/dune floor `>= 0.207.5` 유지, SHA 핀이 코드 운반. 로컬 0.207.3 drift도 해소.
- catalog 데이터(oas#2155)는 런타임 심링크로 읽혀 이 핀과 무관.

## 2계층 방어 (전체)
- layer 1 (본 PR §1): 부팅 시 미등록 모델 abort
- layer 2 (oas#2156, 본 PR §2 핀으로 소비): completion 시 미충족 thinking-disable를 typed AcceptRejected
- 즉시 fix: oas#2155(catalog entry) MERGED

## ⚠️ 배포 (사용자 직접)
1. 로컬 oas main `git pull`(심링크 타깃에 #2155 반영) — librarian 즉시 복구
2. `opam-pin-external-deps.sh --install`(새 SHA 8a30a9a25 재핀 + agent_sdk 재설치) → masc 재빌드 → #2156 가드 활성
3. masc-mcp 재시작(키퍼 fleet 중단)
배포 순서: #2155 catalog가 로컬 oas main에 있어야 부팅 게이트가 minimax를 통과(아니면 정상 abort).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>