### PR TITLE
feat(dashboard): 컴팩션 토큰 게이트 편집 가능화 (dead-control 해소)

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -376,6 +376,18 @@ describe('buildRuntimePayload — sandbox diffing', () => {
     expect(payload.network_mode).toBeUndefined()
   })
 
+  it('omits compaction_token_gate when unchanged but emits it when edited', () => {
+    const c = makeKeeperConfigForSandbox({})
+    // Unchanged draft → not in payload.
+    expect(buildRuntimePayload(draftFrom(c), c).compaction_token_gate).toBeUndefined()
+    // Editing the token gate (now reachable via the InlineNumberRow) → emitted.
+    const edited = buildRuntimePayload(
+      draftFrom(c, { compaction_token_gate: c.compaction.token_gate + 4096 }),
+      c,
+    )
+    expect(edited.compaction_token_gate).toBe(c.compaction.token_gate + 4096)
+  })
+
   it('emits runtime_id when selected runtime changes', () => {
     const c = makeKeeperConfigForSandbox({
       execution: {

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -601,6 +601,23 @@ describe('KeeperConfigPanel', () => {
     expect(textareas[0]?.value).toContain('Ship stable keeper ops')
   })
 
+  it('renders the compaction token gate as an editable number input (not a read-only row)', async () => {
+    // Regression guard for the ConfigRow → InlineNumberRow swap: a read-only
+    // ConfigRow renders no <input>, so asserting the input exists verifies the
+    // actual render change (buildRuntimePayload alone passed before the swap).
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    const tokenGateInput = container.querySelector(
+      'input[aria-label="토큰 게이트"]',
+    ) as HTMLInputElement | null
+    expect(tokenGateInput).not.toBeNull()
+    expect(tokenGateInput!.type).toBe('number')
+    // Value reflects the loaded config (makeKeeperConfig compaction.token_gate = 24000).
+    expect(tokenGateInput!.value).toBe('24000')
+  })
+
   it('patches runtime_id from the dashboard panel', async () => {
     mocks.patchKeeperConfig.mockResolvedValueOnce(
       makeKeeperConfig({

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -936,7 +936,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           onChange=${(v: number) => updateRuntimeDraft('compaction_message_gate', v)}
           min=${0} max=${500} step=${5}
           dirty=${dirtyFlags.compaction_message_gate} />
-        <${ConfigRow} label="토큰 게이트" value=${formatTokens(c.compaction.token_gate)} />
+        <${InlineNumberRow} label="토큰 게이트" value=${rd.compaction_token_gate}
+          onChange=${(v: number) => updateRuntimeDraft('compaction_token_gate', v)}
+          min=${0} max=${1000000} step=${1000} suffix="tok"
+          dirty=${dirtyFlags.compaction_token_gate} />
         <${InlineNumberRow} label="쿨다운 (초)" value=${rd.compaction_cooldown_sec}
           onChange=${(v: number) => updateRuntimeDraft('compaction_cooldown_sec', v)}
           min=${0} max=${3600} step=${30} suffix="s"


### PR DESCRIPTION
slot 시스템 감사 E3(dead-control) 해소. "숨은 편집 컨트롤 노출"의 확정 가능한 부분.

## 문제 (E3)
`compaction_token_gate`는 write 파이프라인 전체가 배선돼 있음 — RuntimeDraft 필드, `initRuntimeDraftFromConfig`, `buildRuntimePayload` diff, dirty flags, backend 파서(`keeper_meta_json_parse.ml`가 `"compaction_token_gate"` 읽음), runtime consumer — 그런데 편집 모드 패널이 **읽기전용 ConfigRow**로 렌더해 값을 바꿀 수 없었음(dead-control). 나머지 두 게이트(비율/메시지)는 이미 편집형 `InlineNumberRow`.

## 변경
- 토큰 게이트를 `rd.compaction_token_gate` 바인딩 `InlineNumberRow`로 교체(편집 모드). 뷰 모드는 읽기전용 유지.
- `buildRuntimePayload` 테스트 추가(미변경 시 omit / 편집 시 emit).

## 로컬 검증
- `tsc` 0 / `vitest` keeper-config-panel 36 passed / `eslint` 0

## backend 확인 결과 — 나머지 두 컨트롤은 별도 (보고)
"backend 확인 후 노출" 약속대로 확인한 결과, 세 컨트롤이 균일하지 않음:
- **tool_denylist**: config PATCH가 아니라 **별도 `action: "set_policy"` 엔드포인트**(`server_dashboard_http_keeper_api_post.ml`의 `tool_denylist = deny`)로만 write 가능. config 패널에 노출하려면 set_policy 호출 배선 필요(별도 tool-policy 편집기 경로일 수 있어 조사 선행). → 후속.
- **mention_targets**: keeper meta엔 존재하나(`keeper_meta_json_parse.ml`) 대시보드 write 엔드포인트 미확인. backend 작업 필요 가능성. → 후속.

## 연관
- slot 감사 시리즈: #21587(머지), #21597(Layout A), #21604(introspection 정리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)