### PR TITLE
[codex] preserve structured keeper error wrapping

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -119,6 +119,39 @@ describe('ChatTranscript', () => {
     expect(bubble?.textContent).toContain('✓')
   })
 
+  it('preserves structured failure messages as preformatted text', () => {
+    const text = 'Keeper request failed: Internal error: [masc_oas_error] {"kind":"accept_rejected","scope":"ollama_cloud.deepseek-v4-flash","reason_kind":"no_usable_progress","last_tool_effect":"mutating"}'
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'err-1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text,
+            rawText: text,
+            delivery: 'error',
+            error: text,
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const pre = container.querySelector('[data-chat-structured-error]')
+    expect(pre?.tagName).toBe('PRE')
+    expect(pre?.classList.contains('chat-error-text')).toBe(true)
+    expect(pre?.classList.contains('break-words')).toBe(false)
+    expect(pre?.textContent).toContain('ollama_cloud.deepseek-v4-flash')
+    expect(Array.from(pre?.querySelectorAll('.chat-error-token') ?? []).some(node =>
+      node.textContent?.includes('ollama_cloud.deepseek-v4-flash'),
+    )).toBe(true)
+    expect(container.querySelector('[data-chat-blocks]')).toBeNull()
+  })
+
   it('marks a failed tool call with the error status glyph', () => {
     recordToolCallOutputs([
       toolCallOutput({ tool_use_id: 'toolu_y', success: false, output: 'boom' }),

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1141,6 +1141,13 @@ function LiveMessagePlaceholder({ label }: { label: string }) {
   `
 }
 
+function renderStructuredFailureText(text: string): Array<string | VNode> {
+  return text.split(/(\s+)/).map((part, index) => {
+    if (!part || /^\s+$/.test(part)) return part
+    return html`<span class="chat-error-token" key=${index}>${part}</span>`
+  })
+}
+
 function AttachmentCard({ attachment }: { attachment: KeeperConversationAttachment }) {
   const [open, setOpen] = useState(false)
   const canDownload = isSafeAttachmentHref(attachment)
@@ -1332,12 +1339,20 @@ function ChatMessageBubble({
   const liveLabel = liveMessageLabel(entry)
   const messageText = liveLabel ? '' : entry.text || '(empty reply)'
   const messageLength = messageText.length
+  const isFailureMessage =
+    (entry.delivery === 'error' || entry.delivery === 'timeout' || entry.delivery === 'interrupted')
+    && !!entry.error?.trim()
   const parsedBlocks = useMemo(() => {
+    if (isFailureMessage) return null
     if (hasBlocks) return null
     if (entry.role !== 'assistant' && entry.role !== 'system') return null
     return parseMarkdownToBlocks(messageText)
-  }, [hasBlocks, entry.role, messageText])
-  const effectiveBlocks = entry.blocks && entry.blocks.length > 0 ? entry.blocks : (parsedBlocks ?? [])
+  }, [hasBlocks, isFailureMessage, entry.role, messageText])
+  const effectiveBlocks = isFailureMessage
+    ? []
+    : entry.blocks && entry.blocks.length > 0
+      ? entry.blocks
+      : (parsedBlocks ?? [])
   const hasEffectiveBlocks = effectiveBlocks.length > 0
   const collapseThreshold = 1200
   const isCollapsible = !hasEffectiveBlocks && messageLength > collapseThreshold
@@ -1519,7 +1534,14 @@ function ChatMessageBubble({
       ${liveLabel
         ? html`<${LiveMessagePlaceholder} label=${liveLabel} />`
         : html`
-            ${hasEffectiveBlocks
+            ${isFailureMessage
+              ? html`
+                  <pre
+                    class="chat-error-text"
+                    data-chat-structured-error
+                  >${renderStructuredFailureText(messageText)}</pre>
+                `
+              : hasEffectiveBlocks
               ? html`<${ChatBlocks} blocks=${effectiveBlocks} />`
               : html`
                   <div

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -98,6 +98,24 @@
   background: linear-gradient(180deg, rgb(var(--color-accent-glow) / .10), var(--color-bg-surface));
 }
 
+.chat-error-text {
+  margin: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: pre-wrap;
+  overflow-wrap: normal;
+  word-break: keep-all;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.6;
+  color: var(--color-fg-primary);
+}
+
+.chat-error-token {
+  white-space: nowrap;
+}
+
 /* ════ Keeper v2 multimodal composer ════ */
 
 .composer {


### PR DESCRIPTION
## What changed

- Render keeper transport/runtime failure messages as preformatted structured error text instead of the normal markdown paragraph path.
- Preserve long model/scope/error tokens by wrapping non-whitespace tokens in nowrap spans while allowing whitespace wrapping and horizontal overflow.
- Add a chat primitive regression test for `[masc_oas_error]` style messages such as `ollama_cloud.deepseek-v4-flash`.

## Why

The Keeper dashboard could tear structured runtime error strings across arbitrary token boundaries. In the observed case, `[masc_oas_error]` / `accept_rejected` text became hard to read because model and scope tokens were line-broken inside the token.

## Validation

- `git diff --check`
- `tsc --noEmit --pretty`
- `eslint src/components/chat/primitives.ts src/components/chat/primitives.test.ts`

Vitest note: local `vitest run --config vitest.config.ts src/components/chat/primitives.test.ts --no-file-parallelism --maxWorkers=1` did not start because this worktree has no local `dashboard/node_modules`, and reusing the main checkout `.bin` failed before tests with missing `jsdom`. CI should run with the lockfile dependencies installed.