### PR TITLE
chore(dashboard): drop redundant explicit *-v2.css imports from main.ts

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -33,9 +33,8 @@ import './styles/styleseed-base.css'
 // Global utilities and layout
 import './styles/global.css'
 import './styles/chat.css'
-import './styles/chat-blocks-v2.css'
-import './styles/surfaces-v2.css'
-import './styles/cockpit-v2.css'
+// chat-blocks-v2.css / surfaces-v2.css / cockpit-v2.css load via the *-v2.css
+// glob below (see ordering note there) — no per-surface import line here.
 
 // Component-specific styles
 import './styles/ui.css'
@@ -50,18 +49,15 @@ import './styles/paper-theme.css'
 import './styles/keeper-workspace.css'
 import './styles/copilot-dock.css'
 import './styles/keeper-turn-inspector.css'
-import './styles/ide-v2.css'
-import './styles/work-v2.css'
 import './styles/design-canvas.css'
 import './styles/states.css'
-import './styles/connectors-v2.css'
-import './styles/telemetry-v2.css'
-import './styles/craft-v2.css'
+// ide-v2.css / work-v2.css / connectors-v2.css / telemetry-v2.css /
+// craft-v2.css load via the *-v2.css glob below.
 
-// v2 skin — cool-charcoal palette + voltage accent (brass/blood/ice) +
-// Space Grotesk display, for the --color-* surfaces. Activated by
-// data-skin="v2" on <html> (index.html), scoped to yield to paper/styleseed.
-import './styles/skin-v2.css'
+// v2 skin (skin-v2.css) — cool-charcoal palette + voltage accent
+// (brass/blood/ice) + Space Grotesk display, for the --color-* surfaces.
+// Activated by data-skin="v2" on <html> (index.html), scoped to yield to
+// paper/styleseed. Loaded via the *-v2.css glob below.
 // StyleSeed → keeper-v2 Dark Fantasy bridge. Re-points the StyleSeed token
 // VALUES (--ss-* / --background / --card / --brand, defined LIGHT by
 // app-shell-v2.css) at the Dark Fantasy spine, so the migrated surfaces render


### PR DESCRIPTION
## 무엇을

`dashboard/src/main.ts`에서 중복된 명시적 `*-v2.css` import 9개를 제거했습니다.
(chat-blocks / surfaces / cockpit / ide / work / connectors / telemetry / craft / skin-v2)

## 왜

`*-v2.css` surface 스타일시트는 main.ts 하단 `import.meta.glob('./styles/*-v2.css')`가 이미 빌드타임에 주입합니다. 9개 파일이 명시적으로도 import돼 glob과 중복이었고, "새 v2 surface는 main.ts에 import 줄을 추가하지 않는다"는 같은 파일의 주석 컨벤션과도 모순이었습니다.

## 검증 (전/후 `vite build` CSS 번들 diff)

- Vite는 공유 CSS 모듈을 dedupe하므로 명시적 import은 번들 순서에 사실상 no-op이었습니다.
- 번들 diff 결과 **순수 삽입(0 규칙 제거·재배열)** — 기존 surface 스타일은 byte 단위로 동일한 순서를 유지합니다. 즉 cascade 회귀가 없습니다.
- 유일한 델타: 새 import 그래프에서 Tailwind JIT가 추가로 emit하는 미사용 유틸 32개 (+2.5KB, 컴포넌트 참조 0건).
- 관련 테스트 통과: `app` / `surfaces-v2` / `cockpit-v2` (32 tests).

## 영향

- 시각 회귀 없음 (기존 규칙 순서 불변).
- 소스 명료성 + 병렬 surface PR의 merge-conflict anchor 제거.

RFC-WAIVED: dashboard 진입점의 CSS import 정리. credential / operator / sandbox / hooks / workflow subsystem 미해당.
