### PR TITLE
feat(fusion): 키퍼 채팅에 fusion 심의 결과 카드 렌더

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -101,6 +101,13 @@ export const KeeperChatBlockSchema = union([
     desc: optional(string()),
     meta: optional(string()),
   }),
+  // RFC-0252: fusion deliberation card. Must be accepted here or a message
+  // carrying a fusion block (the keeper conclusion) is dropped wholesale.
+  object({
+    t: literal('fusion'),
+    board_post_id: string(),
+    run_id: optional(string()),
+  }),
 ])
 
 export type KeeperChatBlock = InferOutput<typeof KeeperChatBlockSchema>

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -9,9 +9,14 @@ import type { ToolCallEntry } from '../../api/dashboard'
 import { ChatComposer, ChatTranscript } from './primitives'
 import { collectAttachments } from './attachments'
 import { recordToolCallOutputs, resetToolCallOutputs } from '../../tool-call-output-store'
+import { fetchBoardPost } from '../../api/board'
 
 vi.mock('./attachments', () => ({
   collectAttachments: vi.fn(),
+}))
+
+vi.mock('../../api/board', () => ({
+  fetchBoardPost: vi.fn(),
 }))
 
 const flushUi = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 30))
@@ -1555,5 +1560,80 @@ describe('ChatMessageBubble — workspace source badge (C2)', () => {
       container,
     )
     expect(container.querySelector('.kw-src-badge')).toBeNull()
+  })
+})
+
+describe('fusion chat card', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    vi.mocked(fetchBoardPost).mockReset()
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  function fusionEntry(): KeeperConversationEntry {
+    return {
+      id: 'fusion-1',
+      role: 'assistant',
+      source: 'internal_assistant',
+      label: 'sangsu',
+      text: 'Fusion deliberation (run fus-1) — answer — done',
+      rawText: 'Fusion deliberation (run fus-1) — answer — done',
+      timestamp: '2026-06-19T00:00:00.000Z',
+      delivery: 'history',
+      streamState: null,
+      details: null,
+      error: null,
+      blocks: [{ t: 'fusion', board_post_id: 'p-1', run_id: 'fus-1' }],
+    }
+  }
+
+  it('renders a collapsed fusion card without fetching the board post', () => {
+    render(html`<${ChatTranscript} entries=${[fusionEntry()]} emptyText="empty" />`, container)
+    const card = container.querySelector('[data-fusion-card]')
+    expect(card).not.toBeNull()
+    expect(card?.textContent).toContain('Fusion 심의')
+    // Collapsed: no detail rendered and no network call yet.
+    expect(container.querySelector('[data-fusion-detail]')).toBeNull()
+    expect(fetchBoardPost).not.toHaveBeenCalled()
+  })
+
+  it('lazy-fetches the board post and renders panel answers + judge on expand', async () => {
+    vi.mocked(fetchBoardPost).mockResolvedValue({
+      meta: {
+        source: 'fusion',
+        panel: [
+          { model: 'ollama_cloud.kimi-k2-6', status: 'answered', answer: 'PANEL ONE ANSWER' },
+          { model: 'ollama_cloud.minimax-m3', status: 'failed', reason: 'timeout' },
+        ],
+        judge: { status: 'synthesized', decision: 'answer — ok', resolved_answer: 'JUDGE RESOLVED ANSWER' },
+      },
+    } as unknown as Awaited<ReturnType<typeof fetchBoardPost>>)
+
+    render(html`<${ChatTranscript} entries=${[fusionEntry()]} emptyText="empty" />`, container)
+    const toggle = container.querySelector('[data-fusion-card] button') as HTMLButtonElement | null
+    expect(toggle).not.toBeNull()
+    fireEvent.click(toggle as HTMLButtonElement)
+    await flushUi()
+
+    expect(fetchBoardPost).toHaveBeenCalledWith('p-1')
+    const detail = container.querySelector('[data-fusion-detail]')
+    expect(detail?.textContent).toContain('PANEL ONE ANSWER')
+    expect(detail?.textContent).toContain('timeout')
+    expect(detail?.textContent).toContain('JUDGE RESOLVED ANSWER')
+  })
+
+  it('shows an error message when the board post fetch fails', async () => {
+    vi.mocked(fetchBoardPost).mockRejectedValue(new Error('boom'))
+    render(html`<${ChatTranscript} entries=${[fusionEntry()]} emptyText="empty" />`, container)
+    fireEvent.click(container.querySelector('[data-fusion-card] button') as HTMLButtonElement)
+    await flushUi()
+    expect(container.querySelector('[data-fusion-detail]')?.textContent).toContain('불러오지 못했습니다')
   })
 })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -18,6 +18,7 @@ import { isSubmitEnter } from '../../lib/keyboard'
 import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatLinkBlock, ChatMermaidBlock, ChatShellBlock, ChatTableBlock, ChatTraceStep, ChatVoiceBlock, KeeperUserInputBlock } from '../../types'
 import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, KeeperConversationSource, SurfaceRef } from '../../types'
 import type { ToolCallEntry, ToolCallOutputBlob } from '../../api/dashboard'
+import { fetchBoardPost } from '../../api/board'
 import { lookupToolCallOutput } from '../../tool-call-output-store'
 import { Sigil } from '../common/sigil-chip'
 import { SuggestionChip } from '../common/suggestion-chip'
@@ -1095,6 +1096,144 @@ function ChatBroadcastBlock(b: ChatBroadcastBlock) {
   `
 }
 
+// RFC-0252: fusion deliberation card. The board post (created by
+// fusion_sink.ml) holds the full panel answers + judge synthesis in its
+// meta_json; the chat message only carries the board_post_id. We lazy-fetch
+// the post the first time the card is expanded so a collapsed transcript does
+// no extra network. meta is a loose Record on the wire, so we narrow defensively.
+type FusionPanelEntry = {
+  model: string
+  status: string
+  answer?: string
+  reason?: string
+}
+
+type FusionJudgeView = {
+  status: string
+  decision?: string
+  resolvedAnswer?: string
+}
+
+function asFusionPanel(meta: unknown): FusionPanelEntry[] {
+  if (!meta || typeof meta !== 'object') return []
+  const panel = (meta as Record<string, unknown>).panel
+  if (!Array.isArray(panel)) return []
+  return panel.flatMap((raw) => {
+    if (!raw || typeof raw !== 'object') return []
+    const r = raw as Record<string, unknown>
+    return [{
+      model: typeof r.model === 'string' ? r.model : '?',
+      status: typeof r.status === 'string' ? r.status : 'unknown',
+      answer: typeof r.answer === 'string' ? r.answer : undefined,
+      reason: typeof r.reason === 'string' ? r.reason : undefined,
+    }]
+  })
+}
+
+function asFusionJudge(meta: unknown): FusionJudgeView | null {
+  if (!meta || typeof meta !== 'object') return null
+  const judge = (meta as Record<string, unknown>).judge
+  if (!judge || typeof judge !== 'object') return null
+  const r = judge as Record<string, unknown>
+  return {
+    status: typeof r.status === 'string' ? r.status : 'unknown',
+    decision: typeof r.decision === 'string' ? r.decision : undefined,
+    resolvedAnswer: typeof r.resolved_answer === 'string' ? r.resolved_answer : undefined,
+  }
+}
+
+function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: string }) {
+  const [expanded, setExpanded] = useState(false)
+  const [state, setState] = useState<{
+    status: 'idle' | 'loading' | 'loaded' | 'error'
+    panel: FusionPanelEntry[]
+    judge: FusionJudgeView | null
+    error?: string
+  }>({ status: 'idle', panel: [], judge: null })
+  // Fetch-once guard. state.status must NOT be in the effect deps: the
+  // setState('loading') below would otherwise re-run the effect, whose cleanup
+  // flips `alive` false and drops the in-flight result (the card stays on
+  // "loading" forever). A ref keeps the trigger out of the dependency array.
+  const fetchedRef = useRef(false)
+
+  useEffect(() => {
+    if (!expanded || fetchedRef.current) return
+    fetchedRef.current = true
+    let alive = true
+    setState((s) => ({ ...s, status: 'loading' }))
+    fetchBoardPost(boardPostId)
+      .then((post) => {
+        if (!alive) return
+        setState({ status: 'loaded', panel: asFusionPanel(post.meta), judge: asFusionJudge(post.meta) })
+      })
+      .catch((err: unknown) => {
+        if (!alive) return
+        setState({ status: 'error', panel: [], judge: null, error: err instanceof Error ? err.message : '불러오기 실패' })
+      })
+    return () => { alive = false }
+  }, [expanded, boardPostId])
+
+  const runLabel = runId ? ` · ${runId.slice(0, 12)}` : ''
+  return html`
+    <div class="rounded-[var(--r-1,8px)] border border-[var(--color-brass-border,#3a3a2a)] bg-[var(--color-brass-soft,rgba(216,166,87,0.06))] overflow-hidden" data-fusion-card>
+      <button
+        type="button"
+        class="w-full flex items-center gap-2 px-3 py-2 text-left text-xs ${ringFocusClasses}"
+        aria-expanded=${expanded}
+        onClick=${() => setExpanded((v) => !v)}
+      >
+        <span aria-hidden="true">${expanded ? '▾' : '▸'}</span>
+        <span class="font-medium">Fusion 심의</span>
+        <span class="text-[var(--color-fg-secondary,#9da7b3)]">패널 합의 상세${runLabel}</span>
+      </button>
+      ${expanded
+        ? html`
+          <div class="px-3 pb-3 flex flex-col gap-3" data-fusion-detail>
+            ${state.status === 'loading'
+              ? html`<div class="text-xs text-[var(--color-fg-secondary,#9da7b3)]">불러오는 중…</div>`
+              : null}
+            ${state.status === 'error'
+              ? html`<div class="text-xs text-[var(--color-danger,#e06c75)]">상세를 불러오지 못했습니다: ${state.error}</div>`
+              : null}
+            ${state.status === 'loaded'
+              ? html`
+                <div class="flex flex-col gap-2">
+                  ${state.panel.map((p, i) => html`
+                    <div key=${i} class="rounded border border-[var(--color-border,#30363d)] px-2 py-1.5">
+                      <div class="text-2xs font-mono text-[var(--color-fg-secondary,#9da7b3)]">${p.model} · ${p.status}</div>
+                      ${p.answer
+                        ? html`<div class="text-xs mt-1 whitespace-pre-wrap">${p.answer}</div>`
+                        : null}
+                      ${p.reason
+                        ? html`<div class="text-xs mt-1 text-[var(--color-danger,#e06c75)]">${p.reason}</div>`
+                        : null}
+                    </div>
+                  `)}
+                </div>
+                ${state.judge
+                  ? html`
+                    <div class="rounded border border-[var(--color-brass-border,#3a3a2a)] px-2 py-1.5" data-fusion-judge>
+                      <div class="text-2xs font-mono text-[var(--color-fg-secondary,#9da7b3)]">
+                        judge · ${state.judge.status}${state.judge.decision ? html` · ${state.judge.decision}` : null}
+                      </div>
+                      ${state.judge.resolvedAnswer
+                        ? html`<div class="text-xs mt-1 whitespace-pre-wrap">${state.judge.resolvedAnswer}</div>`
+                        : null}
+                    </div>
+                  `
+                  : null}
+                ${state.panel.length === 0 && !state.judge
+                  ? html`<div class="text-xs text-[var(--color-fg-secondary,#9da7b3)]">패널/심판 상세가 비어 있습니다.</div>`
+                  : null}
+              `
+              : null}
+          </div>
+        `
+        : null}
+    </div>
+  `
+}
+
 function ChatBlock({ block }: { block: ChatBlock }) {
   switch (block.t) {
     case 'p': return html`<${ChatTextBlock} html=${block.html} />`
@@ -1113,6 +1252,7 @@ function ChatBlock({ block }: { block: ChatBlock }) {
     case 'trace': return html`<${ChatTraceBlock} trace=${block.trace} />`
     case 'link': return html`<${ChatLinkBlock} url=${block.url} title=${block.title} desc=${block.desc} meta=${block.meta} fav=${block.fav} kind=${block.kind} />`
     case 'broadcast': return html`<${ChatBroadcastBlock} scope=${block.scope} via=${block.via} note=${block.note} recipients=${block.recipients} />`
+    case 'fusion': return html`<${ChatFusionCard} boardPostId=${block.board_post_id} runId=${block.run_id} />`
     default: return null
   }
 }

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -203,6 +203,15 @@ function normalizeBlocks(raw: unknown): ChatBlock[] | undefined {
             }
           : null
       }
+      // RFC-0252: fusion deliberation card. board_post_id is the lazy-fetch key
+      // and is required; dropping it here would silently strip the card and let
+      // the text fallback overwrite blocks.
+      if (t === 'fusion') {
+        const boardPostId = asString(item.board_post_id)
+        return boardPostId
+          ? { t: 'fusion', board_post_id: boardPostId, run_id: asString(item.run_id) ?? undefined }
+          : null
+      }
       return null
     })
     .filter((b): b is ChatBlock => b !== null)

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -816,6 +816,11 @@ export type ChatLinkBlock = { t: 'link'; url: string; title: string; desc?: stri
 export type ChatBroadcastAck = 'acked' | 'read' | 'delivered' | string
 export type ChatBroadcastRecipient = { id: string; ack: ChatBroadcastAck; at?: string }
 export type ChatBroadcastBlock = { t: 'broadcast'; scope: string; via?: string; note: string; recipients: ChatBroadcastRecipient[] }
+// RFC-0252: a reference from a keeper chat message to a fusion deliberation's
+// board post. Carries only ids (snake_case to match the backend wire shape in
+// keeper_chat_blocks.ml); ChatFusionCard lazy-fetches the board post by
+// board_post_id and renders its meta_json (panel answers + judge synthesis).
+export type ChatFusionBlock = { t: 'fusion'; board_post_id: string; run_id?: string }
 
 export type ChatBlock =
   | ChatTextBlock
@@ -834,6 +839,7 @@ export type ChatBlock =
   | ChatTraceBlock
   | ChatLinkBlock
   | ChatBroadcastBlock
+  | ChatFusionBlock
 export type KeeperConversationStreamState =
   | 'opening'
   | 'thinking'

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -113,26 +113,6 @@ let judge_meta (judge : (Fusion_types.judge_synthesis, string) result) : Yojson.
 let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judge_usage :
     (unit, string) result =
   try
-    (* 키퍼 메인 흐름 통합 ("결과를 키퍼 흐름에 녹이기", RFC-0252 §8 개정).
-       상세 트랜스크립트(패널 답변 N개)는 아래 board post 증거로만 남기고, 키퍼 chat
-       lane에는 judge 결론(decision + resolved_answer)만 키퍼 *메인* conversation
-       (conversation_id 생략)에 append한다. → 키퍼 observation(recent_direct_conversation)이
-       패널 답변으로 도배되지 않고, librarian이 메인 chat 결론을 fact로 추출한다(memory-os
-       fact 타입에 직접 의존하지 않음 = 강결합 없는 통합). judge 실패 시에는 메인 흐름을
-       오염시키지 않으려 결론을 남기지 않는다(board에는 실패도 증거로 남는다). *)
-    (match judge with
-     | Ok j ->
-       let content =
-         Printf.sprintf "Fusion deliberation (run %s) — %s\n\n%s" run_id
-           (render_decision j.Fusion_types.decision) j.Fusion_types.resolved_answer
-       in
-       Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper
-         ~content
-         ();
-       Keeper_chat_broadcast.chat_appended ~keeper_name:keeper ~source:"fusion"
-         ~content
-         ()
-     | Error _ -> ());
     (* 비용 관측(제약 아님) — 패널 N + 심판 1 실측 토큰 합산 (RFC §10). board 증거에만
        남긴다 (cost cap은 v1 제외, 측정값만 — 괴상한 제약 제거 원칙). 실패한 패널/심판은
        완성이 없어 0(usage_of가 완성 응답에서만 토큰을 뽑음). *)
@@ -170,11 +150,45 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judge_usage :
                  ] )
            ])
     in
-    (match
-       Board_dispatch.create_post ~author:keeper ~content:board_headline
-         ~post_kind:Board.System_post ?meta_json ~visibility:Board.Internal
-         ~ttl_hours:board_post_ttl_hours ()
-     with
+    (* board post를 *먼저* 만들어 post id를 확보한다 — 이 id가 키퍼 chat의 fusion block
+       lazy-fetch 키이기 때문이다(대시보드가 board meta_json에서 패널/심판을 펼친다). *)
+    let board_result =
+      Board_dispatch.create_post ~author:keeper ~content:board_headline
+        ~post_kind:Board.System_post ?meta_json ~visibility:Board.Internal
+        ~ttl_hours:board_post_ttl_hours ()
+    in
+    (* 키퍼 메인 흐름 통합 ("결과를 키퍼 흐름에 녹이기", RFC-0252 §8 개정).
+       상세 트랜스크립트(패널 답변 N개)는 위 board post 증거로만 남기고, 키퍼 chat
+       lane에는 judge 결론(decision + resolved_answer)만 키퍼 *메인* conversation
+       (conversation_id 생략)에 append한다. board가 생성됐으면 그 post를 가리키는
+       [Fusion] block을 함께 첨부해 대시보드가 결론 카드를 패널/심판 상세로 펼치게 한다.
+       block은 content가 아니므로 키퍼 observation(recent_direct_conversation, role/content만
+       읽음)을 도배하지 않는다 → librarian은 메인 chat 결론(content)을 fact로 추출하고,
+       사용자만 카드 상세를 본다(강결합 없는 통합). judge 실패 시에는 메인 흐름을
+       오염시키지 않으려 결론을 남기지 않는다(board에는 실패도 증거로 남는다). *)
+    (match judge with
+     | Ok j ->
+       let content =
+         Printf.sprintf "Fusion deliberation (run %s) — %s\n\n%s" run_id
+           (render_decision j.Fusion_types.decision) j.Fusion_types.resolved_answer
+       in
+       let blocks =
+         match board_result with
+         | Ok (post : Board.post) ->
+           Some
+             [ Keeper_chat_blocks.Fusion
+                 { board_post_id = Board.Post_id.to_string post.id; run_id }
+             ]
+         | Error _ -> None
+         (* board 생성 실패 시 카드 링크를 생략하되 결론은 남긴다(키퍼가 인지). *)
+       in
+       Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper
+         ~content ?blocks ();
+       Keeper_chat_broadcast.chat_appended ~keeper_name:keeper ~source:"fusion"
+         ~content
+         ()
+     | Error _ -> ());
+    (match board_result with
      | Ok _post -> Ok ()
      | Error e -> Error (Board.show_board_error e))
   with

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -17,10 +17,16 @@ type link_block = {
 
 type text_block = { html : string }
 
+type fusion_block = {
+  board_post_id : string;
+  run_id : string;
+}
+
 type chat_block =
   | Text of text_block
   | Image of image_block
   | Link of link_block
+  | Fusion of fusion_block
 
 let escape_html raw =
   raw
@@ -154,6 +160,12 @@ let block_to_yojson = function
       ; ("title", `String title)
       ; ("meta", `String meta)
       ]
+  | Fusion { board_post_id; run_id } ->
+    `Assoc
+      [ ("t", `String "fusion")
+      ; ("board_post_id", `String board_post_id)
+      ; ("run_id", `String run_id)
+      ]
 ;;
 
 let blocks_to_yojson blocks = `List (List.map block_to_yojson blocks)
@@ -178,6 +190,12 @@ let block_of_yojson json : chat_block option =
          Option.bind (get_string "title") (fun title ->
            let meta = Option.value (get_string "meta") ~default:title in
            Some (Link { url; title; meta })))
+     | Some "fusion" ->
+       (* board_post_id is the lazy-fetch key and is required; run_id is a
+          display/cross-reference convenience and tolerated as empty. *)
+       Option.bind (get_string "board_post_id") (fun board_post_id ->
+         let run_id = Option.value (get_string "run_id") ~default:"" in
+         Some (Fusion { board_post_id; run_id }))
      | _ -> None)
   | _ -> None
 ;;

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -23,10 +23,21 @@ type link_block = {
 
 type text_block = { html : string }
 
+(** A reference from a keeper chat message to a fusion deliberation's board
+    post (RFC-0252). Carries only ids — the dashboard lazy-fetches the board
+    post by [board_post_id] and renders the panel answers + judge synthesis
+    from its [meta_json]. Kept out of [content] so the keeper observation
+    projection (which reads role/content only) is not polluted. *)
+type fusion_block = {
+  board_post_id : string;
+  run_id : string;
+}
+
 type chat_block =
   | Text of text_block
   | Image of image_block
   | Link of link_block
+  | Fusion of fusion_block
 
 val parse_text_to_blocks : string -> chat_block list
 val block_to_yojson : chat_block -> Yojson.Safe.t

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -156,6 +156,41 @@ let test_blocks_of_yojson_rejects_malformed () =
     true
     (B.blocks_of_yojson (`List [ `Assoc [ ("t", `String "unknown") ] ]) = None)
 
+(* RFC-0252: the fusion block wire shape is the contract the dashboard zod
+   schema mirrors (t=fusion, snake_case ids). Pin it so a drift breaks here. *)
+let test_fusion_block_roundtrip () =
+  let original = [ B.Fusion { board_post_id = "p-abc123"; run_id = "fus-2583b65c" } ] in
+  Alcotest.(check (list yojson_testable))
+    "fusion block json shape"
+    [
+      `Assoc
+        [
+          ("t", `String "fusion");
+          ("board_post_id", `String "p-abc123");
+          ("run_id", `String "fus-2583b65c");
+        ];
+    ]
+    (blocks_to_json_list original);
+  match B.blocks_of_yojson (B.blocks_to_yojson original) with
+  | Some parsed ->
+    Alcotest.(check (list yojson_testable))
+      "fusion roundtrip json"
+      (blocks_to_json_list original)
+      (blocks_to_json_list parsed)
+  | None -> Alcotest.fail "blocks_of_yojson rejected valid fusion block"
+
+let test_fusion_block_requires_board_post_id () =
+  Alcotest.(check bool) "missing board_post_id rejected"
+    true
+    (B.blocks_of_yojson (`List [ `Assoc [ ("t", `String "fusion"); ("run_id", `String "fus-1") ] ])
+     = None)
+
+let test_fusion_block_tolerates_missing_run_id () =
+  (* run_id is a display convenience; board_post_id alone is a valid card. *)
+  match B.blocks_of_yojson (`List [ `Assoc [ ("t", `String "fusion"); ("board_post_id", `String "p-1") ] ]) with
+  | Some [ B.Fusion { board_post_id = "p-1"; run_id = "" } ] -> ()
+  | _ -> Alcotest.fail "fusion block with board_post_id only should decode with empty run_id"
+
 let () =
   Alcotest.run "keeper_chat_blocks"
     [
@@ -192,5 +227,11 @@ let () =
             test_blocks_of_yojson_roundtrip;
           Alcotest.test_case "blocks_of_yojson rejects malformed" `Quick
             test_blocks_of_yojson_rejects_malformed;
+          Alcotest.test_case "fusion block roundtrip" `Quick
+            test_fusion_block_roundtrip;
+          Alcotest.test_case "fusion block requires board_post_id" `Quick
+            test_fusion_block_requires_board_post_id;
+          Alcotest.test_case "fusion block tolerates missing run_id" `Quick
+            test_fusion_block_tolerates_missing_run_id;
         ] );
     ]


### PR DESCRIPTION
## 배경

`masc_fusion`(RFC-0252)은 패널 3모델 + judge 합의 심의 결과를 board post(`meta_json`: panel 답변 + judge 종합)와 키퍼 chat lane(결론 1줄)으로 배출합니다. 그러나 대시보드는 chat의 결론 1줄만 보여주고 패널/심판 상세를 렌더하지 않았습니다 (`post-detail.ts`는 `meta.source`/`state_block`만 표시). 사용자가 fusion을 호출해도 "어떤 모델이 뭐라 했고 judge가 어떻게 종합했는지"를 펼쳐 볼 UI가 없었습니다.

이 PR은 키퍼 채팅에 **접이식 fusion 카드**를 추가합니다. 결론은 chat에, 상세는 board에 두고 카드가 board post를 lazy-fetch합니다 (데이터 중복 0, observation 도배 0).

## 변경

### Backend (OCaml)
- `keeper_chat_blocks`: closed union에 `Fusion of fusion_block`(`board_post_id`, `run_id`) variant 추가. wire shape `{t:"fusion", board_post_id, run_id}` (round-trip 테스트로 고정).
- `fusion_sink`: board post를 먼저 생성해 `post.id`를 확보하고, 결론 메시지에 `Fusion` block을 첨부. **observation 투영(`keeper_world_observation_message_scope`)은 role/content만 읽고 blocks를 보지 않으므로** 패널 상세가 키퍼 컨텍스트로 새지 않습니다 (RFC-0252 §8 의도 보존).

### Frontend (TS)
- `ChatFusionBlock` 타입 + zod 스키마 + `normalizeBlocks` 분기 — **세 게이트 모두** `t=fusion`을 받아야 fusion 메시지가 drop되지 않습니다.
- `ChatFusionCard`: 펼칠 때만 `fetchBoardPost(board_post_id)` lazy-fetch(접힌 동안 네트워크 0), `meta.panel`(3답변) + `meta.judge`(종합) 렌더. loading/error 상태 처리.

## 검증
- 백엔드: `dune build --root . test/test_keeper_chat_blocks.exe` 컴파일 OK + `keeper_chat_blocks` **17 테스트 green** (fusion round-trip/board_post_id-required/run_id-tolerant 3건 포함).
- 프론트: `tsc --noEmit` **0 errors** + `vitest primitives.test.ts` **68 passed** (fusion 카드 collapsed/expand-fetch/error 3건 포함).
- 발견·수정한 버그: `ChatFusionCard` useEffect deps에 `state.status`가 있어 loading 영구 정지 → `fetchedRef`로 1회 fetch 보장 (테스트가 잡음).

## Note (base-broken, 본 PR 무관)
현재 `origin/main` HEAD는 `test/test_keeper_effective_meta_overlay.ml`이 `Unbound module Masc.Runtime`으로 빌드 실패합니다(`lib/runtime`는 `wrapped false`의 별도 `masc_runtime` 라이브러리라 `Masc.Runtime` 미존재). 이 파일은 본 PR diff에 없으며(9파일 전부 keeper_chat_blocks/fusion_sink/dashboard), 변경 없는 pristine main worktree(da85485f87)에서도 동일하게 깨집니다. `fix/keeper-effective-meta-test-runtime-init`(#21596 계열)에서 별도 수정 중입니다.

RFC-0252 follow-up. RFC-0235(chat blocks) 확장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
