### PR TITLE
fix(runtime): require JSON-capable cross verifier

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -98,15 +98,25 @@ let validate_cross_verifier_runtime ~(config_path : string) (runtimes : t list)
   match cross_verifier_id with
   | None -> Ok ()
   | Some id ->
-    if List.exists (fun (r : t) -> String.equal r.id id) runtimes
-    then Ok ()
-    else
+    (match List.find_opt (fun (r : t) -> String.equal r.id id) runtimes with
+     | None ->
       Error
         (Printf.sprintf
            "%s: [runtime].cross_verifier = %S not found among %d runtimes"
            config_path
            id
            (List.length runtimes))
+     | Some runtime ->
+       (match runtime.model.capabilities with
+        | Some caps when caps.supports_response_format_json -> Ok ()
+        | _ ->
+          Error
+            (Printf.sprintf
+               "%s: [runtime].cross_verifier = %S uses model %S, which does \
+                not declare supports-response-format-json"
+               config_path
+               id
+               runtime.model.id)))
 ;;
 
 (* Pure decision for the capability gate, separated from the global OAS catalog

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -360,6 +360,9 @@ let test_librarian_runtime_routing () =
      api-name = \"libr\"\n\
      max-context = 1024\n\
      \n\
+     [models.libr.capabilities]\n\
+     supports-response-format-json = true\n\
+     \n\
      [local.chat]\n\
      \n\
      [local.libr]\n\
@@ -395,6 +398,13 @@ let test_librarian_runtime_routing () =
   with_temp_runtime_toml (base ^ "cross_verifier = \"local.nope\"\n") (fun path ->
     match Runtime.load_list ~config_path:path with
     | Ok _ -> failf "unknown [runtime].cross_verifier id must be rejected at load"
+    | Error _ -> ());
+  with_temp_runtime_toml (base ^ "cross_verifier = \"local.chat\"\n") (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Ok _ ->
+      failf
+        "[runtime].cross_verifier must reject models without JSON response \
+         format support"
     | Error _ -> ())
 
 let () =


### PR DESCRIPTION
Follow-up to #21602 adversarial review.

The merged PR validated only that [runtime].cross_verifier resolves to an existing runtime id. This patch also rejects a selected cross-verifier runtime whose model does not declare supports-response-format-json, keeping the anti-rationalization evaluator from silently routing to a non-JSON model.

Validation:
- git diff --check
- Dune build skipped per operator instruction; full build/CI to cover OCaml compile.