### PR TITLE
fix(fusion): DET/NDT gate — run_id default sound-partial 주석

### DIFF
--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -191,8 +191,11 @@ let block_of_yojson json : chat_block option =
            let meta = Option.value (get_string "meta") ~default:title in
            Some (Link { url; title; meta })))
      | Some "fusion" ->
-       (* board_post_id is the lazy-fetch key and is required; run_id is a
-          display/cross-reference convenience and tolerated as empty. *)
+       (* board_post_id is the lazy-fetch key and is required (Option.bind
+          rejects its absence); run_id is a display/cross-reference convenience.
+          NDT-OK / sound-partial: allow — a missing run_id degrades only the
+          card's run label, not identity, so "" is sound rather than a
+          permissive default over unknown input (mirrors the link arm above). *)
        Option.bind (get_string "board_post_id") (fun board_post_id ->
          let run_id = Option.value (get_string "run_id") ~default:"" in
          Some (Fusion { board_post_id; run_id }))


### PR DESCRIPTION
## 배경

#21611(fusion 채팅 카드)이 컨베이어에 의해 CI 완료 전 머지됐고, 그 후 Meta Guards의 **DET/NDT gate**가 fail했습니다:

```
FAIL: new deterministic-boundary debt added:
origin/main...HEAD: lib/keeper/keeper_chat_blocks.ml:197:
  let run_id = Option.value (get_string "run_id") ~default:"" in
```

## 귀속

진짜 내 코드 지적이 맞습니다 (base-broken 아님). fusion block 디코더가 `run_id` 누락 시 `~default:""`를 쓰는데, 게이트가 "permissive default on unknown input"(CLAUDE.md 안티패턴 #2)으로 잡았습니다.

판단: 이건 **sound-partial**입니다. `board_post_id`(lazy-fetch 키)는 `Option.bind`로 누락을 거부하고, `run_id`는 카드의 표시 라벨 보조값일 뿐 identity가 아닙니다. 누락돼도 라벨만 생략됩니다 (바로 위 `link` arm의 `~default:title`과 동일한 sound-partial 패턴). `run_id option`으로 바꾸는 건 과설계입니다.

## 변경

`keeper_chat_blocks.ml`의 fusion arm 주석에 게이트 ±2라인 윈도우 안으로 `NDT-OK / sound-partial: allow` + 근거 추가.

## 검증
- `bash scripts/ci/check-determinism-contract.sh` → **DET/NDT gate: PASS**
- `ocamlformat` OK, `dune build test/test_keeper_chat_blocks.exe` 컴파일 OK

Fix-forward for #21611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
