### PR TITLE
fix(test): reference Runtime directly in keeper_effective_meta_overlay (main red fix)

### DIFF
--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -7,7 +7,9 @@ module Turn = Masc.Keeper_turn
 module Keeper_tool_surface = Masc.Keeper_tool_surface
 module Keeper_tool_surface_ops = Masc.Keeper_tool_surface_ops
 module Heartbeat_presence = Masc.Keeper_heartbeat_loop_presence
-module Runtime = Masc.Runtime
+(* [Runtime] (init_default) lives in the unwrapped [masc_runtime] library, so it
+   is referenced directly (not via [Masc.]); [Keeper_runtime] (ensure_keeper_meta)
+   lives in the main [masc] library. Same pattern as test_keeper_lifecycle_registry_dispatch. *)
 module Keeper_runtime = Masc.Keeper_runtime
 
 let temp_dir () =


### PR DESCRIPTION
## 목표

main red 복구 (fix-forward). `Error: Unbound module Masc.Runtime`로 `Build and Test`가 실패하던 것을 고친다.

## 원인

#21596("fix(test): split keeper effective meta runtime aliases")이 `test/test_keeper_effective_meta_overlay.ml`에 다음을 넣었다:

```ocaml
-module Runtime = Masc.Keeper_runtime
+module Runtime = Masc.Runtime
+module Keeper_runtime = Masc.Keeper_runtime
```

`init_default`(line 57)는 `Keeper_runtime`이 아니라 진짜 `Runtime`에서 와야 한다는 의도는 맞다. 그러나 `Runtime` 모듈은 `lib/runtime`의 **별도 라이브러리 `masc_runtime`(`wrapped false`)**에 있고, `masc` 라이브러리의 서브모듈이 아니다. 따라서 `Masc.Runtime`은 unbound이고 main build가 깨졌다.

main(9c4691bbfb) `Build and Test` = failure 확인:
```
test/test_keeper_effective_meta_overlay.ml ...
Error: Unbound module Masc.Runtime
```

## 변경

- `test/test_keeper_effective_meta_overlay.ml` — `module Runtime = Masc.Runtime` alias 제거. `masc_runtime`이 `wrapped false`라 `Runtime` 모듈이 전역 노출되므로 `Runtime.init_default`(line 57/59)가 직접 해소된다. 같은 dune `tests` stanza의 `test_keeper_lifecycle_registry_dispatch.ml`(line 80, `module Runtime` alias 없이 `Runtime.init_default` 직접 사용)와 동일한 패턴이다. `Keeper_runtime`(ensure_keeper_meta, line 369)은 그대로 둔다.

## 검증

- 빌드 검증은 CI(`Build and Test`)에 맡긴다.
- 근거: 동일 stanza의 `test_keeper_lifecycle_registry_dispatch`가 alias 없이 `Runtime`을 직접 참조하므로 stanza가 이미 `masc.runtime`을 의존하고 `Runtime`이 전역 노출됨이 보장된다.
