### PR TITLE
fix(keeper): improve result safety in keeper_memory_os_io.ml

### DIFF
--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -5,6 +5,7 @@
     JSONL logs). Reads are bounded tail reads to keep startup cost low. *)
 
 open Keeper_memory_os_types
+open Result.Syntax
 
 let rec ensure_dir path =
   if path = "" || path = Filename.current_dir_name
@@ -349,9 +350,8 @@ let read_facts_all_strict ~keeper_id =
   let rec loop line_number acc = function
     | [] -> Ok (List.rev acc)
     | line :: rest ->
-      (match parse_fact_json_line_strict ~path ~line_number line with
-       | Ok fact -> loop (line_number + 1) (fact :: acc) rest
-       | Error _ as e -> e)
+      let* fact = parse_fact_json_line_strict ~path ~line_number line in
+      loop (line_number + 1) (fact :: acc) rest
   in
   loop 1 [] (read_lines_all path)
 ;;


### PR DESCRIPTION
P2 result-type modernization for `lib/keeper/keeper_memory_os_io.ml`.

## Changes
- Open `Result.Syntax` and rewrite `read_facts_all_strict` to use `let*`, flattening the existing result chain.
- No public `.mli` signatures changed.

## Skipped functions
- `ensure_dir`: used by public `episodes_dir` / `tool_results_dir`; converting to `result` would require breaking API changes.
- `read_facts_for_rewrite`: used by public `cap_facts` and `merge_and_cap_facts`; converting to `result` would require breaking API changes.
- I/O exception re-raises in `append_line` / `write_file_atomically` left as system-level exceptions.

## Validation
- `scripts/dune-local.sh build lib/keeper/keeper_memory_os_io.ml`: OK
- `scripts/dune-local.sh build test/test_keeper_memory_os.exe`: OK
- `test/test_keeper_memory_os.exe`: 1 pre-existing failure in "librarian runtime appends episode bundle" (verified on main; unrelated to this change)
- `ocamlformat --check lib/keeper/keeper_memory_os_io.ml`: OK