### PR TITLE
fix(keeper): improve result safety in lib/keeper/keeper_tool_execute_runtime.ml

### DIFF
--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -338,9 +338,8 @@ let handle_tool_execute_typed
             ()
         else
         let path_missing = pre_dispatch_path_missing ~cwd ir in
-        if Option.is_some path_missing
-        then
-          let missing_path = Option.get path_missing in
+        match path_missing with
+        | Some missing_path ->
           let parent = Filename.dirname missing_path in
           blocked_result
             ~deterministic_reason:Keeper_tool_deterministic_error.Path_not_found
@@ -353,7 +352,7 @@ let handle_tool_execute_typed
             ~alternatives:
               [ Printf.sprintf "Use executable=\"ls\" argv=[%S]." parent ]
             ()
-        else
+        | None ->
           let env_snap =
             Cancel_safe.protect
               ~on_exn:(fun _ -> None)


### PR DESCRIPTION
P2 result modernization for lib/keeper/keeper_tool_execute_runtime.ml.

Changes:
- Replace unsafe Option.get after Option.is_some with a safe match on the option in pre_dispatch_path_missing handling.

Skipped:
- No failwith/invalid_arg/raise conversions: the only raises are Eio.Cancel.Cancelled re-raises, which must propagate.
- No public .mli signature changes.

Validation:
- ocamlformat --check lib/keeper/keeper_tool_execute_runtime.ml: passed
- MASC_DUNE_THROTTLE=0 ./scripts/dune-local.sh build lib/keeper/keeper_tool_execute_runtime.ml: passed
- dune exec test/test_keeper_timing.exe: 5/5 passed
- dune exec test/test_keeper_sandbox_docker_cwd_response.exe: 3/3 passed
- dune exec test/test_keeper_sandbox_docker_route.exe: 22/59 failures (environmental Docker/rg issues, unrelated to change)
- dune exec test/test_keeper_sandbox_read_backend.exe: 10/48 failures (environmental Docker/backend issues, unrelated to change)