### PR TITLE
fix(autonomous): improve result safety in stimulus.ml

### DIFF
--- a/lib/autonomous/stimulus.ml
+++ b/lib/autonomous/stimulus.ml
@@ -1,6 +1,8 @@
 (* Stimulus — Cycle 23 / Tier B6.
    See stimulus.mli for the design rationale. *)
 
+open Result.Syntax
+
 (* ── Source taxonomy ─────────────────────────────────────────────── *)
 
 type source =
@@ -45,20 +47,24 @@ let source_of_string = function
    and violate the "Unknown → Permissive Default" anti-pattern. *)
 let validate_salience s =
   if not (Float.is_finite s) then
-    invalid_arg
-      (Printf.sprintf "Stimulus.make: salience not finite (%f)" s);
-  if s < 0.0 || s > 1.0 then
-    invalid_arg
-      (Printf.sprintf "Stimulus.make: salience out of range [0,1]: %f" s)
+    Error (Printf.sprintf "Stimulus.make: salience not finite (%f)" s)
+  else if s < 0.0 || s > 1.0 then
+    Error (Printf.sprintf "Stimulus.make: salience out of range [0,1]: %f" s)
+  else Ok ()
 
 let validate_id id =
-  if String.length id = 0 then
-    invalid_arg "Stimulus.make: id must be non-empty"
+  if String.length id = 0 then Error "Stimulus.make: id must be non-empty"
+  else Ok ()
 
 let make ~id ~source ~payload ~salience ~timestamp =
-  validate_id id;
-  validate_salience salience;
-  { id; source; payload; salience; timestamp }
+  let () =
+    match validate_id id with
+    | Error msg -> invalid_arg msg
+    | Ok () -> ()
+  in
+  match validate_salience salience with
+  | Error msg -> invalid_arg msg
+  | Ok () -> { id; source; payload; salience; timestamp }
 
 (* ── Scoring ─────────────────────────────────────────────────────── *)
 
@@ -94,7 +100,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
    maps to [Error msg] with a localised reason. The salience and id
    validations re-use the construction-time invariants. *)
 let of_json (j : Yojson.Safe.t) : (t, string) result =
-  let ( let* ) = Result.bind in
   match j with
   | `Assoc fields ->
       let lookup k =
@@ -154,8 +159,9 @@ let of_json (j : Yojson.Safe.t) : (t, string) result =
       in
       (* Re-run construction-time invariants so [of_json |> to_json]
          and [make ...] enforce the same range. *)
-      (try Ok (make ~id ~source ~payload ~salience ~timestamp)
-       with Invalid_argument msg -> Error msg)
+      let* () = validate_id id in
+      let* () = validate_salience salience in
+      Ok { id; source; payload; salience; timestamp }
   | other ->
       Error
         (Printf.sprintf

--- a/lib/autonomous/stimulus.ml
+++ b/lib/autonomous/stimulus.ml
@@ -5,6 +5,8 @@ open Result.Syntax
 
 (* ── Source taxonomy ─────────────────────────────────────────────── *)
 
+open Result.Syntax
+
 type source =
   | User_message [@tla.symbol "user_message"]
   | Memory_recall [@tla.symbol "memory_recall"]
@@ -51,20 +53,24 @@ let validate_salience s =
   else if s < 0.0 || s > 1.0 then
     Error (Printf.sprintf "Stimulus.make: salience out of range [0,1]: %f" s)
   else Ok ()
+;;
 
 let validate_id id =
-  if String.length id = 0 then Error "Stimulus.make: id must be non-empty"
-  else Ok ()
+  if String.length id = 0 then Error "Stimulus.make: id must be non-empty" else Ok ()
+;;
+
+let make_result ~id ~source ~payload ~salience ~timestamp =
+  let open Result.Syntax in
+  let* () = validate_id id in
+  let* () = validate_salience salience in
+  Ok { id; source; payload; salience; timestamp }
+;;
 
 let make ~id ~source ~payload ~salience ~timestamp =
-  let () =
-    match validate_id id with
-    | Error msg -> invalid_arg msg
-    | Ok () -> ()
-  in
-  match validate_salience salience with
+  match make_result ~id ~source ~payload ~salience ~timestamp with
+  | Ok t -> t
   | Error msg -> invalid_arg msg
-  | Ok () -> { id; source; payload; salience; timestamp }
+;;
 
 (* ── Scoring ─────────────────────────────────────────────────────── *)
 
@@ -159,9 +165,7 @@ let of_json (j : Yojson.Safe.t) : (t, string) result =
       in
       (* Re-run construction-time invariants so [of_json |> to_json]
          and [make ...] enforce the same range. *)
-      let* () = validate_id id in
-      let* () = validate_salience salience in
-      Ok { id; source; payload; salience; timestamp }
+      make_result ~id ~source ~payload ~salience ~timestamp
   | other ->
       Error
         (Printf.sprintf

--- a/test/autonomous/test_autonomous_stimulus.ml
+++ b/test/autonomous/test_autonomous_stimulus.ml
@@ -242,6 +242,42 @@ let test_of_json_rejects_out_of_range_salience () =
   in
   match S.of_json j with Ok _ -> assert false | Error _ -> ()
 
+let expect_of_json_error expected json =
+  match S.of_json json with
+  | Ok _ -> assert false
+  | Error actual -> assert (actual = expected)
+
+let expect_of_json_error_prefix expected_prefix json =
+  match S.of_json json with
+  | Ok _ -> assert false
+  | Error actual -> assert (String.starts_with ~prefix:expected_prefix actual)
+
+let test_of_json_rejects_empty_id_with_error () =
+  let j =
+    `Assoc
+      [
+        ("id", `String "");
+        ("source", `String "user_message");
+        ("payload", `Null);
+        ("salience", `Float 0.5);
+        ("timestamp", `Float 0.0);
+      ]
+  in
+  expect_of_json_error "Stimulus.make: id must be non-empty" j
+
+let test_of_json_rejects_nonfinite_salience_with_error () =
+  let j =
+    `Assoc
+      [
+        ("id", `String "x");
+        ("source", `String "user_message");
+        ("payload", `Null);
+        ("salience", `Float Float.infinity);
+        ("timestamp", `Float 0.0);
+      ]
+  in
+  expect_of_json_error_prefix "Stimulus.make: salience not finite" j
+
 let () =
   test_source_to_tla_symbol ();
   test_all_symbols_count ();
@@ -265,4 +301,6 @@ let () =
   test_of_json_rejects_missing_key ();
   test_of_json_rejects_unknown_source ();
   test_of_json_rejects_out_of_range_salience ();
+  test_of_json_rejects_empty_id_with_error ();
+  test_of_json_rejects_nonfinite_salience_with_error ();
   print_endline "test_autonomous_stimulus: all assertions passed"


### PR DESCRIPTION
P2 result modernization for lib/autonomous/stimulus.ml.

- Convert internal [validate_salience] and [validate_id] to return [(unit, string) result].
- Keep [Stimulus.make] signature unchanged; it matches the result and raises [Invalid_argument] on error to preserve the public [.mli] contract.
- Update [of_json] to use [let*] with the result-returning validators instead of [try make ... with Invalid_argument].
- Replace the local [let ( let* ) = Result.bind] with [open Result.Syntax] per MASC convention.

Validation:
- dune build lib/autonomous/stimulus.ml
- dune exec test/autonomous/test_autonomous_stimulus.exe
- ocamlformat --check lib/autonomous/stimulus.ml

Skipped: [make] public signature was not widened to result because that is a breaking change per P2 instructions.