### PR TITLE
feat(dashboard): 도구 거부 목록(tool_denylist) 편집기 + tool_access 타입 정정

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1554,6 +1554,9 @@ describe('fetchKeeperConfig', () => {
     expect(result.hooks?.slots.pre_tool_use?.gates).toEqual(['keeper_deny_list'])
     // deny_list count is derived from the array (deny_list_count field dropped).
     expect(result.hooks?.deny_list).toEqual(['Execute'])
+    // tool_access is a string list (was mistyped as unknown/{}); needed so the
+    // denylist editor can echo it back to set_policy unchanged.
+    expect(result.tools.tool_access).toEqual(['tool_read_file'])
     expect(result.sources.precedence).toEqual(['live_meta'])
     expect(result.metrics.total_cost_usd).toBe(0.12)
     expect(result.runtime.runtime_blocker_class).toBe('stale_fleet_batch')

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2227,7 +2227,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       missing_active_goal_ids: normalizeStringList(workspace.missing_active_goal_ids),
     },
     tools: {
-      tool_access: tools.tool_access ?? {},
+      tool_access: normalizeStringList(tools.tool_access),
       resolved_allowlist: normalizeStringList(tools.resolved_allowlist),
       tool_denylist: normalizeStringList(tools.tool_denylist),
       active_masc_tool_count: asInt(tools.active_masc_tool_count) ?? 0,
@@ -2312,6 +2312,25 @@ export async function patchKeeperConfig(
     `/api/v1/keepers/${encodeURIComponent(name)}/config`,
     payload,
   ).then(raw => normalizeKeeperConfig(raw, name))
+}
+
+// Tool policy is set atomically (tool_access + denylist) via the dedicated
+// /tools endpoint with action=set_policy — a different mutation shape from the
+// /config PATCH above. The caller MUST echo the current tool_access so editing
+// only the denylist does not wipe the keeper's access. The endpoint returns the
+// updated tools block (not the full config), so we re-fetch the config to get a
+// consistent normalized snapshot.
+export async function setKeeperToolPolicy(
+  name: string,
+  policy: { tool_access: string[]; deny: string[] },
+): Promise<KeeperConfig> {
+  await ensureDevToken()
+  await post<unknown>(`/api/v1/keepers/${encodeURIComponent(name)}/tools`, {
+    action: 'set_policy',
+    tool_access: policy.tool_access,
+    deny: policy.deny,
+  })
+  return fetchKeeperConfig(name)
 }
 
 // --- Runtime config (raw runtime.toml editor) ---

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -530,6 +530,7 @@ const mocks = vi.hoisted(() => ({
   })),
   patchKeeperConfig: vi.fn(),
   updateKeeperRuntime: vi.fn(async () => ({ ok: true })),
+  setKeeperToolPolicy: vi.fn(async () => makeKeeperConfig()),
 }))
 
 vi.mock('../api/dashboard', () => ({
@@ -538,6 +539,7 @@ vi.mock('../api/dashboard', () => ({
   fetchKeeperConfig: mocks.fetchKeeperConfig,
   patchKeeperConfig: mocks.patchKeeperConfig,
   updateKeeperRuntime: mocks.updateKeeperRuntime,
+  setKeeperToolPolicy: mocks.setKeeperToolPolicy,
 }))
 
 import { KeeperConfigPanel, loadKeeperConfig, resetKeeperConfig } from './keeper-config-panel'
@@ -626,6 +628,39 @@ describe('KeeperConfigPanel', () => {
     expect(tokenGateInput!.type).toBe('number')
     // Value reflects the loaded config (makeKeeperConfig compaction.token_gate = 24000).
     expect(tokenGateInput!.value).toBe('24000')
+  })
+
+  it('saves the tool denylist via set_policy, echoing current tool_access and deduping entries', async () => {
+    mocks.setKeeperToolPolicy.mockClear()
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    const denylist = container.querySelector(
+      'textarea[aria-label="tool_denylist"]',
+    ) as HTMLTextAreaElement | null
+    expect(denylist).not.toBeNull()
+    expect(denylist!.value).toBe('Execute') // reflects loaded tool_denylist
+
+    // Operator edits: add a tool, with a blank line and a duplicate.
+    denylist!.value = 'Execute\nmcp__masc__masc_board_delete\nExecute\n'
+    denylist!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('정책 저장'),
+    )
+    expect(saveButton).toBeTruthy()
+    saveButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    await flush()
+
+    // Safety: set_policy sets tool_access AND deny atomically, so the current
+    // tool_access must be echoed unchanged; the deny list is trimmed + deduped.
+    expect(mocks.setKeeperToolPolicy).toHaveBeenCalledWith('keeper-sangsu', {
+      tool_access: ['tool_read_file'],
+      deny: ['Execute', 'mcp__masc__masc_board_delete'],
+    })
   })
 
   it('patches runtime_id from the dashboard panel', async () => {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -9,6 +9,7 @@ import {
   fetchDashboardGoalsTree,
   fetchKeeperConfig,
   patchKeeperConfig,
+  setKeeperToolPolicy,
 } from '../api/dashboard'
 import type { KeeperConfigUpdatePayload, SandboxProfile, SandboxNetworkMode, SharedMemoryScope } from '../api/dashboard'
 import type { GoalTreeNode, KeeperConfig, KeeperHookSlot } from '../types'
@@ -182,6 +183,11 @@ export type RuntimeDraft = {
 
 const runtimeDraft = signal<RuntimeDraft | null>(null)
 const runtimeSaving = signal(false)
+// Tool denylist is saved via the separate /tools set_policy endpoint (not the
+// /config PATCH), so it has its own draft/saving state. null draft = "show the
+// live denylist"; a string = the operator's in-progress edit.
+const denylistDraftText = signal<string | null>(null)
+const denylistSaving = signal(false)
 
 export function coerceSandboxProfile(raw: string | undefined): SandboxProfile {
   return raw === 'docker' ? 'docker' : 'local'
@@ -332,6 +338,8 @@ export function resetKeeperConfig(): void {
   promptPreviewTab.value = 'blocks'
   runtimeDraft.value = null
   runtimeSaving.value = false
+  denylistDraftText.value = null
+  denylistSaving.value = false
   hookFilterQuery.value = ''
   globalArchExpanded.value = false
 }
@@ -702,6 +710,33 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
   function resetRuntimeDraft() {
     runtimeDraft.value = initRuntimeDraftFromConfig(c)
+  }
+
+  // Parse the denylist textarea into a deduped, trimmed tool-name list.
+  function parseDenylistDraft(text: string): string[] {
+    return [...new Set(text.split('\n').map((s) => s.trim()).filter(Boolean))]
+  }
+
+  async function saveToolDenylist() {
+    const text = denylistDraftText.value
+    if (text === null) return
+    const deny = parseDenylistDraft(text)
+    denylistSaving.value = true
+    try {
+      // Echo the current tool_access so set_policy (which sets access AND deny
+      // atomically) does not wipe the keeper's tool access.
+      const updated = await setKeeperToolPolicy(keeperName, {
+        tool_access: c.tools.tool_access,
+        deny,
+      })
+      configState.value = loaded(updated)
+      denylistDraftText.value = null
+      showToast('도구 거부 목록 저장 완료', 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : '저장 실패', 'error')
+    } finally {
+      denylistSaving.value = false
+    }
   }
 
   function enterEditMode() {
@@ -1144,6 +1179,41 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           >초기화하기</button>
         </div>
       ` : null}
+
+      ${(() => {
+        const denyText = denylistDraftText.value ?? c.tools.tool_denylist.join('\n')
+        const deduped = parseDenylistDraft(denyText)
+        const changed = JSON.stringify(deduped) !== JSON.stringify(c.tools.tool_denylist)
+        return html`
+          <${SectionHeader} title="도구 거부 목록 (정책)" />
+          <p class="text-3xs text-text-muted mb-2 px-1 leading-relaxed">
+            이 keeper가 사용할 수 없는 도구 이름(한 줄에 하나). 저장 시 set_policy 로 적용되며 현재 도구 접근(tool_access ${c.tools.tool_access.length}개)은 보존됩니다.
+          </p>
+          <div class="py-2.5 px-4 rounded-[var(--r-1)] bg-[var(--color-bg-surface)] mb-2 ${changed ? 'border-l-4 border-l-[var(--color-accent-fg)]' : ''} v2-monitoring-panel">
+            <textarea aria-label="tool_denylist" class="w-full text-sm font-mono bg-[var(--color-bg-hover)] border border-[var(--color-border-default)] rounded-[var(--r-1)] px-3 py-2 text-[var(--color-fg-secondary)] resize-y"
+              rows=${4}
+              value=${denyText}
+              placeholder="예: Execute"
+              onInput=${(e: Event) => { denylistDraftText.value = (e.target as HTMLTextAreaElement).value }}
+            ></textarea>
+            <div class="flex items-center gap-2 mt-2">
+              <span class="text-3xs text-text-muted">${deduped.length} deny</span>
+              <div class="flex-1"></div>
+              <button type="button"
+                class="${BTN_FILLED_BASE} bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)] text-xs"
+                onClick=${saveToolDenylist}
+                disabled=${denylistSaving.value || !changed}
+              >${denylistSaving.value ? '저장 중...' : '정책 저장'}</button>
+              <button type="button"
+                class="${BTN_FILLED_BASE} bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)] text-xs"
+                title="초기화: 편집한 거부 목록을 서버 값으로 되돌립니다"
+                onClick=${() => { denylistDraftText.value = null }}
+                disabled=${denylistSaving.value || !changed}
+              >초기화하기</button>
+            </div>
+          </div>
+        `
+      })()}
 
       ${c.hooks ? (() => {
         const allEntries: readonly HookSlotEntry[] = Object.entries(c.hooks.slots) as HookSlotEntry[]

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -31,7 +31,7 @@ describe('resolveKeeperToolPolicy', () => {
   it('uses keeper config as the authoritative policy source', () => {
     const keeperConfig = {
       tools: {
-        tool_access: {},
+        tool_access: [],
         resolved_allowlist: ['mcp__masc__masc_board_post'],
         tool_denylist: ['mcp__masc__masc_board_delete'],
         active_masc_tool_count: 1,

--- a/dashboard/src/components/keeper-detail-source.test.ts
+++ b/dashboard/src/components/keeper-detail-source.test.ts
@@ -47,7 +47,7 @@ describe('resolveKeeperToolPolicy', () => {
   it('defaults resolved allowlist to an empty array when missing', () => {
     const config = {
       tools: {
-        tool_access: {},
+        tool_access: [],
       },
     } as unknown as Pick<KeeperConfig, 'tools'>
     const result = resolveKeeperToolPolicy(config, 'loaded')
@@ -57,7 +57,7 @@ describe('resolveKeeperToolPolicy', () => {
   it('prefers tools over load status', () => {
     const config = {
       tools: {
-        tool_access: {},
+        tool_access: [],
       },
     } as unknown as Pick<KeeperConfig, 'tools'>
     // Even with error status, tools present means keeper_config

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1443,7 +1443,10 @@ interface KeeperConfigWorkspace {
 }
 
 export interface KeeperConfigTools {
-  tool_access: unknown
+  // Raw configured tool-access allowlist (tool-name strings). The backend
+  // serialises this as a JSON string list (Json_util.json_string_list); the
+  // earlier `unknown` typing masked that and left it unread.
+  tool_access: string[]
   resolved_allowlist: string[]
   tool_denylist: string[]
   active_masc_tool_count: number


### PR DESCRIPTION
slot 시스템 감사 C 단계 — "숨은 컨트롤 노출" 중 tool_denylist. (사용자 선택: tool_denylist 편집기만)

## 배경 (E5 + 조사)
config 패널은 tool_denylist를 **읽기전용 카운트**로만 표시. backend write 경로(`POST /api/v1/keepers/<name>/tools` `{action:"set_policy", tool_access, deny}`)는 존재하나 **대시보드 호출자 0건** → 편집 불가. ("노출"이 아니라 신규 편집기 구축)

## 변경
- `setKeeperToolPolicy(name, {tool_access, deny})`: set_policy POST → config refetch(엔드포인트가 tools 블록만 반환).
- **"도구 거부 목록 (정책)"** textarea 편집기(개행 구분, dedup/trim) + 자체 저장/초기화. allowed_paths 패턴 미러링.
- **tool_access 타입 정정**: backend는 string list(`Json_util.json_string_list`)로 직렬화하는데 대시보드가 `unknown`→`{}`로 오타입/오정규화(아무도 안 읽어 무해했음). `string[]` + `normalizeStringList`로 수정. 구 `{}` 픽스처 2건 정정.

## 안전 설계 (핵심)
set_policy는 tool_access와 tool_denylist를 **원자적으로 함께** 설정합니다. denylist만 편집해도 keeper의 도구 접근이 지워지지 않도록, 편집기는 **현재 tool_access를 그대로 echo**합니다. 테스트가 이 echo를 검증:
`setKeeperToolPolicy('keeper-sangsu', { tool_access: ['tool_read_file'], deny: [...dedup/trim] })`.

## 로컬 검증
- `tsc` 0 / `eslint` 0 errors / `vitest` 140 passed (5 files) — denylist 저장/echo 동작 + tool_access string[] 파싱 포함.

## 범위 밖 (보고)
- **mention_targets**: meta는 지원하나 대시보드 write 엔드포인트 미확인 → backend 확장 필요. 별도 결정.

## slot 감사 시리즈
#21587(머지)·#21597(머지)·#21604(introspection 정리)·#21608(compaction token gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)