### PR TITLE
feat(dashboard): add standalone Approvals surface (keeper HITL queue)

### DIFF
--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -1,0 +1,130 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import * as Vitest from 'vitest'
+import type { DashboardGovernanceResponse, KeeperApprovalQueueItem } from '../../types'
+
+const { afterEach, beforeEach, describe, expect, it, vi } = Vitest
+
+async function flushUi(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+}
+
+function queueItem(overrides: Partial<KeeperApprovalQueueItem> & { id: string }): KeeperApprovalQueueItem {
+  return {
+    keeper_name: 'keeper-x',
+    tool_name: 'fs_write',
+    risk_level: 'critical',
+    waiting_s: 92,
+    input_preview: 'echo hello > /etc/config',
+    task_id: 'T-1',
+    ...overrides,
+  }
+}
+
+function responseWithQueue(approval_queue: KeeperApprovalQueueItem[]): DashboardGovernanceResponse {
+  return {
+    generated_at: '2026-06-19T00:00:00Z',
+    summary: { judge_online: false },
+    items: [],
+    activity: [],
+    judgments: [],
+    pending_actions: [],
+    approval_queue,
+  } as DashboardGovernanceResponse
+}
+
+// Mirrors governance.test.ts loadComponentWithApi: mock the api seam that
+// refreshGovernance() reaches on mount, plus the sse-store refresh registry.
+async function loadSurface(approval_queue: KeeperApprovalQueueItem[]) {
+  vi.resetModules()
+  const resolveGovernanceApproval = vi
+    .fn()
+    .mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' })
+  vi.doMock('../../api', () => ({
+    decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
+    fetchDashboardGovernance: vi.fn().mockResolvedValue(responseWithQueue(approval_queue)),
+    fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(null),
+    resolveGovernanceApproval,
+    deleteGovernanceApprovalRule: vi.fn().mockResolvedValue({ ok: true }),
+    submitGovernanceCaseBrief: vi.fn().mockResolvedValue(null),
+    submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'x' } }),
+  }))
+  vi.doMock('../../sse-store', () => ({ registerGovernanceRefresh: vi.fn() }))
+  const mod = await import('./approvals-surface')
+  return { ApprovalsSurface: mod.ApprovalsSurface, resolveGovernanceApproval }
+}
+
+describe('ApprovalsSurface', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.doUnmock('../../api')
+    vi.doUnmock('../../sse-store')
+  })
+
+  it('renders a card per pending approval bound to the live queue fields', async () => {
+    const { ApprovalsSurface } = await loadSurface([
+      queueItem({ id: 'appr-1', keeper_name: 'masc-improver', tool_name: 'fs_write', risk_level: 'critical' }),
+      queueItem({ id: 'appr-2', keeper_name: 'issue-king', tool_name: 'shell', risk_level: 'low', waiting_s: 12 }),
+    ])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="approvals-surface"]')).not.toBeNull()
+    const cards = container.querySelectorAll('[data-testid="approval-card"]')
+    expect(cards.length).toBe(2)
+    expect(container.textContent).toContain('masc-improver')
+    expect(container.textContent).toContain('fs_write')
+    // risk_level is surfaced uppercased on the .ap-kind badge
+    expect(container.textContent).toContain('CRITICAL')
+    expect(container.textContent).toContain('LOW')
+    // the three live decisions are exposed; the prototype's defer/undo are not
+    expect(container.textContent).toContain('승인')
+    expect(container.textContent).toContain('항상 승인')
+    expect(container.textContent).toContain('거부')
+    expect(container.textContent).not.toContain('보류')
+    expect(container.textContent).not.toContain('되돌리기')
+    // KPI strip counts the queue
+    expect(container.querySelector('[data-testid="approvals-queue"]')).not.toBeNull()
+  }, 20000)
+
+  it('shows the empty state when no approvals are pending', async () => {
+    const { ApprovalsSurface } = await loadSurface([])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="approvals-empty"]')).not.toBeNull()
+    expect(container.textContent).toContain('열린 승인이 없습니다')
+    expect(container.querySelector('[data-testid="approvals-queue"]')).toBeNull()
+  })
+
+  it('routes the 승인 action through respondToKeeperApproval → resolveGovernanceApproval', async () => {
+    const { ApprovalsSurface, resolveGovernanceApproval } = await loadSurface([
+      queueItem({ id: 'appr-9', keeper_name: 'masc-improver' }),
+    ])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const approveBtn = container.querySelector<HTMLButtonElement>('.ap-card .ap-act.approve')
+    expect(approveBtn).not.toBeNull()
+    approveBtn?.click()
+    await flushUi()
+
+    expect(resolveGovernanceApproval).toHaveBeenCalledWith('appr-9', 'approve', false)
+  })
+})

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -1,0 +1,207 @@
+// MASC Dashboard — Approvals Surface
+// Dedicated operator view of the Keeper HITL approval queue: keeper tool calls
+// gated above the risk threshold wait here for an approve / approve+always / reject
+// decision. This is a focused, standalone surface; the broader Governance panel
+// (Command surface) keeps its rules/decisions/monitoring role and shares the SAME
+// underlying signal + action, so resolving here updates both.
+//
+// Data source: governanceData.value?.approval_queue (KeeperApprovalQueueItem[]).
+// Actions: respondToKeeperApproval(id, 'approve' | 'reject', rememberRule).
+// The live decision model is the closed set {approve, reject} (+ rememberRule);
+// there is no defer/undo endpoint, so the prototype's 보류/되돌리기/처리이력 are
+// intentionally not rendered. Visual layout ports the keeper-v2 .ap-* design.
+
+import { html } from 'htm/preact'
+import { useEffect, useMemo } from 'preact/hooks'
+import type { KeeperApprovalQueueItem } from '../../types'
+import { TELEMETRY_AUTO_REFRESH_MS } from '../../config/constants'
+import { setupVisibleAutoRefresh } from '../../lib/auto-refresh'
+import { navigate } from '../../router'
+import { AgentAvatar } from '../overview/agent-avatar'
+import {
+  governanceData,
+  governanceError,
+  governanceApprovalActing,
+  refreshGovernance,
+  respondToKeeperApproval,
+} from '../governance-store'
+
+type Sev = 'bad' | 'warn' | 'info'
+
+// risk_level → prototype severity rail. critical/high are the irreversible-risk
+// band; medium warns; low/unknown is informational. Mirrors the live
+// approvalRiskToneClass banding (governance.ts) but emits the .ap- sev token.
+function apSev(riskLevel: string | null | undefined): Sev {
+  const r = (riskLevel ?? '').trim().toLowerCase()
+  if (r === 'critical' || r === 'high') return 'bad'
+  if (r === 'medium') return 'warn'
+  return 'info'
+}
+
+// seconds-waited → "N분 N초 대기" (prototype apAge).
+function apAge(sec: number | null | undefined): string {
+  const s = Math.max(0, Math.round(sec ?? 0))
+  const m = Math.floor(s / 60)
+  const r = s % 60
+  return m ? `${m}분 ${r}초 대기` : `${r}초 대기`
+}
+
+// Open this keeper's workspace conversation (work.ts idiom).
+function openKeeperWorkspace(name: string): void {
+  navigate('monitoring', { section: 'agents', view: 'keepers', keeper: name })
+}
+
+function ApprovalCard({ item }: { item: KeeperApprovalQueueItem }) {
+  const sev = apSev(item.risk_level)
+  const actingId = governanceApprovalActing.value
+  const busy = actingId === item.id
+  const anyBusy = Boolean(actingId)
+  const title = item.action_key?.trim() || `${item.tool_name} 실행 승인 요청`
+  const sandbox = item.runtime_contract?.sandbox_profile?.trim() || item.sandbox_target?.trim() || null
+  const detailReason = item.disposition_reason?.trim() || null
+
+  return html`
+    <article class=${`ap-card sev-${sev}`} data-testid="approval-card" data-approval-id=${item.id}>
+      <div class="ap-rail"></div>
+      <div class="ap-main">
+        <div class="ap-h">
+          <span class=${`ap-kind sev-${sev}`}>${(item.risk_level ?? 'unknown').toUpperCase()}</span>
+          <span class="ap-tool mono">${item.tool_name}</span>
+          <span class="ap-id mono">${item.id}</span>
+          <span class=${`ap-age sev-${sev}`}>${apAge(item.waiting_s)}</span>
+        </div>
+        <h3 class="ap-title">${title}</h3>
+        ${detailReason ? html`<p class="ap-detail">${detailReason}</p>` : null}
+        <div class="ap-req">
+          <${AgentAvatar} name=${item.keeper_name} size="sm" />
+          <div class="ap-req-body">
+            <div class="ap-req-who">
+              <button
+                type="button"
+                class="ap-klink"
+                onClick=${() => openKeeperWorkspace(item.keeper_name)}
+                title=${`${item.keeper_name} 대화 열기`}
+              >${item.keeper_name}</button>
+              ${item.task_id || item.goal_id
+                ? html`<button
+                    type="button"
+                    class="ap-req-goal mono"
+                    onClick=${() => navigate('workspace', { section: 'work' })}
+                    title="작업 보기"
+                  >${[item.task_id ? `task ${item.task_id}` : null, item.goal_id ? `goal ${item.goal_id}` : null]
+                    .filter(Boolean)
+                    .join(' · ')}</button>`
+                : null}
+              ${sandbox ? html`<span class="ap-req-goal mono">sandbox ${sandbox}</span>` : null}
+            </div>
+            <div class="ap-req-quote">
+              ${item.input_preview?.trim() ? `“${item.input_preview.trim()}”` : '입력 미리보기 없음'}
+            </div>
+          </div>
+        </div>
+        <div class="ap-actions">
+          <button
+            type="button"
+            class="ap-act approve"
+            onClick=${() => void respondToKeeperApproval(item.id, 'approve')}
+            disabled=${anyBusy}
+          >${busy ? '처리 중…' : '승인'}</button>
+          <button
+            type="button"
+            class="ap-act always"
+            onClick=${() => void respondToKeeperApproval(item.id, 'approve', true)}
+            title="승인하고 동일 요청을 자동 승인하는 Always 규칙을 저장합니다"
+            disabled=${anyBusy}
+          >${busy ? '처리 중…' : '항상 승인'}</button>
+          <button
+            type="button"
+            class="ap-act deny"
+            onClick=${() => void respondToKeeperApproval(item.id, 'reject')}
+            disabled=${anyBusy}
+          >${busy ? '처리 중…' : '거부'}</button>
+          <button
+            type="button"
+            class="ap-act ghost"
+            onClick=${() => openKeeperWorkspace(item.keeper_name)}
+            title="맥락 보기"
+            disabled=${anyBusy}
+          >대화에서 검토 →</button>
+        </div>
+      </div>
+    </article>
+  `
+}
+
+export function ApprovalsSurface() {
+  useEffect(() => {
+    void refreshGovernance()
+    const disposeAutoRefresh = setupVisibleAutoRefresh(refreshGovernance, TELEMETRY_AUTO_REFRESH_MS)
+    return () => {
+      disposeAutoRefresh()
+    }
+  }, [])
+
+  const items = governanceData.value?.approval_queue ?? []
+  const error = governanceError.value
+
+  const stats = useMemo(() => {
+    const risky = items.filter(i => apSev(i.risk_level) === 'bad').length
+    const longest = items.reduce((max, i) => Math.max(max, i.waiting_s ?? 0), 0)
+    const keepers = new Set(items.map(i => i.keeper_name)).size
+    return { risky, longest, keepers }
+  }, [items])
+
+  return html`
+    <main class="ov ss-surface bg-surface-page text-text-primary" data-testid="approvals-surface">
+      <div class="ov-scroll">
+        <header class="ov-head">
+          <div>
+            <h1>승인 · HITL 큐</h1>
+            <p class="ov-sub">
+              keeper가 위험·비가역 행동 전 결재를 청한 항목 ·
+              <span title="감독자가 보는 단일 결재 지점">operator가 직접 승인·거부</span>
+            </p>
+          </div>
+          ${items.length > 0
+            ? html`<span class="ap-sla mono" title="가장 오래 대기 중인 건">최장 대기 ${apAge(stats.longest)}</span>`
+            : null}
+        </header>
+
+        ${error ? html`<div class="ap-error" data-testid="approvals-error">${error}</div>` : null}
+
+        <section class="ov-kpis" style=${{ gridTemplateColumns: 'repeat(4, 1fr)' }}>
+          <div class="ov-kpi">
+            <div class="ov-kpi-k">열린 승인</div>
+            <div class=${`ov-kpi-v ${items.length ? 'warn' : 'ok'}`}>${items.length}</div>
+          </div>
+          <div class="ov-kpi">
+            <div class="ov-kpi-k">위험 · 높음</div>
+            <div class=${`ov-kpi-v ${stats.risky ? 'bad' : ''}`}>${stats.risky}</div>
+          </div>
+          <div class="ov-kpi">
+            <div class="ov-kpi-k">최장 대기</div>
+            <div class="ov-kpi-v">${items.length ? apAge(stats.longest) : '—'}</div>
+          </div>
+          <div class="ov-kpi">
+            <div class="ov-kpi-k">관련 키퍼</div>
+            <div class="ov-kpi-v volt">${stats.keepers}</div>
+          </div>
+        </section>
+
+        ${items.length === 0
+          ? html`
+              <div class="ap-clear" data-testid="approvals-empty">
+                <div class="ico">${'✓'}</div>
+                <h3>열린 승인이 없습니다</h3>
+                <div class="ap-clear-sub">HITL 큐가 비어 있습니다 — keeper들이 결재 대기 없이 진행 중입니다.</div>
+              </div>
+            `
+          : html`
+              <div class="ap-queue" data-testid="approvals-queue">
+                ${items.map(item => html`<${ApprovalCard} key=${item.id} item=${item} />`)}
+              </div>
+            `}
+      </div>
+    </main>
+  `
+}

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -42,6 +42,7 @@ import { ErrorPanel } from './common/error-panel'
 import { Bell } from 'lucide-preact'
 import { ringFocusClasses } from './common/ring'
 import { SurfaceIcon } from './surface-icon'
+import { governanceData } from './governance-signals'
 import { Breadcrumb, type BreadcrumbItem } from './common/breadcrumb'
 import { RouteLink } from './common/route-link'
 import {
@@ -75,6 +76,7 @@ const LazyLogViewer = lazy(async () => ({ default: (await import('./logs')).LogV
 const LazyIdeShell = lazy(async () => ({ default: (await import('./ide/ide-shell')).IdeShell }))
 const LazyCockpit = lazy(async () => ({ default: (await import('./cockpit/cockpit')).Cockpit }))
 const LazySettingsSurface = lazy(async () => ({ default: (await import('./settings-surface')).SettingsSurface }))
+const LazyApprovals = lazy(async () => ({ default: (await import('./approvals/approvals-surface')).ApprovalsSurface }))
 
 function lazyTabFallback(label: string) {
   return html`<${LoadingState}>Loading ${label}...<//>`
@@ -1072,6 +1074,9 @@ export function SideRail({
 }) {
   const currentTab = route.value.tab
   const currentSection = currentSectionForRoute(route.value)
+  // Open keeper-approval count for the Approvals nav badge. Same signal the
+  // Approvals/Command surfaces read, so the badge tracks resolutions live.
+  const openApprovals = governanceData.value?.approval_queue?.length ?? 0
   const settingsSurface = DASHBOARD_SURFACES.find(surface => surface.id === 'settings')
   const visibleSurfaces = primaryOnly
     ? PRIMARY_DASHBOARD_SURFACES.filter(surface => surface.id !== 'settings')
@@ -1116,8 +1121,11 @@ export function SideRail({
                   aria-label=${surface.label}
                   ariaCurrent=${isSurfaceActive ? 'page' : undefined}
                 >
-                  <span class="nav-icon" aria-hidden="true"><${SurfaceIcon} icon=${surface.icon} size=${15} /></span>
-                  <span class="sr-only">${surface.label}</span>
+                  <span class="nav-icon ${surface.id === 'approvals' && openApprovals > 0 ? 'relative' : ''}" aria-hidden="true">
+                    <${SurfaceIcon} icon=${surface.icon} size=${15} />
+                    ${surface.id === 'approvals' && openApprovals > 0 ? html`<span class="ap-nav-dot"></span>` : null}
+                  </span>
+                  <span class="sr-only">${surface.label}${surface.id === 'approvals' && openApprovals > 0 ? ` (${openApprovals} 대기)` : ''}</span>
                 <//>
               `
             }
@@ -1136,6 +1144,9 @@ export function SideRail({
                   <div class="nav-label flex-1 min-w-0">
                     <div class="truncate font-mono text-[var(--fs-11)] font-semibold uppercase leading-4 tracking-[var(--track-caps)] ${isSurfaceActive ? 'text-[var(--select)]' : ''}">${surface.label}</div>
                   </div>
+                  ${surface.id === 'approvals' && openApprovals > 0
+                    ? html`<span class="ap-nav-badge" data-testid="approvals-nav-badge" title=${`${openApprovals}건 승인 대기`}>${openApprovals}</span>`
+                    : null}
                 <//>
 
                 ${sections.length > 1 ? html`
@@ -1219,6 +1230,12 @@ function TabContent() {
       return html`
         <${Suspense} fallback=${lazyTabFallback('Board')}>
           <${LazyBoardSurface} />
+        <//>
+      `
+    case 'approvals':
+      return html`
+        <${Suspense} fallback=${lazyTabFallback('Approvals')}>
+          <${LazyApprovals} />
         <//>
       `
     case 'workspace':

--- a/dashboard/src/components/surface-icon.ts
+++ b/dashboard/src/components/surface-icon.ts
@@ -9,6 +9,7 @@ import {
   Plug,
   ScrollText,
   Settings,
+  ShieldCheck,
   SquareKanban,
   UsersRound,
 } from 'lucide-preact'
@@ -30,6 +31,8 @@ export function SurfaceIcon({ icon, size = 16 }: SurfaceIconProps) {
       return html`<${UsersRound} ...${props} />`
     case 'board':
       return html`<${SquareKanban} ...${props} />`
+    case 'approvals':
+      return html`<${ShieldCheck} ...${props} />`
     case 'command':
       return html`<${Gauge} ...${props} />`
     case 'connectors':

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -66,6 +66,7 @@ describe('dashboard surface navigation', () => {
       'workspace',
       'keepers',
       'board',
+      'approvals',
       'code',
       'connectors',
       'settings',
@@ -76,6 +77,7 @@ describe('dashboard surface navigation', () => {
       'Work',
       'Keepers',
       'Board',
+      'Approvals',
       'IDE',
       'Connectors',
       'Settings',
@@ -84,7 +86,7 @@ describe('dashboard surface navigation', () => {
   })
 
   it('uses one sectionless-surface classifier for section stripping and section lookup', () => {
-    const sectionless = ['overview', 'logs', 'settings', 'keepers', 'board'] as const
+    const sectionless = ['overview', 'logs', 'settings', 'keepers', 'board', 'approvals'] as const
     expect(sectionless.filter(id => isSectionlessSurface(id))).toEqual([...sectionless])
     expect(sectionItemsForTab('settings')).toEqual([])
     expect(normalizeRouteParams('settings', { section: 'legacy', surface: 'old', panel: 'theme' })).toEqual({

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -13,6 +13,7 @@ export type DashboardSurfaceIcon =
   | 'code'
   | 'logs'
   | 'settings'
+  | 'approvals'
 
 type SurfaceSectionId =
   // monitoring
@@ -81,6 +82,7 @@ const V2_PRIMARY_SURFACE_IDS: ReadonlyArray<SurfaceId> = [
   'workspace',
   'keepers',
   'board',
+  'approvals',
   'code',
   'connectors',
   'settings',
@@ -102,6 +104,7 @@ const SECTIONLESS_SURFACE_IDS: ReadonlySet<TabId> = new Set([
   'settings',
   'keepers',
   'board',
+  'approvals',
 ])
 
 export function isSectionlessSurface(tabId: TabId): boolean {
@@ -151,6 +154,14 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     description: 'Human, agent, automation, and system posts',
     defaultTab: 'board',
     tabs: ['board'],
+  },
+  {
+    id: 'approvals',
+    label: 'Approvals',
+    icon: 'approvals',
+    description: 'Keeper HITL approval queue — pending tool-call gates',
+    defaultTab: 'approvals',
+    tabs: ['approvals'],
   },
   {
     id: 'command',
@@ -241,6 +252,9 @@ export const PRIMARY_DASHBOARD_NAV_ITEMS: DashboardNavItem[] =
 
 export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavItem[]> = {
   cockpit: [],
+  // Sectionless surface (single tab, no sub-sections) but still a NonHomeTabId
+  // key — the Record is exhaustive over the union, so the empty entry is required.
+  approvals: [],
   monitoring: [
     {
       id: 'agents',

--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -1,0 +1,70 @@
+/* ════════════════════════════════════════════════════════════════
+   APPROVALS — Keeper HITL 결재 큐 (v2 surface)
+   Ported from the keeper-v2 prototype (styles/surfaces.css §APPROVALS).
+   Reuses the shared .ov-* overview classes (already defined live in
+   surfaces-v2.css) for the surface shell, header, and KPI strip.
+   Auto-imported via the *-v2.css glob in main.ts — do not add an import line.
+
+   Adapted to the live model: the live keeper-approval decision set is the
+   closed {approve, reject} + approve-with-rule. The prototype's defer/undo
+   and the resolved-history log have no backing endpoint, so those rules are
+   intentionally omitted here (a defer button would post nowhere). The third
+   action is the live "항상 승인"(Approve+Always rule) → .ap-act.always.
+   ════════════════════════════════════════════════════════════════ */
+
+.ap-sla { font-size: 11px; color: var(--status-warn); border: 1px solid color-mix(in oklab, var(--status-warn) 35%, var(--border-main)); background: color-mix(in oklab, var(--status-warn) 8%, transparent); padding: 4px 10px; border-radius: var(--radius-pill); white-space: nowrap; }
+
+.ap-queue { display: flex; flex-direction: column; gap: 10px; margin-bottom: 22px; }
+.ap-card { display: flex; background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: hidden; transition: border-color 0.16s; }
+.ap-card:hover { border-color: var(--border-highlight); }
+.ap-card .ap-rail { flex: none; width: 3px; background: var(--border-main); }
+.ap-card.sev-bad  .ap-rail { background: var(--status-bad); }
+.ap-card.sev-warn .ap-rail { background: var(--status-warn); }
+.ap-card.sev-info .ap-rail { background: var(--volt-dim); }
+.ap-card.sev-bad { border-color: color-mix(in oklab, var(--status-bad) 32%, var(--border-main)); background: linear-gradient(100deg, color-mix(in oklab, var(--status-bad) 6%, var(--bg-panel)), var(--bg-panel) 60%); }
+.ap-main { flex: 1; min-width: 0; padding: 13px 16px 14px; }
+
+.ap-h { display: flex; align-items: center; gap: 9px; }
+.ap-kind { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 7px; border-radius: var(--radius-xs); border: 1px solid var(--border-main); color: var(--text-mid); white-space: nowrap; }
+.ap-kind.sev-bad  { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); background: color-mix(in oklab, var(--status-bad) 9%, transparent); }
+.ap-kind.sev-warn { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 42%, transparent); background: color-mix(in oklab, var(--status-warn) 7%, transparent); }
+.ap-kind.sev-info { color: var(--volt-strong); border-color: var(--volt-dim); background: var(--volt-wash); }
+.ap-tool { font-size: 10px; color: var(--text-dim); }
+.ap-id { font-size: 10px; color: var(--text-dim); margin-left: auto; letter-spacing: 0.06em; }
+.ap-age { font-size: 10px; font-family: var(--font-mono); color: var(--text-dim); white-space: nowrap; }
+.ap-age.sev-bad { color: var(--status-bad); } .ap-age.sev-warn { color: var(--status-warn); }
+
+.ap-title { font-family: var(--font-display); font-weight: 500; font-size: 15px; color: var(--text-bright); margin: 9px 0 4px; line-height: 1.35; }
+.ap-detail { font-size: 12px; color: var(--text-mid); line-height: 1.55; margin: 0 0 11px; }
+
+.ap-req { display: flex; gap: 10px; padding: 10px 12px; background: var(--bg-sunken); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); margin-bottom: 12px; }
+.ap-req-body { min-width: 0; flex: 1; }
+.ap-req-who { display: flex; align-items: center; gap: 8px; margin-bottom: 3px; }
+.ap-klink { font-family: var(--font-display); font-weight: 600; font-size: 12px; color: var(--text-bright); background: none; border: 0; padding: 0; cursor: pointer; }
+.ap-klink:hover { color: var(--volt-strong); }
+.ap-req-goal { font-size: 10px; color: var(--text-dim); cursor: pointer; background: none; border: 0; padding: 0; font-family: var(--font-mono); }
+.ap-req-goal:hover { color: var(--volt-strong); }
+.ap-req-quote { font-size: 12.5px; color: var(--text-primary); line-height: 1.5; font-style: italic; word-break: break-word; }
+
+.ap-actions { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
+.ap-act { font-family: var(--font-ui); font-size: 11.5px; letter-spacing: 0.04em; padding: 7px 16px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-mid); cursor: pointer; transition: 0.14s; }
+.ap-act:disabled { opacity: 0.5; cursor: default; }
+.ap-act.approve { border-color: color-mix(in oklab, var(--status-ok) 50%, transparent); color: var(--status-ok); }
+.ap-act.approve:hover:not(:disabled) { background: color-mix(in oklab, var(--status-ok) 14%, transparent); color: var(--text-bright); }
+.ap-act.always { border-color: color-mix(in oklab, var(--volt-strong) 40%, transparent); color: var(--volt-strong); }
+.ap-act.always:hover:not(:disabled) { background: var(--volt-wash); }
+.ap-act.deny { border-color: color-mix(in oklab, var(--status-bad) 50%, transparent); color: var(--status-bad); }
+.ap-act.deny:hover:not(:disabled) { background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
+.ap-act.ghost { margin-left: auto; border-color: transparent; color: var(--text-dim); padding: 7px 4px; }
+.ap-act.ghost:hover:not(:disabled) { color: var(--volt-strong); }
+
+.ap-clear { text-align: center; padding: 52px 20px; display: flex; flex-direction: column; align-items: center; gap: 7px; color: var(--text-dim); }
+.ap-clear .ico { width: 46px; height: 46px; display: flex; align-items: center; justify-content: center; border-radius: 50%; font-size: 22px; color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 40%, transparent); background: color-mix(in oklab, var(--status-ok) 8%, transparent); }
+.ap-clear h3 { font-family: var(--font-display); font-weight: 500; font-size: 15px; color: var(--text-mid); margin: 4px 0 0; }
+.ap-clear-sub { font-size: 12px; max-width: 360px; line-height: 1.6; }
+
+.ap-error { font-size: 12px; color: var(--status-bad); border: 1px solid color-mix(in oklab, var(--status-bad) 35%, var(--border-main)); background: color-mix(in oklab, var(--status-bad) 7%, transparent); padding: 10px 12px; border-radius: var(--radius-sm); margin-bottom: 14px; }
+
+/* Nav-rail count badge for the approvals surface (open-approval count). */
+.ap-nav-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 5px; border-radius: var(--radius-pill); font-family: var(--font-mono); font-size: 9.5px; font-weight: 700; line-height: 1; color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 16%, transparent); border: 1px solid color-mix(in oklab, var(--status-bad) 38%, transparent); }
+.ap-nav-dot { position: absolute; top: 3px; right: 3px; width: 6px; height: 6px; border-radius: 50%; background: var(--status-bad); box-shadow: 0 0 0 2px var(--bg-panel); }

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -319,6 +319,7 @@ export type TabId =
   | 'code'
   | 'logs'
   | 'settings'
+  | 'approvals'
 
 export const VALID_TABS: TabId[] = [
   'cockpit',
@@ -333,4 +334,5 @@ export const VALID_TABS: TabId[] = [
   'code',
   'logs',
   'settings',
+  'approvals',
 ]

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -20,6 +20,7 @@ let valid_surfaces =
   ; "code"
   ; "logs"
   ; "settings"
+  ; "approvals"
   ]
 ;;
 


### PR DESCRIPTION
## 무엇을

keeper-v2 프로토타입의 승인 화면을 라이브 대시보드의 **독립 top-level surface**로 포팅했습니다. NavRail에 `Approvals`(ShieldCheck) 항목 + 열린 승인 카운트 배지를 추가하고, 기존 Command 서피스의 Governance 패널은 그대로 유지합니다(공존, 동일 데이터 소스 공유).

## 데이터 / 액션 — 라이브 모델 바인딩 (목업 아님)

- 큐: `governanceData.value.approval_queue` (`KeeperApprovalQueueItem[]`) — 기존 Governance 패널과 동일 시그널. 한쪽에서 처리하면 양쪽이 동기화됩니다.
- 액션: `respondToKeeperApproval(id, 'approve' | 'reject', rememberRule)` — 승인 / 항상 승인(Always 룰) / 거부. busy-lock(`governanceApprovalActing`) 재사용.
- mount 시 `refreshGovernance()` + `setupVisibleAutoRefresh`.
- sev는 `risk_level`(critical/high → bad, medium → warn)에서 파생.

## 프로토타입과의 차이 (의도적)

라이브 결정 모델은 닫힌 `{approve, reject}`(+rule)뿐이고 보류·되돌리기 엔드포인트가 없습니다. 프로토타입의 보류/되돌리기/처리이력을 그대로 옮기면 호출처 없는 버튼이 되므로, 보류 자리에 라이브의 세 번째 실제 액션 `항상 승인`을 넣고 undo/처리이력은 렌더하지 않습니다.

## 변경 파일

- 신규: `dashboard/src/components/approvals/approvals-surface.ts`, `dashboard/src/styles/approvals-v2.css`
- 등록: `dashboard/src/types/sse.ts`(TabId/VALID_TABS), `dashboard/src/config/navigation.ts`(surface metadata/icon union/sectionless/section-record), `dashboard/src/components/surface-icon.ts`(ShieldCheck case), `dashboard/src/components/dashboard-shell.ts`(lazy route + nav 카운트 배지)
- 테스트: `dashboard/src/components/approvals/approvals-surface.test.ts`, `dashboard/src/config/navigation.test.ts`(잠금 배열 갱신)

## 검증

- `tsc --noEmit` 통과 (exhaustive `SurfaceIcon` switch + 전수 `DASHBOARD_SECTION_ITEMS` Record 충족)
- `vitest`: navigation/dashboard-shell/mobile-nav 91/91, approvals-surface 3/3 (populated 카드 / empty 상태 / 승인 클릭 → `resolveGovernanceApproval(id,'approve',false)` 배선)
- `vite build` 성공 — `approvals-surface-*.js` lazy 청크 + `.ap-card` CSS 번들 포함 확인

RFC-WAIVED: dashboard surface 추가. credential / operator / sandbox / keeper containment / hooks / workflow subsystem 미해당.

Co-Authored-By: Claude <noreply@anthropic.com>
