### PR TITLE
chore(runtime): provider_d-http/-cli 거부 잠금 + stale alias 문서 정정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
   Pin metadata, lock metadata, generated docs, and the API surface fingerprint
   were refreshed for the new OAS release.
 
+### Fixed
+- `runtime`: corrected a stale `runtime_toml.mli` doc comment that claimed the
+  TOML parser still "accepts" the deprecated provider-letter protocol aliases
+  (`provider_d-http` / `provider-d-cli`). The parser has no such branch — these
+  labels are rejected with an "unknown protocol" error, so a checked-in config
+  still using them fails to load. Added `test_legacy_protocol_alias_rejected`
+  to lock the rejection and the canonical-label allow-list.
+
 
 ## [0.19.46] - 2026-06-18
 

--- a/lib/runtime/runtime_toml.mli
+++ b/lib/runtime/runtime_toml.mli
@@ -32,10 +32,13 @@ val parse_file : string -> (Runtime_schema.config, parse_error list) result
 (** {1 Internal: protocol resolution} *)
 
 val api_format_of_protocol : string -> (Runtime_schema.api_format, string) result
-(** Map a TOML protocol string to a {!Runtime_schema.api_format} variant.
-    Deprecated provider-letter aliases are accepted only for existing live
-    config compatibility; parsed provider records use canonical protocol
-    labels. *)
+(** Map a TOML protocol string to a {!Runtime_schema.api_format} variant. Only
+    the canonical labels are accepted: [messages-cli], [messages-http],
+    [openai-compatible-cli], [openai-compatible-http], [ollama-http]. The
+    deprecated provider-letter aliases [provider_d-http] / [provider-d-cli]
+    (renamed in v0.19.43) are rejected with an "unknown protocol" error — they
+    are NOT silently canonicalized — so a checked-in config still using them
+    fails to load. Locked by [test_legacy_protocol_alias_rejected]. *)
 
 val transport_of_provider :
   Otoml.t -> string -> (Runtime_schema.transport, string) result

--- a/test/dune
+++ b/test/dune
@@ -1423,6 +1423,8 @@
 
 (include stanzas/test_thinking_control_format_unknown_error.inc)
 
+(include stanzas/test_legacy_protocol_alias_rejected.inc)
+
 (include stanzas/test_workspace_bootstrap.inc)
 
 (include stanzas/test_workspace_base_path_cache.inc)

--- a/test/stanzas/test_legacy_protocol_alias_rejected.inc
+++ b/test/stanzas/test_legacy_protocol_alias_rejected.inc
@@ -1,0 +1,8 @@
+; Per-file dune stanza for the legacy protocol-alias rejection suite.
+; Lives here per test/stanzas/README.md to avoid the conflict-runtime hotspot
+; in the legacy grouped (tests ...) stanza.
+
+(test
+ (name test_legacy_protocol_alias_rejected)
+ (modules test_legacy_protocol_alias_rejected)
+ (libraries masc.runtime alcotest))

--- a/test/test_legacy_protocol_alias_rejected.ml
+++ b/test/test_legacy_protocol_alias_rejected.ml
@@ -1,0 +1,73 @@
+(* Legacy OpenAI-compatible protocol aliases [provider_d-http] / [provider-d-cli]
+   were renamed to [openai-compatible-http] / [openai-compatible-cli]
+   (CHANGELOG v0.19.43, 2026-06-12). The parser rejects the legacy spellings
+   outright via [Runtime_toml.api_format_of_protocol] — there is no
+   canonicalization branch — so a checked-in config still using an old label
+   fails to load: [Runtime.init_default] returns [Error] with no silent
+   fallback.
+
+   This locks that rejection. The .mli for [api_format_of_protocol] previously
+   claimed legacy provider-letter aliases were "accepted for live config
+   compatibility"; the code has no such branch, so that claim was stale and is
+   corrected alongside this test.
+
+   Driven through the public [parse_string] entry. The canonical and legacy
+   TOMLs differ only in the protocol value, isolating it as the cause; the
+   legacy cases additionally assert the error message names the unknown
+   protocol, pinning the protocol field (not transport) as the failure. *)
+
+open Alcotest
+
+let toml_with_protocol proto =
+  Printf.sprintf
+    {|[providers.p]
+protocol = "%s"
+endpoint = "https://example.com"
+|}
+    proto
+
+let is_ok = function Ok _ -> true | Error _ -> false
+
+(* Stdlib has no substring search; this is a plain left-to-right scan. *)
+let contains ~needle haystack =
+  let nl = String.length needle in
+  let hl = String.length haystack in
+  let rec go i =
+    i + nl <= hl
+    && (String.equal (String.sub haystack i nl) needle || go (i + 1))
+  in
+  nl = 0 || go 0
+
+let rejected_as_unknown_protocol toml =
+  match Runtime_toml.parse_string toml with
+  | Ok _ -> false
+  | Error errs ->
+    List.exists
+      (fun (err : Runtime_toml.parse_error) ->
+        contains ~needle:"unknown protocol" err.message)
+      errs
+
+let test_canonical_http_loads () =
+  check bool "canonical openai-compatible-http loads" true
+    (is_ok (Runtime_toml.parse_string (toml_with_protocol "openai-compatible-http")))
+
+let test_legacy_http_alias_rejected () =
+  check bool "legacy provider_d-http rejected as unknown protocol" true
+    (rejected_as_unknown_protocol (toml_with_protocol "provider_d-http"))
+
+let test_legacy_cli_alias_rejected () =
+  check bool "legacy provider-d-cli rejected as unknown protocol" true
+    (rejected_as_unknown_protocol (toml_with_protocol "provider-d-cli"))
+
+let () =
+  run "legacy_protocol_alias_rejected"
+    [
+      ( "parse_string",
+        [
+          test_case "canonical http loads" `Quick test_canonical_http_loads;
+          test_case "legacy provider_d-http rejected" `Quick
+            test_legacy_http_alias_rejected;
+          test_case "legacy provider-d-cli rejected" `Quick
+            test_legacy_cli_alias_rejected;
+        ] );
+    ]


### PR DESCRIPTION
## 무엇을

`runtime.toml` 파서가 거부하는 deprecated protocol 라벨 `provider_d-http` / `provider-d-cli` 에 대해, **거부된다는 사실을 테스트로 잠그고** stale 문서를 정정합니다.

## 왜

- `Runtime_toml.api_format_of_protocol` 는 canonical 라벨(`messages-cli`, `messages-http`, `openai-compatible-cli`, `openai-compatible-http`, `ollama-http`)만 매칭하고 나머지는 `unknown protocol` 에러를 냅니다. 호출부(`runtime_toml.ml:251-260`)에 pre-normalization 이 없어 레거시 라벨은 그대로 거부됩니다.
- 그런데 `runtime_toml.mli` 주석은 "Deprecated provider-letter aliases are accepted only for existing live config compatibility" 라고 **사실과 다르게** 주장하고 있었습니다. 코드엔 그런 수용 분기가 없습니다.
- 결과적으로 레거시 라벨을 쓰는 checked-in config 는 로드에 실패합니다 (`Runtime.init_default` Error, silent fallback 없음). 문서만 보고 레거시 라벨이 동작한다고 오해할 수 있어 정정이 필요합니다.

## 변경

- `lib/runtime/runtime_toml.mli`: `api_format_of_protocol` 문서를 "canonical 라벨만 수용, 레거시 alias 는 unknown protocol 으로 거부" 로 정정.
- `test/test_legacy_protocol_alias_rejected.ml` (신규): `parse_string` 공개 진입점으로 — canonical `openai-compatible-http` 는 로드되고, `provider_d-http` / `provider-d-cli` 는 unknown protocol 으로 거부됨을 단언. canonical/레거시 TOML 은 protocol 값만 다르게 두어 protocol 필드를 원인으로 격리.
- `test/dune`, `test/stanzas/test_legacy_protocol_alias_rejected.inc`: 테스트 등록.
- `CHANGELOG.md`: Unreleased/Fixed 항목.

## 검증

```
dune build --root . test/test_legacy_protocol_alias_rejected.exe   # OK
dune exec  --root . ./test/test_legacy_protocol_alias_rejected.exe # 3/3 OK
```

레거시 라벨이 `Runtime_toml.parse_string` 에서 실제로 거부됨을 실증했습니다 (코드 정독 + 테스트 양쪽).

## 범위 밖 (별도)

- jeong-sik/me `.masc/config/runtime.toml` 의 committed blob 은 아직 `provider_d-http` 화석을 들고 있어 현재 바이너리로 boot-broken — 그쪽은 라이브 reconcile PR 로 별도 처리.
- `test/dune` 의 기존 format 노이즈(line ~1095, ~2216)는 이 PR 범위 밖이라 건드리지 않음.

RFC-WAIVED: 문서 정정 + 회귀 테스트 추가. 동작 변경 없음(파서 거부는 기존 동작). credential/identity/operator/sandbox/hooks/workflow subsystem 무관.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
