### PR TITLE
test(keeper): hook 슬롯 introspection contract lock (drift 가드)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -42,6 +42,7 @@
   test_keeper_identity_id
   test_keeper_idle_threshold_contract
   test_keeper_context_layers
+  test_keeper_hooks_oas_introspection
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection
@@ -339,6 +340,7 @@
   test_keeper_identity_id
   test_keeper_idle_threshold_contract
   test_keeper_context_layers
+  test_keeper_hooks_oas_introspection
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection

--- a/test/test_keeper_hooks_oas_introspection.ml
+++ b/test/test_keeper_hooks_oas_introspection.ml
@@ -1,0 +1,117 @@
+(** Contract lock for {!Keeper_hooks_oas_introspection.hook_introspection_json}.
+
+    This is a CONTRACT LOCK, not a live cross-check. The introspection is a
+    hand-maintained static description of the keeper hook slots, so it can
+    silently drift from the real wiring. This test pins the semantic contract
+    (which slots exist, which are active, their sources, and the cost-telemetry
+    "never enforced" invariant) so any edit to the introspection forces a
+    conscious update here and a re-check against the real hook wiring:
+
+    - lib/keeper/keeper_hooks_oas.ml ([make_hooks]) — the keeper_hooks_oas slots
+    - lib/keeper/keeper_run_tools.ml — before_turn_params
+    - lib/keeper/keeper_guards.ml — pre_tool_use
+
+    A full runtime cross-check that builds the real [make_hooks] record and
+    asserts each field's Some/None against these claims needs a
+    Workspace.config / keeper_meta / turn_ctx_cell fixture and is deferred. *)
+
+open Alcotest
+
+let json = Masc.Keeper_hooks_oas_introspection.hook_introspection_json ~denied_tools:[] ()
+
+let slots_of (j : Yojson.Safe.t) =
+  match j with
+  | `Assoc fields -> (
+    match List.assoc_opt "slots" fields with
+    | Some (`Assoc slots) -> slots
+    | _ -> failwith "introspection JSON missing `slots` assoc")
+  | _ -> failwith "introspection JSON is not an object"
+
+let slot_field slot_name field =
+  match List.assoc_opt slot_name (slots_of json) with
+  | Some (`Assoc sf) -> List.assoc_opt field sf
+  | _ -> None
+
+let slot_bool slot_name field =
+  match slot_field slot_name field with Some (`Bool b) -> Some b | _ -> None
+
+let slot_string slot_name field =
+  match slot_field slot_name field with Some (`String s) -> Some s | _ -> None
+
+(* The 11 slots the introspection claims are wired, and the 3 it claims are
+   not (compaction is handled by keeper_post_turn, not the SDK hooks). *)
+let expected_active =
+  [ "before_turn"
+  ; "before_turn_params"
+  ; "after_turn"
+  ; "pre_tool_use"
+  ; "post_tool_use"
+  ; "post_tool_use_failure"
+  ; "on_stop"
+  ; "on_idle"
+  ; "on_idle_escalated"
+  ; "on_error"
+  ; "on_tool_error"
+  ]
+
+let expected_inactive = [ "pre_compact"; "post_compact"; "on_context_compacted" ]
+
+let test_slot_set () =
+  let names = List.map fst (slots_of json) |> List.sort compare in
+  let expected = List.sort compare (expected_active @ expected_inactive) in
+  check (list string) "introspection exposes exactly the 14 known hook slots" expected names
+
+let test_active_split () =
+  List.iter
+    (fun n -> check (option bool) (n ^ " is active") (Some true) (slot_bool n "active"))
+    expected_active;
+  List.iter
+    (fun n -> check (option bool) (n ^ " is inactive") (Some false) (slot_bool n "active"))
+    expected_inactive
+
+let test_sources () =
+  (* pre_tool_use and before_turn_params come from sibling modules, not the
+     keeper_hooks_oas record; the rest of the active slots are keeper_hooks_oas. *)
+  check (option string) "pre_tool_use source" (Some "keeper_guards")
+    (slot_string "pre_tool_use" "source");
+  check (option string) "before_turn_params source" (Some "keeper_run_tools")
+    (slot_string "before_turn_params" "source");
+  check (option string) "after_turn source" (Some "keeper_hooks_oas")
+    (slot_string "after_turn" "source");
+  List.iter
+    (fun n ->
+      check (option string) (n ^ " source") (Some "not_registered") (slot_string n "source"))
+    expected_inactive
+
+(* The cost budget is advisory-only: keeper_guards.cost_guard ignores
+   max_cost_usd and always returns Continue. The introspection must therefore
+   report enforced:false in BOTH the "no budget" and "budget set" branches —
+   relabelling it as enforced would be a false claim of a control that does not
+   block anything. *)
+let enforced_of (j : Yojson.Safe.t) =
+  match j with
+  | `Assoc fields -> (
+    match List.assoc_opt "cost_telemetry" fields with
+    | Some (`Assoc ct) -> (
+      match List.assoc_opt "enforced" ct with Some (`Bool b) -> Some b | _ -> None)
+    | _ -> None)
+  | _ -> None
+
+let test_cost_telemetry_never_enforced () =
+  check (option bool) "enforced is false with no budget" (Some false) (enforced_of json);
+  let with_budget =
+    Masc.Keeper_hooks_oas_introspection.hook_introspection_json ~denied_tools:[]
+      ~max_cost_usd:5.0 ()
+  in
+  check (option bool) "enforced is false even when a budget is set" (Some false)
+    (enforced_of with_budget)
+
+let () =
+  Alcotest.run "Keeper_hooks_oas_introspection"
+    [ ( "slot contract"
+      , [ test_case "exactly the 14 known slots" `Quick test_slot_set
+        ; test_case "11 active / 3 inactive" `Quick test_active_split
+        ; test_case "slot sources" `Quick test_sources
+        ; test_case "cost telemetry is never enforced" `Quick test_cost_telemetry_never_enforced
+        ] )
+    ]


### PR DESCRIPTION
slot 시스템 감사의 **구조적 뿌리** 대응 (A-core). F3(칩 안 보임)·E1(전역인데 keeper별로 보임)은 전부 "introspection이 손유지 정적 리스트라 실제 등록과 컴파일타임 연결이 없다"는 한 뿌리에서 나왔습니다.

## 문제
`Keeper_hooks_oas_introspection`은 14 slot을 손으로 기술하는 정적 리스트(테스트 0건). 실제 wiring(make_hooks/keeper_run_tools/keeper_guards)과 어긋나도 아무도 막지 못함 → drift 상시 가능.

## 변경
모듈 **첫 테스트** = contract lock. 고정 항목:
- 정확히 14개 알려진 slot 이름 존재
- 11 active / 3 inactive split
- slot sources (pre_tool_use=keeper_guards, before_turn_params=keeper_run_tools, 나머지 active=keeper_hooks_oas, compaction 3종=not_registered)
- **cost_telemetry.enforced = false** (budget 없음 + budget 설정 두 분기 모두) — cost_guard가 advisory-only라 enforced로 표기하면 거짓 주장

## 한계 (정직 표기)
이건 **contract lock**이지 라이브 cross-check가 아닙니다. introspection을 고치면 테스트가 깨져 **의식적 업데이트 + 실제 wiring 재확인**을 강제합니다. 실제 `make_hooks` 레코드를 빌드해 필드별 Some/None을 대조하는 완전 cross-check는 Workspace.config/keeper_meta/turn_ctx_cell fixture가 필요해 후속으로 미룹니다(테스트 주석에 명시).

## 로컬 검증
- `dune build + exec test/test_keeper_hooks_oas_introspection.exe` — 4 tests pass.
- `dune fmt` 적용(무관 base-broken dune 재포맷은 되돌려 surgical 유지).

## slot 감사 시리즈
#21587·#21597·#21604·#21608(머지) / #21623(tool_denylist 편집기, open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)