### PR TITLE
feat(fusion): fusion 카드 markdown 렌더 + synthesis/usage 표시

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1736,4 +1736,59 @@ describe('fusion chat card', () => {
     await flushUi()
     expect(container.querySelector('[data-fusion-detail]')?.textContent).toContain('불러오지 못했습니다')
   })
+
+  it('renders judge.synthesis as markdown (not the raw resolved_answer dump)', async () => {
+    vi.mocked(fetchBoardPost).mockResolvedValue({
+      meta: {
+        source: 'fusion',
+        panel: [{ model: 'm1', status: 'answered', answer: '## Heading One\n\n- bullet item', output_tokens: 100 }],
+        judge: {
+          status: 'synthesized',
+          decision: 'answer — ok',
+          synthesis: '**Consensus**\n\n- agreed point',
+          resolved_answer: 'PLAIN RESOLVED',
+        },
+        observed_usage: { input_tokens: 712, output_tokens: 3432 },
+      },
+    } as unknown as Awaited<ReturnType<typeof fetchBoardPost>>)
+
+    render(html`<${ChatTranscript} entries=${[fusionEntry()]} emptyText="empty" />`, container)
+    fireEvent.click(container.querySelector('[data-fusion-card] button') as HTMLButtonElement)
+    await flushUi()
+
+    const detail = container.querySelector('[data-fusion-detail]')
+    // Panel + judge markdown rendered to real elements, not raw ## / ** text.
+    expect(detail?.querySelector('h2')?.textContent).toBe('Heading One')
+    expect(detail?.querySelector('li')?.textContent).toContain('bullet item')
+    const judge = container.querySelector('[data-fusion-judge]')
+    expect(judge?.querySelector('strong')?.textContent).toBe('Consensus')
+    // synthesis takes precedence over resolved_answer when both present.
+    expect(judge?.textContent).toContain('agreed point')
+    expect(judge?.textContent).not.toContain('PLAIN RESOLVED')
+  })
+
+  it('surfaces token usage and answered count in the header', async () => {
+    vi.mocked(fetchBoardPost).mockResolvedValue({
+      meta: {
+        source: 'fusion',
+        panel: [
+          { model: 'm1', status: 'answered', answer: 'a', output_tokens: 1200 },
+          { model: 'm2', status: 'failed', reason: 'timeout' },
+        ],
+        judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'r' },
+        observed_usage: { input_tokens: 712, output_tokens: 3432 },
+      },
+    } as unknown as Awaited<ReturnType<typeof fetchBoardPost>>)
+
+    render(html`<${ChatTranscript} entries=${[fusionEntry()]} emptyText="empty" />`, container)
+    fireEvent.click(container.querySelector('[data-fusion-card] button') as HTMLButtonElement)
+    await flushUi()
+
+    const card = container.querySelector('[data-fusion-card]')
+    // 1 of 2 answered, total output tokens formatted with separators.
+    expect(card?.textContent).toContain('패널 1/2 합의')
+    expect(card?.textContent).toContain('3,432 tok')
+    // Per-panel token count present.
+    expect(container.querySelector('[data-fusion-detail]')?.textContent).toContain('1,200 tok')
+  })
 })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1112,12 +1112,21 @@ type FusionPanelEntry = {
   status: string
   answer?: string
   reason?: string
+  outputTokens?: number
 }
 
 type FusionJudgeView = {
   status: string
   decision?: string
+  // synthesis is render_judge's markdown (consensus/contradictions/blind-spots
+  // + resolved answer) — the actual deliberation value. Prefer it; fall back to
+  // resolvedAnswer for older posts written before synthesis was serialized.
+  synthesis?: string
   resolvedAnswer?: string
+}
+
+function numOrUndef(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined
 }
 
 function asFusionPanel(meta: unknown): FusionPanelEntry[] {
@@ -1132,6 +1141,7 @@ function asFusionPanel(meta: unknown): FusionPanelEntry[] {
       status: typeof r.status === 'string' ? r.status : 'unknown',
       answer: typeof r.answer === 'string' ? r.answer : undefined,
       reason: typeof r.reason === 'string' ? r.reason : undefined,
+      outputTokens: numOrUndef(r.output_tokens),
     }]
   })
 }
@@ -1144,8 +1154,25 @@ function asFusionJudge(meta: unknown): FusionJudgeView | null {
   return {
     status: typeof r.status === 'string' ? r.status : 'unknown',
     decision: typeof r.decision === 'string' ? r.decision : undefined,
+    synthesis: typeof r.synthesis === 'string' ? r.synthesis : undefined,
     resolvedAnswer: typeof r.resolved_answer === 'string' ? r.resolved_answer : undefined,
   }
+}
+
+function asFusionTotalOutputTokens(meta: unknown): number | undefined {
+  if (!meta || typeof meta !== 'object') return undefined
+  const usage = (meta as Record<string, unknown>).observed_usage
+  if (!usage || typeof usage !== 'object') return undefined
+  return numOrUndef((usage as Record<string, unknown>).output_tokens)
+}
+
+// Render untrusted model/judge markdown through the same sanitized path the rest
+// of the transcript uses (DOMPurify over marked) — never inject raw model output.
+function FusionMarkdown({ text }: { text: string }) {
+  return html`<div
+    class="markdown-body text-xs leading-relaxed"
+    dangerouslySetInnerHTML=${{ __html: purifyHtml(marked.parse(text) as string) }}
+  />`
 }
 
 function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: string }) {
@@ -1154,6 +1181,7 @@ function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: s
     status: 'idle' | 'loading' | 'loaded' | 'error'
     panel: FusionPanelEntry[]
     judge: FusionJudgeView | null
+    totalOutputTokens?: number
     error?: string
   }>({ status: 'idle', panel: [], judge: null })
   // Fetch-once guard. state.status must NOT be in the effect deps: the
@@ -1170,7 +1198,12 @@ function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: s
     fetchBoardPost(boardPostId)
       .then((post) => {
         if (!alive) return
-        setState({ status: 'loaded', panel: asFusionPanel(post.meta), judge: asFusionJudge(post.meta) })
+        setState({
+          status: 'loaded',
+          panel: asFusionPanel(post.meta),
+          judge: asFusionJudge(post.meta),
+          totalOutputTokens: asFusionTotalOutputTokens(post.meta),
+        })
       })
       .catch((err: unknown) => {
         if (!alive) return
@@ -1180,6 +1213,9 @@ function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: s
   }, [expanded, boardPostId])
 
   const runLabel = runId ? ` · ${runId.slice(0, 12)}` : ''
+  const answeredCount = state.panel.filter((p) => p.status === 'answered').length
+  const usageLabel =
+    state.totalOutputTokens !== undefined ? ` · ${state.totalOutputTokens.toLocaleString()} tok` : ''
   return html`
     <div class="rounded-[var(--r-1,8px)] border border-[var(--color-brass-border,#3a3a2a)] bg-[var(--color-brass-soft,rgba(216,166,87,0.06))] overflow-hidden" data-fusion-card>
       <button
@@ -1190,7 +1226,11 @@ function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: s
       >
         <span aria-hidden="true">${expanded ? '▾' : '▸'}</span>
         <span class="font-medium">Fusion 심의</span>
-        <span class="text-[var(--color-fg-secondary,#9da7b3)]">패널 합의 상세${runLabel}</span>
+        <span class="text-[var(--color-fg-secondary,#9da7b3)]">
+          ${state.status === 'loaded'
+            ? `패널 ${answeredCount}/${state.panel.length} 합의${runLabel}${usageLabel}`
+            : `패널 합의 상세${runLabel}`}
+        </span>
       </button>
       ${expanded
         ? html`
@@ -1204,17 +1244,21 @@ function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: s
             ${state.status === 'loaded'
               ? html`
                 <div class="flex flex-col gap-2">
-                  ${state.panel.map((p, i) => html`
-                    <div key=${i} class="rounded border border-[var(--color-border,#30363d)] px-2 py-1.5">
-                      <div class="text-2xs font-mono text-[var(--color-fg-secondary,#9da7b3)]">${p.model} · ${p.status}</div>
-                      ${p.answer
-                        ? html`<div class="text-xs mt-1 whitespace-pre-wrap">${p.answer}</div>`
-                        : null}
-                      ${p.reason
-                        ? html`<div class="text-xs mt-1 text-[var(--color-danger,#e06c75)]">${p.reason}</div>`
-                        : null}
-                    </div>
-                  `)}
+                  ${state.panel.map((p, i) => {
+                    const tok = p.outputTokens !== undefined ? ` · ${p.outputTokens.toLocaleString()} tok` : ''
+                    const failed = p.status !== 'answered'
+                    return html`
+                      <div key=${i} class="rounded border ${failed ? 'border-[var(--color-danger,#e06c75)]/40' : 'border-[var(--color-border,#30363d)]'} px-2 py-1.5">
+                        <div class="text-2xs font-mono text-[var(--color-fg-secondary,#9da7b3)]">${p.model} · ${p.status}${tok}</div>
+                        ${p.answer
+                          ? html`<div class="mt-1 max-h-64 overflow-y-auto"><${FusionMarkdown} text=${p.answer} /></div>`
+                          : null}
+                        ${p.reason
+                          ? html`<div class="text-xs mt-1 text-[var(--color-danger,#e06c75)]">${p.reason}</div>`
+                          : null}
+                      </div>
+                    `
+                  })}
                 </div>
                 ${state.judge
                   ? html`
@@ -1222,9 +1266,11 @@ function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: s
                       <div class="text-2xs font-mono text-[var(--color-fg-secondary,#9da7b3)]">
                         judge · ${state.judge.status}${state.judge.decision ? html` · ${state.judge.decision}` : null}
                       </div>
-                      ${state.judge.resolvedAnswer
-                        ? html`<div class="text-xs mt-1 whitespace-pre-wrap">${state.judge.resolvedAnswer}</div>`
-                        : null}
+                      ${state.judge.synthesis
+                        ? html`<div class="mt-1"><${FusionMarkdown} text=${state.judge.synthesis} /></div>`
+                        : state.judge.resolvedAnswer
+                          ? html`<div class="mt-1"><${FusionMarkdown} text=${state.judge.resolvedAnswer} /></div>`
+                          : null}
                     </div>
                   `
                   : null}


### PR DESCRIPTION
## 배경

fusion 채팅 카드(#21611)가 패널 답변과 judge 답변을 `whitespace-pre-wrap`로 **raw 렌더**해서, 답변 속 마크다운(헤더/표/볼드)이 `##`/`**`/`|` 날것 벽으로 보였습니다. 채팅의 나머지 메시지는 `ChatBlocks`(마크다운+sanitize) 경로를 타서 rich한데, 이 카드만 raw였습니다. 게다가 board `meta_json`의 절반을 안 썼습니다:
- `judge.synthesis` — consensus/모순/사각지대 분해 (**fusion의 진짜 가치**)
- `observed_usage` / 패널별 토큰

## 변경 (dashboard chat — primitives.ts `ChatFusionCard` 1곳)

- **markdown 렌더**: 패널 답변 + judge를 채팅과 동일한 sanitize 경로(DOMPurify over marked)로. ⚠️ untrusted 모델 출력이라 raw 주입 절대 안 함.
- **synthesis 우선**: bare resolved_answer 대신 구조화 synthesis(consensus/모순/사각지대) 표시. 옛 post는 resolved_answer로 fallback.
- **토큰 usage**: 헤더에 total, 패널별 output token. 헤더에 answered/total 패널 수.
- **긴 답변 접기**: 패널 답변 max-height 스크롤(장황한 모델 1개가 끝없는 벽 만드는 것 방지).

## 검증
- `tsc --noEmit` 0 errors
- `vitest primitives.test.ts` **74 passed** (회귀 0). 새 테스트 2건: markdown이 실제 DOM(h2/strong/li)으로 렌더되는지 + synthesis가 resolved_answer보다 우선하는지 + usage/count 표시 — raw text 회귀를 구조적으로 차단.

RFC-0252 follow-up (#21611 enhancement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
