### PR TITLE
feat(workspace): RFC-0262 §9 completion-trust audit (authority+assignee log, offline auditor)

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -139,6 +139,16 @@
  (package masc)
  (libraries masc masc_core unix eio eio_main))
 
+;; Completion-trust audit CLI (RFC-0262 §9): fold .masc/events/ transition log
+;; for foreign-task completions. Pure auditor only — no masc runtime link.
+
+(executable
+ (name masc_completion_trust_audit)
+ (modules masc_completion_trust_audit)
+ (public_name masc-completion-trust-audit)
+ (package masc)
+ (libraries unix yojson masc.completion_trust_audit))
+
 ;; RFC-0232 P4: offline mention backfill for keeper chat lanes.
 ;; Stamps the [mentions] field onto pre-P4 user rows; run with the
 ;; server stopped.

--- a/bin/masc_completion_trust_audit.ml
+++ b/bin/masc_completion_trust_audit.ml
@@ -1,0 +1,152 @@
+(** [masc_completion_trust_audit] — RFC-0262 §9 metric over the live transition
+    log.
+
+    Reads the task-transition event stream from [{base}/.masc/events/YYYY-MM/DD.jsonl]
+    and folds it through {!Completion_trust_audit} to report the two §9 quantities:
+    foreign-task completions by a non-Operator/System actor (§9①, must be 0) and
+    force-equivalent completions (§9②, the Phase-3 evidence-gate baseline).
+
+    Ownership is reconstructed from the stream, so the files must be fed in
+    chronological order — the [YYYY-MM/DD.jsonl] layout is zero-padded, so a plain
+    path sort is chronological.
+
+    Depends only on the pure auditor (+ yojson/unix); it does not link the masc
+    runtime. *)
+
+let usage =
+  {|Usage: masc_completion_trust_audit [OPTIONS]
+
+Options:
+  --events-dir DIR   events root (default: $MASC_BASE_PATH/.masc/events;
+                     required when MASC_BASE_PATH is unset)
+  --month YYYY-MM    restrict the audit to a single month directory
+  --json             emit the metric as JSON instead of the text summary
+  --strict           exit 1 if any §9① foreign completion is found
+                     (default: informational, exit 0 unless IO error)
+  -h, --help         print this help
+
+Exit codes:
+  0  audit ran (PASS, or violations found without --strict)
+  1  --strict and §9① violations found, or invalid argument
+|}
+;;
+
+let error msg =
+  prerr_endline msg;
+  exit 1
+;;
+
+let default_events_dir () =
+  match Sys.getenv_opt "MASC_BASE_PATH" with
+  | Some p when String.trim p <> "" -> Some (Filename.concat (Filename.concat p ".masc") "events")
+  | Some _ | None -> None
+;;
+
+type config = {
+  events_dir : string option;
+  month : string option;
+  json : bool;
+  strict : bool;
+}
+
+let rec parse_args cfg = function
+  | [] -> cfg
+  | ("-h" | "--help") :: _ ->
+    print_string usage;
+    exit 0
+  | "--events-dir" :: dir :: rest -> parse_args { cfg with events_dir = dir } rest
+  | "--month" :: m :: rest -> parse_args { cfg with month = Some m } rest
+  | "--json" :: rest -> parse_args { cfg with json = true } rest
+  | "--strict" :: rest -> parse_args { cfg with strict = true } rest
+  | other :: _ -> error (Printf.sprintf "unknown argument: %S\n%s" other usage)
+;;
+
+let resolve_events_dir = function
+  | Some dir -> dir
+  | None ->
+    (match default_events_dir () with
+     | Some dir -> dir
+     | None ->
+       error
+         "missing --events-dir: set MASC_BASE_PATH or pass --events-dir explicitly")
+
+(* List [YYYY-MM/DD.jsonl] files under [dir], sorted chronologically. A plain
+   [compare] sort is chronological because both segments are zero-padded. *)
+let list_event_files ?month dir =
+  if not (Sys.file_exists dir) || not (Sys.is_directory dir)
+  then []
+  else (
+    let months =
+      Sys.readdir dir
+      |> Array.to_list
+      |> List.filter (fun mo -> Sys.is_directory (Filename.concat dir mo))
+      |> List.sort compare
+    in
+    let months =
+      match month with
+      | Some m -> List.filter (String.equal m) months
+      | None -> months
+    in
+    List.concat_map
+      (fun mo ->
+        let mdir = Filename.concat dir mo in
+        Sys.readdir mdir
+        |> Array.to_list
+        |> List.filter (fun f -> Filename.check_suffix f ".jsonl")
+        |> List.sort compare
+        |> List.map (fun f -> Filename.concat mdir f))
+      months)
+;;
+
+let read_lines path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let rec loop acc =
+        match input_line ic with
+        | line -> loop (line :: acc)
+        | exception End_of_file -> List.rev acc
+      in
+      loop [])
+;;
+
+(* A blank line is not an event (dropped). An unparseable line becomes [`Null] so
+   the auditor counts it under [events_skipped] rather than silently vanishing. *)
+let parse_line line : Yojson.Safe.t option =
+  let line = String.trim line in
+  if line = ""
+  then None
+  else (
+    match Yojson.Safe.from_string line with
+    | json -> Some json
+    | exception _ -> Some `Null)
+;;
+
+let () =
+  let cfg =
+    parse_args
+      { events_dir = None; month = None; json = false; strict = false }
+      (List.tl (Array.to_list Sys.argv))
+  in
+  let events_dir = resolve_events_dir cfg.events_dir in
+  let files = list_event_files ?month:cfg.month events_dir in
+  (if files = []
+   then
+     prerr_endline
+       (Printf.sprintf
+          "warning: no event files under %s%s"
+          events_dir
+          (match cfg.month with Some m -> " for month " ^ m | None -> "")));
+  let events =
+    List.concat_map
+      (fun path -> read_lines path |> List.filter_map parse_line)
+      files
+  in
+  let metric = Completion_trust_audit.audit_events events in
+  if cfg.json
+  then print_endline (Yojson.Safe.to_string (Completion_trust_audit.metric_to_json metric))
+  else print_string (Completion_trust_audit.metric_to_summary metric);
+  if cfg.strict && metric.Completion_trust_audit.foreign_assignee_completions <> []
+  then exit 1
+;;

--- a/bin/masc_completion_trust_audit.ml
+++ b/bin/masc_completion_trust_audit.ml
@@ -54,7 +54,7 @@ let rec parse_args cfg = function
   | ("-h" | "--help") :: _ ->
     print_string usage;
     exit 0
-  | "--events-dir" :: dir :: rest -> parse_args { cfg with events_dir = dir } rest
+  | "--events-dir" :: dir :: rest -> parse_args { cfg with events_dir = Some dir } rest
   | "--month" :: m :: rest -> parse_args { cfg with month = Some m } rest
   | "--json" :: rest -> parse_args { cfg with json = true } rest
   | "--strict" :: rest -> parse_args { cfg with strict = true } rest

--- a/lib/completion_trust_audit/completion_trust_audit.ml
+++ b/lib/completion_trust_audit/completion_trust_audit.ml
@@ -1,0 +1,282 @@
+module SMap = Map.Make (String)
+
+type authority =
+  | Assignee
+  | Operator
+  | System
+  | Legacy_forced
+  | Legacy_unforced
+  | Unknown of string
+
+type done_record = {
+  task_id : string;
+  actor : string;
+  authority : authority;
+  assignee : string option;
+  ts : string;
+}
+
+type metric = {
+  done_total : int;
+  done_assignee : int;
+  done_operator : int;
+  done_system : int;
+  done_legacy_forced : int;
+  done_legacy_unforced : int;
+  done_unknown_authority : int;
+  foreign_assignee_completions : done_record list;
+  verification_approvals : int;
+  force_equivalent_completions : int;
+  indeterminate_ownership : int;
+  events_parsed : int;
+  events_skipped : int;
+}
+
+let empty_metric =
+  { done_total = 0
+  ; done_assignee = 0
+  ; done_operator = 0
+  ; done_system = 0
+  ; done_legacy_forced = 0
+  ; done_legacy_unforced = 0
+  ; done_unknown_authority = 0
+  ; foreign_assignee_completions = []
+  ; verification_approvals = 0
+  ; force_equivalent_completions = 0
+  ; indeterminate_ownership = 0
+  ; events_parsed = 0
+  ; events_skipped = 0
+  }
+;;
+
+let authority_to_string = function
+  | Assignee -> "assignee"
+  | Operator -> "operator"
+  | System -> "system"
+  | Legacy_forced -> "legacy_forced"
+  | Legacy_unforced -> "legacy_unforced"
+  | Unknown s -> Printf.sprintf "unknown(%s)" s
+;;
+
+(* Field extractors pattern-match the [`Assoc] directly rather than using
+   [Yojson.Safe.Util], which raises on type mismatch. A missing or wrong-typed
+   field yields [None] — a log line we cannot interpret never aborts the fold. *)
+let str_field kvs key =
+  match List.assoc_opt key kvs with
+  | Some (`String s) -> Some s
+  | Some _ | None -> None
+;;
+
+let bool_field kvs key =
+  match List.assoc_opt key kvs with
+  | Some (`Bool b) -> Some b
+  | Some _ | None -> None
+;;
+
+(* RFC-0262 wire label -> typed authority. Pre-0262 lines have no [authority]
+   field, so we recover the legacy distinction from [forced]. An unrecognised
+   label is surfaced as [Unknown], not folded into a convenient default
+   (CLAUDE.md: unknown input -> explicit variant, never permissive default). *)
+let parse_authority ~forced authority_label =
+  match authority_label with
+  | None -> if forced then Legacy_forced else Legacy_unforced
+  | Some "assignee" -> Assignee
+  | Some "operator" -> Operator
+  | Some "system" -> System
+  | Some other -> Unknown other
+;;
+
+(* A "self-claim" authority is a non-Operator/System actor acting on its own
+   claim — the only authority for which completing a *foreign* task is a §9①
+   violation. [Unknown] is conservatively excluded (we cannot assert it is a
+   self-claim actor). *)
+let is_self_claim_authority = function
+  | Assignee | Legacy_unforced -> true
+  | Operator | System | Legacy_forced | Unknown _ -> false
+;;
+
+let is_force_equivalent = function
+  | Operator | System | Legacy_forced -> true
+  | Assignee | Legacy_unforced | Unknown _ -> false
+;;
+
+type acc = {
+  claimant : string SMap.t;
+  metric : metric;
+}
+
+let bump_authority metric = function
+  | Assignee -> { metric with done_assignee = metric.done_assignee + 1 }
+  | Operator -> { metric with done_operator = metric.done_operator + 1 }
+  | System -> { metric with done_system = metric.done_system + 1 }
+  | Legacy_forced -> { metric with done_legacy_forced = metric.done_legacy_forced + 1 }
+  | Legacy_unforced ->
+    { metric with done_legacy_unforced = metric.done_legacy_unforced + 1 }
+  | Unknown _ ->
+    { metric with done_unknown_authority = metric.done_unknown_authority + 1 }
+;;
+
+let process_done acc ~task_id ~actor ~authority ~from_status ~logged_assignee ~ts =
+  (* Prefer the owner the transition itself recorded (RFC-0262 §9 [assignee]
+     field); fall back to stream reconstruction only for legacy lines that
+     predate it. A logged assignee removes the out-of-window blind spot, so such
+     a completion is never [indeterminate]. *)
+  let assignee =
+    match logged_assignee with
+    | Some _ as a -> a
+    | None -> SMap.find_opt task_id acc.claimant
+  in
+  let m = acc.metric in
+  let m = { m with done_total = m.done_total + 1 } in
+  let m = bump_authority m authority in
+  let m =
+    if is_force_equivalent authority
+    then { m with force_equivalent_completions = m.force_equivalent_completions + 1 }
+    else m
+  in
+  (* A completion from [awaiting_verification] is an [Approve_verification] by the
+     bound verifier, which the FSM *requires* to differ from the assignee
+     (cross-agent verification, #4). It is never a §9① foreign completion — the
+     foreign check only applies to a *direct* [Done_action] (from claimed /
+     in_progress). Mixing the two is what over-counted the live log. *)
+  let m =
+    match from_status with
+    | "awaiting_verification" ->
+      { m with verification_approvals = m.verification_approvals + 1 }
+    | _ ->
+      (match assignee with
+       | Some a when a <> actor && is_self_claim_authority authority ->
+         let record = { task_id; actor; authority; assignee = Some a; ts } in
+         { m with
+           foreign_assignee_completions = record :: m.foreign_assignee_completions
+         }
+       | None when is_self_claim_authority authority ->
+         (* Ownership matters here but the claim is outside the fed window —
+            indeterminate, not a violation ("indeterminate dominates"). *)
+         { m with indeterminate_ownership = m.indeterminate_ownership + 1 }
+       | Some _ | None -> m)
+  in
+  (* A completion releases ownership of the task. *)
+  { claimant = SMap.remove task_id acc.claimant; metric = m }
+;;
+
+let process_event acc (ev : Yojson.Safe.t) =
+  match ev with
+  | `Assoc kvs ->
+    let acc =
+      { acc with metric = { acc.metric with events_parsed = acc.metric.events_parsed + 1 } }
+    in
+    let task = str_field kvs "task" in
+    let actor = str_field kvs "agent" in
+    let to_status = str_field kvs "to_status" in
+    (match task, to_status with
+     | Some task_id, Some "claimed" ->
+       (match actor with
+        | Some a -> { acc with claimant = SMap.add task_id a acc.claimant }
+        | None -> acc)
+     | Some task_id, Some "todo" ->
+       (* release back to the pool clears ownership *)
+       { acc with claimant = SMap.remove task_id acc.claimant }
+     | Some task_id, Some "cancelled" ->
+       { acc with claimant = SMap.remove task_id acc.claimant }
+     | Some task_id, Some "done" ->
+       let actor = Option.value actor ~default:"" in
+       let forced = Option.value (bool_field kvs "forced") ~default:false in
+       let authority = parse_authority ~forced (str_field kvs "authority") in
+       let from_status = Option.value (str_field kvs "from_status") ~default:"" in
+       let logged_assignee = str_field kvs "assignee" in
+       let ts = Option.value (str_field kvs "ts") ~default:"" in
+       process_done acc ~task_id ~actor ~authority ~from_status ~logged_assignee ~ts
+     | Some _, Some ("in_progress" | "awaiting_verification") ->
+       (* start / verification keep the same claimant — no ownership change *)
+       acc
+     | Some _, Some _ ->
+       (* an unrecognised status string (e.g. a future state): a completion is
+          always [to_status="done"], so anything else cannot be a §9 event. *)
+       acc
+     | Some _, None | None, _ -> acc)
+  | _ -> { acc with metric = { acc.metric with events_skipped = acc.metric.events_skipped + 1 } }
+;;
+
+let audit_events events =
+  let final =
+    List.fold_left process_event { claimant = SMap.empty; metric = empty_metric } events
+  in
+  (* foreign completions were prepended; restore chronological order *)
+  { final.metric with
+    foreign_assignee_completions = List.rev final.metric.foreign_assignee_completions
+  }
+;;
+
+let done_record_to_json r =
+  `Assoc
+    [ "task", `String r.task_id
+    ; "actor", `String r.actor
+    ; "authority", `String (authority_to_string r.authority)
+    ; "assignee", (match r.assignee with Some a -> `String a | None -> `Null)
+    ; "ts", `String r.ts
+    ]
+;;
+
+let metric_to_json m : Yojson.Safe.t =
+  `Assoc
+    [ "done_total", `Int m.done_total
+    ; ( "done_by_authority"
+      , `Assoc
+          [ "assignee", `Int m.done_assignee
+          ; "operator", `Int m.done_operator
+          ; "system", `Int m.done_system
+          ; "legacy_forced", `Int m.done_legacy_forced
+          ; "legacy_unforced", `Int m.done_legacy_unforced
+          ; "unknown", `Int m.done_unknown_authority
+          ] )
+    ; ( "foreign_assignee_completion_count"
+      , `Int (List.length m.foreign_assignee_completions) )
+    ; ( "foreign_assignee_completions"
+      , `List (List.map done_record_to_json m.foreign_assignee_completions) )
+    ; "verification_approvals", `Int m.verification_approvals
+    ; "force_equivalent_completions", `Int m.force_equivalent_completions
+    ; "indeterminate_ownership", `Int m.indeterminate_ownership
+    ; "events_parsed", `Int m.events_parsed
+    ; "events_skipped", `Int m.events_skipped
+    ; ( "section_9_verdict"
+      , `String (if m.foreign_assignee_completions = [] then "PASS" else "FAIL") )
+    ]
+;;
+
+let metric_to_summary m =
+  let buf = Buffer.create 512 in
+  let line fmt = Printf.ksprintf (fun s -> Buffer.add_string buf (s ^ "\n")) fmt in
+  line "RFC-0262 §9 completion-trust audit";
+  line "  events: %d parsed, %d skipped" m.events_parsed m.events_skipped;
+  line "  completions: %d total" m.done_total;
+  line
+    "    by authority: assignee=%d operator=%d system=%d legacy_forced=%d legacy_unforced=%d unknown=%d"
+    m.done_assignee
+    m.done_operator
+    m.done_system
+    m.done_legacy_forced
+    m.done_legacy_unforced
+    m.done_unknown_authority;
+  line
+    "  verification approvals (cross-agent, not §9① foreign): %d"
+    m.verification_approvals;
+  line
+    "  §9② force-equivalent completions (Phase-3 evidence-gate baseline): %d"
+    m.force_equivalent_completions;
+  line "  indeterminate ownership (claim out of window): %d" m.indeterminate_ownership;
+  let foreign = List.length m.foreign_assignee_completions in
+  line "  §9① foreign completions by a non-Operator/System actor: %d" foreign;
+  List.iter
+    (fun r ->
+      line
+        "      VIOLATION task=%s actor=%s assignee=%s authority=%s ts=%s"
+        r.task_id
+        r.actor
+        (Option.value r.assignee ~default:"?")
+        (authority_to_string r.authority)
+        r.ts)
+    m.foreign_assignee_completions;
+  line "  §9① verdict: %s" (if foreign = 0 then "PASS" else "FAIL");
+  Buffer.contents buf
+;;

--- a/lib/completion_trust_audit/completion_trust_audit.mli
+++ b/lib/completion_trust_audit/completion_trust_audit.mli
@@ -1,0 +1,94 @@
+(** Completion_trust_audit — the RFC-0262 §9 metric, computed offline over the
+    task-transition event log.
+
+    RFC-0262 Phase 1 typed task completion as a closed [completion_authority]
+    sum and Phase 2 flipped peer force-completion to default-deny. Neither phase
+    changes the metric by itself — they exist so the §9 invariant becomes
+    *checkable*. This module is that check: a pure fold over the transition log
+    (the lines emitted by [Workspace_task_classify.transition_log_event]) into
+    the two §9 quantities.
+
+    §9, verbatim: "zero foreign-task completions by a non-[Operator]/[System]
+    actor in the live log, and no [Done] reachable from a force-equivalent path
+    that skipped the evidence gate."
+
+    Ownership comes from one of two sources, in order of preference:
+    - the [assignee] field the transition itself records (RFC-0262 §9) — the
+      task's owner immediately before completion. This is exact and needs no
+      history.
+    - failing that (legacy lines predating the field), *reconstruction* from the
+      event stream: the fold tracks [task -> current claimant] from claim /
+      release / cancel transitions and cross-checks it at each completion.
+
+    The [authority] label refines the force-equivalent breakdown ([Operator]
+    override vs [System] code-path satisfier).
+
+    The fold assumes its input is in chronological order (the order daily JSONL
+    files are appended). For a *legacy* completion whose claim is outside the fed
+    window the owner is unknown, so it is [Indeterminate], never a violation —
+    "indeterminate dominates", mirroring {!Deterministic_evidence_evaluator}. A
+    completion carrying a logged [assignee] is never indeterminate. *)
+
+type authority =
+  | Assignee  (** RFC-0262 [authority="assignee"] — actor completing its own claim *)
+  | Operator  (** [authority="operator"] — operator control plane / admin override *)
+  | System  (** [authority="system"] — code-path satisfier (RFC-0199 probe, GC) *)
+  | Legacy_forced
+      (** pre-RFC-0262 line: no [authority] field, [forced]=true (force-equivalent) *)
+  | Legacy_unforced
+      (** pre-RFC-0262 line: no [authority] field, [forced]=false (self-claim) *)
+  | Unknown of string  (** an [authority] label this version does not recognise *)
+
+type done_record = {
+  task_id : string;
+  actor : string;
+  authority : authority;
+  assignee : string option;  (** reconstructed claimant, [None] if claim out of window *)
+  ts : string;
+}
+
+type metric = {
+  done_total : int;
+  done_assignee : int;
+  done_operator : int;
+  done_system : int;
+  done_legacy_forced : int;
+  done_legacy_unforced : int;
+  done_unknown_authority : int;
+  foreign_assignee_completions : done_record list;
+      (** §9①: a non-[Operator]/[System] actor (authority [Assignee] /
+          [Legacy_unforced]) *directly* completed a *foreign* task
+          ([from_status] claimed / in_progress, i.e. a [Done_action]). MUST be
+          empty. Verification approvals are excluded — see
+          [verification_approvals]. *)
+  verification_approvals : int;
+      (** completions reached via [Approve_verification]
+          ([from_status="awaiting_verification"]). The actor here is the bound
+          verifier, which the FSM *requires* to differ from the assignee
+          (cross-agent verification, #4); such a completion is never a §9①
+          violation. Counted separately so the foreign-completion check is not
+          fooled by the verification protocol. *)
+  force_equivalent_completions : int;
+      (** §9②: completions via [Operator] / [System] / [Legacy_forced] — the
+          force-equivalent paths. Phase-3 baseline: every one of these currently
+          skips the evidence gate (RFC-0199 Phase B wires it). *)
+  indeterminate_ownership : int;
+      (** completions whose claim was outside the fed window — ownership unknown,
+          not counted as a violation. *)
+  events_parsed : int;
+  events_skipped : int;  (** non-object / unparseable lines *)
+}
+
+val empty_metric : metric
+
+val authority_to_string : authority -> string
+
+val audit_events : Yojson.Safe.t list -> metric
+(** Fold a chronological transition-event stream into the §9 metric. Pure:
+    ownership is reconstructed per call, nothing is read from disk. *)
+
+val metric_to_json : metric -> Yojson.Safe.t
+
+val metric_to_summary : metric -> string
+(** Human-readable one-screen report, including the §9 verdict
+    (PASS when [foreign_assignee_completions] is empty). *)

--- a/lib/completion_trust_audit/dune
+++ b/lib/completion_trust_audit/dune
@@ -1,0 +1,7 @@
+(include_subdirs no)
+
+(library
+ (name completion_trust_audit)
+ (public_name masc.completion_trust_audit)
+ (modules completion_trust_audit)
+ (libraries yojson))

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -249,6 +249,16 @@ type completion_authority =
           cleanup); never minted by an LLM/keeper turn *)
 [@@deriving show]
 
+(* Stable wire label for transition-log serialization. Deliberately not
+   [show_completion_authority] — [@@deriving show] emits the constructor name and
+   its formatting is an implementation detail; the log schema (and the §9 auditor
+   that reads it) must pin a fixed lowercase token. *)
+let completion_authority_to_string = function
+  | Assignee -> "assignee"
+  | Operator -> "operator"
+  | System -> "system"
+;;
+
 let task_action_of_string s =
   match String.lowercase_ascii s with
   | "claim" -> Ok Claim

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -79,6 +79,11 @@ type completion_authority =
   | System
 [@@deriving show]
 
+val completion_authority_to_string : completion_authority -> string
+(** Stable lowercase wire label ([assignee] / [operator] / [system]) for
+    transition-log serialization. Distinct from {!show_completion_authority},
+    whose output is a [@@deriving] detail not safe to persist. *)
+
 (* RFC-0220: verification sub-state folded into [task_status] (was a separate
    request_status store) so the illegal Todo+Pending pair is unrepresentable. *)
 type verification_phase =

--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -446,6 +446,8 @@ let transition_log_event
       ?duration_ms
       ?handoff_context
       ?(forced = false)
+      ?(authority = Assignee)
+      ?assignee
       ?(now = now_iso ())
       ()
   : Yojson.Safe.t
@@ -462,8 +464,19 @@ let transition_log_event
      ; "from_status", `String (task_status_to_string from_status)
      ; "to_status", `String (task_status_to_string to_status)
      ; "forced", `Bool forced
+       (* RFC-0262 §9: the typed authority the FSM granted this transition.
+          [forced] is now the derived projection ([authority <> Assignee]); the
+          §9 auditor (Completion_trust_audit) keys off [authority] to tell an
+          Operator override from a System code-path satisfier. *)
+     ; "authority", `String (completion_authority_to_string authority)
      ; "ts", `String now
      ]
+     (* RFC-0262 §9: the task's owner *before* this transition (the [from_status]
+        assignee). Recorded so the §9① foreign-completion check is a direct
+        [actor <> assignee] comparison instead of reconstructing ownership from
+        the claim stream — the latter is blind to any claim outside the audited
+        window. [None] for Todo / Cancelled from-states (no owner). *)
+     @ optional_field "assignee" (Option.map (fun v -> `String v) assignee)
      @ optional_field "action" (Option.map (fun v -> `String v) action)
      @ optional_field "notes" (Option.map (fun v -> `String v) notes)
      @ optional_field "reason" (Option.map (fun v -> `String v) reason)

--- a/lib/workspace/workspace_task_classify.mli
+++ b/lib/workspace/workspace_task_classify.mli
@@ -192,6 +192,8 @@ val transition_log_event
   -> ?duration_ms:int
   -> ?handoff_context:Masc_domain.task_handoff_context
   -> ?forced:bool
+  -> ?authority:Masc_domain.completion_authority
+  -> ?assignee:string
   -> ?now:string
   -> unit
   -> Yojson.Safe.t

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -514,6 +514,8 @@ let transition_task_outcome_r
                ~to_status:new_status
                ~action:action_s
                ~forced:forced
+               ~authority
+               ?assignee:(Masc_domain.task_assignee_of_status task.task_status)
                ?notes:(trim_opt (Some notes))
                ?reason:(trim_opt (Some reason))
                ?handoff_context:backlog_update.persisted_handoff_context

--- a/test/dune
+++ b/test/dune
@@ -1109,6 +1109,13 @@
  (modules test_lockfree_atomic)
  (libraries alcotest masc.lockfree_atomic))
 
+; RFC-0262 §9 completion-trust audit (foreign-completion regression oracle).
+
+(test
+ (name test_completion_trust_audit)
+ (modules test_completion_trust_audit)
+ (libraries alcotest yojson masc.completion_trust_audit))
+
 ; Scheduled internal automation domain guardrails.
 
 (test

--- a/test/test_completion_trust_audit.ml
+++ b/test/test_completion_trust_audit.ml
@@ -1,0 +1,229 @@
+(** Tests for Completion_trust_audit — the RFC-0262 §9 metric fold.
+
+    Structured as a TLA+ bug-model pairing at the log level: a *clean* event
+    stream must produce zero §9① violations (PASS), and a stream with a planted
+    foreign completion must be *caught* (FAIL). If the planted-violation test
+    ever passes with [foreign=0], the auditor has stopped detecting the very bug
+    RFC-0262 closed. *)
+
+module A = Completion_trust_audit
+
+let claimed ~task ~agent =
+  `Assoc
+    [ "type", `String "task_transition"
+    ; "agent", `String agent
+    ; "task", `String task
+    ; "to_status", `String "claimed"
+    ; "action", `String "claim"
+    ]
+;;
+
+let done_ev ?authority ?assignee ?(forced = false) ?(from_status = "in_progress") ~task ~agent
+  ()
+  =
+  `Assoc
+    ([ "type", `String "task_transition"
+     ; "agent", `String agent
+     ; "task", `String task
+     ; "from_status", `String from_status
+     ; "to_status", `String "done"
+     ; "action", `String (if from_status = "awaiting_verification" then "approve" else "done")
+     ; "forced", `Bool forced
+     ; "ts", `String "2026-06-19T00:00:00Z"
+     ]
+     @ (match authority with Some a -> [ "authority", `String a ] | None -> [])
+     @ (match assignee with Some a -> [ "assignee", `String a ] | None -> []))
+;;
+
+(* ---- clean stream: every completion is a legitimate self-completion ---- *)
+
+let clean_log =
+  [ claimed ~task:"A" ~agent:"alice"
+  ; done_ev ~authority:"assignee" ~task:"A" ~agent:"alice" ()
+  ; claimed ~task:"B" ~agent:"bob"
+  ; done_ev ~authority:"assignee" ~task:"B" ~agent:"bob" ()
+  ]
+;;
+
+let test_clean_log_passes () =
+  let m = A.audit_events clean_log in
+  Alcotest.(check int) "two completions" 2 m.A.done_total;
+  Alcotest.(check int) "all assignee" 2 m.A.done_assignee;
+  Alcotest.(check int)
+    "no foreign violations"
+    0
+    (List.length m.A.foreign_assignee_completions);
+  Alcotest.(check int) "no force-equivalent" 0 m.A.force_equivalent_completions;
+  Alcotest.(check int) "no indeterminate" 0 m.A.indeterminate_ownership
+;;
+
+(* ---- planted stream: foreign self-claim completions must be caught ---- *)
+
+let planted_log =
+  [ (* legit self-completion *)
+    claimed ~task:"A" ~agent:"alice"
+  ; done_ev ~authority:"assignee" ~task:"A" ~agent:"alice" ()
+  ; (* PLANTED §9① violation: bob claims, carol completes with assignee authority *)
+    claimed ~task:"B" ~agent:"bob"
+  ; done_ev ~authority:"assignee" ~task:"B" ~agent:"carol" ()
+  ; (* legit operator override on a foreign task (not a §9① violation) *)
+    claimed ~task:"C" ~agent:"dave"
+  ; done_ev ~authority:"operator" ~task:"C" ~agent:"ops" ()
+  ; (* legit system code-path completion on a foreign task *)
+    claimed ~task:"D" ~agent:"erin"
+  ; done_ev ~authority:"system" ~task:"D" ~agent:"probe" ()
+  ; (* PLANTED legacy §9① violation: no authority field, forced=false, foreign *)
+    claimed ~task:"E" ~agent:"frank"
+  ; done_ev ~task:"E" ~agent:"grace" ()
+  ; (* legacy forced override (legacy_forced -> force-equivalent, legit) *)
+    claimed ~task:"F" ~agent:"heidi"
+  ; done_ev ~forced:true ~task:"F" ~agent:"ops" ()
+  ; (* indeterminate: assignee-authority completion with no preceding claim *)
+    done_ev ~authority:"assignee" ~task:"G" ~agent:"ivan" ()
+  ; (* legitimate cross-agent verification approval: judy claims, the bound
+       verifier (≠ assignee, by FSM design) approves from awaiting_verification.
+       NOT a §9① foreign completion — this is the live-log over-count we fixed. *)
+    claimed ~task:"H" ~agent:"judy"
+  ; done_ev ~from_status:"awaiting_verification" ~task:"H" ~agent:"verifier-keeper" ()
+  ; (* malformed line *)
+    `String "garbage"
+  ]
+;;
+
+let test_planted_violations_caught () =
+  let m = A.audit_events planted_log in
+  Alcotest.(check int) "eight completions" 8 m.A.done_total;
+  Alcotest.(check int) "one verification approval, not foreign" 1 m.A.verification_approvals;
+  Alcotest.(check int)
+    "two foreign self-claim violations caught"
+    2
+    (List.length m.A.foreign_assignee_completions);
+  (* the violations are B/carol and E/grace, in chronological order *)
+  (match m.A.foreign_assignee_completions with
+   | [ first; second ] ->
+     Alcotest.(check string) "first violation task" "B" first.A.task_id;
+     Alcotest.(check string) "first violation actor" "carol" first.A.actor;
+     Alcotest.(check string) "first violation owner" "bob"
+       (Option.value first.A.assignee ~default:"?");
+     Alcotest.(check string) "second violation task" "E" second.A.task_id;
+     Alcotest.(check string) "second violation actor" "grace" second.A.actor
+   | other ->
+     Alcotest.failf "expected 2 violations, got %d" (List.length other));
+  Alcotest.(check int)
+    "force-equivalent: operator + system + legacy_forced"
+    3
+    m.A.force_equivalent_completions;
+  Alcotest.(check int) "one indeterminate" 1 m.A.indeterminate_ownership;
+  Alcotest.(check int) "one malformed line skipped" 1 m.A.events_skipped
+;;
+
+(* ---- force-equivalent foreign completions are legitimate, not violations ---- *)
+
+let test_force_equivalent_not_flagged () =
+  let log =
+    [ claimed ~task:"X" ~agent:"owner"
+    ; done_ev ~authority:"operator" ~task:"X" ~agent:"someone_else" ()
+    ; claimed ~task:"Y" ~agent:"owner2"
+    ; done_ev ~authority:"system" ~task:"Y" ~agent:"probe" ()
+    ]
+  in
+  let m = A.audit_events log in
+  Alcotest.(check int)
+    "no §9① violation for operator/system foreign"
+    0
+    (List.length m.A.foreign_assignee_completions);
+  Alcotest.(check int) "both force-equivalent" 2 m.A.force_equivalent_completions
+;;
+
+(* ---- unknown authority label surfaces explicitly, never as a violation ---- *)
+
+let test_unknown_authority_bucketed () =
+  let log =
+    [ claimed ~task:"Z" ~agent:"owner"
+    ; done_ev ~authority:"superuser" ~task:"Z" ~agent:"someone_else" ()
+    ]
+  in
+  let m = A.audit_events log in
+  Alcotest.(check int) "unknown authority counted" 1 m.A.done_unknown_authority;
+  Alcotest.(check int)
+    "unknown is not a §9① violation"
+    0
+    (List.length m.A.foreign_assignee_completions);
+  Alcotest.(check int)
+    "unknown is not force-equivalent"
+    0
+    m.A.force_equivalent_completions
+;;
+
+(* ---- a verifier completing from awaiting_verification is never foreign ---- *)
+
+let test_verification_approval_not_foreign () =
+  let log =
+    [ claimed ~task:"V" ~agent:"submitter"
+    ; done_ev ~from_status:"awaiting_verification" ~task:"V" ~agent:"a_different_verifier" ()
+    ]
+  in
+  let m = A.audit_events log in
+  Alcotest.(check int)
+    "verifier approval not counted as §9① foreign"
+    0
+    (List.length m.A.foreign_assignee_completions);
+  Alcotest.(check int) "counted as a verification approval" 1 m.A.verification_approvals;
+  Alcotest.(check int) "no indeterminate" 0 m.A.indeterminate_ownership
+;;
+
+(* ---- logged assignee: foreign caught directly, no claim reconstruction ---- *)
+
+let test_logged_assignee_direct () =
+  (* No claim events at all — ownership comes purely from the logged assignee
+     field. The §9 assignee logging removes the out-of-window blind spot. *)
+  let log =
+    [ done_ev ~authority:"assignee" ~assignee:"real_owner" ~task:"P" ~agent:"intruder" ()
+    ; done_ev ~authority:"assignee" ~assignee:"self" ~task:"Q" ~agent:"self" ()
+    ]
+  in
+  let m = A.audit_events log in
+  Alcotest.(check int)
+    "foreign caught from logged assignee without any claim event"
+    1
+    (List.length m.A.foreign_assignee_completions);
+  Alcotest.(check int)
+    "logged assignee is never indeterminate"
+    0
+    m.A.indeterminate_ownership;
+  match m.A.foreign_assignee_completions with
+  | [ r ] ->
+    Alcotest.(check string) "violation task" "P" r.A.task_id;
+    Alcotest.(check string) "violation owner" "real_owner"
+      (Option.value r.A.assignee ~default:"?")
+  | other -> Alcotest.failf "expected 1, got %d" (List.length other)
+;;
+
+let () =
+  Alcotest.run
+    "completion_trust_audit"
+    [ ( "section_9"
+      , [ Alcotest.test_case "clean log passes" `Quick test_clean_log_passes
+        ; Alcotest.test_case
+            "logged assignee direct measurement"
+            `Quick
+            test_logged_assignee_direct
+        ; Alcotest.test_case
+            "planted violations caught"
+            `Quick
+            test_planted_violations_caught
+        ; Alcotest.test_case
+            "force-equivalent not flagged"
+            `Quick
+            test_force_equivalent_not_flagged
+        ; Alcotest.test_case
+            "verification approval not foreign"
+            `Quick
+            test_verification_approval_not_foreign
+        ; Alcotest.test_case
+            "unknown authority bucketed"
+            `Quick
+            test_unknown_authority_bucketed
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표

RFC-0262 §9 완료신뢰 불변식을 *측정 가능*하게 만든다. Phase 1(typed authority)·Phase 2(default-deny)는 단독으로 행동을 바꾸지 않는다 — §9 불변식이 *검증 가능*해지도록 존재한다. 이 PR이 그 검증기다(MANIFEST "Harness First").

§9: "비-Operator/System actor의 foreign-task 완료 0건, evidence gate를 건너뛴 force-equivalent Done 0건".

## 변경

- `lib/types/types_core.ml(.mli)`: `completion_authority_to_string` — 안정적 소문자 wire 라벨(assignee/operator/system). `[@@deriving show]`와 분리(로그 스키마가 deriving 세부에 의존 안 함).
- `lib/workspace/workspace_task_classify.ml(.mli)` `transition_log_event`: additive `?authority` + `?assignee`.
  - `"authority"`: FSM이 부여한 typed authority. 기존 `"forced"`는 derived projection.
  - `"assignee"`: 전이 *직전* task owner(from_status assignee). §9①이 **직접 actor≠assignee 비교**가 되어 ownership 재구성의 window 사각이 사라짐.
- 신규 lib `lib/completion_trust_audit/`: transition-event 스트림을 §9 metric으로 fold하는 **순수 함수**. ownership은 로깅된 assignee 우선, 없으면(legacy 라인) claim/release/cancel 재구성. "Indeterminate dominates"(legacy + claim이 window 밖 → 위반 아님).
- 신규 bin `bin/masc_completion_trust_audit.ml`: `.masc/events/` 라이브 CLI(순수 auditor만 링크, masc 런타임 의존 없음).

§9① foreign 검사는 **직접 Done_action**(from claimed/in_progress)에만 적용. `awaiting_verification`발 완료는 bound verifier의 Approve_verification(verifier≠assignee가 #4 cross-agent verification의 FSM 설계) — 별도 카운트, 미플래그.

## 적대적 검증 (요청에 따른 self-review)

측정 하네스에서 가장 위험한 건 **false negative**(실재 위반을 놓침). 세 의심을 ground:

1. **제외가 force-completion을 숨기나? → REFUTED**: 라이브 로그에서 forced=true 완료는 claimed(3)·in_progress(47)에서만 옴, `awaiting_verification`발 forced=true = **0건**. 70건 verification 승인은 전부 비-forced → 제외가 어떤 force-completion도 가리지 않음.
2. **커버리지 → 근본 수정**: 초기 재구성-only로는 indeterminate 608/809(claim window 밖) = §9①이 ~18%만 검증. 이를 위해 `assignee`를 done 이벤트에 로깅 → forward 100% 커버리지(재구성 불필요). legacy 로그는 여전히 재구성(정직하게 indeterminate 보고).
3. **task-627 합리화 아닌가? → benign 확인**: `legacy_unforced`(forced:false)라 구 FSM `same_agent assignee || force`에서 same_agent를 참으로 봐 허용 = 런타임 canonical identity 동일(`keeper-issue_king-agent`==`issue_king` keeper persona), 로그 표면 string만 다름. **이름 정규화 하드코딩 거부**(string-classifier 워크어라운드) — exact-match로 후보만 surface, identity 해소는 로그 writer 상위 책임.

**독립 재구현(Python)이 모든 카운트를 재현**(done 809 / foreign 1 / verif 70 / force-equiv 50 / indeterminate 608=577 never-claimed+31 released). OCaml auditor corroborated.

## 검증

- `test_completion_trust_audit` 6 케이스: clean=PASS / **logged-assignee 직접측정(재구성 없이 foreign 검출)** / planted violation=caught(2) / force-equivalent 미플래그 / verification 승인 미플래그 / unknown authority 버킷. TLA+ bug-model 컨벤션의 로그판(clean 통과·planted 잡힘).
- 라이브 audit(32743 events, 809 완료): **§9① 실재 위반 0건**. §9② force-equivalent baseline 50건(Phase 3 evidence-gate 대상).
- 전체 `dune build --root .` green(transition_log_event 변경은 additive, 기존 caller 무영향).

## 베이스 / 의존

`completion_authority` 타입(#21612, RFC-0262 Phase 1)에 의존 → 베이스 `feat/rfc-0262-completion-authority`. #21612 머지 후 main으로 rebase/retarget 필요(컨베이어 squash 시 베이스 커밋 소멸, masc#5303 교훈).

## 워크어라운드 self-check

auditor = read-only 회귀 오라클. telemetry-as-fix 아님(수정은 Phase 1/2에 이미 landed, 이건 *유지*를 측정). string-classifier(authority=closed sum, wire 라벨 decode)·N-of-M·cap-cooldown·catch-all 없음. transition_log_event 변경은 additive.

RFC-0262 §9 인용 (transition log = operator-adjacent subsystem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
