### PR TITLE
docs(dashboard): tool_denylist 편집기 tool_access 근거 정정 + 빈 allowlist 테스트

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2317,10 +2317,12 @@ export async function patchKeeperConfig(
 
 // Tool policy is set atomically (tool_access + denylist) via the dedicated
 // /tools endpoint with action=set_policy — a different mutation shape from the
-// /config PATCH above. The caller MUST echo the current tool_access so editing
-// only the denylist does not wipe the keeper's access. The endpoint returns the
-// updated tools block (not the full config), so we re-fetch the config to get a
-// consistent normalized snapshot.
+// /config PATCH above. The caller should echo the current tool_access so that
+// editing only the denylist preserves the operator's configured allowlist
+// record (which feeds tool visibility + assignment telemetry). Runtime
+// execution gating keys only off the denylist, not tool_access. The endpoint
+// returns the updated tools block (not the full config), so we re-fetch the
+// config to get a consistent normalized snapshot.
 export async function setKeeperToolPolicy(
   name: string,
   policy: { tool_access: string[]; deny: string[] },

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -717,11 +717,46 @@ describe('KeeperConfigPanel', () => {
     await flush()
     await flush()
 
-    // Safety: set_policy sets tool_access AND deny atomically, so the current
-    // tool_access must be echoed unchanged; the deny list is trimmed + deduped.
+    // set_policy overwrites tool_access AND deny atomically, so the editor
+    // echoes the current tool_access unchanged (preserving the configured
+    // allowlist record); the deny list is trimmed + deduped.
     expect(mocks.setKeeperToolPolicy).toHaveBeenCalledWith('keeper-sangsu', {
       tool_access: ['tool_read_file'],
       deny: ['Execute', 'mcp__masc__masc_board_delete'],
+    })
+  })
+
+  it('echoes an empty tool_access allowlist unchanged (never fabricates access)', async () => {
+    mocks.setKeeperToolPolicy.mockClear()
+    const base = makeKeeperConfig()
+    mocks.fetchKeeperConfig.mockResolvedValueOnce(
+      makeKeeperConfig({ tools: { ...base.tools, tool_access: [] } }),
+    )
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    const denylist = container.querySelector(
+      'textarea[aria-label="tool_denylist"]',
+    ) as HTMLTextAreaElement | null
+    expect(denylist).not.toBeNull()
+    denylist!.value = 'Execute\nDangerTool'
+    denylist!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('정책 저장'),
+    )
+    saveButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    await flush()
+
+    // An empty allowlist round-trips as []; the editor must not substitute a
+    // non-empty set. (Runtime gates on the denylist, not tool_access, so [] here
+    // means "all candidates", which the operator's config already chose.)
+    expect(mocks.setKeeperToolPolicy).toHaveBeenCalledWith('keeper-sangsu', {
+      tool_access: [],
+      deny: ['Execute', 'DangerTool'],
     })
   })
 

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -732,8 +732,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     const deny = parseDenylistDraft(text)
     denylistSaving.value = true
     try {
-      // Echo the current tool_access so set_policy (which sets access AND deny
-      // atomically) does not wipe the keeper's tool access.
+      // set_policy overwrites tool_access AND tool_denylist atomically, so echo
+      // the current tool_access to preserve the operator's configured allowlist
+      // record (consumed by tool visibility + assignment telemetry). Runtime
+      // EXECUTION gating keys only off the denylist, not tool_access — see
+      // keeper_tool_policy.ml ("tool_access does NOT gate execution"; empty
+      // tool_access means "all candidates", not "no access").
       const updated = await setKeeperToolPolicy(keeperName, {
         tool_access: c.tools.tool_access,
         deny,


### PR DESCRIPTION
#21623 적대 리뷰 후속(정확성). 코드 동작 변경 없음.

## 배경
#21623의 "echo tool_access so set_policy does not wipe access" 주석이 메커니즘을 과장했습니다. 적대 리뷰가 `keeper_tool_policy.ml`을 grounding해 밝힌 사실:
- 런타임 **실행 게이팅은 denylist만** 본다(tool_access는 게이트 안 함; 주석 line 252).
- empty tool_access = "all candidates"(broaden)이지 "no access"(wipe)가 아님.
- echo는 여전히 옳음 — 운영자의 설정 allowlist **기록**(tool visibility + assignment telemetry가 소비)을 보존. 단 "runtime wipe 방지"는 아님.

## 변경
- `saveToolDenylist` / `setKeeperToolPolicy` 주석을 실제 동작(allowlist 기록 보존, denylist만 게이트)으로 정정.
- **빈 tool_access allowlist가 `[]`로 round-trip**되는 회귀 테스트 추가(편집기가 non-empty access를 날조하지 않음) — 기존 테스트가 non-empty만 커버하던 P3 갭 해소.

## 로컬 검증
- `tsc` 0 / `eslint` 0 errors / `vitest` keeper-config-panel **43 passed**.

## 리뷰가 잡은 P2(중복 denylist textarea, #21598 overlap)는?
**#21630("align runtime list controls")이 main에서 이미 해소**. 현재 denylist 편집기 1개, 테스트 green. 본 PR과 무관(보고용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)