### PR TITLE
fix(dashboard): share approval risk visual banding

### DIFF
--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -78,6 +78,8 @@ describe('ApprovalsSurface', () => {
     const { ApprovalsSurface } = await loadSurface([
       queueItem({ id: 'appr-1', keeper_name: 'masc-improver', tool_name: 'fs_write', risk_level: 'critical' }),
       queueItem({ id: 'appr-2', keeper_name: 'issue-king', tool_name: 'shell', risk_level: 'low', waiting_s: 12 }),
+      queueItem({ id: 'appr-3', keeper_name: 'risk-checker', tool_name: 'shell', risk_level: 'high' }),
+      queueItem({ id: 'appr-4', keeper_name: 'risk-checker', tool_name: 'shell', risk_level: 'medium' }),
     ])
 
     render(html`<${ApprovalsSurface} />`, container)
@@ -85,12 +87,18 @@ describe('ApprovalsSurface', () => {
 
     expect(container.querySelector('[data-testid="approvals-surface"]')).not.toBeNull()
     const cards = container.querySelectorAll('[data-testid="approval-card"]')
-    expect(cards.length).toBe(2)
+    expect(cards.length).toBe(4)
     expect(container.textContent).toContain('masc-improver')
     expect(container.textContent).toContain('fs_write')
     // risk_level is surfaced uppercased on the .ap-kind badge
     expect(container.textContent).toContain('CRITICAL')
+    expect(container.textContent).toContain('HIGH')
+    expect(container.textContent).toContain('MEDIUM')
     expect(container.textContent).toContain('LOW')
+    expect(container.querySelector('[data-approval-id="appr-1"]')?.className).toContain('sev-bad')
+    expect(container.querySelector('[data-approval-id="appr-3"]')?.className).toContain('sev-warn')
+    expect(container.querySelector('[data-approval-id="appr-4"]')?.className).toContain('sev-accent')
+    expect(container.querySelector('[data-approval-id="appr-2"]')?.className).toContain('sev-info')
     // the three live decisions are exposed; the prototype's defer/undo are not
     expect(container.textContent).toContain('승인')
     expect(container.textContent).toContain('항상 승인')

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -16,6 +16,11 @@ import { useEffect, useMemo } from 'preact/hooks'
 import type { KeeperApprovalQueueItem } from '../../types'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../../config/constants'
 import { setupVisibleAutoRefresh } from '../../lib/auto-refresh'
+import {
+  isHighOrCriticalKeeperApprovalRisk,
+  keeperApprovalRiskVisualBand,
+  type KeeperApprovalRiskVisualBand,
+} from '../../lib/governance-risk-level'
 import { navigate } from '../../router'
 import { AgentAvatar } from '../overview/agent-avatar'
 import {
@@ -26,16 +31,8 @@ import {
   respondToKeeperApproval,
 } from '../governance-store'
 
-type Sev = 'bad' | 'warn' | 'info'
-
-// risk_level → prototype severity rail. critical/high are the irreversible-risk
-// band; medium warns; low/unknown is informational. Mirrors the live
-// approvalRiskToneClass banding (governance.ts) but emits the .ap- sev token.
-function apSev(riskLevel: string | null | undefined): Sev {
-  const r = (riskLevel ?? '').trim().toLowerCase()
-  if (r === 'critical' || r === 'high') return 'bad'
-  if (r === 'medium') return 'warn'
-  return 'info'
+function apSev(riskLevel: string | null | undefined): KeeperApprovalRiskVisualBand {
+  return keeperApprovalRiskVisualBand(riskLevel)
 }
 
 // seconds-waited → "N분 N초 대기" (prototype apAge).
@@ -145,7 +142,7 @@ export function ApprovalsSurface() {
   const error = governanceError.value
 
   const stats = useMemo(() => {
-    const risky = items.filter(i => apSev(i.risk_level) === 'bad').length
+    const risky = items.filter(i => isHighOrCriticalKeeperApprovalRisk(i.risk_level)).length
     const longest = items.reduce((max, i) => Math.max(max, i.waiting_s ?? 0), 0)
     const keepers = new Set(items.map(i => i.keeper_name)).size
     return { risky, longest, keepers }

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -16,6 +16,11 @@ import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { TimeAgo } from './common/time-ago'
 import {
+  isHighOrCriticalKeeperApprovalRisk,
+  keeperApprovalRiskVisualBand,
+  maxKeeperApprovalRiskLevel,
+} from '../lib/governance-risk-level'
+import {
   governanceData,
   governanceError,
   governanceLoading,
@@ -311,11 +316,16 @@ function filterApprovalQueue(
 }
 
 export function approvalRiskToneClass(riskLevel: string): string {
-  const normalized = riskLevel.trim().toLowerCase()
-  if (normalized === 'critical') return 'border-bad/30 bg-bad/10 text-bad'
-  if (normalized === 'high') return 'border-warn/30 bg-warn/10 text-warn'
-  if (normalized === 'medium') return 'border-[var(--accent-30)] bg-[var(--accent-10)] text-accent-fg'
-  return 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-text-muted'
+  switch (keeperApprovalRiskVisualBand(riskLevel)) {
+    case 'bad':
+      return 'border-bad/30 bg-bad/10 text-bad'
+    case 'warn':
+      return 'border-warn/30 bg-warn/10 text-warn'
+    case 'accent':
+      return 'border-[var(--accent-30)] bg-[var(--accent-10)] text-accent-fg'
+    case 'info':
+      return 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-text-muted'
+  }
 }
 
 function approvalDispositionToneClass(disposition?: string | null): string {
@@ -326,25 +336,8 @@ function approvalDispositionToneClass(disposition?: string | null): string {
   return 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-text-muted'
 }
 
-const RISK_RANK: Record<string, number> = {
-  critical: 4,
-  high: 3,
-  medium: 2,
-  low: 1,
-}
-
 export function maxApprovalRisk(items: readonly { risk_level?: string | null }[]): string | null {
-  let topRank = 0
-  let topLabel: string | null = null
-  for (const item of items) {
-    const raw = item.risk_level?.trim().toLowerCase()
-    const rank = raw ? (RISK_RANK[raw] ?? 0) : 0
-    if (rank > topRank) {
-      topRank = rank
-      topLabel = raw ?? null
-    }
-  }
-  return topLabel
+  return maxKeeperApprovalRiskLevel(items)
 }
 
 function scrollToKeeperApprovalSection(): void {
@@ -358,7 +351,7 @@ function KeeperApprovalAlertBanner() {
   if (items.length === 0) return null
 
   const maxRisk = maxApprovalRisk(items)
-  const isCritical = maxRisk === 'critical' || maxRisk === 'high'
+  const isCritical = isHighOrCriticalKeeperApprovalRisk(maxRisk)
   const tone = isCritical
     ? 'border-bad/40 bg-bad/10 text-bad'
     : 'border-warn/40 bg-warn/10 text-warn'

--- a/dashboard/src/lib/governance-risk-level.ts
+++ b/dashboard/src/lib/governance-risk-level.ts
@@ -11,6 +11,8 @@
 
 import type { KeeperApprovalRiskLevel } from '../types/governance'
 
+export type KeeperApprovalRiskVisualBand = 'bad' | 'warn' | 'accent' | 'info'
+
 const RISK_LEVEL_VALUES: ReadonlySet<string> = new Set([
   'low',
   'medium',
@@ -31,4 +33,46 @@ export function asKeeperApprovalRiskLevel(
   const trimmed = value.trim().toLowerCase()
   if (trimmed === '') return null
   return isKeeperApprovalRiskLevel(trimmed) ? trimmed : null
+}
+
+export function keeperApprovalRiskVisualBand(value: unknown): KeeperApprovalRiskVisualBand {
+  switch (asKeeperApprovalRiskLevel(value)) {
+    case 'critical':
+      return 'bad'
+    case 'high':
+      return 'warn'
+    case 'medium':
+      return 'accent'
+    case 'low':
+    case null:
+      return 'info'
+  }
+}
+
+export function isHighOrCriticalKeeperApprovalRisk(value: unknown): boolean {
+  const level = asKeeperApprovalRiskLevel(value)
+  return level === 'critical' || level === 'high'
+}
+
+const RISK_RANK: Record<KeeperApprovalRiskLevel, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+}
+
+export function maxKeeperApprovalRiskLevel(
+  items: readonly { risk_level?: string | null }[],
+): KeeperApprovalRiskLevel | null {
+  let topRank = 0
+  let topLabel: KeeperApprovalRiskLevel | null = null
+  for (const item of items) {
+    const level = asKeeperApprovalRiskLevel(item.risk_level)
+    const rank = level ? RISK_RANK[level] : 0
+    if (rank > topRank) {
+      topRank = rank
+      topLabel = level
+    }
+  }
+  return topLabel
 }

--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -20,6 +20,7 @@
 .ap-card .ap-rail { flex: none; width: 3px; background: var(--border-main); }
 .ap-card.sev-bad  .ap-rail { background: var(--status-bad); }
 .ap-card.sev-warn .ap-rail { background: var(--status-warn); }
+.ap-card.sev-accent .ap-rail { background: var(--accent-fg); }
 .ap-card.sev-info .ap-rail { background: var(--volt-dim); }
 .ap-card.sev-bad { border-color: color-mix(in oklab, var(--status-bad) 32%, var(--border-main)); background: linear-gradient(100deg, color-mix(in oklab, var(--status-bad) 6%, var(--bg-panel)), var(--bg-panel) 60%); }
 .ap-main { flex: 1; min-width: 0; padding: 13px 16px 14px; }
@@ -28,11 +29,12 @@
 .ap-kind { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 7px; border-radius: var(--radius-xs); border: 1px solid var(--border-main); color: var(--text-mid); white-space: nowrap; }
 .ap-kind.sev-bad  { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); background: color-mix(in oklab, var(--status-bad) 9%, transparent); }
 .ap-kind.sev-warn { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 42%, transparent); background: color-mix(in oklab, var(--status-warn) 7%, transparent); }
+.ap-kind.sev-accent { color: var(--accent-fg); border-color: var(--accent-30); background: var(--accent-10); }
 .ap-kind.sev-info { color: var(--volt-strong); border-color: var(--volt-dim); background: var(--volt-wash); }
 .ap-tool { font-size: 10px; color: var(--text-dim); }
 .ap-id { font-size: 10px; color: var(--text-dim); margin-left: auto; letter-spacing: 0.06em; }
 .ap-age { font-size: 10px; font-family: var(--font-mono); color: var(--text-dim); white-space: nowrap; }
-.ap-age.sev-bad { color: var(--status-bad); } .ap-age.sev-warn { color: var(--status-warn); }
+.ap-age.sev-bad { color: var(--status-bad); } .ap-age.sev-warn { color: var(--status-warn); } .ap-age.sev-accent { color: var(--accent-fg); }
 
 .ap-title { font-family: var(--font-display); font-weight: 500; font-size: 15px; color: var(--text-bright); margin: 9px 0 4px; line-height: 1.35; }
 .ap-detail { font-size: 12px; color: var(--text-mid); line-height: 1.55; margin: 0 0 11px; }


### PR DESCRIPTION
## Summary
- centralize keeper approval risk visual banding in `governance-risk-level`
- make Approvals use the same visual semantics as Governance: `critical=bad`, `high=warn`, `medium=accent`, `low/unknown=info`
- keep high-or-critical KPI counting explicit via a shared predicate

## Verification
- `git diff --check origin/main..HEAD`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard lint`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/approvals/approvals-surface.test.ts src/components/governance-risk.test.ts` — 2 files / 20 tests passed

Dune build/test not run per owner instruction.