### PR TITLE
fix(tool_library): match keeper_library_read by frontmatter title, not just slug

### DIFF
--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -249,19 +249,46 @@ let handle_read ~tool_name ~start_time _ctx args : Tool_result.result =
     |> Option.value ~default:"" in
   if String.equal topic "" then topic_required ~tool_name ~start_time
   else begin
-    (* Find matching file *)
+    (* Match the query against the filename slug *or* the frontmatter [title].
+       [handle_list] surfaces [fm.title] (a human title with spaces/colons/dashes),
+       so a keeper that reads back a listed title must resolve here too — matching
+       the slug only broke that contract, since none of the title's punctuation
+       survives slugification. The query is lowercased once (it was compared
+       case-sensitively before, so a capitalised title never matched the
+       lowercased basename either). Content read for title-matching is cached so
+       the chosen file is not read twice. *)
+    let topic_lc = String.lowercase_ascii topic in
     let files = list_documents ~include_candidates:true () in
-    let matching = List.filter (fun f ->
-      let base = Filename.basename f in
-      string_contains ~needle:topic (String.lowercase_ascii base)
-    ) files in
-    match matching with
-    | [] ->
+    let title_lc content =
+      match parse_frontmatter content with
+      | Some fm -> String.lowercase_ascii fm.title
+      | None -> ""
+    in
+    let matched =
+      List.find_map
+        (fun path ->
+          let base_lc = String.lowercase_ascii (Filename.basename path) in
+          if string_contains ~needle:topic_lc base_lc
+          then Some (path, None)
+          else (
+            match In_channel.with_open_text path In_channel.input_all with
+            | content when string_contains ~needle:topic_lc (title_lc content) ->
+              Some (path, Some content)
+            | _ -> None
+            | exception Sys_error _ -> None))
+        files
+    in
+    match matched with
+    | None ->
         workflow_err ~tool_name ~start_time
           (sprintf "No document matching '%s'" topic)
-    | path :: _ ->
+    | Some (path, cached) ->
         try
-          let content = In_channel.with_open_text path In_channel.input_all in
+          let content =
+            match cached with
+            | Some c -> c
+            | None -> In_channel.with_open_text path In_channel.input_all
+          in
           text_ok ~tool_name ~start_time
             (sprintf "## %s\n\n%s" (Filename.basename path) content)
         with

--- a/test/test_tool_library_coverage.ml
+++ b/test/test_tool_library_coverage.ml
@@ -175,6 +175,52 @@ let test_read_nonexistent_topic () =
       (msg_contains ~needle:"not found" msg || msg_contains ~needle:"no" msg)
   )
 
+(* The list -> read contract: masc_library_list surfaces the frontmatter title,
+   so reading back that exact title must resolve the document. Before the fix,
+   read matched only the slug filename (which drops the title's spaces, colons,
+   and case), so a title query never matched. *)
+let test_read_by_title_roundtrip () =
+  with_temp_base_path (fun ctx ->
+    let title = "Blocker Chain V3: Repos Exists, The Real Blocker" in
+    let add_args = `Assoc [
+      ("title", `String title);
+      ("content", `String "Body of the document for round-trip.");
+      ("source", `String "direct_experience");
+      ("confidence", `Float 0.9);
+    ] in
+    let (added, _) = dispatch_exn ctx ~name:"masc_library_add" ~args:add_args in
+    Alcotest.(check bool) "add succeeds" true added;
+    let read_args = `Assoc [("topic", `String title)] in
+    let (ok, msg) = dispatch_exn ctx ~name:"masc_library_read" ~args:read_args in
+    Alcotest.(check bool) "read by exact title succeeds" true ok;
+    Alcotest.(check bool) "returns the body" true
+      (msg_contains ~needle:"Body of the document" msg)
+  )
+
+let test_read_by_title_case_insensitive_partial () =
+  with_temp_base_path (fun ctx ->
+    let _ = dispatch_exn ctx ~name:"masc_library_add" ~args:(`Assoc [
+      ("title", `String "Root Cause: Orphan Count Analysis");
+      ("content", `String "details about orphan counting");
+    ]) in
+    let read_args = `Assoc [("topic", `String "root cause: orphan count")] in
+    let (ok, _) = dispatch_exn ctx ~name:"masc_library_read" ~args:read_args in
+    Alcotest.(check bool) "case-insensitive partial title match" true ok
+  )
+
+(* Slug queries must keep working — the fix adds title matching, it does not
+   replace filename matching. *)
+let test_read_by_slug_still_works () =
+  with_temp_base_path (fun ctx ->
+    let _ = dispatch_exn ctx ~name:"masc_library_add" ~args:(`Assoc [
+      ("title", `String "Slug Query Doc");
+      ("content", `String "slug body");
+    ]) in
+    let read_args = `Assoc [("topic", `String "slug-query")] in
+    let (ok, _) = dispatch_exn ctx ~name:"masc_library_read" ~args:read_args in
+    Alcotest.(check bool) "slug substring still matches" true ok
+  )
+
 (* ============================================================
    library_add tests
    ============================================================ *)
@@ -391,6 +437,9 @@ let () =
     ("library_read", [
       Alcotest.test_case "empty topic" `Quick test_read_empty_topic;
       Alcotest.test_case "nonexistent topic" `Quick test_read_nonexistent_topic;
+      Alcotest.test_case "read by exact title (list->read contract)" `Quick test_read_by_title_roundtrip;
+      Alcotest.test_case "read by case-insensitive partial title" `Quick test_read_by_title_case_insensitive_partial;
+      Alcotest.test_case "read by slug still works" `Quick test_read_by_slug_still_works;
     ]);
     ("library_add", [
       Alcotest.test_case "missing title" `Quick test_add_missing_title;


### PR DESCRIPTION
## 증상

keeper(라이브에서 garnet)가 `keeper_library_read`로 문서를 읽으려다 반복적으로 `No document matching '<title>'` 에러 → circuit breaker 트립.

## 근본 원인

`keeper_library_list`는 각 문서의 frontmatter `title`(사람 제목, 공백·콜론·대시 포함)을 보여주는데, `handle_read`는 그 topic을 **파일명 slug에만 substring 매칭**(게다가 case-sensitive)했다. 라이브 확인:
- 키퍼 쿼리: `Blocker Chain v3 — Corrected: repos/ exists, ppx_deriving_yojson is the real blocker`
- 실제 파일: `blocker-chain-v3--corrected-repos-exists-ppxderivingyojson-is-the-real-blocker-20260614.md`
- frontmatter `title`은 키퍼 쿼리와 **정확히 일치** → list가 내보낸 title로 read하면 title의 공백/콜론/대문자가 slug엔 없어 항상 실패 = **깨진 list→read contract**.

## 수정

`lib/tool_library.ml` `handle_read`가 topic을 lowercase하고 파일명 slug **또는** frontmatter `title`에 매칭 (`parse_frontmatter` 재사용). title 매칭 중 읽은 content는 캐시해 이중 읽기 방지. slug 쿼리는 그대로 동작.

## 검증

`test_tool_library_coverage` 22개 통과(신규 3): add→read-by-title 라운드트립 / case-insensitive partial title / slug-still-works guard.
기존 `test_full_workflow`는 read 결과를 `ignore ok4` + "may fail if filename convention differs" 주석으로 **버그를 알면서 무시**하고 있었음 — 이번 수정이 그 contract를 복원(신규 테스트는 read 성공을 *단언*).

## 워크어라운드 self-check

매칭 대상을 올바른 필드(title)로 교정한 것이지 string-classifier 보강이 아님(기존 slug 매칭은 보존, 추가만). telemetry-as-fix·N-of-M·cap-cooldown·catch-all 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
