### PR TITLE
fix(runtime): move OAS capability gate out of load_list to startup (main red fix)

### DIFF
--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -373,7 +373,7 @@ let () =
      clock and runs the panel/judge calls without timeout enforcement. *)
   Masc.Masc_eio_env.init ~sw ~net ~clock:(Eio.Stdenv.clock env) ();
   let config_path = Masc.Fusion_config_loader.runtime_toml_path ~base_path in
-  (match Runtime.init_default ~config_path with
+  (match Runtime.init_default_strict ~config_path with
    | Error msg ->
      Printf.eprintf "runtime init failed (%s): %s\n" config_path msg;
      exit 1

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -200,7 +200,9 @@ let materialize_config ~(config_path : string) (cfg : config)
     validate_cross_verifier_runtime ~config_path runtimes
       cfg.cross_verifier_runtime_id
   in
-  let* () = validate_runtime_model_capabilities ~config_path runtimes in
+  (* The OAS catalog membership gate is intentionally not called here:
+     [load_list] stays a routing-validity parser for tests and config probes.
+     Production startup applies the stricter gate via [init_default_strict]. *)
   Ok
     ( runtimes
     , rt
@@ -252,16 +254,32 @@ let cross_verifier_runtime_id_ref : string option Atomic.t = Atomic.make None
 
 let runtime_ids runtimes = List.map (fun (rt : t) -> rt.id) runtimes
 
-let init_default ~config_path =
-  let* runtimes, rt, assignments, librarian_id, cross_verifier_id =
-    load_list ~config_path
-  in
+let set_loaded (runtimes, rt, assignments, librarian_id, cross_verifier_id) =
   Atomic.set runtimes_ref runtimes;
   Atomic.set default_runtime_ref (Some rt);
   Atomic.set keeper_assignments_ref assignments;
   Atomic.set librarian_runtime_id_ref librarian_id;
-  Atomic.set cross_verifier_runtime_id_ref cross_verifier_id;
+  Atomic.set cross_verifier_runtime_id_ref cross_verifier_id
+
+let init_default ~config_path =
+  let* loaded = load_list ~config_path in
+  set_loaded loaded;
   Ok ()
+
+(* Startup entry point: [load_list] (RFC-0206 routing validation) PLUS the OAS
+   capability-catalog gate. Production callers (server boot, fusion run) use this
+   so an operator runtime.toml whose model is absent from the catalog is rejected
+   before boot — the gate that load_list intentionally no longer applies, kept out
+   of load_list so unit tests stay catalog-independent. *)
+let init_default_strict ~config_path =
+  match load_list ~config_path with
+  | Error _ as e -> e
+  | Ok ((runtimes, _, _, _, _) as loaded) ->
+    (match validate_runtime_model_capabilities ~config_path runtimes with
+     | Error _ as e -> e
+     | Ok () ->
+       set_loaded loaded;
+       Ok ())
 
 let get_default_runtime () = Atomic.get default_runtime_ref
 let get_runtimes () = Atomic.get runtimes_ref

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -20,12 +20,14 @@ val of_binding : config -> binding -> t option
 
 val decide_capability_gate :
   config_path:string -> (string * bool) list -> (unit, string) result
-(** Pure capability-gate decision used by [load_list]/[materialize_config],
-    exposed for testing. [entries] is [(label, known_to_oas_catalog)] per runtime
-    binding. Returns [Error] when any configured model is unknown to the OAS
-    capability catalog: an unknown model resolves to [provider_default] and
-    silently drops thinking/sampling control (corrupted the memory-os librarian for
-    minimax-m3, 2026-06-19). Empty entries are allowed for focused config probes. *)
+(** Pure capability-gate decision applied at startup by [init_default_strict]
+    (not by [load_list], which keeps only RFC-0206 routing validation so unit
+    tests stay catalog-independent), exposed for testing. [entries] is
+    [(label, known_to_oas_catalog)] per runtime binding. Returns [Error] when any
+    configured model is unknown to the OAS capability catalog: an unknown model
+    resolves to [provider_default] and silently drops thinking/sampling control
+    (corrupted the memory-os librarian for minimax-m3, 2026-06-19). Empty entries
+    are allowed for focused config probes. *)
 
 val load_list :
   config_path:string
@@ -51,6 +53,15 @@ val runtime_ids : t list -> string list
     {!get_default_runtime_id} instead. *)
 
 val init_default : config_path:string -> (unit, string) result
+(** Parse + RFC-0206 routing validation + populate the singletons. Does NOT apply
+    the OAS capability-catalog gate (use {!init_default_strict} at production
+    startup). Safe for tests with arbitrary-model runtime fixtures. *)
+
+val init_default_strict : config_path:string -> (unit, string) result
+(** Production startup entry point: {!init_default} PLUS the OAS capability-catalog
+    gate ({!decide_capability_gate}). Rejects ([Error]) a runtime whose model is
+    absent from the catalog before boot. Used by server boot and fusion run. *)
+
 val get_default_runtime : unit -> t option
 val get_runtimes : unit -> t list
 val get_runtime_ids : unit -> string list

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -536,13 +536,14 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          first turn (runtime→Runtime vision: no silent fallback). *)
       (match Runtime.config_path () with
        | Some config_path ->
-         (match Runtime.init_default ~config_path with
+         (match Runtime.init_default_strict ~config_path with
           | Ok () ->
             Log.Server.info "Runtime default initialized: %s"
               (Runtime.get_default_runtime_id ())
           | Error msg ->
             Log.Server.error
-              "Runtime.init_default failed (fatal, refusing to boot): %s" msg;
+              "Runtime.init_default_strict failed (fatal, refusing to boot): %s"
+              msg;
             exit 1)
        | None ->
          Log.Server.error


### PR DESCRIPTION
## 목표

main red 복구 (fix-forward). `Runtime TOML validity gate`의 `test_librarian_runtime_routing` + `max-concurrent` 실패를 고친다.

## 원인

#21607("startup capability gate")이 OAS capability-catalog gate(`validate_runtime_model_capabilities`)를 `materialize_config` 안에 넣었다. 그 결과 `load_list`를 호출하는 **모든** 경로 — routing 로직만 검증하는 단위 test 포함 — 가 OAS catalog membership을 강제당했다.

`test_runtime_config_validity`의 기존 test 2개가 합성 model(`chat`/`libr`, catalog 부재)을 fixture로 쓰는데, 이 gate에 걸려 실패 → main red:

```
2 runtime model(s) absent from the OAS capability catalog ... local.chat, local.libr
```

#21607은 pure gate(`decide_capability_gate`)는 `auth_headers` test로 격리 검증했으나, **통합 경로(load_list)의 기존 fixture 파급은 놓쳤다**(영향 범위 스캔 누락).

## 변경 (경계 분리)

- `load_list` / `materialize_config`: **RFC-0206 routing validation만** 유지(default / assignments / librarian / cross_verifier resolvable). capability gate 호출 제거 → 단위 test가 OAS catalog 독립.
- `init_default_strict`(신규): `init_default` + capability gate. production startup 전용(server boot, fusion run). operator runtime.toml의 model이 catalog에 없으면 여전히 boot 전 거부.
- `set_loaded` 추출: `init_default`/`init_default_strict`가 싱글톤 설정 공유(중복 제거).
- `server_runtime_bootstrap.ml`, `fusion_run.ml`: `init_default` → `init_default_strict` (단일 함수라 N-of-M 아님).

## 설계 근거

- RFC-0206 §4.1: load-time validation = routing(default/id resolvable) fail-fast. capability catalog membership은 #21607이 덧붙인 별개 관심사이므로 startup으로 분리.
- RFC-0206 R2(line 98): "init을 lazy/explicit로 유지하고 test runtime fixture 제공" — 단위 test가 catalog에 종속되지 않아야 한다는 정신과 일치.

## 검증

- `test_runtime_config_validity` 10/10 PASS (이전 2 failures → 전부 OK). librarian routing + max-concurrent 포함.
- full `dune build` clean (runtime.ml/mli + server_runtime_bootstrap + fusion_run 4파일).
- production 보호 유지: `init_default_strict`가 catalog gate를 startup에서 그대로 적용.

RFC-0206 (runtime concept rebirth) §4.1 load-time validation 경계를 따른다. capability gate는 startup 관심사로 재배치.
