### PR TITLE
feat(fusion): 카드 judge 결론 우선 + 패널 접기

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1724,9 +1724,16 @@ describe('fusion chat card', () => {
 
     expect(fetchBoardPost).toHaveBeenCalledWith('p-1')
     const detail = container.querySelector('[data-fusion-detail]')
-    expect(detail?.textContent).toContain('PANEL ONE ANSWER')
-    expect(detail?.textContent).toContain('timeout')
+    // Judge conclusion + failed-panel reason are visible immediately.
     expect(detail?.textContent).toContain('JUDGE RESOLVED ANSWER')
+    expect(detail?.textContent).toContain('timeout')
+    // Answered panel answers are collapsed by default — open the panel to read.
+    expect(detail?.textContent).not.toContain('PANEL ONE ANSWER')
+    const panelToggle = container.querySelector('[data-fusion-panel] button') as HTMLButtonElement | null
+    expect(panelToggle).not.toBeNull()
+    fireEvent.click(panelToggle as HTMLButtonElement)
+    await flushUi()
+    expect(container.querySelector('[data-fusion-detail]')?.textContent).toContain('PANEL ONE ANSWER')
   })
 
   it('shows an error message when the board post fetch fails', async () => {
@@ -1756,15 +1763,19 @@ describe('fusion chat card', () => {
     fireEvent.click(container.querySelector('[data-fusion-card] button') as HTMLButtonElement)
     await flushUi()
 
-    const detail = container.querySelector('[data-fusion-detail]')
-    // Panel + judge markdown rendered to real elements, not raw ## / ** text.
-    expect(detail?.querySelector('h2')?.textContent).toBe('Heading One')
-    expect(detail?.querySelector('li')?.textContent).toContain('bullet item')
+    // Judge synthesis renders to real markdown elements immediately (not collapsed).
     const judge = container.querySelector('[data-fusion-judge]')
     expect(judge?.querySelector('strong')?.textContent).toBe('Consensus')
     // synthesis takes precedence over resolved_answer when both present.
     expect(judge?.textContent).toContain('agreed point')
     expect(judge?.textContent).not.toContain('PLAIN RESOLVED')
+    // Panel answer markdown renders to real elements once its row is opened.
+    // Scope to the panel — the judge synthesis above also contains an <li>.
+    fireEvent.click(container.querySelector('[data-fusion-panel] button') as HTMLButtonElement)
+    await flushUi()
+    const panel = container.querySelector('[data-fusion-panel]')
+    expect(panel?.querySelector('h2')?.textContent).toBe('Heading One')
+    expect(panel?.querySelector('li')?.textContent).toContain('bullet item')
   })
 
   it('surfaces token usage and answered count in the header', async () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1175,6 +1175,42 @@ function FusionMarkdown({ text }: { text: string }) {
   />`
 }
 
+// One panel model's contribution. Collapsed by default so three verbose model
+// answers stay scannable — the judge synthesis above is the conclusion, these
+// are the evidence the reader opens on demand. Failed panels show their short
+// reason inline (nothing to collapse).
+function FusionPanelRow({ entry }: { entry: FusionPanelEntry }) {
+  const [open, setOpen] = useState(false)
+  const failed = entry.status !== 'answered'
+  const tok = entry.outputTokens !== undefined ? ` · ${entry.outputTokens.toLocaleString()} tok` : ''
+  const canToggle = !!entry.answer
+  return html`
+    <div
+      class="rounded border ${failed ? 'border-[var(--color-danger,#e06c75)]/40' : 'border-[var(--color-border,#30363d)]'} px-2 py-1.5"
+      data-fusion-panel
+    >
+      ${canToggle
+        ? html`
+          <button
+            type="button"
+            class="w-full flex items-center gap-1.5 text-left text-2xs font-mono text-[var(--color-fg-secondary,#9da7b3)] ${ringFocusClasses}"
+            aria-expanded=${open}
+            onClick=${() => setOpen((v) => !v)}
+          >
+            <span aria-hidden="true">${open ? '▾' : '▸'}</span>
+            <span>${entry.model} · ${entry.status}${tok}</span>
+          </button>`
+        : html`<div class="text-2xs font-mono text-[var(--color-fg-secondary,#9da7b3)]">${entry.model} · ${entry.status}${tok}</div>`}
+      ${entry.answer && open
+        ? html`<div class="mt-1 max-h-64 overflow-y-auto"><${FusionMarkdown} text=${entry.answer} /></div>`
+        : null}
+      ${entry.reason
+        ? html`<div class="text-xs mt-1 text-[var(--color-danger,#e06c75)]">${entry.reason}</div>`
+        : null}
+    </div>
+  `
+}
+
 function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: string }) {
   const [expanded, setExpanded] = useState(false)
   const [state, setState] = useState<{
@@ -1243,23 +1279,6 @@ function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: s
               : null}
             ${state.status === 'loaded'
               ? html`
-                <div class="flex flex-col gap-2">
-                  ${state.panel.map((p, i) => {
-                    const tok = p.outputTokens !== undefined ? ` · ${p.outputTokens.toLocaleString()} tok` : ''
-                    const failed = p.status !== 'answered'
-                    return html`
-                      <div key=${i} class="rounded border ${failed ? 'border-[var(--color-danger,#e06c75)]/40' : 'border-[var(--color-border,#30363d)]'} px-2 py-1.5">
-                        <div class="text-2xs font-mono text-[var(--color-fg-secondary,#9da7b3)]">${p.model} · ${p.status}${tok}</div>
-                        ${p.answer
-                          ? html`<div class="mt-1 max-h-64 overflow-y-auto"><${FusionMarkdown} text=${p.answer} /></div>`
-                          : null}
-                        ${p.reason
-                          ? html`<div class="text-xs mt-1 text-[var(--color-danger,#e06c75)]">${p.reason}</div>`
-                          : null}
-                      </div>
-                    `
-                  })}
-                </div>
                 ${state.judge
                   ? html`
                     <div class="rounded border border-[var(--color-brass-border,#3a3a2a)] px-2 py-1.5" data-fusion-judge>
@@ -1271,6 +1290,14 @@ function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: s
                         : state.judge.resolvedAnswer
                           ? html`<div class="mt-1"><${FusionMarkdown} text=${state.judge.resolvedAnswer} /></div>`
                           : null}
+                    </div>
+                  `
+                  : null}
+                ${state.panel.length > 0
+                  ? html`
+                    <div class="flex flex-col gap-2">
+                      <div class="text-2xs font-mono uppercase tracking-wide text-[var(--color-fg-secondary,#9da7b3)]">패널 ${state.panel.length}</div>
+                      ${state.panel.map((p, i) => html`<${FusionPanelRow} key=${i} entry=${p} />`)}
                     </div>
                   `
                   : null}


### PR DESCRIPTION
## 배경

markdown 렌더(#21629) 후에도 펼친 카드가 **패널 3답변을 먼저**, judge synthesis(진짜 결론)를 맨 아래 묻어서 — 결론을 보려면 긴 패널을 스크롤로 지나야 했습니다.

## 변경 (primitives.ts `ChatFusionCard`)

정보 위계 재구성 — "결론 먼저, 근거는 필요시":
- **judge synthesis를 맨 위로** (펼치면 항상 보임 = 결론).
- **패널 답변은 접힌 채로** (`FusionPanelRow` 추출, 자체 토글). 실패 패널은 짧은 reason 인라인 유지. 스크롤 벽 → 스캔 가능한 요약.

## 검증
- `tsc --noEmit` 0 errors
- `vitest primitives.test.ts` **74 passed**. 테스트 갱신: judge 결론·실패 reason은 즉시, 답변 패널 markdown은 그 패널 클릭 후에만 (judge synthesis도 li를 가지므로 `[data-fusion-panel]` 범위로 스코프).

RFC-0252 follow-up (#21629 enhancement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
