### PR TITLE
[codex] redesign logs surface

### DIFF
--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect, useMemo } from 'preact/hooks'
+import { ChevronDown, ChevronRight, RefreshCw } from 'lucide-preact'
 import { fetchLogs, fetchProviderLogsCatalog, fetchProviderLogTail } from '../api/dashboard.js'
 import type {
   LogEntry,
@@ -13,6 +14,7 @@ import { asRecord, asNullableString, mergeRouteRecord, hasRouteContext, type Mut
 import { TextInput } from './common/input'
 import { Select } from './common/select'
 import { Checkbox } from './common/checkbox'
+import { LogFilter } from './common/log-filter'
 import { createAsyncResource, loaded } from '../lib/async-state'
 import { toolCategory } from './tool-call-shared'
 import { StatusChip } from './common/status-chip'
@@ -56,9 +58,10 @@ const providerLogLines = signal(200)
 const latestSeq = signal<number | null>(null)
 const categoryFilter = signal('')
 const hideFsmTransitions = signal(false)
+const expandedLogSeq = signal<number | null>(null)
 
 const POLL_INTERVAL_MS = 3000
-const LOG_ROW_HEIGHT = 92
+const ESTIMATED_LOG_ROW_HEIGHT = 78
 const EMPTY_LOG_ENTRIES: LogEntry[] = []
 
 let moduleDebounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -83,21 +86,6 @@ const SOURCE_LABELS: Record<string, string> = {
   sse: 'sse',
 }
 
-const CATEGORIES: readonly string[] = [
-  'fsm',
-  'lifecycle',
-  'directive',
-  'heartbeat',
-  'presence',
-  'task',
-  'tool',
-  'memory',
-  'telemetry',
-  'routine',
-  'boundary',
-  'uncategorized',
-]
-
 const CATEGORY_LABELS: Record<string, string> = {
   fsm: 'FSM',
   lifecycle: 'Lifecycle',
@@ -113,9 +101,39 @@ const CATEGORY_LABELS: Record<string, string> = {
   uncategorized: 'Uncategorized',
 }
 
+const LOG_CATEGORY_FILTERS: readonly { value: string; label: string }[] = [
+  { value: '', label: '전체' },
+  { value: 'tool', label: 'Tool' },
+  { value: 'task', label: 'Task' },
+  { value: 'lifecycle', label: 'Lifecycle' },
+  { value: 'directive', label: 'Directive' },
+  { value: 'telemetry', label: 'Telemetry' },
+]
+
 function categoryLabel(category: string | null | undefined): string | null {
   if (!category) return null
   return CATEGORY_LABELS[category] ?? category
+}
+
+type LogDisplayKind =
+  | 'tool'
+  | 'turn'
+  | 'lifecycle'
+  | 'approval'
+  | 'broadcast'
+  | 'telemetry'
+  | 'task'
+  | 'log'
+
+const LOG_KIND_LABELS: Record<LogDisplayKind, string> = {
+  tool: 'TOOL',
+  turn: 'TURN',
+  lifecycle: 'LIFECYCLE',
+  approval: 'DIRECTIVE',
+  broadcast: 'BROADCAST',
+  telemetry: 'TELEMETRY',
+  task: 'TASK',
+  log: 'LOG',
 }
 
 type LoadMode = 'reset' | 'delta'
@@ -176,6 +194,113 @@ function detailLabel(details: Record<string, unknown> | null, key: string): stri
   if (typeof value === 'string' && value.trim() !== '') return value.trim()
   if (typeof value === 'number' && Number.isFinite(value)) return String(value)
   return null
+}
+
+function logDisplayKind(entry: LogEntry): LogDisplayKind {
+  const details = entryDetails(entry)
+  const toolName = detailLabel(details, 'tool_name') ?? detailLabel(details, 'tool')
+  if (toolName) return 'tool'
+  switch (entry.category) {
+    case 'tool':
+      return 'tool'
+    case 'task':
+      return 'task'
+    case 'lifecycle':
+    case 'fsm':
+    case 'heartbeat':
+    case 'presence':
+      return 'lifecycle'
+    case 'directive':
+    case 'boundary':
+      return 'approval'
+    case 'telemetry':
+    case 'memory':
+      return 'telemetry'
+    case 'routine':
+      return entry.turn_id ? 'turn' : 'log'
+    default:
+      return entry.turn_id ? 'turn' : 'log'
+  }
+}
+
+function logSeverity(entry: LogEntry): 'ok' | 'warn' | 'bad' | 'busy' | 'info' {
+  const level = normalizedLevel(entry)
+  if (level === 'ERROR') return 'bad'
+  if (level === 'WARN') return 'warn'
+  const kind = logDisplayKind(entry)
+  if (kind === 'tool') return 'busy'
+  if (kind === 'telemetry' || kind === 'broadcast') return 'info'
+  return 'ok'
+}
+
+function keeperLabel(entry: LogEntry, details: Record<string, unknown> | null): string {
+  const keeper = entry.keeper_name?.trim()
+  if (keeper) return keeper
+  const clientName = detailLabel(details, 'client_name')
+  if (clientName) return clientName
+  const moduleName = entry.module?.trim()
+  if (moduleName) return moduleName
+  return '(root)'
+}
+
+function keeperInitial(label: string): string {
+  const normalized = label.replace(/^\(|\)$/g, '').trim()
+  if (!normalized) return '?'
+  const [first, second] = normalized.split(/[-_\s]+/).filter(Boolean)
+  if (first && second) return `${first[0] ?? ''}${second[0] ?? ''}`.toUpperCase()
+  return normalized.slice(0, Math.min(2, normalized.length)).toUpperCase()
+}
+
+function formatLogClock(ts: string): string {
+  const match = ts.match(/T(\d{2}:\d{2}:\d{2})/)
+  if (match?.[1]) return match[1]
+  const date = new Date(ts)
+  if (!Number.isNaN(date.getTime())) {
+    return date.toLocaleTimeString('ko-KR', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+  }
+  return ts
+}
+
+function logTimestampMs(entry: LogEntry): number | null {
+  const ms = Date.parse(entry.ts)
+  return Number.isFinite(ms) ? ms : null
+}
+
+function logWindowMinutes(entries: readonly LogEntry[]): number {
+  const times = entries
+    .map(logTimestampMs)
+    .filter((value): value is number => value !== null)
+  if (times.length < 2) return 1
+  const span = Math.max(...times) - Math.min(...times)
+  return Math.max(1, span / 60000)
+}
+
+function logWindowLabel(entries: readonly LogEntry[]): string {
+  if (entries.length === 0) return 'waiting'
+  const minutes = logWindowMinutes(entries)
+  if (minutes < 2) return 'last 1m'
+  if (minutes < 90) return `last ${Math.round(minutes)}m`
+  return `last ${(minutes / 60).toFixed(1)}h`
+}
+
+function eventRatePerMinute(entries: readonly LogEntry[]): string {
+  if (entries.length === 0) return '0.0'
+  return (entries.length / logWindowMinutes(entries)).toFixed(1)
+}
+
+function logActiveIdentityCount(entries: readonly LogEntry[]): number {
+  const ids = new Set<string>()
+  for (const entry of entries) {
+    const details = entryDetails(entry)
+    const id = keeperLabel(entry, details)
+    if (id !== '(root)') ids.add(id)
+  }
+  return ids.size
 }
 
 function interpolateStructuredMessage(
@@ -430,98 +555,96 @@ function renderLogRow(entry: LogEntry) {
   const renderedMessage = renderLogMessage(entry)
   const routeLinks = logRouteLinks(entry)
   const category = categoryLabel(entry.category)
+  const displayKind = logDisplayKind(entry)
+  const severity = logSeverity(entry)
+  const identity = keeperLabel(entry, details)
+  const isExpanded = expandedLogSeq.value === entry.seq
+  const routeLinkButtons = routeLinks.length > 0
+    ? html`
+      ${routeLinks.map(link => html`
+        <button
+          key=${link.id}
+          type="button"
+          data-testid=${link.label === 'Code' ? 'logs-code-link' : undefined}
+          class="logs-route-link"
+          title=${link.evidence}
+          aria-label=${`Open ${link.evidence}`}
+          onClick=${() => openIdeContextRouteLink(link)}
+        >${link.label}</button>
+      `)}
+    `
+    : null
   const diagnosticChip = failure
     ? html`<${StatusChip} tone="bad" uppercase=${false}>${failure.cause_code}</${StatusChip}>`
     : null
   const fallbackDiagnosticChip = !failure && diagnosticCause
     ? html`<${StatusChip} tone=${level === 'ERROR' ? 'bad' : 'warn'} uppercase=${false}>${diagnosticCause}</${StatusChip}>`
     : null
-  let backgroundClass = 'bg-[var(--color-bg-surface)]'
-  if (level === 'ERROR') {
-    backgroundClass = 'bg-[var(--bad-6)]'
-  } else if (level === 'WARN') {
-    backgroundClass = 'bg-[var(--warn-soft)]'
-  }
-
   return html`
     <div
       key=${entry.seq}
-      class="logs-row v2-logs-row grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 rounded-[var(--r-1)] border border-[var(--color-border-divider)] px-3 py-3 ${backgroundClass}"
+      class=${`logs-row v2-logs-row ${isExpanded ? 'is-open' : ''}`}
+      data-sev=${severity}
+      data-kind=${displayKind}
     >
-      <div class="font-mono text-2xs whitespace-nowrap text-[color:var(--color-fg-muted)]">
-        ${entry.ts.replace('T', ' ').replace('Z', '')}
-      </div>
-      <div class="font-mono text-2xs font-semibold whitespace-nowrap" style="color: ${LEVEL_COLORS[level] ?? 'inherit'}">
-        ${level}
-      </div>
-      <div class="min-w-0 font-mono text-2xs text-[color:var(--color-accent-fg)] truncate" title=${entry.module || '(root)'}>
-        ${entry.module || '(root)'}
-      </div>
-      <div class="flex flex-wrap items-start gap-1">
-        <${StatusChip} tone=${sourceClass}>${sourceLabel(source)}</${StatusChip}>
-        ${category
-          ? html`<${MetaTag}>${category}</${MetaTag}>`
-          : null}
-        ${clientName
-          ? html`<${StatusChip} tone="border-[var(--color-accent-soft)] text-[var(--color-accent-fg)]" uppercase=${false}>${clientName}</${StatusChip}>`
-          : null}
-        ${toolName
-          ? html`<${StatusChip} tone="neutral" uppercase=${false} class="gap-1"><span class="font-mono font-bold ${toolCategory(toolName).color}">${toolCategory(toolName).icon}</span><span>${toolName}</span></${StatusChip}>`
-          : null}
-        ${fixes
-          ? html`<${MetaTag}>fixes ${fixes}</${MetaTag}>`
-          : null}
-        ${phase
-          ? html`<${MetaTag}>${phase}</${MetaTag}>`
-          : null}
-        ${event
-          ? html`<${MetaTag}>event ${event}</${MetaTag}>`
-          : null}
-        ${requestId
-          ? html`<${MetaTag}>req ${requestId}</${MetaTag}>`
-          : null}
-        ${sessionId
-          ? html`<${MetaTag}>session ${sessionId}</${MetaTag}>`
-          : null}
-        ${diagnosticChip}
-        ${fallbackDiagnosticChip}
-        ${failure
-          ? html`<${StatusChip} tone="info" uppercase=${false}>${failure.surface}</${StatusChip}>`
-          : null}
-        ${failure
-          ? html`<${MetaTag}>${failure.recoverability}</${MetaTag}>`
-          : null}
-        ${failure?.operator_action
-          ? html`<${StatusChip} tone="info" uppercase=${false}>next ${failure.operator_action}</${StatusChip}>`
-          : null}
-        ${routeLinks.length > 0
-          ? html`
-            ${routeLinks.map(link => html`
-              <button
-                key=${link.id}
-                type="button"
-                data-testid=${link.label === 'Code' ? 'logs-code-link' : undefined}
-                class="logs-route-link rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-semibold text-[var(--color-accent-fg)] hover:border-[var(--color-accent-border)] hover:bg-[var(--color-bg-hover)]"
-                title=${link.evidence}
-                aria-label=${`Open ${link.evidence}`}
-                onClick=${() => openIdeContextRouteLink(link)}
-              >${link.label}</button>
-            `)}
-          `
-          : null}
-      </div>
-      <div
-        class="text-xs leading-relaxed text-[var(--color-fg-primary)]"
-        title=${failure ? `${renderedMessage}\n${failure.summary}` : renderedMessage}
-        style=${{
-          display: '-webkit-box',
-          overflow: 'hidden',
-          WebkitBoxOrient: 'vertical',
-          WebkitLineClamp: 2,
+      <button
+        type="button"
+        class="v2-logs-line"
+        aria-expanded=${isExpanded}
+        onClick=${() => {
+          expandedLogSeq.value = isExpanded ? null : entry.seq
         }}
       >
-        ${renderedMessage}
-      </div>
+        <span class="v2-logs-time mono">${formatLogClock(entry.ts)}</span>
+        <span class="v2-logs-who">
+          <span class="v2-logs-sigil" aria-hidden="true">${keeperInitial(identity)}</span>
+          <span class="v2-logs-identity" title=${identity}>${identity}</span>
+        </span>
+        <span class="v2-logs-kind" data-kind=${displayKind}>${LOG_KIND_LABELS[displayKind]}</span>
+        <span class="v2-logs-message" title=${failure ? `${renderedMessage}\n${failure.summary}` : renderedMessage}>
+          ${renderedMessage}
+        </span>
+        <span class="v2-logs-caret" aria-hidden="true">
+          ${isExpanded ? html`<${ChevronDown} size=${14} />` : html`<${ChevronRight} size=${14} />`}
+        </span>
+      </button>
+      ${routeLinkButtons
+        ? html`<div class="v2-logs-inline-links">${routeLinkButtons}</div>`
+        : null}
+      ${isExpanded
+        ? html`
+          <div class="v2-logs-detail">
+            <div class="v2-logs-detail-grid">
+              <div><span>level</span><b style=${{ color: LEVEL_COLORS[level] ?? 'inherit' }}>${level}</b></div>
+              <div><span>module</span><b>${entry.module || '(root)'}</b></div>
+              <div><span>source</span><b>${sourceLabel(source)}</b></div>
+              <div><span>timestamp</span><b>${entry.ts.replace('T', ' ').replace('Z', '')}</b></div>
+            </div>
+            <div class="v2-logs-tags">
+              <${StatusChip} tone=${sourceClass}>${sourceLabel(source)}</${StatusChip}>
+              ${category ? html`<${MetaTag}>${category}</${MetaTag}>` : null}
+              ${clientName
+                ? html`<${StatusChip} tone="border-[var(--color-accent-soft)] text-[var(--color-accent-fg)]" uppercase=${false}>${clientName}</${StatusChip}>`
+                : null}
+              ${toolName
+                ? html`<${StatusChip} tone="neutral" uppercase=${false} class="gap-1"><span class="font-mono font-bold ${toolCategory(toolName).color}">${toolCategory(toolName).icon}</span><span>${toolName}</span></${StatusChip}>`
+                : null}
+              ${fixes ? html`<${MetaTag}>fixes ${fixes}</${MetaTag}>` : null}
+              ${phase ? html`<${MetaTag}>${phase}</${MetaTag}>` : null}
+              ${event ? html`<${MetaTag}>event ${event}</${MetaTag}>` : null}
+              ${requestId ? html`<${MetaTag}>req ${requestId}</${MetaTag}>` : null}
+              ${sessionId ? html`<${MetaTag}>session ${sessionId}</${MetaTag}>` : null}
+              ${diagnosticChip}
+              ${fallbackDiagnosticChip}
+              ${failure ? html`<${StatusChip} tone="info" uppercase=${false}>${failure.surface}</${StatusChip}>` : null}
+              ${failure ? html`<${MetaTag}>${failure.recoverability}</${MetaTag}>` : null}
+              ${failure?.operator_action
+                ? html`<${StatusChip} tone="info" uppercase=${false}>next ${failure.operator_action}</${StatusChip}>`
+                : null}
+            </div>
+          </div>
+        `
+        : null}
     </div>
   `
 }
@@ -537,7 +660,7 @@ function renderSummaryChip(label: string, value: string | number, tone = 'neutra
 
 function renderLogSummary(summary: LogWindowSummary) {
   return html`
-    <div class="v2-logs-summary mx-3 mt-3 flex flex-wrap items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2 text-2xs">
+    <div class="v2-logs-summary flex flex-wrap items-center gap-2 text-2xs">
       ${renderSummaryChip('ERROR', summary.errors, summary.errors > 0 ? 'bad' : 'neutral')}
       ${renderSummaryChip('WARN', summary.warnings, summary.warnings > 0 ? 'warn' : 'neutral')}
       ${renderSummaryChip('failure envelope', summary.failureEnvelopes, summary.failureEnvelopes > 0 ? 'info' : 'neutral')}
@@ -598,7 +721,7 @@ function renderProviderLogPanel() {
   }
 
   return html`
-    <div class="v2-logs-provider-panel mx-3 mt-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
+    <div class="v2-logs-provider-panel rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
       <div class="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--color-border-divider)] px-3 py-2">
         <div class="flex flex-wrap items-center gap-2 text-2xs">
           <${StatusChip} tone="info" uppercase=${false}>provider logs</${StatusChip}>
@@ -769,88 +892,120 @@ export function LogViewer() {
   // memoizing on [logEntries] skips the recount. In the loading state logEntries
   // is a fresh `[]` so the memo misses, but the derivation is cheap then.
   const summary = useMemo(() => summarizeLogWindow(logEntries), [logEntries])
+  const toolCalls = useMemo(
+    () => logEntries.filter(entry => logDisplayKind(entry) === 'tool').length,
+    [logEntries],
+  )
+  const errRate = logEntries.length > 0
+    ? ((summary.errors / logEntries.length) * 100).toFixed(1)
+    : '0.0'
+  const currentFilterLabel =
+    LOG_CATEGORY_FILTERS.find(filter => filter.value === categoryFilter.value)?.label ?? 'Custom'
 
   return html`
-    <div class="logs-viewer v2-logs-surface flex h-full min-h-0 flex-col gap-4">
-      <section class="v2-logs-panel contain-content flex min-h-0 flex-1 flex-col overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]" aria-label="로그 뷰어">
-        <div class="logs-toolbar v2-logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[var(--color-border-divider)] px-4 py-4">
-          <div class="logs-filters flex flex-wrap gap-2 items-center">
-            <${Select}
-              class="logs-select px-3 py-2 text-xs"
-              name="log-level"
-              ariaLabel="로그 레벨"
-              value=${levelFilter.value}
-              options=${[
-                { value: 'DEBUG', label: 'DEBUG+' },
-                { value: 'INFO', label: 'INFO+' },
-                { value: 'WARN', label: 'WARN+' },
-                { value: 'ERROR', label: 'ERROR' },
-              ]}
-              onInput=${(v: string) => { levelFilter.value = v }}
-            />
+    <div class="logs-viewer v2-logs-surface">
+      <section class="v2-logs-panel" aria-label="로그 뷰어">
+        <header class="v2-logs-head">
+          <div class="v2-logs-head-main">
+            <h1>이벤트 로그</h1>
+            <p class="v2-logs-sub mono">live trace stream · masc runtime · ${logWindowLabel(logEntries)}</p>
+          </div>
+          <div class="v2-logs-stats" aria-label="로그 요약">
+            <div class="v2-logs-stat"><span class="k">이벤트/분</span><span class="v mono">${eventRatePerMinute(logEntries)}</span></div>
+            <div class="v2-logs-stat"><span class="k">오류율</span><span class=${`v mono ${summary.errors > 0 ? 'bad' : ''}`}>${errRate}%</span></div>
+            <div class="v2-logs-stat"><span class="k">Tool 호출</span><span class="v mono">${toolCalls}</span></div>
+            <div class="v2-logs-stat"><span class="k">활성 소스</span><span class="v mono">${logActiveIdentityCount(logEntries)}</span></div>
+          </div>
+        </header>
 
-            <${TextInput}
-              class="min-w-55"
-              name="log-module-filter"
-              ariaLabel="모듈 필터"
-              placeholder="모듈 필터"
-              value=${moduleInput.value}
-              onInput=${(e: Event) => {
-                moduleInput.value = (e.target as HTMLInputElement).value
-                if (moduleDebounceTimer) clearTimeout(moduleDebounceTimer)
-                moduleDebounceTimer = setTimeout(() => {
-                  appliedModuleFilter.value = moduleInput.value
-                }, 300)
-              }}
-              onKeyDown=${(e: KeyboardEvent) => {
-                if (e.key === 'Enter') {
-                  if (moduleDebounceTimer) clearTimeout(moduleDebounceTimer)
-                  moduleDebounceTimer = null
-                  appliedModuleFilter.value = moduleInput.value
-                }
-              }}
-            />
-
-            <${Select}
-              class="logs-select px-3 py-2 text-xs"
-              name="log-limit"
-              ariaLabel="로그 개수"
-              value=${String(logLimit.value)}
-              options=${['100', '200', '500', '1000', '3000']}
-              onInput=${(v: string) => { logLimit.value = parseInt(v, 10) }}
-            />
-
-            <${Select}
-              class="logs-select px-3 py-2 text-xs"
-              name="log-category"
-              ariaLabel="Category"
-              value=${categoryFilter.value}
-              options=${[
-                { value: '', label: 'All categories' },
-                ...CATEGORIES.map(category => ({
-                  value: category,
-                  label: CATEGORY_LABELS[category] ?? category,
-                })),
-              ]}
-              onInput=${(v: string) => { categoryFilter.value = v }}
-            />
-
-            <label class="logs-hide-fsm-label flex items-center gap-1.5 cursor-pointer text-2xs text-[var(--color-fg-muted)]">
-              <${Checkbox}
-                name="log-hide-fsm"
-                ariaLabel="Hide FSM transitions"
-                checked=${hideFsmTransitions.value}
-                onChange=${(checked: boolean) => { hideFsmTransitions.value = checked }}
-              />
-              Hide FSM transitions
-            </label>
+        <div class="logs-toolbar v2-logs-toolbar">
+          <div class="logs-filters v2-logs-filters">
+            ${LOG_CATEGORY_FILTERS.map(filter => html`
+              <${LogFilter}
+                key=${filter.value || 'all'}
+                active=${categoryFilter.value === filter.value}
+                class="v2-logs-filter-chip"
+                onClick=${() => {
+                  categoryFilter.value = filter.value
+                }}
+              >${filter.label}<//>
+            `)}
           </div>
 
-          <div class="logs-actions flex flex-wrap gap-3 items-center text-2xs text-[color:var(--color-fg-muted)]">
+          <div class="v2-logs-toolbar-break"></div>
+
+          <div class="logs-actions v2-logs-actions">
             ${renderLogProvenance(logData)}
-            <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-1 tabular-nums">
+            <button
+              type="button"
+              class=${`v2-logs-attention ${levelFilter.value === 'WARN' ? 'on' : ''}`}
+              aria-pressed=${levelFilter.value === 'WARN'}
+              onClick=${() => { levelFilter.value = levelFilter.value === 'WARN' ? 'INFO' : 'WARN' }}
+            >
+              주의·실패만
+            </button>
+            <span class="v2-logs-count mono" title=${`현재 필터: ${currentFilterLabel}`}>
               ${logEntries.length.toLocaleString()} / ${logTotal.toLocaleString()}
             </span>
+            <details class="v2-logs-advanced-menu">
+              <summary>필터</summary>
+              <div class="v2-logs-advanced">
+                <${Select}
+                  class="logs-select px-3 py-2 text-xs"
+                  name="log-level"
+                  ariaLabel="로그 레벨"
+                  value=${levelFilter.value}
+                  options=${[
+                    { value: 'DEBUG', label: 'DEBUG+' },
+                    { value: 'INFO', label: 'INFO+' },
+                    { value: 'WARN', label: 'WARN+' },
+                    { value: 'ERROR', label: 'ERROR' },
+                  ]}
+                  onInput=${(v: string) => { levelFilter.value = v }}
+                />
+
+                <${TextInput}
+                  class="min-w-55"
+                  name="log-module-filter"
+                  ariaLabel="모듈 필터"
+                  placeholder="모듈 필터"
+                  value=${moduleInput.value}
+                  onInput=${(e: Event) => {
+                    moduleInput.value = (e.target as HTMLInputElement).value
+                    if (moduleDebounceTimer) clearTimeout(moduleDebounceTimer)
+                    moduleDebounceTimer = setTimeout(() => {
+                      appliedModuleFilter.value = moduleInput.value
+                    }, 300)
+                  }}
+                  onKeyDown=${(e: KeyboardEvent) => {
+                    if (e.key === 'Enter') {
+                      if (moduleDebounceTimer) clearTimeout(moduleDebounceTimer)
+                      moduleDebounceTimer = null
+                      appliedModuleFilter.value = moduleInput.value
+                    }
+                  }}
+                />
+
+                <${Select}
+                  class="logs-select px-3 py-2 text-xs"
+                  name="log-limit"
+                  ariaLabel="로그 개수"
+                  value=${String(logLimit.value)}
+                  options=${['100', '200', '500', '1000', '3000']}
+                  onInput=${(v: string) => { logLimit.value = parseInt(v, 10) }}
+                />
+
+                <label class="logs-hide-fsm-label flex items-center gap-1.5 cursor-pointer text-2xs text-[var(--color-fg-muted)]">
+                  <${Checkbox}
+                    name="log-hide-fsm"
+                    ariaLabel="Hide FSM transitions"
+                    checked=${hideFsmTransitions.value}
+                    onChange=${(checked: boolean) => { hideFsmTransitions.value = checked }}
+                  />
+                  Hide FSM transitions
+                </label>
+              </div>
+            </details>
             <label class="logs-auto-label flex items-center gap-1.5 cursor-pointer">
               <${Checkbox}
                 name="log-auto-refresh"
@@ -860,9 +1015,11 @@ export function LogViewer() {
               />
               자동
             </label>
+            <span class="v2-logs-live mono"><span class="dot" />${autoRefresh.value ? 'live poll · 3s' : 'poll paused'}</span>
             <button
               type="button"
-              class="logs-refresh-btn rounded-[var(--r-1)] border border-[var(--accent-22)] bg-[var(--accent-10)] px-3 py-2 text-2xs font-medium text-[var(--color-accent-fg)]"
+              class="logs-refresh-btn v2-logs-refresh"
+              aria-label="새로고침"
               onClick=${() => {
                 latestSeq.value = null
                 logResource.reset()
@@ -872,7 +1029,7 @@ export function LogViewer() {
               }}
               disabled=${logLoading}
             >
-              ${logLoading ? '...' : '새로고침'}
+              <${RefreshCw} size=${14} class=${logLoading ? 'animate-spin' : ''} />
             </button>
           </div>
         </div>
@@ -881,17 +1038,17 @@ export function LogViewer() {
           <div class="mx-4 mt-4 rounded-[var(--r-1)] border border-solid border-[var(--err-border)] bg-[var(--brick-soft)] px-4 py-3 text-xs text-[var(--err-fg)]">${logError}</div>
         ` : null}
 
-        ${renderLogSummary(summary)}
-        ${renderProviderLogPanel()}
+        <div class="v2-logs-support">
+          ${renderLogSummary(summary)}
+          ${renderProviderLogPanel()}
+        </div>
 
-        <div class="px-3 pt-3">
-          <div class="v2-logs-table-header grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">
-            <div>timestamp</div>
-            <div>level</div>
-            <div>module</div>
-            <div>source</div>
-            <div>message</div>
-          </div>
+        <div class="v2-logs-table-header">
+          <span>시각</span>
+          <span>소스</span>
+          <span>유형</span>
+          <span>이벤트</span>
+          <span></span>
         </div>
 
         ${logEntries.length === 0
@@ -903,11 +1060,11 @@ export function LogViewer() {
           : html`
               <${VirtualList}
                 items=${logEntries}
-                itemHeight=${LOG_ROW_HEIGHT}
+                estimatedItemHeight=${ESTIMATED_LOG_ROW_HEIGHT}
                 overscan=${6}
                 getKey=${(entry: LogEntry) => String(entry.seq)}
                 renderItem=${(entry: LogEntry) => renderLogRow(entry)}
-                className="min-h-0 flex-1 overflow-auto px-3 pb-3"
+                className="v2-logs-stream"
               />
             `}
       </section>

--- a/dashboard/src/styles/v2-logs.css
+++ b/dashboard/src/styles/v2-logs.css
@@ -5,26 +5,240 @@
  *
  * Colors come from v2-theme.css; this file handles surface-specific
  * layout, hairlines, hover states, and brass accent touches.
- *
- * Source: /Users/dancer/Downloads/v2/_ds/masc-design-system-a925c77f-042a-40f5-ac15-0675a4a58d3f/ui_kits/dashboard/styles/base.css
  */
 
 .v2-logs-surface {
-  /* Soft brass hairline across the top of the log panel. */
+  --v2-logs-cols: 92px minmax(150px, 230px) 112px minmax(0, 1fr) 24px;
   --v2-logs-top-glow: rgb(var(--brass-glow) / 0.04);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  background:
+    radial-gradient(ellipse at 14% 0%, color-mix(in oklab, var(--volt) 5%, transparent), transparent 55%),
+    var(--bg-deep);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
 }
 
 .v2-logs-panel {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  background: transparent;
   box-shadow: inset 0 1px 0 var(--v2-logs-top-glow);
 }
 
+.v2-logs-head {
+  display: flex;
+  flex: none;
+  align-items: flex-start;
+  gap: 24px;
+  padding: 22px 26px 16px;
+}
+
+.v2-logs-head-main {
+  min-width: 0;
+}
+
+.v2-logs-head h1 {
+  margin: 0;
+  color: var(--text-bright);
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.v2-logs-sub {
+  margin: 6px 0 0;
+  color: var(--text-dim);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+
+.v2-logs-stats {
+  display: flex;
+  gap: 10px;
+  margin-left: auto;
+}
+
+.v2-logs-stat {
+  display: flex;
+  min-width: 74px;
+  flex-direction: column;
+  gap: 3px;
+  padding: 8px 13px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+}
+
+.v2-logs-stat .k {
+  color: var(--text-dim);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.v2-logs-stat .v {
+  color: var(--text-bright);
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  line-height: 1.15;
+}
+
+.v2-logs-stat .v.bad {
+  color: var(--status-bad);
+}
+
 .v2-logs-toolbar {
-  background: linear-gradient(
-    180deg,
-    var(--color-bg-elevated) 0%,
-    var(--color-bg-surface) 100%
-  );
-  border-color: var(--color-border-divider);
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 0 26px 14px;
+  background: transparent;
+  border-color: transparent;
+}
+
+.v2-logs-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.v2-logs-filter-chip.log-f {
+  font-size: 12px;
+  letter-spacing: 0;
+  text-transform: none;
+  padding: 6px 12px;
+}
+
+.v2-logs-toolbar-break {
+  flex: 1;
+}
+
+.v2-logs-advanced {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.v2-logs-advanced-menu {
+  position: relative;
+}
+
+.v2-logs-advanced-menu > summary {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-pill);
+  color: var(--text-mid);
+  cursor: pointer;
+  font-size: 12px;
+  list-style: none;
+}
+
+.v2-logs-advanced-menu > summary::-webkit-details-marker {
+  display: none;
+}
+
+.v2-logs-advanced-menu[open] > summary,
+.v2-logs-advanced-menu > summary:hover {
+  color: var(--text-bright);
+  border-color: var(--volt-dim);
+}
+
+.v2-logs-advanced-menu .v2-logs-advanced {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 15;
+  width: min(520px, calc(100vw - 48px));
+  padding: 12px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  box-shadow: 0 18px 40px rgb(0 0 0 / 0.42);
+}
+
+.v2-logs-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 9px;
+  color: var(--color-fg-muted);
+  font-size: 11px;
+}
+
+.v2-logs-attention {
+  padding: 6px 12px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-mid);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  transition: color .18s ease, border-color .18s ease, background .18s ease;
+}
+
+.v2-logs-attention:hover {
+  color: var(--text-bright);
+  border-color: var(--volt-dim);
+}
+
+.v2-logs-attention.on {
+  color: var(--status-warn);
+  border-color: color-mix(in oklab, var(--status-warn) 50%, transparent);
+  background: color-mix(in oklab, var(--status-warn) 10%, transparent);
+}
+
+.v2-logs-count {
+  padding: 5px 10px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-pill);
+  color: var(--text-mid);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.v2-logs-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.v2-logs-live .dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--status-ok);
+  box-shadow: 0 0 0 0 color-mix(in oklab, var(--status-ok) 60%, transparent);
+  animation: v2-logs-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes v2-logs-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--status-ok) 55%, transparent);
+  }
+
+  50% {
+    box-shadow: 0 0 0 4px transparent;
+  }
 }
 
 .v2-logs-toolbar .logs-refresh-btn,
@@ -38,28 +252,374 @@
   background: var(--color-brass-soft);
 }
 
+.v2-logs-refresh {
+  display: inline-flex;
+  width: 30px;
+  height: 30px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--accent-22);
+  border-radius: var(--radius-sm);
+  background: var(--accent-10);
+  color: var(--color-accent-fg);
+}
+
 .v2-logs-table-header {
+  display: grid;
+  grid-template-columns: var(--v2-logs-cols);
+  flex: none;
+  align-items: center;
+  gap: 14px;
+  padding: 9px 26px;
+  border-top: 1px solid var(--border-main);
   color: var(--color-fg-muted);
   border-bottom: 1px solid var(--color-border-divider);
+  background: var(--bg-panel);
+}
+
+.v2-logs-table-header span {
+  color: var(--text-dim);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.v2-logs-stream {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
 }
 
 .v2-logs-row {
-  transition: border-color 120ms ease, box-shadow 120ms ease;
+  border-bottom: 1px solid var(--border-soft);
+  border-left: 2px solid transparent;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.v2-logs-row[data-sev="warn"] {
+  border-left-color: color-mix(in oklab, var(--status-warn) 70%, transparent);
+}
+
+.v2-logs-row[data-sev="bad"] {
+  border-left-color: var(--status-bad);
+}
+
+.v2-logs-row[data-sev="busy"] {
+  border-left-color: var(--volt);
+}
+
+.v2-logs-row[data-sev="info"] {
+  border-left-color: color-mix(in oklab, var(--info) 60%, transparent);
+}
+
+.v2-logs-row.is-open {
+  background: color-mix(in oklab, var(--volt) 4%, transparent);
 }
 
 .v2-logs-row:hover {
-  border-color: var(--color-border-strong);
-  box-shadow: 0 0 0 1px var(--color-border-strong);
+  background: color-mix(in oklab, var(--text-bright) 4%, transparent);
+}
+
+.v2-logs-line {
+  display: grid;
+  width: 100%;
+  grid-template-columns: var(--v2-logs-cols);
+  align-items: center;
+  gap: 14px;
+  padding: 9px 26px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-family: var(--font-ui);
+  text-align: left;
+}
+
+.v2-logs-time {
+  color: var(--text-mid);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.v2-logs-row[data-sev="bad"] .v2-logs-time {
+  color: var(--status-bad);
+}
+
+.v2-logs-who {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.v2-logs-sigil {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in oklab, var(--volt) 30%, var(--border-main));
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklab, var(--volt) 18%, var(--bg-card));
+  color: var(--text-bright);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.v2-logs-identity {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-logs-kind {
+  justify-self: start;
+  padding: 3px 8px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  white-space: nowrap;
+}
+
+.v2-logs-kind[data-kind="tool"] {
+  color: var(--volt);
+  border-color: color-mix(in oklab, var(--volt) 36%, transparent);
+}
+
+.v2-logs-kind[data-kind="turn"] {
+  color: var(--text-mid);
+}
+
+.v2-logs-kind[data-kind="lifecycle"] {
+  color: var(--status-warn);
+  border-color: color-mix(in oklab, var(--status-warn) 36%, transparent);
+}
+
+.v2-logs-kind[data-kind="approval"] {
+  color: var(--status-bad);
+  border-color: color-mix(in oklab, var(--status-bad) 40%, transparent);
+}
+
+.v2-logs-kind[data-kind="broadcast"],
+.v2-logs-kind[data-kind="telemetry"] {
+  color: var(--info);
+  border-color: color-mix(in oklab, var(--info) 40%, transparent);
+}
+
+.v2-logs-kind[data-kind="task"] {
+  color: var(--status-ok);
+  border-color: color-mix(in oklab, var(--status-ok) 36%, transparent);
+}
+
+.v2-logs-message {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-logs-caret {
+  display: inline-flex;
+  justify-self: center;
+  color: var(--text-dim);
+}
+
+.v2-logs-inline-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 26px 9px calc(26px + 92px + 14px);
+}
+
+.v2-logs-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 4px 26px 16px calc(26px + 92px + 14px);
+}
+
+.v2-logs-detail-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 22px;
+}
+
+.v2-logs-detail-grid div {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.v2-logs-detail-grid span {
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.v2-logs-detail-grid b {
+  color: var(--text-bright);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.v2-logs-tags {
+  display: flex;
+  max-width: 980px;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.v2-logs-inline-links .logs-route-link,
+.v2-logs-tags .logs-route-link {
+  padding: 2px 8px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--color-accent-fg);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.v2-logs-inline-links .logs-route-link:hover,
+.v2-logs-tags .logs-route-link:hover {
+  border-color: var(--volt-dim);
+  background: var(--volt-wash);
 }
 
 .v2-logs-summary {
-  background: var(--color-bg-elevated);
-  border-color: var(--color-border-default);
+  padding: 0;
+}
+
+.v2-logs-support {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 26px 14px;
 }
 
 .v2-logs-provider-panel {
   background: var(--color-bg-elevated);
   border-color: var(--color-border-default);
+}
+
+@media (max-width: 900px) {
+  .v2-logs-surface {
+    --v2-logs-cols: 74px minmax(104px, 1fr) 96px minmax(0, 1.4fr) 22px;
+  }
+
+  .v2-logs-head {
+    flex-direction: column;
+    gap: 14px;
+    padding: 18px 18px 14px;
+  }
+
+  .v2-logs-stats {
+    width: 100%;
+    margin-left: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .v2-logs-toolbar,
+  .v2-logs-table-header,
+  .v2-logs-line,
+  .v2-logs-support {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .v2-logs-advanced {
+    width: 100%;
+  }
+
+  .v2-logs-advanced-menu .v2-logs-advanced {
+    right: auto;
+    left: 0;
+  }
+
+  .v2-logs-detail {
+    padding-left: 18px;
+  }
+}
+
+@media (max-width: 640px) {
+  .v2-logs-surface {
+    --v2-logs-cols: 68px minmax(0, 1fr) 62px 22px;
+  }
+
+  .v2-logs-table-header span:nth-child(4),
+  .v2-logs-table-header span:nth-child(5) {
+    display: none;
+  }
+
+  .v2-logs-line,
+  .v2-logs-table-header {
+    grid-template-columns: var(--v2-logs-cols);
+    gap: 8px;
+  }
+
+  .v2-logs-line {
+    grid-template-areas:
+      "time who kind caret"
+      "message message message message";
+    align-items: start;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  .v2-logs-time {
+    grid-area: time;
+  }
+
+  .v2-logs-who {
+    grid-area: who;
+  }
+
+  .v2-logs-kind {
+    grid-area: kind;
+    padding-right: 6px;
+    padding-left: 6px;
+  }
+
+  .v2-logs-caret {
+    grid-area: caret;
+    padding-top: 2px;
+  }
+
+  .v2-logs-message {
+    display: -webkit-box;
+    grid-area: message;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-height: 1.35;
+    white-space: normal;
+  }
+
+  .v2-logs-inline-links,
+  .v2-logs-detail {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
 }
 
 .v2-sidecar-log-surface {


### PR DESCRIPTION
## Summary

- Redesign the dashboard Logs surface around the Keeper Agent v2 trace-stream reference.
- Add live log KPIs, compact category chips, provenance/summary chips, severity-aware rows, and expandable row details.
- Keep existing log route link behavior for Code and Telemetry navigation, with responsive mobile rows that preserve the event message.

## Impact

This is a dashboard UI change only. It does not change MASC runtime logging semantics, OAS provider handling, or backend log APIs.

## Validation

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/logs.test.ts --no-file-parallelism --maxWorkers=1` passed: 9 tests
- `gtimeout 120s pnpm --dir dashboard exec tsc --noEmit --pretty false` passed
- Playwright render check against local dashboard passed: 200 rows loaded, first row expanded, desktop/mobile screenshots captured
- `git diff --check origin/main...HEAD` passed