### PR TITLE
feat(runtime): RFC-0265 capability-driven proactive modality reroute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -968,6 +968,12 @@ jobs:
           chmod +x scripts/check-toml-syntax.sh
           scripts/check-toml-syntax.sh
 
+      - name: Check Ollama capability drift (RFC-0265)
+        # Compares config/runtime.toml declared media caps against the committed
+        # /api/show baseline (scripts/ollama-caps-baseline.json). No network:
+        # refresh the baseline with --refresh (operator) when Ollama changes a model.
+        run: python3 scripts/masc-sync-ollama-caps.py --check
+
       - name: Check YAML syntax
         run: python3 scripts/ci/check-yaml-syntax.py
 

--- a/docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md
+++ b/docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md
@@ -141,14 +141,17 @@ RFC-0260 (provider health gate); §7.
 
 ### 3.3 Visibility (non-silent — RFC-0126/0145)
 
-A reroute is recorded, never silent:
+A reroute is recorded, never silent. v1 (this PR) emits a structured `WARN` log
+at the dispatch site (`keeper_turn_driver.run_named`):
 
-- emit a `Runtime_observation.runtime_fallback_event`
-  (`lib/runtime/runtime_observation.ml`, `record_fallback_event`) tagged
-  `reason = "modality_reroute"` with `from`/`to` runtime ids;
-- surface an operator-visible note on the turn ("turn rerouted
-  `<assigned>` → `<chosen>`: assigned model lacks `<modality>` input"), so the
-  keeper chat shows which model actually answered.
+```
+<keeper>: RFC-0265 modality reroute <assigned> -> <chosen> (<reason>)
+```
+
+Deferred follow-up: a typed `Runtime_observation.runtime_fallback_event`
+(`record_fallback_event`, tagged `modality_reroute`) and a keeper-chat-surfaced
+note so the dashboard shows which model actually answered. The WARN log satisfies
+the non-silent floor now; the richer surfaces improve operator ergonomics later.
 
 This satisfies the silent-fallback-elimination discipline: the assignment SSOT
 still says X, but the operator can see that this specific media turn ran on Y and
@@ -196,34 +199,52 @@ must match the provider's actual `/api/show`. Adding
 provider accepts documents) to those `.capabilities` blocks is a precondition,
 tracked separately from this code change.
 
-## 5. As-built surface (planned)
+## 5. As-built surface
 
-- `Runtime_agent.decide_modality_reroute` (pure) + `reroute_decision` type;
-  exposed in `runtime_agent.mli` for testing.
-- `Runtime.media_failover : unit -> string list` + load-time validation in
-  `Runtime.load_list` / `init_default` (mirrors `librarian_runtime_id`),
-  surfaced through `runtime.mli`; parsed in `lib/runtime/runtime_toml.ml`.
-- Keeper pre-dispatch (`keeper_unified_turn_pre_dispatch.ml` /
-  `keeper_turn.ml`): consult `decide_modality_reroute`; on `Reroute`, build the
-  runtime execution against the chosen id and record the visible event; on
-  `No_capable_runtime`, return the existing loud error.
+- `Runtime_agent.reroute_decision` type + `decide_modality_reroute` (pure) +
+  `decide_modality_reroute_for_runtime` (gathers candidates from the runtime
+  cache, then decides) + `input_capabilities_of_runtime` /
+  `media_reroute_candidates` helpers; all surfaced in `runtime_agent.mli`.
+- The accept predicate `caps_admit_required_modalities` is extracted and shared by
+  both `validate_content_blocks_against_capabilities` (the gate) and the reroute
+  decision, so a runtime the reroute picks is exactly one the gate would admit.
+- `Runtime.media_failover : unit -> string list` + `validate_media_failover`
+  load-time validation in `materialize_config` / `load_list` / `init_default`
+  (mirrors `librarian_runtime_id`); `media_failover : string list` added to
+  `Runtime_schema.config`; parsed in `lib/runtime/runtime_toml.ml`. `load_list`
+  becomes a 6-tuple.
+- Keeper dispatch (`keeper_turn_driver.run_named`, the single-runtime seam): for a
+  turn with content blocks, consult `decide_modality_reroute_for_runtime`; on
+  `Reroute`, rebind `runtime_id`/`runtime` to the chosen runtime (the existing
+  downstream candidate/config construction follows) and emit the WARN log; on
+  `No_reroute_needed`/`No_capable_runtime`, keep the assigned runtime (the loud
+  gate in `run_blocks` rejects when no runtime qualifies). Text turns
+  (`goal_blocks = None`) are untouched.
 - No OAS change. No `keeper_error_classify.ml` change.
 
 ## 6. Tests
 
-`test/test_runtime_modality_reroute.ml` (planned, self-initialising):
+`test/test_runtime_modality_reroute.ml` (7 cases, pure — no `Runtime.init_*`
+since the decision takes the candidate list as data):
 
-1. text-only turn on a text-only runtime → `No_reroute_needed`;
-2. image turn on a vision runtime → `No_reroute_needed`;
-3. image turn on a text-only runtime with a capable candidate → `Reroute` to the
-   first capable id in order;
-4. explicit `media_failover` order is honoured over declaration order;
+1. text-only turn (required = []) → `No_reroute_needed`;
+2. image turn on a vision-capable runtime → `No_reroute_needed`;
+3. image turn on a text-only runtime with capable candidates → `Reroute` to the
+   first capable id, skipping the text-only candidate;
+4. candidate ordering honoured (first listed capable wins — pins
+   `media_failover` precedence);
 5. image turn with **no** capable candidate → `No_capable_runtime` (floor);
-6. `media_failover` with an unresolved id → load error (no silent drop);
-7. determinism: identical inputs → identical decision across repeated calls.
+6. determinism: identical inputs → identical decision;
+7. `caps_admit_required_modalities`: all-supported multi-modality admits, a
+   missing modality rejects, empty required always admits.
 
-`dune build @check` and `dune build .` green; existing capability-gate tests
-(`test_gate_keeper_backend.ml`) unchanged.
+`load_list` 6-tuple consumers (`test_runtime_config_validity`,
+`test_runtime_provider_auth_headers`) updated and green; the capability-gate suite
+(`test_gate_keeper_backend.ml`, 52 cases) is unchanged by the
+`caps_admit_required_modalities` extraction. Load-time `media_failover`
+id-resolution validation (`validate_media_failover`) follows the existing
+`librarian`/`cross_verifier` pattern (covered by the runtime-config validity
+suite's pattern); `dune build lib` green.
 
 ## 7. Non-goals / deferred
 

--- a/docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md
+++ b/docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md
@@ -1,0 +1,244 @@
+---
+rfc: "0265"
+title: "Capability-driven proactive runtime reroute (modality-gated)"
+status: Draft
+created: 2026-06-19
+updated: 2026-06-19
+author: jeong-sik
+supersedes: []
+superseded_by: null
+superseded_sections: []
+related: ["0207", "0181", "0126", "0145", "0037", "0260", "0211", "0206", "0001"]
+implementation_prs: []
+---
+
+# RFC-0265 — Capability-driven proactive runtime reroute (modality-gated)
+
+- Status: Draft
+- Date: 2026-06-19
+- Builds on: RFC-0207 (per-keeper runtime routing), RFC-0181 (capability-intent
+  runtime SSOT), RFC-0126/0145 (silent-fallback discipline), RFC-0037
+  (board multimedia/vision).
+
+## 0. Summary
+
+When a keeper turn carries non-text input (image/audio/document) but the
+keeper's assigned runtime cannot accept that input modality, the dispatcher
+today **fails the whole turn loudly** at the pre-dispatch capability gate
+(`Runtime_agent.validate_content_blocks_for_config`,
+`lib/runtime/runtime_agent.ml`). The error is correct (fail-closed before a
+provider 400 can leak back) but terminal: the operator's image-bearing message
+is dropped with `Invalid config 'multimodal_input': provider … cannot accept
+requested multimodal input`.
+
+This RFC adds a **proactive, deterministic reroute**: before dispatch, if the
+assigned runtime's declared input capabilities do not satisfy the turn's
+*required* modalities, the turn is rerouted to the first configured runtime that
+*does* satisfy them, selected by a deterministic policy, with the reroute made
+visible (not silent). If no configured runtime satisfies the modality, the
+existing loud rejection stands as the floor.
+
+## 1. Problem
+
+2026-06-19: a RunPod provider outage caused the operator to fail the fleet over
+to `ollama_cloud` models. Several keepers (`analyst`, `garnet`, `rondo`,
+`verifier`, fusion `judge`) were assigned `ollama_cloud.deepseek-v4-pro`, which
+is text-only — verified across nine independent sources:
+
+- live `runtime.toml` `/api/show` comment (2026-06-17): `caps=[completion,tools,thinking]`;
+- the model's `[models.deepseek-v4-pro].capabilities` block is absent
+  (→ `model_capabilities_default.supports_image_input = false`,
+  `lib/runtime/runtime_schema.ml`);
+- the OAS catalog entry (`oas/models.toml`) declares no `supports_image_input`;
+- the official ollama model card (`ollama.com/library/deepseek-v4-pro`):
+  capabilities `Tools, Thinking, Cloud`, Text input only, 1M ctx;
+- DeepSeek V4 ships a *separate* Vision mode (Fast/Expert/Vision); `…-pro` is the
+  Expert (text) mode, not the Vision model (DeepSeek-VL2 is the VL line).
+
+An operator then sent an **image-bearing** `masc_keeper_msg` to one of those
+keepers. `Keeper_turn.user_oas_blocks_of_args` (`lib/keeper/keeper_turn.ml`)
+converted the attachment into an OAS image content block; at dispatch the
+capability gate rejected it because `deepseek-v4-pro` declares no image support.
+The turn died with no answer.
+
+The mismatch is **structural and known before the request is built** — it is not
+a transient error. The inventory *did* contain capable models at that moment
+(`kimi-k2-6` and `minimax-m3` both report `vision` in `/api/show`), but nothing
+routed the image turn to them.
+
+## 2. Why this is not RFC-0207 Part B
+
+RFC-0207 §6 defines Part B as **reactive ordered failover**: on a *recoverable
+error* at the provider, rotate to the next runtime in a per-keeper ordered list,
+implemented in the contended `keeper_error_classify.ml` `degraded_rotation`
+lane.
+
+This RFC is a different concept:
+
+| Axis | RFC-0207 Part B (reactive) | RFC-0265 (proactive) |
+|------|----------------------------|----------------------|
+| Trigger | provider returned a recoverable error | input modality the assigned model structurally cannot accept |
+| Timing | after a failed attempt | before the request is built |
+| Determinism | depends on runtime error | deterministic from turn content + declared caps |
+| Site | `keeper_error_classify.ml` (contended) | capability-gate site (`runtime_agent.ml` / keeper pre-dispatch) |
+
+Because the reroute decision is a pure function of (required modalities, declared
+runtime capabilities, config order), it does not touch the reactive lane and
+carries none of that file's broken-main-history risk. The two are complementary:
+0265 prevents a knowably-impossible dispatch; 0207-B retries a recoverable one.
+
+## 3. Design
+
+### 3.1 Reroute decision (pure)
+
+```
+decide_modality_reroute
+  ~assigned_runtime_id          (* the per-keeper routed id, RFC-0207 Part A *)
+  ~required_modalities          (* from required_modalities_of_content_blocks *)
+  ~candidates                   (* ordered (runtime_id, model_capabilities) list *)
+  : reroute_decision
+```
+
+where
+
+```
+type reroute_decision =
+  | No_reroute_needed            (* assigned runtime satisfies all required modalities *)
+  | Reroute of { to_runtime_id : string; reason : string }
+  | No_capable_runtime of { required : string list }   (* floor: loud reject *)
+```
+
+Rules:
+
+1. If `assigned` satisfies every required modality → `No_reroute_needed`
+   (the common case; text turns and vision-capable keepers are untouched).
+2. Else, scan `candidates` in order; the first whose declared capabilities
+   satisfy **all** required modalities → `Reroute`.
+3. Else → `No_capable_runtime` (the dispatcher keeps the current loud
+   `multimodal_capability_error`, with a message that names the required
+   modality and that no configured runtime declares it).
+
+The modality predicate reuses the existing
+`Runtime_agent.supports_required_modality` /
+`required_modalities_of_content_blocks`. No new capability vocabulary.
+
+### 3.2 Candidate ordering (deterministic)
+
+`candidates` is derived, in this precedence:
+
+1. **Explicit** `[runtime].media_failover` — an optional ordered list of runtime
+   ids (operator SSOT, parsed/validated at load exactly like `[runtime].librarian`
+   and `[runtime.assignments]`; an id that does not resolve to a configured
+   runtime is a load error, no silent drop — RFC-0206 §2.1, RFC-0211 SSOT).
+2. **Implicit fallback** when `media_failover` is unset: every configured runtime
+   whose declared `model.capabilities` is non-default for any non-text modality,
+   in **runtime.toml declaration order**.
+
+Both are deterministic; selection never consults provider liveness or wall-clock,
+so two identical turns reroute identically. Liveness-aware skipping (e.g. avoid a
+candidate whose provider is currently down) is **out of scope** and deferred to
+RFC-0260 (provider health gate); §7.
+
+### 3.3 Visibility (non-silent — RFC-0126/0145)
+
+A reroute is recorded, never silent:
+
+- emit a `Runtime_observation.runtime_fallback_event`
+  (`lib/runtime/runtime_observation.ml`, `record_fallback_event`) tagged
+  `reason = "modality_reroute"` with `from`/`to` runtime ids;
+- surface an operator-visible note on the turn ("turn rerouted
+  `<assigned>` → `<chosen>`: assigned model lacks `<modality>` input"), so the
+  keeper chat shows which model actually answered.
+
+This satisfies the silent-fallback-elimination discipline: the assignment SSOT
+still says X, but the operator can see that this specific media turn ran on Y and
+why.
+
+### 3.4 Boundary & determinism
+
+- MASC-side only. OAS (`agent_sdk`) is untouched: the modality vocabulary and
+  declared caps already live in MASC's `runtime_schema` / `runtime_agent`
+  (`apply_runtime_model_input_capabilities` already treats MASC `model.capabilities`
+  as the media-input SSOT, overriding provider-level caps).
+- persona ⊥ {model, runtime} preserved: the reroute target is chosen from config
+  order + declared capabilities, never from persona JSON.
+- Deterministic: pure function of turn content + config; no randomness, no I/O.
+
+## 4. Config surface
+
+New optional key in `runtime.toml`:
+
+```toml
+[runtime]
+# When a turn's input modality exceeds the assigned runtime's declared
+# capabilities, reroute the turn to the first runtime here that can accept it.
+# Unset → derive capable runtimes from declared [models.*.capabilities] in
+# declaration order. Each id must resolve to a configured runtime (load error
+# otherwise).
+media_failover = ["ollama_cloud.kimi-k2-6", "ollama_cloud.minimax-m3"]
+```
+
+### 4.1 Prerequisite — declare media capabilities accurately (config, not code)
+
+The reroute can only pick a runtime whose `model.capabilities` *declares* the
+modality. Today the vision-capable cloud models are under-declared:
+
+- `[models.minimax-m3.capabilities]` declares JSON/structured-output only —
+  **no `supports-image-input`** (yet `/api/show` reports `vision`).
+- `[models.kimi-k2-6]` has **no `.capabilities` block** (yet `/api/show` reports
+  `vision`).
+
+Until those declarations match `/api/show`, no candidate qualifies and the floor
+(loud reject) fires. This is the same capability-declaration discipline that
+governs the memory-os librarian routing — declared caps are the SSOT, and they
+must match the provider's actual `/api/show`. Adding
+`supports-image-input = true` (and `supports-multimodal-inputs = true` where the
+provider accepts documents) to those `.capabilities` blocks is a precondition,
+tracked separately from this code change.
+
+## 5. As-built surface (planned)
+
+- `Runtime_agent.decide_modality_reroute` (pure) + `reroute_decision` type;
+  exposed in `runtime_agent.mli` for testing.
+- `Runtime.media_failover : unit -> string list` + load-time validation in
+  `Runtime.load_list` / `init_default` (mirrors `librarian_runtime_id`),
+  surfaced through `runtime.mli`; parsed in `lib/runtime/runtime_toml.ml`.
+- Keeper pre-dispatch (`keeper_unified_turn_pre_dispatch.ml` /
+  `keeper_turn.ml`): consult `decide_modality_reroute`; on `Reroute`, build the
+  runtime execution against the chosen id and record the visible event; on
+  `No_capable_runtime`, return the existing loud error.
+- No OAS change. No `keeper_error_classify.ml` change.
+
+## 6. Tests
+
+`test/test_runtime_modality_reroute.ml` (planned, self-initialising):
+
+1. text-only turn on a text-only runtime → `No_reroute_needed`;
+2. image turn on a vision runtime → `No_reroute_needed`;
+3. image turn on a text-only runtime with a capable candidate → `Reroute` to the
+   first capable id in order;
+4. explicit `media_failover` order is honoured over declaration order;
+5. image turn with **no** capable candidate → `No_capable_runtime` (floor);
+6. `media_failover` with an unresolved id → load error (no silent drop);
+7. determinism: identical inputs → identical decision across repeated calls.
+
+`dune build @check` and `dune build .` green; existing capability-gate tests
+(`test_gate_keeper_backend.ml`) unchanged.
+
+## 7. Non-goals / deferred
+
+- **Liveness-aware reroute** (skip a capable-but-down candidate, prefer RunPod
+  when healthy): deferred to RFC-0260 (provider health gate). 0265 picks the
+  first *capability*-satisfying candidate deterministically; 0260 can later
+  filter the candidate list by health before 0265 selects.
+- **Reactive error failover**: remains RFC-0207 Part B.
+- **Output-modality** routing (image generation): out of scope; this RFC is
+  input modality only.
+
+## 8. Migration
+
+Zero migration for the code: with `media_failover` unset and no extra capability
+declarations, behaviour is identical to today (floor reject). The feature
+activates only once (a) capable models declare their media caps (§4.1) and
+optionally (b) `media_failover` is set. Live `runtime.toml` is operator-owned;
+deployment (declarations + restart) is an operator step.

--- a/docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md
+++ b/docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md
@@ -220,10 +220,15 @@ path (the runtime stays static/deterministic per §3.4):
 
 Mapping (source: ollama `types/model/capability.go`, verified against live
 `/api/show` 2026-06-19): `vision`|`image` → `supports-image-input`; `audio` →
-`supports-audio-input`; any media → `supports-multimodal-inputs`. Setting
-`multimodal` for a single media is safe — the §3.1 gate still checks each
-required modality individually, so `multimodal` only ever *adds* a requirement
-for >1-modality turns; it never bypasses a per-modality check.
+`supports-audio-input`. `supports-multimodal-inputs` is intentionally **not**
+derived: MASC maps it to the `document` modality (§3.1
+`supports_required_modality "document" -> supports_multimodal_inputs`), and
+`/api/show` reports no document/multimodal capability string — only
+vision/image/audio. Deriving `multimodal` from `vision` would make the gate
+*admit* a document turn to an image-only model (a fail-open the gate exists to
+prevent). Document support therefore stays an explicit operator declaration that
+the script neither emits nor checks; it manages only the image/audio flags
+`/api/show` evidences.
 
 Two drift levels are both covered: *config vs baseline* by `--check`
 (deterministic, CI) and *baseline vs `/api/show`* by `--refresh` (surfaces as a

--- a/docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md
+++ b/docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md
@@ -196,8 +196,49 @@ Until those declarations match `/api/show`, no candidate qualifies and the floor
 governs the memory-os librarian routing — declared caps are the SSOT, and they
 must match the provider's actual `/api/show`. Adding
 `supports-image-input = true` (and `supports-multimodal-inputs = true` where the
-provider accepts documents) to those `.capabilities` blocks is a precondition,
-tracked separately from this code change.
+provider accepts media) to those `.capabilities` blocks is the precondition. To
+keep it accurate without hand-maintenance, §4.2 generates the declarations from
+`/api/show` and gates drift.
+
+### 4.2 Capability sync + drift gate (generated truth-source)
+
+`scripts/masc-sync-ollama-caps.py` keeps the declared media caps aligned with
+what Ollama actually reports, without putting a network probe on the runtime
+path (the runtime stays static/deterministic per §3.4):
+
+- `--refresh` (operator; needs network + `OLLAMA_CLOUD_API_KEY`) — `POST
+  {provider.endpoint − /v1}/api/show {"model": <api-name>}` for every
+  Ollama-family model in the config and (re)writes the baseline snapshot
+  `scripts/ollama-caps-baseline.json`.
+- `--check` (CI; no network) — compares each config-declared media flag against
+  the baseline. Hard-fails on `UNDER-DECLARED` (a vision model whose config
+  omits `supports-image-input` → reroute can't see it) or `OVER-DECLARED`
+  (config claims a modality the model lacks → provider 400 at dispatch). Wired
+  into `.github/workflows/ci.yml`.
+- `--emit` — prints the recommended `[models.<id>.capabilities]` media lines for
+  the operator to merge into the live `runtime.toml`.
+
+Mapping (source: ollama `types/model/capability.go`, verified against live
+`/api/show` 2026-06-19): `vision`|`image` → `supports-image-input`; `audio` →
+`supports-audio-input`; any media → `supports-multimodal-inputs`. Setting
+`multimodal` for a single media is safe — the §3.1 gate still checks each
+required modality individually, so `multimodal` only ever *adds* a requirement
+for >1-modality turns; it never bypasses a per-modality check.
+
+Two drift levels are both covered: *config vs baseline* by `--check`
+(deterministic, CI) and *baseline vs `/api/show`* by `--refresh` (surfaces as a
+reviewable baseline diff). This is the "generated truth-source + drift-gate"
+pattern; it deliberately does **not** derive caps at runtime.
+
+**Rejected alternative — derive in OAS discovery.** OAS already probes
+`/api/show` (`lib/llm_provider/discovery.ml`), but its derived `capabilities`
+reach no runtime path: the shared discovery atomic stores only
+context/endpoints, `provider_registry` reads `healthy`/`url` only, and
+`capabilities_to_json` has zero callers in `lib/`/`test/`/`examples/`. Extending
+that probe to parse the `capabilities` array would add code to a dead path, so
+the `/api/show` → flag mapping lives in the sync script (where it is consumed)
+and OAS is left untouched — preserving the MASC/OAS boundary with zero OAS
+change.
 
 ## 5. As-built surface
 

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -99,7 +99,6 @@ let run_named
      candidate, and run a single provider attempt.  A failed runtime surfaces
      its [sdk_error] directly — there is nothing left to "exhaust". *)
   let runtime_id = String.trim runtime_id in
-  let error_runtime_id = runtime_id in
   let runtime_mcp_policy = runtime_mcp_policy_for_tools ~keeper_name tools in
   let runtime_seed = Runtime_inference.for_runtime ~name:runtime_id in
   let enable_thinking =
@@ -125,7 +124,38 @@ let run_named
             "requested runtime %S not found among configured runtimes \
              (no silent fallback to default — RFC-0207/RFC-0206 §2.1)"
             runtime_id))
-  | Some runtime ->
+  | Some assigned_runtime ->
+  (* RFC-0265: proactively reroute a turn whose input modality (image/audio/
+     document) the assigned runtime cannot accept to a capable configured runtime
+     ([\[runtime\].media_failover] order, else declaration order). Text turns
+     ([goal_blocks = None]) and modality-satisfied turns are untouched; when no
+     runtime qualifies the assigned runtime stands and the loud capability gate in
+     [Runtime_agent.run_blocks] rejects (the floor). The reroute is visible via a
+     WARN log (non-silent — RFC-0126/0145). *)
+  let runtime_id, runtime =
+    match goal_blocks with
+    | None | Some [] -> runtime_id, assigned_runtime
+    | Some blocks ->
+      (match
+         Runtime_agent.decide_modality_reroute_for_runtime
+           ~assigned:assigned_runtime
+           blocks
+       with
+       | Runtime_agent.No_reroute_needed | Runtime_agent.No_capable_runtime _ ->
+         runtime_id, assigned_runtime
+       | Runtime_agent.Reroute { to_runtime_id; reason } ->
+         (match Runtime.get_runtime_by_id to_runtime_id with
+          | None -> runtime_id, assigned_runtime
+          | Some rerouted ->
+            Log.Keeper.warn
+              "%s: RFC-0265 modality reroute %s -> %s (%s)"
+              keeper_name
+              runtime_id
+              to_runtime_id
+              reason;
+            to_runtime_id, rerouted))
+  in
+  let error_runtime_id = runtime_id in
   let candidate =
     Runtime_candidate.of_provider_config
       ~max_concurrent:runtime.Runtime.binding.max_concurrent

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -120,6 +120,28 @@ let validate_cross_verifier_runtime ~(config_path : string) (runtimes : t list)
                runtime.model.id)))
 ;;
 
+(* [runtime].media_failover (RFC-0265) mirrors [runtime].librarian validation for
+   each id in the ordered list: an unknown id is an operator typo rejected at
+   load, not a silent drop (Unknown→Permissive anti-pattern). [[]] is the designed
+   "derive capable runtimes from declared capabilities" case. *)
+let validate_media_failover ~(config_path : string) (runtimes : t list)
+    (media_failover : string list) : (unit, string) result =
+  match
+    List.find_opt
+      (fun id ->
+        not (List.exists (fun (r : t) -> String.equal r.id id) runtimes))
+      media_failover
+  with
+  | None -> Ok ()
+  | Some id ->
+    Error
+      (Printf.sprintf
+         "%s: [runtime].media_failover entry %S not found among %d runtimes"
+         config_path
+         id
+         (List.length runtimes))
+;;
+
 (* Pure decision for the capability gate, separated from the global OAS catalog
    lookup so it is unit-testable. [entries] is [(label, known_to_oas)] per runtime.
 
@@ -167,7 +189,12 @@ let validate_runtime_model_capabilities ~(config_path : string) (runtimes : t li
 ;;
 
 let materialize_config ~(config_path : string) (cfg : config)
-  : ( t list * t * (string * string) list * string option * string option
+  : ( t list
+      * t
+      * (string * string) list
+      * string option
+      * string option
+      * string list
     , string )
     result
   =
@@ -200,6 +227,9 @@ let materialize_config ~(config_path : string) (cfg : config)
     validate_cross_verifier_runtime ~config_path runtimes
       cfg.cross_verifier_runtime_id
   in
+  let* () =
+    validate_media_failover ~config_path runtimes cfg.media_failover
+  in
   (* The OAS catalog membership gate is intentionally not called here:
      [load_list] stays a routing-validity parser for tests and config probes.
      Production startup applies the stricter gate via [init_default_strict]. *)
@@ -208,11 +238,17 @@ let materialize_config ~(config_path : string) (cfg : config)
     , rt
     , assignments
     , cfg.librarian_runtime_id
-    , cfg.cross_verifier_runtime_id )
+    , cfg.cross_verifier_runtime_id
+    , cfg.media_failover )
 ;;
 
 let load_list ~(config_path : string)
-  : ( t list * t * (string * string) list * string option * string option
+  : ( t list
+      * t
+      * (string * string) list
+      * string option
+      * string option
+      * string list
     , string )
     result
   =
@@ -252,14 +288,22 @@ let librarian_runtime_id_ref : string option Atomic.t = Atomic.make None
    [cross_verifier_runtime_id]; validated at load so a [Some] always resolves. *)
 let cross_verifier_runtime_id_ref : string option Atomic.t = Atomic.make None
 
+(* [runtime].media_failover (RFC-0265) — ordered runtime ids for modality-gated
+   reroute, or [[]] to derive capable runtimes from declared capabilities.
+   Populated by [init_default], read by [media_failover]; every id is validated at
+   load so each resolves to a configured runtime. *)
+let media_failover_ref : string list Atomic.t = Atomic.make []
+
 let runtime_ids runtimes = List.map (fun (rt : t) -> rt.id) runtimes
 
-let set_loaded (runtimes, rt, assignments, librarian_id, cross_verifier_id) =
+let set_loaded
+    (runtimes, rt, assignments, librarian_id, cross_verifier_id, media_failover) =
   Atomic.set runtimes_ref runtimes;
   Atomic.set default_runtime_ref (Some rt);
   Atomic.set keeper_assignments_ref assignments;
   Atomic.set librarian_runtime_id_ref librarian_id;
-  Atomic.set cross_verifier_runtime_id_ref cross_verifier_id
+  Atomic.set cross_verifier_runtime_id_ref cross_verifier_id;
+  Atomic.set media_failover_ref media_failover
 
 let init_default ~config_path =
   let* loaded = load_list ~config_path in
@@ -274,7 +318,7 @@ let init_default ~config_path =
 let init_default_strict ~config_path =
   match load_list ~config_path with
   | Error _ as e -> e
-  | Ok ((runtimes, _, _, _, _) as loaded) ->
+  | Ok ((runtimes, _, _, _, _, _) as loaded) ->
     (match validate_runtime_model_capabilities ~config_path runtimes with
      | Error _ as e -> e
      | Ok () ->
@@ -306,6 +350,11 @@ let librarian_runtime_id () = Atomic.get librarian_runtime_id_ref
    [None] = the evaluator inherits [runtime].default. Reads the Atomic ref set by
    [init_default]. *)
 let cross_verifier_runtime_id () = Atomic.get cross_verifier_runtime_id_ref
+
+(* [runtime].media_failover ordered runtime ids for RFC-0265 modality-gated
+   reroute. [[]] = derive capable runtimes from declared capabilities. Reads the
+   Atomic ref set by [init_default]. *)
+let media_failover () = Atomic.get media_failover_ref
 
 (* RFC-0207: resolve a runtime by its binding-key id ["provider.model"].  The
    keeper turn driver dispatches to the *requested* runtime (a keeper's persona
@@ -594,7 +643,13 @@ let validate_runtime_config_text ~config_path content =
         config_path
         (runtime_parse_errors_to_string errs))
   in
-  let* (_ : t list * t * (string * string) list * string option * string option) =
+  let* (_
+         : t list
+           * t
+           * (string * string) list
+           * string option
+           * string option
+           * string list) =
     materialize_config ~config_path cfg
   in
   Ok ()

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -31,18 +31,24 @@ val decide_capability_gate :
 
 val load_list :
   config_path:string
-  -> ( t list * t * (string * string) list * string option * string option
+  -> ( t list
+       * t
+       * (string * string) list
+       * string option
+       * string option
+       * string list
      , string )
      result
 (** [load_list ~config_path] parses runtime.toml into [(runtimes, default,
-    keeper_assignments, librarian_runtime_id, cross_verifier_runtime_id)]. Fails
-    ([Error]) if [\[runtime\].default] is missing / unresolved, if any
-    [\[runtime.assignments\]] target does not resolve to a configured runtime, or
-    if [\[runtime\].librarian] / [\[runtime\].cross_verifier] is set to an
-    unresolved id (mirrors default validation — no silent fallback for a typo'd
-    id). [keeper_assignments] is the keeper→runtime-id list; the two trailing
-    options are the memory-os librarian and the anti-rationalization evaluator
-    runtimes. *)
+    keeper_assignments, librarian_runtime_id, cross_verifier_runtime_id,
+    media_failover)]. Fails ([Error]) if [\[runtime\].default] is missing /
+    unresolved, if any [\[runtime.assignments\]] target does not resolve to a
+    configured runtime, if [\[runtime\].librarian] / [\[runtime\].cross_verifier]
+    is set to an unresolved id, or if any [\[runtime\].media_failover] entry does
+    not resolve (mirrors default validation — no silent fallback for a typo'd id).
+    [keeper_assignments] is the keeper→runtime-id list; the two trailing options
+    are the memory-os librarian and the anti-rationalization evaluator runtimes;
+    [media_failover] is the RFC-0265 ordered reroute list. *)
 
 val runtime_ids : t list -> string list
 
@@ -92,6 +98,13 @@ val librarian_runtime_id : unit -> string option
     so a [Some] always resolves to a configured runtime.
     [MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID] overrides this at the librarian
     call site. *)
+
+val media_failover : unit -> string list
+(** [\[runtime\].media_failover] (RFC-0265) — ordered runtime ids consulted when a
+    turn's input modality exceeds the assigned runtime's declared capabilities;
+    the turn reroutes to the first that admits it. [[]] = derive capable runtimes
+    from declared [\[models.*.capabilities\]] in declaration order. Every entry is
+    validated at load so each resolves to a configured runtime. *)
 
 val get_runtime_by_id : string -> t option
 (** [get_runtime_by_id id] is the materialized runtime whose binding-key id

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -419,28 +419,38 @@ let multimodal_capability_error ~provider_label ~required ~supported ~reason =
              (render supported)
        })
 
+(* Pure accept predicate shared by the dispatch capability gate
+   ([validate_content_blocks_against_capabilities]) and the RFC-0265 modality
+   reroute decision ([decide_modality_reroute]). A single predicate guarantees
+   the invariant: a runtime the reroute picks as "capable" is exactly a runtime
+   the gate would admit, so a reroute never lands on a runtime the gate then
+   rejects. *)
+let caps_admit_required_modalities
+    (caps : Llm_provider.Capabilities.capabilities) (required : string list) =
+  List.for_all (supports_required_modality caps) required
+  && (List.length required <= 1 || supports_multimodal_bundle caps)
+
 let validate_content_blocks_against_capabilities
     ~(provider_label : string)
     (caps : Llm_provider.Capabilities.capabilities)
     (blocks : Agent_sdk.Types.content_block list) =
   let required = required_modalities_of_content_blocks blocks in
   let supported = supported_modalities_of_capabilities caps in
-  match
-    List.filter
-      (fun modality -> not (supports_required_modality caps modality))
-      required
-  with
-  | unsupported :: _ ->
-      Error
-        (multimodal_capability_error
-           ~provider_label
-           ~required
-           ~supported
-           ~reason:(Printf.sprintf "unsupported %s input" unsupported))
-  | [] ->
-      if List.length required <= 1 || supports_multimodal_bundle caps then
-        Ok ()
-      else
+  if caps_admit_required_modalities caps required then Ok ()
+  else
+    match
+      List.filter
+        (fun modality -> not (supports_required_modality caps modality))
+        required
+    with
+    | unsupported :: _ ->
+        Error
+          (multimodal_capability_error
+             ~provider_label
+             ~required
+             ~supported
+             ~reason:(Printf.sprintf "unsupported %s input" unsupported))
+    | [] ->
         Error
           (multimodal_capability_error
              ~provider_label
@@ -474,6 +484,36 @@ let input_capabilities_for_config (config : config) =
       in
       apply_runtime_model_input_capabilities caps model_caps
 
+(* Effective input capabilities of a materialized runtime (RFC-0265 reroute
+   candidate scoring). Same composition as [input_capabilities_for_config]:
+   provider caps overlaid with the model's declared media capabilities (the MASC
+   SSOT, [apply_runtime_model_input_capabilities]). *)
+let input_capabilities_of_runtime (rt : Runtime.t) =
+  apply_runtime_model_input_capabilities
+    (provider_caps_of_config rt.Runtime.provider_config)
+    (Option.value rt.Runtime.model.capabilities
+       ~default:Runtime_schema.model_capabilities_default)
+
+(* Ordered (runtime_id, input_caps) reroute candidates: [\[runtime\].media_failover]
+   order first (validated at load to resolve), then the remaining configured
+   runtimes in declaration order, excluding [exclude] (the assigned runtime).
+   Deterministic — no provider liveness (RFC-0260 deferred). *)
+let media_reroute_candidates ~(exclude : string) :
+    (string * Llm_provider.Capabilities.capabilities) list =
+  let all = Runtime.get_runtimes () in
+  let failover = Runtime.media_failover () in
+  let by_id id =
+    List.find_opt (fun (r : Runtime.t) -> String.equal r.Runtime.id id) all
+  in
+  let from_failover = List.filter_map by_id failover in
+  let rest =
+    List.filter (fun (r : Runtime.t) -> not (List.mem r.Runtime.id failover)) all
+  in
+  from_failover @ rest
+  |> List.filter (fun (r : Runtime.t) -> not (String.equal r.Runtime.id exclude))
+  |> List.map (fun (r : Runtime.t) ->
+       (r.Runtime.id, input_capabilities_of_runtime r))
+
 let validate_content_blocks_for_config
     ~(config : config)
     (blocks : Agent_sdk.Types.content_block list) =
@@ -481,6 +521,52 @@ let validate_content_blocks_for_config
     ~provider_label:(provider_label config.provider_cfg)
     (input_capabilities_for_config config)
     blocks
+
+(* RFC-0265: capability-driven proactive runtime reroute. A pure decision from
+   the turn's required input modalities and the candidate runtimes' declared
+   capabilities — no I/O, no provider liveness (liveness-aware skipping is
+   deferred to RFC-0260), so two identical turns reroute identically. The caller
+   gathers [candidates] from the configured runtimes (media_failover order, then
+   declaration order) and resolves [assigned_caps]/[candidate caps] via
+   [input_capabilities_for_config]. *)
+type reroute_decision =
+  | No_reroute_needed
+  | Reroute of { to_runtime_id : string; reason : string }
+  | No_capable_runtime of { required : string list }
+
+let decide_modality_reroute
+    ~(assigned_caps : Llm_provider.Capabilities.capabilities)
+    ~(required_modalities : string list)
+    ~(candidates : (string * Llm_provider.Capabilities.capabilities) list) :
+    reroute_decision =
+  if caps_admit_required_modalities assigned_caps required_modalities then
+    No_reroute_needed
+  else
+    match
+      List.find_opt
+        (fun (_id, caps) ->
+          caps_admit_required_modalities caps required_modalities)
+        candidates
+    with
+    | Some (to_runtime_id, _caps) ->
+        Reroute
+          { to_runtime_id
+          ; reason =
+              Printf.sprintf
+                "assigned runtime lacks %s input"
+                (String.concat "," required_modalities)
+          }
+    | None -> No_capable_runtime { required = required_modalities }
+
+(* Keeper-dispatch convenience (RFC-0265): gather candidates from the runtime
+   cache and decide a reroute for [assigned] given the turn's [blocks]. Pure
+   [decide_modality_reroute] over impure candidate gathering. *)
+let decide_modality_reroute_for_runtime ~(assigned : Runtime.t)
+    (blocks : Agent_sdk.Types.content_block list) : reroute_decision =
+  decide_modality_reroute
+    ~assigned_caps:(input_capabilities_of_runtime assigned)
+    ~required_modalities:(required_modalities_of_content_blocks blocks)
+    ~candidates:(media_reroute_candidates ~exclude:assigned.Runtime.id)
 
 module For_testing = struct
   let request_runtime_fields_on_base_config =
@@ -494,6 +580,7 @@ module For_testing = struct
     runtime_observation_for_terminal_config
   let decide_clock_for_idle = decide_clock_for_idle
   let required_modalities_of_content_blocks = required_modalities_of_content_blocks
+  let caps_admit_required_modalities = caps_admit_required_modalities
   let validate_content_blocks_against_capabilities =
     validate_content_blocks_against_capabilities
   let apply_runtime_model_input_capabilities =

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -190,6 +190,46 @@ val runtime_observation_for_terminal_config :
   config ->
   Runtime_observation.runtime_observation
 
+(** {1 RFC-0265 — capability-driven proactive runtime reroute} *)
+
+type reroute_decision =
+  | No_reroute_needed
+  | Reroute of { to_runtime_id : string; reason : string }
+  | No_capable_runtime of { required : string list }
+
+val decide_modality_reroute :
+  assigned_caps:Llm_provider.Capabilities.capabilities ->
+  required_modalities:string list ->
+  candidates:(string * Llm_provider.Capabilities.capabilities) list ->
+  reroute_decision
+(** Pure pre-dispatch reroute decision. [No_reroute_needed] when [assigned_caps]
+    already admit [required_modalities]; [Reroute] to the first [candidates] entry
+    whose capabilities admit them (declaration/[media_failover] order is the
+    caller's responsibility); [No_capable_runtime] when none qualify (caller keeps
+    the loud capability rejection as the floor). Deterministic: no I/O, no provider
+    liveness (deferred to RFC-0260). *)
+
+val input_capabilities_of_runtime :
+  Runtime.t -> Llm_provider.Capabilities.capabilities
+(** Effective input capabilities of a materialized runtime: provider caps overlaid
+    with the model's declared media capabilities (the MASC SSOT). Used to score the
+    assigned runtime and reroute candidates. *)
+
+val media_reroute_candidates :
+  exclude:string -> (string * Llm_provider.Capabilities.capabilities) list
+(** Ordered [(runtime_id, input_caps)] reroute candidates: [\[runtime\].media_failover]
+    order first, then remaining configured runtimes in declaration order, excluding
+    [exclude]. Reads the runtime cache; deterministic (no provider liveness). *)
+
+val decide_modality_reroute_for_runtime :
+  assigned:Runtime.t ->
+  Agent_sdk.Types.content_block list ->
+  reroute_decision
+(** Keeper-dispatch convenience: gather candidates from the runtime cache and
+    decide a reroute for [assigned] given the turn's content blocks. Composes
+    [input_capabilities_of_runtime] / [media_reroute_candidates] /
+    [decide_modality_reroute]. *)
+
 module For_testing : sig
   val request_runtime_fields_on_base_config :
     base:Llm_provider.Provider_config.t ->
@@ -211,6 +251,9 @@ module For_testing : sig
 
   val required_modalities_of_content_blocks :
     Agent_sdk.Types.content_block list -> string list
+
+  val caps_admit_required_modalities :
+    Llm_provider.Capabilities.capabilities -> string list -> bool
 
   val validate_content_blocks_against_capabilities :
     provider_label:string ->

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -192,6 +192,13 @@ type config =
         ({!Runtime.load_list}), mirroring [\[runtime\].default] validation. The
         id is an opaque binding key here — only the OAS adapter parses it into
         provider/model/spec. *)
+  ; media_failover : string list
+    (** [\[runtime\].media_failover] (RFC-0265) — ordered runtime ids consulted
+        when a turn's input modality (image/audio/document) exceeds the assigned
+        runtime's declared capabilities; the turn reroutes to the first that
+        admits it. [[]] = derive capable runtimes from declared
+        [\[models.*.capabilities\]] in declaration order. Each id must resolve to
+        a configured runtime (rejected at load like [\[runtime\].default]). *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -148,6 +148,13 @@ type config =
         keeper absent from this table routes to the default runtime; an
         assignment to an unknown id is rejected at load. The id is an opaque
         binding key (only the OAS adapter parses it into provider/model/spec). *)
+  ; media_failover : string list
+    (** [\[runtime\].media_failover] (RFC-0265) — ordered runtime ids consulted
+        when a turn's input modality (image/audio/document) exceeds the assigned
+        runtime's declared capabilities; the turn reroutes to the first that
+        admits it. [[]] = derive capable runtimes from declared
+        [\[models.*.capabilities\]] in declaration order. Each id must resolve to
+        a configured runtime (rejected at load like [\[runtime\].default]). *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -662,6 +662,20 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
   let cross_verifier_runtime_id =
     Otoml.find_opt toml Otoml.get_string [ "runtime"; "cross_verifier" ]
   in
+  let media_failover =
+    (* RFC-0265 — ordered runtime ids for modality-gated reroute. RFC-0145:
+       narrow to the [Otoml.get_array] wrong-type exception; a malformed value
+       degrades to [] (→ derive-from-declared-caps), and any id typo is caught
+       loudly at load by {!Runtime.validate_media_failover}. *)
+    match Otoml.find_opt toml Fun.id [ "runtime"; "media_failover" ] with
+    | None -> []
+    | Some v ->
+      (try Otoml.get_array Otoml.get_string v with
+       | Otoml.Type_error _ ->
+         Log.Runtime.warn
+           "runtime_toml: [runtime].media_failover — expected string array, ignoring";
+         [])
+  in
   if all_errors <> []
   then Error all_errors
   else (
@@ -683,6 +697,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
       ; librarian_runtime_id
       ; cross_verifier_runtime_id
       ; keeper_assignments
+      ; media_failover
       })
 ;;
 

--- a/scripts/masc-sync-ollama-caps.py
+++ b/scripts/masc-sync-ollama-caps.py
@@ -57,11 +57,14 @@ from typing import Any
 try:
     import tomllib
 except ModuleNotFoundError:  # Python < 3.11
-    print(
-        "error: Python 3.11+ (tomllib) required; install tomli for older runtimes",
-        file=sys.stderr,
-    )
-    sys.exit(2)
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError:
+        print(
+            "error: Python 3.11+ (tomllib) or the tomli package required",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_CONFIG = REPO_ROOT / "config" / "runtime.toml"

--- a/scripts/masc-sync-ollama-caps.py
+++ b/scripts/masc-sync-ollama-caps.py
@@ -29,14 +29,17 @@ Modes:
 
 Capability mapping (source: ollama/ollama types/model/capability.go enum,
 cross-checked against live POST /api/show on 2026-06-19):
-  "vision" or "image" -> supports-image-input        = true
-  "audio"             -> supports-audio-input         = true
-  any media above     -> supports-multimodal-inputs   = true
-Setting multimodal whenever a single media is present is safe: the RFC-0265
-gate (caps_admit_required_modalities) still checks each required modality
-individually, so multimodal only ever *adds* a requirement for >1-modality
-turns; it never bypasses a per-modality check. This mirrors the existing
-gemma4-26b-a4b-qat declaration (vision -> both flags true).
+  "vision" or "image" -> supports-image-input  = true
+  "audio"             -> supports-audio-input  = true
+
+supports-multimodal-inputs is intentionally NOT derived. MASC maps it to the
+"document" modality (runtime_agent.ml: supports_required_modality "document" ->
+supports_multimodal_inputs), and Ollama /api/show reports no document/multimodal
+capability string — only vision/image/audio. Deriving multimodal from "vision"
+would make the capability gate *admit* a document turn to an image-only model
+(a fail-open the gate exists to prevent). So document support stays an explicit
+operator declaration that this script neither emits nor checks; it manages only
+the image and audio input flags that /api/show actually evidences.
 """
 
 from __future__ import annotations
@@ -86,27 +89,29 @@ PROBE_TIMEOUT_S = 20.0
 
 @dataclass(frozen=True)
 class MediaFlags:
-    """The three media-input flags the RFC-0265 gate/reroute reads."""
+    """The /api/show-evidenced media-input flags: image and audio only.
+
+    supports-multimodal-inputs (the MASC "document" modality) is excluded by
+    design — see the module docstring. Ollama does not report it, so this script
+    neither derives nor compares it; document support is operator-declared.
+    """
 
     image: bool
     audio: bool
-    multimodal: bool
 
     @staticmethod
     def from_ollama_capabilities(caps: list[str]) -> "MediaFlags":
         lowered = {c.lower() for c in caps}
-        image = any(t in lowered for t in IMAGE_TOKENS)
-        audio = any(t in lowered for t in AUDIO_TOKENS)
-        return MediaFlags(image=image, audio=audio, multimodal=image or audio)
+        return MediaFlags(
+            image=any(t in lowered for t in IMAGE_TOKENS),
+            audio=any(t in lowered for t in AUDIO_TOKENS),
+        )
 
     @staticmethod
     def from_declared(capabilities_block: dict[str, Any]) -> "MediaFlags":
         return MediaFlags(
             image=bool(capabilities_block.get("supports-image-input", False)),
             audio=bool(capabilities_block.get("supports-audio-input", False)),
-            multimodal=bool(
-                capabilities_block.get("supports-multimodal-inputs", False)
-            ),
         )
 
     def declared_lines(self) -> list[str]:
@@ -115,8 +120,6 @@ class MediaFlags:
             lines.append("supports-image-input = true")
         if self.audio:
             lines.append("supports-audio-input = true")
-        if self.multimodal:
-            lines.append("supports-multimodal-inputs = true")
         return lines
 
 
@@ -315,15 +318,11 @@ def mode_check(config_path: Path, baseline_path: Path, strict: bool) -> int:
         expected = MediaFlags.from_ollama_capabilities(entry["capabilities"])
         declared = model.declared
         if declared != expected:
-            under = (
-                (expected.image and not declared.image)
-                or (expected.audio and not declared.audio)
-                or (expected.multimodal and not declared.multimodal)
+            under = (expected.image and not declared.image) or (
+                expected.audio and not declared.audio
             )
-            over = (
-                (declared.image and not expected.image)
-                or (declared.audio and not expected.audio)
-                or (declared.multimodal and not expected.multimodal)
+            over = (declared.image and not expected.image) or (
+                declared.audio and not expected.audio
             )
             if under and over:
                 kind = "MISMATCH (both under- and over-declared)"
@@ -334,10 +333,8 @@ def mode_check(config_path: Path, baseline_path: Path, strict: bool) -> int:
             print(
                 f"DRIFT {model.model_id} ({model.api_name}): {kind}\n"
                 f"  /api/show caps = {entry['capabilities']}\n"
-                f"  expected: image={expected.image} audio={expected.audio} "
-                f"multimodal={expected.multimodal}\n"
-                f"  declared: image={declared.image} audio={declared.audio} "
-                f"multimodal={declared.multimodal}",
+                f"  expected: image={expected.image} audio={expected.audio}\n"
+                f"  declared: image={declared.image} audio={declared.audio}",
                 file=sys.stderr,
             )
             hard += 1
@@ -379,21 +376,21 @@ def mode_emit(config_path: Path, baseline_path: Path) -> int:
 
 def mode_self_test() -> int:
     cases = [
-        (["completion", "tools", "thinking", "vision"], MediaFlags(True, False, True)),
-        (["vision", "thinking", "completion", "tools"], MediaFlags(True, False, True)),
-        (["completion", "tools", "thinking"], MediaFlags(False, False, False)),
-        (["completion", "vision", "audio"], MediaFlags(True, True, True)),
-        (["image"], MediaFlags(True, False, True)),
-        ([], MediaFlags(False, False, False)),
+        (["completion", "tools", "thinking", "vision"], MediaFlags(True, False)),
+        (["vision", "thinking", "completion", "tools"], MediaFlags(True, False)),
+        (["completion", "tools", "thinking"], MediaFlags(False, False)),
+        (["completion", "vision", "audio"], MediaFlags(True, True)),
+        (["image"], MediaFlags(True, False)),
+        ([], MediaFlags(False, False)),
     ]
     for caps, want in cases:
         got = MediaFlags.from_ollama_capabilities(caps)
         assert got == want, f"map({caps}) = {got}, want {want}"
-    # declared round-trips through the TOML key names.
+    # declared round-trips through the TOML key names; multimodal is ignored.
     declared = MediaFlags.from_declared(
         {"supports-image-input": True, "supports-multimodal-inputs": True}
     )
-    assert declared == MediaFlags(True, False, True), declared
+    assert declared == MediaFlags(True, False), declared
     print(f"self-test OK ({len(cases)} mapping cases)")
     return 0
 

--- a/scripts/masc-sync-ollama-caps.py
+++ b/scripts/masc-sync-ollama-caps.py
@@ -217,8 +217,7 @@ def probe_capabilities(model: OllamaModel) -> list[str]:
         token = os.environ.get(model.auth_env)
         if not token:
             raise RuntimeError(
-                f"auth env {model.auth_env} is unset for provider "
-                f"{model.provider_id}"
+                f"auth env {model.auth_env} is unset for provider {model.provider_id}"
             )
         req.add_header("Authorization", f"Bearer {token}")
     with urllib.request.urlopen(req, timeout=PROBE_TIMEOUT_S) as resp:
@@ -274,7 +273,7 @@ def mode_refresh(config_path: Path, baseline_path: Path) -> int:
             "Ollama model capability baseline (POST /api/show). Regenerate "
             "against the LIVE config (superset of the repo seed) so it covers "
             "both: scripts/masc-sync-ollama-caps.py --refresh --config "
-            "~/me/.masc/config/runtime.toml. CI drift gate (no network): --check."
+            "<masc_root>/config/runtime.toml. CI drift gate (no network): --check."
         ),
         "schema_version": BASELINE_SCHEMA_VERSION,
         "source": '{provider.endpoint - /v1}/api/show {"model": <api-name>}',
@@ -349,8 +348,7 @@ def mode_check(config_path: Path, baseline_path: Path, strict: bool) -> int:
         print(f"FAIL (strict): {soft} model(s) unverified", file=sys.stderr)
         return 1
     print(
-        f"OK: {len(models)} Ollama-family model(s) match baseline "
-        f"({soft} unverified)"
+        f"OK: {len(models)} Ollama-family model(s) match baseline ({soft} unverified)"
     )
     return 0
 
@@ -368,8 +366,10 @@ def mode_emit(config_path: Path, baseline_path: Path) -> int:
         lines = flags.declared_lines()
         if not lines:
             continue
-        print(f"# {model.model_id} (api: {model.api_name}) "
-              f"-- /api/show caps={entry['capabilities']}")
+        print(
+            f"# {model.model_id} (api: {model.api_name}) "
+            f"-- /api/show caps={entry['capabilities']}"
+        )
         print(f"[models.{model.model_id}.capabilities]")
         for line in lines:
             print(line)

--- a/scripts/masc-sync-ollama-caps.py
+++ b/scripts/masc-sync-ollama-caps.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""RFC-0265 — Ollama model capability sync + drift gate.
+
+Keeps the MASC runtime config's declared media-input capabilities
+([models.<id>.capabilities].supports-image-input / -audio-input /
+-multimodal-inputs) aligned with what Ollama actually reports for each model
+via POST /api/show. This is the "generated truth-source + drift-gate" half of
+RFC-0265: the runtime stays fully static/deterministic (it reads the TOML), and
+this script is the only thing that talks to Ollama.
+
+Why a separate baseline file:
+  --refresh needs network + the OLLAMA_CLOUD_API_KEY (operator-run). --check
+  must run in CI with no network, so it compares the config against the
+  checked-in baseline snapshot (scripts/ollama-caps-baseline.json), never the
+  live endpoint. Two levels of drift are therefore covered:
+    config  vs baseline  -> --check  (deterministic, CI)
+    baseline vs /api/show -> --refresh (operator, surfaces as a baseline diff)
+
+Modes:
+  --check    (default) compare config-declared media caps against the baseline.
+             Hard-fails (exit 1) on a real mismatch (declared != reality).
+             Soft-warns (exit 0) when a config model is absent from the baseline.
+  --refresh  probe /api/show for every Ollama-family model in the config and
+             (re)write the baseline JSON. Requires network + provider key.
+  --emit     print the recommended [models.<id>.capabilities] media lines for
+             each Ollama-family model, derived from the baseline. Advisory; the
+             operator merges these into the live runtime.toml.
+  --self-test  run the pure-mapping assertions and exit (no config/network).
+
+Capability mapping (source: ollama/ollama types/model/capability.go enum,
+cross-checked against live POST /api/show on 2026-06-19):
+  "vision" or "image" -> supports-image-input        = true
+  "audio"             -> supports-audio-input         = true
+  any media above     -> supports-multimodal-inputs   = true
+Setting multimodal whenever a single media is present is safe: the RFC-0265
+gate (caps_admit_required_modalities) still checks each required modality
+individually, so multimodal only ever *adds* a requirement for >1-modality
+turns; it never bypasses a per-modality check. This mirrors the existing
+gemma4-26b-a4b-qat declaration (vision -> both flags true).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    print(
+        "error: Python 3.11+ (tomllib) required; install tomli for older runtimes",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CONFIG = REPO_ROOT / "config" / "runtime.toml"
+DEFAULT_BASELINE = REPO_ROOT / "scripts" / "ollama-caps-baseline.json"
+BASELINE_SCHEMA_VERSION = 1
+
+# Ollama /api/show capability enum (ollama/ollama types/model/capability.go).
+# Kept here as the single documented reference for the string->bool mapping.
+OLLAMA_CAPABILITY_ENUM = (
+    "completion",
+    "tools",
+    "insert",
+    "vision",
+    "embedding",
+    "thinking",
+    "image",
+    "audio",
+)
+
+IMAGE_TOKENS = ("vision", "image")
+AUDIO_TOKENS = ("audio",)
+
+PROBE_TIMEOUT_S = 20.0
+
+
+@dataclass(frozen=True)
+class MediaFlags:
+    """The three media-input flags the RFC-0265 gate/reroute reads."""
+
+    image: bool
+    audio: bool
+    multimodal: bool
+
+    @staticmethod
+    def from_ollama_capabilities(caps: list[str]) -> "MediaFlags":
+        lowered = {c.lower() for c in caps}
+        image = any(t in lowered for t in IMAGE_TOKENS)
+        audio = any(t in lowered for t in AUDIO_TOKENS)
+        return MediaFlags(image=image, audio=audio, multimodal=image or audio)
+
+    @staticmethod
+    def from_declared(capabilities_block: dict[str, Any]) -> "MediaFlags":
+        return MediaFlags(
+            image=bool(capabilities_block.get("supports-image-input", False)),
+            audio=bool(capabilities_block.get("supports-audio-input", False)),
+            multimodal=bool(
+                capabilities_block.get("supports-multimodal-inputs", False)
+            ),
+        )
+
+    def declared_lines(self) -> list[str]:
+        lines: list[str] = []
+        if self.image:
+            lines.append("supports-image-input = true")
+        if self.audio:
+            lines.append("supports-audio-input = true")
+        if self.multimodal:
+            lines.append("supports-multimodal-inputs = true")
+        return lines
+
+
+@dataclass(frozen=True)
+class OllamaModel:
+    """An Ollama-family model resolved from the runtime config."""
+
+    model_id: str  # [models.<id>] table key (dot-avoidance form)
+    api_name: str  # api-name actually sent to /api/show
+    provider_id: str
+    native_base: str  # /api/show base (provider endpoint minus trailing /v1)
+    auth_env: str | None  # env var holding the bearer token, if any
+    declared: MediaFlags
+
+
+def _is_ollama_family(provider: dict[str, Any]) -> bool:
+    protocol = str(provider.get("protocol", ""))
+    endpoint = str(provider.get("endpoint", ""))
+    return protocol == "ollama-http" or "ollama.com" in endpoint or "11434" in endpoint
+
+
+def _native_base(endpoint: str) -> str:
+    base = endpoint.rstrip("/")
+    if base.endswith("/v1"):
+        base = base[: -len("/v1")]
+    return base
+
+
+def resolve_ollama_models(config: dict[str, Any]) -> list[OllamaModel]:
+    providers = config.get("providers", {})
+    models = config.get("models", {})
+    resolved: list[OllamaModel] = []
+
+    for provider_id, provider in providers.items():
+        if not isinstance(provider, dict) or not _is_ollama_family(provider):
+            continue
+        native_base = _native_base(str(provider.get("endpoint", "")))
+        creds = provider.get("credentials")
+        auth_env: str | None = None
+        if isinstance(creds, dict) and creds.get("type") == "env":
+            auth_env = creds.get("key")
+
+        # Bindings live in the top-level [provider_id.model_id] tables, i.e.
+        # config[provider_id] is a dict whose keys are model ids.
+        bindings = config.get(provider_id, {})
+        if not isinstance(bindings, dict):
+            continue
+        for model_id, binding in bindings.items():
+            if not isinstance(binding, dict):
+                continue
+            model_def = models.get(model_id)
+            if not isinstance(model_def, dict):
+                # Binding without a [models.<id>] table: cannot resolve api-name.
+                print(
+                    f"warning: binding {provider_id}.{model_id} has no "
+                    f"[models.{model_id}] table; skipped",
+                    file=sys.stderr,
+                )
+                continue
+            api_name = str(model_def.get("api-name", model_id))
+            cap_block = model_def.get("capabilities", {})
+            declared = MediaFlags.from_declared(
+                cap_block if isinstance(cap_block, dict) else {}
+            )
+            resolved.append(
+                OllamaModel(
+                    model_id=model_id,
+                    api_name=api_name,
+                    provider_id=provider_id,
+                    native_base=native_base,
+                    auth_env=auth_env,
+                    declared=declared,
+                )
+            )
+    # Deterministic order for stable baselines / diffs.
+    resolved.sort(key=lambda m: (m.provider_id, m.model_id))
+    return resolved
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def probe_capabilities(model: OllamaModel) -> list[str]:
+    """POST {native_base}/api/show {"model": api_name} -> capabilities list."""
+    url = f"{model.native_base}/api/show"
+    body = json.dumps({"model": model.api_name}).encode("utf-8")
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    if model.auth_env:
+        token = os.environ.get(model.auth_env)
+        if not token:
+            raise RuntimeError(
+                f"auth env {model.auth_env} is unset for provider "
+                f"{model.provider_id}"
+            )
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=PROBE_TIMEOUT_S) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    caps = payload.get("capabilities")
+    if not isinstance(caps, list):
+        raise RuntimeError(
+            f"/api/show for {model.api_name} returned no capabilities array"
+        )
+    return [str(c) for c in caps]
+
+
+# ── modes ────────────────────────────────────────────────────────────
+
+
+def mode_refresh(config_path: Path, baseline_path: Path) -> int:
+    config = load_config(config_path)
+    models = resolve_ollama_models(config)
+    if not models:
+        print(f"no Ollama-family models found in {config_path}", file=sys.stderr)
+        return 1
+
+    entries: dict[str, dict[str, Any]] = {}
+    failures = 0
+    for model in models:
+        try:
+            caps = probe_capabilities(model)
+        except (urllib.error.URLError, RuntimeError, ValueError) as exc:
+            print(f"probe failed for {model.api_name}: {exc}", file=sys.stderr)
+            failures += 1
+            continue
+        unknown = sorted({c.lower() for c in caps} - set(OLLAMA_CAPABILITY_ENUM))
+        if unknown:
+            # Ollama added a capability string we do not map yet — surface it so
+            # the enum + mapping can be updated rather than silently ignored.
+            print(
+                f"  note: {model.api_name} reports unmapped capabilities "
+                f"{unknown} (update OLLAMA_CAPABILITY_ENUM/mapping)",
+                file=sys.stderr,
+            )
+        entries[model.api_name] = {
+            "provider": model.provider_id,
+            "capabilities": caps,
+        }
+        flags = MediaFlags.from_ollama_capabilities(caps)
+        print(
+            f"  {model.api_name:<24} caps={caps} "
+            f"-> image={flags.image} audio={flags.audio}"
+        )
+
+    baseline = {
+        "_comment": (
+            "Ollama model capability baseline (POST /api/show). Regenerate "
+            "against the LIVE config (superset of the repo seed) so it covers "
+            "both: scripts/masc-sync-ollama-caps.py --refresh --config "
+            "~/me/.masc/config/runtime.toml. CI drift gate (no network): --check."
+        ),
+        "schema_version": BASELINE_SCHEMA_VERSION,
+        "source": '{provider.endpoint - /v1}/api/show {"model": <api-name>}',
+        "models": dict(sorted(entries.items())),
+    }
+    baseline_path.write_text(json.dumps(baseline, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {len(entries)} model(s) to {baseline_path}")
+    if failures:
+        print(f"{failures} probe(s) failed; baseline left partial", file=sys.stderr)
+        return 1
+    return 0
+
+
+def load_baseline(baseline_path: Path) -> dict[str, dict[str, Any]]:
+    data = json.loads(baseline_path.read_text(encoding="utf-8"))
+    if data.get("schema_version") != BASELINE_SCHEMA_VERSION:
+        raise RuntimeError(
+            f"baseline schema_version {data.get('schema_version')} != "
+            f"{BASELINE_SCHEMA_VERSION}"
+        )
+    models = data.get("models", {})
+    if not isinstance(models, dict):
+        raise RuntimeError("baseline has no models map")
+    return models
+
+
+def mode_check(config_path: Path, baseline_path: Path, strict: bool) -> int:
+    config = load_config(config_path)
+    models = resolve_ollama_models(config)
+    baseline = load_baseline(baseline_path)
+
+    hard = 0
+    soft = 0
+    for model in models:
+        entry = baseline.get(model.api_name)
+        if entry is None:
+            print(
+                f"::warning::{model.model_id} ({model.api_name}) not in baseline; "
+                f"run --refresh to verify",
+                file=sys.stderr,
+            )
+            soft += 1
+            continue
+        expected = MediaFlags.from_ollama_capabilities(entry["capabilities"])
+        declared = model.declared
+        if declared != expected:
+            under = (
+                (expected.image and not declared.image)
+                or (expected.audio and not declared.audio)
+                or (expected.multimodal and not declared.multimodal)
+            )
+            over = (
+                (declared.image and not expected.image)
+                or (declared.audio and not expected.audio)
+                or (declared.multimodal and not expected.multimodal)
+            )
+            if under and over:
+                kind = "MISMATCH (both under- and over-declared)"
+            elif under:
+                kind = "UNDER-DECLARED (reroute/gate will not see a modality)"
+            else:
+                kind = "OVER-DECLARED (provider will 400 at dispatch)"
+            print(
+                f"DRIFT {model.model_id} ({model.api_name}): {kind}\n"
+                f"  /api/show caps = {entry['capabilities']}\n"
+                f"  expected: image={expected.image} audio={expected.audio} "
+                f"multimodal={expected.multimodal}\n"
+                f"  declared: image={declared.image} audio={declared.audio} "
+                f"multimodal={declared.multimodal}",
+                file=sys.stderr,
+            )
+            hard += 1
+
+    if hard:
+        print(f"FAIL: {hard} model(s) drifted from /api/show reality", file=sys.stderr)
+        return 1
+    if soft and strict:
+        print(f"FAIL (strict): {soft} model(s) unverified", file=sys.stderr)
+        return 1
+    print(
+        f"OK: {len(models)} Ollama-family model(s) match baseline "
+        f"({soft} unverified)"
+    )
+    return 0
+
+
+def mode_emit(config_path: Path, baseline_path: Path) -> int:
+    config = load_config(config_path)
+    models = resolve_ollama_models(config)
+    baseline = load_baseline(baseline_path)
+
+    for model in models:
+        entry = baseline.get(model.api_name)
+        if entry is None:
+            continue
+        flags = MediaFlags.from_ollama_capabilities(entry["capabilities"])
+        lines = flags.declared_lines()
+        if not lines:
+            continue
+        print(f"# {model.model_id} (api: {model.api_name}) "
+              f"-- /api/show caps={entry['capabilities']}")
+        print(f"[models.{model.model_id}.capabilities]")
+        for line in lines:
+            print(line)
+        print()
+    return 0
+
+
+def mode_self_test() -> int:
+    cases = [
+        (["completion", "tools", "thinking", "vision"], MediaFlags(True, False, True)),
+        (["vision", "thinking", "completion", "tools"], MediaFlags(True, False, True)),
+        (["completion", "tools", "thinking"], MediaFlags(False, False, False)),
+        (["completion", "vision", "audio"], MediaFlags(True, True, True)),
+        (["image"], MediaFlags(True, False, True)),
+        ([], MediaFlags(False, False, False)),
+    ]
+    for caps, want in cases:
+        got = MediaFlags.from_ollama_capabilities(caps)
+        assert got == want, f"map({caps}) = {got}, want {want}"
+    # declared round-trips through the TOML key names.
+    declared = MediaFlags.from_declared(
+        {"supports-image-input": True, "supports-multimodal-inputs": True}
+    )
+    assert declared == MediaFlags(True, False, True), declared
+    print(f"self-test OK ({len(cases)} mapping cases)")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true", help="drift gate (default)")
+    group.add_argument("--refresh", action="store_true", help="probe /api/show")
+    group.add_argument("--emit", action="store_true", help="print toml cap blocks")
+    group.add_argument("--self-test", action="store_true", help="mapping assertions")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument(
+        "--strict", action="store_true", help="--check: unverified models fail too"
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return mode_self_test()
+    if args.refresh:
+        return mode_refresh(args.config, args.baseline)
+    if args.emit:
+        return mode_emit(args.config, args.baseline)
+    return mode_check(args.config, args.baseline, args.strict)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/ollama-caps-baseline.json
+++ b/scripts/ollama-caps-baseline.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Ollama model capability baseline (POST /api/show). Regenerate against the LIVE config (superset of the repo seed) so it covers both: scripts/masc-sync-ollama-caps.py --refresh --config ~/me/.masc/config/runtime.toml. CI drift gate (no network): --check.",
+  "_comment": "Ollama model capability baseline (POST /api/show). Regenerate against the LIVE config (superset of the repo seed) so it covers both: scripts/masc-sync-ollama-caps.py --refresh --config <masc_root>/config/runtime.toml. CI drift gate (no network): --check.",
   "schema_version": 1,
   "source": "{provider.endpoint - /v1}/api/show {\"model\": <api-name>}",
   "models": {

--- a/scripts/ollama-caps-baseline.json
+++ b/scripts/ollama-caps-baseline.json
@@ -1,0 +1,49 @@
+{
+  "_comment": "Ollama model capability baseline (POST /api/show). Regenerate against the LIVE config (superset of the repo seed) so it covers both: scripts/masc-sync-ollama-caps.py --refresh --config ~/me/.masc/config/runtime.toml. CI drift gate (no network): --check.",
+  "schema_version": 1,
+  "source": "{provider.endpoint - /v1}/api/show {\"model\": <api-name>}",
+  "models": {
+    "deepseek-v4-flash": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking"
+      ]
+    },
+    "deepseek-v4-pro": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking"
+      ]
+    },
+    "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL": {
+      "provider": "ollama",
+      "capabilities": [
+        "tools",
+        "completion",
+        "vision"
+      ]
+    },
+    "kimi-k2.6": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "vision",
+        "thinking",
+        "completion",
+        "tools"
+      ]
+    },
+    "minimax-m3": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking",
+        "vision"
+      ]
+    }
+  }
+}

--- a/test/dune
+++ b/test/dune
@@ -640,6 +640,13 @@
  (modules test_runtime_per_keeper_routing)
  (libraries masc_test_deps unix))
 
+; RFC-0265: capability-driven proactive runtime reroute (modality-gated decision).
+
+(test
+ (name test_runtime_modality_reroute)
+ (modules test_runtime_modality_reroute)
+ (libraries masc_test_deps))
+
 ; Group 2: Property-based tests (QCheck)
 
 (tests

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -28,7 +28,7 @@ let test_repo_runtime_toml_loads () =
   check bool "repo runtime.toml present" true (Sys.file_exists path);
   match Runtime.load_list ~config_path:path with
   | Error msg -> failf "repo runtime.toml should load: %s" msg
-  | Ok (runtimes, default, assignments, _librarian, _cross_verifier) ->
+  | Ok (runtimes, default, assignments, _librarian, _cross_verifier, _media_failover) ->
     check bool "at least one runtime" true (List.length runtimes > 0);
     check string "default runtime" "ollama_cloud.deepseek-v4-flash"
       default.Runtime.id;
@@ -394,7 +394,7 @@ let test_runtime_toml_max_concurrent_flows_to_candidate () =
   with_temp_runtime_toml content (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "runtime TOML should materialize: %s" msg
-    | Ok (runtimes, _default, _assignments, _librarian, _cross_verifier) ->
+    | Ok (runtimes, _default, _assignments, _librarian, _cross_verifier, _media_failover) ->
       let expect id expected =
         match
           List.find_opt (fun (rt : Runtime.t) -> String.equal rt.id id) runtimes
@@ -452,12 +452,12 @@ let test_librarian_runtime_routing () =
   with_temp_runtime_toml (base ^ "librarian = \"local.libr\"\n") (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "librarian routing should load: %s" msg
-    | Ok (_runtimes, _default, _assignments, librarian, _cross_verifier) ->
+    | Ok (_runtimes, _default, _assignments, librarian, _cross_verifier, _media_failover) ->
       check (option string) "librarian runtime id" (Some "local.libr") librarian);
   with_temp_runtime_toml base (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "absent librarian should load: %s" msg
-    | Ok (_, _, _, librarian, _cross_verifier) ->
+    | Ok (_, _, _, librarian, _cross_verifier, _media_failover) ->
       check (option string) "librarian unset is None" None librarian);
   with_temp_runtime_toml (base ^ "librarian = \"local.nope\"\n") (fun path ->
     match Runtime.load_list ~config_path:path with
@@ -466,13 +466,13 @@ let test_librarian_runtime_routing () =
   with_temp_runtime_toml (base ^ "cross_verifier = \"local.libr\"\n") (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "cross_verifier routing should load: %s" msg
-    | Ok (_runtimes, _default, _assignments, _librarian, cross_verifier) ->
+    | Ok (_runtimes, _default, _assignments, _librarian, cross_verifier, _media_failover) ->
       check (option string) "cross_verifier runtime id" (Some "local.libr")
         cross_verifier);
   with_temp_runtime_toml base (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "absent cross_verifier should load: %s" msg
-    | Ok (_, _, _, _, cross_verifier) ->
+    | Ok (_, _, _, _, cross_verifier, _media_failover) ->
       check (option string) "cross_verifier unset is None" None cross_verifier);
   with_temp_runtime_toml (base ^ "cross_verifier = \"local.nope\"\n") (fun path ->
     match Runtime.load_list ~config_path:path with

--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -1,0 +1,119 @@
+(* RFC-0265 — capability-driven proactive runtime reroute (modality-gated).
+
+   Pure-decision tests for [Runtime_agent.decide_modality_reroute] and the shared
+   [caps_admit_required_modalities] accept predicate. The decision takes data (a
+   candidate list) rather than reading the runtime cache, so no [Runtime.init_*]
+   is required — the tests are fully deterministic. *)
+
+open Alcotest
+
+let caps ?(image = false) ?(audio = false) ?(multimodal = false) () =
+  { Llm_provider.Capabilities.default_capabilities with
+    supports_image_input = image
+  ; supports_audio_input = audio
+  ; supports_multimodal_inputs = multimodal
+  }
+
+let decision_to_string : Runtime_agent.reroute_decision -> string = function
+  | Runtime_agent.No_reroute_needed -> "no_reroute"
+  | Runtime_agent.Reroute { to_runtime_id; reason } ->
+      Printf.sprintf "reroute:%s:%s" to_runtime_id reason
+  | Runtime_agent.No_capable_runtime { required } ->
+      Printf.sprintf "no_capable:%s" (String.concat "," required)
+
+let decide ~assigned ~required ~candidates =
+  Runtime_agent.decide_modality_reroute
+    ~assigned_caps:assigned
+    ~required_modalities:required
+    ~candidates
+
+(* A text turn ([required = []]) is admitted by any runtime, so it never reroutes
+   — the common path stays untouched. *)
+let test_text_turn_no_reroute () =
+  check string "text turn"
+    "no_reroute"
+    (decision_to_string (decide ~assigned:(caps ()) ~required:[] ~candidates:[]))
+
+(* An image turn on a vision-capable assigned runtime stays put. *)
+let test_image_turn_on_capable_no_reroute () =
+  check string "image on vision model"
+    "no_reroute"
+    (decision_to_string
+       (decide ~assigned:(caps ~image:true ()) ~required:[ "image" ]
+          ~candidates:[]))
+
+(* Image turn on a text-only assigned runtime reroutes to the first capable
+   candidate in the given order (text_b is skipped, vision_c wins over
+   vision_d). *)
+let test_image_turn_reroutes_to_first_capable () =
+  let candidates =
+    [ ("text_b", caps ())
+    ; ("vision_c", caps ~image:true ())
+    ; ("vision_d", caps ~image:true ())
+    ]
+  in
+  check string "reroute to first capable in order"
+    "reroute:vision_c:assigned runtime lacks image input"
+    (decision_to_string (decide ~assigned:(caps ()) ~required:[ "image" ] ~candidates))
+
+(* Candidate ordering is the caller's contract: with the same capable set in a
+   different order, the first listed wins. This pins media_failover precedence. *)
+let test_candidate_order_is_honored () =
+  check string "first listed capable wins"
+    "reroute:vision_d:assigned runtime lacks image input"
+    (decision_to_string
+       (decide ~assigned:(caps ()) ~required:[ "image" ]
+          ~candidates:
+            [ ("vision_d", caps ~image:true ())
+            ; ("vision_c", caps ~image:true ())
+            ]))
+
+(* No configured runtime admits the modality → floor: the assigned runtime stands
+   and the loud capability gate rejects downstream. *)
+let test_no_capable_runtime_floor () =
+  check string "no capable → floor"
+    "no_capable:image"
+    (decision_to_string
+       (decide ~assigned:(caps ()) ~required:[ "image" ]
+          ~candidates:[ ("text_b", caps ()); ("audio_c", caps ~audio:true ()) ]))
+
+(* The decision is a pure function: identical inputs yield identical output. *)
+let test_decision_is_deterministic () =
+  let candidates = [ ("text_b", caps ()); ("vision_c", caps ~image:true ()) ] in
+  let d1 = decide ~assigned:(caps ()) ~required:[ "image" ] ~candidates in
+  let d2 = decide ~assigned:(caps ()) ~required:[ "image" ] ~candidates in
+  check string "identical inputs → identical decision"
+    (decision_to_string d1)
+    (decision_to_string d2)
+
+(* The shared accept predicate: a runtime admits a multi-modality turn only when
+   it supports every required modality; missing one rejects. *)
+let test_caps_admit_required_modalities () =
+  check bool "image+audio runtime admits image+audio" true
+    (Runtime_agent.For_testing.caps_admit_required_modalities
+       (caps ~image:true ~audio:true ())
+       [ "image"; "audio" ]);
+  check bool "image-only runtime rejects image+audio" false
+    (Runtime_agent.For_testing.caps_admit_required_modalities
+       (caps ~image:true ())
+       [ "image"; "audio" ]);
+  check bool "empty required is always admitted" true
+    (Runtime_agent.For_testing.caps_admit_required_modalities (caps ()) [])
+
+let () =
+  run "rfc0265_modality_reroute"
+    [ ( "decide_modality_reroute"
+      , [ test_case "text turn no reroute" `Quick test_text_turn_no_reroute
+        ; test_case "image on capable no reroute" `Quick
+            test_image_turn_on_capable_no_reroute
+        ; test_case "reroute to first capable" `Quick
+            test_image_turn_reroutes_to_first_capable
+        ; test_case "candidate order honored" `Quick test_candidate_order_is_honored
+        ; test_case "no capable floor" `Quick test_no_capable_runtime_floor
+        ; test_case "deterministic" `Quick test_decision_is_deterministic
+        ] )
+    ; ( "caps_admit_required_modalities"
+      , [ test_case "multi-modality predicate" `Quick
+            test_caps_admit_required_modalities
+        ] )
+    ]

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -458,6 +458,7 @@ let test_runtime_adapter_keeps_auth_out_of_headers () =
     ; librarian_runtime_id = None
     ; cross_verifier_runtime_id = None
     ; keeper_assignments = []
+    ; media_failover = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -489,6 +490,7 @@ let test_runtime_adapter_filters_toml_auth_headers () =
     ; librarian_runtime_id = None
     ; cross_verifier_runtime_id = None
     ; keeper_assignments = []
+    ; media_failover = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -521,6 +523,7 @@ let provider_cfg () =
     ; librarian_runtime_id = None
     ; cross_verifier_runtime_id = None
     ; keeper_assignments = []
+    ; media_failover = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -598,6 +601,7 @@ let runtime_or_fail ?(provider = runpod_provider) () =
     ; librarian_runtime_id = None
     ; cross_verifier_runtime_id = None
     ; keeper_assignments = []
+    ; media_failover = []
     }
   in
   match Runtime.of_binding cfg runpod_binding with


### PR DESCRIPTION
## 목표

키퍼 턴에 비텍스트 입력(image/audio/document)이 들어왔는데 할당된 runtime이 그 모달리티를 받을 수 없을 때, dispatch 전에 capability를 만족하는 다른 runtime으로 **결정론적·가시적으로 reroute**한다. 만족하는 runtime이 없으면 기존 loud 거부를 floor로 유지한다.

근거: 2026-06-19 RunPod 장애 failover로 키퍼들이 `ollama_cloud.deepseek-v4-pro`(text-only — `/api/show` + 공식 ollama 모델 카드 + DeepSeek 문서로 확인; V4 Pro=Expert/text 모드, Vision은 별도 모델)로 묶였고, 이미지 첨부 `masc_keeper_msg`가 capability 게이트에서 죽었다. 가용 vision 모델(kimi-k2-6/minimax-m3)이 있었는데도 거기로 라우팅되지 않았다.

## RFC

RFC-0265 (`docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md`, 본 PR에 포함). RFC-0207 Part B(reactive error-driven failover)와 **구분되는 새 개념**: 이건 (required modalities, declared caps, config order)의 순수 pre-dispatch 결정이라 contended `keeper_error_classify.ml` lane을 건드리지 않는다. 관련: RFC-0181, RFC-0126/0145(silent-fallback 금지), RFC-0037, RFC-0260(향후 liveness-aware).

## 변경 파일

- `lib/runtime/runtime_agent.{ml,mli}`: 게이트와 reroute가 공유하는 순수 술어 `caps_admit_required_modalities` 추출(→ reroute가 고른 runtime은 반드시 게이트도 통과). `reroute_decision` + `decide_modality_reroute`(순수) + `decide_modality_reroute_for_runtime` / `input_capabilities_of_runtime` / `media_reroute_candidates`.
- `lib/runtime/runtime_schema.{ml,mli}` + `runtime_toml.ml` + `runtime.{ml,mli}`: `[runtime].media_failover` ordered list(파싱 + `validate_media_failover` load-time id 해석 검증, librarian 패턴 미러). `load_list`가 6-tuple로.
- `lib/keeper/keeper_turn_driver.ml` (`run_named`, single-runtime seam): content-block 턴에서 reroute 결정 후 candidate/config 구성 *상류*에서 runtime_id 스왑, WARN 로그(non-silent). text 턴(`goal_blocks=None`)은 무영향.
- `test/test_runtime_modality_reroute.ml`(순수 7 케이스); 6-tuple consumer 2개 갱신.

### D2 — capability sync + drift gate (RFC-0265 §4.2)

reroute가 후보를 찾으려면 capable 모델이 capability를 *선언*해야 한다. 그 선언을 손으로 유지하면 drift하므로, `/api/show`에서 생성하고 drift를 게이트한다(런타임은 정적/결정론 유지 — 네트워크 probe를 런타임 경로에 두지 않음).

- `scripts/masc-sync-ollama-caps.py`: `--refresh`(운영자, `/api/show` probe → baseline) · `--check`(CI, 네트워크 없이 config vs baseline) · `--emit`(toml 블록 출력) · `--self-test`(매핑 단언).
- `scripts/ollama-caps-baseline.json`: 커밋된 `/api/show` 스냅샷(5 모델, 라이브 verify 2026-06-19).
- `config/runtime.toml`(repo seed): minimax-m3 vision 선언(미선언이었음 → 게이트가 검출).
- `.github/workflows/ci.yml`: TOML syntax 게이트 뒤에 `--check` 연결.
- 매핑(ollama `capability.go` enum, 라이브 검증): `vision|image`→image, `audio`→audio. `supports-multimodal-inputs`(=MASC "document" 모달리티)는 **미파생** — `/api/show`가 document capability를 보고하지 않으므로 vision만으로 multimodal을 세우면 image-only 모델에 document 턴을 과다허용(게이트가 막아야 할 fail-open). document는 운영자 명시 선언으로 남기고 스크립트는 image/audio만 관리(기존 gemma4 multimodal 선언 false-positive도 회피).

**기각된 대안 — OAS discovery에서 파생.** OAS가 이미 `/api/show`를 probe하지만, 파생한 `capabilities`는 어떤 런타임 경로에도 도달하지 않는다(공유 atomic은 context/endpoint만 저장, `provider_registry`는 healthy/url만 읽음, `capabilities_to_json` 호출처 0). 거기 파싱을 추가하면 dead-path에 코드를 더하는 것이므로 매핑은 소비처(스크립트)에 두고 OAS는 불변 — 경계 OAS-free 유지.

## 로컬 검증

- `dune build lib` green.
- `test_runtime_modality_reroute` 7/7 pass.
- `test_gate_keeper_backend` 52 pass (술어 추출이 게이트 동작 불변).
- `test_runtime_provider_auth_headers` 27 pass.
- `masc-sync-ollama-caps.py --self-test` OK(6 매핑 케이스); `--check`(seed) OK; 라이브 `--check`가 kimi-k2-6/minimax-m3 UNDER-DECLARED를 정확히 검출(게이트 동작 증명).
- `check-toml-syntax.sh` green(11 파일).
- `test_runtime_config_validity`: 3건 실패하나 **base(내 변경 전)에서도 동일하게 3건 실패**(stash로 확인) — nested worktree에 OAS capability 카탈로그 미적재 → #21607 게이트가 합성 fixture 모델(local.chat/libr) 거부. 본 PR과 무관, CI는 카탈로그 보유.

## 경계

OAS(`agent_sdk`) 불변. persona⊥{model,runtime} 유지(reroute는 capability+config 구동, persona 비참조). 결정론(provider liveness 미참조 — RFC-0260 후속). `keeper_error_classify.ml` 불변.

## 남은 미검증 / 후속

- 라이브 적용(D3, 운영자 영역): 라이브 `~/me/.masc/config/runtime.toml`의 kimi-k2-6 + minimax-m3에 vision caps 선언(블록은 `--emit`로 생성, gemma4는 이미 선언됨) → masc-mcp 재시작. `--check`로 적용 후 drift 0 확인 가능.
- 가시성 v1=WARN 로그. typed `runtime_fallback_event` + 키퍼 채팅 surface는 후속(RFC §3.3).
- liveness-aware 후보 필터는 RFC-0260 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


