### PR TITLE
fix keeper msg cancellation status

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -23,6 +23,8 @@ import {
   fetchKeeperRuntimeTrace,
   pauseKeeper,
   parseKeeperRuntimeTrace,
+  queuedKeeperMessageError,
+  queuedKeeperMessageToReply,
   resumeKeeper,
   sendKeeperMessageDetailed,
   shutdownKeeper,
@@ -132,6 +134,32 @@ describe('fetchQueuedKeeperMessageResult', () => {
     expect(init.headers).toMatchObject({ 'Content-Type': 'application/json' })
     expect(result.status).toBe('done')
     expect(result.result).toEqual({ reply: 'pong' })
+  })
+
+  it('normalizes cancelled queued results as cancellation text', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        request_id: 'kmsg_sangsu_2',
+        keeper_name: 'sangsu',
+        status: 'cancelled',
+        ok: false,
+        result: {
+          cancelled: true,
+          reason: 'keeper_msg request was cancelled by operator',
+          cancelled_by: 'operator',
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchQueuedKeeperMessageResult('kmsg_sangsu_2')
+
+    expect(result.status).toBe('cancelled')
+    expect(queuedKeeperMessageError(result)).toBe('요청이 취소되었습니다.')
+    expect(queuedKeeperMessageToReply(result).text).toBe('요청이 취소되었습니다.')
   })
 })
 

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -308,6 +308,7 @@ export async function cancelQueuedKeeperMessage(
 }
 
 export function queuedKeeperMessageError(result: QueuedKeeperMessageResult): string {
+  if (result.status === 'cancelled') return '요청이 취소되었습니다.'
   const payload = isRecord(result.result) ? result.result : null
   const message = asString(payload?.message) ?? asString(payload?.reason)
   const error = asString(payload?.error)
@@ -315,6 +316,12 @@ export function queuedKeeperMessageError(result: QueuedKeeperMessageResult): str
 }
 
 export function queuedKeeperMessageToReply(result: QueuedKeeperMessageResult): KeeperToolReply {
+  if (result.status === 'cancelled') {
+    return {
+      text: '요청이 취소되었습니다.',
+      details: null,
+    }
+  }
   const payload = isRecord(result.result) ? result.result : null
   const rawReply = asString(payload?.reply, '').trim()
   const details = normalizeKeeperConversationDetails(payload ?? result.result)

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -152,6 +152,8 @@ function deliveryLabel(entry: KeeperConversationEntry): string {
       return entry.streamState === 'finalizing' ? 'finalizing' : 'live'
     case 'timeout':
       return 'timeout'
+    case 'cancelled':
+      return 'cancelled'
     case 'error':
       return 'error'
     case 'interrupted':

--- a/dashboard/src/components/common/status-badge.ts
+++ b/dashboard/src/components/common/status-badge.ts
@@ -46,6 +46,7 @@ export function statusBadgeTone(status: string): StatusBadgeTone {
     case 'inactive':
     case 'offline':
     case 'stopped':
+    case 'cancelled':
     case 'todo':
       return 'neutral'
     case 'active':

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -449,6 +449,43 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     ])
   })
 
+  it('resumes a cancelled pending request without restoring an error bubble', async () => {
+    upsertPendingKeeperChatRequest({
+      requestId: 'kmsg_echo_1',
+      keeperName: 'echo',
+      message: '뭘 해야하나',
+      submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
+    })
+    fetchQueuedKeeperMessageResult.mockResolvedValue({
+      requestId: 'kmsg_echo_1',
+      keeperName: 'echo',
+      status: 'cancelled',
+      ok: false,
+      result: {
+        cancelled: true,
+        reason: 'keeper_msg request was cancelled by operator',
+        cancelled_by: 'operator',
+      },
+    })
+    queuedKeeperMessageError.mockImplementation(() => '요청이 취소되었습니다.')
+    queuedKeeperMessageToReply.mockImplementation(() => ({
+      text: '요청이 취소되었습니다.',
+      details: null,
+    }))
+    fetchKeeperChatHistory.mockResolvedValue([])
+
+    await resumePendingKeeperChatRequests('echo')
+
+    expect(fetchQueuedKeeperMessageResult).toHaveBeenCalledWith('kmsg_echo_1')
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+    expect(keeperActionErrors.value.echo).toBeNull()
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread.map(entry => [entry.role, entry.text, entry.delivery, entry.error])).toEqual([
+      ['user', '뭘 해야하나', 'cancelled', null],
+      ['assistant', '요청이 취소되었습니다.', 'cancelled', null],
+    ])
+  })
+
   it('keeps the user message visible when the server no longer knows request_id', async () => {
     upsertPendingKeeperChatRequest({
       requestId: 'kmsg_echo_1',

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -331,6 +331,7 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
 let localIdCounter = 0
 
 const resumingKeeperChatRequests = new Set<string>()
+const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
 
 async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest): Promise<void> {
   const key = `${request.keeperName}:${request.requestId}`
@@ -352,16 +353,19 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
 
       const reply = queuedKeeperMessageToReply(result)
       const isCheckpoint = reply.details?.turnOutcome === 'continuation_checkpoint'
-      const isError = result.status !== 'done' || result.ok === false
+      const isCancelled = result.status === 'cancelled'
+      const isError = !isCancelled && (result.status !== 'done' || result.ok === false)
       const errorMessage = isError ? queuedKeeperMessageError(result) : null
       let assistantDelivery: KeeperConversationDelivery = 'delivered'
-      if (isCheckpoint) {
+      if (isCancelled) {
+        assistantDelivery = 'cancelled'
+      } else if (isCheckpoint) {
         assistantDelivery = 'queued'
       } else if (isError) {
         assistantDelivery = 'error'
       }
       finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
-        delivery: isError ? 'error' : 'delivered',
+        delivery: isCancelled ? 'cancelled' : isError ? 'error' : 'delivered',
         error: errorMessage,
       })
       finalizeAssistantEntry(request.keeperName, assistantId, {
@@ -676,13 +680,19 @@ export async function sendKeeperThreadMessage(
         }
         removePendingKeeperChatRequest(requestId)
       }
+      finalizeAssistantEntry(keeperName, localId, {
+        delivery: 'cancelled',
+        error: null,
+      })
       finalizeAssistantEntry(keeperName, assistantId, {
-        delivery: 'timeout',
+        text: KEEPER_MESSAGE_CANCELLED_TEXT,
+        rawText: KEEPER_MESSAGE_CANCELLED_TEXT,
+        delivery: 'cancelled',
         streamState: null,
-        error: '요청 취소됨',
+        error: null,
         timestamp: new Date().toISOString(),
       })
-      setRecordValue(keeperActionErrors, keeperName, '요청 취소됨')
+      setRecordValue(keeperActionErrors, keeperName, null)
       throw err
     }
 

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -94,6 +94,26 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.text).toBe('Keeper request failed: Timeout after 630.0s')
   })
 
+  it('renders cancelled request terminal events without an error bubble', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REQUEST_TERMINAL',
+      value: {
+        request_id: 'kmsg_sangsu_1',
+        status: 'cancelled',
+        ok: false,
+        message: 'keeper chat stream cancelled by client',
+      },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.delivery).toBe('cancelled')
+    expect(entry?.streamState).toBeNull()
+    expect(entry?.error).toBeNull()
+    expect(entry?.text).toBe('요청이 취소되었습니다.')
+  })
+
   // RFC-0232 P2: the checkpoint distinction rides the producer-typed
   // `turn_outcome` field, not the reply text.
   it('does not render a declared continuation checkpoint as a chat reply', () => {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -16,6 +16,8 @@ import {
 } from './keeper-state'
 import { isRecord, asString } from './components/common/normalize'
 
+const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
+
 // Most recent TOOL_CALL_START id per keeper — fallback target for
 // TOOL_CALL_ARGS / TOOL_CALL_END events that omit toolCallId.
 const lastToolCallIds = new Map<string, string>()
@@ -33,9 +35,11 @@ export function abortKeeperThreadMessage(name: string): void {
   if (controller) controller.abort()
   if (entryId) {
     finalizeAssistantEntry(keeperName, entryId, {
-      delivery: 'timeout',
+      text: KEEPER_MESSAGE_CANCELLED_TEXT,
+      rawText: KEEPER_MESSAGE_CANCELLED_TEXT,
+      delivery: 'cancelled',
       streamState: null,
-      error: '요청 취소됨',
+      error: null,
       timestamp: new Date().toISOString(),
     })
   }
@@ -138,8 +142,21 @@ export function applyKeeperStreamEvent(
         const terminal = isRecord(event.value) ? event.value : null
         const status = asString(terminal?.status, '').trim()
         const ok = terminal?.ok === true
+        if (status === 'cancelled') {
+          const message =
+            asString(terminal?.message, '').trim() || KEEPER_MESSAGE_CANCELLED_TEXT
+          updateThreadEntry(keeperName, assistantEntryId, entry => ({
+            ...entry,
+            text: KEEPER_MESSAGE_CANCELLED_TEXT,
+            rawText: message,
+            delivery: 'cancelled',
+            streamState: null,
+            error: null,
+          }))
+          return null
+        }
         const failed =
-          !ok && ['error', 'lost', 'cancelled'].includes(status)
+          !ok && ['error', 'lost'].includes(status)
         if (failed) {
           const message =
             asString(terminal?.message, '').trim() || 'Keeper request failed'
@@ -147,7 +164,7 @@ export function applyKeeperStreamEvent(
             ...entry,
             text: entry.text || `Keeper request failed: ${message}`,
             rawText: entry.rawText || message,
-            delivery: status === 'cancelled' ? 'timeout' : 'error',
+            delivery: 'error',
             streamState: null,
             error: message,
           }))

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -693,6 +693,7 @@ export type KeeperConversationDelivery =
   | 'streaming'
   | 'delivered'
   | 'timeout'
+  | 'cancelled'
   | 'error'
   // Stream ended without a terminal RUN_FINISHED / RUN_ERROR event —
   // the transport was cut mid-response, so the text may be incomplete.

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -16,6 +16,10 @@ type request_status =
   | Queued
   | Running
   | Lost of { reason : string }
+  | Cancelled of
+      { reason : string
+      ; cancelled_by : string
+      }
   | Done of
       { ok : bool
       ; body : string
@@ -82,6 +86,7 @@ let status_to_string = function
   | Queued -> "queued"
   | Running -> "running"
   | Lost _ -> "lost"
+  | Cancelled _ -> "cancelled"
   | Done { ok = true; _ } -> "done"
   | Done { ok = false; _ } -> "error"
 ;;
@@ -104,6 +109,8 @@ let entry_record_to_json (e : entry) : Yojson.Safe.t =
     match e.status with
     | Done { ok; body } -> fields @ [ "ok", `Bool ok; "body", `String body ]
     | Lost { reason } -> fields @ [ "reason", `String reason ]
+    | Cancelled { reason; cancelled_by } ->
+      fields @ [ "reason", `String reason; "cancelled_by", `String cancelled_by ]
     | Queued | Running -> fields
   in
   `Assoc fields
@@ -148,6 +155,15 @@ let entry_of_record_json ~base_path json : (entry, string) result =
                  string_member "reason" json
                  |> Option.value
                       ~default:"keeper_msg request was lost before terminal result"
+             })
+      | "cancelled" ->
+        Ok
+          (Cancelled
+             { reason =
+                 string_member "reason" json
+                 |> Option.value ~default:"keeper_msg request was cancelled"
+             ; cancelled_by =
+                 string_member "cancelled_by" json |> Option.value ~default:"unknown"
              })
       | "done" | "error" ->
         let ok =
@@ -226,7 +242,7 @@ let request_id_of_record_filename name =
 
 let should_gc_disk_record ~now (entry : entry) =
   match entry.status with
-  | Done _ | Lost _ -> now -. entry.submitted_at > max_age_sec
+  | Done _ | Lost _ | Cancelled _ -> now -. entry.submitted_at > max_age_sec
   | Queued | Running -> false
 ;;
 
@@ -311,15 +327,15 @@ let gc_stale () =
     Hashtbl.fold
       (fun id entry acc ->
          match entry.status with
-         | (Done _ | Lost _) when now -. entry.submitted_at > max_age_sec -> id :: acc
-         | Queued | Running | Done _ | Lost _ -> acc)
+         | (Done _ | Lost _ | Cancelled _) when now -. entry.submitted_at > max_age_sec -> id :: acc
+         | Queued | Running | Done _ | Lost _ | Cancelled _ -> acc)
       pending
       []
     |> List.iter (fun id -> Hashtbl.remove pending id))
 ;;
 
 let is_terminal_status = function
-  | Done _ | Lost _ -> true
+  | Done _ | Lost _ | Cancelled _ -> true
   | Queued | Running -> false
 ;;
 
@@ -330,7 +346,7 @@ let set_status ?(preserve_terminal = false) request_id status =
     | Some entry ->
       let completed_at =
         match status with
-        | Done _ | Lost _ -> Some (Unix.gettimeofday ())
+        | Done _ | Lost _ | Cancelled _ -> Some (Unix.gettimeofday ())
         | _ -> None
       in
       let updated = { entry with status; completed_at } in
@@ -343,13 +359,20 @@ let set_status_protected ?preserve_terminal request_id status =
   Eio.Cancel.protect (fun () -> set_status ?preserve_terminal request_id status)
 ;;
 
-let cancelled_lost_status exn =
-  Lost
-    { reason =
-        Printf.sprintf
-          "keeper_msg worker cancelled before terminal result: %s"
-          (Printexc.to_string exn)
-    }
+let cancelled_status ~cancelled_by reason =
+  Cancelled { reason; cancelled_by }
+;;
+
+let operator_cancelled_status () =
+  cancelled_status
+    ~cancelled_by:"operator"
+    "keeper_msg request was cancelled by operator"
+;;
+
+let runtime_cancelled_status () =
+  cancelled_status
+    ~cancelled_by:"runtime"
+    "keeper_msg worker was cancelled by runtime before terminal result"
 ;;
 
 let timeout_done_status ~request_id ~keeper_name ~timeout_sec =
@@ -413,8 +436,8 @@ let submit ?clock ?timeout_sec ~sw ~base_path ~(f : unit -> tool_result)
                | Worker_timeout { timeout_sec } ->
                  timeout_done_status ~request_id ~keeper_name ~timeout_sec))
       with
-      | CancelledByOperator as e -> cancelled_lost_status e
-      | Eio.Cancel.Cancelled _ as e -> cancelled_lost_status e
+      | CancelledByOperator -> operator_cancelled_status ()
+      | Eio.Cancel.Cancelled _ -> runtime_cancelled_status ()
       | exn ->
         Done
           { ok = false
@@ -484,15 +507,31 @@ let entry_to_json (e : entry) : Yojson.Safe.t =
       @ [ "ok", `Bool false
         ; "result", `Assoc [ "error", `String "request_lost"; "reason", `String reason ]
         ]
+    | Cancelled { reason; cancelled_by } ->
+      fields
+      @ [ "ok", `Bool false
+        ; ( "result"
+          , `Assoc
+              [ "cancelled", `Bool true
+              ; "reason", `String reason
+              ; "cancelled_by", `String cancelled_by
+              ] )
+        ]
     | _ -> fields
   in
   `Assoc fields
 ;;
 
 let cancel ?base_path request_id : bool =
-  let sw_opt = with_lock (fun () -> Hashtbl.find_opt active_switches request_id) in
+  let sw_opt =
+    with_lock (fun () ->
+      match Hashtbl.find_opt pending request_id, Hashtbl.find_opt active_switches request_id with
+      | Some entry, Some sw when not (is_terminal_status entry.status) -> Some sw
+      | _ -> None)
+  in
   match sw_opt with
   | Some sw ->
+    set_status_protected ~preserve_terminal:true request_id (operator_cancelled_status ());
     Eio.Switch.fail sw CancelledByOperator;
     with_lock (fun () -> Hashtbl.remove active_switches request_id);
     true
@@ -502,10 +541,12 @@ let cancel ?base_path request_id : bool =
     | Some base_path ->
       match load_record ~base_path ~request_id with
       | Found ({ status = Queued | Running; _ } as entry) ->
-        let reason = "keeper_msg request was cancelled by operator" in
         let cancelled_entry =
-          (* NDT-OK: gettimeofday is acceptable for timestamping operator cancelled lost state *)
-          { entry with status = Lost { reason }; completed_at = Some (Unix.gettimeofday ()) }
+          (* NDT-OK: gettimeofday is acceptable for timestamping operator cancelled state *)
+          { entry with
+            status = operator_cancelled_status ()
+          ; completed_at = Some (Unix.gettimeofday ())
+          }
         in
         persist_entry cancelled_entry;
         true

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -160,9 +160,14 @@ let entry_of_record_json ~base_path json : (entry, string) result =
         Ok
           (Cancelled
              { reason =
+                 (* DET-OK: persisted cancelled records may predate reason;
+                    the explicit "cancelled" status tag already determined
+                    control flow, this fallback is display-only. *)
                  string_member "reason" json
                  |> Option.value ~default:"keeper_msg request was cancelled"
              ; cancelled_by =
+                 (* DET-OK: display-only audit attribution fallback for
+                    legacy/corrupt cancelled records. *)
                  string_member "cancelled_by" json |> Option.value ~default:"unknown"
              })
       | "done" | "error" ->
@@ -346,7 +351,10 @@ let set_status ?(preserve_terminal = false) request_id status =
     | Some entry ->
       let completed_at =
         match status with
-        | Done _ | Lost _ | Cancelled _ -> Some (Unix.gettimeofday ())
+        | Done _ | Lost _ | Cancelled _ ->
+          (* NDT-OK: completed_at is observational wall-clock metadata for
+             terminal request records; state transitions are status-derived. *)
+          Some (Unix.gettimeofday ())
         | _ -> None
       in
       let updated = { entry with status; completed_at } in
@@ -545,7 +553,10 @@ let cancel ?base_path request_id : bool =
           (* NDT-OK: gettimeofday is acceptable for timestamping operator cancelled state *)
           { entry with
             status = operator_cancelled_status ()
-          ; completed_at = Some (Unix.gettimeofday ())
+          ; completed_at =
+              (* NDT-OK: completed_at is audit metadata for a disk-only
+                 operator cancellation fallback. *)
+              Some (Unix.gettimeofday ())
           }
         in
         persist_entry cancelled_entry;

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -13,6 +13,10 @@ type request_status =
   | Queued
   | Running
   | Lost of { reason : string }
+  | Cancelled of
+      { reason : string
+      ; cancelled_by : string
+      }
   | Done of
       { ok : bool
       ; body : string
@@ -47,8 +51,9 @@ type load_result =
     [request_id] synchronously. When both [clock] and [timeout_sec] are
     provided, the worker records a terminal timeout error if [f] does not
     return before the deadline. Cancellation of [sw] interrupts the worker
-    and records a terminal [Lost] state before stopping, so pollers do not
-    observe an indefinite [Running] request. *)
+    and records a terminal [Cancelled] state before stopping, so pollers do
+    not observe an indefinite [Running] request. [Lost] is reserved for
+    persisted non-terminal requests recovered without a live worker. *)
 val submit
   :  ?clock:_ Eio.Time.clock
   -> ?timeout_sec:float

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -639,7 +639,11 @@ let keeper_request_terminal_payload ~request_id ~keeper_name ~status ~ok
 
 type keeper_stream_worker_event =
   | Stream_event of Agent_sdk.Types.sse_event
-  | Stream_terminal of bool * string
+  | Stream_terminal of
+      { ok : bool
+      ; status : string
+      ; body : string
+      }
 
 let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
     ~client_disconnects
@@ -800,15 +804,15 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
                 ~keeper_name:payload.name ~source:chat_source
                 ~content:visible_reply
                 ());
-            push_worker_event (Stream_terminal (true, body));
+            push_worker_event (Stream_terminal { ok = true; status = "done"; body });
             Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body
         | Ok (false, err) ->
             persist_failure_reply err;
-            push_worker_event (Stream_terminal (false, err));
+            push_worker_event (Stream_terminal { ok = false; status = "error"; body = err });
             Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
         | Error err ->
             persist_failure_reply err;
-            push_worker_event (Stream_terminal (false, err));
+            push_worker_event (Stream_terminal { ok = false; status = "error"; body = err });
             Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err)
       ()
   in
@@ -822,7 +826,10 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
            ignore (Keeper_msg_async.cancel ~base_path request_id);
            push_worker_event
              (Stream_terminal
-                (false, "keeper chat stream closed by client"))
+                { ok = false
+                ; status = "cancelled"
+                ; body = "keeper chat stream cancelled by client"
+                })
          end));
   Log.Keeper.info
     "keeper_stream: queued request keeper=%s request_id=%s surface=%s"
@@ -856,7 +863,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
       keeper_request_terminal_payload ~request_id ~keeper_name:payload.name
         ~status ~ok ~message ()
     in
-    if ok then
+    if ok || String.equal status "cancelled" then
       Log.Keeper.info
         "keeper_stream: request terminal keeper=%s request_id=%s status=%s"
         payload.name request_id status
@@ -899,11 +906,16 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
              Keeper_chat_events.publish events (Tool_call_end { tool_call_id = tid })
          | _ -> ());
         consume_worker_events ()
-    | Stream_terminal (false, err) ->
+    | Stream_terminal { ok = false; status = "cancelled"; body = message } ->
+        let message = redact_text message in
+        publish_terminal ~status:"cancelled" ~ok:false ~message ();
+        Keeper_chat_events.publish events Text_message_end;
+        Keeper_chat_events.publish events (Run_finished { run_id })
+    | Stream_terminal { ok = false; status; body = err } ->
         let err = redact_text err in
-        publish_terminal ~status:"error" ~ok:false ~message:err ();
+        publish_terminal ~status ~ok:false ~message:err ();
         Keeper_chat_events.publish events (Event_error { message = err })
-    | Stream_terminal (true, body) -> (
+    | Stream_terminal { ok = true; body; _ } -> (
         try
           let payload_json_opt, visible_reply = extract_visible_reply body in
           let visible_reply =

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -639,6 +639,7 @@ let keeper_request_terminal_payload ~request_id ~keeper_name ~status ~ok
 
 type keeper_stream_worker_event =
   | Stream_event of Agent_sdk.Types.sse_event
+  | Stream_client_disconnected
   | Stream_terminal of
       { ok : bool
       ; status : string
@@ -669,6 +670,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
   let text_accum = Keeper_stream_text_accum.create () in
   let worker_events = Eio.Stream.create 512 in
   let terminal_pushed = Atomic.make false in
+  let client_disconnected = Atomic.make false in
   let push_worker_event event =
     match event with
     | Stream_terminal _ ->
@@ -680,6 +682,14 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
                Log.Keeper.warn
                  "keeper_stream: worker terminal push failed: %s"
                  (Printexc.to_string exn))
+    | Stream_client_disconnected ->
+        (try Eio.Stream.add worker_events event
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+             Log.Keeper.warn
+               "keeper_stream: client-disconnect push failed: %s"
+               (Printexc.to_string exn))
     | Stream_event _ ->
         if not !closed then
           try Eio.Stream.add worker_events event
@@ -818,18 +828,15 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
   in
   (match client_disconnects with
    | None -> ()
-   | Some disconnects ->
-       Eio.Fiber.fork ~sw (fun () ->
+   | Some (disconnect_sw, disconnects) ->
+       Eio.Fiber.fork ~sw:disconnect_sw (fun () ->
          let _ = Eio.Stream.take disconnects in
          if not (Atomic.get terminal_pushed) then begin
-           (* fire-and-forget: disconnect cleanup must not block terminal event emission. *)
-           ignore (Keeper_msg_async.cancel ~base_path request_id);
-           push_worker_event
-             (Stream_terminal
-                { ok = false
-                ; status = "cancelled"
-                ; body = "keeper chat stream cancelled by client"
-                })
+           Atomic.set client_disconnected true;
+           Log.Keeper.info
+             "keeper_stream: client disconnected keeper=%s request_id=%s; request continues for polling"
+             payload.name request_id;
+           push_worker_event Stream_client_disconnected
          end));
   Log.Keeper.info
     "keeper_stream: queued request keeper=%s request_id=%s surface=%s"
@@ -876,7 +883,9 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
   in
   let index_to_tool_id = Hashtbl.create 4 in
   let rec consume_worker_events () =
-    match Eio.Stream.take worker_events with
+    if Atomic.get client_disconnected then ()
+    else match Eio.Stream.take worker_events with
+    | Stream_client_disconnected -> ()
     | Stream_event evt ->
         (match evt with
          | Agent_sdk.Types.Connected ->
@@ -1160,10 +1169,10 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
            Eio.Fiber.fork ~sw:stream_sw (fun () ->
              sse_adapter_loop ~events ~writer ~mutex ~closed
                ~on_closed:notify_disconnect);
-           process_single_turn ~state ~clock ~sw:stream_sw
+           process_single_turn ~state ~clock ~sw
              ~auth_token:(auth_token_from_request request)
              ~thread_id ~closed
-             ~client_disconnects:(Some client_disconnects)
+             ~client_disconnects:(Some (stream_sw, client_disconnects))
              ~payload ~run_id ~message_id ~agent_name ~events;
            (* Queue drain is now handled by Keeper_chat_consumer
               (started in server_bootstrap_loops). *)

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -145,7 +145,7 @@ val process_single_turn :
   auth_token:string option ->
   thread_id:string ->
   closed:bool ref ->
-  client_disconnects:unit Eio.Stream.t option ->
+  client_disconnects:(Eio.Switch.t * unit Eio.Stream.t) option ->
   payload:keeper_chat_stream_request ->
   run_id:string ->
   message_id:string ->
@@ -153,9 +153,13 @@ val process_single_turn :
   events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
   unit
 (** Execute a single keeper turn, publishing events to the provided
-    event stream.  [closed] is a mutable flag that suppresses worker
-    event pushes when set to [true] (used by the SSE adapter when the
-    HTTP stream is closed).  [auth_token] is [None] for queue-consumer
+    event stream. [sw] owns the async keeper_msg worker and must outlive
+    a single HTTP stream when resumable dashboard requests are used.
+    [closed] is a mutable flag that suppresses worker event pushes when
+    set to [true] (used by the SSE adapter when the HTTP stream is
+    closed). [client_disconnects] carries the HTTP stream switch and
+    disconnect signal; it stops only the stream projection and does not
+    cancel the accepted request. [auth_token] is [None] for queue-consumer
     turns where no HTTP request is available. *)
 
 (** {1 Testing helpers} *)

--- a/test/stanzas/test_reqd_invalid_state_swallow.inc
+++ b/test/stanzas/test_reqd_invalid_state_swallow.inc
@@ -16,4 +16,5 @@
   ../bin/main_eio.ml
   ../lib/server/server_mcp_transport_http_respond.ml
   ../lib/server/server_mcp_transport_http.ml
+  ../lib/server/server_routes_http_keeper_stream.ml
   ../lib/server/server_ws_standalone.ml))

--- a/test/test_keeper_msg_cancel.ml
+++ b/test/test_keeper_msg_cancel.ml
@@ -60,10 +60,10 @@ let () =
    | Keeper_msg_async.Found entry ->
      let status_str = Keeper_msg_async.status_to_string entry.status in
      Printf.printf "  ✓ Cancelled status: %s\n%!" status_str;
-     if String.equal status_str "lost" then
-       Printf.printf "  ✓ Verification: Lost state correctly recorded\n%!"
+     if String.equal status_str "cancelled" then
+       Printf.printf "  ✓ Verification: Cancelled state correctly recorded\n%!"
      else
-       Printf.printf "  ✗ Verification failed: expected lost but got %s\n%!" status_str
+       Printf.printf "  ✗ Verification failed: expected cancelled but got %s\n%!" status_str
    | Keeper_msg_async.Absent ->
      Printf.printf "  ✗ Status after cancel: Not found\n%!"
    | Keeper_msg_async.Unreadable reason ->

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -55,6 +55,19 @@ let wait_for_lost request_id =
   loop 200
 ;;
 
+let wait_for_cancelled request_id =
+  let rec loop remaining =
+    match Keeper_msg_async.poll request_id with
+    | Keeper_msg_async.Found ({ status = Cancelled _; _ } as entry) -> entry
+    | _ when remaining <= 0 ->
+      failwith (Printf.sprintf "request %s did not become cancelled" request_id)
+    | _ ->
+      Eio.Fiber.yield ();
+      loop (remaining - 1)
+  in
+  loop 200
+;;
+
 let contains_substring ~needle value =
   let needle_len = String.length needle in
   let value_len = String.length value in
@@ -205,7 +218,7 @@ let test_keeper_msg_async_marks_recovered_inflight_lost () =
     Alcotest.fail "expected persisted request"
 ;;
 
-let test_keeper_msg_async_marks_cancelled_worker_lost () =
+let test_keeper_msg_async_marks_cancelled_worker_cancelled () =
   with_eio_env
   @@ fun _env ->
   let request_id =
@@ -225,16 +238,66 @@ let test_keeper_msg_async_marks_cancelled_worker_lost () =
     ignore (wait_for_running request_id : Keeper_msg_async.entry);
     request_id
   in
-  match wait_for_lost request_id with
-  | { Keeper_msg_async.status = Lost { reason }; completed_at = Some _; _ } ->
-    Alcotest.(check bool) "lost reason mentions cancellation" true
+  match wait_for_cancelled request_id with
+  | { Keeper_msg_async.status = Cancelled { reason; cancelled_by }; completed_at = Some _; _ } ->
+    Alcotest.(check string) "cancelled_by runtime" "runtime" cancelled_by;
+    Alcotest.(check bool) "cancelled reason mentions cancellation" true
       (contains_substring ~needle:"cancelled" (String.lowercase_ascii reason))
-  | { Keeper_msg_async.status = Lost _; completed_at = None; _ } ->
+  | { Keeper_msg_async.status = Cancelled _; completed_at = None; _ } ->
     Alcotest.fail "expected cancelled request to have completed_at"
   | entry ->
     Alcotest.failf
-      "expected cancelled request to be lost, got %s"
+      "expected cancelled request to be cancelled, got %s"
       (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
+;;
+
+let test_keeper_msg_async_operator_cancel_is_terminal_cancelled () =
+  with_eio_env
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = temp_dir "keeper-msg-async-operator-cancel-" in
+  let never, _resolver = Eio.Promise.create () in
+  let request_id =
+    Keeper_msg_async.submit
+      ~sw
+      ~base_path
+      ~keeper_name:"operator-cancelled"
+      ~f:(fun () ->
+        Eio.Promise.await never;
+        tr_ok "{}")
+      ()
+  in
+  ignore (wait_for_running request_id : Keeper_msg_async.entry);
+  Alcotest.(check bool)
+    "cancel returns true"
+    true
+    (Keeper_msg_async.cancel ~base_path request_id);
+  (match wait_for_cancelled request_id with
+   | { Keeper_msg_async.status = Cancelled { reason; cancelled_by }; completed_at = Some _; _ } ->
+     Alcotest.(check string) "cancelled_by operator" "operator" cancelled_by;
+     Alcotest.(check bool) "reason mentions operator" true
+       (contains_substring ~needle:"operator" (String.lowercase_ascii reason))
+   | { Keeper_msg_async.status = Cancelled _; completed_at = None; _ } ->
+     Alcotest.fail "expected operator-cancelled request to have completed_at"
+   | entry ->
+     Alcotest.failf
+       "expected operator cancel to be cancelled, got %s"
+       (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status));
+  Keeper_msg_async.For_testing.forget request_id;
+  (match Keeper_msg_async.poll ~base_path request_id with
+   | Keeper_msg_async.Found { Keeper_msg_async.status = Cancelled { cancelled_by; _ }; _ } ->
+     Alcotest.(check string) "persisted cancelled_by operator" "operator" cancelled_by
+   | Keeper_msg_async.Found entry ->
+     Alcotest.failf
+       "expected persisted cancelled, got %s"
+       (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
+   | Keeper_msg_async.Absent | Keeper_msg_async.Unreadable _ ->
+     Alcotest.fail "expected persisted cancelled request");
+  Alcotest.(check bool)
+    "second cancel returns false"
+    false
+    (Keeper_msg_async.cancel ~base_path request_id)
 ;;
 
 let test_keeper_msg_async_timeout_is_terminal_error () =
@@ -549,9 +612,13 @@ let () =
             `Quick
             test_keeper_msg_async_marks_recovered_inflight_lost
         ; test_case
-            "cancelled worker is terminal lost"
+            "cancelled worker is terminal cancelled"
             `Quick
-            test_keeper_msg_async_marks_cancelled_worker_lost
+            test_keeper_msg_async_marks_cancelled_worker_cancelled
+        ; test_case
+            "operator cancel is terminal cancelled"
+            `Quick
+            test_keeper_msg_async_operator_cancel_is_terminal_cancelled
         ; test_case
             "timeout is terminal error"
             `Quick

--- a/test/test_reqd_invalid_state_swallow.ml
+++ b/test/test_reqd_invalid_state_swallow.ml
@@ -64,6 +64,17 @@ let assert_contains ~label haystack needle =
           swallow regression: see 2026-05-05 cycle9 FATAL incident"
          label needle)
 
+let count_occurrences haystack needle =
+  let n = String.length needle in
+  let h = String.length haystack in
+  if n = 0 then 0
+  else (
+    let count = ref 0 in
+    for i = 0 to h - n do
+      if String.sub haystack i n = needle then incr count
+    done;
+    !count)
+
 let resolve_path candidates =
   match List.find_opt Sys.file_exists candidates with
   | Some p -> p
@@ -191,14 +202,7 @@ let () =
      We allow up to 2: the docstring reference and the single call inside
      safe_respond_with_string's try body. *)
   let direct_count =
-    let needle = "Httpun.Reqd.respond_with_string" in
-    let n = String.length needle in
-    let h = String.length mcp_http_src in
-    let count = ref 0 in
-    for i = 0 to h - n do
-      if String.sub mcp_http_src i n = needle then incr count
-    done;
-    !count
+    count_occurrences mcp_http_src "Httpun.Reqd.respond_with_string"
   in
   if direct_count > 2 then
     failwith
@@ -208,6 +212,48 @@ let () =
           safe_respond_with_string try body). Regression: 2026-05-05 cycle9 \
           FATAL."
          direct_count);
+
+  (* ---- lib/server/server_routes_http_keeper_stream.ml ------------------- *)
+  let keeper_stream_src =
+    resolve_path
+      [ Filename.concat project_root
+          "lib/server/server_routes_http_keeper_stream.ml"
+      ; "lib/server/server_routes_http_keeper_stream.ml"
+      ; "../lib/server/server_routes_http_keeper_stream.ml"
+      ]
+    |> read_file
+  in
+
+  (* Anchor KS1: client transport disconnect is a stream-consumer event, not
+     a keeper_msg cancellation. The accepted request must remain resumable via
+     request_id polling. *)
+  assert_contains
+    ~label:"KS1: stream disconnect has its own worker event"
+    keeper_stream_src
+    "Stream_client_disconnected";
+  assert_contains
+    ~label:"KS2: disconnect log says request continues"
+    keeper_stream_src
+    "request continues for polling";
+  assert_contains
+    ~label:"KS3: worker uses server switch"
+    keeper_stream_src
+    "process_single_turn ~state ~clock ~sw\n";
+  assert_contains
+    ~label:"KS4: disconnect watcher uses stream switch"
+    keeper_stream_src
+    "~client_disconnects:(Some (stream_sw, client_disconnects))";
+  let keeper_cancel_count =
+    count_occurrences keeper_stream_src "Keeper_msg_async.cancel"
+  in
+  if keeper_cancel_count > 1 then
+    failwith
+      (Printf.sprintf
+         "[KS5] found %d Keeper_msg_async.cancel calls in \
+          server_routes_http_keeper_stream.ml; expected only the explicit \
+          cancel endpoint. Client transport disconnect must not cancel the \
+          accepted keeper_msg request."
+         keeper_cancel_count);
 
   (* ---- lib/server/server_ws_standalone.ml -------------------------------- *)
   let ws_src =
@@ -219,11 +265,15 @@ let () =
     |> read_file
   in
 
-  (* Anchor W1: send_pong is now inside a try/with. *)
+  (* Anchor W1: send_pong is still guarded by the write-failure classifier. *)
   assert_contains
-    ~label:"W1: send_pong wrapped in try/with"
+    ~label:"W1a: send_pong call still present"
     ws_src
-    "try Ws.Wsd.send_pong wsd";
+    "Ws.Wsd.send_pong session.wsd";
+  assert_contains
+    ~label:"W1b: send_pong write failure classifier"
+    ws_src
+    "classify_write_failure exn";
 
   (* Anchor W2: writer-closed-during-cancel race comment is present
      (the wsd-race incident reference travels with the [send_pong]


### PR DESCRIPTION
## What changed

- Add an explicit `Cancelled` terminal state to `Keeper_msg_async` instead of collapsing operator/runtime cancellation into `Lost`.
- Persist cancelled request records with `reason` and `cancelled_by`, and expose HTTP poll JSON as `status: "cancelled"`.
- Keep `Lost` reserved for recovered non-terminal requests that no live worker owns after restart/eviction.
- Teach the dashboard conversation model a `cancelled` delivery state so explicit cancellations render neutrally instead of as `error`/`timeout`.
- Fix the larger transport bug found during review: a dashboard HTTP/SSE client disconnect no longer calls `Keeper_msg_async.cancel` and no longer runs the worker under the per-stream switch. The accepted request continues under the server switch and remains resumable by request-id polling.

## Why

Operator cancellation was being recorded as `Lost`, with a user-facing reason like:

`keeper_msg worker cancelled before terminal result: Masc.Keeper_msg_async.CancelledByOperator`

During the follow-up audit, live runtime evidence showed the same reason was often caused by transport churn, not explicit user intent:

- `keeper_stream: request terminal ... status=error message=keeper chat stream closed by client` appeared 12 times on 2026-06-19.
- 6 persisted `.masc/keeper_msg_requests/*.json` records had `status: "lost"` with `CancelledByOperator`.
- Example records: `kmsg_idealist_0_1781878251024`, `kmsg_sangsu_5_1781879179677`.

So the fix now separates three states:

- explicit operator cancel -> `cancelled`
- runtime/server cancellation -> `cancelled` with `cancelled_by: "runtime"`
- client stream disconnect -> stream projection stops, keeper request continues and can be polled/resumed

## Validation

- `git diff --check`
- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_reqd_invalid_state_swallow.exe`
- `ocaml test/test_reqd_invalid_state_swallow.ml`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit -p dashboard/tsconfig.json`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/api/keeper.test.ts src/keeper-stream.test.ts src/keeper-actions.test.ts --no-file-parallelism --maxWorkers=1`

Note: full local Dune remains sensitive to this machine's shared Dune/opam locks and local OAS pin state; CI is the full build source of truth for this PR.
