### PR TITLE
fix(dashboard): restore fusion card focus ring + lock 3-gate fusion test coverage

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -187,6 +187,34 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     ])
   })
 
+  it('passes a fusion block through and keeps run_id optional', () => {
+    const withRunId = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        role: 'assistant',
+        blocks: [{ t: 'fusion', board_post_id: 'post-123', run_id: 'fus-abc' }],
+      }),
+    )
+    expect(withRunId?.blocks).toEqual([{ t: 'fusion', board_post_id: 'post-123', run_id: 'fus-abc' }])
+
+    const withoutRunId = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        role: 'assistant',
+        blocks: [{ t: 'fusion', board_post_id: 'post-456' }],
+      }),
+    )
+    expect(withoutRunId?.blocks).toEqual([{ t: 'fusion', board_post_id: 'post-456' }])
+  })
+
+  it('drops the whole row when a fusion block is missing board_post_id', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        role: 'assistant',
+        blocks: [{ t: 'fusion', run_id: 'fus-orphan' }],
+      }),
+    )
+    expect(out).toBeNull()
+  })
+
   it('drops the whole row when blocks contain an unknown shape', () => {
     const out = safeParseKeeperChatHistoryMessage(
       validMessage({

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1702,6 +1702,11 @@ describe('fusion chat card', () => {
     // Collapsed: no detail rendered and no network call yet.
     expect(container.querySelector('[data-fusion-detail]')).toBeNull()
     expect(fetchBoardPost).not.toHaveBeenCalled()
+    // Focus ring must be the resolved CHAT_FOCUS_RING string, not the stringified
+    // ringFocusClasses function (a bare `${ringFocusClasses}` interpolation regression).
+    const expandButton = card?.querySelector('button')
+    expect(expandButton?.className).toContain('focus-visible:outline-none')
+    expect(expandButton?.className).not.toContain('opts')
   })
 
   it('lazy-fetches the board post and renders panel answers + judge on expand', async () => {
@@ -1731,6 +1736,9 @@ describe('fusion chat card', () => {
     expect(detail?.textContent).not.toContain('PANEL ONE ANSWER')
     const panelToggle = container.querySelector('[data-fusion-panel] button') as HTMLButtonElement | null
     expect(panelToggle).not.toBeNull()
+    // Panel toggle carries the resolved focus ring, not a stringified function.
+    expect(panelToggle?.className).toContain('focus-visible:outline-none')
+    expect(panelToggle?.className).not.toContain('opts')
     fireEvent.click(panelToggle as HTMLButtonElement)
     await flushUi()
     expect(container.querySelector('[data-fusion-detail]')?.textContent).toContain('PANEL ONE ANSWER')
@@ -1776,6 +1784,31 @@ describe('fusion chat card', () => {
     const panel = container.querySelector('[data-fusion-panel]')
     expect(panel?.querySelector('h2')?.textContent).toBe('Heading One')
     expect(panel?.querySelector('li')?.textContent).toContain('bullet item')
+  })
+
+  it('sanitizes untrusted model markup in judge synthesis and panel answers', async () => {
+    const xss = '**ok**\n\n<script>alert(1)</script>\n\n<img src=x onerror=alert(2)>\n\n[click](javascript:alert(3))'
+    vi.mocked(fetchBoardPost).mockResolvedValue({
+      meta: {
+        source: 'fusion',
+        panel: [{ model: 'm1', status: 'answered', answer: xss, output_tokens: 10 }],
+        judge: { status: 'synthesized', decision: 'answer', synthesis: xss },
+      },
+    } as unknown as Awaited<ReturnType<typeof fetchBoardPost>>)
+
+    render(html`<${ChatTranscript} entries=${[fusionEntry()]} emptyText="empty" />`, container)
+    fireEvent.click(container.querySelector('[data-fusion-card] button') as HTMLButtonElement)
+    await flushUi()
+    fireEvent.click(container.querySelector('[data-fusion-panel] button') as HTMLButtonElement)
+    await flushUi()
+
+    // Benign markdown still renders, but every executable vector is stripped by purifyHtml.
+    const detail = container.querySelector('[data-fusion-detail]')
+    expect(detail?.querySelector('strong')?.textContent).toBe('ok')
+    expect(container.querySelector('[data-fusion-detail] script')).toBeNull()
+    const html_ = detail?.innerHTML ?? ''
+    expect(html_).not.toContain('onerror')
+    expect(html_.toLowerCase()).not.toContain('javascript:')
   })
 
   it('surfaces token usage and answered count in the header', async () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1193,7 +1193,7 @@ function FusionPanelRow({ entry }: { entry: FusionPanelEntry }) {
         ? html`
           <button
             type="button"
-            class="w-full flex items-center gap-1.5 text-left text-2xs font-mono text-[var(--color-fg-secondary,#9da7b3)] ${ringFocusClasses}"
+            class="w-full flex items-center gap-1.5 text-left text-2xs font-mono text-[var(--color-fg-secondary,#9da7b3)] ${CHAT_FOCUS_RING}"
             aria-expanded=${open}
             onClick=${() => setOpen((v) => !v)}
           >
@@ -1256,7 +1256,7 @@ function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: s
     <div class="rounded-[var(--r-1,8px)] border border-[var(--color-brass-border,#3a3a2a)] bg-[var(--color-brass-soft,rgba(216,166,87,0.06))] overflow-hidden" data-fusion-card>
       <button
         type="button"
-        class="w-full flex items-center gap-2 px-3 py-2 text-left text-xs ${ringFocusClasses}"
+        class="w-full flex items-center gap-2 px-3 py-2 text-left text-xs ${CHAT_FOCUS_RING}"
         aria-expanded=${expanded}
         onClick=${() => setExpanded((v) => !v)}
       >

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -231,6 +231,35 @@ describe('thread history merge & persistence', () => {
     expect(entries[0]?.blocks).toEqual([{ t: 'image', src: 'https://x.com/a.png' }])
   })
 
+  it('passes a fusion block through with board_post_id required and run_id optional', () => {
+    const withRunId = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        content: 'panel concluded',
+        ts: 1_780_000_000,
+        blocks: [{ t: 'fusion', board_post_id: 'post-1', run_id: 'fus-1' }],
+      },
+    ])
+    expect(withRunId[0]?.blocks).toEqual([{ t: 'fusion', board_post_id: 'post-1', run_id: 'fus-1' }])
+
+    const withoutRunId = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        content: 'panel concluded',
+        ts: 1_780_000_000,
+        blocks: [{ t: 'fusion', board_post_id: 'post-2' }] as any,
+      },
+    ])
+    expect(withoutRunId[0]?.blocks).toEqual([{ t: 'fusion', board_post_id: 'post-2', run_id: undefined }])
+  })
+
+  it('drops a fusion block missing board_post_id and falls back to the local parser', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      { role: 'assistant', content: 'panel concluded', ts: 1_780_000_000, blocks: [{ t: 'fusion', run_id: 'fus-orphan' }] as any },
+    ])
+    expect(entries[0]?.blocks).toEqual([{ t: 'p', html: 'panel concluded' }])
+  })
+
   it('falls back to the local parser when server blocks are missing or empty', () => {
     const withMissing = chatHistoryEntriesFromRest('echo', [
       { role: 'assistant', content: 'https://x.com/post', ts: 1_780_000_000 },


### PR DESCRIPTION
## 왜

직전 fusion 카드 작업(#21611·#21629·#21639)의 적대 리뷰(10-agent workflow)에서 **#21639가 넣은 실제 a11y 회귀 1건**과 **3-게이트 회귀 테스트 부재**가 확정됐습니다.

### 1. focus-ring 회귀 (실제 결함, #21639 유래)
`FusionPanelRow` 토글과 `ChatFusionCard` 펼치기 버튼이 `${CHAT_FOCUS_RING}`(미리 계산된 문자열) 대신 `${ringFocusClasses}`(함수 객체)를 보간했습니다. JS 템플릿 리터럴은 함수를 `Function.prototype.toString()`으로 직렬화하므로, **함수 소스 코드가 통째로 class 속성에 박히고** 키보드 `focus-visible` 링이 사라집니다.

mutation으로 증명한 버그 상태의 실제 className:
```
w-full flex items-center gap-2 px-3 py-2 text-left text-xs function ringFocusClasses(opts = {}) {
  const tone = opts.tone ?? "accent"; ...
```
나머지 9개 버튼은 모두 `${CHAT_FOCUS_RING}`을 씁니다. 두 줄만 수정.

### 2. 3-게이트 회귀 테스트 부재 (MEDIUM, 잠재 silent-drop)
chat_block의 fusion arm은 현재 zod 게이트·normalizeBlocks 게이트에 올바르게 존재하지만 각 테스트 파일에 fusion 케이스가 0건이었습니다. 프론트만 잘못 건드리면 메시지가 통째로 silent drop돼도 잡는 테스트가 없었습니다.

## 변경
- `primitives.ts` (production, 2줄): `${ringFocusClasses}` → `${CHAT_FOCUS_RING}`
- `keeper-chat-history.test.ts` (Gate 2 zod): fusion 블록 통과 + run_id optional + board_post_id 누락 시 row drop
- `keeper-state.test.ts` (Gate 3 normalizeBlocks): fusion 통과 + board_post_id 누락 시 local parser fallback
- `primitives.test.ts`: focus-ring class 락(mutation으로 non-vacuous 증명) + judge/panel 마크다운 XSS sanitization 락

## 검증
- `tsc --noEmit`: 0 errors
- `vitest run` (primitives + keeper-state + keeper-chat-history): 133 passed
- focus-ring 락 mutation 검증: 버그 복원 시 테스트 실패(`expected '...' to contain 'focus-visible:outline-none'`) 확인

## 범위 밖 (보존)
- 백엔드 sink·observation projection 무변경
- credential/identity/operator/hooks 등 RFC-게이트 서브시스템 무관

RFC-0235(chat blocks) · RFC-0252(fusion) 후속.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>