### PR TITLE
feat(memory-os): RFC-0259 P1 — volatile external_ref classification + decay

### DIFF
--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -216,15 +216,20 @@ let fact_of_json ~trace_id ~now (json : Yojson.Safe.t) : fact option =
          with a short TTL, durable knowledge with none. RFC-0247 also stopped
          parsing the LLM's [confidence] number: the score it fed is gone. *)
       let category = category_of_string category_str in
+      (* RFC-0259 §3.2(b): a claim naming a PR/issue/task id is volatile — route
+         its [valid_until] through [fact_valid_until] so it gets a finite horizon
+         instead of a durable [None]. *)
+      let external_ref = external_ref_of_claim claim in
       Some
         { claim
         ; category
+        ; external_ref
          ; source = claim_source ~trace_id turn tool_call_id
          (* Tier-1 (per-keeper) facts carry no distinct-keeper corroboration set;
             the consolidator populates observed_by only on promotion (RFC-0244). *)
          ; observed_by = []
          ; first_seen = now
-         ; valid_until = category_valid_until ~now category
+         ; valid_until = fact_valid_until ~now ~external_ref category
          ; last_verified_at = Some now
          ; schema_version
          }

--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -220,14 +220,18 @@ let max_optional_float values =
     values
 ;;
 
-let valid_until_for_group ~now ~members category =
-  match category with
-  | Ephemeral ->
-    (match min_optional_float (List.map (fun (m : fact) -> m.valid_until) members) with
-     | Some _ as valid_until -> valid_until
-     | None -> category_valid_until ~now category)
-  | Fact | Constraint | Preference | Blocker | Goal | Code_change
-  | Validated_approach | Lesson | Unknown _ -> category_valid_until ~now category
+let valid_until_for_group ~now ~external_ref ~members category =
+  match external_ref with
+  (* RFC-0259 §3.2(b): a referenced claim is volatile regardless of category. *)
+  | Some _ -> Some (now +. volatile_external_ttl_seconds)
+  | None ->
+    (match category with
+     | Ephemeral ->
+       (match min_optional_float (List.map (fun (m : fact) -> m.valid_until) members) with
+        | Some _ as valid_until -> valid_until
+        | None -> category_valid_until ~now category)
+     | Fact | Constraint | Preference | Blocker | Goal | Code_change
+     | Validated_approach | Lesson | Unknown _ -> category_valid_until ~now category)
 ;;
 
 let last_verified_for_members members =
@@ -255,12 +259,16 @@ let consolidated_fact ~now ~members (group : merge_group) =
   let observed_by =
     List.concat_map (fun m -> m.observed_by) members |> List.sort_uniq String.compare
   in
+  (* RFC-0259 §3.2(b): the consolidated claim text differs from any member's, so
+     re-parse the external ref from it rather than trusting a member's. *)
+  let external_ref = external_ref_of_claim group.consolidated_claim in
   { claim = group.consolidated_claim
   ; category = group.category
+  ; external_ref
   ; source = earliest.source
   ; observed_by
   ; first_seen
-  ; valid_until = valid_until_for_group ~now ~members group.category
+  ; valid_until = valid_until_for_group ~now ~external_ref ~members group.category
   ; last_verified_at = last_verified_for_members members
   ; schema_version
   }

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -51,7 +51,10 @@ type contribution =
 (* RFC-0247 (purge): eligibility is purely structural — a promotable category.
    The prior confidence floor (only claims above 0.5 count as corroboration) was
    a score gate and is gone. *)
-let eligible fact = is_promotable fact.category
+(* RFC-0259 §3.2(b): a volatile (external-ref) claim is per-keeper status, not
+   durable cross-keeper knowledge — exclude it from promotion so it cannot be
+   resurrected as an immortal shared fact (the #21363 shape). *)
+let eligible fact = is_promotable fact.category && Option.is_none fact.external_ref
 
 (* Pick the representative fact for a claim group by a structural total order:
    earliest first_seen, then lexically smallest claim, then keeper id — so
@@ -91,11 +94,16 @@ let consolidate_into_shared ~now ~min_keepers contribs =
       Some
         { claim = rep.fact.claim
         ; category = rep.fact.category
+        ; external_ref = rep.fact.external_ref
         ; source = rep.fact.source
         ; observed_by = keepers
         ; first_seen =
             List.fold_left (fun acc c -> Float.min acc c.fact.first_seen) rep.fact.first_seen contribs
-        ; valid_until = None
+          (* RFC-0259 §3.2(b): route through [fact_valid_until] as a structural
+             backstop — [eligible] already excludes external-ref claims, so this is
+             [None] for promotable facts, but a volatile claim could never become an
+             immortal shared fact even if that filter regressed. *)
+        ; valid_until = fact_valid_until ~now ~external_ref:rep.fact.external_ref rep.fact.category
           (* The consolidation IS the verification of the shared fact. *)
         ; last_verified_at = Some now
         ; schema_version

--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -70,7 +70,8 @@ let dedup_by_claim items =
 ;;
 
 (* RFC-0247 (purge): GC is now two structural passes only — hard-expire facts
-   past their Ephemeral TTL ([valid_until], a typed category decision), then
+   past their [valid_until] horizon (a typed decision: the Ephemeral TTL, or the
+   RFC-0259 §3.2(b) volatile horizon for an external-ref claim), then
    dedup duplicate claims keeping the most-recently-verified. The score-threshold
    discard ([decide_retention] on [score_fact <= 0.02]) was removed: a fact's
    value is not a number GC can threshold. Forgetting is the librarian's

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -17,15 +17,21 @@ let durable_retention_tier = 1.0e15
 (* RFC-0247 §-1: structural retention rank for the bounded store cap. This is NOT
    a relevance score — it is a deterministic two-tier lexicographic order used
    ONLY to decide which rows the size cap drops when the store grows past its
-   trigger: durable categories outrank Ephemeral (a typed decision via
-   [category_valid_until], which returns [Some] only for Ephemeral), and within a
-   tier the most-recently-verified (else first-seen) fact is kept. It never ranks
-   recall — recall ordering is structural + judgment, not a number. *)
+   trigger: durable claims outrank non-durable ones, and within a tier the
+   most-recently-verified (else first-seen) fact is kept. It never ranks recall —
+   recall ordering is structural + judgment, not a number.
+
+   RFC-0259 §3.2(b): a volatile (external-ref) claim is non-durable even when its
+   category is durable (e.g. a [Fact] naming a PR), so the cap drops it before
+   genuine durable knowledge. Keying off [category_valid_until] alone would keep
+   it durable; OR-in the external ref. The category check still covers legacy
+   Ephemeral rows whose [valid_until] was omitted on disk. *)
 let retention_rank ~now (f : fact) =
   let tier =
-    match category_valid_until ~now f.category with
-    | None -> durable_retention_tier
-    | Some _ -> 0.0
+    if Option.is_some f.external_ref
+       || Option.is_some (category_valid_until ~now f.category)
+    then 0.0
+    else durable_retention_tier
   in
   let recency = match f.last_verified_at with Some t -> t | None -> f.first_seen in
   tier +. recency
@@ -33,14 +39,25 @@ let retention_rank ~now (f : fact) =
 
 (* RFC-0247 (purge): fold a re-observation of an existing fact into that fact.
    [existing] is the persisted row; [incoming] is the newly extracted claim with
-   the same normalized identity. The only effect is to refresh the truth anchor:
-   the librarian re-extracting the same claim is fresh evidence that the claim
-   still holds, so [last_verified_at] advances to [now] and the staleness marker
-   resets. Identity and first-seen provenance are preserved.
+   the same normalized identity. The librarian re-extracting the same claim is
+   fresh evidence that the claim still holds, so [last_verified_at] advances to
+   [now] and the staleness marker resets. Identity and first-seen provenance are
+   preserved.
+
+   RFC-0259 §3.2(b): re-observing IS re-verification, so a volatile (external-ref)
+   claim's decay horizon is refreshed from [now] — the disk re-derive anchors to
+   [first_seen], this anchors to the fresh sighting, so an actively-re-seen status
+   claim survives while an abandoned one decays. A non-volatile fact keeps its
+   [valid_until] (durable [None] or the original Ephemeral expiry).
 
    The prior merge also blended a confidence float and bumped an access counter;
    both fed the deleted composite score and are gone. There is no numeric
    strength to move — re-observation is a binary "seen again now". *)
 let reobserve_fact ~now ~existing ~incoming:(_ : fact) =
-  { existing with last_verified_at = Some now }
+  let valid_until =
+    match existing.external_ref with
+    | Some _ -> Some (now +. volatile_external_ttl_seconds)
+    | None -> existing.valid_until
+  in
+  { existing with last_verified_at = Some now; valid_until }
 ;;

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -4,7 +4,10 @@
     Episodes group related facts with a short summary and metadata for
     downstream retention scoring. *)
 
-let schema_version = "rfc0231-v2"
+(* RFC-0259: bumped from "rfc0231-v2" when the volatile [external_ref] field and
+   the read-side re-derivation of [valid_until] for referenced claims landed. New
+   rows carry this; legacy rows keep their stored version and decode unchanged. *)
+let schema_version = "rfc0259-v1"
 
 (* RFC-0244 Tier 2: the shared semantic store reuses the per-keeper IO/codec
    under a reserved id. A leading underscore is not produced by keeper naming, so
@@ -87,6 +90,120 @@ let is_promotable = function
   | Code_change | Preference | Blocker | Goal | Ephemeral | Unknown _ -> false
 ;;
 
+(* RFC-0259 §3.2(b): an external-state reference named by a claim. A claim that
+   names a PR/issue/task id is about *volatile* external state — true when
+   extracted, false once the world moves on — so [fact_valid_until] gives it a
+   finite horizon rather than letting it persist as a durable, immortal fact
+   (RFC-0259 §2.2 gap #4). [kind] is a closed sum so the future grounding
+   reconciler (RFC-0259 P2/P3) must classify every kind at compile time. *)
+type external_ref_kind =
+  | Pr
+  | Issue
+  | Task
+
+let external_ref_kind_to_string = function
+  | Pr -> "pr"
+  | Issue -> "issue"
+  | Task -> "task"
+;;
+
+let external_ref_kind_of_string s =
+  match String.lowercase_ascii (String.trim s) with
+  | "pr" -> Some Pr
+  | "issue" -> Some Issue
+  | "task" -> Some Task
+  | _ -> None
+;;
+
+type external_ref =
+  { kind : external_ref_kind
+  ; id : string
+  }
+
+(* Parse-don't-validate, once, at the producer boundary. CONSERVATIVE: only an
+   explicit marker counts — "PR #123", "pull request #123", "pull/123",
+   "issue #123", "issues/123", "PK-1234". A bare "#123" with no keyword is prose
+   ("step #3"), not a reference, and yields [None] so the claim keeps its normal
+   durable path. Over-matching would wrongly give a durable fact a finite TTL, so
+   the bar is deliberately high; under-matching only leaves the pre-RFC status quo
+   for that one claim. Returns the earliest-positioned reference when a claim
+   names several. *)
+let external_ref_of_claim claim =
+  let lc = String.lowercase_ascii claim in
+  let n = String.length lc in
+  let is_digit c = c >= '0' && c <= '9' in
+  let is_alpha c = c >= 'a' && c <= 'z' in
+  let digit_run i =
+    let j = ref i in
+    while !j < n && is_digit lc.[!j] do
+      incr j
+    done;
+    String.sub lc i (!j - i)
+  in
+  (* The alphabetic word ending just before [i] (whitespace skipped), with its
+     start index, so a two-word keyword ("pull request") can be recognized. *)
+  let word_before i =
+    let j = ref (i - 1) in
+    while !j >= 0 && (lc.[!j] = ' ' || lc.[!j] = '\t') do
+      decr j
+    done;
+    let e = !j + 1 in
+    while !j >= 0 && is_alpha lc.[!j] do
+      decr j
+    done;
+    String.sub lc (!j + 1) (e - (!j + 1)), !j + 1
+  in
+  let at_word_start i = i = 0 || not (is_alpha lc.[i - 1]) in
+  let best = ref None in
+  let consider pos kind id =
+    if String.length id > 0
+    then (
+      match !best with
+      | Some (p, _, _) when p <= pos -> ()
+      | Some _ | None -> best := Some (pos, kind, id))
+  in
+  (* (1) "#<digits>" anchored on a recognized preceding keyword. *)
+  for i = 0 to n - 1 do
+    if lc.[i] = '#'
+    then (
+      let id = digit_run (i + 1) in
+      if String.length id > 0
+      then (
+        let w1, w1_start = word_before i in
+        match w1 with
+        | "pr" | "pull" -> consider w1_start Pr id
+        | "issue" | "issues" -> consider w1_start Issue id
+        | "request" ->
+          let w2, w2_start = word_before w1_start in
+          if String.equal w2 "pull" then consider w2_start Pr id
+        | _ -> ()))
+  done;
+  (* (2) slash form "pull/<digits>" / "issues/<digits>" and Jira "pk-<digits>". *)
+  let scan_prefix kw sep kind ~keep_key =
+    let klen = String.length kw in
+    for i = 0 to n - klen - 1 do
+      if at_word_start i && String.equal (String.sub lc i klen) kw && lc.[i + klen] = sep
+      then (
+        let id = digit_run (i + klen + 1) in
+        if String.length id > 0
+        then (
+          let id =
+            if keep_key
+            then String.uppercase_ascii kw ^ String.make 1 sep ^ id
+            else id
+          in
+          consider i kind id))
+    done
+  in
+  scan_prefix "pull" '/' Pr ~keep_key:false;
+  scan_prefix "issues" '/' Issue ~keep_key:false;
+  scan_prefix "issue" '/' Issue ~keep_key:false;
+  scan_prefix "pk" '-' Task ~keep_key:true;
+  match !best with
+  | Some (_, kind, id) -> Some { kind; id }
+  | None -> None
+;;
+
 (* RFC-0247 §2.3 (forgetting): retention is a property of the category. A
    coordination event ("checkpoint saved") is stale within a day and worthless in
    a later session, so it gets a short hard TTL; durable knowledge never
@@ -103,6 +220,24 @@ let category_valid_until ~now = function
   | Validated_approach | Lesson | Unknown _ -> None
 ;;
 
+(* RFC-0259 §3.2: a claim that names external state cannot be durable — its truth
+   is only as good as its last verification. Until the grounding reconciler (P2)
+   re-checks it against GitHub, a finite horizon bounds how long an un-re-observed
+   external-state claim survives. Same shape as [ephemeral_ttl_seconds] (a TIME,
+   not a score); 1 day matches the ephemeral horizon. *)
+let volatile_external_ttl_seconds = 86_400.0
+
+(* RFC-0259 §3.2: the write-side [valid_until] producer. An [external_ref] claim is
+   never durable — it gets the volatile horizon regardless of category, so a
+   PR-status claim mislabeled [Fact] (the #21363 shape) or [Unknown] still decays.
+   [external_ref] is checked first so it takes precedence; otherwise the category
+   decides (only [Ephemeral] is finite). *)
+let fact_valid_until ~now ~external_ref category =
+  match external_ref with
+  | Some _ -> Some (now +. volatile_external_ttl_seconds)
+  | None -> category_valid_until ~now category
+;;
+
 (* RFC-0247 (purge): the fact carries only structure — the claim, its typed
    category, provenance, the distinct-keeper corroboration set, and three
    timestamps (first_seen, optional last_verified_at, optional Ephemeral
@@ -112,6 +247,11 @@ let category_valid_until ~now = function
 type fact =
   { claim : string
   ; category : category
+  ; external_ref : external_ref option
+    (* RFC-0259 §3.2(b): set by the producer ([external_ref_of_claim]) when the
+       claim names a PR/issue/task id. Orthogonal to [category] (a [Constraint]
+       can reference a PR). Drives [fact_valid_until]: a referenced claim is
+       volatile, never durable. Omitted from JSON when [None]. *)
   ; source : provenance_event
   ; observed_by : string list
     (* RFC-0244 Tier 2 (shared semantic store) ONLY: the sorted set of distinct
@@ -181,6 +321,23 @@ let json_string_list_field key (fields : (string * Yojson.Safe.t) list) =
     in
     if List.length strings = List.length items then Some strings else None
   | Some (`Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _)
+  | None -> None
+;;
+
+let external_ref_to_json (r : external_ref) =
+  `Assoc
+    [ "kind", `String (external_ref_kind_to_string r.kind); "id", `String r.id ]
+;;
+
+let external_ref_of_json = function
+  | Some (`Assoc fields) ->
+    (match json_string_field "kind" fields, json_string_field "id" fields with
+     | Some kind_s, Some id ->
+       (match external_ref_kind_of_string kind_s with
+        | Some kind -> Some { kind; id }
+        | None -> None)
+     | (Some _, None) | (None, Some _) | (None, None) -> None)
+  | Some (`Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _)
   | None -> None
 ;;
 
@@ -255,6 +412,12 @@ let fact_to_json f =
     @ (match f.observed_by with
        | [] -> []
        | keepers -> [ "observed_by", `List (List.map (fun k -> `String k) keepers) ])
+    (* RFC-0259 §3.2(b): omitted when [None] so claims with no external ref stay
+       byte-identical to pre-RFC-0259 rows (no drift). Appended last to keep the
+       existing key order stable for the snapshot fingerprint. *)
+    @ (match f.external_ref with
+       | Some r -> [ "external_ref", external_ref_to_json r ]
+       | None -> [])
   in
   `Assoc fields
 ;;
@@ -279,8 +442,27 @@ let fact_of_json (json : Yojson.Safe.t) =
         | Some source ->
           (* DET-OK: absent first_seen defaults to epoch for migration safety. *)
           let first_seen = Option.value (json_float_field "first_seen" fields) ~default:0.0 in
-          let valid_until = json_float_field "valid_until" fields in
           let last_verified_at = json_float_field "last_verified_at" fields in
+          (* RFC-0259 §3.2(b): the external ref is stored once written, but legacy
+             rows carry none. Re-derive it from the claim on read (deterministic,
+             idempotent) so an already-persisted volatile claim (e.g. a stale
+             "PR #N is OPEN") is reclassified without waiting for a rewrite. *)
+          let external_ref =
+            match external_ref_of_json (List.assoc_opt "external_ref" fields) with
+            | Some _ as r -> r
+            | None -> external_ref_of_claim claim
+          in
+          (* When a re-derived volatile row also lacks a [valid_until], anchor the
+             horizon to [first_seen] (on disk) so a row extracted days ago is
+             already past horizon — the recall TTL filter and GC drop it on the
+             next pass, closing RFC-0259 §2.2 gap #4 for existing rows, not just
+             new ones. A row that already stores a [valid_until] keeps it. *)
+          let valid_until =
+            match json_float_field "valid_until" fields, external_ref with
+            | None, Some _ -> Some (first_seen +. volatile_external_ttl_seconds)
+            | None, None -> None
+            | (Some _ as v), _ -> v
+          in
           (* DET-OK: absent observed_by defaults to empty (Tier-1 / legacy facts). *)
           let observed_by =
             Option.value (json_string_list_field "observed_by" fields) ~default:[]
@@ -290,6 +472,7 @@ let fact_of_json (json : Yojson.Safe.t) =
             ; (* Parse-once at the read boundary; legacy free-string categories
                  on disk map to their arm or [Unknown] (graceful-degrade). *)
               category = category_of_string category_str
+            ; external_ref
             ; source
             ; observed_by
             ; first_seen

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -64,6 +64,35 @@ val category_of_string : string -> category
     compile time. *)
 val is_promotable : category -> bool
 
+(** RFC-0259 §3.2(b): the kind of external state a claim references. Closed sum so
+    the grounding reconciler (P2/P3) must handle every kind at compile time. *)
+type external_ref_kind =
+  | Pr
+  | Issue
+  | Task
+
+(** Canonical lowercase token for an external-ref kind (round-trips with
+    [external_ref_kind_of_string]). *)
+val external_ref_kind_to_string : external_ref_kind -> string
+
+(** Parse an external-ref kind token; [None] outside the closed set. *)
+val external_ref_kind_of_string : string -> external_ref_kind option
+
+(** RFC-0259 §3.2(b): a reference to verifiable external state named by a claim.
+    [id] is the numeric id for [Pr]/[Issue] and the full key for [Task]
+    (e.g. ["PK-1234"]). *)
+type external_ref =
+  { kind : external_ref_kind
+  ; id : string
+  }
+
+(** RFC-0259 §3.2(b): parse an external-state reference out of a claim, once, at
+    the producer boundary. CONSERVATIVE — only an explicit marker counts
+    ("PR #123", "pull request #123", "pull/123", "issue #123", "issues/123",
+    "PK-1234"); a bare "#123" with no keyword yields [None] (it is prose, not a
+    reference). Returns the earliest-positioned reference when several are named. *)
+val external_ref_of_claim : string -> external_ref option
+
 (** RFC-0247 §2.3 (forgetting): the hard-expiry timestamp a newly written fact of
     this category should carry, given [now]. Exhaustive over {!category}. Only
     [Ephemeral] (coordination boilerplate) gets a finite TTL — the brain's
@@ -73,6 +102,22 @@ val is_promotable : category -> bool
     producer that makes the previously-inert [valid_until] field (and the GC TTL
     pass) reachable. *)
 val category_valid_until : now:float -> category -> float option
+
+(** RFC-0259 §3.2: the volatile-claim decay horizon (a TIME, not a score). Bounds
+    how long an un-re-observed external-state claim survives before the grounding
+    reconciler (P2) lands. *)
+val volatile_external_ttl_seconds : float
+
+(** RFC-0259 §3.2: the write-side [valid_until] producer. An [external_ref] claim
+    is never durable — it gets [volatile_external_ttl_seconds] regardless of
+    category (so a PR-status claim mislabeled [Fact]/[Unknown] still decays);
+    otherwise the category decides (only [Ephemeral] is finite). [external_ref]
+    takes precedence. *)
+val fact_valid_until
+  :  now:float
+  -> external_ref:external_ref option
+  -> category
+  -> float option
 
 (** A single semantic claim extracted from conversation history.
 
@@ -84,6 +129,10 @@ val category_valid_until : now:float -> category -> float option
 type fact =
   { claim : string
   ; category : category
+  ; external_ref : external_ref option
+    (** RFC-0259 §3.2(b): set by the producer when the claim names a PR/issue/task
+        id. Orthogonal to [category]. Drives [fact_valid_until] (a referenced
+        claim is volatile, never durable). Omitted from JSON when [None]. *)
   ; source : provenance_event
   ; observed_by : string list
     (** RFC-0244 Tier 2 (shared semantic store) only: the sorted set of distinct

--- a/test/memory_os_brain_harness.ml
+++ b/test/memory_os_brain_harness.ml
@@ -85,6 +85,7 @@ let mk_fact
   =
   { Types.claim
   ; Types.category
+  ; Types.external_ref = None
   ; Types.source = { Types.trace_id = "harness-trace"; Types.turn = 1; Types.tool_call_id = None }
   ; Types.observed_by = []
   ; Types.first_seen = now -. age_seconds

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -53,6 +53,7 @@ let index_of substring s =
 let fact_fixture ~now () =
   { Types.claim = "User prefers concise responses"
   ; Types.category = Types.Preference
+  ; Types.external_ref = None
   ; Types.source = { Types.trace_id = "trace-123"; Types.turn = 5; Types.tool_call_id = None }
   ; Types.observed_by = []
   ; Types.first_seen = now -. 86400.0
@@ -2275,6 +2276,134 @@ let test_librarian_provider_slot_gate_disabled_at_zero () =
         !first))
 ;;
 
+(* ---------- RFC-0259 P1: volatile-claim classification + decay ---------- *)
+
+let kind_id_of_claim claim =
+  match Types.external_ref_of_claim claim with
+  | Some r -> Some (Types.external_ref_kind_to_string r.Types.kind, r.Types.id)
+  | None -> None
+;;
+
+let test_external_ref_of_claim_parses () =
+  Alcotest.(check (option (pair string string)))
+    "PR #21363"
+    (Some ("pr", "21363"))
+    (kind_id_of_claim "PR #21363 is OPEN, MERGEABLE");
+  Alcotest.(check (option (pair string string)))
+    "issue #5"
+    (Some ("issue", "5"))
+    (kind_id_of_claim "blocked by issue #5");
+  Alcotest.(check (option (pair string string)))
+    "pull request #6"
+    (Some ("pr", "6"))
+    (kind_id_of_claim "the pull request #6 was merged");
+  Alcotest.(check (option (pair string string)))
+    "pull/99 slash form"
+    (Some ("pr", "99"))
+    (kind_id_of_claim "see github.com/o/r/pull/99 for context");
+  Alcotest.(check (option (pair string string)))
+    "PK-1234 jira key"
+    (Some ("task", "PK-1234"))
+    (kind_id_of_claim "tracked in PK-1234")
+;;
+
+let test_external_ref_of_claim_ignores_prose () =
+  let has_ref claim = Option.is_some (Types.external_ref_of_claim claim) in
+  Alcotest.(check bool) "bare #3 is prose" false (has_ref "complete step #3 first");
+  Alcotest.(check bool) "no marker at all" false (has_ref "the build uses dune 3.x");
+  Alcotest.(check bool) "number near non-keyword word" false (has_ref "approach #2 failed");
+  Alcotest.(check bool) "keyword without digits" false (has_ref "the pr # was opened")
+;;
+
+let test_fact_valid_until_volatile () =
+  let now = 1_000_000.0 in
+  let pr_ref = Some { Types.kind = Types.Pr; Types.id = "1" } in
+  Alcotest.(check (option (float 0.001)))
+    "external-ref Fact gets the finite volatile horizon"
+    (Some (now +. Types.volatile_external_ttl_seconds))
+    (Types.fact_valid_until ~now ~external_ref:pr_ref Types.Fact);
+  Alcotest.(check bool)
+    "durable Fact with no ref stays durable (None)"
+    true
+    (Option.is_none (Types.fact_valid_until ~now ~external_ref:None Types.Fact));
+  Alcotest.(check bool)
+    "Ephemeral with no ref still finite"
+    true
+    (Option.is_some (Types.fact_valid_until ~now ~external_ref:None Types.Ephemeral))
+;;
+
+let test_fact_of_json_rederives_legacy_volatile () =
+  let now = 2_000_000.0 in
+  (* first_seen two horizons ago: a re-derived row must already be past horizon. *)
+  let first_seen = now -. (Types.volatile_external_ttl_seconds *. 2.0) in
+  let legacy =
+    `Assoc
+      [ "claim", `String "PR #21363 is OPEN, MERGEABLE, and BLOCKED"
+      ; "category", `String "fact"
+      ; "source", `Assoc [ "trace_id", `String "t"; "turn", `Int 1 ]
+      ; "first_seen", `Float first_seen
+      ; "schema_version", `String "rfc0231-v2"
+      ]
+  in
+  match Types.fact_of_json legacy with
+  | None -> Alcotest.fail "legacy volatile row failed to decode"
+  | Some f ->
+    Alcotest.(check bool)
+      "external_ref re-derived from claim on read"
+      true
+      (Option.is_some f.Types.external_ref);
+    (match f.Types.valid_until with
+     | None -> Alcotest.fail "re-derived volatile row should carry a valid_until"
+     | Some vu ->
+       Alcotest.(check (float 0.001))
+         "valid_until anchored to first_seen"
+         (first_seen +. Types.volatile_external_ttl_seconds)
+         vu;
+       Alcotest.(check bool) "stale row is already past horizon" true (vu < now))
+;;
+
+let test_fact_to_json_omits_external_ref_when_none () =
+  let now = 1_000_000.0 in
+  let f = fact_fixture ~now () in
+  let json_str = Yojson.Safe.to_string (Types.fact_to_json f) in
+  Alcotest.(check bool)
+    "no external_ref key for a fact with no ref (byte-compat)"
+    false
+    (contains "external_ref" json_str)
+;;
+
+let test_reobserve_refreshes_volatile_horizon () =
+  let now = 5_000_000.0 in
+  let older = now -. 100_000.0 in
+  let volatile =
+    { (fact_fixture ~now:older ()) with
+      Types.claim = "PR #42 is OPEN"
+    ; Types.external_ref = Some { Types.kind = Types.Pr; Types.id = "42" }
+    ; Types.valid_until = Some (older +. Types.volatile_external_ttl_seconds)
+    }
+  in
+  let refreshed = Policy.reobserve_fact ~now ~existing:volatile ~incoming:volatile in
+  match refreshed.Types.valid_until with
+  | None -> Alcotest.fail "volatile fact lost its horizon on reobserve"
+  | Some vu ->
+    Alcotest.(check (float 0.001))
+      "horizon re-anchored to now on re-observation"
+      (now +. Types.volatile_external_ttl_seconds)
+      vu
+;;
+
+let test_retention_rank_demotes_volatile () =
+  let now = 1_000_000.0 in
+  let durable = { (fact_fixture ~now ()) with Types.category = Types.Fact } in
+  let volatile =
+    { durable with Types.external_ref = Some { Types.kind = Types.Pr; Types.id = "7" } }
+  in
+  Alcotest.(check bool)
+    "a volatile Fact ranks below a durable Fact (dropped first by the cap)"
+    true
+    (Policy.retention_rank ~now volatile < Policy.retention_rank ~now durable)
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_os"
@@ -2513,6 +2642,36 @@ let () =
             "provider slot gate disabled at capacity 0"
             `Quick
             test_librarian_provider_slot_gate_disabled_at_zero
+        ] )
+    ; ( "rfc-0259 volatile"
+      , [ Alcotest.test_case
+            "external_ref_of_claim parses PR/issue/task markers"
+            `Quick
+            test_external_ref_of_claim_parses
+        ; Alcotest.test_case
+            "external_ref_of_claim ignores bare # and prose"
+            `Quick
+            test_external_ref_of_claim_ignores_prose
+        ; Alcotest.test_case
+            "fact_valid_until: external ref -> finite, durable -> none"
+            `Quick
+            test_fact_valid_until_volatile
+        ; Alcotest.test_case
+            "fact_of_json re-derives a legacy volatile row past horizon"
+            `Quick
+            test_fact_of_json_rederives_legacy_volatile
+        ; Alcotest.test_case
+            "fact_to_json omits external_ref when none (byte-compat)"
+            `Quick
+            test_fact_to_json_omits_external_ref_when_none
+        ; Alcotest.test_case
+            "reobserve refreshes a volatile claim's horizon"
+            `Quick
+            test_reobserve_refreshes_volatile_horizon
+        ; Alcotest.test_case
+            "retention rank demotes a volatile fact below durable"
+            `Quick
+            test_retention_rank_demotes_volatile
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -20,6 +20,7 @@ let fact
   in
   { Types.claim
   ; category
+  ; external_ref = None
   ; source = { Types.trace_id = "t"; turn = 1; tool_call_id = None }
   ; observed_by
   ; first_seen

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -11,6 +11,7 @@ let now = 1_000_000.0
 let fact claim =
   { Types.claim
   ; category = Types.Fact
+  ; external_ref = None
   ; source = { Types.trace_id = "t"; turn = 1; tool_call_id = None }
   ; observed_by = []
   ; first_seen = now


### PR DESCRIPTION
## 목적
키퍼 Memory OS가 외부 휘발 상태를 durable·불멸 fact로 영속화하던 근본 결함(RFC-0259 §2.2 gap #4)을 타입 레벨에서 닫습니다. 라이브 증거(2026-06-19 직접 확인): rondo store의 `"PR #21363 is blocked pending review from jeong-sik"`(durable `blocker`), albini의 `"#21363 ... auto-merge pending"`이 **#21363 CLOSED 후 2일째** recall에 주입되고 있었습니다 — 재검증/철회/만료 경로가 없어서.

RFC: **RFC-0259** §3.2(b) (`docs/rfc/RFC-0259-memory-os-volatile-claim-grounding-retraction-decay.md`). 본 PR은 그 **P1**(독립 출하 가능) 단계입니다. 이건 증상 억제가 아니라 RFC가 명시한 근본 fix입니다.

## 변경 (P1)
- 타입 `external_ref { kind: Pr|Issue|Task; id }` + 보수적 파서 `external_ref_of_claim` (명시 마커만: `PR #N`/`pull request #N`/`pull/N`/`issue #N`/`issues/N`/`PK-N`; 키워드 없는 bare `#3`/prose → `None`).
- SSOT `fact_valid_until`: external_ref claim은 카테고리 무관 유한 휘발 horizon(`volatile_external_ttl_seconds`=1일) 부여. producer/consolidation/reobserve 전부 이 함수 경유.
- 디스크 codec: read 시 claim에서 external_ref 재유도 + `valid_until`을 `first_seen` anchor → **이미 쌓인 #21363류 stale 행이 past-horizon으로 판정**되어 라이브 recall TTL 필터(`fact_is_current`)/GC가 주입에서 제외.
- `retention_rank`: 휘발 fact를 non-durable tier로 (저장소 한도 초과 시 먼저 정리).
- consolidator(Tier-2): external_ref claim은 승격 대상에서 제외 + `valid_until` 라우팅 → 휘발 claim이 불멸 공유 fact로 부활 불가.
- `schema_version` → `rfc0259-v1`; `fact_to_json`은 external_ref가 `None`이면 키 생략(non-ref 행 byte-identical, drift 없음).

## 점수 없음 (제약 준수)
RFC-0247/0259 경계 유지 — 추가된 건 **타입 필드 + 시간 경계(TTL)** 뿐, importance/effectiveness 점수는 0개.

## 범위 밖 (후속 단계)
P2(gh grounding reconciler) · P3(retraction/supersedes) · P4(recall suppression).

## 검증
- `dune build --root .` green, ocamlformat clean (변경 11파일 전부).
- 신규 unit 7개(파서 / `fact_valid_until` / legacy 재유도 past-horizon / byte-compat omit / reobserve 갱신 / retention demotion) + 기존 memory_os·consolidation·consolidation_runtime 스위트 green.
- 유일한 실패 `json: librarian runtime appends episode bundle`("generation")는 **clean origin/main(변경 없이)에서도 동일 재현**(57 tests/1 failure)되는 base-broken(episode generation 번호 산정, facts와 무관)입니다. 본 변경의 회귀 아님(64 tests/동일 1 failure = 신규 실패 0).

RFC-WAIVED: keeper_memory_os_*는 agent_delegation RFC 트리거 subsystem(credential/operator/sandbox/hooks/workflow)에 해당하지 않음. 본 PR은 그럼에도 RFC-0259를 구현·인용함.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
