### PR TITLE
fix(dashboard): make the Work board show goals and unassigned tasks

### DIFF
--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -197,6 +197,42 @@ describe('Work', () => {
       expect(navigateMock).toHaveBeenCalledWith('monitoring', { section: 'agents', view: 'keepers', keeper: 'sangsu' })
     })
 
+    it('surfaces tasks without a goal_id in a dedicated unassigned section', () => {
+      goals.value = [
+        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+      ]
+      tasks.value = [
+        { id: 'J-1', title: 'Linked job', goal_id: 'G-1', status: 'todo' },
+        { id: 'U-1', title: 'Orphan job', goal_id: null, status: 'in_progress' },
+        { id: 'U-2', title: 'Another orphan', status: 'todo' },
+      ]
+
+      render(html`<${Work} />`)
+
+      // KPI counts every task regardless of goal linkage.
+      expect(screen.getByTestId('kpi-jobs').textContent).toBe('3')
+
+      const unassigned = screen.getByTestId('work-unassigned')
+      expect(unassigned).toBeTruthy()
+      expect(unassigned.textContent).toContain('미배정 작업')
+      expect(unassigned.textContent).toContain('(2)')
+      expect(screen.getByText('Orphan job')).toBeTruthy()
+      expect(screen.getByText('Another orphan')).toBeTruthy()
+    })
+
+    it('omits the unassigned section when every task has a goal', () => {
+      goals.value = [
+        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+      ]
+      tasks.value = [
+        { id: 'J-1', title: 'Linked job', goal_id: 'G-1', status: 'todo' },
+      ]
+
+      render(html`<${Work} />`)
+
+      expect(screen.queryByTestId('work-unassigned')).toBeNull()
+    })
+
     it('auto-expands high-priority goals and goals with blocked jobs', () => {
       goals.value = [
         { id: 'G-1', horizon: 'short', title: 'Normal goal', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -259,23 +259,28 @@ function WorkSurfaceV2() {
     })
   }
 
+  // KPI counts span ALL tasks, not only goal-linked ones. goal↔task linkage is
+  // optional (tasks frequently carry no goal_id), so a goal-only sum would read
+  // 0 jobs even with a full backlog.
   const totals = useMemo(() => {
-    let totalJobs = 0
     let doneJobs = 0
     let blockedJobs = 0
-    for (const g of goalList) {
-      const p = goalProgressCounts(g)
-      totalJobs += p.total
-      doneJobs += p.done
-      blockedJobs += p.blocked
+    for (const t of allTasks) {
+      const state = jobStateForTask(t).cls
+      if (state === 'done') doneJobs++
+      else if (state === 'blocked') blockedJobs++
     }
     return {
       goals: goalList.length,
-      jobs: totalJobs,
+      jobs: allTasks.length,
       done: doneJobs,
       blocked: blockedJobs,
     }
   }, [goalList, allTasks])
+
+  // Tasks with no goal_id have no place in the goal→job tree. Surface them in a
+  // dedicated section instead of dropping them from the board.
+  const unassignedTasks = allTasks.filter(task => !task.goal_id)
 
   return html`
     <main class="wk-surface ss-surface bg-surface-page text-text-primary">
@@ -325,7 +330,20 @@ function WorkSurfaceV2() {
             `)}
           </div>
 
-          <div class="wk-foot mono">Goal → job → keeper · job 의 keeper 를 누르면 해당 keeper 대화로 이동</div>
+          ${unassignedTasks.length > 0 ? html`
+            <section class="wk-unassigned ss-card mx-6" data-testid="work-unassigned">
+              <div class="wk-unassigned-h">
+                <span class="wk-unassigned-dot" aria-hidden="true"></span>
+                미배정 작업
+                <span class="wk-unassigned-n mono">(${unassignedTasks.length})</span>
+              </div>
+              <div class="wk-jobs">
+                ${unassignedTasks.map(task => html`<${JobRow} key=${task.id} task=${task} />`)}
+              </div>
+            </section>
+          ` : null}
+
+          <div class="wk-foot mono">Goal → job → keeper · goal 없는 작업은 미배정 · job 의 keeper 를 누르면 해당 keeper 대화로 이동</div>
         </div>
       </div>
     </main>

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -277,6 +277,35 @@
   margin-bottom: 7px;
 }
 
+/* Unassigned jobs: tasks with no goal_id, surfaced below the goal cards. */
+.wk-unassigned {
+  /* Background/border/radius/shadow come from the .ss-card utility. */
+  overflow: hidden;
+}
+
+.wk-unassigned-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 15px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-mid);
+}
+
+.wk-unassigned-dot {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-dim);
+}
+
+.wk-unassigned-n {
+  font-weight: 400;
+  color: var(--text-dim);
+}
+
 .wk-job {
   display: flex;
   align-items: center;

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -123,6 +123,20 @@ describe('refreshPlanForRoute', () => {
   })
 
   it('refreshes the new workspace and lab sections only where store-backed data is needed', () => {
+    // The default Work board (section: 'work') reads the same flat goals + tasks
+    // signals as planning, so it must fetch both. Regression guard: a missing
+    // 'work' branch left the board empty (0 goals / 0 jobs) despite live data.
+    expect(refreshPlanForRoute({
+      tab: 'workspace',
+      params: { section: 'work' },
+    })).toEqual(['goals', 'execution'])
+
+    // Bare workspace route normalizes to the 'work' default section.
+    expect(refreshPlanForRoute({
+      tab: 'workspace',
+      params: {},
+    })).toEqual(['goals', 'execution'])
+
     expect(refreshPlanForRoute({
       tab: 'workspace',
       params: { section: 'planning' },

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -101,14 +101,23 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
         return ['surfaceReadiness']
       }
       return ['namespaceTruth', 'operatorSnapshot', 'operatorWorkspaceDigest']
-    case 'workspace':
-      if (routeState.params.section === 'planning') {
+    case 'workspace': {
+      const section = routeState.params.section
+      // 'work' (the default section) and 'planning' are both store-backed
+      // goal/task surfaces: WorkSurfaceV2 (work) and PlanningPanel (planning)
+      // render the flat `goals` + `tasks` signals. Those signals are only
+      // populated by the `goals` (planning fetch) and `execution` refreshers.
+      // Before this branch, landing on the default Work board returned [] and
+      // left both signals empty, so the board showed 0 goals / 0 jobs even
+      // though live planning/execution data existed.
+      if (!section || section === 'work' || section === 'planning') {
         return ['goals', 'execution']
       }
-      if (routeState.params.section === 'board') {
+      if (section === 'board') {
         return ['board']
       }
       return []
+    }
     case 'lab':
       if (routeState.params.section === 'harness') {
         return ['harness']


### PR DESCRIPTION
## 증상

새 디자인 작업 보드(Work surface, `WorkSurfaceV2`)에 Goal/Task 정보가 표시되지 않음. KPI가 전부 0으로 보임.

원인이 두 가지였다.

## 원인 1 — Goal 미표시: refresh plan 누락

`tab-refresh.ts`의 `refreshPlanForRoute`가 `workspace` 탭에서 `planning`/`board` section만 refresh plan을 선언하고, 기본 section인 `work`는 `[]`(refresh 없음)를 반환했다.

- Work surface의 기본 section은 `work`(`config/navigation.ts` defaultParams).
- `WorkSurfaceV2`는 flat `goals` + `tasks` signal을 렌더한다.
- 두 signal은 각각 `goals`(planning fetch) / `execution` refresher로만 채워진다.
- 따라서 기본 보드 진입 시 두 signal이 비어 0 goals / 0 jobs로 렌더됐다. 라이브 `/api/v1/dashboard/planning`은 goal 68개를 반환하므로 데이터 문제는 아님.

**수정**: `work`(및 정규화 전 bare workspace 진입)를 `planning`과 동일한 `['goals', 'execution']` plan으로 라우팅. `execution` refresher가 `tasks` + `keepers`도 함께 채운다.

## 원인 2 — Task 미표시: goal 없는 task가 보드에서 누락

보드는 `tasks.filter(t => t.goal_id === goal.id)`로 goal당 job을 묶는데, 라이브 task 24개가 전부 `goal_id=null`이었다(goal↔task linkage는 선택적). 이 task들은 goal→job 트리에 자리가 없어 보드에서 완전히 사라졌고, goal이 로드된 뒤에도 "task 정보 안 보임"이 남았다.

**수정**:
- `goal_id`가 없는 task를 모으는 "미배정 작업" 섹션을 goal 카드 아래에 추가. 렌더는 기존 `JobRow`를 재사용(상태/담당 keeper/blocker).
- KPI(jobs/done/blocked)를 goal-linked만이 아니라 전체 task 기준으로 집계 → 헤더가 실제 backlog를 반영.

## 로컬 검증

- `vitest run src/components/work.test.ts src/tab-refresh.test.ts` — 31 passed (신규 4)
- `tsc --noEmit` — exit 0
- `eslint src/components/work.ts src/tab-refresh.ts` — clean
- work-v2.css는 `main.ts`의 `import.meta.glob('./styles/*-v2.css')`로 자동 번들됨.

RFC-WAIVED: dashboard route refresh-plan + 표시 컴포넌트 수정으로 credential/operator/sandbox/hooks/workflow subsystem 무관.
