### PR TITLE
fix(dashboard): render keeper chat markdown richly and surface tool calls

### DIFF
--- a/dashboard/src/components/chat/markdown-blocks.test.ts
+++ b/dashboard/src/components/chat/markdown-blocks.test.ts
@@ -148,4 +148,49 @@ describe('parseMarkdownToBlocks', () => {
     expect(p.html).toContain('<code>')
     expect(p.html).not.toContain('<script>')
   })
+
+  // Strict-superset of lib/chat-blocks.ts: a URL alone on its line becomes a
+  // card, so this parser can supersede the line-based one on the render path
+  // without losing the link/image affordance.
+  it('turns a standalone URL into a link card', () => {
+    const blocks = parseMarkdownToBlocks('https://example.com/docs/page')
+    expect(blocks).toHaveLength(1)
+    const link = blocks[0] as Extract<ChatBlock, { t: 'link' }>
+    expect(link.t).toBe('link')
+    expect(link.url).toBe('https://example.com/docs/page')
+    expect(link.title).toBe('example.com')
+  })
+
+  it('turns a standalone image URL into an image block', () => {
+    const blocks = parseMarkdownToBlocks('https://example.com/pic.png')
+    expect(blocks).toHaveLength(1)
+    const image = blocks[0] as Extract<ChatBlock, { t: 'image' }>
+    expect(image.t).toBe('image')
+    expect(image.src).toBe('https://example.com/pic.png')
+  })
+
+  it('keeps a URL with surrounding prose as an inline link, not a card', () => {
+    const blocks = parseMarkdownToBlocks('See https://example.com for details')
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toMatchObject({ t: 'p' })
+    expect((blocks[0] as Extract<ChatBlock, { t: 'p' }>).html).toContain('<a')
+  })
+
+  // Per-line superset: a soft-wrapped paragraph (single newlines, no blank line)
+  // that interleaves prose with a standalone-URL line must still yield the card,
+  // matching the line-based parser the render path supersedes.
+  it('splits a soft-wrapped paragraph so a mid-message image URL line stays a card', () => {
+    const blocks = parseMarkdownToBlocks('Here is the chart:\nhttps://cdn.example.com/run/abc.png\nLet me know.')
+    expect(blocks).toHaveLength(3)
+    expect(blocks[0]).toMatchObject({ t: 'p' })
+    expect(blocks[1]).toMatchObject({ t: 'image', src: 'https://cdn.example.com/run/abc.png' })
+    expect(blocks[2]).toMatchObject({ t: 'p' })
+  })
+
+  it('splits consecutive bare URL lines into separate link cards', () => {
+    const blocks = parseMarkdownToBlocks('https://a.example.com/x\nhttps://b.example.com/y')
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0]).toMatchObject({ t: 'link', url: 'https://a.example.com/x' })
+    expect(blocks[1]).toMatchObject({ t: 'link', url: 'https://b.example.com/y' })
+  })
 })

--- a/dashboard/src/components/chat/markdown-blocks.ts
+++ b/dashboard/src/components/chat/markdown-blocks.ts
@@ -6,6 +6,37 @@ function escapeHtml(raw: string): string {
   return raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
+// A standalone URL occupying the whole paragraph renders as a link/image card,
+// matching the line-based parser in lib/chat-blocks.ts so this rich parser is a
+// strict superset of it (no link-card regression when it supersedes the simple
+// parser on the assistant/system render path).
+const STANDALONE_URL_RE = /^https?:\/\/\S+$/i
+const IMAGE_URL_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'])
+
+function isImageUrl(url: string): boolean {
+  try {
+    const ext = new URL(url).pathname.toLowerCase().split('.').pop() ?? ''
+    return IMAGE_URL_EXTENSIONS.has(ext)
+  } catch {
+    return false
+  }
+}
+
+function hostnameTitle(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
+}
+
+function standaloneUrlBlock(text: string): ChatBlock | null {
+  const trimmed = text.trim()
+  if (!STANDALONE_URL_RE.test(trimmed)) return null
+  if (isImageUrl(trimmed)) return { t: 'image', src: trimmed }
+  return { t: 'link', url: trimmed, title: hostnameTitle(trimmed), meta: hostnameTitle(trimmed) }
+}
+
 /** Linkify plain URLs without touching existing HTML tags. */
 function linkifyHtml(raw: string): string {
   if (!raw || raw.indexOf('http') === -1) return raw
@@ -66,7 +97,7 @@ function parseList(token: Tokens.List): ChatBlock {
   return { t: 'ul', items }
 }
 
-function parseParagraph(token: Tokens.Paragraph): ChatBlock | null {
+function parseParagraph(token: Tokens.Paragraph): ChatBlock | ChatBlock[] | null {
   if (token.tokens.length === 1 && token.tokens[0]?.type === 'image') {
     const img = token.tokens[0] as Tokens.Image
     return { t: 'image', src: img.href, cap: img.text || img.title || undefined }
@@ -74,6 +105,38 @@ function parseParagraph(token: Tokens.Paragraph): ChatBlock | null {
   const trimmed = token.text.trim()
   if (/^<svg\b[\s\S]*<\/svg>$/i.test(trimmed)) {
     return { t: 'svg', svg: trimmed, cap: undefined }
+  }
+  const urlBlock = standaloneUrlBlock(trimmed)
+  if (urlBlock) return urlBlock
+  // marked folds soft-wrapped lines into one paragraph, but the line-based
+  // parser (lib/chat-blocks.ts / keeper_chat_blocks.ml) emits a link/image card
+  // for any standalone-URL *line* even when adjacent prose shares the paragraph.
+  // Split so each such line becomes a card and prose runs stay paragraphs; this
+  // keeps the parser a true superset, so the render path can supersede the
+  // line-based blocks without dropping a mid-message image/link card.
+  if (token.text.includes('\n')) {
+    const lines = token.text.split('\n')
+    if (lines.some((line) => standaloneUrlBlock(line.trim()))) {
+      const blocks: ChatBlock[] = []
+      let prose: string[] = []
+      const flushProse = () => {
+        if (prose.length === 0) return
+        const html = inlineHtml(prose.join('\n')).trim()
+        if (html) blocks.push({ t: 'p', html })
+        prose = []
+      }
+      for (const line of lines) {
+        const card = standaloneUrlBlock(line.trim())
+        if (card) {
+          flushProse()
+          blocks.push(card)
+        } else {
+          prose.push(line)
+        }
+      }
+      flushProse()
+      return blocks
+    }
   }
   const html = inlineHtml(token.text).trim()
   return html ? { t: 'p', html } : null

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1792,3 +1792,72 @@ describe('fusion chat card', () => {
     expect(container.querySelector('[data-fusion-detail]')?.textContent).toContain('1,200 tok')
   })
 })
+
+describe('ChatMessageBubble — rich markdown rendering of assistant prose', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  function renderEntries(entries: KeeperConversationEntry[]) {
+    render(html`<${ChatTranscript} entries=${entries} emptyText="empty" />`, container)
+  }
+
+  it('renders a code fence in assistant prose as a code block', () => {
+    renderEntries([
+      entry({
+        id: 'a1',
+        role: 'assistant',
+        source: 'direct_assistant',
+        text: 'Here you go:\n\n```ts\nconst x = 1\n```',
+      }),
+    ])
+    const code = container.querySelector('[data-chat-block="code"]')
+    expect(code).not.toBeNull()
+    expect(code?.textContent).toContain('const x = 1')
+  })
+
+  it('re-parses richly even when the backend supplied a degraded p-only block', () => {
+    // The backend persists a line-based parse (escaped <p>); the render path
+    // must still recover the structured code block from the message text.
+    renderEntries([
+      entry({
+        id: 'a2',
+        role: 'assistant',
+        source: 'direct_assistant',
+        text: '```sh\nls -la\n```',
+        blocks: [
+          { t: 'p', html: '```sh' },
+          { t: 'p', html: 'ls -la' },
+          { t: 'p', html: '```' },
+        ],
+      }),
+    ])
+    expect(container.querySelector('[data-chat-block="code"]')).not.toBeNull()
+  })
+
+  it('keeps server blocks as-is when the message carries a non-text card/clip', () => {
+    // A voice clip cannot be reconstructed from text, so the message renders its
+    // server block and does not re-parse the (secondary) transcript prose.
+    renderEntries([
+      entry({
+        id: 'a3',
+        role: 'assistant',
+        source: 'direct_assistant',
+        text: 'transcript mentioning ```code``` inline',
+        blocks: [
+          { t: 'voice', secs: 3, wave: [0.2, 0.4], src: 'https://example.com/v.mp3', transcript: 'note' },
+        ],
+      }),
+    ])
+    expect(container.querySelector('[data-chat-block="voice"]')).not.toBeNull()
+    expect(container.querySelector('[data-chat-block="code"]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1509,6 +1509,22 @@ function AudioPlayer({ clip }: { clip: KeeperConversationAudioClip }) {
   `
 }
 
+// Block types that parseMarkdownToBlocks cannot reproduce from message text:
+// synthesized voice clips, attachments, fusion deliberation cards, artifacts,
+// broadcasts, traces, shell transcripts. When an assistant/system message
+// carries one of these the server blocks are rendered as-is; otherwise the
+// prose is re-parsed richly. (Complement of the markdown-derived block set:
+// p/h4/ul/callout/table/code/mermaid/image/svg/link.)
+const CARD_BLOCK_TYPES: ReadonlySet<ChatBlock['t']> = new Set([
+  'voice',
+  'attach',
+  'fusion',
+  'artifact',
+  'broadcast',
+  'trace',
+  'shell',
+])
+
 function ChatMessageBubble({
   entry,
   showMetadata = true,
@@ -1527,24 +1543,26 @@ function ChatMessageBubble({
   const [messageCollapsed, setMessageCollapsed] = useState(true)
   const expanded = showMetadata && expandedRaw
   const rawExpanded = showMetadata && rawExpandedRaw
-  const hasBlocks = entry.blocks && entry.blocks.length > 0
   const liveLabel = liveMessageLabel(entry)
   const messageText = liveLabel ? '' : entry.text || '(empty reply)'
   const messageLength = messageText.length
   const isFailureMessage =
     (entry.delivery === 'error' || entry.delivery === 'timeout' || entry.delivery === 'interrupted')
     && !!entry.error?.trim()
+  const richTextRole = entry.role === 'assistant' || entry.role === 'system'
+  const hasRealText = !liveLabel && !!entry.text && entry.text.trim().length > 0
+  const hasCardBlock = (entry.blocks ?? []).some((b) => CARD_BLOCK_TYPES.has(b.t))
+  // Re-parse assistant/system prose so markdown (code fences, tables, callouts)
+  // renders as structured blocks. The backend persists only a line-based parse
+  // (lib/keeper/keeper_chat_blocks.ml -> escaped <p>), so without this the rich
+  // renderer never receives a code/table block. Skipped when the message owns a
+  // card/clip the text cannot reproduce (CARD_BLOCK_TYPES) — those server blocks
+  // render as-is.
   const parsedBlocks = useMemo(() => {
-    if (isFailureMessage) return null
-    if (hasBlocks) return null
-    if (entry.role !== 'assistant' && entry.role !== 'system') return null
-    return parseMarkdownToBlocks(messageText)
-  }, [hasBlocks, isFailureMessage, entry.role, messageText])
-  const effectiveBlocks = isFailureMessage
-    ? []
-    : entry.blocks && entry.blocks.length > 0
-      ? entry.blocks
-      : (parsedBlocks ?? [])
+    if (isFailureMessage || !richTextRole || !hasRealText || hasCardBlock) return null
+    return parseMarkdownToBlocks(entry.text ?? '')
+  }, [isFailureMessage, richTextRole, hasRealText, hasCardBlock, entry.text])
+  const effectiveBlocks = isFailureMessage ? [] : (parsedBlocks ?? entry.blocks ?? [])
   const hasEffectiveBlocks = effectiveBlocks.length > 0
   const collapseThreshold = 1200
   const isCollapsible = !hasEffectiveBlocks && messageLength > collapseThreshold

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -33,7 +33,7 @@ import {
   resumePendingKeeperChatRequests,
   sendKeeperThreadMessage,
 } from '../keeper-runtime'
-import { isVisibleDirectConversationEntry } from '../keeper-state'
+import { isDefaultVisibleConversationEntry } from '../keeper-state'
 import {
   enqueueInput,
   clearInputQueue,
@@ -466,7 +466,7 @@ export function KeeperConversationPanel({
   // unrelated signals; memoizing each stage on its stable upstream skips the
   // refilter when rawThread and the relevant UI flag are unchanged.
   const thread = useMemo(
-    () => showInternal ? rawThread : rawThread.filter(isVisibleDirectConversationEntry),
+    () => showInternal ? rawThread : rawThread.filter(isDefaultVisibleConversationEntry),
     [rawThread, showInternal],
   )
   const hiddenCount = rawThread.length - thread.length
@@ -486,7 +486,7 @@ export function KeeperConversationPanel({
   const transcriptEmptyText =
     hasQuery && visibleThread.length > 0
       ? '검색어와 일치하는 메시지가 없습니다.'
-      : '아직 표시할 대화가 없습니다. 내부 메시지와 도구 호출은 토글로 전환할 수 있습니다.'
+      : '아직 표시할 대화가 없습니다. 내부 메시지는 토글로 볼 수 있습니다.'
   const hydrating = keeperHydrating.value[keeperName] ?? false
   const error = keeperActionErrors.value[keeperName]
   const chatAccess = keeperDirectChatAccess(shellAuthSummary.value)
@@ -761,6 +761,7 @@ export function KeeperConversationPanel({
           showMetadata=${showMetadata}
           variant="messenger"
           size="primary"
+          groupToolCalls=${true}
           action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
         />
 
@@ -872,6 +873,7 @@ export function KeeperConversationPanel({
             showMetadata=${showMetadata}
             variant="messenger"
             size="default"
+            groupToolCalls=${true}
             action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
           />
         </div>

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -6,6 +6,8 @@ import {
   attachKeeperAudioClip,
   chatHistoryEntriesFromRest,
   insertThreadEntryBefore,
+  isDefaultVisibleConversationEntry,
+  isToolConversationEntry,
   isVisibleDirectConversationEntry,
   keeperThreads,
   mergeServerHistoryEntries,
@@ -77,6 +79,46 @@ describe('normalizeStatusDetail', () => {
     })
 
     expect(detail.history.every(isVisibleDirectConversationEntry)).toBe(true)
+  })
+})
+
+describe('default conversation visibility (tool calls vs internal)', () => {
+  function mk(partial: Partial<KeeperConversationEntry>): KeeperConversationEntry {
+    return {
+      id: 'e',
+      role: 'assistant',
+      source: 'direct_assistant',
+      label: 'sangsu',
+      text: '',
+      rawText: '',
+      timestamp: '2026-06-19T00:00:00.000Z',
+      delivery: 'history',
+      streamState: null,
+      details: null,
+      ...partial,
+    }
+  }
+
+  it('surfaces tool-call rows by default but keeps them out of direct comms', () => {
+    const tool = mk({ role: 'tool', source: 'tool_result', text: '{"path":"x"}' })
+    // The "direct conversation" predicate is unchanged: tool rows are not direct comms.
+    expect(isVisibleDirectConversationEntry(tool)).toBe(false)
+    expect(isToolConversationEntry(tool)).toBe(true)
+    // The default-visible predicate (toggle off) does include them.
+    expect(isDefaultVisibleConversationEntry(tool)).toBe(true)
+  })
+
+  it('keeps truly-internal sources behind the toggle', () => {
+    for (const source of ['world_state_prompt', 'internal_assistant', 'system'] as const) {
+      const internal = mk({ source })
+      expect(isToolConversationEntry(internal)).toBe(false)
+      expect(isDefaultVisibleConversationEntry(internal)).toBe(false)
+    }
+  })
+
+  it('keeps direct user/assistant turns visible', () => {
+    expect(isDefaultVisibleConversationEntry(mk({ role: 'user', source: 'direct_user' }))).toBe(true)
+    expect(isDefaultVisibleConversationEntry(mk({ role: 'assistant', source: 'direct_assistant' }))).toBe(true)
   })
 })
 

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -120,6 +120,21 @@ export function isVisibleDirectConversationEntry(entry: KeeperConversationEntry)
     && entry.source !== 'system'
 }
 
+/** Tool-call rows (role 'tool', minted live by keeper-stream and persisted to
+ *  history). They are part of the keeper's visible work product, not internal
+ *  prompt plumbing, so the transcript surfaces them (folded into a "작업 과정"
+ *  card by groupToolCalls). */
+export function isToolConversationEntry(entry: KeeperConversationEntry): boolean {
+  return entry.role === 'tool'
+}
+
+/** Entries shown when the internal-message toggle is off: direct user/assistant
+ *  turns plus tool-call rows. Only the truly-internal sources
+ *  (world_state_prompt, internal_assistant, system) stay behind the toggle. */
+export function isDefaultVisibleConversationEntry(entry: KeeperConversationEntry): boolean {
+  return isVisibleDirectConversationEntry(entry) || isToolConversationEntry(entry)
+}
+
 // --- Audio helpers (RFC-0235 P1/P3) ---
 
 /** Canonicalize an audio clip from the wire into the dashboard type.


### PR DESCRIPTION
## 무엇을

키퍼 채팅에서 **리치 마크다운(코드블럭/테이블/callout 등)이 평문으로 떨어지는 문제**와 **도구 사용 블록(작업 과정 카드)이 전혀 안 나타나는 문제**를 근본 수정합니다.

## 근본 원인 (두 개의 독립 버그)

| # | 증상 | 근본 원인 |
|---|------|----------|
| 1 | 코드블럭/테이블/callout이 escape된 평문 | 블록 생산 파이프라인 전체가 line 기반 단순 파서. 백엔드 `keeper_chat_blocks.ml`(`Text\|Image\|Link\|Fusion` 닫힌 합타입)와 프론트 폴백 `lib/chat-blocks.ts`가 `p/image/link`만 생성. 리치 파서 `parseMarkdownToBlocks`(code/table/callout/mermaid)는 `ChatMessageBubble`에서 **blocks가 비었을 때만** 동작하는데, 백엔드가 항상 단순 블록을 영속화 → 리치 경로 dead. |
| 2 | 도구 사용 블록 아예 안 뜸 | tool row(`role='tool'`)가 "내부 메시지"와 한 바구니로 묶여 `showInternal` 토글(기본 OFF) 뒤에 숨음. `isVisibleDirectConversationEntry`가 user/assistant만 통과 → `groupToolCalls` ToolTraceCard가 grouping 전에 걸러진 tool row를 못 받아 영원히 렌더 안 됨. |

## 변경

**#1 — 프론트 리치 렌더 (사용자 승인 방향)**
- `primitives.ts` `ChatMessageBubble`: assistant/system 산문을 `parseMarkdownToBlocks`로 렌더 시점 재파싱. 텍스트로 재현 불가한 카드/클립(`fusion/voice/attach/artifact/broadcast/trace/shell` = `CARD_BLOCK_TYPES`)이 있으면 서버 블록 그대로 렌더(회귀 방지).
- `markdown-blocks.ts`: 단독 URL → 링크/이미지 카드 보강. 단순 파서의 유일한 고유 기능을 흡수해 **strict superset**화(코드+URL 혼재 메시지도 코드블럭 살림).

**#2 — 도구 가시성 분리**
- `keeper-state.ts`: `isToolConversationEntry` + `isDefaultVisibleConversationEntry` 추가. tool row를 기본 표시 집합에 포함, truly-internal(`world_state_prompt/internal_assistant/system`)만 토글 유지. 기존 `isVisibleDirectConversationEntry`는 의미 보존(테스트 green).
- `keeper-shared.ts`: 기본 필터를 새 predicate로 교체 + 나머지 두 채팅 surface에 `groupToolCalls` 적용해 "작업 과정" 카드로 통일 + 빈상태 copy 정정.

## 검증

```
tsc --noEmit            # 0 errors
eslint src              # 0 errors
vitest (영향 파일)      # 137 passed (+9 신규)
```

신규 테스트: 코드펜스/단독URL 리치 렌더, degraded p-only 블록에서도 코드블럭 복원, 카드/클립 보존, tool-vs-internal 가시성 분리.

## 경계 / 범위 밖

- 백엔드(`keeper_chat_blocks.ml`)는 **미변경** — 마크다운 렌더링은 presentation 책임이라 프론트(`marked`)에 둠. 백엔드 단순 블록은 assistant 텍스트 렌더에선 무시되나 user 메시지/fusion 보존에 여전히 사용(무해).
- credential/operator/sandbox/hooks/workflow subsystem 무관.

RFC-WAIVED: 대시보드 채팅 *렌더링* 수정(코드/도구 블록 가시성). credential/identity/operator/sandbox/Claude hooks/workflow 문서 무관 — RFC-게이트 subsystem 미해당.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
