### PR TITLE
[codex] Update Ollama Cloud runtime seed capabilities

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -85,10 +85,20 @@ supports-structured-output = true
 
 [models.deepseek-v4-flash]
 api-name = "deepseek-v4-flash"
-max-context = 262144
+max-context = 1048576
 tools-support = true
 thinking-support = true
 streaming = true
+
+[models.deepseek-v4-flash.capabilities]
+max-output-tokens = 384000
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
 
 [models.glm-4-7-coding]
 api-name = "glm-4.7"
@@ -171,20 +181,48 @@ supports-structured-output = false
 # json_object honored (clean JSON body), model "minimax-m3".
 [models.minimax-m3]
 api-name = "minimax-m3"
-max-context = 1000000
+max-context = 524288
 tools-support = true
 thinking-support = true
 streaming = true
 
 [models.minimax-m3.capabilities]
 max-output-tokens = 131072
-supports-tool-choice = true
+supports-tool-choice = false
 supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
 supports-native-streaming = true
 supports-response-format-json = true
 supports-structured-output = true
+supports-image-input = true
+supports-multimodal-inputs = true
 
 [ollama_cloud.minimax-m3]
+
+# Kimi K2.6 (Ollama Cloud) — vision-capable Cloud runtime. The model name is
+# kept separate from Kimi's direct API route; OAS owns provider/model wire
+# details and MASC declares only runtime-local concrete model capabilities.
+[models.kimi-k2-6]
+api-name = "kimi-k2.6"
+max-context = 262144
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.kimi-k2-6.capabilities]
+max-output-tokens = 32768
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-response-format-json = true
+supports-structured-output = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.kimi-k2-6]
 
 [ollama.gemma4-26b-a4b-qat]
 max-concurrent = 1

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -83,7 +83,45 @@ let test_repo_runtime_toml_loads () =
             caps.supports_tool_choice;
           check bool "GLM Coding Plan extended thinking" true
             caps.supports_extended_thinking
-        | None -> fail "expected GLM Coding Plan capabilities"))
+        | None -> fail "expected GLM Coding Plan capabilities"));
+    (match
+       List.find_opt
+         (fun (runtime : Runtime.t) ->
+            String.equal runtime.id "ollama_cloud.minimax-m3")
+         runtimes
+     with
+     | None -> fail "expected MiniMax M3 Ollama Cloud runtime in seed"
+     | Some runtime ->
+       check string "MiniMax M3 api name" "minimax-m3" runtime.model.api_name;
+       check int "MiniMax M3 context" 524288 runtime.model.max_context;
+       (match runtime.model.capabilities with
+        | Some caps ->
+          check bool "MiniMax M3 image input" true caps.supports_image_input;
+          check bool "MiniMax M3 multimodal input" true
+            caps.supports_multimodal_inputs;
+          check bool "MiniMax M3 forced tool_choice disabled" false
+            caps.supports_tool_choice
+        | None -> fail "expected MiniMax M3 capabilities"));
+    (match
+       List.find_opt
+         (fun (runtime : Runtime.t) ->
+            String.equal runtime.id "ollama_cloud.kimi-k2-6")
+         runtimes
+     with
+     | None -> fail "expected Kimi K2.6 Ollama Cloud runtime in seed"
+     | Some runtime ->
+       check string "Kimi K2.6 api name" "kimi-k2.6" runtime.model.api_name;
+       check int "Kimi K2.6 context" 262144 runtime.model.max_context;
+       (match runtime.model.capabilities with
+        | Some caps ->
+          check bool "Kimi K2.6 image input" true caps.supports_image_input;
+          check bool "Kimi K2.6 multimodal input" true
+            caps.supports_multimodal_inputs;
+          check bool "Kimi K2.6 reasoning effort" true
+            (Runtime_schema.equal_thinking_control_format
+               caps.thinking_control_format
+               Runtime_schema.Reasoning_effort)
+        | None -> fail "expected Kimi K2.6 capabilities"))
 
 let test_toml_catalog_resolves_lifecycle_keys () =
   let doc =


### PR DESCRIPTION
## Summary
- Update the MASC runtime seed for current Ollama Cloud runtimes without changing the live ~/.masc config.
- Align deepseek-v4-flash and minimax-m3 context/capability declarations with the current Ollama Cloud /api/show data.
- Keep deepseek-v4-flash out of JSON-mode librarian eligibility, preserve minimax-m3 as the JSON-capable librarian runtime, and add a vision-capable ollama_cloud.kimi-k2-6 runtime seed.
- Add runtime config tests for minimax-m3 and kimi-k2-6 image/multimodal capability declarations.

## Companion
- OAS catalog/provider-qualified lookup PR: https://github.com/jeong-sik/oas/pull/2161

## Evidence
- Official source: https://ollama.com/api/tags and https://ollama.com/api/show checked on 2026-06-19 KST.
- Related docs: https://docs.ollama.com/cloud, https://docs.ollama.com/capabilities/vision, https://docs.ollama.com/api/openai-compatibility.

## Validation
- ocamlformat --check test/test_runtime_config_validity.ml
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_runtime_config_validity.exe
- _build/default/test/test_runtime_config_validity.exe

Note: the first MASC build attempt without MASC_SKIP_PIN_CHECK stopped on existing local switch drift: installed agent_sdk 0.207.3, repo requires >= 0.207.5. The skipped-pin focused build and test passed; a later redundant build rerun was blocked by an unrelated bare dune build @check process.