### PR TITLE
[dashboard] Copilot Dock 표시 라벨을 Chat으로 변경

### DIFF
--- a/dashboard/src/components/copilot-dock.ts
+++ b/dashboard/src/components/copilot-dock.ts
@@ -248,7 +248,7 @@ export function useCopilotDockShortcuts(dock: CopilotDockApi): void {
       globalShortcutManager.register({
         id: 'copilot-dock.toggle',
         chord: { key: 'j', modifiers: ['Mod'] },
-        description: 'Toggle Copilot Dock',
+        description: 'Toggle Chat Dock',
         scope: 'global',
         preserveInInputs: false,
         action: () => { dock.toggle() },
@@ -258,7 +258,7 @@ export function useCopilotDockShortcuts(dock: CopilotDockApi): void {
       globalShortcutManager.register({
         id: 'copilot-dock.close',
         chord: { key: 'Escape', modifiers: [] },
-        description: 'Close Copilot Dock',
+        description: 'Close Chat Dock',
         scope: 'global',
         preserveInInputs: false,
         action: () => { dock.close() },
@@ -418,14 +418,14 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
       ref=${rootRef}
       class=${`v2-shell-surface dock ${docked ? 'docked' : 'float'}`}
       style=${floatStyle}
-      data-screen-label="Copilot 도크"
+      data-screen-label="Chat 도크"
       data-testid="copilot-dock"
     >
       <div
         class=${`dock-head ${docked ? '' : 'drag'}`}
         onMouseDown=${docked ? undefined : drag}
       >
-        <div class="dock-title"><span class="dock-spark">${SPARK_SVG}</span>Copilot</div>
+        <div class="dock-title"><span class="dock-spark">${SPARK_SVG}</span>Chat</div>
         <div class="spacer"></div>
         <button
           type="button"
@@ -570,10 +570,10 @@ export function CopilotDockFab({ dock }: { dock: CopilotDockApi }) {
       class="v2-shell-action dock-fab"
       onClick=${dock.open}
       data-testid="copilot-dock-fab"
-      aria-label="Open Copilot Dock"
+      aria-label="Open Chat Dock"
     >
       <span class="spark">${SPARK_SVG}</span>
-      <span>Copilot</span>
+      <span>Chat</span>
       <kbd>⌘J</kbd>
     </button>
   `
@@ -587,10 +587,10 @@ export function CopilotDockTopBarButton({ dock }: { dock: CopilotDockApi }) {
       class=${`v2-shell-action topbar-copilot ${on ? 'on' : ''}`}
       onClick=${dock.toggle}
       data-testid="copilot-dock-topbar-button"
-      aria-label="Toggle Copilot Dock"
+      aria-label="Toggle Chat Dock"
     >
       <span class="spark">${SPARK_SVG}</span>
-      <span>Copilot</span>
+      <span>Chat</span>
       <kbd>⌘J</kbd>
     </button>
   `


### PR DESCRIPTION
## 목적
대시보드 채팅 dock이 사용자에게 "Copilot"으로 표시되던 것을 "Chat"으로 변경.

## 변경 (`dashboard/src/components/copilot-dock.ts`)
사용자-facing 라벨 8곳 — "Copilot" → "Chat", "Copilot Dock" → "Chat Dock":
- 헤더 타이틀 (`dock-title`)
- FAB / TopBar 버튼 텍스트 (`<span>`)
- `aria-label` (Open/Toggle Chat Dock)
- `data-screen-label` ("Copilot 도크" → "Chat 도크")
- 단축키 설명 (command palette: Toggle/Close Chat Dock)

## 유지 (시스템 계약 — 표시 텍스트 아님)
- 식별자: `CopilotDock`, `useCopilotDock`, `CopilotDockApi`, `CopilotDockFab`, `CopilotDockTopBarButton`
- data-testid: `copilot-dock`, `copilot-dock-fab`, `copilot-dock-topbar-button` 등
- 백엔드 채널: `channel: 'copilot'` (keeper chat stream 채널 분류)
- CSS class: `topbar-copilot`
- localStorage key: `dashboard:copilot-dock` (기존 dock 상태 보존)

## 검증
- `tsc --noEmit`: green
- `eslint` (copilot-dock.ts): green
- `vitest app.test.ts` (FAB/TopBar 단언, testid 기반): 24/24 passed

## 비고
- 단일 사용자 제품, 표시 라벨만 변경 (최소 범위, surgical).
- 식별자/channel/파일명까지 전체 rename이 필요하면 별도 PR.
- RFC 대상 subsystem(credential/identity/repo/operator/sandbox/hooks/workflow) 아님.

Co-Authored-By: Claude <noreply@anthropic.com>