### PR TITLE
docs(rfc): RFC-0233 §7 amendment — Turn_ref chat↔board turn-identity

### DIFF
--- a/docs/rfc/RFC-0233-turn-observability-execution-identity.md
+++ b/docs/rfc/RFC-0233-turn-observability-execution-identity.md
@@ -3,12 +3,12 @@ rfc: "0233"
 title: "Typed turn observability: TurnRecord prompt-block provenance + canonical tool execution identity"
 status: Draft
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-06-19
 author: vincent
 supersedes: []
 superseded_by: null
-related: ["0225", "0230", "0231"]
-implementation_prs: []
+related: ["0225", "0230", "0231", "0252"]
+implementation_prs: ["20968", "20975", "20985", "20995", "21000"]
 ---
 
 # RFC-0233: TurnRecord + canonical execution identity
@@ -206,3 +206,192 @@ Ledger note: this RFC advances `.next-number` 0231→0234 in one commit —
 lane event model (doc PR #20877, implementation merged via #20896)
 without ledger advancement; skipping past both heals the drift without
 renumbering shipped references.
+
+---
+
+## §7 Amendment (2026-06-19) — `Turn_ref`: chat ↔ board turn-identity reference
+
+> Base RFC (§1–§6) is implemented and merged (2026-06-12): PR-1 #20968,
+> PR-2a #20975, PR-2b #20985, PR-3 #20995, PR-4 #21000. The front-matter
+> `status: Draft` predates those merges and should be reconciled by the
+> author. This amendment extends that identity work to the chat and board
+> surfaces; it is **Proposed** (not yet implemented). Drafted 2026-06-19
+> from the keeper-v2 "Keeper Agent v2" design hand-off (claude.ai/design
+> project `v2`, file `keeper-v2/Keeper Agent v2.html`). Linkage precedent:
+> RFC-0252 (fusion panel/judge → board post → chat block).
+
+### §7.1 Problem — the turn identity is minted but never reaches chat or board
+
+§2 gave one keeper turn a real composite identity, `(trace_id,
+absolute_turn)`, recorded on `Turn_record.t` (`lib/types/turn_record.mli:32-41`
+**(verified 2026-06-19)**) and materialized every turn at
+`lib/keeper/keeper_agent_run.ml:250-251` (`trace_id =
+Keeper_id.Trace_id.to_string meta.runtime.trace_id`; `absolute_turn =
+usage.total_turns + 1`) **(verified)**. That identity stops at the
+TurnRecord observability store. It is never threaded onto the two surfaces
+operators navigate between — the keeper **chat** and the **board**:
+
+| Layer | turn identity today | state |
+|---|---|---|
+| MASC turn record (§2.2) | `(trace_id, absolute_turn)` | present, isolated |
+| MASC chat persist | none — `chat_message` carries a per-message `msg-…` id + typed `surface : Surface_ref.t`, no turn id. The reply payload omits the turn id: `lib/keeper/keeper_turn.ml:927-965` **(verified)** emits `reply/outcome/model/turns/usage` only. | **broken (root)** |
+| MASC board post | none — `board_types` post has no originating-turn field; fusion alone smuggles `run_id` through untyped `meta_json`. | broken |
+| dashboard API | `/chat/history` carries no turn id; `TurnRecordEntry` is a disjoint feed with no shared wire key. | broken |
+| FE chat / turn inspector | matches a turn to a message by a 30-min timestamp window (`dashboard/src/components/keeper-turn-inspector.ts` **(verified 2026-06-19)**); the keeper-v2 prototype fabricates `traceId = 'trc_' + keeper.id + message.id.slice(-4)`. | broken |
+| FE board → chat | `author` (keeper) level only (`navigateToAuthor`); no turn anchor. chat → board exists for fusion only (post-level, one-way). | broken / partial |
+
+Root: the turn id is dropped at the chat-persist producer→consumer seam
+(`keeper_turn.ml:927-965`). Everything above it has a real id; everything
+below has nothing to join on, so the board↔chat-turn link the keeper-v2
+design assumes is visual-only (`docs/design/keeper-v2-v12-gap-current.md`,
+final gap item).
+
+### §7.2 Design — one canonical `Turn_ref`, minted MASC-side, carried to chat and board
+
+**Turn_ref.** A new module in `lib/types/ids.ml`, beside §2.1 `Execution_id`:
+
+```ocaml
+module Turn_ref : sig
+  type t
+  val make : trace_id:string -> absolute_turn:int -> t
+  val to_string : t -> string          (* "<trace_id>#<absolute_turn>" *)
+  val of_string : string -> t option   (* total; None on malformed, no repair *)
+  val trace_id : t -> string
+  val absolute_turn : t -> int
+end
+```
+
+- Serialization `"<trace_id>#<absolute_turn>"` is **derived deterministically**
+  from the pair §2.2 already records, so it joins against `Turn_record.t`
+  with no new mapping table and is reproducible across reloads. Not a fresh
+  UUID.
+- Named `turn_ref`, not `turn_id`: `turn_id` is already the `int` FSM turn
+  counter (`keeper_turn_fsm`); reusing the token invites a collision. The
+  legacy `Ids.Turn_id` (`<thread>-turn-N`, `ids.ml:132`) is effectively
+  unused for keeper turns and is **not** repurposed.
+
+**Flow** (mint once at the turn boundary, thread down — never re-derive
+downstream):
+
+1. Mint at `keeper_agent_run.ml:251`, where `trace_id` + `absolute_turn`
+   already exist.
+2. Stamp `turn_ref` on `Turn_record.t`.
+3. Emit `trace_id` + `turn_ref` in the reply payload (`keeper_turn.ml:945`,
+   `gate_protocol.ml`) — this closes the root seam.
+4. `extract_visible_reply` returns `turn_ref`; chat-store `append_*` accepts
+   `?turn_ref` and persists it on **every** row of the turn (user / tool /
+   assistant); `to_json_array` and the `keeper_chat_appended` SSE emit it.
+5. board post gains a typed `origin`; keeper-originated posts carry the turn
+   that produced them.
+6. dashboard API + FE carry `turn_ref` read-only for navigation.
+
+**Board `origin`.** Replace the fusion `meta_json` smuggle with a typed
+field on the board post record:
+
+```ocaml
+type post_origin =
+  { turn_ref : Ids.Turn_ref.t
+  ; source : Surface_ref.t option   (* the channel the turn entered through *)
+  ; fusion_run_id : string option   (* set for fusion posts; distinct from turn_ref *)
+  }
+(* board post record: + origin : post_origin option *)
+```
+
+threaded through the `create_post` dispatch boundary
+(`mcp_tool_runtime_board.ml:203-228`) beside `agent_name`, serialized in
+`post_to_yojson`, with a real `find_post_by_turn_ref` / `find_post_by_run_id`
+index — never a `meta_json` substring scan.
+
+**Fusion migration.** Today `Keeper_chat_blocks.fusion_block = {
+board_post_id; run_id }` (`lib/keeper/keeper_chat_blocks.mli` **(verified)**)
+and `fusion_sink` creates the board post first to obtain `post.id`, then
+attaches the chat block (the reusable bidirectional handshake, RFC-0252 §8).
+Extend the block to also carry the originating `turn_ref`, set
+`post.origin.{turn_ref; fusion_run_id = run_id}`, and keep RFC-0252 §8 as the
+visibility layer. `run_id` stays a distinct run-correlation id; it is **not**
+collapsed into `turn_ref`.
+
+**Bidirectional navigation contract.**
+
+- board post → exact chat turn: `origin.turn_ref` anchors the chat surface to
+  that turn (scroll/highlight), superseding the keeper-level `navigateToAuthor`.
+- chat turn → board post(s): fusion today; then state-block lifecycle and
+  keeper-authored posts as they gain `origin`.
+
+### §7.3 Boundary invariant (unchanged from §3)
+
+OAS owns the run/turn lifecycle and stays MASC-agnostic. OAS exposes no
+first-class per-turn id — only `(worker_run_id : string, turn : int)` on the
+event bus / `last_raw_trace_run` (**verified 2026-06-19**: `run()` does not
+return the run id). MASC joins that pair MASC-side and mints `Turn_ref`. No
+MASC concept (`turn_ref`, channel) crosses into OAS. The channel axis is
+`Surface_ref.t` (`lib/keeper/surface_ref.ml`: `Dashboard | Discord | Slack |
+Github | Webhook | Agent | Gate`). The keeper-v2 prototype's `imessage`
+source has no first-class variant today — it rides `Gate { label =
+"imessage" }`, or gains an `IMessage` variant as a closed-sum extension
+(total decode preserved) if it becomes a primary channel. **Decision
+deferred** to whoever wires the iMessage gate.
+
+### §7.4 Non-goals
+
+- No OAS API change (per §3).
+- No backfill: legacy chat rows / posts decode `turn_ref = None`; the FE
+  30-min window survives only as an explicit, commented, removal-targeted
+  fallback for `None` rows.
+- `turn_ref` does not replace `Execution_id` (tool-call identity) or fusion
+  `run_id` (run correlation); it is the turn-level join key between them.
+
+### §7.5 Migration (Proposed)
+
+Dependency-ordered. Each builds fully (`dune build --root .`) so a
+shared-record field addition catches every literal construction site (per the
+foundational-record-field rule).
+
+1. **Amendment PR-A** (RFC-gated, largest blast radius): `Ids.Turn_ref` +
+   mint at `keeper_agent_run.ml:251` + `Turn_record.t` field + reply-payload
+   `trace_id`/`turn_ref` + `extract_visible_reply` + chat-store `?turn_ref`
+   on all append sites + `to_json_array` + SSE.
+2. **Amendment PR-B** (RFC-gated, needs A): board `origin` typed field +
+   dispatch-boundary / `create_post` threading + fusion populate +
+   `find_post_by_turn_ref` / `find_post_by_run_id` index.
+3. **Amendment PR-C** (additive, low risk): dashboard API `turn_ref?` on
+   `KeeperChatHistoryMessage` + SSE; `origin?` on `BoardPost` + normalize.
+   Passes the chat-block 3-gate (backend union → zod → `normalizeBlocks`).
+4. **Amendment PR-D** (FE-only): carry `turnRef` onto
+   `KeeperConversationEntry`, remove the prototype `buildTurn()` `trc_`
+   fabrication, turn inspector matches by exact `(trace_id, absolute_turn)`,
+   add board→turn / chat→board nav actions.
+
+### §7.6 Workaround guards (rejected per CLAUDE.md §워크어라운드)
+
+1. Client-side derived turn id (the prototype's `buildTurn` `trc_…`) —
+   render-time fabrication; collides and is non-deterministic across reloads.
+   → backend-minted `Turn_ref` only.
+2. `run_id` / `meta_json` substring or prefix match (`starts_with "fus-"`) —
+   the RFC-0042 string-classifier anti-pattern. → typed `origin` + real index.
+3. 30-min timestamp-window join (already in `keeper-turn-inspector.ts`) — a
+   heuristic standing in for a missing key; mis-attributes under dense/sparse
+   turns or clock skew. → exact `(trace_id, absolute_turn)` join; keep the
+   window only as a commented, removal-targeted fallback for legacy
+   `turn_ref = None` rows.
+4. Telemetry-as-fix ("count chat rows missing turn_ref") — a counter is a
+   backfill metric, not a fix. → propagate the id so new rows never miss it.
+5. Collapsing `run_id` into `turn_ref` — distinct typed concepts (run
+   correlation vs turn identity). → keep both in `origin`.
+6. N-of-M migration (patch the dashboard append site, leave
+   discord/slack/voice/gate/fusion on `_ -> None`) → thread `turn_ref`
+   through all append sites in PR-A, or make it a required argument so the
+   compiler forces every site.
+
+### §7.7 Verification harness
+
+- Unit: `Turn_ref` `to_string`/`of_string` round-trip; `of_string` returns
+  `None` on malformed input (no repair).
+- Behavioral: drive one keeper turn → assert the same `turn_ref` appears on
+  the TurnRecord, on every chat row of that turn, and (for a fusion turn) on
+  the board post's `origin`.
+- API: `/chat/history` and `BoardPost` JSON carry `turn_ref` / `origin` for
+  new rows and `null`/absent for legacy rows.
+- FE: turn inspector opens the correct turn by id (not by window) given
+  `turn_ref`; a board post navigates to its anchored chat turn and back.
+  tsc + vitest, including a board↔chat navigation test.


### PR DESCRIPTION
## 무엇을 / 왜

Keeper Agent v2 디자인(claude.ai/design `v2`, `keeper-v2/Keeper Agent v2.html`)은 라이브 dashboard에 RFC-0253 기반으로 대부분 이식됐고, 남은 핵심 gap은 **board post ↔ keeper chat turn을 안정적 turn-identity로 잇는 hard data contract**입니다 (`docs/design/keeper-v2-v12-gap-current.md` 마지막 항목). 이 PR은 그 계약을 **설계로 확정**하기 위해 RFC-0233을 §7로 확장합니다. **docs-only — 코드 변경 없음.**

근거: RFC-0233은 turn identity `(trace_id, absolute_turn)`를 `Turn_record.t`에 materialize 했지만, 그 id가 chat/board 표면까지 배선되지 않았습니다. 끊긴 seam은 `lib/keeper/keeper_turn.ml:927-965` — reply payload가 `reply/outcome/model/turns/usage`만 emit하고 turn id를 떨어뜨립니다(검증됨). 그 위(turn record)엔 진짜 id가 있고, 아래(board/API/FE)엔 join할 키가 없어 board↔chat-turn 링크가 visual-only로 남아 있습니다.

## 변경 (docs-only)

`docs/rfc/RFC-0233-turn-observability-execution-identity.md`:
- **§7 Amendment 추가** — 단일 canonical `Turn_ref` (`"<trace_id>#<absolute_turn>"`, 기존 페어에서 결정론적 파생), 전파 경로(mint@`keeper_agent_run.ml:251` → `Turn_record.t` → reply payload → `extract_visible_reply` → chat store 모든 append → board `origin` → API → FE), board `origin` typed 필드, fusion 마이그레이션, 양방향 내비 계약, 경계 불변식(OAS 불변), non-goals, 4-PR migration, workaround guards, verification harness.
- **front-matter reconcile** — `implementation_prs` = [20968, 20975, 20985, 20995, 21000] (base PR-1~4 실제 머지 PR, GitHub에서 검증), `updated` → 2026-06-19, `related`에 0252 추가.

## RFC 인용

- 이 PR이 곧 RFC입니다 (RFC-0233 §7 확장). 신규 RFC 아님 — turn identity를 소유한 RFC-0233을 확장.
- linkage 선례: **RFC-0252** (fusion 패널/심판 → board post → chat block의 board-post-first 핸드셰이크).

## 후속 arc (RFC sign-off 후 별도 PR)

- **Amendment PR-A** (RFC-gated): 백엔드 `Turn_ref` 전파 (ids·mint·Turn_record·reply payload·chat store SSE).
- **PR-B** (RFC-gated, A 의존): board `origin` typed 필드 + fusion populate + `find_post_by_turn_ref` 인덱스.
- **PR-C** (additive): dashboard API `turn_ref?`/`origin?` + 3-게이트.
- **PR-D** (FE-only): `turnRef` 배선 + 프로토타입 `buildTurn()` fake 제거 + 정확 id 매칭 + board↔chat nav.

## 검증

- docs-only. `bash ~/me/scripts/pr-rfc-check.sh` PASS.
- 모든 anchor는 origin/main에서 직접 확인 (verified 2026-06-19 표기).
- `status: Draft`는 base 5개 PR이 모두 머지된 시점 이전 값 → Draft→Accepted/Implemented reconcile은 저자(vincent) 판단으로 남겨둠 (§7 머리말에 명시).

## Note — workaround 시그니처 false positive

본문/§7.6이 telemetry-as-fix · substring 분류기 · 30분 window · N-of-M 마이그레이션을 언급하나, 이는 본 RFC가 **거부**하는 안티패턴 목록이지 적용이 아닙니다.

WORKAROUND-WAIVED: docs-only RFC; §7.6 enumerates these signatures as patterns it REJECTS, not as changes it applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
