### PR TITLE
feat(memory-os): RFC-0259 P1 — external_ref classification + volatile valid_until

### DIFF
--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -216,6 +216,11 @@ let fact_of_json ~trace_id ~now (json : Yojson.Safe.t) : fact option =
          with a short TTL, durable knowledge with none. RFC-0247 also stopped
          parsing the LLM's [confidence] number: the score it fed is gone. *)
       let category = category_of_string category_str in
+      (* RFC-0259 §3.2: classify the claim's external referent once, here at the
+         producer boundary. A referenced claim is volatile, so [fact_valid_until]
+         gives it a finite horizon instead of the category's (possibly durable)
+         TTL — closing gap #4 (immortal volatile facts) at creation time. *)
+      let external_ref = parse_external_ref claim in
       Some
         { claim
         ; category
@@ -223,8 +228,9 @@ let fact_of_json ~trace_id ~now (json : Yojson.Safe.t) : fact option =
          (* Tier-1 (per-keeper) facts carry no distinct-keeper corroboration set;
             the consolidator populates observed_by only on promotion (RFC-0244). *)
          ; observed_by = []
+         ; external_ref
          ; first_seen = now
-         ; valid_until = category_valid_until ~now category
+         ; valid_until = fact_valid_until ~now ~external_ref category
          ; last_verified_at = Some now
          ; schema_version
          }

--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -259,8 +259,14 @@ let consolidated_fact ~now ~members (group : merge_group) =
   ; category = group.category
   ; source = earliest.source
   ; observed_by
+  ; external_ref = earliest.external_ref
   ; first_seen
-  ; valid_until = valid_until_for_group ~now ~members group.category
+  ; valid_until =
+      (* RFC-0259 §3.2: a merged claim that names external state stays volatile
+         (never durable); otherwise the group's structural expiry rule applies. *)
+      (match earliest.external_ref with
+       | Some _ as external_ref -> fact_valid_until ~now ~external_ref group.category
+       | None -> valid_until_for_group ~now ~members group.category)
   ; last_verified_at = last_verified_for_members members
   ; schema_version
   }

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -93,10 +93,16 @@ let consolidate_into_shared ~now ~min_keepers contribs =
         ; category = rep.fact.category
         ; source = rep.fact.source
         ; observed_by = keepers
+        ; external_ref = rep.fact.external_ref
         ; first_seen =
             List.fold_left (fun acc c -> Float.min acc c.fact.first_seen) rep.fact.first_seen contribs
-        ; valid_until = None
-          (* The consolidation IS the verification of the shared fact. *)
+        ; valid_until =
+            fact_valid_until ~now ~external_ref:rep.fact.external_ref rep.fact.category
+          (* Consolidation corroborates the claim across keepers and so verifies a
+             durable shared fact (last_verified_at = now, no TTL). But an
+             externally-referenced (volatile) claim still gets a finite horizon
+             (RFC-0259 §3.2): keeper agreement is not external-truth verification —
+             the P2 reconciler must re-check it against the source of truth. *)
         ; last_verified_at = Some now
         ; schema_version
         }

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -103,6 +103,120 @@ let category_valid_until ~now = function
   | Validated_approach | Lesson | Unknown _ -> None
 ;;
 
+(* ---------- External reference (RFC-0259 §3.2) ----------
+
+   A claim about volatile external state ("PR #X is merged", "issue #Y blocked")
+   was true when extracted and goes false when the world moves on. RFC-0259
+   classifies such a claim at the producer boundary so it can be (a) given a
+   finite decay horizon now, and (b) re-grounded against the source of truth by
+   the P2 reconciler later. The kind selects which source of truth to check. *)
+type external_ref_kind =
+  | Pr
+  | Issue
+  | Task
+
+(* [id] is the bare number ("21515"); [kind] selects the source of truth. *)
+type external_ref =
+  { kind : external_ref_kind
+  ; id : string
+  }
+
+let external_ref_kind_to_string = function
+  | Pr -> "pr"
+  | Issue -> "issue"
+  | Task -> "task"
+;;
+
+let external_ref_kind_of_string s =
+  match String.lowercase_ascii (String.trim s) with
+  | "pr" -> Some Pr
+  | "issue" -> Some Issue
+  | "task" -> Some Task
+  | _ -> None
+;;
+
+(* First index >= [from] at which [needle] occurs in [haystack], else None. Naive
+   scan — claims are short, so O(n*m) is fine and avoids a regex dependency. *)
+let substring_index ~haystack ~needle ~from =
+  let hl = String.length haystack
+  and nl = String.length needle in
+  if nl = 0
+  then Some from
+  else (
+    let rec loop i =
+      if i + nl > hl
+      then None
+      else if String.equal (String.sub haystack i nl) needle
+      then Some i
+      else loop (i + 1)
+    in
+    loop (max 0 from))
+;;
+
+(* Read a bare id at [start] in [s]: skip a leading '#'/space run, then take the
+   ASCII-digit run. None when no digits follow the marker. *)
+let read_ref_id s start =
+  let n = String.length s in
+  let rec skip i =
+    if i < n && (Char.equal s.[i] ' ' || Char.equal s.[i] '#') then skip (i + 1) else i
+  in
+  let j = skip start in
+  let rec digits k = if k < n && s.[k] >= '0' && s.[k] <= '9' then digits (k + 1) else k in
+  let e = digits j in
+  if e > j then Some (String.sub s j (e - j)) else None
+;;
+
+(* Explicit markers only (parse-don't-validate): a bare "#123" is left
+   unclassified because PR vs issue is ambiguous and the reconciler needs the
+   kind. Longest/most-specific markers first so "pull request #" wins over a
+   spurious "pr #" prefix match. *)
+let ref_markers =
+  [ "pull request #", Pr
+  ; "pr #", Pr
+  ; "pr#", Pr
+  ; "issue #", Issue
+  ; "issue#", Issue
+  ; "task-", Task
+  ]
+;;
+
+(* RFC-0259 §3.2: parse the first external reference a claim names. Deterministic;
+   None when the claim names no id. Run once at the producer boundary. *)
+let parse_external_ref claim =
+  let lower = String.lowercase_ascii claim in
+  let candidates =
+    List.filter_map
+      (fun (marker, kind) ->
+        match substring_index ~haystack:lower ~needle:marker ~from:0 with
+        | None -> None
+        | Some pos ->
+          (match read_ref_id lower (pos + String.length marker) with
+           | Some id -> Some (pos, { kind; id })
+           | None -> None))
+      ref_markers
+  in
+  match List.sort (fun (a, _) (b, _) -> compare (a : int) b) candidates with
+  | (_, r) :: _ -> Some r
+  | [] -> None
+;;
+
+(* RFC-0259 §3.2: an externally-referenced claim is volatile and must never be
+   durable. It is born with a finite horizon shorter than [ephemeral_ttl] —
+   external status (open/merged/blocked) moves faster than coordination
+   boilerplate. Trade-off: a still-true ref may be re-extracted after the horizon
+   (cheap), versus a stale ref driving action for ~30 turns (the RFC-0259 §2 bug).
+   When the P2 reconciler lands it advances [last_verified_at] for confirmed refs;
+   until then this TTL is the sole backstop against immortal volatile facts. *)
+let volatile_ref_ttl_seconds = 21_600.0
+
+(* The fact-level retention horizon: an external reference forces a finite TTL
+   (closing gap #4) and otherwise the category decides (RFC-0247). *)
+let fact_valid_until ~now ~external_ref category =
+  match external_ref with
+  | Some _ -> Some (now +. volatile_ref_ttl_seconds)
+  | None -> category_valid_until ~now category
+;;
+
 (* RFC-0247 (purge): the fact carries only structure — the claim, its typed
    category, provenance, the distinct-keeper corroboration set, and three
    timestamps (first_seen, optional last_verified_at, optional Ephemeral
@@ -118,6 +232,11 @@ type fact =
        keeper ids that have corroborated this claim. Empty for Tier-1 per-keeper
        facts — a single keeper's store has no distinct keeper-source to track, so
        it is omitted from their JSON. *)
+  ; external_ref : external_ref option
+    (* RFC-0259 §3.2: [Some] when the claim names verifiable external state
+       (PR/issue/task id). Such a fact is volatile — never durable — so it is
+       born with a finite [valid_until]; [None] for claims with no external
+       referent (those follow the category's retention). *)
   ; first_seen : float
   ; valid_until : float option
   ; last_verified_at : float option
@@ -182,6 +301,25 @@ let json_string_list_field key (fields : (string * Yojson.Safe.t) list) =
     if List.length strings = List.length items then Some strings else None
   | Some (`Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _)
   | None -> None
+;;
+
+let external_ref_to_json (r : external_ref) =
+  `Assoc
+    [ "kind", `String (external_ref_kind_to_string r.kind)
+    ; "id", `String r.id
+    ]
+;;
+
+let external_ref_of_json (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+    (match json_string_field "kind" fields, json_string_field "id" fields with
+     | Some kind_str, Some id ->
+       (match external_ref_kind_of_string kind_str with
+        | Some kind -> Some { kind; id }
+        | None -> None)
+     | (Some _, None) | (None, Some _) | (None, None) -> None)
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
 ;;
 
 let provenance_event_to_json (e : provenance_event) =
@@ -250,6 +388,11 @@ let fact_to_json f =
     ]
     @ optional_float_field "valid_until" f.valid_until
     @ optional_float_field "last_verified_at" f.last_verified_at
+    (* Omitted when [None] so facts with no external referent stay byte-identical
+       to pre-RFC-0259 rows; only externally-referenced claims emit it. *)
+    @ (match f.external_ref with
+       | Some r -> [ "external_ref", external_ref_to_json r ]
+       | None -> [])
     (* Tier-1 facts carry [], which is omitted so per-keeper stores stay
        byte-identical to pre-RFC-0244; only Tier-2 shared facts emit it. *)
     @ (match f.observed_by with
@@ -285,6 +428,15 @@ let fact_of_json (json : Yojson.Safe.t) =
           let observed_by =
             Option.value (json_string_list_field "observed_by" fields) ~default:[]
           in
+          (* Round-trip only: classification happens once at the producer boundary
+             (Keeper_librarian.fact_of_json), so a legacy row with no key reads as
+             [None] here rather than being re-parsed — keeps the
+             external_ref=Some ⟹ valid_until=Some invariant a producer property. *)
+          let external_ref =
+            match List.assoc_opt "external_ref" fields with
+            | Some json -> external_ref_of_json json
+            | None -> None
+          in
           Some
             { claim
             ; (* Parse-once at the read boundary; legacy free-string categories
@@ -292,6 +444,7 @@ let fact_of_json (json : Yojson.Safe.t) =
               category = category_of_string category_str
             ; source
             ; observed_by
+            ; external_ref
             ; first_seen
             ; valid_until
             ; last_verified_at

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -74,6 +74,43 @@ val is_promotable : category -> bool
     pass) reachable. *)
 val category_valid_until : now:float -> category -> float option
 
+(** RFC-0259 §3.2: the kind of verifiable external state a claim names. Closed sum
+    so the P2 reconciler's [verify_external] must handle every arm at compile
+    time. *)
+type external_ref_kind =
+  | Pr
+  | Issue
+  | Task
+
+(** A parsed external reference: [id] is the bare number ("21515"), [kind] selects
+    the source of truth to re-check it against. *)
+type external_ref =
+  { kind : external_ref_kind
+  ; id : string
+  }
+
+val external_ref_kind_to_string : external_ref_kind -> string
+val external_ref_kind_of_string : string -> external_ref_kind option
+
+(** RFC-0259 §3.2: parse the first PR/issue/task id a claim names. Deterministic;
+    [None] when the claim carries no explicit "PR #/issue #/task-" marker followed
+    by digits. Run once at the producer boundary (parse-don't-validate). *)
+val parse_external_ref : string -> external_ref option
+
+(** RFC-0259 §3.2: the finite decay horizon an externally-referenced (volatile)
+    claim is born with — deliberately shorter than the ephemeral TTL because
+    external status moves faster than coordination boilerplate. *)
+val volatile_ref_ttl_seconds : float
+
+(** Fact-level retention horizon: an [external_ref = Some _] forces
+    [volatile_ref_ttl_seconds] (closing RFC-0259 gap #4 at the producer), and
+    otherwise the category decides via {!category_valid_until}. *)
+val fact_valid_until
+  :  now:float
+  -> external_ref:external_ref option
+  -> category
+  -> float option
+
 (** A single semantic claim extracted from conversation history.
 
     RFC-0247 (purge): the fact carries only structure — claim, typed category,
@@ -89,6 +126,10 @@ type fact =
     (** RFC-0244 Tier 2 (shared semantic store) only: the sorted set of distinct
         keeper ids that have corroborated this claim. Empty for Tier-1 per-keeper
         facts (omitted from their JSON). Populated by the consolidator. *)
+  ; external_ref : external_ref option
+    (** RFC-0259 §3.2: [Some] when the claim names verifiable external state
+        (PR/issue/task id) — such a fact is volatile, never durable, so it is born
+        with a finite [valid_until]. [None] follows the category's retention. *)
   ; first_seen : float
   ; valid_until : float option
   ; last_verified_at : float option

--- a/test/dune
+++ b/test/dune
@@ -29,6 +29,7 @@
 
 (tests
  (names
+  test_rfc0259_external_ref
   test_keeper_memory_lane
   test_keeper_reactive_wake_backlog_gate
   test_broadcast_wakeup_policy
@@ -326,6 +327,7 @@
   test_relation_materializer
   test_keeper_behavior_trace)
  (modules
+  test_rfc0259_external_ref
   test_keeper_memory_lane
   test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate

--- a/test/memory_os_brain_harness.ml
+++ b/test/memory_os_brain_harness.ml
@@ -87,6 +87,7 @@ let mk_fact
   ; Types.category
   ; Types.source = { Types.trace_id = "harness-trace"; Types.turn = 1; Types.tool_call_id = None }
   ; Types.observed_by = []
+  ; Types.external_ref = None
   ; Types.first_seen = now -. age_seconds
   ; Types.valid_until
   ; Types.last_verified_at = Some (now -. age_seconds)

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -55,6 +55,7 @@ let fact_fixture ~now () =
   ; Types.category = Types.Preference
   ; Types.source = { Types.trace_id = "trace-123"; Types.turn = 5; Types.tool_call_id = None }
   ; Types.observed_by = []
+  ; Types.external_ref = None
   ; Types.first_seen = now -. 86400.0
   ; Types.valid_until = None
   ; Types.last_verified_at = Some (now -. 3600.0)

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -11,6 +11,7 @@ let fact
       ?valid_until
       ?last_verified_at
       ?(observed_by = [])
+      ?(external_ref = None)
       claim
   =
   let last_verified_at =
@@ -22,6 +23,7 @@ let fact
   ; category
   ; source = { Types.trace_id = "t"; turn = 1; tool_call_id = None }
   ; observed_by
+  ; external_ref
   ; first_seen
   ; valid_until
   ; last_verified_at

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -13,6 +13,7 @@ let fact claim =
   ; category = Types.Fact
   ; source = { Types.trace_id = "t"; turn = 1; tool_call_id = None }
   ; observed_by = []
+  ; external_ref = None
   ; first_seen = now
   ; valid_until = None
   ; last_verified_at = Some now

--- a/test/test_rfc0259_external_ref.ml
+++ b/test/test_rfc0259_external_ref.ml
@@ -1,0 +1,172 @@
+(** RFC-0259 P1 — external_ref classification + volatile valid_until.
+
+    Pins the two type-level guarantees P1 ships:
+    1. [parse_external_ref] deterministically classifies the first PR/issue/task
+       id a claim names (and only an explicit marker, never a bare "#123").
+    2. [fact_valid_until] gives an externally-referenced claim a finite horizon
+       (closing gap #4: immortal volatile facts) while leaving non-referenced
+       durable claims durable — and round-trips through the JSON codec. *)
+
+module Types = Masc.Keeper_memory_os_types
+
+let now = 1_000_000.0
+
+(* ---------- parse_external_ref ---------- *)
+
+let ref_testable =
+  Alcotest.testable
+    (fun ppf -> function
+      | None -> Format.fprintf ppf "None"
+      | Some (r : Types.external_ref) ->
+        Format.fprintf
+          ppf
+          "Some(%s #%s)"
+          (Types.external_ref_kind_to_string r.kind)
+          r.id)
+    ( = )
+;;
+
+let check_ref name expected claim =
+  Alcotest.check ref_testable name expected (Types.parse_external_ref claim)
+;;
+
+let test_parse_pr () =
+  check_ref "PR marker" (Some { Types.kind = Pr; id = "21515" }) "PR #21515 is merged";
+  check_ref "lowercase pr" (Some { Types.kind = Pr; id = "5" }) "fixing pr #5 now";
+  check_ref "pull request" (Some { Types.kind = Pr; id = "99" }) "pull request #99 blocked";
+  check_ref "no space" (Some { Types.kind = Pr; id = "7" }) "pr#7 landed"
+;;
+
+let test_parse_issue () =
+  check_ref "issue marker" (Some { Types.kind = Issue; id = "123" }) "issue #123 is open";
+  check_ref "issue no space" (Some { Types.kind = Issue; id = "8" }) "issue#8"
+;;
+
+let test_parse_task () =
+  check_ref "task marker" (Some { Types.kind = Task; id = "1418" }) "task-1418 needs work"
+;;
+
+let test_parse_none () =
+  check_ref "no reference" None "deployment uses blue-green";
+  (* bare "#123" is ambiguous (PR vs issue) → left unclassified on purpose *)
+  check_ref "bare hash ambiguous" None "see #123 for details";
+  check_ref "marker without digits" None "the PR # is unknown"
+;;
+
+let test_parse_first () =
+  (* the earliest-positioned reference wins (RFC-0259: "the first id") *)
+  check_ref
+    "first of many"
+    (Some { Types.kind = Pr; id = "21515" })
+    "PR #21515 supersedes issue #99"
+;;
+
+(* ---------- fact_valid_until ---------- *)
+
+let opt_float = Alcotest.(option (float 0.001))
+
+let test_valid_until_volatile () =
+  (* gap #4 closed: an externally-referenced Fact is NOT durable *)
+  Alcotest.check
+    opt_float
+    "ref forces finite TTL"
+    (Some (now +. Types.volatile_ref_ttl_seconds))
+    (Types.fact_valid_until
+       ~now
+       ~external_ref:(Some { Types.kind = Pr; id = "1" })
+       Types.Fact)
+;;
+
+let test_valid_until_durable_preserved () =
+  (* a durable claim with no external referent stays durable (RFC-0247) *)
+  Alcotest.check
+    opt_float
+    "durable Fact stays durable"
+    None
+    (Types.fact_valid_until ~now ~external_ref:None Types.Fact)
+;;
+
+let test_valid_until_ephemeral () =
+  Alcotest.check
+    opt_float
+    "ephemeral keeps its TTL"
+    (Some (now +. 86_400.0))
+    (Types.fact_valid_until ~now ~external_ref:None Types.Ephemeral)
+;;
+
+(* ---------- JSON round-trip ---------- *)
+
+let sample_fact ~external_ref =
+  { Types.claim = "PR #21515 is merged"
+  ; category = Types.Fact
+  ; source = { Types.trace_id = "t"; turn = 1; tool_call_id = None }
+  ; observed_by = []
+  ; external_ref
+  ; first_seen = now
+  ; valid_until = Types.fact_valid_until ~now ~external_ref Types.Fact
+  ; last_verified_at = Some now
+  ; schema_version = Types.schema_version
+  }
+;;
+
+let roundtrip f =
+  match Types.fact_of_json (Types.fact_to_json f) with
+  | Some f' -> f'
+  | None -> Alcotest.fail "fact_of_json returned None"
+;;
+
+let test_roundtrip_some () =
+  let f = sample_fact ~external_ref:(Some { Types.kind = Pr; id = "21515" }) in
+  let f' = roundtrip f in
+  Alcotest.check
+    ref_testable
+    "external_ref preserved"
+    (Some { Types.kind = Pr; id = "21515" })
+    f'.Types.external_ref
+;;
+
+let test_roundtrip_none () =
+  let f = sample_fact ~external_ref:None in
+  let f' = roundtrip f in
+  Alcotest.check ref_testable "no ref stays none" None f'.Types.external_ref
+;;
+
+let test_roundtrip_legacy () =
+  (* a legacy row with no external_ref key decodes to None — the disk codec does
+     not re-parse (classification is a producer-boundary property). *)
+  let json =
+    `Assoc
+      [ "claim", `String "PR #999 merged"
+      ; "category", `String "fact"
+      ; "source", `Assoc [ "trace_id", `String "t"; "turn", `Int 1 ]
+      ; "first_seen", `Float now
+      ; "schema_version", `String Types.schema_version
+      ]
+  in
+  match Types.fact_of_json json with
+  | Some f -> Alcotest.check ref_testable "legacy no-key -> None" None f.Types.external_ref
+  | None -> Alcotest.fail "legacy decode failed"
+;;
+
+let () =
+  Alcotest.run
+    "rfc0259_external_ref"
+    [ ( "parse"
+      , [ Alcotest.test_case "pr" `Quick test_parse_pr
+        ; Alcotest.test_case "issue" `Quick test_parse_issue
+        ; Alcotest.test_case "task" `Quick test_parse_task
+        ; Alcotest.test_case "none" `Quick test_parse_none
+        ; Alcotest.test_case "first-wins" `Quick test_parse_first
+        ] )
+    ; ( "valid_until"
+      , [ Alcotest.test_case "volatile" `Quick test_valid_until_volatile
+        ; Alcotest.test_case "durable-preserved" `Quick test_valid_until_durable_preserved
+        ; Alcotest.test_case "ephemeral" `Quick test_valid_until_ephemeral
+        ] )
+    ; ( "roundtrip"
+      , [ Alcotest.test_case "some" `Quick test_roundtrip_some
+        ; Alcotest.test_case "none" `Quick test_roundtrip_none
+        ; Alcotest.test_case "legacy" `Quick test_roundtrip_legacy
+        ] )
+    ]
+;;


### PR DESCRIPTION
## RFC-0259 P1 — external_ref classification + volatile valid_until

RFC: `docs/rfc/RFC-0259-memory-os-volatile-claim-grounding-retraction-decay.md` (MERGED #21539)

### 문제 (라이브 증거)
키퍼가 volatile external state("PR #X merged", "issue #Y blocked")를 **durable** fact(`valid_until = None`)로 박고, retraction/grounding/decay 부재로 ~30턴 재주입된다. 2026-06-19 `issue_king`이 존재하지 않는 #21515 syntax error를 confabulate하고 권한 escalation을 요구한 사건이 이 버그의 라이브 실증이다(라이브 store 9개 키퍼에서 85개 stale/false fact 수동 purge로 즉시 완화함).

### 범위 (P1만)
RFC-0259 §3.2 / Phasing **P1**: `external_ref` 분류 + volatile `valid_until`. RFC 근본 원인표의 **gap #4 (durable facts are immortal)**를 타입 레벨에서 닫는다. P2(reconciler) / P3(retraction) / P4(recall suppression)는 후속 PR.

### 변경
- `keeper_memory_os_types.ml/.mli`: `external_ref_kind = Pr | Issue | Task` (닫힌 sum), `external_ref` 타입, `parse_external_ref`(결정론 파서 — 명시적 `PR #/pull request #/issue #/task-` 마커 + digits만, 모호한 bare `#123`은 분류 안 함), `volatile_ref_ttl_seconds`(6h), `fact_valid_until`(external_ref=Some → finite TTL, else category). `fact` 레코드에 `external_ref` 필드 + JSON round-trip.
- `keeper_librarian.ml`: producer 경계(LLM→fact)에서 claim 파싱 → external_ref + volatile valid_until.
- `keeper_memory_os_consolidation.ml` / `keeper_memory_os_consolidator.ml`: Tier2 promotion에서 external_ref 보존 + volatile TTL (keeper 동의는 external-truth 검증이 아니므로 volatile claim은 여전히 finite horizon).

### 경계 (설계 근거)
- 파싱은 **producer 경계 한 곳**(librarian)에서만. 디스크 역직렬화는 JSON 키 round-trip만(재파싱 안 함) — 불변식 `external_ref=Some ⟹ valid_until=Some`을 producer 속성으로 유지(디스크 read엔 `now`가 없어 TTL 재계산 불가).
- legacy 디스크 행은 `None`으로 로드 → librarian 재관찰 시 자연 마이그레이션. P1은 신규 생성 경로에서 gap #4를 닫고, 기존 store는 위 수동 purge + P2 reconciler가 처리.

### 검증
- 신규 `test/test_rfc0259_external_ref.ml`: parse(pr/issue/task/none/first-wins), valid_until(volatile/durable-preserved/ephemeral), round-trip(some/none/legacy) — **11/11 통과**.
- 회귀: `test_keeper_memory_os_consolidation`, `_consolidation_runtime`, `memory_os_brain_harness` 통과.
- `test_keeper_memory_os`의 `json` #14 (generation Expected `7` / Received `0`)은 **pre-existing base-broken**: `git stash -u`로 base(origin/main `8c67fd65b8`)에서 동일한 단일 실패를 재현 확인 — generation 넘버링 이슈로 본 PR과 무관.
- `dune build @check` green, `dune build @fmt` 내 파일 clean.

### 워크어라운드 게이트
해당 없음. telemetry-as-fix / string-classifier / N-of-M 시그니처 없음. `external_ref`는 닫힌 sum + exhaustive로 typed boundary를 *추가*(string 분류기 보강 아님). RFC-0259가 명세한 구조적 근본 수정.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
