### PR TITLE
fix(ci): boot release-evidence smoke with a catalog-known model

### DIFF
--- a/scripts/release-evidence.sh
+++ b/scripts/release-evidence.sh
@@ -226,20 +226,30 @@ copy_install_smoke() {
   cp config/tool_policy.toml "$base_path/.masc/config/tool_policy.toml"
   cat >"$base_path/.masc/config/runtime.toml" <<'EOF'
 [runtime]
-default = "release_evidence.smoke"
+# The smoke runtime's model id must be known to the OAS capability catalog, or
+# the startup capability gate (validate_runtime_model_capabilities, RFC-0206)
+# refuses to boot (a fixture model named "smoke" is absent from the catalog and
+# was rejected, breaking this evidence step on every OCaml push to main).
+# deepseek-v4-flash is the catalog-known fleet default; the provider endpoint
+# below is an isolated dead port and MASC_KEEPER_BOOTSTRAP_ENABLED=false, so no
+# real provider call is made — this fixture only checks the binary boots and
+# serves /health. The [models.deepseek-v4-flash] block mirrors
+# config/runtime.toml's shape so the runtime resolves; its model id is what the
+# gate matches against the catalog.
+default = "release_evidence.deepseek-v4-flash"
 
 [providers.release_evidence]
 display-name = "Release Evidence Smoke"
 protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:9/v1"
 
-[models.smoke]
-api-name = "smoke"
+[models.deepseek-v4-flash]
+api-name = "deepseek-v4-flash"
 max-context = 32768
 tools-support = true
 streaming = true
 
-[release_evidence.smoke]
+[release_evidence.deepseek-v4-flash]
 is-default = true
 max-concurrent = 1
 EOF


### PR DESCRIPTION
## 목표

`Generate main release evidence bundle` step이 capability gate에 거부되어 OCaml(lib/bin/test) push마다 fail하는 **잠복 main red**를 복구한다.

## 증상 / 재현

이 step은 `push && main`에서만 실행되어 PR CI(pull_request)는 surface하지 않는다. lib/bin/test 변경이 main에 머지되면 Build and Test job이 돌면서:

```
Runtime.init_default_strict failed (fatal, refusing to boot):
  release_evidence.smoke (model=smoke) — 1 runtime model absent from OAS capability catalog
```

최근 main이 green인 건 dashboard/docs-only 커밋이라 build job이 path filter로 skip된 착시이며, 결함은 그대로 잠복해 있었다.

## 원인

- #21607(`e2abe2508a`)이 startup capability gate(`validate_runtime_model_capabilities`)를 server boot에 도입하며 `scripts/release-evidence.sh`의 fixture를 고려하지 않음.
- #21638이 gate를 `init_default_strict`로 옮겨 server boot 경로에 유지(동작 보존).
- `release-binary-smoke.sh`는 repo `config/runtime.toml`(catalog-known `deepseek-v4-flash`)을 복사해 통과하지만, `release-evidence.sh`만 catalog 부재 model `smoke`를 생성 → gate 거부. 두 smoke 스크립트의 config 전략 불일치가 표면화된 것.

## 변경

`release-evidence.sh`의 smoke runtime.toml model을 `smoke` → catalog-known `deepseek-v4-flash`로 변경. provider endpoint는 isolated dead port(`127.0.0.1:9`) 유지 + `MASC_KEEPER_BOOTSTRAP_ENABLED=false`라 실제 provider 호출은 0. fixture는 여전히 binary boot + `/health`만 검증한다. `[models.deepseek-v4-flash]` 블록은 `config/runtime.toml`의 `[provider.model-id]` 형태를 따라 runtime이 resolve되도록 한다.

## 검증 (로컬)

동일한 `main_eio.exe`로 before/after 대조:

- before (model=smoke): `exit 1`, `release_evidence.smoke (model=smoke) absent from the OAS capability catalog`
- after (model=deepseek-v4-flash): `exit 0`, evidence bundle(78 lines) 생성, gate/health 에러 없음

## 설계 근거

capability gate(RFC-0206 §2.1 no-silent-fallback)는 production operator runtime.toml의 catalog 미등록 model을 boot 전 거부하는 보호 장치다. release-evidence는 실제 LLM 호출이 없는 CI fixture이므로, gate를 우회/약화하지 않고 catalog-known model id로 정렬해 정당하게 통과한다. OCaml 코드 무변경 — capability gate의 production 보호는 그대로 유지된다.

RFC-WAIVED: scripts-only CI fixture 변경. credential/identity/operator/sandbox/dashboard/hooks/workflow subsystem 미해당이며 capability gate 코드는 변경하지 않는다(RFC-0206 경계 준수).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
