### PR TITLE
fix(task): drop unimplemented auto-link claim from goal_id tool schema

### DIFF
--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -53,7 +53,7 @@ Example: %s({title: 'Fix login bug', priority: 1, description: 'Users cannot log
         ]);
         ("goal_id", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional structured goal link for rollups. If omitted, scoped agents may auto-link a single active goal; otherwise the task remains unscoped.");
+          ("description", `String "Optional structured goal link for rollups. If omitted, the task is created unscoped (goalless); pass goal_id explicitly to link it to a goal.");
         ]);
         ("contract", `Assoc [
           ("type", `String "object");
@@ -111,7 +111,7 @@ Example: masc_batch_add_tasks({tasks: [{title: 'Task A', priority: 2}, {title: '
               ]);
               ("goal_id", `Assoc [
                 ("type", `String "string");
-                ("description", `String "Optional structured goal link for rollups. If omitted, scoped agents may auto-link a single active goal; otherwise the task remains unscoped.");
+                ("description", `String "Optional structured goal link for rollups. If omitted, the task is created unscoped (goalless); pass goal_id explicitly to link it to a goal.");
               ]);
               ("contract", `Assoc [
                 ("type", `String "object");


### PR DESCRIPTION
## 배경

Work 보드 조사(#21645) 중 라이브 task 24개가 전부 `goal_id=null`인 이유를 추적하다 발견. add_task/batch 도구 스키마의 `goal_id` 설명이 존재하지 않는 동작을 약속하고 있었다.

## 결함

스키마 설명(`tool_task_schemas.ml`):
> "Optional structured goal link for rollups. If omitted, scoped agents **may auto-link a single active goal**; otherwise the task remains unscoped."

이 auto-link은 **구현돼 있지 않다**. `link_task_to_goal` 호출처는 정확히 2곳(`workspace_goal_index.ml`, `workspace_task_create.ml`)이고 둘 다 **명시적 goal_id가 있을 때만** 실행된다. goal_id를 생략하면 생성 agent의 active goal로 사후 연결하는 turn-hook/스케줄러도 없다(`handle_add_task` `tool_task_handlers.ml:270-314`, `workspace_task_create.add_task:116-119` 확인).

결과: 명시적 goal_id 없이 만든 task는 전부 goalless. 이건 버그가 아니라 **의도된 상태**다 — `RFC-0245`가 goalless WIP를 per-goal cap에서 면제한다. 유일한 결함은 **존재하지 않는 컨트롤을 약속한 스키마 텍스트**(introspection/description drift).

## 변경

add_task + batch_add_tasks 두 설명을 실제 동작으로 정정:
> "...If omitted, the task is created unscoped (goalless); pass goal_id explicitly to link it to a goal."

순수 description 수정 — 동작 변경 0, LLM-visible 텍스트만 바뀜.

## 검증

- `dune build @lib/task/check` — exit 0
- description-lock/스냅샷 테스트 없음(grep 확인) → 깨지는 테스트 없음

RFC-WAIVED: task 도구 스키마 description-only 정정으로 credential/operator/sandbox/hooks/workflow subsystem 무관. 동작·바인딩 의미 변경 없음.
