### PR TITLE
[codex] Add all Ollama Cloud runtime seed models

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -224,6 +224,642 @@ supports-multimodal-inputs = true
 
 [ollama_cloud.kimi-k2-6]
 
+# Ollama Cloud canonical model seeds
+# Source: https://ollama.com/api/tags + /api/show, checked 2026-06-20 KST.
+# Runtime model keys are TOML-safe slugs; api-name preserves the official Cloud model id.
+
+[models.ollama-cloud-deepseek-v3-1-671b]
+api-name = "deepseek-v3.1:671b"
+max-context = 163840
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-deepseek-v3-1-671b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-deepseek-v3-1-671b]
+
+[models.ollama-cloud-deepseek-v3-2]
+api-name = "deepseek-v3.2"
+max-context = 163840
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-deepseek-v3-2.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-deepseek-v3-2]
+
+[models.ollama-cloud-deepseek-v4-flash]
+api-name = "deepseek-v4-flash"
+max-context = 1048576
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-deepseek-v4-flash.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-deepseek-v4-flash]
+
+[models.ollama-cloud-deepseek-v4-pro]
+api-name = "deepseek-v4-pro"
+max-context = 524288
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-deepseek-v4-pro.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-deepseek-v4-pro]
+
+[models.ollama-cloud-devstral-2-123b]
+api-name = "devstral-2:123b"
+max-context = 262144
+tools-support = true
+thinking-support = false
+streaming = true
+
+[models.ollama-cloud-devstral-2-123b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = false
+supports-reasoning-budget = false
+thinking-control-format = "none"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-devstral-2-123b]
+
+[models.ollama-cloud-devstral-small-2-24b]
+api-name = "devstral-small-2:24b"
+max-context = 262144
+tools-support = true
+thinking-support = false
+streaming = true
+
+[models.ollama-cloud-devstral-small-2-24b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = false
+supports-reasoning-budget = false
+thinking-control-format = "none"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-devstral-small-2-24b]
+
+[models.ollama-cloud-gemini-3-flash-preview]
+api-name = "gemini-3-flash-preview"
+max-context = 1048576
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-gemini-3-flash-preview.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-gemini-3-flash-preview]
+
+[models.ollama-cloud-gemma3-4b]
+api-name = "gemma3:4b"
+max-context = 131072
+tools-support = false
+thinking-support = false
+streaming = true
+
+[models.ollama-cloud-gemma3-4b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = false
+supports-reasoning-budget = false
+thinking-control-format = "none"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-gemma3-4b]
+
+[models.ollama-cloud-gemma3-12b]
+api-name = "gemma3:12b"
+max-context = 131072
+tools-support = false
+thinking-support = false
+streaming = true
+
+[models.ollama-cloud-gemma3-12b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = false
+supports-reasoning-budget = false
+thinking-control-format = "none"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-gemma3-12b]
+
+[models.ollama-cloud-gemma3-27b]
+api-name = "gemma3:27b"
+max-context = 131072
+tools-support = false
+thinking-support = false
+streaming = true
+
+[models.ollama-cloud-gemma3-27b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = false
+supports-reasoning-budget = false
+thinking-control-format = "none"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-gemma3-27b]
+
+[models.ollama-cloud-gemma4-31b]
+api-name = "gemma4:31b"
+max-context = 262144
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-gemma4-31b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-gemma4-31b]
+
+[models.ollama-cloud-glm-4-7]
+api-name = "glm-4.7"
+max-context = 202752
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-glm-4-7.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-glm-4-7]
+
+[models.ollama-cloud-glm-5]
+api-name = "glm-5"
+max-context = 202752
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-glm-5.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-glm-5]
+
+[models.ollama-cloud-glm-5-1]
+api-name = "glm-5.1"
+max-context = 202752
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-glm-5-1.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-glm-5-1]
+
+[models.ollama-cloud-glm-5-2]
+api-name = "glm-5.2"
+max-context = 1000000
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-glm-5-2.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-glm-5-2]
+
+[models.ollama-cloud-gpt-oss-20b]
+api-name = "gpt-oss:20b"
+max-context = 131072
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-gpt-oss-20b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-gpt-oss-20b]
+
+[models.ollama-cloud-gpt-oss-120b]
+api-name = "gpt-oss:120b"
+max-context = 131072
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-gpt-oss-120b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-gpt-oss-120b]
+
+[models.ollama-cloud-kimi-k2-5]
+api-name = "kimi-k2.5"
+max-context = 262144
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-kimi-k2-5.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-kimi-k2-5]
+
+[models.ollama-cloud-kimi-k2-6]
+api-name = "kimi-k2.6"
+max-context = 262144
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-kimi-k2-6.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-kimi-k2-6]
+
+[models.ollama-cloud-kimi-k2-7-code]
+api-name = "kimi-k2.7-code"
+max-context = 262144
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-kimi-k2-7-code.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-kimi-k2-7-code]
+
+[models.ollama-cloud-minimax-m2-1]
+api-name = "minimax-m2.1"
+max-context = 204800
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-minimax-m2-1.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-minimax-m2-1]
+
+[models.ollama-cloud-minimax-m2-5]
+api-name = "minimax-m2.5"
+max-context = 196608
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-minimax-m2-5.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-minimax-m2-5]
+
+[models.ollama-cloud-minimax-m2-7]
+api-name = "minimax-m2.7"
+max-context = 196608
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-minimax-m2-7.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-minimax-m2-7]
+
+[models.ollama-cloud-minimax-m3]
+api-name = "minimax-m3"
+max-context = 524288
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-minimax-m3.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-response-format-json = true
+supports-structured-output = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-minimax-m3]
+
+[models.ollama-cloud-ministral-3-3b]
+api-name = "ministral-3:3b"
+max-context = 262144
+tools-support = true
+thinking-support = false
+streaming = true
+
+[models.ollama-cloud-ministral-3-3b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = false
+supports-reasoning-budget = false
+thinking-control-format = "none"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-ministral-3-3b]
+
+[models.ollama-cloud-ministral-3-8b]
+api-name = "ministral-3:8b"
+max-context = 262144
+tools-support = true
+thinking-support = false
+streaming = true
+
+[models.ollama-cloud-ministral-3-8b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = false
+supports-reasoning-budget = false
+thinking-control-format = "none"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-ministral-3-8b]
+
+[models.ollama-cloud-ministral-3-14b]
+api-name = "ministral-3:14b"
+max-context = 262144
+tools-support = true
+thinking-support = false
+streaming = true
+
+[models.ollama-cloud-ministral-3-14b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = false
+supports-reasoning-budget = false
+thinking-control-format = "none"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-ministral-3-14b]
+
+[models.ollama-cloud-mistral-large-3-675b]
+api-name = "mistral-large-3:675b"
+max-context = 262144
+tools-support = true
+thinking-support = false
+streaming = true
+
+[models.ollama-cloud-mistral-large-3-675b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = false
+supports-reasoning-budget = false
+thinking-control-format = "none"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-mistral-large-3-675b]
+
+[models.ollama-cloud-nemotron-3-nano-30b]
+api-name = "nemotron-3-nano:30b"
+max-context = 262144
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-nemotron-3-nano-30b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-nemotron-3-nano-30b]
+
+[models.ollama-cloud-nemotron-3-super]
+api-name = "nemotron-3-super"
+max-context = 262144
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-nemotron-3-super.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-nemotron-3-super]
+
+[models.ollama-cloud-nemotron-3-ultra]
+api-name = "nemotron-3-ultra"
+max-context = 262144
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-nemotron-3-ultra.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-nemotron-3-ultra]
+
+[models.ollama-cloud-qwen3-coder-480b]
+api-name = "qwen3-coder:480b"
+max-context = 262144
+tools-support = true
+thinking-support = false
+streaming = true
+
+[models.ollama-cloud-qwen3-coder-480b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = false
+supports-reasoning-budget = false
+thinking-control-format = "none"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-qwen3-coder-480b]
+
+[models.ollama-cloud-qwen3-coder-next]
+api-name = "qwen3-coder-next"
+max-context = 262144
+tools-support = true
+thinking-support = false
+streaming = true
+
+[models.ollama-cloud-qwen3-coder-next.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = false
+supports-reasoning-budget = false
+thinking-control-format = "none"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-qwen3-coder-next]
+
+[models.ollama-cloud-qwen3-5-397b]
+api-name = "qwen3.5:397b"
+max-context = 262144
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-qwen3-5-397b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-native-streaming = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud.ollama-cloud-qwen3-5-397b]
+
+[models.ollama-cloud-rnj-1-8b]
+api-name = "rnj-1:8b"
+max-context = 32768
+tools-support = true
+thinking-support = false
+streaming = true
+
+[models.ollama-cloud-rnj-1-8b.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = false
+supports-reasoning-budget = false
+thinking-control-format = "none"
+supports-native-streaming = true
+supports-image-input = false
+supports-multimodal-inputs = false
+
+[ollama_cloud.ollama-cloud-rnj-1-8b]
+
 [ollama.gemma4-26b-a4b-qat]
 max-concurrent = 1
 

--- a/oas-models.toml
+++ b/oas-models.toml
@@ -114,3 +114,936 @@ supports_native_streaming = true
 supports_seed = true
 input_per_million = 0.0
 output_per_million = 0.0
+
+# Ollama Cloud Models (canonical 2026-06 seed)
+# Source: https://ollama.com/api/tags + /api/show, checked 2026-06-20 KST.
+# Provider-qualified entries preserve Ollama Cloud wire behavior when a model id overlaps another provider.
+
+[[models]]
+id_prefix = "ollama_cloud/deepseek-v3.1:671b"
+base = "ollama_cloud"
+max_context_tokens = 163840
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/deepseek-v3.2"
+base = "ollama_cloud"
+max_context_tokens = 163840
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/deepseek-v4-flash"
+base = "ollama_cloud"
+max_context_tokens = 1048576
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/deepseek-v4-pro"
+base = "ollama_cloud"
+max_context_tokens = 524288
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/devstral-2:123b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/devstral-small-2:24b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/gemini-3-flash-preview"
+base = "ollama_cloud"
+max_context_tokens = 1048576
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/gemma3:4b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/gemma3:12b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/gemma3:27b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/gemma4:31b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/glm-4.7"
+base = "ollama_cloud"
+max_context_tokens = 202752
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/glm-5"
+base = "ollama_cloud"
+max_context_tokens = 202752
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/glm-5.1"
+base = "ollama_cloud"
+max_context_tokens = 202752
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/glm-5.2"
+base = "ollama_cloud"
+max_context_tokens = 1000000
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/gpt-oss:20b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/gpt-oss:120b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/kimi-k2.5"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/kimi-k2.6"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/kimi-k2.7-code"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/minimax-m2.1"
+base = "ollama_cloud"
+max_context_tokens = 204800
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/minimax-m2.5"
+base = "ollama_cloud"
+max_context_tokens = 196608
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/minimax-m2.7"
+base = "ollama_cloud"
+max_context_tokens = 196608
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/minimax-m3"
+base = "ollama_cloud"
+max_context_tokens = 524288
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_response_format_json = true
+supports_structured_output = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/ministral-3:3b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/ministral-3:8b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/ministral-3:14b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/mistral-large-3:675b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/nemotron-3-nano:30b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/nemotron-3-super"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/nemotron-3-ultra"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/qwen3-coder:480b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/qwen3-coder-next"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/qwen3.5:397b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ollama_cloud/rnj-1:8b"
+base = "ollama_cloud"
+max_context_tokens = 32768
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+# Bare entries for Cloud models not already represented above by a direct-provider seed.
+# Runtime startup still checks bare model membership before OAS provider-qualified dispatch.
+
+[[models]]
+id_prefix = "deepseek-v3.1:671b"
+base = "ollama_cloud"
+max_context_tokens = 163840
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "deepseek-v3.2"
+base = "ollama_cloud"
+max_context_tokens = 163840
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "devstral-2:123b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "devstral-small-2:24b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "gemini-3-flash-preview"
+base = "ollama_cloud"
+max_context_tokens = 1048576
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "gemma3:4b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "gemma3:12b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "gemma3:27b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = false
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "gemma4:31b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "glm-5"
+base = "ollama_cloud"
+max_context_tokens = 202752
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "glm-5.1"
+base = "ollama_cloud"
+max_context_tokens = 202752
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "glm-5.2"
+base = "ollama_cloud"
+max_context_tokens = 1000000
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "gpt-oss:20b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "gpt-oss:120b"
+base = "ollama_cloud"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "kimi-k2.5"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "kimi-k2.6"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "kimi-k2.7-code"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "minimax-m2.1"
+base = "ollama_cloud"
+max_context_tokens = 204800
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "minimax-m2.5"
+base = "ollama_cloud"
+max_context_tokens = 196608
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "minimax-m2.7"
+base = "ollama_cloud"
+max_context_tokens = 196608
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ministral-3:3b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ministral-3:8b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "ministral-3:14b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "mistral-large-3:675b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "nemotron-3-nano:30b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "nemotron-3-super"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "nemotron-3-ultra"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "qwen3-coder:480b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "qwen3-coder-next"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "qwen3.5:397b"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "rnj-1:8b"
+base = "ollama_cloud"
+max_context_tokens = 32768
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = false
+supports_extended_thinking = false
+supports_reasoning_budget = false
+thinking_control_format = "none"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true

--- a/scripts/audit-ollama-cloud-catalog.py
+++ b/scripts/audit-ollama-cloud-catalog.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Audit the MASC Ollama Cloud model catalog against Ollama's public API.
+
+This script is intentionally not wired into CI: it performs live network calls
+to ollama.com. Use it when refreshing the runtime seed or proving that the
+checked-in catalog still covers the current Ollama Cloud model set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import tomllib
+
+
+TAGS_URL = "https://ollama.com/api/tags"
+SHOW_URL = "https://ollama.com/api/show"
+
+
+@dataclass(frozen=True)
+class OfficialModel:
+    name: str
+    max_context_tokens: int
+    supports_tools: bool
+    supports_thinking: bool
+    supports_vision: bool
+    capabilities: tuple[str, ...]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Audit checked-in MASC/OAS Ollama Cloud catalogs against ollama.com."
+    )
+    parser.add_argument(
+        "--runtime",
+        default="config/runtime.toml",
+        help="Path to MASC runtime.toml seed (default: config/runtime.toml).",
+    )
+    parser.add_argument(
+        "--oas-models",
+        default="oas-models.toml",
+        help="Path to MASC-local OAS model catalog (default: oas-models.toml).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="HTTP timeout in seconds for each official API request.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a JSON report instead of the human-readable summary.",
+    )
+    return parser.parse_args()
+
+
+def fetch_json(
+    url: str, *, payload: dict[str, Any] | None = None, timeout: float
+) -> dict[str, Any]:
+    data = None
+    headers: dict[str, str] = {}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=data, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            value = json.load(response)
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"failed to fetch {url}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{url}: expected JSON object")
+    return value
+
+
+def context_length_from_show(model_name: str, show: dict[str, Any]) -> int:
+    model_info = show.get("model_info")
+    if not isinstance(model_info, dict):
+        raise RuntimeError(f"{model_name}: /api/show missing model_info object")
+    context_lengths = [
+        value
+        for key, value in model_info.items()
+        if key.endswith(".context_length") and isinstance(value, int)
+    ]
+    if len(context_lengths) != 1:
+        raise RuntimeError(
+            f"{model_name}: expected one *.context_length in /api/show, got {context_lengths}"
+        )
+    return context_lengths[0]
+
+
+def load_official_models(timeout: float) -> list[OfficialModel]:
+    tags = fetch_json(TAGS_URL, timeout=timeout)
+    rows = tags.get("models")
+    if not isinstance(rows, list):
+        raise RuntimeError(f"{TAGS_URL}: expected 'models' array")
+
+    names: list[str] = []
+    for row in rows:
+        if not isinstance(row, dict) or not isinstance(row.get("name"), str):
+            raise RuntimeError(f"{TAGS_URL}: malformed model row {row!r}")
+        names.append(row["name"])
+
+    official: list[OfficialModel] = []
+    for name in sorted(names):
+        show = fetch_json(SHOW_URL, payload={"model": name}, timeout=timeout)
+        raw_capabilities = show.get("capabilities", [])
+        if not isinstance(raw_capabilities, list) or not all(
+            isinstance(item, str) for item in raw_capabilities
+        ):
+            raise RuntimeError(f"{name}: /api/show capabilities must be a string array")
+        capabilities = tuple(sorted(raw_capabilities))
+        official.append(
+            OfficialModel(
+                name=name,
+                max_context_tokens=context_length_from_show(name, show),
+                supports_tools="tools" in capabilities,
+                supports_thinking="thinking" in capabilities,
+                supports_vision="vision" in capabilities,
+                capabilities=capabilities,
+            )
+        )
+    return official
+
+
+def load_toml(path: str) -> dict[str, Any]:
+    with Path(path).open("rb") as handle:
+        data = tomllib.load(handle)
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{path}: expected TOML object")
+    return data
+
+
+def bool_value(table: dict[str, Any], key: str) -> bool:
+    value = table.get(key)
+    return value if isinstance(value, bool) else False
+
+
+def int_value(table: dict[str, Any], key: str) -> int | None:
+    value = table.get(key)
+    return value if isinstance(value, int) else None
+
+
+def runtime_catalog(
+    runtime: dict[str, Any],
+) -> tuple[dict[str, str], set[str], dict[str, Any]]:
+    models = runtime.get("models", {})
+    bindings = runtime.get("ollama_cloud", {})
+    if not isinstance(models, dict):
+        raise RuntimeError("runtime.toml: [models.*] must parse as a TOML table")
+    if not isinstance(bindings, dict):
+        raise RuntimeError("runtime.toml: [ollama_cloud.*] must parse as a TOML table")
+
+    api_name_to_slug: dict[str, str] = {}
+    for slug, table in models.items():
+        if not isinstance(slug, str) or not slug.startswith("ollama-cloud-"):
+            continue
+        if not isinstance(table, dict):
+            raise RuntimeError(f"runtime.toml: models.{slug} must be a table")
+        api_name = table.get("api-name")
+        if not isinstance(api_name, str):
+            raise RuntimeError(f"runtime.toml: models.{slug}.api-name must be a string")
+        api_name_to_slug[api_name] = slug
+    return api_name_to_slug, set(bindings), models
+
+
+def oas_catalog(
+    oas_models: dict[str, Any],
+) -> tuple[dict[str, dict[str, Any]], set[str]]:
+    rows = oas_models.get("models", [])
+    if not isinstance(rows, list):
+        raise RuntimeError("oas-models.toml: [[models]] must parse as an array")
+
+    provider_qualified: dict[str, dict[str, Any]] = {}
+    bare_membership: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            raise RuntimeError(f"oas-models.toml: malformed model row {row!r}")
+        id_prefix = row.get("id_prefix")
+        if not isinstance(id_prefix, str):
+            raise RuntimeError("oas-models.toml: every [[models]] row needs id_prefix")
+        if id_prefix.startswith("ollama_cloud/"):
+            provider_qualified[id_prefix.removeprefix("ollama_cloud/")] = row
+        elif "/" not in id_prefix:
+            bare_membership.add(id_prefix)
+    return provider_qualified, bare_membership
+
+
+def check_catalog(
+    official: list[OfficialModel],
+    runtime: dict[str, Any],
+    oas_models: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    official_by_name = {model.name: model for model in official}
+    official_names = set(official_by_name)
+    runtime_api_to_slug, runtime_bindings, runtime_models = runtime_catalog(runtime)
+    oas_provider_qualified, oas_bare = oas_catalog(oas_models)
+
+    errors: list[str] = []
+    runtime_names = set(runtime_api_to_slug)
+    oas_provider_names = set(oas_provider_qualified)
+
+    for name in sorted(official_names - runtime_names):
+        errors.append(f"missing runtime seed for official model: {name}")
+    for name in sorted(runtime_names - official_names):
+        errors.append(f"runtime seed no longer present in official API: {name}")
+    for name in sorted(official_names - oas_provider_names):
+        errors.append(f"missing OAS provider-qualified model: ollama_cloud/{name}")
+    for name in sorted(oas_provider_names - official_names):
+        errors.append(
+            f"OAS provider-qualified model no longer official: ollama_cloud/{name}"
+        )
+    for name in sorted(official_names - oas_bare):
+        errors.append(f"missing OAS bare membership model: {name}")
+
+    for name, model in sorted(official_by_name.items()):
+        slug = runtime_api_to_slug.get(name)
+        if slug is not None and slug not in runtime_bindings:
+            errors.append(f"missing runtime provider binding: [ollama_cloud.{slug}]")
+
+        runtime_row = runtime_models.get(slug) if slug is not None else None
+        if isinstance(runtime_row, dict):
+            runtime_caps = runtime_row.get("capabilities", {})
+            if not isinstance(runtime_caps, dict):
+                errors.append(f"runtime model {slug}: capabilities must be a table")
+                runtime_caps = {}
+            if int_value(runtime_row, "max-context") != model.max_context_tokens:
+                errors.append(
+                    f"runtime model {slug}: max-context "
+                    f"{int_value(runtime_row, 'max-context')} != official {model.max_context_tokens}"
+                )
+            if bool_value(runtime_row, "tools-support") != model.supports_tools:
+                errors.append(
+                    f"runtime model {slug}: tools-support mismatch for official {name}"
+                )
+            if bool_value(runtime_row, "thinking-support") != model.supports_thinking:
+                errors.append(
+                    f"runtime model {slug}: thinking-support mismatch for official {name}"
+                )
+            if (
+                bool_value(runtime_caps, "supports-image-input")
+                != model.supports_vision
+            ):
+                errors.append(
+                    f"runtime model {slug}: supports-image-input mismatch for official {name}"
+                )
+            if (
+                bool_value(runtime_caps, "supports-multimodal-inputs")
+                != model.supports_vision
+            ):
+                errors.append(
+                    f"runtime model {slug}: supports-multimodal-inputs mismatch for official {name}"
+                )
+
+        oas_row = oas_provider_qualified.get(name)
+        if isinstance(oas_row, dict):
+            if int_value(oas_row, "max_context_tokens") != model.max_context_tokens:
+                errors.append(
+                    f"OAS model ollama_cloud/{name}: max_context_tokens "
+                    f"{int_value(oas_row, 'max_context_tokens')} != official {model.max_context_tokens}"
+                )
+            if bool_value(oas_row, "supports_tools") != model.supports_tools:
+                errors.append(f"OAS model ollama_cloud/{name}: supports_tools mismatch")
+            if bool_value(oas_row, "supports_reasoning") != model.supports_thinking:
+                errors.append(
+                    f"OAS model ollama_cloud/{name}: supports_reasoning mismatch"
+                )
+            if (
+                bool_value(oas_row, "supports_extended_thinking")
+                != model.supports_thinking
+            ):
+                errors.append(
+                    f"OAS model ollama_cloud/{name}: supports_extended_thinking mismatch"
+                )
+            if bool_value(oas_row, "supports_image_input") != model.supports_vision:
+                errors.append(
+                    f"OAS model ollama_cloud/{name}: supports_image_input mismatch"
+                )
+            if (
+                bool_value(oas_row, "supports_multimodal_inputs")
+                != model.supports_vision
+            ):
+                errors.append(
+                    f"OAS model ollama_cloud/{name}: supports_multimodal_inputs mismatch"
+                )
+
+    vision_models = sorted(model.name for model in official if model.supports_vision)
+    report = {
+        "checked_at_kst": datetime.now(ZoneInfo("Asia/Seoul")).isoformat(
+            timespec="seconds"
+        ),
+        "official_source": [TAGS_URL, SHOW_URL],
+        "official_count": len(official_names),
+        "official_vision_count": len(vision_models),
+        "runtime_canonical_count": len(runtime_names),
+        "runtime_binding_count": sum(
+            1 for slug in runtime_bindings if slug.startswith("ollama-cloud-")
+        ),
+        "oas_provider_qualified_count": len(oas_provider_names),
+        "oas_bare_membership_count": len(official_names & oas_bare),
+        "vision_models": vision_models,
+    }
+    return report, errors
+
+
+def print_text_report(report: dict[str, Any], errors: list[str]) -> None:
+    print(f"checked_at_kst={report['checked_at_kst']}")
+    print(f"official_source={','.join(report['official_source'])}")
+    print(f"official_count={report['official_count']}")
+    print(f"official_vision_count={report['official_vision_count']}")
+    print(f"runtime_canonical_count={report['runtime_canonical_count']}")
+    print(f"runtime_binding_count={report['runtime_binding_count']}")
+    print(f"oas_provider_qualified_count={report['oas_provider_qualified_count']}")
+    print(f"oas_bare_membership_count={report['oas_bare_membership_count']}")
+    print("vision_models=" + ",".join(report["vision_models"]))
+    if errors:
+        print("status=FAIL")
+        for error in errors:
+            print(f"error={error}")
+    else:
+        print("status=OK")
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        official = load_official_models(args.timeout)
+        runtime = load_toml(args.runtime)
+        oas_models = load_toml(args.oas_models)
+        report, errors = check_catalog(official, runtime, oas_models)
+    except RuntimeError as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(
+            json.dumps({"report": report, "errors": errors}, indent=2, sort_keys=True)
+        )
+    else:
+        print_text_report(report, errors)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -19,6 +19,309 @@ let rec repo_root_from dir =
 
 let repo_root () = repo_root_from (Sys.getcwd ())
 
+type ollama_cloud_case =
+  { runtime_id : string
+  ; api_name : string
+  ; context : int
+  ; tools : bool
+  ; thinking : bool
+  ; vision : bool
+  }
+
+let ollama_cloud_seed_cases =
+  [ { runtime_id = "ollama_cloud.ollama-cloud-deepseek-v3-1-671b"
+    ; api_name = "deepseek-v3.1:671b"
+    ; context = 163840
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-deepseek-v3-2"
+    ; api_name = "deepseek-v3.2"
+    ; context = 163840
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-deepseek-v4-flash"
+    ; api_name = "deepseek-v4-flash"
+    ; context = 1048576
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-deepseek-v4-pro"
+    ; api_name = "deepseek-v4-pro"
+    ; context = 524288
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-devstral-2-123b"
+    ; api_name = "devstral-2:123b"
+    ; context = 262144
+    ; tools = true
+    ; thinking = false
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-devstral-small-2-24b"
+    ; api_name = "devstral-small-2:24b"
+    ; context = 262144
+    ; tools = true
+    ; thinking = false
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-gemini-3-flash-preview"
+    ; api_name = "gemini-3-flash-preview"
+    ; context = 1048576
+    ; tools = true
+    ; thinking = true
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-gemma3-4b"
+    ; api_name = "gemma3:4b"
+    ; context = 131072
+    ; tools = false
+    ; thinking = false
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-gemma3-12b"
+    ; api_name = "gemma3:12b"
+    ; context = 131072
+    ; tools = false
+    ; thinking = false
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-gemma3-27b"
+    ; api_name = "gemma3:27b"
+    ; context = 131072
+    ; tools = false
+    ; thinking = false
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-gemma4-31b"
+    ; api_name = "gemma4:31b"
+    ; context = 262144
+    ; tools = true
+    ; thinking = true
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-glm-4-7"
+    ; api_name = "glm-4.7"
+    ; context = 202752
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-glm-5"
+    ; api_name = "glm-5"
+    ; context = 202752
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-glm-5-1"
+    ; api_name = "glm-5.1"
+    ; context = 202752
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-glm-5-2"
+    ; api_name = "glm-5.2"
+    ; context = 1000000
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-gpt-oss-20b"
+    ; api_name = "gpt-oss:20b"
+    ; context = 131072
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-gpt-oss-120b"
+    ; api_name = "gpt-oss:120b"
+    ; context = 131072
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-kimi-k2-5"
+    ; api_name = "kimi-k2.5"
+    ; context = 262144
+    ; tools = true
+    ; thinking = true
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-kimi-k2-6"
+    ; api_name = "kimi-k2.6"
+    ; context = 262144
+    ; tools = true
+    ; thinking = true
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-kimi-k2-7-code"
+    ; api_name = "kimi-k2.7-code"
+    ; context = 262144
+    ; tools = true
+    ; thinking = true
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-minimax-m2-1"
+    ; api_name = "minimax-m2.1"
+    ; context = 204800
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-minimax-m2-5"
+    ; api_name = "minimax-m2.5"
+    ; context = 196608
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-minimax-m2-7"
+    ; api_name = "minimax-m2.7"
+    ; context = 196608
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-minimax-m3"
+    ; api_name = "minimax-m3"
+    ; context = 524288
+    ; tools = true
+    ; thinking = true
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-ministral-3-3b"
+    ; api_name = "ministral-3:3b"
+    ; context = 262144
+    ; tools = true
+    ; thinking = false
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-ministral-3-8b"
+    ; api_name = "ministral-3:8b"
+    ; context = 262144
+    ; tools = true
+    ; thinking = false
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-ministral-3-14b"
+    ; api_name = "ministral-3:14b"
+    ; context = 262144
+    ; tools = true
+    ; thinking = false
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-mistral-large-3-675b"
+    ; api_name = "mistral-large-3:675b"
+    ; context = 262144
+    ; tools = true
+    ; thinking = false
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-nemotron-3-nano-30b"
+    ; api_name = "nemotron-3-nano:30b"
+    ; context = 262144
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-nemotron-3-super"
+    ; api_name = "nemotron-3-super"
+    ; context = 262144
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-nemotron-3-ultra"
+    ; api_name = "nemotron-3-ultra"
+    ; context = 262144
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-qwen3-coder-480b"
+    ; api_name = "qwen3-coder:480b"
+    ; context = 262144
+    ; tools = true
+    ; thinking = false
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-qwen3-coder-next"
+    ; api_name = "qwen3-coder-next"
+    ; context = 262144
+    ; tools = true
+    ; thinking = false
+    ; vision = false
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-qwen3-5-397b"
+    ; api_name = "qwen3.5:397b"
+    ; context = 262144
+    ; tools = true
+    ; thinking = true
+    ; vision = true
+    }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-rnj-1-8b"
+    ; api_name = "rnj-1:8b"
+    ; context = 32768
+    ; tools = true
+    ; thinking = false
+    ; vision = false
+    }
+  ]
+
+let has_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len && String.sub value 0 prefix_len = prefix
+
+let find_runtime runtimes runtime_id =
+  List.find_opt
+    (fun (runtime : Runtime.t) -> String.equal runtime.id runtime_id)
+    runtimes
+
+let assert_ollama_cloud_seed_runtime runtimes case =
+  match find_runtime runtimes case.runtime_id with
+  | None -> failf "expected Ollama Cloud runtime in seed: %s" case.runtime_id
+  | Some runtime ->
+    check string (case.runtime_id ^ " api name") case.api_name
+      runtime.model.api_name;
+    check int (case.runtime_id ^ " context") case.context
+      runtime.model.max_context;
+    check bool (case.runtime_id ^ " tools") case.tools
+      runtime.model.tools_support;
+    check bool (case.runtime_id ^ " thinking") case.thinking
+      runtime.model.thinking_support;
+    check bool (case.api_name ^ " known to OAS catalog") true
+      (Option.is_some (Llm_provider.Capabilities.for_model_id case.api_name));
+    (match runtime.model.capabilities with
+     | None -> failf "expected capabilities for %s" case.runtime_id
+     | Some caps ->
+       let expected_thinking_format =
+         if case.thinking
+         then Runtime_schema.Reasoning_effort
+         else Runtime_schema.No_thinking_control
+       in
+       check bool (case.runtime_id ^ " forced tool_choice disabled") false
+         caps.supports_tool_choice;
+       check bool (case.runtime_id ^ " image input") case.vision
+         caps.supports_image_input;
+       check bool (case.runtime_id ^ " multimodal input") case.vision
+         caps.supports_multimodal_inputs;
+       check bool (case.runtime_id ^ " extended thinking") case.thinking
+         caps.supports_extended_thinking;
+       check bool (case.runtime_id ^ " reasoning budget") case.thinking
+         caps.supports_reasoning_budget;
+       check bool (case.runtime_id ^ " thinking control") true
+         (Runtime_schema.equal_thinking_control_format
+            caps.thinking_control_format
+            expected_thinking_format))
+
 let test_runtime_json_not_in_repo_config () =
   let path = Filename.concat (repo_root ()) "config/runtime.json" in
   check bool "retired runtime.json absent" false (Sys.file_exists path)
@@ -36,6 +339,16 @@ let test_repo_runtime_toml_loads () =
     check (option string) "nick0cave Gemma canary pin"
       (Some "ollama.gemma4-26b-a4b-qat")
       (List.assoc_opt "nick0cave" assignments);
+    check int "Ollama Cloud canonical seed count"
+      (List.length ollama_cloud_seed_cases)
+      (List.length
+         (List.filter
+            (fun (runtime : Runtime.t) ->
+               has_prefix ~prefix:"ollama_cloud.ollama-cloud-" runtime.id)
+            runtimes));
+    List.iter
+      (assert_ollama_cloud_seed_runtime runtimes)
+      ollama_cloud_seed_cases;
     (match
        List.find_opt
          (fun (runtime : Runtime.t) ->


### PR DESCRIPTION
## Summary
- Add canonical MASC runtime seed bindings for all 35 current Ollama Cloud models.
- Add matching `oas-models.toml` provider-qualified projections so Cloud models remain known to the OAS capability gate from the MASC checkout.
- Extend `test_runtime_config_validity` to assert the full Cloud seed set, context, tools/thinking, and vision flags.
- Add `scripts/audit-ollama-cloud-catalog.py` for reproducible live comparison against Ollama's official `/api/tags` and `/api/show` APIs.

## Evidence
- Official model source: `https://ollama.com/api/tags` and `https://ollama.com/api/show`, checked 2026-06-20 KST.
- Latest live audit output: `official_count 35`, `official_vision_count 15`, `runtime_canonical_count 35`, `runtime_binding_count 35`, `oas_provider_qualified_count 35`, `oas_bare_membership_count 35`, `status=OK`.
- Runtime ids use TOML-safe `ollama_cloud.ollama-cloud-*` slugs; `api-name` preserves the official Cloud model id.

## Validation
- `python3 scripts/audit-ollama-cloud-catalog.py`
- `ruff check scripts/audit-ollama-cloud-catalog.py`
- `ruff format --check scripts/audit-ollama-cloud-catalog.py`
- `pyright --outputjson scripts/audit-ollama-cloud-catalog.py`
- `ocamlformat --check test/test_runtime_config_validity.ml`
- `git diff --check`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build --cache=disabled test/test_runtime_config_validity.exe`
- `_build/default/test/test_runtime_config_validity.exe`

## Notes
- The normal local wrapper still reports existing local `agent_sdk` pin drift (`0.207.3`, expected `>=0.207.5`), so the focused local build used `MASC_SKIP_PIN_CHECK=1`.
- Existing runtime aliases (`ollama_cloud.deepseek-v4-flash`, `ollama_cloud.minimax-m3`, `ollama_cloud.kimi-k2-6`) are preserved for compatibility.
- Existing live runtime roots are intentionally not mutated by this PR; `config/runtime.toml` seeds new workspaces and explicit runtime config updates.
- Live follow-up applied separately on 2026-06-20 KST: `/Users/dancer/me/.masc/config/runtime.toml` now has 35 canonical `ollama_cloud.ollama-cloud-*` runtimes, was reloaded through `POST /api/v1/runtime/config/raw` with `reloaded=true`, and `/api/v1/providers` reports `missing_in_runtime=[]` / `extra_in_runtime=[]` against the official 35-model list.
