### PR TITLE
[codex] add fusion dashboard surface

### DIFF
--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -77,6 +77,7 @@ const LazyIdeShell = lazy(async () => ({ default: (await import('./ide/ide-shell
 const LazyCockpit = lazy(async () => ({ default: (await import('./cockpit/cockpit')).Cockpit }))
 const LazySettingsSurface = lazy(async () => ({ default: (await import('./settings-surface')).SettingsSurface }))
 const LazyApprovals = lazy(async () => ({ default: (await import('./approvals/approvals-surface')).ApprovalsSurface }))
+const LazyFusionSurface = lazy(async () => ({ default: (await import('./fusion/fusion-surface')).FusionSurface }))
 
 function lazyTabFallback(label: string) {
   return html`<${LoadingState}>Loading ${label}...<//>`
@@ -1236,6 +1237,12 @@ function TabContent() {
       return html`
         <${Suspense} fallback=${lazyTabFallback('Approvals')}>
           <${LazyApprovals} />
+        <//>
+      `
+    case 'fusion':
+      return html`
+        <${Suspense} fallback=${lazyTabFallback('Fusion')}>
+          <${LazyFusionSurface} />
         <//>
       `
     case 'workspace':

--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -1,0 +1,156 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { BoardPost } from '../../types'
+import { route } from '../../router'
+import { boardLoading, boardPosts } from '../../store'
+import { FusionSurface } from './fusion-surface'
+
+function boardPost(overrides: Partial<BoardPost> & { id: string; meta: BoardPost['meta'] }): BoardPost {
+  const { id, meta, ...rest } = overrides
+  return {
+    id,
+    author: 'fusion-keeper',
+    author_identity: {
+      kind: 'keeper',
+      id: 'fusion-keeper',
+      key: 'keeper:fusion-keeper',
+      display_name: 'Fusion Keeper',
+      raw: 'fusion-keeper',
+    },
+    post_kind: 'automation',
+    pinned: false,
+    title: 'Fusion deliberation',
+    body: 'Fusion body',
+    content: 'Fusion content',
+    meta,
+    tags: [],
+    votes: null,
+    comment_count: 0,
+    created_at: '2026-06-19T01:00:00Z',
+    updated_at: '2026-06-19T01:02:00Z',
+    ...rest,
+  }
+}
+
+describe('FusionSurface', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    window.location.hash = '#fusion'
+    route.value = { tab: 'fusion', params: {}, postId: null }
+    boardLoading.value = false
+    boardPosts.value = []
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    boardLoading.value = false
+    boardPosts.value = []
+    route.value = { tab: 'overview', params: {}, postId: null }
+    window.location.hash = '#overview'
+  })
+
+  it('renders live top-level fusion board metadata', () => {
+    boardPosts.value = [
+      boardPost({
+        id: 'post-fus-1',
+        title: 'Fusion deliberation (run fus-1): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-1',
+          question: 'Which deploy path should we take?',
+          panel: [
+            {
+              model: 'gpt-5',
+              status: 'answered',
+              answer: 'Use the canary path.',
+              input_tokens: 1200,
+              output_tokens: 340,
+            },
+            {
+              model: 'claude-sonnet-4',
+              status: 'failed',
+              reason: 'timeout',
+            },
+          ],
+          judge: {
+            status: 'synthesized',
+            decision: 'answer',
+            synthesis: 'Canary has the best rollback evidence.',
+            resolved_answer: 'Ship canary first, then expand.',
+          },
+          observed_usage: {
+            input_tokens: 1300,
+            output_tokens: 360,
+          },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    expect(container.querySelector('[data-testid="fusion-surface"]')).not.toBeNull()
+    expect(container.textContent).toContain('fus-1')
+    expect(container.textContent).toContain('Which deploy path should we take?')
+    expect(container.textContent).toContain('gpt-5')
+    expect(container.textContent).toContain('claude-sonnet-4')
+    expect(container.textContent).toContain('Canary has the best rollback evidence.')
+    expect(container.textContent).toContain('Ship canary first, then expand.')
+    expect(container.textContent).toContain('1,300')
+    expect(container.textContent).toContain('360')
+  })
+
+  it('supports older nested fusion_deliberation metadata and route selection', () => {
+    boardPosts.value = [
+      boardPost({
+        id: 'post-fus-1',
+        updated_at: '2026-06-19T01:00:00Z',
+        meta: {
+          fusion_deliberation: {
+            run_id: 'fus-1',
+            question: 'older run',
+            panel: [],
+            judge: { status: 'synthesized', resolved_answer: 'older answer' },
+          },
+        },
+      }),
+      boardPost({
+        id: 'post-fus-2',
+        updated_at: '2026-06-19T02:00:00Z',
+        meta: {
+          fusion_deliberation: {
+            run_id: 'fus-2',
+            question: 'newer run',
+            panel: [],
+            judge: { status: 'synthesized', resolved_answer: 'newer answer' },
+          },
+        },
+      }),
+    ]
+    route.value = { tab: 'fusion', params: { run_id: 'fus-1' }, postId: null }
+
+    render(html`<${FusionSurface} />`, container)
+
+    expect(container.querySelector('[data-testid="fusion-detail"]')?.textContent).toContain('older answer')
+
+    const secondRow = Array.from(container.querySelectorAll<HTMLButtonElement>('.fus-run-row'))
+      .find(button => button.textContent?.includes('fus-2'))
+    expect(secondRow).not.toBeUndefined()
+    secondRow?.click()
+
+    expect(route.value.tab).toBe('fusion')
+    expect(route.value.params).toEqual({ run_id: 'fus-2' })
+    expect(window.location.hash).toBe('#fusion?run_id=fus-2')
+  })
+
+  it('shows an empty state when no fusion board posts are loaded', () => {
+    render(html`<${FusionSurface} />`, container)
+
+    expect(container.querySelector('[data-testid="fusion-empty"]')).not.toBeNull()
+    expect(container.textContent).toContain('No fusion runs found')
+  })
+})

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -1,0 +1,434 @@
+import { html } from 'htm/preact'
+import { useMemo } from 'preact/hooks'
+import type { BoardPost } from '../../types'
+import { navigate, replaceRoute, route } from '../../router'
+import { boardLoading, boardPosts, refreshBoard } from '../../store'
+import { TimeAgo } from '../common/time-ago'
+import { ringFocusClasses } from '../common/ring'
+import { AgentAvatar } from '../overview/agent-avatar'
+
+type FusionRunStatus = 'complete' | 'failed' | 'running'
+type FusionTone = 'ok' | 'warn' | 'bad' | 'volt' | 'muted'
+
+const FUSION_BOARD_SOURCE = 'fusion'
+
+interface FusionPanelEntry {
+  model: string
+  status: string
+  answer: string | null
+  reason: string | null
+  inputTokens: number | null
+  outputTokens: number | null
+}
+
+interface FusionJudge {
+  status: string | null
+  decision: string | null
+  synthesis: string | null
+  resolvedAnswer: string | null
+  error: string | null
+}
+
+interface FusionUsage {
+  inputTokens: number | null
+  outputTokens: number | null
+  costUsd: number | null
+}
+
+interface FusionRunView {
+  runId: string
+  boardPostId: string
+  keeperName: string
+  title: string
+  question: string
+  status: FusionRunStatus
+  tone: FusionTone
+  panel: FusionPanelEntry[]
+  judge: FusionJudge
+  usage: FusionUsage
+  createdAt: string
+  updatedAt: string
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function firstString(source: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = asString(source[key])
+    if (value) return value
+  }
+  return null
+}
+
+function firstNumber(source: Record<string, unknown>, keys: string[]): number | null {
+  for (const key of keys) {
+    const value = asNumber(source[key])
+    if (value !== null) return value
+  }
+  return null
+}
+
+function fusionMeta(post: BoardPost): Record<string, unknown> | null {
+  const meta = asRecord(post.meta)
+  if (!meta) return null
+  if (asString(meta.source) === FUSION_BOARD_SOURCE) return meta
+
+  const nested = asRecord(meta.fusion_deliberation)
+  if (nested) return { ...nested, source: FUSION_BOARD_SOURCE }
+
+  return null
+}
+
+function normalizePanelEntry(value: unknown, index: number): FusionPanelEntry | null {
+  const entry = asRecord(value)
+  if (!entry) return null
+  const usage = asRecord(entry.usage)
+  const model = firstString(entry, ['model', 'name', 'provider']) ?? `panel-${index + 1}`
+  return {
+    model,
+    status: firstString(entry, ['status']) ?? 'unknown',
+    answer: firstString(entry, ['answer', 'content', 'output']),
+    reason: firstString(entry, ['reason', 'error', 'error_text']),
+    inputTokens: firstNumber(entry, ['input_tokens', 'inputTokens']) ?? firstNumber(usage ?? {}, ['input_tokens', 'inputTokens']),
+    outputTokens: firstNumber(entry, ['output_tokens', 'outputTokens']) ?? firstNumber(usage ?? {}, ['output_tokens', 'outputTokens']),
+  }
+}
+
+function normalizePanel(value: unknown): FusionPanelEntry[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((entry, index) => {
+    const normalized = normalizePanelEntry(entry, index)
+    return normalized ? [normalized] : []
+  })
+}
+
+function normalizeJudge(value: unknown): FusionJudge {
+  const judge = asRecord(value) ?? {}
+  return {
+    status: firstString(judge, ['status']),
+    decision: firstString(judge, ['decision', 'verdict']),
+    synthesis: firstString(judge, ['synthesis', 'rationale', 'summary']),
+    resolvedAnswer: firstString(judge, ['resolved_answer', 'resolvedAnswer', 'answer']),
+    error: firstString(judge, ['error', 'reason', 'error_text']),
+  }
+}
+
+function normalizeUsage(meta: Record<string, unknown>, panel: FusionPanelEntry[]): FusionUsage {
+  const observed = asRecord(meta.observed_usage) ?? {}
+  const summedInput = panel.reduce((sum, entry) => sum + (entry.inputTokens ?? 0), 0)
+  const summedOutput = panel.reduce((sum, entry) => sum + (entry.outputTokens ?? 0), 0)
+  const inputTokens = firstNumber(observed, ['input_tokens', 'inputTokens'])
+    ?? firstNumber(meta, ['input_tokens', 'inputTokens'])
+    ?? (summedInput > 0 ? summedInput : null)
+  const outputTokens = firstNumber(observed, ['output_tokens', 'outputTokens'])
+    ?? firstNumber(meta, ['output_tokens', 'outputTokens'])
+    ?? (summedOutput > 0 ? summedOutput : null)
+  return {
+    inputTokens,
+    outputTokens,
+    costUsd: firstNumber(meta, ['cost_usd', 'costUsd', 'observed_cost_usd']),
+  }
+}
+
+function statusFor(judge: FusionJudge, panel: FusionPanelEntry[]): FusionRunStatus {
+  const status = judge.status?.toLowerCase() ?? ''
+  if (status.includes('fail')) return 'failed'
+  if (judge.error) return 'failed'
+  if (judge.resolvedAnswer || judge.synthesis || judge.decision || status.includes('synth')) return 'complete'
+  if (panel.length > 0 && panel.every(entry => entry.status.toLowerCase().includes('fail'))) return 'failed'
+  return 'running'
+}
+
+function toneFor(status: FusionRunStatus, decision: string | null): FusionTone {
+  if (status === 'failed') return 'bad'
+  const lower = decision?.toLowerCase() ?? ''
+  if (lower.includes('answer')) return 'ok'
+  if (lower.includes('recommend')) return 'volt'
+  if (lower.includes('insufficient') || lower.includes('uncertain')) return 'warn'
+  return status === 'running' ? 'muted' : 'ok'
+}
+
+function keeperNameFor(post: BoardPost): string {
+  return post.author_identity?.display_name
+    || post.author_identity?.id
+    || post.author
+    || 'system'
+}
+
+function fusionRunFromPost(post: BoardPost): FusionRunView | null {
+  const meta = fusionMeta(post)
+  if (!meta) return null
+
+  const panel = normalizePanel(meta.panel)
+  const judge = normalizeJudge(meta.judge)
+  const usage = normalizeUsage(meta, panel)
+  const runId = firstString(meta, ['run_id', 'runId', 'id']) ?? post.id
+  const question = firstString(meta, ['question', 'prompt']) ?? post.body ?? post.content ?? post.title
+  const status = statusFor(judge, panel)
+  const tone = toneFor(status, judge.decision)
+
+  return {
+    runId,
+    boardPostId: post.id,
+    keeperName: keeperNameFor(post),
+    title: post.title || `Fusion run ${runId}`,
+    question,
+    status,
+    tone,
+    panel,
+    judge,
+    usage,
+    createdAt: post.created_at,
+    updatedAt: post.updated_at || post.created_at,
+  }
+}
+
+function timeValue(iso: string): number {
+  const parsed = Date.parse(iso)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function buildFusionRuns(posts: readonly BoardPost[]): FusionRunView[] {
+  return posts
+    .flatMap(post => {
+      const run = fusionRunFromPost(post)
+      return run ? [run] : []
+    })
+    .sort((a, b) => timeValue(b.updatedAt) - timeValue(a.updatedAt))
+}
+
+function formatTokens(value: number | null): string {
+  if (value === null) return 'n/a'
+  return new Intl.NumberFormat().format(value)
+}
+
+function formatCost(value: number | null): string {
+  if (value === null) return 'n/a'
+  return `$${value.toFixed(4)}`
+}
+
+function statusLabel(status: FusionRunStatus): string {
+  switch (status) {
+    case 'complete':
+      return 'complete'
+    case 'failed':
+      return 'failed'
+    case 'running':
+      return 'running'
+  }
+}
+
+function compactText(value: string, max = 180): string {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  if (normalized.length <= max) return normalized
+  return `${normalized.slice(0, max - 1)}...`
+}
+
+function FusionMetric({ label, value, tone = 'muted' }: { label: string; value: string | number; tone?: FusionTone }) {
+  return html`
+    <div class=${`fus-kpi tone-${tone}`}>
+      <div class="fus-kpi-k">${label}</div>
+      <div class="fus-kpi-v">${value}</div>
+    </div>
+  `
+}
+
+function FusionPanelCard({ entry }: { entry: FusionPanelEntry }) {
+  const failed = entry.status.toLowerCase().includes('fail')
+  const body = entry.answer ?? entry.reason ?? 'No panel output captured.'
+  return html`
+    <article class=${`fus-panel-card ${failed ? 'failed' : 'answered'}`}>
+      <div class="fus-panel-head">
+        <span class="fus-panel-model">${entry.model}</span>
+        <span class=${`fus-mini-status ${failed ? 'bad' : 'ok'}`}>${entry.status}</span>
+      </div>
+      <p class="fus-panel-body">${compactText(body, 360)}</p>
+      <div class="fus-panel-foot">
+        <span>in ${formatTokens(entry.inputTokens)}</span>
+        <span>out ${formatTokens(entry.outputTokens)}</span>
+      </div>
+    </article>
+  `
+}
+
+function FusionRunRow({ run, active }: { run: FusionRunView; active: boolean }) {
+  return html`
+    <button
+      type="button"
+      class=${`fus-run-row ${active ? 'active' : ''} ${ringFocusClasses}`}
+      aria-current=${active ? 'true' : undefined}
+      onClick=${() => replaceRoute('fusion', { run_id: run.runId })}
+    >
+      <span class="fus-row-top">
+        <span class="fus-run-id">${run.runId}</span>
+        <span class=${`fus-status tone-${run.tone}`}>${statusLabel(run.status)}</span>
+      </span>
+      <span class="fus-row-question">${compactText(run.question, 110)}</span>
+      <span class="fus-row-meta">
+        <span>${run.keeperName}</span>
+        <${TimeAgo} timestamp=${run.updatedAt} />
+      </span>
+    </button>
+  `
+}
+
+function FusionRunDetail({ run }: { run: FusionRunView }) {
+  const answered = run.panel.filter(entry => !entry.status.toLowerCase().includes('fail')).length
+  const failed = run.panel.length - answered
+  const synthesis = run.judge.synthesis ?? run.judge.error ?? 'No judge synthesis captured.'
+  const resolved = run.judge.resolvedAnswer ?? 'No resolved answer captured.'
+
+  return html`
+    <article class="fus-detail" data-testid="fusion-detail">
+      <header class="fus-detail-head">
+        <div class="fus-detail-title">
+          <div class="fus-detail-meta">
+            <span class=${`fus-status tone-${run.tone}`}>${statusLabel(run.status)}</span>
+            <span class="fus-run-id">${run.runId}</span>
+            <${TimeAgo} timestamp=${run.updatedAt} mode="both" />
+          </div>
+          <h2>${run.title}</h2>
+        </div>
+        <div class="fus-actions">
+          <button
+            type="button"
+            class=${`fus-action ${ringFocusClasses}`}
+            onClick=${() => navigate('keepers', { keeper: run.keeperName })}
+          >Open keeper</button>
+          <button
+            type="button"
+            class=${`fus-action primary ${ringFocusClasses}`}
+            onClick=${() => navigate('board', { post: run.boardPostId })}
+          >Open board post</button>
+        </div>
+      </header>
+
+      <section class="fus-question">
+        <div class="fus-label">Prompt</div>
+        <p>${run.question}</p>
+      </section>
+
+      <section class="fus-kpis" aria-label="Fusion run metrics">
+        <${FusionMetric} label="panel" value=${`${answered}/${run.panel.length}`} tone=${failed > 0 ? 'warn' : 'ok'} />
+        <${FusionMetric} label="input tokens" value=${formatTokens(run.usage.inputTokens)} />
+        <${FusionMetric} label="output tokens" value=${formatTokens(run.usage.outputTokens)} tone="volt" />
+        <${FusionMetric} label="cost" value=${formatCost(run.usage.costUsd)} />
+      </section>
+
+      <section class="fus-section">
+        <div class="fus-section-head">
+          <h3>Panel</h3>
+          <span>${run.panel.length} models</span>
+        </div>
+        ${run.panel.length === 0
+          ? html`<div class="fus-empty-inline">No panel entries captured for this run.</div>`
+          : html`<div class="fus-panel-grid">${run.panel.map(entry => html`<${FusionPanelCard} key=${entry.model} entry=${entry} />`)}</div>`}
+      </section>
+
+      <section class="fus-judge">
+        <div class="fus-section-head">
+          <h3>Judge</h3>
+          <span>${run.judge.decision ?? run.judge.status ?? 'n/a'}</span>
+        </div>
+        <pre class="fus-synthesis">${synthesis}</pre>
+      </section>
+
+      <section class="fus-resolved">
+        <div class="fus-label">Resolved answer</div>
+        <p>${resolved}</p>
+      </section>
+
+      <section class="fus-sink">
+        <div>
+          <div class="fus-label">Sink</div>
+          <p>Board post ${run.boardPostId}</p>
+        </div>
+        <${AgentAvatar} name=${run.keeperName} size="sm" />
+      </section>
+    </article>
+  `
+}
+
+export function FusionSurface() {
+  const posts = boardPosts.value
+  const runs = useMemo(() => buildFusionRuns(posts), [posts])
+  const selectedRunId = route.value.params.run_id ?? route.value.params.run
+  const selected = runs.find(run => run.runId === selectedRunId) ?? runs[0] ?? null
+  const running = runs.filter(run => run.status === 'running').length
+  const failed = runs.filter(run => run.status === 'failed').length
+
+  return html`
+    <main class="ov ss-surface bg-surface-page text-text-primary v2-fusion-surface" data-testid="fusion-surface">
+      <div class="ov-scroll fus-scroll">
+        <header class="ov-head fus-head">
+          <div>
+            <h1>Fusion</h1>
+            <p class="ov-sub">
+              Panel deliberations, judge synthesis, and board sink evidence from masc_fusion.
+            </p>
+          </div>
+          <button
+            type="button"
+            class=${`fus-refresh ${ringFocusClasses}`}
+            onClick=${() => void refreshBoard()}
+            disabled=${boardLoading.value}
+          >${boardLoading.value ? 'Refreshing...' : 'Refresh'}</button>
+        </header>
+
+        <section class="fus-top-kpis" aria-label="Fusion overview">
+          <${FusionMetric} label="runs" value=${runs.length} tone=${runs.length ? 'ok' : 'muted'} />
+          <${FusionMetric} label="running" value=${running} tone=${running ? 'warn' : 'muted'} />
+          <${FusionMetric} label="failed" value=${failed} tone=${failed ? 'bad' : 'muted'} />
+          <${FusionMetric} label="source" value="board meta" tone="volt" />
+        </section>
+
+        ${runs.length === 0
+          ? html`
+              <section class="fus-empty" data-testid="fusion-empty">
+                <div class="fus-empty-mark">F</div>
+                <h2>No fusion runs found</h2>
+                <p>Load board posts with <code>meta.source = "fusion"</code> to review panel and judge output here.</p>
+              </section>
+            `
+          : html`
+              <div class="fus-layout">
+                <aside class="fus-list" aria-label="Fusion runs">
+                  <div class="fus-list-head">
+                    <span>Runs</span>
+                    <span>${runs.length}</span>
+                  </div>
+                  <div class="fus-run-scroll">
+                    ${runs.map(run => html`
+                      <${FusionRunRow}
+                        key=${run.runId}
+                        run=${run}
+                        active=${selected?.runId === run.runId}
+                      />
+                    `)}
+                  </div>
+                </aside>
+                ${selected ? html`<${FusionRunDetail} run=${selected} />` : null}
+              </div>
+            `}
+      </div>
+    </main>
+  `
+}

--- a/dashboard/src/components/surface-icon.ts
+++ b/dashboard/src/components/surface-icon.ts
@@ -12,6 +12,7 @@ import {
   ShieldCheck,
   SquareKanban,
   UsersRound,
+  Workflow,
 } from 'lucide-preact'
 import type { DashboardSurfaceIcon } from '../config/navigation'
 
@@ -31,6 +32,8 @@ export function SurfaceIcon({ icon, size = 16 }: SurfaceIconProps) {
       return html`<${UsersRound} ...${props} />`
     case 'board':
       return html`<${SquareKanban} ...${props} />`
+    case 'fusion':
+      return html`<${Workflow} ...${props} />`
     case 'approvals':
       return html`<${ShieldCheck} ...${props} />`
     case 'command':

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -67,6 +67,7 @@ describe('dashboard surface navigation', () => {
       'keepers',
       'board',
       'approvals',
+      'fusion',
       'code',
       'connectors',
       'settings',
@@ -78,6 +79,7 @@ describe('dashboard surface navigation', () => {
       'Keepers',
       'Board',
       'Approvals',
+      'Fusion',
       'IDE',
       'Connectors',
       'Settings',
@@ -86,11 +88,14 @@ describe('dashboard surface navigation', () => {
   })
 
   it('uses one sectionless-surface classifier for section stripping and section lookup', () => {
-    const sectionless = ['overview', 'logs', 'settings', 'keepers', 'board', 'approvals'] as const
+    const sectionless = ['overview', 'logs', 'settings', 'keepers', 'board', 'approvals', 'fusion'] as const
     expect(sectionless.filter(id => isSectionlessSurface(id))).toEqual([...sectionless])
     expect(sectionItemsForTab('settings')).toEqual([])
     expect(normalizeRouteParams('settings', { section: 'legacy', surface: 'old', panel: 'theme' })).toEqual({
       panel: 'theme',
+    })
+    expect(normalizeRouteParams('fusion', { section: 'legacy', surface: 'old', run_id: 'fus-1' })).toEqual({
+      run_id: 'fus-1',
     })
   })
 })

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -6,6 +6,7 @@ export type DashboardSurfaceIcon =
   | 'monitoring'
   | 'keepers'
   | 'board'
+  | 'fusion'
   | 'command'
   | 'connectors'
   | 'workspace'
@@ -83,6 +84,7 @@ const V2_PRIMARY_SURFACE_IDS: ReadonlyArray<SurfaceId> = [
   'keepers',
   'board',
   'approvals',
+  'fusion',
   'code',
   'connectors',
   'settings',
@@ -105,6 +107,7 @@ const SECTIONLESS_SURFACE_IDS: ReadonlySet<TabId> = new Set([
   'keepers',
   'board',
   'approvals',
+  'fusion',
 ])
 
 export function isSectionlessSurface(tabId: TabId): boolean {
@@ -162,6 +165,14 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     description: 'Keeper HITL approval queue — pending tool-call gates',
     defaultTab: 'approvals',
     tabs: ['approvals'],
+  },
+  {
+    id: 'fusion',
+    label: 'Fusion',
+    icon: 'fusion',
+    description: 'Panel and judge deliberations emitted by masc_fusion',
+    defaultTab: 'fusion',
+    tabs: ['fusion'],
   },
   {
     id: 'command',
@@ -255,6 +266,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
   // Sectionless surface (single tab, no sub-sections) but still a NonHomeTabId
   // key — the Record is exhaustive over the union, so the empty entry is required.
   approvals: [],
+  fusion: [],
   monitoring: [
     {
       id: 'agents',

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -42,6 +42,13 @@ describe('navigate', () => {
     expect(window.location.hash).toBe('#board?post=post-1&comment=comment-1')
   })
 
+  it('navigates to top-level fusion without section baggage', () => {
+    navigate('fusion', { section: 'workspace', run_id: 'fus-1', surface: 'old' })
+    expect(route.value.tab).toBe('fusion')
+    expect(route.value.params).toEqual({ run_id: 'fus-1' })
+    expect(window.location.hash).toBe('#fusion?run_id=fus-1')
+  })
+
   it('keeps workspace board deep links routeable for compatibility', () => {
     navigate('workspace', { section: 'board', post: 'post-1' })
     expect(route.value.tab).toBe('workspace')

--- a/dashboard/src/styles/fusion-v2.css
+++ b/dashboard/src/styles/fusion-v2.css
@@ -1,0 +1,480 @@
+.v2-fusion-surface {
+  --fus-line: var(--color-border-default);
+  --fus-panel: color-mix(in srgb, var(--color-bg-elevated) 72%, transparent);
+  --fus-panel-strong: color-mix(in srgb, var(--color-bg-elevated) 88%, var(--color-bg-surface));
+  --fus-text: var(--color-fg-primary);
+  --fus-muted: var(--color-fg-muted);
+}
+
+.v2-fusion-surface .fus-scroll {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.v2-fusion-surface .fus-head {
+  align-items: flex-start;
+}
+
+.v2-fusion-surface .fus-refresh,
+.v2-fusion-surface .fus-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-2);
+  background: var(--fus-panel);
+  color: var(--fus-text);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0 12px;
+}
+
+.v2-fusion-surface .fus-refresh:hover,
+.v2-fusion-surface .fus-action:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-hover);
+}
+
+.v2-fusion-surface .fus-refresh:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.v2-fusion-surface .fus-action.primary {
+  border-color: var(--ok-border);
+  background: var(--ok-soft);
+  color: var(--ok-fg);
+}
+
+.v2-fusion-surface .fus-top-kpis,
+.v2-fusion-surface .fus-kpis {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.v2-fusion-surface .fus-kpi {
+  min-width: 0;
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-3);
+  background: var(--fus-panel);
+  padding: 11px 12px;
+}
+
+.v2-fusion-surface .fus-kpi-k {
+  color: var(--fus-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.v2-fusion-surface .fus-kpi-v {
+  margin-top: 4px;
+  color: var(--fus-text);
+  font-size: 22px;
+  font-weight: 760;
+  line-height: 1.05;
+  overflow-wrap: anywhere;
+}
+
+.v2-fusion-surface .fus-kpi.tone-ok .fus-kpi-v {
+  color: var(--ok-fg);
+}
+
+.v2-fusion-surface .fus-kpi.tone-warn .fus-kpi-v {
+  color: var(--warn-fg);
+}
+
+.v2-fusion-surface .fus-kpi.tone-bad .fus-kpi-v {
+  color: var(--bad-light);
+}
+
+.v2-fusion-surface .fus-kpi.tone-volt .fus-kpi-v {
+  color: var(--volt-strong);
+}
+
+.v2-fusion-surface .fus-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+  min-height: 0;
+}
+
+.v2-fusion-surface .fus-list,
+.v2-fusion-surface .fus-detail,
+.v2-fusion-surface .fus-empty {
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-3);
+  background: var(--fus-panel);
+}
+
+.v2-fusion-surface .fus-list {
+  position: sticky;
+  top: 16px;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 180px);
+  min-height: 420px;
+  overflow: hidden;
+}
+
+.v2-fusion-surface .fus-list-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--fus-line);
+  color: var(--fus-muted);
+  font-size: 12px;
+  font-weight: 800;
+  padding: 12px 14px;
+  text-transform: uppercase;
+}
+
+.v2-fusion-surface .fus-run-scroll {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 8px;
+  overflow: auto;
+  padding: 10px;
+}
+
+.v2-fusion-surface .fus-run-row {
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: var(--r-2);
+  background: transparent;
+  color: var(--fus-text);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  min-height: 96px;
+  padding: 11px;
+  text-align: left;
+}
+
+.v2-fusion-surface .fus-run-row:hover {
+  border-color: var(--fus-line);
+  background: var(--color-bg-hover);
+}
+
+.v2-fusion-surface .fus-run-row.active {
+  border-color: var(--ok-border);
+  background: color-mix(in srgb, var(--ok-soft) 72%, var(--fus-panel));
+}
+
+.v2-fusion-surface .fus-row-top,
+.v2-fusion-surface .fus-row-meta,
+.v2-fusion-surface .fus-detail-meta,
+.v2-fusion-surface .fus-panel-head,
+.v2-fusion-surface .fus-panel-foot,
+.v2-fusion-surface .fus-section-head,
+.v2-fusion-surface .fus-sink {
+  display: flex;
+  align-items: center;
+}
+
+.v2-fusion-surface .fus-row-top,
+.v2-fusion-surface .fus-panel-head,
+.v2-fusion-surface .fus-section-head,
+.v2-fusion-surface .fus-sink {
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.v2-fusion-surface .fus-row-meta,
+.v2-fusion-surface .fus-detail-meta,
+.v2-fusion-surface .fus-panel-foot {
+  color: var(--fus-muted);
+  font-size: 11px;
+  gap: 8px;
+}
+
+.v2-fusion-surface .fus-run-id {
+  color: var(--fus-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-fusion-surface .fus-row-question {
+  color: var(--fus-text);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.v2-fusion-surface .fus-status,
+.v2-fusion-surface .fus-mini-status {
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-1);
+  background: var(--color-bg-surface);
+  color: var(--fus-muted);
+  flex: 0 0 auto;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+  padding: 4px 6px;
+  text-transform: uppercase;
+}
+
+.v2-fusion-surface .fus-status.tone-ok,
+.v2-fusion-surface .fus-mini-status.ok {
+  border-color: var(--ok-border);
+  background: var(--ok-soft);
+  color: var(--ok-fg);
+}
+
+.v2-fusion-surface .fus-status.tone-warn {
+  border-color: var(--warn-border);
+  background: var(--warn-soft);
+  color: var(--warn-fg);
+}
+
+.v2-fusion-surface .fus-status.tone-bad,
+.v2-fusion-surface .fus-mini-status.bad {
+  border-color: var(--bad-30);
+  background: var(--bad-10);
+  color: var(--bad-light);
+}
+
+.v2-fusion-surface .fus-status.tone-volt {
+  border-color: color-mix(in srgb, var(--volt-strong) 38%, transparent);
+  background: var(--volt-wash);
+  color: var(--volt-strong);
+}
+
+.v2-fusion-surface .fus-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+  padding: 16px;
+}
+
+.v2-fusion-surface .fus-detail-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.v2-fusion-surface .fus-detail-title {
+  min-width: 0;
+}
+
+.v2-fusion-surface .fus-detail-title h2 {
+  color: var(--fus-text);
+  font-size: 24px;
+  font-weight: 780;
+  line-height: 1.12;
+  margin: 8px 0 0;
+}
+
+.v2-fusion-surface .fus-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 8px;
+}
+
+.v2-fusion-surface .fus-question,
+.v2-fusion-surface .fus-judge,
+.v2-fusion-surface .fus-resolved,
+.v2-fusion-surface .fus-sink {
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-3);
+  background: var(--fus-panel-strong);
+  padding: 14px;
+}
+
+.v2-fusion-surface .fus-question p,
+.v2-fusion-surface .fus-resolved p,
+.v2-fusion-surface .fus-sink p {
+  color: var(--fus-text);
+  font-size: 14px;
+  line-height: 1.55;
+  margin: 6px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.v2-fusion-surface .fus-label {
+  color: var(--fus-muted);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.v2-fusion-surface .fus-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.v2-fusion-surface .fus-section-head h3 {
+  color: var(--fus-text);
+  font-size: 14px;
+  font-weight: 800;
+  margin: 0;
+}
+
+.v2-fusion-surface .fus-section-head span {
+  color: var(--fus-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.v2-fusion-surface .fus-panel-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.v2-fusion-surface .fus-panel-card {
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-3);
+  background: var(--fus-panel-strong);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 180px;
+  min-width: 0;
+  padding: 13px;
+}
+
+.v2-fusion-surface .fus-panel-card.answered {
+  border-top-color: var(--ok-border);
+}
+
+.v2-fusion-surface .fus-panel-card.failed {
+  border-top-color: var(--bad-30);
+}
+
+.v2-fusion-surface .fus-panel-model {
+  color: var(--fus-text);
+  font-size: 13px;
+  font-weight: 800;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-fusion-surface .fus-panel-body {
+  color: var(--fus-text);
+  flex: 1;
+  font-size: 13px;
+  line-height: 1.52;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.v2-fusion-surface .fus-panel-foot {
+  border-top: 1px solid var(--fus-line);
+  justify-content: flex-start;
+  padding-top: 8px;
+}
+
+.v2-fusion-surface .fus-synthesis {
+  color: var(--fus-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  margin: 10px 0 0;
+  max-height: 320px;
+  overflow: auto;
+  white-space: pre-wrap;
+}
+
+.v2-fusion-surface .fus-empty-inline,
+.v2-fusion-surface .fus-empty {
+  color: var(--fus-muted);
+}
+
+.v2-fusion-surface .fus-empty-inline {
+  border: 1px dashed var(--fus-line);
+  border-radius: var(--r-3);
+  padding: 18px;
+}
+
+.v2-fusion-surface .fus-empty {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  justify-content: center;
+  min-height: 300px;
+  padding: 32px;
+  text-align: center;
+}
+
+.v2-fusion-surface .fus-empty-mark {
+  align-items: center;
+  border: 1px solid var(--ok-border);
+  border-radius: var(--r-3);
+  background: var(--ok-soft);
+  color: var(--ok-fg);
+  display: inline-flex;
+  font-size: 22px;
+  font-weight: 800;
+  height: 48px;
+  justify-content: center;
+  width: 48px;
+}
+
+.v2-fusion-surface .fus-empty h2 {
+  color: var(--fus-text);
+  font-size: 22px;
+  font-weight: 780;
+  margin: 0;
+}
+
+.v2-fusion-surface .fus-empty p {
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0;
+  max-width: 520px;
+}
+
+@media (max-width: 1100px) {
+  .v2-fusion-surface .fus-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .v2-fusion-surface .fus-list {
+    position: static;
+    max-height: none;
+    min-height: 0;
+  }
+
+  .v2-fusion-surface .fus-run-scroll {
+    max-height: 360px;
+  }
+
+  .v2-fusion-surface .fus-panel-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .v2-fusion-surface .fus-top-kpis,
+  .v2-fusion-surface .fus-kpis,
+  .v2-fusion-surface .fus-panel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .v2-fusion-surface .fus-detail-head,
+  .v2-fusion-surface .fus-actions {
+    flex-direction: column;
+  }
+
+  .v2-fusion-surface .fus-action,
+  .v2-fusion-surface .fus-refresh {
+    width: 100%;
+  }
+}

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -68,6 +68,8 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       return ['namespaceTruth', 'execution', 'missionSnapshot']
     case 'board':
       return ['board']
+    case 'fusion':
+      return ['board']
     case 'monitoring':
       if (routeState.params.section === 'observatory') {
         return ['namespaceTruth', 'observatory']

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -312,6 +312,7 @@ export type TabId =
   | 'monitoring'
   | 'keepers'
   | 'board'
+  | 'fusion'
   | 'command'
   | 'connectors'
   | 'workspace'
@@ -327,6 +328,7 @@ export const VALID_TABS: TabId[] = [
   'monitoring',
   'keepers',
   'board',
+  'fusion',
   'command',
   'connectors',
   'workspace',

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -13,6 +13,7 @@ let valid_surfaces =
   ; "monitoring"
   ; "keepers"
   ; "board"
+  ; "fusion"
   ; "command"
   ; "connectors"
   ; "workspace"


### PR DESCRIPTION
## Summary

- Add a top-level Fusion dashboard surface from the keeper-v2 handoff, wired into the v2 primary navigation and shell lazy-loading.
- Render completed fusion deliberations from board posts with `meta.source = "fusion"`, including panel answers, judge synthesis, resolved answer, token usage, and source board-post links.
- Preserve compatibility with older nested `meta.fusion_deliberation` artifacts and add route/navigation coverage for `#fusion?run_id=...`.

## Relation to #21655 / RFC-0266

- This PR is the completed-run dashboard consumer for the current fusion board-post sink, not the run registry layer described in #21655 Phase 2.
- The data boundary remains board posts: current durable records are discovered from `meta.source = "fusion"`, while legacy records are read from nested `meta.fusion_deliberation`.
- #21655/RFC-0266 should own in-progress visibility: run registry, status tool, and running/completed state transitions. This PR does not create that registry or duplicate in-progress state.
- When the registry-backed visibility path lands, this surface can switch to or augment from that registry while keeping the same top-level `#fusion?run_id=...` route and detail layout.

## Validation

- `pnpm --dir dashboard typecheck`
- `pnpm exec vitest run --config vitest.config.ts src/tab-refresh.test.ts src/config/navigation.test.ts src/router.test.ts src/components/fusion/fusion-surface.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard build`
- Targeted ESLint on changed files passed.
- Review-response check: `pnpm --dir dashboard typecheck`
- Review-response check: `pnpm exec vitest run --config vitest.config.ts src/components/fusion/fusion-surface.test.ts --no-file-parallelism --maxWorkers=1`
- Review-response check: `pnpm --dir dashboard exec eslint src/components/fusion/fusion-surface.ts src/components/fusion/fusion-surface.test.ts`

## Known unrelated issue

- Full `pnpm --dir dashboard lint` still fails on pre-existing `dashboard/src/keeper-actions.ts:368` (`no-nested-ternary`), outside this diff.