### PR TITLE
[codex] Render fusion evidence on board posts

### DIFF
--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -26,6 +26,7 @@ import { BoardCurationPanel } from './board-curation-panel'
 import { BoardKarmaPanel } from './board-karma-panel'
 import { extractMentionTargets, MentionInbox, MentionInboxPanel } from './mention-inbox'
 import { PostDetail, CommentThread, CommentForm } from './post-detail'
+import { FusionBoardEvidence } from './fusion-evidence'
 import { ReactionBar } from './reaction-bar'
 import { StateBlockMessages } from './state-block-messages'
 import {
@@ -584,6 +585,7 @@ function BdThreadDetail({ post, onClose }: { post: BoardPost; onClose: () => voi
 
   const authorLabel = boardActorDisplayName(post.author, post.author_identity)
   const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
+  const evidencePost = detailPostId.value === post.id && detailPost.value ? detailPost.value : post
 
   return html`
     <aside class="bd-detail has-post" data-testid="bd-thread-detail">
@@ -599,6 +601,7 @@ function BdThreadDetail({ post, onClose }: { post: BoardPost; onClose: () => voi
             <div class="bd-th-body">
               <div class="text-sm font-semibold mb-1">${stripInlineMarkdown(post.title)}</div>
               <${RichContent} text=${stripStateBlocks(post.body)} previewLimit=${4} />
+              <${FusionBoardEvidence} post=${evidencePost} class="mt-3" />
             </div>
           </div>
         </div>

--- a/dashboard/src/components/board/fusion-evidence.ts
+++ b/dashboard/src/components/board/fusion-evidence.ts
@@ -13,6 +13,8 @@ type FusionPanelEntry = {
 type FusionJudgeView = {
   status: string
   decision?: string
+  // fusion_sink.ml writes render_judge markdown here; keep it ahead of
+  // resolvedAnswer so board detail and chat fusion cards share the same SSOT.
   synthesis?: string
   resolvedAnswer?: string
   error?: string

--- a/dashboard/src/components/board/fusion-evidence.ts
+++ b/dashboard/src/components/board/fusion-evidence.ts
@@ -1,0 +1,208 @@
+import { html } from 'htm/preact'
+import { RichContent } from '../common/rich-content'
+import type { BoardPost } from '../../types/core'
+
+type FusionPanelEntry = {
+  model: string
+  status: string
+  answer?: string
+  reason?: string
+  outputTokens?: number
+}
+
+type FusionJudgeView = {
+  status: string
+  decision?: string
+  synthesis?: string
+  resolvedAnswer?: string
+  error?: string
+}
+
+type FusionUsage = {
+  inputTokens?: number
+  outputTokens?: number
+}
+
+type FusionEvidenceView = {
+  runId?: string
+  question?: string
+  panel: FusionPanelEntry[]
+  judge: FusionJudgeView | null
+  usage: FusionUsage | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key]
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+function numberField(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function parsePanel(meta: Record<string, unknown>): FusionPanelEntry[] {
+  const panel = meta.panel
+  if (!Array.isArray(panel)) return []
+  return panel.flatMap((item) => {
+    if (!isRecord(item)) return []
+    return [{
+      model: stringField(item, 'model') ?? '?',
+      status: stringField(item, 'status') ?? 'unknown',
+      answer: stringField(item, 'answer'),
+      reason: stringField(item, 'reason'),
+      outputTokens: numberField(item, 'output_tokens'),
+    }]
+  })
+}
+
+function parseJudge(meta: Record<string, unknown>): FusionJudgeView | null {
+  const judge = meta.judge
+  if (!isRecord(judge)) return null
+  return {
+    status: stringField(judge, 'status') ?? 'unknown',
+    decision: stringField(judge, 'decision'),
+    synthesis: stringField(judge, 'synthesis'),
+    resolvedAnswer: stringField(judge, 'resolved_answer'),
+    error: stringField(judge, 'error'),
+  }
+}
+
+function parseUsage(meta: Record<string, unknown>): FusionUsage | null {
+  const usage = meta.observed_usage
+  if (!isRecord(usage)) return null
+  const inputTokens = numberField(usage, 'input_tokens')
+  const outputTokens = numberField(usage, 'output_tokens')
+  return inputTokens === undefined && outputTokens === undefined
+    ? null
+    : { inputTokens, outputTokens }
+}
+
+function parseFusionEvidence(meta: BoardPost['meta'] | undefined | null): FusionEvidenceView | null {
+  if (!isRecord(meta)) return null
+  const panel = parsePanel(meta)
+  const judge = parseJudge(meta)
+  const source = stringField(meta, 'source')
+  const runId = stringField(meta, 'run_id')
+  const isFusion = source === 'fusion' || (panel.length > 0 && (judge !== null || Boolean(runId)))
+  if (!isFusion) return null
+  return {
+    runId,
+    question: stringField(meta, 'question'),
+    panel,
+    judge,
+    usage: parseUsage(meta),
+  }
+}
+
+function formatTokens(value: number | undefined): string | null {
+  return value === undefined ? null : `${value.toLocaleString()} tok`
+}
+
+function statusClass(status: string): string {
+  return status === 'answered' || status === 'synthesized'
+    ? 'border-[var(--ok-30)] bg-[var(--ok-soft)] text-[var(--color-status-ok)]'
+    : status === 'failed'
+      ? 'border-[var(--bad-30)] bg-[var(--bad-15)] text-[var(--bad-light)]'
+      : 'border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)]'
+}
+
+function metaChip(label: string, value: string | number | null | undefined) {
+  if (value === null || value === undefined || value === '') return null
+  return html`
+    <span class="inline-flex items-center gap-1 rounded-[var(--r-1)] border border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs text-[var(--color-fg-secondary)]">
+      <span class="font-mono uppercase tracking-wide text-[var(--color-fg-muted)]">${label}</span>
+      <span class="font-mono">${value}</span>
+    </span>
+  `
+}
+
+function PanelCard({ panel }: { panel: FusionPanelEntry }) {
+  const tokenLabel = formatTokens(panel.outputTokens)
+  return html`
+    <article class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-divider)] bg-[var(--color-bg-surface)] p-3" data-fusion-panel>
+      <div class="mb-2 flex flex-wrap items-center gap-2">
+        <span class="min-w-0 break-all font-mono text-2xs text-[var(--color-fg-secondary)]">${panel.model}</span>
+        <span class=${`inline-flex rounded-[var(--r-0)] border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wide ${statusClass(panel.status)}`}>${panel.status}</span>
+        ${tokenLabel ? html`<span class="font-mono text-2xs text-[var(--color-fg-muted)]">${tokenLabel}</span>` : null}
+      </div>
+      ${panel.answer
+        ? html`<div class="max-h-72 overflow-y-auto"><${RichContent} text=${panel.answer} previewLimit=${0} /></div>`
+        : null}
+      ${panel.reason
+        ? html`<div class="text-xs leading-relaxed text-[var(--bad-light)]">${panel.reason}</div>`
+        : null}
+    </article>
+  `
+}
+
+function JudgeBlock({ judge }: { judge: FusionJudgeView }) {
+  const body = judge.synthesis ?? judge.resolvedAnswer ?? judge.error
+  return html`
+    <section class="rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] p-3" data-fusion-judge>
+      <div class="mb-2 flex flex-wrap items-center gap-2">
+        <span class="font-semibold text-[var(--color-fg-secondary)]">심판 종합</span>
+        <span class=${`inline-flex rounded-[var(--r-0)] border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wide ${statusClass(judge.status)}`}>${judge.status}</span>
+        ${judge.decision ? html`<span class="font-mono text-2xs text-[var(--color-fg-muted)]">${judge.decision}</span>` : null}
+      </div>
+      ${body
+        ? html`<${RichContent} text=${body} previewLimit=${0} />`
+        : html`<div class="text-xs text-[var(--color-fg-muted)]">심판 상세가 비어 있습니다.</div>`}
+    </section>
+  `
+}
+
+export function FusionBoardEvidence({
+  post,
+  class: className,
+}: {
+  post: Pick<BoardPost, 'meta'>
+  class?: string
+}) {
+  const evidence = parseFusionEvidence(post.meta)
+  if (!evidence) return null
+
+  const answeredCount = evidence.panel.filter(panel => panel.status === 'answered').length
+  const rootClass = [
+    'rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-bg-surface)] p-4',
+    className,
+  ].filter(Boolean).join(' ')
+  return html`
+    <section
+      class=${rootClass}
+      aria-label="Fusion 심의 증거"
+      data-testid="fusion-board-evidence"
+    >
+      <div class="mb-3 flex flex-wrap items-start gap-2">
+        <div class="min-w-0 flex-1">
+          <h2 class="m-0 text-sm font-semibold text-[var(--color-fg-secondary)]">Fusion 심의 증거</h2>
+          <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-muted)]">패널 답변과 심판 종합은 board meta_json에서 렌더됩니다.</div>
+        </div>
+        ${metaChip('run', evidence.runId)}
+        ${metaChip('panel', `${answeredCount}/${evidence.panel.length}`)}
+        ${metaChip('out', formatTokens(evidence.usage?.outputTokens))}
+      </div>
+
+      ${evidence.question
+        ? html`
+          <div class="mb-3 rounded-[var(--r-1)] border border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] p-3" data-fusion-question>
+            <div class="mb-1 font-mono text-3xs uppercase tracking-wide text-[var(--color-fg-muted)]">question</div>
+            <div class="text-xs leading-relaxed text-[var(--color-fg-primary)]">${evidence.question}</div>
+          </div>
+        `
+        : null}
+
+      ${evidence.judge ? html`<${JudgeBlock} judge=${evidence.judge} />` : null}
+
+      <div class="mt-3 grid gap-2" data-fusion-panel-list>
+        ${evidence.panel.map((panel, index) => html`<${PanelCard} key=${`${panel.model}-${index}`} panel=${panel} />`)}
+      </div>
+    </section>
+  `
+}

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -660,6 +660,7 @@ describe('PostDetail', () => {
             model: 'ollama_cloud.kimi-k2-6',
             status: 'answered',
             answer: 'Panel one answer',
+            input_tokens: 700,
             output_tokens: 1200,
           },
           {
@@ -671,7 +672,7 @@ describe('PostDetail', () => {
         judge: {
           status: 'synthesized',
           decision: 'answer — ship',
-          synthesis: 'Judge synthesis answer',
+          synthesis: '**[judge]** synthesis\n\n**Consensus**\n- Judge synthesis answer (models: ollama_cloud.kimi-k2-6)\n\n**Resolved answer**\nShip it.\n\n**Decision**: answer — ship\n',
           resolved_answer: 'Resolved answer fallback',
         },
         observed_usage: {
@@ -691,6 +692,8 @@ describe('PostDetail', () => {
     expect(evidence).toHaveTextContent('Should we ship the fusion board renderer?')
     expect(evidence).toHaveTextContent('Panel one answer')
     expect(evidence).toHaveTextContent('Timeout')
+    expect(evidence).toHaveTextContent('**[judge]** synthesis')
+    expect(evidence).toHaveTextContent('Consensus')
     expect(evidence).toHaveTextContent('Judge synthesis answer')
     expect(evidence).not.toHaveTextContent('Resolved answer fallback')
     expect(container.querySelectorAll('[data-fusion-panel]')).toHaveLength(2)

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -638,6 +638,89 @@ describe('PostDetail', () => {
     expect(audit).toHaveTextContent('목록 정렬/필터에 따라 위치가 바뀔 수 있습니다.')
   })
 
+  it('renders fusion panel and judge evidence from board meta', () => {
+    const post = {
+      id: 'post-fusion',
+      author: 'fusion-keeper',
+      title: 'Fusion deliberation (run fus-1): answer',
+      body: 'Fusion deliberation headline',
+      content: 'Fusion deliberation headline',
+      created_at: '2026-06-19T00:00:00Z',
+      updated_at: '2026-06-19T00:00:00Z',
+      votes: 0,
+      comment_count: 0,
+      post_kind: 'system',
+      comments: [],
+      meta: {
+        source: 'fusion',
+        run_id: 'fus-1234567890',
+        question: 'Should we ship the fusion board renderer?',
+        panel: [
+          {
+            model: 'ollama_cloud.kimi-k2-6',
+            status: 'answered',
+            answer: 'Panel one answer',
+            output_tokens: 1200,
+          },
+          {
+            model: 'ollama_cloud.minimax-m3',
+            status: 'failed',
+            reason: 'Timeout',
+          },
+        ],
+        judge: {
+          status: 'synthesized',
+          decision: 'answer — ship',
+          synthesis: 'Judge synthesis answer',
+          resolved_answer: 'Resolved answer fallback',
+        },
+        observed_usage: {
+          input_tokens: 300,
+          output_tokens: 3432,
+        },
+      },
+    } as any
+
+    const { container } = render(h(PostDetail, { post }))
+
+    const evidence = screen.getByTestId('fusion-board-evidence')
+    expect(evidence).toHaveTextContent('Fusion 심의 증거')
+    expect(evidence).toHaveTextContent('fus-1234567890')
+    expect(evidence).toHaveTextContent('1/2')
+    expect(evidence).toHaveTextContent('3,432 tok')
+    expect(evidence).toHaveTextContent('Should we ship the fusion board renderer?')
+    expect(evidence).toHaveTextContent('Panel one answer')
+    expect(evidence).toHaveTextContent('Timeout')
+    expect(evidence).toHaveTextContent('Judge synthesis answer')
+    expect(evidence).not.toHaveTextContent('Resolved answer fallback')
+    expect(container.querySelectorAll('[data-fusion-panel]')).toHaveLength(2)
+  })
+
+  it('does not render fusion evidence for ordinary board meta', () => {
+    const post = {
+      id: 'post-ordinary',
+      author: 'sleepers',
+      title: 'Post',
+      body: 'Body',
+      content: 'Body',
+      created_at: '2026-06-19T00:00:00Z',
+      updated_at: '2026-06-19T00:00:00Z',
+      votes: 0,
+      comment_count: 0,
+      post_kind: 'direct',
+      comments: [],
+      meta: {
+        source: 'manual',
+        state_block: 'state only',
+      },
+    } as any
+
+    render(h(PostDetail, { post }))
+
+    expect(screen.queryByTestId('fusion-board-evidence')).not.toBeInTheDocument()
+    expect(screen.getByText(/출처:/)).toBeInTheDocument()
+  })
+
   it('renders and clears the board comment route focus receipt', () => {
     const post = {
       id: 'post-1',

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -15,6 +15,7 @@ import { route } from '../../router'
 import { votePost, voteComment } from '../../api/board'
 import { ModerationBadge } from './moderation-badge'
 import { ReactionBar } from './reaction-bar'
+import { FusionBoardEvidence } from './fusion-evidence'
 import {
   boardActorAvatarKey,
   boardActorDisplayName,
@@ -568,6 +569,8 @@ export function PostDetail({ post }: { post: BoardPost }) {
           <div class="text-sm text-[var(--color-fg-primary)] leading-loose">
             <${RichContent} text=${stripStateBlocks(post.body)} previewLimit=${4} />
           </div>
+
+          <${FusionBoardEvidence} post=${post} />
 
           <!-- Author and meta -->
           <div class="flex gap-2.5 items-center flex-wrap pt-3 border-t border-[var(--color-border-divider)]">


### PR DESCRIPTION
## Summary
- Add a board fusion evidence renderer for `meta.panel`, `meta.judge`, `meta.question`, `meta.run_id`, and token usage.
- Render the evidence block in both board route post detail and the right-side thread detail.
- Cover fusion and ordinary meta behavior in `post-detail.test.ts`.

## Why
`fusion-spec.html` section 8 option B called out that fusion board posts preserved structured evidence in `meta_json`, but board UI only exposed source/state metadata. This PR makes the board post the durable evidence surface while keeping the data source in board meta.

## Validation
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/board/post-detail.test.ts --no-file-parallelism --maxWorkers=1`
- `gtimeout 120s pnpm --dir dashboard exec tsc --noEmit --pretty false`
- Playwright fallback smoke against `http://127.0.0.1:5178/dashboard/#board` with synthetic `/api/v1/dashboard/board` and `/api/v1/board/fusion-post-1` responses; checked desktop and mobile screenshots at `/private/tmp/masc-fusion-board-desktop.png` and `/private/tmp/masc-fusion-board-mobile.png`.

## Notes
- Live board currently had no real fusion post during validation, so the browser smoke used route interception rather than mutating runtime board state.