### PR TITLE
fix(keeper): keep turn event bus drain alive

### DIFF
--- a/lib/keeper/keeper_unified_turn_event_bus.ml
+++ b/lib/keeper/keeper_unified_turn_event_bus.ml
@@ -199,9 +199,12 @@ let start_background_drain ~clock t =
           let rec loop () =
             try
               let _summary = drain ~site:"background_poll" t in
-              ()
+              Eio.Time.sleep clock (Keeper_turn_helpers.turn_event_bus_drain_interval_sec ());
+              loop ()
             with
-            | Eio.Cancel.Cancelled _ as e -> raise e
+            | Eio.Cancel.Cancelled _ ->
+              (* [unsubscribe] cancels this background worker as normal teardown. *)
+              ()
             | exn ->
               Log.Keeper.warn
                 "%s: keeper_turn event-bus drain failed: %s"

--- a/scripts/lint/tool-keeper-boundary-ratchet.sh
+++ b/scripts/lint/tool-keeper-boundary-ratchet.sh
@@ -92,7 +92,9 @@ current_callers() {
     done < <(
       {
         find lib \( -name 'tool_*.ml' -o -name 'tool_*.mli' \) ! -name '*test*'
-        printf '%s\n' lib/tools.ml lib/tools.mli
+        for f in lib/tools.ml lib/tools.mli; do
+          [[ -f "$f" ]] && printf '%s\n' "$f"
+        done
       } | sort -u
     )
   ) | sort -u

--- a/test/dune
+++ b/test/dune
@@ -2227,7 +2227,7 @@
 (test
  (name test_keeper_unified_turn_event_bus)
  (modules test_keeper_unified_turn_event_bus)
- (libraries masc_test_deps masc.runtime))
+ (libraries masc_test_deps masc.runtime masc.keeper_event_bus))
 
 ; Adversarial-review follow-ups: ref -> Atomic conversions (S5-S7).
 

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -173,6 +173,41 @@ let test_take_drain_cancel_clears_active_without_spin () =
     (match get_drain_cancel t with Closed -> true | _ -> false)
 ;;
 
+let test_background_drain_continues_after_first_poll () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  Eio_context.with_test_env
+    ~net:env#net
+    ~clock:env#clock
+    ~mono_clock:env#mono_clock
+    ~sw
+  @@ fun () ->
+  let bus = Agent_sdk.Event_bus.create () in
+  Keeper_event_bus.set bus;
+  let t = EB.create ~keeper_name:"a" ~turn_id:1 () in
+  let interval = Masc.Keeper_turn_helpers.turn_event_bus_drain_interval_sec () in
+  let rec wait_for_event_count expected attempts =
+    if (EB.For_testing.get_state t).summary.event_count >= expected
+    then true
+    else if attempts <= 0
+    then false
+    else (
+      Eio.Time.sleep env#clock interval;
+      wait_for_event_count expected (attempts - 1))
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      match EB.For_testing.take_drain_cancel t with
+      | None -> ()
+      | Some cc -> Eio.Cancel.cancel cc (Failure "background_drain_test_done"))
+    (fun () ->
+       Agent_sdk.Event_bus.publish bus (tool_called "first");
+       EB.start_background_drain ~clock:env#clock t;
+       check bool "first event drained" true (wait_for_event_count 1 20);
+       Agent_sdk.Event_bus.publish bus (tool_called "second");
+       check bool "background drain keeps polling" true (wait_for_event_count 2 20))
+;;
+
 let () =
   Alcotest.run
     "keeper-unified-turn-event-bus"
@@ -191,6 +226,10 @@ let () =
     ; ( "concurrency"
       , [ test_case "pure transitions under concurrent domains" `Quick
             test_state_pending_count_integrity_under_concurrent_updates
+        ] )
+    ; ( "background-drain"
+      , [ test_case "continues after first poll" `Quick
+            test_background_drain_continues_after_first_poll
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- Keep the keeper turn event-bus background drain alive after its first successful poll.
- Treat explicit background-drain cancellation as normal teardown instead of bubbling cancellation out of the worker fiber.
- Make `tool-keeper-boundary-ratchet.sh` skip optional `lib/tools.*` files when they are absent, removing misleading stderr on green runs.
- Add a focused regression test proving the background drain captures a second event after the first poll.

## Product impact

- User-visible change: none directly. Runtime effect is more reliable per-turn tool event capture for keeper turn summaries/FSM observation.

## Evidence

- PASS: `env DUNE_BUILD_DIR=/private/tmp/masc-dune-fix-adversarial-tool-hardening dune build --root /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/fix-adversarial-tool-hardening-20260620 @runtest-test_keeper_unified_turn_event_bus`
- PASS: `bash scripts/lint/tool-keeper-boundary-ratchet.sh`
- PASS: `bash scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json`
- PASS: `bash scripts/lint-spawn-bounded.sh`
- PASS: `bash -n scripts/lint/tool-keeper-boundary-ratchet.sh`
- PASS: `git diff --check`
- Note: `scripts/dune-local.sh build @runtest-test_keeper_unified_turn_event_bus` was attempted but blocked behind an unrelated active `/tmp/me-dune-local.lock` holder, so the focused Dune test was run with an isolated `/private/tmp` build dir instead.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: operator_proxy
stages:
  - command: "env DUNE_BUILD_DIR=/private/tmp/masc-dune-fix-adversarial-tool-hardening dune build --root /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/fix-adversarial-tool-hardening-20260620 @runtest-test_keeper_unified_turn_event_bus"
    result: pass
  - command: "bash scripts/lint/tool-keeper-boundary-ratchet.sh"
    result: pass
  - command: "bash scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json"
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — adversarial review found the turn event-bus background drain did not continue after a clean first poll; boundary ratchet emitted missing-file stderr despite green status.
- [x] Orient — mapped to keeper turn event-bus drain lifecycle and tool/keeper boundary ratchet hygiene.
- [x] Decide — bounded to low-risk MASC-local runtime/test/script fixes; provider/OAS capability findings are intentionally left out of this PR.
- [x] Act — code/test/script changed in the smallest bounded scope; rollback is reverting this commit.
- [x] Verify — focused regression test and local guard scripts passed as listed above.
- [x] Loop — remaining provider/OAS boundary findings are not fixed here by design.

## Review evidence

- Source: local adversarial review in the previous turn; no cross-model review run for this small follow-up.

## Linked issue

- Relates #21653

## Variant addition checklist

- [x] **OCaml** — no variant added/removed.
- [x] **TypeScript** — not applicable.
- [x] **TLA+ spec** — not applicable.
- [x] **Event / JSON schema** — not applicable.
- [ ] **`make check-variants` passes** — not run; no variant/schema/domain literal change.
