### PR TITLE
[codex] fix memory os concurrency guards

### DIFF
--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -385,6 +385,10 @@ let institution_file (config : config) =
   Filename.concat (Workspace_utils.masc_dir config) "institution.json"
 ;;
 
+let with_institution_lock config f =
+  File_lock_eio.with_lock (institution_file config) f
+;;
+
 let load_institution ~fs (config : config) : institution option =
   let file = institution_file config in
   let path = Eio.Path.(fs / file) in
@@ -396,7 +400,7 @@ let load_institution ~fs (config : config) : institution option =
   | Eio.Io _ | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
 ;;
 
-let save_institution ~fs (config : config) (inst : institution) =
+let save_institution_unlocked ~fs (config : config) (inst : institution) =
   let file = institution_file config in
   let path = Eio.Path.(fs / file) in
   let dir = Filename.dirname file in
@@ -406,6 +410,10 @@ let save_institution ~fs (config : config) (inst : institution) =
   let json = institution_to_json inst in
   let content = Yojson.Safe.pretty_to_string json in
   Eio.Path.save ~create:(`Or_truncate 0o644) path content
+;;
+
+let save_institution ~fs config inst =
+  with_institution_lock config (fun () -> save_institution_unlocked ~fs config inst)
 ;;
 
 (** {1 Pure Transformations} *)
@@ -523,12 +531,13 @@ end
 (** {1 Effectful Operations (Eio)} *)
 
 let get_or_create ~fs (config : config) ~name ~mission =
-  match load_institution ~fs config with
-  | Some inst -> inst
-  | None ->
-    let inst = create_institution ~name ~mission () in
-    save_institution ~fs config inst;
-    inst
+  with_institution_lock config (fun () ->
+    match load_institution ~fs config with
+    | Some inst -> inst
+    | None ->
+      let inst = create_institution ~name ~mission () in
+      save_institution_unlocked ~fs config inst;
+      inst)
 ;;
 
 let record_episode ~fs config inst ~event_type ~summary ~participants ~outcome ~learnings =
@@ -750,8 +759,7 @@ let format_for_welcome (inst : institution) : string =
 *)
 let load_and_format_for_welcome ~fs:_ (config : config) : string =
   let file = institution_file config in
-  if Fs_compat.file_exists file
-  then (
+  with_institution_lock config (fun () ->
     try
       let content = Fs_compat.load_file file in
       let json = Yojson.Safe.from_string content in
@@ -759,7 +767,14 @@ let load_and_format_for_welcome ~fs:_ (config : config) : string =
       format_for_welcome inst
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | (Sys_error _ | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _) as exn ->
+    | Sys_error _ as exn ->
+      if Sys.file_exists file
+      then
+        Log.Institution.warn
+          "[load_and_format_for_welcome] institution read failed: %s"
+          (Printexc.to_string exn);
+      ""
+    | (Yojson.Json_error _ | Yojson.Safe.Util.Type_error _) as exn ->
       Log.Institution.warn
         "[load_and_format_for_welcome] institution read failed: %s"
         (Printexc.to_string exn);
@@ -767,7 +782,6 @@ let load_and_format_for_welcome ~fs:_ (config : config) : string =
     | exn ->
       Log.Misc.error "Unexpected institution load error: %s" (Printexc.to_string exn);
       "")
-  else ""
 ;;
 
 (** {1 Lightweight JSONL Episode Recording (No Eio Required)}
@@ -842,9 +856,10 @@ let episodes_jsonl_default_cap = 500
 
 let cap_episodes_jsonl ?(max_lines = episodes_jsonl_default_cap) () : int =
   let path = episodes_jsonl_path () in
-  if not (Sys.file_exists path)
-  then 0
-  else (
+  File_lock_eio.with_lock path (fun () ->
+    if not (Sys.file_exists path)
+    then 0
+    else (
     (* Bounded ring + total counter — O(max_lines) memory regardless
        of input size. The ring holds the trailing [max_lines] parsed
        JSON values that survive into the rewrite. *)
@@ -861,16 +876,18 @@ let cap_episodes_jsonl ?(max_lines = episodes_jsonl_default_cap) () : int =
     if total <= max_lines
     then 0
     else (
-      let tmp_path = path ^ ".tmp" in
-      let oc = open_out tmp_path in
-      Eio_guard.protect
-        ~finally:(fun () -> close_out_noerr oc)
-        (fun () ->
-           Queue.iter
-             (fun line ->
-                output_string oc (Yojson.Safe.to_string line);
-                output_char oc '\n')
-             buf);
-      Sys.rename tmp_path path;
-      total - max_lines))
+      let content =
+        let out = Buffer.create 4096 in
+        Queue.iter
+          (fun line ->
+             Buffer.add_string out (Yojson.Safe.to_string line);
+             Buffer.add_char out '\n')
+          buf;
+        Buffer.contents out
+      in
+      match Fs_compat.save_file_atomic path content with
+      | Ok () -> total - max_lines
+      | Error msg ->
+        Log.Institution.warn "JSONL episode cap failed: %s" msg;
+        0)))
 ;;

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -401,7 +401,10 @@ let extract_and_append_with_provider
     inp
   =
   let generation =
-    Keeper_memory_os_io.next_generation ~keeper_id ~trace_id:inp.Keeper_librarian.trace_id
+    Keeper_memory_os_io.next_generation_with_floor
+      ~floor:inp.Keeper_librarian.generation
+      ~keeper_id
+      ~trace_id:inp.Keeper_librarian.trace_id
   in
   match extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~generation inp with
   | Error _ as e -> e

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -143,23 +143,28 @@ let run ?(dry_run = false) ?min_keepers ~keeper_ids ~now () =
   let source_ids =
     List.filter (fun id -> not (String.equal id shared_store_id)) keeper_ids
   in
-  let rec read_sources acc = function
-    | [] -> Ok (List.rev acc)
-    | id :: rest ->
-      (match Io.read_facts_all_strict ~keeper_id:id with
-       | Ok facts -> read_sources ((id, facts) :: acc) rest
-       | Error message -> Error message)
-  in
-  match read_sources [] source_ids with
-  | Error message -> invalid_arg ("memory os consolidation input invalid: " ^ message)
-  | Ok keeper_facts ->
-    let considered, promoted =
-      promote_facts ?min_keepers ~now ~keeper_facts ()
+  let run_unlocked () =
+    let rec read_sources acc = function
+      | [] -> Ok (List.rev acc)
+      | id :: rest ->
+        (match Io.read_facts_all_strict ~keeper_id:id with
+         | Ok facts -> read_sources ((id, facts) :: acc) rest
+         | Error message -> Error message)
     in
-    if not dry_run then Io.rewrite_facts_atomically ~keeper_id:shared_store_id promoted;
-    { keepers_scanned = List.length source_ids
-    ; claims_considered = considered
-    ; promoted = List.length promoted
-    ; dry_run
-    }
+    match read_sources [] source_ids with
+    | Error message -> invalid_arg ("memory os consolidation input invalid: " ^ message)
+    | Ok keeper_facts ->
+      let considered, promoted =
+        promote_facts ?min_keepers ~now ~keeper_facts ()
+      in
+      if not dry_run then Io.rewrite_facts_atomically ~keeper_id:shared_store_id promoted;
+      { keepers_scanned = List.length source_ids
+      ; claims_considered = considered
+      ; promoted = List.length promoted
+      ; dry_run
+      }
+  in
+  if dry_run
+  then run_unlocked ()
+  else File_lock_eio.with_lock (Io.facts_path ~keeper_id:shared_store_id) run_unlocked
 ;;

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -92,89 +92,11 @@ let episode_path ~keeper_id ~trace_id ~generation =
     (Printf.sprintf "%s-g%04d.json" trace_id generation)
 ;;
 
-(** Compute the next generation number for a trace's episode files.
-
-    Scans the episodes directory for files matching [trace_id-gNNNN.json]
-    and returns [max_gen + 1].  This is a **single-writer** operation:
-    concurrent callers for the same [trace_id] will race on the directory
-    scan and may produce duplicate generation numbers.  The caller must
-    ensure at most one fiber calls [next_generation] for a given
-    [trace_id] at a time (e.g. via a per-trace sequencer or by running
-    all extractions for one trace on a single fiber). *)
-let next_generation ~keeper_id ~trace_id =
-  let dir = episodes_dir ~keeper_id in
-  let prefix = Printf.sprintf "%s-g" trace_id in
-  let max_gen =
-    Sys.readdir dir
-    |> Array.to_list
-    |> List.filter_map (fun name ->
-      if String.starts_with ~prefix name then
-        let plen = String.length prefix in
-        let rest = String.sub name plen (String.length name - plen) in
-        if String.length rest >= 4 then int_of_string_opt (String.sub rest 0 4) else None
-      else None)
-    |> List.fold_left max (-1)
-  in
-  max_gen + 1
-;;
-
-let unique_episode_path ~keeper_id episode =
-  let created_ms =
-    episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float
-  in
-  let base =
-    Filename.concat
-      (episodes_dir ~keeper_id)
-      (Printf.sprintf
-         "%s-g%04d-t%013Ld"
-         episode.trace_id
-         episode.generation
-         created_ms)
-  in
-  let rec loop suffix =
-    let path =
-      if suffix = 0
-      then base ^ ".json"
-      else Printf.sprintf "%s-%04d.json" base suffix
-    in
-    if Sys.file_exists path then loop (suffix + 1) else path
-  in
-  loop 0
-;;
-
-(* ---------- Append helpers ---------- *)
-
 let remove_noerr path =
   try
     if Sys.file_exists path then Sys.remove path
   with
   | Sys_error _ | Unix.Unix_error _ -> ()
-;;
-
-let append_line path line =
-  ensure_dir (Filename.dirname path);
-  let oc = open_out_gen [ Open_append; Open_creat; Open_text ] 0o644 path in
-  let close_attempted = ref false in
-  try
-    output_string oc (line ^ "\n");
-    close_attempted := true;
-    close_out oc
-  with
-  | exn ->
-    if not !close_attempted then close_out_noerr oc;
-    raise exn
-;;
-
-let append_json path json =
-  append_line path (Yojson.Safe.to_string json)
-;;
-
-let append_fact ~keeper_id fact =
-  append_json (facts_path ~keeper_id) (fact_to_json fact)
-;;
-
-let append_event ~keeper_id episode =
-  append_json (events_path ~keeper_id) (episode_to_json episode)
 ;;
 
 let write_file_atomically path content =
@@ -204,6 +126,113 @@ let write_file_atomically path content =
     if not !close_attempted then close_out_noerr oc;
     remove_noerr tmp;
     raise exn
+;;
+
+let generation_counter_path ~keeper_id ~trace_id =
+  Filename.concat (episodes_dir ~keeper_id) (Printf.sprintf "%s.generation" trace_id)
+;;
+
+let max_generation_from_files ~keeper_id ~trace_id =
+  let dir = episodes_dir ~keeper_id in
+  let prefix = Printf.sprintf "%s-g" trace_id in
+  Sys.readdir dir
+  |> Array.to_list
+  |> List.filter_map (fun name ->
+    if String.starts_with ~prefix name then
+      let plen = String.length prefix in
+      let rest = String.sub name plen (String.length name - plen) in
+      if String.length rest >= 4 then int_of_string_opt (String.sub rest 0 4) else None
+    else None)
+  |> List.fold_left max (-1)
+;;
+
+let read_generation_counter path =
+  if not (Sys.file_exists path)
+  then None
+  else (
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let len = in_channel_length ic in
+         really_input_string ic len |> String.trim |> int_of_string_opt))
+;;
+
+(** Compute the next generation number for a trace's episode files.
+
+    Scans the episodes directory for files matching [trace_id-gNNNN.json]
+    and reserves [max(floor, max_gen + 1, counter_next)] under a per-trace file
+    lock. The counter intentionally allows gaps when extraction later fails;
+    uniqueness is more important than contiguous numbering across fibers or
+    processes. *)
+let next_generation_with_floor ~floor ~keeper_id ~trace_id =
+  let counter_path = generation_counter_path ~keeper_id ~trace_id in
+  File_lock_eio.with_lock counter_path (fun () ->
+    let next_from_files = max_generation_from_files ~keeper_id ~trace_id + 1 in
+    let next_from_counter =
+      match read_generation_counter counter_path with
+      | Some next -> next
+      | None -> 0
+    in
+    let generation = max floor (max next_from_files next_from_counter) in
+    write_file_atomically counter_path (Printf.sprintf "%d\n" (generation + 1));
+    generation)
+;;
+
+let next_generation ~keeper_id ~trace_id =
+  next_generation_with_floor ~floor:0 ~keeper_id ~trace_id
+;;
+
+let unique_episode_path ~keeper_id episode =
+  let created_ms =
+    episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float
+  in
+  let base =
+    Filename.concat
+      (episodes_dir ~keeper_id)
+      (Printf.sprintf
+         "%s-g%04d-t%013Ld"
+         episode.trace_id
+         episode.generation
+         created_ms)
+  in
+  let rec loop suffix =
+    let path =
+      if suffix = 0
+      then base ^ ".json"
+      else Printf.sprintf "%s-%04d.json" base suffix
+    in
+    if Sys.file_exists path then loop (suffix + 1) else path
+  in
+  loop 0
+;;
+
+(* ---------- Append helpers ---------- *)
+
+let append_line path line =
+  ensure_dir (Filename.dirname path);
+  let oc = open_out_gen [ Open_append; Open_creat; Open_text ] 0o644 path in
+  let close_attempted = ref false in
+  try
+    output_string oc (line ^ "\n");
+    close_attempted := true;
+    close_out oc
+  with
+  | exn ->
+    if not !close_attempted then close_out_noerr oc;
+    raise exn
+;;
+
+let append_json path json =
+  append_line path (Yojson.Safe.to_string json)
+;;
+
+let append_fact ~keeper_id fact =
+  append_json (facts_path ~keeper_id) (fact_to_json fact)
+;;
+
+let append_event ~keeper_id episode =
+  append_json (events_path ~keeper_id) (episode_to_json episode)
 ;;
 
 let append_episode ~keeper_id episode =

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -18,7 +18,17 @@ val episodes_dir : keeper_id:string -> string
 val tool_results_dir : keeper_id:string -> string
 val tool_result_path : keeper_id:string -> tool_call_id:string -> string
 val episode_path : keeper_id:string -> trace_id:string -> generation:int -> string
+
+(** Reserve the next episode generation for [(keeper_id, trace_id)].
+    The reservation is serialized with a per-trace file lock and a small counter
+    file, so concurrent callers cannot receive the same generation. Gaps are
+    possible if a caller reserves a generation and later fails before appending
+    the episode. *)
 val next_generation : keeper_id:string -> trace_id:string -> int
+
+(** Like {!next_generation}, but preserves a caller-provided generation lower
+    bound while still advancing the counter past it. *)
+val next_generation_with_floor : floor:int -> keeper_id:string -> trace_id:string -> int
 
 (** {1 Atomic writes} *)
 

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -235,6 +235,19 @@ type render_result =
   ; n_facts_in_store : int
   }
 
+let with_fact_store_locks keeper_ids f =
+  let paths =
+    keeper_ids
+    |> List.map (fun keeper_id -> Keeper_memory_os_io.facts_path ~keeper_id)
+    |> List.sort_uniq String.compare
+  in
+  let rec loop = function
+    | [] -> f ()
+    | path :: rest -> File_lock_eio.with_lock path (fun () -> loop rest)
+  in
+  loop paths
+;;
+
 let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
   let max_facts = max 0 max_facts in
   let max_episodes = max 0 max_episodes in
@@ -248,27 +261,39 @@ let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
      facts. RFC-0247: order by the structural truth anchor (most-recently-verified
      first); the composite score, lexical seed-rerank, and spreading-activation
      reranking were all removed in the purge. *)
-  let all_facts =
-    Keeper_memory_os_io.read_facts_tail ~keeper_id ~n:Keeper_memory_os_io.fact_store_max
-  in
-  let n_facts_in_store = List.length all_facts in
-  let facts = all_facts |> facts_recency_ranked ~now |> take max_facts in
-  (* RFC-0244 Tier 2: append shared-semantic facts after the keeper's own, with
-     private precedence — a claim already surfaced from this keeper's store is not
-     repeated from the shared store. The shared store is read under the reserved
-     [shared_store_id]; reading it for the shared store itself is a no-op guard.
-     Unlike per-keeper stores, the consolidator rewrites the shared tier directly
-     and does not apply [fact_store_max], so recall must scan every shared fact
-     before ranking and taking the small communal slice. *)
-  let private_keys = List.map (fun f -> normalize_claim f.claim) facts in
-  let shared_facts =
-    if String.equal keeper_id shared_store_id
-    then []
-    else
-      Keeper_memory_os_io.read_facts_all ~keeper_id:shared_store_id
-      |> facts_recency_ranked ~now
-      |> List.filter (fun f -> not (List.mem (normalize_claim f.claim) private_keys))
-      |> take default_max_shared_facts
+  let facts, private_keys, shared_facts, n_facts_in_store =
+    let fact_store_ids =
+      if String.equal keeper_id shared_store_id
+      then [ keeper_id ]
+      else [ keeper_id; shared_store_id ]
+    in
+    with_fact_store_locks fact_store_ids (fun () ->
+      let all_facts =
+        Keeper_memory_os_io.read_facts_tail
+          ~keeper_id
+          ~n:Keeper_memory_os_io.fact_store_max
+      in
+      let n_facts_in_store = List.length all_facts in
+      let facts = all_facts |> facts_recency_ranked ~now |> take max_facts in
+      (* RFC-0244 Tier 2: append shared-semantic facts after the keeper's own,
+         with private precedence — a claim already surfaced from this keeper's
+         store is not repeated from the shared store. Both stores are read under
+         their facts locks in deterministic path order, so the private dedup keys
+         and shared slice come from one serialized snapshot boundary. Unlike
+         per-keeper stores, the consolidator rewrites the shared tier directly
+         and does not apply [fact_store_max], so recall must scan every shared
+         fact before ranking and taking the small communal slice. *)
+      let private_keys = List.map (fun f -> normalize_claim f.claim) facts in
+      let shared_facts =
+        if String.equal keeper_id shared_store_id
+        then []
+        else
+          Keeper_memory_os_io.read_facts_all ~keeper_id:shared_store_id
+          |> facts_recency_ranked ~now
+          |> List.filter (fun f -> not (List.mem (normalize_claim f.claim) private_keys))
+          |> take default_max_shared_facts
+      in
+      facts, private_keys, shared_facts, n_facts_in_store)
   in
   let episodes =
     Keeper_memory_os_io.read_episodes_tail

--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -41,6 +41,11 @@ let procedures_dir ~agent_name =
 let procedures_path ~agent_name =
   sprintf "%s/procedures.jsonl" (procedures_dir ~agent_name)
 
+let with_procedures_lock ~agent_name f =
+  let dir = procedures_dir ~agent_name in
+  Fs_compat.mkdir_p dir;
+  File_lock_eio.with_lock (procedures_path ~agent_name) f
+
 (* ================================================================ *)
 (* JSON Serialization                                               *)
 (* ================================================================ *)
@@ -87,29 +92,28 @@ let of_json (json : Yojson.Safe.t) : procedure option =
 (* ================================================================ *)
 
 let load_procedures ~agent_name : procedure list =
-  let path = procedures_path ~agent_name in
-  Fs_compat.load_jsonl path
-  |> List.filter_map of_json
+  with_procedures_lock ~agent_name (fun () ->
+    let path = procedures_path ~agent_name in
+    Fs_compat.load_jsonl path
+    |> List.filter_map of_json)
 
 let save_procedure ~agent_name (p : procedure) =
-  let dir = procedures_dir ~agent_name in
-  Fs_compat.mkdir_p dir;
-  let path = procedures_path ~agent_name in
-  Fs_compat.append_jsonl path (to_json p)
+  with_procedures_lock ~agent_name (fun () ->
+    let path = procedures_path ~agent_name in
+    Fs_compat.append_jsonl path (to_json p))
 
 let rewrite_procedures ~agent_name (procs : procedure list) =
-  let dir = procedures_dir ~agent_name in
-  Fs_compat.mkdir_p dir;
-  let path = procedures_path ~agent_name in
-  let content =
-    procs
-    |> List.map (fun p -> Yojson.Safe.to_string (to_json p))
-    |> String.concat "\n"
-    |> fun s -> if s = "" then "" else s ^ "\n"
-  in
-  match Fs_compat.save_file_atomic path content with
-  | Ok () -> ()
-  | Error msg -> Log.Config.warn "procedural_memory save: %s" msg
+  with_procedures_lock ~agent_name (fun () ->
+    let path = procedures_path ~agent_name in
+    let content =
+      procs
+      |> List.map (fun p -> Yojson.Safe.to_string (to_json p))
+      |> String.concat "\n"
+      |> fun s -> if s = "" then "" else s ^ "\n"
+    in
+    match Fs_compat.save_file_atomic path content with
+    | Ok () -> ()
+    | Error msg -> Log.Config.warn "procedural_memory save: %s" msg)
 
 (** Minimum evidence count required for crystallization.
     Configurable via MASC_PROC_MIN_EVIDENCE (default: 3).

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -184,6 +184,14 @@ let wait_for_ref ~clock label r =
   | Eio.Time.Timeout -> Alcotest.failf "timed out waiting for %s" label
 ;;
 
+let with_eio_guard f =
+  let restore_eio_guard = Eio_guard.is_ready () in
+  Eio_guard.enable ();
+  Fun.protect
+    ~finally:(fun () -> if not restore_eio_guard then Eio_guard.disable ())
+    f
+;;
+
 let episode_fixture ~now ~trace_id ~generation ~summary =
   let fact =
     { (fact_fixture ~now ()) with
@@ -1024,6 +1032,38 @@ let test_next_generation_scans_episode_files () =
       "missing trace remains zero"
       0
       (Memory_io.next_generation ~keeper_id ~trace_id:"trace-missing"))
+;;
+
+let test_next_generation_reserves_without_episode_file () =
+  with_temp_keepers_dir (fun _keepers_dir ->
+    let keeper_id = "episode-generation-reservation-keeper" in
+    Alcotest.(check int)
+      "first reservation starts at zero"
+      0
+      (Memory_io.next_generation ~keeper_id ~trace_id:"trace-reserve");
+    Alcotest.(check int)
+      "second reservation advances even before append"
+      1
+      (Memory_io.next_generation ~keeper_id ~trace_id:"trace-reserve");
+    Memory_io.append_episode
+      ~keeper_id
+      (episode_fixture
+         ~now:1_000_000.0
+         ~trace_id:"trace-reserve"
+         ~generation:5
+         ~summary:"manual higher generation");
+    Alcotest.(check int)
+      "existing files still advance the reservation floor"
+      6
+      (Memory_io.next_generation ~keeper_id ~trace_id:"trace-reserve");
+    Alcotest.(check int)
+      "caller floor can reserve a higher generation"
+      12
+      (Memory_io.next_generation_with_floor ~floor:12 ~keeper_id ~trace_id:"trace-floor");
+    Alcotest.(check int)
+      "counter advances past caller floor"
+      13
+      (Memory_io.next_generation ~keeper_id ~trace_id:"trace-floor"))
 ;;
 
 let test_episode_file_tail_uses_created_at_not_filename () =
@@ -2217,6 +2257,71 @@ let test_consolidator_rejects_corrupt_source_store () =
         (contains (Memory_io.facts_path ~keeper_id:"alpha") msg);
       Alcotest.(check bool) "error includes line number" true (contains ":2:" msg))
 ;;
+
+let test_consolidator_waits_for_shared_store_lock () =
+  with_eio (fun ~sw ~net:_ ~clock ->
+    with_eio_guard (fun () ->
+      with_temp_keepers_dir (fun _keepers_dir ->
+        let now = 1_000_000.0 in
+        Memory_io.append_fact ~keeper_id:"alpha" (mk_shared_fixture ~now "locked shared claim");
+        Memory_io.append_fact ~keeper_id:"beta" (mk_shared_fixture ~now "locked shared claim");
+        let result = ref None in
+        let started, resolve_started = Eio.Promise.create () in
+        File_lock_eio.with_lock
+          (Memory_io.facts_path ~keeper_id:Types.shared_store_id)
+          (fun () ->
+             Eio.Fiber.fork ~sw (fun () ->
+               Eio.Promise.resolve resolve_started ();
+               result := Some (Consolidator.run ~keeper_ids:[ "alpha"; "beta" ] ~now ()));
+             Eio.Promise.await started;
+             Eio.Time.sleep clock 0.02;
+             Alcotest.(check bool)
+               "consolidator waits while shared store lock is held"
+               true
+               (Option.is_none !result));
+        wait_for_ref ~clock "consolidator after shared lock" result;
+        match !result with
+        | Some report ->
+          Alcotest.(check int) "claim promoted after lock release" 1 report.Consolidator.promoted
+        | None -> Alcotest.fail "expected consolidator report")))
+;;
+
+let test_recall_waits_for_shared_fact_lock () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_eio (fun ~sw ~net:_ ~clock ->
+        with_eio_guard (fun () ->
+          with_temp_keepers_dir (fun _keepers_dir ->
+            let now = 1_000_000.0 in
+            let shared_fact =
+              { (mk_shared_fixture ~now "locked recall shared fact") with
+                Types.observed_by = [ "alpha"; "beta" ]
+              }
+            in
+            Memory_io.append_fact ~keeper_id:Types.shared_store_id shared_fact;
+            let result = ref None in
+            let started, resolve_started = Eio.Promise.create () in
+            File_lock_eio.with_lock
+              (Memory_io.facts_path ~keeper_id:Types.shared_store_id)
+              (fun () ->
+                 Eio.Fiber.fork ~sw (fun () ->
+                   Eio.Promise.resolve resolve_started ();
+                   result := Some (Recall.render_context ~keeper_id:"observer" ~now ()));
+                 Eio.Promise.await started;
+                 Eio.Time.sleep clock 0.02;
+                 Alcotest.(check bool)
+                   "recall waits while shared fact lock is held"
+                   true
+                   (Option.is_none !result));
+            wait_for_ref ~clock "recall after shared lock" result;
+            match !result with
+            | Some block ->
+              Alcotest.(check bool)
+                "shared fact rendered after lock release"
+                true
+                (contains "locked recall shared fact" block)
+            | None -> Alcotest.fail "expected recall block")))))
+;;
 let test_librarian_provider_slot_gate_caps_at_capacity () =
   with_env "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT" "1" (fun () ->
     with_eio (fun ~sw ~net:_ ~clock ->
@@ -2487,6 +2592,10 @@ let () =
             `Quick
             test_next_generation_scans_episode_files
         ; Alcotest.test_case
+            "next generation reserves before episode append"
+            `Quick
+            test_next_generation_reserves_without_episode_file
+        ; Alcotest.test_case
             "episode file tail uses created_at"
             `Quick
             test_episode_file_tail_uses_created_at_not_filename
@@ -2629,9 +2738,17 @@ let () =
             `Quick
             test_recall_scans_whole_shared_store
         ; Alcotest.test_case
+            "recall waits for shared fact lock"
+            `Quick
+            test_recall_waits_for_shared_fact_lock
+        ; Alcotest.test_case
             "corrupt source store fails loud"
             `Quick
             test_consolidator_rejects_corrupt_source_store
+        ; Alcotest.test_case
+            "consolidator waits for shared store lock"
+            `Quick
+            test_consolidator_waits_for_shared_store_lock
         ] )
     ; ( "librarian runtime"
       , [ Alcotest.test_case


### PR DESCRIPTION
## What changed

- Added per-trace generation reservation for Memory OS episodes using `File_lock_eio`, plus a runtime floor path so librarian turns preserve the caller generation lower bound.
- Serialized shared-store consolidation writes on `_shared.facts.jsonl` and made recall read private/shared fact stores under a deterministic lock order.
- Added locking/atomic rewrite coverage to institution snapshot/JSONL cap paths and procedural-memory file operations.
- Added regression coverage for generation reservation, shared-store consolidation locking, and shared recall locking.

## Why

The adversarial audit found read-modify-write races in Memory OS, institution, and procedural-memory file stores. Single-file atomic writes were not enough when readers and rewriters interleaved across fibers or processes.

## Review response

- FD pressure: `File_lock_eio.with_lock` scopes every OS flock fd through `release_flock_fd`, and the in-process lock table is bounded by `max_lock_entries = 512` with stale-entry pruning. This PR adds lock usage but does not introduce long-lived fd ownership.
- Lock order: multi-store fact recall goes through `with_fact_store_locks`, which maps keeper ids to fact paths and applies `List.sort_uniq String.compare` before nested acquisition. Consolidation/librarian write paths take a single fact-store lock, so they cannot invert private/shared ordering.
- Existing tests cover generation reservation, shared consolidation locking, and shared recall locking; no extra code change was needed for the review note.

## Validation

- `scripts/opam-pin-external-deps.sh --install` to repair `agent_sdk` pin drift from `0.207.3` to `0.207.5`.
- `scripts/dune-local.sh build ./test/test_keeper_memory_os.exe`
- `./_build/default/test/test_keeper_memory_os.exe` (67 tests)
- `scripts/dune-local.sh build ./test/test_institution_ids.exe ./test/test_procedural_memory.exe`
- `./_build/default/test/test_institution_ids.exe` (1 test)
- `./_build/default/test/test_procedural_memory.exe` (5 tests)
- `git diff --check`
- `ocamlformat --check` on touched OCaml files
