### PR TITLE
fix(keeper): cap quota-driven runtime rotation

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -18,6 +18,10 @@ default = "ollama_cloud.deepseek-v4-flash"
 # process with MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID. Unset = inherit each
 # keeper's runtime (legacy).
 librarian = "ollama_cloud.minimax-m3"
+# Anti-rationalization/cross-verifier work asks for JSON and higher judgment.
+# Keep normal keeper turns on the fleet default flash runtime; reserve Pro for
+# this explicit smart lane.
+cross_verifier = "deepseek.deepseek-v4-pro"
 
 [providers.ollama_cloud]
 display-name = "Ollama Cloud"
@@ -234,6 +238,8 @@ max-concurrent = 1
 #
 # Seed only nick0cave to the local Gemma 4 canary. Other keepers use the
 # fleet default unless their live config overrides this seed.
+# Do not assign general keeper lanes to Pro here. Pro is reserved for explicit
+# judge/evaluator lanes ([runtime].cross_verifier and [fusion].judge).
 [runtime.assignments]
 nick0cave = "ollama.gemma4-26b-a4b-qat"
 
@@ -272,9 +278,9 @@ per_hour_budget = 20
 # 단계에서 fail-fast). 튜닝은 재컴파일 없이 이 값만 바꾸면 된다.
 [fusion.presets.trio]
 panel = [
-  "deepseek.deepseek-v4-pro",
-  "glm-coding.glm-5-turbo",
   "ollama_cloud.deepseek-v4-flash",
+  "glm-coding.glm-5-turbo",
+  "ollama_cloud.minimax-m3",
 ]
 judge = "deepseek.deepseek-v4-pro"
 panel_system_prompt = """

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -435,10 +435,10 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
            where OAS surfaces the error directly) should still trigger rotation
            when a different runtime may succeed.
 
-           429 rate-limit (non-hard-quota): keep it local to provider health
-           and do not rotate in the same turn. In practice this can be
-           account/session-scoped; treating it as fallback-worthy causes
-           all runtimes in the same credential pool to be hammered.
+           429 rate-limit (non-hard-quota): rotate only to candidates outside
+           the throttled runtime's credential pool. The filter lives at the
+           candidate boundary below, where runtime/provider credentials are
+           available.
 
            5xx server errors: the provider is unhealthy or overloaded; a
            different runtime may be healthy.
@@ -447,10 +447,12 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
            different runtime with different credentials may succeed.
 
            Hard-quota 429s are already handled above by sdk_error_is_hard_quota.
-           Soft (non-hard-quota) rate limits intentionally return [None]. *)
+           Soft (non-hard-quota) rate limits intentionally keep [Rate_limit]
+           so pool-aware candidate filtering can preserve independent-provider
+           failover. *)
         (match err with
          | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _) ->
-             None
+             Some Rate_limit
          | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _) ->
              Some Capacity_backpressure
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError { status; _ })
@@ -463,7 +465,7 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some Auth_error
          | Agent_sdk.Error.Provider
              (Llm_provider.Error.RateLimit _) ->
-             None
+             Some Rate_limit
          | Agent_sdk.Error.Provider (Llm_provider.Error.CapacityExhausted _) ->
              Some Capacity_backpressure
          | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) ->
@@ -490,8 +492,8 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
              | Llm_provider.Error.UnknownVariant _
              | Llm_provider.Error.ProviderTerminal _) ->
              None
-         (* Sub-500 server errors (4xx already handled above for AuthError /
-            RateLimited) are not classified as recoverable runtime failures. *)
+         (* Sub-500 server errors and remaining 4xx API errors are not
+            classified as recoverable runtime failures. *)
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
@@ -574,6 +576,21 @@ let degraded_rotation_candidates
   |> List.filter (fun candidate ->
          not (String.equal candidate normalized_effective))
 
+let filter_rate_limit_rotation_candidates
+      ~credential_pool_of_runtime_id
+      ~effective_runtime
+      candidates
+  =
+  match credential_pool_of_runtime_id effective_runtime with
+  | None -> candidates
+  | Some effective_pool ->
+    List.filter
+      (fun candidate ->
+         match credential_pool_of_runtime_id candidate with
+         | None -> true
+         | Some candidate_pool -> not (String.equal candidate_pool effective_pool))
+      candidates
+
 (** [true] when the error is a completion contract violation.
     Contract violations should cap rotation because retrying the same
     or different runtime will not satisfy the contract. Non-contract
@@ -595,9 +612,10 @@ let degraded_reason_allows_candidate_cycle = function
   | Auth_error -> true
 
 let degraded_rotation_after_recoverable_error
-    ?fallback_hint
-    ~(base_runtime : string)
-    ~(effective_runtime : string)
+      ?(credential_pool_of_runtime_id = fun _ -> None)
+      ?fallback_hint
+      ~(base_runtime : string)
+      ~(effective_runtime : string)
     ~(attempted_runtimes : string list)
     (err : Agent_sdk.Error.sdk_error) : degraded_retry option =
   match recoverable_runtime_failure_reason err with
@@ -617,6 +635,24 @@ let degraded_rotation_after_recoverable_error
           ~catalog_names
           ~fallback_hint
           ~base_runtime ~effective_runtime
+      in
+      let candidates =
+        match fallback_reason with
+        | Rate_limit ->
+          filter_rate_limit_rotation_candidates
+            ~credential_pool_of_runtime_id
+            ~effective_runtime
+            candidates
+        | Hard_quota
+        | Resumable_cli_session
+        | Admission_queue_timeout
+        | Provider_timeout
+        | Turn_timeout
+        | Runtime_candidates_filtered
+        | Runtime_exhausted
+        | Capacity_backpressure
+        | Server_error
+        | Auth_error -> candidates
       in
       let untried =
         List.find_opt

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -435,8 +435,10 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
            where OAS surfaces the error directly) should still trigger rotation
            when a different runtime may succeed.
 
-           429 rate-limit (non-hard-quota): the current provider is throttled;
-           a different runtime/provider may have capacity.
+           429 rate-limit (non-hard-quota): keep it local to provider health
+           and do not rotate in the same turn. In practice this can be
+           account/session-scoped; treating it as fallback-worthy causes
+           all runtimes in the same credential pool to be hammered.
 
            5xx server errors: the provider is unhealthy or overloaded; a
            different runtime may be healthy.
@@ -444,11 +446,11 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
            401/403 auth errors: the credential for this runtime is invalid; a
            different runtime with different credentials may succeed.
 
-           Hard-quota 429s are already handled above by sdk_error_is_hard_quota,
-           so only soft (non-hard-quota) rate limits reach this arm. *)
+           Hard-quota 429s are already handled above by sdk_error_is_hard_quota.
+           Soft (non-hard-quota) rate limits intentionally return [None]. *)
         (match err with
          | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _) ->
-             Some Rate_limit
+             None
          | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _) ->
              Some Capacity_backpressure
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError { status; _ })
@@ -461,7 +463,7 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some Auth_error
          | Agent_sdk.Error.Provider
              (Llm_provider.Error.RateLimit _) ->
-             Some Rate_limit
+             None
          | Agent_sdk.Error.Provider (Llm_provider.Error.CapacityExhausted _) ->
              Some Capacity_backpressure
          | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) ->
@@ -580,6 +582,18 @@ let degraded_rotation_candidates
 let is_completion_contract_violation (_ : Agent_sdk.Error.sdk_error) : bool =
   false
 
+let degraded_reason_allows_candidate_cycle = function
+  | Hard_quota | Rate_limit -> false
+  | Resumable_cli_session
+  | Admission_queue_timeout
+  | Provider_timeout
+  | Turn_timeout
+  | Runtime_candidates_filtered
+  | Runtime_exhausted
+  | Capacity_backpressure
+  | Server_error
+  | Auth_error -> true
+
 let degraded_rotation_after_recoverable_error
     ?fallback_hint
     ~(base_runtime : string)
@@ -613,18 +627,20 @@ let degraded_rotation_after_recoverable_error
       (match untried with
        | Some next_runtime ->
          Some { next_runtime; fallback_reason }
-       | None when not (is_completion_contract_violation err) ->
-         (* Non-contract errors (provider timeout, rate limit, server error)
-            are transient. Allow cycling through candidates again because
-            the same runtime may succeed on a subsequent attempt. Only
-            contract violations cap rotation — retrying cannot satisfy the
-            contract. #19930 *)
+       | None
+         when (not (is_completion_contract_violation err))
+              && degraded_reason_allows_candidate_cycle fallback_reason ->
+         (* Non-contract transient infrastructure errors (provider timeout,
+            server error, capacity backpressure) may succeed on a later
+            candidate pass. Quota/rate-limit classes cap after all candidates:
+            retrying the same credential pool just amplifies an account-scoped
+            limit. #19930 *)
          (match candidates with
           | [] -> None
           | first_candidate :: _ ->
             Some { next_runtime = first_candidate; fallback_reason })
        | None ->
-         (* Contract violation: all candidates exhausted. Cap rotation. *)
+         (* Contract violation or quota/rate-limit exhaustion: cap rotation. *)
          None)
 
 let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -133,7 +133,8 @@ val fallback_runtime_for_unavailable_profile :
 
     Status-code-aware rotation: raw API errors that are not wrapped in a MASC
     internal error are also classified when a different runtime may succeed:
-    - [RateLimited] (non-hard-quota) → ["rate_limit"]
+    - [RateLimited] hard-quota messages → ["hard_quota"]
+    - [RateLimited] soft provider throttles → [None] (provider cooldown only)
     - [Overloaded] and Cloudflare 524 → ["capacity_backpressure"]
     - [ServerError] with status >= 500 → ["server_error"]
     - [AuthError] → ["auth_error"]
@@ -161,10 +162,11 @@ val degraded_retry_after_recoverable_error :
     any other candidate; if it duplicates the effective runtime or has
     already been attempted, the next legal candidate is returned.
 
-    Non-contract errors (provider timeout, rate limit, server error) allow
-    cycling through candidates again when all are exhausted, because the
-    same runtime may succeed on a subsequent attempt. Contract violations
-    cap rotation — retrying cannot satisfy the contract.
+    Non-contract transient infrastructure errors (provider timeout, server
+    error, capacity backpressure) allow cycling through candidates again when
+    all are exhausted, because the same runtime may succeed on a subsequent
+    attempt. Contract violations and quota/rate-limit classes cap rotation:
+    retrying the same credential pool amplifies account-scoped limits.
     @since 0.174.0 *)
 val degraded_rotation_after_recoverable_error :
   ?fallback_hint:string ->

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -134,7 +134,8 @@ val fallback_runtime_for_unavailable_profile :
     Status-code-aware rotation: raw API errors that are not wrapped in a MASC
     internal error are also classified when a different runtime may succeed:
     - [RateLimited] hard-quota messages → ["hard_quota"]
-    - [RateLimited] soft provider throttles → [None] (provider cooldown only)
+    - [RateLimited] soft provider throttles → ["rate_limit"] (rotation filters
+      candidates sharing the same credential pool)
     - [Overloaded] and Cloudflare 524 → ["capacity_backpressure"]
     - [ServerError] with status >= 500 → ["server_error"]
     - [AuthError] → ["auth_error"]
@@ -162,13 +163,18 @@ val degraded_retry_after_recoverable_error :
     any other candidate; if it duplicates the effective runtime or has
     already been attempted, the next legal candidate is returned.
 
-    Non-contract transient infrastructure errors (provider timeout, server
-    error, capacity backpressure) allow cycling through candidates again when
-    all are exhausted, because the same runtime may succeed on a subsequent
-    attempt. Contract violations and quota/rate-limit classes cap rotation:
-    retrying the same credential pool amplifies account-scoped limits.
+    For ["rate_limit"], candidates sharing the effective runtime's credential
+    pool, as reported by [credential_pool_of_runtime_id], are excluded before
+    attempt filtering, preserving independent-provider failover while avoiding
+    same-account fan-out. If no pool function is supplied, no credential-pool
+    filtering is applied. Non-contract transient infrastructure errors
+    (provider timeout, server error, capacity backpressure) allow cycling
+    through candidates again when all are exhausted, because the same runtime may
+    succeed on a subsequent attempt. Contract violations and quota/rate-limit
+    classes cap rotation.
     @since 0.174.0 *)
 val degraded_rotation_after_recoverable_error :
+  ?credential_pool_of_runtime_id:(string -> string option) ->
   ?fallback_hint:string ->
   base_runtime:string ->
   effective_runtime:string ->

--- a/lib/keeper/keeper_runtime_attempt.ml
+++ b/lib/keeper/keeper_runtime_attempt.ml
@@ -242,32 +242,25 @@ let enrich_sdk_error ~runtime_id ~(provider_cfg : Llm_provider.Provider_config.t
          })
   | _ -> err
 
-let cli_wrapped_hard_quota_indicators =
-  [ "hard_quota"
-  ; "terminalquotaerror"
-  ; "quota_exhausted"
-  ; "exhausted your capacity on this model"
-  ; "quota will reset after"
-  ; "\"api_error_status\":429"
-  ; "you've hit your limit"
-  ; "monthly usage limit"
-  ; "org's monthly usage limit"
-  ; "reached your specified api usage limits"
-  ; "you will regain access on"
-  ]
+(* Legacy accessors stay here for module compatibility.  The classifier SSOT is
+   the provider-attempt path used by the live turn driver. *)
+let message_looks_like_cli_wrapped_hard_quota =
+  Keeper_turn_driver_provider_attempt.message_looks_like_cli_wrapped_hard_quota
 
-let message_looks_like_cli_wrapped_hard_quota message =
-  List.exists
-    (fun needle -> String_util.contains_substring_ci message needle)
-    cli_wrapped_hard_quota_indicators
+let message_looks_like_capacity_backpressure =
+  Keeper_turn_driver_provider_attempt.message_looks_like_capacity_backpressure
 
-let capacity_backpressure_indicators =
-  [ "client capacity"; "capacity exhausted"; "local_resource_exhaustion"; "slot full" ]
+let sdk_error_is_hard_quota =
+  Keeper_turn_driver_provider_attempt.sdk_error_is_hard_quota
 
-let message_looks_like_capacity_backpressure message =
-  List.exists
-    (fun needle -> String_util.contains_substring_ci message needle)
-    capacity_backpressure_indicators
+let sdk_error_soft_rate_limited =
+  Keeper_turn_driver_provider_attempt.sdk_error_soft_rate_limited
+
+let sdk_error_is_max_turns_exceeded =
+  Keeper_turn_driver_provider_attempt.sdk_error_is_max_turns_exceeded
+
+let sdk_error_runtime_fallback_class =
+  Keeper_turn_driver_provider_attempt.sdk_error_runtime_fallback_class
 
 let exit_code_of_message message =
   let prefix = "exited with code " in
@@ -315,25 +308,6 @@ let sdk_error_is_terminal_provider_runtime_failure = function
     message_looks_like_terminal_provider_runtime_failure message
   | _ -> false
 
-let sdk_error_is_hard_quota = function
-  | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _ as err)
-    when Llm_provider.Retry.is_hard_quota err -> true
-  | Agent_sdk.Error.Api
-      (Llm_provider.Retry.RateLimited { message; _ }
-      | InvalidRequest { message }
-      | NetworkError { message; _ }
-      | Overloaded { message }
-      | ServerError { message; _ }) ->
-    message_looks_like_cli_wrapped_hard_quota message
-  | _ -> false
-
-let sdk_error_soft_rate_limited = function
-  | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited { retry_after; _ } as err) ->
-    if Llm_provider.Retry.is_hard_quota err then None else Some retry_after
-  | Agent_sdk.Error.Provider (Llm_provider.Error.RateLimit { retry_after; _ }) ->
-    Some retry_after
-  | _ -> None
-
 type capacity_backpressure_retry_hint =
   | Cbr_explicit of float
   | Cbr_synthetic_default of float
@@ -362,14 +336,3 @@ let sdk_error_capacity_backpressure_retry_after_s = function
   | Agent_sdk.Error.Provider (Llm_provider.Error.CapacityExhausted { retry_after; _ }) ->
     Some retry_after
   | _ -> None
-
-let sdk_error_is_max_turns_exceeded = function
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _) -> true
-  | _ -> false
-
-let sdk_error_runtime_fallback_class err =
-  match Keeper_internal_error.classify_masc_internal_error err with
-  | Some internal -> Some (Keeper_internal_error.kind_of_masc_internal_error internal)
-  | None when sdk_error_is_hard_quota err -> Some "hard_quota"
-  | None when sdk_error_is_max_turns_exceeded err -> Some "max_turns"
-  | None -> None

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -185,6 +185,8 @@ let cli_wrapped_hard_quota_indicators = [
   "you've hit your limit";
   "monthly usage limit";
   "org's monthly usage limit";
+  "session usage limit";
+  "add extra usage";
   "resets apr ";
   "reached your specified api usage limits";
   "you will regain access on";

--- a/lib/keeper/keeper_turn_runtime_budget_routing.ml
+++ b/lib/keeper/keeper_turn_runtime_budget_routing.ml
@@ -6,6 +6,24 @@ open Keeper_types_profile
 open Keeper_context_runtime
 module EC = Keeper_error_classify
 
+let credential_pool_of_runtime_id runtime_id =
+  match Runtime.get_runtime_by_id runtime_id with
+  | None -> None
+  | Some (runtime : Runtime.t) ->
+    let transport =
+      match runtime.provider.transport with
+      | Runtime_schema.Http endpoint -> "http:" ^ endpoint
+      | Runtime_schema.Cli command -> "cli:" ^ command
+    in
+    let credential =
+      match runtime.provider.credentials with
+      | Some (Runtime_schema.Env key) -> "env:" ^ key
+      | Some (Runtime_schema.File path) -> "file:" ^ path
+      | Some (Runtime_schema.Inline _) -> "inline:" ^ runtime.provider.id
+      | None -> "none"
+    in
+    Some (transport ^ "|" ^ credential)
+
 let next_fail_open_runtime_for_turn
       ~(base_runtime : string)
       ~(effective_runtime : string)
@@ -14,6 +32,7 @@ let next_fail_open_runtime_for_turn
   : EC.degraded_retry option
   =
   EC.degraded_rotation_after_recoverable_error
+    ~credential_pool_of_runtime_id
     ~base_runtime
     ~effective_runtime
     ~attempted_runtimes

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -17,6 +17,7 @@
 module AE = Masc.Keeper_agent_error
 module Code = Masc.Keeper_turn_terminal_code
 module EC = Masc.Keeper_error_classify
+module KTD = Masc.Keeper_turn_driver
 module SdkE = Agent_sdk.Error
 module Retry = Agent_sdk.Retry
 module Http = Llm_provider.Http_client
@@ -187,6 +188,52 @@ let test_user_message_of_network_errors () =
     (AE.user_message_of_sdk_error guardrail)
 ;;
 
+let test_ollama_session_limit_is_hard_quota () =
+  let message =
+    "you (yousleepwhen) have reached your session usage limit, add extra usage: \
+     https://ollama.com/settings"
+  in
+  let err = SdkE.Api (Retry.RateLimited { retry_after = None; message }) in
+  Alcotest.(check bool)
+    "session usage limit is hard quota"
+    true
+    (KTD.sdk_error_is_hard_quota err);
+  match EC.recoverable_runtime_failure_reason err with
+  | Some EC.Hard_quota -> ()
+  | Some reason ->
+    Alcotest.failf
+      "expected hard_quota, got %s"
+      (EC.degraded_retry_reason_to_string reason)
+  | None -> Alcotest.fail "expected hard_quota recoverable reason"
+;;
+
+let test_soft_rate_limit_stays_on_provider_cooldown () =
+  let api_err =
+    SdkE.Api
+      (Retry.RateLimited
+         { retry_after = Some 30.0; message = "rate limited, retry later" })
+  in
+  let provider_err =
+    SdkE.Provider
+      (Llm_provider.Error.RateLimit
+         { provider = "ollama_cloud"
+         ; retry_after = Some 30.0
+         ; detail = "rate limited, retry later"
+         })
+  in
+  List.iter
+    (fun (label, err) ->
+       Alcotest.(check bool)
+         (label ^ " is not hard quota")
+         false
+         (KTD.sdk_error_is_hard_quota err);
+       Alcotest.(check bool)
+         (label ^ " has no degraded rotation reason")
+         false
+         (Option.is_some (EC.recoverable_runtime_failure_reason err)))
+    [ "api", api_err; "provider", provider_err ]
+;;
+
 let () =
   Alcotest.run
     "keeper_sdk_error_typed_bridge"
@@ -213,6 +260,16 @@ let () =
             "network errors are presented as runtime availability failures"
             `Quick
             test_user_message_of_network_errors
+        ] )
+    ; ( "runtime quota guard"
+      , [ Alcotest.test_case
+            "ollama cloud session usage limit is classified as hard quota"
+            `Quick
+            test_ollama_session_limit_is_hard_quota
+        ; Alcotest.test_case
+            "soft rate limits do not trigger degraded runtime rotation"
+            `Quick
+            test_soft_rate_limit_stays_on_provider_cooldown
         ] )
     ]
 ;;

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -207,7 +207,7 @@ let test_ollama_session_limit_is_hard_quota () =
   | None -> Alcotest.fail "expected hard_quota recoverable reason"
 ;;
 
-let test_soft_rate_limit_stays_on_provider_cooldown () =
+let test_soft_rate_limit_classifies_as_rate_limit () =
   let api_err =
     SdkE.Api
       (Retry.RateLimited
@@ -227,11 +227,137 @@ let test_soft_rate_limit_stays_on_provider_cooldown () =
          (label ^ " is not hard quota")
          false
          (KTD.sdk_error_is_hard_quota err);
-       Alcotest.(check bool)
-         (label ^ " has no degraded rotation reason")
-         false
-         (Option.is_some (EC.recoverable_runtime_failure_reason err)))
+       match EC.recoverable_runtime_failure_reason err with
+       | Some EC.Rate_limit -> ()
+       | Some reason ->
+         Alcotest.failf
+           "%s expected rate_limit, got %s"
+           label
+           (EC.degraded_retry_reason_to_string reason)
+       | None -> Alcotest.failf "%s expected rate_limit recoverable reason" label)
     [ "api", api_err; "provider", provider_err ]
+;;
+
+let rate_limit_pool_of_runtime_id = function
+  | "same.a"
+  | "same.b" -> Some "pool:same"
+  | "other.c" -> Some "pool:other"
+  | _ -> Some "pool:same"
+;;
+
+let with_temp_runtime_toml content f =
+  let path = Filename.temp_file "runtime-rate-limit-pool" ".toml" in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc;
+  Fun.protect
+    ~finally:(fun () ->
+      try Sys.remove path with
+      | _ -> ())
+    (fun () -> f path)
+;;
+
+let rate_limit_pool_runtime_toml =
+  {|
+[runtime]
+default = "same.a"
+
+[providers.same]
+display-name = "Same Pool"
+protocol = "openai-compatible-http"
+endpoint = "https://same.example/v1"
+
+[providers.same.credentials]
+type = "env"
+key = "SAME_POOL_API_KEY"
+
+[providers.other]
+display-name = "Other Pool"
+protocol = "openai-compatible-http"
+endpoint = "https://other.example/v1"
+
+[providers.other.credentials]
+type = "env"
+key = "OTHER_POOL_API_KEY"
+
+[models.a]
+api-name = "a"
+max-context = 1024
+tools-support = true
+thinking-support = true
+
+[models.b]
+api-name = "b"
+max-context = 1024
+tools-support = true
+thinking-support = true
+
+[models.c]
+api-name = "c"
+max-context = 1024
+tools-support = true
+thinking-support = true
+
+[same.a]
+
+[same.b]
+
+[other.c]
+|}
+;;
+
+let init_rate_limit_pool_runtime () =
+  with_temp_runtime_toml rate_limit_pool_runtime_toml (fun path ->
+    match Runtime.init_default ~config_path:path with
+    | Ok () -> ()
+    | Error msg -> Alcotest.failf "Runtime.init_default failed: %s" msg)
+;;
+
+let soft_rate_limit_err =
+  SdkE.Api
+    (Retry.RateLimited
+       { retry_after = Some 30.0; message = "rate limited, retry later" })
+;;
+
+let test_soft_rate_limit_skips_same_credential_pool () =
+  init_rate_limit_pool_runtime ();
+  let retry =
+    EC.degraded_rotation_after_recoverable_error
+      ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
+      ~fallback_hint:"same.b"
+      ~base_runtime:"same.a"
+      ~effective_runtime:"same.a"
+      ~attempted_runtimes:[ "same.a" ]
+      soft_rate_limit_err
+  in
+  Alcotest.(check bool)
+    "same credential pool is not a rotation target"
+    false
+    (Option.is_some retry)
+;;
+
+let test_soft_rate_limit_preserves_independent_pool_failover () =
+  init_rate_limit_pool_runtime ();
+  match
+    EC.degraded_rotation_after_recoverable_error
+      ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
+      ~fallback_hint:"other.c"
+      ~base_runtime:"same.a"
+      ~effective_runtime:"same.a"
+      ~attempted_runtimes:[ "same.a" ]
+      soft_rate_limit_err
+  with
+  | Some { EC.next_runtime; fallback_reason = EC.Rate_limit } ->
+    Alcotest.(check string)
+      "independent credential pool remains eligible"
+      "other.c"
+      next_runtime
+  | Some { fallback_reason; next_runtime } ->
+    Alcotest.failf
+      "expected rate_limit -> other.c, got %s -> %s"
+      (EC.degraded_retry_reason_to_string fallback_reason)
+      next_runtime
+  | None -> Alcotest.fail "expected independent credential pool failover"
 ;;
 
 let () =
@@ -267,9 +393,17 @@ let () =
             `Quick
             test_ollama_session_limit_is_hard_quota
         ; Alcotest.test_case
-            "soft rate limits do not trigger degraded runtime rotation"
+            "soft rate limits remain rate_limit reasons"
             `Quick
-            test_soft_rate_limit_stays_on_provider_cooldown
+            test_soft_rate_limit_classifies_as_rate_limit
+        ; Alcotest.test_case
+            "soft rate limits skip same credential-pool candidates"
+            `Quick
+            test_soft_rate_limit_skips_same_credential_pool
+        ; Alcotest.test_case
+            "soft rate limits preserve independent credential-pool failover"
+            `Quick
+            test_soft_rate_limit_preserves_independent_pool_failover
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- keep the runtime seed default on DeepSeek v4 Flash while reserving Pro for explicit evaluator/judge lanes
- classify Ollama Cloud session usage-limit messages as hard quota
- keep soft 429s as typed `rate_limit` recovery reasons, then filter degraded-rotation candidates by credential pool
- preserve independent-provider failover while preventing same-account/session fan-out
- SSOT the legacy `Keeper_runtime_attempt` quota/rate-limit accessors through `Keeper_turn_driver_provider_attempt`

## Review response
- Addressed the broad soft-429 suppression review: `Rate_limit` is produced again, and the rotation boundary excludes candidates sharing the effective runtime credential pool instead of blocking all configs.
- Addressed the dead duplicate classifier review: `keeper_runtime_attempt.ml` no longer carries its own stale quota/rate-limit classifier copy; compatibility accessors delegate to the live provider-attempt classifier.
- Added regression coverage for same-pool filtering and independent-pool failover.

## Verification
- `ocamlformat --check lib/keeper/keeper_runtime_attempt.ml lib/keeper/keeper_error_classify.ml lib/keeper/keeper_error_classify.mli lib/keeper/keeper_turn_runtime_budget_routing.ml test/test_keeper_sdk_error_typed_bridge.ml`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/check_test_coverage.py`
- `./_build/default/test/test_keeper_sdk_error_typed_bridge.exe` -> 8 tests pass

## CI
- Running on head `dcecd3c5f269231c365e4827891ce5349af3628e`; no failing check observed at the last sweep, several long CI jobs still in progress.
