### PR TITLE
feat(types): RFC-0233 §7 PR-A1 — Turn_ref + TurnRecord turn-identity field

### DIFF
--- a/lib/keeper/keeper_turn_record_writer.ml
+++ b/lib/keeper/keeper_turn_record_writer.ml
@@ -15,6 +15,7 @@ let write
     ; keeper = keeper_name
     ; trace_id
     ; absolute_turn
+    ; turn_ref = Some (Ids.Turn_ref.make ~trace_id ~absolute_turn)
     ; blocks
     ; runtime_profile
     ; sampling

--- a/lib/types/ids.ml
+++ b/lib/types/ids.ml
@@ -95,6 +95,57 @@ end = struct
              (Json_util.kind_name other))
 end
 
+(** Turn reference — RFC-0233 §7. Canonical per-turn join key, derived
+    deterministically from the [(trace_id, absolute_turn)] pair already
+    recorded on {!Turn_record.t}. Serializes as ["<trace_id>#<absolute_turn>"]
+    so keeper chat rows and board posts join on one stable value across
+    reloads, with no mapping table. Distinct from {!Turn_id} (a
+    thread-relative ["<thread>-turn-N"] label); the name collision is
+    avoided on purpose. *)
+module Turn_ref : sig
+  type t
+  val make : trace_id:string -> absolute_turn:int -> t
+  val to_string : t -> string
+  val of_string : string -> t option
+  val trace_id : t -> string
+  val absolute_turn : t -> int
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+end = struct
+  type t = { trace_id : string; absolute_turn : int }
+  let make ~trace_id ~absolute_turn = { trace_id; absolute_turn }
+  let to_string t = Printf.sprintf "%s#%d" t.trace_id t.absolute_turn
+  (* Split on the LAST '#': the absolute_turn suffix is always an int, so a
+     trace_id that itself contains '#' still parses unambiguously. *)
+  let of_string s =
+    match String.rindex_opt s '#' with
+    | None -> None
+    | Some i ->
+      let trace = String.sub s 0 i in
+      let suffix = String.sub s (i + 1) (String.length s - i - 1) in
+      (match int_of_string_opt suffix with
+       | Some absolute_turn when trace <> "" ->
+         Some { trace_id = trace; absolute_turn }
+       | Some _ | None -> None)
+  let trace_id t = t.trace_id
+  let absolute_turn t = t.absolute_turn
+  let equal a b =
+    String.equal a.trace_id b.trace_id && a.absolute_turn = b.absolute_turn
+  let pp fmt t = Format.fprintf fmt "%s" (to_string t)
+  let to_yojson t = `String (to_string t)
+  let of_yojson = function
+    | `String s -> (
+      match of_string s with
+      | Some t -> Ok t
+      | None -> Error (Printf.sprintf "Invalid Turn_ref (received %S)" s))
+    | other ->
+      Error
+        (Printf.sprintf "Expected string for Turn_ref (received %s)"
+           (Json_util.kind_name other))
+end
+
 (** Thread identifier - conversation thread ID *)
 module Thread_id : sig
   type t

--- a/lib/types/ids.mli
+++ b/lib/types/ids.mli
@@ -48,6 +48,24 @@ module Execution_id : sig
   val of_yojson : Yojson.Safe.t -> (t, string) result
 end
 
+(** Turn reference — RFC-0233 §7. Canonical per-turn join key derived from
+    [(trace_id, absolute_turn)]; serializes as ["<trace_id>#<absolute_turn>"].
+    The identity keeper chat rows and board posts join on. [of_string]
+    returns [None] on malformed input rather than repairing it. Distinct
+    from {!Turn_id}. *)
+module Turn_ref : sig
+  type t
+  val make : trace_id:string -> absolute_turn:int -> t
+  val to_string : t -> string
+  val of_string : string -> t option
+  val trace_id : t -> string
+  val absolute_turn : t -> int
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+end
+
 (** Conversation thread identifier — timestamp-prefixed sequence. *)
 module Thread_id : sig
   type t

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -20,6 +20,7 @@ type t =
   ; keeper : string
   ; trace_id : string
   ; absolute_turn : int
+  ; turn_ref : Ids.Turn_ref.t option
   ; blocks : prompt_block list
   ; runtime_profile : string
   ; sampling : sampling
@@ -50,6 +51,7 @@ let to_json (r : t) : Yojson.Safe.t =
      ; ("blocks", `List (List.map prompt_block_to_json r.blocks))
      ; ("runtime_profile", `String r.runtime_profile)
      ]
+    @ opt_field "turn_ref" Ids.Turn_ref.to_yojson r.turn_ref
     @ opt_field "temperature" (fun v -> `Float v) r.sampling.temperature
     @ opt_field "thinking_budget" (fun v -> `Int v) r.sampling.thinking_budget
     @ opt_field "enable_thinking" (fun v -> `Bool v) r.sampling.enable_thinking
@@ -89,6 +91,11 @@ let opt_member name fields decode =
 let as_bool name = function
   | `Bool b -> Ok b
   | _ -> Error (Printf.sprintf "turn_record: field %S is not a bool" name)
+
+let as_turn_ref name json =
+  match Ids.Turn_ref.of_yojson json with
+  | Ok t -> Ok t
+  | Error e -> Error (Printf.sprintf "turn_record: field %S: %s" name e)
 
 let prompt_block_of_json (json : Yojson.Safe.t) : (prompt_block, string) result =
   match json with
@@ -133,6 +140,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
       in
       let* profile_json = require "runtime_profile" fields in
       let* runtime_profile = as_string "runtime_profile" profile_json in
+      let* turn_ref = opt_member "turn_ref" fields as_turn_ref in
       let* temperature = opt_member "temperature" fields as_float in
       let* thinking_budget = opt_member "thinking_budget" fields as_int in
       let* enable_thinking = opt_member "enable_thinking" fields as_bool in
@@ -145,6 +153,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         ; keeper
         ; trace_id
         ; absolute_turn
+        ; turn_ref
         ; blocks
         ; runtime_profile
         ; sampling = { temperature; thinking_budget; enable_thinking }

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -33,6 +33,9 @@ type t =
   ; keeper : string
   ; trace_id : string
   ; absolute_turn : int
+  ; turn_ref : Ids.Turn_ref.t option
+    (* RFC-0233 §7 — "<trace_id>#<absolute_turn>" join key for chat/board.
+       [option] so pre-§7 rows decode as [None]. *)
   ; blocks : prompt_block list (* assembly order *)
   ; runtime_profile : string
   ; sampling : sampling

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -37,6 +37,8 @@ let sample_record () : Turn_record.t =
   ; keeper = "sangsu"
   ; trace_id = "trace-1780648779957-00000"
   ; absolute_turn = 4071
+  ; turn_ref =
+      Some (Ids.Turn_ref.make ~trace_id:"trace-1780648779957-00000" ~absolute_turn:4071)
   ; blocks =
       [ sample_block Prompt_block_id.Persona "aaaa"
       ; sample_block Prompt_block_id.Dynamic_context "bbbb"
@@ -61,6 +63,11 @@ let test_codec_roundtrip () =
     check string "keeper" record.keeper decoded.keeper;
     check string "trace_id" record.trace_id decoded.trace_id;
     check int "absolute_turn" record.absolute_turn decoded.absolute_turn;
+    check bool "turn_ref preserved" true
+      (match record.turn_ref, decoded.turn_ref with
+       | Some a, Some b -> Ids.Turn_ref.equal a b
+       | None, None -> true
+       | Some _, None | None, Some _ -> false);
     check int "blocks count" 3 (List.length decoded.blocks);
     check bool "blocks preserved in order" true
       (List.for_all2
@@ -87,6 +94,7 @@ let test_codec_optional_fields_absent () =
     { (sample_record ()) with
       sampling = { temperature = None; thinking_budget = None; enable_thinking = None }
     ; usage = { input_tokens = None; output_tokens = None }
+    ; turn_ref = None
     }
   in
   match Turn_record.of_json (Turn_record.to_json record) with
@@ -94,7 +102,8 @@ let test_codec_optional_fields_absent () =
   | Ok decoded ->
     check (option (float 0.0001)) "temperature absent" None
       decoded.sampling.temperature;
-    check (option int) "input_tokens absent" None decoded.usage.input_tokens
+    check (option int) "input_tokens absent" None decoded.usage.input_tokens;
+    check bool "turn_ref absent" true (decoded.turn_ref = None)
 
 let test_codec_rejects_malformed () =
   (match Turn_record.of_json (`String "not a record") with
@@ -195,6 +204,37 @@ let test_entries_with_diffs_same_trace_only () =
     check bool "trace boundary yields no diff" true (third = None)
   | _ -> fail "expected three paired entries"
 
+(* ── Turn_ref (RFC-0233 §7) ───────────────────────────── *)
+
+let turn_ref_t =
+  testable (Fmt.of_to_string Ids.Turn_ref.to_string) Ids.Turn_ref.equal
+
+let test_turn_ref_roundtrip () =
+  let r =
+    Ids.Turn_ref.make ~trace_id:"trace-1780648779957-00000" ~absolute_turn:4071
+  in
+  check string "to_string" "trace-1780648779957-00000#4071"
+    (Ids.Turn_ref.to_string r);
+  (match Ids.Turn_ref.of_string (Ids.Turn_ref.to_string r) with
+   | Some back -> check turn_ref_t "of_string roundtrip" r back
+   | None -> fail "of_string returned None on its own output");
+  check string "trace_id accessor" "trace-1780648779957-00000"
+    (Ids.Turn_ref.trace_id r);
+  check int "absolute_turn accessor" 4071 (Ids.Turn_ref.absolute_turn r)
+
+let test_turn_ref_trace_with_hash () =
+  (* trace_id containing '#' still parses: split on the LAST '#'. *)
+  match Ids.Turn_ref.of_string "weird#trace#12" with
+  | Some r ->
+    check string "trace keeps inner '#'" "weird#trace" (Ids.Turn_ref.trace_id r);
+    check int "turn is the last segment" 12 (Ids.Turn_ref.absolute_turn r)
+  | None -> fail "expected Some for a trace_id containing '#'"
+
+let test_turn_ref_rejects_malformed () =
+  check bool "no separator -> None" true (Ids.Turn_ref.of_string "noseparator" = None);
+  check bool "non-int suffix -> None" true (Ids.Turn_ref.of_string "trace#abc" = None);
+  check bool "empty trace -> None" true (Ids.Turn_ref.of_string "#4" = None)
+
 let () =
   run "turn_record"
     [ ( "prompt_block_id"
@@ -215,5 +255,13 @@ let () =
             test_diff_identical_records_is_empty
         ; test_case "entries_with_diffs pairs same-trace only" `Quick
             test_entries_with_diffs_same_trace_only
+        ] )
+    ; ( "turn_ref"
+      , [ test_case "make/to_string/of_string roundtrip" `Quick
+            test_turn_ref_roundtrip
+        ; test_case "trace_id with '#' splits on last separator" `Quick
+            test_turn_ref_trace_with_hash
+        ; test_case "of_string rejects malformed" `Quick
+            test_turn_ref_rejects_malformed
         ] )
     ]


### PR DESCRIPTION
## 무엇을 / 왜

RFC-0233 §7(어멘드먼트, #21649 머지됨)의 첫 증분 — **`Turn_ref` 타입 + `Turn_record` turn-identity 필드**. 4-PR arc 중 backend 전파(Amendment PR-A)의 foundational 절반(PR-A1).

RFC-0233은 keeper 턴에 `(trace_id, absolute_turn)` 페어를 `Turn_record.t`에 materialize 했지만 그걸 잇는 단일 canonical 키가 없었습니다. 이 PR은 그 키 `Turn_ref = "<trace_id>#<absolute_turn>"`를 도입하고 observability store(TurnRecord)에 실어, 이후 chat/board가 join할 토대를 만듭니다.

## 변경

- `lib/types/ids.ml` / `.mli` — `Ids.Turn_ref` 모듈. `make ~trace_id ~absolute_turn` / `to_string` / `of_string : string -> t option` / `trace_id` / `absolute_turn` / `equal` / `pp` / yojson. 내부는 `{ trace_id; absolute_turn }` record (Parse-don't-validate: record가 곧 파싱된 형태). `of_string`은 malformed에 `None` 반환 — silent repair 없음. trace_id에 `#`가 있어도 **마지막 `#`** 기준 분할로 안전.
- `lib/types/turn_record.ml` / `.mli` — `turn_ref : Ids.Turn_ref.t option` 필드 + to_json(opt_field)/of_json(opt_member). `option`이라 pre-§7 행은 `None`으로 디코드(backward-compat).
- `lib/keeper/keeper_turn_record_writer.ml` — record 구축 시 `turn_ref = Some (Ids.Turn_ref.make ~trace_id ~absolute_turn)`. **이미 받는 2개 param에서 파생** → writer 시그니처 불변, 새 호출자 영향 0.
- `test/test_turn_record.ml` — `Turn_ref` 단위(round-trip / inner-`#` 분할 / malformed 거부) + codec round-trip이 turn_ref 보존/부재 검증.

## 경계

OAS 무변경. `Turn_ref`는 MASC가 이미 가진 페어에서 MASC-side로 합성 (RFC-0233 §3·§7.3 경계 불변식 준수).

## 검증

- `dune build --root .` 전체 빌드 green (공유 record 필드 추가의 모든 literal 구축 사이트 확인 — writer + test sample_record뿐).
- `dune exec test/test_turn_record.exe` 12/12 OK.

## RFC

RFC-0233 §7 (PR #21649 머지) — turn identity 소유 RFC. 신규 RFC 아님.

## 후속 (의존순)

- **PR-A2**: reply payload(`keeper_turn.ml:927-965` seam)→`extract_visible_reply`→chat store `?turn_ref` 모든 append site + SSE.
- **PR-B**: board `origin` typed 필드 + fusion + `find_post_by_turn_ref` 인덱스.
- **PR-C**: dashboard API `turn_ref?`/`origin?`.
- **PR-D**: FE nav (`buildTurn` fake 제거, 정확 id 매칭, board↔chat nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
