### PR TITLE
feat(memory-os): RFC-0259 P2 — observe-only grounding reconciler (default-off)

### DIFF
--- a/lib/keeper/keeper_memory_os_grounding.ml
+++ b/lib/keeper/keeper_memory_os_grounding.ml
@@ -1,0 +1,239 @@
+(** Keeper_memory_os_grounding — RFC-0259 P2: observe-only grounding reconciler.
+
+    For a fact whose claim names verifiable external state (an [external_ref] from
+    P1), this re-checks the PR/issue against GitHub and produces a PROVISIONAL,
+    log-only verdict. It performs NO writes: it never mutates a fact, never
+    advances [last_verified_at], never retracts. Its sole output is an
+    [observation] the maintenance fiber logs, so an operator can measure how often
+    the cheap deterministic predicate disagrees with reality before P3 trusts it to
+    retract (RFC-0259 §3.3 dry-run-before-enable discipline).
+
+    Boundary (RFC-0247/0259): no importance/effectiveness SCORE is computed — the
+    fetched state is a closed enum and the verdict a closed 3-valued sum, both
+    typed observations, not numbers. Any uncertainty (no token, HTTP 401/403/404,
+    GraphQL errors, missing node, timeout, or a [Task] ref with no GitHub analogue)
+    yields [Indeterminate]; a false [Confirmed]/[Contradicted_candidate] is never
+    produced (CLAUDE.md anti-pattern #2: unknown -> Unknown, not a permissive
+    default). *)
+
+open Keeper_memory_os_types
+
+(* RFC-0259 P2: re-checked external state. Closed sum (mirrors [external_ref_kind])
+   so a future state forces a compile-time decision. *)
+type fetched_state =
+  | Open
+  | Closed
+  | Merged
+  | Not_found
+
+let fetched_state_to_string = function
+  | Open -> "open"
+  | Closed -> "closed"
+  | Merged -> "merged"
+  | Not_found -> "not_found"
+;;
+
+(* Abstention-biased: only [Confirmed]/[Contradicted_candidate] carry signal, and
+   [Contradicted_candidate] is a LOGGED HYPOTHESIS for P3 review, not grounds to
+   retract. Everything uncertain collapses to [Indeterminate]. *)
+type provisional_verdict =
+  | Confirmed
+  | Contradicted_candidate
+  | Indeterminate
+
+let provisional_verdict_to_string = function
+  | Confirmed -> "confirmed"
+  | Contradicted_candidate -> "contradicted_candidate"
+  | Indeterminate -> "indeterminate"
+;;
+
+(* Injected so tests drive verdicts with a fake and no network (mirrors
+   [Keeper_librarian_runtime]'s [complete_fn] seam). [Ok state] = determined;
+   [Error reason] = could not determine, which the caller maps to [Indeterminate]. *)
+type verify_external = external_ref -> (fetched_state, string) result
+
+(* Pure classification of the re-checked state into a provisional verdict.
+   CONSERVATIVE and measurement-only: a non-terminal [Open] state leaves an ongoing
+   claim [Confirmed]; a terminal [Closed]/[Merged] marks the volatile claim a
+   [Contradicted_candidate] for P3 to weigh — it may be a TRUE "was merged" claim,
+   which is exactly the disagreement the dry-run exists to measure; [Not_found] is
+   [Indeterminate]. This is NOT a retraction rule (P3 decides retraction using the
+   dry-run log this produces), and it reads no claim text — claim-aware refinement
+   is deferred to P3. *)
+let classify_state = function
+  | Open -> Confirmed
+  | Closed | Merged -> Contradicted_candidate
+  | Not_found -> Indeterminate
+;;
+
+type observation =
+  { keeper_id : string
+  ; ref_kind : external_ref_kind
+  ; ref_id : string
+  ; normalized_claim : string
+  ; first_seen : float
+  ; last_verified_at : float option
+  ; age_seconds : float
+  ; fetched : (fetched_state, string) result
+  ; verdict : provisional_verdict
+  }
+
+(* A volatile claim becomes eligible for re-grounding once its truth anchor is
+   older than this horizon. Same shape as the P1 volatile TTL (a TIME, not a
+   score). *)
+let default_grounding_horizon_seconds = volatile_external_ttl_seconds
+
+(* Default GitHub coordinates; the fiber may override via env. *)
+let default_owner = "jeong-sik"
+let default_repo = "masc"
+
+let fact_age ~now (f : fact) =
+  let anchor =
+    match f.last_verified_at with
+    | Some t -> t
+    | None -> f.first_seen
+  in
+  now -. anchor
+;;
+
+(* Pure given [verify_external]: scan a keeper's facts, re-check each volatile
+   claim past the horizon, and return one observation per checked fact. Performs
+   NO writes — the module has no fact-store write dependency at all. *)
+let grounding_pass ~verify_external ~now ~grounding_horizon ~keeper_id (facts : fact list) =
+  List.filter_map
+    (fun (f : fact) ->
+      match f.external_ref with
+      | None -> None
+      | Some ref ->
+        let age = fact_age ~now f in
+        if age < grounding_horizon
+        then None
+        else (
+          let fetched = verify_external ref in
+          let verdict =
+            match fetched with
+            | Ok state -> classify_state state
+            | Error _ -> Indeterminate
+          in
+          Some
+            { keeper_id
+            ; ref_kind = ref.kind
+            ; ref_id = ref.id
+            ; normalized_claim = normalize_claim f.claim
+            ; first_seen = f.first_seen
+            ; last_verified_at = f.last_verified_at
+            ; age_seconds = age
+            ; fetched
+            ; verdict
+            }))
+    facts
+;;
+
+(* Single-line log record for the maintenance fiber. Carries the fields P3 needs
+   to reproduce the verdict offline and measure the per-claim-shape disagreement
+   rate: keeper, ref, normalized claim (P3 retraction keys on it), age, fetched
+   state (or the error that forced Indeterminate), and the verdict. *)
+let observation_log_line o =
+  let fetched_str =
+    match o.fetched with
+    | Ok s -> fetched_state_to_string s
+    | Error e -> "indeterminate(" ^ e ^ ")"
+  in
+  Printf.sprintf
+    "keeper=%s ref=%s#%s state=%s verdict=%s age=%.0fs claim=%S"
+    o.keeper_id
+    (external_ref_kind_to_string o.ref_kind)
+    o.ref_id
+    fetched_str
+    (provisional_verdict_to_string o.verdict)
+    o.age_seconds
+    o.normalized_claim
+;;
+
+(* ---------- Real verify_external on the GitHub GraphQL API ---------- *)
+
+(* Parse a GitHub GraphQL response body into a [fetched_state]. Any shape we do
+   not positively recognize (parse error, top-level [errors], null node, missing
+   or unknown state string) is an [Error] -> [Indeterminate]; only an explicit
+   OPEN/CLOSED/MERGED maps to a state. *)
+let parse_state_response ~(kind : external_ref_kind) (body : string) : (fetched_state, string) result =
+  match Yojson.Safe.from_string body with
+  | exception _ -> Error "unparseable response"
+  | json ->
+    (try
+       let open Yojson.Safe.Util in
+       match member "errors" json with
+       | `List (_ :: _) -> Error "graphql errors"
+       | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List [] | `Null | `String _ ->
+         let node_field =
+           match kind with
+           | Pr -> "pullRequest"
+           | Issue -> "issue"
+           (* Task is short-circuited before parsing; map defensively. *)
+           | Task -> "issue"
+         in
+         let node = json |> member "data" |> member "repository" |> member node_field in
+         (match node with
+          | `Null -> Ok Not_found
+          | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `String _ ->
+            (match member "state" node with
+             | `String "OPEN" -> Ok Open
+             | `String "CLOSED" -> Ok Closed
+             | `String "MERGED" -> Ok Merged
+             | `String other -> Error ("unknown state " ^ other)
+             | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null ->
+               Error "missing state"))
+     with
+     | _ -> Error "unexpected response shape")
+;;
+
+(* The injected [verify_external] backed by a real GitHub GraphQL call. Returns
+   [Error] (-> [Indeterminate]) on every failure path; never a false verdict.
+   [timeout_sec] MUST be > 0 so a hung connection cannot stall the reconciler
+   fiber (Masc_http_client races the call against the clock). *)
+let github_verify ~token ~clock ~timeout_sec ~owner ~repo : verify_external =
+  fun ref ->
+  match ref.kind with
+  | Task -> Error "no github analogue for task ref"
+  | Pr | Issue ->
+    (match int_of_string_opt ref.id with
+     | None -> Error ("non-numeric ref id: " ^ ref.id)
+     | Some number ->
+       let node =
+         match ref.kind with
+         | Pr -> Printf.sprintf "pullRequest(number:%d){state}" number
+         | Issue -> Printf.sprintf "issue(number:%d){state}" number
+         (* Unreachable: the outer match excludes Task. *)
+         | Task -> assert false
+       in
+       let query =
+         Printf.sprintf "query{repository(owner:%S,name:%S){%s}}" owner repo node
+       in
+       let body = `Assoc [ "query", `String query ] |> Yojson.Safe.to_string in
+       (match
+          Masc_http_client.post_sync
+            ~clock
+            ~timeout_sec
+            ~url:"https://api.github.com/graphql"
+            ~headers:
+              [ "Authorization", "bearer " ^ token
+              ; "Accept", "application/vnd.github+json"
+              ; (* GitHub rejects GraphQL/REST without a User-Agent (HTTP 403). *)
+                "User-Agent", "masc-grounding-reconciler"
+              ; "Content-Type", "application/json"
+              ]
+            ~body
+            ()
+        with
+        | Error e -> Error e
+        | Ok (code, resp) ->
+          if code < 200 || code >= 300
+          then Error (Printf.sprintf "http %d" code)
+          else parse_state_response ~kind:ref.kind resp))
+;;
+
+(* The degenerate verify_external used when no token is provisioned: every ref is
+   Indeterminate. Lets the fiber run harmlessly (log-only) without GitHub access. *)
+let no_token_verify : verify_external =
+  fun _ref -> Error "no MASC_GROUNDING_GITHUB_TOKEN"
+;;

--- a/lib/keeper/keeper_memory_os_grounding.mli
+++ b/lib/keeper/keeper_memory_os_grounding.mli
@@ -1,0 +1,96 @@
+(** Keeper_memory_os_grounding — RFC-0259 P2: observe-only grounding reconciler.
+
+    Re-checks a fact's external_ref (P1) against GitHub and emits a PROVISIONAL,
+    log-only verdict. Performs NO writes (never mutates a fact, advances
+    [last_verified_at], or retracts) — its output is an [observation] the
+    maintenance fiber logs so an operator can measure the cheap predicate's
+    disagreement rate before P3 trusts it to retract. Introduces no numeric score:
+    a closed-enum state and a closed 3-valued verdict only. Any uncertainty is
+    [Indeterminate], never a false verdict. *)
+
+open Keeper_memory_os_types
+
+(** Re-checked external state (closed sum). *)
+type fetched_state =
+  | Open
+  | Closed
+  | Merged
+  | Not_found
+
+val fetched_state_to_string : fetched_state -> string
+
+(** Abstention-biased provisional verdict. [Contradicted_candidate] is a logged
+    hypothesis for P3, not grounds to retract. *)
+type provisional_verdict =
+  | Confirmed
+  | Contradicted_candidate
+  | Indeterminate
+
+val provisional_verdict_to_string : provisional_verdict -> string
+
+(** Injected external-state check (fake-able in tests). [Ok state] = determined;
+    [Error _] = could not determine (mapped to [Indeterminate]). *)
+type verify_external = external_ref -> (fetched_state, string) result
+
+(** Pure, measurement-only classification: [Open] -> [Confirmed], terminal
+    ([Closed]/[Merged]) -> [Contradicted_candidate], [Not_found] -> [Indeterminate].
+    NOT a retraction rule; reads no claim text (P3 may refine). *)
+val classify_state : fetched_state -> provisional_verdict
+
+(** One re-checked fact's record, logged for P3 evidence. *)
+type observation =
+  { keeper_id : string
+  ; ref_kind : external_ref_kind
+  ; ref_id : string
+  ; normalized_claim : string
+  ; first_seen : float
+  ; last_verified_at : float option
+  ; age_seconds : float
+  ; fetched : (fetched_state, string) result
+  ; verdict : provisional_verdict
+  }
+
+(** Re-grounding horizon: a volatile claim is eligible once its truth anchor is
+    older than this (a TIME, not a score). Defaults to the P1 volatile TTL. *)
+val default_grounding_horizon_seconds : float
+
+(** Default GitHub coordinates (the fiber may override via env). *)
+val default_owner : string
+
+val default_repo : string
+
+(** Pure given [verify_external]: scan [facts], re-check each volatile claim past
+    [grounding_horizon], return one observation per checked fact. Writes nothing. *)
+val grounding_pass
+  :  verify_external:verify_external
+  -> now:float
+  -> grounding_horizon:float
+  -> keeper_id:string
+  -> fact list
+  -> observation list
+
+(** Single-line log record (keeper, ref, normalized claim, age, fetched state or
+    error, verdict). *)
+val observation_log_line : observation -> string
+
+(** Parse a GitHub GraphQL response body into a state; any unrecognized shape is
+    [Error] -> [Indeterminate]. Exposed for unit tests. *)
+val parse_state_response
+  :  kind:external_ref_kind
+  -> string
+  -> (fetched_state, string) result
+
+(** [verify_external] backed by a real GitHub GraphQL call. [timeout_sec] must be
+    > 0 so a hung connection cannot stall the reconciler fiber. Returns [Error]
+    (-> [Indeterminate]) on every failure path; never a false verdict. *)
+val github_verify
+  :  token:string
+  -> clock:[> float Eio.Time.clock_ty ] Eio.Resource.t
+  -> timeout_sec:float
+  -> owner:string
+  -> repo:string
+  -> verify_external
+
+(** Degenerate [verify_external] for when no token is provisioned: every ref is
+    [Indeterminate]. *)
+val no_token_verify : verify_external

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -170,6 +170,77 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
         loop ()
       in
       loop ());
+  (* RFC-0259 P2: memory-os grounding reconciler. Off the keeper hot path, every
+     [interval]s it re-checks each keeper's volatile (external_ref) facts past the
+     grounding horizon against GitHub and LOGS a provisional verdict. OBSERVE-ONLY:
+     no writes — no retraction, no last_verified_at advance — so the log is the
+     dry-run evidence P3 uses to design the real contradiction policy (RFC-0259
+     §3.3 dry-run-before-enable). Default OFF (mirrors the GC/consolidation gates).
+     With no MASC_GROUNDING_GITHUB_TOKEN every verdict is Indeterminate and it runs
+     harmlessly. Per-keeper failures are caught so one store cannot cancel siblings;
+     a 1s inter-keeper sleep spreads GitHub calls across the sweep. *)
+  if
+    Keeper_memory_bank_env.memory_env_bool_logged
+      "MASC_KEEPER_MEMORY_OS_GROUNDING"
+      ~default:false
+  then
+    fork_logged_fiber
+      ~sw
+      ~on_error:(log_server_fiber_crash "memory_os_grounding")
+      (fun () ->
+        (* Coarse cadence: grounding is advisory and off the hot path. *)
+        let interval = 600.0 in
+        let env_or name ~default =
+          match Keeper_memory_bank_env.memory_env_opt name with
+          | Some v when String.trim v <> "" -> v
+          | Some _ | None -> default
+        in
+        let owner = env_or "MASC_GROUNDING_GITHUB_OWNER" ~default:Keeper_memory_os_grounding.default_owner in
+        let repo = env_or "MASC_GROUNDING_GITHUB_REPO" ~default:Keeper_memory_os_grounding.default_repo in
+        let verify_external =
+          match Keeper_memory_bank_env.memory_env_opt "MASC_GROUNDING_GITHUB_TOKEN" with
+          | Some token when String.trim token <> "" ->
+            Keeper_memory_os_grounding.github_verify ~token ~clock ~timeout_sec:10.0 ~owner ~repo
+          | Some _ | None ->
+            Log.Server.warn
+              "memory_os_grounding: no MASC_GROUNDING_GITHUB_TOKEN; all verdicts Indeterminate";
+            Keeper_memory_os_grounding.no_token_verify
+        in
+        let rec loop () =
+          List.iter
+            (fun keeper_id ->
+              (try
+                 let facts = Keeper_memory_os_io.read_facts_all ~keeper_id in
+                 let observations =
+                   Keeper_memory_os_grounding.grounding_pass
+                     ~verify_external
+                     ~now:(Time_compat.now ())
+                     ~grounding_horizon:
+                       Keeper_memory_os_grounding.default_grounding_horizon_seconds
+                     ~keeper_id
+                     facts
+                 in
+                 List.iter
+                   (fun o ->
+                     Log.Server.info
+                       "memory_os_grounding: %s"
+                       (Keeper_memory_os_grounding.observation_log_line o))
+                   observations
+               with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn ->
+                 Log.Server.warn
+                   "memory_os_grounding: keeper=%s tick crashed: %s"
+                   keeper_id
+                   (Printexc.to_string exn));
+              Eio.Time.sleep clock 1.0)
+            (List.filter
+               (fun id -> not (String.equal id Keeper_memory_os_types.shared_store_id))
+               (Keeper_memory_os_io.list_fact_store_keeper_ids ()));
+          Eio.Time.sleep clock interval;
+          loop ()
+        in
+        loop ());
   (* #9876: Hebbian consolidation fiber. Prior to this, the graph was
      write-only — strengthen/weaken populated synapses but decay +
      pruning never ran (zero production callers of [consolidate]).

--- a/test/dune
+++ b/test/dune
@@ -87,6 +87,7 @@
   test_keeper_memory_os
   test_keeper_memory_os_consolidation
   test_keeper_memory_os_consolidation_runtime
+  test_keeper_memory_os_grounding
   eval_memory_os_value
   test_keeper_reconcile_state
   test_attempt_state
@@ -383,6 +384,7 @@
   test_keeper_memory_os
   test_keeper_memory_os_consolidation
   test_keeper_memory_os_consolidation_runtime
+  test_keeper_memory_os_grounding
   eval_memory_os_value
   test_keeper_reconcile_state
   test_attempt_state

--- a/test/dune
+++ b/test/dune
@@ -1089,6 +1089,13 @@
  (modules memory_os_brain_harness)
  (libraries masc_test_deps))
 
+; RFC-0259 P2: standalone observe-only grounding dry-run runner (network tool,
+; not a CI test — executable so `dune test`/@runtest never runs it).
+(executable
+ (name eval_grounding_dry_run)
+ (modules eval_grounding_dry_run)
+ (libraries masc_test_deps eio_main masc_eio_context))
+
 (test
  (name test_json_field)
  (modules test_json_field)

--- a/test/eval_grounding_dry_run.ml
+++ b/test/eval_grounding_dry_run.ml
@@ -1,0 +1,81 @@
+(** eval_grounding_dry_run — RFC-0259 P2 standalone dry-run runner.
+
+    Runs the observe-only grounding reconciler's logic as a one-shot CLI so an
+    operator can SEE what P3 retraction would face — without merging the fiber or
+    restarting the server. Reads the LIVE keeper fact stores (read-only),
+    re-checks each volatile (external_ref) fact past the grounding horizon against
+    GitHub using the token in [MASC_GROUNDING_GITHUB_TOKEN], and prints the
+    provisional verdicts plus a summary. Performs NO writes.
+
+    Usage:
+      MASC_GROUNDING_GITHUB_TOKEN=<repo-read PAT> \
+        dune exec test/eval_grounding_dry_run.exe -- [--owner O] [--repo R] [--horizon-seconds N]
+
+    With no token every verdict is Indeterminate (the run still lists which facts
+    WOULD be checked). The token is read from the environment by this process; it
+    is never written or logged. *)
+
+module Grounding = Masc.Keeper_memory_os_grounding
+module Io = Masc.Keeper_memory_os_io
+module Types = Masc.Keeper_memory_os_types
+
+let () =
+  let owner = ref Grounding.default_owner in
+  let repo = ref Grounding.default_repo in
+  let horizon = ref Grounding.default_grounding_horizon_seconds in
+  Arg.parse
+    [ "--owner", Arg.Set_string owner, " GitHub owner (default jeong-sik)"
+    ; "--repo", Arg.Set_string repo, " GitHub repo (default masc)"
+    ; "--horizon-seconds", Arg.Set_float horizon, " re-grounding horizon in seconds"
+    ]
+    (fun _ -> ())
+    "eval_grounding_dry_run [--owner O] [--repo R] [--horizon-seconds N]";
+  let token = Sys.getenv_opt "MASC_GROUNDING_GITHUB_TOKEN" in
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      (* Masc_http_client resolves its per-domain pool via Eio_context. *)
+      Eio_context.set_switch sw;
+      Eio_context.set_env env;
+      let clock = Eio.Stdenv.clock env in
+      let verify_external =
+        match token with
+        | Some t when String.trim t <> "" ->
+          Grounding.github_verify ~token:t ~clock ~timeout_sec:10.0 ~owner:!owner ~repo:!repo
+        | Some _ | None ->
+          prerr_endline
+            "[dry-run] no MASC_GROUNDING_GITHUB_TOKEN set; every verdict is Indeterminate";
+          Grounding.no_token_verify
+      in
+      let now = Eio.Time.now clock in
+      let keepers =
+        List.filter
+          (fun id -> not (String.equal id Types.shared_store_id))
+          (Io.list_fact_store_keeper_ids ())
+      in
+      let counts = Hashtbl.create 4 in
+      let bump key =
+        Hashtbl.replace counts key (1 + Option.value (Hashtbl.find_opt counts key) ~default:0)
+      in
+      List.iter
+        (fun keeper_id ->
+          let facts = try Io.read_facts_all ~keeper_id with _ -> [] in
+          let observations =
+            Grounding.grounding_pass
+              ~verify_external
+              ~now
+              ~grounding_horizon:!horizon
+              ~keeper_id
+              facts
+          in
+          List.iter
+            (fun (o : Grounding.observation) ->
+              bump (Grounding.provisional_verdict_to_string o.verdict);
+              print_endline (Grounding.observation_log_line o))
+            observations)
+        keepers;
+      Printf.printf "\n--- dry-run summary (keepers=%d, horizon=%.0fs) ---\n" (List.length keepers) !horizon;
+      List.iter
+        (fun key ->
+          Printf.printf "%s: %d\n" key (Option.value (Hashtbl.find_opt counts key) ~default:0))
+        [ "confirmed"; "contradicted_candidate"; "indeterminate" ]))
+;;

--- a/test/test_keeper_memory_os_grounding.ml
+++ b/test/test_keeper_memory_os_grounding.ml
@@ -1,0 +1,159 @@
+(* RFC-0259 P2: unit tests for the observe-only grounding reconciler. Pure,
+   deterministic, no network — verify_external is faked, and the GitHub response
+   parser is exercised on canned JSON. *)
+
+module Types = Masc.Keeper_memory_os_types
+module Grounding = Masc.Keeper_memory_os_grounding
+
+let failed = ref 0
+
+let check name cond =
+  if cond then Printf.printf "[PASS] %s\n%!" name
+  else (
+    incr failed;
+    Printf.printf "[FAIL] %s\n%!" name)
+
+let mk_fact ?(external_ref = None) ?(first_seen = 0.0) ?last_verified_at ~claim () : Types.fact =
+  { Types.claim
+  ; Types.category = Types.Fact
+  ; Types.external_ref
+  ; Types.source = { Types.trace_id = "t"; Types.turn = 1; Types.tool_call_id = None }
+  ; Types.observed_by = []
+  ; Types.first_seen
+  ; Types.valid_until = None
+  ; Types.last_verified_at
+  ; Types.schema_version = Types.schema_version
+  }
+;;
+
+let pr_body state =
+  Printf.sprintf {|{"data":{"repository":{"pullRequest":{"state":"%s"}}}}|} state
+;;
+
+let () =
+  (* ---- parse_state_response ---- *)
+  check
+    "parse OPEN"
+    (Grounding.parse_state_response ~kind:Types.Pr (pr_body "OPEN") = Ok Grounding.Open);
+  check
+    "parse CLOSED"
+    (Grounding.parse_state_response ~kind:Types.Pr (pr_body "CLOSED") = Ok Grounding.Closed);
+  check
+    "parse MERGED"
+    (Grounding.parse_state_response ~kind:Types.Pr (pr_body "MERGED") = Ok Grounding.Merged);
+  check
+    "parse issue CLOSED"
+    (Grounding.parse_state_response
+       ~kind:Types.Issue
+       {|{"data":{"repository":{"issue":{"state":"CLOSED"}}}}|}
+     = Ok Grounding.Closed);
+  check
+    "parse null node -> Not_found"
+    (Grounding.parse_state_response
+       ~kind:Types.Pr
+       {|{"data":{"repository":{"pullRequest":null}}}|}
+     = Ok Grounding.Not_found);
+  check
+    "parse graphql errors -> Error (Indeterminate)"
+    (Result.is_error
+       (Grounding.parse_state_response
+          ~kind:Types.Pr
+          {|{"errors":[{"message":"bad"}]}|}));
+  check
+    "parse unknown state -> Error"
+    (Result.is_error
+       (Grounding.parse_state_response
+          ~kind:Types.Pr
+          (pr_body "DRAFTED")));
+  check
+    "parse garbage -> Error"
+    (Result.is_error (Grounding.parse_state_response ~kind:Types.Pr "not json"));
+  (* ---- classify_state ---- *)
+  check "classify Open -> Confirmed" (Grounding.classify_state Grounding.Open = Grounding.Confirmed);
+  check
+    "classify Closed -> Contradicted_candidate"
+    (Grounding.classify_state Grounding.Closed = Grounding.Contradicted_candidate);
+  check
+    "classify Merged -> Contradicted_candidate"
+    (Grounding.classify_state Grounding.Merged = Grounding.Contradicted_candidate);
+  check
+    "classify Not_found -> Indeterminate"
+    (Grounding.classify_state Grounding.Not_found = Grounding.Indeterminate);
+  (* ---- grounding_pass (fake verify_external, no network) ---- *)
+  let horizon = 1000.0 in
+  let now = 100_000.0 in
+  let pr_ref = Some { Types.kind = Types.Pr; Types.id = "21363" } in
+  let fake : Grounding.verify_external =
+    fun r -> if String.equal r.Types.id "21363" then Ok Grounding.Closed else Error "unknown"
+  in
+  let stale_volatile =
+    mk_fact ~external_ref:pr_ref ~first_seen:(now -. (horizon *. 2.0)) ~claim:"PR #21363 is OPEN" ()
+  in
+  let fresh_volatile =
+    mk_fact ~external_ref:pr_ref ~first_seen:(now -. (horizon /. 2.0)) ~claim:"PR #21363 is OPEN" ()
+  in
+  let non_volatile =
+    mk_fact ~external_ref:None ~first_seen:(now -. (horizon *. 2.0)) ~claim:"durable knowledge" ()
+  in
+  let obs =
+    Grounding.grounding_pass
+      ~verify_external:fake
+      ~now
+      ~grounding_horizon:horizon
+      ~keeper_id:"k"
+      [ stale_volatile; fresh_volatile; non_volatile ]
+  in
+  check "only the stale volatile fact is observed" (List.length obs = 1);
+  (match obs with
+   | [ o ] ->
+     check
+       "verdict is contradicted_candidate (CLOSED)"
+       (o.Grounding.verdict = Grounding.Contradicted_candidate);
+     check "fetched state is Closed" (o.Grounding.fetched = Ok Grounding.Closed);
+     check
+       "normalized claim preserved (P3 retraction key)"
+       (String.equal o.Grounding.normalized_claim (Types.normalize_claim "PR #21363 is OPEN"))
+   | _ -> check "exactly one observation" false);
+  (* age uses last_verified_at when present: an old first_seen but recent
+     re-verification keeps the fact under the horizon (excluded). *)
+  let reverified =
+    mk_fact
+      ~external_ref:pr_ref
+      ~first_seen:(now -. (horizon *. 5.0))
+      ~last_verified_at:(now -. (horizon /. 2.0))
+      ~claim:"PR #21363 is OPEN"
+      ()
+  in
+  check
+    "recently re-verified volatile fact is excluded (age anchors on last_verified_at)"
+    (List.length
+       (Grounding.grounding_pass
+          ~verify_external:fake
+          ~now
+          ~grounding_horizon:horizon
+          ~keeper_id:"k"
+          [ reverified ])
+     = 0);
+  (* verify_external Error collapses to Indeterminate, never a false verdict. *)
+  let err_fake : Grounding.verify_external = fun _ -> Error "boom" in
+  (match
+     Grounding.grounding_pass
+       ~verify_external:err_fake
+       ~now
+       ~grounding_horizon:horizon
+       ~keeper_id:"k"
+       [ stale_volatile ]
+   with
+   | [ o ] ->
+     check "verify Error -> Indeterminate verdict" (o.Grounding.verdict = Grounding.Indeterminate)
+   | _ -> check "one observation for the error path" false);
+  (* no_token_verify degrades every ref to Error (-> Indeterminate). *)
+  check
+    "no_token_verify is always Error"
+    (Result.is_error (Grounding.no_token_verify { Types.kind = Types.Pr; Types.id = "1" }));
+  if !failed > 0
+  then (
+    Printf.printf "\n%d check(s) failed\n%!" !failed;
+    exit 1)
+  else Printf.printf "\nall checks passed\n%!"
+;;


### PR DESCRIPTION
## 목적
P1(#21644, MERGED)은 휘발 fact에 시간 TTL을 줘 거짓 기억을 ≤1일 decay시킵니다. P2는 **능동 검증**을 추가합니다: default-OFF·off-hot-path reconciler가 키퍼의 휘발(PR/issue) fact 중 grounding horizon을 넘긴 것을 GitHub와 대조해 **provisional verdict를 로그**합니다.

RFC: **RFC-0259** §3.3. 3-렌즈 적대 워크플로로 feasibility/IO안전/correctness 검증 완료.

## ⚠️ 라이브 동작 변화: 없음 (observe-only)
default-OFF + **write 0**(retraction 없음, `last_verified_at` 미변경). enable해도 로그만 남고 fact store/recall은 불변. 이 dry-run 로그가 P3의 실제 retraction 정책을 설계할 근거입니다(RFC-0259 §3.3 dry-run-before-enable 규율 — 측정 먼저, 삭제는 나중).

## ⚠️ 운영자 prereq (live verdict용, 코드 블로커 아님)
서버 env에 `MASC_GROUNDING_GITHUB_TOKEN`(repo-read PAT) 프로비저닝 필요. 없으면 모든 verdict가 `Indeterminate`로 안전 degrade(머지·동작 정상, 1회 경고 로그). jeong-sik/masc는 private라 unauth=404→Indeterminate. credential-adjacent라 명시합니다.

## 변경
- 신규 `Keeper_memory_os_grounding`: `fetched_state`(Open|Closed|Merged|Not_found)·`provisional_verdict`(Confirmed|Contradicted_candidate|Indeterminate) **closed sum**, 주입형 `verify_external`(fake-able), 순수 `grounding_pass`(fact-store write 의존성 0), `github_verify`(`masc_http_client` GraphQL + Authorization bearer + **필수 User-Agent**, 없으면 403), `parse_state_response`.
- 모든 불확실(토큰 없음 / HTTP 401·403·404 / GraphQL errors / null 노드 / timeout / Task ref) → `Indeterminate`. **거짓 verdict 0**(CLAUDE.md 안티패턴#2: unknown→Unknown).
- 신규 default-OFF fiber `MASC_KEEPER_MEMORY_OS_GROUNDING`(GC fiber 패턴 복제): 토큰 없으면 1회 경고+무해 동작, **10s per-call timeout 필수**, 1s inter-keeper pacing, `Eio.Cancel.Cancelled` re-raise.

## 점수 없음 (제약 준수)
closed enum + 3치 verdict만. importance/effectiveness/confidence 숫자 0(RFC-0247/0259 경계 유지).

## 범위 밖 (P3)
실제 retraction(Contradicted 시 제거 + librarian `supersedes`) + Confirmed 시 `last_verified_at` advance. P2 dry-run 로그의 disagreement rate를 본 뒤 정책 확정.

## 검증
- `dune build --root .` green, ocamlformat clean. main rebase(squash된 P1 위) 후 재빌드 green.
- 신규 `test_keeper_memory_os_grounding` **19 checks green**(network 0): parse 8 + classify 4 + grounding_pass 7(horizon 필터, `last_verified_at` anchor, Error→Indeterminate, no_token).

WORKAROUND-WAIVED: observe-only 로깅은 telemetry-as-fix가 아니라 RFC-0259 §3.3이 규정한 dry-run-before-enable 단계입니다(P3이 fix이며 이 측정에 게이트됨).
RFC-WAIVED: keeper_memory_os_*는 agent_delegation RFC 트리거 subsystem 아님. RFC-0259 구현·인용(GitHub 토큰 credential-adjacent는 위 prereq에 명시).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
