### PR TITLE
feat(memory-os): RFC-0259 P2 — grounding reconciler (dry-run, default-OFF)

### DIFF
--- a/lib/keeper/keeper_memory_os_reconcile.ml
+++ b/lib/keeper/keeper_memory_os_reconcile.ml
@@ -1,0 +1,82 @@
+(** Keeper_memory_os_reconcile — RFC-0259 §3.3 grounding reconciler (P2 core).
+
+    See the .mli for the boundary rationale. This module is pure: the only IO (a
+    [gh] call) is the injected {!verify_fn}. *)
+
+open Keeper_memory_os_types
+
+type external_state =
+  | Still_open
+  | Terminal
+  | Unverifiable
+
+type verify_fn = external_ref -> external_state
+
+type verdict =
+  | Fresh
+  | Stale_open
+  | Stale_terminal
+  | Stale_unknown
+
+let verdict_to_string = function
+  | Fresh -> "fresh"
+  | Stale_open -> "stale_open"
+  | Stale_terminal -> "stale_terminal"
+  | Stale_unknown -> "stale_unknown"
+;;
+
+(* Re-ground at half the volatile TTL so a still-true ref is confirmed (and would
+   have its last_verified_at advanced by P3) before the TTL would hard-expire it. *)
+let default_grounding_horizon_seconds = volatile_external_ttl_seconds /. 2.0
+
+(* The reference time a fact was last known good: last_verified_at if set, else
+   first_seen — a never-re-verified fact is as old as its extraction. *)
+let reference_time (f : fact) =
+  match f.last_verified_at with
+  | Some t -> t
+  | None -> f.first_seen
+;;
+
+let classify ~now ~horizon ~(verify : verify_fn) (f : fact) : verdict =
+  match f.external_ref with
+  | None -> Fresh
+  | Some r ->
+    if now -. reference_time f <= horizon
+    then Fresh
+    else (
+      match verify r with
+      | Still_open -> Stale_open
+      | Terminal -> Stale_terminal
+      | Unverifiable -> Stale_unknown)
+;;
+
+type dry_run_report =
+  { scanned : int
+  ; stale_open : int
+  ; stale_terminal : int
+  ; stale_unknown : int
+  }
+
+let empty_report = { scanned = 0; stale_open = 0; stale_terminal = 0; stale_unknown = 0 }
+
+let dry_run ~now ~horizon ~verify (facts : fact list)
+  : dry_run_report * (fact * verdict) list
+  =
+  let report, rev_items =
+    List.fold_left
+      (fun (report, items) f ->
+        let v = classify ~now ~horizon ~verify f in
+        let report = { report with scanned = report.scanned + 1 } in
+        match v with
+        | Fresh -> report, items
+        | Stale_open ->
+          { report with stale_open = report.stale_open + 1 }, (f, v) :: items
+        | Stale_terminal ->
+          { report with stale_terminal = report.stale_terminal + 1 }, (f, v) :: items
+        | Stale_unknown ->
+          { report with stale_unknown = report.stale_unknown + 1 }, (f, v) :: items)
+      (empty_report, [])
+      facts
+  in
+  report, List.rev rev_items
+;;

--- a/lib/keeper/keeper_memory_os_reconcile.mli
+++ b/lib/keeper/keeper_memory_os_reconcile.mli
@@ -1,0 +1,67 @@
+(** Keeper_memory_os_reconcile — RFC-0259 §3.3 grounding reconciler (P2 core).
+
+    A keeper accumulates facts about volatile external state ("PR #X is OPEN",
+    "issue #Y blocked"). P1 ({!Keeper_memory_os_types.external_ref_of_claim}) gives
+    such a fact a finite TTL; this module re-checks it against the source of truth
+    so a still-true ref is kept fresh and a now-terminal ref is flagged.
+
+    The IO (a [gh] call) is injected as {!verify_fn}, so the classification core is
+    pure and fake-testable. P2 only classifies (dry-run, default-OFF fiber); P3
+    turns the verdicts into the actual [last_verified_at] advance / retraction
+    under the facts lock. The boundary is RFC-0259's: deciding *which* claim is
+    externally-referenced is deterministic; the external state is the only IO. *)
+
+open Keeper_memory_os_types
+
+(** The current external state of a referenced PR/issue/task as seen by the
+    injected verifier. Closed sum so every state is handled at compile time. *)
+type external_state =
+  | Still_open (** the ref is live (open PR/issue) — the claim's subject is active *)
+  | Terminal
+      (** the ref is merged/closed — a claim treating it as in-progress is stale *)
+  | Unverifiable
+      (** could not determine: network/transient, 404, or a kind not grounded yet
+          (Task/Jira). Reconciliation never acts on this — uncertainty is not
+          contradiction. *)
+
+(** Injected external verifier. The live implementation shells out to [gh]; tests
+    pass a deterministic fake. *)
+type verify_fn = external_ref -> external_state
+
+(** Per-fact reconciliation verdict. P2 classifies only; P3 maps these to the
+    real advance/retract. *)
+type verdict =
+  | Fresh (** no [external_ref], or last verified within the horizon — leave alone *)
+  | Stale_open (** past horizon, ref still open — P3 advances [last_verified_at] *)
+  | Stale_terminal
+      (** past horizon, ref terminal — P3 retracts (the live-store false-fact class) *)
+  | Stale_unknown
+      (** past horizon, ref unverifiable — skip; never delete on uncertainty *)
+
+val verdict_to_string : verdict -> string
+
+(** RFC-0259 §3.3: the default re-grounding horizon. Shorter than
+    {!Keeper_memory_os_types.volatile_external_ttl_seconds} so a referenced fact is
+    re-checked before it would otherwise hard-expire. *)
+val default_grounding_horizon_seconds : float
+
+(** Classify one fact. [Fresh] unless it carries an [external_ref] and has not been
+    verified within [horizon]; then the injected [verify] decides. Pure. *)
+val classify : now:float -> horizon:float -> verify:verify_fn -> fact -> verdict
+
+type dry_run_report =
+  { scanned : int
+  ; stale_open : int
+  ; stale_terminal : int
+  ; stale_unknown : int
+  }
+
+(** Classify a keeper's facts. Returns aggregate counts plus the per-fact verdicts
+    for the stale ones (in input order; [Fresh] facts are omitted to keep the
+    dry-run log focused). *)
+val dry_run
+  :  now:float
+  -> horizon:float
+  -> verify:verify_fn
+  -> fact list
+  -> dry_run_report * (fact * verdict) list

--- a/lib/keeper/keeper_memory_os_reconcile_gh.ml
+++ b/lib/keeper/keeper_memory_os_reconcile_gh.ml
@@ -1,59 +1,101 @@
-(** gh-backed external verifier for the grounding reconciler (RFC-0259 §3.3 P2).
+(** GitHub-backed external verifier for the grounding reconciler (RFC-0259 §3.3 P2).
 
-    See the .mli. Every failure path collapses to [Unverifiable] so the reconciler
-    never treats an unreachable/ambiguous ref as a contradiction. *)
+    See the .mli. Every failure path collapses to [Unverifiable] so the
+    reconciler never treats an unreachable/ambiguous ref as a contradiction. *)
 
 open Keeper_memory_os_types
 module R = Keeper_memory_os_reconcile
 
-(* gh prints the state field as a bare JSON object: {"state":"MERGED"}. Read the
-   [state] string; anything else (malformed, missing) is unverifiable. *)
-let state_of_json_output (out : string) : string option =
-  match Yojson.Safe.from_string (String.trim out) with
-  | `Assoc fields ->
-    (match List.assoc_opt "state" fields with
-     | Some (`String s) -> Some (String.uppercase_ascii (String.trim s))
-     | _ -> None)
-  | _ | (exception _) -> None
-;;
-
-(* Map a gh state token to external_state. OPEN -> live; MERGED/CLOSED -> terminal
-   (a claim treating the ref as in-progress is stale). Unknown token -> conservative
-   Unverifiable (we do not invent a verdict for a state we do not model). *)
+(* Map a GitHub state token to external_state. OPEN -> live; MERGED/CLOSED ->
+   terminal. Unknown token -> conservative Unverifiable; do not invent a verdict
+   for a state we do not model. *)
 let external_state_of_token = function
   | "OPEN" -> R.Still_open
   | "MERGED" | "CLOSED" -> R.Terminal
   | _ -> R.Unverifiable
 ;;
 
-(* The gh subcommand for a kind. [Task] (Jira/PK ids) has no gh source of truth,
-   so it is never grounded here — returns [None] and the caller yields
-   Unverifiable. *)
-let gh_subcommand = function
-  | Pr -> Some "pr"
+let node_field = function
+  | Pr -> Some "pullRequest"
   | Issue -> Some "issue"
   | Task -> None
 ;;
 
+let parse_state_response ~(kind : external_ref_kind) (body : string) : R.external_state =
+  match Yojson.Safe.from_string body with
+  | exception _ -> R.Unverifiable
+  | json ->
+    (try
+       let open Yojson.Safe.Util in
+       match member "errors" json with
+       | `List (_ :: _) -> R.Unverifiable
+       | _ ->
+         (match node_field kind with
+          | None -> R.Unverifiable
+          | Some field ->
+            let node = json |> member "data" |> member "repository" |> member field in
+            (match node with
+             | `Null -> R.Unverifiable
+             | _ ->
+               (match member "state" node with
+                | `String state ->
+                  external_state_of_token (String.uppercase_ascii (String.trim state))
+                | _ -> R.Unverifiable)))
+     with
+     | _ -> R.Unverifiable)
+;;
+
+let repo_owner_name repo =
+  match String.split_on_char '/' (String.trim repo) with
+  | [ owner; name ] when String.trim owner <> "" && String.trim name <> "" ->
+    Some (String.trim owner, String.trim name)
+  | _ -> None
+;;
+
+let graphql_query ~(owner : string) ~(name : string) ~(kind : external_ref_kind) ~(number : int) =
+  let node =
+    match kind with
+    | Pr -> Printf.sprintf "pullRequest(number:%d){state}" number
+    | Issue -> Printf.sprintf "issue(number:%d){state}" number
+    | Task -> assert false
+  in
+  Printf.sprintf "query{repository(owner:%S,name:%S){%s}}" owner name node
+;;
+
+let no_token_verify (_ : external_ref) : R.external_state = R.Unverifiable
+
 let verify_external
-      ~(proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t)
+      ~token
+      ~clock
+      ~timeout_sec
       ~repo
       (r : external_ref)
   : R.external_state
   =
-  match gh_subcommand r.kind with
-  | None -> R.Unverifiable
-  | Some sub ->
-    let argv = [ "gh"; sub; "view"; r.id; "--repo"; repo; "--json"; "state" ] in
-    (* parse_out manages its own switch (spawn/drain/await/reap) and raises on
-       non-zero exit / spawn failure / read error; all of those mean "could not
-       determine", never "contradicted", so they collapse to [Unverifiable]. *)
-    (try
-       let out = Eio.Process.parse_out proc_mgr Eio.Buf_read.take_all argv in
-       match state_of_json_output out with
-       | Some token -> external_state_of_token token
-       | None -> R.Unverifiable
+  match r.kind, repo_owner_name repo, int_of_string_opt r.id with
+  | Task, _, _ -> R.Unverifiable
+  | (Pr | Issue), None, _ -> R.Unverifiable
+  | (Pr | Issue), _, None -> R.Unverifiable
+  | (Pr | Issue), Some (owner, name), Some number ->
+    let query = graphql_query ~owner ~name ~kind:r.kind ~number in
+    let body = `Assoc [ "query", `String query ] |> Yojson.Safe.to_string in
+    (match
+       Masc_http_client.post_sync
+         ~clock
+         ~timeout_sec
+         ~url:"https://api.github.com/graphql"
+         ~headers:
+           [ "Authorization", "bearer " ^ String.trim token
+           ; "Accept", "application/vnd.github+json"
+           ; "User-Agent", "masc-memory-os-reconcile"
+           ; "Content-Type", "application/json"
+           ]
+         ~body
+         ()
      with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | _ -> R.Unverifiable)
+     | Error _ -> R.Unverifiable
+     | Ok (status, response_body) ->
+       if status < 200 || status >= 300
+       then R.Unverifiable
+       else parse_state_response ~kind:r.kind response_body)
 ;;

--- a/lib/keeper/keeper_memory_os_reconcile_gh.ml
+++ b/lib/keeper/keeper_memory_os_reconcile_gh.ml
@@ -1,0 +1,59 @@
+(** gh-backed external verifier for the grounding reconciler (RFC-0259 §3.3 P2).
+
+    See the .mli. Every failure path collapses to [Unverifiable] so the reconciler
+    never treats an unreachable/ambiguous ref as a contradiction. *)
+
+open Keeper_memory_os_types
+module R = Keeper_memory_os_reconcile
+
+(* gh prints the state field as a bare JSON object: {"state":"MERGED"}. Read the
+   [state] string; anything else (malformed, missing) is unverifiable. *)
+let state_of_json_output (out : string) : string option =
+  match Yojson.Safe.from_string (String.trim out) with
+  | `Assoc fields ->
+    (match List.assoc_opt "state" fields with
+     | Some (`String s) -> Some (String.uppercase_ascii (String.trim s))
+     | _ -> None)
+  | _ | (exception _) -> None
+;;
+
+(* Map a gh state token to external_state. OPEN -> live; MERGED/CLOSED -> terminal
+   (a claim treating the ref as in-progress is stale). Unknown token -> conservative
+   Unverifiable (we do not invent a verdict for a state we do not model). *)
+let external_state_of_token = function
+  | "OPEN" -> R.Still_open
+  | "MERGED" | "CLOSED" -> R.Terminal
+  | _ -> R.Unverifiable
+;;
+
+(* The gh subcommand for a kind. [Task] (Jira/PK ids) has no gh source of truth,
+   so it is never grounded here — returns [None] and the caller yields
+   Unverifiable. *)
+let gh_subcommand = function
+  | Pr -> Some "pr"
+  | Issue -> Some "issue"
+  | Task -> None
+;;
+
+let verify_external
+      ~(proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t)
+      ~repo
+      (r : external_ref)
+  : R.external_state
+  =
+  match gh_subcommand r.kind with
+  | None -> R.Unverifiable
+  | Some sub ->
+    let argv = [ "gh"; sub; "view"; r.id; "--repo"; repo; "--json"; "state" ] in
+    (* parse_out manages its own switch (spawn/drain/await/reap) and raises on
+       non-zero exit / spawn failure / read error; all of those mean "could not
+       determine", never "contradicted", so they collapse to [Unverifiable]. *)
+    (try
+       let out = Eio.Process.parse_out proc_mgr Eio.Buf_read.take_all argv in
+       match state_of_json_output out with
+       | Some token -> external_state_of_token token
+       | None -> R.Unverifiable
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | _ -> R.Unverifiable)
+;;

--- a/lib/keeper/keeper_memory_os_reconcile_gh.mli
+++ b/lib/keeper/keeper_memory_os_reconcile_gh.mli
@@ -1,0 +1,14 @@
+(** gh-backed external verifier for the grounding reconciler (RFC-0259 §3.3 P2).
+
+    The single external-IO surface. Shells out to [gh pr|issue view <id> --json
+    state]; any failure (network, 404, auth, timeout) or a non-gh kind ([Task] /
+    Jira) yields [Unverifiable], so the reconciler never treats uncertainty as
+    contradiction. Injected into the reconciler as a {!Keeper_memory_os_reconcile.verify_fn}. *)
+
+open Keeper_memory_os_types
+
+val verify_external
+  :  proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
+  -> repo:string
+  -> external_ref
+  -> Keeper_memory_os_reconcile.external_state

--- a/lib/keeper/keeper_memory_os_reconcile_gh.mli
+++ b/lib/keeper/keeper_memory_os_reconcile_gh.mli
@@ -1,14 +1,26 @@
-(** gh-backed external verifier for the grounding reconciler (RFC-0259 §3.3 P2).
+(** GitHub-backed external verifier for the grounding reconciler (RFC-0259 §3.3 P2).
 
-    The single external-IO surface. Shells out to [gh pr|issue view <id> --json
-    state]; any failure (network, 404, auth, timeout) or a non-gh kind ([Task] /
-    Jira) yields [Unverifiable], so the reconciler never treats uncertainty as
-    contradiction. Injected into the reconciler as a {!Keeper_memory_os_reconcile.verify_fn}. *)
+    The single external-IO surface. Uses GitHub GraphQL through
+    {!Masc_http_client} and a MASC-managed token; any failure (network, 404,
+    auth, timeout, malformed response) or a non-GitHub kind ([Task] / Jira)
+    yields [Unverifiable], so the reconciler never treats uncertainty as
+    contradiction. Injected into the reconciler as a
+    {!Keeper_memory_os_reconcile.verify_fn}. *)
 
 open Keeper_memory_os_types
 
+val parse_state_response
+  :  kind:external_ref_kind
+  -> string
+  -> Keeper_memory_os_reconcile.external_state
+
+val no_token_verify
+  : external_ref -> Keeper_memory_os_reconcile.external_state
+
 val verify_external
-  :  proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
+  :  token:string
+  -> clock:[> float Eio.Time.clock_ty ] Eio.Resource.t
+  -> timeout_sec:float
   -> repo:string
   -> external_ref
   -> Keeper_memory_os_reconcile.external_state

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -170,6 +170,72 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
         loop ()
       in
       loop ());
+  (* RFC-0259 §3.3: memory-os grounding reconciler (P2, dry-run). Off the keeper
+     hot path — every [interval]s it re-checks each Tier-1 fact that names verifiable
+     external state (a PR/issue id, P1's [external_ref]) against the source of truth
+     via [gh], and logs what it WOULD do: a still-open ref is fresh, a merged/closed
+     ref backing an in-progress claim is stale_terminal (the live-store false-fact
+     class that had keepers acting on a closed PR for ~30 turns). P2 only classifies;
+     P3 turns stale_terminal into retraction and stale_open into a last_verified_at
+     advance, under the facts lock. Default OFF + dry-run (mirrors the GC/consolidation
+     rollout): the log is reviewed before any write path is enabled. [Unverifiable]
+     (gh failure / non-PR kind) is never acted on — uncertainty is not contradiction.
+     Skipped entirely when proc_mgr is absent (no gh) or no alert repo is configured. *)
+  (match state.Mcp_server.proc_mgr with
+   | Some proc_mgr
+     when Keeper_memory_bank_env.memory_env_bool_logged
+            "MASC_KEEPER_MEMORY_OS_RECONCILE"
+            ~default:false
+          && String.trim Env_config.KeeperAlert.github_repo <> "" ->
+     let repo = String.trim Env_config.KeeperAlert.github_repo in
+     fork_logged_fiber
+       ~sw
+       ~on_error:(log_server_fiber_crash "memory_os_reconcile")
+       (fun () ->
+       (* Coarsest cadence: grounding shells out to gh per referenced fact, so an
+          hourly fleet rescan bounds external calls while still catching a closed
+          PR well within its volatile TTL. *)
+       let interval = 3600.0 in
+       let horizon = Keeper_memory_os_reconcile.default_grounding_horizon_seconds in
+       let verify = Keeper_memory_os_reconcile_gh.verify_external ~proc_mgr ~repo in
+       let rec loop () =
+         List.iter
+           (fun keeper_id ->
+              try
+                let facts = Keeper_memory_os_io.read_facts_all ~keeper_id in
+                let report, _items =
+                  Keeper_memory_os_reconcile.dry_run
+                    ~now:(Time_compat.now ())
+                    ~horizon
+                    ~verify
+                    facts
+                in
+                if report.Keeper_memory_os_reconcile.stale_terminal > 0
+                   || report.stale_open > 0
+                then
+                  Log.Server.info
+                    "memory_os_reconcile[dry-run]: keeper=%s scanned=%d \
+                     stale_open=%d stale_terminal=%d stale_unknown=%d"
+                    keeper_id
+                    report.scanned
+                    report.stale_open
+                    report.stale_terminal
+                    report.stale_unknown
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
+                Log.Server.warn
+                  "memory_os_reconcile: keeper=%s tick crashed: %s"
+                  keeper_id
+                  (Printexc.to_string exn))
+           (List.filter
+              (fun id -> not (String.equal id Keeper_memory_os_types.shared_store_id))
+              (Keeper_memory_os_io.list_fact_store_keeper_ids ()));
+         Eio.Time.sleep clock interval;
+         loop ()
+       in
+       loop ())
+   | Some _ | None -> ());
   (* #9876: Hebbian consolidation fiber. Prior to this, the graph was
      write-only — strengthen/weaken populated synapses but decay +
      pruning never ran (zero production callers of [consolidate]).

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -171,33 +171,47 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       in
       loop ());
   (* RFC-0259 §3.3: memory-os grounding reconciler (P2, dry-run). Off the keeper
-     hot path — every [interval]s it re-checks each Tier-1 fact that names verifiable
-     external state (a PR/issue id, P1's [external_ref]) against the source of truth
-     via [gh], and logs what it WOULD do: a still-open ref is fresh, a merged/closed
-     ref backing an in-progress claim is stale_terminal (the live-store false-fact
-     class that had keepers acting on a closed PR for ~30 turns). P2 only classifies;
-     P3 turns stale_terminal into retraction and stale_open into a last_verified_at
-     advance, under the facts lock. Default OFF + dry-run (mirrors the GC/consolidation
-     rollout): the log is reviewed before any write path is enabled. [Unverifiable]
-     (gh failure / non-PR kind) is never acted on — uncertainty is not contradiction.
-     Skipped entirely when proc_mgr is absent (no gh) or no alert repo is configured. *)
-  (match state.Mcp_server.proc_mgr with
-   | Some proc_mgr
-     when Keeper_memory_bank_env.memory_env_bool_logged
-            "MASC_KEEPER_MEMORY_OS_RECONCILE"
-            ~default:false
-          && String.trim Env_config.KeeperAlert.github_repo <> "" ->
+     hot path — every [interval]s it re-checks each Tier-1 fact that names
+     verifiable external state (a PR/issue id, P1's [external_ref]) against the
+     source of truth through GitHub GraphQL, and logs what it WOULD do: a
+     still-open ref is fresh, a merged/closed ref backing an in-progress claim is
+     stale_terminal (the live-store false-fact class that had keepers acting on a
+     closed PR for ~30 turns). P2 only classifies; P3 turns stale_terminal into
+     retraction and stale_open into a last_verified_at advance, under the facts
+     lock. Default OFF + dry-run (mirrors the GC/consolidation rollout): the log
+     is reviewed before any write path is enabled. [Unverifiable] (GitHub
+     failure / missing token / non-PR kind) is never acted on — uncertainty is
+     not contradiction. Skipped entirely when no alert repo is configured. *)
+  if
+    Keeper_memory_bank_env.memory_env_bool_logged
+      "MASC_KEEPER_MEMORY_OS_RECONCILE"
+      ~default:false
+    && String.trim Env_config.KeeperAlert.github_repo <> ""
+  then (
      let repo = String.trim Env_config.KeeperAlert.github_repo in
      fork_logged_fiber
        ~sw
        ~on_error:(log_server_fiber_crash "memory_os_reconcile")
        (fun () ->
-       (* Coarsest cadence: grounding shells out to gh per referenced fact, so an
-          hourly fleet rescan bounds external calls while still catching a closed
-          PR well within its volatile TTL. *)
+       (* Coarsest cadence: grounding makes one GitHub request per referenced
+          fact, so an hourly fleet rescan bounds external calls while still
+          catching a closed PR well within its volatile TTL. *)
        let interval = 3600.0 in
        let horizon = Keeper_memory_os_reconcile.default_grounding_horizon_seconds in
-       let verify = Keeper_memory_os_reconcile_gh.verify_external ~proc_mgr ~repo in
+       let verify =
+         match Keeper_memory_bank_env.memory_env_opt "MASC_GROUNDING_GITHUB_TOKEN" with
+         | Some token when String.trim token <> "" ->
+           Keeper_memory_os_reconcile_gh.verify_external
+             ~token
+             ~clock
+             ~timeout_sec:10.0
+             ~repo
+         | Some _ | None ->
+           Log.Server.warn
+             "memory_os_reconcile: no MASC_GROUNDING_GITHUB_TOKEN; all refs \
+              Unverifiable";
+           Keeper_memory_os_reconcile_gh.no_token_verify
+       in
        let rec loop () =
          List.iter
            (fun keeper_id ->
@@ -234,8 +248,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
          Eio.Time.sleep clock interval;
          loop ()
        in
-       loop ())
-   | Some _ | None -> ());
+       loop ()));
   (* #9876: Hebbian consolidation fiber. Prior to this, the graph was
      write-only — strengthen/weaken populated synapses but decay +
      pruning never ran (zero production callers of [consolidate]).

--- a/test/dune
+++ b/test/dune
@@ -29,6 +29,7 @@
 
 (tests
  (names
+  test_rfc0259_reconcile
   test_keeper_memory_lane
   test_keeper_reactive_wake_backlog_gate
   test_broadcast_wakeup_policy
@@ -324,6 +325,7 @@
   test_relation_materializer
   test_keeper_behavior_trace)
  (modules
+  test_rfc0259_reconcile
   test_keeper_memory_lane
   test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate

--- a/test/test_rfc0259_reconcile.ml
+++ b/test/test_rfc0259_reconcile.ml
@@ -1,0 +1,145 @@
+(** RFC-0259 P2 — grounding reconciler core (pure classify / dry_run).
+
+    Drives the classifier with a fake [verify_fn] so Confirmed/Contradicted/Unknown
+    paths are deterministic. Pins:
+    - no external_ref           -> Fresh (never grounded)
+    - referenced but in-horizon -> Fresh (not re-checked yet)
+    - past horizon, open        -> Stale_open
+    - past horizon, terminal    -> Stale_terminal
+    - past horizon, unverifiable -> Stale_unknown (never deleted on uncertainty)
+    - dry_run aggregates counts and lists only the stale facts, in order. *)
+
+module Types = Masc.Keeper_memory_os_types
+module R = Masc.Keeper_memory_os_reconcile
+
+let now = 1_000_000.0
+let horizon = 3600.0
+
+let fact ?(external_ref = None) ?last_verified_at ~first_seen claim =
+  { Types.claim
+  ; category = Types.Fact
+  ; external_ref
+  ; source = { Types.trace_id = "t"; turn = 1; tool_call_id = None }
+  ; observed_by = []
+  ; first_seen
+  ; valid_until = None
+  ; last_verified_at
+  ; schema_version = Types.schema_version
+  }
+;;
+
+let pr id = Some { Types.kind = Types.Pr; id }
+
+(* A fake verifier keyed on id so each test fixes the external state. *)
+let verify_const state : R.verify_fn = fun _ref -> state
+let verify_by_id table : R.verify_fn =
+  fun (r : Types.external_ref) ->
+  match List.assoc_opt r.Types.id table with
+  | Some s -> s
+  | None -> R.Unverifiable
+;;
+
+let verdict = Alcotest.testable (fun ppf v -> Format.fprintf ppf "%s" (R.verdict_to_string v)) ( = )
+
+let check_classify name expected ~verify f =
+  Alcotest.check verdict name expected (R.classify ~now ~horizon ~verify f)
+;;
+
+let test_no_ref_is_fresh () =
+  (* old, but no external_ref → never a reconciler concern *)
+  check_classify
+    "no ref"
+    R.Fresh
+    ~verify:(verify_const R.Terminal)
+    (fact ~first_seen:(now -. 100_000.0) "deployment uses blue-green")
+;;
+
+let test_in_horizon_is_fresh () =
+  (* referenced, but verified within the horizon → not re-checked (verify must
+     not even be consulted; use a verify that would FAIL the test if called) *)
+  let verify : R.verify_fn = fun _ -> Alcotest.fail "verify called inside horizon" in
+  check_classify
+    "in horizon"
+    R.Fresh
+    ~verify
+    (fact ~external_ref:(pr "1") ~last_verified_at:(now -. 10.0) ~first_seen:(now -. 10.0) "PR #1 open")
+;;
+
+let test_past_horizon_open () =
+  check_classify
+    "past horizon, open"
+    R.Stale_open
+    ~verify:(verify_const R.Still_open)
+    (fact ~external_ref:(pr "2") ~last_verified_at:(now -. 100_000.0) ~first_seen:(now -. 100_000.0) "PR #2 open")
+;;
+
+let test_past_horizon_terminal () =
+  (* the live-store false-fact class: a closed/merged PR backing an in-progress claim *)
+  check_classify
+    "past horizon, terminal"
+    R.Stale_terminal
+    ~verify:(verify_const R.Terminal)
+    (fact ~external_ref:(pr "21515") ~first_seen:(now -. 100_000.0) "PR #21515 blocked, needs fix")
+;;
+
+let test_past_horizon_unknown () =
+  (* uncertainty (gh failure / Task kind) is never a contradiction *)
+  check_classify
+    "past horizon, unverifiable"
+    R.Stale_unknown
+    ~verify:(verify_const R.Unverifiable)
+    (fact ~external_ref:(pr "3") ~first_seen:(now -. 100_000.0) "PR #3 status unknown")
+;;
+
+let test_no_last_verified_uses_first_seen () =
+  (* last_verified_at = None → first_seen is the reference time *)
+  check_classify
+    "none last_verified, old first_seen → checked"
+    R.Stale_terminal
+    ~verify:(verify_const R.Terminal)
+    (fact ~external_ref:(pr "4") ~first_seen:(now -. 100_000.0) "PR #4 merged");
+  check_classify
+    "none last_verified, fresh first_seen → fresh"
+    R.Fresh
+    ~verify:(verify_const R.Terminal)
+    (fact ~external_ref:(pr "5") ~first_seen:(now -. 10.0) "PR #5 just seen")
+;;
+
+let test_dry_run_aggregates () =
+  let facts =
+    [ fact ~first_seen:(now -. 100_000.0) "no ref durable"
+    ; fact ~external_ref:(pr "10") ~first_seen:(now -. 100_000.0) "PR #10"
+    ; fact ~external_ref:(pr "11") ~first_seen:(now -. 100_000.0) "PR #11"
+    ; fact ~external_ref:(pr "12") ~first_seen:(now -. 100_000.0) "PR #12"
+    ; fact ~external_ref:(pr "13") ~last_verified_at:(now -. 5.0) ~first_seen:(now -. 5.0) "PR #13 recent"
+    ]
+  in
+  let verify =
+    verify_by_id
+      [ "10", R.Still_open; "11", R.Terminal; "12", R.Unverifiable; "13", R.Terminal ]
+  in
+  let report, items = R.dry_run ~now ~horizon ~verify facts in
+  Alcotest.(check int) "scanned" 5 report.R.scanned;
+  Alcotest.(check int) "stale_open" 1 report.R.stale_open;
+  Alcotest.(check int) "stale_terminal" 1 report.R.stale_terminal;
+  Alcotest.(check int) "stale_unknown" 1 report.R.stale_unknown;
+  (* only the 3 stale facts are listed; the durable and the in-horizon are omitted *)
+  Alcotest.(check int) "items length" 3 (List.length items);
+  let claims = List.map (fun (f, _) -> f.Types.claim) items in
+  Alcotest.(check (list string)) "stale claims in order" [ "PR #10"; "PR #11"; "PR #12" ] claims
+;;
+
+let () =
+  Alcotest.run
+    "rfc0259_reconcile"
+    [ ( "classify"
+      , [ Alcotest.test_case "no-ref-fresh" `Quick test_no_ref_is_fresh
+        ; Alcotest.test_case "in-horizon-fresh" `Quick test_in_horizon_is_fresh
+        ; Alcotest.test_case "past-open" `Quick test_past_horizon_open
+        ; Alcotest.test_case "past-terminal" `Quick test_past_horizon_terminal
+        ; Alcotest.test_case "past-unknown" `Quick test_past_horizon_unknown
+        ; Alcotest.test_case "ref-time-fallback" `Quick test_no_last_verified_uses_first_seen
+        ] )
+    ; ("dry_run", [ Alcotest.test_case "aggregates" `Quick test_dry_run_aggregates ])
+    ]
+;;

--- a/test/test_rfc0259_reconcile.ml
+++ b/test/test_rfc0259_reconcile.ml
@@ -11,6 +11,7 @@
 
 module Types = Masc.Keeper_memory_os_types
 module R = Masc.Keeper_memory_os_reconcile
+module GH = Masc.Keeper_memory_os_reconcile_gh
 
 let now = 1_000_000.0
 let horizon = 3600.0
@@ -40,6 +41,18 @@ let verify_by_id table : R.verify_fn =
 ;;
 
 let verdict = Alcotest.testable (fun ppf v -> Format.fprintf ppf "%s" (R.verdict_to_string v)) ( = )
+let external_state =
+  Alcotest.testable
+    (fun ppf v ->
+       Format.fprintf
+         ppf
+         "%s"
+         (match v with
+          | R.Still_open -> "still_open"
+          | R.Terminal -> "terminal"
+          | R.Unverifiable -> "unverifiable"))
+    ( = )
+;;
 
 let check_classify name expected ~verify f =
   Alcotest.check verdict name expected (R.classify ~now ~horizon ~verify f)
@@ -129,6 +142,58 @@ let test_dry_run_aggregates () =
   Alcotest.(check (list string)) "stale claims in order" [ "PR #10"; "PR #11"; "PR #12" ] claims
 ;;
 
+let pr_state_body state =
+  Printf.sprintf {|{"data":{"repository":{"pullRequest":{"state":"%s"}}}}|} state
+;;
+
+let test_github_parse_states () =
+  Alcotest.check
+    external_state
+    "OPEN -> still_open"
+    R.Still_open
+    (GH.parse_state_response ~kind:Types.Pr (pr_state_body "OPEN"));
+  Alcotest.check
+    external_state
+    "MERGED -> terminal"
+    R.Terminal
+    (GH.parse_state_response ~kind:Types.Pr (pr_state_body "MERGED"));
+  Alcotest.check
+    external_state
+    "issue CLOSED -> terminal"
+    R.Terminal
+    (GH.parse_state_response
+       ~kind:Types.Issue
+       {|{"data":{"repository":{"issue":{"state":"CLOSED"}}}}|})
+;;
+
+let test_github_parse_uncertainty_is_unverifiable () =
+  List.iter
+    (fun (label, body) ->
+       Alcotest.check
+         external_state
+         label
+         R.Unverifiable
+         (GH.parse_state_response ~kind:Types.Pr body))
+    [ "null node", {|{"data":{"repository":{"pullRequest":null}}}|}
+    ; "graphql errors", {|{"errors":[{"message":"bad"}]}|}
+    ; "unknown state", pr_state_body "DRAFTED"
+    ; "garbage", "not json"
+    ];
+  Alcotest.check
+    external_state
+    "task refs are not GitHub-verifiable"
+    R.Unverifiable
+    (GH.parse_state_response ~kind:Types.Task (pr_state_body "OPEN"))
+;;
+
+let test_no_token_verify_is_unverifiable () =
+  Alcotest.check
+    external_state
+    "missing token"
+    R.Unverifiable
+    (GH.no_token_verify { Types.kind = Types.Pr; Types.id = "1" })
+;;
+
 let () =
   Alcotest.run
     "rfc0259_reconcile"
@@ -141,5 +206,16 @@ let () =
         ; Alcotest.test_case "ref-time-fallback" `Quick test_no_last_verified_uses_first_seen
         ] )
     ; ("dry_run", [ Alcotest.test_case "aggregates" `Quick test_dry_run_aggregates ])
+    ; ( "github_verify"
+      , [ Alcotest.test_case "parse states" `Quick test_github_parse_states
+        ; Alcotest.test_case
+            "uncertainty is unverifiable"
+            `Quick
+            test_github_parse_uncertainty_is_unverifiable
+        ; Alcotest.test_case
+            "no token is unverifiable"
+            `Quick
+            test_no_token_verify_is_unverifiable
+        ] )
     ]
 ;;


### PR DESCRIPTION
## RFC-0259 P2 — grounding reconciler (dry-run, default-OFF)

RFC: `docs/rfc/RFC-0259-...decay.md` §3.3. Builds on **P1 #21644** (`external_ref`).

### Scope
RFC-0259 Phasing **P2**: reconciler fiber + injected `verify_external`, **default-OFF + dry-run**. It classifies only and performs no fact-store writes. P3 owns retraction/advance under lock.

### Review Response
- This PR is the selected P2 SSOT over #21663: it keeps the cleaner core/IO split and horizon-aware classifier.
- The GitHub verifier no longer shells out to `gh`; `keeper_memory_os_reconcile_gh` now uses `Masc_http_client.post_sync` against GitHub GraphQL with `MASC_GROUNDING_GITHUB_TOKEN`.
- Missing token, missing/invalid repo slug, HTTP/GraphQL errors, malformed responses, non-numeric refs, and `Task` refs all collapse to `Unverifiable`.
- The maintenance fiber no longer depends on `proc_mgr` or ambient `gh` auth. It remains default-OFF via `MASC_KEEPER_MEMORY_OS_RECONCILE`.

### Changes
- **`keeper_memory_os_reconcile.ml/.mli`**: pure core. `external_state` (`Still_open | Terminal | Unverifiable`), injected `verify_fn`, horizon-aware `classify`, and dry-run aggregation.
- **`keeper_memory_os_reconcile_gh.ml/.mli`**: single external-IO surface. GitHub GraphQL via `Masc_http_client`, MASC-managed token, fail-closed parser.
- **`server_bootstrap_maintenance.ml`**: default-OFF reconcile fiber using the managed verifier. No writes.
- **`test_rfc0259_reconcile.ml`**: pure classifier tests plus GraphQL parser and token-missing degradation coverage.

### Verification
- `opam exec -- ocamlformat --check lib/keeper/keeper_memory_os_reconcile_gh.ml lib/keeper/keeper_memory_os_reconcile_gh.mli lib/server/server_bootstrap_maintenance.ml test/test_rfc0259_reconcile.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_rfc0259_reconcile.exe`
- `./_build/default/test/test_rfc0259_reconcile.exe` -> 10 tests pass

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
