### PR TITLE
fix(dashboard): call ringFocusClasses() on fusion surface buttons

### DIFF
--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -104,6 +104,37 @@ describe('FusionSurface', () => {
     expect(container.textContent).toContain('360')
   })
 
+  it('calls ringFocusClasses() for focus rings instead of stringifying the function', () => {
+    boardPosts.value = [
+      boardPost({
+        id: 'post-fus-1',
+        title: 'Fusion deliberation (run fus-1): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-1',
+          question: 'Which deploy path should we take?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Use the canary path.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary first.' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    // Regression guard: a bare `${ringFocusClasses}` interpolation coerces the
+    // function to its source text (which contains the `opts` parameter) into the
+    // class attribute, so the resolved focus-ring utilities are never applied.
+    const refresh = container.querySelector<HTMLButtonElement>('.fus-refresh')
+    expect(refresh).not.toBeNull()
+    expect(refresh?.className).toContain('focus-visible:outline-none')
+    expect(refresh?.className).not.toContain('opts')
+
+    const row = container.querySelector<HTMLButtonElement>('.fus-run-row')
+    expect(row).not.toBeNull()
+    expect(row?.className).toContain('focus-visible:outline-none')
+    expect(row?.className).not.toContain('opts')
+  })
+
   it('supports older nested fusion_deliberation metadata and route selection', () => {
     boardPosts.value = [
       boardPost({

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -273,7 +273,7 @@ function FusionRunRow({ run, active }: { run: FusionRunView; active: boolean }) 
   return html`
     <button
       type="button"
-      class=${`fus-run-row ${active ? 'active' : ''} ${ringFocusClasses}`}
+      class=${`fus-run-row ${active ? 'active' : ''} ${ringFocusClasses()}`}
       aria-current=${active ? 'true' : undefined}
       onClick=${() => replaceRoute('fusion', { run_id: run.runId })}
     >
@@ -310,12 +310,12 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
         <div class="fus-actions">
           <button
             type="button"
-            class=${`fus-action ${ringFocusClasses}`}
+            class=${`fus-action ${ringFocusClasses()}`}
             onClick=${() => navigate('keepers', { keeper: run.keeperName })}
           >Open keeper</button>
           <button
             type="button"
-            class=${`fus-action primary ${ringFocusClasses}`}
+            class=${`fus-action primary ${ringFocusClasses()}`}
             onClick=${() => navigate('board', { post: run.boardPostId })}
           >Open board post</button>
         </div>
@@ -387,7 +387,7 @@ export function FusionSurface() {
           </div>
           <button
             type="button"
-            class=${`fus-refresh ${ringFocusClasses}`}
+            class=${`fus-refresh ${ringFocusClasses()}`}
             onClick=${() => void refreshBoard()}
             disabled=${boardLoading.value}
           >${boardLoading.value ? 'Refreshing...' : 'Refresh'}</button>


### PR DESCRIPTION
## 무엇을

fusion 대시보드 surface(`dashboard/src/components/fusion/fusion-surface.ts`)의 버튼 4곳이 `ringFocusClasses`를 **호출하지 않고**(`${ringFocusClasses}`) 함수 참조만 보간했습니다. `ringFocusClasses`는 `(opts) => string` 함수라, 괄호 없이 template literal에 넣으면 함수 소스 코드가 `class=` 속성에 문자열로 박힙니다. 결과적으로 focus-visible ring 유틸리티 클래스가 적용되지 않고(키보드 포커스 표시 회귀), class 속성이 함수 소스로 오염됩니다.

## 근거

- 버그 4곳: `fusion-surface.ts:276`(fus-run-row), `313`·`318`(fus-action), `390`(fus-refresh).
- 비대칭: 대시보드 전체에서 `ringFocusClasses()` 정상 호출 61곳 vs 괄호 누락 5곳. 그중 4곳이 이 파일이고, 5번째는 회귀를 설명하는 테스트 주석(`chat/primitives.test.ts:1706`)입니다.
- 기존 가드: `chat/primitives.test.ts`가 ChatFusionCard에 대해 정확히 이 회귀(`bare ${ringFocusClasses}` interpolation)를 `.not.toContain('opts')`로 막고 있습니다. #21657이 fusion surface를 새로 만들면서, 이 테스트가 닿지 않는 파일에 동일 회귀를 재도입했습니다.

## 변경

- `fusion-surface.ts`: 4곳 `${ringFocusClasses}` → `${ringFocusClasses()}`.
- `fusion-surface.test.ts`: `.fus-refresh`·`.fus-run-row`의 className이 `focus-visible:outline-none`을 포함하고 `opts`(함수 소스의 파라미터명)를 포함하지 않음을 검증하는 회귀 가드 테스트를 추가했습니다.

## 검증

- 로컬 빌드/테스트는 실행하지 않았습니다(요청에 따름). 수정은 61:5 호출 비대칭과 기존 통과 패턴(`primitives.test.ts`) 미러링으로 grounding했습니다. CI에서 dashboard 테스트로 확인합니다.

## 범위 밖 (후속 분리)

`fusion-surface.ts`는 `board/fusion-evidence.ts`의 fusion board-meta 파서(`parsePanel`/`parseJudge`/`parseFusionEvidence`)와 동일 로직을 `normalizePanel`/`normalizeJudge`로 재구현했습니다. 이 재발명이 이미 한 번 고쳐진 회귀를 되살린 근본 원인입니다. dedupe(기존 파서 재사용)는 surgical scope를 위해 별도 PR로 분리합니다.

배경: #21657 (squash merged) self-review 적대 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
