### PR TITLE
fix(memory-os): RFC-0259 P3 — reconciler demote-not-delete (default-OFF)

### DIFF
--- a/lib/keeper/keeper_memory_os_reconcile.ml
+++ b/lib/keeper/keeper_memory_os_reconcile.ml
@@ -1,7 +1,7 @@
 (** Keeper_memory_os_reconcile — RFC-0259 §3.3/§3.4 grounding reconciler.
 
     The classification core (P2) is pure — the only external IO is the injected
-    {!verify_fn}. The retraction write path (P3, [run_reconcile]) persists the
+    {!verify_fn}. The advance/demote write path (P3, [run_reconcile]) persists the
     result under the per-keeper facts lock. See the .mli for the boundary
     rationale. *)
 
@@ -91,12 +91,12 @@ let dry_run ~now ~horizon ~verify (facts : fact list)
 
 type apply_report =
   { scanned : int
-  ; retracted : int
+  ; terminal_kept : int
   ; advanced : int
   ; kept : int
   }
 
-let empty_apply = { scanned = 0; retracted = 0; advanced = 0; kept = 0 }
+let empty_apply = { scanned = 0; terminal_kept = 0; advanced = 0; kept = 0 }
 
 let reconcile_facts ~now ~horizon ~verify (facts : fact list)
   : fact list * apply_report
@@ -107,15 +107,25 @@ let reconcile_facts ~now ~horizon ~verify (facts : fact list)
         let report = { report with scanned = report.scanned + 1 } in
         match classify ~now ~horizon ~verify f with
         | Stale_terminal ->
-          (* Drop: a merged/closed ref backing an in-progress claim. *)
-          kept, { report with retracted = report.retracted + 1 }
+          (* Demote-not-delete (RFC-0259 §3.4): a now-terminal ref is LEFT IN PLACE
+             for P1's volatile TTL (valid_until = first_seen + ttl) and the GC organ
+             to remove on expiry. Deletion-by-terminal-state was rejected: [classify]
+             reads only the ref's external state, never the claim, so it cannot tell a
+             false "PR #X is open" from a true "PR #X was merged at <sha>" — deleting
+             on state alone erases true historical records (RFC-0259 keeps a still-true
+             claim). The TTL already hides these from recall, so deletion adds no
+             recall benefit, only irreversibility. *)
+          f :: kept, { report with terminal_kept = report.terminal_kept + 1 }
         | Stale_open ->
-          (* Confirmed still live — advance the verification timestamp so it is not
-             re-checked until the next horizon (and survives its volatile TTL). *)
+          (* Confirmed still live — advance the reconciler's re-check anchor
+             ([last_verified_at]) so it is not re-verified until the next horizon.
+             This does NOT touch [valid_until] (first_seen-anchored), so the fact
+             still hard-expires on its volatile TTL; advance only paces the external
+             re-check, it does not make the fact durable. *)
           let f' = { f with last_verified_at = Some now } in
           f' :: kept, { report with advanced = report.advanced + 1 }
         | Fresh | Stale_unknown ->
-          (* Uncertainty (gh failure / Task kind) never deletes; non-volatile and
+          (* Uncertainty (verify failure / Task kind) never deletes; non-volatile and
              in-horizon facts are untouched. *)
           f :: kept, { report with kept = report.kept + 1 })
       ([], empty_apply)
@@ -136,7 +146,9 @@ let run_reconcile ?(dry_run = false) ~keeper_id ~now ~horizon ~verify () : apply
         (Fact_store_corrupt ("memory os reconcile fact store read failed: " ^ message))
     | Ok facts ->
       let survivors, report = reconcile_facts ~now ~horizon ~verify facts in
-      if (not dry_run) && (report.retracted > 0 || report.advanced > 0)
+      (* Only [Stale_open] advances mutate the store; demoted terminal facts are left
+         byte-identical, so a pass that finds no still-open ref writes nothing. *)
+      if (not dry_run) && report.advanced > 0
       then Io.rewrite_facts_atomically ~keeper_id survivors;
       report)
 ;;

--- a/lib/keeper/keeper_memory_os_reconcile.ml
+++ b/lib/keeper/keeper_memory_os_reconcile.ml
@@ -1,9 +1,17 @@
-(** Keeper_memory_os_reconcile — RFC-0259 §3.3 grounding reconciler (P2 core).
+(** Keeper_memory_os_reconcile — RFC-0259 §3.3/§3.4 grounding reconciler.
 
-    See the .mli for the boundary rationale. This module is pure: the only IO (a
-    [gh] call) is the injected {!verify_fn}. *)
+    The classification core (P2) is pure — the only external IO is the injected
+    {!verify_fn}. The retraction write path (P3, [run_reconcile]) persists the
+    result under the per-keeper facts lock. See the .mli for the boundary
+    rationale. *)
 
 open Keeper_memory_os_types
+module Io = Keeper_memory_os_io
+
+(* Raised when the store cannot be fully parsed: preserve over delete — leave a
+   corrupt store untouched and surface the error rather than letting the rewrite
+   erase the rows around one bad line (mirrors GC's Fact_store_corrupt). *)
+exception Fact_store_corrupt of string
 
 type external_state =
   | Still_open
@@ -79,4 +87,56 @@ let dry_run ~now ~horizon ~verify (facts : fact list)
       facts
   in
   report, List.rev rev_items
+;;
+
+type apply_report =
+  { scanned : int
+  ; retracted : int
+  ; advanced : int
+  ; kept : int
+  }
+
+let empty_apply = { scanned = 0; retracted = 0; advanced = 0; kept = 0 }
+
+let reconcile_facts ~now ~horizon ~verify (facts : fact list)
+  : fact list * apply_report
+  =
+  let kept_rev, report =
+    List.fold_left
+      (fun (kept, report) f ->
+        let report = { report with scanned = report.scanned + 1 } in
+        match classify ~now ~horizon ~verify f with
+        | Stale_terminal ->
+          (* Drop: a merged/closed ref backing an in-progress claim. *)
+          kept, { report with retracted = report.retracted + 1 }
+        | Stale_open ->
+          (* Confirmed still live — advance the verification timestamp so it is not
+             re-checked until the next horizon (and survives its volatile TTL). *)
+          let f' = { f with last_verified_at = Some now } in
+          f' :: kept, { report with advanced = report.advanced + 1 }
+        | Fresh | Stale_unknown ->
+          (* Uncertainty (gh failure / Task kind) never deletes; non-volatile and
+             in-horizon facts are untouched. *)
+          f :: kept, { report with kept = report.kept + 1 })
+      ([], empty_apply)
+      facts
+  in
+  List.rev kept_rev, report
+;;
+
+let run_reconcile ?(dry_run = false) ~keeper_id ~now ~horizon ~verify () : apply_report =
+  (* Same per-keeper facts lock as GC/librarian/consolidation: the verify IO runs
+     inside the lock, but it only reads external state (gh) and never touches the
+     store, so unlike the consolidation runtime there is no unlocked read-modify gap
+     to guard with a snapshot CAS — the whole read-classify-rewrite is atomic. *)
+  File_lock_eio.with_lock (Io.facts_path ~keeper_id) (fun () ->
+    match Io.read_facts_all_strict ~keeper_id with
+    | Error message ->
+      raise
+        (Fact_store_corrupt ("memory os reconcile fact store read failed: " ^ message))
+    | Ok facts ->
+      let survivors, report = reconcile_facts ~now ~horizon ~verify facts in
+      if (not dry_run) && (report.retracted > 0 || report.advanced > 0)
+      then Io.rewrite_facts_atomically ~keeper_id survivors;
+      report)
 ;;

--- a/lib/keeper/keeper_memory_os_reconcile.mli
+++ b/lib/keeper/keeper_memory_os_reconcile.mli
@@ -7,7 +7,7 @@
 
     The IO (a [gh] call) is injected as {!verify_fn}, so the classification core is
     pure and fake-testable. P2 only classifies (dry-run, default-OFF fiber); P3
-    turns the verdicts into the actual [last_verified_at] advance / retraction
+    turns the verdicts into the actual [last_verified_at] advance / terminal-demote
     under the facts lock. The boundary is RFC-0259's: deciding *which* claim is
     externally-referenced is deterministic; the external state is the only IO. *)
 
@@ -29,12 +29,13 @@ type external_state =
 type verify_fn = external_ref -> external_state
 
 (** Per-fact reconciliation verdict. P2 classifies only; P3 maps these to the
-    real advance/retract. *)
+    real advance/demote. *)
 type verdict =
   | Fresh (** no [external_ref], or last verified within the horizon — leave alone *)
   | Stale_open (** past horizon, ref still open — P3 advances [last_verified_at] *)
   | Stale_terminal
-      (** past horizon, ref terminal — P3 retracts (the live-store false-fact class) *)
+      (** past horizon, ref terminal — P3 demotes: left for the volatile TTL/GC to
+          remove (deletion-by-state would erase true "was merged" records) *)
   | Stale_unknown
       (** past horizon, ref unverifiable — skip; never delete on uncertainty *)
 
@@ -69,18 +70,21 @@ val dry_run
 (** RFC-0259 §3.4 (P3): the outcome of applying the verdicts to a keeper's facts. *)
 type apply_report =
   { scanned : int
-  ; retracted : int (** [Stale_terminal] facts removed (the false-fact class) *)
+  ; terminal_kept : int
+      (** [Stale_terminal] facts left in place for the volatile TTL/GC to remove
+          (demote-not-delete: never deleted on terminal state alone) *)
   ; advanced : int (** [Stale_open] facts whose [last_verified_at] moved to [now] *)
   ; kept : int (** [Fresh] / [Stale_unknown] facts left unchanged *)
   }
 
-(** RFC-0259 §3.4 (P3): the pure retraction core. Classifies each fact and maps the
+(** RFC-0259 §3.4 (P3): the pure reconcile core. Classifies each fact and maps the
     verdict to a fact-list transform:
-    - [Stale_terminal] -> dropped (the merged/closed-PR false-fact class)
+    - [Stale_terminal] -> kept, left for the volatile TTL/GC to remove (demote, not
+      delete: terminal state alone does not prove the claim false)
     - [Stale_open]     -> kept, [last_verified_at] advanced to [now]
     - [Fresh] / [Stale_unknown] -> kept unchanged (uncertainty never deletes)
-    Order-preserving. Pure: the only IO is the injected [verify]. The [run_reconcile]
-    wrapper persists the result under the facts lock. *)
+    No fact is ever dropped; order-preserving. Pure: the only IO is the injected
+    [verify]. The [run_reconcile] wrapper persists the result under the facts lock. *)
 val reconcile_facts
   :  now:float
   -> horizon:float

--- a/lib/keeper/keeper_memory_os_reconcile.mli
+++ b/lib/keeper/keeper_memory_os_reconcile.mli
@@ -65,3 +65,40 @@ val dry_run
   -> verify:verify_fn
   -> fact list
   -> dry_run_report * (fact * verdict) list
+
+(** RFC-0259 §3.4 (P3): the outcome of applying the verdicts to a keeper's facts. *)
+type apply_report =
+  { scanned : int
+  ; retracted : int (** [Stale_terminal] facts removed (the false-fact class) *)
+  ; advanced : int (** [Stale_open] facts whose [last_verified_at] moved to [now] *)
+  ; kept : int (** [Fresh] / [Stale_unknown] facts left unchanged *)
+  }
+
+(** RFC-0259 §3.4 (P3): the pure retraction core. Classifies each fact and maps the
+    verdict to a fact-list transform:
+    - [Stale_terminal] -> dropped (the merged/closed-PR false-fact class)
+    - [Stale_open]     -> kept, [last_verified_at] advanced to [now]
+    - [Fresh] / [Stale_unknown] -> kept unchanged (uncertainty never deletes)
+    Order-preserving. Pure: the only IO is the injected [verify]. The [run_reconcile]
+    wrapper persists the result under the facts lock. *)
+val reconcile_facts
+  :  now:float
+  -> horizon:float
+  -> verify:verify_fn
+  -> fact list
+  -> fact list * apply_report
+
+(** RFC-0259 §3.4 (P3): apply the reconciler to one keeper's store under the
+    per-keeper facts lock (the lock GC/librarian/consolidation already hold on
+    [facts_path], so no concurrent writer's update is lost). Reads strictly — a
+    corrupt store aborts rather than being partially dropped and overwritten — and
+    rewrites atomically. [dry_run:true] computes the report without writing (the
+    default, mirroring the GC rollout). Must run inside an Eio context. *)
+val run_reconcile
+  :  ?dry_run:bool
+  -> keeper_id:string
+  -> now:float
+  -> horizon:float
+  -> verify:verify_fn
+  -> unit
+  -> apply_report

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -180,18 +180,20 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
         loop ()
       in
       loop ());
-  (* RFC-0259 §3.3: memory-os grounding reconciler (P2, dry-run). Off the keeper
-     hot path — every [interval]s it re-checks each Tier-1 fact that names
-     verifiable external state (a PR/issue id, P1's [external_ref]) against the
-     source of truth through GitHub GraphQL, and logs what it WOULD do: a
-     still-open ref is fresh, a merged/closed ref backing an in-progress claim is
-     stale_terminal (the live-store false-fact class that had keepers acting on a
-     closed PR for ~30 turns). P2 only classifies; P3 turns stale_terminal into
-     retraction and stale_open into a last_verified_at advance, under the facts
-     lock. Default OFF + dry-run (mirrors the GC/consolidation rollout): the log
-     is reviewed before any write path is enabled. [Unverifiable] (GitHub
-     failure / missing token / non-PR kind) is never acted on — uncertainty is
-     not contradiction. Skipped entirely when no alert repo is configured. *)
+  (* RFC-0259 §3.3/§3.4: memory-os grounding reconciler. Off the keeper hot path —
+     every [interval]s it re-checks each Tier-1 fact that names verifiable external
+     state (a PR/issue id, P1's [external_ref]) against the source of truth through
+     GitHub GraphQL: a still-open ref has its [last_verified_at] advanced; a
+     merged/closed ref backing an in-progress claim is retracted (the live-store
+     false-fact class that had keepers acting on a closed PR for ~30 turns);
+     [Unverifiable] (GitHub failure / missing token / non-GitHub kind) is never acted
+     on — uncertainty is not contradiction. The write happens under the per-keeper
+     facts lock ({!Keeper_memory_os_reconcile.run_reconcile}).
+
+     Two gates (mirrors the GC rollout): RECONCILE turns the fiber on; APPLY flips it
+     from dry-run (log what it WOULD do, default) to actually rewriting. An operator
+     reviews the dry-run log before enabling APPLY. Skipped entirely when no alert
+     repo is configured. *)
   if
     Keeper_memory_bank_env.memory_env_bool_logged
       "MASC_KEEPER_MEMORY_OS_RECONCILE"
@@ -199,6 +201,11 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     && String.trim Env_config.KeeperAlert.github_repo <> ""
   then (
      let repo = String.trim Env_config.KeeperAlert.github_repo in
+     let apply =
+       Keeper_memory_bank_env.memory_env_bool_logged
+         "MASC_KEEPER_MEMORY_OS_RECONCILE_APPLY"
+         ~default:false
+     in
      fork_logged_fiber
        ~sw
        ~on_error:(log_server_fiber_crash "memory_os_reconcile")
@@ -222,29 +229,32 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
               Unverifiable";
            Keeper_memory_os_reconcile_gh.no_token_verify
        in
+       let mode = if apply then "apply" else "dry-run" in
        let rec loop () =
          List.iter
            (fun keeper_id ->
               try
-                let facts = Keeper_memory_os_io.read_facts_all ~keeper_id in
-                let report, _items =
-                  Keeper_memory_os_reconcile.dry_run
+                let report =
+                  Keeper_memory_os_reconcile.run_reconcile
+                    ~dry_run:(not apply)
+                    ~keeper_id
                     ~now:(Time_compat.now ())
                     ~horizon
                     ~verify
-                    facts
+                    ()
                 in
-                if report.Keeper_memory_os_reconcile.stale_terminal > 0
-                   || report.stale_open > 0
+                if report.Keeper_memory_os_reconcile.retracted > 0
+                   || report.advanced > 0
                 then
                   Log.Server.info
-                    "memory_os_reconcile[dry-run]: keeper=%s scanned=%d \
-                     stale_open=%d stale_terminal=%d stale_unknown=%d"
+                    "memory_os_reconcile[%s]: keeper=%s scanned=%d retracted=%d \
+                     advanced=%d kept=%d"
+                    mode
                     keeper_id
                     report.scanned
-                    report.stale_open
-                    report.stale_terminal
-                    report.stale_unknown
+                    report.retracted
+                    report.advanced
+                    report.kept
               with
               | Eio.Cancel.Cancelled _ as e -> raise e
               | exn ->

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -184,8 +184,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      every [interval]s it re-checks each Tier-1 fact that names verifiable external
      state (a PR/issue id, P1's [external_ref]) against the source of truth through
      GitHub GraphQL: a still-open ref has its [last_verified_at] advanced; a
-     merged/closed ref backing an in-progress claim is retracted (the live-store
-     false-fact class that had keepers acting on a closed PR for ~30 turns);
+     merged/closed ref is demoted — left in place for P1's volatile TTL/GC to remove
+     rather than deleted, since terminal state alone does not prove the claim false
+     (a true "PR #X was merged at <sha>" reads terminal too);
      [Unverifiable] (GitHub failure / missing token / non-GitHub kind) is never acted
      on — uncertainty is not contradiction. The write happens under the per-keeper
      facts lock ({!Keeper_memory_os_reconcile.run_reconcile}).
@@ -243,16 +244,16 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                     ~verify
                     ()
                 in
-                if report.Keeper_memory_os_reconcile.retracted > 0
+                if report.Keeper_memory_os_reconcile.terminal_kept > 0
                    || report.advanced > 0
                 then
                   Log.Server.info
-                    "memory_os_reconcile[%s]: keeper=%s scanned=%d retracted=%d \
+                    "memory_os_reconcile[%s]: keeper=%s scanned=%d terminal_kept=%d \
                      advanced=%d kept=%d"
                     mode
                     keeper_id
                     report.scanned
-                    report.retracted
+                    report.terminal_kept
                     report.advanced
                     report.kept
               with

--- a/test/test_rfc0259_reconcile.ml
+++ b/test/test_rfc0259_reconcile.ml
@@ -1,7 +1,9 @@
-(** RFC-0259 P2 — grounding reconciler core (pure classify / dry_run).
+(** RFC-0259 P2/P3 — grounding reconciler core (pure classify / dry_run /
+    reconcile_facts).
 
     Drives the classifier with a fake [verify_fn] so Confirmed/Contradicted/Unknown
-    paths are deterministic. Pins:
+    paths are deterministic. P2 pins classification; P3 pins the retraction
+    transform (terminal->drop, open->advance, unknown/fresh->keep). Pins:
     - no external_ref           -> Fresh (never grounded)
     - referenced but in-horizon -> Fresh (not re-checked yet)
     - past horizon, open        -> Stale_open
@@ -194,6 +196,81 @@ let test_no_token_verify_is_unverifiable () =
     (GH.no_token_verify { Types.kind = Types.Pr; Types.id = "1" })
 ;;
 
+(* ---------- P3: reconcile_facts (pure retraction core) ---------- *)
+
+let test_reconcile_retracts_terminal () =
+  (* a merged/closed PR backing an in-progress claim is dropped *)
+  let facts =
+    [ fact ~external_ref:(pr "21515") ~first_seen:(now -. 100_000.0) "PR #21515 blocked, needs fix"
+    ; fact ~first_seen:(now -. 100_000.0) "deployment uses blue-green"
+    ]
+  in
+  let survivors, report =
+    R.reconcile_facts ~now ~horizon ~verify:(verify_const R.Terminal) facts
+  in
+  Alcotest.(check int) "scanned" 2 report.R.scanned;
+  Alcotest.(check int) "retracted" 1 report.R.retracted;
+  Alcotest.(check int) "advanced" 0 report.R.advanced;
+  Alcotest.(check int) "kept" 1 report.R.kept;
+  (* the durable non-ref claim survives; the terminal ref is gone *)
+  Alcotest.(check (list string))
+    "only durable survives"
+    [ "deployment uses blue-green" ]
+    (List.map (fun f -> f.Types.claim) survivors)
+;;
+
+let test_reconcile_advances_open () =
+  (* a still-open ref is kept, last_verified_at advanced to now *)
+  let f =
+    fact ~external_ref:(pr "2") ~first_seen:(now -. 100_000.0) "PR #2 in review"
+  in
+  let survivors, report =
+    R.reconcile_facts ~now ~horizon ~verify:(verify_const R.Still_open) [ f ]
+  in
+  Alcotest.(check int) "advanced" 1 report.R.advanced;
+  Alcotest.(check int) "retracted" 0 report.R.retracted;
+  (match survivors with
+   | [ s ] ->
+     Alcotest.(check (option (float 0.001)))
+       "last_verified advanced to now"
+       (Some now)
+       s.Types.last_verified_at
+   | _ -> Alcotest.fail "expected exactly one survivor")
+;;
+
+let test_reconcile_keeps_unknown_and_fresh () =
+  (* uncertainty never deletes; in-horizon and non-ref are untouched *)
+  let facts =
+    [ fact ~external_ref:(pr "3") ~first_seen:(now -. 100_000.0) "PR #3 unknown state"
+    ; fact ~external_ref:(pr "4") ~last_verified_at:(now -. 5.0) ~first_seen:(now -. 5.0) "PR #4 recent"
+    ; fact ~first_seen:(now -. 100_000.0) "user prefers concise"
+    ]
+  in
+  let survivors, report =
+    R.reconcile_facts ~now ~horizon ~verify:(verify_const R.Unverifiable) facts
+  in
+  Alcotest.(check int) "nothing retracted" 0 report.R.retracted;
+  Alcotest.(check int) "nothing advanced" 0 report.R.advanced;
+  Alcotest.(check int) "all kept" 3 report.R.kept;
+  Alcotest.(check int) "all survive" 3 (List.length survivors)
+;;
+
+let test_reconcile_order_preserved () =
+  (* survivors keep input order after a middle retraction *)
+  let facts =
+    [ fact ~first_seen:(now -. 100_000.0) "A durable"
+    ; fact ~external_ref:(pr "21515") ~first_seen:(now -. 100_000.0) "B terminal ref"
+    ; fact ~first_seen:(now -. 100_000.0) "C durable"
+    ]
+  in
+  let survivors, _ =
+    R.reconcile_facts ~now ~horizon ~verify:(verify_const R.Terminal) facts
+  in
+  Alcotest.(check (list string))
+    "order preserved minus retracted"
+    [ "A durable"; "C durable" ]
+    (List.map (fun f -> f.Types.claim) survivors)
+;;
 let () =
   Alcotest.run
     "rfc0259_reconcile"
@@ -216,6 +293,12 @@ let () =
             "no token is unverifiable"
             `Quick
             test_no_token_verify_is_unverifiable
+        ] )
+    ; ( "reconcile_facts"
+      , [ Alcotest.test_case "retract-terminal" `Quick test_reconcile_retracts_terminal
+        ; Alcotest.test_case "advance-open" `Quick test_reconcile_advances_open
+        ; Alcotest.test_case "keep-unknown-fresh" `Quick test_reconcile_keeps_unknown_and_fresh
+        ; Alcotest.test_case "order-preserved" `Quick test_reconcile_order_preserved
         ] )
     ]
 ;;

--- a/test/test_rfc0259_reconcile.ml
+++ b/test/test_rfc0259_reconcile.ml
@@ -2,8 +2,8 @@
     reconcile_facts).
 
     Drives the classifier with a fake [verify_fn] so Confirmed/Contradicted/Unknown
-    paths are deterministic. P2 pins classification; P3 pins the retraction
-    transform (terminal->drop, open->advance, unknown/fresh->keep). Pins:
+    paths are deterministic. P2 pins classification; P3 pins the demote/advance
+    transform (terminal->keep for TTL, open->advance, unknown/fresh->keep). Pins:
     - no external_ref           -> Fresh (never grounded)
     - referenced but in-horizon -> Fresh (not re-checked yet)
     - past horizon, open        -> Stale_open
@@ -196,10 +196,12 @@ let test_no_token_verify_is_unverifiable () =
     (GH.no_token_verify { Types.kind = Types.Pr; Types.id = "1" })
 ;;
 
-(* ---------- P3: reconcile_facts (pure retraction core) ---------- *)
+(* ---------- P3: reconcile_facts (pure demote/advance core) ---------- *)
 
-let test_reconcile_retracts_terminal () =
-  (* a merged/closed PR backing an in-progress claim is dropped *)
+let test_reconcile_demotes_terminal () =
+  (* demote-not-delete: a merged/closed ref is LEFT IN PLACE for the volatile
+     TTL/GC to remove, never deleted on terminal state alone (terminal state does
+     not prove the claim false — a true "PR #X was merged" reads terminal too) *)
   let facts =
     [ fact ~external_ref:(pr "21515") ~first_seen:(now -. 100_000.0) "PR #21515 blocked, needs fix"
     ; fact ~first_seen:(now -. 100_000.0) "deployment uses blue-green"
@@ -209,13 +211,13 @@ let test_reconcile_retracts_terminal () =
     R.reconcile_facts ~now ~horizon ~verify:(verify_const R.Terminal) facts
   in
   Alcotest.(check int) "scanned" 2 report.R.scanned;
-  Alcotest.(check int) "retracted" 1 report.R.retracted;
+  Alcotest.(check int) "terminal_kept" 1 report.R.terminal_kept;
   Alcotest.(check int) "advanced" 0 report.R.advanced;
   Alcotest.(check int) "kept" 1 report.R.kept;
-  (* the durable non-ref claim survives; the terminal ref is gone *)
+  (* nothing is deleted: both the terminal ref and the durable claim survive, in order *)
   Alcotest.(check (list string))
-    "only durable survives"
-    [ "deployment uses blue-green" ]
+    "no fact dropped"
+    [ "PR #21515 blocked, needs fix"; "deployment uses blue-green" ]
     (List.map (fun f -> f.Types.claim) survivors)
 ;;
 
@@ -228,7 +230,7 @@ let test_reconcile_advances_open () =
     R.reconcile_facts ~now ~horizon ~verify:(verify_const R.Still_open) [ f ]
   in
   Alcotest.(check int) "advanced" 1 report.R.advanced;
-  Alcotest.(check int) "retracted" 0 report.R.retracted;
+  Alcotest.(check int) "nothing demoted" 0 report.R.terminal_kept;
   (match survivors with
    | [ s ] ->
      Alcotest.(check (option (float 0.001)))
@@ -249,14 +251,15 @@ let test_reconcile_keeps_unknown_and_fresh () =
   let survivors, report =
     R.reconcile_facts ~now ~horizon ~verify:(verify_const R.Unverifiable) facts
   in
-  Alcotest.(check int) "nothing retracted" 0 report.R.retracted;
+  Alcotest.(check int) "nothing demoted" 0 report.R.terminal_kept;
   Alcotest.(check int) "nothing advanced" 0 report.R.advanced;
   Alcotest.(check int) "all kept" 3 report.R.kept;
   Alcotest.(check int) "all survive" 3 (List.length survivors)
 ;;
 
 let test_reconcile_order_preserved () =
-  (* survivors keep input order after a middle retraction *)
+  (* demote-not-delete keeps every fact, in input order — including the middle
+     terminal ref *)
   let facts =
     [ fact ~first_seen:(now -. 100_000.0) "A durable"
     ; fact ~external_ref:(pr "21515") ~first_seen:(now -. 100_000.0) "B terminal ref"
@@ -267,8 +270,8 @@ let test_reconcile_order_preserved () =
     R.reconcile_facts ~now ~horizon ~verify:(verify_const R.Terminal) facts
   in
   Alcotest.(check (list string))
-    "order preserved minus retracted"
-    [ "A durable"; "C durable" ]
+    "order preserved, nothing dropped"
+    [ "A durable"; "B terminal ref"; "C durable" ]
     (List.map (fun f -> f.Types.claim) survivors)
 ;;
 let () =
@@ -295,7 +298,7 @@ let () =
             test_no_token_verify_is_unverifiable
         ] )
     ; ( "reconcile_facts"
-      , [ Alcotest.test_case "retract-terminal" `Quick test_reconcile_retracts_terminal
+      , [ Alcotest.test_case "demote-terminal" `Quick test_reconcile_demotes_terminal
         ; Alcotest.test_case "advance-open" `Quick test_reconcile_advances_open
         ; Alcotest.test_case "keep-unknown-fresh" `Quick test_reconcile_keeps_unknown_and_fresh
         ; Alcotest.test_case "order-preserved" `Quick test_reconcile_order_preserved


### PR DESCRIPTION
## RFC-0259 P3 — reconciler demote-not-delete (default-OFF)

RFC: `docs/rfc/RFC-0259-...decay.md` §3.4. **base = `main`** (P2 #21665 머지로 재타겟 완료).

### 방향 전환: retract → demote-not-delete

이 PR은 원래 `Stale_terminal` fact를 **삭제(retract)**했다. 라이브 dry-run + 적대 리뷰 후 **demote-not-delete**로 바꿨다.

**근거 (dry-run, 유효 토큰 184콜):** horizon 초과 휘발 fact **184개 전부가 terminal**(0 still-open). 그런데 `classify`는 ref의 GitHub state만 읽고 **claim 텍스트는 안 읽는다** — 그래서 거짓 `"PR #X is open"`과 *참인* `"PR #X was merged at <sha>"`를 구분 못 한다. 삭제셋에 검증된 참 기록이 실재했다(예: `#21418 squash-merged at 0c90fa8efb`, `gh`로 확인). terminal-state 단독 삭제는 RFC-0259 자체 속성("a still-true claim is preserved")을 위반하고 참 기록을 비가역·무감사 삭제한다.

**왜 demote로 충분한가:** P1의 휘발 TTL(`valid_until = first_seen + ttl`) + 기존 GC가 **이미** 이 fact들을 recall·디스크에서 제거한다(184개 모두 `valid_until < now`). 따라서 destructive 삭제는 recall 이득 0, 비가역성만 추가. terminal fact를 그냥 두고 TTL/GC에 맡기는 게 더 안전하고 RFC 속성과 정합한다.

### 변경
- **`keeper_memory_os_reconcile.reconcile_facts`** (순수 transform):
  - `Stale_terminal` → **유지**(demote): TTL/GC가 `valid_until` 만료 시 제거. 삭제 안 함.
  - `Stale_open` → 유지 + `last_verified_at = now`(advance). **`valid_until` 불변**(first_seen 앵커)이라 fact는 여전히 TTL에 만료 — advance는 재검사 주기만 늦춤, 불멸화 아님.
  - `Fresh`/`Stale_unknown` → 그대로.
  - **아무 fact도 삭제 안 함**, 순서 보존, IO 없음(fake로 테스트).
- **`apply_report.retracted` → `terminal_kept`**: TTL에 맡긴 terminal fact 수(관측용). 삭제 카운트 아님.
- **`run_reconcile`**: `File_lock_eio.with_lock(facts_path)` → `read_facts_all_strict`(corrupt abort) → `reconcile_facts` → **`advanced > 0`일 때만** `rewrite_facts_atomically`(demote는 byte-identical이라 write 불필요).
- **`server_bootstrap_maintenance`**: reconcile fiber 2단계 게이트 유지(`MASC_KEEPER_MEMORY_OS_RECONCILE` + `_APPLY`). 로그 `retracted=%d` → `terminal_kept=%d`.
- **`test_rfc0259_reconcile`**: demote 동작으로 갱신(terminal·중간 ref 모두 보존, 순서 유지).

### 경계 / 안전
- **APPLY default-OFF**: 머지가 라이브 데이터를 mutate하지 않음. demote 채택 후엔 APPLY를 켜도 advance write만(삭제 0).
- verify IO는 in-process GitHub **GraphQL**(`Masc_http_client`), 모든 실패 경로 → `Unverifiable` → 무행동(uncertainty ≠ contradiction).
- `Eio.Cancel.Cancelled` re-raise, corrupt store abort(preserve-over-delete).
- **불멸화 회귀 없음**: advance는 `last_verified_at`만, `valid_until` 미변경(types.ml:455-462 first_seen 앵커 확인).

### 검증
- reconcile 스위트 **14/14**(classify 6 + dry_run 1 + github_verify 3 + reconcile_facts 4), `dune build` green.
- fmt: 내 `.ml`/`.mli` clean(무관 dune-file 드리프트는 미변경).

### 워크어라운드 게이트
해당 없음. 파괴적·content-blind 동작을 **제거**하고 기존 typed TTL 메커니즘에 위임 — telemetry-as-fix/cap/dedup/string-classifier 어디에도 해당 안 됨(오히려 그 반대). 점수 미도입(typed verdict만).

### 후속
`supersedes`(librarian LLM judgment 절반)는 별도 PR. demote 채택으로 audit-ledger(option c, `codex/rfc0259-p3-audit-ledger`)는 불필요해짐(삭제가 없으니 복구 대상 없음).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
