### PR TITLE
Implement scheduled automation recurrence dispatch

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1742,12 +1742,35 @@ export interface DashboardScheduledAutomationFsm {
   next_due_at?: string | null
 }
 
+export interface DashboardScheduledAutomationExecution {
+  execution_id: string
+  schedule_id: string
+  started_at?: number
+  started_at_iso?: string | null
+  finished_at?: number | null
+  finished_at_iso?: string | null
+  due_at?: number
+  payload_digest?: string
+  status: string
+  detail?: unknown | null
+  error?: string | null
+}
+
 export interface DashboardScheduledAutomationRequest {
   schedule_id: string
   status: string
   risk_class: string
   approval_required: boolean
   source: string
+  recurrence?: {
+    kind: string
+    interval_sec?: number
+    hour?: number
+    minute?: number
+    second?: number
+    timezone?: string
+  }
+  recurrence_kind?: string
   requested_at?: number
   requested_at_iso?: string
   due_at?: number
@@ -1756,6 +1779,7 @@ export interface DashboardScheduledAutomationRequest {
   expires_at_iso?: string | null
   payload_digest?: string
   payload_kind?: string | null
+  last_execution?: DashboardScheduledAutomationExecution | null
 }
 
 export interface DashboardScheduledAutomation {

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -41,6 +41,35 @@ function CountChip({ name, count }: { name: string; count: number }) {
   `
 }
 
+function recurrenceLabel(request: DashboardScheduledAutomationRequest): string {
+  const recurrence = request.recurrence
+  const kind = recurrence?.kind ?? request.recurrence_kind ?? 'one_shot'
+  if (kind === 'interval' && typeof recurrence?.interval_sec === 'number') {
+    return `every ${recurrence.interval_sec}s`
+  }
+  if (kind === 'daily') {
+    const hour = recurrence?.hour
+    const minute = recurrence?.minute
+    const second = recurrence?.second ?? 0
+    const timezone = recurrence?.timezone
+    if (typeof hour === 'number' && typeof minute === 'number') {
+      const hh = String(hour).padStart(2, '0')
+      const mm = String(minute).padStart(2, '0')
+      const ss = String(second).padStart(2, '0')
+      return `${hh}:${mm}:${ss}${timezone ? ` ${timezone}` : ''}`
+    }
+  }
+  return enumLabel(kind)
+}
+
+function lastExecutionLabel(request: DashboardScheduledAutomationRequest): string {
+  const execution = request.last_execution
+  if (!execution) return '-'
+  const status = enumLabel(execution.status)
+  const finishedAt = formatDateTimeKo(execution.finished_at_iso ?? execution.started_at_iso ?? null)
+  return finishedAt === '-' ? status : `${status} ${finishedAt}`
+}
+
 function ScheduleRow({ request }: { request: DashboardScheduledAutomationRequest }) {
   return html`
     <tr class="v2-lab-row border-t border-[var(--color-border-default)]">
@@ -50,6 +79,8 @@ function ScheduleRow({ request }: { request: DashboardScheduledAutomationRequest
       </td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${enumLabel(request.risk_class)}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${request.payload_kind ?? '-'}</td>
+      <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${recurrenceLabel(request)}</td>
+      <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${lastExecutionLabel(request)}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${formatDateTimeKo(request.due_at_iso ?? null)}</td>
       <td class="py-2 text-xs text-[var(--color-fg-muted)]">${request.approval_required ? 'required' : 'not required'}</td>
     </tr>
@@ -114,6 +145,8 @@ export function ScheduledAutomationPanel({
                     <th class="pb-2 pr-3 font-medium">status</th>
                     <th class="pb-2 pr-3 font-medium">risk</th>
                     <th class="pb-2 pr-3 font-medium">payload</th>
+                    <th class="pb-2 pr-3 font-medium">recurrence</th>
+                    <th class="pb-2 pr-3 font-medium">last run</th>
                     <th class="pb-2 pr-3 font-medium">due</th>
                     <th class="pb-2 font-medium">approval</th>
                   </tr>

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -129,8 +129,17 @@ describe('Tools', () => {
             risk_class: 'workspace_write',
             approval_required: true,
             source: 'operator_request',
+            recurrence: { kind: 'daily', hour: 9, minute: 30, second: 0, timezone: 'Asia/Seoul' },
+            recurrence_kind: 'daily',
             payload_kind: 'test.reminder',
             due_at_iso: '2026-06-13T01:00:00Z',
+            last_execution: {
+              execution_id: 'exec-1',
+              schedule_id: 'sched-1',
+              started_at_iso: '2026-06-13T00:30:00Z',
+              finished_at_iso: '2026-06-13T00:30:01Z',
+              status: 'succeeded',
+            },
           },
         ],
       },
@@ -142,6 +151,8 @@ describe('Tools', () => {
     expect(container.textContent).toContain('pending approval')
     expect(container.textContent).toContain('sched-1')
     expect(container.textContent).toContain('workspace write')
+    expect(container.textContent).toContain('09:30:00 Asia/Seoul')
+    expect(container.textContent).toContain('succeeded')
     expect(container.textContent).toContain('test.reminder')
     expect(container.querySelector('.v2-lab-table')).not.toBeNull()
     expect(container.querySelector('.v2-lab-row')).not.toBeNull()

--- a/lib/schedule/dune
+++ b/lib/schedule/dune
@@ -1,7 +1,8 @@
 (include_subdirs no)
 
-;; Scheduled internal automation domain + service/store/runner. The runner only
-;; emits generic schedule signals; consumer dispatch stays outside this layer.
+;; Scheduled internal automation domain + service/store/runner. The runner emits
+;; generic schedule signals and can call a consumer supplied by the server layer;
+;; consumer-specific behavior stays outside this library.
 
 (library
  (name masc_schedule)

--- a/lib/schedule/schedule_domain.ml
+++ b/lib/schedule/schedule_domain.ml
@@ -46,6 +46,16 @@ type schedule_source =
   | Automated_request
   | System_request
 
+type recurrence =
+  | One_shot
+  | Interval of { interval_sec : int }
+  | Daily of
+      { hour : int
+      ; minute : int
+      ; second : int
+      ; timezone : string
+      }
+
 type payload =
   { kind : string
   ; schema_version : int
@@ -64,6 +74,7 @@ type schedule_request =
   ; approval_required : bool
   ; status : schedule_status
   ; source : schedule_source
+  ; recurrence : recurrence
   }
 
 type execution_decision =
@@ -84,6 +95,23 @@ type execution_grant =
   ; approved_at : float
   ; decision : execution_decision
   ; evidence : execution_evidence
+  }
+
+type execution_status =
+  | Execution_running
+  | Execution_succeeded
+  | Execution_failed
+
+type execution_record =
+  { execution_id : string
+  ; schedule_id : string
+  ; started_at : float
+  ; finished_at : float option
+  ; due_at : float
+  ; payload_digest : string
+  ; status : execution_status
+  ; detail : Yojson.Safe.t option
+  ; error : string option
   }
 
 type grant_error =
@@ -174,6 +202,25 @@ let schedule_source_of_string = function
   | other -> Error ("unknown schedule_source: " ^ other)
 ;;
 
+let recurrence_kind_to_string = function
+  | One_shot -> "one_shot"
+  | Interval _ -> "interval"
+  | Daily _ -> "daily"
+;;
+
+let execution_status_to_string = function
+  | Execution_running -> "running"
+  | Execution_succeeded -> "succeeded"
+  | Execution_failed -> "failed"
+;;
+
+let execution_status_of_string = function
+  | "running" -> Ok Execution_running
+  | "succeeded" -> Ok Execution_succeeded
+  | "failed" -> Ok Execution_failed
+  | other -> Error ("unknown execution_status: " ^ other)
+;;
+
 let grant_error_to_string = function
   | Grant_schedule_id_mismatch -> "grant schedule_id does not match request"
   | Approver_not_human -> "approver must be a human operator"
@@ -199,6 +246,11 @@ let is_side_effecting = function
 
 let requires_separate_human_grant request =
   request.approval_required || is_side_effecting request.risk_class
+;;
+
+let is_recurring = function
+  | One_shot -> false
+  | Interval _ | Daily _ -> true
 ;;
 
 let rec canonical_json = function
@@ -279,6 +331,108 @@ let bool_field name fields =
   | Error err -> Error (name ^ ": " ^ err)
 ;;
 
+let validate_interval interval_sec =
+  if interval_sec <= 0 then Error "recurrence.interval_sec must be positive"
+  else Ok interval_sec
+;;
+
+let timezone_offset_seconds timezone =
+  let parse_fixed_offset raw =
+    let len = String.length raw in
+    if len <> 6 || raw.[3] <> ':' then
+      None
+    else (
+      let sign =
+        match raw.[0] with
+        | '+' -> Some 1
+        | '-' -> Some (-1)
+        | _ -> None
+      in
+      match sign with
+      | None -> None
+      | Some sign ->
+        let int_sub start len =
+          try Some (int_of_string (String.sub raw start len)) with
+          | Failure _ -> None
+        in
+        match int_sub 1 2, int_sub 4 2 with
+        | Some hour, Some minute when hour <= 23 && minute <= 59 ->
+          Some (sign * ((hour * 3600) + (minute * 60)))
+        | _ -> None)
+  in
+  match String.trim timezone with
+  | "UTC" | "Etc/UTC" | "Z" -> Some 0
+  | "Asia/Seoul" | "KST" -> Some (9 * 3600)
+  | raw ->
+    if String.length raw > 3 && String.sub raw 0 3 = "UTC" then
+      parse_fixed_offset (String.sub raw 3 (String.length raw - 3))
+    else
+      parse_fixed_offset raw
+;;
+
+let validate_daily ~hour ~minute ~second ~timezone =
+  let* timezone = nonempty "recurrence.timezone" timezone in
+  if hour < 0 || hour > 23 then Error "recurrence.hour must be in 0..23"
+  else if minute < 0 || minute > 59 then
+    Error "recurrence.minute must be in 0..59"
+  else if second < 0 || second > 59 then
+    Error "recurrence.second must be in 0..59"
+  else (
+    match timezone_offset_seconds timezone with
+    | Some _ -> Ok (Daily { hour; minute; second; timezone })
+    | None ->
+      Error
+        "recurrence.timezone must be UTC, Asia/Seoul, KST, or a fixed offset like +09:00")
+;;
+
+let validate_recurrence = function
+  | One_shot -> Ok One_shot
+  | Interval { interval_sec } ->
+    let* interval_sec = validate_interval interval_sec in
+    Ok (Interval { interval_sec })
+  | Daily { hour; minute; second; timezone } ->
+    validate_daily ~hour ~minute ~second ~timezone
+;;
+
+let recurrence_to_yojson = function
+  | One_shot -> `Assoc [ "kind", `String "one_shot" ]
+  | Interval { interval_sec } ->
+    `Assoc [ "kind", `String "interval"; "interval_sec", `Int interval_sec ]
+  | Daily { hour; minute; second; timezone } ->
+    `Assoc
+      [ "kind", `String "daily"
+      ; "hour", `Int hour
+      ; "minute", `Int minute
+      ; "second", `Int second
+      ; "timezone", `String timezone
+      ]
+;;
+
+let recurrence_of_yojson = function
+  | `Assoc fields ->
+    let* kind = string_field "kind" fields in
+    (match kind with
+     | "one_shot" -> Ok One_shot
+     | "interval" ->
+       let* interval_sec = int_field "interval_sec" fields in
+       validate_recurrence (Interval { interval_sec })
+     | "daily" ->
+       let* hour = int_field "hour" fields in
+       let* minute = int_field "minute" fields in
+       let* second =
+         match List.assoc_opt "second" fields with
+         | None -> Ok 0
+         | Some value ->
+           (match int_of_yojson value with
+            | Ok value -> Ok value
+            | Error err -> Error ("second: " ^ err))
+       in
+       let* timezone = string_field "timezone" fields in
+       validate_recurrence (Daily { hour; minute; second; timezone })
+     | other -> Error ("unknown recurrence kind: " ^ other))
+  | _ -> Error "expected recurrence object"
+;;
+
 let actor_to_yojson (actor : actor) =
   `Assoc
     [ "id", `String actor.id
@@ -331,6 +485,54 @@ let evidence_of_request (request : schedule_request) =
   ; due_at = request.due_at
   ; risk_class = request.risk_class
   }
+;;
+
+let seconds_per_day = 86400.0
+
+let next_periodic_due_after ~period ~now ~anchor =
+  if period <= 0.0 then
+    None
+  else if anchor > now then
+    Some anchor
+  else
+    let missed = floor ((now -. anchor) /. period) +. 1.0 in
+    Some (anchor +. (missed *. period))
+;;
+
+let next_daily_due_after ~hour ~minute ~second ~timezone ~now =
+  match timezone_offset_seconds timezone with
+  | None -> None
+  | Some offset ->
+    let local_now = now +. float_of_int offset in
+    let day_start = floor (local_now /. seconds_per_day) *. seconds_per_day in
+    let target_second =
+      float_of_int ((hour * 3600) + (minute * 60) + second)
+    in
+    let target_utc = day_start +. target_second -. float_of_int offset in
+    if target_utc > now then Some target_utc else Some (target_utc +. seconds_per_day)
+;;
+
+let next_due_after ~now (request : schedule_request) =
+  match request.recurrence with
+  | One_shot -> None
+  | Interval { interval_sec } ->
+    next_periodic_due_after
+      ~period:(float_of_int interval_sec)
+      ~now
+      ~anchor:request.due_at
+  | Daily { hour; minute; second; timezone } ->
+    next_daily_due_after ~hour ~minute ~second ~timezone ~now
+;;
+
+let reschedule_after_due_signal ~now (request : schedule_request) =
+  match request.status with
+  | Due ->
+    (match next_due_after ~now request with
+     | None -> None
+     | Some due_at -> Some { request with status = Scheduled; due_at })
+  | Pending_approval | Scheduled | Running | Succeeded | Failed | Rejected | Cancelled
+  | Expired ->
+    None
 ;;
 
 let execution_decision_to_yojson = function
@@ -396,6 +598,60 @@ let execution_grant_of_yojson = function
   | _ -> Error "expected execution_grant object"
 ;;
 
+let execution_record_to_yojson (execution : execution_record) =
+  `Assoc
+    [ "execution_id", `String execution.execution_id
+    ; "schedule_id", `String execution.schedule_id
+    ; "started_at", float_to_yojson execution.started_at
+    ; "finished_at", option_to_yojson float_to_yojson execution.finished_at
+    ; "due_at", float_to_yojson execution.due_at
+    ; "payload_digest", `String execution.payload_digest
+    ; "status", `String (execution_status_to_string execution.status)
+    ; "detail", option_to_yojson (fun value -> value) execution.detail
+    ; "error", option_to_yojson (fun value -> `String value) execution.error
+    ]
+;;
+
+let execution_record_of_yojson = function
+  | `Assoc fields ->
+    let* execution_id = string_field "execution_id" fields in
+    let* schedule_id = string_field "schedule_id" fields in
+    let* started_at = float_field "started_at" fields in
+    let* finished_at =
+      match List.assoc_opt "finished_at" fields with
+      | None | Some `Null -> Ok None
+      | Some value ->
+        let* value = float_of_yojson value in
+        Ok (Some value)
+    in
+    let* due_at = float_field "due_at" fields in
+    let* payload_digest = string_field "payload_digest" fields in
+    let* status_name = string_field "status" fields in
+    let* status = execution_status_of_string status_name in
+    let detail =
+      match List.assoc_opt "detail" fields with
+      | None | Some `Null -> None
+      | Some value -> Some value
+    in
+    let* error =
+      match List.assoc_opt "error" fields with
+      | None -> Ok None
+      | Some value -> string_option_of_yojson value
+    in
+    Ok
+      { execution_id
+      ; schedule_id
+      ; started_at
+      ; finished_at
+      ; due_at
+      ; payload_digest
+      ; status
+      ; detail
+      ; error
+      }
+  | _ -> Error "expected execution_record object"
+;;
+
 let schedule_request_to_yojson (request : schedule_request) =
   `Assoc
     [ "schedule_id", `String request.schedule_id
@@ -409,6 +665,7 @@ let schedule_request_to_yojson (request : schedule_request) =
     ; "approval_required", `Bool request.approval_required
     ; "status", `String (schedule_status_to_string request.status)
     ; "source", `String (schedule_source_to_string request.source)
+    ; "recurrence", recurrence_to_yojson request.recurrence
     ]
 ;;
 
@@ -437,6 +694,11 @@ let schedule_request_of_yojson = function
     let* status = schedule_status_of_string status_name in
     let* source_name = string_field "source" fields in
     let* source = schedule_source_of_string source_name in
+    let* recurrence =
+      match List.assoc_opt "recurrence" fields with
+      | None -> Ok One_shot
+      | Some value -> recurrence_of_yojson value
+    in
     Ok
       { schedule_id
       ; requested_by
@@ -449,6 +711,7 @@ let schedule_request_of_yojson = function
       ; approval_required
       ; status
       ; source
+      ; recurrence
       }
   | _ -> Error "expected schedule_request object"
 ;;
@@ -464,12 +727,14 @@ let create_request
   ~risk_class
   ~approval_required
   ~source
+  ?(recurrence = One_shot)
   ()
   =
   let* schedule_id = nonempty "schedule_id" schedule_id in
   let* _ = nonempty "requested_by.id" requested_by.id in
   let* _ = nonempty "scheduled_by.id" scheduled_by.id in
   let* payload = payload_of_yojson payload in
+  let* recurrence = validate_recurrence recurrence in
   let approval_required = approval_required || is_side_effecting risk_class in
   let status = if approval_required then Pending_approval else Scheduled in
   Ok
@@ -484,6 +749,7 @@ let create_request
     ; approval_required
     ; status
     ; source
+    ; recurrence
     }
 ;;
 

--- a/lib/schedule/schedule_domain.mli
+++ b/lib/schedule/schedule_domain.mli
@@ -40,6 +40,16 @@ type schedule_source =
   | Automated_request
   | System_request
 
+type recurrence =
+  | One_shot
+  | Interval of { interval_sec : int }
+  | Daily of
+      { hour : int
+      ; minute : int
+      ; second : int
+      ; timezone : string
+      }
+
 (** Opaque consumer payload.
 
     The schedule domain does not interpret payload kind or body fields, but it
@@ -60,6 +70,7 @@ type schedule_request =
   ; approval_required : bool
   ; status : schedule_status
   ; source : schedule_source
+  ; recurrence : recurrence
   }
 
 type execution_decision =
@@ -80,6 +91,23 @@ type execution_grant =
   ; approved_at : float
   ; decision : execution_decision
   ; evidence : execution_evidence
+  }
+
+type execution_status =
+  | Execution_running
+  | Execution_succeeded
+  | Execution_failed
+
+type execution_record =
+  { execution_id : string
+  ; schedule_id : string
+  ; started_at : float
+  ; finished_at : float option
+  ; due_at : float
+  ; payload_digest : string
+  ; status : execution_status
+  ; detail : Yojson.Safe.t option
+  ; error : string option
   }
 
 type grant_error =
@@ -105,12 +133,16 @@ val create_request :
   risk_class:risk_class ->
   approval_required:bool ->
   source:schedule_source ->
+  ?recurrence:recurrence ->
   unit ->
   (schedule_request, string) result
 
 val is_terminal : schedule_status -> bool
 val is_side_effecting : risk_class -> bool
 val requires_separate_human_grant : schedule_request -> bool
+val is_recurring : recurrence -> bool
+val next_due_after : now:float -> schedule_request -> float option
+val reschedule_after_due_signal : now:float -> schedule_request -> schedule_request option
 
 val payload_of_yojson : Yojson.Safe.t -> (payload, string) result
 val payload_to_yojson : payload -> Yojson.Safe.t
@@ -141,14 +173,22 @@ val schedule_status_to_string : schedule_status -> string
 val schedule_status_of_string : string -> (schedule_status, string) result
 val schedule_source_to_string : schedule_source -> string
 val schedule_source_of_string : string -> (schedule_source, string) result
+val recurrence_kind_to_string : recurrence -> string
+val execution_status_to_string : execution_status -> string
+val execution_status_of_string : string -> (execution_status, string) result
 val grant_error_to_string : grant_error -> string
 
 val actor_to_yojson : actor -> Yojson.Safe.t
 val actor_of_yojson : Yojson.Safe.t -> (actor, string) result
+val recurrence_to_yojson : recurrence -> Yojson.Safe.t
+val recurrence_of_yojson : Yojson.Safe.t -> (recurrence, string) result
 val execution_evidence_to_yojson : execution_evidence -> Yojson.Safe.t
 val execution_evidence_of_yojson :
   Yojson.Safe.t -> (execution_evidence, string) result
 val execution_grant_to_yojson : execution_grant -> Yojson.Safe.t
 val execution_grant_of_yojson : Yojson.Safe.t -> (execution_grant, string) result
+val execution_record_to_yojson : execution_record -> Yojson.Safe.t
+val execution_record_of_yojson :
+  Yojson.Safe.t -> (execution_record, string) result
 val schedule_request_to_yojson : schedule_request -> Yojson.Safe.t
 val schedule_request_of_yojson : Yojson.Safe.t -> (schedule_request, string) result

--- a/lib/schedule/schedule_runner.ml
+++ b/lib/schedule/schedule_runner.ml
@@ -1,3 +1,7 @@
+(* TEL-OK: this library returns structured [dispatch_result] values and persists
+   generic execution records through [Schedule_store]. The server maintenance
+   loop owns runtime Log telemetry when it installs a concrete consumer. *)
+
 type signal_kind =
   | Due_candidate
   | Due_blocked_approval
@@ -16,6 +20,26 @@ type wake_signal =
 type tick_result =
   { due_changed : int
   ; emitted : wake_signal list
+  ; rescheduled : int
+  ; dispatches : dispatch_result list
+  }
+
+and dispatch_status =
+  | Dispatch_succeeded
+  | Dispatch_failed
+  | Dispatch_unsupported
+  | Dispatch_start_rejected
+
+and dispatch_result =
+  { schedule_id : string
+  ; status : dispatch_status
+  ; detail : Yojson.Safe.t option
+  ; error : string option
+  }
+
+type consumer =
+  { accepts : Schedule_domain.schedule_request -> (unit, string) result
+  ; dispatch : Schedule_domain.schedule_request -> (Yojson.Safe.t, string) result
   }
 
 type runner_error =
@@ -38,6 +62,13 @@ let signal_kind_of_string = function
   | "schedule.due_candidate" -> Ok Due_candidate
   | "schedule.due_blocked_approval" -> Ok Due_blocked_approval
   | other -> Error ("unknown schedule signal kind: " ^ other)
+;;
+
+let dispatch_status_to_string = function
+  | Dispatch_succeeded -> "succeeded"
+  | Dispatch_failed -> "failed"
+  | Dispatch_unsupported -> "unsupported"
+  | Dispatch_start_rejected -> "start_rejected"
 ;;
 
 let schedules_dir config =
@@ -211,6 +242,55 @@ let blocked_approval_signals ~now (state : Schedule_store.state) =
   |> List.map (make_signal ~now Due_blocked_approval)
 ;;
 
+let dispatch_result ?detail ?error schedule_id status =
+  { schedule_id; status; detail; error }
+;;
+
+let finish_failed_dispatch config ~now ~schedule_id error =
+  match Schedule_store.fail_running config ~now ~schedule_id ~error with
+  | Ok _ -> dispatch_result ~error schedule_id Dispatch_failed
+  | Error err ->
+    let error =
+      Printf.sprintf
+        "%s; failed to mark schedule failed: %s"
+        error
+        (Schedule_store.store_error_to_string err)
+    in
+    dispatch_result ~error schedule_id Dispatch_failed
+;;
+
+let safe_consumer_dispatch consumer request =
+  try consumer.dispatch request with
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let dispatch_candidate config ~now consumer (request : Schedule_domain.schedule_request) =
+  let schedule_id = request.Schedule_domain.schedule_id in
+  match consumer.accepts request with
+  | Error reason ->
+    dispatch_result ~error:reason schedule_id Dispatch_unsupported
+  | Ok () ->
+    (match Schedule_store.start_due_candidate config ~now ~schedule_id with
+     | Error err ->
+       dispatch_result ~error:(Schedule_store.store_error_to_string err) schedule_id
+         Dispatch_start_rejected
+     | Ok running_request ->
+       (match safe_consumer_dispatch consumer running_request with
+        | Error error -> finish_failed_dispatch config ~now ~schedule_id error
+        | Ok detail ->
+          (match Schedule_store.complete_running config ~now ~schedule_id ~detail () with
+           | Ok _ -> dispatch_result ~detail schedule_id Dispatch_succeeded
+           | Error err ->
+             dispatch_result ~detail
+               ~error:(Schedule_store.store_error_to_string err)
+               schedule_id Dispatch_failed)))
+;;
+
+let dispatch_candidates config ~now consumer state =
+  Schedule_store.due_execution_candidates state
+  |> List.map (dispatch_candidate config ~now consumer)
+;;
+
 let read_recent_signals config n =
   Dated_jsonl.read_recent (signal_store config) n
   |> List.filter_map (fun json ->
@@ -219,13 +299,22 @@ let read_recent_signals config n =
     | Error _ -> None)
 ;;
 
-let tick config ~now =
+let tick ?consumer config ~now =
   match Schedule_store.refresh_due config ~now with
   | Error err -> Error (Service_error (Schedule_service.Store_error err))
   | Ok (state, due_changed) ->
-    let signals =
-      candidate_signals ~now state @ blocked_approval_signals ~now state
-    in
+    let candidate_signals = candidate_signals ~now state in
+    let signals = candidate_signals @ blocked_approval_signals ~now state in
     let* emitted = append_new_signals config signals in
-    Ok { due_changed; emitted }
+    (match consumer with
+     | Some consumer ->
+       let dispatches = dispatch_candidates config ~now consumer state in
+       Ok { due_changed; emitted; rescheduled = 0; dispatches }
+     | None ->
+       let schedule_ids =
+         List.map (fun (signal : wake_signal) -> signal.schedule_id) candidate_signals
+       in
+       (match Schedule_store.reschedule_due_recurring config ~now ~schedule_ids with
+        | Error err -> Error (Service_error (Schedule_service.Store_error err))
+        | Ok (_, rescheduled) -> Ok { due_changed; emitted; rescheduled; dispatches = [] }))
 ;;

--- a/lib/schedule/schedule_runner.mli
+++ b/lib/schedule/schedule_runner.mli
@@ -1,8 +1,9 @@
-(** Due scanner and generic wake-signal feed for scheduled automation.
+(** Due scanner, generic wake-signal feed, and optional consumer dispatch for
+    scheduled automation.
 
-    This module does not dispatch work and does not know consumer domains. It
-    refreshes due schedule state, emits durable generic schedule signals, and
-    leaves interpretation to consumers. *)
+    This module refreshes due schedule state and emits durable generic schedule
+    signals. When a consumer is installed, dispatch remains consumer-opaque and
+    the store records only generic execution evidence. *)
 
 type signal_kind =
   | Due_candidate
@@ -22,6 +23,26 @@ type wake_signal =
 type tick_result =
   { due_changed : int
   ; emitted : wake_signal list
+  ; rescheduled : int
+  ; dispatches : dispatch_result list
+  }
+
+and dispatch_status =
+  | Dispatch_succeeded
+  | Dispatch_failed
+  | Dispatch_unsupported
+  | Dispatch_start_rejected
+
+and dispatch_result =
+  { schedule_id : string
+  ; status : dispatch_status
+  ; detail : Yojson.Safe.t option
+  ; error : string option
+  }
+
+type consumer =
+  { accepts : Schedule_domain.schedule_request -> (unit, string) result
+  ; dispatch : Schedule_domain.schedule_request -> (Yojson.Safe.t, string) result
   }
 
 type runner_error =
@@ -32,6 +53,7 @@ val runner_error_to_string : runner_error -> string
 
 val signal_kind_to_string : signal_kind -> string
 val signal_kind_of_string : string -> (signal_kind, string) result
+val dispatch_status_to_string : dispatch_status -> string
 
 val signals_dir : Workspace_utils.config -> string
 val signal_seen_path : Workspace_utils.config -> string
@@ -44,6 +66,11 @@ val read_recent_signals :
 (** Read at most [n] recent durable wake signals in chronological order. *)
 
 val tick :
-  Workspace_utils.config -> now:float -> (tick_result, runner_error) result
+  ?consumer:consumer ->
+  Workspace_utils.config ->
+  now:float ->
+  (tick_result, runner_error) result
 (** Refresh due state and append at-most-once generic wake signals for newly
-    observable due work or due approval blockers. No consumer is invoked. *)
+    observable due work or due approval blockers. Recurring due work is advanced
+    after the generic due signal path succeeds when no consumer is installed; a
+    consumer dispatch can instead complete/fail the request. *)

--- a/lib/schedule/schedule_service.ml
+++ b/lib/schedule/schedule_service.ml
@@ -49,6 +49,7 @@ let create
   ~payload
   ~risk_class
   ~source
+  ?recurrence
   ()
   =
   (* NDT-OK: API boundary default; callers may provide requested_at explicitly. *)
@@ -57,7 +58,7 @@ let create
   let* request =
     Schedule_domain.create_request ~schedule_id ~requested_by ~scheduled_by
       ~requested_at ~due_at ?expires_at ~payload ~risk_class
-      ~approval_required ~source ()
+      ~approval_required ~source ?recurrence ()
     |> function
     | Ok request -> Ok request
     | Error msg -> Error (Invalid_request msg)

--- a/lib/schedule/schedule_service.mli
+++ b/lib/schedule/schedule_service.mli
@@ -21,6 +21,7 @@ val create :
   payload:Yojson.Safe.t ->
   risk_class:Schedule_domain.risk_class ->
   source:Schedule_domain.schedule_source ->
+  ?recurrence:Schedule_domain.recurrence ->
   unit ->
   (Schedule_domain.schedule_request, service_error) result
 

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -5,6 +5,7 @@ type state =
   ; updated_at : float
   ; schedules : Schedule_domain.schedule_request list
   ; grants : Schedule_domain.execution_grant list
+  ; executions : Schedule_domain.execution_record list
   }
 
 type store_error =
@@ -13,6 +14,8 @@ type store_error =
   | Grant_already_recorded
   | Invalid_initial_status of string
   | Invalid_status_transition of string
+  | Schedule_not_due_candidate
+  | Schedule_not_running
   | Grant_validation_failed of Schedule_domain.grant_error
   | Corrupt_ledger of
       { primary_err : string
@@ -66,6 +69,8 @@ let store_error_to_string = function
   | Grant_already_recorded -> "grant already recorded"
   | Invalid_initial_status reason -> "invalid initial schedule status: " ^ reason
   | Invalid_status_transition reason -> "invalid schedule status transition: " ^ reason
+  | Schedule_not_due_candidate -> "schedule is not an approved due candidate"
+  | Schedule_not_running -> "schedule is not running"
   | Grant_validation_failed err ->
     "grant validation failed: " ^ Schedule_domain.grant_error_to_string err
   | Corrupt_ledger { primary_err; recovery_err } ->
@@ -85,7 +90,7 @@ let recovery_path config = schedules_path config ^ ".last-good"
 let ensure_dirs config = Workspace_utils.mkdir_p (Workspace_utils.masc_dir config)
 
 let default_state () =
-  { version = 1; updated_at = now (); schedules = []; grants = [] }
+  { version = 1; updated_at = now (); schedules = []; grants = []; executions = [] }
 ;;
 
 let state_to_yojson (state : state) =
@@ -96,6 +101,9 @@ let state_to_yojson (state : state) =
       , `List (List.map Schedule_domain.schedule_request_to_yojson state.schedules)
       )
     ; "grants", `List (List.map Schedule_domain.execution_grant_to_yojson state.grants)
+    ; ( "executions"
+      , `List
+          (List.map Schedule_domain.execution_record_to_yojson state.executions) )
     ]
 ;;
 
@@ -121,6 +129,13 @@ let list_field name fields =
   | None -> Error ("missing field: " ^ name)
 ;;
 
+let optional_list_field name fields =
+  match List.assoc_opt name fields with
+  | None -> Ok []
+  | Some (`List value) -> Ok value
+  | Some _ -> Error ("expected list field: " ^ name)
+;;
+
 let collect_results parse rows =
   let rec loop acc = function
     | [] -> Ok (List.rev acc)
@@ -137,13 +152,17 @@ let state_of_yojson = function
     let* updated_at = float_field "updated_at" fields in
     let* schedules_json = list_field "schedules" fields in
     let* grants_json = list_field "grants" fields in
+    let* executions_json = optional_list_field "executions" fields in
     let* schedules =
       collect_results Schedule_domain.schedule_request_of_yojson schedules_json
     in
     let* grants =
       collect_results Schedule_domain.execution_grant_of_yojson grants_json
     in
-    Ok { version; updated_at; schedules; grants }
+    let* executions =
+      collect_results Schedule_domain.execution_record_of_yojson executions_json
+    in
+    Ok { version; updated_at; schedules; grants; executions }
   | json -> Error ("state_of_yojson: " ^ Yojson.Safe.to_string json)
 ;;
 
@@ -221,8 +240,8 @@ let write_state config state =
   Workspace_utils.write_json config (recovery_path config) json
 ;;
 
-let bump_state state ~schedules ~grants =
-  { version = state.version + 1; updated_at = now (); schedules; grants }
+let bump_state state ~schedules ~grants ~executions =
+  { version = state.version + 1; updated_at = now (); schedules; grants; executions }
 ;;
 
 let find_schedule state schedule_id =
@@ -252,17 +271,92 @@ let grant_exists state grant_id =
 let has_approved_grant state schedule_id =
   List.exists
     (fun (grant : execution_grant) ->
-      String.equal grant.schedule_id schedule_id
+      let grant_matches = String.equal grant.schedule_id schedule_id in
+      grant_matches
       &&
-      match grant.decision with
-      | Approve -> true
-      | Reject _ -> false)
+      (match grant.decision with
+       | Approve -> true
+       | Reject _ -> false))
     state.grants
+;;
+
+let is_due_execution_candidate state (request : schedule_request) =
+  match request.status with
+  | Due ->
+    (not (requires_separate_human_grant request))
+    || has_approved_grant state request.schedule_id
+  | Pending_approval | Scheduled | Running | Succeeded | Failed | Rejected | Cancelled
+  | Expired ->
+    false
 ;;
 
 let list_schedules config = (read_state config).schedules
 
 let get_schedule config ~schedule_id = find_schedule (read_state config) schedule_id
+
+let stable_float value = Printf.sprintf "%.17g" value
+
+let sha256_string value = Digestif.SHA256.(digest_string value |> to_hex)
+
+let execution_id ~now (request : schedule_request) =
+  String.concat
+    "|"
+    [ "schedule_execution"
+    ; request.schedule_id
+    ; stable_float request.due_at
+    ; stable_float now
+    ; Schedule_domain.payload_digest request.payload
+    ]
+  |> sha256_string
+  |> Printf.sprintf "exec-%s"
+;;
+
+let make_execution_record ~now (request : schedule_request) =
+  { execution_id = execution_id ~now request
+  ; schedule_id = request.schedule_id
+  ; started_at = now
+  ; finished_at = None
+  ; due_at = request.due_at
+  ; payload_digest = Schedule_domain.payload_digest request.payload
+  ; status = Execution_running
+  ; detail = None
+  ; error = None
+  }
+;;
+
+let compare_execution_desc (left : execution_record) (right : execution_record) =
+  match compare right.started_at left.started_at with
+  | 0 -> String.compare right.execution_id left.execution_id
+  | cmp -> cmp
+;;
+
+let executions_for_schedule state ~schedule_id =
+  state.executions
+  |> List.filter (fun (execution : execution_record) ->
+    String.equal execution.schedule_id schedule_id)
+  |> List.sort compare_execution_desc
+;;
+
+let last_execution_for_schedule state ~schedule_id =
+  match executions_for_schedule state ~schedule_id with
+  | [] -> None
+  | execution :: _ -> Some execution
+;;
+
+let update_latest_running_execution executions ~schedule_id update =
+  let rec loop acc = function
+    | [] ->
+      Error
+        (Invalid_status_transition
+           "running schedule has no matching running execution record")
+    | (execution : execution_record) :: rest
+      when String.equal execution.schedule_id schedule_id
+           && execution.status = Execution_running ->
+      Ok (List.rev_append acc (update execution :: rest))
+    | execution :: rest -> loop (execution :: acc) rest
+  in
+  loop [] executions
+;;
 
 let validate_initial_request (request : Schedule_domain.schedule_request) =
   if Schedule_domain.is_terminal request.status then
@@ -291,7 +385,10 @@ let insert_request config (request : Schedule_domain.schedule_request) =
     | None ->
       let* () = validate_initial_request request in
       let schedules = request :: state.schedules in
-      let next_state = bump_state state ~schedules ~grants:state.grants in
+      let next_state =
+        bump_state state ~schedules ~grants:state.grants
+          ~executions:state.executions
+      in
       write_state config next_state;
       Ok request)
 ;;
@@ -310,7 +407,9 @@ let record_grant config (grant : Schedule_domain.execution_grant) =
         | Ok updated_request ->
           let schedules = replace_schedule state.schedules updated_request in
           let grants = grant :: state.grants in
-          let next_state = bump_state state ~schedules ~grants in
+          let next_state =
+            bump_state state ~schedules ~grants ~executions:state.executions
+          in
           write_state config next_state;
           Ok updated_request))
 ;;
@@ -331,7 +430,10 @@ let cancel_request config ~schedule_id =
           { request with Schedule_domain.status = Schedule_domain.Cancelled }
         in
         let schedules = replace_schedule state.schedules updated_request in
-        let next_state = bump_state state ~schedules ~grants:state.grants in
+        let next_state =
+          bump_state state ~schedules ~grants:state.grants
+            ~executions:state.executions
+        in
         write_state config next_state;
         Ok updated_request)
 ;;
@@ -352,19 +454,118 @@ let refresh_due config ~now =
     if !changed = 0 then
       Ok (state, 0)
     else (
-      let next_state = bump_state state ~schedules ~grants:state.grants in
+      let next_state =
+        bump_state state ~schedules ~grants:state.grants
+          ~executions:state.executions
+      in
       write_state config next_state;
       Ok (next_state, !changed)))
 ;;
 
+let reschedule_due_recurring config ~now ~schedule_ids =
+  Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
+    let* state = load_for_mutation config in
+    let ids = Hashtbl.create (List.length schedule_ids) in
+    List.iter (fun schedule_id -> Hashtbl.replace ids schedule_id ()) schedule_ids;
+    let changed = ref 0 in
+    let schedules =
+      List.map
+        (fun (request : schedule_request) ->
+          if not (Hashtbl.mem ids request.schedule_id) then
+            request
+          else
+            match Schedule_domain.reschedule_after_due_signal ~now request with
+            | None -> request
+            | Some updated ->
+              incr changed;
+              updated)
+        state.schedules
+    in
+    if !changed = 0 then
+      Ok (state, 0)
+    else (
+      let next_state =
+        bump_state state ~schedules ~grants:state.grants
+          ~executions:state.executions
+      in
+      write_state config next_state;
+      Ok (next_state, !changed)))
+;;
+
+let start_due_candidate config ~now ~schedule_id =
+  Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
+    let* state = load_for_mutation config in
+    match find_schedule state schedule_id with
+    | None -> Error Schedule_not_found
+    | Some request ->
+      if not (is_due_execution_candidate state request) then
+        Error Schedule_not_due_candidate
+      else
+        let updated = { request with status = Running } in
+        let schedules = replace_schedule state.schedules updated in
+        let executions = make_execution_record ~now request :: state.executions in
+        let next_state = bump_state state ~schedules ~grants:state.grants ~executions in
+        write_state config next_state;
+        Ok updated)
+;;
+
+let complete_running config ~now ~schedule_id ?detail () =
+  Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
+    let* state = load_for_mutation config in
+    match find_schedule state schedule_id with
+    | None -> Error Schedule_not_found
+    | Some request ->
+      if request.status <> Running then
+        Error Schedule_not_running
+      else
+        let updated =
+          match Schedule_domain.next_due_after ~now request with
+          | Some due_at -> { request with status = Scheduled; due_at }
+          | None -> { request with status = Succeeded }
+        in
+        let schedules = replace_schedule state.schedules updated in
+        let* executions =
+          update_latest_running_execution state.executions ~schedule_id
+            (fun execution ->
+               { execution with
+                 status = Execution_succeeded
+               ; finished_at = Some now
+               ; detail
+               ; error = None
+               })
+        in
+        let next_state = bump_state state ~schedules ~grants:state.grants ~executions in
+        write_state config next_state;
+        Ok updated)
+;;
+
+let fail_running config ~now ~schedule_id ~error =
+  Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
+    let* state = load_for_mutation config in
+    match find_schedule state schedule_id with
+    | None -> Error Schedule_not_found
+    | Some request ->
+      if request.status <> Running then
+        Error Schedule_not_running
+      else
+        let updated = { request with status = Failed } in
+        let schedules = replace_schedule state.schedules updated in
+        let* executions =
+          update_latest_running_execution state.executions ~schedule_id
+            (fun execution ->
+               { execution with
+                 status = Execution_failed
+               ; finished_at = Some now
+               ; detail = None
+               ; error = Some error
+               })
+        in
+        let next_state = bump_state state ~schedules ~grants:state.grants ~executions in
+        write_state config next_state;
+        Ok updated)
+;;
+
 let due_execution_candidates state =
   state.schedules
-  |> List.filter (fun (request : schedule_request) ->
-    match request.status with
-    | Due ->
-      (not (requires_separate_human_grant request))
-      || has_approved_grant state request.schedule_id
-    | Pending_approval | Scheduled | Running | Succeeded | Failed | Rejected | Cancelled
-    | Expired ->
-      false)
+  |> List.filter (is_due_execution_candidate state)
 ;;

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -8,6 +8,7 @@ type state =
   ; updated_at : float
   ; schedules : Schedule_domain.schedule_request list
   ; grants : Schedule_domain.execution_grant list
+  ; executions : Schedule_domain.execution_record list
   }
 
 type store_error =
@@ -16,6 +17,8 @@ type store_error =
   | Grant_already_recorded
   | Invalid_initial_status of string
   | Invalid_status_transition of string
+  | Schedule_not_due_candidate
+  | Schedule_not_running
   | Grant_validation_failed of Schedule_domain.grant_error
   | Corrupt_ledger of
       { primary_err : string
@@ -64,6 +67,10 @@ val state_of_yojson : Yojson.Safe.t -> (state, string) result
 val list_schedules : Workspace_utils.config -> Schedule_domain.schedule_request list
 val get_schedule :
   Workspace_utils.config -> schedule_id:string -> Schedule_domain.schedule_request option
+val executions_for_schedule :
+  state -> schedule_id:string -> Schedule_domain.execution_record list
+val last_execution_for_schedule :
+  state -> schedule_id:string -> Schedule_domain.execution_record option
 
 val insert_request :
   Workspace_utils.config ->
@@ -86,6 +93,42 @@ val refresh_due :
   (state * int, store_error) result
 (** Marks stored [Scheduled] requests as [Due] when [due_at <= now]. The
     integer is the number of requests changed. *)
+
+val reschedule_due_recurring :
+  Workspace_utils.config ->
+  now:float ->
+  schedule_ids:string list ->
+  (state * int, store_error) result
+(** Advances matching recurring [Due] requests back to [Scheduled] after their
+    generic due signal has been durably recorded. One-shot requests are left
+    [Due] for a future consumer/terminal transition. *)
+
+val start_due_candidate :
+  Workspace_utils.config ->
+  now:float ->
+  schedule_id:string ->
+  (Schedule_domain.schedule_request, store_error) result
+(** Atomically transitions an approved due candidate to [Running] and records a
+    generic execution attempt. *)
+
+val complete_running :
+  Workspace_utils.config ->
+  now:float ->
+  schedule_id:string ->
+  ?detail:Yojson.Safe.t ->
+  unit ->
+  (Schedule_domain.schedule_request, store_error) result
+(** Completes a [Running] request. One-shot requests become [Succeeded];
+    recurring requests advance to the next [Scheduled] occurrence. The matching
+    execution attempt is marked [succeeded]. *)
+
+val fail_running :
+  Workspace_utils.config ->
+  now:float ->
+  schedule_id:string ->
+  error:string ->
+  (Schedule_domain.schedule_request, store_error) result
+(** Marks a [Running] request and its matching execution attempt [Failed]. *)
 
 val due_execution_candidates :
   state -> Schedule_domain.schedule_request list

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -51,13 +51,23 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       let interval = 15.0 in
       let rec loop () =
         (try
-           match Schedule_runner.tick (Mcp_server.workspace_config state) ~now:(Time_compat.now ()) with
+           match
+             Schedule_runner.tick
+               ~consumer:Server_schedule_consumers.consumer
+               (Mcp_server.workspace_config state)
+               ~now:(Time_compat.now ())
+           with
            | Ok result ->
-             if result.Schedule_runner.emitted <> [] then
+             if result.Schedule_runner.emitted <> []
+                || result.rescheduled > 0
+                || result.dispatches <> []
+             then
                Log.Server.info
-                 "schedule_runner: due_changed=%d emitted=%d"
+                 "schedule_runner: due_changed=%d emitted=%d rescheduled=%d dispatched=%d"
                  result.due_changed
                  (List.length result.emitted)
+                 result.rescheduled
+                 (List.length result.dispatches)
            | Error err ->
              Log.Server.warn
                "schedule_runner: tick failed: %s"

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1792,7 +1792,21 @@ let schedule_payload_kind request =
   | _ -> None
 ;;
 
-let schedule_request_dashboard_json (request : Schedule_domain.schedule_request) =
+let execution_record_dashboard_json (execution : Schedule_domain.execution_record) =
+  match Schedule_domain.execution_record_to_yojson execution with
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       @ [ "started_at_iso", unix_iso_json execution.started_at
+         ; "finished_at_iso", unix_iso_option_json execution.finished_at
+         ])
+  | other -> other
+;;
+
+let schedule_request_dashboard_json
+  ?last_execution
+  (request : Schedule_domain.schedule_request)
+  =
   `Assoc
     [ "schedule_id", `String request.schedule_id
     ; "status", `String (Schedule_domain.schedule_status_to_string request.status)
@@ -1807,11 +1821,17 @@ let schedule_request_dashboard_json (request : Schedule_domain.schedule_request)
     ; "due_at_iso", unix_iso_json request.due_at
     ; "expires_at", (match request.expires_at with None -> `Null | Some ts -> `Float ts)
     ; "expires_at_iso", unix_iso_option_json request.expires_at
+    ; "recurrence", Schedule_domain.recurrence_to_yojson request.recurrence
+    ; "recurrence_kind", `String (Schedule_domain.recurrence_kind_to_string request.recurrence)
     ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
     ; ( "payload_kind"
       , match schedule_payload_kind request with
         | None -> `Null
         | Some kind -> `String kind )
+    ; ( "last_execution"
+      , match last_execution with
+        | None -> `Null
+        | Some execution -> execution_record_dashboard_json execution )
     ]
 ;;
 
@@ -1819,7 +1839,8 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
   (* NDT-OK: dashboard read-model freshness clock; it derives display-only
      effective-due state and never mutates the schedule store or runs work. *)
   let now = Unix.gettimeofday () in
-  let schedules = Schedule_service.list config () in
+  let state = Schedule_store.read_state config in
+  let schedules = state.schedules in
   let active_count =
     List.fold_left
       (fun count request -> if schedule_request_active request then count + 1 else count)
@@ -1861,7 +1882,16 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
           ; "terminal_count", `Int terminal_count
           ; "next_due_at", unix_iso_option_json (schedule_next_due_at schedules)
           ] )
-    ; "requests", `List (List.map schedule_request_dashboard_json request_rows)
+    ; ( "requests"
+      , `List
+          (List.map
+             (fun (request : Schedule_domain.schedule_request) ->
+                let last_execution =
+                  Schedule_store.last_execution_for_schedule state
+                    ~schedule_id:request.Schedule_domain.schedule_id
+                in
+                schedule_request_dashboard_json ?last_execution request)
+             request_rows) )
     ]
 ;;
 

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -1,0 +1,150 @@
+(* TEL-OK: concrete scheduled consumer details are returned to
+   [Schedule_runner] and persisted as execution records; the server maintenance
+   loop logs aggregate dispatch counts for runtime telemetry. *)
+
+let supported_payload_kinds = [ "masc.board_post" ]
+
+let ( let* ) = Result.bind
+
+let assoc_field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error ("missing field: " ^ name)
+;;
+
+let string_field name fields =
+  let* value = assoc_field name fields in
+  match value with
+  | `String value when String.trim value <> "" -> Ok value
+  | `String _ -> Error (name ^ " must be non-empty")
+  | _ -> Error ("expected string field: " ^ name)
+;;
+
+let optional_string_field name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) ->
+    let value = String.trim value in
+    if String.equal value "" then Ok None else Ok (Some value)
+  | Some _ -> Error ("expected string field: " ^ name)
+;;
+
+let optional_int_field name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`Int value) -> Ok (Some value)
+  | Some _ -> Error ("expected int field: " ^ name)
+;;
+
+let optional_assoc_field name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`Assoc _ as value) -> Ok (Some value)
+  | Some _ -> Error ("expected object field: " ^ name)
+;;
+
+type payload_view =
+  { kind : string
+  ; schema_version : int
+  ; body : (string * Yojson.Safe.t) list
+  }
+
+let payload_view (request : Schedule_domain.schedule_request) =
+  match Schedule_domain.payload_to_yojson request.payload with
+  | `Assoc fields ->
+    let* kind = string_field "kind" fields in
+    let* schema_version =
+      match List.assoc_opt "schema_version" fields with
+      | Some (`Int value) -> Ok value
+      | Some _ -> Error "expected int field: schema_version"
+      | None -> Error "missing field: schema_version"
+    in
+    let* body =
+      match List.assoc_opt "body" fields with
+      | Some (`Assoc fields) -> Ok fields
+      | Some _ -> Error "payload.body must be an object"
+      | None -> Error "missing field: body"
+    in
+    Ok { kind; schema_version; body }
+  | _ -> Error "payload must be an object"
+;;
+
+let accepts_board_post (request : Schedule_domain.schedule_request) payload =
+  if not (String.equal payload.kind "masc.board_post") then
+    Error ("unsupported schedule payload kind: " ^ payload.kind)
+  else if payload.schema_version <> 1 then
+    Error "masc.board_post only supports schema_version=1"
+  else if not (Schedule_domain.is_side_effecting request.risk_class) then
+    Error "masc.board_post requires a side-effecting risk_class"
+  else
+    let* _content = string_field "content" payload.body in
+    let* ttl_hours = optional_int_field "ttl_hours" payload.body in
+    match ttl_hours with
+    | Some ttl when ttl < 0 -> Error "ttl_hours must be non-negative"
+    | _ -> Ok ()
+;;
+
+let accepts request =
+  let* payload = payload_view request in
+  accepts_board_post request payload
+;;
+
+let schedule_meta_json (request : Schedule_domain.schedule_request) payload user_meta =
+  let base =
+    [ "source", `String "scheduled_automation"
+    ; "schedule_id", `String request.schedule_id
+    ; "payload_kind", `String payload.kind
+    ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
+    ; "requested_by", `String request.requested_by.id
+    ; "scheduled_by", `String request.scheduled_by.id
+    ; "risk_class", `String (Schedule_domain.risk_class_to_string request.risk_class)
+    ; "due_at", `Float request.due_at
+    ]
+  in
+  match user_meta with
+  | None -> `Assoc base
+  | Some meta -> `Assoc (base @ [ "payload_meta", meta ])
+;;
+
+let dispatch_board_post request payload =
+  let* content = string_field "content" payload.body in
+  let* title = optional_string_field "title" payload.body in
+  let* author = optional_string_field "author" payload.body in
+  let* hearth = optional_string_field "hearth" payload.body in
+  let* thread_id = optional_string_field "thread_id" payload.body in
+  let* ttl_hours = optional_int_field "ttl_hours" payload.body in
+  let* user_meta = optional_assoc_field "meta" payload.body in
+  let author =
+    (* DET-OK: absent board-post author maps to the stable scheduled automation
+       actor label for auditability. *)
+    match author with
+    | None -> "schedule-bot"
+    | Some author -> author
+  in
+  let meta_json = schedule_meta_json request payload user_meta in
+  match
+    Board_dispatch.create_post ~author ~content ?title ~post_kind:Board.System_post
+      ~meta_json ~visibility:Board.Internal ?ttl_hours ?hearth ?thread_id ()
+  with
+  | Error err -> Error (Board_types.show_board_error err)
+  | Ok post ->
+    let post_id = Board.Post_id.to_string post.id in
+    Ok
+      (`Assoc
+        [ "kind", `String "masc.board_post.created"
+        ; "post_id", `String post_id
+        ; "author", `String author
+        ; ( "hearth"
+          , match hearth with
+            | None -> `Null
+            | Some hearth -> `String hearth )
+        ])
+;;
+
+let dispatch request =
+  let* payload = payload_view request in
+  let* () = accepts_board_post request payload in
+  dispatch_board_post request payload
+;;
+
+let consumer : Schedule_runner.consumer = { accepts; dispatch }

--- a/lib/server/server_schedule_consumers.mli
+++ b/lib/server/server_schedule_consumers.mli
@@ -1,0 +1,7 @@
+val supported_payload_kinds : string list
+
+val consumer : Schedule_runner.consumer
+(** Production scheduled-automation consumer adapter.
+
+    The schedule core remains opaque; this adapter is the MASC server layer that
+    interprets explicitly supported payload envelopes. *)

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -70,6 +70,33 @@ let status_of_arg args =
      | Error msg -> Error msg)
 ;;
 
+let required_int args key =
+  match optional_int args key with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "%s is required" key)
+;;
+
+let recurrence_of_arg args =
+  match string_opt args "recurrence_kind" with
+  | None | Some "one_shot" -> Ok Schedule_domain.One_shot
+  | Some "interval" ->
+    let* interval_sec = required_int args "recurrence_interval_sec" in
+    Ok (Schedule_domain.Interval { interval_sec })
+  | Some "daily" ->
+    let* hour = required_int args "recurrence_hour" in
+    let* minute = required_int args "recurrence_minute" in
+    let second =
+      (* DET-OK: missing seconds means the explicit daily schedule default at
+         the API boundary, not provider/model-derived guessing. *)
+      match optional_int args "recurrence_second" with
+      | None -> 0
+      | Some second -> second
+    in
+    let* timezone = required_string args "recurrence_timezone" in
+    Ok (Schedule_domain.Daily { hour; minute; second; timezone })
+  | Some other -> Error ("unknown recurrence_kind: " ^ other)
+;;
+
 let actor_from_args args ~prefix ~default_id ~default_kind =
   let id =
     match string_opt args (prefix ^ "_id") with
@@ -118,7 +145,7 @@ let payload_from_args args =
         ])
 ;;
 
-let schedule_request_json (request : Schedule_domain.schedule_request) =
+let schedule_request_json ?last_execution (request : Schedule_domain.schedule_request) =
   match Schedule_domain.schedule_request_to_yojson request with
   | `Assoc fields ->
     `Assoc
@@ -130,6 +157,11 @@ let schedule_request_json (request : Schedule_domain.schedule_request) =
          ; ( "requires_separate_human_grant"
            , `Bool (Schedule_domain.requires_separate_human_grant request) )
          ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
+         ; ( "last_execution"
+           , match last_execution with
+             | None -> `Null
+             | Some execution -> Schedule_domain.execution_record_to_yojson execution
+           )
          ])
   | other -> other
 ;;
@@ -171,6 +203,7 @@ let handle_create ~tool_name ~start_time ctx args =
     let* payload = payload_from_args args in
     let* risk_class = risk_class_of_arg args in
     let* source = source_of_arg args in
+    let* recurrence = recurrence_of_arg args in
     let* requested_by =
       actor_from_args args ~prefix:"requested_by" ~default_id:"operator"
         ~default_kind:Schedule_domain.Human_operator
@@ -189,7 +222,7 @@ let handle_create ~tool_name ~start_time ctx args =
     in
     Schedule_service.create ctx.config ?schedule_id ?requested_at ?expires_at
       ~approval_required ~requested_by ~scheduled_by ~due_at ~payload ~risk_class
-      ~source ()
+      ~source ~recurrence ()
     |> Result.map_error Schedule_service.service_error_to_string
   in
   match result with
@@ -216,10 +249,22 @@ let handle_list ~tool_name ~start_time ctx args =
       optional_int args "limit" |> Option.value ~default:50
     in
     let limit = min 200 (max 1 raw_limit) in
+    let state = Schedule_store.read_state ctx.config in
     let schedules =
-      Schedule_service.list ctx.config ?status ()
+      (match status with
+       | None -> state.Schedule_store.schedules
+       | Some expected ->
+         List.filter
+           (fun (request : Schedule_domain.schedule_request) ->
+             request.status = expected)
+           state.schedules)
       |> take limit
-      |> List.map schedule_request_json
+      |> List.map (fun (request : Schedule_domain.schedule_request) ->
+        let last_execution =
+          Schedule_store.last_execution_for_schedule state
+            ~schedule_id:request.Schedule_domain.schedule_id
+        in
+        schedule_request_json ?last_execution request)
     in
     ok ~tool_name ~start_time
       (`Assoc
@@ -233,9 +278,15 @@ let handle_get ~tool_name ~start_time ctx args =
   match required_string args "schedule_id" with
   | Error msg -> workflow_error ~tool_name ~start_time msg
   | Ok schedule_id ->
+    let state = Schedule_store.read_state ctx.config in
     (match Schedule_service.get ctx.config ~schedule_id with
      | None -> workflow_error ~tool_name ~start_time "schedule not found"
-     | Some request -> ok ~tool_name ~start_time (schedule_request_json request))
+     | Some request ->
+       let last_execution =
+         Schedule_store.last_execution_for_schedule state
+           ~schedule_id:request.Schedule_domain.schedule_id
+       in
+       ok ~tool_name ~start_time (schedule_request_json ?last_execution request))
 ;;
 
 let handle_cancel ~tool_name ~start_time ctx args =

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -92,6 +92,7 @@ let statuses =
 let actor_kinds = [ "human_operator"; "automated_actor"; "system" ]
 
 let sources = [ "operator_request"; "automated_request"; "system_request" ]
+let recurrence_kinds = [ "one_shot"; "interval"; "daily" ]
 
 let create_schema =
   object_schema
@@ -113,6 +114,26 @@ let create_schema =
     ; string_prop ~description:"Optional stable schedule id." "schedule_id"
     ; number_prop ~description:"Optional request timestamp for replay/tests." "requested_at_unix"
     ; number_prop ~description:"Optional expiry timestamp." "expires_at_unix"
+    ; string_prop
+        ~description:"Recurrence kind. Defaults to one_shot."
+        ~enum:recurrence_kinds
+        "recurrence_kind"
+    ; integer_prop
+        ~description:"Required when recurrence_kind is interval; seconds between runs."
+        "recurrence_interval_sec"
+    ; integer_prop
+        ~description:"Required when recurrence_kind is daily; local hour in 0..23."
+        "recurrence_hour"
+    ; integer_prop
+        ~description:"Required when recurrence_kind is daily; local minute in 0..59."
+        "recurrence_minute"
+    ; integer_prop
+        ~description:"Optional when recurrence_kind is daily; local second in 0..59."
+        "recurrence_second"
+    ; string_prop
+        ~description:
+          "Required when recurrence_kind is daily. Supported values: UTC, Asia/Seoul, KST, or a fixed offset like +09:00."
+        "recurrence_timezone"
     ; string_prop ~description:"Requester actor id. Defaults to operator." "requested_by_id"
     ; string_prop ~enum:actor_kinds "requested_by_kind"
     ; string_prop ~description:"Requester display name." "requested_by_display_name"

--- a/test/dune
+++ b/test/dune
@@ -1128,6 +1128,11 @@
  (libraries masc_test_deps masc_schedule))
 
 (test
+ (name test_schedule_consumer_dispatch)
+ (modules test_schedule_consumer_dispatch)
+ (libraries masc_test_deps masc_schedule masc_server))
+
+(test
  (name test_schedule_tool_wiring)
  (modules test_schedule_tool_wiring)
  (libraries masc_test_deps masc_schedule))

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -1,0 +1,182 @@
+open Alcotest
+open Masc
+
+let () = Mirage_crypto_rng_unix.use_default ()
+
+let temp_dir () =
+  let path = Filename.temp_file "schedule_consumer_dispatch_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path
+      end
+      else Sys.remove path
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let with_workspace f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  Unix.putenv "MASC_BASE_PATH" dir;
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  let config = Workspace.default_config dir in
+  ignore (Workspace.init config ~agent_name:(Some "test"));
+  f config
+;;
+
+let human id : Schedule_domain.actor =
+  { id; kind = Schedule_domain.Human_operator; display_name = None }
+;;
+
+let automated id : Schedule_domain.actor =
+  { id; kind = Schedule_domain.Automated_actor; display_name = None }
+;;
+
+let board_post_payload =
+  `Assoc
+    [ "kind", `String "masc.board_post"
+    ; "schema_version", `Int 1
+    ; ( "body"
+      , `Assoc
+          [ "title", `String "Scheduled check-in"
+          ; "content", `String "Daily schedule fired"
+          ; "author", `String "schedule-bot"
+          ; "hearth", `String "ops"
+          ; "ttl_hours", `Int 0
+          ; "meta", `Assoc [ "purpose", `String "test" ]
+          ] )
+    ]
+;;
+
+let create_pending_board_schedule config =
+  match
+    Schedule_service.create config ~schedule_id:"board-sched-1"
+      ~requested_at:100.0 ~requested_by:(human "operator")
+      ~scheduled_by:(automated "scheduler-agent") ~due_at:200.0
+      ~payload:board_post_payload ~risk_class:Schedule_domain.Workspace_write
+      ~source:Schedule_domain.Operator_request ()
+  with
+  | Ok request -> request
+  | Error err ->
+    fail ("create failed: " ^ Schedule_service.service_error_to_string err)
+;;
+
+let approve_schedule config (request : Schedule_domain.schedule_request) =
+  match
+    Schedule_service.approve config ~schedule_id:request.Schedule_domain.schedule_id
+      ~approved_by:(human "approver") ()
+  with
+  | Ok request -> request
+  | Error err ->
+    fail ("approve failed: " ^ Schedule_service.service_error_to_string err)
+;;
+
+let tick_ok config ~now =
+  match
+    Schedule_runner.tick ~consumer:Server_schedule_consumers.consumer config ~now
+  with
+  | Ok result -> result
+  | Error err -> fail (Schedule_runner.runner_error_to_string err)
+;;
+
+let test_board_post_consumer_creates_post_and_succeeds_schedule () =
+  with_workspace
+  @@ fun config ->
+  let request = create_pending_board_schedule config in
+  check string "initial status" "pending_approval"
+    (Schedule_domain.schedule_status_to_string request.status);
+  ignore (approve_schedule config request : Schedule_domain.schedule_request);
+  let result = tick_ok config ~now:201.0 in
+  check int "one dispatch" 1 (List.length result.dispatches);
+  check string "dispatch status" "succeeded"
+    (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);
+  (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+   | None -> fail "schedule missing"
+   | Some stored ->
+     check string "schedule succeeded" "succeeded"
+       (Schedule_domain.schedule_status_to_string stored.status));
+  (match
+     Schedule_store.last_execution_for_schedule (Schedule_store.read_state config)
+       ~schedule_id:request.schedule_id
+   with
+   | None -> fail "missing execution record"
+   | Some execution ->
+     check string "execution status" "succeeded"
+       (Schedule_domain.execution_status_to_string execution.status);
+     (match execution.detail with
+      | Some detail ->
+        let open Yojson.Safe.Util in
+        check string "execution detail kind" "masc.board_post.created"
+          (detail |> member "kind" |> to_string)
+      | None -> fail "execution detail missing"));
+  match Board_dispatch.list_posts ~hearth:"ops" ~limit:10 () with
+  | [ post ] ->
+    check string "title" "Scheduled check-in" post.Board.title;
+    check string "content" "Daily schedule fired" post.content;
+    check string "author" "schedule-bot" (Board.Agent_id.to_string post.author);
+    (match post.meta_json with
+     | Some meta ->
+       let open Yojson.Safe.Util in
+       check string "meta source" "scheduled_automation"
+         (meta |> member "source" |> to_string);
+       check string "meta schedule" request.schedule_id
+         (meta |> member "schedule_id" |> to_string);
+       check string "payload meta" "test"
+         (meta |> member "payload_meta" |> member "purpose" |> to_string)
+     | None -> fail "expected schedule meta")
+  | posts -> failf "expected one board post, got %d" (List.length posts)
+;;
+
+let test_board_post_consumer_rejects_read_only_risk () =
+  with_workspace
+  @@ fun config ->
+  let request =
+    match
+      Schedule_service.create config ~schedule_id:"board-read-only"
+        ~requested_at:100.0 ~requested_by:(human "operator")
+        ~scheduled_by:(automated "scheduler-agent") ~due_at:200.0
+        ~payload:board_post_payload ~risk_class:Schedule_domain.Read_only
+        ~source:Schedule_domain.Operator_request ()
+    with
+    | Ok request -> request
+    | Error err ->
+      fail ("create failed: " ^ Schedule_service.service_error_to_string err)
+  in
+  let result = tick_ok config ~now:201.0 in
+  check int "one unsupported decision" 1 (List.length result.dispatches);
+  check string "dispatch status" "unsupported"
+    (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);
+  (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+   | None -> fail "schedule missing"
+   | Some stored ->
+     check string "schedule remains due" "due"
+       (Schedule_domain.schedule_status_to_string stored.status));
+  check int "no post" 0 (List.length (Board_dispatch.list_posts ~limit:10 ()))
+;;
+
+let () =
+  run "Schedule_consumer_dispatch"
+    [ ( "board_post"
+      , [ test_case "creates board post and succeeds schedule" `Quick
+            test_board_post_consumer_creates_post_and_succeeds_schedule
+        ; test_case "rejects read-only risk" `Quick
+            test_board_post_consumer_rejects_read_only_risk
+        ] )
+    ]
+;;

--- a/test/test_schedule_domain.ml
+++ b/test/test_schedule_domain.ml
@@ -21,13 +21,14 @@ let request
   ?(approval_required = false)
   ?(requested_by = human "requester")
   ?(scheduled_by = human "scheduler")
+  ?recurrence
   ()
   =
   match
     create_request ~schedule_id:"sched-1" ~requested_by ~scheduled_by
       ~requested_at:100.0 ~due_at:200.0
       ~payload:(payload_json ()) ~risk_class ~approval_required
-      ~source:Operator_request ()
+      ~source:Operator_request ?recurrence ()
   with
   | Ok request -> request
   | Error msg -> fail msg
@@ -83,6 +84,20 @@ let test_payload_requires_known_envelope_fields () =
   with
   | Ok _ -> fail "expected invalid payload"
   | Error msg -> check string "payload error" "missing field: kind" msg
+;;
+
+let test_invalid_recurrence_rejected () =
+  match
+    create_request ~schedule_id:"sched-1" ~requested_by:(human "requester")
+      ~scheduled_by:(human "scheduler") ~requested_at:100.0 ~due_at:200.0
+      ~payload:(payload_json ()) ~risk_class:Read_only
+      ~approval_required:false ~source:Operator_request
+      ~recurrence:(Interval { interval_sec = 0 })
+      ()
+  with
+  | Ok _ -> fail "expected invalid recurrence"
+  | Error msg ->
+    check string "recurrence error" "recurrence.interval_sec must be positive" msg
 ;;
 
 let test_separate_human_approval_accepts () =
@@ -149,15 +164,59 @@ let test_mark_due_only_scheduled () =
   check_status "pending unchanged" Pending_approval unchanged.status
 ;;
 
+let test_interval_recurrence_next_due () =
+  let req =
+    request ~risk_class:Read_only
+      ~recurrence:(Interval { interval_sec = 60 })
+      ()
+  in
+  check bool "is recurring" true (is_recurring req.recurrence);
+  match next_due_after ~now:201.0 req with
+  | None -> fail "expected next interval due"
+  | Some due_at -> check (float 0.001) "next due" 260.0 due_at
+;;
+
+let test_daily_recurrence_next_due_uses_timezone () =
+  let req =
+    request ~risk_class:Read_only
+      ~recurrence:
+        (Daily { hour = 9; minute = 0; second = 0; timezone = "Asia/Seoul" })
+      ()
+  in
+  match next_due_after ~now:1.0 req with
+  | None -> fail "expected next daily due"
+  | Some due_at -> check (float 0.001) "next KST 09:00" 86400.0 due_at
+;;
+
 let test_schedule_roundtrip () =
-  let req = request ~risk_class:Cost_bearing ~approval_required:true () in
+  let req =
+    request ~risk_class:Cost_bearing ~approval_required:true
+      ~recurrence:(Interval { interval_sec = 300 })
+      ()
+  in
   match schedule_request_to_yojson req |> schedule_request_of_yojson with
   | Error msg -> fail msg
   | Ok decoded ->
     check string "schedule_id" req.schedule_id decoded.schedule_id;
     check_status "status" req.status decoded.status;
+    check string "recurrence" "interval"
+      (recurrence_kind_to_string decoded.recurrence);
     check string "payload digest" (payload_digest req.payload)
       (payload_digest decoded.payload)
+;;
+
+let test_missing_recurrence_defaults_one_shot () =
+  let req = request ~risk_class:Read_only () in
+  let json =
+    match schedule_request_to_yojson req with
+    | `Assoc fields -> `Assoc (List.remove_assoc "recurrence" fields)
+    | other -> other
+  in
+  match schedule_request_of_yojson json with
+  | Error msg -> fail msg
+  | Ok decoded ->
+    check string "recurrence" "one_shot"
+      (recurrence_kind_to_string decoded.recurrence)
 ;;
 
 let test_grant_roundtrip () =
@@ -170,6 +229,32 @@ let test_grant_roundtrip () =
     check string "schedule_id" grant.schedule_id decoded.schedule_id;
     check string "payload digest" grant.evidence.payload_digest
       decoded.evidence.payload_digest
+;;
+
+let test_execution_record_roundtrip () =
+  let req = request ~risk_class:Read_only () in
+  let execution =
+    { execution_id = "exec-1"
+    ; schedule_id = req.schedule_id
+    ; started_at = 201.0
+    ; finished_at = Some 202.0
+    ; due_at = req.due_at
+    ; payload_digest = payload_digest req.payload
+    ; status = Execution_succeeded
+    ; detail = Some (`Assoc [ "kind", `String "test.done" ])
+    ; error = None
+    }
+  in
+  match execution_record_to_yojson execution |> execution_record_of_yojson with
+  | Error msg -> fail msg
+  | Ok decoded ->
+    check string "execution_id" execution.execution_id decoded.execution_id;
+    check string "status" "succeeded"
+      (execution_status_to_string decoded.status);
+    check (option (float 0.001)) "finished_at" execution.finished_at
+      decoded.finished_at;
+    check string "payload digest" execution.payload_digest
+      decoded.payload_digest
 ;;
 
 let () =
@@ -185,8 +270,14 @@ let () =
             test_payload_requires_object_envelope;
           test_case "payload requires envelope fields" `Quick
             test_payload_requires_known_envelope_fields;
+          test_case "invalid recurrence rejected" `Quick
+            test_invalid_recurrence_rejected;
           test_case "mark due only affects scheduled" `Quick
             test_mark_due_only_scheduled;
+          test_case "interval recurrence next due" `Quick
+            test_interval_recurrence_next_due;
+          test_case "daily recurrence next due uses timezone" `Quick
+            test_daily_recurrence_next_due_uses_timezone;
         ] );
       ( "grant",
         [
@@ -204,7 +295,11 @@ let () =
       ( "codec",
         [
           test_case "schedule roundtrip" `Quick test_schedule_roundtrip;
+          test_case "missing recurrence defaults one-shot" `Quick
+            test_missing_recurrence_defaults_one_shot;
           test_case "grant roundtrip" `Quick test_grant_roundtrip;
+          test_case "execution record roundtrip" `Quick
+            test_execution_record_roundtrip;
         ] );
     ]
 ;;

--- a/test/test_schedule_runner.ml
+++ b/test/test_schedule_runner.ml
@@ -51,26 +51,45 @@ let create_ok
   ?(schedule_id = "sched-1")
   ?(risk_class = Read_only)
   ?approval_required
+  ?recurrence
   config
   =
   match
     create config ~schedule_id ?approval_required ~requested_at:100.0
       ~requested_by:(human "requester") ~scheduled_by:(human "scheduler")
       ~due_at:200.0 ~payload:(payload_json "wake me") ~risk_class
-      ~source:Operator_request ()
+      ~source:Operator_request ?recurrence ()
   with
   | Ok request -> request
   | Error err -> fail (service_error_to_string err)
 ;;
 
-let tick_ok config ~now =
-  match tick config ~now with
+let tick_ok ?consumer config ~now =
+  match tick ?consumer config ~now with
   | Ok result -> result
   | Error err -> fail (runner_error_to_string err)
 ;;
 
 let check_kind label expected actual =
   check string label (signal_kind_to_string expected) (signal_kind_to_string actual)
+;;
+
+let check_dispatch_status label expected actual =
+  check string label (dispatch_status_to_string expected) (dispatch_status_to_string actual)
+;;
+
+let accepting_consumer ?(accept = Ok ()) ?dispatch_result calls =
+  let dispatch_result =
+    Option.value
+      ~default:(Ok (`Assoc [ "ok", `Bool true ]))
+      dispatch_result
+  in
+  { accepts = (fun _request -> accept)
+  ; dispatch =
+      (fun request ->
+        calls := request.schedule_id :: !calls;
+        dispatch_result)
+  }
 ;;
 
 let test_tick_emits_due_candidate_once () =
@@ -82,6 +101,7 @@ let test_tick_emits_due_candidate_once () =
   let due = tick_ok config ~now:201.0 in
   check int "one signal" 1 (List.length due.emitted);
   check int "one status transition" 1 due.due_changed;
+  check int "one-shot not rescheduled" 0 due.rescheduled;
   let signal = List.hd due.emitted in
   check_kind "kind" Due_candidate signal.kind;
   check string "schedule id" request.schedule_id signal.schedule_id;
@@ -91,6 +111,58 @@ let test_tick_emits_due_candidate_once () =
   let repeated = tick_ok config ~now:202.0 in
   check int "dedupe repeated tick" 0 (List.length repeated.emitted);
   check int "durable signal count" 1 (List.length (read_recent_signals config 10))
+;;
+
+let test_tick_dispatches_due_candidate_to_success () =
+  with_workspace
+  @@ fun config ->
+  let calls = ref [] in
+  let request = create_ok ~schedule_id:"dispatch-1" config in
+  let result =
+    tick_ok config ~now:201.0 ~consumer:(accepting_consumer calls)
+  in
+  check int "one dispatch" 1 (List.length result.dispatches);
+  check_dispatch_status "dispatch status" Dispatch_succeeded
+    (List.hd result.dispatches).status;
+  check Alcotest.(list string) "consumer called" [ request.schedule_id ] !calls;
+  (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+   | None -> fail "schedule missing after dispatch"
+   | Some stored ->
+     check string "stored succeeded" "succeeded"
+       (schedule_status_to_string stored.status));
+  (match
+     Schedule_store.last_execution_for_schedule (Schedule_store.read_state config)
+       ~schedule_id:request.schedule_id
+   with
+   | None -> fail "missing execution record"
+   | Some execution ->
+     check string "execution status" "succeeded"
+       (Schedule_domain.execution_status_to_string execution.status);
+     (match execution.detail with
+      | Some (`Assoc fields) ->
+        (match List.assoc_opt "ok" fields with
+         | Some (`Bool true) -> ()
+         | _ -> fail "execution detail missing ok=true")
+      | _ -> fail "execution detail missing"))
+;;
+
+let test_tick_leaves_unsupported_candidate_due () =
+  with_workspace
+  @@ fun config ->
+  let calls = ref [] in
+  let request = create_ok ~schedule_id:"unsupported-1" config in
+  let result =
+    tick_ok config ~now:201.0
+      ~consumer:(accepting_consumer ~accept:(Error "unsupported") calls)
+  in
+  check int "one dispatch decision" 1 (List.length result.dispatches);
+  check_dispatch_status "unsupported" Dispatch_unsupported
+    (List.hd result.dispatches).status;
+  check Alcotest.(list string) "consumer not called" [] !calls;
+  (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+   | None -> fail "schedule missing after unsupported"
+   | Some stored ->
+     check string "still due" "due" (schedule_status_to_string stored.status))
 ;;
 
 let test_tick_emits_approval_blocker_then_candidate_after_grant () =
@@ -115,13 +187,108 @@ let test_tick_emits_approval_blocker_then_candidate_after_grant () =
   check int "two durable signals" 2 (List.length (read_recent_signals config 10))
 ;;
 
+let test_tick_reschedules_recurring_candidate_after_signal () =
+  with_workspace
+  @@ fun config ->
+  let request =
+    create_ok ~schedule_id:"loop-1"
+      ~recurrence:(Interval { interval_sec = 60 })
+      config
+  in
+  let due = tick_ok config ~now:201.0 in
+  check int "first signal" 1 (List.length due.emitted);
+  check int "first reschedule" 1 due.rescheduled;
+  (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+   | None -> fail "schedule missing after first tick"
+   | Some stored ->
+     check string "first status" "scheduled"
+       (schedule_status_to_string stored.status);
+     check (float 0.001) "first next due" 260.0 stored.due_at);
+  let before_next_due = tick_ok config ~now:259.0 in
+  check int "no early repeat" 0 (List.length before_next_due.emitted);
+  check int "no early reschedule" 0 before_next_due.rescheduled;
+  let second_due = tick_ok config ~now:260.0 in
+  check int "second signal" 1 (List.length second_due.emitted);
+  check int "second reschedule" 1 second_due.rescheduled;
+  check int "two durable signals" 2 (List.length (read_recent_signals config 10))
+;;
+
+let test_tick_dispatches_recurring_candidate_to_next_due () =
+  with_workspace
+  @@ fun config ->
+  let calls = ref [] in
+  let request =
+    create_ok ~schedule_id:"loop-dispatch-1"
+      ~recurrence:(Interval { interval_sec = 60 })
+      config
+  in
+  let result =
+    tick_ok config ~now:201.0 ~consumer:(accepting_consumer calls)
+  in
+  check int "one dispatch" 1 (List.length result.dispatches);
+  check int "consumer mode does not separately reschedule" 0 result.rescheduled;
+  check Alcotest.(list string) "consumer called" [ request.schedule_id ] !calls;
+  (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+   | None -> fail "schedule missing after recurring dispatch"
+   | Some stored ->
+     check string "stored scheduled" "scheduled"
+       (schedule_status_to_string stored.status);
+     check (float 0.001) "next due" 260.0 stored.due_at);
+  (match
+     Schedule_store.last_execution_for_schedule (Schedule_store.read_state config)
+       ~schedule_id:request.schedule_id
+   with
+   | None -> fail "missing recurring execution"
+   | Some execution ->
+     check string "recurring execution status" "succeeded"
+       (Schedule_domain.execution_status_to_string execution.status);
+     check (float 0.001) "recurring execution due" 200.0 execution.due_at)
+;;
+
+let test_tick_marks_dispatch_failure_failed () =
+  with_workspace
+  @@ fun config ->
+  let calls = ref [] in
+  let request = create_ok ~schedule_id:"dispatch-fail-1" config in
+  let result =
+    tick_ok config ~now:201.0
+      ~consumer:(accepting_consumer ~dispatch_result:(Error "boom") calls)
+  in
+  check int "one dispatch" 1 (List.length result.dispatches);
+  check_dispatch_status "failed" Dispatch_failed (List.hd result.dispatches).status;
+  (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+   | None -> fail "schedule missing after failed dispatch"
+   | Some stored ->
+     check string "stored failed" "failed" (schedule_status_to_string stored.status));
+  (match
+     Schedule_store.last_execution_for_schedule (Schedule_store.read_state config)
+       ~schedule_id:request.schedule_id
+   with
+   | None -> fail "missing failed execution"
+   | Some execution ->
+     check string "failed execution status" "failed"
+       (Schedule_domain.execution_status_to_string execution.status);
+     check (option string) "failed execution error" (Some "boom")
+       execution.error)
+;;
+
 let () =
   run "Schedule_runner"
     [ ( "tick",
         [ test_case "emits due candidate once" `Quick
             test_tick_emits_due_candidate_once
+        ; test_case "dispatches due candidate to success" `Quick
+            test_tick_dispatches_due_candidate_to_success
+        ; test_case "leaves unsupported candidate due" `Quick
+            test_tick_leaves_unsupported_candidate_due
         ; test_case "emits approval blocker then candidate after grant" `Quick
             test_tick_emits_approval_blocker_then_candidate_after_grant
+        ; test_case "reschedules recurring candidate after signal" `Quick
+            test_tick_reschedules_recurring_candidate_after_signal
+        ; test_case "dispatches recurring candidate to next due" `Quick
+            test_tick_dispatches_recurring_candidate_to_next_due
+        ; test_case "marks dispatch failure failed" `Quick
+            test_tick_marks_dispatch_failure_failed
         ] )
     ]
 ;;

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -46,12 +46,17 @@ let payload_json () =
     ]
 ;;
 
-let make_request ?(schedule_id = "sched-1") ?(risk_class = Workspace_write) () =
+let make_request
+  ?(schedule_id = "sched-1")
+  ?(risk_class = Workspace_write)
+  ?recurrence
+  ()
+  =
   match
     create_request ~schedule_id ~requested_by:(human "requester")
       ~scheduled_by:(human "scheduler") ~requested_at:100.0 ~due_at:200.0
       ~payload:(payload_json ()) ~risk_class ~approval_required:false
-      ~source:Operator_request ()
+      ~source:Operator_request ?recurrence ()
   with
   | Ok request -> request
   | Error msg -> fail msg
@@ -189,6 +194,37 @@ let test_read_only_due_candidate_does_not_need_grant () =
     (List.length (due_execution_candidates (read_state config)))
 ;;
 
+let test_reschedule_due_recurring_advances_only_matching_recurring_rows () =
+  with_workspace
+  @@ fun config ->
+  let recurring =
+    make_request ~schedule_id:"loop-1" ~risk_class:Read_only
+      ~recurrence:(Interval { interval_sec = 60 })
+      ()
+  in
+  let one_shot = make_request ~schedule_id:"once-1" ~risk_class:Read_only () in
+  ignore (insert_ok config recurring);
+  ignore (insert_ok config one_shot);
+  (match refresh_due config ~now:201.0 with
+   | Ok (_, changed) -> check int "both due" 2 changed
+   | Error err -> fail (store_error_to_string err));
+  (match
+     reschedule_due_recurring config ~now:201.0
+       ~schedule_ids:[ "loop-1"; "once-1"; "missing" ]
+   with
+   | Error err -> fail (store_error_to_string err)
+   | Ok (_, changed) -> check int "one rescheduled" 1 changed);
+  match
+    get_schedule config ~schedule_id:"loop-1",
+    get_schedule config ~schedule_id:"once-1"
+  with
+  | Some loop, Some once ->
+    check_status "loop scheduled" Scheduled loop.status;
+    check (float 0.001) "loop next due" 260.0 loop.due_at;
+    check_status "one-shot left due" Due once.status
+  | _ -> fail "schedules missing"
+;;
+
 let test_recovers_from_last_good () =
   with_workspace
   @@ fun config ->
@@ -220,7 +256,54 @@ let test_load_fresh_when_file_absent () =
    | Corrupt _ -> fail "absent ledger reported as Corrupt");
   let state = read_state config in
   check int "fresh store has no schedules" 0 (List.length state.schedules);
-  check int "fresh store has no grants" 0 (List.length state.grants)
+  check int "fresh store has no grants" 0 (List.length state.grants);
+  check int "fresh store has no executions" 0 (List.length state.executions)
+;;
+
+let test_start_and_complete_persist_execution_record () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request ~schedule_id:"exec-1" ~risk_class:Read_only () in
+  ignore (insert_ok config req);
+  (match refresh_due config ~now:201.0 with
+   | Ok (_, changed) -> check int "became due" 1 changed
+   | Error err -> fail (store_error_to_string err));
+  (match start_due_candidate config ~now:202.0 ~schedule_id:req.schedule_id with
+   | Ok running -> check_status "running" Running running.status
+   | Error err -> fail (store_error_to_string err));
+  let running_state = read_state config in
+  check int "one execution" 1 (List.length running_state.executions);
+  let execution = List.hd running_state.executions in
+  check string "execution status" "running"
+    (execution_status_to_string execution.status);
+  check string "execution schedule" req.schedule_id execution.schedule_id;
+  check (float 0.001) "started at" 202.0 execution.started_at;
+  check (float 0.001) "execution due" 200.0 execution.due_at;
+  check string "payload digest" (payload_digest req.payload)
+    execution.payload_digest;
+  (match
+     complete_running config ~now:203.0 ~schedule_id:req.schedule_id
+       ~detail:(`Assoc [ "kind", `String "test.done" ])
+       ()
+   with
+   | Ok stored -> check_status "succeeded" Succeeded stored.status
+   | Error err -> fail (store_error_to_string err));
+  let completed_state = read_state config in
+  match
+    last_execution_for_schedule completed_state ~schedule_id:req.schedule_id
+  with
+  | None -> fail "missing completed execution"
+  | Some completed ->
+    check string "completed status" "succeeded"
+      (execution_status_to_string completed.status);
+    check (option (float 0.001)) "finished at" (Some 203.0)
+      completed.finished_at;
+    (match completed.detail with
+     | Some (`Assoc fields) ->
+       (match List.assoc_opt "kind" fields with
+        | Some (`String kind) -> check string "detail kind" "test.done" kind
+        | _ -> fail "detail kind missing")
+     | _ -> fail "detail missing")
 ;;
 
 let test_load_corrupt_when_both_unparseable () =
@@ -337,6 +420,10 @@ let () =
             test_due_candidates_require_approval_grant;
           test_case "read-only due candidate does not need grant" `Quick
             test_read_only_due_candidate_does_not_need_grant;
+          test_case "reschedule due recurring rows" `Quick
+            test_reschedule_due_recurring_advances_only_matching_recurring_rows;
+          test_case "start and complete persist execution record" `Quick
+            test_start_and_complete_persist_execution_record;
         ] );
     ]
 ;;

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -101,6 +101,32 @@ let test_dispatch_create_persists_schedule () =
       (Schedule_domain.schedule_status_to_string request.status)
 ;;
 
+let test_dispatch_create_persists_recurrence () =
+  with_config
+  @@ fun config ->
+  let args =
+    `Assoc
+      ([ "schedule_id", `String "sched-loop"
+       ; "recurrence_kind", `String "interval"
+       ; "recurrence_interval_sec", `Int 900
+       ]
+       @ create_fields)
+  in
+  match
+    Tool_schedule.dispatch (schedule_ctx config)
+      ~name:(schedule_tool_name Tool_schemas_schedule.Create_request)
+      ~args
+  with
+  | None -> fail "dispatch returned None"
+  | Some result ->
+    check bool "create succeeds" true (Tool_result.is_success result);
+    (match Schedule_store.get_schedule config ~schedule_id:"sched-loop" with
+     | None -> fail "schedule missing"
+     | Some request ->
+       check string "recurrence" "interval"
+         (Schedule_domain.recurrence_kind_to_string request.recurrence))
+;;
+
 let test_dispatch_cancel_persists_status () =
   with_config
   @@ fun config ->
@@ -137,16 +163,18 @@ let test_dispatch_cancel_persists_status () =
 
 let create_schedule_exn
   config
+  ?recurrence
   ~schedule_id
   ~due_at
   ~risk_class
   ~requested_by
   ~scheduled_by
+  ()
   =
   match
     Schedule_service.create config ~schedule_id ~requested_at:100.0
       ~requested_by ~scheduled_by ~due_at ~payload ~risk_class
-      ~source:Schedule_domain.Operator_request ()
+      ~source:Schedule_domain.Operator_request ?recurrence ()
   with
   | Ok request -> request
   | Error err ->
@@ -157,14 +185,38 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
   with_config
   @@ fun config ->
   ignore
+    (create_schedule_exn config ~schedule_id:"sched-exec" ~due_at:50.0
+       ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
+       ~scheduled_by:(automated "scheduler-agent")
+       ()
+      : Schedule_domain.schedule_request);
+  (match Schedule_store.refresh_due config ~now:51.0 with
+   | Ok _ -> ()
+   | Error err -> fail (Schedule_store.store_error_to_string err));
+  (match Schedule_store.start_due_candidate config ~now:52.0 ~schedule_id:"sched-exec" with
+   | Ok _ -> ()
+   | Error err -> fail (Schedule_store.store_error_to_string err));
+  (match
+     Schedule_store.complete_running config ~now:53.0 ~schedule_id:"sched-exec"
+       ~detail:(`Assoc [ "kind", `String "test.exec" ])
+       ()
+   with
+   | Ok _ -> ()
+   | Error err -> fail (Schedule_store.store_error_to_string err));
+  ignore
     (create_schedule_exn config ~schedule_id:"sched-due" ~due_at:1.0
        ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
        ~scheduled_by:(automated "scheduler-agent")
+       ~recurrence:
+         (Schedule_domain.Daily
+            { hour = 9; minute = 0; second = 0; timezone = "Asia/Seoul" })
+       ()
       : Schedule_domain.schedule_request);
   ignore
     (create_schedule_exn config ~schedule_id:"sched-approval" ~due_at:300.0
        ~risk_class:Schedule_domain.Workspace_write ~requested_by:(human "operator")
        ~scheduled_by:(automated "scheduler-agent")
+       ()
       : Schedule_domain.schedule_request);
   let json =
     Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
@@ -172,7 +224,7 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
   let open Yojson.Safe.Util in
   check string "schema" "masc.dashboard.scheduled_automation.v1"
     (json |> member "schema" |> to_string);
-  check int "request count" 2 (json |> member "request_count" |> to_int);
+  check int "request count" 3 (json |> member "request_count" |> to_int);
   check string "fsm state" "pending_approval"
     (json |> member "fsm" |> member "state" |> to_string);
   check int "pending count" 1
@@ -180,7 +232,27 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
   check int "scheduled count" 1
     (json |> member "counts" |> member "scheduled" |> to_int);
   check int "due effective count" 1
-    (json |> member "derived_counts" |> member "due_effective" |> to_int)
+    (json |> member "derived_counts" |> member "due_effective" |> to_int);
+  let requests = json |> member "requests" |> to_list in
+  (match requests with
+   | first :: _ ->
+     check string "recurrence kind" "daily"
+       (first |> member "recurrence_kind" |> to_string);
+     check string "recurrence object kind" "daily"
+       (first |> member "recurrence" |> member "kind" |> to_string)
+   | [] -> fail "expected dashboard requests");
+  let exec_row =
+    List.find_opt
+      (fun row -> String.equal (row |> member "schedule_id" |> to_string) "sched-exec")
+      requests
+  in
+  match exec_row with
+  | None -> fail "sched-exec missing from dashboard projection"
+  | Some row ->
+    check string "last execution status" "succeeded"
+      (row |> member "last_execution" |> member "status" |> to_string);
+    check string "last execution detail" "test.exec"
+      (row |> member "last_execution" |> member "detail" |> member "kind" |> to_string)
 ;;
 
 let () =
@@ -190,6 +262,8 @@ let () =
             test_schema_and_descriptor_exposed
         ; test_case "dispatch create persists schedule" `Quick
             test_dispatch_create_persists_schedule
+        ; test_case "dispatch create persists recurrence" `Quick
+            test_dispatch_create_persists_recurrence
         ; test_case "dispatch cancel persists status" `Quick
             test_dispatch_cancel_persists_status
         ; test_case "dashboard projection surfaces schedule FSM" `Quick


### PR DESCRIPTION
## Summary
- add schedule recurrence support for one-shot, interval, and daily fixed-offset schedules
- add optional Schedule_runner consumer dispatch with durable generic execution records
- add MASC server scheduled consumer for approved masc.board_post payloads
- surface recurrence and last execution evidence in schedule tools and dashboard

## Validation
- git diff --check
- dashboard: pnpm typecheck
- dashboard: pnpm exec eslint src/api/dashboard.ts src/components/tools/scheduled-automation-panel.ts src/components/tools/tools-main.test.ts
- dashboard: pnpm exec vitest run --config vitest.config.ts src/components/tools/tools-main.test.ts --no-file-parallelism --maxWorkers=1
- schedule executables: test_schedule_domain/store/service/runner/consumer_dispatch/tool_wiring all passed

## Notes
- focused Dune build passed earlier in this worktree; latest rerun on this exact commit was blocked by an active sibling worktree holding /tmp/me-dune-local.lock after a comment-only lib/schedule/dune tweak