### PR TITLE
[codex] Refresh Ollama Cloud OAS projection + visual_first modality

### DIFF
--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -9,10 +9,10 @@ code_refs:
 
 # Product Operating Plan
 
-> Current package version: v0.19.46
-> Latest changelog entry: v0.19.46 (2026-06-18)
+> Current package version: v0.19.47
+> Latest changelog entry: v0.19.47 (2026-06-20)
 > Latest published GitHub release: v0.19.45 (2026-06-17)
-> Updated: 2026-06-18
+> Updated: 2026-06-20
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history
 
 Execution companion for capsule-only workspace collaboration hardening:

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -11,7 +11,7 @@ code_refs:
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
 > Last Updated: 2026-05-24
-> Snapshot baseline: `dune-project` version `0.19.46`
+> Snapshot baseline: `dune-project` version `0.19.47`
 
 MASC (Multi-Agent Shared Context)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Agent-LLM-A, Provider-F, Agent-Code, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Workspace 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, dashboard/operator read visibility를 제공하며, MCP JSON-RPC 프로토콜을 통해 주요 AI IDE/CLI와 통합된다. Retired orchestration surfaces and internal references remain only as migration context.
 

--- a/oas-models.toml
+++ b/oas-models.toml
@@ -1,4 +1,5 @@
 # MASC runtime seed model catalog for OAS capability lookup.
+# Provenance: the canonical full catalog lives in ../oas/models.toml.
 #
 # OAS discovers this file by walking cwd parents for oas-models.toml. This is a
 # runtime-binding projection scoped to models referenced by config/runtime.toml,

--- a/oas-models.toml
+++ b/oas-models.toml
@@ -1,8 +1,11 @@
 # MASC runtime seed model catalog for OAS capability lookup.
 #
-# OAS discovers this file by walking cwd parents for oas-models.toml. Keep this
-# catalog scoped to models referenced by config/runtime.toml; provider/model
-# capability interpretation remains in OAS.
+# OAS discovers this file by walking cwd parents for oas-models.toml. This is a
+# runtime-binding projection scoped to models referenced by config/runtime.toml,
+# not a full mirror of the canonical OAS models.toml catalog. Provider/model
+# capability interpretation remains in OAS; provider-qualified rows here exist
+# to validate MASC runtime bindings without redefining global bare-model
+# semantics.
 
 # DeepSeek Models
 [[models]]

--- a/oas-models.toml
+++ b/oas-models.toml
@@ -61,6 +61,7 @@ thinking_control_format = "thinking_object"
 supports_response_format_json = true
 supports_structured_output = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 # GLM Models

--- a/oas-models.toml
+++ b/oas-models.toml
@@ -247,6 +247,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -261,6 +262,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -275,6 +277,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -289,6 +292,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -303,6 +307,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -317,6 +322,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -415,6 +421,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -429,6 +436,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -443,6 +451,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -499,6 +508,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_response_format_json = true
 supports_structured_output = true
 supports_native_streaming = true
@@ -515,6 +525,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -529,6 +540,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -543,6 +555,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -557,6 +570,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -641,6 +655,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -714,6 +729,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -728,6 +744,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -742,6 +759,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -756,6 +774,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -770,6 +789,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -784,6 +804,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -868,6 +889,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -882,6 +904,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -896,6 +919,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -952,6 +976,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -966,6 +991,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -980,6 +1006,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -994,6 +1021,7 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
@@ -1078,6 +1106,7 @@ supports_reasoning_budget = true
 thinking_control_format = "reasoning_effort"
 supports_multimodal_inputs = true
 supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]

--- a/oas-models.toml
+++ b/oas-models.toml
@@ -131,6 +131,36 @@ supports_seed = true
 input_per_million = 0.0
 output_per_million = 0.0
 
+# RunPod Models
+
+[[models]]
+id_prefix = "runpod_mtp/qwen36-35b-a3b-mtp"
+base = "openai_chat"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "chat_template_kwargs"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "qwen36-35b-a3b-mtp"
+base = "openai_chat"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "chat_template_kwargs"
+supports_multimodal_inputs = false
+supports_image_input = false
+supports_native_streaming = true
+
 # Ollama Cloud Models (canonical 2026-06 seed)
 # Source: https://ollama.com/api/tags + /api/show, checked 2026-06-20 KST.
 # Provider-qualified entries preserve Ollama Cloud wire behavior when a model id overlaps another provider.

--- a/scripts/audit-ollama-cloud-catalog.py
+++ b/scripts/audit-ollama-cloud-catalog.py
@@ -182,7 +182,7 @@ def oas_catalog(
         raise RuntimeError("oas-models.toml: [[models]] must parse as an array")
 
     provider_qualified: dict[str, dict[str, Any]] = {}
-    bare_membership: set[str] = set()
+    bare_prefixes: set[str] = set()
     for row in rows:
         if not isinstance(row, dict):
             raise RuntimeError(f"oas-models.toml: malformed model row {row!r}")
@@ -192,8 +192,8 @@ def oas_catalog(
         if id_prefix.startswith("ollama_cloud/"):
             provider_qualified[id_prefix.removeprefix("ollama_cloud/")] = row
         elif "/" not in id_prefix:
-            bare_membership.add(id_prefix)
-    return provider_qualified, bare_membership
+            bare_prefixes.add(id_prefix)
+    return provider_qualified, bare_prefixes
 
 
 def check_catalog(
@@ -204,7 +204,7 @@ def check_catalog(
     official_by_name = {model.name: model for model in official}
     official_names = set(official_by_name)
     runtime_api_to_slug, runtime_bindings, runtime_models = runtime_catalog(runtime)
-    oas_provider_qualified, oas_bare = oas_catalog(oas_models)
+    oas_provider_qualified, oas_bare_prefixes = oas_catalog(oas_models)
 
     errors: list[str] = []
     runtime_names = set(runtime_api_to_slug)
@@ -220,8 +220,13 @@ def check_catalog(
         errors.append(
             f"OAS provider-qualified model no longer official: ollama_cloud/{name}"
         )
-    for name in sorted(official_names - oas_bare):
-        errors.append(f"missing OAS bare membership model: {name}")
+    oas_bare_route_names = {
+        name
+        for name in official_names
+        if any(name.startswith(prefix) for prefix in oas_bare_prefixes)
+    }
+    for name in sorted(official_names - oas_bare_route_names):
+        errors.append(f"missing OAS bare route model: {name}")
 
     for name, model in sorted(official_by_name.items()):
         slug = runtime_api_to_slug.get(name)
@@ -307,7 +312,8 @@ def check_catalog(
             1 for slug in runtime_bindings if slug.startswith("ollama-cloud-")
         ),
         "oas_provider_qualified_count": len(oas_provider_names),
-        "oas_bare_membership_count": len(official_names & oas_bare),
+        "oas_bare_exact_membership_count": len(official_names & oas_bare_prefixes),
+        "oas_bare_route_count": len(oas_bare_route_names),
         "vision_models": vision_models,
     }
     return report, errors
@@ -321,7 +327,8 @@ def print_text_report(report: dict[str, Any], errors: list[str]) -> None:
     print(f"runtime_canonical_count={report['runtime_canonical_count']}")
     print(f"runtime_binding_count={report['runtime_binding_count']}")
     print(f"oas_provider_qualified_count={report['oas_provider_qualified_count']}")
-    print(f"oas_bare_membership_count={report['oas_bare_membership_count']}")
+    print(f"oas_bare_exact_membership_count={report['oas_bare_exact_membership_count']}")
+    print(f"oas_bare_route_count={report['oas_bare_route_count']}")
     print("vision_models=" + ",".join(report["vision_models"]))
     if errors:
         print("status=FAIL")

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -383,6 +383,47 @@ let test_repo_runtime_bindings_resolve_through_oas_catalog () =
          | Some _ -> ())
       runtimes
 
+let test_repo_oas_model_catalog_modality_priorities_resolve () =
+  with_repo_oas_model_catalog @@ fun catalog ->
+  let rows =
+    List.filter
+      (fun (entry : Llm_provider.Model_catalog.model_entry) ->
+         Option.is_some entry.modality_priority)
+      catalog
+  in
+  check bool "repo OAS catalog has modality priority rows" true (rows <> []);
+  List.iter
+    (fun (entry : Llm_provider.Model_catalog.model_entry) ->
+       match entry.modality_priority with
+       | None -> ()
+       | Some raw ->
+         let expected =
+           match String.lowercase_ascii (String.trim raw) with
+           | "visual_first" | "visual-first" -> Llm_provider.Modality.Visual_first
+           | "preserve_input_order" | "preserve-input-order" | "preserve" ->
+             Llm_provider.Modality.Preserve_input_order
+           | normalized ->
+             failf
+               "unsupported modality_priority %S (normalized %S) in %s"
+               raw
+               normalized
+               entry.id_prefix
+         in
+         (match
+            Llm_provider.Capabilities.for_model_id_catalog entry.id_prefix
+          with
+          | None ->
+            failf
+              "modality_priority row %s must resolve through repo OAS catalog"
+              entry.id_prefix
+          | Some caps ->
+            check
+              bool
+              (entry.id_prefix ^ " modality_priority resolves")
+              true
+              (caps.modality_priority = expected)))
+    rows
+
 let test_repo_runtime_toml_loads () =
   let path = Filename.concat (repo_root ()) "config/runtime.toml" in
   check bool "repo runtime.toml present" true (Sys.file_exists path);
@@ -901,6 +942,9 @@ let () =
           test_case
             "repo runtime bindings resolve through the OAS catalog"
             `Quick test_repo_runtime_bindings_resolve_through_oas_catalog;
+          test_case
+            "repo OAS catalog modality priority strings resolve"
+            `Quick test_repo_oas_model_catalog_modality_priorities_resolve;
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
           test_case

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -326,6 +326,45 @@ let test_runtime_json_not_in_repo_config () =
   let path = Filename.concat (repo_root ()) "config/runtime.json" in
   check bool "retired runtime.json absent" false (Sys.file_exists path)
 
+let with_repo_oas_model_catalog f =
+  let path = Filename.concat (repo_root ()) "oas-models.toml" in
+  check bool "repo oas-models.toml present" true (Sys.file_exists path);
+  match Llm_provider.Model_catalog.load_file path with
+  | Error msg -> failf "repo oas-models.toml should load: %s" msg
+  | Ok catalog ->
+    Fun.protect
+      ~finally:Llm_provider.Model_catalog.clear_global
+      (fun () ->
+         Llm_provider.Model_catalog.set_global catalog;
+         f catalog)
+
+let test_repo_oas_model_catalog_covers_live_runpod_mtp () =
+  with_repo_oas_model_catalog @@ fun catalog ->
+  let expect_lookup model_id =
+    match Llm_provider.Model_catalog.lookup catalog model_id with
+    | None -> failf "expected repo OAS catalog row for %s" model_id
+    | Some entry ->
+      check (option string) (model_id ^ " base") (Some "openai_chat")
+        entry.base_label
+  in
+  expect_lookup "runpod_mtp/qwen36-35b-a3b-mtp";
+  expect_lookup "qwen36-35b-a3b-mtp";
+  match
+    Llm_provider.Capabilities.for_model_id_catalog
+      "runpod_mtp/qwen36-35b-a3b-mtp"
+  with
+  | None -> fail "expected RunPod qwen3.6 capability lookup"
+  | Some caps ->
+    check (option int) "RunPod qwen3.6 context" (Some 131072)
+      caps.max_context_tokens;
+    check bool "RunPod qwen3.6 tools" true caps.supports_tools;
+    check bool "RunPod qwen3.6 tool choice" true caps.supports_tool_choice;
+    check bool "RunPod qwen3.6 extended thinking" true
+      caps.supports_extended_thinking;
+    check bool "RunPod qwen3.6 chat-template thinking" true
+      (Llm_provider.Capabilities.(
+         caps.thinking_control_format = Chat_template_kwargs))
+
 let test_repo_runtime_toml_loads () =
   let path = Filename.concat (repo_root ()) "config/runtime.toml" in
   check bool "repo runtime.toml present" true (Sys.file_exists path);
@@ -839,6 +878,8 @@ let () =
     [ ( "runtime TOML gate",
         [ test_case "runtime.json is not a repo config source" `Quick
             test_runtime_json_not_in_repo_config;
+          test_case "repo OAS catalog covers live RunPod MTP runtime" `Quick
+            test_repo_oas_model_catalog_covers_live_runpod_mtp;
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
           test_case

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -365,6 +365,24 @@ let test_repo_oas_model_catalog_covers_live_runpod_mtp () =
       (Llm_provider.Capabilities.(
          caps.thinking_control_format = Chat_template_kwargs))
 
+let test_repo_runtime_bindings_resolve_through_oas_catalog () =
+  with_repo_oas_model_catalog @@ fun catalog ->
+  let path = Filename.concat (repo_root ()) "config/runtime.toml" in
+  match Runtime.load_list ~config_path:path with
+  | Error msg -> failf "repo runtime.toml should load: %s" msg
+  | Ok (runtimes, _default, _assignments, _librarian, _cross_verifier, _media_failover) ->
+    check bool "at least one runtime binding" true (List.length runtimes > 0);
+    List.iter
+      (fun (runtime : Runtime.t) ->
+         let model_id = runtime.model.api_name in
+         match Llm_provider.Model_catalog.lookup catalog model_id with
+         | None ->
+           failf
+             "runtime binding %s model %s must resolve through repo OAS catalog"
+             runtime.id model_id
+         | Some _ -> ())
+      runtimes
+
 let test_repo_runtime_toml_loads () =
   let path = Filename.concat (repo_root ()) "config/runtime.toml" in
   check bool "repo runtime.toml present" true (Sys.file_exists path);
@@ -880,6 +898,9 @@ let () =
             test_runtime_json_not_in_repo_config;
           test_case "repo OAS catalog covers live RunPod MTP runtime" `Quick
             test_repo_oas_model_catalog_covers_live_runpod_mtp;
+          test_case
+            "repo runtime bindings resolve through the OAS catalog"
+            `Quick test_repo_runtime_bindings_resolve_through_oas_catalog;
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
           test_case


### PR DESCRIPTION
## Summary

- Refresh the MASC-local OAS projection in `oas-models.toml` for the official Ollama Cloud runtime bindings: 35 official models, 15 vision-capable models.
- Add runtime config coverage so every `ollama_cloud` runtime binding in `config/runtime.toml` must have matching MASC-local OAS catalog coverage.
- Add `modality_priority = "visual_first"` to MASC-local Ollama Cloud rows that support image input, including the bare `minimax-m3` row.
- Add a runtime validity gate that checks every repo OAS catalog `modality_priority` string resolves to the expected MASC runtime modality variant instead of silently falling back.
- Keep the OAS/MASC boundary intact: OAS `models.toml` is the canonical provider/model catalog; MASC `oas-models.toml` is a runtime-binding projection used to validate MASC runtime bindings without redefining global bare-model semantics.
- Update the live audit script so Ollama Cloud wire coverage is proven by provider-qualified `ollama_cloud/<model>` rows, while bare route coverage is tracked separately for runtime membership/prefix routing.
- Sync product/spec doc truth after the repo version moved to `0.19.47`.

## Evidence

- [근거] Official sources: `https://ollama.com/api/tags`, `https://ollama.com/api/show`; checked `2026-06-21T04:21:29+09:00`; confidence High.
- `python3 scripts/audit-ollama-cloud-catalog.py --runtime /Users/dancer/me/.masc/config/runtime.toml --oas-models /Users/dancer/me/workspace/yousleepwhen/masc/oas-models.toml`
  - `official_count=35`
  - `official_vision_count=15`
  - `runtime_canonical_count=35`
  - `runtime_binding_count=35`
  - `oas_provider_qualified_count=35`
  - `oas_bare_exact_membership_count=35`
  - `oas_bare_route_count=35`
  - `vision_models=devstral-small-2:24b,gemini-3-flash-preview,gemma3:12b,gemma3:27b,gemma3:4b,gemma4:31b,kimi-k2.5,kimi-k2.6,kimi-k2.7-code,minimax-m3,ministral-3:14b,ministral-3:3b,ministral-3:8b,mistral-large-3:675b,qwen3.5:397b`
  - `status=OK`
- `python3 -m py_compile scripts/audit-ollama-cloud-catalog.py`
- `python3 -c 'import tomllib; tomllib.load(open("oas-models.toml", "rb")); print("oas-models.toml: OK")'`
- `git diff --check`
- `bash scripts/check-doc-truth.sh`
  - `Version truth OK: package=0.19.47 changelog_entry=0.19.47 published_release=0.19.45`
  - `Doc truth OK: front-door docs and key specs are aligned with current repo truth`
  - `Doc code_refs OK: every frontmatter code_refs path exists in the repo`

## CI

- Current GitHub Actions run: https://github.com/jeong-sik/masc/actions/runs/27878576109
  - `headSha=152fb40182bfe898a168703de8c7b83c5c761805`
  - `conclusion=success`
  - Passed jobs: `PR Sync Check`, `PR Live Gate`, `Detect Changed Surfaces`, `OCaml Structure Ratchet`, `Lint`, `Build and Test`, `Dashboard`, `TLA+ Model Checking`, `Health`, `Shell IR Consumption Ratchet`, `Meta Guards`, and `CI Gate`.
- OAS catalog PR is tracked separately in https://github.com/jeong-sik/oas/pull/2164.

Local build/test intentionally not run per operator direction; MASC CI is the build/test authority for this PR head.

## Live Runtime

- Merged in https://github.com/jeong-sik/masc/pull/21670 at `2026-06-20T18:27:13Z`; merge commit `94728ff19e6cdbccd5ee58defa7f1470d12fad06`.
- `/health?full=1` shows live MASC running from `/Users/dancer/me/workspace/yousleepwhen/masc`, effective runtime root `/Users/dancer/me/.masc`, release `0.19.47`, process commit `62358c759b`.
- `git merge-base --is-ancestor 94728ff19e6cdbccd5ee58defa7f1470d12fad06 62358c759b` confirms the live process commit contains this PR merge.
- Live runtime config audit against `/Users/dancer/me/.masc/config/runtime.toml` and the merged MASC `oas-models.toml` returned `status=OK`.
