### PR TITLE
Clarify schedule daily timezone contract

### DIFF
--- a/lib/schedule/schedule_domain.ml
+++ b/lib/schedule/schedule_domain.ml
@@ -336,6 +336,9 @@ let validate_interval interval_sec =
   else Ok interval_sec
 ;;
 
+(* Daily recurrence intentionally uses fixed offsets only. This keeps dispatch
+   deterministic across host timezone changes and avoids pretending to support
+   DST-aware IANA zone rules. *)
 let timezone_offset_seconds timezone =
   let parse_fixed_offset raw =
     let len = String.length raw in
@@ -382,7 +385,7 @@ let validate_daily ~hour ~minute ~second ~timezone =
     | Some _ -> Ok (Daily { hour; minute; second; timezone })
     | None ->
       Error
-        "recurrence.timezone must be UTC, Asia/Seoul, KST, or a fixed offset like +09:00")
+        "recurrence.timezone must be UTC, Asia/Seoul, KST, or a fixed offset like +09:00; DST-aware IANA zones are not supported")
 ;;
 
 let validate_recurrence = function

--- a/lib/schedule/schedule_domain.mli
+++ b/lib/schedule/schedule_domain.mli
@@ -40,6 +40,12 @@ type schedule_source =
   | Automated_request
   | System_request
 
+(** Recurrence contract.
+
+    [Daily.timezone] is a fixed-offset selector, not full civil-timezone
+    support. It accepts UTC aliases, Asia/Seoul/KST as +09:00 aliases, and
+    explicit fixed offsets such as [+09:00] or [UTC+09:00]. It never consults
+    host local time or DST rules. *)
 type recurrence =
   | One_shot
   | Interval of { interval_sec : int }

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -132,7 +132,7 @@ let create_schema =
         "recurrence_second"
     ; string_prop
         ~description:
-          "Required when recurrence_kind is daily. Supported values: UTC, Asia/Seoul, KST, or a fixed offset like +09:00."
+          "Required when recurrence_kind is daily. Fixed-offset only: UTC, Asia/Seoul/KST as +09:00 aliases, or offsets like +09:00/UTC+09:00. DST-aware IANA zones are not supported."
         "recurrence_timezone"
     ; string_prop ~description:"Requester actor id. Defaults to operator." "requested_by_id"
     ; string_prop ~enum:actor_kinds "requested_by_kind"

--- a/test/test_schedule_domain.ml
+++ b/test/test_schedule_domain.ml
@@ -176,7 +176,7 @@ let test_interval_recurrence_next_due () =
   | Some due_at -> check (float 0.001) "next due" 260.0 due_at
 ;;
 
-let test_daily_recurrence_next_due_uses_timezone () =
+let test_daily_recurrence_next_due_uses_fixed_offset_alias () =
   let req =
     request ~risk_class:Read_only
       ~recurrence:
@@ -186,6 +186,35 @@ let test_daily_recurrence_next_due_uses_timezone () =
   match next_due_after ~now:1.0 req with
   | None -> fail "expected next daily due"
   | Some due_at -> check (float 0.001) "next KST 09:00" 86400.0 due_at
+;;
+
+let test_daily_recurrence_next_due_accepts_explicit_fixed_offset () =
+  let req =
+    request ~risk_class:Read_only
+      ~recurrence:
+        (Daily { hour = 9; minute = 0; second = 0; timezone = "+09:00" })
+      ()
+  in
+  match next_due_after ~now:1.0 req with
+  | None -> fail "expected next daily due"
+  | Some due_at -> check (float 0.001) "next +09:00 09:00" 86400.0 due_at
+;;
+
+let test_daily_recurrence_rejects_dst_iana_timezone () =
+  match
+    create_request ~schedule_id:"sched-1" ~requested_by:(human "requester")
+      ~scheduled_by:(human "scheduler") ~requested_at:100.0 ~due_at:200.0
+      ~payload:(payload_json ()) ~risk_class:Read_only
+      ~approval_required:false ~source:Operator_request
+      ~recurrence:
+        (Daily { hour = 9; minute = 0; second = 0; timezone = "America/New_York" })
+      ()
+  with
+  | Ok _ -> fail "expected DST-aware IANA timezone rejection"
+  | Error msg ->
+    check string "timezone error"
+      "recurrence.timezone must be UTC, Asia/Seoul, KST, or a fixed offset like +09:00; DST-aware IANA zones are not supported"
+      msg
 ;;
 
 let test_schedule_roundtrip () =
@@ -276,8 +305,12 @@ let () =
             test_mark_due_only_scheduled;
           test_case "interval recurrence next due" `Quick
             test_interval_recurrence_next_due;
-          test_case "daily recurrence next due uses timezone" `Quick
-            test_daily_recurrence_next_due_uses_timezone;
+          test_case "daily recurrence next due uses fixed-offset alias" `Quick
+            test_daily_recurrence_next_due_uses_fixed_offset_alias;
+          test_case "daily recurrence next due accepts explicit fixed offset" `Quick
+            test_daily_recurrence_next_due_accepts_explicit_fixed_offset;
+          test_case "daily recurrence rejects DST IANA timezone" `Quick
+            test_daily_recurrence_rejects_dst_iana_timezone;
         ] );
       ( "grant",
         [


### PR DESCRIPTION
## Summary
- document daily schedule recurrence as fixed-offset only, not full civil-timezone/DST support
- clarify the tool schema description for recurrence_timezone
- add tests for explicit fixed offsets and DST-aware IANA timezone rejection

Follow-up to #21669 after the scheduling recurrence integration merged.

## Verification
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_schedule_domain.exe
- ./_build/default/test/test_schedule_domain.exe