### PR TITLE
[codex] fix memory os episode bundle consistency

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -410,44 +410,44 @@ let extract_and_append_with_provider
   | Error _ as e -> e
   | Ok episode ->
     let now = episode.Keeper_memory_os_types.created_at in
-    (* RFC-0243: persist the episode log (unique episode file + event), then
-       UPSERT its claims into the fact store instead of blind-appending. A claim
+    (* RFC-0243: UPSERT claims into the fact store instead of blind-appending. A claim
        re-extracted across turns is folded into the existing row
        (Keeper_memory_os_policy.reobserve_fact: RFC-0247 refreshes
        [last_verified_at] only) rather than accumulating as a duplicate. The same
        call applies the RFC-0239 Q4 retention cap (ranked by the structural
-       [retention_rank]) in one atomic rewrite. The episode log already retains
-       the raw claims, but a fact-merge failure is still reported to the caller so
-       the turn is not counted as a clean librarian write. *)
-    Keeper_memory_os_io.append_episode ~keeper_id episode;
-    Keeper_memory_os_io.append_event ~keeper_id episode;
-    (match
-       try
-         let window = Keeper_memory_os_io.fact_recall_window in
-         let (_ : Keeper_memory_os_io.fact_merge_stats) =
-           File_lock_eio.with_lock ?clock (Keeper_memory_os_io.facts_path ~keeper_id) (fun () ->
-             Keeper_memory_os_io.merge_and_cap_facts
-               ~keeper_id
-               ~merge:(Keeper_memory_os_policy.reobserve_fact ~now)
-               ~incoming:episode.Keeper_memory_os_types.claims
-               ~keep:window
-               ~trigger:Keeper_memory_os_io.fact_store_max
-               ~rank:(Keeper_memory_os_policy.retention_rank ~now))
-         in
-         Ok ()
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-         let message = Printexc.to_string exn in
-         Log.Keeper.warn "memory os fact upsert failed keeper=%s: %s" keeper_id message;
-         Error message
-     with
-     | Ok () ->
-       (* RFC-0251: the co-occurrence edge / spreading-activation organ was removed
-          (dark-by-default, no recall consumer), so the fact upsert above is the only
-          post-merge work. *)
-       Ok episode
-     | Error message -> Error ("memory os fact upsert failed: " ^ message))
+       [retention_rank]) in one atomic rewrite. Only after the facts are durable
+       do we publish the episode file and append the event row; the event row is
+       the reader-visible commit marker for [read_episodes_tail]. *)
+    Keeper_memory_os_io.with_episode_bundle_lock ?clock ~keeper_id (fun () ->
+      match
+        try
+          let window = Keeper_memory_os_io.fact_recall_window in
+          let (_ : Keeper_memory_os_io.fact_merge_stats) =
+            File_lock_eio.with_lock ?clock (Keeper_memory_os_io.facts_path ~keeper_id) (fun () ->
+              Keeper_memory_os_io.merge_and_cap_facts
+                ~keeper_id
+                ~merge:(Keeper_memory_os_policy.reobserve_fact ~now)
+                ~incoming:episode.Keeper_memory_os_types.claims
+                ~keep:window
+                ~trigger:Keeper_memory_os_io.fact_store_max
+                ~rank:(Keeper_memory_os_policy.retention_rank ~now))
+          in
+          Ok ()
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          let message = Printexc.to_string exn in
+          Log.Keeper.warn "memory os fact upsert failed keeper=%s: %s" keeper_id message;
+          Error message
+      with
+      | Ok () ->
+        Keeper_memory_os_io.append_episode ~keeper_id episode;
+        Keeper_memory_os_io.append_event ~keeper_id episode;
+        (* RFC-0251: the co-occurrence edge / spreading-activation organ was removed
+           (dark-by-default, no recall consumer), so the fact upsert above is the only
+           post-merge work. *)
+        Ok episode
+      | Error message -> Error ("memory os fact upsert failed: " ^ message))
 ;;
 
 let provider_for_runtime ~runtime_id =

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -70,6 +70,14 @@ let events_path ~keeper_id =
   Filename.concat (keepers_dir ()) (keeper_id ^ ".events.jsonl")
 ;;
 
+let episode_bundle_lock_path ~keeper_id =
+  Filename.concat (keepers_dir ()) (keeper_id ^ ".episode-bundle")
+;;
+
+let with_episode_bundle_lock ?clock ~keeper_id f =
+  File_lock_eio.with_lock ?clock (episode_bundle_lock_path ~keeper_id) f
+;;
+
 let episodes_dir ~keeper_id =
   let d = Filename.concat (keepers_dir ()) (Filename.concat keeper_id "episodes") in
   ensure_dir d;
@@ -241,9 +249,11 @@ let append_episode ~keeper_id episode =
 ;;
 
 let append_episode_bundle ~keeper_id episode =
-  append_episode ~keeper_id episode;
-  append_event ~keeper_id episode;
-  List.iter (append_fact ~keeper_id) episode.claims
+  with_episode_bundle_lock ~keeper_id (fun () ->
+    File_lock_eio.with_lock (facts_path ~keeper_id) (fun () ->
+      List.iter (append_fact ~keeper_id) episode.claims);
+    append_episode ~keeper_id episode;
+    append_event ~keeper_id episode)
 ;;
 
 let rewrite_facts_atomically ~keeper_id facts =

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -35,6 +35,13 @@ val next_generation_with_floor : floor:int -> keeper_id:string -> trace_id:strin
 val append_fact : keeper_id:string -> fact -> unit
 val append_event : keeper_id:string -> episode -> unit
 val append_episode : keeper_id:string -> episode -> unit
+
+(** Serialize a cross-file episode bundle write for one keeper. Callers that
+    write facts plus episode/event artifacts should take this before the facts
+    lock, then publish [events_path] last as the reader-visible commit marker. *)
+val with_episode_bundle_lock :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t -> keeper_id:string -> (unit -> 'a) -> 'a
+
 val append_episode_bundle : keeper_id:string -> episode -> unit
 val rewrite_facts_atomically : keeper_id:string -> fact list -> unit
 val save_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t -> unit

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -927,7 +927,15 @@ let test_librarian_runtime_reports_fact_upsert_failure () =
           Alcotest.(check bool)
             "fact upsert error returned to caller"
             true
-            (contains "memory os fact upsert failed" msg))))
+            (contains "memory os fact upsert failed" msg);
+          Alcotest.(check int)
+            "episode file not published on fact failure"
+            0
+            (json_episode_file_count ~keeper_id);
+          Alcotest.(check int)
+            "event not published on fact failure"
+            0
+            (List.length (Memory_io.read_events_tail ~keeper_id ~n:10)))))
 ;;
 
 
@@ -1131,6 +1139,58 @@ let test_jsonl_tail_reads_last_entries () =
         second.Types.episode_summary
         event.Types.episode_summary
     | events -> Alcotest.failf "expected one event, got %d" (List.length events))
+;;
+
+let test_append_episode_bundle_waits_for_fact_lock () =
+  with_eio (fun ~sw ~net:_ ~clock ->
+    with_eio_guard (fun () ->
+      with_temp_keepers_dir (fun _keepers_dir ->
+        let keeper_id = "bundle-lock-keeper" in
+        let episode =
+          episode_fixture
+            ~now:1_000_000.0
+            ~trace_id:"trace-bundle"
+            ~generation:1
+            ~summary:"locked bundle"
+        in
+        let result = ref None in
+        let started, resolve_started = Eio.Promise.create () in
+        File_lock_eio.with_lock (Memory_io.facts_path ~keeper_id) (fun () ->
+          Eio.Fiber.fork ~sw (fun () ->
+            Eio.Promise.resolve resolve_started ();
+            Memory_io.append_episode_bundle ~keeper_id episode;
+            result := Some ());
+          Eio.Promise.await started;
+          Eio.Time.sleep clock 0.02;
+          Alcotest.(check bool)
+            "bundle waits while fact store lock is held"
+            true
+            (Option.is_none !result);
+          Alcotest.(check int)
+            "facts not visible before lock release"
+            0
+            (List.length (Memory_io.read_facts_tail ~keeper_id ~n:10));
+          Alcotest.(check int)
+            "events not visible before lock release"
+            0
+            (List.length (Memory_io.read_events_tail ~keeper_id ~n:10));
+          Alcotest.(check int)
+            "episodes not visible before lock release"
+            0
+            (List.length (Memory_io.read_episodes_tail ~keeper_id ~n:10)));
+        wait_for_ref ~clock "bundle append after fact lock" result;
+        Alcotest.(check int)
+          "fact visible after lock release"
+          1
+          (List.length (Memory_io.read_facts_tail ~keeper_id ~n:10));
+        Alcotest.(check int)
+          "event visible after lock release"
+          1
+          (List.length (Memory_io.read_events_tail ~keeper_id ~n:10));
+        Alcotest.(check int)
+          "episode visible after lock release"
+          1
+          (List.length (Memory_io.read_episodes_tail ~keeper_id ~n:10)))))
 ;;
 
 (* RFC-0247 (purge): GC is two structural passes — hard-expire past-TTL facts and
@@ -2603,6 +2663,10 @@ let () =
             "jsonl tail reads last entries"
             `Quick
             test_jsonl_tail_reads_last_entries
+        ; Alcotest.test_case
+            "episode bundle waits for fact lock"
+            `Quick
+            test_append_episode_bundle_waits_for_fact_lock
         ; Alcotest.test_case
             "gc dry-run and rewrite"
             `Quick


### PR DESCRIPTION
## Summary

- serialize Memory OS episode bundle publication with a per-keeper bundle lock
- write facts before episode artifacts and publish the event row last as the reader-visible commit marker
- apply the same ordering to the librarian runtime write path so fact-upsert failures do not leave episode/event artifacts
- add regression coverage for bundle lock waiting and failure-path non-publication

## Validation

- `scripts/dune-local.sh build ./test/test_keeper_memory_os.exe`
- `./_build/default/test/test_keeper_memory_os.exe` (68 tests)
- `ocamlformat --check lib/keeper/keeper_memory_os_io.ml lib/keeper/keeper_memory_os_io.mli lib/keeper/keeper_librarian_runtime.ml test/test_keeper_memory_os.ml`
- `git diff --check`
- `bash scripts/ci/check-determinism-contract.sh`

## Notes

This addresses the adversarial-audit finding around non-atomic multi-file episode bundle publication by narrowing the visible partial-write window: facts are persisted first, then the episode file, then the event log row that `read_episodes_tail` normally consumes.