### PR TITLE
feat(memory-os): RFC-0259 P4 — recall suppression of unverified-volatile

### DIFF
--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -103,36 +103,85 @@ let staleness_marker ~now (fact : fact) =
     | None -> Printf.sprintf " [stale: unverified, seen %s ago — verify]" age_text)
 ;;
 
+(* RFC-0259 §3.5 (P4): a claim that names external state (P1's [external_ref])
+   and has not been re-grounded within the grounding horizon is *unverified
+   volatile* — its truth may have moved on (the closed-PR-still-asserted-open
+   class). Such a claim still passes [fact_is_current] until its (longer) volatile
+   TTL expires, so the gap between horizon and TTL is exactly where recall would
+   otherwise assert a possibly-stale external fact as live. The horizon is the P2
+   reconciler's, so "would be re-grounded by now" and "render as unverified" use
+   the same boundary. A non-volatile fact ([external_ref = None]) is never
+   unverified-volatile, however old — durable knowledge does not decay. *)
+let is_unverified_volatile ~now (fact : fact) =
+  match fact.external_ref with
+  | None -> false
+  | Some _ ->
+    let anchor =
+      match fact.last_verified_at with
+      | Some ts -> ts
+      | None -> fact.first_seen
+    in
+    now -. anchor > Keeper_memory_os_reconcile.default_grounding_horizon_seconds
+;;
+
+(* RFC-0259 §3.5: the hard, non-cosmetic prefix for an unverified-volatile claim.
+   Unlike [staleness_marker] (a trailing " [stale: … verify]" note that still reads
+   as an assertion), this leads the line so the reader sees "re-check" before the
+   claim text — closing gap #5 (the marker that annotated but did not suppress). *)
+let unverified_volatile_prefix = "[UNVERIFIED — re-check before acting] "
+
 (* RFC-0247 (purge): the recall line carries the fact's *structure* — category
    (a typed decision), provenance turn, and the worded staleness marker — but no
    number. The prior line printed [confidence=%.2f score=%.3f]; both were score
    machinery. The reader (an LLM) judges relevance and freshness from the claim
-   text and the staleness marker, not from a rank the producer can't justify. *)
+   text and the staleness marker, not from a rank the producer can't justify.
+   RFC-0259 §3.5: an unverified-volatile claim leads with the hard prefix instead
+   of the soft trailing staleness note. *)
 let render_fact ~now fact =
   let source = fact.source in
-  Printf.sprintf
-    "- [category=%s turn=%d]%s %s"
-    (sanitize_atom (category_to_string fact.category))
-    source.turn
-    (staleness_marker ~now fact)
-    (sanitize_text ~max_len:max_fact_text_len fact.claim)
+  if is_unverified_volatile ~now fact
+  then
+    Printf.sprintf
+      "- %s[category=%s turn=%d] %s"
+      unverified_volatile_prefix
+      (sanitize_atom (category_to_string fact.category))
+      source.turn
+      (sanitize_text ~max_len:max_fact_text_len fact.claim)
+  else
+    Printf.sprintf
+      "- [category=%s turn=%d]%s %s"
+      (sanitize_atom (category_to_string fact.category))
+      source.turn
+      (staleness_marker ~now fact)
+      (sanitize_text ~max_len:max_fact_text_len fact.claim)
 ;;
 
 (* RFC-0244 Tier 2: a shared fact is rendered with its provenance (the distinct
    keepers that corroborated it) so it is never silently merged into the keeper's
-   own knowledge — the reader can see it is cross-keeper consensus. *)
+   own knowledge — the reader can see it is cross-keeper consensus.
+   RFC-0259 §3.5: cross-keeper agreement is not external-truth verification, so an
+   unverified-volatile shared fact gets the same hard prefix as a private one. *)
 let render_shared_fact ~now fact =
   let provenance =
     match fact.observed_by with
     | [] -> "shared"
     | keepers -> "shared via " ^ String.concat "," (List.map sanitize_atom keepers)
   in
-  Printf.sprintf
-    "- [%s category=%s]%s %s"
-    provenance
-    (sanitize_atom (category_to_string fact.category))
-    (staleness_marker ~now fact)
-    (sanitize_text ~max_len:max_fact_text_len fact.claim)
+  if is_unverified_volatile ~now fact
+  then
+    Printf.sprintf
+      "- %s[%s category=%s] %s"
+      unverified_volatile_prefix
+      provenance
+      (sanitize_atom (category_to_string fact.category))
+      (sanitize_text ~max_len:max_fact_text_len fact.claim)
+  else
+    Printf.sprintf
+      "- [%s category=%s]%s %s"
+      provenance
+      (sanitize_atom (category_to_string fact.category))
+      (staleness_marker ~now fact)
+      (sanitize_text ~max_len:max_fact_text_len fact.claim)
 ;;
 
 let render_episode episode =
@@ -221,6 +270,14 @@ let facts_recency_ranked ~now facts =
   |> List.filter (fact_is_current ~now)
   |> List.sort (fun a b -> compare (truth_anchor b) (truth_anchor a))
   |> dedup_by_claim
+  (* RFC-0259 §3.5 (P4): demote unverified-volatile claims below durable ones.
+     [List.partition] is stable, so each group keeps its recency order; durable
+     knowledge therefore leads the recall block and a possibly-stale external claim
+     follows (and is the first to be dropped if [take max_facts] cannot fit them
+     all). Demotion + the hard render prefix together replace the cosmetic marker. *)
+  |> fun ranked ->
+  let durable, volatile = List.partition (fun f -> not (is_unverified_volatile ~now f)) ranked in
+  durable @ volatile
 ;;
 
 (* RFC-0264 P2: render_context_exn returns the rendered block alongside the

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -8,6 +8,7 @@ module Librarian = Masc.Keeper_librarian
 module Librarian_runtime = Masc.Keeper_librarian_runtime
 module Prompt_names = Keeper_prompt_names
 module Recall = Masc.Keeper_memory_os_recall
+module Reconcile = Masc.Keeper_memory_os_reconcile
 module Consolidator = Masc.Keeper_memory_os_consolidator
 
 let contains substring s =
@@ -1477,6 +1478,62 @@ let test_recall_omits_marker_for_fresh_fact () =
             (contains "ago — verify]" block))))
 ;;
 
+(* RFC-0259 §3.5 (P4): an unverified-volatile claim (external_ref set, past the
+   grounding horizon) gets the hard "[UNVERIFIED — re-check before acting]" prefix
+   instead of the soft trailing staleness note — the reader sees "re-check" before
+   the claim, closing gap #5. *)
+let test_recall_prefixes_unverified_volatile_fact () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun keepers_dir ->
+        let keeper_id = "volatile-stale-keeper" in
+        let now = 1_000_000.0 in
+        let horizon = Reconcile.default_grounding_horizon_seconds in
+        let fact =
+          { (fact_fixture ~now ()) with
+            Types.claim = "PR #21515 is blocked and needs a fix"
+          ; Types.external_ref = Some { Types.kind = Types.Pr; id = "21515" }
+          ; Types.first_seen = now -. (horizon *. 2.0)
+          ; Types.last_verified_at = Some (now -. (horizon *. 2.0))
+          ; Types.valid_until = Some (now +. horizon)
+          }
+        in
+        Memory_io.append_fact ~keeper_id fact;
+        match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
+        | None -> Alcotest.fail "expected Some block for a persisted volatile fact"
+        | Some block ->
+          Alcotest.(check bool)
+            "unverified-volatile fact carries the hard prefix"
+            true
+            (contains "[UNVERIFIED — re-check before acting]" block))))
+;;
+
+(* RFC-0259 §3.5: a non-volatile (no external_ref) claim never gets the hard
+   prefix, however old — durable knowledge does not decay into "re-check". *)
+let test_recall_no_prefix_for_non_volatile_fact () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun keepers_dir ->
+        let keeper_id = "durable-old-keeper" in
+        let now = 1_000_000.0 in
+        let fact =
+          { (fact_fixture ~now ()) with
+            Types.claim = "Deployment uses a blue-green strategy"
+          ; Types.external_ref = None
+          ; Types.first_seen = now -. days 30
+          ; Types.last_verified_at = None
+          }
+        in
+        Memory_io.append_fact ~keeper_id fact;
+        match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
+        | None -> Alcotest.fail "expected Some block for a persisted durable fact"
+        | Some block ->
+          Alcotest.(check bool)
+            "durable fact never carries the unverified-volatile prefix"
+            false
+            (contains "[UNVERIFIED — re-check before acting]" block))))
+;;
+
 let test_recall_filters_expired_episodes () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
@@ -2548,6 +2605,14 @@ let () =
             "fresh fact gets no staleness marker"
             `Quick
             test_recall_omits_marker_for_fresh_fact
+        ; Alcotest.test_case
+            "unverified-volatile fact gets the hard prefix"
+            `Quick
+            test_recall_prefixes_unverified_volatile_fact
+        ; Alcotest.test_case
+            "non-volatile fact never gets the hard prefix"
+            `Quick
+            test_recall_no_prefix_for_non_volatile_fact
         ; Alcotest.test_case
             "expired episodes are omitted"
             `Quick


### PR DESCRIPTION
## RFC-0259 P4 — recall suppression of unverified-volatile claims

RFC: `docs/rfc/RFC-0259-...decay.md` §3.5. **Stacked on P3 #21668** (base = `rfc/0259-p3-retraction`, 그 위로 P2 #21665, P1 #21644 MERGED).

> P2/P3가 머지되면 이 PR의 base를 순차로 재타겟해 주세요.

### 문제 (gap #5)
P1이 volatile fact에 valid_until을 줘서 6h(volatile TTL) 후엔 recall에서 자동 제외된다. 하지만 **grounding horizon(3h)~TTL(6h) 구간**의 volatile fact는 여전히 `fact_is_current`를 통과하면서, 기존 `staleness_marker`가 cosmetic `[stale: …verify]` 꼬리표만 붙인 채 **여전히 단언**된다(RFC가 지적한 gap #5: "annotates but neither suppresses nor demotes"). issue_king이 closed PR을 in-progress로 단언한 그 구간이다.

### 범위 (P4, read-path only)
RFC-0259 §3.5: unverified-volatile을 recall block에서 **demote + hard prefix**. store mutation 없음(P3의 write-path retraction과 상보). suppress(완전 제거) 대신 demote+prefix를 택해 정보 손실 최소화 — RFC의 "or at minimum demoted… with a hard UNVERIFIED prefix".

### 변경 (`keeper_memory_os_recall.ml` + test, 2파일)
- `is_unverified_volatile`: `external_ref=Some` AND truth anchor가 `Reconcile.default_grounding_horizon_seconds`보다 오래됨. **non-volatile(external_ref=None)은 아무리 오래돼도 해당 안 됨** — durable 지식은 decay 안 함.
- `facts_recency_ranked`: stable `List.partition`으로 unverified-volatile을 durable 뒤로 demote(각 그룹 recency 순서 유지, take max_facts 시 volatile이 먼저 잘림).
- `render_fact`/`render_shared_fact`: unverified-volatile에 `[UNVERIFIED — re-check before acting]` **선두 prefix**(꼬리 staleness note 대체). shared fact도 동일(cross-keeper 동의≠external-truth 검증).
- 테스트 +2: volatile-stale→prefix 있음, 오래된 non-volatile durable→prefix 없음.

### 경계
- horizon은 P2 reconciler와 **동일 상수** 재사용 → "재검증됐어야 할 시점"과 "unverified로 렌더"가 같은 경계.
- read-path only — 디스크 안 건드림. P3(write-path retraction)와 직교: P3는 APPLY 켜지면 stale_terminal을 *삭제*, P4는 그 전이라도 recall에서 *강등/경고*.

### 검증
- P4 테스트 2/2 통과(recall 10·11). `dune build @check` green, fmt clean.
- `test_keeper_memory_os` json#14(generation Expected `7`/Received `0`)은 **pre-existing base-broken**: P3 base에서 `git stash`로 동일 단일 실패 재현 — 본 PR 무관(P1·P2·P3·P4 4회 동일).

### 워크어라운드 게이트
해당 없음. cosmetic marker를 **구조적 demote+typed prefix로 교체**(gap #5 근본 수정). string 분류기 보강 아님 — `is_unverified_volatile`은 typed `external_ref` + 시간 경계 판정.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
