### PR TITLE
feat(fusion): RFC-0266 Phase 1 — wake calling keeper on async fusion completion

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -110,6 +110,38 @@ let judge_meta (judge : (Fusion_types.judge_synthesis, string) result) : Yojson.
       ]
   | Error e -> `Assoc [ ("status", `String "failed"); ("error", `String e) ]
 
+(* RFC-0266: 심의 완료 시 호출 키퍼를 typed [Fusion_completed] stimulus로 깨운다.
+   board post + chat append(영속)와 별개로, 잠든(Running) 키퍼를 즉시 깨워
+   resolved_answer가 다음 턴의 actionable 입력으로 도착하게 하는 hint+payload 경로다.
+   예외 안전: registry 문제로 sink 결과/실패 알림이 오염되면 안 되므로 자체 흡수하되
+   Eio 구조적 취소(Cancelled)는 재전파한다(record_recovery_stimulus_turn_started 패턴).
+   Paused 키퍼는 강제 재개하지 않는다(board wake와 동일 보수적 기본값, wakeup_keeper가
+   Running 항목만 깨움) — 결과는 board/chat 영속으로 남는다. *)
+let wake_keeper_on_fusion_completion
+      ~base_dir ~keeper ~run_id ~ok ~resolved_answer ~board_post_id =
+  try
+    (* post_id 폴백 규칙은 keeper_world_observation.pending_board_event_of_fusion_completion
+       과 동일해야 한다(둘 다 board_post_id에서 유도) — dedup 일관성. *)
+    let post_id =
+      if String.equal board_post_id "" then "fusion-run:" ^ run_id else board_post_id
+    in
+    let stimulus : Keeper_event_queue.stimulus =
+      { Keeper_event_queue.post_id
+      ; urgency = Keeper_event_queue.Normal
+      ; arrived_at = Time_compat.now ()
+      ; payload =
+          Keeper_event_queue.Fusion_completed { run_id; ok; resolved_answer; board_post_id }
+      }
+    in
+    Log.Keeper.info "fusion completion wake: keeper=%s run_id=%s ok=%b" keeper run_id ok;
+    Keeper_keepalive_signal.wakeup_keeper ~base_path:base_dir ~stimulus keeper
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Keeper.warn ~keeper_name:keeper "fusion completion wake failed run_id=%s: %s"
+      run_id
+      (Printexc.to_string exn)
+
 let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judge_usage :
     (unit, string) result =
   try
@@ -188,8 +220,20 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judge_usage :
          ~content
          ()
      | Error _ -> ());
+    (* RFC-0266: completion 성공 경로(board post 생성됨)에서만 깨운다. board 생성
+       실패(Error)는 orchestrator가 [Sink_failed]로 바꿔 fusion_tool의
+       append_chat_failure가 깨우므로, 여기서도 깨우면 중복 wake가 된다. judge가
+       Error여도 fusion은 끝났으니 ok=false로 통지한다(board엔 실패도 증거로 남음). *)
     (match board_result with
-     | Ok _post -> Ok ()
+     | Ok post ->
+       let ok, resolved_answer =
+         match judge with
+         | Ok j -> true, j.Fusion_types.resolved_answer
+         | Error e -> false, Printf.sprintf "judge failed: %s" e
+       in
+       wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok ~resolved_answer
+         ~board_post_id:(Board.Post_id.to_string post.id);
+       Ok ()
      | Error e -> Error (Board.show_board_error e))
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/fusion/fusion_sink.mli
+++ b/lib/fusion/fusion_sink.mli
@@ -32,3 +32,23 @@ val emit
   -> judge:(Fusion_types.judge_synthesis, string) result
   -> judge_usage:Fusion_types.usage
   -> (unit, string) result
+
+(** RFC-0266: 심의 완료/실패 시 호출 키퍼를 typed [Fusion_completed] stimulus로 깨운다.
+
+    resolved_answer가 다음 키퍼 턴의 actionable 입력으로 도착하게 한다(board post +
+    chat append 영속과 별개의 hint+payload 경로). [ok = false]는 denied/sink_failed/
+    aborted 실패 라벨을 [resolved_answer]에 싣고, board post가 없으면 [board_post_id = ""].
+
+    [emit]은 성공 경로(board post 생성됨)에서 이를 호출하고, 실패 경로는 fusion_tool의
+    append_chat_failure가 호출한다(completion 타입당 단일 wake로 중복 방지).
+
+    예외 안전: [Eio.Cancel.Cancelled]는 재전파, 그 외 예외는 흡수(sink 결과 비오염).
+    Running이 아닌 키퍼는 silent no-op이며 결과는 board/chat 영속으로 남는다. *)
+val wake_keeper_on_fusion_completion :
+     base_dir:string
+  -> keeper:string
+  -> run_id:string
+  -> ok:bool
+  -> resolved_answer:string
+  -> board_post_id:string
+  -> unit

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -19,19 +19,24 @@ let append_chat_failure ~base_dir ~keeper ~run_id content =
      별도 "fusion/<run_id>" 스레드는 메인 오염을 막지 못하면서 한 run의 성공/실패만
      다른 lane으로 흩어지는 split-brain을 만든다. denied/sink_failed/aborted는 키퍼가
      다음 턴에 인지해야 할 운영 실패이므로 메인 lane이 옳다(run_id는 content에 포함). *)
-  try
-    Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper ~content ();
-    Keeper_chat_broadcast.chat_appended ~keeper_name:keeper ~source:"fusion"
-      ~content
-      ()
-  with
-  | Eio.Cancel.Cancelled _ as exn ->
-    (* 구조적 취소는 재전파. *)
-    raise exn
-  | exn ->
-    Log.Keeper.warn ~keeper_name:keeper
-      "fusion run %s failed to append failure message: %s" run_id
-      (Printexc.to_string exn)
+  (try
+     Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper ~content ();
+     Keeper_chat_broadcast.chat_appended ~keeper_name:keeper ~source:"fusion"
+       ~content
+       ()
+   with
+   | Eio.Cancel.Cancelled _ as exn ->
+     (* 구조적 취소는 재전파. *)
+     raise exn
+   | exn ->
+     Log.Keeper.warn ~keeper_name:keeper
+       "fusion run %s failed to append failure message: %s" run_id
+       (Printexc.to_string exn));
+  (* RFC-0266: 실패도 호출 키퍼를 ok=false로 깨워 "결과 안 옴" 폴링 대신 능동 통지한다
+     (성공 경로의 fusion_sink.emit wake와 대칭). content가 실패 사유 라벨이 된다.
+     wake는 자체 예외 안전하므로 chat append 실패와 독립적으로 시도된다. *)
+  Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:false
+    ~resolved_answer:content ~board_post_id:""
 
 let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ~args : string =
   let prompt = Tool_args.get_string args "prompt" "" in

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -75,6 +75,17 @@ let consume_single_heartbeat_stimulus
   match stim.payload with
   | Keeper_event_queue.Board_signal _ ->
     pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+  | Keeper_event_queue.Fusion_completed c ->
+    (* RFC-0266: an async fusion deliberation finished and woke this keeper.
+       Surface the resolved answer as a pending_board_event so this turn acts
+       on it (a non-empty list, unlike Bootstrap/No_progress_recovery which
+       inject nothing — returning [] here would silently drop the result). *)
+    Log.Keeper.info
+      "turn entry: fusion result delivered run_id=%s ok=%b (keeper=%s)"
+      c.run_id
+      c.ok
+      meta_after_triage.name;
+    pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
   | Keeper_event_queue.Bootstrap ->
     Log.Keeper.info
       "turn entry: bootstrap stimulus consumed (keeper=%s)"

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -7,6 +7,7 @@ type stimulus_kind =
   | Board_signal
   | Bootstrap
   | No_progress_recovery
+  | Fusion_completed  (* RFC-0266: async masc_fusion completion wake *)
 
 type reaction_kind =
   | Turn_started
@@ -23,6 +24,7 @@ let stimulus_kind_to_string = function
   | Board_signal -> "board_signal"
   | Bootstrap -> "bootstrap"
   | No_progress_recovery -> "no_progress_recovery"
+  | Fusion_completed -> "fusion_completed"
 ;;
 
 let reaction_kind_to_string = function
@@ -50,6 +52,7 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Board_signal _ -> Board_signal
   | Keeper_event_queue.Bootstrap -> Bootstrap
   | Keeper_event_queue.No_progress_recovery -> No_progress_recovery
+  | Keeper_event_queue.Fusion_completed _ -> Fusion_completed
 ;;
 
 let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
@@ -117,6 +120,8 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       title
   | Keeper_event_queue.Bootstrap -> "bootstrap"
   | Keeper_event_queue.No_progress_recovery -> "no_progress_recovery"
+  | Keeper_event_queue.Fusion_completed fc ->
+    Printf.sprintf "fusion_completed run_id=%s ok=%b" fc.run_id fc.ok
 ;;
 
 let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
@@ -126,7 +131,9 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
   let board_updated_at =
     match stimulus.payload with
     | Keeper_event_queue.Board_signal bs -> bs.updated_at
-    | Keeper_event_queue.Bootstrap | Keeper_event_queue.No_progress_recovery -> None
+    | Keeper_event_queue.Bootstrap
+    | Keeper_event_queue.No_progress_recovery
+    | Keeper_event_queue.Fusion_completed _ -> None
   in
   `Assoc
     (base_fields

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -14,6 +14,7 @@ type stimulus_kind =
   | Board_signal
   | Bootstrap
   | No_progress_recovery
+  | Fusion_completed  (** RFC-0266: async masc_fusion completion wake *)
 
 type reaction_kind =
   | Turn_started

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -252,6 +252,56 @@ let pending_board_event_of_board_signal
   }
 ;;
 
+(* RFC-0266: fusion answers are the deliberation result the keeper requested,
+   so the in-prompt preview is longer than a board headline preview (80). The
+   full answer also persists in the sink's board post + chat lane. *)
+let fusion_result_preview_max_len = 480
+
+(* RFC-0266: turn a completed async fusion deliberation into actionable turn
+   input. The sink already created a System_post board record (authored by this
+   keeper) carrying the panel/judge detail; here we surface that result as a
+   just-arrived [pending_board_event] so the woken turn's act judgment fires
+   (actionable_signal_present only checks [pending_board_events <> []], not
+   provenance/mention). Provenance is classified exactly as the keeper would see
+   the real post on the normal board path — own author + System_post ->
+   Self_narrative -> rendered inside the observational-data envelope (RFC-0247:
+   a keeper reasons over the deliberation it requested, it is not trusted
+   operator instruction). When the sink failed to create the board post
+   ([board_post_id = ""]) we still deliver the answer under a synthetic
+   [fusion-run:<id>] id so it is never silently dropped. *)
+let pending_board_event_of_fusion_completion
+      ~(meta : keeper_meta)
+      ~(arrived_at : float)
+      (fc : Keeper_event_queue.fusion_completion)
+  : pending_board_event
+  =
+  let self_ids = self_ids meta in
+  let post_id =
+    if String.equal fc.board_post_id "" then "fusion-run:" ^ fc.run_id
+    else fc.board_post_id
+  in
+  let title =
+    if fc.ok
+    then Printf.sprintf "Fusion deliberation complete (run %s)" fc.run_id
+    else Printf.sprintf "Fusion deliberation failed (run %s)" fc.run_id
+  in
+  { post_id
+  ; author = meta.name
+  ; title
+  ; preview = short_preview ~max_len:fusion_result_preview_max_len fc.resolved_answer
+  ; hearth = None
+  ; post_kind = Board.System_post
+  ; updated_at = arrived_at
+  ; explicit_mention = false
+  ; matched_targets = []
+  ; self_commented = false
+  ; new_external_since = 0
+  ; latest_external_author = None
+  ; latest_external_preview = None
+  ; provenance = provenance_of ~self_ids Board.System_post ~author:meta.name
+  }
+;;
+
 let pending_board_event_of_stimulus
       ~continuity_summary
       ~(meta : keeper_meta)
@@ -266,6 +316,8 @@ let pending_board_event_of_stimulus
          ~meta
          ~arrived_at:stimulus.arrived_at
          (Board_signal.board_signal_of_board_stimulus ~post_id:stimulus.post_id bs))
+  | Keeper_event_queue.Fusion_completed fc ->
+    Some (pending_board_event_of_fusion_completion ~meta ~arrived_at:stimulus.arrived_at fc)
   | Keeper_event_queue.Bootstrap | Keeper_event_queue.No_progress_recovery -> None
 ;;
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -230,8 +230,21 @@ val board_signal_wake_reason :
   signal:Board_dispatch.board_signal ->
   Keeper_world_observation_board_signal.wake_reason option
 
+(** RFC-0266: build the actionable [pending_board_event] for a completed async
+    [masc_fusion] deliberation. Surfaces the sink's board result as a just-arrived
+    event so the woken turn acts on it; classified [Self_narrative] (own author +
+    System_post) so it renders inside the observational-data envelope (RFC-0247).
+    [board_post_id = ""] falls back to a synthetic [fusion-run:<id>] post id. *)
+val pending_board_event_of_fusion_completion :
+  meta:Keeper_meta_contract.keeper_meta ->
+  arrived_at:float ->
+  Keeper_event_queue.fusion_completion ->
+  pending_board_event
+
 (** Convert a queued Event Layer stimulus back into structured board activity
-    for the next keeper prompt. Returns [None] for non-board stimuli. *)
+    for the next keeper prompt. [Board_signal] and [Fusion_completed] (RFC-0266)
+    produce [Some]; [Bootstrap]/[No_progress_recovery] return [None] (no prompt
+    injection). *)
 val pending_board_event_of_stimulus :
   continuity_summary:string ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -27,6 +27,19 @@ type stimulus_payload =
   | Board_signal of board_stimulus
   | Bootstrap
   | No_progress_recovery
+  | Fusion_completed of fusion_completion
+      (* RFC-0266: an async [masc_fusion] deliberation finished. Wakes the
+         calling keeper so the resolved answer arrives as actionable turn
+         input on its next cycle, instead of being discovered passively. *)
+
+and fusion_completion = {
+  run_id : string;
+  ok : bool;  (* judge synthesized vs denied/sink_failed/aborted. *)
+  resolved_answer : string;
+  (* judge resolved answer; a failure label when [ok = false]. *)
+  board_post_id : string;
+  (* correlates to the sink's board evidence post; "" if none was created. *)
+}
 
 type stimulus = {
   post_id : post_id;
@@ -93,10 +106,11 @@ let payload_kind_label = function
   | Board_signal _ -> "board_signal"
   | Bootstrap -> "bootstrap"
   | No_progress_recovery -> "no_progress_recovery"
+  | Fusion_completed _ -> "fusion_completed"
 
 let is_board_signal = function
   | Board_signal _ -> true
-  | Bootstrap | No_progress_recovery -> false
+  | Bootstrap | No_progress_recovery | Fusion_completed _ -> false
 
 let drain_board_window ?(window_sec = 2.0) (queue : t) : stimulus list * t =
   let now = Unix.gettimeofday () in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -55,10 +55,25 @@ type stimulus_payload =
   | Board_signal of board_stimulus
   | Bootstrap
   | No_progress_recovery
+  | Fusion_completed of fusion_completion
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
     [classify] JSON-prefix round-trip: producers hold the typed value and
     consumers match it exhaustively, so an unrecognised stimulus is
-    unrepresentable rather than silently downgraded to [Unsupported]. *)
+    unrepresentable rather than silently downgraded to [Unsupported].
+    [Fusion_completed] (RFC-0266) wakes the calling keeper when an async
+    [masc_fusion] deliberation finishes so the result arrives as actionable
+    turn input rather than being discovered passively. *)
+
+and fusion_completion = {
+  run_id : string;
+  ok : bool;
+  resolved_answer : string;
+  board_post_id : string;
+}
+(** RFC-0266 payload for [Fusion_completed]: [ok] distinguishes a synthesized
+    judge result from denied/sink_failed/aborted; [resolved_answer] carries the
+    answer (or a failure label when [ok = false]); [board_post_id] correlates to
+    the sink's board evidence post ("" when none was created). *)
 
 type stimulus = {
   post_id : post_id;
@@ -98,7 +113,7 @@ val summary : t -> string
 
 val payload_kind_label : stimulus_payload -> string
 (** Stable short label for logs/metrics: ["board_signal"], ["bootstrap"],
-    or ["no_progress_recovery"]. *)
+    ["no_progress_recovery"], or ["fusion_completed"]. *)
 
 val is_board_signal : stimulus_payload -> bool
 (** [true] iff the payload is a [Board_signal]. *)

--- a/test/dune
+++ b/test/dune
@@ -633,6 +633,14 @@
  (modules test_runtime_config_validity)
  (libraries masc_test_deps))
 
+; RFC-0266: fusion async-completion wake — closed-sum classification +
+; actionable pending_board_event delivery.
+
+(test
+ (name test_fusion_wake)
+ (modules test_fusion_wake)
+ (libraries masc_test_deps))
+
 ; RFC-0207: per-keeper LLM runtime routing (persona [model] selection + driver fail-fast).
 
 (test

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -1,0 +1,130 @@
+(* RFC-0266 Phase 1 — fusion async-completion wake + actionable delivery.
+
+   The wake (Fusion_sink.wake_keeper_on_fusion_completion -> wakeup_keeper) needs
+   a live registry, so it is exercised end-to-end at runtime rather than here.
+   These unit checks pin the two compile-passing-but-silently-wrong failure
+   modes a stub could introduce:
+
+   1. the closed-sum helpers must classify the new [Fusion_completed] variant
+      (label / is_board_signal / reaction-ledger kind); and
+   2. a completed fusion must become a NON-EMPTY [pending_board_event] carrying
+      the resolved answer — returning [] (like the Bootstrap/No_progress_recovery
+      arms) would compile but silently drop the result, defeating the RFC. *)
+
+open Alcotest
+open Masc
+
+(* substring check without pulling in the [str] library *)
+let contains ~needle haystack =
+  let nl = String.length needle and hl = String.length haystack in
+  let rec go i = i + nl <= hl && (String.equal (String.sub haystack i nl) needle || go (i + 1)) in
+  nl = 0 || go 0
+;;
+
+let make_meta ?(name = "fusion-keeper") () : Keeper_meta_contract.keeper_meta =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         [ ("name", `String name)
+         ; ("agent_name", `String name)
+         ; ("trace_id", `String "test-trace-fusion")
+         ])
+  with
+  | Ok meta -> meta
+  | Error e -> failwith (Printf.sprintf "make_meta failed: %s" e)
+;;
+
+let fusion_payload
+      ?(run_id = "fus-1")
+      ?(ok = true)
+      ?(resolved_answer = "use approach B because it is reversible")
+      ?(board_post_id = "post-77")
+      ()
+  : Keeper_event_queue.fusion_completion
+  =
+  { run_id; ok; resolved_answer; board_post_id }
+;;
+
+let fusion_stimulus ?run_id ?ok ?resolved_answer ?board_post_id () : Keeper_event_queue.stimulus =
+  { post_id = "ignored-by-fusion-arm"
+  ; urgency = Keeper_event_queue.Normal
+  ; arrived_at = 1000.0
+  ; payload =
+      Keeper_event_queue.Fusion_completed
+        (fusion_payload ?run_id ?ok ?resolved_answer ?board_post_id ())
+  }
+;;
+
+(* (1) closed-sum helpers classify the new variant *)
+let test_closed_sum_helpers () =
+  let p = Keeper_event_queue.Fusion_completed (fusion_payload ()) in
+  check string "payload_kind_label" "fusion_completed" (Keeper_event_queue.payload_kind_label p);
+  check bool "is_board_signal is false" false (Keeper_event_queue.is_board_signal p);
+  check
+    string
+    "reaction_ledger stimulus_kind_to_string"
+    "fusion_completed"
+    (Keeper_reaction_ledger.stimulus_kind_to_string Keeper_reaction_ledger.Fusion_completed)
+;;
+
+(* (2) THE behavioral guard: a completed fusion becomes a non-empty actionable
+   pending_board_event that carries the resolved answer. *)
+let test_fusion_completion_is_actionable () =
+  let meta = make_meta () in
+  let fc = fusion_payload ~resolved_answer:"ANSWER-TOKEN-xyz" ~board_post_id:"post-77" () in
+  let ev : Keeper_world_observation.pending_board_event =
+    Keeper_world_observation.pending_board_event_of_fusion_completion
+      ~meta
+      ~arrived_at:1000.0
+      fc
+  in
+  check string "post_id correlates to the board post" "post-77" ev.post_id;
+  check bool "preview carries the resolved answer" true (contains ~needle:"ANSWER-TOKEN-xyz" ev.preview);
+  (* RFC-0247: a self-authored System_post fusion result renders observationally,
+     not as trusted operator instruction. *)
+  check
+    bool
+    "provenance is Self_narrative"
+    true
+    (match ev.provenance with
+     | Keeper_world_observation.Self_narrative -> true
+     | _ -> false);
+  (* the stimulus path yields Some (not None like Bootstrap/No_progress_recovery) *)
+  match
+    Keeper_world_observation.pending_board_event_of_stimulus
+      ~continuity_summary:""
+      ~meta
+      (fusion_stimulus ~resolved_answer:"ANSWER-TOKEN-xyz" ())
+  with
+  | Some (ev : Keeper_world_observation.pending_board_event) ->
+    check bool "stimulus path preview carries the answer" true (contains ~needle:"ANSWER-TOKEN-xyz" ev.preview)
+  | None -> fail "Fusion_completed stimulus must produce Some pending_board_event, not None"
+;;
+
+(* (3) an empty board_post_id (sink failed to create the post) still delivers
+   the answer under a synthetic, non-empty post id. *)
+let test_missing_board_post_id_fallback () =
+  let meta = make_meta () in
+  let fc = fusion_payload ~run_id:"fus-9" ~board_post_id:"" () in
+  let ev : Keeper_world_observation.pending_board_event =
+    Keeper_world_observation.pending_board_event_of_fusion_completion ~meta ~arrived_at:1.0 fc
+  in
+  check string "synthetic fallback post id" "fusion-run:fus-9" ev.post_id
+;;
+
+let () =
+  run
+    "fusion_wake"
+    [ ( "rfc-0266"
+      , [ test_case "closed-sum helpers classify Fusion_completed" `Quick test_closed_sum_helpers
+        ; test_case
+            "fusion completion is actionable (non-empty, carries answer)"
+            `Quick
+            test_fusion_completion_is_actionable
+        ; test_case
+            "missing board_post_id falls back to fusion-run id"
+            `Quick
+            test_missing_board_post_id_fallback
+        ] )
+    ]
+;;

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -19,6 +19,14 @@ let () =
   assert (String.equal (payload_kind_label Bootstrap) "bootstrap");
   assert (String.equal (payload_kind_label No_progress_recovery) "no_progress_recovery");
 
+  (* RFC-0266: Fusion_completed is a non-board stimulus with its own label. *)
+  let fusion_payload () =
+    Fusion_completed
+      { run_id = "fus-1"; ok = true; resolved_answer = "ok"; board_post_id = "post-1" }
+  in
+  assert (not (is_board_signal (fusion_payload ())));
+  assert (String.equal (payload_kind_label (fusion_payload ())) "fusion_completed");
+
   (* --- queue operations preserved --- *)
   let board_stim =
     { post_id = "p1"; urgency = Normal; arrived_at = 0.0; payload = board_payload () }


### PR DESCRIPTION
## RFC-0266 Phase 1 — Fusion async-completion wake (WAKE)

RFC: docs/rfc/RFC-0266-fusion-async-completion-wake-and-visibility.md (#21655)
Parent: RFC-0252 (fusion panel/judge deliberation)

### 문제

`masc_fusion`(RFC-0252)은 out-of-band fork로 도는 async 심의다. 완료 시 `Fusion_sink.emit`이 결과를 board post + chat lane에 남기지만, **호출 키퍼를 깨우는 경로가 없다.** 키퍼는 결과를 "나중에 다른 이유로 턴을 돌 때" 수동 발견할 뿐이고, 그나마 자기 과거 발화로 렌더되어 act 판정의 입력이 되지 못한다. 실관측 증상: 한 키퍼가 fusion을 띄운 뒤 대시보드를 반복 폴링하며 "결과 안 왔어"를 되풀이했다 — 구조적 결과다.

소스 적대 추적(2026-06-20, 6-agent workflow, confidence 0.95): `lib/fusion` 전체에 wakeup/enqueue/stimulus 호출 0건, `stimulus_payload`는 fusion variant가 없는 닫힌 합타입.

### 변경 (Phase 1 = WAKE)

완료(성공/실패 공통) 시 호출 키퍼를 typed `Fusion_completed` stimulus로 깨워, resolved answer가 다음 턴의 actionable 입력으로 도착하게 한다.

- `lib/keeper_runtime/keeper_event_queue.{ml,mli}`: 닫힌 합타입 `stimulus_payload`에 4번째 variant `Fusion_completed of fusion_completion { run_id; ok; resolved_answer; board_post_id }` 추가. `payload_kind_label`/`is_board_signal`에 명시 가지.
- `lib/keeper/keeper_reaction_ledger.{ml,mli}`: 미러 타입 `stimulus_kind` + 매퍼/preview/문자열에 명시 가지(컴파일러가 동기화 강제).
- `lib/keeper/keeper_world_observation.{ml,mli}`: `pending_board_event_of_fusion_completion` 추가 — sink가 이미 만든 self-author System_post를 just-arrived `pending_board_event`로 surface(provenance=Self_narrative → observational 봉투, RFC-0247). `pending_board_event_of_stimulus`에 Fusion 가지.
- `lib/keeper/keeper_heartbeat_stimulus_intake.ml`: intake exhaustive match에 `Fusion_completed` 가지 — **non-empty** pending_board_event 반환(Bootstrap/No_progress처럼 `[]` 반환 시 silent drop).
- `lib/fusion/fusion_sink.ml`: `wake_keeper_on_fusion_completion` 추가, `emit` 성공 경로(board Ok)에서 호출.
- `lib/fusion/fusion_tool.ml`: 실패 경로(`append_chat_failure`)에서 ok=false로 호출. completion 타입당 단일 wake로 중복 방지.

### 경계 / 설계 결정

- **순환 없음**: lib/fusion과 lib/keeper는 같은 `masc` umbrella 라이브러리(`include_subdirs unqualified`). wake는 intra-library 호출, 새 dune 의존성 0. wake 트리거 로직은 레이어링을 위해 fusion 쪽(`fusion_sink`)에 둔다(keeper-core가 fusion 개념을 알지 않음).
- **act 판정**: `actionable_signal_present`/`durable_signal_present`는 `pending_board_events <> []`만 검사(provenance/mention 무관) — fusion event 1개로 턴이 act한다(소스 확인).
- **paused 키퍼**: `wakeup_keeper`는 Running 항목만 깨운다(board wake와 동일 보수적 기본값). paused면 결과는 board/chat 영속으로 남고 즉시 wake는 생략 — 강제 재개하지 않는다.
- **예외 안전**: wake는 자체 예외 흡수(Eio Cancelled만 재전파)로 sink 결과/실패 알림을 오염시키지 않는다.

### CLAUDE.md 워크어라운드 self-audit

- 텔레메트리-as-fix **회피** — wake는 실제 전달을 *고친다*(silent failure를 보이게만 하는 것이 아님).
- string/substring 분류기 **회피** — 닫힌 합타입 variant.
- catch-all `_ ->` 추가 **회피** — 명시 가지만 추가, 컴파일러가 누락 강제.
- Unknown→Permissive **회피** — `ok=false` 명시 실패 경로.

### 검증

- `dune build --root . lib/` green; full `dune build --root .` green.
- 신규 `test/test_fusion_wake.ml` 3 cases green. **non-vacuous 증명**: intake/world-observation arm을 `None`(silent-drop)으로 mutate하면 "must produce Some, not None" 가 FAIL(복원 후 green).
- `test_keeper_event_queue`(+Fusion 가지), `test_keeper_reaction_ledger` green.
- DET/NDT 결정론 계약 게이트 PASS.

### 범위 밖 (RFC-0266 후속 phase)

Phase 2 run registry / Phase 3 `masc_fusion_status` 도구 / Phase 4 대시보드 fusion-runs 패널(VISIBILITY). Phase 1만으로 폴링 증상은 해소된다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
