### PR TITLE
Add Gemma 4 coder local catalog entries

### DIFF
--- a/oas-models.toml
+++ b/oas-models.toml
@@ -115,6 +115,42 @@ supports_seed = true
 input_per_million = 0.0
 output_per_million = 0.0
 
+[[models]]
+id_prefix = "gemma4-coder-"
+base = "openai_chat"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = false
+thinking_control_format = "chat_template_token"
+supports_native_streaming = true
+supports_top_k = true
+supports_seed = true
+input_per_million = 0.0
+output_per_million = 0.0
+
+# RunPod Models
+[[models]]
+id_prefix = "qwen36-35b-a3b-mtp"
+base = "openai_chat"
+max_context_tokens = 131072
+max_output_tokens = 81920
+supports_tools = true
+supports_tool_choice = false
+supports_parallel_tool_calls = true
+supports_reasoning = true
+supports_extended_thinking = true
+thinking_control_format = "chat_template_kwargs"
+supports_response_format_json = true
+supports_structured_output = true
+supports_native_streaming = true
+supports_top_k = true
+supports_min_p = true
+input_per_million = 0.0
+output_per_million = 0.0
+
 # Ollama Cloud Models (canonical 2026-06 seed)
 # Source: https://ollama.com/api/tags + /api/show, checked 2026-06-20 KST.
 # Provider-qualified entries preserve Ollama Cloud wire behavior when a model id overlaps another provider.

--- a/oas-models.toml
+++ b/oas-models.toml
@@ -131,26 +131,6 @@ supports_seed = true
 input_per_million = 0.0
 output_per_million = 0.0
 
-# RunPod Models
-[[models]]
-id_prefix = "qwen36-35b-a3b-mtp"
-base = "openai_chat"
-max_context_tokens = 131072
-max_output_tokens = 81920
-supports_tools = true
-supports_tool_choice = false
-supports_parallel_tool_calls = true
-supports_reasoning = true
-supports_extended_thinking = true
-thinking_control_format = "chat_template_kwargs"
-supports_response_format_json = true
-supports_structured_output = true
-supports_native_streaming = true
-supports_top_k = true
-supports_min_p = true
-input_per_million = 0.0
-output_per_million = 0.0
-
 # Ollama Cloud Models (canonical 2026-06 seed)
 # Source: https://ollama.com/api/tags + /api/show, checked 2026-06-20 KST.
 # Provider-qualified entries preserve Ollama Cloud wire behavior when a model id overlaps another provider.

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -326,6 +326,39 @@ let test_runtime_json_not_in_repo_config () =
   let path = Filename.concat (repo_root ()) "config/runtime.json" in
   check bool "retired runtime.json absent" false (Sys.file_exists path)
 
+let with_repo_oas_model_catalog f =
+  let path = Filename.concat (repo_root ()) "oas-models.toml" in
+  check bool "repo oas-models.toml present" true (Sys.file_exists path);
+  match Llm_provider.Model_catalog.load_file path with
+  | Error msg -> failf "repo oas-models.toml should load: %s" msg
+  | Ok catalog ->
+    Fun.protect
+      ~finally:Llm_provider.Model_catalog.clear_global
+      (fun () ->
+         Llm_provider.Model_catalog.set_global catalog;
+         f catalog)
+
+let test_repo_oas_model_catalog_covers_runpod_gemma4_coder () =
+  with_repo_oas_model_catalog @@ fun catalog ->
+  let model_id = "gemma4-coder-smoke" in
+  (match Llm_provider.Model_catalog.lookup catalog model_id with
+   | None -> failf "expected repo OAS catalog row for %s" model_id
+   | Some entry ->
+     check (option string) "RunPod Gemma4 coder base" (Some "openai_chat")
+       entry.base_label);
+  match Llm_provider.Capabilities.for_model_id_catalog model_id with
+  | None -> fail "expected RunPod Gemma4 coder capability lookup"
+  | Some caps ->
+    check (option int) "RunPod Gemma4 coder context" (Some 262144)
+      caps.max_context_tokens;
+    check bool "RunPod Gemma4 coder tools" true caps.supports_tools;
+    check bool "RunPod Gemma4 coder tool choice" true caps.supports_tool_choice;
+    check bool "RunPod Gemma4 coder extended thinking" true
+      caps.supports_extended_thinking;
+    check bool "RunPod Gemma4 coder chat-template-token thinking" true
+      (Llm_provider.Capabilities.(
+         caps.thinking_control_format = Chat_template_token))
+
 let test_repo_runtime_toml_loads () =
   let path = Filename.concat (repo_root ()) "config/runtime.toml" in
   check bool "repo runtime.toml present" true (Sys.file_exists path);
@@ -839,6 +872,8 @@ let () =
     [ ( "runtime TOML gate",
         [ test_case "runtime.json is not a repo config source" `Quick
             test_runtime_json_not_in_repo_config;
+          test_case "repo OAS catalog covers RunPod Gemma4 coder" `Quick
+            test_repo_oas_model_catalog_covers_runpod_gemma4_coder;
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
           test_case


### PR DESCRIPTION
## Summary

- add MASC local OAS catalog coverage for `gemma4-coder-*`
- add the existing Qwen MTP hosted-runtime catalog entry so local `oas-models.toml` boot paths do not fall back to provider defaults
- declare Gemma 4 coder as 262144 context with tools, forced `tool_choice`, reasoning/thinking, native streaming, top-k, and seed support

## Validation

- `python3 -c 'import pathlib,tomllib; p=pathlib.Path("oas-models.toml"); tomllib.loads(p.read_text()); print("ok", p)'`
- `/Users/dancer/me/workspace/yousleepwhen/masc/_build/default/bin/fusion_run.exe --base /Users/dancer/me --preset __config_probe__ catalog-check`
  - run from this worktree
  - expected result: catalog loads 74 entries, then exits at `preset not found: __config_probe__`

## Live Probe

- llama.cpp `/v1/models` on the current hosted endpoint reported `gemma4-coder-fable5-q4km` with `n_ctx=262144`
- OpenAI-compatible `/v1/chat/completions` returned `finish_reason="tool_calls"` for both `tool_choice:"auto"` and forced named `tool_choice`
