### PR TITLE
fix(keeper-prompt): remove non-existent masc_claim_next tool and false current_task_id field

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -130,14 +130,13 @@ Peer consultation contract:
 Task management:
 - View tasks: keeper_tasks_list
 - Create tasks: keeper_task_create when available; otherwise use masc_add_task (single) or masc_batch_add_tasks (multiple)
-- Claim next available: masc_claim_next
 - Claim specific and complete: keeper_task_claim, keeper_task_done
 - For code/PR work: keeper_task_done with task_id and result containing the PR URL or artifact reference
 - Verify submitted work: when status is awaiting_verification, use masc_transition with action="approve" or action="reject" and notes; do not claim or resubmit that task
 
 Progress guidance:
 - Passive reads are valid evidence gathering, but they are not execution progress by themselves. If you inspect tasks, files, board posts, or remote repo state and there is work to do, choose the smallest real next step: keeper_task_claim, Edit/Write, Execute, keeper_board_post, keeper_board_comment, keeper_task_done, or a concrete blocker/no-work response.
-- `keeper_task_claim`, `masc_claim_next`, and `masc_transition(action="claim")` are assignment actions, not execution progress. After claiming or when you already own an active task, continue with real progress when the current evidence supports it: open the repo checkout, edit/read the target code, run a command, post a concrete status/blocker, create the draft PR, or close with keeper_task_done.
+- `keeper_task_claim` and `masc_transition(action="claim")` are assignment actions, not execution progress. After claiming or when you already own an active task, continue with real progress when the current evidence supports it: open the repo checkout, edit/read the target code, run a command, post a concrete status/blocker, create the draft PR, or close with keeper_task_done.
 - Read/observe aliases are passive: Grep, Read, keeper_memory_search, keeper_library_search, keeper_library_read, keeper_tools_list, keeper_tasks_list, keeper_context_status, keeper_board_list, keeper_board_post_get, keeper_time_now, and read-only PR/status commands. Use them to decide, not to pad the turn.
 - After memory/library/code/git-status lookup, either take the next real step or state the concrete blocker/no-work result. Do not call a mutating tool just to satisfy a turn shape.
 - If you only discover a blocker, report the blocker, the tool/error class, and the exact next needed action. Do not invent a state-changing call.

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -38,7 +38,7 @@ Task state is tool state, not repo file state. Do not use shell commands to read
 `repos/<REPO_NAME>/.masc/backlog.json`,
 or guessed repo-local backlog files. Do not query guessed local task APIs such as
 `http://localhost:8080/api/tasks`. Use `keeper_tasks_list` for backlog/task
-status and `keeper_context_status` for current_task_id, keeper identity,
+status and `keeper_context_status` for keeper identity,
 sandbox root, and repo paths.
 
 Verification lifecycle:


### PR DESCRIPTION
## What

Adversarial prompt audit (2026-06-20, 10-dimension × audit+verify, 8 refuted as false-positive) found two **false statements** in keeper-facing prompts that teach keepers non-existent tool names / fields:

### 1. `masc_claim_next` — non-existent keeper tool (`capabilities.md`)
- `capabilities.md:133` listed `masc_claim_next` as the "Claim next available" tool; `:140` grouped it with assignment actions.
- `masc_claim_next` is **not** a keeper tool. `lib/keeper_tooling/keeper_tool_name.ml:138` maps `Task_claim -> "keeper_task_claim"`. `masc_claim_next` is an MCP/operator-surface name keepers cannot call (`rg 'masc_claim_next' lib/ test/` -> 0 keeper-side matches).
- A keeper following the prompt would call a non-existent tool and error.
- Fix: removed `masc_claim_next`. `keeper_task_claim` (next line) is the single canonical claim path.

### 2. `current_task_id` — non-existent field (`unified.system.md`)
- `unified.system.md:41` stated `keeper_context_status` returns `current_task_id`.
- The actual payload (`lib/keeper/keeper_tool_memory_runtime.ml:457-542`) emits name/trace_id/generation/context_*/sandbox_*/continuity_*/recent_tool_calls — **no task id field**.
- A keeper would query the wrong tool for task id.
- Fix: removed `current_task_id`. `keeper_tasks_list` provides task ids.

## Scope / risk
- Prompt markdown only. No OCaml, no live behavior change.
- `validate-prompt-paths.sh` passes.
- Critical prompt anchors (continuity / world / state_block / pr_merge_rules) untouched.

## Audit evidence
- Findings §2.4 (tools-capabilities, `extra`/hallucination) and §2.8 (paths-sandbox, `extra`) from the 2026-06-20 audit.
- Independently re-verified by reading: `keeper_tool_name.ml:138`, `keeper_tool_memory_runtime.ml:457-542`.

Co-Authored-By: Claude <noreply@anthropic.com>
