### PR TITLE
feat(keeper): persist Turn_ref on keeper chat rows (RFC-0233 §7) [PR-A2]

### DIFF
--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -188,6 +188,13 @@ type chat_message = {
          unknown label is reported as a persistence read drop and the
          row reads as [Utterance] (the conservative arm: it renders and
          advances the watermark like any reply). *)
+  turn_ref : Ids.Turn_ref.t option;
+      (* RFC-0233 §7: "<trace_id>#<absolute_turn>" join key for the turn
+         that produced this row.  Stamped by [append_turn] /
+         [append_assistant_message] when the caller supplies it; [None] on
+         inbound user lines (no turn yet) and rows written before §7.  A
+         malformed persisted value is reported as a persistence read drop
+         and reads as [None]; the row stays valid. *)
 }
 
 let redaction_for ~base_dir ~keeper_name =
@@ -294,7 +301,7 @@ let legacy_message_id ~ts ~content =
 
 let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     ?tool_call_name ?surface ?conversation_id ?external_message_id ?speaker
-    ?audio ?blocks ?(mentions = []) ?(kind = Row_kind.Utterance) ()
+    ?audio ?blocks ?(mentions = []) ?(kind = Row_kind.Utterance) ?turn_ref ()
     : string =
   (* RFC-0232 P5: the label is a derivation of the typed surface — the
      single site that turns a [Surface_ref.t] into the legacy [source]
@@ -372,6 +379,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     @ speaker_fields speaker
     @ audio_fields audio
     @ blocks_fields blocks
+    @ opt_string_field "turn_ref" (Option.map Ids.Turn_ref.to_string turn_ref)
   in
   Yojson.Safe.to_string (`Assoc all_fields)
 
@@ -397,6 +405,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     ?conversation_id ?external_message_id ?speaker ?(extra_mentions = [])
     ?(assistant_kind = Row_kind.Utterance)
     ?blocks
+    ?turn_ref
     ~(assistant_content : string)
     () =
   try
@@ -422,7 +431,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     let user_line =
       encode_line ~role:Role.User ~content:user_content ~ts
         ~attachments:persisted_user_attachments ?surface ?conversation_id
-        ?external_message_id ?speaker
+        ?external_message_id ?speaker ?turn_ref
         ~mentions:(user_line_mentions ~extra_mentions user_content) ()
     in
     let tool_lines =
@@ -433,12 +442,12 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
             ~ts
             ~tool_call_id:(normalize_tool_call_id ~position tc.call_id)
             ~tool_call_name:tc.call_name
-            ?surface ?conversation_id ())
+            ?surface ?conversation_id ?turn_ref ())
         tool_calls
     in
     let asst_line =
       encode_line ~role:Role.Assistant ~content:assistant_content ~ts ?surface
-        ?conversation_id ~kind:assistant_kind ?blocks ()
+        ?conversation_id ~kind:assistant_kind ?blocks ?turn_ref ()
     in
     let payload =
       String.concat "\n" ((user_line :: tool_lines) @ [ asst_line ]) ^ "\n"
@@ -457,7 +466,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
 (* RFC-0223 P4: keeper-initiated message on one lane. A single
    assistant line — there is no user turn to pair it with. *)
 let append_assistant_message ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio ?blocks () =
+    ?surface ?conversation_id ?audio ?blocks ?turn_ref () =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
@@ -465,7 +474,7 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line =
-      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id ?audio ?blocks ()
+      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id ?audio ?blocks ?turn_ref ()
     in
     Fs_compat.append_file path (line ^ "\n")
   with
@@ -694,6 +703,21 @@ let parse_line ~file_path (line : string) : chat_message option =
                 ~detail:(Printf.sprintf "unknown chat row kind %S" label);
               Row_kind.Utterance)
     in
+    let turn_ref =
+      (* RFC-0233 §7: parse the join key; a malformed value is surfaced as
+         a read drop and reads as [None] — never repaired. *)
+      match opt_string "turn_ref" with
+      | None -> None
+      | Some s -> (
+          match Ids.Turn_ref.of_string s with
+          | Some _ as tr -> tr
+          | None ->
+              report_persistence_read_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                ~path:file_path
+                ~detail:(Printf.sprintf "invalid turn_ref %S" s);
+              None)
+    in
     if role_label = "" || content = "" then (
       report_persistence_read_drop
         ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
@@ -726,7 +750,7 @@ let parse_line ~file_path (line : string) : chat_message option =
           Some
             { id; role; content; ts; attachments; tool_call_id; tool_call_name;
               source; surface; conversation_id; external_message_id; speaker;
-              audio; blocks; mentions; kind }
+              audio; blocks; mentions; kind; turn_ref }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -961,5 +985,7 @@ let to_json_array ?base_dir (messages : chat_message list) : Yojson.Safe.t =
                      ) atts in
                      [("attachments", `List att_json)])
               @ audio_fields_with_expired ~base_dir m.audio
-              @ blocks_fields m.blocks))
+              @ blocks_fields m.blocks
+              @ opt_string_field "turn_ref"
+                  (Option.map Ids.Turn_ref.to_string m.turn_ref)))
        messages)

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -167,6 +167,13 @@ type chat_message = {
           an unknown label is reported as a persistence read drop and
           reads as [Utterance] — the conservative arm: the row renders
           and advances the watermark like any reply. *)
+  turn_ref : Ids.Turn_ref.t option;
+      (** RFC-0233 §7: ["<trace_id>#<absolute_turn>"] join key for the turn
+          that produced this row.  Stamped by {!append_turn} /
+          {!append_assistant_message} when the caller supplies it; [None]
+          on inbound user lines (no turn yet) and rows written before §7.
+          A malformed persisted value is reported as a persistence read
+          drop and reads as [None]; the row stays valid. *)
 }
 
 (** {1 I/O} *)
@@ -196,6 +203,7 @@ val append_turn :
   ?extra_mentions:Keeper_identity.Keeper_id.t list ->
   ?assistant_kind:Row_kind.t ->
   ?blocks:chat_block list ->
+  ?turn_ref:Ids.Turn_ref.t ->
   assistant_content:string ->
   unit ->
   unit
@@ -213,6 +221,7 @@ val append_assistant_message :
   ?conversation_id:string ->
   ?audio:audio_clip ->
   ?blocks:chat_block list ->
+  ?turn_ref:Ids.Turn_ref.t ->
   unit ->
   unit
 

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1100,6 +1100,54 @@ let test_blocks_roundtrip_and_drop_malformed () =
           | None -> Alcotest.fail "blocks missing")
       | messages -> Alcotest.failf "expected 1 row, got %d" (List.length messages))
 
+(* RFC-0233 §7: append_turn stamps the supplied turn_ref on every row of the
+   completed turn, it round-trips through load, and to_json_array exposes it
+   for the history endpoint. *)
+let test_turn_ref_persisted_on_turn_rows () =
+  let base_dir = temp_base_path "keeper-chat-store-turnref" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-turnref" in
+      let tref = Ids.Turn_ref.make ~trace_id:"trace-abc" ~absolute_turn:7 in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"do it"
+        ~user_attachments:[]
+        ~tool_calls:[ { K.call_id = "t1"; call_name = "Read"; args = "{}" } ]
+        ~turn_ref:tref ~assistant_content:"done" ();
+      let messages = K.load ~base_dir ~keeper_name in
+      List.iter
+        (fun (m : K.chat_message) ->
+          match m.turn_ref with
+          | Some tr ->
+              Alcotest.(check string)
+                (Printf.sprintf "turn_ref on %s row" (K.Role.to_label m.role))
+                "trace-abc#7"
+                (Ids.Turn_ref.to_string tr)
+          | None -> Alcotest.fail "missing turn_ref on a completed-turn row")
+        messages;
+      let s = Yojson.Safe.to_string (K.to_json_array messages) in
+      Alcotest.(check bool) "turn_ref present in to_json_array" true
+        (contains_substring s "trace-abc#7"))
+
+(* A malformed persisted turn_ref is surfaced as a read drop and reads as
+   [None] — never repaired — while the row itself stays valid. *)
+let test_turn_ref_malformed_reads_none () =
+  let base_dir = temp_base_path "keeper-chat-store-turnref-bad" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-turnref-bad" in
+      let path = chat_path ~base_dir ~keeper_name in
+      write_file path
+        ({|{"role":"assistant","content":"x","ts":1.0,"turn_ref":"no-separator"}|}
+        ^ "\n");
+      match K.load ~base_dir ~keeper_name with
+      | [ m ] ->
+          Alcotest.(check bool) "malformed turn_ref reads as None" true
+            (m.turn_ref = None)
+      | messages ->
+          Alcotest.failf "expected 1 message, got %d" (List.length messages))
+
 let () =
   Alcotest.run "keeper_chat_store"
     [
@@ -1189,5 +1237,9 @@ let () =
             test_orphan_leading_tool_lines_trimmed;
           Alcotest.test_case "tail-bounded load matches full-scan window (RFC-0226 P2)"
             `Quick test_tail_bounded_load_matches_full_scan_window;
+          Alcotest.test_case "turn_ref stamped on turn rows + json (RFC-0233 §7)"
+            `Quick test_turn_ref_persisted_on_turn_rows;
+          Alcotest.test_case "malformed turn_ref reads as None (RFC-0233 §7)"
+            `Quick test_turn_ref_malformed_reads_none;
         ] );
     ]

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -64,6 +64,7 @@ let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None)
   ; blocks = None
   ; mentions = Masc.Keeper_lane_mentions.mention_ids_of_content content
   ; kind
+  ; turn_ref = None
   }
 ;;
 
@@ -203,6 +204,7 @@ let tool_line : Store.chat_message =
   ; blocks = None
   ; mentions = []
   ; kind = Store.Row_kind.Utterance
+  ; turn_ref = None
   }
 ;;
 

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -28,6 +28,7 @@ let msg ?ts ?source ?speaker ~role content : Store.chat_message =
     blocks = None;
     mentions = [];
     kind = Store.Row_kind.Utterance;
+    turn_ref = None;
   }
 
 let external_speaker ?name id : Store.speaker =


### PR DESCRIPTION
## 무엇을 / 왜

RFC-0233 §7(Turn_ref 계약)의 **PR-A2 — keeper chat store turn_ref 영속화 capability**.

turn-identity 체인의 끊긴 seam은 MASC chat-persist 경계입니다. 위(`Turn_record.t`)엔 이미 진짜 id(`trace_id` + `absolute_turn`)가 있고, 아래(board/API/FE)엔 join할 키가 없습니다. PR-A1(#21662, merged)이 `Ids.Turn_ref` 타입과 `Turn_record.turn_ref`를 추가했습니다. 이 PR은 그 `Turn_ref`를 keeper chat store가 **영속화·복원**할 수 있게 만듭니다 — 모든 turn row가 board post와 같은 join 키를 들 수 있는 토대.

## 변경

- `chat_message`에 `turn_ref : Ids.Turn_ref.t option` 추가 (inbound user line·§7 이전 row는 `None`)
- `append_turn` / `append_assistant_message`에 `?turn_ref` 인자 — completed turn의 **모든 row**(user/tool/assistant)에 stamp. `append_user_message`는 불변(inbound, pre-turn — 아직 turn id 없음)
- `encode_line`이 `"turn_ref"` emit, `parse_line`이 복원. malformed 값은 persistence read drop으로 보고하고 `None`으로 읽음 — **repair 하지 않음**, row 자체는 유효 유지
- `to_json_array`가 history endpoint용으로 `turn_ref` 노출

## 범위 경계 (capability only)

population 경로(`keeper_turn` reply → `extract_visible_reply` → append site로 minted Turn_ref 전달)는 **PR-A3**로 분리합니다. reply seam에서 `total_turns`를 재유도하면 writer의 `total_turns + 1`과 off-by-one이 날 수 있어, RFC §7.2 **"mint once, thread down — never re-derive"**를 지키기 위함입니다.

## 검증

- `dune build --root .` 전체 green (foundational record 필드 추가라 모든 chat_message literal 생성처를 컴파일러가 강제 — test fixture 3곳 포함 전수 갱신)
- 신규 테스트 2종 `[OK]`:
  - `turn_ref stamped on every turn row` — append_turn이 모든 row에 stamp + load 라운드트립 + `to_json_array` 노출
  - `malformed turn_ref reads as None` — `"no-separator"` 영속값이 read drop + `None`, row 유효
- 기존 실패 1건(`recent context is owner-only`)은 **이 변경과 무관**: standalone `dune exec`에 Eio_main 래퍼가 없어 `direct_owner_conversation_context`가 Memory backend로 fallback하는 로컬 환경 artifact. base(stash)에서 동일 실패(33 tests/1 fail), 내 브랜치(35 tests/1 fail)로 회귀 0 확인. PR-A1이 컨베이어 CI green으로 머지된 사실이 CI에선 통과함을 방증.

## Workaround Guards (RFC-0233 §7 준수)

- typed `Ids.Turn_ref` (string smuggle 아님)
- malformed → read drop + `None` (silent repair 아님, telemetry-as-fix 아님)
- `?turn_ref`로 모든 append site 컴파일러 강제 (N-of-M 마이그레이션 아님)

Refs: RFC-0233 §7. 선행 PR-A1 #21662 (merged).
