### PR TITLE
test(completion-trust): §9 dispatch reject oracle (RFC-0262 E1 scripted backbone)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1114,6 +1114,14 @@
  (modules test_completion_trust_audit)
  (libraries alcotest yojson masc.completion_trust_audit))
 
+; RFC-0262 §9 completion-trust dispatch oracle (E1: scripted backbone).
+; Deterministic reject gates on the full keeper_task_done dispatch path, no LLM.
+
+(test
+ (name test_completion_trust_harness)
+ (modules test_completion_trust_harness)
+ (libraries masc_test_deps))
+
 ; Scheduled internal automation domain guardrails.
 
 (test

--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -1,0 +1,300 @@
+(** RFC-0262 §9 completion-trust dispatch oracle (E1: scripted backbone).
+
+    A deterministic regression oracle for the completion-trust invariants:
+    replay known-bad [keeper_task_done] attempts through the *full* keeper
+    tool-dispatch path ([Keeper_tool_dispatch_runtime.execute_keeper_tool_call_with_outcome])
+    and assert that each deterministic gate rejects them — with no LLM and no
+    network. The point is not to measure a behavior change (RFC-0262 Phase 1 is a
+    behavior-preserving refactor); it is to *catch* a future regression where a
+    Done becomes reachable through an illegitimate path.
+
+    Three deterministic reject gates are on the Done_action path (see
+    [Tool_task.handle_transition] gate ordering):
+
+    1. [completion_state_error] (tool_task_contract_gate.ml) — the tool-layer
+       ownership/lifecycle precondition, fires first:
+         - foreign-owned task + non-owner caller -> [AlreadyClaimed],
+           rule_id "task_done_requires_current_owner" (this is the dispatch-level
+           enforcement of RFC-0262 axis-2 ownership; [owner_authorized] in
+           workspace_task_lifecycle is the deeper redundant defense).
+         - Todo (unclaimed) task -> [NotClaimed],
+           rule_id "task_done_requires_claimed_or_started".
+    2. anti-rationalization Gate 1 (anti_rationalization.ml:644) — completion
+       notes below the substance floor ([min_notes_length] = 10) are rejected
+       before Gate 3 ever calls an LLM. Reachable only when the caller owns the
+       task (otherwise gate 1 above intercepts first).
+
+    Each reject asserts a gate-SPECIFIC signal (distinct rule_id / substring /
+    failure_class), not merely outcome=failure — a tool-not-allowed or unknown-tool
+    reject would also be a failure but carries failure_class "policy_rejection",
+    so the gate-specific assertion is what proves the *intended* gate fired. Each
+    reject also asserts the task FSM was NOT mutated (anti-vacuity).
+
+    Deliberately NOT covered here, with rationale:
+    - A legitimate *completion* success: once notes clear the length floor, the
+      anti-rationalization review reaches its Gate-3 LLM branch, whose
+      unavailable-LLM verdict is governed by operator fail-mode config and is not
+      deterministic in a no-LLM CI fixture. The deterministic success anchor is
+      therefore the *claim* (Test D), which has no review gate.
+    - An evidence-gate rejection on keeper_task_done: the deterministic evidence
+      evaluator is wired into the *claim* auto-complete path, not the done path
+      (a Phase-3 / RFC-0199 gap). Asserting a done-evidence reject here would
+      assert a gate that does not exist. The evaluator's Indeterminate-dominates
+      determinism is already covered by test_keeper_deterministic_evidence_probe.ml.
+
+    The fixture helpers below are intentionally a local copy of the minimal subset
+    used by test_keeper_tool_dispatch_runtime.ml (Eio workspace + a registered
+    keeper). Kept self-contained so this oracle is decoupled from that 1.4k-line
+    test's churn rather than coupling them through a shared module. *)
+
+open Alcotest
+
+module KET = Masc.Keeper_tool_dispatch_runtime
+module Workspace = Masc.Workspace
+
+let temp_dir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir path =
+  let rec rm target =
+    if Sys.file_exists target then
+      if Sys.is_directory target then begin
+        Sys.readdir target
+        |> Array.iter (fun name -> rm (Filename.concat target name));
+        Unix.rmdir target
+      end
+      else Unix.unlink target
+  in
+  try rm path with _ -> ()
+
+let make_meta ?(name = "keeper-completion-trust") () =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ ("name", `String name)
+        ; ("agent_name", `String name)
+        ; ("trace_id", `String "completion-trust-harness-trace")
+        ; ("allowed_paths", `List [ `String "*" ])
+        ; ("policy_voice_enabled", `Bool false)
+        ; ("tool_access", `List [])
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> failwith ("make_meta failed: " ^ err)
+
+let make_ctx () =
+  Masc.Keeper_context_runtime.create ~system_prompt:"test" ~max_tokens:4000
+
+let with_ws name fn =
+  let dir = temp_dir name in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Masc.Workspace.default_config dir in
+      let meta = make_meta () in
+      ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+      Fun.protect
+        ~finally:(fun () ->
+          Masc.Keeper_registry.unregister ~base_path:config.base_path meta.name)
+        (fun () -> fn ~config ~meta ~ctx_work:(make_ctx ())))
+
+let payload_kind = function
+  | KET.Structured_success -> "structured_success"
+  | KET.Structured_error -> "structured_error"
+  | KET.Plain_text -> "plain_text"
+  | KET.Malformed_structured _ -> "malformed_structured"
+
+let outcome_label = function
+  | `Success -> "success"
+  | `Failure -> "failure"
+
+let parse_json raw =
+  try Yojson.Safe.from_string raw with
+  | Yojson.Json_error err -> fail ("invalid json: " ^ err)
+
+let contains_substring text needle =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    idx + needle_len <= text_len
+    && (String.sub text idx needle_len = needle || loop (idx + 1))
+  in
+  needle_len = 0 || loop 0
+
+(* Owner of a task if it is currently Claimed/InProgress, else None. *)
+let assignee_of config task_id =
+  match
+    List.find_opt
+      (fun (t : Masc_domain.task) -> String.equal t.id task_id)
+      (Workspace.get_tasks_raw config)
+  with
+  | Some
+      { task_status =
+          ( Masc_domain.Claimed { assignee; _ }
+          | Masc_domain.InProgress { assignee; _ } )
+      ; _
+      } ->
+    Some assignee
+  | _ -> None
+
+let attempt_done ~config ~meta ~ctx_work ~task_id ~result =
+  KET.execute_keeper_tool_call_with_outcome
+    ~config
+    ~meta
+    ~ctx_work
+    ~exec_cache:None
+    ~name:"keeper_task_done"
+    ~input:(`Assoc [ ("task_id", `String task_id); ("result", `String result) ])
+    ()
+
+let claim_via_dispatch ~config ~meta ~ctx_work ~task_id =
+  KET.execute_keeper_tool_call_with_outcome
+    ~config
+    ~meta
+    ~ctx_work
+    ~exec_cache:None
+    ~name:"keeper_task_claim"
+    ~input:(`Assoc [ ("task_id", `String task_id) ])
+    ()
+
+(* Test A — non-owner completion is denied (RFC-0262 axis-2 ownership gate). *)
+let test_completion_denied_for_non_owner () =
+  with_ws "completion_trust_non_owner" (fun ~config ~meta ~ctx_work ->
+    ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
+    ignore
+      (Workspace.add_task config ~title:"foreign-owned task" ~priority:1
+         ~description:"claimed by another agent");
+    let foreign = "other-keeper" in
+    (match Workspace.claim_task_r config ~agent_name:foreign ~task_id:"task-001" () with
+     | Ok _ -> ()
+     | Error e ->
+       fail ("foreign claim setup failed: " ^ Masc_domain.masc_error_to_string e));
+    (* pre-state: task-001 owned by a non-caller agent (else the reject below
+       would be NotClaimed for the wrong reason). *)
+    (match assignee_of config "task-001" with
+     | Some a ->
+       check bool "pre-state: task owned by a non-caller agent" true
+         (not (String.equal a meta.agent_name))
+     | None ->
+       fail "task-001 must be Claimed/InProgress by the foreign agent before the attack");
+    (* attack: caller (non-owner) tries to complete it, with substantive notes so
+       the reject is unambiguously about ownership, not note length. *)
+    let result =
+      attempt_done ~config ~meta ~ctx_work ~task_id:"task-001"
+        ~result:"I finished another agent's task on their behalf"
+    in
+    check string "non-owner completion outcome" "failure" (outcome_label result.KET.outcome);
+    check string "non-owner completion payload shape" "structured_error"
+      (payload_kind result.KET.payload_shape);
+    let json = parse_json result.KET.raw_output in
+    check bool "rejection is ok=false" false Yojson.Safe.Util.(member "ok" json |> to_bool);
+    check string "ownership reject is a deterministic workflow rejection" "workflow_rejection"
+      Yojson.Safe.Util.(member "failure_class" json |> to_string);
+    check string "ownership reject rule_id" "task_done_requires_current_owner"
+      Yojson.Safe.Util.(member "diagnosis" json |> member "rule_id" |> to_string);
+    (* anti-vacuity: the rejected attempt did NOT advance the FSM. *)
+    (match assignee_of config "task-001" with
+     | Some a ->
+       check bool "task still owned by foreign agent after rejected completion" true
+         (not (String.equal a meta.agent_name))
+     | None -> fail "task-001 must remain Claimed/InProgress after the rejected completion"))
+
+(* Test B — completion of an unclaimed (Todo) task is denied. *)
+let test_completion_denied_when_unclaimed () =
+  with_ws "completion_trust_unclaimed" (fun ~config ~meta ~ctx_work ->
+    ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
+    ignore
+      (Workspace.add_task config ~title:"never claimed" ~priority:1
+         ~description:"still in the backlog");
+    (* task-001 is Todo; nobody claimed it. *)
+    let result =
+      attempt_done ~config ~meta ~ctx_work ~task_id:"task-001"
+        ~result:"pretending an unclaimed backlog item is finished"
+    in
+    check string "unclaimed completion outcome" "failure" (outcome_label result.KET.outcome);
+    check string "unclaimed completion payload shape" "structured_error"
+      (payload_kind result.KET.payload_shape);
+    let json = parse_json result.KET.raw_output in
+    check string "unclaimed reject is a workflow rejection" "workflow_rejection"
+      Yojson.Safe.Util.(member "failure_class" json |> to_string);
+    check string "unclaimed reject rule_id" "task_done_requires_claimed_or_started"
+      Yojson.Safe.Util.(member "diagnosis" json |> member "rule_id" |> to_string);
+    (* anti-vacuity: task stays Todo. *)
+    match
+      List.find_opt
+        (fun (t : Masc_domain.task) -> String.equal t.id "task-001")
+        (Workspace.get_tasks_raw config)
+    with
+    | Some { task_status = Masc_domain.Todo; _ } -> ()
+    | _ -> fail "task-001 must remain Todo after the rejected completion")
+
+(* Test C — completion of one's OWN task with sub-floor notes is denied by the
+   deterministic anti-rationalization length gate. *)
+let test_completion_denied_for_thin_notes () =
+  with_ws "completion_trust_thin_notes" (fun ~config ~meta ~ctx_work ->
+    ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
+    ignore
+      (Workspace.add_task config ~title:"caller's own task" ~priority:1
+         ~description:"claimed by the caller, then completed with no substance");
+    (* precondition: caller legitimately claims its own task (must own it to reach
+       the review gate; otherwise completion_state_error intercepts first). *)
+    let claim = claim_via_dispatch ~config ~meta ~ctx_work ~task_id:"task-001" in
+    check string "self-claim precondition succeeds" "success" (outcome_label claim.KET.outcome);
+    (* attack: complete own task with notes below the substance floor (<10 chars). *)
+    let result = attempt_done ~config ~meta ~ctx_work ~task_id:"task-001" ~result:"done" in
+    check string "thin-notes completion outcome" "failure" (outcome_label result.KET.outcome);
+    check string "thin-notes completion payload shape" "structured_error"
+      (payload_kind result.KET.payload_shape);
+    let json = parse_json result.KET.raw_output in
+    check string "thin-notes reject is a workflow rejection" "workflow_rejection"
+      Yojson.Safe.Util.(member "failure_class" json |> to_string);
+    check bool "thin-notes reject names the anti-rationalization length floor" true
+      (contains_substring result.KET.raw_output "completion notes too short");
+    (* anti-vacuity: caller still owns the task; it was NOT marked Done. *)
+    match assignee_of config "task-001" with
+    | Some assignee -> check string "task still owned by caller, not Done" meta.agent_name assignee
+    | None -> fail "task-001 must remain Claimed/InProgress after the rejected completion")
+
+(* Test D — positive control: the gates are SELECTIVE, not reject-everything.
+   A keeper claiming its own backlog task is accepted on the same dispatch path. *)
+let test_legitimate_claim_succeeds () =
+  with_ws "completion_trust_positive_claim" (fun ~config ~meta ~ctx_work ->
+    ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
+    ignore
+      (Workspace.add_task config ~title:"claimable task" ~priority:1
+         ~description:"unowned backlog work");
+    let result = claim_via_dispatch ~config ~meta ~ctx_work ~task_id:"task-001" in
+    check string "legitimate claim outcome" "success" (outcome_label result.KET.outcome);
+    check string "legitimate claim payload shape" "structured_success"
+      (payload_kind result.KET.payload_shape);
+    match assignee_of config "task-001" with
+    | Some assignee -> check string "claimed task is owned by the caller" meta.agent_name assignee
+    | None -> fail "task-001 must be Claimed/InProgress after a legitimate claim")
+
+let () =
+  Masc_test_deps.init_keeper_tool_registry ();
+  (* The anti-rationalization review resolves an evaluator-runtime id before its
+     gates run (default-arg of [Anti_rationalization.review]); that resolution
+     reads [Workspace_hooks.get_default_runtime_id_fn], which the real server
+     wires at boot (mcp_server.ml) and which raises if left unconnected. Wire a
+     fixed dummy id so Test C reaches Gate 1. The length verdict stays
+     deterministic: notes below [min_notes_length] short-circuit before the
+     Gate-3 LLM call, so no model runtime is ever invoked. *)
+  Atomic.set Workspace_hooks.get_default_runtime_id_fn (fun () -> "test-evaluator-runtime");
+  run "Completion_trust_harness"
+    [ ( "completion_trust_dispatch_oracle"
+      , [ test_case "non-owner completion is denied (ownership gate)" `Quick
+            test_completion_denied_for_non_owner
+        ; test_case "completion of an unclaimed task is denied" `Quick
+            test_completion_denied_when_unclaimed
+        ; test_case "completion with sub-floor notes is denied (anti-rationalization length gate)"
+            `Quick test_completion_denied_for_thin_notes
+        ; test_case "legitimate self-claim is accepted (selectivity control)" `Quick
+            test_legitimate_claim_succeeds
+        ] )
+    ]


### PR DESCRIPTION
## 목표

RFC-0262 §9 completion-trust 측정 하네스의 **eval 축 PR-B (E1: scripted 백본)**. 완료신뢰 불변식의 **결정론 회귀 오라클** — Done이 비합법 경로로 도달하면 *상시 CI에서* 잡는다. RFC-0262 Phase 1(#21612, MERGED)은 behavior-preserving 리팩터라 측정할 "행동 변화"가 없으므로, 측정의 목적은 변화 측정이 아니라 게이트가 *유지되는지* 확인하는 것이다 (MANIFEST "Harness First").

live 축(auditor + CLI + transition-log authority 직렬화)은 #21612로 이미 main에 있다. 이 PR은 그 위에 결정론 dispatch 오라클을 얹는다.

## 변경

신규 `test/test_completion_trust_harness.ml` (+ `test/dune` stanza 1개). 기존 코드 **0 변경**.

알려진 비합법 `keeper_task_done` 시도를 full dispatch 경로(`Keeper_tool_dispatch_runtime.execute_keeper_tool_call_with_outcome`)에 replay하고, 각 **결정론 게이트**가 거부하는지 단언한다 (LLM·네트워크 없음):

| 테스트 | 시도 | 발화 게이트 | 단언 시그널 |
|---|---|---|---|
| A | non-owner가 foreign 태스크 완료 | `completion_state_error` AlreadyClaimed (tool 레이어 ownership = RFC-0262 axis②) | `failure_class=workflow_rejection`, `diagnosis.rule_id=task_done_requires_current_owner` |
| B | unclaimed(Todo) 태스크 완료 | `completion_state_error` NotClaimed | `diagnosis.rule_id=task_done_requires_claimed_or_started` |
| C | 자기 태스크를 <10자 notes로 완료 | anti-rationalization Gate 1 (length floor, Gate 3 LLM 이전) | `error`에 `"completion notes too short"` |
| D | 정당한 self-claim | (positive control) | `outcome=success`, 태스크가 caller 소유 |

각 reject는 **게이트별 고유 시그널**(distinct rule_id / substring / failure_class)을 단언한다 — 단순 `outcome=failure`가 아니라. tool-not-allowed/unknown-tool 거부는 `policy_rejection`이라 게이트별 단언이 *의도한* 게이트 발화를 증명한다. 각 reject는 **FSM 미변경**(anti-vacuity)도 검증한다.

## 의도적 비범위 (근거 명시)

- **정당한 완료 성공**: notes가 length floor를 넘으면 anti-rat review가 Gate 3 LLM 분기에 도달하고, 그 LLM-부재 verdict는 운영자 fail-mode 설정에 좌우돼 no-LLM CI에서 비결정적. 따라서 결정론 성공 앵커는 *claim*(Test D)이다.
- **done 경로 evidence 게이트 거부**: 결정론 evidence evaluator는 *claim* auto-complete 경로에 배선돼 있고 done 경로엔 없다(Phase 3 / RFC-0199 갭). 존재하지 않는 게이트를 단언하면 허위 테스트가 되므로 제외. evaluator의 Indeterminate-dominates 결정론은 이미 `test_keeper_deterministic_evidence_probe.ml`가 커버한다.

## 검증

- `dune build --root . test/test_completion_trust_harness.exe` — green
- `dune exec --root . test/test_completion_trust_harness.exe` — 4/4 pass

## 워크어라운드 self-check

회귀 오라클(read-only test). 텔레메트리-as-fix 아님(수정은 Phase 1/2에 이미 landed, 이건 유지 확인). string-classifier·N-of-M·cap/cooldown/dedup/repair·catch-all 없음. 기존 코드 0 변경.

RFC-0262 §9 (completion-trust metric harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
