### PR TITLE
fix(keeper): surface execute pipeline recovery plans

### DIFF
--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -76,6 +76,69 @@ let typed_validation_deterministic_retry_fields
   Keeper_tool_deterministic_error.deterministic_retry_fields
     Keeper_tool_deterministic_error.Command_shape_blocked
 
+let typed_validation_recovery_fields
+      (err : Keeper_tool_execute_typed_input.validation_error)
+  =
+  let diagnosis ~rule_id =
+    [ ( "diagnosis"
+      , `Assoc
+          [ "rule_id", `String rule_id
+          ; "tool_suggestion", `String "Execute"
+          ; "scope_policy", `String "observe"
+          ] )
+    ]
+  in
+  let recovery_plan ~input_shape ~instruction ~example =
+    [ ( "recovery_plan"
+      , `Assoc
+          [ "next_tool", `String "Execute"
+          ; "input_shape", `String input_shape
+          ; "instruction", `String instruction
+          ; "example", example
+          ] )
+    ]
+  in
+  match err with
+  | Keeper_tool_execute_typed_input.Argv_contains_shell_pipeline_operator _ ->
+    diagnosis ~rule_id:"execute_pipeline_operator_in_argv"
+    @ recovery_plan
+        ~input_shape:"pipeline"
+        ~instruction:
+          "Retry Execute with top-level pipeline=[{executable,argv}, ...], \
+           removing executable/argv from the top level. Do not use sh -c and \
+           do not put '|' in argv."
+        ~example:
+          (`Assoc
+             [ ( "pipeline"
+               , `List
+                   [ `Assoc
+                       [ "executable", `String "git"
+                       ; "argv", `List [ `String "log"; `String "--oneline" ]
+                       ]
+                   ; `Assoc
+                       [ "executable", `String "head"
+                       ; "argv", `List [ `String "-20" ]
+                       ]
+                   ] )
+             ; "cwd", `String "repos/<repo>"
+             ])
+  | Keeper_tool_execute_typed_input.Argv_contains_shell_redirection _ ->
+    diagnosis ~rule_id:"execute_redirection_operator_in_argv"
+    @ recovery_plan
+        ~input_shape:"typed_redirect"
+        ~instruction:
+          "Retry Execute with the typed stdin/stdout/stderr fields and remove \
+           shell redirection tokens from argv. For discarded stderr use \
+           stderr={discard:true}; do not use sh -c."
+        ~example:
+          (`Assoc
+             [ "executable", `String "find"
+             ; "argv", `List [ `String "."; `String "-name"; `String "*.ml" ]
+             ; "stderr", `Assoc [ "discard", `Bool true ]
+             ; "cwd", `String "repos/<repo>"
+             ])
+  | _ -> []
+
 let normalize_path_for_keeper_tool_execute_shell_ir_containment path =
   Keeper_alerting_path.normalize_path_for_check path
   |> Keeper_alerting_path.strip_trailing_slashes
@@ -157,6 +220,7 @@ let handle_tool_execute_typed
              [ "typed", `Bool true; "cwd", `String cwd ]
              @ execution_location_fields cwd
              @ typed_validation_deterministic_retry_fields e
+             @ typed_validation_recovery_fields e
              @
              (match alts with
               | [] -> []
@@ -264,6 +328,7 @@ let handle_tool_execute_typed
             @ response_cwd_field
             @ execution_location_fields cwd
             @ typed_validation_deterministic_retry_fields e
+            @ typed_validation_recovery_fields e
             @
             (match alts with
              | [] -> []

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -137,7 +137,14 @@ let typed_validation_recovery_fields
              ; "stderr", `Assoc [ "discard", `Bool true ]
              ; "cwd", `String "repos/<repo>"
              ])
-  | _ -> []
+  | Keeper_tool_execute_typed_input.Empty_executable _
+  | Keeper_tool_execute_typed_input.Executable_repeated_in_argv0 _
+  | Keeper_tool_execute_typed_input.Argv_contains_shell_metachar _
+  | Keeper_tool_execute_typed_input.Redirect_path_not_absolute _
+  | Keeper_tool_execute_typed_input.Cwd_not_absolute _
+  | Keeper_tool_execute_typed_input.Pipeline_empty
+  | Keeper_tool_execute_typed_input.Pipeline_too_short
+  | Keeper_tool_execute_typed_input.Env_key_invalid _ -> []
 
 let normalize_path_for_keeper_tool_execute_shell_ir_containment path =
   Keeper_alerting_path.normalize_path_for_check path

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -560,10 +560,13 @@ let pp_validation_error ppf = function
     Format.fprintf
       ppf
       "executable %S argv[%d]=%S is a shell pipeline operator; argv tokens \
-       are passed verbatim to execve and never create pipelines. Split the \
-       command into typed Pipeline.stages instead."
+       are passed verbatim to execve and never create pipelines. Retry \
+       Execute with the top-level pipeline field, e.g. \
+       pipeline=[{executable;argv},...]. Do not wrap this in sh/bash and do \
+       not put %S in argv."
       executable
       index
+      token
       token
   | Argv_contains_shell_redirection { executable; index; token } ->
     Format.fprintf
@@ -571,7 +574,8 @@ let pp_validation_error ppf = function
       "executable %S argv[%d]=%S is a shell redirection operator; argv \
        tokens are passed verbatim to execve and never interpreted as \
        redirection. Use the typed redirect fields (RFC-0198 Phase B: \
-       discard_stderr/stdout/stderr) or split into a Pipeline."
+       stderr={discard:true}, stdout={discard:true}, or \
+       {file:\"/abs/path\"}) or use Execute.pipeline."
       executable
       index
       token
@@ -591,17 +595,17 @@ let pp_validation_error ppf = function
       path
   | Cwd_not_absolute path ->
     Format.fprintf ppf "cwd %S is not absolute" path
-  | Pipeline_empty -> Format.pp_print_string ppf "Pipeline.stages is empty"
+  | Pipeline_empty -> Format.pp_print_string ppf "pipeline is empty"
   | Pipeline_too_short ->
-    Format.pp_print_string ppf "Pipeline.stages requires at least two stages"
+    Format.pp_print_string ppf "pipeline requires at least two stages"
   | Env_key_invalid k ->
     Format.fprintf ppf "env key %S is not [A-Za-z0-9_]+" k
 ;;
 
 let validation_error_alternatives : validation_error -> string list = function
   | Argv_contains_shell_metachar _ -> []
-  | Argv_contains_shell_pipeline_operator _ -> [ "Pipeline" ]
+  | Argv_contains_shell_pipeline_operator _ -> [ "Execute.pipeline" ]
   | Argv_contains_shell_redirection _ ->
-    [ "discard_stderr"; "discard_stdout"; "Pipeline" ]
+    [ "stderr:{discard:true}"; "stdout:{discard:true}"; "Execute.pipeline" ]
   | _ -> []
 ;;

--- a/lib/keeper/keeper_tool_execute_typed_input.mli
+++ b/lib/keeper/keeper_tool_execute_typed_input.mli
@@ -18,11 +18,12 @@
       [find . -name *.ml] because [*.ml] is a [find]-internal pattern, not a
       shell glob; it also accepts multiline `gh --body` text because the
       argument is passed directly to [gh].
-    - **Pipelines are explicit**.  [Pipeline.stages] enumerates each
-      [exec_stage] separately; [|]-delimited strings are never parsed.  A
+    - **Pipelines are explicit**.  The top-level JSON [pipeline] field
+      enumerates each [exec_stage] separately; [|]-delimited strings are never
+      parsed.  A
       standalone pipe operator token (["|"] / ["|&"]) in direct [Exec.argv] is
       rejected because it can only become bogus argv data (for example
-      [tail: |: No such file or directory]); use [Pipeline] instead.
+      [tail: |: No such file or directory]); use [pipeline] instead.
     - **Forbidden argv shapes**: [NUL], standalone pipe operator tokens, and
       shell redirection operator tokens.  [NUL] cannot be represented in an
       execve argv string.  Pipe/redirection operator tokens are rejected as
@@ -92,9 +93,10 @@ type validation_error =
     }
       (** Standalone shell pipeline operator token (["|"] or ["|&"]) in
           [Exec.argv].  These tokens are never interpreted as pipelines by
-          execve and commonly become bogus filenames/arguments.  Use
-          [Pipeline.stages]; payload tokens containing pipe characters (for
-          example ["foo|bar"] or multiline markdown bodies) remain valid. *)
+          execve and commonly become bogus filenames/arguments.  Use the
+          top-level JSON [pipeline] field; payload tokens containing pipe
+          characters (for example ["foo|bar"] or multiline markdown bodies)
+          remain valid. *)
   | Argv_contains_shell_redirection of {
       executable : string;
       index : int;

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -20,6 +20,11 @@ let string_assoc key fields =
   | Some (`String value) when String.trim value <> "" -> Some value
   | _ -> None
 
+let same_public_tool ~current next =
+  match is_execute_tool_name current, String.lowercase_ascii next with
+  | true, "execute" -> true
+  | _ -> String.equal current next
+
 let result_cwd raw_result =
   try
     match Yojson.Safe.from_string raw_result with
@@ -170,9 +175,16 @@ let execute_with_observers
           let key_label =
             Keeper_tool_deterministic_error.to_telemetry_key reason
           in
-          [ ( "do_not_retry_tool"
-            , `String name )
-          ; ( "retry_skipped"
+          let recovery_plan_fields = deterministic_recovery_plan_fields raw_result in
+          let do_not_retry_tool_fields =
+            match string_assoc "required_next_tool" recovery_plan_fields with
+            | Some next_tool when same_public_tool ~current:name next_tool -> []
+            | _ -> [ "do_not_retry_tool", `String name ]
+          in
+          do_not_retry_tool_fields
+          @ [ ( "do_not_retry_same_args"
+              , `Bool true )
+            ; ( "retry_skipped"
             , `Bool true )
           ; ( "retry_skipped_reason"
             , `String key_label )
@@ -185,11 +197,11 @@ let execute_with_observers
            | Some classification ->
              [ ( "retry_skipped_source"
                , `String
-                   (Keeper_tool_deterministic_error.classification_source_to_string
-                      classification.source) )
+                      (Keeper_tool_deterministic_error.classification_source_to_string
+                         classification.source) )
              ]
            | None -> [])
-          @ deterministic_recovery_plan_fields raw_result
+          @ recovery_plan_fields
       in
       let recovery_fields =
         workflow_rejection_recovery_fields @ deterministic_recovery_fields

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -752,7 +752,7 @@ let test_execute_typed_single_stage_pipeline_rejected () =
     ~meta
     ~args:(tool_execute_typed_single_stage_pipeline_args ~cwd:playground)
     ()
-  |> check_typed_validation_error "Pipeline.stages requires at least two stages"
+  |> check_typed_validation_error "pipeline requires at least two stages"
 
 let test_execute_typed_repeated_executable_is_deterministic () =
   setup ~sandbox:Keeper_types_profile_sandbox.Local

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -939,6 +939,76 @@ let test_tool_execute_raw_cmd_requires_typed_shell_ir () =
       check bool "single hard-cut rejection does not enrich circuit breaker" true
         Yojson.Safe.Util.(member "circuit_breaker" json = `Null))
 
+let test_tool_execute_pipe_argv_emits_pipeline_recovery_plan () =
+  with_exec_fixture "tool_execute_pipe_argv_emits_pipeline_recovery_plan"
+    (fun ~config ~meta ~ctx_work ->
+      let input =
+        `Assoc
+          [ "executable", `String "git"
+          ; ( "argv"
+            , `List
+                [ `String "log"
+                ; `String "--oneline"
+                ; `String "|"
+                ; `String "head"
+                ; `String "-20"
+                ] )
+          ]
+      in
+      let raw =
+        KET.execute_keeper_tool_call
+          ~config
+          ~meta
+          ~ctx_work
+          ~exec_cache:None
+          ~name:"tool_execute"
+          ~input
+          ()
+      in
+      let json = parse_json raw in
+      let open Yojson.Safe.Util in
+      check bool "typed marker" true (member "typed" json |> to_bool);
+      let error = member "error" json |> to_string in
+      check bool
+        "pipe argv error names executable"
+        true
+        (contains_substring error "executable \"git\" argv[2]=\"|\"");
+      check bool
+        "pipe argv error points at top-level pipeline"
+        true
+        (contains_substring error "top-level pipeline field");
+      check bool
+        "pipe argv error forbids sh/bash wrapper"
+        true
+        (contains_substring error "Do not wrap this in sh/bash");
+      check bool
+        "alternatives point at Execute.pipeline"
+        true
+        (member "alternatives" json |> json_list_contains "Execute.pipeline");
+      let diagnosis = member "diagnosis" json in
+      check string
+        "diagnosis suggests Execute"
+        "Execute"
+        (member "tool_suggestion" diagnosis |> to_string);
+      check string
+        "diagnosis pins pipe rule"
+        "execute_pipeline_operator_in_argv"
+        (member "rule_id" diagnosis |> to_string);
+      let plan = member "recovery_plan" json in
+      check string
+        "recovery plan keeps same public tool"
+        "Execute"
+        (member "next_tool" plan |> to_string);
+      check string
+        "recovery plan names pipeline shape"
+        "pipeline"
+        (member "input_shape" plan |> to_string);
+      check bool
+        "recovery plan forbids sh -c"
+        true
+        (member "instruction" plan |> to_string |> fun s ->
+          contains_substring s "Do not use sh -c"))
+
 let keeper_msg_input_schema () =
   match
     List.find_opt
@@ -1353,6 +1423,8 @@ let () =
         test_workflow_rejection_payload_skips_circuit_breaker;
       test_case "tool_execute raw cmd requires typed Shell IR" `Quick
         test_tool_execute_raw_cmd_requires_typed_shell_ir;
+      test_case "tool_execute pipe argv emits pipeline recovery plan" `Quick
+        test_tool_execute_pipe_argv_emits_pipeline_recovery_plan;
       test_case "OAS handler threads Eio context to keeper dispatch" `Quick
         test_oas_handler_threads_eio_context_to_keeper_dispatch;
       test_case "registered dispatch does not require masc_ prefix" `Quick

--- a/test/test_keeper_tool_execute_typed_input.ml
+++ b/test/test_keeper_tool_execute_typed_input.ml
@@ -720,9 +720,13 @@ let test_standalone_pipe_operator_in_exec_argv_rejected () =
       Alcotest.(check string) (name ^ " token") token actual_token;
       let msg = Format.asprintf "%a" Execute_input.pp_validation_error err in
       Alcotest.(check bool)
-        (name ^ " message points to Pipeline.stages")
+        (name ^ " message points to Execute pipeline field")
         true
-        (String_util.contains_substring_ci msg "Pipeline.stages")
+        (String_util.contains_substring_ci msg "top-level pipeline field");
+      Alcotest.(check bool)
+        (name ^ " message forbids sh/bash wrapper")
+        true
+        (String_util.contains_substring_ci msg "do not wrap this in sh/bash")
     | Error other ->
       Alcotest.failf
         "%s: expected Argv_contains_shell_pipeline_operator, got %a"
@@ -926,9 +930,8 @@ let contains_substring haystack needle =
 
 let test_redirection_rejected_emits_typed_alternative () =
   (* The error message must steer the caller toward typed alternatives
-     (Phase B redirect fields or Pipeline mode), not toward the
-     deprecated "split into Pipeline stages" prose used for
-     control-character rejection. *)
+     (Phase B redirect fields or the public Execute.pipeline shape), not toward
+     stale internal constructor names. *)
   let input =
     Execute_input.Exec
       { executable = "find"
@@ -944,9 +947,9 @@ let test_redirection_rejected_emits_typed_alternative () =
   | Error (Execute_input.Argv_contains_shell_redirection _ as err) ->
     let msg = Format.asprintf "%a" Execute_input.pp_validation_error err in
     Alcotest.(check bool)
-      "error mentions discard_stderr typed field"
+      "error mentions stderr discard shape"
       true
-      (contains_substring msg "discard_stderr");
+      (contains_substring msg "stderr={discard:true}");
     Alcotest.(check bool)
       "error mentions Phase B RFC marker"
       true
@@ -963,7 +966,7 @@ let test_validation_error_alternatives () =
     ~name:"Argv_contains_shell_redirection alternatives"
     (Execute_input.Argv_contains_shell_redirection
        { executable = "find"; index = 3; token = "2>/dev/null" })
-    [ "discard_stderr"; "discard_stdout"; "Pipeline" ];
+    [ "stderr:{discard:true}"; "stdout:{discard:true}"; "Execute.pipeline" ];
   check_alts
     ~name:"Argv_contains_shell_metachar alternatives"
     (Execute_input.Argv_contains_shell_metachar
@@ -973,7 +976,7 @@ let test_validation_error_alternatives () =
     ~name:"Argv_contains_shell_pipeline_operator alternatives"
     (Execute_input.Argv_contains_shell_pipeline_operator
        { executable = "tail"; index = 3; token = "|" })
-    [ "Pipeline" ];
+    [ "Execute.pipeline" ];
   check_alts
     ~name:"Empty_executable has no alternatives"
     (Execute_input.Empty_executable { argv = [ "ls" ] })


### PR DESCRIPTION
## Summary
- replace stale internal Pipeline.stages guidance with the public Execute.pipeline shape
- add structured diagnosis/recovery_plan fields for Execute argv pipe/redirection shape blocks
- avoid telling agents not to retry the whole Execute tool when the recovery plan is to reuse Execute with a corrected input shape
- pin the pipe-argv recovery payload in dispatch/runtime tests

## Why
The deterministic block is correct: argv tokens are passed verbatim to execve and a literal "|" never creates a pipeline. The failure mode in live logs was the recovery surface: it pointed at internal Pipeline naming, and the normalized wrapper also said do_not_retry_tool=tool_execute even when the correct next action was Execute.pipeline.

## Verification
- ocamlformat --check lib/keeper/keeper_tools_oas_handler_exec.ml lib/keeper/keeper_tool_execute_typed_input.ml lib/keeper/keeper_tool_execute_typed_input.mli test/test_keeper_tool_execute_typed_input.ml test/test_keeper_tool_dispatch_runtime.ml test/test_keeper_sandbox_docker_route.ml
- git diff --check
- python3 scripts/check_test_coverage.py

Not run: focused Dune build/test binaries. The local Dune lock was held by other concurrent worktrees, and operator previously asked to leave builds for later.