### PR TITLE
Fix OAS model catalog bootstrap for live runtime

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -32,6 +32,105 @@ let config_bootstrap_mode = Config_root_bootstrap.config_bootstrap_mode
 let bootstrap_base_path_config_root = Config_root_bootstrap.bootstrap_base_path_config_root
 let startup_config_resolution = Config_root_bootstrap.startup_config_resolution
 
+type model_catalog_env_resolution =
+  { path : string
+  ; source : string
+  }
+
+let nonempty_env env name =
+  match env name with
+  | Some value ->
+    let value = String.trim value in
+    if String.equal value "" then None else Some value
+  | None -> None
+
+let existing_file path =
+  let path = String.trim path in
+  if String.equal path "" then
+    None
+  else
+    try
+      if Sys.file_exists path && not (Sys.is_directory path) then Some path else None
+    with
+    | Sys_error _ -> None
+
+let rec find_in_parents filename dir depth =
+  if depth <= 0 then
+    None
+  else
+    let path = Filename.concat dir filename in
+    match existing_file path with
+    | Some _ as found -> found
+    | None ->
+      let parent = Filename.dirname dir in
+      if String.equal parent dir then None else find_in_parents filename parent (depth - 1)
+
+let find_catalog_in_parents ~source dir =
+  match find_in_parents "models.toml" dir 10 with
+  | Some path -> Some { path; source = source ^ ":models.toml" }
+  | None ->
+    (match find_in_parents "oas-models.toml" dir 10 with
+     | Some path -> Some { path; source = source ^ ":oas-models.toml" }
+     | None -> None)
+
+let absolute_or_cwd ~cwd path =
+  let path = String.trim path in
+  if String.equal path "" then
+    None
+  else if String.length path > 0 && Char.equal path.[0] '/' then
+    Some path
+  else
+    Some (Filename.concat cwd path)
+
+let argv0_parent_dir ~cwd argv0 =
+  match absolute_or_cwd ~cwd argv0 with
+  | None -> None
+  | Some path -> Some (Filename.dirname path)
+
+let resolve_oas_model_catalog_path ?(env = Sys.getenv_opt) ?cwd ?argv0 () =
+  match nonempty_env env "OAS_MODEL_CATALOG" with
+  | Some path -> Some { path; source = "OAS_MODEL_CATALOG" }
+  | None ->
+    (match nonempty_env env "MASC_MODEL_CATALOG" with
+     | Some path -> Some { path; source = "MASC_MODEL_CATALOG" }
+     | None ->
+       let cwd =
+         match cwd with
+         | Some cwd when String.trim cwd <> "" -> cwd
+         | _ ->
+           (try Sys.getcwd () with
+            | Sys_error _ -> ".")
+       in
+       let argv0 =
+         match argv0 with
+         | Some argv0 -> argv0
+         | None ->
+           (match Array.to_list Sys.argv with
+            | head :: _ -> head
+            | [] -> "")
+       in
+       (match find_catalog_in_parents ~source:"cwd-parent" cwd with
+        | Some _ as found -> found
+        | None ->
+          (match argv0_parent_dir ~cwd argv0 with
+           | Some dir -> find_catalog_in_parents ~source:"argv0-parent" dir
+           | None -> None)))
+
+let configure_oas_model_catalog_env () =
+  match resolve_oas_model_catalog_path () with
+  | Some { source = "OAS_MODEL_CATALOG"; path } as resolution ->
+    Log.Misc.info "model_catalog: OAS_MODEL_CATALOG=%s already configured" path;
+    resolution
+  | Some { source; path } as resolution ->
+    Unix.putenv "OAS_MODEL_CATALOG" path;
+    Log.Misc.info "model_catalog: OAS_MODEL_CATALOG=%s resolved from %s" path source;
+    resolution
+  | None ->
+    Log.Misc.warn
+      "model_catalog: no OAS model catalog resolved; capability lookups may fall \
+       back to provider_default";
+    None
+
 (* GC tuning for long-running server with bursty allocation.
 
    Dashboard refresh loops create 2GB+ transient allocations per cycle.
@@ -86,19 +185,7 @@ let init_runtime_context env =
   let domain_mgr = Eio.Stdenv.domain_mgr env in
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let fs = Eio.Stdenv.fs env in
-  (* MASC_MODEL_CATALOG as convenience alias for OAS_MODEL_CATALOG.
-     OAS auto-discovers from ~/.masc/config/models.toml, cwd parents,
-     and $OAS_MODEL_CATALOG. Setting MASC_MODEL_CATALOG forwards it
-     so masc operators don't need to know OAS internals.
-     OAS lazily loads the catalog on first model capability query. *)
-  (match Sys.getenv_opt "MASC_MODEL_CATALOG" with
-   | Some path when Sys.getenv_opt "OAS_MODEL_CATALOG" = None ->
-     Unix.putenv "OAS_MODEL_CATALOG" path;
-     Log.Misc.info "model_catalog: MASC_MODEL_CATALOG=%s forwarded to OAS" path
-   | Some _ ->
-     Log.Misc.info "model_catalog: OAS_MODEL_CATALOG already set, MASC_MODEL_CATALOG ignored"
-   | None ->
-     ());
+  let (_ : model_catalog_env_resolution option) = configure_oas_model_catalog_env () in
   (clock, mono_clock, net, domain_mgr, proc_mgr, fs)
 
 let metric_keeper_runtime_config_load_failures =

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -16,6 +16,20 @@ val config_bootstrap_mode : unit -> [ `Auto | `Empty | `Skip ]
 val bootstrap_base_path_config_root : base_path:string -> unit
 val startup_config_resolution : base_path:string -> Config_dir_resolver.resolution
 
+type model_catalog_env_resolution =
+  { path : string
+  ; source : string
+  }
+
+val resolve_oas_model_catalog_path :
+  ?env:(string -> string option) ->
+  ?cwd:string ->
+  ?argv0:string ->
+  unit ->
+  model_catalog_env_resolution option
+
+val configure_oas_model_catalog_env : unit -> model_catalog_env_resolution option
+
 (** {1 Runtime Context}
 
     Extracts Eio resources from the standard environment.

--- a/oas-models.toml
+++ b/oas-models.toml
@@ -115,6 +115,22 @@ supports_seed = true
 input_per_million = 0.0
 output_per_million = 0.0
 
+[[models]]
+id_prefix = "gemma4-coder-"
+base = "openai_chat"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = false
+thinking_control_format = "chat_template_token"
+supports_native_streaming = true
+supports_top_k = true
+supports_seed = true
+input_per_million = 0.0
+output_per_million = 0.0
+
 # Ollama Cloud Models (canonical 2026-06 seed)
 # Source: https://ollama.com/api/tags + /api/show, checked 2026-06-20 KST.
 # Provider-qualified entries preserve Ollama Cloud wire behavior when a model id overlaps another provider.

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -125,6 +125,82 @@ let make_config_root root =
   write_file (Filename.concat config "personas/example.txt") "persona";
   config
 
+let test_model_catalog_resolution_prefers_explicit_env () =
+  let env = function
+    | "OAS_MODEL_CATALOG" -> Some "/explicit/oas-models.toml"
+    | "MASC_MODEL_CATALOG" -> Some "/ignored/masc-models.toml"
+    | _ -> None
+  in
+  (match
+     Server_runtime_bootstrap.resolve_oas_model_catalog_path
+       ~env
+       ~cwd:"/tmp/outside"
+       ~argv0:"/tmp/repo/_build/default/bin/main_eio.exe"
+       ()
+   with
+   | None -> Alcotest.fail "expected explicit OAS_MODEL_CATALOG resolution"
+   | Some resolution ->
+     Alcotest.(check string)
+       "source"
+       "OAS_MODEL_CATALOG"
+       resolution.Server_runtime_bootstrap.source;
+     Alcotest.(check string)
+       "path"
+       "/explicit/oas-models.toml"
+       resolution.Server_runtime_bootstrap.path);
+  let env = function
+    | "MASC_MODEL_CATALOG" -> Some "/explicit/masc-models.toml"
+    | _ -> None
+  in
+  match
+    Server_runtime_bootstrap.resolve_oas_model_catalog_path
+      ~env
+      ~cwd:"/tmp/outside"
+      ~argv0:"/tmp/repo/_build/default/bin/main_eio.exe"
+      ()
+  with
+  | None -> Alcotest.fail "expected MASC_MODEL_CATALOG resolution"
+  | Some resolution ->
+    Alcotest.(check string)
+      "source"
+      "MASC_MODEL_CATALOG"
+      resolution.Server_runtime_bootstrap.source;
+    Alcotest.(check string)
+      "path"
+      "/explicit/masc-models.toml"
+      resolution.Server_runtime_bootstrap.path
+
+let test_model_catalog_resolution_uses_executable_parent_when_cwd_is_base_path () =
+  with_temp_dir "model-catalog-bootstrap" (fun dir ->
+    let repo = Filename.concat dir "repo" in
+    let bin_dir = Filename.concat repo "_build/default/bin" in
+    mkdir_p bin_dir;
+    let outside = Filename.concat dir "base-path" in
+    Unix.mkdir outside 0o755;
+    let catalog = Filename.concat repo "oas-models.toml" in
+    write_file catalog "# repo-local OAS catalog\n";
+    let argv0 = Filename.concat bin_dir "main_eio.exe" in
+    let env _ = None in
+    match
+      Server_runtime_bootstrap.resolve_oas_model_catalog_path
+        ~env
+        ~cwd:outside
+        ~argv0
+        ()
+    with
+    | None ->
+      Alcotest.fail
+        "expected repo oas-models.toml from executable parent when cwd has no catalog"
+    | Some resolution ->
+      Alcotest.(check string)
+        "source"
+        "argv0-parent:oas-models.toml"
+        resolution.Server_runtime_bootstrap.source;
+      Alcotest.(check string)
+        "path"
+        catalog
+        resolution.Server_runtime_bootstrap.path)
+
 let write_config_root_keeper_toml config_root name =
   write_file
     (Filename.concat (Filename.concat config_root "keepers") (name ^ ".toml"))
@@ -3048,6 +3124,13 @@ let () =
           Alcotest.test_case
             "storage enforcement fallback reason is visible"
             `Quick test_storage_enforcement_fallback_reason;
+          Alcotest.test_case
+            "model catalog resolution prefers explicit env"
+            `Quick test_model_catalog_resolution_prefers_explicit_env;
+          Alcotest.test_case
+            "model catalog resolution falls back to executable parent"
+            `Quick
+            test_model_catalog_resolution_uses_executable_parent_when_cwd_is_base_path;
           Alcotest.test_case
             "bootstrap base-path config copies shared seed only"
             `Quick


### PR DESCRIPTION
## Summary
- Resolve and export OAS_MODEL_CATALOG during server bootstrap, preserving explicit OAS_MODEL_CATALOG and MASC_MODEL_CATALOG overrides.
- Add executable-parent fallback so live runs with cwd outside the repo still find the repo-local oas-models.toml.
- Add the RunPod Gemma coder alias to the OAS catalog with thinking support declared, without claiming response_format JSON support.
- Add adversarial regression coverage for env precedence and cwd-outside-repo executable-parent discovery.

## Verification
- ocamlformat --check lib/server/server_runtime_bootstrap.ml lib/server/server_runtime_bootstrap.mli test/test_server_runtime_bootstrap.ml
- git diff --check
- python3 TOML/capability assertions for oas-models.toml
- RunPod response_format=json_object probe timed out after 45s, so supports_response_format_json is intentionally not declared for gemma4-coder-.

## Not run
- scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe did not complete locally because existing Dune/opam lock contention from other worktrees kept the focused build running too long; CI should run the build.