### PR TITLE
refactor(keeper): remove Entropic_oscillation turn-trigger (policy A)

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -90,7 +90,6 @@ type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Task_reactive_cooldown_elapsed
   | Never_started
   | Min_interval_elapsed
-  | Entropic_oscillation
 
 type skip_reason = Keeper_world_observation_turn_types.skip_reason =
   | Keeper_paused
@@ -729,15 +728,6 @@ let effective_scheduled_autonomous_cooldown
     max floor (int_of_float (Float.round (float_of_int health_base *. factor))))
 ;;
 
-let entropic_oscillation_interval_sec = 600
-let entropic_oscillation_probability_percent = 5
-
-let should_inject_entropic_oscillation ~since_last_scheduled_autonomous ~draw_percent =
-  since_last_scheduled_autonomous >= entropic_oscillation_interval_sec
-  && draw_percent >= 0
-  && draw_percent < entropic_oscillation_probability_percent
-;;
-
 let keeper_cycle_decision
       ?(provider_cooldown_remaining_sec = provider_cooldown_remaining_sec_for_runtime)
       ?(reactive_wake = false)
@@ -871,12 +861,6 @@ let keeper_cycle_decision
            on top defeats its purpose. Without this bypass, keepers ignore
            unclaimed work for idle_gate seconds even when the backlog signal
            is ready to fire. Ref: #7226 claim-first + idle_gate observation. *)
-        let should_oscillate =
-          (not min_interval_elapsed)
-          && should_inject_entropic_oscillation
-               ~since_last_scheduled_autonomous
-               ~draw_percent:(Random.int 100)
-        in
         (* Reactive-wake gate (thundering-herd fix). When this evaluation runs
            because an external broadcast woke the keeper early ([reactive_wake]),
            the GLOBAL task backlog must not, on its own, drive a turn: otherwise
@@ -893,7 +877,6 @@ let keeper_cycle_decision
         in
         let should_run =
           is_bootstrap
-          || should_oscillate
           || min_interval_elapsed
           || (proactive_work_ready
               && (backlog_drives_turn || (idle_gate_elapsed && cooldown_elapsed)))
@@ -940,7 +923,6 @@ let keeper_cycle_decision
           then (
             let run_reasons =
               [ Some Scheduled_autonomous_turn
-              ; (if should_oscillate then Some Entropic_oscillation else None)
               ; (if is_bootstrap then Some Never_started else None)
               ; (if min_interval_elapsed then Some Min_interval_elapsed else None)
               ; (if idle_gate_elapsed

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -139,7 +139,6 @@ type turn_reason =
   | Task_reactive_cooldown_elapsed
   | Never_started
   | Min_interval_elapsed
-  | Entropic_oscillation
 
 (** Typed reason for skipping a keeper turn. *)
 type skip_reason =
@@ -324,17 +323,6 @@ val provider_capacity_blocked_task_count :
   claimable_task_count:int ->
   unit ->
   int
-
-val entropic_oscillation_interval_sec : int
-(** Minimum scheduled-autonomous silence before entropy injection can wake a
-    keeper. *)
-
-val entropic_oscillation_probability_percent : int
-(** Percent chance sampled after the interval gate has elapsed. *)
-
-val should_inject_entropic_oscillation :
-  since_last_scheduled_autonomous:int -> draw_percent:int -> bool
-(** Deterministic policy predicate for the stochastic entropy wakeup. *)
 
 val keeper_cycle_decision :
   ?provider_cooldown_remaining_sec:

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -46,7 +46,6 @@ type turn_reason =
   | Task_reactive_cooldown_elapsed
   | Never_started
   | Min_interval_elapsed
-  | Entropic_oscillation
 
 type skip_reason =
   | Keeper_paused
@@ -72,7 +71,6 @@ let turn_reason_to_string = function
   | Task_reactive_cooldown_elapsed -> "task_reactive_cooldown_elapsed"
   | Never_started -> "never_started"
   | Min_interval_elapsed -> "min_interval_elapsed"
-  | Entropic_oscillation -> "entropic_oscillation"
 ;;
 
 let skip_reason_to_string = function

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -23,7 +23,6 @@ type turn_reason =
   | Task_reactive_cooldown_elapsed
   | Never_started
   | Min_interval_elapsed
-  | Entropic_oscillation
 
 type skip_reason =
   | Keeper_paused

--- a/test/dune
+++ b/test/dune
@@ -32,6 +32,7 @@
   test_rfc0259_reconcile
   test_keeper_memory_lane
   test_keeper_reactive_wake_backlog_gate
+  test_keeper_no_signal_silence
   test_broadcast_wakeup_policy
   test_keeper_mention_scope
   test_keeper_lane_mentions
@@ -329,6 +330,7 @@
   test_keeper_memory_lane
   test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate
+  test_keeper_no_signal_silence
   test_broadcast_wakeup_policy
   test_keeper_mention_scope
   test_keeper_lane_mentions

--- a/test/test_keeper_no_signal_silence.ml
+++ b/test/test_keeper_no_signal_silence.ml
@@ -1,0 +1,176 @@
+(** No-signal silence invariant for [keeper_cycle_decision].
+
+    PR #21685 removed the [Entropic_oscillation] turn-trigger: a 600s / 5%
+    random probe that, per the runtime decision log (96 entropic turns over
+    ~19h on the analyst keeper), produced visible action 88.5% of the time —
+    contradicting the prompt policy ([config/prompts/keeper.core_behavior.md:4]:
+    a structured-work-less proactive turn reports [SPEECH_ACT: stay_silent]).
+
+    After the removal, a warm keeper (past bootstrap, [min_interval] not yet
+    elapsed, no provider cooldown) with NO per-keeper signal (no mention, board
+    event, or scope message) and NO global backlog must stay silent:
+    [should_run = false]. This file pins that invariant.
+
+    It is the structural dual of the thundering-herd backlog test
+    ([test_keeper_reactive_wake_backlog_gate]): that file shows global backlog
+    drives a run ([backlog=1] -> [should_run=true]); this file shows the
+    absence of all signals drives silence ([backlog=0] -> [should_run=false]).
+
+    The assertion is sensitive to [should_run]: a [|| true] mutation of the
+    intent flag is killed by this test. The removed [Entropic_oscillation]
+    fired on a 600s interval this warm (30s) meta never reaches, so this case
+    pins the post-removal invariant (signal-less turn -> silence) rather than
+    exercising the entropic path directly; its 5% jitter precluded a
+    deterministic kill regardless. *)
+
+open Alcotest
+
+module WO = Masc.Keeper_world_observation
+
+(* Provider cooldown is global in-memory state; pin it to "no cooldown" so the
+   decision is driven purely by the no-signal branch under test. *)
+let no_provider_cooldown ~keeper_name:_ ~runtime_id:_ = None
+
+(* [keeper_cycle_decision] resolves a runtime id (via [runtime_id_of_meta] ->
+   [Runtime.get_default_runtime_id]) unconditionally, which fails fast when no
+   default runtime is initialised (RFC-0206 §2.1). Initialise a minimal default
+   runtime the same way the other keeper unit tests do. *)
+let runtime_toml =
+  {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+;;
+
+let init_runtime_default_for_tests () =
+  let path = Filename.temp_file "keeper_silence_runtime_" ".toml" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc runtime_toml);
+  match Runtime.init_default ~config_path:path with
+  | Ok () -> ()
+  | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e
+;;
+
+let make_meta name =
+  let json =
+    `Assoc
+      [ ("name", `String name)
+      ; ("agent_name", `String ("agent-" ^ name))
+      ; ("trace_id", `String ("trace-silence-" ^ name))
+      ; ("goal", `String "no-signal silence invariant test")
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
+;;
+
+(* Warm, non-bootstrap meta: a recent-but-past scheduled-autonomous turn so the
+   bootstrap and [min_interval] liveness paths are inactive. This isolates the
+   no-signal branch: with nothing pending and [min_interval] not elapsed, the
+   only thing that could drive a run is a signal, of which there is none. *)
+let warm_meta () =
+  let meta = make_meta "silence" in
+  let now = Time_compat.now () in
+  { meta with
+    proactive = { enabled = true; idle_sec = 600; cooldown_sec = 1800 }
+  ; runtime =
+      { meta.runtime with
+        proactive_rt =
+          { meta.runtime.proactive_rt with
+            last_ts = now -. 30.0
+          ; consecutive_noop_count = 0
+          }
+      }
+  }
+;;
+
+(* No signal whatsoever: no mention, no board event, no scope message, no
+   global backlog, no backlog update since the last scheduled-autonomous turn.
+   This is the state a warm keeper reaches when the world is quiet. *)
+let no_signal_obs : WO.world_observation =
+  { pending_mentions = []
+  ; pending_board_events = []
+  ; pending_scope_messages = []
+  ; idle_seconds = 0
+  ; active_goals = []
+  ; continuity_summary = ""
+  ; context_ratio = lazy 0.0
+  ; unclaimed_task_count = 0
+  ; claimable_task_count = 0
+  ; provider_capacity_blocked_task_count = 0
+  ; failed_task_count = 0
+  ; pending_verification_count = 0
+  ; backlog_updated_since_last_scheduled_autonomous = false
+  ; running_keeper_fiber_count = 1
+  ; connected_surfaces = []
+  }
+;;
+
+let decide_no_signal () =
+  let meta = warm_meta () in
+  WO.keeper_cycle_decision
+    ~provider_cooldown_remaining_sec:no_provider_cooldown
+    ~reactive_wake:false
+    ~meta
+    no_signal_obs
+;;
+
+(* Core invariant (PR #21685): a warm keeper with no signal and no backlog
+   stays silent. The removed [Entropic_oscillation] trigger was the only path
+   that ran a turn in this state; deleting it makes [should_run] deterministically
+   false here. *)
+let test_no_signal_warm_keeper_stays_silent () =
+  let d = decide_no_signal () in
+  check
+    bool
+    "no-signal warm keeper stays silent (PR #21685 entropic removal invariant)"
+    false
+    d.should_run
+
+(* The channel is unaffected: silence is a [Skip] verdict on the
+   scheduled-autonomous channel, not a reactive redirect. *)
+let test_no_signal_keeps_scheduled_channel () =
+  let d = decide_no_signal () in
+  check
+    bool
+    "no-signal silence stays on the scheduled-autonomous channel"
+    true
+    (match d.channel with
+     | WO.Scheduled_autonomous -> true
+     | WO.Reactive -> false)
+
+let () = init_runtime_default_for_tests ()
+
+let () =
+  run
+    "keeper no-signal silence"
+    [ ( "entropic_removal_invariant"
+      , [ test_case
+            "no-signal warm keeper stays silent"
+            `Quick
+            test_no_signal_warm_keeper_stays_silent
+        ; test_case
+            "no-signal silence keeps scheduled channel"
+            `Quick
+            test_no_signal_keeps_scheduled_channel
+        ] )
+    ]
+;;

--- a/test/test_keeper_reactive_wake_backlog_gate.ml
+++ b/test/test_keeper_reactive_wake_backlog_gate.ml
@@ -75,9 +75,10 @@ let make_meta name =
   | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
 
 (* Warm, non-bootstrap meta: a recent-but-past scheduled-autonomous turn so
-   [since_last] is small and finite. This avoids the bootstrap / min_interval /
-   entropic-oscillation paths (all time-based), isolating the global-backlog
-   decision branch. Uses the same clock ([Time_compat.now]) the decision reads. *)
+   [since_last] is small and finite. This avoids the bootstrap / min_interval
+   time-based liveness paths, isolating the global-backlog decision branch.
+   Uses the same clock ([Time_compat.now]) the decision reads. (The
+   entropic-oscillation path this comment used to list was removed in #21685.) *)
 let warm_backlog_meta () =
   let meta = make_meta "herd" in
   let now = Time_compat.now () in


### PR DESCRIPTION
## What

Removes the `Entropic_oscillation` turn-trigger channel and its 600s/5% jitter logic. Policy decision: **option A** from the 2026-06-20 adversarial prompt audit — remove the implementation to align with the existing prompt policy, then redesign liveness in a follow-up RFC only if deadlock/stagnation is actually observed.

## Why

`entropic_oscillation` (PR #12794, "Law 6", 2026-05-04, **no RFC**) was a scheduler-level stochastic wakeup: after 600s of scheduled-autonomous silence, 5% chance per cycle to open a turn with no structured signal. Stated intent: "probe the environment, prevent deadlock/stagnation".

The audit found a three-way contradiction:
1. **Intent** (PR #12794): "probe the environment" — activity.
2. **Prompt** (`config/prompts/keeper.core_behavior.md:4`): a structured-work-less proactive turn must report `SPEECH_ACT: stay_silent` — silence.
3. **Live behavior** (runtime decision log, analyst keeper, 96 entropic turns over ~19h): prompt followed only **10.4%**; **88.5% produced visible action** (board_comment 32, inform 27, claim_task 15, post_board 6, broadcast 5) — including `claim_task`, which is beyond "probe". Example: a keeper declared `need = "none ... no analyst work"` yet wrote a board_post.

Prompt and implementation contradicted, with no reconciling design doc and no documented quantitative basis for 600/5.

## Change

Removes `Entropic_oscillation` entirely (33 lines, 4 files):
- `lib/keeper_contract/keeper_world_observation_turn_types.ml(.mli)`: variant + `turn_reason_to_string` branch
- `lib/keeper/keeper_world_observation.ml(.mli)`: alias variant, `entropic_oscillation_interval_sec` / `_probability_percent` constants, `should_inject_entropic_oscillation` predicate, `should_oscillate` let, `|| should_oscillate` in `should_run`, `Entropic_oscillation` reason emission (+ 3 exposed vals in `.mli`)

The prompt (`core_behavior.md:4`) is **unchanged** — removing the implementation aligns code to the existing prompt policy ("structured work only; else stay_silent"). `scheduled_autonomous` still gates on structured work, so the prompt remains accurate.

## Safety
- Removal is independent (impact audit, confidence 0.95): `should_oscillate` is a pure boolean; `|| should_oscillate` was one OR term that did not enable any other trigger. No other turn trigger, keepalive, or no_progress_recovery path depends on it.
- `dune build` green. `rg 'Entropic_oscillation|should_oscillate' lib/ test/` -> 0 residual references.
- No dedicated test referenced the variant (only unrelated comments).

## Behavioral change / risk
- The 600–900s "early probe" window (entropic fired before `min_interval` 900s) is gone. Keepers wake on their normal cadence (min_interval / idle_gate+cooldown / backlog / reactive signals). Average first-wake under low stimuli is later.
- Intentional under option A: the silent-loop violation (88.5%) stops immediately. The introduction was a non-RFC pilot and actual deadlock/stagnation was not evidenced. If fleet-wide stall is observed in practice, a follow-up RFC will design a proper liveness stimulus (prompt-aligned, backpressure-based rather than 5% random).

## Scope
- Code only. No prompt change, no config change, no live routing change beyond the removed trigger.
- Not a workaround signature (closed-variant removal, not telemetry-as-fix / N-of-M).

Co-Authored-By: Claude <noreply@anthropic.com>
