### PR TITLE
[codex] guard slack mrkdwn block rendering

### DIFF
--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -20,8 +20,36 @@ let slack_block_text_limit = 3000
 
 let redact content = Observability_redact.redact_text content
 
-let truncate_to_limit s limit =
-  if String.length s <= limit then s else String.sub s 0 limit
+let split_at_codepoint s ~limit =
+  let len = String.length s in
+  if limit <= 0 || len = 0 then ("", s)
+  else
+    let rec walk pos count =
+      if pos >= len then (s, "")
+      else if count >= limit then
+        (String.sub s 0 pos, String.sub s pos (len - pos))
+      else
+        let dec = String.get_utf_8_uchar s pos in
+        let step = max 1 (Uchar.utf_decode_length dec) in
+        let step = min step (len - pos) in
+        walk (pos + step) (count + 1)
+    in
+    walk 0 0
+
+let truncate_to_limit s limit = fst (split_at_codepoint s ~limit)
+
+let escape_mrkdwn_text s =
+  let buf = Buffer.create (String.length s) in
+  String.iter
+    (function
+      | '&' -> Buffer.add_string buf "&amp;"
+      | '<' -> Buffer.add_string buf "&lt;"
+      | '>' -> Buffer.add_string buf "&gt;"
+      | c -> Buffer.add_char buf c)
+    s;
+  Buffer.contents buf
+
+let truncate_block_text s = truncate_to_limit s slack_block_text_limit
 
 let strip_trailing_slash s =
   let len = String.length s in
@@ -38,15 +66,15 @@ let public_voice_audio_url ?base_url token =
 (* ── Rich block builders ─────────────────────────────────────────── *)
 
 let link_block_json ~url ~title ~description =
-  let title = redact title in
+  let url = escape_mrkdwn_text url in
+  let title = redact title |> escape_mrkdwn_text in
   let desc =
     match description with
     | None -> ""
-    | Some d -> "\n" ^ redact d
+    | Some d -> "\n" ^ (redact d |> escape_mrkdwn_text)
   in
   let text =
-    Printf.sprintf "*<%s|%s>*%s" url title desc
-    |> fun s -> truncate_to_limit s slack_block_text_limit
+    Printf.sprintf "*<%s|%s>*%s" url title desc |> truncate_block_text
   in
   `Assoc
     [ ("type", `String "section")
@@ -62,11 +90,11 @@ let image_block_json ~url ~caption =
     ]
 
 let audio_block_json ~base_url ~token ~message_text =
-  let url = public_voice_audio_url ?base_url token in
-  let message_text = redact message_text in
+  let url = public_voice_audio_url ?base_url token |> escape_mrkdwn_text in
+  let message_text = redact message_text |> escape_mrkdwn_text in
   let text =
     Printf.sprintf "🎙 <%s|Voice message> (%s)" url message_text
-    |> fun s -> truncate_to_limit s slack_block_text_limit
+    |> truncate_block_text
   in
   `Assoc
     [ ("type", `String "section")
@@ -74,15 +102,16 @@ let audio_block_json ~base_url ~token ~message_text =
     ]
 
 let tool_context_block_json ~name ~args_summary ~result_summary =
-  let args_summary = redact args_summary in
+  let name = redact name |> escape_mrkdwn_text in
+  let args_summary = redact args_summary |> escape_mrkdwn_text in
   let result =
     match result_summary with
     | None -> ""
-    | Some r -> Printf.sprintf "\nresult: %s" (redact r)
+    | Some r -> Printf.sprintf "\nresult: %s" (redact r |> escape_mrkdwn_text)
   in
   let text =
-    Printf.sprintf "*Tool: %s*\nargs: %s%s" name args_summary result
-    |> fun s -> truncate_to_limit s slack_block_text_limit
+    Printf.sprintf "*Tool:* %s\nargs: %s%s" name args_summary result
+    |> truncate_block_text
   in
   `Assoc
     [ ("type", `String "section")
@@ -173,8 +202,38 @@ let content_blocks_of_text text =
 
 (* ── HTTP delivery ───────────────────────────────────────────────── *)
 
+let omitted_blocks_notice omitted =
+  let text =
+    Printf.sprintf
+      ":warning: %d Slack block(s) omitted because Slack allows at most %d \
+       blocks per message."
+      omitted slack_max_blocks
+  in
+  `Assoc
+    [ ("type", `String "section")
+    ; ("text", `Assoc [ ("type", `String "mrkdwn"); ("text", `String text) ])
+    ]
+
+let rec take n xs =
+  if n <= 0 then []
+  else
+    match xs with
+    | [] -> []
+    | x :: rest -> x :: take (n - 1) rest
+
+let limit_blocks_for_slack blocks =
+  let count = List.length blocks in
+  if count <= slack_max_blocks then blocks
+  else
+    let keep = max 0 (slack_max_blocks - 1) in
+    take keep blocks @ [ omitted_blocks_notice (count - keep) ]
+
 let send_message_with_blocks ~token ~channel ~content ~blocks =
-  let content = redact content |> fun s -> truncate_to_limit s slack_message_limit in
+  let content =
+    redact content |> escape_mrkdwn_text |> fun s ->
+    truncate_to_limit s slack_message_limit
+  in
+  let blocks = limit_blocks_for_slack blocks in
   let fields =
     [ ("channel", `String channel); ("text", `String content) ]
   in
@@ -225,8 +284,7 @@ let send_message ~token ~channel ~content =
 
 (* ── Adapter loop ────────────────────────────────────────────────── *)
 
-let add_block acc block =
-  if List.length acc >= slack_max_blocks then acc else block :: acc
+let add_block acc block = block :: acc
 
 let adapter_loop ~token ~channel ~events ?base_url () =
   let rec loop ~acc_text ~acc_blocks ~run_id_opt =
@@ -275,6 +333,9 @@ let adapter_loop ~token ~channel ~events ?base_url () =
   loop ~acc_text:"" ~acc_blocks:[] ~run_id_opt:None
 
 module For_testing = struct
+  let escape_mrkdwn_text = escape_mrkdwn_text
+  let truncate_to_limit = truncate_to_limit
+  let limit_blocks_for_slack = limit_blocks_for_slack
   let public_voice_audio_url = public_voice_audio_url
   let link_block_json = link_block_json
   let image_block_json = image_block_json

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -55,6 +55,12 @@ val adapter_loop :
     The loop exits after one turn. *)
 
 module For_testing : sig
+  val escape_mrkdwn_text : string -> string
+
+  val truncate_to_limit : string -> int -> string
+
+  val limit_blocks_for_slack : Yojson.Safe.t list -> Yojson.Safe.t list
+
   val public_voice_audio_url : ?base_url:string -> string -> string
   (** [public_voice_audio_url ?base_url token] returns the public URL for
       an audio clip. *)

--- a/sidecars/slack-bot/src/bot.py
+++ b/sidecars/slack-bot/src/bot.py
@@ -27,7 +27,7 @@ from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
 from .config import get_config
-from .formatters import response_blocks, strip_state_blocks
+from .formatters import fallback_text, response_blocks, strip_state_blocks
 from .gate_client import GateClient, GateResponse
 
 logging.basicConfig(
@@ -266,18 +266,19 @@ class SlackGateBot:
                 duration_ms=response.duration_ms,
                 tokens_used=response.tokens_used,
             )
+            text = fallback_text(reply)
             if thinking_ts:
                 try:
                     app.client.chat_update(
                         channel=channel_id,
                         ts=thinking_ts,
-                        text=reply,
+                        text=text,
                         blocks=blocks,
                     )
                 except Exception:
-                    say(text=reply, blocks=blocks)
+                    say(text=text, blocks=blocks)
             else:
-                say(text=reply, blocks=blocks)
+                say(text=text, blocks=blocks)
             self._messages_processed += 1
             self._last_message_at = datetime.now(tz=timezone.utc).isoformat()
         elif response.error:

--- a/sidecars/slack-bot/src/formatters.py
+++ b/sidecars/slack-bot/src/formatters.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from .config import SLACK_MESSAGE_LIMIT
+SLACK_MESSAGE_LIMIT = 4000
+SLACK_MAX_BLOCKS = 50
+SLACK_BLOCK_TEXT_LIMIT = 3000
+TRUNCATION_NOTICE = "\n[truncated: Slack block limit]"
 
 _RE_STATE_BLOCK = re.compile(
     r"\[STATE\].*?(?:\[/STATE\]|$)", re.DOTALL
@@ -49,6 +52,16 @@ def chunk_text(text: str, limit: int = SLACK_MESSAGE_LIMIT) -> list[str]:
     return chunks
 
 
+def escape_mrkdwn_text(text: str) -> str:
+    """Escape Slack mrkdwn control characters."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def fallback_text(text: str) -> str:
+    """Build a Slack-safe top-level text fallback."""
+    return escape_mrkdwn_text(text)[:SLACK_MESSAGE_LIMIT]
+
+
 def format_context_block(
     keeper_name: str,
     model_used: str,
@@ -71,9 +84,26 @@ def format_context_block(
     return {
         "type": "context",
         "elements": [
-            {"type": "mrkdwn", "text": " | ".join(parts)},
+            {"type": "mrkdwn", "text": escape_mrkdwn_text(" | ".join(parts))},
         ],
     }
+
+
+def _section_block(text: str) -> dict[str, Any]:
+    return {
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": text[:SLACK_BLOCK_TEXT_LIMIT],
+        },
+    }
+
+
+def _append_truncation_notice(text: str) -> str:
+    if len(text) + len(TRUNCATION_NOTICE) <= SLACK_BLOCK_TEXT_LIMIT:
+        return text + TRUNCATION_NOTICE
+    keep = max(0, SLACK_BLOCK_TEXT_LIMIT - len(TRUNCATION_NOTICE))
+    return text[:keep] + TRUNCATION_NOTICE
 
 
 def response_blocks(
@@ -84,13 +114,14 @@ def response_blocks(
     tokens_used: int = 0,
 ) -> list[dict[str, Any]]:
     """Build Slack Block Kit blocks for a keeper response."""
-    blocks: list[dict[str, Any]] = [
-        {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": text[:SLACK_MESSAGE_LIMIT]},
-        },
-    ]
     ctx = format_context_block(keeper_name, model_used, duration_ms, tokens_used)
+    text_budget = SLACK_MAX_BLOCKS - (1 if ctx is not None else 0)
+    chunks = chunk_text(escape_mrkdwn_text(text), limit=SLACK_BLOCK_TEXT_LIMIT)
+    if len(chunks) > text_budget:
+        chunks = chunks[:text_budget]
+        chunks[-1] = _append_truncation_notice(chunks[-1])
+
+    blocks: list[dict[str, Any]] = [_section_block(chunk) for chunk in chunks]
     if ctx is not None:
         blocks.append(ctx)
     return blocks

--- a/sidecars/slack-bot/tests/test_formatters.py
+++ b/sidecars/slack-bot/tests/test_formatters.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from src.formatters import (
+    SLACK_BLOCK_TEXT_LIMIT,
+    SLACK_MAX_BLOCKS,
     chunk_text,
+    escape_mrkdwn_text,
+    fallback_text,
     format_context_block,
     response_blocks,
     strip_state_blocks,
@@ -33,6 +37,17 @@ class TestChunkText:
             assert len(chunk) <= 100
 
 
+class TestEscapeMrkdwnText:
+    def test_escapes_slack_control_chars(self) -> None:
+        assert (
+            escape_mrkdwn_text("<@U123> & <script>")
+            == "&lt;@U123&gt; &amp; &lt;script&gt;"
+        )
+
+    def test_fallback_text_escapes_control_chars(self) -> None:
+        assert fallback_text("<@U123> & ok") == "&lt;@U123&gt; &amp; ok"
+
+
 class TestFormatContextBlock:
     def test_full_context(self) -> None:
         result = format_context_block("sangsu", "qwen3.5", 4500, 120)
@@ -52,6 +67,13 @@ class TestFormatContextBlock:
         assert result is not None
         assert "sangsu" in result["elements"][0]["text"]
 
+    def test_escapes_context_fields(self) -> None:
+        result = format_context_block("<keeper>", "qwen&sonnet", 0, 0)
+        assert result is not None
+        text = result["elements"][0]["text"]
+        assert "&lt;keeper&gt;" in text
+        assert "qwen&amp;sonnet" in text
+
 
 class TestResponseBlocks:
     def test_produces_section_block(self) -> None:
@@ -59,6 +81,10 @@ class TestResponseBlocks:
         assert len(blocks) == 1
         assert blocks[0]["type"] == "section"
         assert blocks[0]["text"]["text"] == "Hello world"
+
+    def test_escapes_section_text(self) -> None:
+        blocks = response_blocks("<@U123> & <script>")
+        assert blocks[0]["text"]["text"] == "&lt;@U123&gt; &amp; &lt;script&gt;"
 
     def test_includes_context_when_metadata_present(self) -> None:
         blocks = response_blocks("Hi", keeper_name="sangsu", duration_ms=1000)
@@ -68,3 +94,24 @@ class TestResponseBlocks:
     def test_no_context_when_no_metadata(self) -> None:
         blocks = response_blocks("Hi")
         assert len(blocks) == 1
+
+    def test_chunks_section_text_at_slack_block_limit(self) -> None:
+        blocks = response_blocks("a" * (SLACK_BLOCK_TEXT_LIMIT + 10))
+        assert len(blocks) == 2
+        assert len(blocks[0]["text"]["text"]) == SLACK_BLOCK_TEXT_LIMIT
+        assert len(blocks[1]["text"]["text"]) == 10
+
+    def test_chunks_after_escape_expansion(self) -> None:
+        blocks = response_blocks("<" * SLACK_BLOCK_TEXT_LIMIT)
+        assert len(blocks) == 4
+        for block in blocks:
+            assert len(block["text"]["text"]) <= SLACK_BLOCK_TEXT_LIMIT
+
+    def test_caps_blocks_and_marks_truncation(self) -> None:
+        text = "a" * ((SLACK_BLOCK_TEXT_LIMIT * SLACK_MAX_BLOCKS) + 1)
+        blocks = response_blocks(text, keeper_name="sangsu")
+        assert len(blocks) == SLACK_MAX_BLOCKS
+        assert blocks[-1]["type"] == "context"
+        assert "[truncated: Slack block limit]" in blocks[-2]["text"]["text"]
+        for block in blocks[:-1]:
+            assert len(block["text"]["text"]) <= SLACK_BLOCK_TEXT_LIMIT

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -37,6 +37,23 @@ let test_link_block_renders_section () =
   check bool "link syntax" true (contains s "*<https://example.com|Example>*");
   check bool "description" true (contains s "A description")
 
+let test_escape_mrkdwn_control_chars () =
+  check string "control chars escaped"
+    "&lt;@U123&gt; &amp; &lt;b&gt;"
+    (S.escape_mrkdwn_text "<@U123> & <b>")
+
+let test_link_block_escapes_mrkdwn_fields () =
+  let json =
+    S.link_block_json ~url:"https://example.com/?a=1&b=2"
+      ~title:"<@U123> & title" ~description:(Some "a > b")
+  in
+  let s = json_string json in
+  check bool "raw mention removed" false (contains s "<@U123>");
+  check bool "title escaped" true (contains s "&lt;@U123&gt; &amp; title");
+  check bool "url escaped" true
+    (contains s "<https://example.com/?a=1&amp;b=2|");
+  check bool "description escaped" true (contains s "a &gt; b")
+
 let test_image_block_renders_image () =
   let json =
     S.image_block_json ~url:"https://example.com/img.png"
@@ -58,6 +75,15 @@ let test_audio_block_renders_voice_link () =
     (contains s "<https://chat.example.com/api/v1/voice/audio/tok456|Voice message>");
   check bool "message text" true (contains s "hello")
 
+let test_audio_block_escapes_message_text () =
+  let json =
+    S.audio_block_json ~base_url:(Some "https://chat.example.com") ~token:"tok456"
+      ~message_text:"<@U123> & done"
+  in
+  let s = json_string json in
+  check bool "raw mention removed" false (contains s "<@U123>");
+  check bool "message escaped" true (contains s "&lt;@U123&gt; &amp; done")
+
 let test_tool_context_block_renders_tool () =
   let json =
     S.tool_context_block_json ~name:"read_file" ~args_summary:"path: foo.txt"
@@ -65,9 +91,37 @@ let test_tool_context_block_renders_tool () =
   in
   let s = json_string json in
   check bool "type section" true (contains s "\"type\":\"section\"");
-  check bool "tool name" true (contains s "*Tool: read_file*");
+  check bool "tool name" true (contains s "*Tool:* read_file");
   check bool "args" true (contains s "args: path: foo.txt");
   check bool "result" true (contains s "result: contents")
+
+let test_tool_context_block_escapes_summaries () =
+  let json =
+    S.tool_context_block_json ~name:"<tool>" ~args_summary:"<@U123> & args"
+      ~result_summary:(Some "result > ok")
+  in
+  let s = json_string json in
+  check bool "raw mention removed" false (contains s "<@U123>");
+  check bool "name escaped" true (contains s "&lt;tool&gt;");
+  check bool "args escaped" true (contains s "&lt;@U123&gt; &amp; args");
+  check bool "result escaped" true (contains s "result &gt; ok")
+
+let test_truncate_to_limit_keeps_utf8_boundary () =
+  let s = String.concat "" (List.init 10 (fun _ -> "가")) in
+  let truncated = S.truncate_to_limit s 4 in
+  check bool "valid utf8" true (String.is_valid_utf_8 truncated);
+  check string "first four codepoints" "가가가가" truncated
+
+let test_limit_blocks_adds_visible_omission_notice () =
+  let mk_block n =
+    S.link_block_json ~url:(Printf.sprintf "https://example.com/%d" n)
+      ~title:(Printf.sprintf "item %d" n) ~description:None
+  in
+  let blocks = List.init 55 mk_block |> S.limit_blocks_for_slack in
+  check int "max 50 blocks" 50 (List.length blocks);
+  let last = List.nth blocks 49 |> json_string in
+  check bool "visible omission notice" true
+    (contains last "6 Slack block(s) omitted")
 
 (* ── content_blocks_of_text ─────────────────────────────────────── *)
 
@@ -118,11 +172,23 @@ let () =
         ] )
     ; ( "block-rendering"
       , [ test_case "link block renders section" `Quick test_link_block_renders_section
+        ; test_case "escapes mrkdwn control chars" `Quick
+            test_escape_mrkdwn_control_chars
+        ; test_case "link block escapes mrkdwn fields" `Quick
+            test_link_block_escapes_mrkdwn_fields
         ; test_case "image block renders image" `Quick test_image_block_renders_image
         ; test_case "audio block renders voice link" `Quick
             test_audio_block_renders_voice_link
+        ; test_case "audio block escapes message text" `Quick
+            test_audio_block_escapes_message_text
         ; test_case "tool context block renders tool" `Quick
             test_tool_context_block_renders_tool
+        ; test_case "tool context block escapes summaries" `Quick
+            test_tool_context_block_escapes_summaries
+        ; test_case "truncate keeps utf8 boundary" `Quick
+            test_truncate_to_limit_keeps_utf8_boundary
+        ; test_case "block limit adds visible omission notice" `Quick
+            test_limit_blocks_adds_visible_omission_notice
         ] )
     ; ( "content-blocks"
       , [ test_case "empty for plain text" `Quick


### PR DESCRIPTION
## Summary
- escape Slack mrkdwn control characters in OCaml Slack rich-block fields and sidecar response/fallback text
- enforce Slack 50-block message budget with a visible omission marker instead of silently dropping overflow
- chunk Slack sidecar section blocks after escaping so escaped text stays within the 3000-character section limit

## Why
`docs/DESIGN-RICH-CONNECTOR-RENDERING.md` flags Slack rendering as a P0 safety/correctness gap: raw mrkdwn fields can trigger Slack special parsing and Block Kit limits were only partially enforced. This PR takes the narrow Slack slice without moving connector policy into OAS.

## Evidence
- [Slack docs] Block Kit messages allow up to 50 blocks per message: https://docs.slack.dev/reference/block-kit/blocks/
- [Slack docs] section block text maximum is 3000 characters: https://docs.slack.dev/reference/block-kit/blocks/section-block/
- [Slack docs] mrkdwn control characters `&`, `<`, and `>` must be escaped when not used for parsing: https://docs.slack.dev/messaging/formatting-message-text/#escaping-text
- Checked on 2026-06-20 KST; source confidence High.

## Validation
- `MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_keeper_chat_slack.exe`
- `./_build/default/test/test_keeper_chat_slack.exe`
- `PYTHONPATH=sidecars/slack-bot python3 -m pytest sidecars/slack-bot/tests/test_formatters.py -q`
- `ruff check sidecars/slack-bot/src/formatters.py sidecars/slack-bot/src/bot.py sidecars/slack-bot/tests/test_formatters.py`
- `PYTHONPATH=sidecars/slack-bot pyright --outputjson sidecars/slack-bot/src/formatters.py sidecars/slack-bot/tests/test_formatters.py`
- `ocamlformat --check lib/keeper/keeper_chat_slack.ml lib/keeper/keeper_chat_slack.mli test/test_keeper_chat_slack.ml`
- `git diff --check`

## Notes
- Full `bot.py` pyright still requires local `slack_bolt`; this environment does not have the Slack runtime dependency installed. Formatter/test pyright passes.
