### PR TITLE
refactor(fusion): share completion post id derivation

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -120,17 +120,15 @@ let judge_meta (judge : (Fusion_types.judge_synthesis, string) result) : Yojson.
 let wake_keeper_on_fusion_completion
       ~base_dir ~keeper ~run_id ~ok ~resolved_answer ~board_post_id =
   try
-    (* post_id 폴백 규칙은 keeper_world_observation.pending_board_event_of_fusion_completion
-       과 동일해야 한다(둘 다 board_post_id에서 유도) — dedup 일관성. *)
-    let post_id =
-      if String.equal board_post_id "" then "fusion-run:" ^ run_id else board_post_id
+    let fusion_completion =
+      Keeper_event_queue.{ run_id; ok; resolved_answer; board_post_id }
     in
+    let post_id = Keeper_event_queue.fusion_completion_post_id fusion_completion in
     let stimulus : Keeper_event_queue.stimulus =
       { Keeper_event_queue.post_id
       ; urgency = Keeper_event_queue.Normal
       ; arrived_at = Time_compat.now ()
-      ; payload =
-          Keeper_event_queue.Fusion_completed { run_id; ok; resolved_answer; board_post_id }
+      ; payload = Keeper_event_queue.Fusion_completed fusion_completion
       }
     in
     Log.Keeper.info "fusion completion wake: keeper=%s run_id=%s ok=%b" keeper run_id ok;

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -276,10 +276,7 @@ let pending_board_event_of_fusion_completion
   : pending_board_event
   =
   let self_ids = self_ids meta in
-  let post_id =
-    if String.equal fc.board_post_id "" then "fusion-run:" ^ fc.run_id
-    else fc.board_post_id
-  in
+  let post_id = Keeper_event_queue.fusion_completion_post_id fc in
   let title =
     if fc.ok
     then Printf.sprintf "Fusion deliberation complete (run %s)" fc.run_id

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -41,6 +41,10 @@ and fusion_completion = {
   (* correlates to the sink's board evidence post; "" if none was created. *)
 }
 
+let fusion_completion_post_id (fc : fusion_completion) =
+  if String.equal fc.board_post_id "" then "fusion-run:" ^ fc.run_id
+  else fc.board_post_id
+
 type stimulus = {
   post_id : post_id;
   urgency : urgency;

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -75,6 +75,11 @@ and fusion_completion = {
     answer (or a failure label when [ok = false]); [board_post_id] correlates to
     the sink's board evidence post ("" when none was created). *)
 
+val fusion_completion_post_id : fusion_completion -> post_id
+(** Dedup/correlation id for [Fusion_completed]. Uses [board_post_id] when the
+    sink created a board evidence post, otherwise falls back to
+    ["fusion-run:<run_id>"]. *)
+
 type stimulus = {
   post_id : post_id;
   urgency : urgency;

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -26,6 +26,16 @@ let () =
   in
   assert (not (is_board_signal (fusion_payload ())));
   assert (String.equal (payload_kind_label (fusion_payload ())) "fusion_completed");
+  assert (
+    String.equal
+      (fusion_completion_post_id
+         { run_id = "fus-1"; ok = true; resolved_answer = "ok"; board_post_id = "post-1" })
+      "post-1");
+  assert (
+    String.equal
+      (fusion_completion_post_id
+         { run_id = "fus-2"; ok = false; resolved_answer = "sink_failed"; board_post_id = "" })
+      "fusion-run:fus-2");
 
   (* --- queue operations preserved --- *)
   let board_stim =


### PR DESCRIPTION
## Summary
- Add `Keeper_event_queue.fusion_completion_post_id` as the single derivation point for `Fusion_completed` dedup/correlation ids.
- Use the helper from both `fusion_sink` wake stimulus creation and `keeper_world_observation` pending board event projection.
- Removes the hand-maintained duplicate fallback rule noted in #21677 review.

## Validation
- `opam exec -- ocamlformat --check lib/keeper_runtime/keeper_event_queue.ml lib/keeper_runtime/keeper_event_queue.mli lib/fusion/fusion_sink.ml lib/keeper/keeper_world_observation.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_fusion_wake.exe test/test_keeper_event_queue.exe`
- `./_build/default/test/test_fusion_wake.exe` → 3 tests pass
- `./_build/default/test/test_keeper_event_queue.exe` → all passed

Follow-up for #21677 review finding: duplicated `board_post_id` fallback derivation.