### PR TITLE
Fix g0000 consolidator bug — use next_generation instead of hardcoded 0

### DIFF
--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -444,7 +444,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_preview = "";
             consecutive_noop_count = 0;
           };
-          generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name;
+          generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id:trace_id_t;
           trace_id = trace_id_t;
           trace_history = [];
           last_handoff_ts = 0.0;
@@ -479,7 +479,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ~session
             ~agent_name:meta.agent_name
             ~ctx:ctx0
-            ~generation:(Keeper_memory_os_io.next_generation ~keeper_id:p.name)
+            ~generation:(Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id:trace_id_t)
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -444,7 +444,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_preview = "";
             consecutive_noop_count = 0;
           };
-          generation = 0;
+          generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name;
           trace_id = trace_id_t;
           trace_history = [];
           last_handoff_ts = 0.0;
@@ -479,7 +479,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ~session
             ~agent_name:meta.agent_name
             ~ctx:ctx0
-            ~generation:0
+            ~generation:(Keeper_memory_os_io.next_generation ~keeper_id:p.name)
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->


### PR DESCRIPTION
## Problem

All episodes were recorded as generation `g0000` because `keeper_turn_up_create.ml` hardcoded `generation = 0` when creating new keepers.

## Root Cause

Two locations in `lib/keeper/keeper_turn_up_create.ml`:
- Line 447: `generation = 0;`
- Line 482: `~generation:0`

## Fix

Replace both with `Keeper_memory_os_io.next_generation ~keeper_id:p.name` — the same function added by PR #21515.

## Verification

- `dune build` passes
- New keeper episodes will use proper generation numbering instead of all being g0000
- Backward compatible: existing g0000 episodes remain readable