### PR TITLE
[codex] Fix keeper workspace rail UI

### DIFF
--- a/dashboard/src/components/copilot-dock.ts
+++ b/dashboard/src/components/copilot-dock.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { signal } from '@preact/signals'
+import { ChevronDown, MessageCircle, PanelRightClose, PanelRightOpen, Send, Sparkles, X } from 'lucide-preact'
 import { persistentSignal } from '../lib/persistent-signal'
 import { globalShortcutManager } from '../lib/global-shortcut-manager'
 import { route } from '../router'
@@ -39,13 +40,6 @@ interface DockStreaming {
   full: string
   sug: string[]
 }
-
-const SPARK_SVG = html`
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M12 3l1.7 4.8L18.5 9.5l-4.8 1.7L12 16l-1.7-4.8L5.5 9.5l4.8-1.7z" />
-    <path d="M18.5 14l.9 2.4 2.4.9-2.4.9-.9 2.4-.9-2.4-2.4-.9 2.4-.9z" />
-  </svg>
-`
 
 const DOCK_STARTERS: string[] = [
   '이 화면 요약해줘',
@@ -425,7 +419,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
         class=${`dock-head ${docked ? '' : 'drag'}`}
         onMouseDown=${docked ? undefined : drag}
       >
-        <div class="dock-title"><span class="dock-spark">${SPARK_SVG}</span>Chat</div>
+        <div class="dock-title"><span class="dock-spark"><${Sparkles} size=${16} aria-hidden="true" /></span>Chat</div>
         <div class="spacer"></div>
         <button
           type="button"
@@ -434,7 +428,9 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
           onMouseDown=${(e: MouseEvent) => e.stopPropagation()}
           onClick=${() => dock.setMode(docked ? 'float' : 'dock')}
         >
-          ${docked ? '⧉' : '▭'}
+          ${docked
+            ? html`<${PanelRightOpen} size=${15} aria-hidden="true" />`
+            : html`<${PanelRightClose} size=${15} aria-hidden="true" />`}
         </button>
         <button
           type="button"
@@ -443,7 +439,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
           onMouseDown=${(e: MouseEvent) => e.stopPropagation()}
           onClick=${dock.close}
         >
-          ✕
+          <${X} size=${15} aria-hidden="true" />
         </button>
       </div>
 
@@ -458,7 +454,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
           >
             <${DockAvatar} keeper=${keeper} size=${20} beat=${statusLooksRunning(keeper.status)} />
             <span class="nm">${keeper.kr}</span>
-            <span class="cv">▾</span>
+            <span class="cv"><${ChevronDown} size=${12} aria-hidden="true" /></span>
           </button>
           ${pickOpen
             ? html`
@@ -505,7 +501,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
         ${msgs.length === 0 && !streaming
           ? html`
               <div class="dock-empty">
-                <div class="ico">◈</div>
+                <div class="ico"><${MessageCircle} size=${26} aria-hidden="true" /></div>
                 <div class="t">${ctx.label}</div>
                 <div class="s">이 화면에 대해 ${keeper.kr}에게 바로 물어보세요. 같은 맥락을 보고 답합니다.</div>
                 <div class="dsug" style=${{ width: '100%' }}>
@@ -551,7 +547,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
             disabled=${!val.trim() || !!dock.streaming.value}
             onClick=${() => doSend()}
           >
-            ↑
+            <${Send} size=${14} aria-hidden="true" />
           </button>
         </div>
         <div class="dock-foot">
@@ -571,10 +567,9 @@ export function CopilotDockFab({ dock }: { dock: CopilotDockApi }) {
       onClick=${dock.open}
       data-testid="copilot-dock-fab"
       aria-label="Open Chat Dock"
+      title="Chat Dock 열기 (⌘J)"
     >
-      <span class="spark">${SPARK_SVG}</span>
-      <span>Chat</span>
-      <kbd>⌘J</kbd>
+      <span class="spark"><${MessageCircle} size=${22} strokeWidth=${2.4} aria-hidden="true" /></span>
     </button>
   `
 }
@@ -589,7 +584,7 @@ export function CopilotDockTopBarButton({ dock }: { dock: CopilotDockApi }) {
       data-testid="copilot-dock-topbar-button"
       aria-label="Toggle Chat Dock"
     >
-      <span class="spark">${SPARK_SVG}</span>
+      <${MessageCircle} class="spark" size=${14} strokeWidth=${2.2} aria-hidden="true" />
       <span>Chat</span>
       <kbd>⌘J</kbd>
     </button>

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { memo } from 'preact/compat'
 import { useState, useRef, useEffect } from 'preact/hooks'
+import { ChevronLeft, ChevronRight } from 'lucide-preact'
 import type { Keeper } from '../types'
 import { route } from '../router'
 import { keepers } from '../store'
@@ -156,7 +157,7 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
   const [clearPending, setClearPending] = useState(false)
   const [purgePending, setPurgePending] = useState(false)
   const [checkpointRefreshToken, setCheckpointRefreshToken] = useState(0)
-  // 3-pane workspace is the default conversation view; "상세 보기" flips to
+  // 3-pane workspace is the default conversation view; "운영 상세" flips to
   // the full tabbed KeeperDetailBody (FSM / 진단 / 정체성 / 설정 / 디버그).
   const [detailOpen, setDetailOpen] = useState(false)
   const [configOverlayKeeper, setConfigOverlayKeeper] = useState<string | null>(null)
@@ -304,7 +305,7 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
   }
 
   // Full tabbed detail (FSM / 진단 / 정체성 / 설정 / 디버그) — the original
-  // detail-page layout, preserved verbatim and surfaced behind "상세 보기".
+  // detail-page layout, preserved verbatim and surfaced behind "운영 상세".
   const detailContent = html`
     <div class="mx-auto flex w-full max-w-[1380px] flex-col gap-5 pb-8 v2-monitoring-surface" data-route-focused-keeper=${keeper.name}>
       <div class="sm:sticky sm:top-0 z-20 mx-auto w-full max-w-[1180px] overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] shadow-none backdrop-blur-xl v2-monitoring-toolbar">
@@ -416,7 +417,11 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
               aria-pressed=${rosterOpen ? 'true' : 'false'}
               title=${rosterOpen ? '로스터 접기' : '로스터 펼치기'}
               onClick=${() => setRosterOpen(open => !open)}
-            >${rosterOpen ? '◂' : '▸'}</button>
+            >
+              ${rosterOpen
+                ? html`<${ChevronLeft} size=${14} aria-hidden="true" />`
+                : html`<${ChevronRight} size=${14} aria-hidden="true" />`}
+            </button>
             <${KeeperWorkspaceChat}
               keeper=${keeper}
               detailOpen=${false}
@@ -438,7 +443,11 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
               aria-pressed=${railOpen ? 'true' : 'false'}
               title=${railOpen ? '컨텍스트 레일 접기' : '컨텍스트 레일 펼치기'}
               onClick=${() => setRailOpen(open => !open)}
-            >${railOpen ? '▸' : '◂'}</button>
+            >
+              ${railOpen
+                ? html`<${ChevronRight} size=${14} aria-hidden="true" />`
+                : html`<${ChevronLeft} size=${14} aria-hidden="true" />`}
+            </button>
             ${!isMobile && railOpen ? html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => setDetailOpen(true)} />` : null}
             ${isMobile && mobileRailOpen
               ? html`

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render } from '@testing-library/preact'
 import { html } from 'htm/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { tasks } from '../../store'
+import { navigate } from '../../router'
 import { KeeperWorkspaceRail } from './keeper-workspace-rail'
 import type { Keeper, Task } from '../../types'
 
@@ -21,18 +22,8 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
   }
 })
 
-vi.mock('../../api/mcp', () => ({
-  callMcpTool: vi.fn().mockResolvedValue(JSON.stringify({
-    before_tokens: 124000,
-    after_tokens: 62000,
-    saved_tokens: 62000,
-    phase: 'Running',
-    trigger: 'manual_operator_compact',
-  })),
-}))
-
-vi.mock('../common/toast', () => ({
-  showToast: vi.fn(),
+vi.mock('../../router', () => ({
+  navigate: vi.fn(),
 }))
 
 function mkKeeper(partial: Partial<Keeper>): Keeper {
@@ -40,11 +31,6 @@ function mkKeeper(partial: Partial<Keeper>): Keeper {
 }
 function mkTask(partial: Partial<Task>): Task {
   return { id: 'T-0', title: 'task', ...partial } as Task
-}
-
-async function flushPromises(): Promise<void> {
-  await Promise.resolve()
-  await Promise.resolve()
 }
 
 beforeEach(() => {
@@ -57,7 +43,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   tasks.value = []
-  vi.useRealTimers()
+  vi.clearAllMocks()
 })
 
 describe('KeeperWorkspaceRail', () => {
@@ -77,6 +63,15 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('oas·seoul-1')
   })
 
+  it('hides the model cell when no model was reported', () => {
+    const k = mkKeeper({ runtime_canonical: 'runpod_gemma' })
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} onToggleDetail=${() => {}} />`)
+    expect(container.textContent).toContain('런타임 · 처리량')
+    expect(container.textContent).toContain('runpod_gemma')
+    expect(container.textContent).not.toContain('모델')
+    expect(container.textContent).not.toContain('—')
+  })
+
   it('renders the context-window occupancy percent', () => {
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
     expect(container.textContent).toContain('컨텍스트 점유')
@@ -88,6 +83,12 @@ describe('KeeperWorkspaceRail', () => {
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
     expect(container.textContent).toContain('T-4412')
     expect(container.textContent).not.toContain('T-9999')
+  })
+
+  it('opens the planning task detail when an owned task is clicked', () => {
+    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+    fireEvent.click(getByRole('button', { name: /태스크 열기: T-4412/ }))
+    expect(navigate).toHaveBeenCalledWith('workspace', { section: 'planning', task: 'T-4412' })
   })
 
   it('renders the attention section from live blocked-task signal', () => {
@@ -102,16 +103,50 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).not.toContain('차단된 태스크')
   })
 
+  it('uses explicit attention reason text instead of a vague maintenance label', () => {
+    const k = mkKeeper({ needs_attention: true, attention_reason: 'approval_pending', next_human_action: 'resolve_approval' })
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} onToggleDetail=${() => {}} />`)
+    expect(container.textContent).toContain('approval_pending · resolve_approval')
+    expect(container.textContent).not.toContain('점검이 필요합니다')
+  })
+
+  it('labels unqualified attention flags as missing cause data', () => {
+    const k = mkKeeper({ needs_attention: true })
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} onToggleDetail=${() => {}} />`)
+    expect(container.textContent).toContain('주의 플래그 있음 · 원인 미전달')
+    expect(container.textContent).not.toContain('점검이 필요합니다')
+  })
+
   it('renders the auto-compact threshold label', () => {
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
     expect(container.textContent).toContain('compact 85%')
   })
 
-  it('fires onToggleDetail from the 상세 보기 button', () => {
+  it('renders context metrics as missing when only a zero default exists', () => {
+    const k = mkKeeper({ context_ratio: 0, compaction_count: 0, last_compaction_ago_s: 0 })
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} onToggleDetail=${() => {}} />`)
+    expect(container.textContent).toContain('컨텍스트 사용량 미수신')
+    expect(container.textContent).toContain('컴팩트 기록 없음')
+    expect(container.textContent).not.toContain('0%')
+    expect(container.textContent).not.toContain('마지막 컴팩트 0초 전')
+    expect(container.querySelector('.kw-compact-btn')).toBeNull()
+  })
+
+  it('shows token-only context without a fake window percentage', () => {
+    const k = mkKeeper({ context_ratio: 0, context_tokens: 37800 })
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} onToggleDetail=${() => {}} />`)
+    expect(container.textContent).toContain('윈도우 사용률 미수신')
+    expect(container.textContent).toContain('37.8k')
+    expect(container.textContent).not.toContain('0%')
+    expect(container.textContent).not.toContain('compact 85%')
+  })
+
+  it('fires onToggleDetail from the 운영 상세 button', () => {
     const onToggle = vi.fn()
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${onToggle} />`)
     const btn = container.querySelector('.kw-detail-btn') as HTMLElement
     expect(btn).toBeTruthy()
+    expect(btn.textContent).toContain('운영 상세')
     fireEvent.click(btn)
     expect(onToggle).toHaveBeenCalled()
   })
@@ -120,62 +155,5 @@ describe('KeeperWorkspaceRail', () => {
     tasks.value = []
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
     expect(container.textContent).toContain('할당된 태스크 없음')
-  })
-
-  it('shows the manual compact button in idle state', () => {
-    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
-    const btn = container.querySelector('.kw-compact-btn') as HTMLButtonElement
-    expect(btn).toBeTruthy()
-    expect(btn.textContent).toContain('지금 컴팩트')
-    expect(btn.disabled).toBe(false)
-  })
-
-  it('runs manual compaction, shows busy/done states, and adds a snapshot', async () => {
-    vi.useFakeTimers()
-    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
-    const btn = container.querySelector('.kw-compact-btn') as HTMLButtonElement
-
-    fireEvent.click(btn)
-    expect(container.textContent).toContain('압축 중…')
-    expect((container.querySelector('.kw-compact-btn') as HTMLButtonElement).disabled).toBe(true)
-
-    await flushPromises()
-
-    expect(container.textContent).toContain('컴팩션 스냅샷')
-    expect(container.textContent).toContain('124.0k → 62.0k tok')
-    expect(container.textContent).toContain('절약 62.0k tok')
-    expect(container.textContent).toContain('manual_operator_compact')
-    expect(container.textContent).toContain('완료')
-
-    await vi.advanceTimersByTimeAsync(2600)
-    await flushPromises()
-
-    expect((container.querySelector('.kw-compact-btn') as HTMLButtonElement).textContent).toContain('지금 컴팩트')
-  })
-
-  it('accumulates multiple compaction snapshots', async () => {
-    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
-
-    for (let i = 0; i < 2; i++) {
-      fireEvent.click(container.querySelector('.kw-compact-btn') as HTMLButtonElement)
-      await flushPromises()
-    }
-
-    expect(container.querySelectorAll('.kw-cmp-snap').length).toBe(2)
-  })
-
-  it('resets snapshots when the keeper changes', async () => {
-    const { container, rerender } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
-
-    fireEvent.click(container.querySelector('.kw-compact-btn') as HTMLButtonElement)
-    await flushPromises()
-
-    expect(container.querySelectorAll('.kw-cmp-snap').length).toBe(1)
-
-    const other = mkKeeper({ name: 'other-keeper', context_ratio: 0.3, context_tokens: 60000, context_max: 200000 })
-    rerender(html`<${KeeperWorkspaceRail} keeper=${other} onToggleDetail=${() => {}} />`)
-
-    expect(container.querySelectorAll('.kw-cmp-snap').length).toBe(0)
-    expect(container.textContent).toContain('30%')
   })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -1,25 +1,29 @@
 // Keeper Workspace — context rail (right). Runtime/throughput, context-window
-// occupancy, owned tasks, recent tool calls, and the "상세 보기" toggle that
+// occupancy, owned tasks, recent tool calls, and the "운영 상세" toggle that
 // surfaces the full KeeperDetailBody. Most data comes from the live Keeper
 // object + the tasks store; the recent-tool-calls section lazy-loads the rich
 // per-call store (see keeper-workspace-tool-calls.ts).
 
 import { html } from 'htm/preact'
 import type { VNode } from 'preact'
-import { useCallback, useEffect, useState } from 'preact/hooks'
 import { tasks } from '../../store'
 import type { Keeper, Task } from '../../types'
+import { navigate } from '../../router'
 import { keeperModelLabel, keeperRuntimeLabel } from './keeper-workspace-shared'
 import { KeeperWorkspaceRecentTools } from './keeper-workspace-tool-calls'
-import { callMcpTool } from '../../api/mcp'
-import { showToast } from '../common/toast'
-import { asNumber, asString, isRecord } from '../common/normalize'
 import { formatDuration } from '../../lib/format-time'
 
 const COMPACT_AT = 85 // auto-compaction threshold (%) — matches runtime default
 
-function contextPercent(keeper: Keeper): number {
-  const ratio = keeper.context_ratio ?? keeper.context?.context_ratio ?? 0
+function contextRatio(keeper: Keeper): number | null {
+  const ratio = keeper.context_ratio ?? keeper.context?.context_ratio
+  if (typeof ratio !== 'number' || !Number.isFinite(ratio)) return null
+  return Math.max(0, Math.min(1, ratio))
+}
+
+function contextPercent(keeper: Keeper): number | null {
+  const ratio = contextRatio(keeper)
+  if (ratio === null) return null
   return Math.max(0, Math.min(100, Math.round(ratio * 100)))
 }
 
@@ -48,6 +52,23 @@ function taskStateClass(status: Task['status']): string {
   return ''
 }
 
+function nonEmpty(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+function attentionFallback(keeper: Keeper): string | null {
+  if (keeper.needs_attention !== true) return null
+  const summary = nonEmpty(keeper.runtime_blocker_summary)
+  if (summary) return summary
+  const reason = nonEmpty(keeper.attention_reason)
+  const action = nonEmpty(keeper.next_human_action)
+  if (reason && action) return `${reason} · ${action}`
+  if (reason) return `주의 원인: ${reason}`
+  if (action) return `다음 조치: ${action}`
+  return '주의 플래그 있음 · 원인 미전달'
+}
+
 type AttentionItem = { sev: 'bad' | 'warn'; text: string }
 
 /** Attention items from the same live signals the roster badge counts
@@ -59,9 +80,8 @@ function attentionItems(keeper: Keeper): AttentionItem[] {
   if (blocked > 0) items.push({ sev: 'bad', text: `차단된 태스크 ${blocked}건` })
   const awaiting = ownedTasks(keeper).filter(t => t.status === 'awaiting_verification')
   if (awaiting.length > 0) items.push({ sev: 'warn', text: `검증 대기 ${awaiting.length}건` })
-  if (items.length === 0 && keeper.needs_attention === true) {
-    items.push({ sev: 'warn', text: '점검이 필요합니다' })
-  }
+  const fallback = items.length === 0 ? attentionFallback(keeper) : null
+  if (fallback) items.push({ sev: 'warn', text: fallback })
   return items
 }
 
@@ -83,155 +103,96 @@ function AttentionSection({ keeper }: { keeper: Keeper }): VNode | null {
   `
 }
 
-type CompactionSnapshot = {
-  id: string
-  at: string
-  trigger: string
-  phase: string | null
-  beforeTokens: number
-  afterTokens: number
-  savedTokens: number
-}
-
-function nowHM(): string {
-  return new Date().toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false })
-}
-
 function formatAgo(seconds: number | null | undefined): string | null {
   if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) return null
   return `${formatDuration(seconds)} 전`
 }
 
-type CompactButtonState = 'idle' | 'busy' | 'done'
-
-function CompactButton({ state, onClick }: { state: CompactButtonState; onClick: () => void }): VNode {
-  const label = state === 'idle' ? '지금 컴팩트' : state === 'busy' ? '압축 중…' : '완료'
-  const icon = state === 'done' ? '✓ ' : ''
-  return html`
-    <button type="button" class=${`kw-compact-btn ${state}`} disabled=${state === 'busy'} onClick=${onClick}>
-      ${icon}${label}
-    </button>
-  `
-}
-
-function SnapshotList({ snapshots }: { snapshots: CompactionSnapshot[] }): VNode | null {
-  if (snapshots.length === 0) return null
-  return html`
-    <div class="kw-cmp-list">
-      <h5>컴팩션 스냅샷</h5>
-      ${snapshots.map(s => {
-        const reduction = s.beforeTokens > 0
-          ? Math.round((1 - s.afterTokens / s.beforeTokens) * 100)
-          : 0
-        return html`
-          <div class="kw-cmp-snap" key=${s.id}>
-            <div class="kw-cmp-snap-h">
-              <span class="kw-cmp-snap-id">${s.at}</span>
-              ${s.phase ? html`<span class="kw-cmp-snap-phase">${s.phase}</span>` : null}
-              <span class="kw-cmp-snap-reduction">-${reduction}%</span>
-            </div>
-            <div class="kw-cmp-snap-stats">
-              <span>${formatK(s.beforeTokens) ?? '—'} → ${formatK(s.afterTokens) ?? '—'} tok</span>
-              <span>절약 ${formatK(s.savedTokens) ?? '—'} tok</span>
-            </div>
-            <div class="kw-cmp-snap-trigger text-2xs text-[var(--color-fg-muted)]">${s.trigger}</div>
-          </div>
-        `
-      })}
-    </div>
-  `
-}
-
 function ContextSection({ keeper }: { keeper: Keeper }): VNode {
-  const [snapshots, setSnapshots] = useState<CompactionSnapshot[]>([])
-  const [compactState, setCompactState] = useState<CompactButtonState>('idle')
-
-  useEffect(() => {
-    setSnapshots([])
-    setCompactState('idle')
-  }, [keeper.name])
-
   const pct = contextPercent(keeper)
-  const hot = pct >= COMPACT_AT
+  const hot = pct !== null && pct >= COMPACT_AT
   const max = contextMax(keeper)
   const baseTokens = keeper.context_tokens ?? keeper.context?.context_tokens ?? null
   const tokens = formatK(baseTokens)
   const maxLabel = formatK(max)
   const msgCount = keeper.context?.message_count ?? null
   const hasCheckpoint = keeper.context?.has_checkpoint ?? null
-  const contextSource = keeper.context_source ?? keeper.context?.source ?? null
+  const contextSource = nonEmpty(keeper.context_source ?? keeper.context?.source)
   const compactionCount = keeper.compaction_count ?? null
-  const lastCompactionAgo = formatAgo(keeper.last_compaction_ago_s)
-  const lastCompactionSaved = formatK(keeper.last_compaction_saved_tokens)
-
-  const runCompact = useCallback(async () => {
-    if (compactState === 'busy') return
-    setCompactState('busy')
-    try {
-      const text = await callMcpTool('masc_keeper_compact', { name: keeper.name })
-      let parsed: unknown = null
-      try {
-        parsed = JSON.parse(text)
-      } catch {
-        parsed = null
-      }
-      const record = isRecord(parsed) ? parsed : null
-      const beforeTokens = asNumber(record?.before_tokens) ?? 0
-      const afterTokens = asNumber(record?.after_tokens) ?? 0
-      const savedTokens = asNumber(record?.saved_tokens) ?? Math.max(0, beforeTokens - afterTokens)
-      const snapshot: CompactionSnapshot = {
-        id: `cmp-${Date.now()}`,
-        at: nowHM(),
-        trigger: asString(record?.trigger) ?? '수동 컴팩트',
-        phase: asString(record?.phase) ?? null,
-        beforeTokens,
-        afterTokens,
-        savedTokens,
-      }
-      setSnapshots(prev => [snapshot, ...prev])
-      setCompactState('done')
-      window.setTimeout(() => setCompactState('idle'), 2600)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : '컴팩트 요청 실패'
-      showToast(message, 'error')
-      setCompactState('idle')
-    }
-  }, [compactState, keeper.name])
+  const hasCompactionHistory = typeof compactionCount === 'number' && compactionCount > 0
+  const lastCompactionAgo = hasCompactionHistory ? formatAgo(keeper.last_compaction_ago_s) : null
+  const lastCompactionSaved = hasCompactionHistory ? formatK(keeper.last_compaction_saved_tokens) : null
+  const hasUsageBreakdown = baseTokens !== null || max !== null || msgCount !== null || hasCheckpoint !== null || contextSource != null
+  const hasMeterData = pct !== null && (pct > 0 || max !== null)
+  const contextMeta = html`
+    <div class="kw-ctx-meta">
+      ${msgCount !== null ? html`<span>메시지 ${msgCount}개</span>` : null}
+      ${hasCheckpoint === true ? html`<span>체크포인트 보유</span>` : null}
+      ${contextSource ? html`<span>출처 ${contextSource}</span>` : null}
+    </div>
+  `
+  let usageBody: VNode
+  if (hasMeterData) {
+    usageBody = html`
+      <div class="flex items-baseline justify-between">
+        <span class="text-xs text-[var(--color-fg-secondary)]">윈도우 사용량</span>
+        <span class=${`font-mono text-sm ${hot ? 'text-[var(--color-status-err)]' : 'text-[var(--color-accent-fg)]'}`}>${pct ?? 0}%</span>
+      </div>
+      <div class="kw-meter-wrap">
+        <div class=${`kw-meter${hot ? ' hot' : ''}`}><span style=${{ width: `${pct ?? 0}%` }}></span></div>
+        <span class="kw-meter-mark" style=${{ left: `${COMPACT_AT}%` }} title=${`자동 compact 임계치 ${COMPACT_AT}%`}>
+          <i class="kw-meter-mark-lbl">compact ${COMPACT_AT}%</i>
+        </span>
+      </div>
+      ${tokens || maxLabel
+        ? html`<div class="kw-ctx-tok">
+            <span class="mono">${tokens ?? '—'}</span>
+            <span aria-hidden="true">/</span>
+            <span class="mono">${maxLabel ?? '—'}</span>
+            <span class="lbl">사용 / 전체 윈도우</span>
+          </div>`
+        : null}
+      ${contextMeta}
+    `
+  } else if (hasUsageBreakdown) {
+    usageBody = html`
+      <div class="kw-context-empty">
+        <strong>윈도우 사용률 미수신</strong>
+        <span>전체 윈도우 총량이 없어 비율과 compact 임계치를 숨깁니다.</span>
+      </div>
+      ${tokens || maxLabel
+        ? html`<div class="kw-ctx-tok">
+            <span class="mono">${tokens ?? '—'}</span>
+            <span aria-hidden="true">/</span>
+            <span class="mono">${maxLabel ?? '—'}</span>
+            <span class="lbl">사용 / 전체 윈도우</span>
+          </div>`
+        : null}
+      ${contextMeta}
+    `
+  } else {
+    usageBody = html`
+      <div class="kw-context-empty">
+        <strong>컨텍스트 사용량 미수신</strong>
+        <span>런타임이 토큰/윈도우 메트릭을 아직 보내지 않았습니다.</span>
+      </div>
+    `
+  }
 
   return html`
     <div class="kw-sec v2-monitoring-panel">
       <h4>컨텍스트 점유</h4>
       <div class="kw-card v2-monitoring-card">
-        <div class="flex items-baseline justify-between">
-          <span class="text-xs text-[var(--color-fg-secondary)]">윈도우 사용량</span>
-          <span class=${`font-mono text-sm ${hot ? 'text-[var(--color-status-err)]' : 'text-[var(--color-accent-fg)]'}`}>${pct}%</span>
+        ${usageBody}
+        <div class="kw-cmp-readonly">
+          ${hasCompactionHistory
+            ? html`
+                <span>누적 컴팩트 ${compactionCount}회</span>
+                ${lastCompactionAgo ? html`<span>마지막 ${lastCompactionAgo}</span>` : null}
+                ${lastCompactionSaved ? html`<span>절약 ${lastCompactionSaved} tok</span>` : null}
+              `
+            : html`<span>컴팩트 기록 없음</span>`}
         </div>
-        <div class="kw-meter-wrap">
-          <div class=${`kw-meter${hot ? ' hot' : ''}`}><span style=${{ width: `${pct}%` }}></span></div>
-          <span class="kw-meter-mark" style=${{ left: `${COMPACT_AT}%` }} title=${`자동 compact 임계치 ${COMPACT_AT}%`}>
-            <i class="kw-meter-mark-lbl">compact ${COMPACT_AT}%</i>
-          </span>
-        </div>
-        ${tokens || maxLabel
-          ? html`<div class="kw-ctx-tok">
-              <span class="mono">${tokens ?? '—'}</span>
-              <span aria-hidden="true">/</span>
-              <span class="mono">${maxLabel ?? '—'}</span>
-              <span class="lbl">사용 / 전체 윈도우</span>
-            </div>`
-          : null}
-        <div class="mt-2 grid grid-cols-2 gap-2 text-2xs text-[var(--color-fg-secondary)]">
-          ${msgCount !== null ? html`<span>메시지 ${msgCount}개</span>` : null}
-          ${hasCheckpoint === true ? html`<span>체크포인트 보유</span>` : null}
-          ${contextSource ? html`<span>출처 ${contextSource}</span>` : null}
-          ${compactionCount !== null ? html`<span>누적 컴팩트 ${compactionCount}회</span>` : null}
-          ${lastCompactionAgo ? html`<span>마지막 컴팩트 ${lastCompactionAgo}</span>` : null}
-          ${lastCompactionSaved ? html`<span>절약 ${lastCompactionSaved} tok</span>` : null}
-        </div>
-        <div class="kw-cmp-actions">
-          <${CompactButton} state=${compactState} onClick=${() => { void runCompact() }} />
-        </div>
-        <${SnapshotList} snapshots=${snapshots} />
       </div>
     </div>
   `
@@ -249,9 +210,9 @@ function ThroughputSection({ keeper }: { keeper: Keeper }): VNode {
   return html`
     <div class="kw-sec v2-monitoring-panel">
       <h4>런타임 · 처리량</h4>
-      <div class="kw-vitals v2-monitoring-row">
-        <div class="kw-vital"><div class="vk">모델</div><div class="vv" title=${model ?? ''}>${model ?? '—'}</div></div>
-        <div class="kw-vital"><div class="vk">런타임</div><div class="vv" title=${runtime ?? ''}>${runtime ?? '—'}</div></div>
+      <div class=${`kw-vitals ${model ? '' : 'single'} v2-monitoring-row`}>
+        <div class=${`kw-vital ${runtime ? '' : 'muted'}`}><div class="vk">런타임</div><div class="vv" title=${runtime ?? ''}>${runtime ?? '런타임 미수신'}</div></div>
+        ${model ? html`<div class="kw-vital"><div class="vk">모델</div><div class="vv" title=${model}>${model}</div></div>` : null}
         ${scope ? html`<div class="kw-vital" style=${{ gridColumn: '1 / -1' }}><div class="vk">scope</div><div class="vv" title=${scope}>${scope}</div></div>` : null}
       </div>
       ${series.length >= 2
@@ -271,17 +232,27 @@ function ThroughputSection({ keeper }: { keeper: Keeper }): VNode {
 
 function OwnedTasksSection({ keeper }: { keeper: Keeper }): VNode {
   const owned = ownedTasks(keeper)
+  const openTask = (task: Task) => {
+    navigate('workspace', { section: 'planning', task: task.id })
+  }
   return html`
     <div class="kw-sec v2-monitoring-panel">
       <h4>소유 태스크</h4>
       <div class="kw-list v2-monitoring-row">
         ${owned.length
           ? owned.map(t => html`
-              <div class="kw-tasktag v2-monitoring-row" key=${t.id}>
+              <button
+                type="button"
+                class="kw-tasktag v2-monitoring-row"
+                key=${t.id}
+                title=${`${t.id} · ${t.title}`}
+                aria-label=${`태스크 열기: ${t.id} ${t.title}`}
+                onClick=${() => openTask(t)}
+              >
                 <span class="tid">${t.id}</span>
-                <span class="ttl" title=${t.title}>${t.title}</span>
+                <span class="ttl">${t.title}</span>
                 ${t.status ? html`<span class=${`tstate ${taskStateClass(t.status)}`}>${t.status}</span>` : null}
-              </div>
+              </button>
             `)
           : html`<div class="kw-list-empty v2-monitoring-row">할당된 태스크 없음</div>`}
       </div>
@@ -306,8 +277,8 @@ export function KeeperWorkspaceRail({
         <${KeeperWorkspaceRecentTools} keeperName=${keeper.name} />
         <div class="kw-sec v2-monitoring-toolbar">
           <button type="button" class="kw-detail-btn v2-monitoring-action" onClick=${onToggleDetail}>
-            <span>상세 보기</span>
-            <span class="sub">상태 · 진단 · 정체성 · 설정 →</span>
+            <span>운영 상세</span>
+            <span class="sub">FSM · 진단 · 정체성 · 설정 →</span>
           </button>
         </div>
       </div>

--- a/dashboard/src/styles/copilot-dock.css
+++ b/dashboard/src/styles/copilot-dock.css
@@ -40,12 +40,14 @@
   letter-spacing: 0.02em; color: var(--text-bright);
 }
 .dock-spark { width: 16px; height: 16px; color: var(--volt-strong); }
+.dock-spark svg { display: block; }
 .dock-head .spacer { flex: 1; }
 .dock-iconbtn {
   width: 28px; height: 28px; display: flex; align-items: center; justify-content: center;
   border-radius: var(--radius-sm); border: 1px solid transparent; background: transparent;
   color: var(--text-dim); cursor: pointer; transition: 0.14s; font-size: 13px;
 }
+.dock-iconbtn svg { flex: none; }
 .dock-iconbtn:hover { color: var(--text-bright); background: var(--bg-card); }
 
 /* ── identity row (keeper picker) ── */
@@ -58,7 +60,7 @@
 }
 .dock-picker-btn:hover { border-color: var(--border-highlight); }
 .dock-picker-btn .nm { font-size: 11.5px; color: var(--text-bright); font-weight: 600; white-space: nowrap; }
-.dock-picker-btn .cv { color: var(--text-dim); font-size: 9px; }
+.dock-picker-btn .cv { display: inline-flex; color: var(--text-dim); font-size: 9px; }
 .dock-idrow-hint { font-size: 10.5px; color: var(--text-dim); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .dock-idrow-hint .mono { font-family: var(--font-mono); color: var(--text-mid); }
 
@@ -104,7 +106,7 @@
 .dock-thread::-webkit-scrollbar { width: 8px; }
 .dock-thread::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); border: 2px solid transparent; background-clip: padding-box; }
 .dock-empty { margin: auto; text-align: center; color: var(--text-dim); padding: var(--sp-5) var(--sp-3); display: flex; flex-direction: column; gap: var(--sp-3); align-items: center; }
-.dock-empty .ico { font-size: 24px; opacity: 0.5; color: var(--info); }
+.dock-empty .ico { display: inline-flex; opacity: 0.5; color: var(--info); }
 .dock-empty .t { font-family: var(--font-display); font-size: 12.5px; color: var(--text-mid); letter-spacing: 0.03em; }
 .dock-empty .s { font-size: 11.5px; line-height: 1.6; max-width: 250px; }
 
@@ -157,6 +159,7 @@
 .dock-comp-box textarea { flex: 1; resize: none; border: 0; outline: 0; background: transparent; color: var(--text-bright); font-family: var(--font-ui); font-size: 12.5px; line-height: 1.5; padding: 7px 0; max-height: 120px; min-height: 20px; }
 .dock-comp-box textarea::placeholder { color: var(--text-dim); }
 .dock-send { width: 30px; height: 30px; flex: none; border-radius: var(--radius-sm); border: 1px solid var(--volt); background: var(--volt); color: var(--volt-ink); cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 14px; transition: 0.14s; }
+.dock-send svg { flex: none; }
 .dock-send:hover:not(:disabled) { background: var(--volt-strong); box-shadow: 0 0 14px var(--volt-glow); }
 .dock-send:disabled { opacity: 0.4; cursor: default; }
 .dock-foot { display: flex; align-items: center; gap: var(--sp-3); margin-top: 7px; font-size: 10px; color: var(--text-dim); }
@@ -166,14 +169,27 @@
 /* ── triggers: FAB + top-bar button ── */
 .dock-fab {
   position: fixed; right: 22px; bottom: 22px; z-index: 55;
-  height: 44px; padding: 0 16px; display: flex; align-items: center; gap: var(--sp-2);
+  width: 50px; height: 50px; padding: 0; display: flex; align-items: center; justify-content: center; gap: 0;
   border-radius: var(--radius-pill); border: 1px solid var(--volt);
   background: var(--volt); color: var(--volt-ink);
   font-family: var(--font-ui); font-weight: 600; font-size: 12.5px; cursor: pointer;
   box-shadow: 0 8px 24px rgba(0,0,0,0.4), 0 0 18px var(--volt-glow); transition: 0.16s;
 }
 .dock-fab:hover { background: var(--volt-strong); transform: translateY(-1px); }
-.dock-fab .spark { width: 17px; height: 17px; }
+.dock-fab .spark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex: none;
+  color: #10131a;
+}
+.dock-fab .spark svg {
+  display: block;
+  color: #10131a;
+  stroke: #10131a;
+}
 .dock-fab kbd { font-family: var(--font-mono); font-size: 9px; padding: 1px 5px; border-radius: var(--radius-xs); background: color-mix(in oklab, var(--volt-ink) 16%, transparent); }
 
 .topbar-copilot {
@@ -184,7 +200,7 @@
 }
 .topbar-copilot:hover { border-color: var(--volt-dim); color: var(--volt-strong); }
 .topbar-copilot.on { border-color: var(--volt); color: var(--volt-strong); background: var(--volt-wash); }
-.topbar-copilot .spark { width: 14px; height: 14px; }
+.topbar-copilot .spark { width: 14px; height: 14px; flex: none; color: currentColor; }
 .topbar-copilot kbd { font-family: var(--font-mono); font-size: 9px; padding: 1px 4px; border-radius: var(--radius-xs); background: var(--bg-card); border: 1px solid var(--border-main); color: var(--text-dim); /* v2 source override */ }
 
 @media (max-width: 1180px) {

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -59,7 +59,7 @@
 .kw-grid[data-roster="mini"] { --kw-roster-w: 64px; }
 .kw-grid[data-rail="closed"] { --kw-rail-w: 0px; }
 
-/* Detail ("상세 보기") takes over the conversation + rail span as a
+/* Detail ("운영 상세") takes over the conversation + rail span as a
  * single scrollable column; roster stays for keeper switching. */
 .kw-grid[data-detail="open"] { grid-template-columns: var(--kw-roster-w, 286px) minmax(0, 1fr); }
 
@@ -599,8 +599,12 @@
   position: absolute;
   z-index: 5;
   top: 50%;
-  width: 20px;
+  display: inline-flex;
+  width: 24px;
   height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
   transform: translateY(-50%);
   border: 1px solid var(--color-border-default);
   background: var(--color-bg-surface);
@@ -613,6 +617,7 @@
   border-color: var(--color-border-strong);
   background: var(--color-bg-hover);
 }
+.kw-rail-toggle svg { flex: none; }
 .kw-rail-toggle.left { left: calc(var(--kw-roster-w, 286px) - 10px); }
 .kw-rail-toggle.right { right: calc(var(--kw-rail-w, 312px) - 10px); }
 .kw-grid[data-rail="closed"] .kw-rail-toggle.right { right: 2px; }
@@ -701,7 +706,9 @@
 .kw-card { background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: var(--r-2); padding: 13px 14px; }
 
 .kw-vitals { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--color-border-divider); border: 1px solid var(--color-border-default); border-radius: var(--r-2); overflow: hidden; }
+.kw-vitals.single { grid-template-columns: 1fr; }
 .kw-vital { background: var(--color-bg-elevated); padding: 10px 12px; min-width: 0; }
+.kw-vital.muted .vv { color: var(--color-fg-muted); }
 .kw-vital .vk { font-size: var(--fs-11); letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-fg-secondary); font-weight: var(--fw-bold); }
 .kw-vital .vv { font-family: var(--font-mono); font-size: 15px; font-weight: var(--fw-semi); color: var(--color-fg-primary); margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
@@ -718,13 +725,58 @@
 .kw-ctx-tok { display: flex; align-items: baseline; gap: 5px; margin-top: 8px; font-size: var(--fs-12); }
 .kw-ctx-tok .mono { font-family: var(--font-mono); color: var(--color-fg-primary); }
 .kw-ctx-tok .lbl { margin-left: auto; color: var(--color-fg-secondary); font-size: var(--fs-11); }
+.kw-ctx-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px 8px;
+  margin-top: 10px;
+  font-size: var(--fs-11);
+  color: var(--color-fg-secondary);
+}
+.kw-context-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 0 4px;
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-12);
+  line-height: 1.45;
+}
+.kw-context-empty strong {
+  color: var(--color-fg-primary);
+  font-size: var(--fs-13);
+}
 
 .kw-list { display: flex; flex-direction: column; gap: 7px; }
 .kw-list-empty { font-size: var(--fs-13); color: var(--color-fg-secondary); }
-.kw-tasktag { display: flex; align-items: center; gap: 8px; padding: 9px 11px; border-radius: var(--r-1); background: var(--color-bg-elevated); border: 1px solid var(--color-border-divider); font-size: var(--fs-13); color: var(--color-fg-primary); }
-.kw-tasktag .tid { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--color-accent-fg); flex: none; }
-.kw-tasktag .ttl { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 1; }
-.kw-tasktag .tstate { font-size: var(--fs-11); flex: none; color: var(--color-fg-secondary); }
+.kw-tasktag {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: start;
+  width: 100%;
+  padding: 9px 11px;
+  border-radius: var(--r-1);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-divider);
+  font-size: var(--fs-13);
+  color: var(--color-fg-primary);
+  text-align: left;
+  cursor: pointer;
+  transition: background .15s, border-color .15s;
+}
+.kw-tasktag:hover { background: var(--color-bg-hover); border-color: var(--color-border-default); }
+.kw-tasktag:focus-visible { outline: 2px solid var(--color-accent-fg-dim); outline-offset: 2px; }
+.kw-tasktag .tid { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--color-accent-fg); white-space: nowrap; }
+.kw-tasktag .ttl {
+  min-width: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  line-height: 1.35;
+}
+.kw-tasktag .tstate { align-self: start; font-size: var(--fs-11); color: var(--color-fg-secondary); white-space: nowrap; }
 .kw-tasktag .tstate.review { color: var(--color-status-warn); }
 
 /* Recent tool calls: compact rows (status dot + name + duration + age) that
@@ -761,7 +813,7 @@
 .kw-detail-btn:hover { background: var(--color-bg-hover); border-color: var(--color-border-strong); }
 .kw-detail-btn .sub { font-weight: 400; color: var(--color-fg-secondary); font-size: var(--fs-12); }
 
-/* ════ DETAIL ("상세 보기") — reuse KeeperDetailBody, scrollable column ══ */
+/* ════ DETAIL ("운영 상세") — reuse KeeperDetailBody, scrollable column ══ */
 .kw-detail { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--color-bg-page); }
 .kw-detail-head {
   flex: none; display: flex; align-items: center; gap: 10px;
@@ -785,46 +837,16 @@
 .kw-att-text { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 /* ════ CONTEXT COMPACTION (rail) ═════════════════════════════════ */
-.kw-cmp-actions { margin-top: 12px; }
-.kw-compact-btn {
-  width: 100%; display: inline-flex; align-items: center; justify-content: center; gap: 6px;
-  padding: 8px 12px; border-radius: var(--r-1); cursor: pointer; font-size: var(--fs-12); font-weight: var(--fw-semi);
-  border: 1px solid var(--color-accent-fg-dim); background: var(--color-accent-fg); color: var(--color-bg-page);
-  transition: background .15s, border-color .15s, opacity .15s;
+.kw-cmp-readonly {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--color-border-divider);
+  font-size: var(--fs-11);
+  color: var(--color-fg-secondary);
 }
-.kw-compact-btn:hover:not(:disabled) { background: var(--color-accent-fg-dim); border-color: var(--color-accent-fg-dim); }
-.kw-compact-btn:disabled { opacity: 0.6; cursor: not-allowed; }
-.kw-compact-btn.done {
-  background: rgb(var(--color-status-ok-glow) / 0.18);
-  border-color: rgb(var(--color-status-ok-glow) / 0.45);
-  color: var(--color-status-ok);
-}
-
-.kw-cmp-list { margin-top: 14px; display: flex; flex-direction: column; gap: 10px; }
-.kw-cmp-list h5 {
-  font-size: var(--fs-11); font-weight: var(--fw-bold); letter-spacing: 0.1em; text-transform: uppercase;
-  color: var(--color-fg-secondary); margin: 0;
-}
-.kw-cmp-snap {
-  background: var(--color-bg-elevated); border: 1px solid var(--color-border-divider); border-radius: var(--r-1);
-  padding: 10px 11px; font-size: var(--fs-12); color: var(--color-fg-primary);
-}
-.kw-cmp-snap-h {
-  display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 7px;
-}
-.kw-cmp-snap-id { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-accent-fg); }
-.kw-cmp-snap-at { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-muted); margin-left: auto; }
-.kw-cmp-snap-reduction {
-  font-family: var(--font-mono); font-size: var(--fs-11); font-weight: var(--fw-semi);
-  color: var(--color-status-ok); background: rgb(var(--color-status-ok-glow) / 0.12);
-  padding: 1px 6px; border-radius: 9999px;
-}
-.kw-cmp-snap-stats {
-  display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 8px;
-  font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-secondary);
-}
-.kw-cmp-snap-lists { display: flex; flex-direction: column; gap: 4px; font-size: var(--fs-11); color: var(--color-fg-secondary); }
-.kw-cmp-snap-lists b { color: var(--color-fg-primary); font-weight: var(--fw-semi); margin-right: 4px; }
 
 /* ════ B3 — message bubbles: asymmetric "speech tail" + emboss ═══════
  * Ported from the standalone v2 .bubble: a sharp corner on the speaker side


### PR DESCRIPTION
## Summary

- Replaces the vague keeper rail attention fallback with explicit `attention_reason` / `next_human_action` text, or a clear "cause not provided" fallback.
- Makes the runtime rail hide the model cell when no model is reported, instead of showing `—`.
- Removes the non-authoritative manual compact button and local fake snapshot flow from the rail; context/compaction now shows only runtime-reported data.
- Opens owned tasks into the planning task detail and allows task titles to wrap instead of truncating immediately.
- Renames the detail entry point to "운영 상세" and replaces rail toggle glyphs with lucide chevrons.
- Replaces Copilot dock/FAB character glyphs and hand-drawn SVG with lucide icons; the floating Chat FAB is now icon-only.

## Root Cause

The rail mixed missing runtime data with actionable-looking UI:

- `needs_attention=true` without a reason became "점검이 필요합니다", which did not explain what needed inspection.
- The compact button called a tool and then rendered local snapshot state without refreshing authoritative runtime state.
- The model/runtime card always reserved a model column, so missing model data surfaced as a noisy `—`.
- Owned task rows were non-interactive `<div>` elements with single-line truncation.
- Several controls used text glyphs instead of the dashboard icon system.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts src/components/copilot-dock.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm run typecheck`
- `pnpm exec eslint src/components/keeper-detail-page.ts src/components/keeper-workspace/keeper-workspace-rail.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts src/components/copilot-dock.ts`
- `git diff --check`
- Render smoke on local Vite `http://127.0.0.1:5176/dashboard/#monitoring?keeper=albini&section=agents` with Playwright screenshots.
- DOM smoke with `agent-browser`: confirmed `.dock-fab` contains `lucide-message-circle` SVG with visible stroke styling.

Note: full `pnpm run lint` still fails on pre-existing `dashboard/src/keeper-actions.ts:368` (`no-nested-ternary`), outside this diff.
