### PR TITLE
fix(approval): add 180s minimum review guardrail to prevent rubber-stamping

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -479,7 +479,7 @@ let minimum_review_time_s = 180.0
 let resolve_entry ?base_path (entry : pending_approval) (decision : decision) =
   let decision_str = approval_decision_to_string decision in
   let elapsed = Unix.gettimeofday () -. entry.requested_at in
-  if decision = Approve && elapsed < minimum_review_time_s then begin
+  if decision = Agent_sdk.Hooks.Approve && elapsed < minimum_review_time_s then begin
     let remaining = int_of_float (minimum_review_time_s -. elapsed) in
     Log.Keeper.warn
       "HITL_RUBBER_STAMP_REJECTED: id=%s keeper=%s tool=%s elapsed=%.1fs min=%.1fs remaining=%ds"

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -277,6 +277,7 @@ module For_testing = struct
   ;;
 
   let first_cmd_token = first_cmd_token
+  let set_minimum_review_time_s t = minimum_review_time_s := t
 end
 
 let action_key_of_input ~tool_name ~(input : Yojson.Safe.t) =
@@ -474,21 +475,21 @@ let record_pending (entry : pending_approval) =
   broadcast_pending entry
 ;;
 
-let minimum_review_time_s = 180.0
+let minimum_review_time_s = ref 180.0
 
 let resolve_entry ?base_path (entry : pending_approval) (decision : decision) =
   let decision_str = approval_decision_to_string decision in
   let elapsed = Unix.gettimeofday () -. entry.requested_at in
-  if decision = Agent_sdk.Hooks.Approve && elapsed < minimum_review_time_s then begin
-    let remaining = int_of_float (minimum_review_time_s -. elapsed) in
+  if decision = Agent_sdk.Hooks.Approve && elapsed < !minimum_review_time_s then begin
+    let remaining = int_of_float (!minimum_review_time_s -. elapsed) in
     Log.Keeper.warn
       "HITL_RUBBER_STAMP_REJECTED: id=%s keeper=%s tool=%s elapsed=%.1fs min=%.1fs remaining=%ds"
-      entry.id entry.keeper_name entry.tool_name elapsed minimum_review_time_s remaining;
+      entry.id entry.keeper_name entry.tool_name elapsed !minimum_review_time_s remaining;
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string ApprovalQueueFailures)
       ~labels:[ "keeper", entry.keeper_name; "site", "rubber_stamp_rejected" ]
       ();
-    Error (`Msg (Printf.sprintf "Approval rejected: minimum review time is %.0fs (%.0fs elapsed)" minimum_review_time_s elapsed))
+    Error (`Msg (Printf.sprintf "Approval rejected: minimum review time is %.0fs (%.0fs elapsed)" !minimum_review_time_s elapsed))
   end else begin
   Log.Keeper.info
     "HITL_APPROVAL_RESOLVED: id=%s keeper=%s tool=%s decision=%s"

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -474,8 +474,22 @@ let record_pending (entry : pending_approval) =
   broadcast_pending entry
 ;;
 
+let minimum_review_time_s = 180.0
+
 let resolve_entry ?base_path (entry : pending_approval) (decision : decision) =
   let decision_str = approval_decision_to_string decision in
+  let elapsed = Unix.gettimeofday () -. entry.requested_at in
+  if decision = Approve && elapsed < minimum_review_time_s then begin
+    let remaining = int_of_float (minimum_review_time_s -. elapsed) in
+    Log.Keeper.warn
+      "HITL_RUBBER_STAMP_REJECTED: id=%s keeper=%s tool=%s elapsed=%.1fs min=%.1fs remaining=%ds"
+      entry.id entry.keeper_name entry.tool_name elapsed minimum_review_time_s remaining;
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ApprovalQueueFailures)
+      ~labels:[ "keeper", entry.keeper_name; "site", "rubber_stamp_rejected" ]
+      ();
+    Error (`Msg (Printf.sprintf "Approval rejected: minimum review time is %.0fs (%.0fs elapsed)" minimum_review_time_s elapsed))
+  end else begin
   Log.Keeper.info
     "HITL_APPROVAL_RESOLVED: id=%s keeper=%s tool=%s decision=%s"
     entry.id

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -304,6 +304,8 @@ let test_approval_queue_submit_and_resolve () =
        | _ -> Alcotest.fail "no id field")
     | _ -> Alcotest.fail "bad entry"
   in
+  (* Override guardrail: set minimum review time to 0 for this test *)
+  AQ.For_testing.set_minimum_review_time_s 0.0;
   (* Operator resolves: approve *)
   (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
    | Ok () -> ()
@@ -909,6 +911,41 @@ let test_dashboard_resolve_and_delete_rules_use_workspace_base_path () =
       Alcotest.(check int) "env fallback still empty" 0
         (List.length (AQ.list_rules ~base_path:env_base ())))
 
+let test_approval_queue_rejects_rubber_stamp () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let keeper_name = "rubber-stamp-test" in
+  let result = ref None in
+  AQ.For_testing.set_minimum_review_time_s 180.0;
+  Eio.Fiber.fork ~sw (fun () ->
+    let decision =
+      AQ.submit_and_await
+        ~keeper_name
+        ~tool_name:"masc_force_reset"
+        ~input:(`Assoc [])
+        ~risk_level:AQ.Critical
+        ()
+    in
+    result := Some decision
+  );
+  Eio.Fiber.yield ();
+  let id =
+    match pending_id_for_keeper ~keeper_name with
+    | Some id -> id
+    | None -> Alcotest.fail "rubber-stamp: no pending entry"
+  in
+  (* Immediate approve (< 180s) should be rejected *)
+  (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+   | Error (`Msg msg) when String.starts_with ~prefix:"Approval rejected:" msg -> ()
+   | Ok () -> Alcotest.fail "rubber-stamp: expected rejection, got Ok"
+   | Error (`Msg msg) -> Alcotest.fail ("rubber-stamp: unexpected error: " ^ msg));
+  (* Cleanup: restore 0s for other tests *)
+  AQ.For_testing.set_minimum_review_time_s 0.0;
+  (* Resolve with reject to clean up *)
+  (match AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "cleanup after rubber-stamp test") with
+   | Ok () | Error _ -> ());
+  AQ.For_testing.set_minimum_review_time_s 0.0
+
 let test_submit_pending_audit_uses_workspace_base_path () =
   let env_base = temp_dir () in
   let workspace_base = temp_dir () in
@@ -1401,6 +1438,8 @@ let () =
         test_dashboard_resolve_and_delete_rules_use_workspace_base_path;
       Alcotest.test_case "submit_pending audit uses workspace base_path" `Quick
         test_submit_pending_audit_uses_workspace_base_path;
+      Alcotest.test_case "rejects rubber-stamp approval" `Quick
+        test_approval_queue_rejects_rubber_stamp;
       Alcotest.test_case "read_recent_audit scans before keeper filter" `Quick
         test_read_recent_audit_filters_after_wide_scan;
       Alcotest.test_case


### PR DESCRIPTION
## What

Adds a 180-second minimum review time guardrail to prevent rubber-stamping (instant approval without review).

## Changes

- **`keeper_approval_queue.ml`** (+14 lines): In `resolve_entry`, checks `Unix.gettimeofday() -. entry.requested_at < 180.0` for `Approve` decisions. If the review time is below the minimum, the approval is rejected with a warning and the `ApprovalQueueFailures` metric is incremented.
- New constant `minimum_review_time_s = 180.0`

## Why

Addresses task-1441: agents were approving too quickly (rubber-stamping) without adequate review time. The 180s (3 minute) minimum ensures human consideration time before approval is accepted.

## Verification

- Only triggers on `Approve` decisions — `Reject` is unaffected
- Idempotent: no state mutation beyond logging and metrics
- Independent of the GC trigger fix (PR #21690)