### PR TITLE
fix: exempt pure-deletion PRs from coverage check Rule 2

### DIFF
--- a/scripts/check_test_coverage.py
+++ b/scripts/check_test_coverage.py
@@ -5,7 +5,7 @@ Checks that code changes to covered paths have accompanying test changes.
 
 Rules (checked for every non-skipped PR that touches covered code paths):
 - added_code_lines > 10 && test_files == 0 -> warn (enforced)
-- changed_code_files > 3 - changed_code_files > 3 && test_files == 0 -> warn (enforced)- changed_code_files > 3 && test_files == 0 -> warn (enforced) added_lines > 0 - changed_code_files > 3 && test_files == 0 -> warn (enforced)- changed_code_files > 3 && test_files == 0 -> warn (enforced) test_files == 0 -> warn (enforced)
+- changed_code_files > 3 && added_code_lines > 0 && test_files == 0 -> warn (enforced)
 
 Opt-out mechanisms (checked in order):
 1. Branch name contains "ci-skip" — workflow if: guard

--- a/scripts/check_test_coverage.py
+++ b/scripts/check_test_coverage.py
@@ -5,7 +5,7 @@ Checks that code changes to covered paths have accompanying test changes.
 
 Rules (checked for every non-skipped PR that touches covered code paths):
 - added_code_lines > 10 && test_files == 0 -> warn (enforced)
-- changed_code_files > 3 && test_files == 0 -> warn (enforced)
+- changed_code_files > 3 - changed_code_files > 3 && test_files == 0 -> warn (enforced)- changed_code_files > 3 && test_files == 0 -> warn (enforced) added_lines > 0 - changed_code_files > 3 && test_files == 0 -> warn (enforced)- changed_code_files > 3 && test_files == 0 -> warn (enforced) test_files == 0 -> warn (enforced)
 
 Opt-out mechanisms (checked in order):
 1. Branch name contains "ci-skip" — workflow if: guard
@@ -168,7 +168,7 @@ def check_coverage():
             f"Add tests to cover new functionality."
         )
 
-    if len(code_files) > 3 and len(test_files) == 0:
+    if len(code_files) > 3 and len(test_files) == 0 and added_lines > 0:
         violations.append(
             f"Changed {len(code_files)} files in covered code paths but no test files changed. "
             f"Consider adding tests for at least the critical paths."

--- a/scripts/test_check_test_coverage.py
+++ b/scripts/test_check_test_coverage.py
@@ -98,6 +98,50 @@ class CheckTestCoverageTest(unittest.TestCase):
 
         self.assertEqual(raised.exception.code, 1)
 
+    def test_many_code_file_deletions_without_tests_do_not_trigger_rule_2(self):
+        code_files = ["lib/a.ml", "lib/b.ml", "lib/c.ml", "lib/d.ml"]
+        out = io.StringIO()
+        with mock.patch.dict(os.environ, {"PR_BODY": ""}, clear=False):
+            with mock.patch("check_test_coverage.is_opt_out_commit", return_value=False):
+                with mock.patch(
+                    "check_test_coverage.get_changed_covered_files",
+                    return_value=code_files,
+                ):
+                    with mock.patch(
+                        "check_test_coverage.get_changed_test_files", return_value=[]
+                    ):
+                        with mock.patch(
+                            "check_test_coverage.get_added_lines_count", return_value=0
+                        ):
+                            with self.assertRaises(SystemExit) as raised:
+                                with contextlib.redirect_stdout(out):
+                                    coverage.check_coverage()
+
+        self.assertEqual(raised.exception.code, 0)
+        self.assertIn("Test coverage check passed.", out.getvalue())
+
+    def test_many_code_files_with_additions_without_tests_trigger_rule_2(self):
+        code_files = ["lib/a.ml", "lib/b.ml", "lib/c.ml", "lib/d.ml"]
+        out = io.StringIO()
+        with mock.patch.dict(os.environ, {"PR_BODY": ""}, clear=False):
+            with mock.patch("check_test_coverage.is_opt_out_commit", return_value=False):
+                with mock.patch(
+                    "check_test_coverage.get_changed_covered_files",
+                    return_value=code_files,
+                ):
+                    with mock.patch(
+                        "check_test_coverage.get_changed_test_files", return_value=[]
+                    ):
+                        with mock.patch(
+                            "check_test_coverage.get_added_lines_count", return_value=1
+                        ):
+                            with self.assertRaises(SystemExit) as raised:
+                                with contextlib.redirect_stdout(out):
+                                    coverage.check_coverage()
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("Changed 4 files", out.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Exempt pure-deletion covered-code PRs from coverage Rule 2 by requiring Rule 2 to fire only when the covered-code diff has added lines. This handles diffs that touch many covered files only by deleting code, where there is no new behavior to cover.

## Changes

- `scripts/check_test_coverage.py`: keep Rule 2 for `changed_code_files > 3 && test_files == 0`, but only when `added_lines > 0`
- `scripts/check_test_coverage.py`: restore the corrupted top-of-file Rule 2 documentation
- `scripts/test_check_test_coverage.py`: add self-tests for the pure-deletion exemption and for mixed/additive diffs still triggering Rule 2

## Testing

- `python3 scripts/test_check_test_coverage.py`
- `pyright --outputjson scripts/check_test_coverage.py scripts/test_check_test_coverage.py`
- `ruff check scripts/check_test_coverage.py scripts/test_check_test_coverage.py`
- `git diff --check origin/main...HEAD`
