### PR TITLE
[codex] fix dashboard chat theme rendering

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -83,6 +83,9 @@ const TEST_FILES = [
   'src/runtime-counts.test.ts',
   'src/schemas/sse.test.ts',
   'src/sse-store.test.ts',
+  'src/styles/chat-blocks-v2.test.ts',
+  'src/styles/paper-theme.test.ts',
+  'src/styles/skin-v2-paper.test.ts',
 ]
 
 const DEFAULT_PROJECT_FILES = [

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1554,6 +1554,8 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     expect(cards[0]?.textContent).toContain('작업 과정')
     expect(cards[0]?.textContent).toContain('2단계')
     expect(cards[0]?.textContent).toContain('도구 2')
+    expect(cards[0]?.textContent).toContain('keeper_board_list')
+    expect(cards[0]?.textContent).toContain('keeper_tasks_list')
     // Grouped surface keeps no standalone per-row tool bubbles.
     expect(container.querySelectorAll('[data-chat-variant="tool-call"]').length).toBe(0)
   })
@@ -1586,8 +1588,6 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
       container,
     )
     expect(container.querySelector('[data-chat-tool-trace]')?.textContent).toContain('실패 1')
-    ;(container.querySelector('.chat-block-trace-hd') as HTMLButtonElement).click()
-    await flushUi()
     const step = container.querySelector('[data-chat-trace-step="tool"]') as HTMLElement
     expect(step.querySelector('.chat-block-tstep-status.bad')).not.toBeNull()
     ;(step.querySelector('.chat-block-tstep-row') as HTMLElement).click()

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2097,15 +2097,15 @@ function ToolTraceStep({ entry, output }: { entry: KeeperConversationEntry; outp
   `
 }
 
-// Groups a turn's consecutive tool-call entries into one folded "작업 과정"
+// Groups a turn's consecutive tool-call entries into one "작업 과정"
 // trace card placed above the answer bubble — the v2 layout, built from live
-// data. Folded by default so a turn with many probes (a dozen keeper_board_list
-// / keeper_tasks_list calls) collapses to a single summary line instead of a
-// wall of raw-JSON rows. No think/reason steps are synthesised: the live
-// transcript has no reasoning channel, so the card omits them rather than
+// data. The step list is visible by default so operators can see tool names and
+// status without opening the card; each step's raw args/result body remains
+// collapsed to avoid a wall of JSON. No think/reason steps are synthesised: the
+// live transcript has no reasoning channel, so the card omits them rather than
 // fabricate the v2 reference's mock reasoning.
 function ToolTraceCard({ tools }: { tools: KeeperConversationEntry[] }) {
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(true)
   const steps = tools.map((entry) => ({ entry, output: lookupToolCallOutput(entry.id) }))
   const failN = steps.filter(
     (s) => s.output !== null && (s.output.success === false || s.output.semantic_success === false),

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -108,6 +108,14 @@ describe('filterConversationEntries', () => {
     const entries = [entry({ id: 'a', label: '사용자', text: 'plain' })]
     expect(filterConversationEntries(entries, '사용자')).toEqual([])
   })
+
+  it('matches tool rows by visible tool label', () => {
+    const entries = [
+      entry({ id: 'tool-a', role: 'tool', source: 'tool_result', label: 'keeper_board_list', text: '{}' }),
+      entry({ id: 'b', text: 'plain' }),
+    ]
+    expect(filterConversationEntries(entries, 'board_list').map(e => e.id)).toEqual(['tool-a'])
+  })
 })
 
 describe('KeeperConversationPanel', () => {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -222,7 +222,9 @@ function effectiveDiagnostic(keeper: Keeper | null | undefined): KeeperDiagnosti
   return detail?.diagnostic ?? keeper.diagnostic ?? null
 }
 
-/** Case-insensitive substring filter over entry text. Empty or
+/** Case-insensitive substring filter over entry text. Tool rows also match on
+ *  the tool label because their visible name often is not present in `{}` args.
+ *  Empty or
  *  whitespace-only queries return the input unchanged. Migrated from
  *  the former keeper-chat-panel.ts (filterChatMessages). */
 export function filterConversationEntries(
@@ -231,7 +233,11 @@ export function filterConversationEntries(
 ): KeeperConversationEntry[] {
   const q = query.trim().toLowerCase()
   if (!q) return entries
-  return entries.filter(entry => entry.text.toLowerCase().includes(q))
+  return entries.filter(entry => {
+    if (entry.text.toLowerCase().includes(q)) return true
+    if ((entry.rawText ?? '').toLowerCase().includes(q)) return true
+    return entry.role === 'tool' && entry.label.toLowerCase().includes(q)
+  })
 }
 
 function blocksToAttachments(blocks: ChatBlock[]): KeeperConversationAttachment[] {

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -88,15 +88,16 @@ import { startNavTelemetry } from './lib/nav-telemetry'
 import { THEME_STORAGE_KEYS, THEME_SEARCH_PARAM, type ThemeId } from './lib/theme'
 
 function normalizeTheme(raw: string | null): ThemeId {
-  if (raw === 'styleseed' || raw === 'light') {
+  const value = raw?.trim().toLowerCase() ?? null
+  if (value === 'styleseed' || value === 'light') {
     return 'styleseed'
   }
-  if (raw === 'paper') {
+  if (value === 'paper') {
     return 'paper'
   }
   // Preserve compatibility with existing callers that may send dark-themed values
   // while treating explicit dark values as an opt-out to the legacy palette.
-  if (raw === 'dark' || raw === 'dark-fantasy') {
+  if (value === 'dark' || value === 'dark-fantasy') {
     return null
   }
   return null

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -35,9 +35,12 @@
 
 /* ── Trace (collapsible reasoning / tool steps) ──────────────── */
 .chat-block-trace {
-  border: 1px solid var(--color-border-default);
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  border: 1px solid var(--chat-tool-border, var(--color-border-default));
   border-radius: var(--r-1);
-  background: var(--color-bg-surface);
+  background: linear-gradient(180deg, var(--chat-tool-bg, var(--color-bg-surface)), var(--color-bg-surface));
   overflow: hidden;
 }
 
@@ -66,6 +69,7 @@
 
 .chat-block-trace-label {
   font-weight: var(--fw-semi);
+  color: var(--chat-tool-fg, var(--color-fg-secondary));
 }
 
 .chat-block-trace-count,
@@ -138,7 +142,7 @@
 .chat-block-tstep-name {
   font-family: var(--font-mono);
   font-size: var(--fs-xs);
-  color: var(--color-fg-secondary);
+  color: var(--chat-tool-fg, var(--color-fg-secondary));
 }
 
 .chat-block-tstep-status {

--- a/dashboard/src/styles/chat-blocks-v2.test.ts
+++ b/dashboard/src/styles/chat-blocks-v2.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const cssPath = resolve(__dirname, 'chat-blocks-v2.css')
+const css = readFileSync(cssPath, 'utf-8')
+
+function parseBlock(selector: string): Record<string, string> {
+  const start = css.indexOf(selector)
+  if (start === -1) {
+    throw new Error(`Selector not found: ${selector}`)
+  }
+
+  const open = css.indexOf('{', start)
+  const close = css.indexOf('}', open)
+  const block = css.slice(open + 1, close)
+  const props: Record<string, string> = {}
+  for (const line of block.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('/*')) continue
+    const match = /^([\w-]+):\s*([^;]+);/.exec(trimmed)
+    if (match && match[1] && match[2]) {
+      props[match[1]] = match[2].trim()
+    }
+  }
+  return props
+}
+
+describe('chat-blocks-v2.css', () => {
+  it('keeps opened tool traces from shrinking inside the chat flex column', () => {
+    const trace = parseBlock('.chat-block-trace')
+    expect(trace.display).toBe('flex')
+    expect(trace.flex).toBe('none')
+    expect(trace['flex-direction']).toBe('column')
+  })
+})

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -2,6 +2,20 @@
 
 /* ── Chat (merged from chat.css) ───────────────────────── */
 
+:root {
+  --chat-operator-bg: var(--color-brass-soft);
+  --chat-operator-border: var(--brass-border, var(--color-accent-fg-dim));
+  --chat-operator-fg: var(--color-brass-fg, var(--color-accent-fg));
+
+  --chat-keeper-bg: var(--color-info-soft);
+  --chat-keeper-border: var(--info-border, var(--color-border-strong));
+  --chat-keeper-fg: var(--color-info-fg, var(--color-fg-secondary));
+
+  --chat-tool-bg: var(--color-bg-panel-alt);
+  --chat-tool-border: var(--info-border, var(--color-border-default));
+  --chat-tool-fg: var(--color-info-fg, var(--color-fg-secondary));
+}
+
 @utility chat-transcript {
   background:
     radial-gradient(circle at top left, rgb(var(--color-accent-glow) / .12), transparent 38%),
@@ -19,13 +33,18 @@
   box-shadow: var(--elev-4-shadow);
   &.user {
     align-self: flex-end;
-    background: linear-gradient(180deg, rgb(var(--color-accent-glow) / .12), var(--color-bg-elevated));
-    border-color: var(--color-accent-fg-dim);
+    background: linear-gradient(180deg, var(--chat-operator-bg), var(--color-bg-elevated));
+    border-color: var(--chat-operator-border);
   }
   &.assistant {
     align-self: flex-start;
-    background: linear-gradient(180deg, rgb(var(--color-accent-glow) / .08), var(--color-bg-panel-alt));
-    border-color: var(--color-accent-fg-dim);
+    background: linear-gradient(180deg, var(--chat-keeper-bg), var(--color-bg-panel-alt));
+    border-color: var(--chat-keeper-border);
+  }
+  &.tool {
+    align-self: stretch;
+    background: linear-gradient(180deg, var(--chat-tool-bg), var(--color-bg-surface));
+    border-color: var(--chat-tool-border);
   }
   &.system,
   &.error {
@@ -43,14 +62,14 @@
   border-style: solid;
   border-color: var(--color-border-default);
   &.user {
-    border-color: var(--color-accent-fg-dim);
-    background: var(--color-accent-soft);
-    color: var(--chat-user-avatar);
+    border-color: var(--chat-operator-border);
+    background: var(--chat-operator-bg);
+    color: var(--chat-operator-fg);
   }
   &.assistant {
-    border-color: var(--color-accent-fg-dim);
-    background: rgb(var(--color-accent-glow) / .18);
-    color: var(--chat-assistant-avatar);
+    border-color: var(--chat-keeper-border);
+    background: var(--chat-keeper-bg);
+    color: var(--chat-keeper-fg);
   }
   &.error {
     border-color: var(--color-status-err);
@@ -64,14 +83,14 @@
   border-style: solid;
   border-color: var(--color-border-default);
   &.user {
-    border-color: var(--color-accent-fg-dim);
-    color: var(--chat-user-chip);
-    background: rgb(var(--color-accent-glow) / .14);
+    border-color: var(--chat-operator-border);
+    color: var(--chat-operator-fg);
+    background: var(--chat-operator-bg);
   }
   &.assistant {
-    border-color: var(--color-accent-fg-dim);
-    color: var(--chat-assistant-chip);
-    background: rgb(var(--color-accent-glow) / .10);
+    border-color: var(--chat-keeper-border);
+    color: var(--chat-keeper-fg);
+    background: var(--chat-keeper-bg);
   }
   &.error {
     border-color: var(--color-status-err);

--- a/dashboard/src/styles/paper-theme.css
+++ b/dashboard/src/styles/paper-theme.css
@@ -16,7 +16,7 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
 
-[data-theme="paper"] {
+html[data-theme="paper"] {
   color-scheme: light;
 
   /* ───── Paper & ink (design system source of truth) ──────── */
@@ -37,7 +37,7 @@
   --brass:        #8C6A1E;   --brass-fill: #E9DDB8;  --brass-line: #B8933A;
   --brick:        #8B3A3A;   --brick-fill: #E8CFCB;  --brick-line: #B45C5C;
   --ember:        #B35A1F;   --ember-fill: #ECD5BD;  --ember-line: #D07A3A;
-  --slate:        #3E4A5C;   --slate-fill: #D6DBE2;  --slate-line: #6B7A8E;
+  --slate-accent: #3E4A5C;   --slate-accent-fill: #D6DBE2;  --slate-accent-line: #6B7A8E;
   --plum:         #5C3E56;   --plum-fill:  #E0D4DE;  --plum-line:  #855E7D;
   --teal:         #236874;   --teal-fill:  #CEDEE2;  --teal-line:  #4C94A3;
 
@@ -62,14 +62,29 @@
   --color-bg-3: var(--paper-3);
   --color-bg-4: var(--paper-4);
 
+  --color-bg-page: var(--paper);
+  --color-bg-surface: var(--paper-2);
+  --color-bg-panel-alt: var(--paper-3);
+  --color-bg-elevated: var(--paper-2);
+  --color-bg-hover: var(--paper-3);
+
   --color-fg-1: var(--ink);
   --color-fg-2: var(--ink-2);
   --color-fg-3: var(--ink-4);
   --color-fg-4: var(--ink-6);
 
+  --color-fg-primary: var(--ink);
+  --color-fg-secondary: var(--ink-2);
+  --color-fg-muted: var(--ink-4);
+  --color-fg-disabled: var(--ink-6);
+
   --color-line-1: var(--border-3-paper);
   --color-line-2: var(--border-4-paper);
   --color-line-3: var(--border-5-paper);
+
+  --color-border-default: var(--border-3-paper);
+  --color-border-strong: var(--border-2-paper);
+  --color-border-divider: var(--border-4-paper);
 
   --color-brass-1: var(--brass);
   --color-brass-2: var(--brass-line);
@@ -79,9 +94,21 @@
   --color-ok: var(--forest);
   --color-warn: var(--ember);
   --color-err: var(--brick);
-  --color-info: var(--slate);
+  --color-info: var(--slate-accent);
   --color-idle: var(--ink-5);
   --color-stalled: var(--plum);
+
+  --color-status-ok: var(--forest);
+  --color-status-warn: var(--ember);
+  --color-status-err: var(--brick);
+  --color-status-info: var(--slate-accent);
+
+  --color-ok-fg: var(--forest);
+  --color-warn-fg: var(--ember);
+  --color-err-fg: var(--brick);
+  --color-info-fg: var(--slate-accent);
+  --color-idle-fg: var(--ink-5);
+  --color-stalled-fg: var(--plum);
 
   --color-ok-glow: 45 95 78;
   --color-warn-glow: 179 90 31;
@@ -95,6 +122,88 @@
   --color-info-soft: rgb(var(--color-info-glow) / .12);
   --color-stalled-soft: rgb(var(--color-stalled-glow) / .12);
   --color-idle-soft: rgba(135, 131, 121, 0.10);
+
+  --ok-fg: var(--forest);
+  --ok-border: var(--forest-line);
+  --warn-fg: var(--ember);
+  --warn-border: var(--ember-line);
+  --err-fg: var(--brick);
+  --err-border: var(--brick-line);
+  --info-fg: var(--slate-accent);
+  --info-border: var(--slate-accent-line);
+  --idle-fg: var(--ink-5);
+  --idle-border: var(--border-3-paper);
+  --stalled-fg: var(--plum);
+  --stalled-border: var(--plum-line);
+
+  /* StyleSeed / v2 app-shell bridge. Later v2 styles define these at
+     :root; the html[data-theme="paper"] selector intentionally outranks
+     that default so paper mode recolors migrated shell surfaces too. */
+  --background: var(--paper);
+  --surface-page: var(--paper);
+  --card: var(--paper-2);
+  --surface-subtle: var(--paper-3);
+  --surface-muted: var(--paper-4);
+  --text-primary: var(--ink);
+  --text-secondary: var(--ink-3);
+  --text-tertiary: var(--ink-5);
+  --text-disabled: var(--ink-6);
+  --icon-default: var(--ink-4);
+  --border: var(--border-3-paper);
+  --brand: var(--brass);
+  --brand-dim: var(--brass-line);
+  --brand-wash: rgba(140, 106, 30, 0.12);
+  --brand-tint: rgba(140, 106, 30, 0.16);
+  --success: var(--forest);
+  --warning: var(--ember);
+  --destructive: var(--brick);
+  --info: var(--slate-accent);
+
+  --ss-page: var(--paper);
+  --ss-card: var(--paper-2);
+  --ss-card-raised: var(--paper-2);
+  --ss-card-hover: var(--paper-3);
+  --ss-surface: var(--paper-3);
+  --ss-surface-subtle: var(--paper-3);
+  --ss-surface-muted: var(--paper-4);
+  --ss-sunken: var(--paper-4);
+
+  --ss-text-strong: var(--ink);
+  --ss-text-primary: var(--ink-2);
+  --ss-text-secondary: var(--ink-4);
+  --ss-text-tertiary: var(--ink-5);
+  --ss-text-disabled: var(--ink-6);
+
+  --ss-border: var(--border-3-paper);
+  --ss-border-subtle: var(--border-4-paper);
+  --ss-border-strong: var(--border-2-paper);
+  --ss-border-1: var(--border-5-paper);
+  --ss-border-2: var(--border-4-paper);
+  --ss-border-3: var(--border-3-paper);
+
+  --ss-brand: var(--brass);
+  --ss-brand-tint: rgba(140, 106, 30, 0.16);
+  --ss-brand-dim: rgba(140, 106, 30, 0.08);
+  --ss-brand-glow: 140 106 30;
+  --ss-success: var(--forest);
+  --ss-warning: var(--ember);
+  --ss-destructive: var(--brick);
+  --ss-shadow-card: 0 1px 2px rgba(21, 21, 21, 0.06);
+  --ss-shadow-card-hover: 0 2px 5px rgba(21, 21, 21, 0.10);
+  --ss-shadow-elevated: 0 8px 18px rgba(21, 21, 21, 0.10);
+  --ss-shadow-modal: 0 12px 30px rgba(21, 21, 21, 0.16);
+  --ss-radius-card: 8px;
+  --ss-radius-input: 6px;
+
+  --chat-operator-bg: var(--brass-fill);
+  --chat-operator-border: var(--brass-line);
+  --chat-operator-fg: var(--brass);
+  --chat-keeper-bg: var(--teal-fill);
+  --chat-keeper-border: var(--teal-line);
+  --chat-keeper-fg: var(--teal);
+  --chat-tool-bg: var(--slate-accent-fill);
+  --chat-tool-border: var(--slate-accent-line);
+  --chat-tool-fg: var(--slate-accent);
 
   /* =====================================================================
      Bridge to existing MASC semantic tokens.
@@ -147,19 +256,19 @@
 
   /* accent — Working / Info, slate-group.
      #8284 sweep collapsed sky/blue/cyan/teal/indigo/violet/... here. */
-  --accent: var(--slate);
-  --accent-10: var(--slate-fill);
-  --accent-20: var(--slate-fill);
-  --accent-soft: var(--slate-fill);
+  --accent: var(--slate-accent);
+  --accent-10: var(--slate-accent-fill);
+  --accent-20: var(--slate-accent-fill);
+  --accent-soft: var(--slate-accent-fill);
 
   /* Legacy FF-namespaced tokens — kept for any component the
      sweeps haven't reached yet. */
-  --color-accent: var(--slate);
-  --color-accent-soft: var(--slate-fill);
+  --color-accent: var(--slate-accent);
+  --color-accent-soft: var(--slate-accent-fill);
   --color-ff-gold: var(--brass);
   --color-ff-gold-bright: var(--brass-line);
   --color-ff-gold-dim: var(--brass-fill);
-  --color-ff-crystal: var(--slate);
+  --color-ff-crystal: var(--slate-accent);
   --color-ok: var(--forest);
   --color-warn: var(--ember);
   --color-bad: var(--brick);
@@ -191,7 +300,7 @@
   --blue-400-15: rgba(130, 126, 118, 0.15);
 
   /* Sky-family names now use the same neutral tone family. */
-  --sky-400: var(--slate);
+  --sky-400: var(--slate-accent);
   --sky-4: rgba(131, 120, 104, 0.04);
   --sky-8: rgba(131, 120, 104, 0.08);
   --sky-28: rgba(131, 120, 104, 0.28);
@@ -205,7 +314,7 @@
   --slate-fill: var(--paper-3);
 
   /* Indigo and related variants: waiting / dependency-blocking states. */
-  --indigo: var(--slate);
+  --indigo: var(--slate-accent);
   --indigo-4: rgba(62, 74, 92, 0.04);
   --indigo-40: rgba(62, 74, 92, 0.40);
   --indigo-45: rgba(62, 74, 92, 0.45);

--- a/dashboard/src/styles/paper-theme.test.ts
+++ b/dashboard/src/styles/paper-theme.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const cssPath = resolve(__dirname, 'paper-theme.css')
+const css = readFileSync(cssPath, 'utf-8')
+
+function parseBlock(selector: string): Record<string, string> {
+  const start = css.indexOf(selector)
+  if (start === -1) {
+    throw new Error(`Selector not found: ${selector}`)
+  }
+
+  const open = css.indexOf('{', start)
+  let depth = 0
+  let close = open
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === '{') depth++
+    if (css[i] === '}') {
+      depth--
+      if (depth === 0) {
+        close = i
+        break
+      }
+    }
+  }
+
+  const block = css.slice(open + 1, close)
+  const vars: Record<string, string> = {}
+  for (const line of block.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('/*')) continue
+    const match = /^(--[\w-]+):\s*([^;]+);/.exec(trimmed)
+    if (match && match[1] && match[2]) {
+      vars[match[1]] = match[2].trim()
+    }
+  }
+  return vars
+}
+
+describe('paper-theme.css', () => {
+  it('uses html[data-theme="paper"] so later :root v2 tokens cannot override it', () => {
+    expect(css).toContain('html[data-theme="paper"] {')
+  })
+
+  it('bridges paper values into migrated StyleSeed shell tokens', () => {
+    const theme = parseBlock('html[data-theme="paper"]')
+    expect(theme['--ss-page']).toBe('var(--paper)')
+    expect(theme['--ss-card']).toBe('var(--paper-2)')
+    expect(theme['--ss-brand']).toBe('var(--brass)')
+    expect(theme['--color-bg-page']).toBe('var(--paper)')
+    expect(theme['--color-fg-primary']).toBe('var(--ink)')
+  })
+
+  it('assigns distinct paper colors to operator, keeper, and tool chat surfaces', () => {
+    const theme = parseBlock('html[data-theme="paper"]')
+    expect(theme['--chat-operator-bg']).toBe('var(--brass-fill)')
+    expect(theme['--chat-keeper-bg']).toBe('var(--teal-fill)')
+    expect(theme['--chat-tool-bg']).toBe('var(--slate-accent-fill)')
+    expect(theme['--accent']).toBe('var(--slate-accent)')
+  })
+})

--- a/dashboard/src/styles/skin-v2-paper.test.ts
+++ b/dashboard/src/styles/skin-v2-paper.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const cssPath = resolve(__dirname, 'skin-v2.css')
+const css = readFileSync(cssPath, 'utf-8')
+
+function parseBlock(selector: string): Record<string, string> {
+  const start = css.indexOf(selector)
+  if (start === -1) {
+    throw new Error(`Selector not found: ${selector}`)
+  }
+
+  const open = css.indexOf('{', start)
+  let depth = 0
+  let close = open
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === '{') depth++
+    if (css[i] === '}') {
+      depth--
+      if (depth === 0) {
+        close = i
+        break
+      }
+    }
+  }
+
+  const block = css.slice(open + 1, close)
+  const vars: Record<string, string> = {}
+  for (const line of block.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('/*')) continue
+    const match = /^(--[\w-]+):\s*([^;]+);/.exec(trimmed)
+    if (match && match[1] && match[2]) {
+      vars[match[1]] = match[2].trim()
+    }
+  }
+  return vars
+}
+
+describe('skin-v2.css paper bridge', () => {
+  it('uses the paper-theme palette instead of the old gray v2 paper spine', () => {
+    const theme = parseBlock('html[data-skin="v2"][data-theme="paper"]')
+    expect(theme['--bg-deep']).toBe('var(--paper)')
+    expect(theme['--bg-panel']).toBe('var(--paper-2)')
+    expect(theme['--border-main']).toBe('var(--border-3-paper)')
+    expect(theme['--text-bright']).toBe('var(--ink)')
+    expect(theme['--info']).toBe('var(--slate-accent)')
+    expect(theme['--volt']).toBe('var(--brass)')
+  })
+})

--- a/dashboard/src/styles/skin-v2.css
+++ b/dashboard/src/styles/skin-v2.css
@@ -135,59 +135,59 @@ html[data-skin="v2"][data-volt="ice"]:not([data-theme="paper"]):not([data-theme=
    ════════════════════════════════════════════════════════════ */
 html[data-skin="v2"][data-theme="paper"] {
   color-scheme: light;
-  --bg-deep:        #f1f2f5;
-  --bg-panel:       #fafbfc;
-  --bg-panel-alt:   #ffffff;
-  --bg-card:        #ffffff;
-  --bg-card-hover:  #eef0f3;
-  --bg-sunken:      #f3f4f7;
-  --bg-well:        #eef0f3;
+  --bg-deep:        var(--paper);
+  --bg-panel:       var(--paper-2);
+  --bg-panel-alt:   var(--paper-3);
+  --bg-card:        var(--paper-2);
+  --bg-card-hover:  var(--paper-3);
+  --bg-sunken:      var(--paper-4);
+  --bg-well:        var(--paper-3);
 
-  --border-main:      rgba(22,24,29,0.12);
-  --border-soft:      rgba(22,24,29,0.07);
-  --border-highlight: rgba(22,24,29,0.22);
+  --border-main:      var(--border-3-paper);
+  --border-soft:      var(--border-4-paper);
+  --border-highlight: var(--border-2-paper);
 
-  --text-bright:  #16181d;
-  --text-primary: #2f3137;
-  --text-mid:     #565962;
-  --text-dim:     #797d86;
+  --text-bright:  var(--ink);
+  --text-primary: var(--ink-2);
+  --text-mid:     var(--ink-4);
+  --text-dim:     var(--ink-6);
 
   /* status — darkened for legibility on white */
-  --status-ok:    #17803d;
-  --status-warn:  #b45309;
-  --status-bad:   #b42318;
-  --status-idle:  #9298a2;
-  --status-busy:  #1e6fa8;
+  --status-ok:    var(--forest);
+  --status-warn:  var(--ember);
+  --status-bad:   var(--brick);
+  --status-idle:  var(--ink-5);
+  --status-busy:  var(--teal);
 
-  --info:     #2d6cdf;
-  --info-dim: #1e54bc;
+  --info:     var(--slate-accent);
+  --info-dim: var(--slate-accent-line);
 
   /* soft ink shadows instead of black drop shadows */
-  --shadow-card:   0 1px 2px rgba(22,24,29,0.07);
-  --shadow-panel:  0 4px 18px rgba(22,24,29,0.10);
-  --shadow-pop:    0 12px 32px rgba(22,24,29,0.16), 0 0 0 1px var(--border-main);
+  --shadow-card:   var(--ss-shadow-card);
+  --shadow-panel:  var(--ss-shadow-elevated);
+  --shadow-pop:    var(--ss-shadow-modal), 0 0 0 1px var(--border-main);
   --shadow-glow:   0 0 0 1px var(--volt-dim);
 
   /* default voltage (brass) deepened so gold reads on white */
-  --volt:        #b07d1a;
-  --volt-strong: #8c5e0f;
-  --volt-dim:    #e2c987;
-  --volt-ink:    #ffffff;
-  --volt-glow:   rgba(176,125,26,0.16);
-  --volt-wash:   rgba(176,125,26,0.10);
-  --volt-rgb:    176 125 26;
+  --volt:        var(--brass);
+  --volt-strong: var(--brass-line);
+  --volt-dim:    var(--brass-fill);
+  --volt-ink:    var(--paper);
+  --volt-glow:   rgba(140, 106, 30, 0.16);
+  --volt-wash:   rgba(140, 106, 30, 0.12);
+  --volt-rgb:    140 106 30;
   --accent-glow: var(--volt-glow);
 }
 html[data-skin="v2"][data-theme="paper"][data-volt="blood"] {
-  --volt: #b42318; --volt-strong: #8f1b12; --volt-dim: #f0b4ad;
-  --volt-ink: #ffffff; --volt-glow: rgba(180,35,24,0.16); --volt-wash: rgba(180,35,24,0.09);
-  --volt-rgb: 180 35 24;
+  --volt: var(--brick); --volt-strong: var(--brick-line); --volt-dim: var(--brick-fill);
+  --volt-ink: var(--paper); --volt-glow: rgba(139, 58, 58, 0.16); --volt-wash: rgba(139, 58, 58, 0.12);
+  --volt-rgb: 139 58 58;
 }
 html[data-skin="v2"][data-theme="paper"][data-volt="ice"] {
-  --volt: #1e6fa8; --volt-strong: #155888; --volt-dim: #a8d4ea;
-  --volt-ink: #ffffff; --volt-glow: rgba(30,111,168,0.16); --volt-wash: rgba(30,111,168,0.09);
-  --volt-rgb: 30 111 168;
-  --info: #7a4fd0; --info-dim: #5a37a0;
+  --volt: var(--teal); --volt-strong: var(--teal-line); --volt-dim: var(--teal-fill);
+  --volt-ink: var(--paper); --volt-glow: rgba(35, 104, 116, 0.16); --volt-wash: rgba(35, 104, 116, 0.12);
+  --volt-rgb: 35 104 116;
+  --info: var(--plum); --info-dim: var(--plum-line);
 }
 
 /* ══════════════════════════════════════════════════════════════
@@ -378,4 +378,3 @@ html[data-skin="v2"][data-theme="paper"] {
   /* Fonts */
   --font-sans: var(--font-ui);
 }
-


### PR DESCRIPTION
## Summary

- Show dashboard chat tool trace steps by default and prevent opened trace cards from shrinking inside the chat flex column.
- Bridge PAPER theme tokens into the StyleSeed/v2 shell so paper mode recolors migrated surfaces instead of falling back to gray/default tokens.
- Split operator, Keeper, and tool chat colors into separate semantic variables and add regression tests for tool label search and paper token wiring.

## Root Cause

Tool trace rows were present in the DOM but could be clipped because the trace card participated as a shrinkable flex item in the transcript column. PAPER also lost color intent through selector specificity and token aliasing: later `:root`/v2 defaults could override paper values, and the legacy `--slate` alias collided with paper's accent slate.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/components/chat/primitives.test.ts src/components/keeper-shared.test.ts src/styles/chat-blocks-v2.test.ts src/styles/paper-theme.test.ts src/styles/skin-v2-paper.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/styles/chat-blocks-v2.test.ts src/styles/paper-theme.test.ts src/styles/skin-v2-paper.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- Playwright fallback against `http://127.0.0.1:5190/dashboard/?theme=paper#monitoring?section=agents&view=keepers&keeper=sangsu`: verified `data-theme="paper"`, paper computed tokens, visible tool trace steps, and collapse/expand behavior.

## Known Existing Blocker

- `pnpm run lint` still fails on pre-existing `dashboard/src/keeper-actions.ts:368` (`no-nested-ternary`), outside this PR's changed files.