### PR TITLE
feat(fusion): RFC-0266 Phase 2 — in-memory fusion run registry

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -231,6 +231,9 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judge_usage :
          | Ok j -> true, j.Fusion_types.resolved_answer
          | Error e -> false, Printf.sprintf "judge failed: %s" e
        in
+       (* RFC-0266 §7: registry를 Completed로 갱신(가시성). wake와 무관하게 run
+          상태를 반영해야 하므로 wake 직전 무조건 호출. *)
+       Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok;
        wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok ~resolved_answer
          ~board_post_id:(Board.Post_id.to_string post.id);
        Ok ()

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -35,6 +35,9 @@ let append_chat_failure ~base_dir ~keeper ~run_id content =
   (* RFC-0266: 실패도 호출 키퍼를 ok=false로 깨워 "결과 안 옴" 폴링 대신 능동 통지한다
      (성공 경로의 fusion_sink.emit wake와 대칭). content가 실패 사유 라벨이 된다.
      wake는 자체 예외 안전하므로 chat append 실패와 독립적으로 시도된다. *)
+  (* RFC-0266 §7: registry를 Completed{ok=false}로 갱신(가시성). wake와 무관하게
+     run 상태를 반영해야 하므로 별도 호출(Running 키퍼만 깨우는 wake와 달리 무조건). *)
+  Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok:false;
   Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:false
     ~resolved_answer:content ~board_post_id:""
 
@@ -63,6 +66,11 @@ let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ~args : string =
         ; ("reason", `String (Fusion_types.deny_reason_label reason))
         ]
     | Fusion_types.Allow allowed ->
+      (* RFC-0266 §7: 진행중 가시성을 위해 fork 직전 run을 Running으로 등록한다
+         (sink/실패 경로가 Completed로 갱신). 등록은 부수효과 없는 in-memory 기록일
+         뿐, 키퍼를 깨우지 않는다(wake는 별개). *)
+      Fusion_run_registry.register_running Fusion_run_registry.global ~run_id ~keeper
+        ~preset ~started_at:now_unix;
       (* out-of-band: fiber fork → 키퍼 턴은 즉시 진행, 결과는 sink가 chat lane에.
          예산은 orchestrator가 원자적으로 소비한다. 배경 fiber 실패/거부/싱크
          실패는 동일한 chat lane에 기록해 started-but-failed 상태가 남지 않도록 한다.

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -1,0 +1,89 @@
+(* Fusion — in-memory run registry for in-progress + recent fusion visibility
+   (RFC-0266 §7 Phase 2). The fusion tool registers a run [Running] at fork
+   start and the sink/failure path marks it [Completed] on finish, so an
+   operator surface (masc_fusion_status tool = Phase 3, dashboard = Phase 4) can
+   show what is deliberating now and what just finished — instead of run_id only
+   living in the caller's tool-result.
+
+   Lock-free Atomic + CAS, mirroring Fusion_budget; no extra deps. Server-
+   lifetime: a fork that dies on server shutdown takes its registry entry with
+   it, so no orphan [Running] survives a restart (RFC-0266 §10 #4).
+
+   This module never wakes a keeper (that is the WAKE half, Phase 1). Recording
+   a run is the visibility half and is intentionally side-effect-free beyond the
+   in-memory table. *)
+
+type run_status =
+  | Running
+  | Completed of { ok : bool }
+
+type run = {
+  run_id : string;
+  keeper : string;
+  preset : string;
+  started_at : float;  (* unix seconds from the keeper clock at fork start *)
+  status : run_status;
+}
+
+type t = run list Atomic.t
+
+(* Recent-history retention for [Completed] runs. [Running] runs are never
+   evicted (active state must stay accurate) and are bounded in practice by the
+   per-hour fusion budget (RFC-0252 §10). This is a log-retention bound, not a
+   symptom cap — it stops the table from growing without limit over a long
+   server lifetime. *)
+let max_completed_retained = 64
+
+let create () : t = Atomic.make []
+
+let is_running (r : run) =
+  match r.status with
+  | Running -> true
+  | Completed _ -> false
+;;
+
+(* Keep every [Running] run plus the [max_completed_retained] most recent
+   [Completed] runs (newest [started_at] first). *)
+let prune (runs : run list) : run list =
+  let running, completed = List.partition is_running runs in
+  let recent_completed =
+    completed
+    |> List.sort (fun a b -> Float.compare b.started_at a.started_at)
+    |> List.filteri (fun i _ -> i < max_completed_retained)
+  in
+  running @ recent_completed
+;;
+
+let rec update (t : t) (f : run list -> run list) =
+  let cur = Atomic.get t in
+  let next = f cur in
+  if not (Atomic.compare_and_set t cur next) then update t f
+;;
+
+let register_running (t : t) ~run_id ~keeper ~preset ~started_at =
+  update t (fun runs ->
+    let run = { run_id; keeper; preset; started_at; status = Running } in
+    (* defensive: a re-registered run_id replaces its prior entry *)
+    let without_dup = List.filter (fun r -> not (String.equal r.run_id run_id)) runs in
+    prune (run :: without_dup))
+;;
+
+let mark_completed (t : t) ~run_id ~ok =
+  update t (fun runs ->
+    runs
+    |> List.map (fun r ->
+         if String.equal r.run_id run_id then { r with status = Completed { ok } } else r)
+    |> prune)
+;;
+
+let list_runs (t : t) : run list =
+  Atomic.get t |> List.sort (fun a b -> Float.compare b.started_at a.started_at)
+;;
+
+let get (t : t) ~run_id : run option =
+  List.find_opt (fun r -> String.equal r.run_id run_id) (Atomic.get t)
+;;
+
+(* Process-wide registry the fusion tool/sink write to (server-lifetime). Tests
+   use a fresh [create ()] for state isolation, avoiding a reset backdoor. *)
+let global : t = create ()

--- a/lib/fusion_core/fusion_run_registry.mli
+++ b/lib/fusion_core/fusion_run_registry.mli
@@ -1,0 +1,44 @@
+(** Fusion — in-memory run registry for in-progress + recent fusion visibility
+    (RFC-0266 §7 Phase 2).
+
+    The fusion tool calls {!register_running} at fork start and the sink/failure
+    path calls {!mark_completed} on finish, so a status surface (Phase 3 tool,
+    Phase 4 dashboard) can report what is deliberating now and what just
+    finished. Lock-free Atomic + CAS (mirrors {!Fusion_budget}); server-lifetime
+    in-memory (no orphan [Running] survives a restart). Never wakes a keeper. *)
+
+type run_status =
+  | Running
+  | Completed of { ok : bool }
+
+type run = {
+  run_id : string;
+  keeper : string;
+  preset : string;
+  started_at : float;  (** unix seconds from the keeper clock at fork start *)
+  status : run_status;
+}
+
+type t
+
+val create : unit -> t
+(** A fresh, isolated registry. Production uses {!global}; tests use [create ()]
+    so each case starts empty (no shared-state reset backdoor). *)
+
+val register_running :
+  t -> run_id:string -> keeper:string -> preset:string -> started_at:float -> unit
+(** Record a run as [Running]. A repeated [run_id] replaces its prior entry. *)
+
+val mark_completed : t -> run_id:string -> ok:bool -> unit
+(** Transition a run to [Completed]. No-op if [run_id] is unknown. [ok] is the
+    judge/sink outcome (false for denied/sink_failed/aborted). *)
+
+val list_runs : t -> run list
+(** All tracked runs, newest [started_at] first ([Running] + recently
+    [Completed]; older completed runs are pruned). *)
+
+val get : t -> run_id:string -> run option
+(** The run with [run_id], if still tracked. *)
+
+val global : t
+(** Process-wide registry the fusion tool/sink write to (server-lifetime). *)

--- a/test/fusion_core/dune
+++ b/test/fusion_core/dune
@@ -3,5 +3,5 @@
 ; main masc library — runs in seconds.
 
 (tests
- (names test_fusion test_fusion_harness)
+ (names test_fusion test_fusion_harness test_fusion_run_registry)
  (libraries alcotest otoml masc.fusion_core))

--- a/test/fusion_core/test_fusion_run_registry.ml
+++ b/test/fusion_core/test_fusion_run_registry.ml
@@ -1,0 +1,91 @@
+(* RFC-0266 Phase 2 — fusion run registry (in-progress + recent visibility).
+   Pure in-memory state; tested on isolated [create ()] instances. *)
+
+open Alcotest
+module R = Fusion_run_registry
+
+let status_running = function
+  | R.Running -> true
+  | R.Completed _ -> false
+;;
+
+let status_completed_ok = function
+  | R.Completed { ok } -> Some ok
+  | R.Running -> None
+;;
+
+let test_register_then_query () =
+  let t = R.create () in
+  R.register_running t ~run_id:"r1" ~keeper:"k" ~preset:"balanced" ~started_at:10.0;
+  (match R.get t ~run_id:"r1" with
+   | Some run ->
+     check string "keeper" "k" run.R.keeper;
+     check string "preset" "balanced" run.R.preset;
+     check bool "is running" true (status_running run.R.status)
+   | None -> fail "registered run must be retrievable");
+  check int "one run tracked" 1 (List.length (R.list_runs t))
+;;
+
+let test_mark_completed () =
+  let t = R.create () in
+  R.register_running t ~run_id:"r1" ~keeper:"k" ~preset:"deep" ~started_at:1.0;
+  R.mark_completed t ~run_id:"r1" ~ok:true;
+  (match R.get t ~run_id:"r1" with
+   | Some run -> check (option bool) "completed ok=true" (Some true) (status_completed_ok run.R.status)
+   | None -> fail "run should still be tracked after completion");
+  (* a failed completion records ok=false, not a drop *)
+  R.register_running t ~run_id:"r2" ~keeper:"k" ~preset:"deep" ~started_at:2.0;
+  R.mark_completed t ~run_id:"r2" ~ok:false;
+  match R.get t ~run_id:"r2" with
+  | Some run -> check (option bool) "completed ok=false" (Some false) (status_completed_ok run.R.status)
+  | None -> fail "failed run must remain visible as Completed{ok=false}"
+;;
+
+let test_mark_unknown_is_noop () =
+  let t = R.create () in
+  R.mark_completed t ~run_id:"ghost" ~ok:true;
+  check int "unknown run_id does not create an entry" 0 (List.length (R.list_runs t))
+;;
+
+let test_list_newest_first () =
+  let t = R.create () in
+  R.register_running t ~run_id:"old" ~keeper:"k" ~preset:"p" ~started_at:1.0;
+  R.register_running t ~run_id:"new" ~keeper:"k" ~preset:"p" ~started_at:9.0;
+  match R.list_runs t with
+  | first :: _ -> check string "newest started_at first" "new" first.R.run_id
+  | [] -> fail "expected runs"
+;;
+
+(* prune invariant: Running survives a flood of completed; oldest completed are
+   evicted while the newest are kept (newest-first retention). *)
+let test_prune_keeps_running_and_recent () =
+  let t = R.create () in
+  R.register_running t ~run_id:"active" ~keeper:"k" ~preset:"p" ~started_at:1000.0;
+  for i = 0 to 99 do
+    let id = Printf.sprintf "c%d" i in
+    R.register_running t ~run_id:id ~keeper:"k" ~preset:"p" ~started_at:(float_of_int i);
+    R.mark_completed t ~run_id:id ~ok:true
+  done;
+  (* the Running run is never evicted *)
+  (match R.get t ~run_id:"active" with
+   | Some run -> check bool "Running survived the flood" true (status_running run.R.status)
+   | None -> fail "Running run must never be pruned");
+  (* the most recent completed is retained, the oldest is evicted *)
+  check bool "newest completed retained" true (Option.is_some (R.get t ~run_id:"c99"));
+  check bool "oldest completed evicted" true (Option.is_none (R.get t ~run_id:"c0"));
+  (* total is bounded (retention cap + the one Running) *)
+  check bool "registry is bounded under flood" true (List.length (R.list_runs t) <= 65)
+;;
+
+let () =
+  run
+    "fusion_run_registry"
+    [ ( "rfc-0266-phase2"
+      , [ test_case "register then query" `Quick test_register_then_query
+        ; test_case "mark completed (ok true/false)" `Quick test_mark_completed
+        ; test_case "mark unknown run_id is a no-op" `Quick test_mark_unknown_is_noop
+        ; test_case "list_runs is newest-first" `Quick test_list_newest_first
+        ; test_case "prune keeps Running + recent completed" `Quick test_prune_keeps_running_and_recent
+        ] )
+    ]
+;;


### PR DESCRIPTION
## RFC-0266 Phase 2 — in-memory fusion run registry (VISIBILITY 기반)

RFC: docs/rfc/RFC-0266-fusion-async-completion-wake-and-visibility.md §7 (#21655)
Follows: #21677 (Phase 1 WAKE, **MERGED**). Phase 1이 squash-merge된 후 본 브랜치를 origin/main으로 rebase했으므로 base는 `main`이다(stacked 아님). main의 Phase 1 wake 코드 위에 registry 갱신을 얹는다.

### 문제 / 목적

Phase 1(WAKE)은 fusion 완료가 호출 키퍼를 깨우게 했지만, **진행중인 fusion을 볼 곳이 없다**(사용자 요구: "Fusion 진행중인거 정보를 볼 수 있는 곳"). `run_id`는 호출 키퍼의 tool-result에만 있고 이후 어떤 조회 surface와도 연결되지 않는다. Phase 2는 그 데이터 소스 — 진행중/최근완료 run을 추적하는 in-memory registry — 를 만든다.

### 변경

- **`lib/fusion_core/fusion_run_registry.{ml,mli}`** (신규): server-lifetime in-memory registry. `run = { run_id; keeper; preset; started_at; status }`, `status = Running | Completed of { ok }`. Lock-free Atomic + CAS (`Fusion_budget`와 동일 패턴, 추가 의존 0). instance(`t` + `create ()`) + production용 `global` 싱글톤 — 테스트는 격리된 `create ()`를 써 reset backdoor 없이 상태 격리.
- **`lib/fusion/fusion_tool.ml`**: `handle`의 Allow 경로가 fork 직전 `register_running` (Running 등록); `append_chat_failure`가 `mark_completed ~ok:false` (실패).
- **`lib/fusion/fusion_sink.ml`**: `emit` 성공 경로(board Ok)가 `mark_completed ~ok` (judge Ok→true).

completion 타입별 단일 갱신(Phase 1 wake와 동일 분기): `Completed`→emit, `Sink_failed`/`Denied`/`aborted`→append_chat_failure. wake와 달리 mark_completed는 **무조건**(paused 키퍼여도 run 상태는 반영).

### 설계 결정

- **배치**: `fusion_run_registry`는 keeper/board/OAS 의존이 없는 순수 in-memory 상태이므로 `Fusion_budget`과 같은 `lib/fusion_core/`(masc_fusion_core)에 둔다 — fast alcotest로 검증 가능, 일관성.
- **server-lifetime**: fork가 서버 종료와 함께 죽으므로 orphan `Running`이 재시작을 넘기지 않는다(RFC-0266 §10 #4).
- **소비자 없음(의도)**: list_runs/get는 Phase 3(`masc_fusion_status` 도구)·Phase 4(대시보드)가 읽는다. `.mli`로 노출된 공개 API라 dead-code 아님; 본 PR은 테스트로 채워짐을 검증(RFC §9 Phase 2 완료 기준).

### 워크어라운드 self-audit

- `max_completed_retained = 64`는 **log 보존 정책**(오래된 *완료* run을 자르는 ring-buffer 성격)이지 증상 억제 cap이 아니다. 진행중(`Running`) run은 절대 evict 안 함(정확성). 무한 메모리 증가만 막는다.
- 텔레메트리-as-fix 아님 — registry는 사용자가 요구한 가시성 *기능*. catch-all/string 분류기/N-of-M/permissive default 없음.

### 검증

- 신규 `test/fusion_core/test_fusion_run_registry.ml` 5 cases green. **mutation-proven**: prune/mark 로직을 깨면 해당 invariant 테스트가 FAIL.
- `dune build --root . lib/` + full build green.
- prune 불변식 테스트: Running은 flood에도 생존, 최신 완료 보존·최오래 완료 evict, 총량 bounded.

### 범위 밖 (후속)

Phase 3 `masc_fusion_status` 도구(registry를 키퍼/운영자에게 노출), Phase 4 대시보드 fusion-runs 패널 + SSE.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
