### PR TITLE
feat(keeper): populate Turn_ref onto persisted chat rows (RFC-0233 §7) [PR-A3]

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -115,14 +115,16 @@ let metadata_value key metadata =
   | None -> None
 
 let persist_connector_assistant_reply ~base_dir ~keeper_name ~source
-    ?conversation_id ~reply () =
+    ?conversation_id ?turn_ref ~reply () =
   let content = String.trim reply in
   if content <> "" then begin
     (* RFC-0232 P5: the gate recorder knows the connector label only;
        coordinates ride [conversation_id] as before. *)
     let surface = Surface_ref.Gate { label = source; address = [] } in
+    (* RFC-0233 §7: [turn_ref] is the join key the keeper minted into the
+       reply payload, carried onto this connector turn's assistant row. *)
     Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name
-      ~content ~surface ?conversation_id ();
+      ~content ~surface ?conversation_id ?turn_ref ();
     Keeper_chat_broadcast.chat_appended ~keeper_name ~source ~content ()
   end
 
@@ -234,9 +236,17 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
         | Some s -> Some { s with duration_ms }
         | None -> Some { Gate_protocol.model_used = "runtime"; duration_ms; tokens_used = 0 }
       in
+      (* RFC-0233 §7: pull the turn's join key out of the same reply payload
+         (parse, don't repair) so the connector assistant row joins to its
+         Turn_record. *)
+      let turn_ref =
+        Keeper_turn_outcome.turn_ref_of_reply_payload
+          (try Some (Yojson.Safe.from_string body)
+           with Yojson.Json_error _ -> None)
+      in
       persist_connector_assistant_reply
         ~base_dir:config.Workspace.base_path ~keeper_name ~source:lane
-        ?conversation_id ~reply ();
+        ?conversation_id ?turn_ref ~reply ();
       Gate_protocol.Reply { content = reply; structured; stats }
   | Some result ->
       Gate_protocol.Keeper_error_result (redact_text (Tool_result.message result))

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -54,11 +54,14 @@ val persist_connector_assistant_reply :
   keeper_name:string ->
   source:string ->
   ?conversation_id:string ->
+  ?turn_ref:Ids.Turn_ref.t ->
   reply:string ->
   unit ->
   unit
 (** Persist a completed connector direct reply on the same chat lane that
-    received the inbound user line. Empty replies are ignored. *)
+    received the inbound user line. Empty replies are ignored.
+    [turn_ref] (RFC-0233 §7) is the join key the keeper minted into the
+    reply payload, stamped on the assistant row. *)
 
 val filesystem_safe_or_unknown : string -> string
 (** Sanitize a value for use as a filesystem path component.

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -579,6 +579,14 @@ let direct_reply_visible_text body =
 let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args result =
   if get_bool args "direct_reply" false && tool_result_success result then (
     let user_content = get_string args "message" "" |> String.trim in
+    (* RFC-0233 §7: the join key the keeper minted into the reply payload,
+       threaded onto the persisted row of this agent-initiated / connector
+       turn (parse, don't repair — absent/malformed reads as None). *)
+    let turn_ref =
+      Keeper_turn_outcome.turn_ref_of_reply_payload
+        (try Some (Yojson.Safe.from_string (tool_result_body result))
+         with Yojson.Json_error _ -> None)
+    in
     match user_content, direct_reply_visible_text (tool_result_body result) with
     | "", _ | _, None -> ()
     | _, Some assistant_content ->
@@ -601,6 +609,7 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
             ~user_attachments:[]
             ~surface:Surface_ref.Agent
             ~assistant_content
+            ?turn_ref
             ();
           Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source:"agent"
             ~content:assistant_content
@@ -612,6 +621,7 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
             ~keeper_name:name
             ~content:assistant_content
             ~surface:(Surface_ref.Gate { label = channel; address = [] })
+            ?turn_ref
             ();
           Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source:channel
             ~content:assistant_content

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -441,6 +441,19 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
       let turn_task_id = Printf.sprintf "keeper_turn_%s_%d"
         name (int_of_float (Time_compat.now () *. 1000.0)) in
       let keeper_turn_id = meta0.runtime.usage.total_turns + 1 in
+      (* RFC-0233 §7: mint the turn's join key ONCE from the pre-turn meta0 —
+         the same (trace_id, total_turns + 1) snapshot the Turn_record writer
+         stamps (keeper_agent_run.ml:250-251 receives this very meta via the
+         run_turn call below). Threaded into reply_json; never re-derived at
+         the reply seam from updated_meta, whose trace_id is post-lifecycle and
+         is rotated on handoff turns (keeper_rollover) — re-derivation would
+         yield a different join key than the Turn_record for the same turn
+         (RFC §7.2 mint-once, thread down). *)
+      let turn_ref =
+        Ids.Turn_ref.make
+          ~trace_id:(Keeper_id.Trace_id.to_string meta0.runtime.trace_id)
+          ~absolute_turn:keeper_turn_id
+      in
       let turn_tracker = Progress.start_tracking ~task_id:turn_task_id ~total_steps:5 () in
       Progress.Tracker.step turn_tracker ~message:"Preparing keeper turn configuration" ();
       let meta = meta0 in
@@ -960,6 +973,11 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
                     ("cache_read_input_tokens", `Int u.cache_read_input_tokens);
                     ("cost_usd", cost_field);
                   ]);
+                  (* RFC-0233 §7: the turn's join key, minted once from the
+                     pre-turn snapshot above. The server persists it on the
+                     chat row via append_turn ?turn_ref. *)
+                  ( Keeper_turn_outcome.turn_ref_wire_key,
+                    Ids.Turn_ref.to_yojson turn_ref );
                 ]
               in
               tool_result_ok (Yojson.Safe.to_string reply_json)

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -24,6 +24,8 @@ let of_label = function
 
 let wire_key = "turn_outcome"
 
+let turn_ref_wire_key = "turn_ref"
+
 let of_stop_reason = function
   | Runtime_agent.Completed -> Visible_reply
   | Runtime_agent.TurnBudgetExhausted _ -> Continuation_checkpoint
@@ -48,3 +50,13 @@ let of_reply_payload payload =
                  visible_reply"
                 label;
               Visible_reply))
+
+let turn_ref_of_reply_payload payload =
+  (* RFC-0233 §7: read the turn's join key the keeper minted into the
+     reply payload.  Parse, don't repair — an absent field (legacy or
+     transport-failure rows) or a malformed value both decode to [None];
+     [Ids.Turn_ref.of_string] never raises and never guesses. *)
+  Option.bind payload (fun json ->
+      match Json_util.get_string json turn_ref_wire_key with
+      | None -> None
+      | Some s -> Ids.Turn_ref.of_string s)

--- a/lib/keeper/keeper_turn_outcome.mli
+++ b/lib/keeper/keeper_turn_outcome.mli
@@ -24,6 +24,12 @@ val wire_key : string
 (** JSON field name carrying the label in the keeper reply payload:
     ["turn_outcome"]. *)
 
+val turn_ref_wire_key : string
+(** JSON field name carrying the turn's join key in the keeper reply
+    payload: ["turn_ref"] (RFC-0233 §7).  Shared by the producer
+    ({!Keeper_turn} reply_json) and the consumer
+    ({!turn_ref_of_reply_payload}) so the wire name cannot drift. *)
+
 val of_stop_reason : Runtime_agent.stop_reason -> t
 (** [Completed] is the only stop reason whose reply text is model
     output.  [TurnBudgetExhausted] replaces the reply with the synthetic
@@ -39,3 +45,11 @@ val of_reply_payload : Yojson.Safe.t option -> t
     silently {e not} persisted — the lane watermark stalled and the
     keeper re-answered the same message — so decode failure must fail
     toward persisting, never toward dropping. *)
+
+val turn_ref_of_reply_payload : Yojson.Safe.t option -> Ids.Turn_ref.t option
+(** Decode the turn's join key ([turn_ref_wire_key]) from a parsed keeper
+    reply payload (RFC-0233 §7).  Parse, don't repair: absent payload,
+    absent field, or a malformed value all decode to [None]
+    ([Ids.Turn_ref.of_string] never raises).  The server stamps the
+    result on the persisted chat row via {!Keeper_chat_store.append_turn}
+    [?turn_ref]. *)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -797,6 +797,13 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
         match dispatch_result with
         | Ok (true, body) ->
             let payload_json_opt, visible_reply = extract_visible_reply body in
+            (* RFC-0233 §7: the keeper minted this turn's join key into the
+               reply payload (keeper_turn.ml). Decode it via the shared
+               reply-payload parser — never repair: a malformed or absent
+               value reads as None and the row simply carries no turn_ref. *)
+            let turn_ref =
+              Keeper_turn_outcome.turn_ref_of_reply_payload payload_json_opt
+            in
             (match Keeper_turn_outcome.of_reply_payload payload_json_opt with
             | Keeper_turn_outcome.Continuation_checkpoint -> ()
             | Keeper_turn_outcome.Visible_reply ->
@@ -809,6 +816,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
                 ~surface:chat_surface
                 ~speaker:chat_speaker
                 ~assistant_content:visible_reply
+                ?turn_ref
                 ();
               Keeper_chat_broadcast.chat_appended
                 ~keeper_name:payload.name ~source:chat_source

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -87,6 +87,39 @@ let test_prefix_is_dead () =
             (TO.wire_key, `String "continuation_checkpoint")
           ]))
 
+let turn_ref_t : Ids.Turn_ref.t testable =
+  testable
+    (fun fmt t -> Format.pp_print_string fmt (Ids.Turn_ref.to_string t))
+    Ids.Turn_ref.equal
+
+(* RFC-0233 §7: the consumer-side decode of the turn join key the keeper
+   minted into the reply payload.  Parse, don't repair — absent and
+   malformed both decode to None; of_string splits on the LAST '#'. *)
+let test_turn_ref_payload_decode () =
+  check (option turn_ref_t) "no payload -> None" None
+    (TO.turn_ref_of_reply_payload None);
+  check (option turn_ref_t) "field absent -> None" None
+    (TO.turn_ref_of_reply_payload (payload [ ("reply", `String "hi") ]));
+  check (option turn_ref_t) "valid join key decodes"
+    (Some
+       (Ids.Turn_ref.make ~trace_id:"trace-1780648779957-00000"
+          ~absolute_turn:4071))
+    (TO.turn_ref_of_reply_payload
+       (payload
+          [ (TO.turn_ref_wire_key, `String "trace-1780648779957-00000#4071") ]));
+  check (option turn_ref_t) "inner '#' splits on the last separator"
+    (Some (Ids.Turn_ref.make ~trace_id:"weird#trace" ~absolute_turn:12))
+    (TO.turn_ref_of_reply_payload
+       (payload [ (TO.turn_ref_wire_key, `String "weird#trace#12") ]));
+  check (option turn_ref_t) "no separator -> None (never repaired)" None
+    (TO.turn_ref_of_reply_payload
+       (payload [ (TO.turn_ref_wire_key, `String "no-separator") ]));
+  check (option turn_ref_t) "non-int suffix -> None" None
+    (TO.turn_ref_of_reply_payload
+       (payload [ (TO.turn_ref_wire_key, `String "trace#abc") ]));
+  check (option turn_ref_t) "non-string field -> None" None
+    (TO.turn_ref_of_reply_payload (payload [ (TO.turn_ref_wire_key, `Int 5) ]))
+
 let body fields = Yojson.Safe.to_string (`Assoc fields)
 
 let test_direct_reply_visible_text () =
@@ -127,6 +160,8 @@ let () =
         [
           test_case "decode policy" `Quick test_payload_decode;
           test_case "prefix is dead" `Quick test_prefix_is_dead;
+          test_case "turn_ref decode (parse, don't repair)" `Quick
+            test_turn_ref_payload_decode;
         ] );
       ( "direct_reply",
         [


### PR DESCRIPTION
## 무엇을 / 왜

RFC-0233 §7(Turn_ref 계약)의 **PR-A3 — 영속화된 chat row에 minted Turn_ref 채우기(population)**. PR-A2(#21680)가 row가 turn_ref를 *들 수 있게* 했고, 이 PR이 실제 값을 thread해 넣습니다. 이로써 chat 턴과 그 턴이 만든 board post/Turn_record가 같은 join 키를 들 수 있는 토대가 완성됩니다.

> PR-A2 #21680은 이미 MERGED(squash 42e1035940). 이 PR은 origin/main 기준으로 rebase되어 A3 변경만 담습니다(A2 커밋은 patch-id로 skip됨).

## 핵심 정확성 결정 (적대 검증 결과)

understand-phase 워크플로(4 reader 매핑 + 3 적대 lens + 합성)가 off-by-one을 검증했고, 제 원래 정수 우려보다 **더 깊은 버그**를 잡았습니다:

- **정수(absolute_turn)는 안전**: `post == pre+1 == manifest_keeper_turn_id` (턴당 +1 사이트 정확히 하나, lifecycle은 `usage.total_turns` 미변경).
- **trace_id 절반은 handoff에서 rotate됨**: Turn_record writer는 PRE-turn trace_id를 stamp(`apply_post_turn_lifecycle` 전 실행)하지만, reply seam의 `updated_meta.runtime.trace_id`는 POST-rotation(`keeper_rollover.ml:351`). handoff 턴에서 reply seam 재유도는 `NEW_trace#n+1`을, Turn_record는 `OLD_trace#n+1`을 들어 **같은 턴인데 join 키 불일치**.

→ RFC §7.2 **mint-once**: producer가 **pre-turn meta0**(writer와 동일 snapshot)에서 Turn_ref를 한 번 mint하고 thread. `updated_meta`에서 절대 재유도하지 않음. (verified: `keeper_turn.ml:727`의 `run_turn ~meta`가 writer의 `keeper_agent_run.ml:250-251`에 동일 meta를 전달 → byte-identical.)

## 변경

**Producer** (`keeper_turn.ml`): pre-turn meta0에서 turn_ref mint(주석으로 updated_meta 금지 근거 명시) → reply_json에 shared wire key로 emit.

**Shared parser** (`keeper_turn_outcome.ml`): `turn_ref_wire_key` + `turn_ref_of_reply_payload` (parse, don't repair: absent/malformed → None, never raises). producer와 3 consumer가 wire 이름·디코더 하나를 공유 → 문자열 drift 차단.

**Consumers — reply_json→turn-persist 3경로 전부** (N-of-M 마이그레이션 회피):
- `server_routes_http_keeper_stream.ml` — HTTP streaming 턴
- `keeper_tool_surface_ops.ml` — agent-initiated in-process 턴 (agent + connector 두 분기)
- `gate_keeper_backend.ml` — connector gate dispatch

**의도적으로 None 유지** (완료-턴 reply 아님): transport-failure append, keeper-initiated surface post(voice/surface_post/fusion). SSE display 경로는 이미 `KEEPER_REPLY_DETAILS`로 reply payload 전체(turn_ref 포함)를 전달.

## 검증

- `dune build --root . lib/` green (모든 threading compile, `Ids`/`Json_util`/`Keeper_turn_outcome` 접근성 확인)
- 신규 단위 테스트 `[OK]`: `turn_ref decode (parse, don't repair)` — absent/malformed/valid/inner-'#'/non-int/non-string 7케이스. consumer 파서를 PR-A2 store 라운드트립과 합쳐 end-to-end 파싱·영속화를 커버.
- **미검증(follow-up)**: handoff join-key parity end-to-end 통합 테스트는 turn-driving 하네스가 필요해 별도. pre-turn-meta0 mint 불변식은 producer 주석으로 가드(향후 `updated_meta`로 옮기면 안 됨을 명시).
- 전체 빌드/테스트는 CI (사용자 지시).

## Workaround Guards (RFC-0233 §7 준수)

- typed `Ids.Turn_ref` + shared wire key (string smuggle/drift 아님)
- parse, don't repair (malformed→None, telemetry-as-fix 아님)
- 3 persist 경로 전부 thread (N-of-M 아님). 직접 ground-truth로 워크플로 합성이 놓친 surface_ops·gate 경로 포착.

Refs: RFC-0233 §7. Follows PR-A2 #21680 (MERGED).
