### PR TITLE
fix(issue-21650): re-raise Eio.Cancel.Cancelled after recording status

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -445,7 +445,9 @@ let submit ?clock ?timeout_sec ~sw ~base_path ~(f : unit -> tool_result)
                  timeout_done_status ~request_id ~keeper_name ~timeout_sec))
       with
       | CancelledByOperator -> operator_cancelled_status ()
-      | Eio.Cancel.Cancelled _ as e -> runtime_cancelled_status (); raise e
+      | Eio.Cancel.Cancelled _ as e ->
+        set_status_protected ~preserve_terminal:true request_id (runtime_cancelled_status ());
+        raise e
       | exn ->
         Done
           { ok = false

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -445,7 +445,7 @@ let submit ?clock ?timeout_sec ~sw ~base_path ~(f : unit -> tool_result)
                  timeout_done_status ~request_id ~keeper_name ~timeout_sec))
       with
       | CancelledByOperator -> operator_cancelled_status ()
-      | Eio.Cancel.Cancelled _ -> runtime_cancelled_status ()
+      | Eio.Cancel.Cancelled _ as e -> runtime_cancelled_status (); raise e
       | exn ->
         Done
           { ok = false


### PR DESCRIPTION
## Summary

Fixes #21650

`keeper_msg_async.ml:448` was absorbing `Eio.Cancel.Cancelled` without re-raising. All other Cancelled handlers in this file (lines 220, 259, 293, 510) use `as e -> ...; raise e`.

## Change

```ocaml
- | Eio.Cancel.Cancelled _ -> runtime_cancelled_status ()
+ | Eio.Cancel.Cancelled _ as e -> runtime_cancelled_status (); raise e
```