### PR TITLE
fix(dashboard): 키퍼 채팅 응답 대기중 중복 표시(SPA remount) 수정

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -46,6 +46,7 @@ vi.mock('./api/keeper', () => ({
 vi.mock('./store', () => ({ invalidateDashboardCache, refreshDashboard }))
 
 import {
+  _resetLiveSendRequestOwnersForTests,
   activeKeeperName,
   keeperActionErrors,
   keeperHydrating,
@@ -183,6 +184,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     keeperThreads.value = {}
     keeperActionErrors.value = {}
     _clearPendingKeeperChatRequestsForTests()
+    _resetLiveSendRequestOwnersForTests()
     streamKeeperMessage.mockReset()
     fetchKeeperChatHistory.mockReset()
     fetchQueuedKeeperMessageResult.mockReset()
@@ -208,6 +210,52 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       return { terminal }
     }
   }
+
+  it('does not duplicate the pending assistant when a live send is still streaming and the panel remounts', async () => {
+    // A send whose SSE stream stays open (reply pending). The mock fires the
+    // queue-request event synchronously, then returns a promise we resolve
+    // only at cleanup, so the send is still in-flight during the "remount".
+    let resolveStream: (outcome: { terminal: boolean }) => void = () => {}
+    streamKeeperMessage.mockImplementation(async (
+      _name: string,
+      _message: string,
+      opts: { onEvent: (event: KeeperChatStreamEvent) => void },
+    ) => {
+      opts.onEvent({
+        type: 'CUSTOM',
+        name: 'KEEPER_QUEUE_REQUEST',
+        value: { request_id: 'kmsg_echo_1', status: 'queued' },
+      })
+      return new Promise<{ terminal: boolean }>(resolve => {
+        resolveStream = resolve
+      })
+    })
+
+    // Start the send without awaiting — the stream stays live.
+    const sendPromise = sendKeeperThreadMessage('echo', '진행 상황?')
+    await Promise.resolve()
+
+    // Preconditions: one optimistic assistant entry + the request persisted.
+    const before = (keeperThreads.value.echo ?? []).filter(e => e.role === 'assistant')
+    expect(before).toHaveLength(1)
+    expect(before[0]?.id).toMatch(/^reply-\d+-\d+$/)
+    expect(before[0]?.delivery).toBe('queued')
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toHaveLength(1)
+
+    // SPA remount: the mount effect re-runs resume while the send is live.
+    await resumePendingKeeperChatRequests('echo')
+
+    // Fix: no second handler — exactly one assistant entry, no pending-* twin,
+    // and resume started no competing poll loop for the owned request.
+    const after = (keeperThreads.value.echo ?? []).filter(e => e.role === 'assistant')
+    expect(after).toHaveLength(1)
+    expect(after.some(e => e.id === 'pending-assistant-kmsg_echo_1')).toBe(false)
+    expect(fetchQueuedKeeperMessageResult).not.toHaveBeenCalled()
+
+    // Cleanup: end the stream terminally so the send settles.
+    resolveStream({ terminal: true })
+    await sendPromise
+  })
 
   it('marks the reply interrupted when the stream ends without a terminal event', async () => {
     streamKeeperMessage.mockImplementation(emitting([

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -43,6 +43,9 @@ import {
   normalizeKeeperRecoverResult,
   normalizeStatusDetail,
   removeThreadEntries,
+  claimLiveSendRequest,
+  liveSendOwnsRequest,
+  releaseLiveSendRequest,
   setActiveStream,
   setRecordValue,
   setStatusDetail,
@@ -334,6 +337,11 @@ const resumingKeeperChatRequests = new Set<string>()
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
 
 async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest): Promise<void> {
+  // A live in-session send stream still owns this request (e.g. the panel
+  // remounted on an SPA route change while the reply was pending). Defer to
+  // it rather than minting a duplicate pending entry + a second poll loop.
+  // After a full page reload this map is empty, so cold-start resume runs.
+  if (liveSendOwnsRequest(request.requestId)) return
   const key = `${request.keeperName}:${request.requestId}`
   if (resumingKeeperChatRequests.has(key)) return
   resumingKeeperChatRequests.add(key)
@@ -605,6 +613,9 @@ export async function sendKeeperThreadMessage(
         if (event.type === 'CUSTOM' && event.name === 'KEEPER_QUEUE_REQUEST' && isRecord(event.value)) {
           requestId = asString(event.value.request_id, '').trim() || requestId
           if (requestId) {
+            // This live send now owns the request; resume must defer to it
+            // (and not mint a duplicate pending entry) until handoff/finally.
+            claimLiveSendRequest(requestId, keeperName)
             upsertPendingKeeperChatRequest({
               requestId,
               keeperName,
@@ -633,6 +644,9 @@ export async function sendKeeperThreadMessage(
     if (!outcome.terminal) {
       if (requestId) {
         removeThreadEntries(keeperName, [localId, assistantId])
+        // Hand off to resume: release ownership FIRST so our own resume
+        // call below is not blocked by the guard we just set.
+        releaseLiveSendRequest(requestId)
         await resumePendingKeeperChatRequest({
           requestId,
           keeperName,
@@ -729,6 +743,10 @@ export async function sendKeeperThreadMessage(
     setRecordValue(keeperActionErrors, keeperName, errorMessage)
     throw err
   } finally {
+    // Release ownership on every exit (success/abort/error). Idempotent:
+    // the non-terminal handoff above already released, so this is a no-op
+    // there; Map.delete of an absent key is harmless.
+    if (requestId) releaseLiveSendRequest(requestId)
     clearActiveStream(keeperName)
     setRecordValue(keeperSending, keeperName, false)
     setRecordValue(keeperStreamStartedAt, keeperName, null)

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -45,6 +45,12 @@ export const THREAD_ENTRY_CAP = 200
 
 const keeperStreamControllers = new Map<string, AbortController>()
 const keeperStreamEntryIds = new Map<string, string>()
+// requestId -> keeperName: which queued requests a live in-session send
+// stream currently owns. Resume defers to this so an SPA remount does not
+// spin up a second handler/entry for a request the live send already drives.
+// Module state, so it survives unmount/remount exactly like the controller
+// maps above; a full page reload resets it, leaving cold-start resume intact.
+const liveSendRequestOwners = new Map<string, string>()
 
 // --- Helpers ---
 
@@ -1043,4 +1049,22 @@ export function activeStreamEntryId(name: string): string | null {
 
 export function getStreamController(name: string): AbortController | undefined {
   return keeperStreamControllers.get(name)
+}
+
+// --- Live send ownership (in-session, requestId-keyed) ---
+
+export function claimLiveSendRequest(requestId: string, name: string): void {
+  liveSendRequestOwners.set(requestId, name)
+}
+
+export function releaseLiveSendRequest(requestId: string): void {
+  liveSendRequestOwners.delete(requestId)
+}
+
+export function liveSendOwnsRequest(requestId: string): boolean {
+  return liveSendRequestOwners.has(requestId)
+}
+
+export function _resetLiveSendRequestOwnersForTests(): void {
+  liveSendRequestOwners.clear()
 }


### PR DESCRIPTION
## 무엇을

키퍼 채팅에서 **응답 대기 중 다른 화면으로 갔다가 돌아오면 "응답 대기중" 표시가 하나 더 생기는 문제**를 근본 수정합니다.

## 근본 원인 (한 요청에 두 핸들러)

| 단계 | 동작 |
|---|---|
| 1 | 메시지 전송 → send 경로가 낙관적 assistant 엔트리 `reply-N-ts`("응답 대기중" #1) 생성, `KEEPER_QUEUE_REQUEST` 수신 시 `requestId`를 localStorage에 영속 |
| 2 | 키퍼 패널 mount effect(`keeper-shared.ts:457`, deps `[keeperName]`)에 **언마운트 cleanup이 없음** → SPA 라우트 이동이 라이브 SSE 스트림을 abort하지 않음. `keeperSending`은 true, `reply-N-ts`는 active 유지 |
| 3 | 복귀(remount) → effect가 `resumePendingKeeperChatRequests` 재실행. `resumingKeeperChatRequests` guard는 막지 못함(라이브 send는 `streamKeeperMessage` 안, resume 밖). `ensurePendingThreadEntries`는 `pending-assistant-${requestId}` id로만 dedup → `reply-N-ts`와 달라 **두 번째 active 엔트리**("응답 대기중" #2) + 같은 요청에 polling 루프 추가 |

resume 시스템은 **풀 페이지 리로드**(메모리 소거) 생존용입니다. SPA 라우트 이동은 메모리가 살아남는 케이스인데, "라이브 send가 이미 이 요청을 들고 있다"를 cold-start와 구분할 **in-session 소유권 신호가 없었습니다**.

## 변경 (소유권 모델 추가)

- **`keeper-state.ts`**: `requestId -> keeperName` 모듈 레지스트리 `liveSendRequestOwners` + `claim/release/owns` 헬퍼. 컨트롤러 맵처럼 remount를 살아남고, 풀 리로드 시 리셋(cold-start resume 보존).
- **`keeper-actions.ts`**:
  - send 경로가 `KEEPER_QUEUE_REQUEST`에서 `claimLiveSendRequest(requestId, keeperName)`.
  - `finally`에서 release(성공/abort/error 전부). non-terminal **handoff 직전에도** release(자기 resume가 자기 guard에 막히지 않도록 — 검증이 짚은 핵심 race-hole).
  - `resumePendingKeeperChatRequest`: 라이브 send가 소유 중이면 early-return.

## 검증

```
tsc --noEmit        # 0 errors
vitest (영향)        # keeper-actions 43 + keeper-state 43 = 86 pass
vitest (전체)        # 7227 pass (board-surface 1건은 전체 병렬 부하 flaky 타임아웃, 격리 시 50/50 통과)
bug-model           # guard 비활성화 시 새 테스트 실패(엔트리 2개), 활성화 시 통과 → 테스트가 fix를 판별
```

신규 테스트: 라이브 스트림 send 중 remount 시 active assistant 엔트리가 정확히 1개 유지 + 경쟁 polling 루프 미생성. cold-start resume 테스트(`:391`/`:515`/`:565`) 무회귀(레지스트리 empty).

## 경계 / 범위 밖

- 적대 검증(4-lens) 결과 `liveAssistantPlaceholder`·`hydrateKeeperChatHistory`는 중복 원인 아님(전자는 active 엔트리 있으면 suppress, 후자는 delivery 'history'/'error'라 active 아님) — 둘 다 미변경.
- pre-existing eslint 위반(`keeper-actions.ts:376` no-nested-ternary)은 origin/main에 byte-identical로 존재. 이 버그와 무관하고 surgical scope라 미수정.

### 워크어라운드 self-check (CLAUDE.md 시그니처 3종 + 체크리스트 7항)
해당 없음. 텔레메트리-as-fix/string분류기/N-of-M/cap·cooldown·dedup·repair 아님 — 누락된 *in-session 소유권* 개념을 추가하는 root fix(Bar가 backpressure를 root로 지목하는 계열). counter/로그 추가 없음, silent failure 가시화가 아니라 중복 핸들러 자체를 제거.

RFC-WAIVED: dashboard 채팅 state/lifecycle 수정. credential/identity/operator/sandbox/Claude hooks/workflow 문서 subsystem 미해당.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
