### PR TITLE
test(specs): TLA+ bug-model for RFC-0262 §9 completion-authority ownership

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-06-17T10:55:41Z (HEAD: 034279325c)
+Generated: 2026-06-20T02:08:36Z (HEAD: dcea119f1e)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -13,12 +13,12 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | Metric | Value |
 |--------|-------|
-| Total .tla files | 91 |
-| Manual specs | 91 |
+| Total .tla files | 92 |
+| Manual specs | 92 |
 | TTrace (auto-generated) | 0 |
 | Directories | 19 |
-| Total .cfg files | 188 |
-| Buggy .cfg (bug-model pair) | 96 |
+| Total .cfg files | 190 |
+| Buggy .cfg (bug-model pair) | 97 |
 
 `kind` column: **manual** = hand-authored spec; **ttrace** = TLC counterexample export (`*TTrace*` or trace marker in header). `cfg`/`buggy` columns count companion `.cfg` files. `invariants/properties` lists names per cfg label (`clean=...`, `buggy=...`). `source hash` is the tracked `.tla` blob fingerprint.
 
@@ -204,10 +204,11 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | StateProduct.tla | StateProduct | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:StoppedIsForever} buggy={inv:TypeOK, inv:BoundaryViolated} | a73732449a73 |
 | WorkspaceProduct.tla | WorkspaceProduct | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 0d1b9a859a47 |
 
-### specs/task-lifecycle (1 specs)
+### specs/task-lifecycle (2 specs)
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
+| CompletionAuthority.tla | CompletionAuthority | manual | 2 | 1 | clean={inv:TypeOK, inv:CompletionRequiresAuthority} buggy={inv:TypeOK, inv:CompletionRequiresAuthority} | fe9bfbe0fbbd |
 | TaskLifecycle.tla | TaskLifecycle | manual | 2 | 1 | clean={inv:TypeOK, inv:DoneRequiresApproval, inv:InProgressRequiresClaim} buggy={inv:TypeOK, inv:DoneRequiresApproval, inv:InProgressRequiresClaim} | 798af3813447 |
 
 ## Notes

--- a/specs/task-lifecycle/CompletionAuthority-buggy.cfg
+++ b/specs/task-lifecycle/CompletionAuthority-buggy.cfg
@@ -1,0 +1,8 @@
+\* Buggy: BugPeerCompletesAsAssignee (a non-owner completes the task while
+\* recording Assignee authority) MUST violate CompletionRequiresAuthority.
+\* If it passes under SpecBuggy, the invariant is too weak to enforce
+\* RFC-0262 axis-2 ownership and the spec is not actually checking the gate.
+SPECIFICATION SpecBuggy
+CONSTANT Agents = {a1, a2}
+INVARIANT TypeOK
+INVARIANT CompletionRequiresAuthority

--- a/specs/task-lifecycle/CompletionAuthority.cfg
+++ b/specs/task-lifecycle/CompletionAuthority.cfg
@@ -1,0 +1,7 @@
+\* Clean: CompletionRequiresAuthority must pass.
+\* Every reachable Done was produced by an authorized Complete — the owner
+\* under Assignee authority, or any actor under Operator/System.
+SPECIFICATION SpecClean
+CONSTANT Agents = {a1, a2}
+INVARIANT TypeOK
+INVARIANT CompletionRequiresAuthority

--- a/specs/task-lifecycle/CompletionAuthority.tla
+++ b/specs/task-lifecycle/CompletionAuthority.tla
@@ -1,0 +1,136 @@
+----------------------------- MODULE CompletionAuthority -----------------------------
+(* TLA+ bug-model for the RFC-0262 §9 completion-trust ownership invariant.
+
+   Formal companion of the empirical dispatch oracle in
+   test/test_completion_trust_harness.ml (Test A): a task reaches "Done"
+   only if the actor that completed it was *authorized* to.
+
+   Models the OCaml completion-authority gate:
+     - completion_authority = Assignee | Operator | System
+       (lib/types/types_core.ml:completion_authority)
+     - owner_authorized ~authority ~same_agent assignee
+       (lib/workspace/workspace_task_lifecycle.ml):
+           Assignee          -> same_agent assignee   (only the owner)
+           Operator | System -> true                  (privileged override)
+
+   The safety invariant CompletionRequiresAuthority states that a "Done"
+   task's completer was authorized under the recorded authority. The
+   Authorized predicate below is the spec image of owner_authorized:
+   under Assignee the completer must equal the assignee; under
+   Operator/System any actor is permitted (cross-agent completion is a
+   deliberate privileged path, not a violation).
+
+   Bug Model pattern (mirrors specs/task-lifecycle/TaskLifecycle.tla):
+     - Clean cfg: SpecClean + CompletionRequiresAuthority must pass —
+       every reachable Done was reached through an authorized Complete.
+     - Buggy cfg: SpecBuggy adds BugPeerCompletesAsAssignee (a non-owner
+       completes the task while recording Assignee authority) which MUST
+       violate CompletionRequiresAuthority. If it passes, the invariant
+       is too weak to enforce RFC-0262 axis-2 ownership.
+
+   OCaml <-> TLA+ mapping:
+     assignee             <-> Claimed/InProgress { assignee }
+     completer            <-> the agent_name that issued keeper_task_done
+     completion_authority <-> the typed completion_authority on the transition
+     Authorized(a,c,s)    <-> owner_authorized ~authority:a ~same_agent:(c=s) s
+*)
+
+EXTENDS Integers
+
+CONSTANTS Agents          \* finite set of agent identities, e.g. {a1, a2}
+
+Authorities == { "Assignee", "Operator", "System" }
+
+\* Sentinel for "no agent / no authority recorded yet" (state = Todo).
+NoAgent == "none"
+
+VARIABLES state, assignee, completer, completion_authority
+
+vars == << state, assignee, completer, completion_authority >>
+
+States == { "Todo", "Claimed", "Done" }
+
+\* Spec image of owner_authorized: under Assignee the completer must be the
+\* owner; Operator/System are privileged and may complete any task.
+Authorized(authority, c, owner) ==
+    authority = "Assignee" => c = owner
+
+TypeOK ==
+    /\ state \in States
+    /\ assignee \in (Agents \cup { NoAgent })
+    /\ completer \in (Agents \cup { NoAgent })
+    /\ completion_authority \in (Authorities \cup { NoAgent })
+
+\* ── Init ────────────────────────────────────
+
+Init ==
+    /\ state = "Todo"
+    /\ assignee = NoAgent
+    /\ completer = NoAgent
+    /\ completion_authority = NoAgent
+
+\* ── Clean transitions ───────────────────────
+
+\* Claim: Todo -> Claimed. Some agent reserves the task as its owner.
+Claim(a) ==
+    /\ state = "Todo"
+    /\ a \in Agents
+    /\ state' = "Claimed"
+    /\ assignee' = a
+    /\ UNCHANGED << completer, completion_authority >>
+
+\* Complete: Claimed -> Done, but only via an AUTHORIZED completion. This is
+\* the guard owner_authorized enforces at the FSM layer.
+Complete(c, authority) ==
+    /\ state = "Claimed"
+    /\ c \in Agents
+    /\ authority \in Authorities
+    /\ Authorized(authority, c, assignee)
+    /\ state' = "Done"
+    /\ completer' = c
+    /\ completion_authority' = authority
+    /\ UNCHANGED assignee
+
+\* Terminal state stutters so TLC can close the model.
+Terminal ==
+    /\ state = "Done"
+    /\ UNCHANGED vars
+
+NextClean ==
+    \/ \E a \in Agents : Claim(a)
+    \/ \E c \in Agents, authority \in Authorities : Complete(c, authority)
+    \/ Terminal
+
+\* ── Bug: peer completes a foreign task as Assignee ──
+\* Models the wrong_approach where a non-owner marks another agent's task
+\* done while the transition is recorded with Assignee authority (no
+\* privileged override). owner_authorized rejects this at runtime; here it
+\* is admitted on purpose so CompletionRequiresAuthority must catch it.
+
+BugPeerCompletesAsAssignee(c) ==
+    /\ state = "Claimed"
+    /\ c \in Agents
+    /\ c # assignee
+    /\ state' = "Done"
+    /\ completer' = c
+    /\ completion_authority' = "Assignee"
+    /\ UNCHANGED assignee
+
+NextBuggy ==
+    \/ NextClean
+    \/ \E c \in Agents : BugPeerCompletesAsAssignee(c)
+
+\* ── Specs ───────────────────────────────────
+
+SpecClean == Init /\ [][NextClean]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+\* ── Safety ──────────────────────────────────
+
+\* A Done task's completer was authorized under the recorded authority.
+\* Catches BugPeerCompletesAsAssignee: a non-owner completing under Assignee
+\* authority makes Authorized("Assignee", completer, assignee) false.
+CompletionRequiresAuthority ==
+    state = "Done" => Authorized(completion_authority, completer, assignee)
+
+================================================================================


### PR DESCRIPTION
## 목표

RFC-0262 §9 completion-trust 측정 하네스의 **TLA+ 축 (plan item D)**. `test/test_completion_trust_harness.ml` Test A(non-owner의 `keeper_task_done` 거부)의 **형식 증명 짝** — FSM 레벨에서 완료신뢰 ownership 불변식을 TLC로 증명한다. CLAUDE.md "TLA+ Bug Model 패턴"과 기존 `specs/task-lifecycle/TaskLifecycle.tla` 컨벤션을 그대로 따른다.

## 변경

`specs/task-lifecycle/` 신규 3파일 (기존 코드 0 변경):
- `CompletionAuthority.tla` — `owner_authorized`(workspace_task_lifecycle.ml)의 spec 이미지.
- `CompletionAuthority.cfg` (clean) / `CompletionAuthority-buggy.cfg` (buggy).

**불변식 `CompletionRequiresAuthority`**: Done 태스크의 completer는 기록된 authority 하에서 권한이 있었다.
`Authorized(authority, c, owner) == authority = "Assignee" => c = owner` — Assignee면 completer=owner 강제, Operator/System은 임의 actor 허용(권한 override, RFC-0262: 권한자는 cross-agent 완료 가능).

| cfg | spec | BugAction | 기대 |
|---|---|---|---|
| clean | SpecClean | — | 모든 도달 Done이 authorized Complete 경유 → **no error** |
| buggy | SpecBuggy | `BugPeerCompletesAsAssignee` (non-owner가 Assignee authority로 완료) | **불변식 위반** (없으면 invariant too weak) |

## 검증 (tla2tools 1.8.0 로컬)

- `CompletionAuthority.cfg` → **No error has been found** (13 distinct states, depth 3)
- `CompletionAuthority-buggy.cfg` → **Invariant CompletionRequiresAuthority violated**, counterexample: `Claim(a2)` → `BugPeerCompletesAsAssignee(a1)` (completer=a1 ≠ assignee=a2, authority=Assignee)
- Makefile `check-buggy`가 rc 12/13을 violation=OK로 인정(line 135) — 내 rc 12 통과.
- bug-model ratchet: 내 spec이 verdict-capable count를 96→97(== baseline)로 복원(ratchet는 non-gating local hygiene 도구).

## 워크어라운드 self-check

형식 검증 spec(증명 자산). 텔레메트리-as-fix·string classifier·N-of-M·cap/cooldown·catch-all 없음. 기존 코드 0 변경. clean/buggy 양쪽 통과 = 불변식이 실제로 버그를 잡음을 증명.

RFC-0262 §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
