### PR TITLE
[codex] Label copilot icon-only buttons

### DIFF
--- a/dashboard/src/components/copilot-dock.test.ts
+++ b/dashboard/src/components/copilot-dock.test.ts
@@ -181,7 +181,8 @@ describe('CopilotDock', () => {
     const textarea = container.querySelector('[data-testid="copilot-dock-textarea"]') as HTMLTextAreaElement
     fireEvent.input(textarea, { target: { value: '요약해줘' } })
 
-    const sendBtn = container.querySelector('.dock-send') as HTMLButtonElement
+    const sendBtn = container.querySelector('[aria-label="메시지 전송"]') as HTMLButtonElement
+    expect(sendBtn?.classList.contains('dock-send')).toBe(true)
     sendBtn.click()
 
     await waitFor(() => expect(container.querySelectorAll('[data-dock-message="user"]').length).toBe(1))
@@ -205,7 +206,7 @@ describe('CopilotDock', () => {
     const textarea = container.querySelector('[data-testid="copilot-dock-textarea"]') as HTMLTextAreaElement
     fireEvent.input(textarea, { target: { value: '요약해줘' } })
 
-    const sendBtn = container.querySelector('.dock-send') as HTMLButtonElement
+    const sendBtn = container.querySelector('[aria-label="메시지 전송"]') as HTMLButtonElement
     sendBtn.click()
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))

--- a/dashboard/src/components/copilot-dock.ts
+++ b/dashboard/src/components/copilot-dock.ts
@@ -424,6 +424,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
         <button
           type="button"
           class="dock-iconbtn"
+          aria-label=${docked ? '플로팅으로 띄우기' : '오른쪽에 도킹'}
           title=${docked ? '플로팅으로 띄우기' : '오른쪽에 도킹'}
           onMouseDown=${(e: MouseEvent) => e.stopPropagation()}
           onClick=${() => dock.setMode(docked ? 'float' : 'dock')}
@@ -435,6 +436,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
         <button
           type="button"
           class="dock-iconbtn"
+          aria-label="닫기"
           title="닫기 (Esc)"
           onMouseDown=${(e: MouseEvent) => e.stopPropagation()}
           onClick=${dock.close}
@@ -544,6 +546,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
           <button
             type="button"
             class="dock-send"
+            aria-label="메시지 전송"
             disabled=${!val.trim() || !!dock.streaming.value}
             onClick=${() => doSend()}
           >

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -515,8 +515,8 @@ describe('deriveKeeperAttentionReason', () => {
   it('returns default warn reason when keeper has no attention signal', () => {
     const reason = deriveKeeperAttentionReason(makeKeeper({ name: 'plain' }))
     expect(reason.sev).toBe('warn')
-    expect(reason.text).toBe('점검 필요')
-    expect(reason.act).toBe('대화 열기')
+    expect(reason.text).toBe('주의 사유 미보고')
+    expect(reason.act).toBe('상태 상세')
   })
 
   it('marks continue_gate keepers as warn with approval action', () => {

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -26,7 +26,7 @@ import { KpiStripIsland } from '../kpi-strip-island'
 import { AgentAvatar } from './agent-avatar'
 import { missionSnapshot } from '../../mission-store'
 import { agents, tasks, keepers, messages, boardPosts } from '../../store'
-import type { Agent, Task, Keeper, Message, BoardPost } from '../../types/core'
+import type { Agent, Task, Keeper, Message, BoardPost, KeeperRuntimeBlockerClass } from '../../types/core'
 import { SYSTEM_ACTOR_NAME } from '../../types/core'
 import type {
   DashboardMissionResponse,
@@ -35,7 +35,7 @@ import type {
 import { openAgentDetail } from '../agent-detail-state'
 import { openTaskDetail } from '../goals/task-detail-state'
 import { nowSecondsSignal, useNowSecondsTicker } from '../../lib/now-signal'
-import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
+import { keeperDisplayStatus, keeperRuntimeBlockerLabel } from '../../lib/keeper-runtime-display'
 import { isKeeperPaused } from '../../lib/keeper-predicates'
 import { isAgentOffline } from '../../lib/agent-status'
 import { keeperRowLooksRunning } from '../../runtime-counts'
@@ -62,13 +62,32 @@ export interface KeeperAttentionReason {
   act: string
 }
 
-const DEFAULT_ATTENTION_REASON: KeeperAttentionReason = { sev: 'warn', text: '점검 필요', act: '대화 열기' }
+const DEFAULT_ATTENTION_REASON: KeeperAttentionReason = { sev: 'warn', text: '주의 사유 미보고', act: '상태 상세' }
+
+const OPERATOR_ATTENTION_BLOCKERS = new Set<KeeperRuntimeBlockerClass>([
+  'awaiting_operator',
+])
+
+const CRITICAL_ATTENTION_BLOCKERS = new Set<KeeperRuntimeBlockerClass>([
+  'exception',
+  'turn_failures',
+  'heartbeat_failures',
+])
+
+function hasOperatorAttentionBlocker(blockerClass: Keeper['runtime_blocker_class'] | null | undefined): boolean {
+  return blockerClass != null && OPERATOR_ATTENTION_BLOCKERS.has(blockerClass)
+}
+
+function hasCriticalAttentionBlocker(blockerClass: Keeper['runtime_blocker_class'] | null | undefined): boolean {
+  return blockerClass != null && CRITICAL_ATTENTION_BLOCKERS.has(blockerClass)
+}
 
 /** Map a keeper's runtime/trust state to a human attention reason.
  *  Mirrors the hard-coded ATTN_REASON table from keeper-v2/overview.jsx
  *  but derives the text from live dashboard fields. */
 export function deriveKeeperAttentionReason(keeper: Keeper): KeeperAttentionReason {
-  const blockerLabel = keeper.runtime_blocker_class?.replace(/_/g, ' ')
+  const blockerClass = keeper.runtime_blocker_class ?? null
+  const blockerLabel = keeperRuntimeBlockerLabel(blockerClass) ?? blockerClass?.replace(/_/g, ' ')
   const attention = keeper.attention_reason?.trim() || keeper.trust?.attention_reason?.trim()
   const nextAction = keeper.next_human_action?.trim() || keeper.trust?.next_human_action?.trim()
 
@@ -80,13 +99,11 @@ export function deriveKeeperAttentionReason(keeper: Keeper): KeeperAttentionReas
     }
   }
 
-  if (keeper.runtime_blocker_class === 'awaiting_operator') {
+  if (hasOperatorAttentionBlocker(blockerClass)) {
     return { sev: 'warn', text: attention ?? '운영자 조치 대기', act: nextAction ?? '승인 검토' }
   }
 
-  const isCritical = keeper.runtime_blocker_class === 'exception'
-    || keeper.runtime_blocker_class === 'turn_failures'
-    || keeper.runtime_blocker_class === 'heartbeat_failures'
+  const isCritical = hasCriticalAttentionBlocker(blockerClass)
     || keeper.lifecycle_phase === 'Dead'
     || keeper.lifecycle_phase === 'Crashed'
 
@@ -111,7 +128,7 @@ export function pickAttentionKeepers(keeperList: readonly Keeper[]): Keeper[] {
     k.needs_attention === true
     || k.trust?.needs_attention === true
     || k.runtime_blocker_continue_gate === true
-    || k.runtime_blocker_class === 'awaiting_operator'
+    || hasOperatorAttentionBlocker(k.runtime_blocker_class)
     || !!k.attention_reason?.trim()
     || !!k.trust?.attention_reason?.trim(),
   )

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -364,6 +364,12 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       const isCancelled = result.status === 'cancelled'
       const isError = !isCancelled && (result.status !== 'done' || result.ok === false)
       const errorMessage = isError ? queuedKeeperMessageError(result) : null
+      let userDelivery: KeeperConversationDelivery = 'delivered'
+      if (isCancelled) {
+        userDelivery = 'cancelled'
+      } else if (isError) {
+        userDelivery = 'error'
+      }
       let assistantDelivery: KeeperConversationDelivery = 'delivered'
       if (isCancelled) {
         assistantDelivery = 'cancelled'
@@ -373,7 +379,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         assistantDelivery = 'error'
       }
       finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
-        delivery: isCancelled ? 'cancelled' : isError ? 'error' : 'delivered',
+        delivery: userDelivery,
         error: errorMessage,
       })
       finalizeAssistantEntry(request.keeperName, assistantId, {

--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -244,6 +244,8 @@ run_tlc "$REPO_ROOT/specs/state-product" "WorkspaceProduct.tla"
 run_tlc_buggy "$REPO_ROOT/specs/state-product" "WorkspaceProduct.tla"
 run_tlc "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
+run_tlc "$REPO_ROOT/specs/task-lifecycle" "CompletionAuthority.tla"
+run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "CompletionAuthority.tla"
 
 run_tlc "$REPO_ROOT/specs/goal-loop" "TierRouting.tla"
 run_tlc_buggy "$REPO_ROOT/specs/goal-loop" "TierRouting.tla"


### PR DESCRIPTION
Follow-up from adversarial review of #21689.

Changes:
- Add accessible labels to Copilot dock icon-only buttons after lucide icon replacement.
- Pin the send button accessible label in the dock test.
- Remove an existing nested delivery ternary that blocked the full dashboard lint job on current main.
- Route overview keeper blocker decisions through typed helpers/runtime labels and replace the vague default attention copy with an explicit missing-reason state.
- Wire `CompletionAuthority.tla` clean/buggy configs into `scripts/tla-check.sh` so the cfg-backed TLA coverage guard remains green after the latest base changes.

Validation:
- `bash scripts/ci/check-tla-harness-coverage.sh`
- `bash scripts/lint/dashboard-ssot-keeper-state.sh`
- `pnpm exec vitest run --config vitest.config.ts src/components/overview/overview.test.ts src/components/copilot-dock.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm run lint`
- `pnpm run typecheck`
- `git diff --check`