### PR TITLE
[codex] harden keeper chat pending identity and generation reuse

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -462,6 +462,43 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
   })
 
+  it('resumes repeated same-message sends as distinct request ids', async () => {
+    const submittedAt = Date.UTC(2026, 5, 15, 9, 0, 0)
+    upsertPendingKeeperChatRequest({
+      requestId: 'kmsg_echo_1',
+      keeperName: 'echo',
+      message: 'status?',
+      submittedAt,
+    })
+    upsertPendingKeeperChatRequest({
+      requestId: 'kmsg_echo_2',
+      keeperName: 'echo',
+      message: 'status?',
+      submittedAt,
+    })
+    fetchQueuedKeeperMessageResult.mockImplementation(async (requestId: string) => ({
+      requestId,
+      keeperName: 'echo',
+      status: 'done',
+      ok: true,
+      result: { reply: requestId === 'kmsg_echo_1' ? 'first reply' : 'second reply' },
+    }))
+    fetchKeeperChatHistory.mockResolvedValue([])
+
+    await resumePendingKeeperChatRequests('echo')
+
+    expect(fetchQueuedKeeperMessageResult).toHaveBeenCalledTimes(2)
+    expect(fetchQueuedKeeperMessageResult).toHaveBeenNthCalledWith(1, 'kmsg_echo_1')
+    expect(fetchQueuedKeeperMessageResult).toHaveBeenNthCalledWith(2, 'kmsg_echo_2')
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+    expect((keeperThreads.value.echo ?? []).map(entry => [entry.role, entry.text, entry.delivery])).toEqual([
+      ['user', 'status?', 'delivered'],
+      ['assistant', 'first reply', 'delivered'],
+      ['user', 'status?', 'delivered'],
+      ['assistant', 'second reply', 'delivered'],
+    ])
+  })
+
   it('marks a recovered orphan request as lost instead of polling forever', async () => {
     upsertPendingKeeperChatRequest({
       requestId: 'kmsg_echo_1',

--- a/dashboard/src/keeper-chat-pending.test.ts
+++ b/dashboard/src/keeper-chat-pending.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  _clearPendingKeeperChatRequestsForTests,
+  pendingKeeperChatRequestsForKeeper,
+  removePendingKeeperChatRequest,
+  upsertPendingKeeperChatRequest,
+} from './keeper-chat-pending'
+
+describe('keeper chat pending request storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    _clearPendingKeeperChatRequestsForTests()
+  })
+
+  afterEach(() => {
+    _clearPendingKeeperChatRequestsForTests()
+    window.localStorage.clear()
+  })
+
+  it('preserves distinct request ids for repeated same-message sends', () => {
+    const base = {
+      keeperName: 'echo',
+      message: 'status?',
+      submittedAt: 1_780_000_000,
+    }
+
+    upsertPendingKeeperChatRequest({ ...base, requestId: 'kmsg_echo_1' })
+    upsertPendingKeeperChatRequest({ ...base, requestId: 'kmsg_echo_2' })
+
+    expect(pendingKeeperChatRequestsForKeeper('echo').map(request => request.requestId)).toEqual([
+      'kmsg_echo_1',
+      'kmsg_echo_2',
+    ])
+
+    removePendingKeeperChatRequest('kmsg_echo_1')
+
+    expect(pendingKeeperChatRequestsForKeeper('echo').map(request => request.requestId)).toEqual([
+      'kmsg_echo_2',
+    ])
+  })
+})

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -354,6 +354,14 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ()
       in
       let ctx0 = Keeper_context_runtime.create ~system_prompt ~max_tokens:primary_max_context in
+      (* next_generation keys the per-(keeper, trace) counter by the trace_id
+         string; episodes live under that same string dir (ensure_dir/of
+         session_id above), so pass the raw [trace_id] string, not the typed
+         [trace_id_t]. Reuse the reservation for metadata and checkpoint
+         creation so they cannot diverge. *)
+      let generation =
+        Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id
+      in
       let meta = {
         id = None;
         name = p.name;
@@ -444,12 +452,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_preview = "";
             consecutive_noop_count = 0;
           };
-          (* next_generation keys the per-(keeper, trace) counter by the trace_id
-             string; episodes live under that same string dir (ensure_dir/of
-             session_id above), so pass the raw [trace_id] string, not the typed
-             [trace_id_t]. trace_id_t is the typed wrapper stored in the record
-             field below. *)
-          generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id;
+          generation;
           trace_id = trace_id_t;
           trace_history = [];
           last_handoff_ts = 0.0;
@@ -484,7 +487,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ~session
             ~agent_name:meta.agent_name
             ~ctx:ctx0
-            ~generation:(Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id)
+            ~generation
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->

--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -244,6 +244,8 @@ run_tlc "$REPO_ROOT/specs/state-product" "WorkspaceProduct.tla"
 run_tlc_buggy "$REPO_ROOT/specs/state-product" "WorkspaceProduct.tla"
 run_tlc "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
+run_tlc "$REPO_ROOT/specs/task-lifecycle" "CompletionAuthority.tla"
+run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "CompletionAuthority.tla"
 
 run_tlc "$REPO_ROOT/specs/goal-loop" "TierRouting.tla"
 run_tlc_buggy "$REPO_ROOT/specs/goal-loop" "TierRouting.tla"


### PR DESCRIPTION
## What changed

- Rebased onto latest `main`, which already contains #21699: the requestId-based live-send ownership fix for the duplicate keeper-chat waiting bubble.
- Removed the prior content/time-window pending dedupe approach from this PR. Pending storage and resume behavior stay requestId-based.
- Added dashboard regressions proving repeated same-message sends with distinct requestIds are preserved:
  - storage keeps/removes records by `requestId` only;
  - resume polls both request ids and renders both user/assistant pairs.
- Kept the keeper creation generation hardening on top of #21709: reserve `next_generation` once and reuse that value for `meta.runtime.generation` and the initial checkpoint, avoiding side-effect divergence between metadata and checkpoint generation.
- Wired `specs/task-lifecycle/CompletionAuthority.tla` into `scripts/tla-check.sh` after CI Meta Guards showed the cfg-backed spec was not covered by the harness.

## Adversarial / parallel review

- Dashboard verifier rejected old head `454fb3a`: content/time-window dedupe could drop or cancel legitimate repeated sends.
- Current head implements the minimal fix from that review: no content fingerprint, no 5s window, no duplicate-cancel branch.
- OCaml verifier found no blocking issue with the generation hardening. It confirmed `next_generation` writes a counter and should be reserved once.

## Verification

```sh
pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/keeper-chat-pending.test.ts src/keeper-actions.test.ts
```

Result: 2 files passed, 45 tests passed.

```sh
bash scripts/ci/check-tla-harness-coverage.sh
```

Result: PASS.

```sh
git diff --check origin/main...HEAD
```

Result: clean.

Manual grep check:

```sh
rg -n "DUPLICATE_PENDING_REQUEST_WINDOW|pendingKeeperChatRequestFingerprint|isLikelyDuplicate|resumingKeeperChatRequestFingerprints" dashboard/src/keeper-chat-pending.ts dashboard/src/keeper-actions.ts dashboard/src/keeper-actions.test.ts
```

Result: no matches.

## Not run locally

- Dune/full build: left to CI per operator direction.
- Full TLC model checking: left to CI; local check was limited to the harness coverage gate that failed.
