### PR TITLE
feat(dashboard): project registry goal_id onto /execution tasks (RFC-0267 P1)

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -513,7 +513,27 @@ let task_execution_links_json (task : Masc_domain.task) =
   | None -> `Null
 ;;
 
-let task_json (task : Masc_domain.task) =
+(* RFC-0267 Phase 1: project the registry's canonical goal_id onto the wire.
+   The task record carries no goal_id (the goal_task_links registry is SSOT);
+   this is a read-time projection so the Work board can nest jobs under goals.
+   A task may appear under multiple goals in the legacy registry — the first
+   match is chosen deterministically and the multi-goal case is logged rather
+   than hidden, surfacing the single-goal-per-task invariant violation. *)
+let task_canonical_goal_id goal_task_index (task : Masc_domain.task) =
+  match Hashtbl.find_opt goal_task_index task.id with
+  | None | Some [] -> None
+  | Some [ goal_id ] -> Some goal_id
+  | Some (goal_id :: extra) ->
+    Log.Dashboard.warn
+      "[dashboard_execution] task %s linked to %d goals; projecting canonical %s (extra: %s)"
+      task.id
+      (1 + List.length extra)
+      goal_id
+      (String.concat "," extra);
+    Some goal_id
+;;
+
+let task_json ~goal_task_index (task : Masc_domain.task) =
   let fields =
     match Masc_domain.task_to_yojson task with
     | `Assoc assoc -> assoc
@@ -524,6 +544,12 @@ let task_json (task : Masc_domain.task) =
   in
   let fields = assoc_upsert fields "updated_at" (`String (task_updated_at task)) in
   let fields = assoc_upsert fields "execution_links" (task_execution_links_json task) in
+  let fields =
+    assoc_upsert
+      fields
+      "goal_id"
+      (Json_util.string_opt_to_json (task_canonical_goal_id goal_task_index task))
+  in
   let fields =
     match task_completed_at task with
     | Some timestamp -> assoc_upsert fields "completed_at" (`String timestamp)
@@ -664,6 +690,9 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
          so other fibers (SSE, health checks) can progress. *)
     Eio.Fiber.yield ();
     let tasks = tasks_safe config in
+    (* RFC-0267 Phase 1: build the task→goals index once; task_json projects the
+       canonical goal_id per task from it (registry is SSOT for the linkage). *)
+    let goal_task_index = Workspace_goal_index.build_task_goal_index_for_config config in
     let operation_contexts = build_operation_contexts ~tasks in
     let session_contexts = [] in
     let execution_queue = build_execution_queue session_contexts operation_contexts in
@@ -796,7 +825,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
          number. The raw list is surfaced instead; frontend paginates. *)
     let all_visible = active_tasks @ recent_done in
     let task_fields =
-      [ "tasks", `List (List.map task_json all_visible)
+      [ "tasks", `List (List.map (task_json ~goal_task_index) all_visible)
       ; ( "task_counts"
         , `Assoc
             [ "active", `Int (List.length active_tasks)

--- a/lib/dashboard/dashboard_execution.mli
+++ b/lib/dashboard/dashboard_execution.mli
@@ -9,6 +9,16 @@ val json :
   unit ->
   Yojson.Safe.t
 
+(** [task_json ~goal_task_index task] serializes a task for the dashboard
+    execution payload.  [goal_task_index] maps a task id to the goal ids it is
+    linked to (RFC-0267 Phase 1); the task's canonical (first) goal is projected
+    as the ["goal_id"] field — [`Null] when the task is unlinked.  Exposed so
+    unit tests can pin the projection without booting Eio. *)
+val task_json :
+  goal_task_index:(string, string list) Hashtbl.t ->
+  Masc_domain.task ->
+  Yojson.Safe.t
+
 (** #9766: per-render phase timing surfaced in the [slow render] WARN.
     Pure value type so unit tests can pin the formatter without
     booting Eio. *)

--- a/lib/workspace/workspace_goal_index.ml
+++ b/lib/workspace/workspace_goal_index.ml
@@ -230,7 +230,11 @@ let build_task_goal_index
        List.iter
          (fun task_id ->
             let existing = try Hashtbl.find tbl task_id with Not_found -> [] in
-            Hashtbl.replace tbl task_id (goal_id :: existing))
+            (* Preserve registry order for consumers that need a canonical
+               first-linked goal for a task. Multi-goal task links are legacy
+               invariant violations, but the projection must still be stable
+               and match the persisted link order. *)
+            Hashtbl.replace tbl task_id (existing @ [ goal_id ]))
          task_ids)
     goal_task_links;
   tbl

--- a/test/dune
+++ b/test/dune
@@ -665,6 +665,13 @@
  (modules test_runtime_modality_reroute)
  (libraries masc_test_deps))
 
+; RFC-0267 Phase 1: registry goal_id projection onto the /execution task wire.
+
+(test
+ (name test_dashboard_goal_id_projection)
+ (modules test_dashboard_goal_id_projection)
+ (libraries masc_test_deps))
+
 ; Group 2: Property-based tests (QCheck)
 
 (tests

--- a/test/test_dashboard_goal_id_projection.ml
+++ b/test/test_dashboard_goal_id_projection.ml
@@ -1,0 +1,88 @@
+(** RFC-0267 Phase 1 — registry goal_id projection onto the /execution wire.
+
+    The task record carries no goal_id (the goal_task_links registry is SSOT).
+    [Dashboard_execution.task_json] projects a canonical goal_id per task from
+    the task→goals index so the Work board can nest jobs under goals. These
+    tests pin that projection without booting Eio. *)
+
+open Alcotest
+open Masc_domain
+
+module DE = Dashboard_execution
+
+let make_task ~id =
+  { id
+  ; title = "Task " ^ id
+  ; description = ""
+  ; task_status = Todo
+  ; priority = 3
+  ; files = []
+  ; created_at = "2026-06-20T00:00:00Z"
+  ; created_by = None
+  ; contract = None
+  ; handoff_context = None
+  ; cycle_count = 0
+  ; reclaim_policy = None
+  ; do_not_reclaim_reason = None
+  }
+;;
+
+let index pairs =
+  let h = Hashtbl.create 8 in
+  List.iter (fun (k, v) -> Hashtbl.replace h k v) pairs;
+  h
+;;
+
+(* Extract the projected goal_id field from a serialized task. *)
+let goal_id_of json =
+  let open Yojson.Safe.Util in
+  match json |> member "goal_id" with
+  | `Null -> None
+  | `String s -> Some s
+  | _ -> Some "<non-string>"
+;;
+
+let test_linked_task_projects_goal_id () =
+  let idx = index [ "task-1", [ "goal-a" ] ] in
+  let j = DE.task_json ~goal_task_index:idx (make_task ~id:"task-1") in
+  check (option string) "linked task carries its goal_id" (Some "goal-a") (goal_id_of j)
+;;
+
+let test_unlinked_task_projects_null () =
+  let idx = index [ "task-1", [ "goal-a" ] ] in
+  let j = DE.task_json ~goal_task_index:idx (make_task ~id:"task-2") in
+  check (option string) "task absent from index -> goal_id null" None (goal_id_of j)
+;;
+
+let test_empty_link_list_projects_null () =
+  let idx = index [ "task-1", [] ] in
+  let j = DE.task_json ~goal_task_index:idx (make_task ~id:"task-1") in
+  check (option string) "empty link list -> goal_id null" None (goal_id_of j)
+;;
+
+let test_multi_goal_projects_first () =
+  (* Legacy registry rows may link a task to >1 goal; the projection is
+     deterministic (first match) and the board adopts a single-goal model. *)
+  let idx = index [ "task-1", [ "goal-a"; "goal-b"; "goal-c" ] ] in
+  let j = DE.task_json ~goal_task_index:idx (make_task ~id:"task-1") in
+  check
+    (option string)
+    "multi-goal task -> deterministic first goal"
+    (Some "goal-a")
+    (goal_id_of j)
+;;
+
+let () =
+  run
+    "dashboard_goal_id_projection"
+    [ ( "RFC-0267 Phase 1"
+      , [ test_case "linked task projects goal_id" `Quick test_linked_task_projects_goal_id
+        ; test_case "unlinked task projects null" `Quick test_unlinked_task_projects_null
+        ; test_case "empty link list projects null" `Quick test_empty_link_list_projects_null
+        ; test_case
+            "multi-goal projects deterministic first"
+            `Quick
+            test_multi_goal_projects_first
+        ] )
+    ]
+;;

--- a/test/test_dashboard_goal_id_projection.ml
+++ b/test/test_dashboard_goal_id_projection.ml
@@ -9,6 +9,7 @@ open Alcotest
 open Masc_domain
 
 module DE = Dashboard_execution
+module WGI = Workspace_goal_index
 
 let make_task ~id =
   { id
@@ -33,6 +34,10 @@ let index pairs =
   h
 ;;
 
+let index_from_registry goal_task_links =
+  WGI.build_task_goal_index ~goal_task_links ()
+;;
+
 (* Extract the projected goal_id field from a serialized task. *)
 let goal_id_of json =
   let open Yojson.Safe.Util in
@@ -43,13 +48,13 @@ let goal_id_of json =
 ;;
 
 let test_linked_task_projects_goal_id () =
-  let idx = index [ "task-1", [ "goal-a" ] ] in
+  let idx = index_from_registry [ "goal-a", [ "task-1" ] ] in
   let j = DE.task_json ~goal_task_index:idx (make_task ~id:"task-1") in
   check (option string) "linked task carries its goal_id" (Some "goal-a") (goal_id_of j)
 ;;
 
 let test_unlinked_task_projects_null () =
-  let idx = index [ "task-1", [ "goal-a" ] ] in
+  let idx = index_from_registry [ "goal-a", [ "task-1" ] ] in
   let j = DE.task_json ~goal_task_index:idx (make_task ~id:"task-2") in
   check (option string) "task absent from index -> goal_id null" None (goal_id_of j)
 ;;
@@ -62,12 +67,17 @@ let test_empty_link_list_projects_null () =
 
 let test_multi_goal_projects_first () =
   (* Legacy registry rows may link a task to >1 goal; the projection is
-     deterministic (first match) and the board adopts a single-goal model. *)
-  let idx = index [ "task-1", [ "goal-a"; "goal-b"; "goal-c" ] ] in
+     deterministic (first registry match) and the board adopts a single-goal
+     model. This must go through the production index builder so the test pins
+     the persisted link-order semantics rather than a hand-built list. *)
+  let idx =
+    index_from_registry
+      [ "goal-a", [ "task-1" ]; "goal-b", [ "task-1" ]; "goal-c", [ "task-1" ] ]
+  in
   let j = DE.task_json ~goal_task_index:idx (make_task ~id:"task-1") in
   check
     (option string)
-    "multi-goal task -> deterministic first goal"
+    "multi-goal task -> deterministic first registry goal"
     (Some "goal-a")
     (goal_id_of j)
 ;;
@@ -80,7 +90,7 @@ let () =
         ; test_case "unlinked task projects null" `Quick test_unlinked_task_projects_null
         ; test_case "empty link list projects null" `Quick test_empty_link_list_projects_null
         ; test_case
-            "multi-goal projects deterministic first"
+            "multi-goal projects deterministic first registry goal"
             `Quick
             test_multi_goal_projects_first
         ] )


### PR DESCRIPTION
## Summary

Implements Phase 1 of RFC-0267 (#21684): project the registry-owned task↔goal link back onto the `/execution` task wire as `goal_id`.

The task record still carries no persisted `goal_id`; `goal_task_links` remains the SSOT. `Dashboard_execution.task_json` receives a prebuilt task→goals index and projects the canonical goal at render time so the Work board can nest jobs under goals again.

## Change
- read-time `goal_id` projection in `Dashboard_execution.task_json`
- one task→goals index build per dashboard render, not per task
- multi-goal legacy rows warn instead of silently hiding the invariant violation
- `Workspace_goal_index.build_task_goal_index` now preserves registry order, so canonical first-goal projection matches persisted link order
- tests exercise the production index builder, including the multi-goal order case

## Validation
- `ocamlformat --check lib/workspace/workspace_goal_index.ml test/test_dashboard_goal_id_projection.ml lib/dashboard/dashboard_execution.ml lib/dashboard/dashboard_execution.mli`
- `git diff --check`
- Not run to completion: `scripts/dune-local.sh build test/test_dashboard_goal_id_projection.exe` entered Dune but was stopped after a long run; full build deferred per operator instruction.

## Scope
Phase 2 (`masc_task_set_goal` replace/assignment operation) remains separate.
