### PR TITLE
fix(runtime): require /api/show evidence for declared Ollama media caps (RFC-0265)

### DIFF
--- a/docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md
+++ b/docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md
@@ -212,9 +212,16 @@ path (the runtime stays static/deterministic per §3.4):
   `scripts/ollama-caps-baseline.json`.
 - `--check` (CI; no network) — compares each config-declared media flag against
   the baseline. Hard-fails on `UNDER-DECLARED` (a vision model whose config
-  omits `supports-image-input` → reroute can't see it) or `OVER-DECLARED`
-  (config claims a modality the model lacks → provider 400 at dispatch). Wired
-  into `.github/workflows/ci.yml`.
+  omits `supports-image-input` → reroute can't see it), `OVER-DECLARED`
+  (config claims a modality the model lacks → provider 400 at dispatch), or
+  `UNVERIFIED-DECLARED` (config declares image/audio but the model has no
+  `/api/show` evidence in the baseline). The last case closes the loop: a media
+  capability is valid only when backed by a baseline snapshot, so adding a vision
+  model to the config without refreshing the baseline fails CI instead of passing
+  on a soft warning (the gap that let a 31-model config expansion through
+  unverified). A *text-only* model absent from the baseline is fail-closed safe
+  and only soft-warns (`--strict` fails those too). Wired into
+  `.github/workflows/ci.yml`.
 - `--emit` — prints the recommended `[models.<id>.capabilities]` media lines for
   the operator to merge into the live `runtime.toml`.
 

--- a/scripts/masc-sync-ollama-caps.py
+++ b/scripts/masc-sync-ollama-caps.py
@@ -18,8 +18,11 @@ Why a separate baseline file:
 
 Modes:
   --check    (default) compare config-declared media caps against the baseline.
-             Hard-fails (exit 1) on a real mismatch (declared != reality).
-             Soft-warns (exit 0) when a config model is absent from the baseline.
+             Hard-fails (exit 1) on a real mismatch (declared != reality) OR on a
+             declared media capability with no baseline evidence (an unverified
+             over-declaration). Soft-warns (exit 0) only when a *text-only* model
+             is absent from the baseline (declaring nothing is fail-closed safe);
+             --strict fails those too.
   --refresh  probe /api/show for every Ollama-family model in the config and
              (re)write the baseline JSON. Requires network + provider key.
   --emit     print the recommended [models.<id>.capabilities] media lines for
@@ -124,6 +127,59 @@ class MediaFlags:
         if self.audio:
             lines.append("supports-audio-input = true")
         return lines
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """Per-model capability verdict from classify().
+
+    A hard verdict contributes to a non-zero exit (CI fails); a soft verdict is an
+    advisory warning that only fails the run under --strict.
+    """
+
+    hard: bool
+    soft: bool
+    kind: str
+
+
+def classify(declared: MediaFlags, expected: "MediaFlags | None") -> Verdict:
+    """Pure capability verdict for one model. The gate decision is this function.
+
+    `expected` is None when the model has no /api/show evidence in the baseline.
+    A declared media capability with no evidence is an unverified over-declaration
+    and fails: declaring supports-image-input=true with no baseline snapshot
+    proving it is exactly how a text-only model ends up receiving an image turn.
+    A text-only model with no evidence is fail-closed safe, so it only soft-warns.
+
+    When evidence exists, declared must equal it. Over-declaration (a modality the
+    model lacks) makes the provider 400 at dispatch; under-declaration hides a
+    modality the model has from the reroute/gate.
+    """
+    if expected is None:
+        if declared.image or declared.audio:
+            return Verdict(
+                hard=True,
+                soft=False,
+                kind="UNVERIFIED-DECLARED (capability claimed, no /api/show evidence)",
+            )
+        return Verdict(
+            hard=False, soft=True, kind="unverified (text-only, absent from baseline)"
+        )
+    if declared == expected:
+        return Verdict(hard=False, soft=False, kind="ok")
+    under = (expected.image and not declared.image) or (
+        expected.audio and not declared.audio
+    )
+    over = (declared.image and not expected.image) or (
+        declared.audio and not expected.audio
+    )
+    if under and over:
+        kind = "MISMATCH (both under- and over-declared)"
+    elif under:
+        kind = "UNDER-DECLARED (reroute/gate will not see a modality)"
+    else:
+        kind = "OVER-DECLARED (provider will 400 at dispatch)"
+    return Verdict(hard=True, soft=False, kind=kind)
 
 
 @dataclass(frozen=True)
@@ -310,39 +366,44 @@ def mode_check(config_path: Path, baseline_path: Path, strict: bool) -> int:
     for model in models:
         entry = baseline.get(model.api_name)
         if entry is None:
-            print(
-                f"::warning::{model.model_id} ({model.api_name}) not in baseline; "
-                f"run --refresh to verify",
-                file=sys.stderr,
-            )
-            soft += 1
+            verdict = classify(model.declared, None)
+            if verdict.hard:
+                print(
+                    f"DRIFT {model.model_id} ({model.api_name}): {verdict.kind}\n"
+                    f"  baseline: absent — run --refresh to record /api/show\n"
+                    f"  declared: image={model.declared.image} "
+                    f"audio={model.declared.audio}",
+                    file=sys.stderr,
+                )
+                hard += 1
+            elif verdict.soft:
+                print(
+                    f"::warning::{model.model_id} ({model.api_name}) "
+                    f"{verdict.kind}; run --refresh",
+                    file=sys.stderr,
+                )
+                soft += 1
             continue
+        # entry present: classify against /api/show evidence (never soft here).
         expected = MediaFlags.from_ollama_capabilities(entry["capabilities"])
-        declared = model.declared
-        if declared != expected:
-            under = (expected.image and not declared.image) or (
-                expected.audio and not declared.audio
-            )
-            over = (declared.image and not expected.image) or (
-                declared.audio and not expected.audio
-            )
-            if under and over:
-                kind = "MISMATCH (both under- and over-declared)"
-            elif under:
-                kind = "UNDER-DECLARED (reroute/gate will not see a modality)"
-            else:
-                kind = "OVER-DECLARED (provider will 400 at dispatch)"
+        verdict = classify(model.declared, expected)
+        if verdict.hard:
             print(
-                f"DRIFT {model.model_id} ({model.api_name}): {kind}\n"
+                f"DRIFT {model.model_id} ({model.api_name}): {verdict.kind}\n"
                 f"  /api/show caps = {entry['capabilities']}\n"
                 f"  expected: image={expected.image} audio={expected.audio}\n"
-                f"  declared: image={declared.image} audio={declared.audio}",
+                f"  declared: image={model.declared.image} "
+                f"audio={model.declared.audio}",
                 file=sys.stderr,
             )
             hard += 1
 
     if hard:
-        print(f"FAIL: {hard} model(s) drifted from /api/show reality", file=sys.stderr)
+        print(
+            f"FAIL: {hard} model(s) failed capability verification "
+            f"(drift or unverified declaration)",
+            file=sys.stderr,
+        )
         return 1
     if soft and strict:
         print(f"FAIL (strict): {soft} model(s) unverified", file=sys.stderr)
@@ -394,7 +455,27 @@ def mode_self_test() -> int:
         {"supports-image-input": True, "supports-multimodal-inputs": True}
     )
     assert declared == MediaFlags(True, False), declared
-    print(f"self-test OK ({len(cases)} mapping cases)")
+
+    # classify(): a declared capability with no baseline evidence must hard-fail;
+    # a text-only model with no evidence is fail-closed safe (soft only).
+    img = MediaFlags(True, False)
+    aud = MediaFlags(False, True)
+    none = MediaFlags(False, False)
+    classify_cases = [
+        (classify(img, None), True, False),  # declared image, no evidence -> hard
+        (classify(aud, None), True, False),  # declared audio, no evidence -> hard
+        (classify(none, None), False, True),  # text-only, no evidence -> soft
+        (classify(img, img), False, False),  # match -> ok
+        (classify(img, none), True, False),  # over-declared -> hard
+        (classify(none, img), True, False),  # under-declared -> hard
+    ]
+    for verdict, want_hard, want_soft in classify_cases:
+        assert verdict.hard is want_hard, f"{verdict} hard != {want_hard}"
+        assert verdict.soft is want_soft, f"{verdict} soft != {want_soft}"
+
+    print(
+        f"self-test OK ({len(cases)} mapping + {len(classify_cases)} classify cases)"
+    )
     return 0
 
 

--- a/scripts/ollama-caps-baseline.json
+++ b/scripts/ollama-caps-baseline.json
@@ -3,6 +3,22 @@
   "schema_version": 1,
   "source": "{provider.endpoint - /v1}/api/show {\"model\": <api-name>}",
   "models": {
+    "deepseek-v3.1:671b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking"
+      ]
+    },
+    "deepseek-v3.2": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking"
+      ]
+    },
     "deepseek-v4-flash": {
       "provider": "ollama_cloud",
       "capabilities": [
@@ -19,12 +35,123 @@
         "thinking"
       ]
     },
+    "devstral-2:123b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools"
+      ]
+    },
+    "devstral-small-2:24b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "vision"
+      ]
+    },
+    "gemini-3-flash-preview": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking",
+        "vision"
+      ]
+    },
+    "gemma3:12b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "vision"
+      ]
+    },
+    "gemma3:27b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "vision"
+      ]
+    },
+    "gemma3:4b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "vision"
+      ]
+    },
+    "gemma4:31b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "thinking",
+        "tools",
+        "vision"
+      ]
+    },
+    "glm-4.7": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "thinking",
+        "completion",
+        "tools"
+      ]
+    },
+    "glm-5": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "thinking",
+        "completion",
+        "tools"
+      ]
+    },
+    "glm-5.1": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "thinking",
+        "completion",
+        "tools"
+      ]
+    },
+    "glm-5.2": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "thinking",
+        "completion",
+        "tools"
+      ]
+    },
+    "gpt-oss:120b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking"
+      ]
+    },
+    "gpt-oss:20b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking"
+      ]
+    },
     "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL": {
       "provider": "ollama",
       "capabilities": [
         "tools",
         "completion",
         "vision"
+      ]
+    },
+    "kimi-k2.5": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "vision",
+        "thinking",
+        "completion",
+        "tools"
       ]
     },
     "kimi-k2.6": {
@@ -36,6 +163,39 @@
         "tools"
       ]
     },
+    "kimi-k2.7-code": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "vision",
+        "thinking",
+        "completion",
+        "tools"
+      ]
+    },
+    "minimax-m2.1": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking"
+      ]
+    },
+    "minimax-m2.5": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking"
+      ]
+    },
+    "minimax-m2.7": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking"
+      ]
+    },
     "minimax-m3": {
       "provider": "ollama_cloud",
       "capabilities": [
@@ -43,6 +203,92 @@
         "tools",
         "thinking",
         "vision"
+      ]
+    },
+    "ministral-3:14b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "vision"
+      ]
+    },
+    "ministral-3:3b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "vision"
+      ]
+    },
+    "ministral-3:8b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "vision"
+      ]
+    },
+    "mistral-large-3:675b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "vision"
+      ]
+    },
+    "nemotron-3-nano:30b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking"
+      ]
+    },
+    "nemotron-3-super": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "thinking",
+        "tools"
+      ]
+    },
+    "nemotron-3-ultra": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "thinking",
+        "tools"
+      ]
+    },
+    "qwen3-coder-next": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools"
+      ]
+    },
+    "qwen3-coder:480b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools"
+      ]
+    },
+    "qwen3.5:397b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "thinking",
+        "tools",
+        "vision"
+      ]
+    },
+    "rnj-1:8b": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools"
       ]
     }
   }


### PR DESCRIPTION
## RFC-0265 — capability drift gate: require /api/show evidence for declared media caps

### 문제
`scripts/masc-sync-ollama-caps.py --check` (RFC-0265 §4.2 drift gate)가 baseline에 없는 모델을 `supports-image-input`/`supports-audio-input = true`로 선언해도 soft-warn(exit 0)으로 통과시켰다. 이 permissive default 때문에 #21656이 ollama cloud fleet(31개 모델)을 seed config에 추가하면서 capability 선언이 `/api/show` 증거 없이 CI를 통과했다 — 게이트는 green이지만 31개가 미검증 상태. `software-development.md` 안티패턴 #2 "Unknown → Permissive Default"에 해당한다.

### 수정 (root, 워크어라운드 아님)
1. **게이트 로직**: declared media capability(image/audio)인데 baseline에 `/api/show` 증거가 없으면 `UNVERIFIED-DECLARED`로 **hard-fail**. text-only 모델 부재는 fail-closed라 soft-warn 유지(`--strict`는 이것도 fail). 결정을 순수 함수 `classify(declared, expected) -> Verdict`로 추출하고 self-test 6 케이스로 증명.
2. **baseline refresh**: `scripts/ollama-caps-baseline.json`을 5 → 36 모델로 갱신(현재 seed config의 전체 ollama-family를 `/api/show`로 probe). #21656/#21647이 추가한 image/audio 선언이 전부 `/api/show`와 일치함을 실증(0 drift, 0 unverified).

이후 vision 모델을 config에 추가하면서 baseline refresh를 안 하면 CI가 막는다 — 선언/게이트/커버리지 루프가 구조적으로 닫힌다. permissive default(soft-warn)를 enforcement(hard-fail)로 **교체**(추가가 아님)하므로 워크어라운드 시그니처 3종/체크리스트 7항목 해당 없음. 오히려 안티패턴 #2를 닫는다.

### 범위 밖
`supports-multimodal-inputs`(document modality)는 `/api/show`가 document/multimodal capability 문자열을 구조적으로 노출하지 않아 이 게이트로 검증 불가 — 운영자 명시 선언으로 유지(RFC-0265 §4.2 기존 결정). 별도 evidence 소스가 필요한 다른 트랙.

### 검증 (로컬)
- `--self-test`: 6 mapping + 6 classify 케이스 green
- `--check`: `OK: 39 Ollama-family model(s) match baseline (0 unverified)`, exit 0
- stale baseline 회귀 테스트: 13개 `UNVERIFIED-DECLARED` hard-fail (게이트 작동 실증)
- pyright strict: 0 errors, 0 warnings

OCaml 무변경(순수 script + baseline data + RFC doc). OAS 무변경(경계 유지).

RFC: RFC-0265 §4.2

WORKAROUND-WAIVED: false positive (TELEMETRY_AS_FIX) — 이 PR은 permissive default(soft-warn)를 *제거*하고 hard-fail enforcement로 *교체*한다(telemetry-as-fix의 정반대). 시그니처는 삭제 대상 동작을 서술한 "permissive default(soft-warn)" 어구에 매칭된 것이지 관측성 추가가 아니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
