### PR TITLE
[codex] Improve Fusion provider timeout context

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -931,8 +931,8 @@ partial coverage, unique insights, and blind spots, then give one resolved \
 answer. Respond with ONLY the requested JSON object, no prose and no code fences.
 """
 # 구조적 타임아웃(초). 미지정 시 Fusion_policy.default_timeout_s.
-panel_timeout_s = 120.0
-judge_timeout_s = 120.0
+panel_timeout_s = 300.0
+judge_timeout_s = 300.0
 # 패널/심판에 MASC web_search/web_fetch 도구를 주입할지 여부.
 web_tools = false
 # 패널 모델당 최대 tool 호출 수 (0 = 무제한, OpenRouter Fusion 허용 범위 0..16).

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -40,7 +40,7 @@ let run ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question ~panel
   let tools = if web_tools then Fusion_oas.web_tool_bundle () else [] in
   match
     Fusion_oas.build_agent ~sw ~net ~system_prompt:judge_system_prompt ~tools
-      ~max_tool_calls judge_model
+      ~max_tool_calls ~timeout_s judge_model
   with
   | Error reason ->
     Error
@@ -52,7 +52,11 @@ let run ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question ~panel
        Masc_oas_bridge.run_safe ~caller:"fusion_judge" ~timeout_s (fun () ->
          Ok (Agent_sdk.Async_agent.all ~sw [ (agent, prompt) ]))
      with
-     | Error e -> Error ("judge run failed: " ^ Agent_sdk.Error.to_string e)
+     | Error e ->
+       Error
+         ("judge run failed: "
+          ^ Fusion_oas.provider_error_detail ~runtime_id:judge_model
+              (Agent_sdk.Error.to_string e))
      | Ok [] -> Error "judge: empty result"
      | Ok ((_name, Ok resp) :: _) ->
        let text = Fusion_oas.answer_text resp in
@@ -63,4 +67,7 @@ let run ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question ~panel
            (fun synthesis -> (synthesis, Fusion_oas.usage_of resp))
            (Fusion_judge_parse.of_string text)
      | Ok ((_name, Error e) :: _) ->
-       Error ("judge provider error: " ^ Agent_sdk.Error.to_string e))
+       Error
+         ("judge provider error: "
+          ^ Fusion_oas.provider_error_detail ~runtime_id:judge_model
+              (Agent_sdk.Error.to_string e)))

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -37,6 +37,19 @@ let provider_error_detail ~runtime_id detail =
 let timeout_budget_opt timeout_s =
   if Float.is_finite timeout_s && timeout_s > 0.0 then Some timeout_s else None
 
+let apply_timeout_budget ?timeout_s base_config =
+  match Option.bind timeout_s timeout_budget_opt with
+  | None -> base_config
+  | Some timeout_s ->
+    (* Fusion owns the structural wall-clock budget via the outer
+       Masc_oas_bridge.run_safe call. Do not arm Runtime_agent's total
+       max_execution_time_s here; it can kill an active stream with the
+       wrong failure attribution. *)
+    { base_config with
+      stream_idle_timeout_s = Some timeout_s
+    ; body_timeout_s = Some timeout_s
+    }
+
 (** [Keeper_tool_descriptor]에서 날것의 web tool descriptor를 찾아
     [Agent_sdk.Tool.t]로 변환한다. 패널/심판이 web_search/web_fetch를
     호출할 수 있게 하는 목적으로만 쓰인다. *)
@@ -80,19 +93,7 @@ let build_agent ~sw ~net ~system_prompt ?(tools = []) ?(max_tool_calls = 0)
     let base_config =
       Runtime_agent.default_config ~name:model ~provider_cfg ~system_prompt ~tools
     in
-    let base_config =
-      match Option.bind timeout_s timeout_budget_opt with
-      | None -> base_config
-      | Some timeout_s ->
-        (* Fusion owns the structural wall-clock budget via the outer
-           Masc_oas_bridge.run_safe call. Do not arm Runtime_agent's total
-           max_execution_time_s here; it can kill an active stream with the
-           wrong failure attribution. *)
-        { base_config with
-          stream_idle_timeout_s = Some timeout_s
-        ; body_timeout_s = Some timeout_s
-        }
-    in
+    let base_config = apply_timeout_budget ?timeout_s base_config in
     (* max_tool_calls는 OpenRouter Fusion의 per-panel tool budget에 대응.
        Runtime_agent의 max_turns로 근사: tool 호출 횟수 + 최종 답변 1턴. *)
     let config =
@@ -105,3 +106,7 @@ let build_agent ~sw ~net ~system_prompt ?(tools = []) ?(max_tool_calls = 0)
        Error
          (Fusion_types.Provider_error
             (provider_error_detail ~runtime_id:model (Agent_sdk.Error.to_string e))))
+
+module For_testing = struct
+  let apply_timeout_budget = apply_timeout_budget
+end

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -17,6 +17,26 @@ let usage_of (resp : Agent_sdk.Types.api_response) : Fusion_types.usage =
     }
   | None -> Fusion_types.zero_usage
 
+let provider_error_detail ~runtime_id detail =
+  let runtime_id = String.trim runtime_id in
+  let detail = String.trim detail in
+  if String.equal runtime_id "" || String.equal detail "" then detail
+  else
+    let unknown_prefix = "Provider 'unknown'" in
+    let runtime_provider_prefix = Printf.sprintf "Provider '%s'" runtime_id in
+    let runtime_context_prefix = runtime_id ^ ": " in
+    if String.starts_with ~prefix:unknown_prefix detail then
+      runtime_provider_prefix
+      ^ String.sub detail (String.length unknown_prefix)
+          (String.length detail - String.length unknown_prefix)
+    else if String.starts_with ~prefix:runtime_provider_prefix detail
+            || String.starts_with ~prefix:runtime_context_prefix detail
+    then detail
+    else Printf.sprintf "%s: %s" runtime_id detail
+
+let timeout_budget_opt timeout_s =
+  if Float.is_finite timeout_s && timeout_s > 0.0 then Some timeout_s else None
+
 (** [Keeper_tool_descriptor]에서 날것의 web tool descriptor를 찾아
     [Agent_sdk.Tool.t]로 변환한다. 패널/심판이 web_search/web_fetch를
     호출할 수 있게 하는 목적으로만 쓰인다. *)
@@ -48,7 +68,8 @@ let web_tool_bundle () : Agent_sdk.Tool.t list =
   |> List.concat
   |> List.filter_map oas_tool_of_descriptor
 
-let build_agent ~sw ~net ~system_prompt ?(tools = []) ?(max_tool_calls = 0) (model : string)
+let build_agent ~sw ~net ~system_prompt ?(tools = []) ?(max_tool_calls = 0)
+    ?timeout_s (model : string)
   : (Agent_sdk.Agent.t, Fusion_types.panel_failure) result
   =
   match Runtime_oas_runner.resolve_runtime_providers ~runtime_id:model () with
@@ -59,6 +80,16 @@ let build_agent ~sw ~net ~system_prompt ?(tools = []) ?(max_tool_calls = 0) (mod
     let base_config =
       Runtime_agent.default_config ~name:model ~provider_cfg ~system_prompt ~tools
     in
+    let base_config =
+      match Option.bind timeout_s timeout_budget_opt with
+      | None -> base_config
+      | Some timeout_s ->
+        { base_config with
+          stream_idle_timeout_s = Some timeout_s
+        ; max_execution_time_s = Some timeout_s
+        ; body_timeout_s = Some timeout_s
+        }
+    in
     (* max_tool_calls는 OpenRouter Fusion의 per-panel tool budget에 대응.
        Runtime_agent의 max_turns로 근사: tool 호출 횟수 + 최종 답변 1턴. *)
     let config =
@@ -67,4 +98,7 @@ let build_agent ~sw ~net ~system_prompt ?(tools = []) ?(max_tool_calls = 0) (mod
     in
     (match Runtime_agent.build ~sw ~net ~config with
      | Ok agent -> Ok agent
-     | Error e -> Error (Fusion_types.Provider_error (Agent_sdk.Error.to_string e)))
+     | Error e ->
+       Error
+         (Fusion_types.Provider_error
+            (provider_error_detail ~runtime_id:model (Agent_sdk.Error.to_string e))))

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -84,9 +84,12 @@ let build_agent ~sw ~net ~system_prompt ?(tools = []) ?(max_tool_calls = 0)
       match Option.bind timeout_s timeout_budget_opt with
       | None -> base_config
       | Some timeout_s ->
+        (* Fusion owns the structural wall-clock budget via the outer
+           Masc_oas_bridge.run_safe call. Do not arm Runtime_agent's total
+           max_execution_time_s here; it can kill an active stream with the
+           wrong failure attribution. *)
         { base_config with
           stream_idle_timeout_s = Some timeout_s
-        ; max_execution_time_s = Some timeout_s
         ; body_timeout_s = Some timeout_s
         }
     in

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -18,8 +18,15 @@ val build_agent
   -> system_prompt:string
   -> ?tools:Agent_sdk.Tool.t list
   -> ?max_tool_calls:int
+  -> ?timeout_s:float
   -> string
   -> (Agent_sdk.Agent.t, Fusion_types.panel_failure) result
+
+(** Attach Fusion's runtime id to an OAS provider error string.
+    OAS transport errors may surface as ["Provider 'unknown' ..."] because the
+    public SDK error type does not carry MASC runtime ids. Fusion owns the
+    panel/judge runtime id, so it patches that display boundary locally. *)
+val provider_error_detail : runtime_id:string -> string -> string
 
 (** [masc_web_search] / [masc_web_fetch]를 [Agent_sdk.Tool.t]로 변환한 목록.
     [Keeper_tool_descriptor]에서 descriptor를 찾지 못하면 빈 목록을 반환한다. *)

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -11,6 +11,9 @@
     [tools]를 주면 패널/심판이 tool call을 할 수 있다.
     [max_tool_calls] > 0이면 에이전트의 [max_turns]를 해당 횟수+1로 제한해
     OpenRouter Fusion의 per-panel tool budget을 근사한다.
+    [timeout_s]는 OAS transport idle/body budget에만 매핑한다. Fusion의 구조적
+    wall-clock budget은 호출자가 [Masc_oas_bridge.run_safe]로 소유하며, OAS
+    [max_execution_time_s]에는 매핑하지 않는다.
     미존재 runtime·빌드 실패는 [panel_failure]로. *)
 val build_agent
   :  sw:Eio.Switch.t

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -25,6 +25,16 @@ val build_agent
   -> string
   -> (Agent_sdk.Agent.t, Fusion_types.panel_failure) result
 
+(** Test seam for Fusion-local OAS runtime config mapping. Production callers
+    should use [build_agent], which also resolves runtime providers and builds
+    the OAS agent. *)
+module For_testing : sig
+  val apply_timeout_budget
+    :  ?timeout_s:float
+    -> Runtime_agent.config
+    -> Runtime_agent.config
+end
+
 (** Attach Fusion's runtime id to an OAS provider error string.
     OAS transport errors may surface as ["Provider 'unknown' ..."] because the
     public SDK error type does not carry MASC runtime ids. Fusion owns the

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -19,7 +19,10 @@ let outcome_of_result (model : string)
   | Error e ->
     Fusion_types.Failed
       { failed_model = model
-      ; reason = Fusion_types.Provider_error (Agent_sdk.Error.to_string e)
+      ; reason =
+          Fusion_types.Provider_error
+            (Fusion_oas.provider_error_detail ~runtime_id:model
+               (Agent_sdk.Error.to_string e))
       }
 
 let run ~sw ~net ~max_fibers ~timeout_s ~models ~system_prompt ~prompt
@@ -32,7 +35,7 @@ let run ~sw ~net ~max_fibers ~timeout_s ~models ~system_prompt ~prompt
       (fun (oks, fails) model ->
         match
           Fusion_oas.build_agent ~sw ~net ~system_prompt ~tools
-            ~max_tool_calls:max_tool_calls_per_panel model
+            ~max_tool_calls:max_tool_calls_per_panel ~timeout_s model
         with
         | Ok agent -> ((agent, model) :: oks, fails)
         | Error reason ->

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -19,7 +19,7 @@ let max_panel = 8
 
 (* 패널/심판 호출 구조적 타임아웃 기본값 (preset이 명시 안 할 때). 운영 노브 —
    행동 휴리스틱이 아니므로 named SSOT 상수로 둔다 (Magic Number 회피). *)
-let default_timeout_s = 120.0
+let default_timeout_s = 300.0
 
 let preset_size_ok (p : preset) =
   let n = List.length p.panel in

--- a/test/dune
+++ b/test/dune
@@ -127,6 +127,7 @@
   test_sse_stream
   test_health
   test_masc_oas_bridge_timeout_guard
+  test_fusion_oas_error_detail
   test_keeper_llm_bridge
   test_keeper_hooks_oas_log_shape
   test_keeper_idle_metric
@@ -425,6 +426,7 @@
   test_sse_stream
   test_health
   test_masc_oas_bridge_timeout_guard
+  test_fusion_oas_error_detail
   test_keeper_llm_bridge
   test_keeper_hooks_oas_log_shape
   test_keeper_idle_metric

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -17,8 +17,8 @@ let base_policy : Fusion_policy.t =
         ; judge = "a"
         ; panel_system_prompt = "panel"
         ; judge_system_prompt = "judge"
-        ; panel_timeout_s = 120.0
-        ; judge_timeout_s = 120.0
+        ; panel_timeout_s = 300.0
+        ; judge_timeout_s = 300.0
         ; web_tools = false
         ; max_tool_calls_per_panel = 0
         }
@@ -307,8 +307,8 @@ panel = [
 judge = "deepseek.deepseek-v4-pro"
 panel_system_prompt = "answer independently"
 judge_system_prompt = "synthesize the panel"
-panel_timeout_s = 120.0
-judge_timeout_s = 120.0
+panel_timeout_s = 300.0
+judge_timeout_s = 300.0
 |}
 
 let test_config_disabled_with_preset () =

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -1,5 +1,31 @@
 open Masc
 
+let contains substring s =
+  let sub_len = String.length substring in
+  let str_len = String.length s in
+  let rec aux i =
+    if i + sub_len > str_len
+    then false
+    else if String.sub s i sub_len = substring
+    then true
+    else aux (i + 1)
+  in
+  if sub_len = 0 then true else aux 0
+;;
+
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+;;
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+;;
+
 let test_rewrites_unknown_provider () =
   let detail =
     Fusion_oas.provider_error_detail ~runtime_id:"ollama_cloud.kimi-k2-6"
@@ -33,6 +59,14 @@ let test_keeps_already_attributed_error () =
     detail
 ;;
 
+let test_timeout_budget_does_not_set_total_execution_ceiling () =
+  let source = read_file (Filename.concat (repo_root ()) "lib/fusion/fusion_oas.ml") in
+  Alcotest.(check bool)
+    "fusion structural budget must not map to OAS max_execution_time_s"
+    false
+    (contains "max_execution_time_s = Some timeout_s" source)
+;;
+
 let () =
   Alcotest.run
     "Fusion_oas_error_detail"
@@ -49,6 +83,10 @@ let () =
             "keeps already attributed error"
             `Quick
             test_keeps_already_attributed_error
+        ; Alcotest.test_case
+            "timeout budget does not arm OAS total execution ceiling"
+            `Quick
+            test_timeout_budget_does_not_set_total_execution_ceiling
         ] )
     ]
 ;;

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -1,0 +1,54 @@
+open Masc
+
+let test_rewrites_unknown_provider () =
+  let detail =
+    Fusion_oas.provider_error_detail ~runtime_id:"ollama_cloud.kimi-k2-6"
+      "Provider 'unknown' timeout phase=http_operation: HTTP operation exceeded wall-clock timeout"
+  in
+  Alcotest.(check string)
+    "unknown provider replaced with runtime id"
+    "Provider 'ollama_cloud.kimi-k2-6' timeout phase=http_operation: HTTP operation exceeded wall-clock timeout"
+    detail
+;;
+
+let test_prefixes_unattributed_provider_error () =
+  let detail =
+    Fusion_oas.provider_error_detail ~runtime_id:"ollama_cloud.minimax-m3"
+      "HTTP 503 from provider"
+  in
+  Alcotest.(check string)
+    "runtime context prefixed"
+    "ollama_cloud.minimax-m3: HTTP 503 from provider"
+    detail
+;;
+
+let test_keeps_already_attributed_error () =
+  let detail =
+    Fusion_oas.provider_error_detail ~runtime_id:"ollama_cloud.minimax-m3"
+      "Provider 'ollama_cloud.minimax-m3' timeout phase=http_operation"
+  in
+  Alcotest.(check string)
+    "already attributed"
+    "Provider 'ollama_cloud.minimax-m3' timeout phase=http_operation"
+    detail
+;;
+
+let () =
+  Alcotest.run
+    "Fusion_oas_error_detail"
+    [ ( "provider attribution"
+      , [ Alcotest.test_case
+            "rewrites unknown provider"
+            `Quick
+            test_rewrites_unknown_provider
+        ; Alcotest.test_case
+            "prefixes unattributed provider error"
+            `Quick
+            test_prefixes_unattributed_provider_error
+        ; Alcotest.test_case
+            "keeps already attributed error"
+            `Quick
+            test_keeps_already_attributed_error
+        ] )
+    ]
+;;

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -1,29 +1,19 @@
 open Masc
 
-let contains substring s =
-  let sub_len = String.length substring in
-  let str_len = String.length s in
-  let rec aux i =
-    if i + sub_len > str_len
-    then false
-    else if String.sub s i sub_len = substring
-    then true
-    else aux (i + 1)
-  in
-  if sub_len = 0 then true else aux 0
+let provider_cfg () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.Anthropic
+    ~model_id:"fusion-test"
+    ~base_url:"http://localhost"
+    ()
 ;;
 
-let repo_root () =
-  match Sys.getenv_opt "DUNE_SOURCEROOT" with
-  | Some root -> root
-  | None -> Sys.getcwd ()
-;;
-
-let read_file path =
-  let ic = open_in path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () -> really_input_string ic (in_channel_length ic))
+let runtime_config () =
+  Runtime_agent.default_config
+    ~name:"fusion-test"
+    ~provider_cfg:(provider_cfg ())
+    ~system_prompt:""
+    ~tools:[]
 ;;
 
 let test_rewrites_unknown_provider () =
@@ -60,11 +50,23 @@ let test_keeps_already_attributed_error () =
 ;;
 
 let test_timeout_budget_does_not_set_total_execution_ceiling () =
-  let source = read_file (Filename.concat (repo_root ()) "lib/fusion/fusion_oas.ml") in
-  Alcotest.(check bool)
-    "fusion structural budget must not map to OAS max_execution_time_s"
-    false
-    (contains "max_execution_time_s = Some timeout_s" source)
+  let config =
+    Fusion_oas.For_testing.apply_timeout_budget
+      ~timeout_s:300.0
+      (runtime_config ())
+  in
+  Alcotest.(check (option (float 0.001)))
+    "stream idle timeout"
+    (Some 300.0)
+    config.stream_idle_timeout_s;
+  Alcotest.(check (option (float 0.001)))
+    "body timeout"
+    (Some 300.0)
+    config.body_timeout_s;
+  Alcotest.(check (option (float 0.001)))
+    "no total execution ceiling"
+    None
+    config.max_execution_time_s
 ;;
 
 let () =


### PR DESCRIPTION
## Summary

- pass Fusion preset timeout budgets into OAS panel/judge agent config for transport idle/body budgets
- keep Fusion structural wall-clock ownership outside OAS `max_execution_time_s`, avoiding active stream kills with misleading attribution
- preserve Fusion runtime ids in provider error details, replacing unknown-provider messages at the MASC display boundary
- raise the default/seed Fusion panel and judge timeout from 120s to 300s
- add regression coverage for Fusion provider error attribution and the no-total-execution-ceiling mapping

## Boundary note

This stays MASC-local: Fusion owns panel/judge runtime ids and preset budgets, while OAS still owns provider transport behavior. The remaining generic transport gap is tracked separately in jeong-sik/oas#2163: configurable connect/initial-response-header timeout for OpenAI-compatible transports.

## Validation

- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build @check test/test_fusion_oas_error_detail.exe test/fusion_core/test_fusion.exe`
- `./_build/default/test/test_fusion_oas_error_detail.exe`
- `./_build/default/test/fusion_core/test_fusion.exe`
- `ocamlformat --check lib/fusion/fusion_judge.ml lib/fusion/fusion_oas.ml lib/fusion/fusion_oas.mli lib/fusion/fusion_panel.ml lib/fusion_core/fusion_policy.ml test/fusion_core/test_fusion.ml test/test_fusion_oas_error_detail.ml`
- `bash scripts/ci/check-tla-harness-coverage.sh`
- direct TLC: `CompletionAuthority.cfg` clean pass; `CompletionAuthority-buggy.cfg` expected invariant violation exit 12
- `scripts/check-oas-pin.sh --local-only`
- `git diff --check`