### PR TITLE
Fix scheduled automation approval and dashboard readiness

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1759,6 +1759,9 @@ export interface DashboardScheduledAutomationExecution {
 export interface DashboardScheduledAutomationRequest {
   schedule_id: string
   status: string
+  effective_status?: string
+  execution_readiness?: string
+  operator_action?: string | null
   risk_class: string
   approval_required: boolean
   source: string

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -15,9 +15,14 @@ function automationTone(status: string | null | undefined): StatusChipTone {
   switch (status) {
     case 'running':
     case 'scheduled':
+    case 'ready':
+    case 'approved':
       return 'ok'
     case 'pending_approval':
     case 'due':
+    case 'blocked_approval':
+    case 'awaiting_approval':
+    case 'due_pending_refresh':
       return 'warn'
     case 'failed':
     case 'rejected':
@@ -71,12 +76,20 @@ function lastExecutionLabel(request: DashboardScheduledAutomationRequest): strin
 }
 
 function ScheduleRow({ request }: { request: DashboardScheduledAutomationRequest }) {
+  const effectiveStatus = request.effective_status ?? request.status
+  const readiness = request.execution_readiness ?? '-'
+  const action = request.operator_action ?? '-'
   return html`
     <tr class="v2-lab-row border-t border-[var(--color-border-default)]">
       <td class="py-2 pr-3 font-mono text-xs text-[var(--color-fg-secondary)]">${request.schedule_id}</td>
       <td class="py-2 pr-3">
-        <${StatusChip} tone=${automationTone(request.status)} uppercase=${false}>${enumLabel(request.status)}<//>
+        <${StatusChip} tone=${automationTone(effectiveStatus)} uppercase=${false}>${enumLabel(effectiveStatus)}<//>
+        ${effectiveStatus !== request.status
+          ? html`<div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">raw ${enumLabel(request.status)}</div>`
+          : null}
       </td>
+      <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${enumLabel(readiness)}</td>
+      <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${enumLabel(action)}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${enumLabel(request.risk_class)}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${request.payload_kind ?? '-'}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${recurrenceLabel(request)}</td>
@@ -104,6 +117,9 @@ export function ScheduledAutomationPanel({
     .filter(([, count]) => count > 0)
   const rows = automation.requests ?? []
   const dueEffective = automation.derived_counts?.due_effective ?? 0
+  const blockedApproval = automation.derived_counts?.blocked_approval ?? 0
+  const dueExecutionReady = automation.derived_counts?.due_execution_ready ?? 0
+  const expiredEffective = automation.derived_counts?.expired_effective ?? 0
 
   return html`
     <div class="grid gap-4">
@@ -122,6 +138,15 @@ export function ScheduledAutomationPanel({
         </span>
         <span class="text-[var(--color-fg-muted)]">
           due effective <span class="font-mono text-[var(--color-fg-secondary)]">${dueEffective.toLocaleString()}</span>
+        </span>
+        <span class="text-[var(--color-fg-muted)]">
+          blocked <span class="font-mono text-[var(--color-fg-secondary)]">${blockedApproval.toLocaleString()}</span>
+        </span>
+        <span class="text-[var(--color-fg-muted)]">
+          ready <span class="font-mono text-[var(--color-fg-secondary)]">${dueExecutionReady.toLocaleString()}</span>
+        </span>
+        <span class="text-[var(--color-fg-muted)]">
+          expired <span class="font-mono text-[var(--color-fg-secondary)]">${expiredEffective.toLocaleString()}</span>
         </span>
         <span class="text-[var(--color-fg-muted)]">
           next due <span class="font-mono text-[var(--color-fg-secondary)]">${formatDateTimeKo(automation.fsm.next_due_at ?? null)}</span>
@@ -143,6 +168,8 @@ export function ScheduledAutomationPanel({
                   <tr>
                     <th class="pb-2 pr-3 font-medium">schedule</th>
                     <th class="pb-2 pr-3 font-medium">status</th>
+                    <th class="pb-2 pr-3 font-medium">readiness</th>
+                    <th class="pb-2 pr-3 font-medium">action</th>
                     <th class="pb-2 pr-3 font-medium">risk</th>
                     <th class="pb-2 pr-3 font-medium">payload</th>
                     <th class="pb-2 pr-3 font-medium">recurrence</th>

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -115,9 +115,14 @@ describe('Tools', () => {
         request_limit: 20,
         truncated: false,
         counts: { pending_approval: 1 },
-        derived_counts: { due_effective: 0 },
+        derived_counts: {
+          due_effective: 0,
+          blocked_approval: 1,
+          due_execution_ready: 0,
+          expired_effective: 0,
+        },
         fsm: {
-          state: 'pending_approval',
+          state: 'blocked_approval',
           active_count: 1,
           terminal_count: 0,
           next_due_at: '2026-06-13T01:00:00Z',
@@ -126,6 +131,9 @@ describe('Tools', () => {
           {
             schedule_id: 'sched-1',
             status: 'pending_approval',
+            effective_status: 'blocked_approval',
+            execution_readiness: 'blocked_approval',
+            operator_action: 'approve_or_reject',
             risk_class: 'workspace_write',
             approval_required: true,
             source: 'operator_request',
@@ -148,7 +156,9 @@ describe('Tools', () => {
     render(html`<${Tools} />`, container)
     await flush()
 
-    expect(container.textContent).toContain('pending approval')
+    expect(container.textContent).toContain('blocked approval')
+    expect(container.textContent).toContain('raw pending approval')
+    expect(container.textContent).toContain('approve or reject')
     expect(container.textContent).toContain('sched-1')
     expect(container.textContent).toContain('workspace write')
     expect(container.textContent).toContain('09:30:00 Asia/Seoul')

--- a/lib/schedule/schedule_domain.ml
+++ b/lib/schedule/schedule_domain.ml
@@ -227,7 +227,7 @@ let grant_error_to_string = function
   | Approver_is_requester -> "requester cannot approve execution"
   | Approver_is_scheduler -> "scheduler cannot approve execution"
   | Schedule_terminal -> "schedule is already terminal"
-  | Schedule_not_pending_approval -> "schedule is not pending approval"
+  | Schedule_not_pending_approval -> "schedule is not pending approval or due"
   | Evidence_schedule_id_mismatch -> "grant evidence schedule_id mismatch"
   | Evidence_payload_digest_mismatch -> "grant evidence payload_digest mismatch"
   | Evidence_due_at_mismatch -> "grant evidence due_at mismatch"
@@ -775,7 +775,8 @@ let create_execution_grant
 let validate_execution_grant (request : schedule_request) (grant : execution_grant) =
   if grant.schedule_id <> request.schedule_id then Error Grant_schedule_id_mismatch
   else if is_terminal request.status then Error Schedule_terminal
-  else if request.status <> Pending_approval then Error Schedule_not_pending_approval
+  else if request.status <> Pending_approval && request.status <> Due then
+    Error Schedule_not_pending_approval
   else if requires_separate_human_grant request && grant.approved_by.kind <> Human_operator
   then Error Approver_not_human
   else if requires_separate_human_grant request
@@ -800,12 +801,34 @@ let validate_execution_grant (request : schedule_request) (grant : execution_gra
 let apply_execution_grant (request : schedule_request) (grant : execution_grant) =
   let* () = validate_execution_grant request grant in
   match grant.decision with
-  | Approve -> Ok { request with status = Scheduled }
+  | Approve ->
+    let status =
+      match request.status with
+      | Pending_approval -> Scheduled
+      | Due -> Due
+      | Scheduled
+      | Running
+      | Succeeded
+      | Failed
+      | Rejected
+      | Cancelled
+      | Expired ->
+        request.status
+    in
+    Ok { request with status }
   | Reject _ -> Ok { request with status = Rejected }
+;;
+
+let expired_at ~now (request : schedule_request) =
+  match request.expires_at with
+  | Some expires_at when expires_at <= now -> true
+  | None | Some _ -> false
 ;;
 
 let mark_due ~now (request : schedule_request) =
   match request.status with
+  | Pending_approval | Scheduled | Due when expired_at ~now request ->
+    { request with status = Expired }
   | Scheduled when request.due_at <= now -> { request with status = Due }
   | _ -> request
 ;;

--- a/lib/schedule/schedule_domain.mli
+++ b/lib/schedule/schedule_domain.mli
@@ -170,6 +170,9 @@ val apply_execution_grant :
   schedule_request -> execution_grant -> (schedule_request, grant_error) result
 
 val mark_due : now:float -> schedule_request -> schedule_request
+(** Observes time for active requests. [Pending_approval], [Scheduled], and
+    [Due] requests whose [expires_at <= now] become [Expired]; otherwise
+    [Scheduled] requests whose [due_at <= now] become [Due]. *)
 
 val actor_kind_to_string : actor_kind -> string
 val actor_kind_of_string : string -> (actor_kind, string) result

--- a/lib/schedule/schedule_runner.ml
+++ b/lib/schedule/schedule_runner.ml
@@ -236,9 +236,13 @@ let candidate_signals ~now state =
 let blocked_approval_signals ~now (state : Schedule_store.state) =
   state.schedules
   |> List.filter (fun (request : Schedule_domain.schedule_request) ->
-    request.status = Pending_approval
-    && request.due_at <= now
-    && Schedule_domain.requires_separate_human_grant request)
+    request.due_at <= now
+    && Schedule_domain.requires_separate_human_grant request
+    &&
+    match request.status with
+    | Pending_approval -> true
+    | Due -> not (Schedule_store.has_current_approved_grant state request)
+    | Scheduled | Running | Succeeded | Failed | Rejected | Cancelled | Expired -> false)
   |> List.map (make_signal ~now Due_blocked_approval)
 ;;
 
@@ -268,7 +272,16 @@ let dispatch_candidate config ~now consumer (request : Schedule_domain.schedule_
   let schedule_id = request.Schedule_domain.schedule_id in
   match consumer.accepts request with
   | Error reason ->
-    dispatch_result ~error:reason schedule_id Dispatch_unsupported
+    (match Schedule_store.fail_due_candidate config ~now ~schedule_id ~error:reason with
+     | Ok _ -> dispatch_result ~error:reason schedule_id Dispatch_unsupported
+     | Error err ->
+       let error =
+         Printf.sprintf
+           "%s; failed to mark schedule failed: %s"
+           reason
+           (Schedule_store.store_error_to_string err)
+       in
+       dispatch_result ~error schedule_id Dispatch_unsupported)
   | Ok () ->
     (match Schedule_store.start_due_candidate config ~now ~schedule_id with
      | Error err ->

--- a/lib/schedule/schedule_runner.mli
+++ b/lib/schedule/schedule_runner.mli
@@ -73,4 +73,6 @@ val tick :
 (** Refresh due state and append at-most-once generic wake signals for newly
     observable due work or due approval blockers. Recurring due work is advanced
     after the generic due signal path succeeds when no consumer is installed; a
-    consumer dispatch can instead complete/fail the request. *)
+    consumer dispatch can instead complete/fail the request. Consumer payload
+    rejection is recorded as a failed execution instead of leaving the request
+    due forever. *)

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -268,15 +268,23 @@ let grant_exists state grant_id =
     state.grants
 ;;
 
-let has_approved_grant state schedule_id =
+let grant_matches_current_request (request : schedule_request) (grant : execution_grant) =
+  let expected = Schedule_domain.evidence_of_request request in
+  String.equal grant.schedule_id request.schedule_id
+  &&
+  match grant.decision with
+  | Reject _ -> false
+  | Approve ->
+    String.equal grant.evidence.schedule_id expected.schedule_id
+    && String.equal grant.evidence.payload_digest expected.payload_digest
+    && grant.evidence.due_at = expected.due_at
+    && grant.evidence.risk_class = expected.risk_class
+;;
+
+let has_current_approved_grant state (request : schedule_request) =
   List.exists
     (fun (grant : execution_grant) ->
-      let grant_matches = String.equal grant.schedule_id schedule_id in
-      grant_matches
-      &&
-      (match grant.decision with
-       | Approve -> true
-       | Reject _ -> false))
+      grant_matches_current_request request grant)
     state.grants
 ;;
 
@@ -284,7 +292,7 @@ let is_due_execution_candidate state (request : schedule_request) =
   match request.status with
   | Due ->
     (not (requires_separate_human_grant request))
-    || has_approved_grant state request.schedule_id
+    || has_current_approved_grant state request
   | Pending_approval | Scheduled | Running | Succeeded | Failed | Rejected | Cancelled
   | Expired ->
     false
@@ -560,6 +568,30 @@ let fail_running config ~now ~schedule_id ~error =
                ; error = Some error
                })
         in
+        let next_state = bump_state state ~schedules ~grants:state.grants ~executions in
+        write_state config next_state;
+        Ok updated)
+;;
+
+let fail_due_candidate config ~now ~schedule_id ~error =
+  Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
+    let* state = load_for_mutation config in
+    match find_schedule state schedule_id with
+    | None -> Error Schedule_not_found
+    | Some request ->
+      if not (is_due_execution_candidate state request) then
+        Error Schedule_not_due_candidate
+      else
+        let updated = { request with status = Failed } in
+        let execution =
+          { (make_execution_record ~now request) with
+            status = Execution_failed
+          ; finished_at = Some now
+          ; error = Some error
+          }
+        in
+        let schedules = replace_schedule state.schedules updated in
+        let executions = execution :: state.executions in
         let next_state = bump_state state ~schedules ~grants:state.grants ~executions in
         write_state config next_state;
         Ok updated)

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -130,6 +130,23 @@ val fail_running :
   (Schedule_domain.schedule_request, store_error) result
 (** Marks a [Running] request and its matching execution attempt [Failed]. *)
 
+val fail_due_candidate :
+  Workspace_utils.config ->
+  now:float ->
+  schedule_id:string ->
+  error:string ->
+  (Schedule_domain.schedule_request, store_error) result
+(** Atomically marks an approved [Due] request [Failed] and records the failed
+    execution attempt. This is used when a runner-side consumer rejects the
+    payload before work starts, so the schedule does not remain due forever. *)
+
 val due_execution_candidates :
   state -> Schedule_domain.schedule_request list
 (** Returns only due requests that are no longer pending approval. *)
+
+val has_current_approved_grant :
+  state -> Schedule_domain.schedule_request -> bool
+(** Whether [state] contains an approved grant whose evidence matches the
+    request's current [schedule_id], payload digest, [risk_class], and [due_at].
+    Recurring requests therefore need fresh approval for each new occurrence
+    when they require a separate human grant. *)

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1727,7 +1727,20 @@ let schedule_request_active (request : Schedule_domain.schedule_request) =
   not (Schedule_domain.is_terminal request.status)
 ;;
 
+let schedule_effectively_expired ~now (request : Schedule_domain.schedule_request) =
+  match request.status, request.expires_at with
+  | (Schedule_domain.Pending_approval | Schedule_domain.Scheduled | Schedule_domain.Due), Some expires_at
+    when expires_at <= now -> true
+  | _ -> false
+;;
+
+let schedule_request_effectively_active ~now request =
+  schedule_request_active request && not (schedule_effectively_expired ~now request)
+;;
+
 let schedule_effectively_due ~now (request : Schedule_domain.schedule_request) =
+  (not (schedule_effectively_expired ~now request))
+  &&
   match request.status with
   | Schedule_domain.Due -> true
   | Schedule_domain.Scheduled -> request.due_at <= now
@@ -1754,9 +1767,10 @@ let schedule_due_candidate (request : Schedule_domain.schedule_request) =
     false
 ;;
 
-let schedule_next_due_at schedules =
+let schedule_next_due_at ~now schedules =
   schedules
-  |> List.filter schedule_due_candidate
+  |> List.filter (fun request ->
+    schedule_due_candidate request && not (schedule_effectively_expired ~now request))
   |> List.fold_left
        (fun acc (request : Schedule_domain.schedule_request) ->
          match acc with
@@ -1765,21 +1779,108 @@ let schedule_next_due_at schedules =
        None
 ;;
 
-let schedule_fsm_state ~now schedules =
+let schedule_blocked_approval ~now state (request : Schedule_domain.schedule_request) =
+  (not (schedule_effectively_expired ~now request))
+  && request.due_at <= now
+  && Schedule_domain.requires_separate_human_grant request
+  &&
+  match request.status with
+  | Schedule_domain.Pending_approval -> true
+  | Schedule_domain.Due -> not (Schedule_store.has_current_approved_grant state request)
+  | Schedule_domain.Scheduled
+  | Schedule_domain.Running
+  | Schedule_domain.Succeeded
+  | Schedule_domain.Failed
+  | Schedule_domain.Rejected
+  | Schedule_domain.Cancelled
+  | Schedule_domain.Expired ->
+    false
+;;
+
+let schedule_effective_status ~now state (request : Schedule_domain.schedule_request) =
+  if schedule_effectively_expired ~now request
+  then "expired"
+  else
+    match request.status with
+    | Schedule_domain.Pending_approval when request.due_at <= now -> "blocked_approval"
+    | Pending_approval -> "pending_approval"
+    | Scheduled when request.due_at <= now -> "due"
+    | Scheduled -> "scheduled"
+    | Due when schedule_blocked_approval ~now state request -> "blocked_approval"
+    | Due -> "ready"
+    | Running -> "running"
+    | Succeeded -> "succeeded"
+    | Failed -> "failed"
+    | Rejected -> "rejected"
+    | Cancelled -> "cancelled"
+    | Expired -> "expired"
+;;
+
+let schedule_execution_readiness ~now state (request : Schedule_domain.schedule_request) =
+  if schedule_effectively_expired ~now request
+  then "expired"
+  else if Schedule_domain.is_terminal request.status
+  then "terminal"
+  else if request.status = Schedule_domain.Running
+  then "running"
+  else if schedule_blocked_approval ~now state request
+  then "blocked_approval"
+  else if Schedule_store.has_current_approved_grant state request
+  then "approved"
+  else
+    match request.status with
+    | Schedule_domain.Pending_approval -> "awaiting_approval"
+    | Scheduled when request.due_at <= now -> "due_pending_refresh"
+    | Scheduled -> "scheduled"
+    | Due -> "ready"
+    | Running -> "running"
+    | Succeeded | Failed | Rejected | Cancelled | Expired -> "terminal"
+;;
+
+let schedule_operator_action ~now state (request : Schedule_domain.schedule_request) =
+  match schedule_execution_readiness ~now state request with
+  | "blocked_approval" | "awaiting_approval" -> `String "approve_or_reject"
+  | "due_pending_refresh" -> `String "wait_for_runner_tick"
+  | "expired" -> `String "inspect_or_recreate"
+  | "ready" | "approved" -> `String "wait_for_dispatch"
+  | "scheduled" | "running" | "terminal" -> `Null
+  | _ -> `Null
+;;
+
+let schedule_fsm_state ~now state schedules =
   let count status = schedule_status_count schedules status in
+  let count_non_expired status =
+    List.fold_left
+      (fun count (request : Schedule_domain.schedule_request) ->
+         if request.status = status && not (schedule_effectively_expired ~now request)
+         then count + 1
+         else count)
+      0 schedules
+  in
   let due_effective_count =
     List.fold_left
       (fun count request -> if schedule_effectively_due ~now request then count + 1 else count)
       0 schedules
   in
+  let blocked_approval_count =
+    List.fold_left
+      (fun count request ->
+         if schedule_blocked_approval ~now state request then count + 1 else count)
+      0 schedules
+  in
   if count Schedule_domain.Running > 0
   then "running"
-  else if count Schedule_domain.Pending_approval > 0
-  then "pending_approval"
+  else if blocked_approval_count > 0
+  then "blocked_approval"
   else if due_effective_count > 0
   then "due"
-  else if count Schedule_domain.Scheduled > 0
+  else if count_non_expired Schedule_domain.Pending_approval > 0
+  then "pending_approval"
+  else if count_non_expired Schedule_domain.Scheduled > 0
   then "scheduled"
+  else if
+    List.exists (fun request -> schedule_effectively_expired ~now request) schedules
+  then "expired"
   else "idle"
 ;;
 
@@ -1804,12 +1905,17 @@ let execution_record_dashboard_json (execution : Schedule_domain.execution_recor
 ;;
 
 let schedule_request_dashboard_json
+  ~now
+  ~state
   ?last_execution
   (request : Schedule_domain.schedule_request)
   =
   `Assoc
     [ "schedule_id", `String request.schedule_id
     ; "status", `String (Schedule_domain.schedule_status_to_string request.status)
+    ; "effective_status", `String (schedule_effective_status ~now state request)
+    ; "execution_readiness", `String (schedule_execution_readiness ~now state request)
+    ; "operator_action", schedule_operator_action ~now state request
     ; "risk_class", `String (Schedule_domain.risk_class_to_string request.risk_class)
     ; "approval_required", `Bool request.approval_required
     ; "source", `String (Schedule_domain.schedule_source_to_string request.source)
@@ -1843,14 +1949,33 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
   let schedules = state.schedules in
   let active_count =
     List.fold_left
-      (fun count request -> if schedule_request_active request then count + 1 else count)
+      (fun count request ->
+         if schedule_request_effectively_active ~now request then count + 1 else count)
       0 schedules
   in
   let terminal_count = List.length schedules - active_count in
+  let expired_effective_count =
+    List.fold_left
+      (fun count request ->
+         if schedule_effectively_expired ~now request then count + 1 else count)
+      0 schedules
+  in
   let due_effective_count =
     List.fold_left
       (fun count request -> if schedule_effectively_due ~now request then count + 1 else count)
       0 schedules
+  in
+  let blocked_approval_count =
+    List.fold_left
+      (fun count request ->
+         if schedule_blocked_approval ~now state request then count + 1 else count)
+      0 schedules
+  in
+  let due_execution_ready_count =
+    state
+    |> Schedule_store.due_execution_candidates
+    |> List.filter (fun request -> not (schedule_effectively_expired ~now request))
+    |> List.length
   in
   let sorted =
     schedules
@@ -1858,11 +1983,15 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
       match
         ( schedule_request_active left
         , schedule_request_active right
+        , schedule_request_effectively_active ~now left
+        , schedule_request_effectively_active ~now right
         , compare left.due_at right.due_at )
       with
-      | true, false, _ -> -1
-      | false, true, _ -> 1
-      | _, _, due_cmp when due_cmp <> 0 -> due_cmp
+      | _, _, true, false, _ -> -1
+      | _, _, false, true, _ -> 1
+      | true, false, _, _, _ -> -1
+      | false, true, _, _, _ -> 1
+      | _, _, _, _, due_cmp when due_cmp <> 0 -> due_cmp
       | _ -> String.compare left.schedule_id right.schedule_id)
   in
   let request_rows = take schedule_projection_request_limit sorted in
@@ -1874,13 +2003,19 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
     ; "request_limit", `Int schedule_projection_request_limit
     ; "truncated", `Bool (List.length schedules > schedule_projection_request_limit)
     ; "counts", schedule_counts_json schedules
-    ; "derived_counts", `Assoc [ "due_effective", `Int due_effective_count ]
+    ; ( "derived_counts"
+      , `Assoc
+          [ "due_effective", `Int due_effective_count
+          ; "blocked_approval", `Int blocked_approval_count
+          ; "due_execution_ready", `Int due_execution_ready_count
+          ; "expired_effective", `Int expired_effective_count
+          ] )
     ; ( "fsm"
       , `Assoc
-          [ "state", `String (schedule_fsm_state ~now schedules)
+          [ "state", `String (schedule_fsm_state ~now state schedules)
           ; "active_count", `Int active_count
           ; "terminal_count", `Int terminal_count
-          ; "next_due_at", unix_iso_option_json (schedule_next_due_at schedules)
+          ; "next_due_at", unix_iso_option_json (schedule_next_due_at ~now schedules)
           ] )
     ; ( "requests"
       , `List
@@ -1890,7 +2025,7 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
                   Schedule_store.last_execution_for_schedule state
                     ~schedule_id:request.Schedule_domain.schedule_id
                 in
-                schedule_request_dashboard_json ?last_execution request)
+                schedule_request_dashboard_json ~now ~state ?last_execution request)
              request_rows) )
     ]
 ;;

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -167,7 +167,7 @@ let cancel_schema =
 
 let approve_schema =
   object_schema ~required:[ "schedule_id"; "approved_by_id" ]
-    [ string_prop ~description:"Pending schedule id to approve." "schedule_id"
+    [ string_prop ~description:"Pending or due schedule id to approve." "schedule_id"
     ; string_prop ~description:"Human approver id; cannot equal requester or scheduler." "approved_by_id"
     ; string_prop ~description:"Approver display name." "approved_by_display_name"
     ; string_prop ~description:"Optional stable grant id." "grant_id"
@@ -177,7 +177,7 @@ let approve_schema =
 
 let reject_schema =
   object_schema ~required:[ "schedule_id"; "approved_by_id"; "reason" ]
-    [ string_prop ~description:"Pending schedule id to reject." "schedule_id"
+    [ string_prop ~description:"Pending or due schedule id to reject." "schedule_id"
     ; string_prop ~description:"Human approver id; cannot equal requester or scheduler." "approved_by_id"
     ; string_prop ~description:"Approver display name." "approved_by_display_name"
     ; string_prop ~description:"Optional stable grant id." "grant_id"
@@ -222,10 +222,10 @@ let definitions : definition list =
       ~input_schema:cancel_schema ~read_only:false
   ; definition ~action:Approve_request ~id:"approve" ~name:"masc_schedule_approve"
       ~description:
-        "Record a separate human execution grant for a pending scheduled request."
+        "Record a separate human execution grant for a pending or due scheduled request. Recurring side-effecting requests need a fresh grant for each due occurrence."
       ~input_schema:approve_schema ~read_only:false
   ; definition ~action:Reject_request ~id:"reject" ~name:"masc_schedule_reject"
-      ~description:"Reject a pending scheduled request with a human decision."
+      ~description:"Reject a pending or due scheduled request with a human decision."
       ~input_schema:reject_schema ~read_only:false
   ]
 ;;

--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -244,6 +244,8 @@ run_tlc "$REPO_ROOT/specs/state-product" "WorkspaceProduct.tla"
 run_tlc_buggy "$REPO_ROOT/specs/state-product" "WorkspaceProduct.tla"
 run_tlc "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
+run_tlc "$REPO_ROOT/specs/task-lifecycle" "CompletionAuthority.tla"
+run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "CompletionAuthority.tla"
 
 run_tlc "$REPO_ROOT/specs/goal-loop" "TierRouting.tla"
 run_tlc_buggy "$REPO_ROOT/specs/goal-loop" "TierRouting.tla"

--- a/test/dune
+++ b/test/dune
@@ -1147,17 +1147,17 @@
 (test
  (name test_schedule_store)
  (modules test_schedule_store)
- (libraries masc_test_deps masc_schedule))
+ (libraries alcotest eio eio_main fs_compat masc_workspace masc_schedule unix yojson))
 
 (test
  (name test_schedule_service)
  (modules test_schedule_service)
- (libraries masc_test_deps masc_schedule))
+ (libraries alcotest eio eio_main fs_compat masc_workspace masc_schedule unix yojson))
 
 (test
  (name test_schedule_runner)
  (modules test_schedule_runner)
- (libraries masc_test_deps masc_schedule))
+ (libraries alcotest eio eio_main fs_compat masc_workspace masc_schedule unix yojson))
 
 (test
  (name test_schedule_consumer_dispatch)

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -165,8 +165,19 @@ let test_board_post_consumer_rejects_read_only_risk () =
   (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
    | None -> fail "schedule missing"
    | Some stored ->
-     check string "schedule remains due" "due"
+     check string "schedule failed" "failed"
        (Schedule_domain.schedule_status_to_string stored.status));
+  (match
+     Schedule_store.last_execution_for_schedule (Schedule_store.read_state config)
+       ~schedule_id:request.schedule_id
+   with
+   | None -> fail "missing unsupported execution"
+   | Some execution ->
+     check string "execution failed" "failed"
+       (Schedule_domain.execution_status_to_string execution.status);
+     check (option string) "execution error"
+       (Some "masc.board_post requires a side-effecting risk_class")
+       execution.error);
   check int "no post" 0 (List.length (Board_dispatch.list_posts ~limit:10 ()))
 ;;
 

--- a/test/test_schedule_domain.ml
+++ b/test/test_schedule_domain.ml
@@ -116,6 +116,14 @@ let test_reject_grant_marks_rejected () =
   | Ok updated -> check_status "rejected schedule status" Rejected updated.status
 ;;
 
+let test_due_grant_keeps_request_due () =
+  let due = { (request ()) with status = Due } in
+  let grant = grant due in
+  match apply_execution_grant due grant with
+  | Error err -> fail (grant_error_to_string err)
+  | Ok updated -> check_status "due approval stays due" Due updated.status
+;;
+
 let test_requester_cannot_approve () =
   let requested_by = human "same-human" in
   let req = request ~requested_by () in
@@ -317,6 +325,8 @@ let () =
           test_case "separate human approval accepts" `Quick
             test_separate_human_approval_accepts;
           test_case "reject grant marks rejected" `Quick test_reject_grant_marks_rejected;
+          test_case "due grant keeps request due" `Quick
+            test_due_grant_keeps_request_due;
           test_case "requester cannot approve" `Quick test_requester_cannot_approve;
           test_case "scheduler cannot approve" `Quick test_scheduler_cannot_approve;
           test_case "automated actor cannot approve side-effecting" `Quick

--- a/test/test_schedule_runner.ml
+++ b/test/test_schedule_runner.ml
@@ -1,5 +1,4 @@
 open Alcotest
-open Masc
 open Schedule_domain
 open Schedule_runner
 open Schedule_service
@@ -32,8 +31,8 @@ let with_workspace f =
   Eio.Switch.run
   @@ fun sw ->
   Eio.Switch.on_release sw (fun () -> rm_rf dir);
-  let config = Workspace.default_config dir in
-  ignore (Workspace.init config ~agent_name:(Some "test"));
+  let config = Workspace_core.default_config dir in
+  ignore (Workspace_core.init config ~agent_name:(Some "test"));
   f config
 ;;
 
@@ -146,7 +145,7 @@ let test_tick_dispatches_due_candidate_to_success () =
       | _ -> fail "execution detail missing"))
 ;;
 
-let test_tick_leaves_unsupported_candidate_due () =
+let test_tick_marks_unsupported_candidate_failed () =
   with_workspace
   @@ fun config ->
   let calls = ref [] in
@@ -162,7 +161,23 @@ let test_tick_leaves_unsupported_candidate_due () =
   (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
    | None -> fail "schedule missing after unsupported"
    | Some stored ->
-     check string "still due" "due" (schedule_status_to_string stored.status))
+     check string "stored failed" "failed" (schedule_status_to_string stored.status));
+  (match
+     Schedule_store.last_execution_for_schedule (Schedule_store.read_state config)
+       ~schedule_id:request.schedule_id
+   with
+   | None -> fail "missing unsupported execution"
+   | Some execution ->
+     check string "unsupported execution status" "failed"
+       (Schedule_domain.execution_status_to_string execution.status);
+     check (option string) "unsupported execution error" (Some "unsupported")
+       execution.error);
+  let repeated =
+    tick_ok config ~now:202.0
+      ~consumer:(accepting_consumer ~accept:(Error "unsupported") calls)
+  in
+  check int "unsupported does not dispatch repeatedly" 0
+    (List.length repeated.dispatches)
 ;;
 
 let test_tick_emits_approval_blocker_then_candidate_after_grant () =
@@ -245,6 +260,54 @@ let test_tick_dispatches_recurring_candidate_to_next_due () =
      check (float 0.001) "recurring execution due" 200.0 execution.due_at)
 ;;
 
+let test_tick_blocks_recurring_side_effect_until_fresh_grant () =
+  with_workspace
+  @@ fun config ->
+  let calls = ref [] in
+  let request =
+    create_ok ~schedule_id:"write-loop-dispatch-1" ~risk_class:Workspace_write
+      ~recurrence:(Interval { interval_sec = 60 })
+      config
+  in
+  (match
+     approve config ~grant_id:"grant-loop-1" ~approved_at:150.0
+       ~schedule_id:request.schedule_id ~approved_by:(human "approver-1") ()
+   with
+   | Ok _ -> ()
+   | Error err -> fail (service_error_to_string err));
+  let first =
+    tick_ok config ~now:201.0 ~consumer:(accepting_consumer calls)
+  in
+  check int "first dispatch" 1 (List.length first.dispatches);
+  check Alcotest.(list string) "first consumer call" [ request.schedule_id ] !calls;
+  (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+   | None -> fail "schedule missing after first dispatch"
+   | Some stored ->
+     check string "stored scheduled after first dispatch" "scheduled"
+       (schedule_status_to_string stored.status);
+     check (float 0.001) "second due_at" 260.0 stored.due_at);
+  let blocked =
+    tick_ok config ~now:260.0 ~consumer:(accepting_consumer calls)
+  in
+  check int "blocked signal" 1 (List.length blocked.emitted);
+  check_kind "blocked kind" Due_blocked_approval (List.hd blocked.emitted).kind;
+  check int "no stale-grant dispatch" 0 (List.length blocked.dispatches);
+  check Alcotest.(list string) "no second consumer call yet" [ request.schedule_id ] !calls;
+  (match
+     approve config ~grant_id:"grant-loop-2" ~approved_at:260.5
+       ~schedule_id:request.schedule_id ~approved_by:(human "approver-2") ()
+   with
+   | Ok stored -> check string "fresh grant keeps due" "due" (schedule_status_to_string stored.status)
+   | Error err -> fail (service_error_to_string err));
+  let second =
+    tick_ok config ~now:261.0 ~consumer:(accepting_consumer calls)
+  in
+  check int "second dispatch" 1 (List.length second.dispatches);
+  check Alcotest.(list string) "second consumer call"
+    [ request.schedule_id; request.schedule_id ]
+    !calls
+;;
+
 let test_tick_marks_dispatch_failure_failed () =
   with_workspace
   @@ fun config ->
@@ -279,14 +342,16 @@ let () =
             test_tick_emits_due_candidate_once
         ; test_case "dispatches due candidate to success" `Quick
             test_tick_dispatches_due_candidate_to_success
-        ; test_case "leaves unsupported candidate due" `Quick
-            test_tick_leaves_unsupported_candidate_due
+        ; test_case "marks unsupported candidate failed" `Quick
+            test_tick_marks_unsupported_candidate_failed
         ; test_case "emits approval blocker then candidate after grant" `Quick
             test_tick_emits_approval_blocker_then_candidate_after_grant
         ; test_case "reschedules recurring candidate after signal" `Quick
             test_tick_reschedules_recurring_candidate_after_signal
         ; test_case "dispatches recurring candidate to next due" `Quick
             test_tick_dispatches_recurring_candidate_to_next_due
+        ; test_case "blocks recurring side-effect until fresh grant" `Quick
+            test_tick_blocks_recurring_side_effect_until_fresh_grant
         ; test_case "marks dispatch failure failed" `Quick
             test_tick_marks_dispatch_failure_failed
         ] )

--- a/test/test_schedule_service.ml
+++ b/test/test_schedule_service.ml
@@ -1,5 +1,4 @@
 open Alcotest
-open Masc
 open Schedule_domain
 open Schedule_service
 
@@ -31,8 +30,8 @@ let with_workspace f =
   Eio.Switch.run
   @@ fun sw ->
   Eio.Switch.on_release sw (fun () -> rm_rf dir);
-  let config = Workspace.default_config dir in
-  ignore (Workspace.init config ~agent_name:(Some "test"));
+  let config = Workspace_core.default_config dir in
+  ignore (Workspace_core.init config ~agent_name:(Some "test"));
   f config
 ;;
 

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -1,5 +1,4 @@
 open Alcotest
-open Masc
 open Schedule_domain
 open Schedule_store
 
@@ -31,8 +30,8 @@ let with_workspace f =
   Eio.Switch.run
   @@ fun sw ->
   Eio.Switch.on_release sw (fun () -> rm_rf dir);
-  let config = Workspace.default_config dir in
-  ignore (Workspace.init config ~agent_name:(Some "test"));
+  let config = Workspace_core.default_config dir in
+  ignore (Workspace_core.init config ~agent_name:(Some "test"));
   f config
 ;;
 
@@ -49,13 +48,14 @@ let payload_json () =
 let make_request
   ?(schedule_id = "sched-1")
   ?(risk_class = Workspace_write)
+  ?expires_at
   ?recurrence
   ()
   =
   match
     create_request ~schedule_id ~requested_by:(human "requester")
       ~scheduled_by:(human "scheduler") ~requested_at:100.0 ~due_at:200.0
-      ~payload:(payload_json ()) ~risk_class ~approval_required:false
+      ?expires_at ~payload:(payload_json ()) ~risk_class ~approval_required:false
       ~source:Operator_request ?recurrence ()
   with
   | Ok request -> request
@@ -194,6 +194,44 @@ let test_read_only_due_candidate_does_not_need_grant () =
     (List.length (due_execution_candidates (read_state config)))
 ;;
 
+let test_refresh_due_expires_pending_scheduled_and_due () =
+  with_workspace
+  @@ fun config ->
+  let pending =
+    make_request ~schedule_id:"expire-pending" ~risk_class:Workspace_write
+      ~expires_at:150.0 ()
+  in
+  let scheduled =
+    make_request ~schedule_id:"expire-scheduled" ~risk_class:Read_only
+      ~expires_at:150.0 ()
+  in
+  let due =
+    make_request ~schedule_id:"expire-due" ~risk_class:Read_only
+      ~expires_at:250.0 ()
+  in
+  ignore (insert_ok config pending);
+  ignore (insert_ok config scheduled);
+  ignore (insert_ok config due);
+  (match refresh_due config ~now:201.0 with
+   | Ok (_, changed) -> check int "pending expired, scheduled expired, due marked" 3 changed
+   | Error err -> fail (store_error_to_string err));
+  (match refresh_due config ~now:251.0 with
+   | Ok (_, changed) -> check int "due expired" 1 changed
+   | Error err -> fail (store_error_to_string err));
+  (match
+     get_schedule config ~schedule_id:"expire-pending",
+     get_schedule config ~schedule_id:"expire-scheduled",
+     get_schedule config ~schedule_id:"expire-due"
+   with
+   | Some pending, Some scheduled, Some due ->
+     check_status "pending expired" Expired pending.status;
+     check_status "scheduled expired" Expired scheduled.status;
+     check_status "due expired" Expired due.status;
+     check int "expired schedules are not due candidates" 0
+       (List.length (due_execution_candidates (read_state config)))
+   | _ -> fail "expired schedules missing")
+;;
+
 let test_reschedule_due_recurring_advances_only_matching_recurring_rows () =
   with_workspace
   @@ fun config ->
@@ -230,7 +268,7 @@ let test_recovers_from_last_good () =
   @@ fun config ->
   let req = make_request ~risk_class:Read_only () in
   ignore (insert_ok config req);
-  Workspace.write_text config (schedules_path config) "{not json";
+  Workspace_core.write_text config (schedules_path config) "{not json";
   let recovered = read_state config in
   check int "recovered schedule" 1 (List.length recovered.schedules)
 ;;
@@ -242,8 +280,8 @@ let recovery_path config = schedules_path config ^ ".last-good"
    with non-JSON to simulate out-of-band corruption (e.g. partial write / schema
    evolution). *)
 let corrupt_both config =
-  Workspace.write_text config (schedules_path config) "{not json";
-  Workspace.write_text config (recovery_path config) "}also not json"
+  Workspace_core.write_text config (schedules_path config) "{not json";
+  Workspace_core.write_text config (recovery_path config) "}also not json"
 ;;
 
 let test_load_fresh_when_file_absent () =
@@ -306,6 +344,84 @@ let test_start_and_complete_persist_execution_record () =
      | _ -> fail "detail missing")
 ;;
 
+let test_fail_due_candidate_records_failed_execution () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request ~schedule_id:"unsupported-1" ~risk_class:Read_only () in
+  ignore (insert_ok config req);
+  (match refresh_due config ~now:201.0 with
+   | Ok (_, changed) -> check int "became due" 1 changed
+   | Error err -> fail (store_error_to_string err));
+  (match
+     fail_due_candidate config ~now:202.0 ~schedule_id:req.schedule_id
+       ~error:"unsupported payload"
+   with
+   | Ok stored -> check_status "failed" Failed stored.status
+   | Error err -> fail (store_error_to_string err));
+  (match get_schedule config ~schedule_id:req.schedule_id with
+   | Some stored -> check_status "stored failed" Failed stored.status
+   | None -> fail "schedule missing");
+  (match
+     last_execution_for_schedule (read_state config) ~schedule_id:req.schedule_id
+   with
+   | None -> fail "missing failed execution"
+   | Some execution ->
+     check string "failed execution status" "failed"
+       (execution_status_to_string execution.status);
+     check (option string) "failed execution error" (Some "unsupported payload")
+       execution.error;
+     check (option (float 0.001)) "finished at" (Some 202.0)
+       execution.finished_at)
+;;
+
+let test_recurring_grant_is_scoped_to_current_due_at () =
+  with_workspace
+  @@ fun config ->
+  let req =
+    make_request ~schedule_id:"write-loop-1" ~risk_class:Workspace_write
+      ~recurrence:(Interval { interval_sec = 60 })
+      ()
+  in
+  ignore (insert_ok config req);
+  (match record_grant config (grant req) with
+   | Ok stored -> check_status "approved first occurrence" Scheduled stored.status
+   | Error err -> fail (store_error_to_string err));
+  (match refresh_due config ~now:201.0 with
+   | Ok (_, changed) -> check int "first due" 1 changed
+   | Error err -> fail (store_error_to_string err));
+  check int "first occurrence candidate" 1
+    (List.length (due_execution_candidates (read_state config)));
+  (match start_due_candidate config ~now:202.0 ~schedule_id:req.schedule_id with
+   | Ok running -> check_status "running first occurrence" Running running.status
+   | Error err -> fail (store_error_to_string err));
+  (match complete_running config ~now:203.0 ~schedule_id:req.schedule_id () with
+   | Ok stored ->
+     check_status "rescheduled" Scheduled stored.status;
+     check (float 0.001) "next due" 260.0 stored.due_at
+   | Error err -> fail (store_error_to_string err));
+  (match refresh_due config ~now:260.0 with
+   | Ok (_, changed) -> check int "second due" 1 changed
+   | Error err -> fail (store_error_to_string err));
+  let state = read_state config in
+  let due =
+    match get_schedule config ~schedule_id:req.schedule_id with
+    | Some due -> due
+    | None -> fail "rescheduled request missing"
+  in
+  check bool "old grant is stale" false (has_current_approved_grant state due);
+  check int "second occurrence blocked before fresh grant" 0
+    (List.length (due_execution_candidates state));
+  let fresh_grant =
+    create_execution_grant ~grant_id:"grant-2" ~approved_by:(human "approver-2")
+      ~approved_at:261.0 ~decision:Approve due
+  in
+  (match record_grant config fresh_grant with
+   | Ok stored -> check_status "fresh due grant keeps due" Due stored.status
+   | Error err -> fail (store_error_to_string err));
+  check int "second occurrence candidate after fresh grant" 1
+    (List.length (due_execution_candidates (read_state config)))
+;;
+
 let test_load_corrupt_when_both_unparseable () =
   with_workspace
   @@ fun config ->
@@ -340,14 +456,14 @@ let test_mutation_refused_and_preserves_corrupt_ledger () =
   let req = make_request ~risk_class:Read_only () in
   ignore (insert_ok config req);
   corrupt_both config;
-  let primary_before = Workspace.read_text config (schedules_path config) in
-  let recovery_before = Workspace.read_text config (recovery_path config) in
+  let primary_before = Workspace_core.read_text config (schedules_path config) in
+  let recovery_before = Workspace_core.read_text config (recovery_path config) in
   (match insert_request config (make_request ~schedule_id:"sched-2" ~risk_class:Read_only ()) with
    | Ok _ -> fail "insert on corrupt ledger unexpectedly succeeded"
    | Error (Corrupt_ledger _) -> ()
    | Error err -> fail ("expected Corrupt_ledger, got: " ^ store_error_to_string err));
-  let primary_after = Workspace.read_text config (schedules_path config) in
-  let recovery_after = Workspace.read_text config (recovery_path config) in
+  let primary_after = Workspace_core.read_text config (schedules_path config) in
+  let recovery_after = Workspace_core.read_text config (recovery_path config) in
   check string "corrupt primary preserved" primary_before primary_after;
   check string "corrupt recovery preserved" recovery_before recovery_after
 ;;
@@ -370,7 +486,7 @@ let test_last_good_is_parseable_after_good_write () =
   @@ fun config ->
   let req = make_request ~risk_class:Read_only () in
   ignore (insert_ok config req);
-  let recovery_json = Workspace.read_json config (recovery_path config) in
+  let recovery_json = Workspace_core.read_json config (recovery_path config) in
   match Schedule_store.state_of_yojson recovery_json with
   | Ok state -> check int "last-good holds the schedule" 1 (List.length state.schedules)
   | Error msg -> fail (".last-good is not parseable: " ^ msg)
@@ -420,10 +536,16 @@ let () =
             test_due_candidates_require_approval_grant;
           test_case "read-only due candidate does not need grant" `Quick
             test_read_only_due_candidate_does_not_need_grant;
+          test_case "refresh_due expires pending scheduled and due" `Quick
+            test_refresh_due_expires_pending_scheduled_and_due;
           test_case "reschedule due recurring rows" `Quick
             test_reschedule_due_recurring_advances_only_matching_recurring_rows;
           test_case "start and complete persist execution record" `Quick
             test_start_and_complete_persist_execution_record;
+          test_case "fail due candidate records failed execution" `Quick
+            test_fail_due_candidate_records_failed_execution;
+          test_case "recurring grant is scoped to current due_at" `Quick
+            test_recurring_grant_is_scoped_to_current_due_at;
         ] );
     ]
 ;;

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -65,11 +65,23 @@ let schedule_tool_name action =
 
 let test_schema_and_descriptor_exposed () =
   let create_name = schedule_tool_name Tool_schemas_schedule.Create_request in
+  let approve_schema =
+    (schedule_definition Tool_schemas_schedule.Approve_request).schema
+  in
+  let reject_schema =
+    (schedule_definition Tool_schemas_schedule.Reject_request).schema
+  in
   let schema_names =
     Config.raw_all_tool_schemas
     |> List.map (fun (s : Masc_domain.tool_schema) -> s.name)
   in
   check bool "raw schema has create" true (List.mem create_name schema_names);
+  check string "approve describes due grants"
+    "Record a separate human execution grant for a pending or due scheduled request. Recurring side-effecting requests need a fresh grant for each due occurrence."
+    approve_schema.description;
+  check string "reject describes due decisions"
+    "Reject a pending or due scheduled request with a human decision."
+    reject_schema.description;
   check bool "tag registered" true
     (Tool_dispatch.lookup_tag create_name = Some Tool_dispatch.Mod_schedule);
   let descriptor_names =
@@ -163,6 +175,7 @@ let test_dispatch_cancel_persists_status () =
 
 let create_schedule_exn
   config
+  ?expires_at
   ?recurrence
   ~schedule_id
   ~due_at
@@ -174,7 +187,7 @@ let create_schedule_exn
   match
     Schedule_service.create config ~schedule_id ~requested_at:100.0
       ~requested_by ~scheduled_by ~due_at ~payload ~risk_class
-      ~source:Schedule_domain.Operator_request ?recurrence ()
+      ~source:Schedule_domain.Operator_request ?expires_at ?recurrence ()
   with
   | Ok request -> request
   | Error err ->
@@ -184,6 +197,9 @@ let create_schedule_exn
 let test_dashboard_projection_surfaces_schedule_fsm () =
   with_config
   @@ fun config ->
+  let now = Time_compat.now () in
+  let past_due = now -. 10.0 in
+  let future_due = now +. 3600.0 in
   ignore
     (create_schedule_exn config ~schedule_id:"sched-exec" ~due_at:50.0
        ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
@@ -200,11 +216,11 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
      Schedule_store.complete_running config ~now:53.0 ~schedule_id:"sched-exec"
        ~detail:(`Assoc [ "kind", `String "test.exec" ])
        ()
-   with
-   | Ok _ -> ()
-   | Error err -> fail (Schedule_store.store_error_to_string err));
+  with
+  | Ok _ -> ()
+  | Error err -> fail (Schedule_store.store_error_to_string err));
   ignore
-    (create_schedule_exn config ~schedule_id:"sched-due" ~due_at:1.0
+    (create_schedule_exn config ~schedule_id:"sched-due" ~due_at:past_due
        ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
        ~scheduled_by:(automated "scheduler-agent")
        ~recurrence:
@@ -213,8 +229,21 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
        ()
       : Schedule_domain.schedule_request);
   ignore
-    (create_schedule_exn config ~schedule_id:"sched-approval" ~due_at:300.0
+    (create_schedule_exn config ~schedule_id:"sched-approval" ~due_at:future_due
        ~risk_class:Schedule_domain.Workspace_write ~requested_by:(human "operator")
+       ~scheduled_by:(automated "scheduler-agent")
+       ()
+      : Schedule_domain.schedule_request);
+  ignore
+    (create_schedule_exn config ~schedule_id:"sched-blocked" ~due_at:past_due
+       ~risk_class:Schedule_domain.Workspace_write ~requested_by:(human "operator")
+       ~scheduled_by:(automated "scheduler-agent")
+       ()
+      : Schedule_domain.schedule_request);
+  ignore
+    (create_schedule_exn config ~schedule_id:"sched-expired-effective"
+       ~due_at:past_due ~expires_at:(now -. 1.0) ~risk_class:Schedule_domain.Read_only
+       ~requested_by:(human "operator")
        ~scheduled_by:(automated "scheduler-agent")
        ()
       : Schedule_domain.schedule_request);
@@ -224,23 +253,60 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
   let open Yojson.Safe.Util in
   check string "schema" "masc.dashboard.scheduled_automation.v1"
     (json |> member "schema" |> to_string);
-  check int "request count" 3 (json |> member "request_count" |> to_int);
-  check string "fsm state" "pending_approval"
+  check int "request count" 5 (json |> member "request_count" |> to_int);
+  check string "fsm state" "blocked_approval"
     (json |> member "fsm" |> member "state" |> to_string);
-  check int "pending count" 1
+  check int "effective active count" 3
+    (json |> member "fsm" |> member "active_count" |> to_int);
+  check int "effective terminal count" 2
+    (json |> member "fsm" |> member "terminal_count" |> to_int);
+  check int "pending count" 2
     (json |> member "counts" |> member "pending_approval" |> to_int);
-  check int "scheduled count" 1
+  check int "scheduled count" 2
     (json |> member "counts" |> member "scheduled" |> to_int);
   check int "due effective count" 1
     (json |> member "derived_counts" |> member "due_effective" |> to_int);
+  check int "blocked approval count" 1
+    (json |> member "derived_counts" |> member "blocked_approval" |> to_int);
+  check int "due execution ready count" 0
+    (json |> member "derived_counts" |> member "due_execution_ready" |> to_int);
+  check int "expired effective count" 1
+    (json |> member "derived_counts" |> member "expired_effective" |> to_int);
   let requests = json |> member "requests" |> to_list in
-  (match requests with
-   | first :: _ ->
-     check string "recurrence kind" "daily"
-       (first |> member "recurrence_kind" |> to_string);
-     check string "recurrence object kind" "daily"
-       (first |> member "recurrence" |> member "kind" |> to_string)
-   | [] -> fail "expected dashboard requests");
+  let find_request schedule_id =
+    match
+      List.find_opt
+        (fun row -> String.equal (row |> member "schedule_id" |> to_string) schedule_id)
+        requests
+    with
+    | Some row -> row
+    | None -> fail ("schedule missing from dashboard projection: " ^ schedule_id)
+  in
+  let due_row = find_request "sched-due" in
+  check string "due recurrence kind" "daily"
+    (due_row |> member "recurrence_kind" |> to_string);
+  check string "due recurrence object kind" "daily"
+    (due_row |> member "recurrence" |> member "kind" |> to_string);
+  check string "due effective status" "due"
+    (due_row |> member "effective_status" |> to_string);
+  check string "due readiness" "due_pending_refresh"
+    (due_row |> member "execution_readiness" |> to_string);
+  check string "due action" "wait_for_runner_tick"
+    (due_row |> member "operator_action" |> to_string);
+  let blocked_row = find_request "sched-blocked" in
+  check string "blocked effective status" "blocked_approval"
+    (blocked_row |> member "effective_status" |> to_string);
+  check string "blocked readiness" "blocked_approval"
+    (blocked_row |> member "execution_readiness" |> to_string);
+  check string "blocked action" "approve_or_reject"
+    (blocked_row |> member "operator_action" |> to_string);
+  let expired_row = find_request "sched-expired-effective" in
+  check string "expired effective status" "expired"
+    (expired_row |> member "effective_status" |> to_string);
+  check string "expired readiness" "expired"
+    (expired_row |> member "execution_readiness" |> to_string);
+  check string "expired action" "inspect_or_recreate"
+    (expired_row |> member "operator_action" |> to_string);
   let exec_row =
     List.find_opt
       (fun row -> String.equal (row |> member "schedule_id" |> to_string) "sched-exec")
@@ -249,6 +315,10 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
   match exec_row with
   | None -> fail "sched-exec missing from dashboard projection"
   | Some row ->
+    check string "terminal effective status" "succeeded"
+      (row |> member "effective_status" |> to_string);
+    check string "terminal readiness" "terminal"
+      (row |> member "execution_readiness" |> to_string);
     check string "last execution status" "succeeded"
       (row |> member "last_execution" |> member "status" |> to_string);
     check string "last execution detail" "test.exec"


### PR DESCRIPTION
## Summary
- expire pending/scheduled/due requests before dispatch and fail unsupported due candidates durably
- require recurring side-effect approvals to match the current due_at/payload/risk evidence
- expose schedule dashboard effective status, readiness, operator action, blocked/expired derived counts, and effective active/terminal counts
- surface the new dashboard fields in the tools panel

## Validation
Current head `47d98c8bc3`:
- `opam exec -- ocamlformat --check lib/tool_schemas/tool_schemas_schedule.ml test/test_schedule_tool_wiring.ml`
- `git diff --check`
- GitHub Actions restarted on the current head; final build/test proof is CI-owned for this update.

Earlier local evidence before the final dashboard/tool-surface amends:
- `scripts/dune-local.sh build test/test_schedule_domain.exe test/test_schedule_store.exe test/test_schedule_service.exe test/test_schedule_runner.exe test/test_schedule_consumer_dispatch.exe test/test_schedule_tool_wiring.exe`
- `./_build/default/test/test_schedule_domain.exe && ./_build/default/test/test_schedule_store.exe && ./_build/default/test/test_schedule_service.exe && ./_build/default/test/test_schedule_runner.exe && ./_build/default/test/test_schedule_consumer_dispatch.exe && ./_build/default/test/test_schedule_tool_wiring.exe`
- `pnpm typecheck`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/tools/tools-main.test.ts`
- `pnpm exec eslint src/api/dashboard.ts src/components/tools/scheduled-automation-panel.ts src/components/tools/tools-main.test.ts`

## Known unrelated local baseline
- `pnpm lint` currently fails on pre-existing `dashboard/src/keeper-actions.ts:368 no-nested-ternary`, outside this patch.
