### PR TITLE
[codex] address dashboard theme review feedback

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -84,6 +84,7 @@ const TEST_FILES = [
   'src/schemas/sse.test.ts',
   'src/sse-store.test.ts',
   'src/styles/chat-blocks-v2.test.ts',
+  'src/styles/css-test-utils.ts',
   'src/styles/paper-theme.test.ts',
   'src/styles/skin-v2-paper.test.ts',
 ]

--- a/dashboard/src/styles/app-shell-v2.css
+++ b/dashboard/src/styles/app-shell-v2.css
@@ -14,45 +14,115 @@
    Defined at :root so v2-shell.css and shell components can share them.
    ═══════════════════════════════════════════════════════════════ */
 
-:root {
-  /* Surfaces */
-  --ss-page: #FAFAFA;
-  --ss-card: #FFFFFF;
-  --ss-surface: #F5F5F5;
-  --ss-surface-subtle: #FAFAFA;
-  --ss-surface-muted: #E8E8E8;
+@layer theme-defaults, theme-overrides;
 
-  /* Text hierarchy (darkest is #2A2A2A, never pure black) */
-  --ss-text-primary: #2A2A2A;
-  --ss-text-secondary: #6A6A6A;
-  --ss-text-tertiary: #7A7A7A;
-  --ss-text-disabled: #9B9B9B;
+@layer theme-defaults {
+  :root {
+    /* Surfaces */
+    --theme-background: #FAFAFA;
+    --theme-surface-page: #FAFAFA;
+    --theme-card: #FFFFFF;
+    --theme-card-raised: #FFFFFF;
+    --theme-card-hover: #F5F5F5;
+    --theme-surface: #F5F5F5;
+    --theme-surface-subtle: #FAFAFA;
+    --theme-surface-muted: #E8E8E8;
+    --theme-sunken: #EFEFEF;
 
-  /* Hairlines */
-  --ss-border: rgba(0, 0, 0, 0.08);
-  --ss-border-subtle: rgba(0, 0, 0, 0.05);
-  --ss-border-strong: rgba(0, 0, 0, 0.12);
+    /* Text hierarchy (darkest is #2A2A2A, never pure black) */
+    --theme-text-strong: #2A2A2A;
+    --theme-text-primary: #2A2A2A;
+    --theme-text-secondary: #6A6A6A;
+    --theme-text-tertiary: #7A7A7A;
+    --theme-text-disabled: #9B9B9B;
+    --theme-icon-default: #7A7A7A;
 
-  /* Single accent (--brand) */
-  --ss-brand: #721FE5;
-  --ss-brand-tint: rgba(114, 31, 229, 0.10);
-  --ss-brand-dim: rgba(114, 31, 229, 0.06);
-  --ss-brand-glow: 114 31 229;
+    /* Hairlines */
+    --theme-border: rgba(0, 0, 0, 0.08);
+    --theme-border-subtle: rgba(0, 0, 0, 0.05);
+    --theme-border-strong: rgba(0, 0, 0, 0.12);
+    --theme-border-1: var(--theme-border-subtle);
+    --theme-border-2: var(--theme-border);
+    --theme-border-3: var(--theme-border-strong);
 
-  /* Status */
-  --ss-success: #6B9B7A;
-  --ss-warning: #D97706;
-  --ss-destructive: #d4183d;
+    /* Single accent (--brand) */
+    --theme-brand: #721FE5;
+    --theme-brand-tint: rgba(114, 31, 229, 0.10);
+    --theme-brand-dim: rgba(114, 31, 229, 0.06);
+    --theme-brand-glow: 114 31 229;
+    --theme-brand-wash: rgba(114, 31, 229, 0.08);
 
-  /* Shadows (<= 8% opacity) */
-  --ss-shadow-card: 0 1px 3px rgba(0, 0, 0, 0.04);
-  --ss-shadow-card-hover: 0 2px 4px rgba(0, 0, 0, 0.08);
-  --ss-shadow-elevated: 0 4px 12px rgba(0, 0, 0, 0.08);
-  --ss-shadow-modal: 0 8px 24px rgba(0, 0, 0, 0.12);
+    /* Status */
+    --theme-success: #6B9B7A;
+    --theme-warning: #D97706;
+    --theme-destructive: #d4183d;
+    --theme-info: #2563eb;
 
-  /* Shape */
-  --ss-radius-card: 1rem;       /* 16px = rounded-2xl */
-  --ss-radius-input: 0.375rem;  /* 6px */
+    /* Shadows (<= 8% opacity) */
+    --theme-shadow-card: 0 1px 3px rgba(0, 0, 0, 0.04);
+    --theme-shadow-card-hover: 0 2px 4px rgba(0, 0, 0, 0.08);
+    --theme-shadow-elevated: 0 4px 12px rgba(0, 0, 0, 0.08);
+    --theme-shadow-modal: 0 8px 24px rgba(0, 0, 0, 0.12);
+
+    /* Shape */
+    --theme-radius-card: 1rem;       /* 16px = rounded-2xl */
+    --theme-radius-input: 0.375rem;  /* 6px */
+
+    --background: var(--theme-background);
+    --surface-page: var(--theme-surface-page);
+    --card: var(--theme-card);
+    --surface-subtle: var(--theme-surface-subtle);
+    --surface-muted: var(--theme-surface-muted);
+    --text-primary: var(--theme-text-primary);
+    --text-secondary: var(--theme-text-secondary);
+    --text-tertiary: var(--theme-text-tertiary);
+    --text-disabled: var(--theme-text-disabled);
+    --icon-default: var(--theme-icon-default);
+    --border: var(--theme-border);
+    --border-subtle: var(--theme-border-subtle);
+    --border-strong: var(--theme-border-strong);
+    --brand: var(--theme-brand);
+    --brand-dim: var(--theme-brand-dim);
+    --brand-wash: var(--theme-brand-wash);
+    --brand-tint: var(--theme-brand-tint);
+    --success: var(--theme-success);
+    --warning: var(--theme-warning);
+    --destructive: var(--theme-destructive);
+    --info: var(--theme-info);
+
+    --ss-page: var(--theme-surface-page);
+    --ss-card: var(--theme-card);
+    --ss-card-raised: var(--theme-card-raised);
+    --ss-card-hover: var(--theme-card-hover);
+    --ss-surface: var(--theme-surface);
+    --ss-surface-subtle: var(--theme-surface-subtle);
+    --ss-surface-muted: var(--theme-surface-muted);
+    --ss-sunken: var(--theme-sunken);
+    --ss-text-strong: var(--theme-text-strong);
+    --ss-text-primary: var(--theme-text-primary);
+    --ss-text-secondary: var(--theme-text-secondary);
+    --ss-text-tertiary: var(--theme-text-tertiary);
+    --ss-text-disabled: var(--theme-text-disabled);
+    --ss-border: var(--theme-border);
+    --ss-border-subtle: var(--theme-border-subtle);
+    --ss-border-strong: var(--theme-border-strong);
+    --ss-border-1: var(--theme-border-1);
+    --ss-border-2: var(--theme-border-2);
+    --ss-border-3: var(--theme-border-3);
+    --ss-brand: var(--theme-brand);
+    --ss-brand-tint: var(--theme-brand-tint);
+    --ss-brand-dim: var(--theme-brand-dim);
+    --ss-brand-glow: var(--theme-brand-glow);
+    --ss-success: var(--theme-success);
+    --ss-warning: var(--theme-warning);
+    --ss-destructive: var(--theme-destructive);
+    --ss-shadow-card: var(--theme-shadow-card);
+    --ss-shadow-card-hover: var(--theme-shadow-card-hover);
+    --ss-shadow-elevated: var(--theme-shadow-elevated);
+    --ss-shadow-modal: var(--theme-shadow-modal);
+    --ss-radius-card: var(--theme-radius-card);
+    --ss-radius-input: var(--theme-radius-input);
+  }
 }
 
 /* ═══════════════════════════════════════════════════════════════

--- a/dashboard/src/styles/chat-blocks-v2.test.ts
+++ b/dashboard/src/styles/chat-blocks-v2.test.ts
@@ -2,34 +2,14 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { declarationsForSelector } from './css-test-utils'
 
 const cssPath = resolve(__dirname, 'chat-blocks-v2.css')
 const css = readFileSync(cssPath, 'utf-8')
 
-function parseBlock(selector: string): Record<string, string> {
-  const start = css.indexOf(selector)
-  if (start === -1) {
-    throw new Error(`Selector not found: ${selector}`)
-  }
-
-  const open = css.indexOf('{', start)
-  const close = css.indexOf('}', open)
-  const block = css.slice(open + 1, close)
-  const props: Record<string, string> = {}
-  for (const line of block.split('\n')) {
-    const trimmed = line.trim()
-    if (!trimmed || trimmed.startsWith('/*')) continue
-    const match = /^([\w-]+):\s*([^;]+);/.exec(trimmed)
-    if (match && match[1] && match[2]) {
-      props[match[1]] = match[2].trim()
-    }
-  }
-  return props
-}
-
 describe('chat-blocks-v2.css', () => {
   it('keeps opened tool traces from shrinking inside the chat flex column', () => {
-    const trace = parseBlock('.chat-block-trace')
+    const trace = declarationsForSelector(css, '.chat-block-trace')
     expect(trace.display).toBe('flex')
     expect(trace.flex).toBe('none')
     expect(trace['flex-direction']).toBe('column')

--- a/dashboard/src/styles/css-test-utils.ts
+++ b/dashboard/src/styles/css-test-utils.ts
@@ -1,0 +1,21 @@
+import { parse } from 'postcss'
+
+export function declarationsForSelector(css: string, selector: string): Record<string, string> {
+  const declarations: Record<string, string> = {}
+  let found = false
+
+  parse(css).walkRules((rule) => {
+    if (!rule.selectors.includes(selector)) return
+
+    found = true
+    rule.walkDecls((decl) => {
+      declarations[decl.prop] = decl.value.trim()
+    })
+  })
+
+  if (!found) {
+    throw new Error(`Selector not found: ${selector}`)
+  }
+
+  return declarations
+}

--- a/dashboard/src/styles/paper-theme.css
+++ b/dashboard/src/styles/paper-theme.css
@@ -16,7 +16,7 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
 
-html[data-theme="paper"] {
+[data-theme="paper"] {
   color-scheme: light;
 
   /* ───── Paper & ink (design system source of truth) ──────── */
@@ -136,64 +136,44 @@ html[data-theme="paper"] {
   --stalled-fg: var(--plum);
   --stalled-border: var(--plum-line);
 
-  /* StyleSeed / v2 app-shell bridge. Later v2 styles define these at
-     :root; the html[data-theme="paper"] selector intentionally outranks
-     that default so paper mode recolors migrated shell surfaces too. */
-  --background: var(--paper);
-  --surface-page: var(--paper);
-  --card: var(--paper-2);
-  --surface-subtle: var(--paper-3);
-  --surface-muted: var(--paper-4);
-  --text-primary: var(--ink);
-  --text-secondary: var(--ink-3);
-  --text-tertiary: var(--ink-5);
-  --text-disabled: var(--ink-6);
-  --icon-default: var(--ink-4);
-  --border: var(--border-3-paper);
-  --brand: var(--brass);
-  --brand-dim: var(--brass-line);
-  --brand-wash: rgba(140, 106, 30, 0.12);
-  --brand-tint: rgba(140, 106, 30, 0.16);
-  --success: var(--forest);
-  --warning: var(--ember);
-  --destructive: var(--brick);
-  --info: var(--slate-accent);
-
-  --ss-page: var(--paper);
-  --ss-card: var(--paper-2);
-  --ss-card-raised: var(--paper-2);
-  --ss-card-hover: var(--paper-3);
-  --ss-surface: var(--paper-3);
-  --ss-surface-subtle: var(--paper-3);
-  --ss-surface-muted: var(--paper-4);
-  --ss-sunken: var(--paper-4);
-
-  --ss-text-strong: var(--ink);
-  --ss-text-primary: var(--ink-2);
-  --ss-text-secondary: var(--ink-4);
-  --ss-text-tertiary: var(--ink-5);
-  --ss-text-disabled: var(--ink-6);
-
-  --ss-border: var(--border-3-paper);
-  --ss-border-subtle: var(--border-4-paper);
-  --ss-border-strong: var(--border-2-paper);
-  --ss-border-1: var(--border-5-paper);
-  --ss-border-2: var(--border-4-paper);
-  --ss-border-3: var(--border-3-paper);
-
-  --ss-brand: var(--brass);
-  --ss-brand-tint: rgba(140, 106, 30, 0.16);
-  --ss-brand-dim: rgba(140, 106, 30, 0.08);
-  --ss-brand-glow: 140 106 30;
-  --ss-success: var(--forest);
-  --ss-warning: var(--ember);
-  --ss-destructive: var(--brick);
-  --ss-shadow-card: 0 1px 2px rgba(21, 21, 21, 0.06);
-  --ss-shadow-card-hover: 0 2px 5px rgba(21, 21, 21, 0.10);
-  --ss-shadow-elevated: 0 8px 18px rgba(21, 21, 21, 0.10);
-  --ss-shadow-modal: 0 12px 30px rgba(21, 21, 21, 0.16);
-  --ss-radius-card: 8px;
-  --ss-radius-input: 6px;
+  /* StyleSeed / v2 app-shell bridge. app-shell-v2 owns the public
+     --ss-* aliases; paper only swaps the theme roles those aliases resolve. */
+  --theme-background: var(--paper);
+  --theme-surface-page: var(--paper);
+  --theme-card: var(--paper-2);
+  --theme-card-raised: var(--paper-2);
+  --theme-card-hover: var(--paper-3);
+  --theme-surface: var(--paper-3);
+  --theme-surface-subtle: var(--paper-3);
+  --theme-surface-muted: var(--paper-4);
+  --theme-sunken: var(--paper-4);
+  --theme-text-strong: var(--ink);
+  --theme-text-primary: var(--ink-2);
+  --theme-text-secondary: var(--ink-4);
+  --theme-text-tertiary: var(--ink-5);
+  --theme-text-disabled: var(--ink-6);
+  --theme-icon-default: var(--ink-4);
+  --theme-border: var(--border-3-paper);
+  --theme-border-subtle: var(--border-4-paper);
+  --theme-border-strong: var(--border-2-paper);
+  --theme-border-1: var(--border-5-paper);
+  --theme-border-2: var(--border-4-paper);
+  --theme-border-3: var(--border-3-paper);
+  --theme-brand: var(--brass);
+  --theme-brand-dim: rgba(140, 106, 30, 0.08);
+  --theme-brand-wash: rgba(140, 106, 30, 0.12);
+  --theme-brand-tint: rgba(140, 106, 30, 0.16);
+  --theme-brand-glow: 140 106 30;
+  --theme-success: var(--forest);
+  --theme-warning: var(--ember);
+  --theme-destructive: var(--brick);
+  --theme-info: var(--slate-accent);
+  --theme-shadow-card: 0 1px 2px rgba(21, 21, 21, 0.06);
+  --theme-shadow-card-hover: 0 2px 5px rgba(21, 21, 21, 0.10);
+  --theme-shadow-elevated: 0 8px 18px rgba(21, 21, 21, 0.10);
+  --theme-shadow-modal: 0 12px 30px rgba(21, 21, 21, 0.16);
+  --theme-radius-card: 8px;
+  --theme-radius-input: 6px;
 
   --chat-operator-bg: var(--brass-fill);
   --chat-operator-border: var(--brass-line);
@@ -363,9 +343,9 @@ html[data-theme="paper"] {
 }
 
 /* Base surface + text when paper theme is active.
-   Scoped to html[data-theme="paper"] so non-theme pages stay unaffected. */
-html[data-theme="paper"],
-html[data-theme="paper"] body {
+   Scoped to [data-theme="paper"] so non-theme pages stay unaffected. */
+[data-theme="paper"],
+[data-theme="paper"] body {
   background: var(--paper);
   color: var(--ink);
   font-family: var(--font-sans-paper);
@@ -373,10 +353,10 @@ html[data-theme="paper"] body {
 
 /* Mono elements in paper theme should use JetBrains Mono with
    tabular-nums, per design system rule #5. */
-html[data-theme="paper"] code,
-html[data-theme="paper"] pre,
-html[data-theme="paper"] .tabular-nums,
-html[data-theme="paper"] [class*="font-mono"] {
+[data-theme="paper"] code,
+[data-theme="paper"] pre,
+[data-theme="paper"] .tabular-nums,
+[data-theme="paper"] [class*="font-mono"] {
   font-family: var(--font-mono-paper);
   font-variant-numeric: tabular-nums;
 }

--- a/dashboard/src/styles/paper-theme.test.ts
+++ b/dashboard/src/styles/paper-theme.test.ts
@@ -2,59 +2,40 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { declarationsForSelector } from './css-test-utils'
 
-const cssPath = resolve(__dirname, 'paper-theme.css')
-const css = readFileSync(cssPath, 'utf-8')
-
-function parseBlock(selector: string): Record<string, string> {
-  const start = css.indexOf(selector)
-  if (start === -1) {
-    throw new Error(`Selector not found: ${selector}`)
-  }
-
-  const open = css.indexOf('{', start)
-  let depth = 0
-  let close = open
-  for (let i = open; i < css.length; i++) {
-    if (css[i] === '{') depth++
-    if (css[i] === '}') {
-      depth--
-      if (depth === 0) {
-        close = i
-        break
-      }
-    }
-  }
-
-  const block = css.slice(open + 1, close)
-  const vars: Record<string, string> = {}
-  for (const line of block.split('\n')) {
-    const trimmed = line.trim()
-    if (!trimmed || trimmed.startsWith('/*')) continue
-    const match = /^(--[\w-]+):\s*([^;]+);/.exec(trimmed)
-    if (match && match[1] && match[2]) {
-      vars[match[1]] = match[2].trim()
-    }
-  }
-  return vars
-}
+const paperCssPath = resolve(__dirname, 'paper-theme.css')
+const paperCss = readFileSync(paperCssPath, 'utf-8')
+const appShellCssPath = resolve(__dirname, 'app-shell-v2.css')
+const appShellCss = readFileSync(appShellCssPath, 'utf-8')
 
 describe('paper-theme.css', () => {
-  it('uses html[data-theme="paper"] so later :root v2 tokens cannot override it', () => {
-    expect(css).toContain('html[data-theme="paper"] {')
+  it('uses cascade layers rather than selector specificity to override v2 defaults', () => {
+    expect(appShellCss).toContain('@layer theme-defaults, theme-overrides;')
+    expect(paperCss).toContain('[data-theme="paper"] {')
+    expect(paperCss).not.toContain('html[data-theme="paper"] {')
   })
 
-  it('bridges paper values into migrated StyleSeed shell tokens', () => {
-    const theme = parseBlock('html[data-theme="paper"]')
-    expect(theme['--ss-page']).toBe('var(--paper)')
-    expect(theme['--ss-card']).toBe('var(--paper-2)')
-    expect(theme['--ss-brand']).toBe('var(--brass)')
+  it('keeps the StyleSeed alias bridge centralized in app-shell-v2.css', () => {
+    const root = declarationsForSelector(appShellCss, ':root')
+    expect(root['--ss-page']).toBe('var(--theme-surface-page)')
+    expect(root['--ss-card']).toBe('var(--theme-card)')
+    expect(root['--ss-brand']).toBe('var(--theme-brand)')
+    expect(root['--background']).toBe('var(--theme-background)')
+  })
+
+  it('bridges paper values into migrated shell role tokens', () => {
+    const theme = declarationsForSelector(paperCss, '[data-theme="paper"]')
+    expect(theme['--theme-surface-page']).toBe('var(--paper)')
+    expect(theme['--theme-card']).toBe('var(--paper-2)')
+    expect(theme['--theme-brand']).toBe('var(--brass)')
+    expect(Object.keys(theme).some((name) => name.startsWith('--ss-'))).toBe(false)
     expect(theme['--color-bg-page']).toBe('var(--paper)')
     expect(theme['--color-fg-primary']).toBe('var(--ink)')
   })
 
   it('assigns distinct paper colors to operator, keeper, and tool chat surfaces', () => {
-    const theme = parseBlock('html[data-theme="paper"]')
+    const theme = declarationsForSelector(paperCss, '[data-theme="paper"]')
     expect(theme['--chat-operator-bg']).toBe('var(--brass-fill)')
     expect(theme['--chat-keeper-bg']).toBe('var(--teal-fill)')
     expect(theme['--chat-tool-bg']).toBe('var(--slate-accent-fill)')

--- a/dashboard/src/styles/skin-v2-paper.test.ts
+++ b/dashboard/src/styles/skin-v2-paper.test.ts
@@ -2,46 +2,14 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { declarationsForSelector } from './css-test-utils'
 
 const cssPath = resolve(__dirname, 'skin-v2.css')
 const css = readFileSync(cssPath, 'utf-8')
 
-function parseBlock(selector: string): Record<string, string> {
-  const start = css.indexOf(selector)
-  if (start === -1) {
-    throw new Error(`Selector not found: ${selector}`)
-  }
-
-  const open = css.indexOf('{', start)
-  let depth = 0
-  let close = open
-  for (let i = open; i < css.length; i++) {
-    if (css[i] === '{') depth++
-    if (css[i] === '}') {
-      depth--
-      if (depth === 0) {
-        close = i
-        break
-      }
-    }
-  }
-
-  const block = css.slice(open + 1, close)
-  const vars: Record<string, string> = {}
-  for (const line of block.split('\n')) {
-    const trimmed = line.trim()
-    if (!trimmed || trimmed.startsWith('/*')) continue
-    const match = /^(--[\w-]+):\s*([^;]+);/.exec(trimmed)
-    if (match && match[1] && match[2]) {
-      vars[match[1]] = match[2].trim()
-    }
-  }
-  return vars
-}
-
 describe('skin-v2.css paper bridge', () => {
   it('uses the paper-theme palette instead of the old gray v2 paper spine', () => {
-    const theme = parseBlock('html[data-skin="v2"][data-theme="paper"]')
+    const theme = declarationsForSelector(css, 'html[data-skin="v2"][data-theme="paper"]')
     expect(theme['--bg-deep']).toBe('var(--paper)')
     expect(theme['--bg-panel']).toBe('var(--paper-2)')
     expect(theme['--border-main']).toBe('var(--border-3-paper)')

--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -244,6 +244,8 @@ run_tlc "$REPO_ROOT/specs/state-product" "WorkspaceProduct.tla"
 run_tlc_buggy "$REPO_ROOT/specs/state-product" "WorkspaceProduct.tla"
 run_tlc "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
+run_tlc "$REPO_ROOT/specs/task-lifecycle" "CompletionAuthority.tla"
+run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "CompletionAuthority.tla"
 
 run_tlc "$REPO_ROOT/specs/goal-loop" "TierRouting.tla"
 run_tlc_buggy "$REPO_ROOT/specs/goal-loop" "TierRouting.tla"


### PR DESCRIPTION
## Summary
- Follow-up to merged #21694 review feedback.
- Replace dashboard CSS test hand parsers with a PostCSS exact-selector helper.
- Centralize the v2 StyleSeed `--ss-*` alias bridge in `app-shell-v2.css` behind low-priority theme defaults, and let PAPER override role tokens instead of mirroring every alias.
- Keep active PAPER chat/theme tokens on `[data-theme="paper"]` so existing unlayered dashboard CSS cannot override operator/Keeper/tool colors.
- Wire `specs/task-lifecycle/CompletionAuthority.tla` into `scripts/tla-check.sh`; #21701 added cfg-backed clean/buggy configs, and Meta Guards require cfg-backed specs to be covered by the harness.

## Verification
- `pnpm exec vitest run --config vitest.config.ts src/styles/chat-blocks-v2.test.ts src/styles/paper-theme.test.ts src/styles/skin-v2-paper.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/styles/chat-blocks-v2.test.ts src/styles/paper-theme.test.ts src/styles/skin-v2-paper.test.ts src/styles/css-test-utils.ts`
- `pnpm run typecheck`
- `pnpm run build` (passes; existing Vite font/dynamic-import/chunk warnings remain)
- `bash scripts/ci/check-tla-harness-coverage.sh`
- `java -XX:+UseParallelGC -Xmx4g -cp /Users/dancer/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC -config specs/task-lifecycle/CompletionAuthority.cfg -workers auto -deadlock specs/task-lifecycle/CompletionAuthority.tla`
- `java -XX:+UseParallelGC -Xmx4g -cp /Users/dancer/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC -config specs/task-lifecycle/CompletionAuthority-buggy.cfg -workers auto -deadlock specs/task-lifecycle/CompletionAuthority.tla` (expected exit 12: invariant violation)
- Playwright computed PAPER tokens: operator `#E9DDB8`, Keeper `#CEDEE2`, tool `#D6DBE2`; synthetic trace `display:flex`, `flex:0 0 auto`, `flex-direction:column`.

## Known Existing Failure
- `pnpm run lint` still fails on pre-existing `dashboard/src/keeper-actions.ts:368` `no-nested-ternary`; changed-file targeted ESLint passes.