### PR TITLE
fix(keeper): restore main build — pass trace_id string to next_generation

### DIFF
--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -444,7 +444,12 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_preview = "";
             consecutive_noop_count = 0;
           };
-          generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id:trace_id_t;
+          (* next_generation keys the per-(keeper, trace) counter by the trace_id
+             string; episodes live under that same string dir (ensure_dir/of
+             session_id above), so pass the raw [trace_id] string, not the typed
+             [trace_id_t]. trace_id_t is the typed wrapper stored in the record
+             field below. *)
+          generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id;
           trace_id = trace_id_t;
           trace_history = [];
           last_handoff_ts = 0.0;
@@ -479,7 +484,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ~session
             ~agent_name:meta.agent_name
             ~ctx:ctx0
-            ~generation:(Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id:trace_id_t)
+            ~generation:(Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id)
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->


### PR DESCRIPTION
## 요약

`main`이 #21688(`273412072d`) 머지 이후 **컴파일 실패** 상태입니다. `keeper_turn_up_create`가 typed `trace_id_t`(`Keeper_id.Trace_id.t`)를 `Keeper_memory_os_io.next_generation`(시그니처 `~trace_id:string`)에 넘겨 타입 에러가 납니다.

```
447 | generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id:trace_id_t;
Error: The value trace_id_t has type Keeper_id.Trace_id.t
```

`Build and Test` / `Health` job이 이 에러로 exit 1 → `main` push CI가 `273412072d` 이후 연속 red(273412072d/3013c16b/c5635dc 모두 failure). path-scope로 dashboard-only 머지(#21694 등)는 Build를 skip해서 표면상 묻혔을 뿐, OCaml을 빌드하는 모든 PR이 막힙니다.

## 근본 원인

semantic merge conflict:
- #21625가 `keeper_turn_up_create`에 typed binding(`match Keeper_id.Trace_id.of_string trace_id with | Ok trace_id_t -> ...`)을 도입 — `trace_id_t : Trace_id.t`.
- #21688이 같은 스코프에서 hardcoded `generation = 0`을 `next_generation ~trace_id:trace_id_t` 호출로 교체.
- 두 PR은 각자 시점엔 green이었으나, 합쳐지자 caller(typed)와 signature(string)가 불일치. conveyor가 red 상태로 머지하면서 `main`에 잠복.

## 변경

`lib/keeper/keeper_turn_up_create.ml` 2 사이트(line 447, 482)에서 `~trace_id:trace_id_t` → `~trace_id:trace_id`(원본 string).

`trace_id` string으로 넘기는 것이 cast가 아니라 **정확한 값**인 근거:
- generation 카운터는 trace_id **string**으로 키잉되고, 에피소드 디렉터리도 같은 string으로 생성됨(같은 함수 내 `Keeper_fs.ensure_dir (Filename.concat base_dir trace_id)` / `create_session ~session_id:trace_id`). 카운터와 에피소드가 같은 디렉터리를 가리키려면 string이어야 함.
- `~trace_id:string`은 SSOT: `keeper_memory_os_io.mli`, 그리고 모든 다른 caller(`keeper_librarian_runtime`, `test_keeper_memory_os`)가 string을 넘김.
- typed `trace_id_t`는 레코드 필드(`trace_id = trace_id_t`)로 그대로 유지.

## 검증

- 로컬 `dune build` clean(수정 전엔 위 타입 에러로 fail). 모듈 단독 + 전체 빌드 모두 green.
- 회귀 가드는 기존 `Build and Test` job 자체(컴파일 에러 = 빌드 실패).

## 비범위

- conveyor가 red CI에서 admin-merge한 프로세스 이슈는 별도. 이 PR은 `main` 컴파일 복구만.

RFC-WAIVED: gated subsystem(credential/identity/operator/sandbox) 아님 — keeper memory-os create 경로의 타입 정합성 복구. 신규 동작/설계 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
