### PR TITLE
fix(keeper): next_generation에 string trace_id 전달 (main 컴파일 복구)

### DIFF
--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -444,7 +444,9 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_preview = "";
             consecutive_noop_count = 0;
           };
-          generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id:trace_id_t;
+          generation =
+            Keeper_memory_os_io.next_generation ~keeper_id:p.name
+              ~trace_id:(Keeper_id.Trace_id.to_string trace_id_t);
           trace_id = trace_id_t;
           trace_history = [];
           last_handoff_ts = 0.0;
@@ -479,7 +481,9 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ~session
             ~agent_name:meta.agent_name
             ~ctx:ctx0
-            ~generation:(Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id:trace_id_t)
+            ~generation:
+              (Keeper_memory_os_io.next_generation ~keeper_id:p.name
+                 ~trace_id:(Keeper_id.Trace_id.to_string trace_id_t))
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->


### PR DESCRIPTION
## 무엇을

main을 깨뜨려 레포 전체 CI를 red로 만든 컴파일 타입 에러를 수정합니다.

## 근본 원인

PR #21688("Fix g0000 consolidator bug — use next_generation instead of hardcoded 0")이 `keeper_turn_up_create.ml` 두 곳에서 `Keeper_memory_os_io.next_generation ~trace_id:trace_id_t`로 호출했습니다. 그런데:

- `trace_id_t : Keeper_id.Trace_id.t` (RFC-0233 §7 turn-identity 타이핑, #21662)
- `next_generation : keeper_id:string -> trace_id:string -> int` (`keeper_memory_os_io.mli:27`)

typed `Trace_id.t`를 `string` 자리에 넘겨 `warn-error=+a` 빌드가 깨졌습니다. `dune build @install --force` 실패 → **Lint / Build and Test / Health 잡 전부 red, 모든 PR CI가 막힘**.

(#21688이 컨베이어 mid-CI admin-merge로 CI가 cancel된 채 머지되며 컴파일 에러가 통과한 것으로 보입니다.)

## 변경

`keeper_turn_up_create.ml` 447, 482 두 call site에서 `~trace_id:(Keeper_id.Trace_id.to_string trace_id_t)`로 변환. 레코드 필드 `trace_id = trace_id_t`와 같은 typed 값에서 generation 키를 파생해 일관성을 유지합니다. repo 전수 grep으로 `next_generation`에 `Trace_id.t`를 넘기는 사이트가 이 둘뿐임을 확인(나머지는 내부 string 위임).

## 검증

```
opam exec -- dune build @check   # 타입 에러 해소 확인
```

## 경계 / 범위 밖

- 사용자 선택(call-site 최소 변환)에 따름. `next_generation` 시그니처를 `Trace_id.t`로 바꾸는 root 변경(.mli + 모든 호출부)은 별도 트랙 — 긴급 언블록 범위 밖.
- WORKAROUND 아님: string-keyed IO 레이어가 실제로 원하는 값으로의 올바른 경계 변환(typed keeper 도메인 → string-keyed memory_os_io).

RFC-WAIVED: 타입 mismatch 컴파일 fix. `keeper_turn_up_create.ml`은 turn-lifecycle, credential/identity/sandbox/operator subsystem 미해당.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
