### PR TITLE
feat(fusion): masc_fusion_status keeper tool (RFC-0266 Phase 3)

### DIFF
--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -83,9 +83,11 @@ let is_masc_mcp_descriptor (d : Keeper_tool_descriptor.t) =
   | Tool_voice_dispatch
   | Tool_task_dispatch
   | Board_tool_dispatch
-  (* masc_fusion is a keeper-native in-process tool (own orchestrator), not a
-     masc-MCP coordination proxy — routed via descriptors, not this alias path. *)
-  | Tool_masc_fusion_dispatch -> false
+  (* masc_fusion / masc_fusion_status are keeper-native in-process tools (own
+     orchestrator / registry read), not masc-MCP coordination proxies — routed
+     via descriptors, not this alias path. *)
+  | Tool_masc_fusion_dispatch
+  | Tool_masc_fusion_status -> false
 ;;
 
 let add_internal_names t (d : Keeper_tool_descriptor.t) =

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -58,6 +58,7 @@ type runtime_handler =
   | Tool_masc_keeper_dispatch
   | Tool_masc_surface_audit
   | Tool_masc_fusion_dispatch
+  | Tool_masc_fusion_status
 
 type policy =
   { visibility : Tool_catalog.visibility
@@ -148,6 +149,7 @@ let runtime_handler_to_string = function
   | Tool_masc_keeper_dispatch -> "tool_masc_keeper_dispatch"
   | Tool_masc_surface_audit -> "tool_masc_surface_audit"
   | Tool_masc_fusion_dispatch -> "tool_masc_fusion_dispatch"
+  | Tool_masc_fusion_status -> "tool_masc_fusion_status"
 ;;
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?readonly_of_input
@@ -777,11 +779,22 @@ let masc_fusion_schema =
     ]
 ;;
 
+let masc_fusion_status_schema =
+  object_schema
+    [ property
+        "run_id"
+        "string"
+        "Optional fusion run id (the run_id returned by masc_fusion). When \
+         given, returns that single run's status; when omitted, lists every \
+         tracked run (in-progress and recently completed)."
+    ]
+;;
+
 let read_only_in_process_policy ?(inline_safe = false) ?(maintenance_only = false)
-      ()
+      ?(visibility = Tool_catalog.Hidden) ()
   =
   policy
-    ~visibility:Tool_catalog.Hidden
+    ~visibility
     ~readonly:true
     ~effect_domain:Tool_catalog.Read_only
     ~approval:No_approval
@@ -1183,6 +1196,25 @@ let internal_descriptors : t list =
          쓰면 키퍼가 도구를 못 봐 자율 호출이 불가능해 RFC 의도와 모순된다. *)
       ~policy:(write_in_process_policy ~visibility:Tool_catalog.Default ())
       ~handler:Tool_masc_fusion_dispatch
+    (* ── fusion status (RFC-0266 §7 Phase 3) ──────────────────── *)
+  ; in_process_descriptor
+      ~id:"masc.fusion.status"
+      ~name:"masc_fusion_status"
+      ~description:
+        "Read the status of out-of-band fusion deliberations started by \
+         masc_fusion. With no argument, lists tracked runs (in-progress and \
+         recently completed); with a run_id, returns that single run. Each run \
+         reports keeper, preset, started_at (unix seconds), and status \
+         (running | completed | failed). Read-only — does not start a \
+         deliberation. In-memory and server-lifetime: runs do not survive a \
+         restart."
+      ~input_schema:masc_fusion_status_schema
+      (* read-only, but visibility=Default so the keeper LLM can poll its own
+         fusion runs (sibling to masc_fusion, which is also Default). Without
+         the override read_only_in_process_policy defaults to Hidden and the
+         keeper could not see the tool. *)
+      ~policy:(read_only_in_process_policy ~visibility:Tool_catalog.Default ())
+      ~handler:Tool_masc_fusion_status
     (* ── voice cluster (RFC-0179 PR-3, 6 tools) ───────────────── *)
   ; voice_descriptor
       "keeper_voice_speak"

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -63,6 +63,7 @@ type runtime_handler =
   | Tool_masc_keeper_dispatch
   | Tool_masc_surface_audit
   | Tool_masc_fusion_dispatch
+  | Tool_masc_fusion_status
 
 type policy =
   { visibility : Tool_catalog.visibility

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -429,7 +429,8 @@ let tool_tutor_for_validation ~tool_name ~input =
      | Keeper_tool_descriptor.Tool_masc_schedule_dispatch
      | Keeper_tool_descriptor.Tool_masc_keeper_dispatch
      | Keeper_tool_descriptor.Tool_masc_surface_audit
-     | Keeper_tool_descriptor.Tool_masc_fusion_dispatch -> None)
+     | Keeper_tool_descriptor.Tool_masc_fusion_dispatch
+     | Keeper_tool_descriptor.Tool_masc_fusion_status -> None)
 ;;
 
 let append_assoc_fields json extra_fields =

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -408,6 +408,57 @@ let handle_masc_fusion ~(config : Workspace.config) ~(meta : keeper_meta) ~args 
          ])
 ;;
 
+(* RFC-0266 §7 Phase 3 — masc_fusion_status: read-only view of the fusion run
+   registry (in-progress + recently completed). [fusion_status_json] is the
+   pure projection over any registry instance, so tests exercise it on an
+   isolated [Fusion_run_registry.create ()]; [handle_masc_fusion_status] binds
+   the process-wide [global] the fusion tool/sink write to. *)
+let fusion_status_json ~(registry : Fusion_run_registry.t) ~run_id : string =
+  let status_label (status : Fusion_run_registry.run_status) =
+    match status with
+    | Fusion_run_registry.Running -> "running"
+    | Fusion_run_registry.Completed { ok = true } -> "completed"
+    | Fusion_run_registry.Completed { ok = false } -> "failed"
+  in
+  let run_to_yojson (r : Fusion_run_registry.run) : Yojson.Safe.t =
+    `Assoc
+      [ "run_id", `String r.run_id
+      ; "keeper", `String r.keeper
+      ; "preset", `String r.preset
+      ; "started_at", `Float r.started_at
+      ; "status", `String (status_label r.status)
+      ]
+  in
+  if String.equal run_id ""
+  then begin
+    let runs = Fusion_run_registry.list_runs registry in
+    Yojson.Safe.to_string
+      (`Assoc
+         [ "ok", `Bool true
+         ; "count", `Int (List.length runs)
+         ; "runs", `List (List.map run_to_yojson runs)
+         ])
+  end
+  else (
+    match Fusion_run_registry.get registry ~run_id with
+    | Some run ->
+      Yojson.Safe.to_string
+        (`Assoc [ "ok", `Bool true; "found", `Bool true; "run", run_to_yojson run ])
+    | None ->
+      Yojson.Safe.to_string
+        (`Assoc
+           [ "ok", `Bool true
+           ; "found", `Bool false
+           ; "run_id", `String run_id
+           ; "status", `String "not_found"
+           ]))
+;;
+
+let handle_masc_fusion_status ~args () =
+  let run_id = Safe_ops.json_string ~default:"" "run_id" args |> String.trim in
+  fusion_status_json ~registry:Fusion_run_registry.global ~run_id
+;;
+
 (* RFC-0182 §3.1 — masc_tool_shard cluster.  [Tool_shard.execute]
    returns the older [(bool * Yojson.Safe.t)] tuple (predates RFC-0189
    typed-result migration), same shape as Tool_local_runtime.  Tool_shard

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -219,6 +219,24 @@ val handle_masc_fusion
   -> unit
   -> string
 
+(** RFC-0266 §7 Phase 3 — [fusion_status_json] projects a fusion run registry
+    to the masc_fusion_status tool's JSON string. With an empty [run_id] it
+    lists every tracked run ([{ ok; count; runs }]); with a non-empty [run_id]
+    it returns the single run ([{ ok; found; run }]) or a not-found envelope
+    ([{ ok; found = false; run_id; status = "not_found" }]). Each run's status
+    is rendered as ["running"], ["completed"] (ok), or ["failed"] (denied /
+    sink-failed / aborted). Pure over [registry] so tests can pass an isolated
+    [Fusion_run_registry.create ()]. *)
+val fusion_status_json
+  :  registry:Fusion_run_registry.t
+  -> run_id:string
+  -> string
+
+(** RFC-0266 §7 Phase 3 — in-process handler for the [masc_fusion_status]
+    read-only tool. Parses the optional [run_id] argument and projects the
+    process-wide [Fusion_run_registry.global] via {!fusion_status_json}. *)
+val handle_masc_fusion_status : args:Yojson.Safe.t -> unit -> string
+
 (** RFC-0182 §3.1 — [handle_masc_keeper] is the descriptor-projection
     cluster handler for the [masc_keeper_*] ctx-free tool surface.
     Dispatches via [Keeper_dispatch_ref] registered by [Keeper_tool_surface] at

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -75,7 +75,8 @@ let handle_filesystem ctx descriptor args =
   | Tool_masc_schedule_dispatch
   | Tool_masc_keeper_dispatch
   | Tool_masc_surface_audit
-  | Tool_masc_fusion_dispatch -> None
+  | Tool_masc_fusion_dispatch
+  | Tool_masc_fusion_status -> None
 ;;
 
 (* Shell IR mechanics live under Execute lowerers. Keeper_tool_command_runtime is
@@ -130,7 +131,8 @@ let handle_shell_ir ctx descriptor args =
   | Tool_masc_schedule_dispatch
   | Tool_masc_keeper_dispatch
   | Tool_masc_surface_audit
-  | Tool_masc_fusion_dispatch -> None
+  | Tool_masc_fusion_dispatch
+  | Tool_masc_fusion_status -> None
 ;;
 
 let handle_in_process ctx descriptor args =
@@ -301,6 +303,9 @@ let handle_in_process ctx descriptor args =
          ~meta:ctx.meta
          ~args
          ())
+  | Tool_masc_fusion_status ->
+    (* read-only: reads the in-memory run registry, no server context needed. *)
+    Some (Keeper_tool_in_process_runtime.handle_masc_fusion_status ~args ())
   | Tool_execute
   | Tool_search_files
   | Tool_read_file

--- a/test/dune
+++ b/test/dune
@@ -643,6 +643,14 @@
  (modules test_fusion_wake)
  (libraries masc_test_deps))
 
+; RFC-0266 Phase 3: masc_fusion_status tool — JSON projection of the run
+; registry + keeper-LLM visibility (Pass B Default gate). Needs masc.fusion_core
+; for the Fusion_run_registry module (not re-exported via masc_test_deps).
+(test
+ (name test_fusion_status_tool)
+ (modules test_fusion_status_tool)
+ (libraries masc_test_deps masc.fusion_core))
+
 ; RFC-0207: per-keeper LLM runtime routing (persona [model] selection + driver fail-fast).
 
 (test

--- a/test/test_fusion_status_tool.ml
+++ b/test/test_fusion_status_tool.ml
@@ -1,0 +1,147 @@
+(* RFC-0266 §7 Phase 3 — masc_fusion_status tool.
+
+   Two failure modes a stub could introduce while still compiling:
+
+   1. the JSON projection [fusion_status_json] mislabels a run status (e.g.
+      reports a denied/sink-failed run as "completed"), or returns the wrong
+      shape for list vs single-run vs unknown-run_id; and
+   2. the tool is wired but NOT visible to the keeper LLM (Pass B requires
+      visibility=Default; read_only_in_process_policy defaults to Hidden, so a
+      missing override would silently hide the tool while compiling fine).
+
+   [fusion_status_json] is pure over a registry instance, so it is exercised on
+   isolated [Fusion_run_registry.create ()] tables (no global-state coupling). *)
+
+open Alcotest
+open Masc
+module R = Fusion_run_registry
+module H = Keeper_tool_in_process_runtime
+
+let parse s = Yojson.Safe.from_string s
+
+let field j k =
+  match j with
+  | `Assoc l -> List.assoc_opt k l
+  | _ -> None
+;;
+
+let str j k =
+  match field j k with
+  | Some (`String s) -> s
+  | _ -> failwith (Printf.sprintf "missing string field %s" k)
+;;
+
+let bool_ j k =
+  match field j k with
+  | Some (`Bool b) -> b
+  | _ -> failwith (Printf.sprintf "missing bool field %s" k)
+;;
+
+let int_ j k =
+  match field j k with
+  | Some (`Int i) -> i
+  | _ -> failwith (Printf.sprintf "missing int field %s" k)
+;;
+
+let runs_of j =
+  match field j "runs" with
+  | Some (`List l) -> l
+  | _ -> failwith "missing runs list"
+;;
+
+let find_run runs id =
+  match List.find_opt (fun r -> String.equal (str r "run_id") id) runs with
+  | Some r -> r
+  | None -> failwith (Printf.sprintf "run %s not present in list" id)
+;;
+
+(* a registry carrying one of each terminal/active status *)
+let seeded () =
+  let t = R.create () in
+  R.register_running t ~run_id:"r-run" ~keeper:"k1" ~preset:"balanced" ~started_at:300.0;
+  R.register_running t ~run_id:"r-done" ~keeper:"k2" ~preset:"deep" ~started_at:100.0;
+  R.mark_completed t ~run_id:"r-done" ~ok:true;
+  R.register_running t ~run_id:"r-fail" ~keeper:"k3" ~preset:"deep" ~started_at:200.0;
+  R.mark_completed t ~run_id:"r-fail" ~ok:false;
+  t
+;;
+
+(* (1a) list mode: every tracked run, newest-first, with the right status label.
+   The label mapping is the mutation-sensitive core — ok=false must read
+   "failed", not "completed". *)
+let test_list_all () =
+  let json = H.fusion_status_json ~registry:(seeded ()) ~run_id:"" |> parse in
+  check bool "ok" true (bool_ json "ok");
+  check int "count" 3 (int_ json "count");
+  let runs = runs_of json in
+  check string "newest started_at first" "r-run" (str (List.hd runs) "run_id");
+  check string "running label" "running" (str (find_run runs "r-run") "status");
+  check string "completed label" "completed" (str (find_run runs "r-done") "status");
+  check string "failed label (ok=false)" "failed" (str (find_run runs "r-fail") "status");
+  (* run carries its identifying metadata for the operator/keeper *)
+  let r = find_run runs "r-run" in
+  check string "keeper field" "k1" (str r "keeper");
+  check string "preset field" "balanced" (str r "preset")
+;;
+
+(* (1b) single-run lookup: found -> {found=true; run}. *)
+let test_single_found () =
+  let json = H.fusion_status_json ~registry:(seeded ()) ~run_id:"r-fail" |> parse in
+  check bool "ok" true (bool_ json "ok");
+  check bool "found" true (bool_ json "found");
+  let run =
+    match field json "run" with
+    | Some r -> r
+    | None -> failwith "missing run object"
+  in
+  check string "single run id" "r-fail" (str run "run_id");
+  check string "single run status" "failed" (str run "status")
+;;
+
+(* (1c) unknown run_id -> a deterministic not_found envelope, not an empty/ok
+   silent drop. *)
+let test_single_not_found () =
+  let json = H.fusion_status_json ~registry:(seeded ()) ~run_id:"ghost" |> parse in
+  check bool "ok" true (bool_ json "ok");
+  check bool "found is false" false (bool_ json "found");
+  check string "echoes the queried run_id" "ghost" (str json "run_id");
+  check string "status not_found" "not_found" (str json "status")
+;;
+
+(* empty registry lists nothing but still returns the ok/count/runs shape *)
+let test_empty_registry () =
+  let json = H.fusion_status_json ~registry:(R.create ()) ~run_id:"" |> parse in
+  check int "empty count" 0 (int_ json "count");
+  check int "empty runs list" 0 (List.length (runs_of json))
+;;
+
+(* (2) keeper-LLM visibility: masc_fusion_status must be in the Pass-B set
+   (model_visible_descriptors filters visibility=Default). Hidden would compile
+   but silently strip it from the keeper's tool list. Also runs the unified
+   registry boot invariant (enforce_visible_tag_coverage) so a Default-visible
+   tool without a dispatch tag would fail loudly here. *)
+let test_tool_is_keeper_visible () =
+  Masc_test_deps.init_keeper_tool_registry ();
+  let visible_names =
+    Keeper_tool_descriptor.model_visible_descriptors ()
+    |> List.map (fun (d : Keeper_tool_descriptor.t) -> d.public_name)
+  in
+  check
+    bool
+    "masc_fusion_status is keeper-LLM-visible (Pass B Default gate)"
+    true
+    (List.mem "masc_fusion_status" visible_names)
+;;
+
+let () =
+  run
+    "fusion_status_tool"
+    [ ( "rfc-0266-phase3"
+      , [ test_case "list all runs (newest-first, status labels)" `Quick test_list_all
+        ; test_case "single run found" `Quick test_single_found
+        ; test_case "unknown run_id -> not_found" `Quick test_single_not_found
+        ; test_case "empty registry shape" `Quick test_empty_registry
+        ; test_case "tool is visible to the keeper LLM" `Quick test_tool_is_keeper_visible
+        ] )
+    ]
+;;


### PR DESCRIPTION
## RFC-0266 Phase 3 — `masc_fusion_status` keeper tool

A read-only keeper tool that projects the Phase 2 fusion run registry so a keeper can deterministically poll its own out-of-band deliberations by `run_id`, instead of watching the dashboard for a result that arrives asynchronously.

- **no argument** → lists tracked runs (in-progress + recently completed)
- **`run_id`** → that single run, or a `not_found` envelope

Each run reports `keeper`, `preset`, `started_at` (unix seconds), and `status` — one of `running` / `completed` / `failed` (`failed` covers denied-after-start, sink-failure, and abort, mirroring the registry's `Completed { ok = false }`).

This is the pull-complement to Phase 1 WAKE: WAKE pushes the result on completion; this tool answers "is my run still running / did it finish" on demand. It absorbs keeper task-1432.

### Why a tool over a board post

Per RFC-0266 §7, in-progress fusion is intentionally **not** surfaced as a board post (a start-time post would wake *other* keepers via `board_signal`). The registry is the non-waking source; this tool reads it.

### Changes

- New `in_process_descriptor` `masc_fusion_status` with `visibility = Default` so the keeper LLM lists it (sibling to `masc_fusion`). `read_only_in_process_policy` gains a `?visibility` override — symmetric with `write_in_process_policy`; the default stays `Hidden`.
- New `Tool_masc_fusion_status` `runtime_handler` variant. All five exhaustive `runtime_handler` match sites updated by hand (no `_ ->` catch-all), so the closed sum forces each site to choose.
- `fusion_status_json` is pure over a `Fusion_run_registry.t`; `handle_masc_fusion_status` binds the process-wide `global`. Registry types/reads are reused unchanged — no Phase 2 type changes.

### Verification

- `dune build lib/` green; `test/test_fusion_status_tool.ml` 5/5.
- Tests run the projection on isolated `Fusion_run_registry.create ()` instances (no global-state coupling, no reset backdoor) and assert keeper-LLM visibility via `model_visible_descriptors` (the Default gate) + the `enforce_visible_tag_coverage` boot invariant.
- **Mutation-proven**: dropping the `~visibility:Default` override fails the visibility test; mislabelling `ok=false` as `completed` fails the label test.
- Tool ratchets (RFC-0064 / RFC-0194 §3 / retired-husk / synthetic-residue / substrate-adapter) and the DET/NDT determinism contract pass locally.
- ocamlformat clean on changed `.ml`/`.mli`.

RFC-0266 §7 / §9 Phase 3. Phase 1 (#21677) and Phase 2 (#21695) merged. Follow-on: Phase 4 dashboard fusion-runs panel (task-1433).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
