### PR TITLE
test(memory-os): RFC-0259 P3 run_reconcile IO coverage + expose Fact_store_corrupt

### DIFF
--- a/lib/keeper/keeper_memory_os_reconcile.mli
+++ b/lib/keeper/keeper_memory_os_reconcile.mli
@@ -92,6 +92,13 @@ val reconcile_facts
   -> fact list
   -> fact list * apply_report
 
+(** Raised by {!run_reconcile} when the store cannot be fully parsed: the corrupt
+    store is left byte-for-byte untouched and the error surfaced, rather than the
+    rewrite erasing the rows around one bad line (mirrors
+    {!Keeper_memory_os_gc.Fact_store_corrupt}). Exposed so callers — and the IO
+    tests — can tell a preserve-over-delete abort apart from a normal reconcile. *)
+exception Fact_store_corrupt of string
+
 (** RFC-0259 §3.4 (P3): apply the reconciler to one keeper's store under the
     per-keeper facts lock (the lock GC/librarian/consolidation already hold on
     [facts_path], so no concurrent writer's update is lost). Reads strictly — a

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -9,6 +9,7 @@ module Librarian_runtime = Masc.Keeper_librarian_runtime
 module Prompt_names = Keeper_prompt_names
 module Recall = Masc.Keeper_memory_os_recall
 module Consolidator = Masc.Keeper_memory_os_consolidator
+module Reconcile = Masc.Keeper_memory_os_reconcile
 
 let contains substring s =
   let sub_len = String.length substring in
@@ -1288,6 +1289,158 @@ let test_gc_preserves_corrupt_store () =
       "valid fact still on disk"
       1
       (List.length (Memory_io.read_facts_all ~keeper_id))))
+;;
+
+(* RFC-0259 P3: [run_reconcile] is the only code that persists reconciler verdicts
+   to disk. The pure [reconcile_facts] core is covered in test_rfc0259_reconcile;
+   these pin the IO path that had zero coverage (the merge-blocker from the
+   adversarial review): the dry-run write gate, the advance rewrite, the
+   demote-not-delete invariant on terminal state, and the corrupt-store abort. Each
+   test also fails under a specific mutation noted in its body, so they guard
+   behaviour rather than merely exercising it. *)
+
+let reconcile_verify_const state : Reconcile.verify_fn = fun _ref -> state
+
+(* A volatile, past-horizon, ref-bearing fact — the only shape [classify] routes to
+   a non-Fresh verdict (and thus to advance/demote). *)
+let stale_ref_fact ~now ~id claim =
+  { (fact_fixture ~now ()) with
+    Types.claim
+  ; Types.external_ref = Some { Types.kind = Types.Pr; id }
+  ; Types.first_seen = now -. 100_000.0
+  ; Types.last_verified_at = Some (now -. 100_000.0)
+  }
+;;
+
+let test_run_reconcile_dry_run_does_not_write () =
+  with_eio (fun ~sw:_ ~net:_ ~clock:_ ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      let keeper_id = "reconcile-dryrun-keeper" in
+      let now = 1_000_000.0 in
+      let horizon = 3600.0 in
+      (* A still-open ref is the only verdict that writes (advances), so it is the
+         case where the dry-run gate actually has to suppress a write. *)
+      Memory_io.append_fact ~keeper_id (stale_ref_fact ~now ~id:"2" "PR #2 in review");
+      let path = Memory_io.facts_path ~keeper_id in
+      let read_raw () = In_channel.with_open_bin path In_channel.input_all in
+      let before = read_raw () in
+      let report =
+        Reconcile.run_reconcile
+          ~dry_run:true
+          ~keeper_id
+          ~now
+          ~horizon
+          ~verify:(reconcile_verify_const Reconcile.Still_open)
+          ()
+      in
+      (* The verdict is still computed — dry-run reports the advance it WOULD make ... *)
+      Alcotest.(check int) "dry-run still classifies the advance" 1 report.Reconcile.advanced;
+      (* ... but MUTATION: dropping [not dry_run] from the write guard would rewrite
+         the store here, and this byte-for-byte comparison would fail. This is the
+         default-OFF rollout's core promise (review logs before APPLY). *)
+      Alcotest.(check string)
+        "dry-run leaves the store byte-for-byte untouched"
+        before
+        (read_raw ())))
+;;
+
+let test_run_reconcile_apply_demotes_terminal_keeps_it () =
+  with_eio (fun ~sw:_ ~net:_ ~clock:_ ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      let keeper_id = "reconcile-demote-keeper" in
+      let now = 1_000_000.0 in
+      let horizon = 3600.0 in
+      (* A terminal ref alongside a still-open ref. The open ref's advance forces a
+         rewrite, so the terminal ref must SURVIVE that rewrite (demote-not-delete)
+         rather than being filtered out of the persisted survivors. A terminal-only
+         pass would not write at all (write guard is [advanced > 0]), so the
+         demote-vs-delete difference is only observable on disk when a rewrite
+         actually happens — hence the mix. *)
+      List.iter
+        (Memory_io.append_fact ~keeper_id)
+        [ stale_ref_fact ~now ~id:"21515" "PR #21515 merged"
+        ; stale_ref_fact ~now ~id:"2" "PR #2 in review"
+        ];
+      let verify : Reconcile.verify_fn =
+        fun r ->
+        if String.equal r.Types.id "21515" then Reconcile.Terminal else Reconcile.Still_open
+      in
+      let report =
+        Reconcile.run_reconcile ~dry_run:false ~keeper_id ~now ~horizon ~verify ()
+      in
+      Alcotest.(check int) "terminal ref demoted (counted)" 1 report.Reconcile.terminal_kept;
+      Alcotest.(check int) "open ref advanced (forces the rewrite)" 1 report.Reconcile.advanced;
+      (* Demote-not-delete (RFC-0259 §3.4): even though the store is rewritten for the
+         advance, the terminal-ref fact is persisted, not dropped — left for the
+         volatile TTL/GC to remove. MUTATION: reverting [Stale_terminal] to a drop
+         leaves only "PR #2 in review" on disk and this fails. *)
+      Alcotest.(check (list string))
+        "both refs still on disk (terminal demoted, not deleted)"
+        [ "PR #21515 merged"; "PR #2 in review" ]
+        (List.map (fun f -> f.Types.claim) (Memory_io.read_facts_all ~keeper_id))))
+;;
+
+let test_run_reconcile_apply_advance_persists () =
+  with_eio (fun ~sw:_ ~net:_ ~clock:_ ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      let keeper_id = "reconcile-advance-keeper" in
+      let now = 1_000_000.0 in
+      let horizon = 3600.0 in
+      Memory_io.append_fact ~keeper_id (stale_ref_fact ~now ~id:"2" "PR #2 in review");
+      let report =
+        Reconcile.run_reconcile
+          ~dry_run:false
+          ~keeper_id
+          ~now
+          ~horizon
+          ~verify:(reconcile_verify_const Reconcile.Still_open)
+          ()
+      in
+      Alcotest.(check int) "advanced the still-open fact" 1 report.Reconcile.advanced;
+      Alcotest.(check int) "nothing demoted" 0 report.Reconcile.terminal_kept;
+      (* MUTATION: dropping the [advanced > 0] write guard skips this write, so
+         last_verified_at on disk would still read the old value and the ref would be
+         re-verified every cycle. *)
+      match Memory_io.read_facts_all ~keeper_id with
+      | [ s ] ->
+        Alcotest.(check (option (float 0.001)))
+          "last_verified_at advanced to now on disk"
+          (Some now)
+          s.Types.last_verified_at
+      | _ -> Alcotest.fail "expected exactly one survivor"))
+;;
+
+let test_run_reconcile_preserves_corrupt_store () =
+  with_eio (fun ~sw:_ ~net:_ ~clock:_ ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      let keeper_id = "reconcile-corrupt-keeper" in
+      let now = 1_000_000.0 in
+      let horizon = 3600.0 in
+      Memory_io.append_fact ~keeper_id (stale_ref_fact ~now ~id:"2" "PR #2 in review");
+      let path = Memory_io.facts_path ~keeper_id in
+      let oc = open_out_gen [ Open_append; Open_creat ] 0o644 path in
+      output_string oc "{ broken json\n";
+      close_out oc;
+      let read_raw () = In_channel.with_open_bin path In_channel.input_all in
+      let before = read_raw () in
+      (* MUTATION: swapping read_facts_all_strict for the lossy read_facts_all would
+         drop the bad line then rewrite — this would NOT raise and the bytes would
+         change. Both assertions guard the preserve-over-delete invariant. *)
+      (match
+         Reconcile.run_reconcile
+           ~dry_run:false
+           ~keeper_id
+           ~now
+           ~horizon
+           ~verify:(reconcile_verify_const Reconcile.Still_open)
+           ()
+       with
+       | _report -> Alcotest.fail "expected run_reconcile to raise on a corrupt store"
+       | exception Reconcile.Fact_store_corrupt _ -> ());
+      Alcotest.(check string)
+        "corrupt store left byte-for-byte untouched (no silent drop + overwrite)"
+        before
+        (read_raw ())))
 ;;
 
 let test_gc_waits_for_fact_writer_lock () =
@@ -2853,6 +3006,24 @@ let () =
             "retention rank demotes a volatile fact below durable"
             `Quick
             test_retention_rank_demotes_volatile
+        ] )
+    ; ( "rfc-0259 reconcile-io"
+      , [ Alcotest.test_case
+            "dry-run classifies but does not write (P3)"
+            `Quick
+            test_run_reconcile_dry_run_does_not_write
+        ; Alcotest.test_case
+            "apply demotes terminal ref but keeps it on disk (P3)"
+            `Quick
+            test_run_reconcile_apply_demotes_terminal_keeps_it
+        ; Alcotest.test_case
+            "apply advance persists last_verified_at (P3)"
+            `Quick
+            test_run_reconcile_apply_advance_persists
+        ; Alcotest.test_case
+            "corrupt store aborts without overwrite (P3)"
+            `Quick
+            test_run_reconcile_preserves_corrupt_store
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

머지된 RFC-0259 P3(#21668)의 `run_reconcile`(reconciler verdict를 디스크에 영속화하는 유일한 경로)에 대한 **IO 테스트 공백**을 닫는다. P3는 순수 `reconcile_facts`만 테스트했고, lock·strict-read·dry-run 게이트·atomic rewrite를 타는 `run_reconcile`은 어떤 테스트도 호출하지 않았다.

근거: P3 적대 리뷰(6차원, 2-of-3 검증)에서 "삭제/영속화 경로 0 커버리지"가 머지차단급 finding으로 식별됨. P3 본체는 이미 머지되어 demote-not-delete가 라이브이므로, 이 PR은 후속으로 커버리지만 보강한다.

## 변경

- **`test/test_keeper_memory_os.ml`**: `rfc-0259 reconcile-io` 그룹 4 케이스 추가. 기존 GC IO 테스트 하네스(`with_eio` + `with_temp_keepers_dir` + `Memory_io.append_fact`)를 재사용해 `run_reconcile`을 temp keeper store 대상으로 end-to-end 구동.
  - **dry-run**: still-open ref(advance가 write를 강제하는 유일 verdict)에서 `advanced=1`을 분류하지만 store는 byte-for-byte 무변경 (default-OFF 롤아웃의 핵심 약속).
  - **apply demote**: terminal ref + open ref 혼합 — open의 advance가 rewrite를 강제하고, 그 rewrite에서 terminal ref가 *살아남음*(demote-not-delete)을 디스크로 검증. terminal 단독은 무쓰기라 demote↔delete 차이가 디스크에 안 나타나므로 혼합이 필수.
  - **apply advance**: `last_verified_at`가 디스크에 `now`로 영속화됨.
  - **corrupt store**: 깨진 줄 1개에 `Fact_store_corrupt`로 abort + store byte-for-byte 보존(preserve-over-delete).
- **`lib/keeper/keeper_memory_os_reconcile.mli`**: `Fact_store_corrupt` 예외를 노출(`Keeper_memory_os_gc`와 동일 선례). abort 동작을 모듈 계약으로 만들고 caller/테스트가 이름으로 catch 가능하게 함. `.ml` 로직 무변경.

## 검증 (로컬)

- `dune build --root . @check` green.
- `test_keeper_memory_os` 72 tests(신규 4 포함) green.
- **Mutation 검증**(테스트가 vacuous하지 않음 증명): 각 mutation이 정확히 1개 테스트만 실패시킴.
  - `not dry_run` 가드 제거 → dry-run 테스트 fail.
  - `Stale_terminal`을 drop으로 회귀 → demote 테스트 fail (회귀 가드).
  - `read_facts_all_strict` → lossy `read_facts_all` → corrupt 테스트 fail.

## 경계 / 범위

`.ml` 로직은 건드리지 않는다(테스트 + .mli 예외 노출만). P3 적대 리뷰의 나머지 미해소 finding(verify IO를 facts lock 안에서 도는 lock-hold, rewrite의 fsync 부재, demote된 terminal fact가 valid_until까지 recall에 노출되는 tradeoff)은 별도 이슈로 추적하며 이 PR 범위가 아니다.

## 워크어라운드 게이트

해당 없음. 테스트 커버리지 추가 + 기존 예외의 계약 노출이며, telemetry-as-fix/string 분류기/N-of-M/cap-cooldown-dedup-repair 시그니처 아님.

RFC-WAIVED: test-only + .mli 예외 노출. credential/identity/operator/sandbox/dashboard/hooks/workflow subsystem 미해당이며 reconcile `.ml` 로직 무변경(RFC-0259 §3.4 계약 보강).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
