### PR TITLE
fix(discord): stream keeper replies through gate

### DIFF
--- a/lib/gate/channel_gate.ml
+++ b/lib/gate/channel_gate.ml
@@ -55,6 +55,17 @@ type dispatch_fn =
   content:string ->
   Gate_protocol.dispatch_result
 
+type streaming_dispatch_fn =
+  on_text_snapshot:(string -> unit) ->
+  channel:string ->
+  channel_user_id:string ->
+  channel_user_name:string ->
+  channel_workspace_id:string ->
+  keeper_name:string ->
+  metadata:(string * string) list ->
+  content:string ->
+  Gate_protocol.dispatch_result
+
 (* ── Configuration ──────────────────────────────────────────── *)
 
 let max_content_length () = 4000
@@ -159,7 +170,7 @@ let validate (msg : inbound_message) =
 
 (* ── Dispatch ────────────────────────────────────────────────── *)
 
-let handle_inbound ~dispatch (msg : inbound_message) =
+let handle_inbound_with ~dispatch (msg : inbound_message) =
   let channel = msg.channel in
   match validate msg with
   | Error e ->
@@ -219,3 +230,9 @@ let handle_inbound ~dispatch (msg : inbound_message) =
              ~duration_ms:0
              Channel_gate_metrics.Dispatch_unavailable;
            Error Dispatch_unavailable)
+
+let handle_inbound ~dispatch msg =
+  handle_inbound_with ~dispatch msg
+
+let handle_inbound_streaming ~dispatch ~on_text_snapshot msg =
+  handle_inbound_with ~dispatch:(dispatch ~on_text_snapshot) msg

--- a/lib/gate/channel_gate.mli
+++ b/lib/gate/channel_gate.mli
@@ -100,6 +100,21 @@ type dispatch_fn =
   content:string ->
   Gate_protocol.dispatch_result
 
+type streaming_dispatch_fn =
+  on_text_snapshot:(string -> unit) ->
+  channel:string ->
+  channel_user_id:string ->
+  channel_user_name:string ->
+  channel_workspace_id:string ->
+  keeper_name:string ->
+  metadata:(string * string) list ->
+  content:string ->
+  Gate_protocol.dispatch_result
+(** Streaming dispatch function signature. [on_text_snapshot] receives a
+    connector-visible accumulated text snapshot suitable for transports that
+    edit one message in place. {!Gate_keeper_backend.dispatch_with_text_snapshot}
+    redacts provider deltas before invoking it. *)
+
 val handle_inbound :
   dispatch:dispatch_fn ->
   inbound_message ->
@@ -107,6 +122,16 @@ val handle_inbound :
 (** Validate, dedup, dispatch to keeper, return response.
     The only non-deterministic step is the keeper turn itself
     (which is on the other side of the [dispatch] boundary). *)
+
+val handle_inbound_streaming :
+  dispatch:streaming_dispatch_fn ->
+  on_text_snapshot:(string -> unit) ->
+  inbound_message ->
+  (outbound_message, gate_error) result
+(** Streaming variant of {!handle_inbound}. Validation, deduplication,
+    metrics, and result mapping are identical; only the injected dispatch
+    receives [on_text_snapshot]. Validation failures never invoke the
+    streaming callback. *)
 
 (** {1 JSON helpers} *)
 

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -740,6 +740,17 @@ let send_message ~channel_id ~content ?reply_to_message_id () =
       in
       send_chunks true content
 
+let edit_message ~channel_id ~message_id ~content () =
+  match bot_token_opt () with
+  | None -> Error Missing_token
+  | Some token ->
+      (match
+         Discord_rest_client.edit_message ~token ~channel_id ~message_id
+           ~content ()
+       with
+       | Ok () -> Ok ()
+       | Error e -> Error (Rest_error e))
+
 let trigger_typing ~channel_id () =
   match bot_token_opt () with
   | None -> Error Missing_token

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -164,6 +164,18 @@ val send_message :
     Must be called inside an Eio context (the underlying REST
     client uses the piaf-backed http pool). *)
 
+val edit_message :
+  channel_id:string ->
+  message_id:string ->
+  content:string ->
+  unit ->
+  (unit, send_error) result
+(** Patch a previously-created Discord message. Used by the in-process
+    gateway to project keeper streaming snapshots into one edited reply.
+    Content exceeding Discord's message limit is truncated by
+    {!Discord_rest_client.edit_message}; callers that need overflow delivery
+    must send follow-up messages separately. *)
+
 val trigger_typing :
   channel_id:string ->
   unit ->

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -128,7 +128,7 @@ let persist_connector_assistant_reply ~base_dir ~keeper_name ~source
     Keeper_chat_broadcast.chat_appended ~keeper_name ~source ~content ()
   end
 
-let dispatch ~sw ~clock ~proc_mgr ~net ~config
+let dispatch_core ?on_text_snapshot ~sw ~clock ~proc_mgr ~net ~config
     ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
     ~keeper_name ~metadata ~content =
   let keeper_name = String.trim keeper_name in
@@ -219,10 +219,25 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
     net;
   } in
   let start_time = Unix.gettimeofday () in
+  let on_text_delta =
+    match on_text_snapshot with
+    | None -> (fun _ -> ())
+    | Some publish_snapshot ->
+        let streamed_text = Buffer.create 1024 in
+        fun delta ->
+          Buffer.add_string streamed_text delta;
+          let snapshot = redact_text (Buffer.contents streamed_text) in
+          (try publish_snapshot snapshot with
+           | Eio.Cancel.Cancelled _ as exn -> raise exn
+           | exn ->
+               Log.Server.warn
+                 "channel gate text snapshot callback failed (keeper=%s): %s"
+                 keeper_name (Printexc.to_string exn))
+  in
   (* Channel gate needs the final keeper reply, not the async request ACK that
      plain [Keeper_tool_surface.dispatch] returns for masc_keeper_msg. *)
   match
-    Keeper_tool_surface.dispatch_stream ~on_text_delta:(fun _ -> ()) keeper_ctx
+    Keeper_tool_surface.dispatch_stream ~on_text_delta keeper_ctx
       ~name:"masc_keeper_msg" ~args
   with
   | Some result when Tool_result.is_success result ->
@@ -252,3 +267,15 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
       Gate_protocol.Keeper_error_result (redact_text (Tool_result.message result))
   | None ->
       Gate_protocol.Unavailable_result
+
+let dispatch ~sw ~clock ~proc_mgr ~net ~config ~channel ~channel_user_id
+    ~channel_user_name ~channel_workspace_id ~keeper_name ~metadata ~content =
+  dispatch_core ~sw ~clock ~proc_mgr ~net ~config ~channel ~channel_user_id
+    ~channel_user_name ~channel_workspace_id ~keeper_name ~metadata ~content
+
+let dispatch_with_text_snapshot ~on_text_snapshot ~sw ~clock ~proc_mgr ~net
+    ~config ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
+    ~keeper_name ~metadata ~content =
+  dispatch_core ~on_text_snapshot ~sw ~clock ~proc_mgr ~net ~config ~channel
+    ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
+    ~metadata ~content

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -30,6 +30,27 @@ val dispatch :
     connector fields are injected into the keeper-visible message body so
     external user identity survives memory and handoff boundaries. *)
 
+val dispatch_with_text_snapshot :
+  on_text_snapshot:(string -> unit) ->
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t option ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
+  config:Workspace.config ->
+  channel:string ->
+  channel_user_id:string ->
+  channel_user_name:string ->
+  channel_workspace_id:string ->
+  keeper_name:string ->
+  metadata:(string * string) list ->
+  content:string ->
+  Gate_protocol.dispatch_result
+(** Streaming-capable variant of {!dispatch}. The callback receives the
+    accumulated assistant text after keeper-scoped secret redaction, so
+    connector transports can update one visible message without leaking raw
+    provider deltas. The final {!Gate_protocol.dispatch_result} remains the
+    authoritative turn result. *)
+
 val agent_name_for_channel_actor :
   channel:string ->
   channel_workspace_id:string ->

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -130,6 +130,106 @@ let with_response_wait_typing_indicator ~clock ~channel_id f =
         finish ();
         raise exn)
 
+type stream_finish =
+  | Stream_not_started
+  | Stream_completed
+  | Stream_failed of State.send_error
+
+type discord_stream_reply =
+  { channel_id : string
+  ; reply_to_message_id : string
+  ; mutable message_id : string option
+  ; mutable last_edit_time : float
+  ; mutable last_edited_text : string
+  ; mutable disabled : bool
+  }
+
+let streaming_edit_interval_s = 1.0
+
+let make_discord_stream_reply ~channel_id ~reply_to_message_id =
+  { channel_id
+  ; reply_to_message_id
+  ; message_id = None
+  ; last_edit_time = 0.0
+  ; last_edited_text = ""
+  ; disabled = false
+  }
+
+let discord_stream_content snapshot =
+  snapshot
+  |> Observability_redact.redact_text
+  |> Discord_rest_client.truncate_to_limit
+
+let log_stream_error stage state error =
+  Log.Server.warn
+    "discord streaming %s failed (channel=%s reply_to=%s): %s"
+    stage state.channel_id state.reply_to_message_id
+    (Format.asprintf "%a" State.pp_send_error error)
+
+let publish_discord_stream_snapshot state snapshot =
+  if not state.disabled then begin
+    let content = discord_stream_content snapshot in
+    if not (String.equal content "" || String.equal content state.last_edited_text)
+    then
+      match state.message_id with
+      | None -> (
+          match
+            State.send_message ~channel_id:state.channel_id ~content
+              ~reply_to_message_id:state.reply_to_message_id ()
+          with
+          | Ok message_id ->
+              state.message_id <- Some message_id;
+              state.last_edit_time <- Unix.gettimeofday ();
+              state.last_edited_text <- content
+          | Error error ->
+              state.disabled <- true;
+              log_stream_error "initial send" state error)
+      | Some message_id ->
+          let elapsed = Unix.gettimeofday () -. state.last_edit_time in
+          if elapsed >= streaming_edit_interval_s then
+            match
+              State.edit_message ~channel_id:state.channel_id ~message_id
+                ~content ()
+            with
+            | Ok () ->
+                state.last_edit_time <- Unix.gettimeofday ();
+                state.last_edited_text <- content
+            | Error error ->
+                log_stream_error "edit" state error
+  end
+
+let finish_discord_stream_reply state ~final_content =
+  match state.message_id with
+  | None -> Stream_not_started
+  | Some message_id ->
+      let redacted = Observability_redact.redact_text final_content in
+      let head, overflow =
+        Discord_rest_client.split_at_codepoint redacted
+          ~limit:Discord_rest_client.message_content_limit
+      in
+      let edit_result =
+        if String.equal head state.last_edited_text then Ok ()
+        else
+          State.edit_message ~channel_id:state.channel_id ~message_id
+            ~content:head ()
+      in
+      (match edit_result with
+       | Error error ->
+           log_stream_error "final edit" state error;
+           Stream_failed error
+       | Ok () ->
+           state.last_edited_text <- head;
+           if String.equal overflow "" then Stream_completed
+           else
+             match
+               State.send_message ~channel_id:state.channel_id
+                 ~content:overflow ()
+             with
+             | Ok _ -> Stream_completed
+             | Error error ->
+                 log_stream_error "overflow send" state error;
+                 Stream_failed error)
+
 let metadata_opt key = function
   | None -> []
   | Some value ->
@@ -315,9 +415,15 @@ let handle_message_create ~dispatch
       ; metadata
       }
     in
+    let stream_reply =
+      make_discord_stream_reply ~channel_id ~reply_to_message_id:message_id
+    in
+    let on_text_snapshot =
+      publish_discord_stream_snapshot stream_reply
+    in
     (match
        with_response_wait_typing_indicator ~clock ~channel_id (fun () ->
-         Channel_gate.handle_inbound ~dispatch msg)
+         Channel_gate.handle_inbound_streaming ~dispatch ~on_text_snapshot msg)
      with
      | Error gate_err ->
        (match gate_err with
@@ -365,25 +471,37 @@ let handle_message_create ~dispatch
          Discord_observability.record_reply Discord_observability.Reply_empty
        end
        else
-         (match State.send_message ~channel_id ~content:out.content ~reply_to_message_id:message_id () with
-          | Ok _ ->
-            (match attention_event_id with
-             | Some event_id ->
-                 mark_attention_resolved ~base_dir ~keeper_name ~event_id
-                   ~reason:"discord_reply_sent"
-             | None -> ());
-            Discord_observability.record_inbound_dispatch
-              Discord_observability.Reply_sent;
-            Discord_observability.record_reply
-              Discord_observability.Reply_send_ok
-          | Error e ->
-            Discord_observability.record_inbound_dispatch
-              Discord_observability.Reply_send_error;
-            Discord_observability.record_reply
-              Discord_observability.Reply_send_failed;
-            Log.Server.error "discord send_message failed (channel=%s): %s"
-              channel_id
-              (Format.asprintf "%a" State.pp_send_error e)))
+         (match finish_discord_stream_reply stream_reply ~final_content:out.content with
+          | Stream_completed ->
+              (match attention_event_id with
+               | Some event_id ->
+                   mark_attention_resolved ~base_dir ~keeper_name ~event_id
+                     ~reason:"discord_reply_streamed"
+               | None -> ());
+              Discord_observability.record_inbound_dispatch
+                Discord_observability.Reply_sent;
+              Discord_observability.record_reply
+                Discord_observability.Reply_send_ok
+          | Stream_not_started | Stream_failed _ ->
+              (match State.send_message ~channel_id ~content:out.content ~reply_to_message_id:message_id () with
+               | Ok _ ->
+                 (match attention_event_id with
+                  | Some event_id ->
+                      mark_attention_resolved ~base_dir ~keeper_name ~event_id
+                        ~reason:"discord_reply_sent"
+                  | None -> ());
+                 Discord_observability.record_inbound_dispatch
+                   Discord_observability.Reply_sent;
+                 Discord_observability.record_reply
+                   Discord_observability.Reply_send_ok
+               | Error e ->
+                 Discord_observability.record_inbound_dispatch
+                   Discord_observability.Reply_send_error;
+                 Discord_observability.record_reply
+                   Discord_observability.Reply_send_failed;
+                 Log.Server.error "discord send_message failed (channel=%s): %s"
+                   channel_id
+                   (Format.asprintf "%a" State.pp_send_error e))))
 
 let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
   match ev with
@@ -511,7 +629,7 @@ let start ~sw ~env ~clock ~state =
     let policy = resolved_trigger_policy () in
     State.set_trigger_policy policy;
     let dispatch =
-      Gate_keeper_backend.dispatch
+      Gate_keeper_backend.dispatch_with_text_snapshot
         ~sw ~clock
         ~proc_mgr:state.Mcp_server.proc_mgr
         ~net:state.Mcp_server.net

--- a/lib/server/server_discord_in_process_gateway.mli
+++ b/lib/server/server_discord_in_process_gateway.mli
@@ -9,9 +9,11 @@
     2. For each accepted [Message_create] event, looks up the
        channel→keeper binding
        ({!Channel_gate_discord_state.keeper_for_channel}), runs the
-       keeper turn through {!Channel_gate.handle_inbound}, and posts
-       the reply back to the same channel via
-       {!Channel_gate_discord_state.send_message}.
+       keeper turn through {!Channel_gate.handle_inbound_streaming},
+       projects redacted text snapshots by posting/editing one Discord
+       reply, and falls back to
+       {!Channel_gate_discord_state.send_message} when streaming never
+       starts or fails.
 
     Always-on by design: there is no [MASC_DISCORD_BUILTIN]-style
     toggle. The legacy Python sidecar is gone — there is no

--- a/test/test_channel_gate.ml
+++ b/test/test_channel_gate.ml
@@ -261,6 +261,53 @@ let test_handle_inbound_passes_metadata_to_dispatch () =
       | None -> fail "dispatch should receive metadata")
   | Error e -> fail (Channel_gate.gate_error_to_string e)
 
+let test_handle_inbound_streaming_forwards_snapshot_callback () =
+  reset_dedup ();
+  let snapshots = ref [] in
+  let dispatch ~on_text_snapshot ~channel:_ ~channel_user_id:_
+      ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_ ~metadata:_
+      ~content:_ =
+    on_text_snapshot "partial";
+    Gate_protocol.Reply { content = "ok"; structured = None; stats = None }
+  in
+  let msg =
+    make_message ~idempotency_key:(unique_key "dispatch-stream") ()
+  in
+  match
+    Channel_gate.handle_inbound_streaming ~dispatch
+      ~on_text_snapshot:(fun text -> snapshots := text :: !snapshots)
+      msg
+  with
+  | Ok out ->
+      check string "reply content" "ok" out.content;
+      check (list string) "snapshots" [ "partial" ] (List.rev !snapshots)
+  | Error e -> fail (Channel_gate.gate_error_to_string e)
+
+let test_handle_inbound_streaming_validation_blocks_callback () =
+  reset_dedup ();
+  let dispatch_called = ref false in
+  let snapshot_called = ref false in
+  let dispatch ~on_text_snapshot:_ ~channel:_ ~channel_user_id:_
+      ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_ ~metadata:_
+      ~content:_ =
+    dispatch_called := true;
+    Gate_protocol.Reply { content = "ok"; structured = None; stats = None }
+  in
+  let msg =
+    make_message ~content:"   "
+      ~idempotency_key:(unique_key "dispatch-stream-invalid") ()
+  in
+  match
+    Channel_gate.handle_inbound_streaming ~dispatch
+      ~on_text_snapshot:(fun _ -> snapshot_called := true)
+      msg
+  with
+  | Error (Channel_gate.Validation Channel_gate.Empty_content) ->
+      check bool "dispatch not called" false !dispatch_called;
+      check bool "snapshot not called" false !snapshot_called
+  | Error _ -> fail "expected Validation(Empty_content)"
+  | Ok _ -> fail "expected validation to block dispatch"
+
 let () =
   Alcotest.run "Channel_gate"
     [
@@ -295,6 +342,10 @@ let () =
             test_handle_inbound_passes_channel_context_to_dispatch;
           test_case "passes metadata to dispatch" `Quick
             test_handle_inbound_passes_metadata_to_dispatch;
+          test_case "streaming forwards snapshot callback" `Quick
+            test_handle_inbound_streaming_forwards_snapshot_callback;
+          test_case "streaming validation blocks callback" `Quick
+            test_handle_inbound_streaming_validation_blocks_callback;
           test_case "returns keeper error" `Quick
             test_handle_inbound_keeper_error;
           test_case "returns unavailable" `Quick

--- a/test/test_channel_gate_discord_state_in_process.ml
+++ b/test/test_channel_gate_discord_state_in_process.ml
@@ -3,9 +3,10 @@
    - [keeper_for_channel] (binding lookup)
    - [send_error] / [pp_send_error] (typed REST error wrapper)
    - [send_message] error path with [DISCORD_BOT_TOKEN] unset
+   - [edit_message] error path with [DISCORD_BOT_TOKEN] unset
    - [trigger_typing] error path with [DISCORD_BOT_TOKEN] unset
 
-   The happy path of [send_message] and [trigger_typing] requires a live Discord API call
+   The happy path of Discord REST wrappers requires a live Discord API call
    and is left to operational verification. *)
 
 open Alcotest
@@ -90,6 +91,18 @@ let test_trigger_typing_without_token_returns_missing_token () =
          "expected Missing_token, got %a" State.pp_send_error other)
   | Ok () -> fail "expected error, got Ok"
 
+let test_edit_message_without_token_returns_missing_token () =
+  unsetenv "DISCORD_BOT_TOKEN";
+  match
+    State.edit_message ~channel_id:"123" ~message_id:"456" ~content:"hi" ()
+  with
+  | Error State.Missing_token -> ()
+  | Error other ->
+    fail
+      (Format.asprintf
+         "expected Missing_token, got %a" State.pp_send_error other)
+  | Ok () -> fail "expected error, got Ok"
+
 (* ---------------------------------------------------------------- *)
 (* Entry                                                            *)
 (* ---------------------------------------------------------------- *)
@@ -115,6 +128,10 @@ let () =
             test_send_message_without_token_returns_missing_token
         ; test_case "whitespace token => Missing_token" `Quick
             test_send_message_with_whitespace_token_returns_missing_token
+        ] )
+    ; ( "edit_message"
+      , [ test_case "unset token => Missing_token" `Quick
+            test_edit_message_without_token_returns_missing_token
         ] )
     ; ( "trigger_typing"
       , [ test_case "unset token => Missing_token" `Quick


### PR DESCRIPTION
## Summary
- add a streaming-aware Channel_gate entrypoint without changing the existing sync gate contract
- pass provider deltas through Gate_keeper_backend as keeper-redacted accumulated text snapshots
- stream Discord replies by posting one reply message, patching it during the keeper turn, and finalizing/falling back to the existing send path
- expose a typed Discord edit_message wrapper and cover the new gate/state contracts in tests

## Validation
- ocamlformat --check lib/gate/channel_gate.ml lib/gate/channel_gate.mli lib/gate/channel_gate_discord_state.ml lib/gate/channel_gate_discord_state.mli lib/gate_keeper_backend.ml lib/gate_keeper_backend.mli lib/server/server_discord_in_process_gateway.ml lib/server/server_discord_in_process_gateway.mli test/test_channel_gate.ml test/test_channel_gate_discord_state_in_process.ml
- git diff --check HEAD~1..HEAD
- focused Dune build not run locally: scripts/dune-local.sh refused because a bare dune build --root . process was active; CI should build this PR
