### PR TITLE
fix(ci): record CompletionAuthority.tla as known-unchecked TLA spec (unblock Meta Guards)

### DIFF
--- a/scripts/ci/check-tla-harness-coverage.sh
+++ b/scripts/ci/check-tla-harness-coverage.sh
@@ -14,6 +14,12 @@ specs/keeper-state-machine/KeeperRuntimeAttemptFSM.tla
 specs/keeper-state-machine/KeeperRuntimeRouting.tla
 specs/keeper-state-machine/KeeperPostTurnOrchestration.tla
 specs/keeper-state-machine/KeeperRolloverDecision.tla
+# RFC-0262 §9 completion-authority bug-model (#21701) ships clean/buggy cfgs but
+# was not wired into scripts/tla-check.sh, so this guard fails on main and every
+# open PR. Recorded as known unchecked debt to unblock Meta Guards now; proper
+# wiring (mirror TaskLifecycle's clean+buggy entries) is the #21701 owner's
+# follow-up. Tracking: this entry should be removed once the spec is wired.
+specs/task-lifecycle/CompletionAuthority.tla
 EOF
 }
 


### PR DESCRIPTION
## CI 언블록: CompletionAuthority.tla를 known-unchecked TLA spec으로 등록

### 문제 (모든 PR + main 차단)
#21701(RFC-0262 §9 completion-authority bug-model)이 `specs/task-lifecycle/CompletionAuthority.tla`를 clean/buggy cfg와 함께 추가했으나 `scripts/tla-check.sh`에 wiring하지 않음. `check-tla-harness-coverage.sh` 가드가 **main과 모든 열린 PR의 Meta Guards를 fail**시킴(cfg-backed인데 미커버).

증거: 임의 PR의 Meta Guards 로그 — `FAIL: cfg-backed TLA+ specs not covered by scripts/tla-check.sh: specs/task-lifecycle/CompletionAuthority.tla`.

### 변경
`known_unchecked_specs`에 audit note + 1줄 등록. 가드가 명시적으로 제공하는 sanctioned escape("Either wire the spec into scripts/tla-check.sh or add it to the known_unchecked_specs list with an audit note"). **코드/동작 변경 없음**(CI 가드 디버트 리스트만).

### 범위 / 후속
정식 wiring(TaskLifecycle의 clean+buggy 엔트리를 `tla-check.sh`에 미러링)은 **#21701 owner 후속**. note에 "wiring 후 이 엔트리 제거" 추적 명시. bug-model의 clean=pass/buggy=fail 실제 검증은 그 wiring 시점에 활성화됨.

### 검증
`bash scripts/ci/check-tla-harness-coverage.sh` → `=== TLA harness coverage: PASS ===` (이전: CompletionAuthority FAIL).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
