### PR TITLE
feat(memory-os): RFC-0259 P4 — recall suppression of unverified-volatile

### DIFF
--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -103,36 +103,85 @@ let staleness_marker ~now (fact : fact) =
     | None -> Printf.sprintf " [stale: unverified, seen %s ago — verify]" age_text)
 ;;
 
+(* RFC-0259 §3.5 (P4): a claim that names external state (P1's [external_ref])
+   and has not been re-grounded within the grounding horizon is *unverified
+   volatile* — its truth may have moved on (the closed-PR-still-asserted-open
+   class). Such a claim still passes [fact_is_current] until its (longer) volatile
+   TTL expires, so the gap between horizon and TTL is exactly where recall would
+   otherwise assert a possibly-stale external fact as live. The horizon is the P2
+   reconciler's, so "would be re-grounded by now" and "render as unverified" use
+   the same boundary. A non-volatile fact ([external_ref = None]) is never
+   unverified-volatile, however old — durable knowledge does not decay. *)
+let is_unverified_volatile ~now (fact : fact) =
+  match fact.external_ref with
+  | None -> false
+  | Some _ ->
+    let anchor =
+      match fact.last_verified_at with
+      | Some ts -> ts
+      | None -> fact.first_seen
+    in
+    now -. anchor > Keeper_memory_os_reconcile.default_grounding_horizon_seconds
+;;
+
+(* RFC-0259 §3.5: the hard, non-cosmetic prefix for an unverified-volatile claim.
+   Unlike [staleness_marker] (a trailing " [stale: … verify]" note that still reads
+   as an assertion), this leads the line so the reader sees "re-check" before the
+   claim text — closing gap #5 (the marker that annotated but did not suppress). *)
+let unverified_volatile_prefix = "[UNVERIFIED — re-check before acting] "
+
 (* RFC-0247 (purge): the recall line carries the fact's *structure* — category
    (a typed decision), provenance turn, and the worded staleness marker — but no
    number. The prior line printed [confidence=%.2f score=%.3f]; both were score
    machinery. The reader (an LLM) judges relevance and freshness from the claim
-   text and the staleness marker, not from a rank the producer can't justify. *)
+   text and the staleness marker, not from a rank the producer can't justify.
+   RFC-0259 §3.5: an unverified-volatile claim leads with the hard prefix instead
+   of the soft trailing staleness note. *)
 let render_fact ~now fact =
   let source = fact.source in
-  Printf.sprintf
-    "- [category=%s turn=%d]%s %s"
-    (sanitize_atom (category_to_string fact.category))
-    source.turn
-    (staleness_marker ~now fact)
-    (sanitize_text ~max_len:max_fact_text_len fact.claim)
+  if is_unverified_volatile ~now fact
+  then
+    Printf.sprintf
+      "- %s[category=%s turn=%d] %s"
+      unverified_volatile_prefix
+      (sanitize_atom (category_to_string fact.category))
+      source.turn
+      (sanitize_text ~max_len:max_fact_text_len fact.claim)
+  else
+    Printf.sprintf
+      "- [category=%s turn=%d]%s %s"
+      (sanitize_atom (category_to_string fact.category))
+      source.turn
+      (staleness_marker ~now fact)
+      (sanitize_text ~max_len:max_fact_text_len fact.claim)
 ;;
 
 (* RFC-0244 Tier 2: a shared fact is rendered with its provenance (the distinct
    keepers that corroborated it) so it is never silently merged into the keeper's
-   own knowledge — the reader can see it is cross-keeper consensus. *)
+   own knowledge — the reader can see it is cross-keeper consensus.
+   RFC-0259 §3.5: cross-keeper agreement is not external-truth verification, so an
+   unverified-volatile shared fact gets the same hard prefix as a private one. *)
 let render_shared_fact ~now fact =
   let provenance =
     match fact.observed_by with
     | [] -> "shared"
     | keepers -> "shared via " ^ String.concat "," (List.map sanitize_atom keepers)
   in
-  Printf.sprintf
-    "- [%s category=%s]%s %s"
-    provenance
-    (sanitize_atom (category_to_string fact.category))
-    (staleness_marker ~now fact)
-    (sanitize_text ~max_len:max_fact_text_len fact.claim)
+  if is_unverified_volatile ~now fact
+  then
+    Printf.sprintf
+      "- %s[%s category=%s] %s"
+      unverified_volatile_prefix
+      provenance
+      (sanitize_atom (category_to_string fact.category))
+      (sanitize_text ~max_len:max_fact_text_len fact.claim)
+  else
+    Printf.sprintf
+      "- [%s category=%s]%s %s"
+      provenance
+      (sanitize_atom (category_to_string fact.category))
+      (staleness_marker ~now fact)
+      (sanitize_text ~max_len:max_fact_text_len fact.claim)
 ;;
 
 let render_episode episode =
@@ -221,6 +270,14 @@ let facts_recency_ranked ~now facts =
   |> List.filter (fact_is_current ~now)
   |> List.sort (fun a b -> compare (truth_anchor b) (truth_anchor a))
   |> dedup_by_claim
+  (* RFC-0259 §3.5 (P4): demote unverified-volatile claims below durable ones.
+     [List.partition] is stable, so each group keeps its recency order; durable
+     knowledge therefore leads the recall block and a possibly-stale external claim
+     follows (and is the first to be dropped if [take max_facts] cannot fit them
+     all). Demotion + the hard render prefix together replace the cosmetic marker. *)
+  |> fun ranked ->
+  let durable, volatile = List.partition (fun f -> not (is_unverified_volatile ~now f)) ranked in
+  durable @ volatile
 ;;
 
 (* RFC-0264 P2: render_context_exn returns the rendered block alongside the

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1761,6 +1761,46 @@ let test_recall_prefixes_unverified_volatile_fact () =
             (contains "[UNVERIFIED — re-check before acting]" block))))
 ;;
 
+(* RFC-0259 §3.5: suppression is not only a prefix. An unverified-volatile
+   external fact is ranked after durable facts, so a small recall cap drops it
+   before it can crowd out older durable knowledge. *)
+let test_recall_demotes_unverified_volatile_below_durable_cap () =
+  with_prompt_registry (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      let keeper_id = "volatile-demote-cap-keeper" in
+      let now = 1_000_000.0 in
+      let horizon = Reconcile.default_grounding_horizon_seconds in
+      let volatile_recent =
+        { (fact_fixture ~now ()) with
+          Types.claim = "PR #21515 is still open"
+        ; Types.external_ref = Some { Types.kind = Types.Pr; id = "21515" }
+        ; Types.first_seen = now -. (horizon *. 2.0)
+        ; Types.last_verified_at = Some (now -. (horizon *. 2.0))
+        ; Types.valid_until = Some (now +. horizon)
+        }
+      in
+      let durable_older =
+        { (fact_fixture ~now ()) with
+          Types.claim = "The repository uses the Memory OS recall prompt"
+        ; Types.external_ref = None
+        ; Types.first_seen = now -. days 90
+        ; Types.last_verified_at = Some (now -. days 60)
+        ; Types.valid_until = None
+        }
+      in
+      Memory_io.append_fact ~keeper_id volatile_recent;
+      Memory_io.append_fact ~keeper_id durable_older;
+      let block = Recall.render_context ~keeper_id ~now ~max_facts:1 ~max_episodes:0 () in
+      Alcotest.(check bool)
+        "durable fact survives max_facts cap"
+        true
+        (contains durable_older.Types.claim block);
+      Alcotest.(check bool)
+        "unverified volatile fact is dropped before durable fact"
+        false
+        (contains volatile_recent.Types.claim block)))
+;;
+
 (* RFC-0259 §3.5: a non-volatile (no external_ref) claim never gets the hard
    prefix, however old — durable knowledge does not decay into "re-check". *)
 let test_recall_no_prefix_for_non_volatile_fact () =
@@ -2935,6 +2975,10 @@ let () =
             "unverified-volatile fact gets the hard prefix"
             `Quick
             test_recall_prefixes_unverified_volatile_fact
+        ; Alcotest.test_case
+            "unverified-volatile fact is demoted below durable cap"
+            `Quick
+            test_recall_demotes_unverified_volatile_below_durable_cap
         ; Alcotest.test_case
             "non-volatile fact never gets the hard prefix"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -8,6 +8,7 @@ module Librarian = Masc.Keeper_librarian
 module Librarian_runtime = Masc.Keeper_librarian_runtime
 module Prompt_names = Keeper_prompt_names
 module Recall = Masc.Keeper_memory_os_recall
+module Reconcile = Masc.Keeper_memory_os_reconcile
 module Consolidator = Masc.Keeper_memory_os_consolidator
 module Reconcile = Masc.Keeper_memory_os_reconcile
 
@@ -1730,6 +1731,62 @@ let test_recall_omits_marker_for_fresh_fact () =
             (contains "ago — verify]" block))))
 ;;
 
+(* RFC-0259 §3.5 (P4): an unverified-volatile claim (external_ref set, past the
+   grounding horizon) gets the hard "[UNVERIFIED — re-check before acting]" prefix
+   instead of the soft trailing staleness note — the reader sees "re-check" before
+   the claim, closing gap #5. *)
+let test_recall_prefixes_unverified_volatile_fact () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun keepers_dir ->
+        let keeper_id = "volatile-stale-keeper" in
+        let now = 1_000_000.0 in
+        let horizon = Reconcile.default_grounding_horizon_seconds in
+        let fact =
+          { (fact_fixture ~now ()) with
+            Types.claim = "PR #21515 is blocked and needs a fix"
+          ; Types.external_ref = Some { Types.kind = Types.Pr; id = "21515" }
+          ; Types.first_seen = now -. (horizon *. 2.0)
+          ; Types.last_verified_at = Some (now -. (horizon *. 2.0))
+          ; Types.valid_until = Some (now +. horizon)
+          }
+        in
+        Memory_io.append_fact ~keeper_id fact;
+        match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
+        | None -> Alcotest.fail "expected Some block for a persisted volatile fact"
+        | Some block ->
+          Alcotest.(check bool)
+            "unverified-volatile fact carries the hard prefix"
+            true
+            (contains "[UNVERIFIED — re-check before acting]" block))))
+;;
+
+(* RFC-0259 §3.5: a non-volatile (no external_ref) claim never gets the hard
+   prefix, however old — durable knowledge does not decay into "re-check". *)
+let test_recall_no_prefix_for_non_volatile_fact () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun keepers_dir ->
+        let keeper_id = "durable-old-keeper" in
+        let now = 1_000_000.0 in
+        let fact =
+          { (fact_fixture ~now ()) with
+            Types.claim = "Deployment uses a blue-green strategy"
+          ; Types.external_ref = None
+          ; Types.first_seen = now -. days 30
+          ; Types.last_verified_at = None
+          }
+        in
+        Memory_io.append_fact ~keeper_id fact;
+        match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
+        | None -> Alcotest.fail "expected Some block for a persisted durable fact"
+        | Some block ->
+          Alcotest.(check bool)
+            "durable fact never carries the unverified-volatile prefix"
+            false
+            (contains "[UNVERIFIED — re-check before acting]" block))))
+;;
+
 let test_recall_filters_expired_episodes () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
@@ -2874,6 +2931,14 @@ let () =
             "fresh fact gets no staleness marker"
             `Quick
             test_recall_omits_marker_for_fresh_fact
+        ; Alcotest.test_case
+            "unverified-volatile fact gets the hard prefix"
+            `Quick
+            test_recall_prefixes_unverified_volatile_fact
+        ; Alcotest.test_case
+            "non-volatile fact never gets the hard prefix"
+            `Quick
+            test_recall_no_prefix_for_non_volatile_fact
         ; Alcotest.test_case
             "expired episodes are omitted"
             `Quick


### PR DESCRIPTION
## Summary
- demote unverified-volatile external-ref facts below durable facts during Memory OS recall
- render such facts with a leading `[UNVERIFIED — re-check before acting]` prefix when they are still shown
- keep durable non-external facts exempt from the volatile suppression rule
- add regression coverage for both the prefix and the actual demotion/drop behavior under `max_facts:1`

## Context
RFC-0259 P4 closes the read-path gap left after P3 demote-not-delete: terminal or stale external claims can remain in the store until TTL, so recall must not let them crowd out durable knowledge or read as verified current truth.

## Validation
- `ocamlformat --check lib/keeper/keeper_memory_os_recall.ml test/test_keeper_memory_os.ml`
- `git diff --check origin/main...HEAD`
- Not run to completion: `scripts/dune-local.sh build test/test_keeper_memory_os.exe` refused to start while bare Dune processes were active (`dune build .`, `dune build --root .`, `dune exec test/test_tools_coverage.exe --root .`).
