### PR TITLE
test(specs): wire CompletionAuthority into tla-check.sh harness coverage

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -244,6 +244,8 @@ run_tlc "$REPO_ROOT/specs/state-product" "WorkspaceProduct.tla"
 run_tlc_buggy "$REPO_ROOT/specs/state-product" "WorkspaceProduct.tla"
 run_tlc "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
+run_tlc "$REPO_ROOT/specs/task-lifecycle" "CompletionAuthority.tla"
+run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "CompletionAuthority.tla"
 
 run_tlc "$REPO_ROOT/specs/goal-loop" "TierRouting.tla"
 run_tlc_buggy "$REPO_ROOT/specs/goal-loop" "TierRouting.tla"


### PR DESCRIPTION
## 요약

#21701이 `specs/task-lifecycle/CompletionAuthority.tla` + clean/buggy cfg + `specs/INDEX.md`는 추가했으나, **`scripts/tla-check.sh` 등록을 빠뜨려** main에서 Meta Guards가 실패합니다:

```
FAIL: cfg-backed TLA+ specs not covered by scripts/tla-check.sh:
  specs/task-lifecycle/CompletionAuthority.tla
```

## 근본 원인

TLA spec 등록은 **3중 게이트**인데 #21701이 2개만 충족했습니다:
1. `specs/INDEX.md` (drift-check) — ✅ 충족
2. Makefile cfg auto-discovery (TLA+ Main Verification) — ✅ 충족 (main에서 success)
3. `scripts/tla-check.sh` 명시 커버리지 목록 (`check-tla-harness-coverage.sh` = Meta Guards) — ❌ 누락

## 변경

`scripts/tla-check.sh`의 TaskLifecycle 바로 뒤에 2줄 추가:

```sh
run_tlc "$REPO_ROOT/specs/task-lifecycle" "CompletionAuthority.tla"
run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "CompletionAuthority.tla"
```

`known_unchecked_specs`에 추가하는 escape hatch가 아니라 **실제로 harness가 spec을 돌리게** 배선했습니다 — 검증 가능한 spec을 검증에서 면제하지 않음. `run_tlc`는 `CompletionAuthority.cfg`, `run_tlc_buggy`는 `CompletionAuthority-buggy.cfg`를 유도(기존 cfg와 일치).

## 검증

- `bash scripts/ci/check-tla-harness-coverage.sh` → `=== TLA harness coverage: PASS ===` (수정 전엔 위 FAIL).
- cfg verdict 자체는 TLA+ Main Verification(#21701, 446c2b435c)에서 이미 success(clean no-error + buggy invariant violated).

RFC-WAIVED: gated subsystem 아님 — TLA harness 커버리지 등록 누락 보완(#21701 후속).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
