### PR TITLE
fix(fusion): scope status tool to caller keeper

### DIFF
--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -408,12 +408,13 @@ let handle_masc_fusion ~(config : Workspace.config) ~(meta : keeper_meta) ~args 
          ])
 ;;
 
-(* RFC-0266 §7 Phase 3 — masc_fusion_status: read-only view of the fusion run
-   registry (in-progress + recently completed). [fusion_status_json] is the
+(* RFC-0266 §7 Phase 3 — masc_fusion_status: read-only view of the caller's
+   fusion runs (in-progress + recently completed). [fusion_status_json] is the
    pure projection over any registry instance, so tests exercise it on an
    isolated [Fusion_run_registry.create ()]; [handle_masc_fusion_status] binds
-   the process-wide [global] the fusion tool/sink write to. *)
-let fusion_status_json ~(registry : Fusion_run_registry.t) ~run_id : string =
+   the process-wide [global] the fusion tool/sink write to and scopes by the
+   calling keeper. *)
+let fusion_status_json ~(registry : Fusion_run_registry.t) ~keeper ~run_id : string =
   let status_label (status : Fusion_run_registry.run_status) =
     match status with
     | Fusion_run_registry.Running -> "running"
@@ -429,9 +430,23 @@ let fusion_status_json ~(registry : Fusion_run_registry.t) ~run_id : string =
       ; "status", `String (status_label r.status)
       ]
   in
+  let belongs_to_keeper (r : Fusion_run_registry.run) =
+    String.equal r.keeper keeper
+  in
+  let not_found () =
+    Yojson.Safe.to_string
+      (`Assoc
+         [ "ok", `Bool true
+         ; "found", `Bool false
+         ; "run_id", `String run_id
+         ; "status", `String "not_found"
+         ])
+  in
   if String.equal run_id ""
   then begin
-    let runs = Fusion_run_registry.list_runs registry in
+    let runs =
+      Fusion_run_registry.list_runs registry |> List.filter belongs_to_keeper
+    in
     Yojson.Safe.to_string
       (`Assoc
          [ "ok", `Bool true
@@ -441,22 +456,15 @@ let fusion_status_json ~(registry : Fusion_run_registry.t) ~run_id : string =
   end
   else (
     match Fusion_run_registry.get registry ~run_id with
-    | Some run ->
+    | Some run when belongs_to_keeper run ->
       Yojson.Safe.to_string
         (`Assoc [ "ok", `Bool true; "found", `Bool true; "run", run_to_yojson run ])
-    | None ->
-      Yojson.Safe.to_string
-        (`Assoc
-           [ "ok", `Bool true
-           ; "found", `Bool false
-           ; "run_id", `String run_id
-           ; "status", `String "not_found"
-           ]))
+    | Some _ | None -> not_found ())
 ;;
 
-let handle_masc_fusion_status ~args () =
+let handle_masc_fusion_status ~(meta : keeper_meta) ~args () =
   let run_id = Safe_ops.json_string ~default:"" "run_id" args |> String.trim in
-  fusion_status_json ~registry:Fusion_run_registry.global ~run_id
+  fusion_status_json ~registry:Fusion_run_registry.global ~keeper:meta.name ~run_id
 ;;
 
 (* RFC-0182 §3.1 — masc_tool_shard cluster.  [Tool_shard.execute]

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -219,23 +219,31 @@ val handle_masc_fusion
   -> unit
   -> string
 
-(** RFC-0266 §7 Phase 3 — [fusion_status_json] projects a fusion run registry
-    to the masc_fusion_status tool's JSON string. With an empty [run_id] it
-    lists every tracked run ([{ ok; count; runs }]); with a non-empty [run_id]
-    it returns the single run ([{ ok; found; run }]) or a not-found envelope
-    ([{ ok; found = false; run_id; status = "not_found" }]). Each run's status
-    is rendered as ["running"], ["completed"] (ok), or ["failed"] (denied /
-    sink-failed / aborted). Pure over [registry] so tests can pass an isolated
+(** RFC-0266 §7 Phase 3 — [fusion_status_json] projects the calling keeper's
+    fusion runs to the masc_fusion_status tool's JSON string. With an empty
+    [run_id] it lists every tracked run owned by [keeper]
+    ([{ ok; count; runs }]); with a non-empty [run_id] it returns the owned
+    single run ([{ ok; found; run }]) or a not-found envelope
+    ([{ ok; found = false; run_id; status = "not_found" }]). A run owned by a
+    different keeper is reported as not found. Each run's status is rendered as
+    ["running"], ["completed"] (ok), or ["failed"] (denied / sink-failed /
+    aborted). Pure over [registry] so tests can pass an isolated
     [Fusion_run_registry.create ()]. *)
 val fusion_status_json
   :  registry:Fusion_run_registry.t
+  -> keeper:string
   -> run_id:string
   -> string
 
 (** RFC-0266 §7 Phase 3 — in-process handler for the [masc_fusion_status]
     read-only tool. Parses the optional [run_id] argument and projects the
-    process-wide [Fusion_run_registry.global] via {!fusion_status_json}. *)
-val handle_masc_fusion_status : args:Yojson.Safe.t -> unit -> string
+    process-wide [Fusion_run_registry.global] via {!fusion_status_json}, scoped
+    to [meta.name]. *)
+val handle_masc_fusion_status
+  :  meta:Keeper_meta_contract.keeper_meta
+  -> args:Yojson.Safe.t
+  -> unit
+  -> string
 
 (** RFC-0182 §3.1 — [handle_masc_keeper] is the descriptor-projection
     cluster handler for the [masc_keeper_*] ctx-free tool surface.

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -305,7 +305,11 @@ let handle_in_process ctx descriptor args =
          ())
   | Tool_masc_fusion_status ->
     (* read-only: reads the in-memory run registry, no server context needed. *)
-    Some (Keeper_tool_in_process_runtime.handle_masc_fusion_status ~args ())
+    Some
+      (Keeper_tool_in_process_runtime.handle_masc_fusion_status
+         ~meta:ctx.meta
+         ~args
+         ())
   | Tool_execute
   | Tool_search_files
   | Tool_read_file

--- a/test/test_fusion_status_tool.ml
+++ b/test/test_fusion_status_tool.ml
@@ -2,7 +2,8 @@
 
    Two failure modes a stub could introduce while still compiling:
 
-   1. the JSON projection [fusion_status_json] mislabels a run status (e.g.
+   1. the JSON projection [fusion_status_json] leaks another keeper's run or
+      mislabels a run status (e.g.
       reports a denied/sink-failed run as "completed"), or returns the wrong
       shape for list vs single-run vs unknown-run_id; and
    2. the tool is wired but NOT visible to the keeper LLM (Pass B requires
@@ -59,21 +60,28 @@ let find_run runs id =
 let seeded () =
   let t = R.create () in
   R.register_running t ~run_id:"r-run" ~keeper:"k1" ~preset:"balanced" ~started_at:300.0;
-  R.register_running t ~run_id:"r-done" ~keeper:"k2" ~preset:"deep" ~started_at:100.0;
+  R.register_running t ~run_id:"r-done" ~keeper:"k1" ~preset:"deep" ~started_at:100.0;
   R.mark_completed t ~run_id:"r-done" ~ok:true;
-  R.register_running t ~run_id:"r-fail" ~keeper:"k3" ~preset:"deep" ~started_at:200.0;
+  R.register_running t ~run_id:"r-fail" ~keeper:"k1" ~preset:"deep" ~started_at:200.0;
   R.mark_completed t ~run_id:"r-fail" ~ok:false;
+  R.register_running
+    t
+    ~run_id:"r-foreign"
+    ~keeper:"k2"
+    ~preset:"balanced"
+    ~started_at:400.0;
   t
 ;;
 
-(* (1a) list mode: every tracked run, newest-first, with the right status label.
-   The label mapping is the mutation-sensitive core — ok=false must read
-   "failed", not "completed". *)
-let test_list_all () =
-  let json = H.fusion_status_json ~registry:(seeded ()) ~run_id:"" |> parse in
+(* (1a) list mode: only the calling keeper's tracked runs, newest-first, with
+   the right status label. The label mapping is the mutation-sensitive core —
+   ok=false must read "failed", not "completed". *)
+let test_list_scoped_to_keeper () =
+  let json = H.fusion_status_json ~registry:(seeded ()) ~keeper:"k1" ~run_id:"" |> parse in
   check bool "ok" true (bool_ json "ok");
   check int "count" 3 (int_ json "count");
   let runs = runs_of json in
+  check int "only caller keeper runs" 3 (List.length runs);
   check string "newest started_at first" "r-run" (str (List.hd runs) "run_id");
   check string "running label" "running" (str (find_run runs "r-run") "status");
   check string "completed label" "completed" (str (find_run runs "r-done") "status");
@@ -86,7 +94,9 @@ let test_list_all () =
 
 (* (1b) single-run lookup: found -> {found=true; run}. *)
 let test_single_found () =
-  let json = H.fusion_status_json ~registry:(seeded ()) ~run_id:"r-fail" |> parse in
+  let json =
+    H.fusion_status_json ~registry:(seeded ()) ~keeper:"k1" ~run_id:"r-fail" |> parse
+  in
   check bool "ok" true (bool_ json "ok");
   check bool "found" true (bool_ json "found");
   let run =
@@ -98,10 +108,24 @@ let test_single_found () =
   check string "single run status" "failed" (str run "status")
 ;;
 
-(* (1c) unknown run_id -> a deterministic not_found envelope, not an empty/ok
+(* (1c) a keeper cannot fetch another keeper's run_id even when the run exists
+   in the process-wide registry. *)
+let test_single_foreign_run_not_found () =
+  let json =
+    H.fusion_status_json ~registry:(seeded ()) ~keeper:"k1" ~run_id:"r-foreign" |> parse
+  in
+  check bool "ok" true (bool_ json "ok");
+  check bool "found is false" false (bool_ json "found");
+  check string "echoes the queried run_id" "r-foreign" (str json "run_id");
+  check string "status not_found" "not_found" (str json "status")
+;;
+
+(* (1d) unknown run_id -> a deterministic not_found envelope, not an empty/ok
    silent drop. *)
 let test_single_not_found () =
-  let json = H.fusion_status_json ~registry:(seeded ()) ~run_id:"ghost" |> parse in
+  let json =
+    H.fusion_status_json ~registry:(seeded ()) ~keeper:"k1" ~run_id:"ghost" |> parse
+  in
   check bool "ok" true (bool_ json "ok");
   check bool "found is false" false (bool_ json "found");
   check string "echoes the queried run_id" "ghost" (str json "run_id");
@@ -110,7 +134,7 @@ let test_single_not_found () =
 
 (* empty registry lists nothing but still returns the ok/count/runs shape *)
 let test_empty_registry () =
-  let json = H.fusion_status_json ~registry:(R.create ()) ~run_id:"" |> parse in
+  let json = H.fusion_status_json ~registry:(R.create ()) ~keeper:"k1" ~run_id:"" |> parse in
   check int "empty count" 0 (int_ json "count");
   check int "empty runs list" 0 (List.length (runs_of json))
 ;;
@@ -137,8 +161,9 @@ let () =
   run
     "fusion_status_tool"
     [ ( "rfc-0266-phase3"
-      , [ test_case "list all runs (newest-first, status labels)" `Quick test_list_all
+      , [ test_case "list caller runs only (newest-first)" `Quick test_list_scoped_to_keeper
         ; test_case "single run found" `Quick test_single_found
+        ; test_case "foreign run_id -> not_found" `Quick test_single_foreign_run_not_found
         ; test_case "unknown run_id -> not_found" `Quick test_single_not_found
         ; test_case "empty registry shape" `Quick test_empty_registry
         ; test_case "tool is visible to the keeper LLM" `Quick test_tool_is_keeper_visible


### PR DESCRIPTION
## Summary
- scope masc_fusion_status list and single-run lookup to ctx.meta.name
- return not_found for another keeper run_id instead of leaking registry metadata
- add regression coverage for same-keeper status labels and foreign run_id denial

## Context
Follow-up for merged #21712. The adversarial blocker was still present at merge time: the Default-visible keeper tool read Fusion_run_registry.global without an ownership filter.

## Validation
- ocamlformat --check lib/keeper/keeper_tool_in_process_runtime.ml lib/keeper/keeper_tool_in_process_runtime.mli lib/keeper/keeper_tool_runtime.ml test/test_fusion_status_tool.ml
- git diff --check origin/main...HEAD
- Not run to completion: scripts/dune-local.sh build test/test_fusion_status_tool.exe (stopped after it kept running; build deferred per operator instruction)
