### PR TITLE
[codex] connect keeper chat work trace output

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1560,6 +1560,64 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     expect(container.querySelectorAll('[data-chat-variant="tool-call"]').length).toBe(0)
   })
 
+  it('keeps grouped tool calls connected to the following assistant answer', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({ id: 'tool-t1', label: 'keeper_board_list' }),
+          entry({
+            id: 'a',
+            text: '도구 결과로 답합니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            traceSteps: [{ kind: 'think', text: 'reading tool output' }],
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const bundle = container.querySelector('[data-chat-turn-bundle]')
+    expect(bundle).not.toBeNull()
+    expect(bundle?.querySelector('[data-chat-work-trace]')).not.toBeNull()
+    expect(bundle?.querySelector('[data-chat-variant="messenger"]')).not.toBeNull()
+    expect(bundle?.textContent).toContain('Thinking')
+    expect(bundle?.textContent).toContain('reading tool output')
+    expect(bundle?.textContent).toContain('keeper_board_list')
+    expect(bundle?.textContent).toContain('도구 결과로 답합니다')
+  })
+
+  it('renders assistant thinking as 작업 과정 even without tool calls', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'a',
+            text: '곧 답합니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            traceSteps: [{ kind: 'think', text: 'checking context' }],
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const bundle = container.querySelector('[data-chat-turn-bundle]')
+    expect(bundle).not.toBeNull()
+    expect(bundle?.textContent).toContain('작업 과정')
+    expect(bundle?.textContent).toContain('1단계')
+    expect(bundle?.textContent).toContain('Thinking')
+    expect(bundle?.textContent).toContain('checking context')
+    expect(bundle?.textContent).toContain('곧 답합니다')
+  })
+
   it('keeps the flat per-row tool bubbles when grouping is off (default)', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -953,7 +953,7 @@ function ChatTraceStep({ step }: { step: ChatTraceStep }) {
         <div class="min-w-0 flex-1">
           <div class="chat-block-tstep-row">
             <span class="chat-block-tstep-kind">Thinking</span>
-            <span>${step.text}</span>
+            <span class="chat-block-tstep-text">${step.text}</span>
           </div>
         </div>
       </div>
@@ -2097,14 +2097,17 @@ function ToolTraceStep({ entry, output }: { entry: KeeperConversationEntry; outp
   `
 }
 
-// Groups a turn's consecutive tool-call entries into one "작업 과정"
-// trace card placed above the answer bubble — the v2 layout, built from live
-// data. The step list is visible by default so operators can see tool names and
-// status without opening the card; each step's raw args/result body remains
-// collapsed to avoid a wall of JSON. No think/reason steps are synthesised: the
-// live transcript has no reasoning channel, so the card omits them rather than
-// fabricate the v2 reference's mock reasoning.
-function ToolTraceCard({ tools }: { tools: KeeperConversationEntry[] }) {
+// Groups a turn's explicit progress/tool entries into one "작업 과정" trace
+// card placed above the answer bubble. The step list is visible by default so
+// operators can see thinking progress, tool names, and status without opening
+// each raw args/result body.
+function ToolTraceCard({
+  tools,
+  traceSteps = [],
+}: {
+  tools: KeeperConversationEntry[]
+  traceSteps?: ChatTraceStep[]
+}) {
   const [open, setOpen] = useState(true)
   const steps = tools.map((entry) => ({ entry, output: lookupToolCallOutput(entry.id) }))
   const failN = steps.filter(
@@ -2112,9 +2115,10 @@ function ToolTraceCard({ tools }: { tools: KeeperConversationEntry[] }) {
   ).length
   const totalMs = steps.reduce((sum, s) => sum + (s.output?.duration_ms ?? 0), 0)
   const durLabel = totalMs > 0 ? formatMsCompact(totalMs) : null
+  const stepN = traceSteps.length + tools.length
 
   return html`
-    <div class="chat-block-trace ${open ? 'open' : ''}" data-chat-block="trace" data-chat-tool-trace>
+    <div class="chat-block-trace ${open ? 'open' : ''}" data-chat-block="trace" data-chat-work-trace data-chat-tool-trace>
       <button
         type="button"
         class="chat-block-trace-hd"
@@ -2124,9 +2128,9 @@ function ToolTraceCard({ tools }: { tools: KeeperConversationEntry[] }) {
         <span class="chat-block-trace-chev">${open ? '▾' : '▸'}</span>
         <span>◈</span>
         <span class="chat-block-trace-label">작업 과정</span>
-        <span class="chat-block-trace-count">${tools.length}단계</span>
+        <span class="chat-block-trace-count">${stepN}단계</span>
         <span class="chat-block-trace-meta">
-          <span>도구 ${tools.length}</span>
+          ${tools.length > 0 ? html`<span>도구 ${tools.length}</span>` : null}
           ${failN > 0 ? html`<span class="text-[var(--color-status-err)]">실패 ${failN}</span>` : null}
           ${durLabel ? html`<span class="tnum">${durLabel}</span>` : null}
         </span>
@@ -2135,10 +2139,41 @@ function ToolTraceCard({ tools }: { tools: KeeperConversationEntry[] }) {
         ? html`
             <div class="chat-block-trace-steps">
               <span class="chat-block-trace-rail"></span>
+              ${traceSteps.map((step, index) => html`<${ChatTraceStep} key=${`trace-${index}`} step=${step} />`)}
               ${steps.map(({ entry, output }) => html`<${ToolTraceStep} key=${entry.id} entry=${entry} output=${output} />`)}
             </div>
           `
         : null}
+    </div>
+  `
+}
+
+function TurnWorkBundle({
+  tools,
+  assistant,
+  showMetadata,
+  variant,
+  showSourceBadge,
+  action,
+}: {
+  tools: KeeperConversationEntry[]
+  assistant: KeeperConversationEntry
+  showMetadata?: boolean
+  variant: ChatTranscriptVariant
+  showSourceBadge: boolean
+  action?: ChatTranscriptAction
+}) {
+  const traceSteps = assistant.traceSteps ?? []
+  return html`
+    <div class="chat-turn-bundle" data-chat-turn-bundle>
+      <${ToolTraceCard} tools=${tools} traceSteps=${traceSteps} />
+      <${ChatMessageBubble}
+        entry=${assistant}
+        showMetadata=${showMetadata !== false}
+        variant=${variant}
+        showSourceBadge=${showSourceBadge}
+        action=${action}
+      />
     </div>
   `
 }
@@ -2151,14 +2186,12 @@ const STICK_TO_BOTTOM_THRESHOLD_PX = 80
 type ChatRenderUnit =
   | { kind: 'entry'; entry: KeeperConversationEntry }
   | { kind: 'toolGroup'; id: string; entries: KeeperConversationEntry[] }
+  | { kind: 'turnBundle'; id: string; entries: KeeperConversationEntry[]; entry: KeeperConversationEntry }
 
-// Fold maximal runs of consecutive tool-call entries into one group so they
-// render as a single "작업 과정" trace card. Adjacency is the only turn signal
-// on the transcript — chat entries carry no turn/trace id (that lives on the
-// separate ToolCallEntry) — and the live stream inserts a turn's tool rows
-// immediately before its assistant bubble (keeper-stream.ts), so a run of
-// role:'tool' entries is exactly that turn's tool set. With grouping off every
-// entry stays its own unit, leaving the flat render unchanged.
+// Fold maximal runs of consecutive tool-call entries into one group. When the
+// run is immediately followed by an assistant entry, render both as one turn
+// bundle so "작업 과정" visually belongs to the answer it produced. Assistant
+// traceSteps can also produce a bundle without tools (thinking-only turns).
 function buildChatRenderUnits(
   entries: KeeperConversationEntry[],
   groupToolCalls: boolean,
@@ -2175,6 +2208,16 @@ function buildChatRenderUnits(
     if (entry.role === 'tool') {
       run.push(entry)
     } else {
+      if (entry.role === 'assistant' && (run.length > 0 || (entry.traceSteps?.length ?? 0) > 0)) {
+        units.push({
+          kind: 'turnBundle',
+          id: `turn-${run[0]?.id ?? entry.id}`,
+          entries: run,
+          entry,
+        })
+        run = []
+        continue
+      }
       flush()
       units.push({ kind: 'entry', entry })
     }
@@ -2201,7 +2244,10 @@ function renderChatTranscriptBody(opts: {
   // second divider for a day already shown above.
   let lastDayKey: string | null = null
   for (const unit of units) {
-    const ts = unit.kind === 'entry' ? unit.entry.timestamp : unit.entries[0]?.timestamp
+    const ts =
+      unit.kind === 'entry'
+        ? unit.entry.timestamp
+        : unit.entries[0]?.timestamp ?? (unit.kind === 'turnBundle' ? unit.entry.timestamp : null)
     if (showDayDividers) {
       const dk = dayKey(ts)
       if (dk && dk !== lastDayKey) {
@@ -2211,6 +2257,16 @@ function renderChatTranscriptBody(opts: {
     }
     if (unit.kind === 'toolGroup') {
       out.push(html`<${ToolTraceCard} key=${unit.id} tools=${unit.entries} />`)
+    } else if (unit.kind === 'turnBundle') {
+      out.push(html`<${TurnWorkBundle}
+        key=${unit.id}
+        tools=${unit.entries}
+        assistant=${unit.entry}
+        showMetadata=${showMetadata}
+        variant=${variant}
+        showSourceBadge=${showSourceBadge}
+        action=${action}
+      />`)
     } else if (unit.entry.role === 'tool') {
       out.push(html`<${ToolCallBubble} key=${unit.entry.id} entry=${unit.entry} />`)
     } else {
@@ -2225,6 +2281,16 @@ function renderChatTranscriptBody(opts: {
     }
   }
   return out
+}
+
+function traceStepsSignature(entry: KeeperConversationEntry): string {
+  const steps = entry.traceSteps
+  if (!steps?.length) return ''
+  return steps.map((step) => {
+    if (step.kind === 'think') return `think:${step.text.length}`
+    if (step.kind === 'reason') return `reason:${step.text.length}:${step.detail?.length ?? 0}`
+    return `tool:${step.name}:${step.status ?? ''}:${step.dur ?? ''}:${step.result?.length ?? 0}`
+  }).join(',')
 }
 
 export function ChatTranscript({
@@ -2256,7 +2322,7 @@ export function ChatTranscript({
   const pinnedRef = useRef(true)
   const [unread, setUnread] = useState(false)
   const lastSignature = useMemo(
-    () => entries.map(entry => `${entry.id}:${entry.text.length}:${entry.delivery}:${entry.streamState ?? ''}`).join('|'),
+    () => entries.map(entry => `${entry.id}:${entry.text.length}:${entry.delivery}:${entry.streamState ?? ''}:${traceStepsSignature(entry)}`).join('|'),
     [entries],
   )
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-tool-calls.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-tool-calls.ts
@@ -15,6 +15,7 @@ import { useCallback, useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { fetchKeeperToolCalls } from '../../api/dashboard'
 import type { ToolCallEntry, ToolCallsResponse } from '../../api/dashboard'
+import { recordToolCallOutputs } from '../../tool-call-output-store'
 import { useManagedAsyncResource } from '../../lib/use-managed-async-resource'
 import { lastEvent } from '../../sse'
 import { isKeeperToolActivityEvent, sseEventMatchesKeeper } from '../keeper-sse-match'
@@ -91,7 +92,11 @@ export function KeeperWorkspaceRecentTools({ keeperName }: { keeperName: string 
   const expandedKey = useSignal<string | null>(null)
 
   const load = useCallback(
-    (signal: AbortSignal) => fetchKeeperToolCalls(keeperName, RECENT_LIMIT, { signal }),
+    async (signal: AbortSignal) => {
+      const response = await fetchKeeperToolCalls(keeperName, RECENT_LIMIT, { signal })
+      recordToolCallOutputs(response.entries)
+      return response
+    },
     [keeperName],
   )
 

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -31,6 +31,9 @@ const {
   })),
   streamKeeperMessage: vi.fn(),
 }))
+const { fetchKeeperToolCalls } = vi.hoisted(() => ({
+  fetchKeeperToolCalls: vi.fn(async () => ({ entries: [] })),
+}))
 
 vi.mock('./api/mcp', () => ({ callMcpTool }))
 vi.mock('./api/core', () => ({ runOperatorAction }))
@@ -43,6 +46,7 @@ vi.mock('./api/keeper', () => ({
   queuedKeeperMessageToReply,
   streamKeeperMessage,
 }))
+vi.mock('./api/dashboard', () => ({ fetchKeeperToolCalls }))
 vi.mock('./store', () => ({ invalidateDashboardCache, refreshDashboard }))
 
 import {
@@ -76,6 +80,11 @@ import {
 import { KEEPER_HISTORY_TAIL_MESSAGES } from './config/constants'
 import type { KeeperChatStreamEvent } from './api'
 import type { KeeperConversationAttachment, KeeperStatusDetail } from './types'
+
+beforeEach(() => {
+  fetchKeeperToolCalls.mockReset()
+  fetchKeeperToolCalls.mockResolvedValue({ entries: [] })
+})
 
 describe('noteKeeperChatAppended', () => {
   beforeEach(() => {
@@ -162,6 +171,14 @@ describe('hydrateKeeperChatHistory', () => {
     await hydrateKeeperChatHistory('echo')
 
     expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1)
+  })
+
+  it('hydrates tool outputs even when the chat history is empty', async () => {
+    fetchKeeperChatHistory.mockResolvedValue([])
+
+    await hydrateKeeperChatHistory('echo')
+
+    expect(fetchKeeperToolCalls).toHaveBeenCalledWith('echo', 100)
   })
 
   it('allows a retry after a failed fetch', async () => {
@@ -291,6 +308,21 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     // whole dashboard after every chat send (user-visible "refresh").
     expect(refreshDashboard).not.toHaveBeenCalled()
     expect(invalidateDashboardCache).not.toHaveBeenCalled()
+  })
+
+  it('hydrates tool outputs when a live stream finishes a tool call', async () => {
+    streamKeeperMessage.mockImplementation(emitting([
+      { type: 'RUN_STARTED' },
+      { type: 'TOOL_CALL_START', toolCallId: 'tc-1', toolCallName: 'keeper_board_list' },
+      { type: 'TOOL_CALL_END', toolCallId: 'tc-1' },
+      { type: 'TEXT_MESSAGE_START' },
+      { type: 'TEXT_MESSAGE_CONTENT', delta: '완료' },
+      { type: 'RUN_FINISHED' },
+    ], true))
+
+    await sendKeeperThreadMessage('echo', '진행 상황?')
+
+    expect(fetchKeeperToolCalls).toHaveBeenCalledWith('echo', 100)
   })
 
   it('derives text and media user blocks when only attachments are supplied', async () => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -167,13 +167,12 @@ export async function hydrateKeeperChatHistory(
   setRecordValue(keeperHydrating, keeperName, true)
   try {
     const history = await fetchKeeperChatHistory(keeperName)
+    // Tool outputs are stored on a separate durable endpoint. Hydrate even
+    // when chat history is empty so a keeper panel can still join recently
+    // fetched tool rows from the rail/inspector.
+    void hydrateKeeperToolOutputs(keeperName)
     if (history.length === 0) return
     mergeServerHistoryEntries(keeperName, chatHistoryEntriesFromRest(keeperName, history))
-    // Tool outputs live on a separate surface (the chat stream carries only
-    // arguments); fetch them so ToolCallBubble can show results. Fire-and-
-    // forget so transcript hydration latency is unchanged, and the store
-    // update re-renders the affected bubbles when it lands.
-    void hydrateKeeperToolOutputs(keeperName)
   } catch (err) {
     // Allow a later mount to retry instead of caching the failure.
     hydratedChatKeepers.delete(keeperName)
@@ -607,6 +606,7 @@ export async function sendKeeperThreadMessage(
   setActiveStream(keeperName, assistantId, controller)
   let requestId: string | null = null
   let requestTerminalSeen = false
+  let toolCallEnded = false
   try {
     finalizeAssistantEntry(keeperName, localId, { delivery: 'delivered' })
 
@@ -639,6 +639,10 @@ export async function sendKeeperThreadMessage(
         const error = applyKeeperStreamEvent(keeperName, assistantId, event)
         if (error) {
           throw new Error(error)
+        }
+        if (event.type === 'TOOL_CALL_END') {
+          toolCallEnded = true
+          void hydrateKeeperToolOutputs(keeperName)
         }
       },
     })
@@ -674,6 +678,7 @@ export async function sendKeeperThreadMessage(
         error: cutMessage,
       })
       setRecordValue(keeperActionErrors, keeperName, cutMessage)
+      if (toolCallEnded) void hydrateKeeperToolOutputs(keeperName)
       return
     }
 
@@ -689,6 +694,7 @@ export async function sendKeeperThreadMessage(
       timestamp: new Date().toISOString(),
       error: null,
     })
+    if (toolCallEnded) void hydrateKeeperToolOutputs(keeperName)
     if (requestId) removePendingKeeperChatRequest(requestId)
   } catch (err) {
     if (isAbortError(err)) {

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest'
 import { beforeEach } from 'vitest'
 import {
   THREAD_ENTRY_CAP,
+  appendAssistantThinkingDelta,
   appendThreadEntry,
   attachKeeperAudioClip,
   chatHistoryEntriesFromRest,
+  finalizeAssistantEntry,
   insertThreadEntryBefore,
   isDefaultVisibleConversationEntry,
   isToolConversationEntry,
@@ -171,6 +173,42 @@ describe('thread history merge & persistence', () => {
     const matches = (keeperThreads.value.echo ?? []).filter(e => e.text === 'gg')
     expect(matches).toHaveLength(1)
     expect(matches[0]?.delivery).toBe('history')
+  })
+
+  it('preserves live assistant thinking trace when matching server history replaces the entry', () => {
+    appendThreadEntry('echo', entry({
+      id: 'assistant-live',
+      role: 'assistant',
+      text: 'final answer',
+      rawText: 'final answer',
+      delivery: 'streaming',
+      streamState: 'streaming',
+    }))
+    appendAssistantThinkingDelta('echo', 'assistant-live', 'checking ')
+    appendAssistantThinkingDelta('echo', 'assistant-live', 'context')
+    finalizeAssistantEntry('echo', 'assistant-live', {
+      delivery: 'delivered',
+      streamState: null,
+    })
+
+    mergeServerHistoryEntries('echo', [
+      entry({
+        id: 'assistant-history',
+        role: 'assistant',
+        text: 'final answer',
+        rawText: 'final answer',
+        delivery: 'history',
+        timestamp: '2026-06-10T00:00:05.000Z',
+      }),
+    ])
+
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread).toHaveLength(1)
+    expect(thread[0]?.id).toBe('assistant-history')
+    expect(thread[0]?.delivery).toBe('history')
+    expect(thread[0]?.traceSteps).toEqual([
+      { kind: 'think', text: 'checking context' },
+    ])
   })
 
   it('keeps local entries the server has not persisted yet', () => {
@@ -420,6 +458,37 @@ describe('thread history merge & persistence', () => {
     const thread = keeperThreads.value.echo ?? []
     expect(thread.filter(e => e.role === 'tool')).toHaveLength(1)
     expect(thread.map(e => e.role)).toEqual(['user', 'tool', 'assistant'])
+  })
+
+  it('dedups a streaming live tool row when matching history arrives', () => {
+    appendThreadEntry('echo', entry({
+      id: 'tool-toolu_streaming',
+      role: 'tool',
+      source: 'tool_result',
+      label: 'Read',
+      text: '{"path":"x"}',
+      rawText: '{"path":"x"}',
+      delivery: 'streaming',
+      streamState: 'streaming',
+    }))
+
+    mergeServerHistoryEntries('echo', chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'query', ts: 1_780_000_000 },
+      {
+        role: 'tool',
+        content: '{"path":"x"}',
+        ts: 1_780_000_000,
+        tool_call_id: 'toolu_streaming',
+        tool_call_name: 'Read',
+      },
+      { role: 'assistant', content: 'answer', ts: 1_780_000_000 },
+    ]))
+
+    const tools = (keeperThreads.value.echo ?? []).filter(e => e.role === 'tool')
+    expect(tools).toHaveLength(1)
+    expect(tools[0]?.id).toBe('tool-toolu_streaming')
+    expect(tools[0]?.delivery).toBe('history')
+    expect(tools[0]?.streamState).toBeNull()
   })
 
   it('inserts before the target entry and appends when the target is missing', () => {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -835,6 +835,30 @@ export function appendAssistantDelta(name: string, entryId: string, delta: strin
   }))
 }
 
+export function appendAssistantThinkingDelta(name: string, entryId: string, delta: string): void {
+  if (!delta.trim()) return
+  updateThreadEntry(name, entryId, entry => {
+    const existing = entry.traceSteps ?? []
+    const last = existing[existing.length - 1]
+    const traceSteps: ChatTraceStep[] =
+      last?.kind === 'think'
+        ? [
+            ...existing.slice(0, -1),
+            { kind: 'think', text: `${last.text}${delta}` },
+          ]
+        : [
+            ...existing,
+            { kind: 'think', text: delta.trimStart() },
+          ]
+    return {
+      ...entry,
+      traceSteps,
+      streamState: 'thinking',
+      delivery: 'streaming',
+    }
+  })
+}
+
 export function finalizeAssistantEntry(
   name: string,
   entryId: string,

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -874,24 +874,17 @@ export function finalizeAssistantEntry(
 }
 
 // Dedup key for merging server history with locally-appended entries.
-// Compares role + text only: the server stamps a message pair with its
-// completion time while the local entry carries the send time, so
-// timestamp equality never holds for the same logical message and
-// produced duplicate bubbles on every history merge. Source is also
-// excluded — REST history has no source field, so the derived source
-// can differ from the local one for the same message.
-//
-// R3 made every history entry carry the producer-assigned server id, so
-// render keys are now stable; this optimistic-vs-server dedup still keys
-// on role+text because a locally-appended entry is created before the
-// server mints its id and so cannot match by id yet. Replacing it with id
-// equality needs a send-response id handshake (the POST returning the
-// minted id for the optimistic entry to adopt) — tracked as the R3
-// follow-up, deliberately out of this change's scope.
+// Server ids win when both sides have already converged. User/assistant
+// optimistic rows still fall back to role + text because the POST can create
+// the local row before the server-minted id is known. Tool rows are execution
+// facts and can share argument/output text across separate calls, so they only
+// dedup by the explicit `tool-<tool_call_id>` id shape.
 function sameConversationEntry(
   left: KeeperConversationEntry,
   right: KeeperConversationEntry,
 ): boolean {
+  if (left.id === right.id) return true
+  if (left.role === 'tool' || right.role === 'tool') return false
   return left.role === right.role && left.text === right.text
 }
 
@@ -908,6 +901,24 @@ function entryTimeMs(entry: KeeperConversationEntry): number {
   return Number.isFinite(ms) ? ms : TIMESTAMP_SORT_FALLBACK
 }
 
+function mergeLocalAssistantTraceSteps(
+  historyEntry: KeeperConversationEntry,
+  localEntries: KeeperConversationEntry[],
+): KeeperConversationEntry {
+  if (historyEntry.role !== 'assistant') return historyEntry
+  const localTraceSource = localEntries.find(
+    entry =>
+      entry.role === 'assistant'
+      && (entry.traceSteps?.length ?? 0) > 0
+      && sameConversationEntry(entry, historyEntry),
+  )
+  if (!localTraceSource?.traceSteps?.length) return historyEntry
+  return {
+    ...historyEntry,
+    traceSteps: localTraceSource.traceSteps,
+  }
+}
+
 function replaceThread(name: string, entries: KeeperConversationEntry[]): void {
   // An empty history payload means the caller did not request history
   // (e.g. hydrateKeeperStatus fast path with tail_messages: 0), not
@@ -916,15 +927,22 @@ function replaceThread(name: string, entries: KeeperConversationEntry[]): void {
   // refresh / probe / recover.
   if (entries.length === 0) return
   const existing = keeperThreads.value[name] ?? []
+  const historyEntries = entries.map(entry => mergeLocalAssistantTraceSteps(entry, existing))
   const localEntries = existing.filter(
-    entry =>
-      entry.delivery !== 'history'
+    entry => {
+      const coveredByHistory = historyEntries.some(historyEntry => sameConversationEntry(entry, historyEntry))
+      // Tool rows are durable execution facts. If the server history already
+      // has the same tool_call_id, keep the canonical history row even while a
+      // local live row is still marked streaming; otherwise the live row can
+      // later flip to delivered and leave a duplicate "작업 과정" card behind.
+      const isCoveredToolRow = entry.role === 'tool' && coveredByHistory
       // In-flight (sending/streaming/queued) entries represent live state and
       // must survive history merges until they finalize. Otherwise a queued
       // assistant with empty text can be mistaken for an older empty-text
       // history row and dropped, making the queued reply look like an error.
-      && (isInFlightDelivery(entry.delivery)
-        || !entries.some(historyEntry => sameConversationEntry(entry, historyEntry))),
+      const shouldKeepLocalEntry = isInFlightDelivery(entry.delivery) || !coveredByHistory
+      return entry.delivery !== 'history' && !isCoveredToolRow && shouldKeepLocalEntry
+    },
   )
   // Render strictly oldest→newest by timestamp. Server /chat/history is
   // chronological, but locally-appended entries (a live turn's transport error,
@@ -934,7 +952,7 @@ function replaceThread(name: string, entries: KeeperConversationEntry[]): void {
   // position; no-timestamp entries sort last (in-flight tail stays at the
   // bottom) and the original array index breaks ties so same-second tool calls
   // keep their issued order.
-  const merged = [...entries, ...localEntries]
+  const merged = [...historyEntries, ...localEntries]
     .map((entry, index) => ({ entry, index }))
     .sort((a, b) => entryTimeMs(a.entry) - entryTimeMs(b.entry) || a.index - b.index)
     .map(({ entry }) => entry)

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -183,6 +183,28 @@ describe('applyKeeperStreamEvent', () => {
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.streamState).toBe('thinking')
     expect(entry?.delivery).toBe('streaming')
+    expect(entry?.traceSteps).toEqual([
+      { kind: 'think', text: 'reasoning about the problem...' },
+    ])
+  })
+
+  it('appends multiple thinking deltas to one trace step', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { delta: 'checking ' },
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { delta: 'tools' },
+    })
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.traceSteps).toEqual([
+      { kind: 'think', text: 'checking tools' },
+    ])
   })
 })
 

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -3,6 +3,7 @@ import { parseTextToChatBlocks } from './lib/chat-blocks'
 import type { KeeperChatStreamEvent } from './api'
 import {
   appendAssistantDelta,
+  appendAssistantThinkingDelta,
   setAssistantStreamState,
   updateThreadEntry,
   insertThreadEntryBefore,
@@ -118,7 +119,17 @@ export function applyKeeperStreamEvent(
     }
     case 'CUSTOM':
       if (event.name === 'KEEPER_THINKING_DELTA') {
-        setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
+        const delta = isRecord(event.value)
+          ? (typeof event.value.delta === 'string'
+              ? event.value.delta
+              : typeof event.value.text === 'string'
+                ? event.value.text
+                : undefined)
+          : typeof event.value === 'string'
+            ? event.value
+            : undefined
+        if (delta) appendAssistantThinkingDelta(keeperName, assistantEntryId, delta)
+        else setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
         return null
       }
       if (event.name === 'KEEPER_QUEUE_REQUEST') {

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -44,6 +44,30 @@
   overflow: hidden;
 }
 
+.chat-turn-bundle {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  align-self: flex-start;
+  gap: 8px;
+  width: 82%;
+  max-width: 100%;
+}
+
+.chat-turn-bundle .chat-block-trace,
+.chat-turn-bundle .chat-bubble {
+  width: 100%;
+  max-width: 100%;
+}
+
+.chat-turn-bundle .chat-block-trace {
+  border-bottom-left-radius: var(--r-0);
+}
+
+.chat-turn-bundle .chat-bubble.assistant {
+  border-top-left-radius: var(--r-0);
+}
+
 .chat-block-trace-hd {
   display: flex;
   align-items: center;

--- a/dashboard/src/styles/chat-blocks-v2.test.ts
+++ b/dashboard/src/styles/chat-blocks-v2.test.ts
@@ -14,4 +14,13 @@ describe('chat-blocks-v2.css', () => {
     expect(trace.flex).toBe('none')
     expect(trace['flex-direction']).toBe('column')
   })
+
+  it('keeps work trace and answer in one fixed-width turn bundle', () => {
+    const bundle = declarationsForSelector(css, '.chat-turn-bundle')
+    expect(bundle.display).toBe('flex')
+    expect(bundle.flex).toBe('none')
+    expect(bundle['flex-direction']).toBe('column')
+    expect(bundle['align-self']).toBe('flex-start')
+    expect(bundle.width).toBe('82%')
+  })
 })

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -877,6 +877,7 @@ export interface KeeperConversationEntry {
   streamState?: KeeperConversationStreamState
   attachments?: KeeperConversationAttachment[]
   blocks?: ChatBlock[]
+  traceSteps?: ChatTraceStep[]
   details?: KeeperConversationDetails | null
   error?: string | null
   surface?: SurfaceRef | null


### PR DESCRIPTION
Summary:
- preserve KEEPER_THINKING_DELTA as assistant trace steps and render it in the work trace
- preserve live assistant `traceSteps` when matching server history replaces the local assistant entry during rehydrate
- connect grouped tool calls and the following assistant answer in one chat turn bundle
- hydrate tool-call outputs after live tool completion and from recent-tool rail fetches
- dedup live/history tool rows by canonical `tool-<tool_call_id>` identity, not broad role+text matching

Validation:
- `pnpm -C dashboard exec vitest run --config vitest.config.ts src/keeper-state.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm -C dashboard exec eslint src/keeper-state.ts src/keeper-state.test.ts` (0 errors; 2 config-scope ignored-file warnings)
- `git diff --check origin/main...HEAD`

Earlier validation retained from original PR:
- `pnpm -C dashboard exec vitest run --config vitest.config.ts src/keeper-stream.test.ts src/keeper-actions.test.ts src/components/chat/primitives.test.ts src/styles/chat-blocks-v2.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm -C dashboard typecheck`
- `pnpm -C dashboard build`

Not run in this review-response pass:
- full dashboard typecheck/build: local typecheck ran too long and was stopped; build is left to CI/operator direction.

Base:
- rebased onto current `origin/main` after stale CI failure in the prior head.