### PR TITLE
Reject expired schedule execution grants

### DIFF
--- a/lib/schedule/schedule_domain.ml
+++ b/lib/schedule/schedule_domain.ml
@@ -772,9 +772,16 @@ let create_execution_grant
   }
 ;;
 
+let expired_at ~now (request : schedule_request) =
+  match request.expires_at with
+  | Some expires_at when expires_at <= now -> true
+  | None | Some _ -> false
+;;
+
 let validate_execution_grant (request : schedule_request) (grant : execution_grant) =
   if grant.schedule_id <> request.schedule_id then Error Grant_schedule_id_mismatch
   else if is_terminal request.status then Error Schedule_terminal
+  else if expired_at ~now:grant.approved_at request then Error Schedule_terminal
   else if request.status <> Pending_approval && request.status <> Due then
     Error Schedule_not_pending_approval
   else if requires_separate_human_grant request && grant.approved_by.kind <> Human_operator
@@ -817,12 +824,6 @@ let apply_execution_grant (request : schedule_request) (grant : execution_grant)
     in
     Ok { request with status }
   | Reject _ -> Ok { request with status = Rejected }
-;;
-
-let expired_at ~now (request : schedule_request) =
-  match request.expires_at with
-  | Some expires_at when expires_at <= now -> true
-  | None | Some _ -> false
 ;;
 
 let mark_due ~now (request : schedule_request) =

--- a/test/test_schedule_domain.ml
+++ b/test/test_schedule_domain.ml
@@ -21,13 +21,14 @@ let request
   ?(approval_required = false)
   ?(requested_by = human "requester")
   ?(scheduled_by = human "scheduler")
+  ?expires_at
   ?recurrence
   ()
   =
   match
     create_request ~schedule_id:"sched-1" ~requested_by ~scheduled_by
       ~requested_at:100.0 ~due_at:200.0
-      ~payload:(payload_json ()) ~risk_class ~approval_required
+      ?expires_at ~payload:(payload_json ()) ~risk_class ~approval_required
       ~source:Operator_request ?recurrence ()
   with
   | Ok request -> request
@@ -122,6 +123,13 @@ let test_due_grant_keeps_request_due () =
   match apply_execution_grant due grant with
   | Error err -> fail (grant_error_to_string err)
   | Ok updated -> check_status "due approval stays due" Due updated.status
+;;
+
+let test_expired_schedule_blocks_grant () =
+  let req = request ~expires_at:149.0 () in
+  let grant = grant req in
+  check_error "expired approval" Schedule_terminal
+    (validate_execution_grant req grant)
 ;;
 
 let test_requester_cannot_approve () =
@@ -327,6 +335,8 @@ let () =
           test_case "reject grant marks rejected" `Quick test_reject_grant_marks_rejected;
           test_case "due grant keeps request due" `Quick
             test_due_grant_keeps_request_due;
+          test_case "expired schedule blocks grant" `Quick
+            test_expired_schedule_blocks_grant;
           test_case "requester cannot approve" `Quick test_requester_cannot_approve;
           test_case "scheduler cannot approve" `Quick test_scheduler_cannot_approve;
           test_case "automated actor cannot approve side-effecting" `Quick


### PR DESCRIPTION
## Summary
- reject schedule execution grants whose request has expired by the grant approval timestamp
- keep dashboard effective-expired state aligned with Keeper-facing approve/reject behavior
- add a domain regression test for expired grant rejection

## Validation
- `opam exec -- ocamlformat --check lib/schedule/schedule_domain.ml test/test_schedule_domain.ml`
- `git diff --check`

## Notes
- Local build/test intentionally not run; final build/test proof is CI-owned for this update.
- Existing main push `Branch Protection Watchdog` failures are tracked in #21110 and are caused by missing `BRANCH_PROTECTION_AUDIT_TOKEN`, not this patch.
