### PR TITLE
fix(ws): close sessions outside registry lock

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -158,6 +158,38 @@ let __test_slice_index_remove ~session_id ~slice =
 let __test_slice_index_remove_session session_id =
   with_sessions_rw (fun () -> slice_index_remove_session_locked session_id)
 
+(** Detach a session from the global registry before doing any wire-level
+    shutdown.  Closing [Httpun_ws.Wsd.t] takes the per-session [write_mutex]
+    and may run transport code; doing that while [sessions_mutex] is held can
+    stall every session lookup, fanout snapshot, and cleanup path behind one
+    slow or wedged socket. *)
+let detach_session_for_close session_id =
+  with_sessions_rw (fun () ->
+      match Hashtbl.find_opt sessions session_id with
+      | None -> None
+      | Some session ->
+          Atomic.set session.closed true;
+          Hashtbl.remove sessions session_id;
+          slice_index_remove_session_locked session_id;
+          Some session)
+
+let close_detached_session_wsd ?code ~context session =
+  try
+    Eio_guard.with_mutex session.write_mutex (fun () ->
+        if not (Httpun_ws.Wsd.is_closed session.wsd) then
+          match code with
+          | None -> Httpun_ws.Wsd.close session.wsd
+          | Some code -> Httpun_ws.Wsd.close ~code session.wsd)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Server.warn "WS %s failed for %s: %s" context session.id
+        (Printexc.to_string exn)
+
+let update_ws_session_count_metric () =
+  Transport_metrics.set_ws_sessions
+    (with_sessions_rw (fun () -> Hashtbl.length sessions))
+
 (** Generate a unique session ID. *)
 let next_id =
   let counter = Atomic.make 0 in
@@ -928,24 +960,15 @@ let close_session_for_inbound_reject session rejection =
     rejection.reason
     rejection.actual
     rejection.limit;
-  with_sessions_rw (fun () ->
-      if Hashtbl.mem sessions session.id then begin
-        Atomic.set session.closed true;
-        (try
-           Eio_guard.with_mutex session.write_mutex (fun () ->
-             if not (Httpun_ws.Wsd.is_closed session.wsd) then
-               Httpun_ws.Wsd.close ~code:`Message_too_big session.wsd)
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn ->
-             Log.Server.warn "WS reject close failed for %s: %s" session.id
-               (Printexc.to_string exn));
-        Hashtbl.remove sessions session.id;
-        slice_index_remove_session_locked session.id
-      end);
-  Transport_metrics.set_ws_sessions
-    (with_sessions_rw (fun () -> Hashtbl.length sessions));
-  Sse.unsubscribe_external session.id
+  Atomic.set session.closed true;
+  let detached = detach_session_for_close session.id in
+  update_ws_session_count_metric ();
+  Sse.unsubscribe_external session.id;
+  match detached with
+  | None -> ()
+  | Some detached_session ->
+      close_detached_session_wsd ~code:`Message_too_big
+        ~context:"reject close" detached_session
 
 let handle_inbound_text session ~on_message ~is_fin text =
   let chunk_len = String.length text in
@@ -1002,25 +1025,13 @@ let read_inbound_message_frame session ~on_message ~is_fin ~len payload =
 
 (** Remove a session and unsubscribe from SSE. *)
 let cleanup_session session_id =
-  let removed =
-    with_sessions_rw (fun () ->
-        match Hashtbl.find_opt sessions session_id with
-        | None -> false
-        | Some session ->
-            Atomic.set session.closed true;
-            (try
-               Eio_guard.with_mutex session.write_mutex (fun () ->
-                 Httpun_ws.Wsd.close session.wsd)
-             with Eio.Cancel.Cancelled _ as e -> raise e
-                | exn -> Log.Server.warn "WS close failed for %s: %s" session_id (Printexc.to_string exn));
-            Hashtbl.remove sessions session_id;
-            slice_index_remove_session_locked session_id;
-            true)
-  in
-  Transport_metrics.set_ws_sessions
-    (with_sessions_rw (fun () -> Hashtbl.length sessions));
+  let detached = detach_session_for_close session_id in
+  update_ws_session_count_metric ();
   Sse.unsubscribe_external session_id;
-  if removed then
+  match detached with
+  | None -> ()
+  | Some session ->
+    close_detached_session_wsd ~context:"close" session;
     (* #10875: see server_ws_standalone — per-session lifecycle is DEBUG
        to avoid logging amplification during WS storm (#10701). *)
     Log.Server.debug "WebSocket session %s closed" session_id

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -45,6 +45,8 @@
     [next_dashboard_seq], [valid_dashboard_slice] /
     [dashboard_slice_for_sse_type],
     [dashboard_session_result], [find_session],
+    [detach_session_for_close] / [close_detached_session_wsd] /
+    [update_ws_session_count_metric],
     [dashboard_snapshot_provider] cell,
     [dashboard_auth_success_payload],
     [verify_dashboard_token], [dashboard_snapshot],

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -7,6 +7,66 @@
 module Ws = Server_mcp_transport_ws
 module Sse = Masc.Sse
 
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let rec find_source_root_from dir hops rel =
+  if hops > 8 then None
+  else if Sys.file_exists (Filename.concat dir rel) then Some dir
+  else
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then None
+    else find_source_root_from parent (hops + 1) rel
+
+let source_root () =
+  let anchor = "lib/server/server_mcp_transport_ws.ml" in
+  match find_source_root_from (Sys.getcwd ()) 0 anchor with
+  | Some root -> root
+  | None ->
+      Alcotest.failf "could not locate repo source root from cwd=%s" (Sys.getcwd ())
+
+let read_source_file rel = read_file (Filename.concat (source_root ()) rel)
+
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop i =
+    i + needle_len <= haystack_len
+    && (String.equal (String.sub haystack i needle_len) needle || loop (i + 1))
+  in
+  needle_len = 0 || loop 0
+
+let count_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop i acc =
+    if needle_len = 0 || i + needle_len > haystack_len then acc
+    else if String.equal (String.sub haystack i needle_len) needle then
+      loop (i + needle_len) (acc + 1)
+    else loop (i + 1) acc
+  in
+  loop 0 0
+
+let substring_between source ~start_marker ~end_marker =
+  let start_len = String.length start_marker in
+  let end_len = String.length end_marker in
+  let source_len = String.length source in
+  let rec find_from marker marker_len i =
+    if i + marker_len > source_len then None
+    else if String.equal (String.sub source i marker_len) marker then Some i
+    else find_from marker marker_len (i + 1)
+  in
+  match find_from start_marker start_len 0 with
+  | None -> Alcotest.failf "missing marker %S" start_marker
+  | Some start_pos -> (
+      let body_start = start_pos + start_len in
+      match find_from end_marker end_len body_start with
+      | None -> Alcotest.failf "missing marker %S" end_marker
+      | Some end_pos -> String.sub source body_start (end_pos - body_start))
+
 (* ====== Session Registry ====== *)
 
 let test_initial_session_count () =
@@ -18,6 +78,36 @@ let test_close_all_empty () =
   Eio_main.run (fun _env ->
     let closed = Ws.close_all () in
     Alcotest.(check int) "close_all on empty returns 0" 0 closed)
+
+let test_session_close_wire_calls_stay_outside_registry_lock () =
+  let source = read_source_file "lib/server/server_mcp_transport_ws.ml" in
+  let close_marker = "Httpun_ws.Wsd.close" in
+  let detach_helper =
+    substring_between source
+      ~start_marker:"let detach_session_for_close"
+      ~end_marker:"let close_detached_session_wsd"
+  in
+  let close_helper =
+    substring_between source
+      ~start_marker:"let close_detached_session_wsd"
+      ~end_marker:"let update_ws_session_count_metric"
+  in
+  Alcotest.(check int)
+    "all WSD close calls are isolated in the detached close helper"
+    (count_substring source close_marker)
+    (count_substring close_helper close_marker);
+  Alcotest.(check bool)
+    "detaching from the registry does not wait on the session writer lock"
+    false
+    (contains_substring detach_helper "write_mutex");
+  Alcotest.(check bool)
+    "detaching from the registry does not close the wire"
+    false
+    (contains_substring detach_helper close_marker);
+  Alcotest.(check bool)
+    "wire close helper does not acquire sessions_mutex"
+    false
+    (contains_substring close_helper "with_sessions_rw")
 
 (* ====== SHA1 (httpun-ws handshake) ====== *)
 
@@ -823,10 +913,12 @@ let test_missed_pong_threshold_reads_env () =
 
 let () =
   Alcotest.run "WebSocket Transport" [
-    ("session_registry", [
-      Alcotest.test_case "initial count" `Quick test_initial_session_count;
-      Alcotest.test_case "close_all empty" `Quick test_close_all_empty;
-    ]);
+	    ("session_registry", [
+	      Alcotest.test_case "initial count" `Quick test_initial_session_count;
+	      Alcotest.test_case "close_all empty" `Quick test_close_all_empty;
+	      Alcotest.test_case "wire close stays outside registry lock" `Quick
+	        test_session_close_wire_calls_stay_outside_registry_lock;
+	    ]);
     ("sha1", [
       Alcotest.test_case "produces 20 bytes" `Quick test_sha1_produces_20_bytes;
       Alcotest.test_case "deterministic" `Quick test_sha1_deterministic;


### PR DESCRIPTION
## Summary
- detach WS sessions from the global registry and slice index before closing the underlying `Httpun_ws.Wsd.t`
- keep the per-session `write_mutex` close path outside `sessions_mutex` for normal cleanup and inbound size rejection
- add a WS transport invariant test that fails if `Wsd.close` moves back into registry-lock cleanup

## Why
Adversarial WS review found that `cleanup_session` and inbound reject handling held `sessions_mutex` while waiting on the per-session writer lock and running `Wsd.close`. A slow or wedged socket could therefore stall unrelated session lookup, fanout snapshots, and cleanup paths behind the global registry lock.

## Verification
- `opam exec -- ocamlformat --check lib/server/server_mcp_transport_ws.ml lib/server/server_mcp_transport_ws.mli test/test_ws_transport.ml`
- `git diff --check origin/main...HEAD`
- `python3 scripts/check_test_coverage.py`
- `rg -n -C 4 "Httpun_ws\.Wsd\.close" lib/server/server_mcp_transport_ws.ml` confirms `Wsd.close` is now isolated in the detached-session helper, outside `with_sessions_rw`
- parallel adversarial structural review: no blocking findings; no new cleanup/SSE/cancellation regression identified

## Not run locally
- Dune build/Alcotest suite, per operator direction: build will run in CI.

## Boundary
- MASC server WebSocket transport only.
- No OAS/provider/model transport changes.
