### PR TITLE
chore(ws): remove redundant close flag write

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -960,7 +960,6 @@ let close_session_for_inbound_reject session rejection =
     rejection.reason
     rejection.actual
     rejection.limit;
-  Atomic.set session.closed true;
   let detached = detach_session_for_close session.id in
   update_ws_session_count_metric ();
   Sse.unsubscribe_external session.id;


### PR DESCRIPTION
## Summary
- remove the redundant caller-side `Atomic.set session.closed true` before `detach_session_for_close`
- keep close ownership centralized in the detach helper added by #21725

## Why
#21725 merged before this trivial review nit landed. The duplicate write is idempotent, but it weakens the single-owner lifecycle shape: callers should detach, and the detach helper should be the one place that marks the session closed while removing it from the registry/slice index.

## Verification
- `opam exec -- ocamlformat --check lib/server/server_mcp_transport_ws.ml`
- `git diff --check origin/main...HEAD`
- `python3 scripts/check_test_coverage.py`

## Not run locally
- Dune build/Alcotest suite, per operator direction: build will run later/CI.

Follow-up to #21725.