### PR TITLE
fix(gate): repair main-red OCaml gate compile

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -128,9 +128,14 @@ let persist_connector_assistant_reply ~base_dir ~keeper_name ~source
     Keeper_chat_broadcast.chat_appended ~keeper_name ~source ~content ()
   end
 
+(* The trailing [()] makes the leading optional [?on_text_snapshot] erasable
+   (warning 16 [unerasable-optional-argument]). Without it the unerased
+   optional leaks into the inferred type of callers that omit it (e.g.
+   [dispatch]), so that inferred type no longer matches the .mli that
+   declares [dispatch] without [?on_text_snapshot]. *)
 let dispatch_core ?on_text_snapshot ~sw ~clock ~proc_mgr ~net ~config
     ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
-    ~keeper_name ~metadata ~content =
+    ~keeper_name ~metadata ~content () =
   let keeper_name = String.trim keeper_name in
   let redaction =
     Keeper_secret_redaction.snapshot
@@ -271,11 +276,11 @@ let dispatch_core ?on_text_snapshot ~sw ~clock ~proc_mgr ~net ~config
 let dispatch ~sw ~clock ~proc_mgr ~net ~config ~channel ~channel_user_id
     ~channel_user_name ~channel_workspace_id ~keeper_name ~metadata ~content =
   dispatch_core ~sw ~clock ~proc_mgr ~net ~config ~channel ~channel_user_id
-    ~channel_user_name ~channel_workspace_id ~keeper_name ~metadata ~content
+    ~channel_user_name ~channel_workspace_id ~keeper_name ~metadata ~content ()
 
 let dispatch_with_text_snapshot ~on_text_snapshot ~sw ~clock ~proc_mgr ~net
     ~config ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
     ~keeper_name ~metadata ~content =
   dispatch_core ~on_text_snapshot ~sw ~clock ~proc_mgr ~net ~config ~channel
     ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
-    ~metadata ~content
+    ~metadata ~content ()

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -507,7 +507,7 @@ let handle_message_create ~dispatch
               Discord_observability.record_inbound_dispatch
                 Discord_observability.Reply_send_error;
               Discord_observability.record_reply
-                Discord_observability.Reply_send_failed)
+                Discord_observability.Reply_send_failed))
 
 let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
   match ev with


### PR DESCRIPTION
## Summary
Repair the warn-error build break on `main` introduced by #21714 (`fix(discord): stream keeper replies through gate`). The merge of #21714 left two independent compile failures in the keeper/gate path; under `OCAMLPARAM=_,warn-error=+a` (Lint / Build and Test) both are hard errors, so `main` is red. This PR fixes both with the minimal change in each file.

## Root cause (two breaks, both from #21714, surfaced by fast-fail)
1. **`lib/gate_keeper_backend.ml` — warning 16 `[unerasable-optional-argument]`.**
   `dispatch_core ?on_text_snapshot ~sw ... ~content` has the optional followed only by labelled arguments, so it cannot be erased. `dispatch` calls `dispatch_core` without `on_text_snapshot`; the unerased optional propagates into `dispatch`'s inferred type as a trailing `?on_text_snapshot`, which is no longer included in the `.mli`'s `val dispatch : ... -> content:string -> Gate_protocol.dispatch_result`.
2. **`lib/server/server_discord_in_process_gateway.ml` — unmatched `(match`.**
   `handle_message_create` opens `(match with_response_wait_typing_indicator ... with` at line 425 but the final branch closed only the inner `(match finish_discord_stream_reply ...)`, leaving the outer match's `(` unclosed. The compiler reports `Syntax error: ) expected` at the next top-level `let on_event` (line 512) and points at line 425 as the unmatched `(`.

The warn-error build fast-fails, so only (1) was visible on the first red CI; fixing (1) let the build progress from `lib` into `lib/server`, surfacing (2).

## Fix
- `lib/gate_keeper_backend.ml` (internal `dispatch_core`, not in `.mli`): add a trailing `()` positional to `dispatch_core` and its two call sites (`dispatch`, `dispatch_with_text_snapshot`) so the optional is erasable. `dispatch`'s inferred type then matches the `.mli` again. No change to the exposed `dispatch` / `dispatch_with_text_snapshot` signatures or behaviour, and no `.mli` change.
- `lib/server/server_discord_in_process_gateway.ml`: add the missing `)` that closes the outer `(match` in `handle_message_create` (`Reply_send_failed)` → `Reply_send_failed))`). Pure paren balance; no behaviour change.

## Validation
- `ocamlformat --check` clean on both files (ocamlformat-check passes).
- Type-checking / parsing is the proof: the signature match (warning-16 erasure) and the paren balance are compiler-verified, so CI Build and Test + Lint are the authoritative gate.

## RFC / workaround gate
- Not RFC-gated: `gate_keeper_backend.ml` is the channel-gate↔keeper dispatch adapter and `server_discord_in_process_gateway.ml` is the connector gateway, neither is credential/identity/sandbox/containment. Pure compile fixes, no behaviour change.
- Not a workaround: (1) makes the optional erasable (the standard OCaml idiom), resolving the type leak at its root; (2) closes a genuinely missing paren. No telemetry-as-fix, string classifier, N-of-M, or cap/cooldown.

Introduced by #21714 (`fix(discord): stream keeper replies through gate`).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
