### PR TITLE
[codex] Add runtime TOML impact preview

### DIFF
--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -147,6 +147,9 @@ describe('RuntimeTomlEditor', () => {
       expect((container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement).disabled).toBe(false)
       expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('modified')
     })
+    expect(container.querySelector('[data-testid="runtime-toml-impact-preview"]')?.textContent).toContain('적용 미리보기')
+    expect(container.querySelector('[data-testid="runtime-toml-default-impact"]')?.textContent).toContain('default unchanged')
+    expect(container.querySelector('[data-testid="runtime-toml-assignments-impact"]')?.textContent).toContain('assignments changed')
 
     fireEvent.click(container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement)
 
@@ -156,6 +159,7 @@ describe('RuntimeTomlEditor', () => {
     })
     expect(saveButton.disabled).toBe(true)
     expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe(nextSource)
+    expect(container.querySelector('[data-testid="runtime-toml-impact-preview"]')).toBeNull()
   })
 
   it('edits runtime environment fields through the structured controls', async () => {

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -7,6 +7,10 @@ import {
   type RuntimeTomlConfig,
 } from '../api/dashboard'
 import { errorToString } from '../lib/format-string'
+import {
+  runtimeTomlImpactSummary,
+  type RuntimeTomlImpactSummary,
+} from '../lib/runtime-toml-config'
 import { ActionButton } from './common/button'
 import { SectionCard } from './common/card'
 import { copyToClipboard } from './common/copyable-code'
@@ -42,6 +46,57 @@ function runtimeTomlDraftStats(sourceText: string): RuntimeTomlDraftStats {
 
 function runtimeTomlLineNumbers(lineCount: number): string {
   return Array.from({ length: lineCount }, (_, index) => String(index + 1)).join('\n')
+}
+
+function signedDelta(value: number): string {
+  if (value > 0) return `+${value}`
+  return String(value)
+}
+
+function runtimeLabel(value: string): string {
+  return value.trim() || 'unset'
+}
+
+function RuntimeTomlImpactPreview({ impact }: { impact: RuntimeTomlImpactSummary }) {
+  const catalogDelta =
+    impact.providerCountDelta !== 0 || impact.modelCountDelta !== 0 || impact.bindingCountDelta !== 0
+
+  return html`
+    <div
+      class="mt-2 flex flex-wrap items-center gap-2 border-t border-[var(--color-border-subtle)] pt-2 text-2xs text-[var(--color-fg-muted)]"
+      data-testid="runtime-toml-impact-preview"
+    >
+      <span class="uppercase tracking-[var(--track-caps)] text-[var(--color-fg-secondary)]">적용 미리보기</span>
+      <span
+        class="rounded-[var(--r-0)] border border-[var(--color-border-subtle)] px-2 py-0.5 font-mono"
+        data-testid="runtime-toml-default-impact"
+      >
+        default ${impact.defaultRuntimeChanged
+          ? `${runtimeLabel(impact.defaultRuntimeBefore)} -> ${runtimeLabel(impact.defaultRuntimeAfter)}`
+          : 'unchanged'}
+      </span>
+      <span
+        class="rounded-[var(--r-0)] border border-[var(--color-border-subtle)] px-2 py-0.5"
+        data-testid="runtime-toml-assignments-impact"
+      >
+        assignments ${impact.runtimeAssignmentsChanged ? 'changed' : 'unchanged'}
+      </span>
+      <span class="rounded-[var(--r-0)] border border-[var(--color-border-subtle)] px-2 py-0.5">
+        lines ${signedDelta(impact.lineDelta)}
+      </span>
+      <span class="rounded-[var(--r-0)] border border-[var(--color-border-subtle)] px-2 py-0.5">
+        chars ${signedDelta(impact.charDelta)}
+      </span>
+      <span
+        class="rounded-[var(--r-0)] border border-[var(--color-border-subtle)] px-2 py-0.5"
+        data-testid="runtime-toml-catalog-impact"
+      >
+        catalog ${catalogDelta
+          ? `p${signedDelta(impact.providerCountDelta)} m${signedDelta(impact.modelCountDelta)} b${signedDelta(impact.bindingCountDelta)}`
+          : 'unchanged'}
+      </span>
+    </div>
+  `
 }
 
 const editorFocusClasses = ringFocusClasses({
@@ -177,6 +232,10 @@ export function RuntimeTomlEditor() {
     () => runtimeTomlLineNumbers(stats.lineCount),
     [stats.lineCount],
   )
+  const impact = useMemo(
+    () => (config !== null && dirty ? runtimeTomlImpactSummary(config.source_text, draft) : null),
+    [config, dirty, draft],
+  )
 
   return html`
     <${SectionCard}
@@ -248,13 +307,13 @@ export function RuntimeTomlEditor() {
                 onClick=${handleSave}
                 disabled=${!dirty || saving || loadState === 'loading'}
                 ariaBusy=${saving}
-                ariaLabel="runtime.toml 저장"
-                title="저장"
+                ariaLabel="runtime.toml 라이브 적용"
+                title="라이브 적용"
                 testId="runtime-toml-save"
                 class="inline-flex items-center gap-1"
               >
                 <${Save} size=${13} strokeWidth=${2.25} aria-hidden="true" />
-                <span>${saving ? '저장 중' : '저장'}</span>
+                <span>${saving ? '적용 중' : '라이브 적용'}</span>
               <//>
             </div>
           </div>
@@ -266,6 +325,7 @@ export function RuntimeTomlEditor() {
             <span>${stats.charCount} chars</span>
             <span>${dirty ? 'unsaved' : 'synced'}</span>
           </div>
+          ${impact ? html`<${RuntimeTomlImpactPreview} impact=${impact} />` : null}
         </div>
 
         ${error ? html`<${ErrorState} message=${error} />` : null}

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   deleteRuntimeTomlKey,
   parseRuntimeTomlEnvironment,
+  runtimeTomlImpactSummary,
   setRuntimeTomlBindingField,
   setRuntimeTomlDefault,
   setRuntimeTomlModelField,
@@ -129,5 +130,28 @@ describe('runtime TOML dashboard editing helpers', () => {
 
     expect(next).not.toContain('keep-alive = "10m"')
     expect(next).toContain('max-concurrent = 4')
+  })
+
+  it('summarizes runtime.toml apply impact from before and after source', () => {
+    const next = `${setRuntimeTomlDefault(sourceText, 'openai.gpt')}
+
+[runtime.assignments]
+sangsu = "openai.gpt"
+
+[models.extra]
+api-name = "extra"
+`
+
+    const impact = runtimeTomlImpactSummary(sourceText, next)
+
+    expect(impact.defaultRuntimeChanged).toBe(true)
+    expect(impact.defaultRuntimeBefore).toBe('runpod_mtp.qwen')
+    expect(impact.defaultRuntimeAfter).toBe('openai.gpt')
+    expect(impact.runtimeAssignmentsChanged).toBe(true)
+    expect(impact.providerCountDelta).toBe(0)
+    expect(impact.modelCountDelta).toBe(1)
+    expect(impact.bindingCountDelta).toBe(0)
+    expect(impact.lineDelta).toBeGreaterThan(0)
+    expect(impact.charDelta).toBeGreaterThan(0)
   })
 })

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -154,4 +154,21 @@ api-name = "extra"
     expect(impact.lineDelta).toBeGreaterThan(0)
     expect(impact.charDelta).toBeGreaterThan(0)
   })
+
+  it('does not report assignment-only reformatting as an assignment change', () => {
+    const before = `${sourceText}
+
+[runtime.assignments]
+sangsu = "runpod_mtp.qwen"
+`
+    const after = `${sourceText}
+
+[runtime.assignments]
+  sangsu   =   "runpod_mtp.qwen" # same assignment
+`
+
+    const impact = runtimeTomlImpactSummary(before, after)
+
+    expect(impact.runtimeAssignmentsChanged).toBe(false)
+  })
 })

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -41,6 +41,18 @@ export interface RuntimeTomlEnvironment {
   warnings: string[]
 }
 
+export interface RuntimeTomlImpactSummary {
+  defaultRuntimeBefore: string
+  defaultRuntimeAfter: string
+  defaultRuntimeChanged: boolean
+  runtimeAssignmentsChanged: boolean
+  providerCountDelta: number
+  modelCountDelta: number
+  bindingCountDelta: number
+  lineDelta: number
+  charDelta: number
+}
+
 interface TomlSection {
   readonly name: string
   readonly start: number
@@ -237,6 +249,40 @@ export function parseRuntimeTomlEnvironment(sourceText: string): RuntimeTomlEnvi
     models,
     bindings,
     warnings,
+  }
+}
+
+function sourceLineCount(sourceText: string): number {
+  return sourceText.length === 0 ? 1 : sourceText.split('\n').length
+}
+
+function sectionSource(document: TomlDocument, sectionName: string): string {
+  const section = sectionOf(document, sectionName)
+  if (!section) return ''
+  return document.lines.slice(section.start, section.end).join('\n').trim()
+}
+
+export function runtimeTomlImpactSummary(
+  beforeSourceText: string,
+  afterSourceText: string,
+): RuntimeTomlImpactSummary {
+  const beforeDocument = parseDocument(beforeSourceText)
+  const afterDocument = parseDocument(afterSourceText)
+  const beforeEnvironment = parseRuntimeTomlEnvironment(beforeSourceText)
+  const afterEnvironment = parseRuntimeTomlEnvironment(afterSourceText)
+
+  return {
+    defaultRuntimeBefore: beforeEnvironment.defaultRuntimeId,
+    defaultRuntimeAfter: afterEnvironment.defaultRuntimeId,
+    defaultRuntimeChanged: beforeEnvironment.defaultRuntimeId !== afterEnvironment.defaultRuntimeId,
+    runtimeAssignmentsChanged:
+      sectionSource(beforeDocument, 'runtime.assignments') !==
+      sectionSource(afterDocument, 'runtime.assignments'),
+    providerCountDelta: afterEnvironment.providers.length - beforeEnvironment.providers.length,
+    modelCountDelta: afterEnvironment.models.length - beforeEnvironment.models.length,
+    bindingCountDelta: afterEnvironment.bindings.length - beforeEnvironment.bindings.length,
+    lineDelta: sourceLineCount(afterSourceText) - sourceLineCount(beforeSourceText),
+    charDelta: afterSourceText.length - beforeSourceText.length,
   }
 }
 

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -256,10 +256,14 @@ function sourceLineCount(sourceText: string): number {
   return sourceText.length === 0 ? 1 : sourceText.split('\n').length
 }
 
-function sectionSource(document: TomlDocument, sectionName: string): string {
-  const section = sectionOf(document, sectionName)
-  if (!section) return ''
-  return document.lines.slice(section.start, section.end).join('\n').trim()
+function sortedSectionEntries(document: TomlDocument, sectionName: string): Array<[string, TomlScalar]> {
+  return Object.entries(sectionValues(document, sectionName)).sort(([left], [right]) =>
+    left.localeCompare(right),
+  )
+}
+
+function runtimeAssignmentsSignature(document: TomlDocument): string {
+  return JSON.stringify(sortedSectionEntries(document, 'runtime.assignments'))
 }
 
 export function runtimeTomlImpactSummary(
@@ -276,8 +280,7 @@ export function runtimeTomlImpactSummary(
     defaultRuntimeAfter: afterEnvironment.defaultRuntimeId,
     defaultRuntimeChanged: beforeEnvironment.defaultRuntimeId !== afterEnvironment.defaultRuntimeId,
     runtimeAssignmentsChanged:
-      sectionSource(beforeDocument, 'runtime.assignments') !==
-      sectionSource(afterDocument, 'runtime.assignments'),
+      runtimeAssignmentsSignature(beforeDocument) !== runtimeAssignmentsSignature(afterDocument),
     providerCountDelta: afterEnvironment.providers.length - beforeEnvironment.providers.length,
     modelCountDelta: afterEnvironment.models.length - beforeEnvironment.models.length,
     bindingCountDelta: afterEnvironment.bindings.length - beforeEnvironment.bindings.length,


### PR DESCRIPTION
## What changed

- Added `runtimeTomlImpactSummary` for before/after runtime.toml edits.
- Shows a compact dirty-state apply preview in the runtime.toml editor: default runtime, runtime assignments, line/char deltas, and catalog count deltas.
- Compares `runtime.assignments` structurally so harmless line-order churn does not look like a behavior change.
- Renamed the save button copy to `라이브 적용` so the UI better reflects the live runtime reload behavior.

## Why

Runtime config editing currently looks like a plain file save even though it validates and reloads live runtime state. This adds a first safety affordance without changing the backend write path.

MASC linkage: `goal-1781926004068-b034` -> `task-1444`.

## Validation

- `vitest run --config vitest.config.ts src/lib/runtime-toml-config.test.ts src/components/runtime-toml-editor.test.ts --no-file-parallelism --maxWorkers=1` from `dashboard`: 2 files / 23 tests passed.
- `tsc --noEmit --pretty` from `dashboard`: passed.
- `git diff --check origin/main...HEAD`: passed.
- GitHub Dashboard job: passed.

## CI note

Required OCaml CI jobs currently fail on unrelated main-branch compile errors. Tracked separately in #21745.

## Follow-ups

- Stale overwrite guard with source hash/mtime.
- Full diff view before apply.
- Separate validate-only from apply/reload.
- Reduce first-viewport friction for 1k+ line runtime.toml files.
