### PR TITLE
feat(board): typed post origin + turn_ref/run_id indexes (RFC-0233 §7 PR-B)

### DIFF
--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -16,6 +16,26 @@ let get_post store ~post_id : (post, board_error) Result.t =
       | None -> Error (Post_not_found post_id))
 ;;
 
+(* RFC-0233 §7 guard #2: exact O(1) index lookups, mirroring [get_post] by
+   primary key. The index is keyed on the full join string (turn_ref =
+   "trace#turn", or the fusion run_id) — never a meta_json substring or a
+   time-window heuristic. A miss returns [None] (no scan, no false positive). *)
+let find_post_by_turn_ref store ~turn_ref : post option =
+  maybe_sweep store;
+  with_lock store (fun () ->
+    match Hashtbl.find_opt store.posts_by_turn_ref turn_ref with
+    | None -> None
+    | Some pid -> Hashtbl.find_opt store.posts pid)
+;;
+
+let find_post_by_run_id store ~run_id : post option =
+  maybe_sweep store;
+  with_lock store (fun () ->
+    match Hashtbl.find_opt store.posts_by_run_id run_id with
+    | None -> None
+    | Some pid -> Hashtbl.find_opt store.posts pid)
+;;
+
 (* Reads post + comments under a single critical section. The previous
    two-call sequence (get_post then get_comments) acquired
    [store.mutex] twice with [maybe_sweep] dispatching to the flusher

--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -149,6 +149,12 @@ val rotate_if_needed : string -> unit
 (** Appends one post snapshot to {!persist_path}. *)
 val append_post : post -> unit
 
+(** RFC-0233 §7: maintain the origin secondary indexes ([posts_by_turn_ref] /
+    [posts_by_run_id]) from a post's [origin].  Used by the load path to
+    rebuild the indexes that {!find_post_by_turn_ref} / {!find_post_by_run_id}
+    read.  A [None] origin is a no-op. *)
+val index_post_origin : store -> post -> unit
+
 (** Appends one comment snapshot to {!comments_path}. *)
 val append_comment : comment -> unit
 
@@ -231,6 +237,7 @@ val create_post_with_outcome
   -> ?ttl_hours:int
   -> ?hearth:string
   -> ?thread_id:string
+  -> ?origin:post_origin
   -> unit
   -> (create_post_outcome, board_error) Result.t
 
@@ -258,10 +265,22 @@ val create_post
   -> ?ttl_hours:int
   -> ?hearth:string
   -> ?thread_id:string
+  -> ?origin:post_origin
   -> unit
   -> (post, board_error) Result.t
 
 val get_post : store -> post_id:string -> (post, board_error) Result.t
+
+(** RFC-0233 §7: look up a post by the originating turn's join key
+    ([Ids.Turn_ref.to_string], i.e. ["<trace_id>#<absolute_turn>"]).  Exact
+    O(1) index lookup ([posts_by_turn_ref]); [None] on miss.  No meta_json scan
+    and no time-window heuristic (RFC §7.6 guard #2/#3). *)
+val find_post_by_turn_ref : store -> turn_ref:string -> post option
+
+(** RFC-0233 §7: look up a post by its fusion run correlation id
+    ([origin.fusion_run_id]).  Exact O(1) index lookup ([posts_by_run_id]);
+    [None] on miss.  [run_id] is distinct from [turn_ref] (RFC §7.6 guard #5). *)
+val find_post_by_run_id : store -> run_id:string -> post option
 
 (** Coalesces [get_post] + [get_comments] under a single
     {!with_lock} block to avoid the two-call lock churn

--- a/lib/board/board_core_json.ml
+++ b/lib/board/board_core_json.ml
@@ -8,6 +8,25 @@ include Board_core_classify
 
 (** {1 JSON Serialization} *)
 
+(* RFC-0233 §7: encode the typed origin as its own top-level [origin] key
+   (sibling of [meta], NOT nested under it) so the index key needs no
+   meta_json substring scan (RFC §7.6 guard #2). Each sub-field is emitted
+   only when present; turn_ref serializes via [Ids.Turn_ref.to_yojson] (a flat
+   "trace#turn" string), matching the chat-row wire form. *)
+let post_origin_to_yojson (o : post_origin) : Yojson.Safe.t =
+  `Assoc
+    ((match o.turn_ref with
+      | Some tr -> [ "turn_ref", Ids.Turn_ref.to_yojson tr ]
+      | None -> [])
+     @ (match o.source with
+        | Some s -> [ "source", `String s ]
+        | None -> [])
+     @
+     match o.fusion_run_id with
+     | Some r -> [ "fusion_run_id", `String r ]
+     | None -> [])
+;;
+
 let post_to_yojson (p : post) : Yojson.Safe.t =
   `Assoc
     ([ "id", `String (Post_id.to_string p.id)
@@ -32,6 +51,9 @@ let post_to_yojson (p : post) : Yojson.Safe.t =
         | None -> [])
      @ (match p.thread_id with
         | Some t -> [ "thread_id", `String t ]
+        | None -> [])
+     @ (match p.origin with
+        | Some o -> [ "origin", post_origin_to_yojson o ]
         | None -> [])
      @
      match p.meta_json with

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -39,7 +39,43 @@ let create_store () =
   ; flusher_inbox = Eio.Stream.create 1000
   ; sub_boards = Hashtbl.create 64
   ; sub_boards_by_slug = Hashtbl.create 64
+  ; posts_by_turn_ref = Hashtbl.create 256
+  ; posts_by_run_id = Hashtbl.create 256
   }
+;;
+
+(* RFC-0233 §7: maintain the origin secondary indexes. Shared by the create
+   path (create_fresh) and the load path (load_persisted_posts) so the two
+   stay in lockstep — a single maintenance site, not an N-of-M copy. *)
+let index_post_origin store (post : post) =
+  match post.origin with
+  | None -> ()
+  | Some (o : post_origin) ->
+    let pid = Post_id.to_string post.id in
+    (match o.turn_ref with
+     | Some tr -> Hashtbl.replace store.posts_by_turn_ref (Ids.Turn_ref.to_string tr) pid
+     | None -> ());
+    (match o.fusion_run_id with
+     | Some run_id -> Hashtbl.replace store.posts_by_run_id run_id pid
+     | None -> ())
+;;
+
+(* Prune the origin indexes when a post is swept / cap-evicted, mirroring the
+   [comments_by_post] cleanup in the sweeper. Without this the index tables
+   would grow unbounded over the store lifetime (the double-lookup in
+   [find_post_by_*] keeps a stale key from returning a wrong post, but the
+   entry would still leak). Single-valued [remove] matches the single-valued
+   [replace] in [index_post_origin]. *)
+let unindex_post_origin store (post : post) =
+  match post.origin with
+  | None -> ()
+  | Some (o : post_origin) ->
+    (match o.turn_ref with
+     | Some tr -> Hashtbl.remove store.posts_by_turn_ref (Ids.Turn_ref.to_string tr)
+     | None -> ());
+    (match o.fusion_run_id with
+     | Some run_id -> Hashtbl.remove store.posts_by_run_id run_id
+     | None -> ())
 ;;
 
 (** {1 Comment Rate Limiting}  Per-author sliding-window tracker extracted to [Board_comment_rate_limit] (godfile decomp). Module-level Hashtbl avoids changing the store type; all access is inside the ... *)
@@ -114,6 +150,9 @@ let sweep store =
     in
     List.iter
       (fun id ->
+         (match Hashtbl.find_opt store.posts id with
+          | Some p -> unindex_post_origin store p
+          | None -> ());
          Hashtbl.remove store.posts id;
          Hashtbl.remove store.comments_by_post id;
          Stdlib.decr store.post_count)
@@ -173,6 +212,7 @@ let sweep store =
              List.iter
                (fun (post : post) ->
                   let id = Post_id.to_string post.id in
+                  unindex_post_origin store post;
                   Hashtbl.remove store.posts id;
                   Hashtbl.remove store.comments_by_post id;
                   Stdlib.decr store.post_count;
@@ -380,6 +420,7 @@ let create_post_with_outcome
       ?(ttl_hours = Limits.default_ttl_hours)
   ?hearth
   ?thread_id
+  ?origin
   ()
   : (create_post_outcome, board_error) Result.t
   =
@@ -487,9 +528,11 @@ let create_post_with_outcome
                     ; pinned = false
                     ; hearth
                     ; thread_id
+                    ; origin
                     }
                   in
                   Hashtbl.add store.posts (Post_id.to_string post.id) post;
+                  index_post_origin store post;
                   Stdlib.incr store.post_count;
                   invalidate_post_caches store;
                   Ok (`Fresh post)
@@ -578,6 +621,7 @@ let create_post
       ?ttl_hours
       ?hearth
       ?thread_id
+      ?origin
       ()
   =
   match
@@ -593,6 +637,7 @@ let create_post
       ?ttl_hours
       ?hearth
       ?thread_id
+      ?origin
       ()
   with
   | Ok outcome -> Ok (post_of_create_post_outcome outcome)

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -100,6 +100,7 @@ val create_post_with_outcome :
   ?ttl_hours:int ->
   ?hearth:string ->
   ?thread_id:string ->
+  ?origin:post_origin ->
   unit ->
   (create_post_outcome, board_error) result
 
@@ -115,5 +116,11 @@ val create_post :
   ?ttl_hours:int ->
   ?hearth:string ->
   ?thread_id:string ->
+  ?origin:post_origin ->
   unit ->
   (post, board_error) result
+
+(** RFC-0233 §7: maintain the [posts_by_turn_ref] / [posts_by_run_id]
+    secondary indexes from a post's [origin].  Idempotent; a [None] origin is
+    a no-op.  Called on create and on load so the two paths stay in lockstep. *)
+val index_post_origin : store -> post -> unit

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -354,12 +354,13 @@ let matching_post_ids_for_comment_author_filter ~needle (comments : Board.commen
 
 let create_post ~author ~content ?title ?body ~post_kind ?meta_json
     ?(visibility = Board.Internal)
-    ?(ttl_hours = Board.Limits.default_ttl_hours) ?hearth ?thread_id () =
+    ?(ttl_hours = Board.Limits.default_ttl_hours) ?hearth ?thread_id ?origin () =
   match backend () with
   | Jsonl store ->
       (match
          Board.create_post_with_outcome store ~author ~content ?title ?body
-           ~post_kind ?meta_json ~visibility ~ttl_hours ?hearth ?thread_id ()
+           ~post_kind ?meta_json ~visibility ~ttl_hours ?hearth ?thread_id
+           ?origin ()
        with
       | Ok (Board.Fresh_post post) ->
           let pid = Board.Post_id.to_string post.id in

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -139,6 +139,7 @@ val create_post :
   ?ttl_hours:int ->
   ?hearth:string ->
   ?thread_id:string ->
+  ?origin:Board.post_origin ->
   unit ->
   (Board.post, Board.board_error) Result.t
 

--- a/lib/board/board_votes_json.ml
+++ b/lib/board/board_votes_json.ml
@@ -10,6 +10,28 @@ let record_post_meta_json_read_drop () =
 
 let visibility_of_string = Board_core_classify.visibility_of_string
 
+(* RFC-0233 §7: decode the typed post origin. Parse, don't repair — an absent
+   [origin], a non-object value, or a malformed sub-field all degrade to [None]
+   (per-field for the sub-fields), NEVER dropping the row: origin is provenance
+   metadata, not load-bearing identity (contrast the [meta] row-drop below).
+   [Ids.Turn_ref.of_string] is total and returns [None] on a malformed join
+   key. An all-[None] origin decodes to [None] (no empty record carried). *)
+let post_origin_of_yojson (json : Yojson.Safe.t) : post_origin option =
+  match json with
+  | `Assoc _ ->
+    let turn_ref =
+      match Safe_ops.json_string_opt "turn_ref" json with
+      | Some s -> Ids.Turn_ref.of_string s
+      | None -> None
+    in
+    let source = Safe_ops.json_string_opt "source" json in
+    let fusion_run_id = Safe_ops.json_string_opt "fusion_run_id" json in
+    (match turn_ref, source, fusion_run_id with
+     | None, None, None -> None
+     | _ -> Some { turn_ref; source; fusion_run_id })
+  | _ -> None
+;;
+
 let post_of_yojson (json : Yojson.Safe.t) : post option =
   match
     ( Safe_ops.json_string_opt "id" json
@@ -54,6 +76,11 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
               record_post_meta_json_read_drop ();
               None)
          | None -> None)
+    in
+    let origin =
+      match Safe_ops.json_member_opt "origin" json with
+      | Some o -> post_origin_of_yojson o
+      | None -> None
     in
     (match
        ( Post_id.of_string id_str
@@ -108,6 +135,7 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
             ; pinned
             ; hearth
             ; thread_id
+            ; origin
             })
      | _ -> None)
   | _ -> None
@@ -177,6 +205,11 @@ let load_persisted_posts store =
              when Float.compare p.expires_at 0.0 = 0
                   || Float.compare p.expires_at now > 0 ->
              Hashtbl.replace store.posts (Post_id.to_string p.id) p;
+             (* RFC-0233 §7: rebuild the origin indexes on load (derive-on-load,
+                mirroring comments_by_post below) so find_post_by_turn_ref /
+                find_post_by_run_id survive a restart without a second persisted
+                SSOT that could drift from the post rows. *)
+             index_post_origin store p;
              incr loaded
            | _ -> ())
         lines;

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -143,6 +143,24 @@ type automation_label =
   | Smoke_named         (* contains "smoke" *)
   | Probe_named         (* contains "probe" *)
 
+(* RFC-0233 §7: typed provenance of a board post — which keeper turn produced
+   it and through which channel. Replaces the fusion [meta_json] [run_id]
+   smuggle with a first-class field that a real index can key on (no
+   meta_json substring scan, RFC §7.6 guard #2).
+
+   [source] is the channel's [Surface_ref.lane_label] string, NOT a typed
+   [Surface_ref.t]: Surface_ref lives in the [masc] umbrella, which depends on
+   [masc_board], so referencing the typed variant here would form a cycle.
+
+   [turn_ref] and [fusion_run_id] are distinct (RFC §7.6 guard #5): turn_ref is
+   the turn-level join key, fusion_run_id correlates a fusion deliberation run.
+   All sub-fields optional; an all-[None] origin is represented as [origin = None]. *)
+type post_origin = {
+  turn_ref: Ids.Turn_ref.t option;
+  source: string option;
+  fusion_run_id: string option;
+}
+
 type post = {
   id: Post_id.t;
   author: Agent_id.t;
@@ -161,6 +179,7 @@ type post = {
   pinned: bool;              (* Operator-curated pin (owner-gated): floats the post to the top of its category *)
   hearth: string option;     (* Topic category within the Board *)
   thread_id: string option;  (* Linked Conversation thread *)
+  origin: post_origin option; (* RFC-0233 §7: originating turn / channel provenance *)
 }
 
 type comment = {
@@ -320,4 +339,9 @@ type store = {
   flusher_inbox: flusher_msg Eio.Stream.t;                               (** Last deferred flush time *)
   sub_boards: (string, sub_board) Hashtbl.t;               (** sub_board_id -> sub_board *)
   sub_boards_by_slug: (string, string) Hashtbl.t;          (** slug -> sub_board_id *)
+  (* RFC-0233 §7 guard #2: real secondary indexes for origin lookup, mirroring
+     [sub_boards_by_slug]. Maintained on create and rebuilt on load (derive-on-
+     load, no separately-persisted SSOT). Never a meta_json substring scan. *)
+  posts_by_turn_ref: (string, string) Hashtbl.t;           (** Turn_ref.to_string -> post_id *)
+  posts_by_run_id: (string, string) Hashtbl.t;             (** fusion_run_id -> post_id *)
 }

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -89,6 +89,18 @@ type automation_label =
 
 (** {1 Records — Mandatory TTL} *)
 
+(** RFC-0233 §7: typed provenance of a board post — which keeper turn produced
+    it and through which channel.  [source] is the channel's
+    [Surface_ref.lane_label] string (not the typed [Surface_ref.t], which lives
+    in the [masc] umbrella that depends on [masc_board]).  [turn_ref] and
+    [fusion_run_id] are distinct (RFC §7.6 guard #5).  All sub-fields optional;
+    an all-[None] origin is represented as [origin = None]. *)
+type post_origin = {
+  turn_ref : Ids.Turn_ref.t option;
+  source : string option;
+  fusion_run_id : string option;
+}
+
 type post = {
   id : Post_id.t;
   author : Agent_id.t;
@@ -107,6 +119,7 @@ type post = {
   pinned : bool;
   hearth : string option;
   thread_id : string option;
+  origin : post_origin option;
 }
 
 type comment = {
@@ -264,4 +277,10 @@ type store = {
   (** Sub-board id -> sub_board record. *)
   sub_boards_by_slug : (string, string) Hashtbl.t;
   (** slug -> sub_board id index for O(1) slug lookup. *)
+  posts_by_turn_ref : (string, string) Hashtbl.t;
+  (** RFC-0233 §7: [Ids.Turn_ref.to_string] -> post id. Maintained on
+      create, rebuilt on load. *)
+  posts_by_run_id : (string, string) Hashtbl.t;
+  (** RFC-0233 §7: fusion run_id -> post id. Maintained on create, rebuilt
+      on load. *)
 }

--- a/lib/board_types/dune
+++ b/lib/board_types/dune
@@ -8,6 +8,10 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries yojson re re.str re.pcre eio masc_random_id masc.config)
+ ; masc_types provides Ids.Turn_ref for the typed post origin (RFC-0233 §7).
+ ; masc_types has no board/keeper edge, so this is cycle-safe; the origin
+ ; source stays a string (Surface_ref.lane_label) because Surface_ref lives
+ ; in the masc umbrella, which already depends on masc_board.
+ (libraries yojson re re.str re.pcre eio masc_random_id masc.config masc_types)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_tla)))

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -182,10 +182,21 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judge_usage :
     in
     (* board post를 *먼저* 만들어 post id를 확보한다 — 이 id가 키퍼 chat의 fusion block
        lazy-fetch 키이기 때문이다(대시보드가 board meta_json에서 패널/심판을 펼친다). *)
+    (* RFC-0233 §7: typed origin. [fusion_run_id] is in scope here ([run_id]),
+       so a real index ([posts_by_run_id]) can key on it instead of the legacy
+       meta_json substring. [turn_ref = None]: fusion is an out-of-band
+       server-root-switch fork, so the triggering keeper's turn_ref is not in
+       this scope; threading it through [fusion_request] is a separate change.
+       The legacy meta_json [run_id] (above) is kept ADDITIVELY this release —
+       existing dashboard / on-disk readers depend on it; its removal is a
+       later migration, not this PR. *)
+    let origin : Board.post_origin =
+      { turn_ref = None; source = Some "fusion"; fusion_run_id = Some run_id }
+    in
     let board_result =
       Board_dispatch.create_post ~author:keeper ~content:board_headline
         ~post_kind:Board.System_post ?meta_json ~visibility:Board.Internal
-        ~ttl_hours:board_post_ttl_hours ()
+        ~ttl_hours:board_post_ttl_hours ~origin ()
     in
     (* 키퍼 메인 흐름 통합 ("결과를 키퍼 흐름에 녹이기", RFC-0252 §8 개정).
        상세 트랜스크립트(패널 답변 N개)는 위 board post 증거로만 남기고, 키퍼 chat

--- a/test/dune
+++ b/test/dune
@@ -1407,6 +1407,8 @@
 
 (include stanzas/test_board_persistence_load_contract.inc)
 
+(include stanzas/test_board_post_origin.inc)
+
 (include stanzas/test_board_sse_canonical_event_type.inc)
 
 (include stanzas/test_briefing_compactors.inc)

--- a/test/stanzas/test_board_post_origin.inc
+++ b/test/stanzas/test_board_post_origin.inc
@@ -1,0 +1,6 @@
+; RFC-0233 §7 (PR-B): board post typed origin codec + secondary indexes
+
+(test
+ (name test_board_post_origin)
+ (modules test_board_post_origin)
+ (libraries masc_test_deps))

--- a/test/test_board_post_origin.ml
+++ b/test/test_board_post_origin.ml
@@ -1,0 +1,218 @@
+(** RFC-0233 §7 (PR-B): board post typed [origin] codec + secondary indexes.
+
+    Pins the board-side half of the turn-identity contract:
+    - {!Board_core_json.post_to_yojson} / {!Board_votes_json.post_of_yojson}
+      round-trip the typed [origin] (turn_ref / source / fusion_run_id).
+    - decode is parse-don't-repair: a non-object origin or a malformed
+      [turn_ref] degrades to [None] WITHOUT dropping the post (origin is
+      provenance, not load-bearing identity — contrast the [meta] row-drop).
+    - {!Board_core.find_post_by_turn_ref} / {!find_post_by_run_id} are exact
+      O(1) index lookups (RFC §7.6 guard #2/#3, no meta_json scan, no window),
+      and the indexes are rebuilt on load.
+
+    The producer side (which keeper turn populates [origin.turn_ref]) is a
+    named follow-up; PR-B wires only fusion's [fusion_run_id], whose effect —
+    a post findable by [find_post_by_run_id] — is exercised here via a
+    fusion-shaped origin. *)
+
+open Masc
+
+let () = Mirage_crypto_rng_unix.use_default ()
+let () = Random.self_init ()
+
+let set_temp_base () =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-board-origin-%06x" (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir;
+  dir
+;;
+
+(* Each test runs in its own Eio scope with a fresh persistence base path so
+   the on-disk JSONL (written by [create_post], read by [load_persisted_posts])
+   is isolated. Mirrors test_board_content_dedup's harness. *)
+let with_eio f () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  ignore (set_temp_base ());
+  f ()
+;;
+
+let make_origin ?turn_ref ?source ?fusion_run_id () : Board.post_origin =
+  { turn_ref; source; fusion_run_id }
+;;
+
+let create store ~origin ~content =
+  match
+    Board_core.create_post store ~author:"origin-test" ~content
+      ~post_kind:Board.Human_post ~origin ()
+  with
+  | Ok post -> post
+  | Error e -> Alcotest.failf "create_post failed: %s" (Board.show_board_error e)
+;;
+
+let create_no_origin store ~content =
+  match
+    Board_core.create_post store ~author:"origin-test" ~content
+      ~post_kind:Board.Human_post ()
+  with
+  | Ok post -> post
+  | Error e -> Alcotest.failf "create_post failed: %s" (Board.show_board_error e)
+;;
+
+let decode = Masc_board_handlers.Board_votes_json.post_of_yojson
+
+let replace_key json key value =
+  match json with
+  | `Assoc fields ->
+    `Assoc
+      (List.map
+         (fun (k, v) -> if String.equal k key then k, value else k, v)
+         fields)
+  | other -> other
+;;
+
+let test_codec_round_trip () =
+  let store = Board_core.create_store () in
+  let tr = Ids.Turn_ref.make ~trace_id:"trace-abc" ~absolute_turn:42 in
+  let origin = make_origin ~turn_ref:tr ~source:"fusion" ~fusion_run_id:"fus-7" () in
+  let post = create store ~origin ~content:"round trip" in
+  let decoded =
+    match decode (Board_core.post_to_yojson post) with
+    | Some p -> p
+    | None -> Alcotest.fail "encode/decode dropped the post"
+  in
+  match decoded.origin with
+  | Some (o : Board.post_origin) ->
+    Alcotest.(check (option string))
+      "turn_ref preserved" (Some "trace-abc#42")
+      (Option.map Ids.Turn_ref.to_string o.turn_ref);
+    Alcotest.(check (option string)) "source preserved" (Some "fusion") o.source;
+    Alcotest.(check (option string))
+      "fusion_run_id preserved" (Some "fus-7") o.fusion_run_id
+  | None -> Alcotest.fail "origin lost in round trip"
+;;
+
+let test_codec_absent_origin () =
+  let store = Board_core.create_store () in
+  let post = create_no_origin store ~content:"no origin" in
+  Alcotest.(check bool) "post created without origin" true (Option.is_none post.origin);
+  let decoded =
+    match decode (Board_core.post_to_yojson post) with
+    | Some p -> p
+    | None -> Alcotest.fail "round trip dropped origin-less post"
+  in
+  Alcotest.(check bool) "absent origin decodes to None" true (Option.is_none decoded.origin)
+;;
+
+let test_malformed_origin_preserves_post () =
+  let store = Board_core.create_store () in
+  let tr = Ids.Turn_ref.make ~trace_id:"t" ~absolute_turn:1 in
+  let post = create store ~origin:(make_origin ~turn_ref:tr ()) ~content:"malformed origin" in
+  let json = Board_core.post_to_yojson post in
+  (* origin as a non-object value -> degrade to None, keep the row. *)
+  (match decode (replace_key json "origin" (`Int 5)) with
+   | Some p -> Alcotest.(check bool) "non-object origin -> None" true (Option.is_none p.origin)
+   | None -> Alcotest.fail "row dropped on non-object origin (must be preserved)");
+  (* malformed turn_ref string -> turn_ref None, but a valid sibling field is
+     kept (per-field degrade, not whole-origin drop, not row drop). *)
+  let bad_origin =
+    `Assoc [ "turn_ref", `String "no-separator"; "source", `String "fusion" ]
+  in
+  match decode (replace_key json "origin" bad_origin) with
+  | Some p ->
+    (match p.origin with
+     | Some (o : Board.post_origin) ->
+       Alcotest.(check bool) "malformed turn_ref -> None" true (Option.is_none o.turn_ref);
+       Alcotest.(check (option string)) "valid sibling kept" (Some "fusion") o.source
+     | None -> Alcotest.fail "origin fully dropped though source was valid")
+  | None -> Alcotest.fail "row dropped on malformed turn_ref (must be preserved)"
+;;
+
+let test_index_lookup_hit_and_miss () =
+  let store = Board_core.create_store () in
+  let tr = Ids.Turn_ref.make ~trace_id:"idx-trace" ~absolute_turn:9 in
+  let origin = make_origin ~turn_ref:tr ~fusion_run_id:"run-xyz" () in
+  let post = create store ~origin ~content:"indexed" in
+  let pid = Board.Post_id.to_string post.id in
+  (match Board_core.find_post_by_turn_ref store ~turn_ref:(Ids.Turn_ref.to_string tr) with
+   | Some p -> Alcotest.(check string) "turn_ref index hit" pid (Board.Post_id.to_string p.id)
+   | None -> Alcotest.fail "turn_ref index miss");
+  (match Board_core.find_post_by_run_id store ~run_id:"run-xyz" with
+   | Some p -> Alcotest.(check string) "run_id index hit" pid (Board.Post_id.to_string p.id)
+   | None -> Alcotest.fail "run_id index miss");
+  Alcotest.(check bool) "absent turn_ref -> None (no scan)" true
+    (Option.is_none (Board_core.find_post_by_turn_ref store ~turn_ref:"absent#0"));
+  Alcotest.(check bool) "absent run_id -> None (no scan)" true
+    (Option.is_none (Board_core.find_post_by_run_id store ~run_id:"nope"))
+;;
+
+let test_index_rebuilt_on_load () =
+  let store1 = Board_core.create_store () in
+  let tr = Ids.Turn_ref.make ~trace_id:"load-trace" ~absolute_turn:3 in
+  let origin = make_origin ~turn_ref:tr ~fusion_run_id:"load-run" () in
+  let _ = create store1 ~origin ~content:"persisted with origin" in
+  (* Fresh store loads from the same MASC_BASE_PATH persist file. *)
+  let store2 = Board_core.create_store () in
+  (match Masc_board_handlers.Board_votes_json.load_persisted_posts store2 with
+   | Ok n when n >= 1 -> ()
+   | Ok n -> Alcotest.failf "expected >= 1 loaded post, got %d" n
+   | Error (p, e) -> Alcotest.failf "load failed: %s (%s)" p (Printexc.to_string e));
+  Alcotest.(check bool) "turn_ref index rebuilt on load" true
+    (Option.is_some
+       (Board_core.find_post_by_turn_ref store2 ~turn_ref:(Ids.Turn_ref.to_string tr)));
+  Alcotest.(check bool) "run_id index rebuilt on load" true
+    (Option.is_some (Board_core.find_post_by_run_id store2 ~run_id:"load-run"))
+;;
+
+let test_index_pruned_on_sweep () =
+  let store = Board_core.create_store () in
+  let tr = Ids.Turn_ref.make ~trace_id:"sweep-trace" ~absolute_turn:5 in
+  let origin = make_origin ~turn_ref:tr ~fusion_run_id:"sweep-run" () in
+  let post = create store ~origin ~content:"to be swept" in
+  let key = Ids.Turn_ref.to_string tr in
+  Alcotest.(check bool) "indexed before sweep" true
+    (Stdlib.Hashtbl.mem store.posts_by_turn_ref key);
+  (* Force-expire the post in place (epoch + 1s is < now), then sweep. *)
+  let expired = { post with expires_at = 1.0 } in
+  Stdlib.Hashtbl.replace store.posts (Board.Post_id.to_string post.id) expired;
+  let _ : int * int = Board_core.sweep store in
+  Alcotest.(check bool) "post removed by sweep" true
+    (Option.is_none (Board_core.find_post_by_turn_ref store ~turn_ref:key));
+  (* Direct index check: [find_post_by_*] would return None even with a stale
+     key (double-lookup), so prove the prune against the index table itself. *)
+  Alcotest.(check bool) "turn_ref index pruned" false
+    (Stdlib.Hashtbl.mem store.posts_by_turn_ref key);
+  Alcotest.(check bool) "run_id index pruned" false
+    (Stdlib.Hashtbl.mem store.posts_by_run_id "sweep-run")
+;;
+
+let () =
+  Alcotest.run
+    "board_post_origin"
+    [ ( "codec"
+      , [ Alcotest.test_case "origin round trip" `Quick (with_eio test_codec_round_trip)
+        ; Alcotest.test_case "absent origin -> None" `Quick (with_eio test_codec_absent_origin)
+        ; Alcotest.test_case
+            "malformed origin -> None, post preserved"
+            `Quick
+            (with_eio test_malformed_origin_preserves_post)
+        ] )
+    ; ( "index"
+      , [ Alcotest.test_case
+            "find_post_by_turn_ref / run_id hit + miss"
+            `Quick
+            (with_eio test_index_lookup_hit_and_miss)
+        ; Alcotest.test_case
+            "indexes rebuilt on load"
+            `Quick
+            (with_eio test_index_rebuilt_on_load)
+        ; Alcotest.test_case
+            "indexes pruned on sweep"
+            `Quick
+            (with_eio test_index_pruned_on_sweep)
+        ] )
+    ]
+;;


### PR DESCRIPTION
> ⚠️ **BASE-BROKEN (PR-B 무관)**: 현재 `main`은 #21721(`fix(discord)`, `dispatch_core` unerasable-optional)로 `lib/gate_keeper_backend.ml`이 컴파일 안 됨 — GitHub CI가 #21721 머지 커밋에 `Build and Test: failure`를 기록(컨베이어 mid-CI 머지). 이 PR은 `gate_keeper_backend`를 건드리지 않음(`git diff origin/main -- lib/gate_keeper_backend.*` 비어 있음). 따라서 full-tree CI의 gate_keeper_backend 실패는 base 탓이며 PR-B 코드와 무관. PR-B 자체는 `lib/board`/`lib/fusion` dev-profile 빌드 green + 신규 테스트 6/6(buildable base). main 수정 후 rebase하면 green.

## 무엇을 / 왜

RFC-0233 §7(Turn_ref 계약)의 **PR-B — board post에 typed `origin` 필드 + 실제 인덱스**. board post가 자신을 만든 turn/채널을 first-class로 들 수 있게 해, 향후 board↔chat-turn 양방향 내비게이션의 join 키를 board 쪽에 심는다. PR-A(#21662/#21680/#21696)가 turn_ref를 mint해 chat row에 영속화했고, 이 PR이 board 쪽 절반을 추가한다.

RFC §7.2 계약대로:
- `post_origin = { turn_ref : Ids.Turn_ref.t option; source : string option; fusion_run_id : string option }`, post record에 `origin : post_origin option`.
- `?origin`을 `create_post` dispatch 경계로 thread.
- top-level `origin` JSON 키로 직렬화(`meta` 안에 nesting 금지 → 인덱스가 meta_json substring scan 불필요, §7.6 guard #2).
- 실제 Hashtbl 인덱스 `posts_by_turn_ref` / `posts_by_run_id` (생성 시 유지, **load 시 재구성**=derive-on-load, **sweep/cap-eviction 시 prune**=`comments_by_post` cleanup 미러, 테이블 누수 방지. 별도 영속 SSOT 없음).
- `find_post_by_turn_ref` / `find_post_by_run_id` — O(1) exact 키 조회(window/scan 아님, §7.6 guard #2/#3).
- fusion이 `origin.fusion_run_id` 채움(`run_id`). `run_id`는 `turn_ref`와 별개 유지(§7.6 guard #5, collapse 안 함).

## 설계 결정 (understand-phase 워크플로 + 직접 검증)

**두 가지 load-bearing 정정**(map+verify 3개 에이전트가 틀렸고 직접 grep으로 확인):
- `Surface_ref`는 **이미 존재**(`lib/keeper/surface_ref.ml`, closed variant + `lane_label`). 단 `masc` umbrella → `masc_board` 의존 방향이라 board record가 typed `Surface_ref.t`를 참조하면 **사이클**. ∴ `origin.source`는 `string option`(lane_label 문자열). dune은 `masc_types`만 board_types에 추가(cycle-safe: masc_types는 board/keeper 엣지 없음).

**Scope (RFC §7.5 PR-B 충실, 의도적 분할):**
- ✅ board origin field + `?origin` threading + fusion producer + 두 인덱스 + codec.
- ⏭️ **keeper-turn board producer는 named follow-up**: keeper가 턴 중 `masc_board_post`로 만든 post(SITE: `keeper_social_model_bdi_speech_v1.ml:317`, `board_tool_post.ml:142`)에 `origin.turn_ref`를 채우려면 mint된 turn_ref를 tool dispatch 경계까지 cell-carrier로 thread해야 한다(`keeper_tool_call_log_context` cell이 trace_id+keeper_turn_id를 들지만 board handler까지 안 닿음). dispatch에서 재유도는 handoff 턴 post-rotation trace로 join 키가 어긋나 **불가**(PR-A3와 동일한 근거). 이는 A2/A3 capability/population 분할과 같은 패턴이며 **silent N-of-M가 아님**(§7.6 guard #6): board capability는 atomically 완결되고, 미채움 keeper 사이트는 named follow-up으로 escalate.
- ❌ **드롭**: synthesizer가 제안한 `keeper_chat_blocks` fusion_block에 `turn_ref` 추가. fusion turn_ref는 out-of-band fork가 trigger 턴을 떨어뜨려 어차피 `None`(정보 0)인데, FE zod 3-gate row-drop 리스크만 발생(MEMORY: chat-block 3-gate). 정보가 실리는 fusion-trigger turn_ref 배선과 함께 가야 한다. → **이 PR은 backend-only, FE 무변경**.

system/cron/bot 사이트(`verification_protocol.ml`, `server_schedule_consumers.ml`, `keeper_alerting.ml`)는 keeper LLM 턴이 만들지 않으므로 **영구 None**(연기 아님).

## 검증

- `dune build --root .` 전체 green(exit 0) — foundational record(`post`에 필드 추가)라 컴파일러가 모든 literal 생성처를 강제. 누락 site 0(literal은 create_fresh + decode 둘뿐, 나머지는 `{ post with }`/패턴매치).
- 신규 `test/test_board_post_origin.ml` **6/6 [OK]**: codec round-trip(full origin) / absent→None / **malformed→None + post 보존**(non-object origin·malformed turn_ref 둘 다, parse-don't-repair: meta는 row-drop, origin은 per-field degrade) / 인덱스 hit+miss(no scan) / **인덱스 load 시 재구성** / **인덱스 sweep 시 prune**(인덱스 Hashtbl 직접 검사).
- 기존 board 테스트 회귀 0: `test_board_dispatch`(60) / `test_board_content_dedup`(9) / `test_board_ttl`(13, sweep 경로) / `test_board_persistence_load_contract`(2) 전부 green. backward-compat(기존 origin-less post는 origin 키 미방출 → decode None → 안정).
- fresh-context 적대 리뷰(5 공격 벡터: totality/wire-compat/index-soundness/N-of-M/.mli) 전부 NON-ISSUE. 리뷰가 짚은 인덱스 누수(sweep prune 부재)는 위 prune로 해소.

## Workaround Guards (RFC-0233 §7.6 준수)

- **#2 string classifier 금지**: typed `origin` + 실제 Hashtbl 인덱스(top-level `origin` 키). meta_json substring scan 아님.
- **#3 window join 금지**: `find_post_by_*`는 full join 문자열(`trace#turn` / run_id)의 exact O(1) 조회.
- **#4 telemetry-as-fix 아님**: typed 필드 + 인덱스로 join을 구조적으로 가능케 함. 카운터 없음.
- **#5 run_id≠turn_ref**: `origin`에 둘 다 별개 보존.
- **#6 N-of-M 아님**: codec 양쪽 + 두 full literal을 OCaml record exhaustiveness가 강제(빌드가 누락 시 fail). producer는 단일 완결 producer(fusion); keeper-turn producer는 별개 cell-carrier 배선 필요한 **named follow-up**.

## Follow-up (named)

1. **keeper-turn board producer**: mint된 turn_ref를 `keeper_tool_call_log_context` cell로 board dispatch까지 thread → SITE BDI/board_tool_post의 `origin.turn_ref` 채움 + handoff parity 적대 검증. (한 turn이 복수 board post 시 `posts_by_turn_ref`를 list-valued로 — `comments_by_post` 패턴.)
2. **fusion-trigger turn_ref**: `fusion_request`로 trigger 턴 turn_ref 전파 → fusion `origin.turn_ref` + chat fusion_block turn_ref(FE 3-gate 동반).

Refs: RFC-0233 §7 (§7.2 계약, §7.5 PR-B, §7.6 guards). Follows PR-A (#21662, #21680, #21696 — all MERGED).
