### PR TITLE
feat(fusion): dashboard fusion-runs panel + SSE (RFC-0266 Phase 4)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -220,6 +220,64 @@ export function parseContextThresholds(
 // that could drift independently. SSOT now lives in `./dashboard-hot`.
 export { fetchDashboardNamespaceTruth } from './dashboard-hot'
 
+// --- RFC-0266 §7 Phase 4: fusion run registry (in-progress + recent) ---
+
+/** Status of a tracked fusion deliberation, mirroring the backend
+    Fusion_run_registry.status_label vocabulary: a run is `running`, or finished
+    `completed` (judge ok) / `failed` (denied / sink-failed / aborted). */
+export type FusionRunStatusLabel = 'running' | 'completed' | 'failed'
+
+/** One row of the fusion run registry from GET /api/v1/dashboard/fusion-runs.
+    The registry tracks what the board-post view cannot: an in-progress
+    deliberation has no board post yet, so only the registry shows it as
+    `running`. Distinct from `FusionRunView` (board-meta-derived detail). */
+export interface FusionRunRecord {
+  runId: string
+  keeper: string
+  preset: string
+  startedAt: number // unix seconds
+  status: FusionRunStatusLabel
+}
+
+export interface DashboardFusionRunsResponse {
+  runs: FusionRunRecord[]
+  count: number
+  generatedAt: string | null
+}
+
+// The backend emits a closed three-label enum, so an unrecognized value can only
+// come from a protocol break. Map it to `failed` (conservative: never let a
+// garbled row pose as a healthy `completed` or an active `running`) rather than
+// to a convenient default — see CLAUDE.md "Unknown → Permissive Default".
+function asFusionRunStatus(value: unknown): FusionRunStatusLabel {
+  return value === 'running' || value === 'completed' || value === 'failed' ? value : 'failed'
+}
+
+export function parseFusionRunsResponse(raw: unknown): DashboardFusionRunsResponse {
+  const root = isRecord(raw) ? raw : {}
+  const runs: FusionRunRecord[] = asRecordArray(root.runs)
+    .map(row => ({
+      runId: asString(row.run_id) ?? '',
+      keeper: asString(row.keeper) ?? '',
+      preset: asString(row.preset) ?? '',
+      startedAt: asNumber(row.started_at) ?? 0,
+      status: asFusionRunStatus(row.status),
+    }))
+    .filter(run => run.runId.length > 0)
+  return {
+    runs,
+    count: asInt(root.count) ?? runs.length,
+    generatedAt: asString(root.generated_at) ?? null,
+  }
+}
+
+export async function fetchFusionRuns(
+  opts?: AbortableRequestOptions,
+): Promise<DashboardFusionRunsResponse> {
+  const raw = await get<unknown>('/api/v1/dashboard/fusion-runs', { signal: opts?.signal })
+  return parseFusionRunsResponse(raw)
+}
+
 export function fetchDashboardExecution(opts?: AbortableRequestOptions): Promise<DashboardExecutionResponse> {
   return get('/api/v1/dashboard/execution', { signal: opts?.signal })
 }

--- a/dashboard/src/components/fusion/fusion-runs-panel.test.ts
+++ b/dashboard/src/components/fusion/fusion-runs-panel.test.ts
@@ -1,0 +1,121 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { parseFusionRunsResponse } from '../../api/dashboard'
+import { fusionRuns, fusionRunsLoading } from '../../store'
+import { FusionRunsPanel, fusionRunStatusText, fusionRunStatusTone } from './fusion-runs-panel'
+
+describe('parseFusionRunsResponse', () => {
+  it('maps snake_case rows to FusionRunRecord and falls back count to length', () => {
+    const parsed = parseFusionRunsResponse({
+      generated_at: '2026-06-20T01:00:00Z',
+      runs: [
+        { run_id: 'r-1', keeper: 'k1', preset: 'balanced', started_at: 100, status: 'running' },
+        { run_id: 'r-2', keeper: 'k2', preset: 'deep', started_at: 200, status: 'completed' },
+      ],
+    })
+    expect(parsed.generatedAt).toBe('2026-06-20T01:00:00Z')
+    expect(parsed.count).toBe(2)
+    expect(parsed.runs[0]).toEqual({
+      runId: 'r-1',
+      keeper: 'k1',
+      preset: 'balanced',
+      startedAt: 100,
+      status: 'running',
+    })
+  })
+
+  it('maps an unrecognized status to failed (never a healthy default) and drops rows without a run_id', () => {
+    const parsed = parseFusionRunsResponse({
+      runs: [
+        { run_id: 'r-ok', keeper: 'k', preset: 'p', started_at: 1, status: 'weird' },
+        { keeper: 'k', preset: 'p', started_at: 2, status: 'running' }, // no run_id -> dropped
+      ],
+    })
+    expect(parsed.runs).toHaveLength(1)
+    expect(parsed.runs[0]?.runId).toBe('r-ok')
+    expect(parsed.runs[0]?.status).toBe('failed')
+  })
+
+  it('returns an empty, well-formed response for a non-object payload', () => {
+    const parsed = parseFusionRunsResponse(null)
+    expect(parsed.runs).toEqual([])
+    expect(parsed.count).toBe(0)
+    expect(parsed.generatedAt).toBeNull()
+  })
+})
+
+describe('fusion run status helpers', () => {
+  it('maps status to the reused chip tone', () => {
+    expect(fusionRunStatusTone('running')).toBe('warn')
+    expect(fusionRunStatusTone('completed')).toBe('ok')
+    expect(fusionRunStatusTone('failed')).toBe('bad')
+  })
+
+  it('keeps the wire label as the display text', () => {
+    expect(fusionRunStatusText('running')).toBe('running')
+    expect(fusionRunStatusText('completed')).toBe('completed')
+    expect(fusionRunStatusText('failed')).toBe('failed')
+  })
+})
+
+describe('FusionRunsPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    fusionRuns.value = []
+    fusionRunsLoading.value = false
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    fusionRuns.value = []
+    fusionRunsLoading.value = false
+  })
+
+  it('shows the empty state when there are no runs', () => {
+    render(html`<${FusionRunsPanel} />`, container)
+    expect(container.querySelector('[data-testid="fusion-runs-empty"]')).not.toBeNull()
+    expect(container.textContent).toContain('No active or recent fusion runs')
+  })
+
+  it('shows a loading hint while empty and loading', () => {
+    fusionRunsLoading.value = true
+    render(html`<${FusionRunsPanel} />`, container)
+    expect(container.textContent).toContain('Loading fusion runs')
+  })
+
+  it('renders one card per run with its status and a running indicator', () => {
+    fusionRuns.value = [
+      { runId: 'r-run', keeper: 'k1', preset: 'balanced', startedAt: 300, status: 'running' },
+      { runId: 'r-done', keeper: 'k2', preset: 'deep', startedAt: 100, status: 'completed' },
+      { runId: 'r-fail', keeper: 'k3', preset: 'deep', startedAt: 200, status: 'failed' },
+    ]
+    render(html`<${FusionRunsPanel} />`, container)
+
+    const cards = container.querySelectorAll('[data-testid="fusion-run-status-card"]')
+    expect(cards).toHaveLength(3)
+
+    const byRun = (id: string) =>
+      Array.from(cards).find(card => card.getAttribute('data-run-id') === id)
+    expect(byRun('r-run')?.getAttribute('data-status')).toBe('running')
+    expect(byRun('r-done')?.getAttribute('data-status')).toBe('completed')
+    expect(byRun('r-fail')?.getAttribute('data-status')).toBe('failed')
+
+    // the running indicator counts only in-progress runs
+    expect(container.textContent).toContain('1 running')
+    expect(container.textContent).toContain('r-run')
+    expect(container.textContent).toContain('k1')
+  })
+
+  it('omits the running indicator when nothing is in progress', () => {
+    fusionRuns.value = [
+      { runId: 'r-done', keeper: 'k2', preset: 'deep', startedAt: 100, status: 'completed' },
+    ]
+    render(html`<${FusionRunsPanel} />`, container)
+    expect(container.querySelector('.fus-runs-live')).toBeNull()
+  })
+})

--- a/dashboard/src/components/fusion/fusion-runs-panel.ts
+++ b/dashboard/src/components/fusion/fusion-runs-panel.ts
@@ -1,0 +1,89 @@
+// RFC-0266 §7 Phase 4 — fusion run status panel.
+//
+// Renders the in-memory fusion run registry (GET /api/v1/dashboard/fusion-runs)
+// as a live status strip: in-progress (`running`) deliberations plus recently
+// finished (`completed` / `failed`) ones. This is the half the board-meta detail
+// view (FusionSurface) cannot show — a deliberation has no board post while it is
+// still running, so only the registry surfaces it. The `fusion_run_status` SSE
+// event re-fetches the signal, so a `running` card flips to completed/failed
+// without the operator polling.
+
+import { html } from 'htm/preact'
+import type { FusionRunRecord, FusionRunStatusLabel } from '../../api/dashboard'
+import { fusionRuns, fusionRunsLoading } from '../../store'
+import { TimeAgo } from '../common/time-ago'
+
+type StatusTone = 'ok' | 'warn' | 'bad'
+
+// Reuses the existing `.fus-status.tone-*` chip styling. `running` is `warn`
+// (drawing the eye to active work), `completed` `ok`, `failed` `bad`.
+export function fusionRunStatusTone(status: FusionRunStatusLabel): StatusTone {
+  switch (status) {
+    case 'running':
+      return 'warn'
+    case 'completed':
+      return 'ok'
+    case 'failed':
+      return 'bad'
+  }
+}
+
+export function fusionRunStatusText(status: FusionRunStatusLabel): string {
+  switch (status) {
+    case 'running':
+      return 'running'
+    case 'completed':
+      return 'completed'
+    case 'failed':
+      return 'failed'
+  }
+}
+
+function FusionRunStatusCard({ run }: { run: FusionRunRecord }) {
+  const tone = fusionRunStatusTone(run.status)
+  return html`
+    <li
+      class="fus-runs-card"
+      data-testid="fusion-run-status-card"
+      data-run-id=${run.runId}
+      data-status=${run.status}
+    >
+      <span class=${`fus-status tone-${tone}`}>${fusionRunStatusText(run.status)}</span>
+      <span class="fus-runs-id">${run.runId}</span>
+      <span class="fus-runs-meta">
+        <span class="fus-runs-keeper">${run.keeper || 'system'}</span>
+        ${run.preset ? html`<span class="fus-runs-preset">${run.preset}</span>` : null}
+        <${TimeAgo} timestamp=${run.startedAt} />
+      </span>
+    </li>
+  `
+}
+
+export function FusionRunsPanel() {
+  const runs = fusionRuns.value
+  const loading = fusionRunsLoading.value
+  const runningCount = runs.filter(run => run.status === 'running').length
+
+  return html`
+    <section class="fus-runs-panel" data-testid="fusion-runs-panel" aria-label="Fusion run status">
+      <header class="fus-runs-head">
+        <h2>Run status</h2>
+        <div class="fus-runs-head-meta">
+          ${runningCount > 0
+            ? html`<span class="fus-runs-live" title="Deliberations in progress">
+                <span class="fus-runs-live-dot"></span>${runningCount} running
+              </span>`
+            : null}
+          <span class="fus-runs-count">${runs.length}</span>
+        </div>
+      </header>
+      ${runs.length === 0
+        ? html`<p class="fus-runs-empty" data-testid="fusion-runs-empty">
+            ${loading ? 'Loading fusion runs...' : 'No active or recent fusion runs.'}
+          </p>`
+        : html`<ul class="fus-runs-list" aria-live="polite">
+            ${runs.map(run => html`<${FusionRunStatusCard} key=${run.runId} run=${run} />`)}
+          </ul>`}
+    </section>
+  `
+}

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -6,6 +6,7 @@ import { boardLoading, boardPosts, refreshBoard } from '../../store'
 import { TimeAgo } from '../common/time-ago'
 import { ringFocusClasses } from '../common/ring'
 import { AgentAvatar } from '../overview/agent-avatar'
+import { FusionRunsPanel } from './fusion-runs-panel'
 
 type FusionRunStatus = 'complete' | 'failed' | 'running'
 type FusionTone = 'ok' | 'warn' | 'bad' | 'volt' | 'muted'
@@ -392,6 +393,8 @@ export function FusionSurface() {
             disabled=${boardLoading.value}
           >${boardLoading.value ? 'Refreshing...' : 'Refresh'}</button>
         </header>
+
+        <${FusionRunsPanel} />
 
         <section class="fus-top-kpis" aria-label="Fusion overview">
           <${FusionMetric} label="runs" value=${runs.length} tone=${runs.length ? 'ok' : 'muted'} />

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -8,6 +8,7 @@ import { formatCost } from './lib/format-number'
 import { isRecord } from './lib/type-guards'
 import {
   removeBoardPost,
+  refreshFusionRuns,
 } from './store'
 import {
   defaultJournalSeverity,
@@ -556,6 +557,13 @@ function handleEvent(event: SSEEvent): void {
         )
         break
       }
+    case 'fusion_run_status':
+      // RFC-0266 §7 Phase 4: a fusion run changed state (running →
+      // completed/failed). Re-fetch the registry snapshot, which is the SSOT;
+      // the event is only a change trigger, never the source of truth, so a
+      // missed/duplicated event self-heals on the next change or route visit.
+      void refreshFusionRuns()
+      break
     case 'keeper_turn_complete':
       {
         const keeperName = keeperTraceNameFromEvent(event, agent)

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -306,6 +306,17 @@ export const goals = signal<Goal[]>([])
 export const goalsLoading = signal(false)
 export const workspaceFsmSnapshot = signal<DashboardWorkspaceFsmSnapshot | null>(null)
 
+// --- Fusion run registry state (RFC-0266 §7 Phase 4) ---
+
+import type { FusionRunRecord } from './api/dashboard'
+
+// In-progress + recently completed fusion deliberations from the in-memory
+// registry endpoint. Distinct from `boardPosts` (the board-derived detail the
+// FusionSurface already renders): the registry is the only source that shows a
+// run while it is still `running`, before any board post exists.
+export const fusionRuns = signal<FusionRunRecord[]>([])
+export const fusionRunsLoading = signal(false)
+
 // --- OAS monitoring state ---
 
 import type { OasAgentEvent, OasHealthSummary, OasKeeperSnapshot } from './types/oas'
@@ -1219,6 +1230,25 @@ export async function refreshGoals(): Promise<void> {
     console.warn('[Planning] fetch error:', err)
   } finally {
     goalsLoading.value = false
+  }
+}
+
+// --- Fusion run registry fetcher (RFC-0266 §7 Phase 4) ---
+
+// Re-fetched on route visit (tab-refresh) and on each `fusion_run_status` SSE
+// event. The endpoint is the SSOT for run status; the dashboard never
+// reconstructs registry state from the event payload, so a dropped/duplicated
+// event self-heals on the next fetch.
+export async function refreshFusionRuns(): Promise<void> {
+  fusionRunsLoading.value = true
+  try {
+    const { fetchFusionRuns } = await import('./api/dashboard')
+    const data = await fetchFusionRuns()
+    fusionRuns.value = data.runs
+  } catch (err) {
+    console.warn('[Fusion] runs fetch error:', err)
+  } finally {
+    fusionRunsLoading.value = false
   }
 }
 

--- a/dashboard/src/styles/fusion-v2.css
+++ b/dashboard/src/styles/fusion-v2.css
@@ -478,3 +478,131 @@
     width: 100%;
   }
 }
+
+/* RFC-0266 §7 Phase 4 — fusion run status panel (registry-backed live strip).
+   Reuses the `.fus-status.tone-*` chip; only layout is defined here. */
+.v2-fusion-surface .fus-runs-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-2);
+  background: var(--fus-panel);
+  padding: 12px 14px;
+}
+
+.v2-fusion-surface .fus-runs-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.v2-fusion-surface .fus-runs-head h2 {
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fus-muted);
+  margin: 0;
+}
+
+.v2-fusion-surface .fus-runs-head-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.v2-fusion-surface .fus-runs-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--warn-fg);
+}
+
+.v2-fusion-surface .fus-runs-live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--warn-fg);
+  animation: fus-runs-pulse 1.6s ease-in-out infinite;
+}
+
+.v2-fusion-surface .fus-runs-count {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--fus-muted);
+}
+
+.v2-fusion-surface .fus-runs-empty {
+  font-size: 12px;
+  color: var(--fus-muted);
+  margin: 0;
+  padding: 4px 0;
+}
+
+.v2-fusion-surface .fus-runs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.v2-fusion-surface .fus-runs-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-1);
+  background: var(--fus-panel-strong);
+  padding: 7px 10px;
+}
+
+.v2-fusion-surface .fus-runs-id {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--fus-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-fusion-surface .fus-runs-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--fus-muted);
+  flex: 0 0 auto;
+}
+
+.v2-fusion-surface .fus-runs-preset {
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-1);
+  padding: 2px 6px;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 10px;
+}
+
+@keyframes fus-runs-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .v2-fusion-surface .fus-runs-live-dot {
+    animation: none;
+  }
+}

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -1,5 +1,5 @@
 import type { RouteState } from './types'
-import { refreshExecution, refreshBoard, refreshGoals, refreshShell } from './store'
+import { refreshExecution, refreshBoard, refreshFusionRuns, refreshGoals, refreshShell } from './store'
 import { requestNamespaceTruth } from './namespace-truth-store'
 import { refreshMissionSnapshot } from './mission-store'
 import { refreshOperatorWorkspaceDigest, refreshOperatorSnapshot } from './operator-store'
@@ -48,6 +48,7 @@ type RefreshTask =
   | 'surfaceReadiness'
   | 'operatorSnapshot'
   | 'operatorWorkspaceDigest'
+  | 'fusionRuns'
 
 // Monitor data ownership is partitioned by section. Two tiers:
 //   Tier 1 — visible lanes (agents / fleet-health / runtime / observatory)
@@ -69,7 +70,10 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
     case 'board':
       return ['board']
     case 'fusion':
-      return ['board']
+      // 'board' feeds the board-meta-derived detail browser; 'fusionRuns' feeds
+      // the registry-backed live status panel (running + recent) that the SSE
+      // `fusion_run_status` event also re-fetches.
+      return ['board', 'fusionRuns']
     case 'monitoring':
       if (routeState.params.section === 'observatory') {
         return ['namespaceTruth', 'observatory']
@@ -154,6 +158,7 @@ const REFRESHERS: Record<RefreshTask, (routeState: Pick<RouteState, 'tab' | 'par
   surfaceReadiness: () => { void refreshSurfaceReadinessSurface() },
   operatorSnapshot: () => { void refreshOperatorSnapshot({ force: true }) },
   operatorWorkspaceDigest: () => { void refreshOperatorWorkspaceDigest({ force: true }) },
+  fusionRuns: () => { void refreshFusionRuns() },
 }
 
 // --- Tab visit counter (localStorage-persisted) ---

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -117,6 +117,29 @@ let judge_meta (judge : (Fusion_types.judge_synthesis, string) result) : Yojson.
    Eio 구조적 취소(Cancelled)는 재전파한다(record_recovery_stimulus_turn_started 패턴).
    Paused 키퍼는 강제 재개하지 않는다(board wake와 동일 보수적 기본값, wakeup_keeper가
    Running 항목만 깨움) — 결과는 board/chat 영속으로 남는다. *)
+(* RFC-0266 §7 Phase 4: push the registry delta to the dashboard fusion-runs
+   panel so a [Running] card flips to completed/failed live (no polling). Reads
+   the canonical run back from the registry and serializes it through the shared
+   [Fusion_run_registry.run_to_yojson] so the SSE payload matches the HTTP list
+   endpoint exactly. Like wake, this is best-effort: a broadcast failure must not
+   abort the fusion sink, so every non-cancel exception is swallowed + logged
+   (mirrors Keeper_chat_broadcast). An unknown run_id is a no-op. *)
+let broadcast_run_status ~registry ~run_id =
+  try
+    match Fusion_run_registry.get registry ~run_id with
+    | None -> ()
+    | Some run ->
+      Sse.broadcast
+        (`Assoc
+           [ ("type", `String "fusion_run_status")
+           ; ("run", Fusion_run_registry.run_to_yojson run)
+           ])
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Keeper.warn "fusion_run_broadcast run_id=%s failed: %s" run_id
+      (Printexc.to_string exn)
+
 let wake_keeper_on_fusion_completion
       ~base_dir ~keeper ~run_id ~ok ~resolved_answer ~board_post_id =
   try
@@ -232,6 +255,7 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judge_usage :
        (* RFC-0266 §7: registry를 Completed로 갱신(가시성). wake와 무관하게 run
           상태를 반영해야 하므로 wake 직전 무조건 호출. *)
        Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok;
+       broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
        wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok ~resolved_answer
          ~board_post_id:(Board.Post_id.to_string post.id);
        Ok ()

--- a/lib/fusion/fusion_sink.mli
+++ b/lib/fusion/fusion_sink.mli
@@ -52,3 +52,13 @@ val wake_keeper_on_fusion_completion :
   -> resolved_answer:string
   -> board_post_id:string
   -> unit
+
+(** RFC-0266 §7 Phase 4: broadcast a [fusion_run_status] SSE event carrying the
+    current registry snapshot of [run_id] so the dashboard fusion-runs panel
+    reflects running→completed transitions live. Reads the canonical run back
+    from [registry] and serializes it via [Fusion_run_registry.run_to_yojson]
+    (same shape as the HTTP list endpoint). Best-effort: an unknown [run_id] is a
+    no-op, and every exception except [Eio.Cancel.Cancelled] is swallowed +
+    logged so a broadcast failure never aborts the fusion tool/sink. Callers
+    invoke it right after [register_running] / [mark_completed]. *)
+val broadcast_run_status : registry:Fusion_run_registry.t -> run_id:string -> unit

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -38,6 +38,7 @@ let append_chat_failure ~base_dir ~keeper ~run_id content =
   (* RFC-0266 §7: registry를 Completed{ok=false}로 갱신(가시성). wake와 무관하게
      run 상태를 반영해야 하므로 별도 호출(Running 키퍼만 깨우는 wake와 달리 무조건). *)
   Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok:false;
+  Fusion_sink.broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
   Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:false
     ~resolved_answer:content ~board_post_id:""
 
@@ -71,6 +72,10 @@ let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ~args : string =
          뿐, 키퍼를 깨우지 않는다(wake는 별개). *)
       Fusion_run_registry.register_running Fusion_run_registry.global ~run_id ~keeper
         ~preset ~started_at:now_unix;
+      (* RFC-0266 §7 Phase 4: push the new [Running] card to the dashboard panel
+         (no polling). wake-free, broadcast-failure-safe; see
+         Fusion_sink.broadcast_run_status. *)
+      Fusion_sink.broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
       (* out-of-band: fiber fork → 키퍼 턴은 즉시 진행, 결과는 sink가 chat lane에.
          예산은 orchestrator가 원자적으로 소비한다. 배경 fiber 실패/거부/싱크
          실패는 동일한 chat lane에 기록해 started-but-failed 상태가 남지 않도록 한다.

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -84,6 +84,30 @@ let get (t : t) ~run_id : run option =
   List.find_opt (fun r -> String.equal r.run_id run_id) (Atomic.get t)
 ;;
 
+(* Stable status vocabulary shared by every fusion-run surface (Phase 3 keeper
+   tool, Phase 4 dashboard route, the [fusion_run_status] SSE event). Hand-
+   written rather than [@@deriving] so the on-wire labels stay
+   "running"/"completed"/"failed" regardless of the variant shape — a consumer
+   never reconstructs run state from the variant, only reads these labels. *)
+let status_label = function
+  | Running -> "running"
+  | Completed { ok = true } -> "completed"
+  | Completed { ok = false } -> "failed"
+;;
+
+(* The single per-run JSON object. The HTTP list endpoint, the SSE delta, and the
+   keeper status tool all serialize a run through here so the field set and the
+   status label never drift between surfaces. *)
+let run_to_yojson (r : run) : Yojson.Safe.t =
+  `Assoc
+    [ ("run_id", `String r.run_id)
+    ; ("keeper", `String r.keeper)
+    ; ("preset", `String r.preset)
+    ; ("started_at", `Float r.started_at)
+    ; ("status", `String (status_label r.status))
+    ]
+;;
+
 (* Process-wide registry the fusion tool/sink write to (server-lifetime). Tests
    use a fresh [create ()] for state isolation, avoiding a reset backdoor. *)
 let global : t = create ()

--- a/lib/fusion_core/fusion_run_registry.mli
+++ b/lib/fusion_core/fusion_run_registry.mli
@@ -40,5 +40,16 @@ val list_runs : t -> run list
 val get : t -> run_id:string -> run option
 (** The run with [run_id], if still tracked. *)
 
+val status_label : run_status -> string
+(** Stable wire label: [Running -> "running"], [Completed {ok=true} ->
+    "completed"], [Completed {ok=false} -> "failed"]. The one place the status
+    vocabulary is defined, shared by the Phase 3 tool, the Phase 4 dashboard
+    route, and the [fusion_run_status] SSE event so it never drifts. *)
+
+val run_to_yojson : run -> Yojson.Safe.t
+(** Canonical per-run JSON: [{run_id, keeper, preset, started_at, status}]. The
+    single serializer for every fusion-run surface (tool / HTTP list / SSE
+    delta). *)
+
 val global : t
 (** Process-wide registry the fusion tool/sink write to (server-lifetime). *)

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -415,21 +415,12 @@ let handle_masc_fusion ~(config : Workspace.config) ~(meta : keeper_meta) ~args 
    the process-wide [global] the fusion tool/sink write to and scopes by the
    calling keeper. *)
 let fusion_status_json ~(registry : Fusion_run_registry.t) ~keeper ~run_id : string =
-  let status_label (status : Fusion_run_registry.run_status) =
-    match status with
-    | Fusion_run_registry.Running -> "running"
-    | Fusion_run_registry.Completed { ok = true } -> "completed"
-    | Fusion_run_registry.Completed { ok = false } -> "failed"
-  in
-  let run_to_yojson (r : Fusion_run_registry.run) : Yojson.Safe.t =
-    `Assoc
-      [ "run_id", `String r.run_id
-      ; "keeper", `String r.keeper
-      ; "preset", `String r.preset
-      ; "started_at", `Float r.started_at
-      ; "status", `String (status_label r.status)
-      ]
-  in
+  (* Per-run serialization (field set + status vocabulary) is owned by
+     Fusion_run_registry.run_to_yojson — the single serializer shared with the
+     Phase 4 dashboard HTTP route and the fusion_run_status SSE event, so the
+     shape never drifts between the tool and the dashboard. This function only
+     adds the tool envelope + per-keeper scoping. *)
+  let run_to_yojson = Fusion_run_registry.run_to_yojson in
   let belongs_to_keeper (r : Fusion_run_registry.run) =
     String.equal r.keeper keeper
   in

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -19,6 +19,10 @@
   ;; #20929: server bootstrap converges <base>/.masc/config/prompts onto the
   ;; binary-embedded config/ tree so merged prompt edits ship on restart.
   masc.embedded_config
+  ;; RFC-0266 Phase 4: GET /api/v1/dashboard/fusion-runs names
+  ;; Fusion_run_registry directly; dune does not re-export it through the masc
+  ;; dep, so masc_server lists masc.fusion_core explicitly.
+  masc.fusion_core
   masc.masc_tool_surface
   masc.operator
   masc.voice_bridge_core

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -256,6 +256,23 @@ let add_routes ~sw ~clock router =
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
+  (* RFC-0266 §7 Phase 4: read-only snapshot of the in-memory fusion run registry
+     (in-progress + recently completed). The fusion panel fetches this on load and
+     re-fetches on the [fusion_run_status] SSE event. Registry reads are O(runs)
+     in-memory, so no Dashboard_cache layer; each run serializes through the shared
+     Fusion_run_registry.run_to_yojson so the shape matches the SSE delta. *)
+  |> Http.Router.get "/api/v1/dashboard/fusion-runs" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let runs = Fusion_run_registry.list_runs Fusion_run_registry.global in
+         let json =
+           `Assoc
+             [ ("generated_at", `String (Masc_domain.now_iso ()))
+             ; ("count", `Int (List.length runs))
+             ; ("runs", `List (List.map Fusion_run_registry.run_to_yojson runs))
+             ]
+         in
+         Http.Response.json_value ~compress:true ~request:req json reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/branches" (fun request reqd ->
        with_public_read (fun state req reqd ->
          (* /branches spawns `git -C <repo> branch` via Exec_gate. Cache +

--- a/test/fusion_core/test_fusion_run_registry.ml
+++ b/test/fusion_core/test_fusion_run_registry.ml
@@ -14,6 +14,18 @@ let status_completed_ok = function
   | R.Running -> None
 ;;
 
+let yojson_field j k =
+  match j with
+  | `Assoc l -> List.assoc_opt k l
+  | _ -> None
+;;
+
+let yojson_str j k =
+  match yojson_field j k with
+  | Some (`String s) -> s
+  | _ -> Printf.ksprintf failwith "missing string field %s" k
+;;
+
 let test_register_then_query () =
   let t = R.create () in
   R.register_running t ~run_id:"r1" ~keeper:"k" ~preset:"balanced" ~started_at:10.0;
@@ -77,6 +89,34 @@ let test_prune_keeps_running_and_recent () =
   check bool "registry is bounded under flood" true (List.length (R.list_runs t) <= 65)
 ;;
 
+(* Phase 4: the shared status vocabulary used by the dashboard route + SSE +
+   keeper tool. "failed" (ok=false) must never collapse into "completed". *)
+let test_status_label () =
+  check string "running label" "running" (R.status_label R.Running);
+  check string "completed label" "completed" (R.status_label (R.Completed { ok = true }));
+  check string "failed label" "failed" (R.status_label (R.Completed { ok = false }))
+;;
+
+(* Phase 4: run_to_yojson is the one per-run serializer for every fusion-run
+   surface — the field set and the status label are asserted here so a drift
+   between the HTTP list, the SSE delta, and the tool is caught at the source. *)
+let test_run_to_yojson_shape () =
+  let t = R.create () in
+  R.register_running t ~run_id:"r-ser" ~keeper:"kx" ~preset:"deep" ~started_at:42.0;
+  R.mark_completed t ~run_id:"r-ser" ~ok:false;
+  match R.get t ~run_id:"r-ser" with
+  | None -> fail "run must be present"
+  | Some run ->
+    let j = R.run_to_yojson run in
+    check string "run_id" "r-ser" (yojson_str j "run_id");
+    check string "keeper" "kx" (yojson_str j "keeper");
+    check string "preset" "deep" (yojson_str j "preset");
+    check string "status label (ok=false -> failed)" "failed" (yojson_str j "status");
+    (match yojson_field j "started_at" with
+     | Some (`Float f) -> check (float 0.001) "started_at" 42.0 f
+     | _ -> fail "started_at must serialize as a float field")
+;;
+
 let () =
   run
     "fusion_run_registry"
@@ -86,6 +126,10 @@ let () =
         ; test_case "mark unknown run_id is a no-op" `Quick test_mark_unknown_is_noop
         ; test_case "list_runs is newest-first" `Quick test_list_newest_first
         ; test_case "prune keeps Running + recent completed" `Quick test_prune_keeps_running_and_recent
+        ] )
+    ; ( "rfc-0266-phase4"
+      , [ test_case "status_label vocabulary" `Quick test_status_label
+        ; test_case "run_to_yojson shape + label" `Quick test_run_to_yojson_shape
         ] )
     ]
 ;;


### PR DESCRIPTION
## RFC-0266 §7 / §9 Phase 4 — dashboard fusion-runs panel + SSE

The Phase 2 fusion run registry (#21695) tracks every deliberation as `Running` then `Completed { ok }`, but nothing read it yet. This wires it to the dashboard so an operator sees what is deliberating now and what just finished, with `running → completed/failed` transitions arriving over SSE — no polling.

This is the VISIBILITY half of RFC-0266 (Phase 1 WAKE #21677 is the keeper-facing half). It absorbs keeper task-1433.

### Scope decision — panel inside the existing `fusion` surface, not a new nav surface

`fusion` is already a top-level surface, but it renders runs derived from **board posts** — which only exist once a deliberation has *finished* (the sink writes the post). An in-progress run has no board post, so the board-derived view structurally cannot show `running`. The registry is the only source that can.

So Phase 4 adds a registry-backed **status strip** at the top of the existing `fusion` surface rather than a new top-level surface. This keeps `nav-event parity` trivially intact (no `valid_surfaces` / `VALID_TABS` / parity-script change), avoids the sectionless-surface locked test, and ships the RFC's "fusion-runs 패널" without touching the nav registry. The board-derived detail browser stays below as the deep-dive.

### One serializer, three surfaces (no hand-mirror)

`Fusion_run_registry.run_to_yojson` / `status_label` are added to `fusion_core` as the single per-run serializer and the single status vocabulary (`running` / `completed` / `failed`). The HTTP list endpoint and the SSE delta both go through it, so the field set and the labels cannot drift between surfaces. The Phase 3 `masc_fusion_status` tool (#21712, merged) hand-rolled an identical `status_label` + `run_to_yojson`; the second commit here points it at the shared serializer too, so the keeper tool and the dashboard cannot drift. The tool keeps only its envelope + per-keeper scoping.

### Changes

**Backend (OCaml)**
- `lib/fusion_core/fusion_run_registry.{ml,mli}` — `status_label` + `run_to_yojson` (the shared SSOT serializer).
- `lib/server/server_routes_http_routes_dashboard.ml` — `GET /api/v1/dashboard/fusion-runs` (`with_public_read`, no cache: registry reads are in-memory). Envelope `{ generated_at, count, runs }`, each run via the shared serializer. `fusion_core` is already in the dep tree; no dune change.
- `lib/fusion/fusion_sink.ml` — `broadcast_run_status`: reads the canonical run back from the registry and broadcasts a `fusion_run_status` SSE event `{ type, run }`. Best-effort (mirrors `Keeper_chat_broadcast`): re-raises `Cancelled`, swallows + logs everything else, no-ops an unknown run_id — a broadcast failure never aborts the fusion sink.
- Emit at the three registry-write sites: `register_running` (running card appears live) and both `mark_completed` paths (success in `fusion_sink`, denied/sink-failed/aborted in `fusion_tool.append_chat_failure`).

**Frontend (dashboard TS)**
- `api/dashboard.ts` — `FusionRunRecord` / `DashboardFusionRunsResponse` types, `parseFusionRunsResponse`, `fetchFusionRuns()`. An unrecognized status maps to `failed` (conservative — never lets a garbled row pose as a healthy `completed`/`running`).
- `store.ts` — `fusionRuns` / `fusionRunsLoading` signals + `refreshFusionRuns()`.
- `tab-refresh.ts` — the `fusion` route plan gains `fusionRuns`.
- `sse.ts` — `case 'fusion_run_status'` re-fetches the registry. The event is only a change trigger; the endpoint stays the source of truth, so a missed/duplicate event self-heals on the next fetch (no client-side registry reconstruction).
- `components/fusion/fusion-runs-panel.ts` — the status strip (reuses the existing `.fus-status.tone-*` chip; `aria-live="polite"` so transitions are announced). Mounted at the top of `FusionSurface`.
- `styles/fusion-v2.css` — `fus-runs-*` layout only (chip colors reused, not redefined); pulse respects `prefers-reduced-motion`.

### Verification

- `dune build` (full umbrella + server) green.
- `test/fusion_core/test_fusion_run_registry.ml` — 2 new Phase 4 cases (status_label vocabulary, run_to_yojson shape). Mutation-relevant: `ok=false` must serialize to `failed`, never `completed`.
- `lib/server` built clean before the rebase (the route needed `masc.fusion_core` added to `lib/server/dune`; dune does not re-export it through the `masc` dep — the byte test-exe build surfaced the missing dep). `lib/server/dune` is included here.
- dashboard `pnpm typecheck` clean; `pnpm vitest` — `fusion-runs-panel.test.ts` (parse / helpers / panel render + running indicator), `fusion-surface.test.ts` (regression with the new child), `tab-refresh.test.ts` all green (33 tests), re-confirmed after the rebase onto current `main`.

Base-broken caveat (not this diff): `main` itself is red — the `CI` workflow has `conclusion: failure` on HEAD and the last several commits, with errors in files this PR does not touch: `gate_keeper_backend.ml` (warning 16, unerasable optional argument), a duplicate `Reconcile` module, and a `Syntax error: ) expected`. On `main` HEAD, `Lint` fails first and `Build and Test` / `Health` are skipped. This PR inherits those failures: **none of this PR's files appear in the CI error set** — `fusion_core` builds with 7 green tests and the dashboard is green (typecheck + 33 vitest). Once `main` goes green a rebase clears this PR; the base breakage is unrelated churn and is not addressed here.

### Not in scope
- Phase 3 tool adopting the shared serializer (follow-up after #21712 merges).
- A dedicated nav surface (intentionally avoided — see scope decision).

RFC-0266 §7 (VISIBILITY) / §9 Phase 4. Phase 1 (#21677) and Phase 2 (#21695) merged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
