### PR TITLE
fix(dashboard): key keeper sends by client action

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -4,7 +4,7 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { fireEvent } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { ChatBlock, KeeperConversationEntry } from '../../types'
+import type { ChatBlock, KeeperConversationAttachment, KeeperConversationEntry } from '../../types'
 import type { ToolCallEntry } from '../../api/dashboard'
 import { ChatComposer, ChatTranscript, type ChatComposerSendPayload } from './primitives'
 import { collectAttachments } from './attachments'
@@ -1341,6 +1341,52 @@ describe('ChatComposer multimodal', () => {
     const secondId = onSend.mock.calls[1]?.[0].clientActionId
     expect(firstId).toBe(secondId)
     expect(firstId).toContain('same text')
+  })
+
+  it('changes the client action id when attachment data changes', async () => {
+    const baseAttachment: Omit<KeeperConversationAttachment, 'data'> = {
+      id: 'att-same',
+      type: 'image',
+      name: 'screen.png',
+      size: 1024,
+      mimeType: 'image/png',
+      dims: '100×100',
+    }
+    vi.mocked(collectAttachments)
+      .mockResolvedValueOnce({
+        attachments: [{ ...baseAttachment, data: 'data:image/png;base64,AAAA' }],
+        errors: [],
+      })
+      .mockResolvedValueOnce({
+        attachments: [{ ...baseAttachment, data: 'data:image/png;base64,BBBB' }],
+        errors: [],
+      })
+
+    const onSend = vi.fn()
+    renderComposer({ draft: 'same text', onSend })
+
+    let fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    setInputFiles(fileInput, [new File(['a'], 'screen.png', { type: 'image/png' })])
+    fileInput.dispatchEvent(new Event('change'))
+    await new Promise((r) => setTimeout(r, 10))
+
+    let sendBtn = container.querySelector('.send') as HTMLButtonElement
+    sendBtn.click()
+    await new Promise((r) => setTimeout(r, 10))
+
+    fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    setInputFiles(fileInput, [new File(['b'], 'screen.png', { type: 'image/png' })])
+    fileInput.dispatchEvent(new Event('change'))
+    await new Promise((r) => setTimeout(r, 10))
+
+    sendBtn = container.querySelector('.send') as HTMLButtonElement
+    sendBtn.click()
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(onSend).toHaveBeenCalledTimes(2)
+    const firstId = onSend.mock.calls[0]?.[0].clientActionId
+    const secondId = onSend.mock.calls[1]?.[0].clientActionId
+    expect(firstId).not.toBe(secondId)
   })
 
   it('preserves audio attachments as audio user blocks', async () => {

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -4,9 +4,9 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { fireEvent } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { ChatBlock, KeeperConversationEntry, KeeperUserInputBlock } from '../../types'
+import type { ChatBlock, KeeperConversationEntry } from '../../types'
 import type { ToolCallEntry } from '../../api/dashboard'
-import { ChatComposer, ChatTranscript } from './primitives'
+import { ChatComposer, ChatTranscript, type ChatComposerSendPayload } from './primitives'
 import { collectAttachments } from './attachments'
 import { recordToolCallOutputs, resetToolCallOutputs } from '../../tool-call-output-store'
 import { fetchBoardPost } from '../../api/board'
@@ -1182,7 +1182,7 @@ describe('ChatComposer multimodal', () => {
 
   function renderComposer(props: {
     draft?: string
-    onSend?: (payload: { blocks: ChatBlock[]; userBlocks: KeeperUserInputBlock[] }) => void
+    onSend?: (payload: ChatComposerSendPayload) => void
     disabled?: boolean
     streaming?: boolean
   } = {}) {
@@ -1322,6 +1322,25 @@ describe('ChatComposer multimodal', () => {
       },
       { type: 'text', text: 'check this <tag>' },
     ])
+    const clientActionId = onSend.mock.calls[0]?.[0].clientActionId
+    expect(clientActionId).toContain('check this <tag>')
+    expect(clientActionId).toContain('att-img')
+  })
+
+  it('mints the same client action id for repeated sends of the same draft', async () => {
+    const onSend = vi.fn()
+    renderComposer({ draft: 'same text', onSend })
+
+    const sendBtn = container.querySelector('.send') as HTMLButtonElement
+    sendBtn.click()
+    sendBtn.click()
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(onSend).toHaveBeenCalledTimes(2)
+    const firstId = onSend.mock.calls[0]?.[0].clientActionId
+    const secondId = onSend.mock.calls[1]?.[0].clientActionId
+    expect(firstId).toBe(secondId)
+    expect(firstId).toContain('same text')
   })
 
   it('preserves audio attachments as audio user blocks', async () => {
@@ -1361,6 +1380,7 @@ describe('ChatComposer multimodal', () => {
         size: 2048,
       },
     ])
+    expect(onSend.mock.calls[0]?.[0].clientActionId).toContain('att-audio')
   })
 
   it('keeps send disabled until there is content', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -308,6 +308,15 @@ function attachmentMeta(attachment: KeeperConversationAttachment): string {
   return [attachment.mimeType, formatAttachmentSize(attachment.size)].filter(Boolean).join(' · ')
 }
 
+function actionFingerprint(value: string): string {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(36)
+}
+
 function composerAttachmentActionFingerprint(attachment: KeeperConversationAttachment): Record<string, unknown> {
   return {
     id: attachment.id,
@@ -317,6 +326,7 @@ function composerAttachmentActionFingerprint(attachment: KeeperConversationAttac
     size: attachment.size,
     dims: attachment.dims ?? null,
     dataLength: attachment.data.length,
+    dataHash: actionFingerprint(attachment.data),
   }
 }
 

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -32,6 +32,12 @@ export interface SigilBadgeKeeper {
   sigil?: string
 }
 
+export interface ChatComposerSendPayload {
+  blocks: ChatBlock[]
+  userBlocks: KeeperUserInputBlock[]
+  clientActionId: string
+}
+
 /** Status dot wrapper — maps keeper-v2 status strings to shared StatusDot tones. */
 export function ChatStatusDot({ status, pulse }: { status: string; pulse?: boolean }): VNode {
   const state = status === 'run' ? 'ok' : status === 'pause' ? 'warn' : status === 'off' ? 'idle' : status
@@ -300,6 +306,28 @@ function isRenderableImageAttachment(attachment: KeeperConversationAttachment): 
 
 function attachmentMeta(attachment: KeeperConversationAttachment): string {
   return [attachment.mimeType, formatAttachmentSize(attachment.size)].filter(Boolean).join(' · ')
+}
+
+function composerAttachmentActionFingerprint(attachment: KeeperConversationAttachment): Record<string, unknown> {
+  return {
+    id: attachment.id,
+    type: attachment.type,
+    name: attachment.name,
+    mimeType: attachment.mimeType,
+    size: attachment.size,
+    dims: attachment.dims ?? null,
+    dataLength: attachment.data.length,
+  }
+}
+
+function composerClientActionId(
+  text: string,
+  attachments: readonly KeeperConversationAttachment[],
+): string {
+  return JSON.stringify({
+    text,
+    attachments: attachments.map(composerAttachmentActionFingerprint),
+  })
 }
 
 function dataUriToText(data: string): string | null {
@@ -2474,7 +2502,7 @@ export function ChatComposer({
   queueEnabled?: boolean
   queueCount?: number
   onDraftChange: (value: string) => void
-  onSend: (payload: { blocks: ChatBlock[]; userBlocks: KeeperUserInputBlock[] }) => void | Promise<void>
+  onSend: (payload: ChatComposerSendPayload) => void | Promise<void>
   onAbort?: () => void
   layout?: 'default' | 'primary'
 }) {
@@ -2583,7 +2611,11 @@ export function ChatComposer({
       blocks.push({ t: 'p', html: escapeHtml(text) } as ChatBlock)
       userBlocks.push({ type: 'text', text })
     }
-    void onSend({ blocks, userBlocks })
+    void onSend({
+      blocks,
+      userBlocks,
+      clientActionId: composerClientActionId(text, attachments),
+    })
     onDraftChange('')
     setAttachments([])
     if (textareaRef.current) textareaRef.current.style.height = 'auto'

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -58,7 +58,7 @@ vi.mock('./common/toast', () => ({
 import { keeperActionErrors, keeperHydrating, keeperSending, keeperStreamStartedAt, keeperThreads } from '../keeper-runtime'
 import { keeperStatusDetails } from '../keeper-runtime'
 import { hydrateKeeperStatus, isKeeperThreadMessageSendInFlight } from '../keeper-runtime'
-import { _resetChatStoreForTests, getQueueLength } from '../keeper-chat-store'
+import { _resetChatStoreForTests, enqueueInput, getQueueLength } from '../keeper-chat-store'
 import { shellAuthSummary } from '../store'
 import type { KeeperConversationEntry } from '../types'
 import {
@@ -335,6 +335,27 @@ describe('KeeperConversationPanel', () => {
     fireEvent.click(sendButton)
 
     expect(getQueueLength('sangsu')).toBe(0)
+  })
+
+  it('does not enqueue a duplicate submit for an already queued client action', async () => {
+    keeperSending.value = { sangsu: true }
+    const clientActionId = JSON.stringify({ text: 'same draft', attachments: [] })
+    enqueueInput('sangsu', 'same draft', undefined, clientActionId)
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'same draft' } })
+    await Promise.resolve()
+
+    const sendButton = container.querySelector('.send') as HTMLButtonElement
+    fireEvent.click(sendButton)
+
+    expect(getQueueLength('sangsu')).toBe(1)
   })
 
   it('forwards the message-level turn inspector action to the transcript', async () => {

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { bootKeeper, shutdownKeeper } = vi.hoisted(() => ({
@@ -32,6 +33,7 @@ vi.mock('../keeper-runtime', async () => {
     recoverKeeperRuntime: vi.fn(),
     resumePendingKeeperChatRequests: vi.fn(async () => undefined),
     sendKeeperThreadMessage: vi.fn(async () => null),
+    isKeeperThreadMessageSendInFlight: vi.fn(() => false),
   }
 })
 
@@ -55,7 +57,8 @@ vi.mock('./common/toast', () => ({
 
 import { keeperActionErrors, keeperHydrating, keeperSending, keeperStreamStartedAt, keeperThreads } from '../keeper-runtime'
 import { keeperStatusDetails } from '../keeper-runtime'
-import { hydrateKeeperStatus } from '../keeper-runtime'
+import { hydrateKeeperStatus, isKeeperThreadMessageSendInFlight } from '../keeper-runtime'
+import { _resetChatStoreForTests, getQueueLength } from '../keeper-chat-store'
 import { shellAuthSummary } from '../store'
 import type { KeeperConversationEntry } from '../types'
 import {
@@ -137,11 +140,15 @@ describe('KeeperConversationPanel', () => {
     keeperActionErrors.value = {}
     keeperStreamStartedAt.value = {}
     shellAuthSummary.value = null
+    _resetChatStoreForTests()
+    vi.mocked(isKeeperThreadMessageSendInFlight).mockReset()
+    vi.mocked(isKeeperThreadMessageSendInFlight).mockReturnValue(false)
   })
 
   afterEach(() => {
     render(null, container)
     container.remove()
+    _resetChatStoreForTests()
     vi.unstubAllGlobals()
   })
 
@@ -308,6 +315,26 @@ describe('KeeperConversationPanel', () => {
     expect(container.querySelector('[title="이미지·파일 첨부"]')).not.toBeNull()
     expect(container.querySelector('input[type="file"]')).not.toBeNull()
     expect(container.querySelector('input[name="keeper_chat_search"]')).not.toBeNull()
+  })
+
+  it('does not enqueue a duplicate submit for the active client action', async () => {
+    keeperSending.value = { sangsu: true }
+    vi.mocked(isKeeperThreadMessageSendInFlight).mockReturnValue(true)
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'same draft' } })
+    await Promise.resolve()
+
+    const sendButton = container.querySelector('.send') as HTMLButtonElement
+    fireEvent.click(sendButton)
+
+    expect(getQueueLength('sangsu')).toBe(0)
   })
 
   it('forwards the message-level turn inspector action to the transcript', async () => {

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { fireEvent } from '@testing-library/preact'
+import { fireEvent, waitFor } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { bootKeeper, shutdownKeeper } = vi.hoisted(() => ({
@@ -57,7 +57,7 @@ vi.mock('./common/toast', () => ({
 
 import { keeperActionErrors, keeperHydrating, keeperSending, keeperStreamStartedAt, keeperThreads } from '../keeper-runtime'
 import { keeperStatusDetails } from '../keeper-runtime'
-import { hydrateKeeperStatus, isKeeperThreadMessageSendInFlight } from '../keeper-runtime'
+import { hydrateKeeperStatus, isKeeperThreadMessageSendInFlight, sendKeeperThreadMessage } from '../keeper-runtime'
 import { _resetChatStoreForTests, enqueueInput, getQueueLength } from '../keeper-chat-store'
 import { shellAuthSummary } from '../store'
 import type { KeeperConversationEntry } from '../types'
@@ -141,6 +141,8 @@ describe('KeeperConversationPanel', () => {
     keeperStreamStartedAt.value = {}
     shellAuthSummary.value = null
     _resetChatStoreForTests()
+    vi.mocked(sendKeeperThreadMessage).mockReset()
+    vi.mocked(sendKeeperThreadMessage).mockResolvedValue(undefined)
     vi.mocked(isKeeperThreadMessageSendInFlight).mockReset()
     vi.mocked(isKeeperThreadMessageSendInFlight).mockReturnValue(false)
   })
@@ -356,6 +358,60 @@ describe('KeeperConversationPanel', () => {
     fireEvent.click(sendButton)
 
     expect(getQueueLength('sangsu')).toBe(1)
+  })
+
+  it('keeps queued client action ids attached when draining the queue', async () => {
+    enqueueInput('sangsu', 'queued one', undefined, 'queued-click-1')
+    enqueueInput('sangsu', 'queued two', undefined, 'queued-click-2')
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'trigger drain' } })
+    await Promise.resolve()
+
+    const sendButton = container.querySelector('.send') as HTMLButtonElement
+    fireEvent.click(sendButton)
+
+    await waitFor(() => expect(sendKeeperThreadMessage).toHaveBeenCalledTimes(2))
+    expect(vi.mocked(sendKeeperThreadMessage).mock.calls[1]?.[1]).toBe('queued one\n\n---\n\nqueued two')
+    expect(vi.mocked(sendKeeperThreadMessage).mock.calls[1]?.[2]).toEqual(expect.objectContaining({
+      clientActionIds: ['queued-click-1', 'queued-click-2'],
+    }))
+  })
+
+  it('continues draining messages queued while a queue batch is in flight', async () => {
+    vi.mocked(sendKeeperThreadMessage).mockImplementation(async (_keeperName, message) => {
+      if (message === 'queued one') {
+        enqueueInput('sangsu', 'queued during drain', undefined, 'queued-click-3')
+      }
+    })
+    enqueueInput('sangsu', 'queued one', undefined, 'queued-click-1')
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'trigger drain' } })
+    await Promise.resolve()
+
+    const sendButton = container.querySelector('.send') as HTMLButtonElement
+    fireEvent.click(sendButton)
+
+    await waitFor(() => expect(sendKeeperThreadMessage).toHaveBeenCalledTimes(3))
+    expect(vi.mocked(sendKeeperThreadMessage).mock.calls[1]?.[1]).toBe('queued one')
+    expect(vi.mocked(sendKeeperThreadMessage).mock.calls[2]?.[1]).toBe('queued during drain')
+    expect(vi.mocked(sendKeeperThreadMessage).mock.calls[2]?.[2]).toEqual(expect.objectContaining({
+      clientActionIds: ['queued-click-3'],
+    }))
+    expect(getQueueLength('sangsu')).toBe(0)
   })
 
   it('forwards the message-level turn inspector action to the transcript', async () => {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -522,23 +522,30 @@ export function KeeperConversationPanel({
   }
 
   const drainQueue = async () => {
-    const queued = getQueuedMessages(keeperName)
-    if (queued.length === 0) return
-    clearInputQueue(keeperName)
-    bumpQueue()
+    for (;;) {
+      const queued = getQueuedMessages(keeperName)
+      if (queued.length === 0) return
+      clearInputQueue(keeperName)
+      bumpQueue()
 
-    const batchedContent = queued.map(q => q.content.trim()).filter(Boolean).join('\n\n---\n\n')
-    const batchedAttachments = queued.flatMap(q => q.attachments ?? [])
-    if (!batchedContent && batchedAttachments.length === 0) return
+      const batchedContent = queued.map(q => q.content.trim()).filter(Boolean).join('\n\n---\n\n')
+      const batchedAttachments = queued.flatMap(q => q.attachments ?? [])
+      const batchedClientActionIds = queued
+        .map(q => q.clientActionId?.trim())
+        .filter((clientActionId): clientActionId is string => Boolean(clientActionId))
+      if (!batchedContent && batchedAttachments.length === 0) continue
 
-    try {
-      await sendKeeperThreadMessage(keeperName, batchedContent, {
-        attachments: batchedAttachments.length > 0 ? batchedAttachments : undefined,
-      })
-    } catch (err) {
-      if (isAbortError(err)) return
-      const message = err instanceof Error ? err.message : `${keeperName} 메시지 전송 실패`
-      showToast(message, 'error')
+      try {
+        await sendKeeperThreadMessage(keeperName, batchedContent, {
+          attachments: batchedAttachments.length > 0 ? batchedAttachments : undefined,
+          clientActionIds: batchedClientActionIds,
+        })
+      } catch (err) {
+        if (isAbortError(err)) return
+        const message = err instanceof Error ? err.message : `${keeperName} 메시지 전송 실패`
+        showToast(message, 'error')
+        return
+      }
     }
   }
 

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -27,6 +27,7 @@ import {
   keeperStreamStartedAt,
   keeperStreamLastEventAt,
   keeperThreads,
+  isKeeperThreadMessageSendInFlight,
   probeKeeperRuntime,
   recoverKeeperRuntime,
   resumePendingKeeperChatRequests,
@@ -38,6 +39,7 @@ import {
   clearInputQueue,
   getQueueLength,
   getQueuedMessages,
+  hasQueuedInputClientAction,
   updateQueuedMessage,
   removeQueuedMessage,
   type QueuedMessage,
@@ -550,7 +552,18 @@ export function KeeperConversationPanel({
     const attachments = blocksToAttachments(blocks)
     setDraft('')
     if (keeperSending.value[keeperName]) {
-      enqueueInput(keeperName, prompt, attachments.length > 0 ? attachments : undefined)
+      if (
+        isKeeperThreadMessageSendInFlight(keeperName, clientActionId)
+        || hasQueuedInputClientAction(keeperName, clientActionId)
+      ) {
+        return
+      }
+      enqueueInput(
+        keeperName,
+        prompt,
+        attachments.length > 0 ? attachments : undefined,
+        clientActionId,
+      )
       bumpQueue()
       return
     }

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -12,7 +12,6 @@ import type {
   KeeperConversationAttachment,
   KeeperConversationEntry,
   KeeperDiagnostic,
-  KeeperUserInputBlock,
 } from '../types'
 import {
   abortKeeperThreadMessage,
@@ -43,7 +42,7 @@ import {
   removeQueuedMessage,
   type QueuedMessage,
 } from '../keeper-chat-store'
-import { AttachDraftChip, ChatComposer, ChatTranscript, STREAM_STALL_THRESHOLD_S, formatAttachmentSize } from './chat/primitives'
+import { AttachDraftChip, ChatComposer, ChatTranscript, STREAM_STALL_THRESHOLD_S, formatAttachmentSize, type ChatComposerSendPayload } from './chat/primitives'
 import { showToast } from './common/toast'
 import { TextInput } from './common/input'
 import { shellAuthSummary } from '../store'
@@ -541,7 +540,7 @@ export function KeeperConversationPanel({
     }
   }
 
-  const submit = async ({ blocks, userBlocks }: { blocks: ChatBlock[]; userBlocks: KeeperUserInputBlock[] }) => {
+  const submit = async ({ blocks, userBlocks, clientActionId }: ChatComposerSendPayload) => {
     const prompt = draft.trim()
     if (chatAccess.blocked) {
       showToast(chatAccess.message, 'error')
@@ -556,7 +555,7 @@ export function KeeperConversationPanel({
       return
     }
     try {
-      await sendKeeperThreadMessage(keeperName, prompt, { attachments, userBlocks })
+      await sendKeeperThreadMessage(keeperName, prompt, { attachments, clientActionId, userBlocks })
     } catch (err) {
       if (isAbortError(err)) return
       const message = err instanceof Error ? err.message : `${keeperName} 메시지 전송 실패`
@@ -687,7 +686,7 @@ export function KeeperConversationPanel({
               queueEnabled=${true}
               queueCount=${queueCount}
               onDraftChange=${setDraft}
-              onSend=${(payload: { blocks: ChatBlock[]; userBlocks: KeeperUserInputBlock[] }) => { void submit(payload) }}
+              onSend=${(payload: ChatComposerSendPayload) => { void submit(payload) }}
               onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
               layout="primary"
             />
@@ -802,7 +801,7 @@ export function KeeperConversationPanel({
             queueEnabled=${true}
             queueCount=${queueCount}
             onDraftChange=${setDraft}
-            onSend=${(payload: { blocks: ChatBlock[]; userBlocks: KeeperUserInputBlock[] }) => { void submit(payload) }}
+            onSend=${(payload: ChatComposerSendPayload) => { void submit(payload) }}
             onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
             layout="primary"
           />
@@ -915,7 +914,7 @@ export function KeeperConversationPanel({
             queueEnabled=${true}
             queueCount=${queueCount}
             onDraftChange=${setDraft}
-            onSend=${(payload: { blocks: ChatBlock[]; userBlocks: KeeperUserInputBlock[] }) => { void submit(payload) }}
+            onSend=${(payload: ChatComposerSendPayload) => { void submit(payload) }}
             onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
           />
         </div>

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -60,6 +60,7 @@ import {
   keeperThreads,
 } from './keeper-state'
 import {
+  _resetKeeperThreadMessageSendGuardsForTests,
   _resetChatHydrationForTests,
   dispatchKeeperInterjectAction,
   hydrateKeeperChatHistory,
@@ -201,6 +202,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     keeperThreads.value = {}
     keeperActionErrors.value = {}
     _clearPendingKeeperChatRequestsForTests()
+    _resetKeeperThreadMessageSendGuardsForTests()
     _resetLiveSendRequestOwnersForTests()
     streamKeeperMessage.mockReset()
     fetchKeeperChatHistory.mockReset()
@@ -227,6 +229,29 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       return { terminal }
     }
   }
+
+  it('ignores a direct duplicate send while the keeper stream is already active', async () => {
+    let resolveStream: (outcome: { terminal: boolean }) => void = () => {}
+    streamKeeperMessage
+      .mockImplementationOnce(async () => new Promise<{ terminal: boolean }>(resolve => {
+        resolveStream = resolve
+      }))
+      .mockResolvedValueOnce({ terminal: true })
+
+    const firstSend = sendKeeperThreadMessage('echo', '진행 상황?')
+    await Promise.resolve()
+
+    await sendKeeperThreadMessage('echo', '진행 상황?')
+
+    expect(streamKeeperMessage).toHaveBeenCalledTimes(1)
+    expect((keeperThreads.value.echo ?? []).filter(entry => entry.role === 'assistant')).toHaveLength(1)
+
+    resolveStream({ terminal: true })
+    await firstSend
+
+    await sendKeeperThreadMessage('echo', '다음 질문')
+    expect(streamKeeperMessage).toHaveBeenCalledTimes(2)
+  })
 
   it('does not duplicate the pending assistant when a live send is still streaming and the panel remounts', async () => {
     // A send whose SSE stream stays open (reply pending). The mock fires the

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -67,6 +67,7 @@ import {
   dispatchKeeperInterjectAction,
   hydrateKeeperChatHistory,
   hydrateKeeperStatus,
+  isKeeperThreadMessageSendInFlight,
   loadFullKeeperHistory,
   noteKeeperChatAppended,
   probeKeeperRuntime,
@@ -289,6 +290,33 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       clientActionId: 'send-button-click-2',
     })
     expect(streamKeeperMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps queued client action ids guarded while a batched queue send is in flight', async () => {
+    let resolveStream: (outcome: { terminal: boolean }) => void = () => {}
+    streamKeeperMessage.mockImplementationOnce(async () => new Promise<{ terminal: boolean }>(resolve => {
+      resolveStream = resolve
+    }))
+
+    const firstSend = sendKeeperThreadMessage('echo', 'queued drafts', {
+      clientActionIds: ['queue-click-1', 'queue-click-2'],
+    })
+    await Promise.resolve()
+
+    expect(isKeeperThreadMessageSendInFlight('echo', 'queue-click-1')).toBe(true)
+    expect(isKeeperThreadMessageSendInFlight('echo', 'queue-click-2')).toBe(true)
+
+    await sendKeeperThreadMessage('echo', 'queued drafts', {
+      clientActionId: 'queue-click-1',
+    })
+
+    expect(streamKeeperMessage).toHaveBeenCalledTimes(1)
+
+    resolveStream({ terminal: true })
+    await firstSend
+
+    expect(isKeeperThreadMessageSendInFlight('echo', 'queue-click-1')).toBe(false)
+    expect(isKeeperThreadMessageSendInFlight('echo', 'queue-click-2')).toBe(false)
   })
 
   it('does not suppress the same text when the attachment payload differs', async () => {

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -51,11 +51,13 @@ vi.mock('./store', () => ({ invalidateDashboardCache, refreshDashboard }))
 
 import {
   _resetLiveSendRequestOwnersForTests,
+  activeStreamEntryId,
   activeKeeperName,
   keeperActionErrors,
   keeperHydrating,
   keeperProbing,
   keeperRecovering,
+  keeperSending,
   keeperStatusDetails,
   keeperThreads,
 } from './keeper-state'
@@ -230,7 +232,37 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     }
   }
 
-  it('ignores a direct duplicate send while the keeper stream is already active', async () => {
+  function abortError(): Error {
+    const err = new Error('Aborted')
+    err.name = 'AbortError'
+    return err
+  }
+
+  it('does not content-deduplicate repeated same-text sends', async () => {
+    streamKeeperMessage
+      .mockImplementationOnce(async (
+        _name: string,
+        _message: string,
+        opts: { signal?: AbortSignal },
+      ) => new Promise<{ terminal: boolean }>((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () => { reject(abortError()) }, { once: true })
+      }))
+      .mockResolvedValueOnce({ terminal: true })
+
+    const firstSend = sendKeeperThreadMessage('echo', '진행 상황?').catch(err => err)
+    await Promise.resolve()
+
+    await sendKeeperThreadMessage('echo', '진행 상황?')
+
+    expect(streamKeeperMessage).toHaveBeenCalledTimes(2)
+    expect((keeperThreads.value.echo ?? []).filter(entry => entry.role === 'user')).toHaveLength(2)
+    expect((keeperThreads.value.echo ?? []).filter(entry => entry.role === 'assistant')).toHaveLength(2)
+    const firstError = await firstSend
+    expect(firstError).toBeInstanceOf(Error)
+    expect(firstError.name).toBe('AbortError')
+  })
+
+  it('dedupes repeated firing of the same client action id while in flight', async () => {
     let resolveStream: (outcome: { terminal: boolean }) => void = () => {}
     streamKeeperMessage
       .mockImplementationOnce(async () => new Promise<{ terminal: boolean }>(resolve => {
@@ -238,10 +270,14 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       }))
       .mockResolvedValueOnce({ terminal: true })
 
-    const firstSend = sendKeeperThreadMessage('echo', '진행 상황?')
+    const firstSend = sendKeeperThreadMessage('echo', '진행 상황?', {
+      clientActionId: 'send-button-click-1',
+    })
     await Promise.resolve()
 
-    await sendKeeperThreadMessage('echo', '진행 상황?')
+    await sendKeeperThreadMessage('echo', '진행 상황?', {
+      clientActionId: 'send-button-click-1',
+    })
 
     expect(streamKeeperMessage).toHaveBeenCalledTimes(1)
     expect((keeperThreads.value.echo ?? []).filter(entry => entry.role === 'assistant')).toHaveLength(1)
@@ -249,8 +285,90 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     resolveStream({ terminal: true })
     await firstSend
 
-    await sendKeeperThreadMessage('echo', '다음 질문')
+    await sendKeeperThreadMessage('echo', '진행 상황?', {
+      clientActionId: 'send-button-click-2',
+    })
     expect(streamKeeperMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not suppress the same text when the attachment payload differs', async () => {
+    const firstAttachment: KeeperConversationAttachment = {
+      id: 'att-first',
+      type: 'image',
+      name: 'first.png',
+      size: 128,
+      mimeType: 'image/png',
+      data: 'data:image/png;base64,first',
+    }
+    const secondAttachment: KeeperConversationAttachment = {
+      id: 'att-second',
+      type: 'image',
+      name: 'second.png',
+      size: 256,
+      mimeType: 'image/png',
+      data: 'data:image/png;base64,second',
+    }
+    streamKeeperMessage
+      .mockImplementationOnce(async (
+        _name: string,
+        _message: string,
+        opts: { signal?: AbortSignal },
+      ) => new Promise<{ terminal: boolean }>((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () => { reject(abortError()) }, { once: true })
+      }))
+      .mockResolvedValueOnce({ terminal: true })
+
+    const firstSend = sendKeeperThreadMessage('echo', 'describe this', {
+      attachments: [firstAttachment],
+    }).catch(err => err)
+    await Promise.resolve()
+
+    await sendKeeperThreadMessage('echo', 'describe this', {
+      attachments: [secondAttachment],
+    })
+
+    expect(streamKeeperMessage).toHaveBeenCalledTimes(2)
+    expect(streamKeeperMessage.mock.calls[1]?.[2]).toEqual(expect.objectContaining({
+      attachments: [secondAttachment],
+    }))
+    const firstError = await firstSend
+    expect(firstError).toBeInstanceOf(Error)
+    expect(firstError.name).toBe('AbortError')
+  })
+
+  it('keeps a replacement stream active when the superseded send aborts later', async () => {
+    let resolveSecond: (outcome: { terminal: boolean }) => void = () => {}
+    streamKeeperMessage
+      .mockImplementationOnce(async (
+        _name: string,
+        _message: string,
+        opts: { signal?: AbortSignal },
+      ) => new Promise<{ terminal: boolean }>((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () => { reject(abortError()) }, { once: true })
+      }))
+      .mockImplementationOnce(async () => new Promise<{ terminal: boolean }>(resolve => {
+        resolveSecond = resolve
+      }))
+
+    const firstSend = sendKeeperThreadMessage('echo', 'first').catch(err => err)
+    await Promise.resolve()
+
+    const secondSend = sendKeeperThreadMessage('echo', 'second')
+    await Promise.resolve()
+
+    const firstError = await firstSend
+    expect(firstError).toBeInstanceOf(Error)
+    expect(firstError.name).toBe('AbortError')
+    expect(streamKeeperMessage).toHaveBeenCalledTimes(2)
+    expect(keeperSending.value.echo).toBe(true)
+    const activeAssistant = (keeperThreads.value.echo ?? [])
+      .find(entry => entry.role === 'assistant' && entry.delivery === 'sending')
+    expect(activeStreamEntryId('echo')).toBe(activeAssistant?.id)
+
+    resolveSecond({ terminal: true })
+    await secondSend
+    expect(keeperSending.value.echo).toBe(false)
+    expect(activeStreamEntryId('echo')).toBeNull()
   })
 
   it('does not duplicate the pending assistant when a live send is still streaming and the panel remounts', async () => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -333,7 +333,16 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
 let localIdCounter = 0
 
 const resumingKeeperChatRequests = new Set<string>()
+const sendingKeeperThreadMessages = new Set<string>()
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
+
+function keeperThreadMessageSendKey(keeperName: string, message: string): string {
+  return `${keeperName}\u0000${message}`
+}
+
+export function _resetKeeperThreadMessageSendGuardsForTests(): void {
+  sendingKeeperThreadMessages.clear()
+}
 
 async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest): Promise<void> {
   // A live in-session send stream still owns this request (e.g. the panel
@@ -572,6 +581,9 @@ export async function sendKeeperThreadMessage(
       : deriveUserBlocks(prompt, attachments)
   const message = prompt.trim() || fallbackMessageForUserBlocks(userBlocks ?? [])
   if (!keeperName || !message) return
+  const sendKey = keeperThreadMessageSendKey(keeperName, message)
+  if (sendingKeeperThreadMessages.has(sendKey)) return
+  sendingKeeperThreadMessages.add(sendKey)
   abortKeeperThreadMessage(keeperName)
   const localId = `local-${++localIdCounter}-${Date.now()}`
   const assistantId = `reply-${++localIdCounter}-${Date.now()}`
@@ -759,6 +771,7 @@ export async function sendKeeperThreadMessage(
     // the non-terminal handoff above already released, so this is a no-op
     // there; Map.delete of an absent key is harmless.
     if (requestId) releaseLiveSendRequest(requestId)
+    sendingKeeperThreadMessages.delete(sendKey)
     clearActiveStream(keeperName)
     setRecordValue(keeperSending, keeperName, false)
     setRecordValue(keeperStreamStartedAt, keeperName, null)

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -345,6 +345,18 @@ function keeperThreadMessageSendKey(
   return actionId ? `${keeperName}\u0000${actionId}` : null
 }
 
+function keeperThreadMessageSendKeys(
+  keeperName: string,
+  clientActionIds: readonly (string | undefined)[],
+): string[] {
+  const keys = new Set<string>()
+  for (const clientActionId of clientActionIds) {
+    const key = keeperThreadMessageSendKey(keeperName, clientActionId)
+    if (key) keys.add(key)
+  }
+  return Array.from(keys)
+}
+
 export function _resetKeeperThreadMessageSendGuardsForTests(): void {
   sendingKeeperThreadMessages.clear()
 }
@@ -583,6 +595,7 @@ export async function sendKeeperThreadMessage(
   options: {
     attachments?: KeeperConversationAttachment[]
     clientActionId?: string
+    clientActionIds?: readonly string[]
     userBlocks?: KeeperUserInputBlock[]
   } = {},
 ): Promise<void> {
@@ -595,9 +608,12 @@ export async function sendKeeperThreadMessage(
       : deriveUserBlocks(prompt, attachments)
   const message = prompt.trim() || fallbackMessageForUserBlocks(userBlocks ?? [])
   if (!keeperName || !message) return
-  const sendKey = keeperThreadMessageSendKey(keeperName, options.clientActionId)
-  if (sendKey && sendingKeeperThreadMessages.has(sendKey)) return
-  if (sendKey) sendingKeeperThreadMessages.add(sendKey)
+  const sendKeys = keeperThreadMessageSendKeys(keeperName, [
+    options.clientActionId,
+    ...(options.clientActionIds ?? []),
+  ])
+  if (sendKeys.some(key => sendingKeeperThreadMessages.has(key))) return
+  sendKeys.forEach(key => sendingKeeperThreadMessages.add(key))
   abortKeeperThreadMessage(keeperName)
   const localId = `local-${++localIdCounter}-${Date.now()}`
   const assistantId = `reply-${++localIdCounter}-${Date.now()}`
@@ -785,7 +801,7 @@ export async function sendKeeperThreadMessage(
     // the non-terminal handoff above already released, so this is a no-op
     // there; Map.delete of an absent key is harmless.
     if (requestId) releaseLiveSendRequest(requestId)
-    if (sendKey) sendingKeeperThreadMessages.delete(sendKey)
+    sendKeys.forEach(key => sendingKeeperThreadMessages.delete(key))
     if (activeStreamEntryId(keeperName) === assistantId) {
       clearActiveStream(keeperName)
       setRecordValue(keeperSending, keeperName, false)

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -33,6 +33,7 @@ import {
   keeperStreamStartedAt,
   keeperStreamLastEventAt,
   keeperThreads,
+  activeStreamEntryId,
   appendThreadEntry,
   attachKeeperAudioClip,
   chatHistoryEntriesFromRest,
@@ -336,8 +337,12 @@ const resumingKeeperChatRequests = new Set<string>()
 const sendingKeeperThreadMessages = new Set<string>()
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
 
-function keeperThreadMessageSendKey(keeperName: string, message: string): string {
-  return `${keeperName}\u0000${message}`
+function keeperThreadMessageSendKey(
+  keeperName: string,
+  clientActionId: string | undefined,
+): string | null {
+  const actionId = clientActionId?.trim() ?? ''
+  return actionId ? `${keeperName}\u0000${actionId}` : null
 }
 
 export function _resetKeeperThreadMessageSendGuardsForTests(): void {
@@ -569,6 +574,7 @@ export async function sendKeeperThreadMessage(
   prompt: string,
   options: {
     attachments?: KeeperConversationAttachment[]
+    clientActionId?: string
     userBlocks?: KeeperUserInputBlock[]
   } = {},
 ): Promise<void> {
@@ -581,9 +587,9 @@ export async function sendKeeperThreadMessage(
       : deriveUserBlocks(prompt, attachments)
   const message = prompt.trim() || fallbackMessageForUserBlocks(userBlocks ?? [])
   if (!keeperName || !message) return
-  const sendKey = keeperThreadMessageSendKey(keeperName, message)
-  if (sendingKeeperThreadMessages.has(sendKey)) return
-  sendingKeeperThreadMessages.add(sendKey)
+  const sendKey = keeperThreadMessageSendKey(keeperName, options.clientActionId)
+  if (sendKey && sendingKeeperThreadMessages.has(sendKey)) return
+  if (sendKey) sendingKeeperThreadMessages.add(sendKey)
   abortKeeperThreadMessage(keeperName)
   const localId = `local-${++localIdCounter}-${Date.now()}`
   const assistantId = `reply-${++localIdCounter}-${Date.now()}`
@@ -771,11 +777,13 @@ export async function sendKeeperThreadMessage(
     // the non-terminal handoff above already released, so this is a no-op
     // there; Map.delete of an absent key is harmless.
     if (requestId) releaseLiveSendRequest(requestId)
-    sendingKeeperThreadMessages.delete(sendKey)
-    clearActiveStream(keeperName)
-    setRecordValue(keeperSending, keeperName, false)
-    setRecordValue(keeperStreamStartedAt, keeperName, null)
-    setRecordValue(keeperStreamLastEventAt, keeperName, null)
+    if (sendKey) sendingKeeperThreadMessages.delete(sendKey)
+    if (activeStreamEntryId(keeperName) === assistantId) {
+      clearActiveStream(keeperName)
+      setRecordValue(keeperSending, keeperName, false)
+      setRecordValue(keeperStreamStartedAt, keeperName, null)
+      setRecordValue(keeperStreamLastEventAt, keeperName, null)
+    }
     // No refreshDashboardState() here: forcing a full dashboard
     // refetch after every chat message re-rendered every panel and was
     // the main "the screen keeps refreshing" complaint. Keeper status

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -349,6 +349,14 @@ export function _resetKeeperThreadMessageSendGuardsForTests(): void {
   sendingKeeperThreadMessages.clear()
 }
 
+export function isKeeperThreadMessageSendInFlight(
+  keeperName: string,
+  clientActionId: string | undefined,
+): boolean {
+  const sendKey = keeperThreadMessageSendKey(keeperName, clientActionId)
+  return sendKey ? sendingKeeperThreadMessages.has(sendKey) : false
+}
+
 async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest): Promise<void> {
   // A live in-session send stream still owns this request (e.g. the panel
   // remounted on an SPA route change while the reply was pending). Defer to

--- a/dashboard/src/keeper-chat-store.test.ts
+++ b/dashboard/src/keeper-chat-store.test.ts
@@ -5,8 +5,10 @@ import {
   dequeueInput,
   markInputSent,
   clearInputQueue,
+  hasQueuedInputClientAction,
   getQueueLength,
   getQueueTotal,
+  updateQueuedMessage,
 } from './keeper-chat-store'
 
 describe('keeper-chat-store input queue', () => {
@@ -21,6 +23,18 @@ describe('keeper-chat-store input queue', () => {
   it('enqueues a message while streaming', () => {
     enqueueInput('keeper-q', 'hello queue')
     expect(getQueueLength('keeper-q')).toBe(1)
+  })
+
+  it('dedupes queued messages by client action id, not content', () => {
+    const first = enqueueInput('keeper-q', 'same text', undefined, 'click-1')
+    const duplicate = enqueueInput('keeper-q', 'same text', undefined, 'click-1')
+    const repeatedContent = enqueueInput('keeper-q', 'same text', undefined, 'click-2')
+
+    expect(duplicate).toBe(first)
+    expect(repeatedContent).not.toBe(first)
+    expect(getQueueLength('keeper-q')).toBe(2)
+    expect(hasQueuedInputClientAction('keeper-q', 'click-1')).toBe(true)
+    expect(hasQueuedInputClientAction('keeper-q', 'missing')).toBe(false)
   })
 
   it('dequeues messages in FIFO order', () => {
@@ -96,5 +110,15 @@ describe('keeper-chat-store input queue', () => {
     enqueueInput('keeper-q', 'plain')
     const msg = dequeueInput('keeper-q')
     expect(msg!.attachments).toBeUndefined()
+  })
+
+  it('clears the client action id when a queued message is edited', () => {
+    const msg = enqueueInput('keeper-q', 'original', undefined, 'click-1')
+
+    updateQueuedMessage('keeper-q', msg.id, { content: 'edited' })
+
+    expect(hasQueuedInputClientAction('keeper-q', 'click-1')).toBe(false)
+    enqueueInput('keeper-q', 'original', undefined, 'click-1')
+    expect(getQueueLength('keeper-q')).toBe(2)
   })
 })

--- a/dashboard/src/keeper-chat-store.ts
+++ b/dashboard/src/keeper-chat-store.ts
@@ -16,6 +16,7 @@ export interface QueuedMessage {
   timestamp: number
   sent: boolean
   attachments?: KeeperConversationAttachment[]
+  clientActionId?: string
 }
 
 export interface InputQueue {
@@ -40,17 +41,34 @@ export function enqueueInput(
   keeperName: string,
   content: string,
   attachments?: KeeperConversationAttachment[],
+  clientActionId?: string,
 ): QueuedMessage {
   const q = _ensureQueue(keeperName)
+  const actionId = clientActionId?.trim()
+  if (actionId) {
+    const existing = q.items.find(item => item.clientActionId === actionId)
+    if (existing) return existing
+  }
   const msg: QueuedMessage = {
     id: `${keeperName}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     content,
     timestamp: Date.now(),
     sent: false,
     ...(attachments && attachments.length > 0 ? { attachments } : {}),
+    ...(actionId ? { clientActionId: actionId } : {}),
   }
   q.items.push(msg)
   return msg
+}
+
+export function hasQueuedInputClientAction(
+  keeperName: string,
+  clientActionId: string | undefined,
+): boolean {
+  const actionId = clientActionId?.trim()
+  if (!actionId) return false
+  const q = _queues.get(keeperName)
+  return q ? q.items.some(item => item.clientActionId === actionId) : false
 }
 
 /** Return all queued items for a keeper (newest last). */
@@ -69,8 +87,18 @@ export function updateQueuedMessage(
   if (!q) return null
   const item = q.items.find(i => i.id === id)
   if (!item) return null
+  let changed = false
   if (typeof updates.content === 'string') item.content = updates.content
-  if (updates.attachments) item.attachments = updates.attachments
+  if (typeof updates.content === 'string') changed = true
+  if ('attachments' in updates) {
+    if (updates.attachments && updates.attachments.length > 0) {
+      item.attachments = updates.attachments
+    } else {
+      delete item.attachments
+    }
+    changed = true
+  }
+  if (changed) delete item.clientActionId
   return item
 }
 

--- a/dashboard/src/keeper-runtime.ts
+++ b/dashboard/src/keeper-runtime.ts
@@ -24,6 +24,7 @@ export {
   noteKeeperChatAppended,
   resumePendingKeeperChatRequests,
   sendKeeperThreadMessage,
+  isKeeperThreadMessageSendInFlight,
   probeKeeperRuntime,
   recoverKeeperRuntime,
 } from './keeper-actions'

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -67,6 +67,65 @@ let substring_between source ~start_marker ~end_marker =
       | None -> Alcotest.failf "missing marker %S" end_marker
       | Some end_pos -> String.sub source body_start (end_pos - body_start))
 
+let find_substring_from source needle start =
+  let source_len = String.length source in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if needle_len = 0 then Some start
+    else if i + needle_len > source_len then None
+    else if String.equal (String.sub source i needle_len) needle then Some i
+    else loop (i + 1)
+  in
+  loop start
+
+let skip_spaces source i =
+  let len = String.length source in
+  let rec loop pos =
+    if pos >= len then pos
+    else
+      match source.[pos] with
+      | ' ' | '\n' | '\r' | '\t' -> loop (pos + 1)
+      | _ -> pos
+  in
+  loop i
+
+let matching_paren source open_pos =
+  let len = String.length source in
+  if open_pos >= len || not (Char.equal source.[open_pos] '(') then None
+  else
+    let rec loop pos depth =
+      if pos >= len then None
+      else
+        match source.[pos] with
+        | '(' -> loop (pos + 1) (depth + 1)
+        | ')' ->
+            let next_depth = depth - 1 in
+            if next_depth = 0 then Some pos else loop (pos + 1) next_depth
+        | _ -> loop (pos + 1) depth
+    in
+    loop open_pos 0
+
+let function_call_spans source marker =
+  let marker_len = String.length marker in
+  let rec loop from acc =
+    match find_substring_from source marker from with
+    | None -> List.rev acc
+    | Some marker_pos -> (
+        let args_start = skip_spaces source (marker_pos + marker_len) in
+        if args_start >= String.length source
+           || not (Char.equal source.[args_start] '(')
+        then loop (marker_pos + marker_len) acc
+        else
+          match matching_paren source args_start with
+          | None -> loop (marker_pos + marker_len) acc
+          | Some args_end ->
+              let span =
+                String.sub source marker_pos (args_end - marker_pos + 1)
+              in
+              loop (args_end + 1) (span :: acc))
+  in
+  loop 0 []
+
 (* ====== Session Registry ====== *)
 
 let test_initial_session_count () =
@@ -107,7 +166,15 @@ let test_session_close_wire_calls_stay_outside_registry_lock () =
   Alcotest.(check bool)
     "wire close helper does not acquire sessions_mutex"
     false
-    (contains_substring close_helper "with_sessions_rw")
+    (contains_substring close_helper "with_sessions_rw");
+  List.iteri
+    (fun i span ->
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "registry lock span %d does not invoke detached wire close" i)
+        false
+        (contains_substring span "close_detached_session_wsd"))
+    (function_call_spans source "with_sessions_rw")
 
 (* ====== SHA1 (httpun-ws handshake) ====== *)
 


### PR DESCRIPTION
## Summary
- Strengthen the WebSocket close-lock invariant test so detached wire-close calls cannot be moved back under `with_sessions_rw` without failing the ratchet.
- Key keeper direct-send dedupe by a UI `clientActionId`, and have the composer mint a deterministic payload fingerprint so repeated firing of the same submit action is ignored without content-deduping legitimate separate sends.
- Include an attachment data hash in the action fingerprint so same-length, same-metadata attachments do not collapse into the same submit action.
- Close the adversarial queue-path gaps: repeated firing of an already active or already queued client action is ignored, queued action ids remain guarded while batched queue sends are in flight, and the queue keeps draining if new messages arrive during a batch.
- Guard stream cleanup so a superseded send cannot clear the replacement stream controller/sending state.
- Add dashboard regression coverage for same-action dedupe, same-text legitimate sends, attachment sends, active stream cleanup, queued duplicate suppression, attachment-data fingerprinting, batched queued action guards, and recursive queue drain.

## Verification
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/chat/primitives.test.ts src/components/keeper-shared.test.ts src/keeper-chat-store.test.ts src/keeper-actions.test.ts` (161 tests)
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check`
- `python3 scripts/check_test_coverage.py`
- Earlier before the queue-path follow-up: `opam exec -- ocamlformat --check test/test_ws_transport.ml`

## Not run / blocked
- `scripts/dune-local.sh build test/test_ws_transport.exe`: attempted, but local Dune currently fails before this target on unrelated untouched OCaml compile errors in the base tree (observed in `lib/server/server_discord_in_process_gateway.ml` and `lib/gate_keeper_backend.ml`). CI is the build authority for this PR.
