### PR TITLE
fix(build): restore main build broken by #21714 and #21721

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -128,9 +128,13 @@ let persist_connector_assistant_reply ~base_dir ~keeper_name ~source
     Keeper_chat_broadcast.chat_appended ~keeper_name ~source ~content ()
   end
 
+(* Trailing [()] keeps [?on_text_snapshot] erasable (warning 16): the wrappers
+   below either pass it ([dispatch_with_text_snapshot]) or omit it so it defaults
+   to [None] ([dispatch]). Without the unit the optional leaks into [dispatch]'s
+   inferred type and breaks the .mli signature. Do not drop the [()]. *)
 let dispatch_core ?on_text_snapshot ~sw ~clock ~proc_mgr ~net ~config
     ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
-    ~keeper_name ~metadata ~content =
+    ~keeper_name ~metadata ~content () =
   let keeper_name = String.trim keeper_name in
   let redaction =
     Keeper_secret_redaction.snapshot
@@ -271,11 +275,11 @@ let dispatch_core ?on_text_snapshot ~sw ~clock ~proc_mgr ~net ~config
 let dispatch ~sw ~clock ~proc_mgr ~net ~config ~channel ~channel_user_id
     ~channel_user_name ~channel_workspace_id ~keeper_name ~metadata ~content =
   dispatch_core ~sw ~clock ~proc_mgr ~net ~config ~channel ~channel_user_id
-    ~channel_user_name ~channel_workspace_id ~keeper_name ~metadata ~content
+    ~channel_user_name ~channel_workspace_id ~keeper_name ~metadata ~content ()
 
 let dispatch_with_text_snapshot ~on_text_snapshot ~sw ~clock ~proc_mgr ~net
     ~config ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
     ~keeper_name ~metadata ~content =
   dispatch_core ~on_text_snapshot ~sw ~clock ~proc_mgr ~net ~config ~channel
     ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
-    ~metadata ~content
+    ~metadata ~content ()

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -507,7 +507,7 @@ let handle_message_create ~dispatch
               Discord_observability.record_inbound_dispatch
                 Discord_observability.Reply_send_error;
               Discord_observability.record_reply
-                Discord_observability.Reply_send_failed)
+                Discord_observability.Reply_send_failed))
 
 let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
   match ev with

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -10,7 +10,6 @@ module Prompt_names = Keeper_prompt_names
 module Recall = Masc.Keeper_memory_os_recall
 module Reconcile = Masc.Keeper_memory_os_reconcile
 module Consolidator = Masc.Keeper_memory_os_consolidator
-module Reconcile = Masc.Keeper_memory_os_reconcile
 
 let contains substring s =
   let sub_len = String.length substring in


### PR DESCRIPTION
## 목표

main 빌드 RED 복구. 최근 머지 후 CI `Build and Test`/`Lint`가 fast-fail하면서 뒤의 compile break가 가려졌습니다. 적대적으로 끝까지 추적하면 현재 main에는 세 가지 compile-shape 문제가 있습니다.

## Break 1 — `lib/gate_keeper_backend.ml`

`dispatch_core`가 leading `?on_text_snapshot` 옵셔널을 받고 마지막 인자가 labeled `~content`로 끝나서 optional이 erase될 수 없습니다. 그 결과 `dispatch`의 inferred type에 `?on_text_snapshot`이 새어 `.mli`의 `dispatch` 선언과 불일치합니다.

수정: `dispatch_core`에 trailing `()` positional을 추가하고 내부 호출처 2곳에서 `()`를 전달합니다. `.mli` 무변경, 런타임 동작 변화 없음.

## Break 2 — `lib/server/server_discord_in_process_gateway.ml`

`Stream_failed` 분기 split 이후 `with_response_wait_typing_indicator` outer match를 닫는 `)`가 하나 빠져 `let on_event`에서 `Syntax error: ) expected`가 납니다.

수정: `Stream_overflow_send_failed` tail에서 누락된 outer match paren을 복원합니다.

## Break 3 — `test/test_keeper_memory_os.ml`

`module Reconcile = Masc.Keeper_memory_os_reconcile`가 top-level에 두 번 선언되어 `test_rfc0259_reconcile` target build에서 `Multiple definition of the module name Reconcile`로 실패합니다.

수정: 중복 alias 한 줄을 제거합니다.

## 검증

- `opam exec -- ocamlformat --check lib/gate_keeper_backend.ml lib/server/server_discord_in_process_gateway.ml test/test_keeper_memory_os.ml`
- `git diff --check origin/main...HEAD`
- `rg "module Reconcile" test/test_keeper_memory_os.ml` → single occurrence

Full Dune/build는 owner 지시에 따라 로컬에서는 돌리지 않았습니다. CI `Build and Test`가 이 PR의 authoritative gate입니다.

## 경계 / RFC

순수 compile-shape 복구입니다. 공개 `.mli` 변경, telemetry/counter, cap/cooldown, 문자열 classifier, runtime behavior 변경 없음. RFC 불필요.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
