### PR TITLE
fix(schedule): support cron recurrence

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1771,6 +1771,7 @@ export interface DashboardScheduledAutomationRequest {
     hour?: number
     minute?: number
     second?: number
+    expression?: string
     timezone?: string
   }
   recurrence_kind?: string

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -64,6 +64,10 @@ function recurrenceLabel(request: DashboardScheduledAutomationRequest): string {
       return `${hh}:${mm}:${ss}${timezone ? ` ${timezone}` : ''}`
     }
   }
+  if (kind === 'cron' && typeof recurrence?.expression === 'string' && recurrence.expression.trim()) {
+    const timezone = recurrence.timezone
+    return `cron ${recurrence.expression}${timezone ? ` ${timezone}` : ''}`
+  }
   return enumLabel(kind)
 }
 

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -137,8 +137,8 @@ describe('Tools', () => {
             risk_class: 'workspace_write',
             approval_required: true,
             source: 'operator_request',
-            recurrence: { kind: 'daily', hour: 9, minute: 30, second: 0, timezone: 'Asia/Seoul' },
-            recurrence_kind: 'daily',
+            recurrence: { kind: 'cron', expression: '0 9 * * 1-5', timezone: 'Asia/Seoul' },
+            recurrence_kind: 'cron',
             payload_kind: 'test.reminder',
             due_at_iso: '2026-06-13T01:00:00Z',
             last_execution: {
@@ -161,7 +161,7 @@ describe('Tools', () => {
     expect(container.textContent).toContain('approve or reject')
     expect(container.textContent).toContain('sched-1')
     expect(container.textContent).toContain('workspace write')
-    expect(container.textContent).toContain('09:30:00 Asia/Seoul')
+    expect(container.textContent).toContain('cron 0 9 * * 1-5 Asia/Seoul')
     expect(container.textContent).toContain('succeeded')
     expect(container.textContent).toContain('test.reminder')
     expect(container.querySelector('.v2-lab-table')).not.toBeNull()

--- a/lib/schedule/schedule_domain.ml
+++ b/lib/schedule/schedule_domain.ml
@@ -55,6 +55,10 @@ type recurrence =
       ; second : int
       ; timezone : string
       }
+  | Cron of
+      { expression : string
+      ; timezone : string
+      }
 
 type payload =
   { kind : string
@@ -206,6 +210,7 @@ let recurrence_kind_to_string = function
   | One_shot -> "one_shot"
   | Interval _ -> "interval"
   | Daily _ -> "daily"
+  | Cron _ -> "cron"
 ;;
 
 let execution_status_to_string = function
@@ -250,7 +255,7 @@ let requires_separate_human_grant request =
 
 let is_recurring = function
   | One_shot -> false
-  | Interval _ | Daily _ -> true
+  | Interval _ | Daily _ | Cron _ -> true
 ;;
 
 let rec canonical_json = function
@@ -388,6 +393,151 @@ let validate_daily ~hour ~minute ~second ~timezone =
         "recurrence.timezone must be UTC, Asia/Seoul, KST, or a fixed offset like +09:00; DST-aware IANA zones are not supported")
 ;;
 
+type cron_field =
+  { any : bool
+  ; values : int list
+  }
+
+type cron_spec =
+  { minute : cron_field
+  ; hour : cron_field
+  ; dom : cron_field
+  ; month : cron_field
+  ; dow : cron_field
+  }
+
+let split_char sep value =
+  let rec loop acc start idx =
+    if idx >= String.length value
+    then List.rev (String.sub value start (idx - start) :: acc)
+    else if Char.equal value.[idx] sep
+    then loop (String.sub value start (idx - start) :: acc) (idx + 1) (idx + 1)
+    else loop acc start (idx + 1)
+  in
+  loop [] 0 0
+;;
+
+let int_of_token ~field token =
+  try Ok (int_of_string token) with
+  | Failure _ -> Error (Printf.sprintf "recurrence.cron.%s has non-numeric token: %s" field token)
+;;
+
+let dedupe_sorted values =
+  values
+  |> List.sort_uniq Int.compare
+;;
+
+let range_values ~field ~min_v ~max_v ~map_value start stop step =
+  if step <= 0
+  then Error (Printf.sprintf "recurrence.cron.%s step must be positive" field)
+  else if start > stop
+  then Error (Printf.sprintf "recurrence.cron.%s range start must be <= end" field)
+  else if start < min_v || stop > max_v
+  then
+    Error
+      (Printf.sprintf
+         "recurrence.cron.%s value must be in %d..%d"
+         field
+         min_v
+         max_v)
+  else (
+    let rec loop acc value =
+      if value > stop
+      then Ok (List.rev acc)
+      else
+        let* mapped = map_value value in
+        loop (mapped :: acc) (value + step)
+    in
+    loop [] start)
+;;
+
+let parse_cron_atom ~field ~min_v ~max_v ~map_value atom =
+  let atom = String.trim atom in
+  if String.equal atom ""
+  then Error (Printf.sprintf "recurrence.cron.%s contains an empty token" field)
+  else (
+    let base, step =
+      match split_char '/' atom with
+      | [ base ] -> base, 1
+      | [ base; step_s ] ->
+        (match int_of_token ~field step_s with
+         | Ok step -> base, step
+         | Error _ -> base, -1)
+      | _ -> atom, -1
+    in
+    if step <= 0
+    then Error (Printf.sprintf "recurrence.cron.%s step must be positive" field)
+    else if String.equal base "*"
+    then range_values ~field ~min_v ~max_v ~map_value min_v max_v step
+    else (
+      match split_char '-' base with
+      | [ one ] ->
+        let* value = int_of_token ~field one in
+        range_values ~field ~min_v ~max_v ~map_value value value step
+      | [ start_s; stop_s ] ->
+        let* start = int_of_token ~field start_s in
+        let* stop = int_of_token ~field stop_s in
+        range_values ~field ~min_v ~max_v ~map_value start stop step
+      | _ ->
+        Error
+          (Printf.sprintf
+             "recurrence.cron.%s token must be *, n, n-m, */s, or n-m/s: %s"
+             field
+             atom)))
+;;
+
+let parse_cron_field ~field ~min_v ~max_v ?(map_value = fun value -> Ok value) raw =
+  let raw = String.trim raw in
+  if String.equal raw ""
+  then Error (Printf.sprintf "recurrence.cron.%s must be non-empty" field)
+  else (
+    let atoms = split_char ',' raw in
+    let rec loop acc = function
+      | [] -> Ok { any = String.equal raw "*"; values = dedupe_sorted acc }
+      | atom :: rest ->
+        let* values = parse_cron_atom ~field ~min_v ~max_v ~map_value atom in
+        loop (List.rev_append values acc) rest
+    in
+    loop [] atoms)
+;;
+
+let parse_cron_expression expression =
+  let fields =
+    expression
+    |> String.trim
+    |> String.split_on_char ' '
+    |> List.filter (fun part -> not (String.equal part ""))
+  in
+  match fields with
+  | [ minute_s; hour_s; dom_s; month_s; dow_s ] ->
+    let dow_map value =
+      match value with
+      | 7 -> Ok 0
+      | value -> Ok value
+    in
+    let* minute = parse_cron_field ~field:"minute" ~min_v:0 ~max_v:59 minute_s in
+    let* hour = parse_cron_field ~field:"hour" ~min_v:0 ~max_v:23 hour_s in
+    let* dom = parse_cron_field ~field:"day_of_month" ~min_v:1 ~max_v:31 dom_s in
+    let* month = parse_cron_field ~field:"month" ~min_v:1 ~max_v:12 month_s in
+    let* dow = parse_cron_field ~field:"day_of_week" ~min_v:0 ~max_v:7 ~map_value:dow_map dow_s in
+    Ok { minute; hour; dom; month; dow }
+  | _ ->
+    Error
+      "recurrence.cron.expression must be a 5-field cron expression: minute hour day-of-month month day-of-week"
+;;
+
+let validate_cron ~expression ~timezone =
+  let* expression = nonempty "recurrence.cron.expression" expression in
+  let* timezone = nonempty "recurrence.timezone" timezone in
+  match timezone_offset_seconds timezone with
+  | None ->
+    Error
+      "recurrence.timezone must be UTC, Asia/Seoul, KST, or a fixed offset like +09:00; DST-aware IANA zones are not supported"
+  | Some _ ->
+    let* _ = parse_cron_expression expression in
+    Ok (Cron { expression; timezone })
+;;
+
 let validate_recurrence = function
   | One_shot -> Ok One_shot
   | Interval { interval_sec } ->
@@ -395,6 +545,7 @@ let validate_recurrence = function
     Ok (Interval { interval_sec })
   | Daily { hour; minute; second; timezone } ->
     validate_daily ~hour ~minute ~second ~timezone
+  | Cron { expression; timezone } -> validate_cron ~expression ~timezone
 ;;
 
 let recurrence_to_yojson = function
@@ -407,6 +558,12 @@ let recurrence_to_yojson = function
       ; "hour", `Int hour
       ; "minute", `Int minute
       ; "second", `Int second
+      ; "timezone", `String timezone
+      ]
+  | Cron { expression; timezone } ->
+    `Assoc
+      [ "kind", `String "cron"
+      ; "expression", `String expression
       ; "timezone", `String timezone
       ]
 ;;
@@ -432,6 +589,10 @@ let recurrence_of_yojson = function
        in
        let* timezone = string_field "timezone" fields in
        validate_recurrence (Daily { hour; minute; second; timezone })
+     | "cron" ->
+       let* expression = string_field "expression" fields in
+       let* timezone = string_field "timezone" fields in
+       validate_recurrence (Cron { expression; timezone })
      | other -> Error ("unknown recurrence kind: " ^ other))
   | _ -> Error "expected recurrence object"
 ;;
@@ -515,6 +676,54 @@ let next_daily_due_after ~hour ~minute ~second ~timezone ~now =
     if target_utc > now then Some target_utc else Some (target_utc +. seconds_per_day)
 ;;
 
+let field_matches field value = List.mem value field.values
+
+let cron_day_matches spec tm =
+  let dom_matches = field_matches spec.dom tm.Unix.tm_mday in
+  let dow_matches = field_matches spec.dow tm.Unix.tm_wday in
+  match spec.dom.any, spec.dow.any with
+  | true, true -> true
+  | true, false -> dow_matches
+  | false, true -> dom_matches
+  | false, false -> dom_matches || dow_matches
+;;
+
+let cron_matches spec tm =
+  field_matches spec.minute tm.Unix.tm_min
+  && field_matches spec.hour tm.Unix.tm_hour
+  && field_matches spec.month (tm.Unix.tm_mon + 1)
+  && cron_day_matches spec tm
+;;
+
+let next_cron_due_after ~expression ~timezone ~now =
+  match parse_cron_expression expression, timezone_offset_seconds timezone with
+  | Error _, _ | _, None -> None
+  | Ok spec, Some offset ->
+    let first_candidate =
+      ((floor (now /. 60.0) *. 60.0) +. 60.0) |> int_of_float
+    in
+    let offset = float_of_int offset in
+    let max_minutes = 5 * 366 * 24 * 60 in
+    let rec loop remaining candidate =
+      if remaining <= 0
+      then None
+      else (
+        let local_ts = float_of_int candidate +. offset in
+        let tm = Unix.gmtime local_ts in
+        if cron_matches spec tm
+        then Some (float_of_int candidate)
+        else loop (remaining - 1) (candidate + 60))
+    in
+    loop max_minutes first_candidate
+;;
+
+let first_due_after ~now = function
+  | One_shot | Interval _ -> None
+  | Daily { hour; minute; second; timezone } ->
+    next_daily_due_after ~hour ~minute ~second ~timezone ~now
+  | Cron { expression; timezone } -> next_cron_due_after ~expression ~timezone ~now
+;;
+
 let next_due_after ~now (request : schedule_request) =
   match request.recurrence with
   | One_shot -> None
@@ -525,6 +734,7 @@ let next_due_after ~now (request : schedule_request) =
       ~anchor:request.due_at
   | Daily { hour; minute; second; timezone } ->
     next_daily_due_after ~hour ~minute ~second ~timezone ~now
+  | Cron { expression; timezone } -> next_cron_due_after ~expression ~timezone ~now
 ;;
 
 let reschedule_after_due_signal ~now (request : schedule_request) =

--- a/lib/schedule/schedule_domain.mli
+++ b/lib/schedule/schedule_domain.mli
@@ -45,7 +45,14 @@ type schedule_source =
     [Daily.timezone] is a fixed-offset selector, not full civil-timezone
     support. It accepts UTC aliases, Asia/Seoul/KST as +09:00 aliases, and
     explicit fixed offsets such as [+09:00] or [UTC+09:00]. It never consults
-    host local time or DST rules. *)
+    host local time or DST rules.
+
+    [Cron.expression] is a standard 5-field expression
+    [minute hour day-of-month month day-of-week]. It supports wildcards,
+    comma lists, numeric ranges, and step syntax such as [*/15] and [1-5/2].
+    Day-of-week accepts [0] or [7] for Sunday. When both day-of-month and
+    day-of-week are restricted, matching follows Vixie cron semantics: either
+    field may match. *)
 type recurrence =
   | One_shot
   | Interval of { interval_sec : int }
@@ -53,6 +60,10 @@ type recurrence =
       { hour : int
       ; minute : int
       ; second : int
+      ; timezone : string
+      }
+  | Cron of
+      { expression : string
       ; timezone : string
       }
 
@@ -147,6 +158,10 @@ val is_terminal : schedule_status -> bool
 val is_side_effecting : risk_class -> bool
 val requires_separate_human_grant : schedule_request -> bool
 val is_recurring : recurrence -> bool
+val first_due_after : now:float -> recurrence -> float option
+(** Compute the first due time for calendar recurrences that do not need an
+    explicit [due_at] anchor. Returns [None] for [One_shot] and [Interval]. *)
+
 val next_due_after : now:float -> schedule_request -> float option
 val reschedule_after_due_signal : now:float -> schedule_request -> schedule_request option
 

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -219,6 +219,9 @@ let handle_create ~tool_name ~start_time ctx args =
     let* risk_class = risk_class_of_arg args in
     let* source = source_of_arg args in
     let* recurrence = recurrence_of_arg args in
+    (* NDT-OK: absent requested_at_unix means "schedule this from the tool
+       dispatch boundary now"; replay/tests can pass requested_at_unix
+       explicitly. *)
     let requested_at = optional_float args "requested_at_unix" |> Option.value ~default:start_time in
     let* due_at = resolve_due_at ~requested_at recurrence args in
     let* requested_by =

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -219,10 +219,11 @@ let handle_create ~tool_name ~start_time ctx args =
     let* risk_class = risk_class_of_arg args in
     let* source = source_of_arg args in
     let* recurrence = recurrence_of_arg args in
-    (* NDT-OK: absent requested_at_unix means "schedule this from the tool
-       dispatch boundary now"; replay/tests can pass requested_at_unix
-       explicitly. *)
-    let requested_at = optional_float args "requested_at_unix" |> Option.value ~default:start_time in
+    let requested_at =
+      (* NDT-OK: absent requested_at_unix means "schedule this from the tool
+         dispatch boundary now"; replay/tests can pass requested_at_unix explicitly. *)
+      optional_float args "requested_at_unix" |> Option.value ~default:start_time
+    in
     let* due_at = resolve_due_at ~requested_at recurrence args in
     let* requested_by =
       actor_from_args args ~prefix:"requested_by" ~default_id:"operator"

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -28,12 +28,24 @@ let optional_bool args key = Json_util.get_bool args key
 
 let parse_due_at args =
   match optional_float args "due_at_unix", string_opt args "due_at_iso" with
-  | Some due_at, _ -> Ok due_at
+  | Some due_at, _ -> Ok (Some due_at)
   | None, Some iso ->
     (match Masc_domain.parse_iso8601_opt iso with
-     | Some due_at -> Ok due_at
+     | Some due_at -> Ok (Some due_at)
      | None -> Error "due_at_iso must be a parseable ISO-8601 timestamp")
-  | None, None -> Error "one of due_at_unix or due_at_iso is required"
+  | None, None -> Ok None
+;;
+
+let resolve_due_at ~requested_at recurrence args =
+  let* due_at = parse_due_at args in
+  match due_at with
+  | Some due_at -> Ok due_at
+  | None ->
+    (match Schedule_domain.first_due_after ~now:requested_at recurrence with
+     | Some due_at -> Ok due_at
+     | None ->
+       Error
+         "one of due_at_unix or due_at_iso is required unless recurrence_kind is daily or cron")
 ;;
 
 let actor_kind_of_arg args key default =
@@ -94,6 +106,10 @@ let recurrence_of_arg args =
     in
     let* timezone = required_string args "recurrence_timezone" in
     Ok (Schedule_domain.Daily { hour; minute; second; timezone })
+  | Some "cron" ->
+    let* expression = required_string args "recurrence_cron" in
+    let* timezone = required_string args "recurrence_timezone" in
+    Ok (Schedule_domain.Cron { expression; timezone })
   | Some other -> Error ("unknown recurrence_kind: " ^ other)
 ;;
 
@@ -199,11 +215,12 @@ let request_result ~tool_name ~start_time = function
    MCP calls. *)
 let handle_create ~tool_name ~start_time ctx args =
   let result =
-    let* due_at = parse_due_at args in
     let* payload = payload_from_args args in
     let* risk_class = risk_class_of_arg args in
     let* source = source_of_arg args in
     let* recurrence = recurrence_of_arg args in
+    let requested_at = optional_float args "requested_at_unix" |> Option.value ~default:start_time in
+    let* due_at = resolve_due_at ~requested_at recurrence args in
     let* requested_by =
       actor_from_args args ~prefix:"requested_by" ~default_id:"operator"
         ~default_kind:Schedule_domain.Human_operator
@@ -213,14 +230,13 @@ let handle_create ~tool_name ~start_time ctx args =
         ~default_kind:Schedule_domain.Automated_actor
     in
     let schedule_id = string_opt args "schedule_id" in
-    let requested_at = optional_float args "requested_at_unix" in
     let expires_at = optional_float args "expires_at_unix" in
     let approval_required =
       (* DET-OK: omitted approval_required uses the domain risk policy; callers
          must opt in only to stricter approval. *)
       optional_bool args "approval_required" |> Option.value ~default:false
     in
-    Schedule_service.create ctx.config ?schedule_id ?requested_at ?expires_at
+    Schedule_service.create ctx.config ?schedule_id ~requested_at ?expires_at
       ~approval_required ~requested_by ~scheduled_by ~due_at ~payload ~risk_class
       ~source ~recurrence ()
     |> Result.map_error Schedule_service.service_error_to_string

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -92,13 +92,19 @@ let statuses =
 let actor_kinds = [ "human_operator"; "automated_actor"; "system" ]
 
 let sources = [ "operator_request"; "automated_request"; "system_request" ]
-let recurrence_kinds = [ "one_shot"; "interval"; "daily" ]
+let recurrence_kinds = [ "one_shot"; "interval"; "daily"; "cron" ]
 
 let create_schema =
   object_schema
     ~required:[ "risk_class" ]
-    [ number_prop ~description:"Unix timestamp in seconds. Provide this or due_at_iso." "due_at_unix"
-    ; string_prop ~description:"ISO-8601 timestamp. Provide this or due_at_unix." "due_at_iso"
+    [ number_prop
+        ~description:
+          "Unix timestamp in seconds. Provide this, due_at_iso, or a calendar recurrence (daily/cron) that can derive the first due time."
+        "due_at_unix"
+    ; string_prop
+        ~description:
+          "ISO-8601 timestamp. Provide this, due_at_unix, or a calendar recurrence (daily/cron) that can derive the first due time."
+        "due_at_iso"
     ; object_prop
         ~description:
           "Typed schedule payload envelope: {kind:string, schema_version:int, body:object}."
@@ -132,7 +138,11 @@ let create_schema =
         "recurrence_second"
     ; string_prop
         ~description:
-          "Required when recurrence_kind is daily. Fixed-offset only: UTC, Asia/Seoul/KST as +09:00 aliases, or offsets like +09:00/UTC+09:00. DST-aware IANA zones are not supported."
+          "Required when recurrence_kind is cron. Standard 5-field cron expression: minute hour day-of-month month day-of-week. Supports wildcards, comma lists, numeric ranges, and steps such as */15 or 1-5/2."
+        "recurrence_cron"
+    ; string_prop
+        ~description:
+          "Required when recurrence_kind is daily or cron. Fixed-offset only: UTC, Asia/Seoul/KST as +09:00 aliases, or offsets like +09:00/UTC+09:00. DST-aware IANA zones are not supported."
         "recurrence_timezone"
     ; string_prop ~description:"Requester actor id. Defaults to operator." "requested_by_id"
     ; string_prop ~enum:actor_kinds "requested_by_kind"

--- a/test/test_schedule_domain.ml
+++ b/test/test_schedule_domain.ml
@@ -233,6 +233,43 @@ let test_daily_recurrence_rejects_dst_iana_timezone () =
       msg
 ;;
 
+let test_cron_recurrence_next_due_weekdays () =
+  let req =
+    request ~risk_class:Read_only
+      ~recurrence:(Cron { expression = "0 9 * * 1-5"; timezone = "UTC" })
+      ()
+  in
+  check bool "is recurring" true (is_recurring req.recurrence);
+  match next_due_after ~now:32400.0 req with
+  | None -> fail "expected next cron due"
+  | Some due_at -> check (float 0.001) "next weekday 09:00" 118800.0 due_at
+;;
+
+let test_cron_recurrence_supports_steps_ranges_and_sunday_alias () =
+  let req =
+    request ~risk_class:Read_only
+      ~recurrence:(Cron { expression = "*/30 9-10 * * 7"; timezone = "UTC" })
+      ()
+  in
+  match next_due_after ~now:259199.0 req with
+  | None -> fail "expected next Sunday cron due"
+  | Some due_at -> check (float 0.001) "Sunday 09:00" 291600.0 due_at
+;;
+
+let test_cron_recurrence_rejects_invalid_expression () =
+  match
+    create_request ~schedule_id:"sched-1" ~requested_by:(human "requester")
+      ~scheduled_by:(human "scheduler") ~requested_at:100.0 ~due_at:200.0
+      ~payload:(payload_json ()) ~risk_class:Read_only
+      ~approval_required:false ~source:Operator_request
+      ~recurrence:(Cron { expression = "*/0 9 * * 1-5"; timezone = "UTC" })
+      ()
+  with
+  | Ok _ -> fail "expected invalid cron rejection"
+  | Error msg ->
+    check string "cron error" "recurrence.cron.minute step must be positive" msg
+;;
+
 let test_schedule_roundtrip () =
   let req =
     request ~risk_class:Cost_bearing ~approval_required:true
@@ -248,6 +285,24 @@ let test_schedule_roundtrip () =
       (recurrence_kind_to_string decoded.recurrence);
     check string "payload digest" (payload_digest req.payload)
       (payload_digest decoded.payload)
+;;
+
+let test_cron_schedule_roundtrip () =
+  let req =
+    request ~risk_class:Read_only
+      ~recurrence:(Cron { expression = "0 9 * * 1-5"; timezone = "Asia/Seoul" })
+      ()
+  in
+  match schedule_request_to_yojson req |> schedule_request_of_yojson with
+  | Error msg -> fail msg
+  | Ok decoded ->
+    check string "recurrence" "cron"
+      (recurrence_kind_to_string decoded.recurrence);
+    (match decoded.recurrence with
+     | Cron { expression; timezone } ->
+       check string "expression" "0 9 * * 1-5" expression;
+       check string "timezone" "Asia/Seoul" timezone
+     | _ -> fail "expected cron recurrence")
 ;;
 
 let test_missing_recurrence_defaults_one_shot () =
@@ -327,6 +382,12 @@ let () =
             test_daily_recurrence_next_due_accepts_explicit_fixed_offset;
           test_case "daily recurrence rejects DST IANA timezone" `Quick
             test_daily_recurrence_rejects_dst_iana_timezone;
+          test_case "cron recurrence next due weekdays" `Quick
+            test_cron_recurrence_next_due_weekdays;
+          test_case "cron recurrence supports steps ranges and Sunday alias" `Quick
+            test_cron_recurrence_supports_steps_ranges_and_sunday_alias;
+          test_case "cron recurrence rejects invalid expression" `Quick
+            test_cron_recurrence_rejects_invalid_expression;
         ] );
       ( "grant",
         [
@@ -348,6 +409,7 @@ let () =
       ( "codec",
         [
           test_case "schedule roundtrip" `Quick test_schedule_roundtrip;
+          test_case "cron schedule roundtrip" `Quick test_cron_schedule_roundtrip;
           test_case "missing recurrence defaults one-shot" `Quick
             test_missing_recurrence_defaults_one_shot;
           test_case "grant roundtrip" `Quick test_grant_roundtrip;

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -263,6 +263,29 @@ let test_reschedule_due_recurring_advances_only_matching_recurring_rows () =
   | _ -> fail "schedules missing"
 ;;
 
+let test_reschedule_due_cron_advances_to_next_match () =
+  with_workspace
+  @@ fun config ->
+  let cron =
+    make_request ~schedule_id:"cron-1" ~risk_class:Read_only
+      ~recurrence:(Cron { expression = "0 9 * * 1-5"; timezone = "UTC" })
+      ()
+  in
+  let cron = { cron with due_at = 32400.0 } in
+  ignore (insert_ok config cron);
+  (match refresh_due config ~now:32401.0 with
+   | Ok (_, changed) -> check int "cron due" 1 changed
+   | Error err -> fail (store_error_to_string err));
+  (match reschedule_due_recurring config ~now:32401.0 ~schedule_ids:[ "cron-1" ] with
+   | Error err -> fail (store_error_to_string err)
+   | Ok (_, changed) -> check int "cron rescheduled" 1 changed);
+  match get_schedule config ~schedule_id:"cron-1" with
+  | Some stored ->
+    check_status "cron scheduled" Scheduled stored.status;
+    check (float 0.001) "cron next due" 118800.0 stored.due_at
+  | None -> fail "cron schedule missing"
+;;
+
 let test_recovers_from_last_good () =
   with_workspace
   @@ fun config ->
@@ -540,6 +563,8 @@ let () =
             test_refresh_due_expires_pending_scheduled_and_due;
           test_case "reschedule due recurring rows" `Quick
             test_reschedule_due_recurring_advances_only_matching_recurring_rows;
+          test_case "reschedule due cron rows" `Quick
+            test_reschedule_due_cron_advances_to_next_match;
           test_case "start and complete persist execution record" `Quick
             test_start_and_complete_persist_execution_record;
           test_case "fail due candidate records failed execution" `Quick

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -139,6 +139,38 @@ let test_dispatch_create_persists_recurrence () =
          (Schedule_domain.recurrence_kind_to_string request.recurrence))
 ;;
 
+let test_dispatch_create_derives_due_at_for_cron_recurrence () =
+  with_config
+  @@ fun config ->
+  let args =
+    `Assoc
+      [ "schedule_id", `String "sched-cron"
+      ; "requested_at_unix", `Float 32400.0
+      ; "risk_class", `String "read_only"
+      ; "payload", payload
+      ; "requested_by_id", `String "operator"
+      ; "scheduled_by_id", `String "scheduler-agent"
+      ; "recurrence_kind", `String "cron"
+      ; "recurrence_cron", `String "0 9 * * 1-5"
+      ; "recurrence_timezone", `String "UTC"
+      ]
+  in
+  match
+    Tool_schedule.dispatch (schedule_ctx config)
+      ~name:(schedule_tool_name Tool_schemas_schedule.Create_request)
+      ~args
+  with
+  | None -> fail "dispatch returned None"
+  | Some result ->
+    check bool "create succeeds" true (Tool_result.is_success result);
+    (match Schedule_store.get_schedule config ~schedule_id:"sched-cron" with
+     | None -> fail "schedule missing"
+     | Some request ->
+       check string "recurrence" "cron"
+         (Schedule_domain.recurrence_kind_to_string request.recurrence);
+       check (float 0.001) "derived due_at" 118800.0 request.due_at)
+;;
+
 let test_dispatch_cancel_persists_status () =
   with_config
   @@ fun config ->
@@ -334,6 +366,8 @@ let () =
             test_dispatch_create_persists_schedule
         ; test_case "dispatch create persists recurrence" `Quick
             test_dispatch_create_persists_recurrence
+        ; test_case "dispatch create derives due_at for cron recurrence" `Quick
+            test_dispatch_create_derives_due_at_for_cron_recurrence
         ; test_case "dispatch cancel persists status" `Quick
             test_dispatch_cancel_persists_status
         ; test_case "dashboard projection surfaces schedule FSM" `Quick


### PR DESCRIPTION
## Summary
- add a cron recurrence variant to the schedule domain with fixed-offset timezone handling
- expose recurrence_kind=cron / recurrence_cron through masc_schedule_create and derive the first due_at when no explicit due is supplied
- surface cron recurrence labels in the dashboard scheduled automation panel
- add domain/store/tool wiring regressions for cron parsing, reschedule, and tool create

## Verification
- opam exec -- ocamlformat --check lib/schedule/schedule_domain.ml lib/schedule/schedule_domain.mli lib/tool_schedule.ml lib/tool_schemas/tool_schemas_schedule.ml test/test_schedule_domain.ml test/test_schedule_store.ml test/test_schedule_tool_wiring.ml
- git diff --check
- danger-pattern grep over touched OCaml files; only pre-existing test cleanup helpers matched Fun.protect/Sys.readdir

## Not run locally
- Dune/TS builds; operator will verify through CI