### PR TITLE
fix(memory-os): drop duplicate module Reconcile in test (P4 build break)

### DIFF
--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -8,7 +8,6 @@ module Librarian = Masc.Keeper_librarian
 module Librarian_runtime = Masc.Keeper_librarian_runtime
 module Prompt_names = Keeper_prompt_names
 module Recall = Masc.Keeper_memory_os_recall
-module Reconcile = Masc.Keeper_memory_os_reconcile
 module Consolidator = Masc.Keeper_memory_os_consolidator
 module Reconcile = Masc.Keeper_memory_os_reconcile
 


### PR DESCRIPTION
## What
Remove a duplicate `module Reconcile = Masc.Keeper_memory_os_reconcile` binding in `test/test_keeper_memory_os.ml`.

## Why
RFC-0259 P4 (#21718) added the binding after `module Recall`, but an identical binding already existed after `module Consolidator` (a rebase artifact). OCaml rejects two definitions of the same module name in one structure:

```
Error: Multiple definition of the module name Reconcile.
       Names must be unique in a given structure or signature.
```

So `test/test_keeper_memory_os.ml` stopped compiling and **Build and Test went red at the P4 merge (`da40bea1ab`)**.

## Change
- Remove the P4-added duplicate line; keep the single pre-existing binding.
- No test logic change — `Reconcile` stays in scope for the P4 recall-suppression tests (`is_unverified_volatile`, demote-below-durable).

## Verification
- `dune build --root . test/test_keeper_memory_os.exe`: the `Multiple definition` error is resolved (see PR checks).
- Note: full Build and Test green also depends on a **separate** lib break — `gate_keeper_backend.mli` `on_text_snapshot` (introduced by #21714), fixed by **#21730**. That is out of scope here; this PR only unblocks the test-file compile.

## Scope
- Touches only `test/test_keeper_memory_os.ml` (1 line removed). Does NOT touch the gate fix (#21730).

RFC: RFC-0259 P4 follow-up. Test-build fix only; no new behavior.

## Adversarial review evidence
A 4-lens adversarial review (correctness / no-scores / over-suppression / composition) of the merged P4 found the duplicate `module Reconcile` as the **only** real defect (confirmed HIGH: hard OCaml compile error — "Names must be unique in a given structure"). The recall-logic lenses (no-scores compliance, over-suppression/false-positive, P1/P3 composition) returned **zero** findings — `is_unverified_volatile` + demote-below-durable are sound and score-free. Reproduced deterministically: `dune build --root . test/test_keeper_memory_os.exe` on the merged tree fails with `Multiple definition of the module name Reconcile`; after this one-line deletion that error is gone (only the separate `gate_keeper_backend` lib break remains, owned by #21730).
