### PR TITLE
issue king/task 1440 g0000 fix

### DIFF
--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -444,7 +444,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_preview = "";
             consecutive_noop_count = 0;
           };
-          generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id:trace_id_t;
+          let generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id:trace_id_t in
           trace_id = trace_id_t;
           trace_history = [];
           last_handoff_ts = 0.0;
@@ -479,7 +479,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ~session
             ~agent_name:meta.agent_name
             ~ctx:ctx0
-            ~generation:(Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id:trace_id_t)
+            ~generation
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -452,7 +452,11 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_preview = "";
             consecutive_noop_count = 0;
           };
+<<<<<<< HEAD
           generation;
+=======
+          generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name;
+>>>>>>> 48cfb5aec (fix(consolidator): replace hardcoded generation=0 with next_generation call)
           trace_id = trace_id_t;
           trace_history = [];
           last_handoff_ts = 0.0;
@@ -487,7 +491,11 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ~session
             ~agent_name:meta.agent_name
             ~ctx:ctx0
+<<<<<<< HEAD
             ~generation
+=======
+            ~generation:(Keeper_memory_os_io.next_generation ~keeper_id:p.name)
+>>>>>>> 48cfb5aec (fix(consolidator): replace hardcoded generation=0 with next_generation call)
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -354,14 +354,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ()
       in
       let ctx0 = Keeper_context_runtime.create ~system_prompt ~max_tokens:primary_max_context in
-      (* next_generation keys the per-(keeper, trace) counter by the trace_id
-         string; episodes live under that same string dir (ensure_dir/of
-         session_id above), so pass the raw [trace_id] string, not the typed
-         [trace_id_t]. Reuse the reservation for metadata and checkpoint
-         creation so they cannot diverge. *)
-      let generation =
-        Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id
-      in
       let meta = {
         id = None;
         name = p.name;
@@ -452,11 +444,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_preview = "";
             consecutive_noop_count = 0;
           };
-<<<<<<< HEAD
-          generation;
-=======
-          generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name;
->>>>>>> 48cfb5aec (fix(consolidator): replace hardcoded generation=0 with next_generation call)
+          generation = Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id:trace_id_t;
           trace_id = trace_id_t;
           trace_history = [];
           last_handoff_ts = 0.0;
@@ -491,11 +479,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ~session
             ~agent_name:meta.agent_name
             ~ctx:ctx0
-<<<<<<< HEAD
-            ~generation
-=======
-            ~generation:(Keeper_memory_os_io.next_generation ~keeper_id:p.name)
->>>>>>> 48cfb5aec (fix(consolidator): replace hardcoded generation=0 with next_generation call)
+            ~generation:(Keeper_memory_os_io.next_generation ~keeper_id:p.name ~trace_id:trace_id_t)
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->


### PR DESCRIPTION
- Wire scheduled automation tools (#21061)
- fix(keeper): tutor bad tool calls (#21087)
- fix(config): declare Gemma4 QAT supports-tool-choice as false (#21094)
- fix(runtime): thread binding keep-alive and num-ctx into Provider_config (#21090)
- fix(runtime): honor rerank runtime_id and delete silently-ignored routing args (#21092)
- fix(keeper): surface crashed heartbeat cycle as turn failure (#21088)
- refactor(workspace): typed no-op outcome for task transitions (#21091)
- fix(gate): record Discord WSS writer fiber death cause (#21111)
- fix(keeper): distinguish corrupt vs missing async request records (#21112)
- Simplify keeper prompt injection map (#21113)
- fix(gate): serialize Discord thread-parent table access (#21084)
- fix(cdal): make adversarial finding IDs atomic (#21086)
- fix(server): make memory-subsystems cache thread-safe (#21073)
- ci(watchdog): skip branch-protection audit on PRs when audit token is absent (#21117)
- fix(server): make LSP message router IDs and pending table thread-safe (#21089)
- fix(dashboard): make harness health JSONL stores thread-safe (#21093)
- fix(keeper): serialize accountability snapshot cache refresh (#21082)
- fix(keeper): route dashboard meta writes through CAS merge, not force (#21116)
- fix(keeper): persist OAS telemetry events to dated JSONL (re-land #20853) (#21115)
- fix(discord): chunk/truncate Discord text on codepoint boundaries (#21118)
- fix(attempt_fsm): respect accept_on_exhaustion on Call_err path (#21005)
- fix(keeper): stop thinking-only accept loops (#21067)
- fix(auth): serialize stale-token warn dedup hashtbl
- fix: route task-done workflow recovery (#21063)
- fix(discord): suppress bot/webhook turn-starts; unify trigger parser (#21119)
- perf(keeper): bound external-attention dedup scan to a recent tail (#21124)
- ci(coverage): wire the coverage-checker self-test into CI (#21120)
- fix(keeper): preserve typed fleet blocker causes (#21121)
- fix(streamable_http): make session.last_seen an explicit Atomic.t (#21123)
- refactor(keeper): drop dead Memory OS retention-verdict cluster (#21125)
- test(keeper): pin self-model meta keys as canonical (#21047)
- feat(task): thread scope_widened into claim_observation payload (#21126)
- chore(masc): legacy cleanup — dead code, Boundary_redaction SSOT, provider-letter purge (#21122)
- chore(release): bump version to 0.19.44 and OAS agent_sdk pin to 0.206.9 (#21131)
- ci(fundamental): stale-base revert guard (RFC-0235) (#21132)
- fix(exec,keeper): dangling-else stream duplication + non-routable tool hint (merge-audit quick fixes) (#21076)
- fix(board_moderation): protect global store with Eio.Mutex (#21129)
- fix(mcp_server): store workspace_config in an Atomic.t (#21128)
- fix(voice_bridge): make health cache atomic (#21130)
- fix(otel): make override refs atomic (#21133)
- fix dashboard chat stale token retry (#21134)
- fix(dashboard): surface stale bearer token state (#21040)
- refactor(dashboard): simplify prompt assembly recipe (#21135)
- fix(keeper_turn): protect shared Hashtbls with Eio.Mutex (#21136)
- fix(tool_operator): make operator tool registry an atomic record (#21137)
- fix(transport_bridge): make provider registry atomic (#21138)
- fix(exec_policy): fill Cwd_not_directory hint with real sibling dirs from disk (#21139)
- fix(voice_bridge): add NDT-OK rationale for cached availability default
- fix(keeper): pin C message locale for sandbox EINTR retry marker (#21149)
- [codex] fix keeper tool pair repair (#21062)
- [codex] Improve keeper context compaction summaries (#21058)
- fix(dashboard): keep workspace config reads coherent (#21143)
- fix: bound keeper OAS turn budgets (#21060)
- docs(rfc): RFC-0236 keeper git credential helper (roots 146 git auth failures) (#21140)
- docs(spec): add 04-turn-lifecycle.md as SSOT for keeper turn lifecycle (#21071)
- refactor(dashboard): hide prompt keys from recipe default (#21146)
- docs(audit): document MASC turn FSM drift / SSOT gaps (#21109)
- [RFC-0235] Voice output browser transport — P1 1-4a (server side) (#21144)
- fix(keeper_memory_bank): exclude voice_output from recent-note preview (#21153)
- fix(prompts): align keeper workspace guidance with worktree-optional architecture (#21154)
- Fix keeper release owner-mismatch guidance (#21152)
- fix(prompts): root the optional worktree example path to satisfy drift gate (#21156)
- feat(dashboard): mobile-first navigation, touch targets, and dialogs (#21145)
- docs: add claim filter design specification (#21157)
- [RFC-0236] Voice input transport — browser speech-to-text (P1) (#21159)
- fix(task): mark todo completion rejection recoverable (#21160)
- fix(keeper): remove dead GITHUB_TOKEN allow_exact entry, assert denied (#21161)
- refactor(dashboard): simplify prompt recipe wording (#21162)
- refactor(keeper): remove write_meta ~force escape hatch, route via CAS+merge (RFC-0237) (#21164)
- fix(voice): gate STT uploads to admin tokens (#21163)
- chore(deps): bump OAS agent_sdk pin to v0.206.12 (#21165)
- refactor(dashboard): make prompt recipe model-first (#21170)
- refactor(keeper): type the event-queue stimulus payload (RFC-0020) (#21174)
- refactor(keeper): type the board wake_reason carrier (RFC-0020) (#21189)
- refactor(keeper): type the cycle channel carrier (RFC-0020) (#21190)
- fix(schedule): fail loud on corrupt durable ledger instead of silent default (#21193)
- Improve Memory OS stale fact lifecycle (#21195)
- fix(keeper): mark typed execute validation deterministic (#21184)
- refactor(dashboard): simplify prompt recipe audit wording (#21185)
- [RFC-0239] 키퍼 confabulation 루프 정지: semantic-identity 가드 (R3+R4+R2) (#21196)
- fix(dashboard,auth): gate 401 retry on typed auth_error_code, not substring (#21194)
- docs(rfc): RFC-0239 concurrency ownership model (#21198)
- docs(rfc): RFC-0240 tool-pair invariant write-time enforcement (#21197)
- fix(keeper): drop deleted keeper_report_state from recovery_block prompt (#21173)
- docs(rfc): RFC-0241 external-attention store lifecycle (#21199)
- [RFC-0239 Q4] Memory OS fact store retention sweep (cap_facts) (#21200)
- chore(rfc): bump .next-number 0238->0242 (ledger monotonic fix after RFC-0239/0240 merge) (#21201)
- refactor(keeper): tutor 분류를 typed tutor_alias/runtime_handler로 (#21087 후속) (#21202)
- fix(keeper): harden memory os librarian extraction (#21205)
- refactor(keeper): remove forced tool choice pressure (#21206)
- docs(rfc): RFC-0242 typed continuity-summary filter (RFC-0239 guard #6) (#21207)
- docs: refresh runtime tunables catalog (#21208)
- feat(keeper): make Memory OS confidence mutable via write-side fact upsert (RFC-0243) (#21209)
- Improve keeper detail roster and chat layout (#21210)
- fix dashboard websocket same-origin upgrade (#21211)
- docs(rfc): reframe RFC-0242 to enforce typed continuity state, retire prose filter (#21212)
- refactor(keeper): type the agent-runtime status carrier (RFC-0089) (#21213)
- fix(keeper): tune memory os librarian timeout (#21214)
- Fix keeper detail test selector (#21215)
- Add keeper chat workspace surface (#21216)
- remove keeper stay silent legacy (#21217)
- refactor(keeper): type state_snapshot_source as closed variant (RFC-0242 §3.2) (#21219)
- refactor(keeper): type the memory-bank provenance carrier (RFC-0020) (#21204)
- docs(rfc): add RFC-0244 turn-seeded deterministic lexical recall (#21220)
- add local searxng websearch helper (#21221)
- fix(dashboard): resume pending keeper chat requests (#21223)
- remove stay silent legacy residues (#21226)
- refactor(server): route SSE stream primers through the sse_retry_ms SSOT (RFC-0089) (#21225)
- feat(keeper): turn-seeded deterministic lexical recall (RFC-0244 P1) (#21224)
- feat(dashboard): enrich keeper roster rows and enlarge workspace chrome fonts (#21229)
- fix(keeper): exempt goalless tasks from per-goal WIP claim cap (RFC-0245) (#21227)
- refactor(otel): route OTLP probe port through the otel_default_port SSOT (RFC-0089) (#21232)
- refactor(config): extract nickname word lists to a shared Nickname_words SSOT (RFC-0089) (#21233)
- fix(dashboard): drop stale pending keeper requests (#21231)
- feat(keeper): RFC-0244 Tier 2 cross-keeper shared semantic memory store (#21237)
- docs(rfc): collapse RFC-0244 P2 into shared semantic tier (ground-truth correction) (#21234)
- fix(memory-os): default consolidation fiber OFF until librarian taxonomy fix (#21244)
- feat(dashboard): surface keeper error states and slim the chat header (#21242)
- fix(keeper): keep voice output out of prompt echo (#21247)
- fix(memory-os): typed librarian category + suppress ephemeral extraction (#21241) (#21248)
- fix(dashboard): route websocket discovery to standalone (#21240)
- task-1291: add missing ppx deps (ppxlib, ppx_deriving_yojson, ppx_let, ppx_deriving, bisect_ppx, ocaml-protoc-plugin) to Dockerfile.keeper-sandbox (#21249)
- style(dashboard): reclaim vertical space for keeper-workspace transcript (#21252)
- pre_compact: publish keeper snapshot to Masc_event_bus after SSE broadcast (#21236)
- fix(memory-os): rewrite librarian prompt with durability gate + per-category criteria (#21257)
- fix(discord): ignore stale gateway reader inputs (#21261)
- refactor(keeper): type the keeper surface_status carrier (RFC-0089) (#21218)
- refactor(goal): derive goal phase/action enums from Goal_phase ADT (RFC-0089) (#21222)
- fix(runtime): reject unknown thinking-control-format instead of silent downgrade (RFC-0089) (#21262)
- wire websearch runtime toml overrides (#21228)
- fix(dashboard): resume keeper chat after stream cut (#21239)
- fix(keeper): run issue_king in local sandbox (#21253)
- refactor(keeper): assemble the world-state prompt as a typed ordered layer fold (#21254)
- feat(keeper): wake-cascade recovery tombstone (RFC-0246 P1+P2) (#21256)
- fix(keeper): keep operator pauses durable (#21263)
- feat(dashboard): rich recent tool-calls in keeper-workspace rail (#21266)
- fix(dashboard): don't trip SSE fallback on clean WS close (#21271)
- fix(keeper): gate memory librarian completions (#21230)
- fix(keeper): suppress wake storms and preserve operator pauses (#21260)
- fix(keeper): suppress no-target broadcast wake fanout (#21264)
- fix(dashboard): reconcile keeper chat stream failures (#21238)
- feat(board): operator-gated post pinning (#21273)
- feat(keeper): producer-assigned chat message id, dashboard keys off it (R3) (#21274)
- Fail loud on recent runtime persistence gaps (#21272)
- feat(keeper): bound librarian parse-retry instead of dropping unparseable episodes (C6) (#21258)
- refactor(keeper): type recent_direct_line role as a closed sum (RFC-0232 P1) (#21246)
- fix(keeper): keep operator pauses durable (#21268)
- Phase 0-2 + P3-2..P3-5 foundations + RFC-0246 keeper brain (#21267) (#21265)
- feat(dashboard): surface worktree origin + web URL on worktree-status (#21277)
- refactor(dashboard): drop SSE fallback, make WS/WSS the sole transport (#21279)
- Improve dashboard render stability (#21280)
- feat(logs): typed categories, FSM filters, and fix false-positive keeper directive warns (#21276)
- P3-4: wire RFC-0235 voice output into dashboard chat (#21282)
- fix(keeper): preserve reasoning carrier and FSM completion (#21278)
- test(dashboard): sync stale KeeperWorkspaceRail test after #21266 lazy-load migration (#21284)
- style(dashboard): apply v2 design-system chrome to left rail and status tray (#21285)
- fix(keeper): run memory-os consolidation always-on, drop the env toggle (#21283)
- fix(board): emit human-readable classification reason and 404 body, not derived show (#21286)
- refactor(dashboard): remove dead task-worktree projection (TaskWorktreeInfo) (#21287)
- feat(memory-os): add episode TTL recall guard (#21288)
- style(dashboard): apply v2 design-system chrome to header and health strip (#21289)
- style(dashboard): migrate Logs, Sidecar Log Viewer, Overview, and Cockpit to v2 design system (#21292)
- feat(dashboard): surface memory os recall source (#21295)
- test(dashboard): fold EmptyState DOM tests into feedback-state.test.ts, drop stale duplicate (#21296)
- feat(dashboard): surface tool-call output in chat ToolCallBubble (#21298)
- refactor(dashboard): de-anonymize vendor-purge cipher in test fixtures (#21300)
- refactor(runtime): de-anonymize vendor-purge cipher to brand names (OCaml layer) (#21297)
- fix(board): stop leaking derived show_board_error into HTTP/MCP error surfaces (#21302)
- feat(keeper-memory-os): render recall staleness as worded age, not dead stale=0.00 (#21303)
- chore: remove stale env flag surfaces (#21291)
- feat(keeper): typed observation provenance for board activity (RFC-0248 PR-1) (#21294)
- test(keeper-memory-os): match staleness marker tail, not wrapper prose (#21304)
- fix(dashboard): decode chat-history attachments + transport_failure kind (#21305)
- chore(oas-pin): bump agent_sdk floor to 0.206.12.1, pin masc-pin-timeout-2099 (#21306)
- perf(main_eio): reduce CPU/GC pressure from backlog reads and JSON parsing (#21308)
- fix(dashboard): decode tool-call semantic_outcome/success + goal_ids (#21309)
- style(dashboard): migrate Connectors and Monitoring surfaces to v2 design system (#21310)
- fix(dashboard): decode keeper-decisions terminal_reason_code into the runtime column (#21311)
- feat(keeper): structural board trust partition (RFC-0248 PR-2) (#21312)
- fix(keeper-event-bridge): demote duplicate oas:event turn/tool logs to routine (#21313)
- docs(oas-pin): repair KEEPER-USER-MANUAL via sync-oas-pin-docs (#21315)
- fix(dashboard): decode runtime config_path + telemetry active_coverage_gap_count (#21316)
- fix(dashboard): decode keeper-trust latest_event_at + causal-event trace_id (#21317)
- fix(dashboard): label chat tool-call args as input, mark empty {} no-args (#21307)
- feat(keeper): remove dead stale_factor field (RFC-0249) (#21321)
- style(dashboard): v2 foundation tokens, surface CSS skeletons, and invalid utility fixes (#21323)
- style(dashboard): migrate Command / Operations surface to v2 (#21325)
- test(keeper): memory-os brain end-to-end composition harness (RFC-0247) (#21290)
- fix(dashboard): surface proactive keeper work in roster previews (#21324)
- style(dashboard): migrate Workspace / Board surfaces to v2 (#21327)
- perf(main_eio): reduce CPU/GC pressure from metric store, UTF-8, and dashboard trust snapshots (#21326)
- feat(keeper): wire stale-run window (RFC-0250) (#21328)
- feat(dashboard): migrate Planning & Goals surfaces to v2 workspace markers (#21329)
- feat(dashboard): migrate Monitoring leftovers to v2 monitoring markers (#21330)
- feat(dashboard): migrate Lab / Tools & Harness to v2 lab markers (#21331)
- feat(dashboard): migrate Code / IDE to v2 ide markers (#21332)
- feat(shell-ir): parallel/async/visibility/approval level-up (#21334)
- feat(dashboard): apply remaining v2 foundation markers and lock with tests (#21335)
- perf(dashboard): isolate keepers signal out of keeper-detail render body (#21336)
- fix(keeper): gate proactive preview on typed turn outcome (RFC-0232) (#21337)
- fix(keeper): stop synthesizing reply text for empty-body tool turns (RFC-0232) (#21340)
- feat(dashboard): apply leftover v2 marker classes across nested surfaces (#21341)
- docs(rfc): RFC-0251 — Memory OS record well, do not value (remove scoring layer) (#21342)
- feat(keeper): RFC-0251 phase 2 — recall orders by relevance, shows no worth (#21345)
- feat(keeper): RFC-0251 phase 3 — librarian derivability gate (record well) (#21346)
- feat(voice): allow public read for /api/v1/voice/audio/<token> (#21347)
- chore(keeper): remove unimplemented persona roster + purge placeholder names (#21348)
- ui(dashboard): improve readability across menus, cards, tables, and primitives
- feat(dashboard): apply keeper-v2 foundation bridge — tokens, virtual-list, roster (#21349)
- refactor(keeper): immutable turn state for lifecycle, event bus, and runtime budget (#21350)
- feat(dashboard): apply keeper-v2 copilot dock (#21352)
- feat(masc): adversarial hardening — eio-concurrency-core (#21353)
- feat(dashboard): apply keeper-v2 settings surface (#21356)
- feat(dashboard): apply keeper-v2 loading indicators (#21359)
- feat(masc): adversarial hardening — legacy-purge-safe (#21355)
- feat(dashboard): apply keeper-v2 rich chat blocks (#21361)
- chore(docs): purge dead withdrawn RFCs + archived audit reports (#21370)
- feat(masc): adversarial hardening — security-secrets-hardening (#21354)
- feat(dashboard): apply keeper-v2 memory graph + goal dossier surfaces (#21358)
- refactor(keeper): drop cost/token budget enforcement, bump OAS pin to 0.207.0 (#21368)
- feat(dashboard): apply keeper-v2 atomic primitives (#21362)
- feat(dashboard): exhaustive v2 marker pass across all remaining nested surfaces (#21371)
- fix(keeper): remediate SSOT drift across turn lifecycle, registry, and task dispatch (#21369)
- feat(dashboard): apply keeper-v2 turn inspector styling (#21360)
- refactor(keeper): immutable state for sandbox guard, holders, livelock, and FSM metrics (#21380)
- build(masc): bump OAS agent_sdk pin to 0.207.2 (#21381)
- feat(keeper): add adversarial review + PR ownership to active unified prompt (#21374)
- feat(dashboard): apply keeper-v2 board surface (#21378)
- feat(dashboard): apply keeper-v2 IDE surface styling (#21382)
- fix: agent_sdk 0.207.2 compile follow-ups
- feat(dashboard): apply keeper-v2 work surface (#21373)
- feat(dashboard): apply final leftover v2 markers to unmarked surfaces (#21388)
- feat(dashboard): apply keeper-v2 tweaks panel + craft layer (#21389)
- feat(dashboard): apply keeper-v2 telemetry primitives (#21365)
- feat(dashboard): apply keeper-v2 connectors surface (#21384)
- OTel/Grafana integration cleanup: runtime selection, tool types, and dashboard fixes (#21385)
- feat(dashboard): apply keeper-v2 design canvas surface (#21386)
- feat(dashboard): apply remaining keeper-v2 surface styles (#21390)
- feat(dashboard): apply keeper-v2 app shell styling (#21391)
- refactor(dashboard): auto-import keeper-v2 surface CSS via import.meta.glob (#21392)
- feat(dashboard): apply keeper-v2 cockpit / command map surface (#21393)
- feat(dashboard): apply keeper-v2 overview surface component (#21394)
- feat(dashboard): add keeper-v2 fixture catalog to design canvas (#21395)
- feat(dashboard): apply keeper-v2 update batch 5 — state surfaces + keeper config + log filter (#21397)
- docs(rfc): RFC-0253 — dashboard keeper-v2 spacing/radius token scale (#21398)
- refactor(keeper/runtime): immutable state for supervisor sweep, launch/self-preservation, agent helpers, and runtime globals
- feat(dashboard): keeper-v2 Phase A/B/C — nav wiring, mobile shell, new surfaces (#21399)
- feat(dashboard): apply keeper-v2 design-system theme tokens (#21405)
- feat(dashboard): add keeper-v2 design-system UI kits (experimental) (#21406)
- feat(dashboard): add keeper-v2 brand assets and self-hosted fonts (#21404)
- build(deps): bump dompurify (#21407)
- feat(dashboard): apply keeper-v2 v8 polish (#21400)
- fix(dashboard): restore left rail visibility and main content scrolling (#21412)
- build(deps-dev): bump vite (#21413)
- fix(dashboard): keeper detail scroll, navigation, design tokens (#21414)
- fix(dashboard): remove nested scroll container from keeper conversation thread (#21416)
- feat(dashboard): apply keeper-v2 multimodal chat composer (#21417)
- fix(dashboard): keeper detail thread scroll height regression (#21419)
- feat(dashboard): add manual context compaction to keeper workspace rail (#21421)
- fix(main_eio): fail switch on graceful shutdown to cancel background fibers (#21422)
- fix(dashboard): keeper chat UX follow-up — auto-scroll, queue edit, batch send, bubble borders (#21423)
- feat(dashboard): add StyleSeed-inspired opt-in theme foundation (#21424)
- fix(redact): anchor secret-prefix regexes at word boundary (#21427)
- fix(dashboard): keeper chat UX follow-up (#21429)
- feat(dashboard): dark-fantasy foundation — palette + Cinzel + scroll (#21430)
- test(dashboard): lock dark-fantasy mermaid colors in harness-health (#21431)
- fix(keeper): expose WebSearch/WebFetch usage examples and enforce Exclusive_external concurrency (#21432)
- fix(dashboard): prefer lifecycle phase over status so running keepers do not show Idle (#21433)
- feat(dashboard): activate StyleSeed as default theme (#21435)
- fix(keeper/rfc): close Atomic RMW race in self-preservation escape_state and restore RFC ledger monotonicity (#21402)
- feat(dashboard): migrate app shell to StyleSeed (#21436)
- feat(dashboard): migrate shared primitives to StyleSeed (#21437)
- feat(dashboard): migrate major surfaces to StyleSeed card layout (#21438)
- feat(dashboard): rich 1:1 chat with markdown blocks, Shiki, Mermaid, and artifact panel (#21445)
- feat(shell-ir): RFC-0254 autonomous approval policy (trust-independent catastrophic floor) (#21434)
- fix(dashboard): wire real compaction API and surface context fields in workspace rail (#21439)
- feat(dashboard): migrate IDE/connectors/lab surfaces to StyleSeed (#21442)
- fix(prompts): avoid forbidden internal web tool literal in unified system prompt (#21451)
- fix(redact): remove generic length-based secret matcher (keeper identity false-positive) (#21452)
- fix(dashboard): stabilize rich chat CI — pin DOMPurify and reuse shared Shiki highlighter (#21448)
- feat(comm): rich blocks, voice playback, and cross-channel tool context (#21449)
- fix(dashboard): align stale tests with current shell/button output
- refactor(fusion): gate by structure + LLM judgment, not score thresholds (#21425)
- fix(dashboard): sync nav-event allowlist with navigation.ts (#21453)
- fix(exec_policy): exempt gh REST endpoints from shell-IR path jail (#21462)
- chore(fusion): enable masc_fusion by default (personal dev canary) (#21461)
- fix(fusion): pattern-match create_post result against Board.post, not unit (#21460)
- feat(dashboard): split v2 high-contrast skin into scoped keeper-chat CSS (#21457)
- fix(keeper): make turn event-bus pending count and drain-cancel atomic (S1-S3) (#21447)
- refactor(dashboard): extract Make_probe_cache functor from duplicated git-probe caches (#21446)
- fix: filter own-agent name from stale orphan count (short-term patch)
- feat(dashboard): keeper-v2 Dark Fantasy default over StyleSeed token layer + readable type scale (#21464)
- refactor(process): migrate hand-rolled Mutex lock/protect to Mutex.protect (#21463)
- fix(exec): complete catastrophic floor for fs-format family and bundled git force flags (#21468)
- fix(keeper): convert sandbox state, supervisor global switch, and manifest seq to Atomic (S5-S7)
- fix(keeper): parenthesize Running record constructor after ref->Atomic conversion
- fix(keeper): add determinism-contract allow comment for supervisor switch fallback
- fix(keeper): move Obj.magic out of lib into test for sandbox For_testing
- feat(copilot): wire dashboard Copilot Dock to keeper chat stream (#21465)
- feat(bin): add masc_shell_ir_probe offline Shell IR pipeline probe (#21467)
- fix(build): expose keeper_unified_turn_event_bus so its test compiles (#21469)
- fix(fusion): expose masc_fusion to keepers (visibility Hidden->Default) (#21470)
- feat(comm): backend blocks, Slack rich posts, Voice MCP browser audio, expired audio UI (#21472)
- fix(probe): mirror keeper command gate (gate_typed) not the exec_policy wrapper (#21473)
- fix(keeper): stop event-bus unsubscribe busy-spinning at 100% CPU (drain-cancel CAS) (#21475)
- fix(comm): follow-up fixes from adversarial review of #21472 (#21478)
- fix(runtime): make binding capacity opt-in
- fix(runtime): address adversarial review on PR #21320
- fix(test): use String_util.contains_substring in runtime config validity
- fix(dashboard): resolve loopback auth race condition on app startup and sync agent_sdk pin
- fix(runtime): catch Otoml.Type_error in binding field parser
- fix(keeper): reduce stagnation and wire adversarial review tool
- docs(runtime-tunables): regenerate env knob catalog
- fix(keeper): remove per-task worktree auto-provisioning
- refactor(workspace): remove claim_post_provision hook from runtime
- test: remove claim_post_provision_hook regression test
- refactor(server): remove dashboard worktree-status route
- refactor(dashboard): remove worktree-status from IDE presence strip
- test(dashboard): update presence strip tests after worktree removal
- fix(keeper): harden prompt-injection defense and refresh branch
- fix(keeper): address adversarial review on PR #21357
- chore(docs): regenerate runtime-tunables.md catalog (350 knobs)
- fix(keeper): registry-driven strip of stale tool tokens in prompts
- fix(keeper): preserve alarms and sentence structure when stripping stale tool tokens
- fix(keeper): strip stale tool tokens from continuity_summary
- fix(dashboard): restore missing chat.css import
- Merge keeper-v2 paper/dark design-system deltas into dashboard (#21480)
- fix(dashboard): address review follow-ups from #21478
- fix(dashboard): address review follow-ups from #21480
- feat(dashboard): standalone keeper-v2 'Keeper Agent v2' prototype at /dashboard/v2
- fix(dashboard): lower top-level const/let to var in v2 prototype build
- test(dashboard): unit-test the v2 build const/let -> var rewrite
- Revert "Merge pull request #21486 from jeong-sik/feat/dashboard-v2-standalone"
- fix(keeper): convert unprotected global shared refs/caches to Atomic
- chore(deps): bump agent_sdk pin to OAS v0.207.3 and masc 0.19.46 (#21491)
- feat(keeper): librarian extraction cadence — cut per-turn provider load (#21458)
- fix(dashboard): keep queued keeper chat entries across history merges (#21492)
- feat(transport): harden WebSocket transport against frequent disconnects (#21489)
- refactor(mutex): Phase 1 cluster — 15 general-domain files to Mutex.protect (RFC-0255) (#21483)
- perf: dashboard DOM + server/streaming optimizations (27 commits) (#21481)
- fix(transport): address review follow-ups from #21489 (#21497)
- feat(shell-ir): RFC-0255 P1+P2 — path-jail kill-switch + recoverability floor narrow (#21488)
- fix(exec): enforce catastrophic floor on the always-run dispatch path (flag-independent) (#21495)
- fix(keeper): unify surface_context formatter as SSOT across HTTP and MCP paths (#21465) (#21498)
- fix(keeper): orphan audit uses keeper-aware staleness; drop self-filter workaround (#21418) (#21496)
- redesign(memory-os): decision-layer correction — scoring → LLM judgment + value eval (#21319)
- feat(dashboard): apply keeper-v2 design system increments (tone-rail, roster sort, token/label cleanup) (#21502)
- fix(dashboard): 모바일 keeper 채팅 단일 pane 레이아웃 + 헤더 overflow/nav 드로어 수정 (#21513)
- fix(keeper): annotate surface context boundary (#21504)
- fix(tool-registry): derive workspace-state routing from schema (#21512)
- feat(keeper): relocate librarian serialization to per-keeper lane, retain optional fleet-wide gate (RFC-0257) (#21376)
- chore(dashboard): remove 7 dead CSS files unused after v1->v2 migration (#21520)
- config(runtime): add minimax-m3 (ollama_cloud) for memory-os librarian (#21519)
- test: guard workspace tool registry drift (#21518)
- feat(keeper): adversarial review verdict + author wake-on-fail (PoC) (#21401)
- docs(rfc): RFC-0258 grounded verdict + unified adversarial-review routing (#21499)
- feat(verifier): add grounded verdict evidence parser (#21522)
- feat(keeper-workspace): adopt standalone v2 chat polish (B1-B5, C1, C2) (#21527)
- feat(runtime): [runtime].librarian config-driven memory-os librarian routing (#21521)
- fix: address review follow-ups from #21495 (#21501)
- fix: address review follow-ups from #21481 (#21505)
- fix: address review follow-ups from #21488 (#21503)
- fix(keeper): soften runtime network errors (#21524)
- [codex] align keeper v2 dashboard surfaces (#21525)
- fix: address review follow-ups from #21496 (#21507)
- tool-orchestration P1: typed ToolJob envelope and durable ToolEvent ledger (#21526)
- fix: assign incrementing generation numbers to episodes (#21515)
- chore(release): sync ROADMAP and lockfile versions after v0.19.45/v0.19.46 (#21494)
- [codex] Align keeper v2 shell navigation (#21528)
- fix(dashboard): run metrics-cache compute in an Eio context, not a bare systhread (#21530)
- fix(dashboard): restore Logs to the primary desktop nav surface set (#21531)
- fix(docs): regenerate env knob catalog total (350->351) to clear drift gate (#21506)
- fix(discord): reconnect with backoff on gateway connect failure instead of dying (#21532)
- fix(core): surface an actionable error when Eio work runs on a bare systhread (#21535)
- refactor(keeper): remove dark edges/spreading-activation organ (RFC-0251) (#21536)
- build(deps): bump dompurify from 3.4.2 to 3.4.9 in /dashboard in the npm_and_yarn group across 1 directory (#21455)
- docs(rfc): add RFC-0256 Mutex.protect migration roadmap (#21471)
- docs(readme): rewrite README to remove hype and match reality (#21479)
- [codex] Align keeper v2 connectors surface (#21533)
- feat(fusion): standalone keeper-independent fusion harness (RFC-0252) (#21493)
- Wire grounded review evidence to dashboard attention (#21537)
- fix(memory-os): GC reads strictly + holds the facts lock to stop silent fact loss (#21529)
- fix: wire visible fusion descriptor into keeper bundle (#21540)
- Document connector review follow-up (#21541)
- fix(memory-bank): persist trace_id on cross-trace recurrence promotion (#21543)
- fix(memory-os): recall scans the whole bounded store via fact_store_max SSOT (#21534)
- fix(dashboard): keeper-v2 design-system audit cleanup (#21551)
- fix(grpc): tear down LSP proc + pipe FDs on failed initialize (RFC-0261, #21546) (#21550)
- build(deps): bump dompurify (#21538)
- fix(rng): make ensure_rng_init atomic under concurrent fibers (#21552)
- [codex] Tighten keeper v2 connectors visual parity (#21544)
- fix(sse): scope drain/ping pumps to a per-connection switch (#21548) (#21558)
- fix(http-pool): release Piaf client on cancel during body read (#21547) (#21553)
- fix(session): reset registry loop_started on switch release and drain pending mailbox (#21554)
- docs(rfc): RFC-0260 provider health gate and audited failover (#21542)
- fix(shutdown): make hook registry atomic to prevent registration races (#21556)
- fix(pulse): make shutdown and nudge race-safe (#21557)
- fix(keeper): skip board-event collection for paused keepers (#21555)
- fix(session): assert McpSessionStore.get return value, not stale immutable record (#21570)
- fix(librarian): default memory-os librarian timeout to 600 seconds (#21567)
- feat(dashboard): surface runtime assignment governance (#21569)
- docs(rfc): RFC-0259 memory-os volatile claim grounding, retraction & decay (#21539)
- refactor(institution): use random_id for memory ids (#21561)
- add multimodal dashboard chat blocks (#21571)
- fix(masc_oas_bridge): remove fragile Eio internal exception string match (#21564)
- fix(keeper): prevent evidence probe host fallback (#20756) (#21563)
- fix(ws): key heartbeat liveness on last_pong_at, not a tick counter (#21575)
- fix(runtime_params): auto-persist and audit set/clear (#21565)
- fix(dashboard): repair keeper-chat send label, voice icon, tool grouping, and stale-error ordering (#21574)
- chore(oas): bump agent sdk pin to 0.207.5 (#21576)
- fix(server): terminate activity SSE keepalive loop on client disconnect (#21562) (#21583)
- fix(keeper): repair identity drift (#21577)
- refactor(backend): use Result syntax in lib/backend/backend.ml (#21580)
- fix(fusion): materialize descriptor-backed keeper schemas (#21545)
- docs(rfc): add RFC-0262 completion authority typing (#21566)
- fix(keeper): scope config discovery to workspace (#21584)
- Make overview telemetry use live data (#21585)
- refactor(keeper): purge keeper LLM force_done/force_release tools (#21586)
- docs(rfc): add RFC-0263 owner-priority turn preemption (#21573)
- fix(dashboard): 훅 슬롯 상세 태그가 첫 범주만 보이던 문제 수정 (#21587)
- [RFC-0264] Memory OS recall outcome-anchored eval harness (#21579)
- fix(test): split keeper effective meta runtime aliases (#21596)
- refactor(workspace): use Result syntax in lib/workspace/workspace_utils_ops.ml (#21581)
- refactor(server): use Result syntax in lib/server/server_auth.ml (#21582)
- refactor(workspace): remove dead force_release_task_outcome_r (#21589)
- fix(keeper): normalize multimodal rich chat payloads (#21600)
- feat(runtime): add [runtime].cross_verifier knob for anti-rationalization evaluator (#21602)
- fix(dashboard): preserve structured keeper errors (#21609)
- feat(fusion): render fusion deliberation as expandable keeper chat cards (#21611)
- refactor(keeper): stop emitting derived counts from hook introspection JSON (#21604)
- feat(dashboard): group keeper-agnostic hook block under collapsible "전역 런타임 아키텍처" (#21597)
- refactor(keeper): reuse String_util for multimodal MIME checks (#21615)
- fix(fusion): annotate run_id default as sound-partial for DET/NDT gate (#21614)
- fix(test): reference Runtime directly in keeper_effective_meta_overlay (#21616)
- feat(runtime): startup capability gate + consume OAS thinking-control guard (pin bump) (#21607)
- fix(test): annotate effective meta record scope (#21621)
- refactor(verification): use Result syntax in lib/verification.ml (#21592)
- refactor(workspace): use Result syntax in workspace_eio.ml (#21593)
- [RFC-0264 P2] Memory OS recall injection ledger (#21603)
- fix(keeper): restore effective meta build and persona sync (#21601)
- fix(runtime): require JSON-capable cross verifier (#21613)
- feat(dashboard): 컴팩션 토큰 게이트 편집 가능화 (dead-control 해소) (#21608)
- refactor(runtime): use Result syntax in lib/runtime/runtime.ml (#21588)
- tool orchestration read batch planning (#21606)
- feat(dashboard): add tool denylist editor (set_policy) + fix tool_access typing (#21623)
- chore(runtime): lock provider_d-http/-cli rejection, fix stale alias doc (#21625)
- chore(dashboard): drop redundant explicit *-v2.css imports from main.ts (#21610)
- refactor(voice): use Result syntax in lib/voice/voice_bridge.ml (#21590)
- refactor(keeper): use Result syntax in keeper_tool_filesystem_runtime.ml (#21591)
- refactor(goal): use Result syntax in lib/goal/goal_verification.ml (#21595)
- fix(dashboard): expose keeper runtime policy controls (#21598)
- chore(oas): sync KEEPER-USER-MANUAL pin doc (#21607 follow-up) (#21626)
- refactor(keeper): use Result syntax in keeper_tool_surface_ops.ml (#21605)
- fix(keeper): improve result safety in keeper_memory_os_io.ml (#21617)
- fix(server): improve result safety in lib/server/server_ide_lsp_proxy.ml (#21618)
- fix(keeper): improve result safety in keeper_unified_turn.ml (#21619)
- fix(keeper): improve result safety in lib/keeper/keeper_tool_execute_runtime.ml (#21620)
- fix(autonomous): improve result safety in stimulus.ml (#21622)
- feat(fusion): render fusion card content as markdown + surface synthesis/usage (#21629)
- test(keeper): contract-lock the hook-slot introspection (drift guard) (#21628)
- fix(dashboard): align runtime list controls (#21630)
- feat(dashboard): add standalone Approvals surface (keeper HITL queue) (#21624)
- fix(librarian): tolerate malformed episode JSON and update retry nudge (#21631)
- fix(dashboard): share approval risk visual banding (#21635)
- test(keeper): cross-check hook introspection runtime slots (#21636)
- fix(runtime): move OAS capability gate out of load_list to startup (#21638)
- fix(tool_library): match keeper_library_read by frontmatter title, not just slug (#21637)
- feat(fusion): lead the card with judge synthesis, collapse panels by default (#21639)
- redesign logs surface (#21640)
- docs(dashboard): correct tool-denylist editor's tool_access rationale + test empty allowlist (#21634)
- fix(dashboard): restore fusion card focus ring and lock 3-gate fusion coverage (#21643)
- purge: remove 44 verified-dead modules/files (~-3k LoC) (#21560)
- fix keeper msg cancellation status (#21642)
- feat(memory-os): RFC-0259 P1 — volatile external_ref classification + decay (#21644)
- fix(dashboard): make the Work board show goals and unassigned tasks (#21645)
- Update Ollama Cloud runtime seed capabilities (#21647)
- chore(dashboard): relabel Copilot Dock surfaces to Chat (#21648)
- fix(dashboard): render keeper chat markdown richly and surface tool calls (#21646)
- docs(rfc): RFC-0233 §7 amendment — Turn_ref chat↔board turn-identity (#21649)
- fix(ci): boot release-evidence smoke with a catalog-known model (#21652)
- fix(task): drop unimplemented auto-link claim from goal_id tool schema (#21653)
- [codex] Render fusion evidence on board posts (#21658)
- refactor(workspace): type completion authority, retire ~force:bool (RFC-0262 Phase 1) (#21612)
- dashboard: add fusion surface (#21657)
- docs(rfc): RFC-0266 fusion async-completion wake + in-progress visibility (#21655)
- feat(types): RFC-0233 §7 PR-A1 — Turn_ref + TurnRecord turn-identity field (#21662)
- fix memory os concurrency guards (#21660)
- test(task): lock verification self-verdict guardrail (#21654)
- fix(keeper): cap quota-driven runtime rotation (#21661)
- Add all Ollama Cloud runtime seed models (#21656)
- feat(memory-os): RFC-0259 P2 — grounding reconciler (dry-run, default-OFF) (#21665)
- fix(dashboard): call ringFocusClasses() on fusion surface buttons (#21666)
- Implement scheduled automation recurrence dispatch (#21669)
- Document schedule timezone contract (#21671)
- fix(schedule): make daily recurrence offset contract explicit (#21674)
- fix memory os episode bundle consistency (#21673)
- fix(ws): harden discovery and inbound backpressure (#21672)
- feat(runtime): RFC-0265 capability-driven proactive modality reroute (#21641)
- fix(keeper-prompt): remove non-existent masc_claim_next tool and false current_task_id field (#21679)
- feat(fusion): wake calling keeper on async fusion completion (RFC-0266 Phase 1) (#21677)
- feat(keeper): persist Turn_ref on keeper chat rows (RFC-0233 §7) (#21680)
- fix(keeper): keep turn event bus drain alive (#21659)
- test(completion-trust): add §9 dispatch reject oracle (RFC-0262 E1 scripted backbone) (#21681)
- [codex] Define rich connector turn projection design (#21664)
- fix(consolidator): replace hardcoded generation=0 with next_generation call
- fix: add ~trace_id to next_generation calls in keeper_turn_up_create.ml
