### PR TITLE
feat(memory): project draft skill candidates

### DIFF
--- a/lib/skill_candidate_projection.ml
+++ b/lib/skill_candidate_projection.ml
@@ -1,0 +1,280 @@
+(** Read-side draft skill candidates derived from MASC memory. *)
+
+type promotion_state = Candidate
+
+type skill_candidate =
+  { id : string
+  ; agent_name : string
+  ; source_kind : string
+  ; source_id : string
+  ; source_ref : string
+  ; pattern : string
+  ; evidence_refs : string list
+  ; success_count : int
+  ; failure_count : int
+  ; confidence : float
+  ; applicable_tools : string list
+  ; promotion_state : promotion_state
+  ; risk_notes : string list
+  }
+
+let promotion_state_to_string = function Candidate -> "candidate"
+
+let is_slug_char = function
+  | 'a' .. 'z' | '0' .. '9' | '-' | '_' -> true
+  | _ -> false
+;;
+
+let slugify raw =
+  let raw = raw |> String.trim |> String.lowercase_ascii in
+  let buf = Buffer.create (String.length raw) in
+  String.iter
+    (fun ch -> Buffer.add_char buf (if is_slug_char ch then ch else '-'))
+    raw;
+  let s = Buffer.contents buf in
+  let len = String.length s in
+  let rec left i =
+    if i >= len then len else if Char.equal s.[i] '-' then left (i + 1) else i
+  in
+  let rec right i =
+    if i < 0 then -1 else if Char.equal s.[i] '-' then right (i - 1) else i
+  in
+  let l = left 0 in
+  let r = right (len - 1) in
+  if l > r then "untitled" else String.sub s l (r - l + 1)
+;;
+
+let has_uri_scheme s =
+  let len = String.length s in
+  let rec loop i =
+    if i + 2 >= len
+    then false
+    else if Char.equal s.[i] ':' && Char.equal s.[i + 1] '/' && Char.equal s.[i + 2] '/'
+    then i > 0
+    else loop (i + 1)
+  in
+  loop 0
+;;
+
+let dedup_preserve_order xs =
+  let seen = Hashtbl.create 8 in
+  List.filter
+    (fun x ->
+      if Hashtbl.mem seen x
+      then false
+      else (
+        Hashtbl.add seen x ();
+        true))
+    xs
+;;
+
+let source_procedure_ref (p : Procedural_memory.procedure) =
+  Printf.sprintf "procedure://%s/%s" (slugify p.agent_name) (slugify p.id)
+;;
+
+let source_memory_fact_ref ~agent_name (fact : Keeper_memory_os_types.fact) =
+  Printf.sprintf "memory-os-fact://%s/%s/%s" (slugify agent_name)
+    (slugify fact.source.trace_id)
+    (slugify (Keeper_memory_os_types.normalize_claim fact.claim))
+;;
+
+let evidence_ref_of_procedure p evidence =
+  let evidence = String.trim evidence in
+  if String.equal evidence ""
+  then None
+  else if has_uri_scheme evidence
+  then Some evidence
+  else
+    Some
+      (Printf.sprintf "%s/evidence/%s" (source_procedure_ref p) (slugify evidence))
+;;
+
+let evidence_refs (p : Procedural_memory.procedure) =
+  source_procedure_ref p
+  :: (p.evidence |> List.filter_map (evidence_ref_of_procedure p))
+  |> dedup_preserve_order
+;;
+
+let candidate_id ~source_kind ~source_id =
+  match source_kind with
+  | "procedure" -> Printf.sprintf "skill-candidate-%s" (slugify source_id)
+  | _ -> Printf.sprintf "skill-candidate-%s-%s" (slugify source_kind) (slugify source_id)
+;;
+
+let procedure_risk_notes =
+  [ "generated from procedural memory; requires human approval before installation"
+  ; "verify evidence refs before promoting to an approved skill"
+  ; "applicable tools require human curation before approval"
+  ]
+;;
+
+let memory_fact_risk_notes =
+  [ "generated from Memory OS fact; requires human approval before installation"
+  ; "numeric outcome confidence is unavailable until linked evidence is curated"
+  ; "validated_approach and lesson facts are advisory until evidence is reviewed"
+  ; "do not inject into keeper prompts before approval"
+  ]
+;;
+
+let candidate_of_procedure (p : Procedural_memory.procedure) =
+  if not (Procedural_memory.is_crystallized p)
+  then None
+  else
+    let source_kind = "procedure" in
+    let source_id = p.id in
+    let source_ref = source_procedure_ref p in
+    Some
+      { id = candidate_id ~source_kind ~source_id
+      ; agent_name = p.agent_name
+      ; source_kind
+      ; source_id
+      ; source_ref
+      ; pattern = p.pattern
+      ; evidence_refs = evidence_refs p
+      ; success_count = p.success_count
+      ; failure_count = p.failure_count
+      ; confidence = p.confidence
+      ; applicable_tools = []
+      ; promotion_state = Candidate
+      ; risk_notes = procedure_risk_notes
+      }
+;;
+
+let is_memory_fact_skill_candidate (fact : Keeper_memory_os_types.fact) =
+  match fact.category with
+  | Keeper_memory_os_types.Validated_approach | Keeper_memory_os_types.Lesson -> true
+  | Keeper_memory_os_types.Code_change
+  | Keeper_memory_os_types.Fact
+  | Keeper_memory_os_types.Preference
+  | Keeper_memory_os_types.Blocker
+  | Keeper_memory_os_types.Goal
+  | Keeper_memory_os_types.Constraint
+  | Keeper_memory_os_types.Ephemeral
+  | Keeper_memory_os_types.Unknown _ -> false
+;;
+
+let memory_fact_source_id (fact : Keeper_memory_os_types.fact) =
+  Printf.sprintf "%s-%s" fact.source.trace_id
+    (Keeper_memory_os_types.normalize_claim fact.claim)
+;;
+
+let memory_fact_evidence_refs ~agent_name (fact : Keeper_memory_os_types.fact) =
+  let trace_ref =
+    Printf.sprintf "keeper-turn://%s/%d" (slugify fact.source.trace_id) fact.source.turn
+  in
+  let tool_ref =
+    fact.source.tool_call_id
+    |> Option.map (fun tool_call_id -> Printf.sprintf "tool-call://%s" (slugify tool_call_id))
+  in
+  [ Some (source_memory_fact_ref ~agent_name fact); Some trace_ref; tool_ref ]
+  |> List.filter_map Fun.id
+  |> dedup_preserve_order
+;;
+
+let candidate_of_memory_fact ~agent_name (fact : Keeper_memory_os_types.fact) =
+  if not (is_memory_fact_skill_candidate fact)
+  then None
+  else
+    let source_kind = "memory_os_fact" in
+    let source_id = memory_fact_source_id fact in
+    let source_ref = source_memory_fact_ref ~agent_name fact in
+    Some
+      { id = candidate_id ~source_kind ~source_id
+      ; agent_name
+      ; source_kind
+      ; source_id
+      ; source_ref
+      ; pattern = fact.claim
+      ; evidence_refs = memory_fact_evidence_refs ~agent_name fact
+      ; success_count = 0
+      ; failure_count = 0
+      ; confidence = 0.0
+      ; applicable_tools = []
+      ; promotion_state = Candidate
+      ; risk_notes = memory_fact_risk_notes
+      }
+;;
+
+let candidates_of_procedures procedures =
+  procedures
+  |> List.filter_map candidate_of_procedure
+  |> List.sort (fun a b -> Float.compare b.confidence a.confidence)
+;;
+
+let candidates_of_memory_facts ~agent_name facts =
+  facts
+  |> List.filter_map (candidate_of_memory_fact ~agent_name)
+  |> List.sort (fun a b -> Float.compare b.confidence a.confidence)
+;;
+
+let top_candidates ~agent_name ~limit =
+  Procedural_memory.top_procedures ~agent_name ~limit |> candidates_of_procedures
+;;
+
+let string_list_json xs = `List (List.map (fun s -> `String s) xs)
+
+let to_json (c : skill_candidate) : Yojson.Safe.t =
+  `Assoc
+    [ "schema", `String "masc.skill_candidate_projection.v1"
+    ; "id", `String c.id
+    ; "agent_name", `String c.agent_name
+    ; "source_kind", `String c.source_kind
+    ; "source_id", `String c.source_id
+    ; "source_ref", `String c.source_ref
+    ; "pattern", `String c.pattern
+    ; "evidence_refs", string_list_json c.evidence_refs
+    ; "success_count", `Int c.success_count
+    ; "failure_count", `Int c.failure_count
+    ; "confidence", `Float c.confidence
+    ; "applicable_tools", string_list_json c.applicable_tools
+    ; "promotion_state", `String (promotion_state_to_string c.promotion_state)
+    ; "risk_notes", string_list_json c.risk_notes
+    ]
+;;
+
+let bullet_list = function
+  | [] -> "- (none)"
+  | xs -> xs |> List.map (Printf.sprintf "- %s") |> String.concat "\n"
+;;
+
+let render_skill_draft (c : skill_candidate) =
+  Printf.sprintf
+    {|---
+name: %s
+description: "Draft skill candidate generated from MASC memory; requires approval before use."
+---
+
+# %s
+
+Status: %s
+Agent: %s
+Source: %s
+Confidence: %.3f
+
+## When To Use
+
+%s
+
+## Evidence
+
+%s
+
+## Applicable Tools
+
+%s
+
+## Guardrails
+
+%s
+|}
+    (slugify c.id)
+    c.id
+    (promotion_state_to_string c.promotion_state)
+    c.agent_name
+    c.source_ref
+    c.confidence
+    c.pattern
+    (bullet_list c.evidence_refs)
+    (bullet_list c.applicable_tools)
+    (bullet_list c.risk_notes)
+;;

--- a/lib/skill_candidate_projection.mli
+++ b/lib/skill_candidate_projection.mli
@@ -1,0 +1,67 @@
+(** Skill_candidate_projection — read-side draft skill candidates from MASC
+    memory.
+
+    This module is deliberately advisory. It projects crystallized procedures
+    into reviewable skill candidates, but never installs skills or injects them
+    into keeper prompts. *)
+
+type promotion_state = Candidate
+
+type skill_candidate =
+  { id : string
+  ; agent_name : string
+  ; source_kind : string
+  ; source_id : string
+  ; source_ref : string
+  ; pattern : string
+  ; evidence_refs : string list
+  ; success_count : int
+  ; failure_count : int
+  ; confidence : float
+  ; applicable_tools : string list
+  ; promotion_state : promotion_state
+  ; risk_notes : string list
+  }
+
+val promotion_state_to_string : promotion_state -> string
+
+(** Stable URI for a procedure row. *)
+val source_procedure_ref : Procedural_memory.procedure -> string
+
+(** Stable URI for a Memory OS fact row. *)
+val source_memory_fact_ref
+  :  agent_name:string
+  -> Keeper_memory_os_types.fact
+  -> string
+
+(** Project one crystallized procedure into a candidate. Non-crystallized
+    procedures return [None]. *)
+val candidate_of_procedure : Procedural_memory.procedure -> skill_candidate option
+
+(** Project one Memory OS fact into a candidate. Only [Validated_approach] and
+    [Lesson] facts are eligible; other facts return [None]. *)
+val candidate_of_memory_fact
+  :  agent_name:string
+  -> Keeper_memory_os_types.fact
+  -> skill_candidate option
+
+(** Project and sort candidates by confidence. *)
+val candidates_of_procedures : Procedural_memory.procedure list -> skill_candidate list
+
+(** Project eligible Memory OS facts and sort them by confidence. Memory OS facts
+    do not carry numeric outcome confidence, so candidates use [0.0] until a
+    human or verifier links concrete outcome evidence. *)
+val candidates_of_memory_facts
+  :  agent_name:string
+  -> Keeper_memory_os_types.fact list
+  -> skill_candidate list
+
+(** Load the top crystallized procedures for [agent_name] and project them to
+    candidates. *)
+val top_candidates : agent_name:string -> limit:int -> skill_candidate list
+
+val to_json : skill_candidate -> Yojson.Safe.t
+
+(** Render a human-reviewable SKILL.md draft. The rendered text remains marked
+    as [candidate] and must not be installed without approval. *)
+val render_skill_draft : skill_candidate -> string

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -2,13 +2,15 @@
 
 open Alcotest
 module P = Masc.Procedural_memory
+module S = Masc.Skill_candidate_projection
+module M = Masc.Keeper_memory_os_types
 
 let procedure ?(evidence = []) ?(success_count = 0) ?(failure_count = 0)
-    ?(confidence = 0.0) () : P.procedure =
+    ?(confidence = 0.0) ?(id = "proc-test") ?(pattern = "When a pattern appears, reuse the learned action") () : P.procedure =
   {
-    id = "proc-test";
+    id;
     agent_name = "keeper";
-    pattern = "When a pattern appears, reuse the learned action";
+    pattern;
     evidence;
     success_count;
     failure_count;
@@ -61,6 +63,111 @@ let test_single_perfect_does_not_crystallize () =
     (P.is_crystallized p)
 ;;
 
+let require_candidate p =
+  match S.candidate_of_procedure p with
+  | Some c -> c
+  | None -> fail "expected skill candidate"
+;;
+
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop i =
+    if i + needle_len > haystack_len
+    then false
+    else if String.equal (String.sub haystack i needle_len) needle
+    then true
+    else loop (i + 1)
+  in
+  String.equal needle "" || loop 0
+;;
+
+let test_skill_candidate_projects_crystallized_procedure () =
+  let p =
+    procedure ~id:"Proc Review Loop" ~evidence:[ "task://T-1"; "decision 2" ]
+      ~success_count:3 ~failure_count:0 ~confidence:1.0 ()
+  in
+  let c = require_candidate p in
+  check string "candidate id" "skill-candidate-proc-review-loop" c.id;
+  check string "state" "candidate" (S.promotion_state_to_string c.promotion_state);
+  check (list string) "evidence refs"
+    [ "procedure://keeper/proc-review-loop"
+    ; "task://T-1"
+    ; "procedure://keeper/proc-review-loop/evidence/decision-2"
+    ]
+    c.evidence_refs
+;;
+
+let test_skill_candidate_rejects_uncrystallized_procedure () =
+  let p = procedure ~evidence:[ "only-once" ] ~success_count:1 ~confidence:1.0 () in
+  check bool "not a candidate" true (Option.is_none (S.candidate_of_procedure p))
+;;
+
+let memory_fact ?(category = M.Validated_approach) ?(trace_id = "trace-1") ?(turn = 7)
+    ?tool_call_id claim : M.fact =
+  let source : M.provenance_event = { trace_id; turn; tool_call_id } in
+  {
+    claim;
+    category;
+    external_ref = None;
+    source;
+    observed_by = [];
+    first_seen = 0.0;
+    valid_until = None;
+    last_verified_at = None;
+    schema_version = M.schema_version;
+  }
+;;
+
+let test_skill_candidate_projects_memory_os_lesson () =
+  let fact =
+    memory_fact ~category:M.Lesson ~tool_call_id:"tool 42"
+      "When rate-limit retry succeeds, use bounded backoff"
+  in
+  let c =
+    match S.candidate_of_memory_fact ~agent_name:"keeper" fact with
+    | Some c -> c
+    | None -> fail "expected memory fact candidate"
+  in
+  check string "source kind" "memory_os_fact" c.source_kind;
+  check string "state" "candidate" (S.promotion_state_to_string c.promotion_state);
+  check (float 0.0) "confidence awaits outcome evidence" 0.0 c.confidence;
+  check (list string) "memory evidence refs"
+    [ "memory-os-fact://keeper/trace-1/when-rate-limit-retry-succeeds-use-bounded-backoff"
+    ; "keeper-turn://trace-1/7"
+    ; "tool-call://tool-42"
+    ]
+    c.evidence_refs
+;;
+
+let test_skill_candidate_rejects_generic_memory_fact () =
+  let fact = memory_fact ~category:M.Fact "The repo uses OCaml 5" in
+  check bool "generic facts are not skill candidates" true
+    (Option.is_none (S.candidate_of_memory_fact ~agent_name:"keeper" fact))
+;;
+
+let test_skill_candidate_json_and_draft_are_candidate_only () =
+  let p =
+    procedure ~evidence:[ "proof-store://abc" ] ~success_count:3 ~failure_count:1
+      ~confidence:0.75 ()
+  in
+  let c = require_candidate p in
+  let json = S.to_json c in
+  let member key = function
+    | `Assoc fields -> List.assoc key fields
+    | _ -> `Null
+  in
+  check string "schema" "masc.skill_candidate_projection.v1"
+    (match member "schema" json with `String s -> s | _ -> "");
+  check string "promotion_state" "candidate"
+    (match member "promotion_state" json with `String s -> s | _ -> "");
+  let draft = S.render_skill_draft c in
+  check bool "draft status is explicit" true
+    (contains_substring ~needle:"Status: candidate" draft);
+  check bool "approval guard is explicit" true
+    (contains_substring ~needle:"requires human approval" draft)
+;;
+
 let () =
   run "procedural_memory"
     [
@@ -75,6 +182,19 @@ let () =
             test_rare_near_perfect_does_not_crystallize;
           test_case "single perfect does not crystallize" `Quick
             test_single_perfect_does_not_crystallize;
+        ] );
+      ( "skill candidates",
+        [
+          test_case "projects crystallized procedure" `Quick
+            test_skill_candidate_projects_crystallized_procedure;
+          test_case "rejects uncrystallized procedure" `Quick
+            test_skill_candidate_rejects_uncrystallized_procedure;
+          test_case "projects Memory OS lesson" `Quick
+            test_skill_candidate_projects_memory_os_lesson;
+          test_case "rejects generic Memory OS fact" `Quick
+            test_skill_candidate_rejects_generic_memory_fact;
+          test_case "renders candidate-only JSON and draft" `Quick
+            test_skill_candidate_json_and_draft_are_candidate_only;
         ] );
     ]
 ;;


### PR DESCRIPTION
Summary:
- add Skill_candidate_projection for read-side draft skill candidates from crystallized procedural memory
- project Memory OS Validated_approach/Lesson facts into candidate-only skill drafts with evidence refs
- keep candidates advisory: no skill installation, no prompt injection, approval required

Validation:
- opam exec -- ocamlformat --check lib/skill_candidate_projection.ml lib/skill_candidate_projection.mli test/test_procedural_memory.ml
- scripts/ocaml-structure-ratchet.sh
- scripts/ci/check-determinism-contract.sh
- git diff --check

Note:
- focused Dune target was not run locally because scripts/dune-local.sh refused to start while existing bare Dune processes were active; leaving build proof to CI per operator direction.