### PR TITLE
feat(dashboard): expose turn_ref on chat history API (RFC-0233 §7 PR-C chat)

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -79,6 +79,25 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out?.external_message_id).toBe('1498985300729172039')
   })
 
+  it('passes the RFC-0233 turn_ref join key through when present', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({ turn_ref: 'trace-1780648779957-00000#4071' }),
+    )
+    expect(out?.turn_ref).toBe('trace-1780648779957-00000#4071')
+  })
+
+  it('leaves turn_ref undefined on legacy rows without dropping the message', () => {
+    const out = safeParseKeeperChatHistoryMessage(validMessage())
+    expect(out).not.toBeNull()
+    expect(out?.turn_ref).toBeUndefined()
+  })
+
+  it('returns null when turn_ref has the wrong type', () => {
+    expect(
+      safeParseKeeperChatHistoryMessage(validMessage({ turn_ref: 4071 })),
+    ).toBeNull()
+  })
+
   it('passes surface ref fields through when present', () => {
     const out = safeParseKeeperChatHistoryMessage(
       validMessage({

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -145,6 +145,14 @@ export const KeeperChatHistoryMessageSchema = object({
   speaker_id: optional(string()),
   speaker_name: optional(string()),
   speaker_authority: optional(string()),
+  // RFC-0233 §7: turn join key "<trace_id>#<absolute_turn>" the keeper minted
+  // onto every row of the turn (keeper_chat_store.ml to_json_array emits it).
+  // Read-only here; the board post that the same turn produced carries the
+  // identical string in its origin, so a board post can anchor to the exact
+  // chat turn. Optional for the deploy window and legacy rows (absent ->
+  // undefined, never drops the message). Consumed for navigation in a
+  // follow-up (KeeperConversationEntry.turnRef).
+  turn_ref: optional(string()),
   // RFC-0235 P1/P3: audio clip field. The wire object is accepted as
   // `unknown` at the boundary so malformed clips do not cause the whole
   // message to be dropped; `normalizeAudioClip` validates before use.


### PR DESCRIPTION
## 무엇을 / 왜

RFC-0233 §7(Turn_ref 계약)의 **PR-C (chat 절반) — dashboard chat history API에 `turn_ref?` 노출**. keeper chat-history wire는 이미 turn join 키 `"<trace_id>#<absolute_turn>"`를 싣고 있고(`keeper_chat_store.ml` `to_json_array`, PR-A에서 랜딩), 이 PR이 그것을 dashboard API 경계에서 파싱·노출해 chat 턴을 그 턴이 만든 board post와 매칭할 수 있게 한다.

## 범위 결정 (chat/board 분할)

PR-C는 의존성 경계로 두 갈래다:
- **chat `turn_ref?`** → PR-A(머지됨)에만 의존, **프론트엔드만**(OCaml은 이미 emit). → **이 PR**.
- **board `origin?`** → PR-B(#21732, 미머지)에 의존 + 대시보드 board 직렬화가 `post_to_yojson`가 아닌 4+곳 중복 인라인 serializer라 N-of-M OCaml 변경 필요 + main base-broken(#21721)으로 빌드검증 막힘. → **별도 follow-up**(PR-B+#21730 머지 후).

분할 근거: chat 절반은 머지된 PR-A에만 의존해 main에 독립적으로 검증·머지 가능하고, board 절반의 미머지·base-broken·N-of-M 리스크와 섞지 않는다.

## 변경 (프론트엔드 전용)

- `KeeperChatHistoryMessageSchema`에 `turn_ref: optional(string())` 추가(snake_case=wire 일치). `InferOutput`이 `KeeperChatHistoryMessage` 타입에 자동 carry, `fetchKeeperChatHistory`는 파싱된 메시지를 그대로 반환(whitelist 아님)하므로 API 소비자까지 도달. deploy window·legacy 행 대비 optional: 부재 시 `undefined`로 디코드하고 **메시지를 절대 drop하지 않음**.

OCaml 변경 0. nav 소비(`KeeperConversationEntry.turnRef`)는 PR-D.

## 검증

- `keeper-chat-history.test.ts`: turn_ref present→carry / absent→undefined(메시지 보존) / 잘못된 타입→null. **vitest 21/21**, **`tsc --noEmit` clean(exit 0)**.

## Workaround Guards (RFC-0233 §7.6 준수)

- typed join 키를 그대로 통과(파생·window join·substring 아님). optional이라 backend-ahead deploy/legacy에서 row drop 없음(3-gate: zod 통과 → 소비자 spread, normalize whitelist 없음).

Refs: RFC-0233 §7 (§7.5 PR-C). Follows PR-A (MERGED). board 절반은 PR-B #21732 의존 follow-up.
