### PR TITLE
feat(keeper): project delegation requests

### DIFF
--- a/config/prompts/keeper.deliberation.md
+++ b/config/prompts/keeper.deliberation.md
@@ -20,7 +20,7 @@ Available actions (pick exactly one):
 - board_post: Post to the community board. Requires content and optional hearth.
 - board_comment: Comment on a board post. Requires post_id and content.
 - board_vote: Vote on a board post. Requires post_id and direction (up/down).
-- propose_spawn: Propose spawning a new agent. Requires topic and reason.{{multi_step_line}}
+- propose_spawn: Propose a delegation request for operator/keeper routing. Requires topic and reason. This records a MASC task seed; it does not directly spawn an agent.{{multi_step_line}}
 
 When self_directed_explore triggers, prefer actions that create value: board_post, board_comment, or broadcast. Avoid noop unless truly nothing is worth doing. (To create a task, call the `keeper_task_create` tool directly in your next turn — it is not a deliberation action.)
 

--- a/lib/keeper/keeper_delegation_request.ml
+++ b/lib/keeper/keeper_delegation_request.ml
@@ -1,0 +1,202 @@
+(** Keeper delegation requests projected from deliberation. *)
+
+open Keeper_deliberation
+
+type promotion_state =
+  | Candidate
+  | Promoted
+  | Rejected
+
+let promotion_state_to_string = function
+  | Candidate -> "candidate"
+  | Promoted -> "promoted"
+  | Rejected -> "rejected"
+
+type task_seed = {
+  title : string;
+  description : string;
+  tags : string list;
+}
+
+type t = {
+  id : string;
+  requester : string;
+  topic : string;
+  reason : string;
+  goal : string option;
+  source_action : string;
+  promotion_state : promotion_state;
+  task_seed : task_seed;
+}
+
+let normalize_opt value =
+  match String.trim value with
+  | "" -> None
+  | text -> Some text
+
+let compact_whitespace text =
+  let buf = Buffer.create (String.length text) in
+  let pending_space = ref false in
+  String.iter
+    (fun ch ->
+      match ch with
+      | ' ' | '\n' | '\r' | '\t' ->
+          pending_space := Buffer.length buf > 0
+      | _ ->
+          if !pending_space then Buffer.add_char buf ' ';
+          pending_space := false;
+          Buffer.add_char buf ch)
+    (String.trim text);
+  Buffer.contents buf
+
+let truncate ~max_len text =
+  if String.length text <= max_len then text
+  else
+    let rec utf8_boundary idx =
+      if idx <= 0 then 0
+      else if Char.code text.[idx] land 0xc0 = 0x80 then utf8_boundary (idx - 1)
+      else idx
+    in
+    String.sub text 0 (utf8_boundary max_len)
+
+let digest_id ~requester ?goal ~topic ~reason =
+  let goal_text =
+    match goal with
+    | Some text -> text
+    | None -> ""
+  in
+  let raw =
+    String.concat "\n"
+      [
+        requester;
+        topic;
+        reason;
+        goal_text;
+      ]
+  in
+  let hex = Digest.to_hex (Digest.string raw) in
+  "delegation-" ^ String.sub hex 0 12
+
+let task_seed ~requester ?goal ~topic ~reason () =
+  let title_topic = topic |> compact_whitespace |> truncate ~max_len:80 in
+  let title =
+    if title_topic = "" then "Delegate keeper work"
+    else "Delegate: " ^ title_topic
+  in
+  let reason =
+    match compact_whitespace reason with
+    | "" -> "(no reason supplied)"
+    | text -> text
+  in
+  let goal_lines =
+    match goal with
+    | Some goal -> [ ""; "Goal:"; goal ]
+    | None -> []
+  in
+  let description =
+    String.concat "\n"
+      ([
+         "Delegation request from keeper `" ^ requester ^ "`.";
+         "";
+         "Topic:";
+         topic;
+         "";
+         "Reason:";
+         reason;
+       ]
+      @ goal_lines
+      @ [
+          "";
+          "Execution contract:";
+          "- This is a MASC task seed, not a direct child-agent spawn.";
+          "- Promote by creating/assigning a task or routing to an existing keeper.";
+          "- Do not invoke generic OAS swarm orchestration from this artifact.";
+        ])
+  in
+  let tags =
+    [
+      "keeper_delegation";
+      "propose_spawn";
+      "requester:" ^ requester;
+    ]
+    @
+    match goal with
+    | Some _ -> [ "has_goal" ]
+    | None -> []
+  in
+  { title; description; tags }
+
+let make ~requester ?goal ~topic ~reason () =
+  let requester =
+    match compact_whitespace requester with
+    | "" -> "unknown"
+    | text -> text
+  in
+  let topic = compact_whitespace topic in
+  let reason = compact_whitespace reason in
+  let goal = Option.bind goal normalize_opt in
+  let source_action =
+    deliberation_action_to_string (ProposeSpawn { topic; reason })
+  in
+  {
+    id = digest_id ~requester ?goal ~topic ~reason;
+    requester;
+    topic;
+    reason;
+    goal;
+    source_action;
+    promotion_state = Candidate;
+    task_seed = task_seed ~requester ?goal ~topic ~reason ();
+  }
+
+let rec of_action ~requester ?goal = function
+  | ProposeSpawn { topic; reason } ->
+      Some (make ~requester ?goal ~topic ~reason ())
+  | MultiStep actions ->
+      let rec first = function
+        | [] -> None
+        | action :: rest -> (
+            match of_action ~requester ?goal action with
+            | Some _ as request -> request
+            | None -> first rest)
+      in
+      first actions
+  | Noop _ | BoardPost _ | BoardComment _ | BoardVote _ | TaskClaim _
+  | Broadcast _ ->
+      None
+
+let of_execution_result ~requester ?goal result =
+  of_action ~requester ?goal result.selected_action
+
+let task_seed_to_json seed =
+  `Assoc
+    [
+      ("title", `String seed.title);
+      ("description", `String seed.description);
+      ("tags", `List (List.map (fun tag -> `String tag) seed.tags));
+    ]
+
+let to_json request =
+  `Assoc
+    [
+      ("schema", `String "masc.keeper_delegation_request.v1");
+      ("id", `String request.id);
+      ("requester", `String request.requester);
+      ("topic", `String request.topic);
+      ("reason", `String request.reason);
+      ("goal", Json_util.string_opt_to_json request.goal);
+      ("source_action", `String request.source_action);
+      ( "promotion_state",
+        `String (promotion_state_to_string request.promotion_state) );
+      ("task_seed", task_seed_to_json request.task_seed);
+    ]
+
+let delegation_request_json ~requester ?goal = function
+  | Some execution -> (
+      match of_execution_result ~requester ?goal execution with
+      | Some request -> to_json request
+      | None -> `Null)
+  | None -> `Null
+
+let delegation_request_field ~requester ?goal execution =
+  ("delegation_request", delegation_request_json ~requester ?goal execution)

--- a/lib/keeper/keeper_delegation_request.mli
+++ b/lib/keeper/keeper_delegation_request.mli
@@ -1,0 +1,63 @@
+(** Keeper delegation requests projected from deliberation.
+
+    This module does not spawn agents.  It turns a keeper's
+    [propose_spawn] deliberation into a human/promoter-readable MASC task
+    seed so existing task, board, and keeper surfaces can decide whether and
+    how to route the work. *)
+
+type promotion_state =
+  | Candidate
+  | Promoted
+  | Rejected
+
+val promotion_state_to_string : promotion_state -> string
+
+type task_seed = {
+  title : string;
+  description : string;
+  tags : string list;
+}
+
+type t = {
+  id : string;
+  requester : string;
+  topic : string;
+  reason : string;
+  goal : string option;
+  source_action : string;
+  promotion_state : promotion_state;
+  task_seed : task_seed;
+}
+
+val make :
+  requester:string -> ?goal:string -> topic:string -> reason:string -> unit -> t
+
+val of_action :
+  requester:string ->
+  ?goal:string ->
+  Keeper_deliberation.deliberation_action ->
+  t option
+(** [of_action] projects the first [propose_spawn] in a [multi_step] action.
+    Multiple spawn proposals are intentionally first-wins so the dashboard
+    surfaces keep a single deterministic delegation artifact. *)
+
+val of_execution_result :
+  requester:string ->
+  ?goal:string ->
+  Keeper_deliberation.execution_result ->
+  t option
+
+val task_seed_to_json : task_seed -> Yojson.Safe.t
+val to_json : t -> Yojson.Safe.t
+
+val delegation_request_json :
+  requester:string ->
+  ?goal:string ->
+  Keeper_deliberation.execution_result option ->
+  Yojson.Safe.t
+
+val delegation_request_field :
+  requester:string ->
+  ?goal:string ->
+  Keeper_deliberation.execution_result option ->
+  string * Yojson.Safe.t

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -206,6 +206,8 @@ let append_decision_record
           | Some execution ->
               Keeper_deliberation.execution_result_to_json execution
           | None -> `Null );
+        Keeper_delegation_request.delegation_request_field ~requester:meta.name
+          ~goal:meta.goal deliberation_execution;
         ( "response_preview", Json_util.string_opt_to_json response_preview );
         ( "response_preview_2000",
           match result with

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -164,6 +164,8 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
           | Some execution ->
               Keeper_deliberation.execution_result_to_json execution
           | None -> `Null );
+        Keeper_delegation_request.delegation_request_field ~requester:meta.name
+          ~goal:meta.goal deliberation_execution;
         ("runtime",
          match result.runtime_observation with
          | Some observation -> redacted_runtime_observation_to_json observation

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -4,6 +4,7 @@ end
 module Tool : module type of Masc_task_handlers.Tool_task
 module Anti_rationalization : module type of Masc_task_handlers.Anti_rationalization
 module Dispatch : module type of Masc_task_handlers.Task_dispatch
+module Goal_assignment : module type of Masc_task_handlers.Task_goal_assignment
 module Transition_state : module type of Masc_task_handlers.Task_transition_state
 module Schemas : module type of Masc_task_handlers.Tool_task_schemas
 module Payloads : module type of Masc_task_handlers.Tool_task_payloads

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -4,7 +4,6 @@ end
 module Tool : module type of Masc_task_handlers.Tool_task
 module Anti_rationalization : module type of Masc_task_handlers.Anti_rationalization
 module Dispatch : module type of Masc_task_handlers.Task_dispatch
-module Goal_assignment : module type of Masc_task_handlers.Task_goal_assignment
 module Transition_state : module type of Masc_task_handlers.Task_transition_state
 module Schemas : module type of Masc_task_handlers.Tool_task_schemas
 module Payloads : module type of Masc_task_handlers.Tool_task_payloads

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module D = Masc.Keeper_deliberation
+module R = Masc.Keeper_delegation_request
 module Keeper_types = Keeper_types
 
 let has_prompt_root path =
@@ -33,6 +34,15 @@ let contains_substring text needle =
     ignore (Str.search_forward (Str.regexp_string needle) text 0);
     true
   with Not_found -> false
+
+let json_field key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let json_string_field key json =
+  match json_field key json with
+  | Some (`String value) -> value
+  | _ -> fail ("expected string field " ^ key)
 
 let test_triage_skip_on_empty_observation () =
   let result = D.triage base_obs in
@@ -354,7 +364,9 @@ let test_prompt_contains_action_list () =
      with Not_found -> false);
   check bool "mentions broadcast action" true
     (try ignore (Str.search_forward (Str.regexp_string "broadcast") prompt 0); true
-     with Not_found -> false)
+     with Not_found -> false);
+  check bool "mentions delegation request semantics" true
+    (contains_substring prompt "does not directly spawn an agent")
 
 (* ---------- parse_deliberation_response tests ---------- *)
 
@@ -493,6 +505,66 @@ let test_execute_structured_result_falls_back_to_baseline () =
   | D.Noop reason ->
       check string "fallback noop" "no_trigger" reason
   | _ -> fail "expected fallback noop action"
+
+let test_delegation_request_from_propose_spawn_action () =
+  let request =
+    match
+      R.of_action ~requester:"planner" ~goal:"ship scheduler hardening"
+        (D.ProposeSpawn
+           {
+             topic = "Audit Slack connector rendering";
+             reason = "needs channel-specific formatter work";
+           })
+    with
+    | Some request -> request
+    | None -> fail "expected delegation request"
+  in
+  check string "requester" "planner" request.requester;
+  check string "source action" "propose_spawn" request.source_action;
+  check string "promotion state" "candidate"
+    (R.promotion_state_to_string request.promotion_state);
+  check string "task title" "Delegate: Audit Slack connector rendering"
+    request.task_seed.title;
+  check bool "requester tag" true
+    (List.mem "requester:planner" request.task_seed.tags);
+  check bool "spawn is not direct" true
+    (contains_substring request.task_seed.description
+       "not a direct child-agent spawn")
+
+let test_delegation_request_from_execution_result_uses_selected_action () =
+  let obs = D.{ base_obs with active_goal_count = 1 } in
+  let structured =
+    D.
+      {
+        action =
+          ProposeSpawn
+            {
+              topic = "Review non-dashboard rendering";
+              reason = "existing channels lose rich blocks";
+            };
+        reasoning = "delegate channel-specific work";
+        confidence = 0.7;
+      }
+  in
+  let result = D.execute_structured_result obs structured in
+  let request =
+    match R.of_execution_result ~requester:"rondo" ~goal:"connector parity" result with
+    | Some request -> request
+    | None -> fail "expected delegation request from selected action"
+  in
+  let json = R.to_json request in
+  check string "schema" "masc.keeper_delegation_request.v1"
+    (json_string_field "schema" json);
+  check string "json requester" "rondo"
+    (json_string_field "requester" json);
+  check string "json source action" "propose_spawn"
+    (json_string_field "source_action" json);
+  match json_field "task_seed" json with
+  | Some task_seed ->
+      check string "task seed title"
+        "Delegate: Review non-dashboard rendering"
+        (json_string_field "title" task_seed)
+  | None -> fail "expected task_seed"
 
 let test_parse_json_with_code_fences_rejected () =
   let raw =
@@ -1092,6 +1164,10 @@ let () =
             test_execute_structured_result_keeps_legal_action;
           test_case "falls back to baseline" `Quick
             test_execute_structured_result_falls_back_to_baseline;
+          test_case "delegation request from propose_spawn action" `Quick
+            test_delegation_request_from_propose_spawn_action;
+          test_case "delegation request from selected execution" `Quick
+            test_delegation_request_from_execution_result_uses_selected_action;
         ] );
       ( "parse_deliberation_response",
         [

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -566,6 +566,43 @@ let test_delegation_request_from_execution_result_uses_selected_action () =
         (json_string_field "title" task_seed)
   | None -> fail "expected task_seed"
 
+let test_delegation_request_multistep_first_spawn_wins () =
+  let action =
+    D.MultiStep
+      [
+        D.BoardPost { content = "announce intent"; hearth = None };
+        D.ProposeSpawn
+          { topic = "First delegation"; reason = "primary projection" };
+        D.ProposeSpawn
+          { topic = "Second delegation"; reason = "must not replace first" };
+      ]
+  in
+  match R.of_action ~requester:"planner" action with
+  | Some request ->
+      check string "first spawn topic" "First delegation" request.topic;
+      check string "first spawn reason" "primary projection" request.reason
+  | None -> fail "expected first delegation request"
+
+let test_delegation_request_id_includes_goal () =
+  let a =
+    R.make ~requester:"planner" ~goal:"goal-a" ~topic:"same topic"
+      ~reason:"same reason" ()
+  in
+  let b =
+    R.make ~requester:"planner" ~goal:"goal-b" ~topic:"same topic"
+      ~reason:"same reason" ()
+  in
+  check bool "goal changes id" true (not (String.equal a.id b.id))
+
+let test_delegation_request_title_truncates_utf8_boundary () =
+  let topic = String.make 79 'a' ^ "\xed\x95\x9c" in
+  let request =
+    R.make ~requester:"planner" ~topic ~reason:"unicode boundary" ()
+  in
+  check string "title stops before partial codepoint"
+    ("Delegate: " ^ String.make 79 'a')
+    request.task_seed.title
+
 let test_parse_json_with_code_fences_rejected () =
   let raw =
     "```json\n{\"action\":\"noop\",\"params\":{\"reason\":\"quiet\"},\"reasoning\":\"nothing\",\"confidence\":0.9}\n```"
@@ -1168,6 +1205,12 @@ let () =
             test_delegation_request_from_propose_spawn_action;
           test_case "delegation request from selected execution" `Quick
             test_delegation_request_from_execution_result_uses_selected_action;
+          test_case "delegation request multi_step first spawn wins" `Quick
+            test_delegation_request_multistep_first_spawn_wins;
+          test_case "delegation request id includes goal" `Quick
+            test_delegation_request_id_includes_goal;
+          test_case "delegation request truncates utf8 at boundary" `Quick
+            test_delegation_request_title_truncates_utf8_boundary;
         ] );
       ( "parse_deliberation_response",
         [


### PR DESCRIPTION
## Summary
- turn keeper `propose_spawn` deliberation into a deterministic MASC `delegation_request` / task-seed artifact
- attach `delegation_request` JSON to keeper decision records and metrics snapshots
- clarify prompt semantics: this is operator/keeper routing, not direct child-agent spawning or OAS swarm orchestration
- lock contracts for multi-step first-spawn projection, goal-sensitive ids, and UTF-8-safe title truncation

## Validation
- `opam exec -- ocamlformat --check lib/keeper/keeper_delegation_request.ml lib/keeper/keeper_delegation_request.mli lib/keeper/keeper_unified_metrics_snapshot.ml lib/keeper/keeper_unified_metrics_decision.ml test/test_keeper_deliberation.ml`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/ci/check-determinism-contract.sh`
- `scripts/validate-prompt-paths.sh`

Focused Dune wrapper attempted earlier: `scripts/dune-local.sh build test/test_keeper_deliberation.exe`; it exited 75 because existing bare Dune processes are active, so I did not force another local build.
