### PR TITLE
fix(dashboard): make keeper action ids gesture-scoped

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1323,11 +1323,12 @@ describe('ChatComposer multimodal', () => {
       { type: 'text', text: 'check this <tag>' },
     ])
     const clientActionId = onSend.mock.calls[0]?.[0].clientActionId
-    expect(clientActionId).toContain('check this <tag>')
-    expect(clientActionId).toContain('att-img')
+    expect(clientActionId).toMatch(/^composer-send-\d+-\d+$/)
+    expect(clientActionId).not.toContain('check this <tag>')
+    expect(clientActionId).not.toContain('att-img')
   })
 
-  it('mints the same client action id for repeated sends of the same draft', async () => {
+  it('mints content-independent client action ids for repeated sends', async () => {
     const onSend = vi.fn()
     renderComposer({ draft: 'same text', onSend })
 
@@ -1339,11 +1340,14 @@ describe('ChatComposer multimodal', () => {
     expect(onSend).toHaveBeenCalledTimes(2)
     const firstId = onSend.mock.calls[0]?.[0].clientActionId
     const secondId = onSend.mock.calls[1]?.[0].clientActionId
-    expect(firstId).toBe(secondId)
-    expect(firstId).toContain('same text')
+    expect(firstId).toMatch(/^composer-send-\d+-\d+$/)
+    expect(secondId).toMatch(/^composer-send-\d+-\d+$/)
+    expect(firstId).not.toBe(secondId)
+    expect(firstId).not.toContain('same text')
+    expect(secondId).not.toContain('same text')
   })
 
-  it('changes the client action id when attachment data changes', async () => {
+  it('does not derive client action ids from attachment payloads', async () => {
     const baseAttachment: Omit<KeeperConversationAttachment, 'data'> = {
       id: 'att-same',
       type: 'image',
@@ -1386,7 +1390,13 @@ describe('ChatComposer multimodal', () => {
     expect(onSend).toHaveBeenCalledTimes(2)
     const firstId = onSend.mock.calls[0]?.[0].clientActionId
     const secondId = onSend.mock.calls[1]?.[0].clientActionId
+    expect(firstId).toMatch(/^composer-send-\d+-\d+$/)
+    expect(secondId).toMatch(/^composer-send-\d+-\d+$/)
     expect(firstId).not.toBe(secondId)
+    expect(firstId).not.toContain('same text')
+    expect(firstId).not.toContain('att-same')
+    expect(firstId).not.toContain('AAAA')
+    expect(secondId).not.toContain('BBBB')
   })
 
   it('preserves audio attachments as audio user blocks', async () => {
@@ -1426,7 +1436,8 @@ describe('ChatComposer multimodal', () => {
         size: 2048,
       },
     ])
-    expect(onSend.mock.calls[0]?.[0].clientActionId).toContain('att-audio')
+    expect(onSend.mock.calls[0]?.[0].clientActionId).toMatch(/^composer-send-\d+-\d+$/)
+    expect(onSend.mock.calls[0]?.[0].clientActionId).not.toContain('att-audio')
   })
 
   it('keeps send disabled until there is content', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -308,36 +308,11 @@ function attachmentMeta(attachment: KeeperConversationAttachment): string {
   return [attachment.mimeType, formatAttachmentSize(attachment.size)].filter(Boolean).join(' · ')
 }
 
-function actionFingerprint(value: string): string {
-  let hash = 0x811c9dc5
-  for (let i = 0; i < value.length; i += 1) {
-    hash ^= value.charCodeAt(i)
-    hash = Math.imul(hash, 0x01000193)
-  }
-  return (hash >>> 0).toString(36)
-}
+let composerActionSeq = 0
 
-function composerAttachmentActionFingerprint(attachment: KeeperConversationAttachment): Record<string, unknown> {
-  return {
-    id: attachment.id,
-    type: attachment.type,
-    name: attachment.name,
-    mimeType: attachment.mimeType,
-    size: attachment.size,
-    dims: attachment.dims ?? null,
-    dataLength: attachment.data.length,
-    dataHash: actionFingerprint(attachment.data),
-  }
-}
-
-function composerClientActionId(
-  text: string,
-  attachments: readonly KeeperConversationAttachment[],
-): string {
-  return JSON.stringify({
-    text,
-    attachments: attachments.map(composerAttachmentActionFingerprint),
-  })
+function nextComposerClientActionId(): string {
+  composerActionSeq += 1
+  return `composer-send-${Date.now()}-${composerActionSeq}`
 }
 
 function dataUriToText(data: string): string | null {
@@ -2624,7 +2599,7 @@ export function ChatComposer({
     void onSend({
       blocks,
       userBlocks,
-      clientActionId: composerClientActionId(text, attachments),
+      clientActionId: nextComposerClientActionId(),
     })
     onDraftChange('')
     setAttachments([])

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -339,10 +339,9 @@ describe('KeeperConversationPanel', () => {
     expect(getQueueLength('sangsu')).toBe(0)
   })
 
-  it('does not enqueue a duplicate submit for an already queued client action', async () => {
+  it('enqueues repeated same-draft submits as separate queued actions', async () => {
     keeperSending.value = { sangsu: true }
-    const clientActionId = JSON.stringify({ text: 'same draft', attachments: [] })
-    enqueueInput('sangsu', 'same draft', undefined, clientActionId)
+    enqueueInput('sangsu', 'same draft', undefined, 'queued-action-1')
 
     render(
       html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
@@ -357,7 +356,7 @@ describe('KeeperConversationPanel', () => {
     const sendButton = container.querySelector('.send') as HTMLButtonElement
     fireEvent.click(sendButton)
 
-    expect(getQueueLength('sangsu')).toBe(1)
+    expect(getQueueLength('sangsu')).toBe(2)
   })
 
   it('keeps queued client action ids attached when draining the queue', async () => {

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -4,6 +4,7 @@ end
 module Tool : module type of Masc_task_handlers.Tool_task
 module Anti_rationalization : module type of Masc_task_handlers.Anti_rationalization
 module Dispatch : module type of Masc_task_handlers.Task_dispatch
+module Goal_assignment : module type of Masc_task_handlers.Task_goal_assignment
 module Transition_state : module type of Masc_task_handlers.Task_transition_state
 module Schemas : module type of Masc_task_handlers.Tool_task_schemas
 module Payloads : module type of Masc_task_handlers.Tool_task_payloads


### PR DESCRIPTION
## Summary

Follow-up for #21738 after the merged head regressed from gesture/action identity back to content identity.

This changes the dashboard chat composer so `clientActionId` is opaque and minted per send gesture (`composer-send-<time>-<seq>`), instead of serializing prompt text and attachment metadata into the id.

## Why

The in-flight and queued-message guards are now keyed by `clientActionId`. That is correct only if the id represents the user action. The merged #21738 head made the id a content fingerprint:

- identical text + attachments => same id
- same id => in-flight/queue guard treats the second send as duplicate
- result => legitimate repeated messages like `ok`, `네`, or `?` can be silently dropped while a keeper is busy

## Changes

- Remove prompt/attachment fingerprinting from `ChatComposer`.
- Mint an opaque per-send id.
- Update composer tests so ids must not contain prompt text or attachment ids/data.
- Update keeper panel queue test so repeated same-draft submits are allowed as separate queued actions.

## Validation

- `vitest run --config vitest.config.ts src/components/chat/primitives.test.ts src/components/keeper-shared.test.ts src/keeper-actions.test.ts src/keeper-chat-store.test.ts --no-file-parallelism --maxWorkers=1` -> 4 files / 161 tests passed
- `eslint src/components/chat/primitives.ts src/components/keeper-shared.ts src/keeper-actions.ts` -> passed
- `tsc --noEmit --pretty false --project tsconfig.json` -> passed
- `git diff --check` -> passed

Full local build intentionally not run per operator instruction.
