### PR TITLE
[codex] Fix Fusion timeout follow-up build

### DIFF
--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -37,7 +37,7 @@ let provider_error_detail ~runtime_id detail =
 let timeout_budget_opt timeout_s =
   if Float.is_finite timeout_s && timeout_s > 0.0 then Some timeout_s else None
 
-let apply_timeout_budget ?timeout_s base_config =
+let apply_timeout_budget ?timeout_s (base_config : Runtime_agent.config) =
   match Option.bind timeout_s timeout_budget_opt with
   | None -> base_config
   | Some timeout_s ->
@@ -46,7 +46,7 @@ let apply_timeout_budget ?timeout_s base_config =
        max_execution_time_s here; it can kill an active stream with the
        wrong failure attribution. *)
     { base_config with
-      stream_idle_timeout_s = Some timeout_s
+      Runtime_agent.stream_idle_timeout_s = Some timeout_s
     ; body_timeout_s = Some timeout_s
     }
 

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -509,8 +509,8 @@ let test_keeper_chat_history_persists_attachment_refs_not_raw_media () =
 
 let vision_provider_cfg () =
   Llm_provider.Provider_config.make
-    ~kind:Llm_provider.Provider_config.Glm
-    ~model_id:"glm-5v-turbo"
+    ~kind:Llm_provider.Provider_config.OpenAI_compat
+    ~model_id:"minimax-m3"
     ~base_url:"http://127.0.0.1.invalid"
     ()
 


### PR DESCRIPTION
## Summary

- disambiguate `Runtime_agent.config` timeout record updates after #21706 landed
- keep Fusion timeout mapping on OAS idle/body budgets without arming `max_execution_time_s`
- update the gate multimodal fixture to use an image-capable catalog model

## Context

#21706 merged before this follow-up push. This PR contains only the post-merge fixes needed on top of current `main`.

## Validation

- `scripts/check-oas-pin.sh --local-only`
- `ocamlformat --check lib/fusion/fusion_oas.ml test/test_gate_keeper_backend.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build @check test/test_fusion_oas_error_detail.exe test/fusion_core/test_fusion.exe test/test_gate_keeper_backend.exe`
- `./_build/default/test/test_fusion_oas_error_detail.exe`
- `./_build/default/test/fusion_core/test_fusion.exe`
- `./_build/default/test/test_gate_keeper_backend.exe`