### PR TITLE
feat(board): expose post origin on dashboard board API (RFC-0233 §7 PR-C board)

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -589,6 +589,66 @@ describe('fetchBoard', () => {
     const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('blind_votes=true')
   })
+
+  it('normalizes the RFC-0233 origin (turn_ref / source / fusion_run_id)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        posts: [
+          {
+            id: 'post-origin',
+            author: 'fusion',
+            title: 'Fusion deliberation',
+            body: 'resolved',
+            created_at: 1_713_000_000,
+            updated_at: 1_713_000_000,
+            origin: {
+              source: 'fusion',
+              fusion_run_id: 'fus-abc',
+              turn_ref: 'trace-1780648779957-00000#4071',
+            },
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoard()
+
+    expect(result.posts[0]?.origin).toEqual({
+      source: 'fusion',
+      fusion_run_id: 'fus-abc',
+      turn_ref: 'trace-1780648779957-00000#4071',
+    })
+  })
+
+  it('leaves origin null on legacy posts without dropping the post', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        posts: [
+          {
+            id: 'post-legacy',
+            author: 'analyst',
+            title: 'No origin',
+            body: 'legacy row',
+            created_at: 1_713_000_000,
+            updated_at: 1_713_000_000,
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoard()
+
+    expect(result.posts[0]?.id).toBe('post-legacy')
+    expect(result.posts[0]?.origin).toBeNull()
+  })
 })
 
 describe('fetchBoardHearths', () => {

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -4,7 +4,7 @@ import { asKeeperApprovalRiskLevel } from '../lib/governance-risk-level'
 import { normalizePendingConfirmation } from '../pending-confirm'
 import { timeBoardRequest } from '../board-metrics'
 import type {
-  BoardActorIdentity, BoardPost, BoardComment, BoardReactionSummary,
+  BoardActorIdentity, BoardPost, BoardPostOrigin, BoardComment, BoardReactionSummary,
   BoardReactionTargetType, BoardReactionToggleResult, BoardSortMode,
   BoardVoteDirection, BoardModerationStatus, BoardContributorQuality,
   BoardCurationSnapshot, BoardKarmaLedger, BoardKarmaLedgerEvent, BoardKarmaTotal,
@@ -426,6 +426,23 @@ function normalizeBoardContributorQuality(raw: unknown): BoardContributorQuality
   }
 }
 
+// RFC-0233 §7: parse the typed origin object (post_to_yojson_with_karma emits
+// turn_ref / source / fusion_run_id). Parse, don't repair: a non-object or an
+// all-absent origin -> null (no empty record); each sub-field degrades
+// independently. Never throws, never drops the post.
+function normalizeBoardPostOrigin(raw: unknown): BoardPostOrigin | null {
+  if (!isRecord(raw)) return null
+  const turnRef = asNullableString(raw.turn_ref)
+  const source = asNullableString(raw.source)
+  const fusionRunId = asNullableString(raw.fusion_run_id)
+  if (turnRef === null && source === null && fusionRunId === null) return null
+  return {
+    ...(turnRef !== null ? { turn_ref: turnRef } : {}),
+    ...(source !== null ? { source } : {}),
+    ...(fusionRunId !== null ? { fusion_run_id: fusionRunId } : {}),
+  }
+}
+
 function normalizeBoardPost(raw: unknown): BoardPost | null {
   if (!isRecord(raw)) return null
   const id = asString(raw.id, '').trim()
@@ -507,6 +524,7 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
     moderation_status: normalizeBoardModerationStatus(raw.moderation_status),
     contributor_quality: normalizeBoardContributorQuality(raw.contributor_quality),
     ...(reactions !== undefined ? { reactions } : {}),
+    origin: normalizeBoardPostOrigin(raw.origin),
   }
 }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -156,6 +156,19 @@ export interface BoardActorIdentity {
   runtime_agent_name?: string
 }
 
+/**
+ * RFC-0233 §7: originating-turn provenance of a board post. `turn_ref` is the
+ * join key "<trace_id>#<absolute_turn>" identical to the chat row the same turn
+ * produced (board post -> exact chat turn navigation). `fusion_run_id` is the
+ * distinct fusion run correlation id. All optional: legacy/system posts have no
+ * origin.
+ */
+export interface BoardPostOrigin {
+  turn_ref?: string | null
+  source?: string | null
+  fusion_run_id?: string | null
+}
+
 export interface BoardPost {
   id: string
   author: string
@@ -186,6 +199,7 @@ export interface BoardPost {
   moderation_status?: BoardModerationStatus
   contributor_quality?: BoardContributorQuality | null
   reactions?: BoardReactionSummary[]
+  origin?: BoardPostOrigin | null
 }
 
 export interface BoardComment {

--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -189,6 +189,11 @@ val mark_dirty_comment : store -> string -> unit
 (** {1 Wire encoders} *)
 
 val post_to_yojson : post -> Yojson.Safe.t
+
+(** RFC-0233 §7: encode the typed post origin. Re-exported here so the
+    dashboard board serializer ({!Board_votes.post_to_yojson_with_karma}) can
+    reuse the single origin encoder. *)
+val post_origin_to_yojson : post_origin -> Yojson.Safe.t
 val comment_to_yojson : comment -> Yojson.Safe.t
 val reaction_to_yojson : reaction -> Yojson.Safe.t
 val reaction_of_yojson : Yojson.Safe.t -> reaction option

--- a/lib/board/board_core_json.mli
+++ b/lib/board/board_core_json.mli
@@ -3,6 +3,12 @@
 open Board_types
 
 val post_to_yojson : post -> Yojson.Safe.t
+
+val post_origin_to_yojson : post_origin -> Yojson.Safe.t
+(** RFC-0233 §7: encode the typed post origin (turn_ref / source /
+    fusion_run_id) as a JSON object. Shared with the dashboard board
+    serializer ({!Board_votes.post_to_yojson_with_karma}) so the wire shape
+    matches {!post_to_yojson}. *)
 val comment_to_yojson : comment -> Yojson.Safe.t
 val reaction_to_yojson : reaction -> Yojson.Safe.t
 val reaction_of_yojson : Yojson.Safe.t -> reaction option

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -1007,4 +1007,10 @@ let post_to_yojson_with_karma (p : post) ~author_karma : Yojson.Safe.t =
     ("pinned", `Bool p.pinned);
   ] @ (match p.hearth with Some h -> [("hearth", `String h)] | None -> [])
     @ (match p.thread_id with Some t -> [("thread_id", `String t)] | None -> [])
+    (* RFC-0233 §7: the dashboard board serializer ([board_post_dashboard_json])
+       funnels every board list/detail route through this function, so emitting
+       [origin] here exposes the originating-turn provenance on every
+       dashboard-facing post in one place (no per-route N-of-M). Same encoder as
+       [post_to_yojson] so the wire shape is identical. *)
+    @ (match p.origin with Some o -> [("origin", post_origin_to_yojson o)] | None -> [])
     @ (match p.meta_json with Some meta -> [("meta", meta)] | None -> []))


### PR DESCRIPTION
> ⚠️ **BASE-BROKEN (PR-C-board 무관)**: 현재 `main`은 `lib/fusion/fusion_oas.ml:49`의 unbound record field `stream_idle_timeout_s`로 full-tree 빌드가 안 됨(별개 머지가 컨베이어로 빌드실패 상태 머지된 것으로 추정, fix PR 아직 없음). 이 PR은 fusion을 건드리지 않음(`git diff origin/main -- lib/fusion/` 비어 있음). 따라서 full-tree CI의 fusion_oas 실패는 base 탓이며 PR-C-board 코드와 무관. PR-C-board 자체는 **`lib/board` 빌드 green(fusion 비의존)** + 프론트 **vitest 74/74 + tsc clean**.

## 무엇을 / 왜

RFC-0233 §7의 **PR-C (board 절반) — dashboard board API에 typed post `origin` 노출**. PR-B(#21732, MERGED)가 board post에 typed `origin`을 추가했고, 이 PR이 그것을 dashboard board API로 흘려 board post가 자신을 만든 turn을 들고 프론트가 정확한 chat 턴에 anchor할 수 있게 한다.

## 변경

**Backend (단일 공유 serializer = per-route N-of-M 없음):** 모든 dashboard board list/detail 라우트(activity `/api/v1/board`, detail `/api/v1/board/:id`, h2_gateway, dashboard_http)는 `board_post_dashboard_json` 하나로 funnel되고, 그 base_fields는 `Board_votes.post_to_yojson_with_karma`에서 온다. 이 builder가 이제 `origin`(turn_ref/source/fusion_run_id)을 `post_to_yojson`과 **동일한 `Board_core_json.post_origin_to_yojson` 인코더**로 emit → wire 모양 일치. `post_origin_to_yojson`을 `board_core_json.mli`+`board_core.mli`로 re-export해 board_votes가 단일 인코더 재사용.

**Frontend:** `BoardPost`에 optional `origin: BoardPostOrigin | null` 추가; `normalizeBoardPost`가 `normalizeBoardPostOrigin`으로 파싱(parse-don't-repair: non-object·all-absent→null, per-field degrade, **post를 절대 drop하지 않음**).

## 검증

- **`dune build lib/board` green** (fusion 비의존이라 main의 fusion_oas break와 무관하게 검증).
- **vitest 74/74** (신규: origin present→normalized / legacy→null 포함), **`tsc --noEmit` clean(exit 0)**.

## Workaround Guards (RFC-0233 §7.6 준수)

- **#2 string classifier 없음**: typed origin 객체, 단일 인코더 재사용. meta_json substring scan 아님.
- **#5 run_id≠turn_ref**: origin에 둘 다 별개 보존.
- **#6 N-of-M 없음**: 4개 dashboard 경로가 단일 `post_to_yojson_with_karma`로 funnel → 한 곳 변경. 프론트는 단일 `normalizeBoardPost`.

## Follow-up

keeper-authored board post의 `origin.turn_ref` populate(cell-carrier)는 별도 follow-up. 현재 fusion이 `origin.fusion_run_id` populate(PR-B). board↔chat 양방향 nav 소비는 PR-D.

Refs: RFC-0233 §7 (§7.5 PR-C). Depends on PR-B (#21732, MERGED). PR-C-chat=#21746(별건, 프론트 turn_ref).
