### PR TITLE
refactor(memory-os): RFC-0259 reconcile verify off the facts lock (#21716 #1)

### DIFF
--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -11,7 +11,6 @@
 
 module Io = Keeper_memory_os_io
 module Consolidation = Keeper_memory_os_consolidation
-module Types = Keeper_memory_os_types
 
 (* Same shape as [Keeper_memory_llm_summary.complete_fn]; the LLM call is
    injectable so the loop is driveable with a fake completion in tests. *)
@@ -74,23 +73,16 @@ type outcome =
 
 (* Serialize only the final snapshot validation + rewrite against the per-keeper
    facts file. The provider call runs without this lock, then the locked rewrite
-   validates that the fact snapshot still matches the model input. *)
+   validates that the fact snapshot still matches the model input
+   ([Io.same_fact_snapshot]). Wraps the shared [Io.with_facts_lock] so a contended
+   cycle becomes a typed [Transport_failed] rather than an escaping [Flock_timeout]
+   (the lock/CAS helpers are the SSOT shared with the reconcile rewrite path). *)
 let with_facts_lock ?clock ~keeper_id f =
-  try File_lock_eio.with_lock ?clock (Io.facts_path ~keeper_id) f with
-  | File_lock_eio.Flock_timeout { path; attempts; _ } ->
-    Transport_failed
-      (Printf.sprintf "consolidation lock timeout: %s after %d attempts" path attempts)
-  | Failure msg -> Transport_failed ("consolidation lock timeout: " ^ msg)
-;;
-
-let fact_fingerprint fact = Types.fact_to_json fact |> Yojson.Safe.to_string
-
-let rec same_fact_snapshot left right =
-  match left, right with
-  | [], [] -> true
-  | l :: ls, r :: rs ->
-    String.equal (fact_fingerprint l) (fact_fingerprint r) && same_fact_snapshot ls rs
-  | [], _ :: _ | _ :: _, [] -> false
+  Io.with_facts_lock
+    ?clock
+    ~keeper_id
+    ~on_timeout:(fun msg -> Transport_failed ("consolidation " ^ msg))
+    f
 ;;
 
 let provider_for_consolidation (provider_cfg : Llm_provider.Provider_config.t) =
@@ -130,7 +122,7 @@ let rewrite_if_snapshot_current ?clock ~keeper_id ~facts ~survivors ~before ~aft
     | Error msg ->
       Unparseable ("consolidation fact store changed before rewrite: " ^ msg)
     | Ok current ->
-      if not (same_fact_snapshot facts current)
+      if not (Io.same_fact_snapshot facts current)
       then Snapshot_changed { before; current = List.length current }
       else (
         Io.rewrite_facts_atomically ~keeper_id survivors;

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -267,6 +267,41 @@ let rewrite_facts_atomically ~keeper_id facts =
   write_file_atomically path content
 ;;
 
+(* ---------- Facts snapshot CAS (optimistic concurrency) ---------- *)
+
+(* Byte-level snapshot identity for the read-outside-lock, rewrite-under-lock
+   pattern. [fact_to_json] has a stable key order (see Keeper_memory_os_types — the
+   external_ref key is appended last specifically to keep this fingerprint stable),
+   so a fact's canonical JSON is a sound content key. [same_fact_snapshot snapshot
+   current] is true iff the two lists are positionally byte-identical: any
+   concurrent append (longer), cap/GC (shorter), or re-observation (a row's bytes
+   change) makes them differ, so a caller that classified [snapshot] outside the
+   lock can re-read under the lock and abandon a stale rewrite. Line count and file
+   size are NOT sound CAS keys — [cap_facts]/[merge_and_cap_facts] can hold either
+   steady while rows differ. SSOT for the reconcile and consolidation rewrite
+   paths. *)
+let fact_fingerprint fact = fact_to_json fact |> Yojson.Safe.to_string
+
+let rec same_fact_snapshot left right =
+  match left, right with
+  | [], [] -> true
+  | l :: ls, r :: rs ->
+    String.equal (fact_fingerprint l) (fact_fingerprint r) && same_fact_snapshot ls rs
+  | [], _ :: _ | _ :: _, [] -> false
+;;
+
+(* Run [f] holding the per-keeper facts lock. On lock-acquisition timeout (another
+   writer holds the flock past the retry budget) [on_timeout msg] decides the
+   caller's result rather than letting [Flock_timeout] escape — callers that want a
+   typed skip/no-op outcome pass it here instead of catching the exception
+   themselves. *)
+let with_facts_lock ?clock ~keeper_id ~on_timeout f =
+  try File_lock_eio.with_lock ?clock (facts_path ~keeper_id) f with
+  | File_lock_eio.Flock_timeout { path; attempts; _ } ->
+    on_timeout (Printf.sprintf "lock timeout: %s after %d attempts" path attempts)
+  | Failure msg -> on_timeout ("lock timeout: " ^ msg)
+;;
+
 let save_tool_result ~keeper_id ~tool_call_id json =
   let path = tool_result_path ~keeper_id ~tool_call_id in
   write_file_atomically path (Yojson.Safe.pretty_to_string json)

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -44,6 +44,30 @@ val with_episode_bundle_lock :
 
 val append_episode_bundle : keeper_id:string -> episode -> unit
 val rewrite_facts_atomically : keeper_id:string -> fact list -> unit
+
+(** {1 Facts snapshot CAS} *)
+
+(** Canonical-JSON fingerprint of a fact (stable key order — see
+    {!Keeper_memory_os_types}). *)
+val fact_fingerprint : fact -> string
+
+(** [same_fact_snapshot snapshot current] is true iff the two fact lists are
+    positionally byte-identical. Used for read-outside-lock / rewrite-under-lock
+    optimistic concurrency: a snapshot classified without the lock is revalidated
+    under the lock and a stale rewrite abandoned if any concurrent writer changed
+    the store. Line count / file size are NOT sound CAS keys. *)
+val same_fact_snapshot : fact list -> fact list -> bool
+
+(** [with_facts_lock ?clock ~keeper_id ~on_timeout f] runs [f] holding the
+    per-keeper facts lock. On flock-acquisition timeout, [on_timeout msg] produces
+    the result instead of raising {!File_lock_eio.Flock_timeout}, so callers can
+    return a typed skip/no-op for a contended cycle. *)
+val with_facts_lock :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> keeper_id:string
+  -> on_timeout:(string -> 'a)
+  -> (unit -> 'a)
+  -> 'a
 val save_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t -> unit
 val load_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t option
 

--- a/lib/keeper/keeper_memory_os_reconcile.ml
+++ b/lib/keeper/keeper_memory_os_reconcile.ml
@@ -94,9 +94,12 @@ type apply_report =
   ; terminal_kept : int
   ; advanced : int
   ; kept : int
+  ; committed : bool
   }
 
-let empty_apply = { scanned = 0; terminal_kept = 0; advanced = 0; kept = 0 }
+let empty_apply =
+  { scanned = 0; terminal_kept = 0; advanced = 0; kept = 0; committed = false }
+;;
 
 let reconcile_facts ~now ~horizon ~verify (facts : fact list)
   : fact list * apply_report
@@ -135,20 +138,47 @@ let reconcile_facts ~now ~horizon ~verify (facts : fact list)
 ;;
 
 let run_reconcile ?(dry_run = false) ~keeper_id ~now ~horizon ~verify () : apply_report =
-  (* Same per-keeper facts lock as GC/librarian/consolidation: the verify IO runs
-     inside the lock, but it only reads external state (gh) and never touches the
-     store, so unlike the consolidation runtime there is no unlocked read-modify gap
-     to guard with a snapshot CAS — the whole read-classify-rewrite is atomic. *)
-  File_lock_eio.with_lock (Io.facts_path ~keeper_id) (fun () ->
-    match Io.read_facts_all_strict ~keeper_id with
-    | Error message ->
-      raise
-        (Fact_store_corrupt ("memory os reconcile fact store read failed: " ^ message))
-    | Ok facts ->
-      let survivors, report = reconcile_facts ~now ~horizon ~verify facts in
-      (* Only [Stale_open] advances mutate the store; demoted terminal facts are left
-         byte-identical, so a pass that finds no still-open ref writes nothing. *)
-      if (not dry_run) && report.advanced > 0
-      then Io.rewrite_facts_atomically ~keeper_id survivors;
-      report)
+  (* Phase 1 — NO LOCK. The strict read and the injected [verify] (one gh call per
+     ref-bearing past-horizon fact, ~10s each) run WITHOUT the per-keeper facts lock.
+     The earlier design held the lock across the whole verify loop "because verify
+     never touches the store"; that is true for correctness but holds the lock —
+     shared with librarian/GC/consolidation — across K*10s of network IO, stalling
+     every memory write for the keeper. Off-lock verify removes that stall; the cost
+     is an unlocked read-modify gap, closed by the snapshot CAS in Phase 2. *)
+  match Io.read_facts_all_strict ~keeper_id with
+  | Error message ->
+    raise (Fact_store_corrupt ("memory os reconcile fact store read failed: " ^ message))
+  | Ok facts ->
+    let survivors, report = reconcile_facts ~now ~horizon ~verify facts in
+    if dry_run
+    then report
+    else if report.advanced = 0
+    then
+      (* Only [Stale_open] advances mutate the store (demoted terminal facts stay
+         byte-identical), so a pass with no still-open ref writes nothing and never
+         takes the lock. *)
+      report
+    else
+      (* Phase 2 — LOCK. Re-read under the lock and rewrite only if the store is
+         still byte-for-byte the snapshot we classified (optimistic concurrency CAS,
+         mirroring the consolidation runtime). If a concurrent writer committed
+         during the verify window the snapshot differs, so abandon this cycle's
+         rewrite — the reconciler is periodic and re-runs next tick — rather than
+         clobber the concurrent write with stale survivors. The re-read and rewrite
+         share one lock acquisition, so no third writer can interleave between them.
+         A lock-acquisition timeout yields a no-op cycle (committed=false). *)
+      Io.with_facts_lock ~keeper_id ~on_timeout:(fun _ -> report) (fun () ->
+        match Io.read_facts_all_strict ~keeper_id with
+        | Error message ->
+          (* Preserve over delete: a re-read that now fails to parse must NOT be
+             overwritten by the snapshot's survivors — surface the corruption. *)
+          raise
+            (Fact_store_corrupt
+               ("memory os reconcile fact store changed before rewrite: " ^ message))
+        | Ok current ->
+          if Io.same_fact_snapshot facts current
+          then (
+            Io.rewrite_facts_atomically ~keeper_id survivors;
+            { report with committed = true })
+          else report)
 ;;

--- a/lib/keeper/keeper_memory_os_reconcile.mli
+++ b/lib/keeper/keeper_memory_os_reconcile.mli
@@ -75,6 +75,12 @@ type apply_report =
           (demote-not-delete: never deleted on terminal state alone) *)
   ; advanced : int (** [Stale_open] facts whose [last_verified_at] moved to [now] *)
   ; kept : int (** [Fresh] / [Stale_unknown] facts left unchanged *)
+  ; committed : bool
+      (** whether the advance was actually persisted this cycle. False for a
+          [dry_run], a no-advance pass (nothing to write), a CAS-abandoned rewrite (a
+          concurrent writer committed during the off-lock verify), or a
+          lock-acquisition timeout. The classification counts above are still
+          reported even when [committed] is false. *)
   }
 
 (** RFC-0259 §3.4 (P3): the pure reconcile core. Classifies each fact and maps the
@@ -99,12 +105,20 @@ val reconcile_facts
     tests — can tell a preserve-over-delete abort apart from a normal reconcile. *)
 exception Fact_store_corrupt of string
 
-(** RFC-0259 §3.4 (P3): apply the reconciler to one keeper's store under the
-    per-keeper facts lock (the lock GC/librarian/consolidation already hold on
-    [facts_path], so no concurrent writer's update is lost). Reads strictly — a
-    corrupt store aborts rather than being partially dropped and overwritten — and
-    rewrites atomically. [dry_run:true] computes the report without writing (the
-    default, mirroring the GC rollout). Must run inside an Eio context. *)
+(** RFC-0259 §3.4 (P3): apply the reconciler to one keeper's store. The strict read
+    and the injected [verify] (one external lookup per ref-bearing past-horizon fact)
+    run WITHOUT the per-keeper facts lock, so a slow [verify] does not stall the
+    librarian/GC/consolidation writes that share that lock. The lock is taken only
+    when an advance must be persisted, to re-read and rewrite: the rewrite is applied
+    only if the store is still byte-for-byte the snapshot that was classified
+    (optimistic concurrency — {!Keeper_memory_os_io.same_fact_snapshot}); if a
+    concurrent writer committed during the verify window the rewrite is abandoned and
+    retried on the next tick, never clobbering the concurrent write. A re-read that
+    fails to parse raises [Fact_store_corrupt] rather than being overwritten (preserve
+    over delete). [dry_run:true] computes the report without taking the lock or
+    writing (the default, mirroring the GC rollout). [report.committed] is true iff
+    the rewrite was persisted this cycle. A lock-acquisition timeout yields a no-op
+    cycle (committed=false) instead of raising. Must run inside an Eio context. *)
 val run_reconcile
   :  ?dry_run:bool
   -> keeper_id:string

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -247,15 +247,20 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                 if report.Keeper_memory_os_reconcile.terminal_kept > 0
                    || report.advanced > 0
                 then
+                  (* [committed] distinguishes a persisted advance from a cycle whose
+                     rewrite was abandoned because a concurrent writer changed the
+                     store during the off-lock verify (advanced>0 but committed=false
+                     — re-runs next tick). *)
                   Log.Server.info
                     "memory_os_reconcile[%s]: keeper=%s scanned=%d terminal_kept=%d \
-                     advanced=%d kept=%d"
+                     advanced=%d kept=%d committed=%b"
                     mode
                     keeper_id
                     report.scanned
                     report.terminal_kept
                     report.advanced
                     report.kept
+                    report.committed
               with
               | Eio.Cancel.Cancelled _ as e -> raise e
               | exn ->

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -4,6 +4,7 @@ end
 module Tool : module type of Masc_task_handlers.Tool_task
 module Anti_rationalization : module type of Masc_task_handlers.Anti_rationalization
 module Dispatch : module type of Masc_task_handlers.Task_dispatch
+module Goal_assignment : module type of Masc_task_handlers.Task_goal_assignment
 module Transition_state : module type of Masc_task_handlers.Task_transition_state
 module Schemas : module type of Masc_task_handlers.Tool_task_schemas
 module Payloads : module type of Masc_task_handlers.Tool_task_payloads

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1398,6 +1398,8 @@ let test_run_reconcile_apply_advance_persists () =
       in
       Alcotest.(check int) "advanced the still-open fact" 1 report.Reconcile.advanced;
       Alcotest.(check int) "nothing demoted" 0 report.Reconcile.terminal_kept;
+      (* No concurrent writer, so the CAS matches and the rewrite is persisted. *)
+      Alcotest.(check bool) "advance committed to disk" true report.Reconcile.committed;
       (* MUTATION: dropping the [advanced > 0] write guard skips this write, so
          last_verified_at on disk would still read the old value and the ref would be
          re-verified every cycle. *)
@@ -1441,6 +1443,69 @@ let test_run_reconcile_preserves_corrupt_store () =
         "corrupt store left byte-for-byte untouched (no silent drop + overwrite)"
         before
         (read_raw ())))
+;;
+
+let test_run_reconcile_cas_abandons_on_concurrent_write () =
+  with_eio (fun ~sw:_ ~net:_ ~clock:_ ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      let keeper_id = "reconcile-cas-keeper" in
+      let now = 1_000_000.0 in
+      let horizon = 3600.0 in
+      (* One still-open ref: classify routes it to verify, and [Still_open] makes the
+         pass want to advance (advanced>0 -> it would rewrite). *)
+      Memory_io.append_fact ~keeper_id (stale_ref_fact ~now ~id:"2" "PR #2 in review");
+      (* A verify that, on its first call, commits a concurrent write to the store (a
+         fresh fact) before returning. Because verify now runs with the facts lock
+         RELEASED, this append lands during the verify window. The reconciler must
+         then re-read under the lock, see the snapshot changed, and abandon its (now
+         stale) rewrite rather than clobbering the concurrent fact. *)
+      let injected = ref false in
+      let verify : Reconcile.verify_fn =
+        fun _r ->
+        if not !injected
+        then (
+          injected := true;
+          Memory_io.append_fact
+            ~keeper_id
+            (stale_ref_fact ~now ~id:"99" "PR #99 concurrent append"));
+        Reconcile.Still_open
+      in
+      let report =
+        Reconcile.run_reconcile ~dry_run:false ~keeper_id ~now ~horizon ~verify ()
+      in
+      Alcotest.(check int)
+        "the still-open ref was classified as an advance"
+        1
+        report.Reconcile.advanced;
+      (* The advance was NOT persisted: a concurrent writer changed the store during
+         verify, so the snapshot CAS abandoned the rewrite this cycle (re-runs next
+         tick). [committed] makes that observable to the caller. *)
+      Alcotest.(check bool)
+        "advance not committed when snapshot changed under it"
+        false
+        report.Reconcile.committed;
+      let claims =
+        List.map (fun f -> f.Types.claim) (Memory_io.read_facts_all ~keeper_id)
+      in
+      (* MUTATION: replacing the [same_fact_snapshot] CAS with an unconditional rewrite
+         persists the stale survivors (just "PR #2"), dropping the concurrently-appended
+         "PR #99" — this membership check then fails. That is the lost-update teeth, and
+         it also proves the lock was released during verify (the append could commit). *)
+      Alcotest.(check bool)
+        "concurrently-appended fact survived (not clobbered by a stale rewrite)"
+        true
+        (List.mem "PR #99 concurrent append" claims);
+      match
+        List.find_opt
+          (fun f -> String.equal f.Types.claim "PR #2 in review")
+          (Memory_io.read_facts_all ~keeper_id)
+      with
+      | Some f ->
+        Alcotest.(check (option (float 0.001)))
+          "original ref left un-advanced on disk (rewrite abandoned)"
+          (Some (now -. 100_000.0))
+          f.Types.last_verified_at
+      | None -> Alcotest.fail "the original ref must still be on disk"))
 ;;
 
 let test_gc_waits_for_fact_writer_lock () =
@@ -3132,6 +3197,10 @@ let () =
             "corrupt store aborts without overwrite (P3)"
             `Quick
             test_run_reconcile_preserves_corrupt_store
+        ; Alcotest.test_case
+            "concurrent write during verify abandons the rewrite (P3 lock offload)"
+            `Quick
+            test_run_reconcile_cas_abandons_on_concurrent_write
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1446,7 +1446,7 @@ let test_run_reconcile_preserves_corrupt_store () =
 ;;
 
 let test_run_reconcile_cas_abandons_on_concurrent_write () =
-  with_eio (fun ~sw:_ ~net:_ ~clock:_ ->
+  with_eio (fun ~sw:_ ~net:_ ~clock ->
     with_temp_keepers_dir (fun _keepers_dir ->
       let keeper_id = "reconcile-cas-keeper" in
       let now = 1_000_000.0 in
@@ -1454,25 +1454,38 @@ let test_run_reconcile_cas_abandons_on_concurrent_write () =
       (* One still-open ref: classify routes it to verify, and [Still_open] makes the
          pass want to advance (advanced>0 -> it would rewrite). *)
       Memory_io.append_fact ~keeper_id (stale_ref_fact ~now ~id:"2" "PR #2 in review");
-      (* A verify that, on its first call, commits a concurrent write to the store (a
-         fresh fact) before returning. Because verify now runs with the facts lock
-         RELEASED, this append lands during the verify window. The reconciler must
-         then re-read under the lock, see the snapshot changed, and abandon its (now
-         stale) rewrite rather than clobbering the concurrent fact. *)
+      (* A verify that, on its first call, commits a concurrent write through the
+         same facts-lock helper real writers use before returning. Because verify
+         now runs with the facts lock RELEASED, this write acquires the lock during
+         the verify window. The reconciler must then re-read under the lock, see the
+         snapshot changed, and abandon its stale rewrite rather than clobbering the
+         concurrent fact. *)
       let injected = ref false in
+      let lock_honoring_writer_completed = ref false in
       let verify : Reconcile.verify_fn =
         fun _r ->
         if not !injected
         then (
           injected := true;
-          Memory_io.append_fact
+          Memory_io.with_facts_lock
+            ~clock
             ~keeper_id
-            (stale_ref_fact ~now ~id:"99" "PR #99 concurrent append"));
+            ~on_timeout:(fun msg ->
+              Alcotest.fail ("writer could not acquire facts lock during verify: " ^ msg))
+            (fun () ->
+              Memory_io.append_fact
+                ~keeper_id
+                (stale_ref_fact ~now ~id:"99" "PR #99 concurrent append");
+              lock_honoring_writer_completed := true));
         Reconcile.Still_open
       in
       let report =
         Reconcile.run_reconcile ~dry_run:false ~keeper_id ~now ~horizon ~verify ()
       in
+      Alcotest.(check bool)
+        "lock-honoring writer acquired facts lock during verify"
+        true
+        !lock_honoring_writer_completed;
       Alcotest.(check int)
         "the still-open ref was classified as an advance"
         1
@@ -1489,8 +1502,9 @@ let test_run_reconcile_cas_abandons_on_concurrent_write () =
       in
       (* MUTATION: replacing the [same_fact_snapshot] CAS with an unconditional rewrite
          persists the stale survivors (just "PR #2"), dropping the concurrently-appended
-         "PR #99" — this membership check then fails. That is the lost-update teeth, and
-         it also proves the lock was released during verify (the append could commit). *)
+         "PR #99" — this membership check then fails. That is the lost-update teeth. The
+         explicit writer-completed assertion above proves the lock was released during
+         verify for a writer that also honors the facts lock. *)
       Alcotest.(check bool)
         "concurrently-appended fact survived (not clobbered by a stale rewrite)"
         true


### PR DESCRIPTION
## 목표

RFC-0259 P3 적대 리뷰의 HIGH finding(이슈 #21716 #1)을 해소한다: `run_reconcile`이 per-keeper facts lock을 **느린 verify 동안 내내 보유**해, 그 lock을 공유하는 librarian write / GC / consolidation 을 verify 창 전체 동안 정체시킨다. lock·verify가 `dry_run` 게이트 밖이라, dry-run reconciler(`MASC_KEEPER_MEMORY_OS_RECONCILE`)만 켜도 K개 ref당 ~10s씩 메모리 쓰기가 막힌다. **RECONCILE fiber를 켜기 전 처리 필수**로 분류된 항목.

## 접근 (consolidation 선례 미러링)

같은 모듈군(consolidation runtime)이 *동일 문제*(느린 주입 IO를 facts lock 밖에서)에 이미 쓰는 snapshot-CAS 패턴을 그대로 따른다. 적대 설계 워크플로에서 3개 후보(snapshot-CAS / verdict-merge / fingerprint-retry)를 lost-update·실행가능성 2렌즈로 공격 → 데이터 손실 공격 0건 생존, 새 추상화 최소·선례 일치인 snapshot-CAS 채택.

- **Phase 1 (lock 없음)**: strict read + 주입된 verify(ref당 gh 1회). lock 미보유 → 다른 writer 정체 없음.
- `dry_run` → lock 잡기 전 short-circuit. `advanced=0`(still-open 없음) → 무쓰기, lock 안 잡음.
- **Phase 2 (lock)**: 재-read 후 store가 분류한 snapshot과 **byte-identical일 때만** rewrite(optimistic concurrency, `Keeper_memory_os_io.same_fact_snapshot`). verify 창 동안 동시 writer가 commit했으면 snapshot이 달라 rewrite를 **포기**(다음 tick 재시도) — stale survivor로 덮어쓰지 않음. 재-read가 파싱 실패하면 `Fact_store_corrupt` raise(preserve over delete). 재-read와 rewrite는 한 lock 획득 안 → 제3 writer 끼어들기 불가.

## 변경

- `lib/keeper/keeper_memory_os_reconcile.ml(.mli)`: `run_reconcile` 재구성(off-lock verify + locked CAS). `apply_report`에 `committed:bool` 추가 — caller가 *영속된 advance*와 *CAS-skip/타임아웃된 advance*를 구분해 정직하게 로깅.
- `lib/keeper/keeper_memory_os_io.ml(.mli)`: `fact_fingerprint` / `same_fact_snapshot` / `with_facts_lock`(Flock_timeout→typed skip)을 **SSOT로 승격**.
- `lib/keeper/keeper_memory_os_consolidation_runtime.ml`: 로컬 byte-equality CAS 중복 제거 → 위 공유 헬퍼 사용(메시지 포맷 보존). 중복 CAS 구현 drift 차단(CLAUDE.md "abstraction 부재 admits" 안티패턴).
- `lib/server/server_bootstrap_maintenance.ml`: reconcile 로그에 `committed=%b` 추가.

## 검증 (로컬)

- `dune build --root .` green (clean rebuild).
- `test_keeper_memory_os` green — `rfc-0259 reconcile-io` 그룹에 CAS lost-update 테스트 추가.
- **핵심 테스트(`..._cas_abandons_on_concurrent_write`)**: fake verify가 첫 호출에서 store에 동시 append(verify가 lock 밖이라 가능) → reconcile이 재-read에서 snapshot 변경 감지 → rewrite 포기. 단언: 동시 append된 fact 생존 / 원본 미advance / `committed=false`.
  - **mutation**: CAS를 무조건 rewrite로 교체 → 동시 append fact가 clobber되어 테스트 fail(lost-update teeth). 이 테스트는 lock이 verify 중 풀렸음도 증명(append가 commit 가능했으므로).
- `committed` 양방 커버: advance 테스트(committed=true), CAS 테스트(committed=false).

## 경계 / 범위

RFC-0259 §3.4 **구현 follow-up**(observable semantics 무변경): demote-not-delete / advance-only-Stale_open / uncertainty-never-acts / preserve-over-delete / write-only-on-advance / 2-게이트 롤아웃 전부 보존. `reconcile_facts`(§3.4 순수 core) 무변경. RFC 어멘드먼트 불필요.

후속(이슈 #21716에 잔존): fsync 부재(MED), demote terminal의 valid_until까지 recall 노출(tradeoff). TLA+ NoLostUpdate bug-model은 실행 가능한 mutation 테스트로 우선 충족, 후속 강화 여지.

## 워크어라운드 게이트

해당 없음. CAS-on-contention의 "skip this cycle"은 symptom 억제(cap/cooldown/dedup/repair)가 아니라 **optimistic concurrency의 표준 정합성 기제**(in-tree consolidation 선례와 동일). 근본(느린 IO를 lock 안에서)을 *제거*(lock 밖으로)하고, 그 결과 생기는 unlocked gap을 CAS로 닫는 root fix. telemetry-as-fix / string 분류기 / N-of-M 시그니처 아님.

RFC-WAIVED: RFC-0259 §3.4 구현 정합성 fix(동시성/락). credential/identity/operator/sandbox/dashboard/hooks/workflow subsystem 미해당. memory_os reconcile 동시성 경계 보강.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
