### PR TITLE
fix(task): export goal assignment facade

### DIFF
--- a/lib/task.mli
+++ b/lib/task.mli
@@ -4,6 +4,7 @@ end
 module Tool : module type of Masc_task_handlers.Tool_task
 module Anti_rationalization : module type of Masc_task_handlers.Anti_rationalization
 module Dispatch : module type of Masc_task_handlers.Task_dispatch
+module Goal_assignment : module type of Masc_task_handlers.Task_goal_assignment
 module Transition_state : module type of Masc_task_handlers.Task_transition_state
 module Schemas : module type of Masc_task_handlers.Tool_task_schemas
 module Payloads : module type of Masc_task_handlers.Tool_task_payloads


### PR DESCRIPTION
## Summary

- Export `Task.Goal_assignment` from `lib/task.mli` to match the facade implementation in `lib/task.ml`.
- Restores the public module path used by the merged RFC-0267 P2 dashboard route and `test/test_goal_task_assignment.ml`.

## Validation

- `opam exec -- ocamlformat --check lib/task.mli`
- `git diff --check`

Full build intentionally not run locally per operator instruction; CI is the build authority.

## CI

- Current GitHub Actions run: https://github.com/jeong-sik/masc/actions/runs/27862464526
  - `headSha=3c5c234c6c48de5f41afdb61acb1085fa26eed18`
  - `Health`, `Lint`, `Build and Test`, and `CI Gate` passed.
