### PR TITLE
feat(dashboard): exact turn_ref match in turn inspector (RFC-0233 §7 PR-D core)

### DIFF
--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchKeeperTurnRecords, type TurnRecordsResponse } from '../api/dashboard'
 import {
   initialTurnRowForTimestamp,
+  initialTurnRowForTurnRef,
   KeeperMemoryOsRecallPanel,
   KeeperTurnInspector,
 } from './keeper-turn-inspector'
@@ -209,6 +210,31 @@ describe('KeeperTurnInspector v2 drawer', () => {
     expect(initialTurnRowForTimestamp(response.entries, nearTurn42)?.record.absolute_turn).toBe(42)
     expect(initialTurnRowForTimestamp(response.entries, farFromRetainedTurns)).toBeNull()
     expect(initialTurnRowForTimestamp(response.entries, 'not-a-date')).toBeNull()
+  })
+
+  it('matches an exact turn_ref (trace_id + absolute_turn), no fuzzy fallback', () => {
+    const response = turnRecordsWithMemoryOs()
+
+    // Exact key hits the precise row, not the nearest by time.
+    expect(
+      initialTurnRowForTurnRef(response.entries, 'trace-active#42')?.record.absolute_turn,
+    ).toBe(42)
+    expect(
+      initialTurnRowForTurnRef(response.entries, 'trace-active#41')?.record.absolute_turn,
+    ).toBe(41)
+
+    // A present-but-unmatched key returns null (never a window guess).
+    expect(initialTurnRowForTurnRef(response.entries, 'trace-active#999')).toBeNull()
+    expect(initialTurnRowForTurnRef(response.entries, 'trace-other#42')).toBeNull()
+
+    // Malformed keys decode to null, never throw.
+    expect(initialTurnRowForTurnRef(response.entries, 'no-separator')).toBeNull()
+    expect(initialTurnRowForTurnRef(response.entries, 'trace-active#abc')).toBeNull()
+    expect(initialTurnRowForTurnRef(response.entries, 'trace-active#')).toBeNull()
+    expect(initialTurnRowForTurnRef(response.entries, '#42')).toBeNull()
+    expect(initialTurnRowForTurnRef(response.entries, null)).toBeNull()
+    expect(initialTurnRowForTurnRef(response.entries, undefined)).toBeNull()
+    expect(initialTurnRowForTurnRef([], 'trace-active#42')).toBeNull()
   })
 
   it('opens the detail drawer when an initial timestamp matches a retained turn', async () => {

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -49,6 +49,31 @@ export function initialTurnRowForTimestamp(
   return best && best.delta <= INITIAL_TURN_MATCH_WINDOW_SEC ? best.row : null
 }
 
+// RFC-0233 §7: exact turn join-key match, superseding the 30-min timestamp
+// window (§7.6 guard #3). [turnRef] is "<trace_id>#<absolute_turn>" minted
+// MASC-side and carried on the originating chat row / board post; split on the
+// LAST '#' (a trace_id may itself contain '#') and match trace_id +
+// absolute_turn exactly against the server turn records. A malformed key or a
+// turn not present in the loaded records returns null — never a fuzzy
+// fallback, so an exact key cannot mis-attribute.
+export function initialTurnRowForTurnRef(
+  rows: TurnRecordRow[],
+  turnRef?: string | null,
+): TurnRecordRow | null {
+  if (!turnRef || rows.length === 0) return null
+  const hash = turnRef.lastIndexOf('#')
+  if (hash <= 0 || hash === turnRef.length - 1) return null
+  const suffix = turnRef.slice(hash + 1)
+  if (!/^\d+$/.test(suffix)) return null
+  const trace = turnRef.slice(0, hash)
+  const turn = Number(suffix)
+  return (
+    rows.find(
+      row => row.record.trace_id === trace && row.record.absolute_turn === turn,
+    ) ?? null
+  )
+}
+
 function FreshnessLine({ data }: { data: TelemetryFreshnessMetadata }) {
   const gap = coverageGapDisplay(data)
   return html`
@@ -769,14 +794,19 @@ function TurnRow({
 export function KeeperTurnInspector({
   keeperName,
   initialTurnTimestamp,
+  initialTurnRef,
 }: {
   keeperName: string
   initialTurnTimestamp?: string | null
+  // RFC-0233 §7: exact turn join key from the originating chat row / board
+  // post. When present it supersedes [initialTurnTimestamp] (exact match, no
+  // window). Callers thread it as the turn_ref data flows (PR-C / follow-up).
+  initialTurnRef?: string | null
 }) {
   const resource = useManagedAsyncResource<TurnRecordsResponse | null>(null)
   const [selectedRow, setSelectedRow] = useState<TurnRecordRow | null>(null)
   const [initialMatchState, setInitialMatchState] = useState<'idle' | 'matched' | 'missed'>('idle')
-  const appliedInitialTurnTimestamp = useRef<string | null>(null)
+  const appliedInitialTurnKey = useRef<string | null>(null)
 
   useEffect(() => {
     void resource.load(async (signal) => {
@@ -791,30 +821,41 @@ export function KeeperTurnInspector({
   const rows = response?.entries ?? EMPTY_TURN_RECORD_ROWS
   // Server returns oldest-first; show newest first.
   const sorted = useMemo(() => [...rows].reverse(), [rows])
-  const initialMatchedRow = useMemo(
-    () => initialTurnRowForTimestamp(rows, initialTurnTimestamp),
-    [rows, initialTurnTimestamp],
-  )
+  const initialMatchedRow = useMemo(() => {
+    const exact = initialTurnRowForTurnRef(rows, initialTurnRef)
+    if (exact) return exact
+    // WORKAROUND (RFC-0233 §7.6 #3): legacy chat rows / board posts carry no
+    // turn_ref, so fall back to the 30-min timestamp window for those only.
+    // When a turn_ref IS present, a miss stays null — no fuzzy attribution.
+    // removal target: turn_ref backfilled onto persisted rows + populated by
+    // every producer (RFC-0233 follow-up).
+    if (initialTurnRef) return null
+    return initialTurnRowForTimestamp(rows, initialTurnTimestamp)
+  }, [rows, initialTurnRef, initialTurnTimestamp])
+
+  // Identity of the requested turn: the exact join key when available, else the
+  // timestamp. Drives the apply-once tracking below so either entry point works.
+  const initialTurnKey = initialTurnRef ?? initialTurnTimestamp ?? null
 
   useEffect(() => {
-    appliedInitialTurnTimestamp.current = null
+    appliedInitialTurnKey.current = null
     setInitialMatchState('idle')
     setSelectedRow(null)
-  }, [keeperName, initialTurnTimestamp])
+  }, [keeperName, initialTurnKey])
 
   useEffect(() => {
     if (
-      !initialTurnTimestamp
+      !initialTurnKey
       || rows.length === 0
-      || appliedInitialTurnTimestamp.current === initialTurnTimestamp
+      || appliedInitialTurnKey.current === initialTurnKey
     ) {
       return
     }
 
     setSelectedRow(initialMatchedRow)
     setInitialMatchState(initialMatchedRow ? 'matched' : 'missed')
-    appliedInitialTurnTimestamp.current = initialTurnTimestamp
-  }, [initialTurnTimestamp, initialMatchedRow, rows.length])
+    appliedInitialTurnKey.current = initialTurnKey
+  }, [initialTurnKey, initialMatchedRow, rows.length])
 
   if (resource.state.value.loading) {
     return html`<${LoadingState}>턴 레코드 불러오는 중...<//>`
@@ -855,7 +896,9 @@ export function KeeperTurnInspector({
             class="rounded-[var(--r-1)] border border-[var(--color-status-warn)]/40 bg-[var(--color-bg-surface)] px-2 py-1.5 text-2xs text-[var(--color-fg-muted)] v2-monitoring-row"
             data-testid="turn-linked-empty"
           >
-            메시지 시각과 30분 이내의 turn record 없음. 리스트에서 직접 선택하세요.
+            ${initialTurnRef
+              ? '연결된 turn record를 찾지 못했습니다. 리스트에서 직접 선택하세요.'
+              : '메시지 시각과 30분 이내의 turn record 없음. 리스트에서 직접 선택하세요.'}
           </div>
         `
         : null}


### PR DESCRIPTION
## 무엇을 / 왜

RFC-0233 §7의 **PR-D core — 턴 인스펙터의 정확 turn_ref 매칭**. 기존 30분 timestamp-window 매칭(RFC §7.6 guard #3, dense/sparse 턴·clock skew에서 오귀속하는 휴리스틱)을 **정확 join-key 매칭**으로 대체한다.

## 변경 (프론트엔드 전용)

- `initialTurnRowForTurnRef(rows, turnRef)`: `"<trace_id>#<absolute_turn>"`를 마지막 `#`로 split(trace에 `#` 포함 가능, digits-only suffix)해 서버 turn record와 `trace_id`+`absolute_turn` **정확 매칭**. malformed 키나 로드된 record에 없는 턴 → null, **fuzzy fallback 없음**.
- `KeeperTurnInspector`에 `initialTurnRef` prop 추가 — `initialTurnTimestamp`를 supersede. 30분 window는 turn_ref 없는 **legacy 행 전용 fallback**으로만 생존(주석 + removal target 명시). turn_ref가 *있는데* miss면 null 유지(오귀속 차단).
- apply-once tracking을 timestamp→turn key로 일반화(두 진입점 모두 동작), missed 메시지도 exact/window 모드 반영.

## 의존성 / 범위

`initialTurnRef` prop은 **caller가 thread하기 전까진 dormant**: turn_ref를 `KeeperConversationEntry`에 싣고 chat/board nav 액션에서 전달하는 것은 **PR-C(#21746 chat turn_ref, #21755 board origin) 머지 의존 → PR-D follow-up**. 이 PR은 정확매칭 capability+테스트를 랜딩해 window를 설계상 legacy-only로 강등한다(PR-C-chat/board가 데이터를 흘리면 자동 활성). **PR-C 비의존**(매처는 turn_ref string만 받음)이라 main에 독립 검증·머지 가능.

## 검증

- `keeper-turn-inspector.test.ts`: exact hit(trace+turn) / 미매치 키→null(window guess 안 함) / malformed 키→null(never throws). **vitest 13/13**, **`tsc --noEmit` clean(exit 0)**.

## Workaround Guards (RFC-0233 §7.6 준수)

- **#3 window-join 제거**: 정확 `(trace_id, absolute_turn)` 매칭이 primary. 30분 window는 legacy `turn_ref` 부재 행 전용 commented fallback + removal target(turn_ref backfill 완료 시).
- **#1 client 파생 id 없음**: turn_ref는 MASC-side mint된 키를 파싱만(fabricate 아님).

## Follow-up

`KeeperConversationEntry.turnRef` + chat→turn/board→turn nav 액션이 `initialTurnRef` 전달(PR-C 머지 후). + turn_ref backfill로 window 완전 제거.

Refs: RFC-0233 §7 (§7.5 PR-D, §7.6 #3). 관련: PR-C-chat #21746, PR-C-board #21755.
