### PR TITLE
[codex] Fix goal assignment facade CI break

### DIFF
--- a/lib/task.mli
+++ b/lib/task.mli
@@ -4,6 +4,7 @@ end
 module Tool : module type of Masc_task_handlers.Tool_task
 module Anti_rationalization : module type of Masc_task_handlers.Anti_rationalization
 module Dispatch : module type of Masc_task_handlers.Task_dispatch
+module Goal_assignment : module type of Masc_task_handlers.Task_goal_assignment
 module Transition_state : module type of Masc_task_handlers.Task_transition_state
 module Schemas : module type of Masc_task_handlers.Tool_task_schemas
 module Payloads : module type of Masc_task_handlers.Tool_task_payloads

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1,5 +1,7 @@
 module Types = Masc_domain
 
+let () = Mirage_crypto_rng_unix.use_default ()
+
 module Lib = Masc
 module Auth = Masc.Auth
 module Workspace = Masc.Workspace

--- a/test/test_goal_task_assignment.ml
+++ b/test/test_goal_task_assignment.ml
@@ -11,6 +11,8 @@ open Alcotest
 open Masc_domain
 open Masc
 
+module Goal_assignment = Masc.Task.Goal_assignment
+
 let with_test_env f =
   Eio_main.run
   @@ fun env ->
@@ -52,15 +54,15 @@ let make_unassigned_task config ~title =
   | [] -> fail "task was not created"
 ;;
 
-let err_to_string = Task.Goal_assignment.set_task_goal_error_to_string
+let err_to_string = Goal_assignment.set_task_goal_error_to_string
 
 let test_unknown_task () =
   with_test_env (fun config ->
     make_goal config ~id:"goal-a";
     match
-      Task.Goal_assignment.set_task_goal config ~task_id:"task-nope" ~goal_id:"goal-a"
+      Goal_assignment.set_task_goal config ~task_id:"task-nope" ~goal_id:"goal-a"
     with
-    | Error (Task.Goal_assignment.Unknown_task t) ->
+    | Error (Goal_assignment.Unknown_task t) ->
       check string "names the missing task" "task-nope" t
     | Ok () -> fail "expected Unknown_task, got Ok"
     | Error other -> failf "expected Unknown_task, got %s" (err_to_string other))
@@ -70,9 +72,9 @@ let test_unknown_goal () =
   with_test_env (fun config ->
     let task_id = make_unassigned_task config ~title:"t" in
     match
-      Task.Goal_assignment.set_task_goal config ~task_id ~goal_id:"goal-nope"
+      Goal_assignment.set_task_goal config ~task_id ~goal_id:"goal-nope"
     with
-    | Error (Task.Goal_assignment.Unknown_goal g) ->
+    | Error (Goal_assignment.Unknown_goal g) ->
       check string "names the missing goal" "goal-nope" g
     | Ok () -> fail "expected Unknown_goal, got Ok"
     | Error other -> failf "expected Unknown_goal, got %s" (err_to_string other))
@@ -82,7 +84,7 @@ let test_links_goalless_task () =
   with_test_env (fun config ->
     make_goal config ~id:"goal-a";
     let task_id = make_unassigned_task config ~title:"t" in
-    (match Task.Goal_assignment.set_task_goal config ~task_id ~goal_id:"goal-a" with
+    (match Goal_assignment.set_task_goal config ~task_id ~goal_id:"goal-a" with
      | Ok () -> ()
      | Error e -> failf "expected Ok, got %s" (err_to_string e));
     let links = Workspace_goal_index.read_goal_task_links config in
@@ -101,11 +103,11 @@ let test_rejects_reassignment () =
     make_goal config ~id:"goal-a";
     make_goal config ~id:"goal-b";
     let task_id = make_unassigned_task config ~title:"t" in
-    (match Task.Goal_assignment.set_task_goal config ~task_id ~goal_id:"goal-a" with
+    (match Goal_assignment.set_task_goal config ~task_id ~goal_id:"goal-a" with
      | Ok () -> ()
      | Error e -> failf "first assign should succeed: %s" (err_to_string e));
-    match Task.Goal_assignment.set_task_goal config ~task_id ~goal_id:"goal-b" with
-    | Error (Task.Goal_assignment.Already_assigned { task_id = t; existing_goal_ids }) ->
+    match Goal_assignment.set_task_goal config ~task_id ~goal_id:"goal-b" with
+    | Error (Goal_assignment.Already_assigned { task_id = t; existing_goal_ids }) ->
       check string "error names the task" task_id t;
       check (list string) "reports the existing link" [ "goal-a" ] existing_goal_ids
     | Ok () -> fail "expected Already_assigned, got Ok (reassignment must be rejected)"


### PR DESCRIPTION
## Summary

- expose Task.Goal_assignment from the public Task facade interface
- use an explicit Masc.Task.Goal_assignment alias in the goal assignment regression test
- fixes main CI failures in Lint, Health, and Build caused by Unbound module Task.Goal_assignment

## Validation

- scripts/opam-pin-external-deps.sh --install
- scripts/check-oas-pin.sh --local-only
- ocamlformat --check lib/task.mli test/test_goal_task_assignment.ml
- git diff --check
- env OCAMLPARAM=_,warn-error=+a MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build @install test/test_goal_task_assignment.exe
- ./_build/default/test/test_goal_task_assignment.exe