### PR TITLE
feat(keeper): project chat rich blocks to connectors

### DIFF
--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -263,7 +263,9 @@ let rich_embed_of_chat_block = function
   | Keeper_chat_blocks.Text _ | Keeper_chat_blocks.Fusion _ -> None
 
 let rich_embeds_of_text text =
-  Keeper_chat_blocks.parse_text_to_blocks text
+  text
+  |> Observability_redact.redact_text
+  |> Keeper_chat_blocks.parse_text_to_blocks
   |> List.filter_map rich_embed_of_chat_block
 
 let send_text_rich_embeds ~token ~channel_id text =

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -251,6 +251,36 @@ let send_audio_block ~token ~channel_id ~base_url ~audio_token ~message_text
   in
   send_message ~token ~channel_id ~content
 
+let rich_embed_of_chat_block = function
+  | Keeper_chat_blocks.Image { src; cap } ->
+      let caption = Option.map Observability_redact.redact_text cap in
+      Some (Discord_rest_client.image_embed ~url:src ~caption)
+  | Keeper_chat_blocks.Link { url; title; meta = _ } ->
+      let title = Observability_redact.redact_text title in
+      Some
+        (Discord_rest_client.link_embed ~url ~title ~description:None
+           ~image:None)
+  | Keeper_chat_blocks.Text _ | Keeper_chat_blocks.Fusion _ -> None
+
+let rich_embeds_of_text text =
+  Keeper_chat_blocks.parse_text_to_blocks text
+  |> List.filter_map rich_embed_of_chat_block
+
+let send_text_rich_embeds ~token ~channel_id text =
+  rich_embeds_of_text text
+  |> List.iter (fun embed ->
+         match
+           Discord_rest_client.send_embed_message ~token ~channel_id
+             ~content:"" ~embeds:[ embed ] ()
+         with
+         | Ok _msg_id -> ()
+         | Error err ->
+             let err_str =
+               Format.asprintf "%a" Discord_rest_client.pp_error err
+             in
+             Log.Keeper.warn
+               "keeper_chat_discord: send_text_rich_embed failed: %s" err_str)
+
 (* ── Adapter loop ────────────────────────────────────────────────── *)
 
 (* NDT-OK: wall-clock used for Discord rate-limit backoff only,
@@ -348,6 +378,7 @@ let adapter_loop ~token ~channel_id ~events ?base_url () =
               | Some overflow ->
                send_message ~token ~channel_id ~content:overflow
              ));
+        send_text_rich_embeds ~token ~channel_id acc_text;
         (* Loop exits after one turn. *)
         ()
     | Event_error { message } ->
@@ -427,4 +458,5 @@ module For_testing = struct
   let streaming_patch_content = streaming_patch_content
   let final_head_and_overflow = final_head_and_overflow
   let public_voice_audio_url = public_voice_audio_url
+  let rich_embeds_of_text = rich_embeds_of_text
 end

--- a/lib/keeper/keeper_chat_discord.mli
+++ b/lib/keeper/keeper_chat_discord.mli
@@ -36,6 +36,8 @@ val adapter_loop :
       once per {!min_edit_interval_s}.
     - [Text_message_end]: force PATCH if content changed since last edit.
     - [Run_finished]: force final PATCH with complete text.
+      Standalone links and images in the final text are also projected into
+      Discord embeds using the shared server chat-block parser.
     - [Event_error]: sends error text as a new message.
     - [Link_block], [Image_block], [Audio_block]: send rich block embeds
       or messages.
@@ -62,4 +64,9 @@ module For_testing : sig
   val public_voice_audio_url : ?base_url:string -> string -> string
   (** [public_voice_audio_url ?base_url token] returns the public URL for
       an audio clip. Exposed for testing. *)
+
+  val rich_embeds_of_text : string -> Discord_rest_client.embed list
+  (** Project text-derived server chat blocks into Discord embeds. Text and
+      fusion blocks are omitted because the text message already carries the
+      reply and fusion cards have no Discord-native projection yet. *)
 end

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -128,7 +128,9 @@ let slack_block_of_chat_block = function
   | Keeper_chat_blocks.Text _ | Keeper_chat_blocks.Fusion _ -> None
 
 let content_blocks_of_text text =
-  Keeper_chat_blocks.parse_text_to_blocks text
+  text
+  |> redact
+  |> Keeper_chat_blocks.parse_text_to_blocks
   |> List.filter_map slack_block_of_chat_block
 
 let final_message_blocks ~content ~event_blocks =

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -120,85 +120,19 @@ let tool_context_block_json ~name ~args_summary ~result_summary =
 
 (* ── Content → Slack blocks ──────────────────────────────────────── *)
 
-let image_extensions = [ ".png"; ".jpg"; ".jpeg"; ".gif"; ".webp"; ".svg" ]
-
-let is_image_url url =
-  try
-    let ext = String.lowercase_ascii (Filename.extension (Uri.of_string url |> Uri.path)) in
-    List.mem ext image_extensions
-  with _ -> false
-
-let hostname_of_url url =
-  try
-    match Uri.of_string url |> Uri.host with
-    | Some "" | None -> url
-    | Some host ->
-        let len = String.length host in
-        if len > 4 && String.sub host 0 4 = "www." then
-          String.sub host 4 (len - 4)
-        else host
-  with _ -> url
-
-let standalone_url_re =
-  Re.Pcre.re ~flags:[ `CASELESS ] "^https?://\\S+$" |> Re.compile
-
-let markdown_image_re =
-  Re.Pcre.re "!\\[([^\\]]*)\\]\\(([^)]+)\\)" |> Re.compile
-
-let is_standalone_url line = Re.execp standalone_url_re (String.trim line)
-
-let line_to_block line =
-  let trimmed = String.trim line in
-  if trimmed = "" then None
-  else if is_standalone_url trimmed then
-    if is_image_url trimmed then
-      Some (image_block_json ~url:trimmed ~caption:None)
-    else
-      let title = hostname_of_url trimmed in
-      Some (link_block_json ~url:trimmed ~title ~description:None)
-  else None
+let slack_block_of_chat_block = function
+  | Keeper_chat_blocks.Image { src; cap } ->
+      Some (image_block_json ~url:src ~caption:cap)
+  | Keeper_chat_blocks.Link { url; title; meta = _ } ->
+      Some (link_block_json ~url ~title ~description:None)
+  | Keeper_chat_blocks.Text _ | Keeper_chat_blocks.Fusion _ -> None
 
 let content_blocks_of_text text =
-  let rec scan_images acc pos =
-    if pos >= String.length text then List.rev acc
-    else
-      match Re.exec_opt ~pos markdown_image_re text with
-      | Some group ->
-        let start = Re.Group.start group 0 in
-        let before = String.sub text pos (start - pos) in
-        let alt = Re.Group.get group 1 in
-        let url = Re.Group.get group 2 in
-        let next = Re.Group.stop group 0 in
-        scan_images ((before, Some url, Some alt) :: acc) next
-      | None ->
-        let rest = String.sub text pos (String.length text - pos) in
-        List.rev ((rest, None, None) :: acc)
-  in
-  let fragments = scan_images [] 0 in
-  List.fold_left
-    (fun blocks (fragment, image_url, image_alt) ->
-      let blocks =
-        match image_url with
-        | Some url ->
-            let caption =
-              match image_alt with
-              | Some "" | None -> None
-              | Some alt -> Some alt
-            in
-            image_block_json ~url ~caption :: blocks
-        | None -> blocks
-      in
-      let lines = String.split_on_char '\n' fragment in
-      List.fold_left
-        (fun blocks line ->
-          match line_to_block line with
-          | Some block -> block :: blocks
-          | None -> blocks)
-        blocks
-        lines)
-    []
-    fragments
-  |> List.rev
+  Keeper_chat_blocks.parse_text_to_blocks text
+  |> List.filter_map slack_block_of_chat_block
+
+let final_message_blocks ~content ~event_blocks =
+  content_blocks_of_text content @ event_blocks
 
 (* ── HTTP delivery ───────────────────────────────────────────────── *)
 
@@ -294,7 +228,10 @@ let adapter_loop ~token ~channel ~events ?base_url () =
     | Text_message_end ->
         loop ~acc_text ~acc_blocks ~run_id_opt
     | Run_finished { run_id = _ } ->
-        let blocks = List.rev acc_blocks in
+        let blocks =
+          final_message_blocks ~content:acc_text
+            ~event_blocks:(List.rev acc_blocks)
+        in
         if String.length acc_text > 0 || List.length blocks > 0 then
           ignore
             (send_message_with_blocks ~token ~channel ~content:acc_text ~blocks
@@ -342,4 +279,5 @@ module For_testing = struct
   let audio_block_json = audio_block_json
   let tool_context_block_json = tool_context_block_json
   let content_blocks_of_text = content_blocks_of_text
+  let final_message_blocks = final_message_blocks
 end

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -27,11 +27,13 @@ val send_message_with_blocks :
     [Log.Keeper.warn] and returns the outcome. *)
 
 val content_blocks_of_text : string -> Yojson.Safe.t list
-(** [content_blocks_of_text text] extracts rich Slack blocks from plain text:
+(** [content_blocks_of_text text] projects server chat blocks into Slack
+    Block Kit blocks:
     - Markdown images [![alt](url)] become image blocks.
     - Standalone image URLs (png/jpg/gif/webp/svg) become image blocks.
     - Other standalone URLs become link blocks with a hostname-derived title.
-    Non-URL text is omitted because it is delivered via the [content] field. *)
+    Text and fusion blocks are omitted because text is delivered via the
+    [content] field and fusion cards have no Slack-native projection yet. *)
 
 val adapter_loop :
   token:string ->
@@ -78,4 +80,9 @@ module For_testing : sig
 
   val content_blocks_of_text : string -> Yojson.Safe.t list
   (** Same as {!content_blocks_of_text}; exposed for unit testing. *)
+
+  val final_message_blocks :
+    content:string -> event_blocks:Yojson.Safe.t list -> Yojson.Safe.t list
+  (** Merge text-derived blocks with explicitly emitted rich event blocks in
+      final delivery order. *)
 end

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1134,8 +1134,9 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                     Tool_call_end)
             then loop ()
         | Link_block _ | Image_block _ | Audio_block _ | Tool_context_block _ ->
-            (* Rich blocks are Discord-specific; the SSE stream already
-               receives the underlying text/audio through other events. *)
+            (* Connector rich blocks are delivered by non-dashboard adapters;
+               the SSE stream already receives the underlying text/audio
+               through other events. *)
             loop ()
         | Event_error { message } -> send_error message
         | Run_finished { run_id } ->

--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -86,6 +86,27 @@ let test_rich_embeds_of_text_projects_links_and_images () =
   check bool "image caption" true
     (contains image_json "\"description\":\"diagram\"")
 
+let test_rich_embeds_redacts_text_derived_image_secrets () =
+  let secret = "sk-proj-abcdefghijklmnopqrstuvwxyz" in
+  let embeds =
+    D.rich_embeds_of_text
+      (Printf.sprintf "![%s](https://example.com/diagram.png?token=%s)"
+         secret secret)
+  in
+  check int "one image embed" 1 (List.length embeds);
+  let image_json =
+    Discord_rest_client.embed_to_json (List.hd embeds) |> Yojson.Safe.to_string
+  in
+  check bool "raw secret removed" false (contains image_json secret);
+  check bool "redaction marker present" true
+    (contains image_json "[REDACTED]")
+
+let test_rich_embeds_suppresses_credential_url () =
+  let embeds =
+    D.rich_embeds_of_text "https://user:pass@example.com/diagram.png"
+  in
+  check int "credential URL does not become embed" 0 (List.length embeds)
+
 let () =
   run "keeper_chat_discord"
     [ ( "streaming-redaction"
@@ -109,5 +130,9 @@ let () =
             test_public_voice_audio_url_strips_trailing_slash
         ; test_case "projects text links and images to embeds" `Quick
             test_rich_embeds_of_text_projects_links_and_images
+        ; test_case "redacts text-derived image secrets" `Quick
+            test_rich_embeds_redacts_text_derived_image_secrets
+        ; test_case "suppresses credential URL embeds" `Quick
+            test_rich_embeds_suppresses_credential_url
         ] )
     ]

--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -65,6 +65,27 @@ let test_public_voice_audio_url_strips_trailing_slash () =
   check string "audio URL"
     "https://chat.example.com/api/v1/voice/audio/tok123" url
 
+let test_rich_embeds_of_text_projects_links_and_images () =
+  let embeds =
+    D.rich_embeds_of_text
+      "https://example.com/page\n![diagram](https://example.com/diagram.png)\nplain text"
+  in
+  check int "two embeds" 2 (List.length embeds);
+  let link_json =
+    Discord_rest_client.embed_to_json (List.hd embeds) |> Yojson.Safe.to_string
+  in
+  check bool "link title" true (contains link_json "\"title\":\"example.com\"");
+  check bool "link url" true
+    (contains link_json "\"url\":\"https://example.com/page\"");
+  let image_json =
+    Discord_rest_client.embed_to_json (List.nth embeds 1)
+    |> Yojson.Safe.to_string
+  in
+  check bool "image url" true
+    (contains image_json "\"url\":\"https://example.com/diagram.png\"");
+  check bool "image caption" true
+    (contains image_json "\"description\":\"diagram\"")
+
 let () =
   run "keeper_chat_discord"
     [ ( "streaming-redaction"
@@ -86,5 +107,7 @@ let () =
             test_public_voice_audio_url_uses_base_url
         ; test_case "audio URL strips trailing slash" `Quick
             test_public_voice_audio_url_strips_trailing_slash
+        ; test_case "projects text links and images to embeds" `Quick
+            test_rich_embeds_of_text_projects_links_and_images
         ] )
     ]

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -162,6 +162,24 @@ let test_content_blocks_mixed_content () =
   in
   check int "two blocks" 2 (List.length blocks)
 
+let test_final_message_blocks_merges_text_and_event_blocks () =
+  let event_block =
+    S.link_block_json ~url:"https://event.example.com"
+      ~title:"event" ~description:None
+  in
+  let blocks =
+    S.final_message_blocks
+      ~content:"https://example.com/photo.jpg"
+      ~event_blocks:[ event_block ]
+  in
+  check int "text block plus event block" 2 (List.length blocks);
+  let first = json_string (List.hd blocks) in
+  check bool "text-derived image first" true
+    (contains first "\"image_url\":\"https://example.com/photo.jpg\"");
+  let second = json_string (List.nth blocks 1) in
+  check bool "event block preserved" true
+    (contains second "https://event.example.com")
+
 let () =
   run "keeper_chat_slack"
     [
@@ -199,5 +217,7 @@ let () =
             test_content_blocks_detects_bare_image_url
         ; test_case "detects link" `Quick test_content_blocks_detects_link
         ; test_case "mixed content" `Quick test_content_blocks_mixed_content
+        ; test_case "final delivery merges text and event blocks" `Quick
+            test_final_message_blocks_merges_text_and_event_blocks
         ] )
     ]

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -162,6 +162,24 @@ let test_content_blocks_mixed_content () =
   in
   check int "two blocks" 2 (List.length blocks)
 
+let test_content_blocks_redacts_text_derived_image_secrets () =
+  let secret = "sk-proj-abcdefghijklmnopqrstuvwxyz" in
+  let blocks =
+    S.content_blocks_of_text
+      (Printf.sprintf "![%s](https://example.com/diagram.png?token=%s)"
+         secret secret)
+  in
+  check int "one image block" 1 (List.length blocks);
+  let s = json_string (List.hd blocks) in
+  check bool "raw secret removed" false (contains s secret);
+  check bool "redaction marker present" true (contains s "[REDACTED]")
+
+let test_content_blocks_suppresses_credential_url () =
+  let blocks =
+    S.content_blocks_of_text "https://user:pass@example.com/diagram.png"
+  in
+  check int "credential URL does not become block" 0 (List.length blocks)
+
 let test_final_message_blocks_merges_text_and_event_blocks () =
   let event_block =
     S.link_block_json ~url:"https://event.example.com"
@@ -217,6 +235,10 @@ let () =
             test_content_blocks_detects_bare_image_url
         ; test_case "detects link" `Quick test_content_blocks_detects_link
         ; test_case "mixed content" `Quick test_content_blocks_mixed_content
+        ; test_case "redacts text-derived image secrets" `Quick
+            test_content_blocks_redacts_text_derived_image_secrets
+        ; test_case "suppresses credential URL blocks" `Quick
+            test_content_blocks_suppresses_credential_url
         ; test_case "final delivery merges text and event blocks" `Quick
             test_final_message_blocks_merges_text_and_event_blocks
         ] )


### PR DESCRIPTION
## Summary
- reuse `Keeper_chat_blocks.parse_text_to_blocks` as the server-side rich text SSOT for connector delivery
- make queued Slack chat include text-derived link/image Block Kit blocks, not only explicit rich events
- make Discord project final text links/images into embeds using the same parser
- keep dashboard SSE behavior unchanged; connector rich blocks stay on non-dashboard adapters

## Validation
- `opam exec -- ocamlformat --check lib/keeper/keeper_chat_slack.ml lib/keeper/keeper_chat_slack.mli lib/keeper/keeper_chat_discord.ml lib/keeper/keeper_chat_discord.mli lib/server/server_routes_http_keeper_stream.ml test/test_keeper_chat_slack.ml test/test_keeper_chat_discord.ml`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/ci/check-determinism-contract.sh`
- danger-pattern grep over touched files: no matches

Focused Dune wrapper attempted: `scripts/dune-local.sh build test/test_keeper_chat_slack.exe test/test_keeper_chat_discord.exe`; local run stopped before build because the current opam switch lacks the `agent_sdk` pin. I did not repair the switch in this PR run.

Note: current main/PR merge refs may still show the pre-existing `Task.Goal_assignment` facade failure until #21758 lands.
