### PR TITLE
fix(keeper): expose turn-based voice capability

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1226,8 +1226,9 @@ let internal_descriptors : t list =
       ~readonly:true
   ; voice_descriptor
       "keeper_voice_agent"
-      "Invoke the realtime voice agent for the current keeper."
-      ~readonly:false
+      "Read the keeper voice capability, assigned voice, and active turn-based \
+       session state. This does not start a realtime audio stream."
+      ~readonly:true
   ; voice_descriptor
       "keeper_voice_sessions"
       "List active voice sessions for this keeper."

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -243,9 +243,43 @@ let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) () =
       ; "agent_id", `String meta.name
       ]
 
+let append_assoc_fields json fields =
+  match json with
+  | `Assoc existing -> `Assoc (existing @ fields)
+  | other -> `Assoc (("voice_config", other) :: fields)
+
+let voice_agent_capability_fields ~(meta : keeper_meta) =
+  let mgr = Keeper_voice_local.get_session_manager () in
+  let active_session = Voice_session_manager.get_session mgr ~agent_id:meta.name in
+  [ "conversation_mode", `String "turn_based"
+  ; "realtime_supported", `Bool false
+  ; "session_active", `Bool (Option.is_some active_session)
+  ; ( "active_session"
+    , match active_session with
+      | Some session -> Voice_session_manager.session_to_json session
+      | None -> `Null )
+  ; ( "input_modes"
+    , `List [ `String "browser_record_transcribe"; `String "server_microphone_listen" ] )
+  ; ( "output_modes"
+    , `List [ `String "tts_audio_clip"; `String "local_playback_if_configured" ] )
+  ; ( "session_control_tools"
+    , `List
+        [ `String "keeper_voice_session_start"
+        ; `String "keeper_voice_speak"
+        ; `String "keeper_voice_listen"
+        ; `String "keeper_voice_session_end"
+        ] )
+  ; ( "realtime_gap"
+    , `String
+        "No full-duplex live audio stream is bound to keeper turns; speech input \
+         is transcribed into text before the normal keeper turn." )
+  ]
+
 let handle_agent ~(meta : keeper_meta) =
   match Voice_bridge.get_agent_voice ~agent_id:meta.name with
-  | Ok json -> Yojson.Safe.to_string json
+  | Ok json ->
+    Yojson.Safe.to_string
+      (append_assoc_fields json (voice_agent_capability_fields ~meta))
   | Error err ->
     Tool_args.error_response_with
       [ "agent_id", `String meta.name

--- a/lib/tool_surface/tool_shard_types_schemas_voice.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_voice.ml
@@ -64,8 +64,10 @@ let voice_tools : Masc_domain.tool_schema list =
     }
   ; { name = "keeper_voice_agent"
     ; description =
-        "Get your own voice configuration (assigned voice, available voices). No network \
-         required."
+        "Get your own voice capability and configuration. Reports assigned voice, \
+         available voices, active turn-based voice session state, and \
+         realtime_supported=false when no full-duplex live audio stream is bound to \
+         keeper turns. No network required."
     ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
     }
   ; { name = "keeper_voice_sessions"

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -502,6 +502,60 @@ let test_keeper_voice_session_end_reports_ended () =
       (Yojson.Safe.Util.member "discarded_voice_queue_jobs" end_json = `Null))
 ;;
 
+let test_keeper_voice_agent_reports_turn_based_capability () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let mono_clock = Eio.Stdenv.mono_clock env in
+  Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
+    let config = test_config () in
+    let meta = make_keeper_meta "voice-capability-keeper" in
+    let read_agent () =
+      Masc.Keeper_tool_voice_runtime.handle_voice_tool
+        ~config
+        ~meta
+        ~name:"keeper_voice_agent"
+        ~args:(`Assoc [])
+        ()
+      |> Yojson.Safe.from_string
+    in
+    let end_session () =
+      ignore
+        (Masc.Keeper_tool_voice_runtime.handle_voice_tool
+           ~config
+           ~meta
+           ~name:"keeper_voice_session_end"
+           ~args:(`Assoc [])
+           ())
+    in
+    end_session ();
+    let before = read_agent () in
+    check string "conversation mode" "turn_based"
+      Yojson.Safe.Util.(member "conversation_mode" before |> to_string);
+    check bool "realtime unsupported" false
+      Yojson.Safe.Util.(member "realtime_supported" before |> to_bool);
+    check bool "no active session" false
+      Yojson.Safe.Util.(member "session_active" before |> to_bool);
+    check bool "active_session is null" true
+      (Yojson.Safe.Util.member "active_session" before = `Null);
+    ignore
+      (Masc.Keeper_tool_voice_runtime.handle_voice_tool
+         ~config
+         ~meta
+         ~name:"keeper_voice_session_start"
+         ~args:(`Assoc [])
+         ());
+    let after = read_agent () in
+    check bool "session active" true
+      Yojson.Safe.Util.(member "session_active" after |> to_bool);
+    check string "active session agent" meta.name
+      Yojson.Safe.Util.(member "active_session" after |> member "agent_id" |> to_string);
+    end_session ())
+;;
+
 let test_playback_timeout_parsers_and_budget () =
   check (option (float 0.001)) "afinfo duration line parses"
     (Some 236.6)
@@ -663,6 +717,10 @@ let () =
             "session_end reports ended without queue field"
             `Quick
             test_keeper_voice_session_end_reports_ended
+        ; test_case
+            "voice_agent reports turn-based capability"
+            `Quick
+            test_keeper_voice_agent_reports_turn_based_capability
         ] )
     ; ( "playback_timeout"
       , [ test_case


### PR DESCRIPTION
## Summary
- make `keeper_voice_agent` report the current voice capability as `conversation_mode=turn_based` and `realtime_supported=false`
- include `session_active` and `active_session` so Keeper/dashboard can see whether the local voice session is actually open
- align descriptor/schema text and mark `keeper_voice_agent` read-only instead of implying a realtime audio agent invocation

## Validation
- `opam exec -- ocamlformat --check lib/keeper/keeper_tool_voice_runtime.ml lib/keeper/keeper_tool_descriptor.ml lib/tool_surface/tool_shard_types_schemas_voice.ml test/test_voice_runtime_overlay.ml`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/ci/check-determinism-contract.sh` (passes; existing warnings only)
- `scripts/validate-prompt-paths.sh`
- `scripts/dune-local.sh build test/test_voice_runtime_overlay.exe test/test_voice_command_descriptor_parity.exe test/test_tool_shard_coverage.exe` blocked locally because a live bare `dune build --root .` process was already running outside the wrapper
