### PR TITLE
feat(server): expose hibernation capability status

### DIFF
--- a/lib/server/server_hibernation.ml
+++ b/lib/server/server_hibernation.ml
@@ -1,0 +1,33 @@
+(** Server hibernation capability surface.
+
+    This is intentionally a status contract, not a fake implementation. The
+    current runtime is long-running; pause/resume affects keeper turns, and
+    graceful shutdown drains the process, but neither is scale-to-zero
+    hibernation. *)
+
+let status_json () =
+  `Assoc
+    [ "schema", `String "masc.server_hibernation.v1"
+    ; "status", `String "not_implemented"
+    ; "mode", `String "long_running"
+    ; "scale_to_zero_supported", `Bool false
+    ; "suspend_on_idle_supported", `Bool false
+    ; "resume_orchestrator_present", `Bool false
+    ; "serverless_provider", `Null
+    ; "operator_action_required", `Bool false
+    ; "terminal_reason", `String "no_hibernation_orchestrator"
+    ; ( "supported_controls"
+      , `List
+          [ `String "operator_pause_resume"
+          ; `String "keeper_auto_pause_auto_resume"
+          ; `String "graceful_shutdown"
+          ] )
+    ; ( "unsupported_controls"
+      , `List [ `String "scale_to_zero"; `String "suspend_on_idle"; `String "cold_resume" ]
+      )
+    ; ( "next_action"
+      , `String
+          "Implement a MASC-owned suspend/resume orchestrator before claiming \
+           serverless hibernation support." )
+    ]
+;;

--- a/lib/server/server_hibernation.mli
+++ b/lib/server/server_hibernation.mli
@@ -1,0 +1,8 @@
+(** Server hibernation capability surface.
+
+    MASC currently runs as a long-lived supervisor. This module exposes that
+    fact explicitly so operators and keepers do not infer scale-to-zero support
+    from pause/resume or graceful-shutdown primitives. *)
+
+val status_json : unit -> Yojson.Safe.t
+(** Return the current hibernation capability contract for health snapshots. *)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -557,6 +557,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
     , Keeper_fd_pressure.runtime_state_json ~active_keepers:keeper_fibers
         ~starting_keepers:0 ~requested_keepers:24 () );
     ("fd_accountant", fd_accountant_json);
+    ("server_hibernation", Server_hibernation.status_json ());
     ("keeper_fleet_safety", keeper_fleet_safety);
     ("keeper_identity_drift", keeper_identity_drift_json);
     ("keeper_reaction_ledger", reaction_ledger_json);

--- a/test/dune
+++ b/test/dune
@@ -750,6 +750,7 @@
   test_dashboard_namespace_truth
   test_dashboard_snapshot
   test_server_runtime_bootstrap
+  test_server_hibernation
   test_server_base_path_diagnostics
   test_server_timing
   test_server_startup_takeover
@@ -936,6 +937,7 @@
   test_dashboard_namespace_truth
   test_dashboard_snapshot
   test_server_runtime_bootstrap
+  test_server_hibernation
   test_server_base_path_diagnostics
   test_server_timing
   test_server_startup_takeover

--- a/test/test_server_hibernation.ml
+++ b/test/test_server_hibernation.ml
@@ -1,0 +1,54 @@
+open Alcotest
+
+let member name = function
+  | `Assoc fields ->
+    (match List.assoc_opt name fields with
+     | Some value -> value
+     | None -> failf "missing field %s" name)
+  | _ -> fail "expected JSON object"
+;;
+
+let string_field name json =
+  match member name json with
+  | `String value -> value
+  | _ -> failf "field %s is not a string" name
+;;
+
+let bool_field name json =
+  match member name json with
+  | `Bool value -> value
+  | _ -> failf "field %s is not a bool" name
+;;
+
+let test_status_contract () =
+  let json = Server_hibernation.status_json () in
+  check string "schema" "masc.server_hibernation.v1" (string_field "schema" json);
+  check string "status" "not_implemented" (string_field "status" json);
+  check string "mode" "long_running" (string_field "mode" json);
+  check bool "scale-to-zero unsupported" false
+    (bool_field "scale_to_zero_supported" json);
+  check bool "suspend-on-idle unsupported" false
+    (bool_field "suspend_on_idle_supported" json);
+  check bool "orchestrator absent" false
+    (bool_field "resume_orchestrator_present" json);
+  check string "terminal reason" "no_hibernation_orchestrator"
+    (string_field "terminal_reason" json)
+;;
+
+let test_health_exposes_status () =
+  let request = Httpun.Request.create `GET "/health" in
+  let json = Server_routes_http_runtime.make_health_json request in
+  let hibernation = member "server_hibernation" json in
+  check string "health status" "not_implemented" (string_field "status" hibernation);
+  check string "health mode" "long_running" (string_field "mode" hibernation)
+;;
+
+let () =
+  run
+    "server_hibernation"
+    [ ( "status"
+      , [ test_case "status contract" `Quick test_status_contract
+        ; test_case "health exposes status" `Quick test_health_exposes_status
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- add a `Server_hibernation` capability/status contract for the current server runtime
- expose `server_hibernation` in `/health` full runtime JSON as `mode=long_running`, `status=not_implemented`, and `scale_to_zero_supported=false`
- add a focused unit test for the status contract and health exposure

## Notes
- This does not implement suspend-on-idle or cold resume; it makes the current absence explicit so keepers/operators do not infer serverless support from pause/resume or graceful shutdown.

## Validation
- `opam exec -- ocamlformat --check lib/server/server_hibernation.ml lib/server/server_hibernation.mli lib/server/server_routes_http_runtime.ml test/test_server_hibernation.ml`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/ci/check-determinism-contract.sh` (passes; existing warnings only)
- `scripts/validate-prompt-paths.sh`
- `scripts/dune-local.sh build test/test_server_hibernation.exe` blocked locally because live bare `dune build` processes were already running outside the wrapper
