### PR TITLE
fix(keeper): erase delegation digest optional argument

### DIFF
--- a/lib/keeper/keeper_delegation_request.ml
+++ b/lib/keeper/keeper_delegation_request.ml
@@ -59,7 +59,7 @@ let truncate ~max_len text =
     in
     String.sub text 0 (utf8_boundary max_len)
 
-let digest_id ~requester ?goal ~topic ~reason =
+let digest_id ~requester ?goal ~topic ~reason () =
   let goal_text =
     match goal with
     | Some text -> text
@@ -139,7 +139,7 @@ let make ~requester ?goal ~topic ~reason () =
     deliberation_action_to_string (ProposeSpawn { topic; reason })
   in
   {
-    id = digest_id ~requester ?goal ~topic ~reason;
+    id = digest_id ~requester ?goal ~topic ~reason ();
     requester;
     topic;
     reason;


### PR DESCRIPTION
## Summary
- Add the unit terminator to `digest_id` in `Keeper_delegation_request` so the optional `?goal` argument is erasable under `-warn-error +a`.
- Update the only internal call site.

## Why
- The post-merge CI for #21761 failed in `Health`, `Lint`, and `Build and Test` while compiling `lib/keeper/keeper_delegation_request.ml`:
  `Error (warning 16 [unerasable-optional-argument]): this optional argument cannot be erased.`
- This is from latest `main` after #21750/#21762, not from the WebSocket dispatch cap itself.

## Verification
- `opam exec -- ocamlformat --check lib/keeper/keeper_delegation_request.ml`
- `git diff --check`
- `python3 scripts/check_test_coverage.py`
- Local `scripts/dune-local.sh build @check` was attempted but refused to start because existing bare `dune build` processes were already bypassing the repo-local Dune lock. CI is the compile authority for this follow-up.
