### PR TITLE
fix(keeper): erase delegation digest optional arg

### DIFF
--- a/lib/keeper/keeper_delegation_request.ml
+++ b/lib/keeper/keeper_delegation_request.ml
@@ -59,7 +59,7 @@ let truncate ~max_len text =
     in
     String.sub text 0 (utf8_boundary max_len)
 
-let digest_id ~requester ?goal ~topic ~reason =
+let digest_id ~requester ?goal ~topic ~reason () =
   let goal_text =
     match goal with
     | Some text -> text
@@ -139,7 +139,7 @@ let make ~requester ?goal ~topic ~reason () =
     deliberation_action_to_string (ProposeSpawn { topic; reason })
   in
   {
-    id = digest_id ~requester ?goal ~topic ~reason;
+    id = digest_id ~requester ?goal ~topic ~reason ();
     requester;
     topic;
     reason;


### PR DESCRIPTION
## Summary

- Fix OCaml warning 16 in `Keeper_delegation_request.digest_id`.
- Add the `unit` terminator already used by neighboring helpers so the optional `?goal` argument is erasable.

## Validation

- `opam exec -- ocamlformat --check lib/keeper/keeper_delegation_request.ml`
- `git diff --check`

## Notes

- No local build run; compile validation is left to PR CI per operator direction.
