### PR TITLE
fix(schedule): surface readable recurrence status

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1837,10 +1837,15 @@ export interface DashboardScheduledAutomationRequest {
   requested_at_iso?: string
   due_at?: number
   due_at_iso?: string
+  next_due_at?: number | null
+  next_due_at_iso?: string | null
   expires_at?: number | null
   expires_at_iso?: string | null
   payload_digest?: string
   payload_kind?: string | null
+  recurrence_summary?: string | null
+  requires_separate_human_grant?: boolean
+  approval_policy?: string | null
   last_execution?: DashboardScheduledAutomationExecution | null
 }
 

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -47,6 +47,7 @@ function CountChip({ name, count }: { name: string; count: number }) {
 }
 
 function recurrenceLabel(request: DashboardScheduledAutomationRequest): string {
+  if (request.recurrence_summary?.trim()) return request.recurrence_summary
   const recurrence = request.recurrence
   const kind = recurrence?.kind ?? request.recurrence_kind ?? 'one_shot'
   if (kind === 'interval' && typeof recurrence?.interval_sec === 'number') {
@@ -83,6 +84,8 @@ function ScheduleRow({ request }: { request: DashboardScheduledAutomationRequest
   const effectiveStatus = request.effective_status ?? request.status
   const readiness = request.execution_readiness ?? '-'
   const action = request.operator_action ?? '-'
+  const dueIso = request.next_due_at_iso ?? request.due_at_iso ?? null
+  const approval = request.approval_policy ?? (request.approval_required ? 'required' : 'not_required')
   return html`
     <tr class="v2-lab-row border-t border-[var(--color-border-default)]">
       <td class="py-2 pr-3 font-mono text-xs text-[var(--color-fg-secondary)]">${request.schedule_id}</td>
@@ -98,8 +101,8 @@ function ScheduleRow({ request }: { request: DashboardScheduledAutomationRequest
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${request.payload_kind ?? '-'}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${recurrenceLabel(request)}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${lastExecutionLabel(request)}</td>
-      <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${formatDateTimeKo(request.due_at_iso ?? null)}</td>
-      <td class="py-2 text-xs text-[var(--color-fg-muted)]">${request.approval_required ? 'required' : 'not required'}</td>
+      <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${formatDateTimeKo(dueIso)}</td>
+      <td class="py-2 text-xs text-[var(--color-fg-muted)]">${enumLabel(approval)}</td>
     </tr>
   `
 }

--- a/lib/schedule/schedule_domain.ml
+++ b/lib/schedule/schedule_domain.ml
@@ -213,6 +213,14 @@ let recurrence_kind_to_string = function
   | Cron _ -> "cron"
 ;;
 
+let recurrence_summary = function
+  | One_shot -> "one_shot"
+  | Interval { interval_sec } -> Printf.sprintf "every %ds" interval_sec
+  | Daily { hour; minute; second; timezone } ->
+    Printf.sprintf "daily %02d:%02d:%02d %s" hour minute second timezone
+  | Cron { expression; timezone } -> Printf.sprintf "cron %s %s" expression timezone
+;;
+
 let execution_status_to_string = function
   | Execution_running -> "running"
   | Execution_succeeded -> "succeeded"

--- a/lib/schedule/schedule_domain.mli
+++ b/lib/schedule/schedule_domain.mli
@@ -198,6 +198,10 @@ val schedule_status_of_string : string -> (schedule_status, string) result
 val schedule_source_to_string : schedule_source -> string
 val schedule_source_of_string : string -> (schedule_source, string) result
 val recurrence_kind_to_string : recurrence -> string
+val recurrence_summary : recurrence -> string
+(** Stable, human-readable recurrence summary for dashboard and keeper tool
+    outputs. This is presentation-only; schedule eligibility still uses the
+    typed [recurrence] value. *)
 val execution_status_to_string : execution_status -> string
 val execution_status_of_string : string -> (execution_status, string) result
 val grant_error_to_string : grant_error -> string

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1910,6 +1910,10 @@ let schedule_request_dashboard_json
   ?last_execution
   (request : Schedule_domain.schedule_request)
   =
+  let next_due_at =
+    if Schedule_domain.is_terminal request.status then None else Some request.due_at
+  in
+  let requires_grant = Schedule_domain.requires_separate_human_grant request in
   `Assoc
     [ "schedule_id", `String request.schedule_id
     ; "status", `String (Schedule_domain.schedule_status_to_string request.status)
@@ -1925,10 +1929,22 @@ let schedule_request_dashboard_json
     ; "requested_at_iso", unix_iso_json request.requested_at
     ; "due_at", `Float request.due_at
     ; "due_at_iso", unix_iso_json request.due_at
+    ; ( "next_due_at"
+      , match next_due_at with
+        | None -> `Null
+        | Some ts -> `Float ts )
+    ; "next_due_at_iso", unix_iso_option_json next_due_at
     ; "expires_at", (match request.expires_at with None -> `Null | Some ts -> `Float ts)
     ; "expires_at_iso", unix_iso_option_json request.expires_at
     ; "recurrence", Schedule_domain.recurrence_to_yojson request.recurrence
     ; "recurrence_kind", `String (Schedule_domain.recurrence_kind_to_string request.recurrence)
+    ; "recurrence_summary", `String (Schedule_domain.recurrence_summary request.recurrence)
+    ; ( "requires_separate_human_grant", `Bool requires_grant )
+    ; ( "approval_policy"
+      , `String
+          (if requires_grant
+           then "separate_human_grant_required"
+           else "no_separate_grant_required") )
     ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
     ; ( "payload_kind"
       , match schedule_payload_kind request with

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -162,16 +162,37 @@ let payload_from_args args =
 ;;
 
 let schedule_request_json ?last_execution (request : Schedule_domain.schedule_request) =
+  let next_due_at =
+    if Schedule_domain.is_terminal request.status then None else Some request.due_at
+  in
+  let requires_grant = Schedule_domain.requires_separate_human_grant request in
   match Schedule_domain.schedule_request_to_yojson request with
   | `Assoc fields ->
     `Assoc
       (fields
        @ [ ( "due_at_iso"
            , `String (Masc_domain.iso8601_of_unix_seconds request.due_at) )
+         ; ( "next_due_at"
+           , match next_due_at with
+             | None -> `Null
+             | Some ts -> `Float ts )
+         ; ( "next_due_at_iso"
+           , match next_due_at with
+             | None -> `Null
+             | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts) )
          ; ( "requested_at_iso"
            , `String (Masc_domain.iso8601_of_unix_seconds request.requested_at) )
+         ; ( "recurrence_kind"
+           , `String (Schedule_domain.recurrence_kind_to_string request.recurrence) )
+         ; ( "recurrence_summary"
+           , `String (Schedule_domain.recurrence_summary request.recurrence) )
          ; ( "requires_separate_human_grant"
-           , `Bool (Schedule_domain.requires_separate_human_grant request) )
+           , `Bool requires_grant )
+         ; ( "approval_policy"
+           , `String
+               (if requires_grant
+                then "separate_human_grant_required"
+                else "no_separate_grant_required") )
          ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
          ; ( "last_execution"
            , match last_execution with

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -218,7 +218,7 @@ let definition ~action ~id ~name ~description ~input_schema ~read_only =
 let definitions : definition list =
   [ definition ~action:Create_request ~id:"create" ~name:"masc_schedule_create"
       ~description:
-        "Create a durable scheduled internal automation request. Side-effecting requests start pending approval and require a later separate human grant."
+        "Create a durable scheduled internal automation request. For 'every day at 09:00 KST', use recurrence_kind=daily, recurrence_hour=9, recurrence_minute=0, recurrence_timezone=Asia/Seoul. For compact calendar rules, use recurrence_kind=cron with a 5-field recurrence_cron such as '0 9 * * 1-5'. Side-effecting requests start pending approval and require a later separate human grant."
       ~input_schema:create_schema ~read_only:false
   ; definition ~action:List_requests ~id:"list" ~name:"masc_schedule_list"
       ~description:"List durable scheduled internal automation requests."

--- a/test/test_schedule_domain.ml
+++ b/test/test_schedule_domain.ml
@@ -305,6 +305,17 @@ let test_cron_schedule_roundtrip () =
      | _ -> fail "expected cron recurrence")
 ;;
 
+let test_recurrence_summary () =
+  check string "one-shot summary" "one_shot" (recurrence_summary One_shot);
+  check string "interval summary" "every 900s"
+    (recurrence_summary (Interval { interval_sec = 900 }));
+  check string "daily summary" "daily 09:05:07 Asia/Seoul"
+    (recurrence_summary
+       (Daily { hour = 9; minute = 5; second = 7; timezone = "Asia/Seoul" }));
+  check string "cron summary" "cron 0 9 * * 1-5 UTC"
+    (recurrence_summary (Cron { expression = "0 9 * * 1-5"; timezone = "UTC" }))
+;;
+
 let test_missing_recurrence_defaults_one_shot () =
   let req = request ~risk_class:Read_only () in
   let json =
@@ -410,6 +421,7 @@ let () =
         [
           test_case "schedule roundtrip" `Quick test_schedule_roundtrip;
           test_case "cron schedule roundtrip" `Quick test_cron_schedule_roundtrip;
+          test_case "recurrence summary" `Quick test_recurrence_summary;
           test_case "missing recurrence defaults one-shot" `Quick
             test_missing_recurrence_defaults_one_shot;
           test_case "grant roundtrip" `Quick test_grant_roundtrip;

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -163,6 +163,20 @@ let test_dispatch_create_derives_due_at_for_cron_recurrence () =
   | None -> fail "dispatch returned None"
   | Some result ->
     check bool "create succeeds" true (Tool_result.is_success result);
+    let data = Tool_result.data result in
+    let open Yojson.Safe.Util in
+    check string "result recurrence kind" "cron"
+      (data |> member "recurrence_kind" |> to_string);
+    check string "result recurrence summary" "cron 0 9 * * 1-5 UTC"
+      (data |> member "recurrence_summary" |> to_string);
+    check (float 0.001) "result next due_at" 118800.0
+      (data |> member "next_due_at" |> to_float);
+    check string "result next due_at iso" "1970-01-02T09:00:00Z"
+      (data |> member "next_due_at_iso" |> to_string);
+    check bool "result separate grant" false
+      (data |> member "requires_separate_human_grant" |> to_bool);
+    check string "result approval policy" "no_separate_grant_required"
+      (data |> member "approval_policy" |> to_string);
     (match Schedule_store.get_schedule config ~schedule_id:"sched-cron" with
      | None -> fail "schedule missing"
      | Some request ->
@@ -319,6 +333,15 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     (due_row |> member "recurrence_kind" |> to_string);
   check string "due recurrence object kind" "daily"
     (due_row |> member "recurrence" |> member "kind" |> to_string);
+  check string "due recurrence summary" "daily 09:00:00 Asia/Seoul"
+    (due_row |> member "recurrence_summary" |> to_string);
+  check string "due next due iso"
+    (due_row |> member "due_at_iso" |> to_string)
+    (due_row |> member "next_due_at_iso" |> to_string);
+  check bool "due separate grant" false
+    (due_row |> member "requires_separate_human_grant" |> to_bool);
+  check string "due approval policy" "no_separate_grant_required"
+    (due_row |> member "approval_policy" |> to_string);
   check string "due effective status" "due"
     (due_row |> member "effective_status" |> to_string);
   check string "due readiness" "due_pending_refresh"
@@ -326,6 +349,10 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
   check string "due action" "wait_for_runner_tick"
     (due_row |> member "operator_action" |> to_string);
   let blocked_row = find_request "sched-blocked" in
+  check bool "blocked separate grant" true
+    (blocked_row |> member "requires_separate_human_grant" |> to_bool);
+  check string "blocked approval policy" "separate_human_grant_required"
+    (blocked_row |> member "approval_policy" |> to_string);
   check string "blocked effective status" "blocked_approval"
     (blocked_row |> member "effective_status" |> to_string);
   check string "blocked readiness" "blocked_approval"


### PR DESCRIPTION
## Summary
- add a stable recurrence_summary helper and expose next_due_at / approval_policy on schedule tool results
- project the same schedule readability fields through the dashboard runtime JSON
- render dashboard rows from backend-provided recurrence and approval summaries
- document daily and cron recurrence examples in the schedule create tool description

## Validation
- opam exec -- ocamlformat --check lib/schedule/schedule_domain.ml lib/schedule/schedule_domain.mli lib/tool_schedule.ml lib/server/server_dashboard_http_runtime_info.ml lib/tool_schemas/tool_schemas_schedule.ml test/test_schedule_domain.ml test/test_schedule_tool_wiring.ml
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- scripts/ci/check-determinism-contract.sh
- scripts/validate-prompt-paths.sh

## Not run
- scripts/dune-local.sh build test/test_schedule_domain.exe test/test_schedule_tool_wiring.exe: blocked by existing bare dune build processes outside scripts/dune-local.sh
- pnpm exec tsc --noEmit --pretty false in dashboard: dashboard tsc binary not installed in local node_modules