### PR TITLE
[codex] Fix keeper chat trace output joins

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1641,12 +1641,13 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     render(
       html`<${ChatTranscript}
         entries=${[
-          toolEntry({ id: 'tool-t1', label: 'keeper_board_list' }),
+          toolEntry({ id: 'tool-t1', label: 'keeper_board_list', turnRef: 'trace-a#1' }),
           entry({
             id: 'a',
             text: '도구 결과로 답합니다',
             role: 'assistant',
             source: 'direct_assistant',
+            turnRef: 'trace-a#1',
             traceSteps: [{ kind: 'think', text: 'reading tool output' }],
           }),
         ]}
@@ -1665,6 +1666,32 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     expect(bundle?.textContent).toContain('reading tool output')
     expect(bundle?.textContent).toContain('keeper_board_list')
     expect(bundle?.textContent).toContain('도구 결과로 답합니다')
+  })
+
+  it('does not attach a turn_ref-mismatched tool run to the following assistant', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({ id: 'tool-t1', label: 'keeper_board_list', turnRef: 'trace-a#1' }),
+          entry({
+            id: 'a',
+            text: '다른 턴 답변',
+            role: 'assistant',
+            source: 'direct_assistant',
+            turnRef: 'trace-b#2',
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const trace = container.querySelector('[data-chat-tool-trace]')
+    expect(container.querySelector('[data-chat-turn-bundle]')).toBeNull()
+    expect(trace?.textContent).toContain('keeper_board_list')
+    expect(trace?.textContent).not.toContain('다른 턴 답변')
   })
 
   it('renders assistant thinking as 작업 과정 even without tool calls', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -19,7 +19,7 @@ import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatLinkBlock, Ch
 import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, KeeperConversationSource, SurfaceRef } from '../../types'
 import type { ToolCallEntry, ToolCallOutputBlob } from '../../api/dashboard'
 import { fetchBoardPost } from '../../api/board'
-import { lookupToolCallOutput } from '../../tool-call-output-store'
+import { lookupToolCallOutput, toolCallOutputsById } from '../../tool-call-output-store'
 import { Sigil } from '../common/sigil-chip'
 import { SuggestionChip } from '../common/suggestion-chip'
 import { StatusDot } from '../common/status-dot'
@@ -2201,10 +2201,37 @@ type ChatRenderUnit =
   | { kind: 'toolGroup'; id: string; entries: KeeperConversationEntry[] }
   | { kind: 'turnBundle'; id: string; entries: KeeperConversationEntry[]; entry: KeeperConversationEntry }
 
-// Fold maximal runs of consecutive tool-call entries into one group. When the
-// run is immediately followed by an assistant entry, render both as one turn
-// bundle so "작업 과정" visually belongs to the answer it produced. Assistant
-// traceSteps can also produce a bundle without tools (thinking-only turns).
+function entryTurnRef(entry: KeeperConversationEntry): string | null {
+  const value = entry.turnRef?.trim()
+  return value ? value : null
+}
+
+function canAppendToolToRun(run: KeeperConversationEntry[], entry: KeeperConversationEntry): boolean {
+  if (run.length === 0) return true
+  const firstTurnRef = entryTurnRef(run[0]!)
+  const nextTurnRef = entryTurnRef(entry)
+  if (firstTurnRef || nextTurnRef) {
+    return firstTurnRef !== null && nextTurnRef !== null && firstTurnRef === nextTurnRef
+  }
+  return true
+}
+
+function canBundleToolsWithAssistant(run: KeeperConversationEntry[], assistant: KeeperConversationEntry): boolean {
+  if (run.length === 0) return true
+  const toolTurnRef = entryTurnRef(run[0]!)
+  const assistantTurnRef = entryTurnRef(assistant)
+  if (toolTurnRef || assistantTurnRef) {
+    return toolTurnRef !== null && assistantTurnRef !== null && toolTurnRef === assistantTurnRef
+  }
+  return true
+}
+
+// Fold maximal runs of consecutive tool-call entries into one group. Persisted
+// rows carry turnRef; use it as the hard join key when present, falling back to
+// adjacency only for legacy/live rows that have no turn provenance. When the run
+// belongs to the following assistant entry, render both as one turn bundle so
+// "작업 과정" visually belongs to the answer it produced. Assistant traceSteps
+// can also produce a bundle without tools (thinking-only turns).
 function buildChatRenderUnits(
   entries: KeeperConversationEntry[],
   groupToolCalls: boolean,
@@ -2219,9 +2246,14 @@ function buildChatRenderUnits(
   }
   for (const entry of entries) {
     if (entry.role === 'tool') {
+      if (!canAppendToolToRun(run, entry)) flush()
       run.push(entry)
     } else {
-      if (entry.role === 'assistant' && (run.length > 0 || (entry.traceSteps?.length ?? 0) > 0)) {
+      if (
+        entry.role === 'assistant'
+        && (run.length > 0 || (entry.traceSteps?.length ?? 0) > 0)
+        && canBundleToolsWithAssistant(run, entry)
+      ) {
         units.push({
           kind: 'turnBundle',
           id: `turn-${run[0]?.id ?? entry.id}`,
@@ -2232,6 +2264,15 @@ function buildChatRenderUnits(
         continue
       }
       flush()
+      if (entry.role === 'assistant' && (entry.traceSteps?.length ?? 0) > 0) {
+        units.push({
+          kind: 'turnBundle',
+          id: `turn-${entry.id}`,
+          entries: [],
+          entry,
+        })
+        continue
+      }
       units.push({ kind: 'entry', entry })
     }
   }
@@ -2338,6 +2379,18 @@ export function ChatTranscript({
     () => entries.map(entry => `${entry.id}:${entry.text.length}:${entry.delivery}:${entry.streamState ?? ''}:${traceStepsSignature(entry)}`).join('|'),
     [entries],
   )
+  const toolOutputSignature = useMemo(
+    () => entries
+      .filter(entry => entry.role === 'tool')
+      .map((entry) => {
+        const output = lookupToolCallOutput(entry.id)
+        return output
+          ? `${entry.id}:${output.success}:${output.semantic_success ?? ''}:${output.duration_ms}:${toolOutputDisplay(output.output)?.text.length ?? 0}`
+          : `${entry.id}:pending`
+      })
+      .join('|'),
+    [entries, toolCallOutputsById.value],
+  )
 
   const scrollToBottom = () => {
     const el = scrollerRef.current
@@ -2366,7 +2419,7 @@ export function ChatTranscript({
     } else {
       setUnread(true)
     }
-  }, [lastSignature])
+  }, [lastSignature, toolOutputSignature])
 
   const isPrimary = size === 'primary'
   const heightClass = isPrimary

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2208,7 +2208,9 @@ function entryTurnRef(entry: KeeperConversationEntry): string | null {
 
 function canAppendToolToRun(run: KeeperConversationEntry[], entry: KeeperConversationEntry): boolean {
   if (run.length === 0) return true
-  const firstTurnRef = entryTurnRef(run[0]!)
+  const first = run[0]
+  if (!first) return true
+  const firstTurnRef = entryTurnRef(first)
   const nextTurnRef = entryTurnRef(entry)
   if (firstTurnRef || nextTurnRef) {
     return firstTurnRef !== null && nextTurnRef !== null && firstTurnRef === nextTurnRef
@@ -2218,7 +2220,9 @@ function canAppendToolToRun(run: KeeperConversationEntry[], entry: KeeperConvers
 
 function canBundleToolsWithAssistant(run: KeeperConversationEntry[], assistant: KeeperConversationEntry): boolean {
   if (run.length === 0) return true
-  const toolTurnRef = entryTurnRef(run[0]!)
+  const first = run[0]
+  if (!first) return true
+  const toolTurnRef = entryTurnRef(first)
   const assistantTurnRef = entryTurnRef(assistant)
   if (toolTurnRef || assistantTurnRef) {
     return toolTurnRef !== null && assistantTurnRef !== null && toolTurnRef === assistantTurnRef
@@ -2241,7 +2245,9 @@ function buildChatRenderUnits(
   let run: KeeperConversationEntry[] = []
   const flush = () => {
     if (run.length === 0) return
-    units.push({ kind: 'toolGroup', id: `tracegroup-${run[0]!.id}`, entries: run })
+    const first = run[0]
+    if (!first) return
+    units.push({ kind: 'toolGroup', id: `tracegroup-${first.id}`, entries: run })
     run = []
   }
   for (const entry of entries) {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -392,6 +392,7 @@ function TurnInspectorDrawer({
         </div>
         <${KeeperTurnInspector}
           keeperName=${keeperName}
+          initialTurnRef=${triggerEntry?.turnRef ?? null}
           initialTurnTimestamp=${triggerEntry?.timestamp ?? null}
         />
       </div>

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -182,7 +182,7 @@ describe('hydrateKeeperChatHistory', () => {
 
     await hydrateKeeperChatHistory('echo')
 
-    expect(fetchKeeperToolCalls).toHaveBeenCalledWith('echo', 100)
+    expect(fetchKeeperToolCalls).toHaveBeenCalledWith('echo', 200)
   })
 
   it('allows a retry after a failed fetch', async () => {
@@ -493,7 +493,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
     await sendKeeperThreadMessage('echo', '진행 상황?')
 
-    expect(fetchKeeperToolCalls).toHaveBeenCalledWith('echo', 100)
+    expect(fetchKeeperToolCalls).toHaveBeenCalledWith('echo', 200)
   })
 
   it('derives text and media user blocks when only attachments are supplied', async () => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -185,9 +185,10 @@ export async function hydrateKeeperChatHistory(
   }
 }
 
-// Recent-window size for the tool-call output fetch; mirrors the inspector's
-// fetchKeeperToolCalls(name, 100) so the chat join covers the same horizon.
-const TOOL_OUTPUT_FETCH_LIMIT = 100
+// Match the visible chat history window. A keeper that calls many tools can
+// easily have >100 tool rows inside the 200-row transcript; using the same
+// horizon keeps every visible row eligible for output join.
+const TOOL_OUTPUT_FETCH_LIMIT = KEEPER_HISTORY_TAIL_MESSAGES
 
 /** Best-effort hydration of tool-call outputs into the shared store so the
  *  chat ToolCallBubble can join results onto transcript rows by tool_use_id.

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -433,7 +433,7 @@ describe('thread history merge & persistence', () => {
     expect(entries[1]?.label).toBe('echo')
   })
 
-  it('preserves turn_ref on persisted chat history entries', () => {
+  it('preserves valid turn_ref on every persisted chat-history path and rejects malformed values', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       { role: 'user', content: 'query', ts: 1_780_000_000, turn_ref: 'trace-a#1' },
       {
@@ -445,9 +445,26 @@ describe('thread history merge & persistence', () => {
         turn_ref: 'trace-a#1',
       },
       { role: 'assistant', content: 'answer', ts: 1_780_000_000, turn_ref: 'trace-a#1' },
+      { role: 'assistant', content: 'legacy answer', ts: 1_780_000_001 },
+      { role: 'user', content: 'bad user ref', ts: 1_780_000_002, turn_ref: 42 as unknown as string },
+      {
+        role: 'tool',
+        content: '{"q":2}',
+        ts: 1_780_000_003,
+        tool_call_id: 'toolu_bad_ref',
+        tool_call_name: 'masc_status',
+        turn_ref: 42 as unknown as string,
+      },
     ])
 
-    expect(entries.map(e => e.turnRef)).toEqual(['trace-a#1', 'trace-a#1', 'trace-a#1'])
+    expect(entries.map(e => e.turnRef)).toEqual([
+      'trace-a#1',
+      'trace-a#1',
+      'trace-a#1',
+      null,
+      null,
+      null,
+    ])
   })
 
   it('dedups a rehydrated tool row against the live tool entry', () => {

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -433,6 +433,23 @@ describe('thread history merge & persistence', () => {
     expect(entries[1]?.label).toBe('echo')
   })
 
+  it('preserves turn_ref on persisted chat history entries', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'query', ts: 1_780_000_000, turn_ref: 'trace-a#1' },
+      {
+        role: 'tool',
+        content: '{"q":1}',
+        ts: 1_780_000_000,
+        tool_call_id: 'toolu_turn',
+        tool_call_name: 'masc_status',
+        turn_ref: 'trace-a#1',
+      },
+      { role: 'assistant', content: 'answer', ts: 1_780_000_000, turn_ref: 'trace-a#1' },
+    ])
+
+    expect(entries.map(e => e.turnRef)).toEqual(['trace-a#1', 'trace-a#1', 'trace-a#1'])
+  })
+
   it('dedups a rehydrated tool row against the live tool entry', () => {
     appendThreadEntry('echo', entry({
       id: 'tool-toolu_3',

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -702,6 +702,7 @@ function normalizeHistoryEntry(
   const timestamp = toIsoTimestamp(raw.ts_unix) ?? toIsoTimestamp(raw.timestamp)
   const label = role === 'assistant' && keeperName ? keeperName : roleLabel(role)
   const surface = isRecord(raw.surface) ? (raw.surface as unknown as SurfaceRef) : null
+  // RFC-0233 §7: asString rejects malformed join keys instead of repairing them.
   const turnRef = asString(raw.turn_ref) ?? null
   // keeper_chat_store mints kind=transport_failure (row content is the
   // "Keeper request failed: ..." text) so a reload can tell a failed request
@@ -987,7 +988,8 @@ interface RestChatHistoryMessage {
   tool_call_name?: string
   source?: string
   surface?: SurfaceRef
-  turn_ref?: string
+  // RFC-0233 §7: MASC-minted "<trace_id>#<absolute_turn>" turn join key.
+  turn_ref?: string | null
   audio?: unknown
   // Persisted upload rows (snake_case from keeper_chat_store) — normalized to
   // KeeperConversationAttachment at consume time so reload keeps the cards.
@@ -1027,7 +1029,9 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
     streamState: null,
     details: null,
     surface: message.surface ?? null,
-    turnRef: message.turn_ref ?? null,
+    // Tool rows share the same untrusted REST boundary; reject malformed
+    // turn_ref values here too so this path matches normalizeHistoryEntry.
+    turnRef: asString(message.turn_ref) ?? null,
   }
 }
 

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -702,6 +702,7 @@ function normalizeHistoryEntry(
   const timestamp = toIsoTimestamp(raw.ts_unix) ?? toIsoTimestamp(raw.timestamp)
   const label = role === 'assistant' && keeperName ? keeperName : roleLabel(role)
   const surface = isRecord(raw.surface) ? (raw.surface as unknown as SurfaceRef) : null
+  const turnRef = asString(raw.turn_ref) ?? null
   // keeper_chat_store mints kind=transport_failure (row content is the
   // "Keeper request failed: ..." text) so a reload can tell a failed request
   // apart from a real reply. Map it to the existing error delivery state so
@@ -725,6 +726,7 @@ function normalizeHistoryEntry(
     text,
     rawText,
     timestamp,
+    turnRef,
     delivery,
     streamState: null,
     details: null,
@@ -985,6 +987,7 @@ interface RestChatHistoryMessage {
   tool_call_name?: string
   source?: string
   surface?: SurfaceRef
+  turn_ref?: string
   audio?: unknown
   // Persisted upload rows (snake_case from keeper_chat_store) — normalized to
   // KeeperConversationAttachment at consume time so reload keeps the cards.
@@ -1024,6 +1027,7 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
     streamState: null,
     details: null,
     surface: message.surface ?? null,
+    turnRef: message.turn_ref ?? null,
   }
 }
 
@@ -1053,6 +1057,7 @@ export function chatHistoryEntriesFromRest(
         attachments: message.attachments,
         kind: message.kind,
         blocks: message.blocks,
+        turn_ref: message.turn_ref,
       },
       keeperName,
       previousSource,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -887,6 +887,7 @@ export interface KeeperConversationEntry {
   text: string
   rawText?: string | null
   timestamp?: string | null
+  turnRef?: string | null
   delivery: KeeperConversationDelivery
   streamState?: KeeperConversationStreamState
   attachments?: KeeperConversationAttachment[]

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -887,6 +887,9 @@ export interface KeeperConversationEntry {
   text: string
   rawText?: string | null
   timestamp?: string | null
+  // RFC-0233 §7: MASC-minted "<trace_id>#<absolute_turn>" join key. Carries the
+  // chat message's originating turn so turn consumers can prefer exact matching
+  // over timestamp-window fallback.
   turnRef?: string | null
   delivery: KeeperConversationDelivery
   streamState?: KeeperConversationStreamState


### PR DESCRIPTION
## Summary
- Carry persisted keeper chat `turn_ref` into dashboard conversation entries and use it to prevent mismatched tool traces from attaching to the wrong assistant answer.
- Match keeper chat tool-output hydration to the 200-row visible transcript window, so visible tool rows can join their outputs.
- Include visible tool-output hydration changes in transcript scroll signatures so late outputs do not silently render below the pinned viewport.

## Root cause
The dashboard grouped tool rows with answers by adjacency only, while the backend already persisted a turn join key. Tool output hydration also fetched only 100 recent calls even though the transcript keeps 200 rows.

## Validation
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/keeper-state.test.ts src/keeper-actions.test.ts src/components/chat/primitives.test.ts`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/eslint src/components/chat/primitives.ts src/components/chat/primitives.test.ts src/keeper-actions.ts src/keeper-actions.test.ts src/keeper-state.ts src/keeper-state.test.ts src/types/core.ts` (0 errors; existing config-scope ignored-file warnings for some .ts files)
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vite build` (passes; existing font, dynamic-import, and chunk-size warnings)

## Notes
Browser plugin was not available in this session, and the local 8935 runtime was not running during the preceding review, so this PR is validated by unit/type/build checks rather than live rendered dashboard proof.