### PR TITLE
feat(dashboard): thread turn_ref from chat history to turn inspector (RFC-0233 §7 PR-D nav)

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -392,6 +392,7 @@ function TurnInspectorDrawer({
         </div>
         <${KeeperTurnInspector}
           keeperName=${keeperName}
+          initialTurnRef=${triggerEntry?.turnRef ?? null}
           initialTurnTimestamp=${triggerEntry?.timestamp ?? null}
         />
       </div>

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -260,6 +260,28 @@ describe('thread history merge & persistence', () => {
     expect(tool?.delivery).toBe('history')
   })
 
+  it('threads turn_ref onto entries via every construction path; null when absent or non-string', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'hi', ts: 1_780_000_000, turn_ref: 'trace-a#7' },
+      { role: 'assistant', content: 'hello', ts: 1_780_000_000, turn_ref: 'trace-a#7' },
+      {
+        role: 'tool',
+        content: '{"path":"x"}',
+        ts: 1_780_000_000,
+        tool_call_id: 'toolu_9',
+        tool_call_name: 'Read',
+        turn_ref: 'trace-a#7',
+      },
+      // RFC-0233 §7: turn_ref forwarded on normalizeHistoryEntry AND toolHistoryEntry
+      // paths (N-of-M guard). A legacy row without turn_ref degrades to null so the
+      // inspector falls back to the timestamp window rather than mis-anchoring.
+      { role: 'assistant', content: 'no ref here', ts: 1_780_000_001 },
+      // Non-string turn_ref is rejected by asString → null (parse-don't-repair).
+      { role: 'user', content: 'bad ref', ts: 1_780_000_002, turn_ref: 42 as unknown as string },
+    ])
+    expect(entries.map(e => e.turnRef)).toEqual(['trace-a#7', 'trace-a#7', 'trace-a#7', null, null])
+  })
+
   it('decodes persisted attachments so uploads survive a reload', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -732,6 +732,9 @@ function normalizeHistoryEntry(
     audio,
     attachments,
     blocks,
+    // RFC-0233 §7: thread the MASC-minted turn join key through so the inspector
+    // can anchor to the exact originating turn. asString rejects non-strings.
+    turnRef: asString(raw.turn_ref) ?? null,
   }
 }
 
@@ -1001,6 +1004,9 @@ interface RestChatHistoryMessage {
   // RFC-0235 P3: backend-parsed rich chat blocks. When present the dashboard
   // prefers them over its local parser.
   blocks?: ChatBlock[]
+  // RFC-0233 §7: MASC-minted "<trace_id>#<absolute_turn>" turn join key.
+  // Forwarded to KeeperConversationEntry.turnRef for exact turn-inspector anchoring.
+  turn_ref?: string | null
 }
 
 /** Convert a persisted tool-call row into the same entry shape the live
@@ -1024,6 +1030,9 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
     streamState: null,
     details: null,
     surface: message.surface ?? null,
+    // RFC-0233 §7: tool rows also carry the turn join key. Forward it here too so
+    // turnRef is not silently dropped on the tool-entry construction path.
+    turnRef: message.turn_ref ?? null,
   }
 }
 
@@ -1053,6 +1062,7 @@ export function chatHistoryEntriesFromRest(
         attachments: message.attachments,
         kind: message.kind,
         blocks: message.blocks,
+        turn_ref: message.turn_ref,
       },
       keeperName,
       previousSource,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -896,6 +896,10 @@ export interface KeeperConversationEntry {
   error?: string | null
   surface?: SurfaceRef | null
   audio?: KeeperConversationAudioClip | null
+  // RFC-0233 §7: MASC-minted "<trace_id>#<absolute_turn>" join key. Carries the
+  // chat message's originating turn so the turn inspector can anchor to the
+  // exact turn (initialTurnRowForTurnRef) instead of the 30-min timestamp window.
+  turnRef?: string | null
 }
 
 export interface KeeperStatusDetail {


### PR DESCRIPTION
## 무엇을 / 왜

RFC-0233 §7의 **PR-D nav 배선 (chat 절반)** — chat history wire에서 파싱되던 `turn_ref`를 실제 UI까지 흘려 chat "턴 상세" 액션이 정확한 originating 턴에 anchor하게 한다.

지금까지 양 끝은 완성돼 있었지만 **중간이 끊겨** 있었다: PR-A가 chat persist에 `turn_ref`를 채우고(mint), PR-C-chat(#21746)이 API 스키마로 노출하고, PR-D-core(#21759)가 인스펙터에 `initialTurnRef`+`initialTurnRowForTurnRef` 정확 매처를 추가했다. 그러나 `turn_ref`는 `RestChatHistoryMessage`에 선언되지 않고 `KeeperConversationEntry`로 복사되지 않아, 인스펙터가 chat 경로에서 `initialTurnRef`를 영영 받지 못했다(스키마 주석이 명시한 follow-up: *"Consumed for navigation in a follow-up (`KeeperConversationEntry.turnRef`)"*).

## 변경 (프론트엔드 전용, +37줄/4파일)

- `core.ts`: `KeeperConversationEntry.turnRef?: string | null` 추가.
- `keeper-state.ts`:
  - `RestChatHistoryMessage.turn_ref?: string | null` 선언.
  - **모든** entry 생성 경로에서 forward — `normalizeHistoryEntry`(`asString(raw.turn_ref) ?? null`, wire 가드) **및** `toolHistoryEntry`(`message.turn_ref ?? null`). 한 경로만 채우면 tool 행이 turn_ref를 silent-drop하는 N-of-M 함정을 피한다.
  - `chatHistoryEntriesFromRest`가 `turn_ref`를 normalizer로 통과.
- `keeper-workspace-chat.ts`: `TurnInspectorDrawer`가 `initialTurnRef=${triggerEntry?.turnRef ?? null}`를 `initialTurnTimestamp`와 함께 전달.

## 동작 (라이브 효과)

`turn_ref`가 있는 chat 행에서 "턴 상세"를 누르면 인스펙터가 `(trace_id, absolute_turn)` 정확 매칭으로 anchor한다(미스→null, fuzzy 없음). **legacy 행**(`turn_ref` 부재)은 `turnRef=null`로 degrade → 인스펙터가 30분 timestamp window fallback을 유지(오귀속 차단). dormant prop이 아니라 PR-A/PR-C-chat 데이터가 실제로 흐르는 라이브 경로다.

## 검증

- `keeper-state.test.ts`: 신규 테스트가 chat/assistant/tool 세 생성 경로 모두에서 `turn_ref` forward + 부재→null + 비문자열(`asString` 가드)→null 검증. **vitest 46/46**.
- `keeper-workspace-chat.test.ts` + `keeper-turn-inspector.test.ts`: **19/19**(prop 추가 회귀 없음).
- **`tsc --noEmit` clean (exit 0)**.

## Workaround Guards (RFC-0233 §7.6 준수)

- **#1 client 파생 id 없음**: MASC-mint된 `turn_ref` string을 forward만(fabricate 아님).
- **#3 window-join 강등**: 정확 매칭이 primary, 30분 window는 `turn_ref` 부재 legacy 행 전용 fallback.
- **#6 N-of-M 없음**: `KeeperConversationEntry`를 만드는 두 생성자(normalize + tool) 모두 forward해 컴파일 경로 누락을 차단.

## Follow-up (이 PR 범위 밖)

- **board → turn nav**: 현재 board에는 turn 내비가 전혀 없다. `BoardPost.origin.turn_ref`(PR-C-board #21755로 노출됨)를 읽는 새 nav 액션 + UI affordance + board에서 도달 가능한 인스펙터 mount가 필요 — net-new feature, 별도 PR.
- keeper-authored board post `origin.turn_ref` populate(cell-carrier).
- `turn_ref` backfill 완료 시 timestamp window 완전 제거.

Refs: RFC-0233 §7 (§7.5 PR-D, §7.6 #1/#3/#6). 의존(전부 MERGED): PR-A(#21662/#21680/#21696), PR-C-chat(#21746), PR-D-core(#21759).
