### PR TITLE
feat(keeper): project user model from memory facts

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2961,12 +2961,42 @@ export type MemoryOsTurnRecordSnapshot = {
   }
 }
 
+export type KeeperUserModelItem = {
+  claim: string
+  category: string
+  source: 'keeper' | 'shared' | string
+  observed_by: string[]
+  turn: number
+  first_seen: number
+  first_seen_iso: string | null
+  last_verified_at: number | null
+  last_verified_at_iso: string | null
+}
+
+export type KeeperUserModelSnapshot = {
+  schema: string
+  keeper: string
+  source: string
+  producer: string
+  facts_store: string
+  shared_facts_store: string
+  enabled: boolean
+  now: number | null
+  now_iso: string | null
+  read_errors: { scope: string; error: string }[]
+  source_fact_count: number
+  shared_fact_count: number
+  preferences: KeeperUserModelItem[]
+  constraints: KeeperUserModelItem[]
+}
+
 export type TurnRecordsResponse = TelemetryFreshnessMetadata & {
   keeper: string
   count: number
   // malformed JSONL rows the server refused to decode (never repaired)
   skipped_rows: number
   memory_os: MemoryOsTurnRecordSnapshot | null
+  user_model: KeeperUserModelSnapshot | null
   entries: TurnRecordRow[]
 }
 
@@ -3119,6 +3149,68 @@ function decodeMemoryOsSnapshot(raw: unknown): MemoryOsTurnRecordSnapshot | null
   }
 }
 
+function decodeKeeperUserModelItem(raw: unknown): KeeperUserModelItem | null {
+  if (!isRecord(raw)) return null
+  const claim = asString(raw.claim)
+  const category = asString(raw.category)
+  const source = asString(raw.source)
+  const turn = asNumber(raw.turn)
+  const first_seen = asNumber(raw.first_seen)
+  if (!claim || !category || !source || turn == null || first_seen == null) {
+    return null
+  }
+  return {
+    claim,
+    category,
+    source,
+    observed_by: normalizeStringList(raw.observed_by),
+    turn,
+    first_seen,
+    first_seen_iso: asNullableString(raw.first_seen_iso),
+    last_verified_at: asNumber(raw.last_verified_at) ?? null,
+    last_verified_at_iso: asNullableString(raw.last_verified_at_iso),
+  }
+}
+
+function decodeKeeperUserModelSnapshot(raw: unknown): KeeperUserModelSnapshot | null {
+  if (!isRecord(raw)) return null
+  const schema = asString(raw.schema)
+  const keeper = asString(raw.keeper)
+  const source = asString(raw.source)
+  const producer = asString(raw.producer)
+  const facts_store = asString(raw.facts_store)
+  const shared_facts_store = asString(raw.shared_facts_store)
+  if (!schema || !keeper || !source || !producer || !facts_store || !shared_facts_store) {
+    return null
+  }
+  return {
+    schema,
+    keeper,
+    source,
+    producer,
+    facts_store,
+    shared_facts_store,
+    enabled: asBoolean(raw.enabled, true) ?? true,
+    now: asNumber(raw.now) ?? null,
+    now_iso: asNullableString(raw.now_iso),
+    read_errors: asRecordArray(raw.read_errors)
+      .map((item) => {
+        const scope = asString(item.scope)
+        const error = asString(item.error)
+        return scope && error ? { scope, error } : null
+      })
+      .filter((item): item is { scope: string; error: string } => item !== null),
+    source_fact_count: asNumber(raw.source_fact_count, 0) ?? 0,
+    shared_fact_count: asNumber(raw.shared_fact_count, 0) ?? 0,
+    preferences: asRecordArray(raw.preferences)
+      .map(decodeKeeperUserModelItem)
+      .filter((item): item is KeeperUserModelItem => item !== null),
+    constraints: asRecordArray(raw.constraints)
+      .map(decodeKeeperUserModelItem)
+      .filter((item): item is KeeperUserModelItem => item !== null),
+  }
+}
+
 function decodeTurnRecordsResponse(raw: unknown): TurnRecordsResponse | null {
   if (!isRecord(raw)) return null
   const keeper = asString(raw.keeper)
@@ -3129,6 +3221,7 @@ function decodeTurnRecordsResponse(raw: unknown): TurnRecordsResponse | null {
     count: asNumber(raw.count, 0),
     skipped_rows: asNumber(raw.skipped_rows, 0),
     memory_os: decodeMemoryOsSnapshot(raw.memory_os),
+    user_model: decodeKeeperUserModelSnapshot(raw.user_model),
     entries: asRecordArray(raw.entries)
       .map(decodeTurnRecordRow)
       .filter((row): row is TurnRecordRow => row !== null),

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -76,6 +76,46 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
         expired: 1,
       },
     },
+    user_model: {
+      schema: 'keeper.user_model.dashboard.v1',
+      keeper: 'albini',
+      source: 'memory_os_facts',
+      producer: 'keeper_user_model',
+      facts_store: '.masc/config/keepers/albini.facts.jsonl',
+      shared_facts_store: '.masc/config/keepers/_shared.facts.jsonl',
+      enabled: true,
+      now: 1_781_587_600,
+      now_iso: '2026-06-16T02:00:00Z',
+      read_errors: [],
+      source_fact_count: 6,
+      shared_fact_count: 2,
+      preferences: [
+        {
+          claim: 'User prefers concise answers',
+          category: 'preference',
+          source: 'keeper',
+          observed_by: [],
+          turn: 10,
+          first_seen: 1_781_580_000,
+          first_seen_iso: '2026-06-15T23:53:20Z',
+          last_verified_at: 1_781_587_000,
+          last_verified_at_iso: '2026-06-16T01:50:00Z',
+        },
+      ],
+      constraints: [
+        {
+          claim: 'Let CI be the authority for full builds',
+          category: 'constraint',
+          source: 'shared',
+          observed_by: ['qa-king', 'verifier'],
+          turn: 14,
+          first_seen: 1_781_581_000,
+          first_seen_iso: '2026-06-16T00:10:00Z',
+          last_verified_at: 1_781_587_100,
+          last_verified_at_iso: '2026-06-16T01:51:40Z',
+        },
+      ],
+    },
     entries: [
       {
         record: {
@@ -100,12 +140,16 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
           output_tokens: 280,
           blocks: [
             { block: 'system', bytes: 1200, digest: '1111222233334444' },
+            { block: 'user_model', bytes: 728, digest: '99887766554433221100' },
             { block: 'memory_os_recall', bytes: 3392, digest: 'aabbccddeeff00112233' },
           ],
           execution_ids: ['exec-42'],
         },
         diff_vs_prev: {
-          added: [{ block: 'memory_os_recall', bytes: 3392, digest: 'aabbccddeeff00112233' }],
+          added: [
+            { block: 'user_model', bytes: 728, digest: '99887766554433221100' },
+            { block: 'memory_os_recall', bytes: 3392, digest: 'aabbccddeeff00112233' },
+          ],
           removed: [],
           changed: [],
         },
@@ -149,6 +193,30 @@ describe('KeeperMemoryOsRecallPanel', () => {
     expect(text).toContain('episodes: .masc/config/keepers/albini/episodes')
   })
 
+  it('surfaces user-model preferences and constraints from turn records', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="user-model-source"]')).toBeTruthy()
+    })
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('User model')
+    expect(text).toContain('enabled')
+    expect(text).toContain('latest block')
+    expect(text).toContain('728B')
+    expect(text).toContain('pref 1')
+    expect(text).toContain('constraints 1')
+    expect(text).toContain('facts 6')
+    expect(text).toContain('shared 2')
+    expect(text).toContain('User prefers concise answers')
+    expect(text).toContain('Let CI be the authority for full builds')
+    expect(text).toContain('shared via qa-king,verifier')
+    expect(text).toContain('shared: .masc/config/keepers/_shared.facts.jsonl')
+  })
+
   it('shows a source-missing state when the API has no Memory OS snapshot', async () => {
     fetchKeeperTurnRecordsMock.mockResolvedValue({
       source: 'turn_record',
@@ -157,6 +225,7 @@ describe('KeeperMemoryOsRecallPanel', () => {
       count: 0,
       skipped_rows: 0,
       memory_os: null,
+      user_model: null,
       entries: [],
     })
 

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -12,6 +12,8 @@ import { html } from 'htm/preact'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { fetchKeeperTurnRecords } from '../api/dashboard'
 import type {
+  KeeperUserModelItem,
+  KeeperUserModelSnapshot,
   MemoryOsEpisodeSummary,
   MemoryOsTurnRecordSnapshot,
   TurnBlock,
@@ -100,12 +102,20 @@ function BlockRow({ block }: { block: TurnBlock }) {
   `
 }
 
-function latestMemoryOsBlock(rows: TurnRecordRow[]): TurnBlock | null {
+function latestBlockByName(rows: TurnRecordRow[], blockName: string): TurnBlock | null {
   for (const row of [...rows].reverse()) {
-    const block = row.record.blocks.find(item => item.block === 'memory_os_recall')
+    const block = row.record.blocks.find(item => item.block === blockName)
     if (block) return block
   }
   return null
+}
+
+function latestMemoryOsBlock(rows: TurnRecordRow[]): TurnBlock | null {
+  return latestBlockByName(rows, 'memory_os_recall')
+}
+
+function latestUserModelBlock(rows: TurnRecordRow[]): TurnBlock | null {
+  return latestBlockByName(rows, 'user_model')
 }
 
 function compactIso(value: string | null): string {
@@ -240,6 +250,118 @@ export function KeeperMemoryOsRecallPanel({ keeperName }: { keeperName: string }
     <div class="p-2 v2-monitoring-surface">
       <${MemoryOsRecallSourcePanel} snapshot=${response.memory_os} rows=${response.entries} />
     </div>
+  `
+}
+
+function userModelSourceLabel(item: KeeperUserModelItem): string {
+  if (item.source !== 'shared') return item.source
+  return item.observed_by.length > 0
+    ? `shared via ${item.observed_by.join(',')}`
+    : 'shared'
+}
+
+function UserModelItemRow({ item }: { item: KeeperUserModelItem }) {
+  return html`
+    <div class="min-w-0 border-t border-[var(--color-border-muted)] py-2 first:border-t-0 v2-monitoring-row">
+      <div class="mb-1 flex min-w-0 flex-wrap items-center gap-2">
+        <span class="font-mono text-3xs text-[var(--color-fg-muted)]">
+          ${userModelSourceLabel(item)}
+        </span>
+        <span class="font-mono text-3xs text-[var(--color-fg-disabled)]">
+          ${item.category} turn=${item.turn}
+        </span>
+        ${item.last_verified_at_iso
+          ? html`<span class="font-mono text-3xs text-[var(--color-fg-disabled)]">
+              verified ${compactIso(item.last_verified_at_iso)}
+            </span>`
+          : null}
+      </div>
+      <div class="line-clamp-2 text-2xs leading-relaxed text-[var(--color-fg-muted)]">
+        ${item.claim}
+      </div>
+    </div>
+  `
+}
+
+function UserModelList({
+  title,
+  items,
+}: {
+  title: string
+  items: KeeperUserModelItem[]
+}) {
+  const shown = items.slice(0, 5)
+  return html`
+    <div class="min-w-0 flex-1">
+      <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)] mb-1">
+        ${title} ${items.length}
+      </div>
+      <div class="divide-y divide-[var(--color-border-muted)] v2-monitoring-row">
+        ${shown.length === 0
+          ? html`<div class="py-2 text-2xs text-[var(--color-fg-disabled)] v2-monitoring-row">기록 없음</div>`
+          : shown.map(item => html`<${UserModelItemRow} key=${`${item.source}-${item.turn}-${item.claim}`} item=${item} />`)}
+      </div>
+    </div>
+  `
+}
+
+function UserModelSourcePanel({
+  snapshot,
+  rows,
+}: {
+  snapshot: KeeperUserModelSnapshot
+  rows: TurnRecordRow[]
+}) {
+  const latestBlock = latestUserModelBlock(rows)
+  const readErrorText = snapshot.read_errors.map(item => `${item.scope}: ${item.error}`).join(' · ')
+
+  return html`
+    <section
+      class="mb-3 border-y border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-3 v2-monitoring-panel"
+      data-testid="user-model-source"
+    >
+      <div class="flex min-w-0 flex-wrap items-start gap-3 v2-monitoring-toolbar">
+        <div class="min-w-0 flex-1">
+          <div class="text-xs font-semibold text-[var(--color-fg-primary)]">User model</div>
+          <div class="mt-0.5 text-3xs text-[var(--color-fg-muted)]">
+            ${snapshot.enabled ? 'enabled' : 'disabled'}
+            <span class="mx-1" aria-hidden="true">·</span>
+            ${latestBlock
+              ? html`latest block <span class="font-mono">${latestBlock.bytes}B</span> <span class="font-mono text-[var(--color-fg-disabled)]">${latestBlock.digest.slice(0, 12)}</span>`
+              : 'latest block 없음'}
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-2 text-3xs">
+          <span class="font-mono text-[var(--color-fg-muted)]">
+            pref ${snapshot.preferences.length}
+          </span>
+          <span class="font-mono text-[var(--color-fg-muted)]">
+            constraints ${snapshot.constraints.length}
+          </span>
+          <span class="font-mono text-[var(--color-fg-muted)]">
+            facts ${snapshot.source_fact_count}
+          </span>
+          <span class="font-mono text-[var(--color-fg-muted)]">
+            shared ${snapshot.shared_fact_count}
+          </span>
+        </div>
+      </div>
+
+      ${readErrorText
+        ? html`<div class="mt-2 text-2xs text-[var(--color-status-err)]">${readErrorText}</div>`
+        : null}
+
+      <div class="mt-2 grid gap-3 md:grid-cols-2">
+        <${UserModelList} title="Preferences" items=${snapshot.preferences} />
+        <${UserModelList} title="Constraints" items=${snapshot.constraints} />
+      </div>
+
+      <details class="mt-2 text-3xs text-[var(--color-fg-disabled)] v2-monitoring-detail">
+        <summary class="cursor-pointer">stores</summary>
+        <div class="mt-1 break-all font-mono">facts: ${snapshot.facts_store}</div>
+        <div class="mt-1 break-all font-mono">shared: ${snapshot.shared_facts_store}</div>
+      </details>
+    </section>
   `
 }
 
@@ -868,11 +990,15 @@ export function KeeperTurnInspector({
   const memoryOsPanel = response?.memory_os
     ? html`<${MemoryOsRecallSourcePanel} snapshot=${response.memory_os} rows=${rows} />`
     : null
+  const userModelPanel = response?.user_model
+    ? html`<${UserModelSourcePanel} snapshot=${response.user_model} rows=${rows} />`
+    : null
 
   if (rows.length === 0) {
     return html`
       <div class="p-4 space-y-1 v2-monitoring-panel">
         ${memoryOsPanel}
+        ${userModelPanel}
         <div class="text-xs text-[var(--color-fg-muted)]">턴 레코드 없음 (서버 재시작 이후 keeper 턴까지 기록됩니다)</div>
         <${FreshnessLine} data=${response ?? { source: 'turn_record' }} />
       </div>
@@ -890,6 +1016,7 @@ export function KeeperTurnInspector({
           : null}
       </div>
       ${memoryOsPanel}
+      ${userModelPanel}
       ${initialMatchState === 'missed'
         ? html`
           <div

--- a/lib/dune
+++ b/lib/dune
@@ -190,7 +190,7 @@
   meta_cognition_interpret
   meta_cognition_digest
   keeper_memory_os_gc
-  keeper_memory_os_io
+  keeper_memory_os_io keeper_user_model
   keeper_memory_os_recall)
  (libraries
   mcp_protocol

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -50,12 +50,6 @@ let sanitize_atom text =
     | c -> c)
 ;;
 
-let fact_is_current ~now (fact : fact) =
-  match fact.valid_until with
-  | None -> true
-  | Some ts -> ts >= now
-;;
-
 let episode_is_current ~now (episode : episode) =
   match episode.valid_until with
   | None -> true

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -264,6 +264,12 @@ type fact =
   ; schema_version : string
   }
 
+let fact_is_current ~now (fact : fact) =
+  match fact.valid_until with
+  | None -> true
+  | Some ts -> ts >= now
+;;
+
 type episode =
   { trace_id : string
   ; generation : int

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -144,6 +144,10 @@ type fact =
   ; schema_version : string
   }
 
+(** Whether a fact's hard-expiry horizon still admits it at [now]. Facts with no
+    [valid_until] are durable and current. *)
+val fact_is_current : now:float -> fact -> bool
+
 (** A librarian extraction result: a summary plus structured claims. *)
 type episode =
   { trace_id : string

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -337,6 +337,18 @@ let assemble_hooks
                   else ctx
                 in
                 let ctx =
+                  match
+                    Keeper_user_model.render_if_enabled
+                      ~keeper_id:meta.name
+                      ~now:(Time_compat.now ())
+                      ()
+                  with
+                  | None -> ctx
+                  | Some block ->
+                    record_block Prompt_block_id.User_model block;
+                    append_ctx ctx block
+                in
+                let ctx =
                   (* Memory OS recall — bounded advisory block rendered from
                      persisted facts/episodes (read side; the write side is
                      the librarian wired in #20897). Opt-in via

--- a/lib/keeper/keeper_user_model.ml
+++ b/lib/keeper/keeper_user_model.ml
@@ -136,21 +136,25 @@ let build ~keeper_id ~now ?(max_preferences = default_max_preferences)
   in
   let private_facts, shared_facts =
     with_fact_store_locks fact_store_ids (fun () ->
-      let private_facts =
+      let private_facts : Keeper_memory_os_types.fact list =
         Keeper_memory_os_io.read_facts_tail
           ~keeper_id
           ~n:Keeper_memory_os_io.fact_store_max
         |> rank_facts ~now
       in
-      let private_keys = List.map (fun f -> normalize_claim f.claim) private_facts in
-      let shared_facts =
+      let private_keys =
+        List.map
+          (fun (fact : Keeper_memory_os_types.fact) -> normalize_claim fact.claim)
+          private_facts
+      in
+      let shared_facts : Keeper_memory_os_types.fact list =
         if String.equal keeper_id shared_store_id
         then []
         else
           Keeper_memory_os_io.read_facts_all ~keeper_id:shared_store_id
           |> rank_facts ~now
-          |> List.filter (fun f ->
-            not (List.mem (normalize_claim f.claim) private_keys))
+          |> List.filter (fun (fact : Keeper_memory_os_types.fact) ->
+            not (List.mem (normalize_claim fact.claim) private_keys))
       in
       private_facts, shared_facts)
   in

--- a/lib/keeper/keeper_user_model.ml
+++ b/lib/keeper/keeper_user_model.ml
@@ -1,0 +1,241 @@
+(** Keeper_user_model — operator preference/constraint projection. *)
+
+open Keeper_memory_os_types
+
+type item_source =
+  | Keeper_private
+  | Shared of string list
+
+type item =
+  { claim : string
+  ; category : category
+  ; source : item_source
+  ; turn : int
+  ; first_seen : float
+  ; last_verified_at : float option
+  }
+
+type t =
+  { preferences : item list
+  ; constraints : item list
+  ; source_fact_count : int
+  ; shared_fact_count : int
+  }
+
+let default_max_preferences = 5
+let default_max_constraints = 5
+let max_claim_len = 220
+let max_atom_len = 56
+
+let rec take n xs =
+  if n <= 0
+  then []
+  else (
+    match xs with
+    | [] -> []
+    | x :: rest -> x :: take (n - 1) rest)
+;;
+
+let truncate ~max_len s =
+  if max_len <= 0
+  then ""
+  else if String.length s <= max_len
+  then s
+  else String.sub s 0 (max 0 (max_len - 3)) ^ "..."
+;;
+
+let sanitize_text ~max_len text =
+  match Keeper_run_prompt.safe_memory_fragment text with
+  | None -> ""
+  | Some safe ->
+    safe
+    |> String.split_on_char '\n'
+    |> List.map String.trim
+    |> List.filter (fun line -> not (String.equal line ""))
+    |> String.concat " "
+    |> truncate ~max_len
+;;
+
+let sanitize_atom text =
+  sanitize_text ~max_len:max_atom_len text
+  |> String.map (function
+    | '\t' | '\r' | '\n' -> ' '
+    | c -> c)
+;;
+
+let fact_is_current ~now (fact : fact) =
+  match fact.valid_until with
+  | None -> true
+  | Some ts -> ts >= now
+;;
+
+let eligible_category = function
+  | Preference | Constraint -> true
+  | Code_change | Fact | Blocker | Goal | Ephemeral | Validated_approach | Lesson
+  | Unknown _ -> false
+;;
+
+let truth_anchor (fact : fact) =
+  match fact.last_verified_at with
+  | Some ts -> ts
+  | None -> fact.first_seen
+;;
+
+let dedup_facts_by_claim facts =
+  let seen = Hashtbl.create 16 in
+  List.filter
+    (fun fact ->
+      let key = normalize_claim fact.claim in
+      if Hashtbl.mem seen key
+      then false
+      else (
+        Hashtbl.add seen key ();
+        true))
+    facts
+;;
+
+let rank_facts ~now facts =
+  facts
+  |> List.filter (fact_is_current ~now)
+  |> List.filter (fun (fact : fact) -> eligible_category fact.category)
+  |> List.sort (fun a b -> compare (truth_anchor b) (truth_anchor a))
+  |> dedup_facts_by_claim
+;;
+
+let item_of_fact ~source (fact : fact) =
+  { claim = fact.claim
+  ; category = fact.category
+  ; source
+  ; turn = fact.source.turn
+  ; first_seen = fact.first_seen
+  ; last_verified_at = fact.last_verified_at
+  }
+;;
+
+let item_truth_anchor item =
+  match item.last_verified_at with
+  | Some ts -> ts
+  | None -> item.first_seen
+;;
+
+let with_fact_store_locks keeper_ids f =
+  let paths =
+    keeper_ids
+    |> List.map (fun keeper_id -> Keeper_memory_os_io.facts_path ~keeper_id)
+    |> List.sort_uniq String.compare
+  in
+  let rec loop = function
+    | [] -> f ()
+    | path :: rest -> File_lock_eio.with_lock path (fun () -> loop rest)
+  in
+  loop paths
+;;
+
+let build ~keeper_id ~now ?(max_preferences = default_max_preferences)
+      ?(max_constraints = default_max_constraints) () =
+  let max_preferences = max 0 max_preferences in
+  let max_constraints = max 0 max_constraints in
+  let fact_store_ids =
+    if String.equal keeper_id shared_store_id
+    then [ keeper_id ]
+    else [ keeper_id; shared_store_id ]
+  in
+  let private_facts, shared_facts =
+    with_fact_store_locks fact_store_ids (fun () ->
+      let private_facts =
+        Keeper_memory_os_io.read_facts_tail
+          ~keeper_id
+          ~n:Keeper_memory_os_io.fact_store_max
+        |> rank_facts ~now
+      in
+      let private_keys = List.map (fun f -> normalize_claim f.claim) private_facts in
+      let shared_facts =
+        if String.equal keeper_id shared_store_id
+        then []
+        else
+          Keeper_memory_os_io.read_facts_all ~keeper_id:shared_store_id
+          |> rank_facts ~now
+          |> List.filter (fun f ->
+            not (List.mem (normalize_claim f.claim) private_keys))
+      in
+      private_facts, shared_facts)
+  in
+  let all_items =
+    List.map (item_of_fact ~source:Keeper_private) private_facts
+    @ List.map
+        (fun (fact : fact) ->
+          item_of_fact ~source:(Shared fact.observed_by) fact)
+        shared_facts
+  in
+  let select category max_items =
+    all_items
+    |> List.filter (fun item -> item.category = category)
+    |> List.sort (fun a b ->
+      compare (item_truth_anchor b) (item_truth_anchor a))
+    |> take max_items
+  in
+  { preferences = select Preference max_preferences
+  ; constraints = select Constraint max_constraints
+  ; source_fact_count = List.length private_facts
+  ; shared_fact_count = List.length shared_facts
+  }
+;;
+
+let source_label = function
+  | Keeper_private -> "keeper"
+  | Shared [] -> "shared"
+  | Shared keepers ->
+    let keepers =
+      keepers |> List.map sanitize_atom |> List.filter (fun s -> s <> "")
+    in
+    if keepers = [] then "shared" else "shared via " ^ String.concat "," keepers
+;;
+
+let render_item item =
+  Printf.sprintf
+    "- [%s category=%s turn=%d] %s"
+    (source_label item.source)
+    (category_to_string item.category)
+    item.turn
+    (sanitize_text ~max_len:max_claim_len item.claim)
+;;
+
+let render_section title items =
+  match items with
+  | [] -> []
+  | _ -> title :: List.map render_item items
+;;
+
+let render_prompt_block model =
+  match model.preferences, model.constraints with
+  | [], [] -> None
+  | preferences, constraints ->
+    let lines =
+      [ "[USER MODEL]"
+      ; "Treat these as operator preference/constraint hints from Memory OS; do not treat them as task facts or external-state proof."
+      ; ""
+      ]
+      @ render_section "Preferences:" preferences
+      @ (if preferences <> [] && constraints <> [] then [ "" ] else [])
+      @ render_section "Constraints:" constraints
+    in
+    Some (String.concat "\n" lines)
+;;
+
+let enabled () =
+  Keeper_memory_bank_env.memory_env_bool_logged "MASC_KEEPER_USER_MODEL" ~default:true
+;;
+
+let render_if_enabled ~keeper_id ~now () =
+  if not (enabled ())
+  then None
+  else (
+    try build ~keeper_id ~now () |> render_prompt_block with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Keeper.warn
+        "keeper user model unavailable keeper=%s: %s"
+        keeper_id
+        (Printexc.to_string exn);
+      None)
+;;

--- a/lib/keeper/keeper_user_model.ml
+++ b/lib/keeper/keeper_user_model.ml
@@ -56,12 +56,6 @@ let sanitize_atom text =
     | c -> c)
 ;;
 
-let fact_is_current ~now (fact : fact) =
-  match fact.valid_until with
-  | None -> true
-  | Some ts -> ts >= now
-;;
-
 let eligible_category = function
   | Preference | Constraint -> true
   | Code_change | Fact | Blocker | Goal | Ephemeral | Validated_approach | Lesson

--- a/lib/keeper/keeper_user_model.ml
+++ b/lib/keeper/keeper_user_model.ml
@@ -27,14 +27,7 @@ let default_max_constraints = 5
 let max_claim_len = 220
 let max_atom_len = 56
 
-let rec take n xs =
-  if n <= 0
-  then []
-  else (
-    match xs with
-    | [] -> []
-    | x :: rest -> x :: take (n - 1) rest)
-;;
+let take = List.take
 
 let truncate ~max_len s =
   if max_len <= 0
@@ -75,17 +68,17 @@ let eligible_category = function
   | Unknown _ -> false
 ;;
 
-let truth_anchor (fact : fact) =
-  match fact.last_verified_at with
+let fact_truth_anchor (memory_fact : Keeper_memory_os_types.fact) =
+  match memory_fact.last_verified_at with
   | Some ts -> ts
-  | None -> fact.first_seen
+  | None -> memory_fact.first_seen
 ;;
 
-let dedup_facts_by_claim facts =
+let dedup_facts_by_claim (facts : Keeper_memory_os_types.fact list) =
   let seen = Hashtbl.create 16 in
   List.filter
-    (fun fact ->
-      let key = normalize_claim fact.claim in
+    (fun (memory_fact : Keeper_memory_os_types.fact) ->
+      let key = normalize_claim memory_fact.claim in
       if Hashtbl.mem seen key
       then false
       else (
@@ -98,7 +91,8 @@ let rank_facts ~now facts =
   facts
   |> List.filter (fact_is_current ~now)
   |> List.filter (fun (fact : fact) -> eligible_category fact.category)
-  |> List.sort (fun a b -> compare (truth_anchor b) (truth_anchor a))
+  |> List.sort (fun (a : fact) (b : fact) ->
+    compare (fact_truth_anchor b) (fact_truth_anchor a))
   |> dedup_facts_by_claim
 ;;
 

--- a/lib/keeper/keeper_user_model.ml
+++ b/lib/keeper/keeper_user_model.ml
@@ -34,7 +34,7 @@ let truncate ~max_len s =
   then ""
   else if String.length s <= max_len
   then s
-  else String.sub s 0 (max 0 (max_len - 3)) ^ "..."
+  else String_util.utf8_safe ~max_bytes:max_len ~suffix:"..." s |> String_util.to_string
 ;;
 
 let sanitize_text ~max_len text =

--- a/lib/keeper/keeper_user_model.mli
+++ b/lib/keeper/keeper_user_model.mli
@@ -1,0 +1,41 @@
+(** Keeper_user_model — operator preference/constraint projection.
+
+    This is a read-only MASC-side projection over Memory OS facts. It turns
+    librarian-categorized [Preference] and [Constraint] facts into a compact
+    prompt block for keepers; it does not change Memory OS write semantics or
+    add provider/OAS responsibilities. *)
+
+type item_source =
+  | Keeper_private
+  | Shared of string list
+
+type item =
+  { claim : string
+  ; category : Keeper_memory_os_types.category
+  ; source : item_source
+  ; turn : int
+  ; first_seen : float
+  ; last_verified_at : float option
+  }
+
+type t =
+  { preferences : item list
+  ; constraints : item list
+  ; source_fact_count : int
+  ; shared_fact_count : int
+  }
+
+val build
+  :  keeper_id:string
+  -> now:float
+  -> ?max_preferences:int
+  -> ?max_constraints:int
+  -> unit
+  -> t
+
+val render_prompt_block : t -> string option
+
+val enabled : unit -> bool
+(** Kill-switch flag [MASC_KEEPER_USER_MODEL] (default [true]). *)
+
+val render_if_enabled : keeper_id:string -> now:float -> unit -> string option

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -123,6 +123,77 @@ let memory_os_dashboard_json ~keeper_id =
     ]
 ;;
 
+let user_model_item_source_json = function
+  | Keeper_user_model.Keeper_private -> "keeper", []
+  | Keeper_user_model.Shared keepers -> "shared", keepers
+;;
+
+let user_model_item_json (item : Keeper_user_model.item) =
+  let source, observed_by = user_model_item_source_json item.source in
+  `Assoc
+    [ "claim", `String item.claim
+    ; "category", `String (Keeper_memory_os_types.category_to_string item.category)
+    ; "source", `String source
+    ; "observed_by", `List (List.map (fun name -> `String name) observed_by)
+    ; "turn", `Int item.turn
+    ; "first_seen", `Float item.first_seen
+    ; "first_seen_iso", `String (Masc_domain.iso8601_of_unix_seconds item.first_seen)
+    ; "last_verified_at", json_float_opt item.last_verified_at
+    ; "last_verified_at_iso", json_time_iso_opt item.last_verified_at
+    ]
+;;
+
+let user_model_dashboard_json ~keeper_id =
+  let now = Time_compat.now () in
+  let facts_store = Keeper_memory_os_io.facts_path ~keeper_id in
+  let shared_facts_store =
+    Keeper_memory_os_io.facts_path ~keeper_id:Keeper_memory_os_types.shared_store_id
+  in
+  try
+    let model = Keeper_user_model.build ~keeper_id ~now () in
+    `Assoc
+      [ "schema", `String "keeper.user_model.dashboard.v1"
+      ; "keeper", `String keeper_id
+      ; "source", `String "memory_os_facts"
+      ; "producer", `String "keeper_user_model"
+      ; "facts_store", `String facts_store
+      ; "shared_facts_store", `String shared_facts_store
+      ; "enabled", `Bool (Keeper_user_model.enabled ())
+      ; "now", `Float now
+      ; "now_iso", `String (Masc_domain.iso8601_of_unix_seconds now)
+      ; "read_errors", `List []
+      ; "source_fact_count", `Int model.source_fact_count
+      ; "shared_fact_count", `Int model.shared_fact_count
+      ; "preferences", `List (List.map user_model_item_json model.preferences)
+      ; "constraints", `List (List.map user_model_item_json model.constraints)
+      ]
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    `Assoc
+      [ "schema", `String "keeper.user_model.dashboard.v1"
+      ; "keeper", `String keeper_id
+      ; "source", `String "memory_os_facts"
+      ; "producer", `String "keeper_user_model"
+      ; "facts_store", `String facts_store
+      ; "shared_facts_store", `String shared_facts_store
+      ; "enabled", `Bool (Keeper_user_model.enabled ())
+      ; "now", `Float now
+      ; "now_iso", `String (Masc_domain.iso8601_of_unix_seconds now)
+      ; ( "read_errors"
+        , `List
+            [ `Assoc
+                [ "scope", `String "user_model"
+                ; "error", `String (Printexc.to_string exn)
+                ]
+            ] )
+      ; "source_fact_count", `Int 0
+      ; "shared_fact_count", `Int 0
+      ; "preferences", `List []
+      ; "constraints", `List []
+      ]
+;;
+
 let handle_keeper_get_subroutes state req request reqd =
   let req_path = Http.Request.path req in
   let prefix = keeper_api_prefix in
@@ -524,6 +595,7 @@ let handle_keeper_get_subroutes state req request reqd =
         ( "stale_reason",
           if stale_reason = "" then `Null else `String stale_reason );
         ("memory_os", memory_os_dashboard_json ~keeper_id:name);
+        ("user_model", user_model_dashboard_json ~keeper_id:name);
         ("entries", `List entries);
       ] in
       Http.Response.json_value ~compress:true ~request:req json reqd

--- a/lib/types/prompt_block_id.ml
+++ b/lib/types/prompt_block_id.ml
@@ -6,6 +6,7 @@ type t =
   | Claimed_task_nudge
   | Retry_nudge
   | Memory_os_recall
+  | User_model
   | Connected_surface
   | Other of string
 
@@ -18,11 +19,12 @@ let equal a b =
   | Claimed_task_nudge, Claimed_task_nudge
   | Retry_nudge, Retry_nudge
   | Memory_os_recall, Memory_os_recall
+  | User_model, User_model
   | Connected_surface, Connected_surface -> true
   | Other a, Other b -> String.equal a b
   | ( ( Persona | Continuity | Dynamic_context | Temporal_summary
       | Claimed_task_nudge | Retry_nudge | Memory_os_recall
-      | Connected_surface | Other _ )
+      | User_model | Connected_surface | Other _ )
     , _ ) -> false
 
 let to_string = function
@@ -33,6 +35,7 @@ let to_string = function
   | Claimed_task_nudge -> "claimed_task_nudge"
   | Retry_nudge -> "retry_nudge"
   | Memory_os_recall -> "memory_os_recall"
+  | User_model -> "user_model"
   | Connected_surface -> "connected_surface"
   | Other name -> name
 
@@ -44,6 +47,7 @@ let of_string = function
   | "claimed_task_nudge" -> Claimed_task_nudge
   | "retry_nudge" -> Retry_nudge
   | "memory_os_recall" -> Memory_os_recall
+  | "user_model" -> User_model
   | "connected_surface" -> Connected_surface
   | name -> Other name
 
@@ -55,5 +59,6 @@ let all_known =
   ; Claimed_task_nudge
   ; Retry_nudge
   ; Memory_os_recall
+  ; User_model
   ; Connected_surface
   ]

--- a/lib/types/prompt_block_id.mli
+++ b/lib/types/prompt_block_id.mli
@@ -23,6 +23,7 @@ type t =
   | Claimed_task_nudge
   | Retry_nudge
   | Memory_os_recall
+  | User_model
   | Connected_surface
   | Other of string
 

--- a/test/dune
+++ b/test/dune
@@ -389,6 +389,7 @@
   test_keeper_turn_disposition
   test_keeper_turn_terminal_disposition_field
   test_keeper_memory_os
+  test_keeper_user_model
   test_keeper_memory_os_consolidation
   test_keeper_memory_os_consolidation_runtime
   eval_memory_os_value

--- a/test/dune
+++ b/test/dune
@@ -88,6 +88,7 @@
   test_keeper_turn_disposition
   test_keeper_turn_terminal_disposition_field
   test_keeper_memory_os
+  test_keeper_user_model
   test_keeper_memory_os_consolidation
   test_keeper_memory_os_consolidation_runtime
   eval_memory_os_value

--- a/test/test_keeper_user_model.ml
+++ b/test/test_keeper_user_model.ml
@@ -1,0 +1,164 @@
+(** Tests for Keeper_user_model projection from Memory OS facts. *)
+
+open Alcotest
+
+module Types = Masc.Keeper_memory_os_types
+module Memory_io = Masc.Keeper_memory_os_io
+module User_model = Masc.Keeper_user_model
+
+let contains substring s =
+  let sub_len = String.length substring in
+  let str_len = String.length s in
+  let rec loop i =
+    if i + sub_len > str_len
+    then false
+    else if String.equal (String.sub s i sub_len) substring
+    then true
+    else loop (i + 1)
+  in
+  if sub_len = 0 then true else loop 0
+;;
+
+let with_temp_keepers_dir f =
+  let marker = Filename.temp_file "keeper-user-model-" ".tmp" in
+  Sys.remove marker;
+  Memory_io.For_testing.with_keepers_dir marker (fun () -> f marker)
+;;
+
+let fact
+      ?(observed_by = [])
+      ?valid_until
+      ?last_verified_at
+      ~now
+      ~category
+      ~claim
+      ~trace_id
+      ~turn
+      ()
+  =
+  { Types.claim
+  ; category
+  ; external_ref = None
+  ; source = { trace_id; turn; tool_call_id = None }
+  ; observed_by
+  ; first_seen = now -. float_of_int turn
+  ; valid_until
+  ; last_verified_at
+  ; schema_version = Types.schema_version
+  }
+;;
+
+let test_build_filters_user_model_categories_and_private_precedence () =
+  with_temp_keepers_dir
+  @@ fun _ ->
+  let now = 10_000.0 in
+  Memory_io.append_fact ~keeper_id:"sangsu"
+    (fact
+       ~now
+       ~category:Types.Preference
+       ~claim:"User prefers concise answers"
+       ~trace_id:"trace-private-pref"
+       ~turn:10
+       ~last_verified_at:(now -. 10.0)
+       ());
+  Memory_io.append_fact ~keeper_id:"sangsu"
+    (fact
+       ~now
+       ~category:Types.Constraint
+       ~claim:"Do not recommend launchd unless the user explicitly asks"
+       ~trace_id:"trace-private-constraint"
+       ~turn:11
+       ~last_verified_at:(now -. 20.0)
+       ());
+  Memory_io.append_fact ~keeper_id:"sangsu"
+    (fact
+       ~now
+       ~category:Types.Fact
+       ~claim:"This ordinary fact must not become user model context"
+       ~trace_id:"trace-fact"
+       ~turn:12
+       ());
+  Memory_io.append_fact ~keeper_id:"sangsu"
+    (fact
+       ~now
+       ~category:Types.Preference
+       ~claim:"Expired user preference"
+       ~trace_id:"trace-expired"
+       ~turn:13
+       ~valid_until:(now -. 1.0)
+       ());
+  Memory_io.append_fact ~keeper_id:Types.shared_store_id
+    (fact
+       ~now
+       ~category:Types.Preference
+       ~claim:"User prefers concise answers"
+       ~trace_id:"trace-shared-duplicate"
+       ~turn:99
+       ~observed_by:[ "rondo"; "qa-king" ]
+       ~last_verified_at:(now -. 1.0)
+       ());
+  Memory_io.append_fact ~keeper_id:Types.shared_store_id
+    (fact
+       ~now
+       ~category:Types.Constraint
+       ~claim:"Let CI be the authority for full builds"
+       ~trace_id:"trace-shared-constraint"
+       ~turn:14
+       ~observed_by:[ "qa-king"; "verifier" ]
+       ~last_verified_at:(now -. 5.0)
+       ());
+  let model =
+    User_model.build ~keeper_id:"sangsu" ~now ~max_preferences:5 ~max_constraints:5 ()
+  in
+  check int "preference count" 1 (List.length model.preferences);
+  check int "constraint count" 2 (List.length model.constraints);
+  (match model.preferences with
+   | [ preference ] ->
+     check string "private preference wins duplicate"
+       "User prefers concise answers"
+       preference.claim
+   | _ -> fail "expected exactly one preference");
+  check bool "shared constraint surfaced" true
+    (List.exists
+       (fun (item : User_model.item) ->
+          String.equal item.claim "Let CI be the authority for full builds")
+       model.constraints);
+  let rendered =
+    match User_model.render_prompt_block model with
+    | None -> fail "expected rendered user model"
+    | Some block -> block
+  in
+  check bool "renders header" true (contains "[USER MODEL]" rendered);
+  check bool "renders preferences section" true (contains "Preferences:" rendered);
+  check bool "renders constraints section" true (contains "Constraints:" rendered);
+  check bool "renders shared provenance" true (contains "shared via qa-king,verifier" rendered);
+  check bool "does not render ordinary fact" false
+    (contains "ordinary fact" rendered);
+  check bool "does not render expired preference" false
+    (contains "Expired user preference" rendered);
+  check bool "does not use shared duplicate turn" false (contains "turn=99" rendered)
+;;
+
+let test_render_empty_model_is_none () =
+  let model =
+    { User_model.preferences = []
+    ; constraints = []
+    ; source_fact_count = 0
+    ; shared_fact_count = 0
+    }
+  in
+  check bool "empty render" true (Option.is_none (User_model.render_prompt_block model))
+;;
+
+let () =
+  run
+    "Keeper_user_model"
+    [ ( "projection"
+      , [ test_case
+            "filters user model categories and preserves private precedence"
+            `Quick
+            test_build_filters_user_model_categories_and_private_precedence
+        ; test_case "empty model renders no block" `Quick test_render_empty_model_is_none
+        ] )
+    ]
+;;

--- a/test/test_keeper_user_model.ml
+++ b/test/test_keeper_user_model.ml
@@ -20,9 +20,8 @@ let contains substring s =
 ;;
 
 let with_temp_keepers_dir f =
-  let marker = Filename.temp_file "keeper-user-model-" ".tmp" in
-  Sys.remove marker;
-  Memory_io.For_testing.with_keepers_dir marker (fun () -> f marker)
+  let dir = Filename.temp_dir "keeper-user-model-" "" in
+  Memory_io.For_testing.with_keepers_dir dir (fun () -> f dir)
 ;;
 
 let fact
@@ -150,6 +149,35 @@ let test_render_empty_model_is_none () =
   check bool "empty render" true (Option.is_none (User_model.render_prompt_block model))
 ;;
 
+let test_render_truncates_on_utf8_boundary () =
+  let claim = String.make 218 'a' ^ "한글" in
+  let item : User_model.item =
+    { claim
+    ; category = Types.Preference
+    ; source = User_model.Keeper_private
+    ; turn = 1
+    ; first_seen = 1.0
+    ; last_verified_at = None
+    }
+  in
+  let model =
+    { User_model.preferences = [ item ]
+    ; constraints = []
+    ; source_fact_count = 1
+    ; shared_fact_count = 0
+    }
+  in
+  let rendered =
+    match User_model.render_prompt_block model with
+    | None -> fail "expected rendered user model"
+    | Some block -> block
+  in
+  check bool "rendered prompt remains valid UTF-8" true
+    (String.is_valid_utf_8 rendered);
+  check bool "rendered prompt shows truncation marker" true
+    (contains "..." rendered)
+;;
+
 let () =
   run
     "Keeper_user_model"
@@ -159,6 +187,10 @@ let () =
             `Quick
             test_build_filters_user_model_categories_and_private_precedence
         ; test_case "empty model renders no block" `Quick test_render_empty_model_is_none
+        ; test_case
+            "render truncates on UTF-8 boundary"
+            `Quick
+            test_render_truncates_on_utf8_boundary
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- add a MASC-side Keeper_user_model projection over Memory OS Preference/Constraint facts
- inject the rendered [USER MODEL] block into keeper prompt assembly with prompt receipt id user_model
- expose the current user-model snapshot on /api/v1/keepers/:name/turn-records
- render a User model panel in the keeper turn inspector with latest user_model block metadata, preferences, constraints, source counts, and stores
- add focused OCaml and dashboard coverage for filtering, expired fact exclusion, private-over-shared precedence, shared provenance, and panel rendering
- share the Memory OS fact expiry predicate so recall and user-model projection use the same TTL semantics

## Boundary
- stays inside MASC keeper/runtime prompt assembly and dashboard observability
- does not add OAS/provider-specific user-model behavior
- read-only over Memory OS facts; write/librarian semantics are unchanged

## Validation
- opam exec -- ocamlformat --check lib/server/server_dashboard_http_keeper_api.ml lib/keeper/keeper_memory_os_types.ml lib/keeper/keeper_memory_os_types.mli lib/keeper/keeper_memory_os_recall.ml lib/keeper/keeper_user_model.ml lib/keeper/keeper_user_model.mli lib/types/prompt_block_id.ml lib/types/prompt_block_id.mli lib/keeper/keeper_run_tools_hooks.ml test/test_keeper_user_model.ml
- git diff --check origin/main...HEAD
- scripts/ocaml-structure-ratchet.sh
- scripts/validate-prompt-paths.sh
- scripts/ci/check-determinism-contract.sh
- pnpm --dir dashboard install --offline --frozen-lockfile
- pnpm --dir dashboard typecheck
- pnpm --dir dashboard lint
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/keeper-turn-inspector.test.ts

## Not run locally
- scripts/dune-local.sh build test/test_keeper_user_model.exe test/test_turn_record.exe
  - blocked with exit 75: live bare dune build outside scripts/dune-local.sh detected, so CI should be the build authority for this PR
