### PR TITLE
Harden keeper tool probing and librarian fallback

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -26,6 +26,7 @@ Do NOT use shell status commands whose red/failed state is encoded as a non-zero
 Do NOT use shell redirects or chaining. Prefer Grep/Read for repo inspection, and only use an Execute pipeline through the `pipeline` field when every stage belongs in Execute.
 Do NOT use Execute for grep/rg pipelines such as `cd repos/REPO_NAME && grep -rn "term" lib/ --include="*.ml" | head -40`. Use `Grep { pattern: "term", path: "repos/REPO_NAME/lib", glob: "*.ml" }` when Grep is visible, with `cwd` set only for tools that support it.
 Do NOT run repo-wide Execute scans such as `rg "term" repos/ ...` or `git log --all --grep="term" 2>/dev/null | head -5`. Use Grep with a scoped repo path, or run `git log --oneline -5 --grep=term` from the target repo cwd.
+Do NOT pass wildcard/glob strings as path arguments, such as `lib/keeper/keeper_memory_os_consolidat*`. First list or search the parent directory (`lib/keeper`), then use an exact existing child path. If the tool returns `path_probe.parent_entries`, read that list before retrying.
 ## Tool error grammar (how to read a failed tool result)
 
 Every failed tool call returns a JSON envelope like:

--- a/lib/keeper/keeper_delegation_request.ml
+++ b/lib/keeper/keeper_delegation_request.ml
@@ -50,14 +50,10 @@ let compact_whitespace text =
   Buffer.contents buf
 
 let truncate ~max_len text =
-  if String.length text <= max_len then text
-  else
-    let rec utf8_boundary idx =
-      if idx <= 0 then 0
-      else if Char.code text.[idx] land 0xc0 = 0x80 then utf8_boundary (idx - 1)
-      else idx
-    in
-    String.sub text 0 (utf8_boundary max_len)
+  let prefix, _ =
+    Keeper_text_processing.truncate_utf8_prefix ~max_bytes:max_len text
+  in
+  prefix
 
 let digest_id ~requester ?goal ~topic ~reason () =
   let goal_text =

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -311,13 +311,17 @@ type attempt_outcome =
     (* provider returned output we could not parse into an episode — retryable *)
   | Transport_failed of string (* timeout / HTTP error — not retried here *)
 
+type parse_retry_error =
+  | Retry_exhausted_unparseable of string
+  | Retry_transport_failed of string
+
 let rec run_with_parse_retries ~max_retries ~attempt messages =
   match attempt messages with
   | Parsed episode -> Ok episode
-  | Transport_failed msg -> Error msg
+  | Transport_failed msg -> Error (Retry_transport_failed msg)
   | Unparseable msg ->
     if max_retries <= 0
-    then Error msg
+    then Error (Retry_exhausted_unparseable msg)
     else
       run_with_parse_retries
         ~max_retries:(max_retries - 1)
@@ -383,6 +387,87 @@ let with_timeout ?clock ~timeout_sec f =
      | Eio.Time.Timeout -> None)
 ;;
 
+let unstructured_note_max_chars = 900
+
+let collapse_for_unstructured_note raw =
+  let buf = Buffer.create (String.length raw) in
+  let previous_space = ref true in
+  String.iter
+    (fun c ->
+       match c with
+       | '\n' | '\r' | '\t' | ' ' ->
+         if not !previous_space then Buffer.add_char buf ' ';
+         previous_space := true
+       | c ->
+         Buffer.add_char buf c;
+         previous_space := false)
+    raw;
+  Buffer.contents buf |> String.trim
+
+let truncate_utf8_prefix max_len s =
+  if String.length s <= max_len
+  then s
+  else (
+    let len = min max_len (String.length s) in
+    let rec boundary i =
+      if i <= 0
+      then 0
+      else
+        let code = Char.code s.[i] in
+        if code land 0b1100_0000 = 0b1000_0000 then boundary (i - 1) else i
+    in
+    String.sub s 0 (boundary len))
+
+let unstructured_episode ~generation (inp : Keeper_librarian.input) ~reason ~raw =
+  let now = Unix.gettimeofday () in
+  let raw_excerpt =
+    raw
+    |> collapse_for_unstructured_note
+    |> truncate_utf8_prefix unstructured_note_max_chars
+  in
+  let note =
+    if String.equal raw_excerpt ""
+    then Printf.sprintf "unstructured_note: librarian parse fallback (%s): <empty response>" reason
+    else Printf.sprintf "unstructured_note: librarian parse fallback (%s): %s" reason raw_excerpt
+  in
+  let source_turn_range =
+    match List.length inp.messages with
+    | 0 -> None
+    | n -> Some (0, n - 1)
+  in
+  let fact : Keeper_memory_os_types.fact =
+    { claim = note
+    ; category = Keeper_memory_os_types.Ephemeral
+    ; external_ref = None
+    ; source = { trace_id = inp.trace_id; turn = 0; tool_call_id = None }
+    ; observed_by = []
+    ; first_seen = now
+    ; valid_until =
+        Keeper_memory_os_types.fact_valid_until
+          ~now
+          ~external_ref:None
+          Keeper_memory_os_types.Ephemeral
+    ; last_verified_at = Some now
+    ; schema_version = Keeper_memory_os_types.schema_version
+    }
+  in
+  { Keeper_memory_os_types.trace_id = inp.trace_id
+  ; generation
+  ; episode_summary = "Unstructured librarian note preserved after parse failure"
+  ; claims = [ fact ]
+  ; open_items = []
+  ; constraints = []
+  ; preserved_tool_refs = []
+  ; source_turn_range
+  ; created_at = now
+  ; valid_until =
+      Keeper_memory_os_types.category_valid_until
+        ~now
+        Keeper_memory_os_types.Ephemeral
+  ; terminal_marker = Some "librarian_unstructured_fallback"
+  ; schema_version = Keeper_memory_os_types.schema_version
+  }
+
 let extract_with_provider
     ?(complete = default_complete)
     ?clock
@@ -397,6 +482,7 @@ let extract_with_provider
   | Error _ as e -> e
   | Ok messages ->
     let provider_cfg = provider_for_librarian provider_cfg in
+    let last_unparseable_raw = ref None in
     let attempt messages =
       match
         with_timeout ?clock ~timeout_sec (fun () ->
@@ -407,16 +493,32 @@ let extract_with_provider
       | Some (Ok response) ->
         let raw = Agent_sdk_response.text_of_response response |> String.trim in
         if String.equal raw ""
-        then Unparseable "librarian provider returned empty response"
+        then (
+          last_unparseable_raw := Some raw;
+          Unparseable "librarian provider returned empty response")
         else (
           match Keeper_librarian.episode_of_output ~generation inp raw with
           | Some episode -> Parsed episode
-          | None -> Unparseable "librarian provider returned invalid episode JSON")
+          | None ->
+            last_unparseable_raw := Some raw;
+            Unparseable "librarian provider returned invalid episode JSON")
     in
-    run_with_parse_retries
-      ~max_retries:librarian_max_parse_retries
-      ~attempt
-      messages
+    (match
+       run_with_parse_retries
+         ~max_retries:librarian_max_parse_retries
+         ~attempt
+         messages
+     with
+     | Ok episode -> Ok episode
+     | Error (Retry_transport_failed msg) -> Error msg
+     | Error (Retry_exhausted_unparseable msg) ->
+       let raw = Option.value !last_unparseable_raw ~default:"" in
+       Log.Keeper.warn
+         "memory os librarian preserving unstructured fallback trace_id=%s generation=%d reason=%s"
+         inp.trace_id
+         generation
+         msg;
+       Ok (unstructured_episode ~generation inp ~reason:msg ~raw))
 ;;
 
 let extract_and_append_with_provider

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -404,25 +404,11 @@ let collapse_for_unstructured_note raw =
     raw;
   Buffer.contents buf |> String.trim
 
-let truncate_utf8_prefix max_len s =
-  if String.length s <= max_len
-  then s
-  else (
-    let len = min max_len (String.length s) in
-    let rec boundary i =
-      if i <= 0
-      then 0
-      else
-        let code = Char.code s.[i] in
-        if code land 0b1100_0000 = 0b1000_0000 then boundary (i - 1) else i
-    in
-    String.sub s 0 (boundary len))
-
 let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason ~raw =
-  let raw_excerpt =
-    raw
-    |> collapse_for_unstructured_note
-    |> truncate_utf8_prefix unstructured_note_max_chars
+  let raw_excerpt, _ =
+    Keeper_text_processing.truncate_utf8_prefix
+      ~max_bytes:unstructured_note_max_chars
+      (collapse_for_unstructured_note raw)
   in
   let note =
     if String.equal raw_excerpt ""

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -387,6 +387,12 @@ let with_timeout ?clock ~timeout_sec f =
      | Eio.Time.Timeout -> None)
 ;;
 
+let now_from_clock ?clock () =
+  match clock with
+  | Some clock -> Eio.Time.now clock
+  | None -> Time_compat.now ()
+;;
+
 let unstructured_note_max_chars = 900
 
 let collapse_for_unstructured_note raw =
@@ -502,7 +508,7 @@ let extract_with_provider
          | Some raw -> raw
          | None -> ""
        in
-       let now = Time_compat.now () in
+       let now = now_from_clock ?clock () in
        Log.Keeper.warn
          "memory os librarian preserving unstructured fallback trace_id=%s generation=%d reason=%s"
          inp.trace_id

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -418,8 +418,7 @@ let truncate_utf8_prefix max_len s =
     in
     String.sub s 0 (boundary len))
 
-let unstructured_episode ~generation (inp : Keeper_librarian.input) ~reason ~raw =
-  let now = Unix.gettimeofday () in
+let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason ~raw =
   let raw_excerpt =
     raw
     |> collapse_for_unstructured_note
@@ -512,13 +511,18 @@ let extract_with_provider
      | Ok episode -> Ok episode
      | Error (Retry_transport_failed msg) -> Error msg
      | Error (Retry_exhausted_unparseable msg) ->
-       let raw = Option.value !last_unparseable_raw ~default:"" in
+       let raw =
+         match !last_unparseable_raw with
+         | Some raw -> raw
+         | None -> ""
+       in
+       let now = Time_compat.now () in
        Log.Keeper.warn
          "memory os librarian preserving unstructured fallback trace_id=%s generation=%d reason=%s"
          inp.trace_id
          generation
          msg;
-       Ok (unstructured_episode ~generation inp ~reason:msg ~raw))
+       Ok (unstructured_episode ~now ~generation inp ~reason:msg ~raw))
 ;;
 
 let extract_and_append_with_provider

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -101,16 +101,21 @@ type attempt_outcome =
   | Unparseable of string
   | Transport_failed of string
 
+type parse_retry_error =
+  | Retry_exhausted_unparseable of string
+  | Retry_transport_failed of string
+
 val run_with_parse_retries
   :  max_retries:int
   -> attempt:(Agent_sdk.Types.message list -> attempt_outcome)
   -> Agent_sdk.Types.message list
-  -> (Keeper_memory_os_types.episode, string) result
-(** Drive [attempt] over a growing message list. Returns immediately on [Parsed]
-    (Ok) and [Transport_failed] (Error); on [Unparseable], appends
-    {!parse_retry_nudge} and retries up to [max_retries] times before returning
-    the last error. Pure given a pure [attempt] — the provider side effect lives
-    in the [attempt] supplied by {!extract_with_provider}. *)
+  -> (Keeper_memory_os_types.episode, parse_retry_error) result
+(** Drive [attempt] over a growing message list. Returns immediately on [Parsed].
+    [Transport_failed] returns [Retry_transport_failed] without retry. On
+    [Unparseable], appends {!parse_retry_nudge} and retries up to [max_retries]
+    times before returning [Retry_exhausted_unparseable]. Pure given a pure
+    [attempt] — the provider side effect lives in the [attempt] supplied by
+    {!extract_with_provider}. *)
 
 val global_slot_capacity : unit -> int
 (** Fleet-wide librarian provider gate capacity from

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -135,6 +135,53 @@ let promote_facts ?(min_keepers = default_min_keepers) ~now ~keeper_facts () =
   considered, promoted
 ;;
 
+let sum ints = List.fold_left ( + ) 0 ints
+
+let source_fact_counts keeper_facts =
+  List.map
+    (fun (keeper_id, facts) ->
+       ( keeper_id
+       , List.length facts
+       , List.length (List.filter eligible facts) ))
+    keeper_facts
+
+let source_fact_counts_json counts =
+  `List
+    (List.map
+       (fun (keeper_id, facts, eligible_facts) ->
+          `Assoc
+            [ "keeper_id", `String keeper_id
+            ; "facts", `Int facts
+            ; "eligible_facts", `Int eligible_facts
+            ])
+       counts)
+
+let log_run_summary ~dry_run ~min_keepers ~source_ids ~keeper_facts ~considered ~promoted =
+  let counts = source_fact_counts keeper_facts in
+  let input_facts = sum (List.map (fun (_, facts, _) -> facts) counts) in
+  let eligible_facts = sum (List.map (fun (_, _, eligible_facts) -> eligible_facts) counts) in
+  let promoted_count = List.length promoted in
+  Log.Keeper.info
+    "memory os consolidator run dry_run=%b min_keepers=%d keepers=%d input_facts=%d eligible_facts=%d claims_considered=%d promoted=%d"
+    dry_run
+    min_keepers
+    (List.length source_ids)
+    input_facts
+    eligible_facts
+    considered
+    promoted_count;
+  if promoted_count = 0
+  then
+    Log.Keeper.warn
+      "memory os consolidator promoted_zero dry_run=%b min_keepers=%d keepers=%d input_facts=%d eligible_facts=%d claims_considered=%d source_counts=%s"
+      dry_run
+      min_keepers
+      (List.length source_ids)
+      input_facts
+      eligible_facts
+      considered
+      (Yojson.Safe.to_string (source_fact_counts_json counts))
+
 (* IO-driven entry: read each source keeper's Tier-1 store, consolidate, and
    (unless [dry_run]) rewrite the shared store atomically. The shared id itself
    is filtered out of the source list so a prior sweep's output is never folded
@@ -143,6 +190,7 @@ let run ?(dry_run = false) ?min_keepers ~keeper_ids ~now () =
   let source_ids =
     List.filter (fun id -> not (String.equal id shared_store_id)) keeper_ids
   in
+  let min_keepers = Option.value min_keepers ~default:default_min_keepers in
   let run_unlocked () =
     let rec read_sources acc = function
       | [] -> Ok (List.rev acc)
@@ -152,11 +200,23 @@ let run ?(dry_run = false) ?min_keepers ~keeper_ids ~now () =
          | Error message -> Error message)
     in
     match read_sources [] source_ids with
-    | Error message -> invalid_arg ("memory os consolidation input invalid: " ^ message)
+    | Error message ->
+      Log.Keeper.warn
+        "memory os consolidator input_invalid keepers=%d error=%s"
+        (List.length source_ids)
+        message;
+      invalid_arg ("memory os consolidation input invalid: " ^ message)
     | Ok keeper_facts ->
       let considered, promoted =
-        promote_facts ?min_keepers ~now ~keeper_facts ()
+        promote_facts ~min_keepers ~now ~keeper_facts ()
       in
+      log_run_summary
+        ~dry_run
+        ~min_keepers
+        ~source_ids
+        ~keeper_facts
+        ~considered
+        ~promoted;
       if not dry_run then Io.rewrite_facts_atomically ~keeper_id:shared_store_id promoted;
       { keepers_scanned = List.length source_ids
       ; claims_considered = considered

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -190,7 +190,11 @@ let run ?(dry_run = false) ?min_keepers ~keeper_ids ~now () =
   let source_ids =
     List.filter (fun id -> not (String.equal id shared_store_id)) keeper_ids
   in
-  let min_keepers = Option.value min_keepers ~default:default_min_keepers in
+  let min_keepers =
+    match min_keepers with
+    | Some value -> value
+    | None -> default_min_keepers
+  in
   let run_unlocked () =
     let rec read_sources acc = function
       | [] -> Ok (List.rev acc)

--- a/lib/keeper/keeper_runtime_personality_diff.ml
+++ b/lib/keeper/keeper_runtime_personality_diff.ml
@@ -53,26 +53,6 @@ let personality_diff_summary fields =
       personality_field_diff_entry name current target)
     fields
 
-let utf8_char_width s i =
-  let byte = Char.code s.[i] in
-  if byte land 0x80 = 0 then 1
-  else if byte land 0xE0 = 0xC0 then 2
-  else if byte land 0xF0 = 0xE0 then 3
-  else if byte land 0xF8 = 0xF0 then 4
-  else 1
-
-let truncate_utf8_prefix ~max_bytes s =
-  let len = String.length s in
-  if len <= max_bytes then s, false
-  else
-    let rec loop i =
-      if i >= len then i
-      else
-        let next = i + utf8_char_width s i in
-        if next > max_bytes then i else loop next
-    in
-    String.sub s 0 (loop 0), true
-
 let quote_log_preview s =
   let buf = Buffer.create (String.length s + 2) in
   Buffer.add_char buf '"';
@@ -107,7 +87,9 @@ let personality_field_diff_summary ~field ~current ~target =
   else
     let preview s =
       let trimmed = String.trim s in
-      let prefix, truncated = truncate_utf8_prefix ~max_bytes:32 trimmed in
+      let prefix, truncated =
+        Keeper_text_processing.truncate_utf8_prefix ~max_bytes:32 trimmed
+      in
       quote_log_preview (if truncated then prefix ^ "..." else prefix)
     in
     Some

--- a/lib/keeper/keeper_text_processing.ml
+++ b/lib/keeper/keeper_text_processing.ml
@@ -18,6 +18,28 @@ let re_trailing_punct = Re.Pcre.re "[:;,\\-]$" |> Re.compile
 let re_trailing_connector =
   Re.Pcre.re "(and|or|with|to|for|그리고|또는|및)$" |> Re.compile
 
+let utf8_char_width s i =
+  let byte = Char.code s.[i] in
+  if byte land 0x80 = 0 then 1
+  else if byte land 0xE0 = 0xC0 then 2
+  else if byte land 0xF0 = 0xE0 then 3
+  else if byte land 0xF8 = 0xF0 then 4
+  else 1
+
+let truncate_utf8_prefix ~max_bytes s =
+  let max_bytes = max 0 max_bytes in
+  let len = String.length s in
+  if len <= max_bytes then s, false
+  else
+    let rec loop i =
+      if i >= len
+      then i
+      else
+        let next = i + utf8_char_width s i in
+        if next > max_bytes then i else loop next
+    in
+    String.sub s 0 (loop 0), true
+
 let strip_state_blocks_text (s : string) : string =
   let start_marker = "[STATE]" in
   let end_marker = "[/STATE]" in

--- a/lib/keeper/keeper_text_processing.mli
+++ b/lib/keeper/keeper_text_processing.mli
@@ -6,6 +6,11 @@
 
 (** {1 Reply Markup} *)
 
+(** Return a prefix that does not split a UTF-8 continuation byte, plus whether
+    truncation happened. [max_bytes <= 0] yields [("", true)] for non-empty
+    input. *)
+val truncate_utf8_prefix : max_bytes:int -> string -> string * bool
+
 (** Remove [[STATE]..[/STATE]] blocks from text. *)
 val strip_state_blocks_text : string -> string
 

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -18,9 +18,12 @@ type path_probe =
   ; resolved_parent : string
   ; parent_exists : bool
   ; parent_is_directory : bool
+  ; parent_within_cwd : bool
   ; wildcard_like : bool
   ; parent_entries : string list
   }
+
+let path_probe_parent_entries_limit = 40
 
 let path_contains_glob_meta s =
   String.exists
@@ -44,7 +47,13 @@ let path_probe ~cwd path_argument =
   let resolved_path = resolve_against_cwd ~cwd path_argument in
   let parent_argument = Filename.dirname path_argument in
   let resolved_parent = resolve_against_cwd ~cwd parent_argument in
+  let cwd_norm = Keeper_alerting_path.normalize_path_for_check_stripped cwd in
+  let parent_within_cwd =
+    Keeper_alerting_path.is_within_root_norm ~root_norm:cwd_norm resolved_parent
+  in
   let parent_exists =
+    parent_within_cwd
+    &&
     try Sys.file_exists resolved_parent with
     | Sys_error _ -> false
   in
@@ -61,7 +70,7 @@ let path_probe ~cwd path_argument =
         Sys.readdir resolved_parent
         |> Array.to_list
         |> List.sort String.compare
-        |> take 40
+        |> take path_probe_parent_entries_limit
       with
       | Sys_error _ | Unix.Unix_error _ -> []
     else []
@@ -72,6 +81,7 @@ let path_probe ~cwd path_argument =
   ; resolved_parent
   ; parent_exists
   ; parent_is_directory
+  ; parent_within_cwd
   ; wildcard_like = path_contains_glob_meta path_argument
   ; parent_entries
   }
@@ -84,6 +94,7 @@ let path_probe_json probe =
     ; "resolved_parent", `String probe.resolved_parent
     ; "parent_exists", `Bool probe.parent_exists
     ; "parent_is_directory", `Bool probe.parent_is_directory
+    ; "parent_within_cwd", `Bool probe.parent_within_cwd
     ; "wildcard_like", `Bool probe.wildcard_like
     ; ( "parent_entries"
       , `List (List.map (fun name -> `String name) probe.parent_entries) )

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -11,6 +11,97 @@ let elapsed_duration_ms ~start_time ~end_time =
   | _ when elapsed_ms < 1. -> 1
   | _ -> int_of_float elapsed_ms
 
+type path_probe =
+  { path_argument : string
+  ; resolved_path : string
+  ; parent_argument : string
+  ; resolved_parent : string
+  ; parent_exists : bool
+  ; parent_is_directory : bool
+  ; wildcard_like : bool
+  ; parent_entries : string list
+  }
+
+let path_contains_glob_meta s =
+  String.exists
+    (function
+      | '*' | '?' | '[' | ']' | '{' | '}' -> true
+      | _ -> false)
+    s
+
+let resolve_against_cwd ~cwd path =
+  if Filename.is_relative path then Filename.concat cwd path else path
+
+let take n xs =
+  let rec loop acc remaining = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | x :: rest -> loop (x :: acc) (remaining - 1) rest
+  in
+  loop [] n xs
+
+let path_probe ~cwd path_argument =
+  let resolved_path = resolve_against_cwd ~cwd path_argument in
+  let parent_argument = Filename.dirname path_argument in
+  let resolved_parent = resolve_against_cwd ~cwd parent_argument in
+  let parent_exists =
+    try Sys.file_exists resolved_parent with
+    | Sys_error _ -> false
+  in
+  let parent_is_directory =
+    parent_exists
+    &&
+    try Sys.is_directory resolved_parent with
+    | Sys_error _ -> false
+  in
+  let parent_entries =
+    if parent_is_directory
+    then
+      try
+        Sys.readdir resolved_parent
+        |> Array.to_list
+        |> List.sort String.compare
+        |> take 40
+      with
+      | Sys_error _ | Unix.Unix_error _ -> []
+    else []
+  in
+  { path_argument
+  ; resolved_path
+  ; parent_argument
+  ; resolved_parent
+  ; parent_exists
+  ; parent_is_directory
+  ; wildcard_like = path_contains_glob_meta path_argument
+  ; parent_entries
+  }
+
+let path_probe_json probe =
+  `Assoc
+    [ "path_argument", `String probe.path_argument
+    ; "resolved_path", `String probe.resolved_path
+    ; "parent_argument", `String probe.parent_argument
+    ; "resolved_parent", `String probe.resolved_parent
+    ; "parent_exists", `Bool probe.parent_exists
+    ; "parent_is_directory", `Bool probe.parent_is_directory
+    ; "wildcard_like", `Bool probe.wildcard_like
+    ; ( "parent_entries"
+      , `List (List.map (fun name -> `String name) probe.parent_entries) )
+    ; ( "hint"
+      , `String
+          (if probe.wildcard_like
+           then
+             "The missing path looks like a glob pattern. Probe the parent \
+              directory first, then use Grep glob/pattern fields or find -name; \
+              do not pass wildcard literals as path arguments."
+           else
+             "Probe the parent directory first and retry with an existing child \
+              path; do not infer module names as directory paths.") )
+    ]
+
+let path_probe_fields ~cwd path_argument =
+  [ "path_probe", path_probe_json (path_probe ~cwd path_argument) ]
+
 (* Pre-dispatch path existence validation for typed commands.
    Uses Shell_ir_typed GADT path annotations (exhaustive, no
    string heuristics). Only validates Safe (read-only) Simple
@@ -59,6 +150,7 @@ let typed_execute_response_cwd_json
 
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
+  let path_probe_json ~cwd path = path_probe_json (path_probe ~cwd path)
   let typed_execute_response_cwd_json = typed_execute_response_cwd_json
 end
 
@@ -360,7 +452,14 @@ let handle_tool_execute_typed
           @ response_cwd_field
           @ execution_location_fields cwd
         in
-        let blocked_result ?deterministic_reason ~error ~reason ~alternatives () =
+        let blocked_result
+              ?deterministic_reason
+              ?(extra_fields = [])
+              ~error
+              ~reason
+              ~alternatives
+              ()
+          =
           (* RFC-0208 P1: a blocked typed command emits a Keeper-level audit
              line so denials are greppable, not only returned as tool_error
              JSON to the agent. Covers destructive-block and write-gate; the
@@ -393,6 +492,7 @@ let handle_tool_execute_typed
                     ; "typed", `Bool true
                     ; "execution_time_ms", `Int 0
                     ]
+                  @ extra_fields
                   @ response_cwd_field
                   @ execution_location_fields cwd)
                ())
@@ -413,16 +513,34 @@ let handle_tool_execute_typed
         match path_missing with
         | Some missing_path ->
           let parent = Filename.dirname missing_path in
+          let probe = path_probe ~cwd missing_path in
+          let wildcard_hint =
+            if probe.wildcard_like
+            then
+              " The path also contains glob metacharacters; use Grep \
+               glob/pattern fields or probe the parent with ls/find instead of \
+               passing a wildcard literal as a path."
+            else ""
+          in
           blocked_result
             ~deterministic_reason:Keeper_tool_deterministic_error.Path_not_found
+            ~extra_fields:(path_probe_fields ~cwd missing_path)
             ~error:"path_not_found"
             ~reason:(Printf.sprintf
-              "The path argument %S does not exist. Probe the parent \
-               directory before retrying; do not infer package or module \
-               names as directory paths."
-              missing_path)
+              "The path argument %S does not exist.%s Probe the parent \
+               directory before retrying; do not infer package or module names \
+               as directory paths."
+              missing_path wildcard_hint)
             ~alternatives:
-              [ Printf.sprintf "Use executable=\"ls\" argv=[%S]." parent ]
+              [ Printf.sprintf "Use executable=\"ls\" argv=[%S]." parent
+              ; (if probe.wildcard_like
+                 then
+                   "For filename patterns, prefer Grep with pattern/glob or \
+                    Execute find -name after the parent path is confirmed."
+                 else
+                   "Read path_probe.parent_entries and retry with an existing \
+                    child path.")
+              ]
             ()
         | None ->
           let env_snap =

--- a/lib/keeper/keeper_tool_execute_runtime.mli
+++ b/lib/keeper/keeper_tool_execute_runtime.mli
@@ -14,6 +14,7 @@ val handle_tool_execute :
 
 module For_testing : sig
   val elapsed_duration_ms : start_time:float -> end_time:float -> int
+  val path_probe_json : cwd:string -> string -> Yojson.Safe.t
   val typed_execute_response_cwd_json :
     turn_sandbox_factory:Keeper_sandbox_factory.t option ->
     cwd:string ->

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -23,6 +23,10 @@ let sample_episode () =
   | Some ep -> ep
   | None -> Alcotest.fail "fixture episode failed to parse"
 
+let parse_retry_error_to_string = function
+  | R.Retry_exhausted_unparseable e -> "unparseable: " ^ e
+  | R.Retry_transport_failed e -> "transport: " ^ e
+
 let nudge_count messages =
   List.length
     (List.filter
@@ -43,7 +47,8 @@ let test_succeeds_first_attempt () =
   in
   (match R.run_with_parse_retries ~max_retries:2 ~attempt [] with
    | Ok _ -> ()
-   | Error e -> Alcotest.failf "expected Ok, got Error %s" e);
+   | Error e ->
+     Alcotest.failf "expected Ok, got Error %s" (parse_retry_error_to_string e));
   check int "no retry when first attempt parses" 1 !calls
 
 let test_retries_then_succeeds () =
@@ -55,7 +60,10 @@ let test_retries_then_succeeds () =
   in
   (match R.run_with_parse_retries ~max_retries:2 ~attempt [] with
    | Ok _ -> ()
-   | Error e -> Alcotest.failf "expected Ok after retry, got %s" e);
+   | Error e ->
+     Alcotest.failf
+       "expected Ok after retry, got %s"
+       (parse_retry_error_to_string e));
   check int "one retry to recover" 2 !calls
 
 let test_bounded_then_fails () =
@@ -66,7 +74,10 @@ let test_bounded_then_fails () =
   in
   (match R.run_with_parse_retries ~max_retries:2 ~attempt [] with
    | Ok _ -> Alcotest.fail "expected Error after exhausting retries"
-   | Error e -> check string "last error surfaced" "still bad" e);
+   | Error (R.Retry_exhausted_unparseable e) ->
+     check string "last error surfaced" "still bad" e
+   | Error (R.Retry_transport_failed e) ->
+     Alcotest.failf "expected unparseable exhaustion, got transport %s" e);
   check int "initial attempt + max_retries" 3 !calls
 
 let test_transport_not_retried () =
@@ -77,7 +88,10 @@ let test_transport_not_retried () =
   in
   (match R.run_with_parse_retries ~max_retries:2 ~attempt [] with
    | Ok _ -> Alcotest.fail "expected Error"
-   | Error e -> check string "transport error surfaced" "timeout" e);
+   | Error (R.Retry_transport_failed e) ->
+     check string "transport error surfaced" "timeout" e
+   | Error (R.Retry_exhausted_unparseable e) ->
+     Alcotest.failf "expected transport error, got unparseable %s" e);
   check int "transport failure is not retried" 1 !calls
 
 let test_nudge_appended_each_retry () =

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -913,19 +913,33 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
           ; messages = [ text_message "Please remember the fallback path." ]
           }
         in
-        (match
-           Librarian_runtime.extract_and_append_with_provider
-             ~complete
-             ~clock
-             ~timeout_sec:1.0
-             ~sw
-             ~net
-             ~keeper_id
-             ~provider_cfg:(test_provider_cfg ())
-             inp
-         with
+        let fallback_started_at = Eio.Time.now clock in
+        let fallback_result =
+          Librarian_runtime.extract_and_append_with_provider
+            ~complete
+            ~clock
+            ~timeout_sec:1.0
+            ~sw
+            ~net
+            ~keeper_id
+            ~provider_cfg:(test_provider_cfg ())
+            inp
+        in
+        let fallback_finished_at = Eio.Time.now clock in
+        let fallback_created_at = ref None in
+        let check_in_clock_window label value =
+          Alcotest.(check bool)
+            label
+            true
+            (value >= fallback_started_at && value <= fallback_finished_at +. 0.001)
+        in
+        (match fallback_result with
          | Error msg -> Alcotest.fail msg
          | Ok episode ->
+           fallback_created_at := Some episode.Types.created_at;
+           check_in_clock_window
+             "fallback created_at derives from injected clock"
+             episode.Types.created_at;
            Alcotest.(check int)
              "initial attempt + parse retries"
              (1 + Librarian_runtime.librarian_max_parse_retries)
@@ -947,8 +961,21 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
               Alcotest.(check bool)
                 "fallback is ephemeral"
                 true
-                (fact.Types.category = Types.Ephemeral)
+                (fact.Types.category = Types.Ephemeral);
+              Alcotest.(check (float 0.001))
+                "fallback fact first_seen uses episode timestamp"
+                episode.Types.created_at
+                fact.Types.first_seen;
+              Alcotest.(check (option (float 0.001)))
+                "fallback fact last_verified_at uses episode timestamp"
+                (Some episode.Types.created_at)
+                fact.Types.last_verified_at
             | facts -> Alcotest.failf "expected one fallback fact, got %d" (List.length facts)));
+        let fallback_created_at =
+          match !fallback_created_at with
+          | Some ts -> ts
+          | None -> Alcotest.fail "fallback result timestamp was not captured"
+        in
         Alcotest.(check int)
           "episode file persisted"
           1
@@ -958,14 +985,22 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
            Alcotest.(check (option string))
              "event persisted with fallback marker"
              (Some "librarian_unstructured_fallback")
-             episode.Types.terminal_marker
+             episode.Types.terminal_marker;
+           Alcotest.(check (float 0.001))
+             "event persisted with injected-clock timestamp"
+             fallback_created_at
+             episode.Types.created_at
          | events -> Alcotest.failf "expected one event, got %d" (List.length events));
         match Memory_io.read_facts_tail ~keeper_id ~n:1 with
         | [ fact ] ->
           Alcotest.(check bool)
             "fact persisted as unstructured note"
             true
-            (contains "unstructured_note" fact.Types.claim)
+            (contains "unstructured_note" fact.Types.claim);
+          Alcotest.(check (float 0.001))
+            "persisted fact first_seen uses injected clock"
+            fallback_created_at
+            fact.Types.first_seen
         | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
 ;;
 

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -897,6 +897,78 @@ let test_librarian_runtime_appends_episode_bundle () =
         | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
 ;;
 
+let test_librarian_runtime_preserves_unstructured_fallback () =
+  with_prompt_registry (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      with_eio (fun ~sw ~net ~clock ->
+        let keeper_id = "runtime-librarian-fallback-keeper" in
+        let calls = ref 0 in
+        let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+          incr calls;
+          Ok (fake_response "not json, but keep this observation")
+        in
+        let inp : Librarian.input =
+          { Librarian.trace_id = "trace-runtime-fallback"
+          ; generation = 9
+          ; messages = [ text_message "Please remember the fallback path." ]
+          }
+        in
+        (match
+           Librarian_runtime.extract_and_append_with_provider
+             ~complete
+             ~clock
+             ~timeout_sec:1.0
+             ~sw
+             ~net
+             ~keeper_id
+             ~provider_cfg:(test_provider_cfg ())
+             inp
+         with
+         | Error msg -> Alcotest.fail msg
+         | Ok episode ->
+           Alcotest.(check int)
+             "initial attempt + parse retries"
+             (1 + Librarian_runtime.librarian_max_parse_retries)
+             !calls;
+           Alcotest.(check string)
+             "fallback summary"
+             "Unstructured librarian note preserved after parse failure"
+             episode.Types.episode_summary;
+           Alcotest.(check (option string))
+             "fallback marker"
+             (Some "librarian_unstructured_fallback")
+             episode.Types.terminal_marker;
+           (match episode.Types.claims with
+            | [ fact ] ->
+              Alcotest.(check bool)
+                "fallback claim keeps raw provider text"
+                true
+                (contains "not json, but keep this observation" fact.Types.claim);
+              Alcotest.(check bool)
+                "fallback is ephemeral"
+                true
+                (fact.Types.category = Types.Ephemeral)
+            | facts -> Alcotest.failf "expected one fallback fact, got %d" (List.length facts)));
+        Alcotest.(check int)
+          "episode file persisted"
+          1
+          (json_episode_file_count ~keeper_id);
+        (match Memory_io.read_events_tail ~keeper_id ~n:1 with
+         | [ episode ] ->
+           Alcotest.(check (option string))
+             "event persisted with fallback marker"
+             (Some "librarian_unstructured_fallback")
+             episode.Types.terminal_marker
+         | events -> Alcotest.failf "expected one event, got %d" (List.length events));
+        match Memory_io.read_facts_tail ~keeper_id ~n:1 with
+        | [ fact ] ->
+          Alcotest.(check bool)
+            "fact persisted as unstructured note"
+            true
+            (contains "unstructured_note" fact.Types.claim)
+        | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
+;;
+
 let test_librarian_runtime_reports_fact_upsert_failure () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
@@ -3368,6 +3440,10 @@ let () =
         ] )
     ; ( "librarian runtime"
       , [ Alcotest.test_case
+            "unparseable output is preserved as unstructured fallback"
+            `Quick
+            test_librarian_runtime_preserves_unstructured_fallback
+        ; Alcotest.test_case
             "provider slot gate caps concurrency at capacity (#21376/#21230)"
             `Quick
             test_librarian_provider_slot_gate_caps_at_capacity

--- a/test/test_keeper_sandbox_docker_cwd_response.ml
+++ b/test/test_keeper_sandbox_docker_cwd_response.ml
@@ -35,6 +35,34 @@ let cleanup_dir path =
   in
   rm path
 
+let json_assoc_member key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let json_string key json =
+  match json_assoc_member key json with
+  | Some (`String s) -> Some s
+  | Some (`Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null)
+  | None -> None
+
+let json_bool key json =
+  match json_assoc_member key json with
+  | Some (`Bool b) -> Some b
+  | Some (`Assoc _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _)
+  | None -> None
+
+let json_string_list key json =
+  match json_assoc_member key json with
+  | Some (`List values) ->
+    Some
+      (List.filter_map
+         (function
+           | `String s -> Some s
+           | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null -> None)
+         values)
+  | Some (`Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _)
+  | None -> None
+
 let make_docker_meta ~name : Keeper_meta_contract.keeper_meta =
   let json =
     `Assoc
@@ -134,6 +162,37 @@ let test_typed_execute_response_cwd_uses_container_path () =
            (Astring.String.is_prefix ~affix:"/home/keeper/playground" cwd)
        | _ -> fail "typed Execute cwd response should serialize as a string")
 
+let test_path_probe_lists_parent_entries_for_glob_like_miss () =
+  let base = temp_dir "typed_exec_path_probe_" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let keeper_dir = Filename.concat base "lib/keeper" in
+       Unix.mkdir (Filename.concat base "lib") 0o755;
+       Unix.mkdir keeper_dir 0o755;
+       let oc =
+         open_out (Filename.concat keeper_dir "keeper_memory_os_consolidator.ml")
+       in
+       close_out oc;
+       let probe =
+         Keeper_tool_execute_runtime.For_testing.path_probe_json
+           ~cwd:base
+           "lib/keeper/keeper_memory_os_consolidat*"
+       in
+       check (option bool) "wildcard-like path" (Some true)
+         (json_bool "wildcard_like" probe);
+       check (option string) "parent argument" (Some "lib/keeper")
+         (json_string "parent_argument" probe);
+       check (option bool) "parent exists" (Some true)
+         (json_bool "parent_exists" probe);
+       check (option bool) "parent is directory" (Some true)
+         (json_bool "parent_is_directory" probe);
+       match json_string_list "parent_entries" probe with
+       | Some entries ->
+         check bool "parent listing includes candidate" true
+           (List.mem "keeper_memory_os_consolidator.ml" entries)
+       | None -> fail "path probe should include parent_entries")
+
 (* Source-level pin: assert that no [("cwd", `String <ident>)]
    literal remains in keeper_sandbox_docker.ml. The four sites
    from #11080's sibling leak class must be wired through
@@ -191,5 +250,11 @@ let () =
           test_case
             "no raw (\"cwd\", `String cwd) literal remains in source"
             `Quick test_source_has_no_raw_cwd_string_literal
+        ] )
+    ; ( "path-probe"
+      , [
+          test_case
+            "glob-like missing path returns parent entries"
+            `Quick test_path_probe_lists_parent_entries_for_glob_like_miss
         ] )
     ]

--- a/test/test_keeper_sandbox_docker_cwd_response.ml
+++ b/test/test_keeper_sandbox_docker_cwd_response.ml
@@ -187,10 +187,37 @@ let test_path_probe_lists_parent_entries_for_glob_like_miss () =
          (json_bool "parent_exists" probe);
        check (option bool) "parent is directory" (Some true)
          (json_bool "parent_is_directory" probe);
+       check (option bool) "parent stays inside cwd" (Some true)
+         (json_bool "parent_within_cwd" probe);
        match json_string_list "parent_entries" probe with
        | Some entries ->
          check bool "parent listing includes candidate" true
            (List.mem "keeper_memory_os_consolidator.ml" entries)
+       | None -> fail "path probe should include parent_entries")
+
+let test_path_probe_does_not_list_parent_outside_cwd () =
+  let base = temp_dir "typed_exec_path_probe_base_" in
+  let outside = temp_dir "typed_exec_path_probe_outside_" in
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_dir base;
+      cleanup_dir outside)
+    (fun () ->
+       let oc = open_out (Filename.concat outside "outside_candidate.ml") in
+       close_out oc;
+       let probe =
+         Keeper_tool_execute_runtime.For_testing.path_probe_json
+           ~cwd:base
+           (Filename.concat outside "outside*")
+       in
+       check (option bool) "outside parent is not in cwd" (Some false)
+         (json_bool "parent_within_cwd" probe);
+       check (option bool) "outside parent existence is not probed" (Some false)
+         (json_bool "parent_exists" probe);
+       check (option bool) "outside parent directory is not probed" (Some false)
+         (json_bool "parent_is_directory" probe);
+       match json_string_list "parent_entries" probe with
+       | Some entries -> check (list string) "outside parent entries hidden" [] entries
        | None -> fail "path probe should include parent_entries")
 
 (* Source-level pin: assert that no [("cwd", `String <ident>)]
@@ -256,5 +283,8 @@ let () =
           test_case
             "glob-like missing path returns parent entries"
             `Quick test_path_probe_lists_parent_entries_for_glob_like_miss
+        ; test_case
+            "absolute missing path outside cwd does not list parent"
+            `Quick test_path_probe_does_not_list_parent_outside_cwd
         ] )
     ]


### PR DESCRIPTION
## Summary
- Add path_probe diagnostics for typed Execute path-not-found results, including parent directory entries and glob/wildcard guidance.
- Preserve exhausted librarian parse failures as an Ephemeral unstructured fallback episode/fact instead of dropping the provider output.
- Add Memory OS consolidator run diagnostics for input facts, eligible facts, promotions, and zero-promotion source counts.

## Tests
- [x] ocamlformat --check lib/keeper/keeper_tool_execute_runtime.ml lib/keeper/keeper_tool_execute_runtime.mli lib/keeper/keeper_librarian_runtime.ml lib/keeper/keeper_librarian_runtime.mli lib/keeper/keeper_memory_os_consolidator.ml test/test_keeper_librarian_retry.ml test/test_keeper_memory_os.ml test/test_keeper_sandbox_docker_cwd_response.ml
- [x] git diff --check origin/main...HEAD
- [ ] env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_librarian_retry.exe (blocked locally by agent_sdk pin drift: installed 0.207.5, expected >= 0.207.6)
- [ ] env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_librarian_retry.exe (started compile, no output after >5m, cancelled; CI build delegated)