### PR TITLE
feat(dashboard): board post → originating turn navigation (RFC-0233 §7 PR-D board nav)

### DIFF
--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -91,6 +91,20 @@ vi.mock('./board-state', () => ({
   refreshBoard: vi.fn(),
 }))
 
+// Stub the shared turn-inspector drawer so the board affordance can be tested
+// without the real KeeperTurnInspector self-fetching turn records. Renders the
+// anchor props as data attributes only when open, mirroring the real testId.
+vi.mock('../keeper-turn-inspector-drawer', () => ({
+  TurnInspectorDrawer: ({ keeperName, initialTurnRef, open, testId }: any) =>
+    open
+      ? h('div', {
+          'data-testid': `${testId}-drawer`,
+          'data-keeper': keeperName,
+          'data-initial-turn-ref': initialTurnRef ?? '',
+        })
+      : null,
+}))
+
 import {
   CommentThread,
   PostDetail,
@@ -766,5 +780,60 @@ describe('PostDetail', () => {
       post: 'post-1',
       focus: 'curation',
     })
+  })
+
+  it('shows a turn affordance and opens the inspector at the post origin turn_ref', () => {
+    const post = {
+      id: 'post-origin',
+      author: 'sleepers',
+      title: 'Post',
+      body: 'Body',
+      content: 'Body',
+      created_at: '2026-04-02T00:00:00Z',
+      updated_at: '2026-04-02T00:00:00Z',
+      votes: 0,
+      comment_count: 0,
+      post_kind: 'direct',
+      moderation_status: 'none',
+      origin: { turn_ref: 'trace-x#5', source: 'dashboard', fusion_run_id: null },
+      comments: [],
+    } as any
+
+    render(h(PostDetail, { post }))
+
+    // Drawer stays closed until the affordance is clicked.
+    expect(screen.queryByTestId('board-post-turn-inspector-drawer')).toBeNull()
+
+    fireEvent.click(screen.getByLabelText('원본 턴 검사'))
+
+    const drawer = screen.getByTestId('board-post-turn-inspector-drawer')
+    // keeperName falls back to post.author when no keeper is resolved in-test;
+    // initialTurnRef is the exact origin turn_ref join key (RFC-0233 §7).
+    expect(drawer.getAttribute('data-keeper')).toBe('sleepers')
+    expect(drawer.getAttribute('data-initial-turn-ref')).toBe('trace-x#5')
+  })
+
+  it('omits the turn affordance when the post has no origin turn_ref (e.g. fusion-origin)', () => {
+    const post = {
+      id: 'post-no-origin',
+      author: 'sleepers',
+      title: 'Post',
+      body: 'Body',
+      content: 'Body',
+      created_at: '2026-04-02T00:00:00Z',
+      updated_at: '2026-04-02T00:00:00Z',
+      votes: 0,
+      comment_count: 0,
+      post_kind: 'direct',
+      moderation_status: 'none',
+      // A fusion-origin post carries fusion_run_id but no turn_ref → no affordance.
+      origin: { turn_ref: null, source: 'fusion', fusion_run_id: 'fus-1' },
+      comments: [],
+    } as any
+
+    render(h(PostDetail, { post }))
+
+    expect(screen.queryByLabelText('원본 턴 검사')).toBeNull()
+    expect(screen.queryByTestId('board-post-turn-inspector-drawer')).toBeNull()
   })
 })

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -11,6 +11,8 @@ import { RichComposer } from '../common/rich-composer'
 import { RichContent } from '../common/rich-content'
 import { TextInput } from '../common/input'
 import { stripStateBlocks } from '../../keeper-message'
+import { TurnInspectorDrawer } from '../keeper-turn-inspector-drawer'
+import { findKeeper } from '../../lib/keeper-utils'
 import { route } from '../../router'
 import { votePost, voteComment } from '../../api/board'
 import { ModerationBadge } from './moderation-badge'
@@ -551,6 +553,18 @@ export function PostDetail({ post }: { post: BoardPost }) {
   const auditLabel = postVisibilityAuditLabel(post)
   const focusedCommentId = cleanCommentRouteParam((route.value.params as Record<string, string | undefined>).comment)
 
+  // RFC-0233 §7: a board post minted from a keeper turn carries origin.turn_ref.
+  // When present, surface a "턴" affordance that opens the originating turn in
+  // the shared turn inspector (which self-fetches the keeper's turn records by
+  // keeperName). Resolve the author keeper the same way navigateToAuthor does.
+  const [turnInspectorOpen, setTurnInspectorOpen] = useState(false)
+  const originTurnRef = post.origin?.turn_ref ?? null
+  const originKeeper =
+    post.author_identity?.kind === 'keeper'
+      ? findKeeper(post.author_identity.id) ?? findKeeper(post.author_identity.raw) ?? findKeeper(post.author)
+      : findKeeper(post.author)
+  const turnKeeperName = originKeeper?.name ?? post.author
+
   return html`
     <div>
       <${ActionButton}
@@ -582,6 +596,16 @@ export function PostDetail({ post }: { post: BoardPost }) {
               aria-label=${postVoteAria}
               title=${postVoteLabel}
             >${postVoteLabel}</span>
+            ${originTurnRef
+              ? html`<${ActionButton}
+                  variant="subtle"
+                  size="sm"
+                  class="text-2xs text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] bg-transparent border-none p-0"
+                  title=${`이 글을 만든 원본 턴 검사 (${originTurnRef})`}
+                  ariaLabel="원본 턴 검사"
+                  onClick=${() => setTurnInspectorOpen(true)}
+                >🔎 턴<//>`
+              : null}
           </div>
 
           <div
@@ -669,6 +693,14 @@ export function PostDetail({ post }: { post: BoardPost }) {
           <${CommentForm} postId=${post.id} />
         <//>
       </div>
+      <${TurnInspectorDrawer}
+        testId="board-post-turn-inspector"
+        keeperName=${turnKeeperName}
+        subtitle=${originTurnRef ? `원본 턴 · ${originTurnRef}` : null}
+        initialTurnRef=${originTurnRef}
+        open=${turnInspectorOpen}
+        onClose=${() => setTurnInspectorOpen(false)}
+      />
     </div>
   `
 }

--- a/dashboard/src/components/keeper-turn-inspector-drawer.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector-drawer.test.ts
@@ -1,0 +1,64 @@
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+// Stub KeeperTurnInspector so the drawer can be tested without the inner
+// component's self-fetch of turn records. Surfaces its anchor props as data
+// attributes for assertion.
+vi.mock('./keeper-turn-inspector', () => ({
+  KeeperTurnInspector: ({ keeperName, initialTurnRef, initialTurnTimestamp }: any) =>
+    h('div', {
+      'data-testid': 'turn-inspector-inner',
+      'data-keeper': keeperName,
+      'data-initial-turn-ref': initialTurnRef ?? '',
+      'data-initial-turn-timestamp': initialTurnTimestamp ?? '',
+    }),
+}))
+
+import { TurnInspectorDrawer } from './keeper-turn-inspector-drawer'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('TurnInspectorDrawer', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      h(TurnInspectorDrawer, { keeperName: 'echo', open: false, onClose: () => {}, testId: 'x' }),
+    )
+    expect(container.querySelector('[data-testid="x-drawer"]')).toBeNull()
+  })
+
+  it('renders the drawer and threads anchor props to the inspector when open', () => {
+    render(
+      h(TurnInspectorDrawer, {
+        keeperName: 'echo',
+        subtitle: '원본 턴 · trace-a#9',
+        initialTurnRef: 'trace-a#9',
+        open: true,
+        onClose: () => {},
+        testId: 'board-post-turn-inspector',
+      }),
+    )
+    expect(screen.getByTestId('board-post-turn-inspector-drawer')).toBeInTheDocument()
+    expect(screen.getByText('원본 턴 · trace-a#9')).toBeInTheDocument()
+    const inner = screen.getByTestId('turn-inspector-inner')
+    expect(inner.getAttribute('data-keeper')).toBe('echo')
+    expect(inner.getAttribute('data-initial-turn-ref')).toBe('trace-a#9')
+  })
+
+  it('falls back to keeperName in the header when no subtitle is given', () => {
+    render(h(TurnInspectorDrawer, { keeperName: 'echo', open: true, onClose: () => {}, testId: 'x' }))
+    // The header secondary line shows the keeper name when subtitle is absent.
+    expect(screen.getByText('echo')).toBeInTheDocument()
+  })
+
+  it('invokes onClose from the close button (testId-namespaced)', () => {
+    const onClose = vi.fn()
+    render(h(TurnInspectorDrawer, { keeperName: 'echo', open: true, onClose, testId: 'x' }))
+    fireEvent.click(screen.getByTestId('x-close'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/dashboard/src/components/keeper-turn-inspector-drawer.ts
+++ b/dashboard/src/components/keeper-turn-inspector-drawer.ts
@@ -1,0 +1,68 @@
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+import { KeeperTurnInspector } from './keeper-turn-inspector'
+
+/**
+ * Right-side drawer hosting {@link KeeperTurnInspector}. Shared by the keeper
+ * chat workspace (anchored to a chat entry's turn) and the board post detail
+ * (anchored to a post's origin turn_ref, RFC-0233 §7). KeeperTurnInspector
+ * self-fetches the keeper's turn records by `keeperName`, so a caller only
+ * supplies the anchor (`initialTurnRef`/`initialTurnTimestamp`) and chrome.
+ *
+ * `testId` namespaces the drawer/close data-testids per surface so existing
+ * surface tests keep their stable selectors (`${testId}-drawer`/`-close`).
+ */
+export function TurnInspectorDrawer({
+  keeperName,
+  subtitle,
+  initialTurnRef,
+  initialTurnTimestamp,
+  open,
+  onClose,
+  testId,
+}: {
+  keeperName: string
+  // Header secondary line; falls back to keeperName when null/undefined.
+  subtitle?: string | null
+  initialTurnRef?: string | null
+  initialTurnTimestamp?: string | null
+  open: boolean
+  onClose: () => void
+  testId: string
+}): VNode | null {
+  if (!open) return null
+
+  return html`
+    <div
+      class="fixed inset-0 z-50 flex justify-end bg-black/40"
+      role="dialog"
+      aria-modal="true"
+      aria-label="턴 검사"
+      data-testid=${`${testId}-drawer`}
+      onClick=${onClose}
+    >
+      <div
+        class="h-full w-full max-w-2xl overflow-y-auto bg-[var(--color-bg-page)] shadow-2xl"
+        onClick=${(e: Event) => e.stopPropagation()}
+      >
+        <div class="sticky top-0 z-10 flex items-center justify-between border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-3 v2-monitoring-toolbar">
+          <div>
+            <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">턴 검사</h3>
+            <p class="text-2xs text-[var(--color-fg-muted)]">${subtitle ?? keeperName}</p>
+          </div>
+          <button
+            type="button"
+            class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-2xs text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-hover)]"
+            onClick=${onClose}
+            data-testid=${`${testId}-close`}
+          >닫기</button>
+        </div>
+        <${KeeperTurnInspector}
+          keeperName=${keeperName}
+          initialTurnRef=${initialTurnRef ?? null}
+          initialTurnTimestamp=${initialTurnTimestamp ?? null}
+        />
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -22,7 +22,7 @@ import type { VNode } from 'preact'
 import type { Keeper, KeeperConversationEntry } from '../../types'
 import { KeeperConversationPanel } from '../keeper-shared'
 import { keeperMobilePane } from '../keeper-detail-state'
-import { KeeperTurnInspector } from '../keeper-turn-inspector'
+import { TurnInspectorDrawer as SharedTurnInspectorDrawer } from '../keeper-turn-inspector-drawer'
 import { ChatArtifactPanel } from '../chat/artifact-panel'
 import { keeperThreads } from '../../keeper-state'
 import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
@@ -359,44 +359,23 @@ function TurnInspectorDrawer({
   open: boolean
   onClose: () => void
 }) {
-  if (!open) return null
-
+  // Thin chat-specific wrapper over the shared TurnInspectorDrawer: maps the
+  // chat entry to the drawer's anchor props (turnRef + timestamp window) and
+  // header label. The shared component owns the overlay markup so the board
+  // surface (post-detail) reuses the identical drawer. testId is preserved so
+  // existing chat tests keep their `kw-chat-turn-inspector-*` selectors.
   return html`
-    <div
-      class="fixed inset-0 z-50 flex justify-end bg-black/40"
-      role="dialog"
-      aria-modal="true"
-      aria-label="턴 검사"
-      data-testid="kw-chat-turn-inspector-drawer"
-      onClick=${onClose}
-    >
-      <div
-        class="h-full w-full max-w-2xl overflow-y-auto bg-[var(--color-bg-page)] shadow-2xl"
-        onClick=${(e: Event) => e.stopPropagation()}
-      >
-        <div class="sticky top-0 z-10 flex items-center justify-between border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-3 v2-monitoring-toolbar">
-          <div>
-            <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">턴 검사</h3>
-            <p class="text-2xs text-[var(--color-fg-muted)]">
-              ${triggerEntry
-                ? html`메시지 ${triggerEntry.label} · ${triggerEntry.timestamp ?? triggerEntry.id}`
-                : keeperName}
-            </p>
-          </div>
-          <button
-            type="button"
-            class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-2xs text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-hover)]"
-            onClick=${onClose}
-            data-testid="kw-chat-turn-inspector-close"
-          >닫기</button>
-        </div>
-        <${KeeperTurnInspector}
-          keeperName=${keeperName}
-          initialTurnRef=${triggerEntry?.turnRef ?? null}
-          initialTurnTimestamp=${triggerEntry?.timestamp ?? null}
-        />
-      </div>
-    </div>
+    <${SharedTurnInspectorDrawer}
+      testId="kw-chat-turn-inspector"
+      keeperName=${keeperName}
+      subtitle=${triggerEntry
+        ? `메시지 ${triggerEntry.label} · ${triggerEntry.timestamp ?? triggerEntry.id}`
+        : null}
+      initialTurnRef=${triggerEntry?.turnRef ?? null}
+      initialTurnTimestamp=${triggerEntry?.timestamp ?? null}
+      open=${open}
+      onClose=${onClose}
+    />
   `
 }
 

--- a/scripts/test_check_test_coverage.py
+++ b/scripts/test_check_test_coverage.py
@@ -34,10 +34,11 @@ class CheckTestCoverageTest(unittest.TestCase):
             "check_test_coverage.run_diff_or_fail",
             return_value="lib/a.ml\ndashboard/app.ts\nconfig/runtime.toml\n",
         ) as run_diff:
-            self.assertEqual(
-                coverage.get_changed_covered_files(),
-                ["lib/a.ml", "dashboard/app.ts", "config/runtime.toml"],
-            )
+            with mock.patch.dict(os.environ, {"GITHUB_BASE_REF": "main"}, clear=False):
+                self.assertEqual(
+                    coverage.get_changed_covered_files(),
+                    ["lib/a.ml", "dashboard/app.ts", "config/runtime.toml"],
+                )
 
         self.assertEqual(
             run_diff.call_args.args[0],


### PR DESCRIPTION
> ⚠️ **Stacked PR** — base = `feat/rfc-0233-turn-ref-nav-wiring` (PR-D-nav #21774). 이 diff는 chat 절반 배선 위에 board→turn을 쌓는다(공유 drawer 리팩터가 PR-D-nav의 `triggerEntry?.turnRef`를 흡수). #21774 머지 후 컨베이어가 base를 흡수→main 기준 rebase. **순 변경은 board affordance + 공유 drawer 추출**.

## 무엇을 / 왜

RFC-0233 §7의 **PR-D board nav** — board post detail에 "🔎 턴" affordance를 추가해, 그 글을 만든 keeper 턴을 턴 인스펙터에서 정확히 연다. board→turn 내비는 지금까지 **0**이었다(board는 author-profile 내비만 있었음). PR-C-board(#21755, MERGED)가 `BoardPost.origin.turn_ref`를 노출했고, 이 PR이 그것을 소비하는 **최초의 board 컴포넌트**다.

## 설계 — Option A (board에 로컬 drawer), self-fetch가 가능케 함

`KeeperTurnInspector`는 `keeperName`으로 turn records를 **스스로 fetch**한다(`useEffect([keeperName])` → `/api/v1/keepers/{name}/turn-records`). rows를 prop으로 받지 않으므로, **어디에 mount하든** keeperName + initialTurnRef만 주면 독립 동작한다. 따라서 board에 로컬 drawer를 mount하는 Option A가 cross-surface intent signal(Option B: router/selectedKeeper/chat state 모델 개조)보다 저위험. 컴포넌트의 데이터 소유 방식이 통합 지점의 자유도를 정한 사례.

## 변경 (프론트 전용, +250/−38, 5파일)

- **`keeper-turn-inspector-drawer.ts` (신규)**: 공유 `TurnInspectorDrawer`. chat 워크스페이스와 board post-detail이 동일 overlay markup 재사용. `testId` prop으로 surface별 testid(`${testId}-drawer`/`-close`) 네임스페이스(기존 테스트 selector 보존). `subtitle ?? keeperName` 헤더.
- **`keeper-workspace-chat.ts`**: 인라인 drawer → 공유 drawer thin wrapper로 위임(**동작 보존**: `kw-chat-turn-inspector-*` testid·헤더·props 동일, 19 테스트 green). 인라인 markup 38줄 제거.
- **`post-detail.ts`**: `post.origin?.turn_ref` gated "🔎 턴" 버튼 + 로컬 drawer. author keeper를 `navigateToAuthor`와 **동일하게** 해석(`findKeeper(identity.id) ?? identity.raw ?? author`), 인스펙터를 `initialTurnRef=post.origin.turn_ref`에 anchor. board는 timestamp window를 안 넘김 — **정확 turn_ref 매칭만**.
- **테스트**: 공유 drawer 유닛 4(open/closed·props 전달·subtitle fallback·onClose) + board affordance 2(turn_ref 있을 때 버튼·클릭 시 keeperName/initialTurnRef로 drawer open / fusion-origin turn_ref 없을 때 버튼 없음).

## 동작

- **fusion-origin post**(turn_ref=None, fusion_run_id 있음)는 affordance **없음**(turn_ref gated).
- keeper 미해석 시 `keeperName`은 `post.author`로 fallback(endpoint가 404면 인스펙터가 빈 상태 렌더, 크래시 없음).

## 검증

- **`tsc --noEmit` clean(exit 0)**.
- **vitest 57/57**: drawer 4 + post-detail 21(+2 신규) + chat 19(회귀 없음) + inspector 13.

## Workaround Guards (RFC-0233 §7.6 준수)

- **#3 window-join 없음**: board는 `initialTurnTimestamp` 미전달, 정확 `turn_ref` 매칭만(미스→null).
- **#5 run_id≠turn_ref**: fusion_run_id 있는 post라도 turn_ref 없으면 affordance 없음(둘을 혼동 안 함).
- 중복 코드 회피: drawer를 복붙하지 않고 공유 컴포넌트 추출(2곳 실사용).

## Follow-up

- keeper-authored board post의 `origin.turn_ref` populate(현재 fusion만 origin producer; keeper-turn producer는 cell-carrier follow-up) — 그 전까지 affordance는 turn_ref 있는 post에만 나타남.
- board-surface 카드 레벨 affordance(원하면): 동일 gating + `e.stopPropagation()`.

Refs: RFC-0233 §7 (§7.5 PR-D, §7.6 #3/#5). Depends on PR-D-nav #21774 (stacked). 소비 데이터: PR-C-board #21755 (MERGED), 인스펙터 prop: PR-D-core #21759 (MERGED).
