### PR TITLE
feat(dashboard): wire turn inspector to turn_ref for exact turn selection (RFC-0233 §7)

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -42,6 +42,7 @@ async function loadChat() {
                   text: 'done',
                   timestamp: '2026-03-24T00:02:00.000Z',
                   delivery: 'history',
+                  turnRef: 'trace-xyz#3',
                 })}
               >턴 상세</button>
             `
@@ -53,15 +54,18 @@ async function loadChat() {
     KeeperTurnInspector: ({
       keeperName,
       initialTurnTimestamp,
+      initialTurnRef,
     }: {
       keeperName: string
       initialTurnTimestamp?: string | null
+      initialTurnRef?: string | null
     }) =>
       html`
         <div
           data-testid="kw-turn-inspector"
           data-keeper=${keeperName}
           data-initial-turn-timestamp=${initialTurnTimestamp ?? ''}
+          data-initial-turn-ref=${initialTurnRef ?? ''}
         >TurnInspector</div>
       `,
   }))
@@ -221,6 +225,9 @@ describe('KeeperWorkspaceChat', () => {
     expect(drawer?.textContent).toContain('2026-03-24T00:02:00.000Z')
     expect(container.querySelector('[data-testid="kw-turn-inspector"]')?.getAttribute('data-keeper')).toBe('sangsu')
     expect(container.querySelector('[data-testid="kw-turn-inspector"]')?.getAttribute('data-initial-turn-timestamp')).toBe('2026-03-24T00:02:00.000Z')
+    // RFC-0233 §7: the triggered entry's turn_ref flows through to the
+    // inspector so it can exact-match the turn instead of the timestamp window.
+    expect(container.querySelector('[data-testid="kw-turn-inspector"]')?.getAttribute('data-initial-turn-ref')).toBe('trace-xyz#3')
   })
 
   it('toggles the artifact panel when the artifacts button is clicked', async () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -393,6 +393,7 @@ function TurnInspectorDrawer({
         <${KeeperTurnInspector}
           keeperName=${keeperName}
           initialTurnTimestamp=${triggerEntry?.timestamp ?? null}
+          initialTurnRef=${triggerEntry?.turnRef ?? null}
         />
       </div>
     </div>

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -82,6 +82,28 @@ describe('normalizeStatusDetail', () => {
 
     expect(detail.history.every(isVisibleDirectConversationEntry)).toBe(true)
   })
+
+  it('carries turn_ref onto the entry turnRef (RFC-0233 §7), null on legacy rows', () => {
+    const detail = normalizeStatusDetail('sangsu', '', {
+      history_tail: [
+        {
+          role: 'assistant',
+          source: 'direct_assistant',
+          content: 'reply with a turn ref',
+          ts_unix: 40,
+          turn_ref: 'trace-abc#7',
+        },
+        {
+          role: 'assistant',
+          source: 'direct_assistant',
+          content: 'legacy reply without one',
+          ts_unix: 41,
+        },
+      ],
+    })
+
+    expect(detail.history.map(entry => entry.turnRef)).toEqual(['trace-abc#7', null])
+  })
 })
 
 describe('default conversation visibility (tool calls vs internal)', () => {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -732,6 +732,9 @@ function normalizeHistoryEntry(
     audio,
     attachments,
     blocks,
+    // RFC-0233 §7: carry the row's turn_ref so the turn inspector can anchor
+    // to this exact turn (consumed via KeeperTurnInspector initialTurnRef).
+    turnRef: asString(raw.turn_ref) ?? null,
   }
 }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -896,6 +896,11 @@ export interface KeeperConversationEntry {
   error?: string | null
   surface?: SurfaceRef | null
   audio?: KeeperConversationAudioClip | null
+  // RFC-0233 §7: turn join key "<trace_id>#<absolute_turn>" carried from the
+  // chat row's turn_ref. The turn inspector consumes it (KeeperTurnInspector
+  // initialTurnRef) for an exact-match initial selection instead of the
+  // 30-min timestamp window. Undefined on legacy rows that predate turn_ref.
+  turnRef?: string | null
 }
 
 export interface KeeperStatusDetail {


### PR DESCRIPTION
## 무엇을

턴 인스펙터의 `initialTurnRef` prop(RFC-0233 §7, PR-D core #21759)이 머지됐지만 **호출자가 없어 dormant** 상태였습니다. 인스펙터가 정확한 `turn_ref` 매칭 대신 30분 timestamp window로 폴백하고 있었습니다. 이 PR이 그 navigation 소비 경로를 배선합니다.

## 변경 (프론트 3 + 테스트 2)

- `types/core.ts`: `KeeperConversationEntry`에 `turnRef?: string | null` 추가
- `keeper-state.ts`: `normalizeHistoryEntry`에서 `turn_ref → turnRef` 매핑 (legacy 행은 `null`)
- `keeper-workspace-chat.ts`: TurnInspectorDrawer가 `initialTurnRef=${triggerEntry?.turnRef}` 전달
- 테스트: `turn_ref → turnRef` 매핑(없으면 null) + caller→인스펙터 prop 흐름 단언

## 검증

- `tsc --noEmit` exit 0
- vitest 3파일/65 통과 (`keeper-state` · `keeper-workspace-chat` · `keeper-turn-inspector`), 신규 테스트 2건 포함
- eslint clean

## 범위

직렬화 양쪽(chat #21746, board #21755)은 이미 `turn_ref`를 parse/emit합니다. 이 PR은 그들이 주석으로 참조한 "navigation 소비 후속(`KeeperConversationEntry.turnRef`)"을 닫습니다. 30분 window 폴백은 `turn_ref` 없는 legacy 행 전용으로 유지됩니다. OCaml 백엔드·직렬화 경로는 건드리지 않았습니다.

RFC: RFC-0233 §7 (기존 RFC, 신규 불필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
