### PR TITLE
fix(dashboard): register fusion_run_status at SSE parse boundary (RFC-0266 Phase 4)

### DIFF
--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -226,6 +226,22 @@ describe('parseSSEMessage', () => {
     warnSpy.mockRestore()
   })
 
+  it('keeps fusion_run_status events so the RFC-0266 Phase 4 live panel refresh is not dropped', () => {
+    // Regression: the dashboard sse.ts dispatch has a `case 'fusion_run_status'`,
+    // but it is unreachable unless the type also passes this parse boundary.
+    // If this drops to null, the running -> completed/failed live flip silently
+    // stops working and the panel only updates on tab re-navigation.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const msg = parseSSEMessage({
+      type: 'fusion_run_status',
+      run: { run_id: 'r1', keeper: 'k', preset: 'balanced', started_at: 10, status: 'running' },
+    })
+    expect(msg).not.toBeNull()
+    expect(msg?.type).toBe('fusion_run_status')
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
   it('keeps unknown oas-prefixed events instead of dropping them', () => {
     const msg = parseSSEMessage({
       type: 'oas:slot_scheduler_observed',

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -58,6 +58,10 @@ const FIXED_SSE_EVENT_TYPES = new Set([
   'keeper_tool_skipped',
   'keeper_turn_complete',
   'masc/keeper_turn_complete',
+  // RFC-0266 Phase 4: fusion run-status transitions (running -> completed/failed).
+  // Must be in this closed allowlist or parseSSEMessage drops the event at the
+  // parse boundary, leaving the sse.ts dispatch case dead.
+  'fusion_run_status',
   'client_input_approved',
   'client_input_rejected',
   'client_input_updated',

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -38,6 +38,8 @@ export type SSEEventType =
   | 'keeper_tool_skipped'
   | 'keeper_turn_complete'
   | 'masc/keeper_turn_complete'
+  // RFC-0266 Phase 4: fusion run-status transitions pushed to the dashboard.
+  | 'fusion_run_status'
   | 'client_input_approved'
   | 'client_input_rejected'
   | 'client_input_updated'


### PR DESCRIPTION
## fix(dashboard): register `fusion_run_status` at the SSE parse boundary (RFC-0266 Phase 4 follow-up)

### 증상

Phase 4 (#21735, merged) 가 대시보드 `sse.ts` 에 `case 'fusion_run_status'` 디스패치를 추가했지만, 그 타입을 **닫힌 SSE allowlist 두 곳에 등록하지 않았습니다**:

- `dashboard/src/schemas/sse.ts` 의 `FIXED_SSE_EVENT_TYPES` (런타임 allowlist)
- `dashboard/src/types/sse.ts` 의 `SSEEventType` union (타입)

그 결과 `parseSSEMessage` 가 모든 `fusion_run_status` push 를 파싱 경계에서 **silent drop** 합니다 (`console.warn('[SSE] schema drift, event dropped')`). 디스패치 `case 'fusion_run_status'` (sse.ts) 는 **dead code** 가 되어, `running → completed/failed` 라이브 전이가 패널에 도달하지 못하고 패널은 **tab 재방문(tab-refresh) 때만** 갱신됩니다. Phase 4 의 핵심 약속("operator 폴링 없이 라이브 flip")이 동작하지 않는 상태였습니다.

### 근본 원인

`board_post` / `keeper_turn_complete` 같은 다른 push 이벤트는 `FIXED_SSE_EVENT_TYPES` 와 `SSEEventType` **양쪽 모두**에 등록돼 있어 파싱 경계를 통과합니다. Phase 4 는 디스패치 `case` 만 추가하고 상위 등록 게이트 2곳을 빠뜨렸습니다. (이는 workaround 가 아니라, 백엔드가 실제로 emit 하는 — `lib/fusion/fusion_sink.ml:134` `"fusion_run_status"` — 알려진 이벤트 타입을 닫힌 목록에 등록하는 의도된 확장입니다.)

### 변경

- `dashboard/src/schemas/sse.ts` — `FIXED_SSE_EVENT_TYPES` 에 `'fusion_run_status'` 추가 (+ 누락 시 drop 되는 이유 주석).
- `dashboard/src/types/sse.ts` — `SSEEventType` union 에 `| 'fusion_run_status'` 추가.
- `dashboard/src/schemas/sse.test.ts` — `parseSSEMessage({ type: 'fusion_run_status', ... })` 가 drop 되지 않고(`console.warn` 미호출) 통과하는 round-trip 회귀 테스트. allowlist 에서 다시 빠지면 이 테스트가 fail 하는 drift-guard.

`JournalEventType` (활동 로그) 에는 추가하지 않았습니다 — `fusion_run_status` 는 transient run-status push 이지 저널 항목이 아니기 때문입니다.

### 검증

- `pnpm typecheck` (tsc --noEmit) clean.
- `pnpm vitest run schemas/sse.test.ts` — 30 passed (기존 29 + 신규 round-trip 1).
- 백엔드 wire 타입(`fusion_sink.ml:134` `"fusion_run_status"`) 과 프론트 등록 문자열 일치 확인.

### 범위 밖 (별도 후속 — 동일 감사에서 발견)

- **(lifecycle) 취소/timeout 으로 끝난 fusion fork 가 registry 에 영구 `running` 으로 잔존** — `register_running` 후 `mark_completed` 없이 종료되는 경로(`Eio.Cancel.Cancelled`). 백엔드(`lib/fusion`) 변경 + Eio cleanup 테스트가 필요해 별도 PR 로 분리.
- (frontend) fusion surface 의 수동 `Refresh` 버튼이 board 만 갱신하고 run-status 패널은 안 갱신 — SSE 끊김 시 수동 fallback 부재.
- (low) `started_at <= 0` garbled row 가 1970 으로 렌더 / `fus-runs-list` overflow 미설정.

RFC-0266 §7 (VISIBILITY). Phase 4 (#21735) follow-up.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
