### PR TITLE
fix(fusion): finalize run registry on fusion fork cancel (RFC-0266 Phase 4)

### DIFF
--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -95,7 +95,18 @@ let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ~args : string =
           append_chat_failure ~base_dir ~keeper ~run_id
             (Printf.sprintf "**Fusion run `%s`** _(sink failed: %s)_" run_id msg)
         | exception (Eio.Cancel.Cancelled _ as exn) ->
-          (* 구조적 취소는 흡수하지 않고 재전파 (Eio 규약). *)
+          (* RFC-0266 §7: 취소도 종료 상태다. register_running(위 line 73)으로 [Running]
+             으로 등록된 run을 [Completed{ok=false}]로 갱신하지 않으면, in-memory registry
+             ([global], 서버 수명)에 영구 "running"으로 남아 dashboard fusion-runs 패널과
+             masc_fusion_status가 거짓 "심의중"을 보인다(prune는 [Running]을 evict하지 않음 —
+             fusion_run_registry.ml). 다른 종료 분기(Denied/Sink_failed/exception)는
+             append_chat_failure 경유로 이미 mark_completed 하는데 이 분기만 빠져 있었다.
+             [mark_completed]는 순수 in-memory CAS(suspension 없음)라 취소 컨텍스트에서도
+             안전하다. broadcast는 [Sse.broadcast]가 mailbox에서 suspend/block할 수 있어
+             취소/셧다운 캐스케이드를 deadlock시킬 위험이 있으므로 이 경로에선 생략한다 —
+             registry가 정확해 다음 HTTP fetch / tab-refresh가 패널을 self-heal한다.
+             그 뒤 구조적 취소는 흡수하지 않고 재전파한다 (Eio 규약). *)
+          Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok:false;
           raise exn
         | exception exn ->
           append_chat_failure ~base_dir ~keeper ~run_id


### PR DESCRIPTION
## fix(fusion): finalize the run registry when a fusion fork is cancelled (RFC-0266 Phase 4 follow-up)

### 증상

`masc_fusion` 심의가 **취소**되면 (`Eio.Cancel.Cancelled`) dashboard fusion-runs 패널과 `masc_fusion_status` 도구가 그 run 을 **영구히 "running"(심의중)** 으로 표시합니다. 실제로는 끝난(취소된) run 인데 surface 상으로는 계속 진행중처럼 보입니다.

### 근본 원인

`lib/fusion/fusion_tool.ml` 의 `handle` 는 orchestrator fork **직전**에 run 을 `register_running` 으로 `[Running]` 등록합니다 (line 73). fork 의 종료 분기 5개 중:

- `Completed` → sink 가 `mark_completed`
- `Denied` / `Sink_failed` / 기타 `exception` → `append_chat_failure` → `mark_completed ~ok:false`
- **`exception (Eio.Cancel.Cancelled _) → raise exn`** — `mark_completed` 없이 재전파 ← **누락**

registry 는 `global`(서버 수명 in-memory Atomic)이고 `prune` 은 `[Running]` 을 **절대 evict 하지 않으므로**(`fusion_run_registry.ml`), 취소된 run 은 process 가 살아있는 한(sibling fiber 실패로 인한 `Switch.fail`, sub-switch 취소, soft-restart) 영구 `[Running]` 으로 누적됩니다. (full process restart 면 `global` 이 프로세스와 함께 사라지므로 §10 #4 의 "재시작 시 orphan 없음"은 그 경우에만 성립합니다.)

### 변경 (1줄 + 주석)

취소 분기에서 재전파 **직전** 에 run 을 `Completed{ok=false}` 로 갱신합니다 (다른 실패 분기와 동일한 호출):

```ocaml
| exception (Eio.Cancel.Cancelled _ as exn) ->
  Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok:false;
  raise exn
```

**안전성**: `mark_completed` 는 순수 in-memory `Atomic.compare_and_set` 루프로 **suspension point 가 없어** 취소 컨텍스트에서도 안전합니다(취소는 suspension 지점에서만 작동). `broadcast_run_status` 는 이 경로에서 **의도적으로 생략** 합니다 — `Sse.broadcast` 가 per-client mailbox 에서 suspend/block 할 수 있어, 소비자도 tear-down 중인 취소/셧다운 캐스케이드에서 deadlock 시킬 위험이 있습니다. registry 가 정확해지므로 패널은 다음 HTTP fetch / tab-refresh 에서 self-heal 합니다. `~ok:false`(패널상 "failed")는 기존 `_(aborted: ...)_` 분기와 동일한 종료 표현이라 일관됩니다.

### 검증

- `ocamlformat --check lib/fusion/fusion_tool.ml` 통과 (로컬).
- `Fusion_run_registry.mark_completed` 의 `Running → Completed{ok=false}` 전이는 `test/fusion_core/test_fusion_run_registry.ml:test_mark_completed` 로 이미 unit-tested.
- 변경은 같은 파일의 다른 종료 분기(line 40 등)가 호출하는 것과 **byte-identical 한 1줄**이라 새 심볼/의존성 없음 — compile 영향 최소.
- OCaml 빌드는 CI 가 게이트(로컬 agent_sdk drift). 내 변경은 `lib/fusion/fusion_tool.ml` 단일 파일.

### 테스트에 대하여 (투명성)

별도 통합 테스트를 **추가하지 않았습니다**. 이유: (1) 호출하는 `mark_completed` 자체는 이미 unit-tested 이고, (2) 그것이 순수 CAS 라 "취소 중 안전"은 코드의 동작이 아니라 언어/stdlib 보장이며, (3) `Fusion_tool.handle` 의 fork 취소를 end-to-end 로 태우려면 net/orchestrator/policy 를 mock 하는 하네스가 필요한데 현재 fusion 테스트에 그런 하네스가 없습니다(`test_fusion_harness.ml` 는 majority 로직만). 불확실하게 통과를 장담할 수 없는 통합 테스트를 날조하는 대신, handle fork 하네스 구축을 **후속**으로 남깁니다.

### 후속 (동일 감사, 이 PR 범위 밖)
- (frontend) fusion surface 수동 `Refresh` 버튼이 board 만 갱신, run-status 패널 미갱신.
- (low) `started_at <= 0` garbled row 1970 렌더 / `fus-runs-list` overflow 미설정.
- (검토) 취소를 "failed" 와 구분하려면 `run_status` 에 `Aborted` variant 추가 가능 — 모든 소비자(status_label/run_to_yojson/frontend) 변경이 필요해 별도 검토.

RFC-0266 §7 (VISIBILITY). Phase 4 (#21735) follow-up. SSE 등록 누락 fix #21780 과 별개(이건 backend lifecycle).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
