### PR TITLE
fix(keeper): bound cadence_counters against unbounded trace-rotation growth

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -134,7 +134,25 @@ let cadence_turns () =
    read/write that never yields, and the table is reachable from concurrent
    keeper fibers. *)
 let cadence_mu = Stdlib.Mutex.create ()
-let cadence_counters : (string * string, int) Hashtbl.t = Hashtbl.create 16
+
+(* Each entry carries [last_used] (wall clock of its last touch) alongside the
+   [counter] ("turns since last successful extraction") so that dead traces can
+   be reclaimed by age. *)
+type cadence_entry =
+  { counter : int
+  ; last_used : float
+  }
+
+let cadence_counters : (string * string, cadence_entry) Hashtbl.t = Hashtbl.create 16
+
+(* [cadence_counters] is keyed by (keeper, active trace). A handoff rolls the
+   trace_id, so a keeper accumulates one dead entry per rotation. The table is
+   bounded by reclaiming entries untouched beyond [cadence_stale_seconds] once it
+   exceeds [cadence_max_entries] — the same prune shape as Process file-lock
+   tables. Recently-used entries are always kept, so traces in active rotation
+   retain independent counters; only genuinely dead traces are dropped. *)
+let cadence_max_entries = 512
+let cadence_stale_seconds = 3600.0
 
 (* A counter value below 0 means the (keeper, trace) has never had a successful
    extraction: the next turn is due immediately. *)
@@ -159,22 +177,74 @@ let cadence_step ~cadence ~counter =
     if next >= cadence then cadence, true else next, false)
 ;;
 
-let cadence_due ~keeper_id ~trace_id =
+(* Pure eviction decision: given a [(key, last_used)] snapshot, the keys whose
+   entry is stale (untouched beyond [stale_seconds]) — but only once the snapshot
+   exceeds [max_entries]. Below the cap nothing is dropped, so traces in active
+   rotation keep independent counters. *)
+let stale_cadence_keys ~now ~max_entries ~stale_seconds entries =
+  if List.compare_length_with entries max_entries <= 0
+  then []
+  else
+    List.filter_map
+      (fun (key, last_used) ->
+        if Float.compare (now -. last_used) stale_seconds > 0 then Some key else None)
+      entries
+;;
+
+(* Reclaim dead-trace entries in place. Caller holds [cadence_mu]. *)
+let prune_cadence_table ~now =
+  if Hashtbl.length cadence_counters > cadence_max_entries
+  then (
+    let snapshot =
+      Hashtbl.fold
+        (fun key entry acc -> (key, entry.last_used) :: acc)
+        cadence_counters
+        []
+    in
+    List.iter
+      (Hashtbl.remove cadence_counters)
+      (stale_cadence_keys
+         ~now
+         ~max_entries:cadence_max_entries
+         ~stale_seconds:cadence_stale_seconds
+         snapshot))
+;;
+
+let cadence_due_at ~now ~keeper_id ~trace_id =
   Stdlib.Mutex.protect cadence_mu (fun () ->
+    prune_cadence_table ~now;
     let counter =
       (* sound-partial: allow — an unseen (keeper, trace) is due immediately via
          [fresh_counter]; fresh-state init, not a default hiding a parse error. *)
-      Option.value ~default:fresh_counter
-        (Hashtbl.find_opt cadence_counters (keeper_id, trace_id))
+      match Hashtbl.find_opt cadence_counters (keeper_id, trace_id) with
+      | Some entry -> entry.counter
+      | None -> fresh_counter
     in
     let updated, due = cadence_step ~cadence:(cadence_turns ()) ~counter in
-    Hashtbl.replace cadence_counters (keeper_id, trace_id) updated;
+    Hashtbl.replace
+      cadence_counters
+      (keeper_id, trace_id)
+      { counter = updated; last_used = now };
     due)
+;;
+
+let cadence_due ~keeper_id ~trace_id =
+  cadence_due_at ~now:(Time_compat.now ()) ~keeper_id ~trace_id
 ;;
 
 let cadence_record_success ~keeper_id ~trace_id =
   Stdlib.Mutex.protect cadence_mu (fun () ->
-    Hashtbl.replace cadence_counters (keeper_id, trace_id) 0)
+    Hashtbl.replace
+      cadence_counters
+      (keeper_id, trace_id)
+      { counter = 0; last_used = Time_compat.now () })
+;;
+
+(* Number of [(keeper, trace)] cadence entries currently tracked; bounded by
+   [prune_cadence_table]. Read-only; exposed for the bound's regression test and
+   for diagnostics. *)
+let cadence_tracked_pairs () =
+  Stdlib.Mutex.protect cadence_mu (fun () -> Hashtbl.length cadence_counters)
 ;;
 
 let max_messages () =

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -30,18 +30,37 @@ val cadence_step : cadence:int -> counter:int -> int * bool
     resets it. Exposed for testing the cadence logic without the per-keeper
     counter table. *)
 
+val cadence_max_entries : int
+(** Soft cap on the cadence counter table: once it exceeds this many entries,
+    [cadence_due] reclaims entries untouched past the staleness horizon. Exposed
+    so the bound's regression test does not hardcode the threshold. *)
+
 val cadence_due : keeper_id:string -> trace_id:string -> bool
 (** Advance the persistent cadence counter for ([keeper_id], [trace_id]) by one
     turn and report whether extraction is due now. This is what
     [run_best_effort] gates on. The counter is scoped to the active trace so a
     handoff rollover starts a fresh cadence cycle. First call for an unseen pair
-    is due immediately. *)
+    is due immediately. As a side effect it reclaims dead-trace entries (see
+    [cadence_due_at]) so the counter table stays bounded. *)
+
+val cadence_due_at : now:float -> keeper_id:string -> trace_id:string -> bool
+(** [cadence_due] with an explicit wall-clock [now]. Before reading the counter
+    it prunes entries untouched past the staleness horizon once the table exceeds
+    [cadence_max_entries], so dead traces from handoff rollovers do not
+    accumulate without bound; entries in active rotation are kept, preserving
+    per-trace independence. [cadence_due] is this with [now = Time_compat.now ()].
+    Exposed with an explicit clock so the prune is testable deterministically. *)
 
 val cadence_record_success : keeper_id:string -> trace_id:string -> unit
 (** Record a successful extraction for ([keeper_id], [trace_id]) so the cadence
     counter resets and the next cycle can begin. Must only be called after a
     due turn actually produced an episode; skipped or failed attempts must not
     call this. *)
+
+val cadence_tracked_pairs : unit -> int
+(** Number of [(keeper_id, trace_id)] cadence entries currently tracked. Bounded
+    by the dead-trace prune in [cadence_due_at]. Read-only; exposed for that
+    bound's regression test and for diagnostics. *)
 
 val max_messages : unit -> int
 (** Base per-turn cap on checkpoint messages sent to the librarian prompt. The

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -196,6 +196,36 @@ let test_cadence_due_scoped_by_trace () =
     check bool "trace a counter is independent" false
       (R.cadence_due ~keeper_id:kid ~trace_id:ta))
 
+(* The cadence table is keyed by (keeper, active trace); a handoff rolls the
+   trace_id, leaving one dead entry per rotation. Drive far more rotations than
+   the cap at a fixed [now], then advance the clock past the staleness horizon:
+   the dead entries must be reclaimed so the table stops growing without bound.
+   This is the regression guard for the unbounded-growth leak. *)
+let test_cadence_table_bounds_dead_traces () =
+  let t0 = 2_000_000_000.0 in
+  let fill = R.cadence_max_entries + 100 in
+  for i = 1 to fill do
+    ignore
+      (R.cadence_due_at
+         ~now:t0
+         ~keeper_id:(Printf.sprintf "deadtrace-keeper-%d" i)
+         ~trace_id:"t")
+  done;
+  let peak = R.cadence_tracked_pairs () in
+  (* Same-instant entries are never stale, so the table is allowed past the cap
+     while they are fresh — that is what preserves per-trace independence. *)
+  check bool "fresh entries are kept even past the cap" true (peak > R.cadence_max_entries);
+  (* A later turn, past the staleness horizon, reclaims the now-dead entries. *)
+  ignore
+    (R.cadence_due_at
+       ~now:(t0 +. 10_000_000.0)
+       ~keeper_id:"deadtrace-trigger"
+       ~trace_id:"t");
+  let after = R.cadence_tracked_pairs () in
+  check bool "stale dead-trace entries are reclaimed" true (after < peak);
+  check bool "table is bounded after the prune" true (after <= R.cadence_max_entries)
+;;
+
 (* Tolerant parsing for real-world librarian provider drift. *)
 
 let parse_ep raw =
@@ -317,6 +347,8 @@ let () =
           test_case "cadence_due fires once per period" `Quick test_cadence_due_periodic;
           test_case "cadence_due is per-keeper" `Quick test_cadence_due_independent_keepers;
           test_case "cadence_due is scoped by trace" `Quick test_cadence_due_scoped_by_trace;
+          test_case "dead-trace entries are reclaimed (bounded table)" `Quick
+            test_cadence_table_bounds_dead_traces;
         ] );
       ( "tolerant_parsing",
         [


### PR DESCRIPTION
## What
Bound the librarian `cadence_counters` table so it stops growing once per trace rotation.

## Why
`cadence_counters : (keeper_id, trace_id) -> counter` in `keeper_librarian_runtime.ml` is insert/replace-only — no entry is ever removed. A handoff rolls `trace_id`, so every keeper leaves one dead `(keeper, trace)` entry behind per rotation. Over a long-lived server the table grows without bound.

This is the single confirmed leak from an adversarial code+live audit of the keeper Memory OS (8 failure modes; 5 refuted, this one survived two independent refutation lenses — code-path and live-data). Live fleet measurement: growth ~1 entry per keeper per rotation, reset only on process restart. Severity is latent/slow, but the table is genuinely unbounded.

## Fix
Reclaim dead-trace entries by age, mirroring `File_lock_eio.prune_stale_entries`, which already solves the same "table of per-key state keyed by an ever-rotating key" problem with `max_lock_entries = 512` plus a staleness horizon:

- Each entry carries `last_used` next to its `counter`.
- `cadence_due` prunes before reading: once the table exceeds `cadence_max_entries` (512), entries untouched for longer than `cadence_stale_seconds` (1h) are dropped.
- Entries in active rotation are always kept, so per-trace counters stay independent — the existing `test_cadence_due_scoped_by_trace` still passes. This ruled out the naive "remove this keeper's other-trace entries" fix, which breaks that invariant.

This is a bounded-cache fix, not symptom suppression: the unbounded table *is* the bug and the size bound is the root fix — the same shape the codebase already accepts for file-lock state. No backpressure is being masked, no cooldown/dedup/repair of a downstream symptom.

## Tests
- New `test_cadence_table_bounds_dead_traces`: fills past the cap at a fixed clock (so fresh-over-cap entries are kept = independence preserved), then advances the clock past the horizon and asserts the dead entries are reclaimed and the table is bounded. Deterministic via the injected `cadence_due_at ~now`.
- The 7 existing cadence tests pass unchanged, guarding the value-type refactor (`int` -> `{ counter; last_used }`) and per-trace independence.

## Scope
`lib/keeper/keeper_librarian_runtime.ml` + `.mli` (additive only: `cadence_due_at`, `cadence_max_entries`, `cadence_tracked_pairs`) + `test/test_keeper_librarian_retry.ml`. No production caller changes — `cadence_due` / `cadence_record_success` signatures are unchanged. Not an RFC-trigger subsystem.

Audit report: `~/me/reports/masc-memory-os-leak-stuck-audit-20260620-1614.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
