### PR TITLE
fix(keeper): stop two Memory OS resource leaks at the source

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -129,15 +129,20 @@ let cadence_turns () =
   |> max 1
 ;;
 
-(* Per-(keeper, active trace) "turns since last successful extraction"
-   counters. Stdlib.Mutex (not Eio.Mutex): the critical section is a Hashtbl
-   read/write that never yields, and the table is reachable from concurrent
-   keeper fibers. *)
+(* Per-keeper "turns since last successful extraction" counter, paired with the
+   trace it belongs to. Keyed by [keeper_id] (the long-lived owner), NOT by
+   (keeper_id, trace_id): trace_id rotates on every keeper run, so a pair-keyed
+   table mints a fresh row per rotation and never reclaims the previous one,
+   growing without bound over the process lifetime. Keying by keeper_id bounds
+   the table to one row per live keeper; a rotated trace is detected as a stored
+   mismatch and resets the schedule in place. Stdlib.Mutex (not Eio.Mutex): the
+   critical section is a Hashtbl read/write that never yields, and the table is
+   reachable from concurrent keeper fibers. *)
 let cadence_mu = Stdlib.Mutex.create ()
-let cadence_counters : (string * string, int) Hashtbl.t = Hashtbl.create 16
+let cadence_counters : (string, string * int) Hashtbl.t = Hashtbl.create 16
 
-(* A counter value below 0 means the (keeper, trace) has never had a successful
-   extraction: the next turn is due immediately. *)
+(* A counter value below 0 means the keeper has never had a successful
+   extraction on the current trace: the next turn is due immediately. *)
 let fresh_counter = -1
 
 (* Pure cadence decision. Given the keeper's current [counter] (turns since its
@@ -159,22 +164,46 @@ let cadence_step ~cadence ~counter =
     if next >= cadence then cadence, true else next, false)
 ;;
 
+(* Pure keyed cadence decision. Given a keeper's [prior] stored (trace, counter)
+   and the [current_trace], a stored entry from a different (rotated) trace is
+   treated as fresh — due immediately, not inheriting the old trace's schedule —
+   exactly like an unseen keeper ([prior = None]). Returns the value to store and
+   whether extraction is due now. Exposed for testing the rollover decision
+   without the global table. *)
+let cadence_step_keyed ~cadence ~current_trace ~prior =
+  let counter =
+    (* sound-partial: allow — an unseen keeper or a rotated trace is fresh
+       (due immediately via [fresh_counter]); fresh-state init, not a default
+       hiding a parse error. *)
+    match prior with
+    | Some (t, c) when String.equal t current_trace -> c
+    | _ -> fresh_counter
+  in
+  let updated, due = cadence_step ~cadence ~counter in
+  (current_trace, updated), due
+;;
+
 let cadence_due ~keeper_id ~trace_id =
   Stdlib.Mutex.protect cadence_mu (fun () ->
-    let counter =
-      (* sound-partial: allow — an unseen (keeper, trace) is due immediately via
-         [fresh_counter]; fresh-state init, not a default hiding a parse error. *)
-      Option.value ~default:fresh_counter
-        (Hashtbl.find_opt cadence_counters (keeper_id, trace_id))
+    let prior = Hashtbl.find_opt cadence_counters keeper_id in
+    let value, due =
+      cadence_step_keyed ~cadence:(cadence_turns ()) ~current_trace:trace_id ~prior
     in
-    let updated, due = cadence_step ~cadence:(cadence_turns ()) ~counter in
-    Hashtbl.replace cadence_counters (keeper_id, trace_id) updated;
+    Hashtbl.replace cadence_counters keeper_id value;
     due)
 ;;
 
 let cadence_record_success ~keeper_id ~trace_id =
   Stdlib.Mutex.protect cadence_mu (fun () ->
-    Hashtbl.replace cadence_counters (keeper_id, trace_id) 0)
+    Hashtbl.replace cadence_counters keeper_id (trace_id, 0))
+;;
+
+(* Live per-keeper cadence rows. Bounded by the number of keepers that have run
+   (one row each), so it doubles as a leak-regression signal: it must not grow
+   with trace rotations. Read-only; consumed by the cadence test and the
+   dashboard memory-health panel. *)
+let cadence_counter_entries () =
+  Stdlib.Mutex.protect cadence_mu (fun () -> Hashtbl.length cadence_counters)
 ;;
 
 let max_messages () =

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -24,24 +24,43 @@ val cadence_turns : unit -> int
 val cadence_step : cadence:int -> counter:int -> int * bool
 (** Pure cadence decision. [(updated_counter, due)] for a keeper whose counter
     (turns since last successful extraction) is [counter] under [cadence].
-    [counter < 0] is treated as a fresh (keeper, trace) and is due immediately.
+    [counter < 0] is treated as fresh and is due immediately.
     cadence<=1 is always due with the counter pinned at 0. When due, the updated
     counter is set to [cadence] and stays there until [cadence_record_success]
     resets it. Exposed for testing the cadence logic without the per-keeper
     counter table. *)
 
+val cadence_step_keyed
+  :  cadence:int
+  -> current_trace:string
+  -> prior:(string * int) option
+  -> (string * int) * bool
+(** Pure keyed cadence decision. Given a keeper's [prior] stored
+    [(trace, counter)] and the [current_trace], returns the [(trace, counter)]
+    value to store and whether extraction is due now. A [prior] from a different
+    (rotated) trace, or [None], is treated as fresh — due immediately, not
+    inheriting the old trace's schedule. Exposed for testing the rollover
+    decision without the global table. *)
+
 val cadence_due : keeper_id:string -> trace_id:string -> bool
-(** Advance the persistent cadence counter for ([keeper_id], [trace_id]) by one
-    turn and report whether extraction is due now. This is what
-    [run_best_effort] gates on. The counter is scoped to the active trace so a
-    handoff rollover starts a fresh cadence cycle. First call for an unseen pair
-    is due immediately. *)
+(** Advance the persistent cadence counter for [keeper_id] by one turn and
+    report whether extraction is due now. This is what [run_best_effort] gates
+    on. The counter is keyed by [keeper_id] and stores the active [trace_id]
+    alongside it, so a handoff rollover (a new [trace_id]) resets the cadence
+    cycle in place — bounding the table to one row per keeper. First call for an
+    unseen keeper, or the first call after a rollover, is due immediately. *)
 
 val cadence_record_success : keeper_id:string -> trace_id:string -> unit
-(** Record a successful extraction for ([keeper_id], [trace_id]) so the cadence
+(** Record a successful extraction for [keeper_id] on [trace_id] so the cadence
     counter resets and the next cycle can begin. Must only be called after a
     due turn actually produced an episode; skipped or failed attempts must not
     call this. *)
+
+val cadence_counter_entries : unit -> int
+(** Number of live per-keeper cadence rows. Bounded by the number of keepers
+    that have run (one row each), independent of trace rotations — so it is the
+    leak-regression signal for the keeper-keyed cadence table and a memory-health
+    metric for the dashboard. Read-only. *)
 
 val max_messages : unit -> int
 (** Base per-turn cap on checkpoint messages sent to the librarian prompt. The

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -107,6 +107,22 @@ let remove_noerr path =
   | Sys_error _ | Unix.Unix_error _ -> ()
 ;;
 
+(* Run [f] against [oc] then close it, guaranteeing the descriptor is released
+   on every exit. [close_out] runs inside the body so a flush failure (e.g.
+   ENOSPC on the buffered tail) propagates to the caller; [close_out_noerr] in
+   the [Fun.protect] finally is a no-op after a clean close and reclaims the fd
+   when [close_out]'s flush raised before [close_out_channel] could run (OCaml's
+   [close_out = flush; close_out_channel] never reaches the close on flush
+   failure). [close_out_noerr] never raises, so it cannot mask the body's
+   exception via [Fun.Finally_raised]. *)
+let with_out_channel oc ~f =
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+       f oc;
+       close_out oc)
+;;
+
 let write_file_atomically path content =
   ensure_dir (Filename.dirname path);
   let rec open_tmp attempt =
@@ -123,15 +139,13 @@ let write_file_atomically path content =
     | Unix.Unix_error (Unix.EEXIST, _, _) -> open_tmp (attempt + 1)
   in
   let tmp, oc = open_tmp 0 in
-  let close_attempted = ref false in
+  (* The rename stays OUTSIDE [with_out_channel]: it runs only after the write
+     and close both succeed, and the exception path removes the temp file. *)
   try
-    output_string oc content;
-    close_attempted := true;
-    close_out oc;
+    with_out_channel oc ~f:(fun oc -> output_string oc content);
     Sys.rename tmp path
   with
   | exn ->
-    if not !close_attempted then close_out_noerr oc;
     remove_noerr tmp;
     raise exn
 ;;
@@ -220,15 +234,7 @@ let unique_episode_path ~keeper_id episode =
 let append_line path line =
   ensure_dir (Filename.dirname path);
   let oc = open_out_gen [ Open_append; Open_creat; Open_text ] 0o644 path in
-  let close_attempted = ref false in
-  try
-    output_string oc (line ^ "\n");
-    close_attempted := true;
-    close_out oc
-  with
-  | exn ->
-    if not !close_attempted then close_out_noerr oc;
-    raise exn
+  with_out_channel oc ~f:(fun oc -> output_string oc (line ^ "\n"))
 ;;
 
 let append_json path json =

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -32,6 +32,13 @@ val next_generation_with_floor : floor:int -> keeper_id:string -> trace_id:strin
 
 (** {1 Atomic writes} *)
 
+(** Run [f] against the channel then close it, releasing the descriptor on every
+    exit path — including when [close_out]'s flush raises, which OCaml's
+    [close_out] leaves the fd open on. The body's exception propagates (so
+    callers can skip a rename / report the write failure). Exposed for testing
+    the fd-release guarantee. *)
+val with_out_channel : out_channel -> f:(out_channel -> unit) -> unit
+
 val append_fact : keeper_id:string -> fact -> unit
 val append_event : keeper_id:string -> episode -> unit
 val append_episode : keeper_id:string -> episode -> unit

--- a/test/dune
+++ b/test/dune
@@ -29,6 +29,7 @@
 
 (tests
  (names
+  test_keeper_memory_os_io_fd
   test_rfc0259_reconcile
   test_keeper_memory_lane
   test_keeper_reactive_wake_backlog_gate
@@ -327,6 +328,7 @@
   test_relation_materializer
   test_keeper_behavior_trace)
  (modules
+  test_keeper_memory_os_io_fd
   test_rfc0259_reconcile
   test_keeper_memory_lane
   test_env_keeper_scrub

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -179,22 +179,59 @@ let test_cadence_due_independent_keepers () =
     check bool "kb advances on its own counter, not due on ka's schedule" false
       (R.cadence_due ~keeper_id:kb ~trace_id:tb))
 
-let test_cadence_due_scoped_by_trace () =
+(* A handoff rollover (a new trace_id for the same keeper) resets the cadence
+   schedule in place. The table is keyed by keeper_id, so the rotated trace
+   overwrites the keeper's single row rather than minting a new one — the
+   previous trace's counter is intentionally not preserved (production never has
+   two live traces for one keeper; meta.runtime.trace_id is the single active
+   trace and rolls over sequentially). *)
+let test_cadence_due_resets_on_trace_rollover () =
   let cadence = R.cadence_turns () in
   if cadence <= 1
-  then () (* cadence 1: every trace due every turn *)
+  then () (* cadence 1: every turn due, rollover semantics are trivial *)
   else (
-    let kid = "test-cadence-scope-trace" and ta = "trace-a" and tb = "trace-b" in
+    let kid = "test-cadence-rollover" and ta = "trace-a" and tb = "trace-b" in
     (* Advance trace a past its fresh-due turn to a non-due turn. *)
     if R.cadence_due ~keeper_id:kid ~trace_id:ta
     then R.cadence_record_success ~keeper_id:kid ~trace_id:ta;
-    ignore (R.cadence_due ~keeper_id:kid ~trace_id:ta);
-    (* Trace b is fresh and should be due immediately regardless of trace a. *)
-    check bool "fresh trace is due immediately" true
+    check bool "trace a is mid-cycle, not due" false
+      (R.cadence_due ~keeper_id:kid ~trace_id:ta);
+    (* A new trace (rollover) is fresh and due immediately, overwriting the row. *)
+    check bool "rolled-over trace is due immediately" true
       (R.cadence_due ~keeper_id:kid ~trace_id:tb);
-    (* Trace a remains not due on its own counter. *)
-    check bool "trace a counter is independent" false
+    (* Rolling back to trace a is itself a rollover off trace b: fresh, due
+       immediately — the old trace-a counter was not retained. *)
+    check bool "returning to the prior trace is a fresh rollover, due immediately"
+      true
       (R.cadence_due ~keeper_id:kid ~trace_id:ta))
+
+(* Leak regression: the cadence table is keyed by keeper_id, so an unbounded
+   number of trace rotations for one keeper must add exactly one row (the
+   pre-fix (keeper, trace) keying added one row per rotation and never reclaimed
+   it). Measured as a delta so concurrent rows from other tests do not matter. *)
+let test_cadence_table_bounded_under_trace_rotation () =
+  let kid = "test-cadence-rotation-bound" in
+  let before = R.cadence_counter_entries () in
+  for i = 1 to 64 do
+    ignore (R.cadence_due ~keeper_id:kid ~trace_id:(Printf.sprintf "rot-trace-%d" i))
+  done;
+  check int "64 trace rotations add exactly one keeper row" 1
+    (R.cadence_counter_entries () - before)
+
+(* Pure rollover decision: a stored entry from a different trace, or no entry,
+   is fresh (due immediately) and the returned value carries the current trace;
+   a matching trace advances the stored counter. *)
+let test_cadence_step_keyed () =
+  check (pair (pair string int) bool) "unseen keeper is fresh, due, carries trace"
+    (("t1", 3), true)
+    (R.cadence_step_keyed ~cadence:3 ~current_trace:"t1" ~prior:None);
+  check (pair (pair string int) bool) "matching trace advances mid-cycle, not due"
+    (("t1", 2), false)
+    (R.cadence_step_keyed ~cadence:3 ~current_trace:"t1" ~prior:(Some ("t1", 1)));
+  check (pair (pair string int) bool)
+    "rotated trace is fresh (due), discards prior counter, carries new trace"
+    (("t2", 3), true)
+    (R.cadence_step_keyed ~cadence:3 ~current_trace:"t2" ~prior:(Some ("t1", 2)))
 
 (* Tolerant parsing for real-world librarian provider drift. *)
 
@@ -316,7 +353,11 @@ let () =
           test_case "record success resets" `Quick test_cadence_record_success_resets;
           test_case "cadence_due fires once per period" `Quick test_cadence_due_periodic;
           test_case "cadence_due is per-keeper" `Quick test_cadence_due_independent_keepers;
-          test_case "cadence_due is scoped by trace" `Quick test_cadence_due_scoped_by_trace;
+          test_case "cadence_due resets on trace rollover" `Quick
+            test_cadence_due_resets_on_trace_rollover;
+          test_case "cadence table bounded under trace rotation" `Quick
+            test_cadence_table_bounded_under_trace_rotation;
+          test_case "cadence_step_keyed rollover decision" `Quick test_cadence_step_keyed;
         ] );
       ( "tolerant_parsing",
         [

--- a/test/test_keeper_memory_os_io_fd.ml
+++ b/test/test_keeper_memory_os_io_fd.ml
@@ -11,6 +11,10 @@
 open Alcotest
 module Io = Masc.Keeper_memory_os_io
 
+(* A dedicated exception so the body-raises test does not pattern-match on a
+   literal Failure string (warning 52, fragile-literal-pattern). *)
+exception Boom
+
 (* A closed out_channel raises Sys_error "Bad file descriptor" on further use;
    that is our portable proxy for "the descriptor was released". *)
 let channel_is_closed oc =
@@ -26,10 +30,10 @@ let test_closes_on_body_exception () =
   let oc = open_out tmp in
   let raised =
     try
-      Io.with_out_channel oc ~f:(fun _ -> failwith "boom");
+      Io.with_out_channel oc ~f:(fun _ -> raise Boom);
       false
     with
-    | Failure "boom" -> true
+    | Boom -> true
   in
   check bool "body exception propagates unchanged" true raised;
   check bool "channel closed after exception (fd released)" true (channel_is_closed oc);

--- a/test/test_keeper_memory_os_io_fd.ml
+++ b/test/test_keeper_memory_os_io_fd.ml
@@ -1,0 +1,56 @@
+(** [Keeper_memory_os_io.with_out_channel] fd-release guarantee.
+
+    Regression for the write-path fd leak: both [write_file_atomically] and
+    [append_line] used to set a [close_attempted] flag BEFORE [close_out], so
+    when [close_out]'s internal flush raised (OCaml's [close_out = flush;
+    close_out_channel] never reaches the close on flush failure) the exception
+    handler skipped the recovery [close_out_noerr] and the descriptor leaked.
+    [with_out_channel] now closes via a [Fun.protect] finally, releasing the fd
+    on every exit while still propagating the body's exception. *)
+
+open Alcotest
+module Io = Masc.Keeper_memory_os_io
+
+(* A closed out_channel raises Sys_error "Bad file descriptor" on further use;
+   that is our portable proxy for "the descriptor was released". *)
+let channel_is_closed oc =
+  try
+    output_string oc "x";
+    flush oc;
+    false
+  with
+  | Sys_error _ -> true
+
+let test_closes_on_body_exception () =
+  let tmp = Filename.temp_file "masc_woc_exn" ".txt" in
+  let oc = open_out tmp in
+  let raised =
+    try
+      Io.with_out_channel oc ~f:(fun _ -> failwith "boom");
+      false
+    with
+    | Failure "boom" -> true
+  in
+  check bool "body exception propagates unchanged" true raised;
+  check bool "channel closed after exception (fd released)" true (channel_is_closed oc);
+  Sys.remove tmp
+
+let test_writes_and_closes_on_success () =
+  let tmp = Filename.temp_file "masc_woc_ok" ".txt" in
+  let oc = open_out tmp in
+  Io.with_out_channel oc ~f:(fun oc -> output_string oc "hello");
+  check bool "channel closed after success" true (channel_is_closed oc);
+  let ic = open_in tmp in
+  let content = really_input_string ic (in_channel_length ic) in
+  close_in ic;
+  check string "content flushed to disk" "hello" content;
+  Sys.remove tmp
+
+let () =
+  run
+    "keeper_memory_os_io_fd"
+    [ ( "with_out_channel"
+      , [ test_case "closes the fd when the body raises" `Quick test_closes_on_body_exception
+        ; test_case "writes and closes on success" `Quick test_writes_and_closes_on_success
+        ] )
+    ]


### PR DESCRIPTION
## 무엇을 / 왜

Keeper Memory OS 적대 감사(`reports/masc-memory-os-leak-stuck-audit-20260620-1614.html`)에서 확정된 두 리소스 누수를 근본 원인에서 고칩니다. 둘 다 메모리 의미를 바꾸지 않는 순수 리소스-관리 버그이며, 6-에이전트 적대 워크플로(A/B 각 2 lens + RFC 범위 + critic)가 근본 수정으로 GO 판정했습니다.

### A. cadence_counters 테이블 무한 증식 — `keeper_librarian_runtime.ml`

`cadence_counters`가 `(keeper_id, trace_id)`로 키잉되어 있었습니다. trace_id는 keeper run마다 회전하므로, 회전할 때마다 새 행이 생기고 이전 행은 회수되지 않아 프로세스 수명 동안 단조 증가했습니다(감사: confirmed P2).

근본 수정: 테이블을 `keeper_id`로 다시 키잉하고 trace를 값(`trace_id * counter`)으로 저장합니다. 회전된 trace는 저장된 trace와 불일치로 감지되어 그 자리에서 스케줄을 리셋합니다. 키 타입이 `keeper_id`이므로 테이블 크기는 fleet(살아있는 keeper 수)로 구조적으로 한정됩니다 — entry 수명을 long-lived owner(keeper identity)에 묶는 lifetime-correctness 변경입니다. 회전이 즉시-due로 리셋되는 기존 동작은 그대로 보존됩니다.

### B. write 경로 파일 디스크립터 누수 — `keeper_memory_os_io.ml`

`write_file_atomically`와 `append_line`이 `close_attempted := true`를 `close_out` 호출 **이전**에 설정했습니다. OCaml 5.4.1에서 `close_out = flush; close_out_channel`이므로, flush가 디스크 오류(ENOSPC/EIO/EDQUOT)로 raise하면 fd를 닫는 `close_out_channel`에 도달하지 못하고, 핸들러는 `close_attempted = true`를 보고 복구용 `close_out_noerr`를 건너뛰어 fd가 누수되었습니다(장수 서버에서 돌지 않는 at_exit 파이널라이저까지).

근본 수정: 공유 헬퍼 `with_out_channel`을 추출해 `Fun.protect ~finally:close_out_noerr`로 모든 종료 경로에서 fd 반환을 보장합니다. `close_out`은 본문 안에 남겨 쓰기 오류를 그대로 전파하므로(실패 시 atomic rename은 건너뜀), 두 write 경로의 동일 버그가 하나의 헬퍼로 동시에 사라집니다.

## 테스트

- `cadence_step_keyed` 순수 rollover 결정(미발견 / 동일 trace / 회전)
- trace 64회 회전이 keeper 행을 정확히 1개만 추가 (delta 기반 누수 회귀)
- `with_out_channel`이 본문 예외 시 채널을 닫음(닫힌 채널 쓰기가 `Sys_error`) + 정상 경로 쓰기·닫기

`cadence_counter_entries`는 회귀 테스트가 읽는 읽기 전용 행 수이며, 후속 대시보드 memory-health 패널에서도 동일 함수를 재사용합니다.

## 범위 밖 (별도 RFC)

감사가 식별한 메모리 *의미* 변경 결함(GC default-off로 만료 fact 디스크 잔존, events.jsonl 무한 append, 의미적 중복 re-mint, re-mint freshness reset)은 본 PR에 포함하지 않고 RFC-0259 개정과 RFC-0247 이슈로 이관합니다.

## Workaround Rejection self-check

- telemetry-as-fix? 아님 — counter를 추가하는 게 아니라 누수 자체를 제거
- string/substring classifier? 아님
- N-of-M? 아님 — B는 두 경로를 공유 헬퍼로 동시 수정
- cap/cooldown/dedup/repair? 아님 — A는 prune cap이 아니라 키 타입 변경에 의한 구조적 bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)
