### PR TITLE
feat(dashboard): keeper memory-health observability panel

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -3514,6 +3514,37 @@ export function fetchMemorySubsystems(
   )
 }
 
+// --- Keeper Memory Health ---
+
+export interface KeeperMemoryHealthKeeperEntry {
+  keeper_id: string
+  facts: number
+  facts_bytes: number
+  events: number
+  events_bytes: number
+  events_to_facts_ratio: number
+  ttl_expired_on_disk: number
+  near_duplicate: number
+  external_ref: number
+}
+
+export interface KeeperMemoryHealthResponse {
+  generated_at: number
+  cadence_counter_entries: number
+  keepers: KeeperMemoryHealthKeeperEntry[]
+  totals: {
+    facts: number
+    facts_bytes: number
+    events_bytes: number
+    ttl_expired_on_disk: number
+    near_duplicate: number
+  }
+}
+
+export function fetchKeeperMemoryHealth(): Promise<KeeperMemoryHealthResponse> {
+  return get<KeeperMemoryHealthResponse>('/api/v1/dashboard/keeper-memory-health')
+}
+
 // --- Verification requests (Mission detail table) ---
 // Backend: lib/dashboard/dashboard_verification.ml
 // Route:   GET /api/v1/verification/requests?task_id=&limit=

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -5,8 +5,9 @@ import { HarnessHealth } from './harness-health'
 import { DesignCanvas } from './design-canvas'
 import { LabPerf } from './lab-perf'
 import { MemoryExplore } from './memory/memory-explore'
+import { KeeperMemoryHealth } from './memory/keeper-memory-health'
 
-type LabSection = 'tools' | 'harness' | 'design-canvas' | 'performance' | 'memory-explore'
+type LabSection = 'tools' | 'harness' | 'design-canvas' | 'performance' | 'memory-explore' | 'keeper-memory-health'
 
 function currentSection(): LabSection {
   const section = route.value.params.section
@@ -15,6 +16,7 @@ function currentSection(): LabSection {
     || section === 'design-canvas'
     || section === 'performance'
     || section === 'memory-explore'
+    || section === 'keeper-memory-health'
   ) {
     return section
   }
@@ -44,6 +46,10 @@ export function Lab() {
 
       ${section === 'memory-explore' ? html`
         <${MemoryExplore} />
+      ` : null}
+
+      ${section === 'keeper-memory-health' ? html`
+        <${KeeperMemoryHealth} />
       ` : null}
     </div>
   `

--- a/dashboard/src/components/memory/keeper-memory-health.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.ts
@@ -1,0 +1,185 @@
+// KeeperMemoryHealth — per-keeper fact-store observability panel.
+//
+// Read-only diagnostic surface for Lab > 키퍼 메모리 상태.
+// Shows fact-store sizes, GC dry-run statistics, and the fleet-wide
+// librarian cadence counter so operators can monitor what the
+// disabled GC leaves on disk.
+
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+import {
+  fetchKeeperMemoryHealth,
+  type KeeperMemoryHealthKeeperEntry,
+  type KeeperMemoryHealthResponse,
+} from '../../api/dashboard'
+import { DEFAULT_PANEL_REFRESH_MS, formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../../lib/auto-refresh'
+
+// Rows whose events-to-facts ratio exceeds this threshold are flagged for
+// operator attention — a high ratio suggests the event log has grown much
+// larger than the fact store, which may indicate GC backpressure.
+const EVENTS_TO_FACTS_RATIO_WARN_THRESHOLD = 2
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
+function isRowWarning(entry: KeeperMemoryHealthKeeperEntry): boolean {
+  return (
+    entry.events_to_facts_ratio > EVENTS_TO_FACTS_RATIO_WARN_THRESHOLD
+    || entry.ttl_expired_on_disk > 0
+  )
+}
+
+function KeeperRow({ entry }: { entry: KeeperMemoryHealthKeeperEntry }) {
+  const warn = isRowWarning(entry)
+  const ratioStr = entry.events_to_facts_ratio.toFixed(2)
+
+  return html`
+    <tr class=${warn ? 'kmh-row--warn' : ''}>
+      <td>${entry.keeper_id}</td>
+      <td>${entry.facts.toLocaleString()}</td>
+      <td>${formatBytes(entry.facts_bytes)}</td>
+      <td>
+        ${entry.events_to_facts_ratio > EVENTS_TO_FACTS_RATIO_WARN_THRESHOLD
+          ? html`<span class="kmh-badge kmh-badge--warn">${ratioStr}</span>`
+          : html`<span>${ratioStr}</span>`}
+      </td>
+      <td>
+        ${entry.ttl_expired_on_disk > 0
+          ? html`<span class="kmh-badge kmh-badge--warn">${entry.ttl_expired_on_disk}</span>`
+          : html`<span class="kmh-badge kmh-badge--ok">0</span>`}
+      </td>
+      <td>${entry.near_duplicate}</td>
+      <td>${entry.external_ref}</td>
+    </tr>
+  `
+}
+
+export function KeeperMemoryHealth() {
+  const [data, setData] = useState<KeeperMemoryHealthResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    // useEffect is appropriate here: this is external-system synchronization
+    // (periodic HTTP fetch from the MASC API), not derived state or event response.
+    const controller = new AbortController()
+
+    const refresh = async () => {
+      try {
+        const result = await fetchKeeperMemoryHealth()
+        if (controller.signal.aborted) return
+        setData(result)
+        setError(null)
+      } catch (err) {
+        if (controller.signal.aborted) return
+        setError(err instanceof Error ? err.message : 'keeper-memory-health fetch failed')
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    }
+
+    setLoading(true)
+    void refresh()
+    const cleanup = setupVisibleAutoRefresh(() => { void refresh() }, DEFAULT_PANEL_REFRESH_MS)
+
+    return () => {
+      controller.abort()
+      cleanup()
+    }
+  }, [])
+
+  if (loading && data === null) {
+    return html`
+      <div class="kmh-panel">
+        <p class="kmh-empty">로딩중...</p>
+      </div>
+    `
+  }
+
+  if (error !== null && data === null) {
+    return html`
+      <div class="kmh-panel">
+        <p class="kmh-empty">데이터 로드 실패: ${error}</p>
+      </div>
+    `
+  }
+
+  if (data === null) {
+    return html`
+      <div class="kmh-panel">
+        <p class="kmh-empty">데이터 없음.</p>
+      </div>
+    `
+  }
+
+  const generatedAt = new Date(data.generated_at * 1000).toLocaleTimeString()
+
+  return html`
+    <div class="kmh-panel">
+      <div class="kmh-header">
+        <div class="kmh-title">키퍼 메모리 상태</div>
+        <div class="kmh-totals-strip">
+          <div class="kmh-stat">
+            <span class="kmh-stat-label">전체 사실</span>
+            <span class="kmh-stat-value">${data.totals.facts.toLocaleString()}</span>
+          </div>
+          <div class="kmh-stat">
+            <span class="kmh-stat-label">사실 크기</span>
+            <span class="kmh-stat-value">${formatBytes(data.totals.facts_bytes)}</span>
+          </div>
+          <div class="kmh-stat">
+            <span class="kmh-stat-label">이벤트 크기</span>
+            <span class="kmh-stat-value">${formatBytes(data.totals.events_bytes)}</span>
+          </div>
+          <div class="kmh-stat">
+            <span class="kmh-stat-label">TTL 만료(디스크)</span>
+            <span class=${`kmh-stat-value${data.totals.ttl_expired_on_disk > 0 ? ' kmh-stat-value--warn' : ''}`}>
+              ${data.totals.ttl_expired_on_disk}
+            </span>
+          </div>
+          <div class="kmh-stat">
+            <span class="kmh-stat-label">근접중복</span>
+            <span class="kmh-stat-value">${data.totals.near_duplicate}</span>
+          </div>
+          <div class="kmh-stat">
+            <span class="kmh-stat-label">케이던스 카운터</span>
+            <span class="kmh-stat-value">${data.cadence_counter_entries}</span>
+          </div>
+          <div class="kmh-stat">
+            <span class="kmh-stat-label">키퍼 수</span>
+            <span class="kmh-stat-value">${data.keepers.length}</span>
+          </div>
+        </div>
+        <div class="kmh-refresh-label">
+          ${formatAutoRefreshLabel(DEFAULT_PANEL_REFRESH_MS)} — 기준 ${generatedAt}
+        </div>
+      </div>
+
+      ${data.keepers.length === 0
+        ? html`<p class="kmh-empty">등록된 키퍼 팩트 스토어 없음.</p>`
+        : html`
+          <div class="kmh-table-wrap">
+            <table class="kmh-table">
+              <thead>
+                <tr>
+                  <th>키퍼</th>
+                  <th>사실</th>
+                  <th>bytes</th>
+                  <th>events:facts 비율</th>
+                  <th>만료(디스크)</th>
+                  <th>근접중복</th>
+                  <th>external_ref</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${data.keepers.map(entry => html`<${KeeperRow} key=${entry.keeper_id} entry=${entry} />`)}
+              </tbody>
+            </table>
+          </div>
+        `}
+    </div>
+  `
+}

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -132,6 +132,7 @@ describe('lab navigation', () => {
       'design-canvas',
       'performance',
       'memory-explore',
+      'keeper-memory-health',
     ])
 
     expect(labSections.map(item => item.label)).toEqual([
@@ -140,6 +141,7 @@ describe('lab navigation', () => {
       'Design Canvas',
       'Performance',
       'Memory Explore',
+      '키퍼 메모리 상태',
     ])
     expect(labSections.find(item => item.id === 'performance')?.description).toBe(
       'FPS meter, VirtualList, content-visibility, native dialog, and observer probes.',

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -45,6 +45,7 @@ type SurfaceSectionId =
   | 'design-canvas'
   | 'performance'
   | 'memory-explore'
+  | 'keeper-memory-health'
   // code (Stage 5 IDE plane — shell only in PR-1, 4-pane content in PR-2+)
   | 'ide-shell'
 
@@ -403,6 +404,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'Memory Explore',
       description: 'Memory Lens, Lineage Rail, and Goal Dossier composition.',
       params: { section: 'memory-explore' },
+    },
+    {
+      id: 'keeper-memory-health',
+      label: '키퍼 메모리 상태',
+      description: 'Per-keeper fact-store size, GC statistics, and cadence counter.',
+      params: { section: 'keeper-memory-health' },
     },
   ],
   code: [

--- a/dashboard/src/styles/keeper-memory-health-v2.css
+++ b/dashboard/src/styles/keeper-memory-health-v2.css
@@ -1,0 +1,137 @@
+/* ════════════════════════════════════════════════════════════════
+   KEEPER MEMORY HEALTH — per-keeper fact-store observability panel (Lab)
+   Read-only diagnostic panel for operators monitoring GC-disabled stores.
+   Auto-imported via the *-v2.css glob in main.ts — do not add an import line.
+   ════════════════════════════════════════════════════════════════ */
+
+.kmh-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-4);
+}
+
+.kmh-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.kmh-title {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.kmh-totals-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+}
+
+.kmh-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.kmh-stat-label {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.kmh-stat-value {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.kmh-stat-value--warn {
+  color: var(--accent-warn, #e0a82e);
+}
+
+.kmh-table-wrap {
+  overflow-x: auto;
+}
+
+.kmh-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.kmh-table th {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--border-subtle);
+  white-space: nowrap;
+}
+
+.kmh-table td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.kmh-table tr:last-child td {
+  border-bottom: none;
+}
+
+.kmh-table tr:hover td {
+  background: var(--surface-hovered);
+}
+
+/* Rows with health signals that warrant operator attention. */
+.kmh-row--warn td {
+  background: color-mix(in srgb, var(--accent-warn, #e0a82e) 6%, transparent);
+}
+
+.kmh-row--warn:hover td {
+  background: color-mix(in srgb, var(--accent-warn, #e0a82e) 10%, transparent);
+}
+
+.kmh-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.kmh-badge--warn {
+  background: color-mix(in srgb, var(--accent-warn, #e0a82e) 20%, transparent);
+  color: var(--accent-warn, #e0a82e);
+}
+
+.kmh-badge--ok {
+  background: color-mix(in srgb, var(--status-ok) 15%, transparent);
+  color: var(--status-ok);
+}
+
+.kmh-refresh-label {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  margin-top: var(--space-1);
+}
+
+.kmh-empty {
+  padding: var(--space-8);
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -42,7 +42,7 @@ let valid_sections =
   ; "connectors", [ "connector-status" ]
   ; ( "workspace"
     , [ "board"; "sub-boards"; "moderation"; "planning"; "repositories"; "verification"; "work" ] )
-  ; "lab", [ "tools"; "harness"; "design-canvas"; "memory-explore"; "performance" ]
+  ; "lab", [ "tools"; "harness"; "design-canvas"; "memory-explore"; "performance"; "keeper-memory-health" ]
   ; "code", [ "ide-shell" ]
   ]
 ;;

--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -76,7 +76,7 @@ let dedup_by_claim items =
    discard ([decide_retention] on [score_fact <= 0.02]) was removed: a fact's
    value is not a number GC can threshold. Forgetting is the librarian's
    delete-on-contradiction judgment plus this structural TTL, not a low score. *)
-let run_gc ?(dry_run = false) ~keeper_id ~now () =
+let run_gc ?keepers_dir ?(dry_run = false) ~keeper_id ~now () =
   (* Serialize the whole read-modify-rewrite on the same per-keeper facts lock the
      librarian write path (Keeper_librarian_runtime, wrapping merge_and_cap_facts)
      and the consolidation runtime already hold on facts_path. Without it, a
@@ -92,7 +92,7 @@ let run_gc ?(dry_run = false) ~keeper_id ~now () =
      File_lock_eio already offloads the blocking flock so the Eio domain is not
      stalled. Must run inside an Eio context (the maintenance fiber and tests
      both are). *)
-  File_lock_eio.with_lock (Io.facts_path ~keeper_id) (fun () ->
+  File_lock_eio.with_lock (Io.facts_path ?keepers_dir ~keeper_id) (fun () ->
     (* Read strictly: a malformed JSONL row aborts the sweep rather than being
        silently dropped by the lenient decoder and then erased by the rewrite
        below. Every other destructive rewrite path already refuses to overwrite a
@@ -102,7 +102,7 @@ let run_gc ?(dry_run = false) ~keeper_id ~now () =
        into permanent deletion of the surrounding facts (it read via the lenient
        read_facts_all). Preserve over delete: leave a corrupt store untouched and
        let the raised error surface so an operator can repair it. *)
-    match Io.read_facts_all_strict ~keeper_id with
+    match Io.read_facts_all_strict ?keepers_dir ~keeper_id with
     | Error message ->
       raise (Fact_store_corrupt ("memory os gc fact store read failed: " ^ message))
     | Ok facts ->
@@ -112,7 +112,7 @@ let run_gc ?(dry_run = false) ~keeper_id ~now () =
       in
       let deduped = dedup_by_claim live in
       let survivors = List.map (fun item -> item.fact) deduped in
-      if not dry_run then Io.rewrite_facts_atomically ~keeper_id survivors;
+      if not dry_run then Io.rewrite_facts_atomically ?keepers_dir ~keeper_id survivors;
       { total_input = List.length facts
       ; ttl_expired = List.length expired
       ; dedup_removed = List.length live - List.length deduped

--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -76,7 +76,15 @@ let dedup_by_claim items =
    discard ([decide_retention] on [score_fact <= 0.02]) was removed: a fact's
    value is not a number GC can threshold. Forgetting is the librarian's
    delete-on-contradiction judgment plus this structural TTL, not a low score. *)
-let run_gc ?keepers_dir ?(dry_run = false) ~keeper_id ~now () =
+let run_gc_with_store
+      ~facts_path
+      ~read_facts_all_strict
+      ~rewrite_facts_atomically
+      ?(dry_run = false)
+      ~keeper_id
+      ~now
+      ()
+  =
   (* Serialize the whole read-modify-rewrite on the same per-keeper facts lock the
      librarian write path (Keeper_librarian_runtime, wrapping merge_and_cap_facts)
      and the consolidation runtime already hold on facts_path. Without it, a
@@ -92,7 +100,7 @@ let run_gc ?keepers_dir ?(dry_run = false) ~keeper_id ~now () =
      File_lock_eio already offloads the blocking flock so the Eio domain is not
      stalled. Must run inside an Eio context (the maintenance fiber and tests
      both are). *)
-  File_lock_eio.with_lock (Io.facts_path ?keepers_dir ~keeper_id) (fun () ->
+  File_lock_eio.with_lock facts_path (fun () ->
     (* Read strictly: a malformed JSONL row aborts the sweep rather than being
        silently dropped by the lenient decoder and then erased by the rewrite
        below. Every other destructive rewrite path already refuses to overwrite a
@@ -102,7 +110,7 @@ let run_gc ?keepers_dir ?(dry_run = false) ~keeper_id ~now () =
        into permanent deletion of the surrounding facts (it read via the lenient
        read_facts_all). Preserve over delete: leave a corrupt store untouched and
        let the raised error surface so an operator can repair it. *)
-    match Io.read_facts_all_strict ?keepers_dir ~keeper_id with
+    match read_facts_all_strict () with
     | Error message ->
       raise (Fact_store_corrupt ("memory os gc fact store read failed: " ^ message))
     | Ok facts ->
@@ -112,11 +120,35 @@ let run_gc ?keepers_dir ?(dry_run = false) ~keeper_id ~now () =
       in
       let deduped = dedup_by_claim live in
       let survivors = List.map (fun item -> item.fact) deduped in
-      if not dry_run then Io.rewrite_facts_atomically ?keepers_dir ~keeper_id survivors;
+      if not dry_run then rewrite_facts_atomically survivors;
       { total_input = List.length facts
       ; ttl_expired = List.length expired
       ; dedup_removed = List.length live - List.length deduped
       ; written = List.length survivors
       ; dry_run
       })
+;;
+
+let run_gc ?dry_run ~keeper_id ~now () =
+  run_gc_with_store
+    ~facts_path:(Io.facts_path ~keeper_id)
+    ~read_facts_all_strict:(fun () -> Io.read_facts_all_strict ~keeper_id)
+    ~rewrite_facts_atomically:(fun facts -> Io.rewrite_facts_atomically ~keeper_id facts)
+    ?dry_run
+    ~keeper_id
+    ~now
+    ()
+;;
+
+let run_gc_for_keepers_dir ~keepers_dir ?dry_run ~keeper_id ~now () =
+  run_gc_with_store
+    ~facts_path:(Io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+    ~read_facts_all_strict:(fun () ->
+      Io.read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id)
+    ~rewrite_facts_atomically:(fun facts ->
+      Io.rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts)
+    ?dry_run
+    ~keeper_id
+    ~now
+    ()
 ;;

--- a/lib/keeper/keeper_memory_os_gc.mli
+++ b/lib/keeper/keeper_memory_os_gc.mli
@@ -25,7 +25,14 @@ val ttl_expired : now:float -> fact -> bool
     malformed JSONL row raises [Fact_store_corrupt] and leaves the store
     untouched rather than dropping the bad row and overwriting the survivors. *)
 val run_gc
-  :  ?keepers_dir:string
+  :  ?dry_run:bool
+  -> keeper_id:string
+  -> now:float
+  -> unit
+  -> gc_report
+
+val run_gc_for_keepers_dir
+  :  keepers_dir:string
   -> ?dry_run:bool
   -> keeper_id:string
   -> now:float

--- a/lib/keeper/keeper_memory_os_gc.mli
+++ b/lib/keeper/keeper_memory_os_gc.mli
@@ -25,7 +25,8 @@ val ttl_expired : now:float -> fact -> bool
     malformed JSONL row raises [Fact_store_corrupt] and leaves the store
     untouched rather than dropping the bad row and overwriting the survivors. *)
 val run_gc
-  :  ?dry_run:bool
+  :  ?keepers_dir:string
+  -> ?dry_run:bool
   -> keeper_id:string
   -> now:float
   -> unit

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -25,17 +25,10 @@ let rec ensure_dir path =
 
 let keepers_dir_override : string option ref = ref None
 
-let resolved_keepers_dir ?keepers_dir () =
-  match keepers_dir with
-  | Some path -> path
-  | None ->
-    (match !keepers_dir_override with
-     | Some path -> path
-     | None -> Config_dir_resolver.keepers_dir ())
-;;
-
 let keepers_dir () =
-  resolved_keepers_dir ()
+  match !keepers_dir_override with
+  | Some path -> path
+  | None -> Config_dir_resolver.keepers_dir ()
 ;;
 
 module For_testing = struct
@@ -49,8 +42,12 @@ module For_testing = struct
   ;;
 end
 
-let facts_path ?keepers_dir ~keeper_id =
-  Filename.concat (resolved_keepers_dir ?keepers_dir ()) (keeper_id ^ ".facts.jsonl")
+let facts_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  Filename.concat keepers_dir (keeper_id ^ ".facts.jsonl")
+;;
+
+let facts_path ~keeper_id =
+  facts_path_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
 
 (* RFC-0244 Tier 2: the keeper ids that currently have a Tier-1 fact store, for
@@ -59,8 +56,8 @@ let facts_path ?keepers_dir ~keeper_id =
    keepers with persisted facts. The reserved shared id is excluded so a prior
    sweep's output is never folded back in as a source keeper. Sorted for
    deterministic sweep order. *)
-let list_fact_store_keeper_ids ?keepers_dir () =
-  let dir = resolved_keepers_dir ?keepers_dir () in
+let list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir =
+  let dir = keepers_dir in
   if not (Sys.file_exists dir && Sys.is_directory dir)
   then []
   else
@@ -73,8 +70,16 @@ let list_fact_store_keeper_ids ?keepers_dir () =
     |> List.sort String.compare
 ;;
 
-let events_path ?keepers_dir ~keeper_id =
-  Filename.concat (resolved_keepers_dir ?keepers_dir ()) (keeper_id ^ ".events.jsonl")
+let list_fact_store_keeper_ids () =
+  list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir:(keepers_dir ())
+;;
+
+let events_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  Filename.concat keepers_dir (keeper_id ^ ".events.jsonl")
+;;
+
+let events_path ~keeper_id =
+  events_path_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
 
 let episode_bundle_lock_path ~keeper_id =
@@ -269,8 +274,8 @@ let append_episode_bundle ~keeper_id episode =
     append_event ~keeper_id episode)
 ;;
 
-let rewrite_facts_atomically ?keepers_dir ~keeper_id facts =
-  let path = facts_path ?keepers_dir ~keeper_id in
+let rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts =
+  let path = facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
   let content =
     facts
     |> List.map (fun fact -> fact_to_json fact |> Yojson.Safe.to_string)
@@ -278,6 +283,10 @@ let rewrite_facts_atomically ?keepers_dir ~keeper_id facts =
   in
   let content = if String.equal content "" then "" else content ^ "\n" in
   write_file_atomically path content
+;;
+
+let rewrite_facts_atomically ~keeper_id facts =
+  rewrite_facts_atomically_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id facts
 ;;
 
 (* ---------- Facts snapshot CAS (optimistic concurrency) ---------- *)
@@ -427,13 +436,17 @@ let parse_fact_json_line_strict ~path ~line_number line =
     Error (Printf.sprintf "%s:%d: invalid fact JSON: %s" path line_number message)
 ;;
 
-let read_facts_all ?keepers_dir ~keeper_id =
-  read_lines_all (facts_path ?keepers_dir ~keeper_id)
+let read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id =
+  read_lines_all (facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
   |> List.filter_map (parse_json_line fact_of_json)
 ;;
 
-let read_facts_all_strict ?keepers_dir ~keeper_id =
-  let path = facts_path ?keepers_dir ~keeper_id in
+let read_facts_all ~keeper_id =
+  read_facts_all_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
+;;
+
+let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
+  let path = facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
   let rec loop line_number acc = function
     | [] -> Ok (List.rev acc)
     | line :: rest ->
@@ -441,6 +454,10 @@ let read_facts_all_strict ?keepers_dir ~keeper_id =
       loop (line_number + 1) (fact :: acc) rest
   in
   loop 1 [] (read_lines_all path)
+;;
+
+let read_facts_all_strict ~keeper_id =
+  read_facts_all_strict_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
 let read_facts_tail ~keeper_id ~n =
   read_lines_tail (facts_path ~keeper_id) ~n

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -25,10 +25,17 @@ let rec ensure_dir path =
 
 let keepers_dir_override : string option ref = ref None
 
-let keepers_dir () =
-  match !keepers_dir_override with
+let resolved_keepers_dir ?keepers_dir () =
+  match keepers_dir with
   | Some path -> path
-  | None -> Config_dir_resolver.keepers_dir ()
+  | None ->
+    (match !keepers_dir_override with
+     | Some path -> path
+     | None -> Config_dir_resolver.keepers_dir ())
+;;
+
+let keepers_dir () =
+  resolved_keepers_dir ()
 ;;
 
 module For_testing = struct
@@ -42,8 +49,8 @@ module For_testing = struct
   ;;
 end
 
-let facts_path ~keeper_id =
-  Filename.concat (keepers_dir ()) (keeper_id ^ ".facts.jsonl")
+let facts_path ?keepers_dir ~keeper_id =
+  Filename.concat (resolved_keepers_dir ?keepers_dir ()) (keeper_id ^ ".facts.jsonl")
 ;;
 
 (* RFC-0244 Tier 2: the keeper ids that currently have a Tier-1 fact store, for
@@ -52,8 +59,8 @@ let facts_path ~keeper_id =
    keepers with persisted facts. The reserved shared id is excluded so a prior
    sweep's output is never folded back in as a source keeper. Sorted for
    deterministic sweep order. *)
-let list_fact_store_keeper_ids () =
-  let dir = keepers_dir () in
+let list_fact_store_keeper_ids ?keepers_dir () =
+  let dir = resolved_keepers_dir ?keepers_dir () in
   if not (Sys.file_exists dir && Sys.is_directory dir)
   then []
   else
@@ -66,8 +73,8 @@ let list_fact_store_keeper_ids () =
     |> List.sort String.compare
 ;;
 
-let events_path ~keeper_id =
-  Filename.concat (keepers_dir ()) (keeper_id ^ ".events.jsonl")
+let events_path ?keepers_dir ~keeper_id =
+  Filename.concat (resolved_keepers_dir ?keepers_dir ()) (keeper_id ^ ".events.jsonl")
 ;;
 
 let episode_bundle_lock_path ~keeper_id =
@@ -262,8 +269,8 @@ let append_episode_bundle ~keeper_id episode =
     append_event ~keeper_id episode)
 ;;
 
-let rewrite_facts_atomically ~keeper_id facts =
-  let path = facts_path ~keeper_id in
+let rewrite_facts_atomically ?keepers_dir ~keeper_id facts =
+  let path = facts_path ?keepers_dir ~keeper_id in
   let content =
     facts
     |> List.map (fun fact -> fact_to_json fact |> Yojson.Safe.to_string)
@@ -420,13 +427,13 @@ let parse_fact_json_line_strict ~path ~line_number line =
     Error (Printf.sprintf "%s:%d: invalid fact JSON: %s" path line_number message)
 ;;
 
-let read_facts_all ~keeper_id =
-  read_lines_all (facts_path ~keeper_id)
+let read_facts_all ?keepers_dir ~keeper_id =
+  read_lines_all (facts_path ?keepers_dir ~keeper_id)
   |> List.filter_map (parse_json_line fact_of_json)
 ;;
 
-let read_facts_all_strict ~keeper_id =
-  let path = facts_path ~keeper_id in
+let read_facts_all_strict ?keepers_dir ~keeper_id =
+  let path = facts_path ?keepers_dir ~keeper_id in
   let rec loop line_number acc = function
     | [] -> Ok (List.rev acc)
     | line :: rest ->

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -7,13 +7,16 @@ open Keeper_memory_os_types
 
 (** {1 Path helpers} *)
 
-val facts_path : ?keepers_dir:string -> keeper_id:string -> string
+val facts_path : keeper_id:string -> string
+val facts_path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> string
 
 (** RFC-0244 Tier 2: keeper ids that currently have a [*.facts.jsonl] store, for
     the cross-keeper consolidation sweep. Excludes the reserved shared id; sorted. *)
-val list_fact_store_keeper_ids : ?keepers_dir:string -> unit -> string list
+val list_fact_store_keeper_ids : unit -> string list
+val list_fact_store_keeper_ids_for_keepers_dir : keepers_dir:string -> string list
 
-val events_path : ?keepers_dir:string -> keeper_id:string -> string
+val events_path : keeper_id:string -> string
+val events_path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> string
 val episodes_dir : keeper_id:string -> string
 val tool_results_dir : keeper_id:string -> string
 val tool_result_path : keeper_id:string -> tool_call_id:string -> string
@@ -50,7 +53,9 @@ val with_episode_bundle_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t -> keeper_id:string -> (unit -> 'a) -> 'a
 
 val append_episode_bundle : keeper_id:string -> episode -> unit
-val rewrite_facts_atomically : ?keepers_dir:string -> keeper_id:string -> fact list -> unit
+val rewrite_facts_atomically : keeper_id:string -> fact list -> unit
+val rewrite_facts_atomically_for_keepers_dir :
+  keepers_dir:string -> keeper_id:string -> fact list -> unit
 
 (** {1 Facts snapshot CAS} *)
 
@@ -80,11 +85,14 @@ val load_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t 
 
 (** {1 Bounded tail reads} *)
 
-val read_facts_all : ?keepers_dir:string -> keeper_id:string -> fact list
+val read_facts_all : keeper_id:string -> fact list
+val read_facts_all_for_keepers_dir : keepers_dir:string -> keeper_id:string -> fact list
 (** Read every fact in the store, failing if any JSONL row is malformed or does
     not match the fact schema. Use this before destructive rewrites so corrupt
     input cannot be partially dropped and overwritten. *)
-val read_facts_all_strict : ?keepers_dir:string -> keeper_id:string -> (fact list, string) result
+val read_facts_all_strict : keeper_id:string -> (fact list, string) result
+val read_facts_all_strict_for_keepers_dir :
+  keepers_dir:string -> keeper_id:string -> (fact list, string) result
 val read_facts_tail : keeper_id:string -> n:int -> fact list
 val read_events_tail : keeper_id:string -> n:int -> episode list
 val read_episodes_tail : keeper_id:string -> n:int -> episode list

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -7,13 +7,13 @@ open Keeper_memory_os_types
 
 (** {1 Path helpers} *)
 
-val facts_path : keeper_id:string -> string
+val facts_path : ?keepers_dir:string -> keeper_id:string -> string
 
 (** RFC-0244 Tier 2: keeper ids that currently have a [*.facts.jsonl] store, for
     the cross-keeper consolidation sweep. Excludes the reserved shared id; sorted. *)
-val list_fact_store_keeper_ids : unit -> string list
+val list_fact_store_keeper_ids : ?keepers_dir:string -> unit -> string list
 
-val events_path : keeper_id:string -> string
+val events_path : ?keepers_dir:string -> keeper_id:string -> string
 val episodes_dir : keeper_id:string -> string
 val tool_results_dir : keeper_id:string -> string
 val tool_result_path : keeper_id:string -> tool_call_id:string -> string
@@ -50,7 +50,7 @@ val with_episode_bundle_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t -> keeper_id:string -> (unit -> 'a) -> 'a
 
 val append_episode_bundle : keeper_id:string -> episode -> unit
-val rewrite_facts_atomically : keeper_id:string -> fact list -> unit
+val rewrite_facts_atomically : ?keepers_dir:string -> keeper_id:string -> fact list -> unit
 
 (** {1 Facts snapshot CAS} *)
 
@@ -80,11 +80,11 @@ val load_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t 
 
 (** {1 Bounded tail reads} *)
 
-val read_facts_all : keeper_id:string -> fact list
+val read_facts_all : ?keepers_dir:string -> keeper_id:string -> fact list
 (** Read every fact in the store, failing if any JSONL row is malformed or does
     not match the fact schema. Use this before destructive rewrites so corrupt
     input cannot be partially dropped and overwritten. *)
-val read_facts_all_strict : keeper_id:string -> (fact list, string) result
+val read_facts_all_strict : ?keepers_dir:string -> keeper_id:string -> (fact list, string) result
 val read_facts_tail : keeper_id:string -> n:int -> fact list
 val read_events_tail : keeper_id:string -> n:int -> episode list
 val read_episodes_tail : keeper_id:string -> n:int -> episode list

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -1,0 +1,138 @@
+(** Keeper Memory Health dashboard HTTP JSON helper.
+
+    Produces a read-only snapshot of per-keeper fact-store sizes, GC-dry-run
+    statistics, and the fleet-wide librarian cadence counter for the
+    /api/v1/dashboard/keeper-memory-health endpoint.
+
+    Data sources:
+    - [Keeper_memory_os_io.list_fact_store_keeper_ids] for the keeper list.
+    - [Keeper_memory_os_io.read_facts_all] and file stat for facts count/bytes.
+    - [Keeper_memory_os_io.events_path] + file stat for events bytes.
+    - [Keeper_memory_os_gc.run_gc ~dry_run:true] for TTL-expired and
+      near-duplicate counts without mutating the store.
+    - [Keeper_librarian_runtime.cadence_counter_entries] for the cadence table
+      size (one fleet-wide value). *)
+
+type keeper_health =
+  { keeper_id : string
+  ; facts : int
+  ; facts_bytes : int
+  ; events : int
+  ; events_bytes : int
+  ; events_to_facts_ratio : float
+  ; ttl_expired_on_disk : int
+  ; near_duplicate : int
+  ; external_ref : int
+  }
+
+let count_lines_in_file path =
+  (* NDT-OK: file line count is a read-only diagnostic metric, not a control
+     value. Streams the file so a large append-only events log is not loaded
+     into memory just to be counted. *)
+  if not (Sys.file_exists path)
+  then 0
+  else (
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let count = ref 0 in
+         (try
+            while true do
+              let _ = input_line ic in
+              incr count
+            done
+          with
+          | End_of_file -> ());
+         !count))
+;;
+
+let file_size_bytes path =
+  (* NDT-OK: file size is a diagnostic metric. *)
+  if not (Sys.file_exists path) then 0 else (Unix.stat path).Unix.st_size
+;;
+
+let count_external_ref_facts facts =
+  List.fold_left
+    (fun acc (f : Keeper_memory_os_types.fact) ->
+       if Option.is_some f.external_ref then acc + 1 else acc)
+    0
+    facts
+;;
+
+let keeper_health ~now keeper_id =
+  let facts_count, external_ref_count =
+    (* [read_facts_all] raises on malformed JSONL — treated as a read failure
+       for this keeper; the caller catches and skips it. *)
+    let fs = Keeper_memory_os_io.read_facts_all ~keeper_id in
+    List.length fs, count_external_ref_facts fs
+  in
+  let facts_bytes = file_size_bytes (Keeper_memory_os_io.facts_path ~keeper_id) in
+  let events_p = Keeper_memory_os_io.events_path ~keeper_id in
+  let events_bytes = file_size_bytes events_p in
+  (* dry_run keeps the scan read-only: it reports what TTL-expiry + dedup WOULD
+     prune without rewriting the store. *)
+  let gc_report = Keeper_memory_os_gc.run_gc ~dry_run:true ~keeper_id ~now () in
+  { keeper_id
+  ; facts = facts_count
+  ; facts_bytes
+  ; events = count_lines_in_file events_p
+  ; events_bytes
+  ; events_to_facts_ratio =
+      float_of_int events_bytes /. float_of_int (max 1 facts_bytes)
+  ; ttl_expired_on_disk = gc_report.ttl_expired
+  ; near_duplicate = gc_report.dedup_removed
+  ; external_ref = external_ref_count
+  }
+;;
+
+let keeper_health_to_json h : Yojson.Safe.t =
+  `Assoc
+    [ "keeper_id", `String h.keeper_id
+    ; "facts", `Int h.facts
+    ; "facts_bytes", `Int h.facts_bytes
+    ; "events", `Int h.events
+    ; "events_bytes", `Int h.events_bytes
+    ; "events_to_facts_ratio", `Float h.events_to_facts_ratio
+    ; "ttl_expired_on_disk", `Int h.ttl_expired_on_disk
+    ; "near_duplicate", `Int h.near_duplicate
+    ; "external_ref", `Int h.external_ref
+    ]
+;;
+
+let keeper_memory_health_http_json () : Yojson.Safe.t =
+  (* NDT-OK: one wall-clock instant for the whole snapshot — used as the
+     generated_at timestamp and as the [now] each per-keeper dry-run GC scans
+     against; no retention or control logic depends on the exact value. *)
+  let now = Unix.gettimeofday () in
+  let cadence_counter_entries = Keeper_librarian_runtime.cadence_counter_entries () in
+  let entries =
+    Keeper_memory_os_io.list_fact_store_keeper_ids ()
+    |> List.filter_map (fun keeper_id ->
+      match keeper_health ~now keeper_id with
+      | h -> Some h
+      | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+      | exception exn ->
+        Log.Dashboard.warn
+          "[keeper_memory_health] skipping keeper %s: %s"
+          keeper_id
+          (Printexc.to_string exn);
+        None)
+    (* Largest stores first so the worst offenders surface at the top. *)
+    |> List.sort (fun a b -> compare b.facts_bytes a.facts_bytes)
+  in
+  let sum f = List.fold_left (fun acc h -> acc + f h) 0 entries in
+  `Assoc
+    [ "generated_at", `Float now
+    ; "cadence_counter_entries", `Int cadence_counter_entries
+    ; "keepers", `List (List.map keeper_health_to_json entries)
+    ; ( "totals"
+      , `Assoc
+          [ "facts", `Int (sum (fun h -> h.facts))
+          ; "facts_bytes", `Int (sum (fun h -> h.facts_bytes))
+          ; "events_bytes", `Int (sum (fun h -> h.events_bytes))
+          ; "ttl_expired_on_disk", `Int (sum (fun h -> h.ttl_expired_on_disk))
+          ; "near_duplicate", `Int (sum (fun h -> h.near_duplicate))
+          ] )
+    ]
+;;

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -65,18 +65,28 @@ let keeper_health ~keepers_dir ~now keeper_id =
   let facts_count, external_ref_count =
     (* [read_facts_all] raises on malformed JSONL — treated as a read failure
        for this keeper; the caller catches and skips it. *)
-    let fs = Keeper_memory_os_io.read_facts_all ~keepers_dir ~keeper_id in
+    let fs =
+      Keeper_memory_os_io.read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id
+    in
     List.length fs, count_external_ref_facts fs
   in
   let facts_bytes =
-    file_size_bytes (Keeper_memory_os_io.facts_path ~keepers_dir ~keeper_id)
+    file_size_bytes
+      (Keeper_memory_os_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
   in
-  let events_p = Keeper_memory_os_io.events_path ~keepers_dir ~keeper_id in
+  let events_p =
+    Keeper_memory_os_io.events_path_for_keepers_dir ~keepers_dir ~keeper_id
+  in
   let events_bytes = file_size_bytes events_p in
   (* dry_run keeps the scan read-only: it reports what TTL-expiry + dedup WOULD
      prune without rewriting the store. *)
   let gc_report =
-    Keeper_memory_os_gc.run_gc ~keepers_dir ~dry_run:true ~keeper_id ~now ()
+    Keeper_memory_os_gc.run_gc_for_keepers_dir
+      ~keepers_dir
+      ~dry_run:true
+      ~keeper_id
+      ~now
+      ()
   in
   { keeper_id
   ; facts = facts_count
@@ -113,7 +123,7 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
   let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path in
   let cadence_counter_entries = Keeper_librarian_runtime.cadence_counter_entries () in
   let entries =
-    Keeper_memory_os_io.list_fact_store_keeper_ids ~keepers_dir ()
+    Keeper_memory_os_io.list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir
     |> List.filter_map (fun keeper_id ->
       match keeper_health ~keepers_dir ~now keeper_id with
       | h -> Some h

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -106,9 +106,9 @@ let keeper_health_to_json h : Yojson.Safe.t =
 ;;
 
 let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
-  (* NDT-OK: one wall-clock instant for the whole snapshot — used as the
-     generated_at timestamp and as the [now] each per-keeper dry-run GC scans
-     against; no retention or control logic depends on the exact value. *)
+  (* One wall-clock instant is shared by the snapshot timestamp and dry-run GC
+     scans; no retention or control logic depends on the exact value. *)
+  (* NDT-OK: diagnostic snapshot timestamp only. *)
   let now = Unix.gettimeofday () in
   let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path in
   let cadence_counter_entries = Keeper_librarian_runtime.cadence_counter_entries () in

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -5,6 +5,7 @@
     /api/v1/dashboard/keeper-memory-health endpoint.
 
     Data sources:
+    - [Config_dir_resolver.keepers_dir_for_base_path] for request-scoped paths.
     - [Keeper_memory_os_io.list_fact_store_keeper_ids] for the keeper list.
     - [Keeper_memory_os_io.read_facts_all] and file stat for facts count/bytes.
     - [Keeper_memory_os_io.events_path] + file stat for events bytes.
@@ -60,19 +61,23 @@ let count_external_ref_facts facts =
     facts
 ;;
 
-let keeper_health ~now keeper_id =
+let keeper_health ~keepers_dir ~now keeper_id =
   let facts_count, external_ref_count =
     (* [read_facts_all] raises on malformed JSONL — treated as a read failure
        for this keeper; the caller catches and skips it. *)
-    let fs = Keeper_memory_os_io.read_facts_all ~keeper_id in
+    let fs = Keeper_memory_os_io.read_facts_all ~keepers_dir ~keeper_id in
     List.length fs, count_external_ref_facts fs
   in
-  let facts_bytes = file_size_bytes (Keeper_memory_os_io.facts_path ~keeper_id) in
-  let events_p = Keeper_memory_os_io.events_path ~keeper_id in
+  let facts_bytes =
+    file_size_bytes (Keeper_memory_os_io.facts_path ~keepers_dir ~keeper_id)
+  in
+  let events_p = Keeper_memory_os_io.events_path ~keepers_dir ~keeper_id in
   let events_bytes = file_size_bytes events_p in
   (* dry_run keeps the scan read-only: it reports what TTL-expiry + dedup WOULD
      prune without rewriting the store. *)
-  let gc_report = Keeper_memory_os_gc.run_gc ~dry_run:true ~keeper_id ~now () in
+  let gc_report =
+    Keeper_memory_os_gc.run_gc ~keepers_dir ~dry_run:true ~keeper_id ~now ()
+  in
   { keeper_id
   ; facts = facts_count
   ; facts_bytes
@@ -100,16 +105,17 @@ let keeper_health_to_json h : Yojson.Safe.t =
     ]
 ;;
 
-let keeper_memory_health_http_json () : Yojson.Safe.t =
+let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
   (* NDT-OK: one wall-clock instant for the whole snapshot — used as the
      generated_at timestamp and as the [now] each per-keeper dry-run GC scans
      against; no retention or control logic depends on the exact value. *)
   let now = Unix.gettimeofday () in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path in
   let cadence_counter_entries = Keeper_librarian_runtime.cadence_counter_entries () in
   let entries =
-    Keeper_memory_os_io.list_fact_store_keeper_ids ()
+    Keeper_memory_os_io.list_fact_store_keeper_ids ~keepers_dir ()
     |> List.filter_map (fun keeper_id ->
-      match keeper_health ~now keeper_id with
+      match keeper_health ~keepers_dir ~now keeper_id with
       | h -> Some h
       | exception (Eio.Cancel.Cancelled _ as e) -> raise e
       | exception exn ->

--- a/lib/server/server_dashboard_http_keeper_memory_health.mli
+++ b/lib/server/server_dashboard_http_keeper_memory_health.mli
@@ -4,4 +4,4 @@
     statistics, and the fleet-wide librarian cadence counter for the
     /api/v1/dashboard/keeper-memory-health endpoint. *)
 
-val keeper_memory_health_http_json : unit -> Yojson.Safe.t
+val keeper_memory_health_http_json : base_path:string -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_keeper_memory_health.mli
+++ b/lib/server/server_dashboard_http_keeper_memory_health.mli
@@ -1,0 +1,7 @@
+(** Keeper Memory Health dashboard HTTP JSON helper.
+
+    Produces a read-only snapshot of per-keeper fact-store sizes, GC-dry-run
+    statistics, and the fleet-wide librarian cadence counter for the
+    /api/v1/dashboard/keeper-memory-health endpoint. *)
+
+val keeper_memory_health_http_json : unit -> Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -611,6 +611,16 @@ let add_routes ~sw ~clock router =
            (fun state _agent_name req reqd -> handler state req reqd)
            request reqd
        else with_public_read handler request reqd)
+  |> Http.Router.get "/api/v1/dashboard/keeper-memory-health" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let cache_key = "keeper_memory_health" in
+         let json =
+           Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
+             Domain_pool_ref.submit_io_or_inline (fun () ->
+               Server_dashboard_http_keeper_memory_health.keeper_memory_health_http_json ()))
+         in
+         Http.Response.json_value ~compress:true ~request:req json reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/governance" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let base_path = (Mcp_server.workspace_config state).base_path in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -612,12 +612,14 @@ let add_routes ~sw ~clock router =
            request reqd
        else with_public_read handler request reqd)
   |> Http.Router.get "/api/v1/dashboard/keeper-memory-health" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
-         let cache_key = "keeper_memory_health" in
+       with_public_read (fun state req reqd ->
+         let base_path = (Mcp_server.workspace_config state).base_path in
+         let cache_key = Printf.sprintf "keeper_memory_health:%s" base_path in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
              Domain_pool_ref.submit_io_or_inline (fun () ->
-               Server_dashboard_http_keeper_memory_health.keeper_memory_health_http_json ()))
+               Server_dashboard_http_keeper_memory_health.keeper_memory_health_http_json
+                 ~base_path))
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)

--- a/test/dune
+++ b/test/dune
@@ -113,6 +113,7 @@
   test_dashboard_tool_host_events
   test_dashboard_nav_event
   test_server_dashboard_http_memory_subsystems
+  test_server_dashboard_http_keeper_memory_health
   test_dashboard_execute_output
   test_tool_assignment_telemetry
   test_dashboard_link_preview

--- a/test/dune
+++ b/test/dune
@@ -414,6 +414,7 @@
   test_dashboard_tool_host_events
   test_dashboard_nav_event
   test_server_dashboard_http_memory_subsystems
+  test_server_dashboard_http_keeper_memory_health
   test_dashboard_execute_output
   test_tool_assignment_telemetry
   test_dashboard_link_preview

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -2,7 +2,7 @@
 
 module Types = Masc.Keeper_memory_os_types
 module Io = Masc.Keeper_memory_os_io
-module Health = Masc.Server_dashboard_http_keeper_memory_health
+module Health = Server_dashboard_http_keeper_memory_health
 
 let fresh_dir prefix =
   let path = Filename.temp_file prefix ".dir" in

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -63,11 +63,11 @@ let test_uses_explicit_base_path_not_ambient_resolver () =
   let ambient_keepers_dir =
     Config_dir_resolver.keepers_dir_for_base_path ~base_path:ambient_base
   in
-  Io.rewrite_facts_atomically
+  Io.rewrite_facts_atomically_for_keepers_dir
     ~keepers_dir:target_keepers_dir
     ~keeper_id:"target"
     [ fact ~now "target workspace fact" ];
-  Io.rewrite_facts_atomically
+  Io.rewrite_facts_atomically_for_keepers_dir
     ~keepers_dir:ambient_keepers_dir
     ~keeper_id:"ambient"
     [ fact ~now "ambient workspace fact" ];

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -1,0 +1,88 @@
+(** Regression tests for the keeper memory-health dashboard helper. *)
+
+module Types = Masc.Keeper_memory_os_types
+module Io = Masc.Keeper_memory_os_io
+module Health = Masc.Server_dashboard_http_keeper_memory_health
+
+let fresh_dir prefix =
+  let path = Filename.temp_file prefix ".dir" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let fact ~now claim =
+  { Types.claim
+  ; Types.category = Types.Fact
+  ; Types.external_ref = None
+  ; Types.source = { Types.trace_id = "health-test"; Types.turn = 1; Types.tool_call_id = None }
+  ; Types.observed_by = []
+  ; Types.first_seen = now
+  ; Types.valid_until = None
+  ; Types.last_verified_at = Some now
+  ; Types.schema_version = Types.schema_version
+  }
+;;
+
+let keeper_ids json =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "keepers" fields with
+     | Some (`List keepers) ->
+       List.filter_map
+         (function
+           | `Assoc keeper_fields ->
+             (match List.assoc_opt "keeper_id" keeper_fields with
+              | Some (`String id) -> Some id
+              | _ -> None)
+           | _ -> None)
+         keepers
+     | _ -> [])
+  | _ -> []
+;;
+
+let with_env name value f =
+  let old = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.putenv name (Option.value old ~default:"");
+      Config_dir_resolver.reset ())
+    f
+;;
+
+let test_uses_explicit_base_path_not_ambient_resolver () =
+  Eio_main.run
+  @@ fun _env ->
+  let now = 1_700_000_000.0 in
+  let target_base = fresh_dir "masc-memory-health-target" in
+  let ambient_base = fresh_dir "masc-memory-health-ambient" in
+  let target_keepers_dir =
+    Config_dir_resolver.keepers_dir_for_base_path ~base_path:target_base
+  in
+  let ambient_keepers_dir =
+    Config_dir_resolver.keepers_dir_for_base_path ~base_path:ambient_base
+  in
+  Io.rewrite_facts_atomically
+    ~keepers_dir:target_keepers_dir
+    ~keeper_id:"target"
+    [ fact ~now "target workspace fact" ];
+  Io.rewrite_facts_atomically
+    ~keepers_dir:ambient_keepers_dir
+    ~keeper_id:"ambient"
+    [ fact ~now "ambient workspace fact" ];
+  with_env "MASC_BASE_PATH" ambient_base (fun () ->
+    let json = Health.keeper_memory_health_http_json ~base_path:target_base in
+    Alcotest.(check (list string)) "explicit base-path keeper ids" [ "target" ] (keeper_ids json))
+;;
+
+let () =
+  Alcotest.run
+    "server_dashboard_http_keeper_memory_health"
+    [ ( "paths"
+      , [ Alcotest.test_case
+            "uses explicit request base path instead of ambient resolver"
+            `Quick
+            test_uses_explicit_base_path_not_ambient_resolver
+        ] )
+    ]


### PR DESCRIPTION
## 무엇을 / 왜

Keeper Memory OS 적대 감사가 식별한 누적 문제(GC default-off로 만료 fact 디스크 잔존, events.jsonl 무한 append, cadence 테이블 증식)를 **운영자가 관찰**할 수 있는 read-only Lab 패널을 추가합니다. 실제 수정(리소스 누수 #21787, 의미 변경 RFC 추적 #21789)을 **보완하는 observability harness**이며, 수정의 대체물이 아닙니다.

> base: `fix/memory-os-leak-fixes` (#21787) 위에 스택. `cadence_counter_entries` 메트릭을 재사용합니다.

## 지표 (per-keeper)
- facts 수 / bytes
- events:facts byte 비율 (높으면 행 강조 — events 로그가 fact store보다 훨씬 큼)
- TTL 만료(디스크) 수, 근접중복 수 — `run_gc ~dry_run:true`(store 무변경) 재사용
- external_ref fact 수
- fleet-wide librarian cadence-counter 테이블 크기

## 구현
- **백엔드**: `server_dashboard_http_keeper_memory_health`가 기존 producer만 조합(`list_fact_store_keeper_ids` / `read_facts_all` / `run_gc ~dry_run` / `cadence_counter_entries`). 메모리 의미 로직 신규 추가 없음. 라우트는 memory-subsystems 엔드포인트 패턴 그대로(`with_public_read`, `Dashboard_cache.get_or_compute ~ttl`, domain-pool IO, `json_value ~compress:true`).
- **프론트**: Lab 섹션 패널(`키퍼 메모리 상태`), `setupVisibleAutoRefresh`로 self-poll. nav surface + 백엔드 nav-event parity 갱신.

## 검증 (로컬)
- `scripts/check-dashboard-nav-event-parity.sh` → exit 0
- `pnpm run typecheck` (tsc --noEmit) → exit 0
- `vitest run src/config/navigation.test.ts` → 50 passed
- 백엔드 OCaml 빌드는 CI에서 검증

## 설계 노트
패널은 `run_gc ~dry_run:true`로 "GC가 켜지면 무엇을 prune할지"를 계산만 합니다(디스크 미변경). 이는 GC default-off 상태(#21789 C)에서 누적량을 노출하는 진단이며, 수정은 RFC-0259 P5에서 다룹니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
