### PR TITLE
fix(runtime-toml-editor): unify toast/discard copy to 적용 verb (#21749)

### DIFF
--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -155,7 +155,7 @@ describe('RuntimeTomlEditor', () => {
 
     await waitFor(() => {
       expect(apiMocks.saveRuntimeTomlConfig).toHaveBeenCalledWith(nextSource)
-      expect(container.textContent).toContain('저장됨')
+      expect(container.textContent).toContain('적용됨')
     })
     expect(saveButton.disabled).toBe(true)
     expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe(nextSource)

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -157,7 +157,7 @@ export function RuntimeTomlEditor() {
       const saved = await saveRuntimeTomlConfig(nextSourceText)
       setConfig(saved)
       setDraft(saved.source_text)
-      setNotice('저장됨')
+      setNotice('적용됨')
     } catch (err: unknown) {
       setError(errorToString(err))
     } finally {
@@ -170,7 +170,7 @@ export function RuntimeTomlEditor() {
       const confirmed =
         typeof window === 'undefined' ||
         typeof window.confirm !== 'function' ||
-        window.confirm('저장하지 않은 runtime.toml 변경을 버리고 다시 불러올까요?')
+        window.confirm('적용하지 않은 runtime.toml 변경을 버리고 다시 불러올까요?')
       if (!confirmed) return
     }
     await refresh()


### PR DESCRIPTION
Fixes #21749

After #21731 renamed the save button to 라이브 적용, the success toast still said 저장됨 and the discard-confirm dialog said 저장하지 않은. Both now use the 적용 (apply) verb for consistency.

Changes:
- `dashboard/src/components/runtime-toml-editor.ts:160` — `setNotice('적용됨')`
- `dashboard/src/components/runtime-toml-editor.ts:173` — confirm msg `적용하지 않은`