### PR TITLE
fix #21728: add mark_attention_resolved to Stream_overflow_send_failed branch

### DIFF
--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -504,6 +504,11 @@ let handle_message_create ~dispatch
                    channel_id
                    (Format.asprintf "%a" State.pp_send_error e))
           | Stream_overflow_send_failed _ ->
+              (match attention_event_id with
+               | Some event_id ->
+                   mark_attention_resolved ~base_dir ~keeper_name ~event_id
+                     ~reason:"discord_reply_partial_overflow"
+               | None -> ());
               Discord_observability.record_inbound_dispatch
                 Discord_observability.Reply_send_error;
               Discord_observability.record_reply


### PR DESCRIPTION
Fixes #21728

## Problem
`Stream_overflow_send_failed` branch in `server_discord_in_process_gateway.ml` did not call `mark_attention_resolved`, unlike the other 3 branches (`Stream_completed`, `Stream_not_started`, `Stream_final_edit_failed`). This caused attention_event to remain permanently in `triggered` state when Discord 2000-char overflow send fails.

## Fix
Added `mark_attention_resolved ~reason:"discord_reply_partial_overflow"` to the `Stream_overflow_send_failed` branch, matching the pattern used by the other branches.

## Verification
- [x] Edit applied: 5 lines added to `lib/server/server_discord_in_process_gateway.ml`
- [x] Committed and pushed to `issue_king/task-1447-fix-21728`
- [ ] CI checks pending