### PR TITLE
fix(fusion): normalize panel failure reasons

### DIFF
--- a/dashboard/src/components/board/fusion-evidence.ts
+++ b/dashboard/src/components/board/fusion-evidence.ts
@@ -50,6 +50,9 @@ function numberField(record: Record<string, unknown>, key: string): number | und
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
+// Legacy-only migration for board posts written before fusion_sink emitted
+// reason_detail/reason_code. Fusion board posts use a one-week TTL, so this
+// raw-constructor parser should be removed after that compatibility window.
 function decodeOcamlStringLiteral(value: string): string {
   return value
     .replace(/\\\\/g, '\u0000')

--- a/dashboard/src/components/board/fusion-evidence.ts
+++ b/dashboard/src/components/board/fusion-evidence.ts
@@ -6,6 +6,7 @@ type FusionPanelEntry = {
   model: string
   status: string
   answer?: string
+  reasonCode?: string
   reason?: string
   outputTokens?: number
 }
@@ -49,16 +50,46 @@ function numberField(record: Record<string, unknown>, key: string): number | und
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
+function decodeOcamlStringLiteral(value: string): string {
+  return value
+    .replace(/\\\\/g, '\u0000')
+    .replace(/\\"/g, '"')
+    .replace(/\\n/g, '\n')
+    .replace(/\\t/g, '\t')
+    .replace(/\u0000/g, '\\')
+}
+
+function normalizeProviderAttribution(model: string, reason: string): string {
+  const unknownPrefix = "Provider 'unknown'"
+  if (model === '?' || !reason.startsWith(unknownPrefix)) return reason
+  return `Provider '${model}'${reason.slice(unknownPrefix.length)}`
+}
+
+function normalizePanelReason(model: string, reason: string | undefined): string | undefined {
+  if (!reason) return undefined
+  const trimmed = reason.trim()
+  const providerMatch = trimmed.match(/^\(?\s*Fusion_types\.Provider_error\s+"([\s\S]*)"\s*\)?$/)
+  if (providerMatch) {
+    return normalizeProviderAttribution(model, decodeOcamlStringLiteral(providerMatch[1] ?? '').trim())
+  }
+  if (/^\(?\s*Fusion_types\.Timeout\s*\)?$/.test(trimmed)) return 'timeout'
+  if (/^\(?\s*Fusion_types\.Empty_response\s*\)?$/.test(trimmed)) return 'empty response'
+  return normalizeProviderAttribution(model, trimmed)
+}
+
 function parsePanel(meta: Record<string, unknown>): FusionPanelEntry[] {
   const panel = meta.panel
   if (!Array.isArray(panel)) return []
   return panel.flatMap((item) => {
     if (!isRecord(item)) return []
+    const model = stringField(item, 'model') ?? '?'
+    const reason = stringField(item, 'reason_detail') ?? stringField(item, 'reason')
     return [{
-      model: stringField(item, 'model') ?? '?',
+      model,
       status: stringField(item, 'status') ?? 'unknown',
       answer: stringField(item, 'answer'),
-      reason: stringField(item, 'reason'),
+      reasonCode: stringField(item, 'reason_code'),
+      reason: normalizePanelReason(model, reason),
       outputTokens: numberField(item, 'output_tokens'),
     }]
   })

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -666,7 +666,7 @@ describe('PostDetail', () => {
           {
             model: 'ollama_cloud.minimax-m3',
             status: 'failed',
-            reason: 'Timeout',
+            reason: '(Fusion_types.Provider_error\n   "Provider \'unknown\' timeout phase=http_operation: HTTP operation exceeded wall-clock timeout")',
           },
         ],
         judge: {
@@ -691,7 +691,9 @@ describe('PostDetail', () => {
     expect(evidence).toHaveTextContent('3,432 tok')
     expect(evidence).toHaveTextContent('Should we ship the fusion board renderer?')
     expect(evidence).toHaveTextContent('Panel one answer')
-    expect(evidence).toHaveTextContent('Timeout')
+    expect(evidence).toHaveTextContent("Provider 'ollama_cloud.minimax-m3' timeout phase=http_operation")
+    expect(evidence).not.toHaveTextContent('Fusion_types.Provider_error')
+    expect(evidence).not.toHaveTextContent("Provider 'unknown'")
     expect(evidence).toHaveTextContent('**[judge]** synthesis')
     expect(evidence).toHaveTextContent('Consensus')
     expect(evidence).toHaveTextContent('Judge synthesis answer')

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -45,7 +45,7 @@ let run ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question ~panel
   | Error reason ->
     Error
       (Printf.sprintf "judge build failed: %s"
-         (Fusion_types.show_panel_failure reason))
+         (Fusion_oas.panel_failure_detail ~runtime_id:judge_model reason))
   | Ok agent ->
     let prompt = compose_prompt ~question ~panel in
     (match

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -34,6 +34,16 @@ let provider_error_detail ~runtime_id detail =
     then detail
     else Printf.sprintf "%s: %s" runtime_id detail
 
+let panel_failure_code = function
+  | Fusion_types.Timeout -> "timeout"
+  | Fusion_types.Provider_error _ -> "provider_error"
+  | Fusion_types.Empty_response -> "empty_response"
+
+let panel_failure_detail ~runtime_id = function
+  | Fusion_types.Timeout -> "timeout"
+  | Fusion_types.Provider_error detail -> provider_error_detail ~runtime_id detail
+  | Fusion_types.Empty_response -> "empty response"
+
 let timeout_budget_opt timeout_s =
   if Float.is_finite timeout_s && timeout_s > 0.0 then Some timeout_s else None
 

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -41,6 +41,12 @@ end
     panel/judge runtime id, so it patches that display boundary locally. *)
 val provider_error_detail : runtime_id:string -> string -> string
 
+(** Stable machine-readable panel failure class. *)
+val panel_failure_code : Fusion_types.panel_failure -> string
+
+(** Human-readable panel failure detail with runtime attribution when available. *)
+val panel_failure_detail : runtime_id:string -> Fusion_types.panel_failure -> string
+
 (** [masc_web_search] / [masc_web_fetch]를 [Agent_sdk.Tool.t]로 변환한 목록.
     [Keeper_tool_descriptor]에서 descriptor를 찾지 못하면 빈 목록을 반환한다. *)
 val web_tool_bundle : unit -> Agent_sdk.Tool.t list

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -89,10 +89,14 @@ let panel_meta (o : Fusion_types.panel_outcome) : Yojson.Safe.t =
       ; ("output_tokens", `Int usage.Fusion_types.output_tokens)
       ]
   | Fusion_types.Failed { failed_model; reason } ->
+    let reason_code = Fusion_oas.panel_failure_code reason in
+    let reason_detail = Fusion_oas.panel_failure_detail ~runtime_id:failed_model reason in
     `Assoc
       [ ("model", `String failed_model)
       ; ("status", `String "failed")
-      ; ("reason", `String (Fusion_types.show_panel_failure reason))
+      ; ("reason_code", `String reason_code)
+      ; ("reason_detail", `String reason_detail)
+      ; ("reason", `String reason_detail)
       ]
 
 (* 심판 결과를 board meta_json 원소로. *)

--- a/test/dune
+++ b/test/dune
@@ -128,7 +128,6 @@
   test_sse_stream
   test_health
   test_masc_oas_bridge_timeout_guard
-  test_fusion_oas_error_detail
   test_keeper_llm_bridge
   test_keeper_hooks_oas_log_shape
   test_keeper_idle_metric
@@ -428,7 +427,6 @@
   test_sse_stream
   test_health
   test_masc_oas_bridge_timeout_guard
-  test_fusion_oas_error_detail
   test_keeper_llm_bridge
   test_keeper_hooks_oas_log_shape
   test_keeper_idle_metric
@@ -648,6 +646,13 @@
  (name test_fusion_wake)
  (modules test_fusion_wake)
  (libraries masc_test_deps))
+
+; Fusion OAS failure-detail tests need Fusion_types constructors from
+; masc.fusion_core, which is intentionally not re-exported via masc.
+(test
+ (name test_fusion_oas_error_detail)
+ (modules test_fusion_oas_error_detail)
+ (libraries masc_test_deps masc.fusion_core))
 
 ; RFC-0266 Phase 3: masc_fusion_status tool — JSON projection of the run
 ; registry + keeper-LLM visibility (Pass B Default gate). Needs masc.fusion_core

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -49,6 +49,23 @@ let test_keeps_already_attributed_error () =
     detail
 ;;
 
+let test_panel_failure_detail_rewrites_unknown_provider () =
+  let detail =
+    Fusion_oas.panel_failure_detail ~runtime_id:"ollama_cloud.kimi-k2-6"
+      (Fusion_types.Provider_error
+         "Provider 'unknown' timeout phase=http_operation: HTTP operation exceeded wall-clock timeout")
+  in
+  Alcotest.(check string)
+    "panel failure detail"
+    "Provider 'ollama_cloud.kimi-k2-6' timeout phase=http_operation: HTTP operation exceeded wall-clock timeout"
+    detail;
+  Alcotest.(check string)
+    "panel failure code"
+    "provider_error"
+    (Fusion_oas.panel_failure_code
+       (Fusion_types.Provider_error "Provider 'unknown' timeout"))
+;;
+
 let test_timeout_budget_does_not_set_total_execution_ceiling () =
   let config =
     Fusion_oas.For_testing.apply_timeout_budget
@@ -85,6 +102,10 @@ let () =
             "keeps already attributed error"
             `Quick
             test_keeps_already_attributed_error
+        ; Alcotest.test_case
+            "panel failure detail rewrites unknown provider"
+            `Quick
+            test_panel_failure_detail_rewrites_unknown_provider
         ; Alcotest.test_case
             "timeout budget does not arm OAS total execution ceiling"
             `Quick


### PR DESCRIPTION
## Summary
- store Fusion failed-panel metadata as structured `reason_code` + human `reason_detail` instead of raw OCaml constructor output
- reuse Fusion runtime attribution so `Provider 'unknown'` timeout messages render with the panel runtime id
- normalize legacy board meta in the dashboard so existing posts stop showing `Fusion_types.Provider_error ... Provider 'unknown'`

## Verification
- `ocamlformat --check lib/fusion/fusion_oas.ml lib/fusion/fusion_oas.mli lib/fusion/fusion_sink.ml lib/fusion/fusion_judge.ml test/test_fusion_oas_error_detail.ml`
- `git diff --check origin/main..HEAD`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/board/post-detail.test.ts`

Local Dune build/test intentionally not run; Dune proof is delegated to CI per operator instruction.