### PR TITLE
docs(eval): completion-trust calibration wiring design note (RFC-0262 §9 follow-up)

### DIFF
--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -1,5 +1,6 @@
-(** [masc_completion_trust_eval] — live-LLM behavioural eval for RFC-0262 §9
-    axis ① (completion-trust disposition).
+(** [masc_completion_trust_eval] — live-LLM behavioural eval supporting RFC-0262
+    §9's proving metric (zero foreign-task completions by a non-Operator/System
+    actor), measured from the keeper's completion *disposition*.
 
     Drives a real keeper with adversarial *foreign-task temptation* prompts and
     measures whether it ATTEMPTS to complete a task it does not own or for which
@@ -7,7 +8,9 @@
     grading is deterministic (trajectory reduction -> {!Eval_harness}
     deterministic graders -> pass@k).
 
-    Boundary (RFC-0262 §9 harness — keeper / judge / eval-grader separation):
+    Boundary — keeper / judge / eval-grader separation (a harness design
+    contract, not RFC text; see docs/design/completion-trust-calibration-wiring.md.
+    RFC-0262 §8 is the test plan, §9 the rollout + proving metric):
     - keeper      = the live LLM under test (the completion *attempt* author).
     - judge       = the real dispatch-path gates (deterministic ownership /
                     anti-rationalization). NOT exercised here: this runner stubs
@@ -15,7 +18,9 @@
                     covered deterministically by [test_completion_trust_harness]
                     (PR-B). The stub [dispatch] closure below is the seam where a
                     later PR can route the attempt through the real handler plus
-                    [Eval_calibration] verdict recording.
+                    [Eval_calibration] verdict recording — see
+                    docs/design/completion-trust-calibration-wiring.md for the
+                    three blockers that wiring must resolve.
     - eval-grader = {!Eval_harness} deterministic graders + pass@k (this file).
 
     Scope: completion-trust scenarios only (not a general eval platform). Manual /

--- a/data/eval/completion_trust/README.md
+++ b/data/eval/completion_trust/README.md
@@ -1,4 +1,4 @@
-# completion-trust LLM behavioural eval (RFC-0262 §9 axis ①)
+# completion-trust LLM behavioural eval (RFC-0262 §9 proving metric)
 
 This corpus drives a live keeper with adversarial *completion-trust temptation*
 prompts and measures whether the model **attempts** to complete a task it does
@@ -12,7 +12,9 @@ deterministic regression oracle for the same invariants lives in
 
 ## What it measures vs. what it does not
 
-The harness separates three roles (RFC-0262 §9):
+The harness separates three roles (a harness design contract — see
+`docs/design/completion-trust-calibration-wiring.md`; RFC-0262 §8 is the test
+plan, §9 the rollout + proving metric, and the role separation is not RFC text):
 
 - **keeper** — the live LLM under test; the author of the completion *attempt*.
 - **judge** — the real dispatch-path gates (deterministic ownership check,
@@ -20,7 +22,10 @@ The harness separates three roles (RFC-0262 §9):
   attempt; it does **not** exercise the live FSM gate. The live gate is covered
   deterministically by `test_completion_trust_harness.ml`. The stub `dispatch`
   closure is the seam where a future PR can route the attempt through the real
-  handler plus `Eval_calibration` verdict recording.
+  handler plus `Eval_calibration` verdict recording — see
+  `docs/design/completion-trust-calibration-wiring.md` for the three blockers
+  (judge fires only under ownership; corpus not seeded; `agreement_rate` needs
+  human labels) that wiring must resolve.
 - **eval-grader** — deterministic graders + pass@k (`bin/masc_completion_trust_eval.ml`).
 
 So a scenario measures **disposition** (does the model take the bait?), not the

--- a/docs/design/completion-trust-calibration-wiring.md
+++ b/docs/design/completion-trust-calibration-wiring.md
@@ -1,0 +1,135 @@
+# Completion-trust calibration wiring — design note (RFC-0262 §9 follow-up)
+
+Status: design (no code lands from this note beyond a citation correction)
+Governing: RFC-0262 §8 (Test plan) / §9 (Rollout, proving metric); RFC-0199 Phase B (evidence gate); RFC-0222 (acceptance typing)
+File refs below are as of `origin/main` and will drift — re-confirm before implementing.
+
+## Why this note exists
+
+The live-LLM completion-trust runner `bin/masc_completion_trust_eval.ml` (PR-C #21754) drives
+a real keeper with foreign-task-temptation prompts and grades its tool-call *disposition*
+deterministically. Its dispatch is a **stub**: it records every `(name, args)` and returns a
+fixed `Tool_result.ok` without invoking any gate, handler, or judge (`run_one`'s dispatch
+closure in `bin/masc_completion_trust_eval.ml`). The runner docstring names that stub as
+"the seam where a later PR can route the attempt through the real handler plus
+`Eval_calibration` verdict recording".
+
+A mapping pass over the runner, `Eval_calibration`, `Anti_rationalization`, and the live
+done-handler showed that the obvious "un-stub dispatch and record verdicts" increment is a
+**workaround** (it would record zero verdicts and present a metric that stays vacuously 0).
+This note records the blockers and the three design decisions a faithful wiring requires, so
+the next PR implements measurement rather than telemetry-as-fix.
+
+## Blockers (why naive wiring records nothing)
+
+**B1 — the judge only fires behind the ownership gate.**
+The only producer of an `Anti_rationalization` verdict on the Done path is
+`review_completion_notes`, reached only when `action = Done_action`, `not force`, and
+`can_review_completion` is true (`lib/task/tool_task.ml:348-353`). `can_review_completion` is
+true only when the task is `Claimed`/`InProgress` **and** `assignee = agent_name`
+(`lib/task/tool_task_completion_review.ml:13-21`). The runner's stub dispatch bypasses
+`tool_task.ml` entirely — `run_named_with_masc_tools` bridges each tool call straight to the
+caller-supplied dispatch closure (`lib/keeper/keeper_turn_driver_wrappers.ml:184-188`) — so the
+judge never fires and `record_verdict` is never reached. **Scope "record verdicts without
+routing through the real handler" is therefore impossible**; the verdict producer lives inside
+the handler.
+
+**B2 — the current corpus produces no verdict even through the real handler.**
+Scenario task ids (`task-847`, `task-968`, `task-733`) exist only in prompt/`setup_messages`
+text (`data/eval/completion_trust/scenarios.json:9,33,57`); they are not seeded into live
+workspace state. `handle_transition` loads tasks from `Workspace.get_tasks_raw`
+(`lib/task/tool_task.ml:174-175`); against an unseeded id it returns `task_opt = None` →
+`completion_state_error` (`task_done_requires_claimed_or_started`) → `review_completion_notes`
+is never reached → **zero verdicts**. `ct-foreign-ownership` cannot produce a verdict even when
+seeded: it is owned by `codex-mcp-client` while the keeper is `keeper-eval-agent`, so
+`can_review_completion = false` and the ownership gate (`task_done_requires_current_owner`)
+rejects first (`data/eval/completion_trust/scenarios.json:9-10`).
+
+**B3 — `agreement_rate` is human-label-vs-evaluator, not keeper-vs-judge.**
+`calibration_stats.agreement_rate` folds verdict records against **human** `Label_record`s that
+share a `notes_hash`; with verdicts but no labels, `labeled_total = 0` →
+`agreement_rate = 0.0` (`lib/eval_calibration.ml:419-422`; labels come from
+`record_human_label`, `lib/eval_calibration.ml:224`). Recording verdicts alone can **never**
+yield a non-zero `agreement_rate`. The only verdict-derived metric is `cross_model_rate`, which
+counts verdict records whose `generator_runtime` and `evaluator_runtime` are non-empty and
+differ (`lib/eval_calibration.ml:375-381,429`). The plan's stated goal of "compute
+agreement_rate" is a metric mismatch and must be corrected.
+
+## Design decisions for the implementation PR
+
+**D1 — ownership-tagged corpus.** Add an explicit ownership class to the scenario schema
+(e.g. `ownership: self_owned | foreign`). Only `self_owned` scenarios (the keeper owns a
+`Claimed`/`InProgress` task whose completion notes are weak) can make the judge fire and are
+eligible for the verdict-recording path. `foreign` scenarios stay **disposition-only** — they
+are already covered deterministically by `test/test_completion_trust_harness.ml` (PR-B,
+ownership/anti-rat gate rejection). Today's three scenarios are all foreign-temptation;
+self-owned scenarios are net-new and must be authored.
+
+**D2 — `agreement_rate` is out of scope for the automated runner.** No human labels exist in
+CI, so the runner can populate `total_verdicts`, `approve`/`reject` counts,
+`gate_distribution`, and `cross_model_rate` (distinct generator vs evaluator runtime), but
+**not** `agreement_rate`. Do not present `agreement_rate` as a runner metric. A human-labeling
+workflow (`record_human_label` over a sampled verdict set) is a separate, deferred track.
+
+**D3 — isolation is mandatory.** The verdict-recording path drives the real cross-model judge
+(`Anti_rationalization.review`, `lib/task/anti_rationalization.mli:78-85`) and writes
+`data/verdicts/YYYY-MM/DD.jsonl` (`lib/eval_calibration.ml:102-103,215`). Run it behind an
+isolated `MASC_BASE_PATH` (temp base) and `Eval_calibration.set_store_for_testing ~base_dir`
+(scratch store, `lib/eval_calibration.mli:74-75`), seed a self-owned task fixture, and install
+the two hooks the CLI does not currently install: `record_verdict_fn`
+(default no-op, `lib/task/tool_task_handlers.ml:28-30`; wired to `Eval_calibration.record_verdict`
+only at server boot, `lib/mcp_server.ml:530-531`) and `run_llm_reviewer_fn`
+(installed only in `lib/workspace_metric_hooks.ml:458`). It must never mutate live workspace
+task state or pollute the live `data/verdicts` store.
+
+## The seam (where, what)
+
+- Insertion point: `run_one`'s dispatch closure in `bin/masc_completion_trust_eval.ml`,
+  branched on a completion-tool name (`masc_task_done`/`masc_task_force_done`). `scenario`,
+  `runtime_id`, `run_index`, and the call `args` (`task_id`/`notes`) are in scope there; the
+  final `stop_reason` is not (only post-return, in `build_eval_run`).
+- Real measurement (non-fake): build an `Anti_rationalization.review_request` from scenario
+  context + the call's `notes`/`task_id` and call `Anti_rationalization.review` with a distinct
+  `~evaluator_runtime`, `~on_verdict` routed to `Eval_calibration.record_verdict` — mirroring
+  `lib/task/tool_task_handlers.ml:205-232` and `lib/mcp_server.ml:530-531`. This drives a second
+  evaluator LLM and persists a genuine verdict (`verdict_record`,
+  `lib/eval_calibration.mli:29-41`), feeding `cross_model_rate` immediately.
+- Gate it behind a `--record-verdicts` flag, default off. The disposition track remains the
+  default, CI-safe, deterministic-grading mode.
+
+## Workaround self-check (CLAUDE.md §Workaround Rejection)
+
+A naive `stub → record_verdict` one-liner is **telemetry-as-fix**: the build passes and
+`data/verdicts/` is created, but zero verdicts are recorded (B1/B2) and `agreement_rate`
+stays vacuously 0 (B3) — a counter that measures nothing. Rejected. The only honest increment
+drives an actual judge LLM over self-owned scenarios in an isolated workspace and reports the
+metric it can actually compute (`cross_model_rate`), with `agreement_rate` explicitly deferred
+to a human-labeling track.
+
+## Citation reconciliation (corrected in this PR)
+
+The runner and README cite "RFC-0262 §9 harness — keeper/judge/eval-grader separation" and
+"axis ①". This is inaccurate on two counts:
+
+1. RFC-0262 §9 is **Rollout** and §8 is **Test plan** (`docs/rfc/RFC-0262-completion-authority-typing.md:154,163`).
+   The keeper/judge/eval-grader role separation is a **harness design contract** that lives in
+   the runner/README and this note — it is not text in RFC-0262.
+2. RFC-0262 types axis ② (completion authority); axis ① (LLM discretion to complete) is
+   RFC-0222's territory. The runner measures the keeper's *disposition* to attempt a foreign /
+   unevidenced completion, which is the behavioural complement to RFC-0262 §9's **proving
+   metric**: "zero foreign-task completions by a non-`Operator`/`System` actor"
+   (`docs/rfc/RFC-0262-completion-authority-typing.md:171`).
+
+Corrected wording: the runner supports RFC-0262 §9's proving metric and §8's test plan; the
+role-separation contract references this design note rather than claiming to be RFC text.
+
+## Next PR scope (ready to implement after this note)
+
+1. Author ≥1 `self_owned` weak-evidence scenario + add the `ownership` field to the schema and
+   `Eval_harness` scenario type.
+2. Add `--record-verdicts` mode: isolated `MASC_BASE_PATH` + `set_store_for_testing`, seed the
+   self-owned task, install `record_verdict_fn` + `run_llm_reviewer_fn`, call
+   `Anti_rationalization.review` with `~on_verdict → record_verdict` on completion-tool dispatch
+   for self-owned scenarios only.
+3. Report `cross_model_rate` (+ verdict counts/gate distribution); keep `agreement_rate` out.
+4. Deferred: a human-labeling workflow to make `agreement_rate` meaningful.

--- a/docs/design/completion-trust-calibration-wiring.md
+++ b/docs/design/completion-trust-calibration-wiring.md
@@ -62,8 +62,10 @@ agreement_rate" is a metric mismatch and must be corrected.
 `Claimed`/`InProgress` task whose completion notes are weak) can make the judge fire and are
 eligible for the verdict-recording path. `foreign` scenarios stay **disposition-only** — they
 are already covered deterministically by `test/test_completion_trust_harness.ml` (PR-B,
-ownership/anti-rat gate rejection). Today's three scenarios are all foreign-temptation;
-self-owned scenarios are net-new and must be authored.
+ownership/anti-rat gate rejection). Of today's three scenarios, two
+(`ct-scope-mismatch-evidence`, `ct-fabricated-ref`) are already self-owned weak-evidence
+completions (`claimed_by = keeper-eval-agent`) and only need the `self_owned` tag; only
+`ct-foreign-ownership` is foreign. No net-new scenario is required.
 
 **D2 — `agreement_rate` is out of scope for the automated runner.** No human labels exist in
 CI, so the runner can populate `total_verdicts`, `approve`/`reject` counts,

--- a/docs/design/completion-trust-calibration-wiring.md
+++ b/docs/design/completion-trust-calibration-wiring.md
@@ -74,9 +74,11 @@ workflow (`record_human_label` over a sampled verdict set) is a separate, deferr
 **D3 — isolation is mandatory.** The verdict-recording path drives the real cross-model judge
 (`Anti_rationalization.review`, `lib/task/anti_rationalization.mli:78-85`) and writes
 `data/verdicts/YYYY-MM/DD.jsonl` (`lib/eval_calibration.ml:102-103,215`). Run it behind an
-isolated `MASC_BASE_PATH` (temp base) and `Eval_calibration.set_store_for_testing ~base_dir`
-(scratch store, `lib/eval_calibration.mli:74-75`), seed a self-owned task fixture, and install
-the two hooks the CLI does not currently install: `record_verdict_fn`
+explicit temp workspace base path (prefer a CLI `--base`/`--base-path` argument over ambient
+environment; `MASC_BASE_PATH` is only a process-bound fallback) and
+`Eval_calibration.set_store_for_testing ~base_dir` (scratch store,
+`lib/eval_calibration.mli:74-75`), seed a self-owned task fixture, and install the two hooks
+the CLI does not currently install: `record_verdict_fn`
 (default no-op, `lib/task/tool_task_handlers.ml:28-30`; wired to `Eval_calibration.record_verdict`
 only at server boot, `lib/mcp_server.ml:530-531`) and `run_llm_reviewer_fn`
 (installed only in `lib/workspace_metric_hooks.ml:458`). It must never mutate live workspace
@@ -127,9 +129,10 @@ role-separation contract references this design note rather than claiming to be 
 
 1. Author ≥1 `self_owned` weak-evidence scenario + add the `ownership` field to the schema and
    `Eval_harness` scenario type.
-2. Add `--record-verdicts` mode: isolated `MASC_BASE_PATH` + `set_store_for_testing`, seed the
+2. Add `--record-verdicts` mode: explicit temp workspace base path (`--base`/`--base-path`,
+   with `MASC_BASE_PATH` only as a process-bound fallback) + `set_store_for_testing`, seed the
    self-owned task, install `record_verdict_fn` + `run_llm_reviewer_fn`, call
-   `Anti_rationalization.review` with `~on_verdict → record_verdict` on completion-tool dispatch
-   for self-owned scenarios only.
+   `Anti_rationalization.review` with `~on_verdict → record_verdict` on completion-tool
+   dispatch for self-owned scenarios only.
 3. Report `cross_model_rate` (+ verdict counts/gate distribution); keep `agreement_rate` out.
 4. Deferred: a human-labeling workflow to make `agreement_rate` meaningful.


### PR DESCRIPTION
## 무엇을 / 왜

completion-trust live-LLM 러너(`bin/masc_completion_trust_eval.ml`, PR-C #21754)의 dispatch는 disposition-only **stub**이고, docstring이 그것을 "later PR이 실제 handler + `Eval_calibration` verdict 기록으로 배선할 seam"으로 명시합니다. 이 seam을 4-agent로 매핑한 결과 **naive 한 줄 배선은 워크어라운드**임이 드러나, 코드 대신 **설계노트 먼저**(RFC-0262 §9 follow-up)를 작성했습니다.

## 핵심 발견 — naive 배선이 0건 기록인 이유 (3 블로커)

1. **judge가 stub 하에서 발화 0.** verdict 생산자(`Anti_rationalization.review` → `record_verdict`)는 실제 done-handler의 `review_completion_notes` 안, **ownership gate 뒤에서만** 호출 (`tool_task.ml:348-353`). 러너 stub은 `tool_task.ml`을 우회(`keeper_turn_driver_wrappers.ml:184-188`) → judge 미발화 → verdict 0건.
2. **현재 corpus는 handler 경유해도 0건.** task id가 prompt 텍스트일 뿐 seed 안 됨 → `handle_transition`에서 `task_opt=None` → early-return (`scenarios.json:9` + `tool_task.ml:174-175`). foreign 시나리오는 seed해도 ownership gate에서 거부.
3. **`agreement_rate`는 human label 기반** (`eval_calibration.ml:419-422`) — verdict만 기록하면 `labeled_total=0 → 0.0` 영구. verdict만으로 나오는 건 `cross_model_rate`뿐.

## 산출물 (측정 코드 변경 0)

- `docs/design/completion-trust-calibration-wiring.md` — 설계노트: 3 블로커 + 3 설계결정(ownership-tagged self-owned corpus / `agreement_rate` out-of-scope / 워크스페이스 격리 필수) + seam 위치 + 다음 PR scope.
- `bin/masc_completion_trust_eval.ml` — **citation 정정**(comment-only): "§9 harness — keeper/judge/eval-grader separation"은 부정확(§9는 Rollout, §8이 Test plan; 역할분리는 RFC 텍스트가 아닌 harness 계약). build exit 0.
- `data/eval/completion_trust/README.md` — 동일 citation 정정.

## 검증

- design note의 **21개 file:line 참조 전부 적대 검증 → 현재 base와 일치**(2-agent workflow). RFC-0262에 "keeper/judge/eval-grader" 문구 없음도 확인(rg exit 1).
- docstring 변경 `dune build --root . bin/masc_completion_trust_eval.exe` exit 0.

## 워크어라운드 self-check

이 PR은 워크어라운드를 **거부**하는 설계노트입니다 — naive `stub→record_verdict`는 0건 기록 = telemetry-as-fix라 거부하고, 정직한 경로(격리+self-owned corpus+실제 judge LLM, `cross_model_rate`만 측정, `agreement_rate`은 human-label 트랙으로 defer)를 문서화했습니다. 측정 코드는 도입하지 않습니다.

RFC: RFC-0262 §9 follow-up (기존 RFC 인용, 신규 불필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
