### PR TITLE
feat(dashboard): converge tone pills into a canonical <Pill> primitive

### DIFF
--- a/dashboard/src/components/common/index.ts
+++ b/dashboard/src/components/common/index.ts
@@ -1,0 +1,39 @@
+// Barrel for the converged tone-indicator family. `<Pill>` is the canonical
+// entry for new code and migrated forks; the other three are kept primitives
+// (StatusChip shares the Pill engine; CountBadge + StatusBadge are a separate
+// styling lineage reconciled later — see docs/design/dashboard-pill-convergence.md).
+
+export {
+  Pill,
+  pillClasses,
+  isPillTone,
+  summarizePill,
+  type PillTone,
+  type PillProps,
+  type PillClassOptions,
+  type PillSummary,
+} from './pill'
+
+export {
+  StatusChip,
+  statusChipClasses,
+  isSemanticTone,
+  keeperStateTone,
+  summarizeStatusChip,
+  type StatusChipTone,
+  type StatusChipProps,
+} from './status-chip'
+
+export {
+  CountBadge,
+  countBadgeClasses,
+  summarizeCountBadge,
+  type BadgeTone,
+  type CountBadgeProps,
+} from './badge'
+
+export {
+  StatusBadge,
+  statusBadgeTone,
+  statusDotColor,
+} from './status-badge'

--- a/dashboard/src/components/common/pill.test.ts
+++ b/dashboard/src/components/common/pill.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Pill, pillClasses, isPillTone, summarizePill } from './pill'
+import { statusChipClasses } from './status-chip'
+
+describe('isPillTone (pure)', () => {
+  it('accepts the 8 chip tones plus the volt accent', () => {
+    for (const tone of ['neutral', 'ok', 'warn', 'bad', 'info', 'volt', 'paused', 'select', ''] as const) {
+      expect(isPillTone(tone)).toBe(true)
+    }
+  })
+
+  it('rejects raw Tailwind class strings (they pass through verbatim)', () => {
+    expect(isPillTone('bg-[var(--color-status-ok)]')).toBe(false)
+    expect(isPillTone('text-accent-fg')).toBe(false)
+  })
+})
+
+describe('pillClasses (pure)', () => {
+  it('default (no tone) uses neutral mapping + base shape', () => {
+    const cls = pillClasses()
+    for (const t of ['inline-flex', 'rounded-[var(--r-0)]', 'border', 'px-2', 'py-0.5', 'text-[11px]', 'uppercase', 'tracking-[0.05em]']) {
+      expect(cls).toContain(t)
+    }
+    expect(cls).toContain('text-text-tertiary') // neutral fallback
+  })
+
+  it('maps each semantic tone to its palette', () => {
+    expect(pillClasses('ok')).toContain('text-success')
+    expect(pillClasses('ok')).toContain('bg-success/10')
+    expect(pillClasses('warn')).toContain('text-warning')
+    expect(pillClasses('bad')).toContain('text-destructive')
+    expect(pillClasses('info')).toContain('text-brand')
+    expect(pillClasses('paused')).toContain('text-[var(--paused)]')
+    expect(pillClasses('select')).toContain('text-[var(--select)]')
+  })
+
+  it('volt maps to the --volt-* triple', () => {
+    const cls = pillClasses('volt')
+    expect(cls).toContain('text-[var(--volt-strong)]')
+    expect(cls).toContain('border-[var(--volt-dim)]')
+    expect(cls).toContain('bg-[var(--volt-wash)]')
+  })
+
+  it('raw Tailwind tone passes through without semantic expansion', () => {
+    const cls = pillClasses('bg-[var(--color-status-ok)]')
+    expect(cls).toContain('bg-[var(--color-status-ok)]')
+    expect(cls).not.toContain('text-success')
+  })
+
+  it('uppercase=false drops uppercase + tracking, keeps shape + tone', () => {
+    const cls = pillClasses('neutral', { uppercase: false })
+    expect(cls).not.toContain('uppercase')
+    expect(cls).not.toContain('tracking-[0.05em]')
+    expect(cls).toContain('rounded-[var(--r-0)]')
+    expect(cls).toContain('text-text-tertiary')
+  })
+
+  it('mono adds font-mono', () => {
+    expect(pillClasses('ok', { mono: true })).toContain('font-mono')
+    expect(pillClasses('ok')).not.toContain('font-mono')
+  })
+
+  it('soft strips the bg token but keeps border + text', () => {
+    const cls = pillClasses('ok', { soft: true })
+    expect(cls).not.toContain('bg-success/10')
+    expect(cls).toContain('border-success/20')
+    expect(cls).toContain('text-success')
+  })
+
+  it('extra appended; empty/undefined extra leaves no trailing space', () => {
+    expect(pillClasses('warn', { extra: 'shrink-0 ml-2' })).toContain('shrink-0 ml-2')
+    expect(pillClasses('ok', { extra: '' })).not.toMatch(/\s$/)
+    expect(pillClasses('ok', { extra: undefined })).not.toMatch(/\s$/)
+  })
+})
+
+// The convergence contract: StatusChip's class helper now delegates here, so
+// the two MUST agree for every shape the old inline implementation produced.
+describe('convergence: statusChipClasses === pillClasses', () => {
+  const tones = ['', 'ok', 'warn', 'bad', 'info', 'neutral', 'paused', 'select', 'bg-[var(--accent-12)]']
+  it('matches for every tone (uppercase default)', () => {
+    for (const tone of tones) {
+      expect(statusChipClasses(tone)).toBe(pillClasses(tone, { uppercase: true }))
+    }
+  })
+  it('matches with uppercase=false and with an extra class', () => {
+    for (const tone of tones) {
+      expect(statusChipClasses(tone, 'ml-2', false)).toBe(pillClasses(tone, { uppercase: false, extra: 'ml-2' }))
+    }
+  })
+})
+
+describe('summarizePill (pure)', () => {
+  it('summarizes the default pill', () => {
+    expect(summarizePill({})).toEqual({
+      tone: 'neutral',
+      isSemanticTone: true,
+      uppercase: true,
+      hasDot: false,
+      contentSource: 'empty',
+      hasCustomClass: false,
+      hasTestId: false,
+    })
+  })
+
+  it('summarizes a raw-tone pill with children + custom class', () => {
+    expect(summarizePill({ tone: 'bg-[var(--x)]', children: 'hi', class: 'ml-2', dot: true, testId: 't' })).toEqual({
+      tone: 'bg-[var(--x)]',
+      isSemanticTone: false,
+      uppercase: true,
+      hasDot: true,
+      contentSource: 'children',
+      hasCustomClass: true,
+      hasTestId: true,
+    })
+  })
+})
+
+describe('Pill component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders <span data-pill> with children and tone metadata', () => {
+    render(html`<${Pill} tone="ok">running<//>`, container)
+    const el = container.querySelector('[data-pill]')!
+    expect(el.tagName).toBe('SPAN')
+    expect(el.textContent).toBe('running')
+    expect(el.getAttribute('data-pill-tone')).toBe('ok')
+    expect(el.getAttribute('data-pill-semantic-tone')).toBe('true')
+    expect(el.getAttribute('data-pill-content-source')).toBe('children')
+  })
+
+  it('raw tone marks non-semantic', () => {
+    render(html`<${Pill} tone="bg-[var(--accent-12)]">x<//>`, container)
+    expect(container.querySelector('[data-pill]')!.getAttribute('data-pill-semantic-tone')).toBe('false')
+  })
+
+  it('dot renders a leading pip and reflects data-pill-has-dot', () => {
+    render(html`<${Pill} tone="ok" dot=${true}>live<//>`, container)
+    const el = container.querySelector('[data-pill]')!
+    expect(el.getAttribute('data-pill-has-dot')).toBe('true')
+    expect(el.querySelector('span.bg-current')).toBeTruthy()
+  })
+
+  it('testId renders as data-testid', () => {
+    render(html`<${Pill} testId="my-pill">x<//>`, container)
+    expect(container.querySelector('[data-testid="my-pill"]')).toBeTruthy()
+    expect(container.querySelector('[data-pill]')!.getAttribute('data-pill-has-test-id')).toBe('true')
+  })
+
+  it('uppercase=false reflects on data-pill-uppercase', () => {
+    render(html`<${Pill} uppercase=${false}>x<//>`, container)
+    expect(container.querySelector('[data-pill]')!.getAttribute('data-pill-uppercase')).toBe('false')
+  })
+})

--- a/dashboard/src/components/common/pill.ts
+++ b/dashboard/src/components/common/pill.ts
@@ -1,0 +1,175 @@
+// Pill — the converged tone-pill primitive (keeper-v2 design system).
+//
+// The keeper-v2 design collapses a family of forked `*Pill/*Badge/*Chip`
+// spans into ONE `<Pill>` with a tone + a few shape variants. This file is
+// the canonical class engine + component for the bordered tone-pill shape
+// (the StatusChip lineage, generalised): semantic tones, a `volt` accent,
+// and `uppercase` / `mono` / `soft` / `dot` modifiers.
+//
+// Convergence path (see docs/design/dashboard-pill-convergence.md):
+//   - `status-chip.ts` delegates its class assembly here (no fork; 33 callers
+//     keep their API + `data-*` contract; output is byte-identical).
+//   - Forked tone-pills across feature components migrate to `<Pill>` in
+//     follow-up PRs (one family per PR).
+//   - `badge.ts` (CountBadge, count shape) and `status-badge.ts` (`.status-badge`
+//     CSS-utility shape) are a DIFFERENT styling lineage and are reconciled
+//     separately — they are intentionally NOT routed through this engine yet.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
+
+/** Semantic tones, plus the design's `volt` accent. A raw Tailwind class
+ *  string (e.g. the output of a `verdictTone()` helper) is also accepted by
+ *  {@link pillClasses} and passes through verbatim — exactly as the previous
+ *  `statusChipClasses` did. */
+export type PillTone =
+  | 'neutral'
+  | 'ok'
+  | 'warn'
+  | 'bad'
+  | 'info'
+  | 'volt'
+  | 'paused'
+  | 'select'
+
+/** Bordered-chip tone palette. `''` aliases `neutral` so an unset tone renders
+ *  the muted pill (the StatusChip default). `volt` mirrors the `--volt-*`
+ *  triple used by settings-surface/StatCell (`--volt-strong` === `--brand`). */
+const CHIP_TONE: Record<string, string> = {
+  neutral: 'border-border bg-surface-subtle text-text-tertiary',
+  '': 'border-border bg-surface-subtle text-text-tertiary',
+  ok: 'border-success/20 bg-success/10 text-success',
+  warn: 'border-warning/20 bg-warning/10 text-warning',
+  bad: 'border-destructive/20 bg-destructive/10 text-destructive',
+  info: 'border-brand/20 bg-brand/10 text-brand',
+  volt: 'border-[var(--volt-dim)] bg-[var(--volt-wash)] text-[var(--volt-strong)]',
+  paused: 'border-[var(--paused-20)] bg-[var(--paused-10)] text-[var(--paused)]',
+  select: 'border-[var(--select-20)] bg-[var(--select-10)] text-[var(--select)]',
+}
+
+const CHIP_SHAPE =
+  'inline-flex items-center rounded-[var(--r-0)] border px-2 py-0.5 text-[11px]'
+const UPPERCASE_CLASS = 'uppercase tracking-[0.05em]'
+const MONO_CLASS = 'font-mono'
+
+/** True when `tone` is a known semantic tone (incl. `''` and `volt`). Raw
+ *  Tailwind strings fall through as `false` so they compose verbatim. Exposed
+ *  so `status-chip.ts` and higher-level helpers branch on one source. */
+export function isPillTone(tone: string): boolean {
+  return tone in CHIP_TONE
+}
+
+export interface PillClassOptions {
+  /** Render `uppercase tracking-[0.05em]` (default true). Set false for plain
+   *  tag pills (file paths, enum values) where all-caps changes the grammar. */
+  uppercase?: boolean
+  /** Monospace face (former FsmChip). */
+  mono?: boolean
+  /** Transparent ground (former TraitPill): keep border + text, drop the bg. */
+  soft?: boolean
+  /** Extra caller classes (margin, shrink-0, …) appended last. */
+  extra?: string
+}
+
+/** Pure class engine for the bordered tone-pill. Shape tokens are always
+ *  present; `uppercase`/`mono` are conditional; a semantic `tone` maps to the
+ *  palette while a raw Tailwind string passes through. `soft` strips the bg
+ *  token from the resolved tone class.
+ *
+ *  Invariant: `pillClasses(tone, { uppercase, extra })` reproduces the previous
+ *  `statusChipClasses(tone, extra, uppercase)` byte-for-byte (mono/soft default
+ *  off contribute nothing and do not reorder the existing tokens). */
+export function pillClasses(tone: string = '', opts: PillClassOptions = {}): string {
+  const { uppercase = true, mono = false, soft = false, extra } = opts
+  // isPillTone guarantees the key exists; `?? ''` only satisfies
+  // noUncheckedIndexedAccess (never taken for a real tone).
+  let toneClass = isPillTone(tone) ? (CHIP_TONE[tone] ?? '') : tone
+  if (soft && toneClass !== '') {
+    toneClass = toneClass.replace(/\s*\bbg-\S+/g, '').trim()
+  }
+  const parts = [CHIP_SHAPE]
+  if (uppercase) parts.push(UPPERCASE_CLASS)
+  if (mono) parts.push(MONO_CLASS)
+  if (toneClass !== '') parts.push(toneClass)
+  if (extra !== undefined && extra !== '') parts.push(extra)
+  return parts.join(' ')
+}
+
+export interface PillSummary {
+  readonly tone: string
+  readonly isSemanticTone: boolean
+  readonly uppercase: boolean
+  readonly hasDot: boolean
+  readonly contentSource: 'children' | 'empty'
+  readonly hasCustomClass: boolean
+  readonly hasTestId: boolean
+}
+
+export interface PillProps {
+  /** A {@link PillTone} member, or a raw Tailwind class string (passthrough). */
+  tone?: PillTone | string
+  /** Leading status pip, coloured by the tone (currentColor). */
+  dot?: boolean
+  dotPulse?: boolean
+  uppercase?: boolean
+  mono?: boolean
+  soft?: boolean
+  class?: string
+  title?: string
+  testId?: string
+  children?: ComponentChildren
+}
+
+/** Pure: the Pill's render-independent metadata (mirrors the `summarize*`
+ *  pattern used by the other common primitives so behaviour is unit-testable
+ *  without a DOM). */
+export function summarizePill({
+  tone = 'neutral',
+  uppercase = true,
+  dot = false,
+  class: cx,
+  testId,
+  children,
+}: Pick<PillProps, 'tone' | 'uppercase' | 'dot' | 'class' | 'testId' | 'children'>): PillSummary {
+  return {
+    tone,
+    isSemanticTone: isPillTone(tone),
+    uppercase,
+    hasDot: dot,
+    contentSource: children !== undefined && children !== null ? 'children' : 'empty',
+    hasCustomClass: cx !== undefined && cx !== '',
+    hasTestId: testId !== undefined && testId !== '',
+  }
+}
+
+/** The converged tone-pill. New code and migrated forks render `<Pill>`;
+ *  `status-chip.ts` shares this engine. */
+export function Pill({
+  tone = 'neutral',
+  dot = false,
+  dotPulse = false,
+  uppercase = true,
+  mono = false,
+  soft = false,
+  class: cx,
+  title,
+  testId,
+  children,
+}: PillProps) {
+  const summary = summarizePill({ tone, uppercase, dot, class: cx, testId, children })
+  const cls = pillClasses(tone, { uppercase, mono, soft, extra: cx })
+  const dotCls = `size-1.5 rounded-full bg-current${dotPulse ? ' animate-pulse' : ''}${dot ? ' mr-1.5' : ''}`
+  return html`<span
+    class=${cls}
+    data-pill
+    data-pill-tone=${tone}
+    data-pill-semantic-tone=${summary.isSemanticTone}
+    data-pill-uppercase=${summary.uppercase ? 'true' : 'false'}
+    data-pill-has-dot=${summary.hasDot}
+    data-pill-content-source=${summary.contentSource}
+    data-pill-has-custom-class=${summary.hasCustomClass}
+    data-pill-has-test-id=${summary.hasTestId}
+    title=${title}
+    data-testid=${testId}
+  >${dot ? html`<span class=${dotCls}></span>` : null}${children}</span>`
+}

--- a/dashboard/src/components/common/status-chip.ts
+++ b/dashboard/src/components/common/status-chip.ts
@@ -38,6 +38,7 @@
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
+import { pillClasses } from './pill'
 
 export type StatusChipTone =
   | 'ok'
@@ -62,20 +63,13 @@ export interface StatusChipSummary {
   readonly testIdLength: number
 }
 
-const BASE_SHAPE =
-  'inline-flex items-center rounded-[var(--r-0)] border px-2 py-0.5 text-[11px]'
-const UPPERCASE_CLASS = 'uppercase tracking-[0.05em]'
-
-const SEMANTIC_TONE: Record<StatusChipTone, string> = {
-  ok: 'border-success/20 bg-success/10 text-success',
-  warn: 'border-warning/20 bg-warning/10 text-warning',
-  bad: 'border-destructive/20 bg-destructive/10 text-destructive',
-  info: 'border-brand/20 bg-brand/10 text-brand',
-  neutral: 'border-border bg-surface-subtle text-text-tertiary',
-  paused: 'border-[var(--paused-20)] bg-[var(--paused-10)] text-[var(--paused)]',
-  select: 'border-[var(--select-20)] bg-[var(--select-10)] text-[var(--select)]',
-  '': 'border-border bg-surface-subtle text-text-tertiary',
-}
+// Tone class strings + base shape now live in `pill.ts` (single source — the
+// convergence). StatusChip keeps only its own public tone-enum membership so
+// its type guard stays honest: the `volt` accent is Pill-only, not a
+// StatusChip tone.
+const STATUS_CHIP_TONES: ReadonlySet<string> = new Set([
+  'ok', 'warn', 'bad', 'info', 'neutral', 'paused', 'select', '',
+])
 
 /** Keeper lifecycle state → StatusChip tone.
  *
@@ -140,7 +134,7 @@ export function keeperStateTone(state: string): StatusChipTone {
     Tailwind class strings (`bg-[var(--color-status-ok)]`) fall through and are
     composed as-is. Exposed so higher-level helpers can branch. */
 export function isSemanticTone(tone: string): tone is StatusChipTone {
-  return tone in SEMANTIC_TONE
+  return STATUS_CHIP_TONES.has(tone)
 }
 
 /** Pure: class string for given tone + optional extra + optional
@@ -156,12 +150,9 @@ export function statusChipClasses(
   extra?: string,
   uppercase: boolean = true,
 ): string {
-  const toneClass = isSemanticTone(tone) ? SEMANTIC_TONE[tone] : tone
-  const parts = [BASE_SHAPE]
-  if (uppercase) parts.push(UPPERCASE_CLASS)
-  if (toneClass !== '') parts.push(toneClass)
-  if (extra !== undefined && extra !== '') parts.push(extra)
-  return parts.join(' ')
+  // Delegates to the converged engine; output is byte-identical to the prior
+  // inline implementation (pill.ts CHIP_TONE === the old SEMANTIC_TONE).
+  return pillClasses(tone, { uppercase, extra })
 }
 
 function hasChildrenContent(children: ComponentChildren | undefined): boolean {

--- a/dashboard/src/components/design-canvas.ts
+++ b/dashboard/src/components/design-canvas.ts
@@ -12,6 +12,7 @@ import { InlineSpinner } from './common/inline-spinner'
 import { LoadingBar } from './common/loading-bar'
 import { ActionButton } from './common/button'
 import { StatusChip } from './common/status-chip'
+import { Pill } from './common/pill'
 import { StatusBadge } from './common/status-badge'
 import { CountBadge } from './common/badge'
 import { PanelCard } from './common/panel-card'
@@ -162,6 +163,20 @@ function PrimitivesGallery() {
           <${StatusChip} tone="info">working<//>
           <${CountBadge} tone="accent">12<//>
           <${CountBadge} tone="warn">3<//>
+        </div>
+      <//>
+
+      <${Artboard} title="Pill (converged)">
+        <div class="dc-row-wrap">
+          <${Pill} tone="ok" dot=${true}>running<//>
+          <${Pill} tone="warn">failing<//>
+          <${Pill} tone="bad">crashed<//>
+          <${Pill} tone="info">working<//>
+          <${Pill} tone="volt">accent<//>
+          <${Pill} tone="neutral">idle<//>
+          <${Pill} tone="ok" soft=${true}>soft<//>
+          <${Pill} tone="info" mono=${true}>FSM<//>
+          <${Pill} tone="neutral" uppercase=${false}>path.kind<//>
         </div>
       <//>
 

--- a/docs/design/dashboard-pill-convergence.md
+++ b/docs/design/dashboard-pill-convergence.md
@@ -1,0 +1,90 @@
+# Dashboard `<Pill>` primitive convergence
+
+Status: in progress (PR 1 landed the engine + StatusChip delegation)
+Date: 2026-06-20
+Scope: `dashboard/src/components/common` + feature components rendering tone pills
+Related: `docs/design/keeper-v2-v12-gap-current.md`, keeper-v2 design ("v2" project)
+
+## Context
+
+The keeper-v2 gap analysis (2026-06-20) found the design's central primitive thesis — **one `<Pill>`
+with a tone + a few variants** — unimplemented in the dashboard. Three competing badge primitives
+coexist in `common/` with divergent tone enums, and ~66 forked `*Pill/*Badge/*Chip` definitions live
+across feature components, including **two distinct same-named `StatusPill`** (`feature-health.ts`,
+`harness-health-sections.ts`). Every keeper-v2 surface port re-rolls these atoms, so the divergence
+compounds. This doc defines the converged `<Pill>` and the migration policy.
+
+Why a doc and not an RFC: this is an additive, test-guarded design-system convergence with no
+behavior change to existing callers. (The RFC-0270 slot is occupied by an unrelated open PR; we use a
+design doc to avoid a numbering collision. Promote to an RFC if the team wants stronger authority.)
+
+## The three existing primitives (two styling lineages)
+
+| Primitive | Shape | Tone system |
+|---|---|---|
+| `status-chip.ts` (`StatusChip`, 33 consumers) | bordered tag, `border px-2 py-0.5 rounded-[var(--r-0)] text-[11px]` | inline Tailwind palette (`bg-success/10 text-success`) + raw passthrough |
+| `badge.ts` (`CountBadge`, 6) | compact count, `px-1.5 py-px rounded-md tabular-nums` | inline Tailwind, distinct `default`/`accent` tones |
+| `status-badge.ts` (`StatusBadge`, 8) | dot + label | `.status-badge` **CSS-utility class** (`.status-badge.ok`), NOT Tailwind palette |
+
+StatusChip and CountBadge share the inline-Tailwind lineage; StatusBadge is a separate CSS-utility
+lineage. A single class engine therefore converges the **StatusChip lineage** cleanly; CountBadge and
+StatusBadge are reconciled separately (below) to avoid breaking their CSS/test contracts.
+
+## `<Pill>` API (`common/pill.ts`)
+
+```ts
+type PillTone = 'neutral'|'ok'|'warn'|'bad'|'info'|'volt'|'paused'|'select'
+interface PillProps { tone?, dot?, dotPulse?, uppercase?, mono?, soft?, class?, title?, testId?, children? }
+pillClasses(tone, { uppercase?, mono?, soft?, extra? }) -> string   // pure engine
+```
+
+- Tones map to the bordered-chip palette; `volt` → the `--volt-dim/--volt-wash/--volt-strong` triple
+  (`--volt-strong === --brand`), mirroring StatCell/Vital/settings-surface.
+- A non-enum `tone` string passes through verbatim (raw Tailwind, e.g. a `verdictTone()` result).
+- Variants: `uppercase` (default true), `mono` (FsmChip), `soft` (transparent ground — drops `bg-*`),
+  `dot` (leading `bg-current` pip).
+- `<Pill>` emits `data-pill*` attributes for testability, matching the pattern of the other primitives.
+
+**Convergence invariant (tested):** `pillClasses(tone, { uppercase, extra })` is byte-identical to the
+former `statusChipClasses(tone, extra, uppercase)`. `status-chip.ts` now delegates to `pillClasses`;
+its public API, span, and 9 `data-status-chip-*` attributes are unchanged, so all 33 callers and the
+existing test suite are untouched. Proven by `common/pill.test.ts` (`statusChipClasses === pillClasses`)
+plus the unchanged `status-chip.test.ts`.
+
+## Migration policy
+
+**Use `<Pill>` for any new tone/status/badge span.** Do not add a new `*Pill/*Badge/*Chip` component or
+inline `rounded-[var(--r-0)] border px-2 py-0.5 …` span for a tone indicator — render `<Pill tone=…>`.
+
+Migrate the existing forks by family, one family per PR (each PR complete within its scope — no
+partial/N-of-M migrations):
+
+- **(a) Semantic status pills** (~8-12) → `<Pill>`. Headlines the two duplicate `StatusPill`,
+  plus SnapshotBadge / PhaseBadge / KeeperPresencePill / RuntimeBadge / TraitPill(`soft`) / RolePill(`mono`).
+- **(b) Count badges** (~6-8) and **(g) class-builder helpers** (~16-20) → route through the engine
+  (a `count` variant is added to `pillClasses` when family (b) is migrated).
+- **(e) Inline Tailwind pill strings** (~10-15) and **(d) tone-label domain badges** → `<Pill>` case-by-case.
+
+**Keep distinct (NOT `<Pill>`):** `Sigil`/`SigilChip`/`KeeperBadge` (slot-color identity), `FilterChip`,
+`LogFilter`, `SuggestionChip`, `IdPill`, `heartbeat-*-chip` — these are separate atoms, kept distinct in
+the design too. Health-chip factory builders (`dashboard-shell.ts`) keep their structured
+`DashboardHealthChip` shape; only the rendered span adopts `<Pill>`.
+
+Collisions to resolve during migration: a local `Pill` in `connector-readiness-rail.ts` and
+`connectorStatusPillClass/Label` in `connector-status.ts` → the canonical `common/pill.ts` `Pill`.
+
+## Follow-ups (not in PR 1)
+
+- **CountBadge** → delegate `countBadgeClasses` to a `pillClasses` `count` variant (straightforward;
+  exact-class tests must stay green).
+- **StatusBadge** → reconcile the `.status-badge` CSS-utility lineage with `<Pill dot>` (needs a CSS-token
+  pass; deferred).
+- **Re-fork guard** → a *principled* AST-based ESLint rule detecting the duplicated pill shape with an
+  allowlist for the kept atoms. A name-based grep guard would false-positive on the kept atoms and reads
+  as a string-classifier workaround, so it is intentionally deferred until it can be done by shape.
+
+## Verification
+
+- `pnpm test` — `common/{pill,status-chip,badge,status-badge}.test.ts` green; existing primitive tests
+  pass unchanged (proves API + `data-*` preserved).
+- `pnpm typecheck` clean; `<Pill>` renders in the Lab → Design Canvas "Pill (converged)" artboard.


### PR DESCRIPTION
## What

Unit 0 of the keeper-v2 dashboard port: converge the forked tone-pill primitives into one canonical `<Pill>`.

The keeper-v2 gap analysis (2026-06-20) found ~66 forked `*Pill/*Badge/*Chip` definitions across feature components — including two distinct same-named `StatusPill` (`feature-health.ts`, `harness-health-sections.ts`) — re-rolling the same badge atom. This blocks faithful per-surface ports (every surface re-rolls the fork). This PR lands the foundational primitive; fork-site migration follows by family.

## Changes

- **`common/pill.ts`** — `<Pill>` + a pure `pillClasses(tone, opts)` engine. Tones `neutral|ok|warn|bad|info|volt|paused|select` (+ raw-Tailwind passthrough); variants `dot`/`dotPulse`/`uppercase`/`mono`/`soft`. `volt` maps to the `--volt-dim/--volt-wash/--volt-strong` triple.
- **`common/status-chip.ts`** — `statusChipClasses` now delegates to `pillClasses`. Public API, span, and the nine `data-status-chip-*` attributes are unchanged; the 33 callers and the existing test suite are untouched.
- **`common/index.ts`** — barrel for the converged tone-indicator family.
- **`design-canvas.ts`** — a "Pill (converged)" artboard in the primitives gallery.
- **`docs/design/dashboard-pill-convergence.md`** — the `<Pill>` API, the migration policy (no new forked badges; migrate by family), and the kept-distinct atoms.

## Scope boundary

- `CountBadge` (count shape) and `StatusBadge` (`.status-badge` CSS-utility lineage) are a separate styling system and are intentionally NOT routed through this engine yet — reconciled in a follow-up to avoid breaking their CSS/test contracts. No fork sites are migrated in this PR (those are follow-up PRs, one family each).

## Verification

- `pnpm test` — `common/{pill,status-chip,badge,status-badge}.test.ts` + `design-canvas.test.ts` green (77 tests). The existing primitive tests pass **unchanged**, proving the StatusChip API + `data-*` contract is preserved.
- `pill.test.ts` asserts the convergence invariant: `statusChipClasses(tone, extra, uppercase) === pillClasses(tone, { uppercase, extra })` for every tone.
- `pnpm typecheck` clean; `pnpm eslint` clean on changed files.

## Notes

- Documented as a design doc rather than an RFC to avoid an RFC-number collision with an unrelated open PR (RFC-0270 / #21775); promote to an RFC if preferred.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
